### PR TITLE
redisserver: expose treedb tuning flags (lanes/shards)

### DIFF
--- a/cmd/redisserver/main.go
+++ b/cmd/redisserver/main.go
@@ -36,6 +36,10 @@ func main() {
 	flag.BoolVar(&cfg.TreeDBDisableWAL, "treedb-disable-wal", false, "TreeDB: disable WAL")
 	flag.BoolVar(&cfg.TreeDBDisableJournal, "treedb-disable-journal", false, "TreeDB: disable journal")
 	flag.BoolVar(&cfg.TreeDBRelaxedSync, "treedb-relaxed-sync", false, "TreeDB: relaxed sync")
+	flag.BoolVar(&cfg.TreeDBAllowUnsafe, "treedb-allow-unsafe", false, "TreeDB: allow unsafe options (required for journal/WAL disable, relaxed sync, and memtable vlog pointers)")
+	flag.IntVar(&cfg.TreeDBJournalLanes, "treedb-journal-lanes", 0, "TreeDB: journal/value-log lanes (0=default)")
+	flag.IntVar(&cfg.TreeDBMemtableShards, "treedb-memtable-shards", 0, "TreeDB: memtable shard count (0=default)")
+	flag.BoolVar(&cfg.TreeDBMemtableVlogPtrs, "treedb-memtable-vlog-pointers", false, "TreeDB: store large values as pointers in memtable (unsafe; requires -treedb-allow-unsafe and value-log)")
 
 	flag.Float64Var(&cfg.CompactDeadRatio, "compact-dead-ratio", 0.50, "compaction dead ratio threshold")
 	flag.Uint64Var(&cfg.CompactMinBytes, "compact-min-bytes", 1*1024*1024, "compaction minimum slab bytes")

--- a/internal/redisserver/config.go
+++ b/internal/redisserver/config.go
@@ -30,6 +30,10 @@ type Config struct {
 	TreeDBDisableWAL        bool
 	TreeDBDisableJournal    bool
 	TreeDBRelaxedSync       bool
+	TreeDBAllowUnsafe       bool
+	TreeDBJournalLanes      int
+	TreeDBMemtableShards    int
+	TreeDBMemtableVlogPtrs  bool
 
 	// TreeDB compaction defaults (used by COMPACT/BGREWRITEAOF).
 	CompactDeadRatio         float64

--- a/internal/redisserver/engine.go
+++ b/internal/redisserver/engine.go
@@ -55,6 +55,10 @@ func openTreeDB(cfg Config) (kvstore.DB, error) {
 		DisableWAL:               cfg.TreeDBDisableWAL,
 		DisableJournal:           cfg.TreeDBDisableJournal,
 		RelaxedSync:              cfg.TreeDBRelaxedSync,
+		AllowUnsafe:              cfg.TreeDBAllowUnsafe,
+		JournalLanes:             cfg.TreeDBJournalLanes,
+		MemtableShards:           cfg.TreeDBMemtableShards,
+		MemtableValueLogPointers: cfg.TreeDBMemtableVlogPtrs,
 	}
 	switch strings.ToLower(strings.TrimSpace(cfg.TreeDBMode)) {
 	case "", "cached":

--- a/internal/redisserver/engine_options_test.go
+++ b/internal/redisserver/engine_options_test.go
@@ -1,0 +1,76 @@
+package redisserver
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+func TestOpenEngine_TreeDB_JournalLanesCreatesSegments(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Dir:                dir,
+		Engine:             "treedb",
+		TreeDBJournalLanes: 4,
+	}
+	db, err := OpenEngine(cfg)
+	if err != nil {
+		t.Fatalf("OpenEngine: %v", err)
+	}
+	// NOTE: TreeDB stores its main DB in Dir/maindb/, so the caching WAL dir is
+	// Dir/maindb/wal/.
+	walDir := filepath.Join(dir, "maindb", "wal")
+	entries, err := os.ReadDir(walDir)
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("ReadDir(%s): %v", walDir, err)
+	}
+	re := regexp.MustCompile(`^commit-l([0-9]+)-`)
+	lanes := make(map[int]struct{})
+	for _, e := range entries {
+		m := re.FindStringSubmatch(e.Name())
+		if m == nil {
+			continue
+		}
+		lane, err := strconv.Atoi(m[1])
+		if err != nil {
+			t.Fatalf("parse lane %q: %v", m[1], err)
+		}
+		lanes[lane] = struct{}{}
+	}
+	for i := 0; i < 4; i++ {
+		if _, ok := lanes[i]; !ok {
+			_ = db.Close()
+			t.Fatalf("expected commit log segment for lane %d; got lanes=%v", i, lanes)
+		}
+	}
+	_ = db.Close()
+}
+
+func TestOpenEngine_TreeDB_MemtableVlogPointersRequireAllowUnsafe(t *testing.T) {
+	dir := t.TempDir()
+	_, err := OpenEngine(Config{
+		Dir:                    dir,
+		Engine:                 "treedb",
+		TreeDBMemtableVlogPtrs: true,
+	})
+	if !errors.Is(err, treedb.ErrUnsafeOptions) {
+		t.Fatalf("expected ErrUnsafeOptions, got %v", err)
+	}
+
+	db, err := OpenEngine(Config{
+		Dir:                    t.TempDir(),
+		Engine:                 "treedb",
+		TreeDBAllowUnsafe:      true,
+		TreeDBMemtableVlogPtrs: true,
+	})
+	if err != nil {
+		t.Fatalf("OpenEngine with AllowUnsafe: %v", err)
+	}
+	_ = db.Close()
+}

--- a/scripts/memtier_bench.sh
+++ b/scripts/memtier_bench.sh
@@ -15,6 +15,10 @@ MEMTIER_USE_DOCKER="${MEMTIER_USE_DOCKER:-auto}"
 BENCH_SERVERS="${BENCH_SERVERS:-hashdb,treedb,redis,valkey,dragonfly}"
 BASE_PORT="${BASE_PORT:-6380}"
 
+REDISSERVER_ARGS_ALL="${REDISSERVER_ARGS_ALL:-}"
+REDISSERVER_ARGS_HASHDB="${REDISSERVER_ARGS_HASHDB:-}"
+REDISSERVER_ARGS_TREEDB="${REDISSERVER_ARGS_TREEDB:-}"
+
 # Matrix inputs (comma-separated).
 KEYS_LIST="${KEYS_LIST:-100000}"
 CLIENTS_LIST="${CLIENTS_LIST:-}"
@@ -84,7 +88,13 @@ start_redisserver() {
   local engine="$1"
   local port="$2"
   local dir="$3"
-  "$BIN" -engine "$engine" -dir "$dir" -addr ":$port" >/dev/null 2>&1 &
+  local extra="$REDISSERVER_ARGS_ALL"
+  case "$engine" in
+    hashdb) extra="$extra $REDISSERVER_ARGS_HASHDB" ;;
+    treedb) extra="$extra $REDISSERVER_ARGS_TREEDB" ;;
+  esac
+  # shellcheck disable=SC2086
+  "$BIN" -engine "$engine" -dir "$dir" -addr ":$port" $extra >/dev/null 2>&1 &
   echo $!
 }
 

