### PR TITLE
unified-bench: auto-run benchprof with profile-dir

### DIFF
--- a/cmd/benchprof/README.md
+++ b/cmd/benchprof/README.md
@@ -19,7 +19,7 @@ make benchprof
 ## Typical flow
 
 1. Run `unified-bench` with profile outputs into one directory.
-2. Run `benchprof` on that directory.
+2. `unified-bench` auto-runs `benchprof` at the end when `./bin/benchprof` is available. If it is unavailable, run it manually.
 
 Example:
 
@@ -35,6 +35,8 @@ mkdir -p /tmp/scan-profiles
   -test full_scan,prefix_scan \
   -profile-dir /tmp/scan-profiles \
   -progress=false
+
+# If needed (for ad-hoc runs), this is the equivalent manual invocation:
 
 ./bin/benchprof \
   -profiles-dir /tmp/scan-profiles

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -99,7 +99,7 @@ Side-by-side benchmarks for `HashDB`, `BTreeOnHashDB`, `TreeDB` (cached), Badger
 - `-allocsprofilerate` allocation sampling rate in bytes for `runtime.MemProfileRate` (default `524288`)
 - `-checkpoint-cpuprofile` write per-checkpoint CPU profiles to `<prefix>_checkpoint_<test>_<db>.pprof`
 - `-checkpoint-cpuprofile-tests` restrict checkpoint CPU profiling to a CSV list of tests
-- `-profile-dir` write all profile outputs into one directory (auto-sets defaults for `-cpuprofile`, `-allocsprofile`, `-checkpoint-cpuprofile`, `-blockprofile`, `-mutexprofile`, `-trace`; explicit flags still win). Also emits `benchprof_results.json` and `benchprof_results.md` for `benchprof`.
+- `-profile-dir` write all profile outputs into one directory (auto-sets defaults for `-cpuprofile`, `-allocsprofile`, `-checkpoint-cpuprofile`, `-blockprofile`, `-mutexprofile`, `-trace`; explicit flags still win). Also emits `benchprof_results.json` and `benchprof_results.md`, then automatically runs `./bin/benchprof` when available.
 - `-treedb-cache-stats-before-reads` print select `treedb.cache.*` stats before read/scan tests (treedb only)
 - `-blockprofile`, `-mutexprofile`, `-trace` write profiling artifacts to files
 - `-max-wall` abort the run if wall time exceeds this duration (guardrail; `0` = disabled)
@@ -154,8 +154,6 @@ OUT=$(mktemp -d /tmp/gomap_profiles_XXXXXX)
   -test random_write,random_delete,random_read,full_scan,prefix_scan \
   -profile-dir "$OUT" \
   -progress=false
