### PR TITLE
PR-AT4: throughput-based candidate tuning

### DIFF
--- a/TreeDB/.pr/PR4_description.md
+++ b/TreeDB/.pr/PR4_description.md
@@ -1,0 +1,10 @@
+## Summary
+- Add `valuelog.AutotuneOptions` + wiring through public/cached options.
+- Trainer now evaluates dict candidates and K using throughput scoring when IO cost is known, with gain/dwell gating for switches.
+- Integrate autotune candidates, safety margins, and size gating in the cached value-log path.
+
+## Testing
+- `go test ./... -count=1`
+
+## Benchmarks
+- Not run.

--- a/TreeDB/AGENTS.md
+++ b/TreeDB/AGENTS.md
@@ -1041,3 +1041,4 @@ Worklog - update below with summary of each action - update on each commit
 - 2026-01-22 PR-AT1: FrameStats now uses Attempted/Kept + sampled EncodeNs; writer reports Attempted on fallback; updated caching + benches for Kept; tests: `go test ./... -count=1`.
 - 2026-01-22 PR-AT2: added wall-time EWMAs + vlog autotune metrics/logging, wired append boundary measurements; tests: `go test ./... -count=1`.
 - 2026-01-22 PR-AT3: throughput-aware keep decision + unit tests; writer uses EWMA estimates; tests: `go test ./internal/valuelog -count=1`, `go test ./... -count=1`.
+- 2026-01-22 PR-AT4: added AutotuneOptions, throughput-based dict/K selection with gain/dwell gating, and candidate tuning wiring; tests: `go test ./... -count=1`.

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1282,6 +1282,10 @@ type Options struct {
 	// does not improve by at least this fraction (0 uses default).
 	ValueLogDictMinPayloadSavingsRatio float64
 
+	// ValueLogCompressionAutotune configures the wall-time value-log compression autotuner.
+	// Cached mode only (SplitValueLog must be enabled).
+	ValueLogCompressionAutotune valuelog.AutotuneOptions
+
 	// NotifyError is an optional hook for background maintenance failures.
 	NotifyError func(error)
 }
@@ -1370,7 +1374,10 @@ type DB struct {
 		attempted atomic.Uint64
 		kept      atomic.Uint64
 	}
-	valueLogAutotuneMetrics vlogAutotuneMetrics
+	valueLogAutotuneMetrics          vlogAutotuneMetrics
+	valueLogAutotuneOptions          valuelog.AutotuneOptions
+	valueLogAutotuneLastProfile      atomic.Value // *vlogAutotuneProfile
+	valueLogAutotuneLastSwitchFrames atomic.Uint64
 
 	valueLogDictPauseRemaining      atomic.Uint64
 	valueLogDictProbeBytes          uint64
@@ -1965,19 +1972,28 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	if !disableValueLog {
 		splitValueLog = true
 	}
+	valueLogAutotune := valuelog.NormalizeAutotuneOptions(opts.ValueLogCompressionAutotune, splitValueLog)
 
 	// Value-log dictionary compression is a core performance feature of the
 	// value-store path. For unsafe/bench workloads (AllowUnsafe=true), enable
 	// background dict training by default when the value log is active unless
 	// the caller explicitly configured it.
 	if opts.AllowUnsafe && splitValueLog && !disableValueLog && valueLogDictTrain.TrainBytes == 0 {
-		valueLogDictTrain.TrainBytes = compression.DefaultTrainBytes
+		if valueLogAutotune.Mode != valuelog.AutotuneOff && valueLogAutotune.MaxSampleBytes > 0 {
+			valueLogDictTrain.TrainBytes = int(valueLogAutotune.MaxSampleBytes)
+		} else {
+			valueLogDictTrain.TrainBytes = compression.DefaultTrainBytes
+		}
 	}
 	// Keep dict training overhead bounded by default. The trainer already applies
 	// its own backpressure (queue limits), but sampling less aggressively further
 	// reduces CPU+GC impact on write-heavy workloads.
 	if valueLogDictTrain.TrainBytes > 0 && valueLogDictTrain.SampleStride == 0 {
-		valueLogDictTrain.SampleStride = 4
+		if valueLogAutotune.SampleStride > 0 {
+			valueLogDictTrain.SampleStride = int(valueLogAutotune.SampleStride)
+		} else {
+			valueLogDictTrain.SampleStride = 4
+		}
 	}
 
 	// If dict training is enabled but no adaptive ratio is specified, default to
