### PR TITLE
TreeDB: improve online vlog rewrite throughput

### DIFF
--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -115,6 +115,21 @@ type ValueLogRewriteStats struct {
 	TemplateOuterLeafInputBytes       int64
 	TemplateOuterLeafOutputBytes      int64
 	TemplateOuterLeafReasons          map[string]uint64
+
+	// Rewrite stage timings are coarse wall-clock timings for the main online
+	// rewrite phases. ReadDecodeNanos includes both source reads and value-log
+	// decode because the current ReadUnsafeTo API does not separate them.
+	PlanNanos         int64
+	SourceScanNanos   int64
+	ReadDecodeNanos   int64
+	EncodeAppendNanos int64
+	SwapCommitNanos   int64
+	BookkeepingNanos  int64
+	LeafRefNanos      int64
+
+	ReadCalls   int
+	AppendCalls int
+	SwapBatches int
 }
 
 // ValueLogRewritePlan summarizes which segments a sparse online rewrite would
@@ -1315,6 +1330,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	planStart := time.Now()
 	if err := db.publishValueLogSetNoRefresh(); err != nil {
 		return stats, err
 	}
@@ -1426,7 +1442,18 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		set = nil
 		stats.SegmentsAfter = stats.SegmentsBefore
 		stats.BytesAfter = stats.BytesBefore
+		stats.PlanNanos += time.Since(planStart).Nanoseconds()
 		return stats, nil
+	}
+	stats.PlanNanos += time.Since(planStart).Nanoseconds()
+	var preferredLeafDictID uint64
+	if db.indexOuterLeavesInValueLog && set != nil && db.valueLogManager != nil && db.valueLogManager.DictLookup() != nil {
+		preferredLeafDictID, err = scanValueLogSetPreferredDictID(set)
+		if err != nil {
+			_ = db.valueLogManager.Release(set)
+			set = nil
+			return stats, err
+		}
 	}
 
 	nextRID := uint64(0)
@@ -1490,6 +1517,13 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	writer := newRewriteWriter(filepath.Join(db.dir, "wal"), lane, startSeq, maxBytes)
 	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
 	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
+	if writer.blockCompression && preferredLeafDictID != 0 {
+		if dictLookup := db.valueLogManager.DictLookup(); dictLookup != nil {
+			if dictBytes, dictErr := dictLookup(preferredLeafDictID); dictErr == nil && len(dictBytes) > 0 {
+				writer.SetLeafDict(preferredLeafDictID, dictBytes)
+			}
+		}
+	}
 	defer func() { _ = writer.Close() }()
 
 	batchSize := normalizeValueLogRewriteBatchSize(opts.BatchSize)
@@ -1529,6 +1563,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			if rewriteReadScratch == nil {
 				rewriteReadScratch = make([]byte, 0, rewriteReadScratchInitCap)
 			}
+			readStart := time.Now()
 			val, usedScratch, err := db.valueLogManager.ReadUnsafeTo(candidate.oldPtr, rewriteReadScratch)
 			if err != nil && errors.Is(err, valuelog.ErrFileNotFound) && !readRefreshRetried {
 				if refreshErr := db.RefreshValueLogSet(); refreshErr != nil {
@@ -1537,10 +1572,15 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 				readRefreshRetried = true
 				val, usedScratch, err = db.valueLogManager.ReadUnsafeTo(candidate.oldPtr, rewriteReadScratch)
 			}
+			stats.ReadDecodeNanos += time.Since(readStart).Nanoseconds()
+			stats.ReadCalls++
 			if err != nil {
 				return err
 			}
+			appendStart := time.Now()
 			newPtr, err := writer.appendValue(startRID, val)
+			stats.EncodeAppendNanos += time.Since(appendStart).Nanoseconds()
+			stats.AppendCalls++
 			if err != nil {
 				return err
 			}
@@ -1571,6 +1611,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 				newPtr: newPtr,
 			})
 		}
+		bookkeepingStart := time.Now()
 		if opts.SyncEachBatch {
 			if err := writer.Sync(); err != nil {
 				return err
@@ -1596,9 +1637,13 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			lastRegisteredCreatedID = id
 			hasLastRegisteredID = true
 		}
+		stats.BookkeepingNanos += time.Since(bookkeepingStart).Nanoseconds()
+		swapStart := time.Now()
 		if err := db.applyRewriteSwapBatch(swaps, opts.SyncEachBatch); err != nil {
 			return err
 		}
+		stats.SwapCommitNanos += time.Since(swapStart).Nanoseconds()
+		stats.SwapBatches++
 		candidates = candidates[:0]
 		if cap(candidateKeyArena) > rewriteKeyArenaMaxCap {
 			candidateKeyArena = nil
@@ -1614,6 +1659,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		return stats, fmt.Errorf("missing snapshot state")
 	}
 	it := snap.tree.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+	scanStart := time.Now()
 	for ; it.Valid(); it.Next() {
 		if err := ctx.Err(); err != nil {
 			canceledErr = err
@@ -1669,16 +1715,19 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		})
 		selectedSourceBytes += sourceBytes
 		if len(candidates) >= batchSize {
+			stats.SourceScanNanos += time.Since(scanStart).Nanoseconds()
 			if err := flushBatch(); err != nil {
 				_ = it.Close()
 				closeRewriteSnapshot(&err, snap)
 				return stats, err
 			}
+			scanStart = time.Now()
 		}
 		if maxCopiedBytes > 0 && selectedSourceBytes >= maxCopiedBytes {
 			break
 		}
 	}
+	stats.SourceScanNanos += time.Since(scanStart).Nanoseconds()
 	iterErr := it.Error()
 	_ = it.Close()
 	closeRewriteSnapshot(&err, snap)
