### PR TITLE
TreeDB: speed up template decode reads

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2317,7 +2317,18 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	valueLogAutotune := valuelog.NormalizeAutotuneOptions(opts.ValueLogCompressionAutotune, true)
 	valueLogTemplateEnabled := opts.ValueLogTemplateMode != template.TemplateOff
 	valueLogTemplateCfg := template.NormalizeConfig(opts.ValueLogTemplateConfig)
-	valueLogTemplateDecodeOpts := template.DecodeOptions{MaxGaps: valueLogTemplateCfg.MaxGaps, MaxDecodedBytes: valueLogTemplateCfg.MaxDecodedBytes}
+	if opts.ValueLogTemplateMode == template.TemplatePrepass {
+		// TemplatePrepass can be CPU-heavy (template match + dict/zstd encode). If
+		// templates have not been kept recently, enter cold mode sooner so we don't
+		// pay candidate lookup/matching cost on every value.
+		if opts.ValueLogTemplateConfig.ColdSearchAfter <= 0 {
+			valueLogTemplateCfg.ColdSearchAfter = 64
+		}
+		if opts.ValueLogTemplateConfig.ColdSearchProbeEvery <= 0 {
+			valueLogTemplateCfg.ColdSearchProbeEvery = 64
+		}
+	}
+	valueLogTemplateDecodeOpts := template.DecodeOptions{MaxGaps: valueLogTemplateCfg.MaxGaps, MaxDecodedBytes: valueLogTemplateCfg.MaxDecodedBytes, DefCacheSize: valueLogTemplateCfg.DefCacheSize}
 	if valueLogTemplateDecodeOpts.MaxDecodedBytes <= 0 && limits.MaxRecordSize > 0 {
 		valueLogTemplateDecodeOpts.MaxDecodedBytes = int(limits.MaxRecordSize)
 	}
@@ -3474,6 +3485,15 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			templatePrepass = true
 		}
 	}
+
+	if dictID == 0 || templatePrepass {
+		records, _ = db.valueLogTemplateEncodeRecords(records)
+		rawPayloadBytes = 0
+		for i := range records {
+			rawPayloadBytes += len(records[i].Value)
+		}
+	}
+
 	attemptCompression, probeCompression, paused := db.valueLogDictShouldAttemptCompression(rawPayloadBytes)
 	if dictID != 0 && !attemptCompression {
 		dictID = 0
@@ -3493,10 +3513,6 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			dictID = 0
 			dict = nil
 		}
-	}
-
-	if dictID == 0 || templatePrepass {
-		records, _ = db.valueLogTemplateEncodeRecords(records)
 	}
 	db.valueLogDictCollectSamples(records)
 
@@ -3759,7 +3775,6 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 		err        error
 	)
 
-	attemptCompression, probeCompression, _ := db.valueLogDictShouldAttemptCompression(len(value))
 	templatePrepass := false
 	if db.valueLogTemplateEnabled && db.valueLogTemplateMode != template.TemplateOff {
 		if db.valueLogTemplateMode == template.TemplateOnly {
@@ -3769,6 +3784,14 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 			templatePrepass = true
 		}
 	}
+
+	if (dictID == 0 || templatePrepass) && db.templateCompressionEnabled() {
+		if payload, ok := db.valueLogTemplateEngine.Encode(nil, value, db.templateStore); ok {
+			value = payload
+		}
+	}
+
+	attemptCompression, probeCompression, _ := db.valueLogDictShouldAttemptCompression(len(value))
 	if dictID != 0 && !attemptCompression {
 		dictID = 0
 		dict = nil
@@ -3786,12 +3809,6 @@ func (db *DB) appendValueLogOne(l *lane, dictID uint64, dict []byte, rid uint64,
 		}
 	}
 	db.valueLogDictCollectSample(value)
-
-	if (dictID == 0 || templatePrepass) && db.templateCompressionEnabled() {
-		if payload, ok := db.valueLogTemplateEngine.Encode(nil, value, db.templateStore); ok {
-			value = payload
-		}
-	}
 
 	l.vlogMu.Lock()
 	w := l.vlog
@@ -7623,6 +7640,16 @@ func (db *DB) Stats() map[string]string {
 	if db.valueLogTemplateEngine != nil {
 		for k, v := range db.valueLogTemplateEngine.StatsSnapshot() {
 			stats["treedb.cache.vlog_template."+k] = v
+		}
+	}
+	if db.valueLogReader != nil {
+		hits, misses, entries, capacity := db.valueLogReader.TemplateDefCacheStats()
+		stats["treedb.cache.vlog_template_def_cache.hits"] = fmt.Sprintf("%d", hits)
+		stats["treedb.cache.vlog_template_def_cache.misses"] = fmt.Sprintf("%d", misses)
+		stats["treedb.cache.vlog_template_def_cache.entries"] = fmt.Sprintf("%d", entries)
+		stats["treedb.cache.vlog_template_def_cache.capacity"] = fmt.Sprintf("%d", capacity)
+		if total := hits + misses; total > 0 {
+			stats["treedb.cache.vlog_template_def_cache.hit_ratio"] = fmt.Sprintf("%.6f", float64(hits)/float64(total))
 		}
 	}
 	stats["treedb.cache.vlog_dict.pause_remaining_bytes"] = fmt.Sprintf("%d", db.valueLogDictPauseRemaining.Load())

--- a/TreeDB/cmd/vlog_dict_realdata/main.go
+++ b/TreeDB/cmd/vlog_dict_realdata/main.go
@@ -88,50 +88,55 @@ const (
 )
 
 type benchReport struct {
-	Mode                string   `json:"mode"`
-	Compression         string   `json:"compression"`
-	Template            string   `json:"template"`
-	KeyMode             string   `json:"key_mode"`
-	RawMiB              int      `json:"raw_mib"`
-	Batch               int      `json:"batch"`
-	Workers             int      `json:"workers,omitempty"`
-	PointerThreshold    int      `json:"pointer_threshold"`
-	FlushThresholdMiB   int      `json:"flush_threshold_mib,omitempty"`
-	DictTrainMiB        int      `json:"dict_train_mib,omitempty"`
-	DictSampleStride    int      `json:"dict_sample_stride,omitempty"`
-	LoadSeconds         float64  `json:"load_seconds"`
-	PreSteadyDictID     *uint64  `json:"pre_steady_dict_id,omitempty"`
-	PreSteadyFramesKept *uint64  `json:"pre_steady_frames_kept,omitempty"`
-	TrainSeconds        float64  `json:"train_seconds"`
-	TrainRawBytes       int64    `json:"train_raw_bytes"`
-	TrainRecords        int      `json:"train_records"`
-	SteadySeconds       float64  `json:"steady_seconds"`
-	SteadyRawBytes      int64    `json:"steady_raw_bytes"`
-	SteadyRecords       int      `json:"steady_records"`
-	SteadyRawMBps       float64  `json:"steady_raw_MBps"`
-	SpeedupVsOff        *float64 `json:"speedup_vs_off,omitempty"`
-	AttemptedFrac       *float64 `json:"attempted_frac,omitempty"`
-	KeptFrac            *float64 `json:"kept_frac,omitempty"`
-	CurrentK            *int     `json:"current_k,omitempty"`
-	DictID              *uint64  `json:"dict_id,omitempty"`
-	FramesTotal         *uint64  `json:"frames_total,omitempty"`
-	FramesAttempted     *uint64  `json:"frames_attempted,omitempty"`
-	FramesKept          *uint64  `json:"frames_kept,omitempty"`
-	KeptOfAttemptedFrac *float64 `json:"kept_of_attempted_frac,omitempty"`
-	TemplateAttempted   *uint64  `json:"template_attempted,omitempty"`
-	TemplateMatched     *uint64  `json:"template_matched,omitempty"`
-	TemplateKept        *uint64  `json:"template_kept,omitempty"`
-	TemplateSavedBytes  *uint64  `json:"template_saved_bytes,omitempty"`
-	TemplatesPublished  *uint64  `json:"templates_published,omitempty"`
-	MaskSparseUsed      *uint64  `json:"mask_sparse_used,omitempty"`
-	MaskFullUsed        *uint64  `json:"mask_full_used,omitempty"`
-	MaskSparseFrac      *float64 `json:"mask_sparse_frac,omitempty"`
-	ValueLogBytes       int64    `json:"value_log_bytes,omitempty"`
-	IndexBytes          int64    `json:"index_bytes,omitempty"`
-	WritePathMode       string   `json:"write_path_mode"`
-	WritePathValueStore string   `json:"write_path_value_store"`
-	WritePathRedoLog    string   `json:"write_path_redo_log"`
-	BenchDir            string   `json:"bench_dir"`
+	Mode                     string   `json:"mode"`
+	Compression              string   `json:"compression"`
+	Template                 string   `json:"template"`
+	KeyMode                  string   `json:"key_mode"`
+	RawMiB                   int      `json:"raw_mib"`
+	Batch                    int      `json:"batch"`
+	Workers                  int      `json:"workers,omitempty"`
+	PointerThreshold         int      `json:"pointer_threshold"`
+	FlushThresholdMiB        int      `json:"flush_threshold_mib,omitempty"`
+	DictTrainMiB             int      `json:"dict_train_mib,omitempty"`
+	DictSampleStride         int      `json:"dict_sample_stride,omitempty"`
+	LoadSeconds              float64  `json:"load_seconds"`
+	PreSteadyDictID          *uint64  `json:"pre_steady_dict_id,omitempty"`
+	PreSteadyFramesKept      *uint64  `json:"pre_steady_frames_kept,omitempty"`
+	TrainSeconds             float64  `json:"train_seconds"`
+	TrainRawBytes            int64    `json:"train_raw_bytes"`
+	TrainRecords             int      `json:"train_records"`
+	SteadySeconds            float64  `json:"steady_seconds"`
+	SteadyRawBytes           int64    `json:"steady_raw_bytes"`
+	SteadyRecords            int      `json:"steady_records"`
+	SteadyRawMBps            float64  `json:"steady_raw_MBps"`
+	SpeedupVsOff             *float64 `json:"speedup_vs_off,omitempty"`
+	AttemptedFrac            *float64 `json:"attempted_frac,omitempty"`
+	KeptFrac                 *float64 `json:"kept_frac,omitempty"`
+	CurrentK                 *int     `json:"current_k,omitempty"`
+	DictID                   *uint64  `json:"dict_id,omitempty"`
+	FramesTotal              *uint64  `json:"frames_total,omitempty"`
+	FramesAttempted          *uint64  `json:"frames_attempted,omitempty"`
+	FramesKept               *uint64  `json:"frames_kept,omitempty"`
+	KeptOfAttemptedFrac      *float64 `json:"kept_of_attempted_frac,omitempty"`
+	TemplateAttempted        *uint64  `json:"template_attempted,omitempty"`
+	TemplateMatched          *uint64  `json:"template_matched,omitempty"`
+	TemplateKept             *uint64  `json:"template_kept,omitempty"`
+	TemplateSavedBytes       *uint64  `json:"template_saved_bytes,omitempty"`
+	TemplatesPublished       *uint64  `json:"templates_published,omitempty"`
+	MaskSparseUsed           *uint64  `json:"mask_sparse_used,omitempty"`
+	MaskFullUsed             *uint64  `json:"mask_full_used,omitempty"`
+	MaskSparseFrac           *float64 `json:"mask_sparse_frac,omitempty"`
+	TemplateDefCacheHits     *uint64  `json:"template_def_cache_hits,omitempty"`
+	TemplateDefCacheMisses   *uint64  `json:"template_def_cache_misses,omitempty"`
+	TemplateDefCacheHitRatio *float64 `json:"template_def_cache_hit_ratio,omitempty"`
+	TemplateDefCacheEntries  *uint64  `json:"template_def_cache_entries,omitempty"`
+	TemplateDefCacheCapacity *uint64  `json:"template_def_cache_capacity,omitempty"`
+	ValueLogBytes            int64    `json:"value_log_bytes,omitempty"`
+	IndexBytes               int64    `json:"index_bytes,omitempty"`
+	WritePathMode            string   `json:"write_path_mode"`
+	WritePathValueStore      string   `json:"write_path_value_store"`
+	WritePathRedoLog         string   `json:"write_path_redo_log"`
+	BenchDir                 string   `json:"bench_dir"`
 }
 
 type benchKeyState struct {
@@ -753,6 +758,18 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 			maskSparseFracOK = true
 		}
 	}
