### PR TITLE
treedb: optimize bounded v2 fence seek for range scans

### DIFF
--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -152,6 +152,38 @@ func (r valueReader) decodeValueForKeyFound(ptr page.ValuePtr, key, raw []byte, 
 		// oversized entries.
 		return raw, true, nil
 	}
+	if len(key) > 0 {
+		entry, ok, found, _, decErr := outerleaf.DecodeEntryForKey(raw, key, nil)
+		if decErr != nil {
+			return nil, false, decErr
+		}
+		if !ok {
+			return nil, false, nil
+		}
+		if !found {
+			return nil, false, nil
+		}
+		if r.cache != nil && entry.Kind == outerleaf.EntryKindInline {
+			if block := outerleaf.DecodeSingleInlineBlock(raw, key, entry); block != nil {
+				r.cache.put(newOuterLeafBlockKey(ptr), block)
+				val, err := r.resolveLookupResult(entry, unsafe)
+				if err != nil {
+					return nil, false, err
+				}
+				return val, true, nil
+			}
+			// Preserve cache admission for non-single blocks in non-append paths so
+			// follow-up lookups reuse decoded metadata.
+			if _, err := r.outerLeafBlock(ptr, raw); err != nil {
+				return nil, false, err
+			}
+		}
+		val, err := r.resolveLookupResult(entry, unsafe)
+		if err != nil {
+			return nil, false, err
+		}
+		return val, true, nil
+	}
 	block, err := r.outerLeafBlock(ptr, raw)
 	if err != nil {
 		return nil, false, err
@@ -404,6 +436,62 @@ func (r valueReader) ReadUnsafeFenceBlockSeek(ptr page.ValuePtr, key []byte) (po
 	return lower, false, false, blockKeys, true, nil
 }
 
+func (r valueReader) ReadUnsafeFenceBlockSeekRange(ptr page.ValuePtr, key []byte, upper []byte) (pos int, below bool, above bool, keys [][]byte, ok bool, err error) {
+	if !r.fenceLookupModeEnabled() {
+		return 0, false, false, nil, false, nil
+	}
+	if len(key) > 0 && len(upper) > 0 && bytes.Compare(key, upper) >= 0 {
+		return 0, false, false, nil, true, nil
+	}
+	if cachedKeys := r.cachedOuterLeafKeys(ptr); cachedKeys != nil {
+		lower, isBelow, isAbove := classifyFenceKeys(cachedKeys, key)
+		if isBelow || isAbove {
+			return lower, isBelow, isAbove, nil, true, nil
+		}
+		ranged := sliceFenceKeysRange(cachedKeys, key, upper)
+		if len(ranged) == 0 {
+			return 0, false, false, nil, true, nil
+		}
+		return 0, false, false, ranged, true, nil
+	}
+	if block := r.cachedOuterLeafBlock(ptr); block != nil {
+		lower, isBelow, isAbove, lowerErr := block.LowerBound(key)
+		if lowerErr != nil {
+			return 0, false, false, nil, true, lowerErr
+		}
+		if isBelow || isAbove {
+			return lower, isBelow, isAbove, nil, true, nil
+		}
+		blockKeys, keyErr := block.KeysRange(nil, key, upper)
+		if keyErr != nil {
+			return 0, false, false, nil, true, keyErr
+		}
+		if len(blockKeys) == 0 {
+			return 0, false, false, nil, true, nil
+		}
+		return 0, false, false, blockKeys, true, nil
+	}
+
+	raw, readErr := r.readRawUnsafe(ptr)
+	if readErr != nil {
+		return 0, false, false, nil, true, readErr
+	}
+	if !outerleaf.HasMagic(raw) {
+		return 0, false, false, nil, false, nil
+	}
+	lower, isBelow, isAbove, blockKeys, decErr := outerleaf.DecodeLowerBoundAndKeysRangeOnMatchWithVerify(raw, key, upper, !r.skipOuterLeafChecksums)
+	if decErr != nil {
+		return 0, false, false, nil, true, decErr
+	}
+	if isBelow || isAbove {
+		return lower, isBelow, isAbove, nil, true, nil
+	}
+	if len(blockKeys) == 0 {
+		return 0, false, false, nil, true, nil
+	}
+	return 0, false, false, blockKeys, true, nil
+}
+
 func classifyFenceKeys(keys [][]byte, key []byte) (pos int, below bool, above bool) {
 	if len(keys) == 0 {
 		return 0, false, true
@@ -592,6 +680,12 @@ func (r valueReader) ReadUnsafeAppendForKey(ptr page.ValuePtr, key []byte, dst [
 			}
 			if r.cache == nil || entry.Kind == outerleaf.EntryKindBlobRef {
 				return r.resolveLookupResultAppend(entry, dst)
+			}
+			if key != nil {
+				if block := outerleaf.DecodeSingleInlineBlock(raw, key, entry); block != nil {
+					r.cache.put(newOuterLeafBlockKey(ptr), block)
+					return r.resolveLookupResultAppend(entry, dst)
+				}
 			}
 		}
 		raw = r.stableOuterLeafPayload(raw)

--- a/TreeDB/db/value_reader_bench_test.go
+++ b/TreeDB/db/value_reader_bench_test.go
@@ -157,3 +157,84 @@ func BenchmarkValueReaderReadUnsafeAppendBatchForKeys_RawReadsPerBatch(b *testin
 		b.Fatalf("raw read count = %d, want > 0 from batch reader path", reader.readUnsafeAppendCalls)
 	}
 }
+
+func BenchmarkValueReaderReadUnsafeForKey_CacheHitSkipsRawRead(b *testing.B) {
+	payload, ptr := makeBenchOuterLeafPayload(
+		b,
+		uint8(ValueLogBlockSnappy),
+		128,
+		[]outerleaf.Entry{
+			{Key: []byte("k1"), Value: []byte("v1")},
+			{Key: []byte("k2"), Value: []byte("v2")},
+			{Key: []byte("k3"), Value: []byte("v3")},
+		},
+	)
+	reader := &stubValueLogReader{
+		payloads: map[page.ValuePtr][]byte{ptr: payload},
+	}
+	cache := newOuterLeafBlockCache(8)
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+		cache:         cache,
+	}
+
+	key := []byte("k2")
+	dst := make([]byte, 0, 16)
+	if _, err := r.ReadUnsafeForKey(ptr, key); err != nil {
+		b.Fatalf("warmup: %v", err)
+	}
+	if _, misses, _, _ := cache.stats(); misses != 1 {
+		b.Fatalf("warmup misses = %d, want 1", misses)
+	}
+	reader.readUnsafeCalls = 0
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		val, err := r.ReadUnsafeForKey(ptr, key)
+		if err != nil {
+			b.Fatalf("read %d: %v", i, err)
+		}
+		dst = append(dst[:0], val...)
+	}
+	b.ReportMetric(float64(reader.readUnsafeCalls)/float64(b.N), "raw_reads/op")
+	if reader.readUnsafeCalls != 0 {
+		b.Fatalf("raw read count = %d, want 0 in warmed cache path", reader.readUnsafeCalls)
+	}
+}
+
+func BenchmarkValueReaderReadUnsafeForKey_NoCacheAlwaysReads(b *testing.B) {
+	payload, ptr := makeBenchOuterLeafPayload(
+		b,
+		uint8(ValueLogBlockSnappy),
+		256,
+		[]outerleaf.Entry{
+			{Key: []byte("k1"), Value: []byte("v1")},
+			{Key: []byte("k2"), Value: []byte("v2")},
+		},
+	)
+	reader := &stubValueLogReader{
+		payloads: map[page.ValuePtr][]byte{ptr: payload},
+	}
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+	}
+
+	key := []byte("k2")
+	dst := make([]byte, 0, 16)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		val, err := r.ReadUnsafeForKey(ptr, key)
+		if err != nil {
+			b.Fatalf("read %d: %v", i, err)
+		}
+		dst = append(dst[:0], val...)
+	}
+	b.ReportMetric(float64(reader.readUnsafeCalls)/float64(b.N), "raw_reads/op")
+	if reader.readUnsafeCalls != b.N {
+		b.Fatalf("raw read count = %d, want %d", reader.readUnsafeCalls, b.N)
+	}
+}

