### PR TITLE
unified-bench: add profile-dir shorthand for profiling artifacts

### DIFF
--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -72,6 +72,7 @@ Side-by-side benchmarks for `HashDB`, `BTreeOnHashDB`, `TreeDB` (cached), Badger
 - `-cpuprofile-tests` restrict CPU profiling to a CSV list of tests (e.g. `random_read,batch_random`)
 - `-checkpoint-cpuprofile` write per-checkpoint CPU profiles to `<prefix>_checkpoint_<test>_<db>.pprof`
 - `-checkpoint-cpuprofile-tests` restrict checkpoint CPU profiling to a CSV list of tests
+- `-profile-dir` write all profile outputs into one directory (auto-sets defaults for `-cpuprofile`, `-checkpoint-cpuprofile`, `-blockprofile`, `-mutexprofile`, `-trace`; explicit flags still win)
 - `-treedb-cache-stats-before-reads` print select `treedb.cache.*` stats before read/scan tests (treedb only)
 - `-blockprofile`, `-mutexprofile`, `-trace` write profiling artifacts to files
 - `-max-wall` abort the run if wall time exceeds this duration (guardrail; `0` = disabled)

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -59,6 +59,7 @@ var (
 	seed               = flag.Int64("seed", 1, "PRNG seed for randomized tests (0 = time-based)")
 	cpuProfile         = flag.String("cpuprofile", "", "write cpu profile to file")
 	cpuProfileTestsArg = flag.String("cpuprofile-tests", "", "Comma-separated list of tests to profile when -cpuprofile is set (default: all selected tests)")
+	profileDir         = flag.String("profile-dir", "", "Write profiling artifacts to this directory (enables defaults for -cpuprofile, -checkpoint-cpuprofile, -blockprofile, -mutexprofile, -trace unless explicitly set)")
 
 	blockProfile              = flag.String("blockprofile", "", "write goroutine blocking profile (pprof) to file")
 	blockRate                 = flag.Int("blockprofilerate", 1, "runtime.SetBlockProfileRate sampling rate (1 = sample all)")
@@ -259,6 +260,9 @@ func main() {
 	explicitFlags = isSet
 	if err := applyProfile(*profileArg, isSet); err != nil {
 		log.Fatalf("profile: %v", err)
+	}
+	if err := applyProfileArtifactDir(*profileDir, isSet); err != nil {
+		log.Fatalf("profile-dir: %v", err)
 	}
 
 	seedUsed := *seed
@@ -584,6 +588,22 @@ func sanitizeProfileSegment(s string) string {
 			return '_'
 		}
 	}, s)
