### PR TITLE
[codex] TreeDB: reduce steady flush copy churn

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -10716,10 +10716,7 @@ func buildOpRuns(mem memtable.Table, chunkCap int) ([][]batch.Entry, int, error)
 	deleteOps := 0
 	ops := getEntrySlice(chunkCap)
 	ops = ops[:0]
-	stableUnsafe := false
-	if stable, ok := mem.(memtable.StableUnsafeIteratorTable); ok {
-		stableUnsafe = stable.StableUnsafeIteratorSlices()
-	}
+	stableUnsafe := stableUnsafeIteratorSlices(mem)
 	for iter.Valid() {
 		val, ptr, flags := iter.UnsafeEntry()
 		key := iter.UnsafeKey()
@@ -10763,6 +10760,13 @@ func buildOpRuns(mem memtable.Table, chunkCap int) ([][]batch.Entry, int, error)
 		putEntrySlice(ops)
 	}
 	return runs, deleteOps, nil
+}
+
+func stableUnsafeIteratorSlices(mem memtable.Table) bool {
+	if stable, ok := mem.(memtable.StableUnsafeIteratorTable); ok {
+		return stable.StableUnsafeIteratorSlices()
+	}
+	return false
 }
 
 type walFastItem struct {
@@ -21632,13 +21636,14 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			return nil
 		}
 		for _, unit := range units {
+			stableUnsafe := stableUnsafeIteratorSlices(unit.mem)
 			iter := unit.mem.NewIterator(nil, nil)
 			for iter.Valid() {
 				key := iter.UnsafeKey()
 				val, ptr, flags := iter.UnsafeEntry()
 				if flags&node.FlagTombstone != 0 {
 					var err error
-					if dv != nil {
+					if stableUnsafe && dv != nil {
 						err = dv.DeleteView(key)
 					} else {
 						err = backendBatch.Delete(key)
@@ -21657,7 +21662,7 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 						return false
 					}
 				} else if flags&node.FlagPointer != 0 {
-					if psv != nil {
+					if stableUnsafe && psv != nil {
 						if err := psv.SetPointerView(key, ptr); err != nil {
 							db.reportError(fmt.Errorf("cachingdb: flush failed (set ptr): %w", err))
 							_ = iter.Close()
@@ -21683,7 +21688,11 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 								return false
 							}
 						} else {
-							single[0] = batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true}
+							entryKey := key
+							if !stableUnsafe {
+								entryKey = append([]byte(nil), key...)
+							}
+							single[0] = batch.Entry{Type: batch.OpPut, Key: entryKey, ValuePtr: ptr, IsPtr: true}
 							if err := backendBatch.SetOps(single[:]); err != nil {
 								db.reportError(fmt.Errorf("cachingdb: flush failed (setops ptr): %w", err))
 								_ = iter.Close()
@@ -21701,7 +21710,7 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 					}
 				} else {
 					var err error
-					if sv != nil {
+					if stableUnsafe && sv != nil {
 						err = sv.SetView(key, val)
 					} else {
 						err = backendBatch.Set(key, val)
@@ -22020,12 +22029,13 @@ func (db *DB) flushOneLocked(sync bool) bool {
 				return nil
 			}
 
+			stableUnsafe := stableUnsafeIteratorSlices(mem)
 			for iter.Valid() {
 				key := iter.UnsafeKey()
 				val, ptr, flags := iter.UnsafeEntry()
 				if flags&node.FlagTombstone != 0 {
 					var err error
-					if dv != nil {
+					if stableUnsafe && dv != nil {
 						err = dv.DeleteView(key)
 					} else {
 						err = backendBatch.Delete(key)
@@ -22044,7 +22054,7 @@ func (db *DB) flushOneLocked(sync bool) bool {
 						return false
 					}
 				} else if flags&node.FlagPointer != 0 {
-					if psv != nil {
+					if stableUnsafe && psv != nil {
 						if err := psv.SetPointerView(key, ptr); err != nil {
 							db.reportError(fmt.Errorf("cachingdb: flush failed (set ptr): %w", err))
 							_ = iter.Close()
@@ -22059,7 +22069,11 @@ func (db *DB) flushOneLocked(sync bool) bool {
 							return false
 						}
 					} else {
-						single[0] = batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true}
+						entryKey := key
+						if !stableUnsafe {
+							entryKey = append([]byte(nil), key...)
+						}
+						single[0] = batch.Entry{Type: batch.OpPut, Key: entryKey, ValuePtr: ptr, IsPtr: true}
 						if err := backendBatch.SetOps(single[:]); err != nil {
 							db.reportError(fmt.Errorf("cachingdb: flush failed (setops ptr): %w", err))
 							_ = iter.Close()
@@ -22076,7 +22090,7 @@ func (db *DB) flushOneLocked(sync bool) bool {
 					}
 				} else {
 					var err error
-					if sv != nil {
+					if stableUnsafe && sv != nil {
 						err = sv.SetView(key, val)
 					} else {
 						err = backendBatch.Set(key, val)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2774,14 +2774,31 @@ func (db *DB) rewriteValueLogOpsForBackend(ops []batch.Entry, durability journal
 	return ops, nil
 }
 
+type backendBatchReserveHint interface {
+	Reserve(int)
+}
+
+type backendBatchSetViewer interface {
+	SetView(key, value []byte) error
+}
+
+type backendBatchDeleteViewer interface {
+	DeleteView(key []byte) error
+}
+
+type backendBatchPointerSetter interface {
+	SetPointer(key []byte, ptr page.ValuePtr) error
+}
+
+type backendBatchPointerSetterView interface {
+	SetPointerView(key []byte, ptr page.ValuePtr) error
+}
+
 func reserveBackendBatchOps(backendBatch batch.Interface, n int) {
 	if backendBatch == nil || n <= 0 {
 		return
 	}
-	type reserveHint interface {
-		Reserve(int)
-	}
-	if r, ok := backendBatch.(reserveHint); ok {
+	if r, ok := backendBatch.(backendBatchReserveHint); ok {
 		r.Reserve(n)
 	}
 }
@@ -2805,24 +2822,10 @@ func (db *DB) flushDeferredValueLogMemtable(
 
 	allowPointers := db.allowValueLogPointers()
 
-	type (
-		setViewer interface {
-			SetView(key, value []byte) error
-		}
-		deleteViewer interface {
-			DeleteView(key []byte) error
-		}
-		ptrSetter interface {
-			SetPointer(key []byte, ptr page.ValuePtr) error
-		}
-		ptrSetterView interface {
-			SetPointerView(key []byte, ptr page.ValuePtr) error
-		}
-	)
-	sv, _ := backendBatch.(setViewer)
-	dv, _ := backendBatch.(deleteViewer)
-	psv, _ := backendBatch.(ptrSetterView)
-	ps, _ := backendBatch.(ptrSetter)
+	sv, _ := backendBatch.(backendBatchSetViewer)
+	dv, _ := backendBatch.(backendBatchDeleteViewer)
+	psv, _ := backendBatch.(backendBatchPointerSetterView)
+	ps, _ := backendBatch.(backendBatchPointerSetter)
 	reserveHint := memLen
 	if db.flushBackendMaxEntries > 0 && reserveHint > db.flushBackendMaxEntries {
 		reserveHint = db.flushBackendMaxEntries
@@ -3011,24 +3014,10 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 		return 0, errors.New("cachingdb: missing backend batch")
 	}
 
-	type (
-		setViewer interface {
-			SetView(key, value []byte) error
-		}
-		deleteViewer interface {
-			DeleteView(key []byte) error
-		}
-		ptrSetter interface {
-			SetPointer(key []byte, ptr page.ValuePtr) error
-		}
-		ptrSetterView interface {
-			SetPointerView(key []byte, ptr page.ValuePtr) error
-		}
-	)
-	sv, _ := backendBatch.(setViewer)
-	dv, _ := backendBatch.(deleteViewer)
-	psv, _ := backendBatch.(ptrSetterView)
-	ps, _ := backendBatch.(ptrSetter)
+	sv, _ := backendBatch.(backendBatchSetViewer)
+	dv, _ := backendBatch.(backendBatchDeleteViewer)
+	psv, _ := backendBatch.(backendBatchPointerSetterView)
+	ps, _ := backendBatch.(backendBatchPointerSetter)
 
 	chunkCap := db.flushBuildChunkCap
 	if chunkCap <= 0 {
@@ -21285,22 +21274,10 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 		chunkBackend := totalLen > backendEntriesCap
 		emittedChunk := false
 
-		type setViewer interface {
-			SetView(key, value []byte) error
-		}
-		type deleteViewer interface {
-			DeleteView(key []byte) error
-		}
-		type ptrSetterView interface {
-			SetPointerView(key []byte, ptr page.ValuePtr) error
-		}
-		type ptrSetter interface {
-			SetPointer(key []byte, ptr page.ValuePtr) error
-		}
-		sv, _ := backendBatch.(setViewer)
-		dv, _ := backendBatch.(deleteViewer)
-		psv, _ := backendBatch.(ptrSetterView)
-		ps, _ := backendBatch.(ptrSetter)
+		sv, _ := backendBatch.(backendBatchSetViewer)
+		dv, _ := backendBatch.(backendBatchDeleteViewer)
+		psv, _ := backendBatch.(backendBatchPointerSetterView)
+		ps, _ := backendBatch.(backendBatchPointerSetter)
 		var single [1]batch.Entry
 
 		// Best-effort: ensure value-log bytes are flushed before we start committing
@@ -21333,10 +21310,10 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			}
 			backendBatch = db.newBackendBatchWithSize(sizeHint)
 			reserveBackendBatchOps(backendBatch, reserveChunkOps)
-			sv, _ = backendBatch.(setViewer)
-			dv, _ = backendBatch.(deleteViewer)
-			psv, _ = backendBatch.(ptrSetterView)
-			ps, _ = backendBatch.(ptrSetter)
+			sv, _ = backendBatch.(backendBatchSetViewer)
+			dv, _ = backendBatch.(backendBatchDeleteViewer)
+			psv, _ = backendBatch.(backendBatchPointerSetterView)
+			ps, _ = backendBatch.(backendBatchPointerSetter)
 			backendPendingOps = 0
 			return nil
 		}
@@ -21576,24 +21553,10 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 		}
 		backendPendingOps = pendingOps
 	} else {
-		type (
-			setViewer interface {
-				SetView(key, value []byte) error
-			}
-			deleteViewer interface {
-				DeleteView(key []byte) error
-			}
-			ptrSetter interface {
-				SetPointer(key []byte, ptr page.ValuePtr) error
-			}
-			ptrSetterView interface {
-				SetPointerView(key []byte, ptr page.ValuePtr) error
-			}
-		)
-		sv, _ := backendBatch.(setViewer)
-		dv, _ := backendBatch.(deleteViewer)
-		psv, _ := backendBatch.(ptrSetterView)
-		ps, _ := backendBatch.(ptrSetter)
+		sv, _ := backendBatch.(backendBatchSetViewer)
+		dv, _ := backendBatch.(backendBatchDeleteViewer)
+		psv, _ := backendBatch.(backendBatchPointerSetterView)
+		ps, _ := backendBatch.(backendBatchPointerSetter)
 		var single [1]batch.Entry
 
 		// Best-effort: ensure value-log bytes are flushed before we start committing
@@ -21628,10 +21591,10 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			}
 			backendBatch = db.newBackendBatchWithSize(sizeHint)
 			reserveBackendBatchOps(backendBatch, reserveChunkOps)
-			sv, _ = backendBatch.(setViewer)
-			dv, _ = backendBatch.(deleteViewer)
-			psv, _ = backendBatch.(ptrSetterView)
-			ps, _ = backendBatch.(ptrSetter)
+			sv, _ = backendBatch.(backendBatchSetViewer)
+			dv, _ = backendBatch.(backendBatchDeleteViewer)
+			psv, _ = backendBatch.(backendBatchPointerSetterView)
+			ps, _ = backendBatch.(backendBatchPointerSetter)
 			backendPendingOps = 0
 			return nil
 		}
@@ -21677,10 +21640,7 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 							return false
 						}
 					} else {
-						type ptrSetterLegacy interface {
-							SetPointer(key []byte, ptr page.ValuePtr) error
-						}
-						if psl, ok := backendBatch.(ptrSetterLegacy); ok {
+						if psl, ok := backendBatch.(backendBatchPointerSetter); ok {
 							if err := psl.SetPointer(key, ptr); err != nil {
 								db.reportError(fmt.Errorf("cachingdb: flush failed (set ptr): %w", err))
 								_ = iter.Close()
@@ -21981,24 +21941,10 @@ func (db *DB) flushOneLocked(sync bool) bool {
 			}
 
 			t0 := time.Now()
-			type (
-				setViewer interface {
-					SetView(key, value []byte) error
-				}
-				deleteViewer interface {
-					DeleteView(key []byte) error
-				}
-				ptrSetter interface {
-					SetPointer(key []byte, ptr page.ValuePtr) error
-				}
-				ptrSetterView interface {
-					SetPointerView(key []byte, ptr page.ValuePtr) error
-				}
-			)
-			sv, _ := backendBatch.(setViewer)
-			dv, _ := backendBatch.(deleteViewer)
-			psv, _ := backendBatch.(ptrSetterView)
-			ps, _ := backendBatch.(ptrSetter)
+			sv, _ := backendBatch.(backendBatchSetViewer)
+			dv, _ := backendBatch.(backendBatchDeleteViewer)
+			psv, _ := backendBatch.(backendBatchPointerSetterView)
+			ps, _ := backendBatch.(backendBatchPointerSetter)
 			var single [1]batch.Entry
 
 			flushBackendChunk := func() error {
@@ -22021,10 +21967,10 @@ func (db *DB) flushOneLocked(sync bool) bool {
 				}
 				backendBatch = db.newBackendBatchWithSize(sizeHint)
 				reserveBackendBatchOps(backendBatch, reserveChunkOps)
-				sv, _ = backendBatch.(setViewer)
-				dv, _ = backendBatch.(deleteViewer)
-				psv, _ = backendBatch.(ptrSetterView)
-				ps, _ = backendBatch.(ptrSetter)
+				sv, _ = backendBatch.(backendBatchSetViewer)
+				dv, _ = backendBatch.(backendBatchDeleteViewer)
+				psv, _ = backendBatch.(backendBatchPointerSetterView)
+				ps, _ = backendBatch.(backendBatchPointerSetter)
 				backendPendingOps = 0
 				return nil
 			}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -21281,12 +21281,20 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 		chunkBackend := totalLen > backendEntriesCap
 		emittedChunk := false
 
+		type setViewer interface {
+			SetView(key, value []byte) error
+		}
+		type deleteViewer interface {
+			DeleteView(key []byte) error
+		}
 		type ptrSetterView interface {
 			SetPointerView(key []byte, ptr page.ValuePtr) error
 		}
 		type ptrSetter interface {
 			SetPointer(key []byte, ptr page.ValuePtr) error
 		}
+		sv, _ := backendBatch.(setViewer)
+		dv, _ := backendBatch.(deleteViewer)
 		psv, _ := backendBatch.(ptrSetterView)
 		ps, _ := backendBatch.(ptrSetter)
 		var single [1]batch.Entry
@@ -21321,6 +21329,8 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			}
 			backendBatch = db.newBackendBatchWithSize(sizeHint)
 			reserveBackendBatchOps(backendBatch, reserveChunkOps)
+			sv, _ = backendBatch.(setViewer)
+			dv, _ = backendBatch.(deleteViewer)
 			psv, _ = backendBatch.(ptrSetterView)
 			ps, _ = backendBatch.(ptrSetter)
 			backendPendingOps = 0
@@ -21371,7 +21381,11 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			)
 			switch {
 			case entry.Type == batch.OpDelete:
-				err = backendBatch.Delete(entry.Key)
+				if dv != nil {
+					err = dv.DeleteView(entry.Key)
+				} else {
+					err = backendBatch.Delete(entry.Key)
+				}
 				applied = true
 			case entry.IsPtr:
 				if psv != nil {
@@ -21384,7 +21398,11 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 				}
 				applied = true
 			default:
-				err = backendBatch.Set(entry.Key, entry.Value)
+				if sv != nil {
+					err = sv.SetView(entry.Key, entry.Value)
+				} else {
+					err = backendBatch.Set(entry.Key, entry.Value)
+				}
 				applied = true
 			}
 			if err != nil {
@@ -21555,6 +21573,12 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 		backendPendingOps = pendingOps
 	} else {
 		type (
+			setViewer interface {
+				SetView(key, value []byte) error
+			}
+			deleteViewer interface {
+				DeleteView(key []byte) error
+			}
 			ptrSetter interface {
 				SetPointer(key []byte, ptr page.ValuePtr) error
 			}
@@ -21562,6 +21586,8 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 				SetPointerView(key []byte, ptr page.ValuePtr) error
 			}
 		)
+		sv, _ := backendBatch.(setViewer)
+		dv, _ := backendBatch.(deleteViewer)
 		psv, _ := backendBatch.(ptrSetterView)
 		ps, _ := backendBatch.(ptrSetter)
 		var single [1]batch.Entry
@@ -21598,6 +21624,8 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			}
 			backendBatch = db.newBackendBatchWithSize(sizeHint)
 			reserveBackendBatchOps(backendBatch, reserveChunkOps)
+			sv, _ = backendBatch.(setViewer)
+			dv, _ = backendBatch.(deleteViewer)
 			psv, _ = backendBatch.(ptrSetterView)
 			ps, _ = backendBatch.(ptrSetter)
 			backendPendingOps = 0
@@ -21609,7 +21637,13 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 				key := iter.UnsafeKey()
 				val, ptr, flags := iter.UnsafeEntry()
 				if flags&node.FlagTombstone != 0 {
-					if err := backendBatch.Delete(key); err != nil {
+					var err error
+					if dv != nil {
+						err = dv.DeleteView(key)
+					} else {
+						err = backendBatch.Delete(key)
+					}
+					if err != nil {
 						db.reportError(fmt.Errorf("cachingdb: flush failed (delete): %w", err))
 						_ = iter.Close()
 						_ = backendBatch.Close()
@@ -21666,7 +21700,13 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 						return false
 					}
 				} else {
-					if err := backendBatch.Set(key, val); err != nil {
+					var err error
+					if sv != nil {
+						err = sv.SetView(key, val)
+					} else {
+						err = backendBatch.Set(key, val)
+					}
+					if err != nil {
 						db.reportError(fmt.Errorf("cachingdb: flush failed (set): %w", err))
 						_ = iter.Close()
 						_ = backendBatch.Close()

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -847,15 +847,20 @@ func TestAppendOnlyMemtableLeaseReuse(t *testing.T) {
 
 func TestFlushLaneOnce_UsesViewMethodsForInlineEntries_SerialAndParallel(t *testing.T) {
 	t.Run("serial", func(t *testing.T) {
-		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, false, true)
+		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, false, true, true)
 	})
 	t.Run("parallel", func(t *testing.T) {
-		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, true, true)
+		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, true, true, true)
 	})
 }
 
 func TestFlushLaneOnce_FallsBackFromViewMethodsForUnstableIterators(t *testing.T) {
-	testFlushLaneOnceUsesViewMethodsForInlineEntries(t, false, false)
+	t.Run("serial-direct-iterator", func(t *testing.T) {
+		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, false, false, false)
+	})
+	t.Run("parallel-copied-runs", func(t *testing.T) {
+		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, true, false, true)
+	})
 }
 
 type unstableIteratorMemtable struct {
@@ -864,7 +869,7 @@ type unstableIteratorMemtable struct {
 
 func (unstableIteratorMemtable) StableUnsafeIteratorSlices() bool { return false }
 
-func testFlushLaneOnceUsesViewMethodsForInlineEntries(t *testing.T, forceParallel, stableUnsafe bool) {
+func testFlushLaneOnceUsesViewMethodsForInlineEntries(t *testing.T, forceParallel, stableUnsafe, expectViewMethods bool) {
 	t.Helper()
 	dir := t.TempDir()
 	backend := &viewCountingBackend{MockBackend: NewMockBackend()}
@@ -919,7 +924,7 @@ func testFlushLaneOnceUsesViewMethodsForInlineEntries(t *testing.T, forceParalle
 	}
 
 	setCalls, setViewCalls, deleteCalls, deleteViewCalls := backend.totals()
-	if stableUnsafe {
+	if expectViewMethods {
 		if setCalls != 0 {
 			t.Fatalf("backend Set calls=%d, want 0", setCalls)
 		}

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -14,13 +14,15 @@ import (
 )
 
 type pointerBatch struct {
-	entries      []batch.Entry
-	reserveCalls int
-	lastReserve  int
-	setCalls     int
-	setViewCalls int
-	deleteCalls  int
-	deleteViews  int
+	entries             []batch.Entry
+	reserveCalls        int
+	lastReserve         int
+	setCalls            int
+	setViewCalls        int
+	deleteCalls         int
+	deleteViews         int
+	setPointerCalls     int
+	setPointerViewCalls int
 }
 
 type viewCountingBackend struct {
@@ -44,6 +46,14 @@ func (b *viewCountingBackend) totals() (setCalls, setViewCalls, deleteCalls, del
 		setViewCalls += pb.setViewCalls
 		deleteCalls += pb.deleteCalls
 		deleteViewCalls += pb.deleteViews
+	}
+	return
+}
+
+func (b *viewCountingBackend) pointerTotals() (setPointerCalls, setPointerViewCalls int) {
+	for _, pb := range b.batches {
+		setPointerCalls += pb.setPointerCalls
+		setPointerViewCalls += pb.setPointerViewCalls
 	}
 	return
 }
@@ -81,12 +91,15 @@ func (b *pointerBatch) DeleteView(key []byte) error {
 }
 
 func (b *pointerBatch) SetPointer(key []byte, ptr page.ValuePtr) error {
+	b.setPointerCalls++
 	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true})
 	return nil
 }
 
 func (b *pointerBatch) SetPointerView(key []byte, ptr page.ValuePtr) error {
-	return b.SetPointer(key, ptr)
+	b.setPointerViewCalls++
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true})
+	return nil
 }
 
 func (b *pointerBatch) SetOps(ops []batch.Entry) error {
@@ -834,14 +847,24 @@ func TestAppendOnlyMemtableLeaseReuse(t *testing.T) {
 
 func TestFlushLaneOnce_UsesViewMethodsForInlineEntries_SerialAndParallel(t *testing.T) {
 	t.Run("serial", func(t *testing.T) {
-		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, false)
+		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, false, true)
 	})
 	t.Run("parallel", func(t *testing.T) {
-		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, true)
+		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, true, true)
 	})
 }
 
-func testFlushLaneOnceUsesViewMethodsForInlineEntries(t *testing.T, forceParallel bool) {
+func TestFlushLaneOnce_FallsBackFromViewMethodsForUnstableIterators(t *testing.T) {
+	testFlushLaneOnceUsesViewMethodsForInlineEntries(t, false, false)
+}
+
+type unstableIteratorMemtable struct {
+	memtable.Table
+}
+
+func (unstableIteratorMemtable) StableUnsafeIteratorSlices() bool { return false }
+
+func testFlushLaneOnceUsesViewMethodsForInlineEntries(t *testing.T, forceParallel, stableUnsafe bool) {
 	t.Helper()
 	dir := t.TempDir()
 	backend := &viewCountingBackend{MockBackend: NewMockBackend()}
@@ -878,6 +901,12 @@ func testFlushLaneOnceUsesViewMethodsForInlineEntries(t *testing.T, forceParalle
 			t.Fatalf("Delete unit %d: %v", unit, err)
 		}
 		db.mu.Lock()
+		if !stableUnsafe {
+			shard := &db.mutableShards[0]
+			shard.mu.Lock()
+			shard.mem = unstableIteratorMemtable{Table: shard.mem}
+			shard.mu.Unlock()
+		}
 		if err := db.rotateMemtableLocked(false); err != nil {
 			db.mu.Unlock()
 			t.Fatalf("rotateMemtableLocked unit %d: %v", unit, err)
@@ -890,17 +919,70 @@ func testFlushLaneOnceUsesViewMethodsForInlineEntries(t *testing.T, forceParalle
 	}
 
 	setCalls, setViewCalls, deleteCalls, deleteViewCalls := backend.totals()
-	if setCalls != 0 {
-		t.Fatalf("backend Set calls=%d, want 0", setCalls)
+	if stableUnsafe {
+		if setCalls != 0 {
+			t.Fatalf("backend Set calls=%d, want 0", setCalls)
+		}
+		if deleteCalls != 0 {
+			t.Fatalf("backend Delete calls=%d, want 0", deleteCalls)
+		}
+		if setViewCalls != queueUnits {
+			t.Fatalf("backend SetView calls=%d, want %d", setViewCalls, queueUnits)
+		}
+		if deleteViewCalls != queueUnits {
+			t.Fatalf("backend DeleteView calls=%d, want %d", deleteViewCalls, queueUnits)
+		}
+		return
 	}
-	if deleteCalls != 0 {
-		t.Fatalf("backend Delete calls=%d, want 0", deleteCalls)
+	if setViewCalls != 0 {
+		t.Fatalf("backend SetView calls=%d, want 0", setViewCalls)
 	}
-	if setViewCalls != queueUnits {
-		t.Fatalf("backend SetView calls=%d, want %d", setViewCalls, queueUnits)
+	if deleteViewCalls != 0 {
+		t.Fatalf("backend DeleteView calls=%d, want 0", deleteViewCalls)
 	}
-	if deleteViewCalls != queueUnits {
-		t.Fatalf("backend DeleteView calls=%d, want %d", deleteViewCalls, queueUnits)
+	if setCalls != queueUnits {
+		t.Fatalf("backend Set calls=%d, want %d", setCalls, queueUnits)
+	}
+	if deleteCalls != queueUnits {
+		t.Fatalf("backend Delete calls=%d, want %d", deleteCalls, queueUnits)
+	}
+}
+
+func TestFlushLaneOnce_FallsBackFromPointerViewForUnstableIterators(t *testing.T) {
+	dir := t.TempDir()
+	backend := &viewCountingBackend{MockBackend: NewMockBackend()}
+	db, err := Open(dir, backend, Options{
+		FlushThreshold: 1 << 60,
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ptr := page.ValuePtr{FileID: page.ValueLogFileID(1), Offset: 32, Length: 8}
+	shard := &db.mutableShards[0]
+	shard.mu.Lock()
+	shard.mem.SetEntry([]byte("a"), nil, ptr, node.FlagPointer)
+	shard.mem = unstableIteratorMemtable{Table: shard.mem}
+	shard.mu.Unlock()
+	db.mu.Lock()
+	if err := db.rotateMemtableLocked(false); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("rotateMemtableLocked: %v", err)
+	}
+	db.mu.Unlock()
+
+	if !db.flushLaneOnce(false, 0) {
+		t.Fatal("flushLaneOnce returned false")
+	}
+
+	setPointerCalls, setPointerViewCalls := backend.pointerTotals()
+	if setPointerViewCalls != 0 {
+		t.Fatalf("backend SetPointerView calls=%d, want 0", setPointerViewCalls)
+	}
+	if setPointerCalls != 1 {
+		t.Fatalf("backend SetPointer calls=%d, want 1", setPointerCalls)
 	}
 }
 

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -17,6 +17,35 @@ type pointerBatch struct {
 	entries      []batch.Entry
 	reserveCalls int
 	lastReserve  int
+	setCalls     int
+	setViewCalls int
+	deleteCalls  int
+	deleteViews  int
+}
+
+type viewCountingBackend struct {
+	*MockBackend
+	batches []*pointerBatch
+}
+
+func (b *viewCountingBackend) NewBatch() batch.Interface {
+	pb := &pointerBatch{}
+	b.batches = append(b.batches, pb)
+	return pb
+}
+
+func (b *viewCountingBackend) NewBatchWithSize(size int) batch.Interface {
+	return b.NewBatch()
+}
+
+func (b *viewCountingBackend) totals() (setCalls, setViewCalls, deleteCalls, deleteViewCalls int) {
+	for _, pb := range b.batches {
+		setCalls += pb.setCalls
+		setViewCalls += pb.setViewCalls
+		deleteCalls += pb.deleteCalls
+		deleteViewCalls += pb.deleteViews
+	}
+	return
 }
 
 var entrySlicePoolTestMu sync.Mutex
@@ -28,21 +57,27 @@ func lockEntrySlicePoolStateForTest(t *testing.T) {
 }
 
 func (b *pointerBatch) Set(key, value []byte) error {
+	b.setCalls++
 	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, Value: value})
 	return nil
 }
 
 func (b *pointerBatch) SetView(key, value []byte) error {
-	return b.Set(key, value)
+	b.setViewCalls++
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, Value: value})
+	return nil
 }
 
 func (b *pointerBatch) Delete(key []byte) error {
+	b.deleteCalls++
 	b.entries = append(b.entries, batch.Entry{Type: batch.OpDelete, Key: key})
 	return nil
 }
 
 func (b *pointerBatch) DeleteView(key []byte) error {
-	return b.Delete(key)
+	b.deleteViews++
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpDelete, Key: key})
+	return nil
 }
 
 func (b *pointerBatch) SetPointer(key []byte, ptr page.ValuePtr) error {
@@ -794,6 +829,78 @@ func TestAppendOnlyMemtableLeaseReuse(t *testing.T) {
 	}
 	if gotAppendOnly != mt {
 		t.Fatalf("expected leased append-only memtable reuse")
+	}
+}
+
+func TestFlushLaneOnce_UsesViewMethodsForInlineEntries_SerialAndParallel(t *testing.T) {
+	t.Run("serial", func(t *testing.T) {
+		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, false)
+	})
+	t.Run("parallel", func(t *testing.T) {
+		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, true)
+	})
+}
+
+func testFlushLaneOnceUsesViewMethodsForInlineEntries(t *testing.T, forceParallel bool) {
+	t.Helper()
+	dir := t.TempDir()
+	backend := &viewCountingBackend{MockBackend: NewMockBackend()}
+	db, err := Open(dir, backend, Options{
+		FlushThreshold: 1 << 60,
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	oldProcs := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(oldProcs)
+
+	if forceParallel {
+		db.flushBuildConcurrency = 2
+		db.flushBuildMinEntries = 1
+		db.flushBuildMinUnits = 2
+		db.flushBuildChunkCap = 2
+	}
+
+	queueUnits := 1
+	if forceParallel {
+		queueUnits = 2
+	}
+	for unit := 0; unit < queueUnits; unit++ {
+		putKey := []byte{byte('a' + unit)}
+		delKey := []byte{byte('k' + unit)}
+		if err := db.Set(putKey, []byte("value")); err != nil {
+			t.Fatalf("Set unit %d: %v", unit, err)
+		}
+		if err := db.Delete(delKey); err != nil {
+			t.Fatalf("Delete unit %d: %v", unit, err)
+		}
+		db.mu.Lock()
+		if err := db.rotateMemtableLocked(false); err != nil {
+			db.mu.Unlock()
+			t.Fatalf("rotateMemtableLocked unit %d: %v", unit, err)
+		}
+		db.mu.Unlock()
+	}
+
+	if !db.flushLaneOnce(false, 0) {
+		t.Fatal("flushLaneOnce returned false")
+	}
+
+	setCalls, setViewCalls, deleteCalls, deleteViewCalls := backend.totals()
+	if setCalls != 0 {
+		t.Fatalf("backend Set calls=%d, want 0", setCalls)
+	}
+	if deleteCalls != 0 {
+		t.Fatalf("backend Delete calls=%d, want 0", deleteCalls)
+	}
+	if setViewCalls != queueUnits {
+		t.Fatalf("backend SetView calls=%d, want %d", setViewCalls, queueUnits)
+	}
+	if deleteViewCalls != queueUnits {
+		t.Fatalf("backend DeleteView calls=%d, want %d", deleteViewCalls, queueUnits)
 	}
 }
 

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -20,7 +20,7 @@ type pointerBatch struct {
 	setCalls            int
 	setViewCalls        int
 	deleteCalls         int
-	deleteViews         int
+	deleteViewCalls     int
 	setPointerCalls     int
 	setPointerViewCalls int
 }
@@ -45,7 +45,7 @@ func (b *viewCountingBackend) totals() (setCalls, setViewCalls, deleteCalls, del
 		setCalls += pb.setCalls
 		setViewCalls += pb.setViewCalls
 		deleteCalls += pb.deleteCalls
-		deleteViewCalls += pb.deleteViews
+		deleteViewCalls += pb.deleteViewCalls
 	}
 	return
 }
@@ -85,7 +85,7 @@ func (b *pointerBatch) Delete(key []byte) error {
 }
 
 func (b *pointerBatch) DeleteView(key []byte) error {
-	b.deleteViews++
+	b.deleteViewCalls++
 	b.entries = append(b.entries, batch.Entry{Type: batch.OpDelete, Key: key})
 	return nil
 }
@@ -900,13 +900,13 @@ func testFlushLaneOnceUsesViewMethodsForInlineEntries(t *testing.T, forceParalle
 		if err := db.Delete(delKey); err != nil {
 			t.Fatalf("Delete unit %d: %v", unit, err)
 		}
-		db.mu.Lock()
 		if !stableUnsafe {
 			shard := &db.mutableShards[0]
 			shard.mu.Lock()
 			shard.mem = unstableIteratorMemtable{Table: shard.mem}
 			shard.mu.Unlock()
 		}
+		db.mu.Lock()
 		if err := db.rotateMemtableLocked(false); err != nil {
 			db.mu.Unlock()
 			t.Fatalf("rotateMemtableLocked unit %d: %v", unit, err)

--- a/TreeDB/caching/lane.go
+++ b/TreeDB/caching/lane.go
@@ -104,7 +104,7 @@ const (
 	vlogGenerationClassCold
 )
 
-const leafLogLaneID = 255
+const leafLogLaneID = valuelog.ReservedLeafLogLaneID
 
 func commitLogName(laneID, seq int) string {
 	return fmt.Sprintf("commit-l%d-%06d.log", laneID, seq)

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -26,41 +26,6 @@ type Snapshot struct {
 	backend *backenddb.Snapshot
 
 	closed atomic.Bool
-	next   *Snapshot
-}
-
-var snapshotPoolHead atomic.Pointer[Snapshot]
-
-func acquirePooledSnapshot() *Snapshot {
-	for {
-		head := snapshotPoolHead.Load()
-		if head == nil {
-			return &Snapshot{}
-		}
-		next := head.next
-		if !snapshotPoolHead.CompareAndSwap(head, next) {
-			continue
-		}
-		head.next = nil
-		head.closed.Store(false)
-		return head
-	}
-}
-
-func releasePooledSnapshot(s *Snapshot) {
-	if s == nil {
-		return
-	}
-	s.db = nil
-	s.view = nil
-	s.backend = nil
-	for {
-		head := snapshotPoolHead.Load()
-		s.next = head
-		if snapshotPoolHead.CompareAndSwap(head, s) {
-			return
-		}
-	}
 }
 
 type backendSnapshotProvider interface {
@@ -72,7 +37,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	if db == nil || db.backend == nil || db.closing.Load() {
 		return nil
 	}
-	snap := acquirePooledSnapshot()
+	snap := &Snapshot{}
 
 	view := db.retainMemtableView()
 	needsRotate := db.mutableBytes.Load() > 0
@@ -107,7 +72,6 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 				if db.notifyError != nil {
 					db.notifyError(err)
 				}
-				releasePooledSnapshot(snap)
 				return nil
 			}
 		}
@@ -125,7 +89,6 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		if view != nil {
 			db.releaseMemtableView(view)
 		}
-		releasePooledSnapshot(snap)
 		return nil
 	}
 	backendSnap := provider.AcquireSnapshot()
@@ -133,7 +96,6 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		if view != nil {
 			db.releaseMemtableView(view)
 		}
-		releasePooledSnapshot(snap)
 		return nil
 	}
 
@@ -165,17 +127,16 @@ func (s *Snapshot) Close() error {
 		return nil
 	}
 
-	var errs []error
+	var err error
 	if s.backend != nil {
-		errs = append(errs, s.backend.Close())
+		err = s.backend.Close()
 		s.backend = nil
 	}
 	if s.view != nil && s.db != nil {
 		s.db.releaseMemtableView(s.view)
 		s.view = nil
 	}
-	err := errors.Join(errs...)
-	releasePooledSnapshot(s)
+	s.db = nil
 	return err
 }
 

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -3,6 +3,7 @@ package caching
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -25,8 +26,29 @@ type Snapshot struct {
 	view    *memtableView
 	backend *backenddb.Snapshot
 
-	closeOnce sync.Once
-	closeErr  error
+	closed atomic.Bool
+}
+
+var snapshotPool = sync.Pool{
+	New: func() any {
+		return &Snapshot{}
+	},
+}
+
+func acquirePooledSnapshot() *Snapshot {
+	s := snapshotPool.Get().(*Snapshot)
+	s.closed.Store(false)
+	return s
+}
+
+func releasePooledSnapshot(s *Snapshot) {
+	if s == nil {
+		return
+	}
+	s.db = nil
+	s.view = nil
+	s.backend = nil
+	snapshotPool.Put(s)
 }
 
 type backendSnapshotProvider interface {
@@ -38,6 +60,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	if db == nil || db.backend == nil || db.closing.Load() {
 		return nil
 	}
+	snap := acquirePooledSnapshot()
 
 	view := db.retainMemtableView()
 	needsRotate := db.mutableBytes.Load() > 0
@@ -72,6 +95,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 				if db.notifyError != nil {
 					db.notifyError(err)
 				}
+				releasePooledSnapshot(snap)
 				return nil
 			}
 		}
@@ -89,6 +113,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		if view != nil {
 			db.releaseMemtableView(view)
 		}
+		releasePooledSnapshot(snap)
 		return nil
 	}
 	backendSnap := provider.AcquireSnapshot()
@@ -96,10 +121,14 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		if view != nil {
 			db.releaseMemtableView(view)
 		}
+		releasePooledSnapshot(snap)
 		return nil
 	}
 
-	return &Snapshot{db: db, view: view, backend: backendSnap}
+	snap.db = db
+	snap.view = view
+	snap.backend = backendSnap
+	return snap
 }
 
 func (s *Snapshot) Pager() *pager.Pager {
@@ -120,19 +149,22 @@ func (s *Snapshot) Close() error {
 	if s == nil {
 		return nil
 	}
-	s.closeOnce.Do(func() {
-		var errs []error
-		if s.backend != nil {
-			errs = append(errs, s.backend.Close())
-			s.backend = nil
-		}
-		if s.view != nil && s.db != nil {
-			s.db.releaseMemtableView(s.view)
-			s.view = nil
-		}
-		s.closeErr = errors.Join(errs...)
-	})
-	return s.closeErr
+	if !s.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+
+	var errs []error
+	if s.backend != nil {
+		errs = append(errs, s.backend.Close())
+		s.backend = nil
+	}
+	if s.view != nil && s.db != nil {
+		s.db.releaseMemtableView(s.view)
+		s.view = nil
+	}
+	err := errors.Join(errs...)
+	releasePooledSnapshot(s)
+	return err
 }
 
 func (s *Snapshot) lookupQueueEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"errors"
+	"sync"
 	"sync/atomic"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -31,6 +32,12 @@ type Snapshot struct {
 	closed atomic.Bool
 }
 
+var snapshotWrapperPool = sync.Pool{
+	New: func() any {
+		return &Snapshot{}
+	},
+}
+
 type backendSnapshotProvider interface {
 	AcquireSnapshot() *backenddb.Snapshot
 }
@@ -40,7 +47,8 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	if db == nil || db.backend == nil || db.closing.Load() {
 		return nil
 	}
-	snap := &Snapshot{}
+	snap := snapshotWrapperPool.Get().(*Snapshot)
+	snap.closed.Store(false)
 
 	view := db.retainMemtableView()
 	needsRotate := db.mutableBytes.Load() > 0
@@ -75,6 +83,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 				if db.notifyError != nil {
 					db.notifyError(err)
 				}
+				releaseSnapshotWrapper(snap)
 				return nil
 			}
 		}
@@ -92,6 +101,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		if view != nil {
 			db.releaseMemtableView(view)
 		}
+		releaseSnapshotWrapper(snap)
 		return nil
 	}
 	backendSnap := provider.AcquireSnapshot()
@@ -99,6 +109,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		if view != nil {
 			db.releaseMemtableView(view)
 		}
+		releaseSnapshotWrapper(snap)
 		return nil
 	}
 
@@ -140,7 +151,18 @@ func (s *Snapshot) Close() error {
 		s.view = nil
 	}
 	s.db = nil
+	releaseSnapshotWrapper(s)
 	return err
+}
+
+func releaseSnapshotWrapper(s *Snapshot) {
+	if s == nil {
+		return
+	}
+	s.db = nil
+	s.view = nil
+	s.backend = nil
+	snapshotWrapperPool.Put(s)
 }
 
 func (s *Snapshot) lookupQueueEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -20,6 +20,9 @@ import (
 //
 // Mutable memtables are intentionally ignored so that writes after AcquireSnapshot
 // are not visible through the snapshot.
+//
+// Snapshot pointers are single-use: after Close returns, callers must discard the
+// pointer and treat further use as invalid.
 type Snapshot struct {
 	db      *DB
 	view    *memtableView

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -2,7 +2,6 @@ package caching
 
 import (
 	"errors"
-	"sync"
 	"sync/atomic"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -27,18 +26,25 @@ type Snapshot struct {
 	backend *backenddb.Snapshot
 
 	closed atomic.Bool
+	next   *Snapshot
 }
 
-var snapshotPool = sync.Pool{
-	New: func() any {
-		return &Snapshot{}
-	},
-}
+var snapshotPoolHead atomic.Pointer[Snapshot]
 
 func acquirePooledSnapshot() *Snapshot {
-	s := snapshotPool.Get().(*Snapshot)
-	s.closed.Store(false)
-	return s
+	for {
+		head := snapshotPoolHead.Load()
+		if head == nil {
+			return &Snapshot{}
+		}
+		next := head.next
+		if !snapshotPoolHead.CompareAndSwap(head, next) {
+			continue
+		}
+		head.next = nil
+		head.closed.Store(false)
+		return head
+	}
 }
 
 func releasePooledSnapshot(s *Snapshot) {
@@ -48,7 +54,13 @@ func releasePooledSnapshot(s *Snapshot) {
 	s.db = nil
 	s.view = nil
 	s.backend = nil
-	snapshotPool.Put(s)
+	for {
+		head := snapshotPoolHead.Load()
+		s.next = head
+		if snapshotPoolHead.CompareAndSwap(head, s) {
+			return
+		}
+	}
 }
 
 type backendSnapshotProvider interface {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -40,7 +40,6 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	if db == nil || db.backend == nil || db.closing.Load() {
 		return nil
 	}
-	snap := &Snapshot{}
 
 	view := db.retainMemtableView()
 	needsRotate := db.mutableBytes.Load() > 0
@@ -102,10 +101,11 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		return nil
 	}
 
-	snap.db = db
-	snap.view = view
-	snap.backend = backendSnap
-	return snap
+	return &Snapshot{
+		db:      db,
+		view:    view,
+		backend: backendSnap,
+	}
 }
 
 func (s *Snapshot) Pager() *pager.Pager {

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -157,7 +157,46 @@ func TestAcquireSnapshot_AllocsBoundedAfterWarmPath(t *testing.T) {
 			t.Fatalf("Close: %v", err)
 		}
 	})
-	if allocs > 1.05 {
-		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 1.05 after warm path", allocs)
+	if allocs > 0.05 {
+		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 0.05 after warm path", allocs)
+	}
+}
+
+func TestSnapshotClose_IdempotentBeforeWrapperReuse(t *testing.T) {
+	dir, err := os.MkdirTemp("", "treedb-snapshot-close-idempotent-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cached.Close()
+
+	snap := cached.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	if err := snap.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := snap.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+
+	next := cached.AcquireSnapshot()
+	if next == nil {
+		t.Fatal("second AcquireSnapshot=nil")
+	}
+	if err := next.Close(); err != nil {
+		t.Fatalf("close second snapshot: %v", err)
 	}
 }

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -117,3 +117,44 @@ func TestIteratorSnapshotIsolation(t *testing.T) {
 		t.Error("Iterator saw key 'b' written AFTER iterator creation (Snapshot Isolation violation)")
 	}
 }
+
+func TestAcquireSnapshot_AllocsAfterWarmPool(t *testing.T) {
+	dir, err := os.MkdirTemp("", "treedb-snapshot-pool-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{FlushThreshold: 1024 * 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cached.Close()
+
+	warm := cached.AcquireSnapshot()
+	if warm == nil {
+		t.Fatal("warm AcquireSnapshot=nil")
+	}
+	if err := warm.Close(); err != nil {
+		t.Fatalf("warm Close: %v", err)
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		snap := cached.AcquireSnapshot()
+		if snap == nil {
+			t.Fatal("AcquireSnapshot=nil")
+		}
+		if err := snap.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+	if allocs > 0.05 {
+		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 0.05 after warm pool", allocs)
+	}
+}

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -118,7 +118,10 @@ func TestIteratorSnapshotIsolation(t *testing.T) {
 	}
 }
 
-func TestAcquireSnapshot_AllocsAfterWarmPool(t *testing.T) {
+func TestAcquireSnapshot_AllocsBoundedAfterWarmPath(t *testing.T) {
+	if testRaceEnabled {
+		t.Skip("AllocsPerRun is not stable under -race")
+	}
 	dir, err := os.MkdirTemp("", "treedb-snapshot-pool-")
 	if err != nil {
 		t.Fatal(err)
@@ -154,7 +157,7 @@ func TestAcquireSnapshot_AllocsAfterWarmPool(t *testing.T) {
 			t.Fatalf("Close: %v", err)
 		}
 	})
-	if allocs > 0.05 {
-		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 0.05 after warm pool", allocs)
+	if allocs > 1.05 {
+		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 1.05 after warm path", allocs)
 	}
 }

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -531,7 +531,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.root_page"] = fmt.Sprintf("%d", state.RootPageID)
 	stats["treedb.system_root_page"] = fmt.Sprintf("%d", state.SystemRootPageID)
 
-	writeLeafGenerationMetrics(stats, db.collectLeafGenerationMetrics(state.ValueLogSet, snap.leafGenerationIDs))
+	writeLeafGenerationMetrics(stats, db.collectLeafGenerationMetrics(state.ValueLogSet, snap.leafGenerationPinnedIDs))
 
 	stats["treedb.pages.total"] = fmt.Sprintf("%d", idx.pager.PageCount())
 	// PR1 generational scaffolding (backend/read-only path). Cached mode exports

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2075,6 +2075,9 @@ func (db *DB) publishSnapshotView(idx *indexGen, state *DBState, vm *valuelog.Ma
 		state:       state,
 		vlogManager: vm,
 	})
+	if state.LeafGenerations != nil && db.snapshotAcquireInFlight() == 0 {
+		db.leafGenerationPins.pruneInactiveGenerationIDs(state.LeafGenerations.GenerationOrder)
+	}
 }
 
 func (db *DB) clearSnapshotView() {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -756,19 +756,21 @@ type Options struct {
 }
 
 type Snapshot struct {
-	db                 *DB
-	idx                *indexGen
-	state              *DBState
-	vlogManager        *valuelog.Manager
-	vlogPinned         bool
-	leafGenerationIDs  []uint64
-	leafGenerationRefs []*leafGenerationPinRef
-	registryID         int64
-	reader             valueReader
-	tree               tree.Tree
-	closed             atomic.Bool
-	treePager          *pager.Pager
-	treeRoot           uint64
+	db                      *DB
+	idx                     *indexGen
+	state                   *DBState
+	vlogManager             *valuelog.Manager
+	vlogPinned              bool
+	leafGenerationIDs       []uint64
+	leafGenerationPinnedIDs []uint64
+	leafGenerationRefs      []*leafGenerationPinRef
+	leafGenerationPinSet    *leafGenerationPinSet
+	registryID              int64
+	reader                  valueReader
+	tree                    tree.Tree
+	closed                  atomic.Bool
+	treePager               *pager.Pager
+	treeRoot                uint64
 	// registryShardHint is used to route reader registrations to a stable fast
 	// registry shard for this snapshot object across operations.
 	registryShardHint int
@@ -849,17 +851,29 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		registryID, snap.registryShardHint = idx.registry.RegisterWithHint(state.CommitSeq, snap.registryShardHint)
 	}
 	if state.LeafGenerations != nil {
-		snap.leafGenerationIDs = append(snap.leafGenerationIDs[:0], state.LeafGenerations.GenerationOrder...)
-		if len(state.LeafGenerations.PinRefs) == len(state.LeafGenerations.GenerationOrder) && len(state.LeafGenerations.PinRefs) > 0 {
+		snap.leafGenerationIDs = state.LeafGenerations.GenerationOrder
+		if state.LeafGenerations.PinSet != nil {
+			snap.leafGenerationPinSet = state.LeafGenerations.PinSet
+			if db.retainLeafGenerationPinSet(snap.leafGenerationPinSet) {
+				snap.leafGenerationPinnedIDs = snap.leafGenerationIDs
+			} else {
+				snap.leafGenerationPinnedIDs = nil
+			}
+			snap.leafGenerationRefs = snap.leafGenerationRefs[:0]
+		} else if len(state.LeafGenerations.PinRefs) == len(state.LeafGenerations.GenerationOrder) && len(state.LeafGenerations.PinRefs) > 0 {
 			snap.leafGenerationRefs = append(snap.leafGenerationRefs[:0], state.LeafGenerations.PinRefs...)
 			db.pinLeafGenerationRefs(snap.leafGenerationRefs)
+			snap.leafGenerationPinnedIDs = snap.leafGenerationIDs
 		} else {
 			snap.leafGenerationRefs = snap.leafGenerationRefs[:0]
 			db.pinLeafGenerationIDs(snap.leafGenerationIDs)
+			snap.leafGenerationPinnedIDs = snap.leafGenerationIDs
 		}
 	} else {
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.leafGenerationIDs = nil
+		snap.leafGenerationPinnedIDs = nil
 		snap.leafGenerationRefs = snap.leafGenerationRefs[:0]
+		snap.leafGenerationPinSet = nil
 	}
 
 	snap.db = db
@@ -894,13 +908,17 @@ func (s *Snapshot) releaseLeafGenerationPins() {
 	}
 	if s.db != nil {
 		switch {
+		case s.leafGenerationPinSet != nil:
+			s.db.releaseLeafGenerationPinSet(s.leafGenerationPinSet)
 		case len(s.leafGenerationRefs) > 0:
 			s.db.unpinLeafGenerationRefs(s.leafGenerationRefs)
 		case len(s.leafGenerationIDs) > 0:
 			s.db.unpinLeafGenerationIDs(s.leafGenerationIDs)
 		}
 	}
-	s.leafGenerationIDs = s.leafGenerationIDs[:0]
+	s.leafGenerationIDs = nil
+	s.leafGenerationPinnedIDs = nil
+	s.leafGenerationPinSet = nil
 	clear(s.leafGenerationRefs)
 	s.leafGenerationRefs = s.leafGenerationRefs[:0]
 }
@@ -2069,6 +2087,10 @@ func (db *DB) publishSnapshotView(idx *indexGen, state *DBState, vm *valuelog.Ma
 	if idx == nil || state == nil {
 		db.snapshotViewRO.Store(nil)
 		return
+	}
+	old := db.snapshotViewRO.Load()
+	if old != nil && old.state != nil && old.state.LeafGenerations != state.LeafGenerations {
+		db.markLeafGenerationPinSetStale(old.state.LeafGenerations.PinSet)
 	}
 	db.snapshotViewRO.Store(&snapshotView{
 		idx:         idx,

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -901,6 +901,7 @@ func (s *Snapshot) releaseLeafGenerationPins() {
 		}
 	}
 	s.leafGenerationIDs = s.leafGenerationIDs[:0]
+	clear(s.leafGenerationRefs)
 	s.leafGenerationRefs = s.leafGenerationRefs[:0]
 }
 

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -756,18 +756,19 @@ type Options struct {
 }
 
 type Snapshot struct {
-	db                *DB
-	idx               *indexGen
-	state             *DBState
-	vlogManager       *valuelog.Manager
-	vlogPinned        bool
-	leafGenerationIDs []uint64
-	registryID        int64
-	reader            valueReader
-	tree              tree.Tree
-	closed            atomic.Bool
-	treePager         *pager.Pager
-	treeRoot          uint64
+	db                 *DB
+	idx                *indexGen
+	state              *DBState
+	vlogManager        *valuelog.Manager
+	vlogPinned         bool
+	leafGenerationIDs  []uint64
+	leafGenerationRefs []*leafGenerationPinRef
+	registryID         int64
+	reader             valueReader
+	tree               tree.Tree
+	closed             atomic.Bool
+	treePager          *pager.Pager
+	treeRoot           uint64
 	// registryShardHint is used to route reader registrations to a stable fast
 	// registry shard for this snapshot object across operations.
 	registryShardHint int
@@ -849,9 +850,16 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	}
 	if state.LeafGenerations != nil {
 		snap.leafGenerationIDs = append(snap.leafGenerationIDs[:0], state.LeafGenerations.GenerationOrder...)
-		db.pinLeafGenerationIDs(snap.leafGenerationIDs)
+		if len(state.LeafGenerations.PinRefs) == len(state.LeafGenerations.GenerationOrder) && len(state.LeafGenerations.PinRefs) > 0 {
+			snap.leafGenerationRefs = append(snap.leafGenerationRefs[:0], state.LeafGenerations.PinRefs...)
+			db.pinLeafGenerationRefs(snap.leafGenerationRefs)
+		} else {
+			snap.leafGenerationRefs = snap.leafGenerationRefs[:0]
+			db.pinLeafGenerationIDs(snap.leafGenerationIDs)
+		}
 	} else {
 		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.leafGenerationRefs = snap.leafGenerationRefs[:0]
 	}
 
 	snap.db = db
@@ -880,6 +888,22 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	return snap
 }
 
+func (s *Snapshot) releaseLeafGenerationPins() {
+	if s == nil {
+		return
+	}
+	if s.db != nil {
+		switch {
+		case len(s.leafGenerationRefs) > 0:
+			s.db.unpinLeafGenerationRefs(s.leafGenerationRefs)
+		case len(s.leafGenerationIDs) > 0:
+			s.db.unpinLeafGenerationIDs(s.leafGenerationIDs)
+		}
+	}
+	s.leafGenerationIDs = s.leafGenerationIDs[:0]
+	s.leafGenerationRefs = s.leafGenerationRefs[:0]
+}
+
 // Close releases the snapshot.
 func (s *Snapshot) Close() error {
 	if s == nil {
@@ -905,9 +929,7 @@ func (s *Snapshot) Close() error {
 			}
 		}
 	}
-	if s.db != nil && len(s.leafGenerationIDs) > 0 {
-		s.db.unpinLeafGenerationIDs(s.leafGenerationIDs)
-	}
+	s.releaseLeafGenerationPins()
 	if s.db != nil {
 		s.db.snapPool.Put(s)
 	}

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2089,7 +2089,7 @@ func (db *DB) publishSnapshotView(idx *indexGen, state *DBState, vm *valuelog.Ma
 		return
 	}
 	old := db.snapshotViewRO.Load()
-	if old != nil && old.state != nil && old.state.LeafGenerations != state.LeafGenerations {
+	if old != nil && old.state != nil && old.state.LeafGenerations != nil && old.state.LeafGenerations != state.LeafGenerations {
 		db.markLeafGenerationPinSetStale(old.state.LeafGenerations.PinSet)
 	}
 	db.snapshotViewRO.Store(&snapshotView{

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -65,8 +65,7 @@ func (db *DB) LeafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		return stats, ErrClosed
 	}
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	if snap.state == nil || snap.state.LeafGenerations == nil {
 		_ = snap.Close()

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -216,8 +216,9 @@ func TestLeafGenerationGC_RetiresPinnedGenerationUntilSnapshotCloses(t *testing.
 	if snap == nil {
 		t.Fatal("expected snapshot")
 	}
-	if got, want := db.leafGenerationPinCountForTesting(gen1.GenerationID), uint64(1); got != want {
-		t.Fatalf("pin count=%d, want %d", got, want)
+	if got := db.leafGenerationPinCountForTesting(gen1.GenerationID); got != 0 {
+		closeNoErr(t, snap)
+		t.Fatalf("pin count before republish=%d, want 0", got)
 	}
 
 	if err := leafLog.rotateLeaf(); err != nil {
@@ -225,6 +226,10 @@ func TestLeafGenerationGC_RetiresPinnedGenerationUntilSnapshotCloses(t *testing.
 		t.Fatalf("rotateLeaf: %v", err)
 	}
 	writeLeafGenerationKeys(t, db, "k", 64, 'b')
+	if got, want := db.leafGenerationPinCountForTesting(gen1.GenerationID), uint64(1); got != want {
+		closeNoErr(t, snap)
+		t.Fatalf("pin count after republish=%d, want %d", got, want)
+	}
 
 	stats1, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})
 	if err != nil {

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -161,8 +161,7 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 		return plan, ErrClosed
 	}
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	defer func() { _ = snap.Close() }()
 

--- a/TreeDB/db/leaf_generation_plan_bench_test.go
+++ b/TreeDB/db/leaf_generation_plan_bench_test.go
@@ -205,8 +205,7 @@ func BenchmarkLeafGenerationLiveStatsPersistedIndex_SavedHome(b *testing.B) {
 	}
 	b.Cleanup(func() { _ = snap.Close() })
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 
 	b.ReportAllocs()
@@ -243,8 +242,7 @@ func BenchmarkLeafGenerationLiveStatsVerifiedPagesPersistedIndex_SavedHome(b *te
 	}
 	b.Cleanup(func() { _ = snap.Close() })
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	if _, err := db.scanLeafGenerationLiveStats(context.Background(), snap); err != nil {
 		b.Fatalf("warm scanLeafGenerationLiveStats: %v", err)
@@ -284,8 +282,7 @@ func BenchmarkLeafGenerationLiveStatsWarmIndexesVerifiedPages_SavedHome(b *testi
 	}
 	b.Cleanup(func() { _ = snap.Close() })
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	if _, err := db.scanLeafGenerationLiveStats(context.Background(), snap); err != nil {
 		b.Fatalf("warm scanLeafGenerationLiveStats: %v", err)
@@ -414,8 +411,7 @@ func BenchmarkLeafGenerationPlanLeafRefStats_SavedHome(b *testing.B) {
 			b.Fatal(ErrClosed)
 		}
 		if len(snap.leafGenerationIDs) > 0 {
-			db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-			snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+			snap.releaseLeafGenerationPins()
 		}
 
 		seen := make(map[page.LeafLogPtr]struct{}, 1024)
@@ -461,8 +457,7 @@ func BenchmarkLeafGenerationPlanLeafRefPageStats_SavedHome(b *testing.B) {
 			b.Fatal(ErrClosed)
 		}
 		if len(snap.leafGenerationIDs) > 0 {
-			db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-			snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+			snap.releaseLeafGenerationPins()
 		}
 
 		seenPages := make(map[uint64]struct{}, 1024)

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -347,8 +347,7 @@ func TestLeafGenerationRecordLengthForPlan_LoadsPersistedSidecarWithoutRescan(t 
 	}
 	defer func() { _ = snap.Close() }()
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	view := snap.state.LeafGenerations
 	if view == nil {
@@ -424,8 +423,7 @@ func TestLeafGenerationRecordLengthForPlan_UsesWritableIndex(t *testing.T) {
 	}
 	defer func() { _ = snap.Close() }()
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	view := snap.state.LeafGenerations
 	if view == nil {
@@ -504,8 +502,7 @@ func TestLeafGenerationLiveStats_MarksPagerPagesVerified(t *testing.T) {
 	}
 	defer func() { _ = snap.Close() }()
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	if snap.idx == nil || snap.idx.pager == nil {
 		t.Fatal("expected pager")
@@ -561,8 +558,7 @@ func TestLeafGenerationRecordLengthForPlan_UsesSealedIndex(t *testing.T) {
 	}
 	defer func() { _ = snap.Close() }()
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	view := snap.state.LeafGenerations
 	if view == nil {
@@ -645,8 +641,7 @@ func TestLeafGenerationPlan_CachesLiveStatsPerPublishedState(t *testing.T) {
 		t.Fatal("expected snapshot")
 	}
 	if len(snap.leafGenerationIDs) > 0 {
-		db.unpinLeafGenerationIDs(snap.leafGenerationIDs)
-		snap.leafGenerationIDs = snap.leafGenerationIDs[:0]
+		snap.releaseLeafGenerationPins()
 	}
 	if _, err := collectLiveLeafGenerationIDs(context.Background(), snap); err != nil {
 		_ = snap.Close()

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -783,8 +783,8 @@ func TestLeafGenerationPlan_DoesNotLeaveExtraSnapshotPins(t *testing.T) {
 
 	before1 := db.leafGenerationPinCountForTesting(gen1.GenerationID)
 	before2 := db.leafGenerationPinCountForTesting(gen2.GenerationID)
-	if before1 == 0 || before2 == 0 {
-		t.Fatalf("expected non-zero pins before plan: gen1=%d gen2=%d", before1, before2)
+	if before1 != 0 || before2 != 0 {
+		t.Fatalf("expected current-view snapshot pins to stay at zero before plan: gen1=%d gen2=%d", before1, before2)
 	}
 
 	if _, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{}); err != nil {

--- a/TreeDB/db/leaf_generation_runtime.go
+++ b/TreeDB/db/leaf_generation_runtime.go
@@ -1,10 +1,14 @@
 package db
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 type leafGenerationView struct {
 	CurrentGenerationID uint64
 	GenerationOrder     []uint64
+	PinRefs             []*leafGenerationPinRef
 	Generations         map[uint64]leafGenerationViewGeneration
 	FileToGeneration    map[uint32]uint64
 }
@@ -46,50 +50,120 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 	if db == nil || db.leafGenerationManifest == nil {
 		return nil
 	}
-	return newLeafGenerationView(db.leafGenerationManifest)
+	view := newLeafGenerationView(db.leafGenerationManifest)
+	if view != nil && len(view.GenerationOrder) > 0 {
+		view.PinRefs = db.leafGenerationPins.refsForGenerationIDs(view.GenerationOrder)
+	}
+	return view
+}
+
+type leafGenerationPinRef struct {
+	count atomic.Int64
 }
 
 type leafGenerationPinTracker struct {
-	mu     sync.Mutex
-	counts map[uint64]uint64
+	mu   sync.RWMutex
+	refs map[uint64]*leafGenerationPinRef
 }
 
-func (t *leafGenerationPinTracker) pin(ids []uint64) {
+func (t *leafGenerationPinTracker) refsForGenerationIDs(ids []uint64) []*leafGenerationPinRef {
 	if len(ids) == 0 {
-		return
+		return nil
 	}
+	t.mu.RLock()
+	allPresent := t.refs != nil
+	if allPresent {
+		for _, id := range ids {
+			if id == 0 {
+				continue
+			}
+			if t.refs[id] == nil {
+				allPresent = false
+				break
+			}
+		}
+	}
+	if allPresent {
+		refs := make([]*leafGenerationPinRef, 0, len(ids))
+		for _, id := range ids {
+			if id == 0 {
+				continue
+			}
+			if ref := t.refs[id]; ref != nil {
+				refs = append(refs, ref)
+			}
+		}
+		t.mu.RUnlock()
+		return refs
+	}
+	t.mu.RUnlock()
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.counts == nil {
-		t.counts = make(map[uint64]uint64, len(ids))
+	if t.refs == nil {
+		t.refs = make(map[uint64]*leafGenerationPinRef, len(ids))
 	}
+	refs := make([]*leafGenerationPinRef, 0, len(ids))
 	for _, id := range ids {
 		if id == 0 {
 			continue
 		}
-		t.counts[id]++
+		ref := t.refs[id]
+		if ref == nil {
+			ref = &leafGenerationPinRef{}
+			t.refs[id] = ref
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func (t *leafGenerationPinTracker) lookupRefs(ids []uint64) []*leafGenerationPinRef {
+	if len(ids) == 0 {
+		return nil
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if len(t.refs) == 0 {
+		return nil
+	}
+	refs := make([]*leafGenerationPinRef, 0, len(ids))
+	for _, id := range ids {
+		if id == 0 {
+			continue
+		}
+		if ref := t.refs[id]; ref != nil {
+			refs = append(refs, ref)
+		}
+	}
+	return refs
+}
+
+func (t *leafGenerationPinTracker) pin(ids []uint64) {
+	t.pinRefs(t.refsForGenerationIDs(ids))
+}
+
+func (t *leafGenerationPinTracker) pinRefs(refs []*leafGenerationPinRef) {
+	for _, ref := range refs {
+		if ref == nil {
+			continue
+		}
+		ref.count.Add(1)
 	}
 }
 
 func (t *leafGenerationPinTracker) unpin(ids []uint64) {
-	if len(ids) == 0 {
-		return
-	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if len(t.counts) == 0 {
-		return
-	}
-	for _, id := range ids {
-		if id == 0 {
+	t.unpinRefs(t.lookupRefs(ids))
+}
+
+func (t *leafGenerationPinTracker) unpinRefs(refs []*leafGenerationPinRef) {
+	for _, ref := range refs {
+		if ref == nil {
 			continue
 		}
-		count := t.counts[id]
-		if count <= 1 {
-			delete(t.counts, id)
-			continue
+		if ref.count.Add(-1) < 0 {
+			ref.count.Store(0)
 		}
-		t.counts[id] = count - 1
 	}
 }
 
@@ -97,9 +171,17 @@ func (t *leafGenerationPinTracker) count(id uint64) uint64 {
 	if id == 0 {
 		return 0
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.counts[id]
+	t.mu.RLock()
+	ref := t.refs[id]
+	t.mu.RUnlock()
+	if ref == nil {
+		return 0
+	}
+	count := ref.count.Load()
+	if count <= 0 {
+		return 0
+	}
+	return uint64(count)
 }
 
 func (db *DB) pinLeafGenerationIDs(ids []uint64) {
@@ -114,6 +196,20 @@ func (db *DB) unpinLeafGenerationIDs(ids []uint64) {
 		return
 	}
 	db.leafGenerationPins.unpin(ids)
+}
+
+func (db *DB) pinLeafGenerationRefs(refs []*leafGenerationPinRef) {
+	if db == nil {
+		return
+	}
+	db.leafGenerationPins.pinRefs(refs)
+}
+
+func (db *DB) unpinLeafGenerationRefs(refs []*leafGenerationPinRef) {
+	if db == nil {
+		return
+	}
+	db.leafGenerationPins.unpinRefs(refs)
 }
 
 func (db *DB) leafGenerationPinCountForTesting(id uint64) uint64 {

--- a/TreeDB/db/leaf_generation_runtime.go
+++ b/TreeDB/db/leaf_generation_runtime.go
@@ -65,10 +65,12 @@ type leafGenerationPinRef struct {
 }
 
 type leafGenerationPinSet struct {
-	refs    []*leafGenerationPinRef
-	holders atomic.Int64
-	stale   atomic.Bool
-	pinned  atomic.Bool
+	refs []*leafGenerationPinRef
+
+	mu      sync.Mutex
+	holders int64
+	stale   bool
+	pinned  bool
 }
 
 func newLeafGenerationPinSet(refs []*leafGenerationPinRef) *leafGenerationPinSet {
@@ -82,8 +84,13 @@ func (s *leafGenerationPinSet) retain(tracker *leafGenerationPinTracker) bool {
 	if s == nil || tracker == nil {
 		return false
 	}
-	if s.holders.Add(1) == 1 && s.stale.Load() {
-		return s.pinIfNeeded(tracker)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.holders++
+	if s.stale && !s.pinned {
+		tracker.pinRefs(s.refs)
+		s.pinned = true
+		return true
 	}
 	return false
 }
@@ -92,8 +99,15 @@ func (s *leafGenerationPinSet) release(tracker *leafGenerationPinTracker) {
 	if s == nil || tracker == nil {
 		return
 	}
-	if s.holders.Add(-1) == 0 {
-		s.unpinIfNeeded(tracker)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.holders == 0 {
+		return
+	}
+	s.holders--
+	if s.holders == 0 && s.pinned {
+		tracker.unpinRefs(s.refs)
+		s.pinned = false
 	}
 }
 
@@ -101,31 +115,15 @@ func (s *leafGenerationPinSet) markStale(tracker *leafGenerationPinTracker) {
 	if s == nil || tracker == nil {
 		return
 	}
-	if !s.stale.CompareAndSwap(false, true) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stale {
 		return
 	}
-	if s.holders.Load() > 0 {
-		s.pinIfNeeded(tracker)
-	}
-}
-
-func (s *leafGenerationPinSet) pinIfNeeded(tracker *leafGenerationPinTracker) bool {
-	if s == nil || tracker == nil {
-		return false
-	}
-	if s.pinned.CompareAndSwap(false, true) {
+	s.stale = true
+	if s.holders > 0 && !s.pinned {
 		tracker.pinRefs(s.refs)
-		return true
-	}
-	return false
-}
-
-func (s *leafGenerationPinSet) unpinIfNeeded(tracker *leafGenerationPinTracker) {
-	if s == nil || tracker == nil {
-		return
-	}
-	if s.pinned.CompareAndSwap(true, false) {
-		tracker.unpinRefs(s.refs)
+		s.pinned = true
 	}
 }
 

--- a/TreeDB/db/leaf_generation_runtime.go
+++ b/TreeDB/db/leaf_generation_runtime.go
@@ -51,6 +51,9 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 		return nil
 	}
 	view := newLeafGenerationView(db.leafGenerationManifest)
+	if view != nil {
+		db.leafGenerationPins.pruneInactiveGenerationIDs(view.GenerationOrder)
+	}
 	if view != nil && len(view.GenerationOrder) > 0 {
 		view.PinRefs = db.leafGenerationPins.refsForGenerationIDs(view.GenerationOrder)
 	}
@@ -58,6 +61,7 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 }
 
 type leafGenerationPinRef struct {
+	id    uint64
 	count atomic.Int64
 }
 
@@ -110,7 +114,7 @@ func (t *leafGenerationPinTracker) refsForGenerationIDs(ids []uint64) []*leafGen
 		}
 		ref := t.refs[id]
 		if ref == nil {
-			ref = &leafGenerationPinRef{}
+			ref = &leafGenerationPinRef{id: id}
 			t.refs[id] = ref
 		}
 		refs = append(refs, ref)
@@ -158,11 +162,46 @@ func (t *leafGenerationPinTracker) unpin(ids []uint64) {
 
 func (t *leafGenerationPinTracker) unpinRefs(refs []*leafGenerationPinRef) {
 	for _, ref := range refs {
-		if ref == nil {
+		t.unpinRef(ref)
+	}
+}
+
+func (t *leafGenerationPinTracker) unpinRef(ref *leafGenerationPinRef) {
+	if ref == nil {
+		return
+	}
+	for {
+		current := ref.count.Load()
+		if current <= 0 {
+			return
+		}
+		next := current - 1
+		if !ref.count.CompareAndSwap(current, next) {
 			continue
 		}
-		if ref.count.Add(-1) < 0 {
-			ref.count.Store(0)
+		return
+	}
+}
+
+func (t *leafGenerationPinTracker) pruneInactiveGenerationIDs(active []uint64) {
+	activeSet := make(map[uint64]struct{}, len(active))
+	for _, id := range active {
+		if id != 0 {
+			activeSet[id] = struct{}{}
+		}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for id, ref := range t.refs {
+		if ref == nil {
+			delete(t.refs, id)
+			continue
+		}
+		if _, ok := activeSet[id]; ok {
+			continue
+		}
+		if ref.count.Load() == 0 {
+			delete(t.refs, id)
 		}
 	}
 }

--- a/TreeDB/db/leaf_generation_runtime.go
+++ b/TreeDB/db/leaf_generation_runtime.go
@@ -51,7 +51,7 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 		return nil
 	}
 	view := newLeafGenerationView(db.leafGenerationManifest)
-	if view != nil {
+	if view != nil && db.snapshotAcquireInFlight() == 0 {
 		db.leafGenerationPins.pruneInactiveGenerationIDs(view.GenerationOrder)
 	}
 	if view != nil && len(view.GenerationOrder) > 0 {

--- a/TreeDB/db/leaf_generation_runtime.go
+++ b/TreeDB/db/leaf_generation_runtime.go
@@ -51,9 +51,6 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 		return nil
 	}
 	view := newLeafGenerationView(db.leafGenerationManifest)
-	if view != nil && db.snapshotAcquireInFlight() == 0 {
-		db.leafGenerationPins.pruneInactiveGenerationIDs(view.GenerationOrder)
-	}
 	if view != nil && len(view.GenerationOrder) > 0 {
 		view.PinRefs = db.leafGenerationPins.refsForGenerationIDs(view.GenerationOrder)
 	}

--- a/TreeDB/db/leaf_generation_runtime.go
+++ b/TreeDB/db/leaf_generation_runtime.go
@@ -9,6 +9,7 @@ type leafGenerationView struct {
 	CurrentGenerationID uint64
 	GenerationOrder     []uint64
 	PinRefs             []*leafGenerationPinRef
+	PinSet              *leafGenerationPinSet
 	Generations         map[uint64]leafGenerationViewGeneration
 	FileToGeneration    map[uint32]uint64
 }
@@ -53,6 +54,7 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 	view := newLeafGenerationView(db.leafGenerationManifest)
 	if view != nil && len(view.GenerationOrder) > 0 {
 		view.PinRefs = db.leafGenerationPins.refsForGenerationIDs(view.GenerationOrder)
+		view.PinSet = newLeafGenerationPinSet(view.PinRefs)
 	}
 	return view
 }
@@ -60,6 +62,71 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 type leafGenerationPinRef struct {
 	id    uint64
 	count atomic.Int64
+}
+
+type leafGenerationPinSet struct {
+	refs    []*leafGenerationPinRef
+	holders atomic.Int64
+	stale   atomic.Bool
+	pinned  atomic.Bool
+}
+
+func newLeafGenerationPinSet(refs []*leafGenerationPinRef) *leafGenerationPinSet {
+	if len(refs) == 0 {
+		return nil
+	}
+	return &leafGenerationPinSet{refs: refs}
+}
+
+func (s *leafGenerationPinSet) retain(tracker *leafGenerationPinTracker) bool {
+	if s == nil || tracker == nil {
+		return false
+	}
+	if s.holders.Add(1) == 1 && s.stale.Load() {
+		return s.pinIfNeeded(tracker)
+	}
+	return false
+}
+
+func (s *leafGenerationPinSet) release(tracker *leafGenerationPinTracker) {
+	if s == nil || tracker == nil {
+		return
+	}
+	if s.holders.Add(-1) == 0 {
+		s.unpinIfNeeded(tracker)
+	}
+}
+
+func (s *leafGenerationPinSet) markStale(tracker *leafGenerationPinTracker) {
+	if s == nil || tracker == nil {
+		return
+	}
+	if !s.stale.CompareAndSwap(false, true) {
+		return
+	}
+	if s.holders.Load() > 0 {
+		s.pinIfNeeded(tracker)
+	}
+}
+
+func (s *leafGenerationPinSet) pinIfNeeded(tracker *leafGenerationPinTracker) bool {
+	if s == nil || tracker == nil {
+		return false
+	}
+	if s.pinned.CompareAndSwap(false, true) {
+		tracker.pinRefs(s.refs)
+		return true
+	}
+	return false
+}
+
+func (s *leafGenerationPinSet) unpinIfNeeded(tracker *leafGenerationPinTracker) {
+	if s == nil || tracker == nil {
+		return
+	}
+	if s.pinned.CompareAndSwap(true, false) {
+		tracker.unpinRefs(s.refs)
+	}
 }
 
 type leafGenerationPinTracker struct {
@@ -246,6 +313,27 @@ func (db *DB) unpinLeafGenerationRefs(refs []*leafGenerationPinRef) {
 		return
 	}
 	db.leafGenerationPins.unpinRefs(refs)
+}
+
+func (db *DB) retainLeafGenerationPinSet(pinSet *leafGenerationPinSet) bool {
+	if db == nil || pinSet == nil {
+		return false
+	}
+	return pinSet.retain(&db.leafGenerationPins)
+}
+
+func (db *DB) releaseLeafGenerationPinSet(pinSet *leafGenerationPinSet) {
+	if db == nil || pinSet == nil {
+		return
+	}
+	pinSet.release(&db.leafGenerationPins)
+}
+
+func (db *DB) markLeafGenerationPinSetStale(pinSet *leafGenerationPinSet) {
+	if db == nil || pinSet == nil {
+		return
+	}
+	pinSet.markStale(&db.leafGenerationPins)
 }
 
 func (db *DB) leafGenerationPinCountForTesting(id uint64) uint64 {

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -49,6 +49,7 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.vlogManager = nil
 	s.vlogPinned = false
 	s.leafGenerationIDs = s.leafGenerationIDs[:0]
+	s.leafGenerationRefs = s.leafGenerationRefs[:0]
 	s.reader = valueReader{}
 	s.registryID = 0
 	s.closed.Store(false)

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -49,6 +49,7 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.vlogManager = nil
 	s.vlogPinned = false
 	s.leafGenerationIDs = s.leafGenerationIDs[:0]
+	clear(s.leafGenerationRefs)
 	s.leafGenerationRefs = s.leafGenerationRefs[:0]
 	s.reader = valueReader{}
 	s.registryID = 0

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -48,11 +48,13 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.state = nil
 	s.vlogManager = nil
 	s.vlogPinned = false
-	s.leafGenerationIDs = s.leafGenerationIDs[:0]
+	s.leafGenerationIDs = nil
+	s.leafGenerationPinnedIDs = nil
 	if cap(s.leafGenerationRefs) > 0 {
 		clear(s.leafGenerationRefs[:cap(s.leafGenerationRefs)])
 	}
 	s.leafGenerationRefs = s.leafGenerationRefs[:0]
+	s.leafGenerationPinSet = nil
 	s.reader = valueReader{}
 	s.registryID = 0
 	s.closed.Store(false)

--- a/TreeDB/db/pools.go
+++ b/TreeDB/db/pools.go
@@ -49,7 +49,9 @@ func (p *SnapshotPool) Put(s *Snapshot) {
 	s.vlogManager = nil
 	s.vlogPinned = false
 	s.leafGenerationIDs = s.leafGenerationIDs[:0]
-	clear(s.leafGenerationRefs)
+	if cap(s.leafGenerationRefs) > 0 {
+		clear(s.leafGenerationRefs[:cap(s.leafGenerationRefs)])
+	}
 	s.leafGenerationRefs = s.leafGenerationRefs[:0]
 	s.reader = valueReader{}
 	s.registryID = 0

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -219,3 +219,55 @@ func TestLeafGenerationPinTracker_PrunesInactiveZeroCountRefs(t *testing.T) {
 		t.Fatalf("expected inactive zero-count ref for generation 3 to be pruned")
 	}
 }
+
+func TestCurrentLeafGenerationView_SkipsPruneDuringInFlightSnapshotAcquire(t *testing.T) {
+	db := &DB{}
+	db.leafGenerationManifest = &leafGenerationManifest{
+		CurrentGenerationID: 1,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateWritable, FileIDs: []uint32{111}},
+		},
+	}
+
+	staleRefs := db.leafGenerationPins.refsForGenerationIDs([]uint64{7})
+	if len(staleRefs) != 1 {
+		t.Fatalf("expected one stale ref, got %d", len(staleRefs))
+	}
+	db.snapshotAcquireRO[0].Store(1)
+	view := db.currentLeafGenerationView()
+	db.snapshotAcquireRO[0].Store(0)
+	if view == nil {
+		t.Fatal("expected leaf generation view")
+	}
+
+	db.leafGenerationPins.mu.RLock()
+	_, stillTracked := db.leafGenerationPins.refs[7]
+	db.leafGenerationPins.mu.RUnlock()
+	if !stillTracked {
+		t.Fatalf("expected stale ref to remain tracked while snapshot acquisition is in flight")
+	}
+
+	db.currentLeafGenerationView()
+
+	db.leafGenerationPins.mu.RLock()
+	_, stillTracked = db.leafGenerationPins.refs[7]
+	db.leafGenerationPins.mu.RUnlock()
+	if stillTracked {
+		t.Fatalf("expected stale ref to be pruned once snapshot acquisition is quiescent")
+	}
+}
+
+func TestSnapshotPool_PutClearsLeafGenerationRefs(t *testing.T) {
+	pool := NewSnapshotPool()
+	snap := pool.Get()
+	snap.leafGenerationRefs = append(snap.leafGenerationRefs, &leafGenerationPinRef{id: 1})
+	pool.Put(snap)
+
+	reused := pool.Get()
+	if len(reused.leafGenerationRefs) != 0 {
+		t.Fatalf("expected pooled snapshot refs slice to be reset, got len=%d", len(reused.leafGenerationRefs))
+	}
+	if cap(reused.leafGenerationRefs) > 0 && reused.leafGenerationRefs[:1][0] != nil {
+		t.Fatalf("expected pooled snapshot refs backing array to be cleared")
+	}
+}

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -127,24 +127,30 @@ func TestAcquireSnapshot_ReturnsNilWhenDBIsClosing(t *testing.T) {
 	}
 }
 
-func TestAcquireSnapshot_PinsLeafGenerationView(t *testing.T) {
+func TestAcquireSnapshot_CurrentLeafGenerationViewOnlyPinsWhenItTurnsStale(t *testing.T) {
 	idx := &indexGen{registry: lifecycle.NewReaderRegistry()}
 	idx.refs.Store(1)
-	state := &DBState{
-		CommitSeq:  1,
-		RootPageID: 1,
-		LeafGenerations: &leafGenerationView{
-			CurrentGenerationID: 2,
-			GenerationOrder:     []uint64{1, 2},
-			Generations: map[uint64]leafGenerationViewGeneration{
-				1: {State: leafGenerationStateSealed, FileIDs: []uint32{111}},
-				2: {State: leafGenerationStateWritable, FileIDs: []uint32{222}},
-			},
-			FileToGeneration: map[uint32]uint64{111: 1, 222: 2},
+	db := &DB{snapPool: NewSnapshotPool()}
+	db.leafGenerationManifest = &leafGenerationManifest{
+		CurrentGenerationID: 2,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateSealed, FileIDs: []uint32{111}},
+			{GenerationID: 2, State: leafGenerationStateWritable, FileIDs: []uint32{222}},
 		},
 	}
+	view := db.currentLeafGenerationView()
+	if view == nil {
+		t.Fatal("expected leaf generation view")
+	}
+	if view.PinSet == nil {
+		t.Fatal("expected shared leaf generation pin set")
+	}
+	state := &DBState{
+		CommitSeq:       1,
+		RootPageID:      1,
+		LeafGenerations: view,
+	}
 
-	db := &DB{snapPool: NewSnapshotPool()}
 	db.publishSnapshotView(idx, state, nil)
 
 	snap := db.AcquireSnapshot()
@@ -154,11 +160,39 @@ func TestAcquireSnapshot_PinsLeafGenerationView(t *testing.T) {
 	if got, want := len(snap.leafGenerationIDs), 2; got != want {
 		t.Fatalf("len(leafGenerationIDs)=%d, want %d", got, want)
 	}
+	if snap.leafGenerationPinSet == nil {
+		t.Fatal("expected snapshot to retain shared pin set")
+	}
+	if got := db.leafGenerationPinCountForTesting(1); got != 0 {
+		_ = snap.Close()
+		t.Fatalf("pin count for current generation 1=%d, want 0 before republish", got)
+	}
+	if got := db.leafGenerationPinCountForTesting(2); got != 0 {
+		_ = snap.Close()
+		t.Fatalf("pin count for current generation 2=%d, want 0 before republish", got)
+	}
+
+	db.leafGenerationManifest = &leafGenerationManifest{
+		CurrentGenerationID: 3,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 2, State: leafGenerationStateSealed, FileIDs: []uint32{222}},
+			{GenerationID: 3, State: leafGenerationStateWritable, FileIDs: []uint32{333}},
+		},
+	}
+	state2 := &DBState{
+		CommitSeq:       2,
+		RootPageID:      2,
+		LeafGenerations: db.currentLeafGenerationView(),
+	}
+	db.publishSnapshotView(idx, state2, nil)
+
 	if got, want := db.leafGenerationPinCountForTesting(1), uint64(1); got != want {
-		t.Fatalf("pin count for generation 1=%d, want %d", got, want)
+		_ = snap.Close()
+		t.Fatalf("pin count for stale generation 1=%d, want %d", got, want)
 	}
 	if got, want := db.leafGenerationPinCountForTesting(2), uint64(1); got != want {
-		t.Fatalf("pin count for generation 2=%d, want %d", got, want)
+		_ = snap.Close()
+		t.Fatalf("pin count for stale generation 2=%d, want %d", got, want)
 	}
 	if err := snap.Close(); err != nil {
 		t.Fatalf("close snapshot: %v", err)
@@ -168,6 +202,208 @@ func TestAcquireSnapshot_PinsLeafGenerationView(t *testing.T) {
 	}
 	if got := db.leafGenerationPinCountForTesting(2); got != 0 {
 		t.Fatalf("pin count for generation 2 after close=%d, want 0", got)
+	}
+}
+
+func TestAcquireSnapshot_SharedLeafGenerationPinSetAmortizesPins(t *testing.T) {
+	idx := &indexGen{registry: lifecycle.NewReaderRegistry()}
+	idx.refs.Store(1)
+
+	db := &DB{snapPool: NewSnapshotPool()}
+	db.leafGenerationManifest = &leafGenerationManifest{
+		CurrentGenerationID: 2,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateSealed, FileIDs: []uint32{111}},
+			{GenerationID: 2, State: leafGenerationStateWritable, FileIDs: []uint32{222}},
+		},
+	}
+	view := db.currentLeafGenerationView()
+	if view == nil || view.PinSet == nil {
+		t.Fatal("expected leaf generation view with shared pin set")
+	}
+	state := &DBState{
+		CommitSeq:       1,
+		RootPageID:      1,
+		LeafGenerations: view,
+	}
+	db.publishSnapshotView(idx, state, nil)
+
+	snap1 := db.AcquireSnapshot()
+	if snap1 == nil {
+		t.Fatal("expected first snapshot")
+	}
+	snap2 := db.AcquireSnapshot()
+	if snap2 == nil {
+		_ = snap1.Close()
+		t.Fatal("expected second snapshot")
+	}
+
+	if got := db.leafGenerationPinCountForTesting(1); got != 0 {
+		_ = snap2.Close()
+		_ = snap1.Close()
+		t.Fatalf("pin count for current generation 1=%d, want 0 before republish", got)
+	}
+	if got := db.leafGenerationPinCountForTesting(2); got != 0 {
+		_ = snap2.Close()
+		_ = snap1.Close()
+		t.Fatalf("pin count for current generation 2=%d, want 0 before republish", got)
+	}
+
+	db.leafGenerationManifest = &leafGenerationManifest{
+		CurrentGenerationID: 3,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 2, State: leafGenerationStateSealed, FileIDs: []uint32{222}},
+			{GenerationID: 3, State: leafGenerationStateWritable, FileIDs: []uint32{333}},
+		},
+	}
+	state2 := &DBState{
+		CommitSeq:       2,
+		RootPageID:      2,
+		LeafGenerations: db.currentLeafGenerationView(),
+	}
+	db.publishSnapshotView(idx, state2, nil)
+
+	if got, want := db.leafGenerationPinCountForTesting(1), uint64(1); got != want {
+		_ = snap2.Close()
+		_ = snap1.Close()
+		t.Fatalf("pin count for stale generation 1=%d, want %d with two shared-view snapshots", got, want)
+	}
+	if got, want := db.leafGenerationPinCountForTesting(2), uint64(1); got != want {
+		_ = snap2.Close()
+		_ = snap1.Close()
+		t.Fatalf("pin count for stale generation 2=%d, want %d with two shared-view snapshots", got, want)
+	}
+
+	if err := snap1.Close(); err != nil {
+		_ = snap2.Close()
+		t.Fatalf("close first snapshot: %v", err)
+	}
+	if got, want := db.leafGenerationPinCountForTesting(1), uint64(1); got != want {
+		_ = snap2.Close()
+		t.Fatalf("pin count for generation 1 after first close=%d, want %d", got, want)
+	}
+	if got, want := db.leafGenerationPinCountForTesting(2), uint64(1); got != want {
+		_ = snap2.Close()
+		t.Fatalf("pin count for generation 2 after first close=%d, want %d", got, want)
+	}
+
+	if err := snap2.Close(); err != nil {
+		t.Fatalf("close second snapshot: %v", err)
+	}
+	if got := db.leafGenerationPinCountForTesting(1); got != 0 {
+		t.Fatalf("pin count for generation 1 after second close=%d, want 0", got)
+	}
+	if got := db.leafGenerationPinCountForTesting(2); got != 0 {
+		t.Fatalf("pin count for generation 2 after second close=%d, want 0", got)
+	}
+}
+
+func TestAcquireSnapshot_SharedLeafGenerationPinSet_RemainsPinnedAcrossPublish(t *testing.T) {
+	idx := &indexGen{registry: lifecycle.NewReaderRegistry()}
+	idx.refs.Store(1)
+
+	db := &DB{snapPool: NewSnapshotPool()}
+	db.leafGenerationManifest = &leafGenerationManifest{
+		CurrentGenerationID: 1,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateWritable, FileIDs: []uint32{111}},
+		},
+	}
+	state1 := &DBState{
+		CommitSeq:       1,
+		RootPageID:      1,
+		LeafGenerations: db.currentLeafGenerationView(),
+	}
+	db.publishSnapshotView(idx, state1, nil)
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	if got := db.leafGenerationPinCountForTesting(1); got != 0 {
+		_ = snap.Close()
+		t.Fatalf("pin count for current generation 1=%d, want 0 before republish", got)
+	}
+
+	db.leafGenerationManifest = &leafGenerationManifest{
+		CurrentGenerationID: 2,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 2, State: leafGenerationStateWritable, FileIDs: []uint32{222}},
+		},
+	}
+	state2 := &DBState{
+		CommitSeq:       2,
+		RootPageID:      2,
+		LeafGenerations: db.currentLeafGenerationView(),
+	}
+	db.publishSnapshotView(idx, state2, nil)
+
+	if got, want := db.leafGenerationPinCountForTesting(1), uint64(1); got != want {
+		_ = snap.Close()
+		t.Fatalf("pin count for generation 1 after republish=%d, want %d", got, want)
+	}
+	if got := db.leafGenerationPinCountForTesting(2); got != 0 {
+		_ = snap.Close()
+		t.Fatalf("pin count for generation 2 before new snapshot=%d, want 0", got)
+	}
+
+	if err := snap.Close(); err != nil {
+		t.Fatalf("close snapshot: %v", err)
+	}
+	if got := db.leafGenerationPinCountForTesting(1); got != 0 {
+		t.Fatalf("pin count for generation 1 after close=%d, want 0", got)
+	}
+}
+
+func TestAcquireSnapshot_ManualLeafGenerationViewFallbackStillPinsPerSnapshot(t *testing.T) {
+	idx := &indexGen{registry: lifecycle.NewReaderRegistry()}
+	idx.refs.Store(1)
+	state := &DBState{
+		CommitSeq:  1,
+		RootPageID: 1,
+		LeafGenerations: &leafGenerationView{
+			CurrentGenerationID: 1,
+			GenerationOrder:     []uint64{1},
+			Generations: map[uint64]leafGenerationViewGeneration{
+				1: {State: leafGenerationStateWritable, FileIDs: []uint32{111}},
+			},
+			FileToGeneration: map[uint32]uint64{111: 1},
+		},
+	}
+
+	db := &DB{snapPool: NewSnapshotPool()}
+	db.publishSnapshotView(idx, state, nil)
+
+	snap1 := db.AcquireSnapshot()
+	if snap1 == nil {
+		t.Fatal("expected first snapshot")
+	}
+	snap2 := db.AcquireSnapshot()
+	if snap2 == nil {
+		_ = snap1.Close()
+		t.Fatal("expected second snapshot")
+	}
+
+	if got, want := db.leafGenerationPinCountForTesting(1), uint64(2); got != want {
+		_ = snap2.Close()
+		_ = snap1.Close()
+		t.Fatalf("manual view pin count=%d, want %d", got, want)
+	}
+
+	if err := snap1.Close(); err != nil {
+		_ = snap2.Close()
+		t.Fatalf("close first snapshot: %v", err)
+	}
+	if got, want := db.leafGenerationPinCountForTesting(1), uint64(1); got != want {
+		_ = snap2.Close()
+		t.Fatalf("manual view pin count after first close=%d, want %d", got, want)
+	}
+
+	if err := snap2.Close(); err != nil {
+		t.Fatalf("close second snapshot: %v", err)
+	}
+	if got := db.leafGenerationPinCountForTesting(1); got != 0 {
+		t.Fatalf("manual view pin count after second close=%d, want 0", got)
 	}
 }
 
@@ -283,27 +519,51 @@ func TestPublishSnapshotView_SkipsPruneDuringInFlightSnapshotAcquire(t *testing.
 func TestSnapshotPool_PutClearsLeafGenerationRefs(t *testing.T) {
 	pool := NewSnapshotPool()
 	snap := pool.Get()
+	snap.leafGenerationIDs = []uint64{1}
+	snap.leafGenerationPinnedIDs = []uint64{1}
 	snap.leafGenerationRefs = append(snap.leafGenerationRefs, &leafGenerationPinRef{id: 1})
+	snap.leafGenerationPinSet = &leafGenerationPinSet{}
 	pool.Put(snap)
 
 	reused := pool.Get()
+	if len(reused.leafGenerationIDs) != 0 {
+		t.Fatalf("expected pooled snapshot ids slice to be reset, got len=%d", len(reused.leafGenerationIDs))
+	}
+	if len(reused.leafGenerationPinnedIDs) != 0 {
+		t.Fatalf("expected pooled snapshot pinned ids slice to be reset, got len=%d", len(reused.leafGenerationPinnedIDs))
+	}
 	if len(reused.leafGenerationRefs) != 0 {
 		t.Fatalf("expected pooled snapshot refs slice to be reset, got len=%d", len(reused.leafGenerationRefs))
 	}
 	if cap(reused.leafGenerationRefs) > 0 && reused.leafGenerationRefs[:1][0] != nil {
 		t.Fatalf("expected pooled snapshot refs backing array to be cleared")
 	}
+	if reused.leafGenerationPinSet != nil {
+		t.Fatalf("expected pooled snapshot pin set to be cleared")
+	}
 }
 
 func TestSnapshotReleaseLeafGenerationPins_ClearsRefBackingArray(t *testing.T) {
 	snap := &Snapshot{}
+	snap.leafGenerationIDs = []uint64{1}
+	snap.leafGenerationPinnedIDs = []uint64{1}
 	snap.leafGenerationRefs = append(snap.leafGenerationRefs, &leafGenerationPinRef{id: 1})
+	snap.leafGenerationPinSet = &leafGenerationPinSet{}
 	snap.releaseLeafGenerationPins()
 
+	if len(snap.leafGenerationIDs) != 0 {
+		t.Fatalf("expected leafGenerationIDs len=0 after release, got %d", len(snap.leafGenerationIDs))
+	}
+	if len(snap.leafGenerationPinnedIDs) != 0 {
+		t.Fatalf("expected leafGenerationPinnedIDs len=0 after release, got %d", len(snap.leafGenerationPinnedIDs))
+	}
 	if len(snap.leafGenerationRefs) != 0 {
 		t.Fatalf("expected leafGenerationRefs len=0 after release, got %d", len(snap.leafGenerationRefs))
 	}
 	if cap(snap.leafGenerationRefs) > 0 && snap.leafGenerationRefs[:1][0] != nil {
 		t.Fatalf("expected leafGenerationRefs backing array to be cleared on release")
+	}
+	if snap.leafGenerationPinSet != nil {
+		t.Fatalf("expected leafGenerationPinSet to be cleared on release")
 	}
 }

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -220,7 +220,7 @@ func TestLeafGenerationPinTracker_PrunesInactiveZeroCountRefs(t *testing.T) {
 	}
 }
 
-func TestCurrentLeafGenerationView_SkipsPruneDuringInFlightSnapshotAcquire(t *testing.T) {
+func TestCurrentLeafGenerationView_DoesNotPruneTrackedRefs(t *testing.T) {
 	db := &DB{}
 	db.leafGenerationManifest = &leafGenerationManifest{
 		CurrentGenerationID: 1,
@@ -233,9 +233,7 @@ func TestCurrentLeafGenerationView_SkipsPruneDuringInFlightSnapshotAcquire(t *te
 	if len(staleRefs) != 1 {
 		t.Fatalf("expected one stale ref, got %d", len(staleRefs))
 	}
-	db.snapshotAcquireRO[0].Store(1)
 	view := db.currentLeafGenerationView()
-	db.snapshotAcquireRO[0].Store(0)
 	if view == nil {
 		t.Fatal("expected leaf generation view")
 	}
@@ -244,11 +242,36 @@ func TestCurrentLeafGenerationView_SkipsPruneDuringInFlightSnapshotAcquire(t *te
 	_, stillTracked := db.leafGenerationPins.refs[7]
 	db.leafGenerationPins.mu.RUnlock()
 	if !stillTracked {
+		t.Fatalf("expected currentLeafGenerationView not to prune tracked refs")
+	}
+}
+
+func TestPublishSnapshotView_SkipsPruneDuringInFlightSnapshotAcquire(t *testing.T) {
+	db := &DB{}
+	idx := &indexGen{}
+	state := &DBState{
+		LeafGenerations: &leafGenerationView{
+			CurrentGenerationID: 1,
+			GenerationOrder:     []uint64{1},
+		},
+	}
+
+	staleRefs := db.leafGenerationPins.refsForGenerationIDs([]uint64{7})
+	if len(staleRefs) != 1 {
+		t.Fatalf("expected one stale ref, got %d", len(staleRefs))
+	}
+
+	db.snapshotAcquireRO[0].Store(1)
+	db.publishSnapshotView(idx, state, nil)
+	db.leafGenerationPins.mu.RLock()
+	_, stillTracked := db.leafGenerationPins.refs[7]
+	db.leafGenerationPins.mu.RUnlock()
+	if !stillTracked {
 		t.Fatalf("expected stale ref to remain tracked while snapshot acquisition is in flight")
 	}
 
-	db.currentLeafGenerationView()
-
+	db.snapshotAcquireRO[0].Store(0)
+	db.publishSnapshotView(idx, state, nil)
 	db.leafGenerationPins.mu.RLock()
 	_, stillTracked = db.leafGenerationPins.refs[7]
 	db.leafGenerationPins.mu.RUnlock()

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -516,6 +516,77 @@ func TestPublishSnapshotView_SkipsPruneDuringInFlightSnapshotAcquire(t *testing.
 	}
 }
 
+func TestLeafGenerationPinSet_MarkStaleAfterLastReleaseDoesNotLeakPins(t *testing.T) {
+	var tracker leafGenerationPinTracker
+	pinSet := newLeafGenerationPinSet(tracker.refsForGenerationIDs([]uint64{1}))
+	if pinSet == nil {
+		t.Fatal("expected pin set")
+	}
+	if pinned := pinSet.retain(&tracker); pinned {
+		t.Fatal("expected current view retain not to pin")
+	}
+
+	pinSet.release(&tracker)
+	pinSet.markStale(&tracker)
+
+	if got := tracker.count(1); got != 0 {
+		t.Fatalf("pin count after markStale with no holders=%d, want 0", got)
+	}
+}
+
+func TestLeafGenerationPinSet_StaleRetainRepinsAfterZeroHolderRelease(t *testing.T) {
+	var tracker leafGenerationPinTracker
+	pinSet := newLeafGenerationPinSet(tracker.refsForGenerationIDs([]uint64{1}))
+	if pinSet == nil {
+		t.Fatal("expected pin set")
+	}
+
+	pinSet.markStale(&tracker)
+	if pinned := pinSet.retain(&tracker); !pinned {
+		t.Fatal("expected first stale retain to pin shared refs")
+	}
+	if got, want := tracker.count(1), uint64(1); got != want {
+		t.Fatalf("pin count after first stale retain=%d, want %d", got, want)
+	}
+
+	pinSet.release(&tracker)
+	if got := tracker.count(1); got != 0 {
+		t.Fatalf("pin count after releasing last stale holder=%d, want 0", got)
+	}
+
+	if pinned := pinSet.retain(&tracker); !pinned {
+		t.Fatal("expected stale retain after zero-holder release to repin shared refs")
+	}
+	if got, want := tracker.count(1), uint64(1); got != want {
+		t.Fatalf("pin count after stale repin=%d, want %d", got, want)
+	}
+
+	pinSet.release(&tracker)
+	if got := tracker.count(1); got != 0 {
+		t.Fatalf("pin count after final release=%d, want 0", got)
+	}
+}
+
+func TestPublishSnapshotView_AllowsNilOldLeafGenerations(t *testing.T) {
+	db := &DB{}
+	idx := &indexGen{}
+
+	db.publishSnapshotView(idx, &DBState{CommitSeq: 1, RootPageID: 1}, nil)
+	db.publishSnapshotView(idx, &DBState{
+		CommitSeq:  2,
+		RootPageID: 2,
+		LeafGenerations: &leafGenerationView{
+			CurrentGenerationID: 1,
+			GenerationOrder:     []uint64{1},
+		},
+	}, nil)
+
+	view := db.snapshotViewRO.Load()
+	if view == nil || view.state == nil || view.state.LeafGenerations == nil {
+		t.Fatal("expected published snapshot view with leaf generations")
+	}
+}
+
 func TestSnapshotPool_PutClearsLeafGenerationRefs(t *testing.T) {
 	pool := NewSnapshotPool()
 	snap := pool.Get()

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -271,3 +271,16 @@ func TestSnapshotPool_PutClearsLeafGenerationRefs(t *testing.T) {
 		t.Fatalf("expected pooled snapshot refs backing array to be cleared")
 	}
 }
+
+func TestSnapshotReleaseLeafGenerationPins_ClearsRefBackingArray(t *testing.T) {
+	snap := &Snapshot{}
+	snap.leafGenerationRefs = append(snap.leafGenerationRefs, &leafGenerationPinRef{id: 1})
+	snap.releaseLeafGenerationPins()
+
+	if len(snap.leafGenerationRefs) != 0 {
+		t.Fatalf("expected leafGenerationRefs len=0 after release, got %d", len(snap.leafGenerationRefs))
+	}
+	if cap(snap.leafGenerationRefs) > 0 && snap.leafGenerationRefs[:1][0] != nil {
+		t.Fatalf("expected leafGenerationRefs backing array to be cleared on release")
+	}
+}

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -197,3 +197,25 @@ func TestAcquireSnapshot_DoesNotLeakLeafGenerationPinsOnRegistryNil(t *testing.T
 		t.Fatalf("pin count for generation 1=%d, want 0", got)
 	}
 }
+
+func TestLeafGenerationPinTracker_PrunesInactiveZeroCountRefs(t *testing.T) {
+	var tracker leafGenerationPinTracker
+
+	refs := tracker.refsForGenerationIDs([]uint64{1, 2, 3})
+	tracker.pinRefs(refs)
+	tracker.unpinRefs(refs)
+	tracker.pruneInactiveGenerationIDs([]uint64{1})
+
+	tracker.mu.RLock()
+	defer tracker.mu.RUnlock()
+
+	if _, ok := tracker.refs[1]; !ok {
+		t.Fatalf("expected active generation ref to be retained")
+	}
+	if _, ok := tracker.refs[2]; ok {
+		t.Fatalf("expected inactive zero-count ref for generation 2 to be pruned")
+	}
+	if _, ok := tracker.refs[3]; ok {
+		t.Fatalf("expected inactive zero-count ref for generation 3 to be pruned")
+	}
+}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2581,7 +2581,7 @@ func newRewriteWriter(walDir string, lane, startSeq uint32, maxSize int64) *rewr
 	return &rewriteWriter{walDir: walDir, lane: lane, seq: startSeq, maxSize: maxSize}
 }
 
-const rewriteLeafLogLaneID uint32 = 255
+const rewriteLeafLogLaneID uint32 = valuelog.ReservedLeafLogLaneID
 
 func (w *rewriteWriter) ConfigureLeafLog(leafDir string, lane, startSeq uint32) {
 	if w == nil {

--- a/TreeDB/internal/compression/metrics.go
+++ b/TreeDB/internal/compression/metrics.go
@@ -141,10 +141,6 @@ func (m *Metrics) finishLocked(reason string) {
 }
 
 func (m *Metrics) Reset(nextSlabID uint32) {
-	if !m.Enabled {
-		m.resetLocked(nextSlabID)
-		return
-	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.resetLocked(nextSlabID)

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -601,8 +601,10 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 			return
 		}
 		m.ordered = false
-		m.latestDirty = true
-		m.clearSnapshotLocked()
+		// Once order breaks, materialize the latest-key index immediately so
+		// subsequent unordered appends can maintain it incrementally instead of
+		// forcing the next iterator/lookup to rebuild the full map from scratch.
+		m.rebuildLatestIndexLocked()
 		return
 	}
 	if !m.latestDirty {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -601,9 +601,12 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 			return
 		}
 		m.ordered = false
-		// Once order breaks, materialize the latest-key index immediately so
-		// subsequent unordered appends can maintain it incrementally instead of
-		// forcing the next iterator/lookup to rebuild the full map from scratch.
+		// Once order breaks, invalidate the cached snapshot state and
+		// materialize the latest-key index immediately so subsequent unordered
+		// appends can maintain it incrementally instead of forcing the next
+		// iterator/lookup to rebuild the full map from scratch.
+		// rebuildLatestIndexLocked clears the cached snapshot as part of the
+		// transition.
 		m.rebuildLatestIndexLocked()
 		return
 	}

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -324,15 +324,15 @@ func TestAppendOnlyResetRetainedArenaBounded(t *testing.T) {
 	}
 }
 
-func TestAppendOnlyUnorderedAppendDefersLatestRebuild(t *testing.T) {
+func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	m.Set([]byte("b"), []byte("v1"))
 	m.Set([]byte("a"), []byte("v2")) // force unordered path
 	if m.ordered {
 		t.Fatalf("expected unordered memtable")
 	}
-	if !m.latestDirty {
-		t.Fatalf("expected latest index to be dirty after order break")
+	if m.latestDirty {
+		t.Fatalf("expected latest index to stay clean after order break")
 	}
 
 	it := m.NewIterator(nil, nil)
@@ -351,7 +351,7 @@ func TestAppendOnlyUnorderedAppendDefersLatestRebuild(t *testing.T) {
 
 	m.Set([]byte("b"), []byte("v3"))
 	if m.latestDirty {
-		t.Fatalf("expected unordered append to keep latest index clean after rebuild")
+		t.Fatalf("expected unordered append to keep latest index clean")
 	}
 	if m.snapCount != 0 {
 		t.Fatalf("expected snapshot invalidation after append; got snapCount=%d", m.snapCount)
@@ -391,8 +391,8 @@ func TestAppendOnlyUnorderedReverseIteratorDoesNotCacheSharedSnapshot(t *testing
 	if m.ordered {
 		t.Fatalf("expected unordered memtable")
 	}
-	if !m.latestDirty {
-		t.Fatalf("expected latest index to be dirty after order break")
+	if m.latestDirty {
+		t.Fatalf("expected latest index to stay clean after order break")
 	}
 
 	it := m.NewReverseIterator(nil, nil)
@@ -411,7 +411,7 @@ func TestAppendOnlyUnorderedReverseIteratorDoesNotCacheSharedSnapshot(t *testing
 
 	m.Set([]byte("b"), []byte("v3"))
 	if m.latestDirty {
-		t.Fatalf("expected unordered append to keep latest index clean after reverse rebuild")
+		t.Fatalf("expected unordered append to keep latest index clean")
 	}
 	if m.snapCount != 0 {
 		t.Fatalf("expected snapshot invalidation after append; got snapCount=%d", m.snapCount)

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -360,8 +360,8 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 			if ordered {
 				t.Fatalf("expected memtable to become unordered")
 			}
-			if !dirty {
-				t.Fatalf("expected latest index to start dirty")
+			if dirty {
+				t.Fatalf("expected latest index to stay clean after order break")
 			}
 
 			if got, del, ok := m.Get(lo); !ok || del || string(got) != "lo" {
@@ -373,7 +373,7 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 			latestSize := kk.latestSize(m)
 			m.mu.RUnlock()
 			if dirty {
-				t.Fatalf("expected point read to rebuild latest index (latestDirty=false)")
+				t.Fatalf("expected point read to keep latest index clean (latestDirty=false)")
 			}
 			if latestSize < 2 {
 				t.Fatalf("expected latest index to be populated, size=%d", latestSize)

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -363,6 +363,20 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 			if dirty {
 				t.Fatalf("expected latest index to stay clean after order break")
 			}
+			m.mu.RLock()
+			latestSizeBeforeGet := kk.latestSize(m)
+			idxBeforeGet, okBeforeGet := kk.latestIdx(m, lo)
+			countBeforeGet := m.count
+			m.mu.RUnlock()
+			if latestSizeBeforeGet < 2 {
+				t.Fatalf("expected latest index to be materialized on order break, size=%d", latestSizeBeforeGet)
+			}
+			if !okBeforeGet {
+				t.Fatalf("expected latest index lookup to succeed immediately after order break")
+			}
+			if idxBeforeGet != countBeforeGet-1 {
+				t.Fatalf("latest index before Get=%d want %d", idxBeforeGet, countBeforeGet-1)
+			}
 
 			if got, del, ok := m.Get(lo); !ok || del || string(got) != "lo" {
 				t.Fatalf("Get(lo) = (%q,%v,%v), want (lo,false,true)", string(got), del, ok)

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1261,7 +1261,7 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 			prev.remapMu.Lock()
 			prev.currentWritable.Store(false)
 			if data, _ := prev.mmapData.Load().([]byte); len(data) > 0 {
-				if m.allowDemotedCurrentMmapLocked(prev) {
+				if m.allowDemotedCurrentMmapLocked(prev, fileID) {
 					prev.sealedLazyMmapDenied.Store(false)
 					prev.sealedLazyMmapDeniedCountCap.Store(0)
 					prev.sealedLazyMmapDeniedBytesCap.Store(0)
@@ -1762,7 +1762,7 @@ func (m *Manager) allowSealedLazyMmapLocked(target *File, targetSize int64) (boo
 	return true, sealedLazyMmapDenyNone
 }
 
-func (m *Manager) allowDemotedCurrentMmapLocked(target *File) bool {
+func (m *Manager) allowDemotedCurrentMmapLocked(target *File, nextCurrentID uint32) bool {
 	if m == nil || target == nil {
 		return false
 	}
@@ -1779,7 +1779,7 @@ func (m *Manager) allowDemotedCurrentMmapLocked(target *File) bool {
 	mappedSealed := 0
 	var mappedSealedBytes uint64
 	for _, f := range m.files {
-		if f == nil || f.currentWritable.Load() {
+		if f == nil || f.ID == nextCurrentID || f.currentWritable.Load() {
 			continue
 		}
 		if isLeafLogFileID(f.ID) != targetIsLeaf {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1259,7 +1259,16 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 	if prevID, ok := m.currentWritableByLane[lane]; ok && prevID != 0 && prevID != fileID {
 		if prev := m.files[prevID]; prev != nil {
 			prev.currentWritable.Store(false)
-			prev.retirePersistentMmapToDead()
+			if data, _ := prev.mmapData.Load().([]byte); len(data) > 0 {
+				targetSize := prev.sealedLazyMmapTargetSize()
+				if allow, _ := m.allowSealedLazyMmapLocked(prev, targetSize); allow {
+					prev.sealedLazyMmapDenied.Store(false)
+					prev.sealedLazyMmapDeniedCountCap.Store(0)
+					prev.sealedLazyMmapDeniedBytesCap.Store(0)
+				} else {
+					prev.retirePersistentMmapToDead()
+				}
+			}
 		}
 	}
 	f.currentWritable.Store(true)

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1258,17 +1258,18 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 	}
 	if prevID, ok := m.currentWritableByLane[lane]; ok && prevID != 0 && prevID != fileID {
 		if prev := m.files[prevID]; prev != nil {
+			prev.remapMu.Lock()
 			prev.currentWritable.Store(false)
 			if data, _ := prev.mmapData.Load().([]byte); len(data) > 0 {
-				targetSize := prev.sealedLazyMmapTargetSize()
-				if allow, _ := m.allowSealedLazyMmapLocked(prev, targetSize); allow {
+				if m.allowDemotedCurrentMmapLocked(prev) {
 					prev.sealedLazyMmapDenied.Store(false)
 					prev.sealedLazyMmapDeniedCountCap.Store(0)
 					prev.sealedLazyMmapDeniedBytesCap.Store(0)
 				} else {
-					prev.retirePersistentMmapToDead()
+					prev.retirePersistentMmapToDeadLocked()
 				}
 			}
+			prev.remapMu.Unlock()
 		}
 	}
 	f.currentWritable.Store(true)
@@ -1759,6 +1760,45 @@ func (m *Manager) allowSealedLazyMmapLocked(target *File, targetSize int64) (boo
 		}
 	}
 	return true, sealedLazyMmapDenyNone
+}
+
+func (m *Manager) allowDemotedCurrentMmapLocked(target *File) bool {
+	if m == nil || target == nil {
+		return false
+	}
+	targetIsLeaf := isLeafLogFileID(target.ID)
+	maxSegments := MaxMappedSealedSegments
+	maxBytes := MaxMappedSealedBytes
+	if targetIsLeaf {
+		maxSegments = MaxMappedLeafSealedSegments
+		maxBytes = MaxMappedLeafSealedBytes
+	}
+	if maxSegments <= 0 {
+		return false
+	}
+	mappedSealed := 0
+	var mappedSealedBytes uint64
+	for _, f := range m.files {
+		if f == nil || f.currentWritable.Load() {
+			continue
+		}
+		if isLeafLogFileID(f.ID) != targetIsLeaf {
+			continue
+		}
+		data, _ := f.mmapData.Load().([]byte)
+		if len(data) == 0 {
+			continue
+		}
+		mappedSealed++
+		mappedSealedBytes += uint64(len(data))
+	}
+	if mappedSealed > maxSegments {
+		return false
+	}
+	if maxBytes > 0 && mappedSealedBytes > uint64(maxBytes) {
+		return false
+	}
+	return true
 }
 
 func (m *Manager) MmapReadStats() (hits uint64, missesOutOfRange uint64, missesNoMapping uint64, missesDeadMappingCap uint64, fallbacksReadAt uint64) {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1685,7 +1685,14 @@ func (m *Manager) allowSealedLazyMmapLocked(target *File, targetSize int64) (boo
 	if m == nil || target == nil {
 		return false, sealedLazyMmapDenyCountCap
 	}
-	if MaxMappedSealedSegments <= 0 {
+	targetIsLeaf := isLeafLogFileID(target.ID)
+	maxSegments := MaxMappedSealedSegments
+	maxBytes := MaxMappedSealedBytes
+	if targetIsLeaf {
+		maxSegments = MaxMappedLeafSealedSegments
+		maxBytes = MaxMappedLeafSealedBytes
+	}
+	if maxSegments <= 0 {
 		return false, sealedLazyMmapDenyCountCap
 	}
 	if target.currentWritable.Load() {
@@ -1699,16 +1706,19 @@ func (m *Manager) allowSealedLazyMmapLocked(target *File, targetSize int64) (boo
 		if f == nil || f.currentWritable.Load() {
 			continue
 		}
+		if isLeafLogFileID(f.ID) != targetIsLeaf {
+			continue
+		}
 		data, _ := f.mmapData.Load().([]byte)
 		if len(data) > 0 {
 			mappedSealed++
 			mappedSealedBytes += uint64(len(data))
-			if !targetMapped && mappedSealed >= MaxMappedSealedSegments {
+			if !targetMapped && mappedSealed >= maxSegments {
 				return false, sealedLazyMmapDenyCountCap
 			}
 		}
 	}
-	if MaxMappedSealedBytes > 0 {
+	if maxBytes > 0 {
 		targetBytes := uint64(targetSize)
 		if targetBytes == 0 {
 			if known := target.fileSize.Load(); known > 0 {
@@ -1721,7 +1731,7 @@ func (m *Manager) allowSealedLazyMmapLocked(target *File, targetSize int64) (boo
 			}
 		}
 		if targetBytes > 0 {
-			limit := uint64(MaxMappedSealedBytes)
+			limit := uint64(maxBytes)
 			if targetMapped {
 				currentBytes := uint64(len(targetData))
 				if targetBytes > currentBytes {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1259,6 +1259,7 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 	if prevID, ok := m.currentWritableByLane[lane]; ok && prevID != 0 && prevID != fileID {
 		if prev := m.files[prevID]; prev != nil {
 			prev.currentWritable.Store(false)
+			prev.retirePersistentMmapToDead()
 		}
 	}
 	f.currentWritable.Store(true)

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -621,6 +621,68 @@ func TestReadUnsafe_LeafLaneUsesLeafSealedMmapByteBudget(t *testing.T) {
 	}
 }
 
+func TestReadUnsafe_LeafLaneDenyCacheRechecksWhenLeafBudgetChanges(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	withMappedSealedBudget(t, 8)
+	withMappedSealedBytesBudget(t, 1<<30)
+	withMappedLeafSealedBudget(t, 8)
+	withMappedLeafSealedBytesBudget(t, 1)
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+
+	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile(f1): %v", err)
+	}
+	defer func() { _ = f1.Close() }()
+
+	f2, err := openFile(filepath.Join(dir, "value-l255-000002.log"), id2, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile(f2): %v", err)
+	}
+	defer func() { _ = f2.Close() }()
+
+	mgr := &Manager{
+		files:                 map[uint32]*File{id1: f1, id2: f2},
+		currentWritableByLane: make(map[uint32]uint32),
+	}
+	f1.manager = mgr
+	f2.manager = mgr
+
+	set := mgr.CurrentSetNoRefresh()
+	defer func() { _ = mgr.Release(set) }()
+
+	if got, err := set.ReadUnsafe(ptr1); err != nil {
+		t.Fatalf("ReadUnsafe(ptr1): %v", err)
+	} else if !bytes.Equal(got, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ptr1 mismatch")
+	}
+	if _, err := set.ReadUnsafe(ptr2); err != nil {
+		t.Fatalf("ReadUnsafe(ptr2 first): %v", err)
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) != 0 {
+		t.Fatalf("expected initial leaf-lane read to stay unmapped under tight leaf budget")
+	}
+	if got := f2.sealedMapDeniedByBytes.Load(); got == 0 {
+		t.Fatalf("expected leaf-lane byte-cap deny to increment")
+	}
+
+	MaxMappedLeafSealedBytes = 1 << 30
+
+	if got, err := set.ReadUnsafe(ptr2); err != nil {
+		t.Fatalf("ReadUnsafe(ptr2 second): %v", err)
+	} else if !bytes.Equal(got, bytes.Repeat([]byte("b"), 64)) {
+		t.Fatalf("ptr2 second mismatch")
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected leaf-lane deny cache to re-check after leaf budget change")
+	}
+}
+
 func TestReadUnsafe_SealedMappedOutOfRangeRemapsToKnownFileSize(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -445,6 +445,48 @@ func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallbac
 	}
 }
 
+func TestFileRemapToFileSizePersistentOnly_SkipsDemotedLeafSegment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	dir := t.TempDir()
+	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
+	path := filepath.Join(dir, "value-l255-000001.log")
+
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	if _, err := w.Append(0, nil, 1, bytes.Repeat([]byte("leaf"), 64)); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	f, err := openFile(path, fileID, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	mgr := &Manager{
+		files:                 map[uint32]*File{fileID: f},
+		currentWritableByLane: make(map[uint32]uint32),
+	}
+	f.manager = mgr
+	f.currentWritable.Store(true)
+	f.currentWritable.Store(false)
+
+	f.remapToFileSizePersistentOnly()
+
+	if data, _ := f.mmapData.Load().([]byte); len(data) != 0 {
+		t.Fatalf("expected demoted leaf segment to skip persistent-only remap, len=%d", len(data))
+	}
+}
+
 func TestFileRead_CountsDeadMappingCapFallback(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := EncodeFileID(0, 1)

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -537,6 +537,95 @@ func TestManagerPromoteCurrentWritable_KeepsLeafCurrentMmapWhenSealedBudgetAllow
 	}
 }
 
+func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlreadyFull(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	var files []*File
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMappedLeafSealedBudget(t, 1)
+	withMappedLeafSealedBytesBudget(t, 1<<20)
+	t.Cleanup(func() {
+		waitForRemapIdle(t, files...)
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+	id3, _ := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 3, 3, bytes.Repeat([]byte("c"), 64))
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	path1 := filepath.Join(dir, "value-l255-000001.log")
+	path2 := filepath.Join(dir, "value-l255-000002.log")
+	path3 := filepath.Join(dir, "value-l255-000003.log")
+	if err := mgr.RegisterSegment(path1, id1); err != nil {
+		t.Fatalf("RegisterSegment(path1): %v", err)
+	}
+	if err := mgr.RegisterSegment(path2, id2); err != nil {
+		t.Fatalf("RegisterSegment(path2): %v", err)
+	}
+	if err := mgr.RegisterSegment(path3, id3); err != nil {
+		t.Fatalf("RegisterSegment(path3): %v", err)
+	}
+
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr1); err != nil {
+		t.Fatalf("ReadUnsafe(ptr1 current): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(id2); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr2); err != nil {
+		t.Fatalf("ReadUnsafe(ptr2 current): %v", err)
+	}
+
+	f1 := mgr.files[id1]
+	f2 := mgr.files[id2]
+	f3 := mgr.files[id3]
+	files = []*File{f1, f2, f3}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected first sealed leaf segment to remain mapped while within budget")
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected second current leaf segment to be mapped before demotion")
+	}
+
+	if err := mgr.PromoteCurrentWritable(id3); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id3): %v", err)
+	}
+	if f2.currentWritable.Load() {
+		t.Fatalf("expected second segment to be sealed after promotion")
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) != 0 {
+		t.Fatalf("expected demoted second segment to retire active mmap once sealed budget is full, len=%d", len(data))
+	}
+	if dead := f2.deadMappingsCount.Load(); dead == 0 {
+		t.Fatalf("expected demoted second segment to move prior current mmap into deadMappings")
+	}
+	currentSegs, _, sealedSegs, _, deadMappings, _ := mgr.MmapResidencyStats()
+	if currentSegs != 0 {
+		t.Fatalf("expected new current segment to remain unmapped before any read, currentSegs=%d", currentSegs)
+	}
+	if sealedSegs != 1 {
+		t.Fatalf("expected sealed mmap count to stay capped at one, sealedSegs=%d", sealedSegs)
+	}
+	if deadMappings == 0 {
+		t.Fatalf("expected deadMappings to record the retired second segment")
+	}
+}
+
 func TestFileRemapToFileSizePersistentOnly_SkipsDemotedLeafSegment(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -56,7 +56,19 @@ func waitForRemapIdle(t *testing.T, files ...*File) {
 	for {
 		allIdle := true
 		for _, f := range files {
-			if f != nil && f.remapRequested.Load() {
+			if f == nil {
+				continue
+			}
+			if f.remapRequested.Load() {
+				allIdle = false
+				break
+			}
+			if !f.remapMu.TryLock() {
+				allIdle = false
+				break
+			}
+			f.remapMu.Unlock()
+			if f.remapRequested.Load() {
 				allIdle = false
 				break
 			}
@@ -67,8 +79,17 @@ func waitForRemapIdle(t *testing.T, files ...*File) {
 		if time.Now().After(deadline) {
 			t.Fatalf("timed out waiting for remap goroutine to drain")
 		}
-		time.Sleep(1 * time.Millisecond)
+		runtime.Gosched()
 	}
+}
+
+func withMaxDeadMappings(t *testing.T, max int) {
+	t.Helper()
+	prev := MaxDeadMappings
+	MaxDeadMappings = max
+	t.Cleanup(func() {
+		MaxDeadMappings = prev
+	})
 }
 
 func TestManagerMmapReadStatsAggregatesCounters(t *testing.T) {
@@ -306,7 +327,7 @@ func TestManagerReadUnsafe_CurrentWritableLeafUsesPersistentMmapByDefault(t *tes
 
 	dir := t.TempDir()
 	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
-	path := filepath.Join(dir, "value-l255-000001.log")
+	path := segmentPathForID(dir, fileID)
 
 	w, err := NewWriter(path, fileID)
 	if err != nil {
@@ -392,8 +413,8 @@ func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallbac
 	}
 	defer func() { _ = mgr.Close() }()
 
-	path1 := filepath.Join(dir, "value-l255-000001.log")
-	path2 := filepath.Join(dir, "value-l255-000002.log")
+	path1 := segmentPathForID(dir, id1)
+	path2 := segmentPathForID(dir, id2)
 	if err := mgr.RegisterSegment(path1, id1); err != nil {
 		t.Fatalf("RegisterSegment(path1): %v", err)
 	}
@@ -472,8 +493,8 @@ func TestManagerPromoteCurrentWritable_KeepsLeafCurrentMmapWhenSealedBudgetAllow
 	}
 	defer func() { _ = mgr.Close() }()
 
-	path1 := filepath.Join(dir, "value-l255-000001.log")
-	path2 := filepath.Join(dir, "value-l255-000002.log")
+	path1 := segmentPathForID(dir, id1)
+	path2 := segmentPathForID(dir, id2)
 	if err := mgr.RegisterSegment(path1, id1); err != nil {
 		t.Fatalf("RegisterSegment(path1): %v", err)
 	}
@@ -537,6 +558,74 @@ func TestManagerPromoteCurrentWritable_KeepsLeafCurrentMmapWhenSealedBudgetAllow
 	}
 }
 
+func TestManagerPromoteCurrentWritable_ExcludesNextCurrentFromSealedBudget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	var files []*File
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMappedLeafSealedBudget(t, 1)
+	withMappedLeafSealedBytesBudget(t, 1<<20)
+	t.Cleanup(func() {
+		waitForRemapIdle(t, files...)
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	if err := mgr.RegisterSegment(segmentPathForID(dir, id1), id1); err != nil {
+		t.Fatalf("RegisterSegment(id1): %v", err)
+	}
+	if err := mgr.RegisterSegment(segmentPathForID(dir, id2), id2); err != nil {
+		t.Fatalf("RegisterSegment(id2): %v", err)
+	}
+
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1 first): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr1); err != nil {
+		t.Fatalf("ReadUnsafe(ptr1): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(id2); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr2); err != nil {
+		t.Fatalf("ReadUnsafe(ptr2): %v", err)
+	}
+
+	f1 := mgr.files[id1]
+	f2 := mgr.files[id2]
+	files = []*File{f1, f2}
+
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1 second): %v", err)
+	}
+	if !f1.currentWritable.Load() {
+		t.Fatalf("expected id1 to become current again")
+	}
+	if f2.currentWritable.Load() {
+		t.Fatalf("expected id2 to be sealed after re-promotion")
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected demoted id2 mapping to stay active when the next current file is excluded from sealed budgeting")
+	}
+	if dead := f2.deadMappingsCount.Load(); dead != 0 {
+		t.Fatalf("expected no dead mapping duplication when re-promoting a mapped leaf segment, got=%d", dead)
+	}
+}
+
 func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlreadyFull(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")
@@ -565,9 +654,9 @@ func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlready
 	}
 	defer func() { _ = mgr.Close() }()
 
-	path1 := filepath.Join(dir, "value-l255-000001.log")
-	path2 := filepath.Join(dir, "value-l255-000002.log")
-	path3 := filepath.Join(dir, "value-l255-000003.log")
+	path1 := segmentPathForID(dir, id1)
+	path2 := segmentPathForID(dir, id2)
+	path3 := segmentPathForID(dir, id3)
 	if err := mgr.RegisterSegment(path1, id1); err != nil {
 		t.Fatalf("RegisterSegment(path1): %v", err)
 	}
@@ -626,6 +715,77 @@ func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlready
 	}
 }
 
+func TestManagerPromoteCurrentWritable_DeadMappingCapKeepsDemotedLeafMapped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	var files []*File
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMappedLeafSealedBudget(t, 1)
+	withMappedLeafSealedBytesBudget(t, 1<<20)
+	withMaxDeadMappings(t, 1)
+	t.Cleanup(func() {
+		waitForRemapIdle(t, files...)
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+	id3, _ := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 3, 3, bytes.Repeat([]byte("c"), 64))
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	for _, id := range []uint32{id1, id2, id3} {
+		if err := mgr.RegisterSegment(segmentPathForID(dir, id), id); err != nil {
+			t.Fatalf("RegisterSegment(%d): %v", id, err)
+		}
+	}
+
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr1); err != nil {
+		t.Fatalf("ReadUnsafe(ptr1): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(id2); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr2); err != nil {
+		t.Fatalf("ReadUnsafe(ptr2): %v", err)
+	}
+
+	f1 := mgr.files[id1]
+	f2 := mgr.files[id2]
+	f3 := mgr.files[id3]
+	files = []*File{f1, f2, f3}
+	var deadBefore uint64
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected id2 current mapping before saturating dead-mapping cap")
+	} else {
+		deadBefore = uint64(effectiveMaxDeadMappings(len(data)))
+		f2.deadMappingsCount.Store(deadBefore)
+	}
+
+	if err := mgr.PromoteCurrentWritable(id3); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id3): %v", err)
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected demoted id2 mapping to stay live once dead-mapping cap is exhausted")
+	}
+	if dead := f2.deadMappingsCount.Load(); dead != deadBefore {
+		t.Fatalf("expected demoted id2 to avoid growing dead mappings when cap is exhausted, before=%d after=%d", deadBefore, dead)
+	}
+}
+
 func TestFileRemapToFileSizePersistentOnly_SkipsDemotedLeafSegment(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")
@@ -633,7 +793,7 @@ func TestFileRemapToFileSizePersistentOnly_SkipsDemotedLeafSegment(t *testing.T)
 
 	dir := t.TempDir()
 	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
-	path := filepath.Join(dir, "value-l255-000001.log")
+	path := segmentPathForID(dir, fileID)
 
 	w, err := NewWriter(path, fileID)
 	if err != nil {

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -570,13 +570,13 @@ func TestReadUnsafe_LeafLaneUsesLeafSealedMmapByteBudget(t *testing.T) {
 	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
 	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
 
-	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
+	f1, err := openFile(segmentPathForID(dir, id1), id1, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
 		t.Fatalf("openFile(f1): %v", err)
 	}
 	defer func() { _ = f1.Close() }()
 
-	f2, err := openFile(filepath.Join(dir, "value-l255-000002.log"), id2, nil, nil, templ.DecodeOptions{}, nil)
+	f2, err := openFile(segmentPathForID(dir, id2), id2, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
 		t.Fatalf("openFile(f2): %v", err)
 	}
@@ -634,13 +634,13 @@ func TestReadUnsafe_LeafLaneDenyCacheRechecksWhenLeafBudgetChanges(t *testing.T)
 	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
 	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
 
-	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
+	f1, err := openFile(segmentPathForID(dir, id1), id1, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
 		t.Fatalf("openFile(f1): %v", err)
 	}
 	defer func() { _ = f1.Close() }()
 
-	f2, err := openFile(filepath.Join(dir, "value-l255-000002.log"), id2, nil, nil, templ.DecodeOptions{}, nil)
+	f2, err := openFile(segmentPathForID(dir, id2), id2, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
 		t.Fatalf("openFile(f2): %v", err)
 	}
@@ -808,6 +808,10 @@ func writeTestSegment(t *testing.T, dir string, lane, seq uint32, rid uint64, va
 	return fileID
 }
 
+func segmentPathForID(dir string, id uint32) string {
+	return (&Manager{dir: dir}).SegmentPath(id)
+}
+
 func TestManagerCurrentSetNoRefresh(t *testing.T) {
 	dir := t.TempDir()
 	seg1 := writeTestSegment(t, dir, 0, 1, 1, bytes.Repeat([]byte("a"), 64))
@@ -904,7 +908,7 @@ func TestManagerSegmentPath_UsesRegisteredPathFromExtraScanDir(t *testing.T) {
 		t.Fatalf("MkdirAll(leaf_vlog): %v", err)
 	}
 	segID := writeTestSegment(t, leafDir, 255, 1, 1, bytes.Repeat([]byte("l"), 64))
-	wantPath := filepath.Join(leafDir, "value-l255-000001.log")
+	wantPath := segmentPathForID(leafDir, segID)
 
 	mgr, err := NewManager(dir)
 	if err != nil {

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -341,6 +341,82 @@ func TestManagerReadUnsafe_CurrentWritableLeafUsesPersistentMmapByDefault(t *tes
 	}
 }
 
+func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMappedLeafSealedBudget(t, 0)
+	t.Cleanup(func() {
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, _ := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	path1 := filepath.Join(dir, "value-l255-000001.log")
+	path2 := filepath.Join(dir, "value-l255-000002.log")
+	if err := mgr.RegisterSegment(path1, id1); err != nil {
+		t.Fatalf("RegisterSegment(path1): %v", err)
+	}
+	if err := mgr.RegisterSegment(path2, id2); err != nil {
+		t.Fatalf("RegisterSegment(path2): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1): %v", err)
+	}
+	got, err := mgr.ReadUnsafe(ptr1)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr1 current): %v", err)
+	}
+	if !bytes.Equal(got, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ReadUnsafe(ptr1 current) mismatch")
+	}
+
+	f1 := mgr.files[id1]
+	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected current leaf segment to hold active mmap before promotion")
+	}
+
+	if err := mgr.PromoteCurrentWritable(id2); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
+	}
+	if f1.currentWritable.Load() {
+		t.Fatalf("expected prior leaf segment to be sealed after promotion")
+	}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) != 0 {
+		t.Fatalf("expected prior current leaf mmap to be retired after promotion, len=%d", len(data))
+	}
+	if dead := f1.deadMappingsCount.Load(); dead == 0 {
+		t.Fatalf("expected retired current leaf mapping to move into deadMappings")
+	}
+
+	got, err = mgr.ReadUnsafe(ptr1)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr1 sealed): %v", err)
+	}
+	if !bytes.Equal(got, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ReadUnsafe(ptr1 sealed) mismatch")
+	}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) != 0 {
+		t.Fatalf("expected sealed leaf read to respect zero sealed-map budget after promotion")
+	}
+	if got := f1.mmapReadFallbackReadAt.Load(); got == 0 {
+		t.Fatalf("expected sealed leaf read to fall back to ReadAt under zero sealed-map budget")
+	}
+}
+
 func TestFileRead_CountsDeadMappingCapFallback(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := EncodeFileID(0, 1)

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -567,8 +567,8 @@ func TestReadUnsafe_LeafLaneUsesLeafSealedMmapByteBudget(t *testing.T) {
 	withMappedLeafSealedBytesBudget(t, 1<<30)
 
 	dir := t.TempDir()
-	id1, ptr1 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
-	id2, ptr2 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
 
 	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {
@@ -631,8 +631,8 @@ func TestReadUnsafe_LeafLaneDenyCacheRechecksWhenLeafBudgetChanges(t *testing.T)
 	withMappedLeafSealedBytesBudget(t, 1)
 
 	dir := t.TempDir()
-	id1, ptr1 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
-	id2, ptr2 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
 
 	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
 	if err != nil {

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -267,6 +267,80 @@ func TestManagerReadUnsafe_CurrentWritableFallsBackWithoutPersistentMmap(t *test
 	}
 }
 
+func TestManagerReadUnsafe_CurrentWritableLeafUsesPersistentMmapByDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	t.Cleanup(func() {
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
+	path := filepath.Join(dir, "value-l255-000001.log")
+
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	want := bytes.Repeat([]byte("leaf"), 1024)
+	ptr, err := w.Append(0, nil, 1, want)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	if err := mgr.RegisterSegment(path, fileID); err != nil {
+		t.Fatalf("RegisterSegment: %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(fileID); err != nil {
+		t.Fatalf("PromoteCurrentWritable: %v", err)
+	}
+
+	got, err := mgr.ReadUnsafe(ptr)
+	if err != nil {
+		t.Fatalf("ReadUnsafe: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("ReadUnsafe mismatch")
+	}
+
+	f := mgr.files[fileID]
+	data, _ := f.mmapData.Load().([]byte)
+	if len(data) == 0 {
+		t.Fatalf("expected current leaf segment to install persistent mmap")
+	}
+	if remaps := f.remapCount.Load(); remaps == 0 {
+		t.Fatalf("expected current leaf segment remapCount > 0")
+	}
+	currentSegs, currentBytes, sealedSegs, sealedBytes, deadMappings, deadBytes := mgr.MmapResidencyStats()
+	if currentSegs != 1 || currentBytes == 0 {
+		t.Fatalf("expected one mapped current leaf segment, currentSegs=%d currentBytes=%d", currentSegs, currentBytes)
+	}
+	if sealedSegs != 0 || sealedBytes != 0 || deadMappings != 0 || deadBytes != 0 {
+		t.Fatalf("unexpected non-current residency sealedSegs=%d sealedBytes=%d deadMappings=%d deadBytes=%d", sealedSegs, sealedBytes, deadMappings, deadBytes)
+	}
+	hits, _, _, _, fallbacks := mgr.MmapReadStats()
+	if hits == 0 || fallbacks != 0 {
+		t.Fatalf("expected mmap hit without fallback, hits=%d fallbacks=%d", hits, fallbacks)
+	}
+}
+
 func TestFileRead_CountsDeadMappingCapFallback(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := EncodeFileID(0, 1)

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -445,6 +445,98 @@ func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallbac
 	}
 }
 
+func TestManagerPromoteCurrentWritable_KeepsLeafCurrentMmapWhenSealedBudgetAllows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	var files []*File
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMappedLeafSealedBudget(t, 1)
+	withMappedLeafSealedBytesBudget(t, 1<<20)
+	t.Cleanup(func() {
+		waitForRemapIdle(t, files...)
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, _ := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	path1 := filepath.Join(dir, "value-l255-000001.log")
+	path2 := filepath.Join(dir, "value-l255-000002.log")
+	if err := mgr.RegisterSegment(path1, id1); err != nil {
+		t.Fatalf("RegisterSegment(path1): %v", err)
+	}
+	if err := mgr.RegisterSegment(path2, id2); err != nil {
+		t.Fatalf("RegisterSegment(path2): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1): %v", err)
+	}
+	got, err := mgr.ReadUnsafe(ptr1)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr1 current): %v", err)
+	}
+	if !bytes.Equal(got, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ReadUnsafe(ptr1 current) mismatch")
+	}
+
+	f1 := mgr.files[id1]
+	f2 := mgr.files[id2]
+	files = []*File{f1, f2}
+	beforeRemaps := f1.remapCount.Load()
+	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected current leaf segment to hold active mmap before promotion")
+	}
+
+	if err := mgr.PromoteCurrentWritable(id2); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
+	}
+	if f1.currentWritable.Load() {
+		t.Fatalf("expected prior leaf segment to be sealed after promotion")
+	}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected prior current leaf mmap to remain active when sealed budget allows")
+	}
+	if dead := f1.deadMappingsCount.Load(); dead != 0 {
+		t.Fatalf("expected no dead mappings when sealed budget allows, got=%d", dead)
+	}
+
+	got, err = mgr.ReadUnsafe(ptr1)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr1 sealed): %v", err)
+	}
+	if !bytes.Equal(got, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ReadUnsafe(ptr1 sealed) mismatch")
+	}
+	if got := f1.mmapReadFallbackReadAt.Load(); got != 0 {
+		t.Fatalf("expected sealed leaf read to stay on mmap path, fallbacks=%d", got)
+	}
+	if remaps := f1.remapCount.Load(); remaps != beforeRemaps {
+		t.Fatalf("expected no extra remap for recently sealed leaf segment, before=%d after=%d", beforeRemaps, remaps)
+	}
+	currentSegs, currentBytes, sealedSegs, sealedBytes, deadMappings, deadBytes := mgr.MmapResidencyStats()
+	if currentSegs != 0 || currentBytes != 0 {
+		t.Fatalf("expected no mapped current segment before reading the new current file, currentSegs=%d currentBytes=%d", currentSegs, currentBytes)
+	}
+	if sealedSegs != 1 || sealedBytes == 0 {
+		t.Fatalf("expected one mapped sealed segment after promotion, sealedSegs=%d sealedBytes=%d", sealedSegs, sealedBytes)
+	}
+	if deadMappings != 0 || deadBytes != 0 {
+		t.Fatalf("expected no dead mapping duplication, deadMappings=%d deadBytes=%d", deadMappings, deadBytes)
+	}
+}
+
 func TestFileRemapToFileSizePersistentOnly_SkipsDemotedLeafSegment(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/page"
 	templ "github.com/snissn/gomap/TreeDB/template"
@@ -47,6 +48,27 @@ func withMappedLeafSealedBytesBudget(t *testing.T, maxMappedBytes int64) {
 	t.Cleanup(func() {
 		MaxMappedLeafSealedBytes = prev
 	})
+}
+
+func waitForRemapIdle(t *testing.T, files ...*File) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		allIdle := true
+		for _, f := range files {
+			if f != nil && f.remapRequested.Load() {
+				allIdle = false
+				break
+			}
+		}
+		if allIdle {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for remap goroutine to drain")
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
 }
 
 func TestManagerMmapReadStatsAggregatesCounters(t *testing.T) {
@@ -271,11 +293,13 @@ func TestManagerReadUnsafe_CurrentWritableLeafUsesPersistentMmapByDefault(t *tes
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")
 	}
+	var file *File
 	prevCurrent := enableCurrentWritableMmap
 	prevLeaf := enableCurrentLeafWritableMmap
 	enableCurrentWritableMmap = false
 	enableCurrentLeafWritableMmap = true
 	t.Cleanup(func() {
+		waitForRemapIdle(t, file)
 		enableCurrentWritableMmap = prevCurrent
 		enableCurrentLeafWritableMmap = prevLeaf
 	})
@@ -321,6 +345,7 @@ func TestManagerReadUnsafe_CurrentWritableLeafUsesPersistentMmapByDefault(t *tes
 	}
 
 	f := mgr.files[fileID]
+	file = f
 	data, _ := f.mmapData.Load().([]byte)
 	if len(data) == 0 {
 		t.Fatalf("expected current leaf segment to install persistent mmap")
@@ -345,12 +370,14 @@ func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallbac
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")
 	}
+	var files []*File
 	prevCurrent := enableCurrentWritableMmap
 	prevLeaf := enableCurrentLeafWritableMmap
 	enableCurrentWritableMmap = false
 	enableCurrentLeafWritableMmap = true
 	withMappedLeafSealedBudget(t, 0)
 	t.Cleanup(func() {
+		waitForRemapIdle(t, files...)
 		enableCurrentWritableMmap = prevCurrent
 		enableCurrentLeafWritableMmap = prevLeaf
 	})
@@ -385,6 +412,7 @@ func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallbac
 	}
 
 	f1 := mgr.files[id1]
+	files = []*File{f1, mgr.files[id2]}
 	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
 		t.Fatalf("expected current leaf segment to hold active mmap before promotion")
 	}

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -31,6 +31,24 @@ func withMappedSealedBytesBudget(t *testing.T, maxMappedBytes int64) {
 	})
 }
 
+func withMappedLeafSealedBudget(t *testing.T, maxMapped int) {
+	t.Helper()
+	prev := MaxMappedLeafSealedSegments
+	MaxMappedLeafSealedSegments = maxMapped
+	t.Cleanup(func() {
+		MaxMappedLeafSealedSegments = prev
+	})
+}
+
+func withMappedLeafSealedBytesBudget(t *testing.T, maxMappedBytes int64) {
+	t.Helper()
+	prev := MaxMappedLeafSealedBytes
+	MaxMappedLeafSealedBytes = maxMappedBytes
+	t.Cleanup(func() {
+		MaxMappedLeafSealedBytes = prev
+	})
+}
+
 func TestManagerMmapReadStatsAggregatesCounters(t *testing.T) {
 	mgr := &Manager{
 		files: map[uint32]*File{
@@ -536,6 +554,70 @@ func TestReadUnsafe_SealedLazyMmapByteBudgetFallsBackToReadAt(t *testing.T) {
 	}
 	if byCount, byBytes := mgr.SealedMapDeniedByReasonStats(); byCount != 0 || byBytes == 0 {
 		t.Fatalf("expected byte-cap deny aggregation, got count=%d bytes=%d", byCount, byBytes)
+	}
+}
+
+func TestReadUnsafe_LeafLaneUsesLeafSealedMmapByteBudget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	withMappedSealedBudget(t, 8)
+	withMappedSealedBytesBudget(t, 1)
+	withMappedLeafSealedBudget(t, 8)
+	withMappedLeafSealedBytesBudget(t, 1<<30)
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, ptr2 := writeTestSegmentWithPtr(t, dir, reservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+
+	f1, err := openFile(filepath.Join(dir, "value-l255-000001.log"), id1, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile(f1): %v", err)
+	}
+	defer func() { _ = f1.Close() }()
+
+	f2, err := openFile(filepath.Join(dir, "value-l255-000002.log"), id2, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile(f2): %v", err)
+	}
+	defer func() { _ = f2.Close() }()
+
+	mgr := &Manager{
+		files:                 map[uint32]*File{id1: f1, id2: f2},
+		currentWritableByLane: make(map[uint32]uint32),
+	}
+	f1.manager = mgr
+	f2.manager = mgr
+
+	set := mgr.CurrentSetNoRefresh()
+	defer func() { _ = mgr.Release(set) }()
+
+	got1, err := set.ReadUnsafe(ptr1)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr1): %v", err)
+	}
+	if !bytes.Equal(got1, bytes.Repeat([]byte("a"), 64)) {
+		t.Fatalf("ptr1 mismatch")
+	}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected first leaf-lane sealed segment to be mapped")
+	}
+
+	got2, err := set.ReadUnsafe(ptr2)
+	if err != nil {
+		t.Fatalf("ReadUnsafe(ptr2): %v", err)
+	}
+	if !bytes.Equal(got2, bytes.Repeat([]byte("b"), 64)) {
+		t.Fatalf("ptr2 mismatch")
+	}
+	if data, _ := f2.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected second leaf-lane sealed segment to be mapped under leaf budget")
+	}
+	if got := f2.mmapReadFallbackReadAt.Load(); got != 0 {
+		t.Fatalf("expected leaf-lane sealed mmap to avoid ReadAt fallback, got=%d", got)
+	}
+	if got := f2.sealedMapDeniedByBytes.Load(); got != 0 {
+		t.Fatalf("expected no leaf-lane byte-cap deny, got=%d", got)
 	}
 }
 

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -48,6 +48,7 @@ const (
 	maxDeadMappingsEnvKey           = "TREEDB_VLOG_MAX_DEAD_MAPPINGS"
 	enableAdaptiveCapEnvKey         = "TREEDB_VLOG_ADAPTIVE_DEAD_MAPPINGS"
 	enableCurrentWritableEnvKey     = "TREEDB_VLOG_ENABLE_CURRENT_WRITABLE_MMAP"
+	enableCurrentLeafWritableEnvKey = "TREEDB_VLOG_ENABLE_CURRENT_LEAF_WRITABLE_MMAP"
 	maxMappedSealedEnvKey           = "TREEDB_VLOG_MAX_MAPPED_SEALED_SEGMENTS"
 	maxMappedSealedBytesEnvKey      = "TREEDB_VLOG_MAX_MAPPED_SEALED_BYTES"
 	maxMappedLeafSealedEnvKey       = "TREEDB_VLOG_MAX_MAPPED_LEAF_SEALED_SEGMENTS"
@@ -60,13 +61,14 @@ const (
 )
 
 var (
-	maxDeadMappingsExplicit     bool
-	adaptiveDeadMappings              = defaultAdaptiveCapEnabled
-	enableCurrentWritableMmap         = false
-	MaxMappedSealedSegments           = defaultMaxMappedSealed
-	MaxMappedSealedBytes        int64 = defaultMaxMappedSealedBytes
-	MaxMappedLeafSealedSegments       = defaultMaxMappedLeafSealed
-	MaxMappedLeafSealedBytes    int64 = defaultMaxMappedLeafSealedBytes
+	maxDeadMappingsExplicit       bool
+	adaptiveDeadMappings                = defaultAdaptiveCapEnabled
+	enableCurrentWritableMmap           = false
+	enableCurrentLeafWritableMmap       = true
+	MaxMappedSealedSegments             = defaultMaxMappedSealed
+	MaxMappedSealedBytes          int64 = defaultMaxMappedSealedBytes
+	MaxMappedLeafSealedSegments         = defaultMaxMappedLeafSealed
+	MaxMappedLeafSealedBytes      int64 = defaultMaxMappedLeafSealedBytes
 )
 
 func init() {
@@ -90,6 +92,14 @@ func init() {
 			enableCurrentWritableMmap = false
 		case "1", "true", "on", "yes":
 			enableCurrentWritableMmap = true
+		}
+	}
+	if raw := strings.TrimSpace(os.Getenv(enableCurrentLeafWritableEnvKey)); raw != "" {
+		switch strings.ToLower(raw) {
+		case "0", "false", "off", "no":
+			enableCurrentLeafWritableMmap = false
+		case "1", "true", "on", "yes":
+			enableCurrentLeafWritableMmap = true
 		}
 	}
 	if raw := strings.TrimSpace(os.Getenv(maxMappedSealedEnvKey)); raw != "" {
@@ -117,6 +127,16 @@ func init() {
 func isLeafLogFileID(fileID uint32) bool {
 	lane, _ := DecodeFileID(fileID)
 	return lane == ReservedLeafLogLaneID
+}
+
+func (f *File) currentWritablePersistentMmapEnabled() bool {
+	if f == nil || !f.currentWritable.Load() {
+		return false
+	}
+	if enableCurrentWritableMmap {
+		return true
+	}
+	return enableCurrentLeafWritableMmap && isLeafLogFileID(f.ID)
 }
 
 func effectiveMaxDeadMappings(mappedLen int) int {
@@ -161,14 +181,14 @@ func (f *File) usesPersistentMmap() bool {
 	if f.manager == nil {
 		return true
 	}
-	return enableCurrentWritableMmap && f.currentWritable.Load()
+	return f.currentWritablePersistentMmapEnabled()
 }
 
 func (f *File) tryEnableSealedLazyMmap() bool {
 	if f == nil || f.closed.Load() || f.File == nil {
 		return false
 	}
-	if f.currentWritable.Load() && !enableCurrentWritableMmap {
+	if f.currentWritable.Load() && !f.currentWritablePersistentMmapEnabled() {
 		return false
 	}
 	if f.usesPersistentMmap() {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -182,10 +182,11 @@ func (f *File) tryEnableSealedLazyMmap() bool {
 		return false
 	}
 	if f.sealedLazyMmapDenied.Load() {
+		deniedCountCapWant, deniedBytesCapWant := f.sealedLazyMmapBudgetSnapshot()
 		deniedCountCap := int(f.sealedLazyMmapDeniedCountCap.Load())
 		deniedBytesCap := f.sealedLazyMmapDeniedBytesCap.Load()
 		// Preserve the cheap deny fast-path while budgets stay unchanged.
-		if deniedCountCap == MaxMappedSealedSegments && deniedBytesCap == MaxMappedSealedBytes {
+		if int64(deniedCountCap) == deniedCountCapWant && deniedBytesCap == deniedBytesCapWant {
 			return false
 		}
 		// Budgets changed; re-check once to allow in-process recovery.
@@ -194,8 +195,7 @@ func (f *File) tryEnableSealedLazyMmap() bool {
 		allow, _ := m.allowSealedLazyMmapLocked(f, targetSize)
 		m.mu.Unlock()
 		if !allow {
-			f.sealedLazyMmapDeniedCountCap.Store(int64(MaxMappedSealedSegments))
-			f.sealedLazyMmapDeniedBytesCap.Store(MaxMappedSealedBytes)
+			f.storeSealedLazyMmapBudgetSnapshot()
 			return false
 		}
 		f.sealedLazyMmapDenied.Store(false)
@@ -212,8 +212,7 @@ func (f *File) tryEnableSealedLazyMmap() bool {
 		m.mu.Unlock()
 		if !allow {
 			f.sealedLazyMmapDenied.Store(true)
-			f.sealedLazyMmapDeniedCountCap.Store(int64(MaxMappedSealedSegments))
-			f.sealedLazyMmapDeniedBytesCap.Store(MaxMappedSealedBytes)
+			f.storeSealedLazyMmapBudgetSnapshot()
 			switch denyReason {
 			case sealedLazyMmapDenyCountCap:
 				f.sealedMapDeniedByCount.Add(1)
@@ -234,8 +233,7 @@ func (f *File) tryEnableSealedLazyMmap() bool {
 	m.mu.Unlock()
 	if !allow {
 		f.sealedLazyMmapDenied.Store(true)
-		f.sealedLazyMmapDeniedCountCap.Store(int64(MaxMappedSealedSegments))
-		f.sealedLazyMmapDeniedBytesCap.Store(MaxMappedSealedBytes)
+		f.storeSealedLazyMmapBudgetSnapshot()
 		switch denyReason {
 		case sealedLazyMmapDenyCountCap:
 			f.sealedMapDeniedByCount.Add(1)
@@ -252,6 +250,19 @@ func (f *File) tryEnableSealedLazyMmap() bool {
 	f.remapToFileSize()
 	data, _ := f.mmapData.Load().([]byte)
 	return len(data) > 0
+}
+
+func (f *File) sealedLazyMmapBudgetSnapshot() (countCap int64, bytesCap int64) {
+	if f != nil && isLeafLogFileID(f.ID) {
+		return int64(MaxMappedLeafSealedSegments), MaxMappedLeafSealedBytes
+	}
+	return int64(MaxMappedSealedSegments), MaxMappedSealedBytes
+}
+
+func (f *File) storeSealedLazyMmapBudgetSnapshot() {
+	countCap, bytesCap := f.sealedLazyMmapBudgetSnapshot()
+	f.sealedLazyMmapDeniedCountCap.Store(countCap)
+	f.sealedLazyMmapDeniedBytesCap.Store(bytesCap)
 }
 
 func (f *File) sealedLazyMmapTargetSize() int64 {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -335,10 +335,7 @@ func (f *File) maybeScheduleRemap() {
 	}
 	go func() {
 		defer f.remapRequested.Store(false)
-		if !f.usesPersistentMmap() {
-			return
-		}
-		f.remapToFileSize()
+		f.remapToFileSizePersistentOnly()
 	}()
 }
 
@@ -366,7 +363,15 @@ func (f *File) tryRefreshMmapRange(start, end int64) ([]byte, bool) {
 	return data, true
 }
 
+func (f *File) remapToFileSizePersistentOnly() {
+	f.remapToFileSizeWithPolicy(true)
+}
+
 func (f *File) remapToFileSize() {
+	f.remapToFileSizeWithPolicy(false)
+}
+
+func (f *File) remapToFileSizeWithPolicy(requirePersistent bool) {
 	if f == nil || f.closed.Load() || f.File == nil {
 		return
 	}
@@ -374,6 +379,9 @@ func (f *File) remapToFileSize() {
 	f.remapMu.Lock()
 	defer f.remapMu.Unlock()
 	if f.closed.Load() || f.File == nil {
+		return
+	}
+	if requirePersistent && !f.usesPersistentMmap() {
 		return
 	}
 	// If we have already hit the dead-mapping cap, we cannot remap again without

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -42,25 +42,32 @@ const readViaMmapViewPrefixCacheEnabled = false
 var MaxDeadMappings = defaultMaxDeadMappings
 
 const (
-	defaultMaxDeadMappings      = 64
-	maxAdaptiveDeadMappings     = 4096
-	deadMappingBytesPerStep     = 256 << 10 // increase cap by 1 per 256KiB mapped
-	maxDeadMappingsEnvKey       = "TREEDB_VLOG_MAX_DEAD_MAPPINGS"
-	enableAdaptiveCapEnvKey     = "TREEDB_VLOG_ADAPTIVE_DEAD_MAPPINGS"
-	enableCurrentWritableEnvKey = "TREEDB_VLOG_ENABLE_CURRENT_WRITABLE_MMAP"
-	maxMappedSealedEnvKey       = "TREEDB_VLOG_MAX_MAPPED_SEALED_SEGMENTS"
-	maxMappedSealedBytesEnvKey  = "TREEDB_VLOG_MAX_MAPPED_SEALED_BYTES"
-	defaultAdaptiveCapEnabled   = true
-	defaultMaxMappedSealed      = 8
-	defaultMaxMappedSealedBytes = 64 << 20
+	defaultMaxDeadMappings          = 64
+	maxAdaptiveDeadMappings         = 4096
+	deadMappingBytesPerStep         = 256 << 10 // increase cap by 1 per 256KiB mapped
+	maxDeadMappingsEnvKey           = "TREEDB_VLOG_MAX_DEAD_MAPPINGS"
+	enableAdaptiveCapEnvKey         = "TREEDB_VLOG_ADAPTIVE_DEAD_MAPPINGS"
+	enableCurrentWritableEnvKey     = "TREEDB_VLOG_ENABLE_CURRENT_WRITABLE_MMAP"
+	maxMappedSealedEnvKey           = "TREEDB_VLOG_MAX_MAPPED_SEALED_SEGMENTS"
+	maxMappedSealedBytesEnvKey      = "TREEDB_VLOG_MAX_MAPPED_SEALED_BYTES"
+	maxMappedLeafSealedEnvKey       = "TREEDB_VLOG_MAX_MAPPED_LEAF_SEALED_SEGMENTS"
+	maxMappedLeafBytesEnvKey        = "TREEDB_VLOG_MAX_MAPPED_LEAF_SEALED_BYTES"
+	defaultAdaptiveCapEnabled       = true
+	defaultMaxMappedSealed          = 8
+	defaultMaxMappedSealedBytes     = 64 << 20
+	defaultMaxMappedLeafSealed      = 64
+	defaultMaxMappedLeafSealedBytes = 1 << 30
+	reservedLeafLogLaneID           = 255
 )
 
 var (
-	maxDeadMappingsExplicit   bool
-	adaptiveDeadMappings            = defaultAdaptiveCapEnabled
-	enableCurrentWritableMmap       = false
-	MaxMappedSealedSegments         = defaultMaxMappedSealed
-	MaxMappedSealedBytes      int64 = defaultMaxMappedSealedBytes
+	maxDeadMappingsExplicit     bool
+	adaptiveDeadMappings              = defaultAdaptiveCapEnabled
+	enableCurrentWritableMmap         = false
+	MaxMappedSealedSegments           = defaultMaxMappedSealed
+	MaxMappedSealedBytes        int64 = defaultMaxMappedSealedBytes
+	MaxMappedLeafSealedSegments       = defaultMaxMappedLeafSealed
+	MaxMappedLeafSealedBytes    int64 = defaultMaxMappedLeafSealedBytes
 )
 
 func init() {
@@ -96,6 +103,21 @@ func init() {
 			MaxMappedSealedBytes = v
 		}
 	}
+	if raw := strings.TrimSpace(os.Getenv(maxMappedLeafSealedEnvKey)); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
+			MaxMappedLeafSealedSegments = v
+		}
+	}
+	if raw := strings.TrimSpace(os.Getenv(maxMappedLeafBytesEnvKey)); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v >= 0 {
+			MaxMappedLeafSealedBytes = v
+		}
+	}
+}
+
+func isLeafLogFileID(fileID uint32) bool {
+	lane, _ := DecodeFileID(fileID)
+	return lane == reservedLeafLogLaneID
 }
 
 func effectiveMaxDeadMappings(mappedLen int) int {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -300,6 +300,23 @@ func (f *File) sealedLazyMmapTargetSize() int64 {
 	return targetSize
 }
 
+func (f *File) retirePersistentMmapToDead() {
+	if f == nil {
+		return
+	}
+	f.remapMu.Lock()
+	defer f.remapMu.Unlock()
+
+	data, _ := f.mmapData.Load().([]byte)
+	if len(data) == 0 {
+		return
+	}
+	f.deadMappings = append(f.deadMappings, data)
+	f.deadMappingsCount.Add(1)
+	f.deadMappedBytes.Add(uint64(len(data)))
+	f.mmapData.Store([]byte(nil))
+}
+
 func (f *File) maybeScheduleRemap() {
 	if f == nil || f.closed.Load() || !f.usesPersistentMmap() {
 		return
@@ -318,6 +335,9 @@ func (f *File) maybeScheduleRemap() {
 	}
 	go func() {
 		defer f.remapRequested.Store(false)
+		if !f.usesPersistentMmap() {
+			return
+		}
 		f.remapToFileSize()
 	}()
 }

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -55,9 +55,8 @@ const (
 	defaultAdaptiveCapEnabled       = true
 	defaultMaxMappedSealed          = 8
 	defaultMaxMappedSealedBytes     = 64 << 20
-	defaultMaxMappedLeafSealed      = 64
-	defaultMaxMappedLeafSealedBytes = 1 << 30
-	reservedLeafLogLaneID           = 255
+	defaultMaxMappedLeafSealed      = defaultMaxMappedSealed * 4
+	defaultMaxMappedLeafSealedBytes = defaultMaxMappedSealedBytes * 4
 )
 
 var (
@@ -117,7 +116,7 @@ func init() {
 
 func isLeafLogFileID(fileID uint32) bool {
 	lane, _ := DecodeFileID(fileID)
-	return lane == reservedLeafLogLaneID
+	return lane == ReservedLeafLogLaneID
 }
 
 func effectiveMaxDeadMappings(mappedLen int) int {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -309,18 +309,25 @@ func (f *File) retirePersistentMmapToDead() {
 	f.retirePersistentMmapToDeadLocked()
 }
 
-func (f *File) retirePersistentMmapToDeadLocked() {
+func (f *File) retirePersistentMmapToDeadLocked() bool {
 	if f == nil {
-		return
+		return false
 	}
 	data, _ := f.mmapData.Load().([]byte)
 	if len(data) == 0 {
-		return
+		return false
+	}
+	if deadMappingsCapExhausted(f.deadMappingsCount.Load(), len(data)) {
+		// Keep the existing mapping live as a sealed mapping once the dead-mapping
+		// budget is exhausted. That preserves reader safety without allowing the
+		// dead-mapping list to grow without bound.
+		return false
 	}
 	f.deadMappings = append(f.deadMappings, data)
 	f.deadMappingsCount.Add(1)
 	f.deadMappedBytes.Add(uint64(len(data)))
 	f.mmapData.Store([]byte(nil))
+	return true
 }
 
 func (f *File) maybeScheduleRemap() {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -306,7 +306,13 @@ func (f *File) retirePersistentMmapToDead() {
 	}
 	f.remapMu.Lock()
 	defer f.remapMu.Unlock()
+	f.retirePersistentMmapToDeadLocked()
+}
 
+func (f *File) retirePersistentMmapToDeadLocked() {
+	if f == nil {
+		return
+	}
 	data, _ := f.mmapData.Load().([]byte)
 	if len(data) == 0 {
 		return

--- a/TreeDB/internal/valuelog/segment_id.go
+++ b/TreeDB/internal/valuelog/segment_id.go
@@ -12,6 +12,8 @@ const (
 
 	maxLaneID     = (1 << laneBits) - 1
 	maxSegmentSeq = (1 << seqBits) - 1
+	// ReservedLeafLogLaneID is the dedicated lane used for outer-leaf storage.
+	ReservedLeafLogLaneID = maxLaneID
 )
 
 var ErrSegmentIDRange = errors.New("valuelog: segment id out of range")

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -205,10 +205,10 @@ type BenchRun struct {
 }
 
 type treeDBPerfMetrics struct {
-	Mmap                  treeDBMmapPerfMetrics     `json:"mmap,omitempty"`
-	Snapshot              treeDBSnapshotPerfMetrics `json:"snapshot,omitempty"`
-	LeafGenerationsPinned int64                     `json:"leaf_generations_pinned,omitempty"`
-	LeafPinsTotal         int64                     `json:"leaf_pins_total,omitempty"`
+	Mmap                       treeDBMmapPerfMetrics     `json:"mmap,omitempty"`
+	Snapshot                   treeDBSnapshotPerfMetrics `json:"snapshot,omitempty"`
+	LeafGenerationsPinnedAfter int64                     `json:"leaf_generations_pinned_after,omitempty"`
+	LeafPinsTotalAfter         int64                     `json:"leaf_pins_total_after,omitempty"`
 }
 
 type treeDBMmapPerfMetrics struct {
@@ -245,11 +245,10 @@ type benchprofExport struct {
 }
 
 type benchprofExportRun struct {
-	Keys        int                                     `json:"keys"`
-	Profile     string                                  `json:"profile,omitempty"`
-	Results     map[string]map[string]float64           `json:"results,omitempty"`
-	TreeDBPerf  map[string]map[string]treeDBPerfMetrics `json:"treedb_perf,omitempty"`
-	TreeDBStats map[string]map[string]string            `json:"treedb_stats,omitempty"`
+	Keys       int                                     `json:"keys"`
+	Profile    string                                  `json:"profile,omitempty"`
+	Results    map[string]map[string]float64           `json:"results,omitempty"`
+	TreeDBPerf map[string]map[string]treeDBPerfMetrics `json:"treedb_perf,omitempty"`
 }
 
 type scanDiag struct {
@@ -1054,11 +1053,10 @@ func writeBenchprofArtifacts(dir string, runs []BenchRun) error {
 	}
 	for _, run := range runs {
 		out.Runs = append(out.Runs, benchprofExportRun{
-			Keys:        run.Config.Keys,
-			Profile:     strings.TrimSpace(run.Config.Profile),
-			Results:     run.Results,
-			TreeDBPerf:  run.TreeDBPerf,
-			TreeDBStats: run.TreeDBStats,
+			Keys:       run.Config.Keys,
+			Profile:    strings.TrimSpace(run.Config.Profile),
+			Results:    run.Results,
+			TreeDBPerf: run.TreeDBPerf,
 		})
 	}
 
@@ -1754,15 +1752,15 @@ func snapshotSelectedTreeDBStats(db kvstore.DB) treeDBSelectedStats {
 func computeTreeDBPerfMetrics(before, after treeDBSelectedStats, snapshot treeDBSnapshotPerfMetrics) treeDBPerfMetrics {
 	m := treeDBPerfMetrics{
 		Mmap: treeDBMmapPerfMetrics{
-			Hits:           after.mmapHits - before.mmapHits,
-			MissOutOfRange: after.mmapMissOutOfRange - before.mmapMissOutOfRange,
-			MissNoMapping:  after.mmapMissNoMapping - before.mmapMissNoMapping,
-			MissDeadMapCap: after.mmapMissDeadCap - before.mmapMissDeadCap,
-			FallbackReadAt: after.mmapFallbackReadAt - before.mmapFallbackReadAt,
+			Hits:           saturatingUint64Delta(after.mmapHits, before.mmapHits),
+			MissOutOfRange: saturatingUint64Delta(after.mmapMissOutOfRange, before.mmapMissOutOfRange),
+			MissNoMapping:  saturatingUint64Delta(after.mmapMissNoMapping, before.mmapMissNoMapping),
+			MissDeadMapCap: saturatingUint64Delta(after.mmapMissDeadCap, before.mmapMissDeadCap),
+			FallbackReadAt: saturatingUint64Delta(after.mmapFallbackReadAt, before.mmapFallbackReadAt),
 		},
-		Snapshot:              snapshot,
-		LeafGenerationsPinned: after.leafGenerationsPin,
-		LeafPinsTotal:         after.leafPinsTotal,
+		Snapshot:                   snapshot,
+		LeafGenerationsPinnedAfter: after.leafGenerationsPin,
+		LeafPinsTotalAfter:         after.leafPinsTotal,
 	}
 	totalReads := m.Mmap.Hits + m.Mmap.FallbackReadAt
 	if totalReads > 0 {
@@ -1777,6 +1775,13 @@ func computeTreeDBPerfMetrics(before, after treeDBSelectedStats, snapshot treeDB
 	return m
 }
 
+func saturatingUint64Delta(after, before uint64) uint64 {
+	if after < before {
+		return 0
+	}
+	return after - before
+}
+
 func treeDBPerfMetricsEmpty(m treeDBPerfMetrics) bool {
 	return m.Mmap.Hits == 0 &&
 		m.Mmap.MissOutOfRange == 0 &&
@@ -1788,8 +1793,8 @@ func treeDBPerfMetricsEmpty(m treeDBPerfMetrics) bool {
 		m.Snapshot.AcquireTotalNanos == 0 &&
 		m.Snapshot.CloseCalls == 0 &&
 		m.Snapshot.CloseTotalNanos == 0 &&
-		m.LeafGenerationsPinned == 0 &&
-		m.LeafPinsTotal == 0
+		m.LeafGenerationsPinnedAfter == 0 &&
+		m.LeafPinsTotalAfter == 0
 }
 
 func (p *periodicCheckpoint) Add(db kvstore.DB, opsDelta int, bytesDelta int64) error {
@@ -4725,8 +4730,8 @@ func renderTreeDBPerfString(instances []*DBInstance, finalTestOrder []string, di
 				))
 			}
 			sb.WriteString(fmt.Sprintf("  leaf_generation.generations.pinned.after=%d leaf_generation.pins.total.after=%d\n",
-				m.LeafGenerationsPinned,
-				m.LeafPinsTotal,
+				m.LeafGenerationsPinnedAfter,
+				m.LeafPinsTotalAfter,
 			))
 		}
 		if wroteHeader {

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -199,8 +199,44 @@ type BenchRun struct {
 	VacuumIndexBytes    map[string]map[string][2]uint64 // [0]=before, [1]=after (best-effort; treedb only)
 	TreeDBDiskUsage     map[string]treeDBDiskUsage
 	TreeDBVlogRewrite   map[string]treeDBVlogRewriteReport
+	TreeDBPerf          map[string]map[string]treeDBPerfMetrics
 	TreeDBStats         map[string]map[string]string
 	DiskUsage           map[string]dirDiskUsage
+}
+
+type treeDBPerfMetrics struct {
+	Mmap                  treeDBMmapPerfMetrics     `json:"mmap,omitempty"`
+	Snapshot              treeDBSnapshotPerfMetrics `json:"snapshot,omitempty"`
+	LeafGenerationsPinned int64                     `json:"leaf_generations_pinned,omitempty"`
+	LeafPinsTotal         int64                     `json:"leaf_pins_total,omitempty"`
+}
+
+type treeDBMmapPerfMetrics struct {
+	Hits           uint64  `json:"hits,omitempty"`
+	MissOutOfRange uint64  `json:"miss_out_of_range,omitempty"`
+	MissNoMapping  uint64  `json:"miss_no_mapping,omitempty"`
+	MissDeadMapCap uint64  `json:"miss_dead_mapping_cap,omitempty"`
+	FallbackReadAt uint64  `json:"fallback_readat,omitempty"`
+	HitRatio       float64 `json:"hit_ratio,omitempty"`
+}
+
+type treeDBSnapshotPerfMetrics struct {
+	AcquireCalls      uint64  `json:"acquire_calls,omitempty"`
+	AcquireTotalNanos uint64  `json:"acquire_total_nanos,omitempty"`
+	AcquireAvgMicros  float64 `json:"acquire_avg_micros,omitempty"`
+	CloseCalls        uint64  `json:"close_calls,omitempty"`
+	CloseTotalNanos   uint64  `json:"close_total_nanos,omitempty"`
+	CloseAvgMicros    float64 `json:"close_avg_micros,omitempty"`
+}
+
+type treeDBSelectedStats struct {
+	mmapHits           uint64
+	mmapMissOutOfRange uint64
+	mmapMissNoMapping  uint64
+	mmapMissDeadCap    uint64
+	mmapFallbackReadAt uint64
+	leafGenerationsPin int64
+	leafPinsTotal      int64
 }
 
 type benchprofExport struct {
@@ -209,9 +245,11 @@ type benchprofExport struct {
 }
 
 type benchprofExportRun struct {
-	Keys    int                           `json:"keys"`
-	Profile string                        `json:"profile,omitempty"`
-	Results map[string]map[string]float64 `json:"results,omitempty"`
+	Keys        int                                     `json:"keys"`
+	Profile     string                                  `json:"profile,omitempty"`
+	Results     map[string]map[string]float64           `json:"results,omitempty"`
+	TreeDBPerf  map[string]map[string]treeDBPerfMetrics `json:"treedb_perf,omitempty"`
+	TreeDBStats map[string]map[string]string            `json:"treedb_stats,omitempty"`
 }
 
 type scanDiag struct {
@@ -1016,9 +1054,11 @@ func writeBenchprofArtifacts(dir string, runs []BenchRun) error {
 	}
 	for _, run := range runs {
 		out.Runs = append(out.Runs, benchprofExportRun{
-			Keys:    run.Config.Keys,
-			Profile: strings.TrimSpace(run.Config.Profile),
-			Results: run.Results,
+			Keys:        run.Config.Keys,
+			Profile:     strings.TrimSpace(run.Config.Profile),
+			Results:     run.Results,
+			TreeDBPerf:  run.TreeDBPerf,
+			TreeDBStats: run.TreeDBStats,
 		})
 	}
 
@@ -1645,6 +1685,113 @@ func newPeriodicCheckpoint(cfg BenchConfig) *periodicCheckpoint {
 	}
 }
 
+func parseUint64StatValue(stats map[string]string, keys ...string) (uint64, bool) {
+	if stats == nil {
+		return 0, false
+	}
+	for _, key := range keys {
+		raw, ok := stats[key]
+		if !ok {
+			continue
+		}
+		v, err := strconv.ParseUint(strings.TrimSpace(raw), 10, 64)
+		if err == nil {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func parseInt64StatValue(stats map[string]string, keys ...string) (int64, bool) {
+	if stats == nil {
+		return 0, false
+	}
+	for _, key := range keys {
+		raw, ok := stats[key]
+		if !ok {
+			continue
+		}
+		v, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+		if err == nil {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func snapshotSelectedTreeDBStats(db kvstore.DB) treeDBSelectedStats {
+	sp, ok := db.(kvstore.StatsProvider)
+	if !ok {
+		return treeDBSelectedStats{}
+	}
+	stats := sp.Stats()
+	var snap treeDBSelectedStats
+	snap.mmapHits, _ = parseUint64StatValue(stats,
+		"treedb.cache.vlog_mmap.read.hits",
+		"treedb.vlog.mmap_read.hits",
+	)
+	snap.mmapMissOutOfRange, _ = parseUint64StatValue(stats,
+		"treedb.cache.vlog_mmap.read.miss_out_of_range",
+		"treedb.vlog.mmap_read.miss_out_of_range",
+	)
+	snap.mmapMissNoMapping, _ = parseUint64StatValue(stats,
+		"treedb.cache.vlog_mmap.read.miss_no_mapping",
+		"treedb.vlog.mmap_read.miss_no_mapping",
+	)
+	snap.mmapMissDeadCap, _ = parseUint64StatValue(stats,
+		"treedb.cache.vlog_mmap.read.miss_dead_mapping_cap",
+		"treedb.vlog.mmap_read.miss_dead_mapping_cap",
+	)
+	snap.mmapFallbackReadAt, _ = parseUint64StatValue(stats,
+		"treedb.cache.vlog_mmap.read.fallback_readat",
+		"treedb.vlog.mmap_read.fallback_readat",
+	)
+	snap.leafGenerationsPin, _ = parseInt64StatValue(stats, "treedb.leaf_generation.generations.pinned")
+	snap.leafPinsTotal, _ = parseInt64StatValue(stats, "treedb.leaf_generation.pins.total")
+	return snap
+}
+
+func computeTreeDBPerfMetrics(before, after treeDBSelectedStats, snapshot treeDBSnapshotPerfMetrics) treeDBPerfMetrics {
+	m := treeDBPerfMetrics{
+		Mmap: treeDBMmapPerfMetrics{
+			Hits:           after.mmapHits - before.mmapHits,
+			MissOutOfRange: after.mmapMissOutOfRange - before.mmapMissOutOfRange,
+			MissNoMapping:  after.mmapMissNoMapping - before.mmapMissNoMapping,
+			MissDeadMapCap: after.mmapMissDeadCap - before.mmapMissDeadCap,
+			FallbackReadAt: after.mmapFallbackReadAt - before.mmapFallbackReadAt,
+		},
+		Snapshot:              snapshot,
+		LeafGenerationsPinned: after.leafGenerationsPin,
+		LeafPinsTotal:         after.leafPinsTotal,
+	}
+	totalReads := m.Mmap.Hits + m.Mmap.FallbackReadAt
+	if totalReads > 0 {
+		m.Mmap.HitRatio = float64(m.Mmap.Hits) / float64(totalReads)
+	}
+	if m.Snapshot.AcquireCalls > 0 {
+		m.Snapshot.AcquireAvgMicros = float64(m.Snapshot.AcquireTotalNanos) / float64(m.Snapshot.AcquireCalls) / 1_000.0
+	}
+	if m.Snapshot.CloseCalls > 0 {
+		m.Snapshot.CloseAvgMicros = float64(m.Snapshot.CloseTotalNanos) / float64(m.Snapshot.CloseCalls) / 1_000.0
+	}
+	return m
+}
+
+func treeDBPerfMetricsEmpty(m treeDBPerfMetrics) bool {
+	return m.Mmap.Hits == 0 &&
+		m.Mmap.MissOutOfRange == 0 &&
+		m.Mmap.MissNoMapping == 0 &&
+		m.Mmap.MissDeadMapCap == 0 &&
+		m.Mmap.FallbackReadAt == 0 &&
+		m.Mmap.HitRatio == 0 &&
+		m.Snapshot.AcquireCalls == 0 &&
+		m.Snapshot.AcquireTotalNanos == 0 &&
+		m.Snapshot.CloseCalls == 0 &&
+		m.Snapshot.CloseTotalNanos == 0 &&
+		m.LeafGenerationsPinned == 0 &&
+		m.LeafPinsTotal == 0
+}
+
 func (p *periodicCheckpoint) Add(db kvstore.DB, opsDelta int, bytesDelta int64) error {
 	if p == nil {
 		return nil
@@ -1747,6 +1894,8 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	checkpointDurations := make(map[string]map[string]time.Duration)
 	vacuumDurations := make(map[string]map[string]time.Duration)
 	vacuumIndexBytes := make(map[string]map[string][2]uint64)
+	treeDBPerf := make(map[string]map[string]treeDBPerfMetrics)
+	snapshotPerfByTest := make(map[string]map[string]treeDBSnapshotPerfMetrics)
 
 	// dataset_write_* mirrors op-geth's Write1M when -keys=1_000_000 and -valsize=32 (32B keys).
 	datasetKeySize := 32
@@ -2122,6 +2271,20 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			}
 		}
 		return float64(total) / time.Since(start).Seconds(), nil
+	}
+	recordSnapshotPerf := func(testName string, db kvstore.DB, perf treeDBSnapshotPerfMetrics) {
+		if db == nil {
+			return
+		}
+		if perf.AcquireCalls == 0 && perf.CloseCalls == 0 {
+			return
+		}
+		perDB := snapshotPerfByTest[testName]
+		if perDB == nil {
+			perDB = make(map[string]treeDBSnapshotPerfMetrics)
+			snapshotPerfByTest[testName] = perDB
+		}
+		perDB[db.Name()] = perf
 	}
 	testFuncs := map[string]TestFunc{
 		"vacuum_index": func(db kvstore.DB, _ *rand.Rand) (float64, error) {
@@ -2806,6 +2969,10 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				GetAppend(key, dst []byte) ([]byte, error)
 			})
 			baseSeed := testSeed(cfg.SeedUsed, "random_read_parallel")
+			var snapshotAcquireCalls atomic.Uint64
+			var snapshotAcquireNanos atomic.Uint64
+			var snapshotCloseCalls atomic.Uint64
+			var snapshotCloseNanos atomic.Uint64
 
 			runWorker := func(workerRng *rand.Rand, stop *atomic.Bool) error {
 				getter := interface {
@@ -2814,14 +2981,23 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				workerAppendGetter := appendGetter
 				var closeSnapshot func() error
 				if hasSnapshotter {
+					acquireStarted := time.Now()
 					snap, err := snapshotter.AcquireReadSnapshot()
 					if err != nil && !errors.Is(err, kvstore.ErrUnsupported) {
 						return err
 					}
 					if err == nil {
+						snapshotAcquireCalls.Add(1)
+						snapshotAcquireNanos.Add(uint64(time.Since(acquireStarted)))
 						getter = snap
 						workerAppendGetter = snap
-						closeSnapshot = snap.Close
+						closeSnapshot = func() error {
+							closeStarted := time.Now()
+							err := snap.Close()
+							snapshotCloseCalls.Add(1)
+							snapshotCloseNanos.Add(uint64(time.Since(closeStarted)))
+							return err
+						}
 					} else if !hasAppendGetter {
 						workerAppendGetter = nil
 					}
@@ -2874,6 +3050,12 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if err := runWorker(rng, nil); err != nil {
 					return 0, fmt.Errorf("random_read_parallel: %w", err)
 				}
+				recordSnapshotPerf("random_read_parallel", db, treeDBSnapshotPerfMetrics{
+					AcquireCalls:      snapshotAcquireCalls.Load(),
+					AcquireTotalNanos: snapshotAcquireNanos.Load(),
+					CloseCalls:        snapshotCloseCalls.Load(),
+					CloseTotalNanos:   snapshotCloseNanos.Load(),
+				})
 				return float64(cfg.Keys) / time.Since(start).Seconds(), nil
 			}
 
@@ -2903,6 +3085,12 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				return 0, fmt.Errorf("random_read_parallel: %w", err)
 			default:
 			}
+			recordSnapshotPerf("random_read_parallel", db, treeDBSnapshotPerfMetrics{
+				AcquireCalls:      snapshotAcquireCalls.Load(),
+				AcquireTotalNanos: snapshotAcquireNanos.Load(),
+				CloseCalls:        snapshotCloseCalls.Load(),
+				CloseTotalNanos:   snapshotCloseNanos.Load(),
+			})
 			totalOps := float64(cfg.Keys) * float64(workers)
 			return totalOps / time.Since(start).Seconds(), nil
 		},
@@ -2933,6 +3121,10 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				return 0, fmt.Errorf("random_read_parallel_acquire_snapshot probe close: %w", err)
 			}
 			baseSeed := testSeed(cfg.SeedUsed, "random_read_parallel_acquire_snapshot")
+			var snapshotAcquireCalls atomic.Uint64
+			var snapshotAcquireNanos atomic.Uint64
+			var snapshotCloseCalls atomic.Uint64
+			var snapshotCloseNanos atomic.Uint64
 
 			runWorker := func(workerRng *rand.Rand, stop *atomic.Bool) error {
 				var k [8]byte
@@ -2948,12 +3140,18 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					}
 					encodeKey(k[:], uint64(workerRng.Intn(cfg.Keys)))
 
+					acquireStarted := time.Now()
 					snap, err := snapshotter.AcquireReadSnapshot()
 					if err != nil {
 						return err
 					}
+					snapshotAcquireCalls.Add(1)
+					snapshotAcquireNanos.Add(uint64(time.Since(acquireStarted)))
 					nextBuf, getErr := snap.GetAppend(k[:], buf[:0])
+					closeStarted := time.Now()
 					closeErr := snap.Close()
+					snapshotCloseCalls.Add(1)
+					snapshotCloseNanos.Add(uint64(time.Since(closeStarted)))
 					if closeErr != nil {
 						return fmt.Errorf("random_read_parallel_acquire_snapshot close: %w", closeErr)
 					}
@@ -2981,6 +3179,12 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if err := runWorker(rng, nil); err != nil {
 					return 0, fmt.Errorf("random_read_parallel_acquire_snapshot: %w", err)
 				}
+				recordSnapshotPerf("random_read_parallel_acquire_snapshot", db, treeDBSnapshotPerfMetrics{
+					AcquireCalls:      snapshotAcquireCalls.Load(),
+					AcquireTotalNanos: snapshotAcquireNanos.Load(),
+					CloseCalls:        snapshotCloseCalls.Load(),
+					CloseTotalNanos:   snapshotCloseNanos.Load(),
+				})
 				return float64(cfg.Keys) / time.Since(start).Seconds(), nil
 			}
 
@@ -3010,6 +3214,12 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				return 0, fmt.Errorf("random_read_parallel_acquire_snapshot: %w", err)
 			default:
 			}
+			recordSnapshotPerf("random_read_parallel_acquire_snapshot", db, treeDBSnapshotPerfMetrics{
+				AcquireCalls:      snapshotAcquireCalls.Load(),
+				AcquireTotalNanos: snapshotAcquireNanos.Load(),
+				CloseCalls:        snapshotCloseCalls.Load(),
+				CloseTotalNanos:   snapshotCloseNanos.Load(),
+			})
 			totalOps := float64(cfg.Keys) * float64(workers)
 			return totalOps / time.Since(start).Seconds(), nil
 		},
@@ -3645,6 +3855,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				return BenchRun{}, err
 			}
 
+			var treeStatsBefore treeDBSelectedStats
+			if isTreeDBInstance(inst) {
+				treeStatsBefore = snapshotSelectedTreeDBStats(inst.Wrapper)
+			}
+
 			// Create a fresh PRNG for each DB so they get the same sequence
 			rng := rand.New(rand.NewSource(seed))
 
@@ -3793,6 +4008,20 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				return BenchRun{}, fmt.Errorf("test %s on %s: %w", testName, inst.Name, runErr)
 			}
 
+			if isTreeDBInstance(inst) {
+				treeStatsAfter := snapshotSelectedTreeDBStats(inst.Wrapper)
+				snapshotPerf := snapshotPerfByTest[testName][inst.Wrapper.Name()]
+				metrics := computeTreeDBPerfMetrics(treeStatsBefore, treeStatsAfter, snapshotPerf)
+				if !treeDBPerfMetricsEmpty(metrics) {
+					perDB := treeDBPerf[testName]
+					if perDB == nil {
+						perDB = make(map[string]treeDBPerfMetrics)
+						treeDBPerf[testName] = perDB
+					}
+					perDB[inst.Wrapper.Name()] = metrics
+				}
+			}
+
 			results[testName][inst.Wrapper.Name()] = opsPerSec
 
 			// Update live table cell
@@ -3922,6 +4151,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		VacuumIndexBytes:    vacuumIndexBytes,
 		TreeDBDiskUsage:     treedbDisk,
 		TreeDBVlogRewrite:   treedbRewrite,
+		TreeDBPerf:          treeDBPerf,
 		TreeDBStats:         treedbStats,
 		DiskUsage:           diskUsage,
 	}, nil
@@ -4413,6 +4643,20 @@ func renderMarkdownSingle(run BenchRun) string {
 		sb.WriteString(renderTreeDBVlogRewriteString(run.TreeDBVlogRewrite))
 		sb.WriteString("```\n")
 	}
+	if perf := strings.TrimSpace(renderTreeDBPerfString(run.Instances, run.TestOrder, run.DisplayNames, run.TreeDBPerf)); perf != "" {
+		sb.WriteString("\n")
+		sb.WriteString("## TreeDB Perf Instrumentation\n\n")
+		sb.WriteString("```text\n")
+		sb.WriteString(perf)
+		sb.WriteString("\n```\n")
+	}
+	if stats := strings.TrimSpace(renderTreeDBSelectedStatsString(run.Instances, run.TreeDBStats)); stats != "" {
+		sb.WriteString("\n")
+		sb.WriteString("## TreeDB Selected Stats (End of Run)\n\n")
+		sb.WriteString("```text\n")
+		sb.WriteString(stats)
+		sb.WriteString("\n```\n")
+	}
 	if run.Config.KeepDir {
 		if kept := strings.TrimSpace(renderKeptDirsString(run.Instances)); kept != "" {
 			sb.WriteString("\n")
@@ -4423,6 +4667,118 @@ func renderMarkdownSingle(run BenchRun) string {
 		}
 	}
 	return sb.String()
+}
+
+func renderTreeDBPerfString(instances []*DBInstance, finalTestOrder []string, displayNames map[string]string, perf map[string]map[string]treeDBPerfMetrics) string {
+	if len(perf) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, testName := range finalTestOrder {
+		perDB := perf[testName]
+		if len(perDB) == 0 {
+			continue
+		}
+		label := displayNames[testName]
+		if strings.TrimSpace(label) == "" {
+			label = testName
+		}
+		wroteHeader := false
+		for _, inst := range instances {
+			if inst == nil || inst.Wrapper == nil {
+				continue
+			}
+			dbName := inst.Wrapper.Name()
+			m, ok := perDB[dbName]
+			if !ok || treeDBPerfMetricsEmpty(m) {
+				continue
+			}
+			if wroteHeader {
+				sb.WriteByte('\n')
+			}
+			wroteHeader = true
+			sb.WriteString(label)
+			sb.WriteString(" / ")
+			sb.WriteString(dbName)
+			sb.WriteByte('\n')
+			if m.Snapshot.AcquireCalls > 0 || m.Snapshot.CloseCalls > 0 {
+				sb.WriteString(fmt.Sprintf("  snapshot.acquire.calls=%d total_ms=%.3f avg_us=%.3f\n",
+					m.Snapshot.AcquireCalls,
+					float64(m.Snapshot.AcquireTotalNanos)/1_000_000.0,
+					m.Snapshot.AcquireAvgMicros,
+				))
+				sb.WriteString(fmt.Sprintf("  snapshot.close.calls=%d total_ms=%.3f avg_us=%.3f\n",
+					m.Snapshot.CloseCalls,
+					float64(m.Snapshot.CloseTotalNanos)/1_000_000.0,
+					m.Snapshot.CloseAvgMicros,
+				))
+			}
+			mmapTotal := m.Mmap.Hits + m.Mmap.FallbackReadAt
+			if mmapTotal > 0 || m.Mmap.MissOutOfRange > 0 || m.Mmap.MissNoMapping > 0 || m.Mmap.MissDeadMapCap > 0 {
+				sb.WriteString(fmt.Sprintf("  vlog_mmap.read.hits.delta=%d miss_out_of_range.delta=%d miss_no_mapping.delta=%d miss_dead_mapping_cap.delta=%d fallback_readat.delta=%d hit_ratio.delta=%.6f\n",
+					m.Mmap.Hits,
+					m.Mmap.MissOutOfRange,
+					m.Mmap.MissNoMapping,
+					m.Mmap.MissDeadMapCap,
+					m.Mmap.FallbackReadAt,
+					m.Mmap.HitRatio,
+				))
+			}
+			sb.WriteString(fmt.Sprintf("  leaf_generation.generations.pinned.after=%d leaf_generation.pins.total.after=%d\n",
+				m.LeafGenerationsPinned,
+				m.LeafPinsTotal,
+			))
+		}
+		if wroteHeader {
+			sb.WriteByte('\n')
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func renderTreeDBSelectedStatsString(instances []*DBInstance, treeStats map[string]map[string]string) string {
+	if len(treeStats) == 0 {
+		return ""
+	}
+	keys := []struct {
+		label string
+		alts  []string
+	}{
+		{label: "vlog_mmap.read.hits", alts: []string{"treedb.cache.vlog_mmap.read.hits", "treedb.vlog.mmap_read.hits"}},
+		{label: "vlog_mmap.read.miss_out_of_range", alts: []string{"treedb.cache.vlog_mmap.read.miss_out_of_range", "treedb.vlog.mmap_read.miss_out_of_range"}},
+		{label: "vlog_mmap.read.miss_no_mapping", alts: []string{"treedb.cache.vlog_mmap.read.miss_no_mapping", "treedb.vlog.mmap_read.miss_no_mapping"}},
+		{label: "vlog_mmap.read.miss_dead_mapping_cap", alts: []string{"treedb.cache.vlog_mmap.read.miss_dead_mapping_cap", "treedb.vlog.mmap_read.miss_dead_mapping_cap"}},
+		{label: "vlog_mmap.read.fallback_readat", alts: []string{"treedb.cache.vlog_mmap.read.fallback_readat", "treedb.vlog.mmap_read.fallback_readat"}},
+		{label: "vlog_mmap.read.hit_ratio", alts: []string{"treedb.cache.vlog_mmap.read.hit_ratio", "treedb.vlog.mmap_read.hit_ratio"}},
+		{label: "leaf_generation.generations.pinned", alts: []string{"treedb.leaf_generation.generations.pinned"}},
+		{label: "leaf_generation.pins.total", alts: []string{"treedb.leaf_generation.pins.total"}},
+	}
+	var sb strings.Builder
+	for _, inst := range instances {
+		if inst == nil || inst.Wrapper == nil {
+			continue
+		}
+		dbName := inst.Wrapper.Name()
+		stats := treeStats[dbName]
+		if len(stats) == 0 {
+			continue
+		}
+		sb.WriteString(dbName)
+		sb.WriteString(":\n")
+		for _, key := range keys {
+			for _, alt := range key.alts {
+				if value, ok := stats[alt]; ok {
+					sb.WriteString("  ")
+					sb.WriteString(key.label)
+					sb.WriteString(": ")
+					sb.WriteString(value)
+					sb.WriteByte('\n')
+					break
+				}
+			}
+		}
+	}
+	return strings.TrimSpace(sb.String())
 }
 
 func renderMarkdownSweep(runs []BenchRun) string {

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1197,8 +1197,8 @@ func TestRenderMarkdownSingle_IncludesTreeDBPerfSections(t *testing.T) {
 						CloseTotalNanos:   12_000,
 						CloseAvgMicros:    3,
 					},
-					LeafGenerationsPinned: 1,
-					LeafPinsTotal:         4,
+					LeafGenerationsPinnedAfter: 1,
+					LeafPinsTotalAfter:         4,
 				},
 			},
 		},
@@ -1350,8 +1350,56 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 	if got := parsed.Runs[0].TreeDBPerf["full_scan"]["TreeDB"].Mmap.Hits; got != 10 {
 		t.Fatalf("unexpected TreeDB perf mmap hits: %v", got)
 	}
-	if got := parsed.Runs[0].TreeDBStats["TreeDB"]["treedb.cache.vlog_mmap.read.hits"]; got != "10" {
-		t.Fatalf("unexpected TreeDB stats value: %v", got)
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw json: %v", err)
+	}
+	runsValue, ok := raw["runs"].([]any)
+	if !ok || len(runsValue) != 1 {
+		t.Fatalf("expected 1 raw run in json, got %#v", raw["runs"])
+	}
+	runValue, ok := runsValue[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected raw run object, got %#v", runsValue[0])
+	}
+	if _, ok := runValue["treedb_stats"]; ok {
+		t.Fatalf("expected treedb_stats to be omitted from benchprof json, got: %#v", runValue["treedb_stats"])
+	}
+}
+
+func TestComputeTreeDBPerfMetrics_SaturatesCounterRegression(t *testing.T) {
+	metrics := computeTreeDBPerfMetrics(
+		treeDBSelectedStats{
+			mmapHits:           11,
+			mmapMissOutOfRange: 13,
+			mmapMissNoMapping:  17,
+			mmapMissDeadCap:    19,
+			mmapFallbackReadAt: 23,
+			leafGenerationsPin: 5,
+			leafPinsTotal:      7,
+		},
+		treeDBSelectedStats{
+			mmapHits:           3,
+			mmapMissOutOfRange: 2,
+			mmapMissNoMapping:  1,
+			mmapMissDeadCap:    18,
+			mmapFallbackReadAt: 4,
+			leafGenerationsPin: 2,
+			leafPinsTotal:      9,
+		},
+		treeDBSnapshotPerfMetrics{},
+	)
+	if metrics.Mmap.Hits != 0 || metrics.Mmap.MissOutOfRange != 0 || metrics.Mmap.MissNoMapping != 0 || metrics.Mmap.FallbackReadAt != 0 {
+		t.Fatalf("expected saturating mmap deltas, got %+v", metrics.Mmap)
+	}
+	if metrics.Mmap.MissDeadMapCap != 0 {
+		t.Fatalf("expected saturating dead-map delta, got %d", metrics.Mmap.MissDeadMapCap)
+	}
+	if metrics.LeafGenerationsPinnedAfter != 2 {
+		t.Fatalf("expected after-value leaf generations pinned, got %d", metrics.LeafGenerationsPinnedAfter)
+	}
+	if metrics.LeafPinsTotalAfter != 9 {
+		t.Fatalf("expected after-value leaf pins total, got %d", metrics.LeafPinsTotalAfter)
 	}
 }
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -533,6 +533,45 @@ func TestRunBenchmark_RandomReadParallelAcquireSnapshot_UsesSnapshots(t *testing
 	}
 }
 
+func TestRunBenchmark_TreeDBPerfCapturesSnapshotMetrics(t *testing.T) {
+	run, err := runBenchmark(BenchConfig{
+		Keys:         256,
+		ValueSize:    16,
+		BatchSize:    64,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       "treedb",
+		TestsArg:     "sequential_write,random_read_parallel_acquire_snapshot",
+		KeepDir:      false,
+		Progress:     false,
+		ReadWorkers:  4,
+		SeedUsed:     1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	perTest, ok := run.TreeDBPerf["random_read_parallel_acquire_snapshot"]
+	if !ok {
+		t.Fatalf("expected TreeDB perf entry for snapshot benchmark")
+	}
+	perf, ok := perTest["TreeDB"]
+	if !ok {
+		t.Fatalf("expected TreeDB perf metrics for snapshot benchmark")
+	}
+	if perf.Snapshot.AcquireCalls == 0 {
+		t.Fatalf("expected snapshot acquire calls > 0, got 0")
+	}
+	if perf.Snapshot.CloseCalls == 0 {
+		t.Fatalf("expected snapshot close calls > 0, got 0")
+	}
+	if perf.Snapshot.AcquireTotalNanos == 0 {
+		t.Fatalf("expected snapshot acquire time > 0")
+	}
+	if perf.Snapshot.CloseTotalNanos == 0 {
+		t.Fatalf("expected snapshot close time > 0")
+	}
+}
+
 func TestNormalizeTests_ReadRandomBatchAliases(t *testing.T) {
 	got := normalizeTests(parseList("read_rand_batch,read_random_batch,random_read_batch"))
 	want := []string{"random_read_batch"}
@@ -1122,6 +1161,75 @@ func TestRenderMarkdownSingle_KeepDirIncludesKeptSection(t *testing.T) {
 	}
 }
 
+func TestRenderMarkdownSingle_IncludesTreeDBPerfSections(t *testing.T) {
+	run := BenchRun{
+		Config: BenchConfig{
+			Keys:      100,
+			ValueSize: 16,
+			BatchSize: 10,
+		},
+		Instances: []*DBInstance{
+			{Name: "treedb", Wrapper: &fixedNameDB{name: "TreeDB"}, Dir: "/tmp/bench-treedb"},
+		},
+		TestOrder: []string{"random_read_parallel_acquire_snapshot"},
+		DisplayNames: map[string]string{
+			"random_read_parallel_acquire_snapshot": "Random Read (Parallel, Snapshot Per Key)",
+		},
+		Results: map[string]map[string]float64{
+			"random_read_parallel_acquire_snapshot": {
+				"TreeDB": 1234,
+			},
+		},
+		TreeDBPerf: map[string]map[string]treeDBPerfMetrics{
+			"random_read_parallel_acquire_snapshot": {
+				"TreeDB": {
+					Mmap: treeDBMmapPerfMetrics{
+						Hits:           7,
+						MissNoMapping:  2,
+						FallbackReadAt: 3,
+						HitRatio:       0.7,
+					},
+					Snapshot: treeDBSnapshotPerfMetrics{
+						AcquireCalls:      4,
+						AcquireTotalNanos: 8_000,
+						AcquireAvgMicros:  2,
+						CloseCalls:        4,
+						CloseTotalNanos:   12_000,
+						CloseAvgMicros:    3,
+					},
+					LeafGenerationsPinned: 1,
+					LeafPinsTotal:         4,
+				},
+			},
+		},
+		TreeDBStats: map[string]map[string]string{
+			"TreeDB": {
+				"treedb.cache.vlog_mmap.read.hits":          "7",
+				"treedb.cache.vlog_mmap.read.hit_ratio":     "0.700000",
+				"treedb.leaf_generation.generations.pinned": "1",
+				"treedb.leaf_generation.pins.total":         "4",
+			},
+		},
+	}
+
+	md := renderMarkdownSingle(run)
+	if !strings.Contains(md, "## TreeDB Perf Instrumentation") {
+		t.Fatalf("expected TreeDB perf section, got:\n%s", md)
+	}
+	if !strings.Contains(md, "snapshot.acquire.calls=4") {
+		t.Fatalf("expected snapshot metrics in markdown, got:\n%s", md)
+	}
+	if !strings.Contains(md, "vlog_mmap.read.hits.delta=7") {
+		t.Fatalf("expected mmap metrics in markdown, got:\n%s", md)
+	}
+	if !strings.Contains(md, "## TreeDB Selected Stats (End of Run)") {
+		t.Fatalf("expected TreeDB selected stats section, got:\n%s", md)
+	}
+	if !strings.Contains(md, "leaf_generation.pins.total: 4") {
+		t.Fatalf("expected selected stats in markdown, got:\n%s", md)
+	}
+}
+
 func TestRenderMarkdownSweep_KeepDirIncludesKeptSection(t *testing.T) {
 	makeRun := func(keys int, dir string) BenchRun {
 		return BenchRun{
@@ -1197,6 +1305,18 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 					"TreeDB": 1200,
 				},
 			},
+			TreeDBPerf: map[string]map[string]treeDBPerfMetrics{
+				"full_scan": {
+					"TreeDB": {
+						Mmap: treeDBMmapPerfMetrics{Hits: 10, FallbackReadAt: 2, HitRatio: 0.833333},
+					},
+				},
+			},
+			TreeDBStats: map[string]map[string]string{
+				"TreeDB": {
+					"treedb.cache.vlog_mmap.read.hits": "10",
+				},
+			},
 		},
 	}
 
@@ -1226,6 +1346,12 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 	}
 	if got := parsed.Runs[0].Results["full_scan"]["TreeDB"]; got != 1000 {
 		t.Fatalf("unexpected full_scan value: %v", got)
+	}
+	if got := parsed.Runs[0].TreeDBPerf["full_scan"]["TreeDB"].Mmap.Hits; got != 10 {
+		t.Fatalf("unexpected TreeDB perf mmap hits: %v", got)
+	}
+	if got := parsed.Runs[0].TreeDBStats["TreeDB"]["treedb.cache.vlog_mmap.read.hits"]; got != "10" {
+		t.Fatalf("unexpected TreeDB stats value: %v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- switch steady flush paths to use backend `SetView` / `DeleteView` for inline puts and tombstones when the backend batch supports view-based writes
- add regression coverage that exercises both serial and parallel flush paths and proves the backend copy methods are bypassed
- materialize append-only latest-key indexes immediately on first order break so unordered immutable memtables do not defer a full rebuild to the first flush iterator

## Why
The steady flush path was still re-copying inline keys and values into backend batches even after the caching layer already had stable views. That showed up as heavy batch arena churn and unnecessary allocator pressure in `Batch Write (Steady)`.

The append-only memtable also deferred latest-index construction until the first unordered iterator. On this workload that pushes one full rebuild per disordered immutable memtable into the flush path.

## Validation
- `GOWORK=off go test ./TreeDB/caching ./TreeDB/internal/memtable -count=1`
- `./bin/unified-bench -dbs treedb -keys 1000000 -profile-dir /home/mikers/tmp/runprof-1776386659` (baseline provided by user)
- `./bin/unified-bench -dbs treedb -keys 1000000 -profile-dir /home/mikers/tmp/runprof-1776387082`
- `./bin/unified-bench -dbs treedb -keys 1000000 -profile-dir /home/mikers/tmp/runprof-1776387849`
- `./bin/unified-bench -dbs treedb -keys 1000000 -profile-dir /home/mikers/tmp/runprof-1776387899`

## Results
Baseline `Batch Write (Steady)` from `/home/mikers/tmp/runprof-1776386659`: `401,414 ops/s`

Current branch exact reruns:
- `/home/mikers/tmp/runprof-1776387849`: `453,001 ops/s`
- `/home/mikers/tmp/runprof-1776387899`: `447,493 ops/s`

That keeps the branch materially above the baseline while avoiding the slower direct-iterator merge experiment that was evaluated and discarded locally.
