### PR TITLE
outerleaf v2: reusable encode scratch to reduce allocation churn

### DIFF
--- a/.github/workflows/outerleaf-v2-perf.yml
+++ b/.github/workflows/outerleaf-v2-perf.yml
@@ -1,0 +1,93 @@
+name: "outerleaf-v2: perf gate"
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "TreeDB/**"
+      - "cmd/unified_bench/**"
+      - "scripts/outerleaf_v2_perf_gate.sh"
+      - ".github/workflows/outerleaf-v2-perf.yml"
+  schedule:
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  per_pr_gate:
+    name: per-pr fast profile gate
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: |
+            go.sum
+
+      - name: Run outerleaf v2 perf gate (fast profile)
+        env:
+          RUNS: 3
+          WARMUP_RUNS: 1
+          KEYS: 500000
+          PROFILES: fast
+          STRICT_GATE: 1
+          GATE_PROFILES: fast
+          GATE_MIN_RATIO_BATCH_WRITE: 0.70
+          GATE_MIN_RATIO_BATCH_WRITE_STEADY: 0.70
+          GATE_MIN_RATIO_PREFIX_SCAN: 0.35
+        run: |
+          ./scripts/outerleaf_v2_perf_gate.sh
+
+      - name: Upload perf artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: outerleaf-v2-per-pr-artifacts
+          path: artifacts/perf/outerleaf_v2_gate_*/
+
+  nightly_matrix:
+    name: nightly durability matrix (informational)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: |
+            go.sum
+
+      - name: Run outerleaf v2 perf matrix (fast, wal_on_fast, durable)
+        env:
+          RUNS: 3
+          WARMUP_RUNS: 1
+          KEYS: 500000
+          PROFILES: fast,wal_on_fast,durable
+          STRICT_GATE: 0
+        run: |
+          ./scripts/outerleaf_v2_perf_gate.sh
+
+      - name: Upload perf artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: outerleaf-v2-nightly-artifacts
+          path: artifacts/perf/outerleaf_v2_gate_*/

--- a/TreeDB/backpressure_defaults_test.go
+++ b/TreeDB/backpressure_defaults_test.go
@@ -1,0 +1,65 @@
+package treedb
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestNormalizeBackpressureDefaults_Standard(t *testing.T) {
+	opts := Options{}
+	normalizeBackpressureDefaults(&opts)
+
+	if opts.SlowdownBacklogSeconds != defaultSlowdownBacklogSeconds {
+		t.Fatalf("slowdown=%v want %v", opts.SlowdownBacklogSeconds, defaultSlowdownBacklogSeconds)
+	}
+	if opts.StopBacklogSeconds != defaultStopBacklogSeconds {
+		t.Fatalf("stop=%v want %v", opts.StopBacklogSeconds, defaultStopBacklogSeconds)
+	}
+	if opts.MaxBacklogBytes != defaultAdaptiveMaxBacklogBytes {
+		t.Fatalf("max_backlog=%d want %d", opts.MaxBacklogBytes, defaultAdaptiveMaxBacklogBytes)
+	}
+}
+
+func TestNormalizeBackpressureDefaults_V2FenceWALOff(t *testing.T) {
+	opts := Options{
+		Durability:         db.DurabilityWALOffRelaxed,
+		IndexOuterLeafMode: db.IndexOuterLeafModeV2FencePtr,
+	}
+	normalizeBackpressureDefaults(&opts)
+
+	if opts.SlowdownBacklogSeconds != defaultV2FenceSlowdownBacklogSeconds {
+		t.Fatalf("slowdown=%v want %v", opts.SlowdownBacklogSeconds, defaultV2FenceSlowdownBacklogSeconds)
+	}
+	if opts.StopBacklogSeconds != defaultV2FenceStopBacklogSeconds {
+		t.Fatalf("stop=%v want %v", opts.StopBacklogSeconds, defaultV2FenceStopBacklogSeconds)
+	}
+	if opts.MaxBacklogBytes != defaultAdaptiveMaxBacklogBytes {
+		t.Fatalf("max_backlog=%d want %d", opts.MaxBacklogBytes, defaultAdaptiveMaxBacklogBytes)
+	}
+}
+
+func TestNormalizeBackpressureDefaults_ExplicitPreserved(t *testing.T) {
+	opts := Options{
+		Durability:              db.DurabilityWALOffRelaxed,
+		IndexOuterLeafMode:      db.IndexOuterLeafModeV2FencePtr,
+		SlowdownBacklogSeconds:  0.5,
+		StopBacklogSeconds:      1.5,
+		MaxBacklogBytes:         12345,
+		WriterFlushMaxMemtables: 7,
+	}
+	normalizeBackpressureDefaults(&opts)
+
+	if opts.SlowdownBacklogSeconds != 0.5 {
+		t.Fatalf("slowdown=%v want 0.5", opts.SlowdownBacklogSeconds)
+	}
+	if opts.StopBacklogSeconds != 1.5 {
+		t.Fatalf("stop=%v want 1.5", opts.StopBacklogSeconds)
+	}
+	if opts.MaxBacklogBytes != 12345 {
+		t.Fatalf("max_backlog=%d want 12345", opts.MaxBacklogBytes)
+	}
+	if opts.WriterFlushMaxMemtables != 7 {
+		t.Fatalf("writer_flush_max_memtables=%d want 7", opts.WriterFlushMaxMemtables)
+	}
+}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -826,13 +826,75 @@ func lookupVlogDictBytes(dictID uint64, singleDictID uint64, singleDict []byte, 
 }
 
 func (db *DB) deferredValueLogEnabled() bool {
-	if db == nil {
-		return false
-	}
 	// Fence-pointer outer-leaf mode benefits from flush-time regrouping when WAL
 	// is disabled: singleton writes can coalesce into larger outer blocks before
 	// value-log append, reducing index pointer fanout.
+	if db == nil {
+		return false
+	}
 	return db.disableJournal && db.outerLeafFenceV2Enabled() && db.valueLogEnabled() && db.allowValueLogPointers()
+}
+
+// sumKeyValueBytes returns the total bytes across paired key/value entries.
+// If keys and values differ in length, only the shared prefix is counted.
+func sumKeyValueBytes(keys, values [][]byte) uint64 {
+	if len(keys) == 0 || len(values) == 0 {
+		return 0
+	}
+	if len(keys) > len(values) {
+		keys = keys[:len(values)]
+	} else if len(values) > len(keys) {
+		values = values[:len(keys)]
+	}
+	var total uint64
+	for i := 0; i < len(keys); i++ {
+		total += uint64(len(keys[i]) + len(values[i]))
+	}
+	return total
+}
+
+func (db *DB) recordDeferredFenceEnqueued(keys int, bytes uint64) {
+	if db == nil || keys <= 0 {
+		return
+	}
+	db.deferredFenceEnqueuedKeys.Add(uint64(keys))
+	if bytes > 0 {
+		db.deferredFenceEnqueuedBytes.Add(bytes)
+	}
+}
+
+func (db *DB) recordDeferredFenceMaterialized(keys int, bytes uint64) {
+	if db == nil || keys <= 0 {
+		return
+	}
+	// Keep legacy counters for backwards-compatible dashboards.
+	db.deferredFenceCandidateKeys.Add(uint64(keys))
+	db.deferredFenceMaterializedKeys.Add(uint64(keys))
+	if bytes > 0 {
+		db.deferredFenceMaterializedBytes.Add(bytes)
+	}
+}
+
+func (db *DB) shouldFlushDeferredValueLog(writeMode vlogCompressionWriteMode, records []valuelog.Record) bool {
+	if !db.deferredValueLogEnabled() {
+		return false
+	}
+	// For v2 fence-pointer raw outer-leaf payloads, keep appends buffered across
+	// calls; readers flush on demand via flushValueLogForPtr.
+	if db.outerLeafFenceV2Enabled() && writeMode == vlogWriteOff && allOuterLeafRecordValues(records) {
+		return false
+	}
+	return true
+}
+
+func (db *DB) shouldFlushDeferredValueLogValue(writeMode vlogCompressionWriteMode, value []byte) bool {
+	if !db.deferredValueLogEnabled() {
+		return false
+	}
+	if db.outerLeafFenceV2Enabled() && writeMode == vlogWriteOff && outerleaf.HasMagic(value) {
+		return false
+	}
+	return true
 }
 
 func (db *DB) walUsesValueLog() bool {
@@ -991,6 +1053,7 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 	if !db.allowValueLogPointers() {
 		return ops, nil
 	}
+	fenceMode := db.outerLeafFenceV2Enabled()
 
 	eligible := getValueLogEligible(len(ops))
 	defer putValueLogEligible(eligible)
@@ -1044,7 +1107,11 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 		records[i].RID = startRID + uint64(i)
 	}
 
-	durability := journalDurabilityFlush
+	// For deferred value-log appends, unsynced writes intentionally use "none"
+	// value-log flush durability, and synced writes use "sync" value-log flush
+	// durability. Note: these modes control value-log flush behavior here, not
+	// journal/WAL durability.
+	durability := journalDurabilityNone
 	if sync {
 		durability = journalDurabilitySync
 	}
@@ -1061,6 +1128,16 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 		return nil, fmt.Errorf("cachingdb: deferred value-log returned %d ptrs for %d records", len(ptrs), len(records))
 	}
 
+	var eligibleByIdx []bool
+	if fenceMode {
+		eligibleByIdx = make([]bool, len(ops))
+		for _, idx := range eligible {
+			if idx >= 0 && idx < len(eligibleByIdx) {
+				eligibleByIdx[idx] = true
+			}
+		}
+	}
+
 	for i := range groups {
 		ptr := ptrs[i]
 		group := groups[i]
@@ -1070,6 +1147,16 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 			putOuterLeafArena(outerArena)
 			return nil, errors.New("cachingdb: deferred value-log group out of range")
 		}
+		if fenceMode {
+			if group.start < group.end {
+				idx := eligible[group.start]
+				op := &ops[idx]
+				op.ValuePtr = ptr
+				op.IsPtr = true
+				op.Value = nil
+			}
+			continue
+		}
 		for srcPos := group.start; srcPos < group.end; srcPos++ {
 			idx := eligible[srcPos]
 			op := &ops[idx]
@@ -1078,6 +1165,26 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 			op.Value = nil
 		}
 	}
+	if fenceMode && len(eligibleByIdx) > 0 {
+		dst := 0
+		for i := range ops {
+			if eligibleByIdx[i] && !ops[i].IsPtr {
+				// Fence mode keeps one key per grouped block.
+				continue
+			}
+			if dst != i {
+				ops[dst] = ops[i]
+			}
+			dst++
+		}
+		// Clear the discarded tail to avoid retaining large key/value
+		// references in pooled entry slices.
+		for i := dst; i < len(ops); i++ {
+			var zero batch.Entry
+			ops[i] = zero
+		}
+		ops = ops[:dst]
+	}
 	putValueLogPtrs(ptrs)
 	putValueLogRecordsNoClear(records)
 	putOuterLeafArena(outerArena)
@@ -1085,6 +1192,9 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 	retainPath := db.currentValueLogPath(lane)
 	if retainPath != "" {
 		db.markValueLogRetain(retainPath)
+	}
+	if durability == journalDurabilityNone {
+		db.backendReadVlogDirtySeq.Add(1)
 	}
 	return ops, nil
 }
