### PR TITLE
caching: reduce writeRegular allocs and trim batch arena reserve

### DIFF
--- a/TreeDB/caching/batch_log_record_pool_test.go
+++ b/TreeDB/caching/batch_log_record_pool_test.go
@@ -1,0 +1,30 @@
+package caching
+
+import "testing"
+
+func TestBatchLogRecordPool_PutClearsReferences(t *testing.T) {
+	var db DB
+	records := make([]logRecord, 2, 2)
+	records[0] = logRecord{Op: logOpSetInline, Key: []byte("k"), Value: []byte("v"), RID: 7}
+	records[1] = logRecord{Op: logOpDelete, Key: []byte("k2"), Value: []byte("v2"), RID: 11}
+
+	db.putBatchLogRecords(records)
+
+	for i := range records {
+		if records[i].Key != nil || records[i].Value != nil || records[i].RID != 0 {
+			t.Fatalf("record %d not cleared: %+v", i, records[i])
+		}
+	}
+}
+
+func TestBatchLogRecordPool_GetMinCapacity(t *testing.T) {
+	var db DB
+	const wantCap = 64
+	records := db.getBatchLogRecords(wantCap)
+	if len(records) != 0 {
+		t.Fatalf("len(records)=%d want=0", len(records))
+	}
+	if cap(records) < wantCap {
+		t.Fatalf("cap(records)=%d want >= %d", cap(records), wantCap)
+	}
+}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3183,6 +3183,7 @@ type DB struct {
 	batchEntriesPool      sync.Pool
 	batchShardEntriesPool sync.Pool
 	batchIntPool          sync.Pool
+	batchLogRecordPool    sync.Pool
 
 	// memtables is an RCU-style snapshot of (mutable, queue, queueRanges).
 	// Readers load it atomically to avoid holding db.mu around memtable access.
@@ -14063,6 +14064,37 @@ func (db *DB) putBatchIntSlice(idxs []int) {
 	db.batchIntPool.Put(idxs[:0])
 }
 
+func (db *DB) getBatchLogRecords(minCap int) []logRecord {
+	if minCap < 0 {
+		minCap = 0
+	}
+	if db != nil {
+		if pooled := db.batchLogRecordPool.Get(); pooled != nil {
+			if records, ok := pooled.([]logRecord); ok {
+				if cap(records) >= minCap {
+					return records[:0]
+				}
+				if c := cap(records); c > 0 && c <= batchLogRecordPoolMaxRetain {
+					db.batchLogRecordPool.Put(records[:0])
+				}
+			}
+		}
+	}
+	return make([]logRecord, 0, minCap)
+}
+
+func (db *DB) putBatchLogRecords(records []logRecord) {
+	if db == nil || cap(records) == 0 {
+		return
+	}
+	if cap(records) > batchLogRecordPoolMaxRetain {
+		return
+	}
+	full := records[:cap(records)]
+	clear(full)
+	db.batchLogRecordPool.Put(full[:0])
+}
+
 // Reset clears the batch for reuse without closing it.
 //
 // This intentionally keeps internal buffers to avoid per-batch allocations in
@@ -14449,11 +14481,14 @@ const (
 	multiLaneValueLogMinRecords = 1024
 	batchCopyArenaMinChunk      = 4 << 10
 	batchCopyArenaUnsizedInit   = 8 << 10
-	batchCopyArenaBytesPerEntry = 192
+	// Conservative per-entry copy reservation used for initial arena sizing.
+	// Keep this near common key+value payloads to avoid systematic over-allocation.
+	batchCopyArenaBytesPerEntry = 160
 	batchCopyArenaInitMax       = 2 << 20
 	batchCopyArenaMaxRetain     = 4 << 20
 	batchEntriesPoolMaxRetain   = 16 << 10
 	batchIntSlicePoolMaxRetain  = 16 << 10
+	batchLogRecordPoolMaxRetain = 16 << 10
 )
 
 func batchCopyArenaInitCapForEntries(entries int) int {
@@ -15172,7 +15207,10 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	if !b.db.disableJournal {
 		records := b.walBuf[:0]
 		if cap(records) < len(b.entries) {
-			records = make([]logRecord, 0, len(b.entries))
+			if cap(b.walBuf) > 0 {
+				b.db.putBatchLogRecords(b.walBuf)
+			}
+			records = b.db.getBatchLogRecords(len(b.entries))
 		}
 		for i := range b.entries {
 			op := &b.entries[i]
@@ -15665,6 +15703,9 @@ func (b *Batch) Close() error {
 	}
 	b.recycleCopyArenaChunks()
 	b.entries = nil
+	if b.db != nil && b.walBuf != nil {
+		b.db.putBatchLogRecords(b.walBuf)
+	}
 	b.walBuf = nil
 	b.shardIdxs = nil
 	b.eligibleIdxs = nil


### PR DESCRIPTION
## Summary
Follow-up to #576 with one focused change set on the two highest-priority allocation hotspots:

1. `caching.(*Batch).writeRegular`
2. `caching.getBatchArena` / `caching.(*Batch).arenaCopy`

## What changed
- Added pooled `[]logRecord` reuse on `DB` for batch WAL staging in `writeRegular`:
  - new helpers: `getBatchLogRecords` / `putBatchLogRecords`
  - `writeRegular` now acquires WAL record buffers from pool instead of repeated `make([]logRecord, ...)`
  - `Batch.Close` returns retained WAL buffer to pool
- Reduced initial batch copy arena reserve from `192` to `160` bytes/entry:
  - lowers systematic over-allocation for common key+value payloads
- Added tests for WAL record pool behavior:
  - `TestBatchLogRecordPool_PutClearsReferences`
  - `TestBatchLogRecordPool_GetMinCapacity`

## Validation
- `go test ./TreeDB/caching -count=1`
- `go test ./TreeDB/db -count=1`

## Perf/alloc evidence (wal_on_fast, keys=500k, v2_fenceptr)
Baseline profiles: `/tmp/walonfast-1771632960`
New profiles: `/tmp/walonfast-remediate-1771634352`

### alloc_space deltas (flat)
- `batch_delete`:
  - `Batch.writeRegular`: `46.49MB -> 5.02MB` (`-89.2%`)
  - total: `67.77MB -> 30.56MB` (`-54.9%`)
- `batch_random`:
  - `Batch.writeRegular`: `35.62MB -> 10.60MB` (`-70.3%`)
  - total: `189.40MB -> 165.86MB` (`-12.4%`)
- `batch_small_seq`:
  - `Batch.writeRegular`: `54.31MB -> 9.44MB` (`-82.6%`)
  - `getBatchArena`: `102.81MB -> 80.94MB` (`-21.3%`)
  - total: `175.17MB -> 111.01MB` (`-36.6%`)

### Throughput
wal_on_fast throughput is mixed and within expected noise envelope for this single-run pass; no catastrophic regressions observed.

## Scope
This PR intentionally does **not** change behavior/semantics of WAL durability or value-log pointer policy. It is allocation-focused only.
