### PR TITLE
PR24: value-log dict skip-frame hot path

### DIFF
--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -733,8 +733,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 		}
 
 		// If recent probes show compression yields no benefit, temporarily skip
-		// zstd and write raw values without concatenating them into a temporary
-		// buffer. We periodically probe again so we can adapt if data changes.
+		// zstd. We periodically probe again so we can adapt if data changes.
 		if w.skipRemain > 0 {
 			w.skipRemain--
 			bodyLen := FrameHeaderSize + (k * 8) + ((k + 1) * 4) + rawPayloadBytes
@@ -749,64 +748,128 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			}
 
 			start := w.size
-			var header [HeaderSize]byte
-			header[4] = Version
-			header[5] = recordFlagGrouped
-			header[6] = 0
-			header[7] = 0
-			binary.LittleEndian.PutUint64(header[8:16], 0)
-			binary.LittleEndian.PutUint32(header[16:20], uint32(bodyLen))
-
 			prefixLen := FrameHeaderSize + (k * 8) + ((k + 1) * 4)
-			if cap(w.prefixBuf) < prefixLen {
-				w.prefixBuf = make([]byte, 0, prefixLen)
-			}
-			prefix := w.prefixBuf[:prefixLen]
-			prefixOff := 0
-			prefix[prefixOff] = FrameVersion
-			prefix[prefixOff+1] = 0
-			prefix[prefixOff+2] = byte(k)
-			prefix[prefixOff+3] = 0
-			binary.LittleEndian.PutUint64(prefix[prefixOff+4:prefixOff+12], dictID)
-			prefixOff += FrameHeaderSize
-
-			for i := 0; i < k; i++ {
-				rid := records[i].RID
-				if rid == 0 {
-					return nil, FrameStats{}, errors.New("valuelog: missing rid")
-				}
-				binary.LittleEndian.PutUint64(prefix[prefixOff:prefixOff+8], rid)
-				prefixOff += 8
-			}
-			for i := 0; i < k+1; i++ {
-				binary.LittleEndian.PutUint32(prefix[prefixOff:prefixOff+4], offsets[i])
-				prefixOff += 4
-			}
-
-			const maxKeepScratch = 16 << 20 // 16 MiB
 			totalLen := HeaderSize + prefixLen + rawPayloadBytes
