### PR TITLE
treedb: respect autotune-off for vlog dict training

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1979,7 +1979,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	// background dict training by default when the value log is active unless
 	// the caller explicitly configured it. Favor early dict availability by
 	// using a smaller initial sample target.
-	if opts.AllowUnsafe && splitValueLog && !disableValueLog && valueLogDictTrain.TrainBytes == 0 {
+	if opts.AllowUnsafe && splitValueLog && !disableValueLog && valueLogDictTrain.TrainBytes == 0 && valueLogAutotune.Mode != valuelog.AutotuneOff {
 		trainBytes := compression.DefaultTrainBytes
 		if valueLogAutotune.Mode != valuelog.AutotuneOff && valueLogAutotune.MaxSampleBytes > 0 {
 			if valueLogAutotune.MaxSampleBytes < uint64(trainBytes) {

--- a/TreeDB/caching/vlog_dict_defaults_test.go
+++ b/TreeDB/caching/vlog_dict_defaults_test.go
@@ -1,0 +1,31 @@
+package caching
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+)
+
+func TestValueLogDictDefaultTrainingRespectsAutotuneOff(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+
+	opts := Options{
+		AllowUnsafe:                 true,
+		FlushThreshold:              1 << 20,
+		ValueLogCompressionAutotune: valuelog.AutotuneOptions{Mode: valuelog.AutotuneOff},
+	}
+
+	db, err := Open(dir, backend, opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	if db.valueLogDictTrainingEnabled() {
+		t.Fatalf("expected dict training to remain disabled when autotune is off")
+	}
+	if db.valueLogDictTrainer != nil {
+		t.Fatalf("expected no dict trainer when autotune is off")
+	}
+}


### PR DESCRIPTION
## Summary
- stop auto-enabling value-log dict training when autotune is explicitly off
- add coverage for the autotune-off default to prevent accidental dict trainer startup

## Testing
- `go test ./TreeDB/caching -count=1`

## Notes
- This prevents background dict training/compressibility sampling from running in “compression off” mode, avoiding unnecessary CPU overhead in mode3/off runs.
