### PR TITLE
treemap: add vlog-gc for value-log cleanup

### DIFF
--- a/.pr/PR_vlog_gc.md
+++ b/.pr/PR_vlog_gc.md
@@ -1,0 +1,14 @@
+Adds a safe `vlog-gc` command to delete fully-unreferenced value-log segments.
+
+What changed
+- Backend `ValueLogGC` implementation scans user + system trees for value-log pointers and marks unreferenced segments as zombie.
+- Public `(*DB).ValueLogGC` wrapper (checkpoints cached mode first).
+- Treemap CLI adds `vlog-gc -rw [-dry-run]` with summary output.
+- New integration test verifies an unreferenced segment is removed.
+
+How to test
+- `GOWORK=off go test ./TreeDB/... -count=1`
+- `treemap vlog-gc <db-dir> -rw -dry-run`
+
+Notes
+- GC is conservative: it never removes the newest segment per lane, and pinned segments are retained until snapshots drain.

--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -30,6 +31,7 @@ Commands:
   verify          Full scan verification (counts items)
   compact         Compact/rebuild the index.db in-place (requires -rw)
   vacuum          Rebuild index.db via swap (shrinks file; requires -rw)
+  vlog-gc         Delete unreferenced value-log segments (requires -rw)
   get             Get a single key
   keys            List keys in a range/prefix
   scan            Scan keys and values in a range/prefix (requires -allow-values)
