### PR TITLE
Docs: deprecate legacy mode1/WAL terminology

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -99,7 +99,8 @@ Profiles are intended to make intent explicit:
 - `ProfileBench`: deterministic benchmarking profile (not production).
 
 Note: `DisableWAL=true` disables both the journal/redo log and cached value-log
-pointers (legacy mode1; deprecated). To benchmark the value-log path with the
+pointers (legacy mode1; deprecated). Prefer `DisableJournal` / `DisableValueLog`
+to select Mode3/Mode4 explicitly. To benchmark the value-log path with the
 journal disabled, use `DisableJournal=true` (and keep `DisableValueLog=false`)
 with `AllowUnsafe=true`.
 
@@ -136,8 +137,8 @@ Details: `docs/TREEDB_PROFILES.md`.
 | `RelaxedSync` | on | flush-only | no | crash-consistent only |
 | `DisableJournal` | off | backend checkpoint | yes (if not relaxed) | no redo log; durable only after checkpoint |
 | `DisableJournal` + `RelaxedSync` | off | flush-only | no | fastest, least safe |
-| `DisableWAL` | off | backend checkpoint | yes (if not relaxed) | durable only after checkpoint |
-| `DisableWAL` + `RelaxedSync` | off | flush-only | no | fastest, least safe |
+| `DisableWAL` (legacy) | off | backend checkpoint | yes (if not relaxed) | durable only after checkpoint |
+| `DisableWAL` + `RelaxedSync` (legacy) | off | flush-only | no | fastest, least safe |
 
 ## Tuning (Cached Mode)
 

--- a/TreeDB/bench_trace_replay_test.go
+++ b/TreeDB/bench_trace_replay_test.go
@@ -64,6 +64,10 @@ func BenchmarkTraceReplay(b *testing.B) {
 		modeVal = ModeBackend
 	}
 	disableWAL := parseBoolEnv("TREEDB_TRACE_DISABLE_WAL", false)
+	disableJournal := false
+	if _, ok := os.LookupEnv("TREEDB_TRACE_DISABLE_JOURNAL"); ok {
+		disableJournal = parseBoolEnv("TREEDB_TRACE_DISABLE_JOURNAL", false)
+	}
 	disableVlog := parseBoolEnv("TREEDB_TRACE_DISABLE_VLOG", false)
 	scale := parseFloatEnv("TREEDB_TRACE_SCALE", 1.0)
 	flushThreshold := parseIntEnv("TREEDB_TRACE_FLUSH_THRESHOLD", 32*1024*1024)
