### PR TITLE
feat: harden r0 benchmark path labeling (Refs #768)

### DIFF
--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -186,7 +186,10 @@ func parseFlagsFrom(args []string) (config, error) {
 }
 
 func validateExecutionPath(path string) error {
-	if path == "" || path == "oracle" || path == "native-fastpath" {
+	if path == "" {
+		return fmt.Errorf("-execution-path is required; hidden or implied path labels are forbidden")
+	}
+	if path == "oracle" || path == "native-fastpath" {
 		return nil
 	}
 	return fmt.Errorf("-execution-path must be oracle or native-fastpath; mixed-path labels are forbidden (got %q)", path)

--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -1,0 +1,592 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"html/template"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/yuin/goldmark"
+)
+
+type config struct {
+	inputPath         string
+	outDir            string
+	branch            string
+	commit            string
+	worktree          string
+	executionPath     string
+	benchPattern      string
+	count             int
+	benchmarkEngine   string
+	unavailableReason string
+}
+
+type jsonEvent struct {
+	Action string `json:"Action"`
+	Output string `json:"Output"`
+}
+
+type benchmarkSpec struct {
+	Name        string
+	Section     string
+	Description string
+}
+
+type benchmarkSample struct {
+	Name        string  `json:"name"`
+	Iterations  int64   `json:"iterations"`
+	NsPerOp     float64 `json:"ns_per_op"`
+	BytesPerOp  float64 `json:"bytes_per_op"`
+	AllocsPerOp float64 `json:"allocs_per_op"`
+}
+
+type benchmarkAggregate struct {
+	Name            string            `json:"name"`
+	Section         string            `json:"section"`
+	Description     string            `json:"description"`
+	Samples         int               `json:"samples"`
+	MeanNsPerOp     float64           `json:"mean_ns_per_op"`
+	MinNsPerOp      float64           `json:"min_ns_per_op"`
+	MaxNsPerOp      float64           `json:"max_ns_per_op"`
+	MeanBytesPerOp  float64           `json:"mean_bytes_per_op"`
+	MeanAllocsPerOp float64           `json:"mean_allocs_per_op"`
+	OpsPerSec       float64           `json:"ops_per_sec"`
+	Runs            []benchmarkSample `json:"runs"`
+}
+
+type reportSection struct {
+	Title      string               `json:"title"`
+	Benchmarks []benchmarkAggregate `json:"benchmarks"`
+}
+
+type report struct {
+	GeneratedAt       string          `json:"generated_at"`
+	Status            string          `json:"status"`
+	UnavailableReason string          `json:"unavailable_reason,omitempty"`
+	ExecutionPath     string          `json:"execution_path,omitempty"`
+	BenchmarkEngine   string          `json:"benchmark_engine,omitempty"`
+	Worktree          string          `json:"worktree,omitempty"`
+	Branch            string          `json:"branch,omitempty"`
+	Commit            string          `json:"commit,omitempty"`
+	BenchPattern      string          `json:"bench_pattern,omitempty"`
+	Count             int             `json:"count,omitempty"`
+	RawJSONPath       string          `json:"raw_json_path,omitempty"`
+	Sections          []reportSection `json:"sections"`
+}
+
+var benchmarkSpecs = []benchmarkSpec{
+	{Name: "BenchmarkCollectionInsertProvidedID", Section: "Document Path", Description: "Insert documents with caller-provided IDs into the primary collection root."},
+	{Name: "BenchmarkCollectionGetByID", Section: "Document Path", Description: "Lookup documents by primary `_id` from the dedicated primary root."},
+	{Name: "BenchmarkCollectionDeleteByID", Section: "Document Path", Description: "Delete pre-existing documents from the primary root without secondary index maintenance."},
+	{Name: "BenchmarkCollectionInsertWithSecondaryIndexes", Section: "Document Path", Description: "Insert documents while maintaining both unique and non-unique secondary indexes."},
+	{Name: "BenchmarkCollectionDeleteWithSecondaryIndexes", Section: "Document Path", Description: "Delete documents while removing postings from unique and non-unique secondary indexes."},
+	{Name: "BenchmarkSecondaryLookupUnique", Section: "Secondary Index Path", Description: "Resolve a unique secondary index lookup to document IDs."},
+	{Name: "BenchmarkSecondaryLookupNonUnique", Section: "Secondary Index Path", Description: "Resolve a non-unique secondary index lookup that returns multiple document IDs."},
+	{Name: "BenchmarkSecondaryUpsertFieldChange", Section: "Secondary Index Path", Description: "Rewrite a document so an indexed field changes and postings move to the new value."},
+	{Name: "BenchmarkCollectionCreateIndexBackfillExistingDocs", Section: "Secondary Index Path", Description: "Build a new secondary index and backfill it from an existing primary collection root."},
+}
+
+var benchmarkNameRE = regexp.MustCompile(`^(Benchmark\S+)-(\d+)$`)
+
+func main() {
+	cfg := parseFlags()
+	rep, err := buildReport(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collection_bench_report: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.MkdirAll(cfg.outDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "collection_bench_report: create out dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	jsonPath := filepath.Join(cfg.outDir, "collections_report.json")
+	mdPath := filepath.Join(cfg.outDir, "collections_report.md")
+	htmlPath := filepath.Join(cfg.outDir, "collections_report.html")
+
+	payload, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collection_bench_report: marshal json: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(jsonPath, payload, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "collection_bench_report: write json: %v\n", err)
+		os.Exit(1)
+	}
+
+	md := renderMarkdown(rep)
+	if err := os.WriteFile(mdPath, []byte(md), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "collection_bench_report: write markdown: %v\n", err)
+		os.Exit(1)
+	}
+
+	htmlDoc, err := markdownToHTMLDoc(md)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collection_bench_report: render html: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(htmlPath, htmlDoc, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "collection_bench_report: write html: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("wrote report json: %s\n", jsonPath)
+	fmt.Printf("wrote report md:   %s\n", mdPath)
+	fmt.Printf("wrote report html: %s\n", htmlPath)
+}
+
+func parseFlags() config {
+	var cfg config
+	flag.StringVar(&cfg.inputPath, "in", "", "Path to go test -json benchmark output")
+	flag.StringVar(&cfg.outDir, "out-dir", "", "Output directory for report artifacts")
+	flag.StringVar(&cfg.branch, "branch", "", "Optional git branch name to include in report metadata")
+	flag.StringVar(&cfg.commit, "commit", "", "Optional git commit to include in report metadata")
+	flag.StringVar(&cfg.worktree, "worktree", "", "Optional worktree path to include in report metadata")
+	flag.StringVar(&cfg.executionPath, "execution-path", "", "Execution-path label (oracle|native-fastpath)")
+	flag.StringVar(&cfg.benchPattern, "bench-pattern", "", "Optional benchmark regex to include in report metadata")
+	flag.IntVar(&cfg.count, "count", 0, "Optional benchmark count to include in report metadata")
+	flag.StringVar(&cfg.benchmarkEngine, "benchmark-engine", "", "Optional benchmark engine label to include in report metadata")
+	flag.StringVar(&cfg.unavailableReason, "unavailable-reason", "", "Emit an explicit unavailable report instead of parsing benchmark input")
+	flag.Parse()
+	if cfg.outDir == "" {
+		fmt.Fprintln(os.Stderr, "collection_bench_report: -out-dir is required")
+		os.Exit(2)
+	}
+	if cfg.executionPath != "" && cfg.executionPath != "oracle" && cfg.executionPath != "native-fastpath" {
+		fmt.Fprintln(os.Stderr, "collection_bench_report: -execution-path must be oracle or native-fastpath")
+		os.Exit(2)
+	}
+	if cfg.unavailableReason == "" && cfg.inputPath == "" {
+		fmt.Fprintln(os.Stderr, "collection_bench_report: -in is required unless -unavailable-reason is set")
+		os.Exit(2)
+	}
+	return cfg
+}
+
+func buildReport(cfg config) (*report, error) {
+	if cfg.unavailableReason != "" {
+		return &report{
+			GeneratedAt:       time.Now().UTC().Format(time.RFC3339),
+			Status:            "unavailable",
+			UnavailableReason: cfg.unavailableReason,
+			ExecutionPath:     cfg.executionPath,
+			BenchmarkEngine:   cfg.benchmarkEngine,
+			Worktree:          cfg.worktree,
+			Branch:            cfg.branch,
+			Commit:            cfg.commit,
+			BenchPattern:      cfg.benchPattern,
+			Count:             cfg.count,
+			Sections:          nil,
+		}, nil
+	}
+
+	file, err := os.Open(cfg.inputPath)
+	if err != nil {
+		return nil, fmt.Errorf("open input: %w", err)
+	}
+	defer file.Close()
+
+	samples, err := parseBenchmarkSamples(file)
+	if err != nil {
+		return nil, err
+	}
+	if len(samples) == 0 {
+		return nil, fmt.Errorf("no benchmark samples found in %s", cfg.inputPath)
+	}
+
+	aggregates := aggregateSamples(samples)
+	sections := buildSections(aggregates)
+
+	return &report{
+		GeneratedAt:     time.Now().UTC().Format(time.RFC3339),
+		Status:          "ok",
+		ExecutionPath:   cfg.executionPath,
+		BenchmarkEngine: cfg.benchmarkEngine,
+		Worktree:        cfg.worktree,
+		Branch:          cfg.branch,
+		Commit:          cfg.commit,
+		BenchPattern:    cfg.benchPattern,
+		Count:           cfg.count,
+		RawJSONPath:     cfg.inputPath,
+		Sections:        sections,
+	}, nil
+}
+
+func parseBenchmarkSamples(r io.Reader) ([]benchmarkSample, error) {
+	scanner := bufio.NewScanner(r)
+	buf := make([]byte, 0, 1024*1024)
+	scanner.Buffer(buf, 8*1024*1024)
+
+	var samples []benchmarkSample
+	var pending strings.Builder
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var event jsonEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+		if event.Action != "output" {
+			continue
+		}
+		pending.WriteString(event.Output)
+		text := pending.String()
+		lines := strings.Split(text, "\n")
+		pending.Reset()
+		for idx, outputLine := range lines {
+			if idx == len(lines)-1 && !strings.HasSuffix(text, "\n") {
+				pending.WriteString(outputLine)
+				continue
+			}
+			sample, ok := parseBenchmarkLine(outputLine)
+			if ok {
+				samples = append(samples, sample)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan benchmark json: %w", err)
+	}
+	if pending.Len() > 0 {
+		if sample, ok := parseBenchmarkLine(pending.String()); ok {
+			samples = append(samples, sample)
+		}
+	}
+	return samples, nil
+}
+
+func parseBenchmarkLine(line string) (benchmarkSample, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 4 {
+		return benchmarkSample{}, false
+	}
+	match := benchmarkNameRE.FindStringSubmatch(fields[0])
+	if match == nil || fields[3] != "ns/op" {
+		return benchmarkSample{}, false
+	}
+
+	iterations, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return benchmarkSample{}, false
+	}
+	nsPerOp, err := strconv.ParseFloat(fields[2], 64)
+	if err != nil {
+		return benchmarkSample{}, false
+	}
+
+	sample := benchmarkSample{
+		Name:       match[1],
+		Iterations: iterations,
+		NsPerOp:    nsPerOp,
+	}
+	for i := 4; i+1 < len(fields); i += 2 {
+		value, err := strconv.ParseFloat(fields[i], 64)
+		if err != nil {
+			continue
+		}
+		switch fields[i+1] {
+		case "B/op":
+			sample.BytesPerOp = value
+		case "allocs/op":
+			sample.AllocsPerOp = value
+		}
+	}
+	return sample, true
+}
+
+func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
+	type running struct {
+		spec      benchmarkSpec
+		runs      []benchmarkSample
+		sumNs     float64
+		sumBytes  float64
+		sumAllocs float64
+		minNs     float64
+		maxNs     float64
+	}
+
+	specByName := make(map[string]benchmarkSpec, len(benchmarkSpecs))
+	for _, spec := range benchmarkSpecs {
+		specByName[spec.Name] = spec
+	}
+
+	runningByName := make(map[string]*running, len(samples))
+	for _, sample := range samples {
+		entry := runningByName[sample.Name]
+		if entry == nil {
+			spec := specByName[sample.Name]
+			if spec.Name == "" {
+				spec = benchmarkSpec{
+					Name:        sample.Name,
+					Section:     "Other",
+					Description: "Benchmark not yet categorized in the collections report catalog.",
+				}
+			}
+			entry = &running{
+				spec:  spec,
+				minNs: math.MaxFloat64,
+			}
+			runningByName[sample.Name] = entry
+		}
+		entry.runs = append(entry.runs, sample)
+		entry.sumNs += sample.NsPerOp
+		entry.sumBytes += sample.BytesPerOp
+		entry.sumAllocs += sample.AllocsPerOp
+		if sample.NsPerOp < entry.minNs {
+			entry.minNs = sample.NsPerOp
+		}
+		if sample.NsPerOp > entry.maxNs {
+			entry.maxNs = sample.NsPerOp
+		}
+	}
+
+	result := make(map[string]benchmarkAggregate, len(runningByName))
+	for name, entry := range runningByName {
+		sampleCount := float64(len(entry.runs))
+		meanNs := entry.sumNs / sampleCount
+		opsPerSec := 0.0
+		if meanNs > 0 {
+			opsPerSec = 1e9 / meanNs
+		}
+		result[name] = benchmarkAggregate{
+			Name:            name,
+			Section:         entry.spec.Section,
+			Description:     entry.spec.Description,
+			Samples:         len(entry.runs),
+			MeanNsPerOp:     meanNs,
+			MinNsPerOp:      entry.minNs,
+			MaxNsPerOp:      entry.maxNs,
+			MeanBytesPerOp:  entry.sumBytes / sampleCount,
+			MeanAllocsPerOp: entry.sumAllocs / sampleCount,
+			OpsPerSec:       opsPerSec,
+			Runs:            entry.runs,
+		}
+	}
+	return result
+}
+
+func buildSections(aggregates map[string]benchmarkAggregate) []reportSection {
+	sectionOrder := []string{"Document Path", "Secondary Index Path", "Maintenance", "Other"}
+	sections := make(map[string][]benchmarkAggregate, len(sectionOrder))
+	seen := make(map[string]struct{}, len(aggregates))
+
+	for _, spec := range benchmarkSpecs {
+		aggregate, ok := aggregates[spec.Name]
+		if !ok {
+			continue
+		}
+		sections[aggregate.Section] = append(sections[aggregate.Section], aggregate)
+		seen[aggregate.Name] = struct{}{}
+	}
+
+	var other []benchmarkAggregate
+	for name, aggregate := range aggregates {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		other = append(other, aggregate)
+	}
+	sort.Slice(other, func(i, j int) bool { return other[i].Name < other[j].Name })
+	if len(other) > 0 {
+		sections["Other"] = append(sections["Other"], other...)
+	}
+
+	var out []reportSection
+	for _, title := range sectionOrder {
+		benchmarks := sections[title]
+		if len(benchmarks) == 0 {
+			continue
+		}
+		out = append(out, reportSection{
+			Title:      title,
+			Benchmarks: benchmarks,
+		})
+	}
+	return out
+}
+
+func renderMarkdown(rep *report) string {
+	var sb strings.Builder
+	sb.WriteString("# Collections Benchmark Report\n\n")
+	sb.WriteString(fmt.Sprintf("- generated: `%s`\n", rep.GeneratedAt))
+	sb.WriteString(fmt.Sprintf("- status: `%s`\n", rep.Status))
+	if rep.UnavailableReason != "" {
+		sb.WriteString(fmt.Sprintf("- unavailable reason: `%s`\n", rep.UnavailableReason))
+	}
+	if rep.ExecutionPath != "" {
+		sb.WriteString(fmt.Sprintf("- execution path: `%s`\n", rep.ExecutionPath))
+	}
+	if rep.BenchmarkEngine != "" {
+		sb.WriteString(fmt.Sprintf("- benchmark engine: `%s`\n", rep.BenchmarkEngine))
+	}
+	if rep.Worktree != "" {
+		sb.WriteString(fmt.Sprintf("- worktree: `%s`\n", rep.Worktree))
+	}
+	if rep.Branch != "" {
+		sb.WriteString(fmt.Sprintf("- branch: `%s`\n", rep.Branch))
+	}
+	if rep.Commit != "" {
+		sb.WriteString(fmt.Sprintf("- commit: `%s`\n", rep.Commit))
+	}
+	if rep.BenchPattern != "" {
+		sb.WriteString(fmt.Sprintf("- benchmark regex: `%s`\n", rep.BenchPattern))
+	}
+	if rep.Count > 0 {
+		sb.WriteString(fmt.Sprintf("- benchmark count: `%d`\n", rep.Count))
+	}
+	if rep.RawJSONPath != "" {
+		sb.WriteString(fmt.Sprintf("- raw benchmark json: `%s`\n", rep.RawJSONPath))
+	}
+	sb.WriteString("- ops/sec is derived from the mean `ns/op` across captured benchmark runs\n\n")
+
+	if rep.Status == "unavailable" {
+		sb.WriteString("## Availability\n\n")
+		sb.WriteString("This branch does not currently contain a runnable collections benchmark harness.\n")
+		sb.WriteString("Treat this artifact as an explicit placeholder, not as a benchmark result.\n")
+		return sb.String()
+	}
+
+	for _, section := range rep.Sections {
+		sb.WriteString(fmt.Sprintf("## %s\n\n", section.Title))
+		sb.WriteString("| Benchmark | Description | Samples | Ops/sec | ns/op | B/op | allocs/op |\n")
+		sb.WriteString("| --- | --- | ---: | ---: | ---: | ---: | ---: |\n")
+		for _, benchmark := range section.Benchmarks {
+			sb.WriteString("| ")
+			sb.WriteString(fmt.Sprintf("`%s`", benchmark.Name))
+			sb.WriteString(" | ")
+			sb.WriteString(escapeTableCell(benchmark.Description))
+			sb.WriteString(" | ")
+			sb.WriteString(strconv.Itoa(benchmark.Samples))
+			sb.WriteString(" | ")
+			sb.WriteString(formatFloat(benchmark.OpsPerSec))
+			sb.WriteString(" | ")
+			sb.WriteString(formatFloat(benchmark.MeanNsPerOp))
+			sb.WriteString(" | ")
+			sb.WriteString(formatFloat(benchmark.MeanBytesPerOp))
+			sb.WriteString(" | ")
+			sb.WriteString(formatFloat(benchmark.MeanAllocsPerOp))
+			sb.WriteString(" |\n")
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func escapeTableCell(value string) string {
+	return strings.ReplaceAll(value, "|", "\\|")
+}
+
+func formatFloat(value float64) string {
+	return humanizeFloat(value)
+}
+
+func humanizeFloat(value float64) string {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return "-"
+	}
+	rounded := math.Round(value*100) / 100
+	if math.Abs(rounded-math.Round(rounded)) < 0.005 {
+		return formatIntWithCommas(int64(math.Round(rounded)))
+	}
+	return trimTrailingZeros(formatWithCommas(rounded))
+}
+
+func formatWithCommas(value float64) string {
+	negative := value < 0
+	if negative {
+		value = -value
+	}
+	whole := int64(value)
+	fraction := value - float64(whole)
+	base := formatIntWithCommas(whole)
+	if fraction == 0 {
+		if negative {
+			return "-" + base
+		}
+		return base
+	}
+	text := fmt.Sprintf("%s%.2f", "", fraction)
+	text = strings.TrimPrefix(text, "0")
+	if negative {
+		return "-" + base + text
+	}
+	return base + text
+}
+
+func trimTrailingZeros(value string) string {
+	value = strings.TrimRight(value, "0")
+	value = strings.TrimRight(value, ".")
+	return value
+}
+
+func formatIntWithCommas(value int64) string {
+	negative := value < 0
+	if negative {
+		value = -value
+	}
+	raw := strconv.FormatInt(value, 10)
+	if len(raw) <= 3 {
+		if negative {
+			return "-" + raw
+		}
+		return raw
+	}
+	var parts []string
+	for len(raw) > 3 {
+		parts = append(parts, raw[len(raw)-3:])
+		raw = raw[:len(raw)-3]
+	}
+	parts = append(parts, raw)
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+	result := strings.Join(parts, ",")
+	if negative {
+		return "-" + result
+	}
+	return result
+}
+
+func markdownToHTMLDoc(markdown string) ([]byte, error) {
+	var body bytes.Buffer
+	md := goldmark.New()
+	if err := md.Convert([]byte(markdown), &body); err != nil {
+		return nil, err
+	}
+	const pageTmpl = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Collections Benchmark Report</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem auto; max-width: 1100px; padding: 0 1rem; line-height: 1.5; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #d0d7de; padding: 0.45rem 0.65rem; vertical-align: top; }
+    th { background: #f6f8fa; text-align: left; }
+    code { background: #f6f8fa; padding: 0.1rem 0.25rem; border-radius: 4px; }
+  </style>
+</head>
+<body>{{.Body}}</body>
+</html>`
+	tmpl, err := template.New("page").Parse(pageTmpl)
+	if err != nil {
+		return nil, err
+	}
+	var doc bytes.Buffer
+	if err := tmpl.Execute(&doc, struct{ Body template.HTML }{Body: template.HTML(body.String())}); err != nil {
+		return nil, err
+	}
+	return doc.Bytes(), nil
+}

--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -148,31 +148,48 @@ func main() {
 }
 
 func parseFlags() config {
-	var cfg config
-	flag.StringVar(&cfg.inputPath, "in", "", "Path to go test -json benchmark output")
-	flag.StringVar(&cfg.outDir, "out-dir", "", "Output directory for report artifacts")
-	flag.StringVar(&cfg.branch, "branch", "", "Optional git branch name to include in report metadata")
-	flag.StringVar(&cfg.commit, "commit", "", "Optional git commit to include in report metadata")
-	flag.StringVar(&cfg.worktree, "worktree", "", "Optional worktree path to include in report metadata")
-	flag.StringVar(&cfg.executionPath, "execution-path", "", "Execution-path label (oracle|native-fastpath)")
-	flag.StringVar(&cfg.benchPattern, "bench-pattern", "", "Optional benchmark regex to include in report metadata")
-	flag.IntVar(&cfg.count, "count", 0, "Optional benchmark count to include in report metadata")
-	flag.StringVar(&cfg.benchmarkEngine, "benchmark-engine", "", "Optional benchmark engine label to include in report metadata")
-	flag.StringVar(&cfg.unavailableReason, "unavailable-reason", "", "Emit an explicit unavailable report instead of parsing benchmark input")
-	flag.Parse()
-	if cfg.outDir == "" {
-		fmt.Fprintln(os.Stderr, "collection_bench_report: -out-dir is required")
-		os.Exit(2)
-	}
-	if cfg.executionPath != "" && cfg.executionPath != "oracle" && cfg.executionPath != "native-fastpath" {
-		fmt.Fprintln(os.Stderr, "collection_bench_report: -execution-path must be oracle or native-fastpath")
-		os.Exit(2)
-	}
-	if cfg.unavailableReason == "" && cfg.inputPath == "" {
-		fmt.Fprintln(os.Stderr, "collection_bench_report: -in is required unless -unavailable-reason is set")
+	cfg, err := parseFlagsFrom(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collection_bench_report: %v\n", err)
 		os.Exit(2)
 	}
 	return cfg
+}
+
+func parseFlagsFrom(args []string) (config, error) {
+	var cfg config
+	fs := flag.NewFlagSet("collection_bench_report", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&cfg.inputPath, "in", "", "Path to go test -json benchmark output")
+	fs.StringVar(&cfg.outDir, "out-dir", "", "Output directory for report artifacts")
+	fs.StringVar(&cfg.branch, "branch", "", "Optional git branch name to include in report metadata")
+	fs.StringVar(&cfg.commit, "commit", "", "Optional git commit to include in report metadata")
+	fs.StringVar(&cfg.worktree, "worktree", "", "Optional worktree path to include in report metadata")
+	fs.StringVar(&cfg.executionPath, "execution-path", "", "Execution-path label (oracle|native-fastpath)")
+	fs.StringVar(&cfg.benchPattern, "bench-pattern", "", "Optional benchmark regex to include in report metadata")
+	fs.IntVar(&cfg.count, "count", 0, "Optional benchmark count to include in report metadata")
+	fs.StringVar(&cfg.benchmarkEngine, "benchmark-engine", "", "Optional benchmark engine label to include in report metadata")
+	fs.StringVar(&cfg.unavailableReason, "unavailable-reason", "", "Emit an explicit unavailable report instead of parsing benchmark input")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	if cfg.outDir == "" {
+		return config{}, fmt.Errorf("-out-dir is required")
+	}
+	if err := validateExecutionPath(cfg.executionPath); err != nil {
+		return config{}, err
+	}
+	if cfg.unavailableReason == "" && cfg.inputPath == "" {
+		return config{}, fmt.Errorf("-in is required unless -unavailable-reason is set")
+	}
+	return cfg, nil
+}
+
+func validateExecutionPath(path string) error {
+	if path == "" || path == "oracle" || path == "native-fastpath" {
+		return nil
+	}
+	return fmt.Errorf("-execution-path must be oracle or native-fastpath; mixed-path labels are forbidden (got %q)", path)
 }
 
 func buildReport(cfg config) (*report, error) {

--- a/cmd/collection_bench_report/main_test.go
+++ b/cmd/collection_bench_report/main_test.go
@@ -36,6 +36,21 @@ func TestParseFlagsRejectsMixedExecutionPathLabels(t *testing.T) {
 	}
 }
 
+func TestParseFlagsRequiresExecutionPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseFlagsFrom([]string{
+		"-out-dir", t.TempDir(),
+		"-unavailable-reason", "N/A before R0 harness bring-up",
+	})
+	if err == nil {
+		t.Fatal("expected missing execution path to fail")
+	}
+	if !strings.Contains(err.Error(), "-execution-path is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	input := strings.NewReader(strings.Join([]string{
 		`{"Action":"output","Output":"BenchmarkCollectionInsertProvidedID-12\t1000\t2000 ns/op\t128 B/op\t4 allocs/op\n"}`,

--- a/cmd/collection_bench_report/main_test.go
+++ b/cmd/collection_bench_report/main_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildReportAndRenderMarkdown(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		`{"Action":"output","Output":"BenchmarkCollectionInsertProvidedID-12\t1000\t2000 ns/op\t128 B/op\t4 allocs/op\n"}`,
+		`{"Action":"output","Output":"BenchmarkCollectionInsertProvidedID-12\t900\t2200 ns/op\t136 B/op\t5 allocs/op\n"}`,
+		`{"Action":"output","Output":"BenchmarkSecondaryLookupNonUnique-12\t5000\t450 ns/op\t96 B/op\t2 allocs/op\n"}`,
+		`{"Action":"output","Output":"BenchmarkCollectionDeleteWithSecondaryIndexes-12\t"}`,
+		`{"Action":"output","Output":"123\t9000 ns/op\t512 B/op\t8 allocs/op\n"}`,
+		`{"Action":"output","Output":"PASS\n"}`,
+	}, "\n"))
+
+	samples, err := parseBenchmarkSamples(input)
+	if err != nil {
+		t.Fatalf("parseBenchmarkSamples: %v", err)
+	}
+	if got, want := len(samples), 4; got != want {
+		t.Fatalf("len(samples)=%d want %d", got, want)
+	}
+
+	aggregates := aggregateSamples(samples)
+	insert := aggregates["BenchmarkCollectionInsertProvidedID"]
+	if got, want := insert.Samples, 2; got != want {
+		t.Fatalf("insert samples=%d want %d", got, want)
+	}
+	if got, want := insert.MeanNsPerOp, 2100.0; got != want {
+		t.Fatalf("insert mean ns/op=%v want %v", got, want)
+	}
+
+	rep := &report{
+		GeneratedAt:     "2026-03-05T00:00:00Z",
+		Status:          "ok",
+		ExecutionPath:   "oracle",
+		BenchmarkEngine: "cached",
+		Worktree:        "/tmp/oracle",
+		Branch:          "pr/oracle",
+		Commit:          "deadbeef",
+		RawJSONPath:     "/tmp/collections_bench.json",
+		Sections:        buildSections(aggregates),
+	}
+	md := renderMarkdown(rep)
+	if !strings.Contains(md, "- execution path: `oracle`") {
+		t.Fatalf("markdown missing execution path:\n%s", md)
+	}
+	if !strings.Contains(md, "- worktree: `/tmp/oracle`") {
+		t.Fatalf("markdown missing worktree:\n%s", md)
+	}
+	if !strings.Contains(md, "## Document Path") {
+		t.Fatalf("markdown missing document section:\n%s", md)
+	}
+	if !strings.Contains(md, "`BenchmarkSecondaryLookupNonUnique`") {
+		t.Fatalf("markdown missing secondary benchmark row:\n%s", md)
+	}
+}
+
+func TestBuildReportUnavailable(t *testing.T) {
+	rep, err := buildReport(config{
+		outDir:            t.TempDir(),
+		branch:            "pr/native-fastpath-r0-oracle-baseline",
+		commit:            "abc1234",
+		worktree:          "/tmp/native",
+		executionPath:     "native-fastpath",
+		benchmarkEngine:   "cached",
+		unavailableReason: "N/A before R0 harness bring-up",
+	})
+	if err != nil {
+		t.Fatalf("buildReport: %v", err)
+	}
+	if got, want := rep.Status, "unavailable"; got != want {
+		t.Fatalf("status=%q want %q", got, want)
+	}
+	if got, want := rep.UnavailableReason, "N/A before R0 harness bring-up"; got != want {
+		t.Fatalf("unavailableReason=%q want %q", got, want)
+	}
+	md := renderMarkdown(rep)
+	if !strings.Contains(md, "This branch does not currently contain a runnable collections benchmark harness.") {
+		t.Fatalf("markdown missing unavailable explanation:\n%s", md)
+	}
+}

--- a/cmd/collection_bench_report/main_test.go
+++ b/cmd/collection_bench_report/main_test.go
@@ -5,6 +5,37 @@ import (
 	"testing"
 )
 
+func TestParseFlagsRejectsMixedExecutionPathLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "comma separated", path: "oracle,native-fastpath"},
+		{name: "plus separated", path: "native-fastpath+legacy"},
+		{name: "mixed literal", path: "mixed"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseFlagsFrom([]string{
+				"-out-dir", t.TempDir(),
+				"-execution-path", tc.path,
+				"-unavailable-reason", "N/A before R0 harness bring-up",
+			})
+			if err == nil {
+				t.Fatalf("expected execution path %q to fail", tc.path)
+			}
+			if !strings.Contains(err.Error(), "mixed-path labels are forbidden") {
+				t.Fatalf("unexpected error for %q: %v", tc.path, err)
+			}
+		})
+	}
+}
+
 func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	input := strings.NewReader(strings.Join([]string{
 		`{"Action":"output","Output":"BenchmarkCollectionInsertProvidedID-12\t1000\t2000 ns/op\t128 B/op\t4 allocs/op\n"}`,

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -970,7 +970,7 @@ func writeBenchprofArtifacts(dir, executionPath string, runs []BenchRun) error {
 		return fmt.Errorf("mkdir %q: %w", dir, err)
 	}
 	if executionPath != "" && executionPath != "oracle" && executionPath != "native-fastpath" {
-		return fmt.Errorf("invalid execution path %q", executionPath)
+		return fmt.Errorf("invalid execution path %q: mixed-path labels are forbidden", executionPath)
 	}
 
 	out := benchprofExport{

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -66,6 +66,7 @@ var (
 	cpuProfile         = flag.String("cpuprofile", "", "write cpu profile to file")
 	cpuProfileTestsArg = flag.String("cpuprofile-tests", "", "Comma-separated list of tests to profile when -cpuprofile is set (default: all selected tests)")
 	profileDir         = flag.String("profile-dir", "", "Write profiling artifacts to this directory (enables defaults for -cpuprofile, -allocsprofile, -checkpoint-cpuprofile, -blockprofile, -mutexprofile, -trace unless explicitly set)")
+	pathLabel          = flag.String("path-label", "", "Optional benchmark execution-path label for profile-dir artifacts (oracle|native-fastpath)")
 	allocsProfile      = flag.String("allocsprofile", "", "write per-test allocation delta profile prefix to file")
 	allocsProfileTests = flag.String("allocsprofile-tests", "", "Comma-separated list of tests to profile when -allocsprofile is set (default: all selected tests)")
 	allocsProfileRate  = flag.Int("allocsprofilerate", 512*1024, "runtime.MemProfileRate sampling rate in bytes for -allocsprofile")
@@ -207,9 +208,10 @@ type benchprofExport struct {
 }
 
 type benchprofExportRun struct {
-	Keys    int                           `json:"keys"`
-	Profile string                        `json:"profile,omitempty"`
-	Results map[string]map[string]float64 `json:"results,omitempty"`
+	Keys          int                           `json:"keys"`
+	Profile       string                        `json:"profile,omitempty"`
+	ExecutionPath string                        `json:"execution_path,omitempty"`
+	Results       map[string]map[string]float64 `json:"results,omitempty"`
 }
 
 type scanDiag struct {
@@ -950,7 +952,7 @@ func maybeWriteBenchprofArtifacts(dir string, runs []BenchRun) bool {
 	if dir == "" || len(runs) == 0 {
 		return false
 	}
-	if err := writeBenchprofArtifacts(dir, runs); err != nil {
+	if err := writeBenchprofArtifacts(dir, strings.TrimSpace(*pathLabel), runs); err != nil {
 		log.Printf("benchprof artifacts: %v", err)
 		return false
 	}
@@ -963,9 +965,12 @@ func runBenchprof(dir string) {
 	}
 }
 
-func writeBenchprofArtifacts(dir string, runs []BenchRun) error {
+func writeBenchprofArtifacts(dir, executionPath string, runs []BenchRun) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %q: %w", dir, err)
+	}
+	if executionPath != "" && executionPath != "oracle" && executionPath != "native-fastpath" {
+		return fmt.Errorf("invalid execution path %q", executionPath)
 	}
 
 	out := benchprofExport{
@@ -974,9 +979,10 @@ func writeBenchprofArtifacts(dir string, runs []BenchRun) error {
 	}
 	for _, run := range runs {
 		out.Runs = append(out.Runs, benchprofExportRun{
-			Keys:    run.Config.Keys,
-			Profile: strings.TrimSpace(run.Config.Profile),
-			Results: run.Results,
+			Keys:          run.Config.Keys,
+			Profile:       strings.TrimSpace(run.Config.Profile),
+			ExecutionPath: executionPath,
+			Results:       run.Results,
 		})
 	}
 
@@ -993,6 +999,9 @@ func writeBenchprofArtifacts(dir string, runs []BenchRun) error {
 		md = renderMarkdownSingle(runs[0])
 	} else {
 		md = renderMarkdownSweep(runs)
+	}
+	if executionPath != "" {
+		md = fmt.Sprintf("- execution path: `%s`\n\n%s", executionPath, md)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "benchprof_results.md"), []byte(md), 0o644); err != nil {
 		return fmt.Errorf("write benchprof_results.md: %w", err)

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -969,7 +969,10 @@ func writeBenchprofArtifacts(dir, executionPath string, runs []BenchRun) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %q: %w", dir, err)
 	}
-	if executionPath != "" && executionPath != "oracle" && executionPath != "native-fastpath" {
+	if executionPath == "" {
+		return fmt.Errorf("execution path is required for profile-dir artifacts; hidden or implied path labels are forbidden")
+	}
+	if executionPath != "oracle" && executionPath != "native-fastpath" {
 		return fmt.Errorf("invalid execution path %q: mixed-path labels are forbidden", executionPath)
 	}
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1127,6 +1127,22 @@ func TestWriteBenchprofArtifacts_InvalidExecutionPath(t *testing.T) {
 	}
 }
 
+func TestWriteBenchprofArtifacts_RequiresExecutionPath(t *testing.T) {
+	dir := t.TempDir()
+	runs := []BenchRun{{
+		Config: BenchConfig{Keys: 1, Profile: "fast"},
+		Results: map[string]map[string]float64{
+			"full_scan": {"TreeDB": 1},
+		},
+	}}
+
+	if err := writeBenchprofArtifacts(dir, "", runs); err == nil {
+		t.Fatal("expected missing execution path to fail")
+	} else if !strings.Contains(err.Error(), "execution path is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestWriteRuntimeProfileDeltaProfile_EmptyOutputSkipsFile(t *testing.T) {
 	origRunPprofDeltaCommandFn := runPprofDeltaCommandFn
 	runPprofDeltaCommandFn = func(basePath, afterPath string) ([]byte, string, error) {

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1070,7 +1070,7 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 		},
 	}
 
-	if err := writeBenchprofArtifacts(dir, runs); err != nil {
+	if err := writeBenchprofArtifacts(dir, "native-fastpath", runs); err != nil {
 		t.Fatalf("writeBenchprofArtifacts: %v", err)
 	}
 
@@ -1081,6 +1081,13 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 	}
 	if _, err := os.Stat(mdPath); err != nil {
 		t.Fatalf("expected markdown output: %v", err)
+	}
+	mdData, err := os.ReadFile(mdPath)
+	if err != nil {
+		t.Fatalf("read markdown: %v", err)
+	}
+	if !strings.Contains(string(mdData), "- execution path: `native-fastpath`") {
+		t.Fatalf("markdown missing execution path label:\n%s", string(mdData))
 	}
 
 	var parsed benchprofExport
@@ -1094,8 +1101,25 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 	if len(parsed.Runs) != 1 {
 		t.Fatalf("expected 1 run in json, got %d", len(parsed.Runs))
 	}
+	if got, want := parsed.Runs[0].ExecutionPath, "native-fastpath"; got != want {
+		t.Fatalf("unexpected execution path: got %q want %q", got, want)
+	}
 	if got := parsed.Runs[0].Results["full_scan"]["TreeDB"]; got != 1000 {
 		t.Fatalf("unexpected full_scan value: %v", got)
+	}
+}
+
+func TestWriteBenchprofArtifacts_InvalidExecutionPath(t *testing.T) {
+	dir := t.TempDir()
+	runs := []BenchRun{{
+		Config: BenchConfig{Keys: 1, Profile: "fast"},
+		Results: map[string]map[string]float64{
+			"full_scan": {"TreeDB": 1},
+		},
+	}}
+
+	if err := writeBenchprofArtifacts(dir, "mixed", runs); err == nil {
+		t.Fatal("expected invalid execution path to fail")
 	}
 }
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1118,8 +1118,12 @@ func TestWriteBenchprofArtifacts_InvalidExecutionPath(t *testing.T) {
 		},
 	}}
 
-	if err := writeBenchprofArtifacts(dir, "mixed", runs); err == nil {
-		t.Fatal("expected invalid execution path to fail")
+	for _, path := range []string{"mixed", "oracle,native-fastpath", "native-fastpath+legacy"} {
+		if err := writeBenchprofArtifacts(dir, path, runs); err == nil {
+			t.Fatalf("expected invalid execution path %q to fail", path)
+		} else if !strings.Contains(err.Error(), "mixed-path labels are forbidden") {
+			t.Fatalf("unexpected error for %q: %v", path, err)
+		}
 	}
 }
 

--- a/scripts/bench_collections_report.sh
+++ b/scripts/bench_collections_report.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+OUT_DIR="${OUT_DIR:-$(mktemp -d /tmp/gomap_collections_report_XXXXXX)}"
+BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertProvidedID|CollectionGetByID|CollectionDeleteByID|CollectionInsertWithSecondaryIndexes|CollectionDeleteWithSecondaryIndexes|SecondaryLookupUnique|SecondaryLookupNonUnique|SecondaryUpsertFieldChange|CollectionCreateIndexBackfillExistingDocs)}"
+COUNT="${COUNT:-3}"
+BENCHTIME="${BENCHTIME:-}"
+BENCH_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-cached}"
+PATH_LABEL="${TREEDB_COLLECTION_PATH_LABEL:-native-fastpath}"
+
+RAW_JSON="$OUT_DIR/collections_bench.json"
+CPU_PROFILE="$OUT_DIR/collections_cpu.pprof"
+MEM_PROFILE="$OUT_DIR/collections_mem.pprof"
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+COMMIT="$(git rev-parse --short HEAD)"
+WORKTREE="$ROOT"
+
+mkdir -p "$OUT_DIR"
+
+cmd=(
+  go test ./TreeDB/collections
+  -run '^$'
+  -bench "$BENCH_REGEX"
+  -benchmem
+  -count "$COUNT"
+  -json
+  -cpuprofile "$CPU_PROFILE"
+  -memprofile "$MEM_PROFILE"
+)
+
+if [[ -n "$BENCHTIME" ]]; then
+  cmd+=(-benchtime "$BENCHTIME")
+fi
+
+echo "running focused collections benchmarks into: $OUT_DIR"
+echo "benchmark engine: $BENCH_ENGINE"
+echo "execution path: $PATH_LABEL"
+
+if [[ ! -d "$ROOT/TreeDB/collections" ]]; then
+  GOWORK=off go run ./cmd/collection_bench_report \
+    -out-dir "$OUT_DIR" \
+    -branch "$BRANCH" \
+    -commit "$COMMIT" \
+    -worktree "$WORKTREE" \
+    -execution-path "$PATH_LABEL" \
+    -benchmark-engine "$BENCH_ENGINE" \
+    -bench-pattern "$BENCH_REGEX" \
+    -count "$COUNT" \
+    -unavailable-reason "N/A before R0 harness bring-up"
+else
+  TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" GOWORK=off "${cmd[@]}" | tee "$RAW_JSON"
+
+  GOWORK=off go run ./cmd/collection_bench_report \
+    -in "$RAW_JSON" \
+    -out-dir "$OUT_DIR" \
+    -branch "$BRANCH" \
+    -commit "$COMMIT" \
+    -worktree "$WORKTREE" \
+    -execution-path "$PATH_LABEL" \
+    -benchmark-engine "$BENCH_ENGINE" \
+    -bench-pattern "$BENCH_REGEX" \
+    -count "$COUNT"
+fi
+
+cat >"$OUT_DIR/README.md" <<EOF
+# Focused Collections Benchmark Bundle
+
+- output directory: \`$OUT_DIR\`
+- worktree: \`$WORKTREE\`
+- branch: \`$BRANCH\`
+- commit: \`$COMMIT\`
+- execution path: \`$PATH_LABEL\`
+- benchmark engine: \`$BENCH_ENGINE\`
+- benchmark regex: \`$BENCH_REGEX\`
+- benchmark count: \`$COUNT\`
+- raw benchmark json: \`$RAW_JSON\`
+- cpu profile: \`$CPU_PROFILE\`
+- memory profile: \`$MEM_PROFILE\`
+- markdown report: \`$OUT_DIR/collections_report.md\`
+- html report: \`$OUT_DIR/collections_report.html\`
+- json report: \`$OUT_DIR/collections_report.json\`
+- backend-direct override: \`TREEDB_COLLECTION_BENCH_ENGINE=backend_direct scripts/bench_collections_report.sh\`
+- oracle-path override: \`TREEDB_COLLECTION_PATH_LABEL=oracle scripts/bench_collections_report.sh\`
+EOF
+
+echo "markdown report: $OUT_DIR/collections_report.md"
+echo "html report:     $OUT_DIR/collections_report.html"
+echo "bundle index:    $OUT_DIR/README.md"

--- a/scripts/bench_collections_report.sh
+++ b/scripts/bench_collections_report.sh
@@ -9,7 +9,7 @@ BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertProvidedID|CollectionGetBy
 COUNT="${COUNT:-3}"
 BENCHTIME="${BENCHTIME:-}"
 BENCH_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-cached}"
-PATH_LABEL="${TREEDB_COLLECTION_PATH_LABEL:-native-fastpath}"
+PATH_LABEL="${TREEDB_COLLECTION_PATH_LABEL:-}"
 
 RAW_JSON="$OUT_DIR/collections_bench.json"
 CPU_PROFILE="$OUT_DIR/collections_cpu.pprof"
@@ -38,6 +38,11 @@ fi
 echo "running focused collections benchmarks into: $OUT_DIR"
 echo "benchmark engine: $BENCH_ENGINE"
 echo "execution path: $PATH_LABEL"
+
+if [[ -z "$PATH_LABEL" ]]; then
+  echo "TREEDB_COLLECTION_PATH_LABEL is required (oracle|native-fastpath)" >&2
+  exit 2
+fi
 
 if [[ ! -d "$ROOT/TreeDB/collections" ]]; then
   GOWORK=off go run ./cmd/collection_bench_report \


### PR DESCRIPTION
## Summary
- add tests and validators forbidding mixed execution-path labels in benchmark artifacts
- require explicit execution-path metadata for unified-bench profile-dir exports and collection benchmark reports
- remove the silent `native-fastpath` default from the collection harness script

## Validation
- `GOWORK=off go test ./cmd/collection_bench_report -count=1`
- `GOWORK=off go test ./cmd/unified_bench -run 'TestWriteBenchprofArtifacts|TestWriteBenchprofArtifacts_InvalidExecutionPath|TestWriteBenchprofArtifacts_RequiresExecutionPath' -count=1`
- `bash -n scripts/bench_collections_report.sh`
- `TREEDB_COLLECTION_PATH_LABEL=native-fastpath ./scripts/bench_collections_report.sh`

Refs #768
