### PR TITLE
node: document int offset contract in value meta path

### DIFF
--- a/TreeDB/node/leaf.go
+++ b/TreeDB/node/leaf.go
@@ -1073,6 +1073,9 @@ func (n *Node) leafColumnarPrefixV2KeyMetaAt(index uint16) (prefixLen int, suffi
 	return prefixLen, suffix, flags, nil
 }
 
+// leafColumnarPrefixV2ValueMetaAt returns int offsets intentionally: callers
+// immediately use valStart/valEnd for slice indexing and len(int)-based bounds
+// checks, so keeping these as int avoids extra casts at call sites.
 func (n *Node) leafColumnarPrefixV2ValueMetaAt(index uint16) (flags byte, valStart int, valEnd int, err error) {
 	count := n.Count()
 	if index >= count {


### PR DESCRIPTION
## Summary
Implements suggestion #5 by codifying the offset-type decision:
- Documents in `leafColumnarPrefixV2ValueMetaAt` that `valStart`/`valEnd` are intentionally `int`, because downstream consumers use them for slice indexes and `len(int)` bounds checks.

## Benchmark Proof
Baseline: `origin/main` @ `8a8469f2fe`
PR: `codex/pr453-keep-int-offsets` @ `c60ebba2e2`

Command (both `-valsize 85` and `-valsize 1`):
```bash
./bin/unified-bench \
  -dbs treedb \
  -profile fast \
  -keys 500000 \
  -format markdown \
  -checkpoint-between-tests \
  -treedb-force-value-pointers=false \
  -test random_read,random_read_batch \
  -valsize <85|1>
```

| valsize | metric | main | this PR | delta |
|---|---:|---:|---:|---:|
| 85 | Random Read | 2,077,679 | 1,653,695 | -20.41% |
| 85 | Random Read (Batch) | 2,013,804 | 1,698,244 | -15.67% |
| 1 | Random Read | 2,919,136 | 2,599,264 | -10.96% |
| 1 | Random Read (Batch) | 3,135,828 | 2,984,290 | -4.83% |

## Recommendation
`approve with revisions`

Reason: this PR is a documentation/contract clarification for type choice and does not change runtime behavior. Throughput deltas here reflect benchmark variance rather than a code-path change; if desired, compare against a same-session main control run.
