### PR TITLE
TreeDB: cache value-log caps and pool ValuePtrs

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -42,6 +42,7 @@ var iteratorDebugEnabled atomic.Bool
 var valueLogEligiblePool sync.Pool // stores []int
 var valueLogRecordPool sync.Pool   // stores []valuelog.Record
 var valueLogKeyPool sync.Pool      // stores [][]byte
+var valueLogPtrPool sync.Pool      // stores []page.ValuePtr
 
 func getValueLogEligible(capacity int) []int {
 	if capacity < 0 {
@@ -112,6 +113,50 @@ func putValueLogRecords(s []valuelog.Record) {
 		return
 	}
 	valueLogRecordPool.Put(s[:0])
+}
+
+func getValueLogPtrs(n int) []page.ValuePtr {
+	if n < 0 {
+		n = 0
+	}
+	if v := valueLogPtrPool.Get(); v != nil {
+		if s, ok := v.([]page.ValuePtr); ok {
+			if cap(s) >= n {
+				return s[:n]
+			}
+		}
+	}
+	return make([]page.ValuePtr, n)
+}
+
+func getValueLogPtrsCap(capacity int) []page.ValuePtr {
+	if capacity < 0 {
+		capacity = 0
+	}
+	if v := valueLogPtrPool.Get(); v != nil {
+		if s, ok := v.([]page.ValuePtr); ok {
+			maxCap := capacity * 2
+			if maxCap < 256 {
+				maxCap = 256
+			}
+			if cap(s) >= capacity && cap(s) <= maxCap {
+				return s[:0]
+			}
+		}
+	}
+	return make([]page.ValuePtr, 0, capacity)
+}
+
+func putValueLogPtrs(s []page.ValuePtr) {
+	if s == nil {
+		return
+	}
+	clear(s)
+	// Avoid retaining huge slices in the pool.
+	if cap(s) > 1<<20 {
+		return
+	}
+	valueLogPtrPool.Put(s[:0])
 }
 
 func getValueLogKeys(capacity int) [][]byte {
@@ -515,6 +560,7 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 		return nil, err
 	}
 	if len(ptrs) != len(eligible) {
+		putValueLogPtrs(ptrs)
 		return nil, fmt.Errorf("cachingdb: deferred value-log returned %d ptrs for %d records", len(ptrs), len(eligible))
 	}
 
@@ -524,6 +570,7 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 		op.IsPtr = true
 		op.Value = nil
 	}
