### PR TITLE
[codex] TreeDB: mmap current leaf log segments

### DIFF
--- a/TreeDB/caching/lane.go
+++ b/TreeDB/caching/lane.go
@@ -104,7 +104,7 @@ const (
 	vlogGenerationClassCold
 )
 
-const leafLogLaneID = 255
+const leafLogLaneID = valuelog.ReservedLeafLogLaneID
 
 func commitLogName(laneID, seq int) string {
 	return fmt.Sprintf("commit-l%d-%06d.log", laneID, seq)

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -26,41 +26,6 @@ type Snapshot struct {
 	backend *backenddb.Snapshot
 
 	closed atomic.Bool
-	next   *Snapshot
-}
-
-var snapshotPoolHead atomic.Pointer[Snapshot]
-
-func acquirePooledSnapshot() *Snapshot {
-	for {
-		head := snapshotPoolHead.Load()
-		if head == nil {
-			return &Snapshot{}
-		}
-		next := head.next
-		if !snapshotPoolHead.CompareAndSwap(head, next) {
-			continue
-		}
-		head.next = nil
-		head.closed.Store(false)
-		return head
-	}
-}
-
-func releasePooledSnapshot(s *Snapshot) {
-	if s == nil {
-		return
-	}
-	s.db = nil
-	s.view = nil
-	s.backend = nil
-	for {
-		head := snapshotPoolHead.Load()
-		s.next = head
-		if snapshotPoolHead.CompareAndSwap(head, s) {
-			return
-		}
-	}
 }
 
 type backendSnapshotProvider interface {
@@ -72,7 +37,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	if db == nil || db.backend == nil || db.closing.Load() {
 		return nil
 	}
-	snap := acquirePooledSnapshot()
+	snap := &Snapshot{}
 
 	view := db.retainMemtableView()
 	needsRotate := db.mutableBytes.Load() > 0
@@ -107,7 +72,6 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 				if db.notifyError != nil {
 					db.notifyError(err)
 				}
-				releasePooledSnapshot(snap)
 				return nil
 			}
 		}
@@ -125,7 +89,6 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		if view != nil {
 			db.releaseMemtableView(view)
 		}
-		releasePooledSnapshot(snap)
 		return nil
 	}
 	backendSnap := provider.AcquireSnapshot()
@@ -133,7 +96,6 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		if view != nil {
 			db.releaseMemtableView(view)
 		}
-		releasePooledSnapshot(snap)
 		return nil
 	}
 
@@ -165,17 +127,16 @@ func (s *Snapshot) Close() error {
 		return nil
 	}
 
-	var errs []error
+	var err error
 	if s.backend != nil {
-		errs = append(errs, s.backend.Close())
+		err = s.backend.Close()
 		s.backend = nil
 	}
 	if s.view != nil && s.db != nil {
 		s.db.releaseMemtableView(s.view)
 		s.view = nil
 	}
-	err := errors.Join(errs...)
-	releasePooledSnapshot(s)
+	s.db = nil
 	return err
 }
 

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -3,6 +3,7 @@ package caching
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -25,8 +26,29 @@ type Snapshot struct {
 	view    *memtableView
 	backend *backenddb.Snapshot
 
-	closeOnce sync.Once
-	closeErr  error
+	closed atomic.Bool
+}
+
+var snapshotPool = sync.Pool{
+	New: func() any {
+		return &Snapshot{}
+	},
+}
+
+func acquirePooledSnapshot() *Snapshot {
+	s := snapshotPool.Get().(*Snapshot)
+	s.closed.Store(false)
+	return s
+}
+
+func releasePooledSnapshot(s *Snapshot) {
+	if s == nil {
+		return
+	}
+	s.db = nil
+	s.view = nil
+	s.backend = nil
+	snapshotPool.Put(s)
 }
 
 type backendSnapshotProvider interface {
@@ -38,6 +60,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	if db == nil || db.backend == nil || db.closing.Load() {
 		return nil
 	}
+	snap := acquirePooledSnapshot()
 
 	view := db.retainMemtableView()
 	needsRotate := db.mutableBytes.Load() > 0
@@ -72,6 +95,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 				if db.notifyError != nil {
 					db.notifyError(err)
 				}
+				releasePooledSnapshot(snap)
 				return nil
 			}
 		}
@@ -89,6 +113,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		if view != nil {
 			db.releaseMemtableView(view)
 		}
+		releasePooledSnapshot(snap)
 		return nil
 	}
 	backendSnap := provider.AcquireSnapshot()
@@ -96,10 +121,14 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		if view != nil {
 			db.releaseMemtableView(view)
 		}
+		releasePooledSnapshot(snap)
 		return nil
 	}
 
