### PR TITLE
[codex] TreeDB: improve leaf-pack maintenance selection

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -22838,6 +22838,7 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 				MinReclaimPerByteCopiedPPM: minReclaimPerByteCopiedPPM,
 				MaxGenerations:             remainingGenerations,
 				MaxBytesToCopy:             remainingBytesToCopy,
+				ReserveRIDs:                db.ReserveValueLogRIDs,
 			})
 			if runErr != nil {
 				return runErr

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1966,6 +1966,42 @@ func TestLeafGenerationPackMaintenance_RunsWithDefaultBounds(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationPackMaintenance_PassesReserveRIDs(t *testing.T) {
+	t.Setenv(envEnableLeafGenerationPackMaintenance, "1")
+	recorder := &leafPackMaintenanceRecordingBackend{
+		DB:   mustOpenLeafPackBackend(t),
+		resp: leafPackWindowExhaustingStats(7, 1024, 4096),
+	}
+	db, cleanup := openLeafPackMaintenanceTestDB(t, recorder)
+	defer cleanup()
+
+	attempted, ran, err := db.maybeRunLeafGenerationPackMaintenance(false, true, leafGenerationPackMaintenanceAdmission{allowed: true}, vlogGenerationMaintenanceOptions{skipCheckpoint: true})
+	if err != nil {
+		t.Fatalf("maybeRunLeafGenerationPackMaintenance: %v", err)
+	}
+	if !attempted || !ran {
+		t.Fatalf("attempted=%t ran=%t want true/true", attempted, ran)
+	}
+	history := recorder.recordedLeafPackHistory()
+	if len(history) != 1 {
+		t.Fatalf("leaf pack history=%d want 1", len(history))
+	}
+	if history[0].ReserveRIDs == nil {
+		t.Fatal("expected ReserveRIDs to be passed to leaf-pack maintenance")
+	}
+	before := db.nextRID.Load()
+	start, err := history[0].ReserveRIDs(3)
+	if err != nil {
+		t.Fatalf("ReserveRIDs(3): %v", err)
+	}
+	if got, want := start, before+1; got != want {
+		t.Fatalf("ReserveRIDs start=%d want %d", got, want)
+	}
+	if got, want := db.nextRID.Load(), before+3; got != want {
+		t.Fatalf("nextRID after ReserveRIDs=%d want %d", got, want)
+	}
+}
+
 func TestLeafGenerationPackMaintenance_LoopsWithinBudgetAndRunsLeafGC(t *testing.T) {
 	t.Setenv(envEnableLeafGenerationPackMaintenance, "1")
 	t.Setenv(envLeafGenerationPackMaintenanceMaxGenerations, "3")

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -12,6 +12,8 @@ import (
 
 const leafGenerationPackDefaultMinReclaimPerByteCopiedPPM = 10000
 
+var leafGenerationPackRIDStartScanner = nextRewriteRIDStartFromSet
+
 type LeafGenerationPackOptions struct {
 	GenerationIDs              []uint64
 	Sync                       bool
@@ -19,6 +21,7 @@ type LeafGenerationPackOptions struct {
 	MinExpectedReclaimBytes    int64
 	MinExpectedReclaimRatioPPM int
 	MinReclaimPerByteCopiedPPM int
+	ReserveRIDs                func(count int) (start uint64, err error)
 	Force                      bool
 }
 
@@ -80,6 +83,43 @@ func (db *DB) LeafGenerationPack(ctx context.Context, opts LeafGenerationPackOpt
 	if err != nil {
 		return stats, err
 	}
+	return db.leafGenerationPackLocked(ctx, opts, selectedPlan, stats)
+}
+
+func (db *DB) leafGenerationPackSelected(ctx context.Context, opts LeafGenerationPackOptions, selectedPlan LeafGenerationPlan) (stats LeafGenerationPackStats, err error) {
+	if db == nil {
+		return stats, fmt.Errorf("missing db")
+	}
+	if db.readOnly {
+		return stats, ErrReadOnly
+	}
+	if !db.indexOuterLeavesInValueLog {
+		return stats, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	started := time.Now()
+	defer func() {
+		stats.WallTimeNanos = time.Since(started).Nanoseconds()
+	}()
+	stats.GenerationsRequested = len(opts.GenerationIDs)
+	opts = normalizeLeafGenerationPackOptions(opts)
+
+	db.maintenanceMu.Lock()
+	defer db.maintenanceMu.Unlock()
+	stats.SourceGenerationIDs = append(stats.SourceGenerationIDs, selectedPlan.CandidateGenerationIDs...)
+	stats.SourceBytesTotal = selectedPlan.CandidateBytesTotal
+	stats.SourceBytesLive = selectedPlan.CandidateBytesLive
+	stats.SourceBytesDead = selectedPlan.CandidateBytesDead
+	stats.SourceBytesToCopy = selectedPlan.CandidateBytesToCopy
+	stats.ExpectedReclaimBytes = selectedPlan.ExpectedReclaimBytes
+	stats.ExpectedReclaimRatioPPM = selectedPlan.ExpectedReclaimRatioPPM
+	stats.ExpectedReclaimPerByteCopiedPPM = selectedPlan.ExpectedReclaimPerByteCopiedPPM
+	return db.leafGenerationPackLocked(ctx, opts, selectedPlan, stats)
+}
+
+func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationPackOptions, selectedPlan LeafGenerationPlan, stats LeafGenerationPackStats) (LeafGenerationPackStats, error) {
 	rawSourceIDs, matchedGenerations, err := db.resolveLeafGenerationPackSourceFileIDs(opts.GenerationIDs)
 	if err != nil {
 		return stats, err
@@ -107,7 +147,10 @@ func (db *DB) LeafGenerationPack(ctx context.Context, opts LeafGenerationPackOpt
 		return stats, fmt.Errorf("leaf generation pack: value-log set unavailable")
 	}
 	leafStartSeq := maxRewriteLaneSeqFromSet(set, rewriteLeafLogLaneID)
-	nextRID, err := nextRewriteRIDStartFromSet(set)
+	nextRID := uint64(0)
+	if opts.ReserveRIDs == nil {
+		nextRID, err = leafGenerationPackRIDStartScanner(set)
+	}
 	_ = db.valueLogManager.Release(set)
 	if err != nil {
 		return stats, err
@@ -124,7 +167,7 @@ func (db *DB) LeafGenerationPack(ctx context.Context, opts LeafGenerationPackOpt
 	for _, rawID := range rawSourceIDs {
 		sourceValueIDs[page.ValueLogFileID(rawID)] = struct{}{}
 	}
-	ridAlloc := newRewriteRIDAllocator(nextRID, nil)
+	ridAlloc := newRewriteRIDAllocator(nextRID, opts.ReserveRIDs)
 	var rewriteStats leafRefRewriteRunStats
 	stats.LeafPagesCopied, stats.BytesCopied, err = db.rewriteLeafRefsOnline(ctx, writer, ridAlloc, sourceValueIDs, nil, 0, 0, false, 0, opts.Sync, &rewriteStats)
 	stats.InternalPagesVisited = rewriteStats.InternalPagesVisited
@@ -138,6 +181,23 @@ func (db *DB) LeafGenerationPack(ctx context.Context, opts LeafGenerationPackOpt
 	}
 	stats.CreatedFileIDs = filterLeafGenerationRawFileIDs(createdIDs)
 	return stats, nil
+}
+
+func selectedLeafGenerationPackPlan(selection LeafGenerationPackSelection) LeafGenerationPlan {
+	return LeafGenerationPlan{
+		Admission:                       leafGenerationPlanAdmissionEligible,
+		Generations:                     append([]LeafGenerationPlanGeneration(nil), selection.Generations...),
+		Candidates:                      append([]LeafGenerationPlanGeneration(nil), selection.Generations...),
+		CandidateGenerationIDs:          append([]uint64(nil), selection.GenerationIDs...),
+		CandidateBytesTotal:             selection.BytesTotal,
+		CandidateBytesLive:              selection.BytesLive,
+		CandidateBytesDead:              selection.BytesDead,
+		CandidateBytesToCopy:            selection.BytesToCopy,
+		CandidateLivePages:              selection.LivePages,
+		ExpectedReclaimBytes:            selection.ExpectedReclaimBytes,
+		ExpectedReclaimRatioPPM:         selection.ExpectedReclaimRatioPPM,
+		ExpectedReclaimPerByteCopiedPPM: selection.ExpectedReclaimPerByteCopiedPPM,
+	}
 }
 
 func normalizeLeafGenerationPackOptions(opts LeafGenerationPackOptions) LeafGenerationPackOptions {

--- a/TreeDB/db/leaf_generation_pack_from_plan.go
+++ b/TreeDB/db/leaf_generation_pack_from_plan.go
@@ -47,6 +47,7 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 		return LeafGenerationPackStats{}, err
 	}
 	selection, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
+		Force:                      opts.Force,
 		MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
 		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
 		MaxGenerations:             opts.MaxGenerations,

--- a/TreeDB/db/leaf_generation_pack_from_plan.go
+++ b/TreeDB/db/leaf_generation_pack_from_plan.go
@@ -14,16 +14,15 @@ type LeafGenerationPackFromPlanOptions struct {
 	MinReclaimPerByteCopiedPPM int
 	MaxGenerations             int
 	MaxBytesToCopy             int64
+	ReserveRIDs                func(count int) (start uint64, err error)
 }
 
 func leafGenerationPackFromPlanPlanOptions(opts LeafGenerationPackFromPlanOptions) LeafGenerationPlanOptions {
 	return LeafGenerationPlanOptions{
-		MinPublishedAgeCommits:     opts.MinPublishedAgeCommits,
-		MinCandidateGenerations:    opts.MinCandidateGenerations,
-		MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
-		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
-		MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
-		Force:                      opts.Force,
+		MinPublishedAgeCommits:  opts.MinPublishedAgeCommits,
+		MinCandidateGenerations: opts.MinCandidateGenerations,
+		MinExpectedReclaimBytes: opts.MinExpectedReclaimBytes,
+		Force:                   opts.Force,
 	}
 }
 
@@ -35,6 +34,7 @@ func leafGenerationPackFromPlanPackOptions(opts LeafGenerationPackFromPlanOption
 		MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
 		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
 		MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
+		ReserveRIDs:                opts.ReserveRIDs,
 		Force:                      opts.Force,
 	}
 }
@@ -47,6 +47,8 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 		return LeafGenerationPackStats{}, err
 	}
 	selection, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
+		MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
+		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
 		MaxGenerations:             opts.MaxGenerations,
 		MaxBytesToCopy:             opts.MaxBytesToCopy,
 		MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
@@ -54,5 +56,5 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 	if err != nil {
 		return LeafGenerationPackStats{}, err
 	}
-	return db.LeafGenerationPack(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs))
+	return db.leafGenerationPackSelected(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs), selectedLeafGenerationPackPlan(selection))
 }

--- a/TreeDB/db/leaf_generation_pack_run_once.go
+++ b/TreeDB/db/leaf_generation_pack_run_once.go
@@ -29,6 +29,8 @@ func (db *DB) LeafGenerationPackRunOnce(ctx context.Context, opts LeafGeneration
 		return stats, nil
 	}
 	selection, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
+		MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
+		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
 		MaxGenerations:             opts.MaxGenerations,
 		MaxBytesToCopy:             opts.MaxBytesToCopy,
 		MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
@@ -38,7 +40,7 @@ func (db *DB) LeafGenerationPackRunOnce(ctx context.Context, opts LeafGeneration
 		return stats, nil
 	}
 	stats.Selection = selection
-	packStats, err := db.LeafGenerationPack(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs))
+	packStats, err := db.leafGenerationPackSelected(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs), selectedLeafGenerationPackPlan(selection))
 	if err != nil {
 		return stats, err
 	}

--- a/TreeDB/db/leaf_generation_pack_run_once_test.go
+++ b/TreeDB/db/leaf_generation_pack_run_once_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -91,7 +92,7 @@ func TestLeafGenerationPackRunOnce_SkipsDensePlan(t *testing.T) {
 	if stats.Ran {
 		t.Fatalf("expected dense plan to skip, got pack=%+v", stats.Pack)
 	}
-	if got, want := stats.SkipReason, "plan_admission:reclaim_per_copy_too_low"; got != want {
+	if got, want := stats.SkipReason, "selection:leaf generation pack selection: no candidate generations satisfy min-reclaim-per-byte-copied-ppm=10000"; got != want {
 		t.Fatalf("SkipReason=%q, want %q", got, want)
 	}
 }
@@ -112,7 +113,68 @@ func TestLeafGenerationPackRunOnce_SkipsPlanWhenWindowYieldTooLow(t *testing.T) 
 	if stats.Ran {
 		t.Fatalf("expected low-yield window to skip, got pack=%+v", stats.Pack)
 	}
-	if got, want := stats.SkipReason, "plan_admission:reclaim_per_copy_too_low"; got != want {
+	if got, want := stats.SkipReason, "selection:leaf generation pack selection: no candidate generations satisfy min-reclaim-per-byte-copied-ppm=200000"; got != want {
 		t.Fatalf("SkipReason=%q, want %q", got, want)
+	}
+}
+
+func TestLeafGenerationPackRunOnce_BoundedSelectionCanRunWhenWholePlanReclaimPerCopyIsLow(t *testing.T) {
+	db, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "dense", 32768, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf dense: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, db, "dense", 0, 1, 'b')
+
+	writeLeafGenerationKeys(t, db, "sparse", 2048, 'c')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf sparse: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, db, "sparse", 0, 1024, 'd')
+
+	stats, err := db.LeafGenerationPackRunOnce(context.Background(), LeafGenerationPackFromPlanOptions{
+		MaxGenerations:             1,
+		MinReclaimPerByteCopiedPPM: 200000,
+	})
+	if err != nil {
+		t.Fatalf("LeafGenerationPackRunOnce: %v", err)
+	}
+	if !stats.Ran {
+		t.Fatalf("expected bounded selection to run, skip_reason=%q plan=%+v", stats.SkipReason, stats.Plan)
+	}
+	if got, want := len(stats.Selection.GenerationIDs), 1; got != want {
+		t.Fatalf("len(Selection.GenerationIDs)=%d want %d", got, want)
+	}
+	if got := stats.Selection.ExpectedReclaimPerByteCopiedPPM; got < 200000 {
+		t.Fatalf("ExpectedReclaimPerByteCopiedPPM=%d want >= 200000", got)
+	}
+}
+
+func TestLeafGenerationPackRunOnce_CallsLeafGenerationPlanOnce(t *testing.T) {
+	db, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "k", 2048, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, db, "k", 0, 1024, 'b')
+	writeLeafGenerationKeys(t, db, "z", 32, 'z')
+
+	var calls atomic.Int64
+	unregister := registerLeafGenerationPlanCallHook(func() {
+		calls.Add(1)
+	})
+	defer unregister()
+
+	stats, err := db.LeafGenerationPackRunOnce(context.Background(), LeafGenerationPackFromPlanOptions{MaxGenerations: 1, Sync: true})
+	if err != nil {
+		t.Fatalf("LeafGenerationPackRunOnce: %v", err)
+	}
+	if !stats.Ran {
+		t.Fatalf("expected run once to execute, skip_reason=%q", stats.SkipReason)
+	}
+	if got, want := calls.Load(), int64(1); got != want {
+		t.Fatalf("LeafGenerationPlan calls=%d, want %d", got, want)
 	}
 }

