### PR TITLE
TreeDB: reduce hash_sorted memtable allocator churn (issue #351)

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2166,6 +2166,35 @@ func (db *DB) noteWriteKey(key []byte) {
 	stats.hasLastKey = true
 }
 
+// noteWriteSortedRun records a strictly increasing key run in one shot.
+func (db *DB) noteWriteSortedRun(first, last []byte, count int) {
+	if !db.memtableAdaptive || count <= 0 {
+		return
+	}
+	stats := &db.memtableStats
+	stats.writes.Add(uint64(count))
+	if len(last) == 0 {
+		stats.lastKeyMu.Lock()
+		stats.hasLastKey = false
+		stats.lastKeyMu.Unlock()
+		return
+	}
+	seqAdds := uint64(0)
+	if count > 1 {
+		seqAdds += uint64(count - 1)
+	}
+	stats.lastKeyMu.Lock()
+	if len(first) > 0 && stats.hasLastKey && bytes.Compare(stats.lastKey, first) < 0 {
+		seqAdds++
+	}
+	stats.lastKey = append(stats.lastKey[:0], last...)
+	stats.hasLastKey = true
+	stats.lastKeyMu.Unlock()
+	if seqAdds > 0 {
+		stats.seqWrites.Add(seqAdds)
+	}
+}
+
 func (db *DB) noteIterator(start, end []byte) {
 	if !db.memtableAdaptive {
 		return
@@ -10218,10 +10247,7 @@ func (b *Batch) writeRegular(sync bool) error {
 		useStream := b.streamEligible
 		if useStream {
 			if applier, ok := shard.mem.(memtable.SortedBatchApplier); ok {
-				applier.ApplyStealSortedBatch(entries, func(key []byte) {
-					shard.rng.add(key)
-					b.db.noteWriteKey(key)
-				})
+				applier.ApplyStealSortedBatch(entries, nil)
 			} else {
 				for _, op := range entries {
 					if op.Type == batch.OpDelete {
@@ -10237,10 +10263,15 @@ func (b *Batch) writeRegular(sync bool) error {
 							shard.mem.SetSteal(op.Key, op.Value)
 						}
 					}
-					shard.rng.add(op.Key)
-					b.db.noteWriteKey(op.Key)
 				}
 			}
+			first := entries[0].Key
+			last := entries[len(entries)-1].Key
+			shard.rng.add(first)
+			if len(entries) > 1 {
+				shard.rng.add(last)
+			}
+			b.db.noteWriteSortedRun(first, last, len(entries))
 		} else {
 			for _, op := range entries {
 				if op.Type == batch.OpDelete {

--- a/TreeDB/caching/stats_test.go
+++ b/TreeDB/caching/stats_test.go
@@ -128,3 +128,70 @@ func TestChooseAdaptiveMode(t *testing.T) {
 		t.Errorf("range scan mode = %v, want %v", got, memtable.ModeBTree)
 	}
 }
+
+func TestNoteWriteSortedRunMatchesPerKey_NoPrior(t *testing.T) {
+	perKey := &DB{memtableAdaptive: true}
+	perKey.noteWriteKey([]byte("a"))
+	perKey.noteWriteKey([]byte("b"))
+	perKey.noteWriteKey([]byte("c"))
+
+	run := &DB{memtableAdaptive: true}
+	run.noteWriteSortedRun([]byte("a"), []byte("c"), 3)
+
+	assertStatsEquivalent(t, perKey, run)
+}
+
+func TestNoteWriteSortedRunMatchesPerKey_WithPriorSmaller(t *testing.T) {
+	perKey := &DB{memtableAdaptive: true}
+	perKey.noteWriteKey([]byte("c"))
+	perKey.noteWriteKey([]byte("d"))
+	perKey.noteWriteKey([]byte("e"))
+	perKey.noteWriteKey([]byte("f"))
+
+	run := &DB{memtableAdaptive: true}
+	run.noteWriteKey([]byte("c"))
+	run.noteWriteSortedRun([]byte("d"), []byte("f"), 3)
+
+	assertStatsEquivalent(t, perKey, run)
+}
+
+func TestNoteWriteSortedRunMatchesPerKey_WithPriorGreater(t *testing.T) {
+	perKey := &DB{memtableAdaptive: true}
+	perKey.noteWriteKey([]byte("z"))
+	perKey.noteWriteKey([]byte("a"))
+	perKey.noteWriteKey([]byte("b"))
+
+	run := &DB{memtableAdaptive: true}
+	run.noteWriteKey([]byte("z"))
+	run.noteWriteSortedRun([]byte("a"), []byte("b"), 2)
+
+	assertStatsEquivalent(t, perKey, run)
+}
+
+func assertStatsEquivalent(t *testing.T, want, got *DB) {
+	t.Helper()
+
+	if w, g := want.memtableStats.writes.Load(), got.memtableStats.writes.Load(); w != g {
+		t.Fatalf("writes mismatch: want=%d got=%d", w, g)
+	}
+	if w, g := want.memtableStats.seqWrites.Load(), got.memtableStats.seqWrites.Load(); w != g {
+		t.Fatalf("seqWrites mismatch: want=%d got=%d", w, g)
+	}
+
+	want.memtableStats.lastKeyMu.Lock()
+	wantLastKey := append([]byte(nil), want.memtableStats.lastKey...)
+	wantHasLastKey := want.memtableStats.hasLastKey
+	want.memtableStats.lastKeyMu.Unlock()
+
+	got.memtableStats.lastKeyMu.Lock()
+	gotLastKey := append([]byte(nil), got.memtableStats.lastKey...)
+	gotHasLastKey := got.memtableStats.hasLastKey
+	got.memtableStats.lastKeyMu.Unlock()
+
+	if wantHasLastKey != gotHasLastKey {
+		t.Fatalf("hasLastKey mismatch: want=%v got=%v", wantHasLastKey, gotHasLastKey)
+	}
+	if string(wantLastKey) != string(gotLastKey) {
+		t.Fatalf("lastKey mismatch: want=%q got=%q", string(wantLastKey), string(gotLastKey))
+	}
+}

--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -17,6 +17,15 @@ type hashEntry struct {
 	flags byte
 }
 
+const (
+	// Heuristic for initial hash map sizing from configured memtable capacity.
+	// Hash-sorted entries carry map/table overhead beyond key/value payload,
+	// so use a conservative bytes-per-entry estimate to avoid over-allocation.
+	hashSortedEstimatedBytesPerEntry = 64
+	hashSortedMinInitialEntries      = 1024
+	hashSortedMaxInitialEntries      = 4 << 20
+)
+
 func hashEntryValueSize(flags byte, value []byte) int {
 	if flags&node.FlagPointer != 0 {
 		return page.ValuePtrSize + len(value)
@@ -69,6 +78,8 @@ type HashSorted struct {
 	mu          sync.RWMutex
 	items       map[string]hashEntry
 	sizeBytes   int64
+	maxKey      string
+	hasMaxKey   bool
 	sortedKeys  []string
 	sortedDel   []bool
 	sortedValid bool
@@ -102,20 +113,39 @@ type hashSortedIndex struct {
 }
 
 func NewHashSorted() *HashSorted {
-	return NewHashSortedWithIndexer(nil)
+	return NewHashSortedWithCapacityAndIndexer(0, nil)
 }
 
 func NewHashSortedWithIndexer(indexer *HashSortedIndexer) *HashSorted {
+	return NewHashSortedWithCapacityAndIndexer(0, indexer)
+}
+
+func NewHashSortedWithCapacityAndIndexer(capacity int, indexer *HashSortedIndexer) *HashSorted {
 	if indexer == nil {
 		indexer = globalHashSortedIndexer
 	}
+	initialEntries := hashSortedInitialEntries(capacity)
 	m := &HashSorted{
-		items:       make(map[string]hashEntry),
+		items:       make(map[string]hashEntry, initialEntries),
 		sortedValid: true,
 		indexer:     indexer,
 	}
 	m.index.cond = sync.NewCond(&m.index.mu)
 	return m
+}
+
+func hashSortedInitialEntries(capacity int) int {
+	if capacity <= 0 {
+		return 0
+	}
+	entries := capacity / hashSortedEstimatedBytesPerEntry
+	if entries < hashSortedMinInitialEntries {
+		entries = hashSortedMinInitialEntries
+	}
+	if entries > hashSortedMaxInitialEntries {
+		entries = hashSortedMaxInitialEntries
+	}
+	return entries
 }
 
 func (a *hashArena) resetKeepFirstChunk() {
@@ -158,6 +188,8 @@ func (m *HashSorted) Reset() {
 	m.sortedValid = true
 	m.frozen = false
 	m.hasDeletes = false
+	m.maxKey = ""
+	m.hasMaxKey = false
 	m.pendingKeys = nil
 	m.pendingBytes = 0
 	m.nextSeq = 0
@@ -172,22 +204,33 @@ func (m *HashSorted) ApplyStealSortedBatch(entries []batchpkg.Entry, onKey func(
 	var chunks []hashSortedIndexWork
 
 	m.mu.Lock()
-	for _, op := range entries {
-		if op.Type == batchpkg.OpDelete {
-			if chunk, seq := m.setEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true); seq != 0 {
+	if m.canAppendSortedBatchLocked(entries) {
+		for _, op := range entries {
+			if chunk, seq := m.setEntryNewStealLocked(op); seq != 0 {
 				chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
 			}
-		} else if op.IsPtr {
-			if chunk, seq := m.setEntryLocked(op.Key, nil, op.ValuePtr, node.FlagPointer, true); seq != 0 {
-				chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
-			}
-		} else {
-			if chunk, seq := m.setEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true); seq != 0 {
-				chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
+			if onKey != nil {
+				onKey(op.Key)
 			}
 		}
-		if onKey != nil {
-			onKey(op.Key)
+	} else {
+		for _, op := range entries {
+			if op.Type == batchpkg.OpDelete {
+				if chunk, seq := m.setEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true); seq != 0 {
+					chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
+				}
+			} else if op.IsPtr {
+				if chunk, seq := m.setEntryLocked(op.Key, nil, op.ValuePtr, node.FlagPointer, true); seq != 0 {
+					chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
+				}
+			} else {
+				if chunk, seq := m.setEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true); seq != 0 {
+					chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
+				}
+			}
+			if onKey != nil {
+				onKey(op.Key)
+			}
 		}
 	}
 	m.mu.Unlock()
@@ -270,6 +313,7 @@ func (m *HashSorted) PutWithCallback(key, value []byte, cb func(k, v []byte) err
 	keyStored := bytesToStringNoCopy(keyCopy)
 	m.items[keyStored] = hashEntry{value: valCopy, flags: node.FlagInline}
 	m.sizeBytes += int64(len(keyCopy) + hashEntryValueSize(node.FlagInline, valCopy))
+	m.updateMaxKeyLocked(keyStored)
 	chunk, seq = m.noteNewKeyLocked(keyStored)
 	m.mu.Unlock()
 
@@ -330,6 +374,7 @@ func (m *HashSorted) DeleteWithCallback(key []byte, cb func(k, v []byte) error) 
 	keyStored := bytesToStringNoCopy(keyCopy)
 	m.items[keyStored] = hashEntry{flags: node.FlagTombstone}
 	m.sizeBytes += int64(len(keyCopy))
+	m.updateMaxKeyLocked(keyStored)
 	chunk, seq = m.noteNewKeyLocked(keyStored)
 	m.mu.Unlock()
 	if seq != 0 {
@@ -681,7 +726,61 @@ func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags 
 	if flags&node.FlagTombstone != 0 {
 		m.hasDeletes = true
 	}
+	m.updateMaxKeyLocked(keyStored)
 	return m.noteNewKeyLocked(keyStored)
+}
+
+func (m *HashSorted) setEntryNewStealLocked(op batchpkg.Entry) ([]string, uint64) {
+	if op.Key == nil {
+		return nil, 0
+	}
+
+	keyStored := bytesToStringNoCopy(op.Key)
+	flags := byte(node.FlagInline)
+	val := op.Value
+	ptr := page.ValuePtr{}
+	switch {
+	case op.Type == batchpkg.OpDelete:
+		flags = node.FlagTombstone
+		val = nil
+	case op.IsPtr:
+		flags = node.FlagPointer
+		ptr = op.ValuePtr
+	}
+
+	ent := hashEntry{value: val, flags: flags}
+	if flags&node.FlagPointer != 0 {
+		ent.ptr = ptr
+	}
+	m.items[keyStored] = ent
+	m.sizeBytes += int64(len(op.Key) + hashEntryValueSize(flags, val))
+	if flags&node.FlagTombstone != 0 {
+		m.hasDeletes = true
+	}
+	// The fast path is append-only and entries are strictly increasing.
+	m.maxKey = keyStored
+	m.hasMaxKey = true
+	return m.noteNewKeyLocked(keyStored)
+}
+
+func (m *HashSorted) canAppendSortedBatchLocked(entries []batchpkg.Entry) bool {
+	if len(entries) == 0 || entries[0].Key == nil {
+		return false
+	}
+	if len(m.items) == 0 {
+		return true
+	}
+	if !m.hasMaxKey {
+		return false
+	}
+	return strings.Compare(bytesToStringNoCopy(entries[0].Key), m.maxKey) > 0
+}
+
+func (m *HashSorted) updateMaxKeyLocked(key string) {
+	if !m.hasMaxKey || strings.Compare(key, m.maxKey) > 0 {
+		m.maxKey = key
+		m.hasMaxKey = true
+	}
 }
 
 func (m *HashSorted) encodeEntryValueLocked(value []byte, ptr page.ValuePtr, flags byte, steal bool) []byte {

--- a/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
+++ b/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
@@ -1,0 +1,39 @@
+package memtable
+
+import (
+	"testing"
+
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+)
+
+func TestHashSortedApplyStealSortedBatch_AppendAndFallback(t *testing.T) {
+	m := NewHashSorted()
+	m.SetSteal([]byte("b"), []byte("v1"))
+
+	appendEntries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: []byte("c"), Value: []byte("v2")},
+		{Type: batchpkg.OpDelete, Key: []byte("d")},
+	}
+	m.ApplyStealSortedBatch(appendEntries, nil)
+
+	if got, del, ok := m.Get([]byte("c")); !ok || del || string(got) != "v2" {
+		t.Fatalf("key c mismatch: ok=%v del=%v val=%q", ok, del, string(got))
+	}
+	if got, del, ok := m.Get([]byte("d")); !ok || !del || got != nil {
+		t.Fatalf("key d tombstone mismatch: ok=%v del=%v val=%v", ok, del, got)
+	}
+
+	// First key <= current max, so this should use the regular update path.
+	fallbackEntries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: []byte("a"), Value: []byte("va")},
+		{Type: batchpkg.OpPut, Key: []byte("b"), Value: []byte("vb")},
+	}
+	m.ApplyStealSortedBatch(fallbackEntries, nil)
+
+	if got, del, ok := m.Get([]byte("a")); !ok || del || string(got) != "va" {
+		t.Fatalf("key a mismatch: ok=%v del=%v val=%q", ok, del, string(got))
+	}
+	if got, del, ok := m.Get([]byte("b")); !ok || del || string(got) != "vb" {
+		t.Fatalf("key b mismatch after update: ok=%v del=%v val=%q", ok, del, string(got))
+	}
+}

--- a/TreeDB/internal/memtable/memtable.go
+++ b/TreeDB/internal/memtable/memtable.go
@@ -115,7 +115,7 @@ func NewWithCapacityModeAndIndexer(capacity int, mode Mode, indexer *HashSortedI
 	case ModeSkiplist:
 		return NewWithCapacity(capacity), nil
 	case ModeHashSorted:
-		return NewHashSortedWithIndexer(indexer), nil
+		return NewHashSortedWithCapacityAndIndexer(capacity, indexer), nil
 	case ModeBTree:
 		return NewBTree(), nil
 	default:


### PR DESCRIPTION
## Summary
- pre-size `hash_sorted` memtable map from configured shard capacity to reduce rehash/growth churn
- add an append fast-path in `HashSorted.ApplyStealSortedBatch` for strictly increasing keys beyond current max key, avoiding extra map lookup on new inserts
- reduce stream-path per-key overhead in cached batch writes by recording sorted-run range/stats once per run
- add regression tests for:
  - hash-sorted append fast-path + fallback behavior
  - equivalence between per-key and batched sorted-run adaptive stats updates

Closes #351.

## Benchmark
Command used:

```bash
go run ./cmd/unified_bench \
  -dbs treedb \
  -test batch_write,prefix_scan \
  -keys 5000000 \
  -valsize 128 \
  -batchsize 100 \
  -progress=false \
  -format markdown \
  -treedb-force-value-pointers \
  -treedb-vlog-dict both \
  -treedb-vlog-compression-autotune medium \
  -val-pattern ultra_compressible_repeat
```

To reduce dict autotune variance in `vlog_dict=on`, a stabilized run with `-treedb-vlog-dict-k 32` was also recorded.

| case | baseline | this PR | delta |
|---|---:|---:|---:|
| Batch Write (vlog_dict=off) | 1,579,443 | 2,047,794 | +29.6% |
| Batch Write (vlog_dict=on, k=32) | 1,442,348 | 1,495,604 | +3.7% |

Representative non-forced-k run on this branch:
- Batch Write / TreeDB (vlog_dict=off): 2,025,140
- Batch Write / TreeDB (vlog_dict=on): 1,438,355

## Validation
- `go test ./TreeDB/internal/memtable -count=1`
- `go test ./TreeDB/caching -count=1`
- `go test ./... -count=1`
