### PR TITLE
[codex] TreeDB: add persisted value-log debt ledger scaffold

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -58,6 +58,7 @@ type DB struct {
 	snapshotViewRO     atomic.Pointer[snapshotView]
 	snapshotAcquireRO  [snapshotAcquireShardCount]atomic.Int32
 	valueLogRefTracker *valueLogRefTracker
+	valueLogDebtLedger *valueLogDebtLedger
 	leafPageLog        LeafPageLog
 	lock               *lockfile.Lock
 	adaptive           *adaptive.Controller
@@ -1063,6 +1064,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 	db := &DB{
 		valueLogManager:            vm,
 		valueLogRefTracker:         newValueLogRefTracker(),
+		valueLogDebtLedger:         newValueLogDebtLedger(),
 		lock:                       lock,
 		adaptive:                   adaptiveCtrl,
 		keepRecent:                 opts.KeepRecent,
@@ -1148,6 +1150,10 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 	db.state.Store(initialState)
 	db.publishSnapshotView(gen, initialState, vm)
 	if err := db.initValueLogRefTracker(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	if err := db.initValueLogDebtLedger(); err != nil {
 		db.Close()
 		return nil, err
 	}

--- a/TreeDB/db/vlog_debt_ledger.go
+++ b/TreeDB/db/vlog_debt_ledger.go
@@ -1,0 +1,330 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/snissn/gomap/TreeDB/internal/atomicfile"
+)
+
+const (
+	valueLogDebtLedgerFileName = "vlog_debt_ledger.meta"
+	valueLogDebtLedgerVersion  = 1
+	envEnableVlogDebtLedger    = "TREEDB_VLOG_DEBT_LEDGER"
+	envEnableVlogShadowCompare = "TREEDB_VLOG_SHADOW_COMPARE"
+)
+
+type valueLogDebtSegmentSummary struct {
+	FileID               uint32 `json:"file_id"`
+	TotalBytes           uint64 `json:"total_bytes"`
+	LiveBytes            uint64 `json:"live_bytes"`
+	StaleBytes           uint64 `json:"stale_bytes"`
+	LastUpdatedCommitSeq uint64 `json:"last_updated_commit_seq"`
+}
+
+type valueLogDebtLedgerDisk struct {
+	Version   uint32                       `json:"version"`
+	CommitSeq uint64                       `json:"commit_seq"`
+	Segments  []valueLogDebtSegmentSummary `json:"segments,omitempty"`
+}
+
+type valueLogDebtLedger struct {
+	mu        sync.RWMutex
+	commitSeq uint64
+	segments  map[uint32]valueLogDebtSegmentSummary
+	valid     bool
+	dirty     bool
+}
+
+func newValueLogDebtLedger() *valueLogDebtLedger {
+	return &valueLogDebtLedger{segments: make(map[uint32]valueLogDebtSegmentSummary)}
+}
+
+func envDebtLedgerBool(name string) bool {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return false
+	}
+	v = strings.TrimSpace(strings.ToLower(v))
+	if v == "" {
+		return true
+	}
+	switch v {
+	case "1", "true", "t", "yes", "y", "on":
+		return true
+	case "0", "false", "f", "no", "n", "off":
+		return false
+	}
+	if n, err := strconv.Atoi(v); err == nil {
+		return n != 0
+	}
+	return false
+}
+
+func valueLogDebtLedgerEnabled() bool {
+	return envDebtLedgerBool(envEnableVlogDebtLedger)
+}
+
+func valueLogDebtLedgerShadowCompareEnabled() bool {
+	return envDebtLedgerBool(envEnableVlogShadowCompare)
+}
+
+func (l *valueLogDebtLedger) replace(commitSeq uint64, segments map[uint32]valueLogDebtSegmentSummary, dirty bool) {
+	if l == nil {
+		return
+	}
+	next := make(map[uint32]valueLogDebtSegmentSummary, len(segments))
+	for fileID, seg := range segments {
+		if seg.FileID == 0 {
+			seg.FileID = fileID
+		}
+		if seg.LiveBytes > seg.TotalBytes {
+			seg.LiveBytes = seg.TotalBytes
+		}
+		if seg.StaleBytes > seg.TotalBytes {
+			seg.StaleBytes = seg.TotalBytes
+		}
+		next[seg.FileID] = seg
+	}
+	l.mu.Lock()
+	l.commitSeq = commitSeq
+	l.segments = next
+	l.valid = true
+	l.dirty = dirty
+	l.mu.Unlock()
+}
+
+func (l *valueLogDebtLedger) invalidate() {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	l.valid = false
+	l.mu.Unlock()
+}
+
+func (l *valueLogDebtLedger) liveBytesBySegment(commitSeq uint64) (map[uint32]int64, bool) {
+	if l == nil {
+		return nil, false
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if !l.valid || l.commitSeq != commitSeq {
+		return nil, false
+	}
+	out := make(map[uint32]int64, len(l.segments))
+	for fileID, seg := range l.segments {
+		out[fileID] = int64(seg.LiveBytes)
+	}
+	return out, true
+}
+
+func (l *valueLogDebtLedger) dirtySnapshot() (uint64, []valueLogDebtSegmentSummary, bool) {
+	if l == nil {
+		return 0, nil, false
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if !l.valid || !l.dirty {
+		return 0, nil, false
+	}
+	segments := make([]valueLogDebtSegmentSummary, 0, len(l.segments))
+	for _, seg := range l.segments {
+		segments = append(segments, seg)
+	}
+	sort.Slice(segments, func(i, j int) bool { return segments[i].FileID < segments[j].FileID })
+	return l.commitSeq, segments, true
+}
+
+func (l *valueLogDebtLedger) markClean(commitSeq uint64) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	if l.valid && l.commitSeq == commitSeq {
+		l.dirty = false
+	}
+	l.mu.Unlock()
+}
+
+func (db *DB) valueLogDebtLedgerPath() string {
+	if db == nil || db.dir == "" {
+		return ""
+	}
+	return filepath.Join(db.dir, valueLogDebtLedgerFileName)
+}
+
+func (db *DB) initValueLogDebtLedger() error {
+	if db == nil || db.valueLogDebtLedger == nil || !valueLogDebtLedgerEnabled() {
+		return nil
+	}
+	_, err := db.loadValueLogDebtLedger(db.currentCommitSeq())
+	return err
+}
+
+func loadValueLogDebtLedgerFromPath(path string, commitSeq uint64) (valueLogDebtLedgerDisk, bool, error) {
+	if path == "" {
+		return valueLogDebtLedgerDisk{}, false, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return valueLogDebtLedgerDisk{}, false, nil
+		}
+		return valueLogDebtLedgerDisk{}, false, err
+	}
+	var disk valueLogDebtLedgerDisk
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &disk); err != nil {
+			return valueLogDebtLedgerDisk{}, false, nil
+		}
+	}
+	if disk.Version != valueLogDebtLedgerVersion || disk.CommitSeq != commitSeq {
+		return valueLogDebtLedgerDisk{}, false, nil
+	}
+	return disk, true, nil
+}
+
+func (db *DB) loadValueLogDebtLedger(commitSeq uint64) (bool, error) {
+	if db == nil || db.valueLogDebtLedger == nil || !valueLogDebtLedgerEnabled() {
+		return false, nil
+	}
+	path := db.valueLogDebtLedgerPath()
+	disk, ok, err := loadValueLogDebtLedgerFromPath(path, commitSeq)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	segments := make(map[uint32]valueLogDebtSegmentSummary, len(disk.Segments))
+	for _, seg := range disk.Segments {
+		segments[seg.FileID] = seg
+	}
+	db.valueLogDebtLedger.replace(disk.CommitSeq, segments, false)
+	return true, nil
+}
+
+func (db *DB) persistValueLogDebtLedger() error {
+	if db == nil || db.valueLogDebtLedger == nil || !valueLogDebtLedgerEnabled() {
+		return nil
+	}
+	path := db.valueLogDebtLedgerPath()
+	if path == "" {
+		return nil
+	}
+	commitSeq, segments, ok := db.valueLogDebtLedger.dirtySnapshot()
+	if !ok {
+		return nil
+	}
+	blob, err := json.Marshal(valueLogDebtLedgerDisk{
+		Version:   valueLogDebtLedgerVersion,
+		CommitSeq: commitSeq,
+		Segments:  segments,
+	})
+	if err != nil {
+		return err
+	}
+	if err := atomicfile.Write(path, blob, 0o600); err != nil {
+		return err
+	}
+	db.valueLogDebtLedger.markClean(commitSeq)
+	return nil
+}
+
+func (db *DB) persistValueLogDebtLedgerBestEffort() {
+	if err := db.persistValueLogDebtLedger(); err != nil {
+		db.reportError(err)
+	}
+}
+
+func (db *DB) storeValueLogDebtLedgerFromLiveBytes(liveByID map[uint32]int64) error {
+	if db == nil || db.valueLogDebtLedger == nil || !valueLogDebtLedgerEnabled() {
+		return nil
+	}
+	if err := db.valueLogManager.Refresh(); err != nil {
+		return err
+	}
+	set := db.valueLogManager.CurrentSet()
+	if set != nil {
+		defer func() { _ = db.valueLogManager.Release(set) }()
+	}
+	segments := make(map[uint32]valueLogDebtSegmentSummary)
+	if set != nil {
+		for fileID, f := range set.Files {
+			total := uint64(maxInt64Zero(fileSize(f)))
+			live := uint64(maxInt64Zero(liveByID[fileID]))
+			if live > total {
+				live = total
+			}
+			segments[fileID] = valueLogDebtSegmentSummary{
+				FileID:               fileID,
+				TotalBytes:           total,
+				LiveBytes:            live,
+				StaleBytes:           total - live,
+				LastUpdatedCommitSeq: db.currentCommitSeq(),
+			}
+		}
+	}
+	db.valueLogDebtLedger.replace(db.currentCommitSeq(), segments, true)
+	return db.persistValueLogDebtLedger()
+}
+
+func (db *DB) rebuildValueLogDebtLedger(ctx context.Context) error {
+	if db == nil || db.valueLogDebtLedger == nil || !valueLogDebtLedgerEnabled() {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	liveByID, err := db.estimateValueLogLiveBytesBySegment(ctx)
+	if err != nil {
+		return err
+	}
+	return db.storeValueLogDebtLedgerFromLiveBytes(liveByID)
+}
+
+func maxInt64Zero(v int64) int64 {
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+func (db *DB) rebuildValueLogDebtLedgerBestEffort() {
+	if err := db.rebuildValueLogDebtLedger(context.Background()); err != nil {
+		db.reportError(err)
+	}
+}
+
+func sameValueLogLiveBytesBySegment(a, b map[uint32]int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for fileID, live := range a {
+		if b[fileID] != live {
+			return false
+		}
+	}
+	return true
+}
+
+func (db *DB) liveBytesBySegmentFromDebtLedger(ctx context.Context) (map[uint32]int64, bool, error) {
+	if db == nil || db.valueLogDebtLedger == nil || !valueLogDebtLedgerEnabled() {
+		return nil, false, nil
+	}
+	if liveByID, ok := db.valueLogDebtLedger.liveBytesBySegment(db.currentCommitSeq()); ok {
+		return liveByID, true, nil
+	}
+	if err := db.rebuildValueLogDebtLedger(ctx); err != nil {
+		return nil, false, err
+	}
+	liveByID, ok := db.valueLogDebtLedger.liveBytesBySegment(db.currentCommitSeq())
+	return liveByID, ok, nil
+}

--- a/TreeDB/db/vlog_debt_ledger_test.go
+++ b/TreeDB/db/vlog_debt_ledger_test.go
@@ -1,0 +1,58 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestValueLogDebtLedger_RebuildAndLoad(t *testing.T) {
+	t.Setenv(envEnableVlogDebtLedger, "1")
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	ptrs1 := appendPointersInNewSegment(t, dir, 0, 1, 310_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("a"), 256)
+	})
+	ptrs2 := appendPointersInNewSegment(t, dir, 0, 2, 320_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("b"), 256)
+	})
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs1[0]); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := b.SetPointer([]byte("k2"), ptrs2[0]); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	if err := db.rebuildValueLogDebtLedger(context.Background()); err != nil {
+		t.Fatalf("rebuild debt ledger: %v", err)
+	}
+	liveByID, ok, err := db.liveBytesBySegmentFromDebtLedger(context.Background())
+	if err != nil {
+		t.Fatalf("live bytes from debt ledger: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected debt ledger live bytes to be available")
+	}
+	if liveByID[ptrs1[0].FileID] <= 0 || liveByID[ptrs2[0].FileID] <= 0 {
+		t.Fatalf("unexpected live bytes map: %+v", liveByID)
+	}
+
+	path := filepath.Join(dir, valueLogDebtLedgerFileName)
+	if _, ok, err := loadValueLogDebtLedgerFromPath(path, db.currentCommitSeq()); err != nil {
+		t.Fatalf("load persisted debt ledger: %v", err)
+	} else if !ok {
+		t.Fatalf("expected persisted debt ledger to load")
+	}
+}


### PR DESCRIPTION
## What changed
This slice adds a persisted `vlog_debt_ledger.meta` sidecar, open-time load/rebuild logic, and focused debt-ledger tests.

## Why
Rewrite planning and later cleanup work need a durable segment-debt source of truth rather than forcing live-byte scans every time the process restarts.

## Impact
The DB can now rebuild and persist segment live/stale summaries behind `TREEDB_VLOG_DEBT_LEDGER`, but planner and GC cutovers remain in later slices.

## Validation
- `GOWORK=off go test ./TreeDB/db -run 'TestValueLogDebtLedger_RebuildAndLoad' -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'TestValueLogRewriteOnline_SourceFileIDs_RestrictsRewriteSet' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestVlogGenerationRewrite_|TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity' -count=1`

## Follow-up
This is PR 2/6 in the authoritative-catalog stack. Full-stack Celestia validation is running on the six-slice head.