### PR TITLE
perf(caching): tune v2 fence block target for wal-off force-false

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -611,6 +611,7 @@ func normalizeValueLogWALFenceMode(mode string) string {
 
 const defaultOuterLeafBlobThresholdMin = 16 << 10
 const defaultOuterLeafFenceBlockTargetBytes = 4 << 10
+const defaultOuterLeafFenceBlockTargetBytesNoForcePointers = 8 << 10
 
 // For fence-pointer v2 reads, short scans are latency-sensitive and pay decode
 // cost immediately. Keep the user-selected codec for large-value blocks, but
@@ -3771,9 +3772,13 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		valueLogWALFenceMode != string(backenddb.ValueLogWALFenceModeSimpleInline) {
 		return nil, fmt.Errorf("cachingdb: invalid value-log WAL fence mode %q", opts.ValueLogWALFenceMode)
 	}
+	disableJournal := opts.DisableWAL
 	outerLeafBlockTargetOpt := opts.ValueLogOuterLeafBlockTargetBytes
 	if outerLeafBlockTargetOpt <= 0 && indexOuterLeafMode == backenddb.IndexOuterLeafModeV2FencePtr {
 		outerLeafBlockTargetOpt = defaultOuterLeafFenceBlockTargetBytes
+		if !opts.ForceValueLogPointers && disableJournal {
+			outerLeafBlockTargetOpt = defaultOuterLeafFenceBlockTargetBytesNoForcePointers
+		}
 	}
 	outerLeafBlockTarget := outerleaf.NormalizeBlockTargetBytes(outerLeafBlockTargetOpt)
 	outerLeafBlockCodec := opts.ValueLogOuterLeafBlockCodec
@@ -3782,7 +3787,6 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	if outerLeafBlobThreshold < 0 {
 		return nil, fmt.Errorf("cachingdb: invalid value-log outer leaf blob threshold bytes %d", outerLeafBlobThreshold)
 	}
-	disableJournal := opts.DisableWAL
 	if indexOuterLeafMode == backenddb.IndexOuterLeafModeV2FencePtr && !disableJournal {
 		// Keep existing default semantics: WAL-on v2_fenceptr defaults to
 		// simple_inline unless caller explicitly chooses a compatible mode.

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -1277,6 +1277,74 @@ func TestCachingDB_Open_V2FencePtrWALOn_DefaultAutoSimpleInline(t *testing.T) {
 	}
 }
 
+func TestCachingDB_Open_V2FencePtr_DefaultOuterLeafBlockTarget_ForceFalseWALOn(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+
+	cache, err := Open(dir, backend, Options{
+		IndexOuterLeafMode:    db.IndexOuterLeafModeV2FencePtr,
+		ForceValueLogPointers: false,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("cache open: %v", err)
+	}
+	defer cache.Close()
+
+	if got, want := cache.outerLeafBlockTargetBytes, defaultOuterLeafFenceBlockTargetBytes; got != want {
+		t.Fatalf("outerLeafBlockTargetBytes=%d want=%d", got, want)
+	}
+}
+
+func TestCachingDB_Open_V2FencePtr_DefaultOuterLeafBlockTarget_ForceFalseWALOff(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+
+	cache, err := Open(dir, backend, Options{
+		IndexOuterLeafMode:    db.IndexOuterLeafModeV2FencePtr,
+		ForceValueLogPointers: false,
+		DisableWAL:            true,
+		AllowUnsafe:           true,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("cache open: %v", err)
+	}
+	defer cache.Close()
+
+	if got, want := cache.outerLeafBlockTargetBytes, defaultOuterLeafFenceBlockTargetBytesNoForcePointers; got != want {
+		t.Fatalf("outerLeafBlockTargetBytes=%d want=%d", got, want)
+	}
+}
+
+func TestCachingDB_Open_V2FencePtr_DefaultOuterLeafBlockTarget_ForceTrue(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+
+	cache, err := Open(dir, backend, Options{
+		IndexOuterLeafMode:    db.IndexOuterLeafModeV2FencePtr,
+		ForceValueLogPointers: true,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("cache open: %v", err)
+	}
+	defer cache.Close()
+
+	if got, want := cache.outerLeafBlockTargetBytes, defaultOuterLeafFenceBlockTargetBytes; got != want {
+		t.Fatalf("outerLeafBlockTargetBytes=%d want=%d", got, want)
+	}
+}
+
 func TestCachingDB_WALOnFenceModeSimpleInlineDefersAndLogsInline(t *testing.T) {
 	dir := t.TempDir()
 	backendOpts := db.Options{


### PR DESCRIPTION
## Summary
- For `IndexOuterLeafMode=v2_fenceptr`, keep default outer-leaf block target at `4KiB` unless both:
  - `ForceValueLogPointers=false`
  - `DisableWAL=true`
- In that WAL-off + force-false mode, default to `8KiB` block target.
- Add explicit open-path tests covering default target selection for:
  - force=false + WAL on
  - force=false + WAL off
  - force=true

## Why
- This is a low-risk default tuning aimed at force-false v2 scan/read gaps without changing public API.
- Scope is intentionally narrow to WAL-off mode where throughput-first defaults are already active.

## Validation
- `go test ./... -count=1`
- `go test ./TreeDB/caching -run 'TestCachingDB_Open_V2FencePtr_DefaultOuterLeafBlockTarget_Force(FalseWALOn|FalseWALOff|True)' -count=1`
- `make unified-bench`
- `scripts/outerleaf_v2_perf_gate.sh` at `KEYS=500000` (throughput ratios strong; strict CV noise checks were intermittently noisy)
- force-false median harness (3 runs): `artifacts/perf/issue510_fix005_decodeopt_gate_forcefalse_rerun_20260216_180152/summary_medians.json`
