### PR TITLE
treedb: fast-path outerleaf decode in append reads

### DIFF
--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -579,12 +579,27 @@ func (r valueReader) ReadUnsafeAppendForKey(ptr page.ValuePtr, key []byte, dst [
 		if !outerleaf.HasMagic(raw) {
 			return raw, nil
 		}
+		entry, ok, found, _, decErr := outerleaf.DecodeEntryForKey(raw, key, nil)
+		if decErr != nil {
+			return nil, decErr
+		}
+		// Directly decode targeted entries first to avoid constructing a decoded
+		// outer-leaf block on the common append fast-path when full block caching
+		// would not provide additional benefit.
+		if ok {
+			if !found {
+				return nil, fmt.Errorf("value reader: outer-leaf key lookup miss ptr=%+v key=%x", ptr, key)
+			}
+			if r.cache == nil || entry.Kind == outerleaf.EntryKindBlobRef {
+				return r.resolveLookupResultAppend(entry, dst)
+			}
+		}
 		raw = r.stableOuterLeafPayload(raw)
-		block, err := r.outerLeafBlock(ptr, raw)
+		block, err := r.outerLeafBlockFromRaw(ptr, raw)
 		if err != nil {
 			return nil, err
 		}
-		entry, found, err := block.EntryForKey(key)
+		entry, found, err = block.EntryForKey(key)
 		if err != nil {
 			return nil, err
 		}
@@ -702,16 +717,24 @@ func (r valueReader) outerLeafBlock(ptr page.ValuePtr, raw []byte) (*outerleaf.D
 	if block := r.cache.get(key); block != nil {
 		return block, nil
 	}
+	return r.outerLeafBlockFromRaw(ptr, raw)
+}
+
+func (r valueReader) outerLeafBlockFromRaw(ptr page.ValuePtr, raw []byte) (*outerleaf.DecodedBlock, error) {
+	verifyChecksums := !r.skipOuterLeafChecksums
 	block, err := outerleaf.DecodeBlockWithVerify(raw, nil, verifyChecksums)
 	if err != nil {
 		return nil, err
+	}
+	if r.cache == nil {
+		return block, nil
 	}
 	// Blob-ref-dominant fence blocks (large-value mode) exhibit low temporal
 	// locality and high cache churn in prefix scans; skipping cache admission for
 	// those blocks avoids lock/churn overhead while retaining cache benefits for
 	// inline-heavy blocks.
 	if block.FirstKind() != outerleaf.EntryKindBlobRef {
-		r.cache.put(key, block)
+		r.cache.put(newOuterLeafBlockKey(ptr), block)
 	}
 	return block, nil
 }

--- a/TreeDB/db/value_reader_bench_test.go
+++ b/TreeDB/db/value_reader_bench_test.go
@@ -1,0 +1,159 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/outerleaf"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func makeBenchOuterLeafPayload(tb testing.TB, codec uint8, offset uint64, entries []outerleaf.Entry) ([]byte, page.ValuePtr) {
+	tb.Helper()
+	encoded, err := outerleaf.EncodeEntries(nil, entries, codec, 16)
+	if err != nil {
+		tb.Fatalf("encode outer-leaf payload: %v", err)
+	}
+	return encoded, page.ValuePtr{
+		FileID: page.ValueLogFileID(7),
+		Offset: offset,
+		Length: uint32(len(encoded)),
+	}
+}
+
+func BenchmarkValueReaderReadUnsafeAppendForKey_CacheHitSkipsRawRead(b *testing.B) {
+	payload, ptr := makeBenchOuterLeafPayload(
+		b,
+		uint8(ValueLogBlockSnappy),
+		128,
+		[]outerleaf.Entry{
+			{Key: []byte("k1"), Value: []byte("v1")},
+			{Key: []byte("k2"), Value: []byte("v2")},
+			{Key: []byte("k3"), Value: []byte("v3")},
+		},
+	)
+	reader := &stubValueLogAppendReader{
+		stubValueLogReader: stubValueLogReader{
+			payloads: map[page.ValuePtr][]byte{ptr: payload},
+		},
+	}
+	cache := newOuterLeafBlockCache(8)
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+		cache:         cache,
+	}
+
+	key := []byte("k2")
+	dst := make([]byte, 0, 16)
+	if _, err := r.ReadUnsafeAppendForKey(ptr, key, dst); err != nil {
+		b.Fatalf("warmup: %v", err)
+	}
+	if _, misses, _, _ := cache.stats(); misses != 1 {
+		b.Fatalf("warmup misses = %d, want 1", misses)
+	}
+	reader.readUnsafeAppendCalls = 0
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := r.ReadUnsafeAppendForKey(ptr, key, dst[:0]); err != nil {
+			b.Fatalf("read %d: %v", i, err)
+		}
+	}
+	b.ReportMetric(float64(reader.readUnsafeAppendCalls)/float64(b.N), "raw_reads/op")
+	if reader.readUnsafeAppendCalls != 0 {
+		b.Fatalf("raw read count = %d, want 0 in warmed cache path", reader.readUnsafeAppendCalls)
+	}
+}
+
+func BenchmarkValueReaderReadUnsafeAppendForKey_NoCacheAlwaysReads(b *testing.B) {
+	payload, ptr := makeBenchOuterLeafPayload(
+		b,
+		uint8(ValueLogBlockSnappy),
+		256,
+		[]outerleaf.Entry{
+			{Key: []byte("k1"), Value: []byte("v1")},
+			{Key: []byte("k2"), Value: []byte("v2")},
+		},
+	)
+	reader := &stubValueLogAppendReader{
+		stubValueLogReader: stubValueLogReader{
+			payloads: map[page.ValuePtr][]byte{ptr: payload},
+		},
+	}
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+	}
+
+	key := []byte("k2")
+	dst := make([]byte, 0, 16)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := r.ReadUnsafeAppendForKey(ptr, key, dst[:0]); err != nil {
+			b.Fatalf("read %d: %v", i, err)
+		}
+	}
+	b.ReportMetric(float64(reader.readUnsafeAppendCalls)/float64(b.N), "raw_reads/op")
+	if reader.readUnsafeAppendCalls != b.N {
+		b.Fatalf("raw read count = %d, want %d", reader.readUnsafeAppendCalls, b.N)
+	}
+}
+
+func BenchmarkValueReaderReadUnsafeAppendBatchForKeys_RawReadsPerBatch(b *testing.B) {
+	payloadA, ptrA := makeBenchOuterLeafPayload(
+		b,
+		uint8(ValueLogBlockSnappy),
+		384,
+		[]outerleaf.Entry{
+			{Key: []byte("k1"), Value: []byte("v1")},
+			{Key: []byte("k2"), Value: []byte("v2")},
+			{Key: []byte("k3"), Value: []byte("v3")},
+		},
+	)
+	payloadB, ptrB := makeBenchOuterLeafPayload(
+		b,
+		uint8(ValueLogBlockSnappy),
+		448,
+		[]outerleaf.Entry{
+			{Key: []byte("k1"), Value: []byte("w1")},
+			{Key: []byte("k2"), Value: []byte("w2")},
+		},
+	)
+	reader := &stubValueLogAppendReader{
+		stubValueLogReader: stubValueLogReader{
+			payloads: map[page.ValuePtr][]byte{
+				ptrA: payloadA,
+				ptrB: payloadB,
+			},
+		},
+	}
+	cache := newOuterLeafBlockCache(8)
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+		cache:         cache,
+	}
+
+	ptrs := []page.ValuePtr{ptrA, ptrB, ptrA, ptrB}
+	keys := [][]byte{[]byte("k1"), []byte("k2"), []byte("k1"), []byte("k2")}
+	dst := make([][]byte, len(ptrs))
+	_, err := r.ReadUnsafeAppendBatchForKeys(ptrs, keys, dst)
+	if err != nil {
+		b.Fatalf("warmup: %v", err)
+	}
+	reader.readUnsafeAppendCalls = 0
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := r.ReadUnsafeAppendBatchForKeys(ptrs, keys, dst); err != nil {
+			b.Fatalf("batch %d: %v", i, err)
+		}
+	}
+	b.ReportMetric(float64(reader.readUnsafeAppendCalls)/float64(b.N*len(ptrs)), "raw_reads/op")
+	if reader.readUnsafeAppendCalls <= 0 {
+		b.Fatalf("raw read count = %d, want > 0 from batch reader path", reader.readUnsafeAppendCalls)
+	}
+}

