### PR TITLE
TreeDB: pass all-flags median gate with adaptive fallback + hot-path fixes

### DIFF
--- a/TreeDB/node/builder.go
+++ b/TreeDB/node/builder.go
@@ -195,6 +195,7 @@ func (b *Builder) AddLeafEntry(key, value []byte, flags byte, valPtr page.ValueP
 	if b.pType != page.PageTypeLeaf {
 		return ErrInvalidType
 	}
+	b.maybeFallbackCombinedLeafEncoding(key)
 	if b.leafColumnar && !b.leafPrefixCompression {
 		if b.leafColumnarV2 {
 			return b.addLeafEntryColumnarV2(key, value, flags, valPtr)
@@ -206,6 +207,23 @@ func (b *Builder) AddLeafEntry(key, value []byte, flags byte, valPtr page.ValueP
 	// KeyPrefixLen(2) + KeySuffixLen(2) + ValLen(4) + Flags(1) + KeySuffix + Value/Ptr
 	entrySize, prefixLen, suffixLen := b.leafEntrySize(key, value, flags)
 	return b.AddLeafEntryWithPrefix(key, value, flags, valPtr, entrySize, prefixLen, suffixLen)
+}
+
+func (b *Builder) maybeFallbackCombinedLeafEncoding(key []byte) {
+	if b.pType != page.PageTypeLeaf {
+		return
+	}
+	if b.count != 0 {
+		return
+	}
+	// For short keys, combined columnar+prefix often costs more CPU than it saves
+	// on reads/scans. Fallback to plain leaf encoding for this page.
+	if b.leafColumnar && b.leafPrefixCompression && len(key) <= 12 {
+		b.leafPrefixCompression = false
+		b.leafPrefixV2 = false
+		b.leafColumnar = false
+		b.leafColumnarV2 = false
+	}
 }
 
 func (b *Builder) addLeafEntryColumnar(key, value []byte, flags byte, valPtr page.ValuePtr) error {
@@ -391,6 +409,12 @@ func (b *Builder) addLeafEntryColumnarPrefixV2(key, value []byte, flags byte, va
 func (b *Builder) AddLeafEntryWithPrefix(key, value []byte, flags byte, valPtr page.ValuePtr, entrySize, prefixLen, suffixLen int) error {
 	if b.pType != page.PageTypeLeaf {
 		return ErrInvalidType
+	}
+	prevPrefix := b.leafPrefixCompression
+	prevColumnar := b.leafColumnar
+	b.maybeFallbackCombinedLeafEncoding(key)
+	if prevPrefix != b.leafPrefixCompression || prevColumnar != b.leafColumnar {
+		entrySize, prefixLen, suffixLen = b.LeafEntrySizeWithPrefix(key, value, flags)
 	}
 
 	if b.leafColumnar {
@@ -693,6 +717,14 @@ func (b *Builder) addInternalChildBaseDelta(key []byte, childPageID uint64) erro
 	if len(key) > int(^uint16(0)) {
 		return ErrKeyTooLarge
 	}
+	if b.count == 0 && len(key) <= 12 {
+		// Short separator keys are cheaper to keep uncompressed. Falling back on
+		// the first entry avoids finish-time rewrite overhead on write-heavy paths.
+		if err := b.fallbackInternalBaseDeltaToUncompressed(); err != nil {
+			return err
+		}
+		return b.AddInternalChild(key, childPageID)
+	}
 
 	if b.count == 0 {
 		b.internalBaseChildID = childPageID
@@ -829,6 +861,18 @@ func (b *Builder) finishInternalBaseDelta() bool {
 	if count == 0 {
 		return false
 	}
+	tryFallback := func() bool {
+		if err := b.fallbackInternalBaseDeltaToUncompressed(); err != nil {
+			return false
+		}
+		return true
+	}
+	if count < 16 {
+		if tryFallback() {
+			return false
+		}
+		return true
+	}
 
 	baseOff := len(b.data) - 8
 	prefixLenOff := baseOff - 2
@@ -846,7 +890,10 @@ func (b *Builder) finishInternalBaseDelta() bool {
 	}
 
 	prefixLen := sharedPrefixLen(firstKey, lastKey)
-	if count < 2 || prefixLen <= 0 {
+	if count < 2 || prefixLen < 2 {
+		if tryFallback() {
+			return false
+		}
 		return true
 	}
 	if prefixLen > len(firstKey) {
@@ -859,7 +906,9 @@ func (b *Builder) finishInternalBaseDelta() bool {
 	footerBytes := prefixLen + internalBaseDeltaFooterSize
 	footerStart := len(b.data) - footerBytes
 	if footerStart < dirEnd {
-		// Not enough room to store the prefix bytes. Keep prefixLen=0.
+		if tryFallback() {
+			return false
+		}
 		return true
 	}
 
@@ -868,6 +917,39 @@ func (b *Builder) finishInternalBaseDelta() bool {
 	clear(tmp)
 
 	heapStart := footerStart
+
+	totalKeyBytes := 0
+	for i := uint16(0); i < count; i++ {
+		fullKey, _, err := b.internalBaseDeltaEntryView(i)
+		if err != nil {
+			internalBaseDeltaRewritePool.Put(tmp)
+			return true
+		}
+		if len(fullKey) < prefixLen {
+			internalBaseDeltaRewritePool.Put(tmp)
+			if tryFallback() {
+				return false
+			}
+			return true
+		}
+		totalKeyBytes += len(fullKey)
+	}
+	if totalKeyBytes/int(count) <= 12 {
+		internalBaseDeltaRewritePool.Put(tmp)
+		if tryFallback() {
+			return false
+		}
+		return true
+	}
+	plainBytes := int(count)*(2+8) + totalKeyBytes
+	compressedBytes := int(count)*(2+4) + (totalKeyBytes - int(count)*prefixLen) + footerBytes
+	if compressedBytes >= plainBytes || (plainBytes-compressedBytes)*100 < plainBytes*8 {
+		internalBaseDeltaRewritePool.Put(tmp)
+		if tryFallback() {
+			return false
+		}
+		return true
+	}
 
 	prefixStart := footerStart
 	copy(tmp[prefixStart:prefixStart+prefixLen], firstKey[:prefixLen])

--- a/TreeDB/node/internal.go
+++ b/TreeDB/node/internal.go
@@ -49,6 +49,10 @@ func comparePrefixedKey(prefix, suffix, key []byte) int {
 	return bytes.Compare(suffix, key[len(prefix):])
 }
 
+func compareInternalSuffix(suffix, keySuffix []byte) int {
+	return bytes.Compare(suffix, keySuffix)
+}
+
 // InternalEntry represents a parsed entry from an Internal Node.
 type InternalEntry struct {
 	Key         []byte
@@ -175,6 +179,29 @@ func (n *Node) SearchInternal(key []byte) (uint16, bool) {
 		if count == 0 {
 			return 0, false
 		}
+		keySuffix := key
+		if len(prefix) > 0 {
+			prefixLen := len(prefix)
+			if len(key) < prefixLen {
+				cmp := bytes.Compare(prefix[:len(key)], key)
+				if cmp != 0 {
+					if cmp < 0 {
+						return count - 1, true
+					}
+					return 0, false
+				}
+				// key is a strict prefix of all entry keys.
+				return 0, false
+			}
+			cmp := bytes.Compare(prefix, key[:prefixLen])
+			if cmp != 0 {
+				if cmp < 0 {
+					return count - 1, true
+				}
+				return 0, false
+			}
+			keySuffix = key[prefixLen:]
+		}
 		if count <= smallSearchThreshold {
 			last := -1
 			for i := 0; i < int(count); i++ {
@@ -189,7 +216,7 @@ func (n *Node) SearchInternal(key []byte) (uint16, bool) {
 				if suffixLen < 0 || suffixEnd > footerStart {
 					return 0, false
 				}
-				cmp := comparePrefixedKey(prefix, data[suffixStart:suffixEnd], key)
+				cmp := compareInternalSuffix(data[suffixStart:suffixEnd], keySuffix)
 				if cmp <= 0 {
 					last = i
 					continue
@@ -217,7 +244,7 @@ func (n *Node) SearchInternal(key []byte) (uint16, bool) {
 				return 0, false
 			}
 
-			cmp := comparePrefixedKey(prefix, data[suffixStart:suffixEnd], key)
+			cmp := compareInternalSuffix(data[suffixStart:suffixEnd], keySuffix)
 			if cmp <= 0 {
 				i = h + 1
 			} else {

--- a/TreeDB/node/internal_base_delta_test.go
+++ b/TreeDB/node/internal_base_delta_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -237,5 +238,97 @@ func TestInternalBaseDelta_IncreasesFanout(t *testing.T) {
 	// which should yield a measurable increase for typical key sizes.
 	if compressed < plain+(plain/20) {
 		t.Fatalf("expected >=5%% fanout increase: plain=%d compressed=%d", plain, compressed)
+	}
+}
+
+func TestInternalBaseDelta_FallbackLowCount(t *testing.T) {
+	buf := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(buf, page.PageTypeInternal, BuilderOptions{InternalBaseDelta: true})
+	b.SetPageID(1)
+
+	for i := 0; i < 15; i++ {
+		key := []byte(fmt.Sprintf("user:%08d", i))
+		if err := b.AddInternalChild(key, uint64(10_000+i)); err != nil {
+			t.Fatalf("AddInternalChild(%d): %v", i, err)
+		}
+	}
+
+	n := b.Finish()
+	if n.internalBaseDelta() {
+		t.Fatalf("expected fallback to plain internal page when count<16")
+	}
+}
+
+func TestInternalBaseDelta_FallbackLowSharedPrefix(t *testing.T) {
+	buf := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(buf, page.PageTypeInternal, BuilderOptions{InternalBaseDelta: true})
+	b.SetPageID(1)
+
+	for i := 0; i < 20; i++ {
+		key := []byte(fmt.Sprintf("%c_key_%04d", byte('a'+i), i))
+		if err := b.AddInternalChild(key, uint64(20_000+i)); err != nil {
+			t.Fatalf("AddInternalChild(%d): %v", i, err)
+		}
+	}
+
+	n := b.Finish()
+	if n.internalBaseDelta() {
+		t.Fatalf("expected fallback to plain internal page when shared prefix < 2 bytes")
+	}
+}
+
+func TestInternalBaseDelta_FallbackLowSavingsRatio(t *testing.T) {
+	buf := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(buf, page.PageTypeInternal, BuilderOptions{InternalBaseDelta: true})
+	b.SetPageID(1)
+
+	for i := 0; i < 16; i++ {
+		// Long keys with only a 2-byte shared prefix reduce compression ratio.
+		key := append([]byte("aa"), bytes.Repeat([]byte{byte('a' + i)}, 120)...)
+		if err := b.AddInternalChild(key, uint64(30_000+i)); err != nil {
+			t.Fatalf("AddInternalChild(%d): %v", i, err)
+		}
+	}
+
+	n := b.Finish()
+	if n.internalBaseDelta() {
+		t.Fatalf("expected fallback to plain internal page when net savings ratio < 8%%")
+	}
+}
+
+func TestInternalBaseDelta_FallbackShortAverageSeparator(t *testing.T) {
+	buf := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(buf, page.PageTypeInternal, BuilderOptions{InternalBaseDelta: true})
+	b.SetPageID(1)
+
+	for i := 0; i < 64; i++ {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(i))
+		if err := b.AddInternalChild(key[:], uint64(40_000+i)); err != nil {
+			t.Fatalf("AddInternalChild(%d): %v", i, err)
+		}
+	}
+
+	n := b.Finish()
+	if n.internalBaseDelta() {
+		t.Fatalf("expected fallback to plain internal page when average separator key is short")
+	}
+}
+
+func TestInternalBaseDelta_EarlyFallbackShortFirstSeparator(t *testing.T) {
+	buf := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(buf, page.PageTypeInternal, BuilderOptions{InternalBaseDelta: true})
+	b.SetPageID(1)
+
+	var key [8]byte
+	binary.BigEndian.PutUint64(key[:], uint64(1))
+	if err := b.AddInternalChild(key[:], 42); err != nil {
+		t.Fatalf("AddInternalChild: %v", err)
+	}
+	if b.internalBaseDelta {
+		t.Fatalf("expected internal base-delta to disable immediately for short first separator key")
+	}
+	if b.heapStart != int(page.PageSize)-(2+8+len(key)) {
+		t.Fatalf("unexpected heapStart after early fallback: got=%d want=%d", b.heapStart, int(page.PageSize)-(2+8+len(key)))
 	}
 }

--- a/TreeDB/node/leaf.go
+++ b/TreeDB/node/leaf.go
@@ -313,6 +313,57 @@ func (n *Node) GetLeafEntryView(index uint16) (key []byte, val []byte, valPtr pa
 	return key, val, page.ValuePtr{}, flags, nil
 }
 
+// GetLeafKeyFlagsView returns the key and flags for the entry at index without
+// decoding the value bytes/pointer payload.
+func (n *Node) GetLeafKeyFlagsView(index uint16) (key []byte, flags byte, err error) {
+	if n.Type() != page.PageTypeLeaf {
+		return nil, 0, ErrInvalidType
+	}
+	if n.leafPackedValuePtr() && !n.leafPrefixCompressed() && !n.leafColumnar() {
+		offset, err := n.getOffset(index)
+		if err != nil {
+			return nil, 0, err
+		}
+		if int(offset) >= len(n.data) {
+			return nil, 0, ErrCorruptedNode
+		}
+		ptr := int(offset)
+		if ptr < NodeHeaderSize || ptr+7 > len(n.data) {
+			return nil, 0, ErrCorruptedNode
+		}
+		keyLen := int(getUint16(n.data[ptr : ptr+2]))
+		flags = n.data[ptr+6]
+		keyStart := ptr + 7
+		keyEnd := keyStart + keyLen
+		if keyStart < NodeHeaderSize || keyEnd > len(n.data) {
+			return nil, 0, ErrCorruptedNode
+		}
+		return n.data[keyStart:keyEnd], flags, nil
+	}
+	if n.leafColumnar() && n.leafColumnarV2() && !n.leafPrefixCompressed() {
+		count := n.Count()
+		if index >= count {
+			return nil, 0, ErrCorruptedNode
+		}
+		key, err = n.leafColumnarKeyViewAtIndex(int(index))
+		if err != nil {
+			return nil, 0, err
+		}
+		flagsStart := NodeHeaderSize + int(count)*DirectoryEntrySize + int(count)*DirectoryEntrySize
+		flagsOff := flagsStart + int(index)
+		if flagsOff >= len(n.data) {
+			return nil, 0, ErrCorruptedNode
+		}
+		return key, n.data[flagsOff], nil
+	}
+
+	key, layout, _, err := n.leafEntryKeyAt(index)
+	if err != nil {
+		return nil, 0, err
+	}
+	return key, layout.flags, nil
+}
+
 // GetLeafValueView returns the value (inline or pointer) at the given index
 // without reconstructing the key. This is useful for point reads after SearchLeaf.
 func (n *Node) GetLeafValueView(index uint16) (val []byte, valPtr page.ValuePtr, flags byte, err error) {
@@ -322,6 +373,45 @@ func (n *Node) GetLeafValueView(index uint16) (val []byte, valPtr page.ValuePtr,
 
 	if n.leafColumnar() && n.leafColumnarV2() && !n.leafPrefixCompressed() {
 		return n.getLeafValueViewColumnarV2(index)
+	}
+	if n.leafPackedValuePtr() && !n.leafPrefixCompressed() && !n.leafColumnar() {
+		offset, err := n.getOffset(index)
+		if err != nil {
+			return nil, page.ValuePtr{}, 0, err
+		}
+		if int(offset) >= len(n.data) {
+			return nil, page.ValuePtr{}, 0, ErrCorruptedNode
+		}
+		entryStart := int(offset)
+		if entryStart < NodeHeaderSize || entryStart+7 > len(n.data) {
+			return nil, page.ValuePtr{}, 0, ErrCorruptedNode
+		}
+		keyLen := int(getUint16(n.data[entryStart : entryStart+2]))
+		flags = n.data[entryStart+6]
+		valueStart := entryStart + 7 + keyLen
+		if valueStart < NodeHeaderSize || valueStart > len(n.data) {
+			return nil, page.ValuePtr{}, 0, ErrCorruptedNode
+		}
+
+		if flags&FlagTombstone != 0 {
+			return nil, page.ValuePtr{}, flags, nil
+		}
+		if flags&FlagPointer != 0 {
+			if valueStart+page.PackedValuePtrSize > len(n.data) {
+				return nil, page.ValuePtr{}, 0, ErrCorruptedNode
+			}
+			return nil, page.DecodePackedValuePtr(n.data[valueStart : valueStart+page.PackedValuePtrSize]), flags, nil
+		}
+
+		valLenU32 := binary.LittleEndian.Uint32(n.data[entryStart+2 : entryStart+6])
+		if uint64(valLenU32) > uint64(math.MaxInt) {
+			return nil, page.ValuePtr{}, 0, ErrCorruptedNode
+		}
+		valLen := int(valLenU32)
+		if valueStart+valLen > len(n.data) {
+			return nil, page.ValuePtr{}, 0, ErrCorruptedNode
+		}
+		return n.data[valueStart : valueStart+valLen], page.ValuePtr{}, flags, nil
 	}
 
 	offset, err := n.getOffset(index)
@@ -841,6 +931,10 @@ func (n *Node) getLeafValueViewColumnarV2(index uint16) (val []byte, valPtr page
 }
 
 func (n *Node) searchLeafColumnar(key []byte) (uint16, bool, error) {
+	if n.leafColumnarV2() {
+		return n.searchLeafColumnarV2(key)
+	}
+
 	count := n.Count()
 	if count == 0 {
 		return 0, false, nil
@@ -877,6 +971,84 @@ func (n *Node) searchLeafColumnar(key []byte) (uint16, bool, error) {
 
 	if i < int(count) {
 		k, err := n.leafColumnarKeyViewAtIndex(i)
+		if err != nil {
+			return 0, false, err
+		}
+		if bytes.Equal(k, key) {
+			return uint16(i), true, nil
+		}
+	}
+	return uint16(i), false, nil
+}
+
+func (n *Node) searchLeafColumnarV2(key []byte) (uint16, bool, error) {
+	count := int(n.Count())
+	if count == 0 {
+		return 0, false, nil
+	}
+
+	data := n.data
+	keyDirStart := NodeHeaderSize
+	keyDirEnd := keyDirStart + count*DirectoryEntrySize
+	valDirEnd := keyDirEnd + count*DirectoryEntrySize
+	headerEnd := valDirEnd + count // flags[]
+	if headerEnd > len(data) {
+		return 0, false, ErrCorruptedNode
+	}
+
+	keyAt := func(idx int) ([]byte, error) {
+		if idx < 0 || idx >= count {
+			return nil, ErrCorruptedNode
+		}
+		keyOff := keyDirStart + idx*2
+		nextKeyOff := keyOff + 2
+		if nextKeyOff > len(data) {
+			return nil, ErrCorruptedNode
+		}
+		keyStart := int(getUint16(data[keyOff : keyOff+2]))
+		keyEnd := len(data)
+		if idx+1 < count {
+			if nextKeyOff+2 > len(data) {
+				return nil, ErrCorruptedNode
+			}
+			keyEnd = int(getUint16(data[nextKeyOff : nextKeyOff+2]))
+		}
+		if keyStart < headerEnd || keyEnd < keyStart || keyEnd > len(data) {
+			return nil, ErrCorruptedNode
+		}
+		return data[keyStart:keyEnd], nil
+	}
+
+	if count <= smallSearchThreshold {
+		for idx := 0; idx < count; idx++ {
+			k, err := keyAt(idx)
+			if err != nil {
+				return 0, false, err
+			}
+			cmp := bytes.Compare(k, key)
+			if cmp >= 0 {
+				return uint16(idx), cmp == 0, nil
+			}
+		}
+		return uint16(count), false, nil
+	}
+
+	i, j := 0, count
+	for i < j {
+		h := int(uint(i+j) >> 1)
+		k, err := keyAt(h)
+		if err != nil {
+			return 0, false, err
+		}
+		if bytes.Compare(k, key) < 0 {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+
+	if i < count {
+		k, err := keyAt(i)
 		if err != nil {
 			return 0, false, err
 		}
@@ -1164,6 +1336,7 @@ func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, targ
 		return blockEnd, false, nil
 	}
 
+	var stackScratch [128]byte
 	restartKey, err := n.leafColumnarPrefixV2RestartKeyViewAtIndex(blockStart)
 	if err != nil {
 		return 0, false, err
@@ -1194,7 +1367,12 @@ func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, targ
 		}
 
 		keyLen := prefixLen + len(suffix)
-		cur := n.ensureKeyScratch(keyLen)
+		var cur []byte
+		if keyLen <= len(stackScratch) {
+			cur = stackScratch[:keyLen]
+		} else {
+			cur = n.ensureKeyScratch(keyLen)
+		}
 		// If prevKey and cur share backing storage, the existing prefix bytes are
 		// already in place and we only need to overwrite the suffix below.
 		sameBacking := len(prevKey) > 0 && len(cur) > 0 && &prevKey[0] == &cur[0]

--- a/TreeDB/node/leaf_columnar_prefix_v2_test.go
+++ b/TreeDB/node/leaf_columnar_prefix_v2_test.go
@@ -77,3 +77,48 @@ func TestLeafColumnarPrefixV2_RoundTrip(t *testing.T) {
 		}
 	}
 }
+
+func TestLeafColumnarPrefixV2_FallbackShortKeysToPlainLeaf(t *testing.T) {
+	buf := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(buf, page.PageTypeLeaf, BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+	})
+	b.SetPageID(1)
+
+	for i := 0; i < 32; i++ {
+		key := []byte{0, 0, 0, 0, byte(i >> 8), byte(i), byte(i), byte(i)}
+		if err := b.AddLeafEntry(key, nil, FlagPointer, page.ValuePtr{Offset: uint64(i + 1), Length: 4, FileID: 1}); err != nil {
+			t.Fatalf("AddLeafEntry(%d): %v", i, err)
+		}
+	}
+
+	n := b.Finish()
+	if n.leafPrefixCompressed() {
+		t.Fatalf("expected short-key fallback to disable prefix compression")
+	}
+	if n.leafColumnar() {
+		t.Fatalf("expected short-key fallback to disable columnar leaf encoding")
+	}
+}
+
+func TestLeafColumnarPrefixV2_KeepsCombinedForLongKeys(t *testing.T) {
+	buf := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(buf, page.PageTypeLeaf, BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+	})
+	b.SetPageID(1)
+
+	keys := makeBenchKeys(32, 16)
+	for i := 0; i < len(keys); i++ {
+		if err := b.AddLeafEntry(keys[i], nil, FlagPointer, page.ValuePtr{Offset: uint64(i + 1), Length: 4, FileID: 1}); err != nil {
+			t.Fatalf("AddLeafEntry(%d): %v", i, err)
+		}
+	}
+
+	n := b.Finish()
+	if !n.leafPrefixCompressed() || !n.leafColumnar() || !n.leafPrefixV2() {
+		t.Fatalf("expected combined columnar+prefix encoding for long keys")
+	}
+}

--- a/TreeDB/node/leaf_key_flags_view_test.go
+++ b/TreeDB/node/leaf_key_flags_view_test.go
@@ -1,0 +1,73 @@
+package node
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestGetLeafKeyFlagsView_RoundTripAcrossLayouts(t *testing.T) {
+	type variant struct {
+		name string
+		opts BuilderOptions
+	}
+
+	variants := []variant{
+		{name: "plain", opts: BuilderOptions{}},
+		{name: "prefix_v2", opts: BuilderOptions{LeafPrefixCompression: true}},
+		{name: "columnar_v2", opts: BuilderOptions{LeafColumnar: true}},
+		{name: "columnar_prefix_v2", opts: BuilderOptions{LeafPrefixCompression: true, LeafColumnar: true}},
+		{name: "columnar_prefix_v2_packed", opts: BuilderOptions{LeafPrefixCompression: true, LeafColumnar: true, PackedValuePtr: true}},
+	}
+
+	keys := makeBenchKeys(32, 16)
+	for _, v := range variants {
+		t.Run(v.name, func(t *testing.T) {
+			buf := make([]byte, page.PageSize)
+			b := NewBuilderWithOptions(buf, page.PageTypeLeaf, v.opts)
+			b.SetPageID(1)
+
+			flagsWant := make([]byte, len(keys))
+			for i := range keys {
+				var value []byte
+				var ptr page.ValuePtr
+				switch i % 3 {
+				case 0:
+					flagsWant[i] = FlagInline
+					value = []byte{byte(i), byte(i + 1), byte(i + 2)}
+				case 1:
+					flagsWant[i] = FlagPointer
+					ptr = page.ValuePtr{Offset: uint64(i + 1), Length: uint32(10 + i), FileID: 7}
+				default:
+					flagsWant[i] = FlagTombstone
+				}
+				if err := b.AddLeafEntry(keys[i], value, flagsWant[i], ptr); err != nil {
+					t.Fatalf("AddLeafEntry(%d): %v", i, err)
+				}
+			}
+			n := b.Finish()
+
+			for i := range keys {
+				k, flags, err := n.GetLeafKeyFlagsView(uint16(i))
+				if err != nil {
+					t.Fatalf("GetLeafKeyFlagsView(%d): %v", i, err)
+				}
+				if !bytes.Equal(k, keys[i]) {
+					t.Fatalf("key mismatch idx=%d got=%x want=%x", i, k, keys[i])
+				}
+				if flags != flagsWant[i] {
+					t.Fatalf("flags mismatch idx=%d got=%d want=%d", i, flags, flagsWant[i])
+				}
+
+				entryKey, _, _, entryFlags, err := n.GetLeafEntryView(uint16(i))
+				if err != nil {
+					t.Fatalf("GetLeafEntryView(%d): %v", i, err)
+				}
+				if !bytes.Equal(entryKey, k) || entryFlags != flags {
+					t.Fatalf("view mismatch idx=%d key=%x/%x flags=%d/%d", i, entryKey, k, entryFlags, flags)
+				}
+			}
+		})
+	}
+}

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -28,6 +28,7 @@ type Iterator struct {
 	currPtr      page.ValuePtr
 	flags        byte
 	valOK        bool
+	ptrOK        bool
 	reverse      bool
 	verifyAlways bool
 }
@@ -128,6 +129,7 @@ func (it *Iterator) seek(key []byte) {
 	it.currPtr = page.ValuePtr{}
 	it.flags = 0
 	it.valOK = false
+	it.ptrOK = false
 
 	currID := it.tree.rootPageID
 
@@ -189,7 +191,7 @@ func (it *Iterator) loadCurrent() {
 			return
 		}
 
-		top := it.stack[len(it.stack)-1]
+		top := &it.stack[len(it.stack)-1]
 
 		// Check Bounds
 		if top.Index < 0 {
@@ -201,7 +203,7 @@ func (it *Iterator) loadCurrent() {
 			return
 		}
 
-		keyView, valView, valPtr, flags, err := top.Node.GetLeafEntryView(uint16(top.Index))
+		keyView, flags, err := top.Node.GetLeafKeyFlagsView(uint16(top.Index))
 		if err != nil {
 			it.err = err
 			it.valid = false
@@ -224,16 +226,17 @@ func (it *Iterator) loadCurrent() {
 		// Skip tombstones; they are persisted in the index but hidden from iteration.
 		if flags&node.FlagTombstone != 0 {
 			if it.reverse {
-				it.stack[len(it.stack)-1].Index--
+				top.Index--
 			} else {
-				it.stack[len(it.stack)-1].Index++
+				top.Index++
 			}
 			continue
 		}
 
 		it.currKey = keyView
 		it.flags = flags
-		it.currPtr = valPtr
+		it.currPtr = page.ValuePtr{}
+		it.ptrOK = false
 
 		// Inline values are a view into the mmap. Pointer values are loaded on
 		// demand in UnsafeValue/Value.
@@ -241,8 +244,15 @@ func (it *Iterator) loadCurrent() {
 			it.currVal = nil
 			it.valOK = false
 		} else {
+			valView, _, _, err := top.Node.GetLeafValueView(uint16(top.Index))
+			if err != nil {
+				it.err = err
+				it.valid = false
+				return
+			}
 			it.currVal = valView
 			it.valOK = true
+			it.ptrOK = true
 		}
 
 		it.valid = true
@@ -393,6 +403,9 @@ func (it *Iterator) UnsafeValue() []byte {
 		return nil
 	}
 	if it.flags&node.FlagPointer != 0 {
+		if !it.ensurePointerLoaded() {
+			return nil
+		}
 		if it.valOK {
 			return it.currVal
 		}
@@ -409,6 +422,14 @@ func (it *Iterator) UnsafeValue() []byte {
 }
 
 func (it *Iterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	if it.currKey == nil {
+		return nil, page.ValuePtr{}, 0
+	}
+	if it.flags&node.FlagPointer != 0 {
+		if !it.ensurePointerLoaded() {
+			return nil, page.ValuePtr{}, it.flags
+		}
+	}
 	return it.currVal, it.currPtr, it.flags
 }
 
@@ -474,4 +495,34 @@ func (it *Iterator) loadNode(pageID uint64) (node.Node, error) {
 	}
 
 	return n, nil
+}
+
+func (it *Iterator) ensurePointerLoaded() bool {
+	if it.ptrOK {
+		return true
+	}
+	if it.flags&node.FlagPointer == 0 {
+		it.ptrOK = true
+		return true
+	}
+	if len(it.stack) == 0 {
+		it.err = fmt.Errorf("iterator pointer load: empty stack")
+		it.valid = false
+		return false
+	}
+	top := it.stack[len(it.stack)-1]
+	_, ptr, flags, err := top.Node.GetLeafValueView(uint16(top.Index))
+	if err != nil {
+		it.err = err
+		it.valid = false
+		return false
+	}
+	if flags&node.FlagPointer == 0 {
+		it.err = fmt.Errorf("iterator pointer load: entry is not a pointer")
+		it.valid = false
+		return false
+	}
+	it.currPtr = ptr
+	it.ptrOK = true
+	return true
 }

--- a/TreeDB/tree/iterator_test.go
+++ b/TreeDB/tree/iterator_test.go
@@ -197,3 +197,38 @@ func TestIterator_SkipsTombstones(t *testing.T) {
 		t.Fatalf("expected [A C], got %v", got)
 	}
 }
+
+func TestIterator_PointerKeysOnly_DoesNotReadValues(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	p.Alloc(1) // 0
+
+	d0, _ := p.Get(0)
+	n0 := node.NewNode(d0)
+	n0.SetPageID(0)
+	n0.SetType(page.PageTypeLeaf)
+	n0.AddLeafEntry([]byte("A"), nil, node.FlagPointer, page.ValuePtr{Offset: 1, Length: 3, FileID: 1})
+	n0.AddLeafEntry([]byte("B"), nil, node.FlagTombstone, page.ValuePtr{})
+	n0.AddLeafEntry([]byte("C"), nil, node.FlagPointer, page.ValuePtr{Offset: 5, Length: 3, FileID: 1})
+	n0.UpdateChecksum()
+
+	tr := New(p, panicValueReader{}, 0)
+	it := tr.Iterator(nil, nil)
+	defer it.Close()
+
+	var keys []string
+	for ; it.Valid(); it.Next() {
+		keys = append(keys, string(it.Key()))
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if len(keys) != 2 || keys[0] != "A" || keys[1] != "C" {
+		t.Fatalf("expected [A C], got %v", keys)
+	}
+}

--- a/docs/TREEDB_BENCHMARKING.md
+++ b/docs/TREEDB_BENCHMARKING.md
@@ -49,6 +49,53 @@ KEYS=4000000 PROFILES=fast scripts/treedb_forceptr_matrix.sh
 KEYS=2000000 PROFILES=fast,balanced PPROF_TESTS=batch_write,random_write scripts/treedb_forceptr_matrix.sh
 ```
 
+### All-flags gate (script)
+
+To validate the stacked index flags as a bundle, run:
+
+```bash
+scripts/treedb_allflags_gate.sh
+```
+
+Defaults:
+- `RUNS=7`
+- `PROFILE=fast`
+- `KEYS=4000000`
+- `TESTS=batch_write,batch_random,random_read,prefix_scan`
+- both variants include `-checkpoint-between-tests`
+
+Compared variants:
+- `base`: `-treedb-force-value-pointers`
+- `allflags`: base + `-treedb-index-columnar-leaves -treedb-leaf-prefix-compression -treedb-index-internal-base-delta -treedb-index-packed-valueptr`
+
+Pass conditions (median-of-runs):
+- `batch_write`, `batch_random`, `random_read`, `prefix_scan`: all-flags median must be strictly greater than base median.
+- `maindb/index.db`: all-flags median must be strictly smaller than base median.
+
+Outputs:
+- `artifacts/perf/treedb_allflags_gate_<timestamp>/summary.md`
+- `artifacts/perf/treedb_allflags_gate_<timestamp>/summary.json`
+- per-run markdown logs under `.../runs/`
+
+PR benchmark template:
+
+```markdown
+## All-flags gate
+
+- command: `scripts/treedb_allflags_gate.sh`
+- artifact path: `artifacts/perf/treedb_allflags_gate_<timestamp>/`
+
+| metric | base median | all-flags median | delta |
+|---|---:|---:|---:|
+| batch_write | ... | ... | ... |
+| batch_random | ... | ... | ... |
+| random_read | ... | ... | ... |
+| prefix_scan | ... | ... | ... |
+| index_db_bytes | ... | ... | ... |
+
+- gate result: PASS/FAIL
+```
+
 ### Leaf page density harness (prefix compression)
 
 When working on leaf key encodings, it’s useful to measure **keys per leaf page**

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -195,6 +195,24 @@ How to evaluate:
   on/off and compare `maindb/index.db` size + ops/sec.
 - Leaf density microbench: `go test ./TreeDB/node -run '^$' -bench BenchmarkLeafPageDensity -benchmem -count=1`
 
+### Internal base-delta compression (`Options.IndexInternalBaseDelta`)
+
+Internal pages can be encoded with base-child + delta child IDs and separator
+prefix coding. In pre-alpha builds, TreeDB applies this mode adaptively per
+page to avoid throughput regressions on low-benefit pages.
+
+Current fallback policy:
+- fallback to plain internal page when the first separator key length is `<= 12` bytes
+- fallback to plain internal page when `count < 16`
+- fallback when shared separator prefix is `< 2` bytes
+- fallback when average separator key length is `<= 12` bytes
+- fallback when estimated net byte savings is `< 8%`
+
+Rationale:
+- some internal pages gain little compression but still pay extra compare/decode
+  work during seeks; adaptive fallback keeps the hot read path fast while
+  preserving compression on pages where it materially helps.
+
 ### `Options.KeepRecent`
 
 Backend knob used to influence internal lifecycle/retention behavior.

--- a/scripts/treedb_allflags_gate.sh
+++ b/scripts/treedb_allflags_gate.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+OUT_ROOT="${OUT_DIR:-$ROOT/artifacts/perf}"
+TS=$(date +%Y%m%d%H%M%S)
+OUT="${OUT_ROOT}/treedb_allflags_gate_${TS}"
+RUNS="${RUNS:-7}"
+KEYS="${KEYS:-4000000}"
+PROFILE="${PROFILE:-fast}"
+TESTS="${TESTS:-batch_write,batch_random,random_read,prefix_scan}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
+
+BASE_FLAGS="-treedb-force-value-pointers"
+ALL_FLAGS="$BASE_FLAGS -treedb-index-columnar-leaves -treedb-leaf-prefix-compression -treedb-index-internal-base-delta -treedb-index-packed-valueptr"
+
+mkdir -p "$OUT/runs"
+
+cat >"$OUT/meta.txt" <<EOF
+ts=$TS
+git_rev=$(git rev-parse HEAD)
+git_branch=$(git rev-parse --abbrev-ref HEAD)
+runs=$RUNS
+keys=$KEYS
+profile=$PROFILE
+tests=$TESTS
+extra_args=$EXTRA_ARGS
+EOF
+
+echo "treedb all-flags gate"
+echo "out=$OUT"
+echo "runs=$RUNS keys=$KEYS profile=$PROFILE tests=$TESTS"
+
+make unified-bench >/dev/null
+
+run_variant() {
+  local variant="$1"
+  local flags="$2"
+  local run="$3"
+  local out_file="$OUT/runs/${variant}_run${run}.md"
+  echo "--- variant=$variant run=$run ---"
+  # shellcheck disable=SC2086
+  ./bin/unified-bench \
+    -dbs treedb \
+    -profile "$PROFILE" \
+    -keys "$KEYS" \
+    -test "$TESTS" \
+    -format markdown \
+    -progress=false \
+    -checkpoint-between-tests \
+    $flags \
+    $EXTRA_ARGS \
+    2>&1 | tee "$out_file" >/dev/null
+}
+
+for run in $(seq 1 "$RUNS"); do
+  run_variant "base" "$BASE_FLAGS" "$run"
+  run_variant "allflags" "$ALL_FLAGS" "$run"
+done
+
+python3 - "$OUT" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+out = Path(sys.argv[1])
+runs_dir = out / "runs"
+
+metric_labels = {
+    "batch_write": "Batch Write",
+    "batch_random": "Batch Random",
+    "random_read": "Random Read",
+    "prefix_scan": "Prefix Scan",
+}
+metrics = list(metric_labels.keys())
+
+def parse_size_to_bytes(s: str):
+    m = re.match(r"^\s*([0-9]+(?:\.[0-9]+)?)\s*([KMG]iB)\s*$", s)
+    if not m:
+        return None
+    n = float(m.group(1))
+    unit = m.group(2)
+    mul = {"KiB": 1024, "MiB": 1024**2, "GiB": 1024**3}[unit]
+    return int(n * mul)
+
+def fmt_bytes(n):
+    if n is None:
+        return "-"
+    for u, m in (("GiB", 1024**3), ("MiB", 1024**2), ("KiB", 1024)):
+        if n >= m:
+            return f"{n / m:.1f} {u}"
+    return f"{n} B"
+
+def median(values):
+    values = sorted(values)
+    return values[len(values) // 2]
+
+def parse_run(path: Path):
+    text = path.read_text()
+    row = {}
+    for metric, label in metric_labels.items():
+        m = re.search(rf"^{re.escape(label)} / TreeDB = ([0-9,]+)\s*$", text, flags=re.M)
+        if not m:
+            raise SystemExit(f"missing metric {label} in {path}")
+        row[metric] = int(m.group(1).replace(",", ""))
+    m = re.search(r"^\s*maindb/index\.db:\s*(.+?)\s*$", text, flags=re.M)
+    if not m:
+        raise SystemExit(f"missing index.db size in {path}")
+    idx = parse_size_to_bytes(m.group(1).strip())
+    if idx is None:
+        raise SystemExit(f"cannot parse index.db size '{m.group(1).strip()}' in {path}")
+    row["index_db_bytes"] = idx
+    return row
+
+data = {"base": [], "allflags": []}
+for variant in data.keys():
+    files = sorted(runs_dir.glob(f"{variant}_run*.md"))
+    if not files:
+        raise SystemExit(f"no run files for {variant}")
+    for f in files:
+        data[variant].append(parse_run(f))
+
+summary = {"base": {}, "allflags": {}, "delta_pct": {}}
+for metric in metrics + ["index_db_bytes"]:
+    summary["base"][metric] = median([r[metric] for r in data["base"]])
+    summary["allflags"][metric] = median([r[metric] for r in data["allflags"]])
+    b = summary["base"][metric]
+    a = summary["allflags"][metric]
+    if b == 0:
+        summary["delta_pct"][metric] = None
+    else:
+        summary["delta_pct"][metric] = (a - b) * 100.0 / b
+
+pass_checks = []
+for metric in metrics:
+    pass_checks.append(summary["allflags"][metric] > summary["base"][metric])
+pass_checks.append(summary["allflags"]["index_db_bytes"] < summary["base"]["index_db_bytes"])
+gate_pass = all(pass_checks)
+
+summary_path = out / "summary.json"
+summary_payload = {
+    "gate_pass": gate_pass,
+    "summary": summary,
+    "runs": data,
+}
+summary_path.write_text(json.dumps(summary_payload, indent=2))
+
+md = []
+md.append("# TreeDB all-flags gate")
+md.append("")
+md.append(f"- runs per variant: {len(data['base'])}")
+md.append(f"- artifacts: `{out}`")
+md.append("")
+md.append("| metric | base median | all-flags median | delta |")
+md.append("|---|---:|---:|---:|")
+for metric in metrics:
+    b = summary["base"][metric]
+    a = summary["allflags"][metric]
+    d = summary["delta_pct"][metric]
+    md.append(f"| {metric} | {b:,} | {a:,} | {d:+.2f}% |")
+b = summary["base"]["index_db_bytes"]
+a = summary["allflags"]["index_db_bytes"]
+d = summary["delta_pct"]["index_db_bytes"]
+md.append(f"| index_db_bytes | {fmt_bytes(b)} | {fmt_bytes(a)} | {d:+.2f}% |")
+md.append("")
+md.append(f"- gate: {'PASS' if gate_pass else 'FAIL'}")
+
+(out / "summary.md").write_text("\n".join(md) + "\n")
+print((out / "summary.md").read_text())
+
+if not gate_pass:
+    raise SystemExit(3)
+PY
+
+echo "gate artifacts: $OUT"


### PR DESCRIPTION
## Summary
This PR implements the all-flags regression-elimination plan for:
- `-treedb-index-columnar-leaves`
- `-treedb-leaf-prefix-compression`
- `-treedb-index-internal-base-delta`
- `-treedb-index-packed-valueptr`
(with `-treedb-force-value-pointers` baseline)

Key changes:
- Added a deterministic median gate script: `scripts/treedb_allflags_gate.sh`
- Optimized internal base-delta seek/search path (`SearchInternal`) to avoid repeated prefix compares
- Added adaptive/internal early fallback policy to avoid base-delta overhead on short separator-key pages
- Added combined leaf fallback policy (short keys) so all-flags avoids low-CBA encodings
- Optimized iterator key path via `GetLeafKeyFlagsView` + lazy pointer loading
- Fixed iterator to reuse in-stack node state (no per-step scratch churn)
- Added packed plain-leaf fast paths in `GetLeafKeyFlagsView` / `GetLeafValueView`
- Added/updated regression tests around fallback and key-view correctness
- Updated tuning + benchmarking docs

## Gate Results (median of 7)
Command:
- `RUNS=7 scripts/treedb_allflags_gate.sh`

Artifact path:
- `artifacts/perf/treedb_allflags_gate_20260205102810/`

| metric | base median | all-flags median | delta |
|---|---:|---:|---:|
| batch_write | 1,549,486 | 1,627,938 | +5.06% |
| batch_random | 1,242,980 | 1,285,052 | +3.38% |
| random_read | 1,336,512 | 1,388,228 | +3.87% |
| prefix_scan | 12,408,226 | 14,282,317 | +15.10% |
| index_db_bytes | 320.0 MiB | 256.0 MiB | -20.00% |

Gate status: **PASS**

## Validation
- `go test ./... -count=1`
- `RUNS=7 scripts/treedb_allflags_gate.sh`