--- a/TreeDB/db/leaf_generation_pack_run_once_test.go
+++ b/TreeDB/db/leaf_generation_pack_run_once_test.go
@@ -178,3 +178,29 @@ func TestLeafGenerationPackRunOnce_CallsLeafGenerationPlanOnce(t *testing.T) {
 		t.Fatalf("LeafGenerationPlan calls=%d, want %d", got, want)
 	}
 }
+
+func TestLeafGenerationPackFromPlan_ForceBypassesSelectionThresholds(t *testing.T) {
+	db, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "k", 2048, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, db, "k", 0, 1024, 'b')
+	writeLeafGenerationKeys(t, db, "z", 32, 'z')
+
+	stats, err := db.LeafGenerationPackFromPlan(context.Background(), LeafGenerationPackFromPlanOptions{
+		Force:                      true,
+		MaxGenerations:             1,
+		MinExpectedReclaimBytes:    1 << 50,
+		MinExpectedReclaimRatioPPM: 900000,
+		MinReclaimPerByteCopiedPPM: 900000,
+		Sync:                       true,
+	})
+	if err != nil {
+		t.Fatalf("LeafGenerationPackFromPlan: %v", err)
+	}
+	if got, want := stats.GenerationsMatched, 1; got != want {
+		t.Fatalf("GenerationsMatched=%d, want %d", got, want)
+	}
+}

