### PR TITLE
treedb: default value-log pointer threshold = 1KiB

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1252,7 +1252,8 @@ type Options struct {
 	// serves them by pointer from the value log (WAL/vlog). Requires WAL/value-log.
 	MemtableValueLogPointers bool
 	// ValueLogPointerThreshold controls when WAL/vlog pointers are used.
-	// Values <= 0 use the default inline threshold (256 bytes).
+	// Values <= 0 use a conservative default (1024 bytes) to avoid double-writing
+	// mid-sized values (vlog + journal) on common workloads.
 	ValueLogPointerThreshold int
 	// DisableReadChecksum skips CRC verification on value-log reads.
 	DisableReadChecksum bool
@@ -1902,7 +1903,10 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	}
 	valueLogThreshold := opts.ValueLogPointerThreshold
 	if valueLogThreshold <= 0 {
-		valueLogThreshold = page.DefaultInlineThreshold
+		// Default higher than page.DefaultInlineThreshold: for cached-mode writes,
+		// values above the page inline threshold can still land in slabs at flush,
+		// so keeping 512B-1KiB values inline in the journal avoids an extra vlog IO.
+		valueLogThreshold = 1024
 	}
 	disableJournal := opts.DisableJournal || opts.DisableWAL
 	disableValueLog := opts.DisableValueLog || opts.DisableWAL

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -245,7 +245,7 @@ type Options struct {
 	// serves them by pointer from the value log (WAL/vlog). Requires WAL/value-log.
 	MemtableValueLogPointers bool
 	// ValueLogPointerThreshold controls when WAL/vlog pointers are used.
-	// Values <= 0 use the default inline threshold (256 bytes).
+	// Values <= 0 use a conservative default (1024 bytes).
 	ValueLogPointerThreshold int
 	// ForceValuePointers stores all values out-of-line in slabs (no inline values).
 	ForceValuePointers bool


### PR DESCRIPTION
This changes the *default* `ValueLogPointerThreshold` from 256B to 1024B (when the caller passes <=0).

Why
- In head-to-head synthetic comparisons (#135), the rc `mode3/off` write regressions at valsize=512/1024 were largely due to those sizes being treated as “large” and going through the value log pointer path.
- That pointer path necessarily does **two writes** (payload -> value log, commit intent -> journal), whereas inlining mid-sized values keeps them in a single journal write and lets the backend decide slab-vs-inline at flush time.

What changed
- `TreeDB/caching/db.go`: when `ValueLogPointerThreshold <= 0`, default to `1024` instead of `page.DefaultInlineThreshold`.
- `TreeDB/db/db.go`: doc comment updated to match.

Effect (192.168.0.185, go1.25.x)
Using the existing repro harness from #135 but keeping rc at the default threshold (`-treedb-value-log-threshold 0`):

valsize=512 (main WAL-on baseline forced inline via 1GiB threshold)
- main: random_write=880,481; dataset_write_random=817,856
- rc (default threshold 0 => 1KiB): random_write=856,166; dataset_write_random=820,035
  - logs: `~/dev/snissn/gomap/out/rc_default_threshold_1k_20260123_063708/*val512*.md`

valsize=1024
- main: random_write=668,964; dataset_write_random=657,726
- rc (default threshold 0 => 1KiB): random_write=656,240; dataset_write_random=629,751
  - logs: `~/dev/snissn/gomap/out/rc_default_threshold_1k_20260123_063708/*val1024*.md`

Notes
- This does *not* prevent forcing values through the value log for benches or experiments; set `ValueLogPointerThreshold=1` (or any small value) when you want that behavior.
