### PR TITLE
TreeDB vlog dict: pipeline v2 (prepared records)

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3921,11 +3921,11 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	policySetter := caps.keep
 	statsWriter := caps.stats
 	statsWriterInto := caps.statsInto
-	payloadWriterInto := caps.payloadInto
+	preparedWriterInto := caps.preparedInto
 	rawWriterInto := caps.rawInto
 	hasStats := statsWriter != nil
 	hasInto := statsWriterInto != nil
-	hasPayloadInto := payloadWriterInto != nil
+	hasPreparedInto := preparedWriterInto != nil
 	hasRawInto := rawWriterInto != nil
 	startSize := w.Size()
 
@@ -4004,23 +4004,11 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		ptrs = getValueLogPtrs(len(records))
 	}
 	pipelineUsed := false
-	if err == nil && !rawBatchUsed && dictID != 0 && len(dict) > 0 && hasPayloadInto {
+	if err == nil && !rawBatchUsed && dictID != 0 && len(dict) > 0 && hasPreparedInto {
 		frameCount := (len(records) + k - 1) / k
-		// Heuristic: the parallel pipeline has overhead (goroutines/channels and
-		// an extra copy of encoded bytes into the writer). It is only a win when
-		// frames are large enough that dict+zstd encode dominates.
-		//
-		// We gate on average raw bytes per frame rather than total bytes because
-		// small batch sizes can otherwise invoke the pipeline for many tiny frames
-		// and regress throughput.
-		const minAvgRawBytesPerFrame = 16 << 10
-		avgFrameBytes := 0
-		if frameCount > 0 {
-			avgFrameBytes = rawPayloadBytes / frameCount
-		}
-		if frameCount > 1 && db.valueLogDictFramePipelineWorkers > 1 && avgFrameBytes >= minAvgRawBytesPerFrame {
+		if frameCount > 1 && db.valueLogDictFramePipelineWorkers > 1 {
 			rawFrameBytes, storedPayloadBytes, frameRecords, framesTotal, framesAttempted, framesKept, encodeNsTotal, encodeRawBytes, err =
-				db.appendValueLogDictFramesPipeline(payloadWriterInto, dictID, dict, records, k, ptrs)
+				db.appendValueLogDictFramesPipeline(preparedWriterInto, dictID, dict, records, rawPayloadBytes, k, ptrs)
 			pipelineUsed = err == nil
 		}
 	}
@@ -4043,10 +4031,8 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				caps = l.vlogCaps
 				statsWriter = caps.stats
 				statsWriterInto = caps.statsInto
-				payloadWriterInto = caps.payloadInto
 				hasStats = statsWriter != nil
 				hasInto = statsWriterInto != nil
-				hasPayloadInto = payloadWriterInto != nil
 			}
 
 			end := i + k

--- a/TreeDB/caching/vlog_dict_pipeline.go
+++ b/TreeDB/caching/vlog_dict_pipeline.go
@@ -10,8 +10,8 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
-var vlogDictPipelineEncPool sync.Pool // stores []byte
-var vlogDictPipelineJobPool sync.Pool // stores *vlogDictPipelineJob
+var vlogDictPipelineRecordPool sync.Pool // stores []byte
+var vlogDictPipelineJobPool sync.Pool    // stores *vlogDictPipelineJob
 
 func getVlogDictPipelineBuf(p *sync.Pool, capacity int) []byte {
 	if capacity <= 0 {
@@ -118,23 +118,20 @@ type vlogDictPipelineJob struct {
 	enableEntropy bool
 	results       chan<- *vlogDictPipelineJob
 
-	frameIdx int
-	start    int
-	end      int
-	k        int
+	jobIdx     int
+	frameStart int
+	frameEnd   int
+	k          int
 
+	// rawBytes is the sum of raw payload bytes for all frames in this job (used
+	// only for in-flight accounting).
 	rawBytes int
-
-	rids    [valuelog.MaxFrameK]uint64
-	offsets [valuelog.MaxFrameK + 1]uint32
 
 	records []valuelog.Record
 
 	// output
-	encoded  []byte
-	kept     bool
-	encodeNs int64
-	err      error
+	preps []valuelog.PreparedGroupedRecord
+	err   error
 }
 
 type vlogDictFramePipeline struct {
@@ -182,7 +179,17 @@ func (db *DB) runVlogDictFramePipelineWorker(jobs <-chan *vlogDictPipelineJob) {
 	}
 	// Per-worker scratch to avoid per-frame allocations.
 	var rawScratch []byte
-	const maxKeepScratch = 16 << 20 // 16 MiB
+	var encScratch []byte
+	const (
+		maxKeepRawScratch     = 16 << 20 // 16 MiB
+		maxKeepEncScratch     = 4 << 20  // 4 MiB
+		maxKeepPreparedRecord = 8 << 20  // 8 MiB
+	)
+
+	var (
+		rids    [valuelog.MaxFrameK]uint64
+		offsets [valuelog.MaxFrameK + 1]uint32
+	)
 
 	for {
 		select {
@@ -193,38 +200,97 @@ func (db *DB) runVlogDictFramePipelineWorker(jobs <-chan *vlogDictPipelineJob) {
 				continue
 			}
 
-			if job.rawBytes > 0 {
-				if cap(rawScratch) < job.rawBytes && job.rawBytes <= maxKeepScratch {
-					rawScratch = make([]byte, job.rawBytes)
-				}
-				var payload []byte
-				if job.rawBytes <= maxKeepScratch {
-					payload = rawScratch[:job.rawBytes]
+			frames := job.frameEnd - job.frameStart
+			if frames <= 0 || job.k <= 0 {
+				job.err = errors.New("cachingdb: invalid pipeline job")
+			} else {
+				if cap(job.preps) < frames {
+					job.preps = make([]valuelog.PreparedGroupedRecord, frames)
 				} else {
-					payload = make([]byte, job.rawBytes)
-				}
-				off := 0
-				for i := 0; i < job.k; i++ {
-					off += copy(payload[off:], job.records[i].Value)
+					job.preps = job.preps[:frames]
+					for i := range job.preps {
+						job.preps[i] = valuelog.PreparedGroupedRecord{}
+					}
 				}
 
-				// Preallocate destination close to raw size (compressed payloads
-				// should be smaller; allow a small overhead to avoid reallocs on
-				// incompressible inputs).
-				dst := getVlogDictPipelineBuf(&vlogDictPipelineEncPool, job.rawBytes+64)
-				encoded, encErr := valuelog.CompressPayloadWithDictInto(job.dictID, job.dict, payload, job.encodeLevel, job.enableEntropy, dst[:0])
-				if encErr != nil {
-					job.err = encErr
-					putVlogDictPipelineBuf(&vlogDictPipelineEncPool, dst, 4<<20)
-				} else {
-					if len(encoded) < job.rawBytes {
-						job.kept = true
-						job.encoded = encoded
-					} else {
-						job.kept = false
-						putVlogDictPipelineBuf(&vlogDictPipelineEncPool, dst, 4<<20)
-						job.encoded = nil
+				for frameIdx := 0; frameIdx < frames; frameIdx++ {
+					start := frameIdx * job.k
+					end := start + job.k
+					if end > len(job.records) {
+						end = len(job.records)
 					}
+					if start >= end {
+						job.err = errors.New("cachingdb: pipeline frame bounds out of range")
+						break
+					}
+					recs := job.records[start:end]
+					frameK := len(recs)
+
+					rawBytes := 0
+					offsets[0] = 0
+					for i := 0; i < frameK; i++ {
+						rid := recs[i].RID
+						if rid == 0 {
+							job.err = errors.New("cachingdb: missing rid")
+							break
+						}
+						rids[i] = rid
+						rawBytes += len(recs[i].Value)
+						offsets[i+1] = uint32(rawBytes)
+					}
+					if job.err != nil {
+						break
+					}
+
+					var rawPayload []byte
+					if rawBytes > 0 {
+						if rawBytes <= maxKeepRawScratch {
+							if cap(rawScratch) < rawBytes {
+								rawScratch = make([]byte, rawBytes)
+							}
+							rawPayload = rawScratch[:rawBytes]
+						} else {
+							rawPayload = make([]byte, rawBytes)
+						}
+						off := 0
+						for i := 0; i < frameK; i++ {
+							off += copy(rawPayload[off:], recs[i].Value)
+						}
+					}
+
+					attempted := job.dictID != 0 && len(job.dict) > 0 && rawBytes > 0
+					kept := false
+					payload := rawPayload
+
+					if attempted {
+						targetCap := rawBytes + (rawBytes / 16) + 64
+						if targetCap < rawBytes+64 {
+							targetCap = rawBytes + 64
+						}
+						if rawBytes <= maxKeepEncScratch && cap(encScratch) < targetCap {
+							encScratch = make([]byte, 0, targetCap)
+						}
+						encoded, encErr := valuelog.CompressPayloadWithDictInto(job.dictID, job.dict, rawPayload, job.encodeLevel, job.enableEntropy, encScratch[:0])
+						if encErr != nil {
+							job.err = encErr
+							break
+						}
+						if len(encoded) < rawBytes {
+							kept = true
+							payload = encoded
+						}
+					}
+
+					prefixLen := valuelog.FrameHeaderSize + (frameK * 8) + ((frameK + 1) * 4)
+					recordLen := valuelog.HeaderSize + prefixLen + len(payload)
+					recordBuf := getVlogDictPipelineBuf(&vlogDictPipelineRecordPool, recordLen)
+					prep, prepErr := valuelog.BuildPreparedGroupedRecordFromPayloadInto(recordBuf[:0], job.dictID, rids[:frameK], offsets[:frameK+1], rawBytes, payload, attempted, kept, 0)
+					if prepErr != nil {
+						putVlogDictPipelineBuf(&vlogDictPipelineRecordPool, recordBuf, maxKeepPreparedRecord)
+						job.err = prepErr
+						break
+					}
+					job.preps[frameIdx] = prep
 				}
 			}
 
@@ -236,14 +302,14 @@ func (db *DB) runVlogDictFramePipelineWorker(jobs <-chan *vlogDictPipelineJob) {
 	}
 }
 
-func (db *DB) appendValueLogDictFramesPipeline(w framePayloadWriterInto, dictID uint64, dict []byte, records []valuelog.Record, k int, ptrs []page.ValuePtr) (rawFrameBytes, storedPayloadBytes, frameRecords, framesTotal, framesAttempted, framesKept int, encodeNsTotal int64, encodeRawBytes int, err error) {
+func (db *DB) appendValueLogDictFramesPipeline(w framePreparedWriterInto, dictID uint64, dict []byte, records []valuelog.Record, rawPayloadBytes int, k int, ptrs []page.ValuePtr) (rawFrameBytes, storedPayloadBytes, frameRecords, framesTotal, framesAttempted, framesKept int, encodeNsTotal int64, encodeRawBytes int, err error) {
 	if db == nil {
 		return 0, 0, 0, 0, 0, 0, 0, 0, errors.New("cachingdb: nil db")
 	}
 	if w == nil {
 		return 0, 0, 0, 0, 0, 0, 0, 0, errors.New("cachingdb: nil writer")
 	}
-	if dictID == 0 || len(dict) == 0 || len(records) == 0 || k <= 0 {
+	if dictID == 0 || len(dict) == 0 || len(records) == 0 || rawPayloadBytes < 0 || k <= 0 {
 		return 0, 0, 0, 0, 0, 0, 0, 0, errors.New("cachingdb: invalid pipeline args")
 	}
 	if len(ptrs) < len(records) {
@@ -267,11 +333,39 @@ func (db *DB) appendValueLogDictFramesPipeline(w framePayloadWriterInto, dictID 
 		return 0, 0, 0, 0, 0, 0, 0, 0, errors.New("cachingdb: too few frames for pipeline")
 	}
 
+	const targetRawBytesPerJob = 256 << 10
+	framesPerJob := 1
+	if rawPayloadBytes > 0 && frameCount > 0 {
+		avgFrameBytes := rawPayloadBytes / frameCount
+		if avgFrameBytes > 0 {
+			framesPerJob = targetRawBytesPerJob / avgFrameBytes
+		}
+	}
+	if framesPerJob < 1 {
+		framesPerJob = 1
+	}
+	if framesPerJob > 64 {
+		framesPerJob = 64
+	}
+
+	minJobs := workers * 2
+	if minJobs < 1 {
+		minJobs = 1
+	}
+	maxFramesPerJob := (frameCount + minJobs - 1) / minJobs
+	if maxFramesPerJob < 1 {
+		maxFramesPerJob = 1
+	}
+	if framesPerJob > maxFramesPerJob {
+		framesPerJob = maxFramesPerJob
+	}
+	jobCount := (frameCount + framesPerJob - 1) / framesPerJob
+
 	pipeline := db.ensureVlogDictFramePipeline()
 	if pipeline == nil {
 		return 0, 0, 0, 0, 0, 0, 0, 0, errors.New("cachingdb: pipeline unavailable")
 	}
-	call := getVlogDictPipelineCall(workers, frameCount)
+	call := getVlogDictPipelineCall(workers, jobCount)
 	defer putVlogDictPipelineCall(call)
 	results := call.results
 	pending := call.pending
@@ -282,13 +376,21 @@ func (db *DB) appendValueLogDictFramesPipeline(w framePayloadWriterInto, dictID 
 
 	abort := error(nil)
 
-	scheduleFrame := func(frameIdx int) *vlogDictPipelineJob {
-		start := frameIdx * k
-		end := start + k
-		if end > len(records) {
-			end = len(records)
+	scheduleJob := func(jobIdx int) *vlogDictPipelineJob {
+		frameStart := jobIdx * framesPerJob
+		frameEnd := frameStart + framesPerJob
+		if frameEnd > frameCount {
+			frameEnd = frameCount
 		}
-		frameK := end - start
+		recordStart := frameStart * k
+		recordEnd := frameEnd * k
+		if recordEnd > len(records) {
+			recordEnd = len(records)
+		}
+		if recordStart >= recordEnd {
+			return nil
+		}
+
 		jobAny := vlogDictPipelineJobPool.Get()
 		var job *vlogDictPipelineJob
 		if jobAny != nil {
@@ -297,27 +399,26 @@ func (db *DB) appendValueLogDictFramesPipeline(w framePayloadWriterInto, dictID 
 		if job == nil {
 			job = &vlogDictPipelineJob{}
 		}
+		preps := job.preps
+		rawBytes := 0
+		for i := recordStart; i < recordEnd; i++ {
+			rawBytes += len(records[i].Value)
+		}
+
 		*job = vlogDictPipelineJob{
 			dictID:        dictID,
 			dict:          dict,
 			encodeLevel:   encodeLevel,
 			enableEntropy: enableEntropy,
 			results:       results,
-			frameIdx:      frameIdx,
-			start:         start,
-			end:           end,
-			k:             frameK,
-			records:       records[start:end],
+			jobIdx:        jobIdx,
+			frameStart:    frameStart,
+			frameEnd:      frameEnd,
+			k:             k,
+			rawBytes:      rawBytes,
+			records:       records[recordStart:recordEnd],
 		}
-		off := 0
-		job.offsets[0] = 0
-		for i := 0; i < frameK; i++ {
-			rec := records[start+i]
-			job.rids[i] = rec.RID
-			off += len(rec.Value)
-			job.offsets[i+1] = uint32(off)
-		}
-		job.rawBytes = off
+		job.preps = preps[:0]
 		return job
 	}
 
@@ -326,21 +427,35 @@ func (db *DB) appendValueLogDictFramesPipeline(w framePayloadWriterInto, dictID 
 			return
 		}
 		inFlightBytes -= int64(job.rawBytes)
-		if job.encoded != nil {
-			putVlogDictPipelineBuf(&vlogDictPipelineEncPool, job.encoded, 4<<20)
-			job.encoded = nil
+		if job.preps != nil {
+			for i := range job.preps {
+				rec := job.preps[i].Record
+				if len(rec) > 0 {
+					putVlogDictPipelineBuf(&vlogDictPipelineRecordPool, rec, 8<<20)
+					job.preps[i] = valuelog.PreparedGroupedRecord{}
+				}
+			}
+			job.preps = job.preps[:0]
 		}
 		job.records = nil
 		job.dict = nil
 		job.results = nil
-		*job = vlogDictPipelineJob{}
+		job.dictID = 0
+		job.encodeLevel = 0
+		job.enableEntropy = false
+		job.jobIdx = 0
+		job.frameStart = 0
+		job.frameEnd = 0
+		job.k = 0
+		job.rawBytes = 0
+		job.err = nil
 		vlogDictPipelineJobPool.Put(job)
 	}
 
 	var nextJob *vlogDictPipelineJob
 
 	writeReady := func() {
-		for nextWrite < frameCount && pending[nextWrite] != nil {
+		for nextWrite < jobCount && pending[nextWrite] != nil {
 			job := pending[nextWrite]
 			pending[nextWrite] = nil
 
@@ -353,45 +468,39 @@ func (db *DB) appendValueLogDictFramesPipeline(w framePayloadWriterInto, dictID 
 				continue
 			}
 
-			payload := []byte(nil)
-			kept := job.kept
-			if kept && len(job.encoded) > 0 {
-				payload = job.encoded
-			} else {
-				kept = false
-			}
-			if !kept && job.rawBytes > 0 {
-				// Rare path: we didn't keep compression (size inflation); build a
-				// contiguous payload for the writer API.
-				payload = make([]byte, job.rawBytes)
-				off := 0
-				for i := 0; i < job.k; i++ {
-					off += copy(payload[off:], job.records[i].Value)
+			for frameIdx := 0; frameIdx < len(job.preps); frameIdx++ {
+				prep := job.preps[frameIdx]
+				if prep.K <= 0 || len(prep.Record) == 0 {
+					abort = errors.New("cachingdb: missing prepared record")
+					break
 				}
-			}
-			attempted := dictID != 0 && len(dict) > 0 && job.rawBytes > 0
-			dst := ptrs[job.start:job.end]
-			_, stats, wErr := w.AppendFrameFromPayloadWithStatsInto(dictID, job.rids[:job.k], job.offsets[:job.k+1], job.rawBytes, payload, attempted, kept, job.encodeNs, dst)
-			if wErr != nil {
-				abort = wErr
-				freeJob(job)
-				nextWrite++
-				continue
-			}
+				recordStart := (job.frameStart + frameIdx) * k
+				recordEnd := recordStart + prep.K
+				if recordStart < 0 || recordStart >= len(ptrs) || recordEnd > len(ptrs) || recordEnd < recordStart {
+					abort = errors.New("cachingdb: invalid prepared record bounds")
+					break
+				}
+				dst := ptrs[recordStart:recordEnd]
+				_, stats, wErr := w.AppendPreparedGroupedRecordInto(prep, dst)
+				if wErr != nil {
+					abort = wErr
+					break
+				}
 
-			rawFrameBytes += stats.RawPayloadBytes
-			storedPayloadBytes += stats.StoredPayloadBytes
-			frameRecords += stats.Records
-			framesTotal++
-			if stats.Attempted {
-				framesAttempted++
-			}
-			if stats.Kept {
-				framesKept++
-			}
-			if stats.EncodeNs > 0 && stats.RawPayloadBytes > 0 {
-				encodeNsTotal += stats.EncodeNs
-				encodeRawBytes += stats.RawPayloadBytes
+				rawFrameBytes += stats.RawPayloadBytes
+				storedPayloadBytes += stats.StoredPayloadBytes
+				frameRecords += stats.Records
+				framesTotal++
+				if stats.Attempted {
+					framesAttempted++
+				}
+				if stats.Kept {
+					framesKept++
+				}
+				if stats.EncodeNs > 0 && stats.RawPayloadBytes > 0 {
+					encodeNsTotal += stats.EncodeNs
+					encodeRawBytes += stats.RawPayloadBytes
+				}
 			}
 
 			freeJob(job)
@@ -399,7 +508,7 @@ func (db *DB) appendValueLogDictFramesPipeline(w framePayloadWriterInto, dictID 
 		}
 	}
 
-	for nextWrite < frameCount {
+	for nextWrite < jobCount {
 		// Yield periodically so other goroutines can make progress, matching the
 		// sequential append loop behavior.
 		if nextWrite > 0 && nextWrite%256 == 0 {
@@ -409,14 +518,18 @@ func (db *DB) appendValueLogDictFramesPipeline(w framePayloadWriterInto, dictID 
 		if abort != nil {
 			break
 		}
-		if received >= sent && sent >= frameCount {
+		if received >= sent && sent >= jobCount {
 			break
 		}
 
-		canSend := abort == nil && sent < frameCount
+		canSend := abort == nil && sent < jobCount
 		if canSend && nextJob == nil {
-			nextJob = scheduleFrame(sent)
-			inFlightBytes += int64(nextJob.rawBytes)
+			nextJob = scheduleJob(sent)
+			if nextJob == nil {
+				abort = errors.New("cachingdb: failed to schedule pipeline job")
+			} else {
+				inFlightBytes += int64(nextJob.rawBytes)
+			}
 		}
 		if canSend && nextJob != nil {
 			oversize := int64(nextJob.rawBytes) > maxInFlight
@@ -436,7 +549,7 @@ func (db *DB) appendValueLogDictFramesPipeline(w framePayloadWriterInto, dictID 
 			case job := <-results:
 				received++
 				if job != nil {
-					pending[job.frameIdx] = job
+					pending[job.jobIdx] = job
 					if job.err != nil && abort == nil {
 						abort = job.err
 					}
@@ -450,7 +563,7 @@ func (db *DB) appendValueLogDictFramesPipeline(w framePayloadWriterInto, dictID 
 			job := <-results
 			received++
 			if job != nil {
-				pending[job.frameIdx] = job
+				pending[job.jobIdx] = job
 				if job.err != nil && abort == nil {
 					abort = job.err
 				}
@@ -469,10 +582,10 @@ func (db *DB) appendValueLogDictFramesPipeline(w framePayloadWriterInto, dictID 
 	for received < sent {
 		job := <-results
 		received++
-		pending[job.frameIdx] = job
+		pending[job.jobIdx] = job
 	}
 
-	for nextWrite < frameCount {
+	for nextWrite < jobCount {
 		writeReady()
 		if pending[nextWrite] == nil {
 			break

--- a/TreeDB/caching/vlog_dict_pipeline_bench_test.go
+++ b/TreeDB/caching/vlog_dict_pipeline_bench_test.go
@@ -61,6 +61,7 @@ func BenchmarkValueLogDictFramePipelineThroughput_NoIO(b *testing.B) {
 	}
 
 	rawBytesPerOp := int64(valueCnt * valueSize)
+	rawPayloadBytes := int(rawBytesPerOp)
 	b.SetBytes(rawBytesPerOp)
 
 	b.Run("sequential", func(b *testing.B) {
@@ -106,14 +107,14 @@ func BenchmarkValueLogDictFramePipelineThroughput_NoIO(b *testing.B) {
 		}
 
 		ptrs := make([]page.ValuePtr, len(records))
-		if _, _, _, _, _, _, _, _, err := db.appendValueLogDictFramesPipeline(writer, dictID, dict, records, k, ptrs); err != nil {
+		if _, _, _, _, _, _, _, _, err := db.appendValueLogDictFramesPipeline(writer, dictID, dict, records, rawPayloadBytes, k, ptrs); err != nil {
 			b.Fatalf("warmup appendValueLogDictFramesPipeline: %v", err)
 		}
 
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if _, _, _, _, _, _, _, _, err := db.appendValueLogDictFramesPipeline(writer, dictID, dict, records, k, ptrs); err != nil {
+			if _, _, _, _, _, _, _, _, err := db.appendValueLogDictFramesPipeline(writer, dictID, dict, records, rawPayloadBytes, k, ptrs); err != nil {
 				b.Fatalf("appendValueLogDictFramesPipeline: %v", err)
 			}
 		}

--- a/TreeDB/caching/vlog_dict_pipeline_test.go
+++ b/TreeDB/caching/vlog_dict_pipeline_test.go
@@ -59,6 +59,7 @@ func TestValueLogDictFramePipeline_OrderAndPointers(t *testing.T) {
 	for i := range records {
 		records[i] = valuelog.Record{RID: uint64(i + 1), Value: values[i]}
 	}
+	rawPayloadBytes := valueSize * valueCnt
 	ptrs := make([]page.ValuePtr, len(records))
 
 	run := func(t *testing.T, maxInFlight int64) {
@@ -82,7 +83,7 @@ func TestValueLogDictFramePipeline_OrderAndPointers(t *testing.T) {
 		}
 
 		rawFrameBytes, storedPayloadBytes, frameRecords, framesTotal, framesAttempted, _, _, _, err :=
-			db.appendValueLogDictFramesPipeline(writer, dictID, dict, records, k, ptrs)
+			db.appendValueLogDictFramesPipeline(writer, dictID, dict, records, rawPayloadBytes, k, ptrs)
 		if err != nil {
 			t.Fatalf("appendValueLogDictFramesPipeline: %v", err)
 		}

--- a/TreeDB/caching/vlog_writer_caps.go
+++ b/TreeDB/caching/vlog_writer_caps.go
@@ -21,17 +21,22 @@ type framePayloadWriterInto interface {
 	AppendFrameFromPayloadWithStatsInto(dictID uint64, rids []uint64, offsets []uint32, rawPayloadBytes int, payload []byte, attempted bool, kept bool, encodeNs int64, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
 }
 
+type framePreparedWriterInto interface {
+	AppendPreparedGroupedRecordInto(prep valuelog.PreparedGroupedRecord, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
+}
+
 type rawFrameBatchWriterInto interface {
 	AppendRawFramesWritevInto(records []valuelog.Record, k int, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
 }
 
 type vlogWriterCaps struct {
-	writer      valueWriter
-	keep        keepPolicySetter
-	stats       frameStatsWriter
-	statsInto   frameStatsWriterInto
-	payloadInto framePayloadWriterInto
-	rawInto     rawFrameBatchWriterInto
+	writer       valueWriter
+	keep         keepPolicySetter
+	stats        frameStatsWriter
+	statsInto    frameStatsWriterInto
+	payloadInto  framePayloadWriterInto
+	preparedInto framePreparedWriterInto
+	rawInto      rawFrameBatchWriterInto
 }
 
 func computeVlogWriterCaps(w valueWriter) vlogWriterCaps {
@@ -51,6 +56,9 @@ func computeVlogWriterCaps(w valueWriter) vlogWriterCaps {
 	}
 	if v, ok := any(w).(framePayloadWriterInto); ok {
 		caps.payloadInto = v
+	}
+	if v, ok := any(w).(framePreparedWriterInto); ok {
+		caps.preparedInto = v
 	}
 	if v, ok := any(w).(rawFrameBatchWriterInto); ok {
 		caps.rawInto = v


### PR DESCRIPTION
Fixes #330.

### What changed
- Reworked the TreeDB dict-frame “parallel pipeline” to build full `valuelog.PreparedGroupedRecord`s in worker goroutines (compression + framing off-thread).
- Writer stage now only appends prepared records in-order (`AppendPreparedGroupedRecordInto`), avoiding the v1 extra copies/framing work in the writer goroutine.
- Jobs now batch multiple frames (reduces channel/job overhead), with in-flight bytes bounded by `ValueLogDictFramePipelineMaxInFlightBytes`.

### Benchmarks
#### 1) Microbench (no I/O)
Command:
```bash
go test ./TreeDB/caching -run '^$' -bench 'BenchmarkValueLogDictFramePipelineThroughput_NoIO' -benchmem -count 5
```
Median `ns/op` (Apple M3):
- sequential: `1,157,390`
- pipeline `workers=4`: `366,723` (~`3.15x` faster)
- pipeline `workers=8`: `418,550` (~`2.76x` faster)

#### 2) End-to-end `unified_bench` (5 trials)
Command (run 5x; take the median of each column):
```bash
go run ./cmd/unified_bench \
  -dbs treedb \
  -profile fast \
  -keys 200000 \
  -valsize 1024 \
  -batchsize 1000 \
  -progress=false \
  -format markdown \
  -treedb-force-value-pointers \
  -treedb-vlog-dict on \
  -treedb-vlog-dict-frame-pipeline both \
  -treedb-vlog-dict-frame-pipeline-workers 4 \
  -val-pattern ultra_compressible_repeat \
  -test batch_write
```
Median (of 5 runs):
- `TreeDB (vlog_dict=on)`: `1,719,437`
- `TreeDB (vlog_dict=on, …, pipeline=4)`: `2,283,884` (~`1.33x`)
