### PR TITLE
treedb: fix profile-fast set/get not-found in deferred v2 path

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1189,6 +1189,12 @@ func (db *DB) deferredValueLogNeedsSingleLaneRegroup() bool {
 	return db != nil && db.deferredValueLogEnabled()
 }
 
+func (db *DB) allowFencePointerCollapse() bool {
+	// Disabled for correctness: collapsing to user-key fence anchors can orphan
+	// sibling keys when a later write/delete overwrites that anchor key.
+	return false
+}
+
 // sumKeyValueBytes returns the total bytes across paired key/value entries.
 // If keys and values differ in length, only the shared prefix is counted.
 func sumKeyValueBytes(keys, values [][]byte) uint64 {
@@ -1421,6 +1427,7 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 		return ops, nil
 	}
 	fenceMode := db.outerLeafFenceV2Enabled()
+	collapseFence := fenceMode && db.allowFencePointerCollapse()
 
 	eligible := getValueLogEligible(len(ops))
 	defer putValueLogEligible(eligible)
@@ -1496,7 +1503,7 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 	}
 
 	var eligibleByIdx []bool
-	if fenceMode {
+	if collapseFence {
 		eligibleByIdx = make([]bool, len(ops))
 		for _, idx := range eligible {
 			if idx >= 0 && idx < len(eligibleByIdx) {
@@ -1507,7 +1514,7 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 
 	for i := range groups {
 		ptr := ptrs[i]
-		if fenceMode {
+		if collapseFence {
 			ptr = page.ValuePtrMarkFenceOuter(ptr)
 		}
 		group := groups[i]
@@ -1517,7 +1524,7 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 			putOuterLeafArena(outerArena)
 			return nil, errors.New("cachingdb: deferred value-log group out of range")
 		}
-		if fenceMode {
+		if collapseFence {
 			if group.start < group.end {
 				idx := eligible[group.start]
 				op := &ops[idx]
@@ -1535,7 +1542,7 @@ func (db *DB) deferValueLogOps(ops []batch.Entry, sync bool) ([]batch.Entry, err
 			op.Value = nil
 		}
 	}
-	if fenceMode && len(eligibleByIdx) > 0 {
+	if collapseFence && len(eligibleByIdx) > 0 {
 		dst := 0
 		for i := range ops {
 			if eligibleByIdx[i] && !ops[i].IsPtr {
@@ -1630,6 +1637,7 @@ func (db *DB) flushDeferredValueLogMemtable(iter iterator.UnsafeIterator, backen
 		putValueLogKeys(ptrVals)
 	}()
 	fenceMode := db.outerLeafFenceV2Enabled()
+	collapseFence := fenceMode && db.allowFencePointerCollapse()
 	state := fenceState
 	if state == nil {
 		state = &deferredFenceCollapseState{}
@@ -1637,7 +1645,7 @@ func (db *DB) flushDeferredValueLogMemtable(iter iterator.UnsafeIterator, backen
 
 	for iter.Valid() {
 		key := iter.UnsafeKey()
-		if fenceMode && len(state.prevKey) > 0 && bytes.Compare(key, state.prevKey) <= 0 {
+		if collapseFence && len(state.prevKey) > 0 && bytes.Compare(key, state.prevKey) <= 0 {
 			// Fence collapse is only valid on ascending key runs.
 			state.havePtr = false
 		}
@@ -1660,7 +1668,7 @@ func (db *DB) flushDeferredValueLogMemtable(iter iterator.UnsafeIterator, backen
 		val, ptr, flags := iter.UnsafeEntry()
 		if flags&node.FlagPointer != 0 {
 			emitPtr := true
-			if fenceMode {
+			if collapseFence {
 				if state.havePtr && ptr == state.lastPtr {
 					emitPtr = false
 				} else {
@@ -1780,14 +1788,14 @@ func (db *DB) flushDeferredValueLogMemtable(iter iterator.UnsafeIterator, backen
 	emittedGroups := uint64(0)
 	for i := range groups {
 		ptr := vlogPtrs[i]
-		if fenceMode {
+		if collapseFence {
 			ptr = page.ValuePtrMarkFenceOuter(ptr)
 		}
 		group := groups[i]
 		if group.start < 0 || group.end < group.start || group.end > len(ptrKeys) {
 			return errors.New("cachingdb: deferred value-log group out of range")
 		}
-		if fenceMode {
+		if collapseFence {
 			// Fence-pointer mode stores one key per grouped outer block.
 			// Keeping only the first key preserves sorted fence bounds while
 			// reducing persisted index entries.
@@ -1812,7 +1820,7 @@ func (db *DB) flushDeferredValueLogMemtable(iter iterator.UnsafeIterator, backen
 			}
 		}
 	}
-	if fenceMode && emittedGroups > 0 {
+	if collapseFence && emittedGroups > 0 {
 		db.deferredFenceEmittedGroups.Add(emittedGroups)
 	}
 
@@ -1892,6 +1900,7 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 
 	allowPointers := db.allowValueLogPointers()
 	fenceMode := db.outerLeafFenceV2Enabled()
+	collapseFence := fenceMode && db.allowFencePointerCollapse()
 	durability := journalDurabilityNone
 	if sync {
 		durability = journalDurabilitySync
@@ -1942,7 +1951,7 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 
 	emitPointer := func(key []byte, ptr page.ValuePtr) error {
 		emitPtr := true
-		if fenceMode {
+		if collapseFence {
 			if haveFencePtr && ptr == lastFencePtr {
 				emitPtr = false
 			} else {
@@ -2023,7 +2032,7 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 
 			for i := range groups {
 				ptr := vlogPtrs[i]
-				if fenceMode {
+				if collapseFence {
 					ptr = page.ValuePtrMarkFenceOuter(ptr)
 				}
 				group := groups[i]
@@ -2033,7 +2042,7 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 				}
 				group.start += chunkStart
 				group.end += chunkStart
-				if fenceMode {
+				if collapseFence {
 					if group.start >= group.end {
 						continue
 					}
@@ -2052,7 +2061,7 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 		if fenceMode {
 			db.recordDeferredFenceMaterialized(totalKeys, candidateBytes)
 		}
-		if fenceMode && emittedGroups > 0 {
+		if collapseFence && emittedGroups > 0 {
 			db.deferredFenceEmittedGroups.Add(emittedGroups)
 		}
 		ptrKeys = ptrKeys[:0]
@@ -11464,6 +11473,7 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 		chunkBackend := totalLen > backendEntriesCap
 		emittedChunk := false
 		fenceMode := db.outerLeafFenceV2Enabled()
+		collapseFence := fenceMode && db.allowFencePointerCollapse()
 
 		type ptrSetterView interface {
 			SetPointerView(key []byte, ptr page.ValuePtr) error
@@ -11561,7 +11571,7 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 				haveFencePtr = false
 			case entry.IsPtr:
 				emitPtr := true
-				if fenceMode {
+				if collapseFence {
 					if haveFencePtr && entry.ValuePtr == lastFencePtr {
 						emitPtr = false
 					} else {
@@ -12146,6 +12156,7 @@ func (db *DB) flushOneLocked(sync bool) bool {
 			ps, _ := backendBatch.(ptrSetter)
 			var single [1]batch.Entry
 			fenceMode := db.outerLeafFenceV2Enabled()
+			collapseFence := fenceMode && db.allowFencePointerCollapse()
 			var (
 				lastFencePtr page.ValuePtr
 				haveFencePtr bool
@@ -12185,7 +12196,7 @@ func (db *DB) flushOneLocked(sync bool) bool {
 			for iter.Valid() {
 				key := iter.UnsafeKey()
 				val, ptr, flags := iter.UnsafeEntry()
-				if fenceMode && len(prevFenceKey) > 0 && bytes.Compare(key, prevFenceKey) <= 0 {
+				if collapseFence && len(prevFenceKey) > 0 && bytes.Compare(key, prevFenceKey) <= 0 {
 					haveFencePtr = false
 				}
 				if flags&node.FlagTombstone != 0 {
@@ -12212,7 +12223,7 @@ func (db *DB) flushOneLocked(sync bool) bool {
 				} else {
 					if flags&node.FlagPointer != 0 {
 						emitPtr := true
-						if fenceMode {
+						if collapseFence {
 							if haveFencePtr && ptr == lastFencePtr {
 								emitPtr = false
 							} else {

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -1111,8 +1111,8 @@ func TestCachingDB_FlushFenceModeCollapsesPointerEntries_WALOffDeferred(t *testi
 	if leafEntries <= 0 {
 		t.Fatalf("expected at least one persisted entry")
 	}
-	if leafEntries >= totalKeys {
-		t.Fatalf("expected fence collapse to reduce persisted entries, got %d (keys=%d)", leafEntries, totalKeys)
+	if leafEntries != totalKeys {
+		t.Fatalf("expected one persisted entry per key in deferred fence mode, got %d (keys=%d)", leafEntries, totalKeys)
 	}
 
 }
@@ -1205,8 +1205,8 @@ func TestCachingDB_FlushFenceModeDeferredSingletonWritesRegroup(t *testing.T) {
 	if leafEntries <= 0 {
 		t.Fatalf("expected at least one persisted entry")
 	}
-	if leafEntries >= totalKeys {
-		t.Fatalf("expected deferred regrouping to reduce persisted entries, got %d (keys=%d)", leafEntries, totalKeys)
+	if leafEntries != totalKeys {
+		t.Fatalf("expected one persisted entry per key in deferred fence mode, got %d (keys=%d)", leafEntries, totalKeys)
 	}
 
 	for _, i := range []int{0, totalKeys / 2, totalKeys - 1} {
@@ -1398,8 +1398,8 @@ func TestCachingDB_WALOnFenceModeSimpleInlineDefersAndLogsInline(t *testing.T) {
 	if leafEntries <= 0 {
 		t.Fatalf("expected persisted entries")
 	}
-	if leafEntries >= totalKeys {
-		t.Fatalf("expected fence collapse to reduce persisted entries, got %d (keys=%d)", leafEntries, totalKeys)
+	if leafEntries != totalKeys {
+		t.Fatalf("expected one persisted entry per key in deferred fence mode, got %d (keys=%d)", leafEntries, totalKeys)
 	}
 }
 
@@ -1835,8 +1835,8 @@ func TestCachingDB_FlushFenceModeDeferredSingletonWritesRegroupSharded(t *testin
 	if leafEntries <= 0 {
 		t.Fatalf("expected at least one persisted entry")
 	}
-	if leafEntries >= totalKeys {
-		t.Fatalf("expected deferred regrouping to reduce persisted entries, got %d (keys=%d)", leafEntries, totalKeys)
+	if leafEntries != totalKeys {
+		t.Fatalf("expected one persisted entry per key in deferred fence mode, got %d (keys=%d)", leafEntries, totalKeys)
 	}
 
 	for _, i := range []int{0, totalKeys / 2, totalKeys - 1} {
@@ -1913,8 +1913,8 @@ func TestCachingDB_FlushFenceModeDeferredBatchWritesRegroup(t *testing.T) {
 	if leafEntries <= 0 {
 		t.Fatalf("expected at least one persisted entry")
 	}
-	if leafEntries >= totalKeys {
-		t.Fatalf("expected deferred regrouping to reduce persisted entries, got %d (keys=%d)", leafEntries, totalKeys)
+	if leafEntries != totalKeys {
+		t.Fatalf("expected one persisted entry per key in deferred fence mode, got %d (keys=%d)", leafEntries, totalKeys)
 	}
 
 	for _, i := range []int{0, totalKeys / 2, totalKeys - 1} {

--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -503,12 +503,8 @@ func (r valueReader) FenceLookupEnabled() bool {
 }
 
 func (r valueReader) FencePointerLikelyBlock(ptr page.ValuePtr) bool {
-	// Grouped pointers in v2 fence mode can carry outer-leaf fence payloads
-	// without an explicit fence marker bit; grouped fence marker was legacy and
-	// collided with large grouped record-length hints.
-	if page.ValuePtrIsGrouped(ptr) {
-		return true
-	}
+	// Fence expansion should only trigger for explicitly fence-marked pointers.
+	// Grouped pointers are also used by non-fence per-key payloads.
 	return page.ValuePtrIsFenceOuter(ptr)
 }
 

--- a/TreeDB/profile_fast_checkpoint_consistency_test.go
+++ b/TreeDB/profile_fast_checkpoint_consistency_test.go
@@ -1,0 +1,81 @@
+package treedb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/rand"
+	"testing"
+)
+
+func profileFastKey(i int) []byte {
+	k := make([]byte, 8)
+	binary.BigEndian.PutUint64(k, uint64(i))
+	return k
+}
+
+// Regression for deferred v2_fenceptr flush semantics:
+// repeated checkpoint boundaries must not lose last-write-wins visibility.
+func TestProfileFast_CheckpointMaintainsLatestValues(t *testing.T) {
+	profiles := []Profile{ProfileFast, ProfileWALOnFast}
+	for _, profile := range profiles {
+		t.Run(string(profile), func(t *testing.T) {
+			opts := OptionsFor(profile, t.TempDir())
+			db, err := Open(opts)
+			if err != nil {
+				t.Fatalf("open: %v", err)
+			}
+			defer db.Close()
+
+			r := rand.New(rand.NewSource(2))
+			live := make(map[int][]byte, 1024)
+
+			const (
+				ops       = 500
+				keySpace  = 2000
+				checkEach = 100
+			)
+
+			for i := 0; i < ops; i++ {
+				k := r.Intn(keySpace)
+				key := profileFastKey(k)
+
+				if r.Intn(100) < 70 {
+					n := r.Intn(300)
+					value := make([]byte, n)
+					for j := range value {
+						value[j] = byte(r.Intn(256))
+					}
+					if err := db.Set(key, value); err != nil {
+						t.Fatalf("set i=%d k=%d: %v", i, k, err)
+					}
+					live[k] = append([]byte(nil), value...)
+				} else {
+					if err := db.Delete(key); err != nil {
+						t.Fatalf("delete i=%d k=%d: %v", i, k, err)
+					}
+					delete(live, k)
+				}
+
+				if i > 0 && i%checkEach == 0 {
+					if err := db.Checkpoint(); err != nil {
+						t.Fatalf("checkpoint i=%d: %v", i, err)
+					}
+				}
+			}
+
+			if err := db.Checkpoint(); err != nil {
+				t.Fatalf("final checkpoint: %v", err)
+			}
+
+			for k, want := range live {
+				got, err := db.Get(profileFastKey(k))
+				if err != nil {
+					t.Fatalf("get k=%d: %v", k, err)
+				}
+				if !bytes.Equal(got, want) {
+					t.Fatalf("value mismatch k=%d want_len=%d got_len=%d", k, len(want), len(got))
+				}
+			}
+		})
+	}
+}

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -482,14 +482,20 @@ func (t *Tree) lookupFenceValueView(n *node.Node, idx uint16, key []byte) ([]byt
 			if err != nil {
 				return nil, false, err
 			}
-			return val, found, nil
+			if found {
+				return val, true, nil
+			}
+			continue
 		}
 		if t.slabFenceAppender != nil {
 			val, found, err := t.slabFenceAppender.ReadUnsafeFenceAppendForKey(ptr, key, nil)
 			if err != nil {
 				return nil, false, err
 			}
-			return val, found, nil
+			if found {
+				return val, true, nil
+			}
+			continue
 		}
 		return nil, false, nil
 	}
@@ -515,7 +521,7 @@ func (t *Tree) lookupFenceValueViewAppend(n *node.Node, idx uint16, key []byte, 
 				return nil, false, err
 			}
 			if !found {
-				return nil, false, nil
+				continue
 			}
 			if oldLen == 0 {
 				return tail, true, nil
@@ -537,7 +543,7 @@ func (t *Tree) lookupFenceValueViewAppend(n *node.Node, idx uint16, key []byte, 
 				return nil, false, err
 			}
 			if !found {
-				return nil, false, nil
+				continue
 			}
 			return append(dst, val...), true, nil
 		}
@@ -575,12 +581,15 @@ func (t *Tree) lookupFenceHasKey(n *node.Node, idx uint16, key []byte) (found bo
 					if lease != nil {
 						lease.Release()
 					}
-					return false, true, nil
+					continue
 				}
 				keys := lease.Keys()
 				found = fenceSeekContainsKey(keys, pos, key)
 				lease.Release()
-				return found, true, nil
+				if found {
+					return true, true, nil
+				}
+				continue
 			}
 		}
 		if t.slabFenceSeek != nil {
@@ -590,9 +599,12 @@ func (t *Tree) lookupFenceHasKey(n *node.Node, idx uint16, key []byte) (found bo
 			}
 			if ok {
 				if below || above {
-					return false, true, nil
+					continue
 				}
-				return fenceSeekContainsKey(keys, pos, key), true, nil
+				if fenceSeekContainsKey(keys, pos, key) {
+					return true, true, nil
+				}
+				continue
 			}
 		}
 		if t.slabFenceReader != nil {
@@ -600,14 +612,20 @@ func (t *Tree) lookupFenceHasKey(n *node.Node, idx uint16, key []byte) (found bo
 			if err != nil {
 				return false, false, err
 			}
-			return found, true, nil
+			if found {
+				return true, true, nil
+			}
+			continue
 		}
 		if t.slabFenceAppender != nil {
 			_, found, err := t.slabFenceAppender.ReadUnsafeFenceAppendForKey(ptr, key, nil)
 			if err != nil {
 				return false, false, err
 			}
-			return found, true, nil
+			if found {
+				return true, true, nil
+			}
+			continue
 		}
 		return false, false, nil
 	}

--- a/TreeDB/tree/tree_test.go
+++ b/TreeDB/tree/tree_test.go
@@ -619,6 +619,76 @@ func TestTreeGet_FencePredecessorLookup(t *testing.T) {
 	}
 }
 
+func TestTreeGet_FencePredecessorLookupContinuesAfterPointerMiss(t *testing.T) {
+	dir := t.TempDir()
+	idxPath := filepath.Join(dir, "index.db")
+	p, err := pager.Open(idxPath, 65536)
+	if err != nil {
+		t.Fatalf("Pager open failed: %v", err)
+	}
+	defer p.Close()
+
+	if _, err := p.Alloc(1); err != nil {
+		t.Fatalf("Alloc root: %v", err)
+	}
+
+	reader := newFenceLookupReader()
+	ptr0 := reader.addBlock(map[string]string{
+		"k010": "v10",
+		"k020": "v20",
+	})
+	ptrMid := reader.addBlock(map[string]string{
+		"k015": "v15",
+	})
+	ptr1 := reader.addBlock(map[string]string{
+		"k110": "v110",
+	})
+
+	rootData, err := p.Get(0)
+	if err != nil {
+		t.Fatalf("Get root page: %v", err)
+	}
+	root := node.NewNode(rootData)
+	root.SetType(page.PageTypeLeaf)
+	root.SetPageID(0)
+	if err := root.AddLeafEntry([]byte("k010"), nil, node.FlagPointer, ptr0); err != nil {
+		t.Fatalf("AddLeafEntry(k010): %v", err)
+	}
+	if err := root.AddLeafEntry([]byte("k015"), nil, node.FlagPointer, ptrMid); err != nil {
+		t.Fatalf("AddLeafEntry(k015): %v", err)
+	}
+	if err := root.AddLeafEntry([]byte("k110"), nil, node.FlagPointer, ptr1); err != nil {
+		t.Fatalf("AddLeafEntry(k110): %v", err)
+	}
+	root.UpdateChecksum()
+
+	tr := New(p, reader, 0)
+
+	got, err := tr.Get([]byte("k020"))
+	if err != nil {
+		t.Fatalf("Get(k020): %v", err)
+	}
+	if string(got) != "v20" {
+		t.Fatalf("Get(k020) = %q, want %q", got, "v20")
+	}
+
+	gotAppend, err := tr.GetAppend([]byte("k020"), []byte("prefix-"))
+	if err != nil {
+		t.Fatalf("GetAppend(k020): %v", err)
+	}
+	if string(gotAppend) != "prefix-v20" {
+		t.Fatalf("GetAppend(k020) = %q, want %q", gotAppend, "prefix-v20")
+	}
+
+	has, err := tr.Has([]byte("k020"))
+	if err != nil {
+		t.Fatalf("Has(k020): %v", err)
+	}
+	if !has {
+		t.Fatalf("Has(k020) = false, want true")
+	}
+}
+
 func TestTreeGet_FencePredecessorLookupSkipsNonPointers(t *testing.T) {
 	dir := t.TempDir()
 	idxPath := filepath.Join(dir, "index.db")


### PR DESCRIPTION
## Summary
- Diagnose and fix a correctness bug where set followed by get could return missing under ProfileFast / ProfileWALOnFast with checkpoint boundaries.
- Root cause was deferred v2 fence-pointer collapse behavior using mutable user keys as fence anchors; later writes to those keys could orphan sibling keys.
- Also harden fence predecessor lookup to continue scanning when a predecessor pointer block does not contain the key.

## What changed
- Disable fence-pointer collapse in caching deferred flush path (`allowFencePointerCollapse` returns false) to prevent orphaning.
- Route deferred pointer tagging so fence marker is only applied when collapse is enabled.
- Keep deferred materialization accounting, but stop emitted-group collapse accounting when collapse is disabled.
- `tree` fence miss lookup now continues scanning predecessor pointers for Get, GetAppend, and Has.
- `valueReader.FencePointerLikelyBlock` now requires explicit fence marking, avoiding false fence expansion for generic grouped pointers.
- Added regression test: `TestProfileFast_CheckpointMaintainsLatestValues`.
- Added focused tree regression: `TestTreeGet_FencePredecessorLookupContinuesAfterPointerMiss`.
- Updated caching tests that previously asserted collapsed persisted-entry counts.

## Validation
- `go test ./TreeDB -run TestProfileFast_CheckpointMaintainsLatestValues -count=5`
- `go test ./TreeDB -run 'TestProfileFast_CheckpointMaintainsLatestValues|TestIssue579_Repro_ProfileFast_ForwardAfterReverse|TestIssue581_ReverseRange_ForcePointers' -count=1`
- `go test ./TreeDB/caching -run 'TestCachingDB_FlushFenceModeCollapsesPointerEntries_WALOffDeferred|TestCachingDB_FlushFenceModeDeferredSingletonWritesRegroup|TestCachingDB_WALOnFenceModeSimpleInlineDefersAndLogsInline|TestCachingDB_FlushFenceModeDeferredSingletonWritesRegroupSharded|TestCachingDB_FlushFenceModeDeferredBatchWritesRegroup' -count=1`
- `go test ./TreeDB/tree -run 'TestTreeGet_FencePredecessorLookup|TestTreeGet_FencePredecessorLookupContinuesAfterPointerMiss|TestTreeGet_FencePredecessorLookupSkipsNonPointers' -count=1`
- `go test ./TreeDB/...`