--- a/TreeDB/db/value_reader_test.go
+++ b/TreeDB/db/value_reader_test.go
@@ -560,6 +560,154 @@ func TestValueReaderReadUnsafeFenceBlockKeys_OuterLeafKeyCacheChurn(t *testing.T
 	}
 }
 
+func TestValueReaderReadUnsafeAppendForKey_ReadAmortizationAfterWarmup(t *testing.T) {
+	payload, ptr := makeTestOuterLeafPayloadWithCodec(t, uint8(ValueLogBlockSnappy), 64, "v1", "v2", "v3")
+	reader := &stubValueLogAppendReader{
+		stubValueLogReader: stubValueLogReader{
+			payloads: map[page.ValuePtr][]byte{ptr: payload},
+		},
+	}
+	cache := newOuterLeafBlockCache(4)
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+		cache:         cache,
+	}
+	key := []byte("k2")
+	dst := make([]byte, 0, 16)
+
+	first, err := r.ReadUnsafeAppendForKey(ptr, key, dst)
+	if err != nil {
+		t.Fatalf("ReadUnsafeAppendForKey(first): %v", err)
+	}
+	if !bytes.Equal(first, []byte("v2")) {
+		t.Fatalf("first value = %q, want %q", first, "v2")
+	}
+	if reader.readUnsafeAppendCalls != 1 {
+		t.Fatalf("readUnsafeAppendCalls after first read = %d, want 1", reader.readUnsafeAppendCalls)
+	}
+
+	for i := 0; i < 64; i++ {
+		got, err := r.ReadUnsafeAppendForKey(ptr, key, dst[:0])
+		if err != nil {
+			t.Fatalf("ReadUnsafeAppendForKey(repeat=%d): %v", i, err)
+		}
+		if !bytes.Equal(got, []byte("v2")) {
+			t.Fatalf("repeat value at i=%d = %q, want %q", i, got, "v2")
+		}
+	}
+
+	if reader.readUnsafeAppendCalls != 1 {
+		t.Fatalf("readUnsafeAppendCalls after repeated reads = %d, want 1", reader.readUnsafeAppendCalls)
+	}
+
+	hits, misses, entries, capacity := cache.stats()
+	if entries != 1 {
+		t.Fatalf("cache entries = %d, want 1", entries)
+	}
+	if capacity < 1 {
+		t.Fatalf("cache capacity = %d, want >= 1", capacity)
+	}
+	if hits < 63 {
+		t.Fatalf("cache hits = %d, want >= %d", hits, 63)
+	}
+	if misses != 1 {
+		t.Fatalf("cache misses = %d, want 1", misses)
+	}
+}
+
+func TestValueReaderReadUnsafeAppendForKey_BlockCacheMixWithChurn(t *testing.T) {
+	const hotReads = 4
+	const churnKeys = 12
+
+	readerPayloads := make(map[page.ValuePtr][]byte, hotReads+churnKeys)
+	hotPtr := page.ValuePtr{}
+	var hotKey []byte
+	hotPayload, ptr := makeTestOuterLeafSinglePayload(t, uint8(ValueLogBlockSnappy), 128, "hot-k", "hot-v")
+	readerPayloads[ptr] = hotPayload
+	hotPtr = ptr
+	hotKey = []byte("hot-k")
+
+	churnPtrs := make([]page.ValuePtr, churnKeys)
+	for i := 0; i < churnKeys; i++ {
+		payload, cptr := makeTestOuterLeafSinglePayload(
+			t,
+			uint8(ValueLogBlockSnappy),
+			uint64(256+i*64),
+			fmt.Sprintf("churn-%02d", i),
+			fmt.Sprintf("v-%02d", i),
+		)
+		readerPayloads[cptr] = payload
+		churnPtrs[i] = cptr
+	}
+
+	reader := &stubValueLogAppendReader{
+		stubValueLogReader: stubValueLogReader{
+			payloads: readerPayloads,
+		},
+	}
+	// Include churn workload while keeping a bounded cache.
+	cache := newOuterLeafBlockCache(16)
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+		cache:         cache,
+	}
+	dst := make([]byte, 0, 16)
+
+	for i := 0; i < hotReads; i++ {
+		got, err := r.ReadUnsafeAppendForKey(hotPtr, hotKey, dst[:0])
+		if err != nil {
+			t.Fatalf("ReadUnsafeAppendForKey(hot=%d): %v", i, err)
+		}
+		if !bytes.Equal(got, []byte("hot-v")) {
+			t.Fatalf("hot read at i=%d = %q, want %q", i, got, "hot-v")
+		}
+	}
+
+	afterHotCalls := reader.readUnsafeAppendCalls
+	if afterHotCalls != 1 {
+		t.Fatalf("readUnsafeAppendCalls after hot warmup = %d, want 1", afterHotCalls)
+	}
+
+	for i := 0; i < churnKeys; i++ {
+		key := []byte(fmt.Sprintf("churn-%02d", i))
+		got, err := r.ReadUnsafeAppendForKey(churnPtrs[i], key, dst[:0])
+		if err != nil {
+			t.Fatalf("ReadUnsafeAppendForKey(churn=%d): %v", i, err)
+		}
+		want := fmt.Sprintf("v-%02d", i)
+		if !bytes.Equal(got, []byte(want)) {
+			t.Fatalf("churn read=%d = %q, want %q", i, got, want)
+		}
+	}
+
+	for i := 0; i < hotReads; i++ {
+		got, err := r.ReadUnsafeAppendForKey(hotPtr, hotKey, dst[:0])
+		if err != nil {
+			t.Fatalf("ReadUnsafeAppendForKey(post-churn hot=%d): %v", i, err)
+		}
+		if !bytes.Equal(got, []byte("hot-v")) {
+			t.Fatalf("post-churn hot read at i=%d = %q, want %q", i, got, "hot-v")
+		}
+	}
+
+	if reader.readUnsafeAppendCalls < (1 + churnKeys) {
+		t.Fatalf("readUnsafeAppendCalls = %d, want >= %d", reader.readUnsafeAppendCalls, 1+churnKeys)
+	}
+
+	hits, misses, entries, capacity := cache.stats()
+	if misses < uint64(1+churnKeys) {
+		t.Fatalf("cache misses = %d, want >= %d", misses, 1+churnKeys)
+	}
+	if hits < uint64(hotReads-1) {
+		t.Fatalf("cache hits = %d, want >= %d", hits, hotReads-1)
+	}
+	if entries > capacity {
+		t.Fatalf("cache entries = %d, want <= %d", entries, capacity)
+	}
+}
+
 func TestValueReaderReadUnsafeFenceBlockSeek_ClassifiesBoundsAndReusesCache(t *testing.T) {
 	payload, _, ptr := makeTestOuterLeafPayload(t)
 	reader := &stubValueLogReader{payloads: map[page.ValuePtr][]byte{ptr: payload}}

--- a/scripts/outerleaf_v2_perf_gate.sh
+++ b/scripts/outerleaf_v2_perf_gate.sh
@@ -11,6 +11,8 @@ BATCHSIZE="${BATCHSIZE:-8000}"
 SEED="${SEED:-1}"
 PROFILES="${PROFILES:-fast,wal_on_fast,durable}"
 TESTS="${TESTS:-batch_write,batch_write_steady,prefix_scan}"
+READ_TESTS="${READ_TESTS:-random_read,random_read_parallel,random_read_parallel_acquire_snapshot}"
+INCLUDE_READ_TESTS="${INCLUDE_READ_TESTS:-0}"
 VAL_PATTERN="${VAL_PATTERN:-repeat_tail64}"
 RANGE_QUERIES="${RANGE_QUERIES:-200}"
 RANGE_SPAN="${RANGE_SPAN:-100}"
@@ -23,6 +25,9 @@ GATE_PROFILES="${GATE_PROFILES:-fast}"
 GATE_MIN_RATIO_BATCH_WRITE="${GATE_MIN_RATIO_BATCH_WRITE:-0.70}"
 GATE_MIN_RATIO_BATCH_WRITE_STEADY="${GATE_MIN_RATIO_BATCH_WRITE_STEADY:-0.70}"
 GATE_MIN_RATIO_PREFIX_SCAN="${GATE_MIN_RATIO_PREFIX_SCAN:-0.35}"
+GATE_MIN_RATIO_RANDOM_READ="${GATE_MIN_RATIO_RANDOM_READ:-0.80}"
+GATE_MIN_RATIO_RANDOM_READ_PARALLEL="${GATE_MIN_RATIO_RANDOM_READ_PARALLEL:-0.75}"
+GATE_MIN_RATIO_RANDOM_READ_PARALLEL_ACQUIRE_SNAPSHOT="${GATE_MIN_RATIO_RANDOM_READ_PARALLEL_ACQUIRE_SNAPSHOT:-0.70}"
 GATE_MAX_CV_PCT="${GATE_MAX_CV_PCT:-12.0}"
 
 # Determinism/noise knobs.
@@ -43,6 +48,26 @@ fi
 if (( WARMUP_RUNS < 0 )); then
   echo "WARMUP_RUNS must be >= 0" >&2
   exit 2
+fi
+
+if [[ "$INCLUDE_READ_TESTS" != "0" ]]; then
+  merged_tests="${TESTS},${READ_TESTS}"
+  IFS=',' read -r -a _tests <<<"$merged_tests"
+  seen_tests=""
+  deduped=()
+  for t in "${_tests[@]}"; do
+    if [[ -z "$t" ]]; then
+      continue
+    fi
+    if [[ ",$seen_tests," == *",${t},"* ]]; then
+      continue
+    fi
+    seen_tests="${seen_tests:+${seen_tests},}${t}"
+    deduped+=("$t")
+  done
+  IFS=','
+  TESTS="${deduped[*]}"
+  unset IFS
 fi
 
 if [[ -n "$CPUSET" ]]; then
@@ -78,7 +103,12 @@ gate_profiles=$GATE_PROFILES
 gate_min_ratio_batch_write=$GATE_MIN_RATIO_BATCH_WRITE
 gate_min_ratio_batch_write_steady=$GATE_MIN_RATIO_BATCH_WRITE_STEADY
 gate_min_ratio_prefix_scan=$GATE_MIN_RATIO_PREFIX_SCAN
+gate_min_ratio_random_read=$GATE_MIN_RATIO_RANDOM_READ
+gate_min_ratio_random_read_parallel=$GATE_MIN_RATIO_RANDOM_READ_PARALLEL
+gate_min_ratio_random_read_parallel_acquire_snapshot=$GATE_MIN_RATIO_RANDOM_READ_PARALLEL_ACQUIRE_SNAPSHOT
 gate_max_cv_pct=$GATE_MAX_CV_PCT
+include_read_tests=$INCLUDE_READ_TESTS
+read_tests=$READ_TESTS
 run_prefix=$RUN_PREFIX
 cpuset=$CPUSET
 sleep_between_cases_sec=$SLEEP_BETWEEN_CASES_SEC
@@ -209,6 +239,9 @@ thresholds = {
     "batch_write": float(meta.get("gate_min_ratio_batch_write", "0.70")),
     "batch_write_steady": float(meta.get("gate_min_ratio_batch_write_steady", "0.70")),
     "prefix_scan": float(meta.get("gate_min_ratio_prefix_scan", "0.35")),
+    "random_read": float(meta.get("gate_min_ratio_random_read", "0.80")),
+    "random_read_parallel": float(meta.get("gate_min_ratio_random_read_parallel", "0.75")),
+    "random_read_parallel_acquire_snapshot": float(meta.get("gate_min_ratio_random_read_parallel_acquire_snapshot", "0.70")),
 }
 
 cases = []
@@ -223,6 +256,9 @@ display = {
     "batch_write": "Batch Write",
     "batch_write_steady": "Batch Write (Steady)",
     "prefix_scan": "Prefix Scan",
+    "random_read": "Random Read",
+    "random_read_parallel": "Random Read (Parallel)",
+    "random_read_parallel_acquire_snapshot": "Random Read (Parallel, Snapshot Per Key)",
 }
 
 pattern_cache = {}


### PR DESCRIPTION
Stack for issue #510. Adds direct append-path decode for outerleaf pointer reads before full block decode. Includes low-risk cache-preserving behavior for inline blocks + read-path benchmark updates for random_read workloads.