### PR TITLE
Add sharded DB support and TreeDB admin ops to unified_bench

### DIFF
--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -40,6 +40,7 @@ Side-by-side benchmarks for `HashDB`, `BTreeOnHashDB`, `TreeDB` (cached), Badger
 - `-keyscale` generate keycounts by scale: `log10` or `doubling` (uses `-keys-min` / `-keys-max`)
 - `-valsize` value size in bytes (default 128)
 - `-batchsize` batch size (default 1000)
+- `-batch-shards` shard each DB into N hash partitions for key-based routing (default 1)
 - `-range-queries` number of prefix/range queries (default 200)
 - `-range-span` number of keys per range (default 100)
 - `-treedb-flush-threshold` TreeDB (cached) flush threshold in bytes (default 64MB)

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	crand "crypto/rand"
 	"encoding/binary"
+	"errors"
 	"flag"
 	"fmt"
 	"hash/fnv"
@@ -33,6 +34,7 @@ var (
 	valSize            = flag.Int("valsize", 128, "Value size in bytes")
 	datasetValPat      = flag.String("dataset-val-pattern", "random", "Dataset value pattern (random|zero|repeat)")
 	batchSize          = flag.Int("batchsize", 1000, "Size of batches")
+	batchShards        = flag.Int("batch-shards", 1, "Shard each DB into N hash-partitioned shards (1 disables sharding)")
 	rangeQueries       = flag.Int("range-queries", 200, "number of range queries")
 	rangeSpan          = flag.Int("range-span", 100, "number of keys per range")
 	keyCountsArg       = flag.String("keycounts", "", "Comma-separated key counts to sweep over (overrides -keys)")
@@ -76,12 +78,14 @@ type DBInstance struct {
 	Name    string
 	Wrapper kvstore.DB
 	Dir     string
+	Reopen  func() (kvstore.DB, error)
 }
 
 type BenchConfig struct {
 	Keys         int
 	ValueSize    int
 	BatchSize    int
+	BatchShards  int
 	RangeQueries int
 	RangeSpan    int
 
@@ -173,6 +177,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Profile:     (none/custom)\n")
 	}
 	fmt.Fprintf(os.Stderr, "Settings:    keys=%d valsize=%d batchsize=%d\n", *numKeys, *valSize, *batchSize)
+	fmt.Fprintf(os.Stderr, "             batch_shards=%d\n", *batchShards)
 	if *rangeQueries > 0 {
 		fmt.Fprintf(os.Stderr, "             range_queries=%d range_span=%d\n", *rangeQueries, *rangeSpan)
 	}
@@ -186,6 +191,7 @@ func main() {
 		Keys:                             *numKeys,
 		ValueSize:                        *valSize,
 		BatchSize:                        *batchSize,
+		BatchShards:                      *batchShards,
 		RangeQueries:                     *rangeQueries,
 		RangeSpan:                        *rangeSpan,
 		DBsArg:                           *dbsArg,
@@ -362,8 +368,8 @@ func main() {
 	switch format {
 	case "table":
 		for _, run := range runs {
-			fmt.Printf("\nkeys=%s valsize=%d batchsize=%d range-queries=%d range-span=%d\n\n",
-				formatInt(run.Config.Keys), run.Config.ValueSize, run.Config.BatchSize, run.Config.RangeQueries, run.Config.RangeSpan)
+			fmt.Printf("\nkeys=%s valsize=%d batchsize=%d batch-shards=%d range-queries=%d range-span=%d\n\n",
+				formatInt(run.Config.Keys), run.Config.ValueSize, run.Config.BatchSize, run.Config.BatchShards, run.Config.RangeQueries, run.Config.RangeSpan)
 			printResultsTable(run.Instances, run.TestOrder, run.DisplayNames, run.Results)
 			if len(run.CheckpointDurations) > 0 {
 				fmt.Println()
@@ -456,6 +462,15 @@ func printTreeDBCacheStats(w io.Writer, inst *DBInstance, prefix string) {
 	fmt.Fprintf(w, "%s (%s):", prefix, inst.Wrapper.Name())
 	for _, k := range keys {
 		v, ok := stats[k]
+		if !ok {
+			for sk, sv := range stats {
+				if strings.HasSuffix(sk, "."+k) {
+					v = sv
+					ok = true
+					break
+				}
+			}
+		}
 		if !ok || v == "" {
 			continue
 		}
@@ -665,7 +680,13 @@ func (p *periodicCheckpoint) Add(db kvstore.DB, opsDelta int, bytesDelta int64) 
 	if !ok {
 		return nil
 	}
-	return cp.Checkpoint()
+	if err := cp.Checkpoint(); err != nil {
+		if isUnsupported(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func runBenchmark(cfg BenchConfig) (BenchRun, error) {
@@ -677,6 +698,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	}
 	if cfg.BatchSize <= 0 {
 		return BenchRun{}, fmt.Errorf("invalid batchsize: %d", cfg.BatchSize)
+	}
+	if cfg.BatchShards <= 0 {
+		return BenchRun{}, fmt.Errorf("invalid batch-shards: %d", cfg.BatchShards)
 	}
 	if cfg.RangeQueries < 0 || cfg.RangeSpan < 0 {
 		return BenchRun{}, fmt.Errorf("invalid range settings: queries=%d span=%d", cfg.RangeQueries, cfg.RangeSpan)
@@ -699,13 +723,13 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			return BenchRun{}, fmt.Errorf("temp dir: %w", err)
 		}
 
-		db, err := factory(dir)
+		db, reopen, err := openBenchDB(factory, name, dir, cfg.BatchShards)
 		if err != nil {
 			_ = os.RemoveAll(dir)
 			return BenchRun{}, fmt.Errorf("init %s: %w", name, err)
 		}
 
-		instances = append(instances, &DBInstance{Name: name, Wrapper: db, Dir: dir})
+		instances = append(instances, &DBInstance{Name: name, Wrapper: db, Dir: dir, Reopen: reopen})
 	}
 	if len(instances) == 0 {
 		return BenchRun{}, fmt.Errorf("no DBs selected")
@@ -801,43 +825,44 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	checkPrefixCounts := false
 	testFuncs := map[string]TestFunc{
 		"vacuum_index": func(db kvstore.DB, _ *rand.Rand) (float64, error) {
-			td, ok := db.(*treedbadapter.DB)
-			if !ok || td == nil || td.DB == nil {
-				return math.NaN(), nil
-			}
-			if err := td.DB.CompactIndex(); err != nil {
+			if err := treedbCompactIndex(db); err != nil {
+				if isUnsupported(err) {
+					return math.NaN(), nil
+				}
 				return 0, fmt.Errorf("vacuum_index: %w", err)
 			}
 			return math.NaN(), nil
 		},
 		"fragmentation_report_pre": func(db kvstore.DB, _ *rand.Rand) (float64, error) {
-			td, ok := db.(*treedbadapter.DB)
-			if !ok || td == nil || td.DB == nil {
-				return math.NaN(), nil
-			}
-			rep, err := td.DB.FragmentationReport()
+			reports, err := treedbFragmentationReports(db)
 			if err != nil {
+				if isUnsupported(err) {
+					return math.NaN(), nil
+				}
 				return 0, fmt.Errorf("fragmentation_report_pre: %w", err)
 			}
-			if err := treedbdb.ValidateFragmentationReport(rep); err != nil {
-				return 0, fmt.Errorf("fragmentation_report_pre validate: %w", err)
+			for idx, rep := range reports {
+				if err := treedbdb.ValidateFragmentationReport(rep); err != nil {
+					return 0, fmt.Errorf("fragmentation_report_pre validate: %w", err)
+				}
+				printFragmentationReport(os.Stderr, "pre_settle", shardReportName(db.Name(), idx, len(reports)), rep)
 			}
-			printFragmentationReport(os.Stderr, "pre_settle", db.Name(), rep)
 			return math.NaN(), nil
 		},
 		"fragmentation_report_post": func(db kvstore.DB, _ *rand.Rand) (float64, error) {
-			td, ok := db.(*treedbadapter.DB)
-			if !ok || td == nil || td.DB == nil {
-				return math.NaN(), nil
-			}
-			rep, err := td.DB.FragmentationReport()
+			reports, err := treedbFragmentationReports(db)
 			if err != nil {
+				if isUnsupported(err) {
+					return math.NaN(), nil
+				}
 				return 0, fmt.Errorf("fragmentation_report_post: %w", err)
 			}
-			if err := treedbdb.ValidateFragmentationReport(rep); err != nil {
-				return 0, fmt.Errorf("fragmentation_report_post validate: %w", err)
+			for idx, rep := range reports {
+				if err := treedbdb.ValidateFragmentationReport(rep); err != nil {
+					return 0, fmt.Errorf("fragmentation_report_post validate: %w", err)
+				}
+				printFragmentationReport(os.Stderr, "post_settle", shardReportName(db.Name(), idx, len(reports)), rep)
 			}
-			printFragmentationReport(os.Stderr, "post_settle", db.Name(), rep)
 			return math.NaN(), nil
 		},
 		"sequential_write": func(db kvstore.DB, _ *rand.Rand) (float64, error) {
@@ -947,6 +972,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				}
 				batch, err := batcher.NewBatch()
 				if err != nil {
+					if isUnsupported(err) {
+						return math.NaN(), nil
+					}
 					return 0, fmt.Errorf("batch_write: new batch: %w", err)
 				}
 
@@ -1007,6 +1035,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				}
 				batch, err := batcher.NewBatch()
 				if err != nil {
+					if isUnsupported(err) {
+						return math.NaN(), nil
+					}
 					return 0, fmt.Errorf("batch_random: new batch: %w", err)
 				}
 
@@ -1067,6 +1098,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				}
 				batch, err := batcher.NewBatch()
 				if err != nil {
+					if isUnsupported(err) {
+						return math.NaN(), nil
+					}
 					return 0, fmt.Errorf("batch_delete: new batch: %w", err)
 				}
 
@@ -1116,6 +1150,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				}
 				batch, err := batcher.NewBatch()
 				if err != nil {
+					if isUnsupported(err) {
+						return math.NaN(), nil
+					}
 					return 0, fmt.Errorf("batch_small_seq: new batch: %w", err)
 				}
 
@@ -1170,6 +1207,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if batcher, ok := db.(kvstore.Batcher); ok {
 					batch, err := batcher.NewBatch()
 					if err != nil {
+						if isUnsupported(err) {
+							return math.NaN(), nil
+						}
 						return 0, fmt.Errorf("update_fork_choice: new batch: %w", err)
 					}
 					for j := i; j < end; j++ {
@@ -1190,6 +1230,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					for j := i; j < end; j++ {
 						binary.BigEndian.PutUint64(k[:], uint64(rng.Intn(cfg.Keys*10)))
 						if err := syncer.SetSync(k[:], val); err != nil {
+							if isUnsupported(err) {
+								return math.NaN(), nil
+							}
 							return 0, fmt.Errorf("update_fork_choice: set sync: %w", err)
 						}
 					}
@@ -1241,6 +1284,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if batcher, ok := db.(kvstore.Batcher); ok {
 					batch, err := batcher.NewBatch()
 					if err != nil {
+						if isUnsupported(err) {
+							return math.NaN(), nil
+						}
 						return 0, fmt.Errorf("dataset_update_fork_choice: new batch: %w", err)
 					}
 					for j := i; j < end; j++ {
@@ -1261,6 +1307,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					for j := i; j < end; j++ {
 						key := datasetRandomKeys[rng.Intn(len(datasetRandomKeys))]
 						if err := syncer.SetSync(key, val); err != nil {
+							if isUnsupported(err) {
+								return math.NaN(), nil
+							}
 							return 0, fmt.Errorf("dataset_update_fork_choice: set sync: %w", err)
 						}
 					}
@@ -1335,6 +1384,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			if rs, ok := db.(kvstore.RangeScanner); ok {
 				iter, err := rs.Iterator(nil, nil)
 				if err != nil {
+					if isUnsupported(err) {
+						return math.NaN(), nil
+					}
 					return 0, fmt.Errorf("full_scan: iterator: %w", err)
 				}
 				defer func() { _ = iter.Close() }()
@@ -1371,6 +1423,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					}
 					return nil
 				}); err != nil {
+					if isUnsupported(err) {
+						return math.NaN(), nil
+					}
 					return 0, fmt.Errorf("full_scan: foreach: %w", err)
 				}
 				return float64(count) / time.Since(start).Seconds(), nil
@@ -1383,6 +1438,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			if rs, ok := db.(kvstore.RangeScanner); ok {
 				iter, err := rs.Iterator(nil, nil)
 				if err != nil {
+					if isUnsupported(err) {
+						return math.NaN(), nil
+					}
 					return 0, fmt.Errorf("full_scan2: iterator: %w", err)
 				}
 				defer func() { _ = iter.Close() }()
@@ -1416,6 +1474,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					}
 					return nil
 				}); err != nil {
+					if isUnsupported(err) {
+						return math.NaN(), nil
+					}
 					return 0, fmt.Errorf("full_scan2: foreach: %w", err)
 				}
 				return float64(count) / time.Since(start).Seconds(), nil
@@ -1459,6 +1520,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				buildStart := time.Now()
 				iter, err := rs.Iterator(startKey, endKey)
 				if err != nil {
+					if isUnsupported(err) {
+						return math.NaN(), nil
+					}
 					return 0, fmt.Errorf("prefix_scan: iterator: %w", err)
 				}
 				buildDur := time.Since(buildStart)
@@ -1554,6 +1618,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 
 				iter, err := rs.Iterator(startKey, endKey)
 				if err != nil {
+					if isUnsupported(err) {
+						return math.NaN(), nil
+					}
 					return 0, fmt.Errorf("prefix_scan2: iterator: %w", err)
 				}
 
@@ -1677,12 +1744,17 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			}
 
 			// Reopen
-			factory, err := GetDBFactory(inst.Name)
-			if err != nil {
-				return BenchRun{}, err
+			reopen := inst.Reopen
+			if reopen == nil {
+				factory, err := GetDBFactory(inst.Name)
+				if err != nil {
+					return BenchRun{}, err
+				}
+				reopen = func() (kvstore.DB, error) {
+					return factory(inst.Dir)
+				}
 			}
-			// Reopen
-			newWrapper, err := factory(inst.Dir)
+			newWrapper, err := reopen()
 			if err != nil {
 				return BenchRun{}, fmt.Errorf("settle/reopen %s: %w", inst.Name, err)
 			}
@@ -1796,6 +1868,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				}
 
 				if checkpointErr != nil {
+					if isUnsupported(checkpointErr) {
+						continue
+					}
 					return BenchRun{}, fmt.Errorf("checkpoint %s before %s: %w", inst.Name, testName, checkpointErr)
 				}
 				chkMap[inst.Wrapper.Name()] = time.Since(start)
@@ -1890,6 +1965,7 @@ func renderMarkdownSingle(run BenchRun) string {
 	sb.WriteString(fmt.Sprintf("- keys: %s\n", formatInt(run.Config.Keys)))
 	sb.WriteString(fmt.Sprintf("- valsize: %d\n", run.Config.ValueSize))
 	sb.WriteString(fmt.Sprintf("- batchsize: %d\n", run.Config.BatchSize))
+	sb.WriteString(fmt.Sprintf("- batch-shards: %d\n", run.Config.BatchShards))
 	sb.WriteString(fmt.Sprintf("- range-queries: %d\n", run.Config.RangeQueries))
 	sb.WriteString(fmt.Sprintf("- range-span: %d\n", run.Config.RangeSpan))
 	sb.WriteString("\n")
@@ -1924,6 +2000,7 @@ func renderMarkdownSweep(runs []BenchRun) string {
 	sb.WriteString(fmt.Sprintf("- keys: %s\n", formatKeyCounts(runs)))
 	sb.WriteString(fmt.Sprintf("- valsize: %d\n", runs[0].Config.ValueSize))
 	sb.WriteString(fmt.Sprintf("- batchsize: %d\n", runs[0].Config.BatchSize))
+	sb.WriteString(fmt.Sprintf("- batch-shards: %d\n", runs[0].Config.BatchShards))
 	sb.WriteString(fmt.Sprintf("- range-queries: %d\n", runs[0].Config.RangeQueries))
 	sb.WriteString(fmt.Sprintf("- range-span: %d\n", runs[0].Config.RangeSpan))
 	sb.WriteString("\n")
@@ -2055,9 +2132,9 @@ func runReadmeSuite(baseCfg BenchConfig) (string, error) {
 	sb.WriteString(fmt.Sprintf("_Generated at:_ %s\n", generatedAt.Format(time.RFC3339)))
 	sb.WriteString(fmt.Sprintf("_Environment:_ %s\n", env.MarkdownSummary()))
 	sb.WriteString(fmt.Sprintf("_Seed:_ %d\n\n", baseCfg.SeedUsed))
-	sb.WriteString(fmt.Sprintf("_Key counts:_ %s (valsize=%d, batchsize=%d, range-queries=%d, range-span=%d)\n\n",
+	sb.WriteString(fmt.Sprintf("_Key counts:_ %s (valsize=%d, batchsize=%d, batch-shards=%d, range-queries=%d, range-span=%d)\n\n",
 		formatInt(keyCounts[0])+"…"+formatInt(keyCounts[len(keyCounts)-1]),
-		baseCfg.ValueSize, baseCfg.BatchSize, baseCfg.RangeQueries, baseCfg.RangeSpan))
+		baseCfg.ValueSize, baseCfg.BatchSize, baseCfg.BatchShards, baseCfg.RangeQueries, baseCfg.RangeSpan))
 
 	sb.WriteString("Notes:\n")
 	sb.WriteString("- Results depend on hardware and OS.\n")
@@ -2153,6 +2230,7 @@ func runFlushThrashSuite(baseCfg BenchConfig) (string, error) {
 	sb.WriteString(fmt.Sprintf("- keys: %s\n", formatInt(run.Config.Keys)))
 	sb.WriteString(fmt.Sprintf("- valsize: %d\n", run.Config.ValueSize))
 	sb.WriteString(fmt.Sprintf("- batchsize: %d\n", run.Config.BatchSize))
+	sb.WriteString(fmt.Sprintf("- batch-shards: %d\n", run.Config.BatchShards))
 	sb.WriteString(fmt.Sprintf("- treedb-flush-threshold: %d\n", thrashFlushThresholdBytes))
 	sb.WriteString("\n")
 
@@ -2215,6 +2293,7 @@ func runBigKeysGuardSuite(baseCfg BenchConfig) (string, error) {
 	sb.WriteString(fmt.Sprintf("- keys: %s\n", formatInt(run.Config.Keys)))
 	sb.WriteString(fmt.Sprintf("- valsize: %d\n", run.Config.ValueSize))
 	sb.WriteString(fmt.Sprintf("- batchsize: %d\n", run.Config.BatchSize))
+	sb.WriteString(fmt.Sprintf("- batch-shards: %d\n", run.Config.BatchShards))
 	sb.WriteString(fmt.Sprintf("- treedb-flush-threshold: %d\n", guardFlushThresholdBytes))
 	if run.Config.MaxWall > 0 {
 		sb.WriteString(fmt.Sprintf("- max-wall: %s\n", run.Config.MaxWall))
@@ -2291,30 +2370,57 @@ func suiteTreeDBCacheStats(instances []*DBInstance) (string, error) {
 		if inst == nil || inst.Name != "treedb" {
 			continue
 		}
-		db, err := NewTreeDB(inst.Dir)
+		stats, err := treedbCacheStats(inst)
 		if err != nil {
-			return "", fmt.Errorf("suite: reopen treedb for stats: %w", err)
+			return "", err
 		}
-		sp, ok := db.(kvstore.StatsProvider)
-		if ok {
-			stats := sp.Stats()
-			keys := make([]string, 0, len(stats))
-			for k := range stats {
-				if strings.HasPrefix(k, "treedb.cache.") {
-					keys = append(keys, k)
-				}
-			}
-			sort.Strings(keys)
-			for _, k := range keys {
-				sb.WriteString(k)
-				sb.WriteString("=")
-				sb.WriteString(stats[k])
-				sb.WriteString("\n")
-			}
+		for _, line := range stats {
+			sb.WriteString(line)
+			sb.WriteString("\n")
 		}
-		_ = db.Close()
 	}
 	return sb.String(), nil
+}
+
+func treedbCacheStats(inst *DBInstance) ([]string, error) {
+	var (
+		stats map[string]string
+		db    kvstore.DB
+	)
+
+	if inst.Wrapper != nil {
+		if sp, ok := inst.Wrapper.(kvstore.StatsProvider); ok {
+			stats = sp.Stats()
+		}
+	}
+
+	if stats == nil {
+		var err error
+		db, err = NewTreeDB(inst.Dir)
+		if err != nil {
+			return nil, fmt.Errorf("suite: reopen treedb for stats: %w", err)
+		}
+		defer func() { _ = db.Close() }()
+		sp, ok := db.(kvstore.StatsProvider)
+		if !ok {
+			return nil, nil
+		}
+		stats = sp.Stats()
+	}
+
+	keys := make([]string, 0, len(stats))
+	for k := range stats {
+		if strings.Contains(k, "treedb.cache.") {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	lines := make([]string, 0, len(keys))
+	for _, k := range keys {
+		lines = append(lines, fmt.Sprintf("%s=%s", k, stats[k]))
+	}
+	return lines, nil
 }
 
 func suiteCleanupDirs(instances []*DBInstance) error {
@@ -2378,6 +2484,58 @@ func testSeed(seed int64, testName string) int64 {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(testName))
 	return seed ^ int64(h.Sum64())
+}
+
+func isUnsupported(err error) bool {
+	return errors.Is(err, kvstore.ErrUnsupported)
+}
+
+func treedbCompactIndex(db kvstore.DB) error {
+	if db == nil {
+		return kvstore.ErrUnsupported
+	}
+	if admin, ok := db.(interface{ CompactIndex() error }); ok {
+		return admin.CompactIndex()
+	}
+	if td, ok := db.(*treedbadapter.DB); ok && td != nil && td.DB != nil {
+		return td.DB.CompactIndex()
+	}
+	return kvstore.ErrUnsupported
+}
+
+func treedbFragmentationReports(db kvstore.DB) ([]map[string]string, error) {
+	if db == nil {
+		return nil, kvstore.ErrUnsupported
+	}
+	if reporter, ok := db.(interface {
+		FragmentationReports() ([]map[string]string, error)
+	}); ok {
+		return reporter.FragmentationReports()
+	}
+	if reporter, ok := db.(interface {
+		FragmentationReport() (map[string]string, error)
+	}); ok {
+		rep, err := reporter.FragmentationReport()
+		if err != nil {
+			return nil, err
+		}
+		return []map[string]string{rep}, nil
+	}
+	if td, ok := db.(*treedbadapter.DB); ok && td != nil && td.DB != nil {
+		rep, err := td.DB.FragmentationReport()
+		if err != nil {
+			return nil, err
+		}
+		return []map[string]string{rep}, nil
+	}
+	return nil, kvstore.ErrUnsupported
+}
+
+func shardReportName(base string, idx int, total int) string {
+	if total <= 1 {
+		return base
+	}
+	return fmt.Sprintf("%s/shard-%d", base, idx)
 }
 
 func printResultsTable(instances []*DBInstance, finalTestOrder []string, displayNames map[string]string, results map[string]map[string]float64) {

--- a/cmd/unified_bench/profiles.go
+++ b/cmd/unified_bench/profiles.go
@@ -218,7 +218,7 @@ func customUsage() {
 func isWorkloadFlag(name string) bool {
 	switch name {
 	case "keys", "valsize", "batchsize", "range-queries", "range-span",
-		"keycounts", "keyscale", "keys-min", "keys-max", "dbs", "test",
+		"batch-shards", "keycounts", "keyscale", "keys-min", "keys-max", "dbs", "test",
 		"suite", "outdir", "keep", "progress", "seed", "settle-before-scans":
 		return true
 	}

--- a/cmd/unified_bench/sharded_db.go
+++ b/cmd/unified_bench/sharded_db.go
@@ -1,0 +1,459 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"hash/maphash"
+
+	"github.com/snissn/gomap/kvstore"
+)
+
+type shardedDB struct {
+	name   string
+	shards []kvstore.DB
+	seed   maphash.Seed
+}
+
+func newShardedDB(name string, shards []kvstore.DB) *shardedDB {
+	return &shardedDB{
+		name:   name,
+		shards: shards,
+		seed:   maphash.MakeSeed(),
+	}
+}
+
+func (s *shardedDB) Name() string {
+	return fmt.Sprintf("%s[shards=%d]", s.name, len(s.shards))
+}
+
+func (s *shardedDB) Close() error {
+	var firstErr error
+	for _, shard := range s.shards {
+		if err := shard.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (s *shardedDB) shardIndex(key []byte) int {
+	if len(s.shards) == 0 {
+		return 0
+	}
+	if len(s.shards) == 1 {
+		return 0
+	}
+	h := maphash.Bytes(s.seed, key)
+	return int(h % uint64(len(s.shards)))
+}
+
+func (s *shardedDB) shardForKey(key []byte) kvstore.DB {
+	return s.shards[s.shardIndex(key)]
+}
+
+func (s *shardedDB) Get(key []byte) ([]byte, error) {
+	return s.shardForKey(key).Get(key)
+}
+
+func (s *shardedDB) Set(key, value []byte) error {
+	return s.shardForKey(key).Set(key, value)
+}
+
+func (s *shardedDB) Delete(key []byte) error {
+	return s.shardForKey(key).Delete(key)
+}
+
+func (s *shardedDB) Has(key []byte) (bool, error) {
+	shard := s.shardForKey(key)
+	hs, ok := shard.(kvstore.Haser)
+	if !ok {
+		return false, kvstore.ErrUnsupported
+	}
+	return hs.Has(key)
+}
+
+func (s *shardedDB) SetSync(key, value []byte) error {
+	shard := s.shardForKey(key)
+	syncer, ok := shard.(kvstore.Syncer)
+	if !ok {
+		return kvstore.ErrUnsupported
+	}
+	return syncer.SetSync(key, value)
+}
+
+func (s *shardedDB) DeleteSync(key []byte) error {
+	shard := s.shardForKey(key)
+	syncer, ok := shard.(kvstore.Syncer)
+	if !ok {
+		return kvstore.ErrUnsupported
+	}
+	return syncer.DeleteSync(key)
+}
+
+func (s *shardedDB) Stats() map[string]string {
+	stats := make(map[string]string)
+	for i, shard := range s.shards {
+		sp, ok := shard.(kvstore.StatsProvider)
+		if !ok {
+			continue
+		}
+		for k, v := range sp.Stats() {
+			stats[fmt.Sprintf("shard.%d.%s", i, k)] = v
+		}
+	}
+	if len(stats) == 0 {
+		return nil
+	}
+	return stats
+}
+
+func (s *shardedDB) Print() error {
+	var firstErr error
+	for _, shard := range s.shards {
+		pr, ok := shard.(kvstore.Printer)
+		if !ok {
+			return kvstore.ErrUnsupported
+		}
+		if err := pr.Print(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (s *shardedDB) NewBatch() (kvstore.Batch, error) {
+	for _, shard := range s.shards {
+		if _, ok := shard.(kvstore.Batcher); !ok {
+			return nil, kvstore.ErrUnsupported
+		}
+	}
+	return &shardedBatch{
+		shards:   s.shards,
+		shardFor: s.shardIndex,
+		batches:  make([]kvstore.Batch, len(s.shards)),
+	}, nil
+}
+
+func (s *shardedDB) ForEach(fn func(key, value []byte) error) error {
+	for _, shard := range s.shards {
+		if fe, ok := shard.(kvstore.ForEacher); ok {
+			if err := fe.ForEach(fn); err != nil {
+				return err
+			}
+			continue
+		}
+		if rs, ok := shard.(kvstore.RangeScanner); ok {
+			iter, err := rs.Iterator(nil, nil)
+			if err != nil {
+				return err
+			}
+			for iter.Valid() {
+				if err := fn(iter.Key(), iter.Value()); err != nil {
+					_ = iter.Close()
+					return err
+				}
+				iter.Next()
+			}
+			if err := iter.Error(); err != nil {
+				_ = iter.Close()
+				return err
+			}
+			if err := iter.Close(); err != nil {
+				return err
+			}
+			continue
+		}
+		return kvstore.ErrUnsupported
+	}
+	return nil
+}
+
+func (s *shardedDB) Iterator(start, end []byte) (kvstore.Iterator, error) {
+	iters := make([]kvstore.Iterator, 0, len(s.shards))
+	h := &shardIterHeap{reverse: false}
+	for _, shard := range s.shards {
+		rs, ok := shard.(kvstore.RangeScanner)
+		if !ok {
+			return nil, kvstore.ErrUnsupported
+		}
+		iter, err := rs.Iterator(start, end)
+		if err != nil {
+			return nil, err
+		}
+		if iter.Valid() {
+			keyCopy := iter.KeyCopy(nil)
+			heap.Push(h, &shardIter{iter: iter, key: keyCopy})
+		}
+		iters = append(iters, iter)
+	}
+	return newShardedIterator(h, iters), nil
+}
+
+func (s *shardedDB) ReverseIterator(start, end []byte) (kvstore.Iterator, error) {
+	iters := make([]kvstore.Iterator, 0, len(s.shards))
+	h := &shardIterHeap{reverse: true}
+	for _, shard := range s.shards {
+		rs, ok := shard.(kvstore.RangeScanner)
+		if !ok {
+			return nil, kvstore.ErrUnsupported
+		}
+		iter, err := rs.ReverseIterator(start, end)
+		if err != nil {
+			return nil, err
+		}
+		if iter.Valid() {
+			keyCopy := iter.KeyCopy(nil)
+			heap.Push(h, &shardIter{iter: iter, key: keyCopy})
+		}
+		iters = append(iters, iter)
+	}
+	return newShardedIterator(h, iters), nil
+}
+
+func (s *shardedDB) Checkpoint() error {
+	var firstErr error
+	for _, shard := range s.shards {
+		cp, ok := shard.(checkpointer)
+		if !ok {
+			return kvstore.ErrUnsupported
+		}
+		if err := cp.Checkpoint(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (s *shardedDB) CompactIndex() error {
+	var firstErr error
+	for _, shard := range s.shards {
+		admin, ok := shard.(interface{ CompactIndex() error })
+		if !ok {
+			return kvstore.ErrUnsupported
+		}
+		if err := admin.CompactIndex(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (s *shardedDB) FragmentationReports() ([]map[string]string, error) {
+	reports := make([]map[string]string, 0, len(s.shards))
+	for _, shard := range s.shards {
+		reporter, ok := shard.(interface {
+			FragmentationReport() (map[string]string, error)
+		})
+		if !ok {
+			return nil, kvstore.ErrUnsupported
+		}
+		rep, err := reporter.FragmentationReport()
+		if err != nil {
+			return nil, err
+		}
+		reports = append(reports, rep)
+	}
+	return reports, nil
+}
+
+type shardedBatch struct {
+	shards   []kvstore.DB
+	batches  []kvstore.Batch
+	shardFor func([]byte) int
+}
+
+func (b *shardedBatch) batchForKey(key []byte) (kvstore.Batch, error) {
+	idx := b.shardFor(key)
+	if b.batches[idx] != nil {
+		return b.batches[idx], nil
+	}
+	batcher, ok := b.shards[idx].(kvstore.Batcher)
+	if !ok {
+		return nil, kvstore.ErrUnsupported
+	}
+	batch, err := batcher.NewBatch()
+	if err != nil {
+		return nil, err
+	}
+	b.batches[idx] = batch
+	return batch, nil
+}
+
+func (b *shardedBatch) Set(key, value []byte) error {
+	batch, err := b.batchForKey(key)
+	if err != nil {
+		return err
+	}
+	return batch.Set(key, value)
+}
+
+func (b *shardedBatch) Delete(key []byte) error {
+	batch, err := b.batchForKey(key)
+	if err != nil {
+		return err
+	}
+	return batch.Delete(key)
+}
+
+func (b *shardedBatch) Commit() error {
+	var firstErr error
+	for _, batch := range b.batches {
+		if batch == nil {
+			continue
+		}
+		if err := batch.Commit(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (b *shardedBatch) CommitSync() error {
+	var firstErr error
+	for _, batch := range b.batches {
+		if batch == nil {
+			continue
+		}
+		if err := batch.CommitSync(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (b *shardedBatch) Close() error {
+	var firstErr error
+	for i, batch := range b.batches {
+		if batch == nil {
+			continue
+		}
+		if err := batch.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		b.batches[i] = nil
+	}
+	return firstErr
+}
+
+type shardIter struct {
+	iter kvstore.Iterator
+	key  []byte
+}
+
+type shardIterHeap struct {
+	items   []*shardIter
+	reverse bool
+}
+
+func (h shardIterHeap) Len() int { return len(h.items) }
+
+func (h shardIterHeap) Less(i, j int) bool {
+	cmp := bytes.Compare(h.items[i].key, h.items[j].key)
+	if h.reverse {
+		return cmp > 0
+	}
+	return cmp < 0
+}
+
+func (h shardIterHeap) Swap(i, j int) {
+	h.items[i], h.items[j] = h.items[j], h.items[i]
+}
+
+func (h *shardIterHeap) Push(x any) {
+	h.items = append(h.items, x.(*shardIter))
+}
+
+func (h *shardIterHeap) Pop() any {
+	old := h.items
+	n := len(old)
+	item := old[n-1]
+	h.items = old[:n-1]
+	return item
+}
+
+type shardedIterator struct {
+	heap    *shardIterHeap
+	current *shardIter
+	iters   []kvstore.Iterator
+}
+
+func newShardedIterator(h *shardIterHeap, iters []kvstore.Iterator) *shardedIterator {
+	heap.Init(h)
+	s := &shardedIterator{
+		heap:  h,
+		iters: iters,
+	}
+	s.advance()
+	return s
+}
+
+func (s *shardedIterator) advance() {
+	if s.current != nil {
+		s.current.iter.Next()
+		if s.current.iter.Valid() {
+			s.current.key = s.current.iter.KeyCopy(s.current.key[:0])
+			heap.Push(s.heap, s.current)
+		}
+		s.current = nil
+	}
+	if s.heap.Len() == 0 {
+		return
+	}
+	s.current = heap.Pop(s.heap).(*shardIter)
+}
+
+func (s *shardedIterator) Valid() bool {
+	return s.current != nil && s.current.iter.Valid()
+}
+
+func (s *shardedIterator) Next() {
+	s.advance()
+}
+
+func (s *shardedIterator) Key() []byte {
+	if s.current == nil {
+		return nil
+	}
+	return s.current.iter.Key()
+}
+
+func (s *shardedIterator) Value() []byte {
+	if s.current == nil {
+		return nil
+	}
+	return s.current.iter.Value()
+}
+
+func (s *shardedIterator) KeyCopy(dst []byte) []byte {
+	if s.current == nil {
+		return nil
+	}
+	return s.current.iter.KeyCopy(dst)
+}
+
+func (s *shardedIterator) ValueCopy(dst []byte) []byte {
+	if s.current == nil {
+		return nil
+	}
+	return s.current.iter.ValueCopy(dst)
+}
+
+func (s *shardedIterator) Error() error {
+	for _, iter := range s.iters {
+		if err := iter.Error(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *shardedIterator) Close() error {
+	var firstErr error
+	for _, iter := range s.iters {
+		if err := iter.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/cmd/unified_bench/sharded_open.go
+++ b/cmd/unified_bench/sharded_open.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/snissn/gomap/kvstore"
+)
+
+func openBenchDB(factory DBFactory, name, dir string, shards int) (kvstore.DB, func() (kvstore.DB, error), error) {
+	if shards <= 1 {
+		db, err := factory(dir)
+		if err != nil {
+			return nil, nil, err
+		}
+		return db, func() (kvstore.DB, error) {
+			return factory(dir)
+		}, nil
+	}
+	db, err := openShardedDB(factory, name, dir, shards)
+	if err != nil {
+		return nil, nil, err
+	}
+	return db, func() (kvstore.DB, error) {
+		return openShardedDB(factory, name, dir, shards)
+	}, nil
+}
+
+func openShardedDB(factory DBFactory, name, dir string, shards int) (kvstore.DB, error) {
+	if shards <= 1 {
+		return factory(dir)
+	}
+	shardDBs := make([]kvstore.DB, 0, shards)
+	for i := 0; i < shards; i++ {
+		shardDir := filepath.Join(dir, fmt.Sprintf("shard-%d", i))
+		if err := os.MkdirAll(shardDir, 0o755); err != nil {
+			closeShards(shardDBs)
+			return nil, fmt.Errorf("shard dir %s: %w", shardDir, err)
+		}
+		db, err := factory(shardDir)
+		if err != nil {
+			closeShards(shardDBs)
+			return nil, err
+		}
+		shardDBs = append(shardDBs, db)
+	}
+	return newShardedDB(name, shardDBs), nil
+}
+
+func closeShards(shards []kvstore.DB) {
+	for _, shard := range shards {
+		_ = shard.Close()
+	}
+}

--- a/kvstore/adapters/treedb/treedb.go
+++ b/kvstore/adapters/treedb/treedb.go
@@ -86,6 +86,12 @@ func (d *DB) Print() error { return d.DB.Print() }
 
 func (d *DB) Checkpoint() error { return d.DB.Checkpoint() }
 
+func (d *DB) CompactIndex() error { return d.DB.CompactIndex() }
+
+func (d *DB) FragmentationReport() (map[string]string, error) {
+	return d.DB.FragmentationReport()
+}
+
 func (d *DB) Iterator(start, end []byte) (kvstore.Iterator, error) {
 	return d.DB.Iterator(start, end)
 }


### PR DESCRIPTION
### Motivation
- Allow the unified benchmark to shard a DB into hash-partitioned shards so large batched workloads can be routed across multiple DB instances without engine changes.
- Enable TreeDB-specific maintenance tests (index compaction / fragmentation report) to run when the DB is sharded by routing admin ops to all shards and reporting per-shard results.
- Provide an efficient merged iterator across shards for scan/prefix tests by keeping per-shard cursors on a heap.

### Description
- Add `-batch-shards` flag, `BenchConfig.BatchShards`, and plumbing in `main.go` to open sharded DBs via `openBenchDB`/`openShardedDB` and to include shard count in output and reports.
- Add `cmd/unified_bench/sharded_open.go` to create N shard directories and open per-shard DB instances and `cmd/unified_bench/sharded_db.go` to implement `kvstore.DB`-compatible sharded wrapper with routing, batched writes, `ForEach`, merged `Iterator`/`ReverseIterator` using a min-heap of shard cursors, `Checkpoint`, `CompactIndex`, and `FragmentationReports`.
- Extend the TreeDB adapter (`kvstore/adapters/treedb/treedb.go`) to expose `CompactIndex` and `FragmentationReport` so sharded admin calls can be proxied to underlying TreeDB instances.
- Add helpers in `main.go` (`treedbCompactIndex`, `treedbFragmentationReports`, `shardReportName`, `treedbCacheStats`) and make checkpoint/iterator/test paths tolerant of `kvstore.ErrUnsupported` so non-supporting DBs or shard wrappers fail gracefully.
- Implement `shardedBatch` that opens per-shard underlying batches on-demand and commits/close/commit-sync across shards.
- Improve a few stats/reporting locations to include `batch-shards` and to surface per-shard TreeDB stats when available.

### Testing
- Formatted sources with `gofmt` and built/ran the benchmark binary via `go run ./cmd/unified_bench` to validate behavior.
- Executed a representative run: `go run ./cmd/unified_bench -dbs treedb -test batch_write -keys 50000 -valsize 128 -batchsize 1000 -profile fast -batch-shards 2 -progress=false`, which completed successfully and reported `Batch Write = 455,987` ops/sec.
- Verified sharded iterators, batched writes, checkpoints, and TreeDB admin ops (compact/fragmentation) route to shards and that per-shard fragmentation reports are printed and validated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c1be437088322b50c4ab654455ea5)