### PR TITLE
Reduce memtable allocation churn and improve pointer handling

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2851,24 +2851,38 @@ func buildOpRunsWithBuf(mem memtable.Table, chunkCap int) ([]flushOpRun, error) 
 		chunkCap = 8192
 	}
 	iter := mem.NewIterator(nil, nil)
+	type stableEntryIter interface {
+		StableEntry() (key []byte, val []byte, ptr page.ValuePtr, flags byte)
+	}
+	stableIter, hasStable := iter.(stableEntryIter)
 	var runs []flushOpRun
 	ops := getEntrySlice(chunkCap)
 	ops = ops[:0]
 	buf := getOpBuf(0)
 	for iter.Valid() {
-		val, ptr, flags := iter.UnsafeEntry()
-		keyBytes := iter.UnsafeKey()
-		keyOff := len(buf)
-		buf = append(buf, keyBytes...)
-		key := buf[keyOff:len(buf)]
+		var key, val []byte
+		var ptr page.ValuePtr
+		var flags byte
+		if hasStable {
+			key, val, ptr, flags = stableIter.StableEntry()
+		} else {
+			val, ptr, flags = iter.UnsafeEntry()
+			keyBytes := iter.UnsafeKey()
+			keyOff := len(buf)
+			buf = append(buf, keyBytes...)
+			key = buf[keyOff:len(buf)]
+		}
 		if flags&node.FlagTombstone != 0 {
 			ops = append(ops, batch.Entry{Type: batch.OpDelete, Key: key})
 		} else if flags&node.FlagPointer != 0 {
 			ops = append(ops, batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true})
 		} else {
-			valOff := len(buf)
-			buf = append(buf, val...)
-			value := buf[valOff:len(buf)]
+			value := val
+			if !hasStable {
+				valOff := len(buf)
+				buf = append(buf, val...)
+				value = buf[valOff:len(buf)]
+			}
 			ops = append(ops, batch.Entry{Type: batch.OpPut, Key: key, Value: value})
 		}
 		iter.Next()

--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -1015,6 +1015,22 @@ func (it *hashIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	return it.cur.value, page.ValuePtr{}, node.FlagInline
 }
 
+// StableEntry returns key/value views that remain valid until Close.
+// This is safe for HashSorted because entries live in the memtable arena.
+func (it *hashIterator) StableEntry() (key []byte, val []byte, ptr page.ValuePtr, flags byte) {
+	if !it.valid {
+		return nil, nil, page.ValuePtr{}, node.FlagTombstone
+	}
+	it.ensureLoaded()
+	if it.cur.flags&node.FlagTombstone != 0 {
+		return it.cur.key, nil, page.ValuePtr{}, node.FlagTombstone
+	}
+	if it.cur.flags&node.FlagPointer != 0 {
+		return it.cur.key, it.cur.value, it.cur.ptr, it.cur.flags
+	}
+	return it.cur.key, it.cur.value, page.ValuePtr{}, node.FlagInline
+}
+
 func (it *hashIterator) Key() []byte {
 	return it.UnsafeKey()
 }


### PR DESCRIPTION
## Summary
- reduce per-entry allocation churn in HashSorted ApplyStealSortedBatch and setEntry paths
- store value-log pointers separately from inline values to cut encode/decode work
- reuse inline value buffers where safe to trim GC pressure
- add stable iterator entry access to avoid unsafe slice copies in flush build

## Notes
- tests updated to keep existing expectations with the new HashSorted layout
- behavior is unchanged for correctness; changes focus on allocation/GC reduction

## Testing
- go test ./TreeDB/internal/memtable -run HashSorted
- go test ./TreeDB/caching -run ParallelBuild -count=1
