### PR TITLE
CacheKV: add PutNoCopy for redis-style workloads

### DIFF
--- a/HashDB/cached_db.go
+++ b/HashDB/cached_db.go
@@ -75,6 +75,10 @@ func (c *CachedDB) Get(key []byte) ([]byte, error) { return c.cache.Get(key) }
 // Put inserts or updates a key in the write-back cache.
 func (c *CachedDB) Put(key []byte, value []byte) error { return c.cache.Put(key, value) }
 
+// PutNoCopy inserts or updates a key without copying the value.
+// Caller must not mutate value after calling (it may be retained until flushed).
+func (c *CachedDB) PutNoCopy(key []byte, value []byte) error { return c.cache.PutNoCopy(key, value) }
+
 // Add is a compatibility alias for Put.
 func (c *CachedDB) Add(key []byte, value []byte) error { return c.Put(key, value) }
 

--- a/HashDB/cachekv.go
+++ b/HashDB/cachekv.go
@@ -268,6 +268,30 @@ func (c *CacheKV) Put(key, value []byte) error {
 	return nil
 }
 
+// PutNoCopy inserts or updates a key without copying the value.
+// Caller must not mutate value after calling (it may be retained until flushed).
+func (c *CacheKV) PutNoCopy(key, value []byte) error {
+	k := string(key)
+
+	c.walMu.Lock()
+	if c.wal != nil {
+		if err := c.wal.appendPut(key, value); err != nil {
+			c.walMu.Unlock()
+			return err
+		}
+	}
+	c.mu.Lock()
+	c.pending[k] = cacheEntry{value: value}
+	c.pendingLen += len(k) + len(value)
+	shouldFlush := len(c.pending) >= c.maxEntries || c.pendingLen >= c.maxBytes
+	c.mu.Unlock()
+	c.walMu.Unlock()
+	if shouldFlush {
+		return c.Flush()
+	}
+	return nil
+}
+
 // Delete removes a key via the write-back cache.
 func (c *CacheKV) Delete(key []byte) error {
 	k := string(key)

--- a/HashDB/cachekv_test.go
+++ b/HashDB/cachekv_test.go
@@ -90,3 +90,29 @@ func TestCacheKVTicker(t *testing.T) {
 		t.Fatalf("expected ticker flush, got %s", v)
 	}
 }
+
+func TestCacheKVPutNoCopy(t *testing.T) {
+	base := &DummyKV{data: make(map[string][]byte)}
+	c := NewCacheKV(base, 100, 1<<20, 0)
+
+	val := []byte("v1")
+	if err := c.PutNoCopy([]byte("a"), val); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mutating val affects cached value because PutNoCopy avoids copying.
+	val[0] = 'V'
+
+	got, _ := c.Get([]byte("a"))
+	if string(got) != "V1" {
+		t.Fatalf("expected no-copy value, got %s", got)
+	}
+
+	if err := c.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = base.Get([]byte("a"))
+	if string(got) != "V1" {
+		t.Fatalf("expected flushed no-copy value, got %s", got)
+	}
+}

--- a/HashDB/sharded_db.go
+++ b/HashDB/sharded_db.go
@@ -142,6 +142,16 @@ func (h *HashDB) Put(key []byte, value []byte) error {
 	return h.shards[shardIndex].Put(key, value)
 }
 
+// PutNoCopy inserts or updates a key-value pair without copying the value.
+// Caller must not mutate value after calling (it may be retained until flushed).
+func (h *HashDB) PutNoCopy(key []byte, value []byte) error {
+	hash := hash(key)
+	shardIndex := hash % Hash(len(h.shards))
+	h.locks[shardIndex].Lock()
+	defer h.locks[shardIndex].Unlock()
+	return h.shards[shardIndex].PutNoCopy(key, value)
+}
+
 // PutSync performs a durable write. See CachedDB.PutSync for details.
 func (h *HashDB) PutSync(key []byte, value []byte) error {
 	hash := hash(key)


### PR DESCRIPTION
## Summary
- add `PutNoCopy` to CacheKV/CachedDB/HashDB to store values without copying
- document the immutability contract in method comments
- add a test that demonstrates no-copy behavior

## Testing
- `source "$HOME/.gvm/scripts/gvm" && go test ./HashDB/...`
