### PR TITLE
[codex] treedb: expose leafref rewrite traversal stats

### DIFF
--- a/TreeDB/db/vlog_debt_ledger_test.go
+++ b/TreeDB/db/vlog_debt_ledger_test.go
@@ -400,6 +400,12 @@ func TestValueLogDebtLedger_TracksLeafRefRewriteCommits(t *testing.T) {
 	if stats.LeafRefRecordsCopied == 0 {
 		t.Fatalf("expected leafref rewrite to copy leaf pages, stats=%+v", stats)
 	}
+	if stats.LeafRefTreeNodesVisited == 0 || stats.LeafRefInternalNodesVisited == 0 {
+		t.Fatalf("expected leafref rewrite traversal stats, stats=%+v", stats)
+	}
+	if stats.LeafRefRefsVisited == 0 || stats.LeafRefRefsSelected == 0 {
+		t.Fatalf("expected leafref rewrite to report visited and selected refs, stats=%+v", stats)
+	}
 	if !db.valueLogDebtLedger.canTrack(db.currentCommitSeq()) {
 		t.Fatalf("expected debt ledger to stay trackable after leafref rewrite")
 	}

--- a/TreeDB/db/vlog_locator_catalog_test.go
+++ b/TreeDB/db/vlog_locator_catalog_test.go
@@ -288,6 +288,12 @@ func TestValueLogLocatorCatalog_TracksLeafRefRewriteCommits(t *testing.T) {
 	if stats.LeafRefRecordsCopied == 0 {
 		t.Fatalf("expected leafref rewrite to copy leaf pages, stats=%+v", stats)
 	}
+	if stats.LeafRefTreeNodesVisited == 0 || stats.LeafRefInternalNodesVisited == 0 {
+		t.Fatalf("expected leafref rewrite traversal stats, stats=%+v", stats)
+	}
+	if stats.LeafRefRefsVisited == 0 || stats.LeafRefRefsSelected == 0 {
+		t.Fatalf("expected leafref rewrite to report visited and selected refs, stats=%+v", stats)
+	}
 	if !db.valueLogLocatorCatalog.canTrack(db.currentCommitSeq()) {
 		t.Fatalf("expected locator catalog to stay trackable after leafref rewrite")
 	}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -68,6 +68,15 @@ type ValueLogRewriteStats struct {
 	// rewrite path (indexOuterLeavesInValueLog mode).
 	LeafRefRecordsCopied int
 	LeafRefBytesCopied   int64
+	// LeafRef*Visited counters describe the traversal work paid by the leaf-ref
+	// rewrite path while walking the pager tree to find eligible outer-leaf
+	// pages. These are encounter counts, not unique object counts.
+	LeafRefTreeNodesVisited      int
+	LeafRefInternalNodesVisited  int
+	LeafRefPagerLeafNodesVisited int
+	LeafRefRefsVisited           int
+	LeafRefRefsSelected          int
+	LeafRefRefsSkipped           int
 	// SourceSegmentsRequested is the number of source segments selected for this
 	// rewrite run after applying selection filters.
 	SourceSegmentsRequested int
@@ -1929,7 +1938,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			}
 			if maxCopiedBytes <= 0 || leafRefMaxCopiedBytes > 0 {
 				leafRefStart := time.Now()
-				copied, copiedBytes, err := db.rewriteLeafRefsOnline(ctx, writer, ridAlloc, sourceIDs, sourceChunkSet, sourceChunkBytes, singleSourceID, restrictSingleID, leafRefMaxCopiedBytes, opts.SyncEachBatch)
+				copied, copiedBytes, leafRefTraversal, err := db.rewriteLeafRefsOnline(ctx, writer, ridAlloc, sourceIDs, sourceChunkSet, sourceChunkBytes, singleSourceID, restrictSingleID, leafRefMaxCopiedBytes, opts.SyncEachBatch)
 				stats.LeafRefNanos += time.Since(leafRefStart).Nanoseconds()
 				if err != nil {
 					return stats, err
@@ -1937,6 +1946,12 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 				stats.RecordsCopied += copied
 				stats.LeafRefRecordsCopied += copied
 				stats.LeafRefBytesCopied += copiedBytes
+				stats.LeafRefTreeNodesVisited += leafRefTraversal.treeNodesVisited
+				stats.LeafRefInternalNodesVisited += leafRefTraversal.internalNodesVisited
+				stats.LeafRefPagerLeafNodesVisited += leafRefTraversal.pagerLeafNodesVisited
+				stats.LeafRefRefsVisited += leafRefTraversal.refsVisited
+				stats.LeafRefRefsSelected += leafRefTraversal.refsSelected
+				stats.LeafRefRefsSkipped += leafRefTraversal.refsSkipped
 				stats.SourceBytesProcessed += copiedBytes
 			}
 		}
@@ -2164,6 +2179,7 @@ type leafRefRewriteCtx struct {
 	copiedBytes      int64
 	maxCopiedBytes   int64
 	outerLeafChanges *valueLogOuterLeafChangeCollector
+	stats            leafRefRewriteTraversalStats
 
 	readRefreshRetried bool
 }
@@ -2171,6 +2187,15 @@ type leafRefRewriteCtx struct {
 type leafRefRewriteRemap struct {
 	oldID uint64
 	newID uint64
+}
+
+type leafRefRewriteTraversalStats struct {
+	treeNodesVisited      int
+	internalNodesVisited  int
+	pagerLeafNodesVisited int
+	refsVisited           int
+	refsSelected          int
+	refsSkipped           int
 }
 
 func (c *leafRefRewriteCtx) readLeafPage(ptr page.ValuePtr) ([]byte, error) {
@@ -2302,15 +2327,19 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 	}
 
 	if ptr, ok := page.DecodeLeafRef(id); ok {
+		c.stats.refsVisited++
 		if mapped, ok := c.lookupLeafRemap(id); ok {
+			c.stats.refsSelected++
 			return mapped, mapped != id, nil
 		}
 		if c.hasSingleID {
 			if ptr.FileID != c.singleSourceID {
+				c.stats.refsSkipped++
 				return id, false, nil
 			}
 		} else if c.sourceIDs != nil {
 			if _, ok := c.sourceIDs[ptr.FileID]; !ok {
+				c.stats.refsSkipped++
 				return id, false, nil
 			}
 		}
@@ -2320,9 +2349,11 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 				return id, false, err
 			}
 			if !ok {
+				c.stats.refsSkipped++
 				return id, false, nil
 			}
 		}
+		c.stats.refsSelected++
 		if c.leafReader == nil {
 			return id, false, fmt.Errorf("vlog-rewrite: value-log snapshot reader unavailable")
 		}
@@ -2377,8 +2408,10 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 			c.pager.MarkVerified(id)
 		}
 	}
