### PR TITLE
PR-AT2: wall-time metrics + EWMAs

### DIFF
--- a/TreeDB/.pr/PR2_description.md
+++ b/TreeDB/.pr/PR2_description.md
@@ -1,0 +1,10 @@
+## Summary
+- Add value-log autotune metrics with EWMAs for encode cost, IO cost, ratio, and throughput.
+- Measure wall time at value-log append boundaries and feed metrics (with optional env-gated logging).
+- Expose EWMA snapshots via cache stats.
+
+## Testing
+- `go test ./... -count=1`
+
+## Benchmarks
+- Not run.

--- a/TreeDB/AGENTS.md
+++ b/TreeDB/AGENTS.md
@@ -1039,3 +1039,4 @@ This list exists to make the runbook executable without guesswork.
 Worklog - update below with summary of each action - update on each commit
 - 2026-01-22 PR-AT0: added code-map appendix and worklog section; bench metrics now report `kept_frac` only; tests: `go test ./... -count=1`.
 - 2026-01-22 PR-AT1: FrameStats now uses Attempted/Kept + sampled EncodeNs; writer reports Attempted on fallback; updated caching + benches for Kept; tests: `go test ./... -count=1`.
+- 2026-01-22 PR-AT2: added wall-time EWMAs + vlog autotune metrics/logging, wired append boundary measurements; tests: `go test ./... -count=1`.

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1370,6 +1370,7 @@ type DB struct {
 		attempted atomic.Uint64
 		kept      atomic.Uint64
 	}
+	valueLogAutotuneMetrics vlogAutotuneMetrics
 
 	valueLogDictPauseRemaining      atomic.Uint64
 	valueLogDictProbeBytes          uint64
@@ -2071,6 +2072,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		autoCheckpointWriteCh:          make(chan struct{}, 1),
 		lanes:                          lanes,
 	}
+	db.valueLogAutotuneMetrics.init(valuelog.RealClock{})
 	db.bpCond = sync.NewCond(&db.bpMu)
 	db.laneCond = sync.NewCond(&db.laneMu)
 	db.checkpointCond = sync.NewCond(&db.checkpointMu)
@@ -2742,6 +2744,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		return nil, errWALClosed
 	default:
 	}
+	wallStart := db.valueLogAutotuneMetrics.now()
 
 	var (
 		totalBytes int64
@@ -2822,6 +2825,8 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	framesTotal := 0
 	framesAttempted := 0
 	framesKept := 0
+	encodeNsTotal := int64(0)
+	encodeRawBytes := 0
 	rawBatchUsed := false
 	if dictID == 0 && hasRawInto && len(records) > 1 {
 		ptrs = make([]page.ValuePtr, len(records))
@@ -2865,6 +2870,10 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				if stats.Kept {
 					framesKept++
 				}
+				if stats.EncodeNs > 0 && stats.RawPayloadBytes > 0 {
+					encodeNsTotal += stats.EncodeNs
+					encodeRawBytes += stats.RawPayloadBytes
+				}
 				continue
 			}
 			if hasStats {
@@ -2883,6 +2892,10 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				}
 				if stats.Kept {
 					framesKept++
+				}
+				if stats.EncodeNs > 0 && stats.RawPayloadBytes > 0 {
+					encodeNsTotal += stats.EncodeNs
+					encodeRawBytes += stats.RawPayloadBytes
 				}
 				continue
 			}
@@ -2951,6 +2964,11 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	if totalBytes > 0 {
 		l.vlogLiveBytes.Add(totalBytes)
 	}
+	storedForMetrics := storedPayloadBytes
+	if storedForMetrics == 0 && totalBytes > 0 {
+		storedForMetrics = int(totalBytes)
+	}
+	db.valueLogAutotuneMetrics.observe(wallStart, rawPayloadBytes, storedForMetrics, encodeNsTotal, encodeRawBytes)
 	return ptrs, nil
 }
 
@@ -2966,6 +2984,7 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 		return page.ValuePtr{}, "", errWALClosed
 	default:
 	}
