### PR TITLE
redisserver: add Go map backend baseline

### DIFF
--- a/HashDB/redisserver/main.go
+++ b/HashDB/redisserver/main.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/snissn/gomap/HashDB/redisserver/badgerredis"
 	"github.com/snissn/gomap/HashDB/redisserver/hashdbredis"
+	"github.com/snissn/gomap/HashDB/redisserver/mapredis"
 )
 
 func main() {
 	if len(os.Args) < 3 {
-		fmt.Println("Usage: go run redisserver/main.go [hashdb|badger] [dbdir] [addr-or-port?]")
+		fmt.Println("Usage: go run redisserver/main.go [hashdb|badger|map] [dbdir] [addr-or-port?]")
 		os.Exit(1)
 	}
 
@@ -52,9 +53,16 @@ func main() {
 			fmt.Println("Server error:", err)
 		}
 
+	case "map":
+		server := mapredis.NewRedisServer(dbdir)
+		fmt.Printf("Starting Redis server using Go map on %s (dbdir=%s)\n", addr, dbdir)
+		if err := server.Serve(addr); err != nil {
+			fmt.Println("Server error:", err)
+		}
+
 	default:
 		fmt.Println("Unknown mode:", mode)
-		fmt.Println("Usage: go run redisserver/main.go [hashdb|badger] [dbdir] [addr-or-port?]")
+		fmt.Println("Usage: go run redisserver/main.go [hashdb|badger|map] [dbdir] [addr-or-port?]")
 		os.Exit(1)
 	}
 }

