### PR TITLE
TreeDB perf: gate value-log autotune timing

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -316,6 +316,16 @@ func (db *DB) walUsesValueLog() bool {
 	return false
 }
 
+func (db *DB) needsVlogAutotuneTiming() bool {
+	if db == nil {
+		return false
+	}
+	if db.valueLogAutotuneOptions.Mode != valuelog.AutotuneOff {
+		return true
+	}
+	return vlogAutotuneMetricsEnabled.Load()
+}
+
 func (db *DB) pickLane(sync bool, preferred int) (*lane, error) {
 	if db == nil || len(db.lanes) == 0 {
 		return nil, errWALUnavailable
@@ -3305,7 +3315,10 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		return nil, errWALClosed
 	default:
 	}
-	wallStart := db.valueLogAutotuneMetrics.now()
+	wallStart := time.Time{}
+	if db.needsVlogAutotuneTiming() {
+		wallStart = db.valueLogAutotuneMetrics.now()
+	}
 
 	var (
 		totalBytes int64
@@ -3558,11 +3571,13 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	if totalBytes > 0 {
 		l.vlogLiveBytes.Add(totalBytes)
 	}
-	storedForMetrics := storedPayloadBytes
-	if storedForMetrics == 0 && totalBytes > 0 {
-		storedForMetrics = int(totalBytes)
+	if !wallStart.IsZero() {
+		storedForMetrics := storedPayloadBytes
+		if storedForMetrics == 0 && totalBytes > 0 {
+			storedForMetrics = int(totalBytes)
+		}
+		db.valueLogAutotuneMetrics.observe(wallStart, rawPayloadBytes, storedForMetrics, encodeNsTotal, encodeRawBytes)
 	}
-	db.valueLogAutotuneMetrics.observe(wallStart, rawPayloadBytes, storedForMetrics, encodeNsTotal, encodeRawBytes)
 	return ptrs, nil
 }
 
@@ -3578,7 +3593,10 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 		return page.ValuePtr{}, "", errWALClosed
 	default:
 	}
-	wallStart := db.valueLogAutotuneMetrics.now()
+	wallStart := time.Time{}
+	if db.needsVlogAutotuneTiming() {
+		wallStart = db.valueLogAutotuneMetrics.now()
+	}
 
 	var (
 		totalBytes int64
@@ -3704,11 +3722,13 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 		encodeNsTotal = stats.EncodeNs
 		encodeRawBytes = stats.RawPayloadBytes
 	}
-	storedForMetrics := stats.StoredPayloadBytes
-	if storedForMetrics == 0 && totalBytes > 0 {
-		storedForMetrics = int(totalBytes)
+	if !wallStart.IsZero() {
+		storedForMetrics := stats.StoredPayloadBytes
+		if storedForMetrics == 0 && totalBytes > 0 {
+			storedForMetrics = int(totalBytes)
+		}
+		db.valueLogAutotuneMetrics.observe(wallStart, len(value), storedForMetrics, encodeNsTotal, encodeRawBytes)
 	}
-	db.valueLogAutotuneMetrics.observe(wallStart, len(value), storedForMetrics, encodeNsTotal, encodeRawBytes)
 	return ptr, retainPath, nil
 }
 

--- a/TreeDB/caching/vlog_timegate_test.go
+++ b/TreeDB/caching/vlog_timegate_test.go
@@ -1,0 +1,30 @@
+package caching
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+)
+
+func TestNeedsVlogAutotuneTiming(t *testing.T) {
+	db := &DB{}
+	prevMetricsEnabled := vlogAutotuneMetricsEnabled.Load()
+	defer vlogAutotuneMetricsEnabled.Store(prevMetricsEnabled)
+
+	db.valueLogAutotuneOptions = valuelog.AutotuneOptions{Mode: valuelog.AutotuneOff}
+	vlogAutotuneMetricsEnabled.Store(false)
+	if db.needsVlogAutotuneTiming() {
+		t.Fatalf("expected needsVlogAutotuneTiming to be false when autotune=off and metrics disabled")
+	}
+
+	vlogAutotuneMetricsEnabled.Store(true)
+	if !db.needsVlogAutotuneTiming() {
+		t.Fatalf("expected needsVlogAutotuneTiming to be true when env metrics are enabled")
+	}
+
+	vlogAutotuneMetricsEnabled.Store(false)
+	db.valueLogAutotuneOptions = valuelog.AutotuneOptions{Mode: valuelog.AutotuneMedium}
+	if !db.needsVlogAutotuneTiming() {
+		t.Fatalf("expected needsVlogAutotuneTiming to be true when autotune is enabled")
+	}
+}


### PR DESCRIPTION
## Summary
When `-treedb-force-value-pointers` is enabled and value-log compression autotune + metrics are effectively disabled, TreeDB still called `time.Now()` (via `RealClock.Now`) on every value-log append. This PR gates that timing work so it only runs when it will actually be consumed.

Closes #248.

## Changes
- Add `(*DB).needsVlogAutotuneTiming()`.
- Gate `vlogAutotuneMetrics.now()` in `appendValueLog` and `appendValueLogOne`.
- Skip metric arg prep + `observe(...)` call entirely when timing is disabled.
- Add a small unit test for the gating logic.

## Validation
- `go test ./... -count=1`
- `unified-bench` profile check:
  - With default settings (autotune off, env metrics disabled): `RealClock.Now` is absent from `pprof` hot stacks.
  - With `TREEDB_VLOG_AUTOTUNE_METRICS=1`: `RealClock.Now` appears (expected).
