### PR TITLE
PR-AT3: throughput-aware keep decision

### DIFF
--- a/TreeDB/.pr/PR3_description.md
+++ b/TreeDB/.pr/PR3_description.md
@@ -1,0 +1,11 @@
+## Summary
+- Add throughput-based keep decision for value-log compression with safety margin.
+- Writer consumes IO/encode EWMAs via SetKeepPolicy and falls back to size-based when unknown.
+- Add unit tests for the keep inequality and margin sensitivity.
+
+## Testing
+- `go test ./internal/valuelog -count=1`
+- `go test ./... -count=1`
+
+## Benchmarks
+- Not run.

--- a/TreeDB/AGENTS.md
+++ b/TreeDB/AGENTS.md
@@ -1040,3 +1040,4 @@ Worklog - update below with summary of each action - update on each commit
 - 2026-01-22 PR-AT0: added code-map appendix and worklog section; bench metrics now report `kept_frac` only; tests: `go test ./... -count=1`.
 - 2026-01-22 PR-AT1: FrameStats now uses Attempted/Kept + sampled EncodeNs; writer reports Attempted on fallback; updated caching + benches for Kept; tests: `go test ./... -count=1`.
 - 2026-01-22 PR-AT2: added wall-time EWMAs + vlog autotune metrics/logging, wired append boundary measurements; tests: `go test ./... -count=1`.
+- 2026-01-22 PR-AT3: throughput-aware keep decision + unit tests; writer uses EWMA estimates; tests: `go test ./internal/valuelog -count=1`, `go test ./... -count=1`.

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2757,6 +2757,12 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		l.vlogMu.Unlock()
 		return nil, errWALUnavailable
 	}
+	if policySetter, ok := any(w).(interface {
+		SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64)
+	}); ok {
+		snap := db.valueLogAutotuneMetrics.snapshot()
+		policySetter.SetKeepPolicy(snap.IoNsPerStoredByte, snap.EncodeNsPerRawByte, valuelog.DefaultKeepSafetyMargin)
+	}
 	startSize := w.Size()
 
 	rawPayloadBytes := 0
@@ -2996,6 +3002,12 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 	if w == nil {
 		l.vlogMu.Unlock()
 		return page.ValuePtr{}, "", errWALUnavailable
+	}
+	if policySetter, ok := any(w).(interface {
+		SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64)
+	}); ok {
+		snap := db.valueLogAutotuneMetrics.snapshot()
+		policySetter.SetKeepPolicy(snap.IoNsPerStoredByte, snap.EncodeNsPerRawByte, valuelog.DefaultKeepSafetyMargin)
 	}
 	startSize := w.Size()
 

--- a/TreeDB/internal/valuelog/autotune_keep.go
+++ b/TreeDB/internal/valuelog/autotune_keep.go
@@ -1,0 +1,24 @@
+package valuelog
+
+const DefaultKeepSafetyMargin = 0.10
+
+// ShouldKeepCompressed decides whether to keep compressed bytes for a frame.
+// It compares estimated IO savings against encode cost with a safety margin.
+func ShouldKeepCompressed(rawBytes, encodedBytes int, encodeNs int64, ioNsPerStoredByte, safetyMargin float64) bool {
+	if rawBytes <= 0 || encodedBytes < 0 {
+		return false
+	}
+	if encodedBytes >= rawBytes {
+		return false
+	}
+	if ioNsPerStoredByte <= 0 || encodeNs <= 0 {
+		// Fall back to size-based decision when we lack cost estimates.
+		return true
+	}
+	if safetyMargin < 0 {
+		safetyMargin = 0
+	}
+	savings := float64(rawBytes-encodedBytes) * ioNsPerStoredByte
+	cost := float64(encodeNs) * (1 + safetyMargin)
+	return savings > cost
+}