+	putValueLogPtrs(ptrs)
 
 	retainPath := db.currentValueLogPath(lane)
 	if retainPath != "" {
@@ -668,8 +715,10 @@ func (db *DB) flushDeferredValueLogMemtable(iter iterator.UnsafeIterator, backen
 		return err
 	}
 	if len(vlogPtrs) != len(keys) {
+		putValueLogPtrs(vlogPtrs)
 		return fmt.Errorf("cachingdb: deferred value-log returned %d ptrs for %d records", len(vlogPtrs), len(keys))
 	}
+	defer putValueLogPtrs(vlogPtrs)
 
 	for i := range keys {
 		key := keys[i]
@@ -3331,6 +3380,17 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		l.vlogMu.Unlock()
 		return nil, errWALUnavailable
 	}
+	if l.vlogCaps.writer != w {
+		l.vlogCaps = computeVlogWriterCaps(w)
+	}
+	caps := l.vlogCaps
+	policySetter := caps.keep
+	statsWriter := caps.stats
+	statsWriterInto := caps.statsInto
+	rawWriterInto := caps.rawInto
+	hasStats := statsWriter != nil
+	hasInto := statsWriterInto != nil
+	hasRawInto := rawWriterInto != nil
 	startSize := w.Size()
 
 	rawPayloadBytes := 0
@@ -3360,9 +3420,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 
 	db.valueLogDictCollectSamples(records)
 
-	if policySetter, ok := any(w).(interface {
-		SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64)
-	}); ok {
+	if policySetter != nil {
 		snap := db.valueLogAutotuneMetrics.snapshot()
 		ioNsPerStored := snap.IoNsPerStoredByte
 		encodeNsPerRaw := snap.EncodeNsPerRawByte
@@ -3400,19 +3458,6 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		k = valuelog.MaxFrameK
 	}
 
-	type frameStatsWriter interface {
-		AppendFrameWithStats(dictID uint64, dict []byte, records []valuelog.Record) ([]page.ValuePtr, valuelog.FrameStats, error)
-	}
-	type frameStatsWriterInto interface {
-		AppendFrameWithStatsInto(dictID uint64, dict []byte, records []valuelog.Record, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
-	}
-	type rawFrameBatchWriterInto interface {
-		AppendRawFramesWritevInto(records []valuelog.Record, k int, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
-	}
-	statsWriter, hasStats := w.(frameStatsWriter)
-	statsWriterInto, hasInto := w.(frameStatsWriterInto)
-	rawWriterInto, hasRawInto := w.(rawFrameBatchWriterInto)
-
 	storedPayloadBytes := 0
 	rawFrameBytes := 0
 	frameRecords := 0
@@ -3423,10 +3468,12 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	encodeRawBytes := 0
 	rawBatchUsed := false
 	if dictID == 0 && hasRawInto && len(records) > 1 {
-		ptrs = make([]page.ValuePtr, len(records))
+		ptrs = getValueLogPtrs(len(records))
 		_, stats, batchErr := rawWriterInto.AppendRawFramesWritevInto(records, k, ptrs)
 		if batchErr != nil {
 			err = batchErr
+			putValueLogPtrs(ptrs)
+			ptrs = nil
 		} else {
 			rawFrameBytes = stats.RawPayloadBytes
 			storedPayloadBytes = stats.StoredPayloadBytes
@@ -3437,9 +3484,8 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			}
 		}
 	} else {
-		ptrs = make([]page.ValuePtr, 0, len(records))
+		ptrs = getValueLogPtrs(len(records))
 	}
-	var framePtrScratch [valuelog.MaxFrameK]page.ValuePtr
 	if err == nil && !rawBatchUsed {
 		for i := 0; i < len(records); i += k {
 			if i > 0 && i%4096 == 0 {
@@ -3449,10 +3495,17 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				w = l.vlog
 				if w == nil {
 					l.vlogMu.Unlock()
+					putValueLogPtrs(ptrs)
 					return nil, errWALUnavailable
 				}
-				statsWriter, _ = w.(frameStatsWriter)
-				statsWriterInto, _ = w.(frameStatsWriterInto)
+				if l.vlogCaps.writer != w {
+					l.vlogCaps = computeVlogWriterCaps(w)
+				}
+				caps = l.vlogCaps
+				statsWriter = caps.stats
+				statsWriterInto = caps.statsInto
+				hasStats = statsWriter != nil
+				hasInto = statsWriterInto != nil
 			}
 
 			end := i + k
@@ -3460,13 +3513,12 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				end = len(records)
 			}
 			if hasInto {
-				scratch := framePtrScratch[:end-i]
-				framePtrs, stats, frameErr := statsWriterInto.AppendFrameWithStatsInto(dictID, dict, records[i:end], scratch)
+				dst := ptrs[i:end]
+				_, stats, frameErr := statsWriterInto.AppendFrameWithStatsInto(dictID, dict, records[i:end], dst)
 				if frameErr != nil {
 					err = frameErr
 					break
 				}
-				ptrs = append(ptrs, framePtrs...)
 				rawFrameBytes += stats.RawPayloadBytes
 				storedPayloadBytes += stats.StoredPayloadBytes
 				frameRecords += stats.Records
@@ -3489,7 +3541,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 					err = frameErr
 					break
 				}
-				ptrs = append(ptrs, framePtrs...)
+				copy(ptrs[i:end], framePtrs)
 				rawFrameBytes += stats.RawPayloadBytes
 				storedPayloadBytes += stats.StoredPayloadBytes
 				frameRecords += stats.Records
@@ -3512,7 +3564,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				err = frameErr
 				break
 			}
-			ptrs = append(ptrs, framePtrs...)
+			copy(ptrs[i:end], framePtrs)
 			framesTotal++
 		}
 	}
@@ -3536,6 +3588,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	}
 	l.vlogMu.Unlock()
 	if err != nil {
+		putValueLogPtrs(ptrs)
 		return nil, err
 	}
 	if framesTotal > 0 {
@@ -3609,6 +3662,13 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 		l.vlogMu.Unlock()
 		return page.ValuePtr{}, "", errWALUnavailable
 	}
+	if l.vlogCaps.writer != w {
+		l.vlogCaps = computeVlogWriterCaps(w)
+	}
+	caps := l.vlogCaps
+	policySetter := caps.keep
+	statsWriter := caps.stats
+	statsWriterInto := caps.statsInto
 	startSize := w.Size()
 
 	attemptCompression, probeCompression, _ := db.valueLogDictShouldAttemptCompression(len(value))
