### PR TITLE
caching/memtable: harden iterator lease lifecycle

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -13385,6 +13385,11 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 	if !backendRangeKnown || overlapsQuery(start, end, backendRange) {
 		diskIter, err := db.backend.Iterator(start, end)
 		if err != nil {
+			for i := range sources {
+				if sources[i].Iter != nil {
+					_ = sources[i].Iter.Close()
+				}
+			}
 			return nil, err
 		}
 

--- a/TreeDB/caching/iterator_lease_test.go
+++ b/TreeDB/caching/iterator_lease_test.go
@@ -1,0 +1,194 @@
+package caching
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+)
+
+func clearQueueLockedForIteratorLeaseTest(db *DB) {
+	db.queue = nil
+	db.queueShardIDs = nil
+	db.queueLaneIDs = nil
+	db.queueIDs = nil
+	db.queueEnqueueNS = nil
+	db.queueRanges = nil
+	db.queueWALPaths = nil
+	db.queueValueLogPaths = nil
+	db.queueBacklogBytes.Store(0)
+}
+
+func TestIterator_QueuedViewLeaseHeldUntilClose(t *testing.T) {
+	backend := NewMockBackend()
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.Set([]byte("k2"), []byte("v2")); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := db.Set([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+
+	db.mu.Lock()
+	if err := db.rotateMemtableLocked(false); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("rotate: %v", err)
+	}
+	db.mu.Unlock()
+
+	view := db.memtables.Load()
+	if view == nil || len(view.queue) != 1 {
+		t.Fatalf("expected one queued memtable view, got=%v", view)
+	}
+	queued, ok := view.queue[0].(*memtable.AppendOnly)
+	if !ok {
+		t.Fatalf("queued memtable type=%T want *memtable.AppendOnly", view.queue[0])
+	}
+	if refs := view.refs.Load(); refs != 1 {
+		t.Fatalf("view refs before iterator=%d want=1", refs)
+	}
+
+	it, err := db.Iterator(nil, nil)
+	if err != nil {
+		t.Fatalf("iterator: %v", err)
+	}
+
+	if refs := view.refs.Load(); refs != 2 {
+		t.Fatalf("view refs while iterator open=%d want=2", refs)
+	}
+
+	db.mu.Lock()
+	db.queueRetiredMemtableLocked(queued)
+	clearQueueLockedForIteratorLeaseTest(db)
+	db.publishMemtablesLocked()
+	db.mu.Unlock()
+
+	if refs := view.refs.Load(); refs != 1 {
+		t.Fatalf("view refs after publish with iterator open=%d want=1", refs)
+	}
+	if got := queued.Len(); got != 2 {
+		t.Fatalf("queued memtable reset too early len=%d want=2", got)
+	}
+
+	seen := map[string]string{}
+	for it.Valid() {
+		seen[string(it.Key())] = string(it.Value())
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if len(seen) != 2 || seen["k1"] != "v1" || seen["k2"] != "v2" {
+		t.Fatalf("iterator values=%v want map[k1:v1 k2:v2]", seen)
+	}
+
+	if err := it.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+	if refs := view.refs.Load(); refs != 0 {
+		t.Fatalf("view refs after first close=%d want=0", refs)
+	}
+	if got := queued.Len(); got != 0 {
+		t.Fatalf("queued memtable len after first close=%d want=0", got)
+	}
+
+	if err := it.Close(); err != nil {
+		t.Fatalf("close second: %v", err)
+	}
+	if refs := view.refs.Load(); refs != 0 {
+		t.Fatalf("view refs after second close=%d want=0", refs)
+	}
+}
+
+type failingIteratorBackend struct {
+	*MockBackend
+	err error
+}
+
+func (b *failingIteratorBackend) Iterator(start, end []byte) (iterator.UnsafeIterator, error) {
+	return nil, b.err
+}
+
+func TestIterator_BackendErrorClosesQueuedIterators(t *testing.T) {
+	backend := &failingIteratorBackend{
+		MockBackend: NewMockBackend(),
+		err:         errors.New("backend iterator boom"),
+	}
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.Set([]byte("k2"), []byte("v2")); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := db.Set([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+
+	db.mu.Lock()
+	if err := db.rotateMemtableLocked(false); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("rotate: %v", err)
+	}
+	db.backendRangeKnown = true
+	db.backendRange = keyRange{valid: true, min: []byte("a"), max: []byte("z")}
+	db.mu.Unlock()
+	db.backendRangeInit.Do(func() {})
+
+	view := db.memtables.Load()
+	if view == nil || len(view.queue) != 1 {
+		t.Fatalf("expected one queued memtable view, got=%v", view)
+	}
+	queued, ok := view.queue[0].(*memtable.AppendOnly)
+	if !ok {
+		t.Fatalf("queued memtable type=%T want *memtable.AppendOnly", view.queue[0])
+	}
+
+	if _, err := db.Iterator(nil, nil); err == nil {
+		t.Fatalf("expected iterator error")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		db.mu.Lock()
+		db.queueRetiredMemtableLocked(queued)
+		clearQueueLockedForIteratorLeaseTest(db)
+		db.publishMemtablesLocked()
+		db.mu.Unlock()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("publish blocked; queued iterator lease likely leaked on backend error")
+	}
+
+	if refs := view.refs.Load(); refs != 0 {
+		t.Fatalf("view refs after publish=%d want=0", refs)
+	}
+	if got := queued.Len(); got != 0 {
+		t.Fatalf("queued memtable len after publish=%d want=0", got)
+	}
+}

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -77,6 +77,10 @@ type AppendOnly struct {
 	frozen      bool
 	hasLast     bool
 	lastIdx     int
+
+	iteratorLeaseMu   sync.Mutex
+	iteratorLeaseCond *sync.Cond
+	iteratorLeases    int
 }
 
 func (*AppendOnly) StableUnsafeIteratorSlices() bool { return true }
@@ -676,9 +680,41 @@ func (m *AppendOnly) Freeze() {
 	m.mu.Unlock()
 }
 
+func (m *AppendOnly) acquireIteratorLeaseLocked() {
+	m.iteratorLeaseMu.Lock()
+	if m.iteratorLeaseCond == nil {
+		m.iteratorLeaseCond = sync.NewCond(&m.iteratorLeaseMu)
+	}
+	m.iteratorLeases++
+	m.iteratorLeaseMu.Unlock()
+}
+
+func (m *AppendOnly) releaseIteratorLease() {
+	m.iteratorLeaseMu.Lock()
+	if m.iteratorLeases > 0 {
+		m.iteratorLeases--
+		if m.iteratorLeases == 0 && m.iteratorLeaseCond != nil {
+			m.iteratorLeaseCond.Broadcast()
+		}
+	}
+	m.iteratorLeaseMu.Unlock()
+}
+
+func (m *AppendOnly) waitIteratorLeasesLocked() {
+	m.iteratorLeaseMu.Lock()
+	for m.iteratorLeases > 0 {
+		if m.iteratorLeaseCond == nil {
+			m.iteratorLeaseCond = sync.NewCond(&m.iteratorLeaseMu)
+		}
+		m.iteratorLeaseCond.Wait()
+	}
+	m.iteratorLeaseMu.Unlock()
+}
+
 func (m *AppendOnly) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.waitIteratorLeasesLocked()
 	for i := 0; i < m.count; i++ {
 		ent := &m.entries[i]
 		ent.ptr = page.ValuePtr{}
@@ -774,11 +810,14 @@ func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 	if m.frozen {
 		ptrs := getAppendOnlyIteratorPtrs(len(snapshotPtrs))
 		copy(ptrs, snapshotPtrs)
+		m.acquireIteratorLeaseLocked()
 		m.mu.Unlock()
 		it := &appendOnlyIterator{
 			entryPtrs:       ptrs,
 			end:             end,
 			pooledEntryPtrs: true,
+			leaseOwner:      m,
+			leaseHeld:       true,
 		}
 		if start != nil {
 			it.Seek(start)
@@ -814,6 +853,8 @@ type appendOnlyIterator struct {
 	mu              *sync.RWMutex
 	pooledEntries   bool
 	pooledEntryPtrs bool
+	leaseOwner      *AppendOnly
+	leaseHeld       bool
 }
 
 func (it *appendOnlyIterator) len() int {
@@ -947,6 +988,11 @@ func (it *appendOnlyIterator) Close() error {
 		putAppendOnlyIteratorPtrs(it.entryPtrs)
 		it.pooledEntryPtrs = false
 	}
+	if it.leaseHeld && it.leaseOwner != nil {
+		it.leaseOwner.releaseIteratorLease()
+		it.leaseHeld = false
+	}
+	it.leaseOwner = nil
 	it.entries = nil
 	it.entryPtrs = nil
 	return nil

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -2,6 +2,7 @@ package memtable
 
 import (
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/snissn/gomap/TreeDB/node"
@@ -115,8 +116,53 @@ func TestAppendOnlyFrozenUnorderedIteratorUsesPointerSnapshot(t *testing.T) {
 	if it.entryPtrs == nil || len(it.entryPtrs) != 2 {
 		t.Fatalf("unexpected pointer snapshot len=%d", len(it.entryPtrs))
 	}
+	if !it.leaseHeld || it.leaseOwner != m {
+		t.Fatalf("frozen unordered iterator should hold memtable lease until close")
+	}
 	if err := it.Close(); err != nil {
 		t.Fatalf("Close(): %v", err)
+	}
+}
+
+func TestAppendOnlyFrozenUnorderedIteratorBlocksResetUntilClose(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	m.Set([]byte("k2"), []byte("v2"))
+	m.Set([]byte("k1"), []byte("v1")) // force unordered iterator path
+	m.Freeze()
+
+	rawIt := m.NewIterator(nil, nil)
+	it, ok := rawIt.(*appendOnlyIterator)
+	if !ok {
+		t.Fatalf("unexpected iterator type %T", rawIt)
+	}
+	if !it.leaseHeld || it.leaseOwner != m {
+		t.Fatalf("expected frozen iterator to hold a memtable lease")
+	}
+
+	resetDone := make(chan struct{})
+	go func() {
+		m.Reset()
+		close(resetDone)
+	}()
+
+	select {
+	case <-resetDone:
+		_ = it.Close()
+		t.Fatalf("Reset completed while frozen iterator was still open")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	if err := it.Close(); err != nil {
+		t.Fatalf("Close(): %v", err)
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("Close() second: %v", err)
+	}
+
+	select {
+	case <-resetDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Reset did not proceed after iterator close")
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR merges only P1 from issue #560 as a correctness-focused fix.

It hardens iterator/memtable lifetime semantics to prevent use-after-release hazards in queued/frozen iterator paths.

## Changes
- Hold append-only frozen iterator lease until iterator close.
- Make append-only reset wait for active iterator leases.
- Ensure queued iterators are closed if backend iterator creation fails.
- Add regression tests for lease lifecycle and backend error cleanup.

## Scope
- Intentionally excludes P2/P3/P4 performance-tuning branches due to mixed perf evidence.

## Files
- `TreeDB/caching/db.go`
- `TreeDB/caching/iterator_lease_test.go`
- `TreeDB/internal/memtable/append_only.go`
- `TreeDB/internal/memtable/append_only_pool_test.go`

## Validation
- `go test ./TreeDB/caching ./TreeDB/internal/memtable -count=1`
- `go test -race ./TreeDB/caching ./TreeDB/internal/memtable -run 'Iterator|Memtable|Snapshot|RCU' -count=1`
