### PR TITLE
TreeDB/caching: avoid persisting value-log pointers in journal mode

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3861,11 +3861,19 @@ func (db *DB) set(key, value []byte, sync bool) error {
 
 	shard.mu.Lock()
 	if usePointer {
-		memVal := []byte(nil)
-		if !db.memtableValueLogPointers {
-			memVal = value
+		// Journal mode: values may be written to the value-log so the WAL can store
+		// RID records instead of large inline payloads, but the backend must not
+		// persist pointers into the ephemeral WAL/value-log directory. Persist the
+		// value bytes via the normal backend flush path.
+		if !db.disableJournal && !db.memtableValueLogPointers {
+			shard.mem.SetEntry(key, value, page.ValuePtr{}, node.FlagInline)
+		} else {
+			memVal := []byte(nil)
+			if !db.memtableValueLogPointers {
+				memVal = value
+			}
+			shard.mem.SetEntry(key, memVal, ptr, node.FlagPointer)
 		}
-		shard.mem.SetEntry(key, memVal, ptr, node.FlagPointer)
 	} else {
 		shard.mem.SetEntry(key, value, page.ValuePtr{}, node.FlagInline)
 	}
@@ -5089,6 +5097,25 @@ func (db *DB) flushCombinedLocked(sync bool) bool {
 					} else {
 						key := iter.UnsafeKey()
 						if flags&node.FlagPointer != 0 {
+							if !db.disableJournal && page.IsValueLogFileID(ptr.FileID) {
+								if val == nil {
+									if db.valueLogReader == nil {
+										_ = iter.Close()
+										putEntrySlice(ops)
+										return nil, fmt.Errorf("cachingdb: flush missing value-log bytes for key")
+									}
+									readVal, err := db.readValueLog(ptr)
+									if err != nil {
+										_ = iter.Close()
+										putEntrySlice(ops)
+										return nil, err
+									}
+									val = readVal
+								}
+								ops = append(ops, batch.Entry{Type: batch.OpPut, Key: key, Value: val})
+								iter.Next()
+								continue
+							}
 							ops = append(ops, batch.Entry{
 								Type:     batch.OpPut,
 								Key:      key,
@@ -5218,26 +5245,52 @@ func (db *DB) flushCombinedLocked(sync bool) bool {
 					SetPointer(key []byte, ptr page.ValuePtr) error
 				})
 			}
-			for _, unit := range units {
-				iter := unit.mem.NewIterator(nil, nil) // Returns iterator.UnsafeIterator
-				for iter.Valid() {
-					key := iter.UnsafeKey()
-					val, ptr, flags := iter.UnsafeEntry()
-					if flags&node.FlagTombstone != 0 {
-						if err := backendBatch.Delete(key); err != nil {
-							db.reportError(fmt.Errorf("cachingdb: flush failed (delete): %w", err))
-							_ = iter.Close()
-							_ = backendBatch.Close()
-							return false
-						}
-					} else {
-						if flags&node.FlagPointer != 0 {
-							if ptrSetter != nil {
-								if err := ptrSetter.SetPointer(key, ptr); err != nil {
-									db.reportError(fmt.Errorf("cachingdb: flush failed (set ptr): %w", err))
-									_ = iter.Close()
-									_ = backendBatch.Close()
-									return false
+				for _, unit := range units {
+					iter := unit.mem.NewIterator(nil, nil) // Returns iterator.UnsafeIterator
+					for iter.Valid() {
+						key := iter.UnsafeKey()
+						val, ptr, flags := iter.UnsafeEntry()
+						if flags&node.FlagTombstone != 0 {
+							if err := backendBatch.Delete(key); err != nil {
+								db.reportError(fmt.Errorf("cachingdb: flush failed (delete): %w", err))
+								_ = iter.Close()
+								_ = backendBatch.Close()
+								return false
+							}
+						} else {
+							if flags&node.FlagPointer != 0 {
+								if !db.disableJournal && page.IsValueLogFileID(ptr.FileID) {
+									if val == nil {
+										if db.valueLogReader == nil {
+											db.reportError(fmt.Errorf("cachingdb: flush failed (missing value-log bytes for key)"))
+											_ = iter.Close()
+											_ = backendBatch.Close()
+											return false
+										}
+										readVal, err := db.readValueLog(ptr)
+										if err != nil {
+											db.reportError(fmt.Errorf("cachingdb: flush failed (read value-log): %w", err))
+											_ = iter.Close()
+											_ = backendBatch.Close()
+											return false
+										}
+										val = readVal
+									}
+									if err := backendBatch.Set(key, val); err != nil {
+										db.reportError(fmt.Errorf("cachingdb: flush failed (set): %w", err))
+										_ = iter.Close()
+										_ = backendBatch.Close()
+										return false
+									}
+									iter.Next()
+									continue
+								}
+								if ptrSetter != nil {
+									if err := ptrSetter.SetPointer(key, ptr); err != nil {
+										db.reportError(fmt.Errorf("cachingdb: flush failed (set ptr): %w", err))
+										_ = iter.Close()
+										_ = backendBatch.Close()
+										return false
 								}
 							} else if err := backendBatch.SetOps([]batch.Entry{{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true}}); err != nil {
 								db.reportError(fmt.Errorf("cachingdb: flush failed (setops ptr): %w", err))
@@ -5471,6 +5524,27 @@ func (db *DB) flushOneLocked(sync bool) bool {
 				} else {
 					key := iter.UnsafeKey()
 					if flags&node.FlagPointer != 0 {
+						if !db.disableJournal && page.IsValueLogFileID(ptr.FileID) {
+							if val == nil {
+								if db.valueLogReader == nil {
+									db.reportError(fmt.Errorf("cachingdb: flush failed (missing value-log bytes for key)"))
+									_ = iter.Close()
+									_ = backendBatch.Close()
+									return false
+								}
+								readVal, err := db.readValueLog(ptr)
+								if err != nil {
+									db.reportError(fmt.Errorf("cachingdb: flush failed (read value-log): %w", err))
+									_ = iter.Close()
+									_ = backendBatch.Close()
+									return false
+								}
+								val = readVal
+							}
+							ops = append(ops, batch.Entry{Type: batch.OpPut, Key: key, Value: val})
+							iter.Next()
+							continue
+						}
 						ops = append(ops, batch.Entry{
 							Type:     batch.OpPut,
 							Key:      key,
@@ -5517,6 +5591,32 @@ func (db *DB) flushOneLocked(sync bool) bool {
 					key := iter.UnsafeKey()
 					val, ptr, flags := iter.UnsafeEntry()
 					if flags&node.FlagPointer != 0 {
+						if !db.disableJournal && page.IsValueLogFileID(ptr.FileID) {
+							if val == nil {
+								if db.valueLogReader == nil {
+									db.reportError(fmt.Errorf("cachingdb: flush failed (missing value-log bytes for key)"))
+									_ = iter.Close()
+									_ = backendBatch.Close()
+									return false
+								}
+								readVal, err := db.readValueLog(ptr)
+								if err != nil {
+									db.reportError(fmt.Errorf("cachingdb: flush failed (read value-log): %w", err))
+									_ = iter.Close()
+									_ = backendBatch.Close()
+									return false
+								}
+								val = readVal
+							}
+							if err := backendBatch.Set(key, val); err != nil {
+								db.reportError(fmt.Errorf("cachingdb: flush failed (set): %w", err))
+								_ = iter.Close()
+								_ = backendBatch.Close()
+								return false
+							}
+							iter.Next()
+							continue
+						}
 						if ptrSetter != nil {
 							if err := ptrSetter.SetPointer(key, ptr); err != nil {
 								db.reportError(fmt.Errorf("cachingdb: flush failed (set ptr): %w", err))
@@ -6996,6 +7096,11 @@ func (b *Batch) writeRegular(sync bool) error {
 				op.IsPtr = true
 				if b.db.memtableValueLogPointers {
 					op.Value = nil
+				} else if !b.db.disableJournal {
+					// Journal mode: do not keep value-log pointers in the in-memory
+					// layers/backends. Use the value-log only to keep the WAL small.
+					op.IsPtr = false
+					op.ValuePtr = page.ValuePtr{}
 				}
 				if debugPtr {
 					b.db.debugPtrUsed.Add(1)

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -793,7 +793,7 @@ func TestCachingDB_SetDoesNotBlockOnWriteMuRLock(t *testing.T) {
 	}
 }
 
-func TestCachingDB_FlushUsesValueLogPointer(t *testing.T) {
+func TestCachingDB_FlushDoesNotPersistValueLogPointerInJournalMode(t *testing.T) {
 	dir := t.TempDir()
 	backend, err := db.Open(db.Options{Dir: dir, ChunkSize: 64 * 1024})
 	if err != nil {
@@ -831,9 +831,9 @@ func TestCachingDB_FlushUsesValueLogPointer(t *testing.T) {
 		_ = snap.Close()
 		t.Fatalf("expected pointer flag for large value")
 	}
-	if !page.IsValueLogFileID(entry.ValuePtr.FileID) {
+	if page.IsValueLogFileID(entry.ValuePtr.FileID) {
 		_ = snap.Close()
-		t.Fatalf("expected backend to store value-log pointer, got %#x", entry.ValuePtr.FileID)
+		t.Fatalf("expected backend to NOT store value-log pointer in journal mode, got %#x", entry.ValuePtr.FileID)
 	}
 	_ = snap.Close()
 

--- a/TreeDB/caching/journal_vlog_safety_test.go
+++ b/TreeDB/caching/journal_vlog_safety_test.go
@@ -1,0 +1,76 @@
+package caching
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestCachingDB_JournalModeDoesNotDependOnValueLogFilesAfterCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+
+	backend, err := db.Open(db.Options{Dir: dir, ChunkSize: 64 * 1024})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+
+	cache, err := Open(dir, backend, Options{
+		FlushThreshold:           1,
+		ValueLogPointerThreshold: 1,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("cache open: %v", err)
+	}
+
+	key := []byte("k1")
+	val := bytes.Repeat([]byte("v"), page.DefaultInlineThreshold+64)
+	if err := cache.SetSync(key, val); err != nil {
+		_ = cache.Close()
+		t.Fatalf("SetSync: %v", err)
+	}
+	if err := cache.Checkpoint(); err != nil {
+		_ = cache.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := cache.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	walDir := filepath.Join(dir, "wal")
+	entries, err := os.ReadDir(walDir)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadDir(wal): %v", err)
+	}
+	for _, ent := range entries {
+		if ent.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(ent.Name(), ".log") {
+			continue
+		}
+		if err := os.Remove(filepath.Join(walDir, ent.Name())); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("remove wal file %s: %v", ent.Name(), err)
+		}
+	}
+
+	backend2, err := db.Open(db.Options{Dir: dir, ChunkSize: 64 * 1024})
+	if err != nil {
+		t.Fatalf("backend reopen: %v", err)
+	}
+	defer backend2.Close()
+
+	got, err := backend2.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, val) {
+		t.Fatalf("Get mismatch after deleting wal logs")
+	}
+}
+


### PR DESCRIPTION
Fixes iavl-bench treedb mode3 (journal-on) corruption where node reads could return empty bytes (IAVL decode failure) when the backend persisted pointers into the wal/value-log directory.

Changes:
- In journal mode (DisableJournal=false) large values may still be written to the value-log so the WAL can store RID records, but the in-memory layers/flush path no longer persist value-log pointers into the backend.
- Flush now dereferences value-log pointers in journal mode when needed.
- Adds regression test `TestCachingDB_JournalModeDoesNotDependOnValueLogFilesAfterCheckpoint` and updates the existing flush pointer expectation test.

Repro (iavl-bench):
- `DATASET=dev REGEN=1 GEN_VERSIONS=50 GEN_SCALE=20 INCLUDE_MODE3=1 TARGET_VERSION=3 ./scripts/run_matrix.sh` (previously failed at v2).
