### PR TITLE
caching: pre-size delete-only Batch arena copy chunk

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3048,20 +3048,21 @@ type DB struct {
 	checkpointing  atomic.Bool
 
 	// Level 0 (Memory)
-	mutableShards    []memShard
-	mutableShardMask uint64
-	mutableBytes     atomic.Int64
-	mutableThreshold atomic.Int64
-	rotatePending    atomic.Bool
-	queue            []memtable.Table
-	queueShardIDs    []uint16
-	queueLaneIDs     []uint16
-	queueIDs         []uint64
-	queueEnqueueNS   []int64
-	nextQueueID      atomic.Uint64
-	batchEntryHint   atomic.Int32
-	batchEntriesPool sync.Pool
-	batchIntPool     sync.Pool
+	mutableShards         []memShard
+	mutableShardMask      uint64
+	mutableBytes          atomic.Int64
+	mutableThreshold      atomic.Int64
+	rotatePending         atomic.Bool
+	queue                 []memtable.Table
+	queueShardIDs         []uint16
+	queueLaneIDs          []uint16
+	queueIDs              []uint64
+	queueEnqueueNS        []int64
+	nextQueueID           atomic.Uint64
+	batchEntryHint        atomic.Int32
+	batchEntriesPool      sync.Pool
+	batchShardEntriesPool sync.Pool
+	batchIntPool          sync.Pool
 
 	// memtables is an RCU-style snapshot of (mutable, queue, queueRanges).
 	// Readers load it atomically to avoid holding db.mu around memtable access.
@@ -13697,6 +13698,33 @@ func (db *DB) putBatchEntries(entries []batch.Entry) {
 	db.batchEntriesPool.Put(full[:0])
 }
 
+func (db *DB) getBatchShardEntries(minCap int) []batch.Entry {
+	if minCap < 0 {
+		minCap = 0
+	}
+	if db != nil {
+		if pooled := db.batchShardEntriesPool.Get(); pooled != nil {
+			entries := pooled.([]batch.Entry)
+			if cap(entries) >= minCap {
+				return entries[:0]
+			}
+		}
+	}
+	return make([]batch.Entry, 0, minCap)
+}
+
+func (db *DB) putBatchShardEntries(entries []batch.Entry) {
+	if db == nil || cap(entries) == 0 {
+		return
+	}
+	if cap(entries) > batchEntriesPoolMaxRetain {
+		return
+	}
+	full := entries[:cap(entries)]
+	clear(full)
+	db.batchShardEntriesPool.Put(full[:0])
+}
+
 func (db *DB) getBatchIntSlice(minCap int) []int {
 	if minCap < 0 {
 		minCap = 0
@@ -14877,7 +14905,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			if count > 0 {
 				entries := shardEntries[i]
 				if cap(entries) < count {
-					entries = make([]batch.Entry, 0, count)
+					entries = b.db.getBatchShardEntries(count)
 				} else {
 					entries = entries[:0]
 				}
@@ -15253,6 +15281,15 @@ func (b *Batch) Close() error {
 		for i := range full {
 			if full[i] != nil {
 				b.db.putBatchIntSlice(full[i])
+				full[i] = nil
+			}
+		}
+	}
+	if b.db != nil && b.shardEntries != nil && cap(b.shardEntries) > 0 {
+		full := b.shardEntries[:cap(b.shardEntries)]
+		for i := range full {
+			if full[i] != nil {
+				b.db.putBatchShardEntries(full[i])
 				full[i] = nil
 			}
 		}


### PR DESCRIPTION
## Summary
- remove delete-only tracking from `Batch`
- generalize `Batch.arenaCopy` first-chunk sizing for **both put and delete paths**
- seed first chunk from reserved entry capacity (`cap(entries) * firstCopySize`) with a safety cap (`2 MiB`) to reduce geometric growth churn

## Why
Put-heavy and delete-heavy profiles both showed `(*Batch).arenaCopy` + `(*Batch).writeRegular` as top allocation hot spots. The previous pass biased toward delete-only batches; this pass applies one shared mechanism to both operation types.

## Validation
- `go test ./TreeDB/caching -count=1`
- `go test ./TreeDB/db -run 'OuterLeafBlockCache|ValueReader|SnapshotPool' -count=1`

### A/B focused runs (same flags, `v2_fenceptr`, isolated tests)
Current branch (`6b303ec5`) vs prior commit (`8a93268f`):

1. `batch_random`
- ops/s: `5,079,066` vs `3,999,579` (**+27.0%**)
- alloc_space: `(*Batch).arenaCopy` `68.42MB` vs `130.13MB` (**-47.4%**)
- alloc_space: `(*Batch).writeRegular` `34.99MB` vs `45.97MB` (**-23.9%**)

2. `batch_write`
- ops/s: `19,352,217` vs `15,280,298` (**+26.6%**)

3. `batch_delete`
- ops/s: `28,436,356` vs `26,402,233` (**+7.7%**) in one paired run
- repeat runs were noisy but remained directionally non-regressive in throughput

## Notes
- chained on #565 for review simplicity
- behavior is unchanged; this is allocation-shape tuning only
