### PR TITLE
PR-AT0: spec + bench hygiene

### DIFF
--- a/TreeDB/.pr/PR0_description.md
+++ b/TreeDB/.pr/PR0_description.md
@@ -1,0 +1,9 @@
+## Summary
+- Add code-map appendix + worklog section to autotuner runbook.
+- Bench metrics report `kept_frac` only to avoid ambiguous “compressed” labeling.
+
+## Testing
+- `go test ./... -count=1`
+
+## Benchmarks
+- Not run (no behavior change).

--- a/TreeDB/AGENTS.md
+++ b/TreeDB/AGENTS.md
@@ -993,3 +993,48 @@ Rollout (recommended):
 * Provide a single “kill switch” (env var or option) that forces Off.
 
 ---
+
+## Appendix A) Code map (symbols and responsibilities)
+
+This list exists to make the runbook executable without guesswork.
+
+### Value‑log writer / encoding
+- `internal/valuelog/valuelog.go`
+  - `type FrameStats`
+  - `const MaxFrameK`
+- `internal/valuelog/writer.go`
+  - `func (*Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []Record, ptrScratch []byte) (FrameStats, error)`
+  - raw helpers typically named like `appendRawFrameWithDictID(...)` (ensure Attempted survives fallbacks)
+
+### Compression training + profiling
+- `internal/compression/trainer.go`
+  - `type TrainConfig`
+  - `type Trainer`
+  - `func (t *Trainer) Add(value []byte)`
+  - `func (t *Trainer) Train(now time.Time, slabID uint64) (ActiveProfile, ok bool)`
+- `internal/compression/profile.go`
+  - `type ActiveProfile` (dict bytes/hash/historyBytes/k/ratios/cost estimates)
+  - `ChooseKForDict(...)`
+
+### Pause/probe ratio metrics
+- `internal/compression/metrics.go`
+  - `type Metrics`
+  - `func (m *Metrics) Add(slabID uint64, raw, stored, records int, compressed bool) (pauseBytes int)`
+  - `PauseThreshold`, `WindowBytes`, `MinRecords`, `PauseBytes`
+
+### Cached DB integration (value‑log dict loop + state)
+- `caching/vlog_dict.go`
+  - dict sampling, training loop, `applyValueLogDictProfile(...)`
+  - pause/probe fields (atomics) and counters
+- `caching/db.go`
+  - write paths that append to value log:
+    - `appendValueLogOne`
+    - `appendValueLogBatch`
+  - best place to measure wall time and feed observations into autotuner
+
+
+
+## Appendix B
+
+Worklog - update below with summary of each action - update on each commit
+- 2026-01-22 PR-AT0: added code-map appendix and worklog section; bench metrics now report `kept_frac` only; tests: `go test ./... -count=1`.