-	return &Snapshot{db: db, view: view, backend: backendSnap}
+	snap.db = db
+	snap.view = view
+	snap.backend = backendSnap
+	return snap
 }
 
 func (s *Snapshot) Pager() *pager.Pager {
@@ -120,19 +149,22 @@ func (s *Snapshot) Close() error {
 	if s == nil {
 		return nil
 	}
-	s.closeOnce.Do(func() {
-		var errs []error
-		if s.backend != nil {
-			errs = append(errs, s.backend.Close())
-			s.backend = nil
-		}
-		if s.view != nil && s.db != nil {
-			s.db.releaseMemtableView(s.view)
-			s.view = nil
-		}
-		s.closeErr = errors.Join(errs...)
-	})
-	return s.closeErr
+	if !s.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+
+	var errs []error
+	if s.backend != nil {
+		errs = append(errs, s.backend.Close())
+		s.backend = nil
+	}
+	if s.view != nil && s.db != nil {
+		s.db.releaseMemtableView(s.view)
+		s.view = nil
+	}
+	err := errors.Join(errs...)
+	releasePooledSnapshot(s)
+	return err
 }
 
 func (s *Snapshot) lookupQueueEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -20,6 +20,9 @@ import (
 //
 // Mutable memtables are intentionally ignored so that writes after AcquireSnapshot
 // are not visible through the snapshot.
+//
+// Snapshot pointers are single-use: after Close returns, callers must discard the
+// pointer and treat further use as invalid.
 type Snapshot struct {
 	db      *DB
 	view    *memtableView

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -2,7 +2,6 @@ package caching
 
 import (
 	"errors"
-	"sync"
 	"sync/atomic"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -27,18 +26,25 @@ type Snapshot struct {
 	backend *backenddb.Snapshot
 
 	closed atomic.Bool
+	next   *Snapshot
 }
 
-var snapshotPool = sync.Pool{
-	New: func() any {
-		return &Snapshot{}
-	},
-}
+var snapshotPoolHead atomic.Pointer[Snapshot]
 
 func acquirePooledSnapshot() *Snapshot {
-	s := snapshotPool.Get().(*Snapshot)
-	s.closed.Store(false)
-	return s
+	for {
+		head := snapshotPoolHead.Load()
+		if head == nil {
+			return &Snapshot{}
+		}
+		next := head.next
+		if !snapshotPoolHead.CompareAndSwap(head, next) {
+			continue
+		}
+		head.next = nil
+		head.closed.Store(false)
+		return head
+	}
 }
 
 func releasePooledSnapshot(s *Snapshot) {
@@ -48,7 +54,13 @@ func releasePooledSnapshot(s *Snapshot) {
 	s.db = nil
 	s.view = nil
 	s.backend = nil
-	snapshotPool.Put(s)
+	for {
+		head := snapshotPoolHead.Load()
+		s.next = head
+		if snapshotPoolHead.CompareAndSwap(head, s) {
+			return
+		}
+	}
 }
 
 type backendSnapshotProvider interface {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -40,7 +40,6 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	if db == nil || db.backend == nil || db.closing.Load() {
 		return nil
 	}
-	snap := &Snapshot{}
 
 	view := db.retainMemtableView()
 	needsRotate := db.mutableBytes.Load() > 0
@@ -102,10 +101,11 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		return nil
 	}
 
-	snap.db = db
-	snap.view = view
-	snap.backend = backendSnap
-	return snap
+	return &Snapshot{
+		db:      db,
+		view:    view,
+		backend: backendSnap,
+	}
 }
 
 func (s *Snapshot) Pager() *pager.Pager {

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -117,3 +117,44 @@ func TestIteratorSnapshotIsolation(t *testing.T) {
 		t.Error("Iterator saw key 'b' written AFTER iterator creation (Snapshot Isolation violation)")
 	}
 }
+
+func TestAcquireSnapshot_AllocsAfterWarmPool(t *testing.T) {
+	dir, err := os.MkdirTemp("", "treedb-snapshot-pool-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cached.Close()
+
+	warm := cached.AcquireSnapshot()
+	if warm == nil {
+		t.Fatal("warm AcquireSnapshot=nil")
+	}
+	if err := warm.Close(); err != nil {
+		t.Fatalf("warm Close: %v", err)
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		snap := cached.AcquireSnapshot()
+		if snap == nil {
+			t.Fatal("AcquireSnapshot=nil")
+		}
+		if err := snap.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+	if allocs > 0.05 {
+		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 0.05 after warm pool", allocs)
+	}
+}

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -118,7 +118,10 @@ func TestIteratorSnapshotIsolation(t *testing.T) {
 	}
 }
 
-func TestAcquireSnapshot_AllocsAfterWarmPool(t *testing.T) {
+func TestAcquireSnapshot_AllocsBoundedAfterWarmPath(t *testing.T) {
+	if testRaceEnabled {
+		t.Skip("AllocsPerRun is not stable under -race")
+	}
 	dir, err := os.MkdirTemp("", "treedb-snapshot-pool-")
 	if err != nil {
 		t.Fatal(err)
@@ -154,7 +157,7 @@ func TestAcquireSnapshot_AllocsAfterWarmPool(t *testing.T) {
 			t.Fatalf("Close: %v", err)
 		}
 	})
-	if allocs > 0.05 {
-		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 0.05 after warm pool", allocs)
+	if allocs > 1.05 {
+		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 1.05 after warm path", allocs)
 	}
 }

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2075,6 +2075,9 @@ func (db *DB) publishSnapshotView(idx *indexGen, state *DBState, vm *valuelog.Ma
 		state:       state,
 		vlogManager: vm,
 	})
+	if state.LeafGenerations != nil && db.snapshotAcquireInFlight() == 0 {
+		db.leafGenerationPins.pruneInactiveGenerationIDs(state.LeafGenerations.GenerationOrder)
+	}
 }
 
 func (db *DB) clearSnapshotView() {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -901,6 +901,7 @@ func (s *Snapshot) releaseLeafGenerationPins() {
 		}
 	}
 	s.leafGenerationIDs = s.leafGenerationIDs[:0]
+	clear(s.leafGenerationRefs)
 	s.leafGenerationRefs = s.leafGenerationRefs[:0]
 }
 

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -756,18 +756,19 @@ type Options struct {
 }
 
 type Snapshot struct {
-	db                *DB
-	idx               *indexGen
-	state             *DBState
-	vlogManager       *valuelog.Manager
-	vlogPinned        bool
-	leafGenerationIDs []uint64
-	registryID        int64
-	reader            valueReader
-	tree              tree.Tree
-	closed            atomic.Bool
-	treePager         *pager.Pager
-	treeRoot          uint64
+	db                 *DB
+	idx                *indexGen
+	state              *DBState
+	vlogManager        *valuelog.Manager
+	vlogPinned         bool
+	leafGenerationIDs  []uint64
+	leafGenerationRefs []*leafGenerationPinRef
+	registryID         int64
+	reader             valueReader
+	tree               tree.Tree
+	closed             atomic.Bool
+	treePager          *pager.Pager
+	treeRoot           uint64
 	// registryShardHint is used to route reader registrations to a stable fast
 	// registry shard for this snapshot object across operations.
 	registryShardHint int
@@ -849,9 +850,16 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	}
 	if state.LeafGenerations != nil {
 		snap.leafGenerationIDs = append(snap.leafGenerationIDs[:0], state.LeafGenerations.GenerationOrder...)
-		db.pinLeafGenerationIDs(snap.leafGenerationIDs)
+		if len(state.LeafGenerations.PinRefs) == len(state.LeafGenerations.GenerationOrder) && len(state.LeafGenerations.PinRefs) > 0 {
+			snap.leafGenerationRefs = append(snap.leafGenerationRefs[:0], state.LeafGenerations.PinRefs...)
+			db.pinLeafGenerationRefs(snap.leafGenerationRefs)
+		} else {
+			snap.leafGenerationRefs = snap.leafGenerationRefs[:0]
+			db.pinLeafGenerationIDs(snap.leafGenerationIDs)
+		}
 	} else {
 		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.leafGenerationRefs = snap.leafGenerationRefs[:0]
 	}
 
 	snap.db = db
@@ -880,6 +888,22 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	return snap
 }
 
+func (s *Snapshot) releaseLeafGenerationPins() {
+	if s == nil {
+		return
+	}
+	if s.db != nil {
+		switch {
+		case len(s.leafGenerationRefs) > 0:
+			s.db.unpinLeafGenerationRefs(s.leafGenerationRefs)
+		case len(s.leafGenerationIDs) > 0:
+			s.db.unpinLeafGenerationIDs(s.leafGenerationIDs)
+		}
+	}
+	s.leafGenerationIDs = s.leafGenerationIDs[:0]
+	s.leafGenerationRefs = s.leafGenerationRefs[:0]
+}
+
 // Close releases the snapshot.
 func (s *Snapshot) Close() error {
 	if s == nil {
@@ -905,9 +929,7 @@ func (s *Snapshot) Close() error {
 			}
 		}
 	}
-	if s.db != nil && len(s.leafGenerationIDs) > 0 {
-		s.db.unpinLeafGenerationIDs(s.leafGenerationIDs)
-	}
+	s.releaseLeafGenerationPins()
 	if s.db != nil {
 		s.db.snapPool.Put(s)
 	}

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -65,8 +65,7 @@ func (db *DB) LeafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		return stats, ErrClosed
 	}
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	if snap.state == nil || snap.state.LeafGenerations == nil {
 		_ = snap.Close()

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -161,8 +161,7 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 		return plan, ErrClosed
 	}
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	defer func() { _ = snap.Close() }()
 

--- a/TreeDB/db/leaf_generation_plan_bench_test.go
+++ b/TreeDB/db/leaf_generation_plan_bench_test.go
@@ -205,8 +205,7 @@ func BenchmarkLeafGenerationLiveStatsPersistedIndex_SavedHome(b *testing.B) {
 	}
 	b.Cleanup(func() { _ = snap.Close() })
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 
 	b.ReportAllocs()
@@ -243,8 +242,7 @@ func BenchmarkLeafGenerationLiveStatsVerifiedPagesPersistedIndex_SavedHome(b *te
 	}
 	b.Cleanup(func() { _ = snap.Close() })
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	if _, err := db.scanLeafGenerationLiveStats(context.Background(), snap); err != nil {
 		b.Fatalf("warm scanLeafGenerationLiveStats: %v", err)
@@ -284,8 +282,7 @@ func BenchmarkLeafGenerationLiveStatsWarmIndexesVerifiedPages_SavedHome(b *testi
 	}
 	b.Cleanup(func() { _ = snap.Close() })
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	if _, err := db.scanLeafGenerationLiveStats(context.Background(), snap); err != nil {
 		b.Fatalf("warm scanLeafGenerationLiveStats: %v", err)
@@ -414,8 +411,7 @@ func BenchmarkLeafGenerationPlanLeafRefStats_SavedHome(b *testing.B) {
 			b.Fatal(ErrClosed)
 		}
 		if len(snap.leafGenerationIDs) > 0 {
-			db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-			snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+			snap.releaseLeafGenerationPins()
 		}
 
 		seen := make(map[page.LeafLogPtr]struct{}, 1024)
@@ -461,8 +457,7 @@ func BenchmarkLeafGenerationPlanLeafRefPageStats_SavedHome(b *testing.B) {
 			b.Fatal(ErrClosed)
 		}
 		if len(snap.leafGenerationIDs) > 0 {
-			db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-			snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+			snap.releaseLeafGenerationPins()
 		}
 
 		seenPages := make(map[uint64]struct{}, 1024)

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -347,8 +347,7 @@ func TestLeafGenerationRecordLengthForPlan_LoadsPersistedSidecarWithoutRescan(t 
 	}
 	defer func() { _ = snap.Close() }()
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	view := snap.state.LeafGenerations
 	if view == nil {
@@ -424,8 +423,7 @@ func TestLeafGenerationRecordLengthForPlan_UsesWritableIndex(t *testing.T) {
 	}
 	defer func() { _ = snap.Close() }()
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	view := snap.state.LeafGenerations
 	if view == nil {
@@ -504,8 +502,7 @@ func TestLeafGenerationLiveStats_MarksPagerPagesVerified(t *testing.T) {
 	}
 	defer func() { _ = snap.Close() }()
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	if snap.idx == nil || snap.idx.pager == nil {
 		t.Fatal("expected pager")
@@ -561,8 +558,7 @@ func TestLeafGenerationRecordLengthForPlan_UsesSealedIndex(t *testing.T) {
 	}
 	defer func() { _ = snap.Close() }()
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	view := snap.state.LeafGenerations
 	if view == nil {
@@ -645,8 +641,7 @@ func TestLeafGenerationPlan_CachesLiveStatsPerPublishedState(t *testing.T) {
 		t.Fatal("expected snapshot")
 	}
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	if _, err := collectLiveLeafGenerationIDs(context.Background(), snap); err != nil {
 		_ = snap.Close()

--- a/TreeDB/db/leaf_generation_runtime.go
+++ b/TreeDB/db/leaf_generation_runtime.go
@@ -1,10 +1,14 @@
 package db
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 type leafGenerationView struct {
 	CurrentGenerationID uint64
 	GenerationOrder     []uint64
+	PinRefs             []*leafGenerationPinRef
 	Generations         map[uint64]leafGenerationViewGeneration
 	FileToGeneration    map[uint32]uint64
 }
@@ -46,50 +50,120 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 	if db == nil || db.leafGenerationManifest == nil {
 		return nil
 	}
-	return newLeafGenerationView(db.leafGenerationManifest)
+	view := newLeafGenerationView(db.leafGenerationManifest)
+	if view != nil && len(view.GenerationOrder) > 0 {
+		view.PinRefs = db.leafGenerationPins.refsForGenerationIDs(view.GenerationOrder)
+	}
+	return view
+}
+
+type leafGenerationPinRef struct {
+	count atomic.Int64
 }
 
 type leafGenerationPinTracker struct {
-	mu     sync.Mutex
-	counts map[uint64]uint64
+	mu   sync.RWMutex
+	refs map[uint64]*leafGenerationPinRef
 }
 
-func (t *leafGenerationPinTracker) pin(ids []uint64) {
+func (t *leafGenerationPinTracker) refsForGenerationIDs(ids []uint64) []*leafGenerationPinRef {
 	if len(ids) == 0 {
-		return
+		return nil
 	}
+	t.mu.RLock()
+	allPresent := t.refs != nil
+	if allPresent {
+		for _, id := range ids {
+			if id == 0 {
+				continue
+			}
+			if t.refs[id] == nil {
+				allPresent = false
+				break
+			}
+		}
+	}
+	if allPresent {
+		refs := make([]*leafGenerationPinRef, 0, len(ids))
+		for _, id := range ids {
+			if id == 0 {
+				continue
+			}
+			if ref := t.refs[id]; ref != nil {
+				refs = append(refs, ref)
+			}
+		}
+		t.mu.RUnlock()
+		return refs
+	}
+	t.mu.RUnlock()
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.counts == nil {
-		t.counts = make(map[uint64]uint64, len(ids))
+	if t.refs == nil {
+		t.refs = make(map[uint64]*leafGenerationPinRef, len(ids))
 	}
+	refs := make([]*leafGenerationPinRef, 0, len(ids))
 	for _, id := range ids {
 		if id == 0 {
 			continue
 		}
-		t.counts[id]++
+		ref := t.refs[id]
+		if ref == nil {
+			ref = &leafGenerationPinRef{}
+			t.refs[id] = ref
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func (t *leafGenerationPinTracker) lookupRefs(ids []uint64) []*leafGenerationPinRef {
+	if len(ids) == 0 {
+		return nil
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if len(t.refs) == 0 {
+		return nil
+	}
+	refs := make([]*leafGenerationPinRef, 0, len(ids))
+	for _, id := range ids {
+		if id == 0 {
+			continue
+		}
+		if ref := t.refs[id]; ref != nil {
+			refs = append(refs, ref)
+		}
+	}
+	return refs
+}
+
+func (t *leafGenerationPinTracker) pin(ids []uint64) {
+	t.pinRefs(t.refsForGenerationIDs(ids))
+}
+
+func (t *leafGenerationPinTracker) pinRefs(refs []*leafGenerationPinRef) {
+	for _, ref := range refs {
+		if ref == nil {
+			continue
+		}
+		ref.count.Add(1)
 	}
 }
 
 func (t *leafGenerationPinTracker) unpin(ids []uint64) {
-	if len(ids) == 0 {
-		return
-	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if len(t.counts) == 0 {
-		return
-	}
-	for _, id := range ids {
-		if id == 0 {
+	t.unpinRefs(t.lookupRefs(ids))
+}
+
+func (t *leafGenerationPinTracker) unpinRefs(refs []*leafGenerationPinRef) {
+	for _, ref := range refs {
+		if ref == nil {
 			continue
 		}
-		count := t.counts[id]
-		if count <= 1 {
-			delete(t.counts, id)
-			continue
+		if ref.count.Add(-1) < 0 {
+			ref.count.Store(0)
 		}
-		t.counts[id] = count - 1
 	}
 }
 
@@ -97,9 +171,17 @@ func (t *leafGenerationPinTracker) count(id uint64) uint64 {
 	if id == 0 {
 		return 0
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.counts[id]
+	t.mu.RLock()
+	ref := t.refs[id]
+	t.mu.RUnlock()
+	if ref == nil {
+		return 0
+	}
+	count := ref.count.Load()
+	if count <= 0 {
+		return 0
+	}
+	return uint64(count)
 }
 
 func (db *DB) pinLeafGenerationIDs(ids []uint64) {
@@ -114,6 +196,20 @@ func (db *DB) unpinLeafGenerationIDs(ids []uint64) {
 		return
 	}
 	db.leafGenerationPins.unpin(ids)
+}
+
+func (db *DB) pinLeafGenerationRefs(refs []*leafGenerationPinRef) {
+	if db == nil {
+		return
+	}
+	db.leafGenerationPins.pinRefs(refs)
+}
+
+func (db *DB) unpinLeafGenerationRefs(refs []*leafGenerationPinRef) {
+	if db == nil {
+		return
+	}
+	db.leafGenerationPins.unpinRefs(refs)
 }
 
 func (db *DB) leafGenerationPinCountForTesting(id uint64) uint64 {

--- a/TreeDB/db/leaf_generation_runtime.go
+++ b/TreeDB/db/leaf_generation_runtime.go
@@ -51,6 +51,9 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 		return nil
 	}
 	view := newLeafGenerationView(db.leafGenerationManifest)
+	if view != nil {
+		db.leafGenerationPins.pruneInactiveGenerationIDs(view.GenerationOrder)
+	}
 	if view != nil && len(view.GenerationOrder) > 0 {
 		view.PinRefs = db.leafGenerationPins.refsForGenerationIDs(view.GenerationOrder)
 	}
@@ -58,6 +61,7 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 }
 
 type leafGenerationPinRef struct {
+	id    uint64
 	count atomic.Int64
 }
 
@@ -110,7 +114,7 @@ func (t *leafGenerationPinTracker) refsForGenerationIDs(ids []uint64) []*leafGen
 		}
 		ref := t.refs[id]
 		if ref == nil {
-			ref = &leafGenerationPinRef{}
+			ref = &leafGenerationPinRef{id: id}
 			t.refs[id] = ref
 		}
 		refs = append(refs, ref)
@@ -158,11 +162,46 @@ func (t *leafGenerationPinTracker) unpin(ids []uint64) {
 
 func (t *leafGenerationPinTracker) unpinRefs(refs []*leafGenerationPinRef) {
 	for _, ref := range refs {
-		if ref == nil {
+		t.unpinRef(ref)
+	}
+}
+
+func (t *leafGenerationPinTracker) unpinRef(ref *leafGenerationPinRef) {
+	if ref == nil {
+		return
+	}
+	for {
+		current := ref.count.Load()
+		if current <= 0 {
+			return
+		}
+		next := current - 1
+		if !ref.count.CompareAndSwap(current, next) {
 			continue
 		}
-		if ref.count.Add(-1) < 0 {
-			ref.count.Store(0)
+		return
+	}
+}
+
+func (t *leafGenerationPinTracker) pruneInactiveGenerationIDs(active []uint64) {
+	activeSet := make(map[uint64]struct{}, len(active))
+	for _, id := range active {
+		if id != 0 {
+			activeSet[id] = struct{}{}
+		}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for id, ref := range t.refs {
+		if ref == nil {
+			delete(t.refs, id)
+			continue
+		}
+		if _, ok := activeSet[id]; ok {
+			continue
+		}
+		if ref.count.Load() == 0 {
+			delete(t.refs, id)
 		}
 	}
 }

--- a/TreeDB/db/leaf_generation_runtime.go
+++ b/TreeDB/db/leaf_generation_runtime.go
@@ -51,7 +51,7 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 		return nil
 	}
 	view := newLeafGenerationView(db.leafGenerationManifest)
-	if view != nil {
+	if view != nil && db.snapshotAcquireInFlight() == 0 {
 		db.leafGenerationPins.pruneInactiveGenerationIDs(view.GenerationOrder)
 	}
 	if view != nil && len(view.GenerationOrder) > 0 {

--- a/TreeDB/db/leaf_generation_runtime.go
+++ b/TreeDB/db/leaf_generation_runtime.go
@@ -51,9 +51,6 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 		return nil
 	}
 	view := newLeafGenerationView(db.leafGenerationManifest)
-	if view != nil && db.snapshotAcquireInFlight() == 0 {
-		db.leafGenerationPins.pruneInactiveGenerationIDs(view.GenerationOrder)
-	}
 	if view != nil && len(view.GenerationOrder) > 0 {
 		view.PinRefs = db.leafGenerationPins.refsForGenerationIDs(view.GenerationOrder)
 	}

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -49,6 +49,7 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.vlogManager = nil
 	s.vlogPinned = false
 	s.leafGenerationIDs = s.leafGenerationIDs[:0]
+	s.leafGenerationRefs = s.leafGenerationRefs[:0]
 	s.reader = valueReader{}
 	s.registryID = 0
 	s.closed.Store(false)

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -49,6 +49,7 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.vlogManager = nil
 	s.vlogPinned = false
 	s.leafGenerationIDs = s.leafGenerationIDs[:0]
+	clear(s.leafGenerationRefs)
 	s.leafGenerationRefs = s.leafGenerationRefs[:0]
 	s.reader = valueReader{}
 	s.registryID = 0

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -49,7 +49,9 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.vlogManager = nil
 	s.vlogPinned = false
 	s.leafGenerationIDs = s.leafGenerationIDs[:0]
-	clear(s.leafGenerationRefs)
+	if cap(s.leafGenerationRefs) > 0 {
+		clear(s.leafGenerationRefs[:cap(s.leafGenerationRefs)])
+	}
 	s.leafGenerationRefs = s.leafGenerationRefs[:0]
 	s.reader = valueReader{}
 	s.registryID = 0

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -219,3 +219,55 @@ func TestLeafGenerationPinTracker_PrunesInactiveZeroCountRefs(t *testing.T) {
 		t.Fatalf("expected inactive zero-count ref for generation 3 to be pruned")
 	}
 }
+
+func TestCurrentLeafGenerationView_SkipsPruneDuringInFlightSnapshotAcquire(t *testing.T) {
+	db := &DB{}
+	db.leafGenerationManifest = &leafGenerationManifest{
+		CurrentGenerationID: 1,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateWritable, FileIDs: []uint32{111}},
+		},
+	}
+
+	staleRefs := db.leafGenerationPins.refsForGenerationIDs([]uint64{7})
+	if len(staleRefs) != 1 {
+		t.Fatalf("expected one stale ref, got %d", len(staleRefs))
+	}
+	db.snapshotAcquireRO[0].Store(1)
+	view := db.currentLeafGenerationView()
+	db.snapshotAcquireRO[0].Store(0)
+	if view == nil {
+		t.Fatal("expected leaf generation view")
+	}
+
+	db.leafGenerationPins.mu.RLock()
+	_, stillTracked := db.leafGenerationPins.refs[7]
+	db.leafGenerationPins.mu.RUnlock()
+	if !stillTracked {
+		t.Fatalf("expected stale ref to remain tracked while snapshot acquisition is in flight")
+	}
+
+	db.currentLeafGenerationView()
+
+	db.leafGenerationPins.mu.RLock()
+	_, stillTracked = db.leafGenerationPins.refs[7]
+	db.leafGenerationPins.mu.RUnlock()
+	if stillTracked {
+		t.Fatalf("expected stale ref to be pruned once snapshot acquisition is quiescent")
+	}
+}
+
+func TestSnapshotPool_PutClearsLeafGenerationRefs(t *testing.T) {
+	pool := NewSnapshotPool()
+	snap := pool.Get()
+	snap.leafGenerationRefs = append(snap.leafGenerationRefs, &leafGenerationPinRef{id: 1})
+	pool.Put(snap)
+
+	reused := pool.Get()
+	if len(reused.leafGenerationRefs) != 0 {
+		t.Fatalf("expected pooled snapshot refs slice to be reset, got len=%d", len(reused.leafGenerationRefs))
+	}
+	if cap(reused.leafGenerationRefs) > 0 && reused.leafGenerationRefs[:1][0] != nil {
+		t.Fatalf("expected pooled snapshot refs backing array to be cleared")
+	}
+}

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -220,7 +220,7 @@ func TestLeafGenerationPinTracker_PrunesInactiveZeroCountRefs(t *testing.T) {
 	}
 }
 
-func TestCurrentLeafGenerationView_SkipsPruneDuringInFlightSnapshotAcquire(t *testing.T) {
+func TestCurrentLeafGenerationView_DoesNotPruneTrackedRefs(t *testing.T) {
 	db := &DB{}
 	db.leafGenerationManifest = &leafGenerationManifest{
 		CurrentGenerationID: 1,
@@ -233,9 +233,7 @@ func TestCurrentLeafGenerationView_SkipsPruneDuringInFlightSnapshotAcquire(t *te
 	if len(staleRefs) != 1 {
 		t.Fatalf("expected one stale ref, got %d", len(staleRefs))
 	}
-	db.snapshotAcquireRO[0].Store(1)
 	view := db.currentLeafGenerationView()
-	db.snapshotAcquireRO[0].Store(0)
 	if view == nil {
 		t.Fatal("expected leaf generation view")
 	}
@@ -244,11 +242,36 @@ func TestCurrentLeafGenerationView_SkipsPruneDuringInFlightSnapshotAcquire(t *te
 	_, stillTracked := db.leafGenerationPins.refs[7]
 	db.leafGenerationPins.mu.RUnlock()
 	if !stillTracked {
+		t.Fatalf("expected currentLeafGenerationView not to prune tracked refs")
+	}
+}
+
+func TestPublishSnapshotView_SkipsPruneDuringInFlightSnapshotAcquire(t *testing.T) {
+	db := &DB{}
+	idx := &indexGen{}
+	state := &DBState{
+		LeafGenerations: &leafGenerationView{
+			CurrentGenerationID: 1,
+			GenerationOrder:     []uint64{1},
+		},
+	}
+
+	staleRefs := db.leafGenerationPins.refsForGenerationIDs([]uint64{7})
+	if len(staleRefs) != 1 {
+		t.Fatalf("expected one stale ref, got %d", len(staleRefs))
+	}
+
+	db.snapshotAcquireRO[0].Store(1)
+	db.publishSnapshotView(idx, state, nil)
+	db.leafGenerationPins.mu.RLock()
+	_, stillTracked := db.leafGenerationPins.refs[7]
+	db.leafGenerationPins.mu.RUnlock()
+	if !stillTracked {
 		t.Fatalf("expected stale ref to remain tracked while snapshot acquisition is in flight")
 	}
 
-	db.currentLeafGenerationView()
-
+	db.snapshotAcquireRO[0].Store(0)
+	db.publishSnapshotView(idx, state, nil)
 	db.leafGenerationPins.mu.RLock()
 	_, stillTracked = db.leafGenerationPins.refs[7]
 	db.leafGenerationPins.mu.RUnlock()

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -271,3 +271,16 @@ func TestSnapshotPool_PutClearsLeafGenerationRefs(t *testing.T) {
 		t.Fatalf("expected pooled snapshot refs backing array to be cleared")
 	}
 }
+
+func TestSnapshotReleaseLeafGenerationPins_ClearsRefBackingArray(t *testing.T) {
+	snap := &Snapshot{}
+	snap.leafGenerationRefs = append(snap.leafGenerationRefs, &leafGenerationPinRef{id: 1})
+	snap.releaseLeafGenerationPins()
+
+	if len(snap.leafGenerationRefs) != 0 {
+		t.Fatalf("expected leafGenerationRefs len=0 after release, got %d", len(snap.leafGenerationRefs))
+	}
+	if cap(snap.leafGenerationRefs) > 0 && snap.leafGenerationRefs[:1][0] != nil {
+		t.Fatalf("expected leafGenerationRefs backing array to be cleared on release")
+	}
+}

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -197,3 +197,25 @@ func TestAcquireSnapshot_DoesNotLeakLeafGenerationPinsOnRegistryNil(t *testing.T
 		t.Fatalf("pin count for generation 1=%d, want 0", got)
 	}
 }
+
+func TestLeafGenerationPinTracker_PrunesInactiveZeroCountRefs(t *testing.T) {
+	var tracker leafGenerationPinTracker
+
+	refs := tracker.refsForGenerationIDs([]uint64{1, 2, 3})
+	tracker.pinRefs(refs)
+	tracker.unpinRefs(refs)
+	tracker.pruneInactiveGenerationIDs([]uint64{1})
+
+	tracker.mu.RLock()
+	defer tracker.mu.RUnlock()
+
+	if _, ok := tracker.refs[1]; !ok {
+		t.Fatalf("expected active generation ref to be retained")
+	}
+	if _, ok := tracker.refs[2]; ok {
+		t.Fatalf("expected inactive zero-count ref for generation 2 to be pruned")
+	}
+	if _, ok := tracker.refs[3]; ok {
+		t.Fatalf("expected inactive zero-count ref for generation 3 to be pruned")
+	}
+}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2581,7 +2581,7 @@ func newRewriteWriter(walDir string, lane, startSeq uint32, maxSize int64) *rewr
 	return &rewriteWriter{walDir: walDir, lane: lane, seq: startSeq, maxSize: maxSize}
 }
 
-const rewriteLeafLogLaneID uint32 = 255
+const rewriteLeafLogLaneID uint32 = valuelog.ReservedLeafLogLaneID
 
 func (w *rewriteWriter) ConfigureLeafLog(leafDir string, lane, startSeq uint32) {
 	if w == nil {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1261,7 +1261,7 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 			prev.remapMu.Lock()
 			prev.currentWritable.Store(false)
 			if data, _ := prev.mmapData.Load().([]byte); len(data) > 0 {
-				if m.allowDemotedCurrentMmapLocked(prev) {
+				if m.allowDemotedCurrentMmapLocked(prev, fileID) {
 					prev.sealedLazyMmapDenied.Store(false)
 					prev.sealedLazyMmapDeniedCountCap.Store(0)
 					prev.sealedLazyMmapDeniedBytesCap.Store(0)
@@ -1762,7 +1762,7 @@ func (m *Manager) allowSealedLazyMmapLocked(target *File, targetSize int64) (boo
 	return true, sealedLazyMmapDenyNone
 }
 
-func (m *Manager) allowDemotedCurrentMmapLocked(target *File) bool {
+func (m *Manager) allowDemotedCurrentMmapLocked(target *File, nextCurrentID uint32) bool {
 	if m == nil || target == nil {
 		return false
 	}
@@ -1779,7 +1779,7 @@ func (m *Manager) allowDemotedCurrentMmapLocked(target *File) bool {
 	mappedSealed := 0
 	var mappedSealedBytes uint64
 	for _, f := range m.files {
-		if f == nil || f.currentWritable.Load() {
+		if f == nil || f.ID == nextCurrentID || f.currentWritable.Load() {
 			continue
 		}
 		if isLeafLogFileID(f.ID) != targetIsLeaf {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1259,7 +1259,16 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 	if prevID, ok := m.currentWritableByLane[lane]; ok && prevID != 0 && prevID != fileID {
 		if prev := m.files[prevID]; prev != nil {
 			prev.currentWritable.Store(false)
-			prev.retirePersistentMmapToDead()
+			if data, _ := prev.mmapData.Load().([]byte); len(data) > 0 {
+				targetSize := prev.sealedLazyMmapTargetSize()
+				if allow, _ := m.allowSealedLazyMmapLocked(prev, targetSize); allow {
+					prev.sealedLazyMmapDenied.Store(false)
+					prev.sealedLazyMmapDeniedCountCap.Store(0)
+					prev.sealedLazyMmapDeniedBytesCap.Store(0)
+				} else {
+					prev.retirePersistentMmapToDead()
+				}
+			}
 		}
 	}
 	f.currentWritable.Store(true)

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1258,17 +1258,18 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 	}
 	if prevID, ok := m.currentWritableByLane[lane]; ok && prevID != 0 && prevID != fileID {
 		if prev := m.files[prevID]; prev != nil {
+			prev.remapMu.Lock()
 			prev.currentWritable.Store(false)
 			if data, _ := prev.mmapData.Load().([]byte); len(data) > 0 {
-				targetSize := prev.sealedLazyMmapTargetSize()
-				if allow, _ := m.allowSealedLazyMmapLocked(prev, targetSize); allow {
+				if m.allowDemotedCurrentMmapLocked(prev) {
 					prev.sealedLazyMmapDenied.Store(false)
 					prev.sealedLazyMmapDeniedCountCap.Store(0)
 					prev.sealedLazyMmapDeniedBytesCap.Store(0)
 				} else {
-					prev.retirePersistentMmapToDead()
+					prev.retirePersistentMmapToDeadLocked()
 				}
 			}
+			prev.remapMu.Unlock()
 		}
 	}
 	f.currentWritable.Store(true)
@@ -1759,6 +1760,45 @@ func (m *Manager) allowSealedLazyMmapLocked(target *File, targetSize int64) (boo
 		}
 	}
 	return true, sealedLazyMmapDenyNone
+}
+
+func (m *Manager) allowDemotedCurrentMmapLocked(target *File) bool {
+	if m == nil || target == nil {
+		return false
+	}
+	targetIsLeaf := isLeafLogFileID(target.ID)
+	maxSegments := MaxMappedSealedSegments
+	maxBytes := MaxMappedSealedBytes
+	if targetIsLeaf {
+		maxSegments = MaxMappedLeafSealedSegments
+		maxBytes = MaxMappedLeafSealedBytes
+	}
+	if maxSegments <= 0 {
+		return false
+	}
+	mappedSealed := 0
+	var mappedSealedBytes uint64
+	for _, f := range m.files {
+		if f == nil || f.currentWritable.Load() {
+			continue
+		}
+		if isLeafLogFileID(f.ID) != targetIsLeaf {
+			continue
+		}
+		data, _ := f.mmapData.Load().([]byte)
+		if len(data) == 0 {
+			continue
+		}
+		mappedSealed++
+		mappedSealedBytes += uint64(len(data))
+	}
+	if mappedSealed > maxSegments {
+		return false
+	}
+	if maxBytes > 0 && mappedSealedBytes > uint64(maxBytes) {
+		return false
+	}
+	return true
 }
 
 func (m *Manager) MmapReadStats() (hits uint64, missesOutOfRange uint64, missesNoMapping uint64, missesDeadMappingCap uint64, fallbacksReadAt uint64) {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1685,7 +1685,14 @@ func (m *Manager) allowSealedLazyMmapLocked(target *File, targetSize int64) (boo
 	if m == nil || target == nil {
 		return false, sealedLazyMmapDenyCountCap
 	}
-	if MaxMappedSealedSegments <= 0 {
+	targetIsLeaf := isLeafLogFileID(target.ID)
+	maxSegments := MaxMappedSealedSegments
+	maxBytes := MaxMappedSealedBytes
+	if targetIsLeaf {
+		maxSegments = MaxMappedLeafSealedSegments
+		maxBytes = MaxMappedLeafSealedBytes
+	}
+	if maxSegments <= 0 {
 		return false, sealedLazyMmapDenyCountCap
 	}
 	if target.currentWritable.Load() {
@@ -1699,16 +1706,19 @@ func (m *Manager) allowSealedLazyMmapLocked(target *File, targetSize int64) (boo
 		if f == nil || f.currentWritable.Load() {
 			continue
 		}
+		if isLeafLogFileID(f.ID) != targetIsLeaf {
+			continue
+		}
 		data, _ := f.mmapData.Load().([]byte)
 		if len(data) > 0 {
 			mappedSealed++
 			mappedSealedBytes += uint64(len(data))
-			if !targetMapped && mappedSealed >= MaxMappedSealedSegments {
+			if !targetMapped && mappedSealed >= maxSegments {
 				return false, sealedLazyMmapDenyCountCap
 			}
 		}
 	}
-	if MaxMappedSealedBytes > 0 {
+	if maxBytes > 0 {
 		targetBytes := uint64(targetSize)
 		if targetBytes == 0 {
 			if known := target.fileSize.Load(); known > 0 {
@@ -1721,7 +1731,7 @@ func (m *Manager) allowSealedLazyMmapLocked(target *File, targetSize int64) (boo
 			}
 		}
 		if targetBytes > 0 {
-			limit := uint64(MaxMappedSealedBytes)
+			limit := uint64(maxBytes)
 			if targetMapped {
 				currentBytes := uint64(len(targetData))
 				if targetBytes > currentBytes {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1259,6 +1259,7 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 	if prevID, ok := m.currentWritableByLane[lane]; ok && prevID != 0 && prevID != fileID {
 		if prev := m.files[prevID]; prev != nil {
 			prev.currentWritable.Store(false)
+			prev.retirePersistentMmapToDead()
 		}
 	}
 	f.currentWritable.Store(true)

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -621,6 +621,68 @@ func TestReadUnsafe_LeafLaneUsesLeafSealedMmapByteBudget(t *testing.T) {
 	}
 }
 
+func TestReadUnsafe_LeafLaneDenyCacheRechecksWhenLeafBudgetChanges(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	withMappedSealedBudget(t, 8)
+	withMappedSealedBytesBudget(t, 1<<30)
+	withMappedLeafSealedBudget(t, 8)
+	withMappedLeafSealedBytesBudget(t, 1)
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+
+	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile(f1): %v", err)
+	}
+	defer func() { _ = f1.Close() }()
+
+	f2, err := openFile(filepath.Join(dir, "value-l255-000002.log"), id2, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile(f2): %v", err)
+	}
+	defer func() { _ = f2.Close() }()
+
+	mgr := &Manager{
+		files:                 map[uint32]*File{id1: f1, id2: f2},
+		currentWritableByLane: make(map[uint32]uint32),
+	}
+	f1.manager = mgr
+	f2.manager = mgr
+
+	set := mgr.CurrentSetNoRefresh()
+	defer func() { _ = mgr.Release(set) }()
+
+	if got, err := set.ReadUnsafe(ptr1); err != nil {
+		t.Fatalf("ReadUnsafe(ptr1): %v", err)
+	} else if !bytes.Equal(got, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ptr1 mismatch")
+	}
+	if _, err := set.ReadUnsafe(ptr2); err != nil {
+		t.Fatalf("ReadUnsafe(ptr2 first): %v", err)
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) != 0 {
+		t.Fatalf("expected initial leaf-lane read to stay unmapped under tight leaf budget")
+	}
+	if got := f2.sealedMapDeniedByBytes.Load(); got == 0 {
+		t.Fatalf("expected leaf-lane byte-cap deny to increment")
+	}
+
+	MaxMappedLeafSealedBytes = 1 << 30
+
+	if got, err := set.ReadUnsafe(ptr2); err != nil {
+		t.Fatalf("ReadUnsafe(ptr2 second): %v", err)
+	} else if !bytes.Equal(got, bytes.Repeat([]byte("b"), 64)) {
+		t.Fatalf("ptr2 second mismatch")
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected leaf-lane deny cache to re-check after leaf budget change")
+	}
+}
+
 func TestReadUnsafe_SealedMappedOutOfRangeRemapsToKnownFileSize(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -445,6 +445,48 @@ func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallbac
 	}
 }
 
+func TestFileRemapToFileSizePersistentOnly_SkipsDemotedLeafSegment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	dir := t.TempDir()
+	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
+	path := filepath.Join(dir, "value-l255-000001.log")
+
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	if _, err := w.Append(0, nil, 1, bytes.Repeat([]byte("leaf"), 64)); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	f, err := openFile(path, fileID, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	mgr := &Manager{
+		files:                 map[uint32]*File{fileID: f},
+		currentWritableByLane: make(map[uint32]uint32),
+	}
+	f.manager = mgr
+	f.currentWritable.Store(true)
+	f.currentWritable.Store(false)
+
+	f.remapToFileSizePersistentOnly()
+
+	if data, _ := f.mmapData.Load().([]byte); len(data) != 0 {
+		t.Fatalf("expected demoted leaf segment to skip persistent-only remap, len=%d", len(data))
+	}
+}
+
 func TestFileRead_CountsDeadMappingCapFallback(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := EncodeFileID(0, 1)

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -537,6 +537,95 @@ func TestManagerPromoteCurrentWritable_KeepsLeafCurrentMmapWhenSealedBudgetAllow
 	}
 }
 
+func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlreadyFull(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	var files []*File
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMappedLeafSealedBudget(t, 1)
+	withMappedLeafSealedBytesBudget(t, 1<<20)
+	t.Cleanup(func() {
+		waitForRemapIdle(t, files...)
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+	id3, _ := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 3, 3, bytes.Repeat([]byte("c"), 64))
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	path1 := filepath.Join(dir, "value-l255-000001.log")
+	path2 := filepath.Join(dir, "value-l255-000002.log")
+	path3 := filepath.Join(dir, "value-l255-000003.log")
+	if err := mgr.RegisterSegment(path1, id1); err != nil {
+		t.Fatalf("RegisterSegment(path1): %v", err)
+	}
+	if err := mgr.RegisterSegment(path2, id2); err != nil {
+		t.Fatalf("RegisterSegment(path2): %v", err)
+	}
+	if err := mgr.RegisterSegment(path3, id3); err != nil {
+		t.Fatalf("RegisterSegment(path3): %v", err)
+	}
+
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr1); err != nil {
+		t.Fatalf("ReadUnsafe(ptr1 current): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(id2); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr2); err != nil {
+		t.Fatalf("ReadUnsafe(ptr2 current): %v", err)
+	}
+
+	f1 := mgr.files[id1]
+	f2 := mgr.files[id2]
+	f3 := mgr.files[id3]
+	files = []*File{f1, f2, f3}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected first sealed leaf segment to remain mapped while within budget")
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected second current leaf segment to be mapped before demotion")
+	}
+
+	if err := mgr.PromoteCurrentWritable(id3); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id3): %v", err)
+	}
+	if f2.currentWritable.Load() {
+		t.Fatalf("expected second segment to be sealed after promotion")
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) != 0 {
+		t.Fatalf("expected demoted second segment to retire active mmap once sealed budget is full, len=%d", len(data))
+	}
+	if dead := f2.deadMappingsCount.Load(); dead == 0 {
+		t.Fatalf("expected demoted second segment to move prior current mmap into deadMappings")
+	}
+	currentSegs, _, sealedSegs, _, deadMappings, _ := mgr.MmapResidencyStats()
+	if currentSegs != 0 {
+		t.Fatalf("expected new current segment to remain unmapped before any read, currentSegs=%d", currentSegs)
+	}
+	if sealedSegs != 1 {
+		t.Fatalf("expected sealed mmap count to stay capped at one, sealedSegs=%d", sealedSegs)
+	}
+	if deadMappings == 0 {
+		t.Fatalf("expected deadMappings to record the retired second segment")
+	}
+}
+
 func TestFileRemapToFileSizePersistentOnly_SkipsDemotedLeafSegment(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -56,7 +56,19 @@ func waitForRemapIdle(t *testing.T, files ...*File) {
 	for {
 		allIdle := true
 		for _, f := range files {
-			if f != nil && f.remapRequested.Load() {
+			if f == nil {
+				continue
+			}
+			if f.remapRequested.Load() {
+				allIdle = false
+				break
+			}
+			if !f.remapMu.TryLock() {
+				allIdle = false
+				break
+			}
+			f.remapMu.Unlock()
+			if f.remapRequested.Load() {
 				allIdle = false
 				break
 			}
@@ -67,8 +79,17 @@ func waitForRemapIdle(t *testing.T, files ...*File) {
 		if time.Now().After(deadline) {
 			t.Fatalf("timed out waiting for remap goroutine to drain")
 		}
-		time.Sleep(1 * time.Millisecond)
+		runtime.Gosched()
 	}
+}
+
+func withMaxDeadMappings(t *testing.T, max int) {
+	t.Helper()
+	prev := MaxDeadMappings
+	MaxDeadMappings = max
+	t.Cleanup(func() {
+		MaxDeadMappings = prev
+	})
 }
 
 func TestManagerMmapReadStatsAggregatesCounters(t *testing.T) {
@@ -306,7 +327,7 @@ func TestManagerReadUnsafe_CurrentWritableLeafUsesPersistentMmapByDefault(t *tes
 
 	dir := t.TempDir()
 	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
-	path := filepath.Join(dir, "value-l255-000001.log")
+	path := segmentPathForID(dir, fileID)
 
 	w, err := NewWriter(path, fileID)
 	if err != nil {
@@ -392,8 +413,8 @@ func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallbac
 	}
 	defer func() { _ = mgr.Close() }()
 
-	path1 := filepath.Join(dir, "value-l255-000001.log")
-	path2 := filepath.Join(dir, "value-l255-000002.log")
+	path1 := segmentPathForID(dir, id1)
+	path2 := segmentPathForID(dir, id2)
 	if err := mgr.RegisterSegment(path1, id1); err != nil {
 		t.Fatalf("RegisterSegment(path1): %v", err)
 	}
@@ -472,8 +493,8 @@ func TestManagerPromoteCurrentWritable_KeepsLeafCurrentMmapWhenSealedBudgetAllow
 	}
 	defer func() { _ = mgr.Close() }()
 
-	path1 := filepath.Join(dir, "value-l255-000001.log")
-	path2 := filepath.Join(dir, "value-l255-000002.log")
+	path1 := segmentPathForID(dir, id1)
+	path2 := segmentPathForID(dir, id2)
 	if err := mgr.RegisterSegment(path1, id1); err != nil {
 		t.Fatalf("RegisterSegment(path1): %v", err)
 	}
@@ -537,6 +558,74 @@ func TestManagerPromoteCurrentWritable_KeepsLeafCurrentMmapWhenSealedBudgetAllow
 	}
 }
 
+func TestManagerPromoteCurrentWritable_ExcludesNextCurrentFromSealedBudget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	var files []*File
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMappedLeafSealedBudget(t, 1)
+	withMappedLeafSealedBytesBudget(t, 1<<20)
+	t.Cleanup(func() {
+		waitForRemapIdle(t, files...)
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	if err := mgr.RegisterSegment(segmentPathForID(dir, id1), id1); err != nil {
+		t.Fatalf("RegisterSegment(id1): %v", err)
+	}
+	if err := mgr.RegisterSegment(segmentPathForID(dir, id2), id2); err != nil {
+		t.Fatalf("RegisterSegment(id2): %v", err)
+	}
+
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1 first): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr1); err != nil {
+		t.Fatalf("ReadUnsafe(ptr1): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(id2); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr2); err != nil {
+		t.Fatalf("ReadUnsafe(ptr2): %v", err)
+	}
+
+	f1 := mgr.files[id1]
+	f2 := mgr.files[id2]
+	files = []*File{f1, f2}
+
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1 second): %v", err)
+	}
+	if !f1.currentWritable.Load() {
+		t.Fatalf("expected id1 to become current again")
+	}
+	if f2.currentWritable.Load() {
+		t.Fatalf("expected id2 to be sealed after re-promotion")
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected demoted id2 mapping to stay active when the next current file is excluded from sealed budgeting")
+	}
+	if dead := f2.deadMappingsCount.Load(); dead != 0 {
+		t.Fatalf("expected no dead mapping duplication when re-promoting a mapped leaf segment, got=%d", dead)
+	}
+}
+
 func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlreadyFull(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")
@@ -565,9 +654,9 @@ func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlready
 	}
 	defer func() { _ = mgr.Close() }()
 
-	path1 := filepath.Join(dir, "value-l255-000001.log")
-	path2 := filepath.Join(dir, "value-l255-000002.log")
-	path3 := filepath.Join(dir, "value-l255-000003.log")
+	path1 := segmentPathForID(dir, id1)
+	path2 := segmentPathForID(dir, id2)
+	path3 := segmentPathForID(dir, id3)
 	if err := mgr.RegisterSegment(path1, id1); err != nil {
 		t.Fatalf("RegisterSegment(path1): %v", err)
 	}
@@ -626,6 +715,77 @@ func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlready
 	}
 }
 
+func TestManagerPromoteCurrentWritable_DeadMappingCapKeepsDemotedLeafMapped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	var files []*File
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMappedLeafSealedBudget(t, 1)
+	withMappedLeafSealedBytesBudget(t, 1<<20)
+	withMaxDeadMappings(t, 1)
+	t.Cleanup(func() {
+		waitForRemapIdle(t, files...)
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+	id3, _ := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 3, 3, bytes.Repeat([]byte("c"), 64))
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	for _, id := range []uint32{id1, id2, id3} {
+		if err := mgr.RegisterSegment(segmentPathForID(dir, id), id); err != nil {
+			t.Fatalf("RegisterSegment(%d): %v", id, err)
+		}
+	}
+
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr1); err != nil {
+		t.Fatalf("ReadUnsafe(ptr1): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(id2); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr2); err != nil {
+		t.Fatalf("ReadUnsafe(ptr2): %v", err)
+	}
+
+	f1 := mgr.files[id1]
+	f2 := mgr.files[id2]
+	f3 := mgr.files[id3]
+	files = []*File{f1, f2, f3}
+	var deadBefore uint64
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected id2 current mapping before saturating dead-mapping cap")
+	} else {
+		deadBefore = uint64(effectiveMaxDeadMappings(len(data)))
+		f2.deadMappingsCount.Store(deadBefore)
+	}
+
+	if err := mgr.PromoteCurrentWritable(id3); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id3): %v", err)
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected demoted id2 mapping to stay live once dead-mapping cap is exhausted")
+	}
+	if dead := f2.deadMappingsCount.Load(); dead != deadBefore {
+		t.Fatalf("expected demoted id2 to avoid growing dead mappings when cap is exhausted, before=%d after=%d", deadBefore, dead)
+	}
+}
+
 func TestFileRemapToFileSizePersistentOnly_SkipsDemotedLeafSegment(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")
@@ -633,7 +793,7 @@ func TestFileRemapToFileSizePersistentOnly_SkipsDemotedLeafSegment(t *testing.T)
 
 	dir := t.TempDir()
 	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
-	path := filepath.Join(dir, "value-l255-000001.log")
+	path := segmentPathForID(dir, fileID)
 
 	w, err := NewWriter(path, fileID)
 	if err != nil {

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -570,13 +570,13 @@ func TestReadUnsafe_LeafLaneUsesLeafSealedMmapByteBudget(t *testing.T) {
 	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
 	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
 
-	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
+	f1, err := openFile(segmentPathForID(dir, id1), id1, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
 		t.Fatalf("openFile(f1): %v", err)
 	}
 	defer func() { _ = f1.Close() }()
 
-	f2, err := openFile(filepath.Join(dir, "value-l255-000002.log"), id2, nil, nil, templ.DecodeOptions{}, nil)
+	f2, err := openFile(segmentPathForID(dir, id2), id2, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
 		t.Fatalf("openFile(f2): %v", err)
 	}
@@ -634,13 +634,13 @@ func TestReadUnsafe_LeafLaneDenyCacheRechecksWhenLeafBudgetChanges(t *testing.T)
 	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
 	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
 
-	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
+	f1, err := openFile(segmentPathForID(dir, id1), id1, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
 		t.Fatalf("openFile(f1): %v", err)
 	}
 	defer func() { _ = f1.Close() }()
 
-	f2, err := openFile(filepath.Join(dir, "value-l255-000002.log"), id2, nil, nil, templ.DecodeOptions{}, nil)
+	f2, err := openFile(segmentPathForID(dir, id2), id2, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
 		t.Fatalf("openFile(f2): %v", err)
 	}
@@ -808,6 +808,10 @@ func writeTestSegment(t *testing.T, dir string, lane, seq uint32, rid uint64, va
 	return fileID
 }
 
+func segmentPathForID(dir string, id uint32) string {
+	return (&Manager{dir: dir}).SegmentPath(id)
+}
+
 func TestManagerCurrentSetNoRefresh(t *testing.T) {
 	dir := t.TempDir()
 	seg1 := writeTestSegment(t, dir, 0, 1, 1, bytes.Repeat([]byte("a"), 64))
@@ -904,7 +908,7 @@ func TestManagerSegmentPath_UsesRegisteredPathFromExtraScanDir(t *testing.T) {
 		t.Fatalf("MkdirAll(leaf_vlog): %v", err)
 	}
 	segID := writeTestSegment(t, leafDir, 255, 1, 1, bytes.Repeat([]byte("l"), 64))
-	wantPath := filepath.Join(leafDir, "value-l255-000001.log")
+	wantPath := segmentPathForID(leafDir, segID)
 
 	mgr, err := NewManager(dir)
 	if err != nil {

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -341,6 +341,82 @@ func TestManagerReadUnsafe_CurrentWritableLeafUsesPersistentMmapByDefault(t *tes
 	}
 }
 
+func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMappedLeafSealedBudget(t, 0)
+	t.Cleanup(func() {
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, _ := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	path1 := filepath.Join(dir, "value-l255-000001.log")
+	path2 := filepath.Join(dir, "value-l255-000002.log")
+	if err := mgr.RegisterSegment(path1, id1); err != nil {
+		t.Fatalf("RegisterSegment(path1): %v", err)
+	}
+	if err := mgr.RegisterSegment(path2, id2); err != nil {
+		t.Fatalf("RegisterSegment(path2): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1): %v", err)
+	}
+	got, err := mgr.ReadUnsafe(ptr1)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr1 current): %v", err)
+	}
+	if !bytes.Equal(got, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ReadUnsafe(ptr1 current) mismatch")
+	}
+
+	f1 := mgr.files[id1]
+	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected current leaf segment to hold active mmap before promotion")
+	}
+
+	if err := mgr.PromoteCurrentWritable(id2); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
+	}
+	if f1.currentWritable.Load() {
+		t.Fatalf("expected prior leaf segment to be sealed after promotion")
+	}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) != 0 {
+		t.Fatalf("expected prior current leaf mmap to be retired after promotion, len=%d", len(data))
+	}
+	if dead := f1.deadMappingsCount.Load(); dead == 0 {
+		t.Fatalf("expected retired current leaf mapping to move into deadMappings")
+	}
+
+	got, err = mgr.ReadUnsafe(ptr1)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr1 sealed): %v", err)
+	}
+	if !bytes.Equal(got, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ReadUnsafe(ptr1 sealed) mismatch")
+	}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) != 0 {
+		t.Fatalf("expected sealed leaf read to respect zero sealed-map budget after promotion")
+	}
+	if got := f1.mmapReadFallbackReadAt.Load(); got == 0 {
+		t.Fatalf("expected sealed leaf read to fall back to ReadAt under zero sealed-map budget")
+	}
+}
+
 func TestFileRead_CountsDeadMappingCapFallback(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := EncodeFileID(0, 1)

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -567,8 +567,8 @@ func TestReadUnsafe_LeafLaneUsesLeafSealedMmapByteBudget(t *testing.T) {
 	withMappedLeafSealedBytesBudget(t, 1<<30)
 
 	dir := t.TempDir()
-	id1, ptr1 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
-	id2, ptr2 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
 
 	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
@@ -631,8 +631,8 @@ func TestReadUnsafe_LeafLaneDenyCacheRechecksWhenLeafBudgetChanges(t *testing.T)
 	withMappedLeafSealedBytesBudget(t, 1)
 
 	dir := t.TempDir()
-	id1, ptr1 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
-	id2, ptr2 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
 
 	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -267,6 +267,80 @@ func TestManagerReadUnsafe_CurrentWritableFallsBackWithoutPersistentMmap(t *test
 	}
 }
 
+func TestManagerReadUnsafe_CurrentWritableLeafUsesPersistentMmapByDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	t.Cleanup(func() {
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
+	path := filepath.Join(dir, "value-l255-000001.log")
+
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	want := bytes.Repeat([]byte("leaf"), 1024)
+	ptr, err := w.Append(0, nil, 1, want)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	if err := mgr.RegisterSegment(path, fileID); err != nil {
+		t.Fatalf("RegisterSegment: %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(fileID); err != nil {
+		t.Fatalf("PromoteCurrentWritable: %v", err)
+	}
+
+	got, err := mgr.ReadUnsafe(ptr)
+	if err != nil {
+		t.Fatalf("ReadUnsafe: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("ReadUnsafe mismatch")
+	}
+
+	f := mgr.files[fileID]
+	data, _ := f.mmapData.Load().([]byte)
+	if len(data) == 0 {
+		t.Fatalf("expected current leaf segment to install persistent mmap")
+	}
+	if remaps := f.remapCount.Load(); remaps == 0 {
+		t.Fatalf("expected current leaf segment remapCount > 0")
+	}
+	currentSegs, currentBytes, sealedSegs, sealedBytes, deadMappings, deadBytes := mgr.MmapResidencyStats()
+	if currentSegs != 1 || currentBytes == 0 {
+		t.Fatalf("expected one mapped current leaf segment, currentSegs=%d currentBytes=%d", currentSegs, currentBytes)
+	}
+	if sealedSegs != 0 || sealedBytes != 0 || deadMappings != 0 || deadBytes != 0 {
+		t.Fatalf("unexpected non-current residency sealedSegs=%d sealedBytes=%d deadMappings=%d deadBytes=%d", sealedSegs, sealedBytes, deadMappings, deadBytes)
+	}
+	hits, _, _, _, fallbacks := mgr.MmapReadStats()
+	if hits == 0 || fallbacks != 0 {
+		t.Fatalf("expected mmap hit without fallback, hits=%d fallbacks=%d", hits, fallbacks)
+	}
+}
+
 func TestFileRead_CountsDeadMappingCapFallback(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := EncodeFileID(0, 1)

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -445,6 +445,98 @@ func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallbac
 	}
 }
 
+func TestManagerPromoteCurrentWritable_KeepsLeafCurrentMmapWhenSealedBudgetAllows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	var files []*File
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMappedLeafSealedBudget(t, 1)
+	withMappedLeafSealedBytesBudget(t, 1<<20)
+	t.Cleanup(func() {
+		waitForRemapIdle(t, files...)
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, _ := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	path1 := filepath.Join(dir, "value-l255-000001.log")
+	path2 := filepath.Join(dir, "value-l255-000002.log")
+	if err := mgr.RegisterSegment(path1, id1); err != nil {
+		t.Fatalf("RegisterSegment(path1): %v", err)
+	}
+	if err := mgr.RegisterSegment(path2, id2); err != nil {
+		t.Fatalf("RegisterSegment(path2): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1): %v", err)
+	}
+	got, err := mgr.ReadUnsafe(ptr1)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr1 current): %v", err)
+	}
+	if !bytes.Equal(got, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ReadUnsafe(ptr1 current) mismatch")
+	}
+
+	f1 := mgr.files[id1]
+	f2 := mgr.files[id2]
+	files = []*File{f1, f2}
+	beforeRemaps := f1.remapCount.Load()
+	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected current leaf segment to hold active mmap before promotion")
+	}
+
+	if err := mgr.PromoteCurrentWritable(id2); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
+	}
+	if f1.currentWritable.Load() {
+		t.Fatalf("expected prior leaf segment to be sealed after promotion")
+	}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected prior current leaf mmap to remain active when sealed budget allows")
+	}
+	if dead := f1.deadMappingsCount.Load(); dead != 0 {
+		t.Fatalf("expected no dead mappings when sealed budget allows, got=%d", dead)
+	}
+
+	got, err = mgr.ReadUnsafe(ptr1)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr1 sealed): %v", err)
+	}
+	if !bytes.Equal(got, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ReadUnsafe(ptr1 sealed) mismatch")
+	}
+	if got := f1.mmapReadFallbackReadAt.Load(); got != 0 {
+		t.Fatalf("expected sealed leaf read to stay on mmap path, fallbacks=%d", got)
+	}
+	if remaps := f1.remapCount.Load(); remaps != beforeRemaps {
+		t.Fatalf("expected no extra remap for recently sealed leaf segment, before=%d after=%d", beforeRemaps, remaps)
+	}
+	currentSegs, currentBytes, sealedSegs, sealedBytes, deadMappings, deadBytes := mgr.MmapResidencyStats()
+	if currentSegs != 0 || currentBytes != 0 {
+		t.Fatalf("expected no mapped current segment before reading the new current file, currentSegs=%d currentBytes=%d", currentSegs, currentBytes)
+	}
+	if sealedSegs != 1 || sealedBytes == 0 {
+		t.Fatalf("expected one mapped sealed segment after promotion, sealedSegs=%d sealedBytes=%d", sealedSegs, sealedBytes)
+	}
+	if deadMappings != 0 || deadBytes != 0 {
+		t.Fatalf("expected no dead mapping duplication, deadMappings=%d deadBytes=%d", deadMappings, deadBytes)
+	}
+}
+
 func TestFileRemapToFileSizePersistentOnly_SkipsDemotedLeafSegment(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/page"
 	templ "github.com/snissn/gomap/TreeDB/template"
@@ -47,6 +48,27 @@ func withMappedLeafSealedBytesBudget(t *testing.T, maxMappedBytes int64) {
 	t.Cleanup(func() {
 		MaxMappedLeafSealedBytes = prev
 	})
+}
+
+func waitForRemapIdle(t *testing.T, files ...*File) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		allIdle := true
+		for _, f := range files {
+			if f != nil && f.remapRequested.Load() {
+				allIdle = false
+				break
+			}
+		}
+		if allIdle {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for remap goroutine to drain")
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
 }
 
 func TestManagerMmapReadStatsAggregatesCounters(t *testing.T) {
@@ -271,11 +293,13 @@ func TestManagerReadUnsafe_CurrentWritableLeafUsesPersistentMmapByDefault(t *tes
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")
 	}
+	var file *File
 	prevCurrent := enableCurrentWritableMmap
 	prevLeaf := enableCurrentLeafWritableMmap
 	enableCurrentWritableMmap = false
 	enableCurrentLeafWritableMmap = true
 	t.Cleanup(func() {
+		waitForRemapIdle(t, file)
 		enableCurrentWritableMmap = prevCurrent
 		enableCurrentLeafWritableMmap = prevLeaf
 	})
@@ -321,6 +345,7 @@ func TestManagerReadUnsafe_CurrentWritableLeafUsesPersistentMmapByDefault(t *tes
 	}
 
 	f := mgr.files[fileID]
+	file = f
 	data, _ := f.mmapData.Load().([]byte)
 	if len(data) == 0 {
 		t.Fatalf("expected current leaf segment to install persistent mmap")
@@ -345,12 +370,14 @@ func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallbac
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")
 	}
+	var files []*File
 	prevCurrent := enableCurrentWritableMmap
 	prevLeaf := enableCurrentLeafWritableMmap
 	enableCurrentWritableMmap = false
 	enableCurrentLeafWritableMmap = true
 	withMappedLeafSealedBudget(t, 0)
 	t.Cleanup(func() {
+		waitForRemapIdle(t, files...)
 		enableCurrentWritableMmap = prevCurrent
 		enableCurrentLeafWritableMmap = prevLeaf
 	})
@@ -385,6 +412,7 @@ func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallbac
 	}
 
 	f1 := mgr.files[id1]
+	files = []*File{f1, mgr.files[id2]}
 	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
 		t.Fatalf("expected current leaf segment to hold active mmap before promotion")
 	}

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -31,6 +31,24 @@ func withMappedSealedBytesBudget(t *testing.T, maxMappedBytes int64) {
 	})
 }
 
+func withMappedLeafSealedBudget(t *testing.T, maxMapped int) {
+	t.Helper()
+	prev := MaxMappedLeafSealedSegments
+	MaxMappedLeafSealedSegments = maxMapped
+	t.Cleanup(func() {
+		MaxMappedLeafSealedSegments = prev
+	})
+}
+
+func withMappedLeafSealedBytesBudget(t *testing.T, maxMappedBytes int64) {
+	t.Helper()
+	prev := MaxMappedLeafSealedBytes
+	MaxMappedLeafSealedBytes = maxMappedBytes
+	t.Cleanup(func() {
+		MaxMappedLeafSealedBytes = prev
+	})
+}
+
 func TestManagerMmapReadStatsAggregatesCounters(t *testing.T) {
 	mgr := &Manager{
 		files: map[uint32]*File{
@@ -536,6 +554,70 @@ func TestReadUnsafe_SealedLazyMmapByteBudgetFallsBackToReadAt(t *testing.T) {
 	}
 	if byCount, byBytes := mgr.SealedMapDeniedByReasonStats(); byCount != 0 || byBytes == 0 {
 		t.Fatalf("expected byte-cap deny aggregation, got count=%d bytes=%d", byCount, byBytes)
+	}
+}
+
+func TestReadUnsafe_LeafLaneUsesLeafSealedMmapByteBudget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	withMappedSealedBudget(t, 8)
+	withMappedSealedBytesBudget(t, 1)
+	withMappedLeafSealedBudget(t, 8)
+	withMappedLeafSealedBytesBudget(t, 1<<30)
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+
+	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile(f1): %v", err)
+	}
+	defer func() { _ = f1.Close() }()
+
+	f2, err := openFile(filepath.Join(dir, "value-l255-000002.log"), id2, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile(f2): %v", err)
+	}
+	defer func() { _ = f2.Close() }()
+
+	mgr := &Manager{
+		files:                 map[uint32]*File{id1: f1, id2: f2},
+		currentWritableByLane: make(map[uint32]uint32),
+	}
+	f1.manager = mgr
+	f2.manager = mgr
+
+	set := mgr.CurrentSetNoRefresh()
+	defer func() { _ = mgr.Release(set) }()
+
+	got1, err := set.ReadUnsafe(ptr1)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr1): %v", err)
+	}
+	if !bytes.Equal(got1, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ptr1 mismatch")
+	}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected first leaf-lane sealed segment to be mapped")
+	}
+
+	got2, err := set.ReadUnsafe(ptr2)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr2): %v", err)
+	}
+	if !bytes.Equal(got2, bytes.Repeat([]byte("b"), 64)) {
+		t.Fatalf("ptr2 mismatch")
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected second leaf-lane sealed segment to be mapped under leaf budget")
+	}
+	if got := f2.mmapReadFallbackReadAt.Load(); got != 0 {
+		t.Fatalf("expected leaf-lane sealed mmap to avoid ReadAt fallback, got=%d", got)
+	}
+	if got := f2.sealedMapDeniedByBytes.Load(); got != 0 {
+		t.Fatalf("expected no leaf-lane byte-cap deny, got=%d", got)
 	}
 }
 

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -48,6 +48,7 @@ const (
 	maxDeadMappingsEnvKey           = "TREEDB_VLOG_MAX_DEAD_MAPPINGS"
 	enableAdaptiveCapEnvKey         = "TREEDB_VLOG_ADAPTIVE_DEAD_MAPPINGS"
 	enableCurrentWritableEnvKey     = "TREEDB_VLOG_ENABLE_CURRENT_WRITABLE_MMAP"
+	enableCurrentLeafWritableEnvKey = "TREEDB_VLOG_ENABLE_CURRENT_LEAF_WRITABLE_MMAP"
 	maxMappedSealedEnvKey           = "TREEDB_VLOG_MAX_MAPPED_SEALED_SEGMENTS"
 	maxMappedSealedBytesEnvKey      = "TREEDB_VLOG_MAX_MAPPED_SEALED_BYTES"
 	maxMappedLeafSealedEnvKey       = "TREEDB_VLOG_MAX_MAPPED_LEAF_SEALED_SEGMENTS"
@@ -60,13 +61,14 @@ const (
 )
 
 var (
-	maxDeadMappingsExplicit     bool
-	adaptiveDeadMappings              = defaultAdaptiveCapEnabled
-	enableCurrentWritableMmap         = false
-	MaxMappedSealedSegments           = defaultMaxMappedSealed
-	MaxMappedSealedBytes        int64 = defaultMaxMappedSealedBytes
-	MaxMappedLeafSealedSegments       = defaultMaxMappedLeafSealed
-	MaxMappedLeafSealedBytes    int64 = defaultMaxMappedLeafSealedBytes
+	maxDeadMappingsExplicit       bool
+	adaptiveDeadMappings                = defaultAdaptiveCapEnabled
+	enableCurrentWritableMmap           = false
+	enableCurrentLeafWritableMmap       = true
+	MaxMappedSealedSegments             = defaultMaxMappedSealed
+	MaxMappedSealedBytes          int64 = defaultMaxMappedSealedBytes
+	MaxMappedLeafSealedSegments         = defaultMaxMappedLeafSealed
+	MaxMappedLeafSealedBytes      int64 = defaultMaxMappedLeafSealedBytes
 )
 
 func init() {
@@ -90,6 +92,14 @@ func init() {
 			enableCurrentWritableMmap = false
 		case "1", "true", "on", "yes":
 			enableCurrentWritableMmap = true
+		}
+	}
+	if raw := strings.TrimSpace(os.Getenv(enableCurrentLeafWritableEnvKey)); raw != "" {
+		switch strings.ToLower(raw) {
+		case "0", "false", "off", "no":
+			enableCurrentLeafWritableMmap = false
+		case "1", "true", "on", "yes":
+			enableCurrentLeafWritableMmap = true
 		}
 	}
 	if raw := strings.TrimSpace(os.Getenv(maxMappedSealedEnvKey)); raw != "" {
@@ -117,6 +127,16 @@ func init() {
 func isLeafLogFileID(fileID uint32) bool {
 	lane, _ := DecodeFileID(fileID)
 	return lane == ReservedLeafLogLaneID
+}
+
+func (f *File) currentWritablePersistentMmapEnabled() bool {
+	if f == nil || !f.currentWritable.Load() {
+		return false
+	}
+	if enableCurrentWritableMmap {
+		return true
+	}
+	return enableCurrentLeafWritableMmap && isLeafLogFileID(f.ID)
 }
 
 func effectiveMaxDeadMappings(mappedLen int) int {
@@ -161,14 +181,14 @@ func (f *File) usesPersistentMmap() bool {
 	if f.manager == nil {
 		return true
 	}
-	return enableCurrentWritableMmap && f.currentWritable.Load()
+	return f.currentWritablePersistentMmapEnabled()
 }
 
 func (f *File) tryEnableSealedLazyMmap() bool {
 	if f == nil || f.closed.Load() || f.File == nil {
 		return false
 	}
-	if f.currentWritable.Load() && !enableCurrentWritableMmap {
+	if f.currentWritable.Load() && !f.currentWritablePersistentMmapEnabled() {
 		return false
 	}
 	if f.usesPersistentMmap() {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -182,10 +182,11 @@ func (f *File) tryEnableSealedLazyMmap() bool {
 		return false
 	}
 	if f.sealedLazyMmapDenied.Load() {
+		deniedCountCapWant, deniedBytesCapWant := f.sealedLazyMmapBudgetSnapshot()
 		deniedCountCap := int(f.sealedLazyMmapDeniedCountCap.Load())
 		deniedBytesCap := f.sealedLazyMmapDeniedBytesCap.Load()
 		// Preserve the cheap deny fast-path while budgets stay unchanged.
-		if deniedCountCap == MaxMappedSealedSegments && deniedBytesCap == MaxMappedSealedBytes {
+		if int64(deniedCountCap) == deniedCountCapWant && deniedBytesCap == deniedBytesCapWant {
 			return false
 		}
 		// Budgets changed; re-check once to allow in-process recovery.
@@ -194,8 +195,7 @@ func (f *File) tryEnableSealedLazyMmap() bool {
 		allow, _ := m.allowSealedLazyMmapLocked(f, targetSize)
 		m.mu.Unlock()
 		if !allow {
-			f.sealedLazyMmapDeniedCountCap.Store(int64(MaxMappedSealedSegments))
-			f.sealedLazyMmapDeniedBytesCap.Store(MaxMappedSealedBytes)
+			f.storeSealedLazyMmapBudgetSnapshot()
 			return false
 		}
 		f.sealedLazyMmapDenied.Store(false)
@@ -212,8 +212,7 @@ func (f *File) tryEnableSealedLazyMmap() bool {
 		m.mu.Unlock()
 		if !allow {
 			f.sealedLazyMmapDenied.Store(true)
-			f.sealedLazyMmapDeniedCountCap.Store(int64(MaxMappedSealedSegments))
-			f.sealedLazyMmapDeniedBytesCap.Store(MaxMappedSealedBytes)
+			f.storeSealedLazyMmapBudgetSnapshot()
 			switch denyReason {
 			case sealedLazyMmapDenyCountCap:
 				f.sealedMapDeniedByCount.Add(1)
@@ -234,8 +233,7 @@ func (f *File) tryEnableSealedLazyMmap() bool {
 	m.mu.Unlock()
 	if !allow {
 		f.sealedLazyMmapDenied.Store(true)
-		f.sealedLazyMmapDeniedCountCap.Store(int64(MaxMappedSealedSegments))
-		f.sealedLazyMmapDeniedBytesCap.Store(MaxMappedSealedBytes)
+		f.storeSealedLazyMmapBudgetSnapshot()
 		switch denyReason {
 		case sealedLazyMmapDenyCountCap:
 			f.sealedMapDeniedByCount.Add(1)
@@ -252,6 +250,19 @@ func (f *File) tryEnableSealedLazyMmap() bool {
 	f.remapToFileSize()
 	data, _ := f.mmapData.Load().([]byte)
 	return len(data) > 0
+}
+
+func (f *File) sealedLazyMmapBudgetSnapshot() (countCap int64, bytesCap int64) {
+	if f != nil && isLeafLogFileID(f.ID) {
+		return int64(MaxMappedLeafSealedSegments), MaxMappedLeafSealedBytes
+	}
+	return int64(MaxMappedSealedSegments), MaxMappedSealedBytes
+}
+
+func (f *File) storeSealedLazyMmapBudgetSnapshot() {
+	countCap, bytesCap := f.sealedLazyMmapBudgetSnapshot()
+	f.sealedLazyMmapDeniedCountCap.Store(countCap)
+	f.sealedLazyMmapDeniedBytesCap.Store(bytesCap)
 }
 
 func (f *File) sealedLazyMmapTargetSize() int64 {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -335,10 +335,7 @@ func (f *File) maybeScheduleRemap() {
 	}
 	go func() {
 		defer f.remapRequested.Store(false)
-		if !f.usesPersistentMmap() {
-			return
-		}
-		f.remapToFileSize()
+		f.remapToFileSizePersistentOnly()
 	}()
 }
 
@@ -366,7 +363,15 @@ func (f *File) tryRefreshMmapRange(start, end int64) ([]byte, bool) {
 	return data, true
 }
 
+func (f *File) remapToFileSizePersistentOnly() {
+	f.remapToFileSizeWithPolicy(true)
+}
+
 func (f *File) remapToFileSize() {
+	f.remapToFileSizeWithPolicy(false)
+}
+
+func (f *File) remapToFileSizeWithPolicy(requirePersistent bool) {
 	if f == nil || f.closed.Load() || f.File == nil {
 		return
 	}
@@ -374,6 +379,9 @@ func (f *File) remapToFileSize() {
 	f.remapMu.Lock()
 	defer f.remapMu.Unlock()
 	if f.closed.Load() || f.File == nil {
+		return
+	}
+	if requirePersistent && !f.usesPersistentMmap() {
 		return
 	}
 	// If we have already hit the dead-mapping cap, we cannot remap again without

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -42,25 +42,32 @@ const readViaMmapViewPrefixCacheEnabled = false
 var MaxDeadMappings = defaultMaxDeadMappings
 
 const (
-	defaultMaxDeadMappings      = 64
-	maxAdaptiveDeadMappings     = 4096
-	deadMappingBytesPerStep     = 256 << 10 // increase cap by 1 per 256KiB mapped
-	maxDeadMappingsEnvKey       = "TREEDB_VLOG_MAX_DEAD_MAPPINGS"
-	enableAdaptiveCapEnvKey     = "TREEDB_VLOG_ADAPTIVE_DEAD_MAPPINGS"
-	enableCurrentWritableEnvKey = "TREEDB_VLOG_ENABLE_CURRENT_WRITABLE_MMAP"
-	maxMappedSealedEnvKey       = "TREEDB_VLOG_MAX_MAPPED_SEALED_SEGMENTS"
-	maxMappedSealedBytesEnvKey  = "TREEDB_VLOG_MAX_MAPPED_SEALED_BYTES"
-	defaultAdaptiveCapEnabled   = true
-	defaultMaxMappedSealed      = 8
-	defaultMaxMappedSealedBytes = 64 << 20
+	defaultMaxDeadMappings          = 64
+	maxAdaptiveDeadMappings         = 4096
+	deadMappingBytesPerStep         = 256 << 10 // increase cap by 1 per 256KiB mapped
+	maxDeadMappingsEnvKey           = "TREEDB_VLOG_MAX_DEAD_MAPPINGS"
+	enableAdaptiveCapEnvKey         = "TREEDB_VLOG_ADAPTIVE_DEAD_MAPPINGS"
+	enableCurrentWritableEnvKey     = "TREEDB_VLOG_ENABLE_CURRENT_WRITABLE_MMAP"
+	maxMappedSealedEnvKey           = "TREEDB_VLOG_MAX_MAPPED_SEALED_SEGMENTS"
+	maxMappedSealedBytesEnvKey      = "TREEDB_VLOG_MAX_MAPPED_SEALED_BYTES"
+	maxMappedLeafSealedEnvKey       = "TREEDB_VLOG_MAX_MAPPED_LEAF_SEALED_SEGMENTS"
+	maxMappedLeafBytesEnvKey        = "TREEDB_VLOG_MAX_MAPPED_LEAF_SEALED_BYTES"
+	defaultAdaptiveCapEnabled       = true
+	defaultMaxMappedSealed          = 8
+	defaultMaxMappedSealedBytes     = 64 << 20
+	defaultMaxMappedLeafSealed      = 64
+	defaultMaxMappedLeafSealedBytes = 1 << 30
+	reservedLeafLogLaneID           = 255
 )
 
 var (
-	maxDeadMappingsExplicit   bool
-	adaptiveDeadMappings            = defaultAdaptiveCapEnabled
-	enableCurrentWritableMmap       = false
-	MaxMappedSealedSegments         = defaultMaxMappedSealed
-	MaxMappedSealedBytes      int64 = defaultMaxMappedSealedBytes
+	maxDeadMappingsExplicit     bool
+	adaptiveDeadMappings              = defaultAdaptiveCapEnabled
+	enableCurrentWritableMmap         = false
+	MaxMappedSealedSegments           = defaultMaxMappedSealed
+	MaxMappedSealedBytes        int64 = defaultMaxMappedSealedBytes
+	MaxMappedLeafSealedSegments       = defaultMaxMappedLeafSealed
+	MaxMappedLeafSealedBytes    int64 = defaultMaxMappedLeafSealedBytes
 )
 
 func init() {
@@ -96,6 +103,21 @@ func init() {
 			MaxMappedSealedBytes = v
 		}
 	}
+	if raw := strings.TrimSpace(os.Getenv(maxMappedLeafSealedEnvKey)); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
+			MaxMappedLeafSealedSegments = v
+		}
+	}
+	if raw := strings.TrimSpace(os.Getenv(maxMappedLeafBytesEnvKey)); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v >= 0 {
+			MaxMappedLeafSealedBytes = v
+		}
+	}
+}
+
+func isLeafLogFileID(fileID uint32) bool {
+	lane, _ := DecodeFileID(fileID)
+	return lane == reservedLeafLogLaneID
 }
 
 func effectiveMaxDeadMappings(mappedLen int) int {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -300,6 +300,23 @@ func (f *File) sealedLazyMmapTargetSize() int64 {
 	return targetSize
 }
 
+func (f *File) retirePersistentMmapToDead() {
+	if f == nil {
+		return
+	}
+	f.remapMu.Lock()
+	defer f.remapMu.Unlock()
+
+	data, _ := f.mmapData.Load().([]byte)
+	if len(data) == 0 {
+		return
+	}
+	f.deadMappings = append(f.deadMappings, data)
+	f.deadMappingsCount.Add(1)
+	f.deadMappedBytes.Add(uint64(len(data)))
+	f.mmapData.Store([]byte(nil))
+}
+
 func (f *File) maybeScheduleRemap() {
 	if f == nil || f.closed.Load() || !f.usesPersistentMmap() {
 		return
@@ -318,6 +335,9 @@ func (f *File) maybeScheduleRemap() {
 	}
 	go func() {
 		defer f.remapRequested.Store(false)
+		if !f.usesPersistentMmap() {
+			return
+		}
 		f.remapToFileSize()
 	}()
 }

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -55,9 +55,8 @@ const (
 	defaultAdaptiveCapEnabled       = true
 	defaultMaxMappedSealed          = 8
 	defaultMaxMappedSealedBytes     = 64 << 20
-	defaultMaxMappedLeafSealed      = 64
-	defaultMaxMappedLeafSealedBytes = 1 << 30
-	reservedLeafLogLaneID           = 255
+	defaultMaxMappedLeafSealed      = defaultMaxMappedSealed * 4
+	defaultMaxMappedLeafSealedBytes = defaultMaxMappedSealedBytes * 4
 )
 
 var (
@@ -117,7 +116,7 @@ func init() {
 
 func isLeafLogFileID(fileID uint32) bool {
 	lane, _ := DecodeFileID(fileID)
-	return lane == reservedLeafLogLaneID
+	return lane == ReservedLeafLogLaneID
 }
 
 func effectiveMaxDeadMappings(mappedLen int) int {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -309,18 +309,25 @@ func (f *File) retirePersistentMmapToDead() {
 	f.retirePersistentMmapToDeadLocked()
 }
 
-func (f *File) retirePersistentMmapToDeadLocked() {
+func (f *File) retirePersistentMmapToDeadLocked() bool {
 	if f == nil {
-		return
+		return false
 	}
 	data, _ := f.mmapData.Load().([]byte)
 	if len(data) == 0 {
-		return
+		return false
+	}
+	if deadMappingsCapExhausted(f.deadMappingsCount.Load(), len(data)) {
+		// Keep the existing mapping live as a sealed mapping once the dead-mapping
+		// budget is exhausted. That preserves reader safety without allowing the
+		// dead-mapping list to grow without bound.
+		return false
 	}
 	f.deadMappings = append(f.deadMappings, data)
 	f.deadMappingsCount.Add(1)
 	f.deadMappedBytes.Add(uint64(len(data)))
 	f.mmapData.Store([]byte(nil))
+	return true
 }
 
 func (f *File) maybeScheduleRemap() {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -306,7 +306,13 @@ func (f *File) retirePersistentMmapToDead() {
 	}
 	f.remapMu.Lock()
 	defer f.remapMu.Unlock()
+	f.retirePersistentMmapToDeadLocked()
+}
 
+func (f *File) retirePersistentMmapToDeadLocked() {
+	if f == nil {
+		return
+	}
 	data, _ := f.mmapData.Load().([]byte)
 	if len(data) == 0 {
 		return

--- a/TreeDB/internal/valuelog/segment_id.go
+++ b/TreeDB/internal/valuelog/segment_id.go
@@ -12,6 +12,8 @@ const (
 
 	maxLaneID     = (1 << laneBits) - 1
 	maxSegmentSeq = (1 << seqBits) - 1
+	// ReservedLeafLogLaneID is the dedicated lane used for outer-leaf storage.
+	ReservedLeafLogLaneID = maxLaneID
 )
 
 var ErrSegmentIDRange = errors.New("valuelog: segment id out of range")

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -205,10 +205,10 @@ type BenchRun struct {
 }
 
 type treeDBPerfMetrics struct {
-	Mmap                  treeDBMmapPerfMetrics     `json:"mmap,omitempty"`
-	Snapshot              treeDBSnapshotPerfMetrics `json:"snapshot,omitempty"`
-	LeafGenerationsPinned int64                     `json:"leaf_generations_pinned,omitempty"`
-	LeafPinsTotal         int64                     `json:"leaf_pins_total,omitempty"`
+	Mmap                       treeDBMmapPerfMetrics     `json:"mmap,omitempty"`
+	Snapshot                   treeDBSnapshotPerfMetrics `json:"snapshot,omitempty"`
+	LeafGenerationsPinnedAfter int64                     `json:"leaf_generations_pinned_after,omitempty"`
+	LeafPinsTotalAfter         int64                     `json:"leaf_pins_total_after,omitempty"`
 }
 
 type treeDBMmapPerfMetrics struct {
@@ -245,11 +245,10 @@ type benchprofExport struct {
 }
 
 type benchprofExportRun struct {
-	Keys        int                                     `json:"keys"`
-	Profile     string                                  `json:"profile,omitempty"`
-	Results     map[string]map[string]float64           `json:"results,omitempty"`
-	TreeDBPerf  map[string]map[string]treeDBPerfMetrics `json:"treedb_perf,omitempty"`
-	TreeDBStats map[string]map[string]string            `json:"treedb_stats,omitempty"`
+	Keys       int                                     `json:"keys"`
+	Profile    string                                  `json:"profile,omitempty"`
+	Results    map[string]map[string]float64           `json:"results,omitempty"`
+	TreeDBPerf map[string]map[string]treeDBPerfMetrics `json:"treedb_perf,omitempty"`
 }
 
 type scanDiag struct {
@@ -1054,11 +1053,10 @@ func writeBenchprofArtifacts(dir string, runs []BenchRun) error {
 	}
 	for _, run := range runs {
 		out.Runs = append(out.Runs, benchprofExportRun{
-			Keys:        run.Config.Keys,
-			Profile:     strings.TrimSpace(run.Config.Profile),
-			Results:     run.Results,
-			TreeDBPerf:  run.TreeDBPerf,
-			TreeDBStats: run.TreeDBStats,
+			Keys:       run.Config.Keys,
+			Profile:    strings.TrimSpace(run.Config.Profile),
+			Results:    run.Results,
+			TreeDBPerf: run.TreeDBPerf,
 		})
 	}
 
@@ -1754,15 +1752,15 @@ func snapshotSelectedTreeDBStats(db kvstore.DB) treeDBSelectedStats {
 func computeTreeDBPerfMetrics(before, after treeDBSelectedStats, snapshot treeDBSnapshotPerfMetrics) treeDBPerfMetrics {
 	m := treeDBPerfMetrics{
 		Mmap: treeDBMmapPerfMetrics{
-			Hits:           after.mmapHits - before.mmapHits,
-			MissOutOfRange: after.mmapMissOutOfRange - before.mmapMissOutOfRange,
-			MissNoMapping:  after.mmapMissNoMapping - before.mmapMissNoMapping,
-			MissDeadMapCap: after.mmapMissDeadCap - before.mmapMissDeadCap,
-			FallbackReadAt: after.mmapFallbackReadAt - before.mmapFallbackReadAt,
+			Hits:           saturatingUint64Delta(after.mmapHits, before.mmapHits),
+			MissOutOfRange: saturatingUint64Delta(after.mmapMissOutOfRange, before.mmapMissOutOfRange),
+			MissNoMapping:  saturatingUint64Delta(after.mmapMissNoMapping, before.mmapMissNoMapping),
+			MissDeadMapCap: saturatingUint64Delta(after.mmapMissDeadCap, before.mmapMissDeadCap),
+			FallbackReadAt: saturatingUint64Delta(after.mmapFallbackReadAt, before.mmapFallbackReadAt),
 		},
-		Snapshot:              snapshot,
-		LeafGenerationsPinned: after.leafGenerationsPin,
-		LeafPinsTotal:         after.leafPinsTotal,
+		Snapshot:                   snapshot,
+		LeafGenerationsPinnedAfter: after.leafGenerationsPin,
+		LeafPinsTotalAfter:         after.leafPinsTotal,
 	}
 	totalReads := m.Mmap.Hits + m.Mmap.FallbackReadAt
 	if totalReads > 0 {
@@ -1777,6 +1775,13 @@ func computeTreeDBPerfMetrics(before, after treeDBSelectedStats, snapshot treeDB
 	return m
 }
 
+func saturatingUint64Delta(after, before uint64) uint64 {
+	if after < before {
+		return 0
+	}
+	return after - before
+}
+
 func treeDBPerfMetricsEmpty(m treeDBPerfMetrics) bool {
 	return m.Mmap.Hits == 0 &&
 		m.Mmap.MissOutOfRange == 0 &&
@@ -1788,8 +1793,8 @@ func treeDBPerfMetricsEmpty(m treeDBPerfMetrics) bool {
 		m.Snapshot.AcquireTotalNanos == 0 &&
 		m.Snapshot.CloseCalls == 0 &&
 		m.Snapshot.CloseTotalNanos == 0 &&
-		m.LeafGenerationsPinned == 0 &&
-		m.LeafPinsTotal == 0
+		m.LeafGenerationsPinnedAfter == 0 &&
+		m.LeafPinsTotalAfter == 0
 }
 
 func (p *periodicCheckpoint) Add(db kvstore.DB, opsDelta int, bytesDelta int64) error {
@@ -4725,8 +4730,8 @@ func renderTreeDBPerfString(instances []*DBInstance, finalTestOrder []string, di
 				))
 			}
 			sb.WriteString(fmt.Sprintf("  leaf_generation.generations.pinned.after=%d leaf_generation.pins.total.after=%d\n",
-				m.LeafGenerationsPinned,
-				m.LeafPinsTotal,
+				m.LeafGenerationsPinnedAfter,
+				m.LeafPinsTotalAfter,
 			))
 		}
 		if wroteHeader {

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -199,8 +199,44 @@ type BenchRun struct {
 	VacuumIndexBytes    map[string]map[string][2]uint64 // [0]=before, [1]=after (best-effort; treedb only)
 	TreeDBDiskUsage     map[string]treeDBDiskUsage
 	TreeDBVlogRewrite   map[string]treeDBVlogRewriteReport
+	TreeDBPerf          map[string]map[string]treeDBPerfMetrics
 	TreeDBStats         map[string]map[string]string
 	DiskUsage           map[string]dirDiskUsage
+}
+
+type treeDBPerfMetrics struct {
+	Mmap                  treeDBMmapPerfMetrics     `json:"mmap,omitempty"`
+	Snapshot              treeDBSnapshotPerfMetrics `json:"snapshot,omitempty"`
+	LeafGenerationsPinned int64                     `json:"leaf_generations_pinned,omitempty"`
+	LeafPinsTotal         int64                     `json:"leaf_pins_total,omitempty"`
+}
+
+type treeDBMmapPerfMetrics struct {
+	Hits           uint64  `json:"hits,omitempty"`
+	MissOutOfRange uint64  `json:"miss_out_of_range,omitempty"`
+	MissNoMapping  uint64  `json:"miss_no_mapping,omitempty"`
+	MissDeadMapCap uint64  `json:"miss_dead_mapping_cap,omitempty"`
+	FallbackReadAt uint64  `json:"fallback_readat,omitempty"`
+	HitRatio       float64 `json:"hit_ratio,omitempty"`
+}
+
+type treeDBSnapshotPerfMetrics struct {
+	AcquireCalls      uint64  `json:"acquire_calls,omitempty"`
+	AcquireTotalNanos uint64  `json:"acquire_total_nanos,omitempty"`
+	AcquireAvgMicros  float64 `json:"acquire_avg_micros,omitempty"`
+	CloseCalls        uint64  `json:"close_calls,omitempty"`
+	CloseTotalNanos   uint64  `json:"close_total_nanos,omitempty"`
+	CloseAvgMicros    float64 `json:"close_avg_micros,omitempty"`
+}
+
+type treeDBSelectedStats struct {
+	mmapHits           uint64
+	mmapMissOutOfRange uint64
+	mmapMissNoMapping  uint64
+	mmapMissDeadCap    uint64
+	mmapFallbackReadAt uint64
+	leafGenerationsPin int64
+	leafPinsTotal      int64
 }
 
 type benchprofExport struct {
@@ -209,9 +245,11 @@ type benchprofExport struct {
 }
 
 type benchprofExportRun struct {
-	Keys    int                           `json:"keys"`
-	Profile string                        `json:"profile,omitempty"`
-	Results map[string]map[string]float64 `json:"results,omitempty"`
+	Keys        int                                     `json:"keys"`
+	Profile     string                                  `json:"profile,omitempty"`
+	Results     map[string]map[string]float64           `json:"results,omitempty"`
+	TreeDBPerf  map[string]map[string]treeDBPerfMetrics `json:"treedb_perf,omitempty"`
+	TreeDBStats map[string]map[string]string            `json:"treedb_stats,omitempty"`
 }
 
 type scanDiag struct {
@@ -1016,9 +1054,11 @@ func writeBenchprofArtifacts(dir string, runs []BenchRun) error {
 	}
 	for _, run := range runs {
 		out.Runs = append(out.Runs, benchprofExportRun{
-			Keys:    run.Config.Keys,
-			Profile: strings.TrimSpace(run.Config.Profile),
-			Results: run.Results,
+			Keys:        run.Config.Keys,
+			Profile:     strings.TrimSpace(run.Config.Profile),
+			Results:     run.Results,
+			TreeDBPerf:  run.TreeDBPerf,
+			TreeDBStats: run.TreeDBStats,
 		})
 	}
 
@@ -1645,6 +1685,113 @@ func newPeriodicCheckpoint(cfg BenchConfig) *periodicCheckpoint {
 	}
 }
 
+func parseUint64StatValue(stats map[string]string, keys ...string) (uint64, bool) {
+	if stats == nil {
+		return 0, false
+	}
+	for _, key := range keys {
+		raw, ok := stats[key]
+		if !ok {
+			continue
+		}
+		v, err := strconv.ParseUint(strings.TrimSpace(raw), 10, 64)
+		if err == nil {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func parseInt64StatValue(stats map[string]string, keys ...string) (int64, bool) {
+	if stats == nil {
+		return 0, false
+	}
+	for _, key := range keys {
+		raw, ok := stats[key]
+		if !ok {
+			continue
+		}
+		v, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+		if err == nil {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func snapshotSelectedTreeDBStats(db kvstore.DB) treeDBSelectedStats {
+	sp, ok := db.(kvstore.StatsProvider)
+	if !ok {
+		return treeDBSelectedStats{}
+	}
+	stats := sp.Stats()
+	var snap treeDBSelectedStats
+	snap.mmapHits, _ = parseUint64StatValue(stats,
+		"treedb.cache.vlog_mmap.read.hits",
+		"treedb.vlog.mmap_read.hits",
+	)
+	snap.mmapMissOutOfRange, _ = parseUint64StatValue(stats,
+		"treedb.cache.vlog_mmap.read.miss_out_of_range",
+		"treedb.vlog.mmap_read.miss_out_of_range",
+	)
+	snap.mmapMissNoMapping, _ = parseUint64StatValue(stats,
+		"treedb.cache.vlog_mmap.read.miss_no_mapping",
+		"treedb.vlog.mmap_read.miss_no_mapping",
+	)
+	snap.mmapMissDeadCap, _ = parseUint64StatValue(stats,
+		"treedb.cache.vlog_mmap.read.miss_dead_mapping_cap",
+		"treedb.vlog.mmap_read.miss_dead_mapping_cap",
+	)
+	snap.mmapFallbackReadAt, _ = parseUint64StatValue(stats,
+		"treedb.cache.vlog_mmap.read.fallback_readat",
+		"treedb.vlog.mmap_read.fallback_readat",
+	)
+	snap.leafGenerationsPin, _ = parseInt64StatValue(stats, "treedb.leaf_generation.generations.pinned")
+	snap.leafPinsTotal, _ = parseInt64StatValue(stats, "treedb.leaf_generation.pins.total")
+	return snap
+}
+
+func computeTreeDBPerfMetrics(before, after treeDBSelectedStats, snapshot treeDBSnapshotPerfMetrics) treeDBPerfMetrics {
+	m := treeDBPerfMetrics{
+		Mmap: treeDBMmapPerfMetrics{
+			Hits:           after.mmapHits - before.mmapHits,
+			MissOutOfRange: after.mmapMissOutOfRange - before.mmapMissOutOfRange,
+			MissNoMapping:  after.mmapMissNoMapping - before.mmapMissNoMapping,
+			MissDeadMapCap: after.mmapMissDeadCap - before.mmapMissDeadCap,
+			FallbackReadAt: after.mmapFallbackReadAt - before.mmapFallbackReadAt,
+		},
+		Snapshot:              snapshot,
+		LeafGenerationsPinned: after.leafGenerationsPin,
+		LeafPinsTotal:         after.leafPinsTotal,
+	}
+	totalReads := m.Mmap.Hits + m.Mmap.FallbackReadAt
+	if totalReads > 0 {
+		m.Mmap.HitRatio = float64(m.Mmap.Hits) / float64(totalReads)
+	}
+	if m.Snapshot.AcquireCalls > 0 {
+		m.Snapshot.AcquireAvgMicros = float64(m.Snapshot.AcquireTotalNanos) / float64(m.Snapshot.AcquireCalls) / 1_000.0
+	}
+	if m.Snapshot.CloseCalls > 0 {
+		m.Snapshot.CloseAvgMicros = float64(m.Snapshot.CloseTotalNanos) / float64(m.Snapshot.CloseCalls) / 1_000.0
+	}
+	return m
+}
+
+func treeDBPerfMetricsEmpty(m treeDBPerfMetrics) bool {
+	return m.Mmap.Hits == 0 &&
+		m.Mmap.MissOutOfRange == 0 &&
+		m.Mmap.MissNoMapping == 0 &&
+		m.Mmap.MissDeadMapCap == 0 &&
+		m.Mmap.FallbackReadAt == 0 &&
+		m.Mmap.HitRatio == 0 &&
+		m.Snapshot.AcquireCalls == 0 &&
+		m.Snapshot.AcquireTotalNanos == 0 &&
+		m.Snapshot.CloseCalls == 0 &&
+		m.Snapshot.CloseTotalNanos == 0 &&
+		m.LeafGenerationsPinned == 0 &&
+		m.LeafPinsTotal == 0
+}
+
 func (p *periodicCheckpoint) Add(db kvstore.DB, opsDelta int, bytesDelta int64) error {
 	if p == nil {
 		return nil
@@ -1747,6 +1894,8 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	checkpointDurations := make(map[string]map[string]time.Duration)
 	vacuumDurations := make(map[string]map[string]time.Duration)
 	vacuumIndexBytes := make(map[string]map[string][2]uint64)
+	treeDBPerf := make(map[string]map[string]treeDBPerfMetrics)
+	snapshotPerfByTest := make(map[string]map[string]treeDBSnapshotPerfMetrics)
 
 	// dataset_write_* mirrors op-geth's Write1M when -keys=1_000_000 and -valsize=32 (32B keys).
 	datasetKeySize := 32
@@ -2122,6 +2271,20 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			}
 		}
 		return float64(total) / time.Since(start).Seconds(), nil
+	}
+	recordSnapshotPerf := func(testName string, db kvstore.DB, perf treeDBSnapshotPerfMetrics) {
+		if db == nil {
+			return
+		}
+		if perf.AcquireCalls == 0 && perf.CloseCalls == 0 {
+			return
+		}
+		perDB := snapshotPerfByTest[testName]
+		if perDB == nil {
+			perDB = make(map[string]treeDBSnapshotPerfMetrics)
+			snapshotPerfByTest[testName] = perDB
+		}
+		perDB[db.Name()] = perf
 	}
 	testFuncs := map[string]TestFunc{
 		"vacuum_index": func(db kvstore.DB, _ *rand.Rand) (float64, error) {
@@ -2806,6 +2969,10 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				GetAppend(key, dst []byte) ([]byte, error)
 			})
 			baseSeed := testSeed(cfg.SeedUsed, "random_read_parallel")
+			var snapshotAcquireCalls atomic.Uint64
+			var snapshotAcquireNanos atomic.Uint64
+			var snapshotCloseCalls atomic.Uint64
+			var snapshotCloseNanos atomic.Uint64
 
 			runWorker := func(workerRng *rand.Rand, stop *atomic.Bool) error {
 				getter := interface {
@@ -2814,14 +2981,23 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				workerAppendGetter := appendGetter
 				var closeSnapshot func() error
 				if hasSnapshotter {
+					acquireStarted := time.Now()
 					snap, err := snapshotter.AcquireReadSnapshot()
 					if err != nil && !errors.Is(err, kvstore.ErrUnsupported) {
 						return err
 					}
 					if err == nil {
+						snapshotAcquireCalls.Add(1)
+						snapshotAcquireNanos.Add(uint64(time.Since(acquireStarted)))
 						getter = snap
 						workerAppendGetter = snap
-						closeSnapshot = snap.Close
+						closeSnapshot = func() error {
+							closeStarted := time.Now()
+							err := snap.Close()
+							snapshotCloseCalls.Add(1)
+							snapshotCloseNanos.Add(uint64(time.Since(closeStarted)))
+							return err
+						}
 					} else if !hasAppendGetter {
 						workerAppendGetter = nil
 					}
@@ -2874,6 +3050,12 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if err := runWorker(rng, nil); err != nil {
 					return 0, fmt.Errorf("random_read_parallel: %w", err)
 				}
+				recordSnapshotPerf("random_read_parallel", db, treeDBSnapshotPerfMetrics{
+					AcquireCalls:      snapshotAcquireCalls.Load(),
+					AcquireTotalNanos: snapshotAcquireNanos.Load(),
+					CloseCalls:        snapshotCloseCalls.Load(),
+					CloseTotalNanos:   snapshotCloseNanos.Load(),
+				})
 				return float64(cfg.Keys) / time.Since(start).Seconds(), nil
 			}
 
@@ -2903,6 +3085,12 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				return 0, fmt.Errorf("random_read_parallel: %w", err)
 			default:
 			}
+			recordSnapshotPerf("random_read_parallel", db, treeDBSnapshotPerfMetrics{
+				AcquireCalls:      snapshotAcquireCalls.Load(),
+				AcquireTotalNanos: snapshotAcquireNanos.Load(),
+				CloseCalls:        snapshotCloseCalls.Load(),
+				CloseTotalNanos:   snapshotCloseNanos.Load(),
+			})
 			totalOps := float64(cfg.Keys) * float64(workers)
 			return totalOps / time.Since(start).Seconds(), nil
 		},
@@ -2933,6 +3121,10 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				return 0, fmt.Errorf("random_read_parallel_acquire_snapshot probe close: %w", err)
 			}
 			baseSeed := testSeed(cfg.SeedUsed, "random_read_parallel_acquire_snapshot")
+			var snapshotAcquireCalls atomic.Uint64
+			var snapshotAcquireNanos atomic.Uint64
+			var snapshotCloseCalls atomic.Uint64
+			var snapshotCloseNanos atomic.Uint64
 
 			runWorker := func(workerRng *rand.Rand, stop *atomic.Bool) error {
 				var k [8]byte
@@ -2948,12 +3140,18 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					}
 					encodeKey(k[:], uint64(workerRng.Intn(cfg.Keys)))
 
+					acquireStarted := time.Now()
 					snap, err := snapshotter.AcquireReadSnapshot()
 					if err != nil {
 						return err
 					}
+					snapshotAcquireCalls.Add(1)
+					snapshotAcquireNanos.Add(uint64(time.Since(acquireStarted)))
 					nextBuf, getErr := snap.GetAppend(k[:], buf[:0])
+					closeStarted := time.Now()
 					closeErr := snap.Close()
+					snapshotCloseCalls.Add(1)
+					snapshotCloseNanos.Add(uint64(time.Since(closeStarted)))
 					if closeErr != nil {
 						return fmt.Errorf("random_read_parallel_acquire_snapshot close: %w", closeErr)
 					}
@@ -2981,6 +3179,12 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if err := runWorker(rng, nil); err != nil {
 					return 0, fmt.Errorf("random_read_parallel_acquire_snapshot: %w", err)
 				}
+				recordSnapshotPerf("random_read_parallel_acquire_snapshot", db, treeDBSnapshotPerfMetrics{
+					AcquireCalls:      snapshotAcquireCalls.Load(),
+					AcquireTotalNanos: snapshotAcquireNanos.Load(),
+					CloseCalls:        snapshotCloseCalls.Load(),
+					CloseTotalNanos:   snapshotCloseNanos.Load(),
+				})
 				return float64(cfg.Keys) / time.Since(start).Seconds(), nil
 			}
 
@@ -3010,6 +3214,12 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				return 0, fmt.Errorf("random_read_parallel_acquire_snapshot: %w", err)
 			default:
 			}
+			recordSnapshotPerf("random_read_parallel_acquire_snapshot", db, treeDBSnapshotPerfMetrics{
+				AcquireCalls:      snapshotAcquireCalls.Load(),
+				AcquireTotalNanos: snapshotAcquireNanos.Load(),
+				CloseCalls:        snapshotCloseCalls.Load(),
+				CloseTotalNanos:   snapshotCloseNanos.Load(),
+			})
 			totalOps := float64(cfg.Keys) * float64(workers)
 			return totalOps / time.Since(start).Seconds(), nil
 		},
@@ -3645,6 +3855,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				return BenchRun{}, err
 			}
 
+			var treeStatsBefore treeDBSelectedStats
+			if isTreeDBInstance(inst) {
+				treeStatsBefore = snapshotSelectedTreeDBStats(inst.Wrapper)
+			}
+
 			// Create a fresh PRNG for each DB so they get the same sequence
 			rng := rand.New(rand.NewSource(seed))
 
@@ -3793,6 +4008,20 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				return BenchRun{}, fmt.Errorf("test %s on %s: %w", testName, inst.Name, runErr)
 			}
 
+			if isTreeDBInstance(inst) {
+				treeStatsAfter := snapshotSelectedTreeDBStats(inst.Wrapper)
+				snapshotPerf := snapshotPerfByTest[testName][inst.Wrapper.Name()]
+				metrics := computeTreeDBPerfMetrics(treeStatsBefore, treeStatsAfter, snapshotPerf)
+				if !treeDBPerfMetricsEmpty(metrics) {
+					perDB := treeDBPerf[testName]
+					if perDB == nil {
+						perDB = make(map[string]treeDBPerfMetrics)
+						treeDBPerf[testName] = perDB
+					}
+					perDB[inst.Wrapper.Name()] = metrics
+				}
+			}
+
 			results[testName][inst.Wrapper.Name()] = opsPerSec
 
 			// Update live table cell
@@ -3922,6 +4151,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		VacuumIndexBytes:    vacuumIndexBytes,
 		TreeDBDiskUsage:     treedbDisk,
 		TreeDBVlogRewrite:   treedbRewrite,
+		TreeDBPerf:          treeDBPerf,
 		TreeDBStats:         treedbStats,
 		DiskUsage:           diskUsage,
 	}, nil
@@ -4413,6 +4643,20 @@ func renderMarkdownSingle(run BenchRun) string {
 		sb.WriteString(renderTreeDBVlogRewriteString(run.TreeDBVlogRewrite))
 		sb.WriteString("```\n")
 	}
+	if perf := strings.TrimSpace(renderTreeDBPerfString(run.Instances, run.TestOrder, run.DisplayNames, run.TreeDBPerf)); perf != "" {
+		sb.WriteString("\n")
+		sb.WriteString("## TreeDB Perf Instrumentation\n\n")
+		sb.WriteString("```text\n")
+		sb.WriteString(perf)
+		sb.WriteString("\n```\n")
+	}
+	if stats := strings.TrimSpace(renderTreeDBSelectedStatsString(run.Instances, run.TreeDBStats)); stats != "" {
+		sb.WriteString("\n")
+		sb.WriteString("## TreeDB Selected Stats (End of Run)\n\n")
+		sb.WriteString("```text\n")
+		sb.WriteString(stats)
+		sb.WriteString("\n```\n")
+	}
 	if run.Config.KeepDir {
 		if kept := strings.TrimSpace(renderKeptDirsString(run.Instances)); kept != "" {
 			sb.WriteString("\n")
@@ -4423,6 +4667,118 @@ func renderMarkdownSingle(run BenchRun) string {
 		}
 	}
 	return sb.String()
+}
+
+func renderTreeDBPerfString(instances []*DBInstance, finalTestOrder []string, displayNames map[string]string, perf map[string]map[string]treeDBPerfMetrics) string {
+	if len(perf) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, testName := range finalTestOrder {
+		perDB := perf[testName]
+		if len(perDB) == 0 {
+			continue
+		}
+		label := displayNames[testName]
+		if strings.TrimSpace(label) == "" {
+			label = testName
+		}
+		wroteHeader := false
+		for _, inst := range instances {
+			if inst == nil || inst.Wrapper == nil {
+				continue
+			}
+			dbName := inst.Wrapper.Name()
+			m, ok := perDB[dbName]
+			if !ok || treeDBPerfMetricsEmpty(m) {
+				continue
+			}
+			if wroteHeader {
+				sb.WriteByte('\n')
+			}
+			wroteHeader = true
+			sb.WriteString(label)
+			sb.WriteString(" / ")
+			sb.WriteString(dbName)
+			sb.WriteByte('\n')
+			if m.Snapshot.AcquireCalls > 0 || m.Snapshot.CloseCalls > 0 {
+				sb.WriteString(fmt.Sprintf("  snapshot.acquire.calls=%d total_ms=%.3f avg_us=%.3f\n",
+					m.Snapshot.AcquireCalls,
+					float64(m.Snapshot.AcquireTotalNanos)/1_000_000.0,
+					m.Snapshot.AcquireAvgMicros,
+				))
+				sb.WriteString(fmt.Sprintf("  snapshot.close.calls=%d total_ms=%.3f avg_us=%.3f\n",
+					m.Snapshot.CloseCalls,
+					float64(m.Snapshot.CloseTotalNanos)/1_000_000.0,
+					m.Snapshot.CloseAvgMicros,
+				))
+			}
+			mmapTotal := m.Mmap.Hits + m.Mmap.FallbackReadAt
+			if mmapTotal > 0 || m.Mmap.MissOutOfRange > 0 || m.Mmap.MissNoMapping > 0 || m.Mmap.MissDeadMapCap > 0 {
+				sb.WriteString(fmt.Sprintf("  vlog_mmap.read.hits.delta=%d miss_out_of_range.delta=%d miss_no_mapping.delta=%d miss_dead_mapping_cap.delta=%d fallback_readat.delta=%d hit_ratio.delta=%.6f\n",
+					m.Mmap.Hits,
+					m.Mmap.MissOutOfRange,
+					m.Mmap.MissNoMapping,
+					m.Mmap.MissDeadMapCap,
+					m.Mmap.FallbackReadAt,
+					m.Mmap.HitRatio,
+				))
+			}
+			sb.WriteString(fmt.Sprintf("  leaf_generation.generations.pinned.after=%d leaf_generation.pins.total.after=%d\n",
+				m.LeafGenerationsPinned,
+				m.LeafPinsTotal,
+			))
+		}
+		if wroteHeader {
+			sb.WriteByte('\n')
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func renderTreeDBSelectedStatsString(instances []*DBInstance, treeStats map[string]map[string]string) string {
+	if len(treeStats) == 0 {
+		return ""
+	}
+	keys := []struct {
+		label string
+		alts  []string
+	}{
+		{label: "vlog_mmap.read.hits", alts: []string{"treedb.cache.vlog_mmap.read.hits", "treedb.vlog.mmap_read.hits"}},
+		{label: "vlog_mmap.read.miss_out_of_range", alts: []string{"treedb.cache.vlog_mmap.read.miss_out_of_range", "treedb.vlog.mmap_read.miss_out_of_range"}},
+		{label: "vlog_mmap.read.miss_no_mapping", alts: []string{"treedb.cache.vlog_mmap.read.miss_no_mapping", "treedb.vlog.mmap_read.miss_no_mapping"}},
+		{label: "vlog_mmap.read.miss_dead_mapping_cap", alts: []string{"treedb.cache.vlog_mmap.read.miss_dead_mapping_cap", "treedb.vlog.mmap_read.miss_dead_mapping_cap"}},
+		{label: "vlog_mmap.read.fallback_readat", alts: []string{"treedb.cache.vlog_mmap.read.fallback_readat", "treedb.vlog.mmap_read.fallback_readat"}},
+		{label: "vlog_mmap.read.hit_ratio", alts: []string{"treedb.cache.vlog_mmap.read.hit_ratio", "treedb.vlog.mmap_read.hit_ratio"}},
+		{label: "leaf_generation.generations.pinned", alts: []string{"treedb.leaf_generation.generations.pinned"}},
+		{label: "leaf_generation.pins.total", alts: []string{"treedb.leaf_generation.pins.total"}},
+	}
+	var sb strings.Builder
+	for _, inst := range instances {
+		if inst == nil || inst.Wrapper == nil {
+			continue
+		}
+		dbName := inst.Wrapper.Name()
+		stats := treeStats[dbName]
+		if len(stats) == 0 {
+			continue
+		}
+		sb.WriteString(dbName)
+		sb.WriteString(":\n")
+		for _, key := range keys {
+			for _, alt := range key.alts {
+				if value, ok := stats[alt]; ok {
+					sb.WriteString("  ")
+					sb.WriteString(key.label)
+					sb.WriteString(": ")
+					sb.WriteString(value)
+					sb.WriteByte('\n')
+					break
+				}
+			}
+		}
+	}
+	return strings.TrimSpace(sb.String())
 }
 
 func renderMarkdownSweep(runs []BenchRun) string {

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1197,8 +1197,8 @@ func TestRenderMarkdownSingle_IncludesTreeDBPerfSections(t *testing.T) {
 						CloseTotalNanos:   12_000,
 						CloseAvgMicros:    3,
 					},
-					LeafGenerationsPinned: 1,
-					LeafPinsTotal:         4,
+					LeafGenerationsPinnedAfter: 1,
+					LeafPinsTotalAfter:         4,
 				},
 			},
 		},
@@ -1350,8 +1350,56 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 	if got := parsed.Runs[0].TreeDBPerf["full_scan"]["TreeDB"].Mmap.Hits; got != 10 {
 		t.Fatalf("unexpected TreeDB perf mmap hits: %v", got)
 	}
-	if got := parsed.Runs[0].TreeDBStats["TreeDB"]["treedb.cache.vlog_mmap.read.hits"]; got != "10" {
-		t.Fatalf("unexpected TreeDB stats value: %v", got)
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw json: %v", err)
+	}
+	runsValue, ok := raw["runs"].([]any)
+	if !ok || len(runsValue) != 1 {
+		t.Fatalf("expected 1 raw run in json, got %#v", raw["runs"])
+	}
+	runValue, ok := runsValue[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected raw run object, got %#v", runsValue[0])
+	}
+	if _, ok := runValue["treedb_stats"]; ok {
+		t.Fatalf("expected treedb_stats to be omitted from benchprof json, got: %#v", runValue["treedb_stats"])
+	}
+}
+
+func TestComputeTreeDBPerfMetrics_SaturatesCounterRegression(t *testing.T) {
+	metrics := computeTreeDBPerfMetrics(
+		treeDBSelectedStats{
+			mmapHits:           11,
+			mmapMissOutOfRange: 13,
+			mmapMissNoMapping:  17,
+			mmapMissDeadCap:    19,
+			mmapFallbackReadAt: 23,
+			leafGenerationsPin: 5,
+			leafPinsTotal:      7,
+		},
+		treeDBSelectedStats{
+			mmapHits:           3,
+			mmapMissOutOfRange: 2,
+			mmapMissNoMapping:  1,
+			mmapMissDeadCap:    18,
+			mmapFallbackReadAt: 4,
+			leafGenerationsPin: 2,
+			leafPinsTotal:      9,
+		},
+		treeDBSnapshotPerfMetrics{},
+	)
+	if metrics.Mmap.Hits != 0 || metrics.Mmap.MissOutOfRange != 0 || metrics.Mmap.MissNoMapping != 0 || metrics.Mmap.FallbackReadAt != 0 {
+		t.Fatalf("expected saturating mmap deltas, got %+v", metrics.Mmap)
+	}
+	if metrics.Mmap.MissDeadMapCap != 0 {
+		t.Fatalf("expected saturating dead-map delta, got %d", metrics.Mmap.MissDeadMapCap)
+	}
+	if metrics.LeafGenerationsPinnedAfter != 2 {
+		t.Fatalf("expected after-value leaf generations pinned, got %d", metrics.LeafGenerationsPinnedAfter)
+	}
+	if metrics.LeafPinsTotalAfter != 9 {
+		t.Fatalf("expected after-value leaf pins total, got %d", metrics.LeafPinsTotalAfter)
 	}
 }
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -533,6 +533,45 @@ func TestRunBenchmark_RandomReadParallelAcquireSnapshot_UsesSnapshots(t *testing
 	}
 }
 
+func TestRunBenchmark_TreeDBPerfCapturesSnapshotMetrics(t *testing.T) {
+	run, err := runBenchmark(BenchConfig{
+		Keys:         256,
+		ValueSize:    16,
+		BatchSize:    64,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       "treedb",
+		TestsArg:     "sequential_write,random_read_parallel_acquire_snapshot",
+		KeepDir:      false,
+		Progress:     false,
+		ReadWorkers:  4,
+		SeedUsed:     1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	perTest, ok := run.TreeDBPerf["random_read_parallel_acquire_snapshot"]
+	if !ok {
+		t.Fatalf("expected TreeDB perf entry for snapshot benchmark")
+	}
+	perf, ok := perTest["TreeDB"]
+	if !ok {
+		t.Fatalf("expected TreeDB perf metrics for snapshot benchmark")
+	}
+	if perf.Snapshot.AcquireCalls == 0 {
+		t.Fatalf("expected snapshot acquire calls > 0, got 0")
+	}
+	if perf.Snapshot.CloseCalls == 0 {
+		t.Fatalf("expected snapshot close calls > 0, got 0")
+	}
+	if perf.Snapshot.AcquireTotalNanos == 0 {
+		t.Fatalf("expected snapshot acquire time > 0")
+	}
+	if perf.Snapshot.CloseTotalNanos == 0 {
+		t.Fatalf("expected snapshot close time > 0")
+	}
+}
+
 func TestNormalizeTests_ReadRandomBatchAliases(t *testing.T) {
 	got := normalizeTests(parseList("read_rand_batch,read_random_batch,random_read_batch"))
 	want := []string{"random_read_batch"}
@@ -1122,6 +1161,75 @@ func TestRenderMarkdownSingle_KeepDirIncludesKeptSection(t *testing.T) {
 	}
 }
 
+func TestRenderMarkdownSingle_IncludesTreeDBPerfSections(t *testing.T) {
+	run := BenchRun{
+		Config: BenchConfig{
+			Keys:      100,
+			ValueSize: 16,
+			BatchSize: 10,
+		},
+		Instances: []*DBInstance{
+			{Name: "treedb", Wrapper: &fixedNameDB{name: "TreeDB"}, Dir: "/tmp/bench-treedb"},
+		},
+		TestOrder: []string{"random_read_parallel_acquire_snapshot"},
+		DisplayNames: map[string]string{
+			"random_read_parallel_acquire_snapshot": "Random Read (Parallel, Snapshot Per Key)",
+		},
+		Results: map[string]map[string]float64{
+			"random_read_parallel_acquire_snapshot": {
+				"TreeDB": 1234,
+			},
+		},
+		TreeDBPerf: map[string]map[string]treeDBPerfMetrics{
+			"random_read_parallel_acquire_snapshot": {
+				"TreeDB": {
+					Mmap: treeDBMmapPerfMetrics{
+						Hits:           7,
+						MissNoMapping:  2,
+						FallbackReadAt: 3,
+						HitRatio:       0.7,
+					},
+					Snapshot: treeDBSnapshotPerfMetrics{
+						AcquireCalls:      4,
+						AcquireTotalNanos: 8_000,
+						AcquireAvgMicros:  2,
+						CloseCalls:        4,
+						CloseTotalNanos:   12_000,
+						CloseAvgMicros:    3,
+					},
+					LeafGenerationsPinned: 1,
+					LeafPinsTotal:         4,
+				},
+			},
+		},
+		TreeDBStats: map[string]map[string]string{
+			"TreeDB": {
+				"treedb.cache.vlog_mmap.read.hits":          "7",
+				"treedb.cache.vlog_mmap.read.hit_ratio":     "0.700000",
+				"treedb.leaf_generation.generations.pinned": "1",
+				"treedb.leaf_generation.pins.total":         "4",
+			},
+		},
+	}
+
+	md := renderMarkdownSingle(run)
+	if !strings.Contains(md, "## TreeDB Perf Instrumentation") {
+		t.Fatalf("expected TreeDB perf section, got:\n%s", md)
+	}
+	if !strings.Contains(md, "snapshot.acquire.calls=4") {
+		t.Fatalf("expected snapshot metrics in markdown, got:\n%s", md)
+	}
+	if !strings.Contains(md, "vlog_mmap.read.hits.delta=7") {
+		t.Fatalf("expected mmap metrics in markdown, got:\n%s", md)
+	}
+	if !strings.Contains(md, "## TreeDB Selected Stats (End of Run)") {
+		t.Fatalf("expected TreeDB selected stats section, got:\n%s", md)
+	}
+	if !strings.Contains(md, "leaf_generation.pins.total: 4") {
+		t.Fatalf("expected selected stats in markdown, got:\n%s", md)
+	}
+}
+
 func TestRenderMarkdownSweep_KeepDirIncludesKeptSection(t *testing.T) {
 	makeRun := func(keys int, dir string) BenchRun {
 		return BenchRun{
@@ -1197,6 +1305,18 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 					"TreeDB": 1200,
 				},
 			},
+			TreeDBPerf: map[string]map[string]treeDBPerfMetrics{
+				"full_scan": {
+					"TreeDB": {
+						Mmap: treeDBMmapPerfMetrics{Hits: 10, FallbackReadAt: 2, HitRatio: 0.833333},
+					},
+				},
+			},
+			TreeDBStats: map[string]map[string]string{
+				"TreeDB": {
+					"treedb.cache.vlog_mmap.read.hits": "10",
+				},
+			},
 		},
 	}
 
@@ -1226,6 +1346,12 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 	}
 	if got := parsed.Runs[0].Results["full_scan"]["TreeDB"]; got != 1000 {
 		t.Fatalf("unexpected full_scan value: %v", got)
+	}
+	if got := parsed.Runs[0].TreeDBPerf["full_scan"]["TreeDB"].Mmap.Hits; got != 10 {
+		t.Fatalf("unexpected TreeDB perf mmap hits: %v", got)
+	}
+	if got := parsed.Runs[0].TreeDBStats["TreeDB"]["treedb.cache.vlog_mmap.read.hits"]; got != "10" {
+		t.Fatalf("unexpected TreeDB stats value: %v", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

This PR changes TreeDB's mmap policy so the reserved `leaf_vlog` current-writable segment uses persistent mmap by default.

The generic current-writable mmap policy is still off by default. The change is intentionally narrow:

- keep non-leaf current-writable segments on the existing fallback path
- allow the reserved leaf-log lane to use persistent mmap while it is still the current writable segment
- add coverage proving non-leaf current segments still fall back and current leaf segments now install mmap

## Why

The latest benchmark and pprof work on `#971` showed the remaining read-path syscall cost was overwhelmingly `miss_no_mapping`, not sealed-map budget denial.

Static analysis showed the direct cause:

- `ReadUnsafe`/`ReadUnsafeTo` already try mmap first
- sealed lazy mmap was no longer denied by budget
- but current-writable files were still explicitly excluded from persistent mmap unless `TREEDB_VLOG_ENABLE_CURRENT_WRITABLE_MMAP=1`
- the hot read set for `leaf_vlog` is dominated by the active current leaf segment

So the system was still taking `ReadAt` syscalls for the hottest outer-leaf reads because of policy, not because mmap was unavailable.

## Impact

This collapses the `leaf_vlog` no-mapping path in the standard unified-bench configuration without changing the generic value-log policy.

On the exact benchmark command:

```bash
./bin/unified-bench -dbs treedb -keys 1000000 -profile-dir /home/mikers/tmp/runprof-$(date +%s)
```

Baseline before this PR (`runprof-1776373858`):

- `treedb.vlog.mmap_read.hit_ratio`: `0.249296`
- `treedb.vlog.mmap_read.fallback_readat`: `13,711,901`
- `treedb.vlog.mmap_read.miss_no_mapping`: `13,711,918`
- `Random Read (Parallel)`: `6,034,705 ops/s`
- `Random Read (Parallel, Snapshot Per Key)`: `1,521,766 ops/s`

With this PR:

- `runprof-1776375868`
  - `hit_ratio`: `1.000000`
  - `fallback_readat`: `0`
  - `miss_no_mapping`: `14`
  - `Random Read (Parallel)`: `5,877,593 ops/s`
  - `Random Read (Parallel, Snapshot Per Key)`: `1,927,635 ops/s`
- `runprof-1776375957`
  - `hit_ratio`: `1.000000`
  - `fallback_readat`: `0`
  - `miss_no_mapping`: `14`
  - `Random Read (Parallel)`: `5,201,847 ops/s`
  - `Random Read (Parallel, Snapshot Per Key)`: `1,858,167 ops/s`

The key validation point is that the syscall fallback path is eliminated. The remaining hot cost is now decode/checksum work, which is a separate sprint.

## Root cause

The remaining syscall overhead was caused by a policy mismatch:

- sealed segments were mmap-covered
- the active `leaf_vlog` segment was not
- `leaf_vlog` reads were hot enough that the current segment dominated `miss_no_mapping`

## Validation

- `GOWORK=off go test ./TreeDB/internal/valuelog -run 'TestManagerReadUnsafe_CurrentWritable(FallsBackWithoutPersistentMmap|LeafUsesPersistentMmapByDefault)|TestMmapSafety_(ZeroCopy_Remap|Concurrent_Remap)' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'Test(AcquireSnapshot_NotifyErrorOnRotateFailure|IteratorSnapshotIsolation|BackendReadBarrier_SharedBackendFlushesAllCandidateDBs)$' -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'Test(FinalizeCommitFailpoint_DoesNotRegisterCurrentLeafSegment)$' -count=1`
- `GOWORK=off make unified-bench`
- `./bin/unified-bench -dbs treedb -keys 1000000 -profile-dir /home/mikers/tmp/runprof-1776375868`
- `./bin/unified-bench -dbs treedb -keys 1000000 -profile-dir /home/mikers/tmp/runprof-1776375957`
