### PR TITLE
TreeDB: M3 iterator pointer micro-batching

### DIFF
--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -15,6 +15,10 @@ type unsafeAppendReader interface {
 	ReadUnsafeAppend(ptr page.ValuePtr, dst []byte) ([]byte, error)
 }
 
+type unsafeAppendBatchReader interface {
+	ReadUnsafeAppendBatch(ptrs []page.ValuePtr, dst [][]byte) ([][]byte, error)
+}
+
 // ValueReaderForState returns a reader that resolves value-log pointers.
 func ValueReaderForState(state *DBState) tree.SlabReader {
 	if state == nil {
@@ -58,5 +62,27 @@ func (r valueReader) ReadUnsafeAppend(ptr page.ValuePtr, dst []byte) ([]byte, er
 		return nil, err
 	}
 	dst = append(dst[:0], val...)
+	return dst, nil
+}
+
+func (r valueReader) ReadUnsafeAppendBatch(ptrs []page.ValuePtr, dst [][]byte) ([][]byte, error) {
+	if len(ptrs) == 0 {
+		return dst[:0], nil
+	}
+	if app, ok := r.vlogs.(unsafeAppendBatchReader); ok {
+		return app.ReadUnsafeAppendBatch(ptrs, dst)
+	}
+	if cap(dst) < len(ptrs) {
+		dst = make([][]byte, len(ptrs))
+	} else {
+		dst = dst[:len(ptrs)]
+	}
+	for i, ptr := range ptrs {
+		var err error
+		dst[i], err = r.ReadUnsafeAppend(ptr, dst[i][:0])
+		if err != nil {
+			return nil, err
+		}
+	}
 	return dst, nil
 }

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -348,6 +348,39 @@ func (s *Set) ReadUnsafeAppend(ptr page.ValuePtr, dst []byte) ([]byte, error) {
 	return f.ReadUnsafeAppend(ptr, !s.disableReadChecksum, dst)
 }
 
+// ReadUnsafeAppendBatch resolves pointers in order, reusing file lookups for
+// contiguous same-file runs to reduce scan-path overhead.
+func (s *Set) ReadUnsafeAppendBatch(ptrs []page.ValuePtr, dst [][]byte) ([][]byte, error) {
+	if len(ptrs) == 0 {
+		return dst[:0], nil
+	}
+	if cap(dst) < len(ptrs) {
+		dst = make([][]byte, len(ptrs))
+	} else {
+		dst = dst[:len(ptrs)]
+	}
+	var (
+		fileID uint32
+		f      *File
+	)
+	for i, ptr := range ptrs {
+		if i == 0 || ptr.FileID != fileID {
+			next, ok := s.Files[ptr.FileID]
+			if !ok {
+				return nil, fmt.Errorf("valuelog file %d not found in snapshot", ptr.FileID)
+			}
+			fileID = ptr.FileID
+			f = next
+		}
+		var err error
+		dst[i], err = f.ReadUnsafeAppend(ptr, !s.disableReadChecksum, dst[i][:0])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return dst, nil
+}
+
 type Manager struct {
 	dir string
 
@@ -505,6 +538,37 @@ func (m *Manager) ReadUnsafeAppend(ptr page.ValuePtr, dst []byte) ([]byte, error
 		return nil, err
 	}
 	return f.ReadUnsafeAppend(ptr, !m.disableReadChecksum, dst)
+}
+
+func (m *Manager) ReadUnsafeAppendBatch(ptrs []page.ValuePtr, dst [][]byte) ([][]byte, error) {
+	if len(ptrs) == 0 {
+		return dst[:0], nil
+	}
+	if cap(dst) < len(ptrs) {
+		dst = make([][]byte, len(ptrs))
+	} else {
+		dst = dst[:len(ptrs)]
+	}
+	var (
+		fileID uint32
+		f      *File
+	)
+	for i, ptr := range ptrs {
+		if i == 0 || ptr.FileID != fileID {
+			next, err := m.fileFor(ptr.FileID)
+			if err != nil {
+				return nil, err
+			}
+			fileID = ptr.FileID
+			f = next
+		}
+		var err error
+		dst[i], err = f.ReadUnsafeAppend(ptr, !m.disableReadChecksum, dst[i][:0])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return dst, nil
 }
 
 func (m *Manager) fileFor(id uint32) (*File, error) {

--- a/TreeDB/reopen_verify_test.go
+++ b/TreeDB/reopen_verify_test.go
@@ -248,6 +248,67 @@ func TestReopenVerify_WALOn_WriteSync(t *testing.T) {
 	scanAndCheck(t, reopen, values, false, hash)
 }
 
+func TestIterator_GroupedPointerBatching_ReopenDurability(t *testing.T) {
+	dir := t.TempDir()
+	keys, values, hash := buildVerifyDataset(2000)
+
+	opts := treedb.Options{
+		Dir: dir,
+		ValueLog: treedb.ValueLogOptions{
+			PointerThreshold: 1,
+		},
+	}
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	writeDataset(t, db, keys, values, false)
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopen, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopen.Close()
+
+	checkGets(t, reopen, keys, values, false)
+	scanAndCheck(t, reopen, values, false, hash)
+
+	rit, err := reopen.ReverseIterator(nil, nil)
+	if err != nil {
+		t.Fatalf("reverse iterator: %v", err)
+	}
+	defer rit.Close()
+
+	count := 0
+	for idx := len(keys) - 1; rit.Valid(); rit.Next() {
+		key := rit.KeyCopy(nil)
+		if !bytes.Equal(key, keys[idx]) {
+			t.Fatalf("reverse key mismatch at %d: got %x want %x", idx, key, keys[idx])
+		}
+		val := rit.ValueCopy(nil)
+		want := values[string(keys[idx])]
+		if !bytes.Equal(val, want) {
+			t.Fatalf("reverse value mismatch for key %x", key)
+		}
+		idx--
+		count++
+	}
+	if err := rit.Error(); err != nil {
+		t.Fatalf("reverse iterator error: %v", err)
+	}
+	if count != len(keys) {
+		t.Fatalf("reverse scan count mismatch: got %d want %d", count, len(keys))
+	}
+}
+
 func TestReopenVerify_WALOn_Checkpoint_CompressionModes(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -305,13 +305,28 @@ type Iterator struct {
 	ptrOK        bool
 	ptrScratch   []byte
 	slabAppender slabUnsafeAppender
-	reverse      bool
-	verifyAlways bool
+	slabBatcher  slabUnsafeBatchAppender
+
+	prefetchPageID uint64
+	prefetchStart  int
+	prefetchLen    int
+	prefetchStep   int
+	prefetchPtrs   []page.ValuePtr
+	prefetchVals   [][]byte
+	prefetchArmed  bool
+	reverse        bool
+	verifyAlways   bool
 }
 
 type slabUnsafeAppender interface {
 	ReadUnsafeAppend(ptr page.ValuePtr, dst []byte) ([]byte, error)
 }
+
+type slabUnsafeBatchAppender interface {
+	ReadUnsafeAppendBatch(ptrs []page.ValuePtr, dst [][]byte) ([][]byte, error)
+}
+
+const iteratorPointerBatchMax = 2
 
 func (t *Tree) Iterator(start, end []byte) iterator.UnsafeIterator {
 	if start != nil && end != nil && compareTreeKey(start, end) >= 0 {
@@ -327,8 +342,14 @@ func (t *Tree) Iterator(start, end []byte) iterator.UnsafeIterator {
 	if app, ok := t.slabReader.(slabUnsafeAppender); ok {
 		it.slabAppender = app
 	}
+	if batch, ok := t.slabReader.(slabUnsafeBatchAppender); ok {
+		it.slabBatcher = batch
+	}
 	it.resetStack()
 	it.Seek(start)
+	if start == nil {
+		it.prefetchArmed = true
+	}
 	return it
 }
 
@@ -345,6 +366,9 @@ func (t *Tree) ReverseIterator(start, end []byte) iterator.UnsafeIterator {
 	}
 	if app, ok := t.slabReader.(slabUnsafeAppender); ok {
 		it.slabAppender = app
+	}
+	if batch, ok := t.slabReader.(slabUnsafeBatchAppender); ok {
+		it.slabBatcher = batch
 	}
 	it.resetStack()
 	// Reverse seek: Find >= end, then step back.
@@ -364,12 +388,17 @@ func (t *Tree) ReverseIterator(start, end []byte) iterator.UnsafeIterator {
 	if it.valid && it.start != nil && compareTreeKey(it.currKey, it.start) < 0 {
 		it.valid = false
 	}
+	if end == nil {
+		it.prefetchArmed = true
+	}
 
 	return it
 }
 
 func (it *Iterator) seekRightMost() {
 	it.resetStack()
+	it.resetPointerPrefetch()
+	it.prefetchArmed = false
 	it.leafState.resetPage()
 	it.valid = false
 	it.err = nil
@@ -409,6 +438,8 @@ func (it *Iterator) seekRightMost() {
 
 func (it *Iterator) seek(key []byte) {
 	it.resetStack()
+	it.resetPointerPrefetch()
+	it.prefetchArmed = false
 	it.leafState.resetPage()
 	it.valid = false
 	it.err = nil
@@ -682,6 +713,7 @@ func (it *Iterator) Next() {
 		panic("iterator invalid")
 	}
 	if len(it.stack) > 0 {
+		it.prefetchArmed = true
 		if it.reverse {
 			it.stack[len(it.stack)-1].Index--
 		} else {
@@ -711,11 +743,17 @@ func (it *Iterator) UnsafeValue() []byte {
 		return nil
 	}
 	if it.flags&node.FlagPointer != 0 {
-		if !it.ensurePointerLoaded() {
-			return nil
-		}
 		if it.valOK {
 			return it.currVal
+		}
+		if it.tryUsePrefetchedPointerValue() {
+			return it.currVal
+		}
+		if it.prefetchArmed && it.prefetchPointerRun() && it.tryUsePrefetchedPointerValue() {
+			return it.currVal
+		}
+		if !it.ensurePointerLoaded() {
+			return nil
 		}
 		if it.slabAppender != nil {
 			val, err := it.slabAppender.ReadUnsafeAppend(it.currPtr, it.ptrScratch[:0])
@@ -785,6 +823,8 @@ func (it *Iterator) ValueCopy(dst []byte) []byte {
 
 func (it *Iterator) Close() error {
 	it.stack = nil
+	it.resetPointerPrefetch()
+	it.ptrScratch = nil
 	return nil
 }
 
@@ -880,5 +920,125 @@ func (it *Iterator) ensureInlineValueLoaded() bool {
 	it.currVal = val
 	it.valOK = true
 	it.ptrOK = true
+	return true
+}
+
+func (it *Iterator) resetPointerPrefetch() {
+	it.prefetchPageID = 0
+	it.prefetchStart = 0
+	it.prefetchLen = 0
+	it.prefetchStep = 0
+	it.prefetchPtrs = it.prefetchPtrs[:0]
+	it.prefetchVals = it.prefetchVals[:0]
+}
+
+func (it *Iterator) tryUsePrefetchedPointerValue() bool {
+	if len(it.stack) == 0 || it.prefetchLen == 0 {
+		return false
+	}
+	top := &it.stack[len(it.stack)-1]
+	if it.prefetchPageID != top.PageID {
+		return false
+	}
+	var pos int
+	switch it.prefetchStep {
+	case 1:
+		pos = top.Index - it.prefetchStart
+	case -1:
+		pos = it.prefetchStart - top.Index
+	default:
+		return false
+	}
+	if pos < 0 || pos >= it.prefetchLen {
+		return false
+	}
+	it.currVal = it.prefetchVals[pos]
+	it.valOK = true
+	return true
+}
+
+func (it *Iterator) prefetchPointerRun() bool {
+	if len(it.stack) == 0 {
+		return false
+	}
+	top := &it.stack[len(it.stack)-1]
+	if top.Node.Type() != page.PageTypeLeaf {
+		return false
+	}
+	count := int(top.Node.Count())
+	if count == 0 {
+		return false
+	}
+	step := 1
+	if it.reverse {
+		step = -1
+	}
+
+	it.prefetchPageID = top.PageID
+	it.prefetchStart = top.Index
+	it.prefetchLen = 0
+	it.prefetchStep = step
+	it.prefetchPtrs = it.prefetchPtrs[:0]
+
+	for idx := top.Index; idx >= 0 && idx < count && len(it.prefetchPtrs) < iteratorPointerBatchMax; idx += step {
+		_, ptr, flags, err := top.Node.GetLeafValueView(uint16(idx))
+		if err != nil {
+			it.err = err
+			it.valid = false
+			it.resetPointerPrefetch()
+			return false
+		}
+		if flags&node.FlagPointer == 0 || flags&node.FlagTombstone != 0 {
+			if len(it.prefetchPtrs) == 0 {
+				return false
+			}
+			break
+		}
+		it.prefetchPtrs = append(it.prefetchPtrs, ptr)
+	}
+
+	// Keep isolated pointers on the single-read path.
+	prefetchLen := len(it.prefetchPtrs)
+	if prefetchLen < 2 {
+		it.resetPointerPrefetch()
+		return false
+	}
+
+	if cap(it.prefetchVals) < prefetchLen {
+		it.prefetchVals = make([][]byte, prefetchLen)
+	} else {
+		it.prefetchVals = it.prefetchVals[:prefetchLen]
+	}
+	for i := range it.prefetchVals {
+		it.prefetchVals[i] = it.prefetchVals[i][:0]
+	}
+
+	var err error
+	if it.slabBatcher != nil {
+		it.prefetchVals, err = it.slabBatcher.ReadUnsafeAppendBatch(it.prefetchPtrs, it.prefetchVals)
+	} else if it.slabAppender != nil {
+		for i := range it.prefetchPtrs {
+			it.prefetchVals[i], err = it.slabAppender.ReadUnsafeAppend(it.prefetchPtrs[i], it.prefetchVals[i][:0])
+			if err != nil {
+				break
+			}
+		}
+	} else {
+		for i := range it.prefetchPtrs {
+			var val []byte
+			val, err = it.tree.slabReader.ReadUnsafe(it.prefetchPtrs[i])
+			if err != nil {
+				break
+			}
+			it.prefetchVals[i] = append(it.prefetchVals[i][:0], val...)
+		}
+	}
+	if err != nil {
+		it.err = err
+		it.valid = false
+		it.resetPointerPrefetch()
+		return false
+	}
+	it.prefetchLen = prefetchLen
 	return true
 }

--- a/TreeDB/tree/iterator_test.go
+++ b/TreeDB/tree/iterator_test.go
@@ -494,3 +494,210 @@ func TestIterator_CombinedColumnarPrefixV2_MultiRestartBlocks(t *testing.T) {
 		}
 	})
 }
+
+type countingBatchValueReader struct {
+	values      map[page.ValuePtr][]byte
+	singleCalls int
+	batchCalls  int
+}
+
+func newCountingBatchValueReader() *countingBatchValueReader {
+	return &countingBatchValueReader{
+		values: make(map[page.ValuePtr][]byte),
+	}
+}
+
+func (r *countingBatchValueReader) add(fileID uint32, offset uint64, value string) page.ValuePtr {
+	ptr := page.ValuePtr{
+		FileID: fileID,
+		Offset: offset,
+		Length: uint32(len(value)),
+	}
+	r.values[ptr] = []byte(value)
+	return ptr
+}
+
+func (r *countingBatchValueReader) Read(ptr page.ValuePtr) ([]byte, error) {
+	v, ok := r.values[ptr]
+	if !ok {
+		return nil, fmt.Errorf("value pointer not found: %+v", ptr)
+	}
+	out := make([]byte, len(v))
+	copy(out, v)
+	return out, nil
+}
+
+func (r *countingBatchValueReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
+	v, ok := r.values[ptr]
+	if !ok {
+		return nil, fmt.Errorf("value pointer not found: %+v", ptr)
+	}
+	return v, nil
+}
+
+func (r *countingBatchValueReader) ReadUnsafeAppend(ptr page.ValuePtr, dst []byte) ([]byte, error) {
+	r.singleCalls++
+	v, err := r.ReadUnsafe(ptr)
+	if err != nil {
+		return nil, err
+	}
+	dst = append(dst[:0], v...)
+	return dst, nil
+}
+
+func (r *countingBatchValueReader) ReadUnsafeAppendBatch(ptrs []page.ValuePtr, dst [][]byte) ([][]byte, error) {
+	r.batchCalls++
+	if cap(dst) < len(ptrs) {
+		dst = make([][]byte, len(ptrs))
+	} else {
+		dst = dst[:len(ptrs)]
+	}
+	for i, ptr := range ptrs {
+		v, err := r.ReadUnsafe(ptr)
+		if err != nil {
+			return nil, err
+		}
+		dst[i] = append(dst[i][:0], v...)
+	}
+	return dst, nil
+}
+
+func TestIterator_GroupedPointerBatching_StableOrdering(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	p.Alloc(1)
+	data, _ := p.Get(0)
+	n := node.NewNode(data)
+	n.SetPageID(0)
+	n.SetType(page.PageTypeLeaf)
+
+	reader := newCountingBatchValueReader()
+	var wantKeys []string
+	var wantVals []string
+	for i := 0; i < 12; i++ {
+		key := fmt.Sprintf("k%02d", i)
+		val := fmt.Sprintf("v%02d", i)
+		ptr := reader.add(page.ValueLogFileID(1), uint64(100+i*8), val)
+		if err := n.AddLeafEntry([]byte(key), nil, node.FlagPointer, ptr); err != nil {
+			t.Fatalf("AddLeafEntry(%s): %v", key, err)
+		}
+		wantKeys = append(wantKeys, key)
+		wantVals = append(wantVals, val)
+	}
+	n.UpdateChecksum()
+
+	tr := New(p, reader, 0)
+	it := tr.Iterator(nil, nil)
+	defer it.Close()
+
+	var gotKeys []string
+	var gotVals []string
+	for ; it.Valid(); it.Next() {
+		gotKeys = append(gotKeys, string(it.Key()))
+		gotVals = append(gotVals, string(it.ValueCopy(nil)))
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if len(gotKeys) != len(wantKeys) {
+		t.Fatalf("keys length mismatch: got=%d want=%d", len(gotKeys), len(wantKeys))
+	}
+	for i := range wantKeys {
+		if gotKeys[i] != wantKeys[i] || gotVals[i] != wantVals[i] {
+			t.Fatalf("entry %d mismatch: got=(%q,%q) want=(%q,%q)", i, gotKeys[i], gotVals[i], wantKeys[i], wantVals[i])
+		}
+	}
+	if reader.batchCalls == 0 {
+		t.Fatalf("expected batched pointer reads, got batchCalls=0")
+	}
+	if reader.singleCalls != 0 {
+		t.Fatalf("expected no single pointer reads for contiguous pointer run, got singleCalls=%d", reader.singleCalls)
+	}
+}
+
+func TestIterator_GroupedPointerBatching_MixedInlineAndPtr(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	p.Alloc(1)
+	data, _ := p.Get(0)
+	n := node.NewNode(data)
+	n.SetPageID(0)
+	n.SetType(page.PageTypeLeaf)
+
+	reader := newCountingBatchValueReader()
+	ptr := func(off uint64, val string) page.ValuePtr {
+		return reader.add(page.ValueLogFileID(1), off, val)
+	}
+
+	type kv struct {
+		key   string
+		flags byte
+		val   string
+		ptr   page.ValuePtr
+	}
+	entries := []kv{
+		{key: "k00", flags: node.FlagPointer, val: "pv00", ptr: ptr(10, "pv00")},
+		{key: "k01", flags: node.FlagPointer, val: "pv01", ptr: ptr(18, "pv01")},
+		{key: "k02", flags: node.FlagInline, val: "iv02"},
+		{key: "k03", flags: node.FlagPointer, val: "pv03", ptr: ptr(26, "pv03")},
+		{key: "k04", flags: node.FlagInline, val: "iv04"},
+		{key: "k05", flags: node.FlagPointer, val: "pv05", ptr: ptr(34, "pv05")},
+		{key: "k06", flags: node.FlagPointer, val: "pv06", ptr: ptr(42, "pv06")},
+	}
+	for _, e := range entries {
+		var value []byte
+		if e.flags&node.FlagPointer == 0 {
+			value = []byte(e.val)
+		}
+		if err := n.AddLeafEntry([]byte(e.key), value, e.flags, e.ptr); err != nil {
+			t.Fatalf("AddLeafEntry(%s): %v", e.key, err)
+		}
+	}
+	n.UpdateChecksum()
+
+	tr := New(p, reader, 0)
+	it := tr.Iterator(nil, nil)
+	defer it.Close()
+
+	var got []string
+	for ; it.Valid(); it.Next() {
+		got = append(got, fmt.Sprintf("%s=%s", it.Key(), it.ValueCopy(nil)))
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+
+	want := []string{
+		"k00=pv00",
+		"k01=pv01",
+		"k02=iv02",
+		"k03=pv03",
+		"k04=iv04",
+		"k05=pv05",
+		"k06=pv06",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("result length mismatch: got=%d want=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("result mismatch at %d: got=%q want=%q", i, got[i], want[i])
+		}
+	}
+	if reader.batchCalls == 0 {
+		t.Fatalf("expected at least one batched pointer read")
+	}
+	if reader.singleCalls == 0 {
+		t.Fatalf("expected isolated pointer fallback to single read in mixed stream")
+	}
+}


### PR DESCRIPTION
## Summary

Implements #426 (#419 M3): iterator pointer micro-batching for grouped value-log locality.

### What changed

- Added batched unsafe-append pointer reads to value-log readers:
  - `TreeDB/internal/valuelog/manager.go`
  - `TreeDB/db/value_reader.go`
- Added iterator grouped pointer prefetch + batched decode path:
  - `TreeDB/tree/iterator.go`
  - bounded pointer-run prefetch (`iteratorPointerBatchMax=2`)
  - O(1) prefetched value lookup by contiguous run math
  - prefetch arming to avoid overfetch on seek-style point reads
- Added/updated acceptance coverage:
  - `TestIterator_GroupedPointerBatching_StableOrdering`
  - `TestIterator_GroupedPointerBatching_MixedInlineAndPtr`
  - `TestIterator_GroupedPointerBatching_ReopenDurability`

## Correctness validation

- `go test ./TreeDB/tree -run 'TestIterator_GroupedPointerBatching_' -count=1`
- `go test ./TreeDB -run 'TestIterator_GroupedPointerBatching_ReopenDurability' -count=1`
- `go test ./TreeDB/...`

## Perf / profiling evidence

### Focused target-gate medians (3 paired runs, base=`origin/main`, head=this PR)

Command used per run:

```bash
./bin/unified-bench -dbs leveldb,treedb -profile fast -keys 500000 -format markdown -checkpoint-between-tests \
  -test sequential_write,random_write,dataset_write_random,dataset_write_sorted,random_read,full_scan,batch_small_seq
```

Median deltas (TreeDB ops/s):

- Sequential Write: `-1.40%`
- Random Write: `+0.96%`
- Dataset Write (Random): `+0.63%`
- Dataset Write (Sorted): `+1.13%`
- Random Read: `-0.26%`
- Full Scan: `-0.61%`
- Batch Small Seq: `+32.75%`

Artifacts:
- `/tmp/gomap_m3_target_gate8_1770785494/summary.csv`
- `/tmp/gomap_m3_target_gate8_1770785494/median_delta.csv`

### Full profile capture

Command:

```bash
/usr/bin/time -p ./bin/unified-bench -dbs leveldb,treedb -profile fast -keys 500000 -format markdown -checkpoint-between-tests -profile-dir /tmp/gomap_m3_final_prof_GfYUoH
./bin/benchprof -profiles-dir /tmp/gomap_m3_final_prof_GfYUoH
```

Artifacts:
- `/tmp/gomap_m3_final_prof_GfYUoH/unified_bench.md`
- `/tmp/gomap_m3_final_prof_GfYUoH/benchprof_results.md`
- `/tmp/gomap_m3_final_prof_GfYUoH/insights.md`

Closes #426