@@ -76,6 +78,8 @@ func main() {
 		runCompact(dir, args)
 	case "vacuum":
 		runVacuum(dir, args)
+	case "vlog-gc":
+		runVlogGC(dir, args)
 	case "get":
 		runGet(dir, args)
 	case "keys":
@@ -208,6 +212,43 @@ func runVacuum(dir string, args []string) {
 		fatalf("VacuumIndexOffline error: %v", err)
 	}
 	fmt.Println("Index vacuum complete.")
+}
+
+func runVlogGC(dir string, args []string) {
+	fs := flag.NewFlagSet("vlog-gc", flag.ExitOnError)
+	rw := fs.Bool("rw", false, "Open read-write (required; may replay WAL or repair files)")
+	dryRun := fs.Bool("dry-run", false, "Report deletions without removing segments")
+	_ = fs.Parse(args)
+
+	if !*rw {
+		fatalf("vlog-gc requires -rw")
+	}
+
+	db := openTreeDB(dir, true)
+	defer closeTreeDB(db)
+
+	stats, err := db.ValueLogGC(context.Background(), treedb.ValueLogGCOptions{DryRun: *dryRun})
+	if err != nil {
+		fatalf("ValueLogGC error: %v", err)
+	}
+
+	mode := "applied"
+	if *dryRun {
+		mode = "dry-run"
+	}
+	fmt.Printf("vlog-gc (%s): segments total=%d referenced=%d active=%d eligible=%d deleted=%d bytes_total=%d bytes_referenced=%d bytes_active=%d bytes_eligible=%d bytes_deleted=%d\n",
+		mode,
+		stats.SegmentsTotal,
+		stats.SegmentsReferenced,
+		stats.SegmentsActive,
+		stats.SegmentsEligible,
+		stats.SegmentsDeleted,
+		stats.BytesTotal,
+		stats.BytesReferenced,
+		stats.BytesActive,
+		stats.BytesEligible,
+		stats.BytesDeleted,
+	)
 }
 
 func runGet(dir string, args []string) {

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -1,0 +1,202 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/tree"
+)
+
+// ValueLogGCOptions controls value-log garbage collection.
+type ValueLogGCOptions struct {
+	DryRun bool
+}
+
+// ValueLogGCStats summarizes value-log GC work.
+type ValueLogGCStats struct {
+	SegmentsTotal      int
+	SegmentsReferenced int
+	SegmentsActive     int
+	SegmentsEligible   int
+	SegmentsDeleted    int
+	BytesTotal         int64
+	BytesReferenced    int64
+	BytesActive        int64
+	BytesEligible      int64
+	BytesDeleted       int64
+}
+
+// ValueLogGC deletes fully-unreferenced value-log segments.
+//
+// It scans the user + system trees for value-log pointers, computes referenced
+// segments, and removes segments that are:
+//   - not referenced,
+//   - not the currently-active segment per lane,
+//   - and not pinned by active snapshots.
+func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogGCStats, error) {
+	var stats ValueLogGCStats
+	if db == nil {
+		return stats, fmt.Errorf("missing db")
+	}
+	if db.readOnly {
+		return stats, ErrReadOnly
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if db.valueLogManager == nil {
+		return stats, fmt.Errorf("value log manager unavailable")
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil || snap.idx == nil || snap.state == nil {
+		if snap != nil {
+			_ = snap.Close()
+		}
+		return stats, fmt.Errorf("missing db state")
+	}
+
+	referenced := make(map[uint32]struct{})
+
+	userIter := snap.tree.Iterator(nil, nil)
+	if err := collectValueLogRefs(userIter, referenced); err != nil {
+		_ = userIter.Close()
+		return stats, err
+	}
+	_ = userIter.Close()
+
+	sysIter := tree.New(snap.idx.pager, valueReader{vlogs: snap.state.ValueLogSet}, snap.state.SystemRootPageID).Iterator(nil, nil)
+	if err := collectValueLogRefs(sysIter, referenced); err != nil {
+		_ = sysIter.Close()
+		return stats, err
+	}
+	_ = sysIter.Close()
+
+	if err := snap.Close(); err != nil {
+		return stats, err
+	}
+
+	set := db.valueLogManager.CurrentSet()
+	activeIDs := currentValueLogIDs(set)
+	type candidate struct {
+		path string
+		size int64
+	}
+	candidates := make(map[uint32]candidate)
+
+	for id, f := range set.Files {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		size := fileSize(f)
+		stats.SegmentsTotal++
+		stats.BytesTotal += size
+
+		if _, ok := referenced[id]; ok {
+			stats.SegmentsReferenced++
+			stats.BytesReferenced += size
+			continue
+		}
+		if _, ok := activeIDs[id]; ok {
+			stats.SegmentsActive++
+			stats.BytesActive += size
+			continue
+		}
+
+		stats.SegmentsEligible++
+		stats.BytesEligible += size
+
+		if opts.DryRun {
+			continue
+		}
+		if err := db.valueLogManager.MarkZombie(id); err != nil {
+			return stats, err
+		}
+		candidates[id] = candidate{path: f.Path, size: size}
+	}
+
+	if opts.DryRun {
+		if set != nil {
+			_ = db.valueLogManager.Release(set)
+		}
+		return stats, nil
+	}
+
+	if set != nil {
+		_ = db.valueLogManager.Release(set)
+	}
+
+	if err := db.RefreshValueLogSet(); err != nil {
+		return stats, err
+	}
+
+	for _, info := range candidates {
+		if info.path == "" {
+			continue
+		}
+		if _, err := os.Stat(info.path); err != nil {
+			if os.IsNotExist(err) {
+				stats.SegmentsDeleted++
+				stats.BytesDeleted += info.size
+			} else {
+				return stats, err
+			}
+		}
+	}
+
+	return stats, nil
+}
+
+func collectValueLogRefs(it iterator.UnsafeIterator, refs map[uint32]struct{}) error {
+	for it.Valid() {
+		_, ptr, flags := it.UnsafeEntry()
+		if flags&node.FlagPointer != 0 && page.IsValueLogFileID(ptr.FileID) {
+			refs[ptr.FileID] = struct{}{}
+		}
+		it.Next()
+	}
+	return it.Error()
+}
+
+func currentValueLogIDs(set *valuelog.Set) map[uint32]struct{} {
+	active := make(map[uint32]struct{})
+	if set == nil || len(set.Files) == 0 {
+		return active
+	}
+	maxByLane := make(map[uint32]uint32)
+	for id := range set.Files {
+		lane, seq := valuelog.DecodeFileID(id)
+		if cur, ok := maxByLane[lane]; !ok || seq > cur {
+			maxByLane[lane] = seq
+		}
+	}
+	for id := range set.Files {
+		lane, seq := valuelog.DecodeFileID(id)
+		if maxByLane[lane] == seq {
+			active[id] = struct{}{}
+		}
+	}
+	return active
+}
+
+func fileSize(f *valuelog.File) int64 {
+	if f == nil {
+		return 0
+	}
+	if f.File != nil {
+		if info, err := f.File.Stat(); err == nil {
+			return info.Size()
+		}
+	}
+	if f.Path != "" {
+		if info, err := os.Stat(f.Path); err == nil {
+			return info.Size()
+		}
+	}
+	return 0
+}

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -1,0 +1,97 @@
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestValueLogGC_RemovesUnreferencedSegment(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	walDir := filepath.Join(dir, "wal")
+	if err := os.MkdirAll(walDir, 0o755); err != nil {
+		t.Fatalf("mkdir wal: %v", err)
+	}
+
+	path1 := filepath.Join(walDir, "value-l0-000001.log")
+	id1, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("fileid1: %v", err)
+	}
+	w1, err := valuelog.NewWriter(path1, id1)
+	if err != nil {
+		t.Fatalf("writer1: %v", err)
+	}
+	ptr1, err := w1.Append(0, nil, 1, []byte("value-1"))
+	if err != nil {
+		t.Fatalf("append1: %v", err)
+	}
+	if err := w1.Close(); err != nil {
+		t.Fatalf("close1: %v", err)
+	}
+
+	path2 := filepath.Join(walDir, "value-l0-000002.log")
+	id2, err := valuelog.EncodeFileID(0, 2)
+	if err != nil {
+		t.Fatalf("fileid2: %v", err)
+	}
+	w2, err := valuelog.NewWriter(path2, id2)
+	if err != nil {
+		t.Fatalf("writer2: %v", err)
+	}
+	ptr2, err := w2.Append(0, nil, 2, []byte("value-2"))
+	if err != nil {
+		t.Fatalf("append2: %v", err)
+	}
+	if err := w2.Close(); err != nil {
+		t.Fatalf("close2: %v", err)
+	}
+
+	b := db.NewBatch()
+	ptrBatch, ok := b.(interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+	})
+	if !ok {
+		t.Fatalf("missing SetPointer on batch")
+	}
+	if err := ptrBatch.SetPointer([]byte("k1"), ptr1); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := ptrBatch.SetPointer([]byte("k2"), ptr2); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = b.Close()
+
+	if err := db.Delete([]byte("k1")); err != nil {
+		t.Fatalf("delete k1: %v", err)
+	}
+
+	stats, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if stats.SegmentsDeleted == 0 {
+		t.Fatalf("expected at least one segment deleted, got %+v", stats)
+	}
+
+	if _, err := os.Stat(path1); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected segment1 to be removed, err=%v", err)
+	}
+	if _, err := os.Stat(path2); err != nil {
+		t.Fatalf("expected segment2 to remain, err=%v", err)
+	}
+}