@@ -86,6 +90,7 @@ func BenchmarkTraceReplay(b *testing.B) {
 			Dir:                 dir,
 			Mode:                modeVal,
 			DisableWAL:          disableWAL,
+			DisableJournal:      disableJournal,
 			DisableValueLog:     disableVlog,
 			FlushThreshold:      int64(flushThreshold),
 			MemtableShards:      memtableShards,

--- a/TreeDB/bench_trace_timeline_test.go
+++ b/TreeDB/bench_trace_timeline_test.go
@@ -85,6 +85,10 @@ func BenchmarkTraceReplayTimeline(b *testing.B) {
 		modeVal = ModeBackend
 	}
 	disableWAL := parseBoolEnv("TREEDB_TRACE_DISABLE_WAL", false)
+	disableJournal := false
+	if _, ok := os.LookupEnv("TREEDB_TRACE_DISABLE_JOURNAL"); ok {
+		disableJournal = parseBoolEnv("TREEDB_TRACE_DISABLE_JOURNAL", false)
+	}
 	disableVlog := parseBoolEnv("TREEDB_TRACE_DISABLE_VLOG", false)
 	scale := parseFloatEnv("TREEDB_TRACE_SCALE", 1.0)
 	flushThreshold := parseIntEnv("TREEDB_TRACE_FLUSH_THRESHOLD", 32*1024*1024)
@@ -108,6 +112,7 @@ func BenchmarkTraceReplayTimeline(b *testing.B) {
 	opts := Options{
 		Mode:                modeVal,
 		DisableWAL:          disableWAL,
+		DisableJournal:      disableJournal,
 		DisableValueLog:     disableVlog,
 		FlushThreshold:      int64(flushThreshold),
 		MemtableShards:      memtableShards,

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1212,7 +1212,8 @@ type Options struct {
 	// value-log pointers/value storage. A crash may lose writes since the last
 	// checkpoint because there is no redo log to replay.
 	DisableJournal bool
-	// DisableValueLog forces the cached WAL to remain in legacy mode (no value-log pointers).
+	// DisableValueLog forces the cached path to remain in legacy journal-only mode
+	// (no value-log pointers).
 	DisableValueLog bool
 	// SplitValueLog stores WAL records in wal/ while large values go to vlog/
 	// segments, and WAL entries reference them via pointers.

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -216,7 +216,8 @@ type Options struct {
 	// or slab tail repair.
 	AllowUnsafe bool
 
-	// DisableWAL disables the Write-Ahead Log in cached mode.
+	// DisableWAL disables the journal/value-log subsystem in cached mode
+	// (legacy mode1 alias; deprecated).
 	// This improves performance but sacrifices durability: a crash will revert
 	// the database to the last Checkpoint (backend flush).
 	DisableWAL bool

--- a/TreeDB/specs/spec.md
+++ b/TreeDB/specs/spec.md
@@ -701,28 +701,29 @@ func (b *Batch) GetByteSize() (int, error) {
 
 ## 7\. Write-Back Caching Layer & Read Optimizations
 
-To boost performance for write-heavy workloads and improve read throughput, TreeDB implements an LSM-style write-back caching layer (Memtable + WAL) and significant read path optimizations.
+To boost performance for write-heavy workloads and improve read throughput, TreeDB implements an LSM-style write-back caching layer (Memtable + journal/value-log) and significant read path optimizations.
 
 ### 7.1 Write-Back Caching (LSM-style Level 0)
 
-TreeDB implements a two-tiered caching mechanism: a mutable in-memory Memtable and a queue of immutable Memtables, backed by a Write-Ahead Log (WAL).
+TreeDB implements a two-tiered caching mechanism: a mutable in-memory Memtable and a queue of immutable Memtables, backed by a journal (legacy name: WAL) and a value log for large values.
 
 #### 7.1.1 Memtable (`internal/memtable`)
 - **Structure:** Uses a `google/btree` for efficient in-memory key-value storage.
 - **Operations:** Supports `Set`, `Delete` (using tombstones), and `Get`.
 - **Memory Tracking:** Tracks approximate memory usage for flush decisions.
 
-#### 7.1.2 Write-Ahead Log (WAL) (`internal/wal`)
+#### 7.1.2 Journal (legacy WAL) (`internal/wal`)
 - **Purpose:** Ensures durability of in-memory Memtable writes.
 - **Format:** Records operations as `[CRC][OpType][KeyLen][ValLen][Key][Value]`.
 - **Durability:** Provides `Sync()` method to guarantee writes are flushed to disk.
+  - **Note:** In modern cached-mode paths, large values are stored in the value log and referenced by pointers (Mode3/Mode4). `DisableWAL` refers to a legacy mode that disables both journal and value-log pointers.
 
 #### 7.1.3 CachingDB (`caching` package)
 - **Architecture:** Wraps the core `treedb.DB` instance (referred to as `backend`).
 - **Write Path:**
-    1.  `Set`/`Delete`: Operation is first appended to the current WAL.
+    1.  `Set`/`Delete`: Operation is first appended to the current journal (legacy: WAL). Large values may be written to the value log and referenced by pointer.
     2.  Then, the operation is applied to the `mutable` Memtable.
-    3.  `SetSync`/`DeleteSync`: Additionally calls `WAL.Sync()` after appending to the WAL.
+    3.  `SetSync`/`DeleteSync`: Additionally calls `Journal.Sync()` after appending to the journal.
 - **Flush Mechanism:**
     1.  When `mutable.Size()` exceeds `FlushThreshold` (e.g., 4MB):
         - The `mutable` Memtable is moved to the `queue` of immutable Memtables.

--- a/TreeDB/specs/value-log.md
+++ b/TreeDB/specs/value-log.md
@@ -1,6 +1,6 @@
-# Value Log (WAL=Value-Store) Plan
+# Value Log (Journal + Value-Store) Plan
 
-Goal: eliminate cached-mode “double write” for large values (write to WAL, then write again to slab during flush) by turning the cached-mode WAL into a **random-access value log** whose records can be referenced directly by the backend index (`ValuePtr`), while preserving:
+Goal: eliminate cached-mode “double write” for large values (write to journal, then write again to slab during flush) by turning the cached-mode journal stream into a **random-access value log** whose records can be referenced directly by the backend index (`ValuePtr`), while preserving:
 
 - fast random writes (memtable-first),
 - snapshot isolation,
@@ -8,19 +8,21 @@ Goal: eliminate cached-mode “double write” for large values (write to WAL, t
 - the current durability contract (`SetSync`/`WriteSync` are durable; non-sync writes are best-effort).
 
 This doc is a *plan for review* and is intentionally explicit so future agents can execute without missing context.
+Legacy note: this document uses “WAL” in places as a historical synonym for the cached-mode **journal**.
 
 ---
 
 ## Status (implemented)
 
 - Value-log segments live in `wal/vlog-*.log` and store v2 records (CRC + KeyLen + ValueLen + Op + key/value).
-- Cached mode uses the value log by default; use `Options.DisableValueLog` (or `DisableWAL`) to revert to classic WAL.
-- Note: `DisableWAL` disables the WAL/value-log subsystem together; there is not currently a “journal off but value-log on” mode.
+- Cached mode uses the value log by default; use `Options.DisableValueLog` to revert to the legacy journal-only path.
+- `DisableWAL` disables both journal and value log (legacy mode1; deprecated).
+- Journal-off + value-log-on is supported via `DisableJournal=true` (Mode4; unsafe).
 - Backend reads dispatch by `ValuePtr.FileID` high bit via `ValueReader` (`page.IsValueLogFileID`).
 - Cached flush stores pointers for `len(value) > InlineThreshold` (no slab write).
 - Segment retention is conservative (retain any segment that might contain a live pointer); value-log GC/compaction remains a follow-up.
 - Optional guardrail: `MaxValueLogRetainedBytesHard` disables new value-log pointers once retained bytes exceed the threshold.
-- Optional split mode: `SplitValueLog` keeps WAL records in `wal/wal-*.log` and writes large values to `wal/vlog-*.log`, with WAL entries storing `ValuePtr` payloads for large values.
+- Optional split mode: `SplitValueLog` keeps journal records in `wal/commit-*.log` and writes large values to `wal/value-*.log`, with journal entries storing `ValuePtr` payloads for large values.
 
 ## Problem statement
 
@@ -31,7 +33,7 @@ Today in cached mode:
   - small values are written inline into `index.db`,
   - large values are written into `data-*.slab` and referenced by `ValuePtr`.
 
-This is correct and simple, but it doubles write bandwidth for large values (WAL + slab), which shows up as a material wall-time slowdown in write-heavy workloads (e.g. `iavl-bench` with WAL enabled).
+This is correct and simple, but it doubles write bandwidth for large values (journal + slab), which shows up as a material wall-time slowdown in write-heavy workloads (e.g. `iavl-bench` with journal enabled).
 
 ---
 

--- a/cmd/trace_replay/main.go
+++ b/cmd/trace_replay/main.go
@@ -49,7 +49,8 @@ func main() {
 	seed := flag.Int64("seed", 1, "RNG seed")
 	scale := flag.Float64("scale", 1.0, "Scale factor for counts in summary")
 	mode := flag.String("mode", "cached", "TreeDB mode: cached or backend")
-	disableWAL := flag.Bool("disable-wal", false, "Disable WAL")
+	disableWAL := flag.Bool("disable-wal", false, "Disable journal+value log (legacy alias; deprecated)")
+	disableJournal := flag.Bool("disable-journal", false, "Disable journal/redo records while keeping value-log pointers (unsafe)")
 	disableVlog := flag.Bool("disable-vlog", false, "Disable value log")
 	flushThreshold := flag.Int("flush-threshold", 32*1024*1024, "Flush threshold bytes")
 	memtableShards := flag.Int("memtable-shards", 0, "Memtable shards (0 = default)")
@@ -97,6 +98,7 @@ func main() {
 		Dir:                 dir,
 		Mode:                modeVal,
 		DisableWAL:          *disableWAL,
+		DisableJournal:      *disableJournal,
 		DisableValueLog:     *disableVlog,
 		FlushThreshold:      int64(*flushThreshold),
 		MemtableShards:      *memtableShards,

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -65,9 +65,9 @@ var (
 	treedbIndexColumnarLeaves       = flag.Bool("treedb-index-columnar-leaves", false, "TreeDB: enable columnar leaf encoding")
 	treedbIndexInternalBaseDelta    = flag.Bool("treedb-index-internal-base-delta", false, "TreeDB: enable internal base-delta encoding")
 
-	treedbDisableWAL           = flag.Bool("treedb-disable-wal", false, "TreeDB: disable WAL (unsafe)")
+	treedbDisableWAL           = flag.Bool("treedb-disable-wal", false, "TreeDB: disable journal+value log (legacy mode1 alias; unsafe)")
 	treedbDisableJournal       = flag.Bool("treedb-disable-journal", false, "TreeDB: disable journal/redo records while keeping value-log pointers (unsafe)")
-	treedbDisableValueLog      = flag.Bool("treedb-disable-value-log", false, "TreeDB: disable value-log pointers (forces legacy WAL framing; also implied by -treedb-disable-wal)")
+	treedbDisableValueLog      = flag.Bool("treedb-disable-value-log", false, "TreeDB: disable value-log pointers (legacy path; also implied by -treedb-disable-wal)")
 	treedbRelaxedSync          = flag.Bool("treedb-relaxed-sync", false, "TreeDB: relaxed sync (unsafe)")
 	treedbDisableReadChecksum  = flag.Bool("treedb-disable-read-checksum", false, "TreeDB: disable read checksum (unsafe)")
 	treedbAllowUnsafe          = flag.Bool("treedb-allow-unsafe", false, "TreeDB: allow unsafe durability/integrity options (required for -treedb-disable-wal/-treedb-disable-journal/-treedb-relaxed-sync/-treedb-disable-read-checksum)")

--- a/docs/OPT_SPRINT_NEXT.md
+++ b/docs/OPT_SPRINT_NEXT.md
@@ -6,6 +6,7 @@ It is written to be *actionable* and *mergeable*: every milestone below is a PR-
 Backwards compatibility is **not required** (pre-alpha), but **silent corruption is not acceptable**.
 
 **Terminology note (legacy):** some older docs use **WAL** as a synonym for the cached-mode **journal** (redo/commit log). The **value log** is distinct from backend slabs.
+This document also predates the final mode3/mode4 naming; references to “WAL off” or slab-direct paths should be treated as **legacy mode1** unless explicitly noted otherwise.
 
 ---
 

--- a/docs/TREEDB_BENCHMARKING.md
+++ b/docs/TREEDB_BENCHMARKING.md
@@ -123,7 +123,8 @@ Note that results can converge as timeline duration increases.
 These apply to trace replay benchmarks:
 
 - `TREEDB_TRACE_MODE`: `cached` (default) or `backend`
-- `TREEDB_TRACE_DISABLE_WAL`: `1/0` (legacy name; disables the journal)
+- `TREEDB_TRACE_DISABLE_JOURNAL`: `1/0` (preferred; disables the journal; takes precedence when set)
+- `TREEDB_TRACE_DISABLE_WAL`: `1/0` (legacy alias; disables journal + value log)
 - `TREEDB_TRACE_DISABLE_VLOG`: `1/0`
 - `TREEDB_TRACE_FLUSH_THRESHOLD`: bytes
 - `TREEDB_TRACE_MEMTABLE_SHARDS`: int

--- a/docs/TREEDB_PROFILES.md
+++ b/docs/TREEDB_PROFILES.md
@@ -60,7 +60,7 @@ Goal: safest default for production use.
 
 Behavior:
 
-- Keeps cached-mode durability/integrity features enabled:
+- Keeps cached-mode durability/integrity features enabled (**Mode3**):
   - journal enabled (`DisableJournal=false`, `DisableWAL=false`)
   - fsync policy unchanged (`RelaxedSync=false`)
   - read checksums enabled (`DisableReadChecksum=false`)
@@ -91,7 +91,7 @@ Notes:
   a different engine path.
 - `DisableWAL=true` implies the cached value log is also disabled (no value-log
   pointers, no value-log dictionary compression). To benchmark the value-log
-  path with the journal disabled, use `ProfileFastIngest` (or set
+  path with the journal disabled, use `ProfileFastIngest` (**Mode4**) (or set
   `DisableJournal=true` with `DisableWAL=false` and `AllowUnsafe=true`).
   The value-log-disabled path is legacy and should not be recommended for new
   deployments.
@@ -107,7 +107,7 @@ Note: `ProfileFast` requires `Options.AllowUnsafe = true` to open.
 ### `ProfileFastIngest`
 
 Goal: maximize write throughput while explicitly keeping the cached **value-log**
-path enabled (Mode4).
+path enabled (**Mode4**).
 
 Behavior:
 

--- a/docs/TREEDB_STRESS_TEST_PLAN.md
+++ b/docs/TREEDB_STRESS_TEST_PLAN.md
@@ -319,14 +319,14 @@ Additional criteria:
 - Error injection tests validate error propagation and no silent stalls.
 
 ## Open Questions
-- Should stress tests run against both `DisableWAL` true/false variants? (legacy name: disables journal + value log)
+- Should stress tests run against both `DisableJournal` true/false variants? (`DisableWAL` is legacy and disables both journal + value log)
 - Should we gate "heavy" tests on an env var or a build tag?
 - Which DB modes (cached/backend) must be covered in each stress test?
 
 ## Appendix: Config Matrix (Recommended)
 For each stress suite, consider these variants:
 - Mode: cached vs backend.
-- Journal: enabled vs disabled (`DisableWAL`).
+- Journal: enabled vs disabled (`DisableJournal`; `DisableWAL` is legacy).
 - Value log: enabled vs disabled (`DisableValueLog`).
 - Background tasks: enabled vs disabled (`TREEDB_BENCH_DISABLE_BG=1` parity).
 

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -15,7 +15,7 @@ This doc describes the knobs exposed via `treedb.Options` and the cached write-b
 - Cached-mode auto checkpointing:
   - `BackgroundCheckpointInterval`: defaults to 30s
   - `BackgroundCheckpointIdleDuration`: defaults to 2s
-  - `MaxWALBytes`: defaults to 2 GiB
+  - `MaxWALBytes`: defaults to 2 GiB (legacy name; journal/value-log bytes)
 
 ## Options
 
@@ -134,6 +134,7 @@ periodic cached-mode checkpoint by default:
 - `Options.BackgroundCheckpointInterval` (default 30s): periodic checkpoint cadence
 - `Options.BackgroundCheckpointIdleDuration` (default 2s): opportunistic checkpoint after write-idle
 - `Options.MaxWALBytes` (default 2 GiB): safety cap that can trigger checkpointing early
+  based on cached journal/value-log segment bytes (legacy name: WAL).
 
 A checkpoint:
 - blocks writers briefly,

--- a/docs/TREEDB_WRITE_PATHS.md
+++ b/docs/TREEDB_WRITE_PATHS.md
@@ -25,7 +25,8 @@ semantics. All other docs should link here.
 - **Mode2**: historical/unsupported combinations.
 
 Do not recommend Mode1/Mode2 in user-facing docs; keep them only for legacy
-compatibility or migration testing.
+compatibility or migration testing. These legacy paths may be removed in a
+future release.
 
 ## Practical knobs (public API)
 


### PR DESCRIPTION
## Summary
- Mark legacy mode1 / WAL naming as deprecated across docs; promote mode3/mode4 terminology.
- Add `TREEDB_TRACE_DISABLE_JOURNAL` env support and a `-disable-journal` flag in trace replay.
- Clarify legacy aliases (`DisableWAL`, `-treedb-disable-wal`) in help text and options comments.

## Details
- Docs updated: `TreeDB/README.md`, `docs/TREEDB_*`, `docs/OPT_SPRINT_NEXT.md`, `TreeDB/specs/spec.md`, `TreeDB/specs/value-log.md`.
- Trace benchmarks now accept `TREEDB_TRACE_DISABLE_JOURNAL` with precedence over the legacy `TREEDB_TRACE_DISABLE_WAL`.

## Tests
- `gofmt` (via pre-commit)

Refs: #166