--- a/HashDB/redisserver/mapredis/server.go
+++ b/HashDB/redisserver/mapredis/server.go
@@ -1,0 +1,381 @@
+package mapredis
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"unsafe"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/tidwall/redcon"
+)
+
+type connState struct {
+	replyOff bool
+}
+
+// RedisServer is a minimal Redis-compatible server backed by a plain Go map.
+//
+// This backend exists mainly as a baseline for quantifying protocol + redcon
+// overhead versus the storage engines (HashDB/TreeDB).
+//
+// NOTE: For performance, values are stored as-is from redcon's cmd.Args slices.
+// Redcon makes a full copy of the raw RESP command per request, so the slices
+// remain valid after the handler returns. This does mean we retain the raw
+// command backing array for each stored value.
+type RedisServer struct {
+	shards []mapShard
+}
+
+type mapShard struct {
+	mu sync.RWMutex
+	kv map[string][]byte
+}
+
+const defaultShardCount = 256
+
+func NewRedisServer(_ string) *RedisServer {
+	s := &RedisServer{
+		shards: make([]mapShard, defaultShardCount),
+	}
+	for i := range s.shards {
+		s.shards[i].kv = make(map[string][]byte)
+	}
+	return s
+}
+
+func (s *RedisServer) Serve(addr string) error {
+	return redcon.ListenAndServe(addr, s.handle, nil, nil)
+}
+
+func (s *RedisServer) shardForKey(key []byte) *mapShard {
+	// defaultShardCount is a power of two so we can mask rather than mod.
+	idx := int(xxhash.Sum64(key) & uint64(len(s.shards)-1))
+	return &s.shards[idx]
+}
+
+func (s *RedisServer) handle(conn redcon.Conn, cmd redcon.Command) {
+	if len(cmd.Args) == 0 {
+		// Never reply if replies are disabled for this connection.
+		if st, ok := conn.Context().(*connState); ok && st.replyOff {
+			return
+		}
+		conn.WriteError("empty command")
+		return
+	}
+
+	var state *connState
+	if ctx := conn.Context(); ctx != nil {
+		if st, ok := ctx.(*connState); ok {
+			state = st
+		}
+	}
+
+	switch string(cmd.Args[0]) {
+	case "PING":
+		if state != nil && state.replyOff {
+			return
+		}
+		conn.WriteString("PONG")
+
+	case "HELLO":
+		// Minimal RESP3 negotiation (used by noreply_bench).
+		if state != nil && state.replyOff {
+			return
+		}
+		if len(cmd.Args) >= 2 && string(cmd.Args[1]) == "3" {
+			conn.WriteArray(2)
+			conn.WriteBulkString("proto")
+			conn.WriteInt(3)
+			return
+		}
+		conn.WriteString("OK")
+
+	case "CLIENT":
+		// Minimal support for CLIENT REPLY OFF/ON (used by noreply_bench).
+		if len(cmd.Args) >= 3 && string(cmd.Args[1]) == "REPLY" {
+			if state == nil {
+				state = &connState{}
+				conn.SetContext(state)
+			}
+			switch string(cmd.Args[2]) {
+			case "OFF":
+				state.replyOff = true
+				// Redis-style behavior: suppress reply to CLIENT REPLY OFF itself.
+				return
+			case "ON":
+				state.replyOff = false
+				conn.WriteString("OK")
+				return
+			default:
+				if state.replyOff {
+					return
+				}
+				conn.WriteError("ERR unknown CLIENT REPLY mode")
+				return
+			}
+		}
+		if state != nil && state.replyOff {
+			return
+		}
+		conn.WriteError("unknown command")
+
+	case "SET":
+		if len(cmd.Args) < 3 {
+			if state != nil && state.replyOff {
+				return
+			}
+			conn.WriteError("ERR wrong number of arguments for 'SET'")
+			return
+		}
+
+		keyBytes := cmd.Args[1]
+		val := cmd.Args[2]
+
+		keyLookup := bytesToStringNoAlloc(keyBytes)
+
+		shard := s.shardForKey(keyBytes)
+		shard.mu.Lock()
+		if _, ok := shard.kv[keyLookup]; ok {
+			shard.kv[keyLookup] = val
+		} else {
+			// Allocate a stable key string once per unique key. This avoids keeping
+			// the full cmd.Raw (incl. value bytes) alive forever via the map key.
+			shard.kv[string(keyBytes)] = val
+		}
+		shard.mu.Unlock()
+
+		if state != nil && state.replyOff {
+			return
+		}
+		conn.WriteString("OK")
+
+	case "GET":
+		if len(cmd.Args) < 2 {
+			if state != nil && state.replyOff {
+				return
+			}
+			conn.WriteError("ERR wrong number of arguments for 'GET'")
+			return
+		}
+
+		keyLookup := bytesToStringNoAlloc(cmd.Args[1])
+
+		shard := s.shardForKey(cmd.Args[1])
+		shard.mu.RLock()
+		val, ok := shard.kv[keyLookup]
+		shard.mu.RUnlock()
+
+		if state != nil && state.replyOff {
+			return
+		}
+		if !ok || val == nil {
+			conn.WriteNull()
+		} else {
+			conn.WriteBulk(val)
+		}
+
+	case "DEL":
+		if len(cmd.Args) < 2 {
+			if state != nil && state.replyOff {
+				return
+			}
+			conn.WriteError("ERR wrong number of arguments for 'DEL'")
+			return
+		}
+
+		count := 0
+		for i := 1; i < len(cmd.Args); i++ {
+			keyBytes := cmd.Args[i]
+			keyLookup := bytesToStringNoAlloc(keyBytes)
+			shard := s.shardForKey(keyBytes)
+			shard.mu.Lock()
+			if _, ok := shard.kv[keyLookup]; ok {
+				delete(shard.kv, keyLookup)
+				count++
+			}
+			shard.mu.Unlock()
+		}
+
+		if state != nil && state.replyOff {
+			return
+		}
+		conn.WriteInt(count)
+
+	case "MSET":
+		if len(cmd.Args) < 3 || len(cmd.Args)%2 != 1 {
+			if state != nil && state.replyOff {
+				return
+			}
+			conn.WriteError("ERR wrong number of arguments for 'MSET'")
+			return
+		}
+
+		for i := 1; i < len(cmd.Args); i += 2 {
+			keyBytes := cmd.Args[i]
+			val := cmd.Args[i+1]
+			keyLookup := bytesToStringNoAlloc(keyBytes)
+			shard := s.shardForKey(keyBytes)
+			shard.mu.Lock()
+			if _, ok := shard.kv[keyLookup]; ok {
+				shard.kv[keyLookup] = val
+			} else {
+				shard.kv[string(keyBytes)] = val
+			}
+			shard.mu.Unlock()
+		}
+
+		if state != nil && state.replyOff {
+			return
+		}
+		conn.WriteString("OK")
+
+	case "MGET":
+		if len(cmd.Args) < 2 {
+			if state != nil && state.replyOff {
+				return
+			}
+			conn.WriteError("ERR wrong number of arguments for 'MGET'")
+			return
+		}
+
+		keys := cmd.Args[1:]
+		if state != nil && state.replyOff {
+			// Still do the work to match server-side behavior, but suppress reply.
+			// This keeps the fast benchmark path consistent.
+			for _, key := range keys {
+				shard := s.shardForKey(key)
+				shard.mu.RLock()
+				_, _ = shard.kv[bytesToStringNoAlloc(key)]
+				shard.mu.RUnlock()
+			}
+			return
+		}
+
+		conn.WriteArray(len(keys))
+		for _, key := range keys {
+			shard := s.shardForKey(key)
+			shard.mu.RLock()
+			val, ok := shard.kv[bytesToStringNoAlloc(key)]
+			shard.mu.RUnlock()
+			if !ok || val == nil {
+				conn.WriteNull()
+			} else {
+				conn.WriteBulk(val)
+			}
+		}
+
+	case "EXISTS":
+		if len(cmd.Args) < 2 {
+			if state != nil && state.replyOff {
+				return
+			}
+			conn.WriteError("ERR wrong number of arguments for 'EXISTS'")
+			return
+		}
+
+		count := 0
+		for i := 1; i < len(cmd.Args); i++ {
+			keyBytes := cmd.Args[i]
+			shard := s.shardForKey(keyBytes)
+			shard.mu.RLock()
+			v, ok := shard.kv[bytesToStringNoAlloc(keyBytes)]
+			shard.mu.RUnlock()
+			if ok && v != nil {
+				count++
+			}
+		}
+
+		if state != nil && state.replyOff {
+			return
+		}
+		conn.WriteInt(count)
+
+	case "INCR":
+		if len(cmd.Args) != 2 {
+			if state != nil && state.replyOff {
+				return
+			}
+			conn.WriteError("ERR wrong number of arguments for 'INCR'")
+			return
+		}
+
+		keyBytes := cmd.Args[1]
+		keyLookup := bytesToStringNoAlloc(keyBytes)
+
+		var out int64
+		var err error
+		shard := s.shardForKey(keyBytes)
+		shard.mu.Lock()
+		val, ok := shard.kv[keyLookup]
+		if ok && val != nil {
+			out, err = strconv.ParseInt(string(val), 10, 64)
+			if err != nil {
+				shard.mu.Unlock()
+				if state != nil && state.replyOff {
+					return
+				}
+				conn.WriteError("ERR value is not an integer or out of range")
+				return
+			}
+		}
+		out++
+		if ok {
+			shard.kv[keyLookup] = []byte(strconv.FormatInt(out, 10))
+		} else {
+			shard.kv[string(keyBytes)] = []byte(strconv.FormatInt(out, 10))
+		}
+		shard.mu.Unlock()
+
+		if state != nil && state.replyOff {
+			return
+		}
+		conn.WriteInt64(out)
+
+	case "FLUSHDB", "FLUSHALL":
+		for i := range s.shards {
+			shard := &s.shards[i]
+			shard.mu.Lock()
+			clear(shard.kv)
+			shard.mu.Unlock()
+		}
+		if state != nil && state.replyOff {
+			return
+		}
+		conn.WriteString("OK")
+
+	case "SAVE":
+		// In-memory backend has nothing durable to write.
+		if state != nil && state.replyOff {
+			return
+		}
+		conn.WriteString("OK")
+
+	case "INFO":
+		keys := 0
+		for i := range s.shards {
+			shard := &s.shards[i]
+			shard.mu.RLock()
+			keys += len(shard.kv)
+			shard.mu.RUnlock()
+		}
+		info := fmt.Sprintf("# Keyspace\r\nkeys=%d,expires=0,avg_ttl=0\r\n", keys)
+		if state != nil && state.replyOff {
+			return
+		}
+		conn.WriteBulkString(info)
+
+	default:
+		if state != nil && state.replyOff {
+			return
+		}
+		conn.WriteError("unknown command")
+	}
+}
+
+func bytesToStringNoAlloc(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}

