### PR TITLE
node: cache prefix-v2 leaf metadata once per search

### DIFF
--- a/TreeDB/node/leaf.go
+++ b/TreeDB/node/leaf.go
@@ -1683,39 +1683,33 @@ func leafColumnarPrefixV2KeyPartsAtFast(data []byte, count uint16, keysBlobBase 
 	return prefixLen, suffix, nil
 }
 
-func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, target []byte) (uint16, bool, error) {
+func (n *Node) searchLeafColumnarPrefixV2BlockWithMeta(data []byte, count uint16, keysBlobBase int, prefixStart int, blockStart, blockEnd uint16, target []byte) (uint16, bool, error) {
 	if blockStart >= blockEnd {
 		return blockEnd, false, nil
 	}
-	if err := n.leafColumnarPrefixV2EnsureMeta(); err != nil {
-		return 0, false, err
-	}
-	data := n.data
-	count := n.Count()
-	keysBlobBase := n.leafColPrefixKeysBlobBase
-	prefixStart := n.leafColPrefixPrefixStart
 
 	var stackScratch [128]byte
 	restartKeyDirOff := NodeHeaderSize + int(blockStart)*2
-	if restartKeyDirOff+2 > len(data) {
+	keyDirNeeded := NodeHeaderSize + int(blockEnd)*2
+	if blockEnd < count {
+		keyDirNeeded += 2
+	}
+	if restartKeyDirOff < NodeHeaderSize || keyDirNeeded > len(data) {
+		return 0, false, ErrCorruptedNode
+	}
+	prefixDirNeeded := prefixStart + int(blockEnd)*2
+	if prefixStart < NodeHeaderSize || prefixDirNeeded > len(data) {
 		return 0, false, ErrCorruptedNode
 	}
 	restartStart := int(getUint16At(data, restartKeyDirOff))
 	restartEnd := len(data)
 	if blockStart+1 < count {
-		nextKeyOff := restartKeyDirOff + 2
-		if nextKeyOff+2 > len(data) {
-			return 0, false, ErrCorruptedNode
-		}
-		restartEnd = int(getUint16At(data, nextKeyOff))
+		restartEnd = int(getUint16At(data, restartKeyDirOff+2))
 	}
 	if restartStart < keysBlobBase || restartEnd < restartStart || restartEnd > len(data) {
 		return 0, false, ErrCorruptedNode
 	}
 	restartPrefixOff := prefixStart + int(blockStart)*2
-	if restartPrefixOff+2 > len(data) {
-		return 0, false, ErrCorruptedNode
-	}
 	if getUint16At(data, restartPrefixOff) != 0 {
 		return 0, false, ErrCorruptedNode
 	}
@@ -1736,16 +1730,10 @@ func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, targ
 		for idx := blockStart + 1; idx < blockEnd; idx++ {
 			curEnd := len(data)
 			if idx+1 < count {
-				if nextKeyDirOff+2 > len(data) {
-					return 0, false, ErrCorruptedNode
-				}
 				curEnd = int(getUint16At(data, nextKeyDirOff))
 				nextKeyDirOff += 2
 			}
 			if curStart < keysBlobBase || curEnd < curStart || curEnd > len(data) {
-				return 0, false, ErrCorruptedNode
-			}
-			if prefixOff+2 > len(data) {
 				return 0, false, ErrCorruptedNode
 			}
 			prefixLen := int(getUint16At(data, prefixOff))
@@ -1808,19 +1796,20 @@ func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, targ
 	return blockEnd, false, nil
 }
 
-func (n *Node) searchLeafColumnarPrefixV2(key []byte) (uint16, bool, error) {
-	count := n.Count()
+func (n *Node) searchLeafColumnarPrefixV2WithMeta(data []byte, count uint16, keysBlobBase int, prefixStart int, key []byte) (uint16, bool, error) {
 	if count == 0 {
 		return 0, false, nil
 	}
-	if err := n.leafColumnarPrefixV2EnsureMeta(); err != nil {
-		return 0, false, err
+	keyDirEnd := NodeHeaderSize + int(count)*2
+	if keyDirEnd > len(data) {
+		return 0, false, ErrCorruptedNode
 	}
-	data := n.data
-	keysBlobBase := n.leafColPrefixKeysBlobBase
-	prefixStart := n.leafColPrefixPrefixStart
+	prefixDirEnd := prefixStart + int(count)*2
+	if prefixStart < NodeHeaderSize || prefixDirEnd > len(data) {
+		return 0, false, ErrCorruptedNode
+	}
 	if count <= smallSearchThreshold {
-		return n.searchLeafColumnarPrefixV2Block(0, count, key)
+		return n.searchLeafColumnarPrefixV2BlockWithMeta(data, count, keysBlobBase, prefixStart, 0, count, key)
 	}
 
 	interval := leafPrefixRestartInterval
@@ -1838,13 +1827,20 @@ func (n *Node) searchLeafColumnarPrefixV2(key []byte) (uint16, bool, error) {
 			hi = mid
 			continue
 		}
-		restartPrefixLen, k, err := leafColumnarPrefixV2KeyPartsAtFast(data, count, keysBlobBase, prefixStart, idx)
-		if err != nil {
-			return 0, false, err
+		keyOff := NodeHeaderSize + int(idx)*2
+		keyStart := int(getUint16At(data, keyOff))
+		keyEnd := len(data)
+		if idx+1 < count {
+			keyEnd = int(getUint16At(data, keyOff+2))
 		}
+		if keyStart < keysBlobBase || keyEnd < keyStart || keyEnd > len(data) {
+			return 0, false, ErrCorruptedNode
+		}
+		restartPrefixLen := int(getUint16At(data, prefixStart+int(idx)*2))
 		if restartPrefixLen != 0 {
 			return 0, false, ErrCorruptedNode
 		}
+		k := data[keyStart:keyEnd]
 		if compareLeafKey(k, key) <= 0 {
 			lo = mid + 1
 		} else {
@@ -1862,7 +1858,35 @@ func (n *Node) searchLeafColumnarPrefixV2(key []byte) (uint16, bool, error) {
 		blockEnd = count
 	}
 
-	return n.searchLeafColumnarPrefixV2Block(blockStart, blockEnd, key)
+	return n.searchLeafColumnarPrefixV2BlockWithMeta(data, count, keysBlobBase, prefixStart, blockStart, blockEnd, key)
+}
+
+func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, target []byte) (uint16, bool, error) {
+	if err := n.leafColumnarPrefixV2EnsureMeta(); err != nil {
+		return 0, false, err
+	}
+	return n.searchLeafColumnarPrefixV2BlockWithMeta(
+		n.data,
+		n.Count(),
+		n.leafColPrefixKeysBlobBase,
+		n.leafColPrefixPrefixStart,
+		blockStart,
+		blockEnd,
+		target,
+	)
+}
+
+func (n *Node) searchLeafColumnarPrefixV2(key []byte) (uint16, bool, error) {
+	if err := n.leafColumnarPrefixV2EnsureMeta(); err != nil {
+		return 0, false, err
+	}
+	return n.searchLeafColumnarPrefixV2WithMeta(
+		n.data,
+		n.Count(),
+		n.leafColPrefixKeysBlobBase,
+		n.leafColPrefixPrefixStart,
+		key,
+	)
 }
 
 // AddLeafEntry inserts a new entry into the Leaf Node.


### PR DESCRIPTION
## Summary
Implements suggestion #4 (cache restart/block metadata once per search):
- Adds `searchLeafColumnarPrefixV2WithMeta` and `searchLeafColumnarPrefixV2BlockWithMeta` to avoid re-reading metadata and re-running setup across nested calls.
- Pre-validates key/prefix directory windows once for the active search range.
- Inlines restart-key reads in the restart binary-search loop to avoid repeated helper call overhead.

## Benchmark Proof
Baseline: `origin/main` @ `8a8469f2fe`
PR: `codex/pr452-leaf-meta-cache` @ `a668d588da`

Command (both `-valsize 85` and `-valsize 1`):
```bash
./bin/unified-bench \
  -dbs treedb \
  -profile fast \
  -keys 500000 \
  -format markdown \
  -checkpoint-between-tests \
  -treedb-force-value-pointers=false \
  -test random_read,random_read_batch \
  -valsize <85|1>
```

Primary run:

| valsize | metric | main | this PR | delta |
|---|---:|---:|---:|---:|
| 85 | Random Read | 2,077,679 | 1,837,244 | -11.57% |
| 85 | Random Read (Batch) | 2,013,804 | 1,854,782 | -7.90% |
| 1 | Random Read | 2,919,136 | 2,720,380 | -6.81% |
| 1 | Random Read (Batch) | 3,135,828 | 2,448,819 | -21.91% |

Rerun (`valsize=85`) remained below baseline:
- Random Read: `1,562,523`
- Random Read (Batch): `1,669,467`

## Recommendation
`reject`

Reason: consistent throughput regressions in this benchmark profile.