+	templateDefCacheHits, templateDefCacheHitsOK := parseStatUint(statsEnd, "treedb.cache.vlog_template_def_cache.hits")
+	templateDefCacheMisses, templateDefCacheMissesOK := parseStatUint(statsEnd, "treedb.cache.vlog_template_def_cache.misses")
+	templateDefCacheEntries, templateDefCacheEntriesOK := parseStatUint(statsEnd, "treedb.cache.vlog_template_def_cache.entries")
+	templateDefCacheCapacity, templateDefCacheCapacityOK := parseStatUint(statsEnd, "treedb.cache.vlog_template_def_cache.capacity")
+	templateDefCacheHitRatio := 0.0
+	templateDefCacheHitRatioOK := false
+	if templateDefCacheHitsOK && templateDefCacheMissesOK {
+		if total := templateDefCacheHits + templateDefCacheMisses; total > 0 {
+			templateDefCacheHitRatio = float64(templateDefCacheHits) / float64(total)
+			templateDefCacheHitRatioOK = true
+		}
+	}
 	keptOfAttempted := 0.0
 	keptOfAttemptedOK := false
 	if framesAttemptedOK && framesKeptOK && framesAttempted > 0 {
@@ -786,6 +803,13 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 			formatStatUint(maskSparse, maskSparseOK),
 			formatStatUint(maskFull, maskFullOK),
 			formatStatFloat(maskSparseFrac, maskSparseFracOK),
+		)
+		fmt.Printf("vlog_template_def_cache: hits=%s misses=%s hit_ratio=%s entries=%s capacity=%s\n",
+			formatStatUint(templateDefCacheHits, templateDefCacheHitsOK),
+			formatStatUint(templateDefCacheMisses, templateDefCacheMissesOK),
+			formatStatFloat(templateDefCacheHitRatio, templateDefCacheHitRatioOK),
+			formatStatUint(templateDefCacheEntries, templateDefCacheEntriesOK),
+			formatStatUint(templateDefCacheCapacity, templateDefCacheCapacityOK),
 		)
 	}
 	fmt.Printf("disk:     value_log_bytes=%d (%.1f MiB) index_bytes=%d (%.1f MiB)\n",
@@ -937,6 +961,41 @@ func runKVBench(input string, capBytes int, cfg benchConfig, train, eval []kvSam
 		MaskSparseFrac: func() *float64 {
 			if maskSparseFracOK {
 				v := maskSparseFrac
+				return &v
+			}
+			return nil
+		}(),
+		TemplateDefCacheHits: func() *uint64 {
+			if templateDefCacheHitsOK {
+				v := templateDefCacheHits
+				return &v
+			}
+			return nil
+		}(),
+		TemplateDefCacheMisses: func() *uint64 {
+			if templateDefCacheMissesOK {
+				v := templateDefCacheMisses
+				return &v
+			}
+			return nil
+		}(),
+		TemplateDefCacheHitRatio: func() *float64 {
+			if templateDefCacheHitRatioOK {
+				v := templateDefCacheHitRatio
+				return &v
+			}
+			return nil
+		}(),
+		TemplateDefCacheEntries: func() *uint64 {
+			if templateDefCacheEntriesOK {
+				v := templateDefCacheEntries
+				return &v
+			}
+			return nil
+		}(),
+		TemplateDefCacheCapacity: func() *uint64 {
+			if templateDefCacheCapacityOK {
+				v := templateDefCacheCapacity
 				return &v
 			}
 			return nil

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -254,6 +254,15 @@ func (db *DB) Stats() map[string]string {
 		vlogRemaps, vlogDeadMappings := db.valueLogManager.RemapStats()
 		stats["treedb.vlog.mmap_remaps"] = fmt.Sprintf("%d", vlogRemaps)
 		stats["treedb.vlog.mmap_dead_mappings"] = fmt.Sprintf("%d", vlogDeadMappings)
+
+		hits, misses, entries, capacity := db.valueLogManager.TemplateDefCacheStats()
+		stats["treedb.vlog.template_def_cache.hits"] = fmt.Sprintf("%d", hits)
+		stats["treedb.vlog.template_def_cache.misses"] = fmt.Sprintf("%d", misses)
+		stats["treedb.vlog.template_def_cache.entries"] = fmt.Sprintf("%d", entries)
+		stats["treedb.vlog.template_def_cache.capacity"] = fmt.Sprintf("%d", capacity)
+		if total := hits + misses; total > 0 {
+			stats["treedb.vlog.template_def_cache.hit_ratio"] = fmt.Sprintf("%.6f", float64(hits)/float64(total))
+		}
 	}
 
 	pruneStatsInto(stats, &db.pruner)

--- a/TreeDB/internal/valuelog/dict_read_bench_test.go
+++ b/TreeDB/internal/valuelog/dict_read_bench_test.go
@@ -154,7 +154,7 @@ func BenchmarkValueLogDictReadCPU_NoIO(b *testing.B) {
 						}
 
 						// Warm up dict codec cache outside the timed loop.
-						if _, err := decodeRecord(header[:], frame, ptr, false, dictLookup, nil, templ.DecodeOptions{}); err != nil {
+						if _, err := decodeRecord(header[:], frame, ptr, false, dictLookup, nil, nil, templ.DecodeOptions{}); err != nil {
 							b.Fatalf("decode warmup: %v", err)
 						}
 
@@ -164,7 +164,7 @@ func BenchmarkValueLogDictReadCPU_NoIO(b *testing.B) {
 
 						sink := byte(0)
 						for i := 0; i < b.N; i++ {
-							v, err := decodeRecord(header[:], frame, ptr, false, dictLookup, nil, templ.DecodeOptions{})
+							v, err := decodeRecord(header[:], frame, ptr, false, dictLookup, nil, nil, templ.DecodeOptions{})
 							if err != nil {
 								b.Fatalf("decodeRecord: %v", err)
 							}

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -27,6 +27,7 @@ type File struct {
 	dictLookup         DictLookup
 	templateLookup     TemplateLookup
 	templateDecodeOpts templ.DecodeOptions
+	templateDefCache   *templateDefCache
 
 	cacheMu    sync.Mutex
 	cacheStart atomic.Int64
@@ -48,12 +49,12 @@ type File struct {
 	deadMappingsCount atomic.Uint64
 }
 
-func openFile(path string, id uint32, dictLookup DictLookup, templateLookup TemplateLookup, templateOpts templ.DecodeOptions) (*File, error) {
+func openFile(path string, id uint32, dictLookup DictLookup, templateLookup TemplateLookup, templateOpts templ.DecodeOptions, templateCache *templateDefCache) (*File, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	vf := &File{ID: id, Path: path, File: f, dictLookup: dictLookup, templateLookup: templateLookup, templateDecodeOpts: templateOpts}
+	vf := &File{ID: id, Path: path, File: f, dictLookup: dictLookup, templateLookup: templateLookup, templateDecodeOpts: templateOpts, templateDefCache: templateCache}
 	vf.mmapData.Store([]byte(nil))
 	vf.maybeScheduleRemap()
 	return vf, nil
@@ -88,7 +89,7 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 	if val, err, ok := f.readViaMmap(ptr, verifyCRC); ok {
 		return val, err
 	}
-	return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDecodeOpts)
+	return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
 }
 
 func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
@@ -102,7 +103,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 	if val, err, ok := f.readViaMmapView(ptr, verifyCRC); ok {
 		return val, err
 	}
-	return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDecodeOpts)
+	return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
 }
 
 func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte, error) {
@@ -160,13 +161,17 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 					return nil, err
 				}
 				if f.templateLookup != nil && templ.IsEncodedPayload(dst[oldLen:]) {
-					decoded, err := templ.DecodePayload(dst[oldLen:], func(id uint64) ([]byte, error) {
-						return f.templateLookup(id)
+					payload := dst[oldLen:]
+					decodedStart := len(dst)
+					dst, err := templ.DecodePayloadAppend(dst, payload, func(id uint64) (templ.TemplateDef, error) {
+						return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
 					}, f.templateDecodeOpts)
 					if err != nil {
 						return nil, err
 					}
-					dst = append(dst[:oldLen], decoded...)
+					decodedLen := len(dst) - decodedStart
+					copy(dst[oldLen:], dst[decodedStart:])
+					dst = dst[:oldLen+decodedLen]
 				}
 				return dst, nil
 			}
@@ -188,7 +193,7 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 		fFlags := frameHeader[1]
 		if fFlags&FrameFlagCompressed != 0 {
 			// Fallback to the full decoder (will allocate).
-			val, err := ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDecodeOpts)
+			val, err := ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
 			if err != nil {
 				return nil, err
 			}
@@ -255,19 +260,23 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 			return nil, err
 		}
 		if f.templateLookup != nil && templ.IsEncodedPayload(dst[oldLen:]) {
-			decoded, err := templ.DecodePayload(dst[oldLen:], func(id uint64) ([]byte, error) {
-				return f.templateLookup(id)
+			payload := dst[oldLen:]
+			decodedStart := len(dst)
+			dst, err := templ.DecodePayloadAppend(dst, payload, func(id uint64) (templ.TemplateDef, error) {
+				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
 			}, f.templateDecodeOpts)
 			if err != nil {
 				return nil, err
 			}
-			dst = append(dst[:oldLen], decoded...)
+			decodedLen := len(dst) - decodedStart
+			copy(dst[oldLen:], dst[decodedStart:])
+			dst = dst[:oldLen+decodedLen]
 		}
 		return dst, nil
 	}
 
 	// Slow path: use existing decoder and append.
-	val, err := ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDecodeOpts)
+	val, err := ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -330,6 +339,7 @@ type Manager struct {
 	dictLookup          DictLookup
 	templateLookup      TemplateLookup
 	templateDecodeOpts  templ.DecodeOptions
+	templateDefCache    *templateDefCache
 }
 
 func NewManager(dir string) (*Manager, error) {
@@ -363,9 +373,11 @@ func (m *Manager) SetTemplateLookup(lookup TemplateLookup, opts templ.DecodeOpti
 	defer m.mu.Unlock()
 	m.templateLookup = lookup
 	m.templateDecodeOpts = opts
+	m.templateDefCache = newTemplateDefCache(opts.DefCacheSize)
 	for _, f := range m.files {
 		f.templateLookup = lookup
 		f.templateDecodeOpts = opts
+		f.templateDefCache = m.templateDefCache
 	}
 }
 func (m *Manager) Close() error {
@@ -399,7 +411,7 @@ func (m *Manager) Refresh() error {
 		if _, ok := m.files[seg.id]; ok {
 			continue
 		}
-		f, err := openFile(seg.path, seg.id, m.dictLookup, m.templateLookup, m.templateDecodeOpts)
+		f, err := openFile(seg.path, seg.id, m.dictLookup, m.templateLookup, m.templateDecodeOpts, m.templateDefCache)
 		if err != nil {
 			return err
 		}
@@ -556,6 +568,19 @@ func (m *Manager) RemapStats() (remaps uint64, deadMappings uint64) {
 		deadMappings += f.deadMappingsCount.Load()
 	}
 	return remaps, deadMappings
+}
+
+func (m *Manager) TemplateDefCacheStats() (hits, misses uint64, entries, capacity int) {
+	if m == nil {
+		return 0, 0, 0, 0
+	}
+	m.mu.RLock()
+	cache := m.templateDefCache
+	m.mu.RUnlock()
+	if cache == nil {
+		return 0, 0, 0, 0
+	}
+	return cache.Stats()
 }
 
 func (m *Manager) RemoveSegment(id uint32) error {

--- a/TreeDB/internal/valuelog/mmap_safety_test.go
+++ b/TreeDB/internal/valuelog/mmap_safety_test.go
@@ -50,7 +50,7 @@ func TestMmapSafety_ZeroCopy_Remap(t *testing.T) {
 		t.Fatalf("Flush 1: %v", err)
 	}
 
-	f, err := openFile(path, fileID, nil, nil, templ.DecodeOptions{})
+	f, err := openFile(path, fileID, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
 		t.Fatalf("openFile: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestMmapSafety_Concurrent_Remap(t *testing.T) {
 		t.Fatalf("Flush: %v", err)
 	}
 
-	f, err := openFile(path, fileID, nil, nil, templ.DecodeOptions{})
+	f, err := openFile(path, fileID, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
 		t.Fatalf("openFile: %v", err)
 	}

--- a/TreeDB/internal/valuelog/reader.go
+++ b/TreeDB/internal/valuelog/reader.go
@@ -53,6 +53,7 @@ type Reader struct {
 	dictLookup         DictLookup
 	templateLookup     TemplateLookup
 	templateDecodeOpts templ.DecodeOptions
+	templateDefCache   *templateDefCache
 	pending            []frameEntry
 	pendingIndex       int
 }
@@ -99,6 +100,7 @@ func (r *Reader) SetDictLookup(lookup DictLookup) {
 func (r *Reader) SetTemplateLookup(lookup TemplateLookup, opts templ.DecodeOptions) {
 	r.templateLookup = lookup
 	r.templateDecodeOpts = opts
+	r.templateDefCache = newTemplateDefCache(opts.DefCacheSize)
 }
 
 func (r *Reader) ReadNext() (uint64, []byte, page.ValuePtr, error) {
@@ -200,8 +202,8 @@ func (r *Reader) ReadNext() (uint64, []byte, page.ValuePtr, error) {
 			}
 			val = raw[start:end]
 			if r.templateLookup != nil && templ.IsEncodedPayload(val) {
-				decoded, decErr := templ.DecodePayload(val, func(id uint64) ([]byte, error) {
-					return r.templateLookup(id)
+				decoded, decErr := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
+					return resolveTemplateDef(id, r.templateLookup, r.templateDefCache)
 				}, r.templateDecodeOpts)
 				if decErr != nil {
 					return 0, nil, page.ValuePtr{}, decErr
@@ -293,10 +295,10 @@ func decodeFramePayloadTo(header FrameHeader, payload []byte, dictLookup DictLoo
 }
 
 func ReadAt(f *os.File, ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
-	return ReadAtWithDict(f, ptr, verifyCRC, nil, nil, templ.DecodeOptions{})
+	return ReadAtWithDict(f, ptr, verifyCRC, nil, nil, nil, templ.DecodeOptions{})
 }
 
-func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateOpts templ.DecodeOptions) ([]byte, error) {
+func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions) ([]byte, error) {
 	if f == nil {
 		return nil, errors.New("valuelog: nil file")
 	}
@@ -410,8 +412,8 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 				return nil, err
 			}
 			if templateLookup != nil && templ.IsEncodedPayload(val) {
-				decoded, err := templ.DecodePayload(val, func(id uint64) ([]byte, error) {
-					return templateLookup(id)
+				decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
+					return resolveTemplateDef(id, templateLookup, templateCache)
 				}, templateOpts)
 				if err != nil {
 					return nil, err
@@ -432,10 +434,10 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 			return nil, ErrCorrupt
 		}
 	}
-	return decodeRecord(header[:], payload, ptr, false, dictLookup, templateLookup, templateOpts)
+	return decodeRecord(header[:], payload, ptr, false, dictLookup, templateLookup, templateCache, templateOpts)
 }
 
-func decodeRecord(header []byte, payload []byte, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateOpts templ.DecodeOptions) ([]byte, error) {
+func decodeRecord(header []byte, payload []byte, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions) ([]byte, error) {
 	if len(header) < HeaderSize {
 		return nil, ErrCorrupt
 	}
@@ -470,8 +472,8 @@ func decodeRecord(header []byte, payload []byte, ptr page.ValuePtr, verifyCRC bo
 			return nil, ErrCorrupt
 		}
 		if templateLookup != nil && templ.IsEncodedPayload(payload) {
-			decoded, err := templ.DecodePayload(payload, func(id uint64) ([]byte, error) {
-				return templateLookup(id)
+			decoded, err := templ.DecodePayloadAppend(nil, payload, func(id uint64) (templ.TemplateDef, error) {
+				return resolveTemplateDef(id, templateLookup, templateCache)
 			}, templateOpts)
 			if err != nil {
 				return nil, err
@@ -522,8 +524,8 @@ func decodeRecord(header []byte, payload []byte, ptr page.ValuePtr, verifyCRC bo
 		copy(val, raw[start:end])
 		putDecodeScratch(raw)
 		if templateLookup != nil && templ.IsEncodedPayload(val) {
-			decoded, err := templ.DecodePayload(val, func(id uint64) ([]byte, error) {
-				return templateLookup(id)
+			decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
+				return resolveTemplateDef(id, templateLookup, templateCache)
 			}, templateOpts)
 			if err != nil {
 				return nil, err
@@ -541,8 +543,8 @@ func decodeRecord(header []byte, payload []byte, ptr page.ValuePtr, verifyCRC bo
 	}
 	val := raw[start:end]
 	if templateLookup != nil && templ.IsEncodedPayload(val) {
-		decoded, err := templ.DecodePayload(val, func(id uint64) ([]byte, error) {
-			return templateLookup(id)
+		decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
+			return resolveTemplateDef(id, templateLookup, templateCache)
 		}, templateOpts)
 		if err != nil {
 			return nil, err

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -136,6 +136,15 @@ func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error
 
 	// Non-grouped record: the payload is the value.
 	if flags&recordFlagGrouped == 0 {
+		if f.templateLookup != nil && templ.IsEncodedPayload(payload) {
+			decoded, err := templ.DecodePayloadAppend(nil, payload, func(id uint64) (templ.TemplateDef, error) {
+				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
+			}, f.templateDecodeOpts)
+			if err != nil {
+				return nil, err, true
+			}
+			return decoded, nil, true
+		}
 		return payload, nil, true
 	}
 
@@ -191,7 +200,17 @@ func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error
 				if srcStart < 0 || srcEnd < srcStart || srcEnd > len(payload) {
 					return nil, ErrCorrupt, true
 				}
-				return payload[srcStart:srcEnd], nil, true
+				val := payload[srcStart:srcEnd]
+				if f.templateLookup != nil && templ.IsEncodedPayload(val) {
+					decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
+						return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
+					}, f.templateDecodeOpts)
+					if err != nil {
+						return nil, err, true
+					}
+					return decoded, nil, true
+				}
+				return val, nil, true
 			}
 			f.cacheMu.Unlock()
 		}
@@ -236,11 +255,21 @@ func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error
 		if srcStart < 0 || srcEnd < srcStart || srcEnd > len(payload) {
 			return nil, ErrCorrupt, true
 		}
-		return payload[srcStart:srcEnd], nil, true
+		val := payload[srcStart:srcEnd]
+		if f.templateLookup != nil && templ.IsEncodedPayload(val) {
+			decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
+				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
+			}, f.templateDecodeOpts)
+			if err != nil {
+				return nil, err, true
+			}
+			return decoded, nil, true
+		}
+		return val, nil, true
 	}
 
 	// Compressed grouped record: decode (allocates).
-	val, err := decodeRecord(header, payload, ptr, false, f.dictLookup, f.templateLookup, f.templateDecodeOpts)
+	val, err := decodeRecord(header, payload, ptr, false, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
 	if err != nil {
 		return nil, err, true
 	}
@@ -299,13 +328,17 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		dst = grow(dst, len(payload))
 		copy(dst[oldLen:], payload)
 		if f.templateLookup != nil && templ.IsEncodedPayload(dst[oldLen:]) {
-			decoded, err := templ.DecodePayload(dst[oldLen:], func(id uint64) ([]byte, error) {
-				return f.templateLookup(id)
+			payload := dst[oldLen:]
+			decodedStart := len(dst)
+			dst, err := templ.DecodePayloadAppend(dst, payload, func(id uint64) (templ.TemplateDef, error) {
+				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
 			}, f.templateDecodeOpts)
 			if err != nil {
 				return nil, err, true
 			}
-			dst = append(dst[:oldLen], decoded...)
+			decodedLen := len(dst) - decodedStart
+			copy(dst[oldLen:], dst[decodedStart:])
+			dst = dst[:oldLen+decodedLen]
 		}
 		return dst, nil, true
 	}
@@ -325,7 +358,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 	fFlags := frameHeader[1]
 
-	if !verifyCRC && fFlags&FrameFlagCompressed == 0 {
+	if fFlags&FrameFlagCompressed == 0 {
 		subIndex := int(page.ValuePtrSubIndex(ptr))
 		if subIndex < 0 || subIndex >= k {
 			return nil, ErrCorrupt, true
@@ -360,13 +393,17 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 				srcEnd := srcStart + n
 				copy(dst[oldLen:], payload[srcStart:srcEnd])
 				if f.templateLookup != nil && templ.IsEncodedPayload(dst[oldLen:]) {
-					decoded, err := templ.DecodePayload(dst[oldLen:], func(id uint64) ([]byte, error) {
-						return f.templateLookup(id)
+					payload := dst[oldLen:]
+					decodedStart := len(dst)
+					dst, err := templ.DecodePayloadAppend(dst, payload, func(id uint64) (templ.TemplateDef, error) {
+						return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
 					}, f.templateDecodeOpts)
 					if err != nil {
 						return nil, err, true
 					}
-					dst = append(dst[:oldLen], decoded...)
+					decodedLen := len(dst) - decodedStart
+					copy(dst[oldLen:], dst[decodedStart:])
+					dst = dst[:oldLen+decodedLen]
 				}
 				return dst, nil, true
 			}
@@ -414,18 +451,22 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		srcEnd := srcStart + n
 		copy(dst[oldLen:], payload[srcStart:srcEnd])
 		if f.templateLookup != nil && templ.IsEncodedPayload(dst[oldLen:]) {
-			decoded, err := templ.DecodePayload(dst[oldLen:], func(id uint64) ([]byte, error) {
-				return f.templateLookup(id)
+			payload := dst[oldLen:]
+			decodedStart := len(dst)
+			dst, err := templ.DecodePayloadAppend(dst, payload, func(id uint64) (templ.TemplateDef, error) {
+				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
 			}, f.templateDecodeOpts)
 			if err != nil {
 				return nil, err, true
 			}
-			dst = append(dst[:oldLen], decoded...)
+			decodedLen := len(dst) - decodedStart
+			copy(dst[oldLen:], dst[decodedStart:])
+			dst = dst[:oldLen+decodedLen]
 		}
 		return dst, nil, true
 	}
 
-	val, err := decodeRecord(header, payload, ptr, false, f.dictLookup, f.templateLookup, f.templateDecodeOpts)
+	val, err := decodeRecord(header, payload, ptr, false, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
 	if err != nil {
 		return nil, err, true
 	}

--- a/TreeDB/internal/valuelog/template_cache.go
+++ b/TreeDB/internal/valuelog/template_cache.go
@@ -1,0 +1,95 @@
+package valuelog
+
+import (
+	"container/list"
+	"sync"
+	"sync/atomic"
+
+	templ "github.com/snissn/gomap/TreeDB/template"
+)
+
+type templateDefCache struct {
+	maxEntries int
+
+	mu sync.Mutex
+	ll list.List
+	m  map[uint64]*list.Element
+
+	hits   atomic.Uint64
+	misses atomic.Uint64
+}
+
+type templateDefCacheEntry struct {
+	id  uint64
+	def templ.TemplateDef
+}
+
+func newTemplateDefCache(maxEntries int) *templateDefCache {
+	if maxEntries <= 0 {
+		return nil
+	}
+	return &templateDefCache{
+		maxEntries: maxEntries,
+		m:          make(map[uint64]*list.Element, maxEntries),
+	}
+}
+
+func (c *templateDefCache) Stats() (hits, misses uint64, entries, capacity int) {
+	if c == nil {
+		return 0, 0, 0, 0
+	}
+	c.mu.Lock()
+	entries = len(c.m)
+	capacity = c.maxEntries
+	c.mu.Unlock()
+	return c.hits.Load(), c.misses.Load(), entries, capacity
+}
+
+func (c *templateDefCache) Get(id uint64) (templ.TemplateDef, bool) {
+	if c == nil || id == 0 {
+		return templ.TemplateDef{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if elem := c.m[id]; elem != nil {
+		c.ll.MoveToFront(elem)
+		c.hits.Add(1)
+		if ent, ok := elem.Value.(*templateDefCacheEntry); ok && ent != nil {
+			return ent.def, true
+		}
+		return templ.TemplateDef{}, true
+	}
+	c.misses.Add(1)
+	return templ.TemplateDef{}, false
+}
+
+func (c *templateDefCache) Add(id uint64, def templ.TemplateDef) {
+	if c == nil || id == 0 || c.maxEntries <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if elem := c.m[id]; elem != nil {
+		if ent, ok := elem.Value.(*templateDefCacheEntry); ok && ent != nil {
+			ent.def = def
+		} else {
+			elem.Value = &templateDefCacheEntry{id: id, def: def}
+		}
+		c.ll.MoveToFront(elem)
+		return
+	}
+	elem := c.ll.PushFront(&templateDefCacheEntry{id: id, def: def})
+	c.m[id] = elem
+	if len(c.m) <= c.maxEntries {
+		return
+	}
+	back := c.ll.Back()
+	if back == nil {
+		return
+	}
+	ent, ok := back.Value.(*templateDefCacheEntry)
+	if ok && ent != nil {
+		delete(c.m, ent.id)
+	}
+	c.ll.Remove(back)
+}

--- a/TreeDB/internal/valuelog/template_cache_test.go
+++ b/TreeDB/internal/valuelog/template_cache_test.go
@@ -1,0 +1,61 @@
+package valuelog
+
+import (
+	"testing"
+
+	templ "github.com/snissn/gomap/TreeDB/template"
+)
+
+func TestTemplateDefCacheLRU(t *testing.T) {
+	c := newTemplateDefCache(2)
+	if c == nil {
+		t.Fatalf("expected cache")
+	}
+
+	def1 := templ.TemplateDef{Kind: templ.TemplateAnchors, Anchors: [][]byte{[]byte("A")}}
+	def2 := templ.TemplateDef{Kind: templ.TemplateAnchors, Anchors: [][]byte{[]byte("B")}}
+	def3 := templ.TemplateDef{Kind: templ.TemplateAnchors, Anchors: [][]byte{[]byte("C")}}
+
+	c.Add(1, def1)
+	c.Add(2, def2)
+	hits, misses, entries, cap := c.Stats()
+	if hits != 0 || misses != 0 {
+		t.Fatalf("unexpected stats hits=%d misses=%d", hits, misses)
+	}
+	if entries != 2 || cap != 2 {
+		t.Fatalf("unexpected size entries=%d cap=%d", entries, cap)
+	}
+
+	if _, ok := c.Get(1); !ok {
+		t.Fatalf("expected hit for id=1")
+	}
+	c.Add(3, def3) // should evict id=2 (LRU)
+
+	if _, ok := c.Get(2); ok {
+		t.Fatalf("expected id=2 to be evicted")
+	}
+	if got, ok := c.Get(3); !ok {
+		t.Fatalf("expected hit for id=3")
+	} else if len(got.Anchors) != 1 || string(got.Anchors[0]) != "C" {
+		t.Fatalf("unexpected def for id=3: %#v", got)
+	}
+
+	hits, misses, entries, cap = c.Stats()
+	if entries != 2 || cap != 2 {
+		t.Fatalf("unexpected size after eviction entries=%d cap=%d", entries, cap)
+	}
+	if hits != 2 || misses != 1 {
+		t.Fatalf("unexpected stats hits=%d misses=%d", hits, misses)
+	}
+}
+
+func TestTemplateDefCacheDisabled(t *testing.T) {
+	if c := newTemplateDefCache(0); c != nil {
+		t.Fatalf("expected nil cache for size=0")
+	}
+	var c *templateDefCache
+	hits, misses, entries, cap := c.Stats()
+	if hits != 0 || misses != 0 || entries != 0 || cap != 0 {
+		t.Fatalf("unexpected stats for nil cache")
+	}
+}

--- a/TreeDB/internal/valuelog/template_lookup.go
+++ b/TreeDB/internal/valuelog/template_lookup.go
@@ -1,0 +1,28 @@
+package valuelog
+
+import (
+	templ "github.com/snissn/gomap/TreeDB/template"
+)
+
+func resolveTemplateDef(id uint64, lookup TemplateLookup, cache *templateDefCache) (templ.TemplateDef, error) {
+	if cache != nil {
+		if def, ok := cache.Get(id); ok {
+			return def, nil
+		}
+	}
+	if lookup == nil {
+		return templ.TemplateDef{}, ErrMissingTemplate
+	}
+	defBytes, err := lookup(id)
+	if err != nil {
+		return templ.TemplateDef{}, err
+	}
+	def, err := templ.DecodeTemplateDef(defBytes)
+	if err != nil {
+		return templ.TemplateDef{}, err
+	}
+	if cache != nil {
+		cache.Add(id, def)
+	}
+	return def, nil
+}

--- a/TreeDB/internal/valuelog/template_read_bench_test.go
+++ b/TreeDB/internal/valuelog/template_read_bench_test.go
@@ -1,0 +1,268 @@
+package valuelog
+
+import (
+	"bytes"
+	"math/rand"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+	templ "github.com/snissn/gomap/TreeDB/template"
+)
+
+func BenchmarkValueLogTemplateReadAppend(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "value-000001.log")
+	fileID := page.ValueLogFileID(1)
+
+	anchorA := bytes.Repeat([]byte{'A'}, 16)
+	anchorB := bytes.Repeat([]byte{'B'}, 16)
+	def := templ.TemplateDef{Kind: templ.TemplateAnchors, Anchors: [][]byte{anchorA, anchorB}}
+	defBytes, err := templ.EncodeTemplateDef(def, templ.Config{})
+	if err != nil {
+		b.Fatalf("EncodeTemplateDef: %v", err)
+	}
+	templateLookup := func(id uint64) ([]byte, error) {
+		if id != 1 {
+			return nil, ErrMissingTemplate
+		}
+		return defBytes, nil
+	}
+
+	gap0 := bytes.Repeat([]byte{'x'}, 32)
+	gap1 := bytes.Repeat([]byte{'y'}, 32)
+	gap2 := bytes.Repeat([]byte{'z'}, 32)
+	payload, err := templ.EncodePayload(1, [][]byte{gap0, gap1, gap2})
+	if err != nil {
+		b.Fatalf("EncodePayload: %v", err)
+	}
+
+	const frames = 256
+	writePtrs := make([]page.ValuePtr, 0, frames*MaxFrameK)
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		b.Fatalf("NewWriter: %v", err)
+	}
+	rid := uint64(1)
+	for i := 0; i < frames; i++ {
+		var recs [MaxFrameK]Record
+		for j := 0; j < MaxFrameK; j++ {
+			recs[j] = Record{RID: rid, Value: payload}
+			rid++
+		}
+		ptrs, err := w.AppendFrame(0, nil, recs[:])
+		if err != nil {
+			_ = w.Close()
+			b.Fatalf("AppendFrame: %v", err)
+		}
+		writePtrs = append(writePtrs, ptrs...)
+	}
+	if err := w.Close(); err != nil {
+		b.Fatalf("Close: %v", err)
+	}
+
+	outExample, err := templ.DecodePayloadAppend(nil, payload, func(uint64) (templ.TemplateDef, error) {
+		return def, nil
+	}, templ.DecodeOptions{MaxDecodedBytes: 1 << 20, MaxGaps: 16})
+	if err != nil {
+		b.Fatalf("DecodePayloadAppend: %v", err)
+	}
+	decodedLen := len(outExample)
+	if decodedLen == 0 {
+		b.Fatalf("unexpected decoded length")
+	}
+
+	cases := []struct {
+		name      string
+		cacheSize int
+	}{
+		{name: "cache_off", cacheSize: 0},
+		{name: "cache_64", cacheSize: 64},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			var cache *templateDefCache
+			if tc.cacheSize > 0 {
+				cache = newTemplateDefCache(tc.cacheSize)
+			}
+			opts := templ.DecodeOptions{MaxDecodedBytes: 1 << 20, MaxGaps: 16, DefCacheSize: tc.cacheSize}
+
+			f, err := openFile(path, fileID, nil, templateLookup, opts, cache)
+			if err != nil {
+				b.Fatalf("openFile: %v", err)
+			}
+			b.Cleanup(func() { _ = f.Close() })
+			f.remapToFileSize()
+
+			// Warm prefix cache + decoded template cache.
+			buf := make([]byte, 0, decodedLen*2)
+			for _, ptr := range writePtrs[:MaxFrameK] {
+				var readErr error
+				buf, readErr = f.ReadAppend(ptr, true, buf[:0])
+				if readErr != nil {
+					b.Fatalf("warm read: %v", readErr)
+				}
+			}
+
+			b.ReportAllocs()
+			b.SetBytes(int64(decodedLen))
+			b.ResetTimer()
+
+			sink := byte(0)
+			rng := rand.New(rand.NewSource(1))
+			for i := 0; i < b.N; i++ {
+				ptr := writePtrs[rng.Intn(len(writePtrs))]
+				var readErr error
+				buf, readErr = f.ReadAppend(ptr, true, buf[:0])
+				if readErr != nil {
+					b.Fatalf("ReadAppend: %v", readErr)
+				}
+				sink ^= buf[0]
+			}
+			b.StopTimer()
+			if sink == 0xff {
+				b.Fatalf("sink")
+			}
+
+			if cache != nil {
+				hits, misses, _, _ := cache.Stats()
+				if hits+misses > 0 {
+					b.ReportMetric(float64(hits)/float64(hits+misses), "template_def_cache_hit_ratio")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkValueLogTemplateMixedReadWrite(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "value-000001.log")
+	fileID := page.ValueLogFileID(1)
+
+	anchorA := bytes.Repeat([]byte{'A'}, 16)
+	anchorB := bytes.Repeat([]byte{'B'}, 16)
+	def := templ.TemplateDef{Kind: templ.TemplateAnchors, Anchors: [][]byte{anchorA, anchorB}}
+	defBytes, err := templ.EncodeTemplateDef(def, templ.Config{})
+	if err != nil {
+		b.Fatalf("EncodeTemplateDef: %v", err)
+	}
+	templateLookup := func(id uint64) ([]byte, error) {
+		if id != 1 {
+			return nil, ErrMissingTemplate
+		}
+		return defBytes, nil
+	}
+
+	gap0 := bytes.Repeat([]byte{'x'}, 32)
+	gap1 := bytes.Repeat([]byte{'y'}, 32)
+	gap2 := bytes.Repeat([]byte{'z'}, 32)
+	payload, err := templ.EncodePayload(1, [][]byte{gap0, gap1, gap2})
+	if err != nil {
+		b.Fatalf("EncodePayload: %v", err)
+	}
+
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		b.Fatalf("NewWriter: %v", err)
+	}
+	var recs [MaxFrameK]Record
+	rid := uint64(1)
+	for i := 0; i < MaxFrameK; i++ {
+		recs[i] = Record{RID: rid, Value: payload}
+		rid++
+	}
+	ptrs, err := w.AppendFrame(0, nil, recs[:])
+	if err != nil {
+		_ = w.Close()
+		b.Fatalf("AppendFrame: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		b.Fatalf("Close: %v", err)
+	}
+
+	cache := newTemplateDefCache(64)
+	opts := templ.DecodeOptions{MaxDecodedBytes: 1 << 20, MaxGaps: 16, DefCacheSize: 64}
+
+	f, err := openFile(path, fileID, nil, templateLookup, opts, cache)
+	if err != nil {
+		b.Fatalf("openFile: %v", err)
+	}
+	b.Cleanup(func() { _ = f.Close() })
+	f.remapToFileSize()
+
+	// Separate writer for mixed writes.
+	appendWriter, err := NewWriter(path, fileID)
+	if err != nil {
+		b.Fatalf("NewWriter append: %v", err)
+	}
+	b.Cleanup(func() { _ = appendWriter.Close() })
+
+	outExample, err := templ.DecodePayloadAppend(nil, payload, func(uint64) (templ.TemplateDef, error) { return def, nil }, opts)
+	if err != nil {
+		b.Fatalf("DecodePayloadAppend: %v", err)
+	}
+	decodedLen := len(outExample)
+	if decodedLen == 0 {
+		b.Fatalf("unexpected decoded length")
+	}
+
+	// Warm caches.
+	buf := make([]byte, 0, decodedLen*2)
+	for _, ptr := range ptrs {
+		var readErr error
+		buf, readErr = f.ReadAppend(ptr, true, buf[:0])
+		if readErr != nil {
+			b.Fatalf("warm read: %v", readErr)
+		}
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(decodedLen))
+	b.ResetTimer()
+
+	sink := byte(0)
+	rng := rand.New(rand.NewSource(1))
+	writeCount := 0
+	for i := 0; i < b.N; i++ {
+		// 1% writes, 99% reads.
+		if rng.Intn(100) == 0 {
+			ptr, err := appendWriter.Append(0, nil, rid, payload)
+			if err != nil {
+				b.Fatalf("Append: %v", err)
+			}
+			rid++
+			writeCount++
+			// Touch a new record occasionally to keep mmap growth realistic.
+			if writeCount%1024 == 0 {
+				if err := appendWriter.Flush(); err != nil {
+					b.Fatalf("Flush: %v", err)
+				}
+				f.remapToFileSize()
+				buf, err = f.ReadAppend(ptr, true, buf[:0])
+				if err != nil {
+					b.Fatalf("read new: %v", err)
+				}
+				if len(buf) > 0 {
+					sink ^= buf[0]
+				}
+			}
+			continue
+		}
+		ptr := ptrs[rng.Intn(len(ptrs))]
+		var readErr error
+		buf, readErr = f.ReadAppend(ptr, true, buf[:0])
+		if readErr != nil {
+			b.Fatalf("ReadAppend: %v", readErr)
+		}
+		sink ^= buf[0]
+	}
+	b.StopTimer()
+	if sink == 0xff {
+		b.Fatalf("sink")
+	}
+
+	if hits, misses, _, _ := cache.Stats(); hits+misses > 0 {
+		b.ReportMetric(float64(hits)/float64(hits+misses), "template_def_cache_hit_ratio")
+	}
+}

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -204,7 +204,7 @@ func TestReadAtGroupedFastPathWithoutChecksum(t *testing.T) {
 
 	expect := []string{"alpha", "beta", "gamma"}
 	for i, ptr := range ptrs {
-		got, err := ReadAtWithDict(f, ptr, false, nil, nil, templ.DecodeOptions{})
+		got, err := ReadAtWithDict(f, ptr, false, nil, nil, nil, templ.DecodeOptions{})
 		if err != nil {
 			t.Fatalf("read at ptr%d: %v", i+1, err)
 		}
@@ -216,7 +216,7 @@ func TestReadAtGroupedFastPathWithoutChecksum(t *testing.T) {
 		// grouped flag and sub-index are still set.
 		legacy := ptr
 		legacy.Length = page.ValuePtrMarkGrouped(0, page.ValuePtrSubIndex(ptr))
-		gotLegacy, err := ReadAtWithDict(f, legacy, false, nil, nil, templ.DecodeOptions{})
+		gotLegacy, err := ReadAtWithDict(f, legacy, false, nil, nil, nil, templ.DecodeOptions{})
 		if err != nil {
 			t.Fatalf("read at legacy ptr%d: %v", i+1, err)
 		}
@@ -262,7 +262,7 @@ func TestReadAtGroupedFastPathSubIndexRange(t *testing.T) {
 	t.Cleanup(func() { _ = f.Close() })
 
 	for i, ptr := range ptrs {
-		got, err := ReadAtWithDict(f, ptr, false, nil, nil, templ.DecodeOptions{})
+		got, err := ReadAtWithDict(f, ptr, false, nil, nil, nil, templ.DecodeOptions{})
 		if err != nil {
 			t.Fatalf("read at ptr%d: %v", i+1, err)
 		}

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -233,7 +233,7 @@ func Open(opts Options) (*DB, error) {
 			MaxCandidatesPerFP:    tcfg.MaxCandidatesPerFP,
 			MaxCandidateListBytes: tcfg.MaxCandidateListBytes,
 		})
-		decodeOpts := template.DecodeOptions{MaxGaps: tcfg.MaxGaps, MaxDecodedBytes: tcfg.MaxDecodedBytes}
+		decodeOpts := template.DecodeOptions{MaxGaps: tcfg.MaxGaps, MaxDecodedBytes: tcfg.MaxDecodedBytes, DefCacheSize: tcfg.DefCacheSize}
 		if decodeOpts.MaxDecodedBytes <= 0 && limits.MaxRecordSize > 0 {
 			decodeOpts.MaxDecodedBytes = int(limits.MaxRecordSize)
 		}

--- a/TreeDB/template/codec.go
+++ b/TreeDB/template/codec.go
@@ -80,43 +80,85 @@ func EncodeMaskPayload(templateID uint64, mask []byte, vars []byte) ([]byte, err
 	return out, nil
 }
 
-// DecodePayload decodes a TemplateValue payload using the provided lookup.
-// If payload is not template-encoded, it is returned as-is.
-func DecodePayload(payload []byte, lookup func(id uint64) ([]byte, error), opts DecodeOptions) ([]byte, error) {
-	if len(payload) == 0 || !IsEncodedPayload(payload) {
-		return payload, nil
+func grow(dst []byte, n int) []byte {
+	if n <= 0 {
+		return dst
+	}
+	oldLen := len(dst)
+	newLen := oldLen + n
+	if newLen < 0 {
+		return dst[:0]
+	}
+	if cap(dst) < newLen {
+		newCap := cap(dst) * 2
+		if newCap < newLen {
+			newCap = newLen
+		}
+		tmp := make([]byte, oldLen, newCap)
+		copy(tmp, dst)
+		dst = tmp
+	}
+	return dst[:newLen]
+}
+
+// DecodePayloadAppend decodes a TemplateValue payload and appends the decoded
+// bytes to dst.
+//
+// If payload is not template-encoded, it is appended as-is.
+func DecodePayloadAppend(dst, payload []byte, lookup func(id uint64) (TemplateDef, error), opts DecodeOptions) ([]byte, error) {
+	if len(payload) == 0 {
+		return dst, nil
+	}
+	if !IsEncodedPayload(payload) {
+		oldLen := len(dst)
+		dst = grow(dst, len(payload))
+		copy(dst[oldLen:], payload)
+		return dst, nil
 	}
 	if lookup == nil {
-		return nil, ErrMissingTemplate
+		return dst, ErrMissingTemplate
 	}
+
+	baseLen := len(dst)
+	fail := func(err error) ([]byte, error) {
+		if baseLen <= len(dst) {
+			dst = dst[:baseLen]
+		}
+		return dst, err
+	}
+
 	isMask := payload[3]&flagMask != 0
 	isFull := payload[3]&flagMaskFull != 0
+
 	off := payloadHeader
 	id, n := binary.Uvarint(payload[off:])
 	if n <= 0 {
-		return nil, ErrCorrupt
+		return fail(ErrCorrupt)
 	}
 	off += n
+
+	def, err := lookup(id)
+	if err != nil {
+		return fail(err)
+	}
+
 	if isMask {
-		defBytes, err := lookup(id)
-		if err != nil {
-			return nil, err
-		}
-		def, err := DecodeTemplateDef(defBytes)
-		if err != nil {
-			return nil, err
-		}
 		if def.Kind != TemplateMask {
-			return nil, ErrCorrupt
+			return fail(ErrCorrupt)
 		}
 		decodedLen := len(def.Base)
 		if opts.MaxDecodedBytes > 0 && decodedLen > opts.MaxDecodedBytes {
-			return nil, ErrCorrupt
+			return fail(ErrCorrupt)
 		}
+		outStart := len(dst)
+		dst = grow(dst, decodedLen)
+		out := dst[outStart : outStart+decodedLen]
+		copy(out, def.Base)
+
 		if isFull {
 			maskLen := (decodedLen + 7) / 8
 			if off+maskLen > len(payload) {
-				return nil, ErrCorrupt
+				return fail(ErrCorrupt)
 			}
 			mask := payload[off : off+maskLen]
 			off += maskLen
@@ -126,10 +168,8 @@ func DecodePayload(payload []byte, lookup func(id uint64) ([]byte, error), opts 
 				diffCount += bits.OnesCount8(b)
 			}
 			if diffCount != len(varBytes) {
-				return nil, ErrCorrupt
+				return fail(ErrCorrupt)
 			}
-			out := make([]byte, decodedLen)
-			copy(out, def.Base)
 			idx := 0
 			for i := 0; i < decodedLen; i++ {
 				if mask[i/8]&(1<<uint(i%8)) != 0 {
@@ -138,12 +178,13 @@ func DecodePayload(payload []byte, lookup func(id uint64) ([]byte, error), opts 
 				}
 			}
 			if idx != len(varBytes) {
-				return nil, ErrCorrupt
+				return fail(ErrCorrupt)
 			}
-			return out, nil
+			return dst, nil
 		}
+
 		if len(def.Mask) == 0 {
-			return nil, ErrCorrupt
+			return fail(ErrCorrupt)
 		}
 		varCount := len(def.VarPositions)
 		if varCount == 0 {
@@ -152,100 +193,115 @@ func DecodePayload(payload []byte, lookup func(id uint64) ([]byte, error), opts 
 			}
 		}
 		if off+varCount != len(payload) {
-			return nil, ErrCorrupt
+			return fail(ErrCorrupt)
 		}
 		varBytes := payload[off:]
-		out := make([]byte, decodedLen)
-		copy(out, def.Base)
 		if len(def.VarPositions) > 0 {
 			if len(def.VarPositions) != len(varBytes) {
-				return nil, ErrCorrupt
+				return fail(ErrCorrupt)
 			}
 			for i, pos := range def.VarPositions {
 				if int(pos) >= len(out) {
-					return nil, ErrCorrupt
+					return fail(ErrCorrupt)
 				}
 				out[pos] = varBytes[i]
 			}
-		} else {
-			idx := 0
-			for i := 0; i < decodedLen; i++ {
-				if def.Mask[i/8]&(1<<uint(i%8)) != 0 {
-					if idx >= len(varBytes) {
-						return nil, ErrCorrupt
-					}
-					out[i] = varBytes[idx]
-					idx++
+			return dst, nil
+		}
+
+		idx := 0
+		for i := 0; i < decodedLen; i++ {
+			if def.Mask[i/8]&(1<<uint(i%8)) != 0 {
+				if idx >= len(varBytes) {
+					return fail(ErrCorrupt)
 				}
-			}
-			if idx != len(varBytes) {
-				return nil, ErrCorrupt
+				out[i] = varBytes[idx]
+				idx++
 			}
 		}
-		return out, nil
+		if idx != len(varBytes) {
+			return fail(ErrCorrupt)
+		}
+		return dst, nil
 	}
+
+	anchors := def.Anchors
+	if def.Kind != TemplateAnchors && def.Kind != 0 {
+		return fail(ErrCorrupt)
+	}
+
 	gapCount64, n := binary.Uvarint(payload[off:])
 	if n <= 0 {
-		return nil, ErrCorrupt
+		return fail(ErrCorrupt)
 	}
 	off += n
 	if gapCount64 == 0 {
-		return nil, ErrCorrupt
+		return fail(ErrCorrupt)
 	}
 	if opts.MaxGaps > 0 && gapCount64 > uint64(opts.MaxGaps) {
-		return nil, ErrCorrupt
+		return fail(ErrCorrupt)
 	}
 	gapCount := int(gapCount64)
-	gaps := make([][]byte, gapCount)
-	totalGapBytes := 0
+	if len(anchors)+1 != gapCount {
+		return fail(ErrCorrupt)
+	}
+
+	decodedBytes := 0
+	maxDecoded := opts.MaxDecodedBytes
+	if maxDecoded < 0 {
+		maxDecoded = 0
+	}
 	for i := 0; i < gapCount; i++ {
 		gapLen64, n := binary.Uvarint(payload[off:])
 		if n <= 0 {
-			return nil, ErrCorrupt
+			return fail(ErrCorrupt)
 		}
 		off += n
 		if gapLen64 > uint64(len(payload)-off) {
-			return nil, ErrCorrupt
+			return fail(ErrCorrupt)
 		}
 		gapLen := int(gapLen64)
-		gaps[i] = payload[off : off+gapLen]
+		if maxDecoded > 0 && decodedBytes+gapLen > maxDecoded {
+			return fail(ErrCorrupt)
+		}
+		oldLen := len(dst)
+		dst = grow(dst, gapLen)
+		copy(dst[oldLen:], payload[off:off+gapLen])
 		off += gapLen
-		totalGapBytes += gapLen
-	}
-	if off != len(payload) {
-		return nil, ErrCorrupt
-	}
-	defBytes, err := lookup(id)
-	if err != nil {
-		return nil, err
-	}
-	def, err := DecodeTemplateDef(defBytes)
-	if err != nil {
-		return nil, err
-	}
-	if def.Kind != TemplateAnchors {
-		return nil, ErrCorrupt
-	}
-	if len(def.Anchors)+1 != gapCount {
-		return nil, ErrCorrupt
-	}
-	anchorBytes := 0
-	for _, a := range def.Anchors {
-		anchorBytes += len(a)
-	}
-	decodedLen64 := int64(totalGapBytes) + int64(anchorBytes)
-	if decodedLen64 < 0 {
-		return nil, ErrCorrupt
-	}
-	if opts.MaxDecodedBytes > 0 && decodedLen64 > int64(opts.MaxDecodedBytes) {
-		return nil, ErrCorrupt
-	}
-	out := make([]byte, 0, int(decodedLen64))
-	for i, g := range gaps {
-		out = append(out, g...)
-		if i < len(def.Anchors) {
-			out = append(out, def.Anchors[i]...)
+		decodedBytes += gapLen
+
+		if i < len(anchors) {
+			a := anchors[i]
+			if maxDecoded > 0 && decodedBytes+len(a) > maxDecoded {
+				return fail(ErrCorrupt)
+			}
+			oldLen = len(dst)
+			dst = grow(dst, len(a))
+			copy(dst[oldLen:], a)
+			decodedBytes += len(a)
 		}
 	}
-	return out, nil
+	if off != len(payload) {
+		return fail(ErrCorrupt)
+	}
+	return dst, nil
+}
+
+// DecodePayload decodes a TemplateValue payload using the provided lookup.
+// If payload is not template-encoded, it is returned as-is.
+func DecodePayload(payload []byte, lookup func(id uint64) ([]byte, error), opts DecodeOptions) ([]byte, error) {
+	if len(payload) == 0 || !IsEncodedPayload(payload) {
+		return payload, nil
+	}
+	if lookup == nil {
+		return nil, ErrMissingTemplate
+	}
+	dst, err := DecodePayloadAppend(nil, payload, func(id uint64) (TemplateDef, error) {
+		defBytes, err := lookup(id)
+		if err != nil {
+			return TemplateDef{}, err
+		}
+		return DecodeTemplateDef(defBytes)
+	}, opts)
+	return dst, err
 }

--- a/TreeDB/template/codec_append_test.go
+++ b/TreeDB/template/codec_append_test.go
@@ -1,0 +1,128 @@
+package template
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestDecodePayloadAppend_Anchors(t *testing.T) {
+	def := TemplateDef{Kind: TemplateAnchors, Anchors: [][]byte{[]byte("AA"), []byte("BB")}}
+	payload, err := EncodePayload(1, [][]byte{[]byte("x"), []byte("y"), []byte("z")})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	out, err := DecodePayloadAppend([]byte("prefix-"), payload, func(id uint64) (TemplateDef, error) {
+		if id != 1 {
+			return TemplateDef{}, ErrMissingTemplate
+		}
+		return def, nil
+	}, DecodeOptions{MaxDecodedBytes: 1 << 20, MaxGaps: 8})
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if string(out) != "prefix-xAAyBBz" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestDecodePayloadAppend_Mask(t *testing.T) {
+	base := []byte("abcdef")
+	mask := []byte{0b00101100} // variable at positions 2,3,5
+	def := TemplateDef{Kind: TemplateMask, Base: base, Mask: mask}
+
+	vars := []byte{'X', 'Y', 'Z'}
+	want := "abXYeZ"
+
+	// Sparse payload (variable bytes only).
+	sparseLen := payloadHeader + uvarintLen(1) + len(vars)
+	sparse := make([]byte, sparseLen)
+	sparse[0] = magic0
+	sparse[1] = magic1
+	sparse[2] = payloadVer
+	sparse[3] = flagEncoded | flagMask
+	off := payloadHeader
+	off += binary.PutUvarint(sparse[off:], 1)
+	copy(sparse[off:], vars)
+
+	out, err := DecodePayloadAppend(nil, sparse, func(uint64) (TemplateDef, error) {
+		return def, nil
+	}, DecodeOptions{MaxDecodedBytes: 128})
+	if err != nil {
+		t.Fatalf("decode sparse: %v", err)
+	}
+	if string(out) != want {
+		t.Fatalf("sparse mismatch: got %q want %q", out, want)
+	}
+
+	// Full payload (mask + diffs).
+	full, err := EncodeMaskPayload(1, mask, vars)
+	if err != nil {
+		t.Fatalf("encode full: %v", err)
+	}
+	out, err = DecodePayloadAppend(nil, full, func(uint64) (TemplateDef, error) {
+		return def, nil
+	}, DecodeOptions{MaxDecodedBytes: 128})
+	if err != nil {
+		t.Fatalf("decode full: %v", err)
+	}
+	if string(out) != want {
+		t.Fatalf("full mismatch: got %q want %q", out, want)
+	}
+}
+
+func TestDecodePayloadAppend_NoAllocs(t *testing.T) {
+	t.Run("anchors", func(t *testing.T) {
+		def := TemplateDef{Kind: TemplateAnchors, Anchors: [][]byte{[]byte("AA"), []byte("BB")}}
+		payload, err := EncodePayload(1, [][]byte{[]byte("x"), []byte("y"), []byte("z")})
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		lookup := func(id uint64) (TemplateDef, error) {
+			if id != 1 {
+				return TemplateDef{}, ErrMissingTemplate
+			}
+			return def, nil
+		}
+		opts := DecodeOptions{MaxDecodedBytes: 1 << 20, MaxGaps: 8}
+		dst := make([]byte, 0, 64)
+		allocs := testing.AllocsPerRun(1_000, func() {
+			out, err := DecodePayloadAppend(dst[:0], payload, lookup, opts)
+			if err != nil {
+				panic(err)
+			}
+			if len(out) == 0 {
+				panic("empty output")
+			}
+		})
+		if allocs != 0 {
+			t.Fatalf("expected 0 allocs, got %.3f", allocs)
+		}
+	})
+
+	t.Run("mask", func(t *testing.T) {
+		base := []byte("abcdef")
+		mask := []byte{0b00101100} // variable at positions 2,3,5
+		def := TemplateDef{Kind: TemplateMask, Base: base, Mask: mask}
+		full, err := EncodeMaskPayload(1, mask, []byte{'X', 'Y', 'Z'})
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		opts := DecodeOptions{MaxDecodedBytes: 128}
+		dst := make([]byte, 0, 64)
+		allocs := testing.AllocsPerRun(1_000, func() {
+			out, err := DecodePayloadAppend(dst[:0], full, func(uint64) (TemplateDef, error) {
+				return def, nil
+			}, opts)
+			if err != nil {
+				panic(err)
+			}
+			if len(out) == 0 {
+				panic("empty output")
+			}
+		})
+		if allocs != 0 {
+			t.Fatalf("expected 0 allocs, got %.3f", allocs)
+		}
+	})
+}

--- a/TreeDB/template/types.go
+++ b/TreeDB/template/types.go
@@ -57,6 +57,10 @@ type span struct {
 type DecodeOptions struct {
 	MaxDecodedBytes int
 	MaxGaps         int
+
+	// DefCacheSize controls the maximum number of decoded template definitions
+	// cached by value-log readers. Values <= 0 disable caching.
+	DefCacheSize int
 }
 
 func uvarintLen(v uint64) int {


### PR DESCRIPTION
Closes #269.

## Summary
- Add `template.DecodePayloadAppend` to decode template payloads into caller-provided buffers.
- Add a bounded LRU cache for decoded template defs on the value-log read path.
- Switch value-log `ReadAppend`/`ReadAt*` decode sites to use the append API + cache.
- Make `TemplatePrepass` cheaper by applying dict gating *after* template encoding (e.g. skip dict when the post-template avg value size is below the existing `DisableBelowValueBytes` threshold) and enter template cold mode sooner when the user hasn't overridden cold settings.
- Export template-def cache stats into `DB.Stats()` and print them in `vlog_dict_realdata`.

## Testing
- `go test ./...`
- Benchmarks:
  - `go test ./TreeDB/internal/valuelog -run ^$ -bench BenchmarkValueLogTemplateReadAppend -benchmem`
  - `go test ./TreeDB/internal/valuelog -run ^$ -bench BenchmarkValueLogTemplateMixedReadWrite -benchmem`
