### PR TITLE
treedb: restore swap-based index vacuum

### DIFF
--- a/.pr/PR_vacuum_swap.md
+++ b/.pr/PR_vacuum_swap.md
@@ -1,0 +1,17 @@
+Restores swap-based index vacuum semantics (online/offline) for the WAL-on/off-only backend.
+
+What changed
+- Reintroduced backend online/offline vacuum with index swap (`TreeDB/db/vacuum_online.go`, `TreeDB/db/vacuum_offline.go`).
+- Restored vacuum recorder tracking to capture committed ops during online vacuum.
+- Wired public API to call backend vacuum instead of aliasing `CompactIndex`.
+- Treemap CLI now distinguishes:
+  - `compact`: in-place rebuild
+  - `vacuum`: swap-based offline vacuum (shrinks `index.db`).
+- Added vacuum tests (offline shrink, online swap/snapshot, recorder race, concurrent write safety).
+
+How to test
+- `GOWORK=off go test ./TreeDB/... -count=1`
+
+Notes
+- Online vacuum is still unsupported on Windows (same as before).
+- Vacuum is index-only; value-log semantics unchanged.

--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -28,8 +28,8 @@ Commands:
   stats           Print stats
   frag            Print fragmentation report
   verify          Full scan verification (counts items)
-  compact         Compact/rebuild the index.db (requires -rw)
-  vacuum          Alias for compact (index-only)
+  compact         Compact/rebuild the index.db in-place (requires -rw)
+  vacuum          Rebuild index.db via swap (shrinks file; requires -rw)
   get             Get a single key
   keys            List keys in a range/prefix
   scan            Scan keys and values in a range/prefix (requires -allow-values)
@@ -72,8 +72,10 @@ func main() {
 		runFrag(dir, args)
 	case "verify":
 		runVerify(dir, args)
-	case "compact", "vacuum":
+	case "compact":
 		runCompact(dir, args)
+	case "vacuum":
+		runVacuum(dir, args)
 	case "get":
 		runGet(dir, args)
 	case "keys":
@@ -191,6 +193,21 @@ func runCompact(dir string, args []string) {
 		fatalf("CompactIndex error: %v", err)
 	}
 	fmt.Println("Index compaction complete.")
+}
+
+func runVacuum(dir string, args []string) {
+	fs := flag.NewFlagSet("vacuum", flag.ExitOnError)
+	rw := fs.Bool("rw", false, "Open read-write (required; may replay WAL or repair files)")
+	_ = fs.Parse(args)
+
+	if !*rw {
+		fatalf("vacuum requires -rw")
+	}
+
+	if err := treedb.VacuumIndexOffline(treedb.Options{Dir: dir}); err != nil {
+		fatalf("VacuumIndexOffline error: %v", err)
+	}
+	fmt.Println("Index vacuum complete.")
 }
 
 func runGet(dir string, args []string) {

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -149,6 +149,9 @@ func (b *Batch) writeOptimistic(sync bool) (bool, error) {
 		b.db.writeMu.RUnlock()
 		return false, err
 	}
+	if b.db.vacuum.Active() {
+		b.db.vacuum.RecordOps(b.batch.Ops())
+	}
 	b.db.writeMu.RUnlock()
 	return true, nil
 }
