### PR TITLE
node: reduce fallback key reconstruction checks in prefix-v2 leaf search

### DIFF
--- a/TreeDB/node/leaf.go
+++ b/TreeDB/node/leaf.go
@@ -1769,6 +1769,12 @@ func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, targ
 	}
 
 	prevKey := restartKey
+	const (
+		leafKeyBackingPage uint8 = iota
+		leafKeyBackingStack
+		leafKeyBackingHeap
+	)
+	prevBacking := leafKeyBackingPage
 	for idx := blockStart + 1; idx < blockEnd; idx++ {
 		prefixLen, suffix, err := leafColumnarPrefixV2KeyPartsAtFast(data, count, keysBlobBase, prefixStart, idx)
 		if err != nil {
@@ -1785,24 +1791,29 @@ func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, targ
 
 		if prefixLen == 0 {
 			prevKey = suffix
+			prevBacking = leafKeyBackingPage
 			continue
 		}
 
 		keyLen := prefixLen + len(suffix)
 		var cur []byte
+		curBacking := leafKeyBackingStack
 		if keyLen <= len(stackScratch) {
 			cur = stackScratch[:keyLen]
 		} else {
 			cur = n.ensureKeyScratch(keyLen)
+			curBacking = leafKeyBackingHeap
 		}
-		// If prevKey and cur share backing storage, the existing prefix bytes are
-		// already in place and we only need to overwrite the suffix below.
-		sameBacking := len(prevKey) > 0 && len(cur) > 0 && &prevKey[0] == &cur[0]
-		if !sameBacking && prefixLen > 0 {
+		needPrefixCopy := prevBacking != curBacking
+		if !needPrefixCopy && curBacking == leafKeyBackingHeap && len(prevKey) > 0 && len(cur) > 0 {
+			needPrefixCopy = &prevKey[0] != &cur[0]
+		}
+		if needPrefixCopy {
 			copy(cur, prevKey[:prefixLen])
 		}
 		copy(cur[prefixLen:], suffix)
 		prevKey = cur
+		prevBacking = curBacking
 	}
 
 	return blockEnd, false, nil


### PR DESCRIPTION
## Summary
Implements suggestion #1 (reduce fallback reconstruction overhead in leaf search):
- In `searchLeafColumnarPrefixV2Block`, track previous key backing (`page|stack|heap`) and only copy prefix bytes when backing actually changes.
- Removes per-iteration generic pointer-equality checks for the common stack-backed path.

## Benchmark Proof
Baseline: `origin/main` @ `8a8469f2fe`
PR: `codex/pr449-leaf-copyless-fallback` @ `ffb950be8e`

Command (both `-valsize 85` and `-valsize 1`):
```bash
./bin/unified-bench \
  -dbs treedb \
  -profile fast \
  -keys 500000 \
  -format markdown \
  -checkpoint-between-tests \
  -treedb-force-value-pointers=false \
  -test random_read,random_read_batch \
  -valsize <85|1>
```

| valsize | metric | main | this PR | delta |
|---|---:|---:|---:|---:|
| 85 | Random Read | 2,077,679 | 2,094,719 | +0.82% |
| 85 | Random Read (Batch) | 2,013,804 | 1,983,467 | -1.51% |
| 1 | Random Read | 2,919,136 | 2,854,796 | -2.20% |
| 1 | Random Read (Batch) | 3,135,828 | 2,789,260 | -11.05% |

## Recommendation
`reject`

Reason: small single-read gain at `valsize=85`, but regressions in the other three read metrics (especially batch at `valsize=1`).
