### PR TITLE
template: Sprint 2 encode CPU/alloc optimizations

### DIFF
--- a/TreeDB/cmd/vlog_dict_realdata/main.go
+++ b/TreeDB/cmd/vlog_dict_realdata/main.go
@@ -74,6 +74,7 @@ type benchConfig struct {
 	DictBytes         int
 	DictSampleStride  int
 	DictWaitSeconds   int
+	CPUProfileSteady  string
 	OutJSON           string
 	KeepDir           bool
 }
@@ -161,6 +162,7 @@ func main() {
 	benchTemplate := flag.String("bench-template", "off", "Bench template compression: on|off|prepass")
 	benchKeepDir := flag.Bool("bench-keep-dir", false, "Keep bench directory after run")
 	cpuProfile := flag.String("cpu-profile", "", "Write CPU profile to this file (optional)")
+	benchCPUProfile := flag.String("bench-cpu-profile", "", "Write CPU profile for steady-state phase (bench only; optional)")
 	benchRawMiB := flag.Int("bench-raw-mib", 512, "Raw MiB to write in steady-state phase")
 	benchBatch := flag.Int("bench-batch", 1024, "Number of ops per batch write")
 	benchKeyMode := flag.String("bench-key-mode", "random", "Key mode: random|sequential|dataset")
@@ -196,6 +198,9 @@ func main() {
 		if *maxEval > 0 && len(evalPairs) > *maxEval {
 			evalPairs = evalPairs[:*maxEval]
 		}
+		if *cpuProfile != "" && *benchCPUProfile != "" {
+			failf("cannot use -cpu-profile and -bench-cpu-profile together (use -bench-cpu-profile for steady-state-only profiling)")
+		}
 		if *cpuProfile != "" {
 			stop, err := startCPUProfile(*cpuProfile)
 			if err != nil {
@@ -216,6 +221,7 @@ func main() {
 			DictBytes:         *benchDictBytes,
 			DictSampleStride:  *benchDictSampleStride,
 			DictWaitSeconds:   *benchDictWaitSeconds,
+			CPUProfileSteady:  *benchCPUProfile,
 			OutJSON:           *benchOutJSON,
 			KeepDir:           *benchKeepDir,
 		}
@@ -663,8 +669,20 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 	}
 
 	targetRawBytes := int64(cfg.RawMiB) * 1024 * 1024
+	var stopCPUProfile func()
+	if cfg.CPUProfileSteady != "" {
+		stop, err := startCPUProfile(cfg.CPUProfileSteady)
+		if err != nil {
+			return nil, err
+		}
+		stopCPUProfile = stop
+	}
 	steadyStart := time.Now()
 	steadyRaw, steadyRecords, err := writeUntilRawBytes(db, eval, targetRawBytes, cfg.Batch, cfg.KeyMode, keyState)
+	if stopCPUProfile != nil {
+		stopCPUProfile()
+		stopCPUProfile = nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/template/def.go
+++ b/TreeDB/template/def.go
@@ -232,7 +232,16 @@ func DecodeTemplateDef(buf []byte) (TemplateDef, error) {
 			varPositions = buildVarPositions(mask, len(base))
 		}
 		constPositions := buildConstPositions(mask, len(base))
-		return TemplateDef{Kind: TemplateMask, Mask: mask, Base: base, VarPositions: varPositions, ConstPositions: constPositions}, nil
+		varSpans, constSpans := buildMaskSpans(mask, len(base))
+		return TemplateDef{
+			Kind:           TemplateMask,
+			Mask:           mask,
+			Base:           base,
+			VarPositions:   varPositions,
+			ConstPositions: constPositions,
+			maskVarSpans:   varSpans,
+			maskConstSpans: constSpans,
+		}, nil
 	case templateDefVerMaskV2:
 		if payloadLen < 2 {
 			return TemplateDef{}, ErrCorruptTemplateDef
@@ -271,7 +280,16 @@ func DecodeTemplateDef(buf []byte) (TemplateDef, error) {
 		base := buf[off : off+baseLen]
 		varPositions := buildVarPositions(mask, len(base))
 		constPositions := buildConstPositions(mask, len(base))
-		return TemplateDef{Kind: TemplateMask, Mask: mask, Base: base, VarPositions: varPositions, ConstPositions: constPositions}, nil
+		varSpans, constSpans := buildMaskSpans(mask, len(base))
+		return TemplateDef{
+			Kind:           TemplateMask,
+			Mask:           mask,
+			Base:           base,
+			VarPositions:   varPositions,
+			ConstPositions: constPositions,
+			maskVarSpans:   varSpans,
+			maskConstSpans: constSpans,
+		}, nil
 	default:
 		return TemplateDef{}, ErrCorruptTemplateDef
 	}

--- a/TreeDB/template/engine.go
+++ b/TreeDB/template/engine.go
@@ -225,15 +225,6 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 		e.observeTraining(value, store)
 		return value, false
 	}
-	fps := RoutingFingerprints(value, cfg)
-	if len(fps) == 0 {
-		fps = Fingerprints(value, cfg)
-	}
-	if len(fps) == 0 {
-		e.stats.addReason(reasonSkipNoFPs)
-		e.observeTraining(value, store)
-		return value, false
-	}
 	if store == nil {
 		e.stats.addReason(reasonNoCandidates)
 		e.observeTraining(value, store)
@@ -262,6 +253,16 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	var fpBuf [16]uint64
+	fps := appendRoutingFingerprints(fpBuf[:0], value, cfg)
+	if len(fps) == 0 {
+		fps = Fingerprints(value, cfg)
+	}
+	if len(fps) == 0 {
+		e.stats.addReason(reasonSkipNoFPs)
+		e.observeTraining(value, store)
+		return value, false
+	}
 	maxFPReads := cfg.MaxFPReads
 	if maxFPReads <= 0 || maxFPReads > len(fps) {
 		maxFPReads = len(fps)
@@ -289,6 +290,35 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 		}
 	}
 	if len(candMap) == 0 {
+		legacy := RoutingFingerprintsLegacy(value, cfg)
+		if len(legacy) > 0 {
+			maxReads := cfg.MaxFPReads
+			if maxReads <= 0 || maxReads > len(legacy) {
+				maxReads = len(legacy)
+			}
+			for i := 0; i < maxReads; i++ {
+				fp := legacy[i]
+				e.stats.CandidateFPReads.Add(1)
+				cands, err := store.GetCandidates(ctx, fp, cfg.MaxCandidatesPerFP)
+				if err != nil {
+					e.stats.addReason(reasonFPLookupErr)
+					continue
+				}
+				for _, c := range cands {
+					cs, ok := candMap[c.ID]
+					if !ok {
+						cs = candScore{id: c.ID, size: c.Size}
+					}
+					cs.score++
+					if c.Size > 0 && (cs.size == 0 || c.Size < cs.size) {
+						cs.size = c.Size
+					}
+					candMap[c.ID] = cs
+				}
+			}
+		}
+	}
+	if len(candMap) == 0 {
 		e.stats.addReason(reasonNoCandidates)
 		e.observeTraining(value, store)
 		return value, false
@@ -312,7 +342,6 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 		maxFetch = len(candidates)
 	}
 	bestSavings := 0
-	var bestPayload []byte
 	bestMask := false
 	var bestMaskDef TemplateDef
 	var bestMaskID uint64
@@ -357,7 +386,7 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 		e.stats.CandidateTemplatesConsidered.Add(1)
 		switch def.Kind {
 		case 0, TemplateAnchors:
-			gaps, encLen, reason, matched := matchTemplate(value, def.Anchors, cand.id, cfg)
+			encLen, reason, matched := matchTemplateLen(value, def.Anchors, cand.id, cfg)
 			if reason != "" {
 				e.stats.addReason(reason)
 			}
@@ -369,12 +398,7 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 			if savings <= bestSavings {
 				continue
 			}
-			payload, err := EncodePayload(cand.id, gaps)
-			if err != nil {
-				continue
-			}
 			bestSavings = savings
-			bestPayload = payload
 			bestMask = false
 			bestAnchorDef = def
 			bestAnchorID = cand.id
@@ -392,7 +416,6 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 				continue
 			}
 			bestSavings = savings
-			bestPayload = nil
 			bestMask = true
 			bestMaskDef = def
 			bestMaskID = cand.id
@@ -405,7 +428,7 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 	if matchedAny {
 		e.stats.Matched.Add(1)
 	}
-	keep := bestSavings >= cfg.MinSavingsBytes && (bestMask || len(bestPayload) > 0)
+	keep := bestSavings >= cfg.MinSavingsBytes && (bestMask || bestAnchorID != 0)
 	if keep {
 		e.stats.Kept.Add(1)
 		e.stats.BytesSaved.Add(uint64(bestSavings))
@@ -432,9 +455,17 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 			e.recordRecent(bestMaskDef, bestMaskID)
 			return payload, true
 		}
+		gaps, _, _, matched := matchTemplate(value, bestAnchorDef.Anchors, bestAnchorID, cfg)
+		if !matched {
+			return value, false
+		}
+		payload, err := EncodePayload(bestAnchorID, gaps)
+		if err != nil || len(payload) == 0 {
+			return value, false
+		}
 		e.lastKeepSeq.Store(seq)
 		e.recordRecent(bestAnchorDef, bestAnchorID)
-		return bestPayload, true
+		return payload, true
 	}
 	return value, false
 }
@@ -497,7 +528,7 @@ func (e *Engine) tryRecentTemplates(value []byte) ([]byte, bool) {
 			return payload, true
 		}
 		if def.Kind == 0 || def.Kind == TemplateAnchors {
-			gaps, encLen, _, matched := matchTemplate(value, def.Anchors, entry.id, cfg)
+			encLen, _, matched := matchTemplateLen(value, def.Anchors, entry.id, cfg)
 			if !matched {
 				continue
 			}
@@ -508,6 +539,11 @@ func (e *Engine) tryRecentTemplates(value []byte) ([]byte, bool) {
 			}
 			if !e.fastPathEligible(entry, savings) {
 				e.updateRecentHit(entry.id, savings)
+				continue
+			}
+			gaps, _, _, matched := matchTemplate(value, def.Anchors, entry.id, cfg)
+			if !matched {
+				e.updateRecentMiss(entry.id)
 				continue
 			}
 			payload, err := EncodePayload(entry.id, gaps)
@@ -620,15 +656,15 @@ func (e *Engine) observeTraining(value []byte, store Store) {
 	if cfg.FingerprintK <= 0 || len(value) < cfg.FingerprintK {
 		return
 	}
+	seq := e.trainSeq.Add(1)
+	if cfg.TrainSampleStride > 1 && seq%uint64(cfg.TrainSampleStride) != 0 {
+		return
+	}
 	fps := BucketFingerprints(value, cfg)
 	if len(fps) == 0 {
 		fps = Fingerprints(value, cfg)
 	}
 	if len(fps) == 0 {
-		return
-	}
-	seq := e.trainSeq.Add(1)
-	if cfg.TrainSampleStride > 1 && seq%uint64(cfg.TrainSampleStride) != 0 {
 		return
 	}
 	bucketKey := BucketKey(fps)
@@ -682,11 +718,9 @@ func (e *Engine) observeTraining(value []byte, store Store) {
 	}
 	routeFPs := RoutingFingerprints(routeValue, cfg)
 	if len(routeFPs) == 0 {
-		routeFPs = RouteFingerprints(def.Anchors, cfg)
-	}
-	if len(routeFPs) == 0 {
 		return
 	}
+	routeFPs = append(routeFPs, RoutingFingerprintsLegacy(routeValue, cfg)...)
 	if _, err := store.PutTemplateDef(context.Background(), defBytes, routeFPs); err != nil {
 		return
 	}

--- a/TreeDB/template/fingerprint.go
+++ b/TreeDB/template/fingerprint.go
@@ -66,6 +66,34 @@ func lengthFingerprint(length int) uint64 {
 	return xxh3.Hash(buf[:])
 }
 
+const (
+	routeTagLen    uint64 = 1
+	routeTagPrefix uint64 = 2
+	routeTagMid1   uint64 = 3
+	routeTagMid2   uint64 = 4
+	routeTagSuffix uint64 = 5
+)
+
+func mixRouteFP(tag uint64, h uint64) uint64 {
+	// Mix in a small tag so different segment roles don't trivially collide.
+	return h ^ (tag * 0x9e3779b97f4a7c15)
+}
+
+func appendUniqueFP(dst []uint64, fp uint64, limit int) []uint64 {
+	if fp == 0 {
+		return dst
+	}
+	for _, v := range dst {
+		if v == fp {
+			return dst
+		}
+	}
+	if limit > 0 && len(dst) >= limit {
+		return dst
+	}
+	return append(dst, fp)
+}
+
 // BucketFingerprints returns fingerprints for bucketing (prefix-only by default).
 func BucketFingerprints(value []byte, cfg Config) []uint64 {
 	cfg = NormalizeConfig(cfg)
@@ -86,9 +114,102 @@ func BucketFingerprints(value []byte, cfg Config) []uint64 {
 	return fingerprintsLimited(value[:prefixLen], cfg, cfg.RouteFPCount)
 }
 
+// AppendRoutingFingerprints appends deterministic routing fingerprints into dst.
+// It avoids winnowing and favors a few fixed segment hashes (plus length).
+func AppendRoutingFingerprints(dst []uint64, value []byte, cfg Config) []uint64 {
+	cfg = NormalizeConfig(cfg)
+	return appendRoutingFingerprints(dst, value, cfg)
+}
+
+func appendRoutingFingerprints(dst []uint64, value []byte, cfg Config) []uint64 {
+	k := cfg.FingerprintK
+	if k <= 0 || len(value) < k {
+		return dst
+	}
+	limit := cfg.RouteFPCount
+	if limit <= 0 {
+		limit = cfg.MaxFingerprints
+	}
+	if cfg.LengthBucketMinLen > 0 && len(value) >= cfg.LengthBucketMinLen {
+		// Keep the legacy length fingerprint unmodified so templates published by
+		// older versions remain discoverable.
+		dst = appendUniqueFP(dst, lengthFingerprint(len(value)), limit)
+	}
+
+	prefixLen := cfg.RoutePrefixBytes
+	if prefixLen < k {
+		prefixLen = k
+	}
+	suffixLen := cfg.RouteSuffixBytes
+	if suffixLen < k {
+		suffixLen = k
+	}
+	segLen := prefixLen
+	if segLen > len(value) {
+		segLen = len(value)
+	}
+	if segLen < k {
+		segLen = k
+	}
+	if segLen > len(value) {
+		segLen = len(value)
+	}
+	dst = appendUniqueFP(dst, mixRouteFP(routeTagPrefix, xxh3.Hash(value[:segLen])), limit)
+
+	if len(value) >= suffixLen {
+		if suffixLen > len(value) {
+			suffixLen = len(value)
+		}
+		dst = appendUniqueFP(dst, mixRouteFP(routeTagSuffix, xxh3.Hash(value[len(value)-suffixLen:])), limit)
+	}
+
+	// Add one or two middle probes to reduce collision/candidate list size while
+	// keeping routing cost O(1) per value.
+	if len(dst) < limit && segLen < len(value) {
+		start := (len(value) - segLen) / 2
+		dst = appendUniqueFP(dst, mixRouteFP(routeTagMid1, xxh3.Hash(value[start:start+segLen])), limit)
+	}
+	if len(dst) < limit && segLen < len(value) {
+		start := (len(value) - segLen) / 4
+		if start > 0 && start+segLen <= len(value) {
+			dst = appendUniqueFP(dst, mixRouteFP(routeTagMid2, xxh3.Hash(value[start:start+segLen])), limit)
+		}
+	}
+
+	return dst
+}
+
+// BucketKey computes a deterministic bucket key from fingerprints.
+func BucketKey(fps []uint64) uint64 {
+	if len(fps) == 0 {
+		return 0
+	}
+	limit := 8
+	if len(fps) < limit {
+		limit = len(fps)
+	}
+	var buf [8 * 8]byte
+	for i := 0; i < limit; i++ {
+		binary.LittleEndian.PutUint64(buf[i*8:(i+1)*8], fps[i])
+	}
+	return xxh3.Hash(buf[:limit*8])
+}
+
 // RoutingFingerprints returns fingerprints used for routing/bucketing.
-// It prefers prefix+suffix slices to avoid random middle bytes dominating.
+// Prefer AppendRoutingFingerprints to avoid allocations.
 func RoutingFingerprints(value []byte, cfg Config) []uint64 {
+	cfg = NormalizeConfig(cfg)
+	limit := cfg.RouteFPCount
+	if limit <= 0 {
+		limit = cfg.MaxFingerprints
+	}
+	out := make([]uint64, 0, limit)
+	return appendRoutingFingerprints(out, value, cfg)
+}
+
+// RoutingFingerprintsLegacy returns deterministic winnowed routing fingerprints.
+// It prefers prefix+suffix slices to avoid random middle bytes dominating.
+func RoutingFingerprintsLegacy(value []byte, cfg Config) []uint64 {
 	cfg = NormalizeConfig(cfg)
 	k := cfg.FingerprintK
 	if k <= 0 || len(value) < k {
@@ -148,22 +269,6 @@ func RoutingFingerprints(value []byte, cfg Config) []uint64 {
 		seen[fp] = struct{}{}
 	}
 	return out
-}
-
-// BucketKey computes a deterministic bucket key from fingerprints.
-func BucketKey(fps []uint64) uint64 {
-	if len(fps) == 0 {
-		return 0
-	}
-	limit := 8
-	if len(fps) < limit {
-		limit = len(fps)
-	}
-	buf := make([]byte, limit*8)
-	for i := 0; i < limit; i++ {
-		binary.LittleEndian.PutUint64(buf[i*8:(i+1)*8], fps[i])
-	}
-	return xxh3.Hash(buf)
 }
 
 // RouteFingerprints returns deterministic routing fingerprints for template anchors.

--- a/TreeDB/template/mask_spans.go
+++ b/TreeDB/template/mask_spans.go
@@ -1,0 +1,40 @@
+package template
+
+func buildMaskSpans(mask []byte, total int) (varSpans []span, constSpans []span) {
+	if total <= 0 || len(mask) == 0 {
+		return nil, nil
+	}
+	kind := -1
+	start := 0
+	for i := 0; i < total; i++ {
+		isVar := 0
+		if mask[i/8]&(1<<uint(i%8)) != 0 {
+			isVar = 1
+		}
+		if kind == -1 {
+			kind = isVar
+			start = i
+			continue
+		}
+		if isVar == kind {
+			continue
+		}
+		if start < i {
+			if kind == 1 {
+				varSpans = append(varSpans, span{start: start, end: i})
+			} else {
+				constSpans = append(constSpans, span{start: start, end: i})
+			}
+		}
+		kind = isVar
+		start = i
+	}
+	if start < total {
+		if kind == 1 {
+			varSpans = append(varSpans, span{start: start, end: total})
+		} else {
+			constSpans = append(constSpans, span{start: start, end: total})
+		}
+	}
+	return varSpans, constSpans
+}

--- a/TreeDB/template/match.go
+++ b/TreeDB/template/match.go
@@ -28,6 +28,58 @@ func encodedLen(gaps [][]byte, templateID uint64) int {
 	return length
 }
 
+func matchTemplateLen(value []byte, anchors [][]byte, templateID uint64, cfg Config) (encLen int, reason string, matched bool) {
+	rawLen := len(value)
+	gapCount := len(anchors) + 1
+	if cfg.MaxGaps > 0 && gapCount > cfg.MaxGaps {
+		return 0, reasonKeepBounds, false
+	}
+	anchorBytes := 0
+	for _, a := range anchors {
+		anchorBytes += len(a)
+	}
+	minEnc := minEncodedLen(rawLen, gapCount, anchorBytes, templateID)
+	if rawLen-minEnc < cfg.MinSavingsBytes {
+		return 0, reasonMatchExpectedSavings, false
+	}
+	if cfg.MaxDecodedBytes > 0 && rawLen > cfg.MaxDecodedBytes {
+		return 0, reasonKeepBounds, false
+	}
+
+	encLen = payloadHeader + uvarintLen(templateID) + uvarintLen(uint64(gapCount))
+	pos := 0
+	ops := 0
+	for _, a := range anchors {
+		if cfg.MaxAnchorSearchOps > 0 && ops >= cfg.MaxAnchorSearchOps {
+			return 0, reasonMatchOpsCap, false
+		}
+		idx := bytes.Index(value[pos:], a)
+		ops++
+		if idx < 0 {
+			return 0, reasonMatchMissingAnchor, false
+		}
+		start := pos + idx
+		if start < pos {
+			return 0, reasonMatchOverlap, false
+		}
+		gapLen := start - pos
+		encLen += uvarintLen(uint64(gapLen)) + gapLen
+		pos = start + len(a)
+		if pos > len(value) {
+			return 0, reasonMatchOverlap, false
+		}
+	}
+	gapLen := len(value) - pos
+	encLen += uvarintLen(uint64(gapLen)) + gapLen
+	if rawLen-encLen < cfg.MinSavingsBytes {
+		return encLen, reasonKeepNoSavings, true
+	}
+	if cfg.MaxDecodedBytes > 0 && rawLen > cfg.MaxDecodedBytes {
+		return encLen, reasonKeepBounds, true
+	}
+	return encLen, "", true
+}
+
 func matchTemplate(value []byte, anchors [][]byte, templateID uint64, cfg Config) (gaps [][]byte, encLen int, reason string, matched bool) {
 	rawLen := len(value)
 	gapCount := len(anchors) + 1
@@ -117,21 +169,30 @@ func matchMaskTemplateLen(value []byte, def TemplateDef, templateID uint64, cfg 
 			varCount += bits.OnesCount8(b)
 		}
 	}
-	if len(def.VarPositions) > 0 && len(def.ConstPositions) > 0 {
+	if len(def.VarPositions) > 0 && (len(def.maskConstSpans) > 0 || len(def.ConstPositions) > 0) {
 		constMismatch := false
-		for _, pos := range def.ConstPositions {
-			if value[pos] != def.Base[pos] {
-				constMismatch = true
-				break
+		if len(def.maskConstSpans) > 0 {
+			for _, s := range def.maskConstSpans {
+				if !bytes.Equal(value[s.start:s.end], def.Base[s.start:s.end]) {
+					constMismatch = true
+					break
+				}
 			}
-		}
-		diffCount := 0
-		for _, pos := range def.VarPositions {
-			if value[pos] != def.Base[pos] {
-				diffCount++
+		} else {
+			for _, pos := range def.ConstPositions {
+				if value[pos] != def.Base[pos] {
+					constMismatch = true
+					break
+				}
 			}
 		}
 		if !constMismatch {
+			diffCount := 0
+			for _, pos := range def.VarPositions {
+				if value[pos] != def.Base[pos] {
+					diffCount++
+				}
+			}
 			sparseLen := payloadHeader + uvarintLen(templateID) + varCount
 			fullLen := payloadHeader + uvarintLen(templateID) + maskLenFull + diffCount
 			encLen = fullLen
@@ -230,7 +291,12 @@ func encodeMaskTemplate(value []byte, def TemplateDef, templateID uint64, useSpa
 		out[3] = flagEncoded | flagMask
 		off := payloadHeader
 		off += binary.PutUvarint(out[off:], templateID)
-		if len(def.VarPositions) > 0 {
+		if len(def.maskVarSpans) > 0 {
+			dstOff := off
+			for _, s := range def.maskVarSpans {
+				dstOff += copy(out[dstOff:], value[s.start:s.end])
+			}
+		} else if len(def.VarPositions) > 0 {
 			for i, pos := range def.VarPositions {
 				out[off+i] = value[pos]
 			}
@@ -245,6 +311,52 @@ func encodeMaskTemplate(value []byte, def TemplateDef, templateID uint64, useSpa
 			}
 		}
 		return out
+	}
+	if varMask != nil && len(def.VarPositions) > 0 && (len(def.maskConstSpans) > 0 || len(def.ConstPositions) > 0) {
+		constMismatch := false
+		if len(def.maskConstSpans) > 0 {
+			for _, s := range def.maskConstSpans {
+				if !bytes.Equal(value[s.start:s.end], def.Base[s.start:s.end]) {
+					constMismatch = true
+					break
+				}
+			}
+		} else {
+			for _, pos := range def.ConstPositions {
+				if value[pos] != def.Base[pos] {
+					constMismatch = true
+					break
+				}
+			}
+		}
+		if !constMismatch {
+			diffCount := 0
+			for _, pos := range def.VarPositions {
+				if value[pos] != def.Base[pos] {
+					diffCount++
+				}
+			}
+			fullLen := payloadHeader + uvarintLen(templateID) + maskLenFull + diffCount
+			full := make([]byte, fullLen)
+			full[0] = magic0
+			full[1] = magic1
+			full[2] = payloadVer
+			full[3] = flagEncoded | flagMask | flagMaskFull
+			off := payloadHeader
+			off += binary.PutUvarint(full[off:], templateID)
+			maskOff := off
+			diffOff := maskOff + maskLenFull
+			idx := 0
+			for _, pos := range def.VarPositions {
+				if value[pos] == def.Base[pos] {
+					continue
+				}
+				full[maskOff+int(pos)/8] |= 1 << uint(pos%8)
+				full[diffOff+idx] = value[pos]
+				idx++
+			}
+			return full
+		}
 	}
 	diffCount := 0
 	for i := 0; i < len(def.Base); i++ {

--- a/TreeDB/template/types.go
+++ b/TreeDB/template/types.go
@@ -31,6 +31,14 @@ type TemplateDef struct {
 	Base           []byte
 	VarPositions   []uint16
 	ConstPositions []uint16
+
+	maskVarSpans   []span
+	maskConstSpans []span
+}
+
+type span struct {
+	start int
+	end   int
 }
 
 // DecodeOptions control TemplateValue decoding limits.

--- a/docs/TREEDB_BENCHMARKING.md
+++ b/docs/TREEDB_BENCHMARKING.md
@@ -49,6 +49,27 @@ KEYS=4000000 PROFILES=fast scripts/treedb_forceptr_matrix.sh
 KEYS=2000000 PROFILES=fast,balanced PPROF_TESTS=batch_write,random_write scripts/treedb_forceptr_matrix.sh
 ```
 
+### Template encode profiling (steady-only)
+
+For template-compression profiling, prefer the steady-state-only CPU profile
+capture in `TreeDB/cmd/vlog_dict_realdata`:
+
+```bash
+go run ./TreeDB/cmd/vlog_dict_realdata \
+  -input /tmp/treedb_template_smoke.jsonl -input-encoding string \
+  -train 10000 -eval 5000 -cap 0 \
+  -bench-kv -bench-mode wal_off -bench-pointer-threshold 1 \
+  -bench-compression off -bench-template on \
+  -bench-raw-mib 512 -bench-batch 1024 -bench-key-mode dataset \
+  -bench-cpu-profile /tmp/treedb_template_steady.pprof
+
+go tool pprof -http=:0 /tmp/treedb_template_steady.pprof
+```
+
+Notes:
+- `-bench-cpu-profile` focuses on the steady write loop (best for template encode hot paths).
+- `-cpu-profile` profiles the whole program (load + warmup + steady + reporting).
+
 ## 2) Trace Summary Replay (Counts Only)
 
 Uses the JSON summary from trace capture and replays batch sizes + op counts.


### PR DESCRIPTION
Implements #267.

## Summary
This targets template-encode CPU + allocation costs when templates are active, with a focus on routing/fingerprinting and mask-template fast paths.

## Changes
- **Routing fingerprints (fast path):** add `AppendRoutingFingerprints` / internal `appendRoutingFingerprints` using a small set of fixed segment hashes (+ length) instead of per-value winnowing. `Engine.Encode` uses a stack buffer (no alloc) and only falls back to legacy winnowed routing when the fast path yields zero candidates.
- **Mask template matching/encoding:** precompute var/const spans at template-def decode time and use `bytes.Equal` over constant spans (memcmp-style) + var-only loops when constants match.
- **Anchor template candidate loop:** avoid allocating gaps/payload for each candidate; use `matchTemplateLen` for scoring and only build the payload for the winning kept candidate.
- **Training overhead:** move `TrainSampleStride` gating before any fingerprint work; make `BucketKey` allocation-free.
- **Profiling UX:** add `-bench-cpu-profile` to `TreeDB/cmd/vlog_dict_realdata` (steady-phase-only), and document template profiling in `docs/TREEDB_BENCHMARKING.md`.

## How to measure
- Template smoke table (4 modes): `scripts/bench_template_smoke.sh`
- Template-only profiling:
  - `go run ./TreeDB/cmd/vlog_dict_realdata -bench-kv -bench-template on -bench-compression off ... -bench-cpu-profile /tmp/treedb_template_steady.pprof`
  - `go tool pprof -http=:0 /tmp/treedb_template_steady.pprof`

Notes:
- Defaults remain unchanged; template compression remains opt-in.
