### PR TITLE
Fix CI: ensure vlog dict training can bootstrap on single-core

### DIFF
--- a/TreeDB/cmd/vlog_dict_realdata/main.go
+++ b/TreeDB/cmd/vlog_dict_realdata/main.go
@@ -1045,7 +1045,14 @@ func ensureDictActiveBeforeSteady(db *treedb.DB, cfg benchConfig) (bool, map[str
 	// and the dict publish log may appear after steady completes (issue #116).
 
 	// Fast-path: if the dict becomes active quickly, don't perturb mode behavior.
-	if active, snap := waitForDictActivation(db, 2*time.Second); active {
+	quickWait := 2 * time.Second
+	// WAL-off defers value-log writes until a flush boundary, so waiting a long
+	// time before forcing that boundary is wasted (and can be flaky on slow CI
+	// runners). Keep a short "maybe it's already active" check for reopens.
+	if cfg.Mode == "wal_off" {
+		quickWait = 200 * time.Millisecond
+	}
+	if active, snap := waitForDictActivation(db, quickWait); active {
 		return true, snap, nil
 	}
 

--- a/TreeDB/internal/compression/trainer.go
+++ b/TreeDB/internal/compression/trainer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"runtime"
 	"runtime/debug"
 	"sync"
 	"sync/atomic"
@@ -368,9 +369,22 @@ func (t *Trainer) Collect(value []byte) {
 		}
 	}
 	if len(t.sampleCh) == cap(t.sampleCh) {
-		t.dropped.Add(1)
-		t.recordCollect(started)
-		return
+		// Best-effort backpressure: on single-core / constrained environments,
+		// a tight producer loop can fill the sample queue faster than the trainer
+		// goroutine can drain it, preventing the first dict from ever training.
+		//
+		// Yield a few times before dropping so we can bootstrap an initial profile
+		// without turning dict sampling into a blocking hot-path.
+		if !t.hasActiveProfile() {
+			for i := 0; i < 16 && len(t.sampleCh) == cap(t.sampleCh); i++ {
+				runtime.Gosched()
+			}
+		}
+		if len(t.sampleCh) == cap(t.sampleCh) {
+			t.dropped.Add(1)
+			t.recordCollect(started)
+			return
+		}
 	}
 	sample := value
 	if len(sample) > t.maxRecord {


### PR DESCRIPTION
Fixes failing CI in `TreeDB/cmd/vlog_dict_realdata` (TestWALOffCompressionActivatesDictBeforeSteady) on slow/1-core runners.

Root cause: dict trainer sample queue is small; a tight producer loop can fill it and drop most samples before the trainer goroutine drains them, so training never reaches TrainBytes and no dict is published pre-steady.

Changes:
- `TreeDB/internal/compression/trainer.go`: when the sample queue is full and we don't yet have an active profile, yield a few times before dropping.
- `TreeDB/cmd/vlog_dict_realdata/main.go`: shorten the pre-flush “quick wait” in wal_off mode (dict can't activate until a flush boundary anyway).

Validation:
- `GOMAXPROCS=1 go test ./TreeDB/cmd/vlog_dict_realdata -run TestWALOffCompressionActivatesDictBeforeSteady -count=1`
- `go test ./TreeDB/...`