### PR TITLE
bench: add random_read_batch and profile-guided read throughput review

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -10499,6 +10499,38 @@ func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
 	return dst, false, nil
 }
 
+type backendManyGetter interface {
+	GetMany(keys [][]byte) ([][]byte, error)
+}
+
+func (db *DB) backendGetMany(keys [][]byte) ([][]byte, error) {
+	if mg, ok := db.backend.(backendManyGetter); ok {
+		return mg.GetMany(keys)
+	}
+	out := make([][]byte, len(keys))
+	for i, key := range keys {
+		val, err := db.backend.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = val
+	}
+	return out, nil
+}
+
+func (db *DB) inMemoryWritesEmpty() bool {
+	if db.mutableBytes.Load() != 0 {
+		return false
+	}
+	if view := db.memtables.Load(); view != nil {
+		return len(view.queue) == 0
+	}
+	db.mu.RLock()
+	empty := len(db.queue) == 0
+	db.mu.RUnlock()
+	return empty
+}
+
 // GetUnsafe returns a safe copy of the value.
 func (db *DB) GetUnsafe(key []byte) ([]byte, error) {
 	return db.Get(key)
@@ -10506,6 +10538,9 @@ func (db *DB) GetUnsafe(key []byte) ([]byte, error) {
 
 // Get returns a safe copy of the value.
 func (db *DB) Get(key []byte) ([]byte, error) {
+	if db.inMemoryWritesEmpty() {
+		return db.backend.Get(key)
+	}
 	val, found, err := db.getMemtable(key)
 	if err != nil {
 		return nil, err
@@ -10519,6 +10554,57 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 		return cpy, nil
 	}
 	return db.backend.Get(key)
+}
+
+// GetMany returns safe copies of values for keys.
+//
+// Missing keys are returned as nil entries with no error.
+func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
+	if len(keys) == 0 {
+		return make([][]byte, 0), nil
+	}
+
+	// Fast path: no mutable/queued state, so we can delegate straight to the
+	// backend and let it use a single snapshot when supported.
+	if db.inMemoryWritesEmpty() {
+		return db.backendGetMany(keys)
+	}
+
+	out := make([][]byte, len(keys))
+	backendIdx := make([]int, 0, len(keys))
+	backendKeys := make([][]byte, 0, len(keys))
+	for i, key := range keys {
+		val, found, err := db.getMemtable(key)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			if val == nil {
+				continue
+			}
+			cpy := make([]byte, len(val))
+			copy(cpy, val)
+			out[i] = cpy
+			continue
+		}
+		backendIdx = append(backendIdx, i)
+		backendKeys = append(backendKeys, key)
+	}
+	if len(backendKeys) == 0 {
+		return out, nil
+	}
+
+	backendVals, err := db.backendGetMany(backendKeys)
+	if err != nil {
+		return nil, err
+	}
+	if len(backendVals) != len(backendKeys) {
+		return nil, fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(backendKeys))
+	}
+	for i, outIdx := range backendIdx {
+		out[outIdx] = backendVals[i]
+	}
+	return out, nil
 }
 
 // GetAppend appends the value for the key to dst and returns the new slice.

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -23,6 +23,55 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 	return val, err
 }
 
+// GetMany returns values for keys.
+//
+// Semantics: Returns safe copies of values. Missing keys are returned as nil
+// entries with no error.
+func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
+	out := make([][]byte, len(keys))
+	if len(keys) == 0 {
+		return out, nil
+	}
+	snap := db.AcquireSnapshot()
+	defer snap.Close()
+
+	// Copy all found values into a single arena to avoid one allocation per key.
+	// Each returned slice is capacity-capped to preserve safe-copy semantics.
+	const (
+		getManyValueGuessBytes = 128
+		getManyMaxArenaBytes   = 1 << 20
+	)
+	arenaCap := len(keys) * getManyValueGuessBytes
+	if arenaCap < 0 {
+		arenaCap = 0
+	}
+	if arenaCap > getManyMaxArenaBytes {
+		arenaCap = getManyMaxArenaBytes
+	}
+	arena := make([]byte, 0, arenaCap)
+	for i, key := range keys {
+		val, err := snap.GetUnsafe(key)
+		if err == tree.ErrKeyNotFound {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		if val == nil {
+			continue
+		}
+		n := len(val)
+		if n == 0 {
+			out[i] = []byte{}
+			continue
+		}
+		start := len(arena)
+		arena = append(arena, val...)
+		out[i] = arena[start : start+n : start+n]
+	}
+	return out, nil
+}
+
 // GetUnsafe returns the value for a key.
 //
 // Semantics: Returns a safe copy of the value. For zero-copy views tied to a

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -741,6 +741,20 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 	return db.backend.Get(key)
 }
 
