### PR TITLE
treedb: grouped fence RID WAL records for WAL-on v2_fenceptr

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -637,6 +638,12 @@ func ensureOuterLeafArenaCap(buf []byte, need int) []byte {
 	return grown
 }
 
+// appendOuterLeafRecordGroup encodes one contiguous outerleaf entry range into a
+// single value-log record and tracks its [start,end) source mapping.
+//
+// The encoder parameter is optional. Pass a reusable non-nil encoder when
+// encoding many groups in a loop to reduce allocations; pass nil for one-off
+// calls.
 func appendOuterLeafRecordGroup(db *DB, encoder *outerleaf.Encoder, entries []outerleaf.Entry, groupStart int, records []valuelog.Record, groups []outerLeafRecordGroup, arena []byte, maxEncodedHint int) ([]valuelog.Record, []outerLeafRecordGroup, []byte, error) {
 	if len(entries) == 0 {
 		return records, groups, arena, nil
@@ -2627,6 +2634,9 @@ type Options struct {
 	// ValueLogOuterLeafBlockRestartInterval controls restart cadence encoded in
 	// v2 outer-leaf payload metadata (0=default).
 	ValueLogOuterLeafBlockRestartInterval int
+	// ValueLogWALFenceGroupEncoding selects grouped fence WAL payload encoding
+	// for WAL-on v2_fenceptr writes: "simple" (default) or "prefix".
+	ValueLogWALFenceGroupEncoding string
 	// ValueLogIncompressibleHoldBytes configures auto-mode incompressible hold
 	// window bytes (0=default).
 	ValueLogIncompressibleHoldBytes int
@@ -2776,6 +2786,7 @@ type DB struct {
 	valueLogThreshold              int
 	valueLogDomainThresholds       []backenddb.ValueLogDomainThreshold
 	indexOuterLeafMode             string
+	walFenceGroupEncoding          commitlog.FenceRIDGroupEncoding
 	outerLeafBlockTargetBytes      int
 	outerLeafBlockCodec            uint8
 	outerLeafBlockRestart          int
@@ -2799,6 +2810,10 @@ type DB struct {
 	deferredFenceEnqueuedBytes     atomic.Uint64
 	deferredFenceMaterializedKeys  atomic.Uint64
 	deferredFenceMaterializedBytes atomic.Uint64
+	walFenceGroupRecords           atomic.Uint64
+	walFenceGroupKeys              atomic.Uint64
+	walFenceGroupSingletonFallback atomic.Uint64
+	walFenceGroupChunks            atomic.Uint64
 	valueLogWarned                 atomic.Bool
 	valueLogHardCapWarned          atomic.Bool
 	valueLogRetainedClosedBytes    atomic.Int64
@@ -3621,6 +3636,10 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	outerLeafBlockTarget := outerleaf.NormalizeBlockTargetBytes(opts.ValueLogOuterLeafBlockTargetBytes)
 	outerLeafBlockCodec := opts.ValueLogOuterLeafBlockCodec
 	outerLeafBlockRestart := outerleaf.NormalizeRestartInterval(opts.ValueLogOuterLeafBlockRestartInterval)
+	walFenceGroupEncoding, err := commitlog.ParseFenceRIDGroupEncoding(opts.ValueLogWALFenceGroupEncoding)
+	if err != nil {
+		return nil, err
+	}
 	disableJournal := opts.DisableWAL
 	if writerFlushMaxMemtablesUnset &&
 		disableJournal &&
@@ -3879,6 +3898,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		valueLogThreshold:                    valueLogThreshold,
 		valueLogDomainThresholds:             valueLogDomainThresholds,
 		indexOuterLeafMode:                   indexOuterLeafMode,
+		walFenceGroupEncoding:                walFenceGroupEncoding,
 		outerLeafBlockTargetBytes:            outerLeafBlockTarget,
 		outerLeafBlockCodec:                  outerLeafBlockCodec,
 		outerLeafBlockRestart:                outerLeafBlockRestart,
@@ -4370,6 +4390,166 @@ func (db *DB) logBatchSize(records []logRecord) int64 {
 		total += commitLogRecordHeaderBytes + len(r.Key) + len(r.Value)
 	}
 	return int64(total)
+}
+
+func maxCommitLogValueLen() int {
+	// Commitlog ValueLen is encoded as u32; never allow larger values even when
+	// MaxRecordSize is disabled.
+	const maxU32ValueLen = int64(^uint32(0))
+	intMax := int64(int(^uint(0) >> 1))
+	formatCap := maxU32ValueLen - int64(commitLogRecordHeaderBytes)
+	if formatCap <= 0 {
+		return 0
+	}
+	if formatCap > intMax {
+		formatCap = intMax
+	}
+	if limits.MaxRecordSize <= 0 {
+		return int(formatCap)
+	}
+	maxLen := limits.MaxRecordSize - int64(commitLogRecordHeaderBytes)
+	if maxLen <= 0 {
+		return 0
+	}
+	if maxLen > formatCap {
+		maxLen = formatCap
+	}
+	return int(maxLen)
+}
+
+func canonicalizeBatchEntriesLastWriteWinsSorted(entries []batch.Entry) []batch.Entry {
+	if len(entries) <= 1 {
+		return entries
+	}
+	seen := make(map[uint64][]int, len(entries))
+	out := make([]batch.Entry, 0, len(entries))
+	for i := len(entries) - 1; i >= 0; i-- {
+		entry := entries[i]
+		h := xxhash.Sum64(entry.Key)
+		dup := false
+		for _, outIdx := range seen[h] {
+			if bytes.Equal(out[outIdx].Key, entry.Key) {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		out = append(out, entry)
+		seen[h] = append(seen[h], len(out)-1)
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return bytes.Compare(out[i].Key, out[j].Key) < 0
+	})
+	return out
+}
+
+func batchEntriesByteSize(entries []batch.Entry) int {
+	total := 0
+	for i := range entries {
+		total += len(entries[i].Key)
+		if entries[i].Type == batch.OpPut {
+			total += len(entries[i].Value)
+		}
+	}
+	return total
+}
+
+func uvarintLen(v uint64) int {
+	n := 1
+	for v >= 0x80 {
+		v >>= 7
+		n++
+	}
+	return n
+}
+
+func keyPrefixLen(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return i
+}
+
+func fenceRIDGroupEntryPayloadSize(entries []commitlog.FenceRIDGroupEntry, start, idx int, encoding commitlog.FenceRIDGroupEncoding) (int, error) {
+	if idx < start || idx >= len(entries) {
+		return 0, fmt.Errorf("cachingdb: fence RID group index out of range")
+	}
+	entry := entries[idx]
+	if len(entry.Key) == 0 {
+		return 0, fmt.Errorf("cachingdb: fence RID group key[%d] empty", idx)
+	}
+	if entry.RID == 0 {
+		return 0, fmt.Errorf("cachingdb: fence RID group key[%d] missing RID", idx)
+	}
+	if encoding != commitlog.FenceRIDGroupEncodingPrefix || idx == start {
+		return uvarintLen(uint64(len(entry.Key))) + len(entry.Key) + uvarintLen(entry.RID), nil
+	}
+	prevKey := entries[idx-1].Key
+	if bytes.Compare(prevKey, entry.Key) >= 0 {
+		return 0, fmt.Errorf("cachingdb: fence RID prefix encoding requires strictly increasing keys")
+	}
+	shared := keyPrefixLen(prevKey, entry.Key)
+	suffixLen := len(entry.Key) - shared
+	return uvarintLen(uint64(shared)) + uvarintLen(uint64(suffixLen)) + suffixLen + uvarintLen(entry.RID), nil
+}
+
+func (db *DB) appendFenceRIDGroupedWALRecords(records []logRecord, entries []commitlog.FenceRIDGroupEntry) ([]logRecord, error) {
+	if len(entries) == 0 {
+		return records, nil
+	}
+	maxValLen := maxCommitLogValueLen()
+	if maxValLen <= 0 {
+		return nil, commitlog.ErrRecordTooLarge
+	}
+	for start := 0; start < len(entries); {
+		end := start
+		bodyLen := 0
+		for end < len(entries) {
+			entrySize, err := fenceRIDGroupEntryPayloadSize(entries, start, end, db.walFenceGroupEncoding)
+			if err != nil {
+				return nil, err
+			}
+			nextCount := end - start + 1
+			nextTotal := 2 + uvarintLen(uint64(nextCount)) + bodyLen + entrySize
+			if nextTotal > maxValLen {
+				break
+			}
+			bodyLen += entrySize
+			end++
+		}
+		if end == start {
+			return nil, commitlog.ErrRecordTooLarge
+		}
+		chunk := entries[start:end]
+		db.walFenceGroupChunks.Add(1)
+		if len(chunk) == 1 {
+			db.walFenceGroupSingletonFallback.Add(1)
+			records = append(records, logRecord{Op: logOpSetRID, Key: chunk[0].Key, RID: chunk[0].RID})
+		} else {
+			payload, err := commitlog.EncodeFenceRIDGroupPayload(chunk, db.walFenceGroupEncoding)
+			if err != nil {
+				return nil, err
+			}
+			if len(payload) > maxValLen {
+				return nil, commitlog.ErrRecordTooLarge
+			}
+			db.walFenceGroupRecords.Add(1)
+			db.walFenceGroupKeys.Add(uint64(len(chunk)))
+			records = append(records, logRecord{Op: logOpSetFenceRIDGroup, Value: payload})
+		}
+		start = end
+	}
+	return records, nil
 }
 
 func (db *DB) assignCommitSeq(records []logRecord) {
@@ -12100,6 +12280,10 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.wal_bytes_estimate"] = fmt.Sprintf("%d", walClosedBytes+walCurrentBytes)
 	stats["treedb.cache.wal_closed_bytes_estimate"] = fmt.Sprintf("%d", walClosedBytes)
 	stats["treedb.cache.wal_current_bytes_estimate"] = fmt.Sprintf("%d", walCurrentBytes)
+	stats["treedb.cache.wal_fence_group.records"] = fmt.Sprintf("%d", db.walFenceGroupRecords.Load())
+	stats["treedb.cache.wal_fence_group.keys"] = fmt.Sprintf("%d", db.walFenceGroupKeys.Load())
+	stats["treedb.cache.wal_fence_group.singleton_fallback"] = fmt.Sprintf("%d", db.walFenceGroupSingletonFallback.Load())
+	stats["treedb.cache.wal_fence_group.chunks"] = fmt.Sprintf("%d", db.walFenceGroupChunks.Load())
 	stats["treedb.cache.vlog_queue.enqueued_total"] = fmt.Sprintf("%d", queueDepthEnqueued)
 	stats["treedb.cache.vlog_queue.depth_samples"] = fmt.Sprintf("%d", queueDepthSamples)
 	stats["treedb.cache.vlog_queue.depth_last_sum"] = fmt.Sprintf("%d", queueDepthLast)
@@ -13343,6 +13527,35 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	needRotate := false
 	needSyncBarrier := false
 
+	canonicalizeForFenceGroupWAL := false
+	if !b.db.disableJournal &&
+		b.db.outerLeafFenceV2Enabled() &&
+		b.db.valueLogEnabled() &&
+		b.db.allowValueLogPointers() {
+		for i := range b.entries {
+			op := &b.entries[i]
+			if op.Type != batch.OpPut {
+				continue
+			}
+			if b.db.forceValueLogPointers || len(op.Value) > b.db.valueLogThresholdForKey(op.Key) {
+				canonicalizeForFenceGroupWAL = true
+				break
+			}
+		}
+	}
+	if canonicalizeForFenceGroupWAL {
+		b.entries = canonicalizeBatchEntriesLastWriteWinsSorted(b.entries)
+		b.size = batchEntriesByteSize(b.entries)
+		if len(b.entries) > 0 {
+			b.firstKey = b.entries[0].Key
+			b.lastKey = b.entries[len(b.entries)-1].Key
+			b.streamEligible = true
+		} else {
+			b.firstKey = nil
+			b.lastKey = nil
+		}
+	}
+
 	// 1. Memtable capacity pre-check
 	shardCount := len(b.db.mutableShards)
 	shardAdds := b.shardAdds
@@ -13695,18 +13908,48 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		if cap(records) < len(b.entries) {
 			records = make([]logRecord, 0, len(b.entries))
 		}
+		groupRIDRecords := b.db.outerLeafFenceV2Enabled() && rids != nil
+		var pendingFenceRID []commitlog.FenceRIDGroupEntry
+		if groupRIDRecords {
+			pendingFenceRID = make([]commitlog.FenceRIDGroupEntry, 0, len(b.entries))
+		}
+		flushPendingFenceRID := func() error {
+			if len(pendingFenceRID) == 0 {
+				return nil
+			}
+			var flushErr error
+			records, flushErr = b.db.appendFenceRIDGroupedWALRecords(records, pendingFenceRID)
+			pendingFenceRID = pendingFenceRID[:0]
+			return flushErr
+		}
 		for i := range b.entries {
 			op := &b.entries[i]
 			switch op.Type {
 			case batch.OpDelete:
+				if err := flushPendingFenceRID(); err != nil {
+					b.db.writeMu.RUnlock()
+					return err
+				}
 				records = append(records, logRecord{Op: logOpDelete, Key: op.Key})
 			case batch.OpPut:
 				if rids != nil && rids[i] != 0 {
-					records = append(records, logRecord{Op: logOpSetRID, Key: op.Key, RID: rids[i]})
+					if groupRIDRecords {
+						pendingFenceRID = append(pendingFenceRID, commitlog.FenceRIDGroupEntry{Key: op.Key, RID: rids[i]})
+					} else {
+						records = append(records, logRecord{Op: logOpSetRID, Key: op.Key, RID: rids[i]})
+					}
 				} else {
+					if err := flushPendingFenceRID(); err != nil {
+						b.db.writeMu.RUnlock()
+						return err
+					}
 					records = append(records, logRecord{Op: logOpSetInline, Key: op.Key, Value: op.Value})
 				}
 			}
+		}
+		if err := flushPendingFenceRID(); err != nil {
+			b.db.writeMu.RUnlock()
+			return err
 		}
 		b.walBuf = records
 		if err := b.db.appendWAL(lane, records, durability); err != nil {

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strconv"
 	"sync"
@@ -12,7 +13,9 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/limits"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -149,6 +152,37 @@ func countSnapshotLeafEntries(t *testing.T, snap *db.Snapshot) int {
 		t.Fatalf("count leaf entries: %v", err)
 	}
 	return total
+}
+
+func readCommitLogRecords(t *testing.T, path string) []commitlog.Record {
+	t.Helper()
+	r, err := commitlog.NewReader(path)
+	if err != nil {
+		t.Fatalf("commitlog.NewReader(%s): %v", path, err)
+	}
+	defer func() { _ = r.Close() }()
+
+	var out []commitlog.Record
+	for {
+		batch, err := r.ReadBatch()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("ReadBatch(%s): %v", path, err)
+		}
+		for i := range batch {
+			rec := batch[i]
+			out = append(out, commitlog.Record{
+				Op:    rec.Op,
+				Key:   append([]byte(nil), rec.Key...),
+				Value: append([]byte(nil), rec.Value...),
+				RID:   rec.RID,
+				Seq:   rec.Seq,
+			})
+		}
+	}
+	return out
 }
 
 func (m *MockBackend) Get(key []byte) ([]byte, error) {
@@ -1047,6 +1081,308 @@ func TestCachingDB_FlushFenceModeCollapsesPointerEntries(t *testing.T) {
 		t.Fatalf("expected fence collapse to reduce persisted entries, got %d (keys=%d)", leafEntries, totalKeys)
 	}
 
+}
+
+func TestCachingDB_BatchWALFenceGroupCanonicalizesFinalState(t *testing.T) {
+	dir := t.TempDir()
+	backendOpts := db.Options{
+		Dir:                dir,
+		ChunkSize:          64 * 1024,
+		IndexOuterLeafMode: db.IndexOuterLeafModeV2FencePtr,
+		ValueLog: db.ValueLogOptions{
+			PointerThreshold:      1,
+			ForcePointers:         true,
+			WALFenceGroupEncoding: db.ValueLogWALFenceGroupEncodingSimple,
+		},
+	}
+	backend, err := db.Open(backendOpts)
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+
+	cache, err := Open(dir, backend, Options{
+		FlushThreshold:                1 << 20,
+		JournalLanes:                  1,
+		ForceValueLogPointers:         true,
+		ValueLogPointerThreshold:      1,
+		IndexOuterLeafMode:            db.IndexOuterLeafModeV2FencePtr,
+		ValueLogWALFenceGroupEncoding: db.ValueLogWALFenceGroupEncodingSimple,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("cache open: %v", err)
+	}
+	defer cache.Close()
+
+	val := func(ch byte) []byte { return bytes.Repeat([]byte{ch}, 256) }
+	b := cache.NewBatch()
+	if err := b.Set([]byte("a"), val('1')); err != nil {
+		t.Fatalf("Set a1: %v", err)
+	}
+	if err := b.Set([]byte("a"), val('2')); err != nil {
+		t.Fatalf("Set a2: %v", err)
+	}
+	if err := b.Set([]byte("b"), val('3')); err != nil {
+		t.Fatalf("Set b1: %v", err)
+	}
+	if err := b.Delete([]byte("b")); err != nil {
+		t.Fatalf("Delete b: %v", err)
+	}
+	if err := b.Set([]byte("b"), val('4')); err != nil {
+		t.Fatalf("Set b2: %v", err)
+	}
+	if err := b.Set([]byte("c"), val('5')); err != nil {
+		t.Fatalf("Set c: %v", err)
+	}
+	if err := b.Delete([]byte("c")); err != nil {
+		t.Fatalf("Delete c: %v", err)
+	}
+	if err := b.Set([]byte("d"), val('6')); err != nil {
+		t.Fatalf("Set d: %v", err)
+	}
+	if err := b.Set([]byte("e"), val('7')); err != nil {
+		t.Fatalf("Set e: %v", err)
+	}
+	if err := b.Delete([]byte("e")); err != nil {
+		t.Fatalf("Delete e: %v", err)
+	}
+	if err := b.Set([]byte("f"), val('8')); err != nil {
+		t.Fatalf("Set f1: %v", err)
+	}
+	if err := b.Set([]byte("f"), val('9')); err != nil {
+		t.Fatalf("Set f2: %v", err)
+	}
+	if err := b.Delete([]byte("f")); err != nil {
+		t.Fatalf("Delete f: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync: %v", err)
+	}
+	_ = b.Close()
+
+	checkValue := func(key string, want []byte) {
+		got, err := cache.Get([]byte(key))
+		if err != nil {
+			t.Fatalf("Get(%q): %v", key, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("Get(%q) mismatch", key)
+		}
+	}
+	checkNil := func(key string) {
+		got, err := cache.Get([]byte(key))
+		if err != nil {
+			t.Fatalf("Get(%q): %v", key, err)
+		}
+		if got != nil {
+			t.Fatalf("Get(%q): expected nil, got %q", key, string(got))
+		}
+	}
+	checkValue("a", val('2'))
+	checkValue("b", val('4'))
+	checkValue("d", val('6'))
+	checkNil("c")
+	checkNil("e")
+	checkNil("f")
+
+	walPaths := cache.currentWALPaths()
+	if len(walPaths) != 1 {
+		t.Fatalf("expected one WAL path, got %d", len(walPaths))
+	}
+	records := readCommitLogRecords(t, walPaths[0])
+	if len(records) == 0 {
+		t.Fatalf("expected WAL records")
+	}
+
+	ptrKeys := map[string]uint64{}
+	deleteKeys := map[string]uint64{}
+	for i := range records {
+		rec := records[i]
+		switch rec.Op {
+		case commitlog.OpSetFenceRIDGroup:
+			entries, _, err := commitlog.DecodeFenceRIDGroupPayload(rec.Value, nil)
+			if err != nil {
+				t.Fatalf("DecodeFenceRIDGroupPayload: %v", err)
+			}
+			for _, entry := range entries {
+				ptrKeys[string(entry.Key)]++
+			}
+		case commitlog.OpSetRID:
+			ptrKeys[string(rec.Key)]++
+		case commitlog.OpDelete:
+			deleteKeys[string(rec.Key)]++
+		case commitlog.OpSetInline:
+			t.Fatalf("unexpected inline WAL record for forced-pointer fence batch")
+		default:
+			t.Fatalf("unexpected WAL op %d", rec.Op)
+		}
+	}
+
+	expectedPtr := map[string]struct{}{"a": {}, "b": {}, "d": {}}
+	expectedDelete := map[string]struct{}{"c": {}, "e": {}, "f": {}}
+	if len(ptrKeys) != len(expectedPtr) {
+		t.Fatalf("pointer key count=%d want=%d keys=%v", len(ptrKeys), len(expectedPtr), ptrKeys)
+	}
+	if len(deleteKeys) != len(expectedDelete) {
+		t.Fatalf("delete key count=%d want=%d keys=%v", len(deleteKeys), len(expectedDelete), deleteKeys)
+	}
+	for k := range expectedPtr {
+		if ptrKeys[k] != 1 {
+			t.Fatalf("pointer key %q seen=%d want=1", k, ptrKeys[k])
+		}
+	}
+	for k := range expectedDelete {
+		if deleteKeys[k] != 1 {
+			t.Fatalf("delete key %q seen=%d want=1", k, deleteKeys[k])
+		}
+	}
+
+	stats := cache.Stats()
+	if statUint64(t, stats, "treedb.cache.wal_fence_group.records") == 0 {
+		t.Fatalf("expected grouped WAL records > 0")
+	}
+	if statUint64(t, stats, "treedb.cache.wal_fence_group.keys") == 0 {
+		t.Fatalf("expected grouped WAL keys > 0")
+	}
+	if statUint64(t, stats, "treedb.cache.wal_fence_group.chunks") == 0 {
+		t.Fatalf("expected grouped WAL chunks > 0")
+	}
+}
+
+func TestAppendFenceRIDGroupedWALRecords_SingletonFallbackUnderRecordCap(t *testing.T) {
+	oldMax := limits.MaxRecordSize
+	t.Cleanup(func() { limits.MaxRecordSize = oldMax })
+
+	entries := []commitlog.FenceRIDGroupEntry{
+		{Key: []byte("a"), RID: 1},
+		{Key: []byte("b"), RID: 2},
+	}
+	onePayload, err := commitlog.EncodeFenceRIDGroupPayload(entries[:1], commitlog.FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("encode one: %v", err)
+	}
+	twoPayload, err := commitlog.EncodeFenceRIDGroupPayload(entries, commitlog.FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("encode two: %v", err)
+	}
+	if len(twoPayload) <= len(onePayload) {
+		t.Fatalf("unexpected payload sizes one=%d two=%d", len(onePayload), len(twoPayload))
+	}
+	limits.MaxRecordSize = int64(commitLogRecordHeaderBytes + len(onePayload))
+
+	db := &DB{walFenceGroupEncoding: commitlog.FenceRIDGroupEncodingSimple}
+	recs, err := db.appendFenceRIDGroupedWALRecords(nil, entries)
+	if err != nil {
+		t.Fatalf("appendFenceRIDGroupedWALRecords: %v", err)
+	}
+	if len(recs) != len(entries) {
+		t.Fatalf("record count=%d want=%d", len(recs), len(entries))
+	}
+	for i := range recs {
+		if recs[i].Op != logOpSetRID {
+			t.Fatalf("record[%d] op=%d want OpSetRID", i, recs[i].Op)
+		}
+		if !bytes.Equal(recs[i].Key, entries[i].Key) || recs[i].RID != entries[i].RID {
+			t.Fatalf("record[%d]=(%q,%d) want (%q,%d)", i, recs[i].Key, recs[i].RID, entries[i].Key, entries[i].RID)
+		}
+	}
+	if got := db.walFenceGroupSingletonFallback.Load(); got != uint64(len(entries)) {
+		t.Fatalf("singleton fallback=%d want=%d", got, len(entries))
+	}
+	if got := db.walFenceGroupRecords.Load(); got != 0 {
+		t.Fatalf("group records=%d want=0", got)
+	}
+}
+
+func TestAppendFenceRIDGroupedWALRecords_ChunksAndGroupsUnderRecordCap(t *testing.T) {
+	oldMax := limits.MaxRecordSize
+	t.Cleanup(func() { limits.MaxRecordSize = oldMax })
+
+	entries := []commitlog.FenceRIDGroupEntry{
+		{Key: []byte("a"), RID: 1},
+		{Key: []byte("b"), RID: 2},
+		{Key: []byte("c"), RID: 3},
+		{Key: []byte("d"), RID: 4},
+		{Key: []byte("e"), RID: 5},
+	}
+	twoPayload, err := commitlog.EncodeFenceRIDGroupPayload(entries[:2], commitlog.FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("encode two: %v", err)
+	}
+	threePayload, err := commitlog.EncodeFenceRIDGroupPayload(entries[:3], commitlog.FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("encode three: %v", err)
+	}
+	if len(threePayload) <= len(twoPayload) {
+		t.Fatalf("unexpected payload sizes two=%d three=%d", len(twoPayload), len(threePayload))
+	}
+	limits.MaxRecordSize = int64(commitLogRecordHeaderBytes + len(twoPayload))
+
+	db := &DB{walFenceGroupEncoding: commitlog.FenceRIDGroupEncodingSimple}
+	recs, err := db.appendFenceRIDGroupedWALRecords(nil, entries)
+	if err != nil {
+		t.Fatalf("appendFenceRIDGroupedWALRecords: %v", err)
+	}
+	if len(recs) != 3 {
+		t.Fatalf("record count=%d want=3", len(recs))
+	}
+	if recs[0].Op != logOpSetFenceRIDGroup || recs[1].Op != logOpSetFenceRIDGroup || recs[2].Op != logOpSetRID {
+		t.Fatalf("unexpected record ops: %d %d %d", recs[0].Op, recs[1].Op, recs[2].Op)
+	}
+	for i := 0; i < 2; i++ {
+		decoded, _, err := commitlog.DecodeFenceRIDGroupPayload(recs[i].Value, nil)
+		if err != nil {
+			t.Fatalf("decode grouped[%d]: %v", i, err)
+		}
+		if len(decoded) != 2 {
+			t.Fatalf("grouped[%d] len=%d want=2", i, len(decoded))
+		}
+	}
+	if !bytes.Equal(recs[2].Key, entries[4].Key) || recs[2].RID != entries[4].RID {
+		t.Fatalf("tail singleton=(%q,%d) want (%q,%d)", recs[2].Key, recs[2].RID, entries[4].Key, entries[4].RID)
+	}
+	if got := db.walFenceGroupRecords.Load(); got != 2 {
+		t.Fatalf("group records=%d want=2", got)
+	}
+	if got := db.walFenceGroupKeys.Load(); got != 4 {
+		t.Fatalf("group keys=%d want=4", got)
+	}
+	if got := db.walFenceGroupSingletonFallback.Load(); got != 1 {
+		t.Fatalf("singleton fallback=%d want=1", got)
+	}
+	if got := db.walFenceGroupChunks.Load(); got != 3 {
+		t.Fatalf("chunks=%d want=3", got)
+	}
+}
+
+func TestMaxCommitLogValueLen_CappedByCommitLogFormat(t *testing.T) {
+	oldMax := limits.MaxRecordSize
+	t.Cleanup(func() { limits.MaxRecordSize = oldMax })
+
+	intMax := int64(int(^uint(0) >> 1))
+	formatCap := int64(^uint32(0)) - int64(commitLogRecordHeaderBytes)
+	if formatCap < 0 {
+		formatCap = 0
+	}
+	if formatCap > intMax {
+		formatCap = intMax
+	}
+
+	limits.MaxRecordSize = 0
+	if got := int64(maxCommitLogValueLen()); got != formatCap {
+		t.Fatalf("maxCommitLogValueLen (MaxRecordSize=0)=%d want=%d", got, formatCap)
+	}
+
+	limits.MaxRecordSize = int64(commitLogRecordHeaderBytes) + formatCap + 1024
+	if got := int64(maxCommitLogValueLen()); got != formatCap {
+		t.Fatalf("maxCommitLogValueLen (oversized max)=%d want=%d", got, formatCap)
+	}
+
+	const smallValue = int64(1234)
+	limits.MaxRecordSize = int64(commitLogRecordHeaderBytes) + smallValue
+	if got := int64(maxCommitLogValueLen()); got != smallValue {
+		t.Fatalf("maxCommitLogValueLen (small max)=%d want=%d", got, smallValue)
+	}
 }
 
 func TestCachingDB_FlushFenceModeDeferredSingletonWritesRegroup(t *testing.T) {

--- a/TreeDB/caching/log_writer.go
+++ b/TreeDB/caching/log_writer.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	logOpSetRID    = commitlog.OpSetRID
-	logOpSetInline = commitlog.OpSetInline
-	logOpDelete    = commitlog.OpDelete
+	logOpSetRID           = commitlog.OpSetRID
+	logOpSetInline        = commitlog.OpSetInline
+	logOpDelete           = commitlog.OpDelete
+	logOpSetFenceRIDGroup = commitlog.OpSetFenceRIDGroup
 )
 
 type logRecord = commitlog.Record

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -149,6 +149,17 @@ func normalizeIndexOuterLeafMode(mode string) string {
 	}
 }
 
+func normalizeWALFenceGroupEncoding(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", ValueLogWALFenceGroupEncodingSimple:
+		return ValueLogWALFenceGroupEncodingSimple
+	case ValueLogWALFenceGroupEncodingPrefix:
+		return ValueLogWALFenceGroupEncodingPrefix
+	default:
+		return strings.ToLower(strings.TrimSpace(mode))
+	}
+}
+
 // DurabilityMode configures cached-mode durability semantics.
 //
 // These modes are explicit and intentionally replace the previous boolean
@@ -214,6 +225,15 @@ const (
 	IndexOuterLeafModeV2FencePtr = "v2_fenceptr"
 )
 
+const (
+	// ValueLogWALFenceGroupEncodingSimple stores grouped fence WAL payloads as
+	// repeated key+RID tuples.
+	ValueLogWALFenceGroupEncodingSimple = "simple"
+	// ValueLogWALFenceGroupEncodingPrefix stores grouped fence WAL payloads with
+	// prefix-compressed keys.
+	ValueLogWALFenceGroupEncodingPrefix = "prefix"
+)
+
 // ValueLogAutoPolicy controls auto-mode dict vs block selection bias.
 type ValueLogAutoPolicy uint8
 
@@ -277,6 +297,11 @@ type ValueLogOptions struct {
 	IncompressibleProbeIntervalBytes int
 	// AutoPolicy controls auto-mode bias (throughput, balanced, size).
 	AutoPolicy ValueLogAutoPolicy
+	// WALFenceGroupEncoding selects payload encoding for WAL-on v2_fenceptr
+	// grouped fence records.
+	//
+	// Supported values: "simple" (default), "prefix".
+	WALFenceGroupEncoding string
 
 	// PointerThreshold controls when value-log pointers are used.
 	// Values <= 0 use a default threshold. In cached mode, relaxed durability
@@ -811,6 +836,7 @@ func Open(opts Options) (*DB, error) {
 		opts.ValueLog.Compression = ValueLogCompressionAuto
 	}
 	opts.IndexOuterLeafMode = normalizeIndexOuterLeafMode(opts.IndexOuterLeafMode)
+	opts.ValueLog.WALFenceGroupEncoding = normalizeWALFenceGroupEncoding(opts.ValueLog.WALFenceGroupEncoding)
 
 	if err := validateOptions(opts); err != nil {
 		return nil, err
@@ -911,6 +937,11 @@ func validateOptions(opts Options) error {
 	case ValueLogAutoThroughput, ValueLogAutoBalanced, ValueLogAutoSize:
 	default:
 		return fmt.Errorf("treedb: invalid value-log auto policy %d", opts.ValueLog.AutoPolicy)
+	}
+	switch normalizeWALFenceGroupEncoding(opts.ValueLog.WALFenceGroupEncoding) {
+	case ValueLogWALFenceGroupEncodingSimple, ValueLogWALFenceGroupEncodingPrefix:
+	default:
+		return fmt.Errorf("treedb: invalid value-log WAL fence group encoding %q", opts.ValueLog.WALFenceGroupEncoding)
 	}
 	seenDomains := make(map[string]struct{}, len(opts.ValueLog.DomainInlineThresholds))
 	for i := range opts.ValueLog.DomainInlineThresholds {

--- a/TreeDB/db/outerleaf_cache.go
+++ b/TreeDB/db/outerleaf_cache.go
@@ -138,10 +138,13 @@ func (c *outerLeafBlockCache) shardFor(key outerLeafBlockKey) *outerLeafBlockCac
 	if len(c.shards) == 1 {
 		return &c.shards[0]
 	}
+	// Mix file/offset/length using fixed 64-bit odd constants in the style of
+	// xxHash/SplitMix so shard selection stays stable and well-distributed.
 	h := uint64(key.fileID)*11400714819323198485 ^
 		key.offset*14029467366897019727 ^
 		uint64(key.length)*1609587929392839161
 	h ^= h >> 33
+	// Final avalanche constant (SplitMix64 finalizer).
 	h *= 0xff51afd7ed558ccd
 	h ^= h >> 33
 	idx := int(h & uint64(len(c.shards)-1))

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -295,11 +295,21 @@ func commitBatchSeq(records []commitlog.Record) (uint64, error) {
 
 func commitFenceSatisfied(records []commitlog.Record, ridMap map[uint64]page.ValuePtr) bool {
 	for _, rec := range records {
-		if rec.Op != commitlog.OpSetRID {
-			continue
-		}
-		if _, ok := ridMap[rec.RID]; !ok {
-			return false
+		switch rec.Op {
+		case commitlog.OpSetRID:
+			if _, ok := ridMap[rec.RID]; !ok {
+				return false
+			}
+		case commitlog.OpSetFenceRIDGroup:
+			entries, _, err := commitlog.DecodeFenceRIDGroupPayload(rec.Value, nil)
+			if err != nil {
+				return false
+			}
+			for i := range entries {
+				if _, ok := ridMap[entries[i].RID]; !ok {
+					return false
+				}
+			}
 		}
 	}
 	return true
@@ -336,6 +346,23 @@ func applyCommitBatch(db *DB, records []commitlog.Record, ridMap map[uint64]page
 			}
 			if err := ptrBatch.SetPointer(rec.Key, ptr); err != nil {
 				return err
+			}
+		case commitlog.OpSetFenceRIDGroup:
+			entries, _, err := commitlog.DecodeFenceRIDGroupPayload(rec.Value, nil)
+			if err != nil {
+				return fmt.Errorf("commitlog: invalid fence RID group payload: %w", err)
+			}
+			if !hasPtrBatch {
+				return fmt.Errorf("commitlog: pointer batch unavailable")
+			}
+			for i := range entries {
+				ptr, ok := ridMap[entries[i].RID]
+				if !ok {
+					return fmt.Errorf("commitlog: missing rid %d", entries[i].RID)
+				}
+				if err := ptrBatch.SetPointer(entries[i].Key, ptr); err != nil {
+					return err
+				}
 			}
 		default:
 			return fmt.Errorf("commitlog: unknown op %d", rec.Op)

--- a/TreeDB/docs/spec/recovery.md
+++ b/TreeDB/docs/spec/recovery.md
@@ -80,6 +80,9 @@ Otherwise:
   - batches with non-zero `Seq` sorted by `Seq` then read order,
   - legacy `Seq=0` batches preserve original read order.
 - Truncated tail in commit log stops replay at partial tail safely.
+- For sequence-numbered batches, commit fences are satisfied only when all RID
+  references (including grouped fence-RID payload references) are present in the
+  scanned value-log map.
 
 ### 4.3 Apply batches to backend
 
@@ -88,6 +91,8 @@ Each commit record maps to backend batch op:
 - `OpDelete` -> `Delete(key)`
 - `OpSetInline` -> `Set(key, value)`
 - `OpSetRID` -> lookup `RID` in map, then `SetPointer(key, ptr)`
+- `OpSetFenceRIDGroup` -> decode grouped `(key, RID)` payload, lookup each RID,
+  then `SetPointer(key, ptr)` for each entry
 
 Each replayed batch is committed with `WriteSync`.
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -342,7 +342,7 @@ Record[RecordCount]
 Record format:
 
 ```text
-u8  Op               // 0=set RID, 1=set inline, 2=delete
+u8  Op               // 0=set RID, 1=set inline, 2=delete, 3=set fence RID group
 u16 KeyLen
 u32 ValueLen
 u64 RID
@@ -356,6 +356,51 @@ Validation rules:
 - `OpSetRID`: `RID != 0`, `ValueLen == 0`.
 - `OpSetInline`: `RID == 0`.
 - `OpDelete`: `RID == 0`, `ValueLen == 0`.
+- `OpSetFenceRIDGroup`: `KeyLen == 0`, `RID == 0`, grouped key/RID pairs are encoded in `Value`.
+
+Pre-alpha compatibility note: introducing new opcodes (for example
+`OpSetFenceRIDGroup`) is not backward-compatible with older binaries.
+
+### 8.2 `OpSetFenceRIDGroup` payload
+
+Grouped payload header:
+
+```text
+u8  GroupVersion   // currently 1
+u8  Encoding       // 0=simple, 1=prefix
+uvarint Count      // number of key/RID entries (must be > 0)
+```
+
+`simple` entries:
+
+```text
+uvarint KeyLen
+bytes   Key[KeyLen]
+uvarint RID         // must be > 0
+```
+
+`prefix` entries:
+
+```text
+entry[0]:
+  uvarint KeyLen
+  bytes   Key[KeyLen]
+  uvarint RID
+
+entry[i>0]:
+  uvarint SharedPrefixLen
+  uvarint SuffixLen
+  bytes   Suffix[SuffixLen]
+  uvarint RID
+```
+
+Decoder rules:
+
+- rejects malformed/truncated varints,
+- rejects zero `Count`,
+- rejects non-progressing tails / trailing bytes,
+- rejects invalid prefix references (`SharedPrefixLen > len(prevKey)`),
+- rejects zero RID entries.
 
 ## 9. File Naming Conventions
 

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -47,7 +47,7 @@ For each write batch, implementation conceptually performs:
 
 1. Choose lane.
 2. For eligible values, append to value log and build `ValuePtr` references.
-3. If WAL enabled, append commit-log batch (inline or RID form).
+3. If WAL enabled, append commit-log batch (inline, RID, or grouped fence RID form).
 4. Apply entries to mutable memtable.
 5. Acknowledge caller based on sync mode and durability mode.
 
@@ -67,6 +67,19 @@ sequence acts as a durable commit fence:
 
 This prevents replaying partial pointer commits and avoids phantom pointer
 visibility after crash recovery.
+
+### 3.2 WAL-on `v2_fenceptr` grouped commit records
+
+When `IndexOuterLeafMode=v2_fenceptr` and WAL is enabled, batched pointer writes
+may be emitted as grouped `OpSetFenceRIDGroup` records to reduce WAL bytes.
+
+Rules:
+
+- grouped records carry key/RID tuples in `Record.Value`,
+- record header key is empty (`KeyLen=0`), header RID is zero,
+- chunks are bounded by commitlog record-size limits,
+- singleton chunks must fall back to legacy `OpSetRID` (size deterministic and
+  no grouped framing overhead for one key).
 
 ## 4. Backend Commit Model
 

--- a/TreeDB/internal/commitlog/commitlog.go
+++ b/TreeDB/internal/commitlog/commitlog.go
@@ -5,9 +5,10 @@ import "errors"
 const (
 	Version = 1
 
-	OpSetRID    = byte(0)
-	OpSetInline = byte(1)
-	OpDelete    = byte(2)
+	OpSetRID           = byte(0)
+	OpSetInline        = byte(1)
+	OpDelete           = byte(2)
+	OpSetFenceRIDGroup = byte(3)
 
 	segmentHeaderSize = 8
 	batchHeaderSize   = 1 + 4

--- a/TreeDB/internal/commitlog/commitlog_fuzz_test.go
+++ b/TreeDB/internal/commitlog/commitlog_fuzz_test.go
@@ -34,11 +34,72 @@ func seedCommitLogData() ([]byte, error) {
 	return os.ReadFile(path)
 }
 
+func seedCommitLogFenceGroupedData(encoding FenceRIDGroupEncoding) ([]byte, error) {
+	dir, err := os.MkdirTemp("", "commitlog-fuzz-fence")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "commit.log")
+	w, err := NewWriter(path)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := EncodeFenceRIDGroupPayload([]FenceRIDGroupEntry{
+		{Key: []byte("k001"), RID: 1},
+		{Key: []byte("k002"), RID: 1},
+		{Key: []byte("k003"), RID: 2},
+	}, encoding)
+	if err != nil {
+		_ = w.Close()
+		return nil, err
+	}
+	if err := w.AppendBatch([]Record{{Op: OpSetFenceRIDGroup, Value: payload, Seq: 1}}); err != nil {
+		_ = w.Close()
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(path)
+}
+
 func FuzzCommitLogReader(f *testing.F) {
 	f.Add([]byte{})
 	if seed, err := seedCommitLogData(); err == nil {
 		f.Add(seed)
 	}
+	if seed, err := seedCommitLogFenceGroupedData(FenceRIDGroupEncodingSimple); err == nil {
+		f.Add(seed)
+	}
+	if seed, err := seedCommitLogFenceGroupedData(FenceRIDGroupEncodingPrefix); err == nil {
+		f.Add(seed)
+	}
+	// Malformed grouped payload seeds: broken key varint and truncated RID varint.
+	f.Add([]byte{
+		// segment header (len=32, crc=0) + tiny malformed payload
+		0x20, 0x00, 0x00, 0x00, 0, 0, 0, 0,
+		1, 1, 1, // version, prefix encoding, count=1
+		0x80, // truncated key-len varint
+	})
+	f.Add([]byte{
+		0x21, 0x00, 0x00, 0x00, 0, 0, 0, 0,
+		1, 0, 1, // version, simple encoding, count=1
+		1, 'k',
+		0x80, // truncated RID varint
+	})
+	f.Add([]byte{
+		0x21, 0x00, 0x00, 0x00, 0, 0, 0, 0,
+		1, 0, 100, // version, simple encoding, impossible count for payload bytes
+		1, 'k', 1,
+	})
+	f.Add([]byte{
+		0x24, 0x00, 0x00, 0x00, 0, 0, 0, 0,
+		1, 1, 2, // version, prefix encoding, count=2
+		1, 'b', 1, // first key/rid
+		0, 1, 'a', 2, // non-monotonic second key
+	})
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		if len(data) > commitlogFuzzMaxSegment {

--- a/TreeDB/internal/commitlog/commitlog_test.go
+++ b/TreeDB/internal/commitlog/commitlog_test.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/crc"
+	"github.com/snissn/gomap/TreeDB/internal/limits"
 )
 
 func TestCommitLogWriteReadBatch(t *testing.T) {
@@ -253,4 +256,220 @@ func TestCommitLogTruncatedPayload(t *testing.T) {
 		t.Fatalf("expected unexpected EOF, got %v", err)
 	}
 	_ = reader.Close()
+}
+
+func TestFenceRIDGroupPayloadRoundTrip(t *testing.T) {
+	entries := []FenceRIDGroupEntry{
+		{Key: []byte("k001"), RID: 11},
+		{Key: []byte("k002"), RID: 12},
+		{Key: []byte("k003"), RID: 13},
+	}
+	encodings := []FenceRIDGroupEncoding{
+		FenceRIDGroupEncodingSimple,
+		FenceRIDGroupEncodingPrefix,
+	}
+	for _, enc := range encodings {
+		payload, err := EncodeFenceRIDGroupPayload(entries, enc)
+		if err != nil {
+			t.Fatalf("encode %s: %v", enc.String(), err)
+		}
+		got, gotEnc, err := DecodeFenceRIDGroupPayload(payload, nil)
+		if err != nil {
+			t.Fatalf("decode %s: %v", enc.String(), err)
+		}
+		if gotEnc != enc {
+			t.Fatalf("decode %s encoding mismatch: got=%s", enc.String(), gotEnc.String())
+		}
+		if len(got) != len(entries) {
+			t.Fatalf("decode %s len=%d want=%d", enc.String(), len(got), len(entries))
+		}
+		for i := range entries {
+			if string(got[i].Key) != string(entries[i].Key) || got[i].RID != entries[i].RID {
+				t.Fatalf("decode %s entry[%d]=(%q,%d) want (%q,%d)", enc.String(), i, got[i].Key, got[i].RID, entries[i].Key, entries[i].RID)
+			}
+		}
+	}
+}
+
+func TestFenceRIDGroupPayloadMalformed(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+	}{
+		{name: "empty", payload: nil},
+		{name: "bad_version", payload: []byte{0xFF, 0, 1}},
+		{name: "bad_encoding", payload: []byte{1, 99, 1}},
+		{name: "truncated_count", payload: []byte{1, 0, 0x80}},
+		{name: "truncated_key_len", payload: []byte{1, 0, 1, 0x80}},
+		{name: "truncated_key", payload: []byte{1, 0, 1, 3, 'k'}},
+		{name: "missing_rid", payload: []byte{1, 0, 1, 1, 'k'}},
+		{name: "truncated_rid_varint", payload: []byte{1, 0, 1, 1, 'k', 0x80}},
+		{name: "count_exceeds_payload_bound", payload: []byte{1, 0, 100, 1, 'k', 1}},
+		{name: "prefix_bad_shared", payload: []byte{1, 1, 2, 1, 'a', 1, 2, 1, 'b', 2}},
+		{name: "prefix_non_monotonic", payload: []byte{1, 1, 2, 1, 'b', 1, 0, 1, 'a', 2}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := DecodeFenceRIDGroupPayload(tc.payload, nil); err == nil {
+				t.Fatalf("expected decode error")
+			}
+		})
+	}
+}
+
+func TestCommitLogWriteReadBatchFenceRIDGroup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriter(path)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	payload, err := EncodeFenceRIDGroupPayload([]FenceRIDGroupEntry{
+		{Key: []byte("k1"), RID: 1},
+		{Key: []byte("k2"), RID: 1},
+		{Key: []byte("k3"), RID: 2},
+	}, FenceRIDGroupEncodingPrefix)
+	if err != nil {
+		t.Fatalf("encode payload: %v", err)
+	}
+	records := []Record{
+		{Op: OpSetFenceRIDGroup, Value: payload, Seq: 7},
+	}
+	if err := writer.AppendBatch(records); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	got, err := reader.ReadBatch()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(got) != 1 || got[0].Op != OpSetFenceRIDGroup || got[0].Seq != 7 {
+		t.Fatalf("unexpected records: %+v", got)
+	}
+	if len(got[0].Key) != 0 || got[0].RID != 0 {
+		t.Fatalf("grouped record must keep key/rid header empty")
+	}
+	decoded, _, err := DecodeFenceRIDGroupPayload(got[0].Value, nil)
+	if err != nil {
+		t.Fatalf("decode grouped payload: %v", err)
+	}
+	if len(decoded) != 3 {
+		t.Fatalf("grouped payload len=%d", len(decoded))
+	}
+}
+
+func TestCommitLogFenceRIDGroupRejectsNonEmptyKeyWriter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+	writer, err := NewWriter(path)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+	payload, err := EncodeFenceRIDGroupPayload([]FenceRIDGroupEntry{
+		{Key: []byte("k"), RID: 1},
+		{Key: []byte("k2"), RID: 2},
+	}, FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("encode payload: %v", err)
+	}
+	err = writer.AppendBatch([]Record{
+		{Op: OpSetFenceRIDGroup, Key: []byte("bad"), Value: payload, Seq: 1},
+	})
+	if err == nil {
+		t.Fatalf("expected writer validation error")
+	}
+}
+
+func TestCommitLogFenceRIDGroupReaderRejectsNonEmptyKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	payload, err := EncodeFenceRIDGroupPayload([]FenceRIDGroupEntry{
+		{Key: []byte("k"), RID: 1},
+		{Key: []byte("k2"), RID: 2},
+	}, FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("encode payload: %v", err)
+	}
+	w, err := NewWriter(path)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	if err := w.AppendBatch([]Record{{Op: OpSetFenceRIDGroup, Value: payload, Seq: 1}}); err != nil {
+		_ = w.Close()
+		t.Fatalf("append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(data) < segmentHeaderSize+batchHeaderSize+recordHeaderSize {
+		t.Fatalf("unexpected log size %d", len(data))
+	}
+	off := segmentHeaderSize + batchHeaderSize
+	// Corrupt key length from 0 to 1 and keep CRC consistent.
+	binary.LittleEndian.PutUint16(data[off+1:off+3], 1)
+	payloadLen := int(binary.LittleEndian.Uint32(data[0:4]) & segmentLenMask)
+	raw := data[segmentHeaderSize : segmentHeaderSize+payloadLen]
+	binary.LittleEndian.PutUint32(data[4:8], crcChecksum(raw))
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	r, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+	if _, err := r.ReadBatch(); !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("expected ErrCorrupt, got %v", err)
+	}
+}
+
+func TestCommitLogFenceRIDGroupSizeBoundaries(t *testing.T) {
+	oldMax := limits.MaxRecordSize
+	t.Cleanup(func() { limits.MaxRecordSize = oldMax })
+	okPayload, err := EncodeFenceRIDGroupPayload([]FenceRIDGroupEntry{
+		{Key: []byte("k1"), RID: 1},
+	}, FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("encode ok payload: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+	w, err := NewWriter(path)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	limits.MaxRecordSize = int64(recordHeaderSize + len(okPayload))
+	if err := w.AppendBatch([]Record{{Op: OpSetFenceRIDGroup, Value: okPayload, Seq: 1}}); err != nil {
+		_ = w.Close()
+		t.Fatalf("append ok payload: %v", err)
+	}
+	limits.MaxRecordSize = int64(recordHeaderSize + len(okPayload) - 1)
+	err = w.AppendBatch([]Record{{Op: OpSetFenceRIDGroup, Value: okPayload, Seq: 2}})
+	if !errors.Is(err, ErrRecordTooLarge) {
+		_ = w.Close()
+		t.Fatalf("expected ErrRecordTooLarge, got %v", err)
+	}
+	_ = w.Close()
+}
+
+func crcChecksum(payload []byte) uint32 {
+	return crc.Checksum(payload)
 }

--- a/TreeDB/internal/commitlog/fence_group_codec.go
+++ b/TreeDB/internal/commitlog/fence_group_codec.go
@@ -1,0 +1,282 @@
+package commitlog
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+const (
+	fenceRIDGroupPayloadVersion = byte(1)
+	maxCommitLogKeyLen          = int(^uint16(0))
+)
+
+const (
+	WALFenceGroupEncodingSimple = "simple"
+	WALFenceGroupEncodingPrefix = "prefix"
+)
+
+type FenceRIDGroupEncoding byte
+
+const (
+	FenceRIDGroupEncodingSimple FenceRIDGroupEncoding = iota
+	FenceRIDGroupEncodingPrefix
+)
+
+func (e FenceRIDGroupEncoding) String() string {
+	switch e {
+	case FenceRIDGroupEncodingSimple:
+		return WALFenceGroupEncodingSimple
+	case FenceRIDGroupEncodingPrefix:
+		return WALFenceGroupEncodingPrefix
+	default:
+		return fmt.Sprintf("encoding_%d", byte(e))
+	}
+}
+
+func ParseFenceRIDGroupEncoding(s string) (FenceRIDGroupEncoding, error) {
+	switch strings.TrimSpace(strings.ToLower(s)) {
+	case "", WALFenceGroupEncodingSimple:
+		return FenceRIDGroupEncodingSimple, nil
+	case WALFenceGroupEncodingPrefix:
+		return FenceRIDGroupEncodingPrefix, nil
+	default:
+		return FenceRIDGroupEncodingSimple, fmt.Errorf("commitlog: unsupported WAL fence group encoding %q", s)
+	}
+}
+
+type FenceRIDGroupEntry struct {
+	Key []byte
+	RID uint64
+}
+
+func appendUvarint(dst []byte, v uint64) []byte {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], v)
+	return append(dst, buf[:n]...)
+}
+
+func decodeUvarint(src []byte, off *int) (uint64, error) {
+	if off == nil || *off < 0 || *off > len(src) {
+		return 0, ErrCorrupt
+	}
+	v, n := binary.Uvarint(src[*off:])
+	if n <= 0 {
+		return 0, ErrCorrupt
+	}
+	*off += n
+	return v, nil
+}
+
+func maxFenceRIDGroupDecodeCount(encoding FenceRIDGroupEncoding, remaining int) uint64 {
+	if remaining <= 0 {
+		return 0
+	}
+	rem := uint64(remaining)
+	// The payload format enforces non-empty keys and non-zero RIDs, so each
+	// simple entry must consume at least 3 bytes:
+	//   keyLen(>=1 varint) + key(>=1 byte) + rid(>=1 varint).
+	// Prefix encoding uses the simple form for the first key, and each
+	// subsequent key must consume at least 4 bytes:
+	//   shared(>=1 varint) + suffixLen(>=1 varint) + suffix(>=1 byte) + rid(>=1 varint).
+	switch encoding {
+	case FenceRIDGroupEncodingSimple:
+		return rem / 3
+	case FenceRIDGroupEncodingPrefix:
+		if rem < 3 {
+			return 0
+		}
+		return 1 + (rem-3)/4
+	default:
+		return 0
+	}
+}
+
+func EncodeFenceRIDGroupPayload(entries []FenceRIDGroupEntry, encoding FenceRIDGroupEncoding) ([]byte, error) {
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("commitlog: empty fence RID group")
+	}
+	switch encoding {
+	case FenceRIDGroupEncodingSimple, FenceRIDGroupEncodingPrefix:
+	default:
+		return nil, fmt.Errorf("commitlog: unknown fence RID group encoding %d", encoding)
+	}
+
+	size := 3
+	for i := range entries {
+		entry := entries[i]
+		if len(entry.Key) == 0 {
+			return nil, fmt.Errorf("commitlog: fence RID group key[%d] is empty", i)
+		}
+		if len(entry.Key) > maxCommitLogKeyLen {
+			return nil, ErrRecordTooLarge
+		}
+		if entry.RID == 0 {
+			return nil, fmt.Errorf("commitlog: fence RID group key[%d] missing RID", i)
+		}
+		// 20B overhead leaves room for 2 uvarints in the vast majority of cases.
+		size += len(entry.Key) + 20
+	}
+	if size < 0 {
+		return nil, ErrRecordTooLarge
+	}
+	dst := make([]byte, 0, size)
+	dst = append(dst, fenceRIDGroupPayloadVersion)
+	dst = append(dst, byte(encoding))
+	dst = appendUvarint(dst, uint64(len(entries)))
+
+	var prevKey []byte
+	for i := range entries {
+		entry := entries[i]
+		if encoding == FenceRIDGroupEncodingSimple || i == 0 {
+			dst = appendUvarint(dst, uint64(len(entry.Key)))
+			dst = append(dst, entry.Key...)
+			dst = appendUvarint(dst, entry.RID)
+			prevKey = entry.Key
+			continue
+		}
+
+		shared := commonPrefixLen(prevKey, entry.Key)
+		if bytes.Compare(prevKey, entry.Key) >= 0 {
+			return nil, fmt.Errorf("commitlog: prefix fence RID encoding requires strictly increasing keys")
+		}
+		suffix := entry.Key[shared:]
+		dst = appendUvarint(dst, uint64(shared))
+		dst = appendUvarint(dst, uint64(len(suffix)))
+		dst = append(dst, suffix...)
+		dst = appendUvarint(dst, entry.RID)
+		prevKey = entry.Key
+	}
+
+	return dst, nil
+}
+
+func DecodeFenceRIDGroupPayload(payload []byte, dst []FenceRIDGroupEntry) ([]FenceRIDGroupEntry, FenceRIDGroupEncoding, error) {
+	if len(payload) < 3 {
+		return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+	}
+	off := 0
+	version := payload[off]
+	off++
+	if version != fenceRIDGroupPayloadVersion {
+		return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+	}
+	encoding := FenceRIDGroupEncoding(payload[off])
+	off++
+	switch encoding {
+	case FenceRIDGroupEncodingSimple, FenceRIDGroupEncodingPrefix:
+	default:
+		return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+	}
+	countU, err := decodeUvarint(payload, &off)
+	if err != nil {
+		return nil, FenceRIDGroupEncodingSimple, err
+	}
+	if countU == 0 {
+		return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+	}
+	maxCount := uint64(int(^uint(0) >> 1))
+	if countU > maxCount {
+		return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+	}
+	countBound := maxFenceRIDGroupDecodeCount(encoding, len(payload)-off)
+	if countBound == 0 || countU > countBound {
+		return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+	}
+	count := int(countU)
+	// Avoid attacker-controlled large preallocation on corrupt payloads. We only
+	// reserve a bounded initial capacity and let append grow as needed.
+	initCap := count
+	const maxDecodePrealloc = 4096
+	if initCap > maxDecodePrealloc {
+		initCap = maxDecodePrealloc
+	}
+	if cap(dst) < initCap {
+		dst = make([]FenceRIDGroupEntry, 0, initCap)
+	} else {
+		dst = dst[:0]
+	}
+
+	var prevKey []byte
+	for i := 0; i < count; i++ {
+		if encoding == FenceRIDGroupEncodingSimple || i == 0 {
+			keyLenU, keyErr := decodeUvarint(payload, &off)
+			if keyErr != nil {
+				return nil, FenceRIDGroupEncodingSimple, keyErr
+			}
+			if keyLenU == 0 || keyLenU > uint64(maxCommitLogKeyLen) {
+				return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+			}
+			keyLen := int(keyLenU)
+			if keyLen > len(payload)-off {
+				return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+			}
+			key := payload[off : off+keyLen]
+			off += keyLen
+			rid, ridErr := decodeUvarint(payload, &off)
+			if ridErr != nil || rid == 0 {
+				return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+			}
+			dst = append(dst, FenceRIDGroupEntry{Key: key, RID: rid})
+			prevKey = key
+			continue
+		}
+
+		sharedU, sharedErr := decodeUvarint(payload, &off)
+		if sharedErr != nil {
+			return nil, FenceRIDGroupEncodingSimple, sharedErr
+		}
+		if sharedU > uint64(len(prevKey)) {
+			return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+		}
+		suffixLenU, suffixErr := decodeUvarint(payload, &off)
+		if suffixErr != nil {
+			return nil, FenceRIDGroupEncodingSimple, suffixErr
+		}
+		if suffixLenU == 0 || suffixLenU > uint64(len(payload)-off) {
+			return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+		}
+		suffixLen := int(suffixLenU)
+		suffix := payload[off : off+suffixLen]
+		off += suffixLen
+		rid, ridErr := decodeUvarint(payload, &off)
+		if ridErr != nil || rid == 0 {
+			return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+		}
+		shared := int(sharedU)
+		keyLen := shared + suffixLen
+		if keyLen <= 0 || keyLen > maxCommitLogKeyLen {
+			return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+		}
+		key := make([]byte, keyLen)
+		copy(key, prevKey[:shared])
+		copy(key[shared:], suffix)
+		if bytes.Compare(prevKey, key) >= 0 {
+			return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+		}
+		dst = append(dst, FenceRIDGroupEntry{Key: key, RID: rid})
+		prevKey = key
+	}
+	if off != len(payload) {
+		return nil, FenceRIDGroupEncodingSimple, ErrCorrupt
+	}
+	return dst, encoding, nil
+}
+
+func ValidateFenceRIDGroupPayload(payload []byte) error {
+	_, _, err := DecodeFenceRIDGroupPayload(payload, nil)
+	return err
+}
+
+func commonPrefixLen(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return i
+}

--- a/TreeDB/internal/commitlog/reader.go
+++ b/TreeDB/internal/commitlog/reader.go
@@ -135,6 +135,13 @@ func decodeBatch(payload []byte) ([]Record, error) {
 			if rid != 0 {
 				return nil, ErrCorrupt
 			}
+		case OpSetFenceRIDGroup:
+			if keyLen != 0 || rid != 0 {
+				return nil, ErrCorrupt
+			}
+			if err := ValidateFenceRIDGroupPayload(val); err != nil {
+				return nil, ErrCorrupt
+			}
 		default:
 			return nil, ErrCorrupt
 		}

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -348,6 +348,16 @@ func validateRecord(r *Record) error {
 		if r.RID != 0 {
 			return fmt.Errorf("commitlog: inline record carries RID")
 		}
+	case OpSetFenceRIDGroup:
+		if len(r.Key) != 0 {
+			return fmt.Errorf("commitlog: fence RID group record requires empty key")
+		}
+		if r.RID != 0 {
+			return fmt.Errorf("commitlog: fence RID group record carries RID header")
+		}
+		if err := ValidateFenceRIDGroupPayload(r.Value); err != nil {
+			return fmt.Errorf("commitlog: invalid fence RID group payload: %w", err)
+		}
 	default:
 		return fmt.Errorf("commitlog: unknown op %d", r.Op)
 	}

--- a/TreeDB/internal/outerleaf/block.go
+++ b/TreeDB/internal/outerleaf/block.go
@@ -1171,6 +1171,8 @@ func (d *DecodedBlock) Keys(dst [][]byte) ([][]byte, error) {
 }
 
 func (d *DecodedBlock) cachedV2Keys() ([][]byte, error) {
+	// sync.Once publishes d.keys/d.keysErr safely: all writes in the Do body
+	// happen-before any caller returns from Do.
 	d.keysOnce.Do(func() {
 		encoded := d.entries
 		keys := make([][]byte, 0, d.entryCount)

--- a/TreeDB/options_aliases.go
+++ b/TreeDB/options_aliases.go
@@ -53,6 +53,11 @@ const (
 )
 
 const (
+	ValueLogWALFenceGroupEncodingSimple = db.ValueLogWALFenceGroupEncodingSimple
+	ValueLogWALFenceGroupEncodingPrefix = db.ValueLogWALFenceGroupEncodingPrefix
+)
+
+const (
 	IndexOuterLeafModeV1         = db.IndexOuterLeafModeV1
 	IndexOuterLeafModeV2BlockPtr = db.IndexOuterLeafModeV2BlockPtr
 	IndexOuterLeafModeV2FencePtr = db.IndexOuterLeafModeV2FencePtr

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -491,6 +491,7 @@ func Open(opts Options) (*DB, error) {
 		ValueLogOuterLeafBlockTargetBytes:     opts.ValueLog.OuterLeafBlockTargetBytes,
 		ValueLogOuterLeafBlockCodec:           uint8(opts.ValueLog.OuterLeafBlockCodec),
 		ValueLogOuterLeafBlockRestartInterval: opts.ValueLog.OuterLeafBlockRestartInterval,
+		ValueLogWALFenceGroupEncoding:         opts.ValueLog.WALFenceGroupEncoding,
 		ValueLogIncompressibleHoldBytes:       opts.ValueLog.IncompressibleHoldBytes,
 		ValueLogIncompressibleProbeBytes:      opts.ValueLog.IncompressibleProbeIntervalBytes,
 		ValueLogAutoPolicy:                    uint8(opts.ValueLog.AutoPolicy),

--- a/TreeDB/recovery_spec_test.go
+++ b/TreeDB/recovery_spec_test.go
@@ -619,6 +619,330 @@ func TestRecovery_PartialFlushFence_NoPhantomPointers(t *testing.T) {
 	}
 }
 
+func TestRecovery_PartialFlushFence_NoPhantomPointers_GroupedRID(t *testing.T) {
+	dir := t.TempDir()
+	walDir := filepath.Join(dir, "maindb", "wal")
+	if err := os.MkdirAll(walDir, 0o755); err != nil {
+		t.Fatalf("mkdir wal: %v", err)
+	}
+
+	valuePath := filepath.Join(walDir, "value-l0-000001.log")
+	vw, err := valuelog.NewWriter(valuePath, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("valuelog.NewWriter: %v", err)
+	}
+	if _, err := vw.Append(0, nil, 1, []byte("v1")); err != nil {
+		_ = vw.Close()
+		t.Fatalf("valuelog.Append: %v", err)
+	}
+	if err := vw.Sync(); err != nil {
+		_ = vw.Close()
+		t.Fatalf("valuelog.Sync: %v", err)
+	}
+	if err := vw.Close(); err != nil {
+		t.Fatalf("valuelog.Close: %v", err)
+	}
+
+	payload, err := commitlog.EncodeFenceRIDGroupPayload([]commitlog.FenceRIDGroupEntry{
+		{Key: []byte("k-good"), RID: 1},
+		{Key: []byte("k-missing"), RID: 2},
+	}, commitlog.FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("EncodeFenceRIDGroupPayload: %v", err)
+	}
+
+	commitPath := filepath.Join(walDir, "commit-l0-000001.log")
+	cw, err := commitlog.NewWriter(commitPath)
+	if err != nil {
+		t.Fatalf("commitlog.NewWriter: %v", err)
+	}
+	if err := cw.AppendBatch([]commitlog.Record{
+		{Op: commitlog.OpSetFenceRIDGroup, Value: payload, Seq: 1},
+	}); err != nil {
+		_ = cw.Close()
+		t.Fatalf("commitlog.AppendBatch: %v", err)
+	}
+	if err := cw.Sync(); err != nil {
+		_ = cw.Close()
+		t.Fatalf("commitlog.Sync: %v", err)
+	}
+	if err := cw.Close(); err != nil {
+		t.Fatalf("commitlog.Close: %v", err)
+	}
+
+	db, err := treedb.Open(treedb.Options{Dir: dir, ChunkSize: 64 * 1024})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	got, err := db.Get([]byte("k-good"))
+	if err != nil {
+		t.Fatalf("get k-good: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected k-good to be absent when grouped fence is unsatisfied, got %q", string(got))
+	}
+	got, err = db.Get([]byte("k-missing"))
+	if err != nil {
+		t.Fatalf("get k-missing: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected k-missing to be absent, got %q", string(got))
+	}
+}
+
+func TestRecovery_MixedLegacySeqZeroAndGroupedRID(t *testing.T) {
+	dir := t.TempDir()
+	walDir := filepath.Join(dir, "maindb", "wal")
+	if err := os.MkdirAll(walDir, 0o755); err != nil {
+		t.Fatalf("mkdir wal: %v", err)
+	}
+
+	valuePath := filepath.Join(walDir, "value-l0-000001.log")
+	vw, err := valuelog.NewWriter(valuePath, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("valuelog.NewWriter: %v", err)
+	}
+	if _, err := vw.Append(0, nil, 1, []byte("v1")); err != nil {
+		_ = vw.Close()
+		t.Fatalf("valuelog.Append: %v", err)
+	}
+	if err := vw.Sync(); err != nil {
+		_ = vw.Close()
+		t.Fatalf("valuelog.Sync: %v", err)
+	}
+	if err := vw.Close(); err != nil {
+		t.Fatalf("valuelog.Close: %v", err)
+	}
+
+	groupedPayload, err := commitlog.EncodeFenceRIDGroupPayload([]commitlog.FenceRIDGroupEntry{
+		{Key: []byte("k-rid"), RID: 1},
+	}, commitlog.FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("EncodeFenceRIDGroupPayload: %v", err)
+	}
+
+	commitPath := filepath.Join(walDir, "commit-l0-000001.log")
+	cw, err := commitlog.NewWriter(commitPath)
+	if err != nil {
+		t.Fatalf("commitlog.NewWriter: %v", err)
+	}
+	if err := cw.AppendBatch([]commitlog.Record{
+		{Op: commitlog.OpSetInline, Key: []byte("k-legacy"), Value: []byte("legacy"), Seq: 0},
+	}); err != nil {
+		_ = cw.Close()
+		t.Fatalf("commitlog.AppendBatch seq0: %v", err)
+	}
+	if err := cw.AppendBatch([]commitlog.Record{
+		{Op: commitlog.OpSetFenceRIDGroup, Value: groupedPayload, Seq: 1},
+	}); err != nil {
+		_ = cw.Close()
+		t.Fatalf("commitlog.AppendBatch grouped: %v", err)
+	}
+	if err := cw.Sync(); err != nil {
+		_ = cw.Close()
+		t.Fatalf("commitlog.Sync: %v", err)
+	}
+	if err := cw.Close(); err != nil {
+		t.Fatalf("commitlog.Close: %v", err)
+	}
+
+	db, err := treedb.Open(treedb.Options{Dir: dir, ChunkSize: 64 * 1024})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	legacyVal, err := db.Get([]byte("k-legacy"))
+	if err != nil {
+		t.Fatalf("get k-legacy: %v", err)
+	}
+	if string(legacyVal) != "legacy" {
+		t.Fatalf("get k-legacy: got %q want %q", string(legacyVal), "legacy")
+	}
+	groupVal, err := db.Get([]byte("k-rid"))
+	if err != nil {
+		t.Fatalf("get k-rid: %v", err)
+	}
+	if string(groupVal) != "v1" {
+		t.Fatalf("get k-rid: got %q want %q", string(groupVal), "v1")
+	}
+}
+
+func TestRecovery_MultiLaneOrdering_GroupedRID(t *testing.T) {
+	dir := t.TempDir()
+	walDir := filepath.Join(dir, "maindb", "wal")
+	if err := os.MkdirAll(walDir, 0o755); err != nil {
+		t.Fatalf("mkdir wal: %v", err)
+	}
+
+	fileID0, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID lane0: %v", err)
+	}
+	valuePathLane0 := filepath.Join(walDir, "value-l0-000001.log")
+	vw0, err := valuelog.NewWriter(valuePathLane0, page.ValueLogFileID(fileID0))
+	if err != nil {
+		t.Fatalf("valuelog.NewWriter lane0: %v", err)
+	}
+	if _, err := vw0.Append(0, nil, 2, []byte("v2")); err != nil {
+		_ = vw0.Close()
+		t.Fatalf("valuelog.Append lane0: %v", err)
+	}
+	if err := vw0.Sync(); err != nil {
+		_ = vw0.Close()
+		t.Fatalf("valuelog.Sync lane0: %v", err)
+	}
+	if err := vw0.Close(); err != nil {
+		t.Fatalf("valuelog.Close lane0: %v", err)
+	}
+
+	fileID1, err := valuelog.EncodeFileID(1, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID lane1: %v", err)
+	}
+	valuePathLane1 := filepath.Join(walDir, "value-l1-000001.log")
+	vw1, err := valuelog.NewWriter(valuePathLane1, page.ValueLogFileID(fileID1))
+	if err != nil {
+		t.Fatalf("valuelog.NewWriter lane1: %v", err)
+	}
+	if _, err := vw1.Append(0, nil, 1, []byte("v1")); err != nil {
+		_ = vw1.Close()
+		t.Fatalf("valuelog.Append lane1: %v", err)
+	}
+	if err := vw1.Sync(); err != nil {
+		_ = vw1.Close()
+		t.Fatalf("valuelog.Sync lane1: %v", err)
+	}
+	if err := vw1.Close(); err != nil {
+		t.Fatalf("valuelog.Close lane1: %v", err)
+	}
+
+	payloadLane0, err := commitlog.EncodeFenceRIDGroupPayload([]commitlog.FenceRIDGroupEntry{
+		{Key: []byte("k"), RID: 2},
+	}, commitlog.FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("EncodeFenceRIDGroupPayload lane0: %v", err)
+	}
+	payloadLane1, err := commitlog.EncodeFenceRIDGroupPayload([]commitlog.FenceRIDGroupEntry{
+		{Key: []byte("k"), RID: 1},
+	}, commitlog.FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("EncodeFenceRIDGroupPayload lane1: %v", err)
+	}
+
+	commitPathLane0 := filepath.Join(walDir, "commit-l0-000001.log")
+	cw0, err := commitlog.NewWriter(commitPathLane0)
+	if err != nil {
+		t.Fatalf("commitlog.NewWriter lane0: %v", err)
+	}
+	if err := cw0.AppendBatch([]commitlog.Record{{Op: commitlog.OpSetFenceRIDGroup, Value: payloadLane0, Seq: 2}}); err != nil {
+		_ = cw0.Close()
+		t.Fatalf("commitlog.AppendBatch lane0: %v", err)
+	}
+	if err := cw0.Sync(); err != nil {
+		_ = cw0.Close()
+		t.Fatalf("commitlog.Sync lane0: %v", err)
+	}
+	if err := cw0.Close(); err != nil {
+		t.Fatalf("commitlog.Close lane0: %v", err)
+	}
+
+	commitPathLane1 := filepath.Join(walDir, "commit-l1-000001.log")
+	cw1, err := commitlog.NewWriter(commitPathLane1)
+	if err != nil {
+		t.Fatalf("commitlog.NewWriter lane1: %v", err)
+	}
+	if err := cw1.AppendBatch([]commitlog.Record{{Op: commitlog.OpSetFenceRIDGroup, Value: payloadLane1, Seq: 1}}); err != nil {
+		_ = cw1.Close()
+		t.Fatalf("commitlog.AppendBatch lane1: %v", err)
+	}
+	if err := cw1.Sync(); err != nil {
+		_ = cw1.Close()
+		t.Fatalf("commitlog.Sync lane1: %v", err)
+	}
+	if err := cw1.Close(); err != nil {
+		t.Fatalf("commitlog.Close lane1: %v", err)
+	}
+
+	db, err := treedb.Open(treedb.Options{Dir: dir, ChunkSize: 64 * 1024})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	val, err := db.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(val) != "v2" {
+		t.Fatalf("expected replay order to honor Seq; got %q", string(val))
+	}
+}
+
+func TestRecovery_GroupedRIDPayloadCorruptionFails(t *testing.T) {
+	dir := t.TempDir()
+	walDir := filepath.Join(dir, "maindb", "wal")
+	if err := os.MkdirAll(walDir, 0o755); err != nil {
+		t.Fatalf("mkdir wal: %v", err)
+	}
+
+	payload, err := commitlog.EncodeFenceRIDGroupPayload([]commitlog.FenceRIDGroupEntry{
+		{Key: []byte("k1"), RID: 1},
+		{Key: []byte("k2"), RID: 2},
+	}, commitlog.FenceRIDGroupEncodingSimple)
+	if err != nil {
+		t.Fatalf("EncodeFenceRIDGroupPayload: %v", err)
+	}
+	commitPath := filepath.Join(walDir, "commit-l0-000001.log")
+	cw, err := commitlog.NewWriter(commitPath)
+	if err != nil {
+		t.Fatalf("commitlog.NewWriter: %v", err)
+	}
+	if err := cw.AppendBatch([]commitlog.Record{{Op: commitlog.OpSetFenceRIDGroup, Value: payload, Seq: 1}}); err != nil {
+		_ = cw.Close()
+		t.Fatalf("commitlog.AppendBatch: %v", err)
+	}
+	if err := cw.Close(); err != nil {
+		t.Fatalf("commitlog.Close: %v", err)
+	}
+
+	raw, err := os.ReadFile(commitPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile: %v", err)
+	}
+	payloadLen := int(binary.LittleEndian.Uint32(raw[0:4]))
+	if payloadLen <= 0 || len(raw) < 8+payloadLen {
+		t.Fatalf("unexpected commit payload length %d", payloadLen)
+	}
+	segPayload := raw[8 : 8+payloadLen]
+	// Corrupt grouped payload version byte while keeping segment CRC valid.
+	const (
+		batchHeaderBytes  = 1 + 4
+		recordHeaderBytes = 1 + 2 + 4 + 8 + 8
+	)
+	if len(segPayload) < batchHeaderBytes+recordHeaderBytes {
+		t.Fatalf("unexpected segment payload size %d", len(segPayload))
+	}
+	recordHeaderStart := batchHeaderBytes
+	keyLen := int(binary.LittleEndian.Uint16(segPayload[recordHeaderStart+1 : recordHeaderStart+3]))
+	valLen := int(binary.LittleEndian.Uint32(segPayload[recordHeaderStart+3 : recordHeaderStart+7]))
+	recordPayloadOffset := batchHeaderBytes + recordHeaderBytes + keyLen
+	if keyLen < 0 || valLen <= 0 || recordPayloadOffset+valLen > len(segPayload) {
+		t.Fatalf("unexpected segment payload size %d", len(segPayload))
+	}
+	segPayload[recordPayloadOffset] = 0xFF
+	binary.LittleEndian.PutUint32(raw[4:8], crc.Checksum(segPayload))
+	if err := os.WriteFile(commitPath, raw, 0o600); err != nil {
+		t.Fatalf("os.WriteFile: %v", err)
+	}
+
+	if _, err := treedb.Open(treedb.Options{Dir: dir, ChunkSize: 64 * 1024}); err == nil {
+		t.Fatalf("expected open failure on corrupted grouped payload")
+	}
+}
+
 func TestRecovery_MultiLaneOrdering(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -85,6 +85,7 @@ var (
 	treedbIndexPackedValuePtr             = flag.Bool("treedb-index-packed-valueptr", false, "TreeDB: enable packed 12-byte ValuePtr encoding for pointer entries in leaf pages")
 	treedbIndexInternalBaseDelta          = flag.Bool("treedb-index-internal-base-delta", false, "TreeDB: enable internal base-delta encoding")
 	treedbIndexOuterLeafMode              = flag.String("treedb-index-outer-leaf-mode", "v1", "TreeDB: index outer-leaf mode (v1|v2_blockptr|v2_fenceptr)")
+	treedbWALFenceGroupEncoding           = flag.String("treedb-wal-fence-group-encoding", "simple", "TreeDB: WAL fence RID group encoding for WAL-on v2_fenceptr (simple|prefix)")
 	treedbOuterLeafBlockTargetBytes       = flag.Int("treedb-outer-leaf-block-target-bytes", 0, "TreeDB: experimental outer-leaf block target bytes (0=default)")
 	treedbOuterLeafBlockCodec             = flag.String("treedb-outer-leaf-block-codec", "snappy", "TreeDB: experimental outer-leaf block codec (snappy|lz4)")
 	treedbOuterLeafBlockRestart           = flag.Int("treedb-outer-leaf-block-restart-interval", 0, "TreeDB: experimental outer-leaf restart interval (0=default)")
@@ -271,6 +272,17 @@ func parseTreeDBOuterLeafMode(s string) (string, error) {
 	}
 }
 
+func parseTreeDBWALFenceGroupEncoding(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", treedb.ValueLogWALFenceGroupEncodingSimple:
+		return treedb.ValueLogWALFenceGroupEncodingSimple, nil
+	case treedb.ValueLogWALFenceGroupEncodingPrefix:
+		return treedb.ValueLogWALFenceGroupEncodingPrefix, nil
+	default:
+		return "", fmt.Errorf("unsupported -treedb-wal-fence-group-encoding=%q (expected simple|prefix)", s)
+	}
+}
+
 type treeDBOptionsReport struct {
 	opts     treedb.Options
 	notes    []string
@@ -299,6 +311,7 @@ func (r treeDBOptionsReport) formatText(indent string) string {
 	lines = append(lines, fmt.Sprintf("index_packed_valueptr=%t", r.opts.IndexPackedValuePtr))
 	lines = append(lines, fmt.Sprintf("index_internal_base_delta=%t", r.opts.IndexInternalBaseDelta))
 	lines = append(lines, fmt.Sprintf("index_outer_leaf_mode=%s", strings.TrimSpace(r.opts.IndexOuterLeafMode)))
+	lines = append(lines, fmt.Sprintf("vlog.wal_fence_group_encoding=%s", formatTreeDBWALFenceGroupEncoding(r.opts.ValueLog.WALFenceGroupEncoding)))
 	lines = append(lines, fmt.Sprintf("cached.domain_ingress_workers=%d", r.opts.DomainIngressWorkers))
 	lines = append(lines, fmt.Sprintf("cached.domain_ingress_queue_size=%d", r.opts.DomainIngressQueueSize))
 	lines = append(lines, fmt.Sprintf("vlog.force_pointers=%t", r.opts.ValueLog.ForcePointers))
@@ -438,6 +451,17 @@ func formatTreeDBVlogAutoPolicy(policy treedb.ValueLogAutoPolicy) string {
 	}
 }
 
+func formatTreeDBWALFenceGroupEncoding(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", treedb.ValueLogWALFenceGroupEncodingSimple:
+		return treedb.ValueLogWALFenceGroupEncodingSimple
+	case treedb.ValueLogWALFenceGroupEncodingPrefix:
+		return treedb.ValueLogWALFenceGroupEncodingPrefix
+	default:
+		return strings.ToLower(strings.TrimSpace(mode))
+	}
+}
+
 func resolveIndexOptimizationBool(flagName string, flagValue bool, compositeValue bool, compositeExplicit bool) bool {
 	if flagExplicit(flagName) {
 		return flagValue
@@ -557,6 +581,7 @@ func buildTreeDBOptions(dir string) (treedb.Options, treeDBOptionsReport, error)
 			DictIncompressibleHoldBytes:      *treedbVlogDictIncompressibleHoldBytes,
 			DictProbeIntervalBytes:           *treedbVlogDictProbeIntervalBytes,
 			DictMinPayloadSavingsRatio:       *treedbVlogDictMinSavingsRatio,
+			WALFenceGroupEncoding:            treedb.ValueLogWALFenceGroupEncodingSimple,
 			OuterLeafBlockRestartInterval:    *treedbOuterLeafBlockRestart,
 			OuterLeafBlockCacheEntries:       *treedbOuterLeafBlockCacheEntries,
 		},
@@ -585,6 +610,11 @@ func buildTreeDBOptions(dir string) (treedb.Options, treeDBOptionsReport, error)
 		return treedb.Options{}, treeDBOptionsReport{}, err
 	}
 	opts.IndexOuterLeafMode = outerMode
+	walFenceGroupEncoding, err := parseTreeDBWALFenceGroupEncoding(*treedbWALFenceGroupEncoding)
+	if err != nil {
+		return treedb.Options{}, treeDBOptionsReport{}, err
+	}
+	opts.ValueLog.WALFenceGroupEncoding = walFenceGroupEncoding
 	outerCodec, err := parseTreeDBVlogBlockCodec(*treedbOuterLeafBlockCodec)
 	if err != nil {
 		return treedb.Options{}, treeDBOptionsReport{}, err

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
 
 type savedTreeDBFlagState struct {
 	indexOptimizations bool
@@ -10,6 +14,7 @@ type savedTreeDBFlagState struct {
 	packedValuePtr     bool
 	internalBaseDelta  bool
 	vlogAutoPolicy     string
+	walFenceEncoding   string
 	outerLeafCache     int
 	disableWAL         bool
 	relaxedSync        bool
@@ -32,6 +37,7 @@ func saveTreeDBFlagState() savedTreeDBFlagState {
 		packedValuePtr:     *treedbIndexPackedValuePtr,
 		internalBaseDelta:  *treedbIndexInternalBaseDelta,
 		vlogAutoPolicy:     *treedbVlogAutoPolicy,
+		walFenceEncoding:   *treedbWALFenceGroupEncoding,
 		outerLeafCache:     *treedbOuterLeafBlockCacheEntries,
 		disableWAL:         *treedbDisableWAL,
 		relaxedSync:        *treedbRelaxedSync,
@@ -50,6 +56,7 @@ func restoreTreeDBFlagState(s savedTreeDBFlagState) {
 	*treedbIndexPackedValuePtr = s.packedValuePtr
 	*treedbIndexInternalBaseDelta = s.internalBaseDelta
 	*treedbVlogAutoPolicy = s.vlogAutoPolicy
+	*treedbWALFenceGroupEncoding = s.walFenceEncoding
 	*treedbOuterLeafBlockCacheEntries = s.outerLeafCache
 	*treedbDisableWAL = s.disableWAL
 	*treedbRelaxedSync = s.relaxedSync
@@ -67,6 +74,7 @@ func resetTreeDBIndexFlagsForTest() {
 	*treedbIndexPackedValuePtr = false
 	*treedbIndexInternalBaseDelta = false
 	*treedbVlogAutoPolicy = "balanced"
+	*treedbWALFenceGroupEncoding = treedb.ValueLogWALFenceGroupEncodingSimple
 	*treedbOuterLeafBlockCacheEntries = 0
 	*treedbDisableWAL = false
 	*treedbRelaxedSync = false
@@ -216,5 +224,28 @@ func TestBuildTreeDBOptions_ExplicitCompositeFalseWinsUnlessPerFlagExplicit(t *t
 	}
 	if opts.LeafPrefixCompression || opts.IndexColumnarLeaves || opts.IndexInternalBaseDelta {
 		t.Fatalf("expected explicit composite=false to disable remaining optimization fields")
+	}
+}
+
+func TestBuildTreeDBOptions_WALFenceGroupEncoding_DefaultAndOverride(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	opts, _, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions default: %v", err)
+	}
+	if got := opts.ValueLog.WALFenceGroupEncoding; got != treedb.ValueLogWALFenceGroupEncodingSimple {
+		t.Fatalf("default WAL fence group encoding=%q want %q", got, treedb.ValueLogWALFenceGroupEncodingSimple)
+	}
+
+	*treedbWALFenceGroupEncoding = treedb.ValueLogWALFenceGroupEncodingPrefix
+	opts, _, err = buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions prefix: %v", err)
+	}
+	if got := opts.ValueLog.WALFenceGroupEncoding; got != treedb.ValueLogWALFenceGroupEncodingPrefix {
+		t.Fatalf("override WAL fence group encoding=%q want %q", got, treedb.ValueLogWALFenceGroupEncodingPrefix)
 	}
 }


### PR DESCRIPTION
## Summary
- add new commitlog op `OpSetFenceRIDGroup` for grouped `(key,RID)` payloads
- keep WAL-on `v2_fenceptr` enabled and reduce WAL amplification in batch pointer-heavy paths
- canonicalize WAL-on `v2_fenceptr` batch entries with last-write-wins semantics, then deterministic key ordering before grouped WAL encoding/chunking
- enforce singleton fallback to legacy `OpSetRID`
- add strict grouped payload validation in commitlog reader/writer (`KeyLen==0`, `RID==0`, malformed payload rejection)
- integrate grouped op into recovery fence checks and replay apply
- expose `ValueLog.WALFenceGroupEncoding` (`simple` default, `prefix` opt-in) through public API and unified-bench flag `-treedb-wal-fence-group-encoding`
- add WAL grouped stats counters in caching stats
- update storage/recovery/durability docs for new opcode + replay semantics

## Notes
- keeps `setDirect`/single-call `Set` behavior unchanged (per-key WAL)
- no auto-defaulting of domain ingress workers
- pre-alpha on-disk compatibility note added for new opcode

## Testing
- `go test ./TreeDB/internal/commitlog -run 'TestFenceRIDGroupPayloadRoundTrip|TestFenceRIDGroupPayloadMalformed|TestCommitLogWriteReadBatchFenceRIDGroup|TestCommitLogFenceRIDGroupRejectsNonEmptyKeyWriter|TestCommitLogFenceRIDGroupReaderRejectsNonEmptyKey|TestCommitLogFenceRIDGroupSizeBoundaries'`
- `go test ./TreeDB/caching -run 'TestCachingDB_BatchWALFenceGroupCanonicalizesFinalState|TestCachingDB_FlushFenceModeCollapsesPointerEntries|TestCachingDB_FlushFenceModeDeferredSingletonWritesRegroup'`
- `go test ./TreeDB -run 'TestRecovery_PartialFlushFence_NoPhantomPointers_GroupedRID|TestRecovery_MixedLegacySeqZeroAndGroupedRID|TestRecovery_MultiLaneOrdering_GroupedRID|TestRecovery_GroupedRIDPayloadCorruptionFails|TestRecovery_CommitFence_PublishesOnlyCommittedVLogRefs|TestRecovery_PartialFlushFence_NoPhantomPointers'`
- `go test ./cmd/unified_bench`
- `go test ./TreeDB/...`
