### PR TITLE
TreeDB: pick better dict frame K using IO cost

### DIFF
--- a/TreeDB/caching/vlog_dict.go
+++ b/TreeDB/caching/vlog_dict.go
@@ -70,6 +70,15 @@ func (db *DB) valueLogDictCollectSamples(records []valuelog.Record) {
 	if tr == nil || !tr.ShouldCollect() {
 		return
 	}
+	// Seed the trainer's IO cost model early so the initial dict/K selection can
+	// optimize for end-to-end throughput (encode + IO), rather than falling back
+	// to the decode-cost heuristic when no profile has been published yet.
+	//
+	// This avoids pathological small-K choices (e.g. k=2/4) that increase frame
+	// overhead and reduce write throughput for small values.
+	if db.valueLogAutotuneOptions.Mode != valuelog.AutotuneOff {
+		tr.SetAutotuneIOCost(db.valueLogAutotuneMetrics.snapshot().IoNsPerStoredByte)
+	}
 	stride := db.valueLogDictSampleStride
 	if stride <= 1 {
 		stride = 1
@@ -119,6 +128,9 @@ func (db *DB) valueLogDictCollectSample(value []byte) {
 	tr := db.valueLogDictTrainer
 	if tr == nil || !tr.ShouldCollect() {
 		return
+	}
+	if db.valueLogAutotuneOptions.Mode != valuelog.AutotuneOff {
+		tr.SetAutotuneIOCost(db.valueLogAutotuneMetrics.snapshot().IoNsPerStoredByte)
 	}
 	stride := db.valueLogDictSampleStride
 	if stride <= 1 {

--- a/TreeDB/internal/compression/profile.go
+++ b/TreeDB/internal/compression/profile.go
@@ -229,7 +229,16 @@ func batchTotals(dict []byte, samples [][]byte, k int, encodeNsPerRawByte float6
 		}
 		c := enc.EncodeAll(buf, nil)
 		payload += len(c)
-		meta += 4 * (k + 1)
+		// Account for the full on-disk framing overhead:
+		// - record header (CRC/version/flags/txn/bodyLen)
+		// - frame header + dict_id + RID table + offsets table
+		//
+		// NOTE: Keep these constants in sync with `TreeDB/internal/valuelog/valuelog.go`.
+		const (
+			valueLogRecordHeaderBytes = 20 // valuelog.HeaderSize
+			valueLogFrameHeaderBytes  = 12 // valuelog.FrameHeaderSize
+		)
+		meta += valueLogRecordHeaderBytes + valueLogFrameHeaderBytes + (k * 8) + ((k + 1) * 4)
 	}
 	if encodeNsPerRawByte > 0 {
 		encodeNs = int64(float64(raw) * encodeNsPerRawByte)


### PR DESCRIPTION
This fixes a large write-throughput regression when enabling **value-log dictionary compression** for small values (e.g. 128B) by making the *initial* dict/K selection use the measured IO cost model.

## What changed
- Seed the dict trainer with the current `IoNsPerStoredByte` **during sample collection** so the first trained profile can pick a good frame `k` using the throughput model (encode + IO).
- Fix `ChooseKForDictOptions` scoring to include the **full** on-disk value-log framing overhead (record header + frame header + RID table + offsets table). This also makes the logged `total_ratio` meaningful.

## Why it helps
On `ultra_compressible_repeat` (128B values), the trainer previously published `k=4`, producing many tiny frames and lots of per-frame overhead.

With IO cost available early, the same workload converges to `k=32` (~4KiB raw payload per frame), improving both:
- **throughput** (fewer frames / fewer zstd invocations)
- **space savings** (larger frames make compression more likely to be kept by the keep-policy)

## Bench (5 trials; trimmed mean = drop min/max, avg remaining 3)
Command:
```bash
/tmp/unified_bench -dbs treedb \
  -test batch_write \
  -keys 14000000 -valsize 128 -batchsize 100 \
  -progress=false -format markdown \
  -treedb-force-value-pointers \
  -treedb-vlog-dict both \
  -val-pattern ultra_compressible_repeat
```

Results:
- `main`:
  - Batch Write: `off=1,893,941 ops/s`, `on=1,130,269 ops/s`
  - WAL (dict on): `~595 MiB`
- this PR:
  - Batch Write: `off=1,845,478 ops/s`, `on=1,378,601 ops/s` (**+22% dict-on write throughput**)
  - WAL (dict on): `~472 MiB` (smaller)

## Repro notes
Build once to avoid `go run` compile overhead:
```bash
go build -o /tmp/unified_bench ./cmd/unified_bench
```
