### PR TITLE
Phase 1 (#618): v1_leaflog alias plumbing, guardrails, and anchor scaffolding

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3619,7 +3619,9 @@ type Options struct {
 	// counts by pushing moderate values into the value log.
 	ValueLogPointerThreshold int
 	// IndexOuterLeafMode selects the outer-leaf payload format.
-	// Supported values: "v1", "v1_leaflog", "v2_blockptr", "v2_fenceptr".
+	// Supported values: "v1", "v1_leaflog", "v1_leaflog_legacy",
+	// "v2_blockptr", "v2_fenceptr".
+	// "v1_leaflog_legacy" currently normalizes to "v1_leaflog".
 	// Empty defaults to "v2_fenceptr".
 	IndexOuterLeafMode string
 	// ValueLogWALFenceMode selects WAL encoding behavior for pointer-eligible
@@ -5029,9 +5031,13 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	if valueLogRawWritevMinRecords <= 0 {
 		valueLogRawWritevMinRecords = 8
 	}
-	indexOuterLeafMode := strings.TrimSpace(opts.IndexOuterLeafMode)
+	indexOuterLeafMode := strings.ToLower(strings.TrimSpace(opts.IndexOuterLeafMode))
 	if indexOuterLeafMode == "" {
 		indexOuterLeafMode = backenddb.IndexOuterLeafModeV2FencePtr
+	}
+	if indexOuterLeafMode == backenddb.IndexOuterLeafModeV1LeafLogLegacy {
+		// Compatibility alias: keep current v1_leaflog semantics.
+		indexOuterLeafMode = backenddb.IndexOuterLeafModeV1LeafLog
 	}
 	if indexOuterLeafMode != backenddb.IndexOuterLeafModeV2BlockPtr &&
 		indexOuterLeafMode != backenddb.IndexOuterLeafModeV2FencePtr &&

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -1278,6 +1278,47 @@ func TestCachingDB_Open_NonFenceMode_RejectsSimpleInlineWALFenceMode(t *testing.
 	}
 }
 
+func TestCachingDB_Open_V1LeafLogLegacy_NormalizesToV1LeafLog(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	defer backend.Close()
+
+	cache, err := Open(dir, backend, Options{
+		IndexOuterLeafMode: db.IndexOuterLeafModeV1LeafLogLegacy,
+	})
+	if err != nil {
+		t.Fatalf("open v1_leaflog_legacy: %v", err)
+	}
+	defer cache.Close()
+	if got := cache.indexOuterLeafMode; got != db.IndexOuterLeafModeV1LeafLog {
+		t.Fatalf("indexOuterLeafMode=%q want %q", got, db.IndexOuterLeafModeV1LeafLog)
+	}
+}
+
+func TestCachingDB_Open_V2FencePtrMixedCase_AllowsSimpleInline(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	defer backend.Close()
+
+	cache, err := Open(dir, backend, Options{
+		IndexOuterLeafMode:   "V2_FENCEPTR",
+		ValueLogWALFenceMode: string(db.ValueLogWALFenceModeSimpleInline),
+	})
+	if err != nil {
+		t.Fatalf("open mixed-case v2_fenceptr simple_inline: %v", err)
+	}
+	defer cache.Close()
+	if got := cache.indexOuterLeafMode; got != db.IndexOuterLeafModeV2FencePtr {
+		t.Fatalf("indexOuterLeafMode=%q want %q", got, db.IndexOuterLeafModeV2FencePtr)
+	}
+}
+
 func TestCachingDB_Open_ValueLogOuterLeafBlobThresholdBytes_NegativeRejected(t *testing.T) {
 	dir := t.TempDir()
 	backend, err := db.Open(db.Options{Dir: dir})

--- a/TreeDB/db/anchor_invariants.go
+++ b/TreeDB/db/anchor_invariants.go
@@ -1,0 +1,60 @@
+package db
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+const envDebugAnchorInvariants = "TREEDB_DEBUG_ANCHOR_INVARIANTS"
+
+type v1LeafLogAnchor struct {
+	Key []byte
+	Ptr page.ValuePtr
+}
+
+func debugAnchorInvariantsEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(envDebugAnchorInvariants)))
+	switch v {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// validateV1LeafLogAnchors performs a lightweight ordering/disjointness check
+// for future routing-only anchor paths. It is intentionally side-effect free.
+func validateV1LeafLogAnchors(anchors []v1LeafLogAnchor) error {
+	var (
+		prevKey []byte
+	)
+	seenPtrs := make(map[page.ValuePtr]int, len(anchors))
+	for i := range anchors {
+		a := anchors[i]
+		if len(a.Key) == 0 {
+			return fmt.Errorf("v1_leaflog anchor invariant: empty key at index=%d", i)
+		}
+		if i > 0 {
+			if bytes.Compare(a.Key, prevKey) <= 0 {
+				return fmt.Errorf("v1_leaflog anchor invariant: non-increasing key at index=%d", i)
+			}
+		}
+		if firstIdx, exists := seenPtrs[a.Ptr]; exists {
+			return fmt.Errorf("v1_leaflog anchor invariant: duplicate pointer at index=%d first_index=%d", i, firstIdx)
+		}
+		seenPtrs[a.Ptr] = i
+		prevKey = a.Key
+	}
+	return nil
+}
+
+func debugFailFastOnV1LeafLogAnchorInvariant(err error) {
+	if err == nil || !debugAnchorInvariantsEnabled() {
+		return
+	}
+	panic(err)
+}

--- a/TreeDB/db/anchor_invariants_test.go
+++ b/TreeDB/db/anchor_invariants_test.go
@@ -1,0 +1,51 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestValidateV1LeafLogAnchors_OK(t *testing.T) {
+	anchors := []v1LeafLogAnchor{
+		{Key: []byte("aa"), Ptr: page.ValuePtr{FileID: 1, Offset: 100, Length: 10}},
+		{Key: []byte("ab"), Ptr: page.ValuePtr{FileID: 1, Offset: 200, Length: 10}},
+		{Key: []byte("ac"), Ptr: page.ValuePtr{FileID: 1, Offset: 300, Length: 10}},
+	}
+	if err := validateV1LeafLogAnchors(anchors); err != nil {
+		t.Fatalf("validateV1LeafLogAnchors: %v", err)
+	}
+}
+
+func TestValidateV1LeafLogAnchors_FailsOnNonIncreasingKey(t *testing.T) {
+	anchors := []v1LeafLogAnchor{
+		{Key: []byte("ab"), Ptr: page.ValuePtr{FileID: 1, Offset: 100, Length: 10}},
+		{Key: []byte("aa"), Ptr: page.ValuePtr{FileID: 1, Offset: 200, Length: 10}},
+	}
+	if err := validateV1LeafLogAnchors(anchors); err == nil {
+		t.Fatalf("expected non-increasing key validation failure")
+	}
+}
+
+func TestValidateV1LeafLogAnchors_FailsOnDuplicateAdjacentPointer(t *testing.T) {
+	ptr := page.ValuePtr{FileID: 1, Offset: 100, Length: 10}
+	anchors := []v1LeafLogAnchor{
+		{Key: []byte("aa"), Ptr: ptr},
+		{Key: []byte("ab"), Ptr: ptr},
+	}
+	if err := validateV1LeafLogAnchors(anchors); err == nil {
+		t.Fatalf("expected duplicate adjacent pointer validation failure")
+	}
+}
+
+func TestValidateV1LeafLogAnchors_FailsOnDuplicateNonAdjacentPointer(t *testing.T) {
+	ptr := page.ValuePtr{FileID: 1, Offset: 100, Length: 10}
+	anchors := []v1LeafLogAnchor{
+		{Key: []byte("aa"), Ptr: ptr},
+		{Key: []byte("ab"), Ptr: page.ValuePtr{FileID: 1, Offset: 200, Length: 10}},
+		{Key: []byte("ac"), Ptr: ptr},
+	}
+	if err := validateV1LeafLogAnchors(anchors); err == nil {
+		t.Fatalf("expected duplicate non-adjacent pointer validation failure")
+	}
+}

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -443,6 +443,12 @@ func (db *DB) Stats() map[string]string {
 	if db.indexOuterLeafMode != "" {
 		stats["treedb.index.outer_leaf_mode"] = db.indexOuterLeafMode
 	}
+	// Phase-1 anchor observability scaffolding for the planned routing-only
+	// v1_leaflog path. These remain zero until the path is activated.
+	stats["treedb.v1_leaflog.anchor_lookups"] = "0"
+	stats["treedb.v1_leaflog.anchor_block_decodes"] = "0"
+	stats["treedb.v1_leaflog.anchor_misses"] = "0"
+	stats["treedb.v1_leaflog.anchor_max_probes"] = "0"
 
 	if db.valueLogManager != nil {
 		vlogRemaps, vlogDeadMappings := db.valueLogManager.RemapStats()

--- a/TreeDB/db/api_test.go
+++ b/TreeDB/db/api_test.go
@@ -195,6 +195,32 @@ func TestStatsIncludesWatermarkLagDriftMetric(t *testing.T) {
 	}
 }
 
+func TestStatsIncludesV1LeafLogAnchorScaffolding(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stats := db.Stats()
+	keys := []string{
+		"treedb.v1_leaflog.anchor_lookups",
+		"treedb.v1_leaflog.anchor_block_decodes",
+		"treedb.v1_leaflog.anchor_misses",
+		"treedb.v1_leaflog.anchor_max_probes",
+	}
+	for _, key := range keys {
+		got, ok := stats[key]
+		if !ok {
+			t.Fatalf("missing %s", key)
+		}
+		if got != "0" {
+			t.Fatalf("%s=%q want 0", key, got)
+		}
+	}
+}
+
 func TestIteratorOptions_SnapshotCompatibility(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -148,6 +148,9 @@ func normalizeIndexOuterLeafMode(mode string) string {
 		return IndexOuterLeafModeV1
 	case IndexOuterLeafModeV1LeafLog:
 		return IndexOuterLeafModeV1LeafLog
+	case IndexOuterLeafModeV1LeafLogLegacy:
+		// Compatibility alias: keep legacy per-key semantics for now.
+		return IndexOuterLeafModeV1LeafLog
 	case IndexOuterLeafModeV2BlockPtr:
 		return IndexOuterLeafModeV2BlockPtr
 	case IndexOuterLeafModeV2FencePtr:
@@ -225,9 +228,17 @@ const (
 const (
 	// IndexOuterLeafModeV1 keeps the existing per-key leaf layout.
 	IndexOuterLeafModeV1 = "v1"
-	// IndexOuterLeafModeV1LeafLog keeps v1 exact-key semantics while storing
-	// leaf payload blocks in the value log (no fence fallback semantics).
+	// IndexOuterLeafModeV1LeafLog is reserved for the routing-only outer-leaf
+	// contract:
+	// - index stores routing/internal nodes plus one anchor per outer block
+	// - key/value leaf payloads live in value-log outer blocks
+	//
+	// During migration this constant still maps to legacy per-key behavior.
 	IndexOuterLeafModeV1LeafLog = "v1_leaflog"
+	// IndexOuterLeafModeV1LeafLogLegacy preserves legacy per-key v1_leaflog
+	// semantics for bisect and controlled rollout. It normalizes to
+	// IndexOuterLeafModeV1LeafLog at open time today.
+	IndexOuterLeafModeV1LeafLogLegacy = "v1_leaflog_legacy"
 	// IndexOuterLeafModeV2BlockPtr enables the outer-leaf block-pointer payload
 	// format. Values are encoded as key+value blocks in the value log and index
 	// leaves continue to store pointers.
@@ -536,8 +547,10 @@ type Options struct {
 	// IndexOuterLeafMode selects the index outer-leaf format:
 	// - "": defaults to "v2_fenceptr"
 	// - "v1": existing per-key leaf entries
-	// - "v1_leaflog": v1 exact-key semantics with outer-leaf payload blocks
-	//   stored in the value log (no fence-pointer fallback)
+	// - "v1_leaflog": reserved routing+anchor outer-leaf contract (currently
+	//   normalizes to legacy per-key semantics during migration)
+	// - "v1_leaflog_legacy": explicit compatibility alias for legacy per-key
+	//   v1_leaflog behavior (normalizes to "v1_leaflog")
 	// - "v2_blockptr": pointer payloads encode key+value outer-leaf blocks
 	// - "v2_fenceptr": fence-key-only index entries with outer block payloads
 	IndexOuterLeafMode string

--- a/TreeDB/db/outer_leaf_mode_options_test.go
+++ b/TreeDB/db/outer_leaf_mode_options_test.go
@@ -8,6 +8,7 @@ import (
 func TestOpen_IndexOuterLeafModeV2_Enabled(t *testing.T) {
 	modes := []string{
 		IndexOuterLeafModeV1LeafLog,
+		IndexOuterLeafModeV1LeafLogLegacy,
 		IndexOuterLeafModeV2BlockPtr,
 		IndexOuterLeafModeV2FencePtr,
 	}
@@ -22,6 +23,20 @@ func TestOpen_IndexOuterLeafModeV2_Enabled(t *testing.T) {
 		if err := db.Close(); err != nil {
 			t.Fatalf("close: %v", err)
 		}
+	}
+}
+
+func TestOpen_IndexOuterLeafMode_V1LeafLogLegacyNormalizesToV1LeafLog(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                t.TempDir(),
+		IndexOuterLeafMode: IndexOuterLeafModeV1LeafLogLegacy,
+	})
+	if err != nil {
+		t.Fatalf("open %q: %v", IndexOuterLeafModeV1LeafLogLegacy, err)
+	}
+	defer func() { _ = db.Close() }()
+	if got := db.indexOuterLeafMode; got != IndexOuterLeafModeV1LeafLog {
+		t.Fatalf("index outer leaf mode = %q, want %q", got, IndexOuterLeafModeV1LeafLog)
 	}
 }
 

--- a/TreeDB/options_aliases.go
+++ b/TreeDB/options_aliases.go
@@ -60,10 +60,11 @@ const (
 )
 
 const (
-	IndexOuterLeafModeV1         = db.IndexOuterLeafModeV1
-	IndexOuterLeafModeV1LeafLog  = db.IndexOuterLeafModeV1LeafLog
-	IndexOuterLeafModeV2BlockPtr = db.IndexOuterLeafModeV2BlockPtr
-	IndexOuterLeafModeV2FencePtr = db.IndexOuterLeafModeV2FencePtr
+	IndexOuterLeafModeV1              = db.IndexOuterLeafModeV1
+	IndexOuterLeafModeV1LeafLog       = db.IndexOuterLeafModeV1LeafLog
+	IndexOuterLeafModeV1LeafLogLegacy = db.IndexOuterLeafModeV1LeafLogLegacy
+	IndexOuterLeafModeV2BlockPtr      = db.IndexOuterLeafModeV2BlockPtr
+	IndexOuterLeafModeV2FencePtr      = db.IndexOuterLeafModeV2FencePtr
 )
 
 // Value-log compression autotune types (re-exported from internal packages so

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -268,10 +268,7 @@ func normalizeBackpressureDefaults(opts *Options) {
 
 	slowdown := defaultSlowdownBacklogSeconds
 	stop := defaultStopBacklogSeconds
-	indexOuterLeafMode := strings.ToLower(strings.TrimSpace(opts.IndexOuterLeafMode))
-	if indexOuterLeafMode == "" {
-		indexOuterLeafMode = db.IndexOuterLeafModeV2FencePtr
-	}
+	indexOuterLeafMode := normalizePublicOuterLeafMode(opts.IndexOuterLeafMode)
 	if opts.Durability == db.DurabilityWALOffRelaxed &&
 		indexOuterLeafMode == db.IndexOuterLeafModeV2FencePtr {
 		slowdown = defaultV2FenceSlowdownBacklogSeconds
@@ -283,11 +280,34 @@ func normalizeBackpressureDefaults(opts *Options) {
 	opts.MaxBacklogBytes = defaultAdaptiveMaxBacklogBytes
 }
 
+func normalizePublicOuterLeafMode(mode string) string {
+	trimmed := strings.TrimSpace(mode)
+	if trimmed == "" {
+		return db.IndexOuterLeafModeV2FencePtr
+	}
+	normalized := strings.ToLower(trimmed)
+	switch normalized {
+	case db.IndexOuterLeafModeV1:
+		return db.IndexOuterLeafModeV1
+	case db.IndexOuterLeafModeV1LeafLog:
+		return db.IndexOuterLeafModeV1LeafLog
+	case db.IndexOuterLeafModeV1LeafLogLegacy:
+		// Compatibility alias keeps current v1_leaflog behavior unchanged.
+		return db.IndexOuterLeafModeV1LeafLog
+	case db.IndexOuterLeafModeV2BlockPtr:
+		return db.IndexOuterLeafModeV2BlockPtr
+	case db.IndexOuterLeafModeV2FencePtr:
+		return db.IndexOuterLeafModeV2FencePtr
+	default:
+		// Keep non-alias values unchanged to avoid broad behavior drift in
+		// cached-mode parsing/validation paths.
+		return trimmed
+	}
+}
+
 // Open opens TreeDB. By default it enables caching (write-back layer).
 func Open(opts Options) (*DB, error) {
-	if strings.TrimSpace(opts.IndexOuterLeafMode) == "" {
-		opts.IndexOuterLeafMode = db.IndexOuterLeafModeV2FencePtr
-	}
+	opts.IndexOuterLeafMode = normalizePublicOuterLeafMode(opts.IndexOuterLeafMode)
 
 	// Cached mode writes to the backend in large flush batches, so commit sequence
 	// advances much more slowly than "number of writes". A large KeepRecent value

--- a/TreeDB/public_outer_leaf_mode_test.go
+++ b/TreeDB/public_outer_leaf_mode_test.go
@@ -1,0 +1,48 @@
+package treedb
+
+import (
+	"testing"
+)
+
+func TestNormalizePublicOuterLeafMode_V1LeafLogLegacyAlias(t *testing.T) {
+	if got := normalizePublicOuterLeafMode(IndexOuterLeafModeV1LeafLogLegacy); got != IndexOuterLeafModeV1LeafLog {
+		t.Fatalf("normalizePublicOuterLeafMode=%q want %q", got, IndexOuterLeafModeV1LeafLog)
+	}
+}
+
+func TestNormalizePublicOuterLeafMode_CanonicalizesKnownModeCasing(t *testing.T) {
+	const in = "V2_FENCEPTR"
+	if got := normalizePublicOuterLeafMode(in); got != IndexOuterLeafModeV2FencePtr {
+		t.Fatalf("normalizePublicOuterLeafMode=%q want %q", got, IndexOuterLeafModeV2FencePtr)
+	}
+}
+
+func TestOpen_V1LeafLogLegacyAlias_StatsModeNormalized(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                t.TempDir(),
+		IndexOuterLeafMode: IndexOuterLeafModeV1LeafLogLegacy,
+	})
+	if err != nil {
+		t.Fatalf("open %q: %v", IndexOuterLeafModeV1LeafLogLegacy, err)
+	}
+	defer db.Close()
+
+	stats := db.Stats()
+	if got := stats["treedb.index.outer_leaf_mode"]; got != IndexOuterLeafModeV1LeafLog {
+		t.Fatalf("treedb.index.outer_leaf_mode=%q want %q", got, IndexOuterLeafModeV1LeafLog)
+	}
+}
+
+func TestOpen_V2FencePtrMixedCase_AllowsSimpleInlineWALFenceMode(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                t.TempDir(),
+		IndexOuterLeafMode: "V2_FENCEPTR",
+		ValueLog: ValueLogOptions{
+			WALFenceMode: ValueLogWALFenceModeSimpleInline,
+		},
+	})
+	if err != nil {
+		t.Fatalf("open mixed-case v2_fenceptr simple_inline: %v", err)
+	}
+	defer db.Close()
+}

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -86,7 +86,7 @@ var (
 	treedbIndexColumnarLeaves             = flag.Bool("treedb-index-columnar-leaves", false, "TreeDB: enable columnar leaf encoding")
 	treedbIndexPackedValuePtr             = flag.Bool("treedb-index-packed-valueptr", false, "TreeDB: enable packed 12-byte ValuePtr encoding for pointer entries in leaf pages")
 	treedbIndexInternalBaseDelta          = flag.Bool("treedb-index-internal-base-delta", false, "TreeDB: enable internal base-delta encoding")
-	treedbIndexOuterLeafMode              = flag.String("treedb-index-outer-leaf-mode", "v2_fenceptr", "TreeDB: index outer-leaf mode (v1|v1_leaflog|v2_blockptr|v2_fenceptr)")
+	treedbIndexOuterLeafMode              = flag.String("treedb-index-outer-leaf-mode", "v2_fenceptr", "TreeDB: index outer-leaf mode (v1|v1_leaflog|v1_leaflog_legacy|v2_blockptr|v2_fenceptr)")
 	treedbWALFenceMode                    = flag.String("treedb-wal-fence-mode", "rid_join", "TreeDB: WAL fence mode for v2_fenceptr (rid_join|simple_inline). For WAL-on v2_fenceptr, default remains simple_inline unless explicitly set.")
 	treedbOuterLeafBlockTargetBytes       = flag.Int("treedb-outer-leaf-block-target-bytes", 0, "TreeDB: experimental outer-leaf block target bytes (0=default)")
 	treedbOuterLeafBlockCodec             = flag.String("treedb-outer-leaf-block-codec", "snappy", "TreeDB: experimental outer-leaf block codec (snappy|lz4)")
@@ -270,12 +270,15 @@ func parseTreeDBOuterLeafMode(s string) (string, error) {
 		return treedb.IndexOuterLeafModeV1, nil
 	case "v1_leaflog":
 		return treedb.IndexOuterLeafModeV1LeafLog, nil
+	case "v1_leaflog_legacy":
+		// Compatibility alias for current v1_leaflog semantics.
+		return treedb.IndexOuterLeafModeV1LeafLog, nil
 	case "v2_blockptr":
 		return treedb.IndexOuterLeafModeV2BlockPtr, nil
 	case "v2_fenceptr":
 		return treedb.IndexOuterLeafModeV2FencePtr, nil
 	default:
-		return "", fmt.Errorf("unsupported -treedb-index-outer-leaf-mode=%q (expected v1|v1_leaflog|v2_blockptr|v2_fenceptr)", s)
+		return "", fmt.Errorf("unsupported -treedb-index-outer-leaf-mode=%q (expected v1|v1_leaflog|v1_leaflog_legacy|v2_blockptr|v2_fenceptr)", s)
 	}
 }
 

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -59,6 +59,45 @@ func TestBuildTreeDBOptions_V1LeafLogModeAccepted(t *testing.T) {
 	}
 }
 
+func TestBuildTreeDBOptions_V1LeafLogLegacyModeAccepted(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbIndexOuterLeafMode = "v1_leaflog_legacy"
+
+	opts, rep, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions v1_leaflog_legacy: %v", err)
+	}
+	if got := opts.IndexOuterLeafMode; got != treedb.IndexOuterLeafModeV1LeafLog {
+		t.Fatalf("IndexOuterLeafMode=%q want %q", got, treedb.IndexOuterLeafModeV1LeafLog)
+	}
+	if got := rep.formatText(""); !strings.Contains(got, "index_outer_leaf_mode=v1_leaflog") {
+		t.Fatalf("resolved options missing normalized v1_leaflog outer-leaf mode: %q", got)
+	}
+}
+
+func TestParseTreeDBOuterLeafMode_V1LeafLogLegacyAccepted(t *testing.T) {
+	got, err := parseTreeDBOuterLeafMode("v1_leaflog_legacy")
+	if err != nil {
+		t.Fatalf("parseTreeDBOuterLeafMode: %v", err)
+	}
+	if got != treedb.IndexOuterLeafModeV1LeafLog {
+		t.Fatalf("parseTreeDBOuterLeafMode=%q want %q", got, treedb.IndexOuterLeafModeV1LeafLog)
+	}
+}
+
+func TestParseTreeDBOuterLeafMode_InvalidErrorMentionsLegacyAlias(t *testing.T) {
+	_, err := parseTreeDBOuterLeafMode("unknown_mode")
+	if err == nil {
+		t.Fatalf("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "v1_leaflog_legacy") {
+		t.Fatalf("expected error to mention v1_leaflog_legacy, got %v", err)
+	}
+}
+
 type savedTreeDBFlagState struct {
 	indexOptimizations bool
 	indexOuterLeafMode string
@@ -474,6 +513,21 @@ func TestBuildTreeDBOptions_WALFenceMode_V1LeafLog_RejectsSimpleInline(t *testin
 	}
 	if _, _, err := buildTreeDBOptions(""); err == nil {
 		t.Fatalf("expected simple_inline with v1_leaflog to fail")
+	}
+}
+
+func TestBuildTreeDBOptions_WALFenceMode_V1LeafLogLegacy_RejectsSimpleInline(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbIndexOuterLeafMode = "v1_leaflog_legacy"
+	*treedbWALFenceMode = "simple_inline"
+	explicitFlags = map[string]bool{
+		"treedb-wal-fence-mode": true,
+	}
+	if _, _, err := buildTreeDBOptions(""); err == nil {
+		t.Fatalf("expected simple_inline with v1_leaflog_legacy to fail")
 	}
 }
 


### PR DESCRIPTION
## Summary
This is **Phase 1 / PR1** for the `v1_leaflog` migration plan.

Scope is intentionally limited to mode plumbing, guardrails, and observability scaffolding, with **no core read/write semantic change**.

## What changed
- Added compatibility alias `v1_leaflog_legacy` and normalized it to current `v1_leaflog` behavior:
  - `TreeDB/db/db.go`
  - `TreeDB/options_aliases.go`
  - `TreeDB/public.go`
  - `TreeDB/caching/db.go`
  - `cmd/unified_bench/adapter_treedb.go`
- Updated mode comments/docs-in-code to freeze intended future `v1_leaflog` contract (routing + anchors) while keeping current behavior unchanged.
- Kept/strengthened guardrails: `simple_inline` fence mode remains valid only with `v2_fenceptr`.
- Added phase-1 anchor observability scaffolding in stats (currently zeroed until path activation):
  - `treedb.v1_leaflog.anchor_lookups`
  - `treedb.v1_leaflog.anchor_block_decodes`
  - `treedb.v1_leaflog.anchor_misses`
  - `treedb.v1_leaflog.anchor_max_probes`
- Added invariant helper scaffold for future anchor ordering/disjointness checks:
  - `TreeDB/db/anchor_invariants.go`

## Invariants / behavior guarantees in this PR
- Existing `v1_leaflog` runtime semantics remain unchanged.
- `v1_leaflog_legacy` is accepted as an explicit compatibility alias and currently normalizes to `v1_leaflog` behavior.
- No unbounded lookup algorithm changes in this phase.
- Guardrail behavior is preserved and tested.

## Tests
Ran targeted matrix:
- `GOWORK=off go test ./TreeDB -run 'NormalizePublicOuterLeafMode|V1LeafLogLegacyAlias|V2FencePtrMixedCase|OuterLeaf|ReopenVerify_OuterLeafV1LeafLog' -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'OuterLeaf|V1LeafLog|WALFenceMode|Stats|Anchor' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'CachingDB_Open|V1LeafLog|V2FencePtrMixedCase|Stats' -count=1`
- `GOWORK=off go test ./cmd/unified_bench -run 'BuildTreeDBOptions|ParseTreeDBOuterLeafMode|V1LeafLog' -count=1`

## Reviewer loop
- Independent reviewer pass found medium issues in public mode canonicalization and test coverage.
- Addressed in this PR by canonicalizing known mode spellings, preserving unknown values, and adding mixed-case regression tests.
- Final independent reviewer pass: **no unresolved high/medium findings**.

## Out of scope
- No read-path rewrite yet.
- No write-path atomicity changes yet.
- No iterator/GC/rewrite behavioral changes yet.

Follow-up phases (#619+ ) will implement exact anchor read/write semantics and parity work.