--- a/TreeDB/vlog_gc.go
+++ b/TreeDB/vlog_gc.go
@@ -1,0 +1,52 @@
+package treedb
+
+import (
+	"context"
+
+	treedbdb "github.com/snissn/gomap/TreeDB/db"
+)
+
+// ValueLogGCOptions controls value-log garbage collection.
+type ValueLogGCOptions struct {
+	DryRun bool
+}
+
+// ValueLogGCStats summarizes value-log GC work.
+type ValueLogGCStats struct {
+	SegmentsTotal      int
+	SegmentsReferenced int
+	SegmentsActive     int
+	SegmentsEligible   int
+	SegmentsDeleted    int
+	BytesTotal         int64
+	BytesReferenced    int64
+	BytesActive        int64
+	BytesEligible      int64
+	BytesDeleted       int64
+}
+
+// ValueLogGC deletes fully-unreferenced value-log segments.
+//
+// In cached mode, this first checkpoints to ensure memtable/WAL state is fully
+// reflected in the backend before scanning pointers.
+func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogGCStats, error) {
+	var out ValueLogGCStats
+	if err := db.ensureOpen(); err != nil {
+		return out, err
+	}
+	if db.backend == nil {
+		return out, ErrClosed
+	}
+	if db.cached != nil {
+		if err := db.cached.Checkpoint(); err != nil {
+			return out, err
+		}
+	}
+
+	stats, err := db.backend.ValueLogGC(ctx, treedbdb.ValueLogGCOptions{DryRun: opts.DryRun})
+	if err != nil {
+		return out, err
+	}
+	out = ValueLogGCStats(stats)
+	return out, nil
+}


### PR DESCRIPTION
Adds a safe `vlog-gc` command to delete fully-unreferenced value-log segments.

What changed
- Backend `ValueLogGC` implementation scans user + system trees for value-log pointers and marks unreferenced segments as zombie.
- Public `(*DB).ValueLogGC` wrapper (checkpoints cached mode first).
- Treemap CLI adds `vlog-gc -rw [-dry-run]` with summary output.
- New integration test verifies an unreferenced segment is removed.

How to test
- `GOWORK=off go test ./TreeDB/... -count=1`
- `treemap vlog-gc <db-dir> -rw -dry-run`

Notes
- GC is conservative: it never removes the newest segment per lane, and pinned segments are retained until snapshots drain.
