### PR TITLE
fix: use full leaf split separators for sparse fence layouts

### DIFF
--- a/TreeDB/db/grouped_fence_split_separator_regression_test.go
+++ b/TreeDB/db/grouped_fence_split_separator_regression_test.go
@@ -1,0 +1,146 @@
+package db
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/outerleaf"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func encodeOuterLeafBlockForTest(t *testing.T, start, count int, value []byte) []byte {
+	t.Helper()
+	entries := make([]outerleaf.TypedEntry, 0, count)
+	for i := 0; i < count; i++ {
+		k := []byte(fmt.Sprintf("k%08d", start+i))
+		v := append([]byte(nil), value...)
+		entries = append(entries, outerleaf.TypedEntry{
+			Key:   k,
+			Kind:  outerleaf.EntryKindInline,
+			Value: v,
+		})
+	}
+	payload, err := outerleaf.EncodeTypedEntries(nil, entries, 0, 16)
+	if err != nil {
+		t.Fatalf("EncodeTypedEntries: %v", err)
+	}
+	return payload
+}
+
+// Regression: when leaves are sparse fence anchors, parent separators must use
+// the full right-start key. Shortened separators can route point reads into the
+// wrong child and drop valid keys.
+func TestGroupedFencePointGetAcrossSplitUsesFullSeparator(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{
+		Dir:                     dir,
+		Durability:              DurabilityWALOffRelaxed,
+		LeafPrefixCompression:   true,
+		IndexColumnarLeaves:     true,
+		IndexPackedValuePtr:     true,
+		IndexInternalBaseDelta:  true,
+		IndexOuterLeafMode:      IndexOuterLeafModeV2FencePtr,
+		PreferAppendAlloc:       true,
+		DisablePiggybackCompaction: true,
+		ValueLog: ValueLogOptions{
+			ReadIntegrity:              IntegritySkipChecksums,
+			ForcePointers:              true,
+			OuterLeafBlockCacheEntries: 16384,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	const total = 10000
+	const blockSize = 39
+	const frameK = 16
+	const writeBatch = 257
+	value := bytes.Repeat([]byte{'x'}, 80)
+
+	fileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	segPath := filepath.Join(dir, "wal", "value-l0-000001.log")
+	if err := os.MkdirAll(filepath.Dir(segPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	w, err := valuelog.NewWriter(segPath, fileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type anchorPtr struct {
+		key []byte
+		ptr page.ValuePtr
+	}
+	anchors := make([]anchorPtr, 0, total/blockSize+1)
+	rid := uint64(1)
+	for start := 0; start < total; {
+		recs := make([]valuelog.Record, 0, frameK)
+		keys := make([][]byte, 0, frameK)
+		for j := 0; j < frameK && start < total; j++ {
+			remaining := total - start
+			n := blockSize
+			if remaining < n {
+				n = remaining
+			}
+			payload := encodeOuterLeafBlockForTest(t, start, n, value)
+			recs = append(recs, valuelog.Record{RID: rid, Value: payload})
+			keys = append(keys, []byte(fmt.Sprintf("k%08d", start)))
+			rid++
+			start += n
+		}
+		ptrs, err := w.AppendFrame(0, nil, recs)
+		if err != nil {
+			t.Fatalf("AppendFrame: %v", err)
+		}
+		for i := range ptrs {
+			anchors = append(anchors, anchorPtr{key: keys[i], ptr: ptrs[i]})
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.valueLogManager.Refresh(); err != nil {
+		t.Fatalf("valueLogManager.Refresh: %v", err)
+	}
+	if err := d.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+
+	for i := 0; i < len(anchors); i += writeBatch {
+		end := i + writeBatch
+		if end > len(anchors) {
+			end = len(anchors)
+		}
+		b := d.NewBatch().(*Batch)
+		for _, ap := range anchors[i:end] {
+			if err := b.SetPointer(ap.key, ap.ptr); err != nil {
+				t.Fatalf("SetPointer(%s): %v", ap.key, err)
+			}
+		}
+		if err := b.WriteSync(); err != nil {
+			t.Fatalf("WriteSync anchors: %v", err)
+		}
+		_ = b.Close()
+	}
+
+	for i := 7220; i <= 7253; i++ {
+		k := []byte(fmt.Sprintf("k%08d", i))
+		v, err := d.Get(k)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", k, err)
+		}
+		if len(v) != len(value) {
+			t.Fatalf("Get(%s) len=%d want=%d", k, len(v), len(value))
+		}
+	}
+}

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -868,13 +868,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 		}
 		if err == node.ErrNodeFull {
 			// SPLIT!
-			// Capture the left boundary key before target may be returned to the
-			// builder pool (and potentially reused/reset).
 			allocHint := target.PageID()
-			var leftMax []byte
-			if lm := target.LeafPrevKey(); len(lm) > 0 {
-				leftMax = cloneKeyIntoArena(lm, &splitKeyArena)
-			}
 
 			// 1. Finish current target (writes header/checksum)
 			if target != builder {
@@ -908,12 +902,10 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			splitBuilder.SetPageID(sid)
 
 			// Record split
-			var splitKey []byte
-			if len(leftMax) > 0 {
-				splitKey = shortestSeparatorIntoArena(leftMax, key, &splitKeyArena)
-			} else {
-				splitKey = cloneKeyIntoArena(key, &splitKeyArena)
-			}
+			// Use the full first key of the right node as the parent separator.
+			// Shortened separators are unsafe for sparse/fence layouts where leaf
+			// entries are not a complete key set.
+			splitKey := cloneKeyIntoArena(key, &splitKeyArena)
 			// Split keys escape this call via the returned []Split, so clone out of
 			// the local arena before appending.
 			splitKey = append([]byte(nil), splitKey...)


### PR DESCRIPTION
## Summary
- stop shortening leaf split separators in zipper merge path
- always use the full first key of the right split node as the parent separator
- add a regression test that reproduces grouped-fence point-read misses across a split boundary

## Why
In sparse fence-anchor layouts, shortened separators can route lookups to the wrong child. That caused deterministic misses for keys in the window between persisted fence anchors.

## Testing
- go test ./TreeDB/zipper -count=1
- go test ./TreeDB/db -run TestGroupedFencePointGetAcrossSplitUsesFullSeparator -count=1
- go test ./TreeDB/node -count=1
- go test ./TreeDB/tree -count=1
- go test ./TreeDB/db -count=1