-
-./bin/benchprof -profiles-dir "$OUT"
 ```
 
 This writes:

--- a/cmd/unified_bench/integration_test.go
+++ b/cmd/unified_bench/integration_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -66,4 +68,70 @@ func TestIntegration_NoHangLargeKeys(t *testing.T) {
 	}
 
 	t.Logf("Benchmark completed successfully.\nStdout:\n%s\nStderr:\n%s", stdout.String(), stderr.String())
+}
+
+func TestIntegration_ProfileDir_AutoRunsBenchprof(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	// Build the unified-bench executable first to test the CLI path.
+	buildCmd := exec.Command("go", "build", "-o", "../../bin/unified-bench", ".")
+	buildCmd.Dir = "."
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("failed to build unified-bench: %v", err)
+	}
+
+	profileDir := t.TempDir()
+	fakeBinDir := t.TempDir()
+	fakeBenchprof := filepath.Join(fakeBinDir, "benchprof")
+	markerPath := filepath.Join(profileDir, ".benchprof_invoked")
+
+	shim := "#!/usr/bin/env sh\n"
+	shim += "touch \"$GOMAP_BENCHPROF_MARKER\"\n"
+	shim += "exit 0\n"
+	if err := os.WriteFile(fakeBenchprof, []byte(shim), 0o755); err != nil {
+		t.Fatalf("write fake benchprof: %v", err)
+	}
+
+	cmd := exec.Command(
+		"../../bin/unified-bench",
+		"-test", "sequential_write",
+		"-dbs", "treedb",
+		"-keys", "128",
+		"-format", "table",
+		"-profile-dir", profileDir,
+		"-progress=false",
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	pathEnv := fakeBinDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	cmd.Env = append(
+		os.Environ(),
+		"PATH="+pathEnv,
+		"GOMAP_BENCHPROF_MARKER="+markerPath,
+	)
+
+	timeout := 120 * time.Second
+	timer := time.AfterFunc(timeout, func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		t.Errorf("benchmark process timed out after %v", timeout)
+	})
+	defer timer.Stop()
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("benchmark failed: %v\nStdout:\n%s\nStderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(profileDir, "benchprof_results.json")); err != nil {
+		t.Fatalf("expected benchprof_results.json: %v", err)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("expected auto-run benchprof marker: %v\nStdout:\n%s\nStderr:\n%s", err, stdout.String(), stderr.String())
+	}
 }

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -596,8 +596,11 @@ func main() {
 			if err != nil {
 				log.Fatalf("benchmark: %v", err)
 			}
-			maybeWriteBenchprofArtifacts(*profileDir, []BenchRun{run})
+			hasArtifacts := maybeWriteBenchprofArtifacts(*profileDir, []BenchRun{run})
 			fmt.Print(renderMarkdownSingle(run))
+			if hasArtifacts {
+				runBenchprof(*profileDir)
+			}
 			return
 		}
 
@@ -605,7 +608,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("benchmark: %v", err)
 		}
-		maybeWriteBenchprofArtifacts(*profileDir, []BenchRun{run})
+		hasArtifacts := maybeWriteBenchprofArtifacts(*profileDir, []BenchRun{run})
 		printResultsTable(run.Instances, run.TestOrder, run.DisplayNames, run.Results)
 		if len(run.CheckpointDurations) > 0 {
 			fmt.Println()
@@ -636,6 +639,9 @@ func main() {
 				}
 			}
 		}
+		if hasArtifacts {
+			runBenchprof(*profileDir)
+		}
 		return
 	}
 
@@ -645,7 +651,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("benchmark sweep: %v", err)
 	}
-	maybeWriteBenchprofArtifacts(*profileDir, runs)
+	hasArtifacts := maybeWriteBenchprofArtifacts(*profileDir, runs)
 
 	switch format {
 	case "table":
@@ -687,6 +693,9 @@ func main() {
 		fmt.Print(renderMarkdownSweep(runs))
 	default:
 		log.Fatalf("unknown -format: %q", format)
+	}
+	if hasArtifacts {
+		runBenchprof(*profileDir)
 	}
 }
 
@@ -824,14 +833,64 @@ func applyProfileArtifactDir(dir string, isSet map[string]bool) error {
 	return nil
 }
 
-func maybeWriteBenchprofArtifacts(dir string, runs []BenchRun) {
+func maybeWriteBenchprofArtifacts(dir string, runs []BenchRun) bool {
 	dir = strings.TrimSpace(dir)
 	if dir == "" || len(runs) == 0 {
-		return
+		return false
 	}
 	if err := writeBenchprofArtifacts(dir, runs); err != nil {
 		log.Printf("benchprof artifacts: %v", err)
+		return false
 	}
+	return true
+}
+
+func runBenchprof(dir string) {
+	path, err := locateBenchprofBinary()
+	if err != nil {
+		log.Printf("benchprof: %v", err)
+		return
+	}
+	cmd := exec.Command(path, "-profiles-dir", dir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Printf("benchprof: %v", err)
+	}
+}
+
+func locateBenchprofBinary() (string, error) {
+	candidates := []string{
+		filepath.Join(".", "bin", "benchprof"),
+	}
+	if runtime.GOOS == "windows" {
+		candidates = append(candidates, filepath.Join(".", "bin", "benchprof.exe"))
+	}
+	if exe, err := os.Executable(); err == nil {
+		candidates = append(candidates, filepath.Join(filepath.Dir(exe), "benchprof"))
+		if runtime.GOOS == "windows" {
+			candidates = append(candidates, filepath.Join(filepath.Dir(exe), "benchprof.exe"))
+		}
+	}
+	candidates = append(candidates, "benchprof")
+	if runtime.GOOS == "windows" {
+		candidates = append(candidates, "benchprof.exe")
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		candidate = filepath.Clean(candidate)
+		if _, dup := seen[candidate]; dup {
+			continue
+		}
+		seen[candidate] = struct{}{}
+
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", errors.New("benchprof binary not found; build it at ./bin/benchprof and ensure it is executable")
 }
 
 func writeBenchprofArtifacts(dir string, runs []BenchRun) error {


### PR DESCRIPTION
Closes #524.

## Summary
- Automatically run `benchprof -profiles-dir <profile-dir>` after profile runs when artifacts are written successfully.
- Add non-fatal helper wiring with graceful fallback when `benchprof` is unavailable.
- Keep behavior unchanged when no profile artifacts are emitted.
- Add an integration test (`TestIntegration_ProfileDir_AutoRunsBenchprof`) that uses a fake `benchprof` shim in `PATH`.
- Update CLI docs to reflect automatic `benchprof` execution from `-profile-dir`.

## Testing
- Added/updated integration test coverage for auto-invocation behavior.
