### PR TITLE
TreeDB: add v1_leaflog GC/rewrite/recovery integration parity (#623)

### DIFF
--- a/TreeDB/recovery_spec_test.go
+++ b/TreeDB/recovery_spec_test.go
@@ -168,7 +168,7 @@ func TestHelperTreeDBCrashRecoveryDurabilityWriter(t *testing.T) {
 	switch outerLeafMode {
 	case "":
 		// default mode
-	case treedb.IndexOuterLeafModeV2BlockPtr, treedb.IndexOuterLeafModeV2FencePtr:
+	case treedb.IndexOuterLeafModeV1LeafLog, treedb.IndexOuterLeafModeV2BlockPtr, treedb.IndexOuterLeafModeV2FencePtr:
 		opts.IndexOuterLeafMode = outerLeafMode
 		opts.ValueLog.OuterLeafBlockCodec = treedb.ValueLogBlockLZ4
 		opts.ValueLog.OuterLeafBlockTargetBytes = 4 << 10
@@ -259,7 +259,7 @@ func TestHelperTreeDBCrashRecoveryDeleteRangeNoTrailingSyncWriter(t *testing.T) 
 	switch outerLeafMode {
 	case "":
 		// default mode
-	case treedb.IndexOuterLeafModeV2BlockPtr, treedb.IndexOuterLeafModeV2FencePtr:
+	case treedb.IndexOuterLeafModeV1LeafLog, treedb.IndexOuterLeafModeV2BlockPtr, treedb.IndexOuterLeafModeV2FencePtr:
 		opts.IndexOuterLeafMode = outerLeafMode
 		opts.ValueLog.OuterLeafBlockCodec = treedb.ValueLogBlockLZ4
 		opts.ValueLog.OuterLeafBlockTargetBytes = 4 << 10
@@ -432,6 +432,15 @@ func TestCrashRecovery_DeleteRangeWithoutTrailingSync_ReplaysCorrectKeys(t *test
 			},
 			outerMode: treedb.IndexOuterLeafModeV2BlockPtr,
 		},
+		{
+			name: "wal_on_relaxed_v1_leaflog",
+			env: []string{
+				"TREEDB_CRASH_DISABLE_WAL=0",
+				"TREEDB_CRASH_RELAXED_SYNC=1",
+				"TREEDB_CRASH_OUTERLEAF_MODE=v1_leaflog",
+			},
+			outerMode: treedb.IndexOuterLeafModeV1LeafLog,
+		},
 	}
 
 	for _, tc := range tiers {
@@ -539,6 +548,17 @@ func TestCrashRecovery_DurabilityTiers(t *testing.T) {
 			},
 			expectLarge: true,
 			outerMode:   treedb.IndexOuterLeafModeV2BlockPtr,
+		},
+		{
+			name: "wal_on_strict_sync_large_value_outerleaf_v1_leaflog",
+			env: []string{
+				"TREEDB_CRASH_DISABLE_WAL=0",
+				"TREEDB_CRASH_RELAXED_SYNC=0",
+				"TREEDB_CRASH_LARGE_VALUE=1",
+				"TREEDB_CRASH_OUTERLEAF_MODE=v1_leaflog",
+			},
+			expectLarge: true,
+			outerMode:   treedb.IndexOuterLeafModeV1LeafLog,
 		},
 		{
 			name: "wal_on_strict_sync_large_value_outerleaf_v2_fenceptr",

--- a/TreeDB/reopen_verify_test.go
+++ b/TreeDB/reopen_verify_test.go
@@ -831,12 +831,17 @@ func TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity(t *testing
 		_ = db.Close()
 		t.Fatalf("checkpoint before rewrite: %v", err)
 	}
-	if _, err := db.ValueLogRewriteOnline(context.Background(), treedb.ValueLogRewriteOnlineOptions{
+	stats, err := db.ValueLogRewriteOnline(context.Background(), treedb.ValueLogRewriteOnlineOptions{
 		BatchSize:     2,
 		SyncEachBatch: true,
-	}); err != nil {
+	})
+	if err != nil {
 		_ = db.Close()
 		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if stats.RecordsCopied == 0 {
+		_ = db.Close()
+		t.Fatalf("expected rewrite to copy records, stats=%+v", stats)
 	}
 	if err := db.Close(); err != nil {
 		t.Fatalf("close after rewrite: %v", err)
@@ -860,71 +865,24 @@ func TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity(t *testing
 }
 
 func TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity_OuterLeafV2(t *testing.T) {
-	dir := t.TempDir()
-	opts := treedb.Options{
-		Dir:                dir,
-		IndexOuterLeafMode: treedb.IndexOuterLeafModeV2BlockPtr,
-		ValueLog: treedb.ValueLogOptions{
-			PointerThreshold:              1,
-			OuterLeafBlockCodec:           treedb.ValueLogBlockLZ4,
-			OuterLeafBlockTargetBytes:     1024,
-			OuterLeafBlockRestartInterval: 8,
-		},
-	}
-	db, err := treedb.Open(opts)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-
-	values := map[string][]byte{
-		"k1": bytes.Repeat([]byte("a"), 2*1024),
-		"k2": bytes.Repeat([]byte("b"), 2*1024),
-		"k3": bytes.Repeat([]byte("c"), 2*1024),
-		"k4": bytes.Repeat([]byte("d"), 2*1024),
-	}
-	for k, v := range values {
-		if err := db.Set([]byte(k), v); err != nil {
-			_ = db.Close()
-			t.Fatalf("set %s: %v", k, err)
-		}
-	}
-	if err := db.Checkpoint(); err != nil {
-		_ = db.Close()
-		t.Fatalf("checkpoint before rewrite: %v", err)
-	}
-	if _, err := db.ValueLogRewriteOnline(context.Background(), treedb.ValueLogRewriteOnlineOptions{
-		BatchSize:     2,
-		SyncEachBatch: true,
-	}); err != nil {
-		_ = db.Close()
-		t.Fatalf("ValueLogRewriteOnline: %v", err)
-	}
-	if err := db.Close(); err != nil {
-		t.Fatalf("close after rewrite: %v", err)
-	}
-
-	reopen, err := treedb.Open(opts)
-	if err != nil {
-		t.Fatalf("reopen: %v", err)
-	}
-	defer reopen.Close()
-
-	for k, want := range values {
-		got, err := reopen.Get([]byte(k))
-		if err != nil {
-			t.Fatalf("reopen get %s: %v", k, err)
-		}
-		if !bytes.Equal(got, want) {
-			t.Fatalf("reopen mismatch key=%s got=%dB want=%dB", k, len(got), len(want))
-		}
-	}
+	runValueLogRewriteBatchedPointerSwapReopenParityOuterLeaf(t, treedb.IndexOuterLeafModeV2BlockPtr)
 }
 
 func TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity_OuterLeafV2FencePtr(t *testing.T) {
+	runValueLogRewriteBatchedPointerSwapReopenParityOuterLeaf(t, treedb.IndexOuterLeafModeV2FencePtr)
+}
+
+func TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity_OuterLeafV1LeafLog(t *testing.T) {
+	runValueLogRewriteBatchedPointerSwapReopenParityOuterLeaf(t, treedb.IndexOuterLeafModeV1LeafLog)
+}
+
+func runValueLogRewriteBatchedPointerSwapReopenParityOuterLeaf(t *testing.T, mode string) {
+	t.Helper()
+
 	dir := t.TempDir()
 	opts := treedb.Options{
 		Dir:                dir,
-		IndexOuterLeafMode: treedb.IndexOuterLeafModeV2FencePtr,
+		IndexOuterLeafMode: mode,
 		ValueLog: treedb.ValueLogOptions{
 			PointerThreshold:              1,
 			OuterLeafBlockCodec:           treedb.ValueLogBlockLZ4,
@@ -953,12 +911,17 @@ func TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity_OuterLeafV
 		_ = db.Close()
 		t.Fatalf("checkpoint before rewrite: %v", err)
 	}
-	if _, err := db.ValueLogRewriteOnline(context.Background(), treedb.ValueLogRewriteOnlineOptions{
+	stats, err := db.ValueLogRewriteOnline(context.Background(), treedb.ValueLogRewriteOnlineOptions{
 		BatchSize:     2,
 		SyncEachBatch: true,
-	}); err != nil {
+	})
+	if err != nil {
 		_ = db.Close()
 		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if stats.RecordsCopied == 0 {
+		_ = db.Close()
+		t.Fatalf("expected rewrite to copy records, stats=%+v", stats)
 	}
 	if err := db.Close(); err != nil {
 		t.Fatalf("close after rewrite: %v", err)
@@ -982,80 +945,24 @@ func TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity_OuterLeafV
 }
 
 func TestReopenVerify_ValueLogGC_OuterLeafV2_ReopenParity(t *testing.T) {
-	dir := t.TempDir()
-	opts := treedb.Options{
-		Dir:                dir,
-		IndexOuterLeafMode: treedb.IndexOuterLeafModeV2BlockPtr,
-		ValueLog: treedb.ValueLogOptions{
-			PointerThreshold:              1,
-			OuterLeafBlockCodec:           treedb.ValueLogBlockSnappy,
-			OuterLeafBlockTargetBytes:     512,
-			OuterLeafBlockRestartInterval: 8,
-		},
-	}
-	db, err := treedb.Open(opts)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-
-	const total = 240
-	for i := 0; i < total; i++ {
-		key := []byte(fmt.Sprintf("gc-key-%04d", i))
-		val := bytes.Repeat([]byte{byte(i % 251)}, 256)
-		if err := db.Set(key, val); err != nil {
-			_ = db.Close()
-			t.Fatalf("set %q: %v", string(key), err)
-		}
-	}
-	for i := 0; i < 140; i++ {
-		key := []byte(fmt.Sprintf("gc-key-%04d", i))
-		if err := db.Delete(key); err != nil {
-			_ = db.Close()
-			t.Fatalf("delete %q: %v", string(key), err)
-		}
-	}
-	if err := db.Checkpoint(); err != nil {
-		_ = db.Close()
-		t.Fatalf("checkpoint before gc: %v", err)
-	}
-	if _, err := db.ValueLogGC(context.Background(), treedb.ValueLogGCOptions{}); err != nil {
-		_ = db.Close()
-		t.Fatalf("ValueLogGC: %v", err)
-	}
-	if err := db.Close(); err != nil {
-		t.Fatalf("close: %v", err)
-	}
-
-	reopen, err := treedb.Open(opts)
-	if err != nil {
-		t.Fatalf("reopen: %v", err)
-	}
-	defer reopen.Close()
-
-	for i := 0; i < total; i++ {
-		key := []byte(fmt.Sprintf("gc-key-%04d", i))
-		got, err := reopen.Get(key)
-		if i < 140 {
-			if err == nil && got != nil {
-				t.Fatalf("expected deleted key %q to be absent", string(key))
-			}
-			continue
-		}
-		if err != nil {
-			t.Fatalf("reopen get %q: %v", string(key), err)
-		}
-		want := bytes.Repeat([]byte{byte(i % 251)}, 256)
-		if !bytes.Equal(got, want) {
-			t.Fatalf("reopen mismatch key=%q got=%dB want=%dB", string(key), len(got), len(want))
-		}
-	}
+	runValueLogGCReopenParityOuterLeaf(t, treedb.IndexOuterLeafModeV2BlockPtr)
 }
 
 func TestReopenVerify_ValueLogGC_OuterLeafV2FencePtr_ReopenParity(t *testing.T) {
+	runValueLogGCReopenParityOuterLeaf(t, treedb.IndexOuterLeafModeV2FencePtr)
+}
+
+func TestReopenVerify_ValueLogGC_OuterLeafV1LeafLog_ReopenParity(t *testing.T) {
+	runValueLogGCReopenParityOuterLeaf(t, treedb.IndexOuterLeafModeV1LeafLog)
+}
+
+func runValueLogGCReopenParityOuterLeaf(t *testing.T, mode string) {
+	t.Helper()
+
 	dir := t.TempDir()
 	opts := treedb.Options{
 		Dir:                dir,
-		IndexOuterLeafMode: treedb.IndexOuterLeafModeV2FencePtr,
+		IndexOuterLeafMode: mode,
 		ValueLog: treedb.ValueLogOptions{
 			PointerThreshold:              1,
 			OuterLeafBlockCodec:           treedb.ValueLogBlockSnappy,
@@ -1088,9 +995,14 @@ func TestReopenVerify_ValueLogGC_OuterLeafV2FencePtr_ReopenParity(t *testing.T) 
 		_ = db.Close()
 		t.Fatalf("checkpoint before gc: %v", err)
 	}
-	if _, err := db.ValueLogGC(context.Background(), treedb.ValueLogGCOptions{}); err != nil {
+	stats, err := db.ValueLogGC(context.Background(), treedb.ValueLogGCOptions{})
+	if err != nil {
 		_ = db.Close()
 		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if stats.SegmentsDeleted == 0 || stats.SegmentsEligible == 0 {
+		_ = db.Close()
+		t.Fatalf("expected GC to delete eligible segments, stats=%+v", stats)
 	}
 	if err := db.Close(); err != nil {
 		t.Fatalf("close: %v", err)


### PR DESCRIPTION
## Summary
Phase 6 for #610 / #623: extend `v1_leaflog` integration coverage across value-log rewrite, value-log GC, and crash-recovery replay paths.

## What changed
- `TreeDB/reopen_verify_test.go`
  - Added `v1_leaflog` parity variants:
    - `TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity_OuterLeafV1LeafLog`
    - `TestReopenVerify_ValueLogGC_OuterLeafV1LeafLog_ReopenParity`
  - Refactored duplicated outer-leaf rewrite/GC parity tests into shared helpers used by `v2_blockptr`, `v2_fenceptr`, and `v1_leaflog`.
  - Hardened invariants to avoid vacuous pass:
    - rewrite asserts `RecordsCopied > 0`
    - GC asserts `SegmentsEligible > 0` and `SegmentsDeleted > 0`

- `TreeDB/recovery_spec_test.go`
  - Extended crash helper mode acceptance to include `v1_leaflog` in both durability and delete-range-no-trailing-sync writer helpers.
  - Added `v1_leaflog` tiers to crash replay matrices:
    - `TestCrashRecovery_DeleteRangeWithoutTrailingSync_ReplaysCorrectKeys`
    - `TestCrashRecovery_DurabilityTiers`

## Invariants covered
- Rewrite remap correctness for `v1_leaflog` survives close/reopen and returns exact values.
- GC for `v1_leaflog` removes eligible unreachable segments while preserving live keys across reopen.
- Crash recovery replay in `v1_leaflog` preserves delete-range and large-value durability semantics under configured durability tiers.

## Reviewer loop log
- Round B: no high/medium findings; low coverage-hardening suggestions.
- Round C: added rewrite/GC activity assertions to ensure non-noop behavior.
- Round D: no unresolved high/medium findings.

## Validation
- `GOWORK=off go test ./TreeDB -run 'TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity_OuterLeaf(V2|V2FencePtr|V1LeafLog)|TestReopenVerify_ValueLogGC_OuterLeaf(V2|V2FencePtr|V1LeafLog)_ReopenParity|TestCrashRecovery_DeleteRangeWithoutTrailingSync_ReplaysCorrectKeys|TestCrashRecovery_DurabilityTiers' -count=1`
- `GOWORK=off go test ./TreeDB -count=1`
- `GOWORK=off go test ./TreeDB/db -count=1`

## Risks
- Test-only change; no production runtime-path mutation in this PR.
