### PR TITLE
[codex] TreeDB: use locator catalog for selected rewrite scans

### DIFF
--- a/TreeDB/db/vlog_locator_catalog_test.go
+++ b/TreeDB/db/vlog_locator_catalog_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/node"
 )
 
 func TestValueLogLocatorCatalog_RebuildAndLoad(t *testing.T) {
@@ -51,5 +53,60 @@ func TestValueLogLocatorCatalog_RebuildAndLoad(t *testing.T) {
 		t.Fatalf("load locator catalog: %v", err)
 	} else if !ok {
 		t.Fatalf("expected locator catalog to load")
+	}
+}
+
+func TestValueLogRewriteOnline_SourceFileIDs_UsesLocatorCatalogWhenEnabled(t *testing.T) {
+	t.Setenv(envEnableVlogLocatorCatalog, "1")
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	ptrs1 := appendPointersInNewSegment(t, dir, 0, 1, 340_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("a"), 256)
+	})
+	ptrs2 := appendPointersInNewSegment(t, dir, 0, 2, 340_100, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("b"), 256)
+	})
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs1[0]); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := b.SetPointer([]byte("k2"), ptrs2[0]); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs: []uint32{ptrs1[0].FileID},
+		BatchSize:     8,
+	})
+	if err != nil {
+		t.Fatalf("rewrite online: %v", err)
+	}
+	if stats.CandidateScanMode != "locator_catalog" {
+		t.Fatalf("candidate scan mode=%q want locator_catalog", stats.CandidateScanMode)
+	}
+	if stats.RecordsCopied != 1 {
+		t.Fatalf("records copied=%d want 1", stats.RecordsCopied)
+	}
+
+	ptrK1, flagsK1 := readProjectedPointerByKey(t, db, []byte("k1"))
+	ptrK2, flagsK2 := readProjectedPointerByKey(t, db, []byte("k2"))
+	if flagsK1&node.FlagPointer == 0 || flagsK2&node.FlagPointer == 0 {
+		t.Fatalf("expected pointer flags for rewritten keys: k1=%#x k2=%#x", flagsK1, flagsK2)
+	}
+	if ptrK1.FileID == ptrs1[0].FileID {
+		t.Fatalf("expected k1 pointer to move off source segment %d", ptrs1[0].FileID)
+	}
+	if ptrK2.FileID != ptrs2[0].FileID {
+		t.Fatalf("expected k2 pointer to remain on non-selected segment %d, got %d", ptrs2[0].FileID, ptrK2.FileID)
 	}
 }

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -138,13 +138,13 @@ type ValueLogRewriteStats struct {
 	CopyNanos          int64
 	SwapNanos          int64
 	CleanupNanos       int64
-	PlanNanos         int64
-	SourceScanNanos   int64
-	ReadDecodeNanos   int64
-	EncodeAppendNanos int64
-	SwapCommitNanos   int64
-	BookkeepingNanos  int64
-	LeafRefNanos      int64
+	PlanNanos          int64
+	SourceScanNanos    int64
+	ReadDecodeNanos    int64
+	EncodeAppendNanos  int64
+	SwapCommitNanos    int64
+	BookkeepingNanos   int64
+	LeafRefNanos       int64
 
 	ReadCalls   int
 	AppendCalls int
@@ -1742,83 +1742,170 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		closeRewriteSnapshot(&err, snap)
 		return stats, fmt.Errorf("missing snapshot state")
 	}
-	it := snap.tree.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-	stats.CandidateScanMode = "tree"
 	stats.CandidateScanCount = 1
 	candidateScanStart := time.Now()