--- a/TreeDB/internal/valuelog/autotune_keep_test.go
+++ b/TreeDB/internal/valuelog/autotune_keep_test.go
@@ -1,0 +1,88 @@
+package valuelog
+
+import "testing"
+
+func TestShouldKeepCompressed(t *testing.T) {
+	tests := []struct {
+		name         string
+		rawBytes     int
+		encodedBytes int
+		encodeNs     int64
+		ioNsPerByte  float64
+		safetyMargin float64
+		wantKeep     bool
+	}{
+		{
+			name:         "encoded_ge_raw_never_keep",
+			rawBytes:     100,
+			encodedBytes: 100,
+			encodeNs:     1,
+			ioNsPerByte:  10,
+			safetyMargin: 0.10,
+			wantKeep:     false,
+		},
+		{
+			name:         "savings_below_threshold",
+			rawBytes:     1000,
+			encodedBytes: 900,
+			encodeNs:     1000,
+			ioNsPerByte:  10, // savings=100*10=1000, cost=1100
+			safetyMargin: 0.10,
+			wantKeep:     false,
+		},
+		{
+			name:         "savings_above_threshold",
+			rawBytes:     1000,
+			encodedBytes: 800,
+			encodeNs:     1000,
+			ioNsPerByte:  10, // savings=2000, cost=1100
+			safetyMargin: 0.10,
+			wantKeep:     true,
+		},
+		{
+			name:         "safety_margin_sensitivity_aggressive",
+			rawBytes:     1000,
+			encodedBytes: 900,
+			encodeNs:     950, // savings=1000, cost=969
+			ioNsPerByte:  10,
+			safetyMargin: 0.02,
+			wantKeep:     true,
+		},
+		{
+			name:         "safety_margin_sensitivity_medium",
+			rawBytes:     1000,
+			encodedBytes: 900,
+			encodeNs:     950, // savings=1000, cost=1045
+			ioNsPerByte:  10,
+			safetyMargin: 0.10,
+			wantKeep:     false,
+		},
+		{
+			name:         "fallback_when_encode_ns_missing",
+			rawBytes:     1000,
+			encodedBytes: 900,
+			encodeNs:     0,
+			ioNsPerByte:  10,
+			safetyMargin: 0.10,
+			wantKeep:     true,
+		},
+		{
+			name:         "fallback_when_io_cost_missing",
+			rawBytes:     1000,
+			encodedBytes: 900,
+			encodeNs:     1000,
+			ioNsPerByte:  0,
+			safetyMargin: 0.10,
+			wantKeep:     true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := ShouldKeepCompressed(tc.rawBytes, tc.encodedBytes, tc.encodeNs, tc.ioNsPerByte, tc.safetyMargin)
+			if got != tc.wantKeep {
+				t.Fatalf("got %v want %v", got, tc.wantKeep)
+			}
+		})
+	}
+}

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -31,26 +31,29 @@ func recordSizeExceedsMax(valueLen uint32) bool {
 }
 
 type Writer struct {
-	f                  *os.File
-	bw                 *bufio.Writer
-	size               int64
-	fileID             uint32
-	appendBuf          []byte
-	appendMax          int
-	scratch            []byte
-	prefixBuf          []byte
-	rawScratch         []byte
-	encScratch         []byte
-	encLimiter         limitedSliceWriter
-	skipDictID         uint64
-	codecsID           uint64
-	codecs             *dictCodecEntry
-	noBenefit          uint8
-	skipRemain         uint16
-	syncFn             func(*os.File) error
-	clock              Clock
-	encodeSampleStride uint64
-	encodeSampleCount  uint64
+	f                      *os.File
+	bw                     *bufio.Writer
+	size                   int64
+	fileID                 uint32
+	appendBuf              []byte
+	appendMax              int
+	scratch                []byte
+	prefixBuf              []byte
+	rawScratch             []byte
+	encScratch             []byte
+	encLimiter             limitedSliceWriter
+	skipDictID             uint64
+	codecsID               uint64
+	codecs                 *dictCodecEntry
+	noBenefit              uint8
+	skipRemain             uint16
+	syncFn                 func(*os.File) error
+	clock                  Clock
+	encodeSampleStride     uint64
+	encodeSampleCount      uint64
+	keepIoNsPerStoredByte  float64
+	keepEncodeNsPerRawByte float64
+	keepSafetyMargin       float64
 }
 
 var errEncodedTooLarge = errors.New("valuelog: encoded payload too large")
@@ -179,27 +182,29 @@ func NewWriter(path string, fileID uint32) (*Writer, error) {
 		return nil, err
 	}
 	return &Writer{
-		f:         f,
-		bw:        bufio.NewWriterSize(f, defaultBufferSize),
-		size:      info.Size(),
-		fileID:    fileID,
-		appendMax: defaultBufferSize,
-		appendBuf: make([]byte, 0, defaultBufferSize),
-		scratch:   make([]byte, 0, defaultBufferSize),
-		prefixBuf: make([]byte, 0, FrameHeaderSize+(MaxFrameK*8)+((MaxFrameK+1)*4)),
-		syncFn:    func(file *os.File) error { return file.Sync() },
-		clock:     RealClock{},
+		f:                f,
+		bw:               bufio.NewWriterSize(f, defaultBufferSize),
+		size:             info.Size(),
+		fileID:           fileID,
+		appendMax:        defaultBufferSize,
+		appendBuf:        make([]byte, 0, defaultBufferSize),
+		scratch:          make([]byte, 0, defaultBufferSize),
+		prefixBuf:        make([]byte, 0, FrameHeaderSize+(MaxFrameK*8)+((MaxFrameK+1)*4)),
+		syncFn:           func(file *os.File) error { return file.Sync() },
+		clock:            RealClock{},
+		keepSafetyMargin: DefaultKeepSafetyMargin,
 	}, nil
 }
 
 func newWriterWithSink(sink io.Writer, fileID uint32) *Writer {
 	return &Writer{
-		bw:        bufio.NewWriterSize(sink, defaultBufferSize),
-		fileID:    fileID,
-		appendMax: 0,
-		scratch:   make([]byte, 0, defaultBufferSize),
-		prefixBuf: make([]byte, 0, FrameHeaderSize+(MaxFrameK*8)+((MaxFrameK+1)*4)),
-		clock:     RealClock{},
+		bw:               bufio.NewWriterSize(sink, defaultBufferSize),
+		fileID:           fileID,
+		appendMax:        0,
+		scratch:          make([]byte, 0, defaultBufferSize),
+		prefixBuf:        make([]byte, 0, FrameHeaderSize+(MaxFrameK*8)+((MaxFrameK+1)*4)),
+		clock:            RealClock{},
+		keepSafetyMargin: DefaultKeepSafetyMargin,
 	}
 }
 