--- a/HashDB/redisserver/mapredis/server_test.go
+++ b/HashDB/redisserver/mapredis/server_test.go
@@ -1,0 +1,226 @@
+package mapredis
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/tidwall/redcon"
+)
+
+func TestRedisServer_SetGet(t *testing.T) {
+	addr, stop := startTestServer(t)
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	r := bufio.NewReader(c)
+	w := bufio.NewWriter(c)
+
+	writeCommand(t, w, "SET", "k", "v")
+	flush(t, w)
+	if resp := readResp(t, r); resp.kind != '+' || resp.line != "OK" {
+		t.Fatalf("SET resp = %#v", resp)
+	}
+
+	writeCommand(t, w, "GET", "k")
+	flush(t, w)
+	if resp := readResp(t, r); resp.kind != '$' || string(resp.bulk) != "v" {
+		t.Fatalf("GET resp = %#v", resp)
+	}
+
+	writeCommand(t, w, "GET", "missing")
+	flush(t, w)
+	if resp := readResp(t, r); resp.kind != '$' || resp.bulk != nil {
+		t.Fatalf("GET missing resp = %#v", resp)
+	}
+
+	writeCommand(t, w, "DEL", "k")
+	flush(t, w)
+	if resp := readResp(t, r); resp.kind != ':' || resp.int64 != 1 {
+		t.Fatalf("DEL resp = %#v", resp)
+	}
+}
+
+func TestRedisServer_ClientReplyOffOn(t *testing.T) {
+	addr, stop := startTestServer(t)
+	defer stop()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	r := bufio.NewReader(c)
+	w := bufio.NewWriter(c)
+
+	writeCommand(t, w, "CLIENT", "REPLY", "OFF")
+	flush(t, w)
+
+	// Redis-style behavior: no reply to CLIENT REPLY OFF itself.
+	_ = c.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, err = r.ReadByte()
+	if err == nil {
+		t.Fatalf("expected no reply after CLIENT REPLY OFF")
+	}
+	if !isTimeout(err) {
+		t.Fatalf("expected timeout, got %T %v", err, err)
+	}
+	_ = c.SetReadDeadline(time.Time{})
+
+	// All subsequent replies should be suppressed.
+	writeCommand(t, w, "PING")
+	flush(t, w)
+	_ = c.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, err = r.ReadByte()
+	if err == nil {
+		t.Fatalf("expected no reply to PING while reply-off")
+	}
+	if !isTimeout(err) {
+		t.Fatalf("expected timeout, got %T %v", err, err)
+	}
+	_ = c.SetReadDeadline(time.Time{})
+
+	// Turn replies back on.
+	writeCommand(t, w, "CLIENT", "REPLY", "ON")
+	flush(t, w)
+	if resp := readResp(t, r); resp.kind != '+' || resp.line != "OK" {
+		t.Fatalf("CLIENT REPLY ON resp = %#v", resp)
+	}
+
+	writeCommand(t, w, "PING")
+	flush(t, w)
+	if resp := readResp(t, r); resp.kind != '+' || resp.line != "PONG" {
+		t.Fatalf("PING resp = %#v", resp)
+	}
+}
+
+func startTestServer(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+
+	srv := NewRedisServer("")
+	rc := redcon.NewServer("127.0.0.1:0", srv.handle, nil, nil)
+
+	sig := make(chan error, 1)
+	go func() {
+		_ = rc.ListenServeAndSignal(sig)
+	}()
+	if err := <-sig; err != nil {
+		t.Fatalf("ListenServeAndSignal: %v", err)
+	}
+
+	return rc.Addr().String(), func() {
+		_ = rc.Close()
+	}
+}
+
+func writeCommand(t *testing.T, w *bufio.Writer, args ...string) {
+	t.Helper()
+	if _, err := fmt.Fprintf(w, "*%d\r\n", len(args)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	for _, arg := range args {
+		if _, err := fmt.Fprintf(w, "$%d\r\n%s\r\n", len(arg), arg); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+}
+
+func flush(t *testing.T, w *bufio.Writer) {
+	t.Helper()
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+}
+
+type resp struct {
+	kind  byte
+	line  string
+	bulk  []byte
+	int64 int64
+}
+
+func readResp(t *testing.T, r *bufio.Reader) resp {
+	t.Helper()
+
+	kind, err := r.ReadByte()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	switch kind {
+	case '+', '-':
+		line, err := r.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read line: %v", err)
+		}
+		line = trimCRLF(line)
+		return resp{kind: kind, line: line}
+
+	case ':':
+		line, err := r.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read int: %v", err)
+		}
+		line = trimCRLF(line)
+		n, err := strconv.ParseInt(line, 10, 64)
+		if err != nil {
+			t.Fatalf("parse int: %v", err)
+		}
+		return resp{kind: kind, int64: n}
+
+	case '$':
+		line, err := r.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read bulk len: %v", err)
+		}
+		line = trimCRLF(line)
+		n, err := strconv.Atoi(line)
+		if err != nil {
+			t.Fatalf("parse bulk len: %v", err)
+		}
+		if n == -1 {
+			return resp{kind: kind}
+		}
+		buf := make([]byte, n+2)
+		if _, err := io.ReadFull(r, buf); err != nil {
+			t.Fatalf("read bulk: %v", err)
+		}
+		return resp{kind: kind, bulk: buf[:n]}
+
+	default:
+		t.Fatalf("unexpected kind: %q", kind)
+		return resp{}
+	}
+}
+
+func trimCRLF(s string) string {
+	if len(s) >= 2 && s[len(s)-2] == '\r' {
+		return s[:len(s)-2]
+	}
+	if len(s) >= 1 && s[len(s)-1] == '\n' {
+		return s[:len(s)-1]
+	}
+	return s
+}
+
+func isTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	return false
+}