+	wallStart := db.valueLogAutotuneMetrics.now()
 
 	var (
 		totalBytes int64
@@ -3068,6 +3087,17 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 	if totalBytes > 0 {
 		l.vlogLiveBytes.Add(totalBytes)
 	}
+	encodeNsTotal := int64(0)
+	encodeRawBytes := 0
+	if stats.EncodeNs > 0 && stats.RawPayloadBytes > 0 {
+		encodeNsTotal = stats.EncodeNs
+		encodeRawBytes = stats.RawPayloadBytes
+	}
+	storedForMetrics := stats.StoredPayloadBytes
+	if storedForMetrics == 0 && totalBytes > 0 {
+		storedForMetrics = int(totalBytes)
+	}
+	db.valueLogAutotuneMetrics.observe(wallStart, len(value), storedForMetrics, encodeNsTotal, encodeRawBytes)
 	return ptr, retainPath, nil
 }
 
@@ -6140,6 +6170,12 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_dict.pause_remaining_bytes"] = fmt.Sprintf("%d", db.valueLogDictPauseRemaining.Load())
 	stats["treedb.cache.vlog_dict.last_applied_dict_id"] = fmt.Sprintf("%d", db.valueLogDictLastAppliedDictID.Load())
 	stats["treedb.cache.vlog_dict.current_k"] = fmt.Sprintf("%d", db.valueLogDictCurrentK.Load())
+	if snap := db.valueLogAutotuneMetrics.snapshot(); snap.hasData() {
+		stats["treedb.cache.vlog_autotune.encode_ns_per_raw_byte"] = fmt.Sprintf("%.3f", snap.EncodeNsPerRawByte)
+		stats["treedb.cache.vlog_autotune.io_ns_per_stored_byte"] = fmt.Sprintf("%.3f", snap.IoNsPerStoredByte)
+		stats["treedb.cache.vlog_autotune.throughput_raw_MBps"] = fmt.Sprintf("%.3f", snap.ThroughputRawMBps)
+		stats["treedb.cache.vlog_autotune.observed_ratio"] = fmt.Sprintf("%.6f", snap.ObservedRatio)
+	}
 	return stats
 }
 