--- a/TreeDB/db/value_reader_test.go
+++ b/TreeDB/db/value_reader_test.go
@@ -151,6 +151,30 @@ func TestValueReaderReadUnsafeAppendForKey_CacheHitSkipsReadUnsafe(t *testing.T)
 	}
 }
 
+func TestValueReaderReadUnsafeForKey_CacheHitSkipsReadUnsafe(t *testing.T) {
+	payload, block, ptr := makeTestOuterLeafPayload(t)
+	reader := &stubValueLogReader{payloads: map[page.ValuePtr][]byte{ptr: payload}}
+	cache := newOuterLeafBlockCache(8)
+	cache.put(newOuterLeafBlockKey(ptr), block)
+
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+		cache:         cache,
+	}
+
+	got, err := r.ReadUnsafeForKey(ptr, []byte("k2"))
+	if err != nil {
+		t.Fatalf("ReadUnsafeForKey: %v", err)
+	}
+	if !bytes.Equal(got, []byte("v2")) {
+		t.Fatalf("value = %q, want %q", got, "v2")
+	}
+	if reader.readUnsafeCalls != 0 {
+		t.Fatalf("readUnsafeCalls = %d, want 0 (cache hit should bypass raw value-log read)", reader.readUnsafeCalls)
+	}
+}
+
 func TestValueReaderReadUnsafeAppendForKey_CacheWarmsAfterMiss(t *testing.T) {
 	payload, _, ptr := makeTestOuterLeafPayload(t)
 	reader := &stubValueLogReader{payloads: map[page.ValuePtr][]byte{ptr: payload}}
@@ -760,6 +784,56 @@ func TestValueReaderReadUnsafeFenceBlockSeek_ClassifiesBoundsAndReusesCache(t *t
 	}
 	if reader.readUnsafeCalls != 2 {
 		t.Fatalf("readUnsafeCalls after cache reuse = %d, want 2", reader.readUnsafeCalls)
+	}
+}
+
+func TestValueReaderReadUnsafeFenceBlockSeekRange_UsesBoundedWindowAndKeyCache(t *testing.T) {
+	payload, _, ptr := makeTestOuterLeafPayload(t)
+	reader := &stubValueLogReader{payloads: map[page.ValuePtr][]byte{ptr: payload}}
+	keyCache := newOuterLeafKeyCache(8)
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+		keyCache:      keyCache,
+	}
+
+	all, ok, err := r.ReadUnsafeFenceBlockKeys(ptr)
+	if err != nil {
+		t.Fatalf("ReadUnsafeFenceBlockKeys warm: %v", err)
+	}
+	if !ok || len(all) != 3 {
+		t.Fatalf("warm keys ok=%v len=%d, want ok=true len=3", ok, len(all))
+	}
+	if reader.readUnsafeCalls != 1 {
+		t.Fatalf("readUnsafeCalls after warm = %d, want 1", reader.readUnsafeCalls)
+	}
+
+	pos, below, above, keys, ok, err := r.ReadUnsafeFenceBlockSeekRange(ptr, []byte("k2"), []byte("k3"))
+	if err != nil {
+		t.Fatalf("ReadUnsafeFenceBlockSeekRange(k2,k3): %v", err)
+	}
+	if !ok {
+		t.Fatalf("ok=false, want true")
+	}
+	if pos != 0 || below || above || len(keys) != 1 || !bytes.Equal(keys[0], []byte("k2")) {
+		t.Fatalf("seekRange(k2,k3) got pos=%d below=%v above=%v keys=%q, want pos=0 below=false above=false keys=[k2]", pos, below, above, keys)
+	}
+	if reader.readUnsafeCalls != 1 {
+		t.Fatalf("readUnsafeCalls after key-cache seekRange = %d, want 1", reader.readUnsafeCalls)
+	}
+
+	pos, below, above, keys, ok, err = r.ReadUnsafeFenceBlockSeekRange(ptr, []byte("k9"), nil)
+	if err != nil {
+		t.Fatalf("ReadUnsafeFenceBlockSeekRange(k9,nil): %v", err)
+	}
+	if !ok {
+		t.Fatalf("ok=false, want true")
+	}
+	if pos != 3 || below || !above || keys != nil {
+		t.Fatalf("seekRange(k9,nil) got pos=%d below=%v above=%v keys=%v, want pos=3 below=false above=true keys=nil", pos, below, above, keys)
+	}
+	if reader.readUnsafeCalls != 1 {
+		t.Fatalf("readUnsafeCalls after above classification = %d, want 1", reader.readUnsafeCalls)
 	}
 }
 

