### PR TITLE
outerleaf: tighten payload lease lifecycle on decode/caller paths

### DIFF
--- a/TreeDB/db/outerleaf_cache.go
+++ b/TreeDB/db/outerleaf_cache.go
@@ -117,8 +117,12 @@ func (c *outerLeafBlockCache) put(key outerLeafBlockKey, block *outerleaf.Decode
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if idx, ok := s.entries[key]; ok {
+		prevBlock := s.nodes[idx].block
 		s.nodes[idx].block = block
 		s.moveToFront(idx)
+		if prevBlock != nil && prevBlock != block {
+			prevBlock.Release()
+		}
 		return
 	}
 	if s.capacity <= 0 {
@@ -135,8 +139,12 @@ func (c *outerLeafBlockCache) put(key outerLeafBlockKey, block *outerleaf.Decode
 			return
 		}
 		evictedKey := s.nodes[idx].key
+		evictedBlock := s.nodes[idx].block
 		s.unlink(idx)
 		delete(s.entries, evictedKey)
+		if evictedBlock != nil {
+			evictedBlock.Release()
+		}
 	}
 	node := &s.nodes[idx]
 	node.key = key

--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -388,7 +388,11 @@ func (r valueReader) ReadUnsafeFenceBlock(ptr page.ValuePtr) ([]tree.FenceBlockE
 	if !r.fenceLookupModeEnabled() {
 		return nil, false, nil
 	}
+	fromCache := false
 	block := r.cachedOuterLeafBlock(ptr)
+	if block != nil {
+		fromCache = true
+	}
 	if block == nil {
 		raw, err := r.readRawUnsafe(ptr)
 		if err != nil {
@@ -403,21 +407,50 @@ func (r valueReader) ReadUnsafeFenceBlock(ptr page.ValuePtr) ([]tree.FenceBlockE
 		}
 		block = decoded
 	}
-	decoded, err := block.TypedEntries(nil)
+
+	// Blocks skipped from cache admission (blob-ref first entry) or decoded with
+	// caching disabled can release their decode lease after materializing stable
+	// output bytes for the caller.
+	detach := !fromCache && (r.cache == nil || block.FirstKind() == outerleaf.EntryKindBlobRef)
+	if detach {
+		defer block.Release()
+	}
+
+	typed, err := block.TypedEntries(nil)
 	if err != nil {
 		return nil, true, err
 	}
-	entries := make([]tree.FenceBlockEntry, len(decoded))
-	for i := range decoded {
-		val, err := r.resolveLookupResult(outerleaf.LookupResult{
-			Kind:    decoded[i].Kind,
-			Value:   decoded[i].Value,
-			BlobPtr: decoded[i].BlobPtr,
-		}, true)
+	entries := make([]tree.FenceBlockEntry, len(typed))
+	for i := range typed {
+		entry := outerleaf.LookupResult{
+			Kind:    typed[i].Kind,
+			Value:   typed[i].Value,
+			BlobPtr: typed[i].BlobPtr,
+		}
+		val, err := r.resolveLookupResult(entry, true)
 		if err != nil {
 			return nil, true, err
 		}
-		entries[i] = tree.FenceBlockEntry{Key: decoded[i].Key, Value: val}
+		key := typed[i].Key
+		if detach {
+			if len(key) > 0 {
+				keyCopy := make([]byte, len(key))
+				copy(keyCopy, key)
+				key = keyCopy
+			} else if key != nil {
+				key = []byte{}
+			}
+			if entry.Kind == outerleaf.EntryKindInline {
+				if len(val) > 0 {
+					valCopy := make([]byte, len(val))
+					copy(valCopy, val)
+					val = valCopy
+				} else if val != nil {
+					val = []byte{}
+				}
+			}
+		}
+		entries[i] = tree.FenceBlockEntry{Key: key, Value: val}
 	}
 	return entries, true, nil
 }

--- a/TreeDB/db/value_reader_test.go
+++ b/TreeDB/db/value_reader_test.go
@@ -718,3 +718,58 @@ func TestValueReaderBlobRefResolution_ReadUnsafeAppendForKey_CacheHitUsesAppendR
 		t.Fatalf("readUnsafeCalls = %d, want 0", reader.readUnsafeCalls)
 	}
 }
+
+func TestValueReaderReadUnsafeFenceBlock_BlobRefFirstDetachesInlineValues(t *testing.T) {
+	blobPtr := page.ValuePtr{FileID: page.ValueLogFileID(44), Offset: 4096, Length: 8}
+	inlineVal := bytes.Repeat([]byte("inline-v"), 16)
+	outerPayload, err := outerleaf.EncodeTypedEntries(nil, []outerleaf.TypedEntry{
+		{Key: []byte("k1"), Kind: outerleaf.EntryKindBlobRef, BlobPtr: blobPtr},
+		{Key: []byte("k2"), Kind: outerleaf.EntryKindInline, Value: inlineVal},
+	}, uint8(ValueLogBlockSnappy), 8)
+	if err != nil {
+		t.Fatalf("EncodeTypedEntries: %v", err)
+	}
+	outerPtr := page.ValuePtr{FileID: page.ValueLogFileID(45), Offset: 1024, Length: uint32(len(outerPayload))}
+	reader := &stubValueLogReader{
+		payloads: map[page.ValuePtr][]byte{
+			outerPtr: outerPayload,
+			blobPtr:  []byte("blob-val"),
+		},
+	}
+	cache := newOuterLeafBlockCache(8)
+	r := valueReader{
+		vlogs:         reader,
+		outerLeafMode: outerleaf.ModeV2FencePtr,
+		cache:         cache,
+	}
+
+	first, ok, err := r.ReadUnsafeFenceBlock(outerPtr)
+	if err != nil {
+		t.Fatalf("first ReadUnsafeFenceBlock: %v", err)
+	}
+	if !ok {
+		t.Fatalf("first ReadUnsafeFenceBlock ok=false")
+	}
+	second, ok, err := r.ReadUnsafeFenceBlock(outerPtr)
+	if err != nil {
+		t.Fatalf("second ReadUnsafeFenceBlock: %v", err)
+	}
+	if !ok {
+		t.Fatalf("second ReadUnsafeFenceBlock ok=false")
+	}
+	if len(first) != 2 || len(second) != 2 {
+		t.Fatalf("unexpected fence entry lens first=%d second=%d", len(first), len(second))
+	}
+	if !bytes.Equal(first[0].Value, []byte("blob-val")) || !bytes.Equal(second[0].Value, []byte("blob-val")) {
+		t.Fatalf("blob-ref values mismatch")
+	}
+	if !bytes.Equal(first[1].Value, inlineVal) {
+		t.Fatalf("first inline value mismatch")
+	}
+	if !bytes.Equal(second[1].Value, inlineVal) {
+		t.Fatalf("second inline value mismatch")
+	}
+	if _, _, entries, _ := cache.stats(); entries != 0 {
+		t.Fatalf("cache entries = %d, want 0 for blob-ref-first block", entries)
+	}
+}

--- a/TreeDB/internal/outerleaf/block.go
+++ b/TreeDB/internal/outerleaf/block.go
@@ -170,6 +170,7 @@ type DecodedBlock struct {
 	version      uint8
 	entryCount   int
 	raw          []byte
+	rawLease     *payloadLease
 	entries      []byte
 	restartRaw   []byte
 	restartCount int
@@ -187,6 +188,21 @@ type DecodedBlock struct {
 	restartsErr     error
 	restartKeysOnce sync.Once
 	restartKeysErr  error
+	releaseOnce     sync.Once
+}
+
+// Release returns internal lease-owned buffers (if any) to pools.
+// It is safe to call multiple times.
+func (d *DecodedBlock) Release() {
+	if d == nil {
+		return
+	}
+	d.releaseOnce.Do(func() {
+		if d.rawLease != nil {
+			d.rawLease.Release()
+			d.rawLease = nil
+		}
+	})
 }
 
 // Encoder reuses encode scratch buffers across outer-leaf block encodes.
@@ -1765,7 +1781,7 @@ func decodeBlock(payload []byte, scratch []byte, verifyChecksum bool) (*DecodedB
 		if rawLen < 0 || keyLen < 0 || valueLen < 0 {
 			return nil, fmt.Errorf("outerleaf: invalid lengths")
 		}
-		outScratch, err := decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, scratch, true, verifyChecksum)
+		outScratch, rawLease, err := decodeAndVerifyPayloadLeaseWithChecksum(payload, rawLen, codec, scratch, true, verifyChecksum)
 		if err != nil {
 			return nil, err
 		}
@@ -1773,6 +1789,7 @@ func decodeBlock(payload []byte, scratch []byte, verifyChecksum bool) (*DecodedB
 			version:    version,
 			entryCount: 1,
 			raw:        outScratch,
+			rawLease:   rawLease,
 			entries:    outScratch,
 			firstKey:   outScratch[:keyLen],
 			firstKind:  EntryKindInline,
@@ -1788,23 +1805,30 @@ func decodeBlock(payload []byte, scratch []byte, verifyChecksum bool) (*DecodedB
 		if rawLen <= 0 {
 			return nil, fmt.Errorf("outerleaf: invalid raw length %d", rawLen)
 		}
-		outScratch, err := decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, scratch, true, verifyChecksum)
+		outScratch, rawLease, err := decodeAndVerifyPayloadLeaseWithChecksum(payload, rawLen, codec, scratch, true, verifyChecksum)
 		if err != nil {
 			return nil, err
 		}
 		restartInterval := int(binary.LittleEndian.Uint16(payload[6:8]))
 		entries, restartRaw, restartCount, splitErr := splitV2RawMeta(outScratch, entriesLen, entryCount, restartInterval)
 		if splitErr != nil {
+			if rawLease != nil {
+				rawLease.Release()
+			}
 			return nil, splitErr
 		}
 		firstKey, firstValue, err := decodeFirstV2(entries)
 		if err != nil {
+			if rawLease != nil {
+				rawLease.Release()
+			}
 			return nil, err
 		}
 		return &DecodedBlock{
 			version:      version,
 			entryCount:   entryCount,
 			raw:          outScratch,
+			rawLease:     rawLease,
 			entries:      entries,
 			restartRaw:   restartRaw,
 			restartCount: restartCount,
@@ -1822,23 +1846,30 @@ func decodeBlock(payload []byte, scratch []byte, verifyChecksum bool) (*DecodedB
 		if rawLen <= 0 {
 			return nil, fmt.Errorf("outerleaf: invalid raw length %d", rawLen)
 		}
-		outScratch, err := decodeAndVerifyPayloadModeWithChecksum(payload, rawLen, codec, scratch, true, verifyChecksum)
+		outScratch, rawLease, err := decodeAndVerifyPayloadLeaseWithChecksum(payload, rawLen, codec, scratch, true, verifyChecksum)
 		if err != nil {
 			return nil, err
 		}
 		restartInterval := int(binary.LittleEndian.Uint16(payload[6:8]))
 		entries, restartRaw, restartCount, splitErr := splitV2RawMeta(outScratch, entriesLen, entryCount, restartInterval)
 		if splitErr != nil {
+			if rawLease != nil {
+				rawLease.Release()
+			}
 			return nil, splitErr
 		}
 		firstKey, first, err := decodeFirstV3(entries)
 		if err != nil {
+			if rawLease != nil {
+				rawLease.Release()
+			}
 			return nil, err
 		}
 		return &DecodedBlock{
 			version:      version,
 			entryCount:   entryCount,
 			raw:          outScratch,
+			rawLease:     rawLease,
 			entries:      entries,
 			restartRaw:   restartRaw,
 			restartCount: restartCount,

--- a/TreeDB/internal/outerleaf/block_test.go
+++ b/TreeDB/internal/outerleaf/block_test.go
@@ -377,6 +377,31 @@ func TestDecodeAndVerifyPayloadModeWithChecksumCompatibility(t *testing.T) {
 	}
 }
 
+func TestDecodeBlockCompressedPayloadLeaseReleaseIdempotence(t *testing.T) {
+	enc, err := EncodeEntries(nil, []Entry{
+		{Key: []byte("k1"), Value: bytes.Repeat([]byte("v"), 512)},
+		{Key: []byte("k2"), Value: bytes.Repeat([]byte("v"), 512)},
+	}, 0, 4)
+	if err != nil {
+		t.Fatalf("EncodeEntries: %v", err)
+	}
+	if len(enc) < blockHeaderSize || enc[5] == blockCodecNone {
+		t.Fatalf("expected compressed payload for lease coverage, codec=%d", enc[5])
+	}
+	blk, err := DecodeBlock(enc, nil)
+	if err != nil {
+		t.Fatalf("DecodeBlock: %v", err)
+	}
+	if blk.rawLease == nil {
+		t.Fatalf("rawLease=nil want non-nil for compressed decode without caller scratch")
+	}
+	blk.Release()
+	blk.Release()
+	if blk.rawLease != nil {
+		t.Fatalf("rawLease should be cleared after Release")
+	}
+}
+
 func TestEncodeDecodeEntriesLookup(t *testing.T) {
 	codecs := []struct {
 		name  string


### PR DESCRIPTION
## Summary
This is a rework of issue #529 intended to replace/supersede #537.

### Core payload-lease work
- keep lease-aware decode helpers and compatibility wrappers from #537:
  - `decodePayloadLease`
  - `decodeAndVerifyPayloadLeaseWithChecksum`
- keep migrated lease-aware callers:
  - `DecodeKeysWithVerify`
  - `DecodeKeysRangeLeaseWithVerify`
  - `DecodeLowerBoundAndKeysOnMatchLeaseWithVerify`

### Lifecycle tightening added in this PR
- `DecodedBlock` now tracks decode payload lease ownership and exposes idempotent `Release()`
- `decodeBlock` now wires lease ownership into returned `DecodedBlock` for compressed decode paths
- `outerLeafBlockCache` now calls `Release()` when entries are replaced/evicted
- `valueReader.ReadUnsafeFenceBlock` now detaches output bytes on non-cached paths (cache-disabled or blob-ref-first blocks), then releases the decoded block lease deterministically

## Tests Added
- `TestDecodeBlockCompressedPayloadLeaseReleaseIdempotence`
- `TestValueReaderReadUnsafeFenceBlock_BlobRefFirstDetachesInlineValues`
- existing lease tests from #537 retained:
  - lease release idempotence
  - allowRawView+codec-none no-copy path
  - preallocated decode no-alloc behavior
  - error-path lease buffer return
  - wrapper compatibility semantics

## Scope / Compatibility
- no on-disk format changes
- no public API contract changes for decode behavior

## Notes
- benchmark/profile loop was not run in this pass
- supersedes #537 for issue #529 resolution

Closes #529
