### PR TITLE
[v1_leaflog PR-1] mode plumbing + guardrails (no semantic change)

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3619,7 +3619,7 @@ type Options struct {
 	// counts by pushing moderate values into the value log.
 	ValueLogPointerThreshold int
 	// IndexOuterLeafMode selects the outer-leaf payload format.
-	// Supported values: "v1", "v2_blockptr", "v2_fenceptr".
+	// Supported values: "v1", "v1_leaflog", "v2_blockptr", "v2_fenceptr".
 	// Empty defaults to "v2_fenceptr".
 	IndexOuterLeafMode string
 	// ValueLogWALFenceMode selects WAL encoding behavior for pointer-eligible
@@ -5034,7 +5034,8 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		indexOuterLeafMode = backenddb.IndexOuterLeafModeV2FencePtr
 	}
 	if indexOuterLeafMode != backenddb.IndexOuterLeafModeV2BlockPtr &&
-		indexOuterLeafMode != backenddb.IndexOuterLeafModeV2FencePtr {
+		indexOuterLeafMode != backenddb.IndexOuterLeafModeV2FencePtr &&
+		indexOuterLeafMode != backenddb.IndexOuterLeafModeV1LeafLog {
 		indexOuterLeafMode = backenddb.IndexOuterLeafModeV1
 	}
 	rawValueLogWALFenceMode := strings.TrimSpace(opts.ValueLogWALFenceMode)
@@ -5042,6 +5043,10 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	if valueLogWALFenceMode != string(backenddb.ValueLogWALFenceModeRIDJoin) &&
 		valueLogWALFenceMode != string(backenddb.ValueLogWALFenceModeSimpleInline) {
 		return nil, fmt.Errorf("cachingdb: invalid value-log WAL fence mode %q", opts.ValueLogWALFenceMode)
+	}
+	if indexOuterLeafMode != backenddb.IndexOuterLeafModeV2FencePtr &&
+		valueLogWALFenceMode == string(backenddb.ValueLogWALFenceModeSimpleInline) {
+		return nil, fmt.Errorf("cachingdb: value-log WAL fence mode %q requires index outer leaf mode %q", opts.ValueLogWALFenceMode, backenddb.IndexOuterLeafModeV2FencePtr)
 	}
 	outerLeafBlockTargetOpt := opts.ValueLogOuterLeafBlockTargetBytes
 	if outerLeafBlockTargetOpt <= 0 && indexOuterLeafMode == backenddb.IndexOuterLeafModeV2FencePtr {

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -1258,6 +1258,26 @@ func TestCachingDB_Open_V2FencePtrWALOn_ExplicitRIDJoinAllowed(t *testing.T) {
 	}
 }
 
+func TestCachingDB_Open_NonFenceMode_RejectsSimpleInlineWALFenceMode(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	defer backend.Close()
+
+	_, err = Open(dir, backend, Options{
+		IndexOuterLeafMode:   db.IndexOuterLeafModeV1LeafLog,
+		ValueLogWALFenceMode: string(db.ValueLogWALFenceModeSimpleInline),
+	})
+	if err == nil {
+		t.Fatalf("expected simple_inline guardrail error in non-fence mode")
+	}
+	if !strings.Contains(err.Error(), "requires index outer leaf mode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestCachingDB_Open_ValueLogOuterLeafBlobThresholdBytes_NegativeRejected(t *testing.T) {
 	dir := t.TempDir()
 	backend, err := db.Open(db.Options{Dir: dir})

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -146,6 +146,8 @@ func normalizeIndexOuterLeafMode(mode string) string {
 		return IndexOuterLeafModeV2FencePtr
 	case IndexOuterLeafModeV1:
 		return IndexOuterLeafModeV1
+	case IndexOuterLeafModeV1LeafLog:
+		return IndexOuterLeafModeV1LeafLog
 	case IndexOuterLeafModeV2BlockPtr:
 		return IndexOuterLeafModeV2BlockPtr
 	case IndexOuterLeafModeV2FencePtr:
@@ -223,6 +225,9 @@ const (
 const (
 	// IndexOuterLeafModeV1 keeps the existing per-key leaf layout.
 	IndexOuterLeafModeV1 = "v1"
+	// IndexOuterLeafModeV1LeafLog keeps v1 exact-key semantics while storing
+	// leaf payload blocks in the value log (no fence fallback semantics).
+	IndexOuterLeafModeV1LeafLog = "v1_leaflog"
 	// IndexOuterLeafModeV2BlockPtr enables the outer-leaf block-pointer payload
 	// format. Values are encoded as key+value blocks in the value log and index
 	// leaves continue to store pointers.
@@ -531,6 +536,8 @@ type Options struct {
 	// IndexOuterLeafMode selects the index outer-leaf format:
 	// - "": defaults to "v2_fenceptr"
 	// - "v1": existing per-key leaf entries
+	// - "v1_leaflog": v1 exact-key semantics with outer-leaf payload blocks
+	//   stored in the value log (no fence-pointer fallback)
 	// - "v2_blockptr": pointer payloads encode key+value outer-leaf blocks
 	// - "v2_fenceptr": fence-key-only index entries with outer block payloads
 	IndexOuterLeafMode string
@@ -919,7 +926,7 @@ func validateOptions(opts Options) error {
 	}
 	indexOuterLeafMode := normalizeIndexOuterLeafMode(opts.IndexOuterLeafMode)
 	switch indexOuterLeafMode {
-	case IndexOuterLeafModeV1, IndexOuterLeafModeV2BlockPtr, IndexOuterLeafModeV2FencePtr:
+	case IndexOuterLeafModeV1, IndexOuterLeafModeV1LeafLog, IndexOuterLeafModeV2BlockPtr, IndexOuterLeafModeV2FencePtr:
 	default:
 		return fmt.Errorf("treedb: invalid index outer leaf mode %q", opts.IndexOuterLeafMode)
 	}
@@ -928,6 +935,9 @@ func validateOptions(opts Options) error {
 	case ValueLogWALFenceModeRIDJoin, ValueLogWALFenceModeSimpleInline:
 	default:
 		return fmt.Errorf("treedb: invalid value-log WAL fence mode %q", opts.ValueLog.WALFenceMode)
+	}
+	if indexOuterLeafMode != IndexOuterLeafModeV2FencePtr && walFenceMode == ValueLogWALFenceModeSimpleInline {
+		return fmt.Errorf("treedb: value-log WAL fence mode %q requires index outer leaf mode %q", opts.ValueLog.WALFenceMode, IndexOuterLeafModeV2FencePtr)
 	}
 	if opts.ValueLog.BlockTargetCompressedBytes < 0 {
 		return fmt.Errorf("treedb: invalid value-log block target compressed bytes %d", opts.ValueLog.BlockTargetCompressedBytes)

--- a/TreeDB/db/outer_leaf_mode_options_test.go
+++ b/TreeDB/db/outer_leaf_mode_options_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestOpen_IndexOuterLeafModeV2_Enabled(t *testing.T) {
 	modes := []string{
+		IndexOuterLeafModeV1LeafLog,
 		IndexOuterLeafModeV2BlockPtr,
 		IndexOuterLeafModeV2FencePtr,
 	}
@@ -133,6 +134,22 @@ func TestOpen_ValueLogWALFenceMode_V2FencePtrWALOff_ExplicitRIDJoinAllowed(t *te
 	}
 	if err := dbWALOff.Close(); err != nil {
 		t.Fatalf("close WAL-off rid_join: %v", err)
+	}
+}
+
+func TestOpen_ValueLogWALFenceMode_V1LeafLog_RejectsSimpleInline(t *testing.T) {
+	_, err := Open(Options{
+		Dir:                t.TempDir(),
+		IndexOuterLeafMode: IndexOuterLeafModeV1LeafLog,
+		ValueLog: ValueLogOptions{
+			WALFenceMode: ValueLogWALFenceModeSimpleInline,
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "requires index outer leaf mode") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/TreeDB/internal/outerleaf/block.go
+++ b/TreeDB/internal/outerleaf/block.go
@@ -18,6 +18,7 @@ import (
 )
 
 const (
+	ModeV1LeafLog  = "v1_leaflog"
 	ModeV2BlockPtr = "v2_blockptr"
 	ModeV2FencePtr = "v2_fenceptr"
 
@@ -264,7 +265,7 @@ func HasMagic(payload []byte) bool {
 
 func ModeEnabled(mode string) bool {
 	switch strings.TrimSpace(mode) {
-	case ModeV2BlockPtr, ModeV2FencePtr:
+	case ModeV1LeafLog, ModeV2BlockPtr, ModeV2FencePtr:
 		return true
 	default:
 		return false

--- a/TreeDB/options_aliases.go
+++ b/TreeDB/options_aliases.go
@@ -61,6 +61,7 @@ const (
 
 const (
 	IndexOuterLeafModeV1         = db.IndexOuterLeafModeV1
+	IndexOuterLeafModeV1LeafLog  = db.IndexOuterLeafModeV1LeafLog
 	IndexOuterLeafModeV2BlockPtr = db.IndexOuterLeafModeV2BlockPtr
 	IndexOuterLeafModeV2FencePtr = db.IndexOuterLeafModeV2FencePtr
 )

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -86,7 +86,7 @@ var (
 	treedbIndexColumnarLeaves             = flag.Bool("treedb-index-columnar-leaves", false, "TreeDB: enable columnar leaf encoding")
 	treedbIndexPackedValuePtr             = flag.Bool("treedb-index-packed-valueptr", false, "TreeDB: enable packed 12-byte ValuePtr encoding for pointer entries in leaf pages")
 	treedbIndexInternalBaseDelta          = flag.Bool("treedb-index-internal-base-delta", false, "TreeDB: enable internal base-delta encoding")
-	treedbIndexOuterLeafMode              = flag.String("treedb-index-outer-leaf-mode", "v2_fenceptr", "TreeDB: index outer-leaf mode (v1|v2_blockptr|v2_fenceptr)")
+	treedbIndexOuterLeafMode              = flag.String("treedb-index-outer-leaf-mode", "v2_fenceptr", "TreeDB: index outer-leaf mode (v1|v1_leaflog|v2_blockptr|v2_fenceptr)")
 	treedbWALFenceMode                    = flag.String("treedb-wal-fence-mode", "rid_join", "TreeDB: WAL fence mode for v2_fenceptr (rid_join|simple_inline). For WAL-on v2_fenceptr, default remains simple_inline unless explicitly set.")
 	treedbOuterLeafBlockTargetBytes       = flag.Int("treedb-outer-leaf-block-target-bytes", 0, "TreeDB: experimental outer-leaf block target bytes (0=default)")
 	treedbOuterLeafBlockCodec             = flag.String("treedb-outer-leaf-block-codec", "snappy", "TreeDB: experimental outer-leaf block codec (snappy|lz4)")
@@ -268,12 +268,14 @@ func parseTreeDBOuterLeafMode(s string) (string, error) {
 		return treedb.IndexOuterLeafModeV2FencePtr, nil
 	case "v1":
 		return treedb.IndexOuterLeafModeV1, nil
+	case "v1_leaflog":
+		return treedb.IndexOuterLeafModeV1LeafLog, nil
 	case "v2_blockptr":
 		return treedb.IndexOuterLeafModeV2BlockPtr, nil
 	case "v2_fenceptr":
 		return treedb.IndexOuterLeafModeV2FencePtr, nil
 	default:
-		return "", fmt.Errorf("unsupported -treedb-index-outer-leaf-mode=%q (expected v1|v2_blockptr|v2_fenceptr)", s)
+		return "", fmt.Errorf("unsupported -treedb-index-outer-leaf-mode=%q (expected v1|v1_leaflog|v2_blockptr|v2_fenceptr)", s)
 	}
 }
 
@@ -612,6 +614,10 @@ func buildTreeDBOptions(dir string) (treedb.Options, treeDBOptionsReport, error)
 	walFenceMode, err := parseTreeDBWALFenceMode(*treedbWALFenceMode)
 	if err != nil {
 		return treedb.Options{}, treeDBOptionsReport{}, err
+	}
+	if opts.IndexOuterLeafMode != treedb.IndexOuterLeafModeV2FencePtr &&
+		walFenceMode == treedb.ValueLogWALFenceModeSimpleInline {
+		return treedb.Options{}, treeDBOptionsReport{}, fmt.Errorf("unsupported -treedb-wal-fence-mode=%q for -treedb-index-outer-leaf-mode=%q (simple_inline requires v2_fenceptr)", *treedbWALFenceMode, *treedbIndexOuterLeafMode)
 	}
 	walFenceModeExplicit := flagExplicit("treedb-wal-fence-mode")
 	walEnabled := opts.Durability != treedb.DurabilityWALOffRelaxed

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -40,6 +40,25 @@ func TestBuildTreeDBOptions_DefaultOuterLeafModeUsesV2FencePtr(t *testing.T) {
 	}
 }
 
+func TestBuildTreeDBOptions_V1LeafLogModeAccepted(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbIndexOuterLeafMode = "v1_leaflog"
+
+	opts, rep, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions v1_leaflog: %v", err)
+	}
+	if got := opts.IndexOuterLeafMode; got != treedb.IndexOuterLeafModeV1LeafLog {
+		t.Fatalf("IndexOuterLeafMode=%q want %q", got, treedb.IndexOuterLeafModeV1LeafLog)
+	}
+	if got := rep.formatText(""); !strings.Contains(got, "index_outer_leaf_mode=v1_leaflog") {
+		t.Fatalf("resolved options missing v1_leaflog outer-leaf mode: %q", got)
+	}
+}
+
 type savedTreeDBFlagState struct {
 	indexOptimizations bool
 	indexOuterLeafMode string
@@ -322,6 +341,7 @@ func TestBuildTreeDBOptions_WALFenceMode_DefaultAndOverride(t *testing.T) {
 	}
 
 	resetTreeDBIndexFlagsForTest()
+	*treedbIndexOuterLeafMode = "v2_fenceptr"
 	*treedbWALFenceMode = "simple_inline"
 	opts, rep, err = buildTreeDBOptions("")
 	if err != nil {
@@ -439,6 +459,21 @@ func TestBuildTreeDBOptions_WALFenceMode_InvalidRejected(t *testing.T) {
 	*treedbWALFenceMode = "bad_mode"
 	if _, _, err := buildTreeDBOptions(""); err == nil {
 		t.Fatalf("expected invalid wal fence mode to fail")
+	}
+}
+
+func TestBuildTreeDBOptions_WALFenceMode_V1LeafLog_RejectsSimpleInline(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbIndexOuterLeafMode = "v1_leaflog"
+	*treedbWALFenceMode = "simple_inline"
+	explicitFlags = map[string]bool{
+		"treedb-wal-fence-mode": true,
+	}
+	if _, _, err := buildTreeDBOptions(""); err == nil {
+		t.Fatalf("expected simple_inline with v1_leaflog to fail")
 	}
 }
 


### PR DESCRIPTION
## Summary
Implements Phase 1 of `#610` / child issue `#618`: adds `v1_leaflog` mode plumbing and fail-closed guardrails without changing read/write semantics.

## Scope
- Added new outer-leaf mode constant: `v1_leaflog`.
- Wired normalization/validation and option aliases so mode is selectable end-to-end.
- Kept defaults unchanged (`v2_fenceptr` remains default).
- Kept fence behavior unchanged: `v1_leaflog` is outer-leaf enabled, but not fence lookup mode.
- Added guardrail: `simple_inline` WAL fence mode is only valid with `v2_fenceptr`.

## Files
- `TreeDB/db/db.go`
- `TreeDB/internal/outerleaf/block.go`
- `TreeDB/options_aliases.go`
- `TreeDB/caching/db.go`
- `TreeDB/caching/db_test.go`
- `TreeDB/db/outer_leaf_mode_options_test.go`
- `cmd/unified_bench/adapter_treedb.go`
- `cmd/unified_bench/profiles_treedb_index_test.go`

## Invariants / Guardrails
- `v1_leaflog` is accepted as a valid `IndexOuterLeafMode`.
- `v1_leaflog` participates in outer-leaf decoding (`ModeEnabled`) but never enables fence lookup behavior.
- `ValueLog.WALFenceMode=simple_inline` is rejected unless `IndexOuterLeafMode=v2_fenceptr`.

## Reviewer loop
- Independent codex-xhigh review pass found one medium issue (entrypoint guardrail mismatch) and one test gap.
- Follow-up patch resolved both:
  - unified-bench guardrail now matches backend behavior for all non-`v2_fenceptr` modes.
  - added caching-layer guardrail test.
- Re-review result: no unresolved blocking findings.

## Tests run
- `GOWORK=off go test ./TreeDB/db -count=1`
- `GOWORK=off go test ./TreeDB/caching -count=1`
- `GOWORK=off go test ./cmd/unified_bench -count=1`

## Risk
- Low: this PR intentionally introduces validation failures for previously-accepted invalid flag combinations (`simple_inline` outside `v2_fenceptr`).

## Owner sign-off
Phase 1 scope is complete and limited to plumbing/guardrails (no runtime semantic migration). Proceeding to next phase only after this PR gate.

Refs: #618
