### PR TITLE
node: tighten internal SearchInternalChildID bounds checks

### DIFF
--- a/TreeDB/node/internal.go
+++ b/TreeDB/node/internal.go
@@ -561,6 +561,11 @@ func (n *Node) SearchInternalChildID(key []byte) (childID uint64, found bool, er
 	}
 	data := n.data
 	deltaWidth, entryHeader := n.internalBaseDeltaEntryWidths()
+	footerStart := meta.footerStart
+	entryLimit := footerStart - entryHeader
+	if entryLimit < NodeHeaderSize {
+		return 0, false, ErrCorruptedNode
+	}
 	keySuffix := key
 	if len(meta.prefix) > 0 {
 		prefixLen := len(meta.prefix)
@@ -611,13 +616,13 @@ func (n *Node) SearchInternalChildID(key []byte) (childID uint64, found bool, er
 		for i := 0; i < int(count); i++ {
 			offset := getUint16At(data, NodeHeaderSize+i*2)
 			ptr := int(offset)
-			if ptr < NodeHeaderSize || ptr+entryHeader > meta.footerStart {
+			if ptr < NodeHeaderSize || ptr > entryLimit {
 				return 0, false, ErrCorruptedNode
 			}
 			suffixLen := int(getUint16At(data, ptr))
 			suffixStart := ptr + entryHeader
 			suffixEnd := suffixStart + suffixLen
-			if suffixLen < 0 || suffixEnd > meta.footerStart {
+			if suffixEnd > footerStart {
 				return 0, false, ErrCorruptedNode
 			}
 
@@ -682,13 +687,13 @@ func (n *Node) SearchInternalChildID(key []byte) (childID uint64, found bool, er
 		h := int(uint(i+j) >> 1)
 		offset := getUint16At(data, NodeHeaderSize+h*2)
 		ptr := int(offset)
-		if ptr < NodeHeaderSize || ptr+entryHeader > meta.footerStart {
+		if ptr < NodeHeaderSize || ptr > entryLimit {
 			return 0, false, ErrCorruptedNode
 		}
 		suffixLen := int(getUint16At(data, ptr))
 		suffixStart := ptr + entryHeader
 		suffixEnd := suffixStart + suffixLen
-		if suffixLen < 0 || suffixEnd > meta.footerStart {
+		if suffixEnd > footerStart {
 			return 0, false, ErrCorruptedNode
 		}
 


### PR DESCRIPTION
## Summary
Implements suggestion #3 (internal search loop tightening):
- Hoists `footerStart`/`entryLimit` locals in `SearchInternalChildID`.
- Removes impossible negative-length checks from u16-decoded suffix lengths.
- Keeps corruption guards intact while reducing branch work in hot loops.

## Benchmark Proof
Baseline: `origin/main` @ `8a8469f2fe`
PR: `codex/pr451-internal-tight-checks` @ `62344f4190`

Command (both `-valsize 85` and `-valsize 1`):
```bash
./bin/unified-bench \
  -dbs treedb \
  -profile fast \
  -keys 500000 \
  -format markdown \
  -checkpoint-between-tests \
  -treedb-force-value-pointers=false \
  -test random_read,random_read_batch \
  -valsize <85|1>
```

Primary run:

| valsize | metric | main | this PR | delta |
|---|---:|---:|---:|---:|
| 85 | Random Read | 2,077,679 | 1,592,636 | -23.35% |
| 85 | Random Read (Batch) | 2,013,804 | 1,685,524 | -16.30% |
| 1 | Random Read | 2,919,136 | 2,702,237 | -7.43% |
| 1 | Random Read (Batch) | 3,135,828 | 2,986,643 | -4.76% |

Rerun (`valsize=85`) still below baseline:
- Random Read: `1,677,357`
- Random Read (Batch): `1,714,893`

## Recommendation
`reject`

Reason: throughput regresses across all measured read metrics.