@@ -1997,6 +2013,9 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 			// incompressible payloads.
 			valueLogDictMetricsWindow = 256 << 10
 		}
+		if valueLogDictMetricsPauseBytes <= 0 && valueLogAutotune.Mode != valuelog.AutotuneOff && valueLogAutotune.PauseBytes > 0 {
+			valueLogDictMetricsPauseBytes = int(valueLogAutotune.PauseBytes)
+		}
 		if valueLogDictMetricsPauseBytes <= 0 {
 			// Degraded streams should stay paused long enough that "dict enabled"
 			// is effectively free on incompressible data, while still allowing
@@ -2008,6 +2027,9 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	// When dict compression is paused, periodically probe compression to recover
 	// quickly if the payload stream becomes compressible again.
 	probeBytes := valueLogDictMetricsPauseBytes
+	if probeBytes <= 0 && valueLogAutotune.Mode != valuelog.AutotuneOff && valueLogAutotune.ProbeBytes > 0 {
+		probeBytes = int(valueLogAutotune.ProbeBytes)
+	}
 	if probeBytes <= 0 {
 		probeBytes = 64 << 20
 	}
@@ -2063,6 +2085,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		valueLogDictMetricsPauseBytes:  valueLogDictMetricsPauseBytes,
 		valueLogDictProbeBytes:         uint64(probeBytes),
 		valueLogDictPausedSampleStride: pausedSampleStride,
+		valueLogAutotuneOptions:        valueLogAutotune,
 		mutableShards:                  mutableShards,
 		mutableShardMask:               uint64(shardCount - 1),
 		hashSortedIndexer:              indexer,
@@ -2757,12 +2780,6 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		l.vlogMu.Unlock()
 		return nil, errWALUnavailable
 	}
-	if policySetter, ok := any(w).(interface {
-		SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64)
-	}); ok {
-		snap := db.valueLogAutotuneMetrics.snapshot()
-		policySetter.SetKeepPolicy(snap.IoNsPerStoredByte, snap.EncodeNsPerRawByte, valuelog.DefaultKeepSafetyMargin)
-	}
 	startSize := w.Size()
 
 	rawPayloadBytes := 0
@@ -2774,6 +2791,13 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		dictID = 0
 		dict = nil
 	}
+	if dictID != 0 && db.valueLogAutotuneOptions.DisableBelowValueBytes > 0 {
+		avg := rawPayloadBytes / len(records)
+		if avg < db.valueLogAutotuneOptions.DisableBelowValueBytes {
+			dictID = 0
+			dict = nil
+		}
+	}
 	if dictID != 0 && len(dict) == 0 {
 		if b, dictErr := db.dictBytes(context.Background(), dictID); dictErr == nil {
 			dict = b
@@ -2784,6 +2808,19 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	}
 
 	db.valueLogDictCollectSamples(records)
+
+	if policySetter, ok := any(w).(interface {
+		SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64)
+	}); ok {
+		snap := db.valueLogAutotuneMetrics.snapshot()
+		ioNsPerStored := snap.IoNsPerStoredByte
+		encodeNsPerRaw := snap.EncodeNsPerRawByte
+		if db.valueLogAutotuneOptions.Mode == valuelog.AutotuneOff || probeCompression {
+			ioNsPerStored = 0
+			encodeNsPerRaw = 0
+		}
+		policySetter.SetKeepPolicy(ioNsPerStored, encodeNsPerRaw, db.valueLogAutotuneSafetyMargin())
+	}
 
 	k := 1
 	if dictID != 0 && len(dict) > 0 {
@@ -3003,16 +3040,14 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 		l.vlogMu.Unlock()
 		return page.ValuePtr{}, "", errWALUnavailable
 	}
-	if policySetter, ok := any(w).(interface {
-		SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64)
-	}); ok {
-		snap := db.valueLogAutotuneMetrics.snapshot()
-		policySetter.SetKeepPolicy(snap.IoNsPerStoredByte, snap.EncodeNsPerRawByte, valuelog.DefaultKeepSafetyMargin)
-	}
 	startSize := w.Size()
 
 	attemptCompression, probeCompression, _ := db.valueLogDictShouldAttemptCompression(len(value))
 	if dictID != 0 && !attemptCompression {
+		dictID = 0
+		dict = nil
+	}
+	if dictID != 0 && db.valueLogAutotuneOptions.DisableBelowValueBytes > 0 && len(value) < db.valueLogAutotuneOptions.DisableBelowValueBytes {
 		dictID = 0
 		dict = nil
 	}