--- a/TreeDB/caching/vlog_autotune_metrics.go
+++ b/TreeDB/caching/vlog_autotune_metrics.go
@@ -1,0 +1,180 @@
+package caching
+
+import (
+	"log"
+	"math"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+)
+
+const (
+	vlogAutotuneEWMAAlpha        = 0.1
+	vlogAutotuneLogEveryDefault  = 1024
+	vlogAutotuneLogBudgetDefault = 200
+	vlogAutotuneMetricsEnv       = "TREEDB_VLOG_AUTOTUNE_METRICS"
+	vlogAutotuneMetricsEveryEnv  = "TREEDB_VLOG_AUTOTUNE_METRICS_EVERY"
+	vlogAutotuneMetricsBudgetEnv = "TREEDB_VLOG_AUTOTUNE_METRICS_BUDGET"
+)
+
+var (
+	vlogAutotuneMetricsEnabled atomic.Bool
+	vlogAutotuneMetricsEvery   atomic.Uint64
+	vlogAutotuneMetricsBudget  atomic.Int64
+)
+
+func init() {
+	vlogAutotuneMetricsEvery.Store(vlogAutotuneLogEveryDefault)
+	if os.Getenv(vlogAutotuneMetricsEnv) == "" {
+		return
+	}
+	vlogAutotuneMetricsEnabled.Store(true)
+	if s := os.Getenv(vlogAutotuneMetricsEveryEnv); s != "" {
+		if v, err := strconv.ParseUint(s, 10, 64); err == nil && v > 0 {
+			vlogAutotuneMetricsEvery.Store(v)
+		}
+	}
+	budget := int64(vlogAutotuneLogBudgetDefault)
+	if s := os.Getenv(vlogAutotuneMetricsBudgetEnv); s != "" {
+		if v, err := strconv.ParseInt(s, 10, 64); err == nil && v >= 0 {
+			budget = v
+		}
+	}
+	vlogAutotuneMetricsBudget.Store(budget)
+}
+
+type vlogAutotuneMetrics struct {
+	clock              valuelog.Clock
+	encodeNsPerRawByte atomic.Uint64
+	ioNsPerStoredByte  atomic.Uint64
+	throughputRawMBps  atomic.Uint64
+	observedRatio      atomic.Uint64
+	updates            atomic.Uint64
+}
+
+type vlogAutotuneSnapshot struct {
+	EncodeNsPerRawByte float64
+	IoNsPerStoredByte  float64
+	ThroughputRawMBps  float64
+	ObservedRatio      float64
+}
+
+func (s vlogAutotuneSnapshot) hasData() bool {
+	return s.EncodeNsPerRawByte > 0 || s.IoNsPerStoredByte > 0 || s.ThroughputRawMBps > 0 || s.ObservedRatio > 0
+}
+
+func (m *vlogAutotuneMetrics) init(clock valuelog.Clock) {
+	if m == nil {
+		return
+	}
+	if clock == nil {
+		clock = valuelog.RealClock{}
+	}
+	m.clock = clock
+}
+
+func (m *vlogAutotuneMetrics) setClock(clock valuelog.Clock) {
+	if m == nil {
+		return
+	}
+	if clock == nil {
+		clock = valuelog.RealClock{}
+	}
+	m.clock = clock
+}
+
+func (m *vlogAutotuneMetrics) now() time.Time {
+	if m == nil {
+		return time.Time{}
+	}
+	if m.clock == nil {
+		m.clock = valuelog.RealClock{}
+	}
+	return m.clock.Now()
+}
+
+func (m *vlogAutotuneMetrics) observe(start time.Time, rawBytes, storedBytes int, encodeNs int64, encodeRawBytes int) {
+	if m == nil || rawBytes <= 0 || start.IsZero() {
+		return
+	}
+	if m.clock == nil {
+		m.clock = valuelog.RealClock{}
+	}
+	wallNs := m.clock.Now().Sub(start).Nanoseconds()
+	if wallNs <= 0 {
+		return
+	}
+	if storedBytes <= 0 {
+		storedBytes = rawBytes
+	}
+	throughput := float64(rawBytes) * 1e3 / float64(wallNs)
+	ioNsPerStored := float64(wallNs) / float64(storedBytes)
+	observedRatio := float64(storedBytes) / float64(rawBytes)
+
+	updateEWMA(&m.throughputRawMBps, throughput)
+	updateEWMA(&m.ioNsPerStoredByte, ioNsPerStored)
+	updateEWMA(&m.observedRatio, observedRatio)
+	if encodeNs > 0 && encodeRawBytes > 0 {
+		encodeNsPerRaw := float64(encodeNs) / float64(encodeRawBytes)
+		updateEWMA(&m.encodeNsPerRawByte, encodeNsPerRaw)
+	}
+
+	updates := m.updates.Add(1)
+	if !vlogAutotuneMetricsEnabled.Load() {
+		return
+	}
+	every := vlogAutotuneMetricsEvery.Load()
+	if every == 0 || updates%every != 0 {
+		return
+	}
+	if vlogAutotuneMetricsBudget.Add(-1) < 0 {
+		return
+	}
+	snap := m.snapshot()
+	log.Printf("treedb: vlog_autotune_metrics raw=%d stored=%d wall_ns=%d encode_ns=%d encode_raw=%d encode_ns_per_raw_byte=%.3f io_ns_per_stored_byte=%.3f throughput_raw_MBps=%.3f observed_ratio=%.3f",
+		rawBytes,
+		storedBytes,
+		wallNs,
+		encodeNs,
+		encodeRawBytes,
+		snap.EncodeNsPerRawByte,
+		snap.IoNsPerStoredByte,
+		snap.ThroughputRawMBps,
+		snap.ObservedRatio,
+	)
+}
+
+func (m *vlogAutotuneMetrics) snapshot() vlogAutotuneSnapshot {
+	if m == nil {
+		return vlogAutotuneSnapshot{}
+	}
+	return vlogAutotuneSnapshot{
+		EncodeNsPerRawByte: math.Float64frombits(m.encodeNsPerRawByte.Load()),
+		IoNsPerStoredByte:  math.Float64frombits(m.ioNsPerStoredByte.Load()),
+		ThroughputRawMBps:  math.Float64frombits(m.throughputRawMBps.Load()),
+		ObservedRatio:      math.Float64frombits(m.observedRatio.Load()),
+	}
+}
+
+func updateEWMA(dst *atomic.Uint64, sample float64) float64 {
+	if dst == nil || sample <= 0 || math.IsNaN(sample) || math.IsInf(sample, 0) {
+		if dst == nil {
+			return 0
+		}
+		return math.Float64frombits(dst.Load())
+	}
+	for {
+		oldBits := dst.Load()
+		old := math.Float64frombits(oldBits)
+		next := sample
+		if old > 0 && !math.IsNaN(old) && !math.IsInf(old, 0) {
+			next = (1-vlogAutotuneEWMAAlpha)*old + vlogAutotuneEWMAAlpha*sample
+		}
+		if dst.CompareAndSwap(oldBits, math.Float64bits(next)) {
+			return next
+		}
+	}
+}

