### PR TITLE
caching: atomic lane sequence reads in value-log flush checks

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -616,15 +616,9 @@ func (db *DB) currentValueLogSeq(l *lane) int {
 		return 0
 	}
 	if db.splitValueLogEnabled() {
-		l.vlogMu.Lock()
-		seq := l.vlogSeq
-		l.vlogMu.Unlock()
-		return seq
+		return int(l.vlogSeqAtomic.Load())
 	}
-	l.walMu.Lock()
-	seq := l.walSeq
-	l.walMu.Unlock()
-	return seq
+	return int(l.walSeqAtomic.Load())
 }
 
 func (db *DB) currentWALPaths() []string {
@@ -1109,6 +1103,9 @@ func (db *DB) flushValueLogForPtr(ptr page.ValuePtr) error {
 	l := &db.lanes[laneID]
 	currentSeq := db.currentValueLogSeq(l)
 	if currentSeq == int(seq) {
+		if db.splitValueLogEnabled() && !l.vlogDirty.Load() {
+			return nil
+		}
 		return db.flushValueLogLane(l)
 	}
 	return nil
@@ -2905,6 +2902,8 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		lanes[i].id = i
 		lanes[i].walSeq = maxWALSeq[i]
 		lanes[i].vlogSeq = maxVlogSeq[i]
+		lanes[i].walSeqAtomic.Store(int64(maxWALSeq[i]))
+		lanes[i].vlogSeqAtomic.Store(int64(maxVlogSeq[i]))
 		lanes[i].vlogCompressionSelector = newVlogCompressionSelectorWithSeed(
 			valueLogAutoPolicy,
 			uint64(valueLogIncompressibleHold),
@@ -8785,6 +8784,7 @@ func (db *DB) rotateWALLockedWithOptions(l *lane, rotateValueLog bool) error {
 	l.walMu.Lock()
 	defer l.walMu.Unlock()
 	l.walSeq++
+	l.walSeqAtomic.Store(int64(l.walSeq))
 	name := commitLogName(l.id, l.walSeq)
 	path := filepath.Join(db.dir, name)
 
@@ -8835,6 +8835,7 @@ func (db *DB) rotateValueLogLocked(l *lane) error {
 
 func (db *DB) rotateValueLogMuHeld(l *lane) error {
 	l.vlogSeq++
+	l.vlogSeqAtomic.Store(int64(l.vlogSeq))
 	name := valueLogName(l.id, l.vlogSeq)
 	path := filepath.Join(db.dir, name)
 	fileID, err := valuelog.EncodeFileID(uint32(l.id), uint32(l.vlogSeq))

--- a/TreeDB/caching/lane.go
+++ b/TreeDB/caching/lane.go
@@ -14,6 +14,7 @@ type lane struct {
 	wal            commitWriter
 	walPath        string
 	walSeq         int
+	walSeqAtomic   atomic.Int64
 	walMu          sync.Mutex
 	walCh          chan walWriteRequest
 	walFastMu      sync.Mutex
@@ -28,6 +29,7 @@ type lane struct {
 	vlog                    valueWriter
 	vlogPath                string
 	vlogSeq                 int
+	vlogSeqAtomic           atomic.Int64
 	vlogRetainedPath        string
 	vlogModeWriter          valueWriter
 	vlogModeSet             bool

--- a/TreeDB/caching/vlog_autotune_bench.go
+++ b/TreeDB/caching/vlog_autotune_bench.go
@@ -425,6 +425,7 @@ func installBenchWriter(db *DB, clock *valuelog.VirtualClock) (*benchValueWriter
 	l.vlog = bw
 	l.vlogPath = "bench://vlog"
 	l.vlogSeq = 1
+	l.vlogSeqAtomic.Store(1)
 	l.vlogMu.Unlock()
 	return bw, ioSink, nil
 }


### PR DESCRIPTION
## Summary\n- read lane WAL/value-log sequence via atomics in currentValueLogSeq\n- keep atomics updated on open and rotate\n- skip split-vlog flush when lane is known clean\n\n## Scope\n- cached mode lane sequence/flush decision path\n- no API/semantic changes\n\n## Validation\n- go test ./TreeDB/caching\n- perf gate results to follow in PR comments