### PR TITLE
[v1_leaflog PR-2] read path: exact lookup + no-fallback parity

### DIFF
--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -489,9 +489,16 @@ func (r valueReader) outerLeafModeEnabled() bool {
 
 func (r valueReader) fenceLookupModeEnabled() bool {
 	if r.modeInit {
+		if r.outerLeafMode == outerleaf.ModeV1LeafLog {
+			return false
+		}
 		return r.fenceLookupEnabled
 	}
-	return strings.TrimSpace(r.outerLeafMode) == outerleaf.ModeV2FencePtr
+	mode := strings.TrimSpace(r.outerLeafMode)
+	if mode == outerleaf.ModeV1LeafLog {
+		return false
+	}
+	return mode == outerleaf.ModeV2FencePtr
 }
 
 func (r valueReader) KeyAwareEnabled() bool {
@@ -503,6 +510,13 @@ func (r valueReader) FenceLookupEnabled() bool {
 }
 
 func (r valueReader) FencePointerLikelyBlock(ptr page.ValuePtr) bool {
+	if r.modeInit {
+		if r.outerLeafMode == outerleaf.ModeV1LeafLog {
+			return false
+		}
+	} else if strings.TrimSpace(r.outerLeafMode) == outerleaf.ModeV1LeafLog {
+		return false
+	}
 	// Fence expansion should only trigger for explicitly fence-marked pointers.
 	// Grouped pointers are also used by non-fence per-key payloads.
 	return page.ValuePtrIsFenceOuter(ptr)

--- a/TreeDB/db/value_reader_test.go
+++ b/TreeDB/db/value_reader_test.go
@@ -143,6 +143,35 @@ func TestValueReader_FencePointerLikelyBlock_RequiresExplicitFenceMarker(t *test
 	}
 }
 
+func TestValueReader_FenceLookupDisabledForV1LeafLog(t *testing.T) {
+	r := newValueReader(nil, outerleaf.ModeV1LeafLog, false, nil, nil)
+	defer (&r).releaseDecodeContext()
+
+	if !r.KeyAwareEnabled() {
+		t.Fatalf("v1_leaflog should keep key-aware outer-leaf reads enabled")
+	}
+	if r.FenceLookupEnabled() {
+		t.Fatalf("v1_leaflog must not enable fence lookup mode")
+	}
+
+	base := page.ValuePtr{
+		FileID: page.ValueLogFileID(7),
+		Offset: 123,
+		Length: 4096,
+	}
+	fence := page.ValuePtrMarkFenceOuter(base)
+	if r.FencePointerLikelyBlock(fence) {
+		t.Fatalf("v1_leaflog must not classify pointers as fence blocks")
+	}
+
+	grouped := base
+	grouped.Length = page.ValuePtrMarkGrouped(base.Length, 3)
+	groupedFence := page.ValuePtrMarkFenceOuter(grouped)
+	if r.FencePointerLikelyBlock(groupedFence) {
+		t.Fatalf("v1_leaflog must not classify grouped pointers as fence blocks")
+	}
+}
+
 func TestOuterLeafFenceDecodeScratchPoolCapBounded(t *testing.T) {
 	const maxExpected = 8 << 20
 	if outerLeafFenceDecodeScratchMaxRetain > maxExpected {

--- a/TreeDB/reopen_verify_test.go
+++ b/TreeDB/reopen_verify_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -269,6 +270,111 @@ func TestReopenVerify_WALOn_Checkpoint_OuterLeafV2(t *testing.T) {
 	defer reopen.Close()
 
 	checkGets(t, reopen, keys, values, false)
+	scanAndCheck(t, reopen, values, false, hash)
+}
+
+func TestReopenVerify_WALOn_Checkpoint_OuterLeafV1LeafLog_ReadPath_HitMiss_ReopenParity(t *testing.T) {
+	dir := t.TempDir()
+	keys, values, hash := buildVerifyDataset(2000)
+
+	opts := treedb.Options{
+		Dir:                dir,
+		IndexOuterLeafMode: treedb.IndexOuterLeafModeV1LeafLog,
+		ValueLog: treedb.ValueLogOptions{
+			PointerThreshold:              1,
+			OuterLeafBlockCodec:           treedb.ValueLogBlockLZ4,
+			OuterLeafBlockTargetBytes:     4 << 10,
+			OuterLeafBlockRestartInterval: 16,
+		},
+	}
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	writeDataset(t, db, keys, values, false)
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	hitKey := keys[len(keys)/3]
+	missingKey := make([]byte, 8)
+	binary.BigEndian.PutUint64(missingKey, uint64(len(keys))+111)
+
+	got, err := db.Get(hitKey)
+	if err != nil {
+		t.Fatalf("get hit before reopen: %v", err)
+	}
+	if want := values[string(hitKey)]; !bytes.Equal(got, want) {
+		t.Fatalf("get hit before reopen mismatch")
+	}
+	if got, err := db.Get(missingKey); err != nil || got != nil {
+		t.Fatalf("get miss before reopen got=%v err=%v, want nil,nil", got, err)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatalf("snapshot before reopen: nil")
+	}
+	entry, err := snap.GetEntry(hitKey)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("snapshot GetEntry hit before reopen: %v", err)
+	}
+	if entry.Flags&node.FlagPointer == 0 {
+		_ = snap.Close()
+		t.Fatalf("expected pointer-backed entry in v1_leaflog mode, flags=%08b", entry.Flags)
+	}
+	if _, err := snap.GetEntry(missingKey); !errors.Is(err, treedb.ErrKeyNotFound) {
+		_ = snap.Close()
+		t.Fatalf("snapshot GetEntry miss before reopen err=%v, want ErrKeyNotFound", err)
+	}
+	if err := snap.Close(); err != nil {
+		t.Fatalf("snapshot close before reopen: %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopen, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopen.Close()
+
+	got, err = reopen.Get(hitKey)
+	if err != nil {
+		t.Fatalf("get hit after reopen: %v", err)
+	}
+	if want := values[string(hitKey)]; !bytes.Equal(got, want) {
+		t.Fatalf("get hit after reopen mismatch")
+	}
+	if got, err := reopen.Get(missingKey); err != nil || got != nil {
+		t.Fatalf("get miss after reopen got=%v err=%v, want nil,nil", got, err)
+	}
+
+	snap = reopen.AcquireSnapshot()
+	if snap == nil {
+		t.Fatalf("snapshot after reopen: nil")
+	}
+	entry, err = snap.GetEntry(hitKey)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("snapshot GetEntry hit after reopen: %v", err)
+	}
+	if entry.Flags&node.FlagPointer == 0 {
+		_ = snap.Close()
+		t.Fatalf("expected pointer-backed entry after reopen in v1_leaflog mode, flags=%08b", entry.Flags)
+	}
+	if _, err := snap.GetEntry(missingKey); !errors.Is(err, treedb.ErrKeyNotFound) {
+		_ = snap.Close()
+		t.Fatalf("snapshot GetEntry miss after reopen err=%v, want ErrKeyNotFound", err)
+	}
+	if err := snap.Close(); err != nil {
+		t.Fatalf("snapshot close after reopen: %v", err)
+	}
 	scanAndCheck(t, reopen, values, false, hash)
 }
 


### PR DESCRIPTION
## Summary
Implements Phase 2 of `#610` / child issue `#619`: read-path correctness for `v1_leaflog` with explicit no-fallback semantics and parity tests.

## Scope
- Added fail-closed `v1_leaflog` read guards in value-reader fence gating.
- Added value-reader unit test ensuring `v1_leaflog` never enables fence lookup/classification.
- Added reopen parity test for `v1_leaflog` covering:
  - pointer-backed exact hit reads
  - exact miss behavior
  - snapshot `GetEntry` hit/miss behavior
  - reopen parity and full-scan parity

## Files
- `TreeDB/db/value_reader.go`
- `TreeDB/db/value_reader_test.go`
- `TreeDB/reopen_verify_test.go`

## Invariants
- `v1_leaflog` remains key-aware outer-leaf mode.
- `v1_leaflog` cannot activate fence lookup path.
- Miss behavior is exact and bounded (no predecessor/global fallback usage).

## Reviewer loop
- Independent codex-xhigh review reported no unresolved high/medium findings after follow-up tightening.
- Additional improvement applied: avoid extra hot-path trim overhead by using `modeInit` fast path in the new guards.

## Tests run
- `GOWORK=off go test ./TreeDB/db -count=1`
- `GOWORK=off go test ./TreeDB -run 'ReopenVerify|ValueReader' -count=1`

## Risk
- Low: changes are isolated to read-mode gating and tests; no write-path mutations.

## Owner sign-off
Phase 2 scope is complete: exact read semantics and no-fallback behavior for `v1_leaflog` are now explicitly enforced and tested.

Refs: #619
