### PR TITLE
[codex] treedb: maintain debt ledger on commit path

### DIFF
--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -187,6 +187,11 @@ func (b *Batch) writeOptimistic(sync bool) (bool, error) {
 
 	tracker := newAllocTracker(idx.allocator)
 	z := idx.zipper.CloneWithAllocator(tracker)
+	var outerLeafChanges *valueLogOuterLeafChangeCollector
+	if b.db.valueLogDebtLedger != nil && valueLogDebtLedgerEnabled() && b.db.valueLogDebtLedger.canTrack(baseSeq) {
+		outerLeafChanges = &valueLogOuterLeafChangeCollector{}
+		z.SetOuterLeafRecordObserver(outerLeafChanges.Observe)
+	}
 	newRoot, retired, metrics, err := z.Apply(rootID, b.batch)
 	if err != nil {
 		freeErr := tracker.FreeAll()
@@ -198,6 +203,15 @@ func (b *Batch) writeOptimistic(sync bool) (bool, error) {
 	}
 	entries := b.batch.SortedEntries()
 	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries)
+	if err != nil {
+		freeErr := tracker.FreeAll()
+		b.db.writeMu.RUnlock()
+		if freeErr != nil {
+			return false, freeErr
+		}
+		return false, err
+	}
+	vlogDebtDelta, err := b.db.buildValueLogDebtDelta(idx.pager, rootID, baseSeq, entries, outerLeafChanges)
 	if err != nil {
 		freeErr := tracker.FreeAll()
 		b.db.writeMu.RUnlock()
@@ -238,7 +252,7 @@ func (b *Batch) writeOptimistic(sync bool) (bool, error) {
 		return false, nil
 	}
 
-	post, err := b.db.finalizeCommitLocked(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, vlogLocatorDelta)
+	post, err := b.db.finalizeCommitLocked(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, vlogDebtDelta, vlogLocatorDelta)
 	b.db.commitMu.Unlock()
 	if err != nil {
 		b.db.writeMu.RUnlock()
@@ -272,12 +286,22 @@ func (b *Batch) writeSerialized(sync bool) error {
 
 	defer idx.registry.Unregister(regID)
 
+	var outerLeafChanges *valueLogOuterLeafChangeCollector
+	if b.db.valueLogDebtLedger != nil && valueLogDebtLedgerEnabled() && b.db.valueLogDebtLedger.canTrack(baseSeq) {
+		outerLeafChanges = &valueLogOuterLeafChangeCollector{}
+		idx.zipper.SetOuterLeafRecordObserver(outerLeafChanges.Observe)
+		defer idx.zipper.SetOuterLeafRecordObserver(nil)
+	}
 	newRoot, retired, metrics, err := idx.zipper.Apply(rootID, b.batch)
 	if err != nil {
 		return err
 	}
 	entries := b.batch.SortedEntries()
 	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries)
+	if err != nil {
+		return err
+	}
+	vlogDebtDelta, err := b.db.buildValueLogDebtDelta(idx.pager, rootID, baseSeq, entries, outerLeafChanges)
 	if err != nil {
 		return err
 	}
@@ -303,7 +327,7 @@ func (b *Batch) writeSerialized(sync bool) error {
 	sysRoot := b.db.meta.SystemRootPageID
 	b.db.mu.Unlock()
 
-	if err := b.db.finalizeCommit(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, vlogLocatorDelta); err != nil {
+	if err := b.db.finalizeCommit(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, vlogDebtDelta, vlogLocatorDelta); err != nil {
 		return err
 	}
 	vlogRefDelta = nil

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1497,6 +1497,7 @@ type finalizeCommitPost struct {
 	oldState         *DBState
 	metrics          adaptive.Metrics
 	vlogRefDelta     *valueLogRefDelta
+	vlogDebtDelta    *valueLogDebtDelta
 	vlogLocatorDelta *valueLogLocatorDelta
 	commitSeq        uint64
 	kickPrune        bool
@@ -1512,7 +1513,7 @@ type finalizeCommitPost struct {
 // finalizeCommitLocked performs the durability-critical publish path.
 // Callers that already hold commit serialization may run post work after
 // releasing the serialization lock.
-func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta, vlogLocatorDelta *valueLogLocatorDelta) (finalizeCommitPost, error) {
+func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta, vlogDebtDelta *valueLogDebtDelta, vlogLocatorDelta *valueLogLocatorDelta) (finalizeCommitPost, error) {
 	post := finalizeCommitPost{
 		metrics: metrics,
 	}
@@ -1663,6 +1664,7 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 	db.publishSnapshotView(idx, newState, db.valueLogManager)
 	post.commitSeq = nextMeta.CommitSeq
 	post.vlogRefDelta = vlogRefDelta
+	post.vlogDebtDelta = vlogDebtDelta
 	post.vlogLocatorDelta = vlogLocatorDelta
 	db.mu.Unlock()
 	watermarkHold += time.Since(holdStart)
@@ -1696,6 +1698,20 @@ func (db *DB) finalizeCommitPostWork(post finalizeCommitPost) {
 			}
 		} else {
 			db.valueLogRefTracker.invalidate()
+		}
+	}
+	if db.valueLogDebtLedger != nil && valueLogDebtLedgerEnabled() {
+		if post.vlogDebtDelta != nil {
+			totals, err := db.currentValueLogSegmentTotals(post.vlogDebtDelta.fileIDs())
+			if err != nil {
+				db.valueLogDebtLedger.invalidate()
+				db.reportError(err)
+			} else if err := db.valueLogDebtLedger.applyDelta(post.commitSeq, post.vlogDebtDelta, totals); err != nil {
+				db.valueLogDebtLedger.invalidate()
+				db.reportError(err)
+			}
+		} else {
+			db.valueLogDebtLedger.invalidate()
 		}
 	}
 	if db.valueLogLocatorCatalog != nil && valueLogLocatorCatalogEnabled() {
@@ -1744,8 +1760,8 @@ func (db *DB) finalizeCommitPostWork(post finalizeCommitPost) {
 }
 
 // finalizeCommit handles durability and state updates.
-func (db *DB) finalizeCommit(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta, vlogLocatorDelta *valueLogLocatorDelta) error {
-	post, err := db.finalizeCommitLocked(newRootID, sysRootID, retired, sync, metrics, touchedValueLogSegments, forceValueLogRefresh, vlogRefDelta, vlogLocatorDelta)
+func (db *DB) finalizeCommit(newRootID uint64, sysRootID uint64, retired []uint64, sync bool, metrics adaptive.Metrics, touchedValueLogSegments []uint32, forceValueLogRefresh bool, vlogRefDelta *valueLogRefDelta, vlogDebtDelta *valueLogDebtDelta, vlogLocatorDelta *valueLogLocatorDelta) error {
+	post, err := db.finalizeCommitLocked(newRootID, sysRootID, retired, sync, metrics, touchedValueLogSegments, forceValueLogRefresh, vlogRefDelta, vlogDebtDelta, vlogLocatorDelta)
 	if err != nil {
 		return err
 	}
@@ -1777,7 +1793,7 @@ func (db *DB) Commit(newRootID uint64) error {
 	sysRoot := db.meta.SystemRootPageID
 	db.mu.RUnlock()
 
-	return db.finalizeCommit(newRootID, sysRoot, nil, true, adaptive.Metrics{}, nil, true, nil, nil)
+	return db.finalizeCommit(newRootID, sysRoot, nil, true, adaptive.Metrics{}, nil, true, nil, nil, nil)
 }
 
 // Prune reclaims pages from the graveyard.
@@ -2048,7 +2064,7 @@ func (db *DB) CompactIndex() error {
 	db.mu.Unlock()
 
 	// Commit new root and retire the old tree pages.
-	return db.finalizeCommit(newRoot, sysRoot, retired, true, adaptive.Metrics{}, nil, true, nil, nil)
+	return db.finalizeCommit(newRoot, sysRoot, retired, true, adaptive.Metrics{}, nil, true, nil, nil, nil)
 }
 
 type pagerAllocator struct {

--- a/TreeDB/db/vlog_debt_ledger.go
+++ b/TreeDB/db/vlog_debt_ledger.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -10,7 +12,14 @@ import (
 	"strings"
 	"sync"
 
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/atomicfile"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 const (
@@ -34,16 +43,49 @@ type valueLogDebtLedgerDisk struct {
 	Segments  []valueLogDebtSegmentSummary `json:"segments,omitempty"`
 }
 
+type valueLogDebtRecordKey struct {
+	FileID uint32
+	Start  uint64
+}
+
+type valueLogDebtRecordRef struct {
+	Key       valueLogDebtRecordKey
+	RecordLen uint32
+	RefCount  uint32
+}
+
+type valueLogDebtDeltaChange struct {
+	RecordLen uint32
+	RefDelta  int32
+}
+
+type valueLogDebtDelta struct {
+	changes map[valueLogDebtRecordKey]valueLogDebtDeltaChange
+}
+
+type valueLogOuterLeafChangeCollector struct {
+	oldPtrs []page.ValuePtr
+	newPtrs []page.ValuePtr
+}
+
 type valueLogDebtLedger struct {
 	mu        sync.RWMutex
 	commitSeq uint64
 	segments  map[uint32]valueLogDebtSegmentSummary
+	records   map[valueLogDebtRecordKey]valueLogDebtRecordRef
 	valid     bool
 	dirty     bool
 }
 
 func newValueLogDebtLedger() *valueLogDebtLedger {
-	return &valueLogDebtLedger{segments: make(map[uint32]valueLogDebtSegmentSummary)}
+	return &valueLogDebtLedger{
+		segments: make(map[uint32]valueLogDebtSegmentSummary),
+		records:  make(map[valueLogDebtRecordKey]valueLogDebtRecordRef),
+	}
+}
+
+func newValueLogDebtDelta() *valueLogDebtDelta {
+	return &valueLogDebtDelta{changes: make(map[valueLogDebtRecordKey]valueLogDebtDeltaChange)}
 }
 
 func envDebtLedgerBool(name string) bool {
@@ -75,11 +117,106 @@ func valueLogDebtLedgerShadowCompareEnabled() bool {
 	return envDebtLedgerBool(envEnableVlogShadowCompare)
 }
 
-func (l *valueLogDebtLedger) replace(commitSeq uint64, segments map[uint32]valueLogDebtSegmentSummary, dirty bool) {
+func valueLogDebtRecordKeyForPtr(ptr page.ValuePtr) (valueLogDebtRecordKey, error) {
+	if !page.IsValueLogFileID(ptr.FileID) {
+		return valueLogDebtRecordKey{}, fmt.Errorf("treedb: non-vlog pointer for debt key: file=%d", ptr.FileID)
+	}
+	if ptr.Offset < 4 {
+		return valueLogDebtRecordKey{}, fmt.Errorf("treedb: invalid value-log pointer offset %d", ptr.Offset)
+	}
+	return valueLogDebtRecordKey{FileID: ptr.FileID, Start: uint64(ptr.Offset - 4)}, nil
+}
+
+func (d *valueLogDebtDelta) addRecord(key valueLogDebtRecordKey, recordLen uint32, refDelta int32) {
+	if d == nil || refDelta == 0 || key.FileID == 0 {
+		return
+	}
+	if d.changes == nil {
+		d.changes = make(map[valueLogDebtRecordKey]valueLogDebtDeltaChange)
+	}
+	change := d.changes[key]
+	if change.RecordLen == 0 {
+		change.RecordLen = recordLen
+	}
+	change.RefDelta += refDelta
+	if change.RefDelta == 0 {
+		delete(d.changes, key)
+		return
+	}
+	d.changes[key] = change
+}
+
+func (d *valueLogDebtDelta) addPtr(ptr page.ValuePtr, recordLen uint32, refDelta int32) error {
+	if d == nil || refDelta == 0 || !page.IsValueLogFileID(ptr.FileID) {
+		return nil
+	}
+	key, err := valueLogDebtRecordKeyForPtr(ptr)
+	if err != nil {
+		return err
+	}
+	d.addRecord(key, recordLen, refDelta)
+	return nil
+}
+
+func (d *valueLogDebtDelta) fileIDs() []uint32 {
+	if d == nil || len(d.changes) == 0 {
+		return nil
+	}
+	seen := make(map[uint32]struct{}, len(d.changes))
+	ids := make([]uint32, 0, len(d.changes))
+	for key := range d.changes {
+		if _, ok := seen[key.FileID]; ok {
+			continue
+		}
+		seen[key.FileID] = struct{}{}
+		ids = append(ids, key.FileID)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+func (c *valueLogOuterLeafChangeCollector) Observe(oldPtrs, newPtrs []page.ValuePtr) {
+	if c == nil {
+		return
+	}
+	if len(oldPtrs) > 0 {
+		c.oldPtrs = append(c.oldPtrs, oldPtrs...)
+	}
+	if len(newPtrs) > 0 {
+		c.newPtrs = append(c.newPtrs, newPtrs...)
+	}
+}
+
+func (c *valueLogOuterLeafChangeCollector) appendToDebtDelta(db *DB, delta *valueLogDebtDelta) error {
+	if c == nil || delta == nil {
+		return nil
+	}
+	for _, ptr := range c.oldPtrs {
+		recordLen, err := db.valueLogRecordLengthForRewrite(ptr)
+		if err != nil {
+			return err
+		}
+		if err := delta.addPtr(ptr, recordLen, -1); err != nil {
+			return err
+		}
+	}
+	for _, ptr := range c.newPtrs {
+		recordLen, err := db.valueLogRecordLengthForRewrite(ptr)
+		if err != nil {
+			return err
+		}
+		if err := delta.addPtr(ptr, recordLen, 1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *valueLogDebtLedger) replace(commitSeq uint64, segments map[uint32]valueLogDebtSegmentSummary, records map[valueLogDebtRecordKey]valueLogDebtRecordRef, dirty bool) {
 	if l == nil {
 		return
 	}
-	next := make(map[uint32]valueLogDebtSegmentSummary, len(segments))
+	nextSegments := make(map[uint32]valueLogDebtSegmentSummary, len(segments))
 	for fileID, seg := range segments {
 		if seg.FileID == 0 {
 			seg.FileID = fileID
@@ -90,14 +227,34 @@ func (l *valueLogDebtLedger) replace(commitSeq uint64, segments map[uint32]value
 		if seg.StaleBytes > seg.TotalBytes {
 			seg.StaleBytes = seg.TotalBytes
 		}
-		next[seg.FileID] = seg
+		nextSegments[seg.FileID] = seg
+	}
+	nextRecords := make(map[valueLogDebtRecordKey]valueLogDebtRecordRef, len(records))
+	for key, rec := range records {
+		if rec.Key.FileID == 0 {
+			rec.Key = key
+		}
+		if rec.Key.FileID == 0 || rec.RefCount == 0 || rec.RecordLen == 0 {
+			continue
+		}
+		nextRecords[rec.Key] = rec
 	}
 	l.mu.Lock()
 	l.commitSeq = commitSeq
-	l.segments = next
+	l.segments = nextSegments
+	l.records = nextRecords
 	l.valid = true
 	l.dirty = dirty
 	l.mu.Unlock()
+}
+
+func (l *valueLogDebtLedger) canTrack(baseSeq uint64) bool {
+	if l == nil {
+		return false
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.valid && l.commitSeq == baseSeq && len(l.records) > 0
 }
 
 func (l *valueLogDebtLedger) invalidate() {
@@ -120,6 +277,9 @@ func (l *valueLogDebtLedger) liveBytesBySegment(commitSeq uint64) (map[uint32]in
 	}
 	out := make(map[uint32]int64, len(l.segments))
 	for fileID, seg := range l.segments {
+		if seg.LiveBytes == 0 {
+			continue
+		}
 		out[fileID] = int64(seg.LiveBytes)
 	}
 	return out, true
@@ -151,6 +311,101 @@ func (l *valueLogDebtLedger) markClean(commitSeq uint64) {
 		l.dirty = false
 	}
 	l.mu.Unlock()
+}
+
+func (l *valueLogDebtLedger) applyDelta(nextCommitSeq uint64, delta *valueLogDebtDelta, totals map[uint32]uint64) error {
+	if l == nil {
+		return nil
+	}
+	if delta == nil {
+		return errors.New("treedb: missing value-log debt delta")
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if !l.valid {
+		return errors.New("treedb: value-log debt ledger invalid")
+	}
+	if nextCommitSeq != l.commitSeq+1 {
+		return fmt.Errorf("treedb: value-log debt ledger sequence mismatch: have=%d next=%d", l.commitSeq, nextCommitSeq)
+	}
+	if len(l.records) == 0 {
+		return errors.New("treedb: value-log debt ledger missing record refs")
+	}
+
+	touched := make(map[uint32]struct{}, len(delta.changes)+len(totals))
+	for key, change := range delta.changes {
+		if change.RefDelta == 0 {
+			continue
+		}
+		rec := l.records[key]
+		curRefCount := int64(rec.RefCount)
+		nextRefCount := curRefCount + int64(change.RefDelta)
+		if nextRefCount < 0 {
+			return fmt.Errorf("treedb: value-log debt ledger refcount underflow: file=%d start=%d have=%d delta=%d", key.FileID, key.Start, rec.RefCount, change.RefDelta)
+		}
+		recordLen := rec.RecordLen
+		if recordLen == 0 {
+			recordLen = change.RecordLen
+		}
+		if nextRefCount > 0 && recordLen == 0 {
+			return fmt.Errorf("treedb: missing record length for value-log debt delta: file=%d start=%d", key.FileID, key.Start)
+		}
+		seg := l.segments[key.FileID]
+		seg.FileID = key.FileID
+		switch {
+		case curRefCount == 0 && nextRefCount > 0:
+			seg.LiveBytes += uint64(recordLen)
+		case curRefCount > 0 && nextRefCount == 0:
+			if uint64(recordLen) > seg.LiveBytes {
+				return fmt.Errorf("treedb: value-log debt live-byte underflow: file=%d have=%d dec=%d", key.FileID, seg.LiveBytes, recordLen)
+			}
+			seg.LiveBytes -= uint64(recordLen)
+		}
+		seg.LastUpdatedCommitSeq = nextCommitSeq
+		l.segments[key.FileID] = seg
+		touched[key.FileID] = struct{}{}
+
+		if nextRefCount == 0 {
+			delete(l.records, key)
+			continue
+		}
+		rec.Key = key
+		rec.RecordLen = recordLen
+		rec.RefCount = uint32(nextRefCount)
+		l.records[key] = rec
+	}
+
+	for fileID, total := range totals {
+		seg := l.segments[fileID]
+		seg.FileID = fileID
+		seg.TotalBytes = total
+		if seg.LiveBytes > seg.TotalBytes {
+			seg.LiveBytes = seg.TotalBytes
+		}
+		seg.StaleBytes = seg.TotalBytes - seg.LiveBytes
+		seg.LastUpdatedCommitSeq = nextCommitSeq
+		l.segments[fileID] = seg
+		touched[fileID] = struct{}{}
+	}
+	for fileID := range touched {
+		seg := l.segments[fileID]
+		if seg.LiveBytes > seg.TotalBytes {
+			seg.LiveBytes = seg.TotalBytes
+		}
+		if seg.TotalBytes >= seg.LiveBytes {
+			seg.StaleBytes = seg.TotalBytes - seg.LiveBytes
+		} else {
+			seg.StaleBytes = 0
+		}
+		seg.LastUpdatedCommitSeq = nextCommitSeq
+		l.segments[fileID] = seg
+	}
+
+	l.commitSeq = nextCommitSeq
+	l.dirty = true
+	return nil
 }
 
 func (db *DB) valueLogDebtLedgerPath() string {
@@ -207,7 +462,7 @@ func (db *DB) loadValueLogDebtLedger(commitSeq uint64) (bool, error) {
 	for _, seg := range disk.Segments {
 		segments[seg.FileID] = seg
 	}
-	db.valueLogDebtLedger.replace(disk.CommitSeq, segments, false)
+	db.valueLogDebtLedger.replace(disk.CommitSeq, segments, nil, false)
 	return true, nil
 }
 
@@ -272,8 +527,192 @@ func (db *DB) storeValueLogDebtLedgerFromLiveBytes(liveByID map[uint32]int64) er
 			}
 		}
 	}
-	db.valueLogDebtLedger.replace(db.currentCommitSeq(), segments, true)
+	// Segment-only snapshots remain useful for planning, but commit-path deltas
+	// require a rebuilt physical-record catalog before the ledger becomes
+	// authoritative again.
+	db.valueLogDebtLedger.replace(db.currentCommitSeq(), segments, nil, true)
 	return db.persistValueLogDebtLedger()
+}
+
+func observeValueLogDebtRecord(db *DB, ptr page.ValuePtr, records map[valueLogDebtRecordKey]valueLogDebtRecordRef, set *valuelog.Set) error {
+	if db == nil || records == nil || !page.IsValueLogFileID(ptr.FileID) {
+		return nil
+	}
+	key, err := valueLogDebtRecordKeyForPtr(ptr)
+	if err != nil {
+		return err
+	}
+	recordLen, err := db.valueLogRecordLengthForRewriteInSet(ptr, set)
+	if err != nil {
+		return err
+	}
+	rec := records[key]
+	rec.Key = key
+	rec.RecordLen = recordLen
+	rec.RefCount++
+	records[key] = rec
+	return nil
+}
+
+func (db *DB) collectValueLogRecordRefs(ctx context.Context, it iterator.UnsafeIterator, records map[valueLogDebtRecordKey]valueLogDebtRecordRef, set *valuelog.Set) error {
+	for it.Valid() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_, ptr, flags := it.UnsafeEntry()
+		if flags&node.FlagPointer == 0 || !page.IsValueLogFileID(ptr.FileID) {
+			it.Next()
+			continue
+		}
+		if err := observeValueLogDebtRecord(db, ptr, records, set); err != nil {
+			return err
+		}
+		it.Next()
+	}
+	return it.Error()
+}
+
+func (db *DB) collectLeafRefValueLogRecordRefs(ctx context.Context, p *pager.Pager, rootID uint64, records map[valueLogDebtRecordKey]valueLogDebtRecordRef, set *valuelog.Set) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if p == nil || rootID == 0 || records == nil {
+		return nil
+	}
+	if ptr, ok := page.DecodeLeafRef(rootID); ok {
+		return observeValueLogDebtRecord(db, ptr, records, set)
+	}
+	stack := make([]uint64, 0, 128)
+	stack = append(stack, rootID)
+	visited := make(map[uint64]struct{}, 1024)
+	verifyAlways := p.VerifyOnRead()
+
+	for len(stack) > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		pageID := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if _, ok := visited[pageID]; ok {
+			continue
+		}
+		visited[pageID] = struct{}{}
+
+		data, err := p.Get(pageID)
+		if err != nil {
+			return err
+		}
+		n := node.NewNodeView(data)
+		if verifyAlways || !p.IsVerified(pageID) {
+			if !n.VerifyChecksum() {
+				return fmt.Errorf("checksum mismatch on page %d", pageID)
+			}
+			if !verifyAlways {
+				p.MarkVerified(pageID)
+			}
+		}
+
+		switch n.Type() {
+		case page.PageTypeInternal:
+			count := n.Count()
+			for i := uint16(0); i < count; i++ {
+				childID, err := n.GetInternalChildID(i)
+				if err != nil {
+					return err
+				}
+				if ptr, ok := page.DecodeLeafRef(childID); ok {
+					if err := observeValueLogDebtRecord(db, ptr, records, set); err != nil {
+						return err
+					}
+					continue
+				}
+				stack = append(stack, childID)
+			}
+		case page.PageTypeLeaf:
+			// Pager-backed leaves are possible during transitional states. They do
+			// not contribute value-log debt directly.
+		default:
+			return fmt.Errorf("invalid page type %d on page %d", n.Type(), pageID)
+		}
+	}
+	return nil
+}
+
+func buildValueLogDebtSegmentsFromRecords(set *valuelog.Set, records map[valueLogDebtRecordKey]valueLogDebtRecordRef, commitSeq uint64) map[uint32]valueLogDebtSegmentSummary {
+	segments := make(map[uint32]valueLogDebtSegmentSummary)
+	if set != nil {
+		for fileID, f := range set.Files {
+			total := uint64(maxInt64Zero(fileSize(f)))
+			segments[fileID] = valueLogDebtSegmentSummary{
+				FileID:               fileID,
+				TotalBytes:           total,
+				LastUpdatedCommitSeq: commitSeq,
+			}
+		}
+	}
+	for _, rec := range records {
+		if rec.RefCount == 0 || rec.RecordLen == 0 {
+			continue
+		}
+		seg := segments[rec.Key.FileID]
+		seg.FileID = rec.Key.FileID
+		seg.LiveBytes += uint64(rec.RecordLen)
+		seg.LastUpdatedCommitSeq = commitSeq
+		segments[rec.Key.FileID] = seg
+	}
+	for fileID, seg := range segments {
+		if seg.LiveBytes > seg.TotalBytes {
+			seg.LiveBytes = seg.TotalBytes
+		}
+		if seg.TotalBytes >= seg.LiveBytes {
+			seg.StaleBytes = seg.TotalBytes - seg.LiveBytes
+		} else {
+			seg.StaleBytes = 0
+		}
+		segments[fileID] = seg
+	}
+	return segments
+}
+
+func (db *DB) scanValueLogDebtLedger(ctx context.Context) (map[uint32]valueLogDebtSegmentSummary, map[valueLogDebtRecordKey]valueLogDebtRecordRef, uint64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil || snap.state == nil || snap.idx == nil {
+		closeRewriteSnapshot(nil, snap)
+		return nil, nil, 0, fmt.Errorf("missing snapshot state")
+	}
+	var closeErr error
+	defer closeRewriteSnapshot(&closeErr, snap)
+
+	records := make(map[valueLogDebtRecordKey]valueLogDebtRecordRef, 1024)
+
+	userIter := snap.tree.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+	if err := db.collectValueLogRecordRefs(ctx, userIter, records, snap.state.ValueLogSet); err != nil {
+		_ = userIter.Close()
+		return nil, nil, 0, err
+	}
+	_ = userIter.Close()
+
+	sysIter := tree.New(snap.idx.pager, newValueReader(snap.state.ValueLogSet), snap.state.SystemRootPageID).
+		IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+	if err := db.collectValueLogRecordRefs(ctx, sysIter, records, snap.state.ValueLogSet); err != nil {
+		_ = sysIter.Close()
+		return nil, nil, 0, err
+	}
+	_ = sysIter.Close()
+
+	if err := db.collectLeafRefValueLogRecordRefs(ctx, snap.idx.pager, snap.state.RootPageID, records, snap.state.ValueLogSet); err != nil {
+		return nil, nil, 0, err
+	}
+	if err := db.collectLeafRefValueLogRecordRefs(ctx, snap.idx.pager, snap.state.SystemRootPageID, records, snap.state.ValueLogSet); err != nil {
+		return nil, nil, 0, err
+	}
+
+	segments := buildValueLogDebtSegmentsFromRecords(snap.state.ValueLogSet, records, snap.state.CommitSeq)
+	return segments, records, snap.state.CommitSeq, nil
 }
 
 func (db *DB) rebuildValueLogDebtLedger(ctx context.Context) error {
@@ -283,11 +722,24 @@ func (db *DB) rebuildValueLogDebtLedger(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	liveByID, err := db.estimateValueLogLiveBytesBySegment(ctx)
-	if err != nil {
+	scan := func() error {
+		segments, records, commitSeq, err := db.scanValueLogDebtLedger(ctx)
+		if err != nil {
+			return err
+		}
+		db.valueLogDebtLedger.replace(commitSeq, segments, records, true)
+		return db.persistValueLogDebtLedger()
+	}
+	if err := scan(); err != nil {
+		if errors.Is(err, valuelog.ErrFileNotFound) {
+			if refreshErr := db.RefreshValueLogSet(); refreshErr != nil {
+				return refreshErr
+			}
+			return scan()
+		}
 		return err
 	}
-	return db.storeValueLogDebtLedgerFromLiveBytes(liveByID)
+	return nil
 }
 
 func maxInt64Zero(v int64) int64 {
@@ -319,12 +771,125 @@ func (db *DB) liveBytesBySegmentFromDebtLedger(ctx context.Context) (map[uint32]
 	if db == nil || db.valueLogDebtLedger == nil || !valueLogDebtLedgerEnabled() {
 		return nil, false, nil
 	}
-	if liveByID, ok := db.valueLogDebtLedger.liveBytesBySegment(db.currentCommitSeq()); ok {
+	commitSeq := db.currentCommitSeq()
+	if liveByID, ok := db.valueLogDebtLedger.liveBytesBySegment(commitSeq); ok {
+		if db.valueLogDebtLedger.canTrack(commitSeq) {
+			return liveByID, true, nil
+		}
+		// Persisted segment summaries remain useful for planning, but rebuild once
+		// so subsequent commits can stay authoritative in-process.
+		if err := db.rebuildValueLogDebtLedger(ctx); err == nil {
+			if rebuilt, rebuiltOK := db.valueLogDebtLedger.liveBytesBySegment(commitSeq); rebuiltOK {
+				return rebuilt, true, nil
+			}
+		} else {
+			db.reportError(err)
+		}
 		return liveByID, true, nil
 	}
 	if err := db.rebuildValueLogDebtLedger(ctx); err != nil {
 		return nil, false, err
 	}
-	liveByID, ok := db.valueLogDebtLedger.liveBytesBySegment(db.currentCommitSeq())
+	liveByID, ok := db.valueLogDebtLedger.liveBytesBySegment(commitSeq)
 	return liveByID, ok, nil
+}
+
+func lookupValueLogPtrAtKey(tr *tree.Tree, key []byte) (page.ValuePtr, bool, error) {
+	if tr == nil {
+		return page.ValuePtr{}, false, nil
+	}
+	entry, err := tr.GetEntry(key)
+	if err != nil {
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			return page.ValuePtr{}, false, nil
+		}
+		return page.ValuePtr{}, false, err
+	}
+	if entry.Flags&node.FlagPointer == 0 || !page.IsValueLogFileID(entry.ValuePtr.FileID) {
+		return page.ValuePtr{}, false, nil
+	}
+	return entry.ValuePtr, true, nil
+}
+
+func (db *DB) buildValueLogDebtDelta(p *pager.Pager, rootID uint64, baseSeq uint64, entries []batchpkg.Entry, outerLeafChanges *valueLogOuterLeafChangeCollector) (*valueLogDebtDelta, error) {
+	if db == nil || db.valueLogDebtLedger == nil || !valueLogDebtLedgerEnabled() || !db.valueLogDebtLedger.canTrack(baseSeq) {
+		return nil, nil
+	}
+	delta := newValueLogDebtDelta()
+	if p != nil {
+		var tr *tree.Tree
+		if state := db.state.Load(); state != nil {
+			reader := newValueReader(state.ValueLogSet)
+			tr = tree.New(p, &reader, rootID)
+		} else {
+			tr = tree.New(p, nil, rootID)
+		}
+		for i := range entries {
+			oldPtr, oldRef, err := lookupValueLogPtrAtKey(tr, entries[i].Key)
+			if err != nil {
+				return nil, err
+			}
+			if oldRef {
+				recordLen, err := db.valueLogRecordLengthForRewrite(oldPtr)
+				if err != nil {
+					return nil, err
+				}
+				if err := delta.addPtr(oldPtr, recordLen, -1); err != nil {
+					return nil, err
+				}
+			}
+			if entries[i].Type == batchpkg.OpPut && entries[i].IsPtr && page.IsValueLogFileID(entries[i].ValuePtr.FileID) {
+				recordLen, err := db.valueLogRecordLengthForRewrite(entries[i].ValuePtr)
+				if err != nil {
+					return nil, err
+				}
+				if err := delta.addPtr(entries[i].ValuePtr, recordLen, 1); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	if err := outerLeafChanges.appendToDebtDelta(db, delta); err != nil {
+		return nil, err
+	}
+	return delta, nil
+}
+
+func (db *DB) currentValueLogSegmentTotals(fileIDs []uint32) (map[uint32]uint64, error) {
+	if db == nil || db.valueLogManager == nil || len(fileIDs) == 0 {
+		return nil, nil
+	}
+	currentSet := db.valueLogManager.CurrentSetNoRefresh()
+	if currentSet == nil {
+		if err := db.valueLogManager.Refresh(); err != nil {
+			return nil, err
+		}
+		currentSet = db.valueLogManager.CurrentSetNoRefresh()
+	}
+	if currentSet == nil {
+		return nil, fmt.Errorf("treedb: value-log set unavailable")
+	}
+	defer func() { _ = db.valueLogManager.Release(currentSet) }()
+
+	totals := make(map[uint32]uint64, len(fileIDs))
+	for _, fileID := range fileIDs {
+		if file, ok := currentSet.Files[fileID]; ok && file != nil {
+			size := int64(-1)
+			switch {
+			case file.File != nil:
+				if info, err := file.File.Stat(); err == nil {
+					size = info.Size()
+				}
+			case file.Path != "":
+				if info, err := os.Stat(file.Path); err == nil {
+					size = info.Size()
+				}
+			}
+			if size < 0 {
+				size = fileSize(file)
+			}
+			totals[fileID] = uint64(maxInt64Zero(size))
+		}
+	}
+	return totals, nil
 }

--- a/TreeDB/db/vlog_debt_ledger_test.go
+++ b/TreeDB/db/vlog_debt_ledger_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -111,5 +112,277 @@ func TestReferencedValueLogSegments_UsesPersistedDebtLedgerAcrossReopen(t *testi
 	}
 	if got := legacyCalls.Load(); got != 0 {
 		t.Fatalf("legacy referenced-segment scan calls=%d want 0", got)
+	}
+}
+
+func TestValueLogDebtLedger_TracksCommitDeltaAcrossPointerWrites(t *testing.T) {
+	t.Setenv(envEnableVlogDebtLedger, "1")
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	ptrs1 := appendPointersInNewSegment(t, dir, 0, 10, 360_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("a"), 256)
+	})
+	ptrs2 := appendPointersInNewSegment(t, dir, 0, 11, 361_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("b"), 256)
+	})
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs1[0]); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := b.SetPointer([]byte("k2"), ptrs2[0]); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	if err := db.rebuildValueLogDebtLedger(context.Background()); err != nil {
+		t.Fatalf("rebuild debt ledger: %v", err)
+	}
+	if !db.valueLogDebtLedger.canTrack(db.currentCommitSeq()) {
+		t.Fatalf("expected debt ledger to become trackable after rebuild")
+	}
+
+	ptrs3 := appendPointersInNewSegment(t, dir, 0, 12, 362_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("c"), 256)
+	})
+	b = db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs3[0]); err != nil {
+		t.Fatalf("update k1: %v", err)
+	}
+	if err := b.Delete([]byte("k2")); err != nil {
+		t.Fatalf("delete k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("delta write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	if !db.valueLogDebtLedger.canTrack(db.currentCommitSeq()) {
+		t.Fatalf("expected debt ledger to stay trackable after pointer delta commit")
+	}
+	ledgerLive, ok, err := db.liveBytesBySegmentFromDebtLedger(context.Background())
+	if err != nil {
+		t.Fatalf("live bytes from debt ledger: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected live bytes from debt ledger after delta commit")
+	}
+	scanLive, err := db.estimateValueLogLiveBytesBySegment(context.Background())
+	if err != nil {
+		t.Fatalf("estimate live bytes: %v", err)
+	}
+	if !sameValueLogLiveBytesBySegment(ledgerLive, scanLive) {
+		t.Fatalf("debt ledger live bytes mismatch after pointer delta: ledger=%+v scan=%+v", ledgerLive, scanLive)
+	}
+}
+
+func TestValueLogDebtLedger_TracksOuterLeafCommitDeltaAcrossWrites(t *testing.T) {
+	t.Setenv(envEnableVlogDebtLedger, "1")
+	dir := t.TempDir()
+
+	db, err := Open(Options{
+		Dir:                        dir,
+		Durability:                 DurabilityWALOffRelaxed,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		LeafPrefixCompression:      true,
+		IndexColumnarLeaves:        true,
+		IndexPackedValuePtr:        true,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	leafLog := &registeredLeafPageLog{db: db, dir: dir}
+	db.SetLeafPageLog(leafLog)
+	db.idx.Load().zipper.SetLeafPageReader(db.valueLogManager)
+
+	value := bytes.Repeat([]byte("outer-leaf-value-"), 4)
+	b := db.NewBatch().(*Batch)
+	for i := 0; i < 512; i++ {
+		if err := b.Set([]byte(fmt.Sprintf("k%04d", i)), value); err != nil {
+			t.Fatalf("seed set %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh value-log set: %v", err)
+	}
+
+	if err := db.rebuildValueLogDebtLedger(context.Background()); err != nil {
+		t.Fatalf("rebuild debt ledger: %v", err)
+	}
+	if !db.valueLogDebtLedger.canTrack(db.currentCommitSeq()) {
+		t.Fatalf("expected debt ledger to become trackable after outer-leaf rebuild")
+	}
+	beforeLeafCounts := make(map[uint32]int, 16)
+	stateBefore := db.State()
+	collectLeafRefFileCountsBench(t, db.Pager(), stateBefore.RootPageID, beforeLeafCounts)
+	collectLeafRefFileCountsBench(t, db.Pager(), stateBefore.SystemRootPageID, beforeLeafCounts)
+
+	b = db.NewBatch().(*Batch)
+	for i := 0; i < 64; i++ {
+		if err := b.Set([]byte(fmt.Sprintf("k%04d", i)), append(value, byte(i))); err != nil {
+			t.Fatalf("delta set %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("delta write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	if !db.valueLogDebtLedger.canTrack(db.currentCommitSeq()) {
+		t.Fatalf("expected debt ledger to stay trackable after outer-leaf delta commit")
+	}
+	ledgerLive, ok, err := db.liveBytesBySegmentFromDebtLedger(context.Background())
+	if err != nil {
+		t.Fatalf("live bytes from debt ledger: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected live bytes from debt ledger after outer-leaf delta commit")
+	}
+	scanLive, err := db.estimateValueLogLiveBytesBySegment(context.Background())
+	if err != nil {
+		t.Fatalf("estimate live bytes: %v", err)
+	}
+	if !sameValueLogLiveBytesBySegment(ledgerLive, scanLive) {
+		afterLeafCounts := make(map[uint32]int, 16)
+		stateAfter := db.State()
+		collectLeafRefFileCountsBench(t, db.Pager(), stateAfter.RootPageID, afterLeafCounts)
+		collectLeafRefFileCountsBench(t, db.Pager(), stateAfter.SystemRootPageID, afterLeafCounts)
+		ledgerRecordCounts := make(map[uint32]int, 16)
+		for key, rec := range db.valueLogDebtLedger.records {
+			if rec.RefCount == 0 {
+				continue
+			}
+			ledgerRecordCounts[key.FileID]++
+		}
+		t.Fatalf("debt ledger live bytes mismatch after outer-leaf delta: ledger=%+v scan=%+v before_leaf_counts=%+v after_leaf_counts=%+v ledger_record_counts=%+v", ledgerLive, scanLive, beforeLeafCounts, afterLeafCounts, ledgerRecordCounts)
+	}
+}
+
+func TestValueLogDebtLedger_TracksLeafRefRewriteCommits(t *testing.T) {
+	t.Setenv(envEnableVlogDebtLedger, "1")
+	db, sourceIDs, cleanup := setupLeafRefRewriteBench(t, 768)
+	defer cleanup()
+
+	if err := db.rebuildValueLogDebtLedger(context.Background()); err != nil {
+		t.Fatalf("rebuild debt ledger: %v", err)
+	}
+	if !db.valueLogDebtLedger.canTrack(db.currentCommitSeq()) {
+		t.Fatalf("expected debt ledger to become trackable before leafref rewrite")
+	}
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs:     sourceIDs,
+		MaxSourceSegments: len(sourceIDs),
+		BatchSize:         64,
+		SyncEachBatch:     true,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if stats.LeafRefRecordsCopied == 0 {
+		t.Fatalf("expected leafref rewrite to copy leaf pages, stats=%+v", stats)
+	}
+	if !db.valueLogDebtLedger.canTrack(db.currentCommitSeq()) {
+		t.Fatalf("expected debt ledger to stay trackable after leafref rewrite")
+	}
+	ledgerLive, ok, err := db.liveBytesBySegmentFromDebtLedger(context.Background())
+	if err != nil {
+		t.Fatalf("live bytes from debt ledger: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected live bytes from debt ledger after leafref rewrite")
+	}
+	scanLive, err := db.estimateValueLogLiveBytesBySegment(context.Background())
+	if err != nil {
+		t.Fatalf("estimate live bytes: %v", err)
+	}
+	if !sameValueLogLiveBytesBySegment(ledgerLive, scanLive) {
+		t.Fatalf("debt ledger live bytes mismatch after leafref rewrite: ledger=%+v scan=%+v", ledgerLive, scanLive)
+	}
+}
+
+func TestValueLogOuterLeafChangeCollector_CapturesLeafSplit(t *testing.T) {
+	t.Setenv(envEnableVlogDebtLedger, "1")
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                        dir,
+		Durability:                 DurabilityWALOffRelaxed,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		LeafPrefixCompression:      true,
+		IndexColumnarLeaves:        true,
+		IndexPackedValuePtr:        true,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	leafLog := &registeredLeafPageLog{db: db, dir: dir}
+	db.SetLeafPageLog(leafLog)
+	db.idx.Load().zipper.SetLeafPageReader(db.valueLogManager)
+
+	value := bytes.Repeat([]byte("outer-leaf-value-"), 4)
+	b := db.NewBatch().(*Batch)
+	for i := 0; i < 512; i++ {
+		if err := b.Set([]byte(fmt.Sprintf("k%04d", i)), value); err != nil {
+			t.Fatalf("seed set %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	idx := db.idx.Load()
+	db.mu.RLock()
+	rootID := db.meta.UserRootPageID
+	db.mu.RUnlock()
+
+	b = db.NewBatch().(*Batch)
+	for i := 0; i < 64; i++ {
+		if err := b.Set([]byte(fmt.Sprintf("k%04d", i)), append(value, byte(i))); err != nil {
+			t.Fatalf("delta set %d: %v", i, err)
+		}
+	}
+	collector := &valueLogOuterLeafChangeCollector{}
+	tracker := newAllocTracker(idx.allocator)
+	z := idx.zipper.CloneWithAllocator(tracker)
+	z.SetOuterLeafRecordObserver(collector.Observe)
+	_, _, _, err = z.Apply(rootID, b.batch)
+	if err != nil {
+		closeNoErr(t, b)
+		t.Fatalf("apply: %v", err)
+	}
+	if len(collector.oldPtrs) == 0 || len(collector.newPtrs) <= len(collector.oldPtrs) {
+		closeNoErr(t, b)
+		t.Fatalf("unexpected outer-leaf observer capture old=%d new=%d", len(collector.oldPtrs), len(collector.newPtrs))
+	}
+	if err := db.rebuildValueLogDebtLedger(context.Background()); err != nil {
+		closeNoErr(t, b)
+		t.Fatalf("rebuild debt ledger: %v", err)
+	}
+	delta, err := db.buildValueLogDebtDelta(idx.pager, rootID, db.currentCommitSeq(), b.batch.SortedEntries(), collector)
+	closeNoErr(t, b)
+	if err != nil {
+		t.Fatalf("build debt delta: %v", err)
+	}
+	if delta == nil || len(delta.changes) == 0 {
+		t.Fatalf("expected non-empty debt delta from outer-leaf split")
 	}
 }

--- a/TreeDB/db/vlog_locator_catalog_test.go
+++ b/TreeDB/db/vlog_locator_catalog_test.go
@@ -263,3 +263,32 @@ func TestValueLogLocatorCatalog_TracksRewriteSwapCommits(t *testing.T) {
 		t.Fatalf("new segment keys=%q want [k1]", newKeys)
 	}
 }
+
+func TestValueLogLocatorCatalog_TracksLeafRefRewriteCommits(t *testing.T) {
+	t.Setenv(envEnableVlogLocatorCatalog, "1")
+	db, sourceIDs, cleanup := setupLeafRefRewriteBench(t, 768)
+	defer cleanup()
+
+	if err := db.rebuildValueLogLocatorCatalog(context.Background()); err != nil {
+		t.Fatalf("rebuild locator catalog: %v", err)
+	}
+	if !db.valueLogLocatorCatalog.canTrack(db.currentCommitSeq()) {
+		t.Fatalf("expected locator catalog to become trackable before leafref rewrite")
+	}
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs:     sourceIDs,
+		MaxSourceSegments: len(sourceIDs),
+		BatchSize:         64,
+		SyncEachBatch:     true,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if stats.LeafRefRecordsCopied == 0 {
+		t.Fatalf("expected leafref rewrite to copy leaf pages, stats=%+v", stats)
+	}
+	if !db.valueLogLocatorCatalog.canTrack(db.currentCommitSeq()) {
+		t.Fatalf("expected locator catalog to stay trackable after leafref rewrite")
+	}
+}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -662,7 +662,8 @@ func (db *DB) ValueLogRewritePlan(ctx context.Context, opts ValueLogRewriteOnlin
 					}
 					if !sameValueLogLiveBytesBySegment(liveByID, scanLiveByID) {
 						liveByID = scanLiveByID
-						if err := db.storeValueLogDebtLedgerFromLiveBytes(scanLiveByID); err != nil {
+						db.valueLogDebtLedger.invalidate()
+						if err := db.rebuildValueLogDebtLedger(ctx); err != nil {
 							db.reportError(err)
 						}
 					}
@@ -2158,10 +2159,11 @@ type leafRefRewriteCtx struct {
 	internalRemapInline    [leafRefRewriteInlineRemapCap]leafRefRewriteRemap
 	internalRemapInlineLen int
 
-	retired        []uint64
-	copied         int
-	copiedBytes    int64
-	maxCopiedBytes int64
+	retired          []uint64
+	copied           int
+	copiedBytes      int64
+	maxCopiedBytes   int64
+	outerLeafChanges *valueLogOuterLeafChangeCollector
 
 	readRefreshRetried bool
 }
@@ -2347,6 +2349,9 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 			return id, false, err
 		}
 		c.storeLeafRemap(id, leafID)
+		if c.outerLeafChanges != nil {
+			c.outerLeafChanges.Observe([]page.ValuePtr{ptr}, []page.ValuePtr{newPtr})
+		}
 		c.copied++
 		c.copiedBytes += int64(len(leafPage))
 		return leafID, true, nil
@@ -2529,6 +2534,9 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		hasSingleID:      hasSingleSourceID,
 		maxCopiedBytes:   maxCopiedBytes,
 	}
+	if db.valueLogDebtLedger != nil && valueLogDebtLedgerEnabled() && db.valueLogDebtLedger.canTrack(snap.state.CommitSeq) {
+		leafCtx.outerLeafChanges = &valueLogOuterLeafChangeCollector{}
+	}
 	if toer, ok := leafCtx.leafReader.(unsafeToReader); ok {
 		leafCtx.leafToer = toer
 		leafCtx.leafScratch = make([]byte, 0, page.PageSize)
@@ -2572,8 +2580,15 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 			}
 		}
 	}
-
-	if err := db.finalizeCommit(newRoot, newSysRoot, leafCtx.retired, sync, adaptive.Metrics{}, createdIDs, false, nil, nil); err != nil {
+	vlogDebtDelta, err := db.buildValueLogDebtDelta(nil, 0, snap.state.CommitSeq, nil, leafCtx.outerLeafChanges)
+	if err != nil {
+		return 0, 0, err
+	}
+	var vlogLocatorDelta *valueLogLocatorDelta
+	if db.valueLogLocatorCatalog != nil && valueLogLocatorCatalogEnabled() && db.valueLogLocatorCatalog.canTrack(snap.state.CommitSeq) {
+		vlogLocatorDelta = newValueLogLocatorDelta()
+	}
+	if err := db.finalizeCommit(newRoot, newSysRoot, leafCtx.retired, sync, adaptive.Metrics{}, createdIDs, false, nil, vlogDebtDelta, vlogLocatorDelta); err != nil {
 		return 0, 0, err
 	}
 	tracker = nil
@@ -2805,6 +2820,11 @@ func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (b
 
 	tracker := newAllocTracker(idx.allocator)
 	z := idx.zipper.CloneWithAllocator(tracker)
+	var outerLeafChanges *valueLogOuterLeafChangeCollector
+	if db.valueLogDebtLedger != nil && valueLogDebtLedgerEnabled() && db.valueLogDebtLedger.canTrack(baseSeq) {
+		outerLeafChanges = &valueLogOuterLeafChangeCollector{}
+		z.SetOuterLeafRecordObserver(outerLeafChanges.Observe)
+	}
 	newRoot, retired, metrics, err := z.Apply(rootID, b)
 	if err != nil {
 		freeErr := tracker.FreeAll()
@@ -2816,6 +2836,14 @@ func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (b
 	var vlogRefDelta *valueLogRefDelta
 	if trackValueLogRefDelta {
 		vlogRefDelta = rewriteDelta
+	}
+	vlogDebtDelta, err := db.buildValueLogDebtDelta(idx.pager, rootID, baseSeq, entries, outerLeafChanges)
+	if err != nil {
+		freeErr := tracker.FreeAll()
+		if freeErr != nil {
+			return false, errors.Join(err, freeErr)
+		}
+		return false, err
 	}
 	defer func() {
 		if vlogRefDelta != nil {
@@ -2845,7 +2873,7 @@ func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (b
 		}
 	}
 
-	post, err := db.finalizeCommitLocked(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta, vlogLocatorDelta)
+	post, err := db.finalizeCommitLocked(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta, vlogDebtDelta, vlogLocatorDelta)
 	db.commitMu.Unlock()
 	if err != nil {
 		return false, err
@@ -2902,6 +2930,12 @@ func (db *DB) applyRewriteSwapBatchSerialized(swaps []rewriteSwap, sync bool) er
 	noteRewriteSwapTouchedSegments(b, swaps)
 	touchedValueLogSegments := b.TouchedValueLogSegments()
 
+	var outerLeafChanges *valueLogOuterLeafChangeCollector
+	if db.valueLogDebtLedger != nil && valueLogDebtLedgerEnabled() && db.valueLogDebtLedger.canTrack(baseSeq) {
+		outerLeafChanges = &valueLogOuterLeafChangeCollector{}
+		idx.zipper.SetOuterLeafRecordObserver(outerLeafChanges.Observe)
+		defer idx.zipper.SetOuterLeafRecordObserver(nil)
+	}
 	newRoot, retired, metrics, err := idx.zipper.Apply(rootID, b)
 	if err != nil {
 		return err
@@ -2909,6 +2943,10 @@ func (db *DB) applyRewriteSwapBatchSerialized(swaps []rewriteSwap, sync bool) er
 	var vlogRefDelta *valueLogRefDelta
 	if trackValueLogRefDelta {
 		vlogRefDelta = rewriteDelta
+	}
+	vlogDebtDelta, err := db.buildValueLogDebtDelta(idx.pager, rootID, baseSeq, entries, outerLeafChanges)
+	if err != nil {
+		return err
 	}
 	defer func() {
 		if vlogRefDelta != nil {
@@ -2922,7 +2960,7 @@ func (db *DB) applyRewriteSwapBatchSerialized(swaps []rewriteSwap, sync bool) er
 			return err
 		}
 	}
-	if err := db.finalizeCommit(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta, vlogLocatorDelta); err != nil {
+	if err := db.finalizeCommit(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, db.indexOuterLeavesInValueLog, vlogRefDelta, vlogDebtDelta, vlogLocatorDelta); err != nil {
 		return err
 	}
 	vlogRefDelta = nil

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -3476,8 +3476,8 @@ func TestValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first plan: %v", err)
 	}
-	if got := counter.Load(); got != 1 {
-		t.Fatalf("estimate runs after first plan=%d want 1", got)
+	if got := counter.Load(); got != 0 {
+		t.Fatalf("estimate runs after first plan=%d want 0 with commit-path debt ledger", got)
 	}
 	closeNoErr(t, db)
 
@@ -3491,8 +3491,8 @@ func TestValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen(t *testing.T) {
 		t.Fatalf("reopen plan: %v", err)
 	}
 	assertRewritePlanStableFieldsEqual(t, plan2, plan1)
-	if got := counter.Load(); got != 1 {
-		t.Fatalf("estimate runs after reopen plan=%d want 1", got)
+	if got := counter.Load(); got != 0 {
+		t.Fatalf("estimate runs after reopen plan=%d want 0 with persisted debt ledger", got)
 	}
 }
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -30,6 +30,8 @@ type LeafPageReader interface {
 	ReadUnsafe(ptr page.ValuePtr) ([]byte, error)
 }
 
+type OuterLeafRecordObserver func(oldPtrs, newPtrs []page.ValuePtr)
+
 type leafPageUnsafeToReader interface {
 	ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]byte, bool, error)
 }
@@ -90,6 +92,7 @@ type Zipper struct {
 	outerLeavesInValueLog bool
 	leafPageLog           LeafPageLog
 	leafPageReader        LeafPageReader
+	outerLeafObserver     OuterLeafRecordObserver
 	leafRefCacheMu        sync.RWMutex
 	leafRefCache          map[uint64][]byte
 
@@ -641,6 +644,7 @@ func (z *Zipper) CloneWithAllocator(a PageAllocator) *Zipper {
 		outerLeavesInValueLog:     z.outerLeavesInValueLog,
 		leafPageLog:               z.leafPageLog,
 		leafPageReader:            z.leafPageReader,
+		outerLeafObserver:         z.outerLeafObserver,
 		leafReserveBytes:          z.leafReserveBytes,
 		internalReserveBytes:      z.internalReserveBytes,
 		piggybackCompaction:       z.piggybackCompaction,
@@ -696,6 +700,10 @@ func (z *Zipper) SetLeafPageLog(log LeafPageLog) {
 
 func (z *Zipper) SetLeafPageReader(reader LeafPageReader) {
 	z.leafPageReader = reader
+}
+
+func (z *Zipper) SetOuterLeafRecordObserver(observer OuterLeafRecordObserver) {
+	z.outerLeafObserver = observer
 }
 
 func (z *Zipper) SetAdaptiveLeafEncoding(enabled bool) {
@@ -1121,30 +1129,30 @@ func (z *Zipper) loadNode(id uint64, scratchCtx *mergeScratch) (node.Node, bool,
 	return node.NewNodeView(data), true, nil, false, nil
 }
 
-func (z *Zipper) persistLeafPage(b *node.Builder) (uint64, error) {
+func (z *Zipper) persistLeafPage(b *node.Builder) (uint64, page.ValuePtr, error) {
 	if b == nil {
-		return 0, errors.New("zipper: nil leaf builder")
+		return 0, page.ValuePtr{}, errors.New("zipper: nil leaf builder")
 	}
 	if !z.outerLeavesInValueLog {
-		return b.PageID(), nil
+		return b.PageID(), page.ValuePtr{}, nil
 	}
 	if z.leafPageLog == nil {
-		return 0, errors.New("zipper: missing leaf page log")
+		return 0, page.ValuePtr{}, errors.New("zipper: missing leaf page log")
 	}
 	ptr, err := z.leafPageLog.AppendLeafPage(b.Data())
 	if err != nil {
-		return 0, err
+		return 0, page.ValuePtr{}, err
 	}
 	leafID, err := page.EncodeLeafRef(ptr)
 	if err != nil {
-		return 0, err
+		return 0, page.ValuePtr{}, err
 	}
 	z.leafRefCacheMu.Lock()
 	if z.leafRefCache != nil {
 		z.leafRefCache[leafID] = b.Data()
 	}
 	z.leafRefCacheMu.Unlock()
-	return leafID, nil
+	return leafID, ptr, nil
 }
 
 // writeRecursive handles the COW merge.
@@ -1186,7 +1194,7 @@ func (z *Zipper) writeRecursive(pageID uint64, ops []batch.Entry, maintenance bo
 				}
 			}()
 			builder.SetPageID(0)
-			return z.mergeLeaf(&oldNode, builder, ops, metrics, scratch, reuseOuterLeafPages)
+			return z.mergeLeaf(pageID, &oldNode, builder, ops, metrics, scratch, reuseOuterLeafPages)
 		}
 
 		// Pager-backed leaf.
@@ -1201,7 +1209,7 @@ func (z *Zipper) writeRecursive(pageID uint64, ops []batch.Entry, maintenance bo
 		builder := z.newPooledLeafBuilder(newData, ops)
 		defer releasePooledBuilder(builder)
 		builder.SetPageID(newPageID)
-		return z.mergeLeaf(&oldNode, builder, ops, metrics, scratch, false)
+		return z.mergeLeaf(pageID, &oldNode, builder, ops, metrics, scratch, false)
 
 	case page.PageTypeInternal:
 		// Internal merge is always pager-backed.
@@ -1243,7 +1251,7 @@ func (z *Zipper) writeRecursive(pageID uint64, ops []batch.Entry, maintenance bo
 	return 0, nil, page.ErrInvalidPageType
 }
 
-func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batch.Entry, metrics *adaptive.Metrics, scratch *mergeScratch, reuseOuterLeafPages bool) (uint64, []Split, error) {
+func (z *Zipper) mergeLeaf(oldPageID uint64, oldNode *node.Node, builder *node.Builder, ops []batch.Entry, metrics *adaptive.Metrics, scratch *mergeScratch, reuseOuterLeafPages bool) (uint64, []Split, error) {
 	oldIdx := uint16(0)
 	oldCount := oldNode.Count()
 	opIdx := 0
@@ -1253,6 +1261,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 		rootNodeID      uint64
 		rootPersisted   bool
 		pendingSplitIdx int
+		newLeafPtrs     []page.ValuePtr
 	)
 	pendingSplitIdx = -1
 
@@ -1287,9 +1296,12 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			metrics.Splits++
 		}
 
-		nodeID, err := z.persistLeafPage(target)
+		nodeID, newPtr, err := z.persistLeafPage(target)
 		if err != nil {
 			return 0, err
+		}
+		if z.outerLeavesInValueLog {
+			newLeafPtrs = append(newLeafPtrs, newPtr)
 		}
 
 		if target == builder {
@@ -1501,6 +1513,13 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 		if _, err := persistTarget(); err != nil {
 			return 0, nil, err
 		}
+	}
+	if z.outerLeavesInValueLog && z.outerLeafObserver != nil && len(newLeafPtrs) > 0 {
+		var oldPtrs []page.ValuePtr
+		if ptr, ok := page.DecodeLeafRef(oldPageID); ok {
+			oldPtrs = append(oldPtrs, ptr)
+		}
+		z.outerLeafObserver(oldPtrs, newLeafPtrs)
 	}
 
 	return rootNodeID, splits, nil
@@ -2003,7 +2022,7 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 		return uint32((used * 1_000_000) / page.PageSize)
 	}
 
-	buildMergedLeaf := func(left, right *node.Node) (uint64, bool, error) {
+	buildMergedLeaf := func(left *node.Node, leftOldID uint64, right *node.Node, rightOldID uint64) (uint64, bool, error) {
 		var (
 			pid  uint64
 			data []byte
@@ -2062,12 +2081,22 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 		b.FinishNoNode()
 		metrics.IndexWriteBytes += page.PageSize
 		metrics.LeafFill += float64(page.PageSize-b.FreeSpace()) / float64(page.PageSize)
-		leafID, err := z.persistLeafPage(b)
+		leafID, leafPtr, err := z.persistLeafPage(b)
 		if err != nil {
 			if !z.outerLeavesInValueLog {
 				retired = append(retired, pid)
 			}
 			return 0, false, err
+		}
+		if z.outerLeavesInValueLog && z.outerLeafObserver != nil {
+			var oldPtrs []page.ValuePtr
+			if ptr, ok := page.DecodeLeafRef(leftOldID); ok {
+				oldPtrs = append(oldPtrs, ptr)
+			}
+			if ptr, ok := page.DecodeLeafRef(rightOldID); ok {
+				oldPtrs = append(oldPtrs, ptr)
+			}
+			z.outerLeafObserver(oldPtrs, []page.ValuePtr{leafPtr})
 		}
 		return leafID, true, nil
 	}
@@ -2120,17 +2149,22 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 		}
 		b.FinishNoNode()
 		metrics.IndexWriteBytes += page.PageSize
-		leafID, err := z.persistLeafPage(b)
+		leafID, leafPtr, err := z.persistLeafPage(b)
 		if err != nil {
 			if !z.outerLeavesInValueLog {
 				retired = append(retired, pid)
 			}
 			return 0, err
 		}
+		if z.outerLeavesInValueLog && z.outerLeafObserver != nil {
+			if ptr, ok := page.DecodeLeafRef(id); ok {
+				z.outerLeafObserver([]page.ValuePtr{ptr}, []page.ValuePtr{leafPtr})
+			}
+		}
 		return leafID, nil
 	}
 
-	rebalanceLeaves := func(left, right *node.Node) (leftID uint64, rightID uint64, rightStart []byte, ok bool, err error) {
+	rebalanceLeaves := func(left *node.Node, leftOldID uint64, right *node.Node, rightOldID uint64) (leftID uint64, rightID uint64, rightStart []byte, ok bool, err error) {
 		var (
 			lid uint64
 			rid uint64
@@ -2280,19 +2314,29 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 		metrics.IndexWriteBytes += 2 * page.PageSize
 		metrics.LeafFill += float64(page.PageSize-lb.FreeSpace()) / float64(page.PageSize)
 		metrics.LeafFill += float64(page.PageSize-rb.FreeSpace()) / float64(page.PageSize)
-		leftID, err = z.persistLeafPage(lb)
+		leftID, leftPtr, err := z.persistLeafPage(lb)
 		if err != nil {
 			if !z.outerLeavesInValueLog {
 				retired = append(retired, lid, rid)
 			}
 			return 0, 0, nil, false, err
 		}
-		rightID, err = z.persistLeafPage(rb)
+		rightID, rightPtr, err := z.persistLeafPage(rb)
 		if err != nil {
 			if !z.outerLeavesInValueLog {
 				retired = append(retired, lid, rid)
 			}
 			return 0, 0, nil, false, err
+		}
+		if z.outerLeavesInValueLog && z.outerLeafObserver != nil {
+			var oldPtrs []page.ValuePtr
+			if ptr, ok := page.DecodeLeafRef(leftOldID); ok {
+				oldPtrs = append(oldPtrs, ptr)
+			}
+			if ptr, ok := page.DecodeLeafRef(rightOldID); ok {
+				oldPtrs = append(oldPtrs, ptr)
+			}
+			z.outerLeafObserver(oldPtrs, []page.ValuePtr{leftPtr, rightPtr})
 		}
 		return leftID, rightID, rightStart, true, nil
 	}
@@ -2391,7 +2435,7 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 			mergeCap = pageCap - z.leafReserveBytes
 		}
 		if leftBytes+rightBytes <= mergeCap {
-			mergedID, ok, err := buildMergedLeaf(&left, &right)
+			mergedID, ok, err := buildMergedLeaf(&left, leftID, &right, rightID)
 			if err != nil {
 				releaseLeafScratch()
 				return nil, nil, err
@@ -2415,7 +2459,7 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 		}
 
 		// If merge isn't possible, attempt a bounded rebalance.
-		leftNewID, rightNewID, rightStart, ok, err := rebalanceLeaves(&left, &right)
+		leftNewID, rightNewID, rightStart, ok, err := rebalanceLeaves(&left, leftID, &right, rightID)
 		if err != nil {
 			releaseLeafScratch()
 			return nil, nil, err

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -192,7 +192,7 @@ func TestZipperLeafRefCacheAvoidsUnflushedReads(t *testing.T) {
 	}
 	b.FinishNoNode()
 
-	leafID, err := z.persistLeafPage(b)
+	leafID, _, err := z.persistLeafPage(b)
 	if err != nil {
 		t.Fatalf("persistLeafPage: %v", err)
 	}
@@ -586,7 +586,7 @@ func TestMergeLeaf_SplitKeysDoNotAliasBatchKeys(t *testing.T) {
 	scratch := newMergeScratch()
 
 	var metrics adaptive.Metrics
-	_, splits, err := z.mergeLeaf(oldNode, builder, ops, &metrics, scratch, false)
+	_, splits, err := z.mergeLeaf(0, oldNode, builder, ops, &metrics, scratch, false)
 	if err != nil {
 		t.Fatalf("mergeLeaf failed: %v", err)
 	}

--- a/worklog/2026-04-10-authoritative-catalogs.md
+++ b/worklog/2026-04-10-authoritative-catalogs.md
@@ -84,3 +84,41 @@
   - make the locator catalog commit-path maintained for normal writes and rewrite swap commits
 - follow-on required for true end state:
   - replace count-only ref deltas with physical-record debt deltas that cover grouped values and outer-leaf value-log records
+
+### Second-Sprint Slice 2
+
+- status:
+  - complete locally on top of `8b6972ae`
+- goal:
+  - make the debt ledger commit-path authoritative for the same write shapes that still left live minute-15 size above the offline rewrite floor
+
+#### Landed locally
+
+- added a physical-record debt delta path in `TreeDB/db/vlog_debt_ledger.go`
+  - tracks `(file_id, record_start)` refcounts with exact record lengths
+  - rebuilds the transient record catalog from the live tree and leafref-backed outer leaves
+  - updates segment live/stale bytes from commit deltas instead of forcing planner-time rediscovery
+- wired commit publication to apply debt deltas in `TreeDB/db/db.go`
+  - normal batch commits now build and publish `vlogDebtDelta`
+  - rewrite swap commits now build and publish `vlogDebtDelta`
+  - leafref rewrite commits now publish debt deltas instead of invalidating the ledger
+- added outer-leaf observation support in `TreeDB/zipper/zipper.go`
+  - leaf page persistence now exposes the new value-log pointer
+  - merge/copy/rebalance paths report old/new outer-leaf record pointers so commit deltas can stay exact
+- kept locator-catalog authority intact for the same leafref rewrite path
+  - leafref rewrite commits now send an explicit empty locator delta instead of forcing invalidation
+- adjusted planner expectation tests
+  - with commit-path-authoritative debt tracking, `ValueLogRewritePlan` no longer needs a fallback live-byte estimate on first plan after reopen
+
+#### Validation
+
+- `GOWORK=off go test ./TreeDB/zipper ./TreeDB/db -run 'Test(ValueLogDebtLedger_(RebuildAndLoad|TracksCommitDeltaAcrossPointerWrites|TracksOuterLeafCommitDeltaAcrossWrites|TracksLeafRefRewriteCommits)|ValueLogOuterLeafChangeCollector_CapturesLeafSplit|ValueLogLocatorCatalog_TracksLeafRefRewriteCommits|ZipperLeafRefCacheAvoidsUnflushedReads|MergeLeaf_SplitKeysDoNotAliasBatchKeys)$' -count=1`
+- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogLocatorCatalog_RebuildAndLoad|ValueLogRewriteOnline_SourceFileIDs_UsesLocatorCatalogWhenEnabled|ValueLogLocatorCatalog_AppliesCommitDeltaAcrossWrites|ValueLogLocatorCatalog_TracksRewriteSwapCommits|ValueLogRewriteOnline_SourceFileIDs_RestrictsRewriteSet|ValueLogDebtLedger_RebuildAndLoad|ReferencedValueLogSegments_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_ShadowCompareRepairsDebtLedgerMismatch|ValueLogDebtLedger_TracksCommitDeltaAcrossPointerWrites|ValueLogDebtLedger_TracksOuterLeafCommitDeltaAcrossWrites|ValueLogDebtLedger_TracksLeafRefRewriteCommits|ValueLogOuterLeafChangeCollector_CapturesLeafSplit|ValueLogLocatorCatalog_TracksLeafRefRewriteCommits)' -count=1`
+- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewrite_|Checkpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity)' -count=1`
+
+#### Remaining gap after this slice
+
+- the debt ledger is now authoritative in-memory once rebuilt and then maintained on the commit path for the covered shapes
+- the remaining world-class gap is durability of the richer catalogs themselves:
+  - persist enough authoritative record/locator state to avoid rebuild hydration on reopen
+  - converge cleanup and GC fully onto the same catalog truth


### PR DESCRIPTION
## What changed
- added physical-record debt deltas so the debt ledger can track exact value-log record liveness by `(file_id, record_start)` with record lengths
- applied debt-ledger deltas on normal batch commits, rewrite swap commits, and leafref rewrite commits
- added outer-leaf pointer observation in the zipper so commit publication can account for leaf-page value-log records exactly
- kept locator-catalog authority intact during leafref rewrite publication instead of invalidating it
- updated planner expectations so a reopen with an authoritative debt ledger no longer requires a fallback live-byte estimate scan
- recorded the slice in `worklog/2026-04-10-authoritative-catalogs.md`

## Why
The first authoritative-catalog stack still depended on rebuild/scan truth for the exact `fast` / `wal_on_fast` shapes we care about. In particular, outer-leaf-in-vlog writes and leafref rewrite publication could leave the debt ledger non-authoritative, which meant planner/runtime reclaim behavior still fell back toward rediscovery. This slice moves debt truth onto commit publication for those paths.

## Impact
- the debt ledger becomes commit-path maintained for pointer writes, outer-leaf writes, rewrite swap commits, and leafref rewrite commits
- planner state after reopen can stay on the debt-ledger path instead of forcing a first-plan estimate scan
- this narrows the remaining second-sprint gap to durable persistence of the richer catalog state itself, plus full cleanup/GC convergence on the same catalog truth

## Validation
- `GOWORK=off go test ./TreeDB/zipper ./TreeDB/db -run 'Test(ValueLogDebtLedger_(RebuildAndLoad|TracksCommitDeltaAcrossPointerWrites|TracksOuterLeafCommitDeltaAcrossWrites|TracksLeafRefRewriteCommits)|ValueLogOuterLeafChangeCollector_CapturesLeafSplit|ValueLogLocatorCatalog_TracksLeafRefRewriteCommits|ZipperLeafRefCacheAvoidsUnflushedReads|MergeLeaf_SplitKeysDoNotAliasBatchKeys)$' -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogLocatorCatalog_RebuildAndLoad|ValueLogRewriteOnline_SourceFileIDs_UsesLocatorCatalogWhenEnabled|ValueLogLocatorCatalog_AppliesCommitDeltaAcrossWrites|ValueLogLocatorCatalog_TracksRewriteSwapCommits|ValueLogRewriteOnline_SourceFileIDs_RestrictsRewriteSet|ValueLogDebtLedger_RebuildAndLoad|ReferencedValueLogSegments_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_ShadowCompareRepairsDebtLedgerMismatch|ValueLogDebtLedger_TracksCommitDeltaAcrossPointerWrites|ValueLogDebtLedger_TracksOuterLeafCommitDeltaAcrossWrites|ValueLogDebtLedger_TracksLeafRefRewriteCommits|ValueLogOuterLeafChangeCollector_CapturesLeafSplit|ValueLogLocatorCatalog_TracksLeafRefRewriteCommits)' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewrite_|Checkpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity)' -count=1`

## Notes
- a broad `go test ./TreeDB/zipper ./TreeDB/db ./TreeDB/caching -count=1` sweep did not finish quickly enough to use as a publish gate here, so this PR is gated on the targeted coverage above rather than a full package sweep
