### PR TITLE
[codex] Add unified-bench TreeDB perf instrumentation

### DIFF
--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -4768,20 +4768,27 @@ func renderTreeDBSelectedStatsString(instances []*DBInstance, treeStats map[stri
 		if len(stats) == 0 {
 			continue
 		}
-		sb.WriteString(dbName)
-		sb.WriteString(":\n")
+		var dbSB strings.Builder
+		foundSelectedStat := false
 		for _, key := range keys {
 			for _, alt := range key.alts {
 				if value, ok := stats[alt]; ok {
-					sb.WriteString("  ")
-					sb.WriteString(key.label)
-					sb.WriteString(": ")
-					sb.WriteString(value)
-					sb.WriteByte('\n')
+					dbSB.WriteString("  ")
+					dbSB.WriteString(key.label)
+					dbSB.WriteString(": ")
+					dbSB.WriteString(value)
+					dbSB.WriteByte('\n')
+					foundSelectedStat = true
 					break
 				}
 			}
 		}
+		if !foundSelectedStat {
+			continue
+		}
+		sb.WriteString(dbName)
+		sb.WriteString(":\n")
+		sb.WriteString(dbSB.String())
 	}
 	return strings.TrimSpace(sb.String())
 }
@@ -4892,6 +4899,48 @@ func renderMarkdownSweep(runs []BenchRun) string {
 			sb.WriteString("```text\n")
 			sb.WriteString(renderTreeDBVlogRewriteString(run.TreeDBVlogRewrite))
 			sb.WriteString("```\n\n")
+		}
+	}
+
+	anyPerf := false
+	for _, run := range runs {
+		if strings.TrimSpace(renderTreeDBPerfString(run.Instances, run.TestOrder, run.DisplayNames, run.TreeDBPerf)) != "" {
+			anyPerf = true
+			break
+		}
+	}
+	if anyPerf {
+		sb.WriteString("## TreeDB Perf Instrumentation\n\n")
+		for _, run := range runs {
+			perf := strings.TrimSpace(renderTreeDBPerfString(run.Instances, run.TestOrder, run.DisplayNames, run.TreeDBPerf))
+			if perf == "" {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("keys=%s\n\n", formatInt(run.Config.Keys)))
+			sb.WriteString("```text\n")
+			sb.WriteString(perf)
+			sb.WriteString("\n```\n\n")
+		}
+	}
+
+	anyTreeStats := false
+	for _, run := range runs {
+		if strings.TrimSpace(renderTreeDBSelectedStatsString(run.Instances, run.TreeDBStats)) != "" {
+			anyTreeStats = true
+			break
+		}
+	}
+	if anyTreeStats {
+		sb.WriteString("## TreeDB Selected Stats (End of Run)\n\n")
+		for _, run := range runs {
+			stats := strings.TrimSpace(renderTreeDBSelectedStatsString(run.Instances, run.TreeDBStats))
+			if stats == "" {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("keys=%s\n\n", formatInt(run.Config.Keys)))
+			sb.WriteString("```text\n")
+			sb.WriteString(stats)
+			sb.WriteString("\n```\n\n")
 		}
 	}
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1271,6 +1271,92 @@ func TestRenderMarkdownSweep_KeepDirIncludesKeptSection(t *testing.T) {
 	}
 }
 
