### PR TITLE
PR29: cache dict codecs per Writer

### DIFF
--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -41,6 +41,8 @@ type Writer struct {
 	rawScratch []byte
 	encScratch []byte
 	skipDictID uint64
+	codecsID   uint64
+	codecs     *dictCodecEntry
 	noBenefit  uint8
 	skipRemain uint16
 	syncFn     func(*os.File) error
@@ -898,7 +900,14 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			pos += len(records[i].Value)
 		}
 
-		codecs := getDictCodecs(dictID, dict)
+		codecs := w.codecs
+		if codecs == nil || w.codecsID != dictID {
+			codecs = getDictCodecs(dictID, dict)
+			if codecs != nil {
+				w.codecsID = dictID
+				w.codecs = codecs
+			}
+		}
 		if codecs == nil || codecs.encPool == nil {
 			return nil, FrameStats{}, ErrMissingDict
 		}


### PR DESCRIPTION
Summary
- Cache dict codec entry (encoder/decoder pools) per value-log Writer to avoid grabbing the global dict codec cache mutex on every frame when dictID is stable.

Tests
- go test ./... -count=1

Bench (CPU no-IO)
- go test ./TreeDB/internal/valuelog -run ^$ -bench "ValueLogDictCompressibilityCPU_NoIO/valsize=1024/highly_compressible_tail64/dict_on" -benchmem -benchtime=2s -count=5
  - PR28 (baseline) ns/op: 7358 / 7451 / 7346 / 7369 / 7372  (mid3 avg=7366)
  - PR29 ns/op:          7293 / 7368 / 7237 / 7310 / 7306  (mid3 avg=7303)

unified_bench output
- Posted in PR comment (vlog_dict suite).