### PR TITLE
bench: ensure mode4 dict active before steady

### DIFF
--- a/TreeDB/cmd/vlog_dict_realdata/main.go
+++ b/TreeDB/cmd/vlog_dict_realdata/main.go
@@ -88,6 +88,8 @@ type benchReport struct {
 	DictTrainMiB        int      `json:"dict_train_mib,omitempty"`
 	DictSampleStride    int      `json:"dict_sample_stride,omitempty"`
 	LoadSeconds         float64  `json:"load_seconds"`
+	PreSteadyDictID     *uint64  `json:"pre_steady_dict_id,omitempty"`
+	PreSteadyFramesKept *uint64  `json:"pre_steady_frames_kept,omitempty"`
 	TrainSeconds        float64  `json:"train_seconds"`
 	TrainRawBytes       int64    `json:"train_raw_bytes"`
 	TrainRecords        int      `json:"train_records"`
@@ -581,6 +583,9 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 
 	keyState := newBenchKeyState(cfg.KeyMode)
 
+	var preSteadyDictIDPtr *uint64
+	var preSteadyKeptFramesPtr *uint64
+
 	warmStart := time.Now()
 	warmRaw, warmRecords, err := writeSamplesOnce(db, train, cfg.Batch, cfg.KeyMode, keyState)
 	if err != nil {
@@ -595,9 +600,20 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 	fmt.Printf("warmup:   raw_bytes=%d records=%d elapsed=%.3fs raw_MBps=%.3f\n", warmRaw, warmRecords, warmSecs, warmMBps)
 
 	if cfg.Compression == "on" {
-		active, snap := waitForDictActivation(db, 30*time.Second)
+		active, snap, err := ensureDictActiveBeforeSteady(db, cfg)
+		if err != nil {
+			return nil, err
+		}
 		dictID, dictOK := parseStatUint(snap, "treedb.cache.vlog_dict.last_applied_dict_id")
 		keptFrames, keptOK := parseStatUint(snap, "treedb.cache.vlog_dict.frames_kept")
+		if dictOK {
+			v := dictID
+			preSteadyDictIDPtr = &v
+		}
+		if keptOK {
+			v := keptFrames
+			preSteadyKeptFramesPtr = &v
+		}
 		fmt.Printf("dict:     active=%t dict_id=%s kept_frames=%s\n",
 			active,
 			formatStatUint(dictID, dictOK),
@@ -732,6 +748,8 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 		DictTrainMiB:        cfg.DictTrainMiB,
 		DictSampleStride:    cfg.DictSampleStride,
 		LoadSeconds:         loadDur.Seconds(),
+		PreSteadyDictID:     preSteadyDictIDPtr,
+		PreSteadyFramesKept: preSteadyKeptFramesPtr,
 		TrainSeconds:        warmSecs,
 		TrainRawBytes:       warmRaw,
 		TrainRecords:        warmRecords,
@@ -988,6 +1006,33 @@ func waitForDictActivation(db *treedb.DB, maxWait time.Duration) (bool, map[stri
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
+}
+
+func ensureDictActiveBeforeSteady(db *treedb.DB, cfg benchConfig) (bool, map[string]string, error) {
+	// Mode4 uses deferred value-log pointers, so warmup writes may not hit the
+	// value log until a flush/checkpoint happens. If we start steady-state before
+	// the dict is applied, stats will misleadingly show dict_id=0/attempted_frac=0
+	// and the dict publish log may appear after steady completes (issue #116).
+
+	// Fast-path: if the dict becomes active quickly, don't perturb mode behavior.
+	if active, snap := waitForDictActivation(db, 2*time.Second); active {
+		return true, snap, nil
+	}
+
+	if cfg.Mode == "mode4" {
+		// Force a flush boundary so deferred values reach the value log and dict
+		// training/publish can complete before we start the steady timer.
+		fmt.Printf("dict:     pre-steady not active; forcing Checkpoint() (mode4 deferred value log) to enable dict during steady\n")
+		if err := db.Checkpoint(); err != nil {
+			return false, db.Stats(), fmt.Errorf("checkpoint before steady (mode4) failed: %w", err)
+		}
+	}
+
+	active, snap := waitForDictActivation(db, 10*time.Second)
+	if !active {
+		return false, snap, fmt.Errorf("value-log dict did not become active before steady (mode=%s). Try increasing -train/-bench-raw-mib or lowering -bench-flush-threshold-mib; if it persists, this is a bug", cfg.Mode)
+	}
+	return true, snap, nil
 }
 
 func parseStatInt(stats map[string]string, key string) (int, bool) {

--- a/TreeDB/cmd/vlog_dict_realdata/main_test.go
+++ b/TreeDB/cmd/vlog_dict_realdata/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestMode4CompressionActivatesDictBeforeSteady(t *testing.T) {
+	// Regression coverage for #116:
+	// mode4 uses deferred value-log pointers, so small warmup phases can otherwise
+	// leave the dict inactive until after steady completes.
+
+	train := make([]kvSample, 20000)
+	eval := make([]kvSample, 5000)
+	// Synthetic-but-realistic-ish payloads: fixed-size, compressible, with a
+	// small varying prefix to avoid degenerate "all identical" training.
+	const valueLen = 256
+	fill := bytes.Repeat([]byte("a"), valueLen)
+	for i := range train {
+		prefix := append([]byte("celestia/height/"), strconv.AppendInt(nil, int64(i), 10)...)
+		val := append([]byte(nil), prefix...)
+		val = append(val, fill...)
+		val = val[:valueLen]
+		train[i] = kvSample{Val: val}
+	}
+	for i := range eval {
+		prefix := append([]byte("celestia/height/"), strconv.AppendInt(nil, int64(1_000_000+i), 10)...)
+		val := append([]byte(nil), prefix...)
+		val = append(val, fill...)
+		val = val[:valueLen]
+		eval[i] = kvSample{Val: val}
+	}
+
+	stats := datasetStats{
+		count: len(train) + len(eval),
+		total: (len(train) + len(eval)) * valueLen,
+		min:   valueLen,
+		max:   valueLen,
+		avg:   float64(valueLen),
+	}
+
+	cfg := benchConfig{
+		Mode:             "mode4",
+		Compression:      "on",
+		RawMiB:           64,
+		Batch:            1024,
+		KeyMode:          "random",
+		PointerThreshold: 1,
+		DictTrainMiB:     1,
+		DictSampleStride: 1,
+	}
+
+	start := time.Now()
+	report, err := runKVBench("synthetic", 512, cfg, train, eval, stats, 0)
+	if err != nil {
+		t.Fatalf("runKVBench failed: %v", err)
+	}
+	if time.Since(start) > 30*time.Second {
+		t.Fatalf("bench took too long; dict activation should not time out pre-steady (elapsed=%s)", time.Since(start))
+	}
+
+	if report.DictID == nil || *report.DictID == 0 {
+		t.Fatalf("expected non-zero dict_id in report; got %#v", report.DictID)
+	}
+	if report.PreSteadyDictID == nil || *report.PreSteadyDictID == 0 {
+		t.Fatalf("expected non-zero pre_steady_dict_id in report; got %#v", report.PreSteadyDictID)
+	}
+}


### PR DESCRIPTION
Fixes #116.

Mode4 uses the deferred value-log path (`value_store=value_log_deferred`), so warmup writes may not emit any value-log frames until a flush/checkpoint boundary. That meant the value-log dict could train/publish only after the steady phase, and the live bench headline would misleadingly show `dict_id=0` / `attempted_frac=0`.

What changed
- `TreeDB/cmd/vlog_dict_realdata`: in `-bench-kv` mode, when `mode4` + `compression=on`, the bench now ensures the dict is active *before* starting the steady timer. It does this by checkpointing (only when needed) and then waiting for dict activation.
- Added a small regression test that exercises the mode4+compression path and asserts we observe a non-zero `pre_steady_dict_id`.
- Bench JSON report now includes `pre_steady_dict_id` / `pre_steady_frames_kept` (when available).

How to run
```bash
go run ./TreeDB/cmd/vlog_dict_realdata \
  -input /path/to/celestia-db.head.jsonl \
  -bench-kv \
  -bench-mode mode4 \
  -bench-compression on \
  -bench-raw-mib 64 \
  -bench-batch 1024 \
  -bench-pointer-threshold 1 \
  -train 20000 \
  -eval 5000
```

Before/after (celestia-db.head.jsonl)
- Before: `dict: active=false dict_id=0 ...` then `headline ... attempted_frac=0.000000 ... dict_id=0`
- After: checkpoint pre-steady, dict publishes before steady, and the headline reflects dict usage:

```text
dict:     pre-steady not active; forcing Checkpoint() (mode4 deferred value log) to enable dict during steady
dict:     active=true dict_id=5243143984035719728 kept_frames=0
headline: steady_raw_MBps=191.977 speedup_vs_off=n/a attempted_frac=0.352546 kept_frac=0.352546 current_k=8 dict_id=5243143984035719728
```

Notes
- This intentionally keeps steady-state timing scoped to `Batch.Set` + `Batch.Write`. The checkpoint is outside the steady timer and only done for mode4 when the dict is still inactive after warmup.
