### PR TITLE
[codex] TreeDB: maintain locator catalog on commit path

### DIFF
--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 // Batch implements the cosmos-db Batch interface.
@@ -205,6 +206,18 @@ func (b *Batch) writeOptimistic(sync bool) (bool, error) {
 		}
 		return false, err
 	}
+	var vlogLocatorDelta *valueLogLocatorDelta
+	if b.db.valueLogLocatorCatalog != nil && valueLogLocatorCatalogEnabled() && b.db.valueLogLocatorCatalog.canTrack(baseSeq) {
+		vlogLocatorDelta, err = buildValueLogLocatorDelta(tree.New(idx.pager, nil, rootID), entries)
+		if err != nil {
+			freeErr := tracker.FreeAll()
+			b.db.writeMu.RUnlock()
+			if freeErr != nil {
+				return false, freeErr
+			}
+			return false, err
+		}
+	}
 	defer func() {
 		if vlogRefDelta != nil {
 			releaseValueLogRefDelta(vlogRefDelta)
@@ -225,7 +238,7 @@ func (b *Batch) writeOptimistic(sync bool) (bool, error) {
 		return false, nil
 	}
 
-	post, err := b.db.finalizeCommitLocked(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta)
+	post, err := b.db.finalizeCommitLocked(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, vlogLocatorDelta)
 	b.db.commitMu.Unlock()
 	if err != nil {
 		b.db.writeMu.RUnlock()
@@ -268,6 +281,13 @@ func (b *Batch) writeSerialized(sync bool) error {
 	if err != nil {
 		return err
 	}
+	var vlogLocatorDelta *valueLogLocatorDelta
+	if b.db.valueLogLocatorCatalog != nil && valueLogLocatorCatalogEnabled() && b.db.valueLogLocatorCatalog.canTrack(baseSeq) {
+		vlogLocatorDelta, err = buildValueLogLocatorDelta(tree.New(idx.pager, nil, rootID), entries)
+		if err != nil {
+			return err
+		}
+	}
 	defer func() {
 		if vlogRefDelta != nil {
 			releaseValueLogRefDelta(vlogRefDelta)
@@ -283,7 +303,7 @@ func (b *Batch) writeSerialized(sync bool) error {
 	sysRoot := b.db.meta.SystemRootPageID
 	b.db.mu.Unlock()
 
-	if err := b.db.finalizeCommit(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta); err != nil {
+	if err := b.db.finalizeCommit(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, vlogLocatorDelta); err != nil {
 		return err
 	}
 	vlogRefDelta = nil

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1494,24 +1494,25 @@ func (db *DB) writeMeta(pageID uint64, meta page.MetaPageBody) error {
 }
 
 type finalizeCommitPost struct {
-	oldState     *DBState
-	metrics      adaptive.Metrics
-	vlogRefDelta *valueLogRefDelta
-	commitSeq    uint64
-	kickPrune    bool
-	doPrune      bool
-	debug        bool
-	sync         bool
-	start        time.Time
-	durSync1     time.Duration
-	durMeta      time.Duration
-	durSync2     time.Duration
+	oldState         *DBState
+	metrics          adaptive.Metrics
+	vlogRefDelta     *valueLogRefDelta
+	vlogLocatorDelta *valueLogLocatorDelta
+	commitSeq        uint64
+	kickPrune        bool
+	doPrune          bool
+	debug            bool
+	sync             bool
+	start            time.Time
+	durSync1         time.Duration
+	durMeta          time.Duration
+	durSync2         time.Duration
 }
 
 // finalizeCommitLocked performs the durability-critical publish path.
 // Callers that already hold commit serialization may run post work after
 // releasing the serialization lock.
-func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta) (finalizeCommitPost, error) {
+func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta, vlogLocatorDelta *valueLogLocatorDelta) (finalizeCommitPost, error) {
 	post := finalizeCommitPost{
 		metrics: metrics,
 	}
@@ -1662,6 +1663,7 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 	db.publishSnapshotView(idx, newState, db.valueLogManager)
 	post.commitSeq = nextMeta.CommitSeq
 	post.vlogRefDelta = vlogRefDelta
+	post.vlogLocatorDelta = vlogLocatorDelta
 	db.mu.Unlock()
 	watermarkHold += time.Since(holdStart)
 	db.observePublishWatermark(watermarkWait, watermarkHold, watermarkWait+watermarkHold)
@@ -1694,6 +1696,18 @@ func (db *DB) finalizeCommitPostWork(post finalizeCommitPost) {
 			}
 		} else {
 			db.valueLogRefTracker.invalidate()
+		}
+	}
+	if db.valueLogLocatorCatalog != nil && valueLogLocatorCatalogEnabled() {
+		if post.vlogLocatorDelta != nil {
+			if err := db.valueLogLocatorCatalog.applyDelta(post.commitSeq, post.vlogLocatorDelta); err != nil {
+				db.valueLogLocatorCatalog.invalidate()
+				db.reportError(err)
+			} else {
+				db.persistValueLogLocatorCatalogBestEffort()
+			}
+		} else {
+			db.valueLogLocatorCatalog.invalidate()
 		}
 	}
 
@@ -1730,8 +1744,8 @@ func (db *DB) finalizeCommitPostWork(post finalizeCommitPost) {
 }
 
 // finalizeCommit handles durability and state updates.
-func (db *DB) finalizeCommit(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta) error {
-	post, err := db.finalizeCommitLocked(newRootID, sysRootID, retired, sync, metrics, touchedValueLogSegments, forceValueLogRefresh, vlogRefDelta)
+func (db *DB) finalizeCommit(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta, vlogLocatorDelta *valueLogLocatorDelta) error {
+	post, err := db.finalizeCommitLocked(newRootID, sysRootID, retired, sync, metrics, touchedValueLogSegments, forceValueLogRefresh, vlogRefDelta, vlogLocatorDelta)
 	if err != nil {
 		return err
 	}
@@ -1763,7 +1777,7 @@ func (db *DB) Commit(newRootID uint64) error {
 	sysRoot := db.meta.SystemRootPageID
 	db.mu.RUnlock()
 
-	return db.finalizeCommit(newRootID, sysRoot, nil, true, adaptive.Metrics{}, nil, true, nil)
+	return db.finalizeCommit(newRootID, sysRoot, nil, true, adaptive.Metrics{}, nil, true, nil, nil)
 }
 
 // Prune reclaims pages from the graveyard.
@@ -2034,7 +2048,7 @@ func (db *DB) CompactIndex() error {
 	db.mu.Unlock()
 
 	// Commit new root and retire the old tree pages.
-	return db.finalizeCommit(newRoot, sysRoot, retired, true, adaptive.Metrics{}, nil, true, nil)
+	return db.finalizeCommit(newRoot, sysRoot, retired, true, adaptive.Metrics{}, nil, true, nil, nil)
 }
 
 type pagerAllocator struct {

--- a/TreeDB/db/vlog_locator_catalog.go
+++ b/TreeDB/db/vlog_locator_catalog.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"sync"
 
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/atomicfile"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -33,6 +34,11 @@ type valueLogLocatorCatalogDisk struct {
 	Segments  []valueLogLocatorCatalogSegment `json:"segments,omitempty"`
 }
 
+type valueLogLocatorDelta struct {
+	adds    map[uint32][][]byte
+	removes map[uint32][][]byte
+}
+
 type valueLogLocatorCatalog struct {
 	mu        sync.RWMutex
 	commitSeq uint64
@@ -47,6 +53,27 @@ func newValueLogLocatorCatalog() *valueLogLocatorCatalog {
 
 func valueLogLocatorCatalogEnabled() bool {
 	return envDebtLedgerBool(envEnableVlogLocatorCatalog)
+}
+
+func newValueLogLocatorDelta() *valueLogLocatorDelta {
+	return &valueLogLocatorDelta{
+		adds:    make(map[uint32][][]byte),
+		removes: make(map[uint32][][]byte),
+	}
+}
+
+func (d *valueLogLocatorDelta) add(fileID uint32, key []byte) {
+	if d == nil || fileID == 0 || len(key) == 0 {
+		return
+	}
+	d.adds[fileID] = append(d.adds[fileID], append([]byte(nil), key...))
+}
+
+func (d *valueLogLocatorDelta) remove(fileID uint32, key []byte) {
+	if d == nil || fileID == 0 || len(key) == 0 {
+		return
+	}
+	d.removes[fileID] = append(d.removes[fileID], append([]byte(nil), key...))
 }
 
 func normalizeLocatorSegments(segments []valueLogLocatorCatalogSegment) []valueLogLocatorCatalogSegment {
@@ -137,6 +164,15 @@ func (c *valueLogLocatorCatalog) replace(commitSeq uint64, segments map[uint32]m
 	c.mu.Unlock()
 }
 
+func (c *valueLogLocatorCatalog) canTrack(baseSeq uint64) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.valid && c.commitSeq == baseSeq
+}
+
 func (c *valueLogLocatorCatalog) invalidate() {
 	if c == nil {
 		return
@@ -169,6 +205,47 @@ func (c *valueLogLocatorCatalog) keysForSegments(commitSeq uint64, fileIDs []uin
 	}
 	sort.Slice(out, func(i, j int) bool { return string(out[i]) < string(out[j]) })
 	return out, true
+}
+
+func (c *valueLogLocatorCatalog) applyDelta(nextCommitSeq uint64, delta *valueLogLocatorDelta) error {
+	if c == nil {
+		return nil
+	}
+	if delta == nil {
+		return errors.New("treedb: missing value-log locator delta")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.valid {
+		return errors.New("treedb: value-log locator catalog invalid")
+	}
+	if nextCommitSeq != c.commitSeq+1 {
+		return errors.New("treedb: value-log locator catalog sequence mismatch")
+	}
+	for fileID, keys := range delta.removes {
+		seg := c.segments[fileID]
+		for _, key := range keys {
+			delete(seg, string(key))
+		}
+		if len(seg) == 0 {
+			delete(c.segments, fileID)
+		} else {
+			c.segments[fileID] = seg
+		}
+	}
+	for fileID, keys := range delta.adds {
+		seg := c.segments[fileID]
+		if seg == nil {
+			seg = make(map[string][]byte, len(keys))
+		}
+		for _, key := range keys {
+			seg[string(key)] = append([]byte(nil), key...)
+		}
+		c.segments[fileID] = seg
+	}
+	c.commitSeq = nextCommitSeq
+	c.dirty = true
+	return nil
 }
 
 func (c *valueLogLocatorCatalog) dirtySnapshot() (uint64, []valueLogLocatorCatalogSegment, bool) {
@@ -347,4 +424,24 @@ func (db *DB) locatorKeysForSegments(ctx context.Context, fileIDs []uint32) ([][
 	}
 	keys, ok := db.valueLogLocatorCatalog.keysForSegments(db.currentCommitSeq(), fileIDs)
 	return keys, ok, nil
+}
+
+func buildValueLogLocatorDelta(tr *tree.Tree, entries []batchpkg.Entry) (*valueLogLocatorDelta, error) {
+	if tr == nil {
+		return nil, nil
+	}
+	delta := newValueLogLocatorDelta()
+	for i := range entries {
+		oldFileID, oldRef, err := lookupValueLogRefAtKey(tr, entries[i].Key)
+		if err != nil {
+			return nil, err
+		}
+		if oldRef {
+			delta.remove(oldFileID, entries[i].Key)
+		}
+		if entries[i].Type == batchpkg.OpPut && entries[i].IsPtr && page.IsValueLogFileID(entries[i].ValuePtr.FileID) {
+			delta.add(entries[i].ValuePtr.FileID, entries[i].Key)
+		}
+	}
+	return delta, nil
 }

--- a/TreeDB/db/vlog_locator_catalog_test.go
+++ b/TreeDB/db/vlog_locator_catalog_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/node"
@@ -108,5 +109,157 @@ func TestValueLogRewriteOnline_SourceFileIDs_UsesLocatorCatalogWhenEnabled(t *te
 	}
 	if ptrK2.FileID != ptrs2[0].FileID {
 		t.Fatalf("expected k2 pointer to remain on non-selected segment %d, got %d", ptrs2[0].FileID, ptrK2.FileID)
+	}
+}
+
+func TestValueLogLocatorCatalog_AppliesCommitDeltaAcrossWrites(t *testing.T) {
+	t.Setenv(envEnableVlogLocatorCatalog, "1")
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	ptrs1 := appendPointersInNewSegment(t, dir, 0, 1, 350_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("a"), 256)
+	})
+	ptrs2 := appendPointersInNewSegment(t, dir, 0, 2, 350_100, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("b"), 256)
+	})
+
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs1[0]); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := b.SetPointer([]byte("k2"), ptrs1[0]); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	if err := db.rebuildValueLogLocatorCatalog(context.Background()); err != nil {
+		t.Fatalf("rebuild locator catalog: %v", err)
+	}
+	baseSeq := db.currentCommitSeq()
+	if !db.valueLogLocatorCatalog.canTrack(baseSeq) {
+		t.Fatalf("expected locator catalog to track commit seq %d", baseSeq)
+	}
+
+	b = db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs2[0]); err != nil {
+		t.Fatalf("move k1: %v", err)
+	}
+	if err := b.Delete([]byte("k2")); err != nil {
+		t.Fatalf("delete k2: %v", err)
+	}
+	if err := b.SetPointer([]byte("k3"), ptrs1[0]); err != nil {
+		t.Fatalf("set k3: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("delta write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	seq := db.currentCommitSeq()
+	if !db.valueLogLocatorCatalog.canTrack(seq) {
+		t.Fatalf("expected locator catalog to stay valid at commit seq %d", seq)
+	}
+
+	keys1, ok := db.valueLogLocatorCatalog.keysForSegments(seq, []uint32{ptrs1[0].FileID})
+	if !ok {
+		t.Fatalf("expected locator catalog keys for segment %d", ptrs1[0].FileID)
+	}
+	got1 := make([]string, 0, len(keys1))
+	for _, key := range keys1 {
+		got1 = append(got1, string(key))
+	}
+	slices.Sort(got1)
+	if !slices.Equal(got1, []string{"k3"}) {
+		t.Fatalf("segment %d keys=%v want [k3]", ptrs1[0].FileID, got1)
+	}
+
+	keys2, ok := db.valueLogLocatorCatalog.keysForSegments(seq, []uint32{ptrs2[0].FileID})
+	if !ok {
+		t.Fatalf("expected locator catalog keys for segment %d", ptrs2[0].FileID)
+	}
+	got2 := make([]string, 0, len(keys2))
+	for _, key := range keys2 {
+		got2 = append(got2, string(key))
+	}
+	slices.Sort(got2)
+	if !slices.Equal(got2, []string{"k1"}) {
+		t.Fatalf("segment %d keys=%v want [k1]", ptrs2[0].FileID, got2)
+	}
+}
+
+func TestValueLogLocatorCatalog_TracksRewriteSwapCommits(t *testing.T) {
+	t.Setenv(envEnableVlogLocatorCatalog, "1")
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	ptrs1 := appendPointersInNewSegment(t, dir, 0, 1, 360_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("a"), 256)
+	})
+
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs1[0]); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	if err := db.rebuildValueLogLocatorCatalog(context.Background()); err != nil {
+		t.Fatalf("rebuild locator catalog: %v", err)
+	}
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs: []uint32{ptrs1[0].FileID},
+		BatchSize:     8,
+	})
+	if err != nil {
+		t.Fatalf("rewrite online: %v", err)
+	}
+	if stats.RecordsCopied != 1 {
+		t.Fatalf("records copied=%d want 1", stats.RecordsCopied)
+	}
+
+	ptrK1, flags := readProjectedPointerByKey(t, db, []byte("k1"))
+	if flags&node.FlagPointer == 0 {
+		t.Fatalf("expected k1 pointer after rewrite, flags=%#x", flags)
+	}
+	if ptrK1.FileID == ptrs1[0].FileID {
+		t.Fatalf("expected k1 pointer to move off source segment %d", ptrs1[0].FileID)
+	}
+
+	seq := db.currentCommitSeq()
+	if !db.valueLogLocatorCatalog.canTrack(seq) {
+		t.Fatalf("expected locator catalog to stay valid at commit seq %d", seq)
+	}
+
+	oldKeys, ok := db.valueLogLocatorCatalog.keysForSegments(seq, []uint32{ptrs1[0].FileID})
+	if !ok {
+		t.Fatalf("expected locator catalog query to succeed for old segment")
+	}
+	if len(oldKeys) != 0 {
+		t.Fatalf("old segment keys=%q want empty", oldKeys)
+	}
+
+	newKeys, ok := db.valueLogLocatorCatalog.keysForSegments(seq, []uint32{ptrK1.FileID})
+	if !ok {
+		t.Fatalf("expected locator catalog query to succeed for new segment")
+	}
+	if len(newKeys) != 1 || string(newKeys[0]) != "k1" {
+		t.Fatalf("new segment keys=%q want [k1]", newKeys)
 	}
 }

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2573,7 +2573,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		}
 	}
 
-	if err := db.finalizeCommit(newRoot, newSysRoot, leafCtx.retired, sync, adaptive.Metrics{}, createdIDs, false, nil); err != nil {
+	if err := db.finalizeCommit(newRoot, newSysRoot, leafCtx.retired, sync, adaptive.Metrics{}, createdIDs, false, nil, nil); err != nil {
 		return 0, 0, err
 	}
 	tracker = nil
@@ -2837,7 +2837,15 @@ func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (b
 		return false, nil
 	}
 
-	post, err := db.finalizeCommitLocked(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta)
+	var vlogLocatorDelta *valueLogLocatorDelta
+	if db.valueLogLocatorCatalog != nil && valueLogLocatorCatalogEnabled() && db.valueLogLocatorCatalog.canTrack(baseSeq) {
+		vlogLocatorDelta, err = buildValueLogLocatorDelta(tree.New(idx.pager, vlogSet, rootID), entries)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	post, err := db.finalizeCommitLocked(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta, vlogLocatorDelta)
 	db.commitMu.Unlock()
 	if err != nil {
 		return false, err
@@ -2907,7 +2915,14 @@ func (db *DB) applyRewriteSwapBatchSerialized(swaps []rewriteSwap, sync bool) er
 			releaseValueLogRefDelta(vlogRefDelta)
 		}
 	}()
-	if err := db.finalizeCommit(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta); err != nil {
+	var vlogLocatorDelta *valueLogLocatorDelta
+	if db.valueLogLocatorCatalog != nil && valueLogLocatorCatalogEnabled() && db.valueLogLocatorCatalog.canTrack(baseSeq) {
+		vlogLocatorDelta, err = buildValueLogLocatorDelta(tree.New(idx.pager, vlogSet, rootID), entries)
+		if err != nil {
+			return err
+		}
+	}
+	if err := db.finalizeCommit(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta, vlogLocatorDelta); err != nil {
 		return err
 	}
 	vlogRefDelta = nil

--- a/worklog/2026-04-10-authoritative-catalogs.md
+++ b/worklog/2026-04-10-authoritative-catalogs.md
@@ -1,0 +1,86 @@
+## 2026-04-10
+
+### Scope
+
+- first-stack branch head:
+  - `eb1325b3` `treedb: use debt ledger for referenced segment reads`
+- stacked draft PRs:
+  - `#951` selected-source rewrite accounting
+  - `#952` persisted debt-ledger scaffold
+  - `#953` planner-from-ledger cutover
+  - `#954` locator-catalog scaffold
+  - `#955` locator-backed selected rewrite scans
+  - `#956` debt-ledger-backed referenced segment reads
+
+### Celestia Validation
+
+- artifact root:
+  - `artifacts/celestia_profile_signals/authoritative_catalogs_stack_20260410154942`
+
+#### `wal_on_fast`
+
+- `sync_only`
+  - `t_sync = 360s`
+  - `max_rss_kb = 10540612`
+  - `post_run_app_bytes = 3505308754`
+  - `post_rewrite_app_bytes = 2070383609`
+- `dwell15m`
+  - `t_sync = 374s`
+  - `t_total = 1274s`
+  - `max_rss_kb = 12364776`
+  - `max_hwm_kb = 13182896`
+  - minute 15:
+    - `app_bytes = 3257479284`
+    - `wal_bytes = 3200670298`
+    - `maintenance_attempts = 44`
+    - `maintenance_acquired = 39`
+    - `maintenance_with_rewrite = 9`
+    - `rewrite_runs = 9`
+    - `queued_exec_runs = 8`
+    - `debt_visible_source = ledger`
+    - `debt_visible_bytes_stale = 3448029`
+
+#### `fast`
+
+- `sync_only`
+  - `t_sync = 425s`
+  - `max_rss_kb = 10764388`
+  - `post_run_app_bytes = 3498758005`
+  - `post_rewrite_app_bytes = 2080519205`
+- `dwell15m`
+  - `t_sync = 312s`
+  - `t_total = 1212s`
+  - `max_rss_kb = 12353964`
+  - `max_hwm_kb = 12373524`
+  - minute 15:
+    - `app_bytes = 3241285403`
+    - `wal_bytes = 3178152696`
+    - `maintenance_attempts = 140`
+    - `maintenance_acquired = 140`
+    - `maintenance_with_rewrite = 11`
+    - `rewrite_runs = 11`
+    - `queued_exec_runs = 11`
+    - no visible runtime debt remained
+
+### Conclusion
+
+- the first stack is worth keeping:
+  - both `wal_on_fast` and `fast` now execute rewrite work naturally during the 15-minute dwell
+  - both profiles reduce live minute-15 app size materially versus the previous steady-state failure mode
+- the first stack is not the end state:
+  - `wal_on_fast` minute-15 gap versus offline rewrite remains about `1.19 GB`
+  - `fast` minute-15 gap versus offline rewrite remains about `1.16 GB`
+
+### Second-Sprint Root Cause
+
+- current commit-path metadata is still not authoritative for the workload we care about:
+  - `buildValueLogRefDelta(...)` returns `nil` when `indexOuterLeavesInValueLog` is enabled
+  - rewrite leafref publication also commits with `nil` ref delta
+- this means the persisted debt ledger still depends on rebuild/scan truth instead of commit publication truth in the exact `fast` / `wal_on_fast` shape we are optimizing
+
+### Second-Sprint Start
+
+- first bounded slice:
+  - make the locator catalog commit-path maintained for normal writes and rewrite swap commits
+- follow-on required for true end state:
+  - replace count-only ref deltas with physical-record debt deltas that cover grouped values and outer-leaf value-log records


### PR DESCRIPTION
## What changed
This slice makes the locator catalog publish-path maintained for ordinary pointer writes and rewrite swap commits when the current commit path has enough information to update it safely.

It also records the validated first-stack results in a dated worklog entry.

## Why
The validated first stack proved the scan-driven architecture is worth keeping, but the locator catalog was still rebuild-on-demand. That left the executor side only partially catalog-backed.

This slice is the first bounded step of the second sprint: make one catalog commit-updated where the hooks already exist, and explicitly invalidate it on unsupported paths rather than silently drifting.

## Impact
- normal batch writes can now move/add/remove locator entries across commits
- rewrite swap commits can keep the locator catalog valid without forcing a rebuild
- unsupported commit paths still invalidate the catalog to preserve correctness

## Validation
- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogLocatorCatalog_RebuildAndLoad|ValueLogRewriteOnline_SourceFileIDs_UsesLocatorCatalogWhenEnabled|ValueLogLocatorCatalog_AppliesCommitDeltaAcrossWrites|ValueLogLocatorCatalog_TracksRewriteSwapCommits|ValueLogRewriteOnline_SourceFileIDs_RestrictsRewriteSet|ValueLogDebtLedger_RebuildAndLoad|ReferencedValueLogSegments_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_ShadowCompareRepairsDebtLedgerMismatch)' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestVlogGenerationRewrite_|TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity' -count=1`

## Measured baseline carried into this sprint
First-stack Celestia validation artifact:
- `artifacts/celestia_profile_signals/authoritative_catalogs_stack_20260410154942`

The remaining minute-15 live-size gap versus offline rewrite is still about `1.16-1.19 GB` in both `wal_on_fast` and `fast`, which is why the commit-path-authoritative sprint continues after `#956`.