@@ -1228,6 +1338,7 @@ func (db *DB) flushDeferredValueLogMemtable(iter iterator.UnsafeIterator, backen
 	if len(ptrKeys) != len(ptrVals) {
 		return errors.New("cachingdb: internal deferred value-log mismatch")
 	}
+	candidateBytes := sumKeyValueBytes(ptrKeys, ptrVals)
 	records, groups, outerArena, err := db.buildOuterLeafValueRecords(ptrKeys, ptrVals)
 	if err != nil {
 		return err
@@ -1271,7 +1382,11 @@ func (db *DB) flushDeferredValueLogMemtable(iter iterator.UnsafeIterator, backen
 		return fmt.Errorf("cachingdb: deferred value-log returned %d ptrs for %d records", len(vlogPtrs), len(records))
 	}
 	defer putValueLogPtrs(vlogPtrs)
+	if fenceMode {
+		db.recordDeferredFenceMaterialized(len(ptrKeys), candidateBytes)
+	}
 
+	emittedGroups := uint64(0)
 	for i := range groups {
 		ptr := vlogPtrs[i]
 		group := groups[i]
@@ -1285,6 +1400,7 @@ func (db *DB) flushDeferredValueLogMemtable(iter iterator.UnsafeIterator, backen
 			if group.start >= group.end {
 				continue
 			}
+			emittedGroups++
 			group.end = group.start + 1
 		}
 		for srcPos := group.start; srcPos < group.end; srcPos++ {
@@ -1301,6 +1417,9 @@ func (db *DB) flushDeferredValueLogMemtable(iter iterator.UnsafeIterator, backen
 				return errors.New("cachingdb: backend batch missing SetPointer")
 			}
 		}
+	}
+	if fenceMode && emittedGroups > 0 {
+		db.deferredFenceEmittedGroups.Add(emittedGroups)
 	}
 
 	retainPath := db.currentValueLogPath(lane)
@@ -1380,6 +1499,10 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 
 	allowPointers := db.allowValueLogPointers()
 	fenceMode := db.outerLeafFenceV2Enabled()
+	durability := journalDurabilityNone
+	if sync {
+		durability = journalDurabilitySync
+	}
 	var (
 		backendPendingOps int
 		lastFencePtr      page.ValuePtr
@@ -1389,6 +1512,7 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 		vlogLane          *lane
 		dictID            uint64
 		dictIDReady       bool
+		vlogAppended      bool
 	)
 
 	ensureVlogLane := func() error {
@@ -1451,58 +1575,79 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 		if len(ptrKeys) != len(ptrVals) {
 			return errors.New("cachingdb: deferred inline pointer grouping mismatch")
 		}
-		records, groups, outerArena, err := db.buildOuterLeafValueRecords(ptrKeys, ptrVals)
-		if err != nil {
-			return err
-		}
-		if len(records) == 0 {
-			putValueLogRecordsNoClear(records)
-			putOuterLeafArena(outerArena)
-			ptrKeys = ptrKeys[:0]
-			ptrVals = ptrVals[:0]
-			return nil
-		}
-		defer putValueLogRecordsNoClear(records)
-		defer putOuterLeafArena(outerArena)
+		totalKeys := len(ptrKeys)
+		candidateBytes := sumKeyValueBytes(ptrKeys, ptrVals)
 		if err := ensureVlogLane(); err != nil {
 			return err
 		}
+		emittedGroups := uint64(0)
+		// Cap keys per inline group to keep regroup allocations bounded while
+		// still emitting large enough batches to amortize value-log append costs.
+		const maxInlineGroupKeys = 32768
+		for chunkStart := 0; chunkStart < totalKeys; chunkStart += maxInlineGroupKeys {
+			chunkEnd := chunkStart + maxInlineGroupKeys
+			if chunkEnd > totalKeys {
+				chunkEnd = totalKeys
+			}
+			chunkKeys := ptrKeys[chunkStart:chunkEnd]
+			chunkVals := ptrVals[chunkStart:chunkEnd]
 
-		startRID := db.nextRID.Add(uint64(len(records))) - uint64(len(records)) + 1
-		for i := range records {
-			records[i].RID = startRID + uint64(i)
-		}
-		durability := journalDurabilityFlush
-		if sync {
-			durability = journalDurabilitySync
-		}
-		vlogPtrs, err := db.appendValueLog(vlogLane, dictID, nil, records, durability)
-		if err != nil {
-			return err
-		}
-		if len(vlogPtrs) != len(records) {
+			records, groups, outerArena, err := db.buildOuterLeafValueRecords(chunkKeys, chunkVals)
+			if err != nil {
+				return err
+			}
+			if len(records) == 0 {
+				putValueLogRecordsNoClear(records)
+				putOuterLeafArena(outerArena)
+				continue
+			}
+
+			startRID := db.nextRID.Add(uint64(len(records))) - uint64(len(records)) + 1
+			for i := range records {
+				records[i].RID = startRID + uint64(i)
+			}
+			vlogPtrs, err := db.appendValueLog(vlogLane, dictID, nil, records, durability)
+			putValueLogRecordsNoClear(records)
+			putOuterLeafArena(outerArena)
+			if err != nil {
+				return err
+			}
+			vlogAppended = true
+			if len(vlogPtrs) != len(records) {
+				putValueLogPtrs(vlogPtrs)
+				return fmt.Errorf("cachingdb: deferred value-log returned %d ptrs for %d records", len(vlogPtrs), len(records))
+			}
+
+			for i := range groups {
+				ptr := vlogPtrs[i]
+				group := groups[i]
+				if group.start < 0 || group.end < group.start || group.end > len(chunkKeys) {
+					putValueLogPtrs(vlogPtrs)
+					return errors.New("cachingdb: deferred inline pointer source group out of range")
+				}
+				group.start += chunkStart
+				group.end += chunkStart
+				if fenceMode {
+					if group.start >= group.end {
+						continue
+					}
+					emittedGroups++
+					group.end = group.start + 1
+				}
+				for srcPos := group.start; srcPos < group.end; srcPos++ {
+					if err := emitPointer(ptrKeys[srcPos], ptr); err != nil {
+						putValueLogPtrs(vlogPtrs)
+						return err
+					}
+				}
+			}
 			putValueLogPtrs(vlogPtrs)
-			return fmt.Errorf("cachingdb: deferred value-log returned %d ptrs for %d records", len(vlogPtrs), len(records))
 		}
-		defer putValueLogPtrs(vlogPtrs)
-
-		for i := range groups {
-			ptr := vlogPtrs[i]
-			group := groups[i]
-			if group.start < 0 || group.end < group.start || group.end > len(ptrKeys) {
-				return errors.New("cachingdb: deferred inline pointer source group out of range")
-			}
-			if fenceMode {
-				if group.start >= group.end {
-					continue
-				}
-				group.end = group.start + 1
-			}
-			for srcPos := group.start; srcPos < group.end; srcPos++ {
-				if err := emitPointer(ptrKeys[srcPos], ptr); err != nil {
-					return err
-				}
-			}
+		if fenceMode {
+			db.recordDeferredFenceMaterialized(totalKeys, candidateBytes)
+		}
+		if fenceMode && emittedGroups > 0 {
+			db.deferredFenceEmittedGroups.Add(emittedGroups)
 		}
 		ptrKeys = ptrKeys[:0]
 		ptrVals = ptrVals[:0]
@@ -1584,6 +1729,17 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 		return 0, err
 	}
 	if vlogLane != nil {
+		if vlogAppended {
+			if sync {
+				if err := db.syncValueLogLane(vlogLane); err != nil {
+					return 0, err
+				}
+			} else {
+				if err := db.flushValueLogLane(vlogLane); err != nil {
+					return 0, err
+				}
+			}
+		}
 		retainPath := db.currentValueLogPath(vlogLane)
 		if retainPath != "" {
 			db.markValueLogRetain(retainPath)
@@ -1763,7 +1919,7 @@ func (db *DB) readValueLog(key []byte, ptr page.ValuePtr) ([]byte, error) {
 	if !page.IsValueLogFileID(ptr.FileID) {
 		return nil, fmt.Errorf("cachingdb: non value-log pointer %#x", ptr.FileID)
 	}
-	if db.memtableValueLogPointers && db.valueLogEnabled() {
+	if db.valueLogEnabled() {
 		if err := db.flushValueLogForPtr(ptr); err != nil {
 			return nil, err
 		}
@@ -1782,7 +1938,7 @@ func (db *DB) readValueLogAppend(key []byte, ptr page.ValuePtr, dst []byte) ([]b
 	if !page.IsValueLogFileID(ptr.FileID) {
 		return nil, fmt.Errorf("cachingdb: non value-log pointer %#x", ptr.FileID)
 	}
-	if db.memtableValueLogPointers && db.valueLogEnabled() {
+	if db.valueLogEnabled() {
 		if err := db.flushValueLogForPtr(ptr); err != nil {
 			return nil, err
 		}
@@ -1848,6 +2004,21 @@ func (db *DB) flushValueLog(laneIDs ...int) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func (db *DB) flushDeferredValueLogForBackendRead() error {
+	if db == nil || !db.deferredValueLogEnabled() || !db.valueLogEnabled() {
+		return nil
+	}
+	dirtySeq := db.backendReadVlogDirtySeq.Load()
+	if dirtySeq == 0 || dirtySeq == db.backendReadVlogFlushedSeq.Load() {
+		return nil
+	}
+	if err := db.flushValueLog(); err != nil {
+		return err
+	}
+	db.backendReadVlogFlushedSeq.Store(dirtySeq)
 	return nil
 }
 
@@ -2612,30 +2783,38 @@ type DB struct {
 	splitValueLog            bool
 	memtableValueLogPointers bool
 
-	inlineThreshold              int
-	valueLogThreshold            int
-	valueLogDomainThresholds     []backenddb.ValueLogDomainThreshold
-	indexOuterLeafMode           string
-	outerLeafBlockTargetBytes    int
-	outerLeafBlockCodec          uint8
-	outerLeafBlockRestart        int
-	forceValueLogPointers        bool
-	valueLogRawWritevMinAvgBytes int
-	valueLogRawWritevMinRecords  int
-	valueLogCompressionMode      uint8
-	valueLogBlockCodec           valuelog.BlockCodec
-	valueLogBlockTargetBytes     int
-	valueLogIncompressibleHold   uint64
-	valueLogIncompressibleProbe  uint64
-	valueLogAutoPolicy           uint8
-	valueLogReader               *valuelog.Manager
-	valueLogMu                   sync.Mutex
-	valueLogRetain               map[string]struct{}
-	valueLogWarned               atomic.Bool
-	valueLogHardCapWarned        atomic.Bool
-	valueLogRetainedClosedBytes  atomic.Int64
-	maxValueLogRetainedBytes     int64
-	maxValueLogRetainedBytesHard int64
+	inlineThreshold                int
+	valueLogThreshold              int
+	valueLogDomainThresholds       []backenddb.ValueLogDomainThreshold
+	indexOuterLeafMode             string
+	outerLeafBlockTargetBytes      int
+	outerLeafBlockCodec            uint8
+	outerLeafBlockRestart          int
+	forceValueLogPointers          bool
+	valueLogRawWritevMinAvgBytes   int
+	valueLogRawWritevMinRecords    int
+	valueLogCompressionMode        uint8
+	valueLogBlockCodec             valuelog.BlockCodec
+	valueLogBlockTargetBytes       int
+	valueLogIncompressibleHold     uint64
+	valueLogIncompressibleProbe    uint64
+	valueLogAutoPolicy             uint8
+	valueLogReader                 *valuelog.Manager
+	valueLogMu                     sync.Mutex
+	valueLogRetain                 map[string]struct{}
+	backendReadVlogDirtySeq        atomic.Uint64
+	backendReadVlogFlushedSeq      atomic.Uint64
+	deferredFenceCandidateKeys     atomic.Uint64
+	deferredFenceEmittedGroups     atomic.Uint64
+	deferredFenceEnqueuedKeys      atomic.Uint64
+	deferredFenceEnqueuedBytes     atomic.Uint64
+	deferredFenceMaterializedKeys  atomic.Uint64
+	deferredFenceMaterializedBytes atomic.Uint64
+	valueLogWarned                 atomic.Bool
+	valueLogHardCapWarned          atomic.Bool
+	valueLogRetainedClosedBytes    atomic.Int64
+	maxValueLogRetainedBytes       int64
+	maxValueLogRetainedBytesHard   int64
 
 	// Level 1 (Disk)
 	backend       BackendDB
@@ -2758,16 +2937,20 @@ type DB struct {
 	bgErr              error
 
 	// Backpressure state
-	queueBacklogBytes        atomic.Int64
-	flushBpsEWMA             float64
-	queueLaneIDMisses        atomic.Int64
-	backendWriteBatchesTotal atomic.Int64
-	domainIngressMu          sync.Mutex
-	domainIngressCh          []chan domainIngressRequest
-	domainIngressEnqueued    atomic.Uint64
-	domainIngressProcessed   atomic.Uint64
-	domainIngressFallback    atomic.Uint64
-	domainIngressDepthMax    atomic.Uint64
+	queueBacklogBytes                   atomic.Int64
+	flushBpsEWMA                        float64
+	queueLaneIDMisses                   atomic.Int64
+	backendWriteBatchesTotal            atomic.Int64
+	deferredFenceAssistCalls            atomic.Uint64
+	deferredFenceAssistFlushedMemtables atomic.Uint64
+	deferredFenceAssistEarlyTriggers    atomic.Uint64
+	deferredFenceAssistTicker           atomic.Uint64
+	domainIngressMu                     sync.Mutex
+	domainIngressCh                     []chan domainIngressRequest
+	domainIngressEnqueued               atomic.Uint64
+	domainIngressProcessed              atomic.Uint64
+	domainIngressFallback               atomic.Uint64
+	domainIngressDepthMax               atomic.Uint64
 
 	// Lifecycle
 	closeCh chan struct{}
@@ -3300,6 +3483,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		// length of 4 => ~256MB backlog.
 		opts.MaxQueuedMemtables = defaultMaxQueuedMemtables(opts.FlushThreshold) * shardCount
 	}
+	writerFlushMaxMemtablesUnset := opts.WriterFlushMaxMemtables == 0
 	if opts.WriterFlushMaxMemtables == 0 {
 		opts.WriterFlushMaxMemtables = 1
 	}
@@ -3449,6 +3633,12 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	outerLeafBlockCodec := opts.ValueLogOuterLeafBlockCodec
 	outerLeafBlockRestart := outerleaf.NormalizeRestartInterval(opts.ValueLogOuterLeafBlockRestartInterval)
 	disableJournal := opts.DisableWAL
+	if writerFlushMaxMemtablesUnset &&
+		disableJournal &&
+		indexOuterLeafMode == backenddb.IndexOuterLeafModeV2FencePtr &&
+		opts.WriterFlushMaxMemtables < v2DeferredAssistSlowdownMinMemtables {
+		opts.WriterFlushMaxMemtables = v2DeferredAssistSlowdownMinMemtables
+	}
 	var retained map[string]struct{}
 	for _, seg := range segments {
 		if !seg.valueLog {
@@ -5656,6 +5846,7 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 	}
 	caps := l.vlogCaps
 	rawWriterInto := caps.rawInto
+	rawBufferedInto := caps.rawBuf
 	policySetter := caps.keep
 	preparedAppender := caps.prepared
 	startSize = w.Size()
@@ -5706,8 +5897,19 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 				if err == nil {
 					framesTotal++
 				}
-			} else if plan.writeMode == vlogWriteOff && rawWriterInto != nil {
-				_, stats, batchErr := rawWriterInto.AppendRawFramesWritevInto(segment, plan.k, ptrs[plan.start:plan.end])
+			} else if plan.writeMode == vlogWriteOff && (rawWriterInto != nil || rawBufferedInto != nil) {
+				useBufferedRaw := rawBufferedInto != nil && db.outerLeafFenceV2Enabled() && allOuterLeafRecordValues(segment)
+				var (
+					stats    valuelog.FrameStats
+					batchErr error
+				)
+				if useBufferedRaw {
+					_, stats, batchErr = rawBufferedInto.AppendRawFramesBufferedInto(segment, plan.k, ptrs[plan.start:plan.end])
+				} else if rawWriterInto != nil {
+					_, stats, batchErr = rawWriterInto.AppendRawFramesWritevInto(segment, plan.k, ptrs[plan.start:plan.end])
+				} else {
+					batchErr = errors.New("cachingdb: raw grouped append writer unavailable")
+				}
 				err = batchErr
 				if err == nil && plan.k > 0 {
 					framesTotal += (len(segment) + plan.k - 1) / plan.k
@@ -5862,6 +6064,7 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 		}
 	}
 
+	deferredFlushed := false
 	if err == nil {
 		switch {
 		case needSync:
@@ -5869,8 +6072,9 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 		case needFlush:
 			err = w.Flush()
 		default:
-			if db.deferredValueLogEnabled() {
+			if db.shouldFlushDeferredValueLog(vlogWriteOff, records) {
 				err = w.Flush()
+				deferredFlushed = err == nil
 			}
 		}
 	}
@@ -5878,7 +6082,7 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 		totalBytes = w.Size() - startSize
 	}
 	if err == nil {
-		if needSync || needFlush || db.deferredValueLogEnabled() {
+		if needSync || needFlush || deferredFlushed {
 			l.vlogDirty.Store(false)
 		} else if totalBytes > 0 {
 			l.vlogDirty.Store(true)
@@ -6345,9 +6549,8 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		}
 	}
 
-	// In v2 outer-leaf modes, records are already encoded as compressed
-	// key/value blocks. Re-compressing those payloads in value-log auto mode is
-	// usually redundant work with little write-size benefit.
+	// Track v2 outer-leaf payload batches so raw-mode append paths can use the
+	// buffered frame writer when selected.
 	autoOuterLeafPayloads := db.outerLeafV2Enabled() &&
 		!templatePrepass &&
 		dictID == 0 &&
@@ -6573,10 +6776,12 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	statsWriter := caps.stats
 	statsWriterInto := caps.statsInto
 	rawWriterInto := caps.rawInto
+	rawBufferedInto := caps.rawBuf
 	preparedAppender := caps.prepared
 	hasStats := statsWriter != nil
 	hasInto := statsWriterInto != nil
 	hasRawInto := rawWriterInto != nil
+	hasRawBufferedInto := rawBufferedInto != nil
 	usePreparedDictFrames := dictID != 0 && len(dict) > 0 && preparedAppender != nil && len(preparedDictFrames) > 0
 	segmentStartSize := w.Size()
 
@@ -6594,7 +6799,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	encodeRawBytes := 0
 	rawBatchUsed := false
 	durableBoundary := false
-	if dictID == 0 && hasRawInto && finalWriteMode != vlogWriteBlock && len(records) > 1 {
+	if dictID == 0 && (hasRawInto || hasRawBufferedInto) && finalWriteMode != vlogWriteBlock && len(records) > 1 {
 		if maxBytes := db.valueLogMaxSegmentBytes; maxBytes > 0 {
 			// Ensure the entire raw batch fits within the packed-offset cap so
 			// AppendRawFramesWritevInto never returns pointers with out-of-range
@@ -6624,9 +6829,11 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 				statsWriter = caps.stats
 				statsWriterInto = caps.statsInto
 				rawWriterInto = caps.rawInto
+				rawBufferedInto = caps.rawBuf
 				hasStats = statsWriter != nil
 				hasInto = statsWriterInto != nil
 				hasRawInto = rawWriterInto != nil
+				hasRawBufferedInto = rawBufferedInto != nil
 				segmentStartSize = w.Size()
 			}
 		}
@@ -6660,9 +6867,19 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	}
 
 	if err == nil && !rawBatchUsed {
-		if dictID == 0 && hasRawInto && finalWriteMode != vlogWriteBlock && len(records) > 1 {
+		useRawBatch := dictID == 0 && finalWriteMode != vlogWriteBlock && len(records) > 1
+		preferBufferedRaw := useRawBatch && autoOuterLeafPayloads && hasRawBufferedInto
+		if useRawBatch && (preferBufferedRaw || hasRawInto) {
 			ptrs = getValueLogPtrs(len(records))
-			_, stats, batchErr := rawWriterInto.AppendRawFramesWritevInto(records, k, ptrs)
+			var (
+				stats    valuelog.FrameStats
+				batchErr error
+			)
+			if preferBufferedRaw {
+				_, stats, batchErr = rawBufferedInto.AppendRawFramesBufferedInto(records, k, ptrs)
+			} else {
+				_, stats, batchErr = rawWriterInto.AppendRawFramesWritevInto(records, k, ptrs)
+			}
 			if batchErr != nil {
 				err = batchErr
 				putValueLogPtrs(ptrs)
@@ -6801,7 +7018,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			err = w.Sync()
 			durableBoundary = err == nil
 		default:
-			if db.deferredValueLogEnabled() {
+			if db.shouldFlushDeferredValueLog(finalWriteMode, records) {
 				// In deferred value-log mode, the index will publish pointers to
 				// value-log records during the flush/commit path. Ensure the value-log
 				// bytes are visible to readers even when durability is "none".
@@ -7134,7 +7351,7 @@ func (db *DB) appendValueLogOneWithKey(l *lane, dictID uint64, dict []byte, rid 
 					err = w.Flush()
 					durableBoundary = err == nil
 				default:
-					if db.deferredValueLogEnabled() {
+					if db.shouldFlushDeferredValueLogValue(finalWriteMode, value) {
 						err = w.Flush()
 						durableBoundary = err == nil
 					}
@@ -7322,7 +7539,7 @@ func (db *DB) appendValueLogOneWithKey(l *lane, dictID uint64, dict []byte, rid 
 			err = w.Sync()
 			durableBoundary = err == nil
 		default:
-			if db.deferredValueLogEnabled() {
+			if db.shouldFlushDeferredValueLogValue(finalWriteMode, value) {
 				err = w.Flush()
 				durableBoundary = err == nil
 			}
@@ -7710,6 +7927,18 @@ func (db *DB) computeBackendRange() (keyRange, bool, error) {
 const stopResumeFraction = 0.70
 const stopBackpressureStallLimit = 16
 
+const (
+	// Start pushing down v2 deferred fence debt earlier than the generic
+	// slowdown threshold so checkpoint work is less bursty.
+	// Dividing by 2 starts assists at 50% of the configured slowdown/stop
+	// thresholds when possible.
+	v2DeferredAssistEarlyTriggerDiv = 2
+	// Run the assist path once every 32 write assists to limit overhead.
+	v2DeferredAssistTickMask             = 31 // once every 32 write assists
+	v2DeferredAssistSlowdownMinMemtables = 2
+	v2DeferredAssistStopMinMemtables     = 4
+)
+
 func (db *DB) adaptiveBackpressureEnabled() bool {
 	return db.slowdownBacklogSeconds > 0 || db.stopBacklogSeconds > 0 || db.maxBacklogBytes > 0
 }
@@ -8079,6 +8308,61 @@ func (db *DB) maybeWaitForStop() {
 	}
 }
 
+func (db *DB) deferredAssistTargetMemtables(backlogBytes, slowdownBytes, stopBytes int64) (int, bool) {
+	if db == nil || !db.deferredValueLogEnabled() {
+		return 0, false
+	}
+	maxMemtables := db.writerFlushMaxMemtables
+	if maxMemtables <= 0 {
+		maxMemtables = 1
+	}
+	if stopBytes > 0 && backlogBytes >= stopBytes {
+		if maxMemtables < v2DeferredAssistStopMinMemtables {
+			maxMemtables = v2DeferredAssistStopMinMemtables
+		}
+		return maxMemtables, true
+	}
+	if slowdownBytes > 0 && backlogBytes >= slowdownBytes {
+		if maxMemtables < v2DeferredAssistSlowdownMinMemtables {
+			maxMemtables = v2DeferredAssistSlowdownMinMemtables
+		}
+		return maxMemtables, true
+	}
+	return 0, false
+}
+
+func (db *DB) deferredAssistEarlyTriggerBytes(slowdownBytes, stopBytes int64) int64 {
+	if db == nil || !db.deferredValueLogEnabled() {
+		return 0
+	}
+	early := int64(0)
+	if slowdownBytes > 0 {
+		early = slowdownBytes / v2DeferredAssistEarlyTriggerDiv
+	} else if stopBytes > 0 {
+		early = stopBytes / v2DeferredAssistEarlyTriggerDiv
+	}
+	if db.flushThreshold > 0 {
+		minEarly := db.flushThreshold / v2DeferredAssistEarlyTriggerDiv
+		if minEarly <= 0 {
+			minEarly = db.flushThreshold
+		}
+		if early == 0 || early < minEarly {
+			early = minEarly
+		}
+	}
+	return early
+}
+
+func (db *DB) recordDeferredAssist(flushed int) {
+	if db == nil {
+		return
+	}
+	db.deferredFenceAssistCalls.Add(1)
+	if flushed > 0 {
+		db.deferredFenceAssistFlushedMemtables.Add(uint64(flushed))
+	}
+}
+
 func (db *DB) maybeAssistFlush() {
 	if db.writerFlushMaxMemtables <= 0 && db.writerFlushMaxDuration <= 0 {
 		return
@@ -8100,12 +8384,27 @@ func (db *DB) maybeAssistFlush() {
 		db.bpMu.Unlock()
 
 		backlog = db.queueBacklogBytes.Load()
+		if maxMemtables, ok := db.deferredAssistTargetMemtables(backlog, slowdownBytes, stopBytes); ok {
+			flushed := db.flushSome(false, maxMemtables, db.writerFlushMaxDuration)
+			db.recordDeferredAssist(flushed)
+			return
+		}
 		if stopBytes > 0 && backlog >= stopBytes {
 			db.flushSome(false, db.writerFlushMaxMemtables, db.writerFlushMaxDuration)
 			return
 		}
 		if slowdownBytes > 0 && backlog > slowdownBytes {
 			db.TriggerFlush()
+			return
+		}
+		if early := db.deferredAssistEarlyTriggerBytes(slowdownBytes, stopBytes); early > 0 && backlog >= early {
+			db.deferredFenceAssistEarlyTriggers.Add(1)
+			db.TriggerFlush()
+			tick := db.deferredFenceAssistTicker.Add(1)
+			if tick&v2DeferredAssistTickMask == 0 {
+				flushed := db.flushSome(false, db.writerFlushMaxMemtables, db.writerFlushMaxDuration)
+				db.recordDeferredAssist(flushed)
+			}
 		}
 		return
 	}
@@ -8122,9 +8421,9 @@ func (db *DB) maybeAssistFlush() {
 	}
 }
 
-func (db *DB) flushSome(sync bool, maxMemtables int, maxDuration time.Duration) {
+func (db *DB) flushSome(sync bool, maxMemtables int, maxDuration time.Duration) int {
 	if maxMemtables <= 0 && maxDuration <= 0 {
-		return
+		return 0
 	}
 	db.flushMu.Lock()
 	defer db.flushMu.Unlock()
@@ -8134,18 +8433,18 @@ func (db *DB) flushSome(sync bool, maxMemtables int, maxDuration time.Duration) 
 	flushed := 0
 	for {
 		if maxMemtables > 0 && flushed >= maxMemtables {
-			return
+			return flushed
 		}
 		if maxDuration > 0 && time.Since(start) >= maxDuration {
-			return
+			return flushed
 		}
 		laneID, ok := db.pickFlushLane()
 		if !ok {
-			return
+			return flushed
 		}
 		if laneID < len(db.flushLaneMu) {
 			if !db.flushLaneMu[laneID].TryLock() {
-				return
+				return flushed
 			}
 		}
 		okFlush := db.flushLaneOnce(sync, laneID)
@@ -8153,7 +8452,7 @@ func (db *DB) flushSome(sync bool, maxMemtables int, maxDuration time.Duration) 
 			db.flushLaneMu[laneID].Unlock()
 		}
 		if !okFlush {
-			return
+			return flushed
 		}
 		flushed++
 	}
@@ -8445,6 +8744,9 @@ func (db *DB) setDirect(key, value []byte, sync bool) error {
 		// value-log at flush time.
 		deferPointers = true
 		allowPointers = false
+		if eligible {
+			db.recordDeferredFenceEnqueued(1, uint64(len(key)+len(value)))
+		}
 	}
 	if allowPointers && db.disableJournal && !db.memtableValueLogPointers {
 		// WAL-off: when the journal is disabled, defer value-log appends to the flush boundary
@@ -11488,6 +11790,9 @@ type backendManyGetter interface {
 }
 
 func (db *DB) backendGetMany(keys [][]byte) ([][]byte, error) {
+	if err := db.flushDeferredValueLogForBackendRead(); err != nil {
+		return nil, err
+	}
 	if mg, ok := db.backend.(backendManyGetter); ok {
 		return mg.GetMany(keys)
 	}
@@ -11510,6 +11815,9 @@ func (db *DB) GetUnsafe(key []byte) ([]byte, error) {
 // Get returns a safe copy of the value.
 func (db *DB) Get(key []byte) ([]byte, error) {
 	if db.canBypassMemtableRead(db.memtables.Load(), key) {
+		if err := db.flushDeferredValueLogForBackendRead(); err != nil {
+			return nil, err
+		}
 		return db.backend.Get(key)
 	}
 	val, found, err := db.getMemtable(key)
@@ -11523,6 +11831,9 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 		cpy := make([]byte, len(val))
 		copy(cpy, val)
 		return cpy, nil
+	}
+	if err := db.flushDeferredValueLogForBackendRead(); err != nil {
+		return nil, err
 	}
 	return db.backend.Get(key)
 }
@@ -11591,6 +11902,9 @@ func (db *DB) GetAppend(key, dst []byte) ([]byte, error) {
 	}
 
 	// 2. Backend
+	if err := db.flushDeferredValueLogForBackendRead(); err != nil {
+		return dst, err
+	}
 	return db.backend.GetAppend(key, dst)
 }
 
@@ -11681,6 +11995,13 @@ func (db *DB) Stats() map[string]string {
 	var queueDepthMax uint64
 	var queueDepthLast uint64
 	var queueDepthPositiveRunMaxNs uint64
+	var rawWritevSyscalls uint64
+	var rawWritevBytes uint64
+	var rawWritevIovecs uint64
+	var rawWritevFlushes uint64
+	var rawWriteSyscalls uint64
+	var rawWriteBytes uint64
+	var rawWriteCalls uint64
 	for i := range db.lanes {
 		l := &db.lanes[i]
 		walCurrentBytes += l.walLiveBytes.Load()
@@ -11705,6 +12026,26 @@ func (db *DB) Stats() map[string]string {
 		queueDepthLast += depthSnap.Last
 		if depthSnap.PositiveRunMaxNs > queueDepthPositiveRunMaxNs {
 			queueDepthPositiveRunMaxNs = depthSnap.PositiveRunMaxNs
+		}
+		l.vlogMu.Lock()
+		vlogWriter := l.vlog
+		l.vlogMu.Unlock()
+		if snapper, ok := any(vlogWriter).(interface {
+			RawWritevStats() valuelog.RawWritevStats
+		}); ok {
+			snap := snapper.RawWritevStats()
+			rawWritevSyscalls += snap.Syscalls
+			rawWritevBytes += snap.Bytes
+			rawWritevIovecs += snap.Iovecs
+			rawWritevFlushes += snap.Flushes
+		}
+		if snapper, ok := any(vlogWriter).(interface {
+			RawWriteStats() valuelog.RawWriteStats
+		}); ok {
+			snap := snapper.RawWriteStats()
+			rawWriteSyscalls += snap.Syscalls
+			rawWriteBytes += snap.Bytes
+			rawWriteCalls += snap.Calls
 		}
 
 		laneLagP99 := estimateVlogQueueLagPercentile(lagSnap.Buckets, lagSnap.Count, 0.99)
@@ -11795,6 +12136,63 @@ func (db *DB) Stats() map[string]string {
 	vlogSegments, vlogBytes := db.valueLogRetainedStats()
 	stats["treedb.cache.vlog_retained_segments"] = fmt.Sprintf("%d", vlogSegments)
 	stats["treedb.cache.vlog_retained_bytes_estimate"] = fmt.Sprintf("%d", vlogBytes)
+	stats["treedb.cache.vlog_writev.syscalls"] = fmt.Sprintf("%d", rawWritevSyscalls)
+	stats["treedb.cache.vlog_writev.bytes"] = fmt.Sprintf("%d", rawWritevBytes)
+	stats["treedb.cache.vlog_writev.iovecs"] = fmt.Sprintf("%d", rawWritevIovecs)
+	stats["treedb.cache.vlog_writev.flushes"] = fmt.Sprintf("%d", rawWritevFlushes)
+	if rawWritevSyscalls > 0 {
+		stats["treedb.cache.vlog_writev.bytes_per_syscall"] = fmt.Sprintf("%.1f", float64(rawWritevBytes)/float64(rawWritevSyscalls))
+		stats["treedb.cache.vlog_writev.iovecs_per_syscall"] = fmt.Sprintf("%.2f", float64(rawWritevIovecs)/float64(rawWritevSyscalls))
+	}
+	if rawWritevFlushes > 0 {
+		stats["treedb.cache.vlog_writev.bytes_per_flush"] = fmt.Sprintf("%.1f", float64(rawWritevBytes)/float64(rawWritevFlushes))
+		stats["treedb.cache.vlog_writev.syscalls_per_flush"] = fmt.Sprintf("%.2f", float64(rawWritevSyscalls)/float64(rawWritevFlushes))
+	}
+	stats["treedb.cache.vlog_write.syscalls"] = fmt.Sprintf("%d", rawWriteSyscalls)
+	stats["treedb.cache.vlog_write.bytes"] = fmt.Sprintf("%d", rawWriteBytes)
+	stats["treedb.cache.vlog_write.calls"] = fmt.Sprintf("%d", rawWriteCalls)
+	if rawWriteSyscalls > 0 {
+		stats["treedb.cache.vlog_write.bytes_per_syscall"] = fmt.Sprintf("%.1f", float64(rawWriteBytes)/float64(rawWriteSyscalls))
+	}
+	if rawWriteCalls > 0 {
+		stats["treedb.cache.vlog_write.bytes_per_call"] = fmt.Sprintf("%.1f", float64(rawWriteBytes)/float64(rawWriteCalls))
+		stats["treedb.cache.vlog_write.syscalls_per_call"] = fmt.Sprintf("%.2f", float64(rawWriteSyscalls)/float64(rawWriteCalls))
+	}
+	totalVlogSyscalls := rawWritevSyscalls + rawWriteSyscalls
+	totalVlogBytes := rawWritevBytes + rawWriteBytes
+	stats["treedb.cache.vlog_io.syscalls"] = fmt.Sprintf("%d", totalVlogSyscalls)
+	stats["treedb.cache.vlog_io.bytes"] = fmt.Sprintf("%d", totalVlogBytes)
+	if totalVlogSyscalls > 0 {
+		stats["treedb.cache.vlog_io.bytes_per_syscall"] = fmt.Sprintf("%.1f", float64(totalVlogBytes)/float64(totalVlogSyscalls))
+	}
+	fenceCandidates := db.deferredFenceCandidateKeys.Load()
+	fenceGroups := db.deferredFenceEmittedGroups.Load()
+	fenceEnqueuedKeys := db.deferredFenceEnqueuedKeys.Load()
+	fenceEnqueuedBytes := db.deferredFenceEnqueuedBytes.Load()
+	fenceMaterializedKeys := db.deferredFenceMaterializedKeys.Load()
+	fenceMaterializedBytes := db.deferredFenceMaterializedBytes.Load()
+	fencePendingKeys := uint64(0)
+	if fenceEnqueuedKeys > fenceMaterializedKeys {
+		fencePendingKeys = fenceEnqueuedKeys - fenceMaterializedKeys
+	}
+	fencePendingBytes := uint64(0)
+	if fenceEnqueuedBytes > fenceMaterializedBytes {
+		fencePendingBytes = fenceEnqueuedBytes - fenceMaterializedBytes
+	}
+	stats["treedb.cache.v2_fenceptr.deferred_candidates"] = fmt.Sprintf("%d", fenceCandidates)
+	stats["treedb.cache.v2_fenceptr.deferred_groups"] = fmt.Sprintf("%d", fenceGroups)
+	stats["treedb.cache.v2_fenceptr.deferred_enqueued_keys"] = fmt.Sprintf("%d", fenceEnqueuedKeys)
+	stats["treedb.cache.v2_fenceptr.deferred_enqueued_bytes"] = fmt.Sprintf("%d", fenceEnqueuedBytes)
+	stats["treedb.cache.v2_fenceptr.deferred_materialized_keys"] = fmt.Sprintf("%d", fenceMaterializedKeys)
+	stats["treedb.cache.v2_fenceptr.deferred_materialized_bytes"] = fmt.Sprintf("%d", fenceMaterializedBytes)
+	stats["treedb.cache.v2_fenceptr.deferred_pending_keys_estimate"] = fmt.Sprintf("%d", fencePendingKeys)
+	stats["treedb.cache.v2_fenceptr.deferred_pending_bytes_estimate"] = fmt.Sprintf("%d", fencePendingBytes)
+	stats["treedb.cache.v2_fenceptr.assist_calls"] = fmt.Sprintf("%d", db.deferredFenceAssistCalls.Load())
+	stats["treedb.cache.v2_fenceptr.assist_flushed_memtables"] = fmt.Sprintf("%d", db.deferredFenceAssistFlushedMemtables.Load())
+	stats["treedb.cache.v2_fenceptr.assist_early_triggers"] = fmt.Sprintf("%d", db.deferredFenceAssistEarlyTriggers.Load())
+	if fenceGroups > 0 {
+		stats["treedb.cache.v2_fenceptr.avg_keys_per_group"] = fmt.Sprintf("%.3f", float64(fenceCandidates)/float64(fenceGroups))
+	}
 	if db.adaptiveBackpressureEnabled() {
 		stats["treedb.cache.backpressure_mode"] = "adaptive"
 	} else {
@@ -12064,12 +12462,23 @@ func (db *DB) CompactionAssist() {
 		db.bpMu.Unlock()
 
 		backlog := db.queueBacklogBytes.Load()
+		if maxMemtables, ok := db.deferredAssistTargetMemtables(backlog, slowdownBytes, stopBytes); ok {
+			flushed := db.flushSome(false, maxMemtables, db.writerFlushMaxDuration)
+			db.recordDeferredAssist(flushed)
+			return
+		}
 		if stopBytes > 0 && backlog >= stopBytes {
 			db.flushSome(false, db.writerFlushMaxMemtables, db.writerFlushMaxDuration)
 			return
 		}
 		if slowdownBytes > 0 && backlog > slowdownBytes {
 			db.flushSome(false, db.writerFlushMaxMemtables, db.writerFlushMaxDuration)
+			return
+		}
+		if early := db.deferredAssistEarlyTriggerBytes(slowdownBytes, stopBytes); early > 0 && backlog >= early {
+			db.deferredFenceAssistEarlyTriggers.Add(1)
+			flushed := db.flushSome(false, db.writerFlushMaxMemtables, db.writerFlushMaxDuration)
+			db.recordDeferredAssist(flushed)
 			return
 		}
 		return
@@ -12117,6 +12526,9 @@ func (db *DB) Drain() error {
 // Iterator implements DB.Iterator
 func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 	if err := db.ensureBackendRange(); err != nil {
+		return nil, err
+	}
+	if err := db.flushDeferredValueLogForBackendRead(); err != nil {
 		return nil, err
 	}
 
@@ -12848,7 +13260,8 @@ func (b *Batch) tryWriteWALOffStreamBypass(sync bool) (bool, error) {
 	}
 	if b.db.outerLeafFenceV2Enabled() {
 		// Fence-pointer mode needs flush-time fence collapse semantics; direct
-		// stream bypass emits per-key pointer ops and defeats that compaction.
+		// stream bypass emits backend pointer ops at commit boundaries and can
+		// regress immediate read/prefix-scan behavior.
 		return false, nil
 	}
 	if b.backend != nil || !b.streamEligible {
@@ -13028,8 +13441,19 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		}
 	}
 	eligibleCount := len(eligibleIdxs)
+	deferredFencePath := b.db.deferredValueLogEnabled()
 	allowPointers := eligibleCount > 0 && valueLogEnabled && b.db.allowValueLogPointers()
-	if allowPointers && b.db.disableJournal && !b.db.memtableValueLogPointers {
+	if allowPointers && deferredFencePath {
+		// v2 fence-pointer WAL-off path: keep values inline in mutable memtables
+		// and materialize grouped value-log pointers once at flush time.
+		var deferredBytes uint64
+		for _, idx := range eligibleIdxs {
+			op := &b.entries[idx]
+			deferredBytes += uint64(len(op.Key) + len(op.Value))
+		}
+		b.db.recordDeferredFenceEnqueued(eligibleCount, deferredBytes)
+		allowPointers = false
+	} else if allowPointers && b.db.disableJournal && !b.db.memtableValueLogPointers {
 		// WAL-off: when the journal is disabled, defer value-log appends to the flush boundary
 		// so repeated overwrites can coalesce in the memtable before hitting disk.
 		allowPointers = false

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -1009,6 +1009,30 @@ func TestCachingDB_FlushFenceModeCollapsesPointerEntries(t *testing.T) {
 	if err := cache.Checkpoint(); err != nil {
 		t.Fatalf("Checkpoint: %v", err)
 	}
+	stats := cache.Stats()
+	parseStatUint := func(key string) uint64 {
+		t.Helper()
+		v, ok := stats[key]
+		if !ok {
+			t.Fatalf("missing stats key %q", key)
+		}
+		n, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			t.Fatalf("parse %s=%q: %v", key, v, err)
+		}
+		return n
+	}
+	enqueuedKeys := parseStatUint("treedb.cache.v2_fenceptr.deferred_enqueued_keys")
+	materializedKeys := parseStatUint("treedb.cache.v2_fenceptr.deferred_materialized_keys")
+	pendingKeys := parseStatUint("treedb.cache.v2_fenceptr.deferred_pending_keys_estimate")
+	_ = parseStatUint("treedb.cache.v2_fenceptr.deferred_enqueued_bytes")
+	_ = parseStatUint("treedb.cache.v2_fenceptr.deferred_materialized_bytes")
+	_ = parseStatUint("treedb.cache.v2_fenceptr.assist_calls")
+	_ = parseStatUint("treedb.cache.v2_fenceptr.assist_flushed_memtables")
+	_ = parseStatUint("treedb.cache.v2_fenceptr.assist_early_triggers")
+	if enqueuedKeys != 0 || materializedKeys != 0 || pendingKeys != 0 {
+		t.Fatalf("expected non-deferred fence path to keep deferred counters at zero, enqueued=%d materialized=%d pending=%d", enqueuedKeys, materializedKeys, pendingKeys)
+	}
 
 	snap := backend.AcquireSnapshot()
 	if snap == nil {
@@ -1087,6 +1111,21 @@ func TestCachingDB_FlushFenceModeDeferredSingletonWritesRegroup(t *testing.T) {
 
 	if err := cache.Checkpoint(); err != nil {
 		t.Fatalf("Checkpoint: %v", err)
+	}
+	stats := cache.Stats()
+	enqueuedKeys, err := strconv.ParseUint(stats["treedb.cache.v2_fenceptr.deferred_enqueued_keys"], 10, 64)
+	if err != nil {
+		t.Fatalf("parse deferred_enqueued_keys: %v", err)
+	}
+	materializedKeys, err := strconv.ParseUint(stats["treedb.cache.v2_fenceptr.deferred_materialized_keys"], 10, 64)
+	if err != nil {
+		t.Fatalf("parse deferred_materialized_keys: %v", err)
+	}
+	if enqueuedKeys == 0 || materializedKeys == 0 {
+		t.Fatalf("expected deferred fence stats to record work, enqueued=%d materialized=%d", enqueuedKeys, materializedKeys)
+	}
+	if materializedKeys > enqueuedKeys {
+		t.Fatalf("materialized keys exceeds enqueued keys: materialized=%d enqueued=%d", materializedKeys, enqueuedKeys)
 	}
 
 	snap := backend.AcquireSnapshot()
@@ -1262,6 +1301,101 @@ func TestCachingDB_FlushFenceModeDeferredBatchWritesRegroup(t *testing.T) {
 		if !bytes.Equal(got, valueFor(i)) {
 			t.Fatalf("backend value mismatch for %s", key)
 		}
+	}
+}
+
+func TestCachingDB_FlushFenceModeDeferredBatchWritesImmediateRead(t *testing.T) {
+	dir := t.TempDir()
+	backendOpts := db.Options{
+		Dir:                dir,
+		ChunkSize:          64 * 1024,
+		IndexOuterLeafMode: db.IndexOuterLeafModeV2FencePtr,
+		ValueLog: db.ValueLogOptions{
+			PointerThreshold:          1,
+			ForcePointers:             true,
+			OuterLeafBlockCodec:       db.ValueLogBlockLZ4,
+			OuterLeafBlockTargetBytes: 1 << 20,
+		},
+	}
+	backend, err := db.Open(backendOpts)
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+
+	cache, err := Open(dir, backend, Options{
+		AllowUnsafe:                       true,
+		DisableWAL:                        true,
+		FlushThreshold:                    1 << 30,
+		MemtableShards:                    4,
+		ForceValueLogPointers:             true,
+		ValueLogPointerThreshold:          1,
+		IndexOuterLeafMode:                db.IndexOuterLeafModeV2FencePtr,
+		ValueLogOuterLeafBlockCodec:       uint8(db.ValueLogBlockLZ4),
+		ValueLogOuterLeafBlockTargetBytes: 1 << 20,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("cache open: %v", err)
+	}
+	defer cache.Close()
+
+	const totalKeys = 5000
+	valueFor := func(i int) []byte { return bytes.Repeat([]byte{byte(i)}, 256) }
+	b := cache.NewBatch()
+	for i := 0; i < totalKeys; i++ {
+		key := []byte(fmt.Sprintf("k%08d", i))
+		if err := b.Set(key, valueFor(i)); err != nil {
+			t.Fatalf("Set(%s): %v", key, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	_ = b.Close()
+
+	// Deferred fence mode should keep mutable values inline before flush.
+	for i := range cache.mutableShards {
+		shard := &cache.mutableShards[i]
+		shard.mu.Lock()
+		it := shard.mem.NewIterator(nil, nil)
+		for it.Valid() {
+			_, _, flags := it.UnsafeEntry()
+			if flags&node.FlagPointer != 0 {
+				_ = it.Close()
+				shard.mu.Unlock()
+				t.Fatalf("expected inline mutable entry in deferred fence mode (shard=%d)", i)
+			}
+			it.Next()
+		}
+		_ = it.Close()
+		shard.mu.Unlock()
+	}
+
+	for _, i := range []int{0, totalKeys / 2, totalKeys - 1} {
+		key := []byte(fmt.Sprintf("k%08d", i))
+		got, err := cache.Get(key)
+		if err != nil {
+			t.Fatalf("cache Get(%s): %v", key, err)
+		}
+		if !bytes.Equal(got, valueFor(i)) {
+			t.Fatalf("cache value mismatch for %s", key)
+		}
+	}
+
+	it, err := cache.Iterator(nil, nil)
+	if err != nil {
+		t.Fatalf("Iterator: %v", err)
+	}
+	count := 0
+	for it.Valid() {
+		count++
+		it.Next()
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("Iterator close: %v", err)
+	}
+	if count != totalKeys {
+		t.Fatalf("iterator count=%d want=%d", count, totalKeys)
 	}
 }
 

--- a/TreeDB/caching/vlog_writer_caps.go
+++ b/TreeDB/caching/vlog_writer_caps.go
@@ -21,6 +21,10 @@ type rawFrameBatchWriterInto interface {
 	AppendRawFramesWritevInto(records []valuelog.Record, k int, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
 }
 
+type rawFrameBatchBufferedWriterInto interface {
+	AppendRawFramesBufferedInto(records []valuelog.Record, k int, dst []page.ValuePtr) ([]page.ValuePtr, valuelog.FrameStats, error)
+}
+
 type preparedFrameAppender interface {
 	AppendEncodedFrameInto(body []byte, k int, dst []page.ValuePtr) ([]page.ValuePtr, error)
 }
@@ -39,6 +43,7 @@ type vlogWriterCaps struct {
 	stats     frameStatsWriter
 	statsInto frameStatsWriterInto
 	rawInto   rawFrameBatchWriterInto
+	rawBuf    rawFrameBatchBufferedWriterInto
 	prepared  preparedFrameAppender
 }
 
@@ -59,6 +64,9 @@ func computeVlogWriterCaps(w valueWriter) vlogWriterCaps {
 	}
 	if v, ok := any(w).(rawFrameBatchWriterInto); ok {
 		caps.rawInto = v
+	}
+	if v, ok := any(w).(rawFrameBatchBufferedWriterInto); ok {
+		caps.rawBuf = v
 	}
 	if v, ok := any(w).(preparedFrameAppender); ok {
 		caps.prepared = v

--- a/TreeDB/db/outerleaf_cache.go
+++ b/TreeDB/db/outerleaf_cache.go
@@ -27,7 +27,7 @@ type outerLeafBlockCacheEntry struct {
 	block *outerleaf.DecodedBlock
 }
 
-type outerLeafBlockCache struct {
+type outerLeafBlockCacheShard struct {
 	mu       sync.Mutex
 	list     *list.List
 	entries  map[outerLeafBlockKey]*list.Element
@@ -36,52 +36,114 @@ type outerLeafBlockCache struct {
 	capacity int
 }
 
+type outerLeafBlockCache struct {
+	shards   []outerLeafBlockCacheShard
+	capacity int
+}
+
 func newOuterLeafBlockCache(capacity int) *outerLeafBlockCache {
 	if capacity <= 0 {
 		return nil
 	}
+
+	// Keep per-shard capacity reasonably sized (target ~256 entries/shard)
+	// while bounding lock fanout.
+	shardCount := 1
+	targetShards := capacity / 256
+	if targetShards < 1 {
+		targetShards = 1
+	}
+	for shardCount < targetShards && shardCount < 64 {
+		shardCount <<= 1
+	}
+	if shardCount > capacity {
+		shardCount = 1
+		for shardCount<<1 <= capacity {
+			shardCount <<= 1
+		}
+	}
+
+	shards := make([]outerLeafBlockCacheShard, shardCount)
+	baseCap := capacity / shardCount
+	extra := capacity % shardCount
+	for i := range shards {
+		capI := baseCap
+		if i < extra {
+			capI++
+		}
+		shards[i] = outerLeafBlockCacheShard{
+			list:     list.New(),
+			entries:  make(map[outerLeafBlockKey]*list.Element, capI),
+			capacity: capI,
+		}
+	}
+
 	return &outerLeafBlockCache{
-		list:     list.New(),
-		entries:  make(map[outerLeafBlockKey]*list.Element),
+		shards:   shards,
 		capacity: capacity,
 	}
 }
 
 func (c *outerLeafBlockCache) get(key outerLeafBlockKey) *outerleaf.DecodedBlock {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	elem, ok := c.entries[key]
+	s := c.shardFor(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	elem, ok := s.entries[key]
 	if !ok {
-		c.misses++
+		s.misses++
 		return nil
 	}
-	c.hits++
-	c.list.MoveToFront(elem)
+	s.hits++
+	s.list.MoveToFront(elem)
 	return elem.Value.(*outerLeafBlockCacheEntry).block
 }
 
 func (c *outerLeafBlockCache) put(key outerLeafBlockKey, block *outerleaf.DecodedBlock) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if elem, ok := c.entries[key]; ok {
+	s := c.shardFor(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if elem, ok := s.entries[key]; ok {
 		elem.Value.(*outerLeafBlockCacheEntry).block = block
-		c.list.MoveToFront(elem)
+		s.list.MoveToFront(elem)
 		return
 	}
 	entry := &outerLeafBlockCacheEntry{key: key, block: block}
-	elem := c.list.PushFront(entry)
-	c.entries[key] = elem
-	if c.list.Len() > c.capacity {
-		tail := c.list.Back()
+	elem := s.list.PushFront(entry)
+	s.entries[key] = elem
+	if s.list.Len() > s.capacity {
+		tail := s.list.Back()
 		if tail != nil {
-			c.list.Remove(tail)
-			delete(c.entries, tail.Value.(*outerLeafBlockCacheEntry).key)
+			s.list.Remove(tail)
+			delete(s.entries, tail.Value.(*outerLeafBlockCacheEntry).key)
 		}
 	}
 }
 
 func (c *outerLeafBlockCache) stats() (hits uint64, misses uint64, entries int, capacity int) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.hits, c.misses, c.list.Len(), c.capacity
+	var totalEntries int
+	var totalHits uint64
+	var totalMisses uint64
+	for i := range c.shards {
+		s := &c.shards[i]
+		s.mu.Lock()
+		totalHits += s.hits
+		totalMisses += s.misses
+		totalEntries += s.list.Len()
+		s.mu.Unlock()
+	}
+	return totalHits, totalMisses, totalEntries, c.capacity
+}
+
+func (c *outerLeafBlockCache) shardFor(key outerLeafBlockKey) *outerLeafBlockCacheShard {
+	if len(c.shards) == 1 {
+		return &c.shards[0]
+	}
+	h := uint64(key.fileID)*11400714819323198485 ^
+		key.offset*14029467366897019727 ^
+		uint64(key.length)*1609587929392839161
+	h ^= h >> 33
+	h *= 0xff51afd7ed558ccd
+	h ^= h >> 33
+	idx := int(h & uint64(len(c.shards)-1))
+	return &c.shards[idx]
 }

--- a/TreeDB/internal/outerleaf/block.go
+++ b/TreeDB/internal/outerleaf/block.go
@@ -83,6 +83,10 @@ type DecodedBlock struct {
 	restartKeys [][]byte
 	firstKey    []byte
 	firstValue  []byte
+
+	keysOnce sync.Once
+	keys     [][]byte
+	keysErr  error
 }
 
 // Encoder reuses encode scratch buffers across outer-leaf block encodes.
@@ -186,6 +190,9 @@ func shouldBypassCompressionProbe(codec uint8, raw []byte, dst []byte) bool {
 	if len(raw) < outerLeafIncompressibleProbeMinBytes {
 		return false
 	}
+	if normalizeCodec(codec) != blockCodecLZ4 {
+		return false
+	}
 	var sampleBuf [outerLeafIncompressibleProbeBytes]byte
 	sample := sampleForIncompressibleProbe(raw, &sampleBuf)
 	// Fast-path clearly high-entropy blocks to raw mode and skip probe/full
@@ -193,31 +200,19 @@ func shouldBypassCompressionProbe(codec uint8, raw []byte, dst []byte) bool {
 	if isLikelyHighEntropy(sample) {
 		return true
 	}
-	switch codec {
-	case blockCodecLZ4:
-		bound := lz4.CompressBlockBound(len(sample))
-		if cap(dst) < bound {
-			dst = make([]byte, bound)
-		}
-		dst = dst[:bound]
-		n, err := lz4.CompressBlock(sample, dst, nil)
-		if err != nil {
-			return false
-		}
-		if n <= 0 {
-			return true
-		}
-		return !keepCompressedPayload(len(sample), n)
-	default:
-		need := snappy.MaxEncodedLen(len(sample))
-		if cap(dst) < need {
-			dst = make([]byte, need)
-		} else {
-			dst = dst[:need]
-		}
-		enc := snappy.Encode(dst, sample)
-		return !keepCompressedPayload(len(sample), len(enc))
+	bound := lz4.CompressBlockBound(len(sample))
+	if cap(dst) < bound {
+		dst = make([]byte, bound)
 	}
+	dst = dst[:bound]
+	n, err := lz4.CompressBlock(sample, dst, nil)
+	if err != nil {
+		return false
+	}
+	if n <= 0 {
+		return true
+	}
+	return !keepCompressedPayload(len(sample), n)
 }
 
 func isLikelyHighEntropy(sample []byte) bool {
@@ -238,7 +233,11 @@ func encodePayload(codec uint8, raw []byte, dst []byte) ([]byte, uint8, error) {
 		return nil, blockCodecNone, nil
 	}
 	codec = normalizeCodec(codec)
-	if shouldBypassCompressionProbe(codec, raw, dst) {
+	// Snappy is the default outer-leaf codec. Running a probe (sample + optional
+	// sample-compress) on every block adds measurable CPU overhead on
+	// compressible write-heavy paths while the full encode still applies
+	// keepCompressedPayload gating. Keep probe logic for non-default codecs.
+	if codec != blockCodecSnappy && shouldBypassCompressionProbe(codec, raw, dst) {
 		return raw, blockCodecNone, nil
 	}
 	switch codec {
@@ -1139,40 +1138,66 @@ func (d *DecodedBlock) Keys(dst [][]byte) ([][]byte, error) {
 	if d == nil {
 		return nil, fmt.Errorf("outerleaf: nil block")
 	}
-	if cap(dst) < d.entryCount {
-		dst = make([][]byte, 0, d.entryCount)
-	} else {
-		dst = dst[:0]
-	}
 	switch d.version {
 	case blockVersionV1:
+		if cap(dst) < d.entryCount {
+			dst = make([][]byte, 0, d.entryCount)
+		} else {
+			dst = dst[:0]
+		}
 		if d.firstKey == nil {
 			return nil, fmt.Errorf("outerleaf: missing v1 key")
 		}
 		dst = append(dst, d.firstKey)
 		return dst, nil
 	case blockVersionV2:
+		keys, err := d.cachedV2Keys()
+		if err != nil {
+			return nil, err
+		}
+		if dst == nil {
+			return keys, nil
+		}
+		if cap(dst) < len(keys) {
+			dst = make([][]byte, len(keys))
+		} else {
+			dst = dst[:len(keys)]
+		}
+		copy(dst, keys)
+		return dst, nil
+	default:
+		return nil, fmt.Errorf("outerleaf: unsupported version %d", d.version)
+	}
+}
+
+func (d *DecodedBlock) cachedV2Keys() ([][]byte, error) {
+	d.keysOnce.Do(func() {
 		encoded := d.entries
+		keys := make([][]byte, 0, d.entryCount)
 		off := 0
 		var prevKey []byte
 		for i := 0; i < d.entryCount; i++ {
 			if off+8 > len(encoded) {
-				return nil, fmt.Errorf("outerleaf: truncated v2 entry header")
+				d.keysErr = fmt.Errorf("outerleaf: truncated v2 entry header")
+				return
 			}
 			shared := int(binary.LittleEndian.Uint16(encoded[off : off+2]))
 			suffixLen := int(binary.LittleEndian.Uint16(encoded[off+2 : off+4]))
 			valueLen := int(binary.LittleEndian.Uint32(encoded[off+4 : off+8]))
 			off += 8
 			if shared < 0 || shared > len(prevKey) {
-				return nil, fmt.Errorf("outerleaf: invalid shared prefix")
+				d.keysErr = fmt.Errorf("outerleaf: invalid shared prefix")
+				return
 			}
 			if suffixLen < 0 || off+suffixLen > len(encoded) {
-				return nil, fmt.Errorf("outerleaf: invalid key suffix length")
+				d.keysErr = fmt.Errorf("outerleaf: invalid key suffix length")
+				return
 			}
 			suffix := encoded[off : off+suffixLen]
 			off += suffixLen
 			if valueLen < 0 || off+valueLen > len(encoded) {
-				return nil, fmt.Errorf("outerleaf: invalid value length")
+				d.keysErr = fmt.Errorf("outerleaf: invalid value length")
+				return
 			}
 			off += valueLen
 
@@ -1184,16 +1209,19 @@ func (d *DecodedBlock) Keys(dst [][]byte) ([][]byte, error) {
 				copy(key, prevKey[:shared])
 				copy(key[shared:], suffix)
 			}
-			dst = append(dst, key)
+			keys = append(keys, key)
 			prevKey = key
 		}
 		if off != len(encoded) {
-			return nil, fmt.Errorf("outerleaf: trailing v2 entry bytes")
+			d.keysErr = fmt.Errorf("outerleaf: trailing v2 entry bytes")
+			return
 		}
-		return dst, nil
-	default:
-		return nil, fmt.Errorf("outerleaf: unsupported version %d", d.version)
+		d.keys = keys
+	})
+	if d.keysErr != nil {
+		return nil, d.keysErr
 	}
+	return d.keys, nil
 }
 
 // Decode returns the first key/value in an encoded outer-leaf payload.

--- a/TreeDB/internal/outerleaf/block_test.go
+++ b/TreeDB/internal/outerleaf/block_test.go
@@ -384,6 +384,43 @@ func TestDecodedBlockEntries(t *testing.T) {
 			t.Fatalf("Entries(v2)[%d] value mismatch", i)
 		}
 	}
+	keys, err := blk.Keys(nil)
+	if err != nil {
+		t.Fatalf("Keys(v2): %v", err)
+	}
+	if len(keys) != len(v2Entries) {
+		t.Fatalf("Keys(v2) len=%d want=%d", len(keys), len(v2Entries))
+	}
+	for i := range v2Entries {
+		if !bytes.Equal(keys[i], v2Entries[i].Key) {
+			t.Fatalf("Keys(v2)[%d] key mismatch got=%q want=%q", i, keys[i], v2Entries[i].Key)
+		}
+	}
+	// Repeated nil-dst calls should reuse decoded key materialization.
+	keys2, err := blk.Keys(nil)
+	if err != nil {
+		t.Fatalf("Keys(v2) second call: %v", err)
+	}
+	if len(keys2) != len(keys) {
+		t.Fatalf("Keys(v2) second call len=%d want=%d", len(keys2), len(keys))
+	}
+	for i := range keys {
+		if !bytes.Equal(keys2[i], keys[i]) {
+			t.Fatalf("Keys(v2) second call key[%d] mismatch", i)
+		}
+	}
+	keysCopy, err := blk.Keys(make([][]byte, 0, len(v2Entries)))
+	if err != nil {
+		t.Fatalf("Keys(v2) dst call: %v", err)
+	}
+	if len(keysCopy) != len(v2Entries) {
+		t.Fatalf("Keys(v2) dst call len=%d want=%d", len(keysCopy), len(v2Entries))
+	}
+	for i := range v2Entries {
+		if !bytes.Equal(keysCopy[i], v2Entries[i].Key) {
+			t.Fatalf("Keys(v2) dst call key[%d] mismatch got=%q want=%q", i, keysCopy[i], v2Entries[i].Key)
+		}
+	}
 
 	v1Key := []byte("single:key")
 	v1Val := bytes.Repeat([]byte("z"), 40)
@@ -404,6 +441,13 @@ func TestDecodedBlockEntries(t *testing.T) {
 	}
 	if !bytes.Equal(got[0].Key, v1Key) || !bytes.Equal(got[0].Value, v1Val) {
 		t.Fatalf("Entries(v1) mismatch")
+	}
+	keys, err = blk.Keys(nil)
+	if err != nil {
+		t.Fatalf("Keys(v1): %v", err)
+	}
+	if len(keys) != 1 || !bytes.Equal(keys[0], v1Key) {
+		t.Fatalf("Keys(v1) mismatch")
 	}
 }
 

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/snissn/compress/zstd"
@@ -46,6 +47,13 @@ type Writer struct {
 	rawWritevIovs          [][]byte
 	rawWritevVecs          []writevIovec
 	rawWritevMeta          []byte
+	rawWritevSyscalls      atomic.Uint64
+	rawWritevBytes         atomic.Uint64
+	rawWritevIovecs        atomic.Uint64
+	rawWritevFlushes       atomic.Uint64
+	rawWriteSyscalls       atomic.Uint64
+	rawWriteBytes          atomic.Uint64
+	rawWriteCalls          atomic.Uint64
 	encScratch             []byte
 	encLimiter             limitedSliceWriter
 	blockScratch           []byte
@@ -85,11 +93,20 @@ func (w *limitedSliceWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func writeAllToFile(f *os.File, buf []byte) error {
+func (w *Writer) writeAllToFile(buf []byte) error {
+	if w == nil {
+		return errors.New("valuelog: nil file writer")
+	}
+	if w.f == nil {
+		return errors.New("valuelog: nil file writer")
+	}
+	w.rawWriteCalls.Add(1)
 	written := 0
 	for written < len(buf) {
-		n, err := f.Write(buf[written:])
+		w.rawWriteSyscalls.Add(1)
+		n, err := w.f.Write(buf[written:])
 		if n > 0 {
+			w.rawWriteBytes.Add(uint64(n))
 			written += n
 		}
 		if err != nil {
@@ -114,7 +131,7 @@ func (w *Writer) flushAppendBuf() error {
 		w.appendBuf = w.appendBuf[:0]
 		return err
 	}
-	if err := writeAllToFile(w.f, w.appendBuf); err != nil {
+	if err := w.writeAllToFile(w.appendBuf); err != nil {
 		return err
 	}
 	w.appendBuf = w.appendBuf[:0]
@@ -148,22 +165,67 @@ func (w *Writer) writeBytes(buf []byte) error {
 		if err := w.flushAppendBuf(); err != nil {
 			return err
 		}
-		return writeAllToFile(w.f, buf)
+		return w.writeAllToFile(buf)
 	}
 	if len(w.appendBuf) == 0 && len(buf) >= directThreshold {
-		return writeAllToFile(w.f, buf)
+		return w.writeAllToFile(buf)
 	}
 	if len(w.appendBuf)+len(buf) > max {
 		if err := w.flushAppendBuf(); err != nil {
 			return err
 		}
 		if len(buf) >= directThreshold {
-			return writeAllToFile(w.f, buf)
+			return w.writeAllToFile(buf)
 		}
 	}
 	w.appendBuf = append(w.appendBuf, buf...)
 	if len(w.appendBuf) >= max {
 		return w.flushAppendBuf()
+	}
+	return nil
+}
+
+// writeBytesBuffered appends bytes through appendBuf even for medium/large
+// payloads, avoiding direct-write threshold bypass so callers can coalesce
+// multiple records into fewer large writes.
+func (w *Writer) writeBytesBuffered(buf []byte) error {
+	if w == nil {
+		return errors.New("valuelog: nil writer")
+	}
+	if len(buf) == 0 {
+		return nil
+	}
+	if w.f == nil {
+		_, err := w.bw.Write(buf)
+		return err
+	}
+
+	max := w.appendMax
+	if max <= 0 {
+		max = defaultBufferSize
+	}
+	for len(buf) > 0 {
+		if len(w.appendBuf) >= max {
+			if err := w.flushAppendBuf(); err != nil {
+				return err
+			}
+		}
+		avail := max - len(w.appendBuf)
+		if avail <= 0 {
+			continue
+		}
+		if len(buf) <= avail {
+			w.appendBuf = append(w.appendBuf, buf...)
+			if len(w.appendBuf) >= max {
+				return w.flushAppendBuf()
+			}
+			return nil
+		}
+		w.appendBuf = append(w.appendBuf, buf[:avail]...)
+		buf = buf[avail:]
+		if err := w.flushAppendBuf(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/TreeDB/internal/valuelog/writer_writev.go
+++ b/TreeDB/internal/valuelog/writer_writev.go
@@ -14,6 +14,12 @@ const (
 	defaultRawWritevMinBatchRecords = 8
 )
 
+type writevCallStats struct {
+	syscalls uint64
+	bytes    uint64
+	iovecs   uint64
+}
+
 func rawWritevLimits(w *Writer) (maxBytes, maxIovs int) {
 	maxBytes = defaultBufferSize
 	if w != nil && w.appendMax > 0 {
@@ -164,6 +170,9 @@ func (w *Writer) shouldUseRawWritev(records []Record, k int, rawPayloadBytes int
 // user-space copying for large value workloads. It always flushes the writev
 // queue before returning, so it does not retain references to the input slices.
 //
+// Prefer this when the caller needs pointers durably visible at function
+// return and cannot rely on future appends to coalesce writes.
+//
 // dst must be at least len(records) long.
 func (w *Writer) AppendRawFramesWritevInto(records []Record, k int, dst []page.ValuePtr) ([]page.ValuePtr, FrameStats, error) {
 	if w == nil {
@@ -253,11 +262,18 @@ func (w *Writer) AppendRawFramesWritevInto(records []Record, k int, dst []page.V
 			queuedBytes = 0
 			return nil
 		}
-		var err error
-		vecs, err = writevAll(fd, iovs, vecs)
+		var (
+			err      error
+			callStat writevCallStats
+		)
+		vecs, callStat, err = writevAll(fd, iovs, vecs)
 		if err != nil {
 			return err
 		}
+		w.rawWritevSyscalls.Add(callStat.syscalls)
+		w.rawWritevBytes.Add(callStat.bytes)
+		w.rawWritevIovecs.Add(callStat.iovecs)
+		w.rawWritevFlushes.Add(1)
 		w.size += int64(queuedBytes)
 		iovs = iovs[:0]
 		meta = meta[:0]
@@ -385,6 +401,169 @@ func (w *Writer) AppendRawFramesWritevInto(records []Record, k int, dst []page.V
 
 	if err := flush(); err != nil {
 		return nil, FrameStats{}, err
+	}
+
+	return dst, FrameStats{
+		Records:            len(records),
+		RawPayloadBytes:    rawPayloadBytes,
+		StoredPayloadBytes: rawPayloadBytes,
+		Kept:               false,
+	}, nil
+}
+
+// AppendRawFramesBufferedInto appends raw grouped frames through the writer's
+// append buffer, allowing multiple calls to coalesce into larger write syscalls.
+//
+// Compared to AppendRawFramesWritevInto, this path stages frame bytes in the
+// writer append buffer and flushes later, so independent append calls can merge
+// into fewer, larger writes.
+//
+// Prefer this for high-throughput append streams where delayed flush is
+// acceptable and syscall coalescing across calls is desirable.
+//
+// dst must be at least len(records) long.
+func (w *Writer) AppendRawFramesBufferedInto(records []Record, k int, dst []page.ValuePtr) ([]page.ValuePtr, FrameStats, error) {
+	if w == nil {
+		return nil, FrameStats{}, errors.New("valuelog: nil writer")
+	}
+	if len(records) == 0 {
+		return dst[:0], FrameStats{}, nil
+	}
+	if len(dst) < len(records) {
+		return nil, FrameStats{}, errors.New("valuelog: dst too small")
+	}
+	if k <= 0 || k > MaxFrameK {
+		return nil, FrameStats{}, ErrRecordTooLarge
+	}
+	dst = dst[:len(records)]
+
+	rawPayloadBytes := 0
+	for i := range records {
+		if records[i].RID == 0 {
+			return nil, FrameStats{}, errors.New("valuelog: missing rid")
+		}
+		if len(records[i].Value) > int(^uint32(0)) {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+		rawPayloadBytes += len(records[i].Value)
+		if rawPayloadBytes < 0 || rawPayloadBytes > int(^uint32(0)) {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+	}
+
+	meta := w.rawWritevMeta[:0]
+	if cap(meta) < 4096 {
+		meta = make([]byte, 0, 4096)
+	}
+	defer func() {
+		w.rawWritevMeta = meta[:0]
+	}()
+
+	pos := 0
+	for pos < len(records) {
+		end := pos + k
+		if end > len(records) {
+			end = len(records)
+		}
+		frameRecords := records[pos:end]
+		kFrame := len(frameRecords)
+		if kFrame <= 0 || kFrame > MaxFrameK {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+
+		var offsets [MaxFrameK + 1]uint32
+		offsets[0] = 0
+		framePayloadBytes := 0
+		for i := 0; i < kFrame; i++ {
+			framePayloadBytes += len(frameRecords[i].Value)
+			if framePayloadBytes < 0 || framePayloadBytes > int(^uint32(0)) {
+				return nil, FrameStats{}, ErrRecordTooLarge
+			}
+			offsets[i+1] = uint32(framePayloadBytes)
+		}
+		if limits.MaxRecordSize > 0 && int64(framePayloadBytes) > limits.MaxRecordSize {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+
+		prefixLen := FrameHeaderSize + (kFrame * 8) + ((kFrame + 1) * 4)
+		bodyLen := prefixLen + framePayloadBytes
+		if limits.MaxRecordSize > 0 && int64(HeaderSize+bodyLen) > limits.MaxRecordSize {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+		if bodyLen > int(^uint32(0)) {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+		if recordSizeExceedsMax(uint32(bodyLen)) {
+			return nil, FrameStats{}, ErrRecordTooLarge
+		}
+
+		start := w.size
+		recordLenHint := uint32(headerWithoutCRC) + uint32(bodyLen)
+		if recordLenHint > page.ValuePtrGroupedMaxRecordLen {
+			recordLenHint = 0
+		}
+		for i := 0; i < kFrame; i++ {
+			dst[pos+i] = page.ValuePtr{
+				Offset: uint64(start + 4),
+				Length: page.ValuePtrMarkGrouped(recordLenHint, uint8(i)),
+				FileID: w.fileID,
+			}
+		}
+
+		metaNeed := HeaderSize + prefixLen
+		if cap(meta) < metaNeed {
+			meta = make([]byte, metaNeed)
+		} else {
+			meta = meta[:metaNeed]
+		}
+		header := meta[:HeaderSize]
+		prefix := meta[HeaderSize : HeaderSize+prefixLen]
+
+		header[4] = Version
+		header[5] = recordFlagGrouped
+		header[6] = 0
+		header[7] = 0
+		binary.LittleEndian.PutUint64(header[8:16], 0)
+		binary.LittleEndian.PutUint32(header[16:20], uint32(bodyLen))
+
+		prefixOff := 0
+		prefix[prefixOff] = FrameVersion
+		prefix[prefixOff+1] = 0
+		prefix[prefixOff+2] = byte(kFrame)
+		prefix[prefixOff+3] = 0
+		binary.LittleEndian.PutUint64(prefix[prefixOff+4:prefixOff+12], 0)
+		prefixOff += FrameHeaderSize
+		for i := 0; i < kFrame; i++ {
+			binary.LittleEndian.PutUint64(prefix[prefixOff:prefixOff+8], frameRecords[i].RID)
+			prefixOff += 8
+		}
+		for i := 0; i < kFrame+1; i++ {
+			binary.LittleEndian.PutUint32(prefix[prefixOff:prefixOff+4], offsets[i])
+			prefixOff += 4
+		}
+
+		sum := uint32(0)
+		sum = crc.Update(sum, header[4:HeaderSize])
+		sum = crc.Update(sum, prefix)
+		for i := 0; i < kFrame; i++ {
+			sum = crc.Update(sum, frameRecords[i].Value)
+		}
+		binary.LittleEndian.PutUint32(header[0:4], sum)
+
+		if err := w.writeBytesBuffered(header); err != nil {
+			return nil, FrameStats{}, err
+		}
+		if err := w.writeBytesBuffered(prefix); err != nil {
+			return nil, FrameStats{}, err
+		}
+		for i := 0; i < kFrame; i++ {
+			if err := w.writeBytesBuffered(frameRecords[i].Value); err != nil {
+				return nil, FrameStats{}, err
+			}
+		}
+		w.size += int64(HeaderSize + bodyLen)
+
+		pos = end
 	}
 
 	return dst, FrameStats{

--- a/TreeDB/internal/valuelog/writev_stats.go
+++ b/TreeDB/internal/valuelog/writev_stats.go
@@ -1,0 +1,42 @@
+package valuelog
+
+// RawWritevStats captures low-level writev syscall behavior for grouped raw
+// frame appends.
+type RawWritevStats struct {
+	Syscalls uint64
+	Bytes    uint64
+	Iovecs   uint64
+	Flushes  uint64
+}
+
+// RawWriteStats captures plain write(2)-based append behavior.
+type RawWriteStats struct {
+	Syscalls uint64
+	Bytes    uint64
+	Calls    uint64
+}
+
+// RawWritevStats returns cumulative writev syscall counters for this writer.
+func (w *Writer) RawWritevStats() RawWritevStats {
+	if w == nil {
+		return RawWritevStats{}
+	}
+	return RawWritevStats{
+		Syscalls: w.rawWritevSyscalls.Load(),
+		Bytes:    w.rawWritevBytes.Load(),
+		Iovecs:   w.rawWritevIovecs.Load(),
+		Flushes:  w.rawWritevFlushes.Load(),
+	}
+}
+
+// RawWriteStats returns cumulative plain write(2) counters for this writer.
+func (w *Writer) RawWriteStats() RawWriteStats {
+	if w == nil {
+		return RawWriteStats{}
+	}
+	return RawWriteStats{
+		Syscalls: w.rawWriteSyscalls.Load(),
+		Bytes:    w.rawWriteBytes.Load(),
+		Calls:    w.rawWriteCalls.Load(),
+	}
+}

--- a/TreeDB/internal/valuelog/writev_stub.go
+++ b/TreeDB/internal/valuelog/writev_stub.go
@@ -10,6 +10,6 @@ const writevMaxIovs = 0
 
 type writevIovec struct{}
 
-func writevAll(fd int, iovs [][]byte, scratch []writevIovec) ([]writevIovec, error) {
-	return scratch[:0], errors.New("valuelog: writev unsupported")
+func writevAll(fd int, iovs [][]byte, scratch []writevIovec) ([]writevIovec, writevCallStats, error) {
+	return scratch[:0], writevCallStats{}, errors.New("valuelog: writev unsupported")
 }

--- a/TreeDB/internal/valuelog/writev_unix.go
+++ b/TreeDB/internal/valuelog/writev_unix.go
@@ -24,9 +24,10 @@ type writevIovec = unix.Iovec
 // Callers must treat iovs as immutable for the duration of this call. The
 // generated unix.Iovec entries point at the backing arrays in iovs until
 // writevAll returns.
-func writevAll(fd int, iovs [][]byte, scratch []writevIovec) ([]writevIovec, error) {
+func writevAll(fd int, iovs [][]byte, scratch []writevIovec) ([]writevIovec, writevCallStats, error) {
+	var stats writevCallStats
 	if len(iovs) == 0 {
-		return scratch[:0], nil
+		return scratch[:0], stats, nil
 	}
 	if cap(scratch) < len(iovs) {
 		scratch = make([]writevIovec, len(iovs))
@@ -42,16 +43,19 @@ func writevAll(fd int, iovs [][]byte, scratch []writevIovec) ([]writevIovec, err
 		vecs[i].SetLen(0)
 	}
 	for len(vecs) > 0 {
+		stats.syscalls++
+		stats.iovecs += uint64(len(vecs))
 		n, err := rawWritev(fd, vecs)
 		if err != nil {
 			if err == unix.EINTR || err == unix.EAGAIN {
 				continue
 			}
-			return scratch, err
+			return scratch, stats, err
 		}
 		if n <= 0 {
-			return scratch, errors.New("valuelog: short writev")
+			return scratch, stats, errors.New("valuelog: short writev")
 		}
+		stats.bytes += uint64(n)
 		written := n
 		for written > 0 && len(vecs) > 0 {
 			iovLen := int(vecs[0].Len)
@@ -69,7 +73,7 @@ func writevAll(fd int, iovs [][]byte, scratch []writevIovec) ([]writevIovec, err
 			written = 0
 		}
 	}
-	return scratch, nil
+	return scratch, stats, nil
 }
 
 func rawWritev(fd int, iovs []writevIovec) (int, error) {

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -28,6 +28,12 @@ type Options = db.Options
 const (
 	defaultChunkSize     = 16 * 1024 * 1024
 	defaultDictChunkSize = 1 * 1024 * 1024
+
+	defaultSlowdownBacklogSeconds              = 1.0
+	defaultStopBacklogSeconds                  = 2.0
+	defaultV2FenceSlowdownBacklogSeconds       = 0.5
+	defaultV2FenceStopBacklogSeconds           = 1.0
+	defaultAdaptiveMaxBacklogBytes       int64 = 2 << 30
 )
 
 // Iterator is the public iterator contract returned by TreeDB.
@@ -238,6 +244,36 @@ func maintenanceStatsInto(stats map[string]string, m *maintenanceCoordinator) {
 	}
 }
 
+func normalizeBackpressureDefaults(opts *Options) {
+	if opts == nil {
+		return
+	}
+	if opts.SlowdownBacklogSeconds < 0 {
+		opts.SlowdownBacklogSeconds = 0
+	}
+	if opts.StopBacklogSeconds < 0 {
+		opts.StopBacklogSeconds = 0
+	}
+	if opts.MaxBacklogBytes < 0 {
+		opts.MaxBacklogBytes = 0
+	}
+	if opts.SlowdownBacklogSeconds != 0 || opts.StopBacklogSeconds != 0 || opts.MaxBacklogBytes != 0 {
+		return
+	}
+
+	slowdown := defaultSlowdownBacklogSeconds
+	stop := defaultStopBacklogSeconds
+	if opts.Durability == db.DurabilityWALOffRelaxed &&
+		strings.ToLower(strings.TrimSpace(opts.IndexOuterLeafMode)) == db.IndexOuterLeafModeV2FencePtr {
+		slowdown = defaultV2FenceSlowdownBacklogSeconds
+		stop = defaultV2FenceStopBacklogSeconds
+	}
+
+	opts.SlowdownBacklogSeconds = slowdown
+	opts.StopBacklogSeconds = stop
+	opts.MaxBacklogBytes = defaultAdaptiveMaxBacklogBytes
+}
+
 // Open opens TreeDB. By default it enables caching (write-back layer).
 func Open(opts Options) (*DB, error) {
 	// Cached mode writes to the backend in large flush batches, so commit sequence
@@ -401,20 +437,7 @@ func Open(opts Options) (*DB, error) {
 		return &DB{backend: backend, dictdb: dictBackend, templateDB: templateDB, writePath: writePath, notifyError: opts.NotifyError, durabilityMode: computeDurabilityMode(opts), dir: rootDir}, nil
 	}
 
-	if opts.SlowdownBacklogSeconds < 0 {
-		opts.SlowdownBacklogSeconds = 0
-	}
-	if opts.StopBacklogSeconds < 0 {
-		opts.StopBacklogSeconds = 0
-	}
-	if opts.MaxBacklogBytes < 0 {
-		opts.MaxBacklogBytes = 0
-	}
-	if opts.SlowdownBacklogSeconds == 0 && opts.StopBacklogSeconds == 0 && opts.MaxBacklogBytes == 0 {
-		opts.SlowdownBacklogSeconds = 1
-		opts.StopBacklogSeconds = 2
-		opts.MaxBacklogBytes = 2 << 30
-	}
+	normalizeBackpressureDefaults(&opts)
 	if opts.MemtableMode == "" {
 		opts.MemtableMode = "adaptive"
 	}

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -641,6 +641,16 @@ func (it *Iterator) setCurrentFenceEntry(entry FenceBlockEntry) {
 	it.valid = true
 }
 
+func (it *Iterator) shouldPreferFenceKeyOnly() bool {
+	if it.mode == IteratorModeKeysOnly {
+		return true
+	}
+	// For bounded range scans in full mode, prefer key-only fence expansion.
+	// Values remain available via lazy fallback when Value()/UnsafeValue() is
+	// requested, but key-only scans avoid materializing block values they never use.
+	return it.mode == IteratorModeFull && it.start != nil && it.end != nil
+}
+
 func lowerBoundFenceEntries(entries []FenceBlockEntry, key []byte) int {
 	if len(key) == 0 {
 		return 0
@@ -667,6 +677,7 @@ func (it *Iterator) tryRepositionPendingFence(top *CursorItem) (bool, error) {
 		return false, nil
 	}
 	seekKey := it.pendingSeekKey
+	preferFenceEntries := it.slabFenceBlocks != nil && (it.slabFenceKeys == nil || !it.shouldPreferFenceKeyOnly())
 	for scan := top.Index - 1; scan >= 0; scan-- {
 		_, ptr, flags, err := top.Node.GetLeafValueView(uint16(scan))
 		if err != nil {
@@ -675,12 +686,14 @@ func (it *Iterator) tryRepositionPendingFence(top *CursorItem) (bool, error) {
 		if flags&node.FlagTombstone != 0 || flags&node.FlagPointer == 0 {
 			continue
 		}
+		keyReaderUsable := false
 		if it.slabFenceKeys != nil {
 			keys, ok, err := it.slabFenceKeys.ReadUnsafeFenceBlockKeys(ptr)
 			if err != nil {
 				return false, err
 			}
 			if ok {
+				keyReaderUsable = true
 				pos := lowerBoundFenceKeys(keys, seekKey)
 				if pos < len(keys) {
 					top.Index = scan
@@ -696,7 +709,7 @@ func (it *Iterator) tryRepositionPendingFence(top *CursorItem) (bool, error) {
 				continue
 			}
 		}
-		if it.slabFenceBlocks != nil {
+		if it.slabFenceBlocks != nil && (preferFenceEntries || !keyReaderUsable) {
 			entries, ok, err := it.slabFenceBlocks.ReadUnsafeFenceBlock(ptr)
 			if err != nil {
 				return false, err
@@ -744,7 +757,7 @@ func (it *Iterator) expandFenceBlockAt(top *CursorItem) (handled bool, produced 
 		entries []FenceBlockEntry
 		ok      bool
 	)
-	preferKeyOnlyExpansion := it.mode == IteratorModeKeysOnly || it.slabFenceBlocks == nil
+	preferKeyOnlyExpansion := it.shouldPreferFenceKeyOnly() || it.slabFenceBlocks == nil
 	if preferKeyOnlyExpansion && it.slabFenceKeys != nil {
 		keys, keyOK, keyErr := it.slabFenceKeys.ReadUnsafeFenceBlockKeys(ptr)
 		if keyErr != nil {

--- a/TreeDB/tree/iterator_test.go
+++ b/TreeDB/tree/iterator_test.go
@@ -17,6 +17,15 @@ type countingValueReader struct {
 	reads int
 }
 
+type fenceLookupReaderKeysUnavailable struct {
+	*fenceLookupReader
+}
+
+func (r *fenceLookupReaderKeysUnavailable) ReadUnsafeFenceBlockKeys(ptr page.ValuePtr) ([][]byte, bool, error) {
+	r.keyCalls++
+	return nil, false, nil
+}
+
 func newCountingValueReader() *countingValueReader {
 	return &countingValueReader{inner: newMapValueReader()}
 }
@@ -625,6 +634,144 @@ func TestIterator_FencePointerExpansionForwardAndRange(t *testing.T) {
 		if keys[i] != wantRange[i] {
 			t.Fatalf("range key[%d]=%q want=%q", i, keys[i], wantRange[i])
 		}
+	}
+}
+
+func TestIterator_FencePointerRangeFullModeUsesKeyExpansionWithLazyValues(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	if _, err := p.Alloc(1); err != nil {
+		t.Fatalf("Alloc root: %v", err)
+	}
+
+	reader := newFenceLookupReader()
+	ptr0 := reader.addBlock(map[string]string{
+		"f010": "v10",
+		"f020": "v20",
+		"f030": "v30",
+	})
+	ptr1 := reader.addBlock(map[string]string{
+		"f100": "v100",
+		"f110": "v110",
+	})
+
+	rootData, err := p.Get(0)
+	if err != nil {
+		t.Fatalf("Get root page: %v", err)
+	}
+	root := node.NewNode(rootData)
+	root.SetType(page.PageTypeLeaf)
+	root.SetPageID(0)
+	if err := root.AddLeafEntry([]byte("f010"), nil, node.FlagPointer, ptr0); err != nil {
+		t.Fatalf("AddLeafEntry(f010): %v", err)
+	}
+	if err := root.AddLeafEntry([]byte("f100"), nil, node.FlagPointer, ptr1); err != nil {
+		t.Fatalf("AddLeafEntry(f100): %v", err)
+	}
+	root.UpdateChecksum()
+
+	tr := New(p, reader, 0)
+	it := tr.Iterator([]byte("f015"), []byte("f115"))
+	defer it.Close()
+
+	var keys []string
+	var vals []string
+	for ; it.Valid(); it.Next() {
+		keys = append(keys, string(it.Key()))
+		vals = append(vals, string(it.Value()))
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+
+	wantKeys := []string{"f020", "f030", "f100", "f110"}
+	wantVals := []string{"v20", "v30", "v100", "v110"}
+	if len(keys) != len(wantKeys) {
+		t.Fatalf("keys len=%d want=%d (%v)", len(keys), len(wantKeys), keys)
+	}
+	for i := range wantKeys {
+		if keys[i] != wantKeys[i] || vals[i] != wantVals[i] {
+			t.Fatalf("entry[%d] key=%q val=%q want key=%q val=%q", i, keys[i], vals[i], wantKeys[i], wantVals[i])
+		}
+	}
+	if reader.keyCalls == 0 {
+		t.Fatalf("expected key-only fence block expansion in bounded full-mode range")
+	}
+	if reader.blockCalls == 0 {
+		t.Fatalf("expected lazy value fallback to read fence block entries")
+	}
+}
+
+func TestIterator_FencePointerRangeFullModeFallsBackWhenKeyExpansionUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	if _, err := p.Alloc(1); err != nil {
+		t.Fatalf("Alloc root: %v", err)
+	}
+
+	baseReader := newFenceLookupReader()
+	reader := &fenceLookupReaderKeysUnavailable{fenceLookupReader: baseReader}
+	ptr0 := reader.addBlock(map[string]string{
+		"f010": "v10",
+		"f020": "v20",
+		"f030": "v30",
+	})
+	ptr1 := reader.addBlock(map[string]string{
+		"f100": "v100",
+		"f110": "v110",
+	})
+
+	rootData, err := p.Get(0)
+	if err != nil {
+		t.Fatalf("Get root page: %v", err)
+	}
+	root := node.NewNode(rootData)
+	root.SetType(page.PageTypeLeaf)
+	root.SetPageID(0)
+	if err := root.AddLeafEntry([]byte("f010"), nil, node.FlagPointer, ptr0); err != nil {
+		t.Fatalf("AddLeafEntry(f010): %v", err)
+	}
+	if err := root.AddLeafEntry([]byte("f100"), nil, node.FlagPointer, ptr1); err != nil {
+		t.Fatalf("AddLeafEntry(f100): %v", err)
+	}
+	root.UpdateChecksum()
+
+	tr := New(p, reader, 0)
+	it := tr.Iterator([]byte("f015"), []byte("f115"))
+	defer it.Close()
+
+	var keys []string
+	for ; it.Valid(); it.Next() {
+		keys = append(keys, string(it.Key()))
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+
+	want := []string{"f020", "f030", "f100", "f110"}
+	if len(keys) != len(want) {
+		t.Fatalf("keys len=%d want=%d (%v)", len(keys), len(want), keys)
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("key[%d]=%q want=%q", i, keys[i], want[i])
+		}
+	}
+	if reader.keyCalls == 0 {
+		t.Fatalf("expected key-expansion attempts before fallback")
+	}
+	if reader.blockCalls == 0 {
+		t.Fatalf("expected block expansion fallback when key expansion is unavailable")
 	}
 }
 

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -61,6 +61,12 @@ type slabUnsafeFenceKeyReader interface {
 	ReadUnsafeFenceForKey(ptr page.ValuePtr, key []byte) ([]byte, bool, error)
 }
 
+// Optional capability probe for fence-key lookup mode.
+// When false, tree miss paths can skip fence fallback scans entirely.
+type slabFenceLookupMode interface {
+	FenceLookupEnabled() bool
+}
+
 // Optional block expansion reads for fence-only outer-leaf mode.
 // ok=false means the reader is not in fence expansion mode for this pointer.
 type slabUnsafeFenceBlockReader interface {
@@ -88,11 +94,6 @@ type slabKeyAwareCapability interface {
 	KeyAwareEnabled() bool
 }
 
-// Optional capability gate for fence-pointer lookup/expansion interfaces.
-type slabFenceLookupCapability interface {
-	FenceLookupEnabled() bool
-}
-
 func keyAwarePointerReadsEnabled(sr SlabReader) bool {
 	if gate, ok := sr.(slabKeyAwareCapability); ok {
 		return gate.KeyAwareEnabled()
@@ -101,7 +102,7 @@ func keyAwarePointerReadsEnabled(sr SlabReader) bool {
 }
 
 func fencePointerLookupsEnabled(sr SlabReader) bool {
-	if gate, ok := sr.(slabFenceLookupCapability); ok {
+	if gate, ok := sr.(slabFenceLookupMode); ok {
 		return gate.FenceLookupEnabled()
 	}
 	return true
@@ -113,6 +114,7 @@ type Tree struct {
 	slabAppender    slabUnsafeAppender
 	slabKeyReader   slabUnsafeKeyReader
 	slabFenceReader slabUnsafeFenceKeyReader
+	fenceLookupMode bool
 	slabFenceBlocks slabUnsafeFenceBlockReader
 	slabFenceKeys   slabUnsafeFenceBlockKeyReader
 	slabKeyAppender slabUnsafeKeyAppender
@@ -153,6 +155,7 @@ func New(p *pager.Pager, sr SlabReader, root uint64) *Tree {
 			t.slabFenceKeys = fenceKeys
 		}
 	}
+	t.fenceLookupMode = fenceEnabled && t.slabFenceReader != nil
 	return t
 }
 
@@ -209,6 +212,7 @@ func (t *Tree) Reset(p *pager.Pager, sr SlabReader, root uint64) {
 		t.slabFenceBlocks = nil
 		t.slabFenceKeys = nil
 	}
+	t.fenceLookupMode = fenceEnabled && t.slabFenceReader != nil
 	t.rootPageID = root
 }
 
@@ -304,11 +308,13 @@ func (t *Tree) GetEntry(key []byte) (node.LeafEntry, error) {
 }
 
 func (t *Tree) lookupFenceValueView(n *node.Node, idx uint16, key []byte) ([]byte, bool, error) {
-	if t.slabFenceReader == nil || n == nil || idx == 0 {
+	if !t.fenceLookupMode || t.slabFenceReader == nil || n == nil || idx == 0 {
 		return nil, false, nil
 	}
 	for scan := idx; scan > 0; scan-- {
-		_, _, ptr, flags, err := n.GetLeafEntryView(scan - 1)
+		// Fence lookup only needs pointer+flags. Avoid full leaf-entry decode
+		// (key reconstruction) on every probe in columnar-prefix leaves.
+		_, ptr, flags, err := n.GetLeafValueView(scan - 1)
 		if err != nil {
 			return nil, false, err
 		}

--- a/TreeDB/tree/tree_test.go
+++ b/TreeDB/tree/tree_test.go
@@ -23,6 +23,12 @@ type fenceLookupReader struct {
 	nextOffset uint64
 	fileID     uint32
 	fenceCalls int
+	blockCalls int
+	keyCalls   int
+}
+
+func (r *fenceLookupReader) FenceLookupEnabled() bool {
+	return true
 }
 
 func newFenceLookupReader() *fenceLookupReader {
@@ -69,6 +75,7 @@ func (r *fenceLookupReader) ReadUnsafeFenceForKey(ptr page.ValuePtr, key []byte)
 }
 
 func (r *fenceLookupReader) ReadUnsafeFenceBlock(ptr page.ValuePtr) ([]FenceBlockEntry, bool, error) {
+	r.blockCalls++
 	block, ok := r.blocks[ptr]
 	if !ok {
 		return nil, true, fmt.Errorf("missing block ptr %+v", ptr)
@@ -86,6 +93,24 @@ func (r *fenceLookupReader) ReadUnsafeFenceBlock(ptr page.ValuePtr) ([]FenceBloc
 		})
 	}
 	return entries, true, nil
+}
+
+func (r *fenceLookupReader) ReadUnsafeFenceBlockKeys(ptr page.ValuePtr) ([][]byte, bool, error) {
+	r.keyCalls++
+	block, ok := r.blocks[ptr]
+	if !ok {
+		return nil, true, fmt.Errorf("missing block ptr %+v", ptr)
+	}
+	keys := make([]string, 0, len(block))
+	for k := range block {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([][]byte, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, []byte(k))
+	}
+	return out, true, nil
 }
 
 func (r *trackedValueReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -54,7 +54,7 @@ var (
 	keysMax            = flag.Int("keys-max", 10000000, "Maximum key count for -keyscale")
 	dbsArg             = flag.String("dbs", "all", "Comma-separated list of DBs to run. Use 'all' for registered DBs.")
 	dbsExcludeArg      = flag.String("exclude-dbs", "", "Comma-separated list of DBs to exclude")
-	testArg            = flag.String("test", "all", "Comma-separated list of tests (sequential_write,random_read,random_read_parallel,random_read_parallel_acquire_snapshot,random_read_batch,random_write,random_write_parallel,dataset_write_random,dataset_write_sorted,dataset_update_fork_choice,dataset_read_random,random_delete,full_scan,prefix_scan,batch_write,batch_random,batch_delete,update_fork_choice); aliases: write_seq->sequential_write, write_rand->random_write, write_sorted->dataset_write_sorted, write_dataset->dataset_write_random, read_rand->random_read, read_rand_parallel->random_read_parallel, read_rand_batch->random_read_batch, read_random_batch->random_read_batch, delete_rand->random_delete, scan->full_scan, range_scan->prefix_scan, forkchoice->update_fork_choice")
+	testArg            = flag.String("test", "all", "Comma-separated list of tests (sequential_write,random_read,random_read_parallel,random_read_parallel_acquire_snapshot,random_read_batch,random_write,random_write_parallel,dataset_write_random,dataset_write_sorted,dataset_update_fork_choice,dataset_read_random,random_delete,full_scan,prefix_scan,batch_write,batch_write_steady,batch_random,batch_delete,update_fork_choice); aliases: write_seq->sequential_write, write_rand->random_write, write_sorted->dataset_write_sorted, write_dataset->dataset_write_random, read_rand->random_read, read_rand_parallel->random_read_parallel, read_rand_batch->random_read_batch, read_random_batch->random_read_batch, delete_rand->random_delete, scan->full_scan, range_scan->prefix_scan, batch_write_ss->batch_write_steady, forkchoice->update_fork_choice")
 	formatArg          = flag.String("format", "table", "Output format: table or markdown")
 	suiteArg           = flag.String("suite", "", "Named benchmark suite (e.g. readme)")
 	outDirArg          = flag.String("outdir", "", "Write plots/results to this directory (used by -suite readme)")
@@ -79,15 +79,17 @@ var (
 	maxWall  = flag.Duration("max-wall", 0, "Abort the benchmark run if wall time exceeds this (0=disabled)")
 	maxRSSMB = flag.Int("max-rss-mb", 0, "Abort the benchmark run if RSS exceeds this many MiB (0=disabled; Linux-only)")
 
-	checkpointBetweenTests = flag.Bool("checkpoint-between-tests", false, "Force a best-effort durability checkpoint between each benchmark test (DBs that support Checkpoint())")
-	vacuumBetweenTests     = flag.Bool("vacuum-between-tests", false, "Vacuum supported DBs between each benchmark test (implies -checkpoint-between-tests; TreeDB: VacuumIndexOnline)")
-	checkpointEveryOps     = flag.Int("checkpoint-every-ops", 0, "Force a best-effort durability checkpoint every N ops during write-heavy tests (0=disabled; DBs that support Checkpoint())")
-	checkpointEveryBytes   = flag.Int64("checkpoint-every-bytes", 0, "Force a best-effort durability checkpoint every N approx bytes during write-heavy tests (0=disabled; DBs that support Checkpoint())")
+	checkpointBetweenTests          = flag.Bool("checkpoint-between-tests", false, "Force a best-effort durability checkpoint between each benchmark test (DBs that support Checkpoint())")
+	vacuumBetweenTests              = flag.Bool("vacuum-between-tests", false, "Vacuum supported DBs between each benchmark test (implies -checkpoint-between-tests; TreeDB: VacuumIndexOnline)")
+	checkpointEveryOps              = flag.Int("checkpoint-every-ops", 0, "Force a best-effort durability checkpoint every N ops during write-heavy tests (0=disabled; DBs that support Checkpoint())")
+	checkpointEveryBytes            = flag.Int64("checkpoint-every-bytes", 0, "Force a best-effort durability checkpoint every N approx bytes during write-heavy tests (0=disabled; DBs that support Checkpoint())")
+	batchWriteSteadyCheckpointBytes = flag.Int64("batch-write-steady-checkpoint-bytes", 64<<20, "batch_write_steady: default periodic checkpoint interval in bytes when checkpoint-every-* flags are unset (0 disables)")
 
 	flushdrainCheckpointMax = flag.Duration("flushdrain-checkpoint-max", 0, "Abort flushdrain suite if checkpoint-before-random_read exceeds this duration (0=disabled)")
 
 	settleBeforeScans           = flag.Bool("settle-before-scans", false, "Close+reopen DBs before scan tests to measure settled scan performance (flushes caches/WAL)")
 	treedbCacheStatsBeforeReads = flag.Bool("treedb-cache-stats-before-reads", false, "Print select treedb.cache.* stats before read/scan tests (treedb only)")
+	treedbCacheStatsAfterTests  = flag.Bool("treedb-cache-stats-after-tests", false, "Print select treedb.cache.* stats after each benchmark test (treedb only)")
 )
 
 var explicitFlags = map[string]bool{}
@@ -146,10 +148,11 @@ type BenchConfig struct {
 	MaxWall  time.Duration
 	MaxRSSMB int
 
-	CheckpointBetweenTests bool
-	VacuumBetweenTests     bool
-	CheckpointEveryOps     int
-	CheckpointEveryBytes   int64
+	CheckpointBetweenTests          bool
+	VacuumBetweenTests              bool
+	CheckpointEveryOps              int
+	CheckpointEveryBytes            int64
+	BatchWriteSteadyCheckpointBytes int64
 
 	SettleBeforeScans bool
 
@@ -163,6 +166,7 @@ type BenchConfig struct {
 	TreeDBDisablePiggybackCompaction bool
 
 	TreeDBCacheStatsBeforeReads bool
+	TreeDBCacheStatsAfterTests  bool
 }
 
 type dirDiskUsage struct {
@@ -321,6 +325,21 @@ func main() {
 	}
 	fmt.Fprintf(os.Stderr, "DBs:         %s\n", *dbsArg)
 	fmt.Fprintf(os.Stderr, "Tests:       %s\n", *testArg)
+	selectedTests := normalizeTests(parseList(*testArg))
+	selectedDBs := resolveDBs(*dbsArg, *dbsExcludeArg)
+	runsTreeDB := false
+	for _, name := range selectedDBs {
+		if strings.HasPrefix(strings.ToLower(name), "treedb") {
+			runsTreeDB = true
+			break
+		}
+	}
+	hasAllTests := contains(selectedTests, "all")
+	runsBatchWrite := hasAllTests || contains(selectedTests, "batch_write")
+	runsBatchWriteSteady := hasAllTests || contains(selectedTests, "batch_write_steady")
+	if runsTreeDB && runsBatchWrite && !runsBatchWriteSteady {
+		fmt.Fprintf(os.Stderr, "Note:        TreeDB batch_write reports front-end ingest only; use batch_write_steady for settled backend throughput.\n")
+	}
 	fmt.Fprintf(os.Stderr, "Seed:        %d\n", seedUsed)
 	fmt.Fprintf(os.Stderr, "\n")
 
@@ -362,8 +381,10 @@ func main() {
 		VacuumBetweenTests:               *vacuumBetweenTests,
 		CheckpointEveryOps:               *checkpointEveryOps,
 		CheckpointEveryBytes:             *checkpointEveryBytes,
+		BatchWriteSteadyCheckpointBytes:  *batchWriteSteadyCheckpointBytes,
 		SettleBeforeScans:                *settleBeforeScans,
 		TreeDBCacheStatsBeforeReads:      *treedbCacheStatsBeforeReads,
+		TreeDBCacheStatsAfterTests:       *treedbCacheStatsAfterTests,
 		TreeDBIterDebug:                  *treedbIterDebug,
 		TreeDBIterDebugLimit:             *treedbIterDebugLimit,
 		TreeDBDisableWAL:                 *treedbDisableWAL,
@@ -873,8 +894,10 @@ func printTreeDBCacheStats(w io.Writer, inst *DBInstance, prefix string) {
 		"treedb.cache.flush_threshold_bytes",
 		"treedb.cache.max_queued_memtables",
 		"treedb.cache.flush_bps_ewma",
+		"treedb.cache.stats.backend_write_batches_total",
 		"treedb.cache.wal_bytes_estimate",
 		"treedb.cache.vlog_retained_bytes_estimate",
+		"treedb.cache.materialization.lag_age_ms",
 		"treedb.cache.vlog_auto.frames.off",
 		"treedb.cache.vlog_auto.frames.dict",
 		"treedb.cache.vlog_auto.frames.block_snappy",
@@ -896,6 +919,31 @@ func printTreeDBCacheStats(w io.Writer, inst *DBInstance, prefix string) {
 		"treedb.cache.vlog_dict.frames_attempted",
 		"treedb.cache.vlog_dict.frames_kept",
 		"treedb.cache.vlog_dict.current_k",
+		"treedb.cache.vlog_writev.syscalls",
+		"treedb.cache.vlog_writev.bytes",
+		"treedb.cache.vlog_writev.iovecs",
+		"treedb.cache.vlog_writev.flushes",
+		"treedb.cache.vlog_writev.bytes_per_syscall",
+		"treedb.cache.vlog_writev.iovecs_per_syscall",
+		"treedb.cache.vlog_writev.bytes_per_flush",
+		"treedb.cache.vlog_writev.syscalls_per_flush",
+		"treedb.cache.vlog_write.syscalls",
+		"treedb.cache.vlog_write.bytes",
+		"treedb.cache.vlog_write.calls",
+		"treedb.cache.vlog_write.bytes_per_syscall",
+		"treedb.cache.vlog_write.bytes_per_call",
+		"treedb.cache.vlog_write.syscalls_per_call",
+		"treedb.cache.vlog_io.syscalls",
+		"treedb.cache.vlog_io.bytes",
+		"treedb.cache.vlog_io.bytes_per_syscall",
+		"treedb.cache.v2_fenceptr.deferred_candidates",
+		"treedb.cache.v2_fenceptr.deferred_groups",
+		"treedb.cache.v2_fenceptr.deferred_pending_keys_estimate",
+		"treedb.cache.v2_fenceptr.deferred_pending_bytes_estimate",
+		"treedb.cache.v2_fenceptr.avg_keys_per_group",
+		"treedb.cache.v2_fenceptr.assist_calls",
+		"treedb.cache.v2_fenceptr.assist_flushed_memtables",
+		"treedb.cache.v2_fenceptr.assist_early_triggers",
 		"treedb.vlog.outer_leaf_block_cache.hits",
 		"treedb.vlog.outer_leaf_block_cache.misses",
 		"treedb.vlog.outer_leaf_block_cache.hit_ratio",
@@ -1298,6 +1346,170 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	encodeKey := func(dst []byte, key uint64) {
 		keyShape.encode(dst, key)
 	}
+	runBatchWrite := func(db kvstore.DB, steady bool) (float64, error) {
+		batcher, ok := db.(kvstore.Batcher)
+		if !ok {
+			return math.NaN(), nil
+		}
+		testLabel := "batch_write"
+		if steady {
+			testLabel = "batch_write_steady"
+		}
+		values, err := getWriteValuePool()
+		if err != nil {
+			return 0, fmt.Errorf("%s values: %w", testLabel, err)
+		}
+		start := time.Now()
+		pc := newPeriodicCheckpoint(cfg)
+		if steady && pc == nil && cfg.BatchWriteSteadyCheckpointBytes > 0 {
+			pc = &periodicCheckpoint{everyBytes: cfg.BatchWriteSteadyCheckpointBytes}
+		}
+		perOpBytes := int64(8 + cfg.ValueSize)
+		total := cfg.Keys
+		valPos := 0
+		// Keep the precomputed-key optimization bounded so very large runs do
+		// not retain a huge contiguous key buffer for the whole benchmark.
+		const maxPrecomputedKeyBytes = 128 << 20 // 128 MiB
+		precomputeKeys := total > 0 && total <= maxPrecomputedKeyBytes/8
+		var keyBytes []byte
+		if precomputeKeys {
+			keyBytes = make([]byte, total*8)
+			for j := 0; j < total; j++ {
+				encodeKey(keyBytes[j*8:(j+1)*8], uint64(j+cfg.Keys))
+			}
+		}
+		type batcherWithSize interface {
+			NewBatchWithSize(size int) (kvstore.Batch, error)
+		}
+		type batchSetView interface {
+			SetView(key, value []byte) error
+		}
+		type resettableBatch interface {
+			Reset()
+		}
+		var (
+			batch      kvstore.Batch
+			setView    func(key, value []byte) error
+			resetBatch func()
+		)
+		openBatch := func() error {
+			var err error
+			if bs, ok := batcher.(batcherWithSize); ok {
+				batch, err = bs.NewBatchWithSize(cfg.BatchSize)
+			} else {
+				batch, err = batcher.NewBatch()
+			}
+			if err != nil {
+				return err
+			}
+			setView = nil
+			if sv, ok := batch.(batchSetView); ok {
+				setView = sv.SetView
+			}
+			resetBatch = nil
+			if rb, ok := batch.(resettableBatch); ok {
+				resetBatch = rb.Reset
+			}
+			return nil
+		}
+		defer func() {
+			if batch != nil {
+				_ = batch.Close()
+			}
+		}()
+		for i := 0; i < total; i += cfg.BatchSize {
+			if i&8191 == 0 {
+				if err := guard.Checkpoint(); err != nil {
+					return 0, err
+				}
+			}
+			if batch == nil {
+				if err := openBatch(); err != nil {
+					return 0, fmt.Errorf("%s: new batch: %w", testLabel, err)
+				}
+			} else if resetBatch != nil {
+				resetBatch()
+			} else {
+				if err := batch.Close(); err != nil {
+					return 0, fmt.Errorf("%s: close: %w", testLabel, err)
+				}
+				batch = nil
+				if err := openBatch(); err != nil {
+					return 0, fmt.Errorf("%s: new batch: %w", testLabel, err)
+				}
+			}
+
+			end := i + cfg.BatchSize
+			if end > total {
+				end = total
+			}
+			if setView != nil {
+				if precomputeKeys {
+					// batch_write uses immutable values from a prebuilt pool and
+					// precomputed immutable keys.
+					for j := i; j < end; j++ {
+						keyView := keyBytes[j*8 : (j+1)*8]
+						value := values[valPos%len(values)]
+						valPos++
+						if err := setView(keyView, value); err != nil {
+							return 0, fmt.Errorf("%s: set: %w", testLabel, err)
+						}
+					}
+				} else {
+					// Keep the zero-copy SetView path for large key counts by using
+					// one owned key slab per batch (stable beyond Commit()).
+					need := (end - i) * 8
+					keysView := make([]byte, need)
+					for j := i; j < end; j++ {
+						off := (j - i) * 8
+						keyView := keysView[off : off+8]
+						encodeKey(keyView, uint64(j+cfg.Keys))
+						value := values[valPos%len(values)]
+						valPos++
+						if err := setView(keyView, value); err != nil {
+							return 0, fmt.Errorf("%s: set: %w", testLabel, err)
+						}
+					}
+				}
+			} else {
+				for j := i; j < end; j++ {
+					var keyView []byte
+					if precomputeKeys {
+						keyView = keyBytes[j*8 : (j+1)*8]
+					} else {
+						var key [8]byte
+						encodeKey(key[:], uint64(j+cfg.Keys))
+						keyView = key[:]
+					}
+					value := values[valPos%len(values)]
+					valPos++
+					if err := batch.Set(keyView, value); err != nil {
+						return 0, fmt.Errorf("%s: set: %w", testLabel, err)
+					}
+				}
+			}
+			if err := batch.Commit(); err != nil {
+				return 0, fmt.Errorf("%s: commit: %w", testLabel, err)
+			}
+			if resetBatch == nil {
+				if err := batch.Close(); err != nil {
+					return 0, fmt.Errorf("%s: close: %w", testLabel, err)
+				}
+				batch = nil
+			}
+			if err := pc.Add(db, end-i, int64(end-i)*perOpBytes); err != nil {
+				return 0, fmt.Errorf("%s checkpoint: %w", testLabel, err)
+			}
+		}
+		if steady {
+			if cp, ok := db.(checkpointer); ok {
+				if err := cp.Checkpoint(); err != nil {
+					return 0, fmt.Errorf("%s final checkpoint: %w", testLabel, err)
+				}
+			}
+		}
+		return float64(total) / time.Since(start).Seconds(), nil
+	}
 	testFuncs := map[string]TestFunc{
 		"vacuum_index": func(db kvstore.DB, _ *rand.Rand) (float64, error) {
 			td, ok := db.(*treedbadapter.DB)
@@ -1540,137 +1752,10 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			return float64(len(datasetSortedKeys)) / time.Since(start).Seconds(), nil
 		},
 		"batch_write": func(db kvstore.DB, _ *rand.Rand) (float64, error) {
-			batcher, ok := db.(kvstore.Batcher)
-			if !ok {
-				return math.NaN(), nil
-			}
-			values, err := getWriteValuePool()
-			if err != nil {
-				return 0, fmt.Errorf("batch_write values: %w", err)
-			}
-			start := time.Now()
-			pc := newPeriodicCheckpoint(cfg)
-			perOpBytes := int64(8 + cfg.ValueSize)
-			total := cfg.Keys
-			valPos := 0
-			// Keep the precomputed-key optimization bounded so very large runs do
-			// not retain a huge contiguous key buffer for the whole benchmark.
-			const maxPrecomputedKeyBytes = 128 << 20 // 128 MiB
-			precomputeKeys := total > 0 && total <= maxPrecomputedKeyBytes/8
-			var keyBytes []byte
-			if precomputeKeys {
-				keyBytes = make([]byte, total*8)
-				for j := 0; j < total; j++ {
-					encodeKey(keyBytes[j*8:(j+1)*8], uint64(j+cfg.Keys))
-				}
-			}
-			type batcherWithSize interface {
-				NewBatchWithSize(size int) (kvstore.Batch, error)
-			}
-			type batchSetView interface {
-				SetView(key, value []byte) error
-			}
-			type resettableBatch interface {
-				Reset()
-			}
-			var (
-				batch      kvstore.Batch
-				setView    func(key, value []byte) error
-				resetBatch func()
-			)
-			openBatch := func() error {
-				var err error
-				if bs, ok := batcher.(batcherWithSize); ok {
-					batch, err = bs.NewBatchWithSize(cfg.BatchSize)
-				} else {
-					batch, err = batcher.NewBatch()
-				}
-				if err != nil {
-					return err
-				}
-				setView = nil
-				if sv, ok := batch.(batchSetView); ok {
-					setView = sv.SetView
-				}
-				resetBatch = nil
-				if rb, ok := batch.(resettableBatch); ok {
-					resetBatch = rb.Reset
-				}
-				return nil
-			}
-			defer func() {
-				if batch != nil {
-					_ = batch.Close()
-				}
-			}()
-			for i := 0; i < total; i += cfg.BatchSize {
-				if i&8191 == 0 {
-					if err := guard.Checkpoint(); err != nil {
-						return 0, err
-					}
-				}
-				if batch == nil {
-					if err := openBatch(); err != nil {
-						return 0, fmt.Errorf("batch_write: new batch: %w", err)
-					}
-				} else if resetBatch != nil {
-					resetBatch()
-				} else {
-					if err := batch.Close(); err != nil {
-						return 0, fmt.Errorf("batch_write: close: %w", err)
-					}
-					batch = nil
-					if err := openBatch(); err != nil {
-						return 0, fmt.Errorf("batch_write: new batch: %w", err)
-					}
-				}
-
-				end := i + cfg.BatchSize
-				if end > total {
-					end = total
-				}
-				if setView != nil && precomputeKeys {
-					// batch_write uses immutable values from a prebuilt pool and
-					// precomputed immutable keys.
-					for j := i; j < end; j++ {
-						keyView := keyBytes[j*8 : (j+1)*8]
-						value := values[valPos%len(values)]
-						valPos++
-						if err := setView(keyView, value); err != nil {
-							return 0, fmt.Errorf("batch_write: set: %w", err)
-						}
-					}
-				} else {
-					for j := i; j < end; j++ {
-						var keyView []byte
-						if precomputeKeys {
-							keyView = keyBytes[j*8 : (j+1)*8]
-						} else {
-							var key [8]byte
-							encodeKey(key[:], uint64(j+cfg.Keys))
-							keyView = key[:]
-						}
-						value := values[valPos%len(values)]
-						valPos++
-						if err := batch.Set(keyView, value); err != nil {
-							return 0, fmt.Errorf("batch_write: set: %w", err)
-						}
-					}
-				}
-				if err := batch.Commit(); err != nil {
-					return 0, fmt.Errorf("batch_write: commit: %w", err)
-				}
-				if resetBatch == nil {
-					if err := batch.Close(); err != nil {
-						return 0, fmt.Errorf("batch_write: close: %w", err)
-					}
-					batch = nil
-				}
-				if err := pc.Add(db, end-i, int64(end-i)*perOpBytes); err != nil {
-					return 0, fmt.Errorf("batch_write checkpoint: %w", err)
-				}
-			}
-			return float64(total) / time.Since(start).Seconds(), nil
+			return runBatchWrite(db, false)
+		},
+		"batch_write_steady": func(db kvstore.DB, _ *rand.Rand) (float64, error) {
+			return runBatchWrite(db, true)
 		},
 		"batch_random": func(db kvstore.DB, rng *rand.Rand) (float64, error) {
 			batcher, ok := db.(kvstore.Batcher)
@@ -2589,7 +2674,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		},
 	}
 
-	allTestOrder := []string{"sequential_write", "random_write", "dataset_write_random", "dataset_write_sorted", "batch_write", "batch_random", "batch_delete", "batch_small_seq", "random_delete", "random_read", "random_read_parallel", "random_read_parallel_acquire_snapshot", "random_read_batch", "full_scan", "prefix_scan"}
+	allTestOrder := []string{"sequential_write", "random_write", "dataset_write_random", "dataset_write_sorted", "batch_write", "batch_write_steady", "batch_random", "batch_delete", "batch_small_seq", "random_delete", "random_read", "random_read_parallel", "random_read_parallel_acquire_snapshot", "random_read_batch", "full_scan", "prefix_scan"}
 	displayNames := map[string]string{
 		"vacuum_index":                          "VACUUM (Index)",
 		"fragmentation_report_pre":              "Fragmentation Report (Pre-Settle)",
@@ -2608,6 +2693,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		"prefix_scan":                           "Prefix Scan",
 		"prefix_scan2":                          "Prefix Scan (After VACUUM)",
 		"batch_write":                           "Batch Write",
+		"batch_write_steady":                    "Batch Write (Steady)",
 		"batch_random":                          "Batch Random",
 		"batch_delete":                          "Batch Delete",
 		"batch_small_seq":                       "Batch Small Seq",
@@ -2650,7 +2736,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	if containsAny(finalTestOrder, "random_write", "random_write_parallel", "batch_random", "update_fork_choice") {
 		setMaxEncoded(mulUint64Cap(uint64(cfg.Keys), 10))
 	}
-	if containsAny(finalTestOrder, "batch_write", "prefix_scan", "prefix_scan2") {
+	if containsAny(finalTestOrder, "batch_write", "batch_write_steady", "prefix_scan", "prefix_scan2") {
 		setMaxEncoded(mulUint64Cap(uint64(cfg.Keys), 2))
 	}
 	if err := keyShape.validate(maxEncodedKey); err != nil {
@@ -2667,6 +2753,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		"dataset_write_random",
 		"dataset_write_sorted",
 		"batch_write",
+		"batch_write_steady",
 		"batch_random",
 		"batch_small_seq",
 	)
@@ -2702,7 +2789,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		expectedFullScanCount = cfg.Keys
 	}
 
-	if contains(finalTestOrder, "batch_write") && !contains(finalTestOrder, "sequential_write") && !contains(finalTestOrder, "random_write") && !contains(finalTestOrder, "dataset_write_random") && !contains(finalTestOrder, "dataset_write_sorted") {
+	if containsAny(finalTestOrder, "batch_write", "batch_write_steady") && !contains(finalTestOrder, "sequential_write") && !contains(finalTestOrder, "random_write") && !contains(finalTestOrder, "dataset_write_random") && !contains(finalTestOrder, "dataset_write_sorted") {
 		prefixScanBase = cfg.Keys
 	}
 
@@ -2956,6 +3043,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 
 			// Update live table cell
 			_ = liveTbl.UpdateCell(testName, inst.Wrapper.Name(), opsPerSec)
+		}
+		if cfg.TreeDBCacheStatsAfterTests {
+			for _, inst := range instances {
+				printTreeDBCacheStats(os.Stderr, inst, "post-"+testName+" treedb.cache")
+			}
 		}
 	}
 
@@ -4231,6 +4323,8 @@ func normalizeTests(list []string) []string {
 			t = "batch_random"
 		case "batch_write_small_seq":
 			t = "batch_small_seq"
+		case "batch_write_ss":
+			t = "batch_write_steady"
 		}
 		if t == "" {
 			continue

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -174,6 +174,31 @@ func TestRunBenchmark_RandomReadBatch_Smoke(t *testing.T) {
 	}
 }
 
+func TestRunBenchmark_BatchWriteSteady_Smoke(t *testing.T) {
+	run, err := runBenchmark(BenchConfig{
+		Keys:         2_000,
+		ValueSize:    16,
+		BatchSize:    128,
+		RangeQueries: 50,
+		RangeSpan:    20,
+		DBsArg:       "treedb",
+		TestsArg:     "batch_write_steady",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	got, ok := run.Results["batch_write_steady"]["TreeDB"]
+	if !ok {
+		t.Fatalf("expected batch_write_steady result for TreeDB")
+	}
+	if math.IsNaN(got) || got <= 0 {
+		t.Fatalf("expected batch_write_steady > 0 for TreeDB, got %v", got)
+	}
+}
+
 func TestRunBenchmark_RandomReadBatch_PropagatesReadBatchError(t *testing.T) {
 	want := errors.New("readbatch forced failure")
 	runRandomReadBatchErrorCase(t, "random_read_batch_error_db_batch_reader", func(_ string) (kvstore.DB, error) {

--- a/cmd/unified_bench/profiles.go
+++ b/cmd/unified_bench/profiles.go
@@ -28,6 +28,9 @@ func init() {
 		setBoolIfUnset("treedb-allow-unsafe", true, isSet, treedbAllowUnsafe)
 		setBoolIfUnset("treedb-index-optimizations", true, isSet, treedbIndexOptimizations)
 		setStringIfUnset("treedb-vlog-auto-policy", "throughput", isSet, treedbVlogAutoPolicy)
+		// Fence-pointer outer-leaf reads are decode-heavy without a decoded-block
+		// cache; keep a moderate default in throughput profiles.
+		setIntIfUnset("treedb-outer-leaf-block-cache-entries", 8192, isSet, treedbOuterLeafBlockCacheEntries)
 
 		// Badger
 		setBoolIfUnset("badger-nosync", true, isSet, badgerNoSync)
@@ -57,6 +60,8 @@ func init() {
 		setBoolIfUnset("treedb-allow-unsafe", true, isSet, treedbAllowUnsafe)
 		setBoolIfUnset("treedb-index-optimizations", true, isSet, treedbIndexOptimizations)
 		setStringIfUnset("treedb-vlog-auto-policy", "throughput", isSet, treedbVlogAutoPolicy)
+		// Match fast profile defaults for decode-heavy fence-pointer reads.
+		setIntIfUnset("treedb-outer-leaf-block-cache-entries", 8192, isSet, treedbOuterLeafBlockCacheEntries)
 
 		// Other DBs: match "fast" behavior (nosync).
 		setBoolIfUnset("badger-nosync", true, isSet, badgerNoSync)

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -10,6 +10,7 @@ type savedTreeDBFlagState struct {
 	packedValuePtr     bool
 	internalBaseDelta  bool
 	vlogAutoPolicy     string
+	outerLeafCache     int
 	disableWAL         bool
 	relaxedSync        bool
 	disableChecksum    bool
@@ -31,6 +32,7 @@ func saveTreeDBFlagState() savedTreeDBFlagState {
 		packedValuePtr:     *treedbIndexPackedValuePtr,
 		internalBaseDelta:  *treedbIndexInternalBaseDelta,
 		vlogAutoPolicy:     *treedbVlogAutoPolicy,
+		outerLeafCache:     *treedbOuterLeafBlockCacheEntries,
 		disableWAL:         *treedbDisableWAL,
 		relaxedSync:        *treedbRelaxedSync,
 		disableChecksum:    *treedbDisableReadChecksum,
@@ -48,6 +50,7 @@ func restoreTreeDBFlagState(s savedTreeDBFlagState) {
 	*treedbIndexPackedValuePtr = s.packedValuePtr
 	*treedbIndexInternalBaseDelta = s.internalBaseDelta
 	*treedbVlogAutoPolicy = s.vlogAutoPolicy
+	*treedbOuterLeafBlockCacheEntries = s.outerLeafCache
 	*treedbDisableWAL = s.disableWAL
 	*treedbRelaxedSync = s.relaxedSync
 	*treedbDisableReadChecksum = s.disableChecksum
@@ -64,6 +67,7 @@ func resetTreeDBIndexFlagsForTest() {
 	*treedbIndexPackedValuePtr = false
 	*treedbIndexInternalBaseDelta = false
 	*treedbVlogAutoPolicy = "balanced"
+	*treedbOuterLeafBlockCacheEntries = 0
 	*treedbDisableWAL = false
 	*treedbRelaxedSync = false
 	*treedbDisableReadChecksum = false
@@ -86,6 +90,9 @@ func TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations(t *testing.T) {
 	if got := *treedbVlogAutoPolicy; got != "throughput" {
 		t.Fatalf("expected fast profile to set treedb-vlog-auto-policy=throughput, got %q", got)
 	}
+	if got := *treedbOuterLeafBlockCacheEntries; got != 8192 {
+		t.Fatalf("expected fast profile to set treedb-outer-leaf-block-cache-entries=8192, got %d", got)
+	}
 
 	resetTreeDBIndexFlagsForTest()
 	if err := applyProfile("wal_on_fast", map[string]bool{}); err != nil {
@@ -96,6 +103,9 @@ func TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations(t *testing.T) {
 	}
 	if got := *treedbVlogAutoPolicy; got != "throughput" {
 		t.Fatalf("expected wal_on_fast profile to set treedb-vlog-auto-policy=throughput, got %q", got)
+	}
+	if got := *treedbOuterLeafBlockCacheEntries; got != 8192 {
+		t.Fatalf("expected wal_on_fast profile to set treedb-outer-leaf-block-cache-entries=8192, got %d", got)
 	}
 }
 
@@ -117,6 +127,23 @@ func TestApplyProfile_FastKeepsDefaultFlushThreshold(t *testing.T) {
 	}
 	if got, want := *treedbFlushThreshold, int64(64*1024*1024); got != want {
 		t.Fatalf("wal_on_fast profile flush threshold = %d want %d", got, want)
+	}
+}
+
+func TestApplyProfile_FastRespectsExplicitOuterLeafCacheOverride(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbOuterLeafBlockCacheEntries = 256
+	explicitFlags = map[string]bool{
+		"treedb-outer-leaf-block-cache-entries": true,
+	}
+	if err := applyProfile("fast", explicitFlags); err != nil {
+		t.Fatalf("applyProfile fast: %v", err)
+	}
+	if got := *treedbOuterLeafBlockCacheEntries; got != 256 {
+		t.Fatalf("expected explicit outer leaf cache override to remain 256, got %d", got)
 	}
 }
 

--- a/scripts/outerleaf_v2_perf_gate.sh
+++ b/scripts/outerleaf_v2_perf_gate.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+RUNS="${RUNS:-3}"
+WARMUP_RUNS="${WARMUP_RUNS:-1}"
+KEYS="${KEYS:-1000000}"
+BATCHSIZE="${BATCHSIZE:-8000}"
+SEED="${SEED:-1}"
+PROFILES="${PROFILES:-fast,wal_on_fast,durable}"
+TESTS="${TESTS:-batch_write,batch_write_steady,prefix_scan}"
+VAL_PATTERN="${VAL_PATTERN:-repeat_tail64}"
+RANGE_QUERIES="${RANGE_QUERIES:-200}"
+RANGE_SPAN="${RANGE_SPAN:-100}"
+CHUNK_SIZE="${CHUNK_SIZE:-262144}"
+BATCH_WRITE_STEADY_CHECKPOINT_BYTES="${BATCH_WRITE_STEADY_CHECKPOINT_BYTES:-67108864}"
+CHECKPOINT_BETWEEN_TESTS="${CHECKPOINT_BETWEEN_TESTS:-1}"
+
+STRICT_GATE="${STRICT_GATE:-1}"
+GATE_PROFILES="${GATE_PROFILES:-fast}"
+GATE_MIN_RATIO_BATCH_WRITE="${GATE_MIN_RATIO_BATCH_WRITE:-0.70}"
+GATE_MIN_RATIO_BATCH_WRITE_STEADY="${GATE_MIN_RATIO_BATCH_WRITE_STEADY:-0.70}"
+GATE_MIN_RATIO_PREFIX_SCAN="${GATE_MIN_RATIO_PREFIX_SCAN:-0.35}"
+
+OUT_ROOT="${OUT_DIR:-$ROOT/artifacts/perf}"
+TS=$(date +%Y%m%d%H%M%S)
+OUT="${OUT_ROOT}/outerleaf_v2_gate_${TS}"
+mkdir -p "$OUT/runs"
+
+if (( RUNS < 1 )); then
+  echo "RUNS must be >= 1" >&2
+  exit 2
+fi
+if (( WARMUP_RUNS < 0 )); then
+  echo "WARMUP_RUNS must be >= 0" >&2
+  exit 2
+fi
+
+make unified-bench >/dev/null
+
+cat >"$OUT/meta.txt" <<META
+ts=$TS
+root=$ROOT
+git_rev=$(git rev-parse HEAD)
+git_branch=$(git rev-parse --abbrev-ref HEAD)
+runs=$RUNS
+warmup_runs=$WARMUP_RUNS
+keys=$KEYS
+batchsize=$BATCHSIZE
+seed=$SEED
+profiles=$PROFILES
+tests=$TESTS
+val_pattern=$VAL_PATTERN
+range_queries=$RANGE_QUERIES
+range_span=$RANGE_SPAN
+chunk_size=$CHUNK_SIZE
+batch_write_steady_checkpoint_bytes=$BATCH_WRITE_STEADY_CHECKPOINT_BYTES
+checkpoint_between_tests=$CHECKPOINT_BETWEEN_TESTS
+strict_gate=$STRICT_GATE
+gate_profiles=$GATE_PROFILES
+gate_min_ratio_batch_write=$GATE_MIN_RATIO_BATCH_WRITE
+gate_min_ratio_batch_write_steady=$GATE_MIN_RATIO_BATCH_WRITE_STEADY
+gate_min_ratio_prefix_scan=$GATE_MIN_RATIO_PREFIX_SCAN
+META
+
+cases=(
+  "v1_inline|-treedb-index-outer-leaf-mode=v1 -treedb-force-value-pointers=false"
+  "v1_forceptr|-treedb-index-outer-leaf-mode=v1 -treedb-force-value-pointers=true"
+  "v2_fenceptr|-treedb-index-outer-leaf-mode=v2_fenceptr -treedb-force-value-pointers=true"
+)
+
+CASES_FILE="$OUT/cases.tsv"
+printf '%s\n' "${cases[@]}" >"$CASES_FILE"
+
+run_one() {
+  local profile="$1"
+  local case_id="$2"
+  local variant_flags="$3"
+  local phase="$4"
+  local idx="$5"
+
+  local out_dir="$OUT/runs/$profile/$case_id"
+  mkdir -p "$out_dir"
+  local log="$out_dir/${phase}_${idx}.md"
+
+  local cmd=(
+    ./bin/unified-bench
+    -dbs treedb
+    -profile "$profile"
+    -keys "$KEYS"
+    -batchsize "$BATCHSIZE"
+    -test "$TESTS"
+    -val-pattern "$VAL_PATTERN"
+    -range-queries "$RANGE_QUERIES"
+    -range-span "$RANGE_SPAN"
+    -treedb-chunk-size "$CHUNK_SIZE"
+    -batch-write-steady-checkpoint-bytes "$BATCH_WRITE_STEADY_CHECKPOINT_BYTES"
+    -progress=true
+    -format text
+    -seed "$SEED"
+  )
+  if [[ "$CHECKPOINT_BETWEEN_TESTS" != "0" ]]; then
+    cmd+=(-checkpoint-between-tests)
+  fi
+
+  # shellcheck disable=SC2206
+  local flags=( $variant_flags )
+  cmd+=("${flags[@]}")
+  "${cmd[@]}" >"$log" 2>&1
+}
+
+IFS=',' read -r -a profile_list <<<"$PROFILES"
+for profile in "${profile_list[@]}"; do
+  profile="${profile//[[:space:]]/}"
+  if [[ -z "$profile" ]]; then
+    continue
+  fi
+  for spec in "${cases[@]}"; do
+    IFS='|' read -r case_id variant_flags <<<"$spec"
+    echo "--- profile=$profile case=$case_id ---" >&2
+    for ((i = 1; i <= WARMUP_RUNS; i++)); do
+      run_one "$profile" "$case_id" "$variant_flags" warmup "$i"
+    done
+    for ((i = 1; i <= RUNS; i++)); do
+      run_one "$profile" "$case_id" "$variant_flags" measured "$i"
+    done
+  done
+done
+
+python3 - "$OUT" "$CASES_FILE" <<'PY'
+import json
+import re
+import statistics
+import sys
+from pathlib import Path
+
+out = Path(sys.argv[1])
+cases_file = Path(sys.argv[2])
+
+meta = {}
+for line in (out / "meta.txt").read_text().splitlines():
+    if "=" in line:
+        k, v = line.split("=", 1)
+        meta[k] = v
+
+profiles = [p.strip() for p in meta.get("profiles", "").split(",") if p.strip()]
+tests = [t.strip() for t in meta.get("tests", "").split(",") if t.strip()]
+gate_profiles = {p.strip() for p in meta.get("gate_profiles", "").split(",") if p.strip()}
+strict_gate = meta.get("strict_gate", "1") not in {"0", "false", "False"}
+
+thresholds = {
+    "batch_write": float(meta.get("gate_min_ratio_batch_write", "0.70")),
+    "batch_write_steady": float(meta.get("gate_min_ratio_batch_write_steady", "0.70")),
+    "prefix_scan": float(meta.get("gate_min_ratio_prefix_scan", "0.35")),
+}
+
+cases = []
+for raw in cases_file.read_text().splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    case_id, flags = raw.split("|", 1)
+    cases.append({"id": case_id, "flags": flags})
+
+display = {
+    "batch_write": "Batch Write",
+    "batch_write_steady": "Batch Write (Steady)",
+    "prefix_scan": "Prefix Scan",
+}
+
+pattern_cache = {}
+def metric_pattern(test_name: str):
+    key = test_name
+    if key in pattern_cache:
+        return pattern_cache[key]
+    disp = re.escape(display.get(test_name, test_name))
+    pat = re.compile(rf"^{disp} / TreeDB = ([0-9][0-9,]*(?:\.[0-9]+)?)\s*$", re.M)
+    pattern_cache[key] = pat
+    return pat
+
+def parse_metric(path: Path, test_name: str):
+    text = path.read_text()
+    m = metric_pattern(test_name).search(text)
+    if not m:
+        return None
+    return float(m.group(1).replace(",", ""))
+
+def median(vals):
+    return float(statistics.median(vals))
+
+rows = []
+failures = []
+
+for profile in profiles:
+    for case in cases:
+        case_id = case["id"]
+        logs = sorted((out / "runs" / profile / case_id).glob("measured_*.md"))
+        if not logs:
+            if profile in gate_profiles:
+                for test_name in tests:
+                    failures.append({
+                        "profile": profile,
+                        "case": case_id,
+                        "test": test_name,
+                        "reason": "missing measured logs for case",
+                    })
+            continue
+        for test_name in tests:
+            vals = []
+            missing_metrics = False
+            for log in logs:
+                v = parse_metric(log, test_name)
+                if v is None:
+                    missing_metrics = True
+                    continue
+                vals.append(v)
+            if not vals:
+                if profile in gate_profiles:
+                    failures.append({
+                        "profile": profile,
+                        "case": case_id,
+                        "test": test_name,
+                        "reason": "no metrics parsed for test",
+                    })
+                continue
+            if missing_metrics and profile in gate_profiles:
+                failures.append({
+                    "profile": profile,
+                    "case": case_id,
+                    "test": test_name,
+                    "reason": "some measured logs missing metric for test",
+                })
+                continue
+            rows.append({
+                "profile": profile,
+                "case": case_id,
+                "test": test_name,
+                "runs": vals,
+                "median": median(vals),
+            })
+
+lookup = {(r["profile"], r["case"], r["test"]): r for r in rows}
+compare_rows = []
+
+for profile in profiles:
+    for test_name in tests:
+        v1_inline = lookup.get((profile, "v1_inline", test_name))
+        v1_force = lookup.get((profile, "v1_forceptr", test_name))
+        v2 = lookup.get((profile, "v2_fenceptr", test_name))
+        if not v2:
+            continue
+        med_v2 = v2["median"]
+        med_inline = v1_inline["median"] if v1_inline else None
+        med_force = v1_force["median"] if v1_force else None
+        ratio_vs_inline = (med_v2 / med_inline) if med_inline and med_inline > 0 else None
+        ratio_vs_force = (med_v2 / med_force) if med_force and med_force > 0 else None
+        delta_vs_inline = ((med_v2 - med_inline) / med_inline * 100.0) if med_inline and med_inline > 0 else None
+        delta_vs_force = ((med_v2 - med_force) / med_force * 100.0) if med_force and med_force > 0 else None
+
+        passed = True
+        reason = ""
+        if profile in gate_profiles:
+            if ratio_vs_force is None:
+                passed = False
+                reason = f"{test_name} missing v1_forceptr median for gate comparison"
+                failures.append({"profile": profile, "test": test_name, "reason": reason})
+            else:
+                need = thresholds.get(test_name, 0.0)
+                passed = ratio_vs_force >= need
+                if not passed:
+                    reason = f"{test_name} ratio vs v1_forceptr {ratio_vs_force:.3f} < {need:.3f}"
+                    failures.append({"profile": profile, "test": test_name, "reason": reason})
+
+        compare_rows.append({
+            "profile": profile,
+            "test": test_name,
+            "v1_inline_median": med_inline,
+            "v1_force_median": med_force,
+            "v2_median": med_v2,
+            "ratio_vs_inline": ratio_vs_inline,
+            "ratio_vs_force": ratio_vs_force,
+            "delta_vs_inline_pct": delta_vs_inline,
+            "delta_vs_force_pct": delta_vs_force,
+            "gate_pass": passed,
+            "gate_reason": reason,
+        })
+
+gate_pass = len(failures) == 0
+summary = {
+    "meta": meta,
+    "rows": rows,
+    "comparisons": compare_rows,
+    "gate_pass": gate_pass,
+    "failures": failures,
+}
+(out / "summary.json").write_text(json.dumps(summary, indent=2))
+
+def fmt_num(v):
+    if v is None:
+        return "-"
+    return f"{v:,.0f}"
+
+def fmt_pct(v):
+    if v is None:
+        return "-"
+    return f"{v:+.2f}%"
+
+def fmt_ratio(v):
+    if v is None:
+        return "-"
+    return f"{v:.3f}x"
+
+md = []
+md.append("# outerleaf v2 perf gate")
+md.append("")
+md.append(f"- git: `{meta.get('git_rev', '-')}` (`{meta.get('git_branch', '-')}`)")
+md.append(f"- runs: warmup={meta.get('warmup_runs', '-')} measured={meta.get('runs', '-')}")
+md.append(f"- keys={meta.get('keys', '-')} batchsize={meta.get('batchsize', '-')} seed={meta.get('seed', '-')}")
+md.append(f"- profiles: `{meta.get('profiles', '-')}`")
+md.append(f"- tests: `{meta.get('tests', '-')}`")
+md.append(f"- val-pattern: `{meta.get('val_pattern', '-')}`")
+md.append("")
+
+for profile in profiles:
+    md.append(f"## Profile: {profile}")
+    md.append("")
+    md.append("| test | v1 inline | v1 forceptr | v2 fenceptr | v2 vs v1 inline | v2 vs v1 forceptr | gate |")
+    md.append("|---|---:|---:|---:|---:|---:|---|")
+    for c in compare_rows:
+        if c["profile"] != profile:
+            continue
+        gate = "PASS" if c["gate_pass"] else "FAIL"
+        md.append(
+            f"| {display.get(c['test'], c['test'])} | {fmt_num(c['v1_inline_median'])} | {fmt_num(c['v1_force_median'])} | "
+            f"{fmt_num(c['v2_median'])} | {fmt_ratio(c['ratio_vs_inline'])} ({fmt_pct(c['delta_vs_inline_pct'])}) | "
+            f"{fmt_ratio(c['ratio_vs_force'])} ({fmt_pct(c['delta_vs_force_pct'])}) | {gate} |"
+        )
+    md.append("")
+
+md.append(f"- overall gate: {'PASS' if gate_pass else 'FAIL'}")
+if failures:
+    md.append("- failures:")
+    for f in failures:
+        md.append(f"  - {f['profile']}: {f['reason']}")
+
+summary_md = "\n".join(md) + "\n"
+(out / "summary.md").write_text(summary_md)
+print(summary_md)
+
+if strict_gate and not gate_pass:
+    raise SystemExit(3)
+PY
+
+echo "artifacts: $OUT" >&2


### PR DESCRIPTION
## Summary
- introduces `outerleaf.Encoder` to reuse encode scratch buffers (`raw`, `enc`, `restarts`) across block encodes
- refactors outerleaf encode internals to support scratch-backed and pooled paths via shared core helpers
- wires `caching.buildOuterLeafValueRecords` to use a single reusable `outerleaf.Encoder` per build pass
- adds test coverage for reusable encoder output parity with stateless encode

## Why
`v2_fenceptr` profiling showed high allocation/object churn concentrated in `outerleaf.putPooledBytes`/`putPooledRestarts` during batch outer-leaf block construction. This change reuses scratch in-process instead of round-tripping through pool calls for each block.

## Validation
### Correctness
- `go test ./TreeDB/internal/outerleaf ./TreeDB/caching ./TreeDB/internal/valuelog`

### Throughput guard (interleaved A/B)
Command shape:
- `./bin/unified-bench -dbs treedb -profile fast -keys 2000000 -test batch_write -progress=false -format markdown -treedb-force-value-pointers=true -val-pattern repeat_tail64 -treedb-chunk-size=262144 -treedb-index-outer-leaf-mode=<mode>`

Using interleaved base/candidate runs to reduce thermal drift:
- v1 median: `8,632,983.5 -> 8,650,086.5` (`+0.20%`, no regression)
- v2_fenceptr median: `4,703,493.5 -> 4,680,746.5` (`-0.48%`, essentially neutral)

### Allocation / hotspot evidence (`-profile-dir`)
Representative v2 profile comparison:
- Base profile dir: `/tmp/gomap_profiles_base_v2_alloc_gTY57y`
- Candidate profile dir: `/tmp/gomap_profiles_cand_v2_alloc_DSjQrV`

Notable changes from `insights.md`:
- alloc objects total: `307,149 -> 2,012`
- top alloc hotspot moved away from pool put churn:
  - before: `outerleaf.putPooledBytes` / `outerleaf.putPooledRestarts`
  - after: `buildOuterLeafValueRecords` dominates a much smaller allocation set
- runtime hotspot shift (sampled run):
  - `runtime.madvise` `44.90% -> 18.37%`

## Notes
- This PR is stacked on top of `feature/treedb-outerleaf-v2` for isolation.