--- a/TreeDB/internal/valuelog/dict_autotune_bench_test.go
+++ b/TreeDB/internal/valuelog/dict_autotune_bench_test.go
@@ -272,7 +272,7 @@ func runValueLogDictAutotuneNoIOBench(
 	totalStored := uint64(0)
 	totalFrames := uint64(0)
 	attemptedFrames := uint64(0)
-	compressedFrames := uint64(0)
+	keptFrames := uint64(0)
 
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < k; j++ {
@@ -288,7 +288,7 @@ func runValueLogDictAutotuneNoIOBench(
 			attemptedFrames++
 		}
 		if stats.Compressed {
-			compressedFrames++
+			keptFrames++
 		}
 		totalRaw += uint64(stats.RawPayloadBytes)
 		totalStored += uint64(stats.StoredPayloadBytes)
@@ -302,9 +302,8 @@ func runValueLogDictAutotuneNoIOBench(
 		b.ReportMetric(float64(totalStored)/float64(totalRaw), "observed_ratio")
 	}
 	if totalFrames > 0 {
-		compressedFrac := float64(compressedFrames) / float64(totalFrames)
-		b.ReportMetric(compressedFrac, "compressed_frac")
-		b.ReportMetric(compressedFrac, "kept_frac")
+		keptFrac := float64(keptFrames) / float64(totalFrames)
+		b.ReportMetric(keptFrac, "kept_frac")
 		b.ReportMetric(float64(attemptedFrames)/float64(totalFrames), "attempted_frac")
 	}
 

--- a/TreeDB/internal/valuelog/dict_compressibility_bench_test.go
+++ b/TreeDB/internal/valuelog/dict_compressibility_bench_test.go
@@ -127,7 +127,7 @@ func BenchmarkValueLogDictCompressibilityCPU_NoIO(b *testing.B) {
 					totalStored := uint64(0)
 					totalFrames := uint64(0)
 					attemptedFrames := uint64(0)
-					compressedFrames := uint64(0)
+					keptFrames := uint64(0)
 					for i := 0; i < b.N; i++ {
 						for j := 0; j < k; j++ {
 							records[j] = Record{RID: rid, Value: values[(i+j)%len(values)]}
@@ -142,7 +142,7 @@ func BenchmarkValueLogDictCompressibilityCPU_NoIO(b *testing.B) {
 							attemptedFrames++
 						}
 						if stats.Compressed {
-							compressedFrames++
+							keptFrames++
 						}
 						totalRaw += uint64(stats.RawPayloadBytes)
 						totalStored += uint64(stats.StoredPayloadBytes)
@@ -153,9 +153,8 @@ func BenchmarkValueLogDictCompressibilityCPU_NoIO(b *testing.B) {
 						b.ReportMetric(float64(totalStored)/float64(totalRaw), "observed_ratio")
 					}
 					if totalFrames > 0 {
-						compressedFrac := float64(compressedFrames) / float64(totalFrames)
-						b.ReportMetric(compressedFrac, "compressed_frac")
-						b.ReportMetric(compressedFrac, "kept_frac")
+						keptFrac := float64(keptFrames) / float64(totalFrames)
+						b.ReportMetric(keptFrac, "kept_frac")
 						b.ReportMetric(float64(attemptedFrames)/float64(totalFrames), "attempted_frac")
 					}
 				})
@@ -307,7 +306,7 @@ func BenchmarkValueLogDictCompressibilitySweep(b *testing.B) {
 						totalStored := uint64(0)
 						totalFrames := uint64(0)
 						attemptedFrames := uint64(0)
-						compressedFrames := uint64(0)
+						keptFrames := uint64(0)
 						records := make([]Record, k)
 						ptrScratch := make([]page.ValuePtr, k)
 						for i := 0; i < b.N; i++ {
@@ -324,7 +323,7 @@ func BenchmarkValueLogDictCompressibilitySweep(b *testing.B) {
 								attemptedFrames++
 							}
 							if stats.Compressed {
-								compressedFrames++
+								keptFrames++
 							}
 							totalRaw += uint64(stats.RawPayloadBytes)
 							totalStored += uint64(stats.StoredPayloadBytes)
@@ -340,9 +339,8 @@ func BenchmarkValueLogDictCompressibilitySweep(b *testing.B) {
 							b.ReportMetric(float64(totalStored)/float64(totalRaw), "observed_ratio")
 						}
 						if totalFrames > 0 {
-							compressedFrac := float64(compressedFrames) / float64(totalFrames)
-							b.ReportMetric(compressedFrac, "compressed_frac")
-							b.ReportMetric(compressedFrac, "kept_frac")
+							keptFrac := float64(keptFrames) / float64(totalFrames)
+							b.ReportMetric(keptFrac, "kept_frac")
 							b.ReportMetric(float64(attemptedFrames)/float64(totalFrames), "attempted_frac")
 						}
 					})


### PR DESCRIPTION
## Summary
- Add code-map appendix + worklog section to autotuner runbook.
- Bench metrics report `kept_frac` only to avoid ambiguous “compressed” labeling.

## Testing
- `go test ./... -count=1`

## Benchmarks
- Not run (no behavior change).