--- a/TreeDB/internal/valuelog/clock.go
+++ b/TreeDB/internal/valuelog/clock.go
@@ -6,8 +6,8 @@ type Clock interface {
 	Now() time.Time
 }
 
-type realClock struct{}
+type RealClock struct{}
 
-func (realClock) Now() time.Time {
+func (RealClock) Now() time.Time {
 	return time.Now()
 }

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -188,7 +188,7 @@ func NewWriter(path string, fileID uint32) (*Writer, error) {
 		scratch:   make([]byte, 0, defaultBufferSize),
 		prefixBuf: make([]byte, 0, FrameHeaderSize+(MaxFrameK*8)+((MaxFrameK+1)*4)),
 		syncFn:    func(file *os.File) error { return file.Sync() },
-		clock:     realClock{},
+		clock:     RealClock{},
 	}, nil
 }
 
@@ -199,7 +199,7 @@ func newWriterWithSink(sink io.Writer, fileID uint32) *Writer {
 		appendMax: 0,
 		scratch:   make([]byte, 0, defaultBufferSize),
 		prefixBuf: make([]byte, 0, FrameHeaderSize+(MaxFrameK*8)+((MaxFrameK+1)*4)),
-		clock:     realClock{},
+		clock:     RealClock{},
 	}
 }
 
@@ -208,7 +208,7 @@ func (w *Writer) SetClock(clock Clock) {
 		return
 	}
 	if clock == nil {
-		w.clock = realClock{}
+		w.clock = RealClock{}
 		return
 	}
 	w.clock = clock
@@ -234,7 +234,7 @@ func (w *Writer) sampleEncodeStart() time.Time {
 		return time.Time{}
 	}
 	if w.clock == nil {
-		w.clock = realClock{}
+		w.clock = RealClock{}
 	}
 	return w.clock.Now()
 }
@@ -244,7 +244,7 @@ func (w *Writer) sampleEncodeEnd(start time.Time) int64 {
 		return 0
 	}
 	if w.clock == nil {
-		w.clock = realClock{}
+		w.clock = RealClock{}
 	}
 	return w.clock.Now().Sub(start).Nanoseconds()
 }


### PR DESCRIPTION
## Summary
- Add value-log autotune metrics with EWMAs for encode cost, IO cost, ratio, and throughput.
- Measure wall time at value-log append boundaries and feed metrics (with optional env-gated logging).
- Expose EWMA snapshots via cache stats.

## Testing
- `go test ./... -count=1`

## Benchmarks
- Not run.
