### PR TITLE
outerleaf: use stack restart buffers in hot lookup path

### DIFF
--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -193,15 +193,14 @@ func (s *outerLeafFenceDecodeLeaseSet) release(ctx *outerLeafFenceDecodeContext)
 		releaseOuterLeafFenceDecodeContext(ctx)
 		return
 	}
+	// Apply retention bounds before enqueue so acquire() never observes a context
+	// while its scratch field is being mutated.
+	if cap(ctx.scratch) > outerLeafFenceDecodeScratchMaxRetain {
+		ctx.scratch = nil
+	}
 	retained := false
 	select {
 	case s.pool <- ctx:
-		// Retained lease contexts must obey the same scratch cap as the global
-		// fence decode scratch pool; otherwise one oversized scratch can be pinned
-		// per reader-local slot.
-		if cap(ctx.scratch) > outerLeafFenceDecodeScratchMaxRetain {
-			ctx.scratch = nil
-		}
 		retained = true
 	default:
 	}

--- a/TreeDB/internal/outerleaf/block_test.go
+++ b/TreeDB/internal/outerleaf/block_test.go
@@ -1296,7 +1296,7 @@ func TestGetPooledLeaseKeys_WarmReuseAndClearsBuffer(t *testing.T) {
 	warm[1] = []byte("right")
 	putPooledLeaseKeys(warm)
 	if warm[0] != nil || warm[1] != nil {
-		t.Fatalf("expected putPooledLeaseKeys to clear source buffer, got=%v", warm[:2])
+		t.Fatalf("expected put to clear caller buffer, got=%v", warm[:2])
 	}
 
 	got := getPooledLeaseKeys(1)
@@ -1306,20 +1306,26 @@ func TestGetPooledLeaseKeys_WarmReuseAndClearsBuffer(t *testing.T) {
 	if len(got) != 0 {
 		t.Fatalf("len(got)=%d want=0", len(got))
 	}
-	if cap(got) >= 1 {
-		got = got[:1]
-		if got[0] != nil {
-			t.Fatalf("expected cleared pooled entry, got=%v", got[0])
+	// sync.Pool may drop warm entries between Put/Get; only assert warm reuse
+	// when a warmed-capacity buffer is actually returned.
+	if cap(got) >= cap(warm) {
+		got = got[:2]
+		if got[0] != nil || got[1] != nil {
+			t.Fatalf("expected cleared pooled entries, got=%v", got)
 		}
 		got = got[:0]
 	}
 
-	got = append(got, []byte("mutated"))
+	got = got[:1]
+	got[0] = []byte("mutated")
 	putPooledLeaseKeys(got[:0])
+	if got[0] != nil {
+		t.Fatalf("expected put to clear mutated entry")
+	}
 
 	got = getPooledLeaseKeys(1)
 	if cap(got) < 1 {
-		t.Fatalf("cap(got)=%d want >=1 on warm reuse", cap(got))
+		t.Fatalf("cap(got)=%d want >=1 on reuse", cap(got))
 	}
 	if len(got) != 0 {
 		t.Fatalf("len(got)=%d want=0 on warm reuse", len(got))


### PR DESCRIPTION
## Summary
- avoid `sync.Pool` restart-slice churn in hot v2/v3 lookup paths
- decode restart tables into a small stack buffer when restart count is small
- retain existing pooled fallback for larger restart tables

## Why
With random parallel reads and outer-leaf no-cache mode, restart-table decode is on the hot path for every lookup. Small restart tables dominate this workload and were still going through shared pools, creating extra cross-worker coordination overhead.

## Validation
- `go test ./TreeDB/internal/outerleaf ./TreeDB/db`
- `make unified-bench`
- `./bin/unified-bench ... -treedb-outer-leaf-block-cache-entries=0 -test random_read_parallel -read-workers=4` => `4,275,762`
- `./bin/unified-bench ... -treedb-outer-leaf-block-cache-entries=0 -test random_read_parallel -read-workers=8` => `5,715,871`

## Notes
- stacked on top of #555
