### PR TITLE
Track 1 PR-C: bounded fence predecessor lookups in point-miss paths

### DIFF
--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -826,6 +826,10 @@ func copyFenceKeyRefs(dst [][]byte, src [][]byte) [][]byte {
 }
 
 func (it *Iterator) pointerLikelyFenceBlock(ptr page.ValuePtr) bool {
+	// Explicit fence markers are authoritative and must never be skipped.
+	if page.ValuePtrIsFenceOuter(ptr) {
+		return true
+	}
 	if it != nil && it.slabFencePtrCls != nil {
 		return it.slabFencePtrCls.FencePointerLikelyBlock(ptr)
 	}

--- a/TreeDB/tree/iterator_test.go
+++ b/TreeDB/tree/iterator_test.go
@@ -98,6 +98,10 @@ type fenceLookupReaderSeekLeaseSharedKeys struct {
 	sharedKeys map[page.ValuePtr][][]byte
 }
 
+type iteratorFenceClassifier struct {
+	likely map[page.ValuePtr]bool
+}
+
 func (r *fenceLookupReaderKeysUnavailable) ReadUnsafeFenceBlockKeys(ptr page.ValuePtr) ([][]byte, bool, error) {
 	r.keyCalls++
 	return nil, false, nil
@@ -256,6 +260,57 @@ func (r *fenceLookupReaderSeekLeaseSharedKeys) ReadUnsafeFenceBlockSeekLease(ptr
 		return len(keys), false, true, nil, true, nil
 	}
 	return pos, false, false, &sharedFenceKeysLease{keys: keys}, true, nil
+}
+
+func (c iteratorFenceClassifier) FencePointerLikelyBlock(ptr page.ValuePtr) bool {
+	if c.likely == nil {
+		return true
+	}
+	likely, ok := c.likely[ptr]
+	if !ok {
+		return true
+	}
+	return likely
+}
+
+func TestIteratorPointerLikelyFenceBlock_ExplicitFenceMarkerOverridesClassifier(t *testing.T) {
+	base := page.ValuePtr{
+		FileID: page.ValueLogFileID(3),
+		Offset: 99,
+		Length: 4096,
+	}
+	marked := page.ValuePtrMarkFenceOuter(base)
+	if marked == base {
+		t.Fatalf("expected non-grouped pointer to be fence-marked")
+	}
+	it := &Iterator{
+		slabFencePtrCls: iteratorFenceClassifier{
+			likely: map[page.ValuePtr]bool{
+				marked: false,
+			},
+		},
+	}
+	if !it.pointerLikelyFenceBlock(marked) {
+		t.Fatalf("explicit fence-marked pointer was incorrectly skipped by classifier")
+	}
+}
+
+func TestIteratorPointerLikelyFenceBlock_ClassifierAppliedToUnmarkedPointer(t *testing.T) {
+	unmarked := page.ValuePtr{
+		FileID: page.ValueLogFileID(4),
+		Offset: 11,
+		Length: 2048,
+	}
+	it := &Iterator{
+		slabFencePtrCls: iteratorFenceClassifier{
+			likely: map[page.ValuePtr]bool{
+				unmarked: false,
+			},
+		},
+	}
+	if it.pointerLikelyFenceBlock(unmarked) {
+		t.Fatalf("unmarked pointer unexpectedly treated as fence-likely")
+	}
 }
 
 func newCountingValueReader() *countingValueReader {

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -141,7 +141,8 @@ type slabUnsafeFenceBlockSeekLeaseReader interface {
 }
 
 // Optional fast classifier for whether a pointer is expected to reference a
-// fence-expandable outer-leaf block.
+// fence-expandable outer-leaf block. Returning false must be definitive:
+// callers may skip fence probes entirely on that result.
 type slabFencePointerClassifier interface {
 	FencePointerLikelyBlock(ptr page.ValuePtr) bool
 }
@@ -377,6 +378,18 @@ func (t *Tree) SetRoot(root uint64) {
 	t.rootPageID = root
 }
 
+func (t *Tree) fenceProbeLikelyBlock(ptr page.ValuePtr) bool {
+	// Explicit fence markers are authoritative and must never be skipped.
+	if page.ValuePtrIsFenceOuter(ptr) {
+		return true
+	}
+	if t != nil && t.slabFencePtrCls != nil {
+		return t.slabFencePtrCls.FencePointerLikelyBlock(ptr)
+	}
+	// Readers that do not provide a classifier keep legacy permissive behavior.
+	return true
+}
+
 // GetEntry returns the raw leaf entry (useful for compaction/CAS).
 // CAUTION: Returned entry Key/Value might point directly to mmap memory.
 // Do not modify or hold reference for long.
@@ -477,6 +490,9 @@ func (t *Tree) lookupFenceValueView(n *node.Node, idx uint16, key []byte) ([]byt
 		if flags&node.FlagTombstone != 0 || flags&node.FlagPointer == 0 {
 			continue
 		}
+		if !t.fenceProbeLikelyBlock(ptr) {
+			continue
+		}
 		if t.slabFenceReader != nil {
 			val, found, err := t.slabFenceReader.ReadUnsafeFenceForKey(ptr, key)
 			if err != nil {
@@ -512,6 +528,9 @@ func (t *Tree) lookupFenceValueViewAppend(n *node.Node, idx uint16, key []byte, 
 			return nil, false, err
 		}
 		if flags&node.FlagTombstone != 0 || flags&node.FlagPointer == 0 {
+			continue
+		}
+		if !t.fenceProbeLikelyBlock(ptr) {
 			continue
 		}
 		if t.slabFenceAppender != nil {
@@ -562,6 +581,9 @@ func (t *Tree) lookupFenceHasKey(n *node.Node, idx uint16, key []byte) (found bo
 			return false, false, err
 		}
 		if flags&node.FlagTombstone != 0 || flags&node.FlagPointer == 0 {
+			continue
+		}
+		if !t.fenceProbeLikelyBlock(ptr) {
 			continue
 		}
 		if t.slabFenceSeekL != nil {

--- a/TreeDB/tree/tree_test.go
+++ b/TreeDB/tree/tree_test.go
@@ -29,14 +29,60 @@ type fenceLookupReader struct {
 	keyCalls         int
 }
 
+type fenceLookupClassifierReader struct {
+	*fenceLookupReader
+	likely map[page.ValuePtr]bool
+}
+
+type fenceLookupSeekClassifierReader struct {
+	*fenceLookupSeekReader
+	likely map[page.ValuePtr]bool
+}
+
 func (r *fenceLookupReader) FenceLookupEnabled() bool {
 	return true
+}
+
+func (r *fenceLookupClassifierReader) FencePointerLikelyBlock(ptr page.ValuePtr) bool {
+	if r == nil {
+		return true
+	}
+	if r.likely == nil {
+		return true
+	}
+	likely, ok := r.likely[ptr]
+	if !ok {
+		return true
+	}
+	return likely
+}
+
+func (r *fenceLookupSeekClassifierReader) FencePointerLikelyBlock(ptr page.ValuePtr) bool {
+	if r == nil {
+		return true
+	}
+	if r.likely == nil {
+		return true
+	}
+	likely, ok := r.likely[ptr]
+	if !ok {
+		return true
+	}
+	return likely
 }
 
 func newFenceLookupReader() *fenceLookupReader {
 	return &fenceLookupReader{
 		blocks: make(map[page.ValuePtr]map[string][]byte),
 		fileID: page.ValueLogFileID(1),
+	}
+}
+
+func newFenceLookupClassifierReader() *fenceLookupClassifierReader {
+	base := newFenceLookupReader()
+	return &fenceLookupClassifierReader{
+		fenceLookupReader: base,
+		likely:            make(map[page.ValuePtr]bool),
 	}
 }
 
@@ -130,6 +176,14 @@ func newFenceLookupTailAppenderReader() *fenceLookupTailAppenderReader {
 
 func newFenceLookupSeekReader() *fenceLookupSeekReader {
 	return &fenceLookupSeekReader{fenceLookupReader: newFenceLookupReader()}
+}
+
+func newFenceLookupSeekClassifierReader() *fenceLookupSeekClassifierReader {
+	base := newFenceLookupSeekReader()
+	return &fenceLookupSeekClassifierReader{
+		fenceLookupSeekReader: base,
+		likely:                make(map[page.ValuePtr]bool),
+	}
 }
 
 func newFenceLookupSeekLeaseReader() *fenceLookupSeekLeaseReader {
@@ -689,6 +743,206 @@ func TestTreeGet_FencePredecessorLookupContinuesAfterPointerMiss(t *testing.T) {
 	}
 }
 
+func TestTreeGet_FencePredecessorLookupSkipsPointersClassifiedNonFence(t *testing.T) {
+	dir := t.TempDir()
+	idxPath := filepath.Join(dir, "index.db")
+	p, err := pager.Open(idxPath, 65536)
+	if err != nil {
+		t.Fatalf("Pager open failed: %v", err)
+	}
+	defer p.Close()
+
+	if _, err := p.Alloc(1); err != nil {
+		t.Fatalf("Alloc root: %v", err)
+	}
+
+	reader := newFenceLookupClassifierReader()
+	ptrOld := reader.addBlock(map[string]string{
+		"k010": "v10",
+		"k020": "v20",
+	})
+	ptrSkip := reader.addBlock(map[string]string{
+		"k015": "v15",
+	})
+	ptrUpper := reader.addBlock(map[string]string{
+		"k110": "v110",
+	})
+	reader.likely[ptrOld] = true
+	reader.likely[ptrSkip] = false
+	reader.likely[ptrUpper] = true
+
+	rootData, err := p.Get(0)
+	if err != nil {
+		t.Fatalf("Get root page: %v", err)
+	}
+	root := node.NewNode(rootData)
+	root.SetType(page.PageTypeLeaf)
+	root.SetPageID(0)
+	if err := root.AddLeafEntry([]byte("k010"), nil, node.FlagPointer, ptrOld); err != nil {
+		t.Fatalf("AddLeafEntry(k010): %v", err)
+	}
+	if err := root.AddLeafEntry([]byte("k015"), nil, node.FlagPointer, ptrSkip); err != nil {
+		t.Fatalf("AddLeafEntry(k015): %v", err)
+	}
+	if err := root.AddLeafEntry([]byte("k110"), nil, node.FlagPointer, ptrUpper); err != nil {
+		t.Fatalf("AddLeafEntry(k110): %v", err)
+	}
+	root.UpdateChecksum()
+
+	tr := New(p, reader, 0)
+
+	beforeTotalCalls := reader.fenceCalls + reader.fenceAppendCalls
+	got, err := tr.Get([]byte("k020"))
+	if err != nil {
+		t.Fatalf("Get(k020): %v", err)
+	}
+	if string(got) != "v20" {
+		t.Fatalf("Get(k020) = %q, want %q", got, "v20")
+	}
+	if gotCalls := (reader.fenceCalls + reader.fenceAppendCalls) - beforeTotalCalls; gotCalls != 1 {
+		t.Fatalf("Get(k020) fence lookups = %d, want 1 (classified non-fence predecessor skipped)", gotCalls)
+	}
+
+	beforeTotalCalls = reader.fenceCalls + reader.fenceAppendCalls
+	gotAppend, err := tr.GetAppend([]byte("k020"), []byte("prefix-"))
+	if err != nil {
+		t.Fatalf("GetAppend(k020): %v", err)
+	}
+	if string(gotAppend) != "prefix-v20" {
+		t.Fatalf("GetAppend(k020) = %q, want %q", gotAppend, "prefix-v20")
+	}
+	if gotCalls := (reader.fenceCalls + reader.fenceAppendCalls) - beforeTotalCalls; gotCalls != 1 {
+		t.Fatalf("GetAppend(k020) fence lookups = %d, want 1 (classified non-fence predecessor skipped)", gotCalls)
+	}
+
+	beforeTotalCalls = reader.fenceCalls + reader.fenceAppendCalls
+	has, err := tr.Has([]byte("k020"))
+	if err != nil {
+		t.Fatalf("Has(k020): %v", err)
+	}
+	if !has {
+		t.Fatalf("Has(k020) = false, want true")
+	}
+	if gotCalls := (reader.fenceCalls + reader.fenceAppendCalls) - beforeTotalCalls; gotCalls != 1 {
+		t.Fatalf("Has(k020) fence lookups = %d, want 1 (classified non-fence predecessor skipped)", gotCalls)
+	}
+
+	reader.likely[ptrOld] = false
+	reader.likely[ptrUpper] = false
+	beforeTotalCalls = reader.fenceCalls + reader.fenceAppendCalls
+	if _, err := tr.Get([]byte("k999")); err != ErrKeyNotFound {
+		t.Fatalf("Get(k999): expected ErrKeyNotFound, got %v", err)
+	}
+	if gotCalls := (reader.fenceCalls + reader.fenceAppendCalls) - beforeTotalCalls; gotCalls != 0 {
+		t.Fatalf("Get(k999) issued %d fence lookups despite all predecessors classified non-fence", gotCalls)
+	}
+
+	beforeTotalCalls = reader.fenceCalls + reader.fenceAppendCalls
+	if _, err := tr.GetAppend([]byte("k999"), []byte("prefix-")); err != ErrKeyNotFound {
+		t.Fatalf("GetAppend(k999): expected ErrKeyNotFound, got %v", err)
+	}
+	if gotCalls := (reader.fenceCalls + reader.fenceAppendCalls) - beforeTotalCalls; gotCalls != 0 {
+		t.Fatalf("GetAppend(k999) issued %d fence lookups despite all predecessors classified non-fence", gotCalls)
+	}
+
+	beforeTotalCalls = reader.fenceCalls + reader.fenceAppendCalls
+	has, err = tr.Has([]byte("k999"))
+	if err != nil {
+		t.Fatalf("Has(k999): %v", err)
+	}
+	if has {
+		t.Fatalf("Has(k999) = true, want false")
+	}
+	if gotCalls := (reader.fenceCalls + reader.fenceAppendCalls) - beforeTotalCalls; gotCalls != 0 {
+		t.Fatalf("Has(k999) issued %d fence lookups despite all predecessors classified non-fence", gotCalls)
+	}
+}
+
+func TestTreeGet_FencePredecessorLookupExplicitFenceMarkerOverridesClassifier(t *testing.T) {
+	dir := t.TempDir()
+	idxPath := filepath.Join(dir, "index.db")
+	p, err := pager.Open(idxPath, 65536)
+	if err != nil {
+		t.Fatalf("Pager open failed: %v", err)
+	}
+	defer p.Close()
+
+	if _, err := p.Alloc(1); err != nil {
+		t.Fatalf("Alloc root: %v", err)
+	}
+
+	reader := newFenceLookupClassifierReader()
+	ptrRaw := reader.addBlock(map[string]string{
+		"k010": "v10",
+		"k020": "v20",
+	})
+	ptrMarked := page.ValuePtrMarkFenceOuter(ptrRaw)
+	if ptrMarked == ptrRaw {
+		t.Fatalf("expected non-grouped pointer to be fence-marked")
+	}
+	reader.blocks[ptrMarked] = reader.blocks[ptrRaw]
+	delete(reader.blocks, ptrRaw)
+	reader.likely[ptrMarked] = false // explicit fence marker must still probe
+
+	ptrUpper := reader.addBlock(map[string]string{
+		"k110": "v110",
+	})
+	reader.likely[ptrUpper] = true
+
+	rootData, err := p.Get(0)
+	if err != nil {
+		t.Fatalf("Get root page: %v", err)
+	}
+	root := node.NewNode(rootData)
+	root.SetType(page.PageTypeLeaf)
+	root.SetPageID(0)
+	if err := root.AddLeafEntry([]byte("k010"), nil, node.FlagPointer, ptrMarked); err != nil {
+		t.Fatalf("AddLeafEntry(k010): %v", err)
+	}
+	if err := root.AddLeafEntry([]byte("k110"), nil, node.FlagPointer, ptrUpper); err != nil {
+		t.Fatalf("AddLeafEntry(k110): %v", err)
+	}
+	root.UpdateChecksum()
+
+	tr := New(p, reader, 0)
+
+	beforeTotalCalls := reader.fenceCalls + reader.fenceAppendCalls
+	got, err := tr.Get([]byte("k020"))
+	if err != nil {
+		t.Fatalf("Get(k020): %v", err)
+	}
+	if string(got) != "v20" {
+		t.Fatalf("Get(k020) = %q, want %q", got, "v20")
+	}
+	if gotCalls := (reader.fenceCalls + reader.fenceAppendCalls) - beforeTotalCalls; gotCalls != 1 {
+		t.Fatalf("Get(k020) fence lookups = %d, want 1 (explicit fence marker must probe)", gotCalls)
+	}
+
+	beforeTotalCalls = reader.fenceCalls + reader.fenceAppendCalls
+	gotAppend, err := tr.GetAppend([]byte("k020"), []byte("prefix-"))
+	if err != nil {
+		t.Fatalf("GetAppend(k020): %v", err)
+	}
+	if string(gotAppend) != "prefix-v20" {
+		t.Fatalf("GetAppend(k020) = %q, want %q", gotAppend, "prefix-v20")
+	}
+	if gotCalls := (reader.fenceCalls + reader.fenceAppendCalls) - beforeTotalCalls; gotCalls != 1 {
+		t.Fatalf("GetAppend(k020) fence lookups = %d, want 1 (explicit fence marker must probe)", gotCalls)
+	}
+
+	beforeTotalCalls = reader.fenceCalls + reader.fenceAppendCalls
+	has, err := tr.Has([]byte("k020"))
+	if err != nil {
+		t.Fatalf("Has(k020): %v", err)
+	}
+	if !has {
+		t.Fatalf("Has(k020) = false, want true")
+	}
+	if gotCalls := (reader.fenceCalls + reader.fenceAppendCalls) - beforeTotalCalls; gotCalls != 1 {
+		t.Fatalf("Has(k020) fence lookups = %d, want 1 (explicit fence marker must probe)", gotCalls)
+	}
+}
+
 func TestTreeGet_FencePredecessorLookupContinuesAfterMultiplePointerMisses(t *testing.T) {
 	dir := t.TempDir()
 	idxPath := filepath.Join(dir, "index.db")
@@ -928,6 +1182,142 @@ func TestTreeHas_FencePredecessorLookupUsesSeekWhenAvailable(t *testing.T) {
 	}
 	if reader.fenceAppendCalls != 0 {
 		t.Fatalf("fence append calls = %d, want 0", reader.fenceAppendCalls)
+	}
+}
+
+func TestTreeHas_FencePredecessorLookupSeekSkipsPointersClassifiedNonFence(t *testing.T) {
+	dir := t.TempDir()
+	idxPath := filepath.Join(dir, "index.db")
+	p, err := pager.Open(idxPath, 65536)
+	if err != nil {
+		t.Fatalf("Pager open failed: %v", err)
+	}
+	defer p.Close()
+
+	if _, err := p.Alloc(1); err != nil {
+		t.Fatalf("Alloc root: %v", err)
+	}
+
+	reader := newFenceLookupSeekClassifierReader()
+	ptrOld := reader.addBlock(map[string]string{
+		"k010": "v10",
+		"k020": "v20",
+	})
+	ptrSkip := reader.addBlock(map[string]string{
+		"k015": "v15",
+	})
+	ptrUpper := reader.addBlock(map[string]string{
+		"k110": "v110",
+	})
+	reader.likely[ptrOld] = true
+	reader.likely[ptrSkip] = false
+	reader.likely[ptrUpper] = true
+
+	rootData, err := p.Get(0)
+	if err != nil {
+		t.Fatalf("Get root page: %v", err)
+	}
+	root := node.NewNode(rootData)
+	root.SetType(page.PageTypeLeaf)
+	root.SetPageID(0)
+	if err := root.AddLeafEntry([]byte("k010"), nil, node.FlagPointer, ptrOld); err != nil {
+		t.Fatalf("AddLeafEntry(k010): %v", err)
+	}
+	if err := root.AddLeafEntry([]byte("k015"), nil, node.FlagPointer, ptrSkip); err != nil {
+		t.Fatalf("AddLeafEntry(k015): %v", err)
+	}
+	if err := root.AddLeafEntry([]byte("k110"), nil, node.FlagPointer, ptrUpper); err != nil {
+		t.Fatalf("AddLeafEntry(k110): %v", err)
+	}
+	root.UpdateChecksum()
+
+	tr := New(p, reader, 0)
+
+	beforeSeekCalls := reader.seekCalls
+	has, err := tr.Has([]byte("k020"))
+	if err != nil {
+		t.Fatalf("Has(k020): %v", err)
+	}
+	if !has {
+		t.Fatalf("Has(k020) = false, want true")
+	}
+	if gotCalls := reader.seekCalls - beforeSeekCalls; gotCalls != 1 {
+		t.Fatalf("Has(k020) seek calls = %d, want 1 (classified non-fence predecessor skipped)", gotCalls)
+	}
+
+	reader.likely[ptrOld] = false
+	reader.likely[ptrUpper] = false
+	beforeSeekCalls = reader.seekCalls
+	has, err = tr.Has([]byte("k999"))
+	if err != nil {
+		t.Fatalf("Has(k999): %v", err)
+	}
+	if has {
+		t.Fatalf("Has(k999) = true, want false")
+	}
+	if gotCalls := reader.seekCalls - beforeSeekCalls; gotCalls != 0 {
+		t.Fatalf("Has(k999) seek calls = %d, want 0 when all predecessors classified non-fence", gotCalls)
+	}
+}
+
+func TestTreeHas_FencePredecessorLookupSeekExplicitFenceMarkerOverridesClassifier(t *testing.T) {
+	dir := t.TempDir()
+	idxPath := filepath.Join(dir, "index.db")
+	p, err := pager.Open(idxPath, 65536)
+	if err != nil {
+		t.Fatalf("Pager open failed: %v", err)
+	}
+	defer p.Close()
+
+	if _, err := p.Alloc(1); err != nil {
+		t.Fatalf("Alloc root: %v", err)
+	}
+
+	reader := newFenceLookupSeekClassifierReader()
+	ptrRaw := reader.addBlock(map[string]string{
+		"k010": "v10",
+		"k020": "v20",
+	})
+	ptrMarked := page.ValuePtrMarkFenceOuter(ptrRaw)
+	if ptrMarked == ptrRaw {
+		t.Fatalf("expected non-grouped pointer to be fence-marked")
+	}
+	reader.blocks[ptrMarked] = reader.blocks[ptrRaw]
+	delete(reader.blocks, ptrRaw)
+	reader.likely[ptrMarked] = false // explicit fence marker must still probe
+
+	ptrUpper := reader.addBlock(map[string]string{
+		"k110": "v110",
+	})
+	reader.likely[ptrUpper] = true
+
+	rootData, err := p.Get(0)
+	if err != nil {
+		t.Fatalf("Get root page: %v", err)
+	}
+	root := node.NewNode(rootData)
+	root.SetType(page.PageTypeLeaf)
+	root.SetPageID(0)
+	if err := root.AddLeafEntry([]byte("k010"), nil, node.FlagPointer, ptrMarked); err != nil {
+		t.Fatalf("AddLeafEntry(k010): %v", err)
+	}
+	if err := root.AddLeafEntry([]byte("k110"), nil, node.FlagPointer, ptrUpper); err != nil {
+		t.Fatalf("AddLeafEntry(k110): %v", err)
+	}
+	root.UpdateChecksum()
+
+	tr := New(p, reader, 0)
+
+	beforeSeekCalls := reader.seekCalls
+	has, err := tr.Has([]byte("k020"))
+	if err != nil {
+		t.Fatalf("Has(k020): %v", err)
+	}
+	if !has {
+		t.Fatalf("Has(k020) = false, want true")
+	}
+	if gotCalls := reader.seekCalls - beforeSeekCalls; gotCalls != 1 {
+		t.Fatalf("Has(k020) seek calls = %d, want 1 (explicit fence marker must probe)", gotCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
This is **Track 1 / PR-C** (bounded lookup implementation) for v2 fence-pointer regression work.

It removes unnecessary predecessor fence probes in point-miss paths by gating probes with the fence pointer classifier, while preserving correctness on explicit fence markers.

## What changed
- `TreeDB/tree/tree.go`
  - Added `fenceProbeLikelyBlock` and applied it in:
    - `lookupFenceValueView`
    - `lookupFenceValueViewAppend`
    - `lookupFenceHasKey`
  - Added contract comment on `slabFencePointerClassifier`: `false` is definitive for skip.
  - Added explicit safety override: `page.ValuePtrIsFenceOuter(ptr)` always probes.
- `TreeDB/tree/iterator.go`
  - Updated iterator classifier helper to preserve the same explicit-marker safety rule.
- `TreeDB/tree/tree_test.go`
  - Added classifier-gated predecessor tests for `Get`, `GetAppend`, `Has`.
  - Added all-classified-non-fence negative assertions for `Get`, `GetAppend`, `Has`.
  - Added explicit-fence-marker override tests for both get/has paths.
  - Added seek-path classifier gating test.
  - Added seek-path explicit-fence-marker override test.
- `TreeDB/tree/iterator_test.go`
  - Added unit coverage for iterator pointer classifier helper:
    - explicit marker overrides classifier false
    - classifier applies to unmarked pointers

## Validation
### Focused
- `GOWORK=off go test ./TreeDB/tree -run 'TestTreeGet_FencePredecessorLookupSkipsPointersClassifiedNonFence|TestTreeGet_FencePredecessorLookupExplicitFenceMarkerOverridesClassifier|TestTreeHas_FencePredecessorLookupSeekSkipsPointersClassifiedNonFence|TestTreeHas_FencePredecessorLookupSeekExplicitFenceMarkerOverridesClassifier|TestIteratorPointerLikelyFenceBlock_ExplicitFenceMarkerOverridesClassifier|TestIteratorPointerLikelyFenceBlock_ClassifierAppliedToUnmarkedPointer' -count=1`

### Broad
- `GOWORK=off go test ./TreeDB/tree -count=1`
- `GOWORK=off go test ./TreeDB/db -count=1`
- `GOWORK=off go test ./TreeDB -count=1`
- `GOWORK=off go test ./cmd/unified_bench -count=1`

### Bench smoke
- `./bin/unified-bench -dbs treedb -profile fast -keys 200000 -test random_read -progress=false -format text -treedb-index-outer-leaf-mode v2_fenceptr`
- Result: `Random Read / TreeDB = 64,203` on this branch run.

## Notes
- This PR keeps lookup strictly leaf-predecessor bounded (no unbounded global reverse fallback path introduced).
- Explicit fence markers are treated as authoritative to avoid false negatives when classifier metadata disagrees.
