### PR TITLE
Phase 2 (#619): exact v1_leaflog read path scope + legacy mode split

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3621,7 +3621,6 @@ type Options struct {
 	// IndexOuterLeafMode selects the outer-leaf payload format.
 	// Supported values: "v1", "v1_leaflog", "v1_leaflog_legacy",
 	// "v2_blockptr", "v2_fenceptr".
-	// "v1_leaflog_legacy" currently normalizes to "v1_leaflog".
 	// Empty defaults to "v2_fenceptr".
 	IndexOuterLeafMode string
 	// ValueLogWALFenceMode selects WAL encoding behavior for pointer-eligible
@@ -5035,13 +5034,10 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	if indexOuterLeafMode == "" {
 		indexOuterLeafMode = backenddb.IndexOuterLeafModeV2FencePtr
 	}
-	if indexOuterLeafMode == backenddb.IndexOuterLeafModeV1LeafLogLegacy {
-		// Compatibility alias: keep current v1_leaflog semantics.
-		indexOuterLeafMode = backenddb.IndexOuterLeafModeV1LeafLog
-	}
 	if indexOuterLeafMode != backenddb.IndexOuterLeafModeV2BlockPtr &&
 		indexOuterLeafMode != backenddb.IndexOuterLeafModeV2FencePtr &&
-		indexOuterLeafMode != backenddb.IndexOuterLeafModeV1LeafLog {
+		indexOuterLeafMode != backenddb.IndexOuterLeafModeV1LeafLog &&
+		indexOuterLeafMode != backenddb.IndexOuterLeafModeV1LeafLogLegacy {
 		indexOuterLeafMode = backenddb.IndexOuterLeafModeV1
 	}
 	rawValueLogWALFenceMode := strings.TrimSpace(opts.ValueLogWALFenceMode)

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -1278,7 +1278,7 @@ func TestCachingDB_Open_NonFenceMode_RejectsSimpleInlineWALFenceMode(t *testing.
 	}
 }
 
-func TestCachingDB_Open_V1LeafLogLegacy_NormalizesToV1LeafLog(t *testing.T) {
+func TestCachingDB_Open_V1LeafLogLegacy_Preserved(t *testing.T) {
 	dir := t.TempDir()
 	backend, err := db.Open(db.Options{Dir: dir})
 	if err != nil {
@@ -1293,8 +1293,8 @@ func TestCachingDB_Open_V1LeafLogLegacy_NormalizesToV1LeafLog(t *testing.T) {
 		t.Fatalf("open v1_leaflog_legacy: %v", err)
 	}
 	defer cache.Close()
-	if got := cache.indexOuterLeafMode; got != db.IndexOuterLeafModeV1LeafLog {
-		t.Fatalf("indexOuterLeafMode=%q want %q", got, db.IndexOuterLeafModeV1LeafLog)
+	if got := cache.indexOuterLeafMode; got != db.IndexOuterLeafModeV1LeafLogLegacy {
+		t.Fatalf("indexOuterLeafMode=%q want %q", got, db.IndexOuterLeafModeV1LeafLogLegacy)
 	}
 }
 

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -149,8 +149,7 @@ func normalizeIndexOuterLeafMode(mode string) string {
 	case IndexOuterLeafModeV1LeafLog:
 		return IndexOuterLeafModeV1LeafLog
 	case IndexOuterLeafModeV1LeafLogLegacy:
-		// Compatibility alias: keep legacy per-key semantics for now.
-		return IndexOuterLeafModeV1LeafLog
+		return IndexOuterLeafModeV1LeafLogLegacy
 	case IndexOuterLeafModeV2BlockPtr:
 		return IndexOuterLeafModeV2BlockPtr
 	case IndexOuterLeafModeV2FencePtr:
@@ -228,16 +227,12 @@ const (
 const (
 	// IndexOuterLeafModeV1 keeps the existing per-key leaf layout.
 	IndexOuterLeafModeV1 = "v1"
-	// IndexOuterLeafModeV1LeafLog is reserved for the routing-only outer-leaf
-	// contract:
+	// IndexOuterLeafModeV1LeafLog enables the routing-only outer-leaf contract:
 	// - index stores routing/internal nodes plus one anchor per outer block
 	// - key/value leaf payloads live in value-log outer blocks
-	//
-	// During migration this constant still maps to legacy per-key behavior.
 	IndexOuterLeafModeV1LeafLog = "v1_leaflog"
 	// IndexOuterLeafModeV1LeafLogLegacy preserves legacy per-key v1_leaflog
-	// semantics for bisect and controlled rollout. It normalizes to
-	// IndexOuterLeafModeV1LeafLog at open time today.
+	// semantics for bisect and controlled rollout.
 	IndexOuterLeafModeV1LeafLogLegacy = "v1_leaflog_legacy"
 	// IndexOuterLeafModeV2BlockPtr enables the outer-leaf block-pointer payload
 	// format. Values are encoded as key+value blocks in the value log and index
@@ -547,10 +542,9 @@ type Options struct {
 	// IndexOuterLeafMode selects the index outer-leaf format:
 	// - "": defaults to "v2_fenceptr"
 	// - "v1": existing per-key leaf entries
-	// - "v1_leaflog": reserved routing+anchor outer-leaf contract (currently
-	//   normalizes to legacy per-key semantics during migration)
+	// - "v1_leaflog": routing+anchor outer-leaf contract
 	// - "v1_leaflog_legacy": explicit compatibility alias for legacy per-key
-	//   v1_leaflog behavior (normalizes to "v1_leaflog")
+	//   v1_leaflog behavior
 	// - "v2_blockptr": pointer payloads encode key+value outer-leaf blocks
 	// - "v2_fenceptr": fence-key-only index entries with outer block payloads
 	IndexOuterLeafMode string
@@ -939,7 +933,7 @@ func validateOptions(opts Options) error {
 	}
 	indexOuterLeafMode := normalizeIndexOuterLeafMode(opts.IndexOuterLeafMode)
 	switch indexOuterLeafMode {
-	case IndexOuterLeafModeV1, IndexOuterLeafModeV1LeafLog, IndexOuterLeafModeV2BlockPtr, IndexOuterLeafModeV2FencePtr:
+	case IndexOuterLeafModeV1, IndexOuterLeafModeV1LeafLog, IndexOuterLeafModeV1LeafLogLegacy, IndexOuterLeafModeV2BlockPtr, IndexOuterLeafModeV2FencePtr:
 	default:
 		return fmt.Errorf("treedb: invalid index outer leaf mode %q", opts.IndexOuterLeafMode)
 	}

--- a/TreeDB/db/outer_leaf_mode_options_test.go
+++ b/TreeDB/db/outer_leaf_mode_options_test.go
@@ -26,7 +26,7 @@ func TestOpen_IndexOuterLeafModeV2_Enabled(t *testing.T) {
 	}
 }
 
-func TestOpen_IndexOuterLeafMode_V1LeafLogLegacyNormalizesToV1LeafLog(t *testing.T) {
+func TestOpen_IndexOuterLeafMode_V1LeafLogLegacyPreserved(t *testing.T) {
 	db, err := Open(Options{
 		Dir:                t.TempDir(),
 		IndexOuterLeafMode: IndexOuterLeafModeV1LeafLogLegacy,
@@ -35,8 +35,8 @@ func TestOpen_IndexOuterLeafMode_V1LeafLogLegacyNormalizesToV1LeafLog(t *testing
 		t.Fatalf("open %q: %v", IndexOuterLeafModeV1LeafLogLegacy, err)
 	}
 	defer func() { _ = db.Close() }()
-	if got := db.indexOuterLeafMode; got != IndexOuterLeafModeV1LeafLog {
-		t.Fatalf("index outer leaf mode = %q, want %q", got, IndexOuterLeafModeV1LeafLog)
+	if got := db.indexOuterLeafMode; got != IndexOuterLeafModeV1LeafLogLegacy {
+		t.Fatalf("index outer leaf mode = %q, want %q", got, IndexOuterLeafModeV1LeafLogLegacy)
 	}
 }
 

--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -20,6 +20,8 @@ type valueReader struct {
 	modeInit               bool
 	outerLeafEnabled       bool
 	fenceLookupEnabled     bool
+	fenceGlobalEnabled     bool
+	fenceSingleCandidate   bool
 	skipOuterLeafChecksums bool
 	cache                  *outerLeafBlockCache
 	keyCache               *outerLeafKeyCache
@@ -473,10 +475,20 @@ func (r *valueReader) releaseDecodeContext() {
 }
 
 func (r *valueReader) setOuterLeafMode(mode string) {
-	mode = strings.TrimSpace(mode)
+	mode = strings.ToLower(strings.TrimSpace(mode))
 	r.outerLeafMode = mode
 	r.outerLeafEnabled = outerleaf.ModeEnabled(mode)
-	r.fenceLookupEnabled = mode == outerleaf.ModeV2FencePtr
+	r.fenceLookupEnabled = false
+	r.fenceGlobalEnabled = false
+	r.fenceSingleCandidate = false
+	switch mode {
+	case outerleaf.ModeV1LeafLog:
+		r.fenceLookupEnabled = true
+		r.fenceSingleCandidate = true
+	case outerleaf.ModeV2FencePtr:
+		r.fenceLookupEnabled = true
+		r.fenceGlobalEnabled = true
+	}
 	r.modeInit = true
 }
 
@@ -489,16 +501,14 @@ func (r valueReader) outerLeafModeEnabled() bool {
 
 func (r valueReader) fenceLookupModeEnabled() bool {
 	if r.modeInit {
-		if r.outerLeafMode == outerleaf.ModeV1LeafLog {
-			return false
-		}
 		return r.fenceLookupEnabled
 	}
-	mode := strings.TrimSpace(r.outerLeafMode)
-	if mode == outerleaf.ModeV1LeafLog {
+	switch strings.ToLower(strings.TrimSpace(r.outerLeafMode)) {
+	case outerleaf.ModeV1LeafLog, outerleaf.ModeV2FencePtr:
+		return true
+	default:
 		return false
 	}
-	return mode == outerleaf.ModeV2FencePtr
 }
 
 func (r valueReader) KeyAwareEnabled() bool {
@@ -509,12 +519,26 @@ func (r valueReader) FenceLookupEnabled() bool {
 	return r.fenceLookupModeEnabled()
 }
 
+func (r valueReader) FenceLookupGlobalEnabled() bool {
+	if r.modeInit {
+		return r.fenceGlobalEnabled
+	}
+	return strings.ToLower(strings.TrimSpace(r.outerLeafMode)) == outerleaf.ModeV2FencePtr
+}
+
+func (r valueReader) FenceLookupSingleCandidateEnabled() bool {
+	if r.modeInit {
+		return r.fenceSingleCandidate
+	}
+	return strings.ToLower(strings.TrimSpace(r.outerLeafMode)) == outerleaf.ModeV1LeafLog
+}
+
 func (r valueReader) FencePointerLikelyBlock(ptr page.ValuePtr) bool {
 	if r.modeInit {
-		if r.outerLeafMode == outerleaf.ModeV1LeafLog {
+		if r.outerLeafMode == outerleaf.ModeV1LeafLogLegacy {
 			return false
 		}
-	} else if strings.TrimSpace(r.outerLeafMode) == outerleaf.ModeV1LeafLog {
+	} else if strings.ToLower(strings.TrimSpace(r.outerLeafMode)) == outerleaf.ModeV1LeafLogLegacy {
 		return false
 	}
 	// Fence expansion should only trigger for explicitly fence-marked pointers.

--- a/TreeDB/db/value_reader_test.go
+++ b/TreeDB/db/value_reader_test.go
@@ -143,15 +143,56 @@ func TestValueReader_FencePointerLikelyBlock_RequiresExplicitFenceMarker(t *test
 	}
 }
 
-func TestValueReader_FenceLookupDisabledForV1LeafLog(t *testing.T) {
+func TestValueReader_FenceLookupScopedForV1LeafLog(t *testing.T) {
 	r := newValueReader(nil, outerleaf.ModeV1LeafLog, false, nil, nil)
 	defer (&r).releaseDecodeContext()
 
 	if !r.KeyAwareEnabled() {
 		t.Fatalf("v1_leaflog should keep key-aware outer-leaf reads enabled")
 	}
+	if !r.FenceLookupEnabled() {
+		t.Fatalf("v1_leaflog should enable fence lookup mode")
+	}
+	if r.FenceLookupGlobalEnabled() {
+		t.Fatalf("v1_leaflog must disable global fallback lookups")
+	}
+	if !r.FenceLookupSingleCandidateEnabled() {
+		t.Fatalf("v1_leaflog must probe only one predecessor candidate")
+	}
+
+	base := page.ValuePtr{
+		FileID: page.ValueLogFileID(7),
+		Offset: 123,
+		Length: 4096,
+	}
+	fence := page.ValuePtrMarkFenceOuter(base)
+	if !r.FencePointerLikelyBlock(fence) {
+		t.Fatalf("v1_leaflog should classify explicit fence pointers as fence blocks")
+	}
+
+	grouped := base
+	grouped.Length = page.ValuePtrMarkGrouped(base.Length, 3)
+	groupedFence := page.ValuePtrMarkFenceOuter(grouped)
+	if r.FencePointerLikelyBlock(groupedFence) {
+		t.Fatalf("v1_leaflog must not classify grouped pointers as fence blocks")
+	}
+}
+
+func TestValueReader_FenceLookupDisabledForV1LeafLogLegacy(t *testing.T) {
+	r := newValueReader(nil, outerleaf.ModeV1LeafLogLegacy, false, nil, nil)
+	defer (&r).releaseDecodeContext()
+
+	if !r.KeyAwareEnabled() {
+		t.Fatalf("v1_leaflog_legacy should keep key-aware outer-leaf reads enabled")
+	}
 	if r.FenceLookupEnabled() {
-		t.Fatalf("v1_leaflog must not enable fence lookup mode")
+		t.Fatalf("v1_leaflog_legacy must keep fence lookup mode disabled")
+	}
+	if r.FenceLookupGlobalEnabled() {
+		t.Fatalf("v1_leaflog_legacy must keep global fence fallback disabled")
+	}
+	if r.FenceLookupSingleCandidateEnabled() {
+		t.Fatalf("v1_leaflog_legacy should not advertise single-candidate fence probing")
 	}
 
 	base := page.ValuePtr{
@@ -161,14 +202,7 @@ func TestValueReader_FenceLookupDisabledForV1LeafLog(t *testing.T) {
 	}
 	fence := page.ValuePtrMarkFenceOuter(base)
 	if r.FencePointerLikelyBlock(fence) {
-		t.Fatalf("v1_leaflog must not classify pointers as fence blocks")
-	}
-
-	grouped := base
-	grouped.Length = page.ValuePtrMarkGrouped(base.Length, 3)
-	groupedFence := page.ValuePtrMarkFenceOuter(grouped)
-	if r.FencePointerLikelyBlock(groupedFence) {
-		t.Fatalf("v1_leaflog must not classify grouped pointers as fence blocks")
+		t.Fatalf("v1_leaflog_legacy must not classify pointers as fence blocks")
 	}
 }
 

--- a/TreeDB/internal/outerleaf/block.go
+++ b/TreeDB/internal/outerleaf/block.go
@@ -18,9 +18,10 @@ import (
 )
 
 const (
-	ModeV1LeafLog  = "v1_leaflog"
-	ModeV2BlockPtr = "v2_blockptr"
-	ModeV2FencePtr = "v2_fenceptr"
+	ModeV1LeafLog       = "v1_leaflog"
+	ModeV1LeafLogLegacy = "v1_leaflog_legacy"
+	ModeV2BlockPtr      = "v2_blockptr"
+	ModeV2FencePtr      = "v2_fenceptr"
 
 	defaultBlockTargetBytes = 4 << 10
 	defaultRestartInterval  = 16
@@ -265,7 +266,7 @@ func HasMagic(payload []byte) bool {
 
 func ModeEnabled(mode string) bool {
 	switch strings.TrimSpace(mode) {
-	case ModeV1LeafLog, ModeV2BlockPtr, ModeV2FencePtr:
+	case ModeV1LeafLog, ModeV1LeafLogLegacy, ModeV2BlockPtr, ModeV2FencePtr:
 		return true
 	default:
 		return false

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -292,8 +292,7 @@ func normalizePublicOuterLeafMode(mode string) string {
 	case db.IndexOuterLeafModeV1LeafLog:
 		return db.IndexOuterLeafModeV1LeafLog
 	case db.IndexOuterLeafModeV1LeafLogLegacy:
-		// Compatibility alias keeps current v1_leaflog behavior unchanged.
-		return db.IndexOuterLeafModeV1LeafLog
+		return db.IndexOuterLeafModeV1LeafLogLegacy
 	case db.IndexOuterLeafModeV2BlockPtr:
 		return db.IndexOuterLeafModeV2BlockPtr
 	case db.IndexOuterLeafModeV2FencePtr:

--- a/TreeDB/public_outer_leaf_mode_test.go
+++ b/TreeDB/public_outer_leaf_mode_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 )
 
-func TestNormalizePublicOuterLeafMode_V1LeafLogLegacyAlias(t *testing.T) {
-	if got := normalizePublicOuterLeafMode(IndexOuterLeafModeV1LeafLogLegacy); got != IndexOuterLeafModeV1LeafLog {
-		t.Fatalf("normalizePublicOuterLeafMode=%q want %q", got, IndexOuterLeafModeV1LeafLog)
+func TestNormalizePublicOuterLeafMode_V1LeafLogLegacyPreserved(t *testing.T) {
+	if got := normalizePublicOuterLeafMode(IndexOuterLeafModeV1LeafLogLegacy); got != IndexOuterLeafModeV1LeafLogLegacy {
+		t.Fatalf("normalizePublicOuterLeafMode=%q want %q", got, IndexOuterLeafModeV1LeafLogLegacy)
 	}
 }
 
@@ -17,7 +17,7 @@ func TestNormalizePublicOuterLeafMode_CanonicalizesKnownModeCasing(t *testing.T)
 	}
 }
 
-func TestOpen_V1LeafLogLegacyAlias_StatsModeNormalized(t *testing.T) {
+func TestOpen_V1LeafLogLegacy_StatsModePreserved(t *testing.T) {
 	db, err := Open(Options{
 		Dir:                t.TempDir(),
 		IndexOuterLeafMode: IndexOuterLeafModeV1LeafLogLegacy,
@@ -28,8 +28,8 @@ func TestOpen_V1LeafLogLegacyAlias_StatsModeNormalized(t *testing.T) {
 	defer db.Close()
 
 	stats := db.Stats()
-	if got := stats["treedb.index.outer_leaf_mode"]; got != IndexOuterLeafModeV1LeafLog {
-		t.Fatalf("treedb.index.outer_leaf_mode=%q want %q", got, IndexOuterLeafModeV1LeafLog)
+	if got := stats["treedb.index.outer_leaf_mode"]; got != IndexOuterLeafModeV1LeafLogLegacy {
+		t.Fatalf("treedb.index.outer_leaf_mode=%q want %q", got, IndexOuterLeafModeV1LeafLogLegacy)
 	}
 }
 

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -77,6 +77,18 @@ type slabFenceLookupMode interface {
 	FenceLookupEnabled() bool
 }
 
+// Optional capability probe for global reverse-iterator fallback.
+// When false, miss paths may only use same-leaf predecessor probes.
+type slabFenceLookupGlobalMode interface {
+	FenceLookupGlobalEnabled() bool
+}
+
+// Optional capability probe for same-leaf predecessor scan scope.
+// When true, miss paths probe at most one predecessor candidate.
+type slabFenceLookupSingleCandidateMode interface {
+	FenceLookupSingleCandidateEnabled() bool
+}
+
 // Optional block expansion reads for fence-only outer-leaf mode.
 // ok=false means the reader is not in fence expansion mode for this pointer.
 type slabUnsafeFenceBlockReader interface {
@@ -181,6 +193,20 @@ func fencePointerLookupsEnabled(sr SlabReader) bool {
 	return true
 }
 
+func fencePointerGlobalLookupsEnabled(sr SlabReader) bool {
+	if gate, ok := sr.(slabFenceLookupGlobalMode); ok {
+		return gate.FenceLookupGlobalEnabled()
+	}
+	return true
+}
+
+func fencePointerSingleCandidateEnabled(sr SlabReader) bool {
+	if gate, ok := sr.(slabFenceLookupSingleCandidateMode); ok {
+		return gate.FenceLookupSingleCandidateEnabled()
+	}
+	return false
+}
+
 func (t *Tree) fencePointerLikelyBlock(ptr page.ValuePtr) bool {
 	// Explicit fence markers are authoritative and must never be skipped.
 	if page.ValuePtrIsFenceOuter(ptr) {
@@ -202,6 +228,8 @@ type Tree struct {
 	slabFenceReader   slabUnsafeFenceKeyReader
 	slabFenceAppender slabUnsafeFenceKeyAppender
 	fenceLookupMode   bool
+	fenceLookupGlobal bool
+	fenceLookupSingle bool
 	slabFenceBlocks   slabUnsafeFenceBlockReader
 	slabFenceBlocksI  slabUnsafeFenceBlockIntoReader
 	slabFenceBlocksL  slabUnsafeFenceBlockLeaseIntoReader
@@ -224,6 +252,8 @@ func New(p *pager.Pager, sr SlabReader, root uint64) *Tree {
 	}
 	keyAwareEnabled := keyAwarePointerReadsEnabled(sr)
 	fenceEnabled := fencePointerLookupsEnabled(sr)
+	fenceGlobalEnabled := fencePointerGlobalLookupsEnabled(sr)
+	fenceSingleCandidate := fencePointerSingleCandidateEnabled(sr)
 	if app, ok := sr.(slabUnsafeAppender); ok {
 		t.slabAppender = app
 	}
@@ -277,6 +307,8 @@ func New(p *pager.Pager, sr SlabReader, root uint64) *Tree {
 		}
 	}
 	t.fenceLookupMode = fenceEnabled && (t.slabFenceReader != nil || t.slabFenceAppender != nil)
+	t.fenceLookupGlobal = t.fenceLookupMode && fenceGlobalEnabled
+	t.fenceLookupSingle = t.fenceLookupMode && fenceSingleCandidate
 	return t
 }
 
@@ -286,6 +318,8 @@ func (t *Tree) Reset(p *pager.Pager, sr SlabReader, root uint64) {
 	t.slabReader = sr
 	keyAwareEnabled := keyAwarePointerReadsEnabled(sr)
 	fenceEnabled := fencePointerLookupsEnabled(sr)
+	fenceGlobalEnabled := fencePointerGlobalLookupsEnabled(sr)
+	fenceSingleCandidate := fencePointerSingleCandidateEnabled(sr)
 	if app, ok := sr.(slabUnsafeAppender); ok {
 		t.slabAppender = app
 	} else {
@@ -387,6 +421,8 @@ func (t *Tree) Reset(p *pager.Pager, sr SlabReader, root uint64) {
 		t.slabFencePtrCls = nil
 	}
 	t.fenceLookupMode = fenceEnabled && (t.slabFenceReader != nil || t.slabFenceAppender != nil)
+	t.fenceLookupGlobal = t.fenceLookupMode && fenceGlobalEnabled
+	t.fenceLookupSingle = t.fenceLookupMode && fenceSingleCandidate
 	t.rootPageID = root
 }
 
@@ -718,6 +754,43 @@ func (t *Tree) lookupFenceValueView(n *node.Node, idx uint16, key []byte) ([]byt
 	if !t.fenceLookupMode || n == nil || idx == 0 {
 		return nil, false, nil
 	}
+	if t.fenceLookupSingle {
+		// Single-candidate mode inspects only the immediate predecessor anchor.
+		scan := idx
+		// Fence lookup only needs pointer+flags. Avoid full leaf-entry decode
+		// (key reconstruction) on every probe in columnar-prefix leaves.
+		_, ptr, flags, err := n.GetLeafValueView(scan - 1)
+		if err != nil {
+			return nil, false, err
+		}
+		if flags&node.FlagTombstone != 0 || flags&node.FlagPointer == 0 {
+			return nil, false, nil
+		}
+		if !t.fencePointerLikelyBlock(ptr) {
+			return nil, false, nil
+		}
+		if t.slabFenceReader != nil {
+			val, found, err := t.slabFenceReader.ReadUnsafeFenceForKey(ptr, key)
+			if err != nil {
+				return nil, false, err
+			}
+			if found {
+				return val, true, nil
+			}
+			return nil, false, nil
+		}
+		if t.slabFenceAppender != nil {
+			val, found, err := t.slabFenceAppender.ReadUnsafeFenceAppendForKey(ptr, key, nil)
+			if err != nil {
+				return nil, false, err
+			}
+			if found {
+				return val, true, nil
+			}
+			return nil, false, nil
+		}
+		return nil, false, nil
+	}
 	for scan := idx; scan > 0; scan-- {
 		// Fence lookup only needs pointer+flags. Avoid full leaf-entry decode
 		// (key reconstruction) on every probe in columnar-prefix leaves.
@@ -758,6 +831,48 @@ func (t *Tree) lookupFenceValueView(n *node.Node, idx uint16, key []byte) ([]byt
 
 func (t *Tree) lookupFencePointerSource(n *node.Node, idx uint16, key []byte) ([]byte, page.ValuePtr, bool, error) {
 	if !t.fenceLookupMode || n == nil || idx == 0 {
+		return nil, page.ValuePtr{}, false, nil
+	}
+	if t.fenceLookupSingle {
+		scan := idx
+		_, ptr, flags, err := n.GetLeafValueView(scan - 1)
+		if err != nil {
+			return nil, page.ValuePtr{}, false, err
+		}
+		if flags&node.FlagTombstone != 0 || flags&node.FlagPointer == 0 {
+			return nil, page.ValuePtr{}, false, nil
+		}
+		if !t.fencePointerLikelyBlock(ptr) {
+			return nil, page.ValuePtr{}, false, nil
+		}
+		if t.slabFenceReader != nil {
+			_, found, err := t.slabFenceReader.ReadUnsafeFenceForKey(ptr, key)
+			if err != nil {
+				return nil, page.ValuePtr{}, false, err
+			}
+			if found {
+				srcKey, _, _, _, err := n.GetLeafEntryView(scan - 1)
+				if err != nil {
+					return nil, page.ValuePtr{}, false, err
+				}
+				return append([]byte(nil), srcKey...), ptr, true, nil
+			}
+			return nil, page.ValuePtr{}, false, nil
+		}
+		if t.slabFenceAppender != nil {
+			_, found, err := t.slabFenceAppender.ReadUnsafeFenceAppendForKey(ptr, key, nil)
+			if err != nil {
+				return nil, page.ValuePtr{}, false, err
+			}
+			if found {
+				srcKey, _, _, _, err := n.GetLeafEntryView(scan - 1)
+				if err != nil {
+					return nil, page.ValuePtr{}, false, err
+				}
+				return append([]byte(nil), srcKey...), ptr, true, nil
+			}
+			return nil, page.ValuePtr{}, false, nil
+		}
 		return nil, page.ValuePtr{}, false, nil
 	}
 	for scan := idx; scan > 0; scan-- {
@@ -808,6 +923,40 @@ func (t *Tree) lookupFencePointerSourcePtr(n *node.Node, idx uint16, key []byte)
 	if !t.fenceLookupMode || n == nil || idx == 0 {
 		return page.ValuePtr{}, false, nil
 	}
+	if t.fenceLookupSingle {
+		scan := idx
+		_, ptr, flags, err := n.GetLeafValueView(scan - 1)
+		if err != nil {
+			return page.ValuePtr{}, false, err
+		}
+		if flags&node.FlagTombstone != 0 || flags&node.FlagPointer == 0 {
+			return page.ValuePtr{}, false, nil
+		}
+		if !t.fencePointerLikelyBlock(ptr) {
+			return page.ValuePtr{}, false, nil
+		}
+		if t.slabFenceReader != nil {
+			_, found, err := t.slabFenceReader.ReadUnsafeFenceForKey(ptr, key)
+			if err != nil {
+				return page.ValuePtr{}, false, err
+			}
+			if found {
+				return ptr, true, nil
+			}
+			return page.ValuePtr{}, false, nil
+		}
+		if t.slabFenceAppender != nil {
+			_, found, err := t.slabFenceAppender.ReadUnsafeFenceAppendForKey(ptr, key, nil)
+			if err != nil {
+				return page.ValuePtr{}, false, err
+			}
+			if found {
+				return ptr, true, nil
+			}
+			return page.ValuePtr{}, false, nil
+		}
+		return page.ValuePtr{}, false, nil
+	}
 	for scan := idx; scan > 0; scan-- {
 		_, ptr, flags, err := n.GetLeafValueView(scan - 1)
 		if err != nil {
@@ -845,7 +994,7 @@ func (t *Tree) lookupFencePointerSourcePtr(n *node.Node, idx uint16, key []byte)
 }
 
 func (t *Tree) lookupFencePointerSourceGlobal(key []byte) ([]byte, page.ValuePtr, bool, error) {
-	if !t.fenceLookupMode {
+	if !t.fenceLookupMode || !t.fenceLookupGlobal {
 		return nil, page.ValuePtr{}, false, nil
 	}
 	it := t.ReverseIteratorWithOptions(nil, key, IteratorOptions{Mode: IteratorModePointerProjection})
@@ -889,7 +1038,7 @@ func (t *Tree) lookupFencePointerSourceGlobal(key []byte) ([]byte, page.ValuePtr
 }
 
 func (t *Tree) lookupFencePointerSourceGlobalPtr(key []byte) (page.ValuePtr, bool, error) {
-	if !t.fenceLookupMode {
+	if !t.fenceLookupMode || !t.fenceLookupGlobal {
 		return page.ValuePtr{}, false, nil
 	}
 	it := t.ReverseIteratorWithOptions(nil, key, IteratorOptions{Mode: IteratorModePointerProjection})
@@ -935,7 +1084,7 @@ func (t *Tree) lookupFencePointerSourceGlobalPtr(key []byte) (page.ValuePtr, boo
 }
 
 func (t *Tree) lookupFenceValueViewGlobal(key []byte) ([]byte, bool, error) {
-	if !t.fenceLookupMode {
+	if !t.fenceLookupMode || !t.fenceLookupGlobal {
 		return nil, false, nil
 	}
 	it := t.ReverseIteratorWithOptions(nil, key, IteratorOptions{Mode: IteratorModePointerProjection})
@@ -981,7 +1130,7 @@ func (t *Tree) lookupFenceValueViewGlobal(key []byte) ([]byte, bool, error) {
 }
 
 func (t *Tree) lookupFenceValueViewAppendGlobal(key []byte, dst []byte) ([]byte, bool, error) {
-	if !t.fenceLookupMode {
+	if !t.fenceLookupMode || !t.fenceLookupGlobal {
 		return dst, false, nil
 	}
 	it := t.ReverseIteratorWithOptions(nil, key, IteratorOptions{Mode: IteratorModePointerProjection})
@@ -1046,6 +1195,53 @@ func (t *Tree) lookupFenceValueViewAppend(n *node.Node, idx uint16, key []byte, 
 	if !t.fenceLookupMode || n == nil || idx == 0 {
 		return nil, false, nil
 	}
+	if t.fenceLookupSingle {
+		scan := idx
+		_, ptr, flags, err := n.GetLeafValueView(scan - 1)
+		if err != nil {
+			return nil, false, err
+		}
+		if flags&node.FlagTombstone != 0 || flags&node.FlagPointer == 0 {
+			return nil, false, nil
+		}
+		if !t.fencePointerLikelyBlock(ptr) {
+			return nil, false, nil
+		}
+		if t.slabFenceAppender != nil {
+			oldLen := len(dst)
+			tail, found, err := t.slabFenceAppender.ReadUnsafeFenceAppendForKey(ptr, key, dst[oldLen:oldLen])
+			if err != nil {
+				return nil, false, err
+			}
+			if !found {
+				return nil, false, nil
+			}
+			if oldLen == 0 {
+				return tail, true, nil
+			}
+			if len(tail) == 0 {
+				return dst[:oldLen], true, nil
+			}
+			if cap(dst) > oldLen {
+				base := dst[:cap(dst):cap(dst)]
+				if &tail[0] == &base[oldLen] {
+					return dst[:oldLen+len(tail)], true, nil
+				}
+			}
+			return append(dst[:oldLen], tail...), true, nil
+		}
+		if t.slabFenceReader != nil {
+			val, found, err := t.slabFenceReader.ReadUnsafeFenceForKey(ptr, key)
+			if err != nil {
+				return nil, false, err
+			}
+			if !found {
+				return nil, false, nil
+			}
+			return append(dst, val...), true, nil
+		}
+		return nil, false, nil
+	}
 	for scan := idx; scan > 0; scan-- {
 		_, ptr, flags, err := n.GetLeafValueView(scan - 1)
 		if err != nil {
@@ -1097,6 +1293,83 @@ func (t *Tree) lookupFenceValueViewAppend(n *node.Node, idx uint16, key []byte, 
 
 func (t *Tree) lookupFenceHasKey(n *node.Node, idx uint16, key []byte) (found bool, ok bool, err error) {
 	if !t.fenceLookupMode || n == nil || idx == 0 {
+		return false, false, nil
+	}
+	if t.fenceLookupSingle {
+		scan := idx
+		_, ptr, flags, err := n.GetLeafValueView(scan - 1)
+		if err != nil {
+			return false, false, err
+		}
+		if flags&node.FlagTombstone != 0 || flags&node.FlagPointer == 0 {
+			return false, false, nil
+		}
+		if !t.fencePointerLikelyBlock(ptr) {
+			return false, false, nil
+		}
+		if t.slabFenceSeekL != nil {
+			pos, below, above, lease, ok, err := t.slabFenceSeekL.ReadUnsafeFenceBlockSeekLease(ptr, key)
+			if err != nil {
+				if lease != nil {
+					lease.Release()
+				}
+				return false, false, err
+			}
+			if !ok {
+				if lease != nil {
+					lease.Release()
+				}
+			} else {
+				if below || above || lease == nil {
+					if lease != nil {
+						lease.Release()
+					}
+					return false, true, nil
+				}
+				keys := lease.Keys()
+				found = fenceSeekContainsKey(keys, pos, key)
+				lease.Release()
+				if found {
+					return true, true, nil
+				}
+				return false, true, nil
+			}
+		}
+		if t.slabFenceSeek != nil {
+			pos, below, above, keys, ok, err := t.slabFenceSeek.ReadUnsafeFenceBlockSeek(ptr, key)
+			if err != nil {
+				return false, false, err
+			}
+			if ok {
+				if below || above {
+					return false, true, nil
+				}
+				if fenceSeekContainsKey(keys, pos, key) {
+					return true, true, nil
+				}
+				return false, true, nil
+			}
+		}
+		if t.slabFenceReader != nil {
+			_, found, err := t.slabFenceReader.ReadUnsafeFenceForKey(ptr, key)
+			if err != nil {
+				return false, false, err
+			}
+			if found {
+				return true, true, nil
+			}
+			return false, true, nil
+		}
+		if t.slabFenceAppender != nil {
+			_, found, err := t.slabFenceAppender.ReadUnsafeFenceAppendForKey(ptr, key, nil)
+			if err != nil {
+				return false, false, err
+			}
+			if found {
+				return true, true, nil
+			}
+			return false, true, nil
+		}
 		return false, false, nil
 	}
 	for scan := idx; scan > 0; scan-- {

--- a/TreeDB/tree/tree_test.go
+++ b/TreeDB/tree/tree_test.go
@@ -23,6 +23,8 @@ type fenceLookupReader struct {
 	blocks           map[page.ValuePtr]map[string][]byte
 	nextOffset       uint64
 	fileID           uint32
+	globalEnabled    bool
+	singleCandidate  bool
 	fenceCalls       int
 	fenceAppendCalls int
 	blockCalls       int
@@ -47,6 +49,20 @@ func fenceLookupMissingBlockErr(ptr page.ValuePtr) error {
 
 func (r *fenceLookupReader) FenceLookupEnabled() bool {
 	return true
+}
+
+func (r *fenceLookupReader) FenceLookupGlobalEnabled() bool {
+	if r == nil {
+		return true
+	}
+	return r.globalEnabled
+}
+
+func (r *fenceLookupReader) FenceLookupSingleCandidateEnabled() bool {
+	if r == nil {
+		return false
+	}
+	return r.singleCandidate
 }
 
 func (r *fenceLookupClassifierReader) FencePointerLikelyBlock(ptr page.ValuePtr) bool {
@@ -78,9 +94,15 @@ func (r *fenceLookupSeekClassifierReader) FencePointerLikelyBlock(ptr page.Value
 }
 
 func newFenceLookupReader() *fenceLookupReader {
+	return newFenceLookupReaderWithScope(true, false)
+}
+
+func newFenceLookupReaderWithScope(globalEnabled bool, singleCandidate bool) *fenceLookupReader {
 	return &fenceLookupReader{
-		blocks: make(map[page.ValuePtr]map[string][]byte),
-		fileID: page.ValueLogFileID(1),
+		blocks:          make(map[page.ValuePtr]map[string][]byte),
+		fileID:          page.ValueLogFileID(1),
+		globalEnabled:   globalEnabled,
+		singleCandidate: singleCandidate,
 	}
 }
 
@@ -2312,4 +2334,161 @@ func TestTreeGetEntry_FencePredecessorLookupGlobalRespectsScanLimit(t *testing.T
 	if reader.fenceCalls != fenceGlobalFallbackScanLimit {
 		t.Fatalf("fence calls = %d, want %d (scan limit)", reader.fenceCalls, fenceGlobalFallbackScanLimit)
 	}
+}
+
+func TestTreeGetEntry_FencePredecessorLookupGlobalDisabled(t *testing.T) {
+	dir := t.TempDir()
+	idxPath := filepath.Join(dir, "index.db")
+	p, err := pager.Open(idxPath, 65536)
+	if err != nil {
+		t.Fatalf("Pager open failed: %v", err)
+	}
+	defer p.Close()
+
+	if _, err := p.Alloc(3); err != nil {
+		t.Fatalf("Alloc pages: %v", err)
+	}
+
+	reader := newFenceLookupReaderWithScope(false, false)
+	ptr := reader.addBlock(map[string]string{
+		"k120": "v120",
+	})
+
+	leaf1Data, err := p.Get(1)
+	if err != nil {
+		t.Fatalf("Get leaf1 page: %v", err)
+	}
+	leaf1 := node.NewNode(leaf1Data)
+	leaf1.SetType(page.PageTypeLeaf)
+	leaf1.SetPageID(1)
+	if err := leaf1.AddLeafEntry([]byte("k000"), nil, node.FlagPointer, ptr); err != nil {
+		t.Fatalf("leaf1 AddLeafEntry(k000): %v", err)
+	}
+	leaf1.UpdateChecksum()
+
+	leaf2Data, err := p.Get(2)
+	if err != nil {
+		t.Fatalf("Get leaf2 page: %v", err)
+	}
+	leaf2 := node.NewNode(leaf2Data)
+	leaf2.SetType(page.PageTypeLeaf)
+	leaf2.SetPageID(2)
+	if err := leaf2.AddLeafEntry([]byte("k150"), []byte("v150"), node.FlagInline, page.ValuePtr{}); err != nil {
+		t.Fatalf("leaf2 AddLeafEntry(k150): %v", err)
+	}
+	leaf2.UpdateChecksum()
+
+	rootData, err := p.Get(0)
+	if err != nil {
+		t.Fatalf("Get root page: %v", err)
+	}
+	root := node.NewNode(rootData)
+	root.SetType(page.PageTypeInternal)
+	root.SetPageID(0)
+	if err := root.AddInternalChild([]byte("k000"), 1); err != nil {
+		t.Fatalf("root AddInternalChild(k000): %v", err)
+	}
+	if err := root.AddInternalChild([]byte("k100"), 2); err != nil {
+		t.Fatalf("root AddInternalChild(k100): %v", err)
+	}
+	root.UpdateChecksum()
+
+	tr := New(p, reader, 0)
+
+	if _, err := tr.GetEntry([]byte("k120")); err != ErrKeyNotFound {
+		t.Fatalf("GetEntry(k120): expected ErrKeyNotFound with global fallback disabled, got %v", err)
+	}
+	if _, err := tr.Get([]byte("k120")); err != ErrKeyNotFound {
+		t.Fatalf("Get(k120): expected ErrKeyNotFound with global fallback disabled, got %v", err)
+	}
+	if _, err := tr.GetAppend([]byte("k120"), nil); err != ErrKeyNotFound {
+		t.Fatalf("GetAppend(k120): expected ErrKeyNotFound with global fallback disabled, got %v", err)
+	}
+	if has, err := tr.Has([]byte("k120")); err != nil {
+		t.Fatalf("Has(k120): %v", err)
+	} else if has {
+		t.Fatalf("Has(k120) = true, want false with global fallback disabled")
+	}
+	if srcKey, ptr, ok, err := tr.LookupFencePointerOrigin([]byte("k120")); err != nil {
+		t.Fatalf("LookupFencePointerOrigin(k120): %v", err)
+	} else if ok {
+		t.Fatalf("LookupFencePointerOrigin(k120) returned key=%q ptr=%+v want no source", srcKey, ptr)
+	}
+	if ptr, ok, err := tr.LookupFencePointerSource([]byte("k120")); err != nil {
+		t.Fatalf("LookupFencePointerSource(k120): %v", err)
+	} else if ok {
+		t.Fatalf("LookupFencePointerSource(k120) returned ptr=%+v want no source", ptr)
+	}
+	if reader.fenceCalls != 0 {
+		t.Fatalf("fence calls = %d, want 0 with global fallback disabled", reader.fenceCalls)
+	}
+}
+
+func TestTreeGetEntry_FencePredecessorLookupSingleCandidateBounded(t *testing.T) {
+	build := func(t *testing.T, reader *fenceLookupReader) *Tree {
+		t.Helper()
+		dir := t.TempDir()
+		idxPath := filepath.Join(dir, "index.db")
+		p, err := pager.Open(idxPath, 65536)
+		if err != nil {
+			t.Fatalf("Pager open failed: %v", err)
+		}
+		t.Cleanup(func() { _ = p.Close() })
+
+		if _, err := p.Alloc(1); err != nil {
+			t.Fatalf("Alloc pages: %v", err)
+		}
+
+		ptrFar := reader.addBlock(map[string]string{
+			"k025": "v025",
+		})
+		ptrNear := reader.addBlock(map[string]string{
+			"k020": "v020",
+		})
+
+		leafData, err := p.Get(0)
+		if err != nil {
+			t.Fatalf("Get leaf page: %v", err)
+		}
+		leaf := node.NewNode(leafData)
+		leaf.SetType(page.PageTypeLeaf)
+		leaf.SetPageID(0)
+		if err := leaf.AddLeafEntry([]byte("k010"), nil, node.FlagPointer, ptrFar); err != nil {
+			t.Fatalf("AddLeafEntry(k010): %v", err)
+		}
+		if err := leaf.AddLeafEntry([]byte("k020"), nil, node.FlagPointer, ptrNear); err != nil {
+			t.Fatalf("AddLeafEntry(k020): %v", err)
+		}
+		if err := leaf.AddLeafEntry([]byte("k030"), []byte("v030"), node.FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry(k030): %v", err)
+		}
+		leaf.UpdateChecksum()
+		return New(p, reader, 0)
+	}
+
+	t.Run("single-candidate-miss", func(t *testing.T) {
+		reader := newFenceLookupReaderWithScope(false, true)
+		tr := build(t, reader)
+		if _, err := tr.GetEntry([]byte("k025")); err != ErrKeyNotFound {
+			t.Fatalf("GetEntry(k025): expected ErrKeyNotFound in single-candidate mode, got %v", err)
+		}
+		if reader.fenceCalls != 1 {
+			t.Fatalf("fence calls = %d, want 1 in single-candidate mode", reader.fenceCalls)
+		}
+	})
+
+	t.Run("unbounded-predecessor-hit", func(t *testing.T) {
+		reader := newFenceLookupReaderWithScope(false, false)
+		tr := build(t, reader)
+		entry, err := tr.GetEntry([]byte("k025"))
+		if err != nil {
+			t.Fatalf("GetEntry(k025): %v", err)
+		}
+		if string(entry.Value) != "v025" {
+			t.Fatalf("GetEntry(k025) value = %q, want %q", entry.Value, "v025")
+		}
+		if reader.fenceCalls != 2 {
+			t.Fatalf("fence calls = %d, want 2 with unbounded predecessor scan", reader.fenceCalls)
+		}
+	})
 }

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -271,8 +271,7 @@ func parseTreeDBOuterLeafMode(s string) (string, error) {
 	case "v1_leaflog":
 		return treedb.IndexOuterLeafModeV1LeafLog, nil
 	case "v1_leaflog_legacy":
-		// Compatibility alias for current v1_leaflog semantics.
-		return treedb.IndexOuterLeafModeV1LeafLog, nil
+		return treedb.IndexOuterLeafModeV1LeafLogLegacy, nil
 	case "v2_blockptr":
 		return treedb.IndexOuterLeafModeV2BlockPtr, nil
 	case "v2_fenceptr":

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -70,11 +70,11 @@ func TestBuildTreeDBOptions_V1LeafLogLegacyModeAccepted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildTreeDBOptions v1_leaflog_legacy: %v", err)
 	}
-	if got := opts.IndexOuterLeafMode; got != treedb.IndexOuterLeafModeV1LeafLog {
-		t.Fatalf("IndexOuterLeafMode=%q want %q", got, treedb.IndexOuterLeafModeV1LeafLog)
+	if got := opts.IndexOuterLeafMode; got != treedb.IndexOuterLeafModeV1LeafLogLegacy {
+		t.Fatalf("IndexOuterLeafMode=%q want %q", got, treedb.IndexOuterLeafModeV1LeafLogLegacy)
 	}
-	if got := rep.formatText(""); !strings.Contains(got, "index_outer_leaf_mode=v1_leaflog") {
-		t.Fatalf("resolved options missing normalized v1_leaflog outer-leaf mode: %q", got)
+	if got := rep.formatText(""); !strings.Contains(got, "index_outer_leaf_mode=v1_leaflog_legacy") {
+		t.Fatalf("resolved options missing v1_leaflog_legacy outer-leaf mode: %q", got)
 	}
 }
 
@@ -83,8 +83,8 @@ func TestParseTreeDBOuterLeafMode_V1LeafLogLegacyAccepted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseTreeDBOuterLeafMode: %v", err)
 	}
-	if got != treedb.IndexOuterLeafModeV1LeafLog {
-		t.Fatalf("parseTreeDBOuterLeafMode=%q want %q", got, treedb.IndexOuterLeafModeV1LeafLog)
+	if got != treedb.IndexOuterLeafModeV1LeafLogLegacy {
+		t.Fatalf("parseTreeDBOuterLeafMode=%q want %q", got, treedb.IndexOuterLeafModeV1LeafLogLegacy)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep `v1_leaflog_legacy` distinct end-to-end (no normalization to `v1_leaflog`)
- wire read-scope capability gates from value-reader into tree miss paths:
  - `v1_leaflog`: fence lookup enabled, single-candidate local probe, global reverse fallback disabled
  - `v1_leaflog_legacy`: key-aware reads enabled, fence lookup path disabled (legacy behavior)
  - `v2_fenceptr`: existing behavior preserved (global fallback enabled)
- retain hot-path tight loops for unbounded predecessor scans in non-single-candidate mode

## Correctness intent
- `v1_leaflog` miss path is now bounded and deterministic on one predecessor candidate in-leaf, with no global reverse fallback.
- legacy mode remains explicit and behaviorally separate for bisect/rollout.

## Tests run
- `GOWORK=off go test ./TreeDB/tree -run 'TestTreeGetEntry_FencePredecessorLookup(GlobalDisabled|SingleCandidateBounded|GlobalRespectsScanLimit)$'`
- `GOWORK=off go test ./TreeDB/db -run 'Test(Open_IndexOuterLeafMode_V1LeafLogLegacyPreserved|ValueReader_FenceLookupScopedForV1LeafLog|ValueReader_FenceLookupDisabledForV1LeafLogLegacy)$'`
- `GOWORK=off go test ./TreeDB -run 'Test(NormalizePublicOuterLeafMode_V1LeafLogLegacyPreserved|Open_V1LeafLogLegacy_StatsModePreserved)$'`
- `GOWORK=off go test ./TreeDB/caching -run 'TestCachingDB_Open_V1LeafLogLegacy_Preserved$'`
- `GOWORK=off go test ./cmd/unified_bench -run 'Test(BuildTreeDBOptions_V1LeafLogLegacyModeAccepted|ParseTreeDBOuterLeafMode_V1LeafLogLegacyAccepted)$'`
- `GOWORK=off go test ./TreeDB/... ./cmd/unified_bench/...`

## Reviewer loop
- independent reviewer pass: no unresolved high/medium findings
- follow-up low-risk adjustments applied before final pass (tight unbounded loops + broader gate coverage assertions)

Closes #619
