### PR TITLE
node: split prefix-v2 leaf search into meta-validated hot paths

### DIFF
--- a/TreeDB/node/leaf.go
+++ b/TreeDB/node/leaf.go
@@ -1683,39 +1683,33 @@ func leafColumnarPrefixV2KeyPartsAtFast(data []byte, count uint16, keysBlobBase 
 	return prefixLen, suffix, nil
 }
 
-func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, target []byte) (uint16, bool, error) {
+func (n *Node) searchLeafColumnarPrefixV2BlockWithMeta(data []byte, count uint16, keysBlobBase int, prefixStart int, blockStart, blockEnd uint16, target []byte) (uint16, bool, error) {
 	if blockStart >= blockEnd {
 		return blockEnd, false, nil
 	}
-	if err := n.leafColumnarPrefixV2EnsureMeta(); err != nil {
-		return 0, false, err
-	}
-	data := n.data
-	count := n.Count()
-	keysBlobBase := n.leafColPrefixKeysBlobBase
-	prefixStart := n.leafColPrefixPrefixStart
 
 	var stackScratch [128]byte
 	restartKeyDirOff := NodeHeaderSize + int(blockStart)*2
-	if restartKeyDirOff+2 > len(data) {
+	keyDirNeeded := NodeHeaderSize + int(blockEnd)*2
+	if blockEnd < count {
+		keyDirNeeded += 2
+	}
+	if restartKeyDirOff < NodeHeaderSize || keyDirNeeded > len(data) {
+		return 0, false, ErrCorruptedNode
+	}
+	prefixDirNeeded := prefixStart + int(blockEnd)*2
+	if prefixStart < NodeHeaderSize || prefixDirNeeded > len(data) {
 		return 0, false, ErrCorruptedNode
 	}
 	restartStart := int(getUint16At(data, restartKeyDirOff))
 	restartEnd := len(data)
 	if blockStart+1 < count {
-		nextKeyOff := restartKeyDirOff + 2
-		if nextKeyOff+2 > len(data) {
-			return 0, false, ErrCorruptedNode
-		}
-		restartEnd = int(getUint16At(data, nextKeyOff))
+		restartEnd = int(getUint16At(data, restartKeyDirOff+2))
 	}
 	if restartStart < keysBlobBase || restartEnd < restartStart || restartEnd > len(data) {
 		return 0, false, ErrCorruptedNode
 	}
 	restartPrefixOff := prefixStart + int(blockStart)*2
-	if restartPrefixOff+2 > len(data) {
-		return 0, false, ErrCorruptedNode
-	}
 	if getUint16At(data, restartPrefixOff) != 0 {
 		return 0, false, ErrCorruptedNode
 	}
@@ -1736,16 +1730,10 @@ func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, targ
 		for idx := blockStart + 1; idx < blockEnd; idx++ {
 			curEnd := len(data)
 			if idx+1 < count {
-				if nextKeyDirOff+2 > len(data) {
-					return 0, false, ErrCorruptedNode
-				}
 				curEnd = int(getUint16At(data, nextKeyDirOff))
 				nextKeyDirOff += 2
 			}
 			if curStart < keysBlobBase || curEnd < curStart || curEnd > len(data) {
-				return 0, false, ErrCorruptedNode
-			}
-			if prefixOff+2 > len(data) {
 				return 0, false, ErrCorruptedNode
 			}
 			prefixLen := int(getUint16At(data, prefixOff))
@@ -1808,19 +1796,12 @@ func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, targ
 	return blockEnd, false, nil
 }
 
-func (n *Node) searchLeafColumnarPrefixV2(key []byte) (uint16, bool, error) {
-	count := n.Count()
+func (n *Node) searchLeafColumnarPrefixV2WithMeta(data []byte, count uint16, keysBlobBase int, prefixStart int, key []byte) (uint16, bool, error) {
 	if count == 0 {
 		return 0, false, nil
 	}
-	if err := n.leafColumnarPrefixV2EnsureMeta(); err != nil {
-		return 0, false, err
-	}
-	data := n.data
-	keysBlobBase := n.leafColPrefixKeysBlobBase
-	prefixStart := n.leafColPrefixPrefixStart
 	if count <= smallSearchThreshold {
-		return n.searchLeafColumnarPrefixV2Block(0, count, key)
+		return n.searchLeafColumnarPrefixV2BlockWithMeta(data, count, keysBlobBase, prefixStart, 0, count, key)
 	}
 
 	interval := leafPrefixRestartInterval
@@ -1862,7 +1843,35 @@ func (n *Node) searchLeafColumnarPrefixV2(key []byte) (uint16, bool, error) {
 		blockEnd = count
 	}
 
-	return n.searchLeafColumnarPrefixV2Block(blockStart, blockEnd, key)
+	return n.searchLeafColumnarPrefixV2BlockWithMeta(data, count, keysBlobBase, prefixStart, blockStart, blockEnd, key)
+}
+
+func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, target []byte) (uint16, bool, error) {
+	if err := n.leafColumnarPrefixV2EnsureMeta(); err != nil {
+		return 0, false, err
+	}
+	return n.searchLeafColumnarPrefixV2BlockWithMeta(
+		n.data,
+		n.Count(),
+		n.leafColPrefixKeysBlobBase,
+		n.leafColPrefixPrefixStart,
+		blockStart,
+		blockEnd,
+		target,
+	)
+}
+
+func (n *Node) searchLeafColumnarPrefixV2(key []byte) (uint16, bool, error) {
+	if err := n.leafColumnarPrefixV2EnsureMeta(); err != nil {
+		return 0, false, err
+	}
+	return n.searchLeafColumnarPrefixV2WithMeta(
+		n.data,
+		n.Count(),
+		n.leafColPrefixKeysBlobBase,
+		n.leafColPrefixPrefixStart,
+		key,
+	)
 }
 
 // AddLeafEntry inserts a new entry into the Leaf Node.


### PR DESCRIPTION
## Summary
- Implements optimization idea #2: split prefix-v2 leaf search into meta-validated helpers so `leafColumnarPrefixV2EnsureMeta` is done once and reused through the search.
- Added `searchLeafColumnarPrefixV2WithMeta` and `searchLeafColumnarPrefixV2BlockWithMeta`.
- Hoisted static key-dir/prefix-dir bounds checks out of inner loops in the block search path.

## Benchmark Proof
Baseline branch: `origin/main` @ `8a8469f2fe`
PR branch: `codex/pr2-leaf-meta-hotpath` @ `59d7fe79bd`

Command (run for `-valsize 85` and `-valsize 1`):
```bash
./bin/unified-bench \
  -dbs treedb \
  -profile fast \
  -keys 500000 \
  -format markdown \
  -checkpoint-between-tests \
  -treedb-force-value-pointers=false \
  -test random_read,random_read_batch \
  -valsize <85|1>
```

Results:

| valsize | metric | main | this PR | delta |
|---|---:|---:|---:|---:|
| 85 | Random Read | 1,659,432 | 1,698,473 | +2.35% |
| 85 | Random Read (Batch) | 1,649,824 | 1,666,537 | +1.01% |
| 1 | Random Read | 2,729,453 | 2,749,741 | +0.74% |
| 1 | Random Read (Batch) | 2,971,514 | 2,713,027 | -8.70% |

Additional rerun for `valsize=1` showed high variance and lower `Random Read (Batch)` throughput, so this path needs more validation before merge.

## Recommendation
`accept with revisions`

Reason: single-read results are neutral-to-positive, but batch-read throughput for `valsize=1` is unstable/regressed and should be addressed or explained before merging.
