### PR TITLE
treedb: preserve v2 fence semantics in online value-log rewrite

### DIFF
--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -280,9 +280,14 @@ func preserveFenceMarkerOnRewrite(ptr page.ValuePtr, raw []byte) bool {
 	if !page.ValuePtrIsGrouped(ptr) {
 		return true
 	}
+	if !outerleaf.HasMagic(raw) {
+		return false
+	}
 	// Grouped pointers may carry a legacy bit-23 marker collision. Preserve the
-	// fence marker only when the payload is an actual outer-leaf fence block.
-	return outerleaf.HasMagic(raw)
+	// fence marker only when the payload structurally decodes as an outer-leaf
+	// block (magic prefix alone is not sufficient).
+	_, err := outerleaf.DecodeBlockWithVerify(raw, nil, false)
+	return err == nil
 }
 
 func readValueLogRecordLengthFromHeader(r io.ReaderAt, start int64) (uint32, error) {

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -245,7 +245,10 @@ func TestValueLogRewriteOffline_LegacyGroupedFenceMarkerHint(t *testing.T) {
 func TestValueLogRewrite_HealthMetadata_PreservedAcrossReopen(t *testing.T) {
 	dir := t.TempDir()
 
-	db, err := Open(Options{Dir: dir})
+	db, err := Open(Options{
+		Dir:                dir,
+		IndexOuterLeafMode: IndexOuterLeafModeV1,
+	})
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -307,7 +310,10 @@ func TestValueLogRewrite_HealthMetadata_PreservedAcrossReopen(t *testing.T) {
 func TestValueLogRewrite_BatchedPointerSwap_ReopenPreservesData(t *testing.T) {
 	dir := t.TempDir()
 
-	db, err := Open(Options{Dir: dir})
+	db, err := Open(Options{
+		Dir:                dir,
+		IndexOuterLeafMode: IndexOuterLeafModeV1,
+	})
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -614,7 +620,10 @@ func TestValueLogRewriteOnline_PreservesFenceOuterMarkerAndIteratorParity(t *tes
 func TestValueLogRewriteOnline_LegacyGroupedFenceMarkerHint_DoesNotUpgradeToFencePointer(t *testing.T) {
 	dir := t.TempDir()
 
-	db, err := Open(Options{Dir: dir})
+	db, err := Open(Options{
+		Dir:                dir,
+		IndexOuterLeafMode: IndexOuterLeafModeV1,
+	})
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -637,8 +646,9 @@ func TestValueLogRewriteOnline_LegacyGroupedFenceMarkerHint_DoesNotUpgradeToFenc
 	if err != nil {
 		t.Fatalf("writer: %v", err)
 	}
+	fakeOuterLeafPrefixValue := []byte("TOL2-not-a-valid-outerleaf-block")
 	ptrs, err := w.AppendFrame(0, nil, []valuelog.Record{
-		{RID: 1, Value: []byte("alpha")},
+		{RID: 1, Value: fakeOuterLeafPrefixValue},
 		{RID: 2, Value: []byte("beta")},
 	})
 	if err != nil {
@@ -706,7 +716,7 @@ func TestValueLogRewriteOnline_LegacyGroupedFenceMarkerHint_DoesNotUpgradeToFenc
 
 	if _, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
 		BatchSize:     1,
-		SyncEachBatch: true,
+		SyncEachBatch: false,
 	}); err != nil {
 		t.Fatalf("ValueLogRewriteOnline: %v", err)
 	}
@@ -732,7 +742,7 @@ func TestValueLogRewriteOnline_LegacyGroupedFenceMarkerHint_DoesNotUpgradeToFenc
 	if err != nil {
 		t.Fatalf("get k1 after rewrite: %v", err)
 	}
-	if !bytes.Equal(v1, []byte("alpha")) {
+	if !bytes.Equal(v1, fakeOuterLeafPrefixValue) {
 		t.Fatalf("k1 mismatch after rewrite: got=%q", v1)
 	}
 	v2, err := db.Get([]byte("k2"))
@@ -748,7 +758,10 @@ func TestValueLogRewriteOnline_LegacyGroupedFenceMarkerHint_DoesNotUpgradeToFenc
 	}
 	db = nil
 
-	db, err = Open(Options{Dir: dir})
+	db, err = Open(Options{
+		Dir:                dir,
+		IndexOuterLeafMode: IndexOuterLeafModeV1,
+	})
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -756,7 +769,7 @@ func TestValueLogRewriteOnline_LegacyGroupedFenceMarkerHint_DoesNotUpgradeToFenc
 	if err != nil {
 		t.Fatalf("get k1 after reopen: %v", err)
 	}
-	if !bytes.Equal(v1, []byte("alpha")) {
+	if !bytes.Equal(v1, fakeOuterLeafPrefixValue) {
 		t.Fatalf("k1 mismatch after reopen: got=%q", v1)
 	}
 	v2, err = db.Get([]byte("k2"))


### PR DESCRIPTION
## Summary
- preserve explicit `v2_fenceptr` marker semantics during `ValueLogRewriteOnline` by rewriting fence-pointer records through a non-grouped raw-record path
- keep RID uniqueness by rebuilding rewritten records with the rewrite RID allocator instead of raw-copying source RIDs
- avoid ambiguous grouped-bit upgrades: legacy grouped marker collisions are only preserved as fence markers when payload is actually an outer-leaf block
- add rewrite regression coverage for fence iterator/get parity before/after rewrite and after reopen
- add online legacy-grouped regression coverage to ensure grouped marker collisions are not upgraded into explicit fence pointers

## Validation
- `GOWORK=off go test ./TreeDB/db -run 'TestValueLogRewriteOnline_PreservesFenceOuterMarkerAndIteratorParity|TestValueLogRewriteOnline_LegacyGroupedFenceMarkerHint_DoesNotUpgradeToFencePointer|TestValueLogRewriteOffline_LegacyGroupedFenceMarkerHint' -count=1`
- `GOWORK=off go test ./TreeDB -run 'TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity|TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity_OuterLeafV2|TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity_OuterLeafV2FencePtr' -count=1`
- `GOWORK=off go test ./TreeDB -count=1`
- `GOWORK=off go test ./TreeDB/db -count=1`
- `GOWORK=off go test ./cmd/unified_bench -count=1`
- `./bin/unified-bench -dbs treedb -profile fast -keys 200000 -test random_read -progress=false -format text -treedb-index-outer-leaf-mode v2_fenceptr` (Random Read / TreeDB = 80,532)

## Notes
- this PR is Track 1 / PR-B from the fence-pointer bounded-lookup plan (rewrite/remap correctness gate)