--- a/docs/REDIS_PROTOCOL_BENCHMARKING.md
+++ b/docs/REDIS_PROTOCOL_BENCHMARKING.md
@@ -79,6 +79,36 @@ redis-server --port 6380 --dir "$DBDIR" --save "" --appendonly no
 
 Then run the same `noreply_bench` command (just change the `-label`).
 
+### Baseline: redcon + Go map
+
+`hashdb-redis-wrapper` also includes a `map` mode that uses a sharded Go builtin
+map. This is useful as a rough "protocol + server wrapper ceiling" for this repo:
+
+```bash
+DBDIR=$(mktemp -d)
+./bin/hashdb-redis-wrapper map "$DBDIR" :6380
+```
+
+### Sample Results (Local)
+
+Env:
+
+- Apple M3, 8 cores
+- clients=16, keyspace=100000, value-size=128, test-time=10s
+- `-resp3` + `-reply-off=true`
+
+| Engine | Pipeline | RPS |
+|---|---:|---:|
+| map | 64 | 8,245,266.82 |
+| map | 256 | 8,843,145.41 |
+| map | 512 | 9,052,913.85 |
+| hashdb | 64 | 6,233,215.96 |
+| hashdb | 256 | 6,617,456.07 |
+| hashdb | 512 | 6,938,040.39 |
+| redis | 64 | 1,433,283.34 |
+| redis | 256 | 1,395,026.31 |
+| redis | 512 | 1,382,830.41 |
+
 ## Common Gotchas
 
 - `ENOBUFS` / "no buffer space available" on loopback:
@@ -86,4 +116,3 @@ Then run the same `noreply_bench` command (just change the `-label`).
   - increase OS socket buffer limits if you want to push harder
 - This benchmark is **SET-only** by design. Use `cmd/unified_bench` for mixed
   read/write workloads and engine-level comparisons.
-


### PR DESCRIPTION
Adds a new redisserver mode: `map` (sharded builtin Go map) to provide a rough protocol + redcon throughput ceiling.

Also adds a small integration test for the backend and updates `docs/REDIS_PROTOCOL_BENCHMARKING.md` with sample noreply_bench results for map/hashdb/redis.

Stacked on PR #163.