### PR TITLE
[codex] TreeDB: use debt ledger for referenced segment reads

### DIFF
--- a/TreeDB/db/vlog_debt_ledger_test.go
+++ b/TreeDB/db/vlog_debt_ledger_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 )
 
@@ -54,5 +55,61 @@ func TestValueLogDebtLedger_RebuildAndLoad(t *testing.T) {
 		t.Fatalf("load persisted debt ledger: %v", err)
 	} else if !ok {
 		t.Fatalf("expected persisted debt ledger to load")
+	}
+}
+
+func TestReferencedValueLogSegments_UsesPersistedDebtLedgerAcrossReopen(t *testing.T) {
+	t.Setenv(envEnableVlogDebtLedger, "1")
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	ptrs1 := appendPointersInNewSegment(t, dir, 0, 1, 350_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("a"), 256)
+	})
+	ptrs2 := appendPointersInNewSegment(t, dir, 0, 2, 350_100, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("b"), 256)
+	})
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs1[0]); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := b.SetPointer([]byte("k2"), ptrs2[0]); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+	if err := db.rebuildValueLogDebtLedger(context.Background()); err != nil {
+		t.Fatalf("rebuild debt ledger: %v", err)
+	}
+	closeNoErr(t, db)
+
+	var legacyCalls atomic.Uint64
+	unregister := registerReferencedValueLogSegmentsLegacyHook(func() {
+		legacyCalls.Add(1)
+	})
+	t.Cleanup(unregister)
+
+	db2, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer closeNoErr(t, db2)
+	refs, err := db2.referencedValueLogSegments(context.Background())
+	if err != nil {
+		t.Fatalf("referencedValueLogSegments: %v", err)
+	}
+	if _, ok := refs[ptrs1[0].FileID]; !ok {
+		t.Fatalf("missing referenced file %d in %+v", ptrs1[0].FileID, refs)
+	}
+	if _, ok := refs[ptrs2[0].FileID]; !ok {
+		t.Fatalf("missing referenced file %d in %+v", ptrs2[0].FileID, refs)
+	}
+	if got := legacyCalls.Load(); got != 0 {
+		t.Fatalf("legacy referenced-segment scan calls=%d want 0", got)
 	}
 }

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -412,10 +412,89 @@ func (db *DB) persistValueLogRefTrackerBestEffort() {
 	}
 }
 
+var referencedValueLogSegmentsLegacyHook struct {
+	mu sync.Mutex
+	fn func()
+}
+
+func registerReferencedValueLogSegmentsLegacyHook(hook func()) func() {
+	referencedValueLogSegmentsLegacyHook.mu.Lock()
+	prev := referencedValueLogSegmentsLegacyHook.fn
+	referencedValueLogSegmentsLegacyHook.fn = hook
+	referencedValueLogSegmentsLegacyHook.mu.Unlock()
+	return func() {
+		referencedValueLogSegmentsLegacyHook.mu.Lock()
+		referencedValueLogSegmentsLegacyHook.fn = prev
+		referencedValueLogSegmentsLegacyHook.mu.Unlock()
+	}
+}
+
+func invokeReferencedValueLogSegmentsLegacyHook() {
+	referencedValueLogSegmentsLegacyHook.mu.Lock()
+	hook := referencedValueLogSegmentsLegacyHook.fn
+	referencedValueLogSegmentsLegacyHook.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
+}
+
+func refsFromValueLogLiveBytesBySegment(liveByID map[uint32]int64) map[uint32]struct{} {
+	if len(liveByID) == 0 {
+		return nil
+	}
+	refs := make(map[uint32]struct{}, len(liveByID))
+	for fileID, live := range liveByID {
+		if live <= 0 {
+			continue
+		}
+		refs[fileID] = struct{}{}
+	}
+	return refs
+}
+
+func sameValueLogRefSets(a, b map[uint32]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for fileID := range a {
+		if _, ok := b[fileID]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func (db *DB) referencedValueLogSegments(ctx context.Context) (map[uint32]struct{}, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if valueLogDebtLedgerEnabled() && db.valueLogDebtLedger != nil {
+		liveByID, ok, err := db.liveBytesBySegmentFromDebtLedger(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			refs := refsFromValueLogLiveBytesBySegment(liveByID)
+			if valueLogDebtLedgerShadowCompareEnabled() {
+				legacyRefs, err := db.referencedValueLogSegmentsLegacy(ctx)
+				if err != nil {
+					return nil, err
+				}
+				if !sameValueLogRefSets(refs, legacyRefs) {
+					if rebuildErr := db.rebuildValueLogDebtLedger(ctx); rebuildErr != nil {
+						db.reportError(rebuildErr)
+					}
+					return legacyRefs, nil
+				}
+			}
+			return refs, nil
+		}
+	}
+	return db.referencedValueLogSegmentsLegacy(ctx)
+}
+
+func (db *DB) referencedValueLogSegmentsLegacy(ctx context.Context) (map[uint32]struct{}, error) {
+	invokeReferencedValueLogSegmentsLegacyHook()
 	seq := db.currentCommitSeq()
 	if db.valueLogRefTracker != nil {
 		if refs, ok := db.valueLogRefTracker.referencedSet(seq); ok {


### PR DESCRIPTION
## What changed
This slice teaches referenced-segment reads to prefer the persisted debt ledger, adds a shadow-compare fallback to legacy scan truth, and includes a reopen test proving the legacy scan was bypassed.

## Why
Cleanup and GC should read the same catalog-backed reachability truth as planner/executor instead of forcing independent rediscovery scans.

## Impact
`referencedValueLogSegments` can now derive live references from the debt ledger under `TREEDB_VLOG_DEBT_LEDGER`, with `TREEDB_VLOG_SHADOW_COMPARE` preserving a safe repair path.

## Validation
- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogDebtLedger_RebuildAndLoad|ReferencedValueLogSegments_UsesPersistedDebtLedgerAcrossReopen|ValueLogLocatorCatalog_RebuildAndLoad|ValueLogRewriteOnline_SourceFileIDs_UsesLocatorCatalogWhenEnabled|ValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_ShadowCompareRepairsDebtLedgerMismatch|ValueLogRewriteOnline_SourceFileIDs_RestrictsRewriteSet)' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestVlogGenerationRewrite_|TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity' -count=1`

## Follow-up
This is PR 6/6 in the authoritative-catalog stack. Full-stack Celestia validation is running on the six-slice head.