+func TestRenderTreeDBSelectedStatsString_SkipsDBsWithoutSelectedKeys(t *testing.T) {
+	instances := []*DBInstance{
+		{Name: "tree", Wrapper: &fixedNameDB{name: "TreeDB"}},
+		{Name: "other", Wrapper: &fixedNameDB{name: "OtherDB"}},
+	}
+	stats := map[string]map[string]string{
+		"TreeDB": {
+			"treedb.cache.vlog_mmap.read.hits": "7",
+		},
+		"OtherDB": {
+			"unrelated.stat": "1",
+		},
+	}
+
+	got := renderTreeDBSelectedStatsString(instances, stats)
+	if !strings.Contains(got, "TreeDB:\n") {
+		t.Fatalf("expected TreeDB stats, got:\n%s", got)
+	}
+	if strings.Contains(got, "OtherDB:\n") {
+		t.Fatalf("expected OtherDB to be omitted, got:\n%s", got)
+	}
+}
+
+func TestRenderMarkdownSweep_IncludesTreeDBPerfAndStatsSections(t *testing.T) {
+	makeRun := func(keys int, hits uint64, pinned int64) BenchRun {
+		return BenchRun{
+			Config: BenchConfig{
+				Keys:         keys,
+				ValueSize:    16,
+				BatchSize:    10,
+				RangeQueries: 0,
+				RangeSpan:    0,
+			},
+			Instances: []*DBInstance{
+				{Name: "tree", Wrapper: &fixedNameDB{name: "TreeDB"}},
+			},
+			TestOrder: []string{"random_read_parallel"},
+			DisplayNames: map[string]string{
+				"random_read_parallel": "Random Read (Parallel)",
+			},
+			Results: map[string]map[string]float64{
+				"random_read_parallel": {
+					"TreeDB": 1234,
+				},
+			},
+			TreeDBPerf: map[string]map[string]treeDBPerfMetrics{
+				"random_read_parallel": {
+					"TreeDB": {
+						Mmap: treeDBMmapPerfMetrics{
+							Hits:           hits,
+							FallbackReadAt: 1,
+							HitRatio:       0.5,
+						},
+					},
+				},
+			},
+			TreeDBStats: map[string]map[string]string{
+				"TreeDB": {
+					"treedb.cache.vlog_mmap.read.hits":          "7",
+					"treedb.leaf_generation.generations.pinned": formatInt(int(pinned)),
+				},
+			},
+		}
+	}
+
+	md := renderMarkdownSweep([]BenchRun{
+		makeRun(100, 7, 1),
+		makeRun(200, 9, 2),
+	})
+	if !strings.Contains(md, "## TreeDB Perf Instrumentation") {
+		t.Fatalf("expected TreeDB perf section, got:\n%s", md)
+	}
+	if !strings.Contains(md, "keys=100") || !strings.Contains(md, "keys=200") {
+		t.Fatalf("expected keyed perf/stats subsections, got:\n%s", md)
+	}
+	if !strings.Contains(md, "vlog_mmap.read.hits.delta=7") || !strings.Contains(md, "vlog_mmap.read.hits.delta=9") {
+		t.Fatalf("expected sweep perf details, got:\n%s", md)
+	}
+	if !strings.Contains(md, "## TreeDB Selected Stats (End of Run)") {
+		t.Fatalf("expected TreeDB selected stats section, got:\n%s", md)
+	}
+	if !strings.Contains(md, "leaf_generation.generations.pinned: 1") || !strings.Contains(md, "leaf_generation.generations.pinned: 2") {
+		t.Fatalf("expected sweep selected stats details, got:\n%s", md)
+	}
+}
+
 func TestRunFlushDrainSuite_ShortKeys(t *testing.T) {
 	cfg := BenchConfig{
 		Keys:                   1,


### PR DESCRIPTION
## What changed

This PR adds TreeDB-focused perf instrumentation to `unified-bench` and its profile artifacts.

Specifically:
- captures per-test snapshot lifecycle timing for `random_read_parallel` and `random_read_parallel_acquire_snapshot`
- captures per-test TreeDB `vlog_mmap` read deltas from existing stats
- exports the new perf block in `benchprof_results.json`
- renders the new perf block and selected end-of-run TreeDB stats in `benchprof_results.md`
- adds tests for JSON export, markdown rendering, and live snapshot metric capture

## Why

We need a measurement-only landing point before changing behavior in the read path and snapshot path.

The current profile review identified three immediate questions:
- how expensive snapshot acquire/close is in benchmark terms
- whether read-path syscall cost is really an `mmap` miss/fallback problem
- how to make those counters visible in the normal benchmark artifact flow instead of inspecting raw `Stats()` output manually

This PR addresses that measurement gap without changing TreeDB behavior.

## Validation

- `GOWORK=off go test ./cmd/unified_bench -count=1`
- `GOWORK=off go test ./cmd/benchprof -count=1`
- `GOWORK=off go run ./cmd/unified_bench -dbs treedb -keys 2000 -batchsize 128 -valsize 32 -test sequential_write,random_read_parallel,random_read_parallel_acquire_snapshot -profile-dir <tmpdir>`

## Follow-up

The next PR should consume this instrumentation to attack the first real fix target:
- snapshot acquire/close overhead
- then `leaf_vlog` mmap fallback causes
