### PR TITLE
treedb: tail-fill small staged rewrite plans

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -15612,6 +15612,72 @@ func mergeVlogGenerationRewritePlans(base backenddb.ValueLogRewritePlan, fill ba
 	return merged
 }
 
+func mergeVlogGenerationRewriteChunkPlans(base backenddb.ValueLogRewriteChunkPlan, fill backenddb.ValueLogRewriteChunkPlan) backenddb.ValueLogRewriteChunkPlan {
+	if len(fill.SourceChunks) == 0 {
+		return base
+	}
+	if len(base.SourceChunks) == 0 {
+		return fill
+	}
+	type chunkKey struct {
+		fileID      uint32
+		chunkOffset int64
+	}
+	mergedChunks := make([]backenddb.ValueLogRewritePlanChunk, 0, len(base.SourceChunks)+len(fill.SourceChunks))
+	seen := make(map[chunkKey]struct{}, len(base.SourceChunks)+len(fill.SourceChunks))
+	add := func(chunk backenddb.ValueLogRewritePlanChunk) {
+		if chunk.FileID == 0 {
+			return
+		}
+		key := chunkKey{fileID: chunk.FileID, chunkOffset: chunk.ChunkOffset}
+		if _, dup := seen[key]; dup {
+			return
+		}
+		seen[key] = struct{}{}
+		mergedChunks = append(mergedChunks, chunk)
+	}
+	for _, chunk := range base.SourceChunks {
+		add(chunk)
+	}
+	for _, chunk := range fill.SourceChunks {
+		add(chunk)
+	}
+	merged := base
+	merged.SourceChunks = mergedChunks
+	merged.ChunksSelected = len(mergedChunks)
+	merged.SelectedBytesTotal = 0
+	merged.SelectedBytesLive = 0
+	merged.SelectedBytesStale = 0
+	for _, chunk := range mergedChunks {
+		merged.SelectedBytesTotal += chunk.BytesTotal
+		merged.SelectedBytesLive += chunk.BytesLive
+		merged.SelectedBytesStale += chunk.BytesStale
+	}
+	if fill.ChunkBytes > 0 {
+		merged.ChunkBytes = fill.ChunkBytes
+	}
+	if fill.ChunksTotal > 0 {
+		merged.ChunksTotal = fill.ChunksTotal
+	}
+	if fill.BytesTotal > 0 {
+		merged.BytesTotal = fill.BytesTotal
+	}
+	if fill.BytesLive > 0 {
+		merged.BytesLive = fill.BytesLive
+	}
+	if fill.BytesStale > 0 {
+		merged.BytesStale = fill.BytesStale
+	}
+	if fill.AgeBlockedChunks > 0 {
+		merged.AgeBlockedChunks = fill.AgeBlockedChunks
+		merged.AgeBlockedBytesTotal = fill.AgeBlockedBytesTotal
+		merged.AgeBlockedBytesLive = fill.AgeBlockedBytesLive
+		merged.AgeBlockedBytesStale = fill.AgeBlockedBytesStale
+		merged.AgeBlockedMinRemainingAge = fill.AgeBlockedMinRemainingAge
+	}
+	return merged
+}
+
 func filterVlogGenerationRewriteChunkLedgerByQuality(chunks []backenddb.ValueLogRewritePlanChunk, minStaleRatio float64, minStaleBytes int64) []backenddb.ValueLogRewritePlanChunk {
 	if len(chunks) == 0 {
 		return nil
@@ -16721,12 +16787,15 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 			MinSegmentAge:        db.valueLogRewriteMinSegmentAge,
 		}
 		if hasChunkPlanner && !(plannerRefreshWithQueuedDebt && hasPlanner) {
-			runChunkPlan := func() (backenddb.ValueLogRewriteChunkPlan, error, time.Duration) {
+			runChunkPlanWithOpts := func(runOpts backenddb.ValueLogRewriteOnlineOptions) (backenddb.ValueLogRewriteChunkPlan, error, time.Duration) {
 				ctx, cancel := db.vlogGenerationRewritePlanContext(30*time.Second, opts)
 				planStart := time.Now()
-				plan, err := chunkPlanner.ValueLogRewriteChunkPlan(ctx, planOpts, vlogGenerationRewriteChunkBytesForPlan(maxSourceBytes))
+				plan, err := chunkPlanner.ValueLogRewriteChunkPlan(ctx, runOpts, vlogGenerationRewriteChunkBytesForPlan(maxSourceBytes))
 				cancel()
 				return plan, err, time.Since(planStart)
+			}
+			runChunkPlan := func() (backenddb.ValueLogRewriteChunkPlan, error, time.Duration) {
+				return runChunkPlanWithOpts(planOpts)
 			}
 			chunkPlan, err := func() (backenddb.ValueLogRewriteChunkPlan, error) {
 				plan, err, planDur := runChunkPlan()
@@ -16793,6 +16862,53 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 					return
 				}
 				db.observeVlogGenerationRewritePlanPenaltyFilter(beforePenaltyFilter, len(chunkPlan.SourceChunks))
+				tailFillMinStaleRatio := db.vlogGenerationRewriteMinStaleRatioForTailPass(totalBytes)
+				if len(chunkPlan.SourceChunks) > 0 &&
+					!plannerRefreshWithQueuedDebt &&
+					tailFillMinStaleRatio > 0 &&
+					db.foregroundVlogGenerationLowPressureFor(now) &&
+					len(chunkPlan.SourceChunks) < vlogGenerationRewriteTailPackingMaxSegments {
+					fillOpts := planOpts
+					if fillOpts.MinSegmentStaleRatio == 0 || tailFillMinStaleRatio < fillOpts.MinSegmentStaleRatio {
+						fillOpts.MinSegmentStaleRatio = tailFillMinStaleRatio
+					}
+					fillOpts.MaxSourceSegments = vlogGenerationRewriteTailPackingMaxSegments
+					fillOpts.AllowLiveOnlySelection = true
+					fillPlan, fillErr, fillDur := runChunkPlanWithOpts(fillOpts)
+					db.debugVlogMaintf(
+						"rewrite_chunk_plan stale_ratio_fill max_segments=%d min_ratio=%.6f chunk_bytes=%d selected=%d/%d selected_bytes_total=%d selected_bytes_live=%d selected_bytes_stale=%d total_bytes=%d live_bytes=%d stale_bytes=%d dur_ms=%.3f err=%v",
+						fillOpts.MaxSourceSegments,
+						fillOpts.MinSegmentStaleRatio,
+						fillPlan.ChunkBytes,
+						fillPlan.ChunksSelected,
+						fillPlan.ChunksTotal,
+						fillPlan.SelectedBytesTotal,
+						fillPlan.SelectedBytesLive,
+						fillPlan.SelectedBytesStale,
+						fillPlan.BytesTotal,
+						fillPlan.BytesLive,
+						fillPlan.BytesStale,
+						float64(fillDur.Microseconds())/1000,
+						fillErr,
+					)
+					db.observeVlogGenerationRewriteChunkPlanOutcomeWithDuration(fillPlan, fillErr, fillDur)
+					if fillErr != nil {
+						db.observeVlogGenerationRewriteChunkPlanSnapshot(fillPlan, fillErr)
+						db.clearVlogGenerationRewriteAgeBlockedUntil()
+						if isVlogGenerationPlannerCanceled(fillErr) {
+							db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
+							return
+						}
+						db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerError)
+						if db.notifyError != nil {
+							db.notifyError(fmt.Errorf("cachingdb: generational stale-ratio chunk fill plan: %w", fillErr))
+						}
+						return
+					}
+					if len(fillPlan.SourceChunks) > 0 {
+						chunkPlan = mergeVlogGenerationRewriteChunkPlans(chunkPlan, fillPlan)
+					}
+				}
 				db.observeVlogGenerationRewriteChunkPlanSnapshot(chunkPlan, nil)
 				updatePlanTimestamp = true
 				if len(chunkPlan.SourceChunks) > 0 {
@@ -16944,6 +17060,52 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 					return
 				}
 				db.observeVlogGenerationRewritePlanPenaltyFilter(beforePenaltyFilter, len(plan.SourceFileIDs))
+				tailFillMinStaleRatio := db.vlogGenerationRewriteMinStaleRatioForTailPass(totalBytes)
+				if len(plan.SourceFileIDs) > 0 &&
+					!plannerRefreshWithQueuedDebt &&
+					tailFillMinStaleRatio > 0 &&
+					db.foregroundVlogGenerationLowPressureFor(now) &&
+					len(plan.SourceFileIDs) < vlogGenerationRewriteTailPackingMaxSegments {
+					fillOpts := planOpts
+					if fillOpts.MinSegmentStaleRatio == 0 || tailFillMinStaleRatio < fillOpts.MinSegmentStaleRatio {
+						fillOpts.MinSegmentStaleRatio = tailFillMinStaleRatio
+					}
+					fillOpts.MaxSourceSegments = vlogGenerationRewriteTailPackingMaxSegments
+					fillOpts.AllowLiveOnlySelection = true
+					fillPlan, fillErr, fillDur := runPlanWithOpts(fillOpts)
+					db.debugVlogMaintf(
+						"rewrite_plan stale_ratio_fill max_segments=%d min_ratio=%.6f selected=%d/%d selected_bytes_total=%d selected_bytes_live=%d selected_bytes_stale=%d total_bytes=%d live_bytes=%d stale_bytes=%d dur_ms=%.3f err=%v",
+						fillOpts.MaxSourceSegments,
+						fillOpts.MinSegmentStaleRatio,
+						fillPlan.SegmentsSelected,
+						fillPlan.SegmentsTotal,
+						fillPlan.SelectedBytesTotal,
+						fillPlan.SelectedBytesLive,
+						fillPlan.SelectedBytesStale,
+						fillPlan.BytesTotal,
+						fillPlan.BytesLive,
+						fillPlan.BytesStale,
+						float64(fillDur.Microseconds())/1000,
+						fillErr,
+					)
+					db.observeVlogGenerationRewritePlanOutcomeWithDuration(fillPlan, fillErr, fillDur)
+					if fillErr != nil {
+						db.observeVlogGenerationRewritePlanSnapshot(fillPlan, fillErr)
+						db.clearVlogGenerationRewriteAgeBlockedUntil()
+						if isVlogGenerationPlannerCanceled(fillErr) {
+							db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
+							return
+						}
+						db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerError)
+						if db.notifyError != nil {
+							db.notifyError(fmt.Errorf("cachingdb: generational stale-ratio fill plan: %w", fillErr))
+						}
+						return
+					}
+					if len(fillPlan.SourceFileIDs) > 0 {
+						plan = mergeVlogGenerationRewritePlans(plan, fillPlan)
+					}
+				}
 				db.observeVlogGenerationRewritePlanSnapshot(plan, nil)
 				updatePlanTimestamp = true
 				if len(plan.SourceFileIDs) > 0 {
@@ -17143,6 +17305,52 @@ planned:
 				return
 			}
 			db.observeVlogGenerationRewritePlanPenaltyFilter(beforePenaltyFilter, len(plan.SourceFileIDs))
+			tailFillMinStaleRatio := db.vlogGenerationRewriteMinStaleRatioForTailPass(totalBytes)
+			if len(plan.SourceFileIDs) > 0 &&
+				tailFillMinStaleRatio > 0 &&
+				db.foregroundVlogGenerationLowPressureFor(now) &&
+				len(plan.SourceFileIDs) < vlogGenerationRewriteTailPackingMaxSegments {
+				fillOpts := planOpts
+				if fillOpts.MinSegmentStaleRatio == 0 || tailFillMinStaleRatio < fillOpts.MinSegmentStaleRatio {
+					fillOpts.MinSegmentStaleRatio = tailFillMinStaleRatio
+				}
+				fillOpts.MaxSourceSegments = vlogGenerationRewriteTailPackingMaxSegments
+				fillOpts.AllowLiveOnlySelection = true
+				fillPlan, fillErr, fillDur := runPlanWithOpts(fillOpts)
+				db.debugVlogMaintf(
+					"rewrite_plan pre_rewrite_fill max_segments=%d min_ratio=%.6f selected=%d/%d selected_bytes_total=%d selected_bytes_live=%d selected_bytes_stale=%d total_bytes=%d live_bytes=%d stale_bytes=%d dur_ms=%.3f err=%v",
+					fillOpts.MaxSourceSegments,
+					fillOpts.MinSegmentStaleRatio,
+					fillPlan.SegmentsSelected,
+					fillPlan.SegmentsTotal,
+					fillPlan.SelectedBytesTotal,
+					fillPlan.SelectedBytesLive,
+					fillPlan.SelectedBytesStale,
+					fillPlan.BytesTotal,
+					fillPlan.BytesLive,
+					fillPlan.BytesStale,
+					float64(fillDur.Microseconds())/1000,
+					fillErr,
+				)
+				db.observeVlogGenerationRewritePlanOutcomeWithDuration(fillPlan, fillErr, fillDur)
+				if fillErr != nil {
+					db.observeVlogGenerationRewritePlanSnapshot(fillPlan, fillErr)
+					db.clearVlogGenerationRewriteAgeBlockedUntil()
+					if isVlogGenerationPlannerCanceled(fillErr) {
+						db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
+						return
+					}
+					db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerError)
+					db.vlogGenerationRemapFailures.Add(1)
+					if db.notifyError != nil {
+						db.notifyError(fmt.Errorf("cachingdb: generational pre-rewrite fill plan: %w", fillErr))
+					}
+					return
+				}
+				if len(fillPlan.SourceFileIDs) > 0 {
+					plan = mergeVlogGenerationRewritePlans(plan, fillPlan)
+				}
+			}
 			db.observeVlogGenerationRewritePlanSnapshot(plan, nil)
 		}
 		if len(plan.SourceFileIDs) == 0 {

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -5829,6 +5829,179 @@ func TestVlogGenerationRewritePlan_StagesFreshStaleRatioDebtBeforeRewrite(t *tes
 	}
 }
 
