### PR TITLE
TreeDB/cache: unblock observed-source retained prune convergence

### DIFF
--- a/TreeDB/bench_trace_restore_like_test.go
+++ b/TreeDB/bench_trace_restore_like_test.go
@@ -48,6 +48,10 @@ type restoreLikeTraceReplayMetrics struct {
 	queuedDebtExecRuns          int64
 	queuedDebtReclaimedBytes    int64
 	rewriteQueueLen             int64
+	retainedPruneRuns           int64
+	retainedPruneRemovedBytes   int64
+	retainedPruneObservedBytes  int64
+	observedGCDeletedBytes      int64
 	retainedBytes               int64
 	indexBytes                  int64
 	walBytes                    int64
@@ -122,6 +126,10 @@ func BenchmarkRestoreLikeTraceReplay(b *testing.B) {
 			b.ReportMetric(float64(totals.queuedDebtExecRuns)/n, "queued_exec_runs/op")
 			b.ReportMetric(float64(totals.queuedDebtReclaimedBytes)/n, "queued_reclaimed_B/op")
 			b.ReportMetric(float64(totals.rewriteQueueLen)/n, "rewrite_queue_len/op")
+			b.ReportMetric(float64(totals.retainedPruneRuns)/n, "retained_prune_runs/op")
+			b.ReportMetric(float64(totals.retainedPruneRemovedBytes)/n, "retained_prune_removed_B/op")
+			b.ReportMetric(float64(totals.retainedPruneObservedBytes)/n, "retained_prune_observed_removed_B/op")
+			b.ReportMetric(float64(totals.observedGCDeletedBytes)/n, "observed_gc_deleted_B/op")
 			b.ReportMetric(float64(totals.retainedBytes)/n, "retained_B/op")
 			b.ReportMetric(float64(totals.indexBytes)/n, "index_B/op")
 			b.ReportMetric(float64(totals.walBytes)/n, "wal_B/op")
@@ -143,6 +151,10 @@ func (m *restoreLikeTraceReplayMetrics) add(other restoreLikeTraceReplayMetrics)
 	m.queuedDebtExecRuns += other.queuedDebtExecRuns
 	m.queuedDebtReclaimedBytes += other.queuedDebtReclaimedBytes
 	m.rewriteQueueLen += other.rewriteQueueLen
+	m.retainedPruneRuns += other.retainedPruneRuns
+	m.retainedPruneRemovedBytes += other.retainedPruneRemovedBytes
+	m.retainedPruneObservedBytes += other.retainedPruneObservedBytes
+	m.observedGCDeletedBytes += other.observedGCDeletedBytes
 	m.retainedBytes += other.retainedBytes
 	m.indexBytes += other.indexBytes
 	m.walBytes += other.walBytes
@@ -336,7 +348,7 @@ func waitForRestoreLikeMaintenance(db *DB, timeout time.Duration) time.Duration 
 	var stableSince time.Time
 	last := restoreLikeMaintenanceState{}
 	for time.Now().Before(deadline) {
-		cur := restoreLikeMaintenanceStateFromStats(db.Stats())
+		cur := restoreLikeMaintenanceStateFromDB(db)
 		if cur != last {
 			last = cur
 			stableSince = time.Time{}
@@ -355,17 +367,23 @@ func waitForRestoreLikeMaintenance(db *DB, timeout time.Duration) time.Duration 
 }
 
 type restoreLikeMaintenanceState struct {
-	schedulerState        string
-	checkpointKickActive  bool
-	checkpointKickPending bool
-	rewriteQueuePending   bool
-	rewriteQueueRunning   bool
-	maintenanceAttempts   int64
-	rewriteRuns           int64
+	schedulerState             string
+	checkpointKickActive       bool
+	checkpointKickPending      bool
+	rewriteQueuePending        bool
+	rewriteQueueRunning        bool
+	retainedPruneActive        bool
+	retainedPruneForcePending  bool
+	retainedPruneObservedQueue bool
+	maintenanceAttempts        int64
+	rewriteRuns                int64
 }
 
 func (s restoreLikeMaintenanceState) activeOrPending() bool {
 	if s.checkpointKickActive || s.checkpointKickPending || s.rewriteQueuePending || s.rewriteQueueRunning {
+		return true
+	}
+	if s.retainedPruneActive || s.retainedPruneForcePending || s.retainedPruneObservedQueue {
 		return true
 	}
 	switch s.schedulerState {
@@ -376,35 +394,43 @@ func (s restoreLikeMaintenanceState) activeOrPending() bool {
 	}
 }
 
-func restoreLikeMaintenanceStateFromStats(stats map[string]string) restoreLikeMaintenanceState {
+func restoreLikeMaintenanceStateFromDB(db *DB) restoreLikeMaintenanceState {
+	stats := db.Stats()
 	return restoreLikeMaintenanceState{
-		schedulerState:        stats["treedb.cache.vlog_generation.scheduler_state"],
-		checkpointKickActive:  parseBoolStat(stats, "treedb.cache.vlog_generation.checkpoint_kick.active"),
-		checkpointKickPending: parseBoolStat(stats, "treedb.cache.vlog_generation.checkpoint_kick.pending"),
-		rewriteQueuePending:   parseBoolStat(stats, "treedb.cache.vlog_generation.rewrite.queue.pending"),
-		rewriteQueueRunning:   parseBoolStat(stats, "treedb.cache.vlog_generation.rewrite.queue.running"),
-		maintenanceAttempts:   parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
-		rewriteRuns:           parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
+		schedulerState:             stats["treedb.cache.vlog_generation.scheduler_state"],
+		checkpointKickActive:       parseBoolStat(stats, "treedb.cache.vlog_generation.checkpoint_kick.active"),
+		checkpointKickPending:      parseBoolStat(stats, "treedb.cache.vlog_generation.checkpoint_kick.pending"),
+		rewriteQueuePending:        parseBoolStat(stats, "treedb.cache.vlog_generation.rewrite.queue.pending"),
+		rewriteQueueRunning:        parseBoolStat(stats, "treedb.cache.vlog_generation.rewrite.queue.running"),
+		retainedPruneActive:        parseBoolStat(stats, "treedb.cache.vlog_retained_prune.active"),
+		retainedPruneForcePending:  parseBoolStat(stats, "treedb.cache.vlog_retained_prune.force_pending"),
+		retainedPruneObservedQueue: parseBoolStat(stats, "treedb.cache.vlog_retained_prune.observed_source.pending"),
+		maintenanceAttempts:        parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
+		rewriteRuns:                parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
 	}
 }
 
 func collectRestoreLikeTraceReplayMetrics(stats map[string]string, dir string) restoreLikeTraceReplayMetrics {
 	return restoreLikeTraceReplayMetrics{
-		maintenanceAttempts:      parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
-		maintenanceWithRewrite:   parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.passes.with_rewrite"),
-		checkpointKickRuns:       parseInt64Stat(stats, "treedb.cache.vlog_generation.checkpoint_kick.runs"),
-		rewritePlanRuns:          parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_runs"),
-		rewritePlanEmpty:         parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_empty"),
-		rewritePlanSelected:      parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_selected"),
-		rewriteRuns:              parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
-		rewriteReclaimedBytes:    parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.reclaimed_bytes"),
-		queuedDebtExecRuns:       parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.runs"),
-		queuedDebtReclaimedBytes: parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.reclaimed_bytes"),
-		rewriteQueueLen:          parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queue_len"),
-		retainedBytes:            parseInt64Stat(stats, "treedb.cache.vlog_retained_bytes_estimate"),
-		indexBytes:               fileSizeBytes(filepath.Join(dir, "maindb", "index.db")),
-		walBytes:                 dirSizeBytes(filepath.Join(dir, "maindb", "wal")),
-		homeBytes:                dirSizeBytes(dir),
+		maintenanceAttempts:        parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
+		maintenanceWithRewrite:     parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.passes.with_rewrite"),
+		checkpointKickRuns:         parseInt64Stat(stats, "treedb.cache.vlog_generation.checkpoint_kick.runs"),
+		rewritePlanRuns:            parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_runs"),
+		rewritePlanEmpty:           parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_empty"),
+		rewritePlanSelected:        parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_selected"),
+		rewriteRuns:                parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
+		rewriteReclaimedBytes:      parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.reclaimed_bytes"),
+		queuedDebtExecRuns:         parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.runs"),
+		queuedDebtReclaimedBytes:   parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.reclaimed_bytes"),
+		rewriteQueueLen:            parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queue_len"),
+		retainedPruneRuns:          parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.runs"),
+		retainedPruneRemovedBytes:  parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.removed_bytes"),
+		retainedPruneObservedBytes: parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.observed_source.bytes_removed_total"),
+		observedGCDeletedBytes:     parseInt64Stat(stats, "treedb.cache.vlog_generation.observed_gc.source_bytes_deleted_total"),
+		retainedBytes:              parseInt64Stat(stats, "treedb.cache.vlog_retained_bytes_estimate"),
+		indexBytes:                 fileSizeBytes(filepath.Join(dir, "maindb", "index.db")),
+		walBytes:                   dirSizeBytes(filepath.Join(dir, "maindb", "wal")),
+		homeBytes:                  dirSizeBytes(dir),
 	}
 }
 

--- a/TreeDB/bench_trace_restore_like_test.go
+++ b/TreeDB/bench_trace_restore_like_test.go
@@ -49,6 +49,10 @@ type restoreLikeTraceReplayMetrics struct {
 	queuedDebtExecRuns          int64
 	queuedDebtReclaimedBytes    int64
 	rewriteQueueLen             int64
+	retainedPruneRuns           int64
+	retainedPruneRemovedBytes   int64
+	retainedPruneObservedBytes  int64
+	observedGCDeletedBytes      int64
 	retainedBytes               int64
 	indexBytes                  int64
 	walBytes                    int64
@@ -123,6 +127,10 @@ func BenchmarkRestoreLikeTraceReplay(b *testing.B) {
 			b.ReportMetric(float64(totals.queuedDebtExecRuns)/n, "queued_exec_runs/op")
 			b.ReportMetric(float64(totals.queuedDebtReclaimedBytes)/n, "queued_reclaimed_B/op")
 			b.ReportMetric(float64(totals.rewriteQueueLen)/n, "rewrite_queue_len/op")
+			b.ReportMetric(float64(totals.retainedPruneRuns)/n, "retained_prune_runs/op")
+			b.ReportMetric(float64(totals.retainedPruneRemovedBytes)/n, "retained_prune_removed_B/op")
+			b.ReportMetric(float64(totals.retainedPruneObservedBytes)/n, "retained_prune_observed_removed_B/op")
+			b.ReportMetric(float64(totals.observedGCDeletedBytes)/n, "observed_gc_deleted_B/op")
 			b.ReportMetric(float64(totals.retainedBytes)/n, "retained_B/op")
 			b.ReportMetric(float64(totals.indexBytes)/n, "index_B/op")
 			b.ReportMetric(float64(totals.walBytes)/n, "wal_B/op")
@@ -144,6 +152,10 @@ func (m *restoreLikeTraceReplayMetrics) add(other restoreLikeTraceReplayMetrics)
 	m.queuedDebtExecRuns += other.queuedDebtExecRuns
 	m.queuedDebtReclaimedBytes += other.queuedDebtReclaimedBytes
 	m.rewriteQueueLen += other.rewriteQueueLen
+	m.retainedPruneRuns += other.retainedPruneRuns
+	m.retainedPruneRemovedBytes += other.retainedPruneRemovedBytes
+	m.retainedPruneObservedBytes += other.retainedPruneObservedBytes
+	m.observedGCDeletedBytes += other.observedGCDeletedBytes
 	m.retainedBytes += other.retainedBytes
 	m.indexBytes += other.indexBytes
 	m.walBytes += other.walBytes
@@ -344,7 +356,7 @@ func waitForRestoreLikeMaintenance(db *DB, timeout time.Duration) time.Duration 
 	var stableSince time.Time
 	last := restoreLikeMaintenanceState{}
 	for time.Now().Before(deadline) {
-		cur := restoreLikeMaintenanceStateFromStats(db.Stats())
+		cur := restoreLikeMaintenanceStateFromDB(db)
 		if cur != last {
 			last = cur
 			stableSince = time.Time{}
@@ -363,17 +375,23 @@ func waitForRestoreLikeMaintenance(db *DB, timeout time.Duration) time.Duration 
 }
 
 type restoreLikeMaintenanceState struct {
-	schedulerState        string
-	checkpointKickActive  bool
-	checkpointKickPending bool
-	rewriteQueuePending   bool
-	rewriteQueueRunning   bool
-	maintenanceAttempts   int64
-	rewriteRuns           int64
+	schedulerState             string
+	checkpointKickActive       bool
+	checkpointKickPending      bool
+	rewriteQueuePending        bool
+	rewriteQueueRunning        bool
+	retainedPruneActive        bool
+	retainedPruneForcePending  bool
+	retainedPruneObservedQueue bool
+	maintenanceAttempts        int64
+	rewriteRuns                int64
 }
 
 func (s restoreLikeMaintenanceState) activeOrPending() bool {
 	if s.checkpointKickActive || s.checkpointKickPending || s.rewriteQueuePending || s.rewriteQueueRunning {
+		return true
+	}
+	if s.retainedPruneActive || s.retainedPruneForcePending || s.retainedPruneObservedQueue {
 		return true
 	}
 	switch s.schedulerState {
@@ -384,35 +402,43 @@ func (s restoreLikeMaintenanceState) activeOrPending() bool {
 	}
 }
 
-func restoreLikeMaintenanceStateFromStats(stats map[string]string) restoreLikeMaintenanceState {
+func restoreLikeMaintenanceStateFromDB(db *DB) restoreLikeMaintenanceState {
+	stats := db.Stats()
 	return restoreLikeMaintenanceState{
-		schedulerState:        stats["treedb.cache.vlog_generation.scheduler_state"],
-		checkpointKickActive:  parseBoolStat(stats, "treedb.cache.vlog_generation.checkpoint_kick.active"),
-		checkpointKickPending: parseBoolStat(stats, "treedb.cache.vlog_generation.checkpoint_kick.pending"),
-		rewriteQueuePending:   parseBoolStat(stats, "treedb.cache.vlog_generation.rewrite.queue.pending"),
-		rewriteQueueRunning:   parseBoolStat(stats, "treedb.cache.vlog_generation.rewrite.queue.running"),
-		maintenanceAttempts:   parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
-		rewriteRuns:           parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
+		schedulerState:             stats["treedb.cache.vlog_generation.scheduler_state"],
+		checkpointKickActive:       parseBoolStat(stats, "treedb.cache.vlog_generation.checkpoint_kick.active"),
+		checkpointKickPending:      parseBoolStat(stats, "treedb.cache.vlog_generation.checkpoint_kick.pending"),
+		rewriteQueuePending:        parseBoolStat(stats, "treedb.cache.vlog_generation.rewrite.queue.pending"),
+		rewriteQueueRunning:        parseBoolStat(stats, "treedb.cache.vlog_generation.rewrite.queue.running"),
+		retainedPruneActive:        parseBoolStat(stats, "treedb.cache.vlog_retained_prune.active"),
+		retainedPruneForcePending:  parseBoolStat(stats, "treedb.cache.vlog_retained_prune.force_pending"),
+		retainedPruneObservedQueue: parseBoolStat(stats, "treedb.cache.vlog_retained_prune.observed_source.pending"),
+		maintenanceAttempts:        parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
+		rewriteRuns:                parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
 	}
 }
 
 func collectRestoreLikeTraceReplayMetrics(stats map[string]string, dir string) restoreLikeTraceReplayMetrics {
 	return restoreLikeTraceReplayMetrics{
-		maintenanceAttempts:      parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
-		maintenanceWithRewrite:   parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.passes.with_rewrite"),
-		checkpointKickRuns:       parseInt64Stat(stats, "treedb.cache.vlog_generation.checkpoint_kick.runs"),
-		rewritePlanRuns:          parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_runs"),
-		rewritePlanEmpty:         parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_empty"),
-		rewritePlanSelected:      parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_selected"),
-		rewriteRuns:              parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
-		rewriteReclaimedBytes:    parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.reclaimed_bytes"),
-		queuedDebtExecRuns:       parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.runs"),
-		queuedDebtReclaimedBytes: parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.reclaimed_bytes"),
-		rewriteQueueLen:          parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queue_len"),
-		retainedBytes:            parseInt64Stat(stats, "treedb.cache.vlog_retained_bytes_estimate"),
-		indexBytes:               fileSizeBytes(filepath.Join(dir, "maindb", "index.db")),
-		walBytes:                 dirSizeBytes(filepath.Join(dir, "maindb", "wal")),
-		homeBytes:                dirSizeBytes(dir),
+		maintenanceAttempts:        parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
+		maintenanceWithRewrite:     parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.passes.with_rewrite"),
+		checkpointKickRuns:         parseInt64Stat(stats, "treedb.cache.vlog_generation.checkpoint_kick.runs"),
+		rewritePlanRuns:            parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_runs"),
+		rewritePlanEmpty:           parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_empty"),
+		rewritePlanSelected:        parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_selected"),
+		rewriteRuns:                parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
+		rewriteReclaimedBytes:      parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.reclaimed_bytes"),
+		queuedDebtExecRuns:         parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.runs"),
+		queuedDebtReclaimedBytes:   parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.reclaimed_bytes"),
+		rewriteQueueLen:            parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queue_len"),
+		retainedPruneRuns:          parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.runs"),
+		retainedPruneRemovedBytes:  parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.removed_bytes"),
+		retainedPruneObservedBytes: parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.observed_source.bytes_removed_total"),
+		observedGCDeletedBytes:     parseInt64Stat(stats, "treedb.cache.vlog_generation.observed_gc.source_bytes_deleted_total"),
+		retainedBytes:              parseInt64Stat(stats, "treedb.cache.vlog_retained_bytes_estimate"),
+		indexBytes:                 fileSizeBytes(filepath.Join(dir, "maindb", "index.db")),
+		walBytes:                   dirSizeBytes(filepath.Join(dir, "maindb", "wal")),
+		homeBytes:                  dirSizeBytes(dir),
 	}
 }
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4977,6 +4977,9 @@ func (db *DB) shouldScheduleRetainedValueLogPruneWithForce(force bool) bool {
 		return false
 	}
 	closed := db.valueLogRetainedClosedBytes.Load()
+	if force && db.retainedPruneObservedSourcePending() {
+		return true
+	}
 	if closed <= 0 {
 		return false
 	}
@@ -5385,6 +5388,19 @@ func (db *DB) waitForRetainedValueLogPrune() {
 	if done != nil {
 		<-done
 	}
+}
+
+func (db *DB) retainedPruneObservedSourceInFlight() bool {
+	if db == nil {
+		return false
+	}
+	db.retainedPruneMu.Lock()
+	active := db.retainedPruneDone != nil
+	db.retainedPruneMu.Unlock()
+	if !active {
+		return false
+	}
+	return db.retainedPruneForceRequested.Load() || db.retainedPruneObservedSourcePending()
 }
 
 func (db *DB) runRetainedValueLogPruneInline(force bool, observedSourceIDs map[uint32]struct{}) (retainedValueLogPruneStats, bool) {
@@ -15260,11 +15276,20 @@ func (db *DB) runVlogGenerationMaintenanceRetries(opts vlogGenerationMaintenance
 				db.vlogGenerationMaintenanceActive.Load(),
 			)
 		}
+		attemptOpts := opts
+		if attemptOpts.skipRetainedPruneWait && db.retainedPruneObservedSourceInFlight() {
+			// Once a targeted retained prune for rewrite-observed source IDs is in
+			// flight, let it drain before the next retry-driven rewrite/GC pass
+			// reacquires maintenance. Generic checkpoint-end prune probes should not
+			// block retry progress here; only the observed-source retained path fixes
+			// the retained-protected GC stalemate.
+			attemptOpts.skipRetainedPruneWait = false
+		}
 		// Retry-driven maintenance (checkpoint kick / deferred stage confirmation)
 		// prioritizes rewrite debt progress. Keep periodic/full-scan GC on the
 		// normal scheduler path to avoid introducing long full-scan stalls on hot
 		// checkpoint-triggered retries.
-		ran := db.maybeRunVlogGenerationMaintenanceWithOptions(false, opts)
+		ran := db.maybeRunVlogGenerationMaintenanceWithOptions(false, attemptOpts)
 		if stopWhenAcquired && ran {
 			if opts.debugSource != "" {
 				db.debugVlogMaintf(
@@ -23336,6 +23361,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_retained_bytes_estimate"] = fmt.Sprintf("%d", vlogBytes)
 	stats["treedb.process.memory.vlog_retained_bytes_estimate"] = fmt.Sprintf("%d", vlogBytes)
 	stats["treedb.cache.vlog_retained_prune.closed_bytes"] = fmt.Sprintf("%d", db.valueLogRetainedClosedBytes.Load())
+	stats["treedb.cache.vlog_retained_prune.active"] = fmt.Sprintf("%t", db.retainedPruneActive())
 	stats["treedb.cache.vlog_retained_prune.last_unix_nano"] = fmt.Sprintf("%d", db.retainedValueLogPruneLastUnixNano.Load())
 	stats["treedb.cache.vlog_retained_prune.runs"] = fmt.Sprintf("%d", db.retainedValueLogPruneRuns.Load())
 	stats["treedb.cache.vlog_retained_prune.forced_runs"] = fmt.Sprintf("%d", db.retainedValueLogPruneForcedRuns.Load())
@@ -23366,6 +23392,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_retained_prune.last_observed_source.bytes_parse_skipped"] = fmt.Sprintf("%d", db.retainedValueLogPruneLastObservedSourceParseSkippedBytes.Load())
 	stats["treedb.cache.vlog_retained_prune.last_observed_source.segments_zombie_marked"] = fmt.Sprintf("%d", db.retainedValueLogPruneLastObservedSourceZombieMarkedSegments.Load())
 	stats["treedb.cache.vlog_retained_prune.last_observed_source.bytes_zombie_marked"] = fmt.Sprintf("%d", db.retainedValueLogPruneLastObservedSourceZombieMarkedBytes.Load())
+	stats["treedb.cache.vlog_retained_prune.observed_source.pending"] = fmt.Sprintf("%t", db.retainedPruneObservedSourcePending())
 	stats["treedb.cache.vlog_retained_prune.observed_source.segments_total"] = fmt.Sprintf("%d", db.retainedValueLogPruneObservedSourceSegmentsTotal.Load())
 	stats["treedb.cache.vlog_retained_prune.observed_source.bytes_total"] = fmt.Sprintf("%d", db.retainedValueLogPruneObservedSourceBytesTotal.Load())
 	stats["treedb.cache.vlog_retained_prune.observed_source.segments_candidate_total"] = fmt.Sprintf("%d", db.retainedValueLogPruneObservedSourceCandidateSegmentsTotal.Load())

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -5053,6 +5053,22 @@ func (db *DB) takeRetainedPruneObservedSourceIDs() map[uint32]struct{} {
 	return out
 }
 
+func (db *DB) takeRetainedPruneObservedSourceIDsAndMarkActive() map[uint32]struct{} {
+	if db == nil {
+		return nil
+	}
+	db.retainedPruneObservedMu.Lock()
+	if len(db.retainedPruneObservedSourceIDs) == 0 {
+		db.retainedPruneObservedMu.Unlock()
+		return nil
+	}
+	db.retainedPruneObservedSourceActive.Store(true)
+	out := db.retainedPruneObservedSourceIDs
+	db.retainedPruneObservedSourceIDs = nil
+	db.retainedPruneObservedMu.Unlock()
+	return out
+}
+
 func (db *DB) retainedPruneObservedSourcePending() bool {
 	if db == nil {
 		return false
@@ -5357,7 +5373,10 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 			db.retainedValueLogPruneForcedRuns.Add(1)
 		}
 		db.retainedValueLogPruneLastUnixNano.Store(now.UnixNano())
-		observedSourceIDs := db.takeRetainedPruneObservedSourceIDs()
+		observedSourceIDs := db.takeRetainedPruneObservedSourceIDsAndMarkActive()
+		if len(observedSourceIDs) > 0 {
+			defer db.retainedPruneObservedSourceActive.Store(false)
+		}
 		pruneStats := db.pruneRetainedValueLogsWithObserved(effectiveForce, observedSourceIDs)
 		db.observeRetainedValueLogPruneStats(pruneStats)
 		if len(observedSourceIDs) > 0 && (pruneStats.ObservedSourceZombieMarkedSegments > 0 || pruneStats.ObservedSourceRemovedSegments > 0) {
@@ -5400,7 +5419,10 @@ func (db *DB) retainedPruneObservedSourceInFlight() bool {
 	if !active {
 		return false
 	}
-	return db.retainedPruneForceRequested.Load() || db.retainedPruneObservedSourcePending()
+	if db.retainedPruneObservedSourceActive.Load() {
+		return true
+	}
+	return db.retainedPruneObservedSourcePending()
 }
 
 func (db *DB) runRetainedValueLogPruneInline(force bool, observedSourceIDs map[uint32]struct{}) (retainedValueLogPruneStats, bool) {
@@ -5430,6 +5452,10 @@ func (db *DB) runRetainedValueLogPruneInline(force bool, observedSourceIDs map[u
 		db.retainedValueLogPruneForcedRuns.Add(1)
 	}
 	db.retainedValueLogPruneLastUnixNano.Store(nowPrune.UnixNano())
+	if len(observedSourceIDs) > 0 {
+		db.retainedPruneObservedSourceActive.Store(true)
+		defer db.retainedPruneObservedSourceActive.Store(false)
+	}
 	out = db.pruneRetainedValueLogsWithObserved(force, observedSourceIDs)
 	db.observeRetainedValueLogPruneStats(out)
 	return out, true
@@ -6267,6 +6293,7 @@ type DB struct {
 	retainedValueLogPruneWriteGateRetries                        atomic.Uint64
 	retainedValueLogPruneWriteGateRetrySuccesses                 atomic.Uint64
 	retainedPruneForceRequested                                  atomic.Bool
+	retainedPruneObservedSourceActive                            atomic.Bool
 	retainedPruneObservedMu                                      sync.Mutex
 	retainedPruneObservedSourceIDs                               map[uint32]struct{}
 	vlogGenerationObservedGCMu                                   sync.Mutex

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1213,6 +1213,20 @@ func TestVlogGenerationRewriteSegmentCapForFreshPlan_CheckpointKickUsesFreshPlan
 	}
 }
 
+func TestShouldScheduleRetainedValueLogPruneWithForce_ObservedSourcePendingBypassesClosedBytesGate(t *testing.T) {
+	db := &DB{}
+	if db.shouldScheduleRetainedValueLogPruneWithForce(true) {
+		t.Fatalf("force schedule without closed bytes or observed source pending should be false")
+	}
+	db.queueRetainedPruneObservedSourceIDs([]uint32{7})
+	if !db.shouldScheduleRetainedValueLogPruneWithForce(true) {
+		t.Fatalf("force schedule with observed source pending should bypass closed-bytes gate")
+	}
+	if db.shouldScheduleRetainedValueLogPruneWithForce(false) {
+		t.Fatalf("non-force schedule should still respect closed-bytes gate")
+	}
+}
+
 func TestVlogGenerationObserveRewriteSegmentCapDecision(t *testing.T) {
 	db := &DB{}
 	runDecision := vlogGenerationRewriteSegmentCapDecision{limiter: vlogGenerationRewriteSegmentCapLimiterBudgetTokens}
@@ -1877,8 +1891,11 @@ func TestVlogGenerationMaintenance_ObservedSourceGCBypassQuietIgnoresForegroundR
 	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
 	defer cleanup()
 	skipRetainedPrune(db)
+	db.waitForRetainedValueLogPrune()
 
 	db.queueVlogGenerationObservedSourceGCList([]uint32{11})
+	db.queueRetainedPruneObservedSourceIDs([]uint32{11})
+	db.retainedPruneForceRequested.Store(true)
 	db.vlogGenerationLastGCUnixNano.Store(time.Now().Add(-time.Minute).UnixNano())
 	forceVlogMaintenanceIdle(db)
 
@@ -1907,6 +1924,92 @@ func TestVlogGenerationMaintenance_ObservedSourceGCBypassQuietIgnoresForegroundR
 	}
 	if pending := len(db.takeVlogGenerationObservedSourceGCList()); pending != 0 {
 		t.Fatalf("observed-source gc pending ids=%d want 0", pending)
+	}
+}
+
+func TestVlogGenerationCheckpointKickRetries_WaitsForActiveRetainedPrune(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+	t.Setenv(envDisableVlogGenerationRewrite, "1")
+
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	gcStarted := make(chan struct{}, 1)
+	recorder := &rewriteBudgetRecordingBackend{
+		DB: backend,
+		gcFn: func(ctx context.Context, opts backenddb.ValueLogGCOptions) (backenddb.ValueLogGCStats, error) {
+			select {
+			case gcStarted <- struct{}{}:
+			default:
+			}
+			return backenddb.ValueLogGCStats{
+				ObservedSourceSegments:         len(opts.ObservedSourceFileIDs),
+				ObservedSourceSegmentsEligible: len(opts.ObservedSourceFileIDs),
+				ObservedSourceSegmentsDeleted:  len(opts.ObservedSourceFileIDs),
+				ObservedSourceBytesEligible:    int64(len(opts.ObservedSourceFileIDs)) * 64,
+				ObservedSourceBytesDeleted:     int64(len(opts.ObservedSourceFileIDs)) * 64,
+				BytesEligible:                  int64(len(opts.ObservedSourceFileIDs)) * 64,
+				BytesDeleted:                   int64(len(opts.ObservedSourceFileIDs)) * 64,
+			}, nil
+		},
+	}
+
+	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
+	defer cleanup()
+	skipRetainedPrune(db)
+	db.waitForRetainedValueLogPrune()
+
+	db.queueVlogGenerationObservedSourceGCList([]uint32{11})
+	db.queueRetainedPruneObservedSourceIDs([]uint32{11})
+	db.retainedPruneForceRequested.Store(true)
+	db.vlogGenerationLastGCUnixNano.Store(time.Now().Add(-time.Minute).UnixNano())
+	forceVlogMaintenanceIdle(db)
+
+	retainedDone := make(chan struct{})
+	db.retainedPruneMu.Lock()
+	db.retainedPruneDone = retainedDone
+	db.retainedPruneMu.Unlock()
+	if !db.retainedPruneObservedSourceInFlight() {
+		t.Fatalf("expected retained prune observed-source path to be marked in flight")
+	}
+
+	retriesDone := make(chan struct{})
+	go func() {
+		defer close(retriesDone)
+		db.runVlogGenerationCheckpointKickRetries(vlogGenerationMaintenanceOptions{
+			bypassQuiet:           true,
+			skipRetainedPruneWait: true,
+			skipCheckpoint:        true,
+			rewriteDebtDrain:      true,
+			debugSource:           "checkpoint_pending",
+		})
+	}()
+
+	select {
+	case <-gcStarted:
+		t.Fatalf("observed-source gc started before active retained prune finished")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	db.retainedPruneMu.Lock()
+	close(retainedDone)
+	db.retainedPruneDone = nil
+	db.retainedPruneMu.Unlock()
+
+	select {
+	case <-gcStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("observed-source gc did not start after retained prune finished")
+	}
+	select {
+	case <-retriesDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("checkpoint-kick retries did not finish after retained prune finished")
+	}
+	if got := recorder.recordedGCObservedSourceCalls(); got != 1 {
+		t.Fatalf("observed-source gc calls=%d want 1", got)
 	}
 }
 

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1974,6 +1974,12 @@ func TestVlogGenerationCheckpointKickRetries_WaitsForActiveRetainedPrune(t *test
 	if !db.retainedPruneObservedSourceInFlight() {
 		t.Fatalf("expected retained prune observed-source path to be marked in flight")
 	}
+	db.retainedPruneObservedSourceActive.Store(true)
+	db.retainedPruneForceRequested.Swap(false)
+	db.takeRetainedPruneObservedSourceIDs()
+	if !db.retainedPruneObservedSourceInFlight() {
+		t.Fatalf("expected retained prune observed-source path to remain in flight after prune start")
+	}
 
 	retriesDone := make(chan struct{})
 	go func() {
@@ -1997,6 +2003,7 @@ func TestVlogGenerationCheckpointKickRetries_WaitsForActiveRetainedPrune(t *test
 	close(retainedDone)
 	db.retainedPruneDone = nil
 	db.retainedPruneMu.Unlock()
+	db.retainedPruneObservedSourceActive.Store(false)
 
 	select {
 	case <-gcStarted:


### PR DESCRIPTION
## Summary
- Let observed-source retained-prune work run even when the generic retained closed-bytes hint is weak.
- Make retry-driven rewrite / GC wait for the in-flight observed-source retained prune that the prior pass already started.
- Extend the replay metrics with retained-prune and observed-source GC shape so the reclaim step is visible in the steering loop.

## Replay Delta vs #945
This PR produces the first real storage win on the corrected replay.

`WALOn`:
- `retained_B/op`: `137,466,963 -> 136,051,357` delta `-1,415,606` (`-1.0%`)
- `wal_B/op`: `137,886,606 -> 136,471,000` delta `-1,415,606` (`-1.0%`)
- `home_B/op`: `147,972,400 -> 146,556,793` delta `-1,415,607` (`-1.0%`)
- `retained_prune_runs/op`: `0 -> 1` delta `+1`

`WALOff`:
- `retained_B/op`: `137,356,947 -> 135,961,568` delta `-1,395,379` (`-1.0%`)
- `wal_B/op`: `137,822,062 -> 136,426,683` delta `-1,395,379` (`-1.0%`)
- `home_B/op`: `147,907,770 -> 146,512,390` delta `-1,395,380` (`-0.9%`)
- `retained_prune_runs/op`: `0 -> 1` delta `+1`

Absolute replay metrics on this branch:
- `WALOn`: `retained_B/op = 136,051,357`, `wal_B/op = 136,471,000`, `home_B/op = 146,556,793`, `maint_attempts/op = 2`, `retained_prune_runs/op = 1`, `rewrite_queue_len/op = 4`
- `WALOff`: `retained_B/op = 135,961,568`, `wal_B/op = 136,426,683`, `home_B/op = 146,512,390`, `maint_attempts/op = 6`, `retained_prune_runs/op = 1`, `rewrite_queue_len/op = 4`

## Validation
- `GOWORK=off go test ./TreeDB/caching -run 'TestShouldScheduleRetainedValueLogPruneWithForce_ObservedSourcePendingBypassesClosedBytesGate|TestVlogGenerationMaintenance_WaitsForObservedSourceRetainedPruneBeforeObservedGC|TestVlogGenerationGCProtectedRetained_SchedulesForcePruneWithoutClosedByteHint' -count=1`
- `GOWORK=off go test ./TreeDB -run '^$' -bench '^BenchmarkRestoreLikeTraceReplay$' -benchtime=1x -count=1`
