### PR TITLE
[v1_leaflog PR-4] Split/merge + delete-range structural parity hardening

### DIFF
--- a/TreeDB/db/root_collapse_test.go
+++ b/TreeDB/db/root_collapse_test.go
@@ -69,7 +69,6 @@ func TestDeleteMostKeys_CollapsesRootWhenOneLeafRemains(t *testing.T) {
 		}
 		_ = b.Close()
 	}
-
 	rep, err := d.FragmentationReport()
 	if err != nil {
 		t.Fatalf("FragmentationReport: %v", err)
@@ -130,7 +129,7 @@ func TestDeleteMostKeys_CollapsesRootWhenOneLeafRemains(t *testing.T) {
 	}
 }
 
-func TestDeleteMostKeys_CollapsesRootWhenOneLeafRemains_OuterLeafV2Pointers(t *testing.T) {
+func testDeleteMostKeysCollapsesRootOuterLeafPointerMode(t *testing.T, mode string, expectStrictCollapse bool) {
 	dir := t.TempDir()
 
 	d, err := Open(Options{
@@ -139,7 +138,7 @@ func TestDeleteMostKeys_CollapsesRootWhenOneLeafRemains_OuterLeafV2Pointers(t *t
 		LeafFillTargetPPM:         850_000,
 		InternalFillTargetPPM:     900_000,
 		MaintenanceOpsPerCoalesce: -1,
-		IndexOuterLeafMode:        IndexOuterLeafModeV2BlockPtr,
+		IndexOuterLeafMode:        mode,
 		ValueLog: ValueLogOptions{
 			PointerThreshold:              1,
 			OuterLeafBlockCodec:           ValueLogBlockLZ4,
@@ -152,7 +151,7 @@ func TestDeleteMostKeys_CollapsesRootWhenOneLeafRemains_OuterLeafV2Pointers(t *t
 	}
 	defer d.Close()
 
-	// Force pointer-backed values so this test exercises v2 outer-leaf decode
+	// Force pointer-backed values so this test exercises pointer-mode outer-leaf decode
 	// while stressing split/merge maintenance under delete-heavy churn.
 	val := bytes.Repeat([]byte("y"), 256)
 	const total = 5000
@@ -195,8 +194,11 @@ func TestDeleteMostKeys_CollapsesRootWhenOneLeafRemains_OuterLeafV2Pointers(t *t
 		t.Fatalf("parse leaf before delete: %v", err)
 	}
 
+	keep := 50
+	if expectStrictCollapse {
+		keep = 8
+	}
 	{
-		const keep = 50
 		b := d.NewBatch().(*Batch)
 		for i := keep; i < total; i++ {
 			var k [8]byte
@@ -236,17 +238,26 @@ func TestDeleteMostKeys_CollapsesRootWhenOneLeafRemains_OuterLeafV2Pointers(t *t
 		t.Fatalf("parse internal: %v", err)
 	}
 
-	if beforeLeaf <= leaf {
-		t.Fatalf("expected leaf pages to shrink after heavy deletes, before=%d after=%d", beforeLeaf, leaf)
-	}
-	if leaf > 16 {
-		t.Fatalf("expected post-delete leaf pages to stay small, got %d", leaf)
-	}
-	if internal > 1 {
-		t.Fatalf("expected shallow tree after heavy deletes, got internal pages=%d", internal)
+	if expectStrictCollapse {
+		if leaf != 1 {
+			t.Fatalf("expected strict root-collapse to a single leaf, got leaf pages=%d", leaf)
+		}
+		if internal != 0 {
+			t.Fatalf("expected strict root-collapse to leaf root, got internal pages=%d", internal)
+		}
+	} else {
+		if beforeLeaf <= leaf {
+			t.Fatalf("expected leaf pages to shrink after heavy deletes, before=%d after=%d", beforeLeaf, leaf)
+		}
+		if leaf > 16 {
+			t.Fatalf("expected post-delete leaf pages to stay small, got %d", leaf)
+		}
+		if internal > 1 {
+			t.Fatalf("expected shallow tree after heavy deletes, got internal pages=%d", internal)
+		}
 	}
 
-	for i := 0; i < 50; i++ {
+	for i := 0; i < keep; i++ {
 		var k [8]byte
 		k[0] = byte(i >> 24)
 		k[1] = byte(i >> 16)
@@ -263,7 +274,7 @@ func TestDeleteMostKeys_CollapsesRootWhenOneLeafRemains_OuterLeafV2Pointers(t *t
 			t.Fatalf("value mismatch for key %d", i)
 		}
 	}
-	for i := 50; i < total; i++ {
+	for i := keep; i < total; i++ {
 		var k [8]byte
 		k[0] = byte(i >> 24)
 		k[1] = byte(i >> 16)
@@ -277,4 +288,12 @@ func TestDeleteMostKeys_CollapsesRootWhenOneLeafRemains_OuterLeafV2Pointers(t *t
 			t.Fatalf("expected key %d to be deleted", i)
 		}
 	}
+}
+
+func TestDeleteMostKeys_CollapsesRootWhenOneLeafRemains_OuterLeafV2Pointers(t *testing.T) {
+	testDeleteMostKeysCollapsesRootOuterLeafPointerMode(t, IndexOuterLeafModeV2BlockPtr, false)
+}
+
+func TestDeleteMostKeys_CollapsesRootWhenOneLeafRemains_OuterLeafV1LeafLogPointers(t *testing.T) {
+	testDeleteMostKeysCollapsesRootOuterLeafPointerMode(t, IndexOuterLeafModeV1LeafLog, true)
 }

--- a/TreeDB/delete_range_checkpoint_consistency_test.go
+++ b/TreeDB/delete_range_checkpoint_consistency_test.go
@@ -38,16 +38,18 @@ func collectIteratorInts(t *testing.T, it Iterator) []int {
 	return out
 }
 
-func TestDeleteRange_CheckpointConsistency_ProfileFenceMatrix(t *testing.T) {
+func runDeleteRangeCheckpointConsistencyProfileMatrix(t *testing.T, mode string, allowSimpleInline bool) {
+	t.Helper()
 	profiles := []Profile{ProfileDurable, ProfileFast, ProfileWALOnFast}
 	for _, profile := range profiles {
 		t.Run(string(profile), func(t *testing.T) {
 			opts := OptionsFor(profile, t.TempDir())
-			opts.IndexOuterLeafMode = IndexOuterLeafModeV2FencePtr
+			opts.IndexOuterLeafMode = mode
 			opts.ValueLog.PointerThreshold = 1
 			opts.ValueLog.ForcePointers = true
 			opts.ValueLog.OuterLeafBlobThresholdBytes = 256
-			if profile == ProfileWALOnFast {
+			opts.ValueLog.WALFenceMode = ValueLogWALFenceModeRIDJoin
+			if allowSimpleInline && profile == ProfileWALOnFast {
 				opts.ValueLog.WALFenceMode = ValueLogWALFenceModeSimpleInline
 			}
 
@@ -135,4 +137,12 @@ func TestDeleteRange_CheckpointConsistency_ProfileFenceMatrix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteRange_CheckpointConsistency_ProfileFenceMatrix(t *testing.T) {
+	runDeleteRangeCheckpointConsistencyProfileMatrix(t, IndexOuterLeafModeV2FencePtr, true)
+}
+
+func TestDeleteRange_CheckpointConsistency_ProfileV1LeafLogMatrix(t *testing.T) {
+	runDeleteRangeCheckpointConsistencyProfileMatrix(t, IndexOuterLeafModeV1LeafLog, false)
 }

--- a/TreeDB/reopen_verify_test.go
+++ b/TreeDB/reopen_verify_test.go
@@ -3,7 +3,9 @@ package treedb_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -1255,7 +1257,7 @@ func TestReopenVerify_WALOn_WriteSync_OuterLeafV2FencePtr(t *testing.T) {
 	scanAndCheck(t, reopen, values, false, hash)
 }
 
-func testReopenVerifyOuterLeafV2SplitMergeDeleteRangeIteratorParity(t *testing.T, mode string) {
+func testReopenVerifyOuterLeafSplitMergeDeleteRangeIteratorParity(t *testing.T, mode string) {
 	dir := t.TempDir()
 	const total = 12000
 
@@ -1304,15 +1306,15 @@ func testReopenVerifyOuterLeafV2SplitMergeDeleteRangeIteratorParity(t *testing.T
 	}
 
 	// Force heavy structural churn:
-	// - remove a large middle range (merge/collapse pressure),
+	// - remove a large middle range via DeleteRange (split/merge/collapse pressure),
 	// - overwrite a patterned subset outside the deleted range,
 	// - delete sparse boundary keys.
+	if err := db.DeleteRange(keyFor(2000), keyFor(8000)); err != nil {
+		_ = db.Close()
+		t.Fatalf("delete range: %v", err)
+	}
 	for i := 2000; i < 8000; i++ {
 		key := keyFor(i)
-		if err := db.Delete(key); err != nil {
-			_ = db.Close()
-			t.Fatalf("delete range key %d: %v", i, err)
-		}
 		delete(expected, string(key))
 	}
 	for i := 0; i < total; i++ {
@@ -1475,11 +1477,201 @@ func testReopenVerifyOuterLeafV2SplitMergeDeleteRangeIteratorParity(t *testing.T
 }
 
 func TestReopenVerify_OuterLeafV2_SplitMergeDeleteRange_IteratorParity(t *testing.T) {
-	testReopenVerifyOuterLeafV2SplitMergeDeleteRangeIteratorParity(t, treedb.IndexOuterLeafModeV2BlockPtr)
+	testReopenVerifyOuterLeafSplitMergeDeleteRangeIteratorParity(t, treedb.IndexOuterLeafModeV2BlockPtr)
+}
+
+func TestReopenVerify_OuterLeafV1LeafLog_SplitMergeDeleteRange_IteratorParity(t *testing.T) {
+	testReopenVerifyOuterLeafSplitMergeDeleteRangeIteratorParity(t, treedb.IndexOuterLeafModeV1LeafLog)
 }
 
 func TestReopenVerify_OuterLeafV2FencePtr_SplitMergeDeleteRange_IteratorParity(t *testing.T) {
-	testReopenVerifyOuterLeafV2SplitMergeDeleteRangeIteratorParity(t, treedb.IndexOuterLeafModeV2FencePtr)
+	testReopenVerifyOuterLeafSplitMergeDeleteRangeIteratorParity(t, treedb.IndexOuterLeafModeV2FencePtr)
+}
+
+func TestReopenVerify_OuterLeafV1LeafLog_SplitMergeDeleteRange_ParityWithV1(t *testing.T) {
+	type apiParityFingerprint struct {
+		forwardDigest string
+		forwardCount  int
+		reverseDigest string
+		reverseCount  int
+		rangeDigest   string
+		rangeCount    int
+		pointDigest   string
+	}
+
+	run := func(mode string) apiParityFingerprint {
+		dir := t.TempDir()
+		const total = 12000
+		opts := treedb.Options{
+			Dir:                dir,
+			IndexOuterLeafMode: mode,
+			ValueLog: treedb.ValueLogOptions{
+				PointerThreshold:              1,
+				OuterLeafBlockCodec:           treedb.ValueLogBlockSnappy,
+				OuterLeafBlockTargetBytes:     512,
+				OuterLeafBlockRestartInterval: 8,
+			},
+		}
+
+		db, err := treedb.Open(opts)
+		if err != nil {
+			t.Fatalf("open %s: %v", mode, err)
+		}
+
+		makeValue := func(i int, seed byte) []byte {
+			v := make([]byte, 256)
+			for j := range v {
+				v[j] = seed + byte((i+j)%251)
+			}
+			return v
+		}
+		keyFor := func(i int) []byte {
+			k := make([]byte, 8)
+			binary.BigEndian.PutUint64(k, uint64(i))
+			return k
+		}
+
+		for i := 0; i < total; i++ {
+			if err := db.Set(keyFor(i), makeValue(i, 11)); err != nil {
+				_ = db.Close()
+				t.Fatalf("set %s %d: %v", mode, i, err)
+			}
+		}
+		if err := db.Checkpoint(); err != nil {
+			_ = db.Close()
+			t.Fatalf("checkpoint initial %s: %v", mode, err)
+		}
+		if err := db.DeleteRange(keyFor(2000), keyFor(8000)); err != nil {
+			_ = db.Close()
+			t.Fatalf("delete range %s: %v", mode, err)
+		}
+		for i := 0; i < total; i++ {
+			if i >= 2000 && i < 8000 {
+				continue
+			}
+			key := keyFor(i)
+			if i%7 == 0 {
+				if err := db.Set(key, makeValue(i, 77)); err != nil {
+					_ = db.Close()
+					t.Fatalf("overwrite %s %d: %v", mode, i, err)
+				}
+			}
+			if i%113 == 0 {
+				if err := db.Delete(key); err != nil {
+					_ = db.Close()
+					t.Fatalf("sparse delete %s %d: %v", mode, i, err)
+				}
+			}
+		}
+		if err := db.Checkpoint(); err != nil {
+			_ = db.Close()
+			t.Fatalf("checkpoint churn %s: %v", mode, err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close %s: %v", mode, err)
+		}
+
+		reopen, err := treedb.Open(opts)
+		if err != nil {
+			t.Fatalf("reopen %s: %v", mode, err)
+		}
+		defer reopen.Close()
+
+		out := apiParityFingerprint{}
+
+		it, err := reopen.Iterator(nil, nil)
+		if err != nil {
+			t.Fatalf("iterator %s: %v", mode, err)
+		}
+		defer it.Close()
+		forwardSum := sha256.New()
+		for it.Valid() {
+			_, _ = forwardSum.Write(it.Key())
+			_, _ = forwardSum.Write(it.Value())
+			out.forwardCount++
+			it.Next()
+		}
+		if err := it.Error(); err != nil {
+			t.Fatalf("iterator error %s: %v", mode, err)
+		}
+		out.forwardDigest = hex.EncodeToString(forwardSum.Sum(nil))
+
+		rit, err := reopen.ReverseIterator(nil, nil)
+		if err != nil {
+			t.Fatalf("reverse iterator %s: %v", mode, err)
+		}
+		defer rit.Close()
+		reverseSum := sha256.New()
+		for rit.Valid() {
+			_, _ = reverseSum.Write(rit.Key())
+			_, _ = reverseSum.Write(rit.Value())
+			out.reverseCount++
+			rit.Next()
+		}
+		if err := rit.Error(); err != nil {
+			t.Fatalf("reverse iterator error %s: %v", mode, err)
+		}
+		out.reverseDigest = hex.EncodeToString(reverseSum.Sum(nil))
+
+		rangeIt, err := reopen.Iterator(keyFor(1500), keyFor(2500))
+		if err != nil {
+			t.Fatalf("range iterator %s: %v", mode, err)
+		}
+		defer rangeIt.Close()
+		rangeSum := sha256.New()
+		for rangeIt.Valid() {
+			_, _ = rangeSum.Write(rangeIt.Key())
+			_, _ = rangeSum.Write(rangeIt.Value())
+			out.rangeCount++
+			rangeIt.Next()
+		}
+		if err := rangeIt.Error(); err != nil {
+			t.Fatalf("range iterator error %s: %v", mode, err)
+		}
+		out.rangeDigest = hex.EncodeToString(rangeSum.Sum(nil))
+
+		pointSum := sha256.New()
+		for i := 0; i < total; i++ {
+			key := keyFor(i)
+			_, _ = pointSum.Write(key)
+			got, err := reopen.Get(key)
+			if err != nil {
+				t.Fatalf("get %s %d: %v", mode, i, err)
+			}
+			if got == nil {
+				_, _ = pointSum.Write([]byte{0})
+				continue
+			}
+			_, _ = pointSum.Write([]byte{1})
+			_, _ = pointSum.Write(got)
+		}
+		out.pointDigest = hex.EncodeToString(pointSum.Sum(nil))
+		return out
+	}
+
+	v1 := run(treedb.IndexOuterLeafModeV1)
+	v1LeafLog := run(treedb.IndexOuterLeafModeV1LeafLog)
+	if v1.forwardCount != v1LeafLog.forwardCount {
+		t.Fatalf("forward count mismatch v1=%d v1_leaflog=%d", v1.forwardCount, v1LeafLog.forwardCount)
+	}
+	if v1.forwardDigest != v1LeafLog.forwardDigest {
+		t.Fatalf("forward digest mismatch v1=%s v1_leaflog=%s", v1.forwardDigest, v1LeafLog.forwardDigest)
+	}
+	if v1.reverseCount != v1LeafLog.reverseCount {
+		t.Fatalf("reverse count mismatch v1=%d v1_leaflog=%d", v1.reverseCount, v1LeafLog.reverseCount)
+	}
+	if v1.reverseDigest != v1LeafLog.reverseDigest {
+		t.Fatalf("reverse digest mismatch v1=%s v1_leaflog=%s", v1.reverseDigest, v1LeafLog.reverseDigest)
+	}
+	if v1.rangeCount != v1LeafLog.rangeCount {
+		t.Fatalf("range count mismatch v1=%d v1_leaflog=%d", v1.rangeCount, v1LeafLog.rangeCount)
+	}
+	if v1.rangeDigest != v1LeafLog.rangeDigest {
+		t.Fatalf("range digest mismatch v1=%s v1_leaflog=%s", v1.rangeDigest, v1LeafLog.rangeDigest)
+	}
+	if v1.pointDigest != v1LeafLog.pointDigest {
+		t.Fatalf("point digest mismatch v1=%s v1_leaflog=%s", v1.pointDigest, v1LeafLog.pointDigest)
+	}
 }
 
 func TestReopenVerify_OuterLeafV2FencePtr_CompactIndex_ReopenParity(t *testing.T) {


### PR DESCRIPTION
Parent: #610
Phase: PR-4
Issue: #621

## Problem
Phase 4 requires structural correctness under churn for `v1_leaflog`: split/merge/delete-range maintenance must preserve logical parity and avoid stale/dangling payload-reference behavior.

## What changed
1. Expanded split/merge/delete-range reopen+iterator workload to include `v1_leaflog`.
2. Switched the structural churn workload to use `DeleteRange` for the large middle deletion interval (instead of per-key deletes) so it exercises the intended maintenance path.
3. Added explicit v1 parity test for structural churn (`v1` vs `v1_leaflog`) that compares:
   - full forward iteration digest+count
   - full reverse iteration digest+count
   - bounded range iteration digest+count
   - point-get digest across the entire keyspace
4. Expanded DB-level root-collapse pointer-mode stress coverage:
   - generalized existing outer-leaf pointer test helper
   - added `v1_leaflog` pointer-mode variant with strict collapse expectation
5. Refactored delete-range checkpoint consistency test into a mode/profile matrix helper and added `v1_leaflog` matrix.
6. Made WAL fence mode explicit in that matrix (`rid_join` default; `simple_inline` only for fence-mode WAL-on case).

## Invariants enforced by this PR
- `v1_leaflog` survives heavy split/merge/delete-range churn with correct reopen and iterator behavior.
- `DeleteRange` structural maintenance path is directly exercised in outer-leaf structural parity tests.
- `v1_leaflog` structural end-state parity with `v1` is validated across point reads and iterator APIs.
- Pointer-mode root-collapse for `v1_leaflog` is checked with strict structural expectation.

## Files touched
- `TreeDB/reopen_verify_test.go`
- `TreeDB/db/root_collapse_test.go`
- `TreeDB/delete_range_checkpoint_consistency_test.go`

## Validation (local)
Focused:
- `GOWORK=off go test ./TreeDB -run 'Test(DeleteRange_CheckpointConsistency_Profile(Fence|V1LeafLog)Matrix|ReopenVerify_OuterLeaf(V1LeafLog|V2|V2FencePtr)_SplitMergeDeleteRange_IteratorParity|ReopenVerify_OuterLeafV1LeafLog_SplitMergeDeleteRange_ParityWithV1)' -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'TestDeleteMostKeys_(CollapsesRootWhenOneLeafRemains(_OuterLeaf(V2Pointers|V1LeafLogPointers))?|MergesUnderfullLeafSiblings|MergesUnderfullInternalSiblings)' -count=1`

Broader:
- `GOWORK=off go test ./TreeDB -count=1`
- `GOWORK=off go test ./TreeDB/db -count=1`

All above passed locally.

## Subagent loop log (required)
- Round A (builder-fast): attempted; reported environment constraints and no code changes applied.
- Round B (independent reviewer): flagged 1 medium + 2 low findings.
- Round C (fixes):
  - strengthened `v1_leaflog` collapse invariant path
  - made WAL fence-mode selection explicit in matrix
  - broadened v1/v1_leaflog parity check across APIs
- Round D (independent re-review): no unresolved high/medium findings.

## Residual low-risk notes
- Current bounded iterator parity in the new v1/v1_leaflog parity test uses one bounded forward window; this phase does not yet add bounded reverse window parity (iterator matrix depth is Phase 5 scope).
