### PR TITLE
db: record retired pages at base commit seq (improves prune reuse cadence)

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -951,8 +951,17 @@ func (db *DB) finalizeCommit(newRootID uint64, sysRootID uint64, retired []uint6
 	db.meta = nextMeta
 	db.metaPageID = targetPageID
 
-	// Add retired pages to Graveyard
-	idx.graveyard.Add(nextMeta.CommitSeq, retired)
+	// Add retired pages to the graveyard.
+	//
+	// IMPORTANT: We tag pages with the *base* commit sequence they were last
+	// reachable from (the state we just applied against), not the new commit
+	// sequence. This keeps pruning semantics aligned with ReaderRegistry:
+	//   - readers pinned at baseSeq must continue to see those pages
+	//   - pages become eligible for reuse once MinPinnedSeq advances past baseSeq
+	//
+	// This also reduces index.db high-watermark growth under small KeepRecent
+	// windows by making pages eligible one commit earlier.
+	idx.graveyard.Add(nextMeta.CommitSeq-1, retired)
 
 	// Prune asynchronously to keep commit latency stable under churn.
 	// If background pruning is disabled, fall back to legacy on-commit pruning.

--- a/TreeDB/db/graveyard_retire_seq_test.go
+++ b/TreeDB/db/graveyard_retire_seq_test.go
@@ -1,0 +1,100 @@
+package db
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+)
+
+func TestPruneReclaimsRetiredPagesAfterKeepRecentWindow(t *testing.T) {
+	dir := t.TempDir()
+
+	d, err := Open(Options{
+		Dir:                    dir,
+		Durability:             DurabilityWALOffRelaxed,
+		KeepRecent:             1,
+		DisableBackgroundPrune: true, // deterministic: prune on commit path
+		PreferAppendAlloc:      true, // keep freed pages visible in the freelist
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	// Insert enough keys to ensure multiple pages are created/retired across commits.
+	val1 := bytes.Repeat([]byte("a"), 32)
+	val2 := bytes.Repeat([]byte("b"), 32)
+
+	const keys = 5000
+
+	commit := func(val []byte) {
+		b := d.NewBatch().(*Batch)
+		for i := 0; i < keys; i++ {
+			var k [8]byte
+			k[0] = byte(i >> 24)
+			k[1] = byte(i >> 16)
+			k[2] = byte(i >> 8)
+			k[3] = byte(i)
+			if err := b.Set(k[:], val); err != nil {
+				t.Fatalf("set: %v", err)
+			}
+		}
+		if err := b.Write(); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_ = b.Close()
+	}
+
+	commit(val1) // seq 1
+
+	commit(val2) // seq 2; retires pages last reachable at seq 1
+
+	rep2, err := d.FragmentationReport()
+	if err != nil {
+		t.Fatalf("FragmentationReport(seq2): %v", err)
+	}
+	freeIDs2 := uint64(0)
+	if v := rep2["treedb.freelist.free_ids"]; v != "" {
+		parsed, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			t.Fatalf("parse freelist.free_ids(seq2): %v", err)
+		}
+		freeIDs2 = parsed
+	}
+
+	// A third commit advances the safe history window. With KeepRecent=1 and no
+	// readers, pages retired at seq 1 should become eligible for pruning.
+	{
+		b := d.NewBatch().(*Batch)
+		var k [8]byte
+		if err := b.Set(k[:], val1); err != nil {
+			t.Fatalf("set seq3: %v", err)
+		}
+		if err := b.Write(); err != nil {
+			t.Fatalf("write seq3: %v", err)
+		}
+		_ = b.Close()
+	}
+
+	rep3, err := d.FragmentationReport()
+	if err != nil {
+		t.Fatalf("FragmentationReport(seq3): %v", err)
+	}
+	if rep3["treedb.freelist.head"] == "" {
+		t.Fatalf("missing treedb.freelist.head; rep=%v", rep3)
+	}
+	if rep3["treedb.freelist.head"] == "0" {
+		t.Fatalf("expected freelist head to be non-zero after seq3; rep=%v", rep3)
+	}
+	freeIDsStr := rep3["treedb.freelist.free_ids"]
+	if freeIDsStr == "" {
+		t.Fatalf("missing treedb.freelist.free_ids; rep=%v", rep3)
+	}
+	freeIDs3, err := strconv.ParseUint(freeIDsStr, 10, 64)
+	if err != nil {
+		t.Fatalf("parse freelist.free_ids: %v", err)
+	}
+	if freeIDs3 <= freeIDs2 {
+		t.Fatalf("expected freelist free_ids to increase after seq3 (seq1-retired pages should become reclaimable); before=%d after=%d rep2=%v rep3=%v", freeIDs2, freeIDs3, rep2, rep3)
+	}
+}


### PR DESCRIPTION
Fixes a subtle off-by-one in graveyard retirement sequencing: pages retired during a commit are last-reachable from the *base* state we applied against, so they must be tagged with the base commit seq (not the new commit seq).

Why this matters
- Aligns retire->freelist eligibility with ReaderRegistry semantics (readers pinned at baseSeq must still see those pages).
- Makes pages eligible for pruning/reuse one commit earlier under small KeepRecent windows, reducing high-watermark growth and allocator starvation under churn.

Changes
- TreeDB/db/db.go: add retired pages to graveyard with baseSeq (nextMeta.CommitSeq-1) and document the rationale.
- TreeDB/db/graveyard_retire_seq_test.go: regression test that asserts freelist free_ids increases once KeepRecent window advances.

Follow-up tracking
- Addresses https://github.com/snissn/gomap/issues/238

Test
- go test ./...
- TREEDB_STRESS=1 go test ./TreeDB/caching -run TestCachedBenchBloatVacuum,TestCachedBenchBloat_PageCountRatioVsVacuum,TestCachedSeed_BatchSizeFillShouldBeHigh
