### PR TITLE
TreeDB: fix grouped ValuePtr sub-index + tune vlog k for force pointers

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3447,6 +3447,9 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			k = cur
 		} else {
 			k = 8
+			if db.disableJournal && db.forceValueLogPointers {
+				k = 16
+			}
 		}
 	}
 	k = db.clampValueLogDictK(k)

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -220,6 +221,52 @@ func TestReadAtGroupedFastPathWithoutChecksum(t *testing.T) {
 		}
 		if string(gotLegacy) != expect[i] {
 			t.Fatalf("legacy ptr%d mismatch: got %q want %q", i+1, gotLegacy, expect[i])
+		}
+	}
+}
+
+func TestReadAtGroupedFastPathSubIndexRange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-000001.log")
+
+	writer, err := NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+
+	records := make([]Record, MaxFrameK)
+	expect := make([]string, len(records))
+	for i := range records {
+		expect[i] = fmt.Sprintf("val-%02d", i)
+		records[i] = Record{RID: uint64(i + 1), Value: []byte(expect[i])}
+	}
+
+	ptrs, err := writer.AppendFrame(0, nil, records)
+	if err != nil {
+		_ = writer.Close()
+		t.Fatalf("append: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if len(ptrs) != len(records) {
+		t.Fatalf("expected %d ptrs, got %d", len(records), len(ptrs))
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	for i, ptr := range ptrs {
+		got, err := ReadAtWithDict(f, ptr, false, nil)
+		if err != nil {
+			t.Fatalf("read at ptr%d: %v", i+1, err)
+		}
+		if string(got) != expect[i] {
+			t.Fatalf("ptr%d mismatch: got %q want %q", i+1, string(got), expect[i])
 		}
 	}
 }

--- a/TreeDB/page/value_ptr_flags.go
+++ b/TreeDB/page/value_ptr_flags.go
@@ -4,7 +4,7 @@ const (
 	valuePtrCompressedMask uint32 = 0x80000000
 	valuePtrGroupedMask    uint32 = 0x40000000
 
-	valuePtrSubIndexMask  uint32 = 0x1c000000
+	valuePtrSubIndexMask  uint32 = 0x3c000000
 	valuePtrSubIndexShift        = 26
 )
 
@@ -15,6 +15,11 @@ func ValuePtrRecordLength(ptr ValuePtr) uint32 {
 
 // ValuePtrIsCompressed reports whether the pointer references a compressed value.
 func ValuePtrIsCompressed(ptr ValuePtr) bool {
+	// The value-log record header encodes compression; this bit is currently used
+	// to extend the grouped sub-index range.
+	if ValuePtrIsGrouped(ptr) {
+		return false
+	}
 	return ptr.Length&valuePtrCompressedMask != 0
 }
 
@@ -28,7 +33,11 @@ func ValuePtrSubIndex(ptr ValuePtr) uint8 {
 	if !ValuePtrIsGrouped(ptr) {
 		return 0
 	}
-	return uint8((ptr.Length & valuePtrSubIndexMask) >> valuePtrSubIndexShift)
+	idx := uint8((ptr.Length & valuePtrSubIndexMask) >> valuePtrSubIndexShift)
+	if ptr.Length&valuePtrCompressedMask != 0 {
+		idx |= 0x10
+	}
+	return idx
 }
 
 // ValuePtrMarkCompressed sets the compression flag on a record length.
@@ -36,9 +45,13 @@ func ValuePtrMarkCompressed(length uint32) uint32 {
 	return length | valuePtrCompressedMask
 }
 
-// ValuePtrMarkGrouped sets the grouped flag and sub-index (0-7) on a record length.
+// ValuePtrMarkGrouped sets the grouped flag and sub-index (0-31) on a record length.
 func ValuePtrMarkGrouped(length uint32, subIndex uint8) uint32 {
-	idx := uint32(subIndex & 0x7)
-	length &^= valuePtrSubIndexMask
-	return length | valuePtrGroupedMask | (idx << valuePtrSubIndexShift)
+	idx := uint32(subIndex & 0xf)
+	length &^= (valuePtrSubIndexMask | valuePtrCompressedMask)
+	out := length | valuePtrGroupedMask | (idx << valuePtrSubIndexShift)
+	if subIndex&0x10 != 0 {
+		out |= valuePtrCompressedMask
+	}
+	return out
 }


### PR DESCRIPTION
Fixes #250.

## What changed
- **Correctness:** extend `page.ValuePtr` grouped sub-index to cover the full `valuelog.MaxFrameK` range (0-31) so `k>8` grouped frames don’t alias pointers.
- **Tests:** add a fast-path test that writes a grouped frame with `k=MaxFrameK` and verifies every pointer reads the correct value.
- **Perf/tuning:** for `-profile fast` (WAL off) + `-treedb-force-value-pointers`, use a slightly larger default raw-frame group size (`k=16` instead of 8) when dict compression isn’t being used.

## Benchmark (single run, macOS)
Command:
`./bin/unified-bench -test batch_write,random_write,batch_delete -dbs treedb -profile fast -keys 4000000 -format markdown -treedb-force-value-pointers`

- `main`: Batch Write 2,255,874 | Random Write 1,936,172 | Batch Delete 1,852,636
- This PR: Batch Write 2,219,135 | Random Write 2,031,330 | Batch Delete 1,872,004