@@ -1702,7 +1751,9 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 				}
 			}
 			if maxCopiedBytes <= 0 || leafRefMaxCopiedBytes > 0 {
+				leafRefStart := time.Now()
 				copied, copiedBytes, err := db.rewriteLeafRefsOnline(ctx, writer, ridAlloc, sourceIDs, sourceChunkSet, sourceChunkBytes, singleSourceID, restrictSingleID, leafRefMaxCopiedBytes, opts.SyncEachBatch)
+				stats.LeafRefNanos += time.Since(leafRefStart).Nanoseconds()
 				if err != nil {
 					return stats, err
 				}
@@ -1720,6 +1771,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	if err := writer.Sync(); err != nil {
 		return stats, err
 	}
+	finalBookkeepingStart := time.Now()
 	newValueIDs, err := writer.createdFileIDs()
 	if err != nil {
 		return stats, err
@@ -1883,6 +1935,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		stats.SegmentsAfter = afterSegs
 		stats.BytesAfter = afterBytes
 	}
+	stats.BookkeepingNanos += time.Since(finalBookkeepingStart).Nanoseconds()
 	if canceledErr != nil {
 		return stats, canceledErr
 	}
@@ -2098,7 +2151,7 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 		if err != nil {
 			return id, false, err
 		}
-		newPtr, err := c.writer.appendValue(rid, leafPage)
+		newPtr, err := c.writer.appendLeafPageWithRID(rid, leafPage)
 		if err != nil {
 			return id, false, err
 		}
@@ -3205,6 +3258,16 @@ func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.ValuePtr, error) {
 	if w.nextRID == 0 {
 		return page.ValuePtr{}, fmt.Errorf("value-log rid space exhausted")
 	}
+	return w.appendLeafPageWithRID(rid, leafPage)
+}
+
+func (w *rewriteWriter) appendLeafPageWithRID(rid uint64, leafPage []byte) (page.ValuePtr, error) {
+	if w == nil {
+		return page.ValuePtr{}, errors.New("vlog-rewrite: nil writer")
+	}
+	if rid == 0 {
+		return page.ValuePtr{}, errors.New("vlog-rewrite: missing rid")
+	}
 	if w.blockCompression && w.leafDictID != 0 && len(w.leafDict) > 0 && rewriteAllowDictForSmallPayload(leafPage) {
 		// LeafRef IDs intentionally omit grouped sub-index bits and therefore
 		// require K=1 frames. Use single-record append so decoded LeafRef pointers
@@ -3253,6 +3316,7 @@ func (w *rewriteWriter) rotate() error {
 		if err != nil {
 			return err
 		}
+		writer.SetDeferSealedSync(true)
 		writer.SetBlockCompression(w.blockCodec, w.blockCompression)
 		writer.SetKeepPolicy(w.keepIoNsPerByte, w.keepEncodeNsRaw, w.keepSafetyMargin)
 		w.w = writer
@@ -3265,6 +3329,7 @@ func (w *rewriteWriter) rotate() error {
 	if err := w.w.RotateTo(path, fileID); err != nil {
 		return err
 	}
+	w.w.SetDeferSealedSync(true)
 	w.w.SetBlockCompression(w.blockCodec, w.blockCompression)
 	w.w.SetKeepPolicy(w.keepIoNsPerByte, w.keepEncodeNsRaw, w.keepSafetyMargin)
 	w.seq = nextSeq

--- a/TreeDB/db/vlog_rewrite_bench_test.go
+++ b/TreeDB/db/vlog_rewrite_bench_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/pager"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 func BenchmarkValueLogRewriteOnline_ValuePointers(b *testing.B) {
@@ -27,6 +28,16 @@ func BenchmarkValueLogRewriteOnline_ValuePointers(b *testing.B) {
 	var totalBytes int64
 	var totalRefreshScans uint64
 	var totalRewriteAllocs uint64
+	var totalPlanNs int64
+	var totalScanNs int64
+	var totalReadDecodeNs int64
+	var totalAppendNs int64
+	var totalSwapCommitNs int64
+	var totalBookkeepingNs int64
+	var totalLeafRefNs int64
+	var totalReadCalls int64
+	var totalAppendCalls int64
+	var totalSwapBatches int64
 
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -48,6 +59,16 @@ func BenchmarkValueLogRewriteOnline_ValuePointers(b *testing.B) {
 		totalCopied += int64(stats.ValueRecordsCopied)
 		totalBytes += stats.ValueBytesCopied
 		totalRefreshScans += db.valueLogManager.RefreshScanCount() - refreshBefore
+		totalPlanNs += stats.PlanNanos
+		totalScanNs += stats.SourceScanNanos
+		totalReadDecodeNs += stats.ReadDecodeNanos
+		totalAppendNs += stats.EncodeAppendNanos
+		totalSwapCommitNs += stats.SwapCommitNanos
+		totalBookkeepingNs += stats.BookkeepingNanos
+		totalLeafRefNs += stats.LeafRefNanos
+		totalReadCalls += int64(stats.ReadCalls)
+		totalAppendCalls += int64(stats.AppendCalls)
+		totalSwapBatches += int64(stats.SwapBatches)
 		var memAfter runtime.MemStats
 		runtime.ReadMemStats(&memAfter)
 		if memAfter.Mallocs > memBefore.Mallocs {
@@ -61,6 +82,7 @@ func BenchmarkValueLogRewriteOnline_ValuePointers(b *testing.B) {
 		b.ReportMetric(float64(totalBytes)/float64(b.N), "value_bytes/op")
 		b.ReportMetric(float64(totalRefreshScans)/float64(b.N), "refresh_scans/op")
 		b.ReportMetric(float64(totalRewriteAllocs)/float64(b.N), "rewrite_allocs/op")
+		reportRewriteStageMetrics(b, b.N, totalPlanNs, totalScanNs, totalReadDecodeNs, totalAppendNs, totalSwapCommitNs, totalBookkeepingNs, totalLeafRefNs, totalReadCalls, totalAppendCalls, totalSwapBatches)
 	}
 }
 
@@ -71,6 +93,16 @@ func BenchmarkValueLogRewriteOnline_LeafRefs(b *testing.B) {
 	var totalBytes int64
 	var totalRefreshScans uint64
 	var totalRewriteAllocs uint64
+	var totalPlanNs int64
+	var totalScanNs int64
+	var totalReadDecodeNs int64
+	var totalAppendNs int64
+	var totalSwapCommitNs int64
+	var totalBookkeepingNs int64
+	var totalLeafRefNs int64
+	var totalReadCalls int64
+	var totalAppendCalls int64
+	var totalSwapBatches int64
 
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -92,6 +124,16 @@ func BenchmarkValueLogRewriteOnline_LeafRefs(b *testing.B) {
 		totalCopied += int64(stats.LeafRefRecordsCopied)
 		totalBytes += stats.LeafRefBytesCopied
 		totalRefreshScans += db.valueLogManager.RefreshScanCount() - refreshBefore
+		totalPlanNs += stats.PlanNanos
+		totalScanNs += stats.SourceScanNanos
+		totalReadDecodeNs += stats.ReadDecodeNanos
+		totalAppendNs += stats.EncodeAppendNanos
+		totalSwapCommitNs += stats.SwapCommitNanos
+		totalBookkeepingNs += stats.BookkeepingNanos
+		totalLeafRefNs += stats.LeafRefNanos
+		totalReadCalls += int64(stats.ReadCalls)
+		totalAppendCalls += int64(stats.AppendCalls)
+		totalSwapBatches += int64(stats.SwapBatches)
 		var memAfter runtime.MemStats
 		runtime.ReadMemStats(&memAfter)
 		if memAfter.Mallocs > memBefore.Mallocs {
@@ -105,6 +147,7 @@ func BenchmarkValueLogRewriteOnline_LeafRefs(b *testing.B) {
 		b.ReportMetric(float64(totalBytes)/float64(b.N), "leafref_bytes/op")
 		b.ReportMetric(float64(totalRefreshScans)/float64(b.N), "refresh_scans/op")
 		b.ReportMetric(float64(totalRewriteAllocs)/float64(b.N), "rewrite_allocs/op")
+		reportRewriteStageMetrics(b, b.N, totalPlanNs, totalScanNs, totalReadDecodeNs, totalAppendNs, totalSwapCommitNs, totalBookkeepingNs, totalLeafRefNs, totalReadCalls, totalAppendCalls, totalSwapBatches)
 	}
 }
 
@@ -115,6 +158,16 @@ func BenchmarkValueLogRewriteOnline_LeafRefs_ReserveRIDs(b *testing.B) {
 	var totalBytes int64
 	var totalRefreshScans uint64
 	var totalRewriteAllocs uint64
+	var totalPlanNs int64
+	var totalScanNs int64
+	var totalReadDecodeNs int64
+	var totalAppendNs int64
+	var totalSwapCommitNs int64
+	var totalBookkeepingNs int64
+	var totalLeafRefNs int64
+	var totalReadCalls int64
+	var totalAppendCalls int64
+	var totalSwapBatches int64
 
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -145,6 +198,16 @@ func BenchmarkValueLogRewriteOnline_LeafRefs_ReserveRIDs(b *testing.B) {
 		totalCopied += int64(stats.LeafRefRecordsCopied)
 		totalBytes += stats.LeafRefBytesCopied
 		totalRefreshScans += db.valueLogManager.RefreshScanCount() - refreshBefore
+		totalPlanNs += stats.PlanNanos
+		totalScanNs += stats.SourceScanNanos
+		totalReadDecodeNs += stats.ReadDecodeNanos
+		totalAppendNs += stats.EncodeAppendNanos
+		totalSwapCommitNs += stats.SwapCommitNanos
+		totalBookkeepingNs += stats.BookkeepingNanos
+		totalLeafRefNs += stats.LeafRefNanos
+		totalReadCalls += int64(stats.ReadCalls)
+		totalAppendCalls += int64(stats.AppendCalls)
+		totalSwapBatches += int64(stats.SwapBatches)
 		var memAfter runtime.MemStats
 		runtime.ReadMemStats(&memAfter)
 		if memAfter.Mallocs > memBefore.Mallocs {
@@ -158,7 +221,142 @@ func BenchmarkValueLogRewriteOnline_LeafRefs_ReserveRIDs(b *testing.B) {
 		b.ReportMetric(float64(totalBytes)/float64(b.N), "leafref_bytes/op")
 		b.ReportMetric(float64(totalRefreshScans)/float64(b.N), "refresh_scans/op")
 		b.ReportMetric(float64(totalRewriteAllocs)/float64(b.N), "rewrite_allocs/op")
+		reportRewriteStageMetrics(b, b.N, totalPlanNs, totalScanNs, totalReadDecodeNs, totalAppendNs, totalSwapCommitNs, totalBookkeepingNs, totalLeafRefNs, totalReadCalls, totalAppendCalls, totalSwapBatches)
 	}
+}
+
+func BenchmarkValueLogReadUnsafeTo_ValuePointers(b *testing.B) {
+	db, sourceIDs, cleanup := setupValuePointerRewriteBench(b, 2048, 1024)
+	defer cleanup()
+	if len(sourceIDs) == 0 {
+		b.Fatalf("missing source ids")
+	}
+	sourceID := sourceIDs[0]
+	state := db.State()
+	if state == nil || state.ValueLogSet == nil {
+		b.Fatalf("missing value log set")
+	}
+	ptrs := collectValuePointersForFileBench(b, db, sourceID, 64)
+	if len(ptrs) == 0 {
+		b.Fatalf("no pointers found for source file %d", sourceID)
+	}
+	scratch := make([]byte, 0, 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ptr := ptrs[i%len(ptrs)]
+		buf, usedScratch, err := db.valueLogManager.ReadUnsafeTo(ptr, scratch[:0])
+		if err != nil {
+			b.Fatalf("ReadUnsafeTo: %v", err)
+		}
+		if usedScratch {
+			scratch = buf[:0]
+		}
+	}
+}
+
+func BenchmarkValueLogReadUnsafeTo_LeafRefs(b *testing.B) {
+	db, sourceIDs, cleanup := setupLeafRefRewriteBench(b, 1536)
+	defer cleanup()
+	if len(sourceIDs) == 0 {
+		b.Fatalf("missing source ids")
+	}
+	ptrs := collectLeafRefPointersForFileBench(b, db.Pager(), db.State(), sourceIDs[0], 64)
+	if len(ptrs) == 0 {
+		b.Fatalf("no leaf refs found for source file %d", sourceIDs[0])
+	}
+	scratch := make([]byte, 0, page.PageSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ptr := ptrs[i%len(ptrs)]
+		buf, usedScratch, err := db.valueLogManager.ReadUnsafeTo(ptr, scratch[:0])
+		if err != nil {
+			b.Fatalf("ReadUnsafeTo: %v", err)
+		}
+		if usedScratch {
+			scratch = buf[:0]
+		}
+	}
+}
+
+func BenchmarkRewriteWriterAppendValue(b *testing.B) {
+	value := bytes.Repeat([]byte("value-payload-"), 64)
+	benchRewriteWriterAppendValue(b, "NoRotate", 1<<62, value)
+	benchRewriteWriterAppendValue(b, "Rotate64KiB", 64<<10, value)
+}
+
+func BenchmarkRewriteWriterAppendLeafPage(b *testing.B) {
+	leafPage := bytes.Repeat([]byte("leaf-page-"), page.PageSize/10)
+	if len(leafPage) < page.PageSize {
+		leafPage = append(leafPage, bytes.Repeat([]byte{0}, page.PageSize-len(leafPage))...)
+	}
+	leafPage = leafPage[:page.PageSize]
+	benchRewriteWriterAppendLeafPage(b, "NoRotate", 1<<62, leafPage)
+	benchRewriteWriterAppendLeafPage(b, "Rotate64KiB", 64<<10, leafPage)
+}
+
+func benchRewriteWriterAppendValue(b *testing.B, name string, maxSize int64, value []byte) {
+	b.Helper()
+	b.Run(name, func(b *testing.B) {
+		dir := b.TempDir()
+		walDir := filepath.Join(dir, "wal")
+		if err := os.MkdirAll(walDir, 0o755); err != nil {
+			b.Fatalf("MkdirAll(wal): %v", err)
+		}
+		writer := newRewriteWriter(walDir, 0, 0, maxSize)
+		writer.blockCompression = true
+		writer.blockCodec = valuelog.BlockCodecSnappy
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := writer.appendValue(uint64(i+1), value); err != nil {
+				b.Fatalf("appendValue: %v", err)
+			}
+		}
+		b.StopTimer()
+		if err := writer.Close(); err != nil {
+			b.Fatalf("writer.Close: %v", err)
+		}
+	})
+}
+
+func benchRewriteWriterAppendLeafPage(b *testing.B, name string, maxSize int64, leafPage []byte) {
+	b.Helper()
+	b.Run(name, func(b *testing.B) {
+		dir := b.TempDir()
+		walDir := filepath.Join(dir, "wal")
+		if err := os.MkdirAll(walDir, 0o755); err != nil {
+			b.Fatalf("MkdirAll(wal): %v", err)
+		}
+		writer := newRewriteWriter(walDir, 0, 0, maxSize)
+		writer.blockCompression = true
+		writer.blockCodec = valuelog.BlockCodecSnappy
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := writer.AppendLeafPage(leafPage); err != nil {
+				b.Fatalf("AppendLeafPage: %v", err)
+			}
+		}
+		b.StopTimer()
+		if err := writer.Close(); err != nil {
+			b.Fatalf("writer.Close: %v", err)
+		}
+	})
+}
+
+func reportRewriteStageMetrics(b *testing.B, n int, planNs, scanNs, readDecodeNs, appendNs, swapCommitNs, bookkeepingNs, leafRefNs, readCalls, appendCalls, swapBatches int64) {
+	if b == nil || n <= 0 {
+		return
+	}
+	div := float64(n)
+	b.ReportMetric(float64(planNs)/div, "plan_ns/op")
+	b.ReportMetric(float64(scanNs)/div, "scan_ns/op")
+	b.ReportMetric(float64(readDecodeNs)/div, "read_decode_ns/op")
+	b.ReportMetric(float64(appendNs)/div, "append_ns/op")
+	b.ReportMetric(float64(swapCommitNs)/div, "swap_commit_ns/op")
+	b.ReportMetric(float64(bookkeepingNs)/div, "bookkeeping_ns/op")
+	b.ReportMetric(float64(leafRefNs)/div, "leafref_ns/op")
+	b.ReportMetric(float64(readCalls)/div, "read_calls/op")
+	b.ReportMetric(float64(appendCalls)/div, "append_calls/op")
+	b.ReportMetric(float64(swapBatches)/div, "swap_batches/op")
 }
 
 func setupValuePointerRewriteBench(tb testing.TB, seg1Records, seg2Records int) (*DB, []uint32, func()) {
@@ -341,6 +539,41 @@ func setupLeafRefRewriteBench(tb testing.TB, keyCount int) (*DB, []uint32, func(
 	return db, sourceIDs, cleanup
 }
 
+func collectValuePointersForFileBench(tb testing.TB, db *DB, fileID uint32, limit int) []page.ValuePtr {
+	tb.Helper()
+	if db == nil || fileID == 0 {
+		return nil
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil || snap.state == nil {
+		if snap != nil {
+			_ = snap.Close()
+		}
+		tb.Fatalf("missing snapshot state")
+	}
+	defer func() { _ = snap.Close() }()
+	it := snap.tree.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+	defer func() { _ = it.Close() }()
+	ptrs := make([]page.ValuePtr, 0, limit)
+	for ; it.Valid(); it.Next() {
+		_, ptr, flags := it.UnsafeEntry()
+		if flags&node.FlagPointer == 0 {
+			continue
+		}
+		if ptr.FileID != fileID {
+			continue
+		}
+		ptrs = append(ptrs, ptr)
+		if limit > 0 && len(ptrs) >= limit {
+			break
+		}
+	}
+	if err := it.Error(); err != nil {
+		tb.Fatalf("iterator error: %v", err)
+	}
+	return ptrs
+}
+
 func collectLeafRefFileCountsBench(tb testing.TB, p *pager.Pager, rootID uint64, counts map[uint32]int) {
 	tb.Helper()
 	if p == nil || rootID == 0 || counts == nil {
@@ -393,6 +626,48 @@ func collectLeafRefFileCountsBench(tb testing.TB, p *pager.Pager, rootID uint64,
 			tb.Fatalf("unexpected page type %d at page %d", n.Type(), pageID)
 		}
 	}
+}
+
+func collectLeafRefPointersForFileBench(tb testing.TB, p *pager.Pager, state *DBState, fileID uint32, limit int) []page.ValuePtr {
+	tb.Helper()
+	if p == nil || state == nil || fileID == 0 {
+		return nil
+	}
+	ptrs := make([]page.ValuePtr, 0, limit)
+	var visit func(uint64)
+	visit = func(pageID uint64) {
+		if limit > 0 && len(ptrs) >= limit {
+			return
+		}
+		if ptr, ok := page.DecodeLeafRef(pageID); ok {
+			if ptr.FileID == fileID {
+				ptrs = append(ptrs, ptr)
+			}
+			return
+		}
+		data, err := p.Get(pageID)
+		if err != nil {
+			tb.Fatalf("pager.Get(%d): %v", pageID, err)
+		}
+		n := node.NewNodeView(data)
+		if !n.VerifyChecksum() {
+			tb.Fatalf("checksum mismatch on page %d", pageID)
+		}
+		if n.Type() != page.PageTypeInternal {
+			return
+		}
+		count := n.Count()
+		for i := uint16(0); i < count; i++ {
+			_, childID, err := n.GetInternalEntryView(i)
+			if err != nil {
+				tb.Fatalf("GetInternalEntryView(%d,%d): %v", pageID, i, err)
+			}
+			visit(childID)
+		}
+	}
+	visit(state.SystemRootPageID)
+	visit(state.RootPageID)
+	return ptrs
 }
 
 func appendPointersInNewSegmentBench(tb testing.TB, dir string, lane, seq uint32, ridBase uint64, n int, valueAt func(i int) []byte) []page.ValuePtr {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1075,6 +1075,15 @@ func (m *Manager) SetDictLookup(lookup DictLookup) {
 	}
 }
 
+func (m *Manager) DictLookup() DictLookup {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.dictLookup
+}
+
 func (m *Manager) SetTemplateLookup(lookup TemplateLookup, opts templ.DecodeOptions) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -48,6 +48,11 @@ type Writer struct {
 	bw                     *bufio.Writer
 	size                   int64
 	fileID                 uint32
+	dirSyncPath            string
+	dirSyncPending         bool
+	dirty                  bool
+	deferSealedSync        bool
+	sealedFiles            []*os.File
 	appendBuf              []byte
 	appendMax              int
 	rawWritevMinAvgBytes   int
@@ -127,6 +132,7 @@ func (w *Writer) writeAllToFile(buf []byte) error {
 			return errors.New("valuelog: short write")
 		}
 	}
+	w.dirty = true
 	return nil
 }
 
@@ -139,6 +145,9 @@ func (w *Writer) flushAppendBuf() error {
 	}
 	if w.f == nil {
 		_, err := w.bw.Write(w.appendBuf)
+		if err == nil {
+			w.dirty = true
+		}
 		w.appendBuf = w.appendBuf[:0]
 		return err
 	}
@@ -160,6 +169,7 @@ func (w *Writer) flushNoTrim() error {
 		if err := w.bw.Flush(); err != nil {
 			return err
 		}
+		w.dirty = true
 	}
 	return nil
 }
@@ -207,6 +217,9 @@ func (w *Writer) writeBytes(buf []byte) error {
 	}
 	if w.f == nil {
 		_, err := w.bw.Write(buf)
+		if err == nil {
+			w.dirty = true
+		}
 		return err
 	}
 
@@ -257,6 +270,9 @@ func (w *Writer) writeBytesBuffered(buf []byte) error {
 	}
 	if w.f == nil {
 		_, err := w.bw.Write(buf)
+		if err == nil {
+			w.dirty = true
+		}
 		return err
 	}
 
@@ -402,10 +418,6 @@ func NewWriter(path string, fileID uint32) (*Writer, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := syncDirFn(path); err != nil {
-		_ = f.Close()
-		return nil, err
-	}
 	info, err := f.Stat()
 	if err != nil {
 		_ = f.Close()
@@ -418,6 +430,8 @@ func NewWriter(path string, fileID uint32) (*Writer, error) {
 		bw:                    nil,
 		size:                  info.Size(),
 		fileID:                fileID,
+		dirSyncPath:           path,
+		dirSyncPending:        true,
 		appendMax:             defaultBufferSize,
 		rawWritevMinAvgBytes:  defaultRawWritevMinAvgBytes,
 		rawWritevMinBatchRecs: defaultRawWritevMinBatchRecords,
@@ -444,6 +458,75 @@ func newWriterWithSink(sink io.Writer, fileID uint32) *Writer {
 		clock:                 RealClock{},
 		keepSafetyMargin:      DefaultKeepSafetyMargin,
 	}
+}
+
+func (w *Writer) markDirSyncPending(path string) {
+	if w == nil {
+		return
+	}
+	w.dirSyncPath = path
+	w.dirSyncPending = path != ""
+}
+
+func (w *Writer) syncPendingDir() error {
+	if w == nil || !w.dirSyncPending || w.dirSyncPath == "" {
+		return nil
+	}
+	if err := syncDirFn(w.dirSyncPath); err != nil {
+		return err
+	}
+	w.dirSyncPending = false
+	return nil
+}
+
+func (w *Writer) SetDeferSealedSync(enabled bool) {
+	if w == nil {
+		return
+	}
+	w.deferSealedSync = enabled
+}
+
+func (w *Writer) syncAndCloseSealedFiles() error {
+	if w == nil || len(w.sealedFiles) == 0 {
+		return nil
+	}
+	for i, f := range w.sealedFiles {
+		if f == nil {
+			continue
+		}
+		if w.syncFn != nil {
+			if err := w.syncFn(f); err != nil {
+				return err
+			}
+		} else {
+			if err := f.Sync(); err != nil {
+				return err
+			}
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+		w.sealedFiles[i] = nil
+	}
+	w.sealedFiles = w.sealedFiles[:0]
+	return nil
+}
+
+func (w *Writer) closeSealedFiles() error {
+	if w == nil || len(w.sealedFiles) == 0 {
+		return nil
+	}
+	for i, f := range w.sealedFiles {
+		if f == nil {
+			continue
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+		w.sealedFiles[i] = nil
+	}
+	w.sealedFiles = w.sealedFiles[:0]
+	return nil
 }
 
 // NewWriterWithSink creates a value-log writer that writes to the provided sink.
@@ -675,10 +758,6 @@ func (w *Writer) RotateTo(path string, fileID uint32) error {
 		if err != nil {
 			return err
 		}
-		if err := syncDirFn(path); err != nil {
-			_ = f.Close()
-			return err
-		}
 		info, err := f.Stat()
 		if err != nil {
 			_ = f.Close()
@@ -689,6 +768,7 @@ func (w *Writer) RotateTo(path string, fileID uint32) error {
 		w.bw = nil
 		w.size = info.Size()
 		w.fileID = fileID
+		w.markDirSyncPending(path)
 		w.appendMax = defaultBufferSize
 		if cap(w.appendBuf) < defaultBufferSize {
 			w.appendBuf = make([]byte, 0, defaultBufferSize)
@@ -702,11 +782,6 @@ func (w *Writer) RotateTo(path string, fileID uint32) error {
 	if err := w.flushNoTrim(); err != nil {
 		return err
 	}
-	if w.syncFn != nil {
-		if err := w.syncFn(w.f); err != nil {
-			return err
-		}
-	}
 
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
@@ -714,10 +789,6 @@ func (w *Writer) RotateTo(path string, fileID uint32) error {
 	}
 	info, err := f.Stat()
 	if err != nil {
-		_ = f.Close()
-		return err
-	}
-	if err := syncDirFn(path); err != nil {
 		_ = f.Close()
 		return err
 	}
@@ -735,9 +806,20 @@ func (w *Writer) RotateTo(path string, fileID uint32) error {
 	w.bw = nil
 	w.size = info.Size()
 	w.fileID = fileID
+	w.markDirSyncPending(path)
 	w.appendBuf = w.appendBuf[:0]
-	if err := old.Close(); err != nil {
-		return err
+	if w.deferSealedSync {
+		w.sealedFiles = append(w.sealedFiles, old)
+	} else {
+		if w.syncFn != nil {
+			if err := w.syncFn(old); err != nil {
+				_ = old.Close()
+				return err
+			}
+		}
+		if err := old.Close(); err != nil {
+			return err
+		}
 	}
 	w.trimTransientScratchBuffers()
 	return nil
@@ -2134,16 +2216,34 @@ func (w *Writer) Sync() error {
 	if err := w.flushNoTrim(); err != nil {
 		return err
 	}
+	if !w.dirty && len(w.sealedFiles) == 0 && !w.dirSyncPending {
+		w.trimTransientScratchBuffers()
+		return nil
+	}
 	if w.syncFn != nil {
+		if err := w.syncAndCloseSealedFiles(); err != nil {
+			return err
+		}
 		if err := w.syncFn(w.f); err != nil {
 			return err
 		}
+		if err := w.syncPendingDir(); err != nil {
+			return err
+		}
+		w.dirty = false
 		w.trimTransientScratchBuffers()
 		return nil
+	}
+	if err := w.syncAndCloseSealedFiles(); err != nil {
+		return err
 	}
 	if err := w.f.Sync(); err != nil {
 		return err
 	}
+	if err := w.syncPendingDir(); err != nil {
+		return err
+	}
+	w.dirty = false
 	w.trimTransientScratchBuffers()
 	return nil
 }
@@ -2154,8 +2254,23 @@ func (w *Writer) Close() error {
 	}
 	if err := w.flushNoTrim(); err != nil {
 		_ = w.f.Close()
+		_ = w.closeSealedFiles()
 		return err
 	}
+	if w.deferSealedSync {
+		if err := w.syncAndCloseSealedFiles(); err != nil {
+			_ = w.f.Close()
+			return err
+		}
+	} else if err := w.closeSealedFiles(); err != nil {
+		_ = w.f.Close()
+		return err
+	}
+	if err := w.syncPendingDir(); err != nil {
+		_ = w.f.Close()
+		return err
+	}
+	w.dirty = false
 	if err := w.f.Close(); err != nil {
 		return err
 	}

--- a/TreeDB/internal/valuelog/writer_memory_test.go
+++ b/TreeDB/internal/valuelog/writer_memory_test.go
@@ -2,6 +2,7 @@ package valuelog
 
 import (
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -172,5 +173,167 @@ func TestWriterClose_ReleasesScratchBuffers(t *testing.T) {
 	}
 	if writer.encLimiter.buf != nil || writer.encLimiter.limit != 0 {
 		t.Fatalf("encLimiter not cleared on Close: buf=%v limit=%d", writer.encLimiter.buf != nil, writer.encLimiter.limit)
+	}
+}
+
+func TestNewWriter_DefersDirSyncUntilSync(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-000001.log")
+
+	origSyncDir := syncDirFn
+	var syncDirCalls int
+	syncDirFn = func(path string) error {
+		syncDirCalls++
+		return nil
+	}
+	defer func() { syncDirFn = origSyncDir }()
+
+	writer, err := NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	if syncDirCalls != 0 {
+		t.Fatalf("syncDir calls after NewWriter = %d want 0", syncDirCalls)
+	}
+	if _, err := writer.Append(0, nil, 1, []byte("value")); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if syncDirCalls != 1 {
+		t.Fatalf("syncDir calls after first Sync = %d want 1", syncDirCalls)
+	}
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+	if syncDirCalls != 1 {
+		t.Fatalf("syncDir calls after second Sync = %d want 1", syncDirCalls)
+	}
+}
+
+func TestWriterRotateTo_DefersDirSyncUntilSync(t *testing.T) {
+	origSyncDir := syncDirFn
+	var syncDirCalls int
+	syncDirFn = func(path string) error {
+		syncDirCalls++
+		return nil
+	}
+	defer func() { syncDirFn = origSyncDir }()
+
+	writer := NewWriterWithSink(io.Discard, page.ValueLogFileID(1))
+	dir := t.TempDir()
+	path1 := filepath.Join(dir, "value-000001.log")
+	path2 := filepath.Join(dir, "value-000002.log")
+	if err := writer.RotateTo(path1, page.ValueLogFileID(1)); err != nil {
+		t.Fatalf("RotateTo(path1): %v", err)
+	}
+	if syncDirCalls != 0 {
+		t.Fatalf("syncDir calls after RotateTo(path1) = %d want 0", syncDirCalls)
+	}
+	if _, err := writer.Append(0, nil, 1, []byte("value")); err != nil {
+		t.Fatalf("Append(path1): %v", err)
+	}
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("Sync(path1): %v", err)
+	}
+	if syncDirCalls != 1 {
+		t.Fatalf("syncDir calls after Sync(path1) = %d want 1", syncDirCalls)
+	}
+	if err := writer.RotateTo(path2, page.ValueLogFileID(2)); err != nil {
+		t.Fatalf("RotateTo(path2): %v", err)
+	}
+	if syncDirCalls != 1 {
+		t.Fatalf("syncDir calls after RotateTo(path2) = %d want 1", syncDirCalls)
+	}
+	if _, err := writer.Append(0, nil, 2, []byte("value")); err != nil {
+		t.Fatalf("Append(path2): %v", err)
+	}
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("Sync(path2): %v", err)
+	}
+	if syncDirCalls != 2 {
+		t.Fatalf("syncDir calls after Sync(path2) = %d want 2", syncDirCalls)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestWriterRotateTo_DeferSealedSyncSyncsSealedFilesAtSync(t *testing.T) {
+	dir := t.TempDir()
+	path1 := filepath.Join(dir, "value-000001.log")
+	path2 := filepath.Join(dir, "value-000002.log")
+
+	writer, err := NewWriter(path1, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	var syncCalls int
+	writer.syncFn = func(file *os.File) error {
+		syncCalls++
+		return nil
+	}
+	writer.SetDeferSealedSync(true)
+
+	if _, err := writer.Append(0, nil, 1, []byte("value-1")); err != nil {
+		t.Fatalf("Append(path1): %v", err)
+	}
+	if err := writer.RotateTo(path2, page.ValueLogFileID(2)); err != nil {
+		t.Fatalf("RotateTo(path2): %v", err)
+	}
+	if syncCalls != 0 {
+		t.Fatalf("sync calls after RotateTo = %d want 0", syncCalls)
+	}
+	if len(writer.sealedFiles) != 1 {
+		t.Fatalf("sealed files after RotateTo = %d want 1", len(writer.sealedFiles))
+	}
+	if _, err := writer.Append(0, nil, 2, []byte("value-2")); err != nil {
+		t.Fatalf("Append(path2): %v", err)
+	}
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if syncCalls != 2 {
+		t.Fatalf("sync calls after Sync = %d want 2 (sealed + current)", syncCalls)
+	}
+	if len(writer.sealedFiles) != 0 {
+		t.Fatalf("sealed files after Sync = %d want 0", len(writer.sealedFiles))
+	}
+}
+
+func TestWriterSync_SkipsRedundantSyncWhenClean(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-000001.log")
+
+	writer, err := NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	var syncCalls int
+	writer.syncFn = func(file *os.File) error {
+		syncCalls++
+		return nil
+	}
+	if _, err := writer.Append(0, nil, 1, []byte("value")); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("first Sync: %v", err)
+	}
+	if syncCalls != 1 {
+		t.Fatalf("sync calls after first Sync = %d want 1", syncCalls)
+	}
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+	if syncCalls != 1 {
+		t.Fatalf("sync calls after second Sync = %d want 1", syncCalls)
 	}
 }

--- a/worklog/2026-04-07-issue-948.md
+++ b/worklog/2026-04-07-issue-948.md
@@ -619,3 +619,258 @@
 - benchmark sanity after the final code still passes:
   - `GOWORK=off go test ./TreeDB/caching -count=1`
   - `GOWORK=off go test ./TreeDB -run '^$' -bench '^BenchmarkRestoreLikeTraceReplay$' -benchtime=1x -count=1`
+
+### Online-Rewrite Throughput Sprint: Profile Baseline
+
+- timestamp:
+  - `2026-04-08T18:38:00Z`
+- objective:
+  - target the online rewrite execution path itself, not more debt discovery
+  - measure and optimize throughput for:
+    - value pointer rewrite
+    - leafref rewrite
+    - batched pointer swap
+    - decode / encode / append subpaths
+- baseline profiling artifacts:
+  - `artifacts/rewrite_throughput_profiles/baseline_20260408083836`
+  - `value_ptr.bench.txt`, `value_ptr.cpu.pprof`, `value_ptr.mem.pprof`
+  - `leafref.bench.txt`, `leafref.cpu.pprof`, `leafref.mem.pprof`
+  - `swap.bench.txt`, `swap.cpu.pprof`, `swap.mem.pprof`
+- baseline microbench shape before the new throughput changes:
+  - `BenchmarkValueLogRewriteOnline_ValuePointers`
+    - `~23-24 ms/op`
+    - `~4.33 MB/op`
+    - `~152-153 allocs/op`
+  - `BenchmarkValueLogRewriteOnline_LeafRefs`
+    - `~19-20 ms/op`
+    - `~4.33 MB/op`
+    - `~237-241 allocs/op`
+  - `BenchmarkCollectRewriteSwapPointerMatches_DeltaTracking`
+    - `NoDelta ~260 us/op`
+    - `WithDelta ~368-382 us/op`
+- baseline profile read:
+  - value-pointer rewrite time was concentrated in:
+    - source read / RID scan syscalls
+    - writer append/flush/sync
+    - segment creation / rotation
+  - leafref rewrite time was concentrated in:
+    - leaf-page append / rotate
+    - zipper persistence
+  - swap matching was visible in its own microbench, but much smaller than append/bookkeeping in end-to-end rewrite
+
+### Online-Rewrite Throughput Sprint: Instrumentation
+
+- added coarse stage timings to `TreeDB/db/vlog_rewrite.go`:
+  - `PlanNanos`
+  - `SourceScanNanos`
+  - `ReadDecodeNanos`
+  - `EncodeAppendNanos`
+  - `SwapCommitNanos`
+  - `BookkeepingNanos`
+  - `LeafRefNanos`
+  - `ReadCalls`
+  - `AppendCalls`
+  - `SwapBatches`
+- extended `TreeDB/db/vlog_rewrite_bench_test.go` to report those stage metrics
+- added focused microbenches:
+  - `BenchmarkValueLogReadUnsafeTo_ValuePointers`
+  - `BenchmarkValueLogReadUnsafeTo_LeafRefs`
+  - `BenchmarkRewriteWriterAppendValue`
+  - `BenchmarkRewriteWriterAppendLeafPage`
+- key result from the first stage breakdown:
+  - pure read/decode is cheap
+  - the hot path is append + bookkeeping/persistence
+  - swap/commit is real but secondary
+
+### Throughput Cycle 1: Defer Directory Sync To Durability Boundary
+
+- files:
+  - `TreeDB/internal/valuelog/writer.go`
+  - `TreeDB/internal/valuelog/writer_memory_test.go`
+- implementation:
+  - creating / rotating a segment no longer immediately syncs the directory
+  - dir sync is deferred until `Sync()` / `Close()`
+- focused validation:
+  - `TestNewWriter_DefersDirSyncUntilSync`
+  - `TestWriterRotateTo_DefersDirSyncUntilSync`
+- effect:
+  - remove avoidable directory fsync churn from the hot rewrite path
+
+### Throughput Cycle 2: Dedicated Leaf-Page Append Path
+
+- files:
+  - `TreeDB/db/vlog_rewrite.go`
+  - `TreeDB/internal/valuelog/manager.go`
+- implementation:
+  - leafref rewrite now uses `appendLeafPageWithRID(...)` instead of the generic pointer-value append path
+  - rewrite writer reuses the preferred leaf dictionary from the current value-log set when available
+- focused validation:
+  - `TestRewriteWriter_AppendLeafPageUsesLeafDictWhenConfigured`
+  - `TestValueLogRewriteOnline_RewritesLeafRefsAndReclaimsSegments`
+  - `TestValueLogRewriteOnline_WALOnLeafRefsPreserveNestedValueSegments`
+- effect:
+  - leafref microbench wall time dropped materially
+  - `leafref_ns/op` moved from roughly `~1.05 ms` to roughly `~0.35-0.37 ms` in early focused runs
+
+### Throughput Cycle 3: Defer Sealed-File Sync For Rewrite Writers
+
+- files:
+  - `TreeDB/internal/valuelog/writer.go`
+  - `TreeDB/internal/valuelog/writer_memory_test.go`
+  - `TreeDB/db/vlog_rewrite.go`
+- implementation:
+  - rewrite-created rotated files are flushed and kept open as sealed files
+  - their file sync happens at the rewrite durability boundary instead of on each rotate
+  - enabled only for rewrite writers via `SetDeferSealedSync(true)`
+- focused validation:
+  - `TestWriterRotateTo_DeferSealedSyncSyncsSealedFilesAtSync`
+- effect:
+  - the rotate-heavy append path stopped paying per-rotation fsync cost in the timed hot path
+  - value-pointer rewrite bench moved down into the `~17-18 ms/op` range in the best focused runs
+
+### Throughput Cycle 4: Skip Redundant Clean Syncs
+
+- files:
+  - `TreeDB/internal/valuelog/writer.go`
+  - `TreeDB/internal/valuelog/writer_memory_test.go`
+- implementation:
+  - writer now tracks `dirty`
+  - `Sync()` becomes a no-op when there are:
+    - no unsynced writes
+    - no deferred sealed files
+    - no pending directory sync
+- focused validation:
+  - `TestWriterSync_SkipsRedundantSyncWhenClean`
+  - full writer hot-path regression tests stayed green
+- effect:
+  - removes wasted durability work when rewrite calls `Sync()` after a previously-synced batch
+  - this is a smaller/noisier bench win than cycles 2 and 3, but correctness stayed intact
+
+### Throughput Cycle 5: Low-Pressure Fresh-Probe / Rewrite Cadence
+
+- files:
+  - `TreeDB/caching/db.go`
+  - `TreeDB/caching/vlog_generation_scheduler_test.go`
+- implementation:
+  - added `vlogGenerationRewriteLowPressureMinInterval = 5s`
+  - under steady low-pressure conditions, fresh rewrite probes and fresh non-queued rewrites no longer wait the generic `30s` interval
+  - queued-debt resume semantics remain separate (`1s`), and non-low-pressure behavior remains at the regular cadence
+- focused validation:
+  - `TestVlogGenerationMaintenance_LowPressureTailPackingUsesShorterMinInterval_FastModes`
+  - existing tail-packing periodic rewrite tests stayed green
+- intended effect:
+  - increase minute-15 live compaction by allowing more low-pressure tail-packing passes in the exact steady-state workload we care about
+
+### Throughput Sprint: Current Bench Read Before Final Dwell Validation
+
+- focused validation commands:
+  - `GOWORK=off go test ./TreeDB/internal/valuelog -run 'Test(NewWriter_DefersDirSyncUntilSync|WriterRotateTo_DefersDirSyncUntilSync|WriterRotateTo_DeferSealedSyncSyncsSealedFilesAtSync|WriterSync_SkipsRedundantSyncWhenClean)$' -count=1`
+  - `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationMaintenance_LowPressureTailPackingUsesShorterMinInterval_FastModes|VlogGenerationMaintenance_PeriodicTailPackingRunsAfterEmptyTailPlan_FastModes|VlogGenerationMaintenance_PeriodicTailPlanFillAddsLiveOnlySegments_FastModes|VlogGenerationMaintenance_PeriodicTailRewriteRunsInSteadyFastModes|VlogGenerationMaintenance_PeriodicTailRewriteRunsUnderFullQuietWithoutWrites_FastModes)$' -count=1`
+  - `GOWORK=off go test ./TreeDB/db -run '^$' -bench '^BenchmarkValueLogRewriteOnline_(ValuePointers|LeafRefs)$' -benchmem -count=1`
+- current bench snapshot on the cumulative branch state:
+  - `BenchmarkValueLogRewriteOnline_ValuePointers`
+    - `17173780 ns/op`
+    - `4338628 B/op`
+    - `154 allocs/op`
+    - stage metrics:
+      - `append_ns/op = 854301`
+      - `bookkeeping_ns/op = 435460`
+      - `read_decode_ns/op = 218177`
+      - `swap_commit_ns/op = 160127`
+  - `BenchmarkValueLogRewriteOnline_LeafRefs`
+    - `10693114 ns/op`
+    - `4320569 B/op`
+    - `235 allocs/op`
+    - stage metrics:
+      - `leafref_ns/op = 423586`
+      - `bookkeeping_ns/op = 315347`
+      - `scan_ns/op = 103502`
+- live validation in progress:
+  - exact `fast` + `wal_on_fast` `dwell15m` rerun on the throughput-sprint branch
+  - artifact root:
+    - `artifacts/celestia_profile_signals/throughput_sprint_20260408`
+  - fixed bootstrap:
+    - `/home/mikers/.celestia-bootstrap-issue948-tail-20260408`
+  - fixed stop height:
+    - `10568067`
+
+### Throughput Cycle 5 Result: Rejected
+
+- outcome:
+  - the low-pressure `5s` cadence experiment does not survive the full sprint
+  - it looked promising for `wal_on_fast`, but it regressed `fast` on the real `15m` dwell loop
+- investigation:
+  - first split rerun on `artifacts/celestia_profile_signals/throughput_sprint_20260408` showed:
+    - `fast app_bytes = 3499776720` at minute 15, worse than the cycle-4 floor `3337649925`
+    - `wal_on_fast app_bytes = 3110336217`, better than the cycle-4 floor `3361038505`
+  - narrowed the short cadence to WAL-on fresh probes only, then found the actual rewrite execution min-interval still applied the `5s` path to `fast`
+  - fixed that and reran, but the corrected rerun still had `fast` materially above the cycle-4 floor late in dwell, so the experiment was thrown out
+- decision:
+  - revert all cycle-5 cadence changes
+  - keep cycles 1 through 4 only as the final sprint result
+
+### Throughput Sprint: Final Kept Branch State
+
+- kept changes:
+  - cycle 1: defer directory sync to the durability boundary for rewrite-created files
+  - cycle 2: dedicated leaf-page append path and preferred leaf-dict reuse
+  - cycle 3: defer sealed-file sync for rewrite writers until the durability boundary
+  - cycle 4: skip redundant clean `Sync()` calls
+- discarded change:
+  - cycle 5 low-pressure `5s` rewrite/probe cadence
+- final local validation on the kept state:
+  - `GOWORK=off go test ./TreeDB/internal/valuelog -run 'Test(NewWriter_DefersDirSyncUntilSync|WriterRotateTo_DefersDirSyncUntilSync|WriterRotateTo_DeferSealedSyncSyncsSealedFilesAtSync|WriterSync_SkipsRedundantSyncWhenClean)$' -count=1`
+  - `GOWORK=off go test ./TreeDB/caching -count=1`
+  - `GOWORK=off go test ./TreeDB/db -run '^$' -bench '^BenchmarkValueLogRewriteOnline_(ValuePointers|LeafRefs)$' -benchmem -count=1`
+- final bench snapshot on the kept state:
+  - `BenchmarkValueLogRewriteOnline_ValuePointers`
+    - `16751605 ns/op`
+    - `4335970 B/op`
+    - `153 allocs/op`
+  - `BenchmarkValueLogRewriteOnline_LeafRefs`
+    - `11472326 ns/op`
+    - `4326692 B/op`
+    - `237 allocs/op`
+
+### Throughput Sprint: Final Live/System Evidence
+
+- `fast` exact `15m` dwell on the kept state:
+  - artifacts:
+    - `artifacts/celestia_profile_signals/issue948_mixedtail8_fast_20260408073819/fast_dwell15m`
+    - `artifacts/issue948_post_dwell_offline_compare_fastonly/20260408075919/fast`
+  - live minute-15 sizes:
+    - `app_bytes = 3337649925`
+    - `wal_bytes = 3268782449`
+  - live rewrite activity:
+    - `rewrite_runs = 15`
+    - `queued_exec_runs = 15`
+    - `rewrite_queue_len = 0`
+  - offline compare on the exact post-dwell home:
+    - post-`vlog-gc`: `3337649934`
+    - post-`vlog-rewrite`: `2298580711`
+    - remaining post-dwell offline rewrite gap:
+      - `3337649925 -> 2298580711` delta `-1039069214`
+
+- `wal_on_fast` exact `15m` dwell on the kept state:
+  - artifacts:
+    - `artifacts/celestia_profile_signals/issue948_mixedtail8_walon_20260408080150/wal_on_fast_dwell15m`
+    - `artifacts/issue948_post_dwell_offline_compare/20260408082143/wal_on_fast`
+  - live minute-15 sizes:
+    - `app_bytes = 3361038505`
+    - `wal_bytes = 3298692237`
+  - live rewrite activity:
+    - `rewrite_runs = 9`
+    - `queued_exec_runs = 8`
+    - `rewrite_queue_len = 0`
+  - offline compare on the exact post-dwell home:
+    - post-`vlog-gc`: `3092602287`
+    - post-`vlog-rewrite`: `2099004501`
+    - remaining post-dwell offline rewrite gap:
+      - `3361038505 -> 2099004501` delta `-1262034004`
+
+### Throughput Sprint: Final Conclusion
+
+- the sprint materially improved online rewrite throughput, but not enough to match the offline rewrite floor
+- the durable wins are cycles 1 through 4
+- the largest remaining gap is still online rewrite throughput, not debt discovery or queue generation
+- the rejected cycle-5 cadence experiment is documented here so it does not get reintroduced as a blind follow-up


### PR DESCRIPTION
## Summary
- instrument `ValueLogRewriteOnline` with coarse per-stage timing and expose rewrite hot-path microbenches
- speed up rewrite append persistence by deferring directory/sealed-file sync to the durability boundary and skipping redundant clean syncs
- use a dedicated leaf-page append path plus preferred leaf-dict reuse to reduce leafref rewrite cost
- document the throughput sprint and explicitly discard the attempted low-pressure 5s cadence experiment because it regressed `fast`

## Validation
- `GOWORK=off go test ./TreeDB/internal/valuelog -run 'Test(NewWriter_DefersDirSyncUntilSync|WriterRotateTo_DefersDirSyncUntilSync|WriterRotateTo_DeferSealedSyncSyncsSealedFilesAtSync|WriterSync_SkipsRedundantSyncWhenClean)$' -count=1`
- `GOWORK=off go test ./TreeDB/caching -count=1`
- `GOWORK=off go test ./TreeDB/db -run '^$' -bench '^BenchmarkValueLogRewriteOnline_(ValuePointers|LeafRefs)$' -benchmem -count=1`

## Bench Results
Current kept-state microbenches:
- `BenchmarkValueLogRewriteOnline_ValuePointers`: `16751605 ns/op`, `4335970 B/op`, `153 allocs/op`
- `BenchmarkValueLogRewriteOnline_LeafRefs`: `11472326 ns/op`, `4326692 B/op`, `237 allocs/op`

## Exact 15m Dwell Results
Artifacts are recorded in the repo work log.

`fast` kept-state live dwell + offline compare:
- minute-15 live: `app_bytes=3337649925`, `wal_bytes=3268782449`
- live rewrite: `rewrite_runs=15`, `queued_exec_runs=15`, `rewrite_queue_len=0`
- post-dwell offline compare: `3337649925 -> 3337649934` after `vlog-gc`, `3337649925 -> 2298580711` after `vlog-rewrite`

`wal_on_fast` kept-state live dwell + offline compare:
- minute-15 live: `app_bytes=3361038505`, `wal_bytes=3298692237`
- live rewrite: `rewrite_runs=9`, `queued_exec_runs=8`, `rewrite_queue_len=0`
- post-dwell offline compare: `3361038505 -> 3092602287` after `vlog-gc`, `3361038505 -> 2099004501` after `vlog-rewrite`

## Notes
- The cycle-5 low-pressure `5s` cadence experiment was attempted and rejected. It improved `wal_on_fast` in isolation but regressed `fast` on the exact 15-minute dwell, so it is not included in this PR.
- This PR is intentionally stacked on top of #949.