### PR TITLE
[codex] treedb: persist debt ledger record refs

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1709,6 +1709,8 @@ func (db *DB) finalizeCommitPostWork(post finalizeCommitPost) {
 			} else if err := db.valueLogDebtLedger.applyDelta(post.commitSeq, post.vlogDebtDelta, totals); err != nil {
 				db.valueLogDebtLedger.invalidate()
 				db.reportError(err)
+			} else {
+				db.persistValueLogDebtLedgerBestEffort()
 			}
 		} else {
 			db.valueLogDebtLedger.invalidate()

--- a/TreeDB/db/vlog_debt_ledger.go
+++ b/TreeDB/db/vlog_debt_ledger.go
@@ -41,6 +41,14 @@ type valueLogDebtLedgerDisk struct {
 	Version   uint32                       `json:"version"`
 	CommitSeq uint64                       `json:"commit_seq"`
 	Segments  []valueLogDebtSegmentSummary `json:"segments,omitempty"`
+	Records   []valueLogDebtRecordDisk     `json:"records,omitempty"`
+}
+
+type valueLogDebtRecordDisk struct {
+	FileID    uint32 `json:"file_id"`
+	Start     uint64 `json:"start"`
+	RecordLen uint32 `json:"record_len"`
+	RefCount  uint32 `json:"ref_count"`
 }
 
 type valueLogDebtRecordKey struct {
@@ -285,21 +293,39 @@ func (l *valueLogDebtLedger) liveBytesBySegment(commitSeq uint64) (map[uint32]in
 	return out, true
 }
 
-func (l *valueLogDebtLedger) dirtySnapshot() (uint64, []valueLogDebtSegmentSummary, bool) {
+func (l *valueLogDebtLedger) dirtySnapshot() (uint64, []valueLogDebtSegmentSummary, []valueLogDebtRecordDisk, bool) {
 	if l == nil {
-		return 0, nil, false
+		return 0, nil, nil, false
 	}
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	if !l.valid || !l.dirty {
-		return 0, nil, false
+		return 0, nil, nil, false
 	}
 	segments := make([]valueLogDebtSegmentSummary, 0, len(l.segments))
 	for _, seg := range l.segments {
 		segments = append(segments, seg)
 	}
 	sort.Slice(segments, func(i, j int) bool { return segments[i].FileID < segments[j].FileID })
-	return l.commitSeq, segments, true
+	records := make([]valueLogDebtRecordDisk, 0, len(l.records))
+	for _, rec := range l.records {
+		if rec.Key.FileID == 0 || rec.RecordLen == 0 || rec.RefCount == 0 {
+			continue
+		}
+		records = append(records, valueLogDebtRecordDisk{
+			FileID:    rec.Key.FileID,
+			Start:     rec.Key.Start,
+			RecordLen: rec.RecordLen,
+			RefCount:  rec.RefCount,
+		})
+	}
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].FileID != records[j].FileID {
+			return records[i].FileID < records[j].FileID
+		}
+		return records[i].Start < records[j].Start
+	})
+	return l.commitSeq, segments, records, true
 }
 
 func (l *valueLogDebtLedger) markClean(commitSeq uint64) {
@@ -462,7 +488,19 @@ func (db *DB) loadValueLogDebtLedger(commitSeq uint64) (bool, error) {
 	for _, seg := range disk.Segments {
 		segments[seg.FileID] = seg
 	}
-	db.valueLogDebtLedger.replace(disk.CommitSeq, segments, nil, false)
+	records := make(map[valueLogDebtRecordKey]valueLogDebtRecordRef, len(disk.Records))
+	for _, rec := range disk.Records {
+		if rec.FileID == 0 || rec.RecordLen == 0 || rec.RefCount == 0 {
+			continue
+		}
+		key := valueLogDebtRecordKey{FileID: rec.FileID, Start: rec.Start}
+		records[key] = valueLogDebtRecordRef{
+			Key:       key,
+			RecordLen: rec.RecordLen,
+			RefCount:  rec.RefCount,
+		}
+	}
+	db.valueLogDebtLedger.replace(disk.CommitSeq, segments, records, false)
 	return true, nil
 }
 
@@ -474,7 +512,7 @@ func (db *DB) persistValueLogDebtLedger() error {
 	if path == "" {
 		return nil
 	}
-	commitSeq, segments, ok := db.valueLogDebtLedger.dirtySnapshot()
+	commitSeq, segments, records, ok := db.valueLogDebtLedger.dirtySnapshot()
 	if !ok {
 		return nil
 	}
@@ -482,6 +520,7 @@ func (db *DB) persistValueLogDebtLedger() error {
 		Version:   valueLogDebtLedgerVersion,
 		CommitSeq: commitSeq,
 		Segments:  segments,
+		Records:   records,
 	})
 	if err != nil {
 		return err

--- a/TreeDB/db/vlog_debt_ledger_test.go
+++ b/TreeDB/db/vlog_debt_ledger_test.go
@@ -52,10 +52,12 @@ func TestValueLogDebtLedger_RebuildAndLoad(t *testing.T) {
 	}
 
 	path := filepath.Join(dir, valueLogDebtLedgerFileName)
-	if _, ok, err := loadValueLogDebtLedgerFromPath(path, db.currentCommitSeq()); err != nil {
+	if disk, ok, err := loadValueLogDebtLedgerFromPath(path, db.currentCommitSeq()); err != nil {
 		t.Fatalf("load persisted debt ledger: %v", err)
 	} else if !ok {
 		t.Fatalf("expected persisted debt ledger to load")
+	} else if len(disk.Records) == 0 {
+		t.Fatalf("expected persisted debt ledger to include record refs")
 	}
 }
 
@@ -181,6 +183,107 @@ func TestValueLogDebtLedger_TracksCommitDeltaAcrossPointerWrites(t *testing.T) {
 	}
 	if !sameValueLogLiveBytesBySegment(ledgerLive, scanLive) {
 		t.Fatalf("debt ledger live bytes mismatch after pointer delta: ledger=%+v scan=%+v", ledgerLive, scanLive)
+	}
+}
+
+func TestValueLogDebtLedger_PersistsTrackableStateAcrossReopen(t *testing.T) {
+	t.Setenv(envEnableVlogDebtLedger, "1")
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	ptrs1 := appendPointersInNewSegment(t, dir, 0, 20, 363_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("a"), 256)
+	})
+	ptrs2 := appendPointersInNewSegment(t, dir, 0, 21, 364_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("b"), 256)
+	})
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs1[0]); err != nil {
+		t.Fatalf("set k1: %v", err)
+	}
+	if err := b.SetPointer([]byte("k2"), ptrs2[0]); err != nil {
+		t.Fatalf("set k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	if err := db.rebuildValueLogDebtLedger(context.Background()); err != nil {
+		t.Fatalf("rebuild debt ledger: %v", err)
+	}
+	ptrs3 := appendPointersInNewSegment(t, dir, 0, 22, 365_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("c"), 256)
+	})
+	b = db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs3[0]); err != nil {
+		t.Fatalf("update k1: %v", err)
+	}
+	if err := b.Delete([]byte("k2")); err != nil {
+		t.Fatalf("delete k2: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("delta write: %v", err)
+	}
+	closeNoErr(t, b)
+	closeNoErr(t, db)
+
+	db2, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer closeNoErr(t, db2)
+
+	if !db2.valueLogDebtLedger.canTrack(db2.currentCommitSeq()) {
+		t.Fatalf("expected reopened debt ledger to stay trackable without rebuild")
+	}
+	ledgerLive, ok, err := db2.liveBytesBySegmentFromDebtLedger(context.Background())
+	if err != nil {
+		t.Fatalf("live bytes from debt ledger: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected reopened debt ledger live bytes")
+	}
+	scanLive, err := db2.estimateValueLogLiveBytesBySegment(context.Background())
+	if err != nil {
+		t.Fatalf("estimate live bytes: %v", err)
+	}
+	if !sameValueLogLiveBytesBySegment(ledgerLive, scanLive) {
+		t.Fatalf("reopened debt ledger live bytes mismatch: ledger=%+v scan=%+v", ledgerLive, scanLive)
+	}
+
+	ptrs4 := appendPointersInNewSegment(t, dir, 0, 23, 366_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("d"), 256)
+	})
+	b = db2.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k1"), ptrs4[0]); err != nil {
+		t.Fatalf("second update k1: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("second delta write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	if !db2.valueLogDebtLedger.canTrack(db2.currentCommitSeq()) {
+		t.Fatalf("expected reopened debt ledger to remain trackable after new commit")
+	}
+	ledgerLive, ok, err = db2.liveBytesBySegmentFromDebtLedger(context.Background())
+	if err != nil {
+		t.Fatalf("post-reopen live bytes from debt ledger: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected post-reopen debt ledger live bytes")
+	}
+	scanLive, err = db2.estimateValueLogLiveBytesBySegment(context.Background())
+	if err != nil {
+		t.Fatalf("post-reopen estimate live bytes: %v", err)
+	}
+	if !sameValueLogLiveBytesBySegment(ledgerLive, scanLive) {
+		t.Fatalf("post-reopen debt ledger live bytes mismatch: ledger=%+v scan=%+v", ledgerLive, scanLive)
 	}
 }
 

