### PR TITLE
TreeDB: make columnar leaves compatible with prefix compression

### DIFF
--- a/TreeDB/node/builder.go
+++ b/TreeDB/node/builder.go
@@ -39,9 +39,6 @@ func NewBuilder(data []byte, pType page.PageType) *Builder {
 
 func NewBuilderWithOptions(data []byte, pType page.PageType, opts BuilderOptions) *Builder {
 	leafPrefix := opts.LeafPrefixCompression
-	if opts.LeafColumnar {
-		leafPrefix = false
-	}
 	return &Builder{
 		data:                  data,
 		pType:                 pType,
@@ -102,13 +99,13 @@ func (b *Builder) leafEntrySize(key, value []byte, flags byte) (entrySize int, p
 	if b.leafPackedValuePtr {
 		valPtrSize = page.PackedValuePtrSize
 	}
-	if b.leafColumnar {
+	if b.leafColumnar && !b.leafPrefixCompression {
 		prefixLen = 0
 		suffixLen = len(key)
 		entrySize = leafColumnarHeaderSize + suffixLen
 		if flags&FlagPointer != 0 {
 			entrySize += valPtrSize
-		} else {
+		} else if flags&FlagTombstone == 0 {
 			entrySize += len(value)
 		}
 		return entrySize, prefixLen, suffixLen
@@ -131,12 +128,22 @@ func (b *Builder) leafEntrySize(key, value []byte, flags byte) (entrySize int, p
 		}
 	}
 
-	entrySize = headerSize + suffixLen
+	valSize := 0
 	if flags&FlagPointer != 0 {
-		entrySize += valPtrSize
-	} else {
-		entrySize += len(value)
+		valSize = valPtrSize
+	} else if flags&FlagTombstone == 0 {
+		valSize = len(value)
 	}
+
+	if b.leafColumnar {
+		// Columnar+prefix mode uses the v2 prefix entry header plus explicit
+		// key/value offsets.
+		headerSize += 4 // keyOff + valOff
+		entrySize = headerSize + valSize + suffixLen
+		return entrySize, prefixLen, suffixLen
+	}
+
+	entrySize = headerSize + suffixLen + valSize
 	return entrySize, prefixLen, suffixLen
 }
 
@@ -145,7 +152,7 @@ func (b *Builder) AddLeafEntry(key, value []byte, flags byte, valPtr page.ValueP
 	if b.pType != page.PageTypeLeaf {
 		return ErrInvalidType
 	}
-	if b.leafColumnar {
+	if b.leafColumnar && !b.leafPrefixCompression {
 		return b.addLeafEntryColumnar(key, value, flags, valPtr)
 	}
 
@@ -161,12 +168,15 @@ func (b *Builder) addLeafEntryColumnar(key, value []byte, flags byte, valPtr pag
 		valPtrSize = page.PackedValuePtrSize
 	}
 	valLen := 0
+	valSize := 0
 	entrySize := leafColumnarHeaderSize + len(key)
 	if flags&FlagPointer != 0 {
-		entrySize += valPtrSize
+		valSize = valPtrSize
+		entrySize += valSize
 	} else if flags&FlagTombstone == 0 {
 		valLen = len(value)
-		entrySize += valLen
+		valSize = valLen
+		entrySize += valSize
 	}
 
 	required := entrySize + DirectoryEntrySize
@@ -176,13 +186,10 @@ func (b *Builder) addLeafEntryColumnar(key, value []byte, flags byte, valPtr pag
 	}
 
 	entryStart := b.heapStart - entrySize
-	keyOff := leafColumnarHeaderSize
-	valOff := keyOff + len(key)
+	valOff := leafColumnarHeaderSize
+	keyOff := valOff + valSize
 
 	writeLeafColumnarHeader(b.data[entryStart:entryStart+leafColumnarHeaderSize], len(key), valLen, flags, keyOff, valOff)
-
-	keyStart := entryStart + keyOff
-	copy(b.data[keyStart:keyStart+len(key)], key)
 
 	valueStart := entryStart + valOff
 	if flags&FlagPointer != 0 {
@@ -195,6 +202,9 @@ func (b *Builder) addLeafEntryColumnar(key, value []byte, flags byte, valPtr pag
 		copy(b.data[valueStart:valueStart+valLen], value)
 	}
 
+	keyStart := entryStart + keyOff
+	copy(b.data[keyStart:keyStart+len(key)], key)
+
 	b.data[b.dirEnd] = byte(entryStart)
 	b.data[b.dirEnd+1] = byte(entryStart >> 8)
 
@@ -205,6 +215,97 @@ func (b *Builder) addLeafEntryColumnar(key, value []byte, flags byte, valPtr pag
 	return nil
 }
 
+func (b *Builder) addLeafEntryColumnarPrefixV2(key, value []byte, flags byte, valPtr page.ValuePtr, entrySize, prefixLen, suffixLen int) error {
+	valPtrSize := page.ValuePtrSize
+	if b.leafPackedValuePtr {
+		valPtrSize = page.PackedValuePtrSize
+	}
+
+	valLen := 0
+	valSize := 0
+	if flags&FlagPointer != 0 {
+		valSize = valPtrSize
+	} else if flags&FlagTombstone == 0 {
+		valLen = len(value)
+		valSize = valLen
+	}
+
+	headerSize := leafPrefixHeaderSizeV2(prefixLen, suffixLen, flags, valLen) + 4 // keyOff + valOff
+	valOff := headerSize
+	keyOff := valOff + valSize
+
+	required := entrySize + DirectoryEntrySize
+	freeSpace := b.heapStart - b.dirEnd
+	if freeSpace < required {
+		return ErrNodeFull
+	}
+
+	entryStart := b.heapStart - entrySize
+	ptr := entryStart
+
+	headerOff := ptr
+	extended := prefixLen > 254 || suffixLen > 254
+	if extended {
+		b.data[headerOff] = 0xFF
+		b.data[headerOff+1] = 0xFF
+	} else {
+		b.data[headerOff] = byte(prefixLen)
+		b.data[headerOff+1] = byte(suffixLen)
+	}
+	b.data[headerOff+2] = flags
+	headerOff += 3
+	if extended {
+		putUint16(b.data[headerOff:headerOff+2], uint16(prefixLen))
+		putUint16(b.data[headerOff+2:headerOff+4], uint16(suffixLen))
+		headerOff += 4
+	}
+	if flags&FlagPointer == 0 && flags&FlagTombstone == 0 {
+		var tmp [binary.MaxVarintLen64]byte
+		n := binary.PutUvarint(tmp[:], uint64(valLen))
+		copy(b.data[headerOff:headerOff+n], tmp[:n])
+		headerOff += n
+	}
+
+	putUint16(b.data[headerOff:headerOff+2], uint16(keyOff))
+	putUint16(b.data[headerOff+2:headerOff+4], uint16(valOff))
+	headerOff += 4
+
+	valueStart := ptr + valOff
+	if flags&FlagPointer != 0 {
+		if b.leafPackedValuePtr {
+			page.EncodePackedValuePtr(b.data[valueStart:valueStart+valPtrSize], valPtr)
+		} else {
+			valPtr.Encode(b.data[valueStart : valueStart+valPtrSize])
+		}
+	} else if flags&FlagTombstone == 0 {
+		copy(b.data[valueStart:valueStart+valLen], value)
+	}
+
+	keyStart := ptr + keyOff
+	copy(b.data[keyStart:keyStart+suffixLen], key[prefixLen:])
+
+	b.data[b.dirEnd] = byte(entryStart)
+	b.data[b.dirEnd+1] = byte(entryStart >> 8)
+
+	b.heapStart = entryStart
+	b.dirEnd += DirectoryEntrySize
+	b.count++
+	b.leafIndex++
+	if b.leafPrefixCompression {
+		if len(key) <= len(b.leafPrevKeyBuf) {
+			b.leafPrevKey = b.leafPrevKeyBuf[:len(key)]
+		} else {
+			if cap(b.leafPrevKey) < len(key) {
+				b.leafPrevKey = make([]byte, len(key))
+			}
+			b.leafPrevKey = b.leafPrevKey[:len(key)]
+		}
+		copy(b.leafPrevKey, key)
+	}
+
+	return nil
+}
+
 // AddLeafEntryWithPrefix appends a leaf entry using precomputed size/prefix data.
 // The caller must ensure prefixLen/suffixLen are computed for this builder state.
 func (b *Builder) AddLeafEntryWithPrefix(key, value []byte, flags byte, valPtr page.ValuePtr, entrySize, prefixLen, suffixLen int) error {
@@ -212,11 +313,10 @@ func (b *Builder) AddLeafEntryWithPrefix(key, value []byte, flags byte, valPtr p
 		return ErrInvalidType
 	}
 
-	// Columnar leaves do not use prefix lengths; they have their own header
-	// encoding with explicit key/value offsets. The zipper uses
-	// AddLeafEntryWithPrefix for all leaf modes, so route columnar pages through
-	// the columnar encoder.
 	if b.leafColumnar {
+		if b.leafPrefixCompression {
+			return b.addLeafEntryColumnarPrefixV2(key, value, flags, valPtr, entrySize, prefixLen, suffixLen)
+		}
 		return b.addLeafEntryColumnar(key, value, flags, valPtr)
 	}
 

--- a/TreeDB/node/compact.go
+++ b/TreeDB/node/compact.go
@@ -80,7 +80,7 @@ func entryLength(n *Node, offset int) (int, error) {
 				valSize = page.ValuePtrSize
 			}
 		}
-		keyEnd := layout.keyOff + layout.keyLen
+		keyEnd := layout.keyOff + layout.suffixLen
 		valEnd := layout.valOff + valSize
 		entryLen := keyEnd
 		if valEnd > entryLen {

--- a/TreeDB/node/leaf.go
+++ b/TreeDB/node/leaf.go
@@ -47,17 +47,20 @@ func (n *Node) leafEntryLayoutAt(offset int) (leafEntryLayout, error) {
 		return leafEntryLayout{}, ErrCorruptedNode
 	}
 
-	if n.leafColumnar() {
+	if n.leafPrefixCompressed() {
 		valPtrSize := page.ValuePtrSize
 		if n.leafPackedValuePtr() {
 			valPtrSize = page.PackedValuePtrSize
 		}
-		return parseLeafColumnarLayout(n.data, offset, valPtrSize)
-	}
 
-	if n.leafPrefixCompressed() {
 		if n.leafPrefixV2() {
+			if n.leafColumnar() {
+				return parseLeafColumnarPrefixV2Layout(n.data, offset, valPtrSize)
+			}
 			return parseLeafPrefixV2Layout(n.data, offset)
+		}
+		if n.leafColumnar() {
+			return leafEntryLayout{}, ErrCorruptedNode
 		}
 		if offset+9 > len(n.data) {
 			return leafEntryLayout{}, ErrCorruptedNode
@@ -81,6 +84,14 @@ func (n *Node) leafEntryLayoutAt(offset int) (leafEntryLayout, error) {
 			keyOff:     keyOff,
 			valOff:     keyOff + suffixLen,
 		}, nil
+	}
+
+	if n.leafColumnar() {
+		valPtrSize := page.ValuePtrSize
+		if n.leafPackedValuePtr() {
+			valPtrSize = page.PackedValuePtrSize
+		}
+		return parseLeafColumnarLayout(n.data, offset, valPtrSize)
 	}
 
 	if offset+7 > len(n.data) {
@@ -115,7 +126,7 @@ func (n *Node) leafEntryKeyAt(index uint16) (key []byte, layout leafEntryLayout,
 	}
 	entryStart = int(offset)
 
-	if n.leafColumnar() {
+	if n.leafColumnar() && !n.leafPrefixCompressed() {
 		layout, err = n.leafEntryLayoutAt(entryStart)
 		if err != nil {
 			return nil, leafEntryLayout{}, 0, err
@@ -377,11 +388,11 @@ func (n *Node) GetLeafEntry(index uint16) (LeafEntry, error) {
 // If key is found, found=true.
 // If key is greater than all entries, returns Count, false.
 func (n *Node) SearchLeaf(key []byte) (uint16, bool, error) {
-	if n.leafColumnar() {
-		return n.searchLeafColumnar(key)
-	}
 	if n.leafPrefixCompressed() {
 		return n.searchLeafPrefixCompressed(key)
+	}
+	if n.leafColumnar() {
+		return n.searchLeafColumnar(key)
 	}
 
 	data := n.data
@@ -618,6 +629,9 @@ func (n *Node) AddLeafEntry(key, value []byte, flags byte, valPtr page.ValuePtr)
 	if n.Type() != page.PageTypeLeaf {
 		return ErrInvalidType
 	}
+	if n.leafColumnar() && n.leafPrefixCompressed() {
+		return n.addLeafEntryColumnarPrefixV2Rebuild(key, value, flags, valPtr)
+	}
 	if n.leafColumnar() {
 		return n.addLeafEntryColumnar(key, value, flags, valPtr)
 	}
@@ -756,18 +770,71 @@ func (n *Node) AddLeafEntry(key, value []byte, flags byte, valPtr page.ValuePtr)
 	return nil
 }
 
+func (n *Node) addLeafEntryColumnarPrefixV2Rebuild(key, value []byte, flags byte, valPtr page.ValuePtr) error {
+	idx, found, err := n.SearchLeaf(key)
+	if err != nil {
+		return err
+	}
+
+	count := n.Count()
+	buf := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(buf, page.PageTypeLeaf, BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+		PackedValuePtr:        n.leafPackedValuePtr(),
+	})
+	b.SetPageID(n.PageID())
+
+	inserted := false
+	for i := uint16(0); i < count; i++ {
+		if !inserted && i == idx {
+			if err := b.AddLeafEntry(key, value, flags, valPtr); err != nil {
+				return err
+			}
+			inserted = true
+			if found {
+				continue
+			}
+		}
+
+		k, v, ptr, f, err := n.GetLeafEntryView(i)
+		if err != nil {
+			return err
+		}
+		if err := b.AddLeafEntry(k, v, f, ptr); err != nil {
+			return err
+		}
+	}
+	if !inserted {
+		if err := b.AddLeafEntry(key, value, flags, valPtr); err != nil {
+			return err
+		}
+	}
+
+	newNode := b.Finish()
+	copy(n.data, newNode.data)
+	flags16 := getUint16(n.data[12:14])
+	n.ptype = page.PageType(flags16 & pageTypeMask)
+	n.count = getUint16(n.data[14:16])
+	n.leafValid = false
+	return nil
+}
+
 func (n *Node) addLeafEntryColumnar(key, value []byte, flags byte, valPtr page.ValuePtr) error {
 	valPtrSize := page.ValuePtrSize
 	if n.leafPackedValuePtr() {
 		valPtrSize = page.PackedValuePtrSize
 	}
 	valLen := 0
+	valSize := 0
 	entrySize := leafColumnarHeaderSize + len(key)
 	if flags&FlagPointer != 0 {
-		entrySize += valPtrSize
+		valSize = valPtrSize
+		entrySize += valSize
 	} else if flags&FlagTombstone == 0 {
 		valLen = len(value)
-		entrySize += valLen
+		valSize = valLen
+		entrySize += valSize
 	}
 
 	idx, found, err := n.SearchLeaf(key)
@@ -790,10 +857,9 @@ func (n *Node) addLeafEntryColumnar(key, value []byte, flags byte, valPtr page.V
 	}
 
 	buf := make([]byte, entrySize)
-	keyOff := leafColumnarHeaderSize
-	valOff := keyOff + len(key)
+	valOff := leafColumnarHeaderSize
+	keyOff := valOff + valSize
 	writeLeafColumnarHeader(buf[:leafColumnarHeaderSize], len(key), valLen, flags, keyOff, valOff)
-	copy(buf[keyOff:keyOff+len(key)], key)
 
 	valueStart := valOff
 	if flags&FlagPointer != 0 {
@@ -805,6 +871,8 @@ func (n *Node) addLeafEntryColumnar(key, value []byte, flags byte, valPtr page.V
 	} else if flags&FlagTombstone == 0 {
 		copy(buf[valueStart:valueStart+valLen], value)
 	}
+
+	copy(buf[keyOff:keyOff+len(key)], key)
 
 	heapStart := int(page.PageSize)
 	count := n.Count()

--- a/TreeDB/node/leaf_columnar_prefix_v2.go
+++ b/TreeDB/node/leaf_columnar_prefix_v2.go
@@ -1,0 +1,97 @@
+package node
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+// parseLeafColumnarPrefixV2Layout parses the combined columnar+prefix leaf
+// encoding. It reuses the v2 prefix header for shared/suffix lengths (and
+// inline value length varint), then reads explicit key/value offsets (u16 each).
+//
+// The suffix bytes are located at entryStart+keyOff and have length suffixLen.
+// The value bytes/pointer are located at entryStart+valOff.
+func parseLeafColumnarPrefixV2Layout(data []byte, offset int, valPtrSize int) (leafEntryLayout, error) {
+	const offsetsSize = 4 // keyOff(u16) + valOff(u16)
+	if offset+leafPrefixV2HeaderBaseSize+offsetsSize > len(data) {
+		return leafEntryLayout{}, ErrCorruptedNode
+	}
+
+	shared8 := data[offset]
+	suffix8 := data[offset+1]
+	flags := data[offset+2]
+	headerSize := leafPrefixV2HeaderBaseSize
+
+	prefixLen := 0
+	suffixLen := 0
+	if shared8 == 0xFF || suffix8 == 0xFF {
+		if shared8 != 0xFF || suffix8 != 0xFF {
+			return leafEntryLayout{}, ErrCorruptedNode
+		}
+		if offset+leafPrefixV2HeaderBaseSize+leafPrefixV2HeaderExtSize+offsetsSize > len(data) {
+			return leafEntryLayout{}, ErrCorruptedNode
+		}
+		prefixLen = int(getUint16(data[offset+3 : offset+5]))
+		suffixLen = int(getUint16(data[offset+5 : offset+7]))
+		headerSize += leafPrefixV2HeaderExtSize
+	} else {
+		prefixLen = int(shared8)
+		suffixLen = int(suffix8)
+	}
+	if prefixLen < 0 || suffixLen < 0 {
+		return leafEntryLayout{}, ErrCorruptedNode
+	}
+	if prefixLen > math.MaxInt-suffixLen {
+		return leafEntryLayout{}, ErrCorruptedNode
+	}
+
+	valLen := 0
+	if flags&FlagPointer == 0 && flags&FlagTombstone == 0 {
+		v, n := binary.Uvarint(data[offset+headerSize:])
+		if n <= 0 {
+			return leafEntryLayout{}, ErrCorruptedNode
+		}
+		if v > uint64(math.MaxInt) {
+			return leafEntryLayout{}, ErrCorruptedNode
+		}
+		valLen = int(v)
+		headerSize += n
+	}
+
+	if offset+headerSize+offsetsSize > len(data) {
+		return leafEntryLayout{}, ErrCorruptedNode
+	}
+	keyOff := int(getUint16(data[offset+headerSize : offset+headerSize+2]))
+	valOff := int(getUint16(data[offset+headerSize+2 : offset+headerSize+4]))
+	headerSize += offsetsSize
+
+	remaining := len(data) - offset
+	if keyOff < headerSize || valOff < headerSize || keyOff > remaining || valOff > remaining {
+		return leafEntryLayout{}, ErrCorruptedNode
+	}
+
+	keyStart := offset + keyOff
+	if keyStart+suffixLen > len(data) {
+		return leafEntryLayout{}, ErrCorruptedNode
+	}
+
+	valSize := valLen
+	if flags&FlagPointer != 0 {
+		valSize = valPtrSize
+	}
+	valStart := offset + valOff
+	if valStart+valSize > len(data) {
+		return leafEntryLayout{}, ErrCorruptedNode
+	}
+
+	return leafEntryLayout{
+		headerSize: headerSize,
+		prefixLen:  prefixLen,
+		suffixLen:  suffixLen,
+		keyLen:     prefixLen + suffixLen,
+		valLen:     valLen,
+		flags:      flags,
+		keyOff:     keyOff,
+		valOff:     valOff,
+	}, nil
+}

--- a/TreeDB/node/leaf_columnar_prefix_v2_test.go
+++ b/TreeDB/node/leaf_columnar_prefix_v2_test.go
@@ -1,0 +1,79 @@
+package node
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestLeafColumnarPrefixV2_RoundTrip(t *testing.T) {
+	keys := makeBenchKeys(64, 16)
+	buf := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(buf, page.PageTypeLeaf, BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+	})
+	b.SetPageID(1)
+
+	ptrs := make([]page.ValuePtr, len(keys))
+	values := make([][]byte, len(keys))
+	flags := make([]byte, len(keys))
+	for i := range keys {
+		switch i % 3 {
+		case 0:
+			flags[i] = FlagInline
+			values[i] = []byte{byte(i), byte(i >> 8), byte(i >> 16)}
+		case 1:
+			flags[i] = FlagPointer
+			ptrs[i] = page.ValuePtr{Offset: uint64(i + 1), Length: 123, FileID: 7}
+		default:
+			flags[i] = FlagTombstone
+		}
+		if err := b.AddLeafEntry(keys[i], values[i], flags[i], ptrs[i]); err != nil {
+			t.Fatalf("AddLeafEntry: %v", err)
+		}
+	}
+
+	n := b.Finish()
+	if !n.leafColumnar() || !n.leafPrefixCompressed() || !n.leafPrefixV2() {
+		t.Fatalf("expected leaf flags set: columnar=%v prefix=%v v2=%v", n.leafColumnar(), n.leafPrefixCompressed(), n.leafPrefixV2())
+	}
+
+	for i := range keys {
+		idx, found, err := n.SearchLeaf(keys[i])
+		if err != nil {
+			t.Fatalf("SearchLeaf: %v", err)
+		}
+		if !found || idx != uint16(i) {
+			t.Fatalf("SearchLeaf mismatch i=%d idx=%d found=%v", i, idx, found)
+		}
+
+		k, v, vp, gotFlags, err := n.GetLeafEntryView(idx)
+		if err != nil {
+			t.Fatalf("GetLeafEntryView: %v", err)
+		}
+		if !bytes.Equal(k, keys[i]) {
+			t.Fatalf("key mismatch i=%d", i)
+		}
+		if gotFlags != flags[i] {
+			t.Fatalf("flags mismatch i=%d got=%d want=%d", i, gotFlags, flags[i])
+		}
+		switch gotFlags {
+		case FlagInline:
+			if !bytes.Equal(v, values[i]) || vp != (page.ValuePtr{}) {
+				t.Fatalf("inline mismatch i=%d val=%x want=%x ptr=%+v", i, v, values[i], vp)
+			}
+		case FlagPointer:
+			if v != nil || vp != ptrs[i] {
+				t.Fatalf("ptr mismatch i=%d val=%v ptr=%+v want=%+v", i, v, vp, ptrs[i])
+			}
+		case FlagTombstone:
+			if v != nil || vp != (page.ValuePtr{}) {
+				t.Fatalf("tombstone mismatch i=%d val=%v ptr=%+v", i, v, vp)
+			}
+		default:
+			t.Fatalf("unexpected flags i=%d flags=%d", i, gotFlags)
+		}
+	}
+}

--- a/TreeDB/node/leaf_density_test.go
+++ b/TreeDB/node/leaf_density_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
-func leafKeysPerPage(t *testing.T, prefixCompression bool, prefixBytes int, flags byte, valueSize int) int {
+func leafKeysPerPage(t *testing.T, opts BuilderOptions, prefixBytes int, flags byte, valueSize int) int {
 	t.Helper()
 
 	keys := makeBenchKeys(benchKeyCount, prefixBytes)
@@ -16,7 +16,7 @@ func leafKeysPerPage(t *testing.T, prefixCompression bool, prefixBytes int, flag
 	}
 
 	buf := make([]byte, page.PageSize)
-	b := NewBuilderWithOptions(buf, page.PageTypeLeaf, BuilderOptions{LeafPrefixCompression: prefixCompression})
+	b := NewBuilderWithOptions(buf, page.PageTypeLeaf, opts)
 	b.SetPageID(1)
 
 	var inserted int
@@ -34,8 +34,8 @@ func leafKeysPerPage(t *testing.T, prefixCompression bool, prefixBytes int, flag
 }
 
 func TestLeafPrefixCompression_IncreasesPageDensity_PointerEntries(t *testing.T) {
-	plain := leafKeysPerPage(t, false, 16, FlagPointer, 0)
-	compressed := leafKeysPerPage(t, true, 16, FlagPointer, 0)
+	plain := leafKeysPerPage(t, BuilderOptions{}, 16, FlagPointer, 0)
+	compressed := leafKeysPerPage(t, BuilderOptions{LeafPrefixCompression: true}, 16, FlagPointer, 0)
 
 	if compressed <= plain {
 		t.Fatalf("expected prefix compression to increase keys/page for pointer entries; plain=%d compressed=%d", plain, compressed)
@@ -49,7 +49,7 @@ func TestLeafPrefixCompression_IncreasesPageDensity_PointerEntries(t *testing.T)
 }
 
 func TestLeafPackedValuePtr_IncreasesPageDensity_PointerEntries(t *testing.T) {
-	unpacked := leafKeysPerPage(t, true, 16, FlagPointer, 0)
+	unpacked := leafKeysPerPage(t, BuilderOptions{LeafPrefixCompression: true}, 16, FlagPointer, 0)
 
 	keys := makeBenchKeys(benchKeyCount, 16)
 	buf := make([]byte, page.PageSize)
@@ -82,8 +82,8 @@ func TestLeafPackedValuePtr_IncreasesPageDensity_PointerEntries(t *testing.T) {
 }
 
 func TestLeafPrefixCompression_IncreasesPageDensity_InlineEntries(t *testing.T) {
-	plain := leafKeysPerPage(t, false, 16, FlagInline, 128)
-	compressed := leafKeysPerPage(t, true, 16, FlagInline, 128)
+	plain := leafKeysPerPage(t, BuilderOptions{}, 16, FlagInline, 128)
+	compressed := leafKeysPerPage(t, BuilderOptions{LeafPrefixCompression: true}, 16, FlagInline, 128)
 
 	if compressed <= plain {
 		t.Fatalf("expected prefix compression to increase keys/page for inline entries; plain=%d compressed=%d", plain, compressed)
@@ -94,10 +94,24 @@ func TestLeafPrefixCompression_IncreasesPageDensity_InlineEntries(t *testing.T) 
 	}
 }
 
+func TestLeafColumnarPrefixCompression_IncreasesPageDensity_PointerEntries(t *testing.T) {
+	columnar := leafKeysPerPage(t, BuilderOptions{LeafColumnar: true}, 16, FlagPointer, 0)
+	columnarPrefix := leafKeysPerPage(t, BuilderOptions{LeafPrefixCompression: true, LeafColumnar: true}, 16, FlagPointer, 0)
+
+	if columnarPrefix <= columnar {
+		t.Fatalf("expected columnar+prefix to increase keys/page for pointer entries; columnar=%d columnar_prefix=%d", columnar, columnarPrefix)
+	}
+	min := columnar + columnar/20 // +5%
+	if columnarPrefix < min {
+		t.Fatalf("expected >=5%% density improvement; columnar=%d columnar_prefix=%d min=%d", columnar, columnarPrefix, min)
+	}
+}
+
 func BenchmarkLeafPageDensity(b *testing.B) {
 	type variant struct {
 		name              string
 		prefixCompression bool
+		leafColumnar      bool
 		packedValuePtr    bool
 		prefixBytes       int
 		flags             byte
@@ -107,6 +121,9 @@ func BenchmarkLeafPageDensity(b *testing.B) {
 		{name: "ptr/plain", prefixCompression: false, prefixBytes: 16, flags: FlagPointer},
 		{name: "ptr/prefix", prefixCompression: true, prefixBytes: 16, flags: FlagPointer},
 		{name: "ptr/prefix/packed", prefixCompression: true, packedValuePtr: true, prefixBytes: 16, flags: FlagPointer},
+		{name: "ptr/columnar", leafColumnar: true, prefixBytes: 16, flags: FlagPointer},
+		{name: "ptr/columnar_prefix", prefixCompression: true, leafColumnar: true, prefixBytes: 16, flags: FlagPointer},
+		{name: "ptr/columnar_prefix/packed", prefixCompression: true, leafColumnar: true, packedValuePtr: true, prefixBytes: 16, flags: FlagPointer},
 		{name: "inline128/plain", prefixCompression: false, prefixBytes: 16, flags: FlagInline, valueSize: 128},
 		{name: "inline128/prefix", prefixCompression: true, prefixBytes: 16, flags: FlagInline, valueSize: 128},
 	}
@@ -125,6 +142,7 @@ func BenchmarkLeafPageDensity(b *testing.B) {
 			buildOnce := func() int {
 				builder := NewBuilderWithOptions(buf, page.PageTypeLeaf, BuilderOptions{
 					LeafPrefixCompression: v.prefixCompression,
+					LeafColumnar:          v.leafColumnar,
 					PackedValuePtr:        v.packedValuePtr,
 				})
 				builder.SetPageID(1)

--- a/TreeDB/node/leaf_packed_valueptr_test.go
+++ b/TreeDB/node/leaf_packed_valueptr_test.go
@@ -16,6 +16,7 @@ func TestLeafPackedValuePtr_RoundTripPointerEntries(t *testing.T) {
 		{name: "plain", opts: BuilderOptions{PackedValuePtr: true}},
 		{name: "prefix_v2", opts: BuilderOptions{LeafPrefixCompression: true, PackedValuePtr: true}},
 		{name: "columnar", opts: BuilderOptions{LeafColumnar: true, PackedValuePtr: true}},
+		{name: "columnar_prefix_v2", opts: BuilderOptions{LeafPrefixCompression: true, LeafColumnar: true, PackedValuePtr: true}},
 	}
 
 	keys := makeBenchKeys(128, 16)

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -274,14 +274,11 @@ func buildTreeDBOptions(dir string) (treedb.Options, treeDBOptionsReport, error)
 	leafPrefixEffective := leafPrefixRequested
 	var notes []string
 	var warnings []string
-	if *treedbIndexColumnarLeaves {
-		if leafPrefixRequested {
-			notes = append(notes, "index_columnar_leaves enabled: disabling leaf_prefix_compression (columnar leaf encoding is incompatible)")
-		}
-		leafPrefixEffective = false
-	}
 	if leafPrefixEffective {
 		notes = append(notes, "leaf_prefix_compression uses front-coding with restart points (compact v2 leaf entry header for new pages)")
+	}
+	if leafPrefixEffective && *treedbIndexColumnarLeaves {
+		notes = append(notes, "leaf_prefix_compression + index_columnar_leaves: enabling combined columnar+prefix leaf encoding for new pages")
 	}
 	if *treedbDisableWAL && *treedbRelaxedSync {
 		// This is not an error, but it can be confusing. Document precedence.

--- a/docs/TREEDB_BENCHMARKING.md
+++ b/docs/TREEDB_BENCHMARKING.md
@@ -60,7 +60,8 @@ go test ./TreeDB/node -run '^$' -bench BenchmarkLeafPageDensity -benchmem -count
 
 Regression guardrails:
 - `TreeDB/node/leaf_density_test.go` enforces a minimum density improvement for
-  prefix-heavy key workloads when leaf prefix compression is enabled.
+  prefix-heavy key workloads when leaf prefix compression is enabled (and when
+  the combined columnar+prefix mode is enabled).
 
 ### Template encode profiling (steady-only)
 

--- a/docs/TREEDB_STORAGE_FORMAT.md
+++ b/docs/TREEDB_STORAGE_FORMAT.md
@@ -70,7 +70,8 @@ Leaf-encoding flags (current):
 - `0x2000`: leaf prefix v2 (only valid when prefix-compressed)
 - `0x1000`: leaf packed ValuePtr (pointer payload uses 12B packed encoding)
 
-`leaf columnar` and `leaf prefix-compressed` are mutually exclusive.
+`leaf columnar` and `leaf prefix-compressed` can be combined. When both flags
+are set, leaf entries use a combined columnar+prefix encoding (see below).
 
 #### Plain leaf entries (no prefix compression, non-columnar)
 
@@ -118,6 +119,50 @@ Notes:
 - Tombstone entries store no value bytes.
 - Restart points follow the same fixed interval as v1 (see `TreeDB/node` for the
   current restart interval).
+
+#### Columnar leaf entries (non-prefix)
+
+When `leaf columnar` is enabled and `leaf prefix-compressed` is **not** set:
+
+```text
+[ u16 KeyLen ]
+[ u32 ValueLen ]  ignored for pointer entries
+[ u8  Flags ]
+[ u16 KeyOff ]  offset from entry start to key bytes
+[ u16 ValOff ]  offset from entry start to value bytes / pointer bytes
+[ Key bytes (KeyLen) ]  at entryStart+KeyOff
+[ Inline value bytes (ValueLen) | ValuePtr (16 bytes) | PackedValuePtr (12 bytes) ]  at entryStart+ValOff
+```
+
+Notes:
+- Key/value bytes may be ordered arbitrarily within the entry; offsets are the
+  source of truth.
+- Current TreeDB encoder writes value bytes **before** key bytes to improve
+  cache locality for key-only seeks (search touches the key region without
+  pulling inline values into cache).
+
+#### Columnar + prefix-compressed leaf entries (v2)
+
+When both `leaf columnar` and `leaf prefix-compressed` are set (and `leaf prefix v2` is set):
+
+```text
+[ u8 SharedPrefixLen8 ]
+[ u8 SuffixLen8 ]
+[ u8 Flags ]
+[ optional: u16 SharedPrefixLen16 | u16 SuffixLen16 ]  if both 8-bit lengths are 0xFF
+[ optional: uvarint ValueLen ]  only for inline, non-tombstone entries
+[ u16 KeyOff ]  offset from entry start to key suffix bytes
+[ u16 ValOff ]  offset from entry start to value bytes / pointer bytes
+[ Key suffix bytes (SuffixLen) ]  at entryStart+KeyOff
+[ Inline value bytes (ValueLen) | ValuePtr (16 bytes) | PackedValuePtr (12 bytes) ]  at entryStart+ValOff
+```
+
+Notes:
+- Keys reconstruct the same way as prefix v2: within restart blocks, each entry
+  copies `SharedPrefixLen` bytes from the previous full key, then appends the
+  suffix bytes.
+- Offsets allow value bytes to be placed away from key bytes; current TreeDB
+  encoder writes value bytes **before** key suffix bytes.
 - When `leaf packed ValuePtr` is set, pointer entries use the packed encoding:
   `Offset32 (u32 LE) | Length (u32 LE) | FileID (u32 LE)`. This requires
   value-log segment offsets stay within `u32` (cached mode enforces this when

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -186,7 +186,9 @@ Behavior:
 Tradeoffs:
 - Extra CPU to reconstruct keys during seeks/iteration (restart points bound the
   work).
-- Incompatible with `Options.IndexColumnarLeaves` (columnar leaf encoding).
+- Can be combined with `Options.IndexColumnarLeaves`; when both are enabled,
+  TreeDB uses a combined **columnar+prefix** leaf encoding (front-coded keys +
+  explicit key/value offsets).
 
 How to evaluate:
 - Disk + throughput: `cmd/unified_bench` with `-treedb-leaf-prefix-compression`


### PR DESCRIPTION
Refs #257.

Stacked on top of #299.

## Summary
- Removes the columnar-vs-prefix mutual exclusivity: when `IndexColumnarLeaves` and `LeafPrefixCompression` are both enabled, TreeDB now writes **combined columnar+prefix (v2)** leaf pages.
- Implements a combined leaf entry layout that uses:
  - v2 front-coding header (shared/suffix lengths + optional inline val length)
  - explicit `keyOff` / `valOff` (u16 each)
- Updates the columnar leaf encoder to write **value bytes before key bytes** (offsets are the source of truth), improving key-only seek locality.
- Updates unified-bench option resolution + storage-format/tuning docs.
- Adds roundtrip tests and density guardrails for `columnar_prefix`.

## On-disk format
- `leaf columnar` + `leaf prefix-compressed` is now a valid combination.
- See `docs/TREEDB_STORAGE_FORMAT.md` for the combined encoding.

## Bench (macOS, `scripts/treedb_forceptr_matrix.sh`, forced pointers)
Command:
- `KEYS=4000000 PROFILES=fast PPROF=0 scripts/treedb_forceptr_matrix.sh`

| variant | batch_write | random_write | batch_delete | index.db |
|---|---:|---:|---:|---:|
| base | 2,369,493 | 2,174,945 | 2,228,315 | 256 MiB |
| prefix | 2,518,167 | 2,164,019 | 2,379,348 | 192 MiB |
| columnar | 2,562,964 | 2,230,174 | 2,351,731 | 320 MiB |
| columnar_prefix | 2,529,185 | 2,296,688 | 2,380,243 | 192 MiB |

## Testing
- `go test ./... -count=1`