### PR TITLE
node: defer base-delta child decode in small internal search (PR-A)

### DIFF
--- a/TreeDB/node/internal.go
+++ b/TreeDB/node/internal.go
@@ -596,7 +596,7 @@ func (n *Node) SearchInternalChildID(key []byte) (childID uint64, found bool, er
 
 	if count <= smallSearchThreshold {
 		last := -1
-		lastChildID := uint64(0)
+		lastPtr := -1
 		switch keySuffixLen {
 		case 1:
 			keyByte := keySuffix[0]
@@ -626,11 +626,7 @@ func (n *Node) SearchInternalChildID(key []byte) (childID uint64, found bool, er
 				}
 				if cmp <= 0 {
 					last = i
-					childID, err := n.internalBaseDeltaChildIDAtPtr(meta, ptr, deltaWidth, entryHeader)
-					if err != nil {
-						return 0, false, err
-					}
-					lastChildID = childID
+					lastPtr = ptr
 					continue
 				}
 				break
@@ -663,11 +659,7 @@ func (n *Node) SearchInternalChildID(key []byte) (childID uint64, found bool, er
 				}
 				if cmp <= 0 {
 					last = i
-					childID, err := n.internalBaseDeltaChildIDAtPtr(meta, ptr, deltaWidth, entryHeader)
-					if err != nil {
-						return 0, false, err
-					}
-					lastChildID = childID
+					lastPtr = ptr
 					continue
 				}
 				break
@@ -700,11 +692,7 @@ func (n *Node) SearchInternalChildID(key []byte) (childID uint64, found bool, er
 				}
 				if cmp <= 0 {
 					last = i
-					childID, err := n.internalBaseDeltaChildIDAtPtr(meta, ptr, deltaWidth, entryHeader)
-					if err != nil {
-						return 0, false, err
-					}
-					lastChildID = childID
+					lastPtr = ptr
 					continue
 				}
 				break
@@ -737,11 +725,7 @@ func (n *Node) SearchInternalChildID(key []byte) (childID uint64, found bool, er
 				}
 				if cmp <= 0 {
 					last = i
-					childID, err := n.internalBaseDeltaChildIDAtPtr(meta, ptr, deltaWidth, entryHeader)
-					if err != nil {
-						return 0, false, err
-					}
-					lastChildID = childID
+					lastPtr = ptr
 					continue
 				}
 				break
@@ -763,18 +747,15 @@ func (n *Node) SearchInternalChildID(key []byte) (childID uint64, found bool, er
 				cmp := bytes.Compare(data[suffixStart:suffixEnd], keySuffix)
 				if cmp <= 0 {
 					last = i
-					childID, err := n.internalBaseDeltaChildIDAtPtr(meta, ptr, deltaWidth, entryHeader)
-					if err != nil {
-						return 0, false, err
-					}
-					lastChildID = childID
+					lastPtr = ptr
 					continue
 				}
 				break
 			}
 		}
 		if last >= 0 {
-			return lastChildID, true, nil
+			childID, err := n.internalBaseDeltaChildIDAtPtr(meta, lastPtr, deltaWidth, entryHeader)
+			return childID, true, err
 		}
 		childID, err := n.internalBaseDeltaChildIDAtIndex(meta, 0, deltaWidth, entryHeader)
 		return childID, false, err


### PR DESCRIPTION
## Summary
PR-A: Internal traversal view simplification (`SearchInternalChildID` small-search path).

## What Changed
- Hoisted child ID decode out of the small-loop hit path by tracking `lastPtr` and decoding once at return.

## Read Gate Evidence
Command:
`./bin/unified-bench -dbs treedb -profile fast -keys 500000 -format markdown -checkpoint-between-tests -treedb-force-value-pointers=false -test random_read,random_read_batch -seed 1 -progress=false -valsize {85,1}`

Interleaved A/B with bootstrap CI95:
- valsize=85 (n=5/side)
  - RR: `+0.20%`, CI95 `[-2.53, +1.23]` (neutral)
  - RR Batch: `-0.24%`, CI95 `[-2.17, +0.00]` (neutral)
- valsize=1 (n=25/side)
  - RR: `+3.01%`, CI95 `[+0.52, +2.32]` (uncertain under +1% lower-bound rule)
  - RR Batch: `+2.09%`, CI95 `[-4.54, +1.92]` (uncertain)

Microbench (`GOMAXPROCS=1`, `-count=20`):
- `BenchmarkSearchInternal_BaseDelta_FixedBE8`: `+1.33%` slower
- `BenchmarkSearchInternalChildID_BaseDelta_FixedBE8`: `+1.77%` slower

## Recommendation
`reject`

Rationale: targeted microbench regressions and no clear read-gate improvement with confidence.