--- a/worklog/2026-04-10-authoritative-catalogs.md
+++ b/worklog/2026-04-10-authoritative-catalogs.md
@@ -122,3 +122,28 @@
 - the remaining world-class gap is durability of the richer catalogs themselves:
   - persist enough authoritative record/locator state to avoid rebuild hydration on reopen
   - converge cleanup and GC fully onto the same catalog truth
+
+### Second-Sprint Slice 3
+
+- status:
+  - complete locally on top of `ac41fed8`
+- goal:
+  - keep the debt ledger trackable across close/reopen after commit-path deltas, instead of dropping back to a segment-only sidecar that forces rebuild hydration
+
+#### Landed locally
+
+- extended `vlog_debt_ledger.meta` to persist physical record refs alongside segment summaries
+- persisted debt-ledger state after successful commit-path delta application in `finalizeCommitPostWork`
+- kept segment-only debt snapshots valid as a compatibility fallback when records are absent, but made the normal rebuild-and-delta path durable
+
+#### Validation
+
+- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogDebtLedger_(RebuildAndLoad|TracksCommitDeltaAcrossPointerWrites|PersistsTrackableStateAcrossReopen|TracksOuterLeafCommitDeltaAcrossWrites|TracksLeafRefRewriteCommits)|ReferencedValueLogSegments_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen)$' -count=1`
+- `GOWORK=off go test ./TreeDB/zipper ./TreeDB/db ./TreeDB/caching -run 'Test(ValueLogDebtLedger_(RebuildAndLoad|TracksCommitDeltaAcrossPointerWrites|PersistsTrackableStateAcrossReopen|TracksOuterLeafCommitDeltaAcrossWrites|TracksLeafRefRewriteCommits)|ReferencedValueLogSegments_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen|ValueLogLocatorCatalog_TracksLeafRefRewriteCommits|VlogGenerationRewrite_|Checkpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity)' -count=1`
+
+#### Remaining gap after this slice
+
+- commit-path authority now survives reopen for the debt ledger
+- the next structural gap is executor/cleanup quality, not ledger survival:
+  - reduce remaining rediscovery around locators and cleanup/GC eligibility
+  - move more of the common reclaim lifecycle onto the same maintained catalog truth


