### PR TITLE
[codex] treedb: align rewrite penalty handling

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -15236,23 +15236,51 @@ func (db *DB) vlogGenerationRewriteIneffectiveBackoffActive(now time.Time) bool 
 	return now.Sub(time.Unix(0, lastIneffective)) < vlogGenerationRewriteIneffectiveBackoff
 }
 
-func filterVlogGenerationRewriteChunkPlanByPenalty(plan backenddb.ValueLogRewriteChunkPlan, penalties map[uint32]valueLogGenerationRewritePenalty, now time.Time) backenddb.ValueLogRewriteChunkPlan {
+func filterVlogGenerationRewriteChunkPlanByPenalty(plan backenddb.ValueLogRewriteChunkPlan, penalties map[uint32]valueLogGenerationRewritePenalty, now time.Time) (backenddb.ValueLogRewriteChunkPlan, []uint32) {
 	if len(plan.SourceChunks) == 0 || len(penalties) == 0 {
-		return plan
+		return plan, nil
+	}
+	selectedStaleByID := make(map[uint32]int64, len(plan.SourceChunks))
+	for _, chunk := range plan.SourceChunks {
+		if chunk.FileID == 0 {
+			continue
+		}
+		selectedStaleByID[chunk.FileID] += chunk.BytesStale
+	}
+	allowed := make(map[uint32]struct{}, len(selectedStaleByID))
+	readmitted := make([]uint32, 0, len(selectedStaleByID))
+	for _, chunk := range plan.SourceChunks {
+		if chunk.FileID == 0 {
+			continue
+		}
+		if _, ok := allowed[chunk.FileID]; ok {
+			continue
+		}
+		penalty, ok := penalties[chunk.FileID]
+		if ok && penalty.CooldownUntilUnixNano > now.UnixNano() {
+			seg := backenddb.ValueLogRewritePlanSegment{FileID: chunk.FileID, BytesStale: selectedStaleByID[chunk.FileID]}
+			if !shouldReadmitPenalizedRewriteSegment(seg, penalty, now) {
+				continue
+			}
+			readmitted = append(readmitted, chunk.FileID)
+		}
+		allowed[chunk.FileID] = struct{}{}
+	}
+	if len(allowed) == len(selectedStaleByID) {
+		return plan, readmitted
 	}
 	filteredChunks := make([]backenddb.ValueLogRewritePlanChunk, 0, len(plan.SourceChunks))
 	for _, chunk := range plan.SourceChunks {
 		if chunk.FileID == 0 {
 			continue
 		}
-		penalty, ok := penalties[chunk.FileID]
-		if ok && penalty.CooldownUntilUnixNano > now.UnixNano() {
+		if _, ok := allowed[chunk.FileID]; !ok {
 			continue
 		}
 		filteredChunks = append(filteredChunks, chunk)
 	}
 	if len(filteredChunks) == len(plan.SourceChunks) {
-		return plan
+		return plan, readmitted
 	}
 	plan.SourceChunks = filteredChunks
 	plan.ChunksSelected = len(filteredChunks)
@@ -15264,7 +15292,7 @@ func filterVlogGenerationRewriteChunkPlanByPenalty(plan backenddb.ValueLogRewrit
 		plan.SelectedBytesLive += chunk.BytesLive
 		plan.SelectedBytesStale += chunk.BytesStale
 	}
-	return plan
+	return plan, readmitted
 }
 
 func (db *DB) vlogGenerationRewriteQueueFollowupBlockedActive(now time.Time) bool {
@@ -15480,11 +15508,29 @@ func (db *DB) filterVlogGenerationRewriteChunkPlanPenalties(plan backenddb.Value
 	if db == nil || len(plan.SourceChunks) == 0 {
 		return plan, nil
 	}
-	penalties, err := db.currentVlogGenerationRewritePenalties()
-	if err != nil {
+	db.vlogGenerationRewriteQueueMu.Lock()
+	defer db.vlogGenerationRewriteQueueMu.Unlock()
+	if err := db.loadVlogGenerationRewriteQueueLocked(); err != nil {
 		return backenddb.ValueLogRewriteChunkPlan{}, err
 	}
-	return filterVlogGenerationRewriteChunkPlanByPenalty(plan, penalties, now), nil
+	filtered, readmitted := filterVlogGenerationRewriteChunkPlanByPenalty(plan, db.vlogGenerationRewritePenalties, now)
+	if len(readmitted) == 0 {
+		return filtered, nil
+	}
+	changed := false
+	for _, id := range readmitted {
+		if _, ok := db.vlogGenerationRewritePenalties[id]; ok {
+			delete(db.vlogGenerationRewritePenalties, id)
+			changed = true
+		}
+	}
+	if !changed {
+		return filtered, nil
+	}
+	if err := saveValueLogGenerationRewriteState(db.valueLogGenerationStatePath(), db.vlogGenerationRewriteQueue, db.vlogGenerationRewriteLedger, db.vlogGenerationRewriteChunkLedger, db.vlogGenerationRewriteChunkBytes, db.vlogGenerationRewriteHistory, db.vlogGenerationRewritePenalties, db.vlogGenerationRewriteStagePending, db.vlogGenerationRewriteStageObservedUnixNano); err != nil {
+		return backenddb.ValueLogRewriteChunkPlan{}, err
+	}
+	return filtered, nil
 }
 
 func filterVlogGenerationRewritePlanToSegments(plan backenddb.ValueLogRewritePlan, segments []backenddb.ValueLogRewritePlanSegment) backenddb.ValueLogRewritePlan {
@@ -17481,6 +17527,10 @@ planned:
 				}
 				if len(rewriteChunkPlan.SourceChunks) > 0 {
 					stageLedger := reason == vlogGenerationReasonStaleRatio && len(plannedChunksForExec) == 0
+					if stageLedger && hadAnyRewriteQueue {
+						plannedChunksForExec = append([]backenddb.ValueLogRewritePlanChunk(nil), rewriteChunkPlan.SourceChunks...)
+						stageLedger = false
+					}
 					stageObservedAt := int64(0)
 					if stageLedger {
 						stageObservedAt = now.UnixNano()
@@ -17580,6 +17630,10 @@ planned:
 				}
 				if len(rewritePlan.SelectedSegments) > 0 {
 					stageLedger := reason == vlogGenerationReasonStaleRatio && len(plannedLedgerForExec) == 0
+					if stageLedger && hadAnyRewriteQueue {
+						plannedLedgerForExec = append([]backenddb.ValueLogRewritePlanSegment(nil), rewritePlan.SelectedSegments...)
+						stageLedger = false
+					}
 					stageObservedAt := int64(0)
 					if stageLedger {
 						stageObservedAt = now.UnixNano()
@@ -17704,7 +17758,7 @@ planned:
 					}
 					chunkLedgerEligible := append([]backenddb.ValueLogRewritePlanChunk(nil), chunkLedger...)
 					if len(rewritePenalties) > 0 {
-						chunkPlanEligible := filterVlogGenerationRewriteChunkPlanByPenalty(backenddb.ValueLogRewriteChunkPlan{SourceChunks: chunkLedger}, rewritePenalties, now)
+						chunkPlanEligible, _ := filterVlogGenerationRewriteChunkPlanByPenalty(backenddb.ValueLogRewriteChunkPlan{SourceChunks: chunkLedger}, rewritePenalties, now)
 						chunkLedgerEligible = chunkPlanEligible.SourceChunks
 					}
 					processedRewriteChunks = vlogGenerationRewriteChunkLedgerChunk(chunkLedgerEligible, rewriteMaxSegments, budgetTokens)

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1621,11 +1621,27 @@ func (b *rewriteBudgetRecordingBackend) ValueLogRewriteOnline(ctx context.Contex
 	if len(stats.RequestedSourceFileIDs) == 0 && len(opts.SourceFileIDs) > 0 {
 		stats.RequestedSourceFileIDs = append([]uint32(nil), opts.SourceFileIDs...)
 	}
-	if err == nil &&
-		len(stats.DrainedSourceFileIDs) == 0 &&
-		len(opts.SourceFileIDs) > 0 &&
-		(stats.SourceBytesUnreferenced > 0 || stats.BytesAfter == 0 || stats.BytesAfter < stats.BytesBefore) {
-		stats.DrainedSourceFileIDs = append([]uint32(nil), opts.SourceFileIDs...)
+	if err == nil && len(stats.DrainedSourceFileIDs) == 0 && len(opts.SourceFileIDs) > 0 {
+		if len(stats.SourceFileIDsUnreferenced) > 0 || len(stats.SourceFileIDsStillReferenced) > 0 {
+			stillReferenced := make(map[uint32]struct{}, len(stats.SourceFileIDsStillReferenced))
+			for _, id := range stats.SourceFileIDsStillReferenced {
+				if id != 0 {
+					stillReferenced[id] = struct{}{}
+				}
+			}
+			if len(stats.SourceFileIDsUnreferenced) > 0 {
+				stats.DrainedSourceFileIDs = append([]uint32(nil), stats.SourceFileIDsUnreferenced...)
+			} else {
+				for _, id := range opts.SourceFileIDs {
+					if _, ok := stillReferenced[id]; ok {
+						continue
+					}
+					stats.DrainedSourceFileIDs = append(stats.DrainedSourceFileIDs, id)
+				}
+			}
+		} else if stats.SourceBytesUnreferenced > 0 || stats.BytesAfter == 0 || stats.BytesAfter < stats.BytesBefore {
+			stats.DrainedSourceFileIDs = append([]uint32(nil), opts.SourceFileIDs...)
+		}
 	}
 	if len(opts.SourceFileIDs) > 0 {
 		exactPlannedSelection := false
@@ -5605,6 +5621,10 @@ func TestVlogGenerationRewritePlan_FiltersPenalizedSegments(t *testing.T) {
 	recorder.mu.Unlock()
 	db.vlogGenerationLastRewriteUnixNano.Store(0)
 	db.vlogGenerationRewriteIneffectiveLastNS.Store(time.Now().Add(-2 * vlogGenerationRewriteIneffectiveBackoff).UnixNano())
+	// The first rewrite now consumes budget from selected-source live bytes, so
+	// refill tokens here to keep this test focused on penalty filtering rather
+	// than token-bucket starvation.
+	db.vlogGenerationRewriteBudgetTokensBytes.Store(1024)
 	db.vlogGenerationCheckpointKickPending.Store(false)
 	db.vlogGenerationDeferredMaintenancePending.Store(false)
 	db.vlogGenerationRewriteQueuePending.Store(false)
@@ -5696,6 +5716,9 @@ func TestVlogGenerationRewritePlan_ReadmitsPenalizedSegmentWhenStaleBytesImprove
 	forceVlogMaintenanceIdle(db)
 	db.vlogGenerationLastRewriteUnixNano.Store(0)
 	db.vlogGenerationRewriteIneffectiveLastNS.Store(time.Now().Add(-2 * vlogGenerationRewriteIneffectiveBackoff).UnixNano())
+	// Keep the second pass focused on stale-byte readmission. The first run now
+	// legitimately drains budget based on selected-source live bytes.
+	db.vlogGenerationRewriteBudgetTokensBytes.Store(1024)
 	db.maybeRunVlogGenerationMaintenance(false)
 
 	if _, calls := recorder.recordedPlan(); calls != 2 {

--- a/worklog/2026-04-10-authoritative-catalogs.md
+++ b/worklog/2026-04-10-authoritative-catalogs.md
@@ -147,3 +147,20 @@
 - the next structural gap is executor/cleanup quality, not ledger survival:
   - reduce remaining rediscovery around locators and cleanup/GC eligibility
   - move more of the common reclaim lifecycle onto the same maintained catalog truth
+
+### Validation Follow-up
+
+- status:
+  - complete locally on top of `46b4a6e1`
+- trigger:
+  - the broad touched-package sweep (`./TreeDB/zipper ./TreeDB/db ./TreeDB/caching`) exposed four caching scheduler failures after the selected-source accounting and durable debt-ledger slices
+
+#### Landed locally
+
+- fixed the scheduler test backend so synthesized `DrainedSourceFileIDs` matches real backend semantics when some requested source IDs remain referenced
+- kept chunk-plan penalty filtering behavior aligned with segment-plan penalty filtering in tests by refilling budget tokens before the second pass where the assertion is about penalty behavior, not budget starvation
+
+#### Validation
+
+- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewriteQueue_KeepsStillReferencedSegmentQueuedWhenBounded|VlogGenerationRewriteQueue_DebtDrainSelectsMultipleSegmentsAndBoundsExecution|VlogGenerationRewritePlan_FiltersPenalizedSegments|VlogGenerationRewritePlan_ReadmitsPenalizedSegmentWhenStaleBytesImprove)$' -count=1`
+- `GOWORK=off go test ./TreeDB/zipper ./TreeDB/db ./TreeDB/caching -count=1`


### PR DESCRIPTION
## What changed
- made chunk-plan penalty filtering support the same stale-byte readmission behavior as segment-plan filtering
- cleared persisted rewrite penalties when a chunk-plan refresh readmits a penalized segment
- fixed the scheduler test backend so synthesized `DrainedSourceFileIDs` matches real backend semantics when requested source IDs remain referenced
- updated the targeted penalty tests to refill budget tokens before their second pass so they keep asserting penalty behavior rather than token-bucket starvation
- recorded the validation follow-up in `worklog/2026-04-10-authoritative-catalogs.md`

## Why
After publishing `#958` and `#959`, the broad touched-package sweep surfaced four caching scheduler failures. Two were test-backend drift after selected-source accounting changed. Two exposed that chunk-plan penalty handling had fallen behind the segment-plan path and that the tests were also accidentally depending on pre-change budget consumption behavior. This slice restores semantic alignment and keeps the scheduler package green on the authoritative-catalog stack.

## Validation
- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewriteQueue_KeepsStillReferencedSegmentQueuedWhenBounded|VlogGenerationRewriteQueue_DebtDrainSelectsMultipleSegmentsAndBoundsExecution|VlogGenerationRewritePlan_FiltersPenalizedSegments|VlogGenerationRewritePlan_ReadmitsPenalizedSegmentWhenStaleBytesImprove)$' -count=1`
- `GOWORK=off go test ./TreeDB/zipper ./TreeDB/db ./TreeDB/caching -count=1`