@@ -186,6 +189,9 @@ func (b *Batch) writeSerialized(sync bool) error {
 
 	if err := b.db.finalizeCommit(newRoot, sysRoot, retired, sync, metrics); err != nil {
 		return err
+	}
+	if b.db.vacuum.Active() {
+		b.db.vacuum.RecordOps(b.batch.Ops())
 	}
 	return nil
 }

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -65,12 +65,15 @@ type DB struct {
 	leafPrefixCompression  bool
 	indexColumnarLeaves    bool
 	indexInternalBaseDelta bool
+	piggybackCompaction    bool
 
-	mu         sync.RWMutex
-	writeMu    sync.RWMutex
-	commitMu   sync.Mutex
-	meta       page.MetaPageBody
-	metaPageID uint64
+	mu               sync.RWMutex
+	writeMu          sync.RWMutex
+	commitMu         sync.Mutex
+	vacuumInProgress atomic.Bool
+	vacuum           vacuumRecorder
+	meta             page.MetaPageBody
+	metaPageID       uint64
 
 	state atomic.Pointer[DBState]
 
@@ -463,6 +466,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		leafPrefixCompression:  opts.LeafPrefixCompression,
 		indexColumnarLeaves:    opts.IndexColumnarLeaves,
 		indexInternalBaseDelta: opts.IndexInternalBaseDelta,
+		piggybackCompaction:    !opts.DisablePiggybackCompaction,
 		dir:                    opts.Dir,
 		chunkSize:              opts.ChunkSize,
 		preferAppendAlloc:      opts.PreferAppendAlloc,

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -1,0 +1,218 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/snissn/gomap/TreeDB/internal/bulk"
+	"github.com/snissn/gomap/TreeDB/internal/lockfile"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
+	"github.com/snissn/gomap/TreeDB/tree"
+)
+
+type vacuumFailpoint string
+
+const (
+	vacuumFailNone           vacuumFailpoint = ""
+	vacuumFailAfterNewSync   vacuumFailpoint = "after_new_sync"
+	vacuumFailAfterReady     vacuumFailpoint = "after_ready"
+	vacuumFailAfterRenameOld vacuumFailpoint = "after_rename_old"
+	vacuumFailAfterRenameNew vacuumFailpoint = "after_rename_new"
+)
+
+var errVacuumFailpoint = errors.New("vacuum failpoint")
+
+// VacuumIndexOffline rewrites index.db into a fresh file and swaps it in.
+//
+// This is intended to reclaim space (reduce `index.db` chunk count) and restore
+// locality after long churn. It is an offline operation (requires exclusive
+// open lock).
+func VacuumIndexOffline(opts Options) error {
+	return vacuumIndexOffline(opts, vacuumFailNone)
+}
+
+func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
+	if opts.Dir == "" {
+		return errors.New("db dir required")
+	}
+	if opts.ChunkSize == 0 {
+		opts.ChunkSize = defaultChunkSize
+	}
+	opts.DisableBackgroundPrune = true
+	opts.ReadOnly = true
+
+	lock, err := lockfile.Acquire(filepath.Join(opts.Dir, "LOCK"))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = lock.Close() }()
+
+	if err := recoverIndexSwap(opts.Dir); err != nil {
+		return err
+	}
+
+	// Open the DB without acquiring a second lock (we already hold it).
+	d, err := openReadOnlyNoLock(opts)
+	if err != nil {
+		return err
+	}
+
+	state := d.State()
+	if state == nil {
+		_ = d.Close()
+		return fmt.Errorf("vacuum: missing db state")
+	}
+	if state.ValueLogSet != nil {
+		d.valueLogManager.Acquire(state.ValueLogSet)
+		defer d.valueLogManager.Release(state.ValueLogSet)
+	}
+
+	indexPath := filepath.Join(opts.Dir, indexFileName)
+	newPath := filepath.Join(opts.Dir, indexNewFileName)
+	bakPath := filepath.Join(opts.Dir, indexBakFileName)
+	readyPath := filepath.Join(opts.Dir, indexReadyFileName)
+
+	// Clean up any previous partial artifacts (best-effort).
+	_ = os.Remove(newPath)
+	_ = os.Remove(readyPath)
+
+	newPager, err := pager.Open(newPath, opts.ChunkSize)
+	if err != nil {
+		_ = d.Close()
+		return err
+	}
+
+	if _, err := newPager.Alloc(2); err != nil {
+		_ = newPager.Close()
+		_ = d.Close()
+		return err
+	}
+
+	alloc := &pagerAllocator{p: newPager}
+
+	sysIter := tree.New(d.Pager(), valueReader{vlogs: state.ValueLogSet}, state.SystemRootPageID).Iterator(nil, nil)
+	sysRoot, err := bulk.BuildWithOptions(sysIter, alloc, newPager, bulk.BuildOptions{
+		LeafPrefixCompression: opts.LeafPrefixCompression,
+		LeafColumnar:          opts.IndexColumnarLeaves,
+		InternalBaseDelta:     opts.IndexInternalBaseDelta,
+	})
+	_ = sysIter.Close()
+	if err != nil {
+		_ = newPager.Close()
+		_ = d.Close()
+		return err
+	}
+
+	userIter := tree.New(d.Pager(), valueReader{vlogs: state.ValueLogSet}, state.RootPageID).Iterator(nil, nil)
+	userRoot, err := bulk.BuildWithOptions(userIter, alloc, newPager, bulk.BuildOptions{
+		LeafPrefixCompression: opts.LeafPrefixCompression,
+		LeafColumnar:          opts.IndexColumnarLeaves,
+		InternalBaseDelta:     opts.IndexInternalBaseDelta,
+	})
+	_ = userIter.Close()
+	if err != nil {
+		_ = newPager.Close()
+		_ = d.Close()
+		return err
+	}
+
+	meta := d.meta
+	meta.CommitSeq++
+	meta.UserRootPageID = userRoot
+	meta.SystemRootPageID = sysRoot
+	meta.FreelistHeadID = 0
+	meta.TotalPages = newPager.PageCount()
+
+	if err := writeMetaToPager(newPager, MetaPage0ID, meta); err != nil {
+		_ = newPager.Close()
+		_ = d.Close()
+		return err
+	}
+	if err := writeMetaToPager(newPager, MetaPage1ID, meta); err != nil {
+		_ = newPager.Close()
+		_ = d.Close()
+		return err
+	}
+
+	if err := newPager.Sync(); err != nil {
+		_ = newPager.Close()
+		_ = d.Close()
+		return err
+	}
+	if fail == vacuumFailAfterNewSync {
+		_ = newPager.Close()
+		_ = d.Close()
+		return errVacuumFailpoint
+	}
+
+	if err := os.WriteFile(readyPath, []byte("ready\n"), 0o644); err != nil {
+		_ = newPager.Close()
+		_ = d.Close()
+		return err
+	}
+	if runtime.GOOS != "windows" {
+		if dir, err := os.Open(opts.Dir); err == nil {
+			_ = dir.Sync()
+			_ = dir.Close()
+		}
+	}
+	if fail == vacuumFailAfterReady {
+		_ = newPager.Close()
+		_ = d.Close()
+		return errVacuumFailpoint
+	}
+
+	if err := newPager.Close(); err != nil {
+		_ = d.Close()
+		return err
+	}
+	if err := d.Close(); err != nil {
+		return err
+	}
+
+	// Swap in the new index file.
+	_ = os.Remove(bakPath)
+	if err := os.Rename(indexPath, bakPath); err != nil {
+		return err
+	}
+	if fail == vacuumFailAfterRenameOld {
+		return errVacuumFailpoint
+	}
+	if err := os.Rename(newPath, indexPath); err != nil {
+		_ = os.Rename(bakPath, indexPath)
+		return err
+	}
+	if fail == vacuumFailAfterRenameNew {
+		return errVacuumFailpoint
+	}
+
+	_ = os.Remove(readyPath)
+	_ = os.Remove(bakPath)
+	if runtime.GOOS != "windows" {
+		if dir, err := os.Open(opts.Dir); err == nil {
+			_ = dir.Sync()
+			_ = dir.Close()
+		}
+	}
+
+	return nil
+}
+
+func writeMetaToPager(p *pager.Pager, pageID uint64, meta page.MetaPageBody) error {
+	data, err := p.GetForWrite(pageID)
+	if err != nil {
+		return err
+	}
+	meta.Encode(data[page.PageHeaderSize:])
+	n := node.NewNode(data)
+	n.SetPageID(pageID)
+	n.SetType(page.PageTypeMeta)
+	n.SetCount(0)
+	n.UpdateChecksum()
+	return nil
+}

