### PR TITLE
treedb: deep alloc reductions for batch and fence paths

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -13580,6 +13580,7 @@ type Batch struct {
 	entries      []batch.Entry
 	backend      batch.Interface
 	size         int
+	copyArena    []byte
 	walBuf       []logRecord
 	shardIdxs    []int
 	eligibleIdxs []int
@@ -13637,6 +13638,11 @@ func (b *Batch) Reset() {
 	if b.shardEntries != nil {
 		b.shardEntries = b.shardEntries[:0]
 	}
+	if cap(b.copyArena) > batchCopyArenaMaxRetain {
+		b.copyArena = nil
+	} else if b.copyArena != nil {
+		b.copyArena = b.copyArena[:0]
+	}
 	b.size = 0
 	b.walBuf = b.walBuf[:0]
 	b.streamEligible = true
@@ -13650,6 +13656,48 @@ func (b *Batch) Reset() {
 	b.dictBytesValid = false
 }
 
+func (b *Batch) arenaCopy(n int) []byte {
+	if n == 0 {
+		return nil
+	}
+	if cap(b.copyArena)-len(b.copyArena) < n {
+		chunkCap := cap(b.copyArena) * 2
+		if chunkCap < batchCopyArenaMinChunk {
+			chunkCap = batchCopyArenaMinChunk
+		}
+		if chunkCap < n {
+			chunkCap = n
+		}
+		// Switch to a fresh chunk when exhausted so existing entry slices keep
+		// their backing arrays without per-op allocations.
+		b.copyArena = make([]byte, 0, chunkCap)
+	}
+	start := len(b.copyArena)
+	b.copyArena = b.copyArena[:start+n]
+	return b.copyArena[start : start+n : start+n]
+}
+
+func (b *Batch) cloneKey(key []byte) []byte {
+	dst := b.arenaCopy(len(key))
+	copy(dst, key)
+	return dst
+}
+
+func (b *Batch) cloneValue(value []byte) []byte {
+	dst := b.arenaCopy(len(value))
+	copy(dst, value)
+	return dst
+}
+
+func (b *Batch) cloneKeyValue(key, value []byte) ([]byte, []byte) {
+	buf := b.arenaCopy(len(key) + len(value))
+	keyCopy := buf[:len(key):len(key)]
+	copy(keyCopy, key)
+	valCopy := buf[len(key):]
+	copy(valCopy, value)
+	return keyCopy, valCopy
+}
+
 func (b *Batch) Set(key, value []byte) error {
 	if b.closed {
 		return ErrBatchClosed
@@ -13661,8 +13709,7 @@ func (b *Batch) Set(key, value []byte) error {
 		return ErrValueNil
 	}
 
-	keyCopy := append([]byte(nil), key...)
-	valCopy := append([]byte(nil), value...)
+	keyCopy, valCopy := b.cloneKeyValue(key, value)
 	if b.backend != nil {
 		b.batchRange.add(keyCopy)
 		b.size += len(keyCopy) + len(valCopy)
@@ -13750,7 +13797,7 @@ func (b *Batch) Delete(key []byte) error {
 		return ErrKeyEmpty
 	}
 
-	keyCopy := append([]byte(nil), key...)
+	keyCopy := b.cloneKey(key)
 	if b.backend != nil {
 		b.batchRange.add(keyCopy)
 		b.size += len(keyCopy)
@@ -13829,9 +13876,9 @@ func (b *Batch) SetOps(ops []batch.Entry) error {
 		copied := make([]batch.Entry, len(ops))
 		for i, op := range ops {
 			copiedOp := op
-			copiedOp.Key = append([]byte(nil), op.Key...)
+			copiedOp.Key = b.cloneKey(op.Key)
 			if op.Value != nil {
-				copiedOp.Value = append([]byte(nil), op.Value...)
+				copiedOp.Value = b.cloneValue(op.Value)
 			}
 			copied[i] = copiedOp
 			b.size += len(copiedOp.Key) + len(copiedOp.Value)
@@ -13841,9 +13888,11 @@ func (b *Batch) SetOps(ops []batch.Entry) error {
 	}
 	for _, op := range ops {
 		copied := op
-		copied.Key = append([]byte(nil), op.Key...)
 		if op.Value != nil {
-			copied.Value = append([]byte(nil), op.Value...)
+			copied.Key, copied.Value = b.cloneKeyValue(op.Key, op.Value)
+		} else {
+			copied.Key = b.cloneKey(op.Key)
+			copied.Value = nil
 		}
 		if b.streamEligible {
 			if b.firstKey == nil {
@@ -13868,6 +13917,8 @@ const (
 	// Only fan out value-log appends across multiple lanes when a batch is large
 	// enough to amortize per-lane setup and goroutine overhead.
 	multiLaneValueLogMinRecords = 1024
+	batchCopyArenaMinChunk      = 4 << 10
+	batchCopyArenaMaxRetain     = 1 << 20
 )
 
 func (b *Batch) maybeSwitchToStreaming() {

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -49,25 +49,22 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 		arenaCap = getManyMaxArenaBytes
 	}
 	arena := make([]byte, 0, arenaCap)
+	emptyValue := []byte{}
 	for i, key := range keys {
-		val, err := snap.GetUnsafe(key)
+		start := len(arena)
+		nextArena, err := snap.GetAppend(key, arena)
 		if err == tree.ErrKeyNotFound {
 			continue
 		}
 		if err != nil {
 			return nil, err
 		}
-		if val == nil {
+		arena = nextArena
+		if len(arena) == start {
+			out[i] = emptyValue
 			continue
 		}
-		n := len(val)
-		if n == 0 {
-			out[i] = []byte{}
-			continue
-		}
-		start := len(arena)
-		arena = append(arena, val...)
-		out[i] = arena[start : start+n : start+n]
+		out[i] = arena[start:len(arena):len(arena)]
 	}
 	return out, nil
 }

--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -45,6 +45,11 @@ type cacheRangeFenceKeysLease struct {
 	inUse      bool
 }
 
+type cacheFenceBlockLease struct {
+	cacheLease outerLeafBlockCacheLease
+	inUse      bool
+}
+
 var staticFenceKeysLeasePool = sync.Pool{
 	New: func() any {
 		return &staticFenceKeysLease{}
@@ -60,6 +65,18 @@ var cacheFenceKeysLeasePool = sync.Pool{
 var cacheRangeFenceKeysLeasePool = sync.Pool{
 	New: func() any {
 		return &cacheRangeFenceKeysLease{}
+	},
+}
+
+var cacheFenceBlockLeasePool = sync.Pool{
+	New: func() any {
+		return &cacheFenceBlockLease{}
+	},
+}
+
+var fenceBlockDecodeLeasePool = sync.Pool{
+	New: func() any {
+		return &fenceBlockDecodeLease{}
 	},
 }
 
@@ -139,6 +156,23 @@ func (l *cacheRangeFenceKeysLease) Release() {
 	l.cacheLease = outerLeafBlockCacheLease{}
 	l.inUse = false
 	cacheRangeFenceKeysLeasePool.Put(l)
+}
+
+func acquireCacheFenceBlockLease(cacheLease outerLeafBlockCacheLease) *cacheFenceBlockLease {
+	lease := cacheFenceBlockLeasePool.Get().(*cacheFenceBlockLease)
+	lease.cacheLease = cacheLease
+	lease.inUse = true
+	return lease
+}
+
+func (l *cacheFenceBlockLease) Release() {
+	if l == nil || !l.inUse {
+		return
+	}
+	l.cacheLease.Release()
+	l.cacheLease = outerLeafBlockCacheLease{}
+	l.inUse = false
+	cacheFenceBlockLeasePool.Put(l)
 }
 
 const outerLeafLookupScratchMaxRetain = 1 << 20
@@ -357,6 +391,14 @@ type fenceBlockDecodeLease struct {
 	released bool
 }
 
+func acquireFenceBlockDecodeLease(block *outerleaf.DecodedBlock, scratch []byte) *fenceBlockDecodeLease {
+	lease := fenceBlockDecodeLeasePool.Get().(*fenceBlockDecodeLease)
+	lease.block = block
+	lease.scratch = scratch
+	lease.released = false
+	return lease
+}
+
 func (l *fenceBlockDecodeLease) Release() {
 	if l == nil || l.released {
 		return
@@ -370,6 +412,7 @@ func (l *fenceBlockDecodeLease) Release() {
 	}
 	outerLeafFenceDecodeScratchPut(l.scratch)
 	l.scratch = nil
+	fenceBlockDecodeLeasePool.Put(l)
 }
 
 type unsafeAppendReader interface {
@@ -1180,12 +1223,9 @@ func (r valueReader) ReadUnsafeFenceBlockLeaseInto(ptr page.ValuePtr, dst []tree
 			return nil, nil, true, decErr
 		}
 		block = decoded
-		lease = &fenceBlockDecodeLease{
-			block:   decoded,
-			scratch: nextScratch,
-		}
+		lease = acquireFenceBlockDecodeLease(decoded, nextScratch)
 	} else if cacheLease.ref != nil {
-		lease = &cacheLease
+		lease = acquireCacheFenceBlockLease(cacheLease)
 	}
 	if cap(dst) < block.EntryCount() {
 		dst = make([]tree.FenceBlockEntry, 0, block.EntryCount())


### PR DESCRIPTION
## Summary
This PR is a focused deep-allocation pass for TreeDB `v2_fenceptr` with minimal behavioral change.

It targets three dominant allocation sites from recent profiles:
1. `caching.(*Batch).Set/Delete/SetOps`
2. `valueReader.ReadUnsafeFenceBlockLeaseInto`
3. `DB.GetMany` read path (`cloneInlineValueIfNeeded`-driven churn)

## Changes
- `TreeDB/caching/db.go`
  - Added an internal chunked copy arena on `Batch` to avoid per-op heap objects while preserving `Set/Delete` copy semantics.
  - Updated `Set`, `Delete`, and `SetOps` to clone through the arena.
- `TreeDB/db/value_reader.go`
  - Added pooled lease wrappers for fence block decode leases and cache leases.
  - `ReadUnsafeFenceBlockLeaseInto` now acquires pooled lease objects instead of allocating per call.
- `TreeDB/db/api.go`
  - `DB.GetMany` now uses `Snapshot.GetAppend` into a shared arena (single-copy path), removing clone-then-copy for inline fence values.

## Targeted A/B (cache on, `-treedb-index-outer-leaf-mode=v2_fenceptr`)
- `batch_random`
  - alloc objects: `579,491 -> 9,687` (`-98.33%`)
  - ops/s: `3,613,759 -> 4,196,334` (`+16.12%`)
- `batch_delete`
  - alloc objects: `329,878 -> 2,328` (`-99.29%`)
  - ops/s: `7,585,527 -> 15,701,504` (`+106.99%`)
- `random_read_batch`
  - alloc objects: `509,752 -> 16,133` (`-96.84%`)
  - ops/s: `703,984 -> 876,144` (`+24.46%`)
- `full_scan`
  - alloc objects: `196,776 -> 18` (`-99.99%`)
  - ops/s: `16,626,100 -> 16,716,113` (`+0.54%`)

## Cache-off sanity (`-treedb-outer-leaf-block-cache-entries=0`)
- `batch_random`: `3,179,310 -> 3,730,292` (`+17.3%`), allocs `942,068 -> 4,642`
- `batch_delete`: `12,737,109 -> 14,191,493` (`+11.4%`), allocs `172,815 -> 2,704`
- `random_read_batch`: `945,159 -> 965,247` (`+2.1%`), allocs `538,585 -> 5,613`
- `full_scan`: `16,638,474 -> 16,969,705` (`+2.0%`), allocs `209,852 -> 455`

## Validation
- `go test ./TreeDB/db -count=1`
- `go test ./TreeDB/caching -count=1`
- `go test ./TreeDB/tree -count=1`

## Notes / follow-up
- This PR intentionally does not alter on-disk formats or cache admission policy semantics.
- Remaining notable allocator in write-heavy mixed tests is `caching.(*Batch).writeRegular`; propose a follow-up single-function pass.