+// GetMany returns values for keys.
+//
+// Semantics: Returns safe copies of values. Missing keys are returned as nil
+// entries with no error.
+func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
+	if err := db.ensureOpen(); err != nil {
+		return nil, err
+	}
+	if db.cached != nil {
+		return db.cached.GetMany(keys)
+	}
+	return db.backend.GetMany(keys)
+}
+
 // GetUnsafe returns the value for a key.
 //
 // Semantics: Returns a safe copy of the value. For zero-copy views tied to a

--- a/cmd/unified_bench/adapter_leveldb.go
+++ b/cmd/unified_bench/adapter_leveldb.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 
 	"github.com/snissn/gomap/kvstore"
@@ -134,8 +135,31 @@ func (l *LevelDBWrapper) Name() string {
 }
 func (l *LevelDBWrapper) Set(k, v []byte) error        { return l.db.Put(k, v, nil) }
 func (l *LevelDBWrapper) Get(k []byte) ([]byte, error) { return l.db.Get(k, nil) }
-func (l *LevelDBWrapper) Delete(k []byte) error        { return l.db.Delete(k, nil) }
-func (l *LevelDBWrapper) Close() error                 { return l.db.Close() }
+func (l *LevelDBWrapper) GetMany(keys [][]byte) ([][]byte, error) {
+	out := make([][]byte, len(keys))
+	if len(keys) == 0 {
+		return out, nil
+	}
+	snap, err := l.db.GetSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	defer snap.Release()
+	for i, key := range keys {
+		val, err := snap.Get(key, nil)
+		if err == nil {
+			out[i] = val
+			continue
+		}
+		if errors.Is(err, leveldb.ErrNotFound) {
+			continue
+		}
+		return nil, err
+	}
+	return out, nil
+}
+func (l *LevelDBWrapper) Delete(k []byte) error { return l.db.Delete(k, nil) }
+func (l *LevelDBWrapper) Close() error          { return l.db.Close() }
 func (l *LevelDBWrapper) Checkpoint() error {
 	if l == nil || l.db == nil {
 		return nil

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -52,7 +52,7 @@ var (
 	keysMax            = flag.Int("keys-max", 10000000, "Maximum key count for -keyscale")
 	dbsArg             = flag.String("dbs", "all", "Comma-separated list of DBs to run. Use 'all' for registered DBs.")
 	dbsExcludeArg      = flag.String("exclude-dbs", "", "Comma-separated list of DBs to exclude")
-	testArg            = flag.String("test", "all", "Comma-separated list of tests (sequential_write,random_read,random_write,random_write_parallel,dataset_write_random,dataset_write_sorted,dataset_update_fork_choice,dataset_read_random,random_delete,full_scan,prefix_scan,batch_write,batch_random,batch_delete,update_fork_choice); aliases: write_seq->sequential_write, write_rand->random_write, write_sorted->dataset_write_sorted, write_dataset->dataset_write_random, read_rand->random_read, delete_rand->random_delete, scan->full_scan, range_scan->prefix_scan, forkchoice->update_fork_choice")
+	testArg            = flag.String("test", "all", "Comma-separated list of tests (sequential_write,random_read,random_read_batch,random_write,random_write_parallel,dataset_write_random,dataset_write_sorted,dataset_update_fork_choice,dataset_read_random,random_delete,full_scan,prefix_scan,batch_write,batch_random,batch_delete,update_fork_choice); aliases: write_seq->sequential_write, write_rand->random_write, write_sorted->dataset_write_sorted, write_dataset->dataset_write_random, read_rand->random_read, read_rand_batch->random_read_batch, read_random_batch->random_read_batch, delete_rand->random_delete, scan->full_scan, range_scan->prefix_scan, forkchoice->update_fork_choice")
 	formatArg          = flag.String("format", "table", "Output format: table or markdown")
 	suiteArg           = flag.String("suite", "", "Named benchmark suite (e.g. readme)")
 	outDirArg          = flag.String("outdir", "", "Write plots/results to this directory (used by -suite readme)")
@@ -2040,6 +2040,44 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			}
 			return float64(cfg.Keys) / time.Since(start).Seconds(), nil
 		},
+		"random_read_batch": func(db kvstore.DB, rng *rand.Rand) (float64, error) {
+			start := time.Now()
+			batchSize := cfg.BatchSize
+			if batchSize <= 0 {
+				batchSize = 1
+			}
+			keys := make([][]byte, batchSize)
+			keyBuf := make([]byte, batchSize*8)
+			for i := 0; i < batchSize; i++ {
+				keys[i] = keyBuf[i*8 : (i+1)*8]
+			}
+			mg, hasMany := db.(kvstore.MultiGetter)
+			nextGuard := 0
+			for i := 0; i < cfg.Keys; {
+				if i >= nextGuard {
+					if err := guard.Checkpoint(); err != nil {
+						return 0, err
+					}
+					nextGuard = i + 8192
+				}
+				n := batchSize
+				if remaining := cfg.Keys - i; remaining < n {
+					n = remaining
+				}
+				for j := 0; j < n; j++ {
+					encodeKey(keys[j], uint64(rng.Intn(cfg.Keys)))
+				}
+				if hasMany {
+					_, _ = mg.GetMany(keys[:n])
+				} else {
+					for j := 0; j < n; j++ {
+						_, _ = db.Get(keys[j])
+					}
+				}
+				i += n
+			}
+			return float64(cfg.Keys) / time.Since(start).Seconds(), nil
+		},
 		"dataset_read_random": func(db kvstore.DB, rng *rand.Rand) (float64, error) {
 			if err := ensureWriteDatasets(); err != nil {
 				return 0, fmt.Errorf("dataset_read_random: %w", err)
@@ -2311,7 +2349,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		},
 	}
 
-	allTestOrder := []string{"sequential_write", "random_write", "dataset_write_random", "dataset_write_sorted", "batch_write", "batch_random", "batch_delete", "batch_small_seq", "random_delete", "random_read", "full_scan", "prefix_scan"}
+	allTestOrder := []string{"sequential_write", "random_write", "dataset_write_random", "dataset_write_sorted", "batch_write", "batch_random", "batch_delete", "batch_small_seq", "random_delete", "random_read", "random_read_batch", "full_scan", "prefix_scan"}
 	displayNames := map[string]string{
 		"vacuum_index":               "VACUUM (Index)",
 		"fragmentation_report_pre":   "Fragmentation Report (Pre-Settle)",
@@ -2322,6 +2360,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		"dataset_write_random":       "Dataset Write (Random)",
 		"dataset_write_sorted":       "Dataset Write (Sorted)",
 		"random_read":                "Random Read",
+		"random_read_batch":          "Random Read (Batch)",
 		"full_scan":                  "Full Scan",
 		"full_scan2":                 "Full Scan (After VACUUM)",
 		"prefix_scan":                "Prefix Scan",
@@ -2391,6 +2430,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	)
 	needsExistingData := containsAny(finalTestOrder,
 		"random_read",
+		"random_read_batch",
 		"random_delete",
 		"batch_delete",
 		"full_scan",
@@ -2423,7 +2463,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	}
 
 	// Settle before scans?
-	if cfg.SettleBeforeScans && containsAny(finalTestOrder, "full_scan", "prefix_scan", "random_read") {
+	if cfg.SettleBeforeScans && containsAny(finalTestOrder, "full_scan", "prefix_scan", "random_read", "random_read_batch") {
 		fmt.Fprintf(os.Stderr, "Settling DBs (Close/Open)...\n")
 		for _, inst := range instances {
 			// Close
@@ -2514,7 +2554,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		fn := testFuncs[testName]
 		seed := testSeed(cfg.SeedUsed, testName)
 
-		if cfg.TreeDBCacheStatsBeforeReads && containsAny([]string{testName}, "random_read", "dataset_read_random", "full_scan", "prefix_scan", "full_scan2", "prefix_scan2") {
+		if cfg.TreeDBCacheStatsBeforeReads && containsAny([]string{testName}, "random_read", "random_read_batch", "dataset_read_random", "full_scan", "prefix_scan", "full_scan2", "prefix_scan2") {
 			for _, inst := range instances {
 				printTreeDBCacheStats(os.Stderr, inst, "pre-"+testName+" treedb.cache")
 			}
@@ -3937,6 +3977,8 @@ func normalizeTests(list []string) []string {
 			t = "dataset_write_random"
 		case "read_rand":
 			t = "random_read"
+		case "read_rand_batch", "read_random_batch":
+			t = "random_read_batch"
 		case "delete_rand":
 			t = "random_delete"
 		case "batch_write_random":

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -39,6 +39,44 @@ func TestRunBenchmark_PreloadsForReadAndScanOnly(t *testing.T) {
 	}
 }
 
+func TestRunBenchmark_RandomReadBatch_Smoke(t *testing.T) {
+	run, err := runBenchmark(BenchConfig{
+		Keys:         2_000,
+		ValueSize:    16,
+		BatchSize:    128,
+		RangeQueries: 50,
+		RangeSpan:    20,
+		DBsArg:       "treedb,leveldb",
+		TestsArg:     "sequential_write,random_read_batch",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+
+	for _, dbName := range []string{"TreeDB", "LevelDB"} {
+		got := run.Results["random_read_batch"][dbName]
+		if math.IsNaN(got) || got <= 0 {
+			t.Fatalf("expected random_read_batch > 0 for %s, got %v", dbName, got)
+		}
+	}
+}
+
+func TestNormalizeTests_ReadRandomBatchAliases(t *testing.T) {
+	got := normalizeTests(parseList("read_rand_batch,read_random_batch,random_read_batch"))
+	want := []string{"random_read_batch"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected len: got=%v want=%v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected normalize result: got=%v want=%v", got, want)
+		}
+	}
+}
+
 func TestRunBenchmark_PrefixScanMatchesBatchWriteKeyRange(t *testing.T) {
 	run, err := runBenchmark(BenchConfig{
 		Keys:         2_000,

--- a/docs/benchmarks/random_read_profile_review_2026-02-12.md
+++ b/docs/benchmarks/random_read_profile_review_2026-02-12.md
@@ -1,0 +1,158 @@
+# Random Read Throughput Review (2026-02-12)
+
+## Scope
+
+Review read-path throughput and profiling for TreeDB while preserving current public semantics:
+
+- `Get(key)` returns a safe copy.
+- no behavior changes to missing keys/tombstones.
+- no weakening of snapshot consistency.
+
+## Commands Run
+
+### Branch under test
+
+```bash
+make unified-bench
+/usr/bin/time -p ./bin/unified-bench \
+  -dbs leveldb,treedb \
+  -profile fast \
+  -test sequential_write,random_read,random_read_batch \
+  -keys 500000 \
+  -batchsize 256 \
+  -checkpoint-between-tests \
+  -treedb-force-value-pointers=false \
+  -valsize 85 \
+  -format markdown
+```
+
+3 non-profile runs:
+
+- `/tmp/gomap_cur_runs_RxlP2E/run_1.md`
+- `/tmp/gomap_cur_runs_RxlP2E/run_2.md`
+- `/tmp/gomap_cur_runs_RxlP2E/run_3.md`
+
+Profile run:
+
+```bash
+/usr/bin/time -p ./bin/unified-bench ... -profile-dir /tmp/gomap_cur_prof_tUbqfx
+./bin/benchprof -profiles-dir /tmp/gomap_cur_prof_tUbqfx
+```
+
+### Main baseline worktree
+
+```bash
+git worktree add /tmp/gomap_main_wt origin/main
+cd /tmp/gomap_main_wt
+make unified-bench benchprof
+/usr/bin/time -p ./bin/unified-bench \
+  -dbs leveldb,treedb \
+  -profile fast \
+  -test sequential_write,random_read \
+  -keys 500000 \
+  -batchsize 256 \
+  -checkpoint-between-tests \
+  -treedb-force-value-pointers=false \
+  -valsize 85 \
+  -format markdown
+```
+
+3 non-profile runs:
+
+- `/tmp/gomap_main_runs_C3HVEU/run_1.md`
+- `/tmp/gomap_main_runs_C3HVEU/run_2.md`
+- `/tmp/gomap_main_runs_C3HVEU/run_3.md`
+
+Profile run:
+
+```bash
+/usr/bin/time -p ./bin/unified-bench ... -profile-dir /tmp/gomap_main_prof_XOtWla
+./bin/benchprof -profiles-dir /tmp/gomap_main_prof_XOtWla
+```
+
+## Throughput Summary
+
+All values are ops/s, median of 3 non-profile runs.
+
+| Test | Main TreeDB | Branch TreeDB | Delta |
+|---|---:|---:|---:|
+| Sequential Write | 9,918,593 | 10,317,566 | +4.02% |
+| Random Read | 1,766,942 | 1,850,854 | +4.75% |
+| Random Read (Batch=256) | n/a on main | 2,050,065 | n/a |
+
+LevelDB medians (sanity):
+
+- Sequential Write: 571,965 -> 566,771 (-0.91%)
+- Random Read: 720,773 -> 758,371 (+5.22%, noisy but directionally stable in these runs)
+
+## Profile Findings
+
+### Branch profile (`/tmp/gomap_cur_prof_tUbqfx`)
+
+`random_read` (TreeDB):
+
+- CPU is copy-heavy: `runtime.memmove` is dominant (`65.71%` flat).
+- Alloc objects are concentrated in:
+  - `db.(*DB).AcquireSnapshot` (`51.72%`)
+  - `db.(*Snapshot).Get` (`45.13%`)
+- Alloc space is concentrated in:
+  - `db.(*Snapshot).Get` (`78.04%`)
+  - `db.(*DB).AcquireSnapshot` (`14.91%`)
+
+`random_read_batch` (TreeDB):
+
+- Throughput is higher than single-key reads.
+- Alloc objects are already very low (`total=4,081` for whole run).
+- Alloc space is mostly copy arena in `db.(*DB).GetMany` (`99.14%`).
+  - This is expected with safe-copy semantics.
+
+### Main profile (`/tmp/gomap_main_prof_XOtWla`)
+
+`random_read` (TreeDB):
+
+- Same fundamental shape as branch:
+  - high copy cost in `runtime.memmove`
+  - alloc split between `AcquireSnapshot` and `Snapshot.Get`.
+
+## Top Semantics-Preserving Throughput Opportunities
+
+Ordered by expected impact for `random_read`.
+
+1. Add a reusable read handle API to amortize snapshot setup.
+
+- Problem: `AcquireSnapshot` is a top allocator for single-key reads.
+- Direction: introduce a long-lived read context (for example `ReadHandle`) that pins one snapshot for many `Get` calls.
+- Semantics: each `Get` still returns a safe copy; consistency is explicit per handle lifetime.
+- Expected impact: high for point-read loops.
+
+2. Add `GetManyInto`/`GetInto` APIs with caller-owned buffers.
+
+- Problem: safe-copy semantics force copy cost every call; default APIs must allocate.
+- Direction: add optional APIs that append into caller-provided buffers/slices while preserving value bytes as safe copies.
+- Semantics: existing `Get` behavior unchanged; new API is opt-in.
+- Expected impact: high for benchmark-style and service hot loops that do not retain values long-term.
+
+3. Reduce snapshot registration overhead in backend internals.
+
+- Problem: snapshot acquire/release bookkeeping allocates per read.
+- Direction: optimize reader registry path (fewer heap allocations for register/unregister, cheaper pin tracking).
+- Semantics: no API change, same snapshot safety.
+- Expected impact: medium to high for single-key random read.
+
+4. Add an explicit bulk point-read path on the Tree layer.
+
+- Problem: `GetMany` currently loops over per-key tree traversal.
+- Direction: add internal batch traversal primitive (reuse page/key decode state across neighboring keys, especially on prefix-compressed leaves).
+- Semantics: return array of safe copies in input order.
+- Expected impact: medium, strongest for batch reads.
+
+5. Keep optimizing copy path details without changing semantics.
+
+- Problem: `memmove` dominates point reads.
+- Direction: minimize avoidable intermediate copies and memclr in hot loops, keep one-copy-to-caller as the required semantic boundary.
+- Semantics: unchanged safe-copy contract.
+- Expected impact: medium.
+
+## Recommendation
+
+Next implementation PR should focus on **(1) reusable read handle + (3) snapshot registry cost**, because current profiles show these costs clearly even in inline-value mode (where value-log decode noise is minimal).

--- a/kvstore/adapters/treedb/treedb.go
+++ b/kvstore/adapters/treedb/treedb.go
@@ -41,6 +41,14 @@ func (d *DB) Get(key []byte) ([]byte, error) {
 	return val, err
 }
 
+func (d *DB) GetMany(keys [][]byte) ([][]byte, error) {
+	vals, err := d.DB.GetMany(keys)
+	if errors.Is(err, treedb.ErrClosed) {
+		return make([][]byte, len(keys)), nil
+	}
+	return vals, err
+}
+
 func (d *DB) GetUnsafe(key []byte) ([]byte, error) {
 	val, err := d.DB.GetUnsafe(key)
 	if errors.Is(err, treedb.ErrClosed) {

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -16,6 +16,11 @@ type DB interface {
 	Delete(key []byte) error
 }
 
+// MultiGetter is an optional capability for batched point reads.
+type MultiGetter interface {
+	GetMany(keys [][]byte) ([][]byte, error)
+}
+
 // Haser is an optional capability for checking existence without retrieving values.
 type Haser interface {
 	Has(key []byte) (bool, error)


### PR DESCRIPTION
## Summary

This PR does two things:

1. Adds a new `random_read_batch` benchmark path (with `GetMany`) to isolate per-call snapshot overhead.
2. Captures a fresh benchmark/profile review and documents top semantics-preserving throughput opportunities.

## Code Changes

- Added optional `kvstore.MultiGetter` capability.
- Added `GetMany(keys [][]byte)` support for TreeDB + adapter + LevelDB adapter.
- Added cached-mode fast path: when mutable + queue are empty, `Get`/`GetMany` jump directly to backend.
- Added unified bench test `random_read_batch` (aliases: `read_rand_batch`, `read_random_batch`).
- Added smoke/alias tests in `cmd/unified_bench/main_test.go`.
- Added profile review doc:
  - `docs/benchmarks/random_read_profile_review_2026-02-12.md`

## Bench Results (inline-value config)

Command basis:

- `-dbs leveldb,treedb`
- `-profile fast`
- `-test sequential_write,random_read[,random_read_batch]`
- `-keys 500000 -batchsize 256 -checkpoint-between-tests`
- `-treedb-force-value-pointers=false -valsize 85`

Median of 3 non-profile runs:

- TreeDB `Sequential Write`: `9,918,593` (main) -> `10,317,566` (`+4.02%`)
- TreeDB `Random Read`: `1,766,942` (main) -> `1,850,854` (`+4.75%`)
- TreeDB `Random Read (Batch=256)`: `2,050,065` (new test)

## Profile Findings

Primary current bottlenecks for `random_read` (TreeDB):

- snapshot setup/teardown (`AcquireSnapshot`) allocation overhead
- safe-copy cost (`memmove`) in point read path

See full details and commands in:

- `docs/benchmarks/random_read_profile_review_2026-02-12.md`

## Next Top Optimizations (semantics-preserving)

1. Reusable read handle API to amortize snapshot setup across many gets.
2. Optional `GetInto` / `GetManyInto` APIs with caller-owned buffers.
3. Internal snapshot registry allocation reductions.
4. Internal bulk point-read traversal path for `GetMany`.
5. Further copy-path tightening while preserving safe-copy semantics.
