### PR TITLE
Improve large value-log frame grouping

### DIFF
--- a/.github/scripts/check_vlog_auto_incompressible.go
+++ b/.github/scripts/check_vlog_auto_incompressible.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	reBatchWrite = regexp.MustCompile(`Batch Write / .* = ([0-9][0-9,]*(?:\.[0-9]+)?)`)
-	reWALValue   = regexp.MustCompile(`maindb/wal:[^\n]*\bvalue=([0-9]+(?:\.[0-9]+)?\s*[A-Za-z]+)`)
+	reValueLog   = regexp.MustCompile(`maindb/(?:value_vlog|wal):[^\n]*\bvalue=([0-9]+(?:\.[0-9]+)?\s*[A-Za-z]+)`)
 )
 
 type runMetrics struct {
@@ -30,7 +30,7 @@ func main() {
 	flag.StringVar(&offLogPath, "off-log", "", "path to unified_bench output for treedb_vlog_off")
 	flag.StringVar(&autoLogPath, "auto-log", "", "path to unified_bench output for treedb_vlog_auto")
 	flag.Float64Var(&minThroughputFrac, "min-throughput-frac", 0.95, "minimum allowed auto/off batch-write throughput fraction")
-	flag.Float64Var(&maxSizeFrac, "max-size-frac", 1.02, "maximum allowed auto/off WAL value-bytes fraction")
+	flag.Float64Var(&maxSizeFrac, "max-size-frac", 1.02, "maximum allowed auto/off value-log bytes fraction")
 	flag.Parse()
 
 	if offLogPath == "" || autoLogPath == "" {
@@ -61,7 +61,7 @@ func main() {
 	sizeFrac := auto.WALValue / off.WALValue
 
 	fmt.Printf("incompressible gate: off_ops=%.0f auto_ops=%.0f throughput_frac=%.4f (min=%.4f)\n", off.OpsPerSec, auto.OpsPerSec, throughputFrac, minThroughputFrac)
-	fmt.Printf("incompressible gate: off_wal_value=%.0f auto_wal_value=%.0f size_frac=%.4f (max=%.4f)\n", off.WALValue, auto.WALValue, sizeFrac, maxSizeFrac)
+	fmt.Printf("incompressible gate: off_value_log=%.0f auto_value_log=%.0f size_frac=%.4f (max=%.4f)\n", off.WALValue, auto.WALValue, sizeFrac, maxSizeFrac)
 
 	fail := false
 	if throughputFrac < minThroughputFrac {
@@ -94,13 +94,13 @@ func parseMetrics(path string) (runMetrics, error) {
 		return runMetrics{}, fmt.Errorf("parse ops: %w", err)
 	}
 
-	walMatch := reWALValue.FindStringSubmatch(s)
+	walMatch := reValueLog.FindStringSubmatch(s)
 	if len(walMatch) != 2 {
-		return runMetrics{}, fmt.Errorf("missing maindb/wal value bytes")
+		return runMetrics{}, fmt.Errorf("missing TreeDB value-log bytes")
 	}
 	walBytes, err := parseBytesToken(walMatch[1])
 	if err != nil {
-		return runMetrics{}, fmt.Errorf("parse wal value bytes: %w", err)
+		return runMetrics{}, fmt.Errorf("parse value-log bytes: %w", err)
 	}
 
 	return runMetrics{OpsPerSec: ops, WALValue: walBytes}, nil

--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -297,6 +297,7 @@ func TestCachingDB_AutoCheckpoint_SizeTrigger_TrimsWAL(t *testing.T) {
 	if got := db.effectiveWALBytes(); got < 1<<20 {
 		t.Fatalf("expected WAL bytes >= 1MiB, got %d", got)
 	}
+	db.autoCheckpointMaxWALBytes.Store(1 << 20)
 	db.autoCheckpointSizeArmed.Store(true)
 	db.maybeAutoCheckpoint(1<<20, autoCheckpointModeSize)
 
@@ -352,8 +353,6 @@ func TestCachingDB_AutoCheckpoint_SizeTrigger_SeedsExistingWAL(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 	db.testSkipVlogCheckpointKick = true
-
-	db.StartAutoCheckpoint(0, 1<<20 /* 1MiB */, 0)
 
 	if err := db.Set([]byte("k"), []byte("v")); err != nil {
 		t.Fatalf("Set: %v", err)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3963,7 +3963,7 @@ func (db *DB) cleanupOrphanedRetainedValueLog(path string) bool {
 	db.untrackValueLogSegmentLocked(path)
 	db.mu.Unlock()
 	db.forgetValueLogRetain(path)
-	db.syncDirBestEffort(db.dir)
+	db.syncDirBestEffort(db.valueLogDir)
 	return true
 }
 
@@ -4923,7 +4923,7 @@ func (db *DB) pruneRetainedValueLogsWithObserved(force bool, observedSourceIDs m
 		}
 	}
 	if removed {
-		db.syncDirBestEffort(db.dir)
+		db.syncDirBestEffort(db.valueLogDir)
 	}
 	return out
 }
@@ -6123,6 +6123,7 @@ type DB struct {
 
 	// Config
 	dir                                               string
+	valueLogDir                                       string
 	flushThreshold                                    int64
 	memtableCap                                       int
 	memtableMode                                      atomic.Uint32
@@ -8123,13 +8124,18 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		return nil, err
 	}
 
-	// Ensure wal dir exists
+	// Ensure split log dirs exist.
 	walDir := filepath.Join(dir, "wal")
-	if err := os.MkdirAll(walDir, 0700); err != nil {
-		return nil, err
+	valueLogDir := filepath.Join(dir, "value_vlog")
+	leafLogDir := filepath.Join(dir, "leaf_vlog")
+	for _, path := range []string{walDir, valueLogDir, leafLogDir} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			return nil, err
+		}
 	}
 	warnInsecureDir(walDir, opts.NotifyError)
-	segments, _ := listNonEmptyLogSegments(walDir)
+	warnInsecureDir(valueLogDir, opts.NotifyError)
+	segments, _ := listNonEmptySplitLogSegments(walDir, valueLogDir)
 	// Cached value-log RIDs remain globally unique across reopen/rewrite cycles.
 	// Until we persist nextRID separately, opening must recover the max on-disk
 	// RID here rather than risk reusing low RIDs after a clean reopen.
@@ -8293,7 +8299,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		}
 		mutableShards[i] = memShard{mem: mt}
 	}
-	reader, err := valuelog.NewManager(walDir)
+	reader, err := valuelog.NewManager(valueLogDir)
 	if err != nil {
 		return nil, err
 	}
@@ -8494,6 +8500,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	}
 	db := &DB{
 		dir:                                  walDir,
+		valueLogDir:                          valueLogDir,
 		backend:                              backend,
 		flushThreshold:                       opts.FlushThreshold,
 		memtableCap:                          memCap,
@@ -20030,7 +20037,7 @@ func (db *DB) rotateValueLogMuHeld(l *lane) error {
 		hadClosedPrev bool
 	)
 	name := valueLogName(l.id, nextSeq)
-	path := filepath.Join(db.dir, name)
+	path := filepath.Join(db.valueLogDir, name)
 	fileID, err := valuelog.EncodeFileID(uint32(l.id), uint32(nextSeq))
 	if err != nil {
 		return err
@@ -26820,6 +26827,38 @@ func listNonEmptyLogSegments(walDir string) (segments []logSegmentInfo, nonEmpty
 			nonEmptyBytes += info.Size()
 		}
 	}
+	return segments, nonEmptyBytes
+}
+
+func listNonEmptySplitLogSegments(walDir, valueLogDir string) (segments []logSegmentInfo, nonEmptyBytes int64) {
+	walSegments, walBytes := listNonEmptyLogSegments(walDir)
+	for _, seg := range walSegments {
+		if seg.valueLog {
+			continue
+		}
+		segments = append(segments, seg)
+	}
+	nonEmptyBytes += walBytes
+	vlogSegments, vlogBytes := listNonEmptyLogSegments(valueLogDir)
+	for _, seg := range vlogSegments {
+		if !seg.valueLog {
+			continue
+		}
+		segments = append(segments, seg)
+	}
+	nonEmptyBytes += vlogBytes
+	sort.Slice(segments, func(i, j int) bool {
+		if segments[i].lane != segments[j].lane {
+			return segments[i].lane < segments[j].lane
+		}
+		if segments[i].seq != segments[j].seq {
+			return segments[i].seq < segments[j].seq
+		}
+		if segments[i].valueLog != segments[j].valueLog {
+			return !segments[i].valueLog && segments[j].valueLog
+		}
+		return segments[i].path < segments[j].path
+	})
 	return segments, nonEmptyBytes
 }
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -5515,8 +5515,77 @@ func (db *DB) runWithBackendMaintenanceOptions(opts backendMaintenanceOptions, f
 			return err
 		}
 	}
+	var fnErr error
 	if fn != nil {
-		return fn()
+		fnErr = fn()
+	}
+	reconcileErr := db.reconcileSplitValueLogWritersAfterBackendMaintenance()
+	if fnErr != nil {
+		if reconcileErr != nil {
+			return errors.Join(fnErr, reconcileErr)
+		}
+		return fnErr
+	}
+	return reconcileErr
+}
+
+func (db *DB) reconcileSplitValueLogWritersAfterBackendMaintenance() error {
+	if db == nil {
+		return nil
+	}
+	if db.valueLogReader != nil {
+		if err := db.valueLogReader.Refresh(); err != nil {
+			return err
+		}
+	}
+	if !db.splitValueLogEnabled() || !db.valueLogEnabled() {
+		return nil
+	}
+	segments, _ := listNonEmptySplitLogSegments(db.dir, db.valueLogDir, db.leafLogDir)
+	maxSeqByLane := make(map[int]int, len(db.lanes)+1)
+	for _, seg := range segments {
+		if !seg.valueLog {
+			continue
+		}
+		if seg.seq > maxSeqByLane[seg.lane] {
+			maxSeqByLane[seg.lane] = seg.seq
+		}
+	}
+	for i := range db.lanes {
+		if err := db.advanceValueLogWriterPastObservedSeq(&db.lanes[i], maxSeqByLane[db.lanes[i].id]); err != nil {
+			return err
+		}
+	}
+	if db.indexOuterLeavesInValueLog {
+		if err := db.advanceValueLogWriterPastObservedSeq(&db.leafLog, maxSeqByLane[leafLogLaneID]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (db *DB) advanceValueLogWriterPastObservedSeq(l *lane, observedMaxSeq int) error {
+	if db == nil || l == nil || observedMaxSeq <= 0 {
+		return nil
+	}
+	l.vlogMu.Lock()
+	defer l.vlogMu.Unlock()
+	if observedMaxSeq <= l.vlogSeq {
+		return nil
+	}
+	if l.vlog == nil {
+		l.vlogSeq = observedMaxSeq
+		l.vlogPath = ""
+		l.vlogCaps = vlogWriterCaps{}
+		l.vlogModeSet = false
+		l.vlogModeWriter = nil
+		return nil
+	}
+	origSeq := l.vlogSeq
+	l.vlogSeq = observedMaxSeq
+	if err := db.rotateValueLogMuHeld(l); err != nil {
+		l.vlogSeq = origSeq
+		return err
 	}
 	return nil
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4842,7 +4842,10 @@ func (db *DB) pruneRetainedValueLogsWithObserved(force bool, observedSourceIDs m
 			}
 		}
 		if removed {
-			db.syncDirBestEffort(db.dir)
+			db.syncDirBestEffort(db.valueLogDir)
+			if db.leafLogDir != "" {
+				db.syncDirBestEffort(db.leafLogDir)
+			}
 		}
 		return out
 	}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8330,6 +8330,9 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	if maxLaneID+1 > laneCount {
 		laneCount = maxLaneID + 1
 	}
+	if reserveLeafLogLane && laneCount > leafLogLaneID {
+		return nil, fmt.Errorf("cachingdb: IndexOuterLeavesInValueLog reserves lane %d; recovered WAL/value lanes require rebuild before reopen", leafLogLaneID)
+	}
 
 	inlineThreshold := page.DefaultInlineThreshold
 	if provider, ok := backend.(interface{ InlineThreshold() int }); ok {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2534,7 +2534,7 @@ func (db *DB) valueLogDirForLane(l *lane) string {
 	if db == nil {
 		return ""
 	}
-	if l != nil && l.id == leafLogLaneID && db.leafLogDir != "" {
+	if l != nil && db.indexOuterLeavesInValueLog && l == &db.leafLog && l.id == leafLogLaneID && db.leafLogDir != "" {
 		return db.leafLogDir
 	}
 	return db.valueLogDir

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -5544,7 +5544,9 @@ func (db *DB) reconcileSplitValueLogWritersAfterBackendMaintenance() error {
 	if !db.splitValueLogEnabled() || !db.valueLogEnabled() {
 		return nil
 	}
-	segments, _ := listNonEmptySplitLogSegments(db.dir, db.valueLogDir, db.leafLogDir)
+	// In cached mode DB.dir is the wal/ directory, not the DB root.
+	walDir := db.dir
+	segments, _ := listNonEmptySplitLogSegments(walDir, db.valueLogDir, db.leafLogDir)
 	maxSeqByLane := make(map[int]int, len(db.lanes)+1)
 	for _, seg := range segments {
 		if !seg.valueLog {
@@ -5584,13 +5586,7 @@ func (db *DB) advanceValueLogWriterPastObservedSeq(l *lane, observedMaxSeq int) 
 		l.vlogModeWriter = nil
 		return nil
 	}
-	origSeq := l.vlogSeq
-	l.vlogSeq = observedMaxSeq
-	if err := db.rotateValueLogMuHeld(l); err != nil {
-		l.vlogSeq = origSeq
-		return err
-	}
-	return nil
+	return db.rotateValueLogMuHeldToSeq(l, observedMaxSeq+1)
 }
 
 func hashKey(key []byte) uint64 {
@@ -20231,7 +20227,16 @@ func (db *DB) rotateValueLogLocked(l *lane) error {
 }
 
 func (db *DB) rotateValueLogMuHeld(l *lane) error {
-	nextSeq := l.vlogSeq + 1
+	return db.rotateValueLogMuHeldToSeq(l, l.vlogSeq+1)
+}
+
+func (db *DB) rotateValueLogMuHeldToSeq(l *lane, nextSeq int) error {
+	if l == nil {
+		return errWALUnavailable
+	}
+	if nextSeq <= l.vlogSeq {
+		return nil
+	}
 	oldSeq := l.vlogSeq
 	oldPath := l.vlogPath
 	oldLiveBytes := l.vlogLiveBytes.Load()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8135,6 +8135,9 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	}
 	warnInsecureDir(walDir, opts.NotifyError)
 	warnInsecureDir(valueLogDir, opts.NotifyError)
+	if err := ensureNoLegacyMixedWALValueSegments(walDir); err != nil {
+		return nil, err
+	}
 	segments, _ := listNonEmptySplitLogSegments(walDir, valueLogDir)
 	// Cached value-log RIDs remain globally unique across reopen/rewrite cycles.
 	// Until we persist nextRID separately, opening must recover the max on-disk
@@ -26828,6 +26831,29 @@ func listNonEmptyLogSegments(walDir string) (segments []logSegmentInfo, nonEmpty
 		}
 	}
 	return segments, nonEmptyBytes
+}
+
+func ensureNoLegacyMixedWALValueSegments(walDir string) error {
+	entries, err := os.ReadDir(walDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		matched, err := filepath.Match("value-*.log", entry.Name())
+		if err != nil {
+			return err
+		}
+		if matched {
+			return fmt.Errorf("cachingdb: legacy value-log segments found in %s; rebuild required for split wal/value_vlog layout", walDir)
+		}
+	}
+	return nil
 }
 
 func listNonEmptySplitLogSegments(walDir, valueLogDir string) (segments []logSegmentInfo, nonEmptyBytes int64) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -26845,12 +26845,14 @@ func ensureNoLegacyMixedWALValueSegments(walDir string) error {
 		if entry.IsDir() {
 			continue
 		}
-		matched, err := filepath.Match("value-*.log", entry.Name())
-		if err != nil {
-			return err
-		}
-		if matched {
-			return fmt.Errorf("cachingdb: legacy value-log segments found in %s; rebuild required for split wal/value_vlog layout", walDir)
+		for _, pattern := range []string{"value-*.log", "vlog-*.log"} {
+			matched, err := filepath.Match(pattern, entry.Name())
+			if err != nil {
+				return err
+			}
+			if matched {
+				return fmt.Errorf("cachingdb: legacy value-log segments found in %s; rebuild required for split wal/value_vlog layout", walDir)
+			}
 		}
 	}
 	return nil

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2530,6 +2530,29 @@ func (db *DB) releaseLaneSync(l *lane) {
 	db.laneMu.Unlock()
 }
 
+func (db *DB) valueLogDirForLane(l *lane) string {
+	if db == nil {
+		return ""
+	}
+	if l != nil && l.id == leafLogLaneID && db.leafLogDir != "" {
+		return db.leafLogDir
+	}
+	return db.valueLogDir
+}
+
+func (db *DB) valueLogLaneByID(laneID int) *lane {
+	if db == nil || laneID < 0 {
+		return nil
+	}
+	if laneID < len(db.lanes) {
+		return &db.lanes[laneID]
+	}
+	if laneID == leafLogLaneID && db.indexOuterLeavesInValueLog {
+		return &db.leafLog
+	}
+	return nil
+}
+
 func (db *DB) currentValueLogPath(l *lane) string {
 	if l == nil {
 		return ""
@@ -2582,7 +2605,7 @@ func (db *DB) currentValueLogPaths() []string {
 	if db == nil || !db.valueLogEnabled() {
 		return nil
 	}
-	paths := make([]string, 0, len(db.lanes))
+	paths := make([]string, 0, len(db.lanes)+1)
 	for i := range db.lanes {
 		l := &db.lanes[i]
 		if db.splitValueLogEnabled() {
@@ -2598,6 +2621,13 @@ func (db *DB) currentValueLogPaths() []string {
 			paths = append(paths, l.walPath)
 		}
 		l.walMu.Unlock()
+	}
+	if db.indexOuterLeavesInValueLog && db.splitValueLogEnabled() {
+		db.leafLog.vlogMu.Lock()
+		if db.leafLog.vlogPath != "" {
+			paths = append(paths, db.leafLog.vlogPath)
+		}
+		db.leafLog.vlogMu.Unlock()
 	}
 	return paths
 }
@@ -3522,10 +3552,10 @@ func (db *DB) flushValueLogForPtr(ptr page.ValuePtr) error {
 		return nil
 	}
 	laneID, seq := valuelog.DecodeFileID(ptr.FileID)
-	if laneID >= uint32(len(db.lanes)) {
+	l := db.valueLogLaneByID(int(laneID))
+	if l == nil {
 		return nil
 	}
-	l := &db.lanes[laneID]
 	currentSeq := db.currentValueLogSeq(l)
 	if currentSeq == int(seq) {
 		return db.flushValueLogLane(l)
@@ -3681,10 +3711,10 @@ func dispatchBackendValueLogReadBarrier(key uintptr, fileID uint32) error {
 		if db == nil || db.closing.Load() {
 			continue
 		}
-		if int(laneID) >= len(db.lanes) {
+		l := db.valueLogLaneByID(int(laneID))
+		if l == nil {
 			continue
 		}
-		l := &db.lanes[laneID]
 		// Reads against sealed segments do not need a lane flush barrier.
 		if db.currentValueLogSeq(l) != int(seq) {
 			continue
@@ -3721,10 +3751,11 @@ func (db *DB) installBackendValueLogReadBarrier() {
 	if key == 0 {
 		barrierSetter.SetCurrentValueLogReadBarrier(func(fileID uint32) error {
 			laneID, _ := valuelog.DecodeFileID(fileID)
-			if int(laneID) >= len(db.lanes) {
+			l := db.valueLogLaneByID(int(laneID))
+			if l == nil {
 				return nil
 			}
-			return db.flushValueLogLane(&db.lanes[laneID])
+			return db.flushValueLogLane(l)
 		})
 		return
 	}
@@ -3963,7 +3994,7 @@ func (db *DB) cleanupOrphanedRetainedValueLog(path string) bool {
 	db.untrackValueLogSegmentLocked(path)
 	db.mu.Unlock()
 	db.forgetValueLogRetain(path)
-	db.syncDirBestEffort(db.valueLogDir)
+	db.syncDirBestEffort(filepath.Dir(path))
 	return true
 }
 
@@ -4040,6 +4071,18 @@ func (db *DB) valueLogRetainedStatsDetailed() valueLogRetainedGenerationStats {
 				pathClasses[l.vlogPath] = l.vlogGenerationClass
 			}
 			l.vlogMu.Unlock()
+		}
+		if db.indexOuterLeavesInValueLog {
+			db.leafLog.vlogMu.Lock()
+			for path, size := range db.leafLog.vlogClosedSizes {
+				pathSizes[path] = size
+				pathClasses[path] = db.leafLog.vlogGenerationClass
+			}
+			if db.leafLog.vlogPath != "" {
+				currentSizes[db.leafLog.vlogPath] = db.leafLog.vlogLiveBytes.Load()
+				pathClasses[db.leafLog.vlogPath] = db.leafLog.vlogGenerationClass
+			}
+			db.leafLog.vlogMu.Unlock()
 		}
 	} else {
 		for i := range db.lanes {
@@ -4436,6 +4479,9 @@ func (db *DB) allowValueLogPointers() bool {
 				bytes += l.vlogLiveBytes.Load()
 			}
 		}
+		if db.indexOuterLeavesInValueLog && db.leafLog.vlogPath != "" && db.leafLog.vlogPath == db.leafLog.vlogRetainedPath {
+			bytes += db.leafLog.vlogLiveBytes.Load()
+		}
 	}
 	if bytes >= limit {
 		if db.valueLogHardCapWarned.CompareAndSwap(false, true) {
@@ -4602,10 +4648,13 @@ func (db *DB) valueLogClosedSegmentSize(path string) int64 {
 		return 0
 	}
 	laneID, _, _, ok := parseLogSeq(filepath.Base(path))
-	if !ok || laneID < 0 || laneID >= len(db.lanes) {
+	if !ok {
 		return 0
 	}
-	l := &db.lanes[laneID]
+	l := db.valueLogLaneByID(laneID)
+	if l == nil {
+		return 0
+	}
 	l.vlogMu.Lock()
 	defer l.vlogMu.Unlock()
 	if l.vlogClosedSizes == nil {
@@ -4924,6 +4973,9 @@ func (db *DB) pruneRetainedValueLogsWithObserved(force bool, observedSourceIDs m
 	}
 	if removed {
 		db.syncDirBestEffort(db.valueLogDir)
+		if db.leafLogDir != "" {
+			db.syncDirBestEffort(db.leafLogDir)
+		}
 	}
 	return out
 }
@@ -5986,6 +6038,7 @@ type DB struct {
 
 	// Durability
 	lanes         []lane
+	leafLog       lane
 	laneMu        sync.Mutex
 	laneCond      *sync.Cond
 	nextLane      int
@@ -6124,6 +6177,7 @@ type DB struct {
 	// Config
 	dir                                               string
 	valueLogDir                                       string
+	leafLogDir                                        string
 	flushThreshold                                    int64
 	memtableCap                                       int
 	memtableMode                                      atomic.Uint32
@@ -8135,10 +8189,11 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	}
 	warnInsecureDir(walDir, opts.NotifyError)
 	warnInsecureDir(valueLogDir, opts.NotifyError)
+	warnInsecureDir(leafLogDir, opts.NotifyError)
 	if err := ensureNoLegacyMixedWALValueSegments(walDir); err != nil {
 		return nil, err
 	}
-	segments, _ := listNonEmptySplitLogSegments(walDir, valueLogDir)
+	segments, _ := listNonEmptySplitLogSegments(walDir, valueLogDir, leafLogDir)
 	// Cached value-log RIDs remain globally unique across reopen/rewrite cycles.
 	// Until we persist nextRID separately, opening must recover the max on-disk
 	// RID here rather than risk reusing low RIDs after a clean reopen.
@@ -8147,17 +8202,29 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		return nil, err
 	}
 	maxLaneID := -1
+	maxLeafVlogSeq := 0
 	maxWALSeq := make(map[int]int)
 	maxVlogSeq := make(map[int]int)
 	for _, seg := range segments {
-		if seg.lane > maxLaneID {
-			maxLaneID = seg.lane
-		}
 		if seg.valueLog {
+			if seg.lane == leafLogLaneID {
+				if seg.seq > maxLeafVlogSeq {
+					maxLeafVlogSeq = seg.seq
+				}
+				continue
+			}
+			if seg.lane > maxLaneID {
+				maxLaneID = seg.lane
+			}
 			if seg.seq > maxVlogSeq[seg.lane] {
 				maxVlogSeq[seg.lane] = seg.seq
 			}
-		} else if seg.seq > maxWALSeq[seg.lane] {
+			continue
+		}
+		if seg.lane > maxLaneID {
+			maxLaneID = seg.lane
+		}
+		if seg.seq > maxWALSeq[seg.lane] {
 			maxWALSeq[seg.lane] = seg.seq
 		}
 	}
@@ -8304,6 +8371,10 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	}
 	reader, err := valuelog.NewManager(valueLogDir)
 	if err != nil {
+		return nil, err
+	}
+	if err := reader.AddScanDir(leafLogDir); err != nil {
+		_ = reader.Close()
 		return nil, err
 	}
 	reader.SetDisableReadChecksum(opts.DisableReadChecksum)
@@ -8504,6 +8575,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	db := &DB{
 		dir:                                  walDir,
 		valueLogDir:                          valueLogDir,
+		leafLogDir:                           leafLogDir,
 		backend:                              backend,
 		flushThreshold:                       opts.FlushThreshold,
 		memtableCap:                          memCap,
@@ -8601,6 +8673,17 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		flushLaneMu:                          make([]sync.Mutex, len(lanes)),
 	}
 	db.storeMemtableMode(mode)
+	if opts.IndexOuterLeavesInValueLog {
+		db.leafLog.id = leafLogLaneID
+		db.leafLog.vlogSeq = maxLeafVlogSeq
+		db.leafLog.vlogGenerationClass = vlogGenerationClassHot
+		db.leafLog.vlogCompressionSelector = newVlogCompressionSelectorWithSeed(
+			valueLogAutoPolicy,
+			uint64(valueLogIncompressibleHold),
+			uint64(valueLogIncompressibleProbe),
+			selectorSeedCodec,
+		)
+	}
 	if maxExistingRID > 0 {
 		db.nextRID.Store(maxExistingRID)
 	}
@@ -8639,6 +8722,20 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 				for j := 0; j <= i && j < len(db.lanes); j++ {
 					db.cleanupLaneWALWriters(&db.lanes[j])
 				}
+				db.cleanupLaneWALWriters(&db.leafLog)
+				return nil, err
+			}
+		}
+		if opts.IndexOuterLeavesInValueLog {
+			if err := db.rotateValueLogLocked(&db.leafLog); err != nil {
+				if db.valueLogReader != nil {
+					_ = db.valueLogReader.Close()
+					db.valueLogReader = nil
+				}
+				for i := range db.lanes {
+					db.cleanupLaneWALWriters(&db.lanes[i])
+				}
+				db.cleanupLaneWALWriters(&db.leafLog)
 				return nil, err
 			}
 		}
@@ -8659,10 +8756,16 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	}
 	if len(segments) > 0 {
 		for _, seg := range segments {
-			if seg.lane < 0 || seg.lane >= len(db.lanes) {
-				continue
+			l := db.valueLogLaneByID(seg.lane)
+			if l == nil {
+				if seg.valueLog {
+					continue
+				}
+				if seg.lane < 0 || seg.lane >= len(db.lanes) {
+					continue
+				}
+				l = &db.lanes[seg.lane]
 			}
-			l := &db.lanes[seg.lane]
 			if db.splitValueLog {
 				if seg.valueLog {
 					if seg.path == l.vlogPath {
@@ -8710,10 +8813,13 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		for i := range db.lanes {
 			db.startVlogWriter(&db.lanes[i])
 		}
+		if opts.IndexOuterLeavesInValueLog {
+			db.startVlogWriter(&db.leafLog)
+		}
 	}
 
 	if outerLeafPageLogSetter != nil {
-		outerLeafPageLogSetter.SetLeafPageLog(newCachingLeafPageLog(db, 0))
+		outerLeafPageLogSetter.SetLeafPageLog(newCachingLeafPageLog(db, &db.leafLog))
 	}
 	if opts.DisableWAL {
 		// Stage the adaptive gate on the fastest cached profile first. WAL-on
@@ -18565,6 +18671,18 @@ func (db *DB) Close() error {
 		l.vlogModeWriter = nil
 		l.vlogMu.Unlock()
 	}
+	if db.indexOuterLeavesInValueLog {
+		db.leafLog.vlogMu.Lock()
+		if db.leafLog.vlog != nil {
+			_ = db.leafLog.vlog.Close()
+			db.leafLog.vlog = nil
+			db.leafLog.vlogCaps = vlogWriterCaps{}
+			db.leafLog.vlogLiveBytes.Store(0)
+		}
+		db.leafLog.vlogModeSet = false
+		db.leafLog.vlogModeWriter = nil
+		db.leafLog.vlogMu.Unlock()
+	}
 
 	if walBytes > 0 && !hadMemtables {
 		backendBatch := db.backend.NewBatch()
@@ -20040,7 +20158,7 @@ func (db *DB) rotateValueLogMuHeld(l *lane) error {
 		hadClosedPrev bool
 	)
 	name := valueLogName(l.id, nextSeq)
-	path := filepath.Join(db.valueLogDir, name)
+	path := filepath.Join(db.valueLogDirForLane(l), name)
 	fileID, err := valuelog.EncodeFileID(uint32(l.id), uint32(nextSeq))
 	if err != nil {
 		return err
@@ -20234,10 +20352,13 @@ func (db *DB) untrackWALSegmentLocked(path string) {
 
 func (db *DB) untrackValueLogSegmentLocked(path string) {
 	laneID, _, _, ok := parseLogSeq(filepath.Base(path))
-	if !ok || laneID < 0 || laneID >= len(db.lanes) {
+	if !ok {
 		return
 	}
-	l := &db.lanes[laneID]
+	l := db.valueLogLaneByID(laneID)
+	if l == nil {
+		return
+	}
 	l.vlogMu.Lock()
 	defer l.vlogMu.Unlock()
 	if l.vlogClosedSizes == nil || path == "" {
@@ -26858,7 +26979,7 @@ func ensureNoLegacyMixedWALValueSegments(walDir string) error {
 	return nil
 }
 
-func listNonEmptySplitLogSegments(walDir, valueLogDir string) (segments []logSegmentInfo, nonEmptyBytes int64) {
+func listNonEmptySplitLogSegments(walDir, valueLogDir, leafLogDir string) (segments []logSegmentInfo, nonEmptyBytes int64) {
 	walSegments, walBytes := listNonEmptyLogSegments(walDir)
 	for _, seg := range walSegments {
 		if seg.valueLog {
@@ -26867,14 +26988,16 @@ func listNonEmptySplitLogSegments(walDir, valueLogDir string) (segments []logSeg
 		segments = append(segments, seg)
 	}
 	nonEmptyBytes += walBytes
-	vlogSegments, vlogBytes := listNonEmptyLogSegments(valueLogDir)
-	for _, seg := range vlogSegments {
-		if !seg.valueLog {
-			continue
+	for _, dir := range []string{valueLogDir, leafLogDir} {
+		vlogSegments, vlogBytes := listNonEmptyLogSegments(dir)
+		for _, seg := range vlogSegments {
+			if !seg.valueLog {
+				continue
+			}
+			segments = append(segments, seg)
 		}
-		segments = append(segments, seg)
+		nonEmptyBytes += vlogBytes
 	}
-	nonEmptyBytes += vlogBytes
 	sort.Slice(segments, func(i, j int) bool {
 		if segments[i].lane != segments[j].lane {
 			return segments[i].lane < segments[j].lane

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8263,6 +8263,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		return nil, err
 	}
 	segments, _ := listNonEmptySplitLogSegments(walDir, valueLogDir, leafLogDir)
+	reserveLeafLogLane := opts.IndexOuterLeavesInValueLog
 	// Cached value-log RIDs remain globally unique across reopen/rewrite cycles.
 	// Until we persist nextRID separately, opening must recover the max on-disk
 	// RID here rather than risk reusing low RIDs after a clean reopen.
@@ -8276,7 +8277,10 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	maxVlogSeq := make(map[int]int)
 	for _, seg := range segments {
 		if seg.valueLog {
-			if seg.lane == leafLogLaneID {
+			if reserveLeafLogLane && seg.lane == leafLogLaneID {
+				if filepath.Clean(filepath.Dir(seg.path)) != filepath.Clean(leafLogDir) {
+					return nil, fmt.Errorf("cachingdb: value_vlog lane %d conflicts with reserved leaf_vlog lane; rebuild required", leafLogLaneID)
+				}
 				if seg.seq > maxLeafVlogSeq {
 					maxLeafVlogSeq = seg.seq
 				}
@@ -8301,6 +8305,9 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	laneCountDefaulted := laneCount <= 0
 	if laneCountDefaulted {
 		laneCount = defaultJournalLaneCount(runtime.GOMAXPROCS(0))
+	}
+	if reserveLeafLogLane && laneCount > leafLogLaneID {
+		return nil, fmt.Errorf("cachingdb: IndexOuterLeavesInValueLog reserves lane %d; JournalLanes must be <= %d", leafLogLaneID, leafLogLaneID)
 	}
 	valueLogGenerationPolicy := backenddb.ValueLogGenerationPolicy(opts.ValueLogGenerationPolicy)
 	switch valueLogGenerationPolicy {

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -1112,7 +1112,7 @@ func TestRotateValueLogMuHeld_RestoresUsableWriterAfterRegisterFailure(t *testin
 		vlogSeq:  oldSeq,
 		vlogPath: oldPath,
 	}
-	db := &DB{dir: dir, backend: backend}
+	db := &DB{dir: dir, valueLogDir: dir, backend: backend}
 	t.Cleanup(func() {
 		if l.vlog != nil {
 			_ = l.vlog.Close()
@@ -2831,4 +2831,63 @@ func TestBackendMaintenance_DoesNotBlockOnRetainedValueLogPruneQuietWindow(t *te
 	cache.lastForegroundWriteUnixNano.Store(time.Now().Add(-2 * retainedPruneQuietWindow).UnixNano())
 	cache.lastForegroundReadUnixNano.Store(time.Now().Add(-2 * retainedPruneQuietWindow).UnixNano())
 	cache.waitForRetainedValueLogPrune()
+}
+
+func TestAdvanceValueLogWriterPastObservedSeq_RollsBackToOriginalSeqOnRegisterFailure(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+
+	oldSeq := 59
+	oldPath := filepath.Join(dir, valueLogName(0, oldSeq))
+	oldFileID, err := valuelog.EncodeFileID(0, uint32(oldSeq))
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	writer, err := valuelog.NewWriter(oldPath, oldFileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	l := &lane{
+		id:       0,
+		vlog:     writer,
+		vlogSeq:  oldSeq,
+		vlogPath: oldPath,
+	}
+	db := &DB{dir: dir, valueLogDir: dir, backend: backend}
+	t.Cleanup(func() {
+		if l.vlog != nil {
+			_ = l.vlog.Close()
+			l.vlog = nil
+		}
+		_ = db.removeFileRetry(oldPath)
+		_ = db.removeFileRetry(filepath.Join(dir, valueLogName(0, oldSeq+1)))
+		_ = db.removeFileRetry(filepath.Join(dir, valueLogName(0, oldSeq+2)))
+	})
+
+	backend.registerValueLogErr = errors.New("test: register failed")
+	err = db.advanceValueLogWriterPastObservedSeq(l, oldSeq+1)
+	if err == nil || !strings.Contains(err.Error(), "register failed") {
+		t.Fatalf("advanceValueLogWriterPastObservedSeq err=%v want register failure", err)
+	}
+	if got := l.vlogSeq; got != oldSeq {
+		t.Fatalf("vlogSeq=%d want %d", got, oldSeq)
+	}
+	if got := l.vlogPath; got != oldPath {
+		t.Fatalf("vlogPath=%q want %q", got, oldPath)
+	}
+	if l.vlog == nil {
+		t.Fatalf("expected usable writer restored after register failure")
+	}
+	ptrs, err := db.appendValueLog(l, 0, nil, []valuelog.Record{{RID: 1, Value: []byte("value")}}, journalDurabilityNone)
+	if err != nil {
+		t.Fatalf("appendValueLog after rollback: %v", err)
+	}
+	if len(ptrs) != 1 {
+		t.Fatalf("ptrs len=%d want 1", len(ptrs))
+	}
+	if got := ptrs[0].FileID; got != page.ValueLogFileID(oldFileID) {
+		t.Fatalf("ptr fileID=%d want %d", got, oldFileID)
+	}
+	putValueLogPtrs(ptrs)
 }

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -2081,7 +2081,7 @@ func TestCheckpoint_SchedulesRetainedValueLogPruneAsynchronously(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	retainedPath := filepath.Join(dir, "wal", "value-l0-000099.log")
+	retainedPath := filepath.Join(dir, "value_vlog", "value-l0-000099.log")
 	if err := os.MkdirAll(filepath.Dir(retainedPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2154,7 +2154,7 @@ func TestCheckpoint_DefersRetainedValueLogPruneUntilForegroundQuiet(t *testing.T
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	retainedPath := filepath.Join(dir, "wal", "value-l0-000199.log")
+	retainedPath := filepath.Join(dir, "value_vlog", "value-l0-000199.log")
 	if err := os.MkdirAll(filepath.Dir(retainedPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2227,7 +2227,7 @@ func TestRetainedValueLogPrune_AbortsWhenForegroundWritesResume(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	retainedPath := filepath.Join(dir, "wal", "value-l0-000211.log")
+	retainedPath := filepath.Join(dir, "value_vlog", "value-l0-000211.log")
 	if err := os.MkdirAll(filepath.Dir(retainedPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2307,7 +2307,7 @@ func TestRetainedValueLogPruneForce_RetriesAfterForegroundWritesResume(t *testin
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	retainedPath := filepath.Join(dir, "wal", "value-l0-000212.log")
+	retainedPath := filepath.Join(dir, "value_vlog", "value-l0-000212.log")
 	if err := os.MkdirAll(filepath.Dir(retainedPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2422,7 +2422,7 @@ func TestCheckpoint_RateLimitsRetainedValueLogPrune(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	retainedPath := filepath.Join(dir, "wal", "value-l0-000233.log")
+	retainedPath := filepath.Join(dir, "value_vlog", "value-l0-000233.log")
 	if err := os.MkdirAll(filepath.Dir(retainedPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2504,7 +2504,7 @@ func TestCheckpoint_SkipsRetainedValueLogPruneBelowPressureThreshold(t *testing.
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	retainedPath := filepath.Join(dir, "wal", "value-l0-000244.log")
+	retainedPath := filepath.Join(dir, "value_vlog", "value-l0-000244.log")
 	if err := os.MkdirAll(filepath.Dir(retainedPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2571,7 +2571,7 @@ func TestRetainedValueLogPruneForce_BypassesPressureThreshold(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	retainedPath := filepath.Join(dir, "wal", "value-l0-000245.log")
+	retainedPath := filepath.Join(dir, "value_vlog", "value-l0-000245.log")
 	if err := os.MkdirAll(filepath.Dir(retainedPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2630,7 +2630,7 @@ func TestRetainedValueLogPruneForce_PreemptsQuietWait(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	retainedPath := filepath.Join(dir, "wal", "value-l0-000246.log")
+	retainedPath := filepath.Join(dir, "value_vlog", "value-l0-000246.log")
 	if err := os.MkdirAll(filepath.Dir(retainedPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2696,7 +2696,7 @@ func TestCheckpoint_DoesNotWaitForPriorRetainedValueLogPrune(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	retainedPath := filepath.Join(dir, "wal", "value-l0-000100.log")
+	retainedPath := filepath.Join(dir, "value_vlog", "value-l0-000100.log")
 	if err := os.MkdirAll(filepath.Dir(retainedPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2772,7 +2772,7 @@ func TestBackendMaintenance_DoesNotBlockOnRetainedValueLogPruneQuietWindow(t *te
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	retainedPath := filepath.Join(dir, "wal", "value-l0-000321.log")
+	retainedPath := filepath.Join(dir, "value_vlog", "value-l0-000321.log")
 	if err := os.MkdirAll(filepath.Dir(retainedPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}

--- a/TreeDB/caching/debug_vlog_shape.go
+++ b/TreeDB/caching/debug_vlog_shape.go
@@ -127,7 +127,7 @@ func (db *DB) emitVlogShapeLog() {
 		diskErr       error
 	)
 	if debugVlogShapeDisk.Load() && db.dir != "" {
-		diskL0Segs, diskL0Bytes, diskL255Segs, diskL255Bytes, diskSegsTotal, diskBytes, diskErr = scanVlogSegmentsOnDisk(db.dir)
+		diskL0Segs, diskL0Bytes, diskL255Segs, diskL255Bytes, diskSegsTotal, diskBytes, diskErr = scanVlogSegmentsOnDisk(db.valueLogDir)
 	}
 
 	ts := time.Now().UTC().Format(time.RFC3339Nano)

--- a/TreeDB/caching/debug_vlog_shape.go
+++ b/TreeDB/caching/debug_vlog_shape.go
@@ -85,10 +85,11 @@ func (db *DB) emitVlogShapeLog() {
 	}
 	if !db.valueLogEnabled() || !db.splitValueLogEnabled() {
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
-		fmt.Fprintf(os.Stderr, "ts=%s treedb debug vlog_shape db=%s wal_dir=%s splitValueLog=%t valueLog=%t\n",
+		fmt.Fprintf(os.Stderr, "ts=%s treedb debug vlog_shape db=%s wal_dir=%s value_vlog_dir=%s splitValueLog=%t valueLog=%t\n",
 			ts,
 			filepath.Base(filepath.Dir(db.dir)),
 			db.dir,
+			db.valueLogDir,
 			db.splitValueLogEnabled(),
 			db.valueLogEnabled(),
 		)
@@ -126,16 +127,17 @@ func (db *DB) emitVlogShapeLog() {
 		diskBytes     int64
 		diskErr       error
 	)
-	if debugVlogShapeDisk.Load() && db.dir != "" {
+	if debugVlogShapeDisk.Load() && db.valueLogDir != "" {
 		diskL0Segs, diskL0Bytes, diskL255Segs, diskL255Bytes, diskSegsTotal, diskBytes, diskErr = scanVlogSegmentsOnDisk(db.valueLogDir)
 	}
 
 	ts := time.Now().UTC().Format(time.RFC3339Nano)
 	fmt.Fprintf(os.Stderr,
-		"ts=%s treedb debug vlog_shape db=%s wal_dir=%s l0_segments=%d l0_bytes=%d l0_rotations=%d l0_rotations_idle=%d segments_total=%d bytes_total=%d disk_l0_segments=%d disk_l0_bytes=%d disk_l255_segments=%d disk_l255_bytes=%d disk_segments_total=%d disk_bytes_total=%d disk_err=%v\n",
+		"ts=%s treedb debug vlog_shape db=%s wal_dir=%s value_vlog_dir=%s l0_segments=%d l0_bytes=%d l0_rotations=%d l0_rotations_idle=%d segments_total=%d bytes_total=%d disk_l0_segments=%d disk_l0_bytes=%d disk_l255_segments=%d disk_l255_bytes=%d disk_segments_total=%d disk_bytes_total=%d disk_err=%v\n",
 		ts,
 		filepath.Base(filepath.Dir(db.dir)),
 		db.dir,
+		db.valueLogDir,
 		l0Segs,
 		l0Bytes,
 		l0Rot,

--- a/TreeDB/caching/lane.go
+++ b/TreeDB/caching/lane.go
@@ -104,6 +104,8 @@ const (
 	vlogGenerationClassCold
 )
 
+const leafLogLaneID = 255
+
 func commitLogName(laneID, seq int) string {
 	return fmt.Sprintf("commit-l%d-%06d.log", laneID, seq)
 }

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -47,6 +47,12 @@ func (l *cachingLeafPageLog) Sync() error {
 	if l == nil || l.db == nil || l.lane == nil {
 		return errWALUnavailable
 	}
+	if err := l.db.flushValueLogLane(l.lane); err != nil {
+		return err
+	}
+	if l.db.relaxedSync {
+		return nil
+	}
 	return l.db.syncValueLogLane(l.lane)
 }
 

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -17,12 +17,12 @@ func newCachingLeafPageLog(db *DB, laneID int) backenddb.LeafPageLog {
 	return &cachingLeafPageLog{db: db, laneID: laneID}
 }
 
-func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.ValuePtr, error) {
+func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if l == nil || l.db == nil {
-		return page.ValuePtr{}, errWALUnavailable
+		return page.LeafLogPtr{}, errWALUnavailable
 	}
 	if l.laneID < 0 || l.laneID >= len(l.db.lanes) {
-		return page.ValuePtr{}, errWALUnavailable
+		return page.LeafLogPtr{}, errWALUnavailable
 	}
 	lane := &l.db.lanes[l.laneID]
 	rid := l.db.nextRID.Add(1)
@@ -30,7 +30,11 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.ValuePtr, err
 	if retainPath != "" {
 		l.db.markValueLogRetain(retainPath)
 	}
-	return ptr, err
+	leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
+	if convErr != nil {
+		return page.LeafLogPtr{}, convErr
+	}
+	return leafPtr, err
 }
 
 func (l *cachingLeafPageLog) Flush() error {

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -30,11 +30,14 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	if retainPath != "" {
 		l.db.markValueLogRetain(retainPath)
 	}
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
 	leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
 	if convErr != nil {
 		return page.LeafLogPtr{}, convErr
 	}
-	return leafPtr, err
+	return leafPtr, nil
 }
 
 func (l *cachingLeafPageLog) Flush() error {

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -7,26 +7,22 @@ import (
 )
 
 type cachingLeafPageLog struct {
-	db     *DB
-	laneID int
+	db   *DB
+	lane *lane
 }
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLog)(nil)
 
-func newCachingLeafPageLog(db *DB, laneID int) backenddb.LeafPageLog {
-	return &cachingLeafPageLog{db: db, laneID: laneID}
+func newCachingLeafPageLog(db *DB, l *lane) backenddb.LeafPageLog {
+	return &cachingLeafPageLog{db: db, lane: l}
 }
 
 func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
-	if l == nil || l.db == nil {
+	if l == nil || l.db == nil || l.lane == nil {
 		return page.LeafLogPtr{}, errWALUnavailable
 	}
-	if l.laneID < 0 || l.laneID >= len(l.db.lanes) {
-		return page.LeafLogPtr{}, errWALUnavailable
-	}
-	lane := &l.db.lanes[l.laneID]
 	rid := l.db.nextRID.Add(1)
-	ptr, retainPath, err := l.db.appendValueLogOneInternal(lane, 0, nil, rid, leafPage, journalDurabilityNone, false)
+	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, leafPage, journalDurabilityNone, false)
 	if retainPath != "" {
 		l.db.markValueLogRetain(retainPath)
 	}
@@ -41,35 +37,26 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 }
 
 func (l *cachingLeafPageLog) Flush() error {
-	if l == nil || l.db == nil {
+	if l == nil || l.db == nil || l.lane == nil {
 		return errWALUnavailable
 	}
-	return l.db.flushValueLog(l.laneID)
+	return l.db.flushValueLogLane(l.lane)
 }
 
 func (l *cachingLeafPageLog) Sync() error {
-	if l == nil || l.db == nil {
+	if l == nil || l.db == nil || l.lane == nil {
 		return errWALUnavailable
 	}
-	if err := l.db.flushValueLog(l.laneID); err != nil {
-		return err
-	}
-	if l.db.relaxedSync {
-		return nil
-	}
-	return l.db.syncValueLog(l.laneID)
+	return l.db.syncValueLogLane(l.lane)
 }
 
 // CurrentValueLogSegment reports the lane's current writable value-log segment.
 // Backend publish paths use this to avoid full manager refresh scans.
 func (l *cachingLeafPageLog) CurrentValueLogSegment() (string, uint32, bool) {
-	if l == nil || l.db == nil {
+	if l == nil || l.db == nil || l.lane == nil {
 		return "", 0, false
 	}
-	if l.laneID < 0 || l.laneID >= len(l.db.lanes) {
-		return "", 0, false
-	}
-	lane := &l.db.lanes[l.laneID]
+	lane := l.lane
 	lane.vlogMu.Lock()
 	path := lane.vlogPath
 	seq := lane.vlogSeq
@@ -77,7 +64,7 @@ func (l *cachingLeafPageLog) CurrentValueLogSegment() (string, uint32, bool) {
 	if path == "" || seq <= 0 {
 		return "", 0, false
 	}
-	fileID, err := valuelog.EncodeFileID(uint32(l.laneID), uint32(seq))
+	fileID, err := valuelog.EncodeFileID(uint32(lane.id), uint32(seq))
 	if err != nil {
 		return "", 0, false
 	}

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -2,7 +2,11 @@ package caching
 
 import (
 	"errors"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
 
 func TestCachingLeafPageLog_AppendLeafPageReturnsAppendError(t *testing.T) {
@@ -14,5 +18,42 @@ func TestCachingLeafPageLog_AppendLeafPageReturnsAppendError(t *testing.T) {
 	_, err := leafLog.AppendLeafPage([]byte("leaf"))
 	if !errors.Is(err, errWALClosed) {
 		t.Fatalf("AppendLeafPage error=%v want %v", err, errWALClosed)
+	}
+}
+
+func TestCachingLeafPageLog_SyncRespectsRelaxedSync(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := valuelog.EncodeFileID(uint32(leafLogLaneID), 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := filepath.Join(dir, "leaf.log")
+	writer, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	db := &DB{relaxedSync: true}
+	var flushCalls atomic.Int32
+	var syncCalls atomic.Int32
+	db.testOnVlogFlush = func(laneID int) {
+		flushCalls.Add(1)
+	}
+	db.testOnVlogSync = func(laneID int) {
+		syncCalls.Add(1)
+	}
+	leaf := lane{id: leafLogLaneID, vlog: writer}
+	leaf.vlogDirty.Store(true)
+	leafLog := &cachingLeafPageLog{db: db, lane: &leaf}
+
+	if err := leafLog.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if got := flushCalls.Load(); got != 1 {
+		t.Fatalf("flush calls=%d want 1", got)
+	}
+	if got := syncCalls.Load(); got != 0 {
+		t.Fatalf("sync calls=%d want 0", got)
 	}
 }

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -6,20 +6,12 @@ import (
 )
 
 func TestCachingLeafPageLog_AppendLeafPageReturnsAppendError(t *testing.T) {
-	backend := NewMockBackend()
-	db, err := Open(t.TempDir(), backend, Options{
-		DisableWAL:               true,
-		AllowUnsafe:              true,
-		ValueLogPointerThreshold: 1,
-	})
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	leafLog := &cachingLeafPageLog{db: db, laneID: 0}
-	if err := db.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	_, err = leafLog.AppendLeafPage([]byte("leaf"))
+	db := &DB{}
+	db.closeCh = make(chan struct{})
+	close(db.closeCh)
+	leaf := lane{id: leafLogLaneID}
+	leafLog := &cachingLeafPageLog{db: db, lane: &leaf}
+	_, err := leafLog.AppendLeafPage([]byte("leaf"))
 	if !errors.Is(err, errWALClosed) {
 		t.Fatalf("AppendLeafPage error=%v want %v", err, errWALClosed)
 	}

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -1,0 +1,26 @@
+package caching
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCachingLeafPageLog_AppendLeafPageReturnsAppendError(t *testing.T) {
+	backend := NewMockBackend()
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:               true,
+		AllowUnsafe:              true,
+		ValueLogPointerThreshold: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	leafLog := &cachingLeafPageLog{db: db, laneID: 0}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	_, err = leafLog.AppendLeafPage([]byte("leaf"))
+	if !errors.Is(err, errWALClosed) {
+		t.Fatalf("AppendLeafPage error=%v want %v", err, errWALClosed)
+	}
+}

--- a/TreeDB/caching/leafref_live_ids.go
+++ b/TreeDB/caching/leafref_live_ids.go
@@ -83,9 +83,9 @@ func collectLeafRefValueLogLiveIDs(ctx context.Context, p pageGetter, rootID uin
 			return fmt.Errorf("checksum mismatch on page %d", pageID)
 		}
 		return nil
-	}, func(ptr page.ValuePtr) error {
-		live[ptr.FileID] = struct{}{}
-		return collectNestedLeafPageValueLogLiveIDs(ctx, ptr, reader, live)
+	}, func(ptr page.LeafLogPtr) error {
+		live[ptr.ValueLogFileID()] = struct{}{}
+		return collectNestedLeafPageValueLogLiveIDs(ctx, ptr.ValuePtr(), reader, live)
 	})
 }
 

--- a/TreeDB/caching/leafref_live_ids_test.go
+++ b/TreeDB/caching/leafref_live_ids_test.go
@@ -24,7 +24,7 @@ func (errorSlabReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
 }
 
 func TestCollectLeafRefValueLogLiveIDs_RespectsCanceledContext(t *testing.T) {
-	ptr := page.ValuePtr{FileID: page.ValueLogFileID(1), Offset: 0}
+	ptr := page.LeafLogPtr{FileID: 1, Offset: 0}
 	rootID, err := page.EncodeLeafRef(ptr)
 	if err != nil {
 		t.Fatalf("EncodeLeafRef: %v", err)

--- a/TreeDB/caching/split_leaf_log_lane_reservation_test.go
+++ b/TreeDB/caching/split_leaf_log_lane_reservation_test.go
@@ -1,0 +1,88 @@
+package caching
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+)
+
+func TestOpen_Lane255ValueSegmentsRemainRegularWhenLeafLogDisabled(t *testing.T) {
+	dir := t.TempDir()
+	valueDir := filepath.Join(dir, "value_vlog")
+	if err := os.MkdirAll(valueDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(value_vlog): %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(leafLogLaneID, 7)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	w, err := valuelog.NewWriter(filepath.Join(valueDir, "value-l255-000007.log"), fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if _, err := w.Append(0, nil, 1, bytes.Repeat([]byte("v"), 64)); err != nil {
+		_ = w.Close()
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db, err := Open(dir, NewMockBackend(), Options{JournalLanes: leafLogLaneID + 1})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if got := db.lanes[leafLogLaneID].vlogSeq; got <= 7 {
+		t.Fatalf("lane 255 vlogSeq=%d want >7 after recovering existing regular lane-255 segments", got)
+	}
+	if db.leafLog.vlogSeq != 0 {
+		t.Fatalf("leaf log unexpectedly reserved seq=%d when leaf-log mode disabled", db.leafLog.vlogSeq)
+	}
+}
+
+func TestOpen_RejectsLeafLogLaneConflictWithJournalLanes(t *testing.T) {
+	_, err := Open(t.TempDir(), NewMockBackend(), Options{JournalLanes: leafLogLaneID + 1, IndexOuterLeavesInValueLog: true})
+	if err == nil {
+		t.Fatal("expected JournalLanes/leaf_vlog lane conflict error")
+	}
+	if !strings.Contains(err.Error(), "IndexOuterLeavesInValueLog reserves lane 255") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOpen_RejectsValueLogLane255ConflictWhenLeafLogEnabled(t *testing.T) {
+	dir := t.TempDir()
+	valueDir := filepath.Join(dir, "value_vlog")
+	if err := os.MkdirAll(valueDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(value_vlog): %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(leafLogLaneID, 3)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	w, err := valuelog.NewWriter(filepath.Join(valueDir, "value-l255-000003.log"), fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if _, err := w.Append(0, nil, 1, bytes.Repeat([]byte("x"), 64)); err != nil {
+		_ = w.Close()
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	_, err = Open(dir, NewMockBackend(), Options{JournalLanes: 4, IndexOuterLeavesInValueLog: true})
+	if err == nil {
+		t.Fatal("expected reserved leaf lane conflict error")
+	}
+	if !strings.Contains(err.Error(), "value_vlog lane 255 conflicts with reserved leaf_vlog lane") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/TreeDB/caching/split_leaf_log_lane_reservation_test.go
+++ b/TreeDB/caching/split_leaf_log_lane_reservation_test.go
@@ -56,6 +56,26 @@ func TestOpen_RejectsLeafLogLaneConflictWithJournalLanes(t *testing.T) {
 	}
 }
 
+func TestValueLogDirForLane_UsesLeafDirOnlyForReservedLeafLog(t *testing.T) {
+	db := &DB{
+		valueLogDir: "value_vlog",
+		leafLogDir:  "leaf_vlog",
+	}
+	regularLane255 := &lane{id: leafLogLaneID}
+	if got := db.valueLogDirForLane(regularLane255); got != db.valueLogDir {
+		t.Fatalf("valueLogDirForLane regular lane255=%q want %q when leaf-log mode disabled", got, db.valueLogDir)
+	}
+
+	db.indexOuterLeavesInValueLog = true
+	if got := db.valueLogDirForLane(regularLane255); got != db.valueLogDir {
+		t.Fatalf("valueLogDirForLane regular lane255=%q want %q", got, db.valueLogDir)
+	}
+	db.leafLog.id = leafLogLaneID
+	if got := db.valueLogDirForLane(&db.leafLog); got != db.leafLogDir {
+		t.Fatalf("valueLogDirForLane leaf log=%q want %q", got, db.leafLogDir)
+	}
+}
+
 func TestOpen_RejectsValueLogLane255ConflictWhenLeafLogEnabled(t *testing.T) {
 	dir := t.TempDir()
 	valueDir := filepath.Join(dir, "value_vlog")

--- a/TreeDB/caching/split_leaf_log_lane_reservation_test.go
+++ b/TreeDB/caching/split_leaf_log_lane_reservation_test.go
@@ -86,3 +86,22 @@ func TestOpen_RejectsValueLogLane255ConflictWhenLeafLogEnabled(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestOpen_RejectsRecoveredWALLane255ConflictWhenLeafLogEnabled(t *testing.T) {
+	dir := t.TempDir()
+	walDir := filepath.Join(dir, "wal")
+	if err := os.MkdirAll(walDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(wal): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(walDir, "commit-l255-000001.log"), bytes.Repeat([]byte("w"), 64), 0o600); err != nil {
+		t.Fatalf("WriteFile(wal): %v", err)
+	}
+
+	_, err := Open(dir, NewMockBackend(), Options{JournalLanes: 4, IndexOuterLeavesInValueLog: true})
+	if err == nil {
+		t.Fatal("expected recovered lane-255 WAL conflict error")
+	}
+	if !strings.Contains(err.Error(), "recovered WAL/value lanes require rebuild before reopen") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/TreeDB/caching/unified_wal_comprehensive_test.go
+++ b/TreeDB/caching/unified_wal_comprehensive_test.go
@@ -62,11 +62,14 @@ func TestUnifiedWAL_ValueLogFlow(t *testing.T) {
 func TestUnifiedWAL_CrashRecoveryMissingCommit(t *testing.T) {
 	dir := t.TempDir()
 	walDir := filepath.Join(dir, "wal")
-	if err := os.MkdirAll(walDir, 0755); err != nil {
-		t.Fatalf("mkdir wal: %v", err)
+	valueLogDir := filepath.Join(dir, "value_vlog")
+	for _, path := range []string{walDir, valueLogDir} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatalf("mkdir log dir %s: %v", path, err)
+		}
 	}
 
-	valuePath := filepath.Join(walDir, "value-l0-000001.log")
+	valuePath := filepath.Join(valueLogDir, "value-l0-000001.log")
 	writer, err := valuelog.NewWriter(valuePath, page.ValueLogFileID(1))
 	if err != nil {
 		t.Fatalf("valuelog.NewWriter: %v", err)

--- a/TreeDB/caching/value_log_rid_reopen_test.go
+++ b/TreeDB/caching/value_log_rid_reopen_test.go
@@ -62,7 +62,7 @@ func TestDisableWAL_ReopenDoesNotReuseValueLogRIDs(t *testing.T) {
 	writeSession('a')
 	writeSession('b')
 
-	segments, _ := listNonEmptyLogSegments(filepath.Join(dir, "wal"))
+	segments, _ := listNonEmptyLogSegments(filepath.Join(dir, "value_vlog"))
 	dups := duplicateValueLogRIDCount(t, segments)
 	if dups != 0 {
 		t.Fatalf("expected no duplicate RIDs after reopen, got %d", dups)
@@ -105,7 +105,7 @@ func TestDisableWAL_OnlineRewriteDoesNotReuseValueLogRIDs(t *testing.T) {
 		t.Fatalf("Checkpoint seed: %v", err)
 	}
 
-	segments, _ := listNonEmptyLogSegments(filepath.Join(dir, "wal"))
+	segments, _ := listNonEmptyLogSegments(filepath.Join(dir, "value_vlog"))
 	var sourceID uint32
 	for _, seg := range segments {
 		if seg.valueLog {
@@ -155,7 +155,7 @@ func TestDisableWAL_OnlineRewriteDoesNotReuseValueLogRIDs(t *testing.T) {
 		t.Fatalf("Checkpoint after rewrite: %v", err)
 	}
 
-	segments, _ = listNonEmptyLogSegments(filepath.Join(dir, "wal"))
+	segments, _ = listNonEmptyLogSegments(filepath.Join(dir, "value_vlog"))
 	dups := duplicateValueLogRIDCount(t, segments)
 	if dups != 0 {
 		t.Fatalf("expected no duplicate RIDs after online rewrite, got %d", dups)

--- a/TreeDB/caching/vlog_block_group_large_payload_test.go
+++ b/TreeDB/caching/vlog_block_group_large_payload_test.go
@@ -1,0 +1,136 @@
+package caching
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+const recordFlagGroupedTest byte = 1 << 0
+
+func scanGroupedFrameCounts(t *testing.T, path string) (groupedFrames, groupedSubrecords, ungroupedRecords, maxGrouped int) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	r := bufio.NewReaderSize(f, 1<<20)
+	var payloadBuf []byte
+	for {
+		var header [valuelog.HeaderSize]byte
+		if _, err := io.ReadFull(r, header[:]); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				break
+			}
+			t.Fatalf("read header: %v", err)
+		}
+		valueLen := int(binary.LittleEndian.Uint32(header[16:20]))
+		if cap(payloadBuf) < valueLen {
+			payloadBuf = make([]byte, valueLen)
+		}
+		payload := payloadBuf[:valueLen]
+		if _, err := io.ReadFull(r, payload); err != nil {
+			t.Fatalf("read payload: %v", err)
+		}
+		if header[5]&recordFlagGroupedTest == 0 {
+			ungroupedRecords++
+			continue
+		}
+		_, _, offsets, _, err := valuelog.DecodeFrame(payload)
+		if err != nil {
+			t.Fatalf("DecodeFrame: %v", err)
+		}
+		groupedFrames++
+		subrecs := len(offsets) - 1
+		groupedSubrecords += subrecs
+		if subrecs > maxGrouped {
+			maxGrouped = subrecs
+		}
+	}
+	return groupedFrames, groupedSubrecords, ungroupedRecords, maxGrouped
+}
+
+func TestChooseValueLogBlockWriteK_LargePayloadUsesExpandedTarget(t *testing.T) {
+	db := &DB{
+		valueLogCompressionMode:  uint8(vlogCompressionBlock),
+		valueLogBlockTargetBytes: 4096,
+	}
+	l := &lane{}
+
+	const (
+		records         = 32
+		avgPayloadBytes = 42 << 10
+	)
+	rawPayloadBytes := records * avgPayloadBytes
+	got := db.chooseValueLogBlockWriteK(l, records, rawPayloadBytes, valuelog.BlockCodecLZ4)
+	wantTargetBytes := valuelog.NormalizeBlockTargetCompressedBytes(avgPayloadBytes * largePayloadBlockTargetMultiplier)
+	want := valuelog.ChooseBlockGroupK(records, rawPayloadBytes, wantTargetBytes, largePayloadBlockBootstrapRatio)
+	if got != want {
+		t.Fatalf("expected large-payload K to use expanded target, got=%d want=%d", got, want)
+	}
+	if got <= 1 {
+		t.Fatalf("expected large payload K > 1, got %d", got)
+	}
+}
+
+func TestAppendValueLogForRecords_LargePayloadBatchGroupsFrames(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value.log")
+	writer, err := valuelog.NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	db := &DB{
+		closeCh:                  make(chan struct{}),
+		valueLogCompressionMode:  uint8(vlogCompressionBlock),
+		valueLogBlockCodec:       valuelog.BlockCodecLZ4,
+		valueLogBlockTargetBytes: 4096,
+		lanes: []lane{
+			{id: 0, vlog: writer},
+		},
+	}
+
+	value := bytes.Repeat([]byte("repeatable-large-payload-"), 1792)
+	if len(value) < (42 << 10) {
+		value = append(value, bytes.Repeat([]byte("Z"), (42<<10)-len(value))...)
+	}
+	value = value[:42<<10]
+	records := make([]valuelog.Record, 16)
+	for i := range records {
+		records[i] = valuelog.Record{RID: uint64(i + 1), Value: append([]byte(nil), value...)}
+	}
+
+	ptrs, err := db.appendValueLog(&db.lanes[0], 0, nil, records, journalDurabilityFlush)
+	if err != nil {
+		t.Fatalf("appendValueLog: %v", err)
+	}
+	if len(ptrs) != len(records) {
+		t.Fatalf("expected %d ptrs, got %d", len(records), len(ptrs))
+	}
+
+	groupedFrames, groupedSubrecords, ungroupedRecords, maxGrouped := scanGroupedFrameCounts(t, path)
+	if groupedSubrecords != len(records) {
+		t.Fatalf("expected grouped subrecords=%d, got %d", len(records), groupedSubrecords)
+	}
+	if ungroupedRecords != 0 {
+		t.Fatalf("expected no ungrouped records, got %d", ungroupedRecords)
+	}
+	if groupedFrames >= len(records) {
+		t.Fatalf("expected fewer grouped frames than records, frames=%d records=%d", groupedFrames, len(records))
+	}
+	if maxGrouped < 8 {
+		t.Fatalf("expected max grouped frame >= 8 subrecords, got %d", maxGrouped)
+	}
+}

--- a/TreeDB/caching/vlog_block_group_large_payload_test.go
+++ b/TreeDB/caching/vlog_block_group_large_payload_test.go
@@ -29,7 +29,7 @@ func scanGroupedFrameCounts(t *testing.T, path string) (groupedFrames, groupedSu
 	for {
 		var header [valuelog.HeaderSize]byte
 		if _, err := io.ReadFull(r, header[:]); err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			t.Fatalf("read header: %v", err)

--- a/TreeDB/caching/vlog_block_group_large_payload_test.go
+++ b/TreeDB/caching/vlog_block_group_large_payload_test.go
@@ -134,3 +134,20 @@ func TestAppendValueLogForRecords_LargePayloadBatchGroupsFrames(t *testing.T) {
 		t.Fatalf("expected max grouped frame >= 8 subrecords, got %d", maxGrouped)
 	}
 }
+
+func TestChooseValueLogBlockWriteK_LargePayloadBootstrapKeepsSelectorIncompressibleSignal(t *testing.T) {
+	db := &DB{
+		valueLogCompressionMode:  uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:       uint8(vlogAutoBalanced),
+		valueLogBlockTargetBytes: 4096,
+	}
+	selector := newVlogCompressionSelector(vlogAutoBalanced, 0, 0)
+	selector.dwellBytes = 0
+	selector.observe(vlogWriteBlock, valuelog.BlockCodecSnappy, 42<<10, 42<<10, 1000, false)
+	l := &lane{vlogCompressionSelector: selector}
+
+	got := db.chooseValueLogBlockWriteK(l, 16, 16*(42<<10), valuelog.BlockCodecSnappy)
+	if got != 1 {
+		t.Fatalf("expected incompressible selector signal to keep k=1, got %d", got)
+	}
+}

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -62,6 +62,12 @@ const (
 	// block codec defaults for large no-dict payload streams.
 	largePayloadBlockCodecMinSamples = 4
 	largePayloadBlockCodecTieMargin  = 0.01
+	// Large value-log payloads need a materially larger grouped-frame target than
+	// the generic 4 KiB block target. Otherwise K collapses to 1 on 40+ KiB
+	// records before the selector has any chance to observe cross-record wins.
+	largePayloadBlockTargetMinPayloadBytes = 16 << 10
+	largePayloadBlockTargetMultiplier      = 8
+	largePayloadBlockBootstrapRatio        = 0.92
 )
 
 var (
@@ -1587,6 +1593,7 @@ func (db *DB) chooseValueLogBlockWriteK(l *lane, records, rawPayloadBytes int, c
 	}
 	avgPayloadBytes := rawPayloadBytes / records
 	ratio := 1.0
+	ratioSamples := uint64(0)
 	// K sizing should stay on the lane-observed block ratio in explicit dict
 	// mode. The selector remains responsible for dict-vs-block mode choice, but
 	// feeding selector candidate ratios back into frame grouping in dict mode can
@@ -1599,12 +1606,21 @@ func (db *DB) chooseValueLogBlockWriteK(l *lane, records, rawPayloadBytes int, c
 		ratio = l.vlogCompressionSelector.blockObservedRatio(codec)
 	}
 	if ratio <= 0 || stableFastPath || !useSelectorRatio {
-		ratio = laneVlogBlockObservedRatio(l, codec)
+		ratio, ratioSamples = laneVlogBlockObservedRatioWithSamples(l, codec)
+	}
+	if avgPayloadBytes >= largePayloadBlockTargetMinPayloadBytes && ratioSamples == 0 && ratio >= 0.98 {
+		ratio = largePayloadBlockBootstrapRatio
 	}
 	targetCompressedBytes := db.valueLogBlockTargetBytes
 	if db.forceValueLogPointers && targetCompressedBytes < forcePointerBlockTargetCompressedBytes {
 		if avgPayloadBytes >= forcePointerAutoBlockMinPayloadBytes {
 			targetCompressedBytes = forcePointerBlockTargetCompressedBytes
+		}
+	}
+	if avgPayloadBytes >= largePayloadBlockTargetMinPayloadBytes {
+		largePayloadTargetBytes := valuelog.NormalizeBlockTargetCompressedBytes(avgPayloadBytes * largePayloadBlockTargetMultiplier)
+		if targetCompressedBytes < largePayloadTargetBytes {
+			targetCompressedBytes = largePayloadTargetBytes
 		}
 	}
 	k := valuelog.ChooseBlockGroupK(records, rawPayloadBytes, targetCompressedBytes, ratio)

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -1217,26 +1217,31 @@ func (s *vlogCompressionSelector) observe(mode vlogCompressionWriteMode, blockCo
 }
 
 func (s *vlogCompressionSelector) blockObservedRatio(codec valuelog.BlockCodec) float64 {
+	ratio, _ := s.blockObservedRatioWithSamples(codec)
+	return ratio
+}
+
+func (s *vlogCompressionSelector) blockObservedRatioWithSamples(codec valuelog.BlockCodec) (float64, uint64) {
 	if s == nil {
-		return 1.0
+		return 1.0, 0
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	candidate := blockCandidateFromCodec(codec)
 	m := s.metric(candidate)
 	if m.samples > 0 {
-		return m.ratio
+		return m.ratio, m.samples
 	}
 	// Fall back to whichever block codec has the stronger signal.
 	snappy := s.metric(vlogAutoCandidateBlockSnappy)
 	lz4 := s.metric(vlogAutoCandidateBlockLZ4)
 	if snappy.samples == 0 && lz4.samples == 0 {
-		return 0.92
+		return 0.92, 0
 	}
 	if snappy.samples >= lz4.samples {
-		return snappy.ratio
+		return snappy.ratio, snappy.samples
 	}
-	return lz4.ratio
+	return lz4.ratio, lz4.samples
 }
 
 func (s *vlogCompressionSelector) snapshot() vlogCompressionSelectorStats {
@@ -1603,7 +1608,7 @@ func (db *DB) chooseValueLogBlockWriteK(l *lane, records, rawPayloadBytes int, c
 		((db.forceValueLogPointers && avgPayloadBytes >= forcePointerAutoBlockMinPayloadBytes) ||
 			(normalizeVlogAutoPolicy(db.valueLogAutoPolicy) == vlogAutoThroughput && avgPayloadBytes >= throughputAutoBlockMinPayloadBytes))
 	if useSelectorRatio && !stableFastPath {
-		ratio = l.vlogCompressionSelector.blockObservedRatio(codec)
+		ratio, ratioSamples = l.vlogCompressionSelector.blockObservedRatioWithSamples(codec)
 	}
 	if ratio <= 0 || stableFastPath || !useSelectorRatio {
 		ratio, ratioSamples = laneVlogBlockObservedRatioWithSamples(l, codec)

--- a/TreeDB/caching/vlog_current_segment_readbarrier_open_test.go
+++ b/TreeDB/caching/vlog_current_segment_readbarrier_open_test.go
@@ -1,6 +1,8 @@
 package caching
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -15,6 +17,25 @@ type readBarrierTrackingBackend struct {
 
 func (b *readBarrierTrackingBackend) SetCurrentValueLogReadBarrier(fn func(fileID uint32) error) {
 	b.barrier = fn
+}
+
+func TestOpen_FailsOnLegacyMixedWALValueLayout(t *testing.T) {
+	dir := t.TempDir()
+	walDir := filepath.Join(dir, "wal")
+	if err := os.MkdirAll(walDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(wal): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(walDir, "value-l0-000001.log"), []byte("legacy"), 0o600); err != nil {
+		t.Fatalf("WriteFile(value log): %v", err)
+	}
+
+	_, err := Open(dir, NewMockBackend(), Options{DisableWAL: true, AllowUnsafe: true})
+	if err == nil {
+		t.Fatalf("expected open failure")
+	}
+	if !strings.Contains(err.Error(), "split wal/value_vlog layout") {
+		t.Fatalf("open error=%v want legacy mixed WAL/value-log layout", err)
+	}
 }
 
 func TestOpen_DoesNotInstallBackendReadBarrierWhenOpenFails(t *testing.T) {

--- a/TreeDB/caching/vlog_current_segment_readbarrier_open_test.go
+++ b/TreeDB/caching/vlog_current_segment_readbarrier_open_test.go
@@ -20,21 +20,25 @@ func (b *readBarrierTrackingBackend) SetCurrentValueLogReadBarrier(fn func(fileI
 }
 
 func TestOpen_FailsOnLegacyMixedWALValueLayout(t *testing.T) {
-	dir := t.TempDir()
-	walDir := filepath.Join(dir, "wal")
-	if err := os.MkdirAll(walDir, 0o700); err != nil {
-		t.Fatalf("MkdirAll(wal): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(walDir, "value-l0-000001.log"), []byte("legacy"), 0o600); err != nil {
-		t.Fatalf("WriteFile(value log): %v", err)
-	}
+	for _, name := range []string{"value-l0-000001.log", "vlog-l0-000001.log"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			walDir := filepath.Join(dir, "wal")
+			if err := os.MkdirAll(walDir, 0o700); err != nil {
+				t.Fatalf("MkdirAll(wal): %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(walDir, name), []byte("legacy"), 0o600); err != nil {
+				t.Fatalf("WriteFile(value log): %v", err)
+			}
 
-	_, err := Open(dir, NewMockBackend(), Options{DisableWAL: true, AllowUnsafe: true})
-	if err == nil {
-		t.Fatalf("expected open failure")
-	}
-	if !strings.Contains(err.Error(), "split wal/value_vlog layout") {
-		t.Fatalf("open error=%v want legacy mixed WAL/value-log layout", err)
+			_, err := Open(dir, NewMockBackend(), Options{DisableWAL: true, AllowUnsafe: true})
+			if err == nil {
+				t.Fatalf("expected open failure")
+			}
+			if !strings.Contains(err.Error(), "split wal/value_vlog layout") {
+				t.Fatalf("open error=%v want legacy mixed WAL/value-log layout", err)
+			}
+		})
 	}
 }
 

--- a/TreeDB/caching/vlog_generation_leafref_reopen_test.go
+++ b/TreeDB/caching/vlog_generation_leafref_reopen_test.go
@@ -474,14 +474,18 @@ func TestCachedRewriteLeafRefs_RemainReopenableAfterLaterCheckpoint(t *testing.T
 	}
 	sourceIDs = sourceIDs[:4]
 
-	stats, err := backend.ValueLogRewriteOnline(context.Background(), backenddb.ValueLogRewriteOnlineOptions{
-		BatchSize:      32,
-		SyncEachBatch:  true,
-		ProtectedPaths: db.valueLogProtectedPaths(),
-		SourceFileIDs:  sourceIDs,
-	})
-	if err != nil {
-		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	var stats backenddb.ValueLogRewriteStats
+	if err := db.runWithBackendMaintenance(func() error {
+		var err error
+		stats, err = backend.ValueLogRewriteOnline(context.Background(), backenddb.ValueLogRewriteOnlineOptions{
+			BatchSize:      32,
+			SyncEachBatch:  true,
+			ProtectedPaths: db.valueLogProtectedPaths(),
+			SourceFileIDs:  sourceIDs,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("backend maintenance rewrite: %v", err)
 	}
 	postRewriteCounts := collectLeafRefFileCounts(t, backend.Pager(), backend.State().RootPageID)
 	if hits := countLeafRefHits(postRewriteCounts, sourceIDs); hits != 0 {

--- a/TreeDB/caching/vlog_generation_leafref_reopen_test.go
+++ b/TreeDB/caching/vlog_generation_leafref_reopen_test.go
@@ -26,9 +26,13 @@ var missingValueLogIDPattern = regexp.MustCompile(`valuelog file ([0-9]+) not fo
 
 func ageValueLogFilesForTest(t *testing.T, dir string, age time.Duration) {
 	t.Helper()
-	paths, err := filepath.Glob(filepath.Join(dir, "value_vlog", "value-l*.log"))
-	if err != nil {
-		t.Fatalf("glob value_vlog files: %v", err)
+	var paths []string
+	for _, subdir := range []string{"value_vlog", "leaf_vlog"} {
+		matches, err := filepath.Glob(filepath.Join(dir, subdir, "value-l*.log"))
+		if err != nil {
+			t.Fatalf("glob %s files: %v", subdir, err)
+		}
+		paths = append(paths, matches...)
 	}
 	old := time.Now().Add(-age)
 	for _, path := range paths {
@@ -36,6 +40,15 @@ func ageValueLogFilesForTest(t *testing.T, dir string, age time.Duration) {
 			t.Fatalf("chtimes %s: %v", path, err)
 		}
 	}
+}
+
+func valueLogPathForFileID(root string, fileID uint32) string {
+	lane, seq := valuelog.DecodeFileID(fileID)
+	subdir := "value_vlog"
+	if int(lane) == leafLogLaneID {
+		subdir = "leaf_vlog"
+	}
+	return filepath.Join(root, subdir, fmt.Sprintf("value-l%d-%06d.log", lane, seq))
 }
 
 func extractMissingValueLogID(err error) (uint32, bool) {
@@ -70,8 +83,7 @@ func missingLeafRefPaths(root string, counts map[uint32]int) []string {
 		if count == 0 {
 			continue
 		}
-		lane, seq := valuelog.DecodeFileID(fileID)
-		path := filepath.Join(root, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+		path := valueLogPathForFileID(root, fileID)
 		if _, err := os.Stat(path); err == nil {
 			continue
 		} else if os.IsNotExist(err) {
@@ -1109,10 +1121,7 @@ func TestCachedGenerationalMaintenance_DirectPointersSeedPhaseLarge_WALOn(t *tes
 		refreshedState := backend.State()
 		sample := make([]sourceKind, 0, min(8, len(missingIDs)))
 		for _, id := range missingIDs[:min(8, len(missingIDs))] {
-			seg := page.ValueLogSegmentID(id)
-			laneID := seg >> 23
-			seq := seg & ((1 << 23) - 1)
-			path := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
+			path := valueLogPathForFileID(dir, id)
 			_, statErr := os.Stat(path)
 			inRefreshed := false
 			if refreshedState != nil && refreshedState.ValueLogSet != nil {
@@ -1409,10 +1418,7 @@ func testCachedRepeatedRewriteVacuumLeafRefsRemainReopenable(t *testing.T, disab
 				var missingID uint32
 				if id, ok := extractMissingValueLogID(err); ok {
 					missingID = id
-					seg := page.ValueLogSegmentID(missingID)
-					lane := seg >> 23
-					seq := seg & ((1 << 23) - 1)
-					path := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+					path := valueLogPathForFileID(dir, missingID)
 					_, statErr := os.Stat(path)
 					t.Fatalf("rewrite round %d: %v (missing_id=%d in_leaf_counts=%d in_live_counts=%d in_current_set=%v path=%s stat_err=%v sources=%v)",
 						round, err, missingID, leafCounts[missingID], preRoundCounts[missingID], currentSet.Files[missingID] != nil, path, statErr, sourceIDs[:min(8, len(sourceIDs))])
@@ -1448,16 +1454,13 @@ func testCachedRepeatedRewriteVacuumLeafRefsRemainReopenable(t *testing.T, disab
 				if refreshed != nil && refreshed.ValueLogSet != nil {
 					_, inRefreshedSet = refreshed.ValueLogSet.Files[missingID]
 				}
-				seg := page.ValueLogSegmentID(missingID)
-				laneID := int(seg >> 23)
-				seq := seg & ((1 << 23) - 1)
-				path := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
+				path := valueLogPathForFileID(dir, missingID)
 				_, statErr := os.Stat(path)
+				laneID, _ := valuelog.DecodeFileID(missingID)
 				currentPath := ""
 				currentSeq := 0
 				currentRetained := false
-				if laneID >= 0 && laneID < len(db.lanes) {
-					lane := &db.lanes[laneID]
+				if lane := db.valueLogLaneByID(int(laneID)); lane != nil {
 					lane.vlogMu.Lock()
 					currentPath = lane.vlogPath
 					currentSeq = lane.vlogSeq
@@ -1700,10 +1703,7 @@ func TestCachedManualMaintenanceDirectPointersRemainReopenable_WALOn(t *testing.
 					if refreshedState != nil && refreshedState.ValueLogSet != nil {
 						_, inSet = refreshedState.ValueLogSet.Files[missingID]
 					}
-					seg := page.ValueLogSegmentID(missingID)
-					laneID := seg >> 23
-					seq := seg & ((1 << 23) - 1)
-					path := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
+					path := valueLogPathForFileID(dir, missingID)
 					_, statErr := os.Stat(path)
 					t.Fatalf("rewrite round %d: %v (missing_id=%d in_set=%v path=%s stat_err=%v sources=%v)",
 						round, err, missingID, inSet, path, statErr, sourceIDs[:min(8, len(sourceIDs))])
@@ -1729,10 +1729,7 @@ func TestCachedManualMaintenanceDirectPointersRemainReopenable_WALOn(t *testing.
 				if refreshedState != nil && refreshedState.ValueLogSet != nil {
 					_, inSet = refreshedState.ValueLogSet.Files[missingID]
 				}
-				seg := page.ValueLogSegmentID(missingID)
-				laneID := seg >> 23
-				seq := seg & ((1 << 23) - 1)
-				path := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
+				path := valueLogPathForFileID(dir, missingID)
 				_, statErr := os.Stat(path)
 				t.Fatalf("round %d post-write iterator error: %v (missing_id=%d in_set=%v path=%s stat_err=%v)", round, err, missingID, inSet, path, statErr)
 			}

--- a/TreeDB/caching/vlog_generation_leafref_reopen_test.go
+++ b/TreeDB/caching/vlog_generation_leafref_reopen_test.go
@@ -26,9 +26,9 @@ var missingValueLogIDPattern = regexp.MustCompile(`valuelog file ([0-9]+) not fo
 
 func ageValueLogFilesForTest(t *testing.T, dir string, age time.Duration) {
 	t.Helper()
-	paths, err := filepath.Glob(filepath.Join(dir, "wal", "value-l*.log"))
+	paths, err := filepath.Glob(filepath.Join(dir, "value_vlog", "value-l*.log"))
 	if err != nil {
-		t.Fatalf("glob wal files: %v", err)
+		t.Fatalf("glob value_vlog files: %v", err)
 	}
 	old := time.Now().Add(-age)
 	for _, path := range paths {
@@ -71,7 +71,7 @@ func missingLeafRefPaths(root string, counts map[uint32]int) []string {
 			continue
 		}
 		lane, seq := valuelog.DecodeFileID(fileID)
-		path := filepath.Join(root, "wal", fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+		path := filepath.Join(root, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", lane, seq))
 		if _, err := os.Stat(path); err == nil {
 			continue
 		} else if os.IsNotExist(err) {
@@ -1112,7 +1112,7 @@ func TestCachedGenerationalMaintenance_DirectPointersSeedPhaseLarge_WALOn(t *tes
 			seg := page.ValueLogSegmentID(id)
 			laneID := seg >> 23
 			seq := seg & ((1 << 23) - 1)
-			path := filepath.Join(dir, "wal", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
+			path := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
 			_, statErr := os.Stat(path)
 			inRefreshed := false
 			if refreshedState != nil && refreshedState.ValueLogSet != nil {
@@ -1412,7 +1412,7 @@ func testCachedRepeatedRewriteVacuumLeafRefsRemainReopenable(t *testing.T, disab
 					seg := page.ValueLogSegmentID(missingID)
 					lane := seg >> 23
 					seq := seg & ((1 << 23) - 1)
-					path := filepath.Join(dir, "wal", fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+					path := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", lane, seq))
 					_, statErr := os.Stat(path)
 					t.Fatalf("rewrite round %d: %v (missing_id=%d in_leaf_counts=%d in_live_counts=%d in_current_set=%v path=%s stat_err=%v sources=%v)",
 						round, err, missingID, leafCounts[missingID], preRoundCounts[missingID], currentSet.Files[missingID] != nil, path, statErr, sourceIDs[:min(8, len(sourceIDs))])
@@ -1451,7 +1451,7 @@ func testCachedRepeatedRewriteVacuumLeafRefsRemainReopenable(t *testing.T, disab
 				seg := page.ValueLogSegmentID(missingID)
 				laneID := int(seg >> 23)
 				seq := seg & ((1 << 23) - 1)
-				path := filepath.Join(dir, "wal", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
+				path := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
 				_, statErr := os.Stat(path)
 				currentPath := ""
 				currentSeq := 0
@@ -1703,7 +1703,7 @@ func TestCachedManualMaintenanceDirectPointersRemainReopenable_WALOn(t *testing.
 					seg := page.ValueLogSegmentID(missingID)
 					laneID := seg >> 23
 					seq := seg & ((1 << 23) - 1)
-					path := filepath.Join(dir, "wal", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
+					path := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
 					_, statErr := os.Stat(path)
 					t.Fatalf("rewrite round %d: %v (missing_id=%d in_set=%v path=%s stat_err=%v sources=%v)",
 						round, err, missingID, inSet, path, statErr, sourceIDs[:min(8, len(sourceIDs))])
@@ -1732,7 +1732,7 @@ func TestCachedManualMaintenanceDirectPointersRemainReopenable_WALOn(t *testing.
 				seg := page.ValueLogSegmentID(missingID)
 				laneID := seg >> 23
 				seq := seg & ((1 << 23) - 1)
-				path := filepath.Join(dir, "wal", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
+				path := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", laneID, seq))
 				_, statErr := os.Stat(path)
 				t.Fatalf("round %d post-write iterator error: %v (missing_id=%d in_set=%v path=%s stat_err=%v)", round, err, missingID, inSet, path, statErr)
 			}

--- a/TreeDB/caching/vlog_generation_leafref_reopen_test.go
+++ b/TreeDB/caching/vlog_generation_leafref_reopen_test.go
@@ -243,7 +243,7 @@ func collectLeafRefFileCounts(t *testing.T, p *pager.Pager, rootID uint64) map[u
 		}
 		seen[pageID] = struct{}{}
 		if ptr, ok := page.DecodeLeafRef(pageID); ok {
-			out[ptr.FileID]++
+			out[ptr.ValueLogFileID()]++
 			continue
 		}
 		data, err := p.Get(pageID)
@@ -324,11 +324,11 @@ func collectNestedLeafValueLogFileCounts(t *testing.T, reader interface {
 			continue
 		}
 		if len(sourceSet) > 0 {
-			if _, ok := sourceSet[ptr.FileID]; !ok {
+			if _, ok := sourceSet[ptr.ValueLogFileID()]; !ok {
 				continue
 			}
 		}
-		leafPage, err := reader.ReadUnsafe(ptr)
+		leafPage, err := reader.ReadUnsafe(ptr.ValuePtr())
 		if err != nil {
 			t.Fatalf("read leaf page file=%d offset=%d: %v", ptr.FileID, ptr.Offset, err)
 		}

--- a/TreeDB/caching/vlog_generation_protected_paths_test.go
+++ b/TreeDB/caching/vlog_generation_protected_paths_test.go
@@ -98,9 +98,9 @@ func TestVlogGenerationRewrite_ProtectedPathsIncludeCurrentValueLogPaths(t *test
 	if err := db.Checkpoint(); err != nil {
 		t.Fatalf("checkpoint: %v", err)
 	}
-	paths, err := filepath.Glob(filepath.Join(dir, "wal", "value-l*.log"))
+	paths, err := filepath.Glob(filepath.Join(dir, "value_vlog", "value-l*.log"))
 	if err != nil {
-		t.Fatalf("glob wal files: %v", err)
+		t.Fatalf("glob value_vlog files: %v", err)
 	}
 	old := time.Now().Add(-5 * time.Minute)
 	for _, path := range paths {
@@ -177,9 +177,9 @@ func TestValueLogProtectedPaths_IncludeRetainedPaths(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	retainedPath := filepath.Join(dir, "wal", "value-l0-000999.log")
+	retainedPath := filepath.Join(dir, "value_vlog", "value-l0-000999.log")
 	if err := os.MkdirAll(filepath.Dir(retainedPath), 0o755); err != nil {
-		t.Fatalf("mkdir wal dir: %v", err)
+		t.Fatalf("mkdir value_vlog dir: %v", err)
 	}
 	if err := os.WriteFile(retainedPath, []byte("retained"), 0o644); err != nil {
 		t.Fatalf("write retained path: %v", err)
@@ -248,9 +248,9 @@ func TestVlogGenerationRewrite_UsesSharedRIDAllocator(t *testing.T) {
 	if err := db.Checkpoint(); err != nil {
 		t.Fatalf("checkpoint: %v", err)
 	}
-	paths, err := filepath.Glob(filepath.Join(dir, "wal", "value-l*.log"))
+	paths, err := filepath.Glob(filepath.Join(dir, "value_vlog", "value-l*.log"))
 	if err != nil {
-		t.Fatalf("glob wal files: %v", err)
+		t.Fatalf("glob value_vlog files: %v", err)
 	}
 	old := time.Now().Add(-5 * time.Minute)
 	for _, path := range paths {

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1338,6 +1338,7 @@ type rewriteBudgetRecordingBackend struct {
 	planErr         error
 	planFn          func(backenddb.ValueLogRewriteOnlineOptions) (backenddb.ValueLogRewritePlan, error)
 	rewriteOpts     backenddb.ValueLogRewriteOnlineOptions
+	rewriteHistory  []backenddb.ValueLogRewriteOnlineOptions
 	rewriteCalls    int
 	rewriteResponse backenddb.ValueLogRewriteStats
 	rewriteErr      error
@@ -1382,7 +1383,9 @@ func (b *rewriteBudgetRecordingBackend) ValueLogRewriteChunkPlan(ctx context.Con
 
 func (b *rewriteBudgetRecordingBackend) ValueLogRewriteOnline(ctx context.Context, opts backenddb.ValueLogRewriteOnlineOptions) (backenddb.ValueLogRewriteStats, error) {
 	b.mu.Lock()
-	b.rewriteOpts = cloneRewriteOptsForTest(opts)
+	cloned := cloneRewriteOptsForTest(opts)
+	b.rewriteOpts = cloned
+	b.rewriteHistory = append(b.rewriteHistory, cloned)
 	b.rewriteCalls++
 	stats := b.rewriteResponse
 	err := b.rewriteErr
@@ -1422,6 +1425,14 @@ func (b *rewriteBudgetRecordingBackend) recordedRewrite() (backenddb.ValueLogRew
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.rewriteOpts, b.rewriteCalls
+}
+
+func (b *rewriteBudgetRecordingBackend) recordedRewrites() []backenddb.ValueLogRewriteOnlineOptions {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	history := make([]backenddb.ValueLogRewriteOnlineOptions, len(b.rewriteHistory))
+	copy(history, b.rewriteHistory)
+	return history
 }
 
 func cloneRewriteOptsForTest(opts backenddb.ValueLogRewriteOnlineOptions) backenddb.ValueLogRewriteOnlineOptions {
@@ -5332,28 +5343,27 @@ func TestVlogGenerationRewritePlan_StageConfirmationDebtDrainProcessesMultipleSe
 	})
 
 	rewriteDeadline := time.Now().Add(2 * schedulerTestWait(t))
-	var (
-		rewriteOpts  backenddb.ValueLogRewriteOnlineOptions
-		rewriteCalls int
-	)
+	var rewriteCalls int
 	for {
-		rewriteOpts, rewriteCalls = recorder.recordedRewrite()
+		_, rewriteCalls = recorder.recordedRewrite()
 		if rewriteCalls >= 1 {
 			break
 		}
 		if time.Now().After(rewriteDeadline) {
-			t.Fatalf("rewrite calls after staged confirmation=%d want=1", rewriteCalls)
+			t.Fatalf("rewrite calls after staged confirmation=%d want>=1", rewriteCalls)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if rewriteCalls != 1 {
-		t.Fatalf("rewrite calls after staged confirmation=%d want=1", rewriteCalls)
+	rewriteHistory := recorder.recordedRewrites()
+	if len(rewriteHistory) == 0 {
+		t.Fatalf("rewrite history after staged confirmation empty")
 	}
-	if got := len(rewriteOpts.SourceFileIDs); got <= 1 {
-		t.Fatalf("rewrite SourceFileIDs after staged confirmation=%v want multiple ids", rewriteOpts.SourceFileIDs)
+	firstRewrite := rewriteHistory[0]
+	if got := len(firstRewrite.SourceFileIDs); got <= 1 {
+		t.Fatalf("first rewrite SourceFileIDs after staged confirmation=%v want multiple ids", firstRewrite.SourceFileIDs)
 	}
-	if got := len(rewriteOpts.SourceFileIDs); got > vlogGenerationRewriteDebtDrainMaxSegments {
-		t.Fatalf("rewrite SourceFileIDs len=%d want <= %d", got, vlogGenerationRewriteDebtDrainMaxSegments)
+	if got := len(firstRewrite.SourceFileIDs); got > vlogGenerationRewriteDebtDrainMaxSegments {
+		t.Fatalf("first rewrite SourceFileIDs len=%d want <= %d", got, vlogGenerationRewriteDebtDrainMaxSegments)
 	}
 }
 

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -7548,7 +7548,7 @@ func TestVlogGenerationRewritePlan_RunsOutsideMaintenanceBarrier(t *testing.T) {
 	if err := db.Checkpoint(); err != nil {
 		t.Fatalf("checkpoint: %v", err)
 	}
-	paths, err := filepath.Glob(filepath.Join(dir, "wal", "value-l*.log"))
+	paths, err := filepath.Glob(filepath.Join(dir, "value_vlog", "value-l*.log"))
 	if err != nil {
 		t.Fatalf("glob wal files: %v", err)
 	}

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -5276,9 +5276,11 @@ func TestVlogGenerationRewritePlan_StageConfirmationExecutesConfirmedSubset(t *t
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if rewriteCalls != 1 {
-		t.Fatalf("rewrite calls after staged confirmation=%d want=1", rewriteCalls)
+	rewriteHistory := recorder.recordedRewrites()
+	if len(rewriteHistory) == 0 {
+		t.Fatalf("rewrite history after staged confirmation empty")
 	}
+	rewriteOpts = rewriteHistory[0]
 	if got, want := rewriteOpts.SourceFileIDs, []uint32{22}; len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("rewrite SourceFileIDs after staged confirmation=%v want=%v", got, want)
 	}
@@ -5451,9 +5453,11 @@ func TestVlogGenerationRewritePlan_StageConfirmationReplansEvenWhenOtherTriggers
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if rewriteCalls != 1 {
-		t.Fatalf("rewrite calls after staged confirmation=%d want 1", rewriteCalls)
+	rewriteHistory := recorder.recordedRewrites()
+	if len(rewriteHistory) == 0 {
+		t.Fatalf("rewrite history after staged confirmation empty")
 	}
+	rewriteOpts = rewriteHistory[0]
 	if got, want := rewriteOpts.SourceFileIDs, []uint32{22}; len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("rewrite SourceFileIDs after staged confirmation=%v want=%v", got, want)
 	}

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -5262,12 +5262,9 @@ func TestVlogGenerationRewritePlan_StageConfirmationExecutesConfirmedSubset(t *t
 		time.Sleep(10 * time.Millisecond)
 	}
 	rewriteDeadline := time.Now().Add(2 * schedulerTestWait(t))
-	var (
-		rewriteOpts  backenddb.ValueLogRewriteOnlineOptions
-		rewriteCalls int
-	)
+	var rewriteCalls int
 	for {
-		rewriteOpts, rewriteCalls = recorder.recordedRewrite()
+		_, rewriteCalls = recorder.recordedRewrite()
 		if rewriteCalls >= 1 {
 			break
 		}
@@ -5280,9 +5277,10 @@ func TestVlogGenerationRewritePlan_StageConfirmationExecutesConfirmedSubset(t *t
 	if len(rewriteHistory) == 0 {
 		t.Fatalf("rewrite history after staged confirmation empty")
 	}
-	rewriteOpts = rewriteHistory[0]
-	if got, want := rewriteOpts.SourceFileIDs, []uint32{22}; len(got) != len(want) || got[0] != want[0] {
-		t.Fatalf("rewrite SourceFileIDs after staged confirmation=%v want=%v", got, want)
+	for i, rewriteOpts := range rewriteHistory {
+		if got, want := rewriteOpts.SourceFileIDs, []uint32{22}; len(got) != len(want) || got[0] != want[0] {
+			t.Fatalf("rewrite[%d] SourceFileIDs after staged confirmation=%v want=%v", i, got, want)
+		}
 	}
 }
 
@@ -5439,12 +5437,9 @@ func TestVlogGenerationRewritePlan_StageConfirmationReplansEvenWhenOtherTriggers
 		t.Fatalf("plan calls after staged confirmation=%d want 1", planCalls)
 	}
 	rewriteDeadline := time.Now().Add(2 * schedulerTestWait(t))
-	var (
-		rewriteOpts  backenddb.ValueLogRewriteOnlineOptions
-		rewriteCalls int
-	)
+	var rewriteCalls int
 	for {
-		rewriteOpts, rewriteCalls = recorder.recordedRewrite()
+		_, rewriteCalls = recorder.recordedRewrite()
 		if rewriteCalls >= 1 {
 			break
 		}
@@ -5457,9 +5452,10 @@ func TestVlogGenerationRewritePlan_StageConfirmationReplansEvenWhenOtherTriggers
 	if len(rewriteHistory) == 0 {
 		t.Fatalf("rewrite history after staged confirmation empty")
 	}
-	rewriteOpts = rewriteHistory[0]
-	if got, want := rewriteOpts.SourceFileIDs, []uint32{22}; len(got) != len(want) || got[0] != want[0] {
-		t.Fatalf("rewrite SourceFileIDs after staged confirmation=%v want=%v", got, want)
+	for i, rewriteOpts := range rewriteHistory {
+		if got, want := rewriteOpts.SourceFileIDs, []uint32{22}; len(got) != len(want) || got[0] != want[0] {
+			t.Fatalf("rewrite[%d] SourceFileIDs after staged confirmation=%v want=%v", i, got, want)
+		}
 	}
 }
 

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -148,7 +148,11 @@ func forceRewriteStageConfirmDue(t *testing.T, db *DB) {
 	db.vlogGenerationRewriteQueueMu.Lock()
 	db.vlogGenerationRewriteStageObservedUnixNano = observedAt
 	db.vlogGenerationRewriteQueueMu.Unlock()
-	db.scheduleVlogGenerationRewriteStageConfirmation(observedAt)
+	// Synchronous scheduler tests drive the confirmation pass explicitly. Do not
+	// arm the background confirmation wake here; that introduces a race where the
+	// goroutine can consume staged debt before the test's direct maintenance call,
+	// which has been flaky on slower Windows runners.
+	db.clearVlogGenerationRewriteStageConfirmation()
 }
 
 func disableVlogGenerationLoop(t *testing.T) {

--- a/TreeDB/caching/zipper_pressure_test.go
+++ b/TreeDB/caching/zipper_pressure_test.go
@@ -1,7 +1,9 @@
 package caching
 
 import (
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/zipper"
 )
@@ -20,7 +22,25 @@ func TestOpen_DisableWALWiresZipperParallelMergePressure(t *testing.T) {
 	defer poolPressureTestMu.Unlock()
 
 	resetPoolPressureStateForTest()
-	t.Cleanup(resetPoolPressureStateForTest)
+	savedNow := poolPressureNow
+	savedReadMemStats := poolPressureReadMemStats
+	savedMemLimit := poolPressureMemoryLimit
+	t.Cleanup(func() {
+		poolPressureNow = savedNow
+		poolPressureReadMemStats = savedReadMemStats
+		poolPressureMemoryLimit = savedMemLimit
+		resetPoolPressureStateForTest()
+	})
+	now := time.Unix(1, 0)
+	poolPressureNow = func() time.Time { return now }
+	fake := runtime.MemStats{
+		HeapAlloc: 1 << 20,
+		HeapInuse: 1 << 20,
+		HeapSys:   2 << 20,
+		Sys:       4 << 20,
+	}
+	poolPressureReadMemStats = func(ms *runtime.MemStats) { *ms = fake }
+	poolPressureMemoryLimit = func() int64 { return 1 << 30 }
 
 	dir := t.TempDir()
 	backend := &zipperPressureRecordingBackend{MockBackend: NewMockBackend()}

--- a/TreeDB/caching/zipper_pressure_test.go
+++ b/TreeDB/caching/zipper_pressure_test.go
@@ -16,6 +16,12 @@ func (b *zipperPressureRecordingBackend) SetZipperParallelMergePressureSource(sr
 }
 
 func TestOpen_DisableWALWiresZipperParallelMergePressure(t *testing.T) {
+	poolPressureTestMu.Lock()
+	defer poolPressureTestMu.Unlock()
+
+	resetPoolPressureStateForTest()
+	t.Cleanup(resetPoolPressureStateForTest)
+
 	dir := t.TempDir()
 	backend := &zipperPressureRecordingBackend{MockBackend: NewMockBackend()}
 

--- a/TreeDB/cmd/template_corpus_extract/main.go
+++ b/TreeDB/cmd/template_corpus_extract/main.go
@@ -187,11 +187,9 @@ func extractOuterLeafCorpus(backend *treedbdb.DB, writer *corpusWriter, limit, s
 		}
 	}
 	seen := make(map[outerLeafKey]struct{}, initialCap)
-	visit := func(ptr page.ValuePtr) error {
-		if !page.IsValueLogFileID(ptr.FileID) {
-			return nil
-		}
-		key := outerLeafKey{fileID: ptr.FileID, offset: ptr.Offset}
+	visit := func(ptr page.LeafLogPtr) error {
+
+		key := outerLeafKey{fileID: ptr.ValueLogFileID(), offset: ptr.Offset}
 		if _, ok := seen[key]; ok {
 			return nil
 		}
@@ -200,7 +198,7 @@ func extractOuterLeafCorpus(backend *treedbdb.DB, writer *corpusWriter, limit, s
 			return errStopScan
 		}
 		if shouldSample(scanned, stride) {
-			payload, err := reader.ReadUnsafe(ptr)
+			payload, err := reader.ReadUnsafe(ptr.ValuePtr())
 			if err != nil {
 				return err
 			}

--- a/TreeDB/cmd/template_seed_train/main.go
+++ b/TreeDB/cmd/template_seed_train/main.go
@@ -271,8 +271,8 @@ func trainOuterLeafValues(engine *template.Engine, store *templatedb.Store, back
 		}
 	}
 	seen := make(map[outerLeafKey]struct{}, seenCap)
-	visit := func(ptr page.ValuePtr) error {
-		key := outerLeafKey{fileID: ptr.FileID, offset: ptr.Offset}
+	visit := func(ptr page.LeafLogPtr) error {
+		key := outerLeafKey{fileID: ptr.ValueLogFileID(), offset: ptr.Offset}
 		if _, ok := seen[key]; ok {
 			return nil
 		}
@@ -282,7 +282,7 @@ func trainOuterLeafValues(engine *template.Engine, store *templatedb.Store, back
 			return errStopScan
 		}
 		if shouldSample(stats.scanned, stride) {
-			payload, err := reader.ReadUnsafe(ptr)
+			payload, err := reader.ReadUnsafe(ptr.ValuePtr())
 			if err != nil {
 				return err
 			}
@@ -396,8 +396,8 @@ func probeOuterLeaf(engine *template.Engine, store template.Store, backend *tree
 		}
 	}
 	seen := make(map[outerLeafKey]struct{}, seenCap)
-	visit := func(ptr page.ValuePtr) error {
-		key := outerLeafKey{fileID: ptr.FileID, offset: ptr.Offset}
+	visit := func(ptr page.LeafLogPtr) error {
+		key := outerLeafKey{fileID: ptr.ValueLogFileID(), offset: ptr.Offset}
 		if _, ok := seen[key]; ok {
 			return nil
 		}
@@ -405,7 +405,7 @@ func probeOuterLeaf(engine *template.Engine, store template.Store, backend *tree
 		if limit > 0 && attempted >= limit {
 			return errStopScan
 		}
-		payload, err := reader.ReadUnsafe(ptr)
+		payload, err := reader.ReadUnsafe(ptr.ValuePtr())
 		if err != nil {
 			return err
 		}

--- a/TreeDB/cmd/treemap/vlog_audit.go
+++ b/TreeDB/cmd/treemap/vlog_audit.go
@@ -282,7 +282,7 @@ func collectValueLogAudit(dir string, rewriteOpts treedbdb.ValueLogRewriteOnline
 	}
 	rootDir := resolveTreemapRootDir(filepath.Clean(dir), mainDir)
 	report.MainDir = mainDir
-	report.ValueLogDir = filepath.Join(mainDir, "wal")
+	report.ValueLogDir = treedbdb.ValueLogDirPath(mainDir)
 
 	segs, bytesOnDisk, err := listValueLogSegments(report.ValueLogDir)
 	if err != nil {

--- a/TreeDB/cmd/treemap/vlog_audit.go
+++ b/TreeDB/cmd/treemap/vlog_audit.go
@@ -33,7 +33,7 @@ type valueLogAuditReport struct {
 	Dir            string                       `json:"dir"`
 	MainDir        string                       `json:"main_dir"`
 	ValueLogDir    string                       `json:"value_log_dir"`
-	LeafLogDir     string                       `json:"leaf_log_dir,omitempty"`
+	LeafLogDir     string                       `json:"leaf_log_dir"`
 	Segments       []valueLogSegmentAudit       `json:"segments"`
 	SegmentsOnDisk int                          `json:"segments_on_disk"`
 	BytesOnDisk    int64                        `json:"bytes_on_disk"`

--- a/TreeDB/cmd/treemap/vlog_audit.go
+++ b/TreeDB/cmd/treemap/vlog_audit.go
@@ -33,6 +33,7 @@ type valueLogAuditReport struct {
 	Dir            string                       `json:"dir"`
 	MainDir        string                       `json:"main_dir"`
 	ValueLogDir    string                       `json:"value_log_dir"`
+	LeafLogDir     string                       `json:"leaf_log_dir,omitempty"`
 	Segments       []valueLogSegmentAudit       `json:"segments"`
 	SegmentsOnDisk int                          `json:"segments_on_disk"`
 	BytesOnDisk    int64                        `json:"bytes_on_disk"`
@@ -151,6 +152,9 @@ func runVlogAudit(dir string, args []string) {
 	fmt.Printf("dir=%s\n", report.Dir)
 	fmt.Printf("main_dir=%s\n", report.MainDir)
 	fmt.Printf("value_log_dir=%s\n", report.ValueLogDir)
+	if strings.TrimSpace(report.LeafLogDir) != "" {
+		fmt.Printf("leaf_log_dir=%s\n", report.LeafLogDir)
+	}
 	fmt.Printf("segments_on_disk=%d bytes_on_disk=%d\n", report.SegmentsOnDisk, report.BytesOnDisk)
 	fmt.Printf("rid_scan: records=%d distinct=%d duplicates=%d first_duplicate_rid=%d max_rid=%d\n",
 		report.RIDScan.Records,
@@ -283,8 +287,9 @@ func collectValueLogAudit(dir string, rewriteOpts treedbdb.ValueLogRewriteOnline
 	rootDir := resolveTreemapRootDir(filepath.Clean(dir), mainDir)
 	report.MainDir = mainDir
 	report.ValueLogDir = treedbdb.ValueLogDirPath(mainDir)
+	report.LeafLogDir = treedbdb.LeafLogDirPath(mainDir)
 
-	segs, bytesOnDisk, err := listValueLogSegments(report.ValueLogDir)
+	segs, bytesOnDisk, err := listValueLogSegments(report.ValueLogDir, report.LeafLogDir)
 	if err != nil {
 		return report, err
 	}
@@ -652,45 +657,57 @@ func resolveTreemapRootDir(inputDir, mainDir string) string {
 	return clean
 }
 
-func listValueLogSegments(dir string) ([]valueLogSegmentAudit, int64, error) {
-	info, err := os.Stat(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, 0, nil
+func listValueLogSegments(dirs ...string) ([]valueLogSegmentAudit, int64, error) {
+	var (
+		segs  []valueLogSegmentAudit
+		total int64
+	)
+	for _, dir := range dirs {
+		if strings.TrimSpace(dir) == "" {
+			continue
 		}
-		return nil, 0, err
-	}
-	if !info.IsDir() {
-		return nil, 0, fmt.Errorf("value-log dir is not a directory: %s", dir)
-	}
+		info, err := os.Stat(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, 0, err
+		}
+		if !info.IsDir() {
+			return nil, 0, fmt.Errorf("value-log dir is not a directory: %s", dir)
+		}
 
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, 0, err
-	}
-	segs := make([]valueLogSegmentAudit, 0, len(entries))
-	var total int64
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if !strings.HasPrefix(name, "value-") || !strings.HasSuffix(name, ".log") {
-			continue
-		}
-		path := filepath.Join(dir, name)
-		stat, err := entry.Info()
+		entries, err := os.ReadDir(dir)
 		if err != nil {
 			return nil, 0, err
 		}
-		segs = append(segs, valueLogSegmentAudit{
-			Name:  name,
-			Path:  path,
-			Bytes: stat.Size(),
-		})
-		total += stat.Size()
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if !strings.HasPrefix(name, "value-") || !strings.HasSuffix(name, ".log") {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			stat, err := entry.Info()
+			if err != nil {
+				return nil, 0, err
+			}
+			segs = append(segs, valueLogSegmentAudit{
+				Name:  name,
+				Path:  path,
+				Bytes: stat.Size(),
+			})
+			total += stat.Size()
+		}
 	}
-	sort.Slice(segs, func(i, j int) bool { return segs[i].Name < segs[j].Name })
+	sort.Slice(segs, func(i, j int) bool {
+		if segs[i].Name == segs[j].Name {
+			return segs[i].Path < segs[j].Path
+		}
+		return segs[i].Name < segs[j].Name
+	})
 	return segs, total, nil
 }
 

--- a/TreeDB/cmd/treemap/vlog_audit_test.go
+++ b/TreeDB/cmd/treemap/vlog_audit_test.go
@@ -70,6 +70,42 @@ func TestCollectValueLogAudit_AcceptsMainDBDir(t *testing.T) {
 	}
 }
 
+func TestCollectValueLogAudit_IncludesLeafLogSegments(t *testing.T) {
+	dir := t.TempDir()
+	buildDictCompressedDBForAudit(t, dir)
+
+	leafDir := treedbdb.LeafLogDirPath(filepath.Join(dir, "maindb"))
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(leaf log): %v", err)
+	}
+	fileID := mustEncodeAuditFileID(t, 255, 1)
+	w, err := valuelog.NewWriter(filepath.Join(leafDir, "value-l255-000001.log"), fileID)
+	if err != nil {
+		t.Fatalf("NewWriter(leaf log): %v", err)
+	}
+	if _, err := w.Append(0, nil, 9001, bytes.Repeat([]byte("leaf"), 1024)); err != nil {
+		_ = w.Close()
+		t.Fatalf("Append(leaf log): %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close(leaf log): %v", err)
+	}
+
+	report, err := collectValueLogAudit(dir, treedbdb.ValueLogRewriteOnlineOptions{}, valueLogRIDAuditOptions{}, valueLogFrameScanAuditOptions{})
+	if err != nil {
+		t.Fatalf("collectValueLogAudit(with leaf_vlog): %v", err)
+	}
+	if report.LeafLogDir != leafDir {
+		t.Fatalf("LeafLogDir=%q want %q", report.LeafLogDir, leafDir)
+	}
+	if report.SegmentsOnDisk < 2 {
+		t.Fatalf("expected combined value+leaf segments, got segments=%d", report.SegmentsOnDisk)
+	}
+	if report.RIDScan.MaxRID < 9001 {
+		t.Fatalf("expected RID scan to include leaf_vlog record, got %+v", report.RIDScan)
+	}
+}
+
 func TestParseValueLogAuditFileID_AcceptsLegacyAndLaneNames(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/TreeDB/db/api_test.go
+++ b/TreeDB/db/api_test.go
@@ -144,7 +144,7 @@ func TestSnapshotGet_ReturnsSafeCopyForValueLogPointer(t *testing.T) {
 
 	key := []byte("k")
 	val := bytes.Repeat([]byte("v"), 4096)
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -302,7 +302,7 @@ func TestIteratorOptions_SnapshotCompatibility(t *testing.T) {
 	if err := db.Set([]byte("k-inline"), []byte("inline")); err != nil {
 		t.Fatalf("Set inline: %v", err)
 	}
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -564,7 +564,7 @@ func TestGet_RetriesAfterRefreshingStaleValueLogSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(wal): %v", err)
 	}
@@ -625,7 +625,7 @@ func TestGetMany_RetriesAfterRefreshingStaleValueLogSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(wal): %v", err)
 	}
@@ -694,7 +694,7 @@ func TestGet_ConcurrentStaleReadRetry_DedupesRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(wal): %v", err)
 	}

--- a/TreeDB/db/commit_combiner_fallback_test.go
+++ b/TreeDB/db/commit_combiner_fallback_test.go
@@ -272,7 +272,7 @@ func TestCommitCombinerFallback_PointerCommitDurableAfterReopen(t *testing.T) {
 		_ = d.Close()
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	path := filepath.Join(dir, "wal", "value-l0-000001.log")
+	path := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		_ = d.Close()
 		t.Fatalf("MkdirAll(wal): %v", err)

--- a/TreeDB/db/currentset_refresh_test.go
+++ b/TreeDB/db/currentset_refresh_test.go
@@ -17,7 +17,7 @@ func writeValueLogRecord(t *testing.T, dir string, lane, seq uint32, value []byt
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	path := filepath.Join(dir, "wal", fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+	path := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", lane, seq))
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("MkdirAll(wal): %v", err)
 	}
@@ -54,7 +54,7 @@ func (l *registeredLeafPageLog) ensureWriter() error {
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(l.dir, "wal", "value-l0-000001.log")
+	path := filepath.Join(l.dir, "value_vlog", "value-l0-000001.log")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (l *unregisteredLeafPageLog) ensureWriter() error {
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(l.dir, "wal", "value-l11-000001.log")
+	path := filepath.Join(l.dir, "value_vlog", "value-l11-000001.log")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
@@ -198,7 +198,7 @@ func TestInlineCommitSkipsValueLogRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	path := filepath.Join(dir, "wal", "value-l0-000001.log")
+	path := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("MkdirAll(wal): %v", err)
 	}
@@ -251,7 +251,7 @@ func TestPointerCommitRefreshesValueLogSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	path := filepath.Join(dir, "wal", "value-l0-000001.log")
+	path := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("MkdirAll(wal): %v", err)
 	}
@@ -437,7 +437,7 @@ func TestOuterLeafPointerCommitRefreshesWhenLeafSegmentUnreported(t *testing.T) 
 	// Keep touched pointer segments known so this commit would previously skip
 	// refresh and publish an incomplete ValueLogSet when the leaf segment is not
 	// reportable/registered.
-	pointerPath := filepath.Join(dir, "wal", "value-l0-000001.log")
+	pointerPath := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
 	if err := d.RegisterValueLogSegment(pointerPath, fileID); err != nil {
 		t.Fatalf("RegisterValueLogSegment(pointer): %v", err)
 	}
@@ -546,7 +546,7 @@ func TestRegisterValueLogSegment_DoesNotPublishCurrentSetWithoutExplicitRefresh(
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	path := filepath.Join(dir, "wal", "value-l7-000001.log")
+	path := filepath.Join(dir, "value_vlog", "value-l7-000001.log")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("MkdirAll(wal): %v", err)
 	}

--- a/TreeDB/db/currentset_refresh_test.go
+++ b/TreeDB/db/currentset_refresh_test.go
@@ -76,12 +76,16 @@ func (l *registeredLeafPageLog) ensureWriter() error {
 	return nil
 }
 
-func (l *registeredLeafPageLog) AppendLeafPage(leafPage []byte) (page.ValuePtr, error) {
+func (l *registeredLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if err := l.ensureWriter(); err != nil {
-		return page.ValuePtr{}, err
+		return page.LeafLogPtr{}, err
 	}
 	l.nextRID++
-	return l.w.Append(0, nil, l.nextRID, leafPage)
+	ptr, err := l.w.Append(0, nil, l.nextRID, leafPage)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	return page.LeafLogPtrFromValuePtr(ptr)
 }
 
 func (l *registeredLeafPageLog) Flush() error {
@@ -147,12 +151,16 @@ func (l *unregisteredLeafPageLog) ensureWriter() error {
 	return nil
 }
 
-func (l *unregisteredLeafPageLog) AppendLeafPage(leafPage []byte) (page.ValuePtr, error) {
+func (l *unregisteredLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if err := l.ensureWriter(); err != nil {
-		return page.ValuePtr{}, err
+		return page.LeafLogPtr{}, err
 	}
 	l.nextRID++
-	return l.w.Append(0, nil, l.nextRID, leafPage)
+	ptr, err := l.w.Append(0, nil, l.nextRID, leafPage)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	return page.LeafLogPtrFromValuePtr(ptr)
 }
 
 func (l *unregisteredLeafPageLog) Flush() error {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -898,6 +898,10 @@ func Open(opts Options) (*DB, error) {
 		return openReadOnly(opts)
 	}
 
+	if err := ensureStorageLayoutDirs(opts.Dir); err != nil {
+		return nil, err
+	}
+
 	lock, err := lockfile.Acquire(filepath.Join(opts.Dir, "LOCK"))
 	if err != nil {
 		return nil, err

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1053,6 +1053,11 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		p.Close()
 		return nil, err
 	}
+	if err := vm.AddScanDir(layout.leafVLogDir); err != nil {
+		_ = vm.Close()
+		p.Close()
+		return nil, err
+	}
 	vm.SetDisableReadChecksum(opts.ValueLog.ReadIntegrity == IntegritySkipChecksums)
 	vm.SetDictLookup(opts.ValueLog.DictLookup)
 	vm.SetTemplateLookup(opts.ValueLog.TemplateLookup, opts.ValueLog.TemplateDecodeOptions)

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -893,6 +893,9 @@ func Open(opts Options) (*DB, error) {
 		return nil, err
 	}
 	warnInsecureDir(opts.Dir, opts.NotifyError)
+	if err := ensureNoLegacyMixedWALValueSegments(opts.Dir); err != nil {
+		return nil, err
+	}
 
 	if opts.ReadOnly {
 		return openReadOnly(opts)
@@ -1044,8 +1047,8 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 	}
 	p.SetVerifyOnRead(opts.VerifyOnRead)
 
-	valueLogDir := filepath.Join(opts.Dir, "wal")
-	vm, err := valuelog.NewManager(valueLogDir)
+	layout := resolveStorageLayout(opts.Dir)
+	vm, err := valuelog.NewManager(layout.valueVLogDir)
 	if err != nil {
 		p.Close()
 		return nil, err
@@ -1120,7 +1123,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 	}
 
 	if opts.Durability != DurabilityWALOffRelaxed {
-		segments, err := listWALSegments(opts.Dir)
+		segments, err := listRecoverySegments(opts.Dir)
 		if err != nil {
 			db.Close()
 			return nil, err

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1382,7 +1382,7 @@ func (db *DB) rootPageValid(p *pager.Pager, pageID uint64) bool {
 		if db == nil || db.valueLogManager == nil {
 			return false
 		}
-		data, err := db.valueLogManager.ReadUnsafe(ptr)
+		data, err := db.valueLogManager.ReadUnsafe(ptr.ValuePtr())
 		if err != nil {
 			return false
 		}

--- a/TreeDB/db/layout.go
+++ b/TreeDB/db/layout.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -25,6 +26,18 @@ func resolveStorageLayout(dir string) storageLayout {
 		valueVLogDir: filepath.Join(dir, valueVLogDirName),
 		leafVLogDir:  filepath.Join(dir, leafVLogDirName),
 	}
+}
+
+func WALDirPath(dir string) string {
+	return resolveStorageLayout(dir).walDir
+}
+
+func ValueLogDirPath(dir string) string {
+	return resolveStorageLayout(dir).valueVLogDir
+}
+
+func LeafLogDirPath(dir string) string {
+	return resolveStorageLayout(dir).leafVLogDir
 }
 
 func ensureStorageLayoutDirs(dir string) error {
@@ -59,4 +72,15 @@ func hasLegacyMixedWALValueSegments(dir string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func ensureNoLegacyMixedWALValueSegments(dir string) error {
+	legacy, err := hasLegacyMixedWALValueSegments(dir)
+	if err != nil {
+		return err
+	}
+	if !legacy {
+		return nil
+	}
+	return fmt.Errorf("treedb: legacy value-log segments found in %s; rebuild required for split wal/value_vlog layout", resolveStorageLayout(dir).walDir)
 }

--- a/TreeDB/db/layout.go
+++ b/TreeDB/db/layout.go
@@ -63,12 +63,14 @@ func hasLegacyMixedWALValueSegments(dir string) (bool, error) {
 		if entry.IsDir() {
 			continue
 		}
-		matched, err := filepath.Match("value-*.log", entry.Name())
-		if err != nil {
-			return false, err
-		}
-		if matched {
-			return true, nil
+		for _, pattern := range []string{"value-*.log", "vlog-*.log"} {
+			matched, err := filepath.Match(pattern, entry.Name())
+			if err != nil {
+				return false, err
+			}
+			if matched {
+				return true, nil
+			}
 		}
 	}
 	return false, nil

--- a/TreeDB/db/layout.go
+++ b/TreeDB/db/layout.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	walDirName       = "wal"
+	valueVLogDirName = "value_vlog"
+	leafVLogDirName  = "leaf_vlog"
+)
+
+type storageLayout struct {
+	rootDir      string
+	walDir       string
+	valueVLogDir string
+	leafVLogDir  string
+}
+
+func resolveStorageLayout(dir string) storageLayout {
+	return storageLayout{
+		rootDir:      dir,
+		walDir:       filepath.Join(dir, walDirName),
+		valueVLogDir: filepath.Join(dir, valueVLogDirName),
+		leafVLogDir:  filepath.Join(dir, leafVLogDirName),
+	}
+}
+
+func ensureStorageLayoutDirs(dir string) error {
+	layout := resolveStorageLayout(dir)
+	for _, path := range []string{layout.walDir, layout.valueVLogDir, layout.leafVLogDir} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasLegacyMixedWALValueSegments(dir string) (bool, error) {
+	layout := resolveStorageLayout(dir)
+	entries, err := os.ReadDir(layout.walDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		matched, err := filepath.Match("value-*.log", entry.Name())
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/TreeDB/db/layout_test.go
+++ b/TreeDB/db/layout_test.go
@@ -1,0 +1,86 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLayoutPaths_DefaultSplitDirs(t *testing.T) {
+	dir := t.TempDir()
+
+	layout := resolveStorageLayout(dir)
+	if got, want := layout.rootDir, dir; got != want {
+		t.Fatalf("rootDir=%q, want %q", got, want)
+	}
+	if got, want := layout.walDir, filepath.Join(dir, walDirName); got != want {
+		t.Fatalf("walDir=%q, want %q", got, want)
+	}
+	if got, want := layout.valueVLogDir, filepath.Join(dir, valueVLogDirName); got != want {
+		t.Fatalf("valueVLogDir=%q, want %q", got, want)
+	}
+	if got, want := layout.leafVLogDir, filepath.Join(dir, leafVLogDirName); got != want {
+		t.Fatalf("leafVLogDir=%q, want %q", got, want)
+	}
+}
+
+func TestOpen_FreshDBCreatesSplitStorageDirs(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	layout := resolveStorageLayout(dir)
+	for _, path := range []string{layout.walDir, layout.valueVLogDir, layout.leafVLogDir} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat(%s): %v", path, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("expected %s to be a directory", path)
+		}
+	}
+}
+
+func TestHasLegacyMixedWALValueSegments_DetectsValueLogsInWAL(t *testing.T) {
+	dir := t.TempDir()
+	layout := resolveStorageLayout(dir)
+	if err := os.MkdirAll(layout.walDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(wal): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(layout.walDir, "value-l0-000001.log"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile(value log): %v", err)
+	}
+
+	ok, err := hasLegacyMixedWALValueSegments(dir)
+	if err != nil {
+		t.Fatalf("hasLegacyMixedWALValueSegments: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected legacy mixed WAL/value layout to be detected")
+	}
+}
+
+func TestHasLegacyMixedWALValueSegments_IgnoresCommitOnlyWAL(t *testing.T) {
+	dir := t.TempDir()
+	layout := resolveStorageLayout(dir)
+	if err := os.MkdirAll(layout.walDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(wal): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(layout.walDir, "commit-l0-000001.log"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile(commit log): %v", err)
+	}
+
+	ok, err := hasLegacyMixedWALValueSegments(dir)
+	if err != nil {
+		t.Fatalf("hasLegacyMixedWALValueSegments: %v", err)
+	}
+	if ok {
+		t.Fatalf("unexpected legacy mixed WAL/value layout detection")
+	}
+}

--- a/TreeDB/db/layout_test.go
+++ b/TreeDB/db/layout_test.go
@@ -48,21 +48,25 @@ func TestOpen_FreshDBCreatesSplitStorageDirs(t *testing.T) {
 }
 
 func TestHasLegacyMixedWALValueSegments_DetectsValueLogsInWAL(t *testing.T) {
-	dir := t.TempDir()
-	layout := resolveStorageLayout(dir)
-	if err := os.MkdirAll(layout.walDir, 0o700); err != nil {
-		t.Fatalf("MkdirAll(wal): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(layout.walDir, "value-l0-000001.log"), []byte("x"), 0o600); err != nil {
-		t.Fatalf("WriteFile(value log): %v", err)
-	}
+	for _, name := range []string{"value-l0-000001.log", "vlog-l0-000001.log"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			layout := resolveStorageLayout(dir)
+			if err := os.MkdirAll(layout.walDir, 0o700); err != nil {
+				t.Fatalf("MkdirAll(wal): %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(layout.walDir, name), []byte("x"), 0o600); err != nil {
+				t.Fatalf("WriteFile(value log): %v", err)
+			}
 
-	ok, err := hasLegacyMixedWALValueSegments(dir)
-	if err != nil {
-		t.Fatalf("hasLegacyMixedWALValueSegments: %v", err)
-	}
-	if !ok {
-		t.Fatalf("expected legacy mixed WAL/value layout to be detected")
+			ok, err := hasLegacyMixedWALValueSegments(dir)
+			if err != nil {
+				t.Fatalf("hasLegacyMixedWALValueSegments: %v", err)
+			}
+			if !ok {
+				t.Fatalf("expected legacy mixed WAL/value layout to be detected")
+			}
+		})
 	}
 }
 

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -13,9 +13,9 @@ import (
 // This is used when Options.IndexOuterLeavesInValueLog is enabled.
 // Implementations are expected to reuse the existing value-log record encoding
 // and compression semantics (i.e. they should append normal value-log records
-// and return ValuePtr references).
+// and return LeafLogPtr references).
 type LeafPageLog interface {
-	AppendLeafPage(leafPage []byte) (page.ValuePtr, error)
+	AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error)
 	Flush() error
 	Sync() error
 }

--- a/TreeDB/db/open_readonly.go
+++ b/TreeDB/db/open_readonly.go
@@ -13,6 +13,9 @@ import (
 )
 
 func openReadOnly(opts Options) (*DB, error) {
+	if err := ensureNoLegacyMixedWALValueSegments(opts.Dir); err != nil {
+		return nil, err
+	}
 	var lock *lockfile.Lock
 	lockPath := filepath.Join(opts.Dir, "LOCK")
 	if l, err := lockfile.AcquireShared(lockPath); err == nil {
@@ -37,8 +40,8 @@ func openReadOnly(opts Options) (*DB, error) {
 	}
 	p.SetVerifyOnRead(opts.VerifyOnRead)
 
-	valueLogDir := filepath.Join(opts.Dir, "wal")
-	vm, err := valuelog.NewManager(valueLogDir)
+	layout := resolveStorageLayout(opts.Dir)
+	vm, err := valuelog.NewManager(layout.valueVLogDir)
 	if err != nil {
 		_ = p.Close()
 		_ = lock.Close()
@@ -115,6 +118,9 @@ func openReadOnly(opts Options) (*DB, error) {
 }
 
 func openReadOnlyNoLock(opts Options) (*DB, error) {
+	if err := ensureNoLegacyMixedWALValueSegments(opts.Dir); err != nil {
+		return nil, err
+	}
 	idxPath := filepath.Join(opts.Dir, indexFileName)
 	if _, err := os.Stat(idxPath); err != nil {
 		return nil, err
@@ -129,8 +135,8 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 	}
 	p.SetVerifyOnRead(opts.VerifyOnRead)
 
-	valueLogDir := filepath.Join(opts.Dir, "wal")
-	vm, err := valuelog.NewManager(valueLogDir)
+	layout := resolveStorageLayout(opts.Dir)
+	vm, err := valuelog.NewManager(layout.valueVLogDir)
 	if err != nil {
 		_ = p.Close()
 		return nil, err

--- a/TreeDB/db/open_readonly.go
+++ b/TreeDB/db/open_readonly.go
@@ -47,6 +47,12 @@ func openReadOnly(opts Options) (*DB, error) {
 		_ = lock.Close()
 		return nil, err
 	}
+	if err := vm.AddScanDir(layout.leafVLogDir); err != nil {
+		_ = vm.Close()
+		_ = p.Close()
+		_ = lock.Close()
+		return nil, err
+	}
 	vm.SetDisableReadChecksum(opts.ValueLog.ReadIntegrity == IntegritySkipChecksums)
 	vm.SetDictLookup(opts.ValueLog.DictLookup)
 	vm.SetTemplateLookup(opts.ValueLog.TemplateLookup, opts.ValueLog.TemplateDecodeOptions)
@@ -138,6 +144,11 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 	layout := resolveStorageLayout(opts.Dir)
 	vm, err := valuelog.NewManager(layout.valueVLogDir)
 	if err != nil {
+		_ = p.Close()
+		return nil, err
+	}
+	if err := vm.AddScanDir(layout.leafVLogDir); err != nil {
+		_ = vm.Close()
 		_ = p.Close()
 		return nil, err
 	}

--- a/TreeDB/db/root_collapse_test.go
+++ b/TreeDB/db/root_collapse_test.go
@@ -156,7 +156,7 @@ func testDeleteMostKeysCollapsesRootWithPointerValues(t *testing.T) {
 	val := bytes.Repeat([]byte("y"), 256)
 	const total = 5000
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}

--- a/TreeDB/db/vacuum_online_swap_test.go
+++ b/TreeDB/db/vacuum_online_swap_test.go
@@ -28,7 +28,7 @@ func collectLeafRefIDsFromRoot(t *testing.T, d *DB, rootID uint64) map[uint64]st
 			return fmt.Errorf("checksum mismatch on page %d", pageID)
 		}
 		return nil
-	}, func(ptr page.ValuePtr) error {
+	}, func(ptr page.LeafLogPtr) error {
 		id, err := page.EncodeLeafRef(ptr)
 		if err != nil {
 			return err
@@ -47,7 +47,7 @@ type countingLeafPageLog struct {
 	appends atomic.Uint64
 }
 
-func (l *countingLeafPageLog) AppendLeafPage(leafPage []byte) (page.ValuePtr, error) {
+func (l *countingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	l.appends.Add(1)
 	return l.inner.AppendLeafPage(leafPage)
 }

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -574,13 +574,10 @@ func collectLeafRefValueLogRefCounts(ctx context.Context, p *pager.Pager, rootID
 			}
 		}
 		return nil
-	}, func(ptr page.ValuePtr) error {
-		if !page.IsValueLogFileID(ptr.FileID) {
-			return nil
-		}
-		refs[ptr.FileID]++
+	}, func(ptr page.LeafLogPtr) error {
+		refs[ptr.ValueLogFileID()]++
 		found = true
-		return collectNestedLeafPageValueLogRefCounts(ptr, reader, refs, &leafScratch)
+		return collectNestedLeafPageValueLogRefCounts(ptr.ValuePtr(), reader, refs, &leafScratch)
 	})
 	return found, err
 }

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -41,7 +41,7 @@ func TestValueLogGC_RemovesUnreferencedSegment(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestValueLogGC_ProtectedPathsDoNotKeepHistoricalRewriteLanes(t *testing.T) 
 	}
 
 	protected := []string{
-		filepath.Join(dir, "wal", "value-l0-000002.log"),
+		filepath.Join(dir, "value_vlog", "value-l0-000002.log"),
 	}
 
 	stats, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{ProtectedPaths: protected})
@@ -158,8 +158,8 @@ func TestValueLogGC_ProtectedPathsDoNotKeepHistoricalRewriteLanes(t *testing.T) 
 	}
 
 	for _, path := range []string{
-		filepath.Join(dir, "wal", "value-l250-000001.log"),
-		filepath.Join(dir, "wal", "value-l250-000002.log"),
+		filepath.Join(dir, "value_vlog", "value-l250-000001.log"),
+		filepath.Join(dir, "value_vlog", "value-l250-000002.log"),
 	} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("expected %s to be deleted, err=%v", filepath.Base(path), err)
@@ -167,8 +167,8 @@ func TestValueLogGC_ProtectedPathsDoNotKeepHistoricalRewriteLanes(t *testing.T) 
 	}
 
 	for _, path := range []string{
-		filepath.Join(dir, "wal", "value-l0-000001.log"),
-		filepath.Join(dir, "wal", "value-l0-000002.log"),
+		filepath.Join(dir, "value_vlog", "value-l0-000001.log"),
+		filepath.Join(dir, "value_vlog", "value-l0-000002.log"),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected protected-lane window to retain %s, err=%v", filepath.Base(path), err)
@@ -196,9 +196,9 @@ func TestValueLogGC_ProtectedPathBreakdownStats(t *testing.T) {
 		t.Fatalf("RefreshValueLogSet: %v", err)
 	}
 
-	inUseOnlyPath := filepath.Join(dir, "wal", "value-l0-000001.log")
-	retainedOnlyPath := filepath.Join(dir, "wal", "value-l0-000002.log")
-	overlapPath := filepath.Join(dir, "wal", "value-l0-000003.log")
+	inUseOnlyPath := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
+	retainedOnlyPath := filepath.Join(dir, "value_vlog", "value-l0-000002.log")
+	overlapPath := filepath.Join(dir, "value_vlog", "value-l0-000003.log")
 	observedInUseID, err := valuelog.EncodeFileID(0, 1)
 	if err != nil {
 		t.Fatalf("observed in-use fileid: %v", err)
@@ -319,7 +319,7 @@ func TestValueLogGC_ProtectedPathBreakdownStats(t *testing.T) {
 func TestValueLogGC_KeepsReferencedPointerSegments_WithOuterLeavesInValueLog(t *testing.T) {
 	dir := t.TempDir()
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -373,7 +373,7 @@ func TestValueLogGC_KeepsReferencedPointerSegments_WithOuterLeavesInValueLog(t *
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	leafLog := newRewriteWriter(filepath.Join(dir, "wal"), 0, 0, 0)
+	leafLog := newRewriteWriter(filepath.Join(dir, "value_vlog"), 0, 0, 0)
 	leafLog.blockCompression = false
 	leafLog.blockCodec = valuelog.BlockCodecSnappy
 	db.SetLeafPageLog(leafLog)
@@ -786,7 +786,7 @@ func valueLogRefSetFromCounts(counts map[uint32]uint64) map[uint32]struct{} {
 
 func appendPointersInNewSegment(t *testing.T, dir string, lane, seq uint32, ridBase uint64, n int, valueAt func(i int) []byte) []page.ValuePtr {
 	t.Helper()
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}

--- a/TreeDB/db/vlog_health.go
+++ b/TreeDB/db/vlog_health.go
@@ -150,7 +150,7 @@ func updateValueLogHealthAfterGC(dbDir string, set *valuelog.Set, referenced map
 		}
 	}
 
-	segments, err := listWALSegments(dbDir)
+	segments, err := listValueLogSegments(dbDir)
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func updateValueLogHealthAfterRewrite(dbDir string, oldValueIDs map[uint32]struc
 		return saveValueLogHealth(path, out)
 	}
 
-	segments, err := listWALSegments(dbDir)
+	segments, err := listValueLogSegments(dbDir)
 	if err != nil {
 		return err
 	}

--- a/TreeDB/db/vlog_leafref_maintenance_test.go
+++ b/TreeDB/db/vlog_leafref_maintenance_test.go
@@ -52,7 +52,7 @@ func TestValueLogGC_WithLeafPagesInValueLog_KeepsReferencedLeafSegments(t *testi
 		t.Fatalf("open: %v", err)
 	}
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		_ = db.Close()
 		t.Fatalf("mkdir wal: %v", err)
@@ -120,7 +120,7 @@ func TestValueLogRewriteOffline_PreservesLeafPagesInValueLogFormatConfig(t *test
 		t.Fatalf("open: %v", err)
 	}
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		_ = db.Close()
 		t.Fatalf("mkdir wal: %v", err)
@@ -207,7 +207,7 @@ func TestValueLogRewriteOnline_WithLeafPagesInValueLog_ReopenPreservesData(t *te
 		t.Fatalf("open: %v", err)
 	}
 
-	leafLog := newRewriteWriter(filepath.Join(dir, "wal"), 0, 0, 64<<10)
+	leafLog := newRewriteWriter(filepath.Join(dir, "value_vlog"), 0, 0, 64<<10)
 	leafLog.blockCompression = false
 	leafLog.blockCodec = valuelog.BlockCodecSnappy
 	db.SetLeafPageLog(leafLog)
@@ -392,7 +392,7 @@ func TestValueLogRewriteOnline_RewritesLeafRefsAndReclaimsSegments(t *testing.T)
 		}
 	}()
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -604,7 +604,7 @@ func TestValueLogRewriteOnline_RewritesMultipleLeafRefSourceSegmentsAndReopensRW
 		}
 	}()
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -760,7 +760,7 @@ func TestValueLogRewriteOnline_PostRewriteWritesDoNotReintroduceLeafRefSources(t
 		}
 	}()
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -929,7 +929,7 @@ func TestValueLogRewriteOnline_UnsyncedLeafRefRewriteRemainsReopenable(t *testin
 		}
 	}()
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -1054,7 +1054,7 @@ func TestValueLogRewriteOnline_UnsyncedRewriteThenVacuumRemainsReopenable(t *tes
 		}
 	}()
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -1192,7 +1192,7 @@ func TestValueLogRewriteOnline_WALOnLeafRefsPreserveNestedValueSegments(t *testi
 		}
 	}()
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}

--- a/TreeDB/db/vlog_leafref_maintenance_test.go
+++ b/TreeDB/db/vlog_leafref_maintenance_test.go
@@ -338,11 +338,11 @@ func collectNestedLeafValueLogFileCounts(t *testing.T, reader interface {
 			continue
 		}
 		if len(sourceSet) > 0 {
-			if _, ok := sourceSet[ptr.FileID]; !ok {
+			if _, ok := sourceSet[ptr.ValueLogFileID()]; !ok {
 				continue
 			}
 		}
-		leafPage, err := reader.ReadUnsafe(ptr)
+		leafPage, err := reader.ReadUnsafe(ptr.ValuePtr())
 		if err != nil {
 			t.Fatalf("read leaf page file=%d offset=%d: %v", ptr.FileID, ptr.Offset, err)
 		}
@@ -434,7 +434,7 @@ func TestValueLogRewriteOnline_RewritesLeafRefsAndReclaimsSegments(t *testing.T)
 		if !ok {
 			continue
 		}
-		refsByFile[ptr.FileID] = append(refsByFile[ptr.FileID], id)
+		refsByFile[ptr.ValueLogFileID()] = append(refsByFile[ptr.ValueLogFileID()], id)
 	}
 
 	active := map[uint32]struct{}{}
@@ -478,7 +478,7 @@ func TestValueLogRewriteOnline_RewritesLeafRefsAndReclaimsSegments(t *testing.T)
 	if !ok {
 		t.Fatalf("expected leafref id, got %d", moveID)
 	}
-	leafPage, err := db.valueLogManager.ReadUnsafe(movePtr)
+	leafPage, err := db.valueLogManager.ReadUnsafe(movePtr.ValuePtr())
 	if err != nil {
 		t.Fatalf("read leaf page: %v", err)
 	}
@@ -508,7 +508,7 @@ func TestValueLogRewriteOnline_RewritesLeafRefsAndReclaimsSegments(t *testing.T)
 	inTarget := 0
 	for _, id := range refs2 {
 		ptr, ok := page.DecodeLeafRef(id)
-		if ok && ptr.FileID == targetID {
+		if ok && ptr.ValueLogFileID() == targetID {
 			inTarget++
 		}
 	}
@@ -538,7 +538,7 @@ func TestValueLogRewriteOnline_RewritesLeafRefsAndReclaimsSegments(t *testing.T)
 	refs3 := collectLeafRefs(t, db.Pager(), state3.RootPageID)
 	for _, id := range refs3 {
 		ptr, ok := page.DecodeLeafRef(id)
-		if ok && ptr.FileID == targetID {
+		if ok && ptr.ValueLogFileID() == targetID {
 			t.Fatalf("leaf ref still points at source segment %d after rewrite", targetID)
 		}
 	}
@@ -644,7 +644,7 @@ func TestValueLogRewriteOnline_RewritesMultipleLeafRefSourceSegmentsAndReopensRW
 		if !ok {
 			continue
 		}
-		refsByFile[ptr.FileID]++
+		refsByFile[ptr.ValueLogFileID()]++
 	}
 
 	set := db.valueLogManager.CurrentSet()
@@ -697,8 +697,8 @@ func TestValueLogRewriteOnline_RewritesMultipleLeafRefSourceSegmentsAndReopensRW
 		if !ok {
 			continue
 		}
-		if _, ok := sourceSet[ptr.FileID]; ok {
-			t.Fatalf("leaf ref still points at rewritten source segment %d", ptr.FileID)
+		if _, ok := sourceSet[ptr.ValueLogFileID()]; ok {
+			t.Fatalf("leaf ref still points at rewritten source segment %d", ptr.ValueLogFileID())
 		}
 	}
 
@@ -797,7 +797,7 @@ func TestValueLogRewriteOnline_PostRewriteWritesDoNotReintroduceLeafRefSources(t
 		if !ok {
 			continue
 		}
-		refsByFile[ptr.FileID]++
+		refsByFile[ptr.ValueLogFileID()]++
 	}
 
 	set := db.valueLogManager.CurrentSet()
@@ -842,8 +842,8 @@ func TestValueLogRewriteOnline_PostRewriteWritesDoNotReintroduceLeafRefSources(t
 		if !ok {
 			continue
 		}
-		if _, ok := sourceSet[ptr.FileID]; ok {
-			t.Fatalf("leaf ref still points at rewritten source segment %d after rewrite", ptr.FileID)
+		if _, ok := sourceSet[ptr.ValueLogFileID()]; ok {
+			t.Fatalf("leaf ref still points at rewritten source segment %d after rewrite", ptr.ValueLogFileID())
 		}
 	}
 
@@ -866,8 +866,8 @@ func TestValueLogRewriteOnline_PostRewriteWritesDoNotReintroduceLeafRefSources(t
 		if !ok {
 			continue
 		}
-		if _, ok := sourceSet[ptr.FileID]; ok {
-			t.Fatalf("post-rewrite write reintroduced source segment %d", ptr.FileID)
+		if _, ok := sourceSet[ptr.ValueLogFileID()]; ok {
+			t.Fatalf("post-rewrite write reintroduced source segment %d", ptr.ValueLogFileID())
 		}
 	}
 
@@ -962,7 +962,7 @@ func TestValueLogRewriteOnline_UnsyncedLeafRefRewriteRemainsReopenable(t *testin
 		if !ok {
 			continue
 		}
-		refsByFile[ptr.FileID]++
+		refsByFile[ptr.ValueLogFileID()]++
 	}
 
 	set := db.valueLogManager.CurrentSet()
@@ -1087,7 +1087,7 @@ func TestValueLogRewriteOnline_UnsyncedRewriteThenVacuumRemainsReopenable(t *tes
 		if !ok {
 			continue
 		}
-		refsByFile[ptr.FileID]++
+		refsByFile[ptr.ValueLogFileID()]++
 	}
 
 	set := db.valueLogManager.CurrentSet()
@@ -1238,7 +1238,7 @@ func TestValueLogRewriteOnline_WALOnLeafRefsPreserveNestedValueSegments(t *testi
 		if !ok {
 			continue
 		}
-		refsByFile[ptr.FileID]++
+		refsByFile[ptr.ValueLogFileID()]++
 	}
 
 	set := db.valueLogManager.CurrentSet()

--- a/TreeDB/db/vlog_refresh_scan_test.go
+++ b/TreeDB/db/vlog_refresh_scan_test.go
@@ -13,7 +13,7 @@ import (
 
 func writeValueLogSegment(t *testing.T, dir string, lane, seq uint32) (path string, fileID uint32) {
 	t.Helper()
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1395,10 +1395,11 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 
 	nextRID := uint64(0)
 	var (
-		segments    []logSegment
-		lane        uint32
-		startSeq    uint32
-		needSegScan = true
+		segments     []logSegment
+		lane         uint32
+		startSeq     uint32
+		leafStartSeq uint32
+		needSegScan  = true
 	)
 	if db.valueLogManager != nil {
 		if hintLane, hintSeq, ok := db.valueLogManager.RewriteLaneHint(); ok {
@@ -1407,6 +1408,9 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 				needSegScan = true
 			} else if os.IsNotExist(statErr) {
 				lane, startSeq = hintLane, hintSeq
+				if db.indexOuterLeavesInValueLog {
+					leafStartSeq = maxRewriteLaneSeqFromSet(set, rewriteLeafLogLaneID)
+				}
 				needSegScan = false
 			} else {
 				_ = db.valueLogManager.Release(set)
@@ -1432,6 +1436,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		}
 		if db.indexOuterLeavesInValueLog {
 			lane, startSeq = chooseRewriteLane(segments, rewriteLeafLogLaneID)
+			leafStartSeq = maxRewriteLaneSeq(segments, rewriteLeafLogLaneID)
 		} else {
 			lane, startSeq = chooseRewriteLane(segments)
 		}
@@ -1458,7 +1463,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	layout := resolveStorageLayout(db.dir)
 	writer := newRewriteWriter(layout.valueVLogDir, lane, startSeq, maxBytes)
 	if db.indexOuterLeavesInValueLog {
-		writer.ConfigureLeafLog(layout.leafVLogDir, rewriteLeafLogLaneID, maxRewriteLaneSeq(segments, rewriteLeafLogLaneID))
+		writer.ConfigureLeafLog(layout.leafVLogDir, rewriteLeafLogLaneID, leafStartSeq)
 	}
 	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
 	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
@@ -4452,6 +4457,23 @@ func maxRewriteLaneSeq(segments []logSegment, want uint32) uint32 {
 		}
 		if uint32(seg.seq) > maxSeq {
 			maxSeq = uint32(seg.seq)
+		}
+	}
+	return maxSeq
+}
+
+func maxRewriteLaneSeqFromSet(set *valuelog.Set, want uint32) uint32 {
+	if set == nil || len(set.Files) == 0 {
+		return 0
+	}
+	var maxSeq uint32
+	for id := range set.Files {
+		lane, seq := valuelog.DecodeFileID(id)
+		if lane != want {
+			continue
+		}
+		if seq > maxSeq {
+			maxSeq = seq
 		}
 	}
 	return maxSeq

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1430,7 +1430,11 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		if err != nil {
 			return stats, err
 		}
-		lane, startSeq = chooseRewriteLane(segments)
+		if db.indexOuterLeavesInValueLog {
+			lane, startSeq = chooseRewriteLane(segments, rewriteLeafLogLaneID)
+		} else {
+			lane, startSeq = chooseRewriteLane(segments)
+		}
 	}
 	if opts.ReserveRIDs == nil && nextRID == 0 {
 		nextRID, err = rewriteRIDStartScanner(segments)
@@ -1451,7 +1455,11 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			maxBytes = packedMax
 		}
 	}
-	writer := newRewriteWriter(resolveStorageLayout(db.dir).valueVLogDir, lane, startSeq, maxBytes)
+	layout := resolveStorageLayout(db.dir)
+	writer := newRewriteWriter(layout.valueVLogDir, lane, startSeq, maxBytes)
+	if db.indexOuterLeavesInValueLog {
+		writer.ConfigureLeafLog(layout.leafVLogDir, rewriteLeafLogLaneID, maxRewriteLaneSeq(segments, rewriteLeafLogLaneID))
+	}
 	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
 	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
 	defer func() { _ = writer.Close() }()
@@ -2796,7 +2804,12 @@ func ValueLogRewriteOffline(opts Options) (ValueLogRewriteStats, error) {
 	stats.SegmentsBefore = beforeSegs
 	stats.BytesBefore = beforeBytes
 
-	lane, startSeq := chooseRewriteLane(segments)
+	var lane, startSeq uint32
+	if opts.IndexOuterLeavesInValueLog {
+		lane, startSeq = chooseRewriteLane(segments, rewriteLeafLogLaneID)
+	} else {
+		lane, startSeq = chooseRewriteLane(segments)
+	}
 	nextRID, err := rewriteRIDStartScanner(segments)
 	if err != nil {
 		_ = d.Close()
@@ -2815,7 +2828,11 @@ func ValueLogRewriteOffline(opts Options) (ValueLogRewriteStats, error) {
 			maxBytes = packedMax
 		}
 	}
-	writer := newRewriteWriter(resolveStorageLayout(opts.Dir).valueVLogDir, lane, startSeq, maxBytes)
+	layout := resolveStorageLayout(opts.Dir)
+	writer := newRewriteWriter(layout.valueVLogDir, lane, startSeq, maxBytes)
+	if opts.IndexOuterLeavesInValueLog {
+		writer.ConfigureLeafLog(layout.leafVLogDir, rewriteLeafLogLaneID, maxRewriteLaneSeq(segments, rewriteLeafLogLaneID))
+	}
 	writer.nextRID = nextRID
 	// Offline rewrite prioritizes final bytes on disk over encode CPU, so keep
 	// compressed output whenever it reduces stored bytes.
@@ -3019,15 +3036,20 @@ func ValueLogRewriteOffline(opts Options) (ValueLogRewriteStats, error) {
 }
 
 type rewriteWriter struct {
-	walDir  string
-	lane    uint32
-	seq     uint32
-	maxSize int64
-	nextRID uint64
+	walDir   string
+	lane     uint32
+	seq      uint32
+	maxSize  int64
+	leafDir  string
+	leafLane uint32
+	leafSeq  uint32
+	nextRID  uint64
 	// currentPath/currentFileID cache the active writer segment identity so
 	// CurrentValueLogSegment can avoid per-call path/fileID recomputation.
-	currentPath   string
-	currentFileID uint32
+	currentPath       string
+	currentFileID     uint32
+	leafCurrentPath   string
+	leafCurrentFileID uint32
 	// blockCompression enables per-frame block compression for dictID=0 append
 	// paths (used by online rewrite). Offline rewrites use AppendRawRecord and do
 	// not consult this setting.
@@ -3058,6 +3080,7 @@ type rewriteWriter struct {
 	templateOuterLeafInBytes  int64
 	templateOuterLeafOutBytes int64
 	w                         *valuelog.Writer
+	leafW                     *valuelog.Writer
 	records                   int
 	createdIDs                []uint32
 
@@ -3079,6 +3102,17 @@ const (
 
 func newRewriteWriter(walDir string, lane, startSeq uint32, maxSize int64) *rewriteWriter {
 	return &rewriteWriter{walDir: walDir, lane: lane, seq: startSeq, maxSize: maxSize}
+}
+
+const rewriteLeafLogLaneID uint32 = 255
+
+func (w *rewriteWriter) ConfigureLeafLog(leafDir string, lane, startSeq uint32) {
+	if w == nil {
+		return
+	}
+	w.leafDir = leafDir
+	w.leafLane = lane
+	w.leafSeq = startSeq
 }
 
 func rewriteDictFrameRecordLen(rawPayloadBytes, k int) int64 {
@@ -3180,6 +3214,9 @@ func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error)
 	if w.nextRID == 0 {
 		return page.LeafLogPtr{}, fmt.Errorf("value-log rid space exhausted")
 	}
+	if w.leafDir != "" {
+		return w.appendLeafPageSplit(rid, leafPage)
+	}
 	if w.blockCompression && w.leafDictID != 0 && len(w.leafDict) > 0 && rewriteAllowDictForSmallPayload(leafPage) {
 		// LeafRef IDs intentionally omit grouped sub-index bits and therefore
 		// require K=1 frames. Use single-record append so decoded LeafRef pointers
@@ -3207,10 +3244,52 @@ func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error)
 	return leafPtr, nil
 }
 
+func (w *rewriteWriter) appendLeafPageSplit(rid uint64, leafPage []byte) (page.LeafLogPtr, error) {
+	if err := w.ensureLeafWriter(); err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	dictID := w.leafDictID
+	dict := w.leafDict
+	if w.blockCompression && dictID != 0 && len(dict) > 0 && rewriteAllowDictForSmallPayload(leafPage) {
+		dictID, dict, leafPage = w.applyTemplateCompression(rewriteTemplateClassOuterLeaf, dictID, dict, leafPage)
+		if err := w.maybeRotateLeafForEstimate(rewriteDictFrameRecordLen(len(leafPage), 1)); err != nil {
+			return page.LeafLogPtr{}, err
+		}
+		ptr, err := w.leafW.Append(dictID, dict, rid, leafPage)
+		if err != nil {
+			return page.LeafLogPtr{}, err
+		}
+		w.records++
+		return page.LeafLogPtrFromValuePtr(ptr)
+	}
+	dictID, dict, leafPage = w.applyTemplateCompression(rewriteTemplateClassOuterLeaf, 0, nil, leafPage)
+	if dictID != 0 || len(dict) != 0 {
+		return page.LeafLogPtr{}, fmt.Errorf("vlog-rewrite: unexpected outer-leaf dict/template state")
+	}
+	if err := w.maybeRotateLeafForEstimate(int64(valuelog.HeaderSize + len(leafPage))); err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	ptr, err := w.leafW.Append(0, nil, rid, leafPage)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	w.records++
+	return page.LeafLogPtrFromValuePtr(ptr)
+}
+
 // CurrentValueLogSegment reports the writer's current segment identity.
 // This lets commit publication register the segment without directory scans.
 func (w *rewriteWriter) CurrentValueLogSegment() (string, uint32, bool) {
-	if w == nil || w.currentPath == "" || w.currentFileID == 0 {
+	if w == nil {
+		return "", 0, false
+	}
+	if w.leafDir != "" {
+		if w.leafCurrentPath == "" || w.leafCurrentFileID == 0 {
+			return "", 0, false
+		}
+		return w.leafCurrentPath, w.leafCurrentFileID, true
+	}
+	if w.currentPath == "" || w.currentFileID == 0 {
 		return "", 0, false
 	}
 	return w.currentPath, w.currentFileID, true
@@ -3261,6 +3340,71 @@ func (w *rewriteWriter) rotate() error {
 	return nil
 }
 
+func (w *rewriteWriter) ensureLeafWriter() error {
+	if w == nil {
+		return errors.New("vlog-rewrite: nil writer")
+	}
+	if w.leafDir == "" {
+		return w.ensureWriter()
+	}
+	if w.leafW != nil {
+		return nil
+	}
+	return w.rotateLeaf()
+}
+
+func (w *rewriteWriter) maybeRotateLeafForEstimate(estimate int64) error {
+	if w == nil || w.leafW == nil {
+		return nil
+	}
+	if w.maxSize <= 0 {
+		return nil
+	}
+	if estimate < 0 {
+		estimate = 0
+	}
+	if w.leafW.Size() == 0 {
+		return nil
+	}
+	if w.leafW.Size()+estimate <= w.maxSize {
+		return nil
+	}
+	return w.rotateLeaf()
+}
+
+func (w *rewriteWriter) rotateLeaf() error {
+	nextSeq := w.leafSeq + 1
+	fileID, err := valuelog.EncodeFileID(w.leafLane, nextSeq)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(w.leafDir, fmt.Sprintf("value-l%d-%06d.log", w.leafLane, nextSeq))
+	if w.leafW == nil {
+		writer, err := valuelog.NewWriter(path, fileID)
+		if err != nil {
+			return err
+		}
+		writer.SetBlockCompression(w.blockCodec, w.blockCompression)
+		writer.SetKeepPolicy(w.keepIoNsPerByte, w.keepEncodeNsRaw, w.keepSafetyMargin)
+		w.leafW = writer
+		w.leafSeq = nextSeq
+		w.createdIDs = append(w.createdIDs, fileID)
+		w.leafCurrentPath = path
+		w.leafCurrentFileID = fileID
+		return nil
+	}
+	if err := w.leafW.RotateTo(path, fileID); err != nil {
+		return err
+	}
+	w.leafW.SetBlockCompression(w.blockCodec, w.blockCompression)
+	w.leafW.SetKeepPolicy(w.keepIoNsPerByte, w.keepEncodeNsRaw, w.keepSafetyMargin)
+	w.leafSeq = nextSeq
+	w.createdIDs = append(w.createdIDs, fileID)
+	w.leafCurrentPath = path
+	w.leafCurrentFileID = fileID
+	return nil
+}
+
 func (w *rewriteWriter) SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64) {
 	if w == nil {
 		return
@@ -3270,6 +3414,9 @@ func (w *rewriteWriter) SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, saf
 	w.keepSafetyMargin = safetyMargin
 	if w.w != nil {
 		w.w.SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin)
+	}
+	if w.leafW != nil {
+		w.leafW.SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin)
 	}
 }
 
@@ -3583,9 +3730,18 @@ func (w *rewriteWriter) Sync() error {
 		return err
 	}
 	if w.w == nil {
-		return nil
+		if w.leafW == nil {
+			return nil
+		}
+		return w.leafW.Sync()
 	}
-	return w.w.Sync()
+	if err := w.w.Sync(); err != nil {
+		return err
+	}
+	if w.leafW != nil {
+		return w.leafW.Sync()
+	}
+	return nil
 }
 
 func (w *rewriteWriter) Flush() error {
@@ -3596,9 +3752,18 @@ func (w *rewriteWriter) Flush() error {
 		return err
 	}
 	if w.w == nil {
-		return nil
+		if w.leafW == nil {
+			return nil
+		}
+		return w.leafW.Flush()
 	}
-	return w.w.Flush()
+	if err := w.w.Flush(); err != nil {
+		return err
+	}
+	if w.leafW != nil {
+		return w.leafW.Flush()
+	}
+	return nil
 }
 
 func (w *rewriteWriter) Close() error {
@@ -3609,10 +3774,15 @@ func (w *rewriteWriter) Close() error {
 	if err := w.flushPendingDictBatch(); err != nil {
 		return err
 	}
-	if w.w == nil {
-		return nil
+	if w.w != nil {
+		if err := w.w.Close(); err != nil {
+			return err
+		}
 	}
-	return w.w.Close()
+	if w.leafW != nil {
+		return w.leafW.Close()
+	}
+	return nil
 }
 
 func (w *rewriteWriter) createdFileIDs() ([]uint32, error) {
@@ -4204,9 +4374,13 @@ func readRawRecord(r io.ReaderAt, ptr page.ValuePtr) ([]byte, error) {
 	return buf, nil
 }
 
-func chooseRewriteLane(segments []logSegment) (uint32, uint32) {
+func chooseRewriteLane(segments []logSegment, reserved ...uint32) (uint32, uint32) {
 	used := make(map[uint32]struct{})
 	maxSeq := make(map[uint32]uint32)
+	reservedSet := make(map[uint32]struct{}, len(reserved))
+	for _, lane := range reserved {
+		reservedSet[lane] = struct{}{}
+	}
 	for _, seg := range segments {
 		if !seg.valueLog {
 			continue
@@ -4218,11 +4392,31 @@ func chooseRewriteLane(segments []logSegment) (uint32, uint32) {
 		}
 	}
 	for lane := uint32(255); lane > 0; lane-- {
+		if _, skip := reservedSet[lane]; skip {
+			continue
+		}
 		if _, ok := used[lane]; !ok {
 			return lane, 0
 		}
 	}
 	return 0, maxSeq[0]
+}
+
+func maxRewriteLaneSeq(segments []logSegment, want uint32) uint32 {
+	var maxSeq uint32
+	for _, seg := range segments {
+		if !seg.valueLog {
+			continue
+		}
+		lane, _ := valuelog.DecodeFileID(seg.fileID)
+		if lane != want {
+			continue
+		}
+		if uint32(seg.seq) > maxSeq {
+			maxSeq = uint32(seg.seq)
+		}
+	}
+	return maxSeq
 }
 
 func valueLogSegmentStats(dir string) (count int, bytes int64, err error) {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -41,7 +41,7 @@ const leafRefRewriteInlineChildCap = 64  // stack-backed child-id scratch for co
 const leafRefRewriteInlineRemapCap = 8   // inline remap cache before promoting to map
 
 var rewriteRIDStartScanner = nextRewriteRIDStart
-var rewriteWALSegmentsLister = listWALSegments
+var rewriteWALSegmentsLister = listValueLogSegments
 
 func rewriteAllowDictForSmallPayload(value []byte) bool {
 	if len(value) < page.PageSize {
@@ -1402,7 +1402,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	)
 	if db.valueLogManager != nil {
 		if hintLane, hintSeq, ok := db.valueLogManager.RewriteLaneHint(); ok {
-			probePath := filepath.Join(db.dir, "wal", fmt.Sprintf("value-l%d-%06d.log", hintLane, hintSeq+1))
+			probePath := filepath.Join(resolveStorageLayout(db.dir).valueVLogDir, fmt.Sprintf("value-l%d-%06d.log", hintLane, hintSeq+1))
 			if _, statErr := os.Stat(probePath); statErr == nil {
 				needSegScan = true
 			} else if os.IsNotExist(statErr) {
@@ -1451,7 +1451,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			maxBytes = packedMax
 		}
 	}
-	writer := newRewriteWriter(filepath.Join(db.dir, "wal"), lane, startSeq, maxBytes)
+	writer := newRewriteWriter(resolveStorageLayout(db.dir).valueVLogDir, lane, startSeq, maxBytes)
 	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
 	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
 	defer func() { _ = writer.Close() }()
@@ -2749,7 +2749,7 @@ func ValueLogRewriteOffline(opts Options) (ValueLogRewriteStats, error) {
 		return stats, err
 	}
 
-	segments, err := listWALSegments(opts.Dir)
+	segments, err := listValueLogSegments(opts.Dir)
 	if err != nil {
 		return stats, err
 	}
@@ -2780,7 +2780,6 @@ func ValueLogRewriteOffline(opts Options) (ValueLogRewriteStats, error) {
 		return stats, fmt.Errorf("vlog-rewrite: no value-log segments found")
 	}
 
-	walDir := filepath.Join(opts.Dir, "wal")
 	beforeSegs, beforeBytes, err := valueLogSegmentStats(opts.Dir)
 	if err != nil {
 		_ = d.Close()
@@ -2808,7 +2807,7 @@ func ValueLogRewriteOffline(opts Options) (ValueLogRewriteStats, error) {
 			maxBytes = packedMax
 		}
 	}
-	writer := newRewriteWriter(walDir, lane, startSeq, maxBytes)
+	writer := newRewriteWriter(resolveStorageLayout(opts.Dir).valueVLogDir, lane, startSeq, maxBytes)
 	writer.nextRID = nextRID
 	// Offline rewrite prioritizes final bytes on disk over encode CPU, so keep
 	// compressed output whenever it reduces stored bytes.
@@ -4219,7 +4218,7 @@ func chooseRewriteLane(segments []logSegment) (uint32, uint32) {
 }
 
 func valueLogSegmentStats(dir string) (count int, bytes int64, err error) {
-	segments, err := listWALSegments(dir)
+	segments, err := listValueLogSegments(dir)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2749,15 +2749,23 @@ func ValueLogRewriteOffline(opts Options) (ValueLogRewriteStats, error) {
 		return stats, err
 	}
 
+	walSegments, err := listWALSegments(opts.Dir)
+	if err != nil {
+		return stats, err
+	}
+	for _, seg := range walSegments {
+		if seg.valueLog {
+			continue
+		}
+		return stats, fmt.Errorf("vlog-rewrite requires a clean commitlog; found %s", filepath.Base(seg.path))
+	}
+
 	segments, err := listValueLogSegments(opts.Dir)
 	if err != nil {
 		return stats, err
 	}
-	oldValueIDs := make(map[uint32]struct{})
+	oldValueIDs := make(map[uint32]struct{}, len(segments))
 	for _, seg := range segments {
-		if !seg.valueLog {
-			return stats, fmt.Errorf("vlog-rewrite requires a clean commitlog; found %s", filepath.Base(seg.path))
-		}
 		oldValueIDs[seg.fileID] = struct{}{}
 	}
 

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1696,12 +1696,15 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	if err != nil {
 		return stats, err
 	}
-	if len(newValueIDs) > 0 {
+	createdSegments, err := writer.createdSegmentsSnapshot()
+	if err != nil {
+		return stats, err
+	}
+	if len(createdSegments) > 0 {
 		// Avoid scanning the filesystem after rewrite creates new segments; we
 		// already know their IDs and paths deterministically.
-		for _, id := range newValueIDs {
-			path := db.valueLogManager.SegmentPath(id)
-			if err := db.valueLogManager.RegisterSegment(path, id); err != nil {
+		for _, seg := range createdSegments {
+			if err := db.valueLogManager.RegisterSegment(seg.path, seg.fileID); err != nil {
 				return stats, err
 			}
 		}
@@ -2070,11 +2073,7 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 		if err != nil {
 			return id, false, err
 		}
-		newPtr, err := c.writer.appendValue(rid, leafPage)
-		if err != nil {
-			return id, false, err
-		}
-		leafLogPtr, err := page.LeafLogPtrFromValuePtr(newPtr)
+		leafLogPtr, err := c.writer.appendLeafPageWithRID(rid, leafPage)
 		if err != nil {
 			return id, false, err
 		}
@@ -2297,13 +2296,16 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	if err != nil {
 		return 0, 0, err
 	}
-	if len(createdIDs) > 0 {
+	createdSegments, err := writer.createdSegmentsSnapshot()
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(createdSegments) > 0 {
 		// Register rewrite-created segments before commit publication so
 		// finalizeCommit can publish CurrentSetNoRefresh without forcing a
 		// filesystem rescan in leafref-heavy rewrite paths.
-		for _, id := range createdIDs {
-			path := db.valueLogManager.SegmentPath(id)
-			if err := db.valueLogManager.RegisterSegment(path, id); err != nil {
+		for _, seg := range createdSegments {
+			if err := db.valueLogManager.RegisterSegment(seg.path, seg.fileID); err != nil {
 				return 0, 0, err
 			}
 		}
@@ -3035,6 +3037,11 @@ func ValueLogRewriteOffline(opts Options) (ValueLogRewriteStats, error) {
 	return stats, nil
 }
 
+type rewriteCreatedSegment struct {
+	path   string
+	fileID uint32
+}
+
 type rewriteWriter struct {
 	walDir   string
 	lane     uint32
@@ -3083,6 +3090,7 @@ type rewriteWriter struct {
 	leafW                     *valuelog.Writer
 	records                   int
 	createdIDs                []uint32
+	createdSegments           []rewriteCreatedSegment
 
 	pendingDictID      uint64
 	pendingDict        []byte
@@ -3113,6 +3121,14 @@ func (w *rewriteWriter) ConfigureLeafLog(leafDir string, lane, startSeq uint32) 
 	w.leafDir = leafDir
 	w.leafLane = lane
 	w.leafSeq = startSeq
+}
+
+func (w *rewriteWriter) noteCreatedSegment(path string, fileID uint32) {
+	if w == nil || path == "" || fileID == 0 {
+		return
+	}
+	w.createdIDs = append(w.createdIDs, fileID)
+	w.createdSegments = append(w.createdSegments, rewriteCreatedSegment{path: path, fileID: fileID})
 }
 
 func rewriteDictFrameRecordLen(rawPayloadBytes, k int) int64 {
@@ -3212,6 +3228,16 @@ func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error)
 	rid := w.nextRID
 	w.nextRID++
 	if w.nextRID == 0 {
+		return page.LeafLogPtr{}, fmt.Errorf("value-log rid space exhausted")
+	}
+	return w.appendLeafPageWithRID(rid, leafPage)
+}
+
+func (w *rewriteWriter) appendLeafPageWithRID(rid uint64, leafPage []byte) (page.LeafLogPtr, error) {
+	if w == nil {
+		return page.LeafLogPtr{}, errors.New("vlog-rewrite: nil writer")
+	}
+	if rid == 0 {
 		return page.LeafLogPtr{}, fmt.Errorf("value-log rid space exhausted")
 	}
 	if w.leafDir != "" {
@@ -3323,7 +3349,7 @@ func (w *rewriteWriter) rotate() error {
 		writer.SetKeepPolicy(w.keepIoNsPerByte, w.keepEncodeNsRaw, w.keepSafetyMargin)
 		w.w = writer
 		w.seq = nextSeq
-		w.createdIDs = append(w.createdIDs, fileID)
+		w.noteCreatedSegment(path, fileID)
 		w.currentPath = path
 		w.currentFileID = fileID
 		return nil
@@ -3334,7 +3360,7 @@ func (w *rewriteWriter) rotate() error {
 	w.w.SetBlockCompression(w.blockCodec, w.blockCompression)
 	w.w.SetKeepPolicy(w.keepIoNsPerByte, w.keepEncodeNsRaw, w.keepSafetyMargin)
 	w.seq = nextSeq
-	w.createdIDs = append(w.createdIDs, fileID)
+	w.noteCreatedSegment(path, fileID)
 	w.currentPath = path
 	w.currentFileID = fileID
 	return nil
@@ -3388,7 +3414,7 @@ func (w *rewriteWriter) rotateLeaf() error {
 		writer.SetKeepPolicy(w.keepIoNsPerByte, w.keepEncodeNsRaw, w.keepSafetyMargin)
 		w.leafW = writer
 		w.leafSeq = nextSeq
-		w.createdIDs = append(w.createdIDs, fileID)
+		w.noteCreatedSegment(path, fileID)
 		w.leafCurrentPath = path
 		w.leafCurrentFileID = fileID
 		return nil
@@ -3399,7 +3425,7 @@ func (w *rewriteWriter) rotateLeaf() error {
 	w.leafW.SetBlockCompression(w.blockCodec, w.blockCompression)
 	w.leafW.SetKeepPolicy(w.keepIoNsPerByte, w.keepEncodeNsRaw, w.keepSafetyMargin)
 	w.leafSeq = nextSeq
-	w.createdIDs = append(w.createdIDs, fileID)
+	w.noteCreatedSegment(path, fileID)
 	w.leafCurrentPath = path
 	w.leafCurrentFileID = fileID
 	return nil
@@ -3795,6 +3821,18 @@ func (w *rewriteWriter) createdFileIDs() ([]uint32, error) {
 		return nil, nil
 	}
 	return w.createdIDs[:len(w.createdIDs):len(w.createdIDs)], nil
+}
+
+func (w *rewriteWriter) createdSegmentsSnapshot() ([]rewriteCreatedSegment, error) {
+	if w != nil {
+		if err := w.flushPendingDictBatch(); err != nil {
+			return nil, err
+		}
+	}
+	if w == nil || len(w.createdSegments) == 0 {
+		return nil, nil
+	}
+	return append([]rewriteCreatedSegment(nil), w.createdSegments...), nil
 }
 
 type rewriteIterator struct {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1403,19 +1403,21 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	)
 	if db.valueLogManager != nil {
 		if hintLane, hintSeq, ok := db.valueLogManager.RewriteLaneHint(); ok {
-			probePath := filepath.Join(resolveStorageLayout(db.dir).valueVLogDir, fmt.Sprintf("value-l%d-%06d.log", hintLane, hintSeq+1))
-			if _, statErr := os.Stat(probePath); statErr == nil {
-				needSegScan = true
-			} else if os.IsNotExist(statErr) {
-				lane, startSeq = hintLane, hintSeq
-				if db.indexOuterLeavesInValueLog {
-					leafStartSeq = maxRewriteLaneSeqFromSet(set, rewriteLeafLogLaneID)
+			if !(db.indexOuterLeavesInValueLog && hintLane == rewriteLeafLogLaneID) {
+				probePath := filepath.Join(resolveStorageLayout(db.dir).valueVLogDir, fmt.Sprintf("value-l%d-%06d.log", hintLane, hintSeq+1))
+				if _, statErr := os.Stat(probePath); statErr == nil {
+					needSegScan = true
+				} else if os.IsNotExist(statErr) {
+					lane, startSeq = hintLane, hintSeq
+					if db.indexOuterLeavesInValueLog {
+						leafStartSeq = maxRewriteLaneSeqFromSet(set, rewriteLeafLogLaneID)
+					}
+					needSegScan = false
+				} else {
+					_ = db.valueLogManager.Release(set)
+					set = nil
+					return stats, statErr
 				}
-				needSegScan = false
-			} else {
-				_ = db.valueLogManager.Release(set)
-				set = nil
-				return stats, statErr
 			}
 		}
 	}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -963,16 +963,17 @@ func (db *DB) collectLeafRefValueLogLiveBytes(ctx context.Context, p *pager.Page
 	return nil
 }
 
-func (db *DB) collectLeafRefPtrLiveBytes(ptr page.ValuePtr, liveByID map[uint32]int64, seenGroupedRecords *map[groupedRecordKey]struct{}, set *valuelog.Set) error {
+func (db *DB) collectLeafRefPtrLiveBytes(ptr page.LeafLogPtr, liveByID map[uint32]int64, seenGroupedRecords *map[groupedRecordKey]struct{}, set *valuelog.Set) error {
 	if liveByID == nil {
 		return nil
 	}
-	if !page.IsValueLogFileID(ptr.FileID) {
+	vptr := ptr.ValuePtr()
+	if !page.IsValueLogFileID(vptr.FileID) {
 		return nil
 	}
 	// Dedup grouped-record live-byte accounting (LeafRef pointers are grouped).
-	if page.ValuePtrIsGrouped(ptr) {
-		k, err := groupedRecordKeyForPtr(ptr)
+	if page.ValuePtrIsGrouped(vptr) {
+		k, err := groupedRecordKeyForPtr(vptr)
 		if err != nil {
 			return err
 		}
@@ -992,11 +993,11 @@ func (db *DB) collectLeafRefPtrLiveBytes(ptr page.ValuePtr, liveByID map[uint32]
 		seen[k] = struct{}{}
 	}
 
-	recordLen, err := db.valueLogRecordLengthForRewriteInSet(ptr, set)
+	recordLen, err := db.valueLogRecordLengthForRewriteInSet(vptr, set)
 	if err != nil {
 		return err
 	}
-	liveByID[ptr.FileID] += int64(recordLen)
+	liveByID[vptr.FileID] += int64(recordLen)
 	return nil
 }
 
@@ -2027,16 +2028,16 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 			return mapped, mapped != id, nil
 		}
 		if c.hasSingleID {
-			if ptr.FileID != c.singleSourceID {
+			if ptr.ValueLogFileID() != c.singleSourceID {
 				return id, false, nil
 			}
 		} else if c.sourceIDs != nil {
-			if _, ok := c.sourceIDs[ptr.FileID]; !ok {
+			if _, ok := c.sourceIDs[ptr.ValueLogFileID()]; !ok {
 				return id, false, nil
 			}
 		}
 		if c.sourceChunks != nil {
-			ok, err := rewriteSourceChunkSelected(ptr, c.sourceChunks, c.sourceChunkBytes)
+			ok, err := rewriteSourceChunkSelected(ptr.ValuePtr(), c.sourceChunks, c.sourceChunkBytes)
 			if err != nil {
 				return id, false, err
 			}
@@ -2050,7 +2051,7 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 		if c.writer == nil || c.ridAlloc == nil {
 			return id, false, fmt.Errorf("vlog-rewrite: rewrite writer unavailable")
 		}
-		leafPage, err := c.readLeafPage(ptr)
+		leafPage, err := c.readLeafPage(ptr.ValuePtr())
 		if err != nil {
 			return id, false, err
 		}
@@ -2065,7 +2066,11 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 		if err != nil {
 			return id, false, err
 		}
-		leafID, err := page.EncodeLeafRef(newPtr)
+		leafLogPtr, err := page.LeafLogPtrFromValuePtr(newPtr)
+		if err != nil {
+			return id, false, err
+		}
+		leafID, err := page.EncodeLeafRef(leafLogPtr)
 		if err != nil {
 			return id, false, err
 		}
@@ -3156,9 +3161,9 @@ func (w *rewriteWriter) flushPendingDictBatch() error {
 	return nil
 }
 
-func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.ValuePtr, error) {
+func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if w == nil {
-		return page.ValuePtr{}, errors.New("vlog-rewrite: nil writer")
+		return page.LeafLogPtr{}, errors.New("vlog-rewrite: nil writer")
 	}
 	if w.nextRID == 0 {
 		w.nextRID = 1
@@ -3166,7 +3171,7 @@ func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.ValuePtr, error) {
 	rid := w.nextRID
 	w.nextRID++
 	if w.nextRID == 0 {
-		return page.ValuePtr{}, fmt.Errorf("value-log rid space exhausted")
+		return page.LeafLogPtr{}, fmt.Errorf("value-log rid space exhausted")
 	}
 	if w.blockCompression && w.leafDictID != 0 && len(w.leafDict) > 0 && rewriteAllowDictForSmallPayload(leafPage) {
 		// LeafRef IDs intentionally omit grouped sub-index bits and therefore
@@ -3174,13 +3179,25 @@ func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.ValuePtr, error) {
 		// remain stable and do not alias another subrecord in a grouped batch.
 		ptr, err := w.appendSingleValueWithDictClass(rewriteTemplateClassOuterLeaf, w.leafDictID, w.leafDict, rid, leafPage)
 		if err == nil {
-			return ptr, nil
+			leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
+			if convErr != nil {
+				return page.LeafLogPtr{}, convErr
+			}
+			return leafPtr, nil
 		}
 		if !errors.Is(err, valuelog.ErrMissingDict) {
-			return page.ValuePtr{}, err
+			return page.LeafLogPtr{}, err
 		}
 	}
-	return w.appendValueWithDictClass(rewriteTemplateClassOuterLeaf, 0, nil, rid, leafPage)
+	ptr, err := w.appendValueWithDictClass(rewriteTemplateClassOuterLeaf, 0, nil, rid, leafPage)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
+	if convErr != nil {
+		return page.LeafLogPtr{}, convErr
+	}
+	return leafPtr, nil
 }
 
 // CurrentValueLogSegment reports the writer's current segment identity.

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -3805,15 +3805,14 @@ func (w *rewriteWriter) Close() error {
 	if err := w.flushPendingDictBatch(); err != nil {
 		return err
 	}
+	var err error
 	if w.w != nil {
-		if err := w.w.Close(); err != nil {
-			return err
-		}
+		err = errors.Join(err, w.w.Close())
 	}
 	if w.leafW != nil {
-		return w.leafW.Close()
+		err = errors.Join(err, w.leafW.Close())
 	}
-	return nil
+	return err
 }
 
 func (w *rewriteWriter) createdFileIDs() ([]uint32, error) {

--- a/TreeDB/db/vlog_rewrite_bench_test.go
+++ b/TreeDB/db/vlog_rewrite_bench_test.go
@@ -261,7 +261,7 @@ func setupLeafRefRewriteBench(tb testing.TB, keyCount int) (*DB, []uint32, func(
 		tb.Fatalf("Open: %v", err)
 	}
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		_ = db.Close()
 		_ = os.RemoveAll(dir)
@@ -397,7 +397,7 @@ func collectLeafRefFileCountsBench(tb testing.TB, p *pager.Pager, rootID uint64,
 
 func appendPointersInNewSegmentBench(tb testing.TB, dir string, lane, seq uint32, ridBase uint64, n int, valueAt func(i int) []byte) []page.ValuePtr {
 	tb.Helper()
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		tb.Fatalf("mkdir wal: %v", err)
 	}

--- a/TreeDB/db/vlog_rewrite_bench_test.go
+++ b/TreeDB/db/vlog_rewrite_bench_test.go
@@ -347,7 +347,7 @@ func collectLeafRefFileCountsBench(tb testing.TB, p *pager.Pager, rootID uint64,
 		return
 	}
 	if ptr, ok := page.DecodeLeafRef(rootID); ok {
-		counts[ptr.FileID]++
+		counts[ptr.ValueLogFileID()]++
 		return
 	}
 
@@ -364,7 +364,7 @@ func collectLeafRefFileCountsBench(tb testing.TB, p *pager.Pager, rootID uint64,
 		visited[pageID] = struct{}{}
 
 		if ptr, ok := page.DecodeLeafRef(pageID); ok {
-			counts[ptr.FileID]++
+			counts[ptr.ValueLogFileID()]++
 			continue
 		}
 

--- a/TreeDB/db/vlog_rewrite_chunk_plan.go
+++ b/TreeDB/db/vlog_rewrite_chunk_plan.go
@@ -280,11 +280,11 @@ func (db *DB) collectLeafRefValueLogLiveBytesByChunk(ctx context.Context, p *pag
 	return nil
 }
 
-func (db *DB) collectLeafRefPtrLiveBytesByChunk(ptr page.ValuePtr, liveByChunk map[valueLogChunkKey]int64, seenGroupedRecords *map[groupedRecordKey]struct{}, set *valuelog.Set, chunkBytes int64) error {
+func (db *DB) collectLeafRefPtrLiveBytesByChunk(ptr page.LeafLogPtr, liveByChunk map[valueLogChunkKey]int64, seenGroupedRecords *map[groupedRecordKey]struct{}, set *valuelog.Set, chunkBytes int64) error {
 	if liveByChunk == nil {
 		return nil
 	}
-	return db.collectValueLogPtrLiveBytes(ptr, seenGroupedRecords, set, func(ptr page.ValuePtr, recordLen uint32) error {
+	return db.collectValueLogPtrLiveBytes(ptr.ValuePtr(), seenGroupedRecords, set, func(ptr page.ValuePtr, recordLen uint32) error {
 		chunkOffset, err := valueLogChunkOffsetForPtr(ptr, chunkBytes)
 		if err != nil {
 			return err

--- a/TreeDB/db/vlog_rewrite_concurrency_test.go
+++ b/TreeDB/db/vlog_rewrite_concurrency_test.go
@@ -71,7 +71,7 @@ func TestValueLogRewriteOnline_DoesNotLoseConcurrentWrites(t *testing.T) {
 	)
 
 	dir := t.TempDir()
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -206,7 +206,7 @@ func TestValueLogRewriteOffline_RewritesAndShrinks(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -711,7 +711,7 @@ func TestValueLogRewriteOnline_NoPointerKeys_DoesNotCreateNewSegment(t *testing.
 		t.Fatalf("delete pointer key: %v", err)
 	}
 
-	segmentsBefore, err := listWALSegments(dir)
+	segmentsBefore, err := listValueLogSegments(dir)
 	if err != nil {
 		t.Fatalf("list segments before rewrite: %v", err)
 	}
@@ -733,7 +733,7 @@ func TestValueLogRewriteOnline_NoPointerKeys_DoesNotCreateNewSegment(t *testing.
 		t.Fatalf("expected no copied records, got %+v", stats)
 	}
 
-	segmentsAfter, err := listWALSegments(dir)
+	segmentsAfter, err := listValueLogSegments(dir)
 	if err != nil {
 		t.Fatalf("list segments after rewrite: %v", err)
 	}
@@ -786,7 +786,7 @@ func TestValueLogRewriteOnline_ProtectedPathsDoNotKeepHistoricalRewriteLanes(t *
 	closeNoErr(t, b)
 
 	protected := []string{
-		filepath.Join(dir, "wal", "value-l0-000002.log"),
+		filepath.Join(dir, "value_vlog", "value-l0-000002.log"),
 	}
 	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
 		ProtectedPaths: protected,
@@ -799,8 +799,8 @@ func TestValueLogRewriteOnline_ProtectedPathsDoNotKeepHistoricalRewriteLanes(t *
 	}
 
 	for _, path := range []string{
-		filepath.Join(dir, "wal", "value-l250-000001.log"),
-		filepath.Join(dir, "wal", "value-l250-000002.log"),
+		filepath.Join(dir, "value_vlog", "value-l250-000001.log"),
+		filepath.Join(dir, "value_vlog", "value-l250-000002.log"),
 	} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("expected %s to be deleted after rewrite cleanup, err=%v", filepath.Base(path), err)
@@ -852,7 +852,7 @@ func TestValueLogRewriteOnline_UsesBlockCompressionWhenEnabled(t *testing.T) {
 	}
 	closeNoErr(t, b)
 
-	segmentsBefore, err := listWALSegments(dir)
+	segmentsBefore, err := listValueLogSegments(dir)
 	if err != nil {
 		t.Fatalf("list segments before rewrite: %v", err)
 	}
@@ -872,7 +872,7 @@ func TestValueLogRewriteOnline_UsesBlockCompressionWhenEnabled(t *testing.T) {
 		t.Fatalf("expected copied records, got %+v", stats)
 	}
 
-	segmentsAfter, err := listWALSegments(dir)
+	segmentsAfter, err := listValueLogSegments(dir)
 	if err != nil {
 		t.Fatalf("list segments after rewrite: %v", err)
 	}
@@ -962,7 +962,7 @@ func TestValueLogRewriteOffline_ReencodesSingleUncompressedFramesWhenCompression
 	}
 	closeNoErr(t, b)
 
-	segmentsBefore, err := listWALSegments(dir)
+	segmentsBefore, err := listValueLogSegments(dir)
 	if err != nil {
 		t.Fatalf("list segments before rewrite: %v", err)
 	}
@@ -982,7 +982,7 @@ func TestValueLogRewriteOffline_ReencodesSingleUncompressedFramesWhenCompression
 		t.Fatalf("expected copied records, got %+v", stats)
 	}
 
-	segmentsAfter, err := listWALSegments(dir)
+	segmentsAfter, err := listValueLogSegments(dir)
 	if err != nil {
 		t.Fatalf("list segments after rewrite: %v", err)
 	}
@@ -1078,7 +1078,7 @@ func TestValueLogRewriteOffline_ReencodesLargeBlockFramesWithObservedDict(t *tes
 		t.Fatalf("open: %v", err)
 	}
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -1135,7 +1135,7 @@ func TestValueLogRewriteOffline_ReencodesLargeBlockFramesWithObservedDict(t *tes
 	dictFrames := 0
 	blockFrames := 0
 	maxDictK := 0
-	segments, err := listWALSegments(dir)
+	segments, err := listValueLogSegments(dir)
 	if err != nil {
 		t.Fatalf("list segments: %v", err)
 	}
@@ -1260,7 +1260,7 @@ func TestValueLogRewriteOffline_ReencodesGroupedBlockFramesWithObservedDict(t *t
 		t.Fatalf("open: %v", err)
 	}
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -1327,7 +1327,7 @@ func TestValueLogRewriteOffline_ReencodesGroupedBlockFramesWithObservedDict(t *t
 	dictFrames := 0
 	blockFrames := 0
 	maxDictK := 0
-	segments, err := listWALSegments(dir)
+	segments, err := listValueLogSegments(dir)
 	if err != nil {
 		t.Fatalf("list segments: %v", err)
 	}
@@ -1671,7 +1671,7 @@ func TestValueLogRewriteOffline_ReencodesGroupedBlockOuterLeafPagesWithObservedD
 		t.Fatalf("open: %v", err)
 	}
 
-	walDir := filepath.Join(dir, "wal")
+	walDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(walDir, 0o755); err != nil {
 		t.Fatalf("mkdir wal: %v", err)
 	}
@@ -1735,7 +1735,7 @@ func TestValueLogRewriteOffline_ReencodesGroupedBlockOuterLeafPagesWithObservedD
 	dictFrames := 0
 	blockFrames := 0
 	maxDictK := 0
-	segments, err := listWALSegments(dir)
+	segments, err := listValueLogSegments(dir)
 	if err != nil {
 		t.Fatalf("list segments: %v", err)
 	}
@@ -2757,7 +2757,7 @@ func TestValueLogRewriteOnline_ReserveRIDsUsesExternalAllocator(t *testing.T) {
 	}
 	closeNoErr(t, b)
 
-	segmentsBefore, err := listWALSegments(dir)
+	segmentsBefore, err := listValueLogSegments(dir)
 	if err != nil {
 		t.Fatalf("listWALSegments before: %v", err)
 	}
@@ -2812,7 +2812,7 @@ func TestValueLogRewriteOnline_ReserveRIDsUsesExternalAllocator(t *testing.T) {
 		t.Fatalf("expected ReserveRIDs mode to skip wal segment scan, calls=%d", walScanCalls)
 	}
 
-	segmentsAfter, err := listWALSegments(dir)
+	segmentsAfter, err := listValueLogSegments(dir)
 	if err != nil {
 		t.Fatalf("listWALSegments after: %v", err)
 	}
@@ -2896,14 +2896,14 @@ func TestValueLogRewriteOnline_WithoutReserveRIDs_UsesRIDStartScanner(t *testing
 	walScanCalls := 0
 	rewriteWALSegmentsLister = func(dir string) ([]logSegment, error) {
 		walScanCalls++
-		return listWALSegments(dir)
+		return listValueLogSegments(dir)
 	}
 	t.Cleanup(func() { rewriteWALSegmentsLister = origWALLister })
 	lane, seq, ok := db.valueLogManager.RewriteLaneHint()
 	if !ok {
 		t.Fatalf("RewriteLaneHint: ok=false")
 	}
-	probePath := filepath.Join(dir, "wal", fmt.Sprintf("value-l%d-%06d.log", lane, seq+1))
+	probePath := filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", lane, seq+1))
 	if err := os.WriteFile(probePath, nil, 0o644); err != nil {
 		t.Fatalf("write probe file: %v", err)
 	}

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -3236,9 +3236,12 @@ func TestValueLogRewriteOnline_LeafLogReservedLaneHintFallsBackToScan(t *testing
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer func() { _ = db.Close() }()
 	leafLog := &registeredLeafPageLog{db: db, dir: dir}
 	db.SetLeafPageLog(leafLog)
+	defer func() {
+		_ = leafLog.Close()
+		_ = db.Close()
+	}()
 
 	ptrs := appendPointersInNewSegment(t, dir, 0, 1, 316_000, 1, func(i int) []byte {
 		return bytes.Repeat([]byte{byte(i + 1)}, 256)

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -12,12 +12,14 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/snissn/compress/zstd"
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -310,6 +312,80 @@ func TestValueLogRewriteOffline_RewritesAndShrinks(t *testing.T) {
 	}
 	if !bytes.Equal(val, bytes.Repeat([]byte{0x03}, 128)) {
 		t.Fatalf("k2 mismatch")
+	}
+}
+
+func TestValueLogRewriteOffline_RejectsPendingCommitLog(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
+		t.Fatalf("mkdir value_vlog: %v", err)
+	}
+	path1 := filepath.Join(valueLogDir, "value-l0-000001.log")
+	id1, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("fileid1: %v", err)
+	}
+	w1, err := valuelog.NewWriter(path1, id1)
+	if err != nil {
+		t.Fatalf("writer1: %v", err)
+	}
+	ptr, err := w1.Append(0, nil, 1, bytes.Repeat([]byte{0x01}, 128))
+	if err != nil {
+		t.Fatalf("append1: %v", err)
+	}
+	if err := w1.Close(); err != nil {
+		t.Fatalf("close1: %v", err)
+	}
+
+	b := db.NewBatch()
+	ptrBatch, ok := b.(interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+	})
+	if !ok {
+		t.Fatalf("missing SetPointer on batch")
+	}
+	if err := ptrBatch.SetPointer([]byte("k"), ptr); err != nil {
+		t.Fatalf("set pointer: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	closeNoErr(t, b)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	commitPath := filepath.Join(WALDirPath(dir), "commit-l0-999999.log")
+	ww, err := commitlog.NewWriter(commitPath)
+	if err != nil {
+		t.Fatalf("commitlog.NewWriter: %v", err)
+	}
+	if err := ww.AppendBatch([]commitlog.Record{{
+		Op:    commitlog.OpSetInline,
+		Key:   []byte("pending"),
+		Value: []byte("v"),
+		Seq:   1,
+	}}); err != nil {
+		_ = ww.Close()
+		t.Fatalf("commitlog.AppendBatch: %v", err)
+	}
+	if err := ww.Close(); err != nil {
+		t.Fatalf("commitlog.Close: %v", err)
+	}
+
+	_, err = ValueLogRewriteOffline(Options{Dir: dir})
+	if err == nil {
+		t.Fatalf("expected clean commitlog error")
+	}
+	if got := err.Error(); !strings.Contains(got, "vlog-rewrite requires a clean commitlog") || !strings.Contains(got, filepath.Base(commitPath)) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -2268,9 +2268,9 @@ func TestRewriteWriter_AppendLeafPageUsesLeafDictWhenConfigured(t *testing.T) {
 	if err != nil {
 		t.Fatalf("append leaf C: %v", err)
 	}
-	if page.ValuePtrSubIndex(ptrA) != 0 || page.ValuePtrSubIndex(ptrB) != 0 || page.ValuePtrSubIndex(ptrC) != 0 {
+	if page.ValuePtrSubIndex(ptrA.ValuePtr()) != 0 || page.ValuePtrSubIndex(ptrB.ValuePtr()) != 0 || page.ValuePtrSubIndex(ptrC.ValuePtr()) != 0 {
 		t.Fatalf("leaf pointers must keep grouped sub-index 0 for leafref encoding: A=%d B=%d C=%d",
-			page.ValuePtrSubIndex(ptrA), page.ValuePtrSubIndex(ptrB), page.ValuePtrSubIndex(ptrC))
+			page.ValuePtrSubIndex(ptrA.ValuePtr()), page.ValuePtrSubIndex(ptrB.ValuePtr()), page.ValuePtrSubIndex(ptrC.ValuePtr()))
 	}
 	if err := w.Close(); err != nil {
 		t.Fatalf("close rewrite writer: %v", err)

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -3229,6 +3229,68 @@ func TestValueLogRewriteOnline_WithoutReserveRIDs_UsesSetRIDFastPathWhenLaneHint
 	}
 }
 
+func TestValueLogRewriteOnline_LeafLogReservedLaneHintFallsBackToScan(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	leafLog := &registeredLeafPageLog{db: db, dir: dir}
+	db.SetLeafPageLog(leafLog)
+
+	ptrs := appendPointersInNewSegment(t, dir, 0, 1, 316_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte{byte(i + 1)}, 256)
+	})
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("k"), ptrs[0]); err != nil {
+		t.Fatalf("set pointer: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	closeNoErr(t, b)
+
+	lane, _, ok := db.valueLogManager.RewriteLaneHint()
+	if !ok {
+		t.Fatalf("RewriteLaneHint: ok=false")
+	}
+	if lane != rewriteLeafLogLaneID {
+		t.Fatalf("RewriteLaneHint lane=%d want reserved leaf lane %d", lane, rewriteLeafLogLaneID)
+	}
+
+	sentinel := errors.New("rid-start scan invoked")
+	origRIDStartScanner := rewriteRIDStartScanner
+	ridStartScanCalls := 0
+	rewriteRIDStartScanner = func([]logSegment) (uint64, error) {
+		ridStartScanCalls++
+		return 0, sentinel
+	}
+	t.Cleanup(func() { rewriteRIDStartScanner = origRIDStartScanner })
+	origWALLister := rewriteWALSegmentsLister
+	walScanCalls := 0
+	rewriteWALSegmentsLister = func(dir string) ([]logSegment, error) {
+		walScanCalls++
+		return listValueLogSegments(dir)
+	}
+	t.Cleanup(func() { rewriteWALSegmentsLister = origWALLister })
+
+	_, err = db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs: []uint32{ptrs[0].FileID},
+		BatchSize:     1,
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected rid-start scanner error %v, got %v", sentinel, err)
+	}
+	if ridStartScanCalls != 1 {
+		t.Fatalf("expected one rid-start scan call, got %d", ridStartScanCalls)
+	}
+	if walScanCalls != 1 {
+		t.Fatalf("expected one wal segment scan call, got %d", walScanCalls)
+	}
+}
+
 func TestValueLogRewriteOnline_LeafRefsReserveRIDs_DoesNotRefreshManager(t *testing.T) {
 	db, sourceIDs, cleanup := setupLeafRefRewriteBench(t, 768)
 	defer cleanup()

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -2055,6 +2055,69 @@ func TestRewriteWriter_CreatedFileIDs_StableAcrossCalls(t *testing.T) {
 	}
 }
 
+func TestRewriteWriter_LeafPagesUseConfiguredLeafLogDir(t *testing.T) {
+	root := t.TempDir()
+	valueDir := filepath.Join(root, "value_vlog")
+	leafDir := filepath.Join(root, "leaf_vlog")
+	if err := os.MkdirAll(valueDir, 0o755); err != nil {
+		t.Fatalf("mkdir value dir: %v", err)
+	}
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("mkdir leaf dir: %v", err)
+	}
+
+	w := newRewriteWriter(valueDir, 254, 0, 64<<20)
+	w.ConfigureLeafLog(leafDir, rewriteLeafLogLaneID, 0)
+	if _, err := w.appendValue(1, []byte("value-payload")); err != nil {
+		t.Fatalf("appendValue: %v", err)
+	}
+	leafPtr, err := w.AppendLeafPage(bytes.Repeat([]byte("l"), 4096))
+	if err != nil {
+		t.Fatalf("AppendLeafPage: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	valuePaths, err := filepath.Glob(filepath.Join(valueDir, "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob value_vlog: %v", err)
+	}
+	if len(valuePaths) == 0 {
+		t.Fatalf("expected value_vlog file after append")
+	}
+	leafPaths, err := filepath.Glob(filepath.Join(leafDir, "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob leaf_vlog: %v", err)
+	}
+	if len(leafPaths) == 0 {
+		t.Fatalf("expected leaf_vlog file after leaf append")
+	}
+
+	lane, _ := valuelog.DecodeFileID(leafPtr.FileID)
+	if lane != rewriteLeafLogLaneID {
+		t.Fatalf("leaf ptr lane=%d want=%d", lane, rewriteLeafLogLaneID)
+	}
+
+	ids, err := w.createdFileIDs()
+	if err != nil {
+		t.Fatalf("createdFileIDs: %v", err)
+	}
+	var sawValue, sawLeaf bool
+	for _, id := range ids {
+		lane, _ := valuelog.DecodeFileID(id)
+		if lane == 254 {
+			sawValue = true
+		}
+		if lane == rewriteLeafLogLaneID {
+			sawLeaf = true
+		}
+	}
+	if !sawValue || !sawLeaf {
+		t.Fatalf("expected created IDs to include value and leaf lanes, ids=%v", ids)
+	}
+}
+
 func TestRewriteWriter_TemplatePrepassEncodesBeforeDict(t *testing.T) {
 	walDir := t.TempDir()
 	cfg, store, lookup, value := buildRewriteTemplateFixture(t)

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -195,6 +195,92 @@ func TestLeafRefRewriteCtx_InternalRemapInlinePromotion(t *testing.T) {
 	}
 }
 
+type rewriteTestLeafReader struct {
+	values map[page.ValuePtr][]byte
+}
+
+func (r *rewriteTestLeafReader) Read(ptr page.ValuePtr) ([]byte, error) {
+	val, ok := r.values[ptr]
+	if !ok {
+		return nil, fmt.Errorf("leaf pointer not found")
+	}
+	return append([]byte(nil), val...), nil
+}
+
+func (r *rewriteTestLeafReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
+	val, ok := r.values[ptr]
+	if !ok {
+		return nil, fmt.Errorf("leaf pointer not found")
+	}
+	return val, nil
+}
+
+func TestLeafRefRewriteCtx_RewriteNodeUsesConfiguredLeafLog(t *testing.T) {
+	root := t.TempDir()
+	valueDir := filepath.Join(root, "value_vlog")
+	leafDir := filepath.Join(root, "leaf_vlog")
+	if err := os.MkdirAll(valueDir, 0o755); err != nil {
+		t.Fatalf("mkdir value dir: %v", err)
+	}
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("mkdir leaf dir: %v", err)
+	}
+
+	writer := newRewriteWriter(valueDir, 254, 0, 64<<20)
+	writer.ConfigureLeafLog(leafDir, rewriteLeafLogLaneID, 0)
+	leafPage := bytes.Repeat([]byte("r"), page.PageSize)
+	sourceFileID, err := valuelog.EncodeFileID(3, 9)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	oldPtr := page.ValuePtr{FileID: sourceFileID, Offset: 128, Length: page.ValuePtrMarkGrouped(0, 0)}
+	oldLeafPtr, err := page.LeafLogPtrFromValuePtr(oldPtr)
+	if err != nil {
+		t.Fatalf("LeafLogPtrFromValuePtr: %v", err)
+	}
+	oldID, err := page.EncodeLeafRef(oldLeafPtr)
+	if err != nil {
+		t.Fatalf("EncodeLeafRef: %v", err)
+	}
+
+	ctx := leafRefRewriteCtx{
+		ctx:        context.Background(),
+		leafReader: &rewriteTestLeafReader{values: map[page.ValuePtr][]byte{oldPtr: leafPage}},
+		writer:     writer,
+		ridAlloc:   newRewriteRIDAllocator(1000, nil),
+		sourceIDs:  map[uint32]struct{}{sourceFileID: {}},
+	}
+
+	newID, changed, err := ctx.rewriteNode(oldID)
+	if err != nil {
+		t.Fatalf("rewriteNode: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected leaf ref rewrite to change node")
+	}
+	newLeafPtr, ok := page.DecodeLeafRef(newID)
+	if !ok {
+		t.Fatalf("expected rewritten leaf ref")
+	}
+	lane, _ := valuelog.DecodeFileID(newLeafPtr.ValueLogFileID())
+	if lane != rewriteLeafLogLaneID {
+		t.Fatalf("rewritten leaf lane=%d want=%d", lane, rewriteLeafLogLaneID)
+	}
+	createdSegments, err := writer.createdSegmentsSnapshot()
+	if err != nil {
+		t.Fatalf("createdSegmentsSnapshot: %v", err)
+	}
+	if len(createdSegments) != 1 {
+		t.Fatalf("expected 1 created segment, got %d", len(createdSegments))
+	}
+	if !strings.HasPrefix(createdSegments[0].path, leafDir+string(os.PathSeparator)) {
+		t.Fatalf("rewritten leaf segment path=%q want prefix %q", createdSegments[0].path, leafDir)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
 func TestValueLogRewriteOffline_RewritesAndShrinks(t *testing.T) {
 	dir := t.TempDir()
 
@@ -2115,6 +2201,32 @@ func TestRewriteWriter_LeafPagesUseConfiguredLeafLogDir(t *testing.T) {
 	}
 	if !sawValue || !sawLeaf {
 		t.Fatalf("expected created IDs to include value and leaf lanes, ids=%v", ids)
+	}
+	createdSegments, err := w.createdSegmentsSnapshot()
+	if err != nil {
+		t.Fatalf("createdSegmentsSnapshot: %v", err)
+	}
+	if len(createdSegments) != 2 {
+		t.Fatalf("expected 2 created segments, got %d", len(createdSegments))
+	}
+	var sawValuePath, sawLeafPath bool
+	for _, seg := range createdSegments {
+		lane, _ := valuelog.DecodeFileID(seg.fileID)
+		switch lane {
+		case 254:
+			if !strings.HasPrefix(seg.path, valueDir+string(os.PathSeparator)) {
+				t.Fatalf("value segment path=%q want prefix %q", seg.path, valueDir)
+			}
+			sawValuePath = true
+		case rewriteLeafLogLaneID:
+			if !strings.HasPrefix(seg.path, leafDir+string(os.PathSeparator)) {
+				t.Fatalf("leaf segment path=%q want prefix %q", seg.path, leafDir)
+			}
+			sawLeafPath = true
+		}
+	}
+	if !sawValuePath || !sawLeafPath {
+		t.Fatalf("expected created segments to preserve value and leaf paths, got=%v", createdSegments)
 	}
 }
 

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -81,18 +81,27 @@ func listWALSegments(dir string) ([]logSegment, error) {
 }
 
 func listValueLogSegments(dir string) ([]logSegment, error) {
-	segments, err := listSegmentsInDir(resolveStorageLayout(dir).valueVLogDir)
-	if err != nil {
-		return nil, err
-	}
-	out := segments[:0]
-	for _, seg := range segments {
-		if !seg.valueLog {
-			continue
+	layout := resolveStorageLayout(dir)
+	all := make([]logSegment, 0)
+	for _, segDir := range []string{layout.valueVLogDir, layout.leafVLogDir} {
+		segments, err := listSegmentsInDir(segDir)
+		if err != nil {
+			return nil, err
 		}
-		out = append(out, seg)
+		for _, seg := range segments {
+			if !seg.valueLog {
+				continue
+			}
+			all = append(all, seg)
+		}
 	}
-	return out, nil
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].lane != all[j].lane {
+			return all[i].lane < all[j].lane
+		}
+		return all[i].seq < all[j].seq
+	})
+	return all, nil
 }
 
 func listRecoverySegments(dir string) ([]logSegment, error) {

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -25,9 +25,8 @@ type logSegment struct {
 	fileID   uint32
 }
 
-func listWALSegments(dir string) ([]logSegment, error) {
-	walDir := filepath.Join(dir, "wal")
-	entries, err := os.ReadDir(walDir)
+func listSegmentsInDir(segDir string) ([]logSegment, error) {
+	entries, err := os.ReadDir(segDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -49,7 +48,7 @@ func listWALSegments(dir string) ([]logSegment, error) {
 		seg := logSegment{
 			seq:      seq,
 			lane:     lane,
-			path:     filepath.Join(walDir, name),
+			path:     filepath.Join(segDir, name),
 			valueLog: valueLog,
 		}
 		if info, err := entry.Info(); err == nil {
@@ -73,6 +72,50 @@ func listWALSegments(dir string) ([]logSegment, error) {
 			return segments[i].lane < segments[j].lane
 		}
 		return segments[i].seq < segments[j].seq
+	})
+	return segments, nil
+}
+
+func listWALSegments(dir string) ([]logSegment, error) {
+	return listSegmentsInDir(resolveStorageLayout(dir).walDir)
+}
+
+func listValueLogSegments(dir string) ([]logSegment, error) {
+	segments, err := listSegmentsInDir(resolveStorageLayout(dir).valueVLogDir)
+	if err != nil {
+		return nil, err
+	}
+	out := segments[:0]
+	for _, seg := range segments {
+		if !seg.valueLog {
+			continue
+		}
+		out = append(out, seg)
+	}
+	return out, nil
+}
+
+func listRecoverySegments(dir string) ([]logSegment, error) {
+	walSegments, err := listWALSegments(dir)
+	if err != nil {
+		return nil, err
+	}
+	vlogSegments, err := listValueLogSegments(dir)
+	if err != nil {
+		return nil, err
+	}
+	segments := append(walSegments, vlogSegments...)
+	sort.Slice(segments, func(i, j int) bool {
+		if segments[i].lane != segments[j].lane {
+			return segments[i].lane < segments[j].lane
+		}
+		if segments[i].seq != segments[j].seq {
+			return segments[i].seq < segments[j].seq
+		}
+		if segments[i].valueLog != segments[j].valueLog {
+			return !segments[i].valueLog && segments[j].valueLog
+		}
+		return segments[i].path < segments[j].path
 	})
 	return segments, nil
 }
@@ -374,7 +417,7 @@ func newReplayInlineAppender(db *DB, segments []logSegment, ridMap map[uint64]pa
 		// segments within the same cap used by the write path.
 		maxSegmentBytes = int64(^uint32(0)) - 4
 	}
-	writer := newRewriteWriter(filepath.Join(db.dir, "wal"), 0, maxLane0Seq, maxSegmentBytes)
+	writer := newRewriteWriter(resolveStorageLayout(db.dir).valueVLogDir, 0, maxLane0Seq, maxSegmentBytes)
 	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
 	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
 	return &replayInlineAppender{

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -426,7 +426,11 @@ func newReplayInlineAppender(db *DB, segments []logSegment, ridMap map[uint64]pa
 		// segments within the same cap used by the write path.
 		maxSegmentBytes = int64(^uint32(0)) - 4
 	}
-	writer := newRewriteWriter(resolveStorageLayout(db.dir).valueVLogDir, 0, maxLane0Seq, maxSegmentBytes)
+	layout := resolveStorageLayout(db.dir)
+	writer := newRewriteWriter(layout.valueVLogDir, 0, maxLane0Seq, maxSegmentBytes)
+	if db.indexOuterLeavesInValueLog {
+		writer.ConfigureLeafLog(layout.leafVLogDir, rewriteLeafLogLaneID, maxRewriteLaneSeq(segments, rewriteLeafLogLaneID))
+	}
 	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
 	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
 	return &replayInlineAppender{

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -465,15 +465,11 @@ func (a *replayInlineAppender) AppendLeafPage(leafPage []byte) (page.LeafLogPtr,
 	}
 	rid := a.nextRID
 	a.nextRID++
-	ptr, err := a.writer.appendValue(rid, leafPage)
+	leafPtr, err := a.writer.appendLeafPageWithRID(rid, leafPage)
 	if err != nil {
 		return page.LeafLogPtr{}, err
 	}
 	a.dirty = true
-	leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
-	if convErr != nil {
-		return page.LeafLogPtr{}, convErr
-	}
 	return leafPtr, nil
 }
 

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -400,21 +400,25 @@ func (a *replayInlineAppender) append(value []byte) (page.ValuePtr, error) {
 	return ptr, nil
 }
 
-func (a *replayInlineAppender) AppendLeafPage(leafPage []byte) (page.ValuePtr, error) {
+func (a *replayInlineAppender) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if a == nil || a.writer == nil {
-		return page.ValuePtr{}, fmt.Errorf("commitlog: replay value-log appender unavailable")
+		return page.LeafLogPtr{}, fmt.Errorf("commitlog: replay value-log appender unavailable")
 	}
 	if a.nextRID == 0 {
-		return page.ValuePtr{}, fmt.Errorf("value-log rid space exhausted")
+		return page.LeafLogPtr{}, fmt.Errorf("value-log rid space exhausted")
 	}
 	rid := a.nextRID
 	a.nextRID++
 	ptr, err := a.writer.appendValue(rid, leafPage)
 	if err != nil {
-		return page.ValuePtr{}, err
+		return page.LeafLogPtr{}, err
 	}
 	a.dirty = true
-	return ptr, nil
+	leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
+	if convErr != nil {
+		return page.LeafLogPtr{}, convErr
+	}
+	return leafPtr, nil
 }
 
 func (a *replayInlineAppender) Flush() error {

--- a/TreeDB/db/wal_recovery_test.go
+++ b/TreeDB/db/wal_recovery_test.go
@@ -1,11 +1,13 @@
 package db
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 func TestNewReplayInlineAppender_PackedValuePtrCapsSegmentSize(t *testing.T) {
@@ -81,6 +83,50 @@ func TestNewReplayInlineAppender_ValueLogCompressionOff_DisablesBlockCompression
 
 	if app.writer.blockCompression {
 		t.Fatalf("expected replay writer block compression disabled")
+	}
+}
+
+func TestReplayInlineAppender_LeafPagesUseConfiguredLeafLogDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := ensureStorageLayoutDirs(dir); err != nil {
+		t.Fatalf("ensureStorageLayoutDirs: %v", err)
+	}
+	db := &DB{
+		dir:                        dir,
+		indexOuterLeavesInValueLog: true,
+		valueLogCompression:        ValueLogCompressionBlock,
+		valueLogBlockCodec:         ValueLogBlockSnappy,
+	}
+	app, err := newReplayInlineAppender(db, nil, nil)
+	if err != nil {
+		t.Fatalf("newReplayInlineAppender: %v", err)
+	}
+	leafPtr, err := app.AppendLeafPage(bytes.Repeat([]byte("l"), page.PageSize))
+	if err != nil {
+		_ = app.close()
+		t.Fatalf("AppendLeafPage: %v", err)
+	}
+	if err := app.close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	lane, _ := valuelog.DecodeFileID(leafPtr.ValueLogFileID())
+	if lane != rewriteLeafLogLaneID {
+		t.Fatalf("leaf ptr lane=%d want=%d", lane, rewriteLeafLogLaneID)
+	}
+	valuePaths, err := filepath.Glob(filepath.Join(dir, "value_vlog", "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob value_vlog: %v", err)
+	}
+	if len(valuePaths) != 0 {
+		t.Fatalf("expected no value_vlog files for replayed leaf page, got %v", valuePaths)
+	}
+	leafPaths, err := filepath.Glob(filepath.Join(dir, "leaf_vlog", "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob leaf_vlog: %v", err)
+	}
+	if len(leafPaths) != 1 {
+		t.Fatalf("expected one leaf_vlog file, got %v", leafPaths)
 	}
 }
 

--- a/TreeDB/internal/bulk/builder.go
+++ b/TreeDB/internal/bulk/builder.go
@@ -17,7 +17,7 @@ type Allocator interface {
 // via this interface and returns LeafRef ids (encoded from the returned
 // ValuePtr) in internal children and as the tree root when the height is 1.
 type LeafPageAppender interface {
-	AppendLeafPage(leafPage []byte) (page.ValuePtr, error)
+	AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error)
 }
 
 type levelBuilder struct {

--- a/TreeDB/internal/bulk/builder.go
+++ b/TreeDB/internal/bulk/builder.go
@@ -15,7 +15,7 @@ type Allocator interface {
 //
 // When BuildOptions.LeafPageLog is non-nil, BuildWithOptions writes leaf pages
 // via this interface and returns LeafRef ids (encoded from the returned
-// ValuePtr) in internal children and as the tree root when the height is 1.
+// LeafLogPtr) in internal children and as the tree root when the height is 1.
 type LeafPageAppender interface {
 	AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error)
 }

--- a/TreeDB/internal/bulk/builder_test.go
+++ b/TreeDB/internal/bulk/builder_test.go
@@ -93,19 +93,18 @@ func TestBuild(t *testing.T) {
 }
 
 type mockLeafPageLog struct {
-	ptrs      []page.ValuePtr
+	ptrs      []page.LeafLogPtr
 	pages     [][]byte
 	appendErr error
 }
 
-func (m *mockLeafPageLog) AppendLeafPage(leafPage []byte) (page.ValuePtr, error) {
+func (m *mockLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if m.appendErr != nil {
-		return page.ValuePtr{}, m.appendErr
+		return page.LeafLogPtr{}, m.appendErr
 	}
-	ptr := page.ValuePtr{
-		FileID: page.ValueLogFileID(uint32(len(m.ptrs) + 1)),
+	ptr := page.LeafLogPtr{
+		FileID: uint32(len(m.ptrs) + 1),
 		Offset: uint64(len(m.pages) + 1),
-		Length: uint32(len(leafPage)),
 	}
 	m.ptrs = append(m.ptrs, ptr)
 	m.pages = append(m.pages, append([]byte(nil), leafPage...))

--- a/TreeDB/internal/dictdb/store.go
+++ b/TreeDB/internal/dictdb/store.go
@@ -361,11 +361,11 @@ func (s *Store) ensureValueLogWriterLocked() (*valuelog.Writer, error) {
 	if s.dir == "" {
 		return nil, fmt.Errorf("dictdb: missing backend dir")
 	}
-	walDir := filepath.Join(s.dir, "wal")
-	if err := os.MkdirAll(walDir, 0700); err != nil {
+	valueLogDir := db.ValueLogDirPath(s.dir)
+	if err := os.MkdirAll(valueLogDir, 0700); err != nil {
 		return nil, err
 	}
-	seq, err := nextValueLogSeq(walDir, 0)
+	seq, err := nextValueLogSeq(valueLogDir, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (s *Store) ensureValueLogWriterLocked() (*valuelog.Writer, error) {
 	if err != nil {
 		return nil, err
 	}
-	path := filepath.Join(walDir, fmt.Sprintf("value-l%d-%06d.log", 0, seq))
+	path := filepath.Join(valueLogDir, fmt.Sprintf("value-l%d-%06d.log", 0, seq))
 	writer, err := valuelog.NewWriter(path, fileID)
 	if err != nil {
 		return nil, err

--- a/TreeDB/internal/leafrefscan/walk.go
+++ b/TreeDB/internal/leafrefscan/walk.go
@@ -11,7 +11,7 @@ import (
 
 type GetFunc func(pageID uint64) ([]byte, error)
 type VerifyFunc func(pageID uint64, n node.Node) error
-type VisitFunc func(ptr page.ValuePtr) error
+type VisitFunc func(ptr page.LeafLogPtr) error
 
 type walkState struct {
 	stack   []uint64

--- a/TreeDB/internal/leafrefscan/walk_test.go
+++ b/TreeDB/internal/leafrefscan/walk_test.go
@@ -17,7 +17,7 @@ func TestWalk_ZeroRootIsNoOp(t *testing.T) {
 }
 
 func TestWalk_NilGetReturnsError(t *testing.T) {
-	err := Walk(context.Background(), 1, nil, nil, func(page.ValuePtr) error { return nil })
+	err := Walk(context.Background(), 1, nil, nil, func(page.LeafLogPtr) error { return nil })
 	if err == nil || !strings.Contains(err.Error(), "get function is nil") {
 		t.Fatalf("Walk(nil get) err=%v, want nil-get error", err)
 	}
@@ -31,17 +31,17 @@ func TestWalk_NilVisitReturnsError(t *testing.T) {
 }
 
 func TestWalk_RootLeafRefVisitsPointer(t *testing.T) {
-	want := page.ValuePtr{FileID: page.ValueLogFileID(7), Offset: 42}
+	want := page.LeafLogPtr{FileID: 7, Offset: 42}
 	rootID, err := page.EncodeLeafRef(want)
 	if err != nil {
 		t.Fatalf("EncodeLeafRef: %v", err)
 	}
 
-	var got []page.ValuePtr
+	var got []page.LeafLogPtr
 	err = Walk(context.Background(), rootID, func(uint64) ([]byte, error) {
 		t.Fatal("get should not be called for root leafref")
 		return nil, nil
-	}, nil, func(ptr page.ValuePtr) error {
+	}, nil, func(ptr page.LeafLogPtr) error {
 		got = append(got, ptr)
 		return nil
 	})
@@ -67,7 +67,7 @@ func TestWalk_InternalMixedChildrenVisitsOnlyLeafRefs(t *testing.T) {
 	rootNode.SetType(page.PageTypeInternal)
 	rootNode.SetPageID(1)
 
-	wantPtr := page.ValuePtr{FileID: page.ValueLogFileID(9), Offset: 77}
+	wantPtr := page.LeafLogPtr{FileID: 9, Offset: 77}
 	leafRefID, err := page.EncodeLeafRef(wantPtr)
 	if err != nil {
 		t.Fatalf("EncodeLeafRef: %v", err)
@@ -83,14 +83,14 @@ func TestWalk_InternalMixedChildrenVisitsOnlyLeafRefs(t *testing.T) {
 		1:  rootPage,
 		10: childLeaf,
 	}
-	var visited []page.ValuePtr
+	var visited []page.LeafLogPtr
 	err = Walk(context.Background(), 1, func(pageID uint64) ([]byte, error) {
 		data, ok := pages[pageID]
 		if !ok {
 			return nil, errors.New("missing page")
 		}
 		return data, nil
-	}, nil, func(ptr page.ValuePtr) error {
+	}, nil, func(ptr page.LeafLogPtr) error {
 		visited = append(visited, ptr)
 		return nil
 	})
@@ -116,7 +116,7 @@ func TestWalk_InvalidPageTypeReturnsError(t *testing.T) {
 			t.Fatalf("unexpected pageID %d", pageID)
 		}
 		return rootPage, nil
-	}, nil, func(page.ValuePtr) error { return nil })
+	}, nil, func(page.LeafLogPtr) error { return nil })
 	if err == nil || !strings.Contains(err.Error(), "invalid page type") {
 		t.Fatalf("Walk(invalid type) err=%v want invalid page type", err)
 	}

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -979,7 +979,8 @@ func (s *Set) ReadUnsafeAppendBatch(ptrs []page.ValuePtr, dst [][]byte) ([][]byt
 }
 
 type Manager struct {
-	dir string
+	dir           string
+	extraScanDirs []string
 
 	mu    sync.RWMutex
 	files map[uint32]*File
@@ -1154,24 +1155,49 @@ func (m *Manager) RefreshScanCount() uint64 {
 // Refresh scans the directory and registers any new segments.
 func (m *Manager) Refresh() error {
 	m.refreshScans.Add(1)
-	segments, err := currentScanSegmentPaths()(m.dir)
-	if err != nil {
-		return err
+	dirs := []string{m.dir}
+	m.mu.RLock()
+	if len(m.extraScanDirs) > 0 {
+		dirs = append(dirs, m.extraScanDirs...)
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for _, seg := range segments {
-		if err := m.registerSegmentLocked(seg.path, seg.id); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				// Online rewrite/GC can delete a segment after listSegments() sees it
-				// but before we open it. Treat that as a benign refresh race and
-				// keep scanning the remaining segments.
-				continue
-			}
+	m.mu.RUnlock()
+	for _, dir := range dirs {
+		segments, err := currentScanSegmentPaths()(dir)
+		if err != nil {
 			return err
 		}
+		m.mu.Lock()
+		for _, seg := range segments {
+			if err := m.registerSegmentLocked(seg.path, seg.id); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					// Online rewrite/GC can delete a segment after listSegments() sees it
+					// but before we open it. Treat that as a benign refresh race and
+					// keep scanning the remaining segments.
+					continue
+				}
+				m.mu.Unlock()
+				return err
+			}
+		}
+		m.mu.Unlock()
 	}
 	return nil
+}
+
+func (m *Manager) AddScanDir(dir string) error {
+	if m == nil || dir == "" || dir == m.dir {
+		return nil
+	}
+	m.mu.Lock()
+	for _, existing := range m.extraScanDirs {
+		if existing == dir {
+			m.mu.Unlock()
+			return nil
+		}
+	}
+	m.extraScanDirs = append(m.extraScanDirs, dir)
+	m.mu.Unlock()
+	return m.Refresh()
 }
 
 // RegisterSegment registers a newly created segment without scanning the

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1129,7 +1129,19 @@ func (m *Manager) Close() error {
 func (m *Manager) SegmentPath(id uint32) string {
 	seg := page.ValueLogSegmentID(id)
 	lane, seq := DecodeSegmentID(seg)
-	return filepath.Join(m.dir, fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+	name := fmt.Sprintf("value-l%d-%06d.log", lane, seq)
+	if m == nil {
+		return name
+	}
+	m.mu.RLock()
+	if f := m.files[id]; f != nil && strings.TrimSpace(f.Path) != "" {
+		path := f.Path
+		m.mu.RUnlock()
+		return path
+	}
+	rootDir := m.dir
+	m.mu.RUnlock()
+	return filepath.Join(rootDir, name)
 }
 
 // HasSegment reports whether id is already registered and not marked zombie.

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -753,6 +753,33 @@ func TestManagerRegisterSegment_CurrentSetNoRefresh(t *testing.T) {
 	}
 }
 
+func TestManagerSegmentPath_UsesRegisteredPathFromExtraScanDir(t *testing.T) {
+	dir := t.TempDir()
+	leafDir := filepath.Join(dir, "leaf_vlog")
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(leaf_vlog): %v", err)
+	}
+	segID := writeTestSegment(t, leafDir, 255, 1, 1, bytes.Repeat([]byte("l"), 64))
+	wantPath := filepath.Join(leafDir, "value-l255-000001.log")
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() {
+		if mgr != nil {
+			_ = mgr.Close()
+		}
+	}()
+	if err := mgr.AddScanDir(leafDir); err != nil {
+		t.Fatalf("AddScanDir: %v", err)
+	}
+
+	if got := mgr.SegmentPath(segID); got != wantPath {
+		t.Fatalf("SegmentPath(%d)=%q want %q", segID, got, wantPath)
+	}
+}
+
 func TestManagerReleaseZombieDeletesSegmentOnSuccess(t *testing.T) {
 	dir := t.TempDir()
 	segID := writeTestSegment(t, dir, 0, 1, 1, bytes.Repeat([]byte("x"), 64))

--- a/TreeDB/maintenance_leaf_vlog_test.go
+++ b/TreeDB/maintenance_leaf_vlog_test.go
@@ -321,12 +321,29 @@ func TestValueLogRewriteOffline_LeafPagesInValueLog_ReopenParity(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 
+	mainDir := filepath.Dir(mainIndexPath(dir))
+	leafPathsBefore, err := filepath.Glob(filepath.Join(mainDir, "leaf_vlog", "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob leaf_vlog before rewrite: %v", err)
+	}
+	if len(leafPathsBefore) == 0 {
+		t.Fatalf("expected leaf_vlog files before rewrite")
+	}
+
 	stats, err := treedb.ValueLogRewriteOffline(treedb.Options{Dir: dir})
 	if err != nil {
 		t.Fatalf("ValueLogRewriteOffline: %v", err)
 	}
 	if stats.RecordsCopied == 0 {
 		t.Fatalf("expected offline rewrite to copy records, stats=%+v", stats)
+	}
+
+	leafPathsAfter, err := filepath.Glob(filepath.Join(mainDir, "leaf_vlog", "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob leaf_vlog after rewrite: %v", err)
+	}
+	if len(leafPathsAfter) == 0 {
+		t.Fatalf("expected leaf_vlog files after rewrite")
 	}
 
 	reopen, err := treedb.Open(opts)

--- a/TreeDB/maintenance_leaf_vlog_test.go
+++ b/TreeDB/maintenance_leaf_vlog_test.go
@@ -176,6 +176,56 @@ func TestVacuumIndexOffline_LeafPagesInValueLog_ReopenParity(t *testing.T) {
 	}
 }
 
+func TestOuterLeafPagesUseLeafVLogDir(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.Options{
+		Dir:                        dir,
+		Durability:                 treedb.DurabilityWALOffRelaxed,
+		IndexOuterLeavesInValueLog: true,
+		ValueLog: treedb.ValueLogOptions{
+			PointerThreshold: 1,
+		},
+	}
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	for i := 0; i < 512; i++ {
+		key := []byte(fmt.Sprintf("leaf-vlog-%04d", i))
+		val := bytes.Repeat([]byte{byte(i % 251)}, 96)
+		if err := db.Set(key, val); err != nil {
+			t.Fatalf("set %q: %v", string(key), err)
+		}
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	leafPaths, err := filepath.Glob(filepath.Join(filepath.Dir(mainIndexPath(dir)), "leaf_vlog", "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob leaf_vlog: %v", err)
+	}
+	if len(leafPaths) == 0 {
+		t.Fatalf("expected leaf_vlog segments")
+	}
+	nonEmpty := false
+	for _, p := range leafPaths {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %s: %v", p, err)
+		}
+		if info.Size() > 0 {
+			nonEmpty = true
+			break
+		}
+	}
+	if !nonEmpty {
+		t.Fatalf("expected non-empty leaf_vlog segment, paths=%v", leafPaths)
+	}
+}
+
 func TestValueLogRewriteOnline_LeafPagesInValueLog_ReopenParity(t *testing.T) {
 	dir := t.TempDir()
 	opts := treedb.Options{

--- a/TreeDB/offline_maintenance_template_lookup_test.go
+++ b/TreeDB/offline_maintenance_template_lookup_test.go
@@ -81,17 +81,17 @@ func TestVacuumIndexOffline_WithTemplateFrames_WiresTemplateLookup(t *testing.T)
 	if err != nil {
 		t.Fatalf("Open(writer): %v", err)
 	}
-	walDir := filepath.Join(mainDir, "wal")
-	if err := os.MkdirAll(walDir, 0o755); err != nil {
+	valueLogDir := filepath.Join(mainDir, "value_vlog")
+	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
 		_ = writer.Close()
-		t.Fatalf("MkdirAll(wal): %v", err)
+		t.Fatalf("MkdirAll(value_vlog): %v", err)
 	}
 	fileID, err := valuelog.EncodeFileID(0, 1)
 	if err != nil {
 		_ = writer.Close()
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	vlogWriter, err := valuelog.NewWriter(filepath.Join(walDir, "value-l0-000001.log"), fileID)
+	vlogWriter, err := valuelog.NewWriter(filepath.Join(valueLogDir, "value-l0-000001.log"), fileID)
 	if err != nil {
 		_ = writer.Close()
 		t.Fatalf("NewWriter: %v", err)

--- a/TreeDB/page/leaf_log_ptr.go
+++ b/TreeDB/page/leaf_log_ptr.go
@@ -1,0 +1,35 @@
+package page
+
+import "fmt"
+
+// LeafLogPtr points to a leaf page stored in the external leaf log.
+//
+// The FileID is the raw segment identifier in the leaf-log namespace. It is
+// intentionally distinct from ValuePtr.FileID, which carries the value-log
+// marker bit for payload lookups.
+type LeafLogPtr struct {
+	Offset uint64
+	FileID uint32
+}
+
+func (ptr LeafLogPtr) ValueLogFileID() uint32 {
+	return ValueLogFileID(ptr.FileID)
+}
+
+func (ptr LeafLogPtr) ValuePtr() ValuePtr {
+	return ValuePtr{
+		Offset: ptr.Offset,
+		Length: leafRefPtrLength,
+		FileID: ptr.ValueLogFileID(),
+	}
+}
+
+func LeafLogPtrFromValuePtr(ptr ValuePtr) (LeafLogPtr, error) {
+	if !IsValueLogFileID(ptr.FileID) {
+		return LeafLogPtr{}, fmt.Errorf("page: leaf log pointer requires value-log file id, got %d", ptr.FileID)
+	}
+	return LeafLogPtr{
+		Offset: ptr.Offset,
+		FileID: ValueLogSegmentID(ptr.FileID),
+	}, nil
+}

--- a/TreeDB/page/leaf_ref.go
+++ b/TreeDB/page/leaf_ref.go
@@ -2,40 +2,38 @@ package page
 
 import "fmt"
 
-// LeafRef encodes a value-log pointer for a B+Tree leaf page into a uint64 so it
-// can be stored in InternalEntry.ChildPageID without changing the internal page
-// wire format.
+// LeafRef encodes a leaf-log pointer into a uint64 so it can be stored in
+// InternalEntry.ChildPageID without changing the internal page wire format.
 //
-// Layout (little-endian on disk via u64 encoding, but treated as numeric here):
-//   high 32 bits: ValuePtr.FileID (must be a value-log file id)
-//   low  32 bits: ValuePtr.Offset (must fit in u32)
+// Layout:
+//   bit 63:      leaf-ref marker
+//   bits 32..62: LeafLogPtr.FileID (raw leaf-log file id; must fit in 31 bits)
+//   bits  0..31: LeafLogPtr.Offset (must fit in u32)
 //
-// LeafRef pointers intentionally omit ValuePtr.Length/sub-index. Leaf pages are
-// stored as single-record grouped frames (K=1), so the reader can reconstruct a
-// stable ValuePtr with grouped flag and zero record-length hint.
+// The marker keeps LeafRef ids disjoint from normal pager page ids while
+// keeping file identity typed at the API level instead of smuggling class bits
+// through ValuePtr.FileID.
+
+const leafRefMarker uint64 = uint64(1) << 63
 
 var leafRefPtrLength = ValuePtrMarkGrouped(0, 0)
 
-// EncodeLeafRef encodes ptr as a LeafRef id.
-func EncodeLeafRef(ptr ValuePtr) (uint64, error) {
-	if !IsValueLogFileID(ptr.FileID) {
-		return 0, fmt.Errorf("page: leafref requires value-log file id, got %d", ptr.FileID)
+func EncodeLeafRef(ptr LeafLogPtr) (uint64, error) {
+	if ptr.FileID&(1<<31) != 0 {
+		return 0, fmt.Errorf("page: leafref file id overflows 31 bits: %d", ptr.FileID)
 	}
 	if ptr.Offset > uint64(^uint32(0)) {
 		return 0, fmt.Errorf("page: leafref offset overflows u32: %d", ptr.Offset)
 	}
-	return (uint64(ptr.FileID) << 32) | uint64(uint32(ptr.Offset)), nil
+	return leafRefMarker | (uint64(ptr.FileID) << 32) | uint64(uint32(ptr.Offset)), nil
 }
 
-// DecodeLeafRef decodes a LeafRef id into a ValuePtr.
-func DecodeLeafRef(id uint64) (ValuePtr, bool) {
-	fileID := uint32(id >> 32)
-	if !IsValueLogFileID(fileID) {
-		return ValuePtr{}, false
+func DecodeLeafRef(id uint64) (LeafLogPtr, bool) {
+	if id&leafRefMarker == 0 {
+		return LeafLogPtr{}, false
 	}
-	return ValuePtr{
+	return LeafLogPtr{
 		Offset: uint64(uint32(id)),
-		Length: leafRefPtrLength,
-		FileID: fileID,
+		FileID: uint32((id >> 32) & ((uint64(1) << 31) - 1)),
 	}, true
 }

--- a/TreeDB/page/leaf_ref_test.go
+++ b/TreeDB/page/leaf_ref_test.go
@@ -3,10 +3,10 @@ package page
 import "testing"
 
 func TestLeafRef_EncodeDecode_RoundTrip(t *testing.T) {
-	tests := []ValuePtr{
-		{FileID: ValueLogFileID(1), Offset: 0},
-		{FileID: ValueLogFileID(1), Offset: 123},
-		{FileID: ValueLogFileID(1234), Offset: uint64(^uint32(0))},
+	tests := []LeafLogPtr{
+		{FileID: 1, Offset: 0},
+		{FileID: 1, Offset: 123},
+		{FileID: 1234, Offset: uint64(^uint32(0))},
 	}
 	for _, in := range tests {
 		id, err := EncodeLeafRef(in)
@@ -23,33 +23,43 @@ func TestLeafRef_EncodeDecode_RoundTrip(t *testing.T) {
 		if out.Offset != in.Offset {
 			t.Fatalf("LeafRef Offset mismatch: got=%d want=%d", out.Offset, in.Offset)
 		}
-		if !ValuePtrIsGrouped(out) {
-			t.Fatalf("LeafRef ptr should be grouped: %+v", out)
+		vptr := out.ValuePtr()
+		if !IsValueLogFileID(vptr.FileID) {
+			t.Fatalf("LeafRef ValuePtr should target value-log namespace: %+v", vptr)
 		}
-		if ValuePtrSubIndex(out) != 0 {
-			t.Fatalf("LeafRef sub-index mismatch: got=%d want=0 (%+v)", ValuePtrSubIndex(out), out)
+		if !ValuePtrIsGrouped(vptr) {
+			t.Fatalf("LeafRef ValuePtr should be grouped: %+v", vptr)
 		}
-		if ValuePtrRecordLength(out) != 0 {
-			t.Fatalf("LeafRef record length hint should be 0: got=%d (%+v)", ValuePtrRecordLength(out), out)
+		if ValuePtrSubIndex(vptr) != 0 {
+			t.Fatalf("LeafRef sub-index mismatch: got=%d want=0 (%+v)", ValuePtrSubIndex(vptr), vptr)
+		}
+		if ValuePtrRecordLength(vptr) != 0 {
+			t.Fatalf("LeafRef record length hint should be 0: got=%d (%+v)", ValuePtrRecordLength(vptr), vptr)
 		}
 	}
 }
 
-func TestLeafRef_EncodeRejectsNonValueLogFileID(t *testing.T) {
-	if _, err := EncodeLeafRef(ValuePtr{FileID: 123, Offset: 0}); err == nil {
-		t.Fatalf("expected EncodeLeafRef to reject non-value-log file id")
+func TestLeafRef_EncodeRejectsFileIDOverflow(t *testing.T) {
+	if _, err := EncodeLeafRef(LeafLogPtr{FileID: 1 << 31, Offset: 0}); err == nil {
+		t.Fatalf("expected EncodeLeafRef to reject 31-bit overflow file id")
 	}
 }
 
 func TestLeafRef_EncodeRejectsOffsetOverflow(t *testing.T) {
-	if _, err := EncodeLeafRef(ValuePtr{FileID: ValueLogFileID(1), Offset: uint64(^uint32(0)) + 1}); err == nil {
+	if _, err := EncodeLeafRef(LeafLogPtr{FileID: 1, Offset: uint64(^uint32(0)) + 1}); err == nil {
 		t.Fatalf("expected EncodeLeafRef to reject u32 overflow offset")
 	}
 }
 
-func TestLeafRef_DecodeRejectsNonValueLogFileID(t *testing.T) {
-	id := (uint64(123) << 32) | 1 // FileID without value-log marker.
+func TestLeafRef_DecodeRejectsNonLeafRefID(t *testing.T) {
+	id := (uint64(123) << 32) | 1
 	if _, ok := DecodeLeafRef(id); ok {
-		t.Fatalf("expected DecodeLeafRef ok=false for non-value-log file id")
+		t.Fatalf("expected DecodeLeafRef ok=false for non-leafref id")
+	}
+}
+
+func TestLeafLogPtrFromValuePtr_RejectsNonValueLogID(t *testing.T) {
+	if _, err := LeafLogPtrFromValuePtr(ValuePtr{FileID: 123, Offset: 0}); err == nil {
+		t.Fatalf("expected LeafLogPtrFromValuePtr to reject non-value-log file id")
 	}
 }

--- a/TreeDB/permissions_test.go
+++ b/TreeDB/permissions_test.go
@@ -73,12 +73,12 @@ func TestDefaultPermissions_AreNotWorldReadable(t *testing.T) {
 	checkDirPerms(filepath.Join(dir, "maindb", "wal"))
 	checkDirPerms(filepath.Join(dir, "maindb", "value_vlog"))
 	checkDirPerms(filepath.Join(dir, "maindb", "leaf_vlog"))
-	valueFiles, err := filepath.Glob(filepath.Join(dir, "maindb", "wal", "value-*.log"))
+	valueFiles, err := filepath.Glob(filepath.Join(dir, "maindb", "value_vlog", "value-*.log"))
 	if err != nil {
-		t.Fatalf("Glob wal value logs: %v", err)
+		t.Fatalf("Glob value_vlog value logs: %v", err)
 	}
 	if len(valueFiles) == 0 {
-		t.Fatalf("expected value-log segment in wal dir")
+		t.Fatalf("expected value-log segment in value_vlog dir")
 	}
 	for _, path := range valueFiles {
 		checkFilePerms(path)

--- a/TreeDB/permissions_test.go
+++ b/TreeDB/permissions_test.go
@@ -71,6 +71,8 @@ func TestDefaultPermissions_AreNotWorldReadable(t *testing.T) {
 	checkFilePerms(filepath.Join(dir, "maindb", "index.db"))
 	checkFilePerms(filepath.Join(dir, "maindb", "LOCK"))
 	checkDirPerms(filepath.Join(dir, "maindb", "wal"))
+	checkDirPerms(filepath.Join(dir, "maindb", "value_vlog"))
+	checkDirPerms(filepath.Join(dir, "maindb", "leaf_vlog"))
 	valueFiles, err := filepath.Glob(filepath.Join(dir, "maindb", "wal", "value-*.log"))
 	if err != nil {
 		t.Fatalf("Glob wal value logs: %v", err)

--- a/TreeDB/recovery_spec_test.go
+++ b/TreeDB/recovery_spec_test.go
@@ -505,11 +505,14 @@ func TestRecovery_RIDJoinReplaysValueLog(t *testing.T) {
 	dir := t.TempDir()
 
 	walDir := filepath.Join(dir, "maindb", "wal")
-	if err := os.MkdirAll(walDir, 0755); err != nil {
-		t.Fatalf("mkdir wal: %v", err)
+	valueLogDir := filepath.Join(dir, "maindb", "value_vlog")
+	for _, path := range []string{walDir, valueLogDir} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatalf("mkdir log dir %s: %v", path, err)
+		}
 	}
 
-	valuePath := filepath.Join(walDir, "value-l0-000001.log")
+	valuePath := filepath.Join(valueLogDir, "value-l0-000001.log")
 	vw, err := valuelog.NewWriter(valuePath, page.ValueLogFileID(1))
 	if err != nil {
 		t.Fatalf("valuelog.NewWriter: %v", err)
@@ -567,11 +570,14 @@ func TestRecovery_RIDJoinReplaysValueLog(t *testing.T) {
 func TestRecovery_CommitFence_PublishesOnlyCommittedVLogRefs(t *testing.T) {
 	dir := t.TempDir()
 	walDir := filepath.Join(dir, "maindb", "wal")
-	if err := os.MkdirAll(walDir, 0o755); err != nil {
-		t.Fatalf("mkdir wal: %v", err)
+	valueLogDir := filepath.Join(dir, "maindb", "value_vlog")
+	for _, path := range []string{walDir, valueLogDir} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir log dir %s: %v", path, err)
+		}
 	}
 
-	valuePath := filepath.Join(walDir, "value-l0-000001.log")
+	valuePath := filepath.Join(valueLogDir, "value-l0-000001.log")
 	vw, err := valuelog.NewWriter(valuePath, page.ValueLogFileID(1))
 	if err != nil {
 		t.Fatalf("valuelog.NewWriter: %v", err)
@@ -638,11 +644,14 @@ func TestRecovery_CommitFence_PublishesOnlyCommittedVLogRefs(t *testing.T) {
 func TestRecovery_PartialFlushFence_NoPhantomPointers(t *testing.T) {
 	dir := t.TempDir()
 	walDir := filepath.Join(dir, "maindb", "wal")
-	if err := os.MkdirAll(walDir, 0o755); err != nil {
-		t.Fatalf("mkdir wal: %v", err)
+	valueLogDir := filepath.Join(dir, "maindb", "value_vlog")
+	for _, path := range []string{walDir, valueLogDir} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir log dir %s: %v", path, err)
+		}
 	}
 
-	valuePath := filepath.Join(walDir, "value-l0-000001.log")
+	valuePath := filepath.Join(valueLogDir, "value-l0-000001.log")
 	vw, err := valuelog.NewWriter(valuePath, page.ValueLogFileID(1))
 	if err != nil {
 		t.Fatalf("valuelog.NewWriter: %v", err)
@@ -796,8 +805,11 @@ func TestRecovery_MissingDictFails(t *testing.T) {
 	dir := t.TempDir()
 
 	walDir := filepath.Join(dir, "maindb", "wal")
-	if err := os.MkdirAll(walDir, 0755); err != nil {
-		t.Fatalf("mkdir wal: %v", err)
+	valueLogDir := filepath.Join(dir, "maindb", "value_vlog")
+	for _, path := range []string{walDir, valueLogDir} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatalf("mkdir log dir %s: %v", path, err)
+		}
 	}
 	if err := os.MkdirAll(filepath.Join(dir, "dictdb"), 0755); err != nil {
 		t.Fatalf("mkdir dictdb: %v", err)
@@ -805,7 +817,7 @@ func TestRecovery_MissingDictFails(t *testing.T) {
 
 	dictID := uint64(1)
 	records := []valuelog.Record{{RID: 1, Value: bytes.Repeat([]byte("value"), 1024)}}
-	valuePath := filepath.Join(walDir, "value-l0-000001.log")
+	valuePath := filepath.Join(valueLogDir, "value-l0-000001.log")
 	frame, _, err := valuelog.EncodeFrame(0, nil, records)
 	if err != nil {
 		t.Fatalf("EncodeFrame: %v", err)
@@ -942,11 +954,14 @@ func TestRecovery_TruncatedValueLogRecord(t *testing.T) {
 	dir := t.TempDir()
 
 	walDir := filepath.Join(dir, "maindb", "wal")
-	if err := os.MkdirAll(walDir, 0755); err != nil {
-		t.Fatalf("mkdir wal: %v", err)
+	valueLogDir := filepath.Join(dir, "maindb", "value_vlog")
+	for _, path := range []string{walDir, valueLogDir} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatalf("mkdir log dir %s: %v", path, err)
+		}
 	}
 
-	valuePath := filepath.Join(walDir, "value-l0-000001.log")
+	valuePath := filepath.Join(valueLogDir, "value-l0-000001.log")
 	vw, err := valuelog.NewWriter(valuePath, page.ValueLogFileID(1))
 	if err != nil {
 		t.Fatalf("valuelog.NewWriter: %v", err)

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -1013,7 +1013,7 @@ func (it *Iterator) loadNode(pageID uint64) (node.Node, error) {
 		if cap(it.leafRefScratch) != page.PageSize {
 			it.leafRefScratch = make([]byte, 0, page.PageSize)
 		}
-		data, err := it.slabAppender.ReadUnsafeAppend(ptr, it.leafRefScratch[:0])
+		data, err := it.slabAppender.ReadUnsafeAppend(ptr.ValuePtr(), it.leafRefScratch[:0])
 		if err != nil {
 			return node.Node{}, err
 		}

--- a/TreeDB/tree/iterator_test.go
+++ b/TreeDB/tree/iterator_test.go
@@ -50,8 +50,8 @@ func TestIterator_LeafRefChecksumPolicyHonored(t *testing.T) {
 		leaf.UpdateChecksum()
 		leafData[8] ^= 0x01 // checksum field
 
-		leafRefID, err := page.EncodeLeafRef(page.ValuePtr{
-			FileID: page.ValueLogFileID(1),
+		leafRefID, err := page.EncodeLeafRef(page.LeafLogPtr{
+			FileID: 1,
 			Offset: 8,
 		})
 		if err != nil {
@@ -61,7 +61,7 @@ func TestIterator_LeafRefChecksumPolicyHonored(t *testing.T) {
 		if !ok {
 			t.Fatalf("DecodeLeafRef failed")
 		}
-		tracked.values[ptr] = leafData
+		tracked.values[ptr.ValuePtr()] = leafData
 		return New(nil, tracked, leafRefID)
 	}
 

--- a/TreeDB/tree/leafref_decode_to_test.go
+++ b/TreeDB/tree/leafref_decode_to_test.go
@@ -46,9 +46,9 @@ func (r *trackedLeafRefReader) ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]by
 }
 
 func TestTreeGetAppend_LeafRefPrefersReadUnsafeTo(t *testing.T) {
-	leafPtr := page.ValuePtr{
+	leafPtr := page.LeafLogPtr{
 		Offset: 4,
-		FileID: page.ValueLogFileID(1),
+		FileID: 1,
 	}
 	leafID, err := page.EncodeLeafRef(leafPtr)
 	if err != nil {

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -247,7 +247,7 @@ func (t *Tree) loadNodeView(pageID uint64, verifyAlways bool) (node.Node, error)
 		if t.slabReader == nil {
 			return node.Node{}, errors.New("missing slab reader")
 		}
-		data, err := t.slabReader.ReadUnsafe(ptr)
+		data, err := t.slabReader.ReadUnsafe(ptr.ValuePtr())
 		if err != nil {
 			return node.Node{}, err
 		}
@@ -379,7 +379,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 				)
 				if t.slabToReader != nil {
 					var usedDst bool
-					data, usedDst, err = t.slabToReader.ReadUnsafeTo(ptr, leafScratch.buf)
+					data, usedDst, err = t.slabToReader.ReadUnsafeTo(ptr.ValuePtr(), leafScratch.buf)
 					if err != nil {
 						putLeafRefPageScratch(leafScratch)
 						return nil, page.ValuePtr{}, 0, false, err
@@ -391,7 +391,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 						leafScratch = nil
 					}
 				} else if t.slabAppender != nil {
-					data, err = t.slabAppender.ReadUnsafeAppend(ptr, leafScratch.buf[:0])
+					data, err = t.slabAppender.ReadUnsafeAppend(ptr.ValuePtr(), leafScratch.buf[:0])
 					if err != nil {
 						putLeafRefPageScratch(leafScratch)
 						return nil, page.ValuePtr{}, 0, false, err

--- a/TreeDB/tree/tree_test.go
+++ b/TreeDB/tree/tree_test.go
@@ -270,8 +270,8 @@ func TestTreeGetAppend_UsesAppendReaderForLeafRefPages(t *testing.T) {
 	leaf.AddLeafEntry([]byte("k"), []byte("v"), node.FlagInline, page.ValuePtr{})
 	leaf.UpdateChecksum()
 
-	leafRefID, err := page.EncodeLeafRef(page.ValuePtr{
-		FileID: page.ValueLogFileID(1),
+	leafRefID, err := page.EncodeLeafRef(page.LeafLogPtr{
+		FileID: 1,
 		Offset: 8,
 	})
 	if err != nil {
@@ -281,7 +281,7 @@ func TestTreeGetAppend_UsesAppendReaderForLeafRefPages(t *testing.T) {
 	if !ok {
 		t.Fatalf("DecodeLeafRef failed")
 	}
-	tracked.values[ptr] = append([]byte(nil), leafData...)
+	tracked.values[ptr.ValuePtr()] = append([]byte(nil), leafData...)
 
 	tr := New(nil, tracked, leafRefID)
 	got, err := tr.GetAppend([]byte("k"), nil)
@@ -317,8 +317,8 @@ func TestTreeGetAppend_LeafRefChecksumPolicyHonored(t *testing.T) {
 			trackedValueReader:  &trackedValueReader{mapValueReader: newMapValueReader()},
 			readChecksumEnabled: checksumEnabled,
 		}
-		leafRefID, err := page.EncodeLeafRef(page.ValuePtr{
-			FileID: page.ValueLogFileID(1),
+		leafRefID, err := page.EncodeLeafRef(page.LeafLogPtr{
+			FileID: 1,
 			Offset: 8,
 		})
 		if err != nil {
@@ -328,7 +328,7 @@ func TestTreeGetAppend_LeafRefChecksumPolicyHonored(t *testing.T) {
 		if !ok {
 			t.Fatalf("DecodeLeafRef failed")
 		}
-		tracked.values[ptr] = makeCorruptLeaf()
+		tracked.values[ptr.ValuePtr()] = makeCorruptLeaf()
 		return New(nil, tracked, leafRefID)
 	}
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -23,7 +23,7 @@ type PageAllocator interface {
 }
 
 type LeafPageLog interface {
-	AppendLeafPage(leafPage []byte) (page.ValuePtr, error)
+	AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error)
 }
 
 type LeafPageReader interface {
@@ -1073,7 +1073,7 @@ func (z *Zipper) loadNode(id uint64, scratchCtx *mergeScratch) (node.Node, bool,
 		}
 		if r, ok := z.leafPageReader.(leafPageUnsafeToReader); ok {
 			scratch := acquireLeafPageScratch(scratchCtx)
-			data, usedScratch, err := r.ReadUnsafeTo(ptr, scratch[:0])
+			data, usedScratch, err := r.ReadUnsafeTo(ptr.ValuePtr(), scratch[:0])
 			if err != nil {
 				releaseLeafPageScratch(scratchCtx, scratch)
 				return node.Node{}, false, nil, false, err
@@ -1101,7 +1101,7 @@ func (z *Zipper) loadNode(id uint64, scratchCtx *mergeScratch) (node.Node, bool,
 			return n, false, nil, false, nil
 		}
 
-		data, err := z.leafPageReader.ReadUnsafe(ptr)
+		data, err := z.leafPageReader.ReadUnsafe(ptr.ValuePtr())
 		if err != nil {
 			return node.Node{}, false, nil, false, err
 		}

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -49,14 +49,13 @@ type stubLeafPageLog struct {
 	next uint32
 }
 
-func (l *stubLeafPageLog) AppendLeafPage(_ []byte) (page.ValuePtr, error) {
+func (l *stubLeafPageLog) AppendLeafPage(_ []byte) (page.LeafLogPtr, error) {
 	if l.next == 0 {
 		l.next = 4
 	}
-	ptr := page.ValuePtr{
-		FileID: page.ValueLogFileID(1),
+	ptr := page.LeafLogPtr{
+		FileID: 1,
 		Offset: uint64(l.next),
-		Length: 0,
 	}
 	l.next += 4096 + 32
 	return ptr, nil
@@ -80,7 +79,7 @@ func newMemoryLeafPageStore(z *Zipper) *memoryLeafPageStore {
 	}
 }
 
-func (s *memoryLeafPageStore) AppendLeafPage(leafPage []byte) (page.ValuePtr, error) {
+func (s *memoryLeafPageStore) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if s.z != nil {
 		s.z.leafRefCacheMu.RLock()
 		if s.z.leafRefCache != nil {
@@ -93,15 +92,14 @@ func (s *memoryLeafPageStore) AppendLeafPage(leafPage []byte) (page.ValuePtr, er
 	if s.next == 0 {
 		s.next = 4
 	}
-	ptr := page.ValuePtr{
-		FileID: page.ValueLogFileID(1),
+	ptr := page.LeafLogPtr{
+		FileID: 1,
 		Offset: uint64(s.next),
-		Length: uint32(len(leafPage)),
 	}
 	s.next += 4096 + 32
 	key, err := page.EncodeLeafRef(ptr)
 	if err != nil {
-		return page.ValuePtr{}, err
+		return page.LeafLogPtr{}, err
 	}
 	s.pages[key] = append([]byte(nil), leafPage...)
 	return ptr, nil
@@ -109,7 +107,11 @@ func (s *memoryLeafPageStore) AppendLeafPage(leafPage []byte) (page.ValuePtr, er
 
 func (s *memoryLeafPageStore) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
 	s.readCalls++
-	key, err := page.EncodeLeafRef(ptr)
+	leafPtr, err := page.LeafLogPtrFromValuePtr(ptr)
+	if err != nil {
+		return nil, err
+	}
+	key, err := page.EncodeLeafRef(leafPtr)
 	if err != nil {
 		return nil, err
 	}
@@ -430,11 +432,11 @@ func TestCoalesceInternalChildren_SkipsLeafRefsWhenOuterLeavesInValueLog(t *test
 	z := New(p, alloc)
 	z.SetOuterLeavesInValueLog(true)
 
-	leftID, err := page.EncodeLeafRef(page.ValuePtr{FileID: page.ValueLogFileID(1), Offset: 4})
+	leftID, err := page.EncodeLeafRef(page.LeafLogPtr{FileID: 1, Offset: 4})
 	if err != nil {
 		t.Fatalf("EncodeLeafRef left: %v", err)
 	}
-	rightID, err := page.EncodeLeafRef(page.ValuePtr{FileID: page.ValueLogFileID(1), Offset: 4096})
+	rightID, err := page.EncodeLeafRef(page.LeafLogPtr{FileID: 1, Offset: 4096})
 	if err != nil {
 		t.Fatalf("EncodeLeafRef right: %v", err)
 	}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -247,9 +247,11 @@ type walDiskUsage struct {
 type treeDBDiskUsage struct {
 	MainIndexBytes uint64
 	MainWAL        walDiskUsage
+	MainValueLog   walDiskUsage
 
 	DictIndexBytes uint64
 	DictWAL        walDiskUsage
+	DictValueLog   walDiskUsage
 }
 
 type treeDBVlogRewriteReport struct {
@@ -3898,7 +3900,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		}
 		if isTreeDBInstance(inst) {
 			if usage, err := computeTreeDBDiskUsage(inst.Dir); err == nil {
-				if usage.MainIndexBytes > 0 || usage.MainWAL.TotalBytes > 0 || usage.DictIndexBytes > 0 || usage.DictWAL.TotalBytes > 0 {
+				if usage.MainIndexBytes > 0 || usage.MainWAL.TotalBytes > 0 || usage.MainValueLog.TotalBytes > 0 || usage.DictIndexBytes > 0 || usage.DictWAL.TotalBytes > 0 || usage.DictValueLog.TotalBytes > 0 {
 					treedbDisk[inst.Wrapper.Name()] = usage
 				}
 			}
@@ -4059,6 +4061,10 @@ func computeTreeDBDiskUsage(rootDir string) (treeDBDiskUsage, error) {
 	if u, err := computeWalDiskUsage(mainWAL); err == nil {
 		out.MainWAL = u
 	}
+	mainValueLog := filepath.Join(rootDir, "maindb", "value_vlog")
+	if u, err := computeWalDiskUsage(mainValueLog); err == nil {
+		out.MainValueLog = u
+	}
 
 	dictIndex := filepath.Join(rootDir, "dictdb", "index.db")
 	if st, err := os.Stat(dictIndex); err == nil {
@@ -4069,6 +4075,10 @@ func computeTreeDBDiskUsage(rootDir string) (treeDBDiskUsage, error) {
 	dictWAL := filepath.Join(rootDir, "dictdb", "wal")
 	if u, err := computeWalDiskUsage(dictWAL); err == nil {
 		out.DictWAL = u
+	}
+	dictValueLog := filepath.Join(rootDir, "dictdb", "value_vlog")
+	if u, err := computeWalDiskUsage(dictValueLog); err == nil {
+		out.DictValueLog = u
 	}
 
 	return out, nil
@@ -4123,11 +4133,19 @@ func renderTreeDBDiskUsageString(usage map[string]treeDBDiskUsage) string {
 			sb.WriteString(walLine("  maindb/wal: ", u.MainWAL))
 			sb.WriteByte('\n')
 		}
+		if u.MainValueLog.TotalFiles > 0 || u.MainValueLog.TotalBytes > 0 {
+			sb.WriteString(walLine("  maindb/value_vlog: ", u.MainValueLog))
+			sb.WriteByte('\n')
+		}
 		if u.DictIndexBytes > 0 {
 			sb.WriteString(fmt.Sprintf("  dictdb/index.db: %s\n", formatBytes(u.DictIndexBytes)))
 		}
 		if u.DictWAL.TotalFiles > 0 || u.DictWAL.TotalBytes > 0 {
 			sb.WriteString(walLine("  dictdb/wal: ", u.DictWAL))
+			sb.WriteByte('\n')
+		}
+		if u.DictValueLog.TotalFiles > 0 || u.DictValueLog.TotalBytes > 0 {
+			sb.WriteString(walLine("  dictdb/value_vlog: ", u.DictValueLog))
 			sb.WriteByte('\n')
 		}
 	}
@@ -4169,6 +4187,9 @@ func renderTreeDBVlogRewriteString(reports map[string]treeDBVlogRewriteReport) s
 		}
 		if rep.BeforeTree.MainWAL.TotalBytes > 0 || rep.AfterTree.MainWAL.TotalBytes > 0 {
 			sb.WriteString(fmt.Sprintf("  maindb/wal: %s -> %s\n", formatBytes(rep.BeforeTree.MainWAL.TotalBytes), formatBytes(rep.AfterTree.MainWAL.TotalBytes)))
+		}
+		if rep.BeforeTree.MainValueLog.TotalBytes > 0 || rep.AfterTree.MainValueLog.TotalBytes > 0 {
+			sb.WriteString(fmt.Sprintf("  maindb/value_vlog: %s -> %s\n", formatBytes(rep.BeforeTree.MainValueLog.TotalBytes), formatBytes(rep.AfterTree.MainValueLog.TotalBytes)))
 		}
 		sb.WriteString(fmt.Sprintf("  vlog-rewrite: segments %d -> %d bytes %s -> %s records=%d\n",
 			rep.SegmentsBefore, rep.SegmentsAfter,

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -248,6 +248,7 @@ type treeDBDiskUsage struct {
 	MainIndexBytes uint64
 	MainWAL        walDiskUsage
 	MainValueLog   walDiskUsage
+	MainLeafLog    walDiskUsage
 
 	DictIndexBytes uint64
 	DictWAL        walDiskUsage
@@ -3900,7 +3901,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		}
 		if isTreeDBInstance(inst) {
 			if usage, err := computeTreeDBDiskUsage(inst.Dir); err == nil {
-				if usage.MainIndexBytes > 0 || usage.MainWAL.TotalBytes > 0 || usage.MainValueLog.TotalBytes > 0 || usage.DictIndexBytes > 0 || usage.DictWAL.TotalBytes > 0 || usage.DictValueLog.TotalBytes > 0 {
+				if usage.MainIndexBytes > 0 || usage.MainWAL.TotalBytes > 0 || usage.MainValueLog.TotalBytes > 0 || usage.MainLeafLog.TotalBytes > 0 || usage.DictIndexBytes > 0 || usage.DictWAL.TotalBytes > 0 || usage.DictValueLog.TotalBytes > 0 {
 					treedbDisk[inst.Wrapper.Name()] = usage
 				}
 			}
@@ -4065,6 +4066,10 @@ func computeTreeDBDiskUsage(rootDir string) (treeDBDiskUsage, error) {
 	if u, err := computeWalDiskUsage(mainValueLog); err == nil {
 		out.MainValueLog = u
 	}
+	mainLeafLog := filepath.Join(rootDir, "maindb", "leaf_vlog")
+	if u, err := computeWalDiskUsage(mainLeafLog); err == nil {
+		out.MainLeafLog = u
+	}
 
 	dictIndex := filepath.Join(rootDir, "dictdb", "index.db")
 	if st, err := os.Stat(dictIndex); err == nil {
@@ -4137,6 +4142,10 @@ func renderTreeDBDiskUsageString(usage map[string]treeDBDiskUsage) string {
 			sb.WriteString(walLine("  maindb/value_vlog: ", u.MainValueLog))
 			sb.WriteByte('\n')
 		}
+		if u.MainLeafLog.TotalFiles > 0 || u.MainLeafLog.TotalBytes > 0 {
+			sb.WriteString(walLine("  maindb/leaf_vlog: ", u.MainLeafLog))
+			sb.WriteByte('\n')
+		}
 		if u.DictIndexBytes > 0 {
 			sb.WriteString(fmt.Sprintf("  dictdb/index.db: %s\n", formatBytes(u.DictIndexBytes)))
 		}
@@ -4190,6 +4199,9 @@ func renderTreeDBVlogRewriteString(reports map[string]treeDBVlogRewriteReport) s
 		}
 		if rep.BeforeTree.MainValueLog.TotalBytes > 0 || rep.AfterTree.MainValueLog.TotalBytes > 0 {
 			sb.WriteString(fmt.Sprintf("  maindb/value_vlog: %s -> %s\n", formatBytes(rep.BeforeTree.MainValueLog.TotalBytes), formatBytes(rep.AfterTree.MainValueLog.TotalBytes)))
+		}
+		if rep.BeforeTree.MainLeafLog.TotalBytes > 0 || rep.AfterTree.MainLeafLog.TotalBytes > 0 {
+			sb.WriteString(fmt.Sprintf("  maindb/leaf_vlog: %s -> %s\n", formatBytes(rep.BeforeTree.MainLeafLog.TotalBytes), formatBytes(rep.AfterTree.MainLeafLog.TotalBytes)))
 		}
 		sb.WriteString(fmt.Sprintf("  vlog-rewrite: segments %d -> %d bytes %s -> %s records=%d\n",
 			rep.SegmentsBefore, rep.SegmentsAfter,

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1357,3 +1357,47 @@ func TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing(t *test
 		t.Fatalf("expected mutex_after before allocs_after, events=%v", events)
 	}
 }
+
+func TestRenderTreeDBDiskUsageString_EmitsValueLogWithoutWAL(t *testing.T) {
+	out := renderTreeDBDiskUsageString(map[string]treeDBDiskUsage{
+		"treedb": {
+			MainValueLog: walDiskUsage{
+				TotalFiles: 1,
+				TotalBytes: 2048,
+				ValueBytes: 1536,
+			},
+		},
+	})
+	if !strings.Contains(out, "maindb/value_vlog:") {
+		t.Fatalf("expected value_vlog line, got:\n%s", out)
+	}
+	if strings.Contains(out, "maindb/wal:") {
+		t.Fatalf("did not expect wal line when wal usage is empty, got:\n%s", out)
+	}
+}
+
+func TestRenderTreeDBVlogRewriteString_EmitsValueLogWithoutWAL(t *testing.T) {
+	out := renderTreeDBVlogRewriteString(map[string]treeDBVlogRewriteReport{
+		"treedb": {
+			BeforeUsage: dirDiskUsage{TotalBytes: 4096},
+			AfterUsage:  dirDiskUsage{TotalBytes: 2048},
+			BeforeTree: treeDBDiskUsage{
+				MainValueLog: walDiskUsage{TotalBytes: 4096},
+			},
+			AfterTree: treeDBDiskUsage{
+				MainValueLog: walDiskUsage{TotalBytes: 2048},
+			},
+			SegmentsBefore: 2,
+			SegmentsAfter:  1,
+			BytesBefore:    4096,
+			BytesAfter:     2048,
+			RecordsCopied:  7,
+		},
+	})
+	if !strings.Contains(out, "maindb/value_vlog: 4 KiB -> 2 KiB") {
+		t.Fatalf("expected value_vlog rewrite line, got:\n%s", out)
+	}
+	if strings.Contains(out, "maindb/wal:") {
+		t.Fatalf("did not expect wal line when wal usage is empty, got:\n%s", out)
+	}
+}

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1376,6 +1376,43 @@ func TestRenderTreeDBDiskUsageString_EmitsValueLogWithoutWAL(t *testing.T) {
 	}
 }
 
+func TestComputeTreeDBDiskUsage_IncludesLeafVLog(t *testing.T) {
+	dir := t.TempDir()
+	mainDir := filepath.Join(dir, "maindb")
+	if err := os.MkdirAll(filepath.Join(mainDir, "leaf_vlog"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(leaf_vlog): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mainDir, "leaf_vlog", "value-l255-000001.log"), bytes.Repeat([]byte("x"), 321), 0o644); err != nil {
+		t.Fatalf("WriteFile(leaf_vlog): %v", err)
+	}
+
+	usage, err := computeTreeDBDiskUsage(dir)
+	if err != nil {
+		t.Fatalf("computeTreeDBDiskUsage: %v", err)
+	}
+	if usage.MainLeafLog.TotalFiles != 1 {
+		t.Fatalf("MainLeafLog.TotalFiles=%d want 1", usage.MainLeafLog.TotalFiles)
+	}
+	if usage.MainLeafLog.TotalBytes != 321 {
+		t.Fatalf("MainLeafLog.TotalBytes=%d want 321", usage.MainLeafLog.TotalBytes)
+	}
+}
+
+func TestRenderTreeDBDiskUsageString_EmitsLeafLog(t *testing.T) {
+	out := renderTreeDBDiskUsageString(map[string]treeDBDiskUsage{
+		"treedb": {
+			MainLeafLog: walDiskUsage{
+				TotalFiles: 1,
+				TotalBytes: 3072,
+				ValueBytes: 3072,
+			},
+		},
+	})
+	if !strings.Contains(out, "maindb/leaf_vlog:") {
+		t.Fatalf("expected leaf_vlog line, got:\n%s", out)
+	}
+}
+
 func TestRenderTreeDBVlogRewriteString_EmitsValueLogWithoutWAL(t *testing.T) {
 	out := renderTreeDBVlogRewriteString(map[string]treeDBVlogRewriteReport{
 		"treedb": {
@@ -1399,5 +1436,28 @@ func TestRenderTreeDBVlogRewriteString_EmitsValueLogWithoutWAL(t *testing.T) {
 	}
 	if strings.Contains(out, "maindb/wal:") {
 		t.Fatalf("did not expect wal line when wal usage is empty, got:\n%s", out)
+	}
+}
+
+func TestRenderTreeDBVlogRewriteString_EmitsLeafLog(t *testing.T) {
+	out := renderTreeDBVlogRewriteString(map[string]treeDBVlogRewriteReport{
+		"treedb": {
+			BeforeUsage: dirDiskUsage{TotalBytes: 8192},
+			AfterUsage:  dirDiskUsage{TotalBytes: 4096},
+			BeforeTree: treeDBDiskUsage{
+				MainLeafLog: walDiskUsage{TotalBytes: 6144},
+			},
+			AfterTree: treeDBDiskUsage{
+				MainLeafLog: walDiskUsage{TotalBytes: 2048},
+			},
+			SegmentsBefore: 3,
+			SegmentsAfter:  1,
+			BytesBefore:    6144,
+			BytesAfter:     2048,
+			RecordsCopied:  5,
+		},
+	})
+	if !strings.Contains(out, "maindb/leaf_vlog: 6 KiB -> 2 KiB") {
+		t.Fatalf("expected leaf_vlog rewrite line, got:\n%s", out)
 	}
 }

--- a/cmd/unified_bench/suite_parallel_unlock.go
+++ b/cmd/unified_bench/suite_parallel_unlock.go
@@ -101,7 +101,7 @@ func runSingleTreeDBWriteSuite(baseCfg BenchConfig, testName string) (writeSuite
 	if usage, ok := run.TreeDBDiskUsage[dbName]; ok {
 		out.mainIndexBytes = usage.MainIndexBytes
 		out.mainWALBytes = usage.MainWAL.TotalBytes
-		out.mainValueBytes = usage.MainWAL.ValueBytes
+		out.mainValueBytes = usage.MainValueLog.ValueBytes
 		out.mainFiles = usage.MainWAL.TotalFiles
 	}
 	if snap, ok := run.TreeDBStats[dbName]; ok {
@@ -407,7 +407,7 @@ func runVlogQueueLagSuite(baseCfg BenchConfig) (string, error) {
 	sb.WriteString(fmt.Sprintf("- wall time: %s\n", s.wall.Truncate(time.Millisecond)))
 	sb.WriteString(fmt.Sprintf("- maindb index bytes: %s\n", formatBytes(s.mainIndexBytes)))
 	sb.WriteString(fmt.Sprintf("- maindb wal bytes (total): %s\n", formatBytes(s.mainWALBytes)))
-	sb.WriteString(fmt.Sprintf("- maindb value-log bytes (wal dir): %s\n", formatBytes(s.mainValueBytes)))
+	sb.WriteString(fmt.Sprintf("- maindb value-log bytes (value_vlog dir): %s\n", formatBytes(s.mainValueBytes)))
 	sb.WriteString(fmt.Sprintf("- maindb wal files: %d\n", s.mainFiles))
 	sb.WriteString(fmt.Sprintf("- queue lag samples: %s\n", formatInt(int(lagSamples))))
 	sb.WriteString(fmt.Sprintf("- queue enqueued total: %s\n", formatInt(int(queuedTotal))))

--- a/scripts/issue379_auto_matrix.sh
+++ b/scripts/issue379_auto_matrix.sh
@@ -170,9 +170,12 @@ def parse_run(log_path: Path, time_path: Path, wrapper: str, engine: str):
     size_bytes = 0
     vlog_bytes = None
     if engine == "treedb":
+        m_value_vlog = re.search(r"maindb/value_vlog:[^\n]*\bvalue=([0-9]+(?:\.[0-9]+)?\s*[A-Za-z]+)", txt)
         m_vlog = re.search(r"maindb/wal:[^\n]*\bvlog=([0-9]+(?:\.[0-9]+)?\s*[A-Za-z]+)", txt)
         m_value = re.search(r"maindb/wal:[^\n]*\bvalue=([0-9]+(?:\.[0-9]+)?\s*[A-Za-z]+)", txt)
-        if m_vlog:
+        if m_value_vlog:
+            vlog_bytes = parse_bytes(m_value_vlog.group(1))
+        elif m_vlog:
             vlog_bytes = parse_bytes(m_vlog.group(1))
         elif m_value:
             vlog_bytes = parse_bytes(m_value.group(1))

--- a/scripts/treedb_forceptr_matrix.sh
+++ b/scripts/treedb_forceptr_matrix.sh
@@ -226,6 +226,12 @@ def parse_run(text):
                     out["disk"]["maindb_value_vlog_total"] = total
                 if value is not None:
                     out["disk"]["maindb_value_vlog_value"] = value
+            elif line.startswith("maindb/leaf_vlog:"):
+                total, value = parse_dir_usage(line, "maindb/leaf_vlog:")
+                if total is not None:
+                    out["disk"]["maindb_leaf_vlog_total"] = total
+                if value is not None:
+                    out["disk"]["maindb_leaf_vlog_value"] = value
             elif line.startswith("dictdb/wal:"):
                 total, value = parse_dir_usage(line, "dictdb/wal:")
                 if total is not None:
@@ -264,7 +270,7 @@ lines.append("")
 for profile in profiles:
     lines.append(f"## Profile: {profile}")
     lines.append("")
-    header = ["variant"] + tests + ["index.db", "wal(total)", "dict/index.db"]
+    header = ["variant"] + tests + ["index.db", "external(total)", "dict/index.db"]
     lines.append("| " + " | ".join(header) + " |")
     lines.append("|" + "|".join(["---"] + ["---:"] * (len(header) - 1)) + "|")
     for variant in variants:
@@ -278,7 +284,8 @@ for profile in profiles:
             v = ops.get(t)
             row.append(f"{v:,}" if isinstance(v, int) else "-")
         row.append(fmt_bytes(disk.get("maindb_index")))
-        row.append(fmt_bytes(disk.get("maindb_wal_total")))
+        external_total = sum(int(disk.get(k, 0) or 0) for k in ("maindb_wal_total", "maindb_value_vlog_total", "maindb_leaf_vlog_total"))
+        row.append(fmt_bytes(external_total if external_total > 0 else None))
         row.append(fmt_bytes(disk.get("dictdb_index")))
         lines.append("| " + " | ".join(row) + " |")
     lines.append("")

--- a/scripts/treedb_forceptr_matrix.sh
+++ b/scripts/treedb_forceptr_matrix.sh
@@ -202,11 +202,15 @@ def parse_run(text):
                 sz = line.split(":", 1)[1].strip()
                 out["disk"]["dictdb_index"] = parse_size(sz)
             elif line.startswith("maindb/wal:"):
-                # maindb/wal: total=1.2 GiB files=1 value=1.2 GiB
                 m2 = re.search(r"total=([0-9.]+)\s*([KMG]iB).*value=([0-9.]+)\s*([KMG]iB)", line)
                 if m2:
                     out["disk"]["maindb_wal_total"] = parse_size(f"{m2.group(1)} {m2.group(2)}")
                     out["disk"]["maindb_wal_value"] = parse_size(f"{m2.group(3)} {m2.group(4)}")
+            elif line.startswith("maindb/value_vlog:"):
+                m2 = re.search(r"total=([0-9.]+)\s*([KMG]iB).*value=([0-9.]+)\s*([KMG]iB)", line)
+                if m2:
+                    out["disk"]["maindb_value_vlog_total"] = parse_size(f"{m2.group(1)} {m2.group(2)}")
+                    out["disk"]["maindb_value_vlog_value"] = parse_size(f"{m2.group(3)} {m2.group(4)}")
             elif line.startswith("dictdb/wal:"):
                 m2 = re.search(r"total=([0-9.]+)\s*([KMG]iB).*value=([0-9.]+)\s*([KMG]iB)", line)
                 if m2:

--- a/scripts/treedb_forceptr_matrix.sh
+++ b/scripts/treedb_forceptr_matrix.sh
@@ -147,6 +147,19 @@ def parse_size(s):
     mul = {"KiB": 1024, "MiB": 1024**2, "GiB": 1024**3}[unit]
     return int(n * mul)
 
+def parse_dir_usage(line, prefix):
+    if not line.startswith(prefix):
+        return None, None
+    m_total = re.search(r"\btotal=([0-9.]+)\s*([KMG]iB)", line)
+    if not m_total:
+        return None, None
+    total = parse_size(f"{m_total.group(1)} {m_total.group(2)}")
+    m_value = re.search(r"\bvalue=([0-9.]+)\s*([KMG]iB)", line)
+    value = None
+    if m_value:
+        value = parse_size(f"{m_value.group(1)} {m_value.group(2)}")
+    return total, value
+
 def fmt_bytes(n):
     if not n:
         return "-"
@@ -202,20 +215,29 @@ def parse_run(text):
                 sz = line.split(":", 1)[1].strip()
                 out["disk"]["dictdb_index"] = parse_size(sz)
             elif line.startswith("maindb/wal:"):
-                m2 = re.search(r"total=([0-9.]+)\s*([KMG]iB).*value=([0-9.]+)\s*([KMG]iB)", line)
-                if m2:
-                    out["disk"]["maindb_wal_total"] = parse_size(f"{m2.group(1)} {m2.group(2)}")
-                    out["disk"]["maindb_wal_value"] = parse_size(f"{m2.group(3)} {m2.group(4)}")
+                total, value = parse_dir_usage(line, "maindb/wal:")
+                if total is not None:
+                    out["disk"]["maindb_wal_total"] = total
+                if value is not None:
+                    out["disk"]["maindb_wal_value"] = value
             elif line.startswith("maindb/value_vlog:"):
-                m2 = re.search(r"total=([0-9.]+)\s*([KMG]iB).*value=([0-9.]+)\s*([KMG]iB)", line)
-                if m2:
-                    out["disk"]["maindb_value_vlog_total"] = parse_size(f"{m2.group(1)} {m2.group(2)}")
-                    out["disk"]["maindb_value_vlog_value"] = parse_size(f"{m2.group(3)} {m2.group(4)}")
+                total, value = parse_dir_usage(line, "maindb/value_vlog:")
+                if total is not None:
+                    out["disk"]["maindb_value_vlog_total"] = total
+                if value is not None:
+                    out["disk"]["maindb_value_vlog_value"] = value
             elif line.startswith("dictdb/wal:"):
-                m2 = re.search(r"total=([0-9.]+)\s*([KMG]iB).*value=([0-9.]+)\s*([KMG]iB)", line)
-                if m2:
-                    out["disk"]["dictdb_wal_total"] = parse_size(f"{m2.group(1)} {m2.group(2)}")
-                    out["disk"]["dictdb_wal_value"] = parse_size(f"{m2.group(3)} {m2.group(4)}")
+                total, value = parse_dir_usage(line, "dictdb/wal:")
+                if total is not None:
+                    out["disk"]["dictdb_wal_total"] = total
+                if value is not None:
+                    out["disk"]["dictdb_wal_value"] = value
+            elif line.startswith("dictdb/value_vlog:"):
+                total, value = parse_dir_usage(line, "dictdb/value_vlog:")
+                if total is not None:
+                    out["disk"]["dictdb_value_vlog_total"] = total
+                if value is not None:
+                    out["disk"]["dictdb_value_vlog_value"] = value
             if line == "```":
                 break
     return out


### PR DESCRIPTION
## Summary
- increase grouped block-frame targets for large value-log payloads so 40+ KiB records do not collapse to `k=1`
- use a conservative large-payload bootstrap ratio when no block-ratio signal exists yet, so the first rebuild batches can group immediately
- add regression coverage that writes real large payloads and inspects the resulting value-log frame structure

## Why
On the split value/leaf-log branch, the application-db rebuild was producing a poorly-compressed `maindb/value_vlog` even though the payloads were highly repetitive. Frame scanning showed:

- `records_total=23104`
- `grouped_frames=21543`
- `avg_records_per_grouped_frame=1.072`
- `grouped_ratio=0.579573`
- `value_vlog` size: about `497 MiB`

The root cause was not "compression off". Large payloads were being block-compressed with a tiny grouped-frame target and no bootstrap ratio signal, which mathematically collapsed block grouping to one record per frame.

## Validation
Targeted tests:
- `env GOWORK=off go test ./TreeDB/caching -run 'TestChooseValueLogBlockWriteK_LargePayloadUsesExpandedTarget|TestAppendValueLogForRecords_LargePayloadBatchGroupsFrames' -count=1`
- `env GOWORK=off go test ./TreeDB/caching -count=1`
- `env GOWORK=off go test ./TreeDB -count=1`

Real rebuild validation using the same application-db source used for the engine-matrix work:

Old split-log rebuild result:
- total TreeDB rebuild size: `2.612 GiB`
- `value_vlog`: `497 MiB`
- frame scan: `avg_records_per_grouped_frame=1.072`, `grouped_ratio=0.579573`

New rebuild result from this branch:
- output dir: `/home/mikers/.application-db-engine-matrix-compressionfix-20260413220129`
- total TreeDB rebuild size: `2.259 GiB`
- TreeDB final rewrite size: `2.251 GiB`
- `value_vlog`: `135 MiB`
- `leaf_vlog`: `2.1 GiB`
- frame scan: `avg_records_per_grouped_frame=13.712`, `grouped_ratio=0.157249`
- mode breakdown:
  - `grouped_block_lz4`: `14673` records, ratio `0.049232`
  - `grouped_block_snappy`: `8431` records, ratio `0.397197`

This is the same logical dataset and profile family. The change is the large-payload frame grouping policy.