--- a/TreeDB/db/leaf_generation_pack_select.go
+++ b/TreeDB/db/leaf_generation_pack_select.go
@@ -8,6 +8,7 @@ import (
 // LeafGenerationPackSelectOptions bounds a selected ranked subset of plan
 // candidates.
 type LeafGenerationPackSelectOptions struct {
+	Force                      bool
 	MinExpectedReclaimBytes    int64
 	MinExpectedReclaimRatioPPM int
 	MaxGenerations             int
@@ -46,7 +47,7 @@ func SelectLeafGenerationPackCandidates(plan LeafGenerationPlan, opts LeafGenera
 	if len(plan.Candidates) == 0 {
 		return LeafGenerationPackSelection{}, fmt.Errorf("leaf generation pack selection: plan produced no candidate generations")
 	}
-	if opts.MaxGenerations <= 0 && opts.MaxBytesToCopy <= 0 {
+	if opts.MaxGenerations <= 0 {
 		return selectLeafGenerationPackCandidatesGreedy(plan, opts)
 	}
 	return selectLeafGenerationPackCandidatesBounded(plan, opts)
@@ -64,7 +65,7 @@ func selectLeafGenerationPackCandidatesGreedy(plan LeafGenerationPlan, opts Leaf
 			rejectedOversize = true
 			continue
 		}
-		if opts.MinReclaimPerByteCopiedPPM > 0 {
+		if !opts.Force && opts.MinReclaimPerByteCopiedPPM > 0 {
 			tentativeDead := out.BytesDead + gen.BytesDead
 			tentativeCopy := out.BytesToCopy + gen.BytesToCopy
 			if tentativeCopy > 0 && ratioPPM(tentativeDead, tentativeCopy) < opts.MinReclaimPerByteCopiedPPM {
@@ -149,6 +150,9 @@ func (r *leafGenerationPackSelectionThresholdRejections) merge(other leafGenerat
 
 func leafGenerationPackSelectionThresholdsOK(bytesDead, bytesToCopy int64, opts LeafGenerationPackSelectOptions) (bool, leafGenerationPackSelectionThresholdRejections) {
 	var rejected leafGenerationPackSelectionThresholdRejections
+	if opts.Force {
+		return true, rejected
+	}
 	if opts.MinExpectedReclaimBytes > 0 && bytesDead < opts.MinExpectedReclaimBytes {
 		rejected.minBytes = true
 	}
@@ -162,6 +166,9 @@ func leafGenerationPackSelectionThresholdsOK(bytesDead, bytesToCopy int64, opts 
 }
 
 func leafGenerationPackSelectionThresholdError(opts LeafGenerationPackSelectOptions, rejected leafGenerationPackSelectionThresholdRejections) error {
+	if opts.Force {
+		return nil
+	}
 	switch {
 	case opts.MinExpectedReclaimBytes > 0 && rejected.minBytes:
 		return fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-expected-reclaim-bytes=%d", opts.MinExpectedReclaimBytes)

--- a/TreeDB/db/leaf_generation_pack_select.go
+++ b/TreeDB/db/leaf_generation_pack_select.go
@@ -1,12 +1,15 @@
 package db
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // LeafGenerationPackSelectOptions bounds a selected ranked subset of plan
-// candidates. Selected generations preserve plan rank order, but oversized
-// candidates may be skipped so later ranked generations can still fit a bounded
-// online maintenance window.
+// candidates.
 type LeafGenerationPackSelectOptions struct {
+	MinExpectedReclaimBytes    int64
+	MinExpectedReclaimRatioPPM int
 	MaxGenerations             int
 	MaxBytesToCopy             int64
 	MinReclaimPerByteCopiedPPM int
@@ -26,20 +29,33 @@ type LeafGenerationPackSelection struct {
 	ExpectedReclaimPerByteCopiedPPM int
 }
 
-// SelectLeafGenerationPackCandidates selects a bounded ranked subset from an
-// eligible leaf-generation plan. The selected set never exceeds the requested
-// bytes-to-copy cap and may stop early when adding the next ranked candidate
-// would violate the requested reclaim-per-copy floor.
+type leafGenerationPackSelectionState struct {
+	indices     []int
+	bytesDead   int64
+	bytesToCopy int64
+}
+
+// SelectLeafGenerationPackCandidates selects a bounded subset from an eligible
+// leaf-generation plan. For bounded windows it maximizes reclaimable bytes
+// within the requested generation/copy limits, then emits the chosen
+// generations in their original plan order.
 func SelectLeafGenerationPackCandidates(plan LeafGenerationPlan, opts LeafGenerationPackSelectOptions) (LeafGenerationPackSelection, error) {
-	var out LeafGenerationPackSelection
 	if plan.Admission != leafGenerationPlanAdmissionEligible {
-		return out, fmt.Errorf("leaf generation pack selection: plan admission=%s", plan.Admission)
+		return LeafGenerationPackSelection{}, fmt.Errorf("leaf generation pack selection: plan admission=%s", plan.Admission)
 	}
 	if len(plan.Candidates) == 0 {
-		return out, fmt.Errorf("leaf generation pack selection: plan produced no candidate generations")
+		return LeafGenerationPackSelection{}, fmt.Errorf("leaf generation pack selection: plan produced no candidate generations")
 	}
+	if opts.MaxGenerations <= 0 && opts.MaxBytesToCopy <= 0 {
+		return selectLeafGenerationPackCandidatesGreedy(plan, opts)
+	}
+	return selectLeafGenerationPackCandidatesBounded(plan, opts)
+}
+
+func selectLeafGenerationPackCandidatesGreedy(plan LeafGenerationPlan, opts LeafGenerationPackSelectOptions) (LeafGenerationPackSelection, error) {
+	var out LeafGenerationPackSelection
 	rejectedOversize := false
-	rejectedLowYield := false
+	var rejected leafGenerationPackSelectionThresholdRejections
 	for _, gen := range plan.Candidates {
 		if opts.MaxGenerations > 0 && len(out.GenerationIDs) >= opts.MaxGenerations {
 			break
@@ -52,32 +68,207 @@ func SelectLeafGenerationPackCandidates(plan LeafGenerationPlan, opts LeafGenera
 			tentativeDead := out.BytesDead + gen.BytesDead
 			tentativeCopy := out.BytesToCopy + gen.BytesToCopy
 			if tentativeCopy > 0 && ratioPPM(tentativeDead, tentativeCopy) < opts.MinReclaimPerByteCopiedPPM {
-				rejectedLowYield = true
+				rejected.minPerCopy = true
 				break
 			}
 		}
-		out.GenerationIDs = append(out.GenerationIDs, gen.GenerationID)
-		out.Generations = append(out.Generations, gen)
-		out.BytesTotal += gen.BytesTotal
-		out.BytesLive += gen.BytesLive
-		out.BytesDead += gen.BytesDead
-		out.BytesToCopy += gen.BytesToCopy
-		out.LivePages += gen.LivePages
+		appendLeafGenerationPackSelection(&out, gen)
 	}
+	return finalizeLeafGenerationPackSelection(out, opts, rejectedOversize, rejected)
+}
+
+func selectLeafGenerationPackCandidatesBounded(plan LeafGenerationPlan, opts LeafGenerationPackSelectOptions) (LeafGenerationPackSelection, error) {
+	maxGenerations := opts.MaxGenerations
+	if maxGenerations <= 0 || maxGenerations > len(plan.Candidates) {
+		maxGenerations = len(plan.Candidates)
+	}
+	frontiers := make([][]leafGenerationPackSelectionState, maxGenerations+1)
+	frontiers[0] = []leafGenerationPackSelectionState{{}}
+	rejectedOversize := false
+	for idx, gen := range plan.Candidates {
+		for selected := maxGenerations - 1; selected >= 0; selected-- {
+			if len(frontiers[selected]) == 0 {
+				continue
+			}
+			next := append([]leafGenerationPackSelectionState(nil), frontiers[selected+1]...)
+			for _, state := range frontiers[selected] {
+				tentativeCopy := state.bytesToCopy + gen.BytesToCopy
+				if opts.MaxBytesToCopy > 0 && tentativeCopy > opts.MaxBytesToCopy {
+					rejectedOversize = true
+					continue
+				}
+				indices := append(append([]int(nil), state.indices...), idx)
+				next = append(next, leafGenerationPackSelectionState{
+					indices:     indices,
+					bytesDead:   state.bytesDead + gen.BytesDead,
+					bytesToCopy: tentativeCopy,
+				})
+			}
+			frontiers[selected+1] = pruneLeafGenerationPackSelectionStates(next)
+		}
+	}
+
+	var (
+		bestState leafGenerationPackSelectionState
+		haveBest  bool
+		rejected  leafGenerationPackSelectionThresholdRejections
+	)
+	for selected := 1; selected <= maxGenerations; selected++ {
+		for _, state := range frontiers[selected] {
+			if ok, flags := leafGenerationPackSelectionThresholdsOK(state.bytesDead, state.bytesToCopy, opts); !ok {
+				rejected.merge(flags)
+				continue
+			}
+			if !haveBest || betterLeafGenerationPackSelectionState(state, bestState) {
+				bestState = cloneLeafGenerationPackSelectionState(state)
+				haveBest = true
+			}
+		}
+	}
+	if !haveBest {
+		return finalizeLeafGenerationPackSelection(LeafGenerationPackSelection{}, opts, rejectedOversize, rejected)
+	}
+	var out LeafGenerationPackSelection
+	for _, idx := range bestState.indices {
+		appendLeafGenerationPackSelection(&out, plan.Candidates[idx])
+	}
+	return finalizeLeafGenerationPackSelection(out, opts, rejectedOversize, rejected)
+}
+
+type leafGenerationPackSelectionThresholdRejections struct {
+	minBytes   bool
+	minRatio   bool
+	minPerCopy bool
+}
+
+func (r *leafGenerationPackSelectionThresholdRejections) merge(other leafGenerationPackSelectionThresholdRejections) {
+	r.minBytes = r.minBytes || other.minBytes
+	r.minRatio = r.minRatio || other.minRatio
+	r.minPerCopy = r.minPerCopy || other.minPerCopy
+}
+
+func leafGenerationPackSelectionThresholdsOK(bytesDead, bytesToCopy int64, opts LeafGenerationPackSelectOptions) (bool, leafGenerationPackSelectionThresholdRejections) {
+	var rejected leafGenerationPackSelectionThresholdRejections
+	if opts.MinExpectedReclaimBytes > 0 && bytesDead < opts.MinExpectedReclaimBytes {
+		rejected.minBytes = true
+	}
+	if opts.MinExpectedReclaimRatioPPM > 0 && ratioPPM(bytesDead, bytesDead+bytesToCopy) < opts.MinExpectedReclaimRatioPPM {
+		rejected.minRatio = true
+	}
+	if opts.MinReclaimPerByteCopiedPPM > 0 && ratioPPM(bytesDead, bytesToCopy) < opts.MinReclaimPerByteCopiedPPM {
+		rejected.minPerCopy = true
+	}
+	return !(rejected.minBytes || rejected.minRatio || rejected.minPerCopy), rejected
+}
+
+func leafGenerationPackSelectionThresholdError(opts LeafGenerationPackSelectOptions, rejected leafGenerationPackSelectionThresholdRejections) error {
+	switch {
+	case opts.MinExpectedReclaimBytes > 0 && rejected.minBytes:
+		return fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-expected-reclaim-bytes=%d", opts.MinExpectedReclaimBytes)
+	case opts.MinExpectedReclaimRatioPPM > 0 && rejected.minRatio:
+		return fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-expected-reclaim-ratio-ppm=%d", opts.MinExpectedReclaimRatioPPM)
+	case opts.MinReclaimPerByteCopiedPPM > 0 && rejected.minPerCopy:
+		return fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-reclaim-per-byte-copied-ppm=%d", opts.MinReclaimPerByteCopiedPPM)
+	default:
+		return nil
+	}
+}
+
+func finalizeLeafGenerationPackSelection(out LeafGenerationPackSelection, opts LeafGenerationPackSelectOptions, rejectedOversize bool, rejected leafGenerationPackSelectionThresholdRejections) (LeafGenerationPackSelection, error) {
 	if len(out.GenerationIDs) == 0 {
-		if opts.MinReclaimPerByteCopiedPPM > 0 && rejectedLowYield {
-			return out, fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-reclaim-per-byte-copied-ppm=%d", opts.MinReclaimPerByteCopiedPPM)
+		if err := leafGenerationPackSelectionThresholdError(opts, rejected); err != nil {
+			return out, err
 		}
 		if opts.MaxBytesToCopy > 0 && rejectedOversize {
 			return out, fmt.Errorf("leaf generation pack selection: no candidate generations fit max-bytes-to-copy=%d", opts.MaxBytesToCopy)
 		}
-		if opts.MinReclaimPerByteCopiedPPM > 0 {
-			return out, fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-reclaim-per-byte-copied-ppm=%d", opts.MinReclaimPerByteCopiedPPM)
-		}
 		return out, fmt.Errorf("leaf generation pack selection: plan produced no candidate generations within limits")
+	}
+	if ok, thresholdRejected := leafGenerationPackSelectionThresholdsOK(out.BytesDead, out.BytesToCopy, opts); !ok {
+		return out, leafGenerationPackSelectionThresholdError(opts, thresholdRejected)
 	}
 	out.ExpectedReclaimBytes = out.BytesDead
 	out.ExpectedReclaimRatioPPM = ratioPPM(out.BytesDead, out.BytesTotal)
 	out.ExpectedReclaimPerByteCopiedPPM = ratioPPM(out.BytesDead, out.BytesToCopy)
 	return out, nil
+}
+
+func appendLeafGenerationPackSelection(out *LeafGenerationPackSelection, gen LeafGenerationPlanGeneration) {
+	out.GenerationIDs = append(out.GenerationIDs, gen.GenerationID)
+	out.Generations = append(out.Generations, gen)
+	out.BytesTotal += gen.BytesTotal
+	out.BytesLive += gen.BytesLive
+	out.BytesDead += gen.BytesDead
+	out.BytesToCopy += gen.BytesToCopy
+	out.LivePages += gen.LivePages
+}
+
+func pruneLeafGenerationPackSelectionStates(states []leafGenerationPackSelectionState) []leafGenerationPackSelectionState {
+	if len(states) <= 1 {
+		return states
+	}
+	sort.SliceStable(states, func(i, j int) bool {
+		a := states[i]
+		b := states[j]
+		if a.bytesToCopy != b.bytesToCopy {
+			return a.bytesToCopy < b.bytesToCopy
+		}
+		if a.bytesDead != b.bytesDead {
+			return a.bytesDead > b.bytesDead
+		}
+		return compareLeafGenerationPackSelectionIndices(a.indices, b.indices) < 0
+	})
+	pruned := states[:0]
+	bestDead := int64(-1)
+	for _, state := range states {
+		if state.bytesDead <= bestDead {
+			continue
+		}
+		pruned = append(pruned, state)
+		bestDead = state.bytesDead
+	}
+	return pruned
+}
+
+func betterLeafGenerationPackSelectionState(a, b leafGenerationPackSelectionState) bool {
+	if a.bytesDead != b.bytesDead {
+		return a.bytesDead > b.bytesDead
+	}
+	aRatio := ratioPPM(a.bytesDead, a.bytesToCopy)
+	bRatio := ratioPPM(b.bytesDead, b.bytesToCopy)
+	if aRatio != bRatio {
+		return aRatio > bRatio
+	}
+	if a.bytesToCopy != b.bytesToCopy {
+		return a.bytesToCopy < b.bytesToCopy
+	}
+	if len(a.indices) != len(b.indices) {
+		return len(a.indices) < len(b.indices)
+	}
+	return compareLeafGenerationPackSelectionIndices(a.indices, b.indices) < 0
+}
+
+func compareLeafGenerationPackSelectionIndices(a, b []int) int {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if a[i] < b[i] {
+			return -1
+		}
+		if a[i] > b[i] {
+			return 1
+		}
+	}
+	switch {
+	case len(a) < len(b):
+		return -1
+	case len(a) > len(b):
+		return 1
+	default:
+		return 0
+	}
+}
+
+func cloneLeafGenerationPackSelectionState(state leafGenerationPackSelectionState) leafGenerationPackSelectionState {
+	cloned := state
+	cloned.indices = append([]int(nil), state.indices...)
+	return cloned
 }

--- a/TreeDB/db/leaf_generation_pack_select_test.go
+++ b/TreeDB/db/leaf_generation_pack_select_test.go
@@ -167,3 +167,44 @@ func TestSelectLeafGenerationPackCandidates_PrioritizesOversizeErrorWhenNothingF
 		t.Fatalf("error=%q, want oversize no-fit error", got)
 	}
 }
+
+func TestSelectLeafGenerationPackCandidates_ForceBypassesReclaimThresholds(t *testing.T) {
+	plan := LeafGenerationPlan{
+		Admission: leafGenerationPlanAdmissionEligible,
+		Candidates: []LeafGenerationPlanGeneration{
+			{GenerationID: 17, BytesDead: 5, BytesLive: 95, BytesToCopy: 95},
+		},
+	}
+	selected, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
+		Force:                      true,
+		MinExpectedReclaimBytes:    100,
+		MinExpectedReclaimRatioPPM: 900000,
+		MinReclaimPerByteCopiedPPM: 900000,
+	})
+	if err != nil {
+		t.Fatalf("SelectLeafGenerationPackCandidates: %v", err)
+	}
+	if got, want := selected.GenerationIDs, []uint64{17}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("GenerationIDs=%v, want %v", got, want)
+	}
+}
+
+func TestSelectLeafGenerationPackCandidates_MaxBytesOnlyUsesGreedySelection(t *testing.T) {
+	plan := LeafGenerationPlan{
+		Admission: leafGenerationPlanAdmissionEligible,
+		Candidates: []LeafGenerationPlanGeneration{
+			{GenerationID: 21, BytesDead: 100, BytesLive: 10, BytesToCopy: 10},
+			{GenerationID: 22, BytesDead: 300, BytesLive: 30, BytesToCopy: 30},
+			{GenerationID: 23, BytesDead: 250, BytesLive: 20, BytesToCopy: 20},
+		},
+	}
+	selected, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
+		MaxBytesToCopy: 30,
+	})
+	if err != nil {
+		t.Fatalf("SelectLeafGenerationPackCandidates: %v", err)
+	}
+	if got, want := selected.GenerationIDs, []uint64{21, 23}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("GenerationIDs=%v, want %v", got, want)
+	}
+}

--- a/TreeDB/db/leaf_generation_pack_select_test.go
+++ b/TreeDB/db/leaf_generation_pack_select_test.go
@@ -32,8 +32,8 @@ func TestSelectLeafGenerationPackCandidates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MaxGenerations: %v", err)
 	}
-	if got, want := len(selected.GenerationIDs), 1; got != want || selected.GenerationIDs[0] != 3 {
-		t.Fatalf("GenerationIDs=%v, want [3]", selected.GenerationIDs)
+	if got, want := len(selected.GenerationIDs), 1; got != want || selected.GenerationIDs[0] != 5 {
+		t.Fatalf("GenerationIDs=%v, want [5]", selected.GenerationIDs)
 	}
 
 	selected, err = SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{MaxBytesToCopy: 150})
@@ -79,6 +79,33 @@ func TestSelectLeafGenerationPackCandidates_StopsBeforeLowYieldCandidate(t *test
 	}
 	if got, want := selected.ExpectedReclaimPerByteCopiedPPM, ratioPPM(80, 20); got != want {
 		t.Fatalf("ExpectedReclaimPerByteCopiedPPM=%d, want %d", got, want)
+	}
+}
+
+func TestSelectLeafGenerationPackCandidates_BoundedWindowPrefersHigherReclaimSubset(t *testing.T) {
+	plan := LeafGenerationPlan{
+		Admission: leafGenerationPlanAdmissionEligible,
+		Candidates: []LeafGenerationPlanGeneration{
+			{GenerationID: 31, BytesDead: 50, BytesLive: 5, BytesToCopy: 5},
+			{GenerationID: 32, BytesDead: 180, BytesLive: 30, BytesToCopy: 30},
+			{GenerationID: 33, BytesDead: 180, BytesLive: 30, BytesToCopy: 30},
+		},
+	}
+	selected, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
+		MaxGenerations: 2,
+		MaxBytesToCopy: 60,
+	})
+	if err != nil {
+		t.Fatalf("SelectLeafGenerationPackCandidates: %v", err)
+	}
+	if got, want := selected.GenerationIDs, []uint64{32, 33}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("GenerationIDs=%v, want %v", got, want)
+	}
+	if got, want := selected.ExpectedReclaimBytes, int64(360); got != want {
+		t.Fatalf("ExpectedReclaimBytes=%d, want %d", got, want)
+	}
+	if got, want := selected.BytesToCopy, int64(60); got != want {
+		t.Fatalf("BytesToCopy=%d, want %d", got, want)
 	}
 }
 