--- a/TreeDB/db/vacuum_offline_test.go
+++ b/TreeDB/db/vacuum_offline_test.go
@@ -1,0 +1,127 @@
+package db
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVacuumIndexOffline_PreservesDataAndShrinksFile(t *testing.T) {
+	dir := t.TempDir()
+	chunkSize := int64(64 * 1024)
+
+	d, err := Open(Options{
+		Dir:               dir,
+		ChunkSize:         chunkSize,
+		KeepRecent:        1,
+		PreferAppendAlloc: true, // intentionally bloat index.db
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	value := bytes.Repeat([]byte("v"), 200) // inline-ish to force page pressure
+	for round := 0; round < 8; round++ {
+		b := d.NewBatch()
+		for i := 0; i < 5000; i++ {
+			// Rewrite the same keyset to create lots of retired pages (index bloat)
+			// when PreferAppendAlloc is enabled.
+			k := []byte(fmt.Sprintf("k%06d", i))
+			if err := b.Set(k, value); err != nil {
+				t.Fatalf("set: %v", err)
+			}
+		}
+		if err := b.Write(); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_ = b.Close()
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	indexPath := filepath.Join(dir, indexFileName)
+	beforeInfo, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	if err := VacuumIndexOffline(Options{Dir: dir, ChunkSize: chunkSize, KeepRecent: 1}); err != nil {
+		t.Fatalf("vacuum: %v", err)
+	}
+
+	afterInfo, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if afterInfo.Size() >= beforeInfo.Size() {
+		t.Fatalf("expected vacuum to shrink index.db: before=%d after=%d", beforeInfo.Size(), afterInfo.Size())
+	}
+
+	verify, err := Open(Options{Dir: dir, ChunkSize: chunkSize, KeepRecent: 1})
+	if err != nil {
+		t.Fatalf("open after: %v", err)
+	}
+	defer func() { _ = verify.Close() }()
+
+	got, err := verify.Get([]byte("k000010"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Fatalf("value mismatch")
+	}
+}
+
+func TestVacuumIndexOffline_CrashPointsRecoverOnOpen(t *testing.T) {
+	failpoints := []vacuumFailpoint{
+		vacuumFailAfterNewSync,
+		vacuumFailAfterReady,
+		vacuumFailAfterRenameOld,
+		vacuumFailAfterRenameNew,
+	}
+
+	for _, fp := range failpoints {
+		fp := fp
+		t.Run(string(fp), func(t *testing.T) {
+			dir := t.TempDir()
+			chunkSize := int64(64 * 1024)
+
+			d, err := Open(Options{Dir: dir, ChunkSize: chunkSize, KeepRecent: 1})
+			if err != nil {
+				t.Fatalf("open: %v", err)
+			}
+			if err := d.SetSync([]byte("k"), []byte("v")); err != nil {
+				t.Fatalf("set: %v", err)
+			}
+			if err := d.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+
+			err = vacuumIndexOffline(Options{Dir: dir, ChunkSize: chunkSize, KeepRecent: 1}, fp)
+			if err == nil {
+				t.Fatalf("expected failpoint error")
+			}
+			if !errors.Is(err, errVacuumFailpoint) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			reopen, err := Open(Options{Dir: dir, ChunkSize: chunkSize, KeepRecent: 1})
+			if err != nil {
+				t.Fatalf("reopen: %v", err)
+			}
+			defer func() { _ = reopen.Close() }()
+
+			val, err := reopen.Get([]byte("k"))
+			if err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			if string(val) != "v" {
+				t.Fatalf("bad value: %q", val)
+			}
+		})
+	}
+}

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -1,0 +1,449 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/freelist"
+	"github.com/snissn/gomap/TreeDB/internal/bulk"
+	"github.com/snissn/gomap/TreeDB/pager"
+	"github.com/snissn/gomap/TreeDB/tree"
+	"github.com/snissn/gomap/TreeDB/zipper"
+)
+
+var ErrVacuumInProgress = errors.New("online vacuum already in progress")
+var ErrVacuumUnsupported = errors.New("online vacuum unsupported on this platform")
+
+const (
+	vacuumDeltaBatchSize     = 4096
+	vacuumCatchupPassesMax   = 3
+	vacuumCatchupKeyTarget   = 4096
+	vacuumCutoverMaxKeys     = 8192
+	vacuumCutoverMaxDefers   = 3
+	vacuumInlineThresholdMax = int(^uint(0) >> 1)
+	vacuumMaxGrowthFactor    = 8
+)
+
+type vacuumRecorder struct {
+	active atomic.Bool
+	mu     sync.Mutex
+	ops    map[string]batch.Entry
+}
+
+func (r *vacuumRecorder) Active() bool {
+	return r.active.Load()
+}
+
+func (r *vacuumRecorder) Start() {
+	r.mu.Lock()
+	r.ops = make(map[string]batch.Entry, 1024)
+	r.mu.Unlock()
+	r.active.Store(true)
+}
+
+func (r *vacuumRecorder) Stop() {
+	r.active.Store(false)
+}
+
+func vacuumRecordCopyEntry(entry batch.Entry) batch.Entry {
+	out := entry
+	out.Key = append([]byte(nil), entry.Key...)
+	if entry.Type == batch.OpPut && !entry.IsPtr {
+		out.Value = append([]byte(nil), entry.Value...)
+	} else {
+		out.Value = nil
+	}
+	return out
+}
+
+func (r *vacuumRecorder) RecordOps(ops map[string]batch.Entry) {
+	if !r.active.Load() || len(ops) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.active.Load() {
+		return
+	}
+	if r.ops == nil {
+		r.ops = make(map[string]batch.Entry, len(ops))
+	}
+	for k, entry := range ops {
+		r.ops[k] = vacuumRecordCopyEntry(entry)
+	}
+}
+
+func (r *vacuumRecorder) Drain() map[string]batch.Entry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.ops) == 0 {
+		return nil
+	}
+	out := r.ops
+	r.ops = make(map[string]batch.Entry, 1024)
+	return out
+}
+
+// VacuumIndexOnline rebuilds the index into a new file and swaps it in with a
+// short writer pause. Old snapshots remain valid by pinning the previous index
+// generation until readers drain; disk space is reclaimed once the old mmap is
+// closed.
+func (db *DB) VacuumIndexOnline(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if db.readOnly {
+		return ErrReadOnly
+	}
+	if runtime.GOOS == "windows" {
+		return ErrVacuumUnsupported
+	}
+
+	if !db.vacuumInProgress.CompareAndSwap(false, true) {
+		return ErrVacuumInProgress
+	}
+	defer db.vacuumInProgress.Store(false)
+
+	if db.dir == "" {
+		return errors.New("vacuum: missing db dir")
+	}
+
+	indexPath := filepath.Join(db.dir, indexFileName)
+	newPath := filepath.Join(db.dir, indexNewFileName)
+	bakPath := filepath.Join(db.dir, indexBakFileName)
+	readyPath := filepath.Join(db.dir, indexReadyFileName)
+
+	// Clean up any previous partial artifacts (best-effort).
+	_ = os.Remove(newPath)
+	_ = os.Remove(readyPath)
+
+	newPager, err := pager.Open(newPath, db.chunkSize)
+	if err != nil {
+		return err
+	}
+	cleanupNewPager := func() {
+		_ = newPager.Close()
+		_ = os.Remove(newPath)
+		_ = os.Remove(readyPath)
+	}
+
+	oldGen := db.idx.Load()
+	oldPages := uint64(0)
+	if oldGen != nil && oldGen.pager != nil {
+		oldPages = oldGen.pager.PageCount()
+	}
+	maxPages := uint64(0)
+	if oldPages > 0 {
+		maxPages = oldPages * uint64(vacuumMaxGrowthFactor)
+	}
+	checkGrowth := func() error {
+		if maxPages == 0 {
+			return nil
+		}
+		newPages := newPager.PageCount()
+		if newPages > maxPages {
+			return fmt.Errorf("vacuum: new index page count %d exceeds %dx old (%d)", newPages, vacuumMaxGrowthFactor, oldPages)
+		}
+		return nil
+	}
+
+	if _, err := newPager.Alloc(2); err != nil {
+		cleanupNewPager()
+		return err
+	}
+
+	newAlloc := freelist.New(newPager, 0)
+	newAlloc.SetPreferAppend(db.preferAppendAlloc)
+	newAlloc.SetFreelistRegion(db.freelistRegionPages, db.freelistRegionRadius)
+
+	newZ := zipper.New(newPager, newAlloc)
+	newZ.SetFillTargets(db.leafFillTargetPPM, db.internalFillTargetPPM)
+	newZ.SetPiggybackCompaction(db.piggybackCompaction)
+	newZ.SetLeafPrefixCompression(db.leafPrefixCompression)
+	newZ.SetIndexColumnarLeaves(db.indexColumnarLeaves)
+	newZ.SetIndexInternalBaseDelta(db.indexInternalBaseDelta)
+
+	db.vacuum.Start()
+	defer db.vacuum.Stop()
+
+	// Build a fresh user tree from a stable snapshot.
+	baseSnap := db.AcquireSnapshot()
+	baseIter := baseSnap.tree.Iterator(nil, nil)
+	newRoot, err := bulk.BuildWithOptions(baseIter, newAlloc, newPager, bulk.BuildOptions{
+		LeafPrefixCompression: db.leafPrefixCompression,
+		LeafColumnar:          db.indexColumnarLeaves,
+		InternalBaseDelta:     db.indexInternalBaseDelta,
+	})
+	_ = baseIter.Close()
+	_ = baseSnap.Close()
+	if err != nil {
+		cleanupNewPager()
+		return err
+	}
+	if err := checkGrowth(); err != nil {
+		cleanupNewPager()
+		return err
+	}
+
+	freeRetired := func(retired []uint64) {
+		for _, id := range retired {
+			_ = newAlloc.Free(id)
+		}
+	}
+
+	// Online catch-up: replay recorded keys in bounded passes.
+	for pass := 0; pass < vacuumCatchupPassesMax; pass++ {
+		if err := ctx.Err(); err != nil {
+			cleanupNewPager()
+			return err
+		}
+		opsMap := db.vacuum.Drain()
+		if len(opsMap) == 0 {
+			break
+		}
+		var retired []uint64
+		newRoot, retired, err = db.applyVacuumDelta(newRoot, opsMap, newZ, nil)
+		if err != nil {
+			cleanupNewPager()
+			return err
+		}
+		freeRetired(retired)
+		if err := checkGrowth(); err != nil {
+			cleanupNewPager()
+			return err
+		}
+		if len(opsMap) <= vacuumCatchupKeyTarget {
+			break
+		}
+	}
+
+	// Final cutover: stop recording, apply the tail, rebuild the System tree in
+	// the new file, then swap index.db on disk and publish a new index generation.
+	defers := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			cleanupNewPager()
+			return err
+		}
+
+		db.writeMu.Lock()
+		db.vacuum.Stop()
+		finalOps := db.vacuum.Drain()
+		if len(finalOps) > vacuumCutoverMaxKeys && defers < vacuumCutoverMaxDefers {
+			db.vacuum.Start()
+			db.writeMu.Unlock()
+			defers++
+
+			var retired []uint64
+			newRoot, retired, err = db.applyVacuumDelta(newRoot, finalOps, newZ, nil)
+			if err != nil {
+				cleanupNewPager()
+				return err
+			}
+			freeRetired(retired)
+			if err := checkGrowth(); err != nil {
+				cleanupNewPager()
+				return err
+			}
+			continue
+		}
+
+		if len(finalOps) > 0 {
+			var retired []uint64
+			newRoot, retired, err = db.applyVacuumDelta(newRoot, finalOps, newZ, nil)
+			if err != nil {
+				db.writeMu.Unlock()
+				cleanupNewPager()
+				return err
+			}
+			freeRetired(retired)
+			if err := checkGrowth(); err != nil {
+				db.writeMu.Unlock()
+				cleanupNewPager()
+				return err
+			}
+		}
+
+		// Snapshot current roots/meta while writers are paused.
+		db.mu.RLock()
+		oldGen := db.idx.Load()
+		state := db.state.Load()
+		baseMeta := db.meta
+		db.mu.RUnlock()
+		if oldGen == nil || state == nil {
+			db.writeMu.Unlock()
+			cleanupNewPager()
+			return errors.New("vacuum: missing db state")
+		}
+
+		sysIter := tree.New(oldGen.pager, valueReader{vlogs: state.ValueLogSet}, state.SystemRootPageID).Iterator(nil, nil)
+		newSysRoot, err := bulk.BuildWithOptions(sysIter, newAlloc, newPager, bulk.BuildOptions{
+			LeafPrefixCompression: db.leafPrefixCompression,
+			LeafColumnar:          db.indexColumnarLeaves,
+			InternalBaseDelta:     db.indexInternalBaseDelta,
+		})
+		_ = sysIter.Close()
+		if err != nil {
+			db.writeMu.Unlock()
+			cleanupNewPager()
+			return err
+		}
+		if err := checkGrowth(); err != nil {
+			db.writeMu.Unlock()
+			cleanupNewPager()
+			return err
+		}
+
+		// Prepare new meta.
+		nextMeta := baseMeta
+		nextMeta.CommitSeq++
+		nextMeta.UserRootPageID = newRoot
+		nextMeta.SystemRootPageID = newSysRoot
+		nextMeta.FreelistHeadID = newAlloc.Head()
+		nextMeta.TotalPages = newPager.PageCount()
+
+		// Write redundant Meta pages (0/1) to the new file and sync it.
+		if err := writeMetaToPager(newPager, MetaPage0ID, nextMeta); err != nil {
+			db.writeMu.Unlock()
+			cleanupNewPager()
+			return err
+		}
+		if err := writeMetaToPager(newPager, MetaPage1ID, nextMeta); err != nil {
+			db.writeMu.Unlock()
+			cleanupNewPager()
+			return err
+		}
+		if err := newPager.Sync(); err != nil {
+			db.writeMu.Unlock()
+			cleanupNewPager()
+			return err
+		}
+
+		if err := os.WriteFile(readyPath, []byte("ready\n"), 0o644); err != nil {
+			db.writeMu.Unlock()
+			cleanupNewPager()
+			return err
+		}
+		if runtime.GOOS != "windows" {
+			if dir, err := os.Open(db.dir); err == nil {
+				_ = dir.Sync()
+				_ = dir.Close()
+			}
+		}
+
+		// Swap index.db -> index.db.bak, index.db.new -> index.db.
+		_ = os.Remove(bakPath)
+		if err := os.Rename(indexPath, bakPath); err != nil {
+			db.writeMu.Unlock()
+			cleanupNewPager()
+			return err
+		}
+		if err := os.Rename(newPath, indexPath); err != nil {
+			_ = os.Rename(bakPath, indexPath)
+			db.writeMu.Unlock()
+			cleanupNewPager()
+			return err
+		}
+
+		_ = os.Remove(readyPath)
+		_ = os.Remove(bakPath)
+		if runtime.GOOS != "windows" {
+			if dir, err := os.Open(db.dir); err == nil {
+				_ = dir.Sync()
+				_ = dir.Close()
+			}
+		}
+
+		// Publish the new index generation (old readers keep oldGen pinned).
+		newGen := newIndexGen(db.nextIndexID(), newPager, newAlloc, newZ)
+		db.trackIndex(newGen)
+
+		var oldState *DBState
+		db.mu.Lock()
+		oldState = db.state.Load()
+		db.idx.Store(newGen)
+		db.meta = nextMeta
+		db.metaPageID = MetaPage0ID
+		db.state.Store(&DBState{
+			CommitSeq:        nextMeta.CommitSeq,
+			RootPageID:       nextMeta.UserRootPageID,
+			SystemRootPageID: nextMeta.SystemRootPageID,
+			ValueLogSet:      db.valueLogManager.CurrentSet(),
+		})
+		db.mu.Unlock()
+
+		db.writeMu.Unlock()
+
+		if oldState != nil {
+			_ = db.valueLogManager.Release(oldState.ValueLogSet)
+		}
+
+		// Drop the DB-held reference to the previous generation outside the
+		// writer pause; closing the old mmap can be expensive.
+		db.releaseIndex(oldGen)
+
+		return nil
+	}
+}
+
+func (db *DB) applyVacuumDelta(root uint64, opsMap map[string]batch.Entry, z *zipper.Zipper, retired []uint64) (uint64, []uint64, error) {
+	if len(opsMap) == 0 {
+		return root, retired, nil
+	}
+
+	keys := make([]string, 0, len(opsMap))
+	for k := range opsMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	ops := make([]batch.Entry, 0, vacuumDeltaBatchSize)
+	applyOps := func() error {
+		if len(ops) == 0 {
+			return nil
+		}
+		b := batch.New(db.valueLogManager, vacuumInlineThresholdMax)
+		defer func() { _ = b.Close() }()
+		if err := b.SetOps(ops); err != nil {
+			return err
+		}
+		newRoot, newRetired, _, err := z.Apply(root, b)
+		if err != nil {
+			return err
+		}
+		root = newRoot
+		if len(newRetired) > 0 {
+			retired = append(retired, newRetired...)
+		}
+		ops = ops[:0]
+		return nil
+	}
+
+	for _, key := range keys {
+		entry := opsMap[key]
+		if len(entry.Key) == 0 {
+			entry.Key = []byte(key)
+		}
+		ops = append(ops, entry)
+
+		if len(ops) >= vacuumDeltaBatchSize {
+			if err := applyOps(); err != nil {
+				return 0, nil, err
+			}
+		}
+	}
+
+	if err := applyOps(); err != nil {
+		return 0, nil, err
+	}
+
+	return root, retired, nil
+}