+}
+
+func applyProfileArtifactDir(dir string, isSet map[string]bool) error {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create profile dir %q: %w", dir, err)
+	}
+	setStringIfUnset("cpuprofile", filepath.Join(dir, "cpu"), isSet, cpuProfile)
+	setStringIfUnset("checkpoint-cpuprofile", filepath.Join(dir, "checkpoint_cpu"), isSet, checkpointCPUProfile)
+	setStringIfUnset("blockprofile", filepath.Join(dir, "block.pprof"), isSet, blockProfile)
+	setStringIfUnset("mutexprofile", filepath.Join(dir, "mutex.pprof"), isSet, mutexProfile)
+	setStringIfUnset("trace", filepath.Join(dir, "trace.out"), isSet, traceProfile)
+	return nil
 }
 
 func printTreeDBCacheStats(w io.Writer, inst *DBInstance, prefix string) {

--- a/cmd/unified_bench/profile_artifact_dir_test.go
+++ b/cmd/unified_bench/profile_artifact_dir_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type profilingFlagSnapshot struct {
+	cpu        string
+	checkpoint string
+	block      string
+	mutex      string
+	trace      string
+}
+
+func snapshotProfilingFlags() profilingFlagSnapshot {
+	return profilingFlagSnapshot{
+		cpu:        *cpuProfile,
+		checkpoint: *checkpointCPUProfile,
+		block:      *blockProfile,
+		mutex:      *mutexProfile,
+		trace:      *traceProfile,
+	}
+}
+
+func restoreProfilingFlags(s profilingFlagSnapshot) {
+	*cpuProfile = s.cpu
+	*checkpointCPUProfile = s.checkpoint
+	*blockProfile = s.block
+	*mutexProfile = s.mutex
+	*traceProfile = s.trace
+}
+
+func TestApplyProfileArtifactDir_SetsAllProfilingOutputs(t *testing.T) {
+	snap := snapshotProfilingFlags()
+	defer restoreProfilingFlags(snap)
+
+	*cpuProfile = ""
+	*checkpointCPUProfile = ""
+	*blockProfile = ""
+	*mutexProfile = ""
+	*traceProfile = ""
+
+	dir := filepath.Join(t.TempDir(), "profiles", "run1")
+	if err := applyProfileArtifactDir(dir, map[string]bool{}); err != nil {
+		t.Fatalf("applyProfileArtifactDir: %v", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("expected profile dir to exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected %q to be a directory", dir)
+	}
+
+	if got, want := *cpuProfile, filepath.Join(dir, "cpu"); got != want {
+		t.Fatalf("cpuprofile = %q, want %q", got, want)
+	}
+	if got, want := *checkpointCPUProfile, filepath.Join(dir, "checkpoint_cpu"); got != want {
+		t.Fatalf("checkpoint-cpuprofile = %q, want %q", got, want)
+	}
+	if got, want := *blockProfile, filepath.Join(dir, "block.pprof"); got != want {
+		t.Fatalf("blockprofile = %q, want %q", got, want)
+	}
+	if got, want := *mutexProfile, filepath.Join(dir, "mutex.pprof"); got != want {
+		t.Fatalf("mutexprofile = %q, want %q", got, want)
+	}
+	if got, want := *traceProfile, filepath.Join(dir, "trace.out"); got != want {
+		t.Fatalf("trace = %q, want %q", got, want)
+	}
+}
+
+func TestApplyProfileArtifactDir_RespectsExplicitFlags(t *testing.T) {
+	snap := snapshotProfilingFlags()
+	defer restoreProfilingFlags(snap)
+
+	*cpuProfile = "manual/cpu"
+	*checkpointCPUProfile = "manual/checkpoint"
+	*blockProfile = "manual/block.pprof"
+	*mutexProfile = ""
+	*traceProfile = ""
+
+	dir := filepath.Join(t.TempDir(), "profiles")
+	isSet := map[string]bool{
+		"cpuprofile":            true,
+		"checkpoint-cpuprofile": true,
+		"blockprofile":          true,
+	}
+	if err := applyProfileArtifactDir(dir, isSet); err != nil {
+		t.Fatalf("applyProfileArtifactDir: %v", err)
+	}
+
+	if got, want := *cpuProfile, "manual/cpu"; got != want {
+		t.Fatalf("cpuprofile = %q, want %q", got, want)
+	}
+	if got, want := *checkpointCPUProfile, "manual/checkpoint"; got != want {
+		t.Fatalf("checkpoint-cpuprofile = %q, want %q", got, want)
+	}
+	if got, want := *blockProfile, "manual/block.pprof"; got != want {
+		t.Fatalf("blockprofile = %q, want %q", got, want)
+	}
+	if got, want := *mutexProfile, filepath.Join(dir, "mutex.pprof"); got != want {
+		t.Fatalf("mutexprofile = %q, want %q", got, want)
+	}
+	if got, want := *traceProfile, filepath.Join(dir, "trace.out"); got != want {
+		t.Fatalf("trace = %q, want %q", got, want)
+	}
+}

--- a/cmd/unified_bench/profiles.go
+++ b/cmd/unified_bench/profiles.go
@@ -138,6 +138,12 @@ func setInt64IfUnset(name string, val int64, isSet map[string]bool, target *int6
 	}
 }
 
+func setStringIfUnset(name, val string, isSet map[string]bool, target *string) {
+	if !isSet[name] {
+		*target = val
+	}
+}
+
 func applyProfile(name string, isSet map[string]bool) error {
 	if name == "" {
 		return nil


### PR DESCRIPTION
## Summary
- add `-profile-dir` to `unified-bench` so one folder can enable all profiling outputs
- when set, auto-configure defaults for `-cpuprofile`, `-checkpoint-cpuprofile`, `-blockprofile`, `-mutexprofile`, and `-trace`
- preserve explicit flag precedence: manually provided profiling flags are not overridden
- add unit tests for default expansion and explicit override behavior
- document the new flag in `cmd/unified_bench/README.md`

## Validation
- `go test ./cmd/unified_bench -run 'TestApplyProfileArtifactDir|TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations|TestApplyProfile_DurableAndBalancedDoNotEnableIndexOptimizations' -count=1`
- `go test ./cmd/unified_bench -run TestApplyProfileArtifactDir -count=1 -v`
- `go test ./cmd/unified_bench -short -count=1`
- `make unified-bench`
- smoke run with `-profile-dir` producing cpu/checkpoint/block/mutex/trace artifacts
