### PR TITLE
HashDB: add probe-length resize guard (opt-in)

### DIFF
--- a/HashDB/cached_db.go
+++ b/HashDB/cached_db.go
@@ -193,6 +193,13 @@ func (c *CachedDB) SetCompression(enabled bool) {
 	c.db.SetCompression(enabled)
 }
 
+// SetMaxProbeGroupsBeforeResize sets a probe-length guard on the backend DB.
+func (c *CachedDB) SetMaxProbeGroupsBeforeResize(groups uint64) {
+	c.backendMu.Lock()
+	defer c.backendMu.Unlock()
+	c.db.SetMaxProbeGroupsBeforeResize(groups)
+}
+
 // Update performs a read-modify-write against the backend with cache flush.
 func (c *CachedDB) Update(key []byte, callback func([]byte) ([]byte, error)) error {
 	// For simplicity, bypass cache for read-modify-write to avoid stale reads.

--- a/HashDB/db.go
+++ b/HashDB/db.go
@@ -468,6 +468,13 @@ func (h *DB) SetResizeThreshold(percent uint64) {
 	h.resizeThreshold = percent
 }
 
+// SetMaxProbeGroupsBeforeResize sets a probe-length guard for inserts.
+// If a new insert scans more than this many probe groups, the DB will trigger
+// an incremental resize. Set to 0 to disable.
+func (h *DB) SetMaxProbeGroupsBeforeResize(groups uint64) {
+	h.maxProbeGroupsBeforeResize = groups
+}
+
 // Clear wipes the database (deletes all data) and resets it.
 func (h *DB) Clear() error {
 	// Close resources

--- a/HashDB/hash_probe_guard_test.go
+++ b/HashDB/hash_probe_guard_test.go
@@ -1,0 +1,50 @@
+package hashdb
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestProbeGuardTriggersResize(t *testing.T) {
+	orig := hashFn
+	hashFn = func([]byte) uint64 { return 0 }
+	t.Cleanup(func() { hashFn = orig })
+
+	dir := t.TempDir()
+	var db DB
+	if err := db.Open(dir); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	db.SetResizeThreshold(100)          // disable load-factor resize
+	db.SetMaxProbeGroupsBeforeResize(1) // trigger when >1 group scanned
+
+	key := make([]byte, 8)
+	val := make([]byte, 16)
+
+	for i := 0; i < 8; i++ {
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		binary.LittleEndian.PutUint64(val[:8], uint64(i))
+		if err := db.Put(key, val); err != nil {
+			t.Fatalf("put %d: %v", i, err)
+		}
+	}
+
+	if db.rehashInProgress {
+		t.Fatalf("rehash started early")
+	}
+
+	// 9th insert scans a second group due to constant hash collisions.
+	binary.LittleEndian.PutUint64(key, uint64(8))
+	if err := db.Put(key, val); err != nil {
+		t.Fatalf("put 8: %v", err)
+	}
+
+	if !db.rehashInProgress {
+		t.Fatalf("expected rehash to start after long probe")
+	}
+	if db.capacity != DefaultCapacity*2 {
+		t.Fatalf("expected capacity %d, got %d", DefaultCapacity*2, db.capacity)
+	}
+}

--- a/HashDB/hashindex.go
+++ b/HashDB/hashindex.go
@@ -19,11 +19,11 @@ const (
 	groupSize   = 8
 )
 
-func (h *DB) addKey(key []byte, slabOffset Key) error {
+func (h *DB) addKey(key []byte, slabOffset Key) (bool, uint64, error) {
 	myhash := slabOffset.hash
-	hkey, isnew, err := h.probeForAddWithHash(key, myhash)
+	hkey, isnew, groupsScanned, err := h.probeForAddWithHash(key, myhash)
 	if err != nil {
-		return err
+		return false, 0, err
 	}
 
 	// If rehash is in progress, ensure we mark any existing key in the old table
@@ -31,7 +31,7 @@ func (h *DB) addKey(key []byte, slabOffset Key) error {
 	if h.rehashInProgress && h.rehashOldCapacity > 0 && len(h.rehashOldKeys) > 0 {
 		idx, found, err := h.probeIndexWithHash(h.rehashOldKeys, h.rehashOldControls, h.rehashOldCapacity, key, myhash)
 		if err != nil {
-			return err
+			return false, 0, err
 		}
 		if found {
 			h.rehashOldKeys[idx].slabOffset = Tombstone
@@ -45,7 +45,7 @@ func (h *DB) addKey(key []byte, slabOffset Key) error {
 		h2 := byte(myhash&0x7f) | 0x80
 		h.controls[hkey] = h2
 	}
-	return nil
+	return isnew, groupsScanned, nil
 }
 
 func (h *DB) addBucket(key []byte, slabOffset Key) error {
@@ -55,7 +55,16 @@ func (h *DB) addBucket(key []byte, slabOffset Key) error {
 		}
 	}
 
-	return h.addKey(key, slabOffset)
+	isNew, groupsScanned, err := h.addKey(key, slabOffset)
+	if err != nil {
+		return err
+	}
+	if isNew && h.maxProbeGroupsBeforeResize > 0 && groupsScanned > h.maxProbeGroupsBeforeResize && !h.rehashInProgress {
+		if err := h.startRehash(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func hash(key []byte) Hash {
@@ -229,11 +238,11 @@ func (h *DB) probe(keys []Key, controls []byte, capacity uint64, key []byte) (ui
 
 // probeForAdd searches for a key or an insertion slot.
 // It returns the index to insert at, and whether the key is new.
-func (h *DB) probeForAdd(key []byte) (uint64, bool, error) {
+func (h *DB) probeForAdd(key []byte) (uint64, bool, uint64, error) {
 	return h.probeForAddWithHash(key, hash(key))
 }
 
-func (h *DB) probeForAddWithHash(key []byte, myhash Hash) (uint64, bool, error) {
+func (h *DB) probeForAddWithHash(key []byte, myhash Hash) (uint64, bool, uint64, error) {
 	h1 := uint64(myhash >> 7)
 	h2 := byte(myhash&0x7f) | 0x80
 
@@ -242,8 +251,10 @@ func (h *DB) probeForAddWithHash(key []byte, myhash Hash) (uint64, bool, error) 
 	var firstDeletedIdx uint64
 	foundDeleted := false
 	probes := uint64(0)
+	groupsScanned := uint64(0)
 
 	for probes < h.capacity {
+		groupsScanned++
 		group := loadGroup(h.controls, idx, h.capacity)
 
 		// 1. Check if key already exists
@@ -260,10 +271,10 @@ func (h *DB) probeForAddWithHash(key []byte, myhash Hash) (uint64, bool, error) 
 			if bucket.slabOffset != Tombstone && bucket.hash == myhash {
 				slabKey, err := h.unmarshalKeyFromSlab(bucket)
 				if err != nil {
-					return 0, false, err
+					return 0, false, 0, err
 				}
 				if bytes.Equal(slabKey, key) {
-					return candidateIdx, false, nil // Found existing
+					return candidateIdx, false, groupsScanned, nil // Found existing
 				}
 			}
 		}
@@ -287,9 +298,9 @@ func (h *DB) probeForAddWithHash(key []byte, myhash Hash) (uint64, bool, error) 
 				if ctrl == ctrlEmpty {
 					// Found Empty. Stop search.
 					if foundDeleted {
-						return firstDeletedIdx, true, nil
+						return firstDeletedIdx, true, groupsScanned, nil
 					}
-					return candidateIdx, true, nil
+					return candidateIdx, true, groupsScanned, nil
 				} else if ctrl == ctrlDeleted {
 					if !foundDeleted {
 						firstDeletedIdx = candidateIdx
@@ -304,9 +315,9 @@ func (h *DB) probeForAddWithHash(key []byte, myhash Hash) (uint64, bool, error) 
 	}
 	// Map is full or probed entire capacity
 	if foundDeleted {
-		return firstDeletedIdx, true, nil
+		return firstDeletedIdx, true, groupsScanned, nil
 	}
-	return 0, false, fmt.Errorf("hashmap is full (probed %d slots)", probes)
+	return 0, false, groupsScanned, fmt.Errorf("hashmap is full (probed %d slots)", probes)
 }
 
 func (h *DB) addManyBuckets(items []Item, slabOffsets []Key) error {
@@ -321,7 +332,7 @@ func (h *DB) addManyKeys(items []Item, slabOffsets []Key) error {
 	totalNewKey := uint64(0)
 
 	for i, item := range items {
-		hkey, isnew, err := h.probeForAdd(item.Key)
+		hkey, isnew, _, err := h.probeForAdd(item.Key)
 		if err != nil {
 			return err
 		}

--- a/HashDB/sharded_db.go
+++ b/HashDB/sharded_db.go
@@ -123,6 +123,17 @@ func (h *HashDB) SetCompression(enabled bool) {
 	}
 }
 
+// SetMaxProbeGroupsBeforeResize sets a probe-length guard on all shards.
+// If a new insert scans more than this many probe groups, the shard will
+// trigger an incremental resize. Set to 0 to disable.
+func (h *HashDB) SetMaxProbeGroupsBeforeResize(groups uint64) {
+	for i := 0; i < len(h.shards); i++ {
+		h.locks[i].Lock()
+		h.shards[i].SetMaxProbeGroupsBeforeResize(groups)
+		h.locks[i].Unlock()
+	}
+}
+
 // Get retrieves the value for a given key.
 // It returns nil if the key does not exist.
 func (h *HashDB) Get(key []byte) ([]byte, error) {

--- a/HashDB/types.go
+++ b/HashDB/types.go
@@ -85,7 +85,8 @@ type DB struct {
 	rehashOldControls    []byte
 	rehashIdx            uint64
 
-	resizeThreshold uint64
+	resizeThreshold            uint64
+	maxProbeGroupsBeforeResize uint64
 }
 
 // Hashmap is kept as a compatibility alias for older code.


### PR DESCRIPTION
## What
- Adds an opt-in probe-length guard that triggers incremental resize when a new insert scans more than N probe groups.
- Exposes setters on `DB`, `CachedDB`, and `HashDB`.
- Adds a deterministic test using forced hash collisions to ensure the guard triggers a resize.

## Why
- Makes it safer to run higher `resizeThreshold` values by bounding worst-case probe lengths.

## Tests
- `go test ./HashDB/...`
- New unit test `TestProbeGuardTriggersResize`