### PR TITLE
test: add treemap CLI subprocess integration coverage

### DIFF
--- a/TreeDB/cmd/treemap/treemap_cli_integration_test.go
+++ b/TreeDB/cmd/treemap/treemap_cli_integration_test.go
@@ -147,6 +147,14 @@ func TestTreemapCLI_SafetyGuards(t *testing.T) {
 	if !strings.Contains(scanRes.stderr, "scan requires -allow-values") {
 		t.Fatalf("scan guard stderr mismatch: %q", scanRes.stderr)
 	}
+
+	scanJSONLRes := runTreemapCLI(t, "scan-jsonl", dir)
+	if scanJSONLRes.exitCode != 1 {
+		t.Fatalf("scan-jsonl guard exit code: got %d, want %d (stderr=%q)", scanJSONLRes.exitCode, 1, scanJSONLRes.stderr)
+	}
+	if !strings.Contains(scanJSONLRes.stderr, "scan-jsonl requires -allow-values") {
+		t.Fatalf("scan-jsonl guard stderr mismatch: %q", scanJSONLRes.stderr)
+	}
 }
 
 func TestTreemapCLI_CheckpointRWSuccess(t *testing.T) {


### PR DESCRIPTION
## Summary
- add subprocess-based CLI integration coverage for treemap command dispatch and safety guards
- cover happy-path behavior for get/keys/scan/scan-jsonl/import-jsonl on real temp DBs
- cover usage/help and unknown-command exit paths
- cover operational checkpoint success path and guard failure paths (checkpoint without -rw, scan without -allow-values)

## Why
The package previously had narrow helper-only coverage. These tests execute command paths through main() in isolated subprocesses, increasing confidence in flag wiring, output contracts, and exit behavior.

## Validation
- go test ./TreeDB/cmd/treemap -count=1
- package coverage ~45.7% (up from ~11.6% baseline)