+	c.stats.treeNodesVisited++
 	switch n.Type() {
 	case page.PageTypeInternal:
+		c.stats.internalNodesVisited++
 		count := n.Count()
 		if count == 0 {
 			return id, false, nil
@@ -2452,6 +2485,7 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 		return newID, true, nil
 
 	case page.PageTypeLeaf:
+		c.stats.pagerLeafNodesVisited++
 		// Pager-backed leaf pages are not expected in outer-leaves-in-vlog mode.
 		// Keep them intact.
 		return id, false, nil
@@ -2461,32 +2495,32 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 	}
 }
 
-func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, ridAlloc *rewriteRIDAllocator, sourceIDs map[uint32]struct{}, sourceChunks map[valueLogChunkKey]ValueLogRewritePlanChunk, sourceChunkBytes int64, singleSourceID uint32, hasSingleSourceID bool, maxCopiedBytes int64, sync bool) (copied int, copiedBytes int64, err error) {
+func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, ridAlloc *rewriteRIDAllocator, sourceIDs map[uint32]struct{}, sourceChunks map[valueLogChunkKey]ValueLogRewritePlanChunk, sourceChunkBytes int64, singleSourceID uint32, hasSingleSourceID bool, maxCopiedBytes int64, sync bool) (copied int, copiedBytes int64, traversal leafRefRewriteTraversalStats, err error) {
 	if db == nil {
-		return 0, 0, fmt.Errorf("missing db")
+		return 0, 0, leafRefRewriteTraversalStats{}, fmt.Errorf("missing db")
 	}
 	if !db.indexOuterLeavesInValueLog {
-		return 0, 0, nil
+		return 0, 0, leafRefRewriteTraversalStats{}, nil
 	}
 	if db.readOnly {
-		return 0, 0, ErrReadOnly
+		return 0, 0, leafRefRewriteTraversalStats{}, ErrReadOnly
 	}
 	if db.valueLogManager == nil {
-		return 0, 0, fmt.Errorf("value log manager unavailable")
+		return 0, 0, leafRefRewriteTraversalStats{}, fmt.Errorf("value log manager unavailable")
 	}
 	if writer == nil || ridAlloc == nil {
-		return 0, 0, fmt.Errorf("vlog-rewrite: missing writer/rid state")
+		return 0, 0, leafRefRewriteTraversalStats{}, fmt.Errorf("vlog-rewrite: missing writer/rid state")
 	}
 	// Treat nil sourceIDs (with no single-source constraint) as "all sources"
 	// and an empty, non-nil map as "no sources".
 	if !hasSingleSourceID && sourceIDs != nil && len(sourceIDs) == 0 {
-		return 0, 0, nil
+		return 0, 0, leafRefRewriteTraversalStats{}, nil
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
-		return 0, 0, err
+		return 0, 0, leafRefRewriteTraversalStats{}, err
 	}
 
 	db.writeMu.Lock()
@@ -2495,7 +2529,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	snap := db.AcquireSnapshot()
 	if snap == nil || snap.idx == nil || snap.state == nil {
 		closeRewriteSnapshot(&err, snap)
-		return 0, 0, fmt.Errorf("missing snapshot state")
+		return 0, 0, leafRefRewriteTraversalStats{}, fmt.Errorf("missing snapshot state")
 	}
 	defer closeRewriteSnapshot(&err, snap)
 
@@ -2544,30 +2578,30 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 
 	newSysRoot, sysChanged, err := leafCtx.rewriteNode(sysRoot)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, leafCtx.stats, err
 	}
 	newRoot, userChanged, err := leafCtx.rewriteNode(rootID)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, leafCtx.stats, err
 	}
 	if !sysChanged && !userChanged {
-		return 0, 0, nil
+		return 0, 0, leafCtx.stats, nil
 	}
 
 	// Ensure the copied leaf-page records are visible before publishing new leaf
 	// refs that point at them.
 	if sync {
 		if err := writer.Sync(); err != nil {
-			return 0, 0, err
+			return 0, 0, leafCtx.stats, err
 		}
 	} else {
 		if err := writer.Flush(); err != nil {
-			return 0, 0, err
+			return 0, 0, leafCtx.stats, err
 		}
 	}
 	createdIDs, err := writer.createdFileIDs()
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, leafCtx.stats, err
 	}
 	if len(createdIDs) > 0 {
 		// Register rewrite-created segments before commit publication so
@@ -2576,23 +2610,23 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		for _, id := range createdIDs {
 			path := db.valueLogManager.SegmentPath(id)
 			if err := db.valueLogManager.RegisterSegment(path, id); err != nil {
-				return 0, 0, err
+				return 0, 0, leafCtx.stats, err
 			}
 		}
 	}
 	vlogDebtDelta, err := db.buildValueLogDebtDelta(nil, 0, snap.state.CommitSeq, nil, leafCtx.outerLeafChanges)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, leafCtx.stats, err
 	}
 	var vlogLocatorDelta *valueLogLocatorDelta
 	if db.valueLogLocatorCatalog != nil && valueLogLocatorCatalogEnabled() && db.valueLogLocatorCatalog.canTrack(snap.state.CommitSeq) {
 		vlogLocatorDelta = newValueLogLocatorDelta()
 	}
 	if err := db.finalizeCommit(newRoot, newSysRoot, leafCtx.retired, sync, adaptive.Metrics{}, createdIDs, false, nil, vlogDebtDelta, vlogLocatorDelta); err != nil {
-		return 0, 0, err
+		return 0, 0, leafCtx.stats, err
 	}
 	tracker = nil
