### PR TITLE
valuelog: zero-copy ReadUnsafe via mmap

### DIFF
--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -92,11 +92,11 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 	if f == nil || f.File == nil {
 		return nil, errors.New("valuelog: nil file")
 	}
-	if val, err, ok := f.readViaMmap(ptr, verifyCRC); ok {
+	if val, err, ok := f.readViaMmapView(ptr, verifyCRC); ok {
 		return val, err
 	}
 	f.remapToFileSize()
-	if val, err, ok := f.readViaMmap(ptr, verifyCRC); ok {
+	if val, err, ok := f.readViaMmapView(ptr, verifyCRC); ok {
 		return val, err
 	}
 	return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup)

--- a/TreeDB/internal/valuelog/mmap_safety_test.go
+++ b/TreeDB/internal/valuelog/mmap_safety_test.go
@@ -1,0 +1,183 @@
+package valuelog
+
+import (
+	"bytes"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+func ptrInMapping(view, mapping []byte) bool {
+	if len(view) == 0 || len(mapping) == 0 {
+		return false
+	}
+	vp := uintptr(unsafe.Pointer(&view[0]))
+	mp := uintptr(unsafe.Pointer(&mapping[0]))
+	end := mp + uintptr(len(mapping))
+	return vp >= mp && vp < end
+}
+
+// TestMmapSafety_ZeroCopy_Remap verifies that holding a zero-copy view of an
+// older mmap remains safe even after the File remaps due to growth.
+//
+// Without retaining dead mappings, this test would crash with SIGSEGV.
+func TestMmapSafety_ZeroCopy_Remap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-l0-000001.log")
+	fileID := uint32(123)
+
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	val1 := bytes.Repeat([]byte("v1"), 1024) // 2KB
+	ptr1, err := w.Append(0, nil, 1, val1)
+	if err != nil {
+		t.Fatalf("Append 1: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush 1: %v", err)
+	}
+
+	f, err := openFile(path, fileID, nil)
+	if err != nil {
+		t.Fatalf("openFile: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	view1, err := f.ReadUnsafe(ptr1, false)
+	if err != nil {
+		t.Fatalf("ReadUnsafe 1: %v", err)
+	}
+	if !bytes.Equal(view1, val1) {
+		t.Fatalf("view1 mismatch")
+	}
+	oldMap, _ := f.mmapData.Load().([]byte)
+	if !ptrInMapping(view1, oldMap) {
+		t.Fatalf("expected view1 to reference mmap (zero-copy)")
+	}
+
+	// Grow the file enough to force a remap on the next read.
+	blob := bytes.Repeat([]byte("X"), 1024*1024) // 1MB
+	for i := 0; i < 10; i++ {
+		if _, err := w.Append(0, nil, uint64(2+i), blob); err != nil {
+			t.Fatalf("Append grow %d: %v", i, err)
+		}
+	}
+	val2 := []byte("v2")
+	ptr2, err := w.Append(0, nil, 999, val2)
+	if err != nil {
+		t.Fatalf("Append 2: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush 2: %v", err)
+	}
+
+	view2, err := f.ReadUnsafe(ptr2, false) // forces remap
+	if err != nil {
+		t.Fatalf("ReadUnsafe 2: %v", err)
+	}
+	if string(view2) != "v2" {
+		t.Fatalf("view2 mismatch")
+	}
+	if len(f.deadMappings) == 0 {
+		t.Fatalf("expected at least one dead mapping after remap")
+	}
+
+	// Access view1 again (should not crash).
+	if !bytes.Equal(view1, val1) {
+		t.Fatalf("view1 corrupted after remap")
+	}
+}
+
+// TestMmapSafety_Concurrent_Remap stresses the race where one goroutine holds
+// a view while another triggers remaps.
+func TestMmapSafety_Concurrent_Remap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-l0-000001.log")
+	fileID := uint32(123)
+
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	val := bytes.Repeat([]byte("S"), 1024)
+	ptr, err := w.Append(0, nil, 1, val)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	f, err := openFile(path, fileID, nil)
+	if err != nil {
+		t.Fatalf("openFile: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			v, err := f.ReadUnsafe(ptr, false)
+			if err != nil {
+				t.Errorf("ReadUnsafe: %v", err)
+				return
+			}
+			if len(v) != 1024 || v[0] != 'S' || v[1023] != 'S' {
+				t.Errorf("corrupt read")
+				return
+			}
+			time.Sleep(1 * time.Millisecond)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		blob := make([]byte, 1024*1024)
+		for i := 0; i < 10; i++ {
+			p, err := w.Append(0, nil, uint64(2+i), blob)
+			if err != nil {
+				t.Errorf("Append grow %d: %v", i, err)
+				return
+			}
+			if err := w.Flush(); err != nil {
+				t.Errorf("Flush grow %d: %v", i, err)
+				return
+			}
+			// Force a read of new data to trigger remap.
+			if _, err := f.ReadUnsafe(p, false); err != nil {
+				t.Errorf("ReadUnsafe grow %d: %v", i, err)
+				return
+			}
+		}
+		close(done)
+	}()
+
+	wg.Wait()
+}

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -77,9 +77,173 @@ func (f *File) readViaMmap(ptr page.ValuePtr, verifyCRC bool) ([]byte, error, bo
 	if !ok || err != nil {
 		return nil, err, ok
 	}
-	cpy := make([]byte, len(val))
-	copy(cpy, val)
-	return cpy, nil, true
+	// readViaMmapAppend already returns a copy (it appends into dst).
+	return val, nil, true
+}
+
+// readViaMmapView returns a best-effort zero-copy view into the current mmap.
+//
+// It mirrors readViaMmapAppend's decoding logic but avoids copying for
+// uncompressed records. The returned slice is only valid as long as the mapping
+// remains alive; callers must treat it as ephemeral/unsafe.
+func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error, bool) {
+	data, _ := f.mmapData.Load().([]byte)
+	if data == nil {
+		f.maybeScheduleRemap()
+		return nil, nil, false
+	}
+	if ptr.Offset < 4 {
+		return nil, ErrCorrupt, true
+	}
+	start := int64(ptr.Offset - 4)
+	if start < 0 || start+HeaderSize > int64(len(data)) {
+		f.maybeScheduleRemap()
+		return nil, nil, false
+	}
+
+	header := data[start : start+HeaderSize]
+	crcVal := binary.LittleEndian.Uint32(header[0:4])
+	version := header[4]
+	if version != Version {
+		return nil, ErrCorrupt, true
+	}
+	flags := header[5]
+	valueLen := binary.LittleEndian.Uint32(header[16:20])
+	if recordSizeExceedsMax(valueLen) {
+		return nil, ErrRecordTooLarge, true
+	}
+	if recordLen := page.ValuePtrRecordLength(ptr); recordLen != 0 {
+		expectedLen := uint32(headerWithoutCRC) + valueLen
+		if recordLen != expectedLen {
+			return nil, ErrCorrupt, true
+		}
+	}
+
+	end := start + HeaderSize + int64(valueLen)
+	if end > int64(len(data)) {
+		f.maybeScheduleRemap()
+		return nil, nil, false
+	}
+
+	payload := data[start+HeaderSize : end]
+	if verifyCRC {
+		sum := crc.ChecksumParts(header[4:], payload)
+		if sum != crcVal {
+			return nil, ErrCorrupt, true
+		}
+	}
+
+	// Non-grouped record: the payload is the value.
+	if flags&recordFlagGrouped == 0 {
+		return payload, nil, true
+	}
+
+	if !page.ValuePtrIsGrouped(ptr) {
+		return nil, ErrCorrupt, true
+	}
+	if int64(FrameHeaderSize) > int64(len(payload)) {
+		return nil, ErrCorrupt, true
+	}
+	frameHeader := payload[:FrameHeaderSize]
+	if frameHeader[0] != FrameVersion {
+		return nil, ErrCorrupt, true
+	}
+	k := int(frameHeader[2])
+	if k <= 0 || k > MaxFrameK {
+		return nil, ErrCorrupt, true
+	}
+	fFlags := frameHeader[1]
+
+	// Fast path: grouped + uncompressed; return a subslice view into the mmap.
+	if fFlags&FrameFlagCompressed == 0 {
+		subIndex := int(page.ValuePtrSubIndex(ptr))
+		if subIndex < 0 || subIndex >= k {
+			return nil, ErrCorrupt, true
+		}
+		ridBytes := k * 8
+		offsetBytes := (k + 1) * 4
+		prefixLen := FrameHeaderSize + ridBytes + offsetBytes
+		if int(valueLen) < prefixLen {
+			return nil, ErrCorrupt, true
+		}
+
+		// Cache hit?
+		if f.cacheStart.Load() == start {
+			f.cacheMu.Lock()
+			hit := f.cacheStart.Load() == start && f.cacheK > 0 && f.cacheLen > 0 && subIndex < f.cacheK && f.cacheFlags&FrameFlagCompressed == 0
+			if hit {
+				cPrefixLen := f.cacheLen
+				valStart := f.cacheOffs[subIndex]
+				valEnd := f.cacheOffs[subIndex+1]
+				rawLen := f.cacheOffs[f.cacheK]
+				f.cacheMu.Unlock()
+
+				if valEnd < valStart || valEnd > rawLen {
+					return nil, ErrCorrupt, true
+				}
+				if cPrefixLen+int(rawLen) != int(valueLen) {
+					return nil, ErrCorrupt, true
+				}
+
+				srcStart := cPrefixLen + int(valStart)
+				srcEnd := cPrefixLen + int(valEnd)
+				if srcStart < 0 || srcEnd < srcStart || srcEnd > len(payload) {
+					return nil, ErrCorrupt, true
+				}
+				return payload[srcStart:srcEnd], nil, true
+			}
+			f.cacheMu.Unlock()
+		}
+
+		off := FrameHeaderSize + ridBytes
+		var offsets [MaxFrameK + 1]uint32
+		prev := uint32(0)
+		for i := 0; i < k+1; i++ {
+			cur := binary.LittleEndian.Uint32(payload[off : off+4])
+			if cur < prev {
+				return nil, ErrCorrupt, true
+			}
+			offsets[i] = cur
+			prev = cur
+			off += 4
+		}
+
+		rawLen := offsets[k]
+		if slab.MaxRecordSize > 0 && int64(rawLen) > slab.MaxRecordSize {
+			return nil, ErrRecordTooLarge, true
+		}
+		if prefixLen+int(rawLen) != int(valueLen) {
+			return nil, ErrCorrupt, true
+		}
+		valStart := offsets[subIndex]
+		valEnd := offsets[subIndex+1]
+		if valEnd < valStart || valEnd > rawLen {
+			return nil, ErrCorrupt, true
+		}
+
+		// Publish prefix cache for future reads from this same grouped record.
+		f.cacheMu.Lock()
+		f.cacheK = k
+		f.cacheFlags = fFlags
+		f.cacheLen = prefixLen
+		f.cacheOffs = offsets
+		f.cacheStart.Store(start)
+		f.cacheMu.Unlock()
+
+		srcStart := prefixLen + int(valStart)
+		srcEnd := prefixLen + int(valEnd)
+		if srcStart < 0 || srcEnd < srcStart || srcEnd > len(payload) {
+			return nil, ErrCorrupt, true
+		}
+		return payload[srcStart:srcEnd], nil, true
+	}
+
+	// Compressed grouped record: decode (allocates).
+	val, err := decodeRecord(header, payload, ptr, false, f.dictLookup)
+	if err != nil {
+		return nil, err, true
+	}
+	return val, nil, true
 }
 
 func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte, error, bool) {


### PR DESCRIPTION
Fixes the biggest synthetic read regressions in the rc value-log path by making `valuelog.File.ReadUnsafe` return a zero-copy mmap view for uncompressed records.

Background / why
- Before this change, value-log reads via mmap always copied into a fresh buffer, and `Tree.Get()` then copied again for the user return.
- On 16KiB pointer reads this showed up as heavy `runtime.memmove` + `valuelog.(*File).readViaMmapAppend` CPU, and large `random_read` regressions in the head-to-head suite (see #135).

What changed
- `TreeDB/internal/valuelog/reader_mmap.go`: add `readViaMmapView` that returns an mmap-backed subslice for uncompressed records (grouped + non-grouped). Compressed records still decode (alloc).
- `TreeDB/internal/valuelog/manager.go`: `ReadUnsafe` now prefers the zero-copy view path (with a forced remap on miss).
- `TreeDB/internal/valuelog/reader_mmap.go`: remove an extra redundant copy in `readViaMmap` (it already got a copy from `readViaMmapAppend`).
- `TreeDB/internal/valuelog/mmap_safety_test.go`: add remap + concurrent remap safety tests (skip on Windows).

How to reproduce (synthetic)
- Baseline repro commands are in #135.

Observed impact (192.168.0.185, go1.25.x)
- Repro-style run (rc, mode3/off, valsize=16384): `random_read` improved to ~1.54M ops/s.
  - Log captured on the host at: `~/dev/snissn/gomap/out/rc_perf_fix_bench_20260123_062521/mode3_off_val16384.md`
- Repro-style run (rc, mode4/off, valsize=16384): `random_read` improved to ~768k ops/s.
  - Log captured on the host at: `~/dev/snissn/gomap/out/rc_perf_fix_bench_20260123_062538/mode4_off_val16384.md`

CPU profile sanity (192.168.0.185)
- Before (rc mode3/off random_read 16KiB): hot functions were `runtime.memmove` + `valuelog.(*File).readViaMmapAppend`.
- After: `readViaMmapAppend` disappears; profile is dominated by the single `Tree.Get()` copy.

Notes
- This PR targets the read regressions only. The medium-value write regressions in #135 (valsize=512/1024) still need follow-up.