@@ -3025,6 +3060,19 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 		}
 	}
 	db.valueLogDictCollectSample(value)
+
+	if policySetter, ok := any(w).(interface {
+		SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64)
+	}); ok {
+		snap := db.valueLogAutotuneMetrics.snapshot()
+		ioNsPerStored := snap.IoNsPerStoredByte
+		encodeNsPerRaw := snap.EncodeNsPerRawByte
+		if db.valueLogAutotuneOptions.Mode == valuelog.AutotuneOff || probeCompression {
+			ioNsPerStored = 0
+			encodeNsPerRaw = 0
+		}
+		policySetter.SetKeepPolicy(ioNsPerStored, encodeNsPerRaw, db.valueLogAutotuneSafetyMargin())
+	}
 
 	stats := valuelog.FrameStats{Records: 1, RawPayloadBytes: len(value), StoredPayloadBytes: len(value)}
 	if dictID == 0 {

--- a/TreeDB/caching/vlog_autotune.go
+++ b/TreeDB/caching/vlog_autotune.go
@@ -1,0 +1,96 @@
+package caching
+
+import (
+	"math"
+
+	"github.com/snissn/gomap/TreeDB/internal/compression"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+)
+
+type vlogAutotuneProfile struct {
+	DictHash         uint64
+	HistoryBytes     int
+	K                int
+	TotalRatio       float64
+	EncodeNsEstimate int64
+	AvgSampleBytes   int
+}
+
+func (db *DB) valueLogAutotuneSafetyMargin() float64 {
+	if db == nil {
+		return valuelog.DefaultKeepSafetyMargin
+	}
+	switch db.valueLogAutotuneOptions.Mode {
+	case valuelog.AutotuneAggressive:
+		return 0.02
+	default:
+		return valuelog.DefaultKeepSafetyMargin
+	}
+}
+
+func (db *DB) valueLogAutotuneCandidate(profile *compression.ActiveProfile, k int) *vlogAutotuneProfile {
+	if profile == nil {
+		return nil
+	}
+	return &vlogAutotuneProfile{
+		DictHash:         profile.DictHash,
+		HistoryBytes:     profile.HistoryBytes,
+		K:                k,
+		TotalRatio:       profile.TotalRatio,
+		EncodeNsEstimate: profile.EncodeNsEstimate,
+		AvgSampleBytes:   profile.AvgSampleBytes,
+	}
+}
+
+func (db *DB) valueLogAutotuneScore(profile *vlogAutotuneProfile, ioNsPerStoredByte float64) float64 {
+	if profile == nil || ioNsPerStoredByte <= 0 || profile.TotalRatio <= 0 {
+		return 0
+	}
+	encodeNsPerRaw := 0.0
+	if profile.EncodeNsEstimate > 0 && profile.AvgSampleBytes > 0 {
+		encodeNsPerRaw = float64(profile.EncodeNsEstimate) / float64(profile.AvgSampleBytes)
+	}
+	cost := encodeNsPerRaw + ioNsPerStoredByte*profile.TotalRatio
+	if cost <= 0 || math.IsNaN(cost) || math.IsInf(cost, 0) {
+		return 0
+	}
+	return 1.0 / cost
+}
+
+func (db *DB) valueLogAutotuneShouldSwitch(candidate *vlogAutotuneProfile, ioNsPerStoredByte float64) bool {
+	if db == nil || candidate == nil {
+		return false
+	}
+	opts := db.valueLogAutotuneOptions
+	if opts.Mode == valuelog.AutotuneOff {
+		return true
+	}
+	if opts.MinDwellFrames > 0 {
+		last := db.valueLogAutotuneLastSwitchFrames.Load()
+		if last > 0 {
+			total := db.valueLogDictFrames.total.Load()
+			if total > last && total-last < opts.MinDwellFrames {
+				return false
+			}
+		}
+	}
+	if opts.MinGainToSwitch > 0 && ioNsPerStoredByte > 0 {
+		current, _ := db.valueLogAutotuneLastProfile.Load().(*vlogAutotuneProfile)
+		currentScore := db.valueLogAutotuneScore(current, ioNsPerStoredByte)
+		candidateScore := db.valueLogAutotuneScore(candidate, ioNsPerStoredByte)
+		if currentScore > 0 && candidateScore > 0 {
+			if candidateScore < currentScore*(1+opts.MinGainToSwitch) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (db *DB) valueLogAutotuneRecordSwitch(candidate *vlogAutotuneProfile) {
+	if db == nil || candidate == nil {
+		return
+	}
+	db.valueLogAutotuneLastProfile.Store(candidate)
+	db.valueLogAutotuneLastSwitchFrames.Store(db.valueLogDictFrames.total.Load())
+}

--- a/TreeDB/caching/vlog_dict.go
+++ b/TreeDB/caching/vlog_dict.go
@@ -172,6 +172,7 @@ func (db *DB) ensureValueLogDictTrainer() {
 	if tr == nil {
 		return
 	}
+	tr.SetAutotuneCandidates(db.valueLogAutotuneOptions.CandidateK, db.valueLogAutotuneOptions.CandidateHistoryBytes)
 	db.valueLogDictTrainer = tr
 	db.valueLogDictMetrics = compression.NewMetrics(compression.MetricsOptions{
 		AdaptiveRatio:  db.valueLogDictAdaptiveRatio,
@@ -219,7 +220,16 @@ func (db *DB) applyValueLogDictProfile() {
 	if !ok || profile == nil || len(profile.Dict) == 0 {
 		return
 	}
+	ioNsPerStoredByte := 0.0
+	if db.valueLogAutotuneOptions.Mode != valuelog.AutotuneOff {
+		ioNsPerStoredByte = db.valueLogAutotuneMetrics.snapshot().IoNsPerStoredByte
+		tr.SetAutotuneIOCost(ioNsPerStoredByte)
+	}
 	profileK := db.clampValueLogDictK(profile.K)
+	candidate := db.valueLogAutotuneCandidate(profile, profileK)
+	if candidate == nil {
+		return
+	}
 	prevHash := db.valueLogDictLastAppliedDictHash.Load()
 	if prevHash == profile.DictHash {
 		// Dict bytes unchanged; allow updating K for the current dict.
@@ -227,6 +237,9 @@ func (db *DB) applyValueLogDictProfile() {
 			return
 		}
 		if curK := int(db.valueLogDictCurrentK.Load()); curK == profileK {
+			return
+		}
+		if !db.valueLogAutotuneShouldSwitch(candidate, ioNsPerStoredByte) {
 			return
 		}
 		if ks, ok := store.(dictStoreK); ok {
@@ -252,6 +265,7 @@ func (db *DB) applyValueLogDictProfile() {
 			db.valueLogDictKMu.Unlock()
 			log.Printf("treedb: value-log dict updated k dict_id=%d k=%d", dictID, profileK)
 		}
+		db.valueLogAutotuneRecordSwitch(candidate)
 		return
 	}
 	minSavings := db.valueLogDictMinPayloadSavings
@@ -261,6 +275,9 @@ func (db *DB) applyValueLogDictProfile() {
 	if profile.PayloadRatio >= 1.0-minSavings {
 		// Do not publish no-op dictionaries (common for incompressible payloads).
 		db.valueLogDictLastAppliedDictHash.Store(profile.DictHash)
+		return
+	}
+	if !db.valueLogAutotuneShouldSwitch(candidate, ioNsPerStoredByte) {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -294,6 +311,7 @@ func (db *DB) applyValueLogDictProfile() {
 
 	log.Printf("treedb: value-log dict published dict_id=%d k=%d payload_ratio=%.3f total_ratio=%.3f",
 		dictID, profileK, profile.PayloadRatio, profile.TotalRatio)
+	db.valueLogAutotuneRecordSwitch(candidate)
 }
 
 func (db *DB) valueLogDictPaused() bool {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -279,6 +279,10 @@ type Options struct {
 	// ratio does not improve by at least this fraction (0 uses default ~0.5%).
 	ValueLogDictMinPayloadSavingsRatio float64
 
+	// ValueLogCompressionAutotune configures the wall-time value-log compression autotuner.
+	// Cached mode only (SplitValueLog must be enabled).
+	ValueLogCompressionAutotune valuelog.AutotuneOptions
+
 	// RelaxedSync disables fsync on CommitSync and SetSync operations.
 	// This improves performance for synchronous workloads but provides only
 	// crash consistency (OS buffer cache), not true durability.

--- a/TreeDB/internal/compression/profile.go
+++ b/TreeDB/internal/compression/profile.go
@@ -23,6 +23,11 @@ type ActiveProfile struct {
 	Timestamp        time.Time
 }
 
+type ChooseKOptions struct {
+	CandidateK        []int
+	IoNsPerStoredByte float64
+}
+
 type kScore struct {
 	K            int
 	payload      int
@@ -37,6 +42,10 @@ type kScore struct {
 }
 
 func ChooseKForDict(dict []byte, samples [][]byte) (profile *ActiveProfile) {
+	return ChooseKForDictOptions(dict, samples, ChooseKOptions{})
+}
+
+func ChooseKForDictOptions(dict []byte, samples [][]byte, opts ChooseKOptions) (profile *ActiveProfile) {
 	defer func() {
 		if r := recover(); r != nil {
 			profile = nil
@@ -59,7 +68,11 @@ func ChooseKForDict(dict []byte, samples [][]byte) (profile *ActiveProfile) {
 	}
 
 	nsPerByte := decodeCostEstimate(dict, eval)
-	ks := []int{1, 2, 4, 8, 16, 32}
+	ks := opts.CandidateK
+	if len(ks) == 0 {
+		ks = []int{1, 2, 4, 8, 16, 32}
+	}
+	ks = normalizeCandidateK(ks)
 	scores := make([]kScore, 0, len(ks))
 	var baseline kScore
 	for _, k := range ks {
@@ -103,16 +116,26 @@ func ChooseKForDict(dict []byte, samples [][]byte) (profile *ActiveProfile) {
 		if kr.raw == 0 {
 			continue
 		}
-		bytesSaved := (float64(baseline.totalBytes)/float64(baseline.raw) - float64(kr.totalBytes)/float64(kr.raw)) * avgRaw
-		if bytesSaved < 0 {
-			bytesSaved = 0
+		if opts.IoNsPerStoredByte > 0 {
+			ioCost := float64(kr.totalBytes) * opts.IoNsPerStoredByte
+			encCost := float64(kr.encodeNs)
+			totalCost := ioCost + encCost
+			if totalCost <= 0 {
+				continue
+			}
+			kr.score = float64(kr.raw) / totalCost
+		} else {
+			bytesSaved := (float64(baseline.totalBytes)/float64(baseline.raw) - float64(kr.totalBytes)/float64(kr.raw)) * avgRaw
+			if bytesSaved < 0 {
+				bytesSaved = 0
+			}
+			decCost := nsPerByte*float64(kr.K)*avgRaw + 1.0
+			if decCost <= 0 {
+				decCost = 1
+			}
+			encCost := float64(kr.encodeNs)/float64(kr.records) + 1.0
+			kr.score = bytesSaved / (decCost + encCost)
 		}
-		decCost := nsPerByte*float64(kr.K)*avgRaw + 1.0
-		if decCost <= 0 {
-			decCost = 1
-		}
-		encCost := float64(kr.encodeNs)/float64(kr.records) + 1.0
-		kr.score = bytesSaved / (decCost + encCost)
 		if best.score < 0 || kr.score > best.score*1.02 || (math.Abs(kr.score-best.score) <= best.score*0.02 && kr.K < best.K) {
 			best = kr
 		}
@@ -137,6 +160,29 @@ func ChooseKForDict(dict []byte, samples [][]byte) (profile *ActiveProfile) {
 		Samples:          len(eval),
 		Timestamp:        time.Now(),
 	}
+}
+
+func normalizeCandidateK(values []int) []int {
+	if len(values) == 0 {
+		return values
+	}
+	out := make([]int, 0, len(values)+1)
+	seen := make(map[int]struct{}, len(values)+1)
+	add := func(v int) {
+		if v <= 0 {
+			return
+		}
+		if _, ok := seen[v]; ok {
+			return
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	add(1)
+	for _, v := range values {
+		add(v)
+	}
+	return out
 }
 
 func batchTotals(dict []byte, samples [][]byte, k int) (payload int, meta int, raw int, encodeNs int64) {

--- a/TreeDB/internal/compression/trainer.go
+++ b/TreeDB/internal/compression/trainer.go
@@ -115,6 +115,10 @@ type Trainer struct {
 	dictCacheDictHashes []uint64
 	dictCachePos        int
 	dictCacheIndex      map[uint64]int
+
+	candidateK            []int
+	candidateHistoryBytes []int
+	ioNsPerStoredByte     atomic.Uint64
 }
 
 type trainerSample struct {
@@ -227,6 +231,28 @@ func NewTrainer(opts TrainConfig, cfg Config, readOnly bool, metricsEnabled bool
 	trainer.collecting.Store(true)
 	go trainer.run()
 	return trainer
+}
+
+func (t *Trainer) SetAutotuneCandidates(candidateK, candidateHistoryBytes []int) {
+	if t == nil {
+		return
+	}
+	if len(candidateK) > 0 {
+		t.candidateK = append([]int(nil), candidateK...)
+	}
+	if len(candidateHistoryBytes) > 0 {
+		t.candidateHistoryBytes = append([]int(nil), candidateHistoryBytes...)
+	}
+}
+
+func (t *Trainer) SetAutotuneIOCost(ioNsPerStoredByte float64) {
+	if t == nil {
+		return
+	}
+	if ioNsPerStoredByte <= 0 || math.IsNaN(ioNsPerStoredByte) || math.IsInf(ioNsPerStoredByte, 0) {
+		return
+	}
+	t.ioNsPerStoredByte.Store(math.Float64bits(ioNsPerStoredByte))
 }
 
 func (t *Trainer) Close() {
@@ -467,18 +493,35 @@ func (t *Trainer) train(samples [][]byte, dictBytes int, level zstd.EncoderLevel
 	}
 
 	candidates := make([]int, 0, 4)
-	if dictBytes >= 16<<10 {
-		candidates = append(candidates, 16<<10)
-	}
-	if dictBytes >= 32<<10 {
-		candidates = append(candidates, 32<<10)
-	}
-	if dictBytes >= 40<<10 {
-		candidates = append(candidates, 40<<10)
-	}
-	isStd := dictBytes == 16<<10 || dictBytes == 32<<10 || dictBytes == 40<<10
-	if !isStd {
-		candidates = append(candidates, dictBytes)
+	if len(t.candidateHistoryBytes) > 0 {
+		seen := make(map[int]struct{}, len(t.candidateHistoryBytes))
+		for _, v := range t.candidateHistoryBytes {
+			if v <= 0 {
+				continue
+			}
+			if dictBytes > 0 && v > dictBytes {
+				continue
+			}
+			if _, ok := seen[v]; ok {
+				continue
+			}
+			seen[v] = struct{}{}
+			candidates = append(candidates, v)
+		}
+	} else {
+		if dictBytes >= 16<<10 {
+			candidates = append(candidates, 16<<10)
+		}
+		if dictBytes >= 32<<10 {
+			candidates = append(candidates, 32<<10)
+		}
+		if dictBytes >= 40<<10 {
+			candidates = append(candidates, 40<<10)
+		}
+		isStd := dictBytes == 16<<10 || dictBytes == 32<<10 || dictBytes == 40<<10
+		if !isStd {
+			candidates = append(candidates, dictBytes)
+		}
 	}
 	if len(candidates) == 0 {
 		candidates = append(candidates, dictBytes)
@@ -510,6 +553,7 @@ func (t *Trainer) train(samples [][]byte, dictBytes int, level zstd.EncoderLevel
 		profile   *ActiveProfile
 		fromCache bool
 	}
+	ioNsPerStoredByte := math.Float64frombits(t.ioNsPerStoredByte.Load())
 	candProfiles := make([]dictCandidate, 0, len(candidates))
 	for _, historyBytes := range candidates {
 		if historyBytes <= 0 {
@@ -533,7 +577,10 @@ func (t *Trainer) train(samples [][]byte, dictBytes int, level zstd.EncoderLevel
 			dictHash = xxhash.Sum64(dict)
 			t.storeCachedDict(cacheKey, dictHash, dict)
 		}
-		profile := ChooseKForDict(dict, validSamples)
+		profile := ChooseKForDictOptions(dict, validSamples, ChooseKOptions{
+			CandidateK:        t.candidateK,
+			IoNsPerStoredByte: ioNsPerStoredByte,
+		})
 		if profile == nil || len(profile.Dict) == 0 {
 			continue
 		}
@@ -545,44 +592,101 @@ func (t *Trainer) train(samples [][]byte, dictBytes int, level zstd.EncoderLevel
 		return
 	}
 
-	// Select best dict bytes using a ratio-first, speed-second policy:
-	// - primary: lowest total ratio
-	// - within a small slack window, prefer lower encode cost
+	// Select best dict bytes using throughput when IO cost is known; otherwise
+	// fall back to ratio-first, speed-second policy.
 	const ratioSlack = 0.01
-	bestTotal := candProfiles[0].profile.TotalRatio
-	for i := 1; i < len(candProfiles); i++ {
-		if candProfiles[i].profile.TotalRatio < bestTotal {
-			bestTotal = candProfiles[i].profile.TotalRatio
-		}
-	}
-	bestCut := bestTotal * (1.0 + ratioSlack)
 	bestIdx := -1
-	for i := range candProfiles {
-		p := candProfiles[i].profile
-		if p.TotalRatio > bestCut {
-			continue
+	bestProfile := candProfiles[0].profile
+	bestFromCache := candProfiles[0].fromCache
+	bestScore := -1.0
+	bestEncCost := math.Inf(1)
+	if ioNsPerStoredByte > 0 {
+		scores := make([]float64, len(candProfiles))
+		encCosts := make([]float64, len(candProfiles))
+		for i := range candProfiles {
+			p := candProfiles[i].profile
+			if p == nil || p.TotalRatio <= 0 {
+				continue
+			}
+			encodeNsPerRaw := 0.0
+			if p.EncodeNsEstimate > 0 && p.AvgSampleBytes > 0 {
+				encodeNsPerRaw = float64(p.EncodeNsEstimate) / float64(p.AvgSampleBytes)
+			}
+			denom := encodeNsPerRaw + ioNsPerStoredByte*p.TotalRatio
+			if denom <= 0 {
+				continue
+			}
+			scores[i] = 1.0 / denom
+			encCosts[i] = encodeNsPerRaw
+			if scores[i] > bestScore {
+				bestScore = scores[i]
+			}
 		}
-		if bestIdx < 0 {
-			bestIdx = i
-			continue
-		}
-		best := candProfiles[bestIdx].profile
-		if p.EncodeNsEstimate > 0 && (best.EncodeNsEstimate == 0 || p.EncodeNsEstimate < best.EncodeNsEstimate) {
-			bestIdx = i
-			continue
-		}
-		if p.EncodeNsEstimate == best.EncodeNsEstimate && p.HistoryBytes < best.HistoryBytes {
-			bestIdx = i
-			continue
+		if bestScore > 0 {
+			cut := bestScore * (1.0 - ratioSlack)
+			for i := range candProfiles {
+				if scores[i] <= 0 || scores[i] < cut {
+					continue
+				}
+				if bestIdx < 0 {
+					bestIdx = i
+					bestEncCost = encCosts[i]
+					continue
+				}
+				if scores[i] > bestScore {
+					bestIdx = i
+					bestScore = scores[i]
+					bestEncCost = encCosts[i]
+					continue
+				}
+				if encCosts[i] < bestEncCost {
+					bestIdx = i
+					bestEncCost = encCosts[i]
+					continue
+				}
+				if encCosts[i] == bestEncCost && candProfiles[i].profile.HistoryBytes < candProfiles[bestIdx].profile.HistoryBytes {
+					bestIdx = i
+					bestEncCost = encCosts[i]
+					continue
+				}
+			}
 		}
 	}
 	if bestIdx < 0 {
-		bestIdx = 0
+		bestTotal := candProfiles[0].profile.TotalRatio
+		for i := 1; i < len(candProfiles); i++ {
+			if candProfiles[i].profile.TotalRatio < bestTotal {
+				bestTotal = candProfiles[i].profile.TotalRatio
+			}
+		}
+		bestCut := bestTotal * (1.0 + ratioSlack)
+		for i := range candProfiles {
+			p := candProfiles[i].profile
+			if p.TotalRatio > bestCut {
+				continue
+			}
+			if bestIdx < 0 {
+				bestIdx = i
+				continue
+			}
+			best := candProfiles[bestIdx].profile
+			if p.EncodeNsEstimate > 0 && (best.EncodeNsEstimate == 0 || p.EncodeNsEstimate < best.EncodeNsEstimate) {
+				bestIdx = i
+				continue
+			}
+			if p.EncodeNsEstimate == best.EncodeNsEstimate && p.HistoryBytes < best.HistoryBytes {
+				bestIdx = i
+				continue
+			}
+		}
+		if bestIdx < 0 {
+			bestIdx = 0
+		}
 	}
-	bestProfile := candProfiles[bestIdx].profile
+	bestProfile = candProfiles[bestIdx].profile
+	bestFromCache = candProfiles[bestIdx].fromCache
 
 	t.lastTrainDictHash.Store(bestProfile.DictHash)
-	bestFromCache := candProfiles[bestIdx].fromCache
 	mode, ref := t.recordDictHash(bestProfile.DictHash)
 	dedupMode := mode
 	if dedupMode == dictDedupNone && bestFromCache {

--- a/TreeDB/internal/valuelog/autotune_options.go
+++ b/TreeDB/internal/valuelog/autotune_options.go
@@ -1,0 +1,88 @@
+package valuelog
+
+type AutotuneMode uint8
+
+const (
+	AutotuneOff AutotuneMode = iota
+	AutotuneMedium
+	AutotuneAggressive
+)
+
+type AutotuneOptions struct {
+	Mode AutotuneMode
+
+	CandidateK            []int
+	CandidateHistoryBytes []int
+	CandidateDictBytes    []int
+
+	MinGainToSwitch float64
+	MinDwellFrames  uint64
+
+	SampleStride     uint64
+	MaxSampleBytes   uint64
+	TrainCPUFraction float64
+
+	ProbeBytes uint64
+	PauseBytes uint64
+
+	DisableBelowValueBytes int
+}
+
+func (opts AutotuneOptions) isZero() bool {
+	return opts.Mode == AutotuneOff &&
+		len(opts.CandidateK) == 0 &&
+		len(opts.CandidateHistoryBytes) == 0 &&
+		len(opts.CandidateDictBytes) == 0 &&
+		opts.MinGainToSwitch == 0 &&
+		opts.MinDwellFrames == 0 &&
+		opts.SampleStride == 0 &&
+		opts.MaxSampleBytes == 0 &&
+		opts.TrainCPUFraction == 0 &&
+		opts.ProbeBytes == 0 &&
+		opts.PauseBytes == 0 &&
+		opts.DisableBelowValueBytes == 0
+}
+
+func NormalizeAutotuneOptions(opts AutotuneOptions, splitValueLog bool) AutotuneOptions {
+	if splitValueLog && opts.isZero() {
+		opts.Mode = AutotuneMedium
+	}
+	if opts.Mode == AutotuneOff {
+		return opts
+	}
+	if len(opts.CandidateK) == 0 {
+		opts.CandidateK = []int{1, 2, 4, 8, 16, 32}
+	}
+	if len(opts.CandidateHistoryBytes) == 0 {
+		opts.CandidateHistoryBytes = []int{16 << 10, 32 << 10, 40 << 10}
+	}
+	if len(opts.CandidateDictBytes) == 0 {
+		opts.CandidateDictBytes = []int{40 << 10}
+	}
+	if opts.MinGainToSwitch <= 0 {
+		opts.MinGainToSwitch = 0.05
+	}
+	if opts.MinDwellFrames == 0 {
+		opts.MinDwellFrames = 1 << 16
+	}
+	if opts.SampleStride == 0 {
+		opts.SampleStride = 4
+	}
+	if opts.MaxSampleBytes == 0 {
+		if opts.Mode == AutotuneAggressive {
+			opts.MaxSampleBytes = 32 << 20
+		} else {
+			opts.MaxSampleBytes = 8 << 20
+		}
+	}
+	if opts.TrainCPUFraction == 0 {
+		opts.TrainCPUFraction = 0.02
+	}
+	if opts.ProbeBytes == 0 {
+		opts.ProbeBytes = 16 << 20
+	}
+	if opts.PauseBytes == 0 {
+		opts.PauseBytes = 64 << 20
+	}
+	return opts
+}

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -279,6 +279,7 @@ func Open(opts Options) (*DB, error) {
 		ValueLogDictMetricsMinRecords:      opts.ValueLogDictMetricsMinRecords,
 		ValueLogDictMetricsPauseBytes:      opts.ValueLogDictMetricsPauseBytes,
 		ValueLogDictMinPayloadSavingsRatio: opts.ValueLogDictMinPayloadSavingsRatio,
+		ValueLogCompressionAutotune:        opts.ValueLogCompressionAutotune,
 		AllowUnsafe:                        opts.AllowUnsafe,
 		MaxValueLogRetainedBytes:           opts.MaxValueLogRetainedBytes,
 		MaxValueLogRetainedBytesHard:       opts.MaxValueLogRetainedBytesHard,


### PR DESCRIPTION
## Summary
- Add `valuelog.AutotuneOptions` + wiring through public/cached options.
- Trainer now evaluates dict candidates and K using throughput scoring when IO cost is known, with gain/dwell gating for switches.
- Integrate autotune candidates, safety margins, and size gating in the cached value-log path.

## Testing
- `go test ./... -count=1`

## Benchmarks
- Not run.
