### PR TITLE
[codex] treedb: skip leafref rewrite on non-leaf sources

### DIFF
--- a/TreeDB/db/vlog_debt_ledger.go
+++ b/TreeDB/db/vlog_debt_ledger.go
@@ -24,15 +24,24 @@ import (
 
 const (
 	valueLogDebtLedgerFileName = "vlog_debt_ledger.meta"
-	valueLogDebtLedgerVersion  = 1
+	valueLogDebtLedgerVersion  = 2
 	envEnableVlogDebtLedger    = "TREEDB_VLOG_DEBT_LEDGER"
 	envEnableVlogShadowCompare = "TREEDB_VLOG_SHADOW_COMPARE"
+)
+
+type valueLogDebtRecordKind uint8
+
+const (
+	valueLogDebtRecordKindUnknown valueLogDebtRecordKind = iota
+	valueLogDebtRecordKindValue
+	valueLogDebtRecordKindOuterLeaf
 )
 
 type valueLogDebtSegmentSummary struct {
 	FileID               uint32 `json:"file_id"`
 	TotalBytes           uint64 `json:"total_bytes"`
 	LiveBytes            uint64 `json:"live_bytes"`
+	OuterLeafLiveBytes   uint64 `json:"outer_leaf_live_bytes,omitempty"`
 	StaleBytes           uint64 `json:"stale_bytes"`
 	LastUpdatedCommitSeq uint64 `json:"last_updated_commit_seq"`
 }
@@ -47,6 +56,7 @@ type valueLogDebtLedgerDisk struct {
 type valueLogDebtRecordDisk struct {
 	FileID    uint32 `json:"file_id"`
 	Start     uint64 `json:"start"`
+	Kind      uint8  `json:"kind,omitempty"`
 	RecordLen uint32 `json:"record_len"`
 	RefCount  uint32 `json:"ref_count"`
 }
@@ -54,6 +64,7 @@ type valueLogDebtRecordDisk struct {
 type valueLogDebtRecordKey struct {
 	FileID uint32
 	Start  uint64
+	Kind   valueLogDebtRecordKind
 }
 
 type valueLogDebtRecordRef struct {
@@ -125,14 +136,17 @@ func valueLogDebtLedgerShadowCompareEnabled() bool {
 	return envDebtLedgerBool(envEnableVlogShadowCompare)
 }
 
-func valueLogDebtRecordKeyForPtr(ptr page.ValuePtr) (valueLogDebtRecordKey, error) {
+func valueLogDebtRecordKeyForPtr(ptr page.ValuePtr, kind valueLogDebtRecordKind) (valueLogDebtRecordKey, error) {
 	if !page.IsValueLogFileID(ptr.FileID) {
 		return valueLogDebtRecordKey{}, fmt.Errorf("treedb: non-vlog pointer for debt key: file=%d", ptr.FileID)
 	}
 	if ptr.Offset < 4 {
 		return valueLogDebtRecordKey{}, fmt.Errorf("treedb: invalid value-log pointer offset %d", ptr.Offset)
 	}
-	return valueLogDebtRecordKey{FileID: ptr.FileID, Start: uint64(ptr.Offset - 4)}, nil
+	if kind == valueLogDebtRecordKindUnknown {
+		kind = valueLogDebtRecordKindValue
+	}
+	return valueLogDebtRecordKey{FileID: ptr.FileID, Start: uint64(ptr.Offset - 4), Kind: kind}, nil
 }
 
 func (d *valueLogDebtDelta) addRecord(key valueLogDebtRecordKey, recordLen uint32, refDelta int32) {
@@ -154,11 +168,11 @@ func (d *valueLogDebtDelta) addRecord(key valueLogDebtRecordKey, recordLen uint3
 	d.changes[key] = change
 }
 
-func (d *valueLogDebtDelta) addPtr(ptr page.ValuePtr, recordLen uint32, refDelta int32) error {
+func (d *valueLogDebtDelta) addPtr(ptr page.ValuePtr, kind valueLogDebtRecordKind, recordLen uint32, refDelta int32) error {
 	if d == nil || refDelta == 0 || !page.IsValueLogFileID(ptr.FileID) {
 		return nil
 	}
-	key, err := valueLogDebtRecordKeyForPtr(ptr)
+	key, err := valueLogDebtRecordKeyForPtr(ptr, kind)
 	if err != nil {
 		return err
 	}
@@ -204,7 +218,7 @@ func (c *valueLogOuterLeafChangeCollector) appendToDebtDelta(db *DB, delta *valu
 		if err != nil {
 			return err
 		}
-		if err := delta.addPtr(ptr, recordLen, -1); err != nil {
+		if err := delta.addPtr(ptr, valueLogDebtRecordKindOuterLeaf, recordLen, -1); err != nil {
 			return err
 		}
 	}
@@ -213,7 +227,7 @@ func (c *valueLogOuterLeafChangeCollector) appendToDebtDelta(db *DB, delta *valu
 		if err != nil {
 			return err
 		}
-		if err := delta.addPtr(ptr, recordLen, 1); err != nil {
+		if err := delta.addPtr(ptr, valueLogDebtRecordKindOuterLeaf, recordLen, 1); err != nil {
 			return err
 		}
 	}
@@ -234,6 +248,9 @@ func (l *valueLogDebtLedger) replace(commitSeq uint64, segments map[uint32]value
 		}
 		if seg.StaleBytes > seg.TotalBytes {
 			seg.StaleBytes = seg.TotalBytes
+		}
+		if seg.OuterLeafLiveBytes > seg.LiveBytes {
+			seg.OuterLeafLiveBytes = seg.LiveBytes
 		}
 		nextSegments[seg.FileID] = seg
 	}
@@ -293,6 +310,23 @@ func (l *valueLogDebtLedger) liveBytesBySegment(commitSeq uint64) (map[uint32]in
 	return out, true
 }
 
+func (l *valueLogDebtLedger) hasOuterLeafLiveBytes(commitSeq uint64, fileIDs []uint32) (bool, bool) {
+	if l == nil {
+		return false, false
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if !l.valid || l.commitSeq != commitSeq {
+		return false, false
+	}
+	for _, fileID := range fileIDs {
+		if l.segments[fileID].OuterLeafLiveBytes > 0 {
+			return true, true
+		}
+	}
+	return false, true
+}
+
 func (l *valueLogDebtLedger) dirtySnapshot() (uint64, []valueLogDebtSegmentSummary, []valueLogDebtRecordDisk, bool) {
 	if l == nil {
 		return 0, nil, nil, false
@@ -315,6 +349,7 @@ func (l *valueLogDebtLedger) dirtySnapshot() (uint64, []valueLogDebtSegmentSumma
 		records = append(records, valueLogDebtRecordDisk{
 			FileID:    rec.Key.FileID,
 			Start:     rec.Key.Start,
+			Kind:      uint8(rec.Key.Kind),
 			RecordLen: rec.RecordLen,
 			RefCount:  rec.RefCount,
 		})
@@ -383,11 +418,20 @@ func (l *valueLogDebtLedger) applyDelta(nextCommitSeq uint64, delta *valueLogDeb
 		switch {
 		case curRefCount == 0 && nextRefCount > 0:
 			seg.LiveBytes += uint64(recordLen)
+			if key.Kind == valueLogDebtRecordKindOuterLeaf {
+				seg.OuterLeafLiveBytes += uint64(recordLen)
+			}
 		case curRefCount > 0 && nextRefCount == 0:
 			if uint64(recordLen) > seg.LiveBytes {
 				return fmt.Errorf("treedb: value-log debt live-byte underflow: file=%d have=%d dec=%d", key.FileID, seg.LiveBytes, recordLen)
 			}
 			seg.LiveBytes -= uint64(recordLen)
+			if key.Kind == valueLogDebtRecordKindOuterLeaf {
+				if uint64(recordLen) > seg.OuterLeafLiveBytes {
+					return fmt.Errorf("treedb: value-log debt outer-leaf live-byte underflow: file=%d have=%d dec=%d", key.FileID, seg.OuterLeafLiveBytes, recordLen)
+				}
+				seg.OuterLeafLiveBytes -= uint64(recordLen)
+			}
 		}
 		seg.LastUpdatedCommitSeq = nextCommitSeq
 		l.segments[key.FileID] = seg
@@ -410,6 +454,9 @@ func (l *valueLogDebtLedger) applyDelta(nextCommitSeq uint64, delta *valueLogDeb
 		if seg.LiveBytes > seg.TotalBytes {
 			seg.LiveBytes = seg.TotalBytes
 		}
+		if seg.OuterLeafLiveBytes > seg.LiveBytes {
+			seg.OuterLeafLiveBytes = seg.LiveBytes
+		}
 		seg.StaleBytes = seg.TotalBytes - seg.LiveBytes
 		seg.LastUpdatedCommitSeq = nextCommitSeq
 		l.segments[fileID] = seg
@@ -419,6 +466,9 @@ func (l *valueLogDebtLedger) applyDelta(nextCommitSeq uint64, delta *valueLogDeb
 		seg := l.segments[fileID]
 		if seg.LiveBytes > seg.TotalBytes {
 			seg.LiveBytes = seg.TotalBytes
+		}
+		if seg.OuterLeafLiveBytes > seg.LiveBytes {
+			seg.OuterLeafLiveBytes = seg.LiveBytes
 		}
 		if seg.TotalBytes >= seg.LiveBytes {
 			seg.StaleBytes = seg.TotalBytes - seg.LiveBytes
@@ -493,7 +543,10 @@ func (db *DB) loadValueLogDebtLedger(commitSeq uint64) (bool, error) {
 		if rec.FileID == 0 || rec.RecordLen == 0 || rec.RefCount == 0 {
 			continue
 		}
-		key := valueLogDebtRecordKey{FileID: rec.FileID, Start: rec.Start}
+		key := valueLogDebtRecordKey{FileID: rec.FileID, Start: rec.Start, Kind: valueLogDebtRecordKind(rec.Kind)}
+		if key.Kind == valueLogDebtRecordKindUnknown {
+			key.Kind = valueLogDebtRecordKindValue
+		}
 		records[key] = valueLogDebtRecordRef{
 			Key:       key,
 			RecordLen: rec.RecordLen,
@@ -573,11 +626,11 @@ func (db *DB) storeValueLogDebtLedgerFromLiveBytes(liveByID map[uint32]int64) er
 	return db.persistValueLogDebtLedger()
 }
 
-func observeValueLogDebtRecord(db *DB, ptr page.ValuePtr, records map[valueLogDebtRecordKey]valueLogDebtRecordRef, set *valuelog.Set) error {
+func observeValueLogDebtRecord(db *DB, ptr page.ValuePtr, kind valueLogDebtRecordKind, records map[valueLogDebtRecordKey]valueLogDebtRecordRef, set *valuelog.Set) error {
 	if db == nil || records == nil || !page.IsValueLogFileID(ptr.FileID) {
 		return nil
 	}
-	key, err := valueLogDebtRecordKeyForPtr(ptr)
+	key, err := valueLogDebtRecordKeyForPtr(ptr, kind)
 	if err != nil {
 		return err
 	}
@@ -603,7 +656,7 @@ func (db *DB) collectValueLogRecordRefs(ctx context.Context, it iterator.UnsafeI
 			it.Next()
 			continue
 		}
-		if err := observeValueLogDebtRecord(db, ptr, records, set); err != nil {
+		if err := observeValueLogDebtRecord(db, ptr, valueLogDebtRecordKindValue, records, set); err != nil {
 			return err
 		}
 		it.Next()
@@ -619,7 +672,7 @@ func (db *DB) collectLeafRefValueLogRecordRefs(ctx context.Context, p *pager.Pag
 		return nil
 	}
 	if ptr, ok := page.DecodeLeafRef(rootID); ok {
-		return observeValueLogDebtRecord(db, ptr, records, set)
+		return observeValueLogDebtRecord(db, ptr, valueLogDebtRecordKindOuterLeaf, records, set)
 	}
 	stack := make([]uint64, 0, 128)
 	stack = append(stack, rootID)
@@ -660,7 +713,7 @@ func (db *DB) collectLeafRefValueLogRecordRefs(ctx context.Context, p *pager.Pag
 					return err
 				}
 				if ptr, ok := page.DecodeLeafRef(childID); ok {
-					if err := observeValueLogDebtRecord(db, ptr, records, set); err != nil {
+					if err := observeValueLogDebtRecord(db, ptr, valueLogDebtRecordKindOuterLeaf, records, set); err != nil {
 						return err
 					}
 					continue
@@ -696,12 +749,18 @@ func buildValueLogDebtSegmentsFromRecords(set *valuelog.Set, records map[valueLo
 		seg := segments[rec.Key.FileID]
 		seg.FileID = rec.Key.FileID
 		seg.LiveBytes += uint64(rec.RecordLen)
+		if rec.Key.Kind == valueLogDebtRecordKindOuterLeaf {
+			seg.OuterLeafLiveBytes += uint64(rec.RecordLen)
+		}
 		seg.LastUpdatedCommitSeq = commitSeq
 		segments[rec.Key.FileID] = seg
 	}
 	for fileID, seg := range segments {
 		if seg.LiveBytes > seg.TotalBytes {
 			seg.LiveBytes = seg.TotalBytes
+		}
+		if seg.OuterLeafLiveBytes > seg.LiveBytes {
+			seg.OuterLeafLiveBytes = seg.LiveBytes
 		}
 		if seg.TotalBytes >= seg.LiveBytes {
 			seg.StaleBytes = seg.TotalBytes - seg.LiveBytes
@@ -873,7 +932,7 @@ func (db *DB) buildValueLogDebtDelta(p *pager.Pager, rootID uint64, baseSeq uint
 				if err != nil {
 					return nil, err
 				}
-				if err := delta.addPtr(oldPtr, recordLen, -1); err != nil {
+				if err := delta.addPtr(oldPtr, valueLogDebtRecordKindValue, recordLen, -1); err != nil {
 					return nil, err
 				}
 			}
@@ -882,7 +941,7 @@ func (db *DB) buildValueLogDebtDelta(p *pager.Pager, rootID uint64, baseSeq uint
 				if err != nil {
 					return nil, err
 				}
-				if err := delta.addPtr(entries[i].ValuePtr, recordLen, 1); err != nil {
+				if err := delta.addPtr(entries[i].ValuePtr, valueLogDebtRecordKindValue, recordLen, 1); err != nil {
 					return nil, err
 				}
 			}

--- a/TreeDB/db/vlog_debt_ledger_test.go
+++ b/TreeDB/db/vlog_debt_ledger_test.go
@@ -334,6 +334,14 @@ func TestValueLogDebtLedger_TracksOuterLeafCommitDeltaAcrossWrites(t *testing.T)
 	stateBefore := db.State()
 	collectLeafRefFileCountsBench(t, db.Pager(), stateBefore.RootPageID, beforeLeafCounts)
 	collectLeafRefFileCountsBench(t, db.Pager(), stateBefore.SystemRootPageID, beforeLeafCounts)
+	db.valueLogDebtLedger.mu.RLock()
+	for fileID := range beforeLeafCounts {
+		if db.valueLogDebtLedger.segments[fileID].OuterLeafLiveBytes == 0 {
+			db.valueLogDebtLedger.mu.RUnlock()
+			t.Fatalf("expected tracked outer-leaf live bytes for file %d after rebuild", fileID)
+		}
+	}
+	db.valueLogDebtLedger.mu.RUnlock()
 
 	b = db.NewBatch().(*Batch)
 	for i := 0; i < 64; i++ {
@@ -374,6 +382,17 @@ func TestValueLogDebtLedger_TracksOuterLeafCommitDeltaAcrossWrites(t *testing.T)
 		}
 		t.Fatalf("debt ledger live bytes mismatch after outer-leaf delta: ledger=%+v scan=%+v before_leaf_counts=%+v after_leaf_counts=%+v ledger_record_counts=%+v", ledgerLive, scanLive, beforeLeafCounts, afterLeafCounts, ledgerRecordCounts)
 	}
+	db.valueLogDebtLedger.mu.RLock()
+	for fileID, n := range beforeLeafCounts {
+		if n == 0 {
+			continue
+		}
+		if db.valueLogDebtLedger.segments[fileID].OuterLeafLiveBytes == 0 {
+			db.valueLogDebtLedger.mu.RUnlock()
+			t.Fatalf("expected tracked outer-leaf live bytes for file %d after delta commit", fileID)
+		}
+	}
+	db.valueLogDebtLedger.mu.RUnlock()
 }
 
 func TestValueLogDebtLedger_TracksLeafRefRewriteCommits(t *testing.T) {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1936,7 +1936,13 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 					leafRefMaxCopiedBytes = 0
 				}
 			}
-			if maxCopiedBytes <= 0 || leafRefMaxCopiedBytes > 0 {
+			shouldRewriteLeafRefs := true
+			if len(stats.RequestedSourceFileIDs) > 0 && db.valueLogDebtLedger != nil && valueLogDebtLedgerEnabled() {
+				if hasOuterLeafLiveBytes, ok := db.valueLogDebtLedger.hasOuterLeafLiveBytes(db.currentCommitSeq(), stats.RequestedSourceFileIDs); ok && !hasOuterLeafLiveBytes {
+					shouldRewriteLeafRefs = false
+				}
+			}
+			if shouldRewriteLeafRefs && (maxCopiedBytes <= 0 || leafRefMaxCopiedBytes > 0) {
 				leafRefStart := time.Now()
 				copied, copiedBytes, leafRefTraversal, err := db.rewriteLeafRefsOnline(ctx, writer, ridAlloc, sourceIDs, sourceChunkSet, sourceChunkBytes, singleSourceID, restrictSingleID, leafRefMaxCopiedBytes, opts.SyncEachBatch)
 				stats.LeafRefNanos += time.Since(leafRefStart).Nanoseconds()

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -2756,6 +2756,124 @@ func TestValueLogRewriteOnline_MaxCopiedBytes_DoesNotRunLeafRefRewriteWhenBudget
 	}
 }
 
+func setupValuePointerRewriteWithLeafRefsBench(tb testing.TB, seg1Records, seg2Records int) (*DB, []uint32, func()) {
+	tb.Helper()
+	dir, err := os.MkdirTemp("", "treedb-vlog-rewrite-value-leaf-bench-*")
+	if err != nil {
+		tb.Fatalf("MkdirTemp: %v", err)
+	}
+
+	db, err := Open(Options{
+		Dir:                        dir,
+		Durability:                 DurabilityWALOffRelaxed,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		LeafPrefixCompression:      true,
+		IndexColumnarLeaves:        true,
+		IndexPackedValuePtr:        true,
+		ValueLog: ValueLogOptions{
+			ForcePointers: true,
+		},
+	})
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		tb.Fatalf("Open: %v", err)
+	}
+
+	leafLog := &registeredLeafPageLog{db: db, dir: dir}
+	db.SetLeafPageLog(leafLog)
+	db.idx.Load().zipper.SetLeafPageReader(db.valueLogManager)
+
+	ptrs1 := appendPointersInNewSegmentBench(tb, dir, 253, 1, 1_000_000, seg1Records, func(i int) []byte {
+		return bytes.Repeat([]byte{byte(i % 251)}, 768)
+	})
+	ptrs2 := appendPointersInNewSegmentBench(tb, dir, 254, 1, 2_000_000, seg2Records, func(i int) []byte {
+		return bytes.Repeat([]byte{byte((i + 7) % 251)}, 768)
+	})
+
+	bt, ok := db.NewBatch().(*Batch)
+	if !ok {
+		_ = db.Close()
+		_ = os.RemoveAll(dir)
+		tb.Fatalf("NewBatch type assertion failed")
+	}
+	for i := range ptrs1 {
+		if i%4 != 0 {
+			continue
+		}
+		if err := bt.SetPointer([]byte(fmt.Sprintf("s1-live-%06d", i)), ptrs1[i]); err != nil {
+			_ = bt.Close()
+			_ = db.Close()
+			_ = os.RemoveAll(dir)
+			tb.Fatalf("SetPointer(s1): %v", err)
+		}
+	}
+	for i := range ptrs2 {
+		if err := bt.SetPointer([]byte(fmt.Sprintf("s2-live-%06d", i)), ptrs2[i]); err != nil {
+			_ = bt.Close()
+			_ = db.Close()
+			_ = os.RemoveAll(dir)
+			tb.Fatalf("SetPointer(s2): %v", err)
+		}
+	}
+	if err := bt.Write(); err != nil {
+		_ = bt.Close()
+		_ = db.Close()
+		_ = os.RemoveAll(dir)
+		tb.Fatalf("seed Write: %v", err)
+	}
+	_ = bt.Close()
+
+	if err := db.RefreshValueLogSet(); err != nil {
+		_ = db.Close()
+		_ = os.RemoveAll(dir)
+		tb.Fatalf("RefreshValueLogSet: %v", err)
+	}
+
+	sourceIDs := []uint32{ptrs1[0].FileID}
+	cleanup := func() {
+		_ = db.Close()
+		_ = os.RemoveAll(dir)
+	}
+	return db, sourceIDs, cleanup
+}
+
+func TestValueLogRewriteOnline_SkipsLeafRefTraversalWhenSelectedSourcesHaveNoOuterLeaves(t *testing.T) {
+	t.Setenv(envEnableVlogDebtLedger, "1")
+	db, sourceIDs, cleanup := setupValuePointerRewriteWithLeafRefsBench(t, 512, 256)
+	defer cleanup()
+
+	if err := db.rebuildValueLogDebtLedger(context.Background()); err != nil {
+		t.Fatalf("rebuild debt ledger: %v", err)
+	}
+	if !db.valueLogDebtLedger.canTrack(db.currentCommitSeq()) {
+		t.Fatalf("expected debt ledger to become trackable")
+	}
+	hasOuterLeafLiveBytes, ok := db.valueLogDebtLedger.hasOuterLeafLiveBytes(db.currentCommitSeq(), sourceIDs)
+	if !ok {
+		t.Fatalf("expected outer-leaf live-byte query to be trackable")
+	}
+	if hasOuterLeafLiveBytes {
+		t.Fatalf("expected selected value-pointer source to have no tracked outer-leaf live bytes")
+	}
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs:     sourceIDs,
+		MaxSourceSegments: len(sourceIDs),
+		BatchSize:         64,
+		SyncEachBatch:     true,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if stats.ValueRecordsCopied == 0 {
+		t.Fatalf("expected value-pointer rewrite to copy records, stats=%+v", stats)
+	}
+	if stats.LeafRefRecordsCopied != 0 || stats.LeafRefTreeNodesVisited != 0 || stats.LeafRefRefsVisited != 0 {
+		t.Fatalf("expected leafref traversal to be skipped for non-leaf sources, stats=%+v", stats)
+	}
+}
+
 func TestValueLogRewriteOnline_ReserveRIDsUsesExternalAllocator(t *testing.T) {
 	dir := t.TempDir()
 

--- a/worklog/2026-04-10-authoritative-catalogs.md
+++ b/worklog/2026-04-10-authoritative-catalogs.md
@@ -197,3 +197,38 @@
 - the remaining execution rediscovery gap is now explicit and measurable:
   - leafref rewrite still traverses the tree recursively to rediscover eligible outer-leaf pages
   - a true next structural slice requires a stronger leafref locator form, not just more point optimizations inside the current walk
+
+### Second-Sprint Slice 5
+
+- status:
+  - complete locally on top of `40b061cd`
+- goal:
+  - skip the leafref rewrite walk entirely when the selected source segments have no live outer-leaf pages, using the commit-path-authoritative debt ledger
+
+#### Landed locally
+
+- extended the persisted debt-ledger record catalog to distinguish normal value records from outer-leaf records
+  - bumped `vlog_debt_ledger.meta` version to `2`
+  - tracked `Kind` on physical record refs
+  - added `OuterLeafLiveBytes` to per-segment debt summaries
+- updated debt-ledger rebuild and commit-path delta application to maintain outer-leaf live bytes per segment
+- added a ledger query path that answers whether a selected source set contains any live outer-leaf bytes
+- gated `ValueLogRewriteOnline` so `rewriteLeafRefsOnline` is skipped when the selected source IDs have no tracked outer-leaf bytes
+- added a focused rewrite test that proves:
+  - the selected value-pointer source is tracked as having no outer-leaf live bytes
+  - value-pointer rewrite still runs
+  - leafref traversal counters remain zero because the leafref pass is skipped
+- tightened outer-leaf debt-ledger tests to assert that rebuild/delta tracking preserves non-zero `OuterLeafLiveBytes` for actual leafref segments
+
+#### Validation
+
+- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogRewriteOnline_SkipsLeafRefTraversalWhenSelectedSourcesHaveNoOuterLeaves|ValueLogRewriteOnline_LeafRefsReserveRIDs_DoesNotRefreshManager|ValueLogRewriteOnline_MaxCopiedBytes_DoesNotRunLeafRefRewriteWhenBudgetExhausted|ValueLogDebtLedger_TracksOuterLeafCommitDeltaAcrossWrites)$' -count=1`
+- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewrite_|Checkpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity)' -count=1`
+- `GOWORK=off go test ./TreeDB/db -count=1`
+
+#### Remaining gap after this slice
+
+- online rewrite no longer pays a leafref tree walk for selected source segments that only contain direct value-pointer debt
+- the remaining structural gap is narrower and more explicit:
+  - when selected source segments do contain live outer-leaf pages, execution still rediscover those pages by recursively traversing the tree
+  - removing that cost still requires a stronger leafref locator form than the current key-only locator catalog


### PR DESCRIPTION
## What changed

This teaches the debt ledger to distinguish outer-leaf records from normal value records, then uses that metadata to skip the leafref rewrite pass when the selected source segments have no live outer-leaf pages.

- bump `vlog_debt_ledger.meta` to version `2`
- track `Kind` on persisted physical record refs
- add `OuterLeafLiveBytes` to per-segment debt summaries
- maintain that outer-leaf byte accounting during rebuild and commit-path delta application
- gate `ValueLogRewriteOnline` so `rewriteLeafRefsOnline` is skipped when the selected source IDs have no tracked outer-leaf live bytes
- add a focused rewrite test proving:
  - the selected value-pointer source has no tracked outer-leaf live bytes
  - value-pointer rewrite still runs
  - leafref traversal counters stay at zero because the leafref pass is skipped
- tighten outer-leaf debt-ledger tests to assert real leafref segments keep non-zero `OuterLeafLiveBytes`
- update the in-repo worklog

## Why

After the locator-catalog and debt-ledger cutovers, a remaining common-path waste case was still present: selected-source rewrite would call the recursive leafref walk even when the requested source segments only contained direct value-pointer debt.

That meant some runs still paid a full-tree leafref traversal that could not reclaim anything. This PR removes that wasted work using the maintained ledger, without waiting for the larger leafref locator redesign.

## Impact

This is a real behavior change in the rewrite path:

- if the selected source segments contain live outer-leaf pages, leafref rewrite still runs
- if they do not, the leafref pass is skipped entirely

The broader remaining gap is unchanged: when selected source segments do contain live outer-leaf pages, execution still rediscovers them by traversing the tree.

## Validation

- `GOWORK=off go test ./TreeDB/db -run 'Test(ValueLogRewriteOnline_SkipsLeafRefTraversalWhenSelectedSourcesHaveNoOuterLeaves|ValueLogRewriteOnline_LeafRefsReserveRIDs_DoesNotRefreshManager|ValueLogRewriteOnline_MaxCopiedBytes_DoesNotRunLeafRefRewriteWhenBudgetExhausted|ValueLogDebtLedger_TracksOuterLeafCommitDeltaAcrossWrites)$' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewrite_|Checkpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity)' -count=1`
- `GOWORK=off go test ./TreeDB/db -count=1`