+func TestVlogGenerationRewritePlan_StagesTailFilledFreshStaleRatioDebt_FastModes(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+
+	totalBytes := vlogGenerationRewriteEfficacyMinTotalBytes + 1
+	basePlan := backenddb.ValueLogRewritePlan{
+		SourceFileIDs: []uint32{25},
+		SelectedSegments: []backenddb.ValueLogRewritePlanSegment{
+			{FileID: 25, BytesTotal: 256, BytesLive: 32, BytesStale: 224, StaleRatio: 0.875},
+		},
+		SegmentsTotal:      4,
+		SegmentsSelected:   1,
+		BytesTotal:         totalBytes,
+		BytesLive:          totalBytes - 224,
+		BytesStale:         224,
+		SelectedBytesTotal: 256,
+		SelectedBytesLive:  32,
+		SelectedBytesStale: 224,
+	}
+	fillPlan := backenddb.ValueLogRewritePlan{
+		SourceFileIDs: []uint32{25, 26, 27, 28},
+		SelectedSegments: []backenddb.ValueLogRewritePlanSegment{
+			{FileID: 25, BytesTotal: 256, BytesLive: 32, BytesStale: 224, StaleRatio: 0.875},
+			{FileID: 26, BytesTotal: 256, BytesLive: 256, BytesStale: 0, StaleRatio: 0},
+			{FileID: 27, BytesTotal: 256, BytesLive: 256, BytesStale: 0, StaleRatio: 0},
+			{FileID: 28, BytesTotal: 256, BytesLive: 256, BytesStale: 0, StaleRatio: 0},
+		},
+		SegmentsTotal:      4,
+		SegmentsSelected:   4,
+		BytesTotal:         totalBytes,
+		BytesLive:          totalBytes - 224,
+		BytesStale:         224,
+		SelectedBytesTotal: 1024,
+		SelectedBytesLive:  800,
+		SelectedBytesStale: 224,
+	}
+
+	cases := []struct {
+		name       string
+		disableWAL bool
+	}{
+		{name: "fast", disableWAL: true},
+		{name: "wal_on_fast", disableWAL: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+			if err != nil {
+				t.Fatalf("open backend: %v", err)
+			}
+			recorder := &rewriteBudgetRecordingBackend{
+				DB:              backend,
+				rewriteResponse: backenddb.ValueLogRewriteStats{BytesBefore: 1024, BytesAfter: 800, RecordsCopied: 4},
+			}
+			fillCalls := 0
+			recorder.planFn = func(opts backenddb.ValueLogRewriteOnlineOptions) (backenddb.ValueLogRewritePlan, error) {
+				if opts.AllowLiveOnlySelection {
+					fillCalls++
+					if got, want := opts.MaxSourceSegments, vlogGenerationRewriteTailPackingMaxSegments; got != want {
+						t.Fatalf("stale-ratio fill max source segments=%d want %d", got, want)
+					}
+					if got, want := opts.MinSegmentStaleRatio, vlogGenerationRewriteTailMinSegmentStaleRatio; got != want {
+						t.Fatalf("stale-ratio fill min ratio=%f want %f", got, want)
+					}
+					return fillPlan, nil
+				}
+				return basePlan, nil
+			}
+
+			db, cleanup := openRewriteQueueTestDBWithWALMode(t, dir, recorder, tc.disableWAL)
+			t.Cleanup(cleanup)
+			skipRetainedPrune(db)
+			setRetainedBytesForPeriodicRewriteTest(t, db, totalBytes)
+			db.valueLogRewriteTriggerBytes = 0
+			db.valueLogRewriteTriggerRatioPPM = 500000
+			db.valueLogGenerationHotTarget = 0
+			forceVlogMaintenanceIdle(db)
+			db.lastForegroundWriteUnixNano.Store(time.Now().Add(-vlogForegroundQuietWindow - time.Second).UnixNano())
+			db.lastForegroundReadUnixNano.Store(0)
+			db.mutableBytes.Store(0)
+			db.queueBacklogBytes.Store(0)
+			db.vlogGenerationRewriteBudgetTokensBytes.Store(1 << 20)
+			db.vlogGenerationRewriteBudgetLastUnixNano.Store(time.Now().Add(-time.Second).UnixNano())
+			retained := db.refreshVlogGenerationPlannerRetainedState()
+			if got, want := retained.BytesTotal, totalBytes; got != want {
+				t.Fatalf("retained bytes=%d want %d", got, want)
+			}
+			if got, want := db.vlogGenerationRewriteMinStaleRatioForTailPass(retained.BytesTotal), vlogGenerationRewriteTailMinSegmentStaleRatio; got != want {
+				t.Fatalf("tail fill min ratio=%f want %f", got, want)
+			}
+			if !db.foregroundVlogGenerationLowPressureFor(time.Now()) {
+				t.Fatal("foreground low pressure=false want true")
+			}
+
+			db.maybeRunVlogGenerationMaintenance(false)
+
+			_, planCalls := recorder.recordedPlan()
+			stats := db.Stats()
+			if fillCalls != 1 {
+				t.Fatalf(
+					"stale-ratio fill calls=%d want 1 (plan_calls=%d selected_segments=%q selected_stale=%q result=%q)",
+					fillCalls,
+					planCalls,
+					stats["treedb.cache.vlog_generation.rewrite.plan_last_selected_segments"],
+					stats["treedb.cache.vlog_generation.rewrite.plan_last_selected_bytes_stale"],
+					stats["treedb.cache.vlog_generation.rewrite.plan_last_result"],
+				)
+			}
+			if planCalls != 2 {
+				t.Fatalf("plan calls after first stale-ratio pass=%d want=2", planCalls)
+			}
+			if _, calls := recorder.recordedRewrite(); calls != 0 {
+				t.Fatalf("rewrite calls after first stale-ratio pass=%d want=0", calls)
+			}
+
+			ledger, err := db.currentVlogGenerationRewriteLedger()
+			if err != nil {
+				t.Fatalf("current rewrite ledger: %v", err)
+			}
+			gotLedgerIDs := make([]uint32, 0, len(ledger))
+			for _, seg := range ledger {
+				gotLedgerIDs = append(gotLedgerIDs, seg.FileID)
+			}
+			if got, want := gotLedgerIDs, []uint32{25, 26, 27, 28}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("rewrite ledger after first stale-ratio pass=%v want=%v", got, want)
+			}
+			stagePending, _, err := db.currentVlogGenerationRewriteStage()
+			if err != nil {
+				t.Fatalf("current rewrite stage: %v", err)
+			}
+			if !stagePending {
+				t.Fatal("rewrite stage pending=false want true after merged stale-ratio plan")
+			}
+			if got, want := stats["treedb.cache.vlog_generation.rewrite.plan_last_selected_segments"], "4"; got != want {
+				t.Fatalf("plan last selected segments=%q want %q", got, want)
+			}
+			if got, want := stats["treedb.cache.vlog_generation.rewrite.plan_last_selected_bytes_stale"], "224"; got != want {
+				t.Fatalf("plan last selected stale bytes=%q want %q", got, want)
+			}
+			if got, want := stats["treedb.cache.vlog_generation.rewrite.debt_last_deferral_reason"], "stage_confirm"; got != want {
+				t.Fatalf("debt last deferral reason=%q want %q", got, want)
+			}
+
+			db.vlogGenerationLastRewritePlanUnixNano.Store(0)
+			db.vlogGenerationLastRewriteUnixNano.Store(0)
+			forceRewriteStageConfirmDue(t, db)
+			forceVlogMaintenanceIdle(db)
+			db.maybeRunVlogGenerationMaintenanceWithOptions(false, vlogGenerationMaintenanceOptions{
+				bypassQuiet:           true,
+				skipRetainedPruneWait: true,
+				skipCheckpoint:        false,
+				rewriteDebtDrain:      true,
+				debugSource:           "rewrite_stage_confirm",
+			})
+
+			rewriteOpts, rewriteCalls := recorder.recordedRewrite()
+			if rewriteCalls != 1 {
+				t.Fatalf("rewrite calls after stage-confirm pass=%d want=1", rewriteCalls)
+			}
+			if got, want := rewriteOpts.SourceFileIDs, []uint32{25, 26}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("rewrite SourceFileIDs after staged stale-ratio pass=%v want=%v", got, want)
+			}
+			queue, err := db.currentVlogGenerationRewriteQueue()
+			if err != nil {
+				t.Fatalf("current rewrite queue after first stage-confirm pass: %v", err)
+			}
+			if got, want := queue, []uint32{27, 28}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("rewrite queue after first stage-confirm pass=%v want=%v", got, want)
+			}
+		})
+	}
+}
+
 func TestVlogGenerationRewritePlan_StageConfirmationExecutesConfirmedSubset(t *testing.T) {
 	prepareDirectSchedulerTest(t)
 

--- a/worklog/2026-04-10-authoritative-catalogs.md
+++ b/worklog/2026-04-10-authoritative-catalogs.md
@@ -347,3 +347,47 @@
 
 - `fast` should no longer stage a single tiny stale segment and then confirm only that one segment when low-pressure tail fill can safely widen the same debt set
 - the bounded executor still limits each confirm pass, but the queue now retains the widened tail-packed debt instead of repeatedly rediscovering only the initial tiny stale segment
+
+#### Celestia result
+
+- artifact root:
+  - `artifacts/celestia_profile_signals/tail_fill_staged_plans_20260411051500`
+- outcome:
+  - discard this slice
+
+##### `wal_on_fast`
+
+- compared with the prior `#962` baseline (`skip_leafref_nonleaf_20260410181120`):
+  - `t_sync`: `260s -> 260s` (flat)
+  - `max_rss_kb`: `10785428 -> 13523620` (`+25.39%`)
+  - minute-15 `app_bytes`: `3034120332 -> 3264884377` (`+230764045`, `+7.61%`)
+  - minute-15 `wal_bytes`: `2968366016 -> 3199393280` (`+231027264`, `+7.78%`)
+  - minute-15 `rewrite_runs`: `11 -> 7`
+  - minute-15 `queued_exec_runs`: `10 -> 6`
+- interpretation:
+  - widening the plan did not produce more effective reclaim
+  - it reduced steady-state rewrite throughput and materially increased live size and memory
+
+##### `fast`
+
+- compared with the prior `#962` baseline (`skip_leafref_nonleaf_20260410181120`):
+  - `t_sync`: `314s -> 423s` (`+109s`, `+34.71%`)
+  - `max_rss_kb`: `12242324 -> 12165088` (`-0.63%`, effectively flat)
+  - minute-15 `app_bytes`: `3238457902 -> 3463660421` (`+225202519`, `+6.95%`)
+  - minute-15 `wal_bytes`: `3179812963 -> 3407670399` (`+227857436`, `+7.17%`)
+  - minute-15 `rewrite_runs`: `10 -> 10` (flat)
+  - minute-15 `plan_last_selected_segments`: `1 -> 2`
+  - minute-15 `plan_last_selected_bytes_stale`: `2669693 -> 176209445`
+  - minute-15 visible stale debt dropped from about `373 MB` to about `188 MB`
+- interpretation:
+  - the slice widened the staged plan exactly as intended
+  - but it spent the rewrite budget on larger staged work without converting that into better minute-15 size
+  - sync time regressed materially, so this is not an acceptable trade
+
+##### Conclusion
+
+- the local architectural idea was real:
+  - the scheduler did stop collapsing to a single-segment stage-confirm plan
+- but the system result was wrong:
+  - wider staged debt increased work-in-flight and write amplification without improving minute-15 live size
+- `#963` should stay open only as a failed experiment record and should not be merged in its current form

--- a/worklog/2026-04-10-authoritative-catalogs.md
+++ b/worklog/2026-04-10-authoritative-catalogs.md
@@ -232,3 +232,118 @@
 - the remaining structural gap is narrower and more explicit:
   - when selected source segments do contain live outer-leaf pages, execution still rediscover those pages by recursively traversing the tree
   - removing that cost still requires a stronger leafref locator form than the current key-only locator catalog
+
+### Post-`#962` Celestia Validation
+
+- artifact root:
+  - `artifacts/celestia_profile_signals/skip_leafref_nonleaf_20260410181120`
+- fixed sync stop height:
+  - `10611331`
+- candidate head:
+  - `9f0476d9` `treedb: skip leafref rewrite on non-leaf sources`
+
+#### `wal_on_fast`
+
+- `dwell15m`
+  - `t_sync = 260s`
+  - `t_total = 1160s`
+  - `max_rss_kb = 10785428`
+  - `max_hwm_kb = 10816860`
+  - minute 15:
+    - `app_bytes = 3034120332`
+    - `wal_bytes = 2968366016`
+    - `maintenance_attempts = 36`
+    - `maintenance_acquired = 33`
+    - `maintenance_with_rewrite = 11`
+    - `rewrite_runs = 11`
+    - `queued_exec_runs = 10`
+    - `plan_runs = 26`
+    - `plan_last_result = empty`
+    - `debt_visible_bytes_stale = 0`
+- post-dwell offline maintenance:
+  - `post_dwell_app_bytes = 3030649985`
+  - `post_dwell_post_rewrite_app_bytes = 2082847549`
+  - remaining offline gap:
+    - `947802436 bytes`
+    - `31.27%`
+
+#### `fast`
+
+- `dwell15m`
+  - `t_sync = 314s`
+  - `t_total = 1214s`
+  - `max_rss_kb = 12242324`
+  - `max_hwm_kb = 12833272`
+  - minute 15:
+    - `app_bytes = 3238457902`
+    - `wal_bytes = 3179812963`
+    - `maintenance_attempts = 109`
+    - `maintenance_acquired = 109`
+    - `maintenance_with_rewrite = 10`
+    - `rewrite_runs = 10`
+    - `queued_exec_runs = 10`
+    - `plan_runs = 64`
+    - `plan_last_result = selected`
+    - `plan_last_selected_segments = 1`
+    - `plan_last_selected_bytes_stale = 2669693`
+    - `debt_visible_source = ledger`
+    - `debt_visible_bytes_stale = 373434549`
+    - `debt_last_deferral_reason = stage_confirm`
+    - `rewrite_ledger_bytes_total = 1073746546`
+    - `rewrite_ledger_bytes_stale = 373434549`
+- post-dwell offline maintenance:
+  - `post_dwell_app_bytes = 3246018511`
+  - `post_dwell_post_rewrite_app_bytes = 2116498171`
+  - remaining offline gap:
+    - `1129520340 bytes`
+    - `34.80%`
+
+#### Conclusion
+
+- `#962` materially improved `wal_on_fast`:
+  - minute-15 size and max RSS both dropped
+  - rewrite activity increased from `9` to `11` runs
+- `#962` did not close the `fast` planner gap:
+  - the scheduler still saw about `373 MB` of stale debt at minute 15
+  - the last staged plan only selected about `2.7 MB` of stale bytes in one segment
+  - that left a large offline rewrite delta even though runtime rewrite was active
+
+### Next Slice
+
+- target:
+  - let a small non-empty stale-ratio plan piggyback the existing low-pressure tail-fill path instead of blocking it
+- reason:
+  - the current scheduler only tail-fills after the dedicated tail-compaction probe when the generic stale-ratio plan is empty
+  - in `fast`, the generic path can select a tiny stale segment, set `haveRewritePlan = true`, and skip the fill opportunity that would pack adjacent live-only tail segments into the same staged debt set
+
+### Second-Sprint Slice 6
+
+- status:
+  - complete locally on top of `9f0476d9`
+- goal:
+  - stop a small non-empty stale-ratio / pre-rewrite plan from collapsing stage-confirm execution back to a single segment when low-pressure tail packing could safely widen the staged debt set
+
+#### Landed locally
+
+- added plan-merging support for both segment and chunk rewrite plans in `TreeDB/caching/db.go`
+- extended the scheduler so low-pressure tail-fill can piggyback onto:
+  - sparse stale-ratio trigger plans
+  - ordinary pre-rewrite plans once rewrite is already justified
+- kept stale-ratio stage semantics intact:
+  - the widened plan is still staged/confirmed as stale-ratio debt
+  - the first stage-confirm execution remains bounded by the normal queued rewrite cap instead of turning into an unbounded tail-packing burst
+- added a focused cross-profile scheduler regression test:
+  - `TestVlogGenerationRewritePlan_StagesTailFilledFreshStaleRatioDebt_FastModes`
+  - proves `fast` and `wal_on_fast` both stage the widened debt set
+  - proves the first stage-confirm rewrite executes more than the single stale segment and preserves the remaining widened queue instead of collapsing back to one-segment debt
+
+#### Validation
+
+- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewritePlan_StagesTailFilledFreshStaleRatioDebt_FastModes|VlogGenerationRewritePlan_StagesFreshStaleRatioDebtBeforeRewrite|VlogGenerationMaintenance_PeriodicTailPlanFillAddsLiveOnlySegments_FastModes|VlogGenerationMaintenance_PeriodicTailPackingRunsAfterEmptyTailPlan_FastModes)$' -count=1`
+- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewrite_|Checkpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity)' -count=1`
+- `GOWORK=off go test ./TreeDB/caching -count=1`
+
+#### Expected effect
+
+- `fast` should no longer stage a single tiny stale segment and then confirm only that one segment when low-pressure tail fill can safely widen the same debt set
+- the bounded executor still limits each confirm pass, but the queue now retains the widened tail-packed debt instead of repeatedly rediscovering only the initial tiny stale segment


### PR DESCRIPTION
## Summary
- let small non-empty stale-ratio and pre-rewrite plans piggyback low-pressure tail fill instead of staging only the initial tiny stale segment
- preserve stale-ratio stage-confirm semantics while widening the staged debt set and keeping the bounded executor cap intact
- add regression coverage for `fast` and `wal_on_fast`, and record the latest Celestia evidence plus this slice in the worklog

## Validation
- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewritePlan_StagesTailFilledFreshStaleRatioDebt_FastModes|VlogGenerationRewritePlan_StagesFreshStaleRatioDebtBeforeRewrite|VlogGenerationMaintenance_PeriodicTailPlanFillAddsLiveOnlySegments_FastModes|VlogGenerationMaintenance_PeriodicTailPackingRunsAfterEmptyTailPlan_FastModes)$' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewrite_|Checkpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity)' -count=1`
- `GOWORK=off go test ./TreeDB/caching -count=1`

## Notes
- this is stacked on `codex/948-skip-leafref-traversal-nonleaf-sources`
- no new Celestia run is included in this slice yet; the intended effect is to improve the remaining `fast`-mode minute-15 gap identified in the worklog