-	return leafCtx.copied, leafCtx.copiedBytes, nil
+	return leafCtx.copied, leafCtx.copiedBytes, leafCtx.stats, nil
 }
 
 func nextRewriteRIDStart(segments []logSegment) (uint64, error) {

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -3024,6 +3024,12 @@ func TestValueLogRewriteOnline_LeafRefsReserveRIDs_DoesNotRefreshManager(t *test
 	if stats.LeafRefRecordsCopied == 0 {
 		t.Fatalf("expected leafref rewrite to copy records")
 	}
+	if stats.LeafRefTreeNodesVisited == 0 || stats.LeafRefInternalNodesVisited == 0 {
+		t.Fatalf("expected leafref rewrite traversal stats, stats=%+v", stats)
+	}
+	if stats.LeafRefRefsVisited == 0 || stats.LeafRefRefsSelected == 0 {
+		t.Fatalf("expected leafref rewrite to report visited and selected refs, stats=%+v", stats)
+	}
 	if delta := db.valueLogManager.RefreshScanCount() - refreshBefore; delta != 0 {
 		t.Fatalf("expected reserve leafref rewrite to avoid manager refresh scans, got %d", delta)
 	}

--- a/worklog/2026-04-10-authoritative-catalogs.md
+++ b/worklog/2026-04-10-authoritative-catalogs.md
@@ -164,3 +164,36 @@
 
 - `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewriteQueue_KeepsStillReferencedSegmentQueuedWhenBounded|VlogGenerationRewriteQueue_DebtDrainSelectsMultipleSegmentsAndBoundsExecution|VlogGenerationRewritePlan_FiltersPenalizedSegments|VlogGenerationRewritePlan_ReadmitsPenalizedSegmentWhenStaleBytesImprove)$' -count=1`
 - `GOWORK=off go test ./TreeDB/zipper ./TreeDB/db ./TreeDB/caching -count=1`
+
+### Second-Sprint Slice 4
+
+- status:
+  - complete locally on top of `ad3d58e2`
+- goal:
+  - expose the remaining common-path execution cost in online rewrite after the locator catalog and debt ledger cutovers
+
+#### Landed locally
+
+- extended `TreeDB/db/vlog_rewrite.go` rewrite stats with leafref traversal counters:
+  - `LeafRefTreeNodesVisited`
+  - `LeafRefInternalNodesVisited`
+  - `LeafRefPagerLeafNodesVisited`
+  - `LeafRefRefsVisited`
+  - `LeafRefRefsSelected`
+  - `LeafRefRefsSkipped`
+- threaded a dedicated traversal stats struct through `rewriteLeafRefsOnline`
+  - direct pointer-candidate rewrite already reports `CandidateScanMode=locator_catalog` for selected-source execution
+  - leafref rewrite still recursively walks the pager tree and now returns the amount of traversal paid to find eligible leafrefs
+- tightened existing leafref rewrite tests so this observability is part of the normal regression surface
+
+#### Validation
+
+- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogLocatorCatalog_TracksLeafRefRewriteCommits|ValueLogDebtLedger_TracksLeafRefRewriteCommits|ValueLogRewriteOnline_LeafRefsReserveRIDs_DoesNotRefreshManager|ValueLogRewriteOnline_MaxCopiedBytes_DoesNotRunLeafRefRewriteWhenBudgetExhausted)$' -count=1`
+- `GOWORK=off go test ./TreeDB/db -count=1`
+
+#### Remaining gap after this slice
+
+- selected-source direct value-pointer rewrite is already locator-driven
+- the remaining execution rediscovery gap is now explicit and measurable:
+  - leafref rewrite still traverses the tree recursively to rediscover eligible outer-leaf pages
+  - a true next structural slice requires a stronger leafref locator form, not just more point optimizations inside the current walk


### PR DESCRIPTION
## What changed

This adds explicit leafref traversal observability to `ValueLogRewriteOnline`.

- extend `ValueLogRewriteStats` with counters for:
  - tree nodes visited
  - internal nodes visited
  - pager leaf nodes visited
  - leafref records visited, selected, and skipped
- thread a dedicated traversal stats struct through `rewriteLeafRefsOnline`
- assert the new counters in the existing leafref rewrite tests
- update the in-repo worklog with the slice outcome and remaining gap

## Why

The current common-path gap after the locator-catalog and debt-ledger slices is no longer direct pointer candidate discovery. Selected-source direct rewrite already runs in locator-catalog mode.

The remaining execution rediscovery gap is leafref rewrite: it still walks the pager tree recursively to find eligible outer-leaf pages. This PR makes that residual cost explicit in returned rewrite stats so the next structural slice can be driven by normal tests and Celestia validation rather than ad hoc profiling only.

## Impact

There is no scheduler behavior change in this PR. It is an observability slice that makes the remaining leafref execution cost measurable in the normal rewrite path.

## Validation

- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogLocatorCatalog_TracksLeafRefRewriteCommits|ValueLogDebtLedger_TracksLeafRefRewriteCommits|ValueLogRewriteOnline_LeafRefsReserveRIDs_DoesNotRefreshManager|ValueLogRewriteOnline_MaxCopiedBytes_DoesNotRunLeafRefRewriteWhenBudgetExhausted)$' -count=1`
- `GOWORK=off go test ./TreeDB/db -count=1`
