### PR TITLE
HashDB: hash once per Put/PutMany

### DIFF
--- a/HashDB/hash_hashonce_test.go
+++ b/HashDB/hash_hashonce_test.go
@@ -1,0 +1,78 @@
+package hashdb
+
+import (
+	"encoding/binary"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPutHashesOncePerInsert(t *testing.T) {
+	orig := hashFn
+	var calls atomic.Int64
+	hashFn = func(b []byte) uint64 {
+		calls.Add(1)
+		return orig(b)
+	}
+	defer func() { hashFn = orig }()
+
+	dir := t.TempDir()
+	var db DB
+	if err := db.Open(dir); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	db.SetCompression(false)
+
+	const n = 10_000
+	key := make([]byte, 8)
+	val := make([]byte, 16)
+	for i := 0; i < n; i++ {
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		binary.LittleEndian.PutUint64(val[:8], uint64(i))
+		if err := db.Put(key, val); err != nil {
+			t.Fatalf("put %d: %v", i, err)
+		}
+	}
+
+	if got, want := calls.Load(), int64(n); got != want {
+		t.Fatalf("hash calls=%d, want=%d", got, want)
+	}
+}
+
+func TestPutManyHashesOncePerItem(t *testing.T) {
+	orig := hashFn
+	var calls atomic.Int64
+	hashFn = func(b []byte) uint64 {
+		calls.Add(1)
+		return orig(b)
+	}
+	defer func() { hashFn = orig }()
+
+	dir := t.TempDir()
+	var db DB
+	if err := db.Open(dir); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	db.SetCompression(false)
+
+	const n = 5_000
+	items := make([]Item, n)
+	for i := 0; i < n; i++ {
+		key := make([]byte, 8)
+		val := make([]byte, 16)
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		binary.LittleEndian.PutUint64(val[:8], uint64(i))
+		items[i] = Item{Key: key, Value: val}
+	}
+
+	if err := db.PutMany(items); err != nil {
+		t.Fatalf("putmany: %v", err)
+	}
+
+	if got, want := calls.Load(), int64(n); got != want {
+		t.Fatalf("hash calls=%d, want=%d", got, want)
+	}
+}

--- a/HashDB/hashindex.go
+++ b/HashDB/hashindex.go
@@ -20,7 +20,7 @@ const (
 )
 
 func (h *DB) addKey(key []byte, slabOffset Key) error {
-	myhash := hash(key)
+	myhash := slabOffset.hash
 	hkey, isnew, err := h.probeForAddWithHash(key, myhash)
 	if err != nil {
 		return err
@@ -59,8 +59,10 @@ func (h *DB) addBucket(key []byte, slabOffset Key) error {
 }
 
 func hash(key []byte) Hash {
-	return Hash(xxhash.Sum64(key))
+	return Hash(hashFn(key))
 }
+
+var hashFn = xxhash.Sum64
 
 func (h *DB) getKeys() []Key {
 	// Deprecated/Internal use: returns slice of keys.


### PR DESCRIPTION
## What
- Avoids re-hashing keys during index insert: `addKey` now uses the precomputed `Key.hash` returned from slab writes.

## Why
- `Put`/`PutMany` already compute the key hash when writing the slab record. Recomputing it again during `addBucket` is redundant work on the hot write path.

## Tests
- Adds unit tests that wrap the hasher and assert **1 hash call per inserted key** for `Put` and `PutMany`.

## Notes
- The counting is test-only; production hashing behavior is unchanged.