### PR TITLE
TreeDB/cache: converge replay rewrite to online floor

### DIFF
--- a/TreeDB/bench_trace_restore_like_test.go
+++ b/TreeDB/bench_trace_restore_like_test.go
@@ -1,6 +1,7 @@
 package treedb
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -11,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	treedbdb "github.com/snissn/gomap/TreeDB/db"
 )
 
 //go:embed testdata/trace_replay/restore_like.summary.json
@@ -38,26 +41,46 @@ type restoreLikeTraceReplayConfig struct {
 }
 
 type restoreLikeTraceReplayMetrics struct {
-	maintenanceAttempts         int64
-	maintenanceWithRewrite      int64
-	checkpointKickRuns          int64
-	rewritePlanRuns             int64
-	rewritePlanEmpty            int64
-	rewritePlanSelected         int64
-	rewriteRuns                 int64
-	rewriteReclaimedBytes       int64
-	queuedDebtExecRuns          int64
-	queuedDebtReclaimedBytes    int64
-	rewriteQueueLen             int64
-	retainedPruneRuns           int64
-	retainedPruneRemovedBytes   int64
-	retainedPruneObservedBytes  int64
-	observedGCDeletedBytes      int64
-	retainedBytes               int64
-	indexBytes                  int64
-	walBytes                    int64
-	homeBytes                   int64
-	maintenanceWaitMilliseconds int64
+	maintenanceAttempts                    int64
+	maintenanceWithRewrite                 int64
+	checkpointKickRuns                     int64
+	rewritePlanRuns                        int64
+	rewritePlanEmpty                       int64
+	rewritePlanSelected                    int64
+	rewriteRuns                            int64
+	rewriteReclaimedBytes                  int64
+	rewriteProcessedLiveBytes              int64
+	rewriteProcessedStaleBytes             int64
+	rewriteNoReclaimStaleBytes             int64
+	queuedDebtExecRuns                     int64
+	queuedDebtReclaimedBytes               int64
+	rewriteQueueLen                        int64
+	retainedPruneRuns                      int64
+	retainedPruneForcedRuns                int64
+	retainedPruneRemovedBytes              int64
+	retainedPruneObservedBytes             int64
+	retainedPruneClosedBytes               int64
+	retainedPruneCandidateBytes            int64
+	retainedPruneLiveSkippedBytes          int64
+	retainedPruneZombieMarkedBytes         int64
+	retainedPruneObservedZombieMarkedBytes int64
+	retainedPruneScheduleForcedRequests    int64
+	retainedPruneScheduleSkipMinInterval   int64
+	observedGCDeletedBytes                 int64
+	gcProtectedRetainedBytes               int64
+	strictGCEligibleBytes                  int64
+	strictGCDeletedBytes                   int64
+	strictGCWalBytes                       int64
+	strictGCHomeBytes                      int64
+	offlineRewriteBytesBefore              int64
+	offlineRewriteBytesAfter               int64
+	offlineRewriteWalBytes                 int64
+	offlineRewriteHomeBytes                int64
+	retainedBytes                          int64
+	indexBytes                             int64
+	walBytes                               int64
+	homeBytes                              int64
+	maintenanceWaitMilliseconds            int64
 }
 
 func BenchmarkRestoreLikeTraceReplay(b *testing.B) {
@@ -124,13 +147,33 @@ func BenchmarkRestoreLikeTraceReplay(b *testing.B) {
 			b.ReportMetric(float64(totals.rewritePlanSelected)/n, "rewrite_plan_selected/op")
 			b.ReportMetric(float64(totals.rewriteRuns)/n, "rewrite_runs/op")
 			b.ReportMetric(float64(totals.rewriteReclaimedBytes)/n, "rewrite_reclaimed_B/op")
+			b.ReportMetric(float64(totals.rewriteProcessedLiveBytes)/n, "rewrite_processed_live_B/op")
+			b.ReportMetric(float64(totals.rewriteProcessedStaleBytes)/n, "rewrite_processed_stale_B/op")
+			b.ReportMetric(float64(totals.rewriteNoReclaimStaleBytes)/n, "rewrite_no_reclaim_stale_B/op")
 			b.ReportMetric(float64(totals.queuedDebtExecRuns)/n, "queued_exec_runs/op")
 			b.ReportMetric(float64(totals.queuedDebtReclaimedBytes)/n, "queued_reclaimed_B/op")
 			b.ReportMetric(float64(totals.rewriteQueueLen)/n, "rewrite_queue_len/op")
 			b.ReportMetric(float64(totals.retainedPruneRuns)/n, "retained_prune_runs/op")
+			b.ReportMetric(float64(totals.retainedPruneForcedRuns)/n, "retained_prune_forced_runs/op")
 			b.ReportMetric(float64(totals.retainedPruneRemovedBytes)/n, "retained_prune_removed_B/op")
 			b.ReportMetric(float64(totals.retainedPruneObservedBytes)/n, "retained_prune_observed_removed_B/op")
+			b.ReportMetric(float64(totals.retainedPruneClosedBytes)/n, "retained_prune_closed_B/op")
+			b.ReportMetric(float64(totals.retainedPruneCandidateBytes)/n, "retained_prune_candidate_B/op")
+			b.ReportMetric(float64(totals.retainedPruneLiveSkippedBytes)/n, "retained_prune_live_skipped_B/op")
+			b.ReportMetric(float64(totals.retainedPruneZombieMarkedBytes)/n, "retained_prune_zombie_marked_B/op")
+			b.ReportMetric(float64(totals.retainedPruneObservedZombieMarkedBytes)/n, "retained_prune_observed_zombie_marked_B/op")
+			b.ReportMetric(float64(totals.retainedPruneScheduleForcedRequests)/n, "retained_prune_schedule_forced_requests/op")
+			b.ReportMetric(float64(totals.retainedPruneScheduleSkipMinInterval)/n, "retained_prune_schedule_skip_min_interval/op")
 			b.ReportMetric(float64(totals.observedGCDeletedBytes)/n, "observed_gc_deleted_B/op")
+			b.ReportMetric(float64(totals.gcProtectedRetainedBytes)/n, "gc_protected_retained_B/op")
+			b.ReportMetric(float64(totals.strictGCEligibleBytes)/n, "strict_gc_eligible_B/op")
+			b.ReportMetric(float64(totals.strictGCDeletedBytes)/n, "strict_gc_deleted_B/op")
+			b.ReportMetric(float64(totals.strictGCWalBytes)/n, "strict_gc_wal_B/op")
+			b.ReportMetric(float64(totals.strictGCHomeBytes)/n, "strict_gc_home_B/op")
+			b.ReportMetric(float64(totals.offlineRewriteBytesBefore)/n, "offline_floor_before_B/op")
+			b.ReportMetric(float64(totals.offlineRewriteBytesAfter)/n, "offline_floor_after_B/op")
+			b.ReportMetric(float64(totals.offlineRewriteWalBytes)/n, "offline_floor_wal_B/op")
+			b.ReportMetric(float64(totals.offlineRewriteHomeBytes)/n, "offline_floor_home_B/op")
 			b.ReportMetric(float64(totals.retainedBytes)/n, "retained_B/op")
 			b.ReportMetric(float64(totals.indexBytes)/n, "index_B/op")
 			b.ReportMetric(float64(totals.walBytes)/n, "wal_B/op")
@@ -149,13 +192,33 @@ func (m *restoreLikeTraceReplayMetrics) add(other restoreLikeTraceReplayMetrics)
 	m.rewritePlanSelected += other.rewritePlanSelected
 	m.rewriteRuns += other.rewriteRuns
 	m.rewriteReclaimedBytes += other.rewriteReclaimedBytes
+	m.rewriteProcessedLiveBytes += other.rewriteProcessedLiveBytes
+	m.rewriteProcessedStaleBytes += other.rewriteProcessedStaleBytes
+	m.rewriteNoReclaimStaleBytes += other.rewriteNoReclaimStaleBytes
 	m.queuedDebtExecRuns += other.queuedDebtExecRuns
 	m.queuedDebtReclaimedBytes += other.queuedDebtReclaimedBytes
 	m.rewriteQueueLen += other.rewriteQueueLen
 	m.retainedPruneRuns += other.retainedPruneRuns
+	m.retainedPruneForcedRuns += other.retainedPruneForcedRuns
 	m.retainedPruneRemovedBytes += other.retainedPruneRemovedBytes
 	m.retainedPruneObservedBytes += other.retainedPruneObservedBytes
+	m.retainedPruneClosedBytes += other.retainedPruneClosedBytes
+	m.retainedPruneCandidateBytes += other.retainedPruneCandidateBytes
+	m.retainedPruneLiveSkippedBytes += other.retainedPruneLiveSkippedBytes
+	m.retainedPruneZombieMarkedBytes += other.retainedPruneZombieMarkedBytes
+	m.retainedPruneObservedZombieMarkedBytes += other.retainedPruneObservedZombieMarkedBytes
+	m.retainedPruneScheduleForcedRequests += other.retainedPruneScheduleForcedRequests
+	m.retainedPruneScheduleSkipMinInterval += other.retainedPruneScheduleSkipMinInterval
 	m.observedGCDeletedBytes += other.observedGCDeletedBytes
+	m.gcProtectedRetainedBytes += other.gcProtectedRetainedBytes
+	m.strictGCEligibleBytes += other.strictGCEligibleBytes
+	m.strictGCDeletedBytes += other.strictGCDeletedBytes
+	m.strictGCWalBytes += other.strictGCWalBytes
+	m.strictGCHomeBytes += other.strictGCHomeBytes
+	m.offlineRewriteBytesBefore += other.offlineRewriteBytesBefore
+	m.offlineRewriteBytesAfter += other.offlineRewriteBytesAfter
+	m.offlineRewriteWalBytes += other.offlineRewriteWalBytes
+	m.offlineRewriteHomeBytes += other.offlineRewriteHomeBytes
 	m.retainedBytes += other.retainedBytes
 	m.indexBytes += other.indexBytes
 	m.walBytes += other.walBytes
@@ -284,7 +347,10 @@ func runRestoreLikeTraceReplayIteration(summary traceSummary, cfg restoreLikeTra
 		return restoreLikeTraceReplayMetrics{}, err
 	}
 	closed = true
-	metrics := collectRestoreLikeTraceReplayMetrics(stats, dir)
+	metrics, err := collectRestoreLikeTraceReplayMetrics(stats, dir)
+	if err != nil {
+		return restoreLikeTraceReplayMetrics{}, err
+	}
 	metrics.maintenanceWaitMilliseconds = waited.Milliseconds()
 	return metrics, nil
 }
@@ -418,28 +484,68 @@ func restoreLikeMaintenanceStateFromDB(db *DB) restoreLikeMaintenanceState {
 	}
 }
 
