### PR TITLE
TreeDB: template perf guardrails + move encode out of vlogMu

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -855,7 +855,7 @@ func (db *DB) valueLogTemplateEncodeRecords(records []valuelog.Record) ([]valuel
 	encoded := records
 	used := false
 	for i := range records {
-		payload, ok := engine.Encode(context.Background(), records[i].Value, store)
+		payload, ok := engine.Encode(nil, records[i].Value, store)
 		if ok {
 			if !used {
 				encoded = make([]valuelog.Record, len(records))
@@ -3460,24 +3460,6 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		ptrs       []page.ValuePtr
 		err        error
 	)
-	l.vlogMu.Lock()
-	w := l.vlog
-	if w == nil {
-		l.vlogMu.Unlock()
-		return nil, errWALUnavailable
-	}
-	if l.vlogCaps.writer != w {
-		l.vlogCaps = computeVlogWriterCaps(w)
-	}
-	caps := l.vlogCaps
-	policySetter := caps.keep
-	statsWriter := caps.stats
-	statsWriterInto := caps.statsInto
-	rawWriterInto := caps.rawInto
-	hasStats := statsWriter != nil
-	hasInto := statsWriterInto != nil
-	hasRawInto := rawWriterInto != nil
-	startSize := w.Size()
 
 	rawPayloadBytes := 0
 	for i := range records {
@@ -3517,6 +3499,25 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		records, _ = db.valueLogTemplateEncodeRecords(records)
 	}
 	db.valueLogDictCollectSamples(records)
+
+	l.vlogMu.Lock()
+	w := l.vlog
+	if w == nil {
+		l.vlogMu.Unlock()
+		return nil, errWALUnavailable
+	}
+	if l.vlogCaps.writer != w {
+		l.vlogCaps = computeVlogWriterCaps(w)
+	}
+	caps := l.vlogCaps
+	policySetter := caps.keep
+	statsWriter := caps.stats
+	statsWriterInto := caps.statsInto
+	rawWriterInto := caps.rawInto
+	hasStats := statsWriter != nil
+	hasInto := statsWriterInto != nil
+	hasRawInto := rawWriterInto != nil
+	startSize := w.Size()
 
 	if policySetter != nil {
 		snap := db.valueLogAutotuneMetrics.snapshot()
@@ -3757,20 +3758,6 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 		ptr        page.ValuePtr
 		err        error
 	)
-	l.vlogMu.Lock()
-	w := l.vlog
-	if w == nil {
-		l.vlogMu.Unlock()
-		return page.ValuePtr{}, "", errWALUnavailable
-	}
-	if l.vlogCaps.writer != w {
-		l.vlogCaps = computeVlogWriterCaps(w)
-	}
-	caps := l.vlogCaps
-	policySetter := caps.keep
-	statsWriter := caps.stats
-	statsWriterInto := caps.statsInto
-	startSize := w.Size()
 
 	attemptCompression, probeCompression, _ := db.valueLogDictShouldAttemptCompression(len(value))
 	templatePrepass := false
@@ -3801,10 +3788,25 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 	db.valueLogDictCollectSample(value)
 
 	if (dictID == 0 || templatePrepass) && db.templateCompressionEnabled() {
-		if payload, ok := db.valueLogTemplateEngine.Encode(context.Background(), value, db.templateStore); ok {
+		if payload, ok := db.valueLogTemplateEngine.Encode(nil, value, db.templateStore); ok {
 			value = payload
 		}
 	}
+
+	l.vlogMu.Lock()
+	w := l.vlog
+	if w == nil {
+		l.vlogMu.Unlock()
+		return page.ValuePtr{}, "", errWALUnavailable
+	}
+	if l.vlogCaps.writer != w {
+		l.vlogCaps = computeVlogWriterCaps(w)
+	}
+	caps := l.vlogCaps
+	policySetter := caps.keep
+	statsWriter := caps.stats
+	statsWriterInto := caps.statsInto
+	startSize := w.Size()
 
 	if policySetter != nil {
 		snap := db.valueLogAutotuneMetrics.snapshot()

--- a/TreeDB/template/config.go
+++ b/TreeDB/template/config.go
@@ -30,6 +30,15 @@ type Config struct {
 	FastPathMinHits       int
 	FastPathSavingsSlack  int
 	FastPathMaxMisses     int
+	// ColdSearchAfter controls when Encode enters a "cold" mode after a long
+	// stretch of non-kept values. In cold mode, Encode skips expensive candidate
+	// lookup/matching for most values and only probes periodically.
+	//
+	// Values <= 0 use a default.
+	ColdSearchAfter int
+	// ColdSearchProbeEvery controls how often Encode probes candidates while in
+	// cold mode (every N values). Values <= 0 use a default.
+	ColdSearchProbeEvery int
 
 	// Training / publishing bounds.
 	MaxBuckets                   int
@@ -136,6 +145,12 @@ func NormalizeConfig(cfg Config) Config {
 	}
 	if cfg.FastPathMaxMisses <= 0 {
 		cfg.FastPathMaxMisses = 2
+	}
+	if cfg.ColdSearchAfter <= 0 {
+		cfg.ColdSearchAfter = 256
+	}
+	if cfg.ColdSearchProbeEvery <= 0 {
+		cfg.ColdSearchProbeEvery = 256
 	}
 	if cfg.MaxBuckets <= 0 {
 		cfg.MaxBuckets = 256

--- a/TreeDB/template/engine.go
+++ b/TreeDB/template/engine.go
@@ -20,6 +20,8 @@ type Engine struct {
 	bucketSeq      uint64
 	totalTemplates int
 	trainSeq       atomic.Uint64
+	encodeSeq      atomic.Uint64
+	lastKeepSeq    atomic.Uint64
 	defCache       *defCache
 	recentMu       sync.Mutex
 	recent         []recentTemplate
@@ -47,6 +49,12 @@ type anchorCand struct {
 	start     int
 }
 
+type candScore struct {
+	id    uint64
+	size  int
+	score int
+}
+
 type recentTemplate struct {
 	id         uint64
 	def        TemplateDef
@@ -61,6 +69,83 @@ type defCache struct {
 	ids  []uint64
 	next int
 	defs map[uint64]TemplateDef
+}
+
+var (
+	candScoreMapPool   sync.Pool // map[uint64]candScore
+	candScoreSlicePool sync.Pool // []candScore
+	recentSlicePool    sync.Pool // []recentTemplate
+)
+
+func getCandScoreMap() map[uint64]candScore {
+	if v := candScoreMapPool.Get(); v != nil {
+		if m, ok := v.(map[uint64]candScore); ok {
+			return m
+		}
+	}
+	return make(map[uint64]candScore)
+}
+
+func putCandScoreMap(m map[uint64]candScore) {
+	if m == nil {
+		return
+	}
+	if len(m) > 4096 {
+		return
+	}
+	for k := range m {
+		delete(m, k)
+	}
+	candScoreMapPool.Put(m)
+}
+
+func getCandScores(capacity int) []candScore {
+	if capacity < 0 {
+		capacity = 0
+	}
+	if v := candScoreSlicePool.Get(); v != nil {
+		if s, ok := v.([]candScore); ok {
+			if cap(s) >= capacity && cap(s) <= capacity*2+32 {
+				return s[:0]
+			}
+		}
+	}
+	return make([]candScore, 0, capacity)
+}
+
+func putCandScores(s []candScore) {
+	if s == nil {
+		return
+	}
+	if cap(s) > 4096 {
+		return
+	}
+	candScoreSlicePool.Put(s[:0])
+}
+
+func getRecentSnapshot(capacity int) []recentTemplate {
+	if capacity < 0 {
+		capacity = 0
+	}
+	if v := recentSlicePool.Get(); v != nil {
+		if s, ok := v.([]recentTemplate); ok {
+			if cap(s) >= capacity && cap(s) <= capacity*2+32 {
+				return s[:0]
+			}
+		}
+	}
+	return make([]recentTemplate, 0, capacity)
+}
+
+func putRecentSnapshot(s []recentTemplate) {
+	if s == nil {
+		return
+	}
+	if cap(s) > 1024 {
+		return
+	}
+	clear(s)
+	recentSlicePool.Put(s[:0])
 }
 
 func newDefCache(size int) *defCache {
@@ -154,24 +239,35 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 		e.observeTraining(value, store)
 		return value, false
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	seq := e.encodeSeq.Add(1)
 	e.stats.Attempted.Add(1)
 	if payload, ok := e.tryRecentTemplates(value); ok {
+		e.lastKeepSeq.Store(seq)
 		e.observeTraining(value, store)
 		return payload, true
+	}
+	lastKeepSeq := e.lastKeepSeq.Load()
+	missStreak := seq - lastKeepSeq
+	if missStreak > uint64(cfg.ColdSearchAfter) {
+		probeEvery := uint64(cfg.ColdSearchProbeEvery)
+		if probeEvery == 0 {
+			probeEvery = 1
+		}
+		if seq%probeEvery != 0 {
+			e.stats.addReason(reasonSkipCold)
+			e.observeTraining(value, store)
+			return value, false
+		}
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	maxFPReads := cfg.MaxFPReads
 	if maxFPReads <= 0 || maxFPReads > len(fps) {
 		maxFPReads = len(fps)
 	}
-	type candScore struct {
-		id    uint64
-		size  int
-		score int
-	}
-	candMap := make(map[uint64]*candScore)
+	candMap := getCandScoreMap()
+	defer putCandScoreMap(candMap)
 	for i := 0; i < maxFPReads; i++ {
 		fp := fps[i]
 		e.stats.CandidateFPReads.Add(1)
@@ -181,15 +277,15 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 			continue
 		}
 		for _, c := range cands {
-			cs := candMap[c.ID]
-			if cs == nil {
-				cs = &candScore{id: c.ID, size: c.Size}
-				candMap[c.ID] = cs
+			cs, ok := candMap[c.ID]
+			if !ok {
+				cs = candScore{id: c.ID, size: c.Size}
 			}
 			cs.score++
 			if c.Size > 0 && (cs.size == 0 || c.Size < cs.size) {
 				cs.size = c.Size
 			}
+			candMap[c.ID] = cs
 		}
 	}
 	if len(candMap) == 0 {
@@ -197,7 +293,8 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 		e.observeTraining(value, store)
 		return value, false
 	}
-	candidates := make([]*candScore, 0, len(candMap))
+	candidates := getCandScores(len(candMap))
+	defer putCandScores(candidates)
 	for _, c := range candMap {
 		candidates = append(candidates, c)
 	}
@@ -331,9 +428,11 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 			if len(payload) == 0 {
 				return value, false
 			}
+			e.lastKeepSeq.Store(seq)
 			e.recordRecent(bestMaskDef, bestMaskID)
 			return payload, true
 		}
+		e.lastKeepSeq.Store(seq)
 		e.recordRecent(bestAnchorDef, bestAnchorID)
 		return bestPayload, true
 	}
@@ -346,13 +445,16 @@ func (e *Engine) tryRecentTemplates(value []byte) ([]byte, bool) {
 		return nil, false
 	}
 	e.recentMu.Lock()
-	if len(e.recent) == 0 {
+	n := len(e.recent)
+	if n == 0 {
 		e.recentMu.Unlock()
 		return nil, false
 	}
-	snapshot := make([]recentTemplate, len(e.recent))
+	snapshot := getRecentSnapshot(n)
+	snapshot = snapshot[:n]
 	copy(snapshot, e.recent)
 	e.recentMu.Unlock()
+	defer putRecentSnapshot(snapshot)
 	max := cfg.RecentTemplates
 	if max > len(snapshot) {
 		max = len(snapshot)

--- a/TreeDB/template/engine_test.go
+++ b/TreeDB/template/engine_test.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 )
 
@@ -61,5 +62,79 @@ func TestEngineEncodeDecode(t *testing.T) {
 	}
 	if string(decoded) != string(value) {
 		t.Fatalf("decoded mismatch: %q != %q", decoded, value)
+	}
+}
+
+type countingStore struct {
+	defBytes []byte
+	id       uint64
+	cands    []Candidate
+
+	getCandidates atomic.Uint64
+	getDef        atomic.Uint64
+	putDef        atomic.Uint64
+}
+
+func (s *countingStore) GetCandidates(_ context.Context, _ uint64, _ int) ([]Candidate, error) {
+	s.getCandidates.Add(1)
+	return s.cands, nil
+}
+
+func (s *countingStore) GetTemplateDef(_ context.Context, id uint64) ([]byte, error) {
+	s.getDef.Add(1)
+	if id != s.id {
+		return nil, ErrMissingTemplate
+	}
+	return s.defBytes, nil
+}
+
+func (s *countingStore) PutTemplateDef(_ context.Context, _ []byte, _ []uint64) (uint64, error) {
+	s.putDef.Add(1)
+	return s.id, nil
+}
+
+func TestEngineColdGateLimitsCandidateLookups(t *testing.T) {
+	cfg := Config{
+		MinSavingsBytes:       1,
+		FingerprintK:          4,
+		FingerprintW:          4,
+		MaxFingerprints:       1,
+		MaxFPReads:            1,
+		MaxTemplateFetch:      1,
+		MaxCandidatesPerFP:    1,
+		MinAnchorLen:          4,
+		MaxAnchorLen:          64,
+		MaxAnchorsPerTemplate: 8,
+		MaxAnchorBytesTotal:   256,
+		MaxGaps:               16,
+		ColdSearchAfter:       4,
+		ColdSearchProbeEvery:  8,
+	}
+	def := TemplateDef{Kind: TemplateAnchors, Anchors: [][]byte{[]byte("never-match")}}
+	defBytes, err := EncodeTemplateDef(def, cfg)
+	if err != nil {
+		t.Fatalf("encode template def: %v", err)
+	}
+	store := &countingStore{
+		defBytes: defBytes,
+		id:       1,
+		cands:    []Candidate{{ID: 1, Size: len(defBytes)}},
+	}
+	engine := NewEngine(cfg)
+	value := []byte("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+
+	const iters = 100
+	for i := 0; i < iters; i++ {
+		_, ok := engine.Encode(nil, value, store)
+		if ok {
+			t.Fatalf("unexpected keep at iter=%d", i)
+		}
+	}
+
+	// Without the cold gate, we'd do a candidate lookup on every call.
+	// With ColdSearchAfter=4 and ColdSearchProbeEvery=8, we expect O(iters/8)
+	// candidate lookups after the initial warm-up.
+	if got := store.getCandidates.Load(); got > 25 {
+		t.Fatalf("candidate lookups too high: got=%d", got)
 	}
 }

--- a/TreeDB/template/stats.go
+++ b/TreeDB/template/stats.go
@@ -9,6 +9,7 @@ import (
 const (
 	reasonSkipSmall            = "tmpl_skip_small"
 	reasonSkipNoFPs            = "tmpl_skip_no_fps"
+	reasonSkipCold             = "tmpl_skip_cold"
 	reasonFPLookupErr          = "tmpl_fp_lookup_err"
 	reasonNoCandidates         = "tmpl_no_candidates"
 	reasonTemplateFetchErr     = "tmpl_template_fetch_err"

--- a/scripts/bench_template_smoke.sh
+++ b/scripts/bench_template_smoke.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Template compression smoke bench.
+#
+# Generates a deterministic JSONL dataset and runs TreeDB's realdata KV harness in
+# 4 modes: baseline/off, dict-only, template-only, and template+dict (prepass).
+#
+# Output: small markdown table with steady-state throughput and value-log size.
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+DATASET="${DATASET:-/tmp/treedb_template_smoke.jsonl}"
+REGEN="${REGEN:-0}"
+
+TRAIN_N="${TRAIN_N:-10000}"
+EVAL_N="${EVAL_N:-5000}"
+VALSIZE="${VALSIZE:-1024}"
+
+MODE="${MODE:-wal_off}"           # wal_off|wal_on
+RAW_MIB="${RAW_MIB:-64}"          # steady-state bytes written
+BATCH="${BATCH:-1024}"            # ops per batch
+KEY_MODE="${KEY_MODE:-dataset}"   # random|sequential|dataset
+POINTER_THRESHOLD="${PTR_T:-1}"   # 1 forces value-log pointers
+
+DICT_TRAIN_MIB="${DICT_TRAIN_MIB:-1}"
+DICT_WAIT_S="${DICT_WAIT_S:-10}"
+
+OUT_DIR="${OUT_DIR:-/tmp/treedb_template_smoke_out}"
+mkdir -p "$OUT_DIR"
+
+BIN="${BIN:-/tmp/vlog_dict_realdata}"
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "missing required command: $1" >&2; exit 2; }
+}
+
+need_cmd "$PYTHON_BIN"
+need_cmd go
+
+maybe_gen_dataset() {
+  local want_lines=$((TRAIN_N + EVAL_N))
+  local have_lines=0
+  if [[ -f "$DATASET" ]]; then
+    have_lines=$(wc -l <"$DATASET" | tr -d '[:space:]')
+    if [[ -z "$have_lines" ]]; then
+      have_lines=0
+    fi
+  fi
+
+  if [[ "$REGEN" != "0" || ! -f "$DATASET" || "$have_lines" -lt "$want_lines" ]]; then
+    echo "generating dataset: $DATASET (train=$TRAIN_N eval=$EVAL_N valsize=$VALSIZE)" >&2
+    "$PYTHON_BIN" - "$DATASET" "$TRAIN_N" "$EVAL_N" "$VALSIZE" <<'PY'
+import json
+import os
+import random
+import sys
+
+path = sys.argv[1]
+train_n = int(sys.argv[2])
+eval_n = int(sys.argv[3])
+valsize = int(sys.argv[4])
+
+random.seed(1)
+total = train_n + eval_n
+
+os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+with open(path, "w", encoding="utf-8") as f:
+    for i in range(total):
+        key = f"key-{i:08d}"
+        # Constant prefix/suffix + small variable middle encourages templates.
+        var = f"{random.getrandbits(64):016x}"
+        v = f"prefix|bucket={i%97:02d}|seq={i:08d}|var={var}|suffix"
+        if len(v) < valsize:
+            v = v + ("A" * (valsize - len(v)))
+        else:
+            v = v[:valsize]
+        f.write(json.dumps({"key": key, "val": v}, separators=(",", ":")) + "\n")
+PY
+  fi
+}
+
+build_bin() {
+  echo "building $BIN" >&2
+  go build -o "$BIN" ./TreeDB/cmd/vlog_dict_realdata
+}
+
+run_case() {
+  local name="$1"
+  local compression="$2" # on|off
+  local tmpl="$3"        # off|on|prepass
+
+  local out_json="$OUT_DIR/${name}.json"
+  rm -f "$out_json"
+
+  "$BIN" \
+    -input "$DATASET" \
+    -input-encoding string \
+    -train "$TRAIN_N" \
+    -eval "$EVAL_N" \
+    -cap 0 \
+    -bench-kv \
+    -bench-mode "$MODE" \
+    -bench-compression "$compression" \
+    -bench-template "$tmpl" \
+    -bench-raw-mib "$RAW_MIB" \
+    -bench-batch "$BATCH" \
+    -bench-key-mode "$KEY_MODE" \
+    -bench-pointer-threshold "$POINTER_THRESHOLD" \
+    -bench-dict-train-mib "$DICT_TRAIN_MIB" \
+    -bench-dict-wait-seconds "$DICT_WAIT_S" \
+    -bench-out-json "$out_json" \
+    >/dev/null
+
+  if [[ ! -f "$out_json" ]]; then
+    echo "bench case failed (missing json): case=$name out_json=$out_json" >&2
+    return 1
+  fi
+
+  "$PYTHON_BIN" - "$name" "$out_json" <<'PY'
+import json
+import sys
+
+name = sys.argv[1]
+path = sys.argv[2]
+with open(path, "r", encoding="utf-8") as f:
+    r = json.load(f)
+
+def get(k, default=""):
+    v = r.get(k, default)
+    return v if v is not None else default
+
+steady = get("steady_raw_MBps", 0.0)
+vlog = get("value_log_bytes", 0)
+pub = get("templates_published", 0)
+kept = get("template_kept", 0)
+
+print(f"{name}\t{steady:.2f}\t{vlog}\t{pub}\t{kept}")
+PY
+}
+
+maybe_gen_dataset
+build_bin
+
+echo "template smoke (mode=$MODE raw_mib=$RAW_MIB batch=$BATCH ptr_threshold=$POINTER_THRESHOLD)" >&2
+echo "dataset=$DATASET train=$TRAIN_N eval=$EVAL_N valsize=$VALSIZE" >&2
+
+printf "| case | steady_raw_MBps | value_log_bytes | templates_published | template_kept |\n"
+printf "|---|---:|---:|---:|---:|\n"
+
+for row in \
+  $'off\toff\toff' \
+  $'dict\ton\toff' \
+  $'template\toff\ton' \
+  $'prepass\ton\tprepass'; do
+  IFS=$'\t' read -r name compression tmpl <<<"$row"
+  if ! line=$(run_case "$name" "$compression" "$tmpl"); then
+    echo "smoke failed in case=$name (compression=$compression template=$tmpl)" >&2
+    exit 1
+  fi
+  IFS=$'\t' read -r c mbps vlog pub kept <<<"$line"
+  printf "| %s | %.2f | %s | %s | %s |\n" "$c" "$mbps" "$vlog" "$pub" "$kept"
+done
+
+echo "wrote per-case JSON under: $OUT_DIR" >&2


### PR DESCRIPTION
Implements #266 (Sprint 1).

## What changed
- Move template encoding work out of `l.vlogMu` critical sections (`appendValueLog`, `appendValueLogOne`).
- Add a "cold" early-exit gate in `template.Engine.Encode` to avoid candidate lookup + matching CPU burn when nothing is being kept.
- Reduce per-value allocs in the template hot path via small pools.
- Add a reproducible smoke harness: `scripts/bench_template_smoke.sh`.

## Perf gates (compression OFF)
Ran issue-215-style 2M + 5M gates vs `main`, with value-log dict training disabled:
- flags: `-treedb-vlog-dict-train-bytes -1 -treedb-vlog-compression-autotune off`
- tests: `batch_write,random_write,batch_delete`
- profiles: `fast` and `wal_on_fast`
- variants: inline (default) + forced value-log pointers (`-treedb-force-value-pointers`)

Summary: deltas were within expected run-to-run noise; worst regression observed was ~-7.8% (5M fast + forceptr batch_delete). Full raw logs: `/tmp/gomap_perf_issue266_2m5m/*`.

## How to reproduce
Build 2 binaries (main + this branch):
- `go build -o /tmp/ubench-main ./cmd/unified_bench`
- `go build -o /tmp/ubench-cur  ./cmd/unified_bench`

Example gate run (5M, fast, force pointers, compression off):
- `/tmp/ubench-cur -dbs treedb -profile fast -keys 5000000 -test batch_write,random_write,batch_delete -checkpoint-between-tests -progress=false -format markdown -treedb-force-value-pointers -treedb-vlog-dict-train-bytes -1 -treedb-vlog-compression-autotune off`

Template smoke table (4 modes: off/dict/template/prepass):
- `scripts/bench_template_smoke.sh`
