### PR TITLE
TreeDB/caching: fix CI break from valueWriter test stub drift

### DIFF
--- a/TreeDB/caching/vlog_rotate_reload_test.go
+++ b/TreeDB/caching/vlog_rotate_reload_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/snissn/compress/zstd"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -21,12 +22,18 @@ type rotateSwapValueWriter struct {
 	appends         int
 }
 
+var _ valueWriter = (*rotateSwapValueWriter)(nil)
+
 func (w *rotateSwapValueWriter) Append(dictID uint64, dict []byte, rid uint64, value []byte) (page.ValuePtr, error) {
 	return page.ValuePtr{}, errors.New("test: unexpected Append call")
 }
 
 func (w *rotateSwapValueWriter) AppendFrame(dictID uint64, dict []byte, records []valuelog.Record) ([]page.ValuePtr, error) {
 	return nil, errors.New("test: unexpected AppendFrame call")
+}
+
+func (w *rotateSwapValueWriter) SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntropy bool) {
+	// No-op for test stub.
 }
 
 func (w *rotateSwapValueWriter) AppendRawFramesWritevInto(records []valuelog.Record, k int, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error) {


### PR DESCRIPTION
## Summary
`main` CI is failing in:
- https://github.com/snissn/gomap/actions/runs/21739987063 (`Root: vet+test`)
- https://github.com/snissn/gomap/actions/runs/21739987066 (`TreeDB: vet+test`)

Root cause: test stub `rotateSwapValueWriter` in `TreeDB/caching/vlog_rotate_reload_test.go` no longer satisfied `valueWriter` after `SetDictFrameEncoderOptions(...)` was added to the interface.

This PR is a minimal test-only hotfix:
- Adds missing no-op `SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntropy bool)` to the stub
- Adds `zstd` import required for method signature
- Adds compile-time interface assertion:
  - `var _ valueWriter = (*rotateSwapValueWriter)(nil)`

No production code paths are changed.

## Validation
From repo root:
- `go test ./TreeDB/caching -run TestAppendValueLog_ReloadWriterAfterRotation -count=1`
- `go test ./TreeDB/caching -count=1`
- `go vet ./...`

From `TreeDB/`:
- `go vet ./...`
- `GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 ./...`

All commands pass locally.
