### PR TITLE
outerleaf: reduce bounded key decode alloc churn

### DIFF
--- a/TreeDB/internal/outerleaf/block.go
+++ b/TreeDB/internal/outerleaf/block.go
@@ -2430,8 +2430,10 @@ func decodeStructuredKeysBounded(version uint8, entryCount int, encoded []byte, 
 		estCap = 64
 	}
 	keyArena := make([]byte, 0, estCap)
-	prev := make([]byte, 0, estKeyLen)
-	curr := make([]byte, 0, estKeyLen)
+	var prevStack [128]byte
+	var currStack [128]byte
+	prev := prevStack[:0]
+	curr := currStack[:0]
 	for i := 0; i < entryCount; i++ {
 		if off+headerLen > len(encoded) {
 			return nil, fmt.Errorf("outerleaf: truncated v%d entry header", version)

--- a/TreeDB/internal/outerleaf/block_test.go
+++ b/TreeDB/internal/outerleaf/block_test.go
@@ -989,3 +989,39 @@ func BenchmarkDecodedBlockValueForKeyV2(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkDecodeStructuredKeysBoundedV2Range(b *testing.B) {
+	entries := make([]Entry, 0, 256)
+	for i := 0; i < 256; i++ {
+		entries = append(entries, Entry{
+			Key:   []byte(fmt.Sprintf("k:%06d", i)),
+			Value: bytes.Repeat([]byte{byte('a' + (i % 26))}, 96),
+		})
+	}
+	enc, err := EncodeEntries(nil, entries, 0, 16)
+	if err != nil {
+		b.Fatalf("EncodeEntries: %v", err)
+	}
+	blk, err := DecodeBlock(enc, nil)
+	if err != nil {
+		b.Fatalf("DecodeBlock: %v", err)
+	}
+
+	lower := []byte("k:000120")
+	upper := []byte("k:000180")
+	if got, err := decodeStructuredKeysBounded(blk.version, blk.entryCount, blk.entries, lower, upper); err != nil || len(got) == 0 {
+		b.Fatalf("decodeStructuredKeysBounded warmup len=%d err=%v", len(got), err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		keys, err := decodeStructuredKeysBounded(blk.version, blk.entryCount, blk.entries, lower, upper)
+		if err != nil {
+			b.Fatalf("decodeStructuredKeysBounded: %v", err)
+		}
+		if len(keys) == 0 {
+			b.Fatalf("decodeStructuredKeysBounded returned no keys")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- reduce allocation churn in `decodeStructuredKeysBounded` by moving key reconstruction scratch buffers (`prev`/`curr`) to stack-backed slices
- keep decode behavior unchanged while removing two hot-path heap allocations per decode call
- add `BenchmarkDecodeStructuredKeysBoundedV2Range` to track the bounded decode path over time

## Validation
- `go test ./... -count=1`
- `go test ./TreeDB/internal/outerleaf -run '^$' -bench BenchmarkDecodeStructuredKeysBoundedV2Range -benchmem -count=3`
- force-value-pointers=false A/B medians at keys=500000 (v2/v1 ratio, 3-run median harness):
  - fast `prefix_scan`: `0.443 -> 0.475` (+7.21%)
  - fast `random_read_parallel`: `1.354 -> 1.391` (+2.69%)
  - wal_on_fast `prefix_scan`: `0.505 -> 0.549` (+8.88%)
  - wal_on_fast `random_read_parallel`: `0.987 -> 1.352` (+37.08%)
  - fast `random_read_parallel_acquire_snapshot`: `1.225 -> 1.047` (-14.53%)

Notes:
- this is a low-risk micro-optimization; macro perf remains noisy across runs, so benchmark coverage is included for continued tracking.
