### PR TITLE
db: parallelize GetMany with a worker-pool path

### DIFF
--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -2,11 +2,71 @@ package db
 
 import (
 	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/tree"
 )
+
+const (
+	getManyValueGuessBytes          = 128
+	getManyMaxArenaBytes            = 1 << 20
+	getManyParallelMinKeys          = 128
+	getManyParallelMinKeysPerWorker = 32
+	getManyParallelMaxWorkers       = 8
+)
+
+var getManyEmptyValue = []byte{}
+
+func getManyArenaCap(keyCount int) int {
+	if keyCount <= 0 {
+		return 0
+	}
+	arenaCap := keyCount * getManyValueGuessBytes
+	if arenaCap < 0 {
+		arenaCap = 0
+	}
+	if arenaCap > getManyMaxArenaBytes {
+		arenaCap = getManyMaxArenaBytes
+	}
+	return arenaCap
+}
+
+func getManyWorkerCount(keyCount int) int {
+	if keyCount <= 0 {
+		return 1
+	}
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > getManyParallelMaxWorkers {
+		workers = getManyParallelMaxWorkers
+	}
+	if workers > keyCount {
+		workers = keyCount
+	}
+	return workers
+}
+
+func getManyCanParallelize(keyCount, workers int) bool {
+	if keyCount < getManyParallelMinKeys {
+		return false
+	}
+	if workers <= 1 {
+		return false
+	}
+	return keyCount/workers >= getManyParallelMinKeysPerWorker
+}
+
+func getManyChunkBounds(worker, workers, keyCount int) (int, int) {
+	start := (worker * keyCount) / workers
+	end := ((worker + 1) * keyCount) / workers
+	return start, end
+}
 
 // --- Public API ---
 
@@ -35,21 +95,23 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 	snap := db.AcquireSnapshot()
 	defer snap.Close()
 
+	workers := getManyWorkerCount(len(keys))
+	if getManyCanParallelize(len(keys), workers) {
+		if err := db.getManyParallel(snap, keys, out, workers); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+	if err := db.getManySequential(snap, keys, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (db *DB) getManySequential(snap *Snapshot, keys [][]byte, out [][]byte) error {
 	// Copy all found values into a single arena to avoid one allocation per key.
 	// Each returned slice is capacity-capped to preserve safe-copy semantics.
-	const (
-		getManyValueGuessBytes = 128
-		getManyMaxArenaBytes   = 1 << 20
-	)
-	arenaCap := len(keys) * getManyValueGuessBytes
-	if arenaCap < 0 {
-		arenaCap = 0
-	}
-	if arenaCap > getManyMaxArenaBytes {
-		arenaCap = getManyMaxArenaBytes
-	}
-	arena := make([]byte, 0, arenaCap)
-	emptyValue := []byte{}
+	arena := make([]byte, 0, getManyArenaCap(len(keys)))
 	for i, key := range keys {
 		start := len(arena)
 		nextArena, err := snap.GetAppend(key, arena)
@@ -57,16 +119,64 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 			continue
 		}
 		if err != nil {
-			return nil, err
+			return err
 		}
 		arena = nextArena
 		if len(arena) == start {
-			out[i] = emptyValue
+			out[i] = getManyEmptyValue
 			continue
 		}
 		out[i] = arena[start:len(arena):len(arena)]
 	}
-	return out, nil
+	return nil
+}
+
+func (db *DB) getManyParallel(snap *Snapshot, keys [][]byte, out [][]byte, workers int) error {
+	var (
+		wg       sync.WaitGroup
+		stop     atomic.Bool
+		firstErr error
+		errMu    sync.Mutex
+	)
+	for worker := 0; worker < workers; worker++ {
+		start, end := getManyChunkBounds(worker, workers, len(keys))
+		if start >= end {
+			continue
+		}
+		workerArenaCap := getManyArenaCap(end - start)
+		wg.Add(1)
+		go func(start, end, arenaCap int) {
+			defer wg.Done()
+			arena := make([]byte, 0, arenaCap)
+			for i := start; i < end; i++ {
+				if stop.Load() {
+					return
+				}
+				arenaStart := len(arena)
+				nextArena, err := snap.GetAppend(keys[i], arena)
+				if err == tree.ErrKeyNotFound {
+					continue
+				}
+				if err != nil {
+					errMu.Lock()
+					if firstErr == nil {
+						firstErr = err
+						stop.Store(true)
+					}
+					errMu.Unlock()
+					return
+				}
+				arena = nextArena
+				if len(arena) == arenaStart {
+					out[i] = getManyEmptyValue
+					continue
+				}
+				out[i] = arena[arenaStart:len(arena):len(arena)]
+			}
+		}(start, end, workerArenaCap)
+	}
+	wg.Wait()
+	return firstErr
 }
 
 // GetUnsafe returns the value for a key.

--- a/TreeDB/db/getmany_test.go
+++ b/TreeDB/db/getmany_test.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"bytes"
+	"fmt"
+	"runtime"
 	"testing"
 )
 
