### PR TITLE
perf(outerleaf): avoid restart-slice allocs in no-cache lookups

### DIFF
--- a/TreeDB/internal/outerleaf/block.go
+++ b/TreeDB/internal/outerleaf/block.go
@@ -1152,6 +1152,30 @@ func locateV2Restart(entries []byte, key []byte, restarts []uint32, restartKeys 
 	return lo - 1, nil
 }
 
+func locateV2RestartRaw(entries []byte, key []byte, restartRaw []byte, restartCount int) (int, error) {
+	if restartCount <= 0 {
+		return -1, nil
+	}
+	if len(restartRaw) != restartCount*4 {
+		return -1, fmt.Errorf("outerleaf: invalid restart section")
+	}
+	lo, hi := 0, restartCount
+	for lo < hi {
+		mid := lo + (hi-lo)/2
+		off := int(binary.LittleEndian.Uint32(restartRaw[mid*4 : (mid+1)*4]))
+		rk, err := restartV2Key(entries, off)
+		if err != nil {
+			return -1, err
+		}
+		if bytes.Compare(rk, key) > 0 {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return lo - 1, nil
+}
+
 func lookupV2ValueRange(entries []byte, key []byte, start int, limit int) ([]byte, bool, error) {
 	if start < 0 || start > len(entries) || limit < start || limit > len(entries) {
 		return nil, false, fmt.Errorf("outerleaf: invalid entry range")
@@ -1226,6 +1250,38 @@ func lookupV2Value(entries []byte, entryCount int, key []byte, restarts []uint32
 	limit := len(entries)
 	if restartIdx+1 < len(restarts) {
 		limit = int(restarts[restartIdx+1])
+	}
+	return lookupV2ValueRange(entries, key, start, limit)
+}
+
+func lookupV2ValueWithRestartRaw(entries []byte, entryCount int, key []byte, restartRaw []byte, restartCount int) ([]byte, bool, error) {
+	if entryCount <= 0 {
+		return nil, false, nil
+	}
+	if len(key) == 0 {
+		_, first, err := decodeFirstV2(entries)
+		if err != nil {
+			return nil, false, err
+		}
+		return first, true, nil
+	}
+	if restartCount == 0 {
+		return lookupV2ValueRange(entries, key, 0, len(entries))
+	}
+	if len(restartRaw) != restartCount*4 {
+		return nil, false, fmt.Errorf("outerleaf: invalid restart section")
+	}
+	restartIdx, err := locateV2RestartRaw(entries, key, restartRaw, restartCount)
+	if err != nil {
+		return nil, false, err
+	}
+	if restartIdx < 0 {
+		return nil, false, nil
+	}
+	start := int(binary.LittleEndian.Uint32(restartRaw[restartIdx*4 : (restartIdx+1)*4]))
+	limit := len(entries)
+	if restartIdx+1 < restartCount {
+		limit = int(binary.LittleEndian.Uint32(restartRaw[(restartIdx+1)*4 : (restartIdx+2)*4]))
 	}
 	return lookupV2ValueRange(entries, key, start, limit)
 }
@@ -1324,6 +1380,30 @@ func locateV3Restart(entries []byte, key []byte, restarts []uint32, restartKeys 
 	return lo - 1, nil
 }
 
+func locateV3RestartRaw(entries []byte, key []byte, restartRaw []byte, restartCount int) (int, error) {
+	if restartCount <= 0 {
+		return -1, nil
+	}
+	if len(restartRaw) != restartCount*4 {
+		return -1, fmt.Errorf("outerleaf: invalid restart section")
+	}
+	lo, hi := 0, restartCount
+	for lo < hi {
+		mid := lo + (hi-lo)/2
+		off := int(binary.LittleEndian.Uint32(restartRaw[mid*4 : (mid+1)*4]))
+		rk, err := restartV3Key(entries, off)
+		if err != nil {
+			return -1, err
+		}
+		if bytes.Compare(rk, key) > 0 {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return lo - 1, nil
+}
+
 func lookupV3EntryRange(entries []byte, key []byte, start int, limit int) (LookupResult, bool, error) {
 	if start < 0 || start > len(entries) || limit < start || limit > len(entries) {
 		return LookupResult{}, false, fmt.Errorf("outerleaf: invalid entry range")
@@ -1406,6 +1486,38 @@ func lookupV3Entry(entries []byte, entryCount int, key []byte, restarts []uint32
 	limit := len(entries)
 	if restartIdx+1 < len(restarts) {
 		limit = int(restarts[restartIdx+1])
+	}
+	return lookupV3EntryRange(entries, key, start, limit)
+}
+
+func lookupV3EntryWithRestartRaw(entries []byte, entryCount int, key []byte, restartRaw []byte, restartCount int) (LookupResult, bool, error) {
+	if entryCount <= 0 {
+		return LookupResult{}, false, nil
+	}
+	if len(key) == 0 {
+		_, first, err := decodeFirstV3(entries)
+		if err != nil {
+			return LookupResult{}, false, err
+		}
+		return first, true, nil
+	}
+	if restartCount == 0 {
+		return lookupV3EntryRange(entries, key, 0, len(entries))
+	}
+	if len(restartRaw) != restartCount*4 {
+		return LookupResult{}, false, fmt.Errorf("outerleaf: invalid restart section")
+	}
+	restartIdx, err := locateV3RestartRaw(entries, key, restartRaw, restartCount)
+	if err != nil {
+		return LookupResult{}, false, err
+	}
+	if restartIdx < 0 {
+		return LookupResult{}, false, nil
+	}
+	start := int(binary.LittleEndian.Uint32(restartRaw[restartIdx*4 : (restartIdx+1)*4]))
+	limit := len(entries)
+	if restartIdx+1 < restartCount {
+		limit = int(binary.LittleEndian.Uint32(restartRaw[(restartIdx+1)*4 : (restartIdx+2)*4]))
 	}
 	return lookupV3EntryRange(entries, key, start, limit)
 }
@@ -2818,11 +2930,11 @@ func DecodeEntryForKeyWithVerify(payload []byte, key []byte, scratch []byte, ver
 			return LookupResult{}, true, false, scratch, err
 		}
 		restartsInterval := int(binary.LittleEndian.Uint16(payload[6:8]))
-		entries, restarts, splitErr := splitV2Raw(outScratch, entriesLen, entryCount, restartsInterval)
+		entries, restartRaw, restartCount, splitErr := splitV2RawMeta(outScratch, entriesLen, entryCount, restartsInterval)
 		if splitErr != nil {
 			return LookupResult{}, true, false, outScratch, splitErr
 		}
-		result, found, err := lookupV3Entry(entries, entryCount, key, restarts, nil)
+		result, found, err := lookupV3EntryWithRestartRaw(entries, entryCount, key, restartRaw, restartCount)
 		if err != nil {
 			return LookupResult{}, true, false, outScratch, err
 		}
@@ -2876,11 +2988,11 @@ func decodeValueForKeyWithVerify(payload []byte, key []byte, scratch []byte, ver
 			return nil, true, false, scratch, err
 		}
 		restartsInterval := int(binary.LittleEndian.Uint16(payload[6:8]))
-		entries, restarts, splitErr := splitV2Raw(outScratch, entriesLen, entryCount, restartsInterval)
+		entries, restartRaw, restartCount, splitErr := splitV2RawMeta(outScratch, entriesLen, entryCount, restartsInterval)
 		if splitErr != nil {
 			return nil, true, false, outScratch, splitErr
 		}
-		val, found, err := lookupV2Value(entries, entryCount, key, restarts, nil)
+		val, found, err := lookupV2ValueWithRestartRaw(entries, entryCount, key, restartRaw, restartCount)
 		if err != nil {
 			return nil, true, false, outScratch, err
 		}
@@ -2900,11 +3012,11 @@ func decodeValueForKeyWithVerify(payload []byte, key []byte, scratch []byte, ver
 			return nil, true, false, scratch, err
 		}
 		restartsInterval := int(binary.LittleEndian.Uint16(payload[6:8]))
-		entries, restarts, splitErr := splitV2Raw(outScratch, entriesLen, entryCount, restartsInterval)
+		entries, restartRaw, restartCount, splitErr := splitV2RawMeta(outScratch, entriesLen, entryCount, restartsInterval)
 		if splitErr != nil {
 			return nil, true, false, outScratch, splitErr
 		}
-		entry, found, err := lookupV3Entry(entries, entryCount, key, restarts, nil)
+		entry, found, err := lookupV3EntryWithRestartRaw(entries, entryCount, key, restartRaw, restartCount)
 		if err != nil {
 			return nil, true, false, outScratch, err
 		}

--- a/TreeDB/internal/outerleaf/block_test.go
+++ b/TreeDB/internal/outerleaf/block_test.go
@@ -2,6 +2,7 @@ package outerleaf
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"testing"
 
@@ -371,6 +372,132 @@ func TestDecodeBlockValueForKey_RestartIndexed(t *testing.T) {
 			t.Fatalf("ValueForKey miss(%q): found=%v got=%v", string(miss), found, got)
 		}
 	}
+}
+
+func TestLookupRestartRawParity_V2V3(t *testing.T) {
+	v2Entries := make([]Entry, 0, 128)
+	for i := 0; i < 128; i++ {
+		v2Entries = append(v2Entries, Entry{
+			Key:   []byte(fmt.Sprintf("acct:%04d", i)),
+			Value: bytes.Repeat([]byte{byte('a' + (i % 26))}, 96),
+		})
+	}
+	v2Payload, err := EncodeEntries(nil, v2Entries, 0, 8)
+	if err != nil {
+		t.Fatalf("EncodeEntries(v2): %v", err)
+	}
+	v2RawLen := int(binary.LittleEndian.Uint32(v2Payload[blockV2RawLenOff : blockV2RawLenOff+4]))
+	v2Raw, err := decodeAndVerifyPayloadModeWithChecksum(v2Payload, v2RawLen, v2Payload[5], nil, false, true)
+	if err != nil {
+		t.Fatalf("decode v2 payload: %v", err)
+	}
+	v2EntryCount := int(binary.LittleEndian.Uint16(v2Payload[blockV2EntryCountOff : blockV2EntryCountOff+2]))
+	v2EntriesLen := int(binary.LittleEndian.Uint32(v2Payload[blockV2EntriesLenOff : blockV2EntriesLenOff+4]))
+	v2RestartInterval := int(binary.LittleEndian.Uint16(v2Payload[6:8]))
+	v2EntriesRaw, v2RestartRaw, v2RestartCount, err := splitV2RawMeta(v2Raw, v2EntriesLen, v2EntryCount, v2RestartInterval)
+	if err != nil {
+		t.Fatalf("splitV2RawMeta(v2): %v", err)
+	}
+	v2Restarts, err := decodeRestartsFromRaw(v2EntriesRaw, v2RestartRaw, v2RestartCount)
+	if err != nil {
+		t.Fatalf("decodeRestartsFromRaw(v2): %v", err)
+	}
+
+	checkV2 := func(key []byte) {
+		t.Helper()
+		oldVal, oldFound, oldErr := lookupV2Value(v2EntriesRaw, v2EntryCount, key, v2Restarts, nil)
+		if oldErr != nil {
+			t.Fatalf("lookupV2Value(%q): %v", key, oldErr)
+		}
+		newVal, newFound, newErr := lookupV2ValueWithRestartRaw(v2EntriesRaw, v2EntryCount, key, v2RestartRaw, v2RestartCount)
+		if newErr != nil {
+			t.Fatalf("lookupV2ValueWithRestartRaw(%q): %v", key, newErr)
+		}
+		if oldFound != newFound {
+			t.Fatalf("found mismatch for %q old=%v new=%v", key, oldFound, newFound)
+		}
+		if !bytes.Equal(oldVal, newVal) {
+			t.Fatalf("value mismatch for %q", key)
+		}
+	}
+	checkV2(v2Entries[0].Key)
+	checkV2(v2Entries[7].Key)
+	checkV2(v2Entries[63].Key)
+	checkV2(v2Entries[127].Key)
+	checkV2([]byte("acct:-001"))
+	checkV2([]byte("acct:9999"))
+
+	v3Entries := make([]TypedEntry, 0, 128)
+	for i := 0; i < 128; i++ {
+		k := []byte(fmt.Sprintf("acct:%04d", i))
+		if i%5 == 0 {
+			v3Entries = append(v3Entries, TypedEntry{
+				Key:     k,
+				Kind:    EntryKindBlobRef,
+				BlobPtr: page.ValuePtr{FileID: page.ValueLogFileID(5), Offset: uint64(i * 32), Length: 9},
+			})
+			continue
+		}
+		v3Entries = append(v3Entries, TypedEntry{
+			Key:   k,
+			Kind:  EntryKindInline,
+			Value: bytes.Repeat([]byte{byte('a' + (i % 26))}, 64),
+		})
+	}
+	v3Payload, err := EncodeTypedEntries(nil, v3Entries, 0, 8)
+	if err != nil {
+		t.Fatalf("EncodeTypedEntries(v3): %v", err)
+	}
+	v3RawLen := int(binary.LittleEndian.Uint32(v3Payload[blockV2RawLenOff : blockV2RawLenOff+4]))
+	v3Raw, err := decodeAndVerifyPayloadModeWithChecksum(v3Payload, v3RawLen, v3Payload[5], nil, false, true)
+	if err != nil {
+		t.Fatalf("decode v3 payload: %v", err)
+	}
+	v3EntryCount := int(binary.LittleEndian.Uint16(v3Payload[blockV2EntryCountOff : blockV2EntryCountOff+2]))
+	v3EntriesLen := int(binary.LittleEndian.Uint32(v3Payload[blockV2EntriesLenOff : blockV2EntriesLenOff+4]))
+	v3RestartInterval := int(binary.LittleEndian.Uint16(v3Payload[6:8]))
+	v3EntriesRaw, v3RestartRaw, v3RestartCount, err := splitV2RawMeta(v3Raw, v3EntriesLen, v3EntryCount, v3RestartInterval)
+	if err != nil {
+		t.Fatalf("splitV2RawMeta(v3): %v", err)
+	}
+	v3Restarts, err := decodeRestartsFromRaw(v3EntriesRaw, v3RestartRaw, v3RestartCount)
+	if err != nil {
+		t.Fatalf("decodeRestartsFromRaw(v3): %v", err)
+	}
+
+	checkV3 := func(key []byte) {
+		t.Helper()
+		oldEntry, oldFound, oldErr := lookupV3Entry(v3EntriesRaw, v3EntryCount, key, v3Restarts, nil)
+		if oldErr != nil {
+			t.Fatalf("lookupV3Entry(%q): %v", key, oldErr)
+		}
+		newEntry, newFound, newErr := lookupV3EntryWithRestartRaw(v3EntriesRaw, v3EntryCount, key, v3RestartRaw, v3RestartCount)
+		if newErr != nil {
+			t.Fatalf("lookupV3EntryWithRestartRaw(%q): %v", key, newErr)
+		}
+		if oldFound != newFound {
+			t.Fatalf("found mismatch for %q old=%v new=%v", key, oldFound, newFound)
+		}
+		if !oldFound {
+			return
+		}
+		if oldEntry.Kind != newEntry.Kind {
+			t.Fatalf("kind mismatch for %q old=%d new=%d", key, oldEntry.Kind, newEntry.Kind)
+		}
+		if oldEntry.Kind == EntryKindInline {
+			if !bytes.Equal(oldEntry.Value, newEntry.Value) {
+				t.Fatalf("inline value mismatch for %q", key)
+			}
+		} else if oldEntry.BlobPtr != newEntry.BlobPtr {
+			t.Fatalf("blob ptr mismatch for %q old=%+v new=%+v", key, oldEntry.BlobPtr, newEntry.BlobPtr)
+		}
+	}
+	checkV3(v3Entries[0].Key)
+	checkV3(v3Entries[11].Key)
+	checkV3(v3Entries[64].Key)
+	checkV3(v3Entries[127].Key)
+	checkV3([]byte("acct:-001"))
+	checkV3([]byte("acct:9999"))
 }
 
 func TestDecodedBlockLowerBound(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove per-lookup restart `[]uint32` materialization on no-cache v2/v3 key lookups
- use restart raw bytes directly for restart binary-search bounds in `DecodeEntryForKeyWithVerify`/`decodeValueForKeyWithVerify`
- keep behavior parity with existing path and add explicit parity tests

## Changes
- `TreeDB/internal/outerleaf/block.go`
  - add raw restart helpers: `locateV2RestartRaw`, `locateV3RestartRaw`, `lookupV2ValueWithRestartRaw`, `lookupV3EntryWithRestartRaw`
  - switch no-cache decode paths to `splitV2RawMeta` + raw helpers
- `TreeDB/internal/outerleaf/block_test.go`
  - add `TestLookupRestartRawParity_V2V3` to verify old/new lookup parity on hits + misses across v2 and mixed v3 payloads

## Validation
- `go test ./TreeDB/internal/outerleaf -count=1`
- `go test ./TreeDB/db -count=1`
- `go test ./cmd/unified_bench -count=1`

## Perf notes
Measured with `-keys 500000` and no outer-leaf cache:
`./bin/unified-bench -dbs treedb -profile fast -keys 500000 -test random_read,random_read_parallel,random_read_parallel_acquire_snapshot,random_read_batch -progress=false -format markdown -checkpoint-between-tests -vacuum-between-tests -dataset-val-pattern repeat_tail64 -val-pattern repeat_tail64 -treedb-force-value-pointers=false -treedb-index-outer-leaf-mode=v2_fenceptr -treedb-outer-leaf-block-cache-entries=0`

Median over 5 runs vs base commit `6da118cb28` (same command shape):
- Random Read: `739,685 -> 761,739` (**+2.98%**)
- Random Read (Parallel): `1,551,672 -> 1,540,355` (**-0.73%**)
- Random Read (Parallel, Snapshot Per Key): `1,382,844 -> 1,425,796` (**+3.11%**)
- Random Read (Batch): `1,487,495 -> 1,484,630` (**-0.19%**)

Net: small positive on single-thread and snapshot-per-key reads; neutral/slightly negative on parallel and batch in this sample (within expected noise band).
