### PR TITLE
test: document iterator snapshot pinned-view behavior

### DIFF
--- a/TreeDB/caching/append_only_snapshot_flush_test.go
+++ b/TreeDB/caching/append_only_snapshot_flush_test.go
@@ -90,7 +90,12 @@ func TestAppendOnlyIteratorSnapshot_PinsOldViewAcrossFlush_CurrentBehavior(t *te
 	if err != nil {
 		t.Fatalf("iterator: %v", err)
 	}
-	defer func() { _ = it.Close() }()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = it.Close()
+		}
+	}()
 
 	viewBeforeFlush := db.memtables.Load()
 	if viewBeforeFlush == nil || len(viewBeforeFlush.queue) != 1 {
@@ -152,6 +157,7 @@ func TestAppendOnlyIteratorSnapshot_PinsOldViewAcrossFlush_CurrentBehavior(t *te
 	if err := it.Close(); err != nil {
 		t.Fatalf("iterator close: %v", err)
 	}
+	closed = true
 	if refs := viewBeforeFlush.refs.Load(); refs != 0 {
 		t.Fatalf("old view refs after iterator close=%d want=0", refs)
 	}


### PR DESCRIPTION
## Summary
- add coverage for append-only mutable read-hot behavior (repeated `Get` probes mutable memtable)
- add coverage for current iterator snapshot semantics across flush
- document explicitly that the pinned-old-view behavior is current behavior and a future failure could indicate an intentional improvement

## Why
This codifies the current behavior we observed during sync forensics: flush can publish a newer view while a long-lived iterator keeps using the old pinned view until close.

## Testing
- go test ./TreeDB/caching -run 'TestAppendOnlyIteratorSnapshot_PinsOldViewAcrossFlush_CurrentBehavior|TestAppendOnlyMutable_RepeatedGetsHitMutableMemtable' -count=1
