### PR TITLE
TreeDB: autotune off expressible + unified_bench knob

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -130,7 +130,6 @@ const (
 	adaptiveMinWrites          = 1024
 	adaptiveSequentialWritePct = 0.85
 	adaptiveWarmupBytes        = 16 * 1024 * 1024
-	adaptiveModeSwitchStreak   = 2
 	maxMemtableBytesPerShard   = int64(3 << 30)
 )
 
@@ -1382,26 +1381,24 @@ type DB struct {
 	dictCurrentOps    atomic.Uint64
 
 	// Config
-	dir                       string
-	flushThreshold            int64
-	memtableCap               int
-	memtableMode              memtable.Mode
-	memtableAdaptive          bool
-	memtableWarmupActive      bool
-	memtableWarmupThreshold   int64
-	memtableAdaptiveCandidate memtable.Mode
-	memtableAdaptiveStreak    uint8
-	statsMu                   sync.Mutex
-	memtableStats             memtableStats
-	maxQueuedMemtables        int
-	slowdownBacklogSeconds    float64
-	stopBacklogSeconds        float64
-	maxBacklogBytes           int64
-	writerFlushMaxMemtables   int
-	writerFlushMaxDuration    time.Duration
-	flushBuildConcurrency     int
-	walMaxSegmentBytes        int64
-	journalCompression        bool
+	dir                     string
+	flushThreshold          int64
+	memtableCap             int
+	memtableMode            memtable.Mode
+	memtableAdaptive        bool
+	memtableWarmupActive    bool
+	memtableWarmupThreshold int64
+	statsMu                 sync.Mutex
+	memtableStats           memtableStats
+	maxQueuedMemtables      int
+	slowdownBacklogSeconds  float64
+	stopBacklogSeconds      float64
+	maxBacklogBytes         int64
+	writerFlushMaxMemtables int
+	writerFlushMaxDuration  time.Duration
+	flushBuildConcurrency   int
+	walMaxSegmentBytes      int64
+	journalCompression      bool
 
 	disableJournal     bool
 	relaxedSync        bool
@@ -1711,27 +1708,10 @@ func (db *DB) chooseAdaptiveMemtableModeLocked() memtable.Mode {
 	return memtable.ModeHashSorted
 }
 
-func (db *DB) maybeSwitchAdaptiveMemtableModeLocked() memtable.Mode {
+func (db *DB) applyAdaptiveMemtableModeLocked() memtable.Mode {
 	desired := db.chooseAdaptiveMemtableModeLocked()
-	if desired == db.memtableMode {
-		db.memtableAdaptiveCandidate = desired
-		db.memtableAdaptiveStreak = 0
-		return desired
-	}
-	if db.memtableAdaptiveCandidate != desired {
-		db.memtableAdaptiveCandidate = desired
-		db.memtableAdaptiveStreak = 1
-		return db.memtableMode
-	}
-	if db.memtableAdaptiveStreak < 255 {
-		db.memtableAdaptiveStreak++
-	}
-	if db.memtableAdaptiveStreak >= adaptiveModeSwitchStreak {
-		db.memtableMode = desired
-		db.memtableAdaptiveStreak = 0
-		db.memtableAdaptiveCandidate = desired
-	}
-	return db.memtableMode
+	db.memtableMode = desired
+	return desired
 }
 
 func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
@@ -1882,20 +1862,6 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	}
 	valueLogAutotune := valuelog.NormalizeAutotuneOptions(opts.ValueLogCompressionAutotune, splitValueLog)
 
-	// Value-log dictionary compression is a core performance feature of the
-	// value-store path. For unsafe/bench workloads (AllowUnsafe=true), enable
-	// background dict training by default when the value log is active unless
-	// the caller explicitly configured it. Favor early dict availability by
-	// using a smaller initial sample target.
-	if opts.AllowUnsafe && splitValueLog && !disableValueLog && valueLogDictTrain.TrainBytes == 0 {
-		trainBytes := compression.DefaultTrainBytes
-		if valueLogAutotune.Mode != valuelog.AutotuneOff && valueLogAutotune.MaxSampleBytes > 0 {
-			if valueLogAutotune.MaxSampleBytes < uint64(trainBytes) {
-				trainBytes = int(valueLogAutotune.MaxSampleBytes)
-			}
-		}
-		valueLogDictTrain.TrainBytes = trainBytes
-	}
 	// Favor aggressive sampling so the first dict arrives quickly. The trainer
 	// still caps total work via TrainBytes and queue backpressure.
 	if valueLogDictTrain.TrainBytes > 0 && valueLogDictTrain.SampleStride == 0 {
@@ -1960,7 +1926,6 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		memtableAdaptive:               adaptive,
 		memtableWarmupActive:           adaptive && warmupThreshold < opts.FlushThreshold,
 		memtableWarmupThreshold:        warmupThreshold,
-		memtableAdaptiveCandidate:      mode,
 		maxQueuedMemtables:             opts.MaxQueuedMemtables,
 		slowdownBacklogSeconds:         opts.SlowdownBacklogSeconds,
 		stopBacklogSeconds:             opts.StopBacklogSeconds,
@@ -4190,7 +4155,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 			curMode := db.memtableMode
 			nextMode := curMode
 			if db.memtableAdaptive {
-				nextMode = db.maybeSwitchAdaptiveMemtableModeLocked()
+				nextMode = db.applyAdaptiveMemtableModeLocked()
 				db.memtableWarmupActive = false
 				db.resetMemtableStatsLocked()
 			}
@@ -4246,7 +4211,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 			curMode := db.memtableMode
 			nextMode := curMode
 			if db.memtableAdaptive {
-				nextMode = db.maybeSwitchAdaptiveMemtableModeLocked()
+				nextMode = db.applyAdaptiveMemtableModeLocked()
 				db.memtableWarmupActive = false
 				db.resetMemtableStatsLocked()
 			}
@@ -4611,7 +4576,7 @@ func (db *DB) rotateMemtableLockedWithCapacity(triggerFlush bool, newCapacity in
 		newCapacity = db.memtableCap
 	}
 	if db.memtableAdaptive {
-		db.maybeSwitchAdaptiveMemtableModeLocked()
+		db.applyAdaptiveMemtableModeLocked()
 	}
 	if db.memtableWarmupActive {
 		db.memtableWarmupActive = false
@@ -4722,7 +4687,7 @@ func (db *DB) rotateMutableShardsLocked(newCapacity int, triggerFlush bool) erro
 		newCapacity = db.memtableCap
 	}
 	if db.memtableAdaptive {
-		db.maybeSwitchAdaptiveMemtableModeLocked()
+		db.applyAdaptiveMemtableModeLocked()
 	}
 	if db.memtableWarmupActive {
 		db.memtableWarmupActive = false
@@ -5929,7 +5894,10 @@ func (db *DB) Stats() map[string]string {
 	queueLen := len(db.queue)
 	flushThreshold := db.flushThreshold
 	memtableMode := db.memtableMode
+	memtableAdaptive := db.memtableAdaptive
+	memtableWarmupActive := db.memtableWarmupActive
 	maxQueued := db.maxQueuedMemtables
+	vlogAutotuneMode := db.valueLogAutotuneOptions.Mode
 	db.mu.RUnlock()
 	var walCurrentBytes int64
 	var walClosedBytes int64
@@ -5943,6 +5911,12 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.mutable_bytes"] = fmt.Sprintf("%d", db.mutableBytes.Load())
 	stats["treedb.cache.flush_threshold_bytes"] = fmt.Sprintf("%d", flushThreshold)
 	stats["treedb.cache.memtable_mode"] = memtableMode.String()
+	if memtableAdaptive {
+		stats["treedb.cache.memtable_mode_config"] = "adaptive"
+	} else {
+		stats["treedb.cache.memtable_mode_config"] = "fixed"
+	}
+	stats["treedb.cache.memtable_warmup_active"] = fmt.Sprintf("%t", memtableWarmupActive)
 	stats["treedb.cache.max_queued_memtables"] = fmt.Sprintf("%d", maxQueued)
 	stats["treedb.cache.wal_bytes_estimate"] = fmt.Sprintf("%d", walClosedBytes+walCurrentBytes)
 	stats["treedb.cache.wal_closed_bytes_estimate"] = fmt.Sprintf("%d", walClosedBytes)
@@ -5983,6 +5957,16 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_dict.pause_remaining_bytes"] = fmt.Sprintf("%d", db.valueLogDictPauseRemaining.Load())
 	stats["treedb.cache.vlog_dict.last_applied_dict_id"] = fmt.Sprintf("%d", db.valueLogDictLastAppliedDictID.Load())
 	stats["treedb.cache.vlog_dict.current_k"] = fmt.Sprintf("%d", db.valueLogDictCurrentK.Load())
+	switch vlogAutotuneMode {
+	case valuelog.AutotuneOff:
+		stats["treedb.cache.vlog_compression_autotune.mode"] = "off"
+	case valuelog.AutotuneMedium:
+		stats["treedb.cache.vlog_compression_autotune.mode"] = "medium"
+	case valuelog.AutotuneAggressive:
+		stats["treedb.cache.vlog_compression_autotune.mode"] = "aggressive"
+	default:
+		stats["treedb.cache.vlog_compression_autotune.mode"] = fmt.Sprintf("%d", vlogAutotuneMode)
+	}
 	if snap := db.valueLogAutotuneMetrics.snapshot(); snap.hasData() {
 		stats["treedb.cache.vlog_autotune.encode_ns_per_raw_byte"] = fmt.Sprintf("%.3f", snap.EncodeNsPerRawByte)
 		stats["treedb.cache.vlog_autotune.io_ns_per_stored_byte"] = fmt.Sprintf("%.3f", snap.IoNsPerStoredByte)

--- a/TreeDB/caching/memtable_adaptive_test.go
+++ b/TreeDB/caching/memtable_adaptive_test.go
@@ -1,0 +1,107 @@
+package caching
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+)
+
+func TestAdaptiveMemtableMode_SwitchesAfterWarmupRotation(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+
+	// Use a very large flush threshold so we only ever rotate once (at the warmup
+	// threshold). This reproduces the historical case where adaptive mode needed
+	// two rotations to switch and therefore never took effect.
+	db, err := Open(dir, backend, Options{
+		AllowUnsafe:    true,
+		DisableWAL:     true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "adaptive",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	b := db.NewBatch()
+	rng := rand.New(rand.NewSource(1))
+	value := make([]byte, 8<<10) // 8KiB
+	for i := 0; i < adaptiveMinWrites*2; i++ {
+		var key [16]byte
+		binary.BigEndian.PutUint64(key[0:8], rng.Uint64())
+		binary.BigEndian.PutUint64(key[8:16], uint64(i))
+		if err := b.Set(key[:], value); err != nil {
+			t.Fatalf("Batch.Set: %v", err)
+		}
+	}
+	// Add enough payload to exceed the 16MiB warmup threshold and trigger a single
+	// rotation.
+	for i := 0; i < 600; i++ {
+		var key [16]byte
+		binary.BigEndian.PutUint64(key[0:8], rng.Uint64())
+		binary.BigEndian.PutUint64(key[8:16], uint64(adaptiveMinWrites*2+i))
+		if err := b.Set(key[:], value); err != nil {
+			t.Fatalf("Batch.Set: %v", err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Batch.Write: %v", err)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.cache.memtable_mode_config"]; got != "adaptive" {
+		t.Fatalf("expected adaptive memtable config, got %q", got)
+	}
+	if got := stats["treedb.cache.memtable_warmup_active"]; got != "false" {
+		t.Fatalf("expected warmup to be finished after rotation, got %q", got)
+	}
+	if got := stats["treedb.cache.memtable_mode"]; got != "hash_sorted" {
+		t.Fatalf("expected memtable mode to switch to hash_sorted after warmup rotation, got %q", got)
+	}
+}
+
+func TestAdaptiveMemtableMode_SequentialWritesStaySkiplist(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+
+	db, err := Open(dir, backend, Options{
+		AllowUnsafe:    true,
+		DisableWAL:     true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "adaptive",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	b := db.NewBatch()
+	value := make([]byte, 8<<10)
+	for i := 0; i < adaptiveMinWrites*2+600; i++ {
+		// Break "strictly increasing" so Batch never switches to backend streaming
+		// bypass (which would skip memtable stats/rotation entirely).
+		k := uint64(i)
+		if i == 1 {
+			k = 0
+		}
+		var key [16]byte
+		binary.BigEndian.PutUint64(key[8:16], k)
+		if err := b.Set(key[:], value); err != nil {
+			t.Fatalf("Batch.Set: %v", err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Batch.Write: %v", err)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.cache.memtable_warmup_active"]; got != "false" {
+		t.Fatalf("expected warmup to be finished after rotation, got %q", got)
+	}
+	if got := stats["treedb.cache.memtable_mode"]; got != "skiplist" {
+		t.Fatalf("expected sequential workload to keep skiplist mode, got %q", got)
+	}
+}

--- a/TreeDB/internal/valuelog/autotune_options.go
+++ b/TreeDB/internal/valuelog/autotune_options.go
@@ -3,7 +3,11 @@ package valuelog
 type AutotuneMode uint8
 
 const (
-	AutotuneOff AutotuneMode = iota
+	// AutotuneUnset indicates the caller did not explicitly configure the
+	// autotuner mode. NormalizeAutotuneOptions maps this to a sensible default
+	// based on whether SplitValueLog is enabled.
+	AutotuneUnset AutotuneMode = iota
+	AutotuneOff
 	AutotuneMedium
 	AutotuneAggressive
 )
@@ -29,7 +33,7 @@ type AutotuneOptions struct {
 }
 
 func (opts AutotuneOptions) isZero() bool {
-	return opts.Mode == AutotuneOff &&
+	return opts.Mode == AutotuneUnset &&
 		len(opts.CandidateK) == 0 &&
 		len(opts.CandidateHistoryBytes) == 0 &&
 		len(opts.CandidateDictBytes) == 0 &&
@@ -44,8 +48,15 @@ func (opts AutotuneOptions) isZero() bool {
 }
 
 func NormalizeAutotuneOptions(opts AutotuneOptions, splitValueLog bool) AutotuneOptions {
-	if splitValueLog && opts.isZero() {
-		opts.Mode = AutotuneMedium
+	if opts.Mode == AutotuneUnset {
+		// Default behavior:
+		// - Split value log enabled: enable autotune by default.
+		// - Otherwise: leave compression/autotune off.
+		if splitValueLog {
+			opts.Mode = AutotuneMedium
+		} else {
+			opts.Mode = AutotuneOff
+		}
 	}
 	if opts.Mode == AutotuneOff {
 		return opts

--- a/TreeDB/internal/valuelog/autotune_options_test.go
+++ b/TreeDB/internal/valuelog/autotune_options_test.go
@@ -1,0 +1,25 @@
+package valuelog
+
+import "testing"
+
+func TestNormalizeAutotuneOptions_ExplicitOffStaysOff(t *testing.T) {
+	in := AutotuneOptions{Mode: AutotuneOff}
+	out := NormalizeAutotuneOptions(in, true /* splitValueLog */)
+	if out.Mode != AutotuneOff {
+		t.Fatalf("expected explicit AutotuneOff to remain off, got %v", out.Mode)
+	}
+}
+
+func TestNormalizeAutotuneOptions_UnsetDefaultsToMediumWhenSplitValueLog(t *testing.T) {
+	out := NormalizeAutotuneOptions(AutotuneOptions{}, true /* splitValueLog */)
+	if out.Mode != AutotuneMedium {
+		t.Fatalf("expected unset to default to AutotuneMedium when splitValueLog=true, got %v", out.Mode)
+	}
+}
+
+func TestNormalizeAutotuneOptions_UnsetDefaultsToOffWhenNotSplitValueLog(t *testing.T) {
+	out := NormalizeAutotuneOptions(AutotuneOptions{}, false /* splitValueLog */)
+	if out.Mode != AutotuneOff {
+		t.Fatalf("expected unset to default to AutotuneOff when splitValueLog=false, got %v", out.Mode)
+	}
+}

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"math"
 	"reflect"
 	"strings"
@@ -60,6 +61,7 @@ var (
 	treedbVlogDictMetricsMinRecords = flag.Int("treedb-vlog-dict-metrics-min-records", 0, "TreeDB: value-log dict metrics min records (0=default)")
 	treedbVlogDictMetricsPauseBytes = flag.Int("treedb-vlog-dict-metrics-pause-bytes", 0, "TreeDB: value-log dict pause bytes when degraded (0=default)")
 	treedbVlogDictMinSavingsRatio   = flag.Float64("treedb-vlog-dict-min-savings-ratio", 0, "TreeDB: value-log dict min payload savings ratio (0=default)")
+	treedbVlogCompressionAutotune   = flag.String("treedb-vlog-compression-autotune", "off", "TreeDB: value-log compression autotune mode (off|medium|aggressive|default)")
 	treedbIndexColumnarLeaves       = flag.Bool("treedb-index-columnar-leaves", false, "TreeDB: enable columnar leaf encoding")
 	treedbIndexInternalBaseDelta    = flag.Bool("treedb-index-internal-base-delta", false, "TreeDB: enable internal base-delta encoding")
 
@@ -147,6 +149,40 @@ func setOptionalTrainConfig(opts *treedb.Options, name string, trainBytes, dictB
 	setInt("DedupWindow", dedupWindow)
 }
 
+func setOptionalAutotuneMode(opts *treedb.Options, fieldName string, mode uint64) {
+	v := reflect.ValueOf(opts).Elem()
+	field := v.FieldByName(fieldName)
+	if !field.IsValid() || !field.CanSet() || field.Kind() != reflect.Struct {
+		return
+	}
+	modeField := field.FieldByName("Mode")
+	if !modeField.IsValid() || !modeField.CanSet() {
+		return
+	}
+	switch modeField.Kind() {
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+		modeField.SetUint(mode)
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		modeField.SetInt(int64(mode))
+	}
+}
+
+func parseVlogCompressionAutotuneMode(s string) (uint64, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "default", "unset", "auto":
+		// The actual default is decided by TreeDB depending on SplitValueLog.
+		return 0, nil
+	case "off", "false", "0":
+		return 1, nil
+	case "medium":
+		return 2, nil
+	case "aggressive":
+		return 3, nil
+	default:
+		return 0, fmt.Errorf("unsupported -treedb-vlog-compression-autotune=%q (expected off|medium|aggressive|default)", s)
+	}
+}
+
 func parseSlabCompression(name string, minBytes int, minSavings int) slab.CompressionOptions {
 	opts := slab.CompressionOptions{
 		Kind:            slab.CompressionNone,
@@ -218,6 +254,19 @@ func NewTreeDB(dir string) (kvstore.DB, error) {
 	setOptionalFloat64Option(&opts, "ValueLogDictMinPayloadSavingsRatio", *treedbVlogDictMinSavingsRatio)
 	setOptionalBoolOption(&opts, "IndexColumnarLeaves", *treedbIndexColumnarLeaves)
 	setOptionalBoolOption(&opts, "IndexInternalBaseDelta", *treedbIndexInternalBaseDelta)
+
+	autotuneMode, err := parseVlogCompressionAutotuneMode(*treedbVlogCompressionAutotune)
+	if err != nil {
+		return nil, err
+	}
+	setOptionalAutotuneMode(&opts, "ValueLogCompressionAutotune", autotuneMode)
+	if autotuneMode == 1 {
+		// Compression off should also force dict training off, even if the caller
+		// specified training flags. TreeDB enforces the same invariant internally,
+		// but we keep unified_bench behavior explicit and deterministic.
+		setOptionalTrainConfig(&opts, "ValueLogDictTrain", -1, 0, 0, 0, 0, 0)
+	}
+
 	db, err := treedb.Open(opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR is stacked on #141 (base: `sprint/rc_perf_fix_3`).

What changed
- Fixes an "explicit off can't be expressed" bug for `ValueLogCompressionAutotune.Mode` by introducing a distinct zero value (`AutotuneUnset`) and shifting `AutotuneOff` to a non-zero constant.
  - This makes `Mode: AutotuneOff` round-trip correctly through normalization instead of being treated as "unset".
- Removes the implicit dict-training enablement in cached-mode Open that was gated on `AllowUnsafe`.
  - Dict training is now only enabled when `ValueLogDictTrain.TrainBytes > 0` (as intended).
- Adds repo-root `cmd/unified_bench` flag `-treedb-vlog-compression-autotune` (default `off`).
  - Implemented via reflection because TreeDB's `valuelog` package is internal.
- Makes adaptive memtable mode switching take effect after the first rotation (removes the 2-rotation hysteresis that prevented switching in common warmup-only runs).
  - Adds regression tests to pin the behavior.

How to run / verify
- `go test ./... -count=1`
- `go run ./cmd/unified_bench -h | rg treedb-vlog-compression-autotune`

Notes
- `ValueLogCompressionAutotune.Mode=AutotuneOff` now means "autotuner off" (not "force dict compression off"); fixed-dict mode still works when training/config is enabled.
