### PR TITLE
valuelog: append prepared grouped records API

### DIFF
--- a/TreeDB/internal/valuelog/prepared_grouped_record.go
+++ b/TreeDB/internal/valuelog/prepared_grouped_record.go
@@ -1,0 +1,200 @@
+package valuelog
+
+import (
+	"encoding/binary"
+	"errors"
+
+	"github.com/snissn/gomap/TreeDB/internal/crc"
+	"github.com/snissn/gomap/TreeDB/internal/limits"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+// PreparedGroupedRecord is a fully-prepared grouped value-log record (header +
+// frame prefix + payload) ready to append.
+//
+// This is intended for higher-level pipelines that compute compression
+// concurrently and then append frames sequentially.
+type PreparedGroupedRecord struct {
+	Record []byte
+	K      int
+
+	RawPayloadBytes    int
+	StoredPayloadBytes int
+	Attempted          bool
+	Kept               bool
+	EncodeNs           int64
+}
+
+// BuildPreparedGroupedRecordFromPayloadInto builds a grouped value-log record
+// into dst and returns a PreparedGroupedRecord that can be appended via
+// Writer.AppendPreparedGroupedRecordInto.
+//
+// payload must be either the raw concatenated values (kept=false) or the
+// compressed payload bytes (kept=true).
+func BuildPreparedGroupedRecordFromPayloadInto(dst []byte, dictID uint64, rids []uint64, offsets []uint32, rawPayloadBytes int, payload []byte, attempted bool, kept bool, encodeNs int64) (PreparedGroupedRecord, error) {
+	k := len(rids)
+	if k <= 0 || k > MaxFrameK {
+		return PreparedGroupedRecord{}, ErrRecordTooLarge
+	}
+	if len(offsets) != k+1 {
+		return PreparedGroupedRecord{}, ErrCorrupt
+	}
+	if dictID == 0 {
+		kept = false
+	}
+	if rawPayloadBytes < 0 {
+		return PreparedGroupedRecord{}, ErrRecordTooLarge
+	}
+	if rawPayloadBytes > int(^uint32(0)) {
+		return PreparedGroupedRecord{}, ErrRecordTooLarge
+	}
+	if offsets[0] != 0 {
+		return PreparedGroupedRecord{}, ErrCorrupt
+	}
+	if offsets[k] != uint32(rawPayloadBytes) {
+		return PreparedGroupedRecord{}, ErrCorrupt
+	}
+	last := uint32(0)
+	for i := 1; i < len(offsets); i++ {
+		if offsets[i] < last {
+			return PreparedGroupedRecord{}, ErrCorrupt
+		}
+		last = offsets[i]
+	}
+	if limits.MaxRecordSize > 0 && int64(rawPayloadBytes) > limits.MaxRecordSize {
+		return PreparedGroupedRecord{}, ErrRecordTooLarge
+	}
+
+	prefixLen := FrameHeaderSize + (k * 8) + ((k + 1) * 4)
+	bodyLen := prefixLen + len(payload)
+	if limits.MaxRecordSize > 0 && int64(HeaderSize+bodyLen) > limits.MaxRecordSize {
+		return PreparedGroupedRecord{}, ErrRecordTooLarge
+	}
+	if bodyLen > int(^uint32(0)) {
+		return PreparedGroupedRecord{}, ErrRecordTooLarge
+	}
+	if recordSizeExceedsMax(uint32(bodyLen)) {
+		return PreparedGroupedRecord{}, ErrRecordTooLarge
+	}
+
+	recordLen := HeaderSize + bodyLen
+	if cap(dst) < recordLen {
+		dst = make([]byte, recordLen)
+	} else {
+		dst = dst[:recordLen]
+	}
+
+	header := dst[:HeaderSize]
+	prefix := dst[HeaderSize : HeaderSize+prefixLen]
+	payloadDst := dst[HeaderSize+prefixLen:]
+	copy(payloadDst, payload)
+
+	header[4] = Version
+	header[5] = recordFlagGrouped
+	header[6] = 0
+	header[7] = 0
+	binary.LittleEndian.PutUint64(header[8:16], 0)
+	binary.LittleEndian.PutUint32(header[16:20], uint32(bodyLen))
+
+	prefixOff := 0
+	prefix[prefixOff] = FrameVersion
+	if kept {
+		prefix[prefixOff+1] = FrameFlagCompressed
+	} else {
+		prefix[prefixOff+1] = 0
+	}
+	prefix[prefixOff+2] = byte(k)
+	prefix[prefixOff+3] = 0
+	binary.LittleEndian.PutUint64(prefix[prefixOff+4:prefixOff+12], dictID)
+	prefixOff += FrameHeaderSize
+
+	for i := 0; i < k; i++ {
+		rid := rids[i]
+		if rid == 0 {
+			return PreparedGroupedRecord{}, errors.New("valuelog: missing rid")
+		}
+		binary.LittleEndian.PutUint64(prefix[prefixOff:prefixOff+8], rid)
+		prefixOff += 8
+	}
+	for i := 0; i < k+1; i++ {
+		binary.LittleEndian.PutUint32(prefix[prefixOff:prefixOff+4], offsets[i])
+		prefixOff += 4
+	}
+
+	sum := crc.ChecksumParts(header[4:HeaderSize], prefix, payloadDst)
+	binary.LittleEndian.PutUint32(header[0:4], sum)
+
+	return PreparedGroupedRecord{
+		Record:             dst,
+		K:                  k,
+		RawPayloadBytes:    rawPayloadBytes,
+		StoredPayloadBytes: len(payloadDst),
+		Attempted:          attempted,
+		Kept:               kept,
+		EncodeNs:           encodeNs,
+	}, nil
+}
+
+// AppendPreparedGroupedRecordInto appends a fully-prepared grouped record and
+// fills dst with the returned pointers.
+func (w *Writer) AppendPreparedGroupedRecordInto(prep PreparedGroupedRecord, dst []page.ValuePtr) ([]page.ValuePtr, FrameStats, error) {
+	if w == nil {
+		return nil, FrameStats{}, errors.New("valuelog: nil writer")
+	}
+	if prep.K <= 0 || prep.K > MaxFrameK {
+		return nil, FrameStats{}, ErrRecordTooLarge
+	}
+	if len(dst) < prep.K {
+		return nil, FrameStats{}, errors.New("valuelog: dst too small")
+	}
+	dst = dst[:prep.K]
+	if len(prep.Record) < HeaderSize {
+		return nil, FrameStats{}, ErrCorrupt
+	}
+	if prep.Record[4] != Version {
+		return nil, FrameStats{}, ErrCorrupt
+	}
+	if prep.Record[5]&recordFlagGrouped == 0 {
+		return nil, FrameStats{}, ErrCorrupt
+	}
+	if len(prep.Record) < HeaderSize+FrameHeaderSize {
+		return nil, FrameStats{}, ErrCorrupt
+	}
+	bodyLen := binary.LittleEndian.Uint32(prep.Record[16:20])
+	if int(bodyLen) != len(prep.Record)-HeaderSize {
+		return nil, FrameStats{}, ErrCorrupt
+	}
+	if prep.Record[HeaderSize] != FrameVersion {
+		return nil, FrameStats{}, ErrCorrupt
+	}
+	if int(prep.Record[HeaderSize+2]) != prep.K {
+		return nil, FrameStats{}, ErrCorrupt
+	}
+
+	start := w.size
+	if err := w.writeBytes(prep.Record); err != nil {
+		return nil, FrameStats{}, err
+	}
+	w.size += int64(len(prep.Record))
+
+	recordLenHint := uint32(headerWithoutCRC) + bodyLen
+	if recordLenHint > page.ValuePtrGroupedMaxRecordLen {
+		recordLenHint = 0
+	}
+	for i := range dst {
+		dst[i] = page.ValuePtr{
+			Offset: uint64(start + 4),
+			Length: page.ValuePtrMarkGrouped(recordLenHint, uint8(i)),
+			FileID: w.fileID,
+		}
+	}
+
+	return dst, FrameStats{
+		Records:            prep.K,
+		RawPayloadBytes:    prep.RawPayloadBytes,
+		StoredPayloadBytes: prep.StoredPayloadBytes,
+		Attempted:          prep.Attempted,
+		Kept:               prep.Kept,
+		EncodeNs:           prep.EncodeNs,
+	}, nil
+}

--- a/TreeDB/internal/valuelog/prepared_grouped_record_test.go
+++ b/TreeDB/internal/valuelog/prepared_grouped_record_test.go
@@ -1,0 +1,209 @@
+package valuelog
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/compress/zstd"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestPreparedGroupedRecordAppend_RawParity(t *testing.T) {
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a.vlog")
+	pathB := filepath.Join(dir, "b.vlog")
+
+	records := []Record{
+		{RID: 1, Value: []byte("hello")},
+		{RID: 2, Value: []byte("world")},
+		{RID: 3, Value: []byte("goodbye")},
+	}
+
+	w1, err := NewWriter(pathA, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	ptrScratch1 := make([]page.ValuePtr, len(records))
+	ptrs1, stats1, err := w1.AppendFrameWithStatsInto(0, nil, records, ptrScratch1)
+	if err != nil {
+		t.Fatalf("AppendFrameWithStatsInto: %v", err)
+	}
+	if err := w1.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := w1.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	bytesA, err := os.ReadFile(pathA)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var rids [MaxFrameK]uint64
+	var offsets [MaxFrameK + 1]uint32
+	rawPayloadBytes := 0
+	offsets[0] = 0
+	for i := range records {
+		rids[i] = records[i].RID
+		rawPayloadBytes += len(records[i].Value)
+		offsets[i+1] = uint32(rawPayloadBytes)
+	}
+	rawPayload := make([]byte, rawPayloadBytes)
+	off := 0
+	for i := range records {
+		off += copy(rawPayload[off:], records[i].Value)
+	}
+	prep, err := BuildPreparedGroupedRecordFromPayloadInto(nil, 0, rids[:len(records)], offsets[:len(records)+1], rawPayloadBytes, rawPayload, false, false, 0)
+	if err != nil {
+		t.Fatalf("BuildPreparedGroupedRecordFromPayloadInto: %v", err)
+	}
+
+	w2, err := NewWriter(pathB, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	ptrScratch2 := make([]page.ValuePtr, len(records))
+	ptrs2, stats2, err := w2.AppendPreparedGroupedRecordInto(prep, ptrScratch2)
+	if err != nil {
+		t.Fatalf("AppendPreparedGroupedRecordInto: %v", err)
+	}
+	if err := w2.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := w2.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	bytesB, err := os.ReadFile(pathB)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	if !bytes.Equal(bytesA, bytesB) {
+		t.Fatalf("raw parity: bytes differ")
+	}
+	if !bytes.Equal(bytesB, prep.Record) {
+		t.Fatalf("raw parity: file bytes differ from prepared record")
+	}
+	if stats1 != stats2 {
+		t.Fatalf("raw parity: stats differ: a=%+v b=%+v", stats1, stats2)
+	}
+	if !bytes.Equal(ptrsToBytes(ptrs1), ptrsToBytes(ptrs2)) {
+		t.Fatalf("raw parity: ptrs differ: a=%v b=%v", ptrs1, ptrs2)
+	}
+}
+
+func TestPreparedGroupedRecordAppend_CompressedDecodes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.vlog")
+
+	pattern := bytes.Repeat([]byte("abcdefghijklmnopqrstuvwxyz"), 40)
+	records := []Record{
+		{RID: 1, Value: pattern},
+		{RID: 2, Value: pattern},
+		{RID: 3, Value: pattern},
+		{RID: 4, Value: pattern},
+	}
+
+	dictID := uint64(1)
+	dict, err := zstd.BuildDict(zstd.BuildDictOptions{
+		ID:       uint32(dictID),
+		History:  bytes.Repeat([]byte("0123456789abcdef"), 512),
+		Contents: [][]byte{records[0].Value, records[1].Value},
+		Offsets:  [3]int{1, 4, 8},
+		Level:    zstd.SpeedFastest,
+	})
+	if err != nil {
+		t.Fatalf("BuildDict: %v", err)
+	}
+
+	var rids [MaxFrameK]uint64
+	var offsets [MaxFrameK + 1]uint32
+	rawPayloadBytes := 0
+	offsets[0] = 0
+	for i := range records {
+		rids[i] = records[i].RID
+		rawPayloadBytes += len(records[i].Value)
+		offsets[i+1] = uint32(rawPayloadBytes)
+	}
+	rawPayload := make([]byte, rawPayloadBytes)
+	off := 0
+	for i := range records {
+		off += copy(rawPayload[off:], records[i].Value)
+	}
+
+	encoded, err := CompressPayloadWithDictInto(dictID, dict, rawPayload, zstd.SpeedFastest, false, nil)
+	if err != nil {
+		t.Fatalf("CompressPayloadWithDictInto: %v", err)
+	}
+	if len(encoded) >= rawPayloadBytes {
+		t.Fatalf("expected compressed payload smaller than raw: raw=%d encoded=%d", rawPayloadBytes, len(encoded))
+	}
+
+	prep, err := BuildPreparedGroupedRecordFromPayloadInto(nil, dictID, rids[:len(records)], offsets[:len(records)+1], rawPayloadBytes, encoded, true, true, 0)
+	if err != nil {
+		t.Fatalf("BuildPreparedGroupedRecordFromPayloadInto: %v", err)
+	}
+
+	w, err := NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	ptrScratch := make([]page.ValuePtr, len(records))
+	_, stats, err := w.AppendPreparedGroupedRecordInto(prep, ptrScratch)
+	if err != nil {
+		t.Fatalf("AppendPreparedGroupedRecordInto: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !stats.Kept || !stats.Attempted {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+
+	fileBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(fileBytes, prep.Record) {
+		t.Fatalf("file bytes differ from prepared record")
+	}
+
+	bodyLen := binary.LittleEndian.Uint32(fileBytes[16:20])
+	body := fileBytes[HeaderSize : HeaderSize+int(bodyLen)]
+	frameHeader, _, outOffsets, payload, err := DecodeFrame(body)
+	if err != nil {
+		t.Fatalf("DecodeFrame: %v", err)
+	}
+	rawLen := outOffsets[len(outOffsets)-1]
+	decoded, err := decodeFramePayload(frameHeader, payload, func(id uint64) ([]byte, error) {
+		if id != dictID {
+			return nil, ErrMissingDict
+		}
+		return dict, nil
+	}, rawLen)
+	if err != nil {
+		t.Fatalf("decodeFramePayload: %v", err)
+	}
+	if !bytes.Equal(decoded, rawPayload) {
+		t.Fatalf("decoded payload mismatch")
+	}
+}
+
+func ptrsToBytes(ptrs []page.ValuePtr) []byte {
+	var b []byte
+	for i := range ptrs {
+		p := ptrs[i]
+		var buf [16]byte
+		binary.LittleEndian.PutUint64(buf[0:8], p.Offset)
+		binary.LittleEndian.PutUint32(buf[8:12], p.Length)
+		binary.LittleEndian.PutUint32(buf[12:16], p.FileID)
+		b = append(b, buf[:]...)
+	}
+	return b
+}


### PR DESCRIPTION
Implements #329.

Adds `valuelog.PreparedGroupedRecord` + builder `BuildPreparedGroupedRecordFromPayloadInto` + writer method `(*Writer) AppendPreparedGroupedRecordInto`.

This is a building block for the v2 dict compression pipeline (frame-group jobs): workers can prepare complete grouped records off-thread and the writer stage can append bytes + fill `ValuePtr`s.

Includes tests:
- raw parity with existing `AppendFrameWithStatsInto`
- compressed record decodes correctly
