### PR TITLE
node: specialize fixed-width compare paths in leaf/internal search (PR-C)

### DIFF
--- a/TreeDB/node/internal.go
+++ b/TreeDB/node/internal.go
@@ -98,6 +98,38 @@ func comparePrefixedKey(prefix, suffix, key []byte) int {
 }
 
 func compareInternalSuffix(suffix, keySuffix []byte) int {
+	if len(suffix) == len(keySuffix) {
+		switch len(suffix) {
+		case 8:
+			a := binary.BigEndian.Uint64(suffix)
+			b := binary.BigEndian.Uint64(keySuffix)
+			if a < b {
+				return -1
+			}
+			if a > b {
+				return 1
+			}
+			return 0
+		case 16:
+			aHi := binary.BigEndian.Uint64(suffix[:8])
+			bHi := binary.BigEndian.Uint64(keySuffix[:8])
+			if aHi < bHi {
+				return -1
+			}
+			if aHi > bHi {
+				return 1
+			}
+			aLo := binary.BigEndian.Uint64(suffix[8:])
+			bLo := binary.BigEndian.Uint64(keySuffix[8:])
+			if aLo < bLo {
+				return -1
+			}
+			if aLo > bLo {
+				return 1
+			}
+			return 0
+		}
+	}
 	return bytes.Compare(suffix, keySuffix)
 }
 
@@ -141,6 +173,24 @@ func compareInternalSuffixAt(data []byte, suffixStart int, suffixLen int, keySuf
 				return -1
 			}
 			if a > b {
+				return 1
+			}
+			return 0
+		case 16:
+			aHi := binary.BigEndian.Uint64(data[suffixStart : suffixStart+8])
+			bHi := binary.BigEndian.Uint64(keySuffix[:8])
+			if aHi < bHi {
+				return -1
+			}
+			if aHi > bHi {
+				return 1
+			}
+			aLo := binary.BigEndian.Uint64(data[suffixStart+8 : suffixStart+16])
+			bLo := binary.BigEndian.Uint64(keySuffix[8:])
+			if aLo < bLo {
+				return -1
+			}
+			if aLo > bLo {
 				return 1
 			}
 			return 0
@@ -746,6 +796,51 @@ func (n *Node) SearchInternalChildID(key []byte) (childID uint64, found bool, er
 				}
 				break
 			}
