### PR TITLE
PR16: value-log raw frame writev batching

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2557,51 +2557,71 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	type frameStatsWriterInto interface {
 		AppendFrameWithStatsInto(dictID uint64, dict []byte, records []valuelog.Record, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
 	}
+	type rawFrameBatchWriterInto interface {
+		AppendRawFramesWritevInto(records []valuelog.Record, k int, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
+	}
 	statsWriter, hasStats := w.(frameStatsWriter)
 	statsWriterInto, hasInto := w.(frameStatsWriterInto)
+	rawWriterInto, hasRawInto := w.(rawFrameBatchWriterInto)
 
-	ptrs = make([]page.ValuePtr, 0, len(records))
 	storedPayloadBytes := 0
 	rawFrameBytes := 0
 	frameRecords := 0
+	rawBatchUsed := false
+	if dictID == 0 && hasRawInto && len(records) > 1 {
+		ptrs = make([]page.ValuePtr, len(records))
+		_, stats, batchErr := rawWriterInto.AppendRawFramesWritevInto(records, k, ptrs)
+		if batchErr != nil {
+			err = batchErr
+		} else {
+			rawFrameBytes = stats.RawPayloadBytes
+			storedPayloadBytes = stats.StoredPayloadBytes
+			frameRecords = stats.Records
+			rawBatchUsed = true
+		}
+	} else {
+		ptrs = make([]page.ValuePtr, 0, len(records))
+	}
 	var framePtrScratch [valuelog.MaxFrameK]page.ValuePtr
-	for i := 0; i < len(records); i += k {
-		end := i + k
-		if end > len(records) {
-			end = len(records)
-		}
-		if hasInto {
-			scratch := framePtrScratch[:end-i]
-			framePtrs, stats, frameErr := statsWriterInto.AppendFrameWithStatsInto(dictID, dict, records[i:end], scratch)
-			if frameErr != nil {
-				err = frameErr
-				break
+	if err == nil && !rawBatchUsed {
+		for i := 0; i < len(records); i += k {
+			end := i + k
+			if end > len(records) {
+				end = len(records)
 			}
-			ptrs = append(ptrs, framePtrs...)
-			rawFrameBytes += stats.RawPayloadBytes
-			storedPayloadBytes += stats.StoredPayloadBytes
-			frameRecords += stats.Records
-			continue
-		}
-		if hasStats {
-			framePtrs, stats, frameErr := statsWriter.AppendFrameWithStats(dictID, dict, records[i:end])
-			if frameErr != nil {
-				err = frameErr
-				break
+			if hasInto {
+				scratch := framePtrScratch[:end-i]
+				framePtrs, stats, frameErr := statsWriterInto.AppendFrameWithStatsInto(dictID, dict, records[i:end], scratch)
+				if frameErr != nil {
+					err = frameErr
+					break
+				}
+				ptrs = append(ptrs, framePtrs...)
+				rawFrameBytes += stats.RawPayloadBytes
+				storedPayloadBytes += stats.StoredPayloadBytes
+				frameRecords += stats.Records
+				continue
 			}
-			ptrs = append(ptrs, framePtrs...)
-			rawFrameBytes += stats.RawPayloadBytes
-			storedPayloadBytes += stats.StoredPayloadBytes
-			frameRecords += stats.Records
-			continue
-		}
+			if hasStats {
+				framePtrs, stats, frameErr := statsWriter.AppendFrameWithStats(dictID, dict, records[i:end])
+				if frameErr != nil {
+					err = frameErr
+					break
+				}
+				ptrs = append(ptrs, framePtrs...)
+				rawFrameBytes += stats.RawPayloadBytes
+				storedPayloadBytes += stats.StoredPayloadBytes
+				frameRecords += stats.Records
+				continue
+			}
 
-		framePtrs, frameErr := w.AppendFrame(dictID, dict, records[i:end])
-		if frameErr != nil {
-			err = frameErr
-			break
+			framePtrs, frameErr := w.AppendFrame(dictID, dict, records[i:end])
+			if frameErr != nil {
+				err = frameErr
+				break
+			}
+			ptrs = append(ptrs, framePtrs...)
 		}
-		ptrs = append(ptrs, framePtrs...)
 	}
 	if err == nil {
 		switch durability {

--- a/TreeDB/internal/valuelog/writer_writev.go
+++ b/TreeDB/internal/valuelog/writer_writev.go
@@ -1,0 +1,221 @@
+package valuelog
+
+import (
+	"encoding/binary"
+	"errors"
+
+	"github.com/snissn/gomap/TreeDB/internal/crc"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/slab"
+)
+
+const writevMinAvgValueSize = 16 << 10
+
+// AppendRawFramesWritevInto appends raw (uncompressed) grouped frames using a
+// writev batching strategy.
+//
+// This avoids concatenating payloads into a contiguous frame buffer, reducing
+// user-space copying for large value workloads. It always flushes the writev
+// queue before returning, so it does not retain references to the input slices.
+//
+// dst must be at least len(records) long.
+func (w *Writer) AppendRawFramesWritevInto(records []Record, k int, dst []page.ValuePtr) ([]page.ValuePtr, FrameStats, error) {
+	if w == nil {
+		return nil, FrameStats{}, errors.New("valuelog: nil writer")
+	}
+	if len(records) == 0 {
+		return dst[:0], FrameStats{}, nil
+	}
+	if len(dst) < len(records) {
+		return nil, FrameStats{}, errors.New("valuelog: dst too small")
+	}
+	if k <= 0 || k > MaxFrameK {
+		return nil, FrameStats{}, ErrRecordTooLarge
+	}
+	dst = dst[:len(records)]
+
+	rawPayloadBytes := 0
+	for i := range records {
+		if records[i].RID == 0 {
+			return nil, FrameStats{}, errors.New("valuelog: missing rid")
+		}
+		if len(records[i].Value) > int(^uint32(0)) {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+		rawPayloadBytes += len(records[i].Value)
+		if rawPayloadBytes < 0 || rawPayloadBytes > int(^uint32(0)) {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+	}
+
+	// Only use writev when it is likely to produce large batched writes. For
+	// small average values, iov limits can force tiny writev calls and regress
+	// syscall counts compared to the contiguous-buffer path.
+	if !writevSupported || w.f == nil || (rawPayloadBytes/len(records)) < writevMinAvgValueSize {
+		stats := FrameStats{Compressed: false}
+		for i := 0; i < len(records); i += k {
+			end := i + k
+			if end > len(records) {
+				end = len(records)
+			}
+			_, frameStats, err := w.AppendFrameWithStatsInto(0, nil, records[i:end], dst[i:end])
+			if err != nil {
+				return nil, FrameStats{}, err
+			}
+			stats.Records += frameStats.Records
+			stats.RawPayloadBytes += frameStats.RawPayloadBytes
+			stats.StoredPayloadBytes += frameStats.StoredPayloadBytes
+		}
+		return dst, stats, nil
+	}
+
+	if err := w.flushAppendBuf(); err != nil {
+		return nil, FrameStats{}, err
+	}
+
+	max := w.appendMax
+	if max <= 0 {
+		max = defaultBufferSize
+	}
+	// Leave headroom: some platforms enforce lower limits than UIO_MAXIOV.
+	maxIovs := writevMaxIovs
+	if maxIovs <= 0 {
+		maxIovs = 1024
+	}
+	if maxIovs > 128 {
+		maxIovs -= 64
+	}
+
+	fd := int(w.f.Fd())
+	iovs := make([][]byte, 0, 128)
+	meta := make([]byte, 0, 4096)
+	queuedBytes := 0
+
+	flush := func() error {
+		if len(iovs) == 0 {
+			meta = meta[:0]
+			queuedBytes = 0
+			return nil
+		}
+		if err := writevAll(fd, iovs); err != nil {
+			return err
+		}
+		w.size += int64(queuedBytes)
+		iovs = iovs[:0]
+		meta = meta[:0]
+		queuedBytes = 0
+		return nil
+	}
+
+	pos := 0
+	for pos < len(records) {
+		end := pos + k
+		if end > len(records) {
+			end = len(records)
+		}
+		frameRecords := records[pos:end]
+		kFrame := len(frameRecords)
+		if kFrame <= 0 || kFrame > MaxFrameK {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+
+		var offsets [MaxFrameK + 1]uint32
+		offsets[0] = 0
+		framePayloadBytes := 0
+		for i := 0; i < kFrame; i++ {
+			framePayloadBytes += len(frameRecords[i].Value)
+			if framePayloadBytes < 0 || framePayloadBytes > int(^uint32(0)) {
+				return nil, FrameStats{}, ErrRecordTooLarge
+			}
+			offsets[i+1] = uint32(framePayloadBytes)
+		}
+		if slab.MaxRecordSize > 0 && int64(framePayloadBytes) > slab.MaxRecordSize {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+
+		prefixLen := FrameHeaderSize + (kFrame * 8) + ((kFrame + 1) * 4)
+		bodyLen := prefixLen + framePayloadBytes
+		if slab.MaxRecordSize > 0 && int64(HeaderSize+bodyLen) > slab.MaxRecordSize {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+		if bodyLen > int(^uint32(0)) {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+		if recordSizeExceedsMax(uint32(bodyLen)) {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+
+		totalLen := HeaderSize + bodyLen
+		neededIovs := 2 + kFrame
+		if len(iovs)+neededIovs > maxIovs || queuedBytes+totalLen > max {
+			if err := flush(); err != nil {
+				return nil, FrameStats{}, err
+			}
+		}
+
+		start := w.size + int64(queuedBytes)
+		recordLenNoCRC := uint32(headerWithoutCRC) + uint32(bodyLen)
+		for i := 0; i < kFrame; i++ {
+			dst[pos+i] = page.ValuePtr{
+				Offset: uint64(start + 4),
+				Length: page.ValuePtrMarkGrouped(recordLenNoCRC, uint8(i)),
+				FileID: w.fileID,
+			}
+		}
+
+		metaOff := len(meta)
+		meta = append(meta, make([]byte, HeaderSize+prefixLen)...)
+		header := meta[metaOff : metaOff+HeaderSize]
+		prefix := meta[metaOff+HeaderSize : metaOff+HeaderSize+prefixLen]
+
+		header[4] = Version
+		header[5] = recordFlagGrouped
+		header[6] = 0
+		header[7] = 0
+		binary.LittleEndian.PutUint64(header[8:16], 0)
+		binary.LittleEndian.PutUint32(header[16:20], uint32(bodyLen))
+
+		prefixOff := 0
+		prefix[prefixOff] = FrameVersion
+		prefix[prefixOff+1] = 0
+		prefix[prefixOff+2] = byte(kFrame)
+		prefix[prefixOff+3] = 0
+		binary.LittleEndian.PutUint64(prefix[prefixOff+4:prefixOff+12], 0)
+		prefixOff += FrameHeaderSize
+		for i := 0; i < kFrame; i++ {
+			binary.LittleEndian.PutUint64(prefix[prefixOff:prefixOff+8], frameRecords[i].RID)
+			prefixOff += 8
+		}
+		for i := 0; i < kFrame+1; i++ {
+			binary.LittleEndian.PutUint32(prefix[prefixOff:prefixOff+4], offsets[i])
+			prefixOff += 4
+		}
+
+		sum := uint32(0)
+		sum = crc.Update(sum, header[4:HeaderSize])
+		sum = crc.Update(sum, prefix)
+		for i := 0; i < kFrame; i++ {
+			sum = crc.Update(sum, frameRecords[i].Value)
+		}
+		binary.LittleEndian.PutUint32(header[0:4], sum)
+
+		iovs = append(iovs, header, prefix)
+		for i := 0; i < kFrame; i++ {
+			iovs = append(iovs, frameRecords[i].Value)
+		}
+		queuedBytes += totalLen
+
+		pos = end
+	}
+
+	if err := flush(); err != nil {
+		return nil, FrameStats{}, err
+	}
+
+	return dst, FrameStats{
+		Records:            len(records),
+		RawPayloadBytes:    rawPayloadBytes,
+		StoredPayloadBytes: rawPayloadBytes,
+		Compressed:         false,
+	}, nil
+}

--- a/TreeDB/internal/valuelog/writer_writev_test.go
+++ b/TreeDB/internal/valuelog/writer_writev_test.go
@@ -1,0 +1,83 @@
+package valuelog
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestAppendRawFramesWritevInto(t *testing.T) {
+	if !writevSupported {
+		t.Skip("writev not supported on this platform")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-000001.log")
+
+	writer, err := NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	// Force multiple writev flushes inside the batch append.
+	writer.appendMax = 256 << 10
+
+	const (
+		k        = 4
+		nRecords = 40
+		valSize  = 20 << 10
+	)
+	records := make([]Record, 0, nRecords)
+	for i := 0; i < nRecords; i++ {
+		records = append(records, Record{
+			RID:   uint64(i + 1),
+			Value: bytes.Repeat([]byte{byte(i%251) + 1}, valSize),
+		})
+	}
+
+	dst := make([]page.ValuePtr, len(records))
+	ptrs, stats, err := writer.AppendRawFramesWritevInto(records, k, dst)
+	if err != nil {
+		_ = writer.Close()
+		t.Fatalf("append: %v", err)
+	}
+	if stats.Records != len(records) {
+		_ = writer.Close()
+		t.Fatalf("expected %d records, got %d", len(records), stats.Records)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reader, err := NewReader(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	for i := 0; i < len(records); i++ {
+		rid, val, gotPtr, err := reader.ReadNext()
+		if err != nil {
+			_ = reader.Close()
+			t.Fatalf("read next: %v", err)
+		}
+		if rid != records[i].RID {
+			_ = reader.Close()
+			t.Fatalf("rid mismatch at %d: got %d want %d", i, rid, records[i].RID)
+		}
+		if !bytes.Equal(val, records[i].Value) {
+			_ = reader.Close()
+			t.Fatalf("value mismatch at %d", i)
+		}
+		if gotPtr != ptrs[i] {
+			_ = reader.Close()
+			t.Fatalf("ptr mismatch at %d: got %+v want %+v", i, gotPtr, ptrs[i])
+		}
+	}
+	if _, _, _, err := reader.ReadNext(); !errors.Is(err, io.EOF) {
+		_ = reader.Close()
+		t.Fatalf("expected EOF, got %v", err)
+	}
+	_ = reader.Close()
+}

--- a/TreeDB/internal/valuelog/writev_stub.go
+++ b/TreeDB/internal/valuelog/writev_stub.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package valuelog
+
+import "errors"
+
+const writevSupported = false
+
+const writevMaxIovs = 0
+
+func writevAll(fd int, iovs [][]byte) error {
+	return errors.New("valuelog: writev unsupported")
+}

--- a/TreeDB/internal/valuelog/writev_unix.go
+++ b/TreeDB/internal/valuelog/writev_unix.go
@@ -1,0 +1,43 @@
+//go:build unix
+
+package valuelog
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+const writevSupported = true
+
+// Conservative iovec limit used for batching in userspace.
+//
+// Many unix platforms have IOV_MAX/UIO_MAXIOV of 1024. We cap below this and
+// flush earlier to reduce the risk of hitting a smaller platform limit.
+const writevMaxIovs = 1024
+
+func writevAll(fd int, iovs [][]byte) error {
+	for len(iovs) > 0 {
+		n, err := unix.Writev(fd, iovs)
+		if err != nil {
+			if err == unix.EINTR || err == unix.EAGAIN {
+				continue
+			}
+			return err
+		}
+		if n <= 0 {
+			return errors.New("valuelog: short writev")
+		}
+		written := n
+		for written > 0 && len(iovs) > 0 {
+			if written >= len(iovs[0]) {
+				written -= len(iovs[0])
+				iovs = iovs[1:]
+				continue
+			}
+			iovs[0] = iovs[0][written:]
+			written = 0
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Summary
- Add a writev-batched raw frame append path to reduce user-space payload copying for large values.
- Wire cached-mode value-log append (dictID=0) to use the batch writev path when beneficial.
- Add a valuelog round-trip unit test for the new path.

Tests
- go test ./... -count=1

Bench
- (pending; follow-up after review)