### PR TITLE
db: remove AcquireSnapshot interface-boxing allocation

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -541,6 +541,7 @@ type Snapshot struct {
 	db         *DB
 	idx        *indexGen
 	state      *DBState
+	vreader    valueReader
 	tree       tree.Tree
 	registryID int64
 }
@@ -584,7 +585,10 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	snap.idx = idx
 	snap.state = state
 	if idx != nil {
-		snap.tree.Reset(idx.pager, valueReader{vlogs: state.ValueLogSet}, state.RootPageID)
+		snap.vreader.vlogs = state.ValueLogSet
+		snap.tree.Reset(idx.pager, &snap.vreader, state.RootPageID)
+	} else {
+		snap.vreader.vlogs = nil
 	}
 	snap.registryID = id
 	return snap

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -45,6 +45,7 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.db = nil
 	s.idx = nil
 	s.state = nil
+	s.vreader = valueReader{}
 	s.tree.Reset(nil, nil, 0)
 	s.registryID = 0
 	p.pool.Put(s)


### PR DESCRIPTION
## Summary

This is a **minimal, isolated PR** for the snapshot allocation fix only.

It does not include `GetMany`/benchmark API changes.

## Change

`AcquireSnapshot` was allocating per call due to boxing `valueReader{...}` into the `tree.SlabReader` interface when calling `tree.Reset`.

Fix:

- Store a reusable `valueReader` in `Snapshot` (`Snapshot.vreader`)
- Rebind only its `vlogs` pointer per snapshot acquire
- Pass `&snap.vreader` into `tree.Reset`
- Clear `vreader` in `SnapshotPool.Put`

Files:

- `TreeDB/db/db.go`
- `TreeDB/db/pools.go`

## Validation

- `go test ./TreeDB/db ./TreeDB/caching ./cmd/unified_bench`
- `go test ./TreeDB/db -run ^$ -bench BenchmarkSnapshotPool -benchmem -count=3`

Benchmark result for `BenchmarkSnapshotPool`:

- before: `~16 B/op, 1 allocs/op`
- after: `0 B/op, 0 allocs/op`

This keeps read semantics unchanged (`Get` still returns safe copies).