+		case 16:
+			keyHi := binary.BigEndian.Uint64(keySuffix[:8])
+			keyLo := binary.BigEndian.Uint64(keySuffix[8:])
+			for i := 0; i < int(count); i++ {
+				offset := getUint16At(data, NodeHeaderSize+i*2)
+				ptr := int(offset)
+				if ptr < NodeHeaderSize || ptr+entryHeader > meta.footerStart {
+					return 0, false, ErrCorruptedNode
+				}
+				suffixLen := int(getUint16At(data, ptr))
+				suffixStart := ptr + entryHeader
+				suffixEnd := suffixStart + suffixLen
+				if suffixLen < 0 || suffixEnd > meta.footerStart {
+					return 0, false, ErrCorruptedNode
+				}
+
+				var cmp int
+				if suffixLen == 16 {
+					aHi := getUint64BEAt(data, suffixStart)
+					if aHi < keyHi {
+						cmp = -1
+					} else if aHi > keyHi {
+						cmp = 1
+					} else {
+						aLo := getUint64BEAt(data, suffixStart+8)
+						if aLo < keyLo {
+							cmp = -1
+						} else if aLo > keyLo {
+							cmp = 1
+						}
+					}
+				} else {
+					cmp = bytes.Compare(data[suffixStart:suffixEnd], keySuffix)
+				}
+				if cmp <= 0 {
+					last = i
+					childID, err := n.internalBaseDeltaChildIDAtPtr(meta, ptr, deltaWidth, entryHeader)
+					if err != nil {
+						return 0, false, err
+					}
+					lastChildID = childID
+					continue
+				}
+				break
+			}
 		default:
 			for i := 0; i < int(count); i++ {
 				offset := getUint16At(data, NodeHeaderSize+i*2)
@@ -904,6 +999,47 @@ func (n *Node) SearchInternalChildID(key []byte) (childID uint64, found bool, er
 					cmp = -1
 				} else if a > keyU64 {
 					cmp = 1
+				}
+			} else {
+				cmp = bytes.Compare(data[suffixStart:suffixEnd], keySuffix)
+			}
+			if cmp <= 0 {
+				i = h + 1
+			} else {
+				j = h
+			}
+		}
+	case 16:
+		keyHi := binary.BigEndian.Uint64(keySuffix[:8])
+		keyLo := binary.BigEndian.Uint64(keySuffix[8:])
+		for i < j {
+			h := int(uint(i+j) >> 1)
+			offset := getUint16At(data, NodeHeaderSize+h*2)
+			ptr := int(offset)
+			if ptr < NodeHeaderSize || ptr+entryHeader > meta.footerStart {
+				return 0, false, ErrCorruptedNode
+			}
+			suffixLen := int(getUint16At(data, ptr))
+			suffixStart := ptr + entryHeader
+			suffixEnd := suffixStart + suffixLen
+			if suffixLen < 0 || suffixEnd > meta.footerStart {
+				return 0, false, ErrCorruptedNode
+			}
+
+			var cmp int
+			if suffixLen == 16 {
+				aHi := getUint64BEAt(data, suffixStart)
+				if aHi < keyHi {
+					cmp = -1
+				} else if aHi > keyHi {
+					cmp = 1
+				} else {
+					aLo := getUint64BEAt(data, suffixStart+8)
+					if aLo < keyLo {
+						cmp = -1
+					} else if aLo > keyLo {
+						cmp = 1
+					}
 				}
 			} else {
 				cmp = bytes.Compare(data[suffixStart:suffixEnd], keySuffix)

--- a/TreeDB/node/internal_base_delta_bench_test.go
+++ b/TreeDB/node/internal_base_delta_bench_test.go
@@ -136,6 +136,55 @@ func BenchmarkSearchInternal_BaseDelta_FixedBE8(b *testing.B) {
 	benchmarkSearchInternalFixedBE8(b, true)
 }
 
+func benchmarkSearchInternalFixedBE16(b *testing.B, baseDelta bool) {
+	buf := make([]byte, page.PageSize)
+	opts := BuilderOptions{}
+	if baseDelta {
+		opts.InternalBaseDelta = true
+	}
+
+	builder := NewBuilderWithOptions(buf, page.PageTypeInternal, opts)
+	builder.SetPageID(1)
+
+	var key [16]byte
+	nKeys := 0
+	for ; nKeys < benchKeyCount; nKeys++ {
+		binary.BigEndian.PutUint64(key[:8], uint64(nKeys))
+		binary.BigEndian.PutUint64(key[8:], uint64(nKeys*17+3))
+		if err := builder.AddInternalChild(key[:], uint64(1_000_000+nKeys)); err != nil {
+			if err == ErrNodeFull {
+				break
+			}
+			b.Fatalf("AddInternalChild: %v", err)
+		}
+	}
+	n := builder.Finish()
+	if n.Count() == 0 {
+		b.Fatalf("expected at least one key")
+	}
+
+	queries := make([][16]byte, n.Count())
+	for i := range queries {
+		binary.BigEndian.PutUint64(queries[i][:8], uint64(i))
+		binary.BigEndian.PutUint64(queries[i][8:], uint64(i*17+3))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := queries[i%len(queries)]
+		_, _ = n.SearchInternal(q[:])
+	}
+}
+
+func BenchmarkSearchInternal_Plain_FixedBE16(b *testing.B) {
+	benchmarkSearchInternalFixedBE16(b, false)
+}
+
+func BenchmarkSearchInternal_BaseDelta_FixedBE16(b *testing.B) {
+	benchmarkSearchInternalFixedBE16(b, true)
+}
+
 func benchmarkSearchInternalChildIDFixedBE8(b *testing.B, baseDelta bool) {
 	buf := make([]byte, page.PageSize)
 	opts := BuilderOptions{}
@@ -181,4 +230,53 @@ func BenchmarkSearchInternalChildID_Plain_FixedBE8(b *testing.B) {
 
 func BenchmarkSearchInternalChildID_BaseDelta_FixedBE8(b *testing.B) {
 	benchmarkSearchInternalChildIDFixedBE8(b, true)
+}
+
+func benchmarkSearchInternalChildIDFixedBE16(b *testing.B, baseDelta bool) {
+	buf := make([]byte, page.PageSize)
+	opts := BuilderOptions{}
+	if baseDelta {
+		opts.InternalBaseDelta = true
+	}
+
+	builder := NewBuilderWithOptions(buf, page.PageTypeInternal, opts)
+	builder.SetPageID(1)
+
+	var key [16]byte
+	nKeys := 0
+	for ; nKeys < benchKeyCount; nKeys++ {
+		binary.BigEndian.PutUint64(key[:8], uint64(nKeys))
+		binary.BigEndian.PutUint64(key[8:], uint64(nKeys*17+3))
+		if err := builder.AddInternalChild(key[:], uint64(1_000_000+nKeys)); err != nil {
+			if err == ErrNodeFull {
+				break
+			}
+			b.Fatalf("AddInternalChild: %v", err)
+		}
+	}
+	n := builder.Finish()
+	if n.Count() == 0 {
+		b.Fatalf("expected at least one key")
+	}
+
+	queries := make([][16]byte, n.Count())
+	for i := range queries {
+		binary.BigEndian.PutUint64(queries[i][:8], uint64(i))
+		binary.BigEndian.PutUint64(queries[i][8:], uint64(i*17+3))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := queries[i%len(queries)]
+		_, _, _ = n.SearchInternalChildID(q[:])
+	}
+}
+
+func BenchmarkSearchInternalChildID_Plain_FixedBE16(b *testing.B) {
+	benchmarkSearchInternalChildIDFixedBE16(b, false)
+}
+
+func BenchmarkSearchInternalChildID_BaseDelta_FixedBE16(b *testing.B) {
+	benchmarkSearchInternalChildIDFixedBE16(b, true)
 }

--- a/TreeDB/node/leaf.go
+++ b/TreeDB/node/leaf.go
@@ -34,22 +34,65 @@ type leafEntryLayout struct {
 }
 
 func compareLeafKey(a, b []byte) int {
-	if len(a) == 8 && len(b) == 8 {
-		av := binary.BigEndian.Uint64(a)
-		bv := binary.BigEndian.Uint64(b)
-		if av < bv {
-			return -1
+	if len(a) == len(b) {
+		switch len(a) {
+		case 8:
+			av := binary.BigEndian.Uint64(a)
+			bv := binary.BigEndian.Uint64(b)
+			if av < bv {
+				return -1
+			}
+			if av > bv {
+				return 1
+			}
+			return 0
+		case 16:
+			ahi := binary.BigEndian.Uint64(a[:8])
+			bhi := binary.BigEndian.Uint64(b[:8])
+			if ahi < bhi {
+				return -1
+			}
+			if ahi > bhi {
+				return 1
+			}
+			alo := binary.BigEndian.Uint64(a[8:])
+			blo := binary.BigEndian.Uint64(b[8:])
+			if alo < blo {
+				return -1
+			}
+			if alo > blo {
+				return 1
+			}
+			return 0
 		}
-		if av > bv {
-			return 1
-		}
-		return 0
 	}
 	return bytes.Compare(a, b)
 }
 
 func compareSmallBigEndian(a, b []byte) (int, bool) {
-	if len(a) != len(b) || len(a) > 8 {
+	if len(a) != len(b) {
+		return 0, false
+	}
+	if len(a) == 16 {
+		ahi := binary.BigEndian.Uint64(a[:8])
+		bhi := binary.BigEndian.Uint64(b[:8])
+		if ahi < bhi {
+			return -1, true
+		}
+		if ahi > bhi {
+			return 1, true
+		}
+		alo := binary.BigEndian.Uint64(a[8:])
+		blo := binary.BigEndian.Uint64(b[8:])
+		if alo < blo {
+			return -1, true
+		}
+		if alo > blo {
+			return 1, true
+		}
+		return 0, true
+	}
+	if len(a) > 8 {
 		return 0, false
 	}
 	if len(a) == 0 {


### PR DESCRIPTION
## Summary
PR-C: Compare-path simplification by fixed widths (8/16) across leaf/internal search.

## What Changed
- Added fixed-width BE compare fast paths for 8/16-byte keys in leaf/internal compare paths.
- Extended base-delta `SearchInternalChildID` fixed-width dispatch with a 16-byte case.
- Added fixed-BE16 internal search benches.

## Read Gate Evidence
Command:
`./bin/unified-bench -dbs treedb -profile fast -keys 500000 -format markdown -checkpoint-between-tests -treedb-force-value-pointers=false -test random_read,random_read_batch -seed 1 -progress=false -valsize {85,1}`

Interleaved A/B with bootstrap CI95:
- valsize=85 (n=5/side)
  - RR: `-0.56%`, CI95 `[-1.70, +1.61]` (neutral)
  - RR Batch: `-0.00%`, CI95 `[-1.95, +1.05]` (neutral)
- valsize=1 (n=25/side)
  - RR: `-1.69%`, CI95 `[-7.39, +1.00]` (uncertain)
  - RR Batch: `+1.12%`, CI95 `[-2.33, +5.30]` (uncertain)

Microbench (`GOMAXPROCS=1`, `-count=20`):
- `BenchmarkSearchInternal_BaseDelta_FixedBE8`: `-0.41%` (faster)
- `BenchmarkSearchInternalChildID_BaseDelta_FixedBE8`: `+1.21%` (slower)

## Recommendation
`reject`

Rationale: no clear unified gain and a targeted ChildID microbench regression.