--- a/TreeDB/db/leaf_generation_pack_test.go
+++ b/TreeDB/db/leaf_generation_pack_test.go
@@ -281,6 +281,52 @@ func TestLeafGenerationPack_WriteMetaFailpointCleansCreatedSegments(t *testing.T
 	}
 }
 
+func TestLeafGenerationPackRunOnce_ReserveRIDsUsesExternalAllocator(t *testing.T) {
+	db, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "k", 2048, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, db, "k", 0, 1024, 'b')
+	writeLeafGenerationKeys(t, db, "z", 32, 'z')
+
+	origRIDScanner := leafGenerationPackRIDStartScanner
+	ridScanCalls := 0
+	leafGenerationPackRIDStartScanner = func(*valuelog.Set) (uint64, error) {
+		ridScanCalls++
+		return 0, fmt.Errorf("unexpected rid scan")
+	}
+	t.Cleanup(func() { leafGenerationPackRIDStartScanner = origRIDScanner })
+
+	var reserveCalls int
+	nextRIDBase := uint64(900_000)
+	stats, err := db.LeafGenerationPackRunOnce(context.Background(), LeafGenerationPackFromPlanOptions{
+		MaxGenerations: 1,
+		ReserveRIDs: func(count int) (uint64, error) {
+			if count <= 0 {
+				t.Fatalf("ReserveRIDs count=%d, want > 0", count)
+			}
+			reserveCalls++
+			start := nextRIDBase
+			nextRIDBase += uint64(count)
+			return start, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("LeafGenerationPackRunOnce: %v", err)
+	}
+	if !stats.Ran {
+		t.Fatalf("expected run once to execute, skip_reason=%q", stats.SkipReason)
+	}
+	if reserveCalls == 0 {
+		t.Fatal("expected ReserveRIDs to be called")
+	}
+	if ridScanCalls != 0 {
+		t.Fatalf("expected ReserveRIDs mode to skip rid scan, calls=%d", ridScanCalls)
+	}
+}
+
 func TestLeafGenerationPack_MovesSparseSealedGeneration(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -111,9 +111,35 @@ var leafGenerationLiveScanHook struct {
 	fn func()
 }
 
+var leafGenerationPlanCallHook struct {
+	mu sync.Mutex
+	fn func()
+}
+
 var leafGenerationSubtreeCacheMissHook struct {
 	mu sync.Mutex
 	fn func(uint64)
+}
+
+func registerLeafGenerationPlanCallHook(hook func()) func() {
+	leafGenerationPlanCallHook.mu.Lock()
+	prev := leafGenerationPlanCallHook.fn
+	leafGenerationPlanCallHook.fn = hook
+	leafGenerationPlanCallHook.mu.Unlock()
+	return func() {
+		leafGenerationPlanCallHook.mu.Lock()
+		leafGenerationPlanCallHook.fn = prev
+		leafGenerationPlanCallHook.mu.Unlock()
+	}
+}
+
+func runLeafGenerationPlanCallHook() {
+	leafGenerationPlanCallHook.mu.Lock()
+	hook := leafGenerationPlanCallHook.fn
+	leafGenerationPlanCallHook.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
 }
 
 func registerLeafGenerationLiveScanHook(hook func()) func() {
@@ -145,6 +171,7 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 	if db == nil {
 		return plan, fmt.Errorf("missing db")
 	}
+	runLeafGenerationPlanCallHook()
 	if !db.indexOuterLeavesInValueLog {
 		plan.Admission = leafGenerationPlanAdmissionDisabled
 		return plan, nil

--- a/TreeDB/leaf_generation_pack_from_plan.go
+++ b/TreeDB/leaf_generation_pack_from_plan.go
@@ -31,6 +31,9 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
+		if opts.ReserveRIDs == nil {
+			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
+		}
 	}
 	stats, err := db.backend.LeafGenerationPackFromPlan(ctx, treedbdb.LeafGenerationPackFromPlanOptions(opts))
 	if err != nil {

--- a/TreeDB/leaf_generation_pack_run_once.go
+++ b/TreeDB/leaf_generation_pack_run_once.go
@@ -31,6 +31,9 @@ func (db *DB) LeafGenerationPackRunOnce(ctx context.Context, opts LeafGeneration
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
+		if opts.ReserveRIDs == nil {
+			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
+		}
 	}
 	stats, err := db.backend.LeafGenerationPackRunOnce(ctx, treedbdb.LeafGenerationPackFromPlanOptions(opts))
 	if err != nil {

--- a/TreeDB/leaf_generation_pack_select_test.go
+++ b/TreeDB/leaf_generation_pack_select_test.go
@@ -15,10 +15,10 @@ func TestSelectLeafGenerationPackCandidates_PublicHelper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SelectLeafGenerationPackCandidates: %v", err)
 	}
-	if got, want := len(selected.GenerationIDs), 1; got != want || selected.GenerationIDs[0] != 3 {
-		t.Fatalf("GenerationIDs=%v, want [3]", selected.GenerationIDs)
+	if got, want := len(selected.GenerationIDs), 1; got != want || selected.GenerationIDs[0] != 5 {
+		t.Fatalf("GenerationIDs=%v, want [5]", selected.GenerationIDs)
 	}
-	if got, want := selected.BytesToCopy, int64(100); got != want {
+	if got, want := selected.BytesToCopy, int64(180); got != want {
 		t.Fatalf("BytesToCopy=%d, want %d", got, want)
 	}
 }


### PR DESCRIPTION
This sprint targets the leaf-pack maintenance path directly.

What changed
- removes the extra backend planner pass inside `LeafGenerationPackRunOnce` by reusing the selected plan for execution
- wires cached-mode `ReserveRIDs` into leaf-pack execution so pack rewrite does not rescan value-log segments just to seed RIDs
- moves reclaim-ratio / reclaim-per-copy admission to the bounded selection window instead of the full unbounded plan, which lets maintenance run when the best window is healthy even if the full candidate pool is not
- upgrades bounded candidate selection from simple greedy-prefix behavior to a bounded frontier search that prefers higher reclaim within the configured generation / bytes-to-copy window
- adds regression coverage for plan-call count, external RID allocation, cached maintenance `ReserveRIDs`, and bounded-window candidate choice

Why
- live profiling showed leaf-pack maintenance spending too much time in planner/scanner work
- the previous implementation still allowed full-plan admission to reject maintenance before bounded selection ran, which is the wrong semantic for an online pack window
- cached maintenance was also paying avoidable RID scan overhead during pack rewrite

Impact
- pack maintenance now evaluates the right window semantics for `min_reclaim_per_byte_copied_ppm`
- cached maintenance avoids leaf-pack RID rescans by sharing the live RID allocator
- bounded candidate choice is more effective under `max_generations` / `max_bytes_to_copy`

Validation
- `GOWORK=off go test ./TreeDB/db -run 'Test(SelectLeafGenerationPackCandidates|LeafGenerationPackRunOnce|LeafGenerationPack_)' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestLeafGenerationPackMaintenance_' -count=1`
- `GOWORK=off go test ./TreeDB -run 'TestLeafGenerationPack' -count=1`
- saved-home cached dwell validation on `/home/mikers/.celestia-app-mainnet-treedb-20260416192034/data/application.db`
  - output: `/tmp/leafgen_cached_dwell_leafpack_sprint_v2_20260416203726`
  - before app DB: `2887525770`
  - after dwell app DB: `2600207171`
  - before leaf_vlog: `2663351206`
  - after dwell leaf_vlog: `2387028150`
  - leaf-pack runs: `3`
  - leaf-pack bytes copied: `979947520`
  - leaf-pack attributed reclaim bytes: `279297567`
  - leaf-pack attributed reclaim per copied ppm: `285012`
