### PR TITLE
db: M6 incremental value-log GC accounting with fallback

### DIFF
--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -130,6 +130,16 @@ func (b *Batch) writeOptimistic(sync bool) (bool, error) {
 		}
 		return false, err
 	}
+	entries := b.batch.SortedEntries()
+	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries)
+	if err != nil {
+		freeErr := tracker.FreeAll()
+		b.db.writeMu.RUnlock()
+		if freeErr != nil {
+			return false, freeErr
+		}
+		return false, err
+	}
 	b.db.commitMu.Lock()
 	b.db.mu.RLock()
 	currentRoot := b.db.meta.UserRootPageID
@@ -145,7 +155,7 @@ func (b *Batch) writeOptimistic(sync bool) (bool, error) {
 		return false, nil
 	}
 
-	post, err := b.db.finalizeCommitLocked(newRoot, sysRoot, retired, sync, metrics, refreshValueLogSet)
+	post, err := b.db.finalizeCommitLocked(newRoot, sysRoot, retired, sync, metrics, refreshValueLogSet, vlogRefDelta)
 	b.db.commitMu.Unlock()
 	if err != nil {
 		b.db.writeMu.RUnlock()
@@ -182,6 +192,11 @@ func (b *Batch) writeSerialized(sync bool) error {
 	if err != nil {
 		return err
 	}
+	entries := b.batch.SortedEntries()
+	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries)
+	if err != nil {
+		return err
+	}
 
 	b.db.mu.Lock()
 	if b.db.meta.UserRootPageID != rootID {
@@ -192,7 +207,7 @@ func (b *Batch) writeSerialized(sync bool) error {
 	sysRoot := b.db.meta.SystemRootPageID
 	b.db.mu.Unlock()
 
-	if err := b.db.finalizeCommit(newRoot, sysRoot, retired, sync, metrics, refreshValueLogSet); err != nil {
+	if err := b.db.finalizeCommit(newRoot, sysRoot, retired, sync, metrics, refreshValueLogSet, vlogRefDelta); err != nil {
 		return err
 	}
 	if b.db.vacuum.Active() {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -37,10 +37,11 @@ type DBState struct {
 }
 
 type DB struct {
-	valueLogManager *valuelog.Manager
-	lock            *lockfile.Lock
-	adaptive        *adaptive.Controller
-	pruner          pruneWorker
+	valueLogManager    *valuelog.Manager
+	valueLogRefTracker *valueLogRefTracker
+	lock               *lockfile.Lock
+	adaptive           *adaptive.Controller
+	pruner             pruneWorker
 
 	// idx is the current index generation (pager + MVCC lifecycle state).
 	idx atomic.Pointer[indexGen]
@@ -95,12 +96,18 @@ type DB struct {
 	publishWatermarkLatencySamples atomic.Uint64
 	publishWatermarkLatencyMaxNs   atomic.Uint64
 	publishWatermarkLatencyBuckets [publishWatermarkLatencyBucketCount]atomic.Uint64
+
+	// testFailFinalizeCommit forces finalizeCommitLocked to fail before writing
+	// the next meta page. Used by crash-safety tests.
+	testFailFinalizeCommit atomic.Bool
 }
 
 const (
 	defaultChunkSize                 = 16 * 1024 * 1024
 	defaultMaintenanceOpsPerCoalesce = 400_000
 )
+
+var errTestFinalizeCommitFailpoint = errors.New("treedb: finalize commit failpoint")
 
 // DurabilityMode configures cached-mode durability semantics.
 //
@@ -742,6 +749,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 
 	db := &DB{
 		valueLogManager:           vm,
+		valueLogRefTracker:        newValueLogRefTracker(),
 		lock:                      lock,
 		adaptive:                  adaptiveCtrl,
 		keepRecent:                opts.KeepRecent,
@@ -806,6 +814,10 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		ValueLogSet:      vm.CurrentSet(),
 	}
 	db.state.Store(initialState)
+	if err := db.initValueLogRefTracker(); err != nil {
+		db.Close()
+		return nil, err
+	}
 
 	db.pruner.Start(db, pruneWorkerOptions{
 		enabled:     !opts.DisableBackgroundPrune,
@@ -1087,22 +1099,24 @@ func (db *DB) writeMeta(pageID uint64, meta page.MetaPageBody) error {
 }
 
 type finalizeCommitPost struct {
-	oldState  *DBState
-	metrics   adaptive.Metrics
-	kickPrune bool
-	doPrune   bool
-	debug     bool
-	sync      bool
-	start     time.Time
-	durSync1  time.Duration
-	durMeta   time.Duration
-	durSync2  time.Duration
+	oldState     *DBState
+	metrics      adaptive.Metrics
+	vlogRefDelta *valueLogRefDelta
+	commitSeq    uint64
+	kickPrune    bool
+	doPrune      bool
+	debug        bool
+	sync         bool
+	start        time.Time
+	durSync1     time.Duration
+	durMeta      time.Duration
+	durSync2     time.Duration
 }
 
 // finalizeCommitLocked performs the durability-critical publish path.
 // Callers that already hold commit serialization may run post work after
 // releasing the serialization lock.
-func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, refreshValueLogSet bool) (finalizeCommitPost, error) {
+func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, refreshValueLogSet bool, vlogRefDelta *valueLogRefDelta) (finalizeCommitPost, error) {
 	post := finalizeCommitPost{
 		metrics: metrics,
 	}
@@ -1155,6 +1169,10 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 	db.mu.Unlock()
 	watermarkHold += time.Since(holdStart)
 
+	if db.testFailFinalizeCommit.Load() {
+		return post, errTestFinalizeCommitFailpoint
+	}
+
 	// 3. Write Meta - No DB Lock
 	t0 := time.Now()
 	if err := db.writeMeta(targetPageID, nextMeta); err != nil {
@@ -1199,6 +1217,8 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 		ValueLogSet:      valueLogSet,
 	}
 	db.state.Store(newState)
+	post.commitSeq = nextMeta.CommitSeq
+	post.vlogRefDelta = vlogRefDelta
 	db.mu.Unlock()
 	watermarkHold += time.Since(holdStart)
 	db.observePublishWatermark(watermarkWait, watermarkHold, watermarkWait+watermarkHold)
@@ -1219,6 +1239,17 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 
 func (db *DB) finalizeCommitPostWork(post finalizeCommitPost) {
 	var durPrune time.Duration
+
+	if db.valueLogRefTracker != nil {
+		if post.vlogRefDelta != nil {
+			if err := db.valueLogRefTracker.applyDelta(post.commitSeq, post.vlogRefDelta); err != nil {
+				db.valueLogRefTracker.invalidate()
+				db.reportError(err)
+			}
+		} else {
+			db.valueLogRefTracker.invalidate()
+		}
+	}
 
 	// Keep pruning out of the commit serialization critical section.
 	if post.kickPrune {
@@ -1253,8 +1284,8 @@ func (db *DB) finalizeCommitPostWork(post finalizeCommitPost) {
 }
 
 // finalizeCommit handles durability and state updates.
-func (db *DB) finalizeCommit(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, refreshValueLogSet bool) error {
-	post, err := db.finalizeCommitLocked(newRootID, sysRootID, retired, sync, metrics, refreshValueLogSet)
+func (db *DB) finalizeCommit(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, refreshValueLogSet bool, vlogRefDelta *valueLogRefDelta) error {
+	post, err := db.finalizeCommitLocked(newRootID, sysRootID, retired, sync, metrics, refreshValueLogSet, vlogRefDelta)
 	if err != nil {
 		return err
 	}
@@ -1286,7 +1317,7 @@ func (db *DB) Commit(newRootID uint64) error {
 	sysRoot := db.meta.SystemRootPageID
 	db.mu.RUnlock()
 
-	return db.finalizeCommit(newRootID, sysRoot, nil, true, adaptive.Metrics{}, true)
+	return db.finalizeCommit(newRootID, sysRoot, nil, true, adaptive.Metrics{}, true, nil)
 }
 
 // Prune reclaims pages from the graveyard.
@@ -1454,7 +1485,7 @@ func (db *DB) CompactIndex() error {
 	db.mu.Unlock()
 
 	// Commit new root and retire the old tree pages.
-	return db.finalizeCommit(newRoot, sysRoot, retired, true, adaptive.Metrics{}, true)
+	return db.finalizeCommit(newRoot, sysRoot, retired, true, adaptive.Metrics{}, true, nil)
 }
 
 type pagerAllocator struct {

--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -5,11 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
-	"github.com/snissn/gomap/TreeDB/node"
-	"github.com/snissn/gomap/TreeDB/page"
-	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 // ValueLogGCOptions controls value-log garbage collection.
@@ -56,31 +52,8 @@ func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogG
 		return stats, fmt.Errorf("value log manager unavailable")
 	}
 
-	snap := db.AcquireSnapshot()
-	if snap == nil || snap.idx == nil || snap.state == nil {
-		if snap != nil {
-			_ = snap.Close()
-		}
-		return stats, fmt.Errorf("missing db state")
-	}
-
-	referenced := make(map[uint32]struct{})
-
-	userIter := snap.tree.Iterator(nil, nil)
-	if err := collectValueLogRefs(userIter, referenced); err != nil {
-		_ = userIter.Close()
-		return stats, err
-	}
-	_ = userIter.Close()
-
-	sysIter := tree.New(snap.idx.pager, valueReader{vlogs: snap.state.ValueLogSet}, snap.state.SystemRootPageID).Iterator(nil, nil)
-	if err := collectValueLogRefs(sysIter, referenced); err != nil {
-		_ = sysIter.Close()
-		return stats, err
-	}
-	_ = sysIter.Close()
-
-	if err := snap.Close(); err != nil {
+	referenced, err := db.referencedValueLogSegments(ctx)
+	if err != nil {
 		return stats, err
 	}
 
@@ -139,6 +112,7 @@ func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogG
 		if set != nil {
 			_ = db.valueLogManager.Release(set)
 		}
+		db.persistValueLogRefTrackerBestEffort()
 		return stats, nil
 	}
 
@@ -164,18 +138,8 @@ func (db *DB) ValueLogGC(ctx context.Context, opts ValueLogGCOptions) (ValueLogG
 		}
 	}
 
+	db.persistValueLogRefTrackerBestEffort()
 	return stats, nil
-}
-
-func collectValueLogRefs(it iterator.UnsafeIterator, refs map[uint32]struct{}) error {
-	for it.Valid() {
-		_, ptr, flags := it.UnsafeEntry()
-		if flags&node.FlagPointer != 0 && page.IsValueLogFileID(ptr.FileID) {
-			refs[ptr.FileID] = struct{}{}
-		}
-		it.Next()
-	}
-	return it.Error()
 }
 
 func currentValueLogIDs(set *valuelog.Set) map[uint32]struct{} {

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -1,0 +1,508 @@
+package db
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
+	"github.com/snissn/gomap/TreeDB/tree"
+)
+
+const (
+	valueLogRefCountsFileName = "vlog_ref_counts.meta"
+	valueLogRefCountsVersion  = uint32(1)
+)
+
+var (
+	valueLogRefCountsMagic = [8]byte{'T', 'V', 'R', 'E', 'F', 'C', 'N', 'T'}
+	errValueLogRefCorrupt  = errors.New("treedb: corrupt value-log ref counters metadata")
+)
+
+type valueLogRefDelta struct {
+	changes map[uint32]int64
+}
+
+func newValueLogRefDelta() *valueLogRefDelta {
+	return &valueLogRefDelta{changes: make(map[uint32]int64)}
+}
+
+func (d *valueLogRefDelta) add(fileID uint32, delta int64) {
+	if d == nil || delta == 0 {
+		return
+	}
+	next := d.changes[fileID] + delta
+	if next == 0 {
+		delete(d.changes, fileID)
+		return
+	}
+	d.changes[fileID] = next
+}
+
+type valueLogRefTracker struct {
+	mu        sync.RWMutex
+	commitSeq uint64
+	counts    map[uint32]uint64
+	valid     bool
+	dirty     bool
+}
+
+func newValueLogRefTracker() *valueLogRefTracker {
+	return &valueLogRefTracker{
+		counts: make(map[uint32]uint64),
+	}
+}
+
+func (t *valueLogRefTracker) canTrack(baseSeq uint64) bool {
+	if t == nil {
+		return false
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.valid && t.commitSeq == baseSeq
+}
+
+func (t *valueLogRefTracker) replace(counts map[uint32]uint64, commitSeq uint64, dirty bool) {
+	if t == nil {
+		return
+	}
+	next := make(map[uint32]uint64, len(counts))
+	for fileID, n := range counts {
+		if n == 0 {
+			continue
+		}
+		next[fileID] = n
+	}
+	t.mu.Lock()
+	t.counts = next
+	t.commitSeq = commitSeq
+	t.valid = true
+	t.dirty = dirty
+	t.mu.Unlock()
+}
+
+func (t *valueLogRefTracker) invalidate() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.valid = false
+	t.mu.Unlock()
+}
+
+func (t *valueLogRefTracker) applyDelta(nextCommitSeq uint64, delta *valueLogRefDelta) error {
+	if t == nil {
+		return nil
+	}
+	if delta == nil {
+		return errors.New("treedb: missing value-log ref delta")
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.valid {
+		return errors.New("treedb: value-log ref tracker invalid")
+	}
+	if nextCommitSeq != t.commitSeq+1 {
+		return fmt.Errorf("treedb: value-log ref tracker sequence mismatch: have=%d next=%d", t.commitSeq, nextCommitSeq)
+	}
+
+	for fileID, change := range delta.changes {
+		switch {
+		case change > 0:
+			t.counts[fileID] += uint64(change)
+		case change < 0:
+			cur := t.counts[fileID]
+			dec := uint64(-change)
+			if dec > cur {
+				return fmt.Errorf("treedb: value-log ref tracker underflow: file=%d have=%d dec=%d", fileID, cur, dec)
+			}
+			cur -= dec
+			if cur == 0 {
+				delete(t.counts, fileID)
+			} else {
+				t.counts[fileID] = cur
+			}
+		}
+	}
+
+	t.commitSeq = nextCommitSeq
+	t.dirty = true
+	return nil
+}
+
+func (t *valueLogRefTracker) referencedSet(commitSeq uint64) (map[uint32]struct{}, bool) {
+	if t == nil {
+		return nil, false
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if !t.valid || t.commitSeq != commitSeq {
+		return nil, false
+	}
+	out := make(map[uint32]struct{}, len(t.counts))
+	for fileID, n := range t.counts {
+		if n == 0 {
+			continue
+		}
+		out[fileID] = struct{}{}
+	}
+	return out, true
+}
+
+func (t *valueLogRefTracker) dirtySnapshot() (uint64, map[uint32]uint64, bool) {
+	if t == nil {
+		return 0, nil, false
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if !t.valid || !t.dirty {
+		return 0, nil, false
+	}
+	out := make(map[uint32]uint64, len(t.counts))
+	for fileID, n := range t.counts {
+		if n == 0 {
+			continue
+		}
+		out[fileID] = n
+	}
+	return t.commitSeq, out, true
+}
+
+func (t *valueLogRefTracker) markClean(commitSeq uint64) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if t.valid && t.commitSeq == commitSeq {
+		t.dirty = false
+	}
+	t.mu.Unlock()
+}
+
+func (db *DB) valueLogRefCountsPath() string {
+	if db == nil || db.dir == "" {
+		return ""
+	}
+	return filepath.Join(db.dir, valueLogRefCountsFileName)
+}
+
+func (db *DB) currentCommitSeq() uint64 {
+	if db == nil {
+		return 0
+	}
+	if state := db.state.Load(); state != nil {
+		return state.CommitSeq
+	}
+	db.mu.RLock()
+	seq := db.meta.CommitSeq
+	db.mu.RUnlock()
+	return seq
+}
+
+func (db *DB) initValueLogRefTracker() error {
+	if db == nil || db.valueLogRefTracker == nil {
+		return nil
+	}
+	loaded, err := db.loadValueLogRefTracker(db.currentCommitSeq())
+	if err != nil {
+		return err
+	}
+	if loaded {
+		return nil
+	}
+	counts, commitSeq, err := db.scanValueLogRefCounts(context.Background())
+	if err != nil {
+		return err
+	}
+	db.valueLogRefTracker.replace(counts, commitSeq, true)
+	return db.persistValueLogRefTracker()
+}
+
+func (db *DB) loadValueLogRefTracker(commitSeq uint64) (bool, error) {
+	path := db.valueLogRefCountsPath()
+	if path == "" {
+		return false, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	disk, err := decodeValueLogRefCounts(data)
+	if err != nil {
+		// Corrupt metadata is non-fatal: rebuild from full scan.
+		if errors.Is(err, errValueLogRefCorrupt) {
+			return false, nil
+		}
+		return false, err
+	}
+	if disk.commitSeq != commitSeq {
+		return false, nil
+	}
+	db.valueLogRefTracker.replace(disk.counts, disk.commitSeq, false)
+	return true, nil
+}
+
+func (db *DB) persistValueLogRefTracker() error {
+	if db == nil || db.valueLogRefTracker == nil {
+		return nil
+	}
+	path := db.valueLogRefCountsPath()
+	if path == "" {
+		return nil
+	}
+	commitSeq, counts, ok := db.valueLogRefTracker.dirtySnapshot()
+	if !ok {
+		return nil
+	}
+	blob, err := encodeValueLogRefCounts(commitSeq, counts)
+	if err != nil {
+		return err
+	}
+	if err := writeFileAtomic(path, blob, 0o644); err != nil {
+		return err
+	}
+	db.valueLogRefTracker.markClean(commitSeq)
+	return nil
+}
+
+func (db *DB) persistValueLogRefTrackerBestEffort() {
+	if err := db.persistValueLogRefTracker(); err != nil {
+		db.reportError(err)
+	}
+}
+
+func (db *DB) referencedValueLogSegments(ctx context.Context) (map[uint32]struct{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	seq := db.currentCommitSeq()
+	if db.valueLogRefTracker != nil {
+		if refs, ok := db.valueLogRefTracker.referencedSet(seq); ok {
+			return refs, nil
+		}
+	}
+	counts, scannedSeq, err := db.scanValueLogRefCounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if db.valueLogRefTracker != nil {
+		db.valueLogRefTracker.replace(counts, scannedSeq, true)
+	}
+	refs := make(map[uint32]struct{}, len(counts))
+	for fileID, n := range counts {
+		if n == 0 {
+			continue
+		}
+		refs[fileID] = struct{}{}
+	}
+	return refs, nil
+}
+
+func (db *DB) scanValueLogRefCounts(ctx context.Context) (map[uint32]uint64, uint64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil || snap.idx == nil || snap.state == nil {
+		if snap != nil {
+			_ = snap.Close()
+		}
+		return nil, 0, fmt.Errorf("missing db state")
+	}
+	commitSeq := snap.state.CommitSeq
+	counts := make(map[uint32]uint64)
+
+	userIter := snap.tree.Iterator(nil, nil)
+	if err := collectValueLogRefCounts(ctx, userIter, counts); err != nil {
+		_ = userIter.Close()
+		_ = snap.Close()
+		return nil, 0, err
+	}
+	_ = userIter.Close()
+
+	sysIter := tree.New(snap.idx.pager, valueReader{vlogs: snap.state.ValueLogSet}, snap.state.SystemRootPageID).Iterator(nil, nil)
+	if err := collectValueLogRefCounts(ctx, sysIter, counts); err != nil {
+		_ = sysIter.Close()
+		_ = snap.Close()
+		return nil, 0, err
+	}
+	_ = sysIter.Close()
+
+	if err := snap.Close(); err != nil {
+		return nil, 0, err
+	}
+	return counts, commitSeq, nil
+}
+
+func collectValueLogRefCounts(ctx context.Context, it iterator.UnsafeIterator, refs map[uint32]uint64) error {
+	for it.Valid() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_, ptr, flags := it.UnsafeEntry()
+		if flags&node.FlagPointer != 0 && page.IsValueLogFileID(ptr.FileID) {
+			refs[ptr.FileID]++
+		}
+		it.Next()
+	}
+	return it.Error()
+}
+
+func (db *DB) buildValueLogRefDelta(p *pager.Pager, rootID uint64, baseSeq uint64, entries []batchpkg.Entry) (*valueLogRefDelta, error) {
+	if db == nil || db.valueLogRefTracker == nil || !db.valueLogRefTracker.canTrack(baseSeq) {
+		return nil, nil
+	}
+	delta := newValueLogRefDelta()
+	if p == nil {
+		return delta, nil
+	}
+	tr := tree.New(p, nil, rootID)
+	for i := range entries {
+		oldFileID, oldRef, err := lookupValueLogRefAtKey(tr, entries[i].Key)
+		if err != nil {
+			return nil, err
+		}
+		if oldRef {
+			delta.add(oldFileID, -1)
+		}
+		if entries[i].Type == batchpkg.OpPut && entries[i].IsPtr && page.IsValueLogFileID(entries[i].ValuePtr.FileID) {
+			delta.add(entries[i].ValuePtr.FileID, 1)
+		}
+	}
+	return delta, nil
+}
+
+func lookupValueLogRefAtKey(tr *tree.Tree, key []byte) (uint32, bool, error) {
+	if tr == nil {
+		return 0, false, nil
+	}
+	entry, err := tr.GetEntry(key)
+	if err != nil {
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if entry.Flags&node.FlagPointer == 0 || !page.IsValueLogFileID(entry.ValuePtr.FileID) {
+		return 0, false, nil
+	}
+	return entry.ValuePtr.FileID, true, nil
+}
+
+type valueLogRefCountsDisk struct {
+	commitSeq uint64
+	counts    map[uint32]uint64
+}
+
+func encodeValueLogRefCounts(commitSeq uint64, counts map[uint32]uint64) ([]byte, error) {
+	ids := make([]uint32, 0, len(counts))
+	for fileID, n := range counts {
+		if n == 0 {
+			continue
+		}
+		ids = append(ids, fileID)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	if len(ids) > int(^uint32(0)) {
+		return nil, fmt.Errorf("too many value-log refs: %d", len(ids))
+	}
+
+	size := len(valueLogRefCountsMagic) + 4 + 8 + 4 + len(ids)*(4+8) + 4
+	buf := make([]byte, 0, size)
+	buf = append(buf, valueLogRefCountsMagic[:]...)
+	var tmp4 [4]byte
+	var tmp8 [8]byte
+	binary.LittleEndian.PutUint32(tmp4[:], valueLogRefCountsVersion)
+	buf = append(buf, tmp4[:]...)
+	binary.LittleEndian.PutUint64(tmp8[:], commitSeq)
+	buf = append(buf, tmp8[:]...)
+	binary.LittleEndian.PutUint32(tmp4[:], uint32(len(ids)))
+	buf = append(buf, tmp4[:]...)
+	for _, fileID := range ids {
+		binary.LittleEndian.PutUint32(tmp4[:], fileID)
+		buf = append(buf, tmp4[:]...)
+		binary.LittleEndian.PutUint64(tmp8[:], counts[fileID])
+		buf = append(buf, tmp8[:]...)
+	}
+	crc := crc32.ChecksumIEEE(buf)
+	binary.LittleEndian.PutUint32(tmp4[:], crc)
+	buf = append(buf, tmp4[:]...)
+	return buf, nil
+}
+
+func decodeValueLogRefCounts(data []byte) (valueLogRefCountsDisk, error) {
+	const base = 8 + 4 + 8 + 4 + 4 // magic + version + seq + count + crc
+	if len(data) < base {
+		return valueLogRefCountsDisk{}, errValueLogRefCorrupt
+	}
+	if len(data) < len(valueLogRefCountsMagic)+4 {
+		return valueLogRefCountsDisk{}, errValueLogRefCorrupt
+	}
+	if got := data[:len(valueLogRefCountsMagic)]; string(got) != string(valueLogRefCountsMagic[:]) {
+		return valueLogRefCountsDisk{}, errValueLogRefCorrupt
+	}
+	payload := data[:len(data)-4]
+	gotCRC := binary.LittleEndian.Uint32(data[len(data)-4:])
+	if crc32.ChecksumIEEE(payload) != gotCRC {
+		return valueLogRefCountsDisk{}, errValueLogRefCorrupt
+	}
+	off := len(valueLogRefCountsMagic)
+	ver := binary.LittleEndian.Uint32(payload[off : off+4])
+	off += 4
+	if ver != valueLogRefCountsVersion {
+		return valueLogRefCountsDisk{}, errValueLogRefCorrupt
+	}
+	commitSeq := binary.LittleEndian.Uint64(payload[off : off+8])
+	off += 8
+	n := binary.LittleEndian.Uint32(payload[off : off+4])
+	off += 4
+	expected := len(valueLogRefCountsMagic) + 4 + 8 + 4 + int(n)*(4+8) + 4
+	if len(data) != expected {
+		return valueLogRefCountsDisk{}, errValueLogRefCorrupt
+	}
+	counts := make(map[uint32]uint64, int(n))
+	for i := uint32(0); i < n; i++ {
+		fileID := binary.LittleEndian.Uint32(payload[off : off+4])
+		off += 4
+		refCount := binary.LittleEndian.Uint64(payload[off : off+8])
+		off += 8
+		if refCount == 0 {
+			continue
+		}
+		counts[fileID] = refCount
+	}
+	return valueLogRefCountsDisk{
+		commitSeq: commitSeq,
+		counts:    counts,
+	}, nil
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	if path == "" {
+		return nil
+	}
+	tmp := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
+	if err := os.WriteFile(tmp, data, perm); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -3,8 +3,11 @@ package db
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
@@ -96,4 +99,243 @@ func TestValueLogGC_RemovesUnreferencedSegment(t *testing.T) {
 	if _, err := os.Stat(path2); err != nil {
 		t.Fatalf("expected segment2 to remain, err=%v", err)
 	}
+}
+
+func TestValueLogGC_IncrementalParityWithFullScan(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	key := func(i int) []byte { return []byte(fmt.Sprintf("k%06d", i)) }
+	valueA := func(i int) []byte { return bytes.Repeat([]byte{byte(i % 251)}, 256) }
+	valueB := func(i int) []byte { return bytes.Repeat([]byte{byte((i + 17) % 251)}, 512) }
+
+	ptrsA := appendPointersInNewSegment(t, dir, 0, 1, 10_000, 320, valueA)
+	ptrsB := appendPointersInNewSegment(t, dir, 0, 2, 20_000, 120, valueB)
+
+	b := db.NewBatch().(*Batch)
+	for i := 0; i < 320; i++ {
+		if err := b.SetPointer(key(i), ptrsA[i]); err != nil {
+			t.Fatalf("set initial pointer %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write initial: %v", err)
+	}
+	_ = b.Close()
+
+	b = db.NewBatch().(*Batch)
+	for i := 0; i < 90; i++ {
+		if err := b.Delete(key(i)); err != nil {
+			t.Fatalf("delete %d: %v", i, err)
+		}
+	}
+	for i := 160; i < 280; i++ {
+		if err := b.SetPointer(key(i), ptrsB[i-160]); err != nil {
+			t.Fatalf("set overwrite pointer %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write churn: %v", err)
+	}
+	_ = b.Close()
+
+	seq := db.currentCommitSeq()
+	incRefs, ok := db.valueLogRefTracker.referencedSet(seq)
+	if !ok {
+		t.Fatalf("expected incremental ref set for seq=%d", seq)
+	}
+
+	fullCounts, fullSeq, err := db.scanValueLogRefCounts(context.Background())
+	if err != nil {
+		t.Fatalf("scanValueLogRefCounts: %v", err)
+	}
+	if fullSeq != seq {
+		t.Fatalf("scan seq mismatch: got=%d want=%d", fullSeq, seq)
+	}
+
+	fullRefs := valueLogRefSetFromCounts(fullCounts)
+	if !reflect.DeepEqual(incRefs, fullRefs) {
+		t.Fatalf("incremental/full-scan mismatch: incremental=%d full=%d", len(incRefs), len(fullRefs))
+	}
+}
+
+func TestValueLogGC_IncrementalCounterRollbackOnFailedCommit(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	oldValue := bytes.Repeat([]byte("old"), 128)
+	newValue := bytes.Repeat([]byte("new"), 128)
+	oldPtr := appendPointersInNewSegment(t, dir, 0, 1, 30_000, 1, func(int) []byte { return oldValue })[0]
+	newPtr := appendPointersInNewSegment(t, dir, 0, 2, 40_000, 1, func(int) []byte { return newValue })[0]
+
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k"), oldPtr); err != nil {
+		t.Fatalf("seed set pointer: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	_ = b.Close()
+
+	beforeSeq := db.currentCommitSeq()
+	beforeRefs, ok := db.valueLogRefTracker.referencedSet(beforeSeq)
+	if !ok {
+		t.Fatalf("expected incremental ref set before failpoint seq=%d", beforeSeq)
+	}
+
+	db.testFailFinalizeCommit.Store(true)
+	b = db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k"), newPtr); err != nil {
+		t.Fatalf("failpoint set pointer: %v", err)
+	}
+	err = b.Write()
+	_ = b.Close()
+	db.testFailFinalizeCommit.Store(false)
+	if !errors.Is(err, errTestFinalizeCommitFailpoint) {
+		t.Fatalf("expected failpoint error, got %v", err)
+	}
+
+	afterSeq := db.currentCommitSeq()
+	if afterSeq != beforeSeq {
+		t.Fatalf("commit seq changed on failed commit: before=%d after=%d", beforeSeq, afterSeq)
+	}
+	afterRefs, ok := db.valueLogRefTracker.referencedSet(afterSeq)
+	if !ok {
+		t.Fatalf("expected incremental ref set after failpoint seq=%d", afterSeq)
+	}
+	if !reflect.DeepEqual(beforeRefs, afterRefs) {
+		t.Fatalf("ref set changed on failed commit")
+	}
+
+	got, err := db.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("get after failed commit: %v", err)
+	}
+	if !bytes.Equal(got, oldValue) {
+		t.Fatalf("value changed on failed commit")
+	}
+}
+
+func TestValueLogGC_IncrementalMode_RebuildOnCorruption(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	ptrs := appendPointersInNewSegment(t, dir, 0, 1, 50_000, 200, func(i int) []byte {
+		return bytes.Repeat([]byte{byte(i % 251)}, 256)
+	})
+
+	b := db.NewBatch().(*Batch)
+	for i := 0; i < 200; i++ {
+		key := []byte(fmt.Sprintf("k%05d", i))
+		if err := b.SetPointer(key, ptrs[i]); err != nil {
+			t.Fatalf("seed set pointer %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	_ = b.Close()
+
+	if _, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{DryRun: true}); err != nil {
+		t.Fatalf("ValueLogGC dry-run: %v", err)
+	}
+
+	metaPath := db.valueLogRefCountsPath()
+	orig, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	if len(orig) == 0 {
+		t.Fatalf("expected non-empty metadata")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	corrupt := []byte("not-a-valid-metadata-file")
+	if err := os.WriteFile(metaPath, corrupt, 0o644); err != nil {
+		t.Fatalf("write corrupt metadata: %v", err)
+	}
+
+	db, err = Open(Options{
+		Dir: dir,
+	})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	seq := db.currentCommitSeq()
+	if _, ok := db.valueLogRefTracker.referencedSet(seq); !ok {
+		t.Fatalf("expected ref tracker rebuilt for seq=%d", seq)
+	}
+
+	if _, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{DryRun: true}); err != nil {
+		t.Fatalf("ValueLogGC after rebuild: %v", err)
+	}
+
+	after, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read rebuilt metadata: %v", err)
+	}
+	if bytes.Equal(after, corrupt) {
+		t.Fatalf("expected metadata rewrite after corruption")
+	}
+	if _, err := decodeValueLogRefCounts(after); err != nil {
+		t.Fatalf("rebuilt metadata decode: %v", err)
+	}
+}
+
+func valueLogRefSetFromCounts(counts map[uint32]uint64) map[uint32]struct{} {
+	out := make(map[uint32]struct{}, len(counts))
+	for fileID, n := range counts {
+		if n == 0 {
+			continue
+		}
+		out[fileID] = struct{}{}
+	}
+	return out
+}
+
+func appendPointersInNewSegment(t *testing.T, dir string, lane, seq uint32, ridBase uint64, n int, valueAt func(i int) []byte) []page.ValuePtr {
+	t.Helper()
+	walDir := filepath.Join(dir, "wal")
+	if err := os.MkdirAll(walDir, 0o755); err != nil {
+		t.Fatalf("mkdir wal: %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(lane, seq)
+	if err != nil {
+		t.Fatalf("encode file id lane=%d seq=%d: %v", lane, seq, err)
+	}
+	path := filepath.Join(walDir, fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+	w, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	ptrs := make([]page.ValuePtr, 0, n)
+	for i := 0; i < n; i++ {
+		ptr, err := w.Append(0, nil, ridBase+uint64(i), valueAt(i))
+		if err != nil {
+			t.Fatalf("append rid=%d: %v", ridBase+uint64(i), err)
+		}
+		ptrs = append(ptrs, ptr)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	return ptrs
 }

--- a/TreeDB/docs/spec/value-log-lifecycle.md
+++ b/TreeDB/docs/spec/value-log-lifecycle.md
@@ -29,11 +29,22 @@ Reachability is defined by pointer references found in index trees.
 
 Entries with `node.FlagPointer` and `IsValueLogFileID(ptr.FileID)` mark a segment as referenced.
 
+### 3.1 Incremental Accounting Fast Path
+
+TreeDB maintains commit-time reference counters per value-log segment.
+
+- Counters are updated from commit deltas (old pointer removal / new pointer add).
+- `ValueLogGC` may use these counters as a fast path instead of full-tree scans.
+- A compact metadata snapshot (`vlog_ref_counts.meta`) is stored in the DB dir.
+
+If counters are unavailable, stale, or corrupt, TreeDB rebuilds by scanning trees
+and rewrites metadata.
+
 ## 4. GC Algorithm (`DB.ValueLogGC`)
 
 For each segment in current value-log set:
 
-1. classify as referenced/unreferenced,
+1. determine referenced set (incremental counters when valid; otherwise full scan),
 2. keep if referenced,
 3. keep if current active segment for that lane,
 4. otherwise mark eligible.


### PR DESCRIPTION
## Summary

Implements #424 (M6 from #419): incremental value-log GC accounting with full-scan fallback.

### What changed

- Added commit-time value-log reference accounting:
  - Tracks per-segment pointer refcounts by applying commit deltas.
  - Applies deltas only after commit publish succeeds.
  - Invalidates counters on non-delta commit paths (fail-closed).
- Added persisted metadata snapshot for refcounts:
  - File: `vlog_ref_counts.meta` in DB dir.
  - Includes version + checksum validation.
  - Corrupt/stale metadata rebuilds from full scan.
- Updated `ValueLogGC` to use incremental referenced-set fast path when valid.
  - Falls back to full tree scan when counters unavailable/stale/corrupt.
  - Preserves existing active/protected/eligible deletion semantics.
- Added finalize-commit failpoint for rollback safety testing.
- Updated value-log lifecycle spec doc with incremental accounting behavior.

## Tests

Added/updated in `TreeDB/db/vlog_gc_test.go`:

- `TestValueLogGC_IncrementalParityWithFullScan`
- `TestValueLogGC_IncrementalCounterRollbackOnFailedCommit`
- `TestValueLogGC_IncrementalMode_RebuildOnCorruption`
- Existing `TestValueLogGC_RemovesUnreferencedSegment` remains passing.

Validation run:

- `go test ./TreeDB/...`

## Performance Gate (focused, 3-pair median)

Command:

```bash
./bin/unified-bench \
  -dbs leveldb,treedb \
  -profile fast \
  -keys 500000 \
  -format markdown \
  -checkpoint-between-tests \
  -test sequential_write,random_write,dataset_write_random,dataset_write_sorted,random_read,full_scan,batch_small_seq
```

Median deltas (TreeDB ops/s, main -> M6):

| Test | Delta |
|---|---:|
| Sequential Write | -2.17% |
| Random Write | -1.47% |
| Dataset Write (Random) | +1.55% |
| Dataset Write (Sorted) | +1.39% |
| Random Read | +0.97% |
| Full Scan | +0.55% |
| Batch Small Seq | +10.75% |

No target regression exceeded -5% in the 3-pair median gate.

## Profiling

Profiled fast-suite capture + benchprof run was collected for both main and M6.
Single-run profiled results are noisy but included in PR comments for transparency.

Closes #424
Refs #419
