### PR TITLE
outerleaf: add lease-owned decodePayload path for compressed decode callers

### DIFF
--- a/TreeDB/internal/outerleaf/block.go
+++ b/TreeDB/internal/outerleaf/block.go
@@ -54,11 +54,12 @@ var (
 			return &bytesPoolEntry{}
 		},
 	}
-	outerLeafRestartsPool   sync.Pool
-	outerLeafLeaseKeysPool  sync.Pool
-	outerLeafLeaseArenaPool sync.Pool
-	outerLeafKeyLeasePool   sync.Pool
-	outerLeafKeyChunkPool   = sync.Pool{
+	outerLeafRestartsPool     sync.Pool
+	outerLeafLeaseKeysPool    sync.Pool
+	outerLeafLeaseArenaPool   sync.Pool
+	outerLeafKeyLeasePool     sync.Pool
+	outerLeafPayloadLeasePool sync.Pool
+	outerLeafKeyChunkPool     = sync.Pool{
 		New: func() any {
 			return &keyLeaseChunk{}
 		},
@@ -136,6 +137,11 @@ type KeyLease struct {
 	inUse     bool
 }
 
+type payloadLease struct {
+	buf   []byte
+	inUse bool
+}
+
 // Keys returns decoded keys owned by the lease.
 func (l *KeyLease) Keys() [][]byte {
 	if l == nil {
@@ -147,6 +153,10 @@ func (l *KeyLease) Keys() [][]byte {
 // Release returns lease-owned buffers to pools. It is idempotent.
 func (l *KeyLease) Release() {
 	releaseKeyLease(l)
+}
+
+func (l *payloadLease) Release() {
+	releasePayloadLease(l)
 }
 
 // Entry is one key/value record in an outer-leaf block payload.
@@ -362,17 +372,35 @@ func encodePayload(codec uint8, raw []byte, dst []byte) ([]byte, uint8, error) {
 }
 
 func decodePayload(codec uint8, payload []byte, rawLen int, dst []byte) ([]byte, error) {
+	out, _, err := decodePayloadLeaseMode(codec, payload, rawLen, dst, false)
+	return out, err
+}
+
+func decodePayloadLease(codec uint8, payload []byte, rawLen int, dst []byte) ([]byte, *payloadLease, error) {
+	return decodePayloadLeaseMode(codec, payload, rawLen, dst, true)
+}
+
+func decodePayloadLeaseMode(codec uint8, payload []byte, rawLen int, dst []byte, allowLease bool) ([]byte, *payloadLease, error) {
 	if rawLen < 0 {
-		return nil, fmt.Errorf("outerleaf: invalid raw length %d", rawLen)
+		return nil, nil, fmt.Errorf("outerleaf: invalid raw length %d", rawLen)
 	}
 	if limits.MaxRecordSize > 0 && int64(rawLen) > limits.MaxRecordSize {
-		return nil, fmt.Errorf("outerleaf: payload too large %d", rawLen)
+		return nil, nil, fmt.Errorf("outerleaf: payload too large %d", rawLen)
+	}
+
+	// Only borrow pooled decode scratch when caller did not provide a stable
+	// destination and explicitly opted into lease ownership.
+	usePooledLease := allowLease && dst == nil
+	releaseOnErr := func(lease *payloadLease) {
+		if lease != nil {
+			lease.Release()
+		}
 	}
 
 	switch codec {
 	case blockCodecNone:
 		if len(payload) != rawLen {
-			return nil, fmt.Errorf("outerleaf: raw payload length mismatch got=%d want=%d", len(payload), rawLen)
+			return nil, nil, fmt.Errorf("outerleaf: raw payload length mismatch got=%d want=%d", len(payload), rawLen)
 		}
 		if cap(dst) < rawLen {
 			dst = make([]byte, rawLen)
@@ -380,44 +408,74 @@ func decodePayload(codec uint8, payload []byte, rawLen int, dst []byte) ([]byte,
 			dst = dst[:rawLen]
 		}
 		copy(dst, payload)
-		return dst, nil
+		return dst, nil, nil
 	case blockCodecSnappy:
 		decodedLen, err := snappy.DecodedLen(payload)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if decodedLen != rawLen {
-			return nil, fmt.Errorf("outerleaf: snappy decoded length mismatch got=%d want=%d", decodedLen, rawLen)
+			return nil, nil, fmt.Errorf("outerleaf: snappy decoded length mismatch got=%d want=%d", decodedLen, rawLen)
 		}
-		if cap(dst) < rawLen {
-			dst = make([]byte, rawLen)
-		} else {
+
+		var lease *payloadLease
+		switch {
+		case cap(dst) >= rawLen:
 			dst = dst[:rawLen]
+		case usePooledLease:
+			dst = getPooledBytes(rawLen)
+			dst = dst[:rawLen]
+			lease = acquirePayloadLease(dst)
+		default:
+			dst = make([]byte, rawLen)
 		}
+
 		out, err := snappy.Decode(dst, payload)
 		if err != nil {
-			return nil, err
+			releaseOnErr(lease)
+			return nil, nil, err
 		}
 		if len(out) != rawLen {
-			return nil, fmt.Errorf("outerleaf: snappy decode length mismatch got=%d want=%d", len(out), rawLen)
+			releaseOnErr(lease)
+			return nil, nil, fmt.Errorf("outerleaf: snappy decode length mismatch got=%d want=%d", len(out), rawLen)
 		}
-		return out, nil
+		if lease != nil {
+			if len(out) == 0 || (len(dst) > 0 && &out[0] == &dst[0]) {
+				lease.buf = out[:0]
+			} else {
+				// Defensive only: expected output always aliases dst.
+				lease.Release()
+				lease = nil
+			}
+		}
+		return out, lease, nil
 	case blockCodecLZ4:
-		if cap(dst) < rawLen {
-			dst = make([]byte, rawLen)
-		} else {
+		var lease *payloadLease
+		switch {
+		case cap(dst) >= rawLen:
 			dst = dst[:rawLen]
+		case usePooledLease:
+			dst = getPooledBytes(rawLen)
+			dst = dst[:rawLen]
+			lease = acquirePayloadLease(dst)
+		default:
+			dst = make([]byte, rawLen)
 		}
 		n, err := lz4.UncompressBlock(payload, dst)
 		if err != nil {
-			return nil, err
+			releaseOnErr(lease)
+			return nil, nil, err
 		}
 		if n != rawLen {
-			return nil, fmt.Errorf("outerleaf: lz4 decode length mismatch got=%d want=%d", n, rawLen)
+			releaseOnErr(lease)
+			return nil, nil, fmt.Errorf("outerleaf: lz4 decode length mismatch got=%d want=%d", n, rawLen)
 		}
-		return dst[:n], nil
+		if lease != nil {
+			lease.buf = dst[:0]
+		}
+		return dst[:n], lease, nil
 	default:
-		return nil, fmt.Errorf("outerleaf: unknown codec id %d", codec)
+		return nil, nil, fmt.Errorf("outerleaf: unknown codec id %d", codec)
 	}
 }
 
@@ -647,6 +705,31 @@ func releaseKeyLease(lease *KeyLease) {
 	lease.chunkHead = nil
 	lease.chunkTail = nil
 	outerLeafKeyLeasePool.Put(lease)
+}
+
+func acquirePayloadLease(buf []byte) *payloadLease {
+	var lease *payloadLease
+	if v := outerLeafPayloadLeasePool.Get(); v != nil {
+		if l, ok := v.(*payloadLease); ok {
+			lease = l
+		}
+	}
+	if lease == nil {
+		lease = &payloadLease{}
+	}
+	lease.inUse = true
+	lease.buf = buf[:0]
+	return lease
+}
+
+func releasePayloadLease(lease *payloadLease) {
+	if lease == nil || !lease.inUse {
+		return
+	}
+	lease.inUse = false
+	putPooledBytes(lease.buf)
+	lease.buf = nil
+	outerLeafPayloadLeasePool.Put(lease)
 }
 
 func cloneKeySlices(keys [][]byte) [][]byte {
@@ -1184,31 +1267,46 @@ func decodeAndVerifyPayloadMode(payload []byte, rawLen int, codec uint8, scratch
 }
 
 func decodeAndVerifyPayloadModeWithChecksum(payload []byte, rawLen int, codec uint8, scratch []byte, allowRawView bool, verifyChecksum bool) ([]byte, error) {
+	out, lease, err := decodeAndVerifyPayloadLeaseModeWithChecksum(payload, rawLen, codec, scratch, allowRawView, verifyChecksum, false)
+	if lease != nil {
+		lease.Release()
+	}
+	return out, err
+}
+
+func decodeAndVerifyPayloadLeaseWithChecksum(payload []byte, rawLen int, codec uint8, scratch []byte, allowRawView bool, verifyChecksum bool) ([]byte, *payloadLease, error) {
+	return decodeAndVerifyPayloadLeaseModeWithChecksum(payload, rawLen, codec, scratch, allowRawView, verifyChecksum, true)
+}
+
+func decodeAndVerifyPayloadLeaseModeWithChecksum(payload []byte, rawLen int, codec uint8, scratch []byte, allowRawView bool, verifyChecksum bool, allowLease bool) ([]byte, *payloadLease, error) {
 	if blockHeaderSize > len(payload) {
-		return nil, fmt.Errorf("outerleaf: truncated header")
+		return nil, nil, fmt.Errorf("outerleaf: truncated header")
 	}
 	if verifyChecksum {
 		gotChecksum := binary.LittleEndian.Uint32(payload[blockChecksumOff : blockChecksumOff+blockChecksumSize])
 		wantChecksum := crc.ChecksumParts(payload[:blockChecksumOff], payload[blockHeaderSize:])
 		if gotChecksum != wantChecksum {
-			return nil, fmt.Errorf("outerleaf: checksum mismatch")
+			return nil, nil, fmt.Errorf("outerleaf: checksum mismatch")
 		}
 	}
 	if allowRawView && codec == blockCodecNone {
 		raw := payload[blockHeaderSize:]
 		if len(raw) != rawLen {
-			return nil, fmt.Errorf("outerleaf: raw payload length mismatch got=%d want=%d", len(raw), rawLen)
+			return nil, nil, fmt.Errorf("outerleaf: raw payload length mismatch got=%d want=%d", len(raw), rawLen)
 		}
-		return raw, nil
+		return raw, nil, nil
 	}
-	out, err := decodePayload(codec, payload[blockHeaderSize:], rawLen, scratch)
+	out, lease, err := decodePayloadLeaseMode(codec, payload[blockHeaderSize:], rawLen, scratch, allowLease)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if len(out) != rawLen {
-		return nil, fmt.Errorf("outerleaf: decoded payload length mismatch")
+		if lease != nil {
+			lease.Release()
+		}
+		return nil, nil, fmt.Errorf("outerleaf: decoded payload length mismatch")
 	}
-	return out, nil
+	return out, lease, nil
 }
 
 func splitV2RawMeta(raw []byte, entriesLen int, entryCount int, restartInterval int) (entries []byte, restartRaw []byte, restartCount int, err error) {
@@ -2633,9 +2731,12 @@ func DecodeKeysWithVerify(payload []byte, verifyChecksum bool) ([][]byte, error)
 		if rawLen != expected {
 			return nil, fmt.Errorf("outerleaf: invalid raw length %d want %d", rawLen, expected)
 		}
-		raw, err := decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
+		raw, payloadLease, err := decodeAndVerifyPayloadLeaseWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
 		if err != nil {
 			return nil, err
+		}
+		if payloadLease != nil {
+			defer payloadLease.Release()
 		}
 		if keyLen < 0 || keyLen > len(raw) {
 			return nil, fmt.Errorf("outerleaf: invalid key length %d", keyLen)
@@ -2654,22 +2755,12 @@ func DecodeKeysWithVerify(payload []byte, verifyChecksum bool) ([][]byte, error)
 			return nil, fmt.Errorf("outerleaf: invalid raw length %d", rawLen)
 		}
 		restartInterval := int(binary.LittleEndian.Uint16(payload[6:8]))
-		if codec == blockCodecNone {
-			raw, err := decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
-			if err != nil {
-				return nil, err
-			}
-			entries, _, _, err := splitV2RawMeta(raw, entriesLen, entryCount, restartInterval)
-			if err != nil {
-				return nil, err
-			}
-			return decodeStructuredKeys(version, entryCount, entries)
-		}
-		scratch := getPooledBytes(rawLen)
-		defer putPooledBytes(scratch)
-		raw, err := decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, scratch[:0], true, verifyChecksum)
+		raw, payloadLease, err := decodeAndVerifyPayloadLeaseWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
 		if err != nil {
 			return nil, err
+		}
+		if payloadLease != nil {
+			defer payloadLease.Release()
 		}
 		entries, _, _, err := splitV2RawMeta(raw, entriesLen, entryCount, restartInterval)
 		if err != nil {
@@ -2720,9 +2811,12 @@ func DecodeKeysRangeLeaseWithVerify(payload []byte, lower []byte, upper []byte, 
 		if rawLen != expected {
 			return nil, fmt.Errorf("outerleaf: invalid raw length %d want %d", rawLen, expected)
 		}
-		raw, err := decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
+		raw, payloadLease, err := decodeAndVerifyPayloadLeaseWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
 		if err != nil {
 			return nil, err
+		}
+		if payloadLease != nil {
+			defer payloadLease.Release()
 		}
 		if keyLen < 0 || keyLen > len(raw) {
 			return nil, fmt.Errorf("outerleaf: invalid key length %d", keyLen)
@@ -2752,22 +2846,12 @@ func DecodeKeysRangeLeaseWithVerify(payload []byte, lower []byte, upper []byte, 
 			return nil, fmt.Errorf("outerleaf: invalid raw length %d", rawLen)
 		}
 		restartInterval := int(binary.LittleEndian.Uint16(payload[6:8]))
-		if codec == blockCodecNone {
-			raw, err := decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
-			if err != nil {
-				return nil, err
-			}
-			entries, _, _, err := splitV2RawMeta(raw, entriesLen, entryCount, restartInterval)
-			if err != nil {
-				return nil, err
-			}
-			return decodeStructuredKeysBoundedLease(version, entryCount, entries, lower, upper)
-		}
-		scratch := getPooledBytes(rawLen)
-		defer putPooledBytes(scratch)
-		raw, err := decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, scratch[:0], true, verifyChecksum)
+		raw, payloadLease, err := decodeAndVerifyPayloadLeaseWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
 		if err != nil {
 			return nil, err
+		}
+		if payloadLease != nil {
+			defer payloadLease.Release()
 		}
 		entries, _, _, err := splitV2RawMeta(raw, entriesLen, entryCount, restartInterval)
 		if err != nil {
@@ -2817,9 +2901,12 @@ func DecodeLowerBoundAndKeysOnMatchLeaseWithVerify(payload []byte, target []byte
 		if rawLen != expected {
 			return 0, false, false, nil, fmt.Errorf("outerleaf: invalid raw length %d want %d", rawLen, expected)
 		}
-		raw, decErr := decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
+		raw, payloadLease, decErr := decodeAndVerifyPayloadLeaseWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
 		if decErr != nil {
 			return 0, false, false, nil, decErr
+		}
+		if payloadLease != nil {
+			defer payloadLease.Release()
 		}
 		if keyLen < 0 || keyLen > len(raw) {
 			return 0, false, false, nil, fmt.Errorf("outerleaf: invalid key length %d", keyLen)
@@ -2855,17 +2942,12 @@ func DecodeLowerBoundAndKeysOnMatchLeaseWithVerify(payload []byte, target []byte
 			return 0, false, false, nil, fmt.Errorf("outerleaf: invalid raw length %d", rawLen)
 		}
 		restartInterval := int(binary.LittleEndian.Uint16(payload[6:8]))
-
-		var raw []byte
-		if codec == blockCodecNone {
-			raw, err = decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
-		} else {
-			scratch := getPooledBytes(rawLen)
-			defer putPooledBytes(scratch)
-			raw, err = decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, scratch[:0], true, verifyChecksum)
-		}
+		raw, payloadLease, err := decodeAndVerifyPayloadLeaseWithChecksum(payload, rawLen, codec, nil, true, verifyChecksum)
 		if err != nil {
 			return 0, false, false, nil, err
+		}
+		if payloadLease != nil {
+			defer payloadLease.Release()
 		}
 		entries, _, _, splitErr := splitV2RawMeta(raw, entriesLen, entryCount, restartInterval)
 		if splitErr != nil {

--- a/TreeDB/internal/outerleaf/block_test.go
+++ b/TreeDB/internal/outerleaf/block_test.go
@@ -2,10 +2,12 @@ package outerleaf
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"testing"
 
 	"github.com/golang/snappy"
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 	"github.com/snissn/gomap/TreeDB/internal/limits"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -20,6 +22,37 @@ func pseudoRandomBytes(n int) []byte {
 		out[i] = byte((x * 0x2545F4914F6CDD1D) >> 56)
 	}
 	return out
+}
+
+func makeCodecNonePayloadForTest(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	payload := make([]byte, blockHeaderSize+len(raw))
+	copy(payload[:len(blockMagic)], blockMagic[:])
+	payload[4] = blockVersionV1
+	payload[5] = blockCodecNone
+	binary.LittleEndian.PutUint16(payload[blockV1KeyLenOff:blockV1KeyLenOff+2], 0)
+	binary.LittleEndian.PutUint32(payload[blockV1ValueLenOff:blockV1ValueLenOff+4], uint32(len(raw)))
+	binary.LittleEndian.PutUint32(payload[blockV1RawLenOff:blockV1RawLenOff+4], uint32(len(raw)))
+	copy(payload[blockHeaderSize:], raw)
+	checksum := crc.ChecksumParts(payload[:blockChecksumOff], payload[blockHeaderSize:])
+	binary.LittleEndian.PutUint32(payload[blockChecksumOff:blockChecksumOff+blockChecksumSize], checksum)
+	return payload
+}
+
+func drainOuterLeafBytesPoolForTest() {
+	for {
+		v := outerLeafBytesPool.Get()
+		if v == nil {
+			return
+		}
+		entry, ok := v.(*bytesPoolEntry)
+		if !ok || entry == nil {
+			continue
+		}
+		entry.buf = nil
+		entry.next = nil
+		outerLeafBytesEntryPool.Put(entry)
+	}
 }
 
 func TestEncodeDecodeSingleRoundTrip(t *testing.T) {
@@ -215,6 +248,132 @@ func TestDecodePayloadSnappyPreallocatedDstNoAllocs(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Fatalf("expected zero allocs per run, got %.2f", allocs)
+	}
+}
+
+func TestPayloadLeaseReleaseIdempotence(t *testing.T) {
+	raw := bytes.Repeat([]byte("outerleaf-payload-lease|"), 256)
+	encoded := snappy.Encode(nil, raw)
+
+	decoded, lease, err := decodePayloadLease(blockCodecSnappy, encoded, len(raw), nil)
+	if err != nil {
+		t.Fatalf("decodePayloadLease: %v", err)
+	}
+	if lease == nil {
+		t.Fatalf("lease=nil want non-nil")
+	}
+	if !bytes.Equal(decoded, raw) {
+		t.Fatalf("decoded payload mismatch")
+	}
+	lease.Release()
+	lease.Release()
+}
+
+func TestDecodeAndVerifyPayloadLeaseAllowRawViewNoCopy(t *testing.T) {
+	raw := bytes.Repeat([]byte("outerleaf-raw-view"), 128)
+	payload := makeCodecNonePayloadForTest(t, raw)
+
+	decoded, lease, err := decodeAndVerifyPayloadLeaseWithChecksum(payload, len(raw), blockCodecNone, nil, true, true)
+	if err != nil {
+		t.Fatalf("decodeAndVerifyPayloadLeaseWithChecksum: %v", err)
+	}
+	if lease != nil {
+		t.Fatalf("lease=%v want nil", lease)
+	}
+	want := payload[blockHeaderSize:]
+	if !bytes.Equal(decoded, want) {
+		t.Fatalf("decoded payload mismatch")
+	}
+	if len(decoded) > 0 && &decoded[0] != &want[0] {
+		t.Fatalf("allowRawView codec none should return payload view without copy")
+	}
+}
+
+func TestDecodePayloadLeaseSnappyPreallocatedDstNoAllocs(t *testing.T) {
+	raw := bytes.Repeat([]byte("outerleaf-decode-payload-lease|"), 256)
+	encoded := snappy.Encode(nil, raw)
+	dst := make([]byte, len(raw))
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		decoded, lease, err := decodePayloadLease(blockCodecSnappy, encoded, len(raw), dst[:len(raw)])
+		if err != nil {
+			t.Fatalf("decodePayloadLease: %v", err)
+		}
+		if lease != nil {
+			t.Fatalf("lease=%v want nil", lease)
+		}
+		if len(decoded) != len(raw) {
+			t.Fatalf("decoded len=%d want=%d", len(decoded), len(raw))
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("expected zero allocs per run, got %.2f", allocs)
+	}
+}
+
+func TestDecodePayloadLeaseErrorReleasesBorrowedBuffer(t *testing.T) {
+	drainOuterLeafBytesPoolForTest()
+	t.Cleanup(drainOuterLeafBytesPoolForTest)
+
+	rawLen := 128
+	invalid := []byte{0x01, 0x02, 0x03}
+
+	if _, lease, err := decodePayloadLease(blockCodecLZ4, invalid, rawLen, nil); err == nil {
+		t.Fatalf("expected decode error")
+	} else if lease != nil {
+		t.Fatalf("lease=%v want nil", lease)
+	}
+
+	first := getPooledBytes(rawLen)
+	if cap(first) < rawLen {
+		t.Fatalf("cap(first)=%d want >=%d", cap(first), rawLen)
+	}
+	firstProbe := first[:1]
+	firstAddr := &firstProbe[0]
+	putPooledBytes(first[:0])
+
+	if _, lease, err := decodePayloadLease(blockCodecLZ4, invalid, rawLen, nil); err == nil {
+		t.Fatalf("expected decode error on second run")
+	} else if lease != nil {
+		t.Fatalf("lease=%v want nil on second run", lease)
+	}
+
+	second := getPooledBytes(rawLen)
+	if cap(second) < rawLen {
+		t.Fatalf("cap(second)=%d want >=%d", cap(second), rawLen)
+	}
+	secondProbe := second[:1]
+	if &secondProbe[0] != firstAddr {
+		t.Fatalf("borrowed decode buffer was not returned to pool on error path")
+	}
+	putPooledBytes(second[:0])
+}
+
+func TestDecodeAndVerifyPayloadModeWithChecksumCompatibility(t *testing.T) {
+	raw := bytes.Repeat([]byte("outerleaf-wrapper-compat"), 128)
+	payload := makeCodecNonePayloadForTest(t, raw)
+
+	copied, err := decodeAndVerifyPayloadModeWithChecksum(payload, len(raw), blockCodecNone, nil, false, true)
+	if err != nil {
+		t.Fatalf("decodeAndVerifyPayloadModeWithChecksum copy path: %v", err)
+	}
+	if !bytes.Equal(copied, raw) {
+		t.Fatalf("copy path payload mismatch")
+	}
+	want := payload[blockHeaderSize:]
+	if len(copied) > 0 && &copied[0] == &want[0] {
+		t.Fatalf("allowRawView=false should preserve copy semantics")
+	}
+
+	view, err := decodeAndVerifyPayloadModeWithChecksum(payload, len(raw), blockCodecNone, nil, true, true)
+	if err != nil {
+		t.Fatalf("decodeAndVerifyPayloadModeWithChecksum view path: %v", err)
+	}
+	if !bytes.Equal(view, raw) {
+		t.Fatalf("view path payload mismatch")
+	}
+	if len(view) > 0 && &view[0] != &want[0] {
+		t.Fatalf("allowRawView=true should preserve raw-view semantics")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an internal `payloadLease` with idempotent `Release()` and pooled buffer ownership
- introduce lease-aware payload decode helpers:
  - `decodePayloadLease`
  - `decodeAndVerifyPayloadLeaseWithChecksum`
- keep compatibility behavior for existing wrappers by routing legacy decode paths through non-lease mode
- migrate compressed decode hot callers to the lease-aware core:
  - `DecodeKeysWithVerify`
  - `DecodeKeysRangeLeaseWithVerify`
  - `DecodeLowerBoundAndKeysOnMatchLeaseWithVerify`

## Tests Added
- `TestPayloadLeaseReleaseIdempotence`
- `TestDecodeAndVerifyPayloadLeaseAllowRawViewNoCopy`
- `TestDecodePayloadLeaseSnappyPreallocatedDstNoAllocs`
- `TestDecodePayloadLeaseErrorReleasesBorrowedBuffer`
- `TestDecodeAndVerifyPayloadModeWithChecksumCompatibility`

## Notes
- this PR does not change on-disk format or public decode APIs
- benchmark/profile loop was not run in this pass

Closes #529
