### PR TITLE
PR-AT5: virtual-time tests + fuzz

### DIFF
--- a/TreeDB/.pr/PR5_description.md
+++ b/TreeDB/.pr/PR5_description.md
@@ -1,0 +1,12 @@
+## Summary
+- Add virtual-time helpers and deterministic autotune tests in valuelog/caching.
+- Add fuzz target for frame decode safety.
+- Add race validation for core autotune packages.
+
+## Testing
+- `go test ./internal/valuelog -count=1`
+- `go test ./... -count=1`
+- `go test ./caching ./internal/valuelog ./internal/compression -race`
+
+## Benchmarks
+- Not run.

--- a/TreeDB/AGENTS.md
+++ b/TreeDB/AGENTS.md
@@ -1042,3 +1042,4 @@ Worklog - update below with summary of each action - update on each commit
 - 2026-01-22 PR-AT2: added wall-time EWMAs + vlog autotune metrics/logging, wired append boundary measurements; tests: `go test ./... -count=1`.
 - 2026-01-22 PR-AT3: throughput-aware keep decision + unit tests; writer uses EWMA estimates; tests: `go test ./internal/valuelog -count=1`, `go test ./... -count=1`.
 - 2026-01-22 PR-AT4: added AutotuneOptions, throughput-based dict/K selection with gain/dwell gating, and candidate tuning wiring; tests: `go test ./... -count=1`.
+- 2026-01-22 PR-AT5: added virtual-time tests + fuzz decode + race checks; tests: `go test ./internal/valuelog -count=1`, `go test ./... -count=1`, `go test ./caching ./internal/valuelog ./internal/compression -race`.

--- a/TreeDB/caching/vlog_autotune_integration_test.go
+++ b/TreeDB/caching/vlog_autotune_integration_test.go
@@ -1,0 +1,72 @@
+package caching
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+)
+
+func TestVlogAutotuneMetricsVirtualTime(t *testing.T) {
+	clock := valuelog.NewVirtualClock(time.Unix(0, 0))
+	var metrics vlogAutotuneMetrics
+	metrics.init(clock)
+
+	rawBytes := 1024
+	storedBytes := 512
+	encodeNs := int64(1024 * 10)
+	encodeRawBytes := rawBytes
+	nsPerStoredByte := int64(200)
+
+	start := metrics.now()
+	clock.Advance(int64(storedBytes) * nsPerStoredByte)
+	metrics.observe(start, rawBytes, storedBytes, encodeNs, encodeRawBytes)
+
+	snap := metrics.snapshot()
+	if math.Abs(snap.IoNsPerStoredByte-float64(nsPerStoredByte)) > 0.001 {
+		t.Fatalf("io_ns_per_stored_byte got %.3f want %.3f", snap.IoNsPerStoredByte, float64(nsPerStoredByte))
+	}
+	if snap.EncodeNsPerRawByte <= 0 {
+		t.Fatalf("expected encode_ns_per_raw_byte to be set")
+	}
+	if snap.ThroughputRawMBps <= 0 {
+		t.Fatalf("expected throughput to be > 0")
+	}
+}
+
+func TestValueLogAutotuneShouldSwitch_DwellAndGain(t *testing.T) {
+	db := &DB{}
+	db.valueLogAutotuneOptions = valuelog.AutotuneOptions{
+		Mode:            valuelog.AutotuneMedium,
+		MinGainToSwitch: 0.10,
+		MinDwellFrames:  100,
+	}
+	db.valueLogDictFrames.total.Store(150)
+	db.valueLogAutotuneLastSwitchFrames.Store(80)
+	current := &vlogAutotuneProfile{
+		TotalRatio:       0.9,
+		EncodeNsEstimate: 1000,
+		AvgSampleBytes:   100,
+	}
+	db.valueLogAutotuneLastProfile.Store(current)
+
+	candidate := &vlogAutotuneProfile{
+		TotalRatio:       0.89,
+		EncodeNsEstimate: 1000,
+		AvgSampleBytes:   100,
+	}
+	if db.valueLogAutotuneShouldSwitch(candidate, 10) {
+		t.Fatalf("expected dwell gating to block switch")
+	}
+
+	db.valueLogAutotuneLastSwitchFrames.Store(10)
+	if db.valueLogAutotuneShouldSwitch(candidate, 10) {
+		t.Fatalf("expected gain gating to block switch")
+	}
+
+	candidate.TotalRatio = 0.7
+	if !db.valueLogAutotuneShouldSwitch(candidate, 10) {
+		t.Fatalf("expected switch when gain is sufficient")
+	}
+}

