### PR TITLE
[codex] TreeDB: fix selected-source rewrite accounting

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1889,6 +1889,12 @@ const (
 	envDisableVlogGenerationVacuum         = "TREEDB_DISABLE_VLOG_GENERATION_VACUUM"
 	envDisableVlogGenerationLoop           = "TREEDB_DISABLE_VLOG_GENERATION_LOOP"
 	envDisableVlogGenerationCheckpointKick = "TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK"
+	envEnableVlogQueueWorkItems            = "TREEDB_VLOG_QUEUE_WORKITEMS"
+	envEnableVlogDebtLedger                = "TREEDB_VLOG_DEBT_LEDGER"
+	envEnableVlogLocatorCatalog            = "TREEDB_VLOG_LOCATOR_CATALOG"
+	envEnableVlogCatalogGC                 = "TREEDB_VLOG_CATALOG_GC"
+	envEnableVlogShadowCompare             = "TREEDB_VLOG_SHADOW_COMPARE"
+	envEnableVlogReconcileOnly             = "TREEDB_VLOG_RECONCILE_ONLY"
 	// Optional rewrite debt-drain caps for controlled online experiments.
 	envVlogGenerationRewriteResumeMaxSegments         = "TREEDB_VLOG_GENERATION_REWRITE_RESUME_MAX_SEGMENTS"
 	envVlogGenerationRewriteDebtDrainMaxSegments      = "TREEDB_VLOG_GENERATION_REWRITE_DEBT_DRAIN_MAX_SEGMENTS"
@@ -17860,7 +17866,10 @@ planned:
 				}
 			} else if len(processedRewriteIDs) > 0 {
 				removeRewriteIDs := processedRewriteIDs
-				if rewriteOpts.MaxCopiedBytes > 0 {
+				if len(stats.DrainedSourceFileIDs) > 0 {
+					removeRewriteIDs = append([]uint32(nil), stats.DrainedSourceFileIDs...)
+				}
+				if rewriteOpts.MaxCopiedBytes > 0 && len(stats.DrainedSourceFileIDs) == 0 {
 					removeRewriteIDs = append([]uint32(nil), stats.SourceFileIDsUnreferenced...)
 					if len(removeRewriteIDs) == 0 &&
 						stats.SourceSegmentsRequested == 0 &&
@@ -18345,22 +18354,7 @@ planned:
 				db.vlogGenerationRewriteSourceBytesUnreferencedTotal.Add(sourceBytesUnreferenced)
 				db.vlogGenerationRewriteSourceBytesUnreferencedBySource[activeSourceIdx].Add(sourceBytesUnreferenced)
 			}
-			rewriteBytesIn := int64(0)
-			if stats.SourceBytesProcessed > 0 {
-				rewriteBytesIn = stats.SourceBytesProcessed
-			} else if processedLedgerOK {
-				rewriteBytesIn = processedLedgerLiveBytes
-			} else if len(processedRewriteIDs) > 0 && stats.BytesBefore > 0 {
-				rewriteBytesIn = int64(stats.BytesBefore)
-			} else if haveRewriteChunkPlan && rewriteChunkPlan.SelectedBytesLive > 0 {
-				rewriteBytesIn = rewriteChunkPlan.SelectedBytesLive
-			} else if haveRewritePlan && rewritePlan.SelectedBytesLive > 0 {
-				rewriteBytesIn = rewritePlan.SelectedBytesLive
-			} else if maxSourceBytes > 0 {
-				rewriteBytesIn = maxSourceBytes
-			} else if stats.BytesBefore > 0 {
-				rewriteBytesIn = int64(stats.BytesBefore)
-			}
+			rewriteBytesIn := valueLogRewriteAccountingBytes(stats, processedLedgerOK, processedLedgerLiveBytes, haveRewriteChunkPlan, rewriteChunkPlan, haveRewritePlan, rewritePlan, maxSourceBytes)
 			if rewriteBytesIn > 0 {
 				db.vlogGenerationRewriteBytesIn.Add(uint64(rewriteBytesIn))
 			}
@@ -18375,22 +18369,7 @@ planned:
 			db.vlogGenerationRewriteExecLastBytesOut.Store(rewriteBytesOut)
 			db.vlogGenerationRewriteExecLastDurationNanos.Store(uint64(rewriteDur))
 			db.vlogGenerationRewriteExecLastUnixNano.Store(time.Now().UnixNano())
-			consumed := int64(0)
-			if stats.SourceBytesProcessed > 0 {
-				consumed = stats.SourceBytesProcessed
-			} else if processedLedgerOK {
-				consumed = processedLedgerLiveBytes
-			} else if len(processedRewriteIDs) > 0 && stats.BytesBefore > 0 {
-				consumed = int64(stats.BytesBefore)
-			} else if haveRewriteChunkPlan && rewriteChunkPlan.SelectedBytesLive > 0 {
-				consumed = rewriteChunkPlan.SelectedBytesLive
-			} else if haveRewritePlan && rewritePlan.SelectedBytesLive > 0 {
-				consumed = rewritePlan.SelectedBytesLive
-			} else if maxSourceBytes > 0 {
-				consumed = maxSourceBytes
-			} else if stats.BytesBefore > 0 {
-				consumed = int64(stats.BytesBefore)
-			}
+			consumed := rewriteBytesIn
 			if stats.RecordsCopied > 0 {
 				db.vlogGenerationRemapSuccesses.Add(uint64(stats.RecordsCopied))
 			}
@@ -18409,7 +18388,7 @@ planned:
 			if consumed > 0 {
 				db.vlogGenerationConsumeRewriteBudgetBytes(consumed, activeSourceIdx)
 			}
-			db.maybeRunVlogGenerationIndexVacuum(int64(stats.BytesBefore))
+			db.maybeRunVlogGenerationIndexVacuum(rewriteBytesIn)
 			return nil
 		})
 		if err != nil {
@@ -19067,6 +19046,35 @@ func (db *DB) maybeKickVlogGenerationMaintenanceAfterCheckpoint() {
 			db.vlogGenerationCheckpointKickPending.Load(),
 		)
 	}()