--- a/TreeDB/internal/outerleaf/block.go
+++ b/TreeDB/internal/outerleaf/block.go
@@ -1416,6 +1416,45 @@ func DecodeBlockWithVerify(payload []byte, scratch []byte, verifyChecksum bool) 
 	return decodeBlock(payload, scratch, verifyChecksum)
 }
 
+// DecodeSingleInlineBlock creates a cached decoded-block view for single-entry
+// inline outer-leaf payloads.
+//
+// It returns nil when the payload is not a single-entry inline outer-leaf block.
+func DecodeSingleInlineBlock(raw []byte, lookupKey []byte, entry LookupResult) *DecodedBlock {
+	if len(lookupKey) == 0 {
+		return nil
+	}
+	if entry.Kind != EntryKindInline {
+		return nil
+	}
+	if !HasMagic(raw) {
+		return nil
+	}
+	if len(raw) < blockHeaderSize {
+		return nil
+	}
+	version := raw[4]
+	switch version {
+	case blockVersionV1:
+	case blockVersionV2, blockVersionV3:
+		if binary.LittleEndian.Uint16(raw[blockV2EntryCountOff:blockV2EntryCountOff+2]) != 1 {
+			return nil
+		}
+	default:
+		return nil
+	}
+
+	block := &DecodedBlock{
+		version:    version,
+		entryCount: 1,
+		firstKey:   append([]byte(nil), lookupKey...),
+		firstKind:  entry.Kind,
+		firstValue: append([]byte(nil), entry.Value...),
+		firstBlob:  entry.BlobPtr,
+	}
+	return block
+}
+
 func decodeBlock(payload []byte, scratch []byte, verifyChecksum bool) (*DecodedBlock, error) {
 	if len(payload) < blockHeaderSize {
 		return nil, fmt.Errorf("outerleaf: truncated header")
@@ -2074,8 +2113,16 @@ func lowerBoundStructured(version uint8, entryCount int, encoded []byte, target 
 	if estKeyLen < 64 {
 		estKeyLen = 64
 	}
-	prev := make([]byte, 0, estKeyLen)
-	curr := make([]byte, 0, estKeyLen)
+	var prevStack [128]byte
+	var currStack [128]byte
+	prev := prevStack[:0]
+	curr := currStack[:0]
+	if estKeyLen > cap(prev) {
+		prev = make([]byte, 0, estKeyLen)
+	}
+	if estKeyLen > cap(curr) {
+		curr = make([]byte, 0, estKeyLen)
+	}
 	for i := 0; i < entryCount; i++ {
 		if off+headerLen > len(encoded) {
 			return 0, false, false, fmt.Errorf("outerleaf: truncated v%d entry header", version)
@@ -2130,6 +2177,128 @@ func lowerBoundStructured(version uint8, entryCount int, encoded []byte, target 
 	}
 	if off != len(encoded) {
 		return 0, false, false, fmt.Errorf("outerleaf: trailing v%d entry bytes", version)
+	}
+	return entryCount, false, true, nil
+}
+
+func lowerBoundStructuredWithRestarts(version uint8, entryCount int, encoded []byte, restartRaw []byte, restartCount int, restartInterval int, target []byte) (pos int, below bool, above bool, err error) {
+	if len(target) == 0 {
+		return 0, false, false, nil
+	}
+	if restartCount <= 0 || restartInterval <= 1 {
+		return lowerBoundStructured(version, entryCount, encoded, target)
+	}
+	restarts, err := decodeRestartsFromRaw(encoded, restartRaw, restartCount)
+	if err != nil {
+		return 0, false, false, err
+	}
+	if len(restarts) == 0 {
+		return lowerBoundStructured(version, entryCount, encoded, target)
+	}
+
+	restartIdx := -1
+	switch version {
+	case blockVersionV2:
+		restartIdx, err = locateV2Restart(encoded, target, restarts, nil)
+	case blockVersionV3:
+		restartIdx, err = locateV3Restart(encoded, target, restarts, nil)
+	default:
+		return lowerBoundStructured(version, entryCount, encoded, target)
+	}
+	if err != nil {
+		return 0, false, false, err
+	}
+	if restartIdx < 0 {
+		return 0, true, false, nil
+	}
+
+	start := int(restarts[restartIdx])
+	limit := len(encoded)
+	if restartIdx+1 < len(restarts) {
+		limit = int(restarts[restartIdx+1])
+	}
+	if start < 0 || start > len(encoded) || limit < start || limit > len(encoded) {
+		return 0, false, false, fmt.Errorf("outerleaf: invalid restart range")
+	}
+
+	headerLen := 8
+	valueLenOffDelta := 4
+	if version == blockVersionV3 {
+		headerLen = 9
+		valueLenOffDelta = 5
+	}
+
+	posBase := restartIdx * restartInterval
+	if posBase < 0 {
+		posBase = 0
+	}
+	if posBase > entryCount {
+		posBase = entryCount
+	}
+
+	off := start
+	pos = posBase
+	var prevStack [128]byte
+	var currStack [128]byte
+	prev := prevStack[:0]
+	curr := currStack[:0]
+	for off < limit && pos < entryCount {
+		if off+headerLen > limit {
+			return 0, false, false, fmt.Errorf("outerleaf: truncated v%d entry header", version)
+		}
+		shared := int(binary.LittleEndian.Uint16(encoded[off : off+2]))
+		suffixLen := int(binary.LittleEndian.Uint16(encoded[off+2 : off+4]))
+		valueLen := int(binary.LittleEndian.Uint32(encoded[off+valueLenOffDelta : off+valueLenOffDelta+4]))
+		off += headerLen
+		if shared < 0 || shared > len(prev) {
+			return 0, false, false, fmt.Errorf("outerleaf: invalid shared prefix")
+		}
+		if suffixLen < 0 || off+suffixLen > limit {
+			return 0, false, false, fmt.Errorf("outerleaf: invalid key suffix length")
+		}
+		suffix := encoded[off : off+suffixLen]
+		off += suffixLen
+		if valueLen < 0 || off+valueLen > limit {
+			return 0, false, false, fmt.Errorf("outerleaf: invalid value length")
+		}
+		keyLen := shared + suffixLen
+		if keyLen < 0 {
+			return 0, false, false, fmt.Errorf("outerleaf: invalid key length")
+		}
+		if cap(curr) < keyLen {
+			newCap := cap(curr) * 2
+			if newCap < keyLen {
+				newCap = keyLen
+			}
+			if newCap < 64 {
+				newCap = 64
+			}
+			curr = make([]byte, keyLen, newCap)
+		} else {
+			curr = curr[:keyLen]
+		}
+		if shared > 0 {
+			copy(curr[:shared], prev[:shared])
+		}
+		copy(curr[shared:], suffix)
+
+		if bytes.Compare(curr, target) >= 0 {
+			return pos, false, false, nil
+		}
+
+		off += valueLen
+		pos++
+		prev, curr = curr, prev[:0]
+	}
+	if off != limit {
+		return 0, false, false, fmt.Errorf("outerleaf: trailing v%d entry bytes", version)
+	}
+	if restartIdx+1 < len(restarts) {
+		nextPos := (restartIdx + 1) * restartInterval
+		if nextPos > entryCount {
+			nextPos = entryCount
+		}
+		return nextPos, false, false, nil
 	}
 	return entryCount, false, true, nil
 }
@@ -2548,11 +2717,11 @@ func DecodeLowerBoundAndKeysOnMatchWithVerify(payload []byte, target []byte, ver
 		if err != nil {
 			return 0, false, false, nil, err
 		}
-		entries, _, _, splitErr := splitV2RawMeta(raw, entriesLen, entryCount, restartInterval)
+		entries, restartRaw, restartCount, splitErr := splitV2RawMeta(raw, entriesLen, entryCount, restartInterval)
 		if splitErr != nil {
 			return 0, false, false, nil, splitErr
 		}
-		pos, below, above, err = lowerBoundStructured(version, entryCount, entries, target)
+		pos, below, above, err = lowerBoundStructuredWithRestarts(version, entryCount, entries, restartRaw, restartCount, restartInterval, target)
 		if err != nil {
 			return 0, false, false, nil, err
 		}
@@ -2564,6 +2733,99 @@ func DecodeLowerBoundAndKeysOnMatchWithVerify(payload []byte, target []byte, ver
 			return 0, false, false, nil, err
 		}
 		return pos, false, false, keys, nil
+	default:
+		return 0, false, false, nil, fmt.Errorf("outerleaf: unsupported version %d", version)
+	}
+}
+
+// DecodeLowerBoundAndKeysRangeOnMatchWithVerify classifies target against block
+// bounds and, on in-range matches, returns only keys in [target, upper).
+//
+// For in-range matches, returned pos is relative to returned keys (always 0).
+// For below/above classifications, pos matches the logical lower-bound index in
+// the full block key set and keys is nil.
+func DecodeLowerBoundAndKeysRangeOnMatchWithVerify(payload []byte, target []byte, upper []byte, verifyChecksum bool) (pos int, below bool, above bool, keys [][]byte, err error) {
+	if len(payload) < blockHeaderSize {
+		return 0, false, false, nil, fmt.Errorf("outerleaf: truncated header")
+	}
+	if payload[0] != blockMagic[0] || payload[1] != blockMagic[1] || payload[2] != blockMagic[2] || payload[3] != blockMagic[3] {
+		return 0, false, false, nil, fmt.Errorf("outerleaf: invalid outer-leaf payload")
+	}
+
+	version := payload[4]
+	codec := payload[5]
+	switch version {
+	case blockVersionV1:
+		keyLen := int(binary.LittleEndian.Uint16(payload[blockV1KeyLenOff : blockV1KeyLenOff+2]))
+		valueLen := int(binary.LittleEndian.Uint32(payload[blockV1ValueLenOff : blockV1ValueLenOff+4]))
+		rawLen := int(binary.LittleEndian.Uint32(payload[blockV1RawLenOff : blockV1RawLenOff+4]))
+		expected := keyLen + valueLen
+		if rawLen != expected {
+			return 0, false, false, nil, fmt.Errorf("outerleaf: invalid raw length %d want %d", rawLen, expected)
+		}
+		raw, decErr := decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
+		if decErr != nil {
+			return 0, false, false, nil, decErr
+		}
+		if keyLen < 0 || keyLen > len(raw) {
+			return 0, false, false, nil, fmt.Errorf("outerleaf: invalid key length %d", keyLen)
+		}
+		key := raw[:keyLen]
+		if len(target) > 0 {
+			cmp := bytes.Compare(key, target)
+			if cmp > 0 {
+				return 0, true, false, nil, nil
+			}
+			if cmp < 0 {
+				return 1, false, true, nil, nil
+			}
+		}
+		if len(upper) > 0 && bytes.Compare(key, upper) >= 0 {
+			return 0, false, false, nil, nil
+		}
+		keyCopy := append(make([]byte, 0, len(key)), key...)
+		return 0, false, false, [][]byte{keyCopy}, nil
+	case blockVersionV2, blockVersionV3:
+		entryCount := int(binary.LittleEndian.Uint16(payload[blockV2EntryCountOff : blockV2EntryCountOff+2]))
+		entriesLen := int(binary.LittleEndian.Uint32(payload[blockV2EntriesLenOff : blockV2EntriesLenOff+4]))
+		rawLen := int(binary.LittleEndian.Uint32(payload[blockV2RawLenOff : blockV2RawLenOff+4]))
+		if entryCount <= 0 {
+			return 0, false, false, nil, fmt.Errorf("outerleaf: empty v%d block", version)
+		}
+		if rawLen <= 0 {
+			return 0, false, false, nil, fmt.Errorf("outerleaf: invalid raw length %d", rawLen)
+		}
+		restartInterval := int(binary.LittleEndian.Uint16(payload[6:8]))
+		var raw []byte
+		if codec == blockCodecNone {
+			raw, err = decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
+		} else {
+			scratch := getPooledBytes(rawLen)
+			defer putPooledBytes(scratch)
+			raw, err = decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, scratch[:0], true, verifyChecksum)
+		}
+		if err != nil {
+			return 0, false, false, nil, err
+		}
+		entries, restartRaw, restartCount, splitErr := splitV2RawMeta(raw, entriesLen, entryCount, restartInterval)
+		if splitErr != nil {
+			return 0, false, false, nil, splitErr
+		}
+		pos, below, above, err = lowerBoundStructuredWithRestarts(version, entryCount, entries, restartRaw, restartCount, restartInterval, target)
+		if err != nil {
+			return 0, false, false, nil, err
+		}
+		if below || above {
+			return pos, below, above, nil, nil
+		}
+		keys, err = decodeStructuredKeysBounded(version, entryCount, entries, target, upper)
+		if err != nil {
+			return 0, false, false, nil, err
+		}
+		if len(keys) == 0 {
+			return 0, false, false, nil, nil
+		}
+		return 0, false, false, keys, nil
 	default:
 		return 0, false, false, nil, fmt.Errorf("outerleaf: unsupported version %d", version)
 	}

--- a/TreeDB/internal/outerleaf/block_test.go
+++ b/TreeDB/internal/outerleaf/block_test.go
@@ -78,6 +78,190 @@ func TestHasMagic(t *testing.T) {
 	}
 }
 
+func TestDecodeSingleInlineBlock(t *testing.T) {
+	raw, err := EncodeSingle(nil, []byte("k"), []byte("v"), 0, 16)
+	if err != nil {
+		t.Fatalf("EncodeSingle: %v", err)
+	}
+	entry, ok, found, _, err := DecodeEntryForKey(raw, []byte("k"), nil)
+	if err != nil {
+		t.Fatalf("DecodeEntryForKey: %v", err)
+	}
+	if !ok || !found {
+		t.Fatalf("lookup for k: ok=%v found=%v", ok, found)
+	}
+	if entry.Kind != EntryKindInline {
+		t.Fatalf("entry kind=%d want=%d", entry.Kind, EntryKindInline)
+	}
+
+	block := DecodeSingleInlineBlock(raw, []byte("k"), entry)
+	if block == nil {
+		t.Fatalf("DecodeSingleInlineBlock: expected non-nil")
+	}
+	got, ok, err := block.EntryForKey([]byte("k"))
+	if err != nil {
+		t.Fatalf("EntryForKey: %v", err)
+	}
+	if !ok || !bytes.Equal(got.Value, []byte("v")) {
+		t.Fatalf("EntryForKey: value=%q want=%q", got.Value, []byte("v"))
+	}
+}
+
+func TestDecodeSingleInlineBlockCopiesInputs(t *testing.T) {
+	key := []byte("k")
+	value := []byte("v")
+	raw, err := EncodeSingle(nil, key, value, 0, 16)
+	if err != nil {
+		t.Fatalf("EncodeSingle: %v", err)
+	}
+	entry, ok, found, _, err := DecodeEntryForKey(raw, key, nil)
+	if err != nil {
+		t.Fatalf("DecodeEntryForKey: %v", err)
+	}
+	if !ok || !found {
+		t.Fatalf("lookup for k: ok=%v found=%v", ok, found)
+	}
+
+	block := DecodeSingleInlineBlock(raw, key, entry)
+	if block == nil {
+		t.Fatalf("DecodeSingleInlineBlock: expected non-nil")
+	}
+
+	key[0] = 'z'
+	entry.Value[0] = 'x'
+
+	got, ok, err := block.EntryForKey([]byte("k"))
+	if err != nil {
+		t.Fatalf("EntryForKey: %v", err)
+	}
+	if !ok || !bytes.Equal(got.Value, []byte("v")) {
+		t.Fatalf("EntryForKey after input mutation: value=%q want=%q", got.Value, []byte("v"))
+	}
+}
+
+func TestDecodeSingleInlineBlockRejectsNonCacheableEntry(t *testing.T) {
+	blobPtr := page.ValuePtr{FileID: page.ValueLogFileID(3), Offset: 7, Length: 9}
+	raw, err := EncodeSingleBlobRef(nil, []byte("k"), blobPtr, 0, 16)
+	if err != nil {
+		t.Fatalf("EncodeSingleBlobRef: %v", err)
+	}
+	entry, ok, found, _, err := DecodeEntryForKey(raw, []byte("k"), nil)
+	if err != nil {
+		t.Fatalf("DecodeEntryForKey: %v", err)
+	}
+	if !ok || !found {
+		t.Fatalf("blobref lookup for k: ok=%v found=%v", ok, found)
+	}
+	if DecodeSingleInlineBlock(raw, []byte("k"), entry) != nil {
+		t.Fatalf("expected nil block for blobref entry")
+	}
+
+	raw2, err := EncodeEntries(nil, []Entry{
+		{Key: []byte("k1"), Value: []byte("v1")},
+		{Key: []byte("k2"), Value: []byte("v2")},
+	}, 0, 16)
+	if err != nil {
+		t.Fatalf("EncodeEntries: %v", err)
+	}
+	entry2, ok, found, _, err := DecodeEntryForKey(raw2, []byte("k1"), nil)
+	if err != nil {
+		t.Fatalf("DecodeEntryForKey: %v", err)
+	}
+	if !ok || !found {
+		t.Fatalf("lookup for k1: ok=%v found=%v", ok, found)
+	}
+	if DecodeSingleInlineBlock(raw2, []byte("k1"), entry2) != nil {
+		t.Fatalf("expected nil block for multi-entry payload")
+	}
+}
+
+func TestDecodeLowerBoundAndKeysRangeOnMatchWithVerify(t *testing.T) {
+	raw, err := EncodeEntries(nil, []Entry{
+		{Key: []byte("k1"), Value: []byte("v1")},
+		{Key: []byte("k2"), Value: []byte("v2")},
+		{Key: []byte("k3"), Value: []byte("v3")},
+	}, 0, 16)
+	if err != nil {
+		t.Fatalf("EncodeEntries: %v", err)
+	}
+
+	pos, below, above, keys, err := DecodeLowerBoundAndKeysRangeOnMatchWithVerify(raw, []byte("k0"), []byte("k3"), true)
+	if err != nil {
+		t.Fatalf("DecodeLowerBoundAndKeysRangeOnMatchWithVerify(k0): %v", err)
+	}
+	if pos != 0 || !below || above || keys != nil {
+		t.Fatalf("k0: got pos=%d below=%v above=%v keys=%v, want pos=0 below=true above=false keys=nil", pos, below, above, keys)
+	}
+
+	pos, below, above, keys, err = DecodeLowerBoundAndKeysRangeOnMatchWithVerify(raw, []byte("k2"), []byte("k3"), true)
+	if err != nil {
+		t.Fatalf("DecodeLowerBoundAndKeysRangeOnMatchWithVerify(k2,k3): %v", err)
+	}
+	if pos != 0 || below || above {
+		t.Fatalf("k2,k3: got pos=%d below=%v above=%v, want pos=0 below=false above=false", pos, below, above)
+	}
+	if len(keys) != 1 || !bytes.Equal(keys[0], []byte("k2")) {
+		t.Fatalf("k2,k3: keys=%q want=[k2]", keys)
+	}
+
+	pos, below, above, keys, err = DecodeLowerBoundAndKeysRangeOnMatchWithVerify(raw, []byte("k2"), nil, true)
+	if err != nil {
+		t.Fatalf("DecodeLowerBoundAndKeysRangeOnMatchWithVerify(k2,nil): %v", err)
+	}
+	if pos != 0 || below || above {
+		t.Fatalf("k2,nil: got pos=%d below=%v above=%v, want pos=0 below=false above=false", pos, below, above)
+	}
+	if len(keys) != 2 || !bytes.Equal(keys[0], []byte("k2")) || !bytes.Equal(keys[1], []byte("k3")) {
+		t.Fatalf("k2,nil: keys=%q want=[k2 k3]", keys)
+	}
+
+	pos, below, above, keys, err = DecodeLowerBoundAndKeysRangeOnMatchWithVerify(raw, []byte("k9"), nil, true)
+	if err != nil {
+		t.Fatalf("DecodeLowerBoundAndKeysRangeOnMatchWithVerify(k9): %v", err)
+	}
+	if pos != 3 || below || !above || keys != nil {
+		t.Fatalf("k9: got pos=%d below=%v above=%v keys=%v, want pos=3 below=false above=true keys=nil", pos, below, above, keys)
+	}
+}
+
+func TestLowerBoundStructuredWithRestarts_MatchesLinear(t *testing.T) {
+	entries := make([]Entry, 0, 128)
+	for i := 0; i < 128; i++ {
+		k := fmt.Sprintf("k%03d", i*2)
+		entries = append(entries, Entry{Key: []byte(k), Value: []byte("v")})
+	}
+	raw, err := EncodeEntries(nil, entries, 0, 16)
+	if err != nil {
+		t.Fatalf("EncodeEntries: %v", err)
+	}
+	block, err := DecodeBlockWithVerify(raw, nil, true)
+	if err != nil {
+		t.Fatalf("DecodeBlockWithVerify: %v", err)
+	}
+
+	targets := [][]byte{
+		[]byte("k000"),
+		[]byte("k001"),
+		[]byte("k010"),
+		[]byte("k111"),
+		[]byte("k254"),
+		[]byte("k999"),
+	}
+	for _, target := range targets {
+		wantPos, wantBelow, wantAbove, wantErr := lowerBoundStructured(block.version, block.entryCount, block.entries, target)
+		gotPos, gotBelow, gotAbove, gotErr := lowerBoundStructuredWithRestarts(block.version, block.entryCount, block.entries, block.restartRaw, block.restartCount, 16, target)
+		if (wantErr == nil) != (gotErr == nil) {
+			t.Fatalf("target=%q err mismatch linear=%v restart=%v", target, wantErr, gotErr)
+		}
+		if wantErr != nil {
+			continue
+		}
+		if gotPos != wantPos || gotBelow != wantBelow || gotAbove != wantAbove {
+			t.Fatalf("target=%q got pos=%d below=%v above=%v want pos=%d below=%v above=%v", target, gotPos, gotBelow, gotAbove, wantPos, wantBelow, wantAbove)
+		}
+	}
+}
+
 func TestEncodeSingleCodecHeaderMapping(t *testing.T) {
 	key := []byte("user:codec")
 	value := bytes.Repeat([]byte("v"), 256)

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -330,6 +330,7 @@ type Iterator struct {
 	slabFenceKeys   slabUnsafeFenceBlockKeyReader
 	slabFenceRange  slabUnsafeFenceBlockRangeKeyReader
 	slabFenceSeek   slabUnsafeFenceBlockSeekReader
+	slabFenceSeekR  slabUnsafeFenceBlockSeekRangeReader
 	slabFencePtrCls slabFencePointerClassifier
 	slabKeyAppender slabUnsafeKeyAppender
 	slabKeyBatcher  slabUnsafeKeyBatchAppender
@@ -399,6 +400,7 @@ func (t *Tree) IteratorWithOptions(start, end []byte, opts IteratorOptions) iter
 	it.slabFenceKeys = t.slabFenceKeys
 	it.slabFenceRange = t.slabFenceRange
 	it.slabFenceSeek = t.slabFenceSeek
+	it.slabFenceSeekR = t.slabFenceSeekR
 	it.slabFencePtrCls = t.slabFencePtrCls
 	it.slabKeyAppender = t.slabKeyAppender
 	it.slabKeyBatcher = t.slabKeyBatcher
@@ -437,6 +439,7 @@ func (t *Tree) ReverseIteratorWithOptions(start, end []byte, opts IteratorOption
 	it.slabFenceKeys = t.slabFenceKeys
 	it.slabFenceRange = t.slabFenceRange
 	it.slabFenceSeek = t.slabFenceSeek
+	it.slabFenceSeekR = t.slabFenceSeekR
 	it.slabFencePtrCls = t.slabFencePtrCls
 	it.slabKeyAppender = t.slabKeyAppender
 	it.slabKeyBatcher = t.slabKeyBatcher
@@ -716,6 +719,7 @@ func (it *Iterator) tryRepositionPendingFence(top *CursorItem) (bool, error) {
 	}
 	seekKey := it.pendingSeekKey
 	preferFenceEntries := it.slabFenceBlocks != nil && (it.slabFenceKeys == nil || !it.shouldPreferFenceKeyOnly())
+	preferKeyOnlyExpansion := !preferFenceEntries
 	for scan := top.Index - 1; scan >= 0; scan-- {
 		_, ptr, flags, err := top.Node.GetLeafValueView(uint16(scan))
 		if err != nil {
@@ -728,6 +732,38 @@ func (it *Iterator) tryRepositionPendingFence(top *CursorItem) (bool, error) {
 			continue
 		}
 		keyReaderUsable := false
+		if preferKeyOnlyExpansion && it.end != nil && it.slabFenceSeekR != nil {
+			pos, below, above, seekKeys, ok, err := it.slabFenceSeekR.ReadUnsafeFenceBlockSeekRange(ptr, seekKey, it.end)
+			if err != nil {
+				return false, err
+			}
+			if ok {
+				keyReaderUsable = true
+				if above {
+					break
+				}
+				if below {
+					continue
+				}
+				if pos >= 0 && pos < len(seekKeys) {
+					top.Index = scan
+					it.pendingFencePageID = top.PageID
+					it.pendingFenceLeafIndex = scan
+					it.pendingFenceEntryIdx = pos
+					it.pendingFenceReady = true
+					it.pendingFenceKeys = seekKeys
+					// We already selected the predecessor block that contains seekKey.
+					// Clearing pendingSeekKey avoids a redundant predecessor rescan on
+					// the next loadCurrent loop iteration.
+					it.pendingSeekKey = it.pendingSeekKey[:0]
+					return true, nil
+				}
+				if len(seekKeys) == 0 {
+					continue
+				}
+				break
+			}
+		}
 		if it.slabFenceSeek != nil {
 			pos, below, above, seekKeys, ok, err := it.slabFenceSeek.ReadUnsafeFenceBlockSeek(ptr, seekKey)
 			if err != nil {

--- a/TreeDB/tree/iterator_test.go
+++ b/TreeDB/tree/iterator_test.go
@@ -28,6 +28,13 @@ type fenceLookupReaderRangeAware struct {
 	lastUpper  []byte
 }
 
+type fenceLookupReaderSeekRangeAware struct {
+	*fenceLookupReader
+	seekRangeCalls int
+	lastSeek       []byte
+	lastUpper      []byte
+}
+
 func (r *fenceLookupReaderKeysUnavailable) ReadUnsafeFenceBlockKeys(ptr page.ValuePtr) ([][]byte, bool, error) {
 	r.keyCalls++
 	return nil, false, nil
@@ -53,6 +60,39 @@ func (r *fenceLookupReaderRangeAware) ReadUnsafeFenceBlockKeysRange(ptr page.Val
 		return nil, true, nil
 	}
 	return keys[start:end], true, nil
+}
+
+func (r *fenceLookupReaderSeekRangeAware) ReadUnsafeFenceBlockSeekRange(ptr page.ValuePtr, key []byte, upper []byte) (pos int, below bool, above bool, keys [][]byte, ok bool, err error) {
+	r.seekRangeCalls++
+	r.lastSeek = append(r.lastSeek[:0], key...)
+	r.lastUpper = append(r.lastUpper[:0], upper...)
+	all, ok, err := r.fenceLookupReader.ReadUnsafeFenceBlockKeys(ptr)
+	if err != nil || !ok || len(all) == 0 {
+		return 0, false, true, nil, ok, err
+	}
+	if len(key) == 0 {
+		pos = 0
+	} else {
+		pos = lowerBoundFenceKeys(all, key)
+		if pos == 0 && compareTreeKey(key, all[0]) < 0 {
+			return 0, true, false, nil, true, nil
+		}
+		if pos >= len(all) {
+			return len(all), false, true, nil, true, nil
+		}
+	}
+	if below || above {
+		return pos, below, above, nil, true, nil
+	}
+	start := pos
+	end := len(all)
+	if len(upper) > 0 {
+		end = lowerBoundFenceKeys(all, upper)
+	}
+	if end <= start {
+		return 0, false, false, nil, true, nil
+	}
+	return 0, false, false, all[start:end], true, nil
 }
 
 func newCountingValueReader() *countingValueReader {
@@ -938,6 +978,76 @@ func TestIterator_FencePointerRangeSeek_ReusesPredecessorKeyExpansion(t *testing
 	}
 	if reader.keyCalls != 1 {
 		t.Fatalf("expected predecessor seek to reuse key expansion (keyCalls=1), got %d", reader.keyCalls)
+	}
+}
+
+func TestIterator_FencePointerRangeSeek_UsesBoundedSeekRangeReader(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	if _, err := p.Alloc(1); err != nil {
+		t.Fatalf("Alloc root: %v", err)
+	}
+
+	base := newFenceLookupReader()
+	reader := &fenceLookupReaderSeekRangeAware{fenceLookupReader: base}
+	ptr0 := reader.addBlock(map[string]string{
+		"f010": "v10",
+		"f020": "v20",
+		"f030": "v30",
+	})
+	ptr1 := reader.addBlock(map[string]string{
+		"f100": "v100",
+		"f110": "v110",
+	})
+
+	rootData, err := p.Get(0)
+	if err != nil {
+		t.Fatalf("Get root page: %v", err)
+	}
+	root := node.NewNode(rootData)
+	root.SetType(page.PageTypeLeaf)
+	root.SetPageID(0)
+	if err := root.AddLeafEntry([]byte("f010"), nil, node.FlagPointer, ptr0); err != nil {
+		t.Fatalf("AddLeafEntry(f010): %v", err)
+	}
+	if err := root.AddLeafEntry([]byte("f100"), nil, node.FlagPointer, ptr1); err != nil {
+		t.Fatalf("AddLeafEntry(f100): %v", err)
+	}
+	root.UpdateChecksum()
+
+	tr := New(p, reader, 0)
+	it := tr.Iterator([]byte("f025"), []byte("f040"))
+	defer it.Close()
+
+	var got []string
+	for ; it.Valid(); it.Next() {
+		got = append(got, string(it.Key()))
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	want := []string{"f030"}
+	if len(got) != len(want) {
+		t.Fatalf("keys len=%d want=%d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("key[%d]=%q want=%q", i, got[i], want[i])
+		}
+	}
+	if reader.seekRangeCalls == 0 {
+		t.Fatalf("expected bounded seek-range reader to be used")
+	}
+	if !bytes.Equal(reader.lastSeek, []byte("f025")) {
+		t.Fatalf("seek key=%q want=%q", reader.lastSeek, []byte("f025"))
+	}
+	if !bytes.Equal(reader.lastUpper, []byte("f040")) {
+		t.Fatalf("seek upper=%q want=%q", reader.lastUpper, []byte("f040"))
 	}
 }
 

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -95,6 +95,13 @@ type slabUnsafeFenceBlockSeekReader interface {
 	ReadUnsafeFenceBlockSeek(ptr page.ValuePtr, key []byte) (pos int, below bool, above bool, keys [][]byte, ok bool, err error)
 }
 
+// Optional bounded seek-oriented fence reader. Implementations may classify a
+// predecessor seek probe and materialize only keys in [key, upper), which is
+// useful for bounded forward range scans.
+type slabUnsafeFenceBlockSeekRangeReader interface {
+	ReadUnsafeFenceBlockSeekRange(ptr page.ValuePtr, key []byte, upper []byte) (pos int, below bool, above bool, keys [][]byte, ok bool, err error)
+}
+
 // Optional fast classifier for whether a pointer is expected to reference a
 // fence-expandable outer-leaf block.
 type slabFencePointerClassifier interface {
@@ -141,6 +148,7 @@ type Tree struct {
 	slabFenceKeys   slabUnsafeFenceBlockKeyReader
 	slabFenceRange  slabUnsafeFenceBlockRangeKeyReader
 	slabFenceSeek   slabUnsafeFenceBlockSeekReader
+	slabFenceSeekR  slabUnsafeFenceBlockSeekRangeReader
 	slabFencePtrCls slabFencePointerClassifier
 	slabKeyAppender slabUnsafeKeyAppender
 	slabKeyBatcher  slabUnsafeKeyBatchAppender
@@ -184,6 +192,9 @@ func New(p *pager.Pager, sr SlabReader, root uint64) *Tree {
 		}
 		if fenceSeek, ok := sr.(slabUnsafeFenceBlockSeekReader); ok {
 			t.slabFenceSeek = fenceSeek
+		}
+		if fenceSeekRange, ok := sr.(slabUnsafeFenceBlockSeekRangeReader); ok {
+			t.slabFenceSeekR = fenceSeekRange
 		}
 		if cls, ok := sr.(slabFencePointerClassifier); ok {
 			t.slabFencePtrCls = cls
@@ -251,6 +262,11 @@ func (t *Tree) Reset(p *pager.Pager, sr SlabReader, root uint64) {
 		} else {
 			t.slabFenceSeek = nil
 		}
+		if fenceSeekRange, ok := sr.(slabUnsafeFenceBlockSeekRangeReader); ok {
+			t.slabFenceSeekR = fenceSeekRange
+		} else {
+			t.slabFenceSeekR = nil
+		}
 		if cls, ok := sr.(slabFencePointerClassifier); ok {
 			t.slabFencePtrCls = cls
 		} else {
@@ -262,6 +278,7 @@ func (t *Tree) Reset(p *pager.Pager, sr SlabReader, root uint64) {
 		t.slabFenceKeys = nil
 		t.slabFenceRange = nil
 		t.slabFenceSeek = nil
+		t.slabFenceSeekR = nil
 		t.slabFencePtrCls = nil
 	}
 	t.fenceLookupMode = fenceEnabled && t.slabFenceReader != nil


### PR DESCRIPTION
## Summary
- add a bounded fence seek-range capability for iterators in forward bounded scans
- implement `ReadUnsafeFenceBlockSeekRange` in valueReader and wire iterator predecessor-seek to prefer it
- add `DecodeLowerBoundAndKeysRangeOnMatchWithVerify` and restart-aware lower-bound path for v2/v3 outerleaf decode
- extend tests for outerleaf decode, valueReader bounded seek-range behavior, and iterator integration

## Why
`-test all` with `-treedb-force-value-pointers=false` shows a persistent v2 prefix-scan gap vs v1. This change reduces extra key materialization work in bounded seek paths and improves lower-bound lookup efficiency in v2 fence blocks.

## Validation
- `go test ./... -count=1`
- `KEYS=500000 RUNS=1 WARMUP_RUNS=0 INCLUDE_READ_TESTS=1 PROFILES=fast,wal_on_fast GATE_PROFILES=fast,wal_on_fast STRICT_GATE=0 ./scripts/outerleaf_v2_perf_gate.sh`
- median perf compare (3 runs each, baseline `0721f9c` vs candidate) at `-test all`, `keys=500000`, `force-value-pointers=false`:
  - `fast` Prefix Scan ratio (v2/v1): `0.579 -> 0.602` (+4.10%)
  - `wal_on_fast` Prefix Scan ratio (v2/v1): `0.573 -> 0.646` (+12.84%)

Artifacts:
- `/Users/michaelseiler/dev/snissn/gomap/artifacts/perf/testall_median_compare_20260216164448`
- `/Users/michaelseiler/dev/snissn/gomap/artifacts/perf/outerleaf_v2_gate_20260216164912`
