### PR TITLE
node: sequential fallback scan in prefix-v2 leaf block search

### DIFF
--- a/TreeDB/node/leaf.go
+++ b/TreeDB/node/leaf.go
@@ -1769,11 +1769,29 @@ func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, targ
 	}
 
 	prevKey := restartKey
+	curStart := restartEnd
+	nextKeyDirOff := restartKeyDirOff + 4
+	prefixOff := prefixStart + int(blockStart+1)*2
 	for idx := blockStart + 1; idx < blockEnd; idx++ {
-		prefixLen, suffix, err := leafColumnarPrefixV2KeyPartsAtFast(data, count, keysBlobBase, prefixStart, idx)
-		if err != nil {
-			return 0, false, err
+		curEnd := len(data)
+		if idx+1 < count {
+			if nextKeyDirOff+2 > len(data) {
+				return 0, false, ErrCorruptedNode
+			}
+			curEnd = int(getUint16At(data, nextKeyDirOff))
+			nextKeyDirOff += 2
 		}
+		if curStart < keysBlobBase || curEnd < curStart || curEnd > len(data) {
+			return 0, false, ErrCorruptedNode
+		}
+		if prefixOff+2 > len(data) {
+			return 0, false, ErrCorruptedNode
+		}
+		prefixLen := int(getUint16At(data, prefixOff))
+		prefixOff += 2
+		suffix := data[curStart:curEnd]
+		curStart = curEnd
+
 		if prefixLen > len(prevKey) {
 			return 0, false, ErrCorruptedNode
 		}


### PR DESCRIPTION
## Summary
- Implements optimization idea #1: rewrite the generic fallback loop in `searchLeafColumnarPrefixV2Block` to use a single sequential cursor over key-dir/prefix-dir.
- Removes per-entry calls to `leafColumnarPrefixV2KeyPartsAtFast` from that block fallback hot loop.

## Benchmark Proof
Baseline branch: `origin/main` @ `8a8469f2fe`
PR branch: `codex/pr1-leaf-seq-scan` @ `4f289598ae`

Command (run for `-valsize 85` and `-valsize 1`):
```bash
./bin/unified-bench \
  -dbs treedb \
  -profile fast \
  -keys 500000 \
  -format markdown \
  -checkpoint-between-tests \
  -treedb-force-value-pointers=false \
  -test random_read,random_read_batch \
  -valsize <85|1>
```

Results:

| valsize | metric | main | this PR | delta |
|---|---:|---:|---:|---:|
| 85 | Random Read | 1,659,432 | 1,618,223 | -2.48% |
| 85 | Random Read (Batch) | 1,649,824 | 1,603,999 | -2.78% |
| 1 | Random Read | 2,729,453 | 2,519,030 | -7.71% |
| 1 | Random Read (Batch) | 2,971,514 | 2,990,077 | +0.62% |

## Recommendation
`reject`

Reason: this change does not improve random-read throughput overall and regresses single-read throughput in both tested value sizes.
