### PR TITLE
issue384 M2: add live milestone status reporting tooling

### DIFF
--- a/docs/benchmarks/TREEDB_ISSUE384_PROGRESS.md
+++ b/docs/benchmarks/TREEDB_ISSUE384_PROGRESS.md
@@ -15,7 +15,7 @@ consistent.
 ## Recommended update command
 
 ```bash
-cd /Users/michaelseiler/dev/snissn/gomap
+cd "$(git rev-parse --show-toplevel)"
 ISSUE_NUMBER=384 \
 PR_NUMBER=<milestone_pr_number> \
 MILESTONE=<m0|m1|m2|m3|m4> \

--- a/scripts/issue384_post_status.sh
+++ b/scripts/issue384_post_status.sh
@@ -4,12 +4,27 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT"
 
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 127
+  fi
+}
+
+need_cmd git
+need_cmd gh
+
 ISSUE_NUMBER="${ISSUE_NUMBER:-384}"
 REPO="${REPO:-snissn/gomap}"
 MILESTONE="${MILESTONE:-unspecified}"
 SUMMARY_PATH="${SUMMARY_PATH:-}"
 ARTIFACT_DIR="${ARTIFACT_DIR:-}"
 PR_NUMBER="${PR_NUMBER:-}"
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "gh auth status failed; run 'gh auth login'" >&2
+  exit 2
+fi
 
 if [[ -z "$SUMMARY_PATH" ]]; then
   echo "SUMMARY_PATH is required" >&2
@@ -25,6 +40,10 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 BODY_FILE=$(mktemp)
+cleanup() {
+  rm -f "$BODY_FILE"
+}
+trap cleanup EXIT INT TERM
 {
   echo "Issue #$ISSUE_NUMBER status update ($MILESTONE)"
   echo
@@ -45,5 +64,3 @@ gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file "$BODY_FILE"
 if [[ -n "$PR_NUMBER" ]]; then
   gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$BODY_FILE"
 fi
-
-rm -f "$BODY_FILE"


### PR DESCRIPTION
## Summary

Milestone M2 for #384: live reporting automation for issue/PR status and gate artifacts.

### Added
- `scripts/issue384_post_status.sh`
  - posts a standardized status update to issue #384
  - optionally mirrors the same update to a milestone PR
  - embeds candidate hash, branch, summary markdown, and artifact directory
- `docs/benchmarks/TREEDB_ISSUE384_PROGRESS.md`
  - milestone checklist template
  - reproducible status update invocation pattern

## Why

#384 requires continuous live checklist/status/perfgate profile updates across issue + milestone PRs. This codifies that workflow so updates are repeatable and auditable.

## Validation

- `bash -n scripts/issue384_post_status.sh`

## Milestone checklist (live)

- [x] Scope locked
- [x] Baseline comparison attached (via prior M0/M1 outputs)
- [x] Per-PR gate reporting path attached
- [x] Auto sanity reporting path attached
- [x] Correctness suites unaffected
- [x] Rollback note included

## Rollback note

Revert commit `8885710905` to remove reporting automation and template additions.

Part of #384.