-	scanStart := time.Now()
-	for ; it.Valid(); it.Next() {
-		if err := ctx.Err(); err != nil {
-			canceledErr = err
-			break
+	usedLocatorCatalog := false
+	if restrictSource && len(stats.RequestedSourceFileIDs) > 0 && valueLogLocatorCatalogEnabled() {
+		locatorKeys, ok, locatorErr := db.locatorKeysForSegments(ctx, stats.RequestedSourceFileIDs)
+		if locatorErr != nil {
+			closeRewriteSnapshot(&err, snap)
+			return stats, locatorErr
 		}
-		_, oldPtr, flags := it.UnsafeEntry()
-		if flags&node.FlagPointer == 0 || !page.IsValueLogFileID(oldPtr.FileID) {
-			continue
-		}
-		if restrictSource {
-			if restrictSingleID {
-				if oldPtr.FileID != singleSourceID {
+		if ok {
+			usedLocatorCatalog = true
+			stats.CandidateScanMode = "locator_catalog"
+			scanStart := time.Now()
+			for _, locatorKey := range locatorKeys {
+				if err := ctx.Err(); err != nil {
+					canceledErr = err
+					break
+				}
+				entry, getErr := snap.tree.GetEntry(locatorKey)
+				if getErr != nil {
+					if errors.Is(getErr, tree.ErrKeyNotFound) {
+						continue
+					}
+					closeRewriteSnapshot(&err, snap)
+					return stats, getErr
+				}
+				oldPtr := entry.ValuePtr
+				if entry.Flags&node.FlagPointer == 0 || !page.IsValueLogFileID(oldPtr.FileID) {
 					continue
 				}
-			} else {
-				if _, ok := sourceIDs[oldPtr.FileID]; !ok {
-					continue
+				if restrictSingleID {
+					if oldPtr.FileID != singleSourceID {
+						continue
+					}
+				} else {
+					if _, present := sourceIDs[oldPtr.FileID]; !present {
+						continue
+					}
+				}
+				if sourceChunkSet != nil {
+					selected, chunkErr := rewriteSourceChunkSelected(oldPtr, sourceChunkSet, sourceChunkBytes)
+					if chunkErr != nil {
+						closeRewriteSnapshot(&err, snap)
+						return stats, chunkErr
+					}
+					if !selected {
+						continue
+					}
+				}
+				sourceBytes := int64(0)
+				if maxCopiedBytes > 0 {
+					recordLen, recordErr := db.valueLogRecordLengthForRewrite(oldPtr)
+					if recordErr != nil {
+						closeRewriteSnapshot(&err, snap)
+						return stats, recordErr
+					}
+					sourceBytes = int64(recordLen)
+					if selectedSourceBytes > 0 && selectedSourceBytes+sourceBytes > maxCopiedBytes {
+						break
+					}
+				}
+				keyStart := len(candidateKeyArena)
+				candidateKeyArena = append(candidateKeyArena, locatorKey...)
+				key := candidateKeyArena[keyStart:len(candidateKeyArena):len(candidateKeyArena)]
+				stats.CandidateCount++
+				candidates = append(candidates, rewriteCandidate{
+					key:         key,
+					oldPtr:      oldPtr,
+					sourceBytes: sourceBytes,
+				})
+				selectedSourceBytes += sourceBytes
+				if len(candidates) >= batchSize {
+					stats.SourceScanNanos += time.Since(scanStart).Nanoseconds()
+					if err := flushBatch(); err != nil {
+						closeRewriteSnapshot(&err, snap)
+						return stats, err
+					}
+					scanStart = time.Now()
+				}
+				if maxCopiedBytes > 0 && selectedSourceBytes >= maxCopiedBytes {
+					break
 				}
 			}
-			if sourceChunkSet != nil {
-				ok, chunkErr := rewriteSourceChunkSelected(oldPtr, sourceChunkSet, sourceChunkBytes)
-				if chunkErr != nil {
+			stats.SourceScanNanos += time.Since(scanStart).Nanoseconds()
+		}
+	}
+	iterErr := error(nil)
+	if !usedLocatorCatalog {
+		it := snap.tree.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+		stats.CandidateScanMode = "tree"
+		scanStart := time.Now()
+		for ; it.Valid(); it.Next() {
+			if err := ctx.Err(); err != nil {
+				canceledErr = err
+				break
+			}
+			_, oldPtr, flags := it.UnsafeEntry()
+			if flags&node.FlagPointer == 0 || !page.IsValueLogFileID(oldPtr.FileID) {
+				continue
+			}
+			if restrictSource {
+				if restrictSingleID {
+					if oldPtr.FileID != singleSourceID {
+						continue
+					}
+				} else {
+					if _, ok := sourceIDs[oldPtr.FileID]; !ok {
+						continue
+					}
+				}
+				if sourceChunkSet != nil {
+					ok, chunkErr := rewriteSourceChunkSelected(oldPtr, sourceChunkSet, sourceChunkBytes)
+					if chunkErr != nil {
+						_ = it.Close()
+						closeRewriteSnapshot(&err, snap)
+						return stats, chunkErr
+					}
+					if !ok {
+						continue
+					}
+				}
+			}
+			unsafeKey := it.UnsafeKey()
+			sourceBytes := int64(0)
+			if maxCopiedBytes > 0 {
+				recordLen, err := db.valueLogRecordLengthForRewrite(oldPtr)
+				if err != nil {
 					_ = it.Close()
 					closeRewriteSnapshot(&err, snap)
-					return stats, chunkErr
+					return stats, err
 				}
-				if !ok {
-					continue
+				sourceBytes = int64(recordLen)
+				if selectedSourceBytes > 0 && selectedSourceBytes+sourceBytes > maxCopiedBytes {
+					break
 				}
 			}
-		}
-		unsafeKey := it.UnsafeKey()
-		sourceBytes := int64(0)
-		if maxCopiedBytes > 0 {
-			recordLen, err := db.valueLogRecordLengthForRewrite(oldPtr)
-			if err != nil {
-				_ = it.Close()
-				closeRewriteSnapshot(&err, snap)
-				return stats, err
+			keyStart := len(candidateKeyArena)
+			candidateKeyArena = append(candidateKeyArena, unsafeKey...)
+			key := candidateKeyArena[keyStart:len(candidateKeyArena):len(candidateKeyArena)]
+			stats.CandidateCount++
+			candidates = append(candidates, rewriteCandidate{
+				key:         key,
+				oldPtr:      oldPtr,
+				sourceBytes: sourceBytes,
+			})
+			selectedSourceBytes += sourceBytes
+			if len(candidates) >= batchSize {
+				stats.SourceScanNanos += time.Since(scanStart).Nanoseconds()
+				if err := flushBatch(); err != nil {
+					_ = it.Close()
+					closeRewriteSnapshot(&err, snap)
+					return stats, err
+				}
+				scanStart = time.Now()
 			}
-			sourceBytes = int64(recordLen)
-			if selectedSourceBytes > 0 && selectedSourceBytes+sourceBytes > maxCopiedBytes {
+			if maxCopiedBytes > 0 && selectedSourceBytes >= maxCopiedBytes {
 				break
 			}
 		}
-		keyStart := len(candidateKeyArena)
-		candidateKeyArena = append(candidateKeyArena, unsafeKey...)
-		key := candidateKeyArena[keyStart:len(candidateKeyArena):len(candidateKeyArena)]
-		stats.CandidateCount++
-		candidates = append(candidates, rewriteCandidate{
-			key:         key,
-			oldPtr:      oldPtr,
-			sourceBytes: sourceBytes,
-		})
-		selectedSourceBytes += sourceBytes
-		if len(candidates) >= batchSize {
-			stats.SourceScanNanos += time.Since(scanStart).Nanoseconds()
-			if err := flushBatch(); err != nil {
-				_ = it.Close()
-				closeRewriteSnapshot(&err, snap)
-				return stats, err
-			}
-			scanStart = time.Now()
-		}
-		if maxCopiedBytes > 0 && selectedSourceBytes >= maxCopiedBytes {
-			break
-		}
+		stats.SourceScanNanos += time.Since(scanStart).Nanoseconds()
+		iterErr = it.Error()
+		_ = it.Close()
 	}
-	stats.SourceScanNanos += time.Since(scanStart).Nanoseconds()
 	stats.CandidateScanNanos += time.Since(candidateScanStart).Nanoseconds()
-	iterErr := it.Error()
-	_ = it.Close()
 	closeRewriteSnapshot(&err, snap)
 	if iterErr != nil {
 		return stats, iterErr


### PR DESCRIPTION
## What changed
This slice routes selected-source `ValueLogRewriteOnline` candidate discovery through the locator catalog when it is valid, while preserving the existing tree-scan fallback.

## Why
The common selected-segment execution path should stop paying a full pointer-projection tree scan when a precise locator catalog is already available.

## Impact
Selected rewrite runs can now use `CandidateScanMode=locator_catalog` under `TREEDB_VLOG_LOCATOR_CATALOG` and still fall back safely if the catalog is missing or stale.

## Validation
- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogLocatorCatalog_RebuildAndLoad|ValueLogRewriteOnline_SourceFileIDs_UsesLocatorCatalogWhenEnabled|ValueLogRewriteOnline_SourceFileIDs_RestrictsRewriteSet|ValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_ShadowCompareRepairsDebtLedgerMismatch)' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestVlogGenerationRewrite_|TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity' -count=1`

## Follow-up
This is PR 5/6 in the authoritative-catalog stack. Full-stack Celestia validation is running on the six-slice head.