### PR TITLE
TreeDB/cache: add bounded WAL-on steady rewrite resume

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -6424,13 +6424,17 @@ type DB struct {
 	vlogGenerationCheckpointKickGCRuns                           atomic.Uint64
 	vlogGenerationCheckpointKickSkippedHotNoDebt                 atomic.Uint64
 	vlogGenerationCheckpointKickHotNoDebtWakeRuns                atomic.Uint64
+	vlogGenerationWALOnSteadyResumeAttempts                      atomic.Uint64
+	vlogGenerationWALOnSteadyResumeRewriteRuns                   atomic.Uint64
 	vlogGenerationCheckpointKickPending                          atomic.Bool
 	vlogGenerationCheckpointKickHotNoDebtWakeRunning             atomic.Bool
+	vlogGenerationWALOnSteadyResumeActive                        atomic.Bool
 	vlogGenerationDeferredMaintenancePending                     atomic.Bool
 	vlogGenerationDeferredMaintenanceRunning                     atomic.Bool
 	vlogGenerationRewriteQueuePending                            atomic.Bool
 	vlogGenerationRewriteQueueRunning                            atomic.Bool
 	vlogGenerationRewriteStageWakeObservedNS                     atomic.Int64
+	vlogGenerationWALOnSteadyResumeRemainingAttempts             atomic.Uint32
 	vlogGenerationRewriteQueueMu                                 sync.Mutex
 	vlogGenerationCheckpointKickActive                           atomic.Bool
 	vlogGenerationRewriteQueue                                   []uint32
@@ -6664,6 +6668,7 @@ const (
 	// Coordinate index vacuum with major rewrite windows; do not run on every GC.
 	vlogGenerationVacuumTriggerRewriteBytes = int64(64 << 20)
 	vlogGenerationVacuumMinInterval         = 5 * time.Minute
+	vlogGenerationWALOnSteadyResumeAttempts = uint32(2)
 )
 
 const (
@@ -9397,6 +9402,7 @@ const (
 	vlogGenerationMaintenanceSourcePeriodic = iota
 	vlogGenerationMaintenanceSourceBypass
 	vlogGenerationMaintenanceSourceCheckpointPending
+	vlogGenerationMaintenanceSourceWALOnSteadyResume
 	vlogGenerationMaintenanceSourceRewriteQueuePending
 	vlogGenerationMaintenanceSourceRewriteAgeBlocked
 	vlogGenerationMaintenanceSourceRewriteStageConfirm
@@ -9413,6 +9419,8 @@ func vlogGenerationMaintenanceSourceIndex(source string) int {
 		return vlogGenerationMaintenanceSourceBypass
 	case "checkpoint_pending":
 		return vlogGenerationMaintenanceSourceCheckpointPending
+	case "wal_on_steady_resume":
+		return vlogGenerationMaintenanceSourceWALOnSteadyResume
 	case "rewrite_queue_pending":
 		return vlogGenerationMaintenanceSourceRewriteQueuePending
 	case "rewrite_age_blocked", "rewrite_age_blocked_exit":
@@ -9432,6 +9440,8 @@ func vlogGenerationMaintenanceSourceLabel(idx int) string {
 		return "bypass"
 	case vlogGenerationMaintenanceSourceCheckpointPending:
 		return "checkpoint_pending"
+	case vlogGenerationMaintenanceSourceWALOnSteadyResume:
+		return "wal_on_steady_resume"
 	case vlogGenerationMaintenanceSourceRewriteQueuePending:
 		return "rewrite_queue_pending"
 	case vlogGenerationMaintenanceSourceRewriteAgeBlocked:
@@ -13916,6 +13926,23 @@ func (db *DB) vlogGenerationRewriteSegmentCapForFreshPlanWithHint(queueLen int, 
 		return decision
 	}
 	decision = db.vlogGenerationRewriteSegmentCapForRunWithHint(queueLen, budgetTokens, queueLiveBytes, queueLiveKnown, opts)
+	if opts.bypassQuiet && !opts.skipCheckpoint && decision.maxSegments < freshPlanMax {
+		lifted := queueLen
+		if decision.byBudgetSegments > 0 && decision.byBudgetSegments < lifted {
+			lifted = decision.byBudgetSegments
+		}
+		if freshPlanMax < lifted {
+			lifted = freshPlanMax
+		}
+		if lifted > decision.maxSegments {
+			decision.maxSegments = lifted
+			if decision.byBudgetSegments > 0 && decision.byBudgetSegments < freshPlanMax {
+				decision.limiter = vlogGenerationRewriteSegmentCapLimiterBudgetTokens
+			} else {
+				decision.limiter = vlogGenerationRewriteSegmentCapLimiterFreshPlanCap
+			}
+		}
+	}
 	if decision.maxSegments > freshPlanMax {
 		decision.maxSegments = freshPlanMax
 		decision.limiter = vlogGenerationRewriteSegmentCapLimiterFreshPlanCap
@@ -17403,6 +17430,11 @@ func (db *DB) SetMaintenancePhase(phase MaintenancePhase) {
 		return
 	}
 	db.debugVlogMaintf("maintenance_phase_change from=%s to=%s", maintenancePhaseString(uint32(prev)), maintenancePhaseString(uint32(phase)))
+	if phase != MaintenancePhaseSteady {
+		db.clearVlogGenerationWALOnSteadyResume()
+		return
+	}
+	db.armVlogGenerationWALOnSteadyResume(prev)
 	if phase == MaintenancePhaseSteady {
 		db.scheduleDueVlogGenerationDeferredMaintenance()
 		db.schedulePendingVlogGenerationCheckpointKick()
@@ -17416,6 +17448,71 @@ func (db *DB) suppressBackgroundVlogGenerationForMaintenancePhase() bool {
 	default:
 		return false
 	}
+}
+
+func (db *DB) clearVlogGenerationWALOnSteadyResume() {
+	if db == nil {
+		return
+	}
+	db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Store(0)
+}
+
+func (db *DB) armVlogGenerationWALOnSteadyResume(prev MaintenancePhase) {
+	if db == nil || db.disableJournal || db.closing.Load() {
+		return
+	}
+	if db.valueLogGenerationPolicy != uint8(backenddb.ValueLogGenerationHotWarmCold) {
+		return
+	}
+	if prev != MaintenancePhaseRestore && prev != MaintenancePhaseCatchUp {
+		return
+	}
+	db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Store(vlogGenerationWALOnSteadyResumeAttempts)
+}
+
+func (db *DB) scheduleVlogGenerationWALOnSteadyResume() bool {
+	if db == nil || db.disableJournal || db.closing.Load() {
+		return false
+	}
+	if db.MaintenancePhase() != MaintenancePhaseSteady {
+		return false
+	}
+	if !db.vlogGenerationWALOnSteadyResumeActive.CompareAndSwap(false, true) {
+		return false
+	}
+	remaining := db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Load()
+	if remaining == 0 {
+		db.vlogGenerationWALOnSteadyResumeActive.Store(false)
+		return false
+	}
+	db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Store(remaining - 1)
+	db.vlogGenerationWALOnSteadyResumeAttempts.Add(1)
+	db.wg.Add(1)
+	go func() {
+		defer db.wg.Done()
+		defer db.vlogGenerationWALOnSteadyResumeActive.Store(false)
+		if db.closing.Load() {
+			return
+		}
+		planRunsBefore := db.vlogGenerationRewritePlanRuns.Load()
+		rewriteRunsBefore := db.vlogGenerationRewriteRuns.Load()
+		db.runVlogGenerationCheckpointKickRetries(vlogGenerationMaintenanceOptions{
+			bypassQuiet:           true,
+			skipRetainedPruneWait: true,
+			skipCheckpoint:        false,
+			rewriteDebtDrain:      true,
+			debugSource:           "wal_on_steady_resume",
+		})
+		if db.vlogGenerationRewriteRuns.Load() > rewriteRunsBefore {
+			db.vlogGenerationWALOnSteadyResumeRewriteRuns.Add(1)
+			db.clearVlogGenerationWALOnSteadyResume()
+			return
+		}
+		if db.vlogGenerationRewritePlanRuns.Load() > planRunsBefore {
+			db.clearVlogGenerationWALOnSteadyResume()
+		}
+	}()
+	return true
 }
 
 func (db *DB) maybeKickVlogGenerationMaintenanceAfterCheckpoint() {
@@ -17442,6 +17539,13 @@ func (db *DB) maybeKickVlogGenerationMaintenanceAfterCheckpoint() {
 		return
 	}
 	if !db.disableJournal {
+		if db.scheduleVlogGenerationWALOnSteadyResume() {
+			db.debugVlogMaintf(
+				"checkpoint_kick_wal_on_steady_resume remaining_attempts=%d",
+				db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Load(),
+			)
+			return
+		}
 		// In WAL-on profiles, checkpoint-kick maintenance races with restore/catch-up
 		// work and has produced real post-snapshot state divergence. Keep WAL-on
 		// generation maintenance off the checkpoint-triggered fast path.
@@ -23303,6 +23407,10 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_generation.checkpoint_kick.skipped_hot_no_debt"] = fmt.Sprintf("%d", db.vlogGenerationCheckpointKickSkippedHotNoDebt.Load())
 	stats["treedb.cache.vlog_generation.checkpoint_kick.hot_no_debt_wake.running"] = fmt.Sprintf("%t", db.vlogGenerationCheckpointKickHotNoDebtWakeRunning.Load())
 	stats["treedb.cache.vlog_generation.checkpoint_kick.hot_no_debt_wake.runs"] = fmt.Sprintf("%d", db.vlogGenerationCheckpointKickHotNoDebtWakeRuns.Load())
+	stats["treedb.cache.vlog_generation.wal_on_steady_resume.active"] = fmt.Sprintf("%t", db.vlogGenerationWALOnSteadyResumeActive.Load())
+	stats["treedb.cache.vlog_generation.wal_on_steady_resume.remaining_attempts"] = fmt.Sprintf("%d", db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Load())
+	stats["treedb.cache.vlog_generation.wal_on_steady_resume.attempts"] = fmt.Sprintf("%d", db.vlogGenerationWALOnSteadyResumeAttempts.Load())
+	stats["treedb.cache.vlog_generation.wal_on_steady_resume.rewrite_runs"] = fmt.Sprintf("%d", db.vlogGenerationWALOnSteadyResumeRewriteRuns.Load())
 	stats["treedb.cache.vlog_generation.maintenance.attempts"] = fmt.Sprintf("%d", db.vlogGenerationMaintenanceAttempts.Load())
 	stats["treedb.cache.vlog_generation.maintenance.acquired"] = fmt.Sprintf("%d", db.vlogGenerationMaintenanceAcquired.Load())
 	stats["treedb.cache.vlog_generation.maintenance.collisions"] = fmt.Sprintf("%d", db.vlogGenerationMaintenanceCollisions.Load())

--- a/TreeDB/caching/vlog_generation_checkpoint_kick_walon_test.go
+++ b/TreeDB/caching/vlog_generation_checkpoint_kick_walon_test.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"testing"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
@@ -36,5 +37,224 @@ func TestVlogGenerationCheckpointKick_SkipsWhenWALOn(t *testing.T) {
 	}
 	if db.vlogGenerationCheckpointKickPending.Load() {
 		t.Fatal("checkpoint kick unexpectedly pending")
+	}
+}
+
+func TestVlogGenerationCheckpointKick_WALOnSteadyResumeRunsBoundedMaintenance(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+	t.Setenv(envDisableVlogGenerationCheckpointKick, "0")
+
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB: backend,
+		planResponse: backenddb.ValueLogRewritePlan{
+			SourceFileIDs: []uint32{11},
+			SelectedSegments: []backenddb.ValueLogRewritePlanSegment{
+				{FileID: 11, BytesTotal: 64, BytesLive: 32, BytesStale: 32, StaleRatio: 0.5},
+			},
+			SegmentsSelected:   1,
+			SelectedBytesTotal: 64,
+			SelectedBytesLive:  32,
+			SelectedBytesStale: 32,
+		},
+		rewriteResponse: backenddb.ValueLogRewriteStats{BytesBefore: 64, BytesAfter: 32, RecordsCopied: 1},
+	}
+
+	db, err := Open(dir, recorder, Options{
+		AllowUnsafe:                      true,
+		DisableWAL:                       false,
+		JournalLanes:                     1,
+		ValueLogGenerationPolicy:         uint8(backenddb.ValueLogGenerationHotWarmCold),
+		ValueLogRewriteTriggerTotalBytes: 1,
+		ValueLogRewriteBudgetBytesPerSec: 1024,
+		ForceValueLogPointers:            true,
+	})
+	if err != nil {
+		t.Fatalf("open cache: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	skipRetainedPrune(db)
+
+	value := make([]byte, 2048)
+	b := db.NewBatch()
+	if err := b.Set([]byte("k"), value); err != nil {
+		_ = b.Close()
+		t.Fatalf("set: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		t.Fatalf("write: %v", err)
+	}
+	_ = b.Close()
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	db.testSkipVlogCheckpointKick = false
+	db.vlogGenerationRewriteBudgetTokensBytes.Store(1024)
+	db.vlogGenerationRewriteBudgetLastUnixNano.Store(time.Now().Add(-time.Second).UnixNano())
+	forceVlogMaintenanceIdle(db)
+
+	db.SetMaintenancePhase(MaintenancePhaseRestore)
+	db.SetMaintenancePhase(MaintenancePhaseSteady)
+	if got := db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Load(); got != vlogGenerationWALOnSteadyResumeAttempts {
+		t.Fatalf("steady resume remaining=%d want %d", got, vlogGenerationWALOnSteadyResumeAttempts)
+	}
+
+	db.maybeKickVlogGenerationMaintenanceAfterCheckpoint()
+
+	deadline := time.Now().Add(2 * schedulerTestWait(t))
+	for {
+		if _, calls := recorder.recordedRewrite(); calls >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			_, rewriteCalls := recorder.recordedRewrite()
+			t.Fatalf("rewrite calls=%d want >=1", rewriteCalls)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got := db.vlogGenerationCheckpointKickRuns.Load(); got != 0 {
+		t.Fatalf("checkpoint kick runs=%d want 0 for wal_on steady resume path", got)
+	}
+	if got := db.vlogGenerationWALOnSteadyResumeAttempts.Load(); got != 1 {
+		t.Fatalf("steady resume attempts=%d want 1", got)
+	}
+	if got := db.vlogGenerationWALOnSteadyResumeRewriteRuns.Load(); got != 1 {
+		t.Fatalf("steady resume rewrite runs=%d want 1", got)
+	}
+	if got := db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Load(); got != 0 {
+		t.Fatalf("steady resume remaining=%d want 0 after rewrite", got)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.cache.vlog_generation.maintenance.acquired.source.wal_on_steady_resume"]; got != "1" {
+		t.Fatalf("maintenance acquired source wal_on_steady_resume=%q want 1", got)
+	}
+	if got := stats["treedb.cache.vlog_generation.maintenance.passes.with_rewrite.source.wal_on_steady_resume"]; got != "1" {
+		t.Fatalf("maintenance rewrite passes source wal_on_steady_resume=%q want 1", got)
+	}
+	if got := stats["treedb.cache.vlog_generation.wal_on_steady_resume.attempts"]; got != "1" {
+		t.Fatalf("steady resume stats attempts=%q want 1", got)
+	}
+	if got := stats["treedb.cache.vlog_generation.wal_on_steady_resume.rewrite_runs"]; got != "1" {
+		t.Fatalf("steady resume stats rewrite runs=%q want 1", got)
+	}
+}
+
+func TestVlogGenerationCheckpointKick_WALOnSteadyResumeIsBounded(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+	t.Setenv(envDisableVlogGenerationCheckpointKick, "0")
+
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB:           backend,
+		planResponse: backenddb.ValueLogRewritePlan{},
+	}
+
+	db, err := Open(dir, recorder, Options{
+		AllowUnsafe:                      true,
+		DisableWAL:                       false,
+		JournalLanes:                     1,
+		ValueLogGenerationPolicy:         uint8(backenddb.ValueLogGenerationHotWarmCold),
+		ValueLogRewriteTriggerTotalBytes: 1,
+		ValueLogRewriteBudgetBytesPerSec: 1024,
+		ForceValueLogPointers:            true,
+	})
+	if err != nil {
+		t.Fatalf("open cache: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	skipRetainedPrune(db)
+
+	value := make([]byte, 2048)
+	b := db.NewBatch()
+	if err := b.Set([]byte("k"), value); err != nil {
+		_ = b.Close()
+		t.Fatalf("set: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		t.Fatalf("write: %v", err)
+	}
+	_ = b.Close()
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	db.testSkipVlogCheckpointKick = false
+	db.vlogGenerationRewriteBudgetTokensBytes.Store(0)
+	db.vlogGenerationRewriteBudgetLastUnixNano.Store(0)
+	forceVlogMaintenanceIdle(db)
+
+	db.SetMaintenancePhase(MaintenancePhaseCatchUp)
+	db.SetMaintenancePhase(MaintenancePhaseSteady)
+
+	db.maybeKickVlogGenerationMaintenanceAfterCheckpoint()
+	deadline := time.Now().Add(2 * schedulerTestWait(t))
+	for {
+		if got := db.vlogGenerationWALOnSteadyResumeAttempts.Load(); got >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("steady resume attempt 1 did not run")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, calls := recorder.recordedPlan(); calls != 0 {
+		t.Fatalf("plan calls=%d want 0 on budget-seeding attempt", calls)
+	}
+	if got := db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Load(); got != 1 {
+		t.Fatalf("steady resume remaining=%d want 1 after budget-seeding attempt", got)
+	}
+	deadline = time.Now().Add(2 * schedulerTestWait(t))
+	for db.vlogGenerationWALOnSteadyResumeActive.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("steady resume attempt 1 did not finish")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	db.vlogGenerationRewriteBudgetTokensBytes.Store(1024)
+	db.vlogGenerationRewriteBudgetLastUnixNano.Store(time.Now().Add(-time.Second).UnixNano())
+	db.maybeKickVlogGenerationMaintenanceAfterCheckpoint()
+	deadline = time.Now().Add(2 * schedulerTestWait(t))
+	for {
+		if got := db.vlogGenerationWALOnSteadyResumeAttempts.Load(); got >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("steady resume attempt 2 did not run")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	db.maybeKickVlogGenerationMaintenanceAfterCheckpoint()
+	time.Sleep(50 * time.Millisecond)
+
+	if got := db.vlogGenerationWALOnSteadyResumeAttempts.Load(); got != uint64(vlogGenerationWALOnSteadyResumeAttempts) {
+		t.Fatalf("steady resume attempts=%d want %d", got, vlogGenerationWALOnSteadyResumeAttempts)
+	}
+	if got := db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Load(); got != 0 {
+		t.Fatalf("steady resume remaining=%d want 0 after bounded attempts", got)
+	}
+	if _, calls := recorder.recordedRewrite(); calls != 0 {
+		t.Fatalf("rewrite calls=%d want 0 for empty-plan bounded test", calls)
+	}
+	stats := db.Stats()
+	if got := stats["treedb.cache.vlog_generation.maintenance.acquired.source.wal_on_steady_resume"]; got != "2" {
+		t.Fatalf("maintenance acquired source wal_on_steady_resume=%q want 2", got)
+	}
+	if got := stats["treedb.cache.vlog_generation.rewrite.plan_empty"]; got != "1" {
+		t.Fatalf("rewrite plan empty=%q want 1 after second attempt", got)
 	}
 }

--- a/TreeDB/caching/vlog_generation_checkpoint_kick_walon_test.go
+++ b/TreeDB/caching/vlog_generation_checkpoint_kick_walon_test.go
@@ -74,6 +74,7 @@ func TestVlogGenerationCheckpointKick_WALOnSteadyResumeRunsBoundedMaintenance(t 
 		ForceValueLogPointers:            true,
 	})
 	if err != nil {
+		_ = backend.Close()
 		t.Fatalf("open cache: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
@@ -171,6 +172,7 @@ func TestVlogGenerationCheckpointKick_WALOnSteadyResumeIsBounded(t *testing.T) {
 		ForceValueLogPointers:            true,
 	})
 	if err != nil {
+		_ = backend.Close()
 		t.Fatalf("open cache: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
@@ -256,5 +258,96 @@ func TestVlogGenerationCheckpointKick_WALOnSteadyResumeIsBounded(t *testing.T) {
 	}
 	if got := stats["treedb.cache.vlog_generation.rewrite.plan_empty"]; got != "1" {
 		t.Fatalf("rewrite plan empty=%q want 1 after second attempt", got)
+	}
+}
+
+func TestVlogGenerationCheckpointKick_WALOnSteadyResumeExhaustedStillReachesStageConfirm(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+	t.Setenv(envDisableVlogGenerationCheckpointKick, "0")
+
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB: backend,
+		planResponse: backenddb.ValueLogRewritePlan{
+			SourceFileIDs: []uint32{11},
+			SelectedSegments: []backenddb.ValueLogRewritePlanSegment{
+				{FileID: 11, BytesTotal: 64, BytesLive: 32, BytesStale: 32, StaleRatio: 0.5},
+			},
+			SegmentsSelected:   1,
+			SelectedBytesTotal: 64,
+			SelectedBytesLive:  32,
+			SelectedBytesStale: 32,
+		},
+		rewriteResponse: backenddb.ValueLogRewriteStats{BytesBefore: 64, BytesAfter: 32, RecordsCopied: 1},
+	}
+
+	db, err := Open(dir, recorder, Options{
+		AllowUnsafe:                      true,
+		DisableWAL:                       false,
+		JournalLanes:                     1,
+		ValueLogGenerationPolicy:         uint8(backenddb.ValueLogGenerationHotWarmCold),
+		ValueLogRewriteTriggerTotalBytes: 1,
+		ValueLogRewriteBudgetBytesPerSec: 1024,
+		ForceValueLogPointers:            true,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("open cache: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	skipRetainedPrune(db)
+
+	value := make([]byte, 2048)
+	b := db.NewBatch()
+	if err := b.Set([]byte("k"), value); err != nil {
+		_ = b.Close()
+		t.Fatalf("set: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		t.Fatalf("write: %v", err)
+	}
+	_ = b.Close()
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	db.testSkipVlogCheckpointKick = false
+	db.vlogGenerationRewriteBudgetTokensBytes.Store(1024)
+	db.vlogGenerationRewriteBudgetLastUnixNano.Store(time.Now().Add(-time.Second).UnixNano())
+	forceVlogMaintenanceIdle(db)
+
+	db.SetMaintenancePhase(MaintenancePhaseSteady)
+	db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Store(0)
+	observedAt := time.Now().Add(-2 * vlogGenerationRewriteStageConfirmDelay).UnixNano()
+	if err := db.setVlogGenerationRewriteLedgerWithStage([]backenddb.ValueLogRewritePlanSegment{{
+		FileID:     11,
+		BytesTotal: 64,
+		BytesLive:  32,
+		BytesStale: 32,
+		StaleRatio: 0.5,
+	}}, true, observedAt); err != nil {
+		t.Fatalf("stage rewrite ledger: %v", err)
+	}
+	db.scheduleDueVlogGenerationDeferredMaintenance()
+
+	deadline := time.Now().Add(2 * schedulerTestWait(t))
+	for {
+		if _, calls := recorder.recordedRewrite(); calls >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("stage-confirm rewrite did not run after steady-resume window was exhausted")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.cache.vlog_generation.maintenance.acquired.source.rewrite_stage_confirm"]; got == "0" {
+		t.Fatalf("maintenance acquired source rewrite_stage_confirm=%q want >0", got)
 	}
 }

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1189,6 +1189,30 @@ func TestVlogGenerationRewriteSegmentCapForFreshPlan_UsesQueueLiveHint(t *testin
 	}
 }
 
+func TestVlogGenerationRewriteSegmentCapForFreshPlan_CheckpointKickUsesFreshPlanCap(t *testing.T) {
+	db := &DB{
+		valueLogRewriteBudgetBytes:   1 << 20,
+		valueLogGenerationWarmTarget: 64,
+	}
+	decision := db.vlogGenerationRewriteSegmentCapForFreshPlanWithHint(
+		vlogGenerationRewriteFreshPlanDebtDrainMinSegments+5,
+		1<<20,
+		256,
+		true,
+		vlogGenerationMaintenanceOptions{
+			rewriteDebtDrain: true,
+			bypassQuiet:      true,
+			skipCheckpoint:   false,
+		},
+	)
+	if decision.maxSegments != vlogGenerationRewriteFreshPlanDebtDrainMaxSegments {
+		t.Fatalf("fresh-plan checkpoint kick maxSegments=%d want=%d", decision.maxSegments, vlogGenerationRewriteFreshPlanDebtDrainMaxSegments)
+	}
+	if decision.limiter != vlogGenerationRewriteSegmentCapLimiterFreshPlanCap {
+		t.Fatalf("fresh-plan checkpoint kick limiter=%s want=fresh_plan_cap", vlogGenerationRewriteSegmentCapLimiterString(decision.limiter))
+	}
+}
+
 func TestVlogGenerationObserveRewriteSegmentCapDecision(t *testing.T) {
 	db := &DB{}
 	runDecision := vlogGenerationRewriteSegmentCapDecision{limiter: vlogGenerationRewriteSegmentCapLimiterBudgetTokens}


### PR DESCRIPTION
## Summary
- Add bounded WAL-on steady-state resume so replay does not leave restore/catchup rewrite work completely idle once the DB transitions to steady mode.
- Keep the follow-up bounded and checkpoint-kick compatible rather than reopening an unbounded periodic loop.
- Add focused scheduler tests around WAL-on steady resume and exhausted-window stage-confirm behavior.

## Replay Delta vs #944
This PR improves engagement and queue-drain shape, but it does not move storage yet.

`WALOn`:
- `maint_attempts/op`: `0 -> 2` delta `+2`
- `rewrite_plan_runs/op`: `0 -> 1` delta `+1`
- `rewrite_runs/op`: `0 -> 1` delta `+1`
- `rewrite_queue_len/op`: `0 -> 4` delta `+4`
- `retained_B/op`: `137,466,963 -> 137,466,963` delta `0` (`0.0%`)
- `wal_B/op`: `137,466,963 -> 137,886,606` delta `+419,643` (`+0.3%`)

`WALOff`:
- `rewrite_queue_len/op`: `6 -> 4` delta `-2` (`-33.3%`)
- `retained_B/op`: `137,356,947 -> 137,356,947` delta `0` (`0.0%`)
- `wal_B/op`: `137,599,652 -> 137,822,062` delta `+222,410` (`+0.2%`)

Absolute replay metrics on this branch:
- `WALOn`: `retained_B/op = 137,466,963`, `wal_B/op = 137,886,606`, `home_B/op = 147,972,400`, `maint_attempts/op = 2`, `rewrite_runs/op = 1`, `rewrite_queue_len/op = 4`
- `WALOff`: `retained_B/op = 137,356,947`, `wal_B/op = 137,822,062`, `home_B/op = 147,907,770`, `maint_attempts/op = 2`, `rewrite_runs/op = 1`, `rewrite_queue_len/op = 4`

## Validation
- `GOWORK=off go test ./TreeDB/caching -run 'TestVlogGenerationCheckpointKick_(SkipsWhenWALOn|WALOnSteadyResumeRunsBoundedMaintenance|WALOnSteadyResumeIsBounded|WALOnSteadyResumeExhaustedStillReachesStageConfirm)$' -count=1`
- `GOWORK=off go test ./TreeDB -run '^$' -bench '^BenchmarkRestoreLikeTraceReplay$' -benchtime=1x -count=1`
