### PR TITLE
caching: adaptive batch arena sizing with high-water decay

### DIFF
--- a/TreeDB/caching/batch_arena_sizing_test.go
+++ b/TreeDB/caching/batch_arena_sizing_test.go
@@ -1,0 +1,103 @@
+package caching
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+)
+
+func TestBatchArenaCopy_IgnoresEntrySliceCapacityForFirstChunk(t *testing.T) {
+	b := &Batch{
+		// Simulate a large pooled entry backing array from prior workload phase.
+		entries:      make([]batch.Entry, 0, 8192),
+		copyArenaCap: batchCopyArenaUnsizedInit,
+	}
+
+	_ = b.arenaCopy(136)
+
+	if got, want := cap(b.copyArena), batchCopyArenaUnsizedInit; got != want {
+		t.Fatalf("copyArena first chunk cap=%d want=%d", got, want)
+	}
+}
+
+func TestBatchCopyArenaInitCapForEntries(t *testing.T) {
+	t.Run("unsized", func(t *testing.T) {
+		if got, want := batchCopyArenaInitCapForEntries(0), batchCopyArenaUnsizedInit; got != want {
+			t.Fatalf("unsized init cap=%d want=%d", got, want)
+		}
+	})
+
+	t.Run("sized", func(t *testing.T) {
+		entries := 100
+		got := batchCopyArenaInitCapForEntries(entries)
+		want := entries * batchCopyArenaBytesPerEntry
+		if got != want {
+			t.Fatalf("sized init cap=%d want=%d", got, want)
+		}
+	})
+
+	t.Run("clamped", func(t *testing.T) {
+		got := batchCopyArenaInitCapForEntries(1 << 30)
+		if got != batchCopyArenaInitMax {
+			t.Fatalf("clamped init cap=%d want=%d", got, batchCopyArenaInitMax)
+		}
+	})
+}
+
+func TestBatchCopyArenaHint_DecaysAfterLargeToSmall(t *testing.T) {
+	var db DB
+
+	db.observeBatchCopyBytes(1 << 20)
+	initial := db.batchCopyArenaInitCap(0)
+	if initial < (1 << 19) {
+		t.Fatalf("initial cap too small after large observe: %d", initial)
+	}
+
+	for i := 0; i < 8; i++ {
+		db.observeBatchCopyBytes(16 << 10)
+	}
+	decayed := db.batchCopyArenaInitCap(0)
+	if decayed >= initial {
+		t.Fatalf("expected decayed cap < initial, initial=%d decayed=%d", initial, decayed)
+	}
+	if decayed > (128 << 10) {
+		t.Fatalf("expected decayed cap to drop near small workload, got=%d", decayed)
+	}
+}
+
+func TestBatchCopyArenaHint_NewBatchWithSizeCanRaiseInit(t *testing.T) {
+	var db DB
+
+	db.observeBatchCopyBytes(16 << 10)
+	unsized := db.batchCopyArenaInitCap(0)
+	if unsized != 16<<10 {
+		t.Fatalf("unsized init cap=%d want=%d", unsized, 16<<10)
+	}
+
+	const entries = 8000
+	sized := db.batchCopyArenaInitCap(entries)
+	wantMin := batchCopyArenaInitCapForEntries(entries)
+	if sized < wantMin {
+		t.Fatalf("sized init cap=%d want >= %d", sized, wantMin)
+	}
+}
+
+func TestBatchCopyArenaHint_UsesTotalCopiedBytes(t *testing.T) {
+	var db DB
+	b := &Batch{
+		db:           &db,
+		copyArenaCap: batchCopyArenaMinChunk,
+	}
+
+	// Force multiple chunk switches so len(copyArena) at the end is much smaller
+	// than total copied bytes.
+	for i := 0; i < 1024; i++ {
+		_ = b.arenaCopy(1024)
+	}
+	b.updateBatchCopyHint()
+
+	got := db.batchCopyArenaInitCap(0)
+	if got < (512 << 10) {
+		t.Fatalf("expected init hint to reflect total copied bytes, got=%d", got)
+	}
+}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3060,6 +3060,7 @@ type DB struct {
 	queueEnqueueNS        []int64
 	nextQueueID           atomic.Uint64
 	batchEntryHint        atomic.Int32
+	batchCopyBytesHint    atomic.Int32
 	batchEntriesPool      sync.Pool
 	batchShardEntriesPool sync.Pool
 	batchIntPool          sync.Pool
@@ -13585,6 +13586,8 @@ type Batch struct {
 	backend      batch.Interface
 	size         int
 	copyArena    []byte
+	copyArenaCap int
+	copyBytes    int
 	walBuf       []logRecord
 	shardIdxs    []int
 	eligibleIdxs []int
@@ -13611,14 +13614,24 @@ func (db *DB) NewBatch() *Batch {
 	if db != nil {
 		capHint = db.batchEntriesCapHint(capHint)
 	}
-	return &Batch{db: db, entries: db.getBatchEntries(capHint), streamEligible: true}
+	return &Batch{
+		db:             db,
+		entries:        db.getBatchEntries(capHint),
+		copyArenaCap:   db.batchCopyArenaInitCap(0),
+		streamEligible: true,
+	}
 }
 
 func (db *DB) NewBatchWithSize(size int) *Batch {
 	if size < 0 {
 		size = 0
 	}
-	return &Batch{db: db, entries: db.getBatchEntries(size), streamEligible: true}
+	return &Batch{
+		db:             db,
+		entries:        db.getBatchEntries(size),
+		copyArenaCap:   db.batchCopyArenaInitCap(size),
+		streamEligible: true,
+	}
 }
 
 func (db *DB) batchEntriesCapHint(minCap int) int {
@@ -13666,6 +13679,60 @@ func (db *DB) observeBatchEntries(n int) {
 			return
 		}
 		if db.batchEntryHint.CompareAndSwap(int32(old), int32(next)) {
+			return
+		}
+	}
+}
+
+func (db *DB) batchCopyArenaInitCap(sizeHint int) int {
+	base := batchCopyArenaInitCapForEntries(sizeHint)
+	if db == nil {
+		return base
+	}
+	if hint := int(db.batchCopyBytesHint.Load()); hint > base {
+		base = hint
+	}
+	if base < batchCopyArenaMinChunk {
+		base = batchCopyArenaMinChunk
+	}
+	if base > batchCopyArenaInitMax {
+		base = batchCopyArenaInitMax
+	}
+	return base
+}
+
+func (db *DB) observeBatchCopyBytes(n int) {
+	if db == nil || n <= 0 {
+		return
+	}
+	if n < batchCopyArenaMinChunk {
+		n = batchCopyArenaMinChunk
+	}
+	if n > batchCopyArenaInitMax {
+		n = batchCopyArenaInitMax
+	}
+	for {
+		old := int(db.batchCopyBytesHint.Load())
+		next := n
+		if old > 0 {
+			if n > old {
+				// Increase quickly so large batches avoid repeated growth.
+				next = (old*3 + n + 1) / 4
+			} else {
+				// Decay quickly so high-water marks do not poison small batches.
+				next = (old + n + 1) / 2
+			}
+		}
+		if next < batchCopyArenaMinChunk {
+			next = batchCopyArenaMinChunk
+		}
+		if next > batchCopyArenaInitMax {
+			next = batchCopyArenaInitMax
+		}
+		if next == old {
+			return
+		}
+		if db.batchCopyBytesHint.CompareAndSwap(int32(old), int32(next)) {
 			return
 		}
 	}
@@ -13789,6 +13856,7 @@ func (b *Batch) Reset() {
 		b.copyArena = b.copyArena[:0]
 	}
 	b.size = 0
+	b.copyBytes = 0
 	b.walBuf = b.walBuf[:0]
 	b.streamEligible = true
 	b.streamTried = false
@@ -13824,6 +13892,15 @@ func (b *Batch) updateBatchEntryHint() {
 	}
 }
 
+func (b *Batch) updateBatchCopyHint() {
+	if b == nil || b.db == nil {
+		return
+	}
+	if n := b.copyBytes; n > 0 {
+		b.db.observeBatchCopyBytes(n)
+	}
+}
+
 func (b *Batch) arenaCopy(n int) []byte {
 	if n == 0 {
 		return nil
@@ -13833,17 +13910,11 @@ func (b *Batch) arenaCopy(n int) []byte {
 		if chunkCap < batchCopyArenaMinChunk {
 			chunkCap = batchCopyArenaMinChunk
 		}
-		if cap(b.copyArena) == 0 && n > 0 {
-			// For batched workloads, first-copy size is usually representative.
-			// Use reserved entry capacity to avoid repeated arena growth for both
-			// put and delete heavy paths.
-			if cap(b.entries) <= batchCopyArenaInitMax/n {
-				estimated := cap(b.entries) * n
-				if estimated > chunkCap {
-					chunkCap = estimated
-				}
-			} else if batchCopyArenaInitMax > chunkCap {
-				chunkCap = batchCopyArenaInitMax
+		if cap(b.copyArena) == 0 {
+			// Keep unsized batches conservative. Entry-slice capacity can come from
+			// pooled high-water marks and is not a reliable signal for copy payload.
+			if b.copyArenaCap > chunkCap {
+				chunkCap = b.copyArenaCap
 			}
 		}
 		if chunkCap < n {
@@ -13855,6 +13926,7 @@ func (b *Batch) arenaCopy(n int) []byte {
 	}
 	start := len(b.copyArena)
 	b.copyArena = b.copyArena[:start+n]
+	b.copyBytes += n
 	return b.copyArena[start : start+n : start+n]
 }
 
@@ -14108,11 +14180,30 @@ const (
 	// enough to amortize per-lane setup and goroutine overhead.
 	multiLaneValueLogMinRecords = 1024
 	batchCopyArenaMinChunk      = 4 << 10
+	batchCopyArenaUnsizedInit   = 16 << 10
+	batchCopyArenaBytesPerEntry = 192
 	batchCopyArenaInitMax       = 2 << 20
 	batchCopyArenaMaxRetain     = 1 << 20
 	batchEntriesPoolMaxRetain   = 16 << 10
 	batchIntSlicePoolMaxRetain  = 16 << 10
 )
+
+func batchCopyArenaInitCapForEntries(entries int) int {
+	if entries <= 0 {
+		return batchCopyArenaUnsizedInit
+	}
+	if entries > batchCopyArenaInitMax/batchCopyArenaBytesPerEntry {
+		return batchCopyArenaInitMax
+	}
+	capHint := entries * batchCopyArenaBytesPerEntry
+	if capHint < batchCopyArenaMinChunk {
+		return batchCopyArenaMinChunk
+	}
+	if capHint > batchCopyArenaInitMax {
+		return batchCopyArenaInitMax
+	}
+	return capHint
+}
 
 func (b *Batch) maybeSwitchToStreaming() {
 	if b.streamTried || !b.streamEligible || b.backend != nil {
@@ -14256,6 +14347,7 @@ func (b *Batch) write(sync bool) error {
 			b.db.noteWrite()
 		}
 		b.updateBatchEntryHint()
+		b.updateBatchCopyHint()
 		b.Reset()
 		return err
 	}
@@ -14371,6 +14463,7 @@ func (b *Batch) tryWriteWALOffStreamBypass(sync bool) (bool, error) {
 		b.db.noteWrite()
 	}
 	b.updateBatchEntryHint()
+	b.updateBatchCopyHint()
 	b.Reset()
 	return true, nil
 }
@@ -15008,6 +15101,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	b.db.maybeAssistFlush()
 
 	b.updateBatchEntryHint()
+	b.updateBatchCopyHint()
 	b.Reset()
 	return nil
 }
@@ -15257,6 +15351,7 @@ func (b *Batch) writeBypass(sync bool) error {
 		b.db.noteWrite()
 	}
 	b.updateBatchEntryHint()
+	b.updateBatchCopyHint()
 	b.Reset()
 	return nil
 }


### PR DESCRIPTION
## Summary
- remove `cap(entries)` coupling from `Batch.arenaCopy` first-chunk sizing
- add adaptive copy-bytes hinting with fast decay to avoid stale high-water carryover
- update write paths to observe total copied bytes per batch before reset
- add targeted tests for sizing invariants and high-water decay

## Why
`batch_small_seq` alloc_space showed pathological arena over-allocation from phase ordering/high-water effects. This change makes arena sizing track actual copied bytes instead of pooled entry capacity.

## Validation
- `go test ./TreeDB/caching -count=1`
- `go test ./TreeDB/db -count=1`
- profile runs (`-treedb-index-outer-leaf-mode=v2_fenceptr`):
  - `allocs_batch_small_seq`: `Batch.arenaCopy` 4.76GB -> 79.73MB (-98.32%)
  - `allocs_batch_random`: `Batch.arenaCopy` 79.38MB -> 71.87MB (-9.46%)

## Notes
- stacked on #566
- follow-up phase 2 will move to memtable-owned arena chunk pooling for true payload-lifetime pooling
