### PR TITLE
zipper: gate maintenance to delete batches

### DIFF
--- a/TreeDB/zipper/maintenance_gate_test.go
+++ b/TreeDB/zipper/maintenance_gate_test.go
@@ -18,27 +18,27 @@ func TestZipper_ShouldRunMaintenance_HasDeletesTrue(t *testing.T) {
 	}
 }
 
-func TestZipper_ShouldRunMaintenance_PiggybackTrue(t *testing.T) {
+func TestZipper_ShouldRunMaintenance_PiggybackDoesNotTrigger(t *testing.T) {
 	z := &Zipper{piggybackCompaction: true}
 	ops := []batch.Entry{{Type: batch.OpPut, Key: []byte("k"), Value: []byte("v")}}
 	got, delCount := z.shouldRunMaintenance(ops)
 	if delCount != 0 {
 		t.Fatalf("expected deleteCount=0, got %d", delCount)
 	}
-	if !got {
-		t.Fatalf("expected maintenance=true when piggyback compaction is enabled")
+	if got {
+		t.Fatalf("expected maintenance=false for pure puts (piggyback should not force maintenance)")
 	}
 }
 
-func TestZipper_ShouldRunMaintenance_ReserveBytesTrue(t *testing.T) {
+func TestZipper_ShouldRunMaintenance_ReserveBytesDoesNotTrigger(t *testing.T) {
 	z := &Zipper{leafReserveBytes: 1}
 	ops := []batch.Entry{{Type: batch.OpPut, Key: []byte("k"), Value: []byte("v")}}
 	got, delCount := z.shouldRunMaintenance(ops)
 	if delCount != 0 {
 		t.Fatalf("expected deleteCount=0, got %d", delCount)
 	}
-	if !got {
-		t.Fatalf("expected maintenance=true when reserve bytes are configured")
+	if got {
+		t.Fatalf("expected maintenance=false for pure puts (reserve bytes should not force maintenance)")
 	}
 }
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -268,9 +268,12 @@ func (z *Zipper) shouldRunMaintenance(ops []batch.Entry) (maintenance bool, dele
 			deleteCount++
 		}
 	}
-	// NOTE: This intentionally mirrors the current behavior so unit tests can lock
-	// down the gate before we adjust it in a follow-up commit.
-	maintenance = hasDeletes || z.leafReserveBytes > 0 || z.internalReserveBytes > 0 || z.piggybackCompaction
+	// Maintenance is intentionally limited to delete-containing batches, which can
+	// create empty/underfull pages. Soft-full targets (reserve bytes) and
+	// piggyback compaction should not, by themselves, force coalesce/packing work
+	// on pure-put workloads; that would add high overhead to the steady-state
+	// write path.
+	maintenance = hasDeletes
 	return maintenance, deleteCount
 }
 
@@ -283,10 +286,8 @@ func (z *Zipper) Apply(rootID uint64, b *batch.Batch) (uint64, []uint64, adaptiv
 		return rootID, nil, metrics, nil
 	}
 
-	// Underfull merge/rebalance maintenance is only beneficial when:
-	//   - the batch includes deletes (can create empty/underfull pages), or
-	//   - the caller configured soft-full targets (reserve bytes), which implies
-	//     a preference for more balanced/less churny pages even on updates.
+	// Underfull merge/rebalance maintenance is only beneficial when the batch
+	// includes deletes (can create empty/underfull pages).
 	maintenance, deleteCount := z.shouldRunMaintenance(ops)
 	var budget *maintenanceBudget
 	if maintenance && z.maintenanceOpsPerCoalesce > 0 {


### PR DESCRIPTION
This changes the zipper maintenance gate so pure-put batches no longer trigger coalesce/packing work.

Why
- Random-write workloads were paying zipper maintenance overhead (leaf packing/rebalance/piggyback work) even when the batch contains only puts.
- Soft-full reserve targets and piggyback compaction should not, by themselves, force maintenance on the steady-state write path.

What
- Factor `(*Zipper).shouldRunMaintenance` for testability.
- Change the gate to run maintenance only for delete-containing batches.
- Add unit tests covering the maintenance gate behavior.

Notes
- Piggyback compaction and reserve settings no longer force maintenance for pure-put batches.

Tests
- `go test ./...`