-			var frame []byte
-			if totalLen <= maxKeepScratch {
-				if cap(w.rawScratch) < totalLen {
-					w.rawScratch = make([]byte, totalLen)
+			max := w.appendMax
+			if max <= 0 {
+				max = defaultBufferSize
+			}
+
+			// Hot path: write directly into the writer append buffer so we don't
+			// build `frame` and then copy it into `appendBuf`.
+			if w.f != nil && totalLen <= max {
+				if len(w.appendBuf)+totalLen > max {
+					if err := w.flushAppendBuf(); err != nil {
+						return nil, FrameStats{}, err
+					}
 				}
-				frame = w.rawScratch[:totalLen]
+				if cap(w.appendBuf) < max {
+					w.appendBuf = make([]byte, len(w.appendBuf), max)
+				}
+				base := len(w.appendBuf)
+				w.appendBuf = w.appendBuf[:base+totalLen]
+				frame := w.appendBuf[base : base+totalLen]
+
+				frame[4] = Version
+				frame[5] = recordFlagGrouped
+				frame[6] = 0
+				frame[7] = 0
+				binary.LittleEndian.PutUint64(frame[8:16], 0)
+				binary.LittleEndian.PutUint32(frame[16:20], uint32(bodyLen))
+
+				off := HeaderSize
+				frame[off] = FrameVersion
+				frame[off+1] = 0
+				frame[off+2] = byte(k)
+				frame[off+3] = 0
+				binary.LittleEndian.PutUint64(frame[off+4:off+12], dictID)
+				off += FrameHeaderSize
+
+				for i := 0; i < k; i++ {
+					rid := records[i].RID
+					if rid == 0 {
+						return nil, FrameStats{}, errors.New("valuelog: missing rid")
+					}
+					binary.LittleEndian.PutUint64(frame[off:off+8], rid)
+					off += 8
+				}
+				for i := 0; i < k+1; i++ {
+					binary.LittleEndian.PutUint32(frame[off:off+4], offsets[i])
+					off += 4
+				}
+
+				for i := 0; i < k; i++ {
+					copy(frame[off:], records[i].Value)
+					off += len(records[i].Value)
+				}
+
+				sum := crc.ChecksumParts(frame[4:HeaderSize], frame[HeaderSize:])
+				binary.LittleEndian.PutUint32(frame[0:4], sum)
+				w.size += int64(HeaderSize + bodyLen)
+
+				if len(w.appendBuf) >= max {
+					if err := w.flushAppendBuf(); err != nil {
+						return nil, FrameStats{}, err
+					}
+				}
 			} else {
-				frame = make([]byte, totalLen)
+				if cap(w.prefixBuf) < prefixLen {
+					w.prefixBuf = make([]byte, 0, prefixLen)
+				}
+				prefix := w.prefixBuf[:prefixLen]
+				prefixOff := 0
+				prefix[prefixOff] = FrameVersion
+				prefix[prefixOff+1] = 0
+				prefix[prefixOff+2] = byte(k)
+				prefix[prefixOff+3] = 0
+				binary.LittleEndian.PutUint64(prefix[prefixOff+4:prefixOff+12], dictID)
+				prefixOff += FrameHeaderSize
+
+				for i := 0; i < k; i++ {
+					rid := records[i].RID
+					if rid == 0 {
+						return nil, FrameStats{}, errors.New("valuelog: missing rid")
+					}
+					binary.LittleEndian.PutUint64(prefix[prefixOff:prefixOff+8], rid)
+					prefixOff += 8
+				}
+				for i := 0; i < k+1; i++ {
+					binary.LittleEndian.PutUint32(prefix[prefixOff:prefixOff+4], offsets[i])
+					prefixOff += 4
+				}
+
+				const maxKeepScratch = 16 << 20 // 16 MiB
+				var header [HeaderSize]byte
+				header[4] = Version
+				header[5] = recordFlagGrouped
+				header[6] = 0
+				header[7] = 0
+				binary.LittleEndian.PutUint64(header[8:16], 0)
+				binary.LittleEndian.PutUint32(header[16:20], uint32(bodyLen))
+
+				var frame []byte
+				if totalLen <= maxKeepScratch {
+					if cap(w.rawScratch) < totalLen {
+						w.rawScratch = make([]byte, totalLen)
+					}
+					frame = w.rawScratch[:totalLen]
+				} else {
+					frame = make([]byte, totalLen)
+				}
+				copy(frame[0:HeaderSize], header[:])
+				copy(frame[HeaderSize:HeaderSize+prefixLen], prefix)
+				off := HeaderSize + prefixLen
+				for i := 0; i < k; i++ {
+					copy(frame[off:], records[i].Value)
+					off += len(records[i].Value)
+				}
+				sum := crc.ChecksumParts(frame[4:HeaderSize], frame[HeaderSize:])
+				binary.LittleEndian.PutUint32(frame[0:4], sum)
+				if err := w.writeFrameBatch(frame); err != nil {
+					return nil, FrameStats{}, err
+				}
+				w.size += int64(HeaderSize + bodyLen)
 			}
-			copy(frame[0:HeaderSize], header[:])
-			copy(frame[HeaderSize:HeaderSize+prefixLen], prefix)
-			off := HeaderSize + prefixLen
-			for i := 0; i < k; i++ {
-				copy(frame[off:], records[i].Value)
-				off += len(records[i].Value)
-			}
-			sum := crc.ChecksumParts(frame[4:HeaderSize], frame[HeaderSize:])
-			binary.LittleEndian.PutUint32(frame[0:4], sum)
-			if err := w.writeFrameBatch(frame); err != nil {
-				return nil, FrameStats{}, err
-			}
-			w.size += int64(HeaderSize + bodyLen)
 
 			recordLenNoCRC := uint32(headerWithoutCRC) + uint32(bodyLen)
 			for i := range records {


### PR DESCRIPTION
PR24: value-log dict skip-frame hot path

Summary
- When dictID!=0 and the writer is in "skip compression" mode (skipRemain>0), write the grouped frame directly into the writer append buffer (same approach as dict_off hot path) instead of building a temporary frame and then copying it into appendBuf.
- Goal: reduce steady-state overhead on incompressible / low-savings streams where dict is enabled but compression is mostly skipped.

Bench (before/after)
- Command: `go test ./TreeDB/internal/valuelog -run '^$' -bench 'BenchmarkValueLogDictCompressibilitySweep/valsize=1024/incompressible/dict_on/k=4$' -benchmem -count=5 -benchtime=2s`

Base (PR23)
```
goos: darwin
goarch: arm64
pkg: github.com/snissn/gomap/TreeDB/internal/valuelog
cpu: Apple M3
BenchmarkValueLogDictCompressibilitySweep/valsize=1024/incompressible/dict_on/k=4-8         	 1000000	      7568 ns/op	 541.25 MB/s	         0.004630 attempted_frac	         0.0006690 compressed_frac	         0 dict_fallback	         0.0006690 kept_frac	         0.9994 observed_ratio	      37 B/op	       0 allocs/op
BenchmarkValueLogDictCompressibilitySweep/valsize=1024/incompressible/dict_on/k=4-8         	 1000000	      5640 ns/op	 726.28 MB/s	         0.004630 attempted_frac	         0.0006690 compressed_frac	         0 dict_fallback	         0.0006690 kept_frac	         0.9994 observed_ratio	      37 B/op	       0 allocs/op
BenchmarkValueLogDictCompressibilitySweep/valsize=1024/incompressible/dict_on/k=4-8         	 1000000	      5078 ns/op	 806.59 MB/s	         0.004630 attempted_frac	         0.0006690 compressed_frac	         0 dict_fallback	         0.0006690 kept_frac	         0.9994 observed_ratio	      37 B/op	       0 allocs/op
BenchmarkValueLogDictCompressibilitySweep/valsize=1024/incompressible/dict_on/k=4-8         	 1000000	      2619 ns/op	1563.69 MB/s	         0.004630 attempted_frac	         0.0006690 compressed_frac	         0 dict_fallback	         0.0006690 kept_frac	         0.9994 observed_ratio	      37 B/op	       0 allocs/op
BenchmarkValueLogDictCompressibilitySweep/valsize=1024/incompressible/dict_on/k=4-8         	 1000000	      2482 ns/op	1650.10 MB/s	         0.004630 attempted_frac	         0.0006690 compressed_frac	         0 dict_fallback	         0.0006690 kept_frac	         0.9994 observed_ratio	      37 B/op	       0 allocs/op
PASS
ok  	github.com/snissn/gomap/TreeDB/internal/valuelog	26.067s
```

This PR (PR24)
```
goos: darwin
goarch: arm64
pkg: github.com/snissn/gomap/TreeDB/internal/valuelog
cpu: Apple M3
BenchmarkValueLogDictCompressibilitySweep/valsize=1024/incompressible/dict_on/k=4-8         	 1000000	      2305 ns/op	1776.94 MB/s	         0.004630 attempted_frac	         0.0006690 compressed_frac	         0 dict_fallback	         0.0006690 kept_frac	         0.9994 observed_ratio	      37 B/op	       0 allocs/op
BenchmarkValueLogDictCompressibilitySweep/valsize=1024/incompressible/dict_on/k=4-8         	 1000000	      2392 ns/op	1712.06 MB/s	         0.004630 attempted_frac	         0.0006690 compressed_frac	         0 dict_fallback	         0.0006690 kept_frac	         0.9994 observed_ratio	      37 B/op	       0 allocs/op
BenchmarkValueLogDictCompressibilitySweep/valsize=1024/incompressible/dict_on/k=4-8         	 1000000	      2364 ns/op	1732.53 MB/s	         0.004630 attempted_frac	         0.0006690 compressed_frac	         0 dict_fallback	         0.0006690 kept_frac	         0.9994 observed_ratio	      37 B/op	       0 allocs/op
BenchmarkValueLogDictCompressibilitySweep/valsize=1024/incompressible/dict_on/k=4-8         	 1000000	      2321 ns/op	1765.08 MB/s	         0.004630 attempted_frac	         0.0006690 compressed_frac	         0 dict_fallback	         0.0006690 kept_frac	         0.9994 observed_ratio	      37 B/op	       0 allocs/op
BenchmarkValueLogDictCompressibilitySweep/valsize=1024/incompressible/dict_on/k=4-8         	 1000000	      2201 ns/op	1860.71 MB/s	         0.004630 attempted_frac	         0.0006690 compressed_frac	         0 dict_fallback	         0.0006690 kept_frac	         0.9994 observed_ratio	      37 B/op	       0 allocs/op
PASS
ok  	github.com/snissn/gomap/TreeDB/internal/valuelog	14.603s
```

unified_bench output
- `go run ./cmd/unified_bench -suite vlog_dict -batchsize 1000`
```
# unified_bench suite: vlog_dict

- seed: 1
- batchsize: 1000
- warmup bytes: 16,777,216
- measure bytes: 33,554,432

| mode | dict | pattern | valsize | ops/sec | MB/s | observed_ratio | attempted_frac | kept_frac | dict_id | k | pause_bytes | wal_commit_bytes | wal_value_bytes | wal_total_bytes | index_bytes | dictdb_bytes |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| mode3 | off | highly_compressible_tail64 | 1024 | 1,286,251 | 1,256 | 1.016113 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 51,142,656 | 51,142,656 | 67,108,864 | 67,108,874 |
| mode3 | on | highly_compressible_tail64 | 1024 | 142,822 | 139 | 0.408592 | 1.000000 | 1.000000 | 14715858957706095217 | 2 | 0 | 0 | 20,565,120 | 20,565,120 | 67,108,864 | 67,149,858 |
| mode3 | off | incompressible | 1024 | 1,441,154 | 1,407 | 1.016113 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 51,142,656 | 51,142,656 | 67,108,864 | 67,108,874 |
| mode3 | on | incompressible | 1024 | 646,762 | 632 | 1.016113 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 51,142,656 | 51,142,656 | 67,108,864 | 67,108,874 |
| mode3 | off | highly_compressible_tail64 | 16384 | 106,864 | 1,670 | 1.001007 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 50,382,336 | 50,382,336 | 67,108,864 | 67,108,874 |
| mode3 | on | highly_compressible_tail64 | 16384 | 47,420 | 741 | 0.338122 | 1.000000 | 1.000000 | 17252032062606859535 | 2 | 0 | 0 | 17,018,262 | 17,018,262 | 67,108,864 | 67,149,858 |
| mode3 | off | incompressible | 16384 | 103,512 | 1,617 | 1.001007 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 50,382,336 | 50,382,336 | 67,108,864 | 67,108,874 |
| mode3 | on | incompressible | 16384 | 57,441 | 898 | 1.001007 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 50,382,336 | 50,382,336 | 67,108,864 | 67,108,874 |
| mode4 | off | highly_compressible_tail64 | 1024 | 1,191,432 | 1,164 | 1.016113 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 51,142,656 | 51,142,656 | 67,108,864 | 67,108,874 |
| mode4 | on | highly_compressible_tail64 | 1024 | 300,454 | 293 | 0.394585 | 1.000000 | 1.000000 | 14896282734163780264 | 2 | 0 | 0 | 19,860,096 | 19,860,096 | 67,108,864 | 67,149,858 |
| mode4 | off | incompressible | 1024 | 1,292,804 | 1,263 | 1.016113 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 51,142,656 | 51,142,656 | 67,108,864 | 67,108,874 |
| mode4 | on | incompressible | 1024 | 751,433 | 734 | 1.016113 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 51,142,656 | 51,142,656 | 67,108,864 | 67,108,874 |
| mode4 | off | highly_compressible_tail64 | 16384 | 117,218 | 1,832 | 1.001007 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 50,382,336 | 50,382,336 | 67,108,864 | 67,108,874 |
| mode4 | on | highly_compressible_tail64 | 16384 | 74,858 | 1,170 | 0.337295 | 1.000000 | 1.000000 | 17252032062606859535 | 2 | 0 | 0 | 16,976,596 | 16,976,596 | 67,108,864 | 67,149,858 |
| mode4 | off | incompressible | 16384 | 105,571 | 1,650 | 1.001007 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 50,382,336 | 50,382,336 | 67,108,864 | 67,108,874 |
| mode4 | on | incompressible | 16384 | 58,465 | 914 | 1.001007 | 0.000000 | 0.000000 | 0 | 0 | 0 | 0 | 50,382,336 | 50,382,336 | 67,108,864 | 67,108,874 |
```

Tests
- `go test ./... -count=1`