--- a/TreeDB/internal/valuelog/autotune_virtual_time_test.go
+++ b/TreeDB/internal/valuelog/autotune_virtual_time_test.go
@@ -1,0 +1,52 @@
+package valuelog
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type stepClock struct {
+	now  time.Time
+	step time.Duration
+}
+
+func (c *stepClock) Now() time.Time {
+	if c.step == 0 {
+		return c.now
+	}
+	c.now = c.now.Add(c.step)
+	return c.now
+}
+
+func TestWriterEncodeNsSamplingVirtualTime(t *testing.T) {
+	dict, err := buildFallbackBenchDict(1)
+	if err != nil || len(dict) == 0 {
+		t.Fatalf("buildFallbackBenchDict: %v", err)
+	}
+
+	w := newWriterWithSink(ioDiscard{}, 1)
+	w.SetClock(&stepClock{now: time.Unix(0, 0), step: time.Microsecond})
+	w.SetEncodeSampleStride(1)
+
+	records := []Record{
+		{RID: 1, Value: bytes.Repeat([]byte("compressible-"), 512)},
+	}
+	var ptrScratch [1]page.ValuePtr
+	_, stats, err := w.AppendFrameWithStatsInto(1, dict, records, ptrScratch[:])
+	if err != nil {
+		t.Fatalf("AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected attempted+kept compression")
+	}
+	if stats.EncodeNs <= 0 {
+		t.Fatalf("expected EncodeNs to be sampled")
+	}
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) { return len(p), nil }

--- a/TreeDB/internal/valuelog/fuzz_decode_test.go
+++ b/TreeDB/internal/valuelog/fuzz_decode_test.go
@@ -1,0 +1,20 @@
+package valuelog
+
+import "testing"
+
+func FuzzDecodeFrame(f *testing.F) {
+	raw, _, err := EncodeFrame(0, nil, []Record{{RID: 1, Value: []byte("hello world")}})
+	if err == nil && len(raw) > 0 {
+		f.Add(raw)
+		if len(raw) > 4 {
+			f.Add(raw[:len(raw)/2])
+		}
+	}
+	f.Add([]byte{0x00})
+	f.Add([]byte{0xff, 0xff, 0xff, 0xff})
+	f.Add([]byte{0x01, 0x02, 0x03, 0x04, 0x05})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _, _, _, _ = DecodeFrame(data)
+	})
+}

--- a/TreeDB/internal/valuelog/virtual_clock.go
+++ b/TreeDB/internal/valuelog/virtual_clock.go
@@ -1,0 +1,31 @@
+package valuelog
+
+import (
+	"sync"
+	"time"
+)
+
+// VirtualClock provides deterministic time control for tests.
+type VirtualClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func NewVirtualClock(start time.Time) *VirtualClock {
+	return &VirtualClock{now: start}
+}
+
+func (c *VirtualClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *VirtualClock) Advance(ns int64) {
+	if ns == 0 {
+		return
+	}
+	c.mu.Lock()
+	c.now = c.now.Add(time.Duration(ns))
+	c.mu.Unlock()
+}


### PR DESCRIPTION
## Summary
- Add virtual-time helpers and deterministic autotune tests in valuelog/caching.
- Add fuzz target for frame decode safety.
- Add race validation for core autotune packages.

## Testing
- `go test ./internal/valuelog -count=1`
- `go test ./... -count=1`
- `go test ./caching ./internal/valuelog ./internal/compression -race`

## Benchmarks
- Not run.
