### PR TITLE
TreeDB: optional immutable bloom filters (experiment)

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1233,6 +1233,14 @@ type Options struct {
 	// parallelism.
 	FlushBuildConcurrency int
 
+	// ImmutableBloomFilter enables a per-immutable Bloom filter used as a
+	// read-side fast-path to skip checking immutables that cannot contain the
+	// key. This primarily reduces point-read overhead when there is significant
+	// flush debt (deep immutable queue) with MemtableShards > 1.
+	//
+	// Trade-off: building filters adds work during rotation.
+	ImmutableBloomFilter bool
+
 	// DisableWAL disables the redo/journal log while keeping the value log enabled.
 	DisableWAL bool
 	// JournalLanes controls the number of active commit/value log lanes (0=default).
@@ -1312,6 +1320,7 @@ type DB struct {
 	rotatePending    atomic.Bool
 	queue            []memtable.Table
 	queueShardIDs    []uint16
+	immutableBloom   bool
 
 	// memtables is an RCU-style snapshot of (mutable, queue, queueRanges).
 	// Readers load it atomically to avoid holding db.mu around memtable access.
@@ -1970,6 +1979,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		mutableShards:                  mutableShards,
 		mutableShardMask:               uint64(shardCount - 1),
 		hashSortedIndexer:              indexer,
+		immutableBloom:                 opts.ImmutableBloomFilter,
 		closeCh:                        make(chan struct{}),
 		flushCh:                        make(chan struct{}, 1),
 		autoCheckpointOnceCh:           make(chan struct{}, 1),
@@ -4748,8 +4758,22 @@ func (db *DB) rotateMutableShardsLocked(newCapacity int, triggerFlush bool) erro
 
 		// Freeze and enqueue the old mutable shard.
 		shard.mem.Freeze()
+		oldImmutable := shard.mem
+		if db.immutableBloom {
+			// HashSorted lookups are relatively expensive under deep flush debt due
+			// to hash/map access and per-immutable overhead. Skiplist-based
+			// memtables already have very fast point lookups, so the filter tends
+			// to be pure overhead there.
+			if _, ok := oldImmutable.(*memtable.HashSorted); ok {
+				withBloom, err := newImmutableBloomMemtable(oldImmutable)
+				if err != nil {
+					return err
+				}
+				oldImmutable = withBloom
+			}
+		}
 		memBytes := shard.mem.Size()
-		db.queue = append(db.queue, shard.mem)
+		db.queue = append(db.queue, oldImmutable)
 		db.queueShardIDs = append(db.queueShardIDs, uint16(i))
 		db.queueBacklogBytes.Add(memBytes)
 		db.queueRanges = append(db.queueRanges, shard.rng)
@@ -5676,6 +5700,7 @@ func (db *DB) flushOneLocked(sync bool) bool {
 }
 
 func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
+	keyHash := hashKey(key)
 	view := db.memtables.Load()
 	var (
 		mutables      []memtable.Table
@@ -5703,7 +5728,10 @@ func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
 
 	// check mutable
 	if len(mutables) > 0 {
-		idx := db.shardIndex(key)
+		idx := 0
+		if len(mutables) > 1 {
+			idx = int(keyHash & db.mutableShardMask)
+		}
 		if idx < len(mutables) && mutables[idx] != nil {
 			val, ptr, flags, found := mutables[idx].GetEntry(key)
 			if found {
@@ -5727,11 +5755,14 @@ func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
 
 	// check queue backwards (newest first)
 	shardIdx := 0
-	if len(mutables) > 0 {
-		shardIdx = db.shardIndex(key)
+	if len(mutables) > 1 {
+		shardIdx = int(keyHash & db.mutableShardMask)
 	}
 	for i := len(queue) - 1; i >= 0; i-- {
 		if len(queueShardIDs) > i && int(queueShardIDs[i]) != shardIdx {
+			continue
+		}
+		if chk, ok := queue[i].(immutableBloomChecker); ok && !chk.MightContainHash(keyHash) {
 			continue
 		}
 		val, ptr, flags, found := queue[i].GetEntry(key)
@@ -5756,6 +5787,7 @@ func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
 }
 
 func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
+	keyHash := hashKey(key)
 	view := db.memtables.Load()
 	var (
 		mutables      []memtable.Table
@@ -5781,7 +5813,10 @@ func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
 
 	// check mutable
 	if len(mutables) > 0 {
-		idx := db.shardIndex(key)
+		idx := 0
+		if len(mutables) > 1 {
+			idx = int(keyHash & db.mutableShardMask)
+		}
 		if idx < len(mutables) && mutables[idx] != nil {
 			val, ptr, flags, found := mutables[idx].GetEntry(key)
 			if found {
@@ -5805,11 +5840,14 @@ func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
 
 	// check queue backwards (newest first)
 	shardIdx := 0
-	if len(mutables) > 0 {
-		shardIdx = db.shardIndex(key)
+	if len(mutables) > 1 {
+		shardIdx = int(keyHash & db.mutableShardMask)
 	}
 	for i := len(queue) - 1; i >= 0; i-- {
 		if len(queueShardIDs) > i && int(queueShardIDs[i]) != shardIdx {
+			continue
+		}
+		if chk, ok := queue[i].(immutableBloomChecker); ok && !chk.MightContainHash(keyHash) {
 			continue
 		}
 		val, ptr, flags, found := queue[i].GetEntry(key)
@@ -5872,6 +5910,7 @@ func (db *DB) GetAppend(key, dst []byte) ([]byte, error) {
 }
 
 func (db *DB) Has(key []byte) (bool, error) {
+	keyHash := hashKey(key)
 	view := db.memtables.Load()
 	var (
 		mutables      []memtable.Table
@@ -5896,7 +5935,10 @@ func (db *DB) Has(key []byte) (bool, error) {
 	}
 
 	if len(mutables) > 0 {
-		idx := db.shardIndex(key)
+		idx := 0
+		if len(mutables) > 1 {
+			idx = int(keyHash & db.mutableShardMask)
+		}
 		if idx < len(mutables) && mutables[idx] != nil {
 			_, deleted, found := mutables[idx].Get(key)
 			if found {
@@ -5906,11 +5948,14 @@ func (db *DB) Has(key []byte) (bool, error) {
 	}
 
 	idx := 0
-	if len(mutables) > 0 {
-		idx = db.shardIndex(key)
+	if len(mutables) > 1 {
+		idx = int(keyHash & db.mutableShardMask)
 	}
 	for i := len(queue) - 1; i >= 0; i-- {
 		if len(queueShardIDs) > i && int(queueShardIDs[i]) != idx {
+			continue
+		}
+		if chk, ok := queue[i].(immutableBloomChecker); ok && !chk.MightContainHash(keyHash) {
 			continue
 		}
 		_, deleted, found := queue[i].Get(key)

--- a/TreeDB/caching/immutable_bloom.go
+++ b/TreeDB/caching/immutable_bloom.go
@@ -1,0 +1,113 @@
+package caching
+
+import (
+	"errors"
+
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+)
+
+type immutableBloomChecker interface {
+	// MightContainHash returns false only if the key is definitely not present in
+	// this immutable memtable. False positives are allowed.
+	MightContainHash(keyHash uint64) bool
+}
+
+type immutableBloomMemtable struct {
+	memtable.Table
+	bloom *bloomFilter
+}
+
+func (m *immutableBloomMemtable) MightContainHash(keyHash uint64) bool {
+	if m == nil || m.bloom == nil {
+		return true
+	}
+	return m.bloom.mightContainHash(keyHash)
+}
+
+func newImmutableBloomMemtable(t memtable.Table) (*immutableBloomMemtable, error) {
+	if t == nil {
+		return nil, errors.New("cachingdb: nil immutable memtable")
+	}
+	n := t.Len()
+	if n <= 0 {
+		return &immutableBloomMemtable{Table: t}, nil
+	}
+
+	bloom := newBloomFilter(n)
+	iter := t.NewIterator(nil, nil)
+	defer func() { _ = iter.Close() }()
+	for iter.Valid() {
+		bloom.addHash(hashKey(iter.UnsafeKey()))
+		iter.Next()
+	}
+	if err := iter.Error(); err != nil {
+		return nil, err
+	}
+	return &immutableBloomMemtable{Table: t, bloom: bloom}, nil
+}
+
+type bloomFilter struct {
+	mask uint64
+	bits []uint64
+}
+
+const (
+	bloomBitsPerKey = 10
+	bloomK          = 4
+	bloomMinBits    = 1 << 10 // 1024 bits
+	bloomMaxBits    = 1 << 28 // 256M bits (~32MiB)
+)
+
+func newBloomFilter(n int) *bloomFilter {
+	if n <= 0 {
+		n = 1
+	}
+	want := uint64(n) * bloomBitsPerKey
+	if want < bloomMinBits {
+		want = bloomMinBits
+	}
+	if want > bloomMaxBits {
+		want = bloomMaxBits
+	}
+	m := nextPow2(want)
+	words := (m + 63) / 64
+	return &bloomFilter{
+		mask: m - 1,
+		bits: make([]uint64, words),
+	}
+}
+
+func (b *bloomFilter) addHash(h uint64) {
+	h1 := uint32(h)
+	h2 := uint32(h>>32) | 1
+	for i := uint32(0); i < bloomK; i++ {
+		bit := uint64(h1+i*h2) & b.mask
+		b.bits[bit>>6] |= 1 << (bit & 63)
+	}
+}
+
+func (b *bloomFilter) mightContainHash(h uint64) bool {
+	h1 := uint32(h)
+	h2 := uint32(h>>32) | 1
+	for i := uint32(0); i < bloomK; i++ {
+		bit := uint64(h1+i*h2) & b.mask
+		if (b.bits[bit>>6]>>(bit&63))&1 == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func nextPow2(v uint64) uint64 {
+	if v <= 1 {
+		return 1
+	}
+	v--
+	v |= v >> 1
+	v |= v >> 2
+	v |= v >> 4
+	v |= v >> 8
+	v |= v >> 16
+	v |= v >> 32
+	return v + 1
+}

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -240,6 +240,12 @@ type Options struct {
 	// Values <= 1 disable parallelism.
 	FlushBuildConcurrency int
 
+	// ImmutableBloomFilter enables per-immutable Bloom filters in the cached
+	// layer (TreeDB/caching) as a read-side fast-path under flush debt.
+	//
+	// Trade-off: building filters adds work during rotation.
+	ImmutableBloomFilter bool
+
 	// JournalLanes controls the number of active commit/value log lanes (0=default).
 	// Max supported lanes is 255; value-log segment sequence per lane is capped at 8,388,607.
 	JournalLanes int

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -212,6 +212,7 @@ func Open(opts Options) (*DB, error) {
 		WriterFlushMaxMemtables:            opts.WriterFlushMaxMemtables,
 		WriterFlushMaxDuration:             opts.WriterFlushMaxDuration,
 		FlushBuildConcurrency:              opts.FlushBuildConcurrency,
+		ImmutableBloomFilter:               opts.ImmutableBloomFilter,
 		DisableWAL:                         disableWAL,
 		JournalLanes:                       opts.JournalLanes,
 		WALMaxSegmentBytes:                 opts.WALMaxSegmentBytes,

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -49,6 +49,7 @@ Side-by-side benchmarks for `HashDB`, `BTreeOnHashDB`, `TreeDB` (cached), Badger
 - `-treedb-max-backlog-bytes` TreeDB (cached) absolute cap on queued backlog bytes
 - `-treedb-writer-flush-max-memtables` TreeDB (cached) max memtables a writer will help flush per op
 - `-treedb-writer-flush-max-ms` TreeDB (cached) max time (ms) a writer will help flush per op
+- `-treedb-immutable-bloom` TreeDB (cached): enable per-immutable Bloom filters as a point-read fast-path under flush debt
 - `-treedb-iter-debug` print prefix scan iterator timing + debug stats
 - `-treedb-iter-debug-limit` max per-query debug lines to print (default 20)
 - `-treedb-bg-vacuum-interval` TreeDB: background index vacuum interval (0=disabled)

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -25,6 +25,7 @@ var (
 	treedbMaxBacklogBytes           = flag.Int64("treedb-max-backlog-bytes", 2<<30, "TreeDB (cached): absolute cap on queued flush backlog bytes (0=disabled)")
 	treedbWriterFlushMaxMems        = flag.Int("treedb-writer-flush-max-memtables", 0, "TreeDB (cached): max memtables a writer will help flush per op when backpressure triggers (0=default)")
 	treedbWriterFlushMaxMs          = flag.Int("treedb-writer-flush-max-ms", 0, "TreeDB (cached): max milliseconds a writer will help flush per op when backpressure triggers (0=disabled)")
+	treedbImmutableBloom            = flag.Bool("treedb-immutable-bloom", false, "TreeDB (cached): enable per-immutable Bloom filters as a point-read fast-path under flush debt")
 	treedbPreferAppendAlloc         = flag.Bool("treedb-prefer-append-alloc", false, "TreeDB: allocate new index pages by appending instead of freelist reuse (improves scan locality under churn; grows index.db)")
 	treedbFreelistRegionPages       = flag.Uint64("treedb-freelist-region-pages", 0, "TreeDB: freelist reuse region size in pages (0=default)")
 	treedbFreelistRegionRadius      = flag.Int("treedb-freelist-region-radius", 0, "TreeDB: freelist reuse region radius (0=default, <0=disable bias)")
@@ -184,6 +185,7 @@ func NewTreeDB(dir string) (kvstore.DB, error) {
 		StopBacklogSeconds:      *treedbStopBacklogSeconds,
 		MaxBacklogBytes:         *treedbMaxBacklogBytes,
 		WriterFlushMaxMemtables: *treedbWriterFlushMaxMems,
+		ImmutableBloomFilter:    *treedbImmutableBloom,
 
 		JournalLanes:               *treedbJournalLanes,
 		JournalCompression:         *treedbJournalCompress,

--- a/docs/IMMUTABLE_BLOOM_EXPERIMENT.md
+++ b/docs/IMMUTABLE_BLOOM_EXPERIMENT.md
@@ -1,0 +1,115 @@
+# TreeDB (cached): Immutable Bloom Filter Experiment
+
+Date: 2026-01-27
+
+This is an experiment to evaluate whether adding a per-immutable Bloom filter
+helps point-read throughput under flush debt (deep immutable queue), beyond the
+shard-only immutable lookup fix.
+
+## Implementation summary
+
+- Adds an option `Options.ImmutableBloomFilter` (default false).
+- When enabled, the caching layer wraps immutable **hash_sorted** memtables with
+  a Bloom filter built at rotation time.
+- Point reads (`Get`/`GetAppend`/`Has`) consult the filter before doing the
+  immutable lookup; if the filter is negative the immutable is skipped.
+- Unified bench flag: `-treedb-immutable-bloom`.
+
+## Bench methodology
+
+All runs below are TreeDB only:
+
+- `-profile fast`
+- mixed workload (no checkpoint between tests)
+- `-treedb-cache-stats-before-reads` to record queue/backlog
+
+### Run A (all tests)
+
+Baseline:
+
+```bash
+go run ./cmd/unified_bench -dbs treedb -profile fast -keys 900000 -valsize 128 -batchsize 1000 \
+  -test all -treedb-cache-stats-before-reads -progress=false
+```
+
+Candidate (immutable bloom enabled):
+
+```bash
+go run ./cmd/unified_bench -dbs treedb -profile fast -keys 900000 -valsize 128 -batchsize 1000 \
+  -test all -treedb-cache-stats-before-reads -treedb-immutable-bloom -progress=false
+```
+
+Raw outputs are in:
+Baseline (ops/sec):
+
+```
+Sequential Write:      9,846,244
+Random Write:          1,488,381
+Dataset Write (Random):3,074,501
+Dataset Write (Sorted):3,227,284
+Batch Write:           4,361,116
+Batch Random:          1,506,147
+Batch Delete:          2,300,202
+Batch Small Seq:       3,166,544
+Random Delete:         1,622,010
+Random Read:             640,669
+Full Scan:             1,925,874
+Prefix Scan:             425,214
+```
+
+Candidate (ops/sec):
+
+```
+Sequential Write:      9,803,032
+Random Write:          1,504,210
+Dataset Write (Random):2,611,270
+Dataset Write (Sorted):2,831,067
+Batch Write:           4,384,260
+Batch Random:          1,493,257
+Batch Delete:          2,224,492
+Batch Small Seq:       2,381,720
+Random Delete:         1,763,584
+Random Read:             597,334
+Full Scan:             1,527,160
+Prefix Scan:             204,610
+```
+
+Key deltas (candidate vs baseline):
+
+- `Random Read`: -6.76%
+- `Sequential Write`: -0.44%
+- `Batch Random`: -0.86%
+- `Batch Small Seq`: -24.78%
+
+### Run B (forced deep queue)
+
+This increases rotation frequency and disables backpressure so the immutable
+queue becomes very deep:
+
+```bash
+go run ./cmd/unified_bench -dbs treedb -profile fast -keys 2000000 -valsize 128 -batchsize 1000 \
+  -test sequential_write,random_read -treedb-cache-stats-before-reads \
+  -treedb-flush-threshold 4194304 -treedb-max-queued-memtables 1000 \
+  -treedb-slowdown-backlog-seconds 1000000000 -treedb-stop-backlog-seconds 1000000000 \
+  -treedb-max-backlog-bytes 1099511627776 -progress=false
+```
+
+Raw output:
+Baseline (ops/sec):
+
+```
+Sequential Write: 9,180,481
+Random Read:      1,049,809
+```
+
+Observed: `queue_len=440` with `Random Read` still ~1.05M ops/sec (skiplist memtable mode),
+so the Bloom filter (hash_sorted-only) does not engage here.
+
+## Conclusion (so far)
+
+On these runs, the immutable Bloom filter does **not** improve `random_read` and
+can regress other throughput numbers (notably `batch_small_seq` and scans).
+
+It may still be worth revisiting if/when we have:
+- a benchmark that stresses **miss-heavy** point lookups, or
+- a workload where `memtable_mode=hash_sorted` persists while `queue_len` is very deep.


### PR DESCRIPTION
Experiment: per-immutable Bloom filters as a point-read fast-path under flush debt.

## What
- Adds `Options.ImmutableBloomFilter` (default false).
- When enabled, wraps immutable `hash_sorted` memtables with a Bloom filter built at rotation time.
- Point reads (`Get`/`GetAppend`/`Has`) consult the filter before doing the immutable lookup.
- Unified bench flag: `-treedb-immutable-bloom`.

## Results
So far this does *not* improve `random_read` in the mixed unified_bench runs and can regress other tests.
See `docs/IMMUTABLE_BLOOM_EXPERIMENT.md` for commands + numbers.

## Notes
- This PR is stacked on #195 (base: `sprint/public-api-cleanup`).
- If we keep exploring this idea, it may only make sense for miss-heavy point-lookup workloads or when `hash_sorted` persists with a very deep per-shard immutable queue.