### PR TITLE
PR28: speed up dict encoding via no-entropy

### DIFF
--- a/TreeDB/internal/valuelog/dict_codec_cache.go
+++ b/TreeDB/internal/valuelog/dict_codec_cache.go
@@ -62,6 +62,9 @@ func (c *dictCodecCache) getOrAdd(dictID uint64, dict []byte) *dictCodecEntry {
 		zstd.WithEncoderLevel(zstd.SpeedFastest),
 		zstd.WithEncoderConcurrency(1),
 		zstd.WithEncoderCRC(false),
+		// Trade ratio for throughput: dict-compressed payload streams tend to be
+		// match-heavy, so literal entropy coding can be an expensive marginal win.
+		zstd.WithNoEntropyCompression(true),
 	)
 	if err != nil {
 		return nil
@@ -78,6 +81,7 @@ func (c *dictCodecCache) getOrAdd(dictID uint64, dict []byte) *dictCodecEntry {
 				zstd.WithEncoderLevel(zstd.SpeedFastest),
 				zstd.WithEncoderConcurrency(1),
 				zstd.WithEncoderCRC(false),
+				zstd.WithNoEntropyCompression(true),
 			)
 			return enc
 		},


### PR DESCRIPTION
PR28: speed up dict encoding via no-entropy

Summary
- Enable `zstd.WithNoEntropyCompression(true)` for *dict-backed* value-log encoders.
- Goal: reduce literal entropy coding overhead (Huffman/FSE table work) while keeping strong savings from match-heavy dict streams.

Results (local)
- `BenchmarkValueLogDictCompressibilityCPU_NoIO/valsize=1024/highly_compressible_tail64/dict_on`
  - before: 13,019 ns/op (314.6 MB/s), observed_ratio=0.06979
  - after:   7,206 ns/op (568.4 MB/s), observed_ratio=0.06979
- `unified_bench dataset_write_sorted` (mode3-ish settings; 200k keys, 1KiB values, `repeat_tail64`)
  - before: 215,186 ops/sec
  - after:  451,493 ops/sec

Tests
- go test ./TreeDB/internal/valuelog -count=1
- go test ./... -count=1

Bench outputs

CPU_NoIO (before)
```text
$(cat /private/tmp/pr28_baseline_hc1k_cpu_noio.txt)
```

CPU_NoIO (after)
```text
$(cat /private/tmp/pr28_noentropy_hc1k_cpu_noio.txt)
```

unified_bench dataset_write_sorted (before)
```text
$(cat /private/tmp/pr28_baseline_dataset_sorted_mode3.txt)
```

unified_bench dataset_write_sorted (after)
```text
$(cat /private/tmp/pr28_noentropy_dataset_sorted_mode3.txt)
```

unified_bench suite vlog_dict (after)
```text
$(cat /private/tmp/pr28_vlog_dict_noentropy.txt)
```
