### PR TITLE
node: use endian intrinsics for getUint16At/getUint64BEAt

### DIFF
--- a/TreeDB/node/node.go
+++ b/TreeDB/node/node.go
@@ -51,7 +51,7 @@ func getUint16(b []byte) uint16 {
 }
 
 func getUint16At(b []byte, off int) uint16 {
-	return uint16(b[off]) | uint16(b[off+1])<<8
+	return binary.LittleEndian.Uint16(b[off : off+2])
 }
 
 func getUint64LEAt(b []byte, off int) uint64 {
@@ -66,14 +66,7 @@ func getUint64LEAt(b []byte, off int) uint64 {
 }
 
 func getUint64BEAt(b []byte, off int) uint64 {
-	return uint64(b[off])<<56 |
-		uint64(b[off+1])<<48 |
-		uint64(b[off+2])<<40 |
-		uint64(b[off+3])<<32 |
-		uint64(b[off+4])<<24 |
-		uint64(b[off+5])<<16 |
-		uint64(b[off+6])<<8 |
-		uint64(b[off+7])
+	return binary.BigEndian.Uint64(b[off : off+8])
 }
 
 func putUint32(dst []byte, v uint32) {

--- a/TreeDB/node/node_endian_bench_test.go
+++ b/TreeDB/node/node_endian_bench_test.go
@@ -1,0 +1,102 @@
+package node
+
+import (
+	"encoding/binary"
+	"math/bits"
+	"testing"
+	"unsafe"
+)
+
+var (
+	benchSinkU16 uint16
+	benchSinkU64 uint64
+)
+
+func getUint16AtShift(b []byte, off int) uint16 {
+	return uint16(b[off]) | uint16(b[off+1])<<8
+}
+
+func getUint16AtStdlib(b []byte, off int) uint16 {
+	return binary.LittleEndian.Uint16(b[off : off+2])
+}
+
+func getUint16AtUnsafe(b []byte, off int) uint16 {
+	return *(*uint16)(unsafe.Pointer(&b[off]))
+}
+
+func getUint64BEAtShift(b []byte, off int) uint64 {
+	return uint64(b[off])<<56 |
+		uint64(b[off+1])<<48 |
+		uint64(b[off+2])<<40 |
+		uint64(b[off+3])<<32 |
+		uint64(b[off+4])<<24 |
+		uint64(b[off+5])<<16 |
+		uint64(b[off+6])<<8 |
+		uint64(b[off+7])
+}
+
+func getUint64BEAtStdlib(b []byte, off int) uint64 {
+	return binary.BigEndian.Uint64(b[off : off+8])
+}
+
+func getUint64BEAtUnsafe(b []byte, off int) uint64 {
+	return bits.ReverseBytes64(*(*uint64)(unsafe.Pointer(&b[off])))
+}
+
+func benchmarkUint16At(b *testing.B, fn func([]byte, int) uint16) {
+	buf := make([]byte, 8192)
+	for i := range buf {
+		buf[i] = byte(i*31 + 7)
+	}
+	off := 0
+	const maxOff = 8190
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		off += 2
+		if off > maxOff {
+			off = 0
+		}
+		benchSinkU16 = fn(buf, off)
+	}
+}
+
+func benchmarkUint64BEAt(b *testing.B, fn func([]byte, int) uint64) {
+	buf := make([]byte, 8192)
+	for i := range buf {
+		buf[i] = byte(i*17 + 3)
+	}
+	off := 0
+	const maxOff = 8184
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		off += 8
+		if off > maxOff {
+			off = 0
+		}
+		benchSinkU64 = fn(buf, off)
+	}
+}
+
+func BenchmarkGetUint16At_Shift(b *testing.B) {
+	benchmarkUint16At(b, getUint16AtShift)
+}
+
+func BenchmarkGetUint16At_Stdlib(b *testing.B) {
+	benchmarkUint16At(b, getUint16AtStdlib)
+}
+
+func BenchmarkGetUint16At_Unsafe(b *testing.B) {
+	benchmarkUint16At(b, getUint16AtUnsafe)
+}
+
+func BenchmarkGetUint64BEAt_Shift(b *testing.B) {
+	benchmarkUint64BEAt(b, getUint64BEAtShift)
+}
+
+func BenchmarkGetUint64BEAt_Stdlib(b *testing.B) {
+	benchmarkUint64BEAt(b, getUint64BEAtStdlib)
+}
+
+func BenchmarkGetUint64BEAt_Unsafe(b *testing.B) {
+	benchmarkUint64BEAt(b, getUint64BEAtUnsafe)
+}


### PR DESCRIPTION
## Summary
- Implements optimization idea #4 by replacing manual shift/or loads with endian intrinsics in hot helpers:
  - `getUint16At` -> `binary.LittleEndian.Uint16`
  - `getUint64BEAt` -> `binary.BigEndian.Uint64`
- Adds `TreeDB/node/node_endian_bench_test.go` to track shift vs stdlib vs unsafe alternatives.

## Benchmark Proof
Baseline branch: `origin/main` @ `8a8469f2fe`
PR branch: `codex/pr4-endian-load-opt` @ `1dce917f37`

### Microbenchmark (`go test ./TreeDB/node -run '^$' -bench 'BenchmarkGetUint(16At|64BEAt)_(Shift|Stdlib|Unsafe)$' -count=3`)
Representative ns/op (arm64 / Apple M3):

- `BenchmarkGetUint16At_Shift`: ~1.19
- `BenchmarkGetUint16At_Stdlib`: ~1.20 (roughly tied)
- `BenchmarkGetUint16At_Unsafe`: ~1.20 (roughly tied)

- `BenchmarkGetUint64BEAt_Shift`: ~1.67-1.72
- `BenchmarkGetUint64BEAt_Stdlib`: ~1.23-1.25
- `BenchmarkGetUint64BEAt_Unsafe`: ~1.21-1.43 (less stable)

This PR chooses stdlib intrinsics for portability/safety and near-best speed.

### Unified bench (`random_read` + `random_read_batch`)
Command (run for `-valsize 85` and `-valsize 1`):
```bash
./bin/unified-bench \
  -dbs treedb \
  -profile fast \
  -keys 500000 \
  -format markdown \
  -checkpoint-between-tests \
  -treedb-force-value-pointers=false \
  -test random_read,random_read_batch \
  -valsize <85|1>
```

| valsize | metric | main | this PR | delta |
|---|---:|---:|---:|---:|
| 85 | Random Read | 1,659,432 | 1,737,378 | +4.70% |
| 85 | Random Read (Batch) | 1,649,824 | 1,554,326 | -5.79% |
| 1 | Random Read | 2,729,453 | 2,760,467 | +1.14% |
| 1 | Random Read (Batch) | 2,971,514 | 2,717,874 | -8.54% |

## Recommendation
`accept with revisions`

Reason: microbench evidence is strong for the targeted primitives, but unified batch-read throughput is negative in this run and needs additional A/B validation before merge.