-func collectRestoreLikeTraceReplayMetrics(stats map[string]string, dir string) restoreLikeTraceReplayMetrics {
-	return restoreLikeTraceReplayMetrics{
-		maintenanceAttempts:        parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
-		maintenanceWithRewrite:     parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.passes.with_rewrite"),
-		checkpointKickRuns:         parseInt64Stat(stats, "treedb.cache.vlog_generation.checkpoint_kick.runs"),
-		rewritePlanRuns:            parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_runs"),
-		rewritePlanEmpty:           parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_empty"),
-		rewritePlanSelected:        parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_selected"),
-		rewriteRuns:                parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
-		rewriteReclaimedBytes:      parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.reclaimed_bytes"),
-		queuedDebtExecRuns:         parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.runs"),
-		queuedDebtReclaimedBytes:   parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.reclaimed_bytes"),
-		rewriteQueueLen:            parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queue_len"),
-		retainedPruneRuns:          parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.runs"),
-		retainedPruneRemovedBytes:  parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.removed_bytes"),
-		retainedPruneObservedBytes: parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.observed_source.bytes_removed_total"),
-		observedGCDeletedBytes:     parseInt64Stat(stats, "treedb.cache.vlog_generation.observed_gc.source_bytes_deleted_total"),
-		retainedBytes:              parseInt64Stat(stats, "treedb.cache.vlog_retained_bytes_estimate"),
-		indexBytes:                 fileSizeBytes(filepath.Join(dir, "maindb", "index.db")),
-		walBytes:                   dirSizeBytes(filepath.Join(dir, "maindb", "wal")),
-		homeBytes:                  dirSizeBytes(dir),
+func collectRestoreLikeTraceReplayMetrics(stats map[string]string, dir string) (restoreLikeTraceReplayMetrics, error) {
+	metrics := restoreLikeTraceReplayMetrics{
+		maintenanceAttempts:                    parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
+		maintenanceWithRewrite:                 parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.passes.with_rewrite"),
+		checkpointKickRuns:                     parseInt64Stat(stats, "treedb.cache.vlog_generation.checkpoint_kick.runs"),
+		rewritePlanRuns:                        parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_runs"),
+		rewritePlanEmpty:                       parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_empty"),
+		rewritePlanSelected:                    parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_selected"),
+		rewriteRuns:                            parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
+		rewriteReclaimedBytes:                  parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.reclaimed_bytes"),
+		rewriteProcessedLiveBytes:              parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.processed_live_bytes"),
+		rewriteProcessedStaleBytes:             parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.processed_stale_bytes"),
+		rewriteNoReclaimStaleBytes:             parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.no_reclaim_stale_bytes"),
+		queuedDebtExecRuns:                     parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.runs"),
+		queuedDebtReclaimedBytes:               parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.reclaimed_bytes"),
+		rewriteQueueLen:                        parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queue_len"),
+		retainedPruneRuns:                      parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.runs"),
+		retainedPruneForcedRuns:                parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.forced_runs"),
+		retainedPruneRemovedBytes:              parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.removed_bytes"),
+		retainedPruneObservedBytes:             parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.observed_source.bytes_removed_total"),
+		retainedPruneClosedBytes:               parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.closed_bytes"),
+		retainedPruneCandidateBytes:            parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.candidate_bytes"),
+		retainedPruneLiveSkippedBytes:          parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.live_skipped_bytes"),
+		retainedPruneZombieMarkedBytes:         parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.zombie_marked_bytes"),
+		retainedPruneObservedZombieMarkedBytes: parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.observed_source.bytes_zombie_marked_total"),
+		retainedPruneScheduleForcedRequests:    parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.schedule_forced_requests"),
+		retainedPruneScheduleSkipMinInterval:   parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.schedule_skip.min_interval"),
+		observedGCDeletedBytes:                 parseInt64Stat(stats, "treedb.cache.vlog_generation.observed_gc.source_bytes_deleted_total"),
+		gcProtectedRetainedBytes:               parseInt64Stat(stats, "treedb.cache.vlog_generation.gc.last_protected_retained_bytes"),
+		retainedBytes:                          parseInt64Stat(stats, "treedb.cache.vlog_retained_bytes_estimate"),
+		indexBytes:                             fileSizeBytes(filepath.Join(dir, "maindb", "index.db")),
+		walBytes:                               dirSizeBytes(filepath.Join(dir, "maindb", "wal")),
+		homeBytes:                              dirSizeBytes(dir),
 	}
+
+	backend, cleanup, err := OpenBackend(Options{Dir: dir, ReadOnly: false})
+	if err != nil {
+		return restoreLikeTraceReplayMetrics{}, err
+	}
+	gcStats, gcErr := backend.ValueLogGC(context.Background(), treedbdb.ValueLogGCOptions{})
+	cleanupErr := cleanup()
+	if gcErr != nil {
+		return restoreLikeTraceReplayMetrics{}, gcErr
+	}
+	if cleanupErr != nil {
+		return restoreLikeTraceReplayMetrics{}, cleanupErr
+	}
+	metrics.strictGCEligibleBytes = gcStats.BytesEligible
+	metrics.strictGCDeletedBytes = gcStats.BytesDeleted
+	metrics.strictGCWalBytes = dirSizeBytes(filepath.Join(dir, "maindb", "wal"))
+	metrics.strictGCHomeBytes = dirSizeBytes(dir)
+
+	rewriteStats, err := ValueLogRewriteOffline(Options{Dir: dir})
+	if err != nil {
+		return restoreLikeTraceReplayMetrics{}, err
+	}
+	metrics.offlineRewriteBytesBefore = rewriteStats.BytesBefore
+	metrics.offlineRewriteBytesAfter = rewriteStats.BytesAfter
+	metrics.offlineRewriteWalBytes = dirSizeBytes(filepath.Join(dir, "maindb", "wal"))
+	metrics.offlineRewriteHomeBytes = dirSizeBytes(dir)
+
+	return metrics, nil
 }
 
 func parseInt64Stat(stats map[string]string, key string) int64 {

--- a/TreeDB/bench_trace_restore_like_test.go
+++ b/TreeDB/bench_trace_restore_like_test.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -523,10 +524,12 @@ func collectRestoreLikeTraceReplayMetrics(stats map[string]string, dir string) (
 	if err != nil {
 		return restoreLikeTraceReplayMetrics{}, err
 	}
-	gcStats, gcErr := backend.ValueLogGC(context.Background(), treedbdb.ValueLogGCOptions{})
+	gcCtx, gcCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	gcStats, gcErr := backend.ValueLogGC(gcCtx, treedbdb.ValueLogGCOptions{})
+	gcCancel()
 	cleanupErr := cleanup()
 	if gcErr != nil {
-		return restoreLikeTraceReplayMetrics{}, gcErr
+		return restoreLikeTraceReplayMetrics{}, fmt.Errorf("strict value-log gc: %w", gcErr)
 	}
 	if cleanupErr != nil {
 		return restoreLikeTraceReplayMetrics{}, cleanupErr

--- a/TreeDB/bench_trace_restore_like_test.go
+++ b/TreeDB/bench_trace_restore_like_test.go
@@ -1,6 +1,7 @@
 package treedb
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"math/rand"
@@ -10,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	treedbdb "github.com/snissn/gomap/TreeDB/db"
 )
 
 //go:embed testdata/trace_replay/restore_like.summary.json
@@ -37,26 +40,46 @@ type restoreLikeTraceReplayConfig struct {
 }
 
 type restoreLikeTraceReplayMetrics struct {
-	maintenanceAttempts         int64
-	maintenanceWithRewrite      int64
-	checkpointKickRuns          int64
-	rewritePlanRuns             int64
-	rewritePlanEmpty            int64
-	rewritePlanSelected         int64
-	rewriteRuns                 int64
-	rewriteReclaimedBytes       int64
-	queuedDebtExecRuns          int64
-	queuedDebtReclaimedBytes    int64
-	rewriteQueueLen             int64
-	retainedPruneRuns           int64
-	retainedPruneRemovedBytes   int64
-	retainedPruneObservedBytes  int64
-	observedGCDeletedBytes      int64
-	retainedBytes               int64
-	indexBytes                  int64
-	walBytes                    int64
-	homeBytes                   int64
-	maintenanceWaitMilliseconds int64
+	maintenanceAttempts                    int64
+	maintenanceWithRewrite                 int64
+	checkpointKickRuns                     int64
+	rewritePlanRuns                        int64
+	rewritePlanEmpty                       int64
+	rewritePlanSelected                    int64
+	rewriteRuns                            int64
+	rewriteReclaimedBytes                  int64
+	rewriteProcessedLiveBytes              int64
+	rewriteProcessedStaleBytes             int64
+	rewriteNoReclaimStaleBytes             int64
+	queuedDebtExecRuns                     int64
+	queuedDebtReclaimedBytes               int64
+	rewriteQueueLen                        int64
+	retainedPruneRuns                      int64
+	retainedPruneForcedRuns                int64
+	retainedPruneRemovedBytes              int64
+	retainedPruneObservedBytes             int64
+	retainedPruneClosedBytes               int64
+	retainedPruneCandidateBytes            int64
+	retainedPruneLiveSkippedBytes          int64
+	retainedPruneZombieMarkedBytes         int64
+	retainedPruneObservedZombieMarkedBytes int64
+	retainedPruneScheduleForcedRequests    int64
+	retainedPruneScheduleSkipMinInterval   int64
+	observedGCDeletedBytes                 int64
+	gcProtectedRetainedBytes               int64
+	strictGCEligibleBytes                  int64
+	strictGCDeletedBytes                   int64
+	strictGCWalBytes                       int64
+	strictGCHomeBytes                      int64
+	offlineRewriteBytesBefore              int64
+	offlineRewriteBytesAfter               int64
+	offlineRewriteWalBytes                 int64
+	offlineRewriteHomeBytes                int64
+	retainedBytes                          int64
+	indexBytes                             int64
+	walBytes                               int64
+	homeBytes                              int64
+	maintenanceWaitMilliseconds            int64
 }
 
 func BenchmarkRestoreLikeTraceReplay(b *testing.B) {
@@ -123,13 +146,33 @@ func BenchmarkRestoreLikeTraceReplay(b *testing.B) {
 			b.ReportMetric(float64(totals.rewritePlanSelected)/n, "rewrite_plan_selected/op")
 			b.ReportMetric(float64(totals.rewriteRuns)/n, "rewrite_runs/op")
 			b.ReportMetric(float64(totals.rewriteReclaimedBytes)/n, "rewrite_reclaimed_B/op")
+			b.ReportMetric(float64(totals.rewriteProcessedLiveBytes)/n, "rewrite_processed_live_B/op")
+			b.ReportMetric(float64(totals.rewriteProcessedStaleBytes)/n, "rewrite_processed_stale_B/op")
+			b.ReportMetric(float64(totals.rewriteNoReclaimStaleBytes)/n, "rewrite_no_reclaim_stale_B/op")
 			b.ReportMetric(float64(totals.queuedDebtExecRuns)/n, "queued_exec_runs/op")
 			b.ReportMetric(float64(totals.queuedDebtReclaimedBytes)/n, "queued_reclaimed_B/op")
 			b.ReportMetric(float64(totals.rewriteQueueLen)/n, "rewrite_queue_len/op")
 			b.ReportMetric(float64(totals.retainedPruneRuns)/n, "retained_prune_runs/op")
+			b.ReportMetric(float64(totals.retainedPruneForcedRuns)/n, "retained_prune_forced_runs/op")
 			b.ReportMetric(float64(totals.retainedPruneRemovedBytes)/n, "retained_prune_removed_B/op")
 			b.ReportMetric(float64(totals.retainedPruneObservedBytes)/n, "retained_prune_observed_removed_B/op")
+			b.ReportMetric(float64(totals.retainedPruneClosedBytes)/n, "retained_prune_closed_B/op")
+			b.ReportMetric(float64(totals.retainedPruneCandidateBytes)/n, "retained_prune_candidate_B/op")
+			b.ReportMetric(float64(totals.retainedPruneLiveSkippedBytes)/n, "retained_prune_live_skipped_B/op")
+			b.ReportMetric(float64(totals.retainedPruneZombieMarkedBytes)/n, "retained_prune_zombie_marked_B/op")
+			b.ReportMetric(float64(totals.retainedPruneObservedZombieMarkedBytes)/n, "retained_prune_observed_zombie_marked_B/op")
+			b.ReportMetric(float64(totals.retainedPruneScheduleForcedRequests)/n, "retained_prune_schedule_forced_requests/op")
+			b.ReportMetric(float64(totals.retainedPruneScheduleSkipMinInterval)/n, "retained_prune_schedule_skip_min_interval/op")
 			b.ReportMetric(float64(totals.observedGCDeletedBytes)/n, "observed_gc_deleted_B/op")
+			b.ReportMetric(float64(totals.gcProtectedRetainedBytes)/n, "gc_protected_retained_B/op")
+			b.ReportMetric(float64(totals.strictGCEligibleBytes)/n, "strict_gc_eligible_B/op")
+			b.ReportMetric(float64(totals.strictGCDeletedBytes)/n, "strict_gc_deleted_B/op")
+			b.ReportMetric(float64(totals.strictGCWalBytes)/n, "strict_gc_wal_B/op")
+			b.ReportMetric(float64(totals.strictGCHomeBytes)/n, "strict_gc_home_B/op")
+			b.ReportMetric(float64(totals.offlineRewriteBytesBefore)/n, "offline_floor_before_B/op")
+			b.ReportMetric(float64(totals.offlineRewriteBytesAfter)/n, "offline_floor_after_B/op")
+			b.ReportMetric(float64(totals.offlineRewriteWalBytes)/n, "offline_floor_wal_B/op")
+			b.ReportMetric(float64(totals.offlineRewriteHomeBytes)/n, "offline_floor_home_B/op")
 			b.ReportMetric(float64(totals.retainedBytes)/n, "retained_B/op")
 			b.ReportMetric(float64(totals.indexBytes)/n, "index_B/op")
 			b.ReportMetric(float64(totals.walBytes)/n, "wal_B/op")
@@ -148,13 +191,33 @@ func (m *restoreLikeTraceReplayMetrics) add(other restoreLikeTraceReplayMetrics)
 	m.rewritePlanSelected += other.rewritePlanSelected
 	m.rewriteRuns += other.rewriteRuns
 	m.rewriteReclaimedBytes += other.rewriteReclaimedBytes
+	m.rewriteProcessedLiveBytes += other.rewriteProcessedLiveBytes
+	m.rewriteProcessedStaleBytes += other.rewriteProcessedStaleBytes
+	m.rewriteNoReclaimStaleBytes += other.rewriteNoReclaimStaleBytes
 	m.queuedDebtExecRuns += other.queuedDebtExecRuns
 	m.queuedDebtReclaimedBytes += other.queuedDebtReclaimedBytes
 	m.rewriteQueueLen += other.rewriteQueueLen
 	m.retainedPruneRuns += other.retainedPruneRuns
+	m.retainedPruneForcedRuns += other.retainedPruneForcedRuns
 	m.retainedPruneRemovedBytes += other.retainedPruneRemovedBytes
 	m.retainedPruneObservedBytes += other.retainedPruneObservedBytes
+	m.retainedPruneClosedBytes += other.retainedPruneClosedBytes
+	m.retainedPruneCandidateBytes += other.retainedPruneCandidateBytes
+	m.retainedPruneLiveSkippedBytes += other.retainedPruneLiveSkippedBytes
+	m.retainedPruneZombieMarkedBytes += other.retainedPruneZombieMarkedBytes
+	m.retainedPruneObservedZombieMarkedBytes += other.retainedPruneObservedZombieMarkedBytes
+	m.retainedPruneScheduleForcedRequests += other.retainedPruneScheduleForcedRequests
+	m.retainedPruneScheduleSkipMinInterval += other.retainedPruneScheduleSkipMinInterval
 	m.observedGCDeletedBytes += other.observedGCDeletedBytes
+	m.gcProtectedRetainedBytes += other.gcProtectedRetainedBytes
+	m.strictGCEligibleBytes += other.strictGCEligibleBytes
+	m.strictGCDeletedBytes += other.strictGCDeletedBytes
+	m.strictGCWalBytes += other.strictGCWalBytes
+	m.strictGCHomeBytes += other.strictGCHomeBytes
+	m.offlineRewriteBytesBefore += other.offlineRewriteBytesBefore
+	m.offlineRewriteBytesAfter += other.offlineRewriteBytesAfter
+	m.offlineRewriteWalBytes += other.offlineRewriteWalBytes
+	m.offlineRewriteHomeBytes += other.offlineRewriteHomeBytes
 	m.retainedBytes += other.retainedBytes
 	m.indexBytes += other.indexBytes
 	m.walBytes += other.walBytes
@@ -276,7 +339,10 @@ func runRestoreLikeTraceReplayIteration(summary traceSummary, cfg restoreLikeTra
 	if err := db.Close(); err != nil {
 		return restoreLikeTraceReplayMetrics{}, err
 	}
-	metrics := collectRestoreLikeTraceReplayMetrics(stats, dir)
+	metrics, err := collectRestoreLikeTraceReplayMetrics(stats, dir)
+	if err != nil {
+		return restoreLikeTraceReplayMetrics{}, err
+	}
 	metrics.maintenanceWaitMilliseconds = waited.Milliseconds()
 	return metrics, nil
 }
@@ -410,28 +476,68 @@ func restoreLikeMaintenanceStateFromDB(db *DB) restoreLikeMaintenanceState {
 	}
 }
 
-func collectRestoreLikeTraceReplayMetrics(stats map[string]string, dir string) restoreLikeTraceReplayMetrics {
-	return restoreLikeTraceReplayMetrics{
-		maintenanceAttempts:        parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
-		maintenanceWithRewrite:     parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.passes.with_rewrite"),
-		checkpointKickRuns:         parseInt64Stat(stats, "treedb.cache.vlog_generation.checkpoint_kick.runs"),
-		rewritePlanRuns:            parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_runs"),
-		rewritePlanEmpty:           parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_empty"),
-		rewritePlanSelected:        parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_selected"),
-		rewriteRuns:                parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
-		rewriteReclaimedBytes:      parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.reclaimed_bytes"),
-		queuedDebtExecRuns:         parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.runs"),
-		queuedDebtReclaimedBytes:   parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.reclaimed_bytes"),
-		rewriteQueueLen:            parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queue_len"),
-		retainedPruneRuns:          parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.runs"),
-		retainedPruneRemovedBytes:  parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.removed_bytes"),
-		retainedPruneObservedBytes: parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.observed_source.bytes_removed_total"),
-		observedGCDeletedBytes:     parseInt64Stat(stats, "treedb.cache.vlog_generation.observed_gc.source_bytes_deleted_total"),
-		retainedBytes:              parseInt64Stat(stats, "treedb.cache.vlog_retained_bytes_estimate"),
-		indexBytes:                 fileSizeBytes(filepath.Join(dir, "maindb", "index.db")),
-		walBytes:                   dirSizeBytes(filepath.Join(dir, "maindb", "wal")),
-		homeBytes:                  dirSizeBytes(dir),
+func collectRestoreLikeTraceReplayMetrics(stats map[string]string, dir string) (restoreLikeTraceReplayMetrics, error) {
+	metrics := restoreLikeTraceReplayMetrics{
+		maintenanceAttempts:                    parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.attempts"),
+		maintenanceWithRewrite:                 parseInt64Stat(stats, "treedb.cache.vlog_generation.maintenance.passes.with_rewrite"),
+		checkpointKickRuns:                     parseInt64Stat(stats, "treedb.cache.vlog_generation.checkpoint_kick.runs"),
+		rewritePlanRuns:                        parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_runs"),
+		rewritePlanEmpty:                       parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_empty"),
+		rewritePlanSelected:                    parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.plan_selected"),
+		rewriteRuns:                            parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.runs"),
+		rewriteReclaimedBytes:                  parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.reclaimed_bytes"),
+		rewriteProcessedLiveBytes:              parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.processed_live_bytes"),
+		rewriteProcessedStaleBytes:             parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.processed_stale_bytes"),
+		rewriteNoReclaimStaleBytes:             parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.no_reclaim_stale_bytes"),
+		queuedDebtExecRuns:                     parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.runs"),
+		queuedDebtReclaimedBytes:               parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queued_debt.exec.reclaimed_bytes"),
+		rewriteQueueLen:                        parseInt64Stat(stats, "treedb.cache.vlog_generation.rewrite.queue_len"),
+		retainedPruneRuns:                      parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.runs"),
+		retainedPruneForcedRuns:                parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.forced_runs"),
+		retainedPruneRemovedBytes:              parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.removed_bytes"),
+		retainedPruneObservedBytes:             parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.observed_source.bytes_removed_total"),
+		retainedPruneClosedBytes:               parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.closed_bytes"),
+		retainedPruneCandidateBytes:            parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.candidate_bytes"),
+		retainedPruneLiveSkippedBytes:          parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.live_skipped_bytes"),
+		retainedPruneZombieMarkedBytes:         parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.zombie_marked_bytes"),
+		retainedPruneObservedZombieMarkedBytes: parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.observed_source.bytes_zombie_marked_total"),
+		retainedPruneScheduleForcedRequests:    parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.schedule_forced_requests"),
+		retainedPruneScheduleSkipMinInterval:   parseInt64Stat(stats, "treedb.cache.vlog_retained_prune.schedule_skip.min_interval"),
+		observedGCDeletedBytes:                 parseInt64Stat(stats, "treedb.cache.vlog_generation.observed_gc.source_bytes_deleted_total"),
+		gcProtectedRetainedBytes:               parseInt64Stat(stats, "treedb.cache.vlog_generation.gc.last_protected_retained_bytes"),
+		retainedBytes:                          parseInt64Stat(stats, "treedb.cache.vlog_retained_bytes_estimate"),
+		indexBytes:                             fileSizeBytes(filepath.Join(dir, "maindb", "index.db")),
+		walBytes:                               dirSizeBytes(filepath.Join(dir, "maindb", "wal")),
+		homeBytes:                              dirSizeBytes(dir),
 	}
+
+	backend, cleanup, err := OpenBackend(Options{Dir: dir, ReadOnly: false})
+	if err != nil {
+		return restoreLikeTraceReplayMetrics{}, err
+	}
+	gcStats, gcErr := backend.ValueLogGC(context.Background(), treedbdb.ValueLogGCOptions{})
+	cleanupErr := cleanup()
+	if gcErr != nil {
+		return restoreLikeTraceReplayMetrics{}, gcErr
+	}
+	if cleanupErr != nil {
+		return restoreLikeTraceReplayMetrics{}, cleanupErr
+	}
+	metrics.strictGCEligibleBytes = gcStats.BytesEligible
+	metrics.strictGCDeletedBytes = gcStats.BytesDeleted
+	metrics.strictGCWalBytes = dirSizeBytes(filepath.Join(dir, "maindb", "wal"))
+	metrics.strictGCHomeBytes = dirSizeBytes(dir)
+
+	rewriteStats, err := ValueLogRewriteOffline(Options{Dir: dir})
+	if err != nil {
+		return restoreLikeTraceReplayMetrics{}, err
+	}
+	metrics.offlineRewriteBytesBefore = rewriteStats.BytesBefore
+	metrics.offlineRewriteBytesAfter = rewriteStats.BytesAfter
+	metrics.offlineRewriteWalBytes = dirSizeBytes(filepath.Join(dir, "maindb", "wal"))
+	metrics.offlineRewriteHomeBytes = dirSizeBytes(dir)
+
+	return metrics, nil
 }
 
 func parseInt64Stat(stats map[string]string, key string) int64 {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4360,6 +4360,31 @@ type slabUnsafeToReader interface {
 	ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]byte, bool, error)
 }
 
+const (
+	outerLeafVersionHeaderOffset      = 4
+	outerLeafNestedMinHeaderBytes     = 22
+	outerLeafVersionV1         uint8  = 1
+	outerLeafVersionV2         uint8  = 2
+	outerLeafVersionV3         uint8  = 3
+)
+
+func likelyNestedOuterLeafPayload(raw []byte) bool {
+	if !outerleaf.HasMagic(raw) || len(raw) < outerLeafNestedMinHeaderBytes {
+		return false
+	}
+	switch raw[outerLeafVersionHeaderOffset] {
+	case outerLeafVersionV1, outerLeafVersionV2, outerLeafVersionV3:
+	default:
+		return false
+	}
+	switch raw[outerLeafCodecHeaderOffset] {
+	case outerLeafCodecNoneID, outerLeafCodecSnappyID, outerLeafCodecLZ4ID:
+		return true
+	default:
+		return false
+	}
+}
+
 func collectNestedValueLogLiveIDsFromOuterLeaf(ptr page.ValuePtr, reader tree.SlabReader, live map[uint32]struct{}, scratch *[]byte) error {
 	if len(live) == 0 || reader == nil {
 		return nil
@@ -4383,7 +4408,7 @@ func collectNestedValueLogLiveIDsFromOuterLeaf(ptr page.ValuePtr, reader tree.Sl
 			return err
 		}
 	}
-	if !outerleaf.HasMagic(raw) {
+	if !likelyNestedOuterLeafPayload(raw) {
 		return nil
 	}
 	block, err := outerleaf.DecodeBlockLeaseWithVerify(raw, false)
@@ -17632,7 +17657,7 @@ func (db *DB) armVlogGenerationWALOnSteadyResume(prev MaintenancePhase) {
 }
 
 func (db *DB) scheduleVlogGenerationGCFollowup() bool {
-	if db == nil || db.closing.Load() {
+	if db == nil || db.closing.Load() || db.valueLogGenerationPolicy != uint8(backenddb.ValueLogGenerationHotWarmCold) {
 		return false
 	}
 	db.vlogGenerationGCFollowupPending.Store(true)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4099,6 +4099,16 @@ func (db *DB) valueLogRetainedPaths() []string {
 	return paths
 }
 
+func (db *DB) retainedValueLogPathCount() int {
+	if db == nil {
+		return 0
+	}
+	db.valueLogMu.Lock()
+	count := len(db.valueLogRetain)
+	db.valueLogMu.Unlock()
+	return count
+}
+
 func (db *DB) hasRetainedValueLogPaths() bool {
 	if db == nil {
 		return false
@@ -4395,7 +4405,8 @@ func collectNestedValueLogLiveIDsFromOuterLeaf(ptr page.ValuePtr, reader tree.Sl
 	)
 	if toReader, ok := reader.(slabUnsafeToReader); ok && scratch != nil {
 		var usedDst bool
-		raw, usedDst, err = toReader.ReadUnsafeTo(ptr, *scratch)
+		dst := (*scratch)[:0]
+		raw, usedDst, err = toReader.ReadUnsafeTo(ptr, dst)
 		if err != nil {
 			return err
 		}
@@ -4413,13 +4424,13 @@ func collectNestedValueLogLiveIDsFromOuterLeaf(ptr page.ValuePtr, reader tree.Sl
 	}
 	block, err := outerleaf.DecodeBlockLeaseWithVerify(raw, false)
 	if err != nil {
-		return fmt.Errorf("cachingdb: decode nested outer-leaf block: %w", err)
+		return fmt.Errorf("cachingdb: decode nested outer-leaf block ptr=%+v: %w", ptr, err)
 	}
 	defer block.Release()
 
 	typed, err := block.TypedEntries(nil)
 	if err != nil {
-		return fmt.Errorf("cachingdb: parse nested outer-leaf entries: %w", err)
+		return fmt.Errorf("cachingdb: parse nested outer-leaf entries ptr=%+v: %w", ptr, err)
 	}
 	for i := range typed {
 		if typed[i].Kind != outerleaf.EntryKindBlobRef {
@@ -5335,7 +5346,7 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 		db.retainedPruneActive(),
 		db.retainedPruneObservedSourcePending(),
 		db.valueLogRetainedClosedBytes.Load(),
-		len(db.valueLogRetainedPaths()),
+		db.retainedValueLogPathCount(),
 	)
 	if db.testSkipRetainedPrune {
 		return
@@ -5403,7 +5414,7 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 				effectiveForce,
 				db.retainedPruneObservedSourcePending(),
 				closed,
-				len(db.valueLogRetainedPaths()),
+				db.retainedValueLogPathCount(),
 				db.retainedPrunePressureBytes(),
 			)
 			return
@@ -5451,7 +5462,7 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 			force,
 			effectiveForce,
 			len(observedSourceIDs),
-			len(db.valueLogRetainedPaths()),
+			db.retainedValueLogPathCount(),
 		)
 		pruneStats := db.pruneRetainedValueLogsWithObserved(effectiveForce, observedSourceIDs)
 		db.observeRetainedValueLogPruneStats(pruneStats)
@@ -17624,6 +17635,7 @@ func (db *DB) SetMaintenancePhase(phase MaintenancePhase) {
 	if phase == MaintenancePhaseSteady {
 		db.scheduleDueVlogGenerationDeferredMaintenance()
 		db.schedulePendingVlogGenerationCheckpointKick()
+		db.schedulePendingVlogGenerationGCFollowup()
 	}
 }
 
@@ -17661,6 +17673,9 @@ func (db *DB) scheduleVlogGenerationGCFollowup() bool {
 		return false
 	}
 	db.vlogGenerationGCFollowupPending.Store(true)
+	if db.suppressBackgroundVlogGenerationForMaintenancePhase() {
+		return false
+	}
 	if !db.vlogGenerationGCFollowupRunning.CompareAndSwap(false, true) {
 		return false
 	}
@@ -17682,6 +17697,16 @@ func (db *DB) scheduleVlogGenerationGCFollowup() bool {
 		}
 	}()
 	return true
+}
+
+func (db *DB) schedulePendingVlogGenerationGCFollowup() {
+	if db == nil || db.closing.Load() {
+		return
+	}
+	if !db.vlogGenerationGCFollowupPending.Load() {
+		return
+	}
+	db.scheduleVlogGenerationGCFollowup()
 }
 
 func (db *DB) scheduleVlogGenerationWALOnSteadyResume() bool {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4252,13 +4252,13 @@ func (db *DB) collectValueLogLiveIDsUntil(lastWrite int64) (map[uint32]struct{},
 				leafCtx, leafCancel := db.foregroundWriteResumeContext(lastWrite, 0)
 				defer leafCancel()
 				if state.RootPageID != 0 {
-					if err := db.collectIteratorValueLogLiveIDsUntil(tree.New(p, reader, state.RootPageID).IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection}), live, lastWrite); err != nil {
+					if err := db.collectIteratorValueLogLiveIDsUntil(tree.New(p, reader, state.RootPageID).IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection}), reader, live, lastWrite); err != nil {
 						_ = snap.Close()
 						return nil, err
 					}
 				}
 				if state.SystemRootPageID != 0 {
-					if err := db.collectIteratorValueLogLiveIDsUntil(tree.New(p, reader, state.SystemRootPageID).IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection}), live, lastWrite); err != nil {
+					if err := db.collectIteratorValueLogLiveIDsUntil(tree.New(p, reader, state.SystemRootPageID).IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection}), reader, live, lastWrite); err != nil {
 						_ = snap.Close()
 						return nil, err
 					}
@@ -4305,7 +4305,7 @@ func (db *DB) collectValueLogLiveIDsUntil(lastWrite int64) (map[uint32]struct{},
 	if err != nil {
 		return nil, err
 	}
-	if err := db.collectIteratorValueLogLiveIDsUntil(it, live, lastWrite); err != nil {
+	if err := db.collectIteratorValueLogLiveIDsUntil(it, db.valueLogReader, live, lastWrite); err != nil {
 		return nil, err
 	}
 
@@ -4313,16 +4313,15 @@ func (db *DB) collectValueLogLiveIDsUntil(lastWrite int64) (map[uint32]struct{},
 }
 
 func (db *DB) collectIteratorValueLogLiveIDs(it iterator.UnsafeIterator, live map[uint32]struct{}) error {
-	return db.collectIteratorValueLogLiveIDsUntil(it, live, 0)
+	return db.collectIteratorValueLogLiveIDsUntil(it, db.valueLogReader, live, 0)
 }
 
-func (db *DB) collectIteratorValueLogLiveIDsUntil(it iterator.UnsafeIterator, live map[uint32]struct{}, lastWrite int64) error {
+func (db *DB) collectIteratorValueLogLiveIDsUntil(it iterator.UnsafeIterator, reader tree.SlabReader, live map[uint32]struct{}, lastWrite int64) error {
 	if it == nil {
 		return nil
 	}
 	defer it.Close()
 	seen := 0
-	var outerLeafReadScratch []byte
 	for it.Valid() {
 		if seen > 0 && seen&foregroundWriteResumeCheckMask == 0 && db.foregroundWritesResumedSince(lastWrite) {
 			return errForegroundWritesResumed
@@ -4330,7 +4329,7 @@ func (db *DB) collectIteratorValueLogLiveIDsUntil(it iterator.UnsafeIterator, li
 		_, ptr, flags := it.UnsafeEntry()
 		if flags&node.FlagPointer != 0 && page.IsValueLogFileID(ptr.FileID) {
 			live[ptr.FileID] = struct{}{}
-			if err := db.collectNestedValueLogLiveIDsFromOuterLeaf(ptr, live, &outerLeafReadScratch); err != nil {
+			if err := collectNestedValueLogLiveIDsFromOuterLeaf(ptr, reader, live); err != nil {
 				return err
 			}
 		}
@@ -4346,36 +4345,13 @@ func (db *DB) collectIteratorValueLogLiveIDsUntil(it iterator.UnsafeIterator, li
 	return nil
 }
 
-const nestedOuterLeafReadScratchDefaultCap = 64 << 10
-
-func (db *DB) collectNestedValueLogLiveIDsFromOuterLeaf(ptr page.ValuePtr, live map[uint32]struct{}, readScratch *[]byte) error {
-	if db == nil || len(live) == 0 || db.valueLogReader == nil {
+func collectNestedValueLogLiveIDsFromOuterLeaf(ptr page.ValuePtr, reader tree.SlabReader, live map[uint32]struct{}) error {
+	if len(live) == 0 || reader == nil {
 		return nil
 	}
-	var (
-		raw []byte
-		err error
-	)
-	if readScratch != nil {
-		dst := *readScratch
-		if dst == nil {
-			dst = make([]byte, 0, nestedOuterLeafReadScratchDefaultCap)
-		} else {
-			dst = dst[:0]
-		}
-		var usedDst bool
-		raw, usedDst, err = db.valueLogReader.ReadUnsafeTo(ptr, dst)
-		if err != nil {
-			return err
-		}
-		if usedDst {
-			*readScratch = raw[:0]
-		}
-	} else {
-		raw, err = db.valueLogReader.Read(ptr)
-		if err != nil {
-			return err
-		}
+	raw, err := reader.ReadUnsafe(ptr)
+	if err != nil {
+		return err
 	}
 	if !outerleaf.HasMagic(raw) {
 		return nil
@@ -4595,6 +4571,14 @@ func (db *DB) observeRetainedValueLogPruneStats(pruneStats retainedValueLogPrune
 	if pruneStats.ZombieMarkedBytes > 0 {
 		db.retainedValueLogPruneZombieMarkedBytes.Add(uint64(pruneStats.ZombieMarkedBytes))
 	}
+}
+
+func retainedValueLogPruneNeedsObservedSourceGCRetry(pruneStats retainedValueLogPruneStats) bool {
+	return pruneStats.ObservedSourceZombieMarkedSegments > 0 || pruneStats.ObservedSourceRemovedSegments > 0
+}
+
+func retainedValueLogPruneNeedsGCFollowup(pruneStats retainedValueLogPruneStats) bool {
+	return pruneStats.ZombieMarkedSegments > 0 || pruneStats.RemovedSegments > 0
 }
 
 func (db *DB) valueLogClosedSegmentSize(path string) int64 {
@@ -4976,15 +4960,15 @@ func (db *DB) shouldScheduleRetainedValueLogPruneWithForce(force bool) bool {
 	if db == nil || !db.valueLogEnabled() {
 		return false
 	}
-	closed := db.valueLogRetainedClosedBytes.Load()
 	if force && db.retainedPruneObservedSourcePending() {
 		return true
 	}
+	if force {
+		return len(db.valueLogRetainedPaths()) > 0
+	}
+	closed := db.valueLogRetainedClosedBytes.Load()
 	if closed <= 0 {
 		return false
-	}
-	if force {
-		return true
 	}
 	return closed >= db.retainedPrunePressureBytes()
 }
@@ -5290,6 +5274,14 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 		db.retainedPruneForceRequested.Store(true)
 		db.retainedValueLogPruneScheduleForcedRequests.Add(1)
 	}
+	db.debugVlogMaintf(
+		"retained_prune_schedule_request force=%t active=%t observed_pending=%t closed_bytes=%d retained_paths=%d",
+		force,
+		db.retainedPruneActive(),
+		db.retainedPruneObservedSourcePending(),
+		db.valueLogRetainedClosedBytes.Load(),
+		len(db.valueLogRetainedPaths()),
+	)
 	if db.testSkipRetainedPrune {
 		return
 	}
@@ -5297,12 +5289,14 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 	if db.closing.Load() {
 		db.retainedValueLogPruneScheduleSkipClosing.Add(1)
 		db.retainedPruneMu.Unlock()
+		db.debugVlogMaintf("retained_prune_schedule_skip reason=closing force=%t", force)
 		return
 	}
 	if db.retainedPruneDone != nil {
 		inFlightDone := db.retainedPruneDone
 		db.retainedValueLogPruneScheduleSkipInFlight.Add(1)
 		db.retainedPruneMu.Unlock()
+		db.debugVlogMaintf("retained_prune_schedule_skip reason=inflight force=%t", force)
 		if force && inFlightDone != nil {
 			// Force requests that arrive while a prune is in-flight should get a
 			// follow-up attempt immediately after the active prune exits.
@@ -5334,8 +5328,12 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 		}()
 		requestedForce := db.retainedPruneForceRequested.Swap(false)
 		effectiveForce := force || requestedForce
+		bypassMinInterval := effectiveForce
 		if !effectiveForce {
 			effectiveForce = db.waitForRetainedValueLogPruneQuietOrForce(retainedPruneQuietWindow)
+			if effectiveForce {
+				bypassMinInterval = true
+			}
 		}
 		if !db.shouldScheduleRetainedValueLogPruneWithForce(effectiveForce) {
 			closed := db.valueLogRetainedClosedBytes.Load()
@@ -5344,6 +5342,15 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 			} else if !effectiveForce && closed < db.retainedPrunePressureBytes() {
 				db.retainedValueLogPruneScheduleSkipBelowPressure.Add(1)
 			}
+			db.debugVlogMaintf(
+				"retained_prune_schedule_skip reason=eligibility force=%t effective_force=%t observed_pending=%t closed_bytes=%d retained_paths=%d pressure_bytes=%d",
+				force,
+				effectiveForce,
+				db.retainedPruneObservedSourcePending(),
+				closed,
+				len(db.valueLogRetainedPaths()),
+				db.retainedPrunePressureBytes(),
+			)
 			return
 		}
 		// Retained prune is opportunistic reclaim; do not compete with checkpoint
@@ -5363,8 +5370,15 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 			minInterval = retainedPruneObservedMinInterval
 		}
 		last := db.retainedPruneLastStartUnixNano.Load()
-		if last > 0 && now.Sub(time.Unix(0, last)) < minInterval {
+		if !bypassMinInterval && last > 0 && now.Sub(time.Unix(0, last)) < minInterval {
 			db.retainedValueLogPruneScheduleSkipMinInterval.Add(1)
+			db.debugVlogMaintf(
+				"retained_prune_schedule_skip reason=min_interval force=%t effective_force=%t since_last_ms=%d min_interval_ms=%d",
+				force,
+				effectiveForce,
+				now.Sub(time.Unix(0, last)).Milliseconds(),
+				minInterval.Milliseconds(),
+			)
 			return
 		}
 		db.retainedPruneLastStartUnixNano.Store(now.UnixNano())
@@ -5377,13 +5391,32 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 		if len(observedSourceIDs) > 0 {
 			defer db.retainedPruneObservedSourceActive.Store(false)
 		}
+		db.debugVlogMaintf(
+			"retained_prune_run force=%t effective_force=%t observed_ids=%d retained_paths=%d",
+			force,
+			effectiveForce,
+			len(observedSourceIDs),
+			len(db.valueLogRetainedPaths()),
+		)
 		pruneStats := db.pruneRetainedValueLogsWithObserved(effectiveForce, observedSourceIDs)
 		db.observeRetainedValueLogPruneStats(pruneStats)
-		if len(observedSourceIDs) > 0 && (pruneStats.ObservedSourceZombieMarkedSegments > 0 || pruneStats.ObservedSourceRemovedSegments > 0) {
+		db.debugVlogMaintf(
+			"retained_prune_done force=%t effective_force=%t observed_ids=%d removed_bytes=%d zombie_marked_bytes=%d live_skipped_bytes=%d",
+			force,
+			effectiveForce,
+			len(observedSourceIDs),
+			pruneStats.RemovedBytes,
+			pruneStats.ZombieMarkedBytes,
+			pruneStats.LiveSkippedBytes,
+		)
+		if len(observedSourceIDs) > 0 && retainedValueLogPruneNeedsObservedSourceGCRetry(pruneStats) {
 			// When a retained prune processes rewrite-observed source segments,
 			// queue a near-term maintenance pass so GC can re-check reclaim state.
 			db.queueVlogGenerationObservedSourceGCIDs(observedSourceIDs)
 			db.vlogGenerationCheckpointKickPending.Store(true)
+		}
+		if retainedValueLogPruneNeedsGCFollowup(pruneStats) {
+			db.scheduleVlogGenerationGCFollowup()
 		}
 	}()
 }
@@ -6472,6 +6505,7 @@ type DB struct {
 	vlogGenerationCheckpointKickPending                          atomic.Bool
 	vlogGenerationCheckpointKickHotNoDebtWakeRunning             atomic.Bool
 	vlogGenerationWALOnSteadyResumeActive                        atomic.Bool
+	vlogGenerationGCFollowupRunning                              atomic.Bool
 	vlogGenerationDeferredMaintenancePending                     atomic.Bool
 	vlogGenerationDeferredMaintenanceRunning                     atomic.Bool
 	vlogGenerationRewriteQueuePending                            atomic.Bool
@@ -9447,6 +9481,7 @@ const (
 	vlogGenerationMaintenanceSourceCheckpointPending
 	vlogGenerationMaintenanceSourceWALOnSteadyResume
 	vlogGenerationMaintenanceSourceRewriteQueuePending
+	vlogGenerationMaintenanceSourceRewriteGCFollowup
 	vlogGenerationMaintenanceSourceRewriteAgeBlocked
 	vlogGenerationMaintenanceSourceRewriteStageConfirm
 	vlogGenerationMaintenanceSourceOther
@@ -9466,6 +9501,8 @@ func vlogGenerationMaintenanceSourceIndex(source string) int {
 		return vlogGenerationMaintenanceSourceWALOnSteadyResume
 	case "rewrite_queue_pending":
 		return vlogGenerationMaintenanceSourceRewriteQueuePending
+	case "rewrite_gc_followup":
+		return vlogGenerationMaintenanceSourceRewriteGCFollowup
 	case "rewrite_age_blocked", "rewrite_age_blocked_exit":
 		return vlogGenerationMaintenanceSourceRewriteAgeBlocked
 	case "rewrite_stage_confirm", "rewrite_stage_confirm_exit":
@@ -9487,6 +9524,8 @@ func vlogGenerationMaintenanceSourceLabel(idx int) string {
 		return "wal_on_steady_resume"
 	case vlogGenerationMaintenanceSourceRewriteQueuePending:
 		return "rewrite_queue_pending"
+	case vlogGenerationMaintenanceSourceRewriteGCFollowup:
+		return "rewrite_gc_followup"
 	case vlogGenerationMaintenanceSourceRewriteAgeBlocked:
 		return "rewrite_age_blocked"
 	case vlogGenerationMaintenanceSourceRewriteStageConfirm:
@@ -15048,6 +15087,10 @@ func vlogGenerationIsQueueSource(opts vlogGenerationMaintenanceOptions) bool {
 	return opts.debugSource == "rewrite_queue_pending"
 }
 
+func vlogGenerationIsGCFollowupSource(opts vlogGenerationMaintenanceOptions) bool {
+	return opts.debugSource == "rewrite_gc_followup"
+}
+
 func vlogGenerationIsAgeBlockedSource(opts vlogGenerationMaintenanceOptions) bool {
 	return opts.debugSource == "rewrite_age_blocked" || opts.debugSource == "rewrite_age_blocked_exit"
 }
@@ -15130,7 +15173,7 @@ func (db *DB) startVlogGenerationRewriteQueueMaintenance(opts vlogGenerationMain
 			if qerr == nil && serr == nil && (len(rewriteQueue) == 0 || stagePending) {
 				continue
 			}
-			db.runVlogGenerationMaintenanceRetries(opts, vlogGenerationDeferredRetryWindow, true)
+			db.runVlogGenerationMaintenanceRetries(false, opts, vlogGenerationDeferredRetryWindow, true)
 		}
 	}()
 }
@@ -15174,7 +15217,7 @@ func (db *DB) startVlogGenerationDeferredMaintenance(opts vlogGenerationMaintena
 			if !db.vlogGenerationDeferredMaintenancePending.CompareAndSwap(true, false) {
 				return
 			}
-			db.runVlogGenerationMaintenanceRetries(opts, vlogGenerationDeferredRetryWindow, true)
+			db.runVlogGenerationMaintenanceRetries(false, opts, vlogGenerationDeferredRetryWindow, true)
 		}
 	}()
 }
@@ -15236,10 +15279,14 @@ func (db *DB) scheduleVlogGenerationCheckpointKickHotNoDebtWake() {
 }
 
 func (db *DB) runVlogGenerationCheckpointKickRetries(opts vlogGenerationMaintenanceOptions) {
-	db.runVlogGenerationMaintenanceRetries(opts, vlogGenerationCheckpointKickRetryWindow, true)
+	db.runVlogGenerationMaintenanceRetries(false, opts, vlogGenerationCheckpointKickRetryWindow, true)
 }
 
-func (db *DB) runVlogGenerationMaintenanceRetries(opts vlogGenerationMaintenanceOptions, retryWindow time.Duration, stopWhenAcquired bool) {
+func (db *DB) runVlogGenerationGCFollowupRetries(opts vlogGenerationMaintenanceOptions) {
+	db.runVlogGenerationMaintenanceRetries(true, opts, vlogGenerationCheckpointKickRetryWindow, true)
+}
+
+func (db *DB) runVlogGenerationMaintenanceRetries(runGC bool, opts vlogGenerationMaintenanceOptions, retryWindow time.Duration, stopWhenAcquired bool) {
 	if db == nil || db.closing.Load() {
 		return
 	}
@@ -15260,7 +15307,7 @@ func (db *DB) runVlogGenerationMaintenanceRetries(opts vlogGenerationMaintenance
 	deadline := time.Now().Add(retryWindow)
 	sleepDelay := 10 * time.Millisecond
 	preservePendingIntent := func() {
-		if vlogGenerationIsQueueSource(opts) {
+		if vlogGenerationIsQueueSource(opts) || vlogGenerationIsGCFollowupSource(opts) {
 			db.vlogGenerationRewriteQueuePending.Store(true)
 			return
 		}
@@ -15316,7 +15363,7 @@ func (db *DB) runVlogGenerationMaintenanceRetries(opts vlogGenerationMaintenance
 		// prioritizes rewrite debt progress. Keep periodic/full-scan GC on the
 		// normal scheduler path to avoid introducing long full-scan stalls on hot
 		// checkpoint-triggered retries.
-		ran := db.maybeRunVlogGenerationMaintenanceWithOptions(false, attemptOpts)
+		ran := db.maybeRunVlogGenerationMaintenanceWithOptions(runGC, attemptOpts)
 		if stopWhenAcquired && ran {
 			if opts.debugSource != "" {
 				db.debugVlogMaintf(
@@ -15610,7 +15657,7 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 		return
 	}
 	hasExecutableRewriteQueue := len(rewriteQueueEligible) > 0 && !stagePending && !rewriteQueueFollowupBlocked
-	if hasExecutableRewriteQueue && !vlogGenerationIsQueueSource(opts) && !vlogGenerationIsStageConfirmSource(opts) {
+	if hasExecutableRewriteQueue && !vlogGenerationIsQueueSource(opts) && !vlogGenerationIsGCFollowupSource(opts) && !vlogGenerationIsStageConfirmSource(opts) {
 		db.vlogGenerationRewriteQueuePending.Store(true)
 		db.vlogGenerationMaintenanceSkipPriority.Add(1)
 		return
@@ -15736,6 +15783,10 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 		if hasExecutableRewriteQueue {
 			db.vlogGenerationRewriteQueuedDebtSkipQuiet.Add(1)
 		}
+		shouldRewrite = false
+		reason = vlogGenerationReasonNone
+	}
+	if runGC && vlogGenerationIsGCFollowupSource(opts) {
 		shouldRewrite = false
 		reason = vlogGenerationReasonNone
 	}
@@ -16821,6 +16872,20 @@ planned:
 			if effectiveBytesBefore > effectiveBytesAfter {
 				db.vlogGenerationRewriteReclaimedBytes.Add(uint64(effectiveBytesBefore - effectiveBytesAfter))
 			}
+			remainingRewriteQueueLoaded := false
+			var remainingRewriteQueue []uint32
+			loadRemainingRewriteQueue := func() ([]uint32, error) {
+				if remainingRewriteQueueLoaded {
+					return remainingRewriteQueue, nil
+				}
+				queue, err := db.currentVlogGenerationRewriteQueue()
+				if err != nil {
+					return nil, err
+				}
+				remainingRewriteQueue = queue
+				remainingRewriteQueueLoaded = true
+				return remainingRewriteQueue, nil
+			}
 			queuedDebtExecuted := hadRewriteQueue && len(processedRewriteIDs) > 0
 			if queuedDebtExecuted {
 				db.vlogGenerationRewriteQueuedDebtExecRuns.Add(1)
@@ -16905,8 +16970,17 @@ planned:
 			if locallyEffectiveProcessedDebt {
 				if effectiveBytesAfter >= effectiveBytesBefore {
 					db.vlogGenerationRewriteNoReclaimRuns.Add(1)
+					if gcBytesDeleted == 0 {
+						db.scheduleVlogGenerationGCFollowup()
+					}
 					if !queuedDebtExecuted {
-						db.vlogGenerationRewriteIneffectiveLastNS.Store(time.Now().UnixNano())
+						remainingQueue, queueErr := loadRemainingRewriteQueue()
+						if queueErr != nil {
+							return fmt.Errorf("load generational rewrite queue after locally effective rewrite: %w", queueErr)
+						}
+						if len(remainingQueue) == 0 {
+							db.vlogGenerationRewriteIneffectiveLastNS.Store(time.Now().UnixNano())
+						}
 					}
 					if processedLedgerStaleBytes > 0 {
 						db.vlogGenerationRewriteNoReclaimStaleBytes.Add(uint64(processedLedgerStaleBytes))
@@ -16927,7 +17001,7 @@ planned:
 			}
 			suppressQueuedFollowup := false
 			if queuedDebtExecuted {
-				remainingQueue, queueErr := db.currentVlogGenerationRewriteQueue()
+				remainingQueue, queueErr := loadRemainingRewriteQueue()
 				if queueErr != nil {
 					return fmt.Errorf("load generational rewrite queue after queued execution: %w", queueErr)
 				}
@@ -17259,7 +17333,7 @@ planned:
 	lastGC := db.vlogGenerationLastGCUnixNano.Load()
 	if lastGC > 0 {
 		lastAt := time.Unix(0, lastGC)
-		if !forceObservedSourceGC && now.Sub(lastAt) < vlogGenerationGCMinInterval {
+		if !forceObservedSourceGC && !vlogGenerationIsGCFollowupSource(opts) && now.Sub(lastAt) < vlogGenerationGCMinInterval {
 			db.debugVlogMaintf(
 				"gc_skip reason=min_interval run_gc=%t force_observed=%t observed_ids=%d since_ms=%.3f min_ms=%.3f",
 				runGC,
@@ -17366,7 +17440,7 @@ planned:
 		} else {
 			db.vlogGenerationLastGCNoopUnixNano.Store(0)
 		}
-		if gcStats.BytesProtectedRetained > 0 && gcStats.BytesEligible == 0 && db.valueLogRetainedClosedBytes.Load() > 0 {
+		if gcStats.BytesProtectedRetained > 0 && gcStats.BytesEligible == 0 {
 			// When GC classifies all reclaim blockers as retained-path protection,
 			// trigger an eager retained prune pass to release stale lifecycle pins.
 			if forceObservedSourceGC {
@@ -17520,6 +17594,31 @@ func (db *DB) armVlogGenerationWALOnSteadyResume(prev MaintenancePhase) {
 		return
 	}
 	db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Store(vlogGenerationWALOnSteadyResumeAttempts)
+}
+
+func (db *DB) scheduleVlogGenerationGCFollowup() bool {
+	if db == nil || db.closing.Load() {
+		return false
+	}
+	if !db.vlogGenerationGCFollowupRunning.CompareAndSwap(false, true) {
+		return false
+	}
+	db.wg.Add(1)
+	go func() {
+		defer db.wg.Done()
+		defer db.vlogGenerationGCFollowupRunning.Store(false)
+		if db.closing.Load() {
+			return
+		}
+		db.runVlogGenerationGCFollowupRetries(vlogGenerationMaintenanceOptions{
+			bypassQuiet:           true,
+			skipRetainedPruneWait: true,
+			skipCheckpoint:        false,
+			rewriteDebtDrain:      true,
+			debugSource:           "rewrite_gc_followup",
+		})
+	}()
+	return true
 }
 
 func (db *DB) scheduleVlogGenerationWALOnSteadyResume() bool {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4099,6 +4099,16 @@ func (db *DB) valueLogRetainedPaths() []string {
 	return paths
 }
 
+func (db *DB) hasRetainedValueLogPaths() bool {
+	if db == nil {
+		return false
+	}
+	db.valueLogMu.Lock()
+	hasRetained := len(db.valueLogRetain) > 0
+	db.valueLogMu.Unlock()
+	return hasRetained
+}
+
 // ValueLogRetainedPaths returns a best-effort snapshot of retained value-log
 // segment paths currently pinned by cached-mode pointer lifecycle tracking.
 func (db *DB) ValueLogRetainedPaths() []string {
@@ -4322,6 +4332,7 @@ func (db *DB) collectIteratorValueLogLiveIDsUntil(it iterator.UnsafeIterator, re
 	}
 	defer it.Close()
 	seen := 0
+	var outerLeafScratch []byte
 	for it.Valid() {
 		if seen > 0 && seen&foregroundWriteResumeCheckMask == 0 && db.foregroundWritesResumedSince(lastWrite) {
 			return errForegroundWritesResumed
@@ -4329,7 +4340,7 @@ func (db *DB) collectIteratorValueLogLiveIDsUntil(it iterator.UnsafeIterator, re
 		_, ptr, flags := it.UnsafeEntry()
 		if flags&node.FlagPointer != 0 && page.IsValueLogFileID(ptr.FileID) {
 			live[ptr.FileID] = struct{}{}
-			if err := collectNestedValueLogLiveIDsFromOuterLeaf(ptr, reader, live); err != nil {
+			if err := collectNestedValueLogLiveIDsFromOuterLeaf(ptr, reader, live, &outerLeafScratch); err != nil {
 				return err
 			}
 		}
@@ -4345,26 +4356,45 @@ func (db *DB) collectIteratorValueLogLiveIDsUntil(it iterator.UnsafeIterator, re
 	return nil
 }
 
-func collectNestedValueLogLiveIDsFromOuterLeaf(ptr page.ValuePtr, reader tree.SlabReader, live map[uint32]struct{}) error {
+type slabUnsafeToReader interface {
+	ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]byte, bool, error)
+}
+
+func collectNestedValueLogLiveIDsFromOuterLeaf(ptr page.ValuePtr, reader tree.SlabReader, live map[uint32]struct{}, scratch *[]byte) error {
 	if len(live) == 0 || reader == nil {
 		return nil
 	}
-	raw, err := reader.ReadUnsafe(ptr)
-	if err != nil {
-		return err
+	var (
+		raw []byte
+		err error
+	)
+	if toReader, ok := reader.(slabUnsafeToReader); ok && scratch != nil {
+		var usedDst bool
+		raw, usedDst, err = toReader.ReadUnsafeTo(ptr, *scratch)
+		if err != nil {
+			return err
+		}
+		if usedDst {
+			*scratch = raw[:0]
+		}
+	} else {
+		raw, err = reader.ReadUnsafe(ptr)
+		if err != nil {
+			return err
+		}
 	}
 	if !outerleaf.HasMagic(raw) {
 		return nil
 	}
 	block, err := outerleaf.DecodeBlockLeaseWithVerify(raw, false)
 	if err != nil {
-		return nil
+		return fmt.Errorf("cachingdb: decode nested outer-leaf block: %w", err)
 	}
 	defer block.Release()
 
 	typed, err := block.TypedEntries(nil)
 	if err != nil {
-		return nil
+		return fmt.Errorf("cachingdb: parse nested outer-leaf entries: %w", err)
 	}
 	for i := range typed {
 		if typed[i].Kind != outerleaf.EntryKindBlobRef {
@@ -4964,7 +4994,7 @@ func (db *DB) shouldScheduleRetainedValueLogPruneWithForce(force bool) bool {
 		return true
 	}
 	if force {
-		return len(db.valueLogRetainedPaths()) > 0
+		return db.hasRetainedValueLogPaths()
 	}
 	closed := db.valueLogRetainedClosedBytes.Load()
 	if closed <= 0 {
@@ -6505,6 +6535,7 @@ type DB struct {
 	vlogGenerationCheckpointKickPending                          atomic.Bool
 	vlogGenerationCheckpointKickHotNoDebtWakeRunning             atomic.Bool
 	vlogGenerationWALOnSteadyResumeActive                        atomic.Bool
+	vlogGenerationGCFollowupPending                              atomic.Bool
 	vlogGenerationGCFollowupRunning                              atomic.Bool
 	vlogGenerationDeferredMaintenancePending                     atomic.Bool
 	vlogGenerationDeferredMaintenanceRunning                     atomic.Bool
@@ -15307,8 +15338,12 @@ func (db *DB) runVlogGenerationMaintenanceRetries(runGC bool, opts vlogGeneratio
 	deadline := time.Now().Add(retryWindow)
 	sleepDelay := 10 * time.Millisecond
 	preservePendingIntent := func() {
-		if vlogGenerationIsQueueSource(opts) || vlogGenerationIsGCFollowupSource(opts) {
+		if vlogGenerationIsQueueSource(opts) {
 			db.vlogGenerationRewriteQueuePending.Store(true)
+			return
+		}
+		if vlogGenerationIsGCFollowupSource(opts) {
+			db.vlogGenerationGCFollowupPending.Store(true)
 			return
 		}
 		if !stopWhenAcquired || !opts.bypassQuiet || opts.skipCheckpoint {
@@ -17600,6 +17635,7 @@ func (db *DB) scheduleVlogGenerationGCFollowup() bool {
 	if db == nil || db.closing.Load() {
 		return false
 	}
+	db.vlogGenerationGCFollowupPending.Store(true)
 	if !db.vlogGenerationGCFollowupRunning.CompareAndSwap(false, true) {
 		return false
 	}
@@ -17607,16 +17643,18 @@ func (db *DB) scheduleVlogGenerationGCFollowup() bool {
 	go func() {
 		defer db.wg.Done()
 		defer db.vlogGenerationGCFollowupRunning.Store(false)
-		if db.closing.Load() {
-			return
+		for !db.closing.Load() {
+			if !db.vlogGenerationGCFollowupPending.CompareAndSwap(true, false) {
+				return
+			}
+			db.runVlogGenerationGCFollowupRetries(vlogGenerationMaintenanceOptions{
+				bypassQuiet:           true,
+				skipRetainedPruneWait: true,
+				skipCheckpoint:        false,
+				rewriteDebtDrain:      true,
+				debugSource:           "rewrite_gc_followup",
+			})
 		}
-		db.runVlogGenerationGCFollowupRetries(vlogGenerationMaintenanceOptions{
-			bypassQuiet:           true,
-			skipRetainedPruneWait: true,
-			skipCheckpoint:        false,
-			rewriteDebtDrain:      true,
-			debugSource:           "rewrite_gc_followup",
-		})
 	}()
 	return true
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -17633,6 +17633,12 @@ func (db *DB) SetMaintenancePhase(phase MaintenancePhase) {
 	}
 	db.armVlogGenerationWALOnSteadyResume(prev)
 	if phase == MaintenancePhaseSteady {
+		if !envBool(envDisableVlogGenerationCheckpointKick) && db.scheduleVlogGenerationWALOnSteadyResume() {
+			db.debugVlogMaintf(
+				"steady_resume_schedule remaining_attempts=%d",
+				db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Load(),
+			)
+		}
 		db.scheduleDueVlogGenerationDeferredMaintenance()
 		db.schedulePendingVlogGenerationCheckpointKick()
 		db.schedulePendingVlogGenerationGCFollowup()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4252,13 +4252,13 @@ func (db *DB) collectValueLogLiveIDsUntil(lastWrite int64) (map[uint32]struct{},
 				leafCtx, leafCancel := db.foregroundWriteResumeContext(lastWrite, 0)
 				defer leafCancel()
 				if state.RootPageID != 0 {
-					if err := db.collectIteratorValueLogLiveIDsUntil(tree.New(p, reader, state.RootPageID).IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection}), live, lastWrite); err != nil {
+					if err := db.collectIteratorValueLogLiveIDsUntil(tree.New(p, reader, state.RootPageID).IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection}), reader, live, lastWrite); err != nil {
 						_ = snap.Close()
 						return nil, err
 					}
 				}
 				if state.SystemRootPageID != 0 {
-					if err := db.collectIteratorValueLogLiveIDsUntil(tree.New(p, reader, state.SystemRootPageID).IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection}), live, lastWrite); err != nil {
+					if err := db.collectIteratorValueLogLiveIDsUntil(tree.New(p, reader, state.SystemRootPageID).IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection}), reader, live, lastWrite); err != nil {
 						_ = snap.Close()
 						return nil, err
 					}
@@ -4305,7 +4305,7 @@ func (db *DB) collectValueLogLiveIDsUntil(lastWrite int64) (map[uint32]struct{},
 	if err != nil {
 		return nil, err
 	}
-	if err := db.collectIteratorValueLogLiveIDsUntil(it, live, lastWrite); err != nil {
+	if err := db.collectIteratorValueLogLiveIDsUntil(it, db.valueLogReader, live, lastWrite); err != nil {
 		return nil, err
 	}
 
@@ -4313,16 +4313,15 @@ func (db *DB) collectValueLogLiveIDsUntil(lastWrite int64) (map[uint32]struct{},
 }
 
 func (db *DB) collectIteratorValueLogLiveIDs(it iterator.UnsafeIterator, live map[uint32]struct{}) error {
-	return db.collectIteratorValueLogLiveIDsUntil(it, live, 0)
+	return db.collectIteratorValueLogLiveIDsUntil(it, db.valueLogReader, live, 0)
 }
 
-func (db *DB) collectIteratorValueLogLiveIDsUntil(it iterator.UnsafeIterator, live map[uint32]struct{}, lastWrite int64) error {
+func (db *DB) collectIteratorValueLogLiveIDsUntil(it iterator.UnsafeIterator, reader tree.SlabReader, live map[uint32]struct{}, lastWrite int64) error {
 	if it == nil {
 		return nil
 	}
 	defer it.Close()
 	seen := 0
-	var outerLeafReadScratch []byte
 	for it.Valid() {
 		if seen > 0 && seen&foregroundWriteResumeCheckMask == 0 && db.foregroundWritesResumedSince(lastWrite) {
 			return errForegroundWritesResumed
@@ -4330,7 +4329,7 @@ func (db *DB) collectIteratorValueLogLiveIDsUntil(it iterator.UnsafeIterator, li
 		_, ptr, flags := it.UnsafeEntry()
 		if flags&node.FlagPointer != 0 && page.IsValueLogFileID(ptr.FileID) {
 			live[ptr.FileID] = struct{}{}
-			if err := db.collectNestedValueLogLiveIDsFromOuterLeaf(ptr, live, &outerLeafReadScratch); err != nil {
+			if err := collectNestedValueLogLiveIDsFromOuterLeaf(ptr, reader, live); err != nil {
 				return err
 			}
 		}
@@ -4346,36 +4345,13 @@ func (db *DB) collectIteratorValueLogLiveIDsUntil(it iterator.UnsafeIterator, li
 	return nil
 }
 
-const nestedOuterLeafReadScratchDefaultCap = 64 << 10
-
-func (db *DB) collectNestedValueLogLiveIDsFromOuterLeaf(ptr page.ValuePtr, live map[uint32]struct{}, readScratch *[]byte) error {
-	if db == nil || len(live) == 0 || db.valueLogReader == nil {
+func collectNestedValueLogLiveIDsFromOuterLeaf(ptr page.ValuePtr, reader tree.SlabReader, live map[uint32]struct{}) error {
+	if len(live) == 0 || reader == nil {
 		return nil
 	}
-	var (
-		raw []byte
-		err error
-	)
-	if readScratch != nil {
-		dst := *readScratch
-		if dst == nil {
-			dst = make([]byte, 0, nestedOuterLeafReadScratchDefaultCap)
-		} else {
-			dst = dst[:0]
-		}
-		var usedDst bool
-		raw, usedDst, err = db.valueLogReader.ReadUnsafeTo(ptr, dst)
-		if err != nil {
-			return err
-		}
-		if usedDst {
-			*readScratch = raw[:0]
-		}
-	} else {
-		raw, err = db.valueLogReader.Read(ptr)
-		if err != nil {
-			return err
-		}
+	raw, err := reader.ReadUnsafe(ptr)
+	if err != nil {
+		return err
 	}
 	if !outerleaf.HasMagic(raw) {
 		return nil
@@ -4595,6 +4571,14 @@ func (db *DB) observeRetainedValueLogPruneStats(pruneStats retainedValueLogPrune
 	if pruneStats.ZombieMarkedBytes > 0 {
 		db.retainedValueLogPruneZombieMarkedBytes.Add(uint64(pruneStats.ZombieMarkedBytes))
 	}
+}
+
+func retainedValueLogPruneNeedsObservedSourceGCRetry(pruneStats retainedValueLogPruneStats) bool {
+	return pruneStats.ObservedSourceZombieMarkedSegments > 0 || pruneStats.ObservedSourceRemovedSegments > 0
+}
+
+func retainedValueLogPruneNeedsGCFollowup(pruneStats retainedValueLogPruneStats) bool {
+	return pruneStats.ZombieMarkedSegments > 0 || pruneStats.RemovedSegments > 0
 }
 
 func (db *DB) valueLogClosedSegmentSize(path string) int64 {
@@ -4976,15 +4960,15 @@ func (db *DB) shouldScheduleRetainedValueLogPruneWithForce(force bool) bool {
 	if db == nil || !db.valueLogEnabled() {
 		return false
 	}
-	closed := db.valueLogRetainedClosedBytes.Load()
 	if force && db.retainedPruneObservedSourcePending() {
 		return true
 	}
+	if force {
+		return len(db.valueLogRetainedPaths()) > 0
+	}
+	closed := db.valueLogRetainedClosedBytes.Load()
 	if closed <= 0 {
 		return false
-	}
-	if force {
-		return true
 	}
 	return closed >= db.retainedPrunePressureBytes()
 }
@@ -5274,6 +5258,14 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 		db.retainedPruneForceRequested.Store(true)
 		db.retainedValueLogPruneScheduleForcedRequests.Add(1)
 	}
+	db.debugVlogMaintf(
+		"retained_prune_schedule_request force=%t active=%t observed_pending=%t closed_bytes=%d retained_paths=%d",
+		force,
+		db.retainedPruneActive(),
+		db.retainedPruneObservedSourcePending(),
+		db.valueLogRetainedClosedBytes.Load(),
+		len(db.valueLogRetainedPaths()),
+	)
 	if db.testSkipRetainedPrune {
 		return
 	}
@@ -5281,12 +5273,14 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 	if db.closing.Load() {
 		db.retainedValueLogPruneScheduleSkipClosing.Add(1)
 		db.retainedPruneMu.Unlock()
+		db.debugVlogMaintf("retained_prune_schedule_skip reason=closing force=%t", force)
 		return
 	}
 	if db.retainedPruneDone != nil {
 		inFlightDone := db.retainedPruneDone
 		db.retainedValueLogPruneScheduleSkipInFlight.Add(1)
 		db.retainedPruneMu.Unlock()
+		db.debugVlogMaintf("retained_prune_schedule_skip reason=inflight force=%t", force)
 		if force && inFlightDone != nil {
 			// Force requests that arrive while a prune is in-flight should get a
 			// follow-up attempt immediately after the active prune exits.
@@ -5318,8 +5312,12 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 		}()
 		requestedForce := db.retainedPruneForceRequested.Swap(false)
 		effectiveForce := force || requestedForce
+		bypassMinInterval := effectiveForce
 		if !effectiveForce {
 			effectiveForce = db.waitForRetainedValueLogPruneQuietOrForce(retainedPruneQuietWindow)
+			if effectiveForce {
+				bypassMinInterval = true
+			}
 		}
 		if !db.shouldScheduleRetainedValueLogPruneWithForce(effectiveForce) {
 			closed := db.valueLogRetainedClosedBytes.Load()
@@ -5328,6 +5326,15 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 			} else if !effectiveForce && closed < db.retainedPrunePressureBytes() {
 				db.retainedValueLogPruneScheduleSkipBelowPressure.Add(1)
 			}
+			db.debugVlogMaintf(
+				"retained_prune_schedule_skip reason=eligibility force=%t effective_force=%t observed_pending=%t closed_bytes=%d retained_paths=%d pressure_bytes=%d",
+				force,
+				effectiveForce,
+				db.retainedPruneObservedSourcePending(),
+				closed,
+				len(db.valueLogRetainedPaths()),
+				db.retainedPrunePressureBytes(),
+			)
 			return
 		}
 		// Retained prune is opportunistic reclaim; do not compete with checkpoint
@@ -5347,8 +5354,15 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 			minInterval = retainedPruneObservedMinInterval
 		}
 		last := db.retainedPruneLastStartUnixNano.Load()
-		if last > 0 && now.Sub(time.Unix(0, last)) < minInterval {
+		if !bypassMinInterval && last > 0 && now.Sub(time.Unix(0, last)) < minInterval {
 			db.retainedValueLogPruneScheduleSkipMinInterval.Add(1)
+			db.debugVlogMaintf(
+				"retained_prune_schedule_skip reason=min_interval force=%t effective_force=%t since_last_ms=%d min_interval_ms=%d",
+				force,
+				effectiveForce,
+				now.Sub(time.Unix(0, last)).Milliseconds(),
+				minInterval.Milliseconds(),
+			)
 			return
 		}
 		db.retainedPruneLastStartUnixNano.Store(now.UnixNano())
@@ -5358,13 +5372,32 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 		}
 		db.retainedValueLogPruneLastUnixNano.Store(now.UnixNano())
 		observedSourceIDs := db.takeRetainedPruneObservedSourceIDs()
+		db.debugVlogMaintf(
+			"retained_prune_run force=%t effective_force=%t observed_ids=%d retained_paths=%d",
+			force,
+			effectiveForce,
+			len(observedSourceIDs),
+			len(db.valueLogRetainedPaths()),
+		)
 		pruneStats := db.pruneRetainedValueLogsWithObserved(effectiveForce, observedSourceIDs)
 		db.observeRetainedValueLogPruneStats(pruneStats)
-		if len(observedSourceIDs) > 0 && (pruneStats.ObservedSourceZombieMarkedSegments > 0 || pruneStats.ObservedSourceRemovedSegments > 0) {
+		db.debugVlogMaintf(
+			"retained_prune_done force=%t effective_force=%t observed_ids=%d removed_bytes=%d zombie_marked_bytes=%d live_skipped_bytes=%d",
+			force,
+			effectiveForce,
+			len(observedSourceIDs),
+			pruneStats.RemovedBytes,
+			pruneStats.ZombieMarkedBytes,
+			pruneStats.LiveSkippedBytes,
+		)
+		if len(observedSourceIDs) > 0 && retainedValueLogPruneNeedsObservedSourceGCRetry(pruneStats) {
 			// When a retained prune processes rewrite-observed source segments,
 			// queue a near-term maintenance pass so GC can re-check reclaim state.
 			db.queueVlogGenerationObservedSourceGCIDs(observedSourceIDs)
 			db.vlogGenerationCheckpointKickPending.Store(true)
+		}
+		if retainedValueLogPruneNeedsGCFollowup(pruneStats) {
+			db.scheduleVlogGenerationGCFollowup()
 		}
 	}()
 }
@@ -6445,6 +6478,7 @@ type DB struct {
 	vlogGenerationCheckpointKickPending                          atomic.Bool
 	vlogGenerationCheckpointKickHotNoDebtWakeRunning             atomic.Bool
 	vlogGenerationWALOnSteadyResumeActive                        atomic.Bool
+	vlogGenerationGCFollowupRunning                              atomic.Bool
 	vlogGenerationDeferredMaintenancePending                     atomic.Bool
 	vlogGenerationDeferredMaintenanceRunning                     atomic.Bool
 	vlogGenerationRewriteQueuePending                            atomic.Bool
@@ -9420,6 +9454,7 @@ const (
 	vlogGenerationMaintenanceSourceCheckpointPending
 	vlogGenerationMaintenanceSourceWALOnSteadyResume
 	vlogGenerationMaintenanceSourceRewriteQueuePending
+	vlogGenerationMaintenanceSourceRewriteGCFollowup
 	vlogGenerationMaintenanceSourceRewriteAgeBlocked
 	vlogGenerationMaintenanceSourceRewriteStageConfirm
 	vlogGenerationMaintenanceSourceOther
@@ -9439,6 +9474,8 @@ func vlogGenerationMaintenanceSourceIndex(source string) int {
 		return vlogGenerationMaintenanceSourceWALOnSteadyResume
 	case "rewrite_queue_pending":
 		return vlogGenerationMaintenanceSourceRewriteQueuePending
+	case "rewrite_gc_followup":
+		return vlogGenerationMaintenanceSourceRewriteGCFollowup
 	case "rewrite_age_blocked", "rewrite_age_blocked_exit":
 		return vlogGenerationMaintenanceSourceRewriteAgeBlocked
 	case "rewrite_stage_confirm", "rewrite_stage_confirm_exit":
@@ -9460,6 +9497,8 @@ func vlogGenerationMaintenanceSourceLabel(idx int) string {
 		return "wal_on_steady_resume"
 	case vlogGenerationMaintenanceSourceRewriteQueuePending:
 		return "rewrite_queue_pending"
+	case vlogGenerationMaintenanceSourceRewriteGCFollowup:
+		return "rewrite_gc_followup"
 	case vlogGenerationMaintenanceSourceRewriteAgeBlocked:
 		return "rewrite_age_blocked"
 	case vlogGenerationMaintenanceSourceRewriteStageConfirm:
@@ -15021,6 +15060,10 @@ func vlogGenerationIsQueueSource(opts vlogGenerationMaintenanceOptions) bool {
 	return opts.debugSource == "rewrite_queue_pending"
 }
 
+func vlogGenerationIsGCFollowupSource(opts vlogGenerationMaintenanceOptions) bool {
+	return opts.debugSource == "rewrite_gc_followup"
+}
+
 func vlogGenerationIsAgeBlockedSource(opts vlogGenerationMaintenanceOptions) bool {
 	return opts.debugSource == "rewrite_age_blocked" || opts.debugSource == "rewrite_age_blocked_exit"
 }
@@ -15103,7 +15146,7 @@ func (db *DB) startVlogGenerationRewriteQueueMaintenance(opts vlogGenerationMain
 			if qerr == nil && serr == nil && (len(rewriteQueue) == 0 || stagePending) {
 				continue
 			}
-			db.runVlogGenerationMaintenanceRetries(opts, vlogGenerationDeferredRetryWindow, true)
+			db.runVlogGenerationMaintenanceRetries(false, opts, vlogGenerationDeferredRetryWindow, true)
 		}
 	}()
 }
@@ -15147,7 +15190,7 @@ func (db *DB) startVlogGenerationDeferredMaintenance(opts vlogGenerationMaintena
 			if !db.vlogGenerationDeferredMaintenancePending.CompareAndSwap(true, false) {
 				return
 			}
-			db.runVlogGenerationMaintenanceRetries(opts, vlogGenerationDeferredRetryWindow, true)
+			db.runVlogGenerationMaintenanceRetries(false, opts, vlogGenerationDeferredRetryWindow, true)
 		}
 	}()
 }
@@ -15209,10 +15252,14 @@ func (db *DB) scheduleVlogGenerationCheckpointKickHotNoDebtWake() {
 }
 
 func (db *DB) runVlogGenerationCheckpointKickRetries(opts vlogGenerationMaintenanceOptions) {
-	db.runVlogGenerationMaintenanceRetries(opts, vlogGenerationCheckpointKickRetryWindow, true)
+	db.runVlogGenerationMaintenanceRetries(false, opts, vlogGenerationCheckpointKickRetryWindow, true)
 }
 
-func (db *DB) runVlogGenerationMaintenanceRetries(opts vlogGenerationMaintenanceOptions, retryWindow time.Duration, stopWhenAcquired bool) {
+func (db *DB) runVlogGenerationGCFollowupRetries(opts vlogGenerationMaintenanceOptions) {
+	db.runVlogGenerationMaintenanceRetries(true, opts, vlogGenerationCheckpointKickRetryWindow, true)
+}
+
+func (db *DB) runVlogGenerationMaintenanceRetries(runGC bool, opts vlogGenerationMaintenanceOptions, retryWindow time.Duration, stopWhenAcquired bool) {
 	if db == nil || db.closing.Load() {
 		return
 	}
@@ -15233,7 +15280,7 @@ func (db *DB) runVlogGenerationMaintenanceRetries(opts vlogGenerationMaintenance
 	deadline := time.Now().Add(retryWindow)
 	sleepDelay := 10 * time.Millisecond
 	preservePendingIntent := func() {
-		if vlogGenerationIsQueueSource(opts) {
+		if vlogGenerationIsQueueSource(opts) || vlogGenerationIsGCFollowupSource(opts) {
 			db.vlogGenerationRewriteQueuePending.Store(true)
 			return
 		}
@@ -15289,7 +15336,7 @@ func (db *DB) runVlogGenerationMaintenanceRetries(opts vlogGenerationMaintenance
 		// prioritizes rewrite debt progress. Keep periodic/full-scan GC on the
 		// normal scheduler path to avoid introducing long full-scan stalls on hot
 		// checkpoint-triggered retries.
-		ran := db.maybeRunVlogGenerationMaintenanceWithOptions(false, attemptOpts)
+		ran := db.maybeRunVlogGenerationMaintenanceWithOptions(runGC, attemptOpts)
 		if stopWhenAcquired && ran {
 			if opts.debugSource != "" {
 				db.debugVlogMaintf(
@@ -15583,7 +15630,7 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 		return
 	}
 	hasExecutableRewriteQueue := len(rewriteQueueEligible) > 0 && !stagePending && !rewriteQueueFollowupBlocked
-	if hasExecutableRewriteQueue && !vlogGenerationIsQueueSource(opts) && !vlogGenerationIsStageConfirmSource(opts) {
+	if hasExecutableRewriteQueue && !vlogGenerationIsQueueSource(opts) && !vlogGenerationIsGCFollowupSource(opts) && !vlogGenerationIsStageConfirmSource(opts) {
 		db.vlogGenerationRewriteQueuePending.Store(true)
 		db.vlogGenerationMaintenanceSkipPriority.Add(1)
 		return
@@ -15709,6 +15756,10 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 		if hasExecutableRewriteQueue {
 			db.vlogGenerationRewriteQueuedDebtSkipQuiet.Add(1)
 		}
+		shouldRewrite = false
+		reason = vlogGenerationReasonNone
+	}
+	if runGC && vlogGenerationIsGCFollowupSource(opts) {
 		shouldRewrite = false
 		reason = vlogGenerationReasonNone
 	}
@@ -16794,6 +16845,20 @@ planned:
 			if effectiveBytesBefore > effectiveBytesAfter {
 				db.vlogGenerationRewriteReclaimedBytes.Add(uint64(effectiveBytesBefore - effectiveBytesAfter))
 			}
+			remainingRewriteQueueLoaded := false
+			var remainingRewriteQueue []uint32
+			loadRemainingRewriteQueue := func() ([]uint32, error) {
+				if remainingRewriteQueueLoaded {
+					return remainingRewriteQueue, nil
+				}
+				queue, err := db.currentVlogGenerationRewriteQueue()
+				if err != nil {
+					return nil, err
+				}
+				remainingRewriteQueue = queue
+				remainingRewriteQueueLoaded = true
+				return remainingRewriteQueue, nil
+			}
 			queuedDebtExecuted := hadRewriteQueue && len(processedRewriteIDs) > 0
 			if queuedDebtExecuted {
 				db.vlogGenerationRewriteQueuedDebtExecRuns.Add(1)
@@ -16878,8 +16943,17 @@ planned:
 			if locallyEffectiveProcessedDebt {
 				if effectiveBytesAfter >= effectiveBytesBefore {
 					db.vlogGenerationRewriteNoReclaimRuns.Add(1)
+					if gcBytesDeleted == 0 {
+						db.scheduleVlogGenerationGCFollowup()
+					}
 					if !queuedDebtExecuted {
-						db.vlogGenerationRewriteIneffectiveLastNS.Store(time.Now().UnixNano())
+						remainingQueue, queueErr := loadRemainingRewriteQueue()
+						if queueErr != nil {
+							return fmt.Errorf("load generational rewrite queue after locally effective rewrite: %w", queueErr)
+						}
+						if len(remainingQueue) == 0 {
+							db.vlogGenerationRewriteIneffectiveLastNS.Store(time.Now().UnixNano())
+						}
 					}
 					if processedLedgerStaleBytes > 0 {
 						db.vlogGenerationRewriteNoReclaimStaleBytes.Add(uint64(processedLedgerStaleBytes))
@@ -16900,7 +16974,7 @@ planned:
 			}
 			suppressQueuedFollowup := false
 			if queuedDebtExecuted {
-				remainingQueue, queueErr := db.currentVlogGenerationRewriteQueue()
+				remainingQueue, queueErr := loadRemainingRewriteQueue()
 				if queueErr != nil {
 					return fmt.Errorf("load generational rewrite queue after queued execution: %w", queueErr)
 				}
@@ -17232,7 +17306,7 @@ planned:
 	lastGC := db.vlogGenerationLastGCUnixNano.Load()
 	if lastGC > 0 {
 		lastAt := time.Unix(0, lastGC)
-		if !forceObservedSourceGC && now.Sub(lastAt) < vlogGenerationGCMinInterval {
+		if !forceObservedSourceGC && !vlogGenerationIsGCFollowupSource(opts) && now.Sub(lastAt) < vlogGenerationGCMinInterval {
 			db.debugVlogMaintf(
 				"gc_skip reason=min_interval run_gc=%t force_observed=%t observed_ids=%d since_ms=%.3f min_ms=%.3f",
 				runGC,
@@ -17339,7 +17413,7 @@ planned:
 		} else {
 			db.vlogGenerationLastGCNoopUnixNano.Store(0)
 		}
-		if gcStats.BytesProtectedRetained > 0 && gcStats.BytesEligible == 0 && db.valueLogRetainedClosedBytes.Load() > 0 {
+		if gcStats.BytesProtectedRetained > 0 && gcStats.BytesEligible == 0 {
 			// When GC classifies all reclaim blockers as retained-path protection,
 			// trigger an eager retained prune pass to release stale lifecycle pins.
 			if forceObservedSourceGC {
@@ -17493,6 +17567,31 @@ func (db *DB) armVlogGenerationWALOnSteadyResume(prev MaintenancePhase) {
 		return
 	}
 	db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Store(vlogGenerationWALOnSteadyResumeAttempts)
+}
+
+func (db *DB) scheduleVlogGenerationGCFollowup() bool {
+	if db == nil || db.closing.Load() {
+		return false
+	}
+	if !db.vlogGenerationGCFollowupRunning.CompareAndSwap(false, true) {
+		return false
+	}
+	db.wg.Add(1)
+	go func() {
+		defer db.wg.Done()
+		defer db.vlogGenerationGCFollowupRunning.Store(false)
+		if db.closing.Load() {
+			return
+		}
+		db.runVlogGenerationGCFollowupRetries(vlogGenerationMaintenanceOptions{
+			bypassQuiet:           true,
+			skipRetainedPruneWait: true,
+			skipCheckpoint:        false,
+			rewriteDebtDrain:      true,
+			debugSource:           "rewrite_gc_followup",
+		})
+	}()
+	return true
 }
 
 func (db *DB) scheduleVlogGenerationWALOnSteadyResume() bool {

--- a/TreeDB/caching/leafref_live_ids_test.go
+++ b/TreeDB/caching/leafref_live_ids_test.go
@@ -5,11 +5,19 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/snissn/gomap/TreeDB/internal/outerleaf"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
 type errorSlabReader struct{}
 type errorPageGetter struct{}
+type trackedOuterLeafReader struct {
+	raw   []byte
+	useTo bool
+
+	readUnsafeCalls   int
+	readUnsafeToCalls int
+}
 
 func (errorPageGetter) Get(pageID uint64) ([]byte, error) {
 	return nil, errors.New("unexpected Get call")
@@ -21,6 +29,42 @@ func (errorSlabReader) Read(ptr page.ValuePtr) ([]byte, error) {
 
 func (errorSlabReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
 	return nil, errors.New("unexpected ReadUnsafe call")
+}
+
+func (r *trackedOuterLeafReader) Read(ptr page.ValuePtr) ([]byte, error) {
+	return r.ReadUnsafe(ptr)
+}
+
+func (r *trackedOuterLeafReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
+	r.readUnsafeCalls++
+	return append([]byte(nil), r.raw...), nil
+}
+
+func (r *trackedOuterLeafReader) ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]byte, bool, error) {
+	r.readUnsafeToCalls++
+	if !r.useTo {
+		return append([]byte(nil), r.raw...), false, nil
+	}
+	if cap(dst) < len(r.raw) {
+		dst = make([]byte, len(r.raw))
+	} else {
+		dst = dst[:len(r.raw)]
+	}
+	copy(dst, r.raw)
+	return dst, true, nil
+}
+
+func encodeOuterLeafBlobRefForTest(t *testing.T, ptr page.ValuePtr) []byte {
+	t.Helper()
+	raw, err := outerleaf.EncodeTypedEntries(nil, []outerleaf.TypedEntry{{
+		Key:     []byte("blob"),
+		Kind:    outerleaf.EntryKindBlobRef,
+		BlobPtr: ptr,
+	}}, 0, 2)
+	if err != nil {
+		t.Fatalf("EncodeTypedEntries: %v", err)
+	}
+	return raw
 }
 
 func TestCollectLeafRefValueLogLiveIDs_RespectsCanceledContext(t *testing.T) {
@@ -54,5 +98,42 @@ func TestShouldCheckLeafRefCancellation(t *testing.T) {
 		if got := shouldCheckLeafRefCancellation(tc.i); got != tc.want {
 			t.Fatalf("shouldCheckLeafRefCancellation(%d)=%v want %v", tc.i, got, tc.want)
 		}
+	}
+}
+
+func TestCollectNestedValueLogLiveIDsFromOuterLeaf_PrefersReadUnsafeTo(t *testing.T) {
+	reader := &trackedOuterLeafReader{
+		raw:   encodeOuterLeafBlobRefForTest(t, page.ValuePtr{FileID: page.ValueLogFileID(2), Offset: 17, Length: 9}),
+		useTo: true,
+	}
+	live := map[uint32]struct{}{
+		page.ValueLogFileID(1): {},
+	}
+	var scratch []byte
+
+	if err := collectNestedValueLogLiveIDsFromOuterLeaf(page.ValuePtr{FileID: page.ValueLogFileID(1)}, reader, live, &scratch); err != nil {
+		t.Fatalf("collectNestedValueLogLiveIDsFromOuterLeaf: %v", err)
+	}
+	if _, ok := live[page.ValueLogFileID(2)]; !ok {
+		t.Fatalf("nested blob ref was not collected: live=%v", live)
+	}
+	if reader.readUnsafeToCalls != 1 {
+		t.Fatalf("ReadUnsafeTo calls=%d want 1", reader.readUnsafeToCalls)
+	}
+	if reader.readUnsafeCalls != 0 {
+		t.Fatalf("ReadUnsafe calls=%d want 0", reader.readUnsafeCalls)
+	}
+}
+
+func TestCollectNestedValueLogLiveIDsFromOuterLeaf_PropagatesDecodeError(t *testing.T) {
+	raw := encodeOuterLeafBlobRefForTest(t, page.ValuePtr{FileID: page.ValueLogFileID(2), Offset: 17, Length: 9})
+	reader := &trackedOuterLeafReader{raw: raw[:len(raw)/2]}
+	live := map[uint32]struct{}{
+		page.ValueLogFileID(1): {},
+	}
+	var scratch []byte
+
+	if err := collectNestedValueLogLiveIDsFromOuterLeaf(page.ValuePtr{FileID: page.ValueLogFileID(1)}, reader, live, &scratch); err == nil {
+		t.Fatal("expected decode error for truncated outer-leaf payload")
 	}
 }

--- a/TreeDB/caching/leafref_live_ids_test.go
+++ b/TreeDB/caching/leafref_live_ids_test.go
@@ -137,3 +137,18 @@ func TestCollectNestedValueLogLiveIDsFromOuterLeaf_PropagatesDecodeError(t *test
 		t.Fatal("expected decode error for truncated outer-leaf payload")
 	}
 }
+
+func TestCollectNestedValueLogLiveIDsFromOuterLeaf_IgnoresMagicPrefixNonOuterLeafPayload(t *testing.T) {
+	reader := &trackedOuterLeafReader{raw: append([]byte("TOL2"), []byte("not-an-outer-leaf-payload")...)}
+	live := map[uint32]struct{}{
+		page.ValueLogFileID(1): {},
+	}
+	var scratch []byte
+
+	if err := collectNestedValueLogLiveIDsFromOuterLeaf(page.ValuePtr{FileID: page.ValueLogFileID(1)}, reader, live, &scratch); err != nil {
+		t.Fatalf("collectNestedValueLogLiveIDsFromOuterLeaf err=%v want nil", err)
+	}
+	if len(live) != 1 {
+		t.Fatalf("live=%v want unchanged", live)
+	}
+}

--- a/TreeDB/caching/vlog_generation_checkpoint_kick_walon_test.go
+++ b/TreeDB/caching/vlog_generation_checkpoint_kick_walon_test.go
@@ -102,11 +102,6 @@ func TestVlogGenerationCheckpointKick_WALOnSteadyResumeRunsBoundedMaintenance(t 
 
 	db.SetMaintenancePhase(MaintenancePhaseRestore)
 	db.SetMaintenancePhase(MaintenancePhaseSteady)
-	if got := db.vlogGenerationWALOnSteadyResumeRemainingAttempts.Load(); got != vlogGenerationWALOnSteadyResumeAttempts {
-		t.Fatalf("steady resume remaining=%d want %d", got, vlogGenerationWALOnSteadyResumeAttempts)
-	}
-
-	db.maybeKickVlogGenerationMaintenanceAfterCheckpoint()
 
 	deadline := time.Now().Add(2 * schedulerTestWait(t))
 	for {
@@ -201,7 +196,6 @@ func TestVlogGenerationCheckpointKick_WALOnSteadyResumeIsBounded(t *testing.T) {
 	db.SetMaintenancePhase(MaintenancePhaseCatchUp)
 	db.SetMaintenancePhase(MaintenancePhaseSteady)
 
-	db.maybeKickVlogGenerationMaintenanceAfterCheckpoint()
 	deadline := time.Now().Add(2 * schedulerTestWait(t))
 	for {
 		if got := db.vlogGenerationWALOnSteadyResumeAttempts.Load(); got >= 1 {

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -795,7 +795,7 @@ func TestRunVlogGenerationMaintenanceRetries_CoalescesPendingCollisionRetries(t 
 
 	db.vlogGenerationMaintenanceActive.Store(true)
 	db.vlogGenerationCheckpointKickPending.Store(true)
-	db.runVlogGenerationMaintenanceRetries(vlogGenerationMaintenanceOptions{
+	db.runVlogGenerationMaintenanceRetries(false, vlogGenerationMaintenanceOptions{
 		bypassQuiet:           true,
 		skipRetainedPruneWait: true,
 		skipCheckpoint:        false,
@@ -808,7 +808,7 @@ func TestRunVlogGenerationMaintenanceRetries_CoalescesPendingCollisionRetries(t 
 
 	db.vlogGenerationMaintenanceActive.Store(true)
 	db.vlogGenerationCheckpointKickPending.Store(false)
-	db.runVlogGenerationMaintenanceRetries(vlogGenerationMaintenanceOptions{
+	db.runVlogGenerationMaintenanceRetries(false, vlogGenerationMaintenanceOptions{
 		bypassQuiet:           true,
 		skipRetainedPruneWait: true,
 		skipCheckpoint:        false,
@@ -821,7 +821,7 @@ func TestRunVlogGenerationMaintenanceRetries_CoalescesPendingCollisionRetries(t 
 
 	db.vlogGenerationMaintenanceActive.Store(true)
 	db.vlogGenerationDeferredMaintenancePending.Store(true)
-	db.runVlogGenerationMaintenanceRetries(vlogGenerationMaintenanceOptions{
+	db.runVlogGenerationMaintenanceRetries(false, vlogGenerationMaintenanceOptions{
 		bypassQuiet:           true,
 		skipRetainedPruneWait: true,
 		skipCheckpoint:        false,
@@ -4939,6 +4939,86 @@ func TestVlogGenerationRewrite_DoesNotCoolProcessedDebtWhenLocalStaleWasRewritte
 	if got := stats["treedb.cache.vlog_generation.rewrite.ineffective_runs"]; got != "0" {
 		t.Fatalf("ineffective runs=%q want 0 for locally effective rewrite", got)
 	}
+	if got := db.vlogGenerationRewriteIneffectiveLastNS.Load(); got != 0 {
+		t.Fatalf("ineffective last ts=%d want 0 for locally effective rewrite with remaining debt", got)
+	}
+}
+
+func TestVlogGenerationRewrite_QueuedFollowupRunsAfterLocallyEffectiveFreshPlan(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+
+	dir := t.TempDir()
+
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB: backend,
+		planResponse: backenddb.ValueLogRewritePlan{
+			SourceFileIDs: []uint32{11, 22},
+			SelectedSegments: []backenddb.ValueLogRewritePlanSegment{
+				{FileID: 11, BytesTotal: 64 << 20, BytesLive: 8 << 20, BytesStale: 56 << 20, StaleRatio: 0.875},
+				{FileID: 22, BytesTotal: 64 << 20, BytesLive: 8 << 20, BytesStale: 56 << 20, StaleRatio: 0.875},
+			},
+			SelectedBytesTotal: 128 << 20,
+			SelectedBytesLive:  16 << 20,
+			SelectedBytesStale: 112 << 20,
+		},
+		rewriteResponse: backenddb.ValueLogRewriteStats{
+			BytesBefore:   64 << 20,
+			BytesAfter:    (64 << 20) + 1,
+			RecordsCopied: 1,
+		},
+	}
+
+	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
+	t.Cleanup(cleanup)
+	forceVlogMaintenanceIdle(db)
+
+	db.maybeRunVlogGenerationMaintenance(false)
+
+	if _, calls := recorder.recordedRewrite(); calls != 1 {
+		t.Fatalf("rewrite calls after fresh-plan pass=%d want 1", calls)
+	}
+	queue, err := db.currentVlogGenerationRewriteQueue()
+	if err != nil {
+		t.Fatalf("current queue after fresh-plan pass: %v", err)
+	}
+	if got, want := queue, []uint32{22}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("queue after fresh-plan pass=%v want=%v", got, want)
+	}
+	if got := db.vlogGenerationRewriteIneffectiveLastNS.Load(); got != 0 {
+		t.Fatalf("ineffective last ts=%d want 0 before queued follow-up", got)
+	}
+
+	db.vlogGenerationLastRewriteUnixNano.Store(0)
+	forceVlogMaintenanceIdle(db)
+	db.maybeRunVlogGenerationMaintenanceWithOptions(false, vlogGenerationMaintenanceOptions{
+		bypassQuiet:           true,
+		skipRetainedPruneWait: true,
+		skipCheckpoint:        false,
+		rewriteDebtDrain:      true,
+		debugSource:           "rewrite_queue_pending",
+	})
+
+	if _, calls := recorder.recordedRewrite(); calls != 2 {
+		t.Fatalf("rewrite calls after queued follow-up=%d want 2", calls)
+	}
+	queue, err = db.currentVlogGenerationRewriteQueue()
+	if err != nil {
+		t.Fatalf("current queue after queued follow-up: %v", err)
+	}
+	if len(queue) != 0 {
+		t.Fatalf("queue after queued follow-up=%v want empty", queue)
+	}
+	stats := db.Stats()
+	if got := stats["treedb.cache.vlog_generation.rewrite.queued_debt.rewrite_started"]; got != "1" {
+		t.Fatalf("queued debt rewrite started=%q want 1", got)
+	}
+	if got := stats["treedb.cache.vlog_generation.rewrite.queued_debt.skip.ineffective_backoff"]; got != "0" {
+		t.Fatalf("queued debt ineffective backoff skips=%q want 0", got)
+	}
 }
 
 func TestVlogGenerationRewrite_KeepsDebtWhenGCOffsetsMaterialGrowth(t *testing.T) {
@@ -6415,6 +6495,182 @@ func TestVlogGenerationRewrite_IneffectiveBackoffCheckpointKickFreshPlanSkips(t 
 	}
 	if _, calls := recorder.recordedRewrite(); calls != 0 {
 		t.Fatalf("rewrite calls with checkpoint-kick ineffective-backoff skip=%d want=0", calls)
+	}
+}
+
+func TestVlogGenerationRewriteGCFollowup_RunsGCWhileQueueBackedOff(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+
+	dir := t.TempDir()
+
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB:         backend,
+		gcResponse: backenddb.ValueLogGCStats{BytesDeleted: 64, SegmentsDeleted: 1},
+	}
+
+	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
+	t.Cleanup(cleanup)
+	skipRetainedPrune(db)
+	if err := db.setVlogGenerationRewriteQueue([]uint32{11}); err != nil {
+		t.Fatalf("seed rewrite queue: %v", err)
+	}
+	db.vlogGenerationLastGCUnixNano.Store(time.Now().UnixNano())
+	db.vlogGenerationRewriteIneffectiveLastNS.Store(time.Now().UnixNano())
+	forceVlogMaintenanceIdle(db)
+
+	db.maybeRunVlogGenerationMaintenanceWithOptions(true, vlogGenerationMaintenanceOptions{
+		bypassQuiet:           true,
+		skipRetainedPruneWait: true,
+		skipCheckpoint:        false,
+		rewriteDebtDrain:      true,
+		debugSource:           "rewrite_gc_followup",
+	})
+
+	if _, calls := recorder.recordedRewrite(); calls != 0 {
+		t.Fatalf("rewrite calls=%d want 0 for gc followup source", calls)
+	}
+	if _, calls := recorder.recordedGC(); calls != 1 {
+		t.Fatalf("gc calls=%d want 1 for gc followup source", calls)
+	}
+	if got := recorder.recordedGCObservedSourceCalls(); got != 0 {
+		t.Fatalf("observed-source gc calls=%d want 0 for gc followup source", got)
+	}
+}
+
+func TestRetainedValueLogPruneNeedsGCRetryHelpers(t *testing.T) {
+	if retainedValueLogPruneNeedsObservedSourceGCRetry(retainedValueLogPruneStats{}) {
+		t.Fatalf("observed-source gc retry helper returned true for empty stats")
+	}
+	if retainedValueLogPruneNeedsGCFollowup(retainedValueLogPruneStats{}) {
+		t.Fatalf("gc followup helper returned true for empty stats")
+	}
+	if !retainedValueLogPruneNeedsObservedSourceGCRetry(retainedValueLogPruneStats{ObservedSourceZombieMarkedSegments: 1}) {
+		t.Fatalf("observed-source gc retry helper did not trigger for zombie-marked observed source")
+	}
+	if !retainedValueLogPruneNeedsObservedSourceGCRetry(retainedValueLogPruneStats{ObservedSourceRemovedSegments: 1}) {
+		t.Fatalf("observed-source gc retry helper did not trigger for removed observed source")
+	}
+	if !retainedValueLogPruneNeedsGCFollowup(retainedValueLogPruneStats{ZombieMarkedSegments: 1}) {
+		t.Fatalf("gc followup helper did not trigger for zombie-marked segments")
+	}
+	if !retainedValueLogPruneNeedsGCFollowup(retainedValueLogPruneStats{RemovedSegments: 1}) {
+		t.Fatalf("gc followup helper did not trigger for removed segments")
+	}
+}
+
+func TestShouldScheduleRetainedValueLogPruneWithForce_UsesRetainedPathsWithoutClosedByteHint(t *testing.T) {
+	db := &DB{
+		valueLogRetain: make(map[string]struct{}),
+	}
+	db.splitValueLog = true
+	db.valueLogRetain["/tmp/commit-l0-000001.vlog"] = struct{}{}
+
+	if !db.shouldScheduleRetainedValueLogPruneWithForce(true) {
+		t.Fatalf("forced retained prune should run when retained paths exist even without closed-byte hint")
+	}
+	if db.shouldScheduleRetainedValueLogPruneWithForce(false) {
+		t.Fatalf("non-forced retained prune should not run without closed-byte hint")
+	}
+}
+
+func TestVlogGenerationGCProtectedRetained_SchedulesForcePruneWithoutClosedByteHint(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+	t.Setenv(envDisableVlogGenerationRewrite, "1")
+
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB:         backend,
+		gcResponse: backenddb.ValueLogGCStats{BytesProtectedRetained: 64},
+	}
+
+	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
+	t.Cleanup(cleanup)
+	skipRetainedPrune(db)
+	forceVlogMaintenanceIdle(db)
+
+	db.maybeRunVlogGenerationMaintenanceWithOptions(true, vlogGenerationMaintenanceOptions{
+		bypassQuiet:           true,
+		skipRetainedPruneWait: true,
+		skipCheckpoint:        true,
+		rewriteDebtDrain:      true,
+		debugSource:           "rewrite_gc_followup",
+	})
+
+	if _, calls := recorder.recordedGC(); calls != 1 {
+		t.Fatalf("gc calls=%d want 1", calls)
+	}
+	if !db.retainedPruneForceRequested.Load() {
+		t.Fatalf("force retained prune not requested for protected-retained gc result without closed-byte hint")
+	}
+}
+
+func TestVlogGenerationRewrite_LocallyEffectiveNoReclaimSchedulesGlobalGCFollowup(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+
+	dir := t.TempDir()
+
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB: backend,
+		planResponse: backenddb.ValueLogRewritePlan{
+			SourceFileIDs: []uint32{11},
+			SelectedSegments: []backenddb.ValueLogRewritePlanSegment{{
+				FileID:     11,
+				BytesTotal: 64,
+				BytesLive:  32,
+				BytesStale: 32,
+				StaleRatio: 0.5,
+			}},
+			SegmentsSelected:   1,
+			SelectedBytesTotal: 64,
+			SelectedBytesLive:  32,
+			SelectedBytesStale: 32,
+		},
+		rewriteResponse: backenddb.ValueLogRewriteStats{
+			BytesBefore:   64,
+			BytesAfter:    64,
+			RecordsCopied: 1,
+		},
+		gcResponses: []backenddb.ValueLogGCStats{
+			{ObservedSourceSegments: 1},
+			{BytesDeleted: 64, SegmentsDeleted: 1},
+		},
+	}
+
+	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
+	t.Cleanup(cleanup)
+	skipRetainedPrune(db)
+	forceVlogMaintenanceIdle(db)
+
+	db.maybeRunVlogGenerationMaintenance(false)
+
+	deadline := time.Now().Add(2 * schedulerTestWait(t))
+	for {
+		if _, calls := recorder.recordedGC(); calls >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			_, gcCalls := recorder.recordedGC()
+			t.Fatalf("gc calls=%d want >=2 after no-reclaim local rewrite", gcCalls)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, calls := recorder.recordedRewrite(); calls != 1 {
+		t.Fatalf("rewrite calls=%d want 1", calls)
+	}
+	if got := recorder.recordedGCObservedSourceCalls(); got != 1 {
+		t.Fatalf("observed-source gc calls=%d want 1", got)
 	}
 }
 

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -833,6 +833,26 @@ func TestRunVlogGenerationMaintenanceRetries_CoalescesPendingCollisionRetries(t 
 	}
 }
 
+func TestRunVlogGenerationMaintenanceRetries_PreservesGCFollowupIntentAtDeadline(t *testing.T) {
+	db := &DB{valueLogGenerationPolicy: uint8(backenddb.ValueLogGenerationHotWarmCold)}
+	db.vlogGenerationMaintenanceActive.Store(true)
+
+	db.runVlogGenerationMaintenanceRetries(true, vlogGenerationMaintenanceOptions{
+		bypassQuiet:           true,
+		skipRetainedPruneWait: true,
+		skipCheckpoint:        false,
+		rewriteDebtDrain:      true,
+		debugSource:           "rewrite_gc_followup",
+	}, 30*time.Millisecond, true)
+
+	if !db.vlogGenerationGCFollowupPending.Load() {
+		t.Fatalf("gc followup intent was not preserved at retry deadline")
+	}
+	if db.vlogGenerationRewriteQueuePending.Load() {
+		t.Fatalf("gc followup retry incorrectly downgraded to rewrite-queue pending")
+	}
+}
+
 func TestVlogGenerationRewriteMinStaleRatioForGenericPass_UsesConfiguredTriggerRatio(t *testing.T) {
 	db := &DB{valueLogRewriteTriggerRatioPPM: 200000}
 	if got, want := db.vlogGenerationRewriteMinStaleRatioForGenericPass(8<<30), 0.85; got != want {

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -853,6 +853,20 @@ func TestRunVlogGenerationMaintenanceRetries_PreservesGCFollowupIntentAtDeadline
 	}
 }
 
+func TestScheduleVlogGenerationGCFollowup_SkipsWhenGenerationPolicyOff(t *testing.T) {
+	db := &DB{valueLogGenerationPolicy: uint8(backenddb.ValueLogGenerationOff)}
+
+	if db.scheduleVlogGenerationGCFollowup() {
+		t.Fatal("scheduleVlogGenerationGCFollowup returned true with generation policy off")
+	}
+	if db.vlogGenerationGCFollowupPending.Load() {
+		t.Fatal("gc followup pending set with generation policy off")
+	}
+	if db.vlogGenerationGCFollowupRunning.Load() {
+		t.Fatal("gc followup running set with generation policy off")
+	}
+}
+
 func TestVlogGenerationRewriteMinStaleRatioForGenericPass_UsesConfiguredTriggerRatio(t *testing.T) {
 	db := &DB{valueLogRewriteTriggerRatioPPM: 200000}
 	if got, want := db.vlogGenerationRewriteMinStaleRatioForGenericPass(8<<30), 0.85; got != want {

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -795,7 +795,7 @@ func TestRunVlogGenerationMaintenanceRetries_CoalescesPendingCollisionRetries(t 
 
 	db.vlogGenerationMaintenanceActive.Store(true)
 	db.vlogGenerationCheckpointKickPending.Store(true)
-	db.runVlogGenerationMaintenanceRetries(vlogGenerationMaintenanceOptions{
+	db.runVlogGenerationMaintenanceRetries(false, vlogGenerationMaintenanceOptions{
 		bypassQuiet:           true,
 		skipRetainedPruneWait: true,
 		skipCheckpoint:        false,
@@ -808,7 +808,7 @@ func TestRunVlogGenerationMaintenanceRetries_CoalescesPendingCollisionRetries(t 
 
 	db.vlogGenerationMaintenanceActive.Store(true)
 	db.vlogGenerationCheckpointKickPending.Store(false)
-	db.runVlogGenerationMaintenanceRetries(vlogGenerationMaintenanceOptions{
+	db.runVlogGenerationMaintenanceRetries(false, vlogGenerationMaintenanceOptions{
 		bypassQuiet:           true,
 		skipRetainedPruneWait: true,
 		skipCheckpoint:        false,
@@ -821,7 +821,7 @@ func TestRunVlogGenerationMaintenanceRetries_CoalescesPendingCollisionRetries(t 
 
 	db.vlogGenerationMaintenanceActive.Store(true)
 	db.vlogGenerationDeferredMaintenancePending.Store(true)
-	db.runVlogGenerationMaintenanceRetries(vlogGenerationMaintenanceOptions{
+	db.runVlogGenerationMaintenanceRetries(false, vlogGenerationMaintenanceOptions{
 		bypassQuiet:           true,
 		skipRetainedPruneWait: true,
 		skipCheckpoint:        false,
@@ -4946,6 +4946,86 @@ func TestVlogGenerationRewrite_DoesNotCoolProcessedDebtWhenLocalStaleWasRewritte
 	if got := stats["treedb.cache.vlog_generation.rewrite.ineffective_runs"]; got != "0" {
 		t.Fatalf("ineffective runs=%q want 0 for locally effective rewrite", got)
 	}
+	if got := db.vlogGenerationRewriteIneffectiveLastNS.Load(); got != 0 {
+		t.Fatalf("ineffective last ts=%d want 0 for locally effective rewrite with remaining debt", got)
+	}
+}
+
+func TestVlogGenerationRewrite_QueuedFollowupRunsAfterLocallyEffectiveFreshPlan(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+
+	dir := t.TempDir()
+
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB: backend,
+		planResponse: backenddb.ValueLogRewritePlan{
+			SourceFileIDs: []uint32{11, 22},
+			SelectedSegments: []backenddb.ValueLogRewritePlanSegment{
+				{FileID: 11, BytesTotal: 64 << 20, BytesLive: 8 << 20, BytesStale: 56 << 20, StaleRatio: 0.875},
+				{FileID: 22, BytesTotal: 64 << 20, BytesLive: 8 << 20, BytesStale: 56 << 20, StaleRatio: 0.875},
+			},
+			SelectedBytesTotal: 128 << 20,
+			SelectedBytesLive:  16 << 20,
+			SelectedBytesStale: 112 << 20,
+		},
+		rewriteResponse: backenddb.ValueLogRewriteStats{
+			BytesBefore:   64 << 20,
+			BytesAfter:    (64 << 20) + 1,
+			RecordsCopied: 1,
+		},
+	}
+
+	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
+	t.Cleanup(cleanup)
+	forceVlogMaintenanceIdle(db)
+
+	db.maybeRunVlogGenerationMaintenance(false)
+
+	if _, calls := recorder.recordedRewrite(); calls != 1 {
+		t.Fatalf("rewrite calls after fresh-plan pass=%d want 1", calls)
+	}
+	queue, err := db.currentVlogGenerationRewriteQueue()
+	if err != nil {
+		t.Fatalf("current queue after fresh-plan pass: %v", err)
+	}
+	if got, want := queue, []uint32{22}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("queue after fresh-plan pass=%v want=%v", got, want)
+	}
+	if got := db.vlogGenerationRewriteIneffectiveLastNS.Load(); got != 0 {
+		t.Fatalf("ineffective last ts=%d want 0 before queued follow-up", got)
+	}
+
+	db.vlogGenerationLastRewriteUnixNano.Store(0)
+	forceVlogMaintenanceIdle(db)
+	db.maybeRunVlogGenerationMaintenanceWithOptions(false, vlogGenerationMaintenanceOptions{
+		bypassQuiet:           true,
+		skipRetainedPruneWait: true,
+		skipCheckpoint:        false,
+		rewriteDebtDrain:      true,
+		debugSource:           "rewrite_queue_pending",
+	})
+
+	if _, calls := recorder.recordedRewrite(); calls != 2 {
+		t.Fatalf("rewrite calls after queued follow-up=%d want 2", calls)
+	}
+	queue, err = db.currentVlogGenerationRewriteQueue()
+	if err != nil {
+		t.Fatalf("current queue after queued follow-up: %v", err)
+	}
+	if len(queue) != 0 {
+		t.Fatalf("queue after queued follow-up=%v want empty", queue)
+	}
+	stats := db.Stats()
+	if got := stats["treedb.cache.vlog_generation.rewrite.queued_debt.rewrite_started"]; got != "1" {
+		t.Fatalf("queued debt rewrite started=%q want 1", got)
+	}
+	if got := stats["treedb.cache.vlog_generation.rewrite.queued_debt.skip.ineffective_backoff"]; got != "0" {
+		t.Fatalf("queued debt ineffective backoff skips=%q want 0", got)
+	}
 }
 
 func TestVlogGenerationRewrite_KeepsDebtWhenGCOffsetsMaterialGrowth(t *testing.T) {
@@ -6422,6 +6502,182 @@ func TestVlogGenerationRewrite_IneffectiveBackoffCheckpointKickFreshPlanSkips(t 
 	}
 	if _, calls := recorder.recordedRewrite(); calls != 0 {
 		t.Fatalf("rewrite calls with checkpoint-kick ineffective-backoff skip=%d want=0", calls)
+	}
+}
+
+func TestVlogGenerationRewriteGCFollowup_RunsGCWhileQueueBackedOff(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+
+	dir := t.TempDir()
+
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB:         backend,
+		gcResponse: backenddb.ValueLogGCStats{BytesDeleted: 64, SegmentsDeleted: 1},
+	}
+
+	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
+	t.Cleanup(cleanup)
+	skipRetainedPrune(db)
+	if err := db.setVlogGenerationRewriteQueue([]uint32{11}); err != nil {
+		t.Fatalf("seed rewrite queue: %v", err)
+	}
+	db.vlogGenerationLastGCUnixNano.Store(time.Now().UnixNano())
+	db.vlogGenerationRewriteIneffectiveLastNS.Store(time.Now().UnixNano())
+	forceVlogMaintenanceIdle(db)
+
+	db.maybeRunVlogGenerationMaintenanceWithOptions(true, vlogGenerationMaintenanceOptions{
+		bypassQuiet:           true,
+		skipRetainedPruneWait: true,
+		skipCheckpoint:        false,
+		rewriteDebtDrain:      true,
+		debugSource:           "rewrite_gc_followup",
+	})
+
+	if _, calls := recorder.recordedRewrite(); calls != 0 {
+		t.Fatalf("rewrite calls=%d want 0 for gc followup source", calls)
+	}
+	if _, calls := recorder.recordedGC(); calls != 1 {
+		t.Fatalf("gc calls=%d want 1 for gc followup source", calls)
+	}
+	if got := recorder.recordedGCObservedSourceCalls(); got != 0 {
+		t.Fatalf("observed-source gc calls=%d want 0 for gc followup source", got)
+	}
+}
+
+func TestRetainedValueLogPruneNeedsGCRetryHelpers(t *testing.T) {
+	if retainedValueLogPruneNeedsObservedSourceGCRetry(retainedValueLogPruneStats{}) {
+		t.Fatalf("observed-source gc retry helper returned true for empty stats")
+	}
+	if retainedValueLogPruneNeedsGCFollowup(retainedValueLogPruneStats{}) {
+		t.Fatalf("gc followup helper returned true for empty stats")
+	}
+	if !retainedValueLogPruneNeedsObservedSourceGCRetry(retainedValueLogPruneStats{ObservedSourceZombieMarkedSegments: 1}) {
+		t.Fatalf("observed-source gc retry helper did not trigger for zombie-marked observed source")
+	}
+	if !retainedValueLogPruneNeedsObservedSourceGCRetry(retainedValueLogPruneStats{ObservedSourceRemovedSegments: 1}) {
+		t.Fatalf("observed-source gc retry helper did not trigger for removed observed source")
+	}
+	if !retainedValueLogPruneNeedsGCFollowup(retainedValueLogPruneStats{ZombieMarkedSegments: 1}) {
+		t.Fatalf("gc followup helper did not trigger for zombie-marked segments")
+	}
+	if !retainedValueLogPruneNeedsGCFollowup(retainedValueLogPruneStats{RemovedSegments: 1}) {
+		t.Fatalf("gc followup helper did not trigger for removed segments")
+	}
+}
+
+func TestShouldScheduleRetainedValueLogPruneWithForce_UsesRetainedPathsWithoutClosedByteHint(t *testing.T) {
+	db := &DB{
+		valueLogRetain: make(map[string]struct{}),
+	}
+	db.splitValueLog = true
+	db.valueLogRetain["/tmp/commit-l0-000001.vlog"] = struct{}{}
+
+	if !db.shouldScheduleRetainedValueLogPruneWithForce(true) {
+		t.Fatalf("forced retained prune should run when retained paths exist even without closed-byte hint")
+	}
+	if db.shouldScheduleRetainedValueLogPruneWithForce(false) {
+		t.Fatalf("non-forced retained prune should not run without closed-byte hint")
+	}
+}
+
+func TestVlogGenerationGCProtectedRetained_SchedulesForcePruneWithoutClosedByteHint(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+	t.Setenv(envDisableVlogGenerationRewrite, "1")
+
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB:         backend,
+		gcResponse: backenddb.ValueLogGCStats{BytesProtectedRetained: 64},
+	}
+
+	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
+	t.Cleanup(cleanup)
+	skipRetainedPrune(db)
+	forceVlogMaintenanceIdle(db)
+
+	db.maybeRunVlogGenerationMaintenanceWithOptions(true, vlogGenerationMaintenanceOptions{
+		bypassQuiet:           true,
+		skipRetainedPruneWait: true,
+		skipCheckpoint:        true,
+		rewriteDebtDrain:      true,
+		debugSource:           "rewrite_gc_followup",
+	})
+
+	if _, calls := recorder.recordedGC(); calls != 1 {
+		t.Fatalf("gc calls=%d want 1", calls)
+	}
+	if !db.retainedPruneForceRequested.Load() {
+		t.Fatalf("force retained prune not requested for protected-retained gc result without closed-byte hint")
+	}
+}
+
+func TestVlogGenerationRewrite_LocallyEffectiveNoReclaimSchedulesGlobalGCFollowup(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+
+	dir := t.TempDir()
+
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB: backend,
+		planResponse: backenddb.ValueLogRewritePlan{
+			SourceFileIDs: []uint32{11},
+			SelectedSegments: []backenddb.ValueLogRewritePlanSegment{{
+				FileID:     11,
+				BytesTotal: 64,
+				BytesLive:  32,
+				BytesStale: 32,
+				StaleRatio: 0.5,
+			}},
+			SegmentsSelected:   1,
+			SelectedBytesTotal: 64,
+			SelectedBytesLive:  32,
+			SelectedBytesStale: 32,
+		},
+		rewriteResponse: backenddb.ValueLogRewriteStats{
+			BytesBefore:   64,
+			BytesAfter:    64,
+			RecordsCopied: 1,
+		},
+		gcResponses: []backenddb.ValueLogGCStats{
+			{ObservedSourceSegments: 1},
+			{BytesDeleted: 64, SegmentsDeleted: 1},
+		},
+	}
+
+	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
+	t.Cleanup(cleanup)
+	skipRetainedPrune(db)
+	forceVlogMaintenanceIdle(db)
+
+	db.maybeRunVlogGenerationMaintenance(false)
+
+	deadline := time.Now().Add(2 * schedulerTestWait(t))
+	for {
+		if _, calls := recorder.recordedGC(); calls >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			_, gcCalls := recorder.recordedGC()
+			t.Fatalf("gc calls=%d want >=2 after no-reclaim local rewrite", gcCalls)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, calls := recorder.recordedRewrite(); calls != 1 {
+		t.Fatalf("rewrite calls=%d want 1", calls)
+	}
+	if got := recorder.recordedGCObservedSourceCalls(); got != 1 {
+		t.Fatalf("observed-source gc calls=%d want 1", got)
 	}
 }
 

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -867,6 +867,52 @@ func TestScheduleVlogGenerationGCFollowup_SkipsWhenGenerationPolicyOff(t *testin
 	}
 }
 
+func TestScheduleVlogGenerationGCFollowup_DefersUntilMaintenancePhaseSteady(t *testing.T) {
+	disableVlogGenerationLoop(t)
+
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB:         backend,
+		gcResponse: backenddb.ValueLogGCStats{BytesDeleted: 64, SegmentsDeleted: 1},
+	}
+
+	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
+	t.Cleanup(cleanup)
+	skipRetainedPrune(db)
+	forceVlogMaintenanceIdle(db)
+
+	db.SetMaintenancePhase(MaintenancePhaseCatchUp)
+	if db.scheduleVlogGenerationGCFollowup() {
+		t.Fatal("scheduleVlogGenerationGCFollowup unexpectedly started during catchup phase")
+	}
+	if !db.vlogGenerationGCFollowupPending.Load() {
+		t.Fatal("gc followup intent not preserved during catchup phase")
+	}
+	if db.vlogGenerationGCFollowupRunning.Load() {
+		t.Fatal("gc followup worker should not run while maintenance phase is non-steady")
+	}
+	if _, calls := recorder.recordedGC(); calls != 0 {
+		t.Fatalf("gc calls=%d want 0 while maintenance phase is non-steady", calls)
+	}
+
+	db.SetMaintenancePhase(MaintenancePhaseSteady)
+	deadline := time.Now().Add(2 * schedulerTestWait(t))
+	for {
+		if _, calls := recorder.recordedGC(); calls >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			_, gcCalls := recorder.recordedGC()
+			t.Fatalf("queued gc followup did not run after returning to steady phase: gcCalls=%d", gcCalls)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestVlogGenerationRewriteMinStaleRatioForGenericPass_UsesConfiguredTriggerRatio(t *testing.T) {
 	db := &DB{valueLogRewriteTriggerRatioPPM: 200000}
 	if got, want := db.vlogGenerationRewriteMinStaleRatioForGenericPass(8<<30), 0.85; got != want {

--- a/docs/benchmarks/CELESTIA_COMPRESSION_LOOP.md
+++ b/docs/benchmarks/CELESTIA_COMPRESSION_LOOP.md
@@ -179,7 +179,8 @@ Notes:
 
 - `runs.csv` now also includes rewrite-capacity counters from diagnostics summaries (plan runs/selection, source segment+byte outcomes, ledger bytes, budget utilization, observed-GC drain pct) so candidate/control behavior can be compared without opening each `run.json`.
 - `pairs.csv` now includes absolute per-pair control/candidate values (`t_sync`, `t_total`, `s_sync_app`, `s_post_wal`, `max_rss_kb`) plus `composite_score_pct` (negative is better).
-- `summary.md` now includes `Absolute Medians` (control vs candidate) in addition to pair deltas.
+- `pairs.csv` now also includes pre-offline storage deltas and absolute values for `s_sync_wal_bytes`, `s_sync_data_bytes`, and `s_sync_home_bytes`.
+- `summary.md` now includes `Absolute Medians` (control vs candidate) in addition to pair deltas, including the pre-offline `data/home/wal` size trio.
 - `decision.json` now includes:
   - `absolute_aggregates` (control/candidate median+mean totals for time, size, and RSS)
   - `composite` configuration echo and aggregate composite score fields
@@ -189,6 +190,7 @@ Notes:
 - `pairs.csv` includes per-pair deltas for those KPIs so control/candidate capacity behavior can be compared without post-processing scripts.
 - `pairs.csv` includes `delta_rewrite_queue_run_segment_cap_limiter_count_checkpoint_kick_burst` so checkpoint-kick burst usage changes are visible at pair level.
 - `runs.csv` now includes checkpoint-like (`bypass` + `checkpoint_pending`) vs non-checkpoint rewrite split metrics, and `pairs.csv` includes deltas for source-efficiency fields such as `delta_rewrite_checkpoint_like_budget_share_pct`.
+- When the launcher is run with `POST_SYNC_DWELL_SECONDS>0`, `t_sync_seconds` remains the true sync duration, `t_total_seconds` includes the post-sync dwell and any offline rewrite time, and the `s_sync_*` size trio is captured after that dwell but before any offline rewrite.
 - To use pre-policy behavior, set `AB_POLICY=legacy`.
 
 ### Segment Granularity Sweep Harness

--- a/scripts/run_celestia_ab.sh
+++ b/scripts/run_celestia_ab.sh
@@ -1876,13 +1876,15 @@ if not maintenance:
         maintenance = maintenance_light_fallback
         maintenance_source = "light_stats_post"
 
-t_sync = safe_int(sync.get("duration_seconds"), max(0, run_end - run_start))
+t_sync = safe_int(sync.get("sync_duration_seconds"), safe_int(sync.get("duration_seconds"), max(0, run_end - run_start)))
+t_run = safe_int(sync.get("total_duration_seconds"), t_sync)
+post_sync_dwell_seconds = safe_int(sync.get("post_sync_dwell_elapsed_seconds"), max(0, t_run - t_sync))
 t_rw = rewrite_seconds if rewrite_attempted == 1 else 0
 resolved_invalid_reason = invalid_reason
 if not resolved_invalid_reason and rewrite_attempted == 1 and rewrite_rc != 0:
     resolved_invalid_reason = "rewrite_failed"
 valid = resolved_invalid_reason == ""
-t_total = (t_sync + t_rw) if valid else None
+t_total = (t_run + t_rw) if valid else None
 trust_height = safe_int(sync.get("trust_height"), 0)
 stop_at_local_height = safe_int(sync.get("stop_at_local_height"), 0)
 final_local_height = safe_int(sync.get("final_local_height"), 0)
@@ -1918,6 +1920,8 @@ result = {
     },
     "sync": {
         "duration_seconds": t_sync,
+        "total_duration_seconds": t_run,
+        "post_sync_dwell_elapsed_seconds": post_sync_dwell_seconds,
         "max_rss_kb": safe_int(sync.get("max_rss_kb"), 0),
         "max_hwm_kb": safe_int(sync.get("max_hwm_kb"), 0),
         "freeze_remote_height_at_start": freeze_remote_height_at_start,
@@ -1939,6 +1943,8 @@ result = {
     },
     "sizes": {
         "sync_app_bytes": sync_end_app_bytes,
+        "sync_data_bytes": safe_int(sync.get("end_data_bytes"), 0),
+        "sync_home_bytes": safe_int(sync.get("end_home_bytes"), 0),
         "du_sync_app_bytes": pre_app_bytes,
         "sync_wal_bytes": pre_wal_bytes,
         "post_app_bytes": post_app_bytes,
@@ -1948,7 +1954,10 @@ result = {
         "t_sync_seconds": t_sync,
         "t_rewrite_seconds": t_rw,
         "t_total_seconds": t_total,
+        "t_post_sync_dwell_seconds": post_sync_dwell_seconds,
         "s_sync_app_bytes": sync_end_app_bytes,
+        "s_sync_data_bytes": safe_int(sync.get("end_data_bytes"), 0),
+        "s_sync_home_bytes": safe_int(sync.get("end_home_bytes"), 0),
         "s_du_sync_app_bytes": pre_app_bytes,
         "s_sync_wal_bytes": pre_wal_bytes,
         "s_post_app_bytes": post_app_bytes,
@@ -2098,7 +2107,10 @@ with runs_csv.open("w", newline="", encoding="utf-8") as fh:
         "t_sync_seconds",
         "t_rewrite_seconds",
         "t_total_seconds",
+        "t_post_sync_dwell_seconds",
         "s_sync_app_bytes",
+        "s_sync_data_bytes",
+        "s_sync_home_bytes",
         "s_sync_wal_bytes",
         "s_post_app_bytes",
         "s_post_wal_bytes",
@@ -2334,7 +2346,10 @@ with runs_csv.open("w", newline="", encoding="utf-8") as fh:
             m.get("t_sync_seconds"),
             m.get("t_rewrite_seconds"),
             m.get("t_total_seconds"),
+            m.get("t_post_sync_dwell_seconds"),
             s.get("sync_app_bytes"),
+            s.get("sync_data_bytes"),
+            s.get("sync_home_bytes"),
             s.get("sync_wal_bytes"),
             s.get("post_app_bytes"),
             s.get("post_wal_bytes"),
@@ -2577,6 +2592,9 @@ for pair in sorted(by_pair):
             "delta_t_sync_seconds": None,
             "delta_t_total_seconds": None,
             "delta_s_sync_app_bytes": None,
+            "delta_s_sync_data_bytes": None,
+            "delta_s_sync_home_bytes": None,
+            "delta_s_sync_wal_bytes": None,
             "delta_s_post_wal_bytes": None,
             "delta_blocks_synced": None,
             "delta_s_sync_app_bytes_per_block": None,
@@ -2587,6 +2605,12 @@ for pair in sorted(by_pair):
             "candidate_t_total_seconds": None,
             "control_s_sync_app_bytes": None,
             "candidate_s_sync_app_bytes": None,
+            "control_s_sync_data_bytes": None,
+            "candidate_s_sync_data_bytes": None,
+            "control_s_sync_home_bytes": None,
+            "candidate_s_sync_home_bytes": None,
+            "control_s_sync_wal_bytes": None,
+            "candidate_s_sync_wal_bytes": None,
             "control_s_post_wal_bytes": None,
             "candidate_s_post_wal_bytes": None,
             "control_max_rss_kb": None,
@@ -2662,6 +2686,12 @@ for pair in sorted(by_pair):
     base_sync = bm.get("t_sync_seconds")
     cand_sync_app = cm.get("s_sync_app_bytes")
     base_sync_app = bm.get("s_sync_app_bytes")
+    cand_sync_data = cm.get("s_sync_data_bytes")
+    base_sync_data = bm.get("s_sync_data_bytes")
+    cand_sync_home = cm.get("s_sync_home_bytes")
+    base_sync_home = bm.get("s_sync_home_bytes")
+    cand_sync_wal = cm.get("s_sync_wal_bytes")
+    base_sync_wal = bm.get("s_sync_wal_bytes")
     cand_blocks = cm.get("blocks_synced")
     base_blocks = bm.get("blocks_synced")
     cand_sync_app_per_block = cm.get("s_sync_app_bytes_per_block")
@@ -2678,6 +2708,9 @@ for pair in sorted(by_pair):
     d_sync = delta(cand_sync, base_sync)
     d_post_wal = delta(cand_post_wal, base_post_wal)
     d_sync_app = delta(cand_sync_app, base_sync_app)
+    d_sync_data = delta(cand_sync_data, base_sync_data)
+    d_sync_home = delta(cand_sync_home, base_sync_home)
+    d_sync_wal = delta(cand_sync_wal, base_sync_wal)
     d_blocks = delta(cand_blocks, base_blocks)
     d_sync_app_per_block = delta(cand_sync_app_per_block, base_sync_app_per_block)
     d_total_per_block = delta(cand_total_per_block, base_total_per_block)
@@ -2861,6 +2894,9 @@ for pair in sorted(by_pair):
         "delta_t_sync_seconds": d_sync,
         "delta_t_total_seconds": d_total,
         "delta_s_sync_app_bytes": d_sync_app,
+        "delta_s_sync_data_bytes": d_sync_data,
+        "delta_s_sync_home_bytes": d_sync_home,
+        "delta_s_sync_wal_bytes": d_sync_wal,
         "delta_s_post_wal_bytes": d_post_wal,
         "delta_blocks_synced": d_blocks,
         "delta_s_sync_app_bytes_per_block": d_sync_app_per_block,
@@ -2871,6 +2907,12 @@ for pair in sorted(by_pair):
         "candidate_t_total_seconds": cand_total,
         "control_s_sync_app_bytes": base_sync_app,
         "candidate_s_sync_app_bytes": cand_sync_app,
+        "control_s_sync_data_bytes": base_sync_data,
+        "candidate_s_sync_data_bytes": cand_sync_data,
+        "control_s_sync_home_bytes": base_sync_home,
+        "candidate_s_sync_home_bytes": cand_sync_home,
+        "control_s_sync_wal_bytes": base_sync_wal,
+        "candidate_s_sync_wal_bytes": cand_sync_wal,
         "control_s_post_wal_bytes": base_post_wal,
         "candidate_s_post_wal_bytes": cand_post_wal,
         "control_max_rss_kb": bm.get("max_rss_kb"),
@@ -2944,6 +2986,9 @@ with pairs_csv.open("w", newline="", encoding="utf-8") as fh:
         "delta_t_sync_seconds",
         "delta_t_total_seconds",
         "delta_s_sync_app_bytes",
+        "delta_s_sync_data_bytes",
+        "delta_s_sync_home_bytes",
+        "delta_s_sync_wal_bytes",
         "delta_s_post_wal_bytes",
         "delta_blocks_synced",
         "delta_s_sync_app_bytes_per_block",
@@ -2954,6 +2999,12 @@ with pairs_csv.open("w", newline="", encoding="utf-8") as fh:
         "candidate_t_total_seconds",
         "control_s_sync_app_bytes",
         "candidate_s_sync_app_bytes",
+        "control_s_sync_data_bytes",
+        "candidate_s_sync_data_bytes",
+        "control_s_sync_home_bytes",
+        "candidate_s_sync_home_bytes",
+        "control_s_sync_wal_bytes",
+        "candidate_s_sync_wal_bytes",
         "control_s_post_wal_bytes",
         "candidate_s_post_wal_bytes",
         "control_max_rss_kb",
@@ -3024,6 +3075,9 @@ with pairs_csv.open("w", newline="", encoding="utf-8") as fh:
             r["delta_t_sync_seconds"],
             r["delta_t_total_seconds"],
             r["delta_s_sync_app_bytes"],
+            r["delta_s_sync_data_bytes"],
+            r["delta_s_sync_home_bytes"],
+            r["delta_s_sync_wal_bytes"],
             r["delta_s_post_wal_bytes"],
             r["delta_blocks_synced"],
             r["delta_s_sync_app_bytes_per_block"],
@@ -3034,6 +3088,12 @@ with pairs_csv.open("w", newline="", encoding="utf-8") as fh:
             r["candidate_t_total_seconds"],
             r["control_s_sync_app_bytes"],
             r["candidate_s_sync_app_bytes"],
+            r["control_s_sync_data_bytes"],
+            r["candidate_s_sync_data_bytes"],
+            r["control_s_sync_home_bytes"],
+            r["candidate_s_sync_home_bytes"],
+            r["control_s_sync_wal_bytes"],
+            r["candidate_s_sync_wal_bytes"],
             r["control_s_post_wal_bytes"],
             r["candidate_s_post_wal_bytes"],
             r["control_max_rss_kb"],
@@ -3221,6 +3281,12 @@ control_t_total_vals = collect_float(comparable_rows, "control_t_total_seconds")
 candidate_t_total_vals = collect_float(comparable_rows, "candidate_t_total_seconds")
 control_s_sync_app_vals = collect_float(comparable_rows, "control_s_sync_app_bytes")
 candidate_s_sync_app_vals = collect_float(comparable_rows, "candidate_s_sync_app_bytes")
+control_s_sync_data_vals = collect_float(comparable_rows, "control_s_sync_data_bytes")
+candidate_s_sync_data_vals = collect_float(comparable_rows, "candidate_s_sync_data_bytes")
+control_s_sync_home_vals = collect_float(comparable_rows, "control_s_sync_home_bytes")
+candidate_s_sync_home_vals = collect_float(comparable_rows, "candidate_s_sync_home_bytes")
+control_s_sync_wal_vals = collect_float(comparable_rows, "control_s_sync_wal_bytes")
+candidate_s_sync_wal_vals = collect_float(comparable_rows, "candidate_s_sync_wal_bytes")
 control_s_post_wal_vals = collect_float(comparable_rows, "control_s_post_wal_bytes")
 candidate_s_post_wal_vals = collect_float(comparable_rows, "candidate_s_post_wal_bytes")
 control_max_rss_vals = collect_float(comparable_rows, "control_max_rss_kb")
@@ -3241,6 +3307,18 @@ absolute_aggregates = {
     "median_candidate_s_sync_app_bytes": median(candidate_s_sync_app_vals),
     "mean_control_s_sync_app_bytes": mean(control_s_sync_app_vals),
     "mean_candidate_s_sync_app_bytes": mean(candidate_s_sync_app_vals),
+    "median_control_s_sync_data_bytes": median(control_s_sync_data_vals),
+    "median_candidate_s_sync_data_bytes": median(candidate_s_sync_data_vals),
+    "mean_control_s_sync_data_bytes": mean(control_s_sync_data_vals),
+    "mean_candidate_s_sync_data_bytes": mean(candidate_s_sync_data_vals),
+    "median_control_s_sync_home_bytes": median(control_s_sync_home_vals),
+    "median_candidate_s_sync_home_bytes": median(candidate_s_sync_home_vals),
+    "mean_control_s_sync_home_bytes": mean(control_s_sync_home_vals),
+    "mean_candidate_s_sync_home_bytes": mean(candidate_s_sync_home_vals),
+    "median_control_s_sync_wal_bytes": median(control_s_sync_wal_vals),
+    "median_candidate_s_sync_wal_bytes": median(candidate_s_sync_wal_vals),
+    "mean_control_s_sync_wal_bytes": mean(control_s_sync_wal_vals),
+    "mean_candidate_s_sync_wal_bytes": mean(candidate_s_sync_wal_vals),
     "median_control_s_post_wal_bytes": median(control_s_post_wal_vals),
     "median_candidate_s_post_wal_bytes": median(candidate_s_post_wal_vals),
     "mean_control_s_post_wal_bytes": mean(control_s_post_wal_vals),
@@ -3385,6 +3463,15 @@ lines.append(
     f"- s_sync_app bytes (control/candidate): `{absolute_aggregates.get('median_control_s_sync_app_bytes')}` / `{absolute_aggregates.get('median_candidate_s_sync_app_bytes')}`"
 )
 lines.append(
+    f"- s_sync_data bytes (control/candidate): `{absolute_aggregates.get('median_control_s_sync_data_bytes')}` / `{absolute_aggregates.get('median_candidate_s_sync_data_bytes')}`"
+)
+lines.append(
+    f"- s_sync_home bytes (control/candidate): `{absolute_aggregates.get('median_control_s_sync_home_bytes')}` / `{absolute_aggregates.get('median_candidate_s_sync_home_bytes')}`"
+)
+lines.append(
+    f"- s_sync_wal bytes (control/candidate): `{absolute_aggregates.get('median_control_s_sync_wal_bytes')}` / `{absolute_aggregates.get('median_candidate_s_sync_wal_bytes')}`"
+)
+lines.append(
     f"- s_post_wal bytes (control/candidate): `{absolute_aggregates.get('median_control_s_post_wal_bytes')}` / `{absolute_aggregates.get('median_candidate_s_post_wal_bytes')}`"
 )
 lines.append(
@@ -3412,6 +3499,9 @@ if pair_rows:
     lines.append(f"- delta_t_sync_seconds: `{last['delta_t_sync_seconds']}`")
     lines.append(f"- delta_t_total_seconds: `{last['delta_t_total_seconds']}`")
     lines.append(f"- delta_s_sync_app_bytes: `{last['delta_s_sync_app_bytes']}`")
+    lines.append(f"- delta_s_sync_data_bytes: `{last['delta_s_sync_data_bytes']}`")
+    lines.append(f"- delta_s_sync_home_bytes: `{last['delta_s_sync_home_bytes']}`")
+    lines.append(f"- delta_s_sync_wal_bytes: `{last['delta_s_sync_wal_bytes']}`")
     lines.append(f"- delta_s_post_wal_bytes: `{last['delta_s_post_wal_bytes']}`")
     lines.append(f"- delta_blocks_synced: `{last['delta_blocks_synced']}`")
     lines.append(f"- delta_s_sync_app_bytes_per_block: `{last['delta_s_sync_app_bytes_per_block']}`")
@@ -3420,6 +3510,12 @@ if pair_rows:
     lines.append(f"- candidate_t_sync_seconds: `{last['candidate_t_sync_seconds']}`")
     lines.append(f"- control_t_total_seconds: `{last['control_t_total_seconds']}`")
     lines.append(f"- candidate_t_total_seconds: `{last['candidate_t_total_seconds']}`")
+    lines.append(f"- control_s_sync_data_bytes: `{last['control_s_sync_data_bytes']}`")
+    lines.append(f"- candidate_s_sync_data_bytes: `{last['candidate_s_sync_data_bytes']}`")
+    lines.append(f"- control_s_sync_home_bytes: `{last['control_s_sync_home_bytes']}`")
+    lines.append(f"- candidate_s_sync_home_bytes: `{last['candidate_s_sync_home_bytes']}`")
+    lines.append(f"- control_s_sync_wal_bytes: `{last['control_s_sync_wal_bytes']}`")
+    lines.append(f"- candidate_s_sync_wal_bytes: `{last['candidate_s_sync_wal_bytes']}`")
     lines.append(f"- control_s_post_wal_bytes: `{last['control_s_post_wal_bytes']}`")
     lines.append(f"- candidate_s_post_wal_bytes: `{last['candidate_s_post_wal_bytes']}`")
     lines.append(f"- control_max_rss_kb: `{last['control_max_rss_kb']}`")


### PR DESCRIPTION
## Summary
- Add the final replay-floor metrics so the online runtime state, strict-GC floor, and offline-compaction floor can be compared directly.
- Keep GC-followup scheduling disabled when generational maintenance is off or while restore/catch-up phase suppression is active.
- Tighten nested outer-leaf live-ID detection so arbitrary user values with the `TOL2` prefix do not raise false decode errors.

## Replay Delta vs #946
This PR drains the remaining queued rewrite debt on the corrected replay and reaches the stable online floor.

`WALOn`:
- `retained_B/op`: `136,051,357 -> 134,934,323` delta `-1,117,034` (`-0.8%`)
- `wal_B/op`: `136,471,000 -> 135,844,292` delta `-626,708` (`-0.5%`)
- `home_B/op`: `146,556,793 -> 146,190,807` delta `-365,986` (`-0.2%`)
- `rewrite_queue_len/op`: `4 -> 0` delta `-4` (`-100.0%`)
- `queued_exec_runs/op`: `0 -> 2` delta `+2`
- `rewrite_runs/op`: `1 -> 3` delta `+2`
- `retained_prune_runs/op`: `1 -> 3` delta `+2`

`WALOff`:
- `retained_B/op`: `135,961,568 -> 134,783,751` delta `-1,177,817` (`-0.9%`)
- `wal_B/op`: `136,426,683 -> 135,759,419` delta `-667,264` (`-0.5%`)
- `home_B/op`: `146,512,390 -> 146,105,646` delta `-406,744` (`-0.3%`)
- `rewrite_queue_len/op`: `4 -> 0` delta `-4` (`-100.0%`)
- `queued_exec_runs/op`: `0 -> 3` delta `+3`
- `rewrite_runs/op`: `1 -> 4` delta `+3`
- `retained_prune_runs/op`: `1 -> 4` delta `+3`

Overall delta vs #944 corrected baseline:
- `WALOn retained_B/op`: `137,466,963 -> 134,934,323` delta `-2,532,640` (`-1.8%`)
- `WALOff retained_B/op`: `137,356,947 -> 134,783,751` delta `-2,573,196` (`-1.9%`)
- `WALOn wal_B/op`: `137,466,963 -> 135,844,292` delta `-1,622,671` (`-1.2%`)
- `WALOff wal_B/op`: `137,599,652 -> 135,759,419` delta `-1,840,233` (`-1.3%`)

Stable online floor on this branch:
- `WALOn`: `retained_B/op = 134,934,323`, `wal_B/op = 135,844,292`, `offline_floor_after_B/op = 133,890,574`, gap `1,043,749` (`0.8%`), `rewrite_queue_len/op = 0`, `strict_gc_deleted_B/op = 0`, `strict_gc_eligible_B/op = 0`
- `WALOff`: `retained_B/op = 134,783,751`, `wal_B/op = 135,759,419`, `offline_floor_after_B/op = 133,780,558`, gap `1,003,193` (`0.7%`), `rewrite_queue_len/op = 0`, `strict_gc_deleted_B/op = 0`, `strict_gc_eligible_B/op = 0`
- Extending `TREEDB_TRACE_REPLAY_MAINTENANCE_WAIT_MS` from `5000` to `10000` ms produced identical storage metrics, so this workload is saturated on the online path.
- The final phase-suppression GC-followup fix leaves those storage metrics unchanged; it removes restore/catch-up retry churn without creating new reclaim headroom.

## Validation
- `GOWORK=off go test ./TreeDB/caching -count=1`
- `GOWORK=off go test ./TreeDB -run '^$' -bench '^BenchmarkRestoreLikeTraceReplay$' -benchtime=1x -count=3`
- `TREEDB_TRACE_REPLAY_MAINTENANCE_WAIT_MS=10000 GOWORK=off go test ./TreeDB -run '^$' -bench '^BenchmarkRestoreLikeTraceReplay$' -benchtime=1x -count=1`
- `GOWORK=off GOMAXPROCS=8 go test ./TreeDB -run '^$' -bench 'Benchmark(SyncLatencyCached|WriteParallelCachedRotationStress)$' -benchmem -benchtime=1x -count=3`

Guardrail medians vs #946:
- `BenchmarkSyncLatencyCached`: `95,184,653 -> 97,564,763 ns/op` delta `+2,380,110` (`+2.5%`)
- `BenchmarkWriteParallelCachedRotationStress/G=8`: `49,428,155 -> 48,917,244 ns/op` delta `-510,911` (`-1.0%`)
- bytes/op and allocs/op stayed effectively flat across the guardrails.
