### PR TITLE
perf(tree): cut v2 prefix-scan iterator and key decode allocations

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -14441,6 +14441,20 @@ func (it *singleSourceIterator) Next() {
 	it.advance()
 }
 
+func (it *singleSourceIterator) UnsafeKey() []byte {
+	if !it.valid {
+		return nil
+	}
+	return it.iter.UnsafeKey()
+}
+
+func (it *singleSourceIterator) UnsafeValue() []byte {
+	if !it.valid {
+		return nil
+	}
+	return it.iter.UnsafeValue()
+}
+
 func (it *singleSourceIterator) Valid() bool               { return it.valid }
 func (it *singleSourceIterator) Key() []byte               { return it.iter.Key() }
 func (it *singleSourceIterator) Value() []byte             { return it.iter.Value() }

--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -384,6 +384,14 @@ func (r valueReader) ReadUnsafeFenceBlockKeysRange(ptr page.ValuePtr, lower []by
 	if !outerleaf.HasMagic(raw) {
 		return nil, false, nil
 	}
+	if r.keyCache != nil {
+		allKeys, decErr := outerleaf.DecodeKeysWithVerify(raw, !r.skipOuterLeafChecksums)
+		if decErr != nil {
+			return nil, true, decErr
+		}
+		r.cacheOuterLeafKeys(ptr, allKeys)
+		return sliceFenceKeysRange(allKeys, lower, upper), true, nil
+	}
 	keys, decErr := outerleaf.DecodeKeysRangeWithVerify(raw, lower, upper, !r.skipOuterLeafChecksums)
 	if decErr != nil {
 		return nil, true, decErr
@@ -424,6 +432,18 @@ func (r valueReader) ReadUnsafeFenceBlockSeek(ptr page.ValuePtr, key []byte) (po
 	}
 	if !outerleaf.HasMagic(raw) {
 		return 0, false, false, nil, false, nil
+	}
+	if r.keyCache != nil {
+		allKeys, decErr := outerleaf.DecodeKeysWithVerify(raw, !r.skipOuterLeafChecksums)
+		if decErr != nil {
+			return 0, false, false, nil, true, decErr
+		}
+		r.cacheOuterLeafKeys(ptr, allKeys)
+		lower, isBelow, isAbove := classifyFenceKeys(allKeys, key)
+		if isBelow || isAbove {
+			return lower, isBelow, isAbove, nil, true, nil
+		}
+		return lower, false, false, allKeys, true, nil
 	}
 	lower, isBelow, isAbove, blockKeys, decErr := outerleaf.DecodeLowerBoundAndKeysOnMatchWithVerify(raw, key, !r.skipOuterLeafChecksums)
 	if decErr != nil {
@@ -478,6 +498,22 @@ func (r valueReader) ReadUnsafeFenceBlockSeekRange(ptr page.ValuePtr, key []byte
 	}
 	if !outerleaf.HasMagic(raw) {
 		return 0, false, false, nil, false, nil
+	}
+	if r.keyCache != nil {
+		allKeys, decErr := outerleaf.DecodeKeysWithVerify(raw, !r.skipOuterLeafChecksums)
+		if decErr != nil {
+			return 0, false, false, nil, true, decErr
+		}
+		r.cacheOuterLeafKeys(ptr, allKeys)
+		lower, isBelow, isAbove := classifyFenceKeys(allKeys, key)
+		if isBelow || isAbove {
+			return lower, isBelow, isAbove, nil, true, nil
+		}
+		ranged := sliceFenceKeysRange(allKeys, key, upper)
+		if len(ranged) == 0 {
+			return 0, false, false, nil, true, nil
+		}
+		return 0, false, false, ranged, true, nil
 	}
 	lower, isBelow, isAbove, blockKeys, decErr := outerleaf.DecodeLowerBoundAndKeysRangeOnMatchWithVerify(raw, key, upper, !r.skipOuterLeafChecksums)
 	if decErr != nil {

--- a/TreeDB/db/value_reader_test.go
+++ b/TreeDB/db/value_reader_test.go
@@ -494,6 +494,45 @@ func TestValueReaderReadUnsafeFenceBlockKeysRange_UsesKeyCacheWindow(t *testing.
 	}
 }
 
+func TestValueReaderReadUnsafeFenceBlockKeysRange_RawRangeWarmsFullKeyCache(t *testing.T) {
+	payload, _, ptr := makeTestOuterLeafPayload(t)
+	reader := &stubValueLogReader{payloads: map[page.ValuePtr][]byte{ptr: payload}}
+	keyCache := newOuterLeafKeyCache(8)
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+		keyCache:      keyCache,
+	}
+
+	keys, ok, err := r.ReadUnsafeFenceBlockKeysRange(ptr, []byte("k2"), []byte("k3"))
+	if err != nil {
+		t.Fatalf("ReadUnsafeFenceBlockKeysRange: %v", err)
+	}
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	if len(keys) != 1 || !bytes.Equal(keys[0], []byte("k2")) {
+		t.Fatalf("keys = %q, want [k2]", keys)
+	}
+	if reader.readUnsafeCalls != 1 {
+		t.Fatalf("readUnsafeCalls after range read = %d, want 1", reader.readUnsafeCalls)
+	}
+
+	all, ok, err := r.ReadUnsafeFenceBlockKeys(ptr)
+	if err != nil {
+		t.Fatalf("ReadUnsafeFenceBlockKeys: %v", err)
+	}
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	if len(all) != 3 {
+		t.Fatalf("all keys len = %d, want 3", len(all))
+	}
+	if reader.readUnsafeCalls != 1 {
+		t.Fatalf("readUnsafeCalls after full-key read = %d, want 1 (range read should warm key cache)", reader.readUnsafeCalls)
+	}
+}
+
 func TestValueReaderReadUnsafeFenceBlockKeys_OuterLeafKeyCacheChurn(t *testing.T) {
 	keyCache := newOuterLeafKeyCache(1)
 	if keyCache == nil {
@@ -768,8 +807,8 @@ func TestValueReaderReadUnsafeFenceBlockSeek_ClassifiesBoundsAndReusesCache(t *t
 	if pos != 1 || below || above || len(keys) != 3 {
 		t.Fatalf("seek(k2) got pos=%d below=%v above=%v len(keys)=%d, want pos=1 below=false above=false len(keys)=3", pos, below, above, len(keys))
 	}
-	if reader.readUnsafeCalls != 2 {
-		t.Fatalf("readUnsafeCalls after in-range materialization = %d, want 2", reader.readUnsafeCalls)
+	if reader.readUnsafeCalls != 1 {
+		t.Fatalf("readUnsafeCalls after in-range materialization = %d, want 1", reader.readUnsafeCalls)
 	}
 
 	pos, below, above, keys, ok, err = r.ReadUnsafeFenceBlockSeek(ptr, []byte("k9"))
@@ -782,8 +821,8 @@ func TestValueReaderReadUnsafeFenceBlockSeek_ClassifiesBoundsAndReusesCache(t *t
 	if pos != 3 || below || !above || keys != nil {
 		t.Fatalf("seek(k9) got pos=%d below=%v above=%v keys=%v, want pos=3 below=false above=true keys=nil", pos, below, above, keys)
 	}
-	if reader.readUnsafeCalls != 2 {
-		t.Fatalf("readUnsafeCalls after cache reuse = %d, want 2", reader.readUnsafeCalls)
+	if reader.readUnsafeCalls != 1 {
+		t.Fatalf("readUnsafeCalls after cache reuse = %d, want 1", reader.readUnsafeCalls)
 	}
 }
 
@@ -834,6 +873,45 @@ func TestValueReaderReadUnsafeFenceBlockSeekRange_UsesBoundedWindowAndKeyCache(t
 	}
 	if reader.readUnsafeCalls != 1 {
 		t.Fatalf("readUnsafeCalls after above classification = %d, want 1", reader.readUnsafeCalls)
+	}
+}
+
+func TestValueReaderReadUnsafeFenceBlockSeekRange_RawRangeWarmsFullKeyCache(t *testing.T) {
+	payload, _, ptr := makeTestOuterLeafPayload(t)
+	reader := &stubValueLogReader{payloads: map[page.ValuePtr][]byte{ptr: payload}}
+	keyCache := newOuterLeafKeyCache(8)
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+		keyCache:      keyCache,
+	}
+
+	pos, below, above, keys, ok, err := r.ReadUnsafeFenceBlockSeekRange(ptr, []byte("k2"), []byte("k3"))
+	if err != nil {
+		t.Fatalf("ReadUnsafeFenceBlockSeekRange: %v", err)
+	}
+	if !ok {
+		t.Fatalf("ok=false, want true")
+	}
+	if pos != 0 || below || above || len(keys) != 1 || !bytes.Equal(keys[0], []byte("k2")) {
+		t.Fatalf("seekRange(k2,k3) got pos=%d below=%v above=%v keys=%q, want pos=0 below=false above=false keys=[k2]", pos, below, above, keys)
+	}
+	if reader.readUnsafeCalls != 1 {
+		t.Fatalf("readUnsafeCalls after seekRange = %d, want 1", reader.readUnsafeCalls)
+	}
+
+	pos, below, above, keys, ok, err = r.ReadUnsafeFenceBlockSeek(ptr, []byte("k9"))
+	if err != nil {
+		t.Fatalf("ReadUnsafeFenceBlockSeek(k9): %v", err)
+	}
+	if !ok {
+		t.Fatalf("ok=false, want true")
+	}
+	if pos != 3 || below || !above || keys != nil {
+		t.Fatalf("seek(k9) got pos=%d below=%v above=%v keys=%v, want pos=3 below=false above=true keys=nil", pos, below, above, keys)
+	}
+	if reader.readUnsafeCalls != 1 {
+		t.Fatalf("readUnsafeCalls after seek classification = %d, want 1 (seekRange should warm key cache)", reader.readUnsafeCalls)
 	}
 }
 

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -3,6 +3,7 @@ package tree
 import (
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -13,6 +14,12 @@ type CursorItem struct {
 	PageID uint64
 	Node   node.Node
 	Index  int
+}
+
+var iteratorPool = sync.Pool{
+	New: func() any {
+		return &Iterator{}
+	},
 }
 
 // IteratorMode controls value materialization behavior while scanning.
@@ -310,7 +317,7 @@ func (s *combinedLeafKeyState) rebuildAt(index uint16) (key []byte, flags byte, 
 type Iterator struct {
 	tree            *Tree
 	stack           []CursorItem
-	stackBuf        [16]CursorItem
+	stackBuf        [4]CursorItem
 	leafState       combinedLeafKeyState
 	start           []byte
 	end             []byte
@@ -377,34 +384,39 @@ func normalizeIteratorMode(mode IteratorMode) IteratorMode {
 	}
 }
 
+func (t *Tree) acquireIterator(start, end []byte, mode IteratorMode, reverse bool) *Iterator {
+	it := iteratorPool.Get().(*Iterator)
+	*it = Iterator{
+		tree:            t,
+		start:           start,
+		end:             end,
+		mode:            mode,
+		reverse:         reverse,
+		verifyAlways:    t.pager != nil && t.pager.VerifyOnRead(),
+		slabAppender:    t.slabAppender,
+		slabBatcher:     t.slabBatcher,
+		slabKeyReader:   t.slabKeyReader,
+		slabFenceBlocks: t.slabFenceBlocks,
+		slabFenceKeys:   t.slabFenceKeys,
+		slabFenceRange:  t.slabFenceRange,
+		slabFenceSeek:   t.slabFenceSeek,
+		slabFenceSeekR:  t.slabFenceSeekR,
+		slabFencePtrCls: t.slabFencePtrCls,
+		slabKeyAppender: t.slabKeyAppender,
+		slabKeyBatcher:  t.slabKeyBatcher,
+	}
+	it.resetStack()
+	return it
+}
+
 // IteratorWithOptions returns a forward iterator over [start, end) using the
 // provided value materialization mode.
 func (t *Tree) IteratorWithOptions(start, end []byte, opts IteratorOptions) iterator.UnsafeIterator {
+	mode := normalizeIteratorMode(opts.Mode)
 	if start != nil && end != nil && compareTreeKey(start, end) >= 0 {
-		return &Iterator{tree: t, valid: false, err: nil} // Invalid immediately
+		return t.acquireIterator(nil, nil, mode, false) // Invalid immediately
 	}
-	it := &Iterator{
-		tree:         t,
-		start:        start,
-		end:          end,
-		mode:         normalizeIteratorMode(opts.Mode),
-		reverse:      false,
-		verifyAlways: t.pager != nil && t.pager.VerifyOnRead(),
-	}
-	it.slabAppender = t.slabAppender
-	if batch, ok := t.slabReader.(slabUnsafeBatchAppender); ok {
-		it.slabBatcher = batch
-	}
-	it.slabKeyReader = t.slabKeyReader
-	it.slabFenceBlocks = t.slabFenceBlocks
-	it.slabFenceKeys = t.slabFenceKeys
-	it.slabFenceRange = t.slabFenceRange
-	it.slabFenceSeek = t.slabFenceSeek
-	it.slabFenceSeekR = t.slabFenceSeekR
-	it.slabFencePtrCls = t.slabFencePtrCls
-	it.slabKeyAppender = t.slabKeyAppender
-	it.slabKeyBatcher = t.slabKeyBatcher
-	it.resetStack()
+	it := t.acquireIterator(start, end, mode, false)
 	it.Seek(start)
 	if start == nil {
 		it.prefetchArmed = true
@@ -419,31 +431,11 @@ func (t *Tree) ReverseIterator(start, end []byte) iterator.UnsafeIterator {
 // ReverseIteratorWithOptions returns a reverse iterator over [start, end)
 // using the provided value materialization mode.
 func (t *Tree) ReverseIteratorWithOptions(start, end []byte, opts IteratorOptions) iterator.UnsafeIterator {
+	mode := normalizeIteratorMode(opts.Mode)
 	if start != nil && end != nil && compareTreeKey(start, end) >= 0 {
-		return &Iterator{tree: t, valid: false, err: nil}
+		return t.acquireIterator(nil, nil, mode, true)
 	}
-	it := &Iterator{
-		tree:         t,
-		start:        start,
-		end:          end,
-		mode:         normalizeIteratorMode(opts.Mode),
-		reverse:      true,
-		verifyAlways: t.pager != nil && t.pager.VerifyOnRead(),
-	}
-	it.slabAppender = t.slabAppender
-	if batch, ok := t.slabReader.(slabUnsafeBatchAppender); ok {
-		it.slabBatcher = batch
-	}
-	it.slabKeyReader = t.slabKeyReader
-	it.slabFenceBlocks = t.slabFenceBlocks
-	it.slabFenceKeys = t.slabFenceKeys
-	it.slabFenceRange = t.slabFenceRange
-	it.slabFenceSeek = t.slabFenceSeek
-	it.slabFenceSeekR = t.slabFenceSeekR
-	it.slabFencePtrCls = t.slabFencePtrCls
-	it.slabKeyAppender = t.slabKeyAppender
-	it.slabKeyBatcher = t.slabKeyBatcher
-	it.resetStack()
+	it := t.acquireIterator(start, end, mode, true)
 	// Reverse seek: Find >= end, then step back.
 	if end == nil {
 		it.seekRightMost()
@@ -1463,11 +1455,11 @@ func (it *Iterator) ValueCopy(dst []byte) []byte {
 }
 
 func (it *Iterator) Close() error {
-	it.stack = nil
-	it.resetPointerPrefetch()
-	it.resetFenceCursor()
-	it.clearPendingFenceSeek()
-	it.ptrScratch = nil
+	if it == nil || it.tree == nil {
+		return nil
+	}
+	*it = Iterator{}
+	iteratorPool.Put(it)
 	return nil
 }
 

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -141,6 +141,7 @@ type Tree struct {
 	pager           *pager.Pager
 	slabReader      SlabReader
 	slabAppender    slabUnsafeAppender
+	slabBatcher     slabUnsafeBatchAppender
 	slabKeyReader   slabUnsafeKeyReader
 	slabFenceReader slabUnsafeFenceKeyReader
 	fenceLookupMode bool
@@ -165,6 +166,9 @@ func New(p *pager.Pager, sr SlabReader, root uint64) *Tree {
 	fenceEnabled := fencePointerLookupsEnabled(sr)
 	if app, ok := sr.(slabUnsafeAppender); ok {
 		t.slabAppender = app
+	}
+	if batcher, ok := sr.(slabUnsafeBatchAppender); ok {
+		t.slabBatcher = batcher
 	}
 	if keyAwareEnabled {
 		if keyReader, ok := sr.(slabUnsafeKeyReader); ok {
@@ -214,6 +218,11 @@ func (t *Tree) Reset(p *pager.Pager, sr SlabReader, root uint64) {
 		t.slabAppender = app
 	} else {
 		t.slabAppender = nil
+	}
+	if batcher, ok := sr.(slabUnsafeBatchAppender); ok {
+		t.slabBatcher = batcher
+	} else {
+		t.slabBatcher = nil
 	}
 	if keyAwareEnabled {
 		if keyReader, ok := sr.(slabUnsafeKeyReader); ok {


### PR DESCRIPTION
## Summary
- expose `UnsafeKey`/`UnsafeValue` on caching single-source iterator to avoid adapter key-copy allocations on scan paths
- warm full outer-leaf key cache on raw fence range/seek-range reads so repeated range/seek operations reuse decoded keys
- reduce tree iterator allocation pressure by shrinking embedded stack buffer and reusing iterator objects via a pool
- cache `slabUnsafeBatchAppender` on `Tree` to avoid per-iterator type assertions

## Why
Issue #510 profiling on `prefix_scan` (`fast`, `keys=500000`, `force-value-pointers=false`) highlighted three allocation hotspots:
- `tree.(*Tree).IteratorWithOptions`
- `outerleaf.decodeStructuredKeysBounded`
- `db.(*DBIterator).KeyCopy`

This change set targets those directly.

## Validation
- `go test ./... -count=1`
- `env KEYS=500000 RUNS=3 WARMUP_RUNS=0 TESTS='batch_write,batch_write_steady,prefix_scan,random_read,random_read_parallel,random_read_parallel_acquire_snapshot' INCLUDE_READ_TESTS=1 GATE_PROFILES='fast,wal_on_fast' PROFILES='fast,wal_on_fast' ./scripts/outerleaf_v2_perf_gate.sh`

## Perf snapshot (same host/settings)
`prefix_scan`, `fast`, `keys=500000`, `range_queries=20000`, `range_span=100`, `v2_fenceptr`, `force-value-pointers=false`, `val-pattern=repeat_tail64`

- base `f4892146a0`: `7,924,076` ops/s
- this branch `0141d3c25e`: `19,112,598` ops/s
- delta: `+141.2%`

Alloc profile (`allocs_prefix_scan_treedb.pprof`) total alloc_space:
- base: `697.97MB`
- this branch: `97.75MB`

Top alloc sites (base -> this branch):
- `tree.(*Tree).IteratorWithOptions` flat `115.68MB` -> no longer a top flat allocator (`~1.5MB` in `db.(*DB).IteratorWithOptions` wrapper path)
- `outerleaf.decodeStructuredKeysBounded` flat `121.09MB` -> replaced by `outerleaf.decodeStructuredKeys` flat `13.51MB`
- `db.(*DBIterator).KeyCopy` flat `13.50MB` -> no longer a top allocator

## Notes
The full gate still reports a `prefix_scan` ratio failure vs `v1_forceptr` in one profile, but the targeted hotspot and throughput trend for v2 improved materially.