@@ -219,6 +224,18 @@ func (w *Writer) SetEncodeSampleStride(stride uint64) {
 		return
 	}
 	w.encodeSampleStride = stride
+}
+
+func (w *Writer) SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64) {
+	if w == nil {
+		return
+	}
+	w.keepIoNsPerStoredByte = ioNsPerStoredByte
+	w.keepEncodeNsPerRawByte = encodeNsPerRawByte
+	if safetyMargin < 0 {
+		safetyMargin = 0
+	}
+	w.keepSafetyMargin = safetyMargin
 }
 
 func (w *Writer) sampleEncodeStart() time.Time {
@@ -247,6 +264,14 @@ func (w *Writer) sampleEncodeEnd(start time.Time) int64 {
 		w.clock = RealClock{}
 	}
 	return w.clock.Now().Sub(start).Nanoseconds()
+}
+
+func (w *Writer) shouldKeepCompressed(rawPayloadBytes, encodedLen int, encodeNs int64) bool {
+	encodeNsUsed := encodeNs
+	if encodeNsUsed <= 0 && w.keepEncodeNsPerRawByte > 0 && rawPayloadBytes > 0 {
+		encodeNsUsed = int64(w.keepEncodeNsPerRawByte * float64(rawPayloadBytes))
+	}
+	return ShouldKeepCompressed(rawPayloadBytes, encodedLen, encodeNsUsed, w.keepIoNsPerStoredByte, w.keepSafetyMargin)
 }
 
 func (w *Writer) FileID() uint32 {
@@ -923,7 +948,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			codecs.encPool.Put(enc)
 
 			encodedLen := len(w.appendBuf) - encodedStart
-			if encodedLen >= rawPayloadBytes {
+			if !w.shouldKeepCompressed(rawPayloadBytes, encodedLen, encodeNs) {
 				w.appendBuf = w.appendBuf[:recordStart]
 				if w.noBenefit < 0xff {
 					w.noBenefit++
@@ -1030,15 +1055,14 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 		codecs.encPool.Put(enc)
 		w.encScratch = w.encScratch[:0]
 
-		storedPayloadBytes := rawPayloadBytes
-		switch {
-		case encodeErr == nil && len(encoded) < rawPayloadBytes:
-			storedPayloadBytes = len(encoded)
-			w.noBenefit = 0
-			w.skipRemain = 0
-		case encodeErr != nil && !errors.Is(encodeErr, errEncodedTooLarge):
+		keepCompressed := false
+		if encodeErr == nil {
+			keepCompressed = w.shouldKeepCompressed(rawPayloadBytes, len(encoded), encodeNs)
+		}
+		if encodeErr != nil && !errors.Is(encodeErr, errEncodedTooLarge) {
 			return nil, FrameStats{}, encodeErr
-		default:
+		}
+		if !keepCompressed {
 			// No benefit (or we aborted early because the output grew too large).
 			if w.noBenefit < 0xff {
 				w.noBenefit++
@@ -1046,6 +1070,9 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			w.skipRemain = dictSkipFrames(w.noBenefit)
 			return writeRaw(true, encodeNs)
 		}
+		storedPayloadBytes := len(encoded)
+		w.noBenefit = 0
+		w.skipRemain = 0
 
 		bodyLen := FrameHeaderSize + (k * 8) + ((k + 1) * 4) + len(encoded)
 		if slab.MaxRecordSize > 0 && int64(HeaderSize+bodyLen) > slab.MaxRecordSize {


### PR DESCRIPTION
## Summary
- Add throughput-based keep decision for value-log compression with safety margin.
- Writer consumes IO/encode EWMAs via SetKeepPolicy and falls back to size-based when unknown.
- Add unit tests for the keep inequality and margin sensitivity.

## Testing
- `go test ./internal/valuelog -count=1`
- `go test ./... -count=1`

## Benchmarks
- Not run.
