### PR TITLE
test(valuelog): add red repro for grouped length-hint bit23 collision

### DIFF
--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -503,6 +503,12 @@ func (r valueReader) FenceLookupEnabled() bool {
 }
 
 func (r valueReader) FencePointerLikelyBlock(ptr page.ValuePtr) bool {
+	// Grouped pointers in v2 fence mode can carry outer-leaf fence payloads
+	// without an explicit fence marker bit; grouped fence marker was legacy and
+	// collided with large grouped record-length hints.
+	if page.ValuePtrIsGrouped(ptr) {
+		return true
+	}
 	return page.ValuePtrIsFenceOuter(ptr)
 }
 

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -201,7 +201,11 @@ func (db *DB) collectValueLogLiveBytes(ctx context.Context, it iterator.UnsafeIt
 			it.Next()
 			continue
 		}
-		liveByID[ptr.FileID] += int64(page.ValuePtrRecordLength(ptr))
+		recordLen, err := db.valueLogRecordLengthForRewrite(ptr)
+		if err != nil {
+			return err
+		}
+		liveByID[ptr.FileID] += int64(recordLen)
 		nested, err := db.outerLeafNestedBlobRefLiveBytes(ptr)
 		if err != nil {
 			return err
@@ -249,9 +253,58 @@ func (db *DB) outerLeafNestedBlobRefLiveBytes(ptr page.ValuePtr) (map[uint32]int
 		if !page.IsValueLogFileID(blobPtr.FileID) {
 			return nil, fmt.Errorf("treedb: invalid nested blob pointer file %d", blobPtr.FileID)
 		}
-		refs[blobPtr.FileID] += int64(page.ValuePtrRecordLength(blobPtr))
+		recordLen, err := db.valueLogRecordLengthForRewrite(blobPtr)
+		if err != nil {
+			return nil, err
+		}
+		refs[blobPtr.FileID] += int64(recordLen)
 	}
 	return refs, nil
+}
+
+func valueLogRecordLengthNeedsHeader(ptr page.ValuePtr, hint uint32) bool {
+	if hint == 0 {
+		return true
+	}
+	// Grouped legacy fence markers reuse bit 23 inside the length-hint field.
+	// Use on-disk headers for exact sizing in this ambiguous case.
+	return page.ValuePtrIsGrouped(ptr) && page.ValuePtrIsFenceOuter(ptr)
+}
+
+func readValueLogRecordLengthFromHeader(r io.ReaderAt, start int64) (uint32, error) {
+	var header [valuelog.HeaderSize]byte
+	if _, err := r.ReadAt(header[:], start); err != nil {
+		return 0, err
+	}
+	if header[4] != valuelog.Version {
+		return 0, valuelog.ErrCorrupt
+	}
+	valueLen := uint32(header[16]) | uint32(header[17])<<8 | uint32(header[18])<<16 | uint32(header[19])<<24
+	return uint32(valuelog.HeaderSize-4) + valueLen, nil
+}
+
+func (db *DB) valueLogRecordLengthForRewrite(ptr page.ValuePtr) (uint32, error) {
+	hint := page.ValuePtrRecordLength(ptr)
+	if !valueLogRecordLengthNeedsHeader(ptr, hint) {
+		return hint, nil
+	}
+	if ptr.Offset < 4 {
+		return 0, fmt.Errorf("vlog-rewrite: invalid pointer offset %d", ptr.Offset)
+	}
+	if db == nil || db.valueLogManager == nil {
+		return 0, fmt.Errorf("vlog-rewrite: value-log manager unavailable")
+	}
+	set := db.valueLogManager.CurrentSetNoRefresh()
+	if set == nil {
+		return 0, fmt.Errorf("vlog-rewrite: value-log set unavailable")
+	}
+	defer func() { _ = db.valueLogManager.Release(set) }()
+	f := set.Files[ptr.FileID]
+	if f == nil || f.File == nil {
+		return 0, fmt.Errorf("vlog-rewrite: missing segment %d", ptr.FileID)
+	}
+	start := int64(ptr.Offset - 4)
+	return readValueLogRecordLengthFromHeader(f.File, start)
 }
 
 type rewriteSourceSegment struct {
@@ -1030,7 +1083,6 @@ type iteratorWithEntry interface {
 type recordKey struct {
 	fileID uint32
 	offset uint64
-	length uint32
 }
 
 type recordLoc struct {
@@ -1105,7 +1157,6 @@ func (it *rewriteIterator) rewritePtr(ptr page.ValuePtr) (page.ValuePtr, error) 
 	key := recordKey{
 		fileID: ptr.FileID,
 		offset: ptr.Offset,
-		length: page.ValuePtrRecordLength(ptr),
 	}
 	if cached, ok := it.ptrMap[key]; ok {
 		return page.ValuePtr{Offset: cached.offset, FileID: cached.fileID, Length: ptr.Length}, nil
@@ -1204,16 +1255,12 @@ func readRawRecord(r io.ReaderAt, ptr page.ValuePtr) ([]byte, error) {
 	}
 	start := int64(ptr.Offset - 4)
 	recordLen := page.ValuePtrRecordLength(ptr)
-	if recordLen == 0 {
-		var header [valuelog.HeaderSize]byte
-		if _, err := r.ReadAt(header[:], start); err != nil {
+	if valueLogRecordLengthNeedsHeader(ptr, recordLen) {
+		var err error
+		recordLen, err = readValueLogRecordLengthFromHeader(r, start)
+		if err != nil {
 			return nil, err
 		}
-		if header[4] != valuelog.Version {
-			return nil, valuelog.ErrCorrupt
-		}
-		valueLen := uint32(header[16]) | uint32(header[17])<<8 | uint32(header[18])<<16 | uint32(header[19])<<24
-		recordLen = uint32(valuelog.HeaderSize-4) + valueLen
 	}
 	size := int64(recordLen) + 4
 	if size < int64(valuelog.HeaderSize) {

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -135,6 +135,111 @@ func TestValueLogRewriteOffline_RewritesAndShrinks(t *testing.T) {
 	}
 }
 
+func TestValueLogRewriteOffline_LegacyGroupedFenceMarkerHint(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{
+		Dir: dir,
+		ValueLog: ValueLogOptions{
+			ForcePointers: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	walDir := filepath.Join(dir, "wal")
+	if err := os.MkdirAll(walDir, 0o755); err != nil {
+		t.Fatalf("mkdir wal: %v", err)
+	}
+
+	path := filepath.Join(walDir, "value-l0-000001.log")
+	fileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("fileid: %v", err)
+	}
+	w, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+	ptrs, err := w.AppendFrame(0, nil, []valuelog.Record{
+		{RID: 1, Value: []byte("alpha")},
+		{RID: 2, Value: []byte("beta")},
+	})
+	if err != nil {
+		_ = w.Close()
+		t.Fatalf("append grouped frame: %v", err)
+	}
+	if len(ptrs) != 2 || !page.ValuePtrIsGrouped(ptrs[0]) || !page.ValuePtrIsGrouped(ptrs[1]) {
+		_ = w.Close()
+		t.Fatalf("expected grouped pointers from frame append")
+	}
+	for i := 0; i < 4; i++ {
+		if _, err := w.Append(0, nil, 10+uint64(i), bytes.Repeat([]byte{byte('x' + i)}, 256)); err != nil {
+			_ = w.Close()
+			t.Fatalf("append stale record %d: %v", i, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	const legacyGroupedFenceMarkerBit = 0x00800000 // historical fence-marker bit in grouped length encoding
+	legacyPtr := ptrs[0]
+	legacyPtr.Length |= legacyGroupedFenceMarkerBit
+
+	b := db.NewBatch()
+	ptrBatch, ok := b.(interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+	})
+	if !ok {
+		t.Fatalf("missing SetPointer on batch")
+	}
+	if err := ptrBatch.SetPointer([]byte("k1"), legacyPtr); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := ptrBatch.SetPointer([]byte("k2"), ptrs[1]); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = b.Close()
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	stats, err := ValueLogRewriteOffline(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOffline: %v", err)
+	}
+	if stats.RecordsCopied == 0 {
+		t.Fatalf("expected rewrite to copy records, got stats=%+v", stats)
+	}
+
+	reopen, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopen.Close() }()
+
+	v1, err := reopen.Get([]byte("k1"))
+	if err != nil {
+		t.Fatalf("get k1: %v", err)
+	}
+	if !bytes.Equal(v1, []byte("alpha")) {
+		t.Fatalf("k1 mismatch after rewrite: got=%q", v1)
+	}
+	v2, err := reopen.Get([]byte("k2"))
+	if err != nil {
+		t.Fatalf("get k2: %v", err)
+	}
+	if !bytes.Equal(v2, []byte("beta")) {
+		t.Fatalf("k2 mismatch after rewrite: got=%q", v2)
+	}
+}
+
 func TestValueLogRewrite_HealthMetadata_PreservedAcrossReopen(t *testing.T) {
 	dir := t.TempDir()
 

--- a/TreeDB/internal/valuelog/reader.go
+++ b/TreeDB/internal/valuelog/reader.go
@@ -337,11 +337,9 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 		return nil, ErrRecordTooLarge
 	}
 
-	if recordLen := page.ValuePtrRecordLength(ptr); recordLen != 0 {
-		expectedLen := uint32(headerWithoutCRC) + valueLen
-		if recordLen != expectedLen {
-			return nil, ErrCorrupt
-		}
+	expectedLen := uint32(headerWithoutCRC) + valueLen
+	if !page.ValuePtrRecordLengthHintMatches(ptr, expectedLen) {
+		return nil, ErrCorrupt
 	}
 
 	// Fast path: for grouped, uncompressed frames with checksums disabled, read
@@ -469,11 +467,9 @@ func decodeRecord(header []byte, payload []byte, ptr page.ValuePtr, verifyCRC bo
 	if int(valueLen) != len(payload) {
 		return nil, ErrCorrupt
 	}
-	if recordLen := page.ValuePtrRecordLength(ptr); recordLen != 0 {
-		expectedLen := uint32(headerWithoutCRC) + valueLen
-		if recordLen != expectedLen {
-			return nil, ErrCorrupt
-		}
+	expectedLen := uint32(headerWithoutCRC) + valueLen
+	if !page.ValuePtrRecordLengthHintMatches(ptr, expectedLen) {
+		return nil, ErrCorrupt
 	}
 	if verifyCRC {
 		sum := crc.ChecksumParts(header[4:], payload)

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -121,11 +121,9 @@ func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error
 	if recordSizeExceedsMax(valueLen) {
 		return nil, ErrRecordTooLarge, true
 	}
-	if recordLen := page.ValuePtrRecordLength(ptr); recordLen != 0 {
-		expectedLen := uint32(headerWithoutCRC) + valueLen
-		if recordLen != expectedLen {
-			return nil, ErrCorrupt, true
-		}
+	expectedLen := uint32(headerWithoutCRC) + valueLen
+	if !page.ValuePtrRecordLengthHintMatches(ptr, expectedLen) {
+		return nil, ErrCorrupt, true
 	}
 
 	end := start + HeaderSize + int64(valueLen)
@@ -353,11 +351,9 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	if recordSizeExceedsMax(valueLen) {
 		return nil, ErrRecordTooLarge, true
 	}
-	if recordLen := page.ValuePtrRecordLength(ptr); recordLen != 0 {
-		expectedLen := uint32(headerWithoutCRC) + valueLen
-		if recordLen != expectedLen {
-			return nil, ErrCorrupt, true
-		}
+	expectedLen := uint32(headerWithoutCRC) + valueLen
+	if !page.ValuePtrRecordLengthHintMatches(ptr, expectedLen) {
+		return nil, ErrCorrupt, true
 	}
 
 	end := start + HeaderSize + int64(valueLen)

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -1204,9 +1204,20 @@ func TestReadAtGroupedLengthHintBit23RoundTrip(t *testing.T) {
 		_ = writer.Close()
 		t.Fatalf("expected grouped pointer")
 	}
-	if got, want := page.ValuePtrRecordLength(ptr), targetRecordLen; got != want {
+	// New writes reserve bit 23 and omit the hint once record length exceeds the
+	// safe grouped hint range.
+	if got := page.ValuePtrRecordLength(ptr); got != 0 {
 		_ = writer.Close()
-		t.Fatalf("decoded record length mismatch got=%d want=%d", got, want)
+		t.Fatalf("expected omitted grouped hint for large record, got=%d", got)
+	}
+
+	// Simulate a legacy pointer whose grouped length hint had bit23 set. This
+	// used to collide with the grouped fence marker bit and decode incorrectly.
+	legacyPtr := ptr
+	legacyPtr.Length = page.ValuePtrMarkGrouped(targetRecordLen, page.ValuePtrSubIndex(ptr))
+	if got, want := page.ValuePtrRecordLength(legacyPtr), targetRecordLen; got != want {
+		_ = writer.Close()
+		t.Fatalf("legacy decoded record length mismatch got=%d want=%d", got, want)
 	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close: %v", err)
@@ -1218,12 +1229,124 @@ func TestReadAtGroupedLengthHintBit23RoundTrip(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = f.Close() })
 
-	got, err := ReadAtWithDict(f, ptr, true, nil, nil, nil, templ.DecodeOptions{})
+	got, err := ReadAtWithDict(f, legacyPtr, true, nil, nil, nil, templ.DecodeOptions{})
 	if err != nil {
 		t.Fatalf("read at: %v", err)
 	}
 	if !bytes.Equal(got, value) {
 		t.Fatalf("read value bytes mismatch")
+	}
+}
+
+func TestReadAtGroupedLegacyFenceMarkerHintMatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-000001.log")
+
+	writer, err := NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+
+	value := bytes.Repeat([]byte("k"), 1024)
+	ptr, err := writer.Append(0, nil, 1, value)
+	if err != nil {
+		_ = writer.Close()
+		t.Fatalf("append: %v", err)
+	}
+	if !page.ValuePtrIsGrouped(ptr) {
+		_ = writer.Close()
+		t.Fatalf("expected grouped pointer")
+	}
+	if got := page.ValuePtrRecordLength(ptr); got == 0 {
+		_ = writer.Close()
+		t.Fatalf("expected non-zero grouped hint for small value")
+	}
+
+	// Simulate a legacy grouped fence-marker bit on a non-fence grouped pointer.
+	const legacyGroupedFenceMarkerBit = 0x00800000 // historical fence-marker bit in grouped length encoding
+	legacy := ptr
+	legacy.Length |= legacyGroupedFenceMarkerBit
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	got, err := ReadAtWithDict(f, legacy, true, nil, nil, nil, templ.DecodeOptions{})
+	if err != nil {
+		t.Fatalf("read legacy grouped marker ptr: %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Fatalf("legacy marker value mismatch")
+	}
+}
+
+func TestAppendRawRecord_LegacyGroupedFenceMarkerHintMatch(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "value-src-000001.log")
+
+	srcWriter, err := NewWriter(srcPath, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("new src writer: %v", err)
+	}
+	srcPtrs, err := srcWriter.AppendFrame(0, nil, []Record{
+		{RID: 1, Value: []byte("alpha")},
+		{RID: 2, Value: []byte("beta")},
+	})
+	if err != nil {
+		_ = srcWriter.Close()
+		t.Fatalf("append src frame: %v", err)
+	}
+	if len(srcPtrs) != 2 {
+		_ = srcWriter.Close()
+		t.Fatalf("expected 2 src pointers, got %d", len(srcPtrs))
+	}
+	if !page.ValuePtrIsGrouped(srcPtrs[0]) {
+		_ = srcWriter.Close()
+		t.Fatalf("expected grouped src pointer")
+	}
+	if err := srcWriter.Close(); err != nil {
+		t.Fatalf("close src writer: %v", err)
+	}
+
+	raw, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Fatalf("read raw src record: %v", err)
+	}
+	const legacyGroupedFenceMarkerBit = 0x00800000 // historical fence-marker bit in grouped length encoding
+	legacyLen := srcPtrs[0].Length | legacyGroupedFenceMarkerBit
+
+	dstPath := filepath.Join(dir, "value-dst-000001.log")
+	dstWriter, err := NewWriter(dstPath, page.ValueLogFileID(2))
+	if err != nil {
+		t.Fatalf("new dst writer: %v", err)
+	}
+	dstPtr, err := dstWriter.AppendRawRecord(raw, legacyLen)
+	if err != nil {
+		_ = dstWriter.Close()
+		t.Fatalf("append raw record with legacy grouped marker: %v", err)
+	}
+	if err := dstWriter.Close(); err != nil {
+		t.Fatalf("close dst writer: %v", err)
+	}
+
+	f, err := os.Open(dstPath)
+	if err != nil {
+		t.Fatalf("open dst file: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	got, err := ReadAtWithDict(f, dstPtr, true, nil, nil, nil, templ.DecodeOptions{})
+	if err != nil {
+		t.Fatalf("read appended legacy grouped pointer: %v", err)
+	}
+	if !bytes.Equal(got, []byte("alpha")) {
+		t.Fatalf("value mismatch after append raw with legacy grouped marker")
 	}
 }
 

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -861,15 +861,12 @@ func (w *Writer) AppendRawRecord(raw []byte, length uint32) (page.ValuePtr, erro
 	if w == nil {
 		return page.ValuePtr{}, errors.New("valuelog: nil writer")
 	}
-	if len(raw) == 0 {
+	if len(raw) < 4 {
 		return page.ValuePtr{}, errors.New("valuelog: empty record")
 	}
-	recordLen := page.ValuePtrRecordLength(page.ValuePtr{Length: length})
-	if recordLen != 0 {
-		expected := int64(recordLen) + 4
-		if int64(len(raw)) != expected {
-			return page.ValuePtr{}, errors.New("valuelog: raw record size mismatch")
-		}
+	expected := uint32(len(raw) - 4)
+	if !page.ValuePtrRecordLengthHintMatches(page.ValuePtr{Length: length}, expected) {
+		return page.ValuePtr{}, errors.New("valuelog: raw record size mismatch")
 	}
 	start := w.size
 	if err := w.writeBytes(raw); err != nil {

--- a/TreeDB/page/value_ptr_flags.go
+++ b/TreeDB/page/value_ptr_flags.go
@@ -9,9 +9,11 @@ const (
 	// It intentionally reuses one of the non-grouped sub-index bits so existing
 	// record-length decoding (ValuePtrRecordLength) strips it automatically.
 	valuePtrFenceOuterMask uint32 = 0x20000000
-	// valuePtrFenceOuterGroupedMask marks grouped pointers that reference
-	// outer-leaf fence blocks. This bit sits in the grouped length-hint region;
-	// ValuePtrRecordLength strips it only when present.
+	// valuePtrFenceOuterGroupedMask is a legacy grouped fence marker bit.
+	//
+	// It sits in the grouped length-hint region and therefore collides with
+	// legitimate grouped length hints above 0x007fffff. New writes no longer set
+	// this bit; it is only recognized for backward-compatible hint matching.
 	valuePtrFenceOuterGroupedMask uint32 = 0x00800000
 
 	valuePtrSubIndexMask  uint32 = 0x3c000000
@@ -24,23 +26,43 @@ const (
 )
 
 // ValuePtrGroupedMaxRecordLen is the maximum record length (excluding CRC) that
-// can be encoded in a grouped ValuePtr length hint.
+// can be encoded in a grouped ValuePtr length hint for new writes.
 //
 // Grouped pointers embed a sub-index in the Length field, leaving 24 bits for a
-// best-effort record length hint. Larger records must set the hint to 0 and
-// rely on the value-log record header's ValueLen instead.
-const ValuePtrGroupedMaxRecordLen uint32 = 0x00ffffff
+// best-effort record length hint. Bit 23 is reserved for legacy grouped fence
+// marker compatibility, so new hints are capped at 23 bits. Larger records must
+// set the hint to 0 and rely on the value-log record header's ValueLen instead.
+const ValuePtrGroupedMaxRecordLen uint32 = 0x007fffff
 
 // ValuePtrRecordLength returns the record length with internal flags stripped.
 func ValuePtrRecordLength(ptr ValuePtr) uint32 {
 	mask := valuePtrCompressedMask | valuePtrGroupedMask | valuePtrSubIndexMask
 	if ValuePtrIsGrouped(ptr) {
 		mask |= valuePtrSubIndexHiMask
-		if ptr.Length&valuePtrFenceOuterGroupedMask != 0 {
-			mask |= valuePtrFenceOuterGroupedMask
-		}
 	}
 	return ptr.Length &^ mask
+}
+
+// ValuePtrRecordLengthHintMatches reports whether the encoded record-length hint
+// matches expected.
+//
+// A zero hint means "omitted hint" and always matches.
+//
+// For grouped pointers carrying the legacy grouped fence marker bit, this helper
+// accepts both the raw decoded hint and the marker-cleared variant so older
+// pointers can still validate against on-disk headers.
+func ValuePtrRecordLengthHintMatches(ptr ValuePtr, expected uint32) bool {
+	recordLen := ValuePtrRecordLength(ptr)
+	if recordLen == 0 || recordLen == expected {
+		return true
+	}
+	if ValuePtrIsGrouped(ptr) && ptr.Length&valuePtrFenceOuterGroupedMask != 0 {
+		legacyCleared := recordLen &^ valuePtrFenceOuterGroupedMask
+		if legacyCleared == 0 || legacyCleared == expected {
+			return true
+		}
+	}
+	return false
 }
 
 // ValuePtrIsCompressed reports whether the pointer references a compressed value.
@@ -71,10 +93,13 @@ func ValuePtrSubIndex(ptr ValuePtr) uint8 {
 	return idx
 }
 
-// ValuePtrIsFenceOuter reports whether ptr references a non-grouped outer-leaf
-// fence block payload.
+// ValuePtrIsFenceOuter reports whether ptr references an outer-leaf fence block
+// payload.
+//
+// Grouped pointers may return true only for legacy grouped fence markers.
 func ValuePtrIsFenceOuter(ptr ValuePtr) bool {
 	if ValuePtrIsGrouped(ptr) {
+		// Legacy grouped fence marker bit (new grouped writes do not set this).
 		return ptr.Length&valuePtrFenceOuterGroupedMask != 0
 	}
 	return ptr.Length&valuePtrFenceOuterMask != 0
@@ -82,9 +107,13 @@ func ValuePtrIsFenceOuter(ptr ValuePtr) bool {
 
 // ValuePtrMarkFenceOuter marks a non-grouped pointer as an outer-leaf fence
 // block pointer.
+//
+// Grouped pointers are returned unchanged: grouped fence markers are legacy-only
+// and new grouped writes do not encode a dedicated fence bit.
 func ValuePtrMarkFenceOuter(ptr ValuePtr) ValuePtr {
 	if ValuePtrIsGrouped(ptr) {
-		ptr.Length |= valuePtrFenceOuterGroupedMask
+		// Grouped pointers no longer embed a fence marker bit because it collides
+		// with large grouped length hints.
 		return ptr
 	}
 	ptr.Length |= valuePtrFenceOuterMask

--- a/TreeDB/page/value_ptr_flags_test.go
+++ b/TreeDB/page/value_ptr_flags_test.go
@@ -1,0 +1,60 @@
+package page
+
+import "testing"
+
+func TestValuePtrRecordLength_GroupedKeepsBit23(t *testing.T) {
+	const recordLen = uint32(0x00800080)
+	ptr := ValuePtr{Length: ValuePtrMarkGrouped(recordLen, 3)}
+	if !ValuePtrIsGrouped(ptr) {
+		t.Fatalf("expected grouped pointer")
+	}
+	if got := ValuePtrRecordLength(ptr); got != recordLen {
+		t.Fatalf("record length mismatch: got=%#x want=%#x", got, recordLen)
+	}
+}
+
+func TestValuePtrRecordLengthHintMatches_GroupedLegacyFenceMarkerCompat(t *testing.T) {
+	const expected = uint32(0x00000080)
+	ptr := ValuePtr{Length: ValuePtrMarkGrouped(expected, 1)}
+	if !ValuePtrRecordLengthHintMatches(ptr, expected) {
+		t.Fatalf("expected direct grouped hint to match")
+	}
+
+	// Legacy grouped fence markers reused bit23 and collided with grouped hints.
+	legacy := ptr
+	legacy.Length |= valuePtrFenceOuterGroupedMask
+	if !ValuePtrRecordLengthHintMatches(legacy, expected) {
+		t.Fatalf("expected legacy grouped fence marker compatibility match")
+	}
+	if ValuePtrRecordLengthHintMatches(legacy, expected+1) {
+		t.Fatalf("unexpected match for wrong expected length")
+	}
+}
+
+func TestValuePtrRecordLengthHintMatches_GroupedLegacyMarkerOnlyAsOmitted(t *testing.T) {
+	ptr := ValuePtr{Length: ValuePtrMarkGrouped(0, 1)}
+	legacy := ptr
+	legacy.Length |= valuePtrFenceOuterGroupedMask
+	if !ValuePtrRecordLengthHintMatches(legacy, 12345) {
+		t.Fatalf("expected marker-only grouped hint to be treated as omitted")
+	}
+}
+
+func TestValuePtrMarkFenceOuter_GroupedNoOp(t *testing.T) {
+	ptr := ValuePtr{Length: ValuePtrMarkGrouped(1234, 2)}
+	marked := ValuePtrMarkFenceOuter(ptr)
+	if marked != ptr {
+		t.Fatalf("grouped fence mark should be no-op: got=%#x want=%#x", marked.Length, ptr.Length)
+	}
+}
+
+func TestValuePtrMarkFenceOuter_NonGrouped(t *testing.T) {
+	ptr := ValuePtr{Length: 1234}
+	marked := ValuePtrMarkFenceOuter(ptr)
+	if !ValuePtrIsFenceOuter(marked) {
+		t.Fatalf("expected non-grouped pointer to be fence-marked")
+	}
+	if got, want := ValuePtrRecordLength(marked), uint32(1234); got != want {
+		t.Fatalf("non-grouped record length mismatch: got=%d want=%d", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add a red (failing) regression test for grouped value-log pointers whose length hint sets bit 23
- reproduces the same crash class seen in Celestia startup (`valuelog: corrupt record`)

## Repro details
- new test: `TestReadAtGroupedLengthHintBit23RoundTrip`
- writes a grouped record with `targetRecordLen=0x00800080` (bit 23 set in hint)
- expects normal round-trip decode/read
- currently fails because `ValuePtrRecordLength` decodes to a much smaller value (`got=128`, `want=8388736`)

## Run
```bash
go test ./TreeDB/internal/valuelog -run TestReadAtGroupedLengthHintBit23RoundTrip -count=1
```

Closes #583
