### PR TITLE
TreeDB: avoid ptr-bytes encode/decode in HashSorted memtable

### DIFF
--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -240,7 +240,11 @@ func (m *HashSorted) PutWithCallback(key, value []byte, cb func(k, v []byte) err
 	if ent, ok := m.items[keyLookup]; ok {
 		valCopy := m.encodeEntryValueLocked(value, page.ValuePtr{}, node.FlagInline, false)
 		if cb != nil {
-			if err := cb(key, valCopy); err != nil {
+			keyView := key
+			if len(key) > 0 {
+				keyView = m.arena.copyBytes(key)
+			}
+			if err := cb(keyView, valCopy); err != nil {
 				m.mu.Unlock()
 				return err
 			}
@@ -296,7 +300,11 @@ func (m *HashSorted) DeleteWithCallback(key []byte, cb func(k, v []byte) error) 
 	keyLookup := bytesToStringNoCopy(key)
 	if ent, ok := m.items[keyLookup]; ok {
 		if cb != nil {
-			if err := cb(key, nil); err != nil {
+			keyView := key
+			if len(key) > 0 {
+				keyView = m.arena.copyBytes(key)
+			}
+			if err := cb(keyView, nil); err != nil {
 				m.mu.Unlock()
 				return err
 			}


### PR DESCRIPTION
Fixes #252.

## What changed
- HashSorted memtable no longer stores `page.ValuePtr` as a 16B encoded prefix inside `entry.value`.
- Pointer entries store the `ValuePtr` directly in the entry struct (`entry.ptr`), and `entry.value` now contains only *inline* bytes (if any).
- `GetEntry` / iterator `UnsafeEntry` returns the stored ptr directly (no `DecodeValuePtr`).
- `Size()` accounting preserves prior behavior by counting `page.ValuePtrSize` for pointer entries (even though those bytes are no longer stored in the arena).

## Why
Forced-pointer workloads turn the memtable into a “pointer map”. Avoiding per-entry encode/decode + 16B arena allocations reduces write-path CPU + mem pressure.

## Notes
- `PutWithCallback` / `DeleteWithCallback` keep callback key views in the HashSorted arena when `cb != nil`.

## Perf (local, noisy)
Alternating runs (`-profile fast`, `-treedb-force-value-pointers`, `-keys 2,000,000`) showed median:
- `batch_write`: +6.3%
- `random_write`: +7.9%

