### PR TITLE
node: hoist prefix-v2 leaf block scan invariants (PR-B)

### DIFF
--- a/TreeDB/node/leaf.go
+++ b/TreeDB/node/leaf.go
@@ -1689,24 +1689,26 @@ func (n *Node) searchLeafColumnarPrefixV2BlockWithMeta(data []byte, count uint16
 	}
 
 	var stackScratch [128]byte
+	dataLen := len(data)
+	hasTailDir := blockEnd < count
 	restartKeyDirOff := NodeHeaderSize + int(blockStart)*2
 	keyDirNeeded := NodeHeaderSize + int(blockEnd)*2
-	if blockEnd < count {
+	if hasTailDir {
 		keyDirNeeded += 2
 	}
-	if restartKeyDirOff < NodeHeaderSize || keyDirNeeded > len(data) {
+	if restartKeyDirOff < NodeHeaderSize || keyDirNeeded > dataLen {
 		return 0, false, ErrCorruptedNode
 	}
 	prefixDirNeeded := prefixStart + int(blockEnd)*2
-	if prefixStart < NodeHeaderSize || prefixDirNeeded > len(data) {
+	if prefixStart < NodeHeaderSize || prefixDirNeeded > dataLen {
 		return 0, false, ErrCorruptedNode
 	}
 	restartStart := int(getUint16At(data, restartKeyDirOff))
-	restartEnd := len(data)
+	restartEnd := dataLen
 	if blockStart+1 < count {
 		restartEnd = int(getUint16At(data, restartKeyDirOff+2))
 	}
-	if restartStart < keysBlobBase || restartEnd < restartStart || restartEnd > len(data) {
+	if restartStart < keysBlobBase || restartEnd < restartStart || restartEnd > dataLen {
 		return 0, false, ErrCorruptedNode
 	}
 	restartPrefixOff := prefixStart + int(blockStart)*2
@@ -1727,28 +1729,52 @@ func (n *Node) searchLeafColumnarPrefixV2BlockWithMeta(data []byte, count uint16
 		nextKeyDirOff := restartKeyDirOff + 4
 		prefixOff := prefixStart + int(blockStart+1)*2
 
-		for idx := blockStart + 1; idx < blockEnd; idx++ {
-			curEnd := len(data)
-			if idx+1 < count {
-				curEnd = int(getUint16At(data, nextKeyDirOff))
+		if hasTailDir {
+			for idx := blockStart + 1; idx < blockEnd; idx++ {
+				curEnd := int(getUint16At(data, nextKeyDirOff))
 				nextKeyDirOff += 2
-			}
-			if curStart < keysBlobBase || curEnd < curStart || curEnd > len(data) {
-				return 0, false, ErrCorruptedNode
-			}
-			prefixLen := int(getUint16At(data, prefixOff))
-			prefixOff += 2
+				if curEnd < curStart || curEnd > dataLen {
+					return 0, false, ErrCorruptedNode
+				}
+				prefixLen := int(getUint16At(data, prefixOff))
+				prefixOff += 2
 
-			suffix := data[curStart:curEnd]
-			nextU, ok := composePrefixVirtualKeyU64(prevU, prefixLen, suffix)
-			if !ok {
-				fastOK = false
-				break
+				suffix := data[curStart:curEnd]
+				nextU, ok := composePrefixVirtualKeyU64(prevU, prefixLen, suffix)
+				if !ok {
+					fastOK = false
+					break
+				}
+				prevU = nextU
+				curStart = curEnd
+				if prevU >= targetU {
+					return idx, prevU == targetU, nil
+				}
 			}
-			prevU = nextU
-			curStart = curEnd
-			if prevU >= targetU {
-				return idx, prevU == targetU, nil
+		} else {
+			for idx := blockStart + 1; idx < blockEnd; idx++ {
+				curEnd := dataLen
+				if idx+1 < count {
+					curEnd = int(getUint16At(data, nextKeyDirOff))
+					nextKeyDirOff += 2
+				}
+				if curEnd < curStart || curEnd > dataLen {
+					return 0, false, ErrCorruptedNode
+				}
+				prefixLen := int(getUint16At(data, prefixOff))
+				prefixOff += 2
+
+				suffix := data[curStart:curEnd]
+				nextU, ok := composePrefixVirtualKeyU64(prevU, prefixLen, suffix)
+				if !ok {
+					fastOK = false
+					break
+				}
+				prevU = nextU
+				curStart = curEnd
+				if prevU >= targetU {
+					return idx, prevU == targetU, nil
+				}
 			}
 		}
 		if fastOK {
@@ -1760,55 +1786,93 @@ func (n *Node) searchLeafColumnarPrefixV2BlockWithMeta(data []byte, count uint16
 	curStart := restartEnd
 	nextKeyDirOff := restartKeyDirOff + 4
 	prefixOff := prefixStart + int(blockStart+1)*2
-	for idx := blockStart + 1; idx < blockEnd; idx++ {
-		curEnd := len(data)
-		if idx+1 < count {
-			if nextKeyDirOff+2 > len(data) {
+	if hasTailDir {
+		for idx := blockStart + 1; idx < blockEnd; idx++ {
+			curEnd := int(getUint16At(data, nextKeyDirOff))
+			nextKeyDirOff += 2
+			if curEnd < curStart || curEnd > dataLen {
 				return 0, false, ErrCorruptedNode
 			}
-			curEnd = int(getUint16At(data, nextKeyDirOff))
-			nextKeyDirOff += 2
-		}
-		if curStart < keysBlobBase || curEnd < curStart || curEnd > len(data) {
-			return 0, false, ErrCorruptedNode
-		}
-		if prefixOff+2 > len(data) {
-			return 0, false, ErrCorruptedNode
-		}
-		prefixLen := int(getUint16At(data, prefixOff))
-		prefixOff += 2
-		suffix := data[curStart:curEnd]
-		curStart = curEnd
+			prefixLen := int(getUint16At(data, prefixOff))
+			prefixOff += 2
+			suffix := data[curStart:curEnd]
+			curStart = curEnd
 
-		if prefixLen > len(prevKey) {
-			return 0, false, ErrCorruptedNode
-		}
+			if prefixLen > len(prevKey) {
+				return 0, false, ErrCorruptedNode
+			}
 
-		cmp = compareLeafPrefixVirtualKey(prevKey, prefixLen, suffix, target)
-		if cmp >= 0 {
-			return idx, cmp == 0, nil
-		}
+			cmp = compareLeafPrefixVirtualKey(prevKey, prefixLen, suffix, target)
+			if cmp >= 0 {
+				return idx, cmp == 0, nil
+			}
 
-		if prefixLen == 0 {
-			prevKey = suffix
-			continue
-		}
+			if prefixLen == 0 {
+				prevKey = suffix
+				continue
+			}
 
-		keyLen := prefixLen + len(suffix)
-		var cur []byte
-		if keyLen <= len(stackScratch) {
-			cur = stackScratch[:keyLen]
-		} else {
-			cur = n.ensureKeyScratch(keyLen)
+			keyLen := prefixLen + len(suffix)
+			var cur []byte
+			if keyLen <= len(stackScratch) {
+				cur = stackScratch[:keyLen]
+			} else {
+				cur = n.ensureKeyScratch(keyLen)
+			}
+			// If prevKey and cur share backing storage, the existing prefix bytes are
+			// already in place and we only need to overwrite the suffix below.
+			sameBacking := len(prevKey) > 0 && len(cur) > 0 && &prevKey[0] == &cur[0]
+			if !sameBacking && prefixLen > 0 {
+				copy(cur, prevKey[:prefixLen])
+			}
+			copy(cur[prefixLen:], suffix)
+			prevKey = cur
 		}
-		// If prevKey and cur share backing storage, the existing prefix bytes are
-		// already in place and we only need to overwrite the suffix below.
-		sameBacking := len(prevKey) > 0 && len(cur) > 0 && &prevKey[0] == &cur[0]
-		if !sameBacking && prefixLen > 0 {
-			copy(cur, prevKey[:prefixLen])
+	} else {
+		for idx := blockStart + 1; idx < blockEnd; idx++ {
+			curEnd := dataLen
+			if idx+1 < count {
+				curEnd = int(getUint16At(data, nextKeyDirOff))
+				nextKeyDirOff += 2
+			}
+			if curEnd < curStart || curEnd > dataLen {
+				return 0, false, ErrCorruptedNode
+			}
+			prefixLen := int(getUint16At(data, prefixOff))
+			prefixOff += 2
+			suffix := data[curStart:curEnd]
+			curStart = curEnd
+
+			if prefixLen > len(prevKey) {
+				return 0, false, ErrCorruptedNode
+			}
+
+			cmp = compareLeafPrefixVirtualKey(prevKey, prefixLen, suffix, target)
+			if cmp >= 0 {
+				return idx, cmp == 0, nil
+			}
+
+			if prefixLen == 0 {
+				prevKey = suffix
+				continue
+			}
+
+			keyLen := prefixLen + len(suffix)
+			var cur []byte
+			if keyLen <= len(stackScratch) {
+				cur = stackScratch[:keyLen]
+			} else {
+				cur = n.ensureKeyScratch(keyLen)
+			}
+			// If prevKey and cur share backing storage, the existing prefix bytes are
+			// already in place and we only need to overwrite the suffix below.
+			sameBacking := len(prevKey) > 0 && len(cur) > 0 && &prevKey[0] == &cur[0]
+			if !sameBacking && prefixLen > 0 {
+				copy(cur, prevKey[:prefixLen])
+			}
+			copy(cur[prefixLen:], suffix)
+			prevKey = cur
 		}
-		copy(cur[prefixLen:], suffix)
-		prevKey = cur
 	}
 
 	return blockEnd, false, nil

--- a/TreeDB/node/leaf_columnar_prefix_search_test.go
+++ b/TreeDB/node/leaf_columnar_prefix_search_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"bytes"
+	"encoding/binary"
 	"math/rand"
 	"testing"
 
@@ -178,4 +179,59 @@ func BenchmarkSearchLeaf_ColumnarPrefixV2(b *testing.B) {
 		LeafPrefixCompression: true,
 		LeafColumnar:          true,
 	})
+}
+
+func benchmarkSearchLeafColumnarPrefixV2FixedBE8(b *testing.B, misses bool) {
+	data := make([]byte, page.PageSize)
+	builder := NewBuilderWithOptions(data, page.PageTypeLeaf, BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+	})
+	builder.SetPageID(1)
+
+	inserted := 0
+	for i := 0; ; i++ {
+		var k [8]byte
+		// Use even keys only so odd keys become deterministic misses.
+		binary.BigEndian.PutUint64(k[:], uint64(i*2))
+		if err := builder.AddLeafEntry(k[:], []byte{0x01}, FlagInline, page.ValuePtr{}); err != nil {
+			if err == ErrNodeFull {
+				break
+			}
+			b.Fatalf("AddLeafEntry: %v", err)
+		}
+		inserted++
+	}
+	if inserted == 0 {
+		b.Fatalf("expected at least one key")
+	}
+	n := builder.Finish()
+
+	queries := make([][]byte, inserted)
+	for i := 0; i < inserted; i++ {
+		var k [8]byte
+		if misses {
+			binary.BigEndian.PutUint64(k[:], uint64(i*2+1))
+		} else {
+			binary.BigEndian.PutUint64(k[:], uint64(i*2))
+		}
+		queries[i] = append([]byte(nil), k[:]...)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := queries[i%len(queries)]
+		if _, _, err := n.SearchLeaf(q); err != nil {
+			b.Fatalf("SearchLeaf: %v", err)
+		}
+	}
+}
+
+func BenchmarkSearchLeaf_ColumnarPrefixV2_FixedBE8_Hit(b *testing.B) {
+	benchmarkSearchLeafColumnarPrefixV2FixedBE8(b, false)
+}
+
+func BenchmarkSearchLeaf_ColumnarPrefixV2_FixedBE8_Miss(b *testing.B) {
+	benchmarkSearchLeafColumnarPrefixV2FixedBE8(b, true)
 }


### PR DESCRIPTION
## Summary
PR-B: Prefix-v2 leaf block scan check-hoist in `TreeDB/node/leaf.go`.

## What Changed
- Hoisted repeated per-iteration bounds/check logic in `searchLeafColumnarPrefixV2BlockWithMeta`.
- Split hot loops into tail/non-tail variants to reduce repeated branch checks.
- Added permanent BE8 sensitivity benches:
  - `BenchmarkSearchLeaf_ColumnarPrefixV2_FixedBE8_Hit`
  - `BenchmarkSearchLeaf_ColumnarPrefixV2_FixedBE8_Miss`

## Read Gate Evidence
Command:
`./bin/unified-bench -dbs treedb -profile fast -keys 500000 -format markdown -checkpoint-between-tests -treedb-force-value-pointers=false -test random_read,random_read_batch -seed 1 -progress=false -valsize {85,1}`

Interleaved A/B with bootstrap CI95:
- valsize=85 (n=5/side)
  - RR: `-0.56%`, CI95 `[-1.61, +0.37]` (neutral)
  - RR Batch: `+0.83%`, CI95 `[-0.95, +3.02]` (neutral)
- valsize=1 (n=25/side)
  - RR: `+1.69%`, CI95 `[+0.58, +4.39]` (uncertain under +1% lower-bound rule)
  - RR Batch: `-0.46%`, CI95 `[-0.15, +1.76]` (neutral)

Microbench (`GOMAXPROCS=1`, `-count=20`):
- `BenchmarkSearchLeaf_ColumnarPrefixV2`: `-4.65%` (faster)

## Recommendation
`reject`

Rationale: clear microbench gain but no statistically defensible unified read gain under the gate criteria.
