### PR TITLE
treedb: fix reverse bounded iterator with v2 fence pointers (fix #581)

### DIFF
--- a/TreeDB/issue581_reverse_range_forcepointers_test.go
+++ b/TreeDB/issue581_reverse_range_forcepointers_test.go
@@ -1,0 +1,53 @@
+package treedb
+
+import "testing"
+
+func TestIssue581_Repro_ReverseRangeForcePointers(t *testing.T) {
+	opts := OptionsFor(ProfileDurable, t.TempDir())
+	opts.ValueLog.ForcePointers = true
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	for i := 0; i < 10; i++ {
+		if i == 6 {
+			continue
+		}
+		if err := db.Set(issue579Key(i), []byte{}); err != nil {
+			t.Fatalf("set %d: %v", i, err)
+		}
+	}
+
+	bounded, err := db.ReverseIterator(issue579Key(4), issue579Key(6))
+	if err != nil {
+		t.Fatalf("reverse [4,6): %v", err)
+	}
+	gotBounded := issue579CollectInts(t, bounded)
+	wantBounded := []int{5, 4}
+	if len(gotBounded) != len(wantBounded) {
+		t.Fatalf("reverse [4,6) len mismatch got=%v want=%v", gotBounded, wantBounded)
+	}
+	for i := range wantBounded {
+		if gotBounded[i] != wantBounded[i] {
+			t.Fatalf("reverse [4,6) mismatch got=%v want=%v", gotBounded, wantBounded)
+		}
+	}
+
+	lowerBounded, err := db.ReverseIterator(issue579Key(6), nil)
+	if err != nil {
+		t.Fatalf("reverse [6,nil): %v", err)
+	}
+	gotLowerBounded := issue579CollectInts(t, lowerBounded)
+	wantLowerBounded := []int{9, 8, 7}
+	if len(gotLowerBounded) != len(wantLowerBounded) {
+		t.Fatalf("reverse [6,nil) len mismatch got=%v want=%v", gotLowerBounded, wantLowerBounded)
+	}
+	for i := range wantLowerBounded {
+		if gotLowerBounded[i] != wantLowerBounded[i] {
+			t.Fatalf("reverse [6,nil) mismatch got=%v want=%v", gotLowerBounded, wantLowerBounded)
+		}
+	}
+}

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -1292,19 +1292,12 @@ func (it *Iterator) loadCurrent() {
 			return
 		}
 
-		// Check Range Limits
-		if !it.reverse {
-			if it.end != nil && compareTreeKey(keyView, it.end) >= 0 {
-				it.valid = false
-				it.clearPendingFenceSeek()
-				return
-			}
-		} else {
-			if it.start != nil && compareTreeKey(keyView, it.start) < 0 {
-				it.valid = false
-				it.clearPendingFenceSeek()
-				return
-			}
+		// Forward scans can stop as soon as the physical leaf key reaches the
+		// upper bound because all following keys are >= this key.
+		if !it.reverse && it.end != nil && compareTreeKey(keyView, it.end) >= 0 {
+			it.valid = false
+			it.clearPendingFenceSeek()
+			return
 		}
 
 		// Skip tombstones; they are persisted in the index but hidden from iteration.
@@ -1342,6 +1335,15 @@ func (it *Iterator) loadCurrent() {
 				}
 				continue
 			}
+		}
+
+		// Reverse scans must apply the lower bound after optional fence-block
+		// expansion. The physical pointer key can sit below start while expanded
+		// logical keys are still within [start,end).
+		if it.reverse && it.start != nil && compareTreeKey(keyView, it.start) < 0 {
+			it.valid = false
+			it.clearPendingFenceSeek()
+			return
 		}
 
 		it.currKey = keyView


### PR DESCRIPTION
## Summary
- fix reverse bounded iteration when v2 fence-pointer leaves are active and pointer key is below the lower bound
- move reverse lower-bound cutoff to run after optional fence-block expansion in `tree.Iterator.loadCurrent`
- add regression coverage for the issue scenario with `ForcePointers=true`

## Why
Issue #581 reproduces empty reverse results for bounded ranges (for example `[4,6)` and `[6,nil)`) even though forward ranges and point lookups are correct.

## Validation
- `go test ./TreeDB -run '^TestIssue581_Repro_ReverseRangeForcePointers$' -count=1 -v`
- `go test ./TreeDB -run '^TestIssue579_Repro_ProfileFast_ForwardAfterReverse$' -count=1 -v`
- `go test ./TreeDB/tree -count=1`
- `go test ./TreeDB -count=1`
