### PR TITLE
issue384 M4: add closeout checklist and runbook

### DIFF
--- a/docs/benchmarks/TREEDB_ISSUE384_CLOSEOUT.md
+++ b/docs/benchmarks/TREEDB_ISSUE384_CLOSEOUT.md
@@ -22,14 +22,17 @@ Commands:
 
 ```bash
 cd "$(git rev-parse --show-toplevel)"
-scripts/issue384_invariant_gate.sh
-scripts/issue384_perf_gate.sh
+./scripts/issue384_invariant_gate.sh
+./scripts/issue384_perf_gate.sh
+# profile evidence pair (required for hotspot diff)
+TESTS=batch_write,random_read COMPRESSION=off \
+  ./scripts/issue384_profile_pair.sh
 # nightly/slow gate
-scripts/issue384_nightly_gate.sh
-ISSUE_NUMBER=384 PR_NUMBER=<pr> MILESTONE=<mX> \
+./scripts/issue384_nightly_gate.sh
+ISSUE_NUMBER=384 PR_NUMBER=<milestone_pr_number> MILESTONE=<m0|m1|m2|m3|m4> \
   SUMMARY_PATH=artifacts/perf/<gate_dir>/summary.md \
   ARTIFACT_DIR=artifacts/perf/<gate_dir> \
-  scripts/issue384_post_status.sh
+  ./scripts/issue384_post_status.sh
 ```
 
 ## Required Evidence Per Milestone


### PR DESCRIPTION
## Summary

Milestone M4 for #384: closeout execution checklist and evidence contract doc.

### Added
- `docs/benchmarks/TREEDB_ISSUE384_CLOSEOUT.md`
  - milestone chain summary
  - execution contract (invariants -> perf -> status posting)
  - required evidence list for reviews
  - final operator checklist for issue closeout

## Why

This locks the runbook for final #384 closeout so the issue and milestone PRs stay auditable and consistent.

## Rollback note

Revert commit `e4e510e79a` to remove this closeout documentation.

Part of #384.