--- a/scripts/noreply_bench.sh
+++ b/scripts/noreply_bench.sh
@@ -26,6 +26,10 @@ NR_PIPELINE_LIST="${NR_PIPELINE_LIST:-}"
 NR_RESP3="${NR_RESP3:-1}"
 NR_REPLY_OFF="${NR_REPLY_OFF:-1}"
 
+REDISSERVER_ARGS_ALL="${REDISSERVER_ARGS_ALL:-}"
+REDISSERVER_ARGS_HASHDB="${REDISSERVER_ARGS_HASHDB:-}"
+REDISSERVER_ARGS_TREEDB="${REDISSERVER_ARGS_TREEDB:-}"
+
 REDIS_IMAGE="${REDIS_IMAGE:-redis:8.4.0}"
 VALKEY_IMAGE="${VALKEY_IMAGE:-valkey/valkey:9.0.1}"
 DRAGONFLY_IMAGE="${DRAGONFLY_IMAGE:-docker.dragonflydb.io/dragonflydb/dragonfly:v1.34.2}"
@@ -79,7 +83,13 @@ start_redisserver() {
   local engine="$1"
   local port="$2"
   local dir="$3"
-  "$SERVER_BIN" -engine "$engine" -dir "$dir" -addr ":$port" >/dev/null 2>&1 &
+  local extra="$REDISSERVER_ARGS_ALL"
+  case "$engine" in
+    hashdb) extra="$extra $REDISSERVER_ARGS_HASHDB" ;;
+    treedb) extra="$extra $REDISSERVER_ARGS_TREEDB" ;;
+  esac
+  # shellcheck disable=SC2086
+  "$SERVER_BIN" -engine "$engine" -dir "$dir" -addr ":$port" $extra >/dev/null 2>&1 &
   echo $!
 }
 

--- a/scripts/redis_bench.sh
+++ b/scripts/redis_bench.sh
@@ -17,6 +17,10 @@ BENCH_RESP3="${BENCH_RESP3:-1}"
 BENCH_CONCURRENCY="${BENCH_CONCURRENCY:-}"
 BENCH_SERVERS="${BENCH_SERVERS:-hashdb,treedb,redis,valkey,dragonfly}"
 
+REDISSERVER_ARGS_ALL="${REDISSERVER_ARGS_ALL:-}"
+REDISSERVER_ARGS_HASHDB="${REDISSERVER_ARGS_HASHDB:-}"
+REDISSERVER_ARGS_TREEDB="${REDISSERVER_ARGS_TREEDB:-}"
+
 REDIS_IMAGE="${REDIS_IMAGE:-redis:8.4.0}"
 VALKEY_IMAGE="${VALKEY_IMAGE:-valkey/valkey:9.0.1}"
 DRAGONFLY_IMAGE="${DRAGONFLY_IMAGE:-docker.dragonflydb.io/dragonflydb/dragonfly:v1.34.2}"
@@ -77,7 +81,13 @@ start_redisserver() {
   local engine="$1"
   local port="$2"
   local dir="$3"
-  "$BIN" -engine "$engine" -dir "$dir" -addr ":$port" >/dev/null 2>&1 &
+  local extra="$REDISSERVER_ARGS_ALL"
+  case "$engine" in
+    hashdb) extra="$extra $REDISSERVER_ARGS_HASHDB" ;;
+    treedb) extra="$extra $REDISSERVER_ARGS_TREEDB" ;;
+  esac
+  # shellcheck disable=SC2086
+  "$BIN" -engine "$engine" -dir "$dir" -addr ":$port" $extra >/dev/null 2>&1 &
   echo $!
 }
 


### PR DESCRIPTION
Stacked on #133.\n\n- Adds redisserver flags for TreeDB tuning: `-treedb-allow-unsafe`, `-treedb-journal-lanes`, `-treedb-memtable-shards`, `-treedb-memtable-vlog-pointers`.\n- Adds bench script passthrough args via `REDISSERVER_ARGS_ALL`, `REDISSERVER_ARGS_HASHDB`, `REDISSERVER_ARGS_TREEDB`.\n- Adds tests verifying lanes create per-lane segments + AllowUnsafe requirement.\n\nRefs #148.