### PR TITLE
TreeDB: finalize v1_leaflog docs and perf evidence (#624)

### DIFF
--- a/TreeDB/.pr/PR7_description.md
+++ b/TreeDB/.pr/PR7_description.md
@@ -1,0 +1,63 @@
+# Summary
+- Final Track #610 landing docs and perf evidence for `v1_leaflog`.
+- Clarify outer-leaf mode semantics in canonical spec and user README.
+- Add dedicated mode matrix doc with invariants and reproducible unified-bench workflows.
+
+# Docs Updated
+- `TreeDB/README.md`
+- `TreeDB/docs/spec/README.md`
+- `TreeDB/docs/spec/storage-format.md`
+- `TreeDB/docs/spec/outer-leaf-modes.md` (new)
+
+# Tests
+- `GOWORK=off go test ./TreeDB/docs/... -count=1`
+- `GOWORK=off go test ./TreeDB -run 'TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity_OuterLeaf(V2|V2FencePtr|V1LeafLog)|TestReopenVerify_ValueLogGC_OuterLeaf(V2|V2FencePtr|V1LeafLog)_ReopenParity|TestCrashRecovery_DeleteRangeWithoutTrailingSync_ReplaysCorrectKeys|TestCrashRecovery_DurabilityTiers' -count=1`
+
+# Benchmarks (unified-bench)
+## Command Set A: full suite, forced pointers
+```bash
+./bin/unified-bench -dbs treedb -profile fast -keys 500000 -progress=false -format markdown \
+  -checkpoint-between-tests -test all \
+  -treedb-index-outer-leaf-mode v1 -treedb-force-value-pointers=true
+
+./bin/unified-bench -dbs treedb -profile fast -keys 500000 -progress=false -format markdown \
+  -checkpoint-between-tests -test all \
+  -treedb-index-outer-leaf-mode v1_leaflog -treedb-force-value-pointers=true
+```
+
+| Metric | `v1` | `v1_leaflog` | Delta |
+| --- | ---: | ---: | ---: |
+| Batch Write | 10,801,428 | 7,777,928 | -28.0% |
+| Batch Write (Steady) | 553,422 | 552,181 | -0.2% |
+| Batch Random | 5,029,891 | 3,377,711 | -32.8% |
+| Random Read (Parallel) | 1,984,056 | 5,618,201 | +183.2% |
+| Full Scan | 574,370 | 1,352,491 | +135.5% |
+| Prefix Scan | 10,447,306 | 10,432,717 | -0.1% |
+| `index.db` | 189 MiB | 188 MiB | -0.5% |
+
+## Command Set B: small-value inline candidate
+```bash
+./bin/unified-bench -dbs treedb -profile fast -keys 500000 -valsize 1 -progress=false -format markdown \
+  -checkpoint-between-tests -test batch_write,batch_write_steady,batch_random,random_read_parallel,full_scan,prefix_scan \
+  -treedb-index-optimizations=false -treedb-force-value-pointers=false \
+  -treedb-index-outer-leaf-mode v1
+
+./bin/unified-bench -dbs treedb -profile fast -keys 500000 -valsize 1 -progress=false -format markdown \
+  -checkpoint-between-tests -test batch_write,batch_write_steady,batch_random,random_read_parallel,full_scan,prefix_scan \
+  -treedb-index-optimizations=false -treedb-force-value-pointers=false \
+  -treedb-index-outer-leaf-mode v1_leaflog
+```
+
+| Metric | `v1` | `v1_leaflog` | Delta |
+| --- | ---: | ---: | ---: |
+| Batch Write | 13,028,127 | 12,797,711 | -1.8% |
+| Batch Write (Steady) | 1,732,765 | 1,792,429 | +3.4% |
+| Batch Random | 12,441,100 | 12,670,092 | +1.8% |
+| Random Read (Parallel) | 24,276,306 | 23,865,763 | -1.7% |
+| Full Scan | 15,155,630 | 15,212,936 | +0.4% |
+| Prefix Scan | 16,497,118 | 16,349,153 | -0.9% |
+| `index.db` | 43 MiB | 45 MiB | +4.7% |
+
+# Notes
+- These are pre-alpha comparative measurements for regression tracking.
+- Results are workload and option sensitive; use command-set parity when comparing future changes.

--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -112,6 +112,19 @@ through `wal/` even when WAL is off.
 
 Details: `docs/TREEDB_WRITE_PATHS.md`.
 
+## Outer-Leaf Modes
+
+TreeDB supports four index outer-leaf modes:
+
+- `v1`: baseline exact-key index semantics.
+- `v1_leaflog`: exact-key semantics with outer-leaf payload envelope encoding in the value log.
+- `v2_blockptr`: exact-key index entries that can point to grouped outer-leaf payload blocks.
+- `v2_fenceptr`: fence-key routing mode (smallest index footprint, predecessor-probe lookup model).
+
+If unset (`""`), `IndexOuterLeafMode` defaults to `v2_fenceptr`.
+
+Canonical mode semantics and invariants: `TreeDB/docs/spec/outer-leaf-modes.md`.
+
 ## Durability & Safety Notes
 
 - Safe defaults keep WAL, fsync, and read checksums enabled; relax safety knobs via `Options.Durability` and `Options.ValueLog.ReadIntegrity`.

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -58,6 +58,8 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - complete concurrency mechanism inventory, lock/worker topology, and option/flag matrix for perf/refactor audits.
 - `TreeDB/docs/spec/storage-format.md`
   - on-disk encodings for pages, node layouts, pointers, value-log records/frames, commit-log segments.
+- `TreeDB/docs/spec/outer-leaf-modes.md`
+  - mode matrix for `v1`, `v1_leaflog`, `v2_blockptr`, and `v2_fenceptr`, plus parity requirements and benchmark workflow.
 - `TreeDB/docs/spec/write-path-and-durability.md`
   - write pipeline and durability semantics for all durability modes.
 - `TreeDB/docs/spec/recovery.md`

--- a/TreeDB/docs/spec/outer-leaf-modes.md
+++ b/TreeDB/docs/spec/outer-leaf-modes.md
@@ -1,0 +1,61 @@
+# Outer-Leaf Modes
+
+This document defines behavioral expectations for `IndexOuterLeafMode`.
+
+If `IndexOuterLeafMode` is unset (`""`), TreeDB defaults to `v2_fenceptr`.
+
+## Mode Semantics
+
+| Mode | Index lookup model | Pointer payload model | Intended use |
+| --- | --- | --- | --- |
+| `v1` | exact-key leaf entry per user key | raw value-log record payload | baseline exact-key mode |
+| `v1_leaflog` | exact-key leaf entry per user key | outer-leaf envelope payload (`TOL2`) through mature value-log block codec path | exact-key semantics with outer-leaf payload encoding |
+| `v2_blockptr` | exact-key leaf entry per user key | grouped outer-leaf block payload | better pointer payload batching with exact-key index semantics |
+| `v2_fenceptr` | fence-key routing + predecessor probe (steady state) | grouped outer-leaf block payload; WAL-on `rid_join` oversized writes may temporarily surface direct exact-key pointers before flush collapse | smallest index footprint with fence-key routing |
+
+## Correctness Requirements
+
+`v1_leaflog` MUST satisfy:
+
+1. Point-read parity with `v1` for hit/miss semantics.
+2. Iterator parity with `v1` for forward/reverse/range/prefix bounds.
+3. Reopen parity for overwrite/delete/update sequences.
+4. Value-log rewrite parity: rewritten pointers remain readable after close/reopen.
+5. Value-log GC parity: unreachable segments are eligible/deleted while live keys remain readable after reopen.
+6. Crash-recovery parity under WAL replay for delete-range and large-value durability tiers.
+
+## Validation Coverage
+
+Primary coverage for `v1_leaflog` mode parity:
+
+- `TreeDB/reopen_verify_test.go`
+  - read/write/reopen parity
+  - iterator parity
+  - rewrite + GC reopen parity
+- `TreeDB/recovery_spec_test.go`
+  - crash replay matrices including `v1_leaflog`
+
+## Benchmark Workflow (Unified Bench)
+
+Use unified bench for mode sanity checks:
+
+```bash
+GOWORK=off make unified-bench
+./bin/unified-bench -dbs treedb -profile fast -keys 500000 -progress=false -format markdown \
+  -checkpoint-between-tests -test all \
+  -treedb-index-outer-leaf-mode v1 -treedb-force-value-pointers=true
+./bin/unified-bench -dbs treedb -profile fast -keys 500000 -progress=false -format markdown \
+  -checkpoint-between-tests -test all \
+  -treedb-index-outer-leaf-mode v1_leaflog -treedb-force-value-pointers=true
+```
+
+For small-value workloads (where inline-vs-pointer behavior matters), run with:
+
+```bash
+./bin/unified-bench -dbs treedb -profile fast -keys 500000 -valsize 1 -progress=false -format markdown \
+  -checkpoint-between-tests -test batch_write,batch_write_steady,batch_random,random_read_parallel,full_scan,prefix_scan \
+  -treedb-index-optimizations=false -treedb-force-value-pointers=false \
+  -treedb-index-outer-leaf-mode <v1|v1_leaflog>
+```
+
+Pre-alpha note: benchmark numbers are workload and option sensitive; use them as regression guards, not compatibility contracts.

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -274,14 +274,14 @@ bytes FramePayload
 - If `FrameFlags` indicates compression, frame payload is decoded first.
 - `DictID` selects dictionary for dict-compressed payloads.
 
-### 7.2 Outer-leaf payload envelope (`IndexOuterLeafMode=v2_blockptr|v2_fenceptr`)
+### 7.2 Outer-leaf payload envelope (`IndexOuterLeafMode=v1_leaflog|v2_blockptr|v2_fenceptr`)
 
-When outer-leaf mode `v2_blockptr` or `v2_fenceptr` is enabled, value-log
-payload bytes may be wrapped in an outer-leaf envelope (`Magic="TOL2"`):
+When outer-leaf mode `v1_leaflog`, `v2_blockptr`, or `v2_fenceptr` is enabled,
+value-log payload bytes may be wrapped in an outer-leaf envelope (`Magic="TOL2"`):
 
 ```text
 bytes[4] Magic            // "TOL2"
-u8       Version          // 1=single KV, 2=multi-KV block
+u8       Version          // 1=single KV, 2=multi-KV block, 3=typed-entry block
 u8       Codec            // 0=raw, 1=snappy, 2=lz4
 u16      RestartInterval
 u16/u32  Version-specific fields
@@ -296,15 +296,24 @@ Version 2 stores multiple sorted `{key,value}` pairs in one block payload:
 - a restart-offset table is appended,
 - trailer stores restart-count (`u32`).
 
+Version 3 stores one or more typed entries (inline value or nested blob
+reference) with restart metadata and the same envelope checksum rules.
+
 Mode semantics:
+- `v1_leaflog`: index keeps one logical entry per user key (v1 exact-key
+  lookup semantics) while pointer payload bytes use outer-leaf envelope
+  encoding. Lookups do not use fence-key predecessor probing.
 - `v2_blockptr`: index leaves remain per-user-key pointer entries; each pointer
   can reference a grouped outer-leaf block payload.
 - `v2_fenceptr`: index leaves store one fence-key pointer per outer block;
   user keys are resolved by selecting predecessor fence pointers and searching
-  inside the outer block payload.
+  inside the outer block payload. In WAL-on `rid_join`, oversized values can
+  publish immediate exact-key pointers before flush-time fence collapse.
 
-Read path resolves pointer+key by decoding one block payload and searching
-inside it for the requested key.
+When a pointer references an outer-leaf envelope, read path resolves
+pointer+key by decoding one block payload and searching inside it for the
+requested key. Immediate direct pointers (for example WAL-on `v2_fenceptr`
+`rid_join` oversized path before flush collapse) bypass outer-leaf block decode.
 
 Pre-alpha note: `v2` outer-leaf layouts are still evolving. DB directories
 written by older experimental builds may fail to open under newer binaries (and


### PR DESCRIPTION
# Summary
- Final Track #610 landing docs and perf evidence for `v1_leaflog`.
- Clarify outer-leaf mode semantics in canonical spec and user README.
- Add dedicated mode matrix doc with invariants and reproducible unified-bench workflows.

# Docs Updated
- `TreeDB/README.md`
- `TreeDB/docs/spec/README.md`
- `TreeDB/docs/spec/storage-format.md`
- `TreeDB/docs/spec/outer-leaf-modes.md` (new)

# Tests
- `GOWORK=off go test ./TreeDB/docs/... -count=1`
- `GOWORK=off go test ./TreeDB -run 'TestReopenVerify_ValueLogRewrite_BatchedPointerSwap_ReopenParity_OuterLeaf(V2|V2FencePtr|V1LeafLog)|TestReopenVerify_ValueLogGC_OuterLeaf(V2|V2FencePtr|V1LeafLog)_ReopenParity|TestCrashRecovery_DeleteRangeWithoutTrailingSync_ReplaysCorrectKeys|TestCrashRecovery_DurabilityTiers' -count=1`

# Benchmarks (unified-bench)
## Command Set A: full suite, forced pointers
```bash
./bin/unified-bench -dbs treedb -profile fast -keys 500000 -progress=false -format markdown \
  -checkpoint-between-tests -test all \
  -treedb-index-outer-leaf-mode v1 -treedb-force-value-pointers=true

./bin/unified-bench -dbs treedb -profile fast -keys 500000 -progress=false -format markdown \
  -checkpoint-between-tests -test all \
  -treedb-index-outer-leaf-mode v1_leaflog -treedb-force-value-pointers=true
```

| Metric | `v1` | `v1_leaflog` | Delta |
| --- | ---: | ---: | ---: |
| Batch Write | 10,801,428 | 7,777,928 | -28.0% |
| Batch Write (Steady) | 553,422 | 552,181 | -0.2% |
| Batch Random | 5,029,891 | 3,377,711 | -32.8% |
| Random Read (Parallel) | 1,984,056 | 5,618,201 | +183.2% |
| Full Scan | 574,370 | 1,352,491 | +135.5% |
| Prefix Scan | 10,447,306 | 10,432,717 | -0.1% |
| `index.db` | 189 MiB | 188 MiB | -0.5% |

## Command Set B: small-value inline candidate
```bash
./bin/unified-bench -dbs treedb -profile fast -keys 500000 -valsize 1 -progress=false -format markdown \
  -checkpoint-between-tests -test batch_write,batch_write_steady,batch_random,random_read_parallel,full_scan,prefix_scan \
  -treedb-index-optimizations=false -treedb-force-value-pointers=false \
  -treedb-index-outer-leaf-mode v1

./bin/unified-bench -dbs treedb -profile fast -keys 500000 -valsize 1 -progress=false -format markdown \
  -checkpoint-between-tests -test batch_write,batch_write_steady,batch_random,random_read_parallel,full_scan,prefix_scan \
  -treedb-index-optimizations=false -treedb-force-value-pointers=false \
  -treedb-index-outer-leaf-mode v1_leaflog
```

| Metric | `v1` | `v1_leaflog` | Delta |
| --- | ---: | ---: | ---: |
| Batch Write | 13,028,127 | 12,797,711 | -1.8% |
| Batch Write (Steady) | 1,732,765 | 1,792,429 | +3.4% |
| Batch Random | 12,441,100 | 12,670,092 | +1.8% |
| Random Read (Parallel) | 24,276,306 | 23,865,763 | -1.7% |
| Full Scan | 15,155,630 | 15,212,936 | +0.4% |
| Prefix Scan | 16,497,118 | 16,349,153 | -0.9% |
| `index.db` | 43 MiB | 45 MiB | +4.7% |

# Notes
- These are pre-alpha comparative measurements for regression tracking.
- Results are workload and option sensitive; use command-set parity when comparing future changes.
