### PR TITLE
template: async training/publishing + concurrency scaling

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4561,6 +4561,10 @@ func (db *DB) Close() error {
 	if trainer != nil {
 		trainer.Close()
 	}
+	if db.valueLogTemplateEngine != nil {
+		db.valueLogTemplateEngine.Close()
+		db.valueLogTemplateEngine = nil
+	}
 	if db.hashSortedIndexer != nil {
 		db.hashSortedIndexer.Close()
 		db.hashSortedIndexer = nil

--- a/TreeDB/cmd/vlog_dict_realdata/main.go
+++ b/TreeDB/cmd/vlog_dict_realdata/main.go
@@ -17,6 +17,8 @@ import (
 	"runtime/pprof"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
@@ -67,6 +69,7 @@ type benchConfig struct {
 	Template          string
 	RawMiB            int
 	Batch             int
+	Workers           int
 	KeyMode           string
 	PointerThreshold  int
 	FlushThresholdMiB int
@@ -91,6 +94,7 @@ type benchReport struct {
 	KeyMode             string   `json:"key_mode"`
 	RawMiB              int      `json:"raw_mib"`
 	Batch               int      `json:"batch"`
+	Workers             int      `json:"workers,omitempty"`
 	PointerThreshold    int      `json:"pointer_threshold"`
 	FlushThresholdMiB   int      `json:"flush_threshold_mib,omitempty"`
 	DictTrainMiB        int      `json:"dict_train_mib,omitempty"`
@@ -165,6 +169,7 @@ func main() {
 	benchCPUProfile := flag.String("bench-cpu-profile", "", "Write CPU profile for steady-state phase (bench only; optional)")
 	benchRawMiB := flag.Int("bench-raw-mib", 512, "Raw MiB to write in steady-state phase")
 	benchBatch := flag.Int("bench-batch", 1024, "Number of ops per batch write")
+	benchWorkers := flag.Int("bench-workers", 1, "Number of concurrent workers (bench only)")
 	benchKeyMode := flag.String("bench-key-mode", "random", "Key mode: random|sequential|dataset")
 	benchPointerThreshold := flag.Int("bench-pointer-threshold", 1, "Value-log pointer threshold (bytes)")
 	benchFlushThresholdMiB := flag.Int("bench-flush-threshold-mib", 0, "Flush threshold for cached mode (MiB, 0=default)")
@@ -214,6 +219,7 @@ func main() {
 			Template:          *benchTemplate,
 			RawMiB:            *benchRawMiB,
 			Batch:             *benchBatch,
+			Workers:           *benchWorkers,
 			KeyMode:           *benchKeyMode,
 			PointerThreshold:  *benchPointerThreshold,
 			FlushThresholdMiB: *benchFlushThresholdMiB,
@@ -541,6 +547,9 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 	if cfg.Batch <= 0 {
 		return nil, fmt.Errorf("invalid -bench-batch=%d (must be > 0)", cfg.Batch)
 	}
+	if cfg.Workers <= 0 {
+		cfg.Workers = 1
+	}
 	if cfg.FlushThresholdMiB < 0 {
 		return nil, fmt.Errorf("invalid -bench-flush-threshold-mib=%d (must be >= 0)", cfg.FlushThresholdMiB)
 	}
@@ -584,15 +593,12 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 	fmt.Printf("input:    %s\n", input)
 	fmt.Printf("samples:  train=%d eval=%d cap=%d\n", len(train), len(eval), capBytes)
 	fmt.Printf("stats:    total_bytes=%d avg=%.2f min=%d max=%d\n", stats.total, stats.avg, stats.min, stats.max)
-	fmt.Printf("bench:    mode=%s compression=%s key_mode=%s raw_mib=%d batch=%d pointer_threshold=%d\n", cfg.Mode, cfg.Compression, cfg.KeyMode, cfg.RawMiB, cfg.Batch, cfg.PointerThreshold)
+	fmt.Printf("bench:    mode=%s compression=%s template=%s key_mode=%s raw_mib=%d batch=%d workers=%d pointer_threshold=%d\n", cfg.Mode, cfg.Compression, cfg.Template, cfg.KeyMode, cfg.RawMiB, cfg.Batch, cfg.Workers, cfg.PointerThreshold)
 	if cfg.FlushThresholdMiB > 0 {
 		fmt.Printf("bench:    flush_threshold_mib=%d\n", cfg.FlushThresholdMiB)
 	}
 	if cfg.Compression == "on" {
 		fmt.Printf("bench:    dict_train_mib=%d dict_sample_stride=%d\n", cfg.DictTrainMiB, cfg.DictSampleStride)
-	}
-	if cfg.Template == "on" {
-		fmt.Printf("bench:    template=on\n")
 	}
 	fmt.Printf("load:     %.3fs\n", loadDur.Seconds())
 	fmt.Println()
@@ -634,7 +640,13 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 	var preSteadyKeptFramesPtr *uint64
 
 	warmStart := time.Now()
-	warmRaw, warmRecords, err := writeSamplesOnce(db, train, cfg.Batch, cfg.KeyMode, keyState)
+	var warmRaw int64
+	var warmRecords int
+	if cfg.Workers > 1 {
+		warmRaw, warmRecords, err = writeSamplesOnceConcurrent(db, train, cfg.Batch, cfg.KeyMode, cfg.Workers)
+	} else {
+		warmRaw, warmRecords, err = writeSamplesOnce(db, train, cfg.Batch, cfg.KeyMode, keyState)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -678,7 +690,13 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 		stopCPUProfile = stop
 	}
 	steadyStart := time.Now()
-	steadyRaw, steadyRecords, err := writeUntilRawBytes(db, eval, targetRawBytes, cfg.Batch, cfg.KeyMode, keyState)
+	var steadyRaw int64
+	var steadyRecords int
+	if cfg.Workers > 1 {
+		steadyRaw, steadyRecords, err = writeUntilRawBytesConcurrent(db, eval, targetRawBytes, cfg.Batch, cfg.KeyMode, cfg.Workers)
+	} else {
+		steadyRaw, steadyRecords, err = writeUntilRawBytes(db, eval, targetRawBytes, cfg.Batch, cfg.KeyMode, keyState)
+	}
 	if stopCPUProfile != nil {
 		stopCPUProfile()
 		stopCPUProfile = nil
@@ -843,6 +861,7 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 		KeyMode:             cfg.KeyMode,
 		RawMiB:              cfg.RawMiB,
 		Batch:               cfg.Batch,
+		Workers:             cfg.Workers,
 		PointerThreshold:    cfg.PointerThreshold,
 		FlushThresholdMiB:   cfg.FlushThresholdMiB,
 		DictTrainMiB:        cfg.DictTrainMiB,
@@ -1152,6 +1171,244 @@ func writeUntilRawBytes(db *treedb.DB, samples []kvSample, targetRawBytes int64,
 		}
 	}
 	return rawBytes, records, nil
+}
+
+func keyForSampleConcurrent(keyMode string, sample kvSample, seq *atomic.Uint64, rng *rand.Rand) ([]byte, error) {
+	switch keyMode {
+	case "dataset":
+		if len(sample.Key) == 0 {
+			return nil, fmt.Errorf("dataset key is empty")
+		}
+		return sample.Key, nil
+	case "sequential":
+		if seq == nil {
+			return nil, fmt.Errorf("nil sequential key generator")
+		}
+		buf := make([]byte, 16)
+		n := seq.Add(1) - 1
+		binary.BigEndian.PutUint64(buf[8:], n)
+		return buf, nil
+	case "random":
+		if rng == nil {
+			return nil, fmt.Errorf("random key generator not initialized")
+		}
+		buf := make([]byte, 16)
+		binary.BigEndian.PutUint64(buf[:8], rng.Uint64())
+		binary.BigEndian.PutUint64(buf[8:], rng.Uint64())
+		return buf, nil
+	default:
+		return nil, fmt.Errorf("unsupported bench key mode %q", keyMode)
+	}
+}
+
+func writeSamplesOnceConcurrent(db *treedb.DB, samples []kvSample, batchSize int, keyMode string, workers int) (int64, int, error) {
+	if db == nil {
+		return 0, 0, fmt.Errorf("nil db")
+	}
+	if len(samples) == 0 {
+		return 0, 0, fmt.Errorf("no samples available")
+	}
+	if batchSize <= 0 {
+		return 0, 0, fmt.Errorf("invalid batch size %d", batchSize)
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+
+	var seq atomic.Uint64
+	var rawTotal atomic.Int64
+	var recTotal atomic.Int64
+
+	done := make(chan struct{})
+	var errOnce sync.Once
+	var firstErr error
+
+	var wg sync.WaitGroup
+	for workerID := 0; workerID < workers; workerID++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			rng := rand.New(rand.NewSource(int64(1 + id)))
+			idx := id
+			for idx < len(samples) {
+				select {
+				case <-done:
+					return
+				default:
+				}
+
+				batch := db.NewBatch()
+				if batch == nil {
+					errOnce.Do(func() {
+						firstErr = fmt.Errorf("failed to create batch")
+						close(done)
+					})
+					return
+				}
+
+				ops := 0
+				batchRaw := int64(0)
+				batchRecords := 0
+				for ops < batchSize && idx < len(samples) {
+					sample := samples[idx]
+					idx += workers
+
+					key, err := keyForSampleConcurrent(keyMode, sample, &seq, rng)
+					if err != nil {
+						_ = batch.Close()
+						errOnce.Do(func() {
+							firstErr = err
+							close(done)
+						})
+						return
+					}
+					if err := batch.Set(key, sample.Val); err != nil {
+						_ = batch.Close()
+						errOnce.Do(func() {
+							firstErr = err
+							close(done)
+						})
+						return
+					}
+					batchRaw += int64(len(sample.Val))
+					batchRecords++
+					ops++
+				}
+				if err := batch.Write(); err != nil {
+					_ = batch.Close()
+					errOnce.Do(func() {
+						firstErr = err
+						close(done)
+					})
+					return
+				}
+				if err := batch.Close(); err != nil {
+					errOnce.Do(func() {
+						firstErr = err
+						close(done)
+					})
+					return
+				}
+				rawTotal.Add(batchRaw)
+				recTotal.Add(int64(batchRecords))
+			}
+		}(workerID)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return 0, 0, firstErr
+	}
+	return rawTotal.Load(), int(recTotal.Load()), nil
+}
+
+func writeUntilRawBytesConcurrent(db *treedb.DB, samples []kvSample, targetRawBytes int64, batchSize int, keyMode string, workers int) (int64, int, error) {
+	if db == nil {
+		return 0, 0, fmt.Errorf("nil db")
+	}
+	if len(samples) == 0 {
+		return 0, 0, fmt.Errorf("no samples available")
+	}
+	if targetRawBytes <= 0 {
+		return 0, 0, fmt.Errorf("invalid target raw bytes %d", targetRawBytes)
+	}
+	if batchSize <= 0 {
+		return 0, 0, fmt.Errorf("invalid batch size %d", batchSize)
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+
+	var seq atomic.Uint64
+	var rawTotal atomic.Int64
+	var recTotal atomic.Int64
+
+	done := make(chan struct{})
+	var errOnce sync.Once
+	var firstErr error
+
+	var wg sync.WaitGroup
+	for workerID := 0; workerID < workers; workerID++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			rng := rand.New(rand.NewSource(int64(1 + id)))
+			idx := id
+			for {
+				if rawTotal.Load() >= targetRawBytes {
+					return
+				}
+				select {
+				case <-done:
+					return
+				default:
+				}
+
+				batch := db.NewBatch()
+				if batch == nil {
+					errOnce.Do(func() {
+						firstErr = fmt.Errorf("failed to create batch")
+						close(done)
+					})
+					return
+				}
+
+				ops := 0
+				batchRaw := int64(0)
+				batchRecords := 0
+				for ops < batchSize && rawTotal.Load()+batchRaw < targetRawBytes {
+					sample := samples[idx]
+					idx += workers
+					if idx >= len(samples) {
+						idx = id
+					}
+					key, err := keyForSampleConcurrent(keyMode, sample, &seq, rng)
+					if err != nil {
+						_ = batch.Close()
+						errOnce.Do(func() {
+							firstErr = err
+							close(done)
+						})
+						return
+					}
+					if err := batch.Set(key, sample.Val); err != nil {
+						_ = batch.Close()
+						errOnce.Do(func() {
+							firstErr = err
+							close(done)
+						})
+						return
+					}
+					batchRaw += int64(len(sample.Val))
+					batchRecords++
+					ops++
+				}
+				if err := batch.Write(); err != nil {
+					_ = batch.Close()
+					errOnce.Do(func() {
+						firstErr = err
+						close(done)
+					})
+					return
+				}
+				if err := batch.Close(); err != nil {
+					errOnce.Do(func() {
+						firstErr = err
+						close(done)
+					})
+					return
+				}
+				rawTotal.Add(batchRaw)
+				recTotal.Add(int64(batchRecords))
+			}
+		}(workerID)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return 0, 0, firstErr
+	}
+	return rawTotal.Load(), int(recTotal.Load()), nil
 }
 
 func dictStatsActive(stats map[string]string) bool {

--- a/TreeDB/internal/templatedb/store.go
+++ b/TreeDB/internal/templatedb/store.go
@@ -212,6 +212,165 @@ func (s *Store) PutTemplateDef(_ context.Context, defBytes []byte, routeFPs []ui
 	return id, nil
 }
 
+// PutTemplateDefs stores multiple template definitions and updates routing
+// indices in a single durable batch.
+//
+// This is an optional acceleration used by the template engine when publishing
+// bursts of templates; it is equivalent to calling PutTemplateDef for each
+// template, but coalesces WriteSync.
+func (s *Store) PutTemplateDefs(_ context.Context, defs []template.PublishSpec) ([]uint64, error) {
+	if s == nil || s.kv == nil {
+		return nil, errStoreUnavailable
+	}
+	if len(defs) == 0 {
+		return nil, nil
+	}
+	cfg := NormalizeConfig(s.cfg)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ids := make([]uint64, len(defs))
+	reserved := make(map[uint64][]byte, len(defs))
+
+	type candAdd struct {
+		fp   uint64
+		cand template.Candidate
+	}
+	additions := make([]candAdd, 0, len(defs)*8)
+
+	// Assign IDs and collect candidate list additions.
+	for i := range defs {
+		defBytes := defs[i].DefBytes
+		routeFPs := defs[i].RouteFPs
+
+		// Dedup and sort route fingerprints deterministically.
+		if len(routeFPs) > 0 {
+			sort.Slice(routeFPs, func(i, j int) bool { return routeFPs[i] < routeFPs[j] })
+			j := 0
+			for k := 0; k < len(routeFPs); k++ {
+				if k == 0 || routeFPs[k] != routeFPs[k-1] {
+					routeFPs[j] = routeFPs[k]
+					j++
+				}
+			}
+			routeFPs = routeFPs[:j]
+		}
+		defs[i].RouteFPs = routeFPs
+
+		id := uint64(0)
+		for attempt := 0; attempt < cfg.MaxIDAttempts; attempt++ {
+			id = template.TemplateID(defBytes, byte(attempt))
+			if id == 0 {
+				continue
+			}
+			if existingDef, ok := reserved[id]; ok {
+				if bytes.Equal(existingDef, defBytes) {
+					// Duplicate within the batch; idempotent publish.
+					break
+				}
+				if attempt == cfg.MaxIDAttempts-1 {
+					return nil, fmt.Errorf("templatedb: template id collision for %d", id)
+				}
+				id = 0
+				continue
+			}
+			key := templateKey(id)
+			existing, err := s.kv.Get(key)
+			if err != nil {
+				return nil, err
+			}
+			if existing == nil || bytes.Equal(existing, defBytes) {
+				// Free ID, or idempotent publish.
+				break
+			}
+			if attempt == cfg.MaxIDAttempts-1 {
+				return nil, fmt.Errorf("templatedb: template id collision for %d", id)
+			}
+			id = 0
+		}
+		if id == 0 {
+			return nil, fmt.Errorf("templatedb: unable to assign template id")
+		}
+		ids[i] = id
+		reserved[id] = defBytes
+
+		if len(routeFPs) == 0 {
+			continue
+		}
+		candidateSize := len(defBytes)
+		for _, fp := range routeFPs {
+			additions = append(additions, candAdd{
+				fp:   fp,
+				cand: template.Candidate{ID: id, Size: candidateSize},
+			})
+		}
+	}
+
+	// Coalesce per-fingerprint updates.
+	type fpAdds struct {
+		fp    uint64
+		cands []template.Candidate
+	}
+	fpMap := make(map[uint64][]template.Candidate, len(additions))
+	for _, add := range additions {
+		fpMap[add.fp] = append(fpMap[add.fp], add.cand)
+	}
+
+	updates := make(map[uint64][]byte, len(fpMap))
+	for fp, adds := range fpMap {
+		listBytes, err := s.kv.Get(fpKey(fp))
+		if err != nil {
+			return nil, err
+		}
+		cands, err := decodeCandidates(listBytes)
+		if err != nil {
+			return nil, err
+		}
+		for _, cand := range adds {
+			cands = upsertCandidate(cands, cand)
+		}
+		// Deterministic trimming.
+		sort.Slice(cands, func(i, j int) bool {
+			if cands[i].Size != cands[j].Size {
+				return cands[i].Size < cands[j].Size
+			}
+			return cands[i].ID < cands[j].ID
+		})
+		if cfg.MaxCandidatesPerFP > 0 && len(cands) > cfg.MaxCandidatesPerFP {
+			cands = cands[:cfg.MaxCandidatesPerFP]
+		}
+		encoded := encodeCandidates(cands)
+		for cfg.MaxCandidateListBytes > 0 && len(encoded) > cfg.MaxCandidateListBytes && len(cands) > 1 {
+			cands = cands[:len(cands)-1]
+			encoded = encodeCandidates(cands)
+		}
+		updates[fp] = encoded
+	}
+
+	batch := s.kv.NewBatch()
+	for i := range defs {
+		if err := batch.Set(templateKey(ids[i]), defs[i].DefBytes); err != nil {
+			_ = batch.Close()
+			return nil, err
+		}
+	}
+	for fp, enc := range updates {
+		if err := batch.Set(fpKey(fp), enc); err != nil {
+			_ = batch.Close()
+			return nil, err
+		}
+	}
+	if err := batch.WriteSync(); err != nil {
+		_ = batch.Close()
+		return nil, err
+	}
+	if err := batch.Close(); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
 func templateKey(id uint64) []byte {
 	buf := make([]byte, 2+8)
 	buf[0] = schemaVer

--- a/TreeDB/template/config.go
+++ b/TreeDB/template/config.go
@@ -1,5 +1,10 @@
 package template
 
+import (
+	"runtime"
+	"time"
+)
+
 // Config controls template encoding, routing, and training behavior.
 // Zero values use defaults via NormalizeConfig.
 type Config struct {
@@ -64,6 +69,18 @@ type Config struct {
 	CooldownValues               int
 	MaxTemplatesPerBucket        int
 	MaxTemplatesTotal            int
+
+	// Async training / publishing.
+	//
+	// These settings control the background pipeline used to ingest samples,
+	// synthesize templates, and publish them without stalling writers.
+	TrainShards         int
+	TrainRouters        int
+	TrainQueueSize      int
+	TrainShardQueueSize int
+	TrainMaxValueBytes  int
+	PublishBatchSize    int
+	PublishFlushEvery   time.Duration
 }
 
 // NormalizeConfig applies defaults and bounds for a config.
@@ -217,6 +234,45 @@ func NormalizeConfig(cfg Config) Config {
 	}
 	if cfg.MaxTemplatesTotal <= 0 {
 		cfg.MaxTemplatesTotal = 1 << 20
+	}
+	if cfg.TrainShards <= 0 {
+		cfg.TrainShards = runtime.GOMAXPROCS(0)
+		if cfg.TrainShards > 8 {
+			cfg.TrainShards = 8
+		}
+		if cfg.TrainShards < 1 {
+			cfg.TrainShards = 1
+		}
+	}
+	if cfg.MaxBuckets > 0 && cfg.TrainShards > cfg.MaxBuckets {
+		cfg.TrainShards = cfg.MaxBuckets
+	}
+	if cfg.TrainRouters <= 0 {
+		cfg.TrainRouters = cfg.TrainShards
+		if cfg.TrainRouters > 4 {
+			cfg.TrainRouters = 4
+		}
+		if cfg.TrainRouters < 1 {
+			cfg.TrainRouters = 1
+		}
+	}
+	if cfg.TrainQueueSize <= 0 {
+		cfg.TrainQueueSize = 4096
+	}
+	if cfg.TrainShardQueueSize <= 0 {
+		cfg.TrainShardQueueSize = cfg.TrainQueueSize / cfg.TrainShards
+		if cfg.TrainShardQueueSize < 64 {
+			cfg.TrainShardQueueSize = 64
+		}
+	}
+	if cfg.TrainMaxValueBytes == 0 {
+		cfg.TrainMaxValueBytes = 64 << 10
+	}
+	if cfg.PublishBatchSize <= 0 {
+		cfg.PublishBatchSize = 8
+	}
+	if cfg.PublishFlushEvery <= 0 {
+		cfg.PublishFlushEvery = 50 * time.Millisecond
 	}
 	return cfg
 }

--- a/TreeDB/template/engine.go
+++ b/TreeDB/template/engine.go
@@ -15,14 +15,12 @@ import (
 type Engine struct {
 	cfg            Config
 	stats          TemplateStats
-	trainMu        sync.Mutex
-	buckets        map[uint64]*bucket
-	bucketSeq      uint64
-	totalTemplates int
 	trainSeq       atomic.Uint64
 	encodeSeq      atomic.Uint64
 	lastKeepSeq    atomic.Uint64
 	defCache       *defCache
+	trainer        *trainer
+	totalTemplates atomic.Uint64
 	recentMu       sync.Mutex
 	recent         []recentTemplate
 }
@@ -34,6 +32,7 @@ type bucket struct {
 	samplesSeen        int
 	lastPublishSample  int
 	templatesPublished int
+	publishPending     bool
 	lastSeen           uint64
 }
 
@@ -199,10 +198,21 @@ func (c *defCache) Add(id uint64, def TemplateDef) {
 // NewEngine creates a template engine with normalized config.
 func NewEngine(cfg Config) *Engine {
 	cfg = NormalizeConfig(cfg)
-	return &Engine{
+	e := &Engine{
 		cfg:      cfg,
-		buckets:  make(map[uint64]*bucket),
 		defCache: newDefCache(cfg.DefCacheSize),
+	}
+	e.trainer = newTrainer(e)
+	return e
+}
+
+// Close stops background training/publishing workers.
+func (e *Engine) Close() {
+	if e == nil {
+		return
+	}
+	if t := e.trainer; t != nil {
+		t.Close()
 	}
 }
 
@@ -660,94 +670,13 @@ func (e *Engine) observeTraining(value []byte, store Store) {
 	if cfg.TrainSampleStride > 1 && seq%uint64(cfg.TrainSampleStride) != 0 {
 		return
 	}
-	fps := BucketFingerprints(value, cfg)
-	if len(fps) == 0 {
-		fps = Fingerprints(value, cfg)
-	}
-	if len(fps) == 0 {
+	e.stats.TrainEnqueueAttempts.Add(1)
+	if cfg.TrainMaxValueBytes >= 0 && len(value) > cfg.TrainMaxValueBytes {
+		e.stats.TrainDroppedTooLarge.Add(1)
 		return
 	}
-	bucketKey := BucketKey(fps)
-	if bucketKey == 0 {
-		return
-	}
-	e.trainMu.Lock()
-	defer e.trainMu.Unlock()
-	b := e.buckets[bucketKey]
-	if b == nil {
-		if len(e.buckets) >= cfg.MaxBuckets {
-			e.evictOldestBucket()
-		}
-		b = &bucket{key: bucketKey}
-		e.buckets[bucketKey] = b
-	}
-	e.bucketSeq++
-	b.lastSeen = e.bucketSeq
-	// Add sample (copy).
-	cp := append([]byte(nil), value...)
-	b.samples = append(b.samples, sample{value: cp})
-	b.sampleBytes += len(cp)
-	b.samplesSeen++
-	for (cfg.MaxValuesPerBucket > 0 && len(b.samples) > cfg.MaxValuesPerBucket) || (cfg.MaxBytesPerBucket > 0 && b.sampleBytes > cfg.MaxBytesPerBucket) {
-		old := b.samples[0]
-		b.samples = b.samples[1:]
-		b.sampleBytes -= len(old.value)
-	}
-	if cfg.SynthesizeEverySamples <= 0 || b.samplesSeen%cfg.SynthesizeEverySamples != 0 {
-		return
-	}
-	if cfg.CooldownValues > 0 && b.samplesSeen-b.lastPublishSample < cfg.CooldownValues {
-		return
-	}
-	if cfg.MaxTemplatesPerBucket > 0 && b.templatesPublished >= cfg.MaxTemplatesPerBucket {
-		return
-	}
-	if cfg.MaxTemplatesTotal > 0 && e.totalTemplates >= cfg.MaxTemplatesTotal {
-		return
-	}
-	def, routeValue, activated, ok := synthesizeTemplate(b.samples, cfg)
-	if !ok {
-		return
-	}
-	if !activated {
-		return
-	}
-	defBytes, err := EncodeTemplateDef(def, cfg)
-	if err != nil {
-		return
-	}
-	routeFPs := RoutingFingerprints(routeValue, cfg)
-	if len(routeFPs) == 0 {
-		return
-	}
-	routeFPs = append(routeFPs, RoutingFingerprintsLegacy(routeValue, cfg)...)
-	if _, err := store.PutTemplateDef(context.Background(), defBytes, routeFPs); err != nil {
-		return
-	}
-	b.lastPublishSample = b.samplesSeen
-	b.templatesPublished++
-	e.totalTemplates++
-	e.stats.TemplatesPublished.Add(1)
-}
-
-func (e *Engine) evictOldestBucket() {
-	var (
-		oldestKey  uint64
-		oldestSeen uint64
-		set        bool
-	)
-	for k, b := range e.buckets {
-		if b == nil {
-			continue
-		}
-		if !set || b.lastSeen < oldestSeen || (b.lastSeen == oldestSeen && k < oldestKey) {
-			oldestKey = k
-			oldestSeen = b.lastSeen
-			set = true
-		}
-	}
-	if set {
-		delete(e.buckets, oldestKey)
+	if t := e.trainer; t != nil {
+		t.Enqueue(store, value)
 	}
 }
 

--- a/TreeDB/template/stats.go
+++ b/TreeDB/template/stats.go
@@ -34,6 +34,17 @@ type TemplateStats struct {
 	MaskSparseUsed               atomic.Uint64
 	MaskFullUsed                 atomic.Uint64
 
+	TrainEnqueueAttempts  atomic.Uint64
+	TrainEnqueued         atomic.Uint64
+	TrainDroppedQueueFull atomic.Uint64
+	TrainDroppedTooLarge  atomic.Uint64
+	TrainRouted           atomic.Uint64
+	TrainDroppedShardFull atomic.Uint64
+	TrainProcessed        atomic.Uint64
+	PublishBatches        atomic.Uint64
+	PublishDefs           atomic.Uint64
+	PublishErrors         atomic.Uint64
+
 	reasonsMu sync.Mutex
 	reasons   map[string]uint64
 }
@@ -63,6 +74,16 @@ func (s *TemplateStats) Snapshot() map[string]string {
 		"templates_published_total":            fmt.Sprintf("%d", s.TemplatesPublished.Load()),
 		"mask_sparse_used_total":               fmt.Sprintf("%d", s.MaskSparseUsed.Load()),
 		"mask_full_used_total":                 fmt.Sprintf("%d", s.MaskFullUsed.Load()),
+		"train_enqueue_attempts_total":         fmt.Sprintf("%d", s.TrainEnqueueAttempts.Load()),
+		"train_enqueued_total":                 fmt.Sprintf("%d", s.TrainEnqueued.Load()),
+		"train_dropped_queue_full_total":       fmt.Sprintf("%d", s.TrainDroppedQueueFull.Load()),
+		"train_dropped_too_large_total":        fmt.Sprintf("%d", s.TrainDroppedTooLarge.Load()),
+		"train_routed_total":                   fmt.Sprintf("%d", s.TrainRouted.Load()),
+		"train_dropped_shard_full_total":       fmt.Sprintf("%d", s.TrainDroppedShardFull.Load()),
+		"train_processed_total":                fmt.Sprintf("%d", s.TrainProcessed.Load()),
+		"publish_batches_total":                fmt.Sprintf("%d", s.PublishBatches.Load()),
+		"publish_defs_total":                   fmt.Sprintf("%d", s.PublishDefs.Load()),
+		"publish_errors_total":                 fmt.Sprintf("%d", s.PublishErrors.Load()),
 	}
 	s.reasonsMu.Lock()
 	for k, v := range s.reasons {

--- a/TreeDB/template/trainer.go
+++ b/TreeDB/template/trainer.go
@@ -1,0 +1,396 @@
+package template
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type trainer struct {
+	cfg            Config
+	stats          *TemplateStats
+	defCache       *defCache
+	totalTemplates *atomic.Uint64
+
+	ingestCh chan trainSample
+	done     chan struct{}
+	closed   atomic.Bool
+	wg       sync.WaitGroup
+	once     sync.Once
+
+	shards []trainShard
+}
+
+type trainSample struct {
+	store Store
+	value []byte
+}
+
+type trainTask struct {
+	store     Store
+	bucketKey uint64
+	value     []byte
+}
+
+type pendingPublish struct {
+	store       Store
+	bucket      *bucket
+	samplesSeen int
+	def         TemplateDef
+	defBytes    []byte
+	routeFPs    []uint64
+}
+
+type trainShard struct {
+	cfg            Config
+	stats          *TemplateStats
+	defCache       *defCache
+	totalTemplates *atomic.Uint64
+
+	in         chan trainTask
+	buckets    map[uint64]*bucket
+	maxBuckets int
+	bucketSeq  uint64
+
+	pending []pendingPublish
+}
+
+func newTrainer(e *Engine) *trainer {
+	if e == nil {
+		return nil
+	}
+	cfg := NormalizeConfig(e.cfg)
+	t := &trainer{
+		cfg:            cfg,
+		stats:          &e.stats,
+		defCache:       e.defCache,
+		totalTemplates: &e.totalTemplates,
+		ingestCh:       make(chan trainSample, cfg.TrainQueueSize),
+		done:           make(chan struct{}),
+	}
+
+	shards := make([]trainShard, cfg.TrainShards)
+	maxBuckets := cfg.MaxBuckets
+	if maxBuckets < 1 {
+		maxBuckets = 1
+	}
+	if cfg.TrainShards < 1 {
+		cfg.TrainShards = 1
+	}
+	baseBuckets := maxBuckets / cfg.TrainShards
+	rem := maxBuckets % cfg.TrainShards
+	for i := range shards {
+		limit := baseBuckets
+		if i < rem {
+			limit++
+		}
+		if limit < 1 {
+			limit = 1
+		}
+		shards[i] = trainShard{
+			cfg:            cfg,
+			stats:          &e.stats,
+			defCache:       e.defCache,
+			totalTemplates: &e.totalTemplates,
+			in:             make(chan trainTask, cfg.TrainShardQueueSize),
+			buckets:        make(map[uint64]*bucket),
+			maxBuckets:     limit,
+		}
+	}
+	t.shards = shards
+
+	for i := 0; i < cfg.TrainRouters; i++ {
+		t.wg.Add(1)
+		go t.runRouter()
+	}
+	for i := range t.shards {
+		shard := &t.shards[i]
+		t.wg.Add(1)
+		go shard.run(t.done, &t.wg)
+	}
+	return t
+}
+
+func (t *trainer) Close() {
+	if t == nil {
+		return
+	}
+	t.once.Do(func() {
+		t.closed.Store(true)
+		close(t.done)
+	})
+	t.wg.Wait()
+}
+
+func (t *trainer) Enqueue(store Store, value []byte) {
+	if t == nil || store == nil || t.closed.Load() {
+		return
+	}
+	cfg := t.cfg
+	if cfg.FingerprintK <= 0 || len(value) < cfg.FingerprintK {
+		return
+	}
+	if cap(t.ingestCh) > 0 && len(t.ingestCh) == cap(t.ingestCh) {
+		t.stats.TrainDroppedQueueFull.Add(1)
+		return
+	}
+	cp := append([]byte(nil), value...)
+	select {
+	case t.ingestCh <- trainSample{store: store, value: cp}:
+		t.stats.TrainEnqueued.Add(1)
+	default:
+		t.stats.TrainDroppedQueueFull.Add(1)
+	}
+}
+
+func (t *trainer) runRouter() {
+	defer t.wg.Done()
+	cfg := t.cfg
+	shardCount := len(t.shards)
+	if shardCount == 0 {
+		return
+	}
+	for {
+		select {
+		case <-t.done:
+			// Drain to avoid holding references to large byte slices after Close.
+			for {
+				select {
+				case sample := <-t.ingestCh:
+					_ = sample
+				default:
+					return
+				}
+			}
+		case sample := <-t.ingestCh:
+			if sample.store == nil || len(sample.value) < cfg.FingerprintK {
+				continue
+			}
+			fps := BucketFingerprints(sample.value, cfg)
+			if len(fps) == 0 {
+				fps = Fingerprints(sample.value, cfg)
+			}
+			if len(fps) == 0 {
+				continue
+			}
+			key := BucketKey(fps)
+			if key == 0 {
+				continue
+			}
+			idx := int(key % uint64(shardCount))
+			task := trainTask{store: sample.store, bucketKey: key, value: sample.value}
+			select {
+			case t.shards[idx].in <- task:
+				t.stats.TrainRouted.Add(1)
+			default:
+				t.stats.TrainDroppedShardFull.Add(1)
+			}
+		}
+	}
+}
+
+func (s *trainShard) run(done <-chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+	ticker := time.NewTicker(s.cfg.PublishFlushEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			for {
+				select {
+				case task := <-s.in:
+					_ = task
+				default:
+					goto drained
+				}
+			}
+		drained:
+			s.flushPublishes(context.Background())
+			return
+		case <-ticker.C:
+			s.flushPublishes(context.Background())
+		case task := <-s.in:
+			s.process(task)
+		}
+	}
+}
+
+func (s *trainShard) process(task trainTask) {
+	cfg := s.cfg
+	if task.store == nil {
+		return
+	}
+	b := s.buckets[task.bucketKey]
+	if b == nil {
+		if len(s.buckets) >= s.maxBuckets {
+			s.evictOldestBucket()
+		}
+		b = &bucket{key: task.bucketKey}
+		s.buckets[task.bucketKey] = b
+	}
+	s.bucketSeq++
+	b.lastSeen = s.bucketSeq
+
+	// Add sample (already copied).
+	b.samples = append(b.samples, sample{value: task.value})
+	b.sampleBytes += len(task.value)
+	b.samplesSeen++
+	for (cfg.MaxValuesPerBucket > 0 && len(b.samples) > cfg.MaxValuesPerBucket) || (cfg.MaxBytesPerBucket > 0 && b.sampleBytes > cfg.MaxBytesPerBucket) {
+		old := b.samples[0]
+		b.samples = b.samples[1:]
+		b.sampleBytes -= len(old.value)
+	}
+	s.stats.TrainProcessed.Add(1)
+
+	if cfg.SynthesizeEverySamples <= 0 || b.samplesSeen%cfg.SynthesizeEverySamples != 0 {
+		return
+	}
+	if b.publishPending {
+		return
+	}
+	if cfg.CooldownValues > 0 && b.samplesSeen-b.lastPublishSample < cfg.CooldownValues {
+		return
+	}
+	if cfg.MaxTemplatesPerBucket > 0 && b.templatesPublished >= cfg.MaxTemplatesPerBucket {
+		return
+	}
+	if cfg.MaxTemplatesTotal > 0 && s.totalTemplates.Load() >= uint64(cfg.MaxTemplatesTotal) {
+		return
+	}
+	def, routeValue, activated, ok := synthesizeTemplate(b.samples, cfg)
+	if !ok || !activated {
+		return
+	}
+	defBytes, err := EncodeTemplateDef(def, cfg)
+	if err != nil {
+		return
+	}
+	routeFPs := RoutingFingerprints(routeValue, cfg)
+	if len(routeFPs) == 0 {
+		return
+	}
+	routeFPs = append(routeFPs, RoutingFingerprintsLegacy(routeValue, cfg)...)
+
+	b.publishPending = true
+	s.pending = append(s.pending, pendingPublish{
+		store:       task.store,
+		bucket:      b,
+		samplesSeen: b.samplesSeen,
+		def:         def,
+		defBytes:    defBytes,
+		routeFPs:    routeFPs,
+	})
+	if len(s.pending) >= cfg.PublishBatchSize {
+		s.flushPublishes(context.Background())
+	}
+}
+
+func (s *trainShard) flushPublishes(ctx context.Context) {
+	if len(s.pending) == 0 {
+		return
+	}
+	pending := s.pending
+	s.pending = nil
+
+	s.stats.PublishBatches.Add(1)
+	s.stats.PublishDefs.Add(uint64(len(pending)))
+
+	// Fast path: common case is a single store per engine.
+	firstStore := pending[0].store
+	sameStore := true
+	for i := 1; i < len(pending); i++ {
+		if pending[i].store != firstStore {
+			sameStore = false
+			break
+		}
+	}
+	if sameStore {
+		s.publishBatch(ctx, firstStore, pending)
+		return
+	}
+	for _, item := range pending {
+		s.publishBatch(ctx, item.store, []pendingPublish{item})
+	}
+}
+
+func (s *trainShard) publishBatch(ctx context.Context, store Store, items []pendingPublish) {
+	if store == nil || len(items) == 0 {
+		for i := range items {
+			if items[i].bucket != nil {
+				items[i].bucket.publishPending = false
+			}
+		}
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if bp, ok := store.(BatchPublisher); ok && len(items) > 1 {
+		specs := make([]PublishSpec, len(items))
+		for i := range items {
+			specs[i] = PublishSpec{DefBytes: items[i].defBytes, RouteFPs: items[i].routeFPs}
+		}
+		ids, err := bp.PutTemplateDefs(ctx, specs)
+		if err != nil || len(ids) != len(items) {
+			s.stats.PublishErrors.Add(1)
+			for i := range items {
+				if items[i].bucket != nil {
+					items[i].bucket.publishPending = false
+				}
+			}
+			return
+		}
+		for i := range ids {
+			s.onPublished(ids[i], items[i])
+		}
+		return
+	}
+	for i := range items {
+		id, err := store.PutTemplateDef(ctx, items[i].defBytes, items[i].routeFPs)
+		if err != nil {
+			s.stats.PublishErrors.Add(1)
+			if items[i].bucket != nil {
+				items[i].bucket.publishPending = false
+			}
+			continue
+		}
+		s.onPublished(id, items[i])
+	}
+}
+
+func (s *trainShard) onPublished(id uint64, pub pendingPublish) {
+	if id != 0 {
+		if cache := s.defCache; cache != nil {
+			cache.Add(id, pub.def)
+		}
+	}
+	if pub.bucket != nil {
+		pub.bucket.lastPublishSample = pub.samplesSeen
+		pub.bucket.templatesPublished++
+		pub.bucket.publishPending = false
+	}
+	s.totalTemplates.Add(1)
+	s.stats.TemplatesPublished.Add(1)
+}
+
+func (s *trainShard) evictOldestBucket() {
+	var (
+		oldestKey  uint64
+		oldestSeen uint64
+		set        bool
+	)
+	for k, b := range s.buckets {
+		if b == nil {
+			continue
+		}
+		if !set || b.lastSeen < oldestSeen || (b.lastSeen == oldestSeen && k < oldestKey) {
+			oldestKey = k
+			oldestSeen = b.lastSeen
+			set = true
+		}
+	}
+	if set {
+		delete(s.buckets, oldestKey)
+	}
+}

--- a/TreeDB/template/types.go
+++ b/TreeDB/template/types.go
@@ -23,6 +23,18 @@ type Store interface {
 	PutTemplateDef(ctx context.Context, defBytes []byte, routeFPs []uint64) (uint64, error)
 }
 
+// PublishSpec describes a template definition publish request.
+type PublishSpec struct {
+	DefBytes []byte
+	RouteFPs []uint64
+}
+
+// BatchPublisher is an optional extension to Store that allows publishing
+// multiple templates in a single durable batch.
+type BatchPublisher interface {
+	PutTemplateDefs(ctx context.Context, defs []PublishSpec) ([]uint64, error)
+}
+
 // TemplateDef is an ordered list of anchors.
 type TemplateDef struct {
 	Kind           TemplateKind

--- a/docs/TREEDB_BENCHMARKING.md
+++ b/docs/TREEDB_BENCHMARKING.md
@@ -60,7 +60,7 @@ go run ./TreeDB/cmd/vlog_dict_realdata \
   -train 10000 -eval 5000 -cap 0 \
   -bench-kv -bench-mode wal_off -bench-pointer-threshold 1 \
   -bench-compression off -bench-template on \
-  -bench-raw-mib 512 -bench-batch 1024 -bench-key-mode dataset \
+  -bench-raw-mib 512 -bench-batch 1024 -bench-workers 8 -bench-key-mode dataset \
   -bench-cpu-profile /tmp/treedb_template_steady.pprof
 
 go tool pprof -http=:0 /tmp/treedb_template_steady.pprof

--- a/scripts/bench_template_smoke.sh
+++ b/scripts/bench_template_smoke.sh
@@ -23,6 +23,7 @@ VALSIZE="${VALSIZE:-1024}"
 MODE="${MODE:-wal_off}"           # wal_off|wal_on
 RAW_MIB="${RAW_MIB:-64}"          # steady-state bytes written
 BATCH="${BATCH:-1024}"            # ops per batch
+WORKERS="${WORKERS:-1}"           # concurrent workers
 KEY_MODE="${KEY_MODE:-dataset}"   # random|sequential|dataset
 POINTER_THRESHOLD="${PTR_T:-1}"   # 1 forces value-log pointers
 
@@ -108,6 +109,7 @@ run_case() {
     -bench-template "$tmpl" \
     -bench-raw-mib "$RAW_MIB" \
     -bench-batch "$BATCH" \
+    -bench-workers "$WORKERS" \
     -bench-key-mode "$KEY_MODE" \
     -bench-pointer-threshold "$POINTER_THRESHOLD" \
     -bench-dict-train-mib "$DICT_TRAIN_MIB" \


### PR DESCRIPTION
Closes #268.

## What
- Move template training + publishing off the writer hot path (bounded async pipeline).
- Shard bucket state to remove the global training mutex bottleneck under concurrent writers.
- Batch template publishes (single durable commit for bursts) via optional `PutTemplateDefs` store extension.

## How
- `template.Engine` now enqueues training samples and background workers handle bucketing/synthesis/publish.
- `templatedb.Store` implements `PutTemplateDefs` so publishes coalesce into fewer `WriteSync`s.
- `caching.DB.Close()` now calls `template.Engine.Close()` to avoid goroutine leaks.
- `vlog_dict_realdata` gains `-bench-workers` for concurrency-enabled throughput tests.

## Repro
- `WORKERS=8 RAW_MIB=256 MODE=wal_off scripts/bench_template_smoke.sh`

## Notes
- Template compression remains opt-in (no behavior change unless `ValueLog.TemplateMode != off`).
