### PR TITLE
TreeDB: bump default pager chunk size to 16MiB

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -84,7 +84,7 @@ type DB struct {
 }
 
 const (
-	defaultChunkSize                 = 4 * 1024 * 1024
+	defaultChunkSize                 = 16 * 1024 * 1024
 	defaultMaintenanceOpsPerCoalesce = 400_000
 )
 
@@ -164,7 +164,7 @@ type Options struct {
 	// modifying on-disk state (no recovery truncation, no WAL replay, no background
 	// maintenance). Only read operations are supported.
 	ReadOnly   bool
-	ChunkSize  int64  // Default 4MiB
+	ChunkSize  int64  // Default 16MiB
 	KeepRecent uint64 // Default 10000
 	// PagerSyncConcurrency controls how many goroutines may msync dirty chunks
 	// in parallel during Sync. Values <= 0 use the default (1).

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -22,7 +22,7 @@ import (
 type Options = db.Options
 
 const (
-	defaultChunkSize     = 4 * 1024 * 1024
+	defaultChunkSize     = 16 * 1024 * 1024
 	defaultDictChunkSize = 1 * 1024 * 1024
 )
 

--- a/TreeDB/specs/spec.md
+++ b/TreeDB/specs/spec.md
@@ -59,7 +59,7 @@ Rules:
   * **Filename:** `index.db`
         *   **Access Pattern:** **Chunked Memory Map**.
             * The file is logically a contiguous array of Pages.
-            * Physically, the Go runtime maps it in **Configurable Chunks** (default: 4MiB).
+            * Physically, the Go runtime maps it in **Configurable Chunks** (default: 16MiB).
             * **Alignment Invariant:** `ChunkSize` MUST be an exact multiple of the **Page Size** (4KB). The Pager MUST ensure that no Page physically crosses a chunk boundary.
             * **Growth:** To expand, we strictly **pre-allocate disk space** (via `fallocate`) *before* extending the Mmap.
             * **Safety Protocol:**


### PR DESCRIPTION
TreeDB currently defaults pager chunk size to 4MiB. On APFS and other COW filesystems this can lead to lots of small file-growth / mmap-grow steps under churn.

This bumps the default chunk size to 16MiB (both TreeDB.Open and db.Open) and updates the spec docs accordingly.

Notes:
- Existing callers can still override via Options.ChunkSize / -treedb-chunk-size.
- No behavior change beyond growth granularity; go test ./... passes.