--- a/TreeDB/db/vacuum_online_swap_test.go
+++ b/TreeDB/db/vacuum_online_swap_test.go
@@ -1,0 +1,228 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestVacuumIndexOnline_ShrinksAndPreservesData(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	dir := t.TempDir()
+	chunkSize := int64(64 * 1024)
+
+	d, err := Open(Options{
+		Dir:               dir,
+		ChunkSize:         chunkSize,
+		KeepRecent:        1,
+		PreferAppendAlloc: true, // intentionally bloat index.db under churn
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	value := bytes.Repeat([]byte("v"), 200) // inline-ish to force page pressure
+	for round := 0; round < 6; round++ {
+		b := d.NewBatch()
+		for i := 0; i < 4000; i++ {
+			k := []byte(fmt.Sprintf("k%06d", i))
+			if err := b.Set(k, value); err != nil {
+				t.Fatalf("set: %v", err)
+			}
+		}
+		if err := b.Write(); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_ = b.Close()
+	}
+
+	indexPath := filepath.Join(dir, indexFileName)
+	beforeInfo, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := d.VacuumIndexOnline(ctx); err != nil {
+		t.Fatalf("vacuum: %v", err)
+	}
+
+	afterInfo, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if afterInfo.Size() >= beforeInfo.Size() {
+		t.Fatalf("expected vacuum to shrink index.db: before=%d after=%d", beforeInfo.Size(), afterInfo.Size())
+	}
+
+	got, err := d.Get([]byte("k000010"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Fatalf("value mismatch")
+	}
+}
+
+func TestVacuumIndexOnline_AllowsSnapshotAcrossSwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	dir := t.TempDir()
+	chunkSize := int64(64 * 1024)
+
+	d, err := Open(Options{
+		Dir:        dir,
+		ChunkSize:  chunkSize,
+		KeepRecent: 1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if err := d.SetSync([]byte("k"), []byte("v1")); err != nil {
+		t.Fatalf("set v1: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+
+	if err := d.SetSync([]byte("k"), []byte("v2")); err != nil {
+		t.Fatalf("set v2: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := d.VacuumIndexOnline(ctx); err != nil {
+		t.Fatalf("vacuum: %v", err)
+	}
+
+	// DB reads see the latest value.
+	got, err := d.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(got) != "v2" {
+		t.Fatalf("expected v2, got %q", got)
+	}
+
+	// Old snapshot remains valid and sees the older value.
+	old, err := snap.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("snap get: %v", err)
+	}
+	if string(old) != "v1" {
+		t.Fatalf("expected v1 from snapshot, got %q", old)
+	}
+
+	d.idxMu.Lock()
+	genCount := len(d.idxAll)
+	d.idxMu.Unlock()
+	if genCount < 2 {
+		t.Fatalf("expected at least 2 index generations after vacuum, got %d", genCount)
+	}
+
+	if err := snap.Close(); err != nil {
+		t.Fatalf("snap close: %v", err)
+	}
+
+	d.idxMu.Lock()
+	genCountAfter := len(d.idxAll)
+	d.idxMu.Unlock()
+	if genCountAfter != 1 {
+		t.Fatalf("expected old index generation to be released after snapshot close; gens=%d", genCountAfter)
+	}
+}
+
+func TestVacuumIndexOnline_RepeatWhileSnapshotPinned(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	dir := t.TempDir()
+	chunkSize := int64(64 * 1024)
+
+	d, err := Open(Options{
+		Dir:        dir,
+		ChunkSize:  chunkSize,
+		KeepRecent: 1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if err := d.SetSync([]byte("k"), []byte("v1")); err != nil {
+		t.Fatalf("set v1: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := d.SetSync([]byte("k"), []byte("v2")); err != nil {
+		t.Fatalf("set v2: %v", err)
+	}
+	if err := d.VacuumIndexOnline(ctx); err != nil {
+		t.Fatalf("vacuum 1: %v", err)
+	}
+
+	d.idxMu.Lock()
+	genCount1 := len(d.idxAll)
+	d.idxMu.Unlock()
+	if genCount1 != 2 {
+		t.Fatalf("expected 2 index generations after first vacuum, got %d", genCount1)
+	}
+
+	if err := d.SetSync([]byte("k"), []byte("v3")); err != nil {
+		t.Fatalf("set v3: %v", err)
+	}
+	if err := d.VacuumIndexOnline(ctx); err != nil {
+		t.Fatalf("vacuum 2: %v", err)
+	}
+
+	// DB reads see the latest value.
+	got, err := d.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(got) != "v3" {
+		t.Fatalf("expected v3, got %q", got)
+	}
+
+	// Old snapshot remains valid and sees the older value.
+	old, err := snap.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("snap get: %v", err)
+	}
+	if string(old) != "v1" {
+		t.Fatalf("expected v1 from snapshot, got %q", old)
+	}
+
+	d.idxMu.Lock()
+	genCount2 := len(d.idxAll)
+	d.idxMu.Unlock()
+	if genCount2 < 2 {
+		t.Fatalf("expected at least 2 index generations after second vacuum, got %d", genCount2)
+	}
+
+	if err := snap.Close(); err != nil {
+		t.Fatalf("snap close: %v", err)
+	}
+
+	d.idxMu.Lock()
+	genCountAfter := len(d.idxAll)
+	d.idxMu.Unlock()
+	if genCountAfter != 1 {
+		t.Fatalf("expected old index generations to be released after snapshot close; gens=%d", genCountAfter)
+	}
+}

--- a/TreeDB/db/vacuum_panic_test.go
+++ b/TreeDB/db/vacuum_panic_test.go
@@ -1,0 +1,117 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestVacuumRaceMissingKey simulates a write that commits while online vacuum is
+// in progress. The vacuum recorder must capture the full batch.Entry so vacuum
+// never needs to look up the key in a potentially stale snapshot.
+func TestVacuumRaceMissingKey(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
+	dir, err := os.MkdirTemp("", "vacuum-race")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	opts := Options{
+		Dir:       dir,
+		ChunkSize: 64 * 1024 * 1024,
+	}
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	const initialKeys = 1000
+	b0 := db.NewBatch()
+	for i := 0; i < initialKeys; i++ {
+		k := []byte(fmt.Sprintf("key-%06d", i))
+		v := []byte(fmt.Sprintf("val-%06d", i))
+		if err := b0.Set(k, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := b0.Write(); err != nil {
+		t.Fatal(err)
+	}
+	if err := b0.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 10)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+		if err := db.VacuumIndexOnline(ctx); err != nil {
+			errCh <- fmt.Errorf("vacuum failed: %v", err)
+		}
+	}()
+
+	const newKeysStart = 2000
+	const newKeysCount = 5000
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < newKeysCount; i++ {
+			k := []byte(fmt.Sprintf("key-%06d", newKeysStart+i))
+			v := []byte(fmt.Sprintf("val-%06d", newKeysStart+i))
+
+			b := db.NewBatch()
+			if err := b.Set(k, v); err != nil {
+				errCh <- err
+				return
+			}
+			if err := b.Write(); err != nil {
+				errCh <- err
+				return
+			}
+			_ = b.Close()
+
+			if i%100 == 0 {
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("concurrent op error: %v", err)
+	}
+
+	missing := 0
+	for i := 0; i < newKeysCount; i++ {
+		k := []byte(fmt.Sprintf("key-%06d", newKeysStart+i))
+		val, err := db.Get(k)
+		if err != nil {
+			missing++
+			continue
+		}
+		expected := fmt.Sprintf("val-%06d", newKeysStart+i)
+		if string(val) != expected {
+			t.Errorf("corrupt value for %s: got %q, want %q", k, val, expected)
+		}
+	}
+
+	if missing > 0 {
+		t.Fatalf("consistency failure: %d/%d concurrent keys are missing after vacuum", missing, newKeysCount)
+	}
+}

--- a/TreeDB/db/vacuum_recorder_test.go
+++ b/TreeDB/db/vacuum_recorder_test.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+func TestVacuumRecorder_DoesNotRecordUncommittedWrites(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() {
+		_ = d.Close()
+	}()
+
+	d.vacuum.Start()
+	defer d.vacuum.Stop()
+
+	// Block root reads/commit so a batch write can't complete. If the vacuum
+	// recorder captures keys before commit, it can be drained while the write is
+	// still in-flight, causing online vacuum to miss the eventual update.
+	d.mu.Lock()
+
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		b := d.NewBatch()
+		_ = b.Set([]byte("k"), []byte("v"))
+		done <- b.Write()
+		_ = b.Close()
+	}()
+
+	<-started
+
+	// Give the write goroutine time to start and (if buggy) record its keys, but
+	// ensure the recorder stays empty while the write is blocked.
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if keys := d.vacuum.Drain(); len(keys) > 0 {
+			t.Fatalf("vacuum recorded keys before commit: %v", keys)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	d.mu.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for write to complete")
+	}
+
+	keys := d.vacuum.Drain()
+	if _, ok := keys["k"]; !ok {
+		t.Fatalf("expected committed key to be recorded, got: %v", keys)
+	}
+}

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -720,27 +720,36 @@ func (db *DB) CompactIndex() error {
 	return db.backend.CompactIndex()
 }
 
-// VacuumIndexOnline rebuilds the user index in-place. It is currently an alias
-// for CompactIndex and does not perform a separate file swap.
+// VacuumIndexOnline rebuilds the user index into a new file and swaps it in with
+// a short writer pause. Disk space from the old index is reclaimed once any old
+// snapshots/iterators drain.
 func (db *DB) VacuumIndexOnline(ctx context.Context) error {
-	if ctx != nil {
-		if err := ctx.Err(); err != nil {
+	if err := db.ensureOpen(); err != nil {
+		return err
+	}
+	if db.backend == nil {
+		return ErrClosed
+	}
+
+	// In cached mode, ensure the backend reflects all buffered writes before
+	// rebuilding/switching the index file. This avoids exposing a backend state
+	// that temporarily "forgets" keys that only existed in memtables/WAL, which
+	// can break higher layers that assume a stable durable boundary.
+	if db.cached != nil {
+		if err := db.cached.Checkpoint(); err != nil {
 			return err
 		}
 	}
-	return db.CompactIndex()
+
+	return db.backend.VacuumIndexOnline(ctx)
 }
 
 // VacuumIndexOffline rewrites `index.db` into a fresh file and swaps it in.
 // This is intended to reclaim space and restore locality after long churn.
-// It currently opens the DB and runs CompactIndex in-place.
+//
+// It is an offline operation: it acquires the exclusive open lock for opts.Dir.
 func VacuumIndexOffline(opts Options) error {
-	d, err := Open(opts)
-	if err != nil {
-		return err
-	}
-	defer d.Close()
-	return d.CompactIndex()
+	return db.VacuumIndexOffline(opts)
 }
 
 // FragmentationReport returns best-effort structural stats about the on-disk user


### PR DESCRIPTION
Restores swap-based index vacuum semantics (online/offline) for the WAL-on/off-only backend.

What changed
- Reintroduced backend online/offline vacuum with index swap (`TreeDB/db/vacuum_online.go`, `TreeDB/db/vacuum_offline.go`).
- Restored vacuum recorder tracking to capture committed ops during online vacuum.
- Wired public API to call backend vacuum instead of aliasing `CompactIndex`.
- Treemap CLI now distinguishes:
  - `compact`: in-place rebuild
  - `vacuum`: swap-based offline vacuum (shrinks `index.db`).
- Added vacuum tests (offline shrink, online swap/snapshot, recorder race, concurrent write safety).

How to test
- `GOWORK=off go test ./TreeDB/... -count=1`

Notes
- Online vacuum is still unsupported on Windows (same as before).
- Vacuum is index-only; value-log semantics unchanged.
