### PR TITLE
TreeDB/template: startup cold gate for no-match workloads

### DIFF
--- a/TreeDB/template/engine.go
+++ b/TreeDB/template/engine.go
@@ -249,11 +249,31 @@ func (e *Engine) Encode(ctx context.Context, value []byte, store Store) ([]byte,
 	}
 	lastKeepSeq := e.lastKeepSeq.Load()
 	missStreak := seq - lastKeepSeq
-	if missStreak > uint64(cfg.ColdSearchAfter) {
-		probeEvery := uint64(cfg.ColdSearchProbeEvery)
-		if probeEvery == 0 {
-			probeEvery = 1
+
+	coldAfter := uint64(cfg.ColdSearchAfter)
+	probeEvery := uint64(cfg.ColdSearchProbeEvery)
+	// Startup guardrail: before we've kept any template in this Engine instance,
+	// avoid hammering candidate lookups on every value. We still probe so we can
+	// discover templates that already exist in the store after reopen.
+	//
+	// This only affects the default cold settings to avoid surprising explicit
+	// user tuning.
+	if lastKeepSeq == 0 && cfg.ColdSearchAfter == 256 && cfg.ColdSearchProbeEvery == 256 {
+		if coldAfter > 64 {
+			coldAfter = 64
 		}
+		if probeEvery > 64 {
+			probeEvery = 64
+		}
+	}
+	if coldAfter == 0 {
+		coldAfter = 1
+	}
+	if probeEvery == 0 {
+		probeEvery = 1
+	}
+
+	if missStreak > coldAfter {
 		if seq%probeEvery != 0 {
 			e.stats.addReason(reasonSkipCold)
 			e.observeTraining(value, store)

--- a/TreeDB/template/engine_test.go
+++ b/TreeDB/template/engine_test.go
@@ -138,3 +138,51 @@ func TestEngineColdGateLimitsCandidateLookups(t *testing.T) {
 		t.Fatalf("candidate lookups too high: got=%d", got)
 	}
 }
+
+func TestEngineStartupColdGateLimitsCandidateLookups_DefaultConfig(t *testing.T) {
+	// Default (normalized) cold settings are 256/256. The engine should apply a
+	// startup guardrail before the first keep so we don't hit the store on every
+	// value when templates are enabled but nothing matches.
+	cfg := Config{
+		MinSavingsBytes:       1,
+		FingerprintK:          4,
+		FingerprintW:          4,
+		RouteFPCount:          1,
+		MaxFPReads:            1,
+		MaxTemplateFetch:      1,
+		MaxCandidatesPerFP:    1,
+		MinAnchorLen:          4,
+		MaxAnchorLen:          64,
+		MaxAnchorsPerTemplate: 8,
+		MaxAnchorBytesTotal:   256,
+		MaxGaps:               16,
+		// ColdSearchAfter / ColdSearchProbeEvery intentionally left at 0 to use
+		// defaults via NormalizeConfig.
+	}
+	def := TemplateDef{Kind: TemplateAnchors, Anchors: [][]byte{[]byte("never-match")}}
+	defBytes, err := EncodeTemplateDef(def, cfg)
+	if err != nil {
+		t.Fatalf("encode template def: %v", err)
+	}
+	store := &countingStore{
+		defBytes: defBytes,
+		id:       1,
+		cands:    []Candidate{{ID: 1, Size: len(defBytes)}},
+	}
+	engine := NewEngine(cfg)
+	value := []byte("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+
+	const iters = 200
+	for i := 0; i < iters; i++ {
+		_, ok := engine.Encode(nil, value, store)
+		if ok {
+			t.Fatalf("unexpected keep at iter=%d", i)
+		}
+	}
+
+	// Expect store candidate lookups to be much less than iters due to the
+	// startup cold gate (probes only).
+	if got := store.getCandidates.Load(); got > 80 {
+		t.Fatalf("candidate lookups too high: got=%d", got)
+	}
+}

--- a/scripts/bench_template_smoke.sh
+++ b/scripts/bench_template_smoke.sh
@@ -15,6 +15,7 @@ PYTHON_BIN="${PYTHON_BIN:-python3}"
 
 DATASET="${DATASET:-/tmp/treedb_template_smoke.jsonl}"
 REGEN="${REGEN:-0}"
+DATASET_KIND="${DATASET_KIND:-templatable}" # templatable|random
 
 TRAIN_N="${TRAIN_N:-10000}"
 EVAL_N="${EVAL_N:-5000}"
@@ -53,8 +54,8 @@ maybe_gen_dataset() {
   fi
 
   if [[ "$REGEN" != "0" || ! -f "$DATASET" || "$have_lines" -lt "$want_lines" ]]; then
-    echo "generating dataset: $DATASET (train=$TRAIN_N eval=$EVAL_N valsize=$VALSIZE)" >&2
-    "$PYTHON_BIN" - "$DATASET" "$TRAIN_N" "$EVAL_N" "$VALSIZE" <<'PY'
+    echo "generating dataset: $DATASET (kind=$DATASET_KIND train=$TRAIN_N eval=$EVAL_N valsize=$VALSIZE)" >&2
+    "$PYTHON_BIN" - "$DATASET" "$TRAIN_N" "$EVAL_N" "$VALSIZE" "$DATASET_KIND" <<'PY'
 import json
 import os
 import random
@@ -64,6 +65,10 @@ path = sys.argv[1]
 train_n = int(sys.argv[2])
 eval_n = int(sys.argv[3])
 valsize = int(sys.argv[4])
+kind = sys.argv[5].strip().lower() if len(sys.argv) > 5 else "templatable"
+
+if kind not in ("templatable", "random"):
+    raise SystemExit(f"unsupported dataset kind: {kind!r} (expected templatable|random)")
 
 random.seed(1)
 total = train_n + eval_n
@@ -72,13 +77,17 @@ os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
 with open(path, "w", encoding="utf-8") as f:
     for i in range(total):
         key = f"key-{i:08d}"
-        # Constant prefix/suffix + small variable middle encourages templates.
-        var = f"{random.getrandbits(64):016x}"
-        v = f"prefix|bucket={i%97:02d}|seq={i:08d}|var={var}|suffix"
-        if len(v) < valsize:
-            v = v + ("A" * (valsize - len(v)))
+        if kind == "random":
+            alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+            v = "".join(random.choice(alphabet) for _ in range(valsize))
         else:
-            v = v[:valsize]
+            # Constant prefix/suffix + small variable middle encourages templates.
+            var = f"{random.getrandbits(64):016x}"
+            v = f"prefix|bucket={i%97:02d}|seq={i:08d}|var={var}|suffix"
+            if len(v) < valsize:
+                v = v + ("A" * (valsize - len(v)))
+            else:
+                v = v[:valsize]
         f.write(json.dumps({"key": key, "val": v}, separators=(",", ":")) + "\n")
 PY
   fi
@@ -148,7 +157,7 @@ maybe_gen_dataset
 build_bin
 
 echo "template smoke (mode=$MODE raw_mib=$RAW_MIB batch=$BATCH ptr_threshold=$POINTER_THRESHOLD)" >&2
-echo "dataset=$DATASET train=$TRAIN_N eval=$EVAL_N valsize=$VALSIZE" >&2
+echo "dataset=$DATASET kind=$DATASET_KIND train=$TRAIN_N eval=$EVAL_N valsize=$VALSIZE" >&2
 
 printf "| case | steady_raw_MBps | value_log_bytes | templates_published | template_kept |\n"
 printf "|---|---:|---:|---:|---:|\n"


### PR DESCRIPTION
Closes #266.

## What
- Add a startup guardrail in `template.Engine.Encode`: before the first keep, enter cold mode sooner (default config only) so we don't hammer candidate lookup/matching on workloads where templates never match.
- Add a deterministic unit test that bounds store candidate lookups in this no-match scenario.
- Extend `scripts/bench_template_smoke.sh` with `DATASET_KIND=templatable|random` for easier local comparison.

## Notes
- Template encoding already happens outside `l.vlogMu` in `TreeDB/caching/db.go` (`appendValueLog*`) — this PR keeps it that way.

## Repro
- `DATASET_KIND=templatable scripts/bench_template_smoke.sh`
- `DATASET_KIND=random scripts/bench_template_smoke.sh`

## Tests
- `go test ./...`