+}
+
+func valueLogRewriteAccountingBytes(
+	stats backenddb.ValueLogRewriteStats,
+	processedLedgerOK bool,
+	processedLedgerLiveBytes int64,
+	haveRewriteChunkPlan bool,
+	rewriteChunkPlan backenddb.ValueLogRewriteChunkPlan,
+	haveRewritePlan bool,
+	rewritePlan backenddb.ValueLogRewritePlan,
+	maxSourceBytes int64,
+) int64 {
+	if stats.SourceBytesProcessed > 0 {
+		return stats.SourceBytesProcessed
+	}
+	if stats.SelectedSourceLiveBytesBefore > 0 {
+		return stats.SelectedSourceLiveBytesBefore
+	}
+	if stats.SelectedSourceBytesBefore > 0 {
+		return stats.SelectedSourceBytesBefore
+	}
+	_ = processedLedgerOK
+	_ = processedLedgerLiveBytes
+	_ = haveRewriteChunkPlan
+	_ = rewriteChunkPlan
+	_ = haveRewritePlan
+	_ = rewritePlan
+	_ = maxSourceBytes
+	return 0
 }
 
 func (db *DB) maybeRunVlogGenerationIndexVacuum(rewriteBytesIn int64) {
@@ -25132,6 +25140,12 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_generation.segments.hot"] = fmt.Sprintf("%d", retained.SegmentsHot)
 	stats["treedb.cache.vlog_generation.segments.warm"] = fmt.Sprintf("%d", retained.SegmentsWarm)
 	stats["treedb.cache.vlog_generation.segments.cold"] = fmt.Sprintf("%d", retained.SegmentsCold)
+	stats["treedb.cache.vlog_generation.flags.queue_workitems"] = fmt.Sprintf("%t", envBool(envEnableVlogQueueWorkItems))
+	stats["treedb.cache.vlog_generation.flags.debt_ledger"] = fmt.Sprintf("%t", envBool(envEnableVlogDebtLedger))
+	stats["treedb.cache.vlog_generation.flags.locator_catalog"] = fmt.Sprintf("%t", envBool(envEnableVlogLocatorCatalog))
+	stats["treedb.cache.vlog_generation.flags.catalog_gc"] = fmt.Sprintf("%t", envBool(envEnableVlogCatalogGC))
+	stats["treedb.cache.vlog_generation.flags.shadow_compare"] = fmt.Sprintf("%t", envBool(envEnableVlogShadowCompare))
+	stats["treedb.cache.vlog_generation.flags.reconcile_only"] = fmt.Sprintf("%t", envBool(envEnableVlogReconcileOnly))
 	stats["treedb.cache.vlog_generation.rewrite.bytes_in"] = fmt.Sprintf("%d", rewriteBytesInTotal)
 	stats["treedb.cache.vlog_generation.rewrite.bytes_out"] = fmt.Sprintf("%d", rewriteBytesOutTotal)
 	stats["treedb.cache.vlog_generation.rewrite.value_records_copied"] = fmt.Sprintf("%d", rewriteValueRecordsCopiedTotal)

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1611,9 +1611,77 @@ func (b *rewriteBudgetRecordingBackend) ValueLogRewriteOnline(ctx context.Contex
 	stats := b.rewriteResponse
 	err := b.rewriteErr
 	customFn := b.rewriteFn
+	plan := b.planResponse
 	b.mu.Unlock()
 	if customFn != nil {
 		return customFn(ctx, opts)
+	}
+	stats.RequestedSourceFileIDs = append([]uint32(nil), stats.RequestedSourceFileIDs...)
+	stats.DrainedSourceFileIDs = append([]uint32(nil), stats.DrainedSourceFileIDs...)
+	if len(stats.RequestedSourceFileIDs) == 0 && len(opts.SourceFileIDs) > 0 {
+		stats.RequestedSourceFileIDs = append([]uint32(nil), opts.SourceFileIDs...)
+	}
+	if err == nil &&
+		len(stats.DrainedSourceFileIDs) == 0 &&
+		len(opts.SourceFileIDs) > 0 &&
+		(stats.SourceBytesUnreferenced > 0 || stats.BytesAfter == 0 || stats.BytesAfter < stats.BytesBefore) {
+		stats.DrainedSourceFileIDs = append([]uint32(nil), opts.SourceFileIDs...)
+	}
+	if len(opts.SourceFileIDs) > 0 {
+		exactPlannedSelection := false
+		if len(plan.SourceFileIDs) == len(opts.SourceFileIDs) {
+			exactPlannedSelection = true
+			for _, requestedID := range opts.SourceFileIDs {
+				found := false
+				for _, plannedID := range plan.SourceFileIDs {
+					if plannedID == requestedID {
+						found = true
+						break
+					}
+				}
+				if !found {
+					exactPlannedSelection = false
+					break
+				}
+			}
+		}
+		allowPlannedSelectionBytes := opts.MaxCopiedBytes == 0 && exactPlannedSelection
+		if stats.SelectedSourceBytesBefore == 0 && allowPlannedSelectionBytes {
+			var selectedTotal int64
+			var matched bool
+			for _, seg := range plan.SelectedSegments {
+				for _, id := range opts.SourceFileIDs {
+					if seg.FileID == id {
+						selectedTotal += seg.BytesTotal
+						matched = true
+						break
+					}
+				}
+			}
+			if matched {
+				stats.SelectedSourceBytesBefore = selectedTotal
+			} else if plan.SelectedBytesTotal > 0 {
+				stats.SelectedSourceBytesBefore = plan.SelectedBytesTotal
+			}
+		}
+		if stats.SelectedSourceLiveBytesBefore == 0 && allowPlannedSelectionBytes {
+			var selectedLive int64
+			var matched bool
+			for _, seg := range plan.SelectedSegments {
+				for _, id := range opts.SourceFileIDs {
+					if seg.FileID == id {
+						selectedLive += seg.BytesLive
+						matched = true
+						break
+					}
+				}
+			}
+			if matched {
+				stats.SelectedSourceLiveBytesBefore = selectedLive
+			} else if plan.SelectedBytesLive > 0 {
+				stats.SelectedSourceLiveBytesBefore = plan.SelectedBytesLive
+			}
+		}
 	}
 	return stats, err
 }
@@ -5325,7 +5393,6 @@ func TestVlogGenerationRewrite_QueuedFollowupRunsAfterLocallyEffectiveFreshPlan(
 	if got := db.vlogGenerationRewriteIneffectiveLastNS.Load(); got != 0 {
 		t.Fatalf("ineffective last ts=%d want 0 before queued follow-up", got)
 	}
-
 	db.vlogGenerationLastRewriteUnixNano.Store(0)
 	forceVlogMaintenanceIdle(db)
 	db.maybeRunVlogGenerationMaintenanceWithOptions(false, vlogGenerationMaintenanceOptions{

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -88,6 +88,18 @@ type ValueLogRewriteStats struct {
 	// SourceBytesUnreferenced is the bytes of selected source segments that
 	// became unreferenced after rewrite pointer swaps and cleanup.
 	SourceBytesUnreferenced int64
+	// SelectedSourceBytesBefore is the total bytes across the specific source
+	// segments requested for this rewrite run.
+	SelectedSourceBytesBefore int64
+	// SelectedSourceLiveBytesBefore is the estimated live-byte total across the
+	// specific source segments requested for this rewrite run.
+	SelectedSourceLiveBytesBefore int64
+	// RequestedSourceFileIDs records the sorted source segment IDs requested for
+	// this rewrite run.
+	RequestedSourceFileIDs []uint32
+	// DrainedSourceFileIDs records the requested source segment IDs that were no
+	// longer referenced after rewrite cleanup completed.
+	DrainedSourceFileIDs []uint32
 	// SourceBytesProcessed is the bounded subset of selected source bytes
 	// actually rewritten in this pass. When zero, the rewrite either copied
 	// nothing or ran without a per-pass source-byte bound.
@@ -119,6 +131,13 @@ type ValueLogRewriteStats struct {
 	// Rewrite stage timings are coarse wall-clock timings for the main online
 	// rewrite phases. ReadDecodeNanos includes both source reads and value-log
 	// decode because the current ReadUnsafeTo API does not separate them.
+	CandidateScanMode  string
+	CandidateScanCount int
+	CandidateCount     int
+	CandidateScanNanos int64
+	CopyNanos          int64
+	SwapNanos          int64
+	CleanupNanos       int64
 	PlanNanos         int64
 	SourceScanNanos   int64
 	ReadDecodeNanos   int64
@@ -175,6 +194,18 @@ type ValueLogRewritePlan struct {
 	AgeBlockedBytesLive       int64
 	AgeBlockedBytesStale      int64
 	AgeBlockedMinRemainingAge time.Duration
+}
+
+func sortedValueLogFileIDs(ids map[uint32]struct{}) []uint32 {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]uint32, 0, len(ids))
+	for id := range ids {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
 }
 
 // ValueLogRewriteOnlineOptions controls online rewrite behavior.
@@ -1369,6 +1400,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		restrictSingleID   bool
 		sourceSegmentCount int
 		sourceSegmentBytes map[uint32]int64
+		liveByID           map[uint32]int64
 	)
 	if hasExplicitRewriteChunks(opts) {
 		sourceChunkBytes = normalizeValueLogRewriteChunkBytes(opts.SourceChunkBytes)
@@ -1404,7 +1436,6 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		stats.SourceSegmentsRequested = sourceSegmentCount
 	} else if hasRewriteSourceSelection(opts) {
 		active := currentValueLogIDs(set)
-		var liveByID map[uint32]int64
 		if rewritePlanNeedsLiveEstimate(opts) {
 			liveByID, err = db.estimateValueLogLiveBytesBySegment(ctx)
 			if err != nil {
@@ -1434,6 +1465,28 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 				}
 			}
 			stats.SourceBytesRequested = requestedBytes
+		}
+	}
+	if sourceSegmentCount > 0 {
+		if restrictSingleID {
+			stats.RequestedSourceFileIDs = []uint32{singleSourceID}
+		} else {
+			stats.RequestedSourceFileIDs = sortedValueLogFileIDs(sourceIDs)
+		}
+		stats.SelectedSourceBytesBefore = stats.SourceBytesRequested
+		if stats.SelectedSourceBytesBefore == 0 {
+			for _, size := range sourceSegmentBytes {
+				if size > 0 {
+					stats.SelectedSourceBytesBefore += size
+				}
+			}
+		}
+		if liveByID != nil {
+			for _, id := range stats.RequestedSourceFileIDs {
+				stats.SelectedSourceLiveBytesBefore += liveByID[id]
+			}
+		} else {
+			stats.SelectedSourceLiveBytesBefore = stats.SelectedSourceBytesBefore
 		}
 	}
 	if restrictSource && sourceSegmentCount == 0 {
@@ -1559,6 +1612,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		if err != nil {
 			return err
 		}
+		copyStart := time.Now()
 		for _, candidate := range candidates {
 			if rewriteReadScratch == nil {
 				rewriteReadScratch = make([]byte, 0, rewriteReadScratchInitCap)
@@ -1611,6 +1665,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 				newPtr: newPtr,
 			})
 		}
+		stats.CopyNanos += time.Since(copyStart).Nanoseconds()
 		bookkeepingStart := time.Now()
 		if opts.SyncEachBatch {
 			if err := writer.Sync(); err != nil {
@@ -1642,7 +1697,9 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		if err := db.applyRewriteSwapBatch(swaps, opts.SyncEachBatch); err != nil {
 			return err
 		}
-		stats.SwapCommitNanos += time.Since(swapStart).Nanoseconds()
+		swapElapsed := time.Since(swapStart).Nanoseconds()
+		stats.SwapCommitNanos += swapElapsed
+		stats.SwapNanos += swapElapsed
 		stats.SwapBatches++
 		candidates = candidates[:0]
 		if cap(candidateKeyArena) > rewriteKeyArenaMaxCap {
@@ -1659,6 +1716,9 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		return stats, fmt.Errorf("missing snapshot state")
 	}
 	it := snap.tree.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+	stats.CandidateScanMode = "tree"
+	stats.CandidateScanCount = 1
+	candidateScanStart := time.Now()
 	scanStart := time.Now()
 	for ; it.Valid(); it.Next() {
 		if err := ctx.Err(); err != nil {
@@ -1708,6 +1768,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		keyStart := len(candidateKeyArena)
 		candidateKeyArena = append(candidateKeyArena, unsafeKey...)
 		key := candidateKeyArena[keyStart:len(candidateKeyArena):len(candidateKeyArena)]
+		stats.CandidateCount++
 		candidates = append(candidates, rewriteCandidate{
 			key:         key,
 			oldPtr:      oldPtr,
@@ -1728,6 +1789,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		}
 	}
 	stats.SourceScanNanos += time.Since(scanStart).Nanoseconds()
+	stats.CandidateScanNanos += time.Since(candidateScanStart).Nanoseconds()
 	iterErr := it.Error()
 	_ = it.Close()
 	closeRewriteSnapshot(&err, snap)
@@ -1792,6 +1854,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	// rewrite is logically committed, so value-log segment bookkeeping must always
 	// complete to keep the value-log set and on-disk metadata consistent with the
 	// already-committed pointer swaps, even if the caller's context is canceled.
+	cleanupStart := time.Now()
 	referencedAfter, err := db.referencedValueLogSegments(context.Background())
 	if err != nil {
 		return stats, err
@@ -1935,6 +1998,16 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		stats.SegmentsAfter = afterSegs
 		stats.BytesAfter = afterBytes
 	}
+	if len(stats.RequestedSourceFileIDs) > 0 {
+		stats.DrainedSourceFileIDs = make([]uint32, 0, len(stats.RequestedSourceFileIDs))
+		for _, id := range stats.RequestedSourceFileIDs {
+			if _, ok := referencedAfter[id]; ok {
+				continue
+			}
+			stats.DrainedSourceFileIDs = append(stats.DrainedSourceFileIDs, id)
+		}
+	}
+	stats.CleanupNanos += time.Since(cleanupStart).Nanoseconds()
 	stats.BookkeepingNanos += time.Since(finalBookkeepingStart).Nanoseconds()
 	if canceledErr != nil {
 		return stats, canceledErr

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -2582,6 +2582,27 @@ func TestValueLogRewriteOnline_SourceFileIDs_RestrictsRewriteSet(t *testing.T) {
 	if stats.RecordsCopied != 1 {
 		t.Fatalf("expected one rewritten record, got %d", stats.RecordsCopied)
 	}
+	if got, want := stats.RequestedSourceFileIDs, []uint32{ptrs1[0].FileID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("requested source ids=%v want=%v", got, want)
+	}
+	if got, want := stats.DrainedSourceFileIDs, []uint32{ptrs1[0].FileID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("drained source ids=%v want=%v", got, want)
+	}
+	if stats.SelectedSourceBytesBefore <= 0 {
+		t.Fatalf("expected non-zero selected source bytes before, got %d", stats.SelectedSourceBytesBefore)
+	}
+	if stats.SelectedSourceLiveBytesBefore <= 0 {
+		t.Fatalf("expected non-zero selected source live bytes before, got %d", stats.SelectedSourceLiveBytesBefore)
+	}
+	if stats.CandidateScanCount != 1 {
+		t.Fatalf("candidate scan count=%d want=1", stats.CandidateScanCount)
+	}
+	if stats.CandidateCount != 1 {
+		t.Fatalf("candidate count=%d want=1", stats.CandidateCount)
+	}
+	if stats.CandidateScanNanos <= 0 {
+		t.Fatalf("expected candidate scan nanos > 0, got %d", stats.CandidateScanNanos)
+	}
 
 	ptrK1, flagsK1 := readProjectedPointerByKey(t, db, []byte("k1"))
 	ptrK2, flagsK2 := readProjectedPointerByKey(t, db, []byte("k2"))

--- a/docs/contracts/VLOG_RUNTIME_REWRITE_CONTRACT.md
+++ b/docs/contracts/VLOG_RUNTIME_REWRITE_CONTRACT.md
@@ -1,0 +1,69 @@
+# Runtime Value-Log Rewrite Contract
+
+This note defines the rollout contract for the runtime value-log rewrite redesign.
+
+## Scope
+
+The runtime rewrite path is moving from scan-driven rediscovery toward maintained metadata.
+The transition is staged. During the transition, the legacy scan path remains the fallback and reconciliation path.
+
+## Authoritative-state rules
+
+- New runtime rewrite metadata is authoritative only when its stored `commitSeq` matches the published DB state.
+- On version mismatch, missing files, parse failure, checksum failure, or unsupported catalog shape, TreeDB must fall back to rebuild-or-scan behavior rather than serving stale metadata.
+- Planner, executor, and cleanup may each cut over independently behind flags, but every cutover must preserve a fallback path to the legacy scan implementation.
+- Dual-write must land before read-authoritative cutover.
+
+## Metadata ownership
+
+The intended sidecar metadata families are:
+
+- queue work items: persisted runtime rewrite backlog units
+- debt ledger: authoritative live/stale byte accounting by segment and physical record
+- locator catalog: reverse lookup material for selected-segment execution
+- catalog GC state: cleanup / zombie / GC view driven from the same maintained catalog
+
+These sidecars are pre-alpha and may change format without migration scaffolding.
+
+## Rollout flags
+
+The current flag scaffold is:
+
+- `TREEDB_VLOG_QUEUE_WORKITEMS`
+- `TREEDB_VLOG_DEBT_LEDGER`
+- `TREEDB_VLOG_LOCATOR_CATALOG`
+- `TREEDB_VLOG_CATALOG_GC`
+- `TREEDB_VLOG_SHADOW_COMPARE`
+- `TREEDB_VLOG_RECONCILE_ONLY`
+
+Expected behavior:
+
+- disabled flag: legacy read path remains authoritative
+- enabled dual-write flag: new metadata is written, but reads still use legacy logic unless the corresponding read path has been explicitly cut over
+- shadow compare: execute both old and new planning / selection logic, compare outputs, and preserve the legacy result on mismatch
+- reconcile only: allow rebuild / scrub passes to maintain metadata without making it authoritative for online decisions
+
+## Queue accounting contract
+
+Queued rewrite work must be accounted against the selected source set, not global value-log totals.
+
+The backend rewrite stats therefore distinguish:
+
+- global pre/post totals: `BytesBefore`, `BytesAfter`
+- selected-source totals: `SelectedSourceBytesBefore`, `SelectedSourceLiveBytesBefore`
+- requested source IDs versus drained source IDs
+
+Scheduler budget consumption and queued-run validation must use the selected-source counters.
+Queue consumption must use drained IDs, not merely requested IDs.
+
+## Rebuild and recovery
+
+Every metadata family must support a rebuild path from live tree state.
+Until the maintained catalogs are fully authoritative, full-tree scans remain valid for:
+
+- rebuild
+- reconciliation
+- audit
+- shadow comparison
+
+The long-term target is that scans are no longer required for common planning, execution, or cleanup.


### PR DESCRIPTION
## What changed
This slice fixes the runtime rewrite accounting contract so selected-source runs report selected-source bytes, drained source IDs, and phase timings rather than whole-set totals.

## Why
Queued multi-segment rewrite budgeting and validation were overcounting because `ValueLogRewriteOnline` exposed global `BytesBefore` totals even for explicitly selected source segments.

## Impact
Cached rewrite scheduling can now budget and consume queued work using the backend's actual selected-source results.

## Validation
- `GOWORK=off go test ./TreeDB/db -run 'TestValueLogRewriteOnline_SourceFileIDs_RestrictsRewriteSet' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestVlogGenerationRewrite_|TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity' -count=1`

## Follow-up
This is PR 1/6 in the authoritative-catalog stack. Full-stack Celestia validation is running on the six-slice head.