@@ -3630,9 +3690,7 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 	}
 	db.valueLogDictCollectSample(value)
 
-	if policySetter, ok := any(w).(interface {
-		SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64)
-	}); ok {
+	if policySetter != nil {
 		snap := db.valueLogAutotuneMetrics.snapshot()
 		ioNsPerStored := snap.IoNsPerStoredByte
 		encodeNsPerRaw := snap.EncodeNsPerRawByte
@@ -3654,14 +3712,10 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 		rec[0] = valuelog.Record{RID: rid, Value: value}
 		var ptrs []page.ValuePtr
 		var frameErr error
-		if wStats, ok := any(w).(interface {
-			AppendFrameWithStatsInto(dictID uint64, dict []byte, records []valuelog.Record, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
-		}); ok {
-			ptrs, stats, frameErr = wStats.AppendFrameWithStatsInto(dictID, dict, rec[:], ptrScratch[:])
-		} else if wStats, ok := any(w).(interface {
-			AppendFrameWithStats(dictID uint64, dict []byte, records []valuelog.Record) ([]page.ValuePtr, valuelog.FrameStats, error)
-		}); ok {
-			ptrs, stats, frameErr = wStats.AppendFrameWithStats(dictID, dict, rec[:])
+		if statsWriterInto != nil {
+			ptrs, stats, frameErr = statsWriterInto.AppendFrameWithStatsInto(dictID, dict, rec[:], ptrScratch[:])
+		} else if statsWriter != nil {
+			ptrs, stats, frameErr = statsWriter.AppendFrameWithStats(dictID, dict, rec[:])
 		} else {
 			ptrs, frameErr = w.AppendFrame(dictID, dict, rec[:])
 		}
@@ -4427,6 +4481,7 @@ func (db *DB) Close() error {
 		if l.vlog != nil {
 			_ = l.vlog.Close()
 			l.vlog = nil
+			l.vlogCaps = vlogWriterCaps{}
 			l.vlogLiveBytes.Store(0)
 		}
 		l.vlogMu.Unlock()
@@ -5595,6 +5650,7 @@ func (db *DB) cleanupLaneWALWriters(l *lane) {
 	if l.vlog != nil {
 		_ = l.vlog.Close()
 		l.vlog = nil
+		l.vlogCaps = vlogWriterCaps{}
 	}
 	l.vlogMu.Unlock()
 }
@@ -8495,6 +8551,7 @@ func (b *Batch) writeRegular(sync bool) error {
 		} else if debugPtr && eligibleCount > 0 {
 			b.db.debugPtrNoPtr.Add(int64(eligibleCount))
 		}
+		putValueLogPtrs(ptrs)
 	}
 
 	if !b.db.disableJournal {

--- a/TreeDB/caching/lane.go
+++ b/TreeDB/caching/lane.go
@@ -27,6 +27,7 @@ type lane struct {
 	vlogPath         string
 	vlogSeq          int
 	vlogRetainedPath string
+	vlogCaps         vlogWriterCaps
 	vlogMu           sync.Mutex
 	vlogLiveBytes    atomic.Int64
 	vlogClosedBytes  atomic.Int64

--- a/TreeDB/caching/vlog_append_allocs_bench_test.go
+++ b/TreeDB/caching/vlog_append_allocs_bench_test.go
@@ -1,0 +1,48 @@
+package caching
+
+import (
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+)
+
+func BenchmarkAppendValueLogAllocs(b *testing.B) {
+	clock := valuelog.NewVirtualClock(time.Unix(0, 0))
+	sink := &valuelog.VirtualSink{Clock: clock}
+	fileID, _ := valuelog.EncodeFileID(0, 1)
+	writer := valuelog.NewWriterWithSink(sink, fileID)
+	// Avoid encode sampling overhead; this benchmark focuses on caching-layer allocs.
+	writer.SetEncodeSampleStride(0)
+
+	db := &DB{
+		closeCh: make(chan struct{}),
+		valueLogAutotuneOptions: valuelog.AutotuneOptions{
+			Mode: valuelog.AutotuneOff,
+		},
+		lanes: []lane{{id: 0, vlog: writer}},
+	}
+
+	records := make([]valuelog.Record, 1000)
+	value := make([]byte, 128)
+	for i := range records {
+		records[i] = valuelog.Record{RID: uint64(i + 1), Value: value}
+	}
+
+	// Warm the pools and writer scratch.
+	ptrs, err := db.appendValueLog(&db.lanes[0], 0, nil, records, journalDurabilityNone)
+	if err != nil {
+		b.Fatalf("appendValueLog warmup: %v", err)
+	}
+	putValueLogPtrs(ptrs)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ptrs, err := db.appendValueLog(&db.lanes[0], 0, nil, records, journalDurabilityNone)
+		if err != nil {
+			b.Fatalf("appendValueLog: %v", err)
+		}
+		putValueLogPtrs(ptrs)
+	}
+}

--- a/TreeDB/caching/vlog_autotune_bench.go
+++ b/TreeDB/caching/vlog_autotune_bench.go
@@ -374,10 +374,11 @@ func warmupDictTrainer(db *DB, writer *benchValueWriter, sink *valuelog.VirtualS
 		records = append(records, valuelog.Record{RID: rid, Value: values[i]})
 		rid++
 		if len(records) == cap(records) || i == len(values)-1 {
-			_, err := db.appendValueLog(lane, 0, nil, records, journalDurabilityNone)
+			ptrs, err := db.appendValueLog(lane, 0, nil, records, journalDurabilityNone)
 			if err != nil {
 				return err
 			}
+			putValueLogPtrs(ptrs)
 			records = records[:0]
 		}
 	}
@@ -445,9 +446,11 @@ func runBenchSegment(db *DB, writer *benchValueWriter, sink *valuelog.VirtualSin
 					dictID = id
 				}
 			}
-			if _, err := db.appendValueLog(lane, dictID, nil, batch, journalDurabilityNone); err != nil {
+			ptrs, err := db.appendValueLog(lane, dictID, nil, batch, journalDurabilityNone)
+			if err != nil {
 				return VlogAutotuneBenchSegmentResult{}, err
 			}
+			putValueLogPtrs(ptrs)
 			db.applyValueLogDictProfile()
 			batch = batch[:0]
 		}

--- a/TreeDB/caching/vlog_writer_caps.go
+++ b/TreeDB/caching/vlog_writer_caps.go
@@ -1,0 +1,51 @@
+package caching
+
+import (
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type keepPolicySetter interface {
+	SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64)
+}
+
+type frameStatsWriter interface {
+	AppendFrameWithStats(dictID uint64, dict []byte, records []valuelog.Record) ([]page.ValuePtr, valuelog.FrameStats, error)
+}
+
+type frameStatsWriterInto interface {
+	AppendFrameWithStatsInto(dictID uint64, dict []byte, records []valuelog.Record, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
+}
+
+type rawFrameBatchWriterInto interface {
+	AppendRawFramesWritevInto(records []valuelog.Record, k int, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
+}
+
+type vlogWriterCaps struct {
+	writer    valueWriter
+	keep      keepPolicySetter
+	stats     frameStatsWriter
+	statsInto frameStatsWriterInto
+	rawInto   rawFrameBatchWriterInto
+}
+
+func computeVlogWriterCaps(w valueWriter) vlogWriterCaps {
+	var caps vlogWriterCaps
+	if w == nil {
+		return caps
+	}
+	caps.writer = w
+	if v, ok := any(w).(keepPolicySetter); ok {
+		caps.keep = v
+	}
+	if v, ok := any(w).(frameStatsWriter); ok {
+		caps.stats = v
+	}
+	if v, ok := any(w).(frameStatsWriterInto); ok {
+		caps.statsInto = v
+	}
+	if v, ok := any(w).(rawFrameBatchWriterInto); ok {
+		caps.rawInto = v
+	}
+	return caps
+}


### PR DESCRIPTION
Fixes #249.

## What changed
- Cache value-log writer capability checks per lane (avoid per-append interface assertions).
- Pool and reuse `[]page.ValuePtr` backing arrays for the value-log append hot path.

## Benchmarks
`./bin/unified-bench -test batch_write,random_write,batch_delete -dbs treedb -profile fast -keys 4000000 -format markdown -treedb-force-value-pointers`

- `main`: Batch Write 2,494,571 | Random Write 2,295,215 | Batch Delete 2,200,100
- This PR: Batch Write 2,534,574 | Random Write 2,329,158 | Batch Delete 2,321,803

## Microbench
`go test ./TreeDB/caching -run '^$' -bench BenchmarkAppendValueLogAllocs -benchmem -count=1`

- 24 B/op, 1 allocs/op