@@ -107,5 +109,107 @@ func TestGetMany_ValueSlicesAreCapacityCapped(t *testing.T) {
 	}
 	if !bytes.Equal(second, []byte("WXYZ")) {
 		t.Fatalf("db k2 changed: got=%q want=%q", second, []byte("WXYZ"))
+	}
+}
+
+func TestGetMany_ParallelPath_OrderMissingEmptyAndDefensiveCopy(t *testing.T) {
+	prevProcs := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(prevProcs)
+
+	const (
+		storedKeys = 256
+		batchKeys  = 512
+	)
+	workers := getManyWorkerCount(batchKeys)
+	if !getManyCanParallelize(batchKeys, workers) {
+		t.Skipf("parallel GetMany not enabled for this runtime (workers=%d)", workers)
+	}
+
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+
+	for i := 0; i < storedKeys; i++ {
+		key := []byte(fmt.Sprintf("k%03d", i))
+		value := []byte(fmt.Sprintf("v%03d", i))
+		if err := d.Set(key, value); err != nil {
+			t.Fatalf("Set(%q): %v", key, err)
+		}
+	}
+	if err := d.Set([]byte("dup"), []byte("dup-value")); err != nil {
+		t.Fatalf("Set(dup): %v", err)
+	}
+	if err := d.Set([]byte("empty"), []byte{}); err != nil {
+		t.Fatalf("Set(empty): %v", err)
+	}
+
+	keys := make([][]byte, batchKeys)
+	want := make([][]byte, batchKeys)
+	dupIdx := make([]int, 0, 8)
+	for i := 0; i < batchKeys; i++ {
+		switch {
+		case i%97 == 0:
+			keys[i] = []byte("dup")
+			want[i] = []byte("dup-value")
+			dupIdx = append(dupIdx, i)
+		case i%89 == 0:
+			keys[i] = []byte("empty")
+			want[i] = []byte{}
+		case i%53 == 0:
+			keys[i] = []byte(fmt.Sprintf("missing-%03d", i))
+			want[i] = nil
+		default:
+			idx := i % storedKeys
+			keys[i] = []byte(fmt.Sprintf("k%03d", idx))
+			want[i] = []byte(fmt.Sprintf("v%03d", idx))
+		}
+	}
+
+	got, err := d.GetMany(keys)
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+	if len(got) != len(keys) {
+		t.Fatalf("len(GetMany)=%d want %d", len(got), len(keys))
+	}
+	for i := range keys {
+		if want[i] == nil {
+			if got[i] != nil {
+				t.Fatalf("got[%d]=%q want nil for missing key", i, got[i])
+			}
+			continue
+		}
+		if len(want[i]) == 0 {
+			if got[i] == nil || len(got[i]) != 0 {
+				t.Fatalf("got[%d]=%q want empty (non-nil) value", i, got[i])
+			}
+			continue
+		}
+		if !bytes.Equal(got[i], want[i]) {
+			t.Fatalf("got[%d]=%q want %q", i, got[i], want[i])
+		}
+	}
+
+	if len(dupIdx) < 2 {
+		t.Fatalf("expected at least 2 duplicate entries, got %d", len(dupIdx))
+	}
+	firstDup := dupIdx[0]
+	secondDup := dupIdx[1]
+	if firstDup == secondDup || got[firstDup] == nil || got[secondDup] == nil {
+		t.Fatalf("invalid duplicate slots: first=%d second=%d", firstDup, secondDup)
+	}
+	got[firstDup][0] = 'X'
+	if !bytes.Equal(got[secondDup], []byte("dup-value")) {
+		t.Fatalf("duplicate value aliased after mutation: got[%d]=%q", secondDup, got[secondDup])
+	}
+	latest, err := d.Get([]byte("dup"))
+	if err != nil {
+		t.Fatalf("Get(dup): %v", err)
+	}
+	if !bytes.Equal(latest, []byte("dup-value")) {
+		t.Fatalf("db value changed after caller mutation: got=%q want %q", latest, []byte("dup-value"))
 	}
 }