### PR DESCRIPTION
## What changed
- extended `vlog_debt_ledger.meta` to persist physical record refs alongside segment summaries
- loaded persisted record refs on open so the debt ledger can remain trackable after reopen
- persisted debt-ledger state after successful commit-path delta application in `finalizeCommitPostWork`
- added reopen-focused coverage proving the ledger stays trackable and continues to absorb new commit deltas without a rebuild
- updated the authoritative-catalog worklog with the new durability slice

## Why
`#958` made the debt ledger commit-path authoritative in memory, but the sidecar still only stored segment summaries and commit-path deltas were not persisted after apply. That meant reopen dropped the ledger back to a non-trackable state and forced hydration/rebuild before subsequent commits could stay authoritative. This slice closes that gap.

## Impact
- debt-ledger authority now survives close/reopen for the normal rebuild-and-delta path
- planner and subsequent foreground commits can stay on the debt-ledger path after reopen instead of degrading back toward rebuild hydration
- segment-only ledger snapshots still load as a compatibility fallback, but full authoritative state is now durable when available

## Validation
- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogDebtLedger_(RebuildAndLoad|TracksCommitDeltaAcrossPointerWrites|PersistsTrackableStateAcrossReopen|TracksOuterLeafCommitDeltaAcrossWrites|TracksLeafRefRewriteCommits)|ReferencedValueLogSegments_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen)$' -count=1`
- `GOWORK=off go test ./TreeDB/zipper ./TreeDB/db ./TreeDB/caching -run 'Test(ValueLogDebtLedger_(RebuildAndLoad|TracksCommitDeltaAcrossPointerWrites|PersistsTrackableStateAcrossReopen|TracksOuterLeafCommitDeltaAcrossWrites|TracksLeafRefRewriteCommits)|ReferencedValueLogSegments_UsesPersistedDebtLedgerAcrossReopen|ValueLogRewritePlan_UsesPersistedDebtLedgerAcrossReopen|ValueLogLocatorCatalog_TracksLeafRefRewriteCommits|VlogGenerationRewrite_|Checkpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity)' -count=1`
