### PR TITLE
[codex] TreeDB: plan rewrite selection from debt ledger

### DIFF
--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -648,9 +648,36 @@ func (db *DB) ValueLogRewritePlan(ctx context.Context, opts ValueLogRewriteOnlin
 	// skip estimation, except when callers provide stale-byte/ratio filters and
 	// need current live-byte economics for those exact IDs.
 	if rewritePlanNeedsLiveEstimate(opts) {
-		liveByID, err = db.estimateValueLogLiveBytesBySegment(ctx)
-		if err != nil {
-			return plan, err
+		if valueLogDebtLedgerEnabled() && len(opts.SourceFileIDs) == 0 {
+			ledgerLiveByID, ok, err := db.liveBytesBySegmentFromDebtLedger(ctx)
+			if err != nil {
+				return plan, err
+			}
+			if ok {
+				liveByID = ledgerLiveByID
+				if valueLogDebtLedgerShadowCompareEnabled() {
+					scanLiveByID, scanErr := db.estimateValueLogLiveBytesBySegment(ctx)
+					if scanErr != nil {
+						return plan, scanErr
+					}
+					if !sameValueLogLiveBytesBySegment(liveByID, scanLiveByID) {
+						liveByID = scanLiveByID
+						if err := db.storeValueLogDebtLedgerFromLiveBytes(scanLiveByID); err != nil {
+							db.reportError(err)
+						}
+					}
+				}
+			} else {
+				liveByID, err = db.estimateValueLogLiveBytesBySegment(ctx)
+				if err != nil {
+					return plan, err
+				}
+			}
+		} else {
+			liveByID, err = db.estimateValueLogLiveBytesBySegment(ctx)
+			if err != nil {
+				return plan, err
+			}
 		}
 	}
 

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/crc32"
@@ -3440,6 +3441,142 @@ func TestValueLogRewritePlan_InvalidatesCachedLiveBytesAfterCommit(t *testing.T)
 	}
 	if got := counter.Load(); got != 2 {
 		t.Fatalf("live-byte estimate runs=%d want 2 after commit", got)
+	}
+}
+
+func TestValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen(t *testing.T) {
+	t.Setenv(envEnableVlogDebtLedger, "1")
+	dir := t.TempDir()
+	counter := withRewritePlanEstimateCounter(t)
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	ptrs1 := appendPointersInNewSegment(t, dir, 0, 1, 248_000, 2, func(i int) []byte {
+		return bytes.Repeat([]byte("x"), 256)
+	})
+	ptrs2 := appendPointersInNewSegment(t, dir, 0, 2, 248_100, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("y"), 256)
+	})
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs1[0]); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := b.SetPointer([]byte("k2"), ptrs2[0]); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	opts := ValueLogRewriteOnlineOptions{MaxSourceSegments: 1, MaxSourceBytes: 4 << 20, MinSegmentStaleRatio: 0.10, MinSegmentStaleBytes: 1}
+	plan1, err := db.ValueLogRewritePlan(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("first plan: %v", err)
+	}
+	if got := counter.Load(); got != 1 {
+		t.Fatalf("estimate runs after first plan=%d want 1", got)
+	}
+	closeNoErr(t, db)
+
+	db2, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer closeNoErr(t, db2)
+	plan2, err := db2.ValueLogRewritePlan(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("reopen plan: %v", err)
+	}
+	assertRewritePlanStableFieldsEqual(t, plan2, plan1)
+	if got := counter.Load(); got != 1 {
+		t.Fatalf("estimate runs after reopen plan=%d want 1", got)
+	}
+}
+
+func TestValueLogRewritePlan_ShadowCompareRepairsDebtLedgerMismatch(t *testing.T) {
+	t.Setenv(envEnableVlogDebtLedger, "1")
+	dir := t.TempDir()
+	counter := withRewritePlanEstimateCounter(t)
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	ptrs1 := appendPointersInNewSegment(t, dir, 0, 1, 249_000, 2, func(i int) []byte {
+		return bytes.Repeat([]byte("x"), 256)
+	})
+	ptrs2 := appendPointersInNewSegment(t, dir, 0, 2, 249_100, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("y"), 256)
+	})
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs1[0]); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := b.SetPointer([]byte("k2"), ptrs2[0]); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	opts := ValueLogRewriteOnlineOptions{MaxSourceSegments: 1, MaxSourceBytes: 4 << 20, MinSegmentStaleRatio: 0.10, MinSegmentStaleBytes: 1}
+	plan1, err := db.ValueLogRewritePlan(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("first plan: %v", err)
+	}
+	ledgerPath := db.valueLogDebtLedgerPath()
+	disk, ok, err := loadValueLogDebtLedgerFromPath(ledgerPath, db.currentCommitSeq())
+	if err != nil {
+		t.Fatalf("load debt ledger: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected debt ledger to load before corruption")
+	}
+	for i := range disk.Segments {
+		disk.Segments[i].LiveBytes = 1
+		if disk.Segments[i].TotalBytes > 0 {
+			disk.Segments[i].StaleBytes = disk.Segments[i].TotalBytes - 1
+		}
+	}
+	blob, err := json.Marshal(disk)
+	if err != nil {
+		t.Fatalf("marshal corrupt debt ledger: %v", err)
+	}
+	if err := os.WriteFile(ledgerPath, blob, 0o600); err != nil {
+		t.Fatalf("write corrupt debt ledger: %v", err)
+	}
+	closeNoErr(t, db)
+
+	t.Setenv(envEnableVlogShadowCompare, "1")
+	db2, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer closeNoErr(t, db2)
+	before := counter.Load()
+	plan2, err := db2.ValueLogRewritePlan(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("shadow-compare plan: %v", err)
+	}
+	assertRewritePlanStableFieldsEqual(t, plan2, plan1)
+	if got := counter.Load() - before; got != 1 {
+		t.Fatalf("estimate runs during shadow compare=%d want 1", got)
+	}
+	corrected, ok, err := loadValueLogDebtLedgerFromPath(ledgerPath, db2.currentCommitSeq())
+	if err != nil {
+		t.Fatalf("reload corrected debt ledger: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected corrected debt ledger to load")
+	}
+	for _, seg := range corrected.Segments {
+		if seg.LiveBytes <= 1 && seg.TotalBytes > 1 {
+			t.Fatalf("expected corrected live bytes to exceed corrupted value: %+v", corrected.Segments)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed
This slice teaches `ValueLogRewritePlan` to prefer the persisted debt ledger when sparse planning needs live-byte estimates, with an optional shadow-compare repair path.

## Why
The common planning path should stop rediscovering segment live bytes by scan when the persisted ledger is available and current.

## Impact
Planner reads can come from the ledger under `TREEDB_VLOG_DEBT_LEDGER`, and `TREEDB_VLOG_SHADOW_COMPARE` can repair mismatches back to scan truth.

## Validation
- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogDebtLedger_RebuildAndLoad|ValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_ShadowCompareRepairsDebtLedgerMismatch|ValueLogRewriteOnline_SourceFileIDs_RestrictsRewriteSet)' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestVlogGenerationRewrite_|TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity' -count=1`

## Follow-up
This is PR 3/6 in the authoritative-catalog stack. Full-stack Celestia validation is running on the six-slice head.