### PR TITLE
compression: default zstd dict offsets

### DIFF
--- a/TreeDB/internal/compression/trainer.go
+++ b/TreeDB/internal/compression/trainer.go
@@ -771,7 +771,12 @@ func buildAndValidateDict(dictID uint32, samples [][]byte, history []byte, level
 		ID:       dictID,
 		Contents: samples,
 		History:  history,
-		Level:    level,
+		// Important: BuildDict does not guarantee it will discover 3 non-zero
+		// offsets when content is small/degenerate (it only updates offsets it
+		// observes). If we pass zero offsets, it can emit dictionaries that fail
+		// to load with "invalid offset in dictionary" (issue #117).
+		Offsets: [3]int{1, 4, 8},
+		Level:   level,
 	})
 	if err != nil || len(dict) == 0 {
 		if err != nil {

--- a/TreeDB/internal/compression/trainer_test.go
+++ b/TreeDB/internal/compression/trainer_test.go
@@ -1,12 +1,41 @@
 package compression
 
 import (
+	"bytes"
 	"math"
 	"testing"
 	"time"
 
 	"github.com/snissn/compress/zstd"
 )
+
+func TestBuildAndValidateDict_DefaultOffsetsAvoidInvalidOffset(t *testing.T) {
+	// Regression coverage for #117: If we pass zero offsets into zstd.BuildDict,
+	// it can return a dictionary that fails to load with
+	// "invalid offset in dictionary" (especially with small/degenerate inputs).
+
+	hist := bytes.Repeat([]byte("abcd"), (40<<10)/4)
+	sample := append([]byte("prefix:"), bytes.Repeat([]byte("abcd"), (1024-7)/4)...)
+	sample = sample[:1024]
+
+	dict, err := buildAndValidateDict(1, [][]byte{sample}, hist, zstd.SpeedFastest)
+	if err != nil {
+		t.Fatalf("buildAndValidateDict failed: %v", err)
+	}
+	if len(dict) != 40960 {
+		t.Fatalf("unexpected dict size: got=%d want=40960", len(dict))
+	}
+	info, err := zstd.InspectDictionary(dict)
+	if err != nil {
+		t.Fatalf("InspectDictionary failed: %v", err)
+	}
+	offsets := info.Offsets()
+	for i, off := range offsets {
+		if off <= 0 {
+			t.Fatalf("invalid offsets: idx=%d offsets=%v", i, offsets)
+		}
+	}
+}
 
 func TestTrainerDedupWindowZeroDoesNotPanic(t *testing.T) {
 	tr := &Trainer{}


### PR DESCRIPTION
Fixes #117.

## Problem
During autotune validation and unified_bench runs we were seeing repeated stderr warnings:

```
treedb: slab compression training dict rejected slab=0 err=invalid offset in dictionary
```

This is *not* data corruption; it was caused by how we were calling `zstd.BuildDict`.

## Root Cause
`zstd.BuildDict` can return a dictionary blob that has one or more initial repeat offsets set to 0 when the training input is small/degenerate (it only updates offsets it observes). If we pass zero offsets into `BuildDictOptions`, those zeros can end up serialized into the dictionary.

When the dict is later loaded/validated, zstd rejects it with `invalid offset in dictionary`.

## Fix
Seed `zstd.BuildDictOptions.Offsets` with the standard non-zero defaults `[1,4,8]` in `TreeDB/internal/compression/trainer.go` so that even if BuildDict doesn't discover 3 offsets, the dict remains valid.

## Tests
- Added regression test `TestBuildAndValidateDict_DefaultOffsetsAvoidInvalidOffset` in `TreeDB/internal/compression/trainer_test.go`.

## Manual verification (matches issue repro)
- `go run ./TreeDB/cmd/unified_bench -suite vlog_autotune -validate` no longer emits `invalid offset in dictionary`.
- `go run ./cmd/unified_bench ...` also clean of that warning.