### PR DESCRIPTION
## Summary
- Implement a worker-pool style parallel path for `TreeDB/db.(*DB).GetMany`.
- Keep a guarded sequential fast path for small batches to avoid unnecessary goroutine/sync overhead.
- Preserve correctness semantics: input order, missing keys as `nil`, empty values as non-`nil` empty slices, and defensive-copy behavior.
- Add a dedicated test that forces the parallel path and validates ordering + alias-safety invariants.

## Code Changes
- `TreeDB/db/api.go`
  - Added parallelization helpers (`getManyWorkerCount`, `getManyCanParallelize`, `getManyChunkBounds`, arena sizing).
  - Split implementation into:
    - `getManySequential(...)` (existing arena-copy model)
    - `getManyParallel(...)` (bounded worker pool, per-worker arenas, first-error cancellation)
- `TreeDB/db/getmany_test.go`
  - Added `TestGetMany_ParallelPath_OrderMissingEmptyAndDefensiveCopy`.

## Correctness Validation
- `GOWORK=off go test ./TreeDB/db -run "GetMany|TestGetMany" -count=1`
- `GOWORK=off go test -race ./TreeDB/db -run TestGetMany_ParallelPath_OrderMissingEmptyAndDefensiveCopy -count=1`
- `GOWORK=off go test ./TreeDB/db -count=1`
- `GOWORK=off go test ./kvstore/adapters/treedb -count=1`

## Throughput Validation (`unified-bench`)
Compared a clean baseline build from a detached worktree at the same commit vs this branch.

Command shape:

```bash
./bin/unified-bench \
  -dbs treedb \
  -profile fast \
  -test sequential_write,random_read_batch \
  -keys 300000 \
  -batchsize 512 \
  -checkpoint-between-tests \
  -progress=false \
  -format markdown
```

`random_read_batch` (`batchsize=512`) runs:

| Build | run1 | run2 | run3 | median |
|---|---:|---:|---:|---:|
| baseline | 428,173 | 429,800 | 428,436 | 428,436 |
| this branch | 2,082,561 | 1,946,750 | 1,960,874 | 1,960,874 |

Median delta: **+357.68%**.

Additional spot checks:
- `batchsize=256`: `372,291` -> `1,153,489`
- `batchsize=128` (below parallel threshold): `419,990` -> `426,270`
- `batchsize=16` (sequential fast path): `405,155` -> `401,754`

Scaling sample (`GOMAXPROCS`, `batchsize=512`, this branch):
- `2`: `678,123`
- `4`: `1,274,201`
- `8`: `1,913,761`
- `12`: `1,844,807`

## Allocation Profile Notes
`random_read_batch`, keys=200k, batchsize=512:
- alloc space: `28,342 KB` -> `29,814 KB` (**+5.19%**)
- alloc objects: `832` -> `5,338`
- alloc objects/op: `0.00416` -> `0.02669`

The object count increase comes from per-worker parallel execution structures/arena lifetimes, while overall alloc-space growth is modest relative to throughput gains.
