### PR TITLE
TreeDB: compact sparse leaf-vlog pages

### DIFF
--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -30,8 +30,12 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	if l == nil || l.db == nil || l.lane == nil {
 		return page.LeafLogPtr{}, errWALUnavailable
 	}
+	encodedLeafPage, _, err := valuelog.MaybeCompactLeafLogPayload(leafPage)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
 	rid := l.db.nextRID.Add(1)
-	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, leafPage, journalDurabilityNone, false)
+	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
 	if retainPath != "" {
 		l.db.markValueLogRetain(retainPath)
 	}

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -97,5 +99,52 @@ func TestDB_NoteLeafGenerationRecordLength_ForwardsToBackend(t *testing.T) {
 	}
 	if got := stub.notified[0]; got != ptr {
 		t.Fatalf("notified ptr=%+v want %+v", got, ptr)
+	}
+}
+
+func buildSparseLeafPageForLeafLogTest(t *testing.T) []byte {
+	t.Helper()
+	buf := make([]byte, page.PageSize)
+	b := node.NewBuilderWithOptions(buf, page.PageTypeLeaf, node.BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+		PackedValuePtr:        true,
+	})
+	for i := 0; i < 4; i++ {
+		if err := b.AddLeafEntry([]byte("key-"+string(rune('a'+i))), []byte("value"), node.FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry(%d): %v", i, err)
+		}
+	}
+	b.FinishNoNode()
+	return buf
+}
+
+func TestCachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := valuelog.EncodeFileID(uint32(leafLogLaneID), 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := filepath.Join(dir, "leaf.log")
+	writer, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	db := &DB{closeCh: make(chan struct{})}
+	db.nextRID.Store(0)
+	leaf := lane{id: leafLogLaneID, vlog: writer}
+	leafLog := &cachingLeafPageLog{db: db, lane: &leaf}
+
+	if _, err := leafLog.AppendLeafPage(buildSparseLeafPageForLeafLogTest(t)); err != nil {
+		t.Fatalf("AppendLeafPage: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%q): %v", path, err)
+	}
+	if info.Size() >= int64(valuelog.HeaderSize+page.PageSize) {
+		t.Fatalf("file size=%d want compact leaf payload smaller than raw %d", info.Size(), valuelog.HeaderSize+page.PageSize)
 	}
 }

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -140,6 +140,10 @@ func TestCachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload(t *testing.T
 	if _, err := leafLog.AppendLeafPage(buildSparseLeafPageForLeafLogTest(t)); err != nil {
 		t.Fatalf("AppendLeafPage: %v", err)
 	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	writer = nil
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("Stat(%q): %v", path, err)

--- a/TreeDB/caching/vlog_generation_protected_paths_test.go
+++ b/TreeDB/caching/vlog_generation_protected_paths_test.go
@@ -11,6 +11,8 @@ import (
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 type rewriteRecordingBackend struct {
@@ -461,5 +463,71 @@ func TestPruneRetainedValueLogs_IgnoresLeafPathsInSplitMode(t *testing.T) {
 	}
 	if stats.RemovedSegments+stats.ZombieMarkedSegments != 1 {
 		t.Fatalf("value action count=%d want 1 (removed=%d zombie_marked=%d)", stats.RemovedSegments+stats.ZombieMarkedSegments, stats.RemovedSegments, stats.ZombieMarkedSegments)
+	}
+}
+
+func TestSplitValueLogOwnership_LeafRefStateReaderDecodesCompactLeafPages(t *testing.T) {
+	db := openSplitValueLogOwnershipTestDB(t)
+	snapper, ok := db.backend.(interface{ AcquireSnapshot() *backenddb.Snapshot })
+	if !ok {
+		t.Fatal("backend missing AcquireSnapshot")
+	}
+	snap := snapper.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("missing backend snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	state := snap.State()
+	p := snap.Pager()
+	if state == nil || p == nil {
+		t.Fatal("missing snapshot state/pager")
+	}
+	reader := valueReaderForBackendState(state)
+	if reader == nil {
+		t.Fatal("missing state value-log reader")
+	}
+	refs := collectLeafRefs(t, p, state.RootPageID)
+	if len(refs) == 0 {
+		t.Fatal("expected at least one leaf ref")
+	}
+	ptr, ok := page.DecodeLeafRef(refs[0])
+	if !ok {
+		t.Fatal("expected leaf ref id")
+	}
+	leafPage, err := reader.ReadUnsafe(ptr.ValuePtr())
+	if err != nil {
+		t.Fatalf("ReadUnsafe: %v", err)
+	}
+	if len(leafPage) != page.PageSize {
+		setPage, setErr := state.ValueLogSet.ReadUnsafe(ptr.ValuePtr())
+		managerPage, managerErr := db.valueLogReader.ReadUnsafe(ptr.ValuePtr())
+		t.Fatalf("leaf page len=%d want %d (set_len=%d set_err=%v manager_len=%d manager_err=%v)", len(leafPage), page.PageSize, len(setPage), setErr, len(managerPage), managerErr)
+	}
+}
+
+func TestSplitValueLogOwnership_PointerProjectionIteratorDecodesCompactLeafPages(t *testing.T) {
+	db := openSplitValueLogOwnershipTestDB(t)
+	snapper, ok := db.backend.(interface{ AcquireSnapshot() *backenddb.Snapshot })
+	if !ok {
+		t.Fatal("backend missing AcquireSnapshot")
+	}
+	snap := snapper.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("missing backend snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	state := snap.State()
+	p := snap.Pager()
+	if state == nil || p == nil {
+		t.Fatal("missing snapshot state/pager")
+	}
+	reader := newCachedLiveScanReader(valueReaderForBackendState(state), db.valueLogReader)
+	it := tree.New(p, reader, state.RootPageID).IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+	defer it.Close()
+	if !it.Valid() {
+		t.Fatal("expected iterator to yield entries")
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
 	}
 }

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2738,13 +2738,11 @@ func (w *rewriteWriter) appendLeafPageWithRID(rid uint64, leafPage []byte) (page
 	}
 	encodedLeafPage := leafPage
 	if w.leafPagesUseCompactPayload() {
-		var compacted bool
 		var err error
-		encodedLeafPage, compacted, err = valuelog.MaybeCompactLeafLogPayload(leafPage)
+		encodedLeafPage, _, err = valuelog.MaybeCompactLeafLogPayload(leafPage)
 		if err != nil {
 			return page.LeafLogPtr{}, err
 		}
-		_ = compacted
 	}
 	if w.leafDir != "" {
 		return w.appendLeafPageSplit(rid, encodedLeafPage)

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2780,10 +2780,7 @@ func (w *rewriteWriter) leafPagesUseCompactPayload() bool {
 	if w == nil {
 		return false
 	}
-	if w.leafDir != "" {
-		return true
-	}
-	return w.lane == rewriteLeafLogLaneID
+	return w.leafDir != ""
 }
 
 func (w *rewriteWriter) appendLeafPageSplit(rid uint64, leafPage []byte) (page.LeafLogPtr, error) {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2736,14 +2736,24 @@ func (w *rewriteWriter) appendLeafPageWithRID(rid uint64, leafPage []byte) (page
 	if rid == 0 {
 		return page.LeafLogPtr{}, fmt.Errorf("value-log rid space exhausted")
 	}
-	if w.leafDir != "" {
-		return w.appendLeafPageSplit(rid, leafPage)
+	encodedLeafPage := leafPage
+	if w.leafPagesUseCompactPayload() {
+		var compacted bool
+		var err error
+		encodedLeafPage, compacted, err = valuelog.MaybeCompactLeafLogPayload(leafPage)
+		if err != nil {
+			return page.LeafLogPtr{}, err
+		}
+		_ = compacted
 	}
-	if w.blockCompression && w.leafDictID != 0 && len(w.leafDict) > 0 && rewriteAllowDictForSmallPayload(leafPage) {
+	if w.leafDir != "" {
+		return w.appendLeafPageSplit(rid, encodedLeafPage)
+	}
+	if w.blockCompression && w.leafDictID != 0 && len(w.leafDict) > 0 && rewriteAllowDictForSmallPayload(encodedLeafPage) {
 		// LeafRef IDs intentionally omit grouped sub-index bits and therefore
 		// require K=1 frames. Use single-record append so decoded LeafRef pointers
 		// remain stable and do not alias another subrecord in a grouped batch.
-		ptr, err := w.appendSingleValueWithDictClass(rewriteTemplateClassOuterLeaf, w.leafDictID, w.leafDict, rid, leafPage)
+		ptr, err := w.appendSingleValueWithDictClass(rewriteTemplateClassOuterLeaf, w.leafDictID, w.leafDict, rid, encodedLeafPage)
 		if err == nil {
 			w.lastLeafRecordLen = page.ValuePtrRecordLength(ptr)
 			leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
@@ -2756,7 +2766,7 @@ func (w *rewriteWriter) appendLeafPageWithRID(rid uint64, leafPage []byte) (page
 			return page.LeafLogPtr{}, err
 		}
 	}
-	ptr, err := w.appendValueWithDictClass(rewriteTemplateClassOuterLeaf, 0, nil, rid, leafPage)
+	ptr, err := w.appendValueWithDictClass(rewriteTemplateClassOuterLeaf, 0, nil, rid, encodedLeafPage)
 	if err != nil {
 		return page.LeafLogPtr{}, err
 	}
@@ -2766,6 +2776,16 @@ func (w *rewriteWriter) appendLeafPageWithRID(rid uint64, leafPage []byte) (page
 		return page.LeafLogPtr{}, convErr
 	}
 	return leafPtr, nil
+}
+
+func (w *rewriteWriter) leafPagesUseCompactPayload() bool {
+	if w == nil {
+		return false
+	}
+	if w.leafDir != "" {
+		return true
+	}
+	return w.lane == rewriteLeafLogLaneID
 }
 
 func (w *rewriteWriter) appendLeafPageSplit(rid uint64, leafPage []byte) (page.LeafLogPtr, error) {

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -2230,9 +2230,24 @@ func TestRewriteWriter_LeafPagesUseConfiguredLeafLogDir(t *testing.T) {
 	if _, err := w.appendValue(1, []byte("value-payload")); err != nil {
 		t.Fatalf("appendValue: %v", err)
 	}
-	leafPtr, err := w.AppendLeafPage(bytes.Repeat([]byte("l"), 4096))
+	leafBuf := make([]byte, page.PageSize)
+	leafBuilder := node.NewBuilderWithOptions(leafBuf, page.PageTypeLeaf, node.BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+		PackedValuePtr:        true,
+	})
+	for i := 0; i < 4; i++ {
+		if err := leafBuilder.AddLeafEntry([]byte("rewrite-key-"+string(rune('a'+i))), []byte("value"), node.FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry(%d): %v", i, err)
+		}
+	}
+	leafBuilder.FinishNoNode()
+	leafPtr, err := w.AppendLeafPage(leafBuf)
 	if err != nil {
 		t.Fatalf("AppendLeafPage: %v", err)
+	}
+	if got := w.LastLeafPageRecordLength(); got == 0 || int(got) >= valuelog.HeaderSize+page.PageSize {
+		t.Fatalf("LastLeafPageRecordLength=%d want compact leaf payload smaller than raw %d", got, valuelog.HeaderSize+page.PageSize)
 	}
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -2669,6 +2684,46 @@ func TestRewriteWriter_AppendLeafPageUsesLeafDictWhenConfigured(t *testing.T) {
 	}
 	if blockFrames != 0 {
 		t.Fatalf("expected no block-compressed frames when leaf dict is configured, blockFrames=%d", blockFrames)
+	}
+}
+
+func TestRewriteWriter_AppendLeafPageLane0KeepsRawLeafPayload(t *testing.T) {
+	walDir := t.TempDir()
+	w := newRewriteWriter(walDir, 0, 0, 64<<20)
+	w.blockCompression = false
+
+	leafBuf := make([]byte, page.PageSize)
+	leafBuilder := node.NewBuilderWithOptions(leafBuf, page.PageTypeLeaf, node.BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+		PackedValuePtr:        true,
+	})
+	for i := 0; i < 4; i++ {
+		if err := leafBuilder.AddLeafEntry([]byte("lane0-leaf-"+string(rune('a'+i))), []byte("value"), node.FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry(%d): %v", i, err)
+		}
+	}
+	leafBuilder.FinishNoNode()
+	leafPtr, err := w.AppendLeafPage(leafBuf)
+	if err != nil {
+		t.Fatalf("AppendLeafPage: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	mgr, err := valuelog.NewManager(walDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	got, err := mgr.ReadUnsafe(leafPtr.ValuePtr())
+	if err != nil {
+		t.Fatalf("ReadUnsafe: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("ReadUnsafe len=%d want %d", len(got), page.PageSize)
 	}
 }
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -10,6 +10,8 @@ A TreeDB deployment uses:
 
 - `index.db` (paged B+Tree index and metadata),
 - value-log segments (`value-l*.log`),
+- optional split outer-leaf value-log segments under `leaf_vlog/value-l*.log`
+  when `IndexOuterLeavesInValueLog` is enabled,
 - commit-log segments (`commit-l*.log`),
 - optional side-store DBs (`dictdb`, `templatedb`) using their own `index.db` files.
 
@@ -301,6 +303,47 @@ bytes FramePayload
 - If `FrameFlags` indicates compression, frame payload is decoded first.
 - `DictID` selects dictionary for dict-compressed payloads.
 
+### 7.2 Compact split-leaf payload format
+
+When TreeDB writes outer leaf pages into the split `leaf_vlog` directory, it
+may store them in a compact canonical payload format instead of persisting the
+entire raw `4096`-byte page image. This format is used only for split
+`leaf_vlog` segments, not for generic lane-255 value-log files in `value_vlog`.
+
+Compact payload layout:
+
+```text
+u8  Magic[8]        // 8a 4c 46 50 47 01 91 3c
+u16 PrefixLenLE
+u16 SuffixLenLE
+bytes Prefix[PrefixLen]
+bytes Suffix[SuffixLen]
+```
+
+Semantics:
+
+- `Prefix` is the live byte range from the start of the page through the end of
+  the top metadata/directory region.
+- `Suffix` is the live byte range from the first heap byte through the end of
+  the page.
+- The bytes between them are the free gap of the slotted page and are omitted
+  from the stored payload.
+
+Reconstruction rules:
+
+- decoder allocates a full `4096`-byte page buffer,
+- copies `Prefix` at the start,
+- copies `Suffix` at the end,
+- zero-fills the omitted middle gap.
+
+Encoding rules:
+
+- only valid leaf pages may use this compact format,
+- the canonical compact encoding zero-fills the omitted gap and recomputes the
+  page checksum before storing `Prefix` and `Suffix`,
+- if compact encoding is not smaller than the raw page, TreeDB stores the raw
+  page payload instead.
+
 ## 8. Commit-Log Segment Format
 
 Commit-log file is a sequence of segments.
@@ -354,5 +397,6 @@ Current canonical names:
 
 - commit log: `commit-l<lane>-<seq>.log`
 - value log: `value-l<lane>-<seq>.log`
+- split leaf log: `leaf_vlog/value-l<lane>-<seq>.log`
 
 Recovery parser also accepts legacy names (`commit-`, `value-`, `wal-`, `vlog-`) for backward compatibility during pre-alpha evolution.

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -18,7 +18,7 @@ func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
 	}
 	prefixLen, suffixLen, err := node.LeafPageLiveBounds(leafPage)
 	if err != nil {
-		return nil, false, err
+		return leafPage, false, nil
 	}
 	compactLen := compactLeafPagePayloadHeaderSize + prefixLen + suffixLen
 	if compactLen >= len(leafPage) {

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -78,18 +78,18 @@ func allowsCompactLeafLogPayload(fileID uint32, path string) bool {
 	return filepath.Base(filepath.Dir(path)) == compactLeafPagePayloadDirName
 }
 
-func maybeDecodeLeafLogPayloadTo(fileID uint32, path string, payload, dst []byte) ([]byte, bool, error) {
+func maybeDecodeLeafLogPayloadTo(fileID uint32, path string, payload, dst []byte) ([]byte, bool, bool, error) {
 	if !allowsCompactLeafLogPayload(fileID, path) {
-		return payload, false, nil
+		return payload, false, false, nil
 	}
 	out, usedDst, decoded, err := decodeCompactLeafLogPayloadTo(payload, dst)
 	if err != nil {
-		return nil, false, err
+		return nil, false, decoded, err
 	}
 	if decoded {
-		return out, usedDst, nil
+		return out, usedDst, true, nil
 	}
-	return payload, false, nil
+	return payload, false, false, nil
 }
 
 func appendMaybeDecodeLeafLogPayload(fileID uint32, path string, dst, payload []byte) ([]byte, error) {

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -3,6 +3,7 @@ package valuelog
 import (
 	"bytes"
 	"encoding/binary"
+	"path/filepath"
 
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -11,6 +12,7 @@ import (
 var compactLeafPagePayloadMagic = [8]byte{0x8a, 'L', 'F', 'P', 'G', 0x01, 0x91, 0x3c}
 
 const compactLeafPagePayloadHeaderSize = len(compactLeafPagePayloadMagic) + 4
+const compactLeafPagePayloadDirName = "leaf_vlog"
 
 func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
 	if len(leafPage) != page.PageSize {
@@ -69,8 +71,15 @@ func decodeCompactLeafLogPayloadTo(payload, dst []byte) ([]byte, bool, bool, err
 	return out, usedDst, true, nil
 }
 
-func maybeDecodeLeafLogPayloadTo(fileID uint32, payload, dst []byte) ([]byte, bool, error) {
-	if !isLeafLogFileID(fileID) {
+func allowsCompactLeafLogPayload(fileID uint32, path string) bool {
+	if !isLeafLogFileID(fileID) || path == "" {
+		return false
+	}
+	return filepath.Base(filepath.Dir(path)) == compactLeafPagePayloadDirName
+}
+
+func maybeDecodeLeafLogPayloadTo(fileID uint32, path string, payload, dst []byte) ([]byte, bool, error) {
+	if !allowsCompactLeafLogPayload(fileID, path) {
 		return payload, false, nil
 	}
 	out, usedDst, decoded, err := decodeCompactLeafLogPayloadTo(payload, dst)
@@ -83,8 +92,8 @@ func maybeDecodeLeafLogPayloadTo(fileID uint32, payload, dst []byte) ([]byte, bo
 	return payload, false, nil
 }
 
-func appendMaybeDecodeLeafLogPayload(fileID uint32, dst, payload []byte) ([]byte, error) {
-	if !isLeafLogFileID(fileID) {
+func appendMaybeDecodeLeafLogPayload(fileID uint32, path string, dst, payload []byte) ([]byte, error) {
+	if !allowsCompactLeafLogPayload(fileID, path) {
 		if len(payload) == 0 {
 			return dst, nil
 		}

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -1,0 +1,110 @@
+package valuelog
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+var compactLeafPagePayloadMagic = [8]byte{0x8a, 'L', 'F', 'P', 'G', 0x01, 0x91, 0x3c}
+
+const compactLeafPagePayloadHeaderSize = len(compactLeafPagePayloadMagic) + 4
+
+func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
+	if len(leafPage) != page.PageSize {
+		return leafPage, false, nil
+	}
+	prefixLen, suffixLen, err := node.LeafPageLiveBounds(leafPage)
+	if err != nil {
+		return nil, false, err
+	}
+	compactLen := compactLeafPagePayloadHeaderSize + prefixLen + suffixLen
+	if compactLen >= len(leafPage) {
+		return leafPage, false, nil
+	}
+
+	suffixStart := len(leafPage) - suffixLen
+	var canonical [page.PageSize]byte
+	copy(canonical[:prefixLen], leafPage[:prefixLen])
+	copy(canonical[suffixStart:], leafPage[suffixStart:])
+	page.UpdateChecksum(canonical[:])
+
+	payload := make([]byte, compactLen)
+	copy(payload[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:])
+	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic):len(compactLeafPagePayloadMagic)+2], uint16(prefixLen))
+	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic)+2:compactLeafPagePayloadHeaderSize], uint16(suffixLen))
+	copy(payload[compactLeafPagePayloadHeaderSize:compactLeafPagePayloadHeaderSize+prefixLen], canonical[:prefixLen])
+	copy(payload[compactLeafPagePayloadHeaderSize+prefixLen:], canonical[suffixStart:])
+	return payload, true, nil
+}
+
+func decodeCompactLeafLogPayloadTo(payload, dst []byte) ([]byte, bool, bool, error) {
+	if len(payload) < compactLeafPagePayloadHeaderSize || !bytes.Equal(payload[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:]) {
+		return payload, false, false, nil
+	}
+	prefixLen := int(binary.LittleEndian.Uint16(payload[len(compactLeafPagePayloadMagic) : len(compactLeafPagePayloadMagic)+2]))
+	suffixLen := int(binary.LittleEndian.Uint16(payload[len(compactLeafPagePayloadMagic)+2 : compactLeafPagePayloadHeaderSize]))
+	if prefixLen < node.NodeHeaderSize || suffixLen < 0 || prefixLen+suffixLen > page.PageSize {
+		return nil, false, true, ErrCorrupt
+	}
+	if compactLeafPagePayloadHeaderSize+prefixLen+suffixLen != len(payload) {
+		return nil, false, true, ErrCorrupt
+	}
+	if cap(dst) >= page.PageSize && sliceAliasesBytes(dst[:cap(dst)], payload) {
+		payload = append([]byte(nil), payload...)
+	}
+	out := dst
+	usedDst := false
+	if cap(out) >= page.PageSize {
+		out = out[:page.PageSize]
+		clear(out)
+		usedDst = true
+	} else {
+		out = make([]byte, page.PageSize)
+	}
+	copy(out[:prefixLen], payload[compactLeafPagePayloadHeaderSize:compactLeafPagePayloadHeaderSize+prefixLen])
+	copy(out[page.PageSize-suffixLen:], payload[compactLeafPagePayloadHeaderSize+prefixLen:])
+	return out, usedDst, true, nil
+}
+
+func maybeDecodeLeafLogPayloadTo(fileID uint32, payload, dst []byte) ([]byte, bool, error) {
+	if !isLeafLogFileID(fileID) {
+		return payload, false, nil
+	}
+	out, usedDst, decoded, err := decodeCompactLeafLogPayloadTo(payload, dst)
+	if err != nil {
+		return nil, false, err
+	}
+	if decoded {
+		return out, usedDst, nil
+	}
+	return payload, false, nil
+}
+
+func appendMaybeDecodeLeafLogPayload(fileID uint32, dst, payload []byte) ([]byte, error) {
+	if !isLeafLogFileID(fileID) {
+		if len(payload) == 0 {
+			return dst, nil
+		}
+		if cap(dst) >= len(dst)+len(payload) && sliceAliasesBytes(dst[:cap(dst)], payload) {
+			return dst[:len(dst)+len(payload)], nil
+		}
+		return append(dst, payload...), nil
+	}
+	out, _, decoded, err := decodeCompactLeafLogPayloadTo(payload, nil)
+	if err != nil {
+		return nil, err
+	}
+	if decoded {
+		return append(dst, out...), nil
+	}
+	if len(payload) == 0 {
+		return dst, nil
+	}
+	if cap(dst) >= len(dst)+len(payload) && sliceAliasesBytes(dst[:cap(dst)], payload) {
+		return dst[:len(dst)+len(payload)], nil
+	}
+	return append(dst, payload...), nil
+}

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -3,6 +3,7 @@ package valuelog
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -310,6 +311,63 @@ func TestManagerReadUnsafeAppend_DecodesCompactLeafPayload(t *testing.T) {
 	gotNode := node.NewNodeView(got)
 	if typ := gotNode.Type(); typ != page.PageTypeLeaf {
 		t.Fatalf("ReadUnsafeAppend page type=%d want=%d first16=%x", typ, page.PageTypeLeaf, got[:16])
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, got)
+}
+
+func TestManagerReadUnsafeAppend_LeafCompactPayloadUsesMmapPath(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := filepath.Join(dir, fmt.Sprintf("value-l%d-%06d.log", ReservedLeafLogLaneID, 1))
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	ptr, err := w.Append(0, nil, 1, payload)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	f := mgr.files[fileID]
+	if f == nil {
+		t.Fatalf("manager missing file %d", fileID)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	f.mmapData.Store(data)
+
+	got, err := mgr.ReadUnsafeAppend(ptr, make([]byte, 0, page.PageSize))
+	if err != nil {
+		t.Fatalf("ReadUnsafeAppend: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("ReadUnsafeAppend len=%d want %d", len(got), page.PageSize)
+	}
+	if fallbacks := f.mmapReadFallbackReadAt.Load(); fallbacks != 0 {
+		t.Fatalf("mmapReadFallbackReadAt=%d want 0", fallbacks)
 	}
 	requireLeafPagesLogicallyEqual(t, leaf, got)
 }

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
+	templ "github.com/snissn/gomap/TreeDB/template"
 )
 
 func buildSparseLeafPageForPayloadTest(t *testing.T) []byte {
@@ -427,6 +428,54 @@ func TestManagerReadUnsafe_RegularLane255PathDoesNotDecodeCompactLeafPayload(t *
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("ReadUnsafe unexpectedly decoded reserved-lane non-leaf-dir payload")
 	}
+}
+
+func TestReadAtWithDictTo_CompactLeafPayloadDoesNotClaimDstWhenExpanded(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := compactLeafPayloadTestPath(t, dir, 1)
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	ptr, err := w.Append(0, nil, 1, payload)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open(%q): %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	dst := make([]byte, 0, len(payload))
+	got, usedDst, err := ReadAtWithDictTo(f, ptr, true, nil, nil, nil, templ.DecodeOptions{}, dst)
+	if err != nil {
+		t.Fatalf("ReadAtWithDictTo: %v", err)
+	}
+	if usedDst {
+		t.Fatalf("usedDst=true want false when compact leaf expansion allocates a full page")
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("ReadAtWithDictTo len=%d want %d", len(got), page.PageSize)
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, got)
 }
 
 func TestAppendMaybeDecodeLeafLogPayload_DecodesIntoPrefixBuffer(t *testing.T) {

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -29,6 +29,28 @@ func buildSparseLeafPageForPayloadTest(t *testing.T) []byte {
 	return buf
 }
 
+func compactLeafPayloadTestPath(t *testing.T, root string, seq uint32) string {
+	t.Helper()
+	leafDir := filepath.Join(root, compactLeafPagePayloadDirName)
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", leafDir, err)
+	}
+	return filepath.Join(leafDir, fmt.Sprintf("value-l%d-%06d.log", ReservedLeafLogLaneID, seq))
+}
+
+func newLeafPayloadTestManager(t *testing.T, dir, path string, fileID uint32) *Manager {
+	t.Helper()
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := mgr.RegisterSegment(path, fileID); err != nil {
+		_ = mgr.Close()
+		t.Fatalf("RegisterSegment(%q): %v", path, err)
+	}
+	return mgr
+}
+
 func requireLeafPagesLogicallyEqual(t *testing.T, want, got []byte) {
 	t.Helper()
 	wantNode := node.NewNodeView(want)
@@ -139,7 +161,8 @@ func TestManagerReadUnsafeTo_DecodesCompactLeafPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	w, err := NewWriter(filepath.Join(dir, fmt.Sprintf("value-l%d-%06d.log", ReservedLeafLogLaneID, 1)), fileID)
+	path := compactLeafPayloadTestPath(t, dir, 1)
+	w, err := NewWriter(path, fileID)
 	if err != nil {
 		t.Fatalf("NewWriter: %v", err)
 	}
@@ -160,10 +183,7 @@ func TestManagerReadUnsafeTo_DecodesCompactLeafPayload(t *testing.T) {
 		t.Fatalf("Close writer: %v", err)
 	}
 
-	mgr, err := NewManager(dir)
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
+	mgr := newLeafPayloadTestManager(t, dir, path, fileID)
 	defer func() { _ = mgr.Close() }()
 
 	dst := make([]byte, 0, page.PageSize)
@@ -186,7 +206,8 @@ func TestManagerReadUnsafe_DecodesCompactLeafPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	w, err := NewWriter(filepath.Join(dir, fmt.Sprintf("value-l%d-%06d.log", ReservedLeafLogLaneID, 1)), fileID)
+	path := compactLeafPayloadTestPath(t, dir, 1)
+	w, err := NewWriter(path, fileID)
 	if err != nil {
 		t.Fatalf("NewWriter: %v", err)
 	}
@@ -207,10 +228,7 @@ func TestManagerReadUnsafe_DecodesCompactLeafPayload(t *testing.T) {
 		t.Fatalf("Close writer: %v", err)
 	}
 
-	mgr, err := NewManager(dir)
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
+	mgr := newLeafPayloadTestManager(t, dir, path, fileID)
 	defer func() { _ = mgr.Close() }()
 
 	got, err := mgr.ReadUnsafe(ptr)
@@ -229,7 +247,8 @@ func TestSetReadUnsafe_DecodesCompactLeafPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	w, err := NewWriter(filepath.Join(dir, fmt.Sprintf("value-l%d-%06d.log", ReservedLeafLogLaneID, 1)), fileID)
+	path := compactLeafPayloadTestPath(t, dir, 1)
+	w, err := NewWriter(path, fileID)
 	if err != nil {
 		t.Fatalf("NewWriter: %v", err)
 	}
@@ -250,10 +269,7 @@ func TestSetReadUnsafe_DecodesCompactLeafPayload(t *testing.T) {
 		t.Fatalf("Close writer: %v", err)
 	}
 
-	mgr, err := NewManager(dir)
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
+	mgr := newLeafPayloadTestManager(t, dir, path, fileID)
 	defer func() { _ = mgr.Close() }()
 
 	set := mgr.CurrentSetNoRefresh()
@@ -274,7 +290,8 @@ func TestManagerReadUnsafeAppend_DecodesCompactLeafPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileID: %v", err)
 	}
-	w, err := NewWriter(filepath.Join(dir, fmt.Sprintf("value-l%d-%06d.log", ReservedLeafLogLaneID, 1)), fileID)
+	path := compactLeafPayloadTestPath(t, dir, 1)
+	w, err := NewWriter(path, fileID)
 	if err != nil {
 		t.Fatalf("NewWriter: %v", err)
 	}
@@ -295,10 +312,7 @@ func TestManagerReadUnsafeAppend_DecodesCompactLeafPayload(t *testing.T) {
 		t.Fatalf("Close writer: %v", err)
 	}
 
-	mgr, err := NewManager(dir)
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
+	mgr := newLeafPayloadTestManager(t, dir, path, fileID)
 	defer func() { _ = mgr.Close() }()
 
 	got, err := mgr.ReadUnsafeAppend(ptr, make([]byte, 0, page.PageSize))
@@ -316,6 +330,60 @@ func TestManagerReadUnsafeAppend_DecodesCompactLeafPayload(t *testing.T) {
 }
 
 func TestManagerReadUnsafeAppend_LeafCompactPayloadUsesMmapPath(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := compactLeafPayloadTestPath(t, dir, 1)
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	ptr, err := w.Append(0, nil, 1, payload)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	mgr := newLeafPayloadTestManager(t, dir, path, fileID)
+	defer func() { _ = mgr.Close() }()
+
+	f := mgr.files[fileID]
+	if f == nil {
+		t.Fatalf("manager missing file %d", fileID)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	f.mmapData.Store(data)
+
+	got, err := mgr.ReadUnsafeAppend(ptr, make([]byte, 0, page.PageSize))
+	if err != nil {
+		t.Fatalf("ReadUnsafeAppend: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("ReadUnsafeAppend len=%d want %d", len(got), page.PageSize)
+	}
+	if fallbacks := f.mmapReadFallbackReadAt.Load(); fallbacks != 0 {
+		t.Fatalf("mmapReadFallbackReadAt=%d want 0", fallbacks)
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, got)
+}
+
+func TestManagerReadUnsafe_RegularLane255PathDoesNotDecodeCompactLeafPayload(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
 	if err != nil {
@@ -349,27 +417,16 @@ func TestManagerReadUnsafeAppend_LeafCompactPayloadUsesMmapPath(t *testing.T) {
 	}
 	defer func() { _ = mgr.Close() }()
 
-	f := mgr.files[fileID]
-	if f == nil {
-		t.Fatalf("manager missing file %d", fileID)
-	}
-	data, err := os.ReadFile(path)
+	got, err := mgr.ReadUnsafe(ptr)
 	if err != nil {
-		t.Fatalf("ReadFile(%q): %v", path, err)
+		t.Fatalf("ReadUnsafe: %v", err)
 	}
-	f.mmapData.Store(data)
-
-	got, err := mgr.ReadUnsafeAppend(ptr, make([]byte, 0, page.PageSize))
-	if err != nil {
-		t.Fatalf("ReadUnsafeAppend: %v", err)
+	if len(got) != len(payload) {
+		t.Fatalf("ReadUnsafe len=%d want raw compact payload len=%d", len(got), len(payload))
 	}
-	if len(got) != page.PageSize {
-		t.Fatalf("ReadUnsafeAppend len=%d want %d", len(got), page.PageSize)
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("ReadUnsafe unexpectedly decoded reserved-lane non-leaf-dir payload")
 	}
-	if fallbacks := f.mmapReadFallbackReadAt.Load(); fallbacks != 0 {
-		t.Fatalf("mmapReadFallbackReadAt=%d want 0", fallbacks)
-	}
-	requireLeafPagesLogicallyEqual(t, leaf, got)
 }
 
 func TestAppendMaybeDecodeLeafLogPayload_DecodesIntoPrefixBuffer(t *testing.T) {
@@ -383,7 +440,7 @@ func TestAppendMaybeDecodeLeafLogPayload_DecodesIntoPrefixBuffer(t *testing.T) {
 	}
 	dst := make([]byte, 0, page.PageSize)
 	dst = append(dst, payload...)
-	got, err := appendMaybeDecodeLeafLogPayload(mustEncodeFileID(t, ReservedLeafLogLaneID, 1), dst[:0], dst)
+	got, err := appendMaybeDecodeLeafLogPayload(mustEncodeFileID(t, ReservedLeafLogLaneID, 1), filepath.Join("db", compactLeafPagePayloadDirName, "value-l255-000001.log"), dst[:0], dst)
 	if err != nil {
 		t.Fatalf("appendMaybeDecodeLeafLogPayload: %v", err)
 	}

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -1,0 +1,336 @@
+package valuelog
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func buildSparseLeafPageForPayloadTest(t *testing.T) []byte {
+	t.Helper()
+	buf := make([]byte, page.PageSize)
+	b := node.NewBuilderWithOptions(buf, page.PageTypeLeaf, node.BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+		PackedValuePtr:        true,
+	})
+	b.SetPageID(17)
+	for i := 0; i < 4; i++ {
+		if err := b.AddLeafEntry([]byte("celestia/outer/leaf/key/"+string(rune('a'+i))), []byte("value"), node.FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry(%d): %v", i, err)
+		}
+	}
+	b.FinishNoNode()
+	return buf
+}
+
+func requireLeafPagesLogicallyEqual(t *testing.T, want, got []byte) {
+	t.Helper()
+	wantNode := node.NewNodeView(want)
+	gotNode := node.NewNodeView(got)
+	if wantNode.Type() != gotNode.Type() {
+		t.Fatalf("page types differ: got=%d want=%d", gotNode.Type(), wantNode.Type())
+	}
+	if wantNode.Count() != gotNode.Count() {
+		t.Fatalf("page counts differ: got=%d want=%d", gotNode.Count(), wantNode.Count())
+	}
+	for i := uint16(0); i < wantNode.Count(); i++ {
+		wantKey, wantVal, wantPtr, wantFlags, err := wantNode.GetLeafEntryView(i)
+		if err != nil {
+			t.Fatalf("want GetLeafEntryView(%d): %v", i, err)
+		}
+		gotKey, gotVal, gotPtr, gotFlags, err := gotNode.GetLeafEntryView(i)
+		if err != nil {
+			t.Fatalf("got GetLeafEntryView(%d): %v", i, err)
+		}
+		if !bytes.Equal(gotKey, wantKey) || !bytes.Equal(gotVal, wantVal) || gotPtr != wantPtr || gotFlags != wantFlags {
+			t.Fatalf("leaf entry %d mismatch", i)
+		}
+	}
+}
+
+func TestMaybeCompactLeafLogPayload_SparseLeafRoundTrips(t *testing.T) {
+	leaf := buildSparseLeafPageForPayloadTest(t)
+
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	if len(payload) >= len(leaf) {
+		t.Fatalf("payload len=%d want < %d", len(payload), len(leaf))
+	}
+
+	decoded, usedDst, decodedFlag, err := decodeCompactLeafLogPayloadTo(payload, make([]byte, 0, page.PageSize))
+	if err != nil {
+		t.Fatalf("decodeCompactLeafLogPayloadTo: %v", err)
+	}
+	if !decodedFlag {
+		t.Fatalf("expected compact payload to decode")
+	}
+	if !usedDst {
+		t.Fatalf("expected decode to reuse dst")
+	}
+	if len(decoded) != page.PageSize {
+		t.Fatalf("decoded len=%d want %d", len(decoded), page.PageSize)
+	}
+	if !page.VerifyChecksumNonMutating(decoded) {
+		t.Fatalf("decoded page checksum mismatch")
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, decoded)
+}
+
+func TestDecodeCompactLeafLogPayloadTo_AliasedDstRoundTrips(t *testing.T) {
+	leaf := buildSparseLeafPageForPayloadTest(t)
+
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+
+	buf := make([]byte, 0, page.PageSize)
+	buf = append(buf, payload...)
+	decoded, usedDst, decodedFlag, err := decodeCompactLeafLogPayloadTo(buf, buf[:0])
+	if err != nil {
+		t.Fatalf("decodeCompactLeafLogPayloadTo: %v", err)
+	}
+	if !decodedFlag {
+		t.Fatalf("expected compact payload to decode")
+	}
+	if !usedDst {
+		t.Fatalf("expected decode to reuse aliased dst")
+	}
+	if len(decoded) != page.PageSize {
+		t.Fatalf("decoded len=%d want %d", len(decoded), page.PageSize)
+	}
+	if !page.VerifyChecksumNonMutating(decoded) {
+		t.Fatalf("decoded page checksum mismatch")
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, decoded)
+}
+
+func TestMaybeCompactLeafLogPayload_PassthroughNonPagePayload(t *testing.T) {
+	raw := []byte("not-a-leaf-page")
+	payload, compacted, err := MaybeCompactLeafLogPayload(raw)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if compacted {
+		t.Fatalf("expected passthrough for non-page payload")
+	}
+	if !bytes.Equal(payload, raw) {
+		t.Fatalf("payload changed for passthrough case")
+	}
+}
+
+func TestManagerReadUnsafeTo_DecodesCompactLeafPayload(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	w, err := NewWriter(filepath.Join(dir, fmt.Sprintf("value-l%d-%06d.log", ReservedLeafLogLaneID, 1)), fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	ptr, err := w.Append(0, nil, 1, payload)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	dst := make([]byte, 0, page.PageSize)
+	got, usedDst, err := mgr.ReadUnsafeTo(ptr, dst)
+	if err != nil {
+		t.Fatalf("ReadUnsafeTo: %v", err)
+	}
+	if !usedDst {
+		t.Fatalf("expected ReadUnsafeTo to reuse dst for compact leaf page")
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("ReadUnsafeTo len=%d want %d", len(got), page.PageSize)
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, got)
+}
+
+func TestManagerReadUnsafe_DecodesCompactLeafPayload(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	w, err := NewWriter(filepath.Join(dir, fmt.Sprintf("value-l%d-%06d.log", ReservedLeafLogLaneID, 1)), fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	ptr, err := w.Append(0, nil, 1, payload)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	got, err := mgr.ReadUnsafe(ptr)
+	if err != nil {
+		t.Fatalf("ReadUnsafe: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("ReadUnsafe len=%d want %d", len(got), page.PageSize)
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, got)
+}
+
+func TestSetReadUnsafe_DecodesCompactLeafPayload(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	w, err := NewWriter(filepath.Join(dir, fmt.Sprintf("value-l%d-%06d.log", ReservedLeafLogLaneID, 1)), fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	ptr, err := w.Append(0, nil, 1, payload)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	set := mgr.CurrentSetNoRefresh()
+	defer func() { _ = mgr.Release(set) }()
+	got, err := set.ReadUnsafe(ptr)
+	if err != nil {
+		t.Fatalf("ReadUnsafe: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("Set.ReadUnsafe len=%d want %d", len(got), page.PageSize)
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, got)
+}
+
+func TestManagerReadUnsafeAppend_DecodesCompactLeafPayload(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	w, err := NewWriter(filepath.Join(dir, fmt.Sprintf("value-l%d-%06d.log", ReservedLeafLogLaneID, 1)), fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	ptr, err := w.Append(0, nil, 1, payload)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	got, err := mgr.ReadUnsafeAppend(ptr, make([]byte, 0, page.PageSize))
+	if err != nil {
+		t.Fatalf("ReadUnsafeAppend: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("ReadUnsafeAppend len=%d want %d", len(got), page.PageSize)
+	}
+	gotNode := node.NewNodeView(got)
+	if typ := gotNode.Type(); typ != page.PageTypeLeaf {
+		t.Fatalf("ReadUnsafeAppend page type=%d want=%d first16=%x", typ, page.PageTypeLeaf, got[:16])
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, got)
+}
+
+func TestAppendMaybeDecodeLeafLogPayload_DecodesIntoPrefixBuffer(t *testing.T) {
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	dst := make([]byte, 0, page.PageSize)
+	dst = append(dst, payload...)
+	got, err := appendMaybeDecodeLeafLogPayload(mustEncodeFileID(t, ReservedLeafLogLaneID, 1), dst[:0], dst)
+	if err != nil {
+		t.Fatalf("appendMaybeDecodeLeafLogPayload: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("appendMaybeDecodeLeafLogPayload len=%d want %d", len(got), page.PageSize)
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, got)
+}

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -460,7 +460,14 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 	}
 	if val, err, ok := f.readViaMmap(ptr, verifyCRC); ok {
 		f.mmapReadHits.Add(1)
-		return val, err
+		if err != nil {
+			return nil, err
+		}
+		val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, val, nil)
+		if err != nil {
+			return nil, err
+		}
+		return val, nil
 	}
 	data, _ := f.mmapData.Load().([]byte)
 	if data != nil && deadMappingsCapExhausted(f.deadMappingsCount.Load(), len(data)) {
@@ -469,7 +476,14 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 	if !verifyCRC {
 		if val, _, err, ok := f.readGroupedCompressedFromFileTo(ptr, nil); ok {
 			f.mmapReadFallbackReadAt.Add(1)
-			return val, err
+			if err != nil {
+				return nil, err
+			}
+			val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, val, nil)
+			if err != nil {
+				return nil, err
+			}
+			return val, nil
 		}
 	}
 	f.mmapReadFallbackReadAt.Add(1)
@@ -485,13 +499,27 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 	}
 	if val, err, ok := f.readViaMmapView(ptr, verifyCRC); ok {
 		f.mmapReadHits.Add(1)
-		return val, err
+		if err != nil {
+			return nil, err
+		}
+		val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, val, nil)
+		if err != nil {
+			return nil, err
+		}
+		return val, nil
 	}
 	if !f.usesPersistentMmap() {
 		if f.tryEnableSealedLazyMmap() {
 			if val, err, ok := f.readViaMmapView(ptr, verifyCRC); ok {
 				f.mmapReadHits.Add(1)
-				return val, err
+				if err != nil {
+					return nil, err
+				}
+				val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, val, nil)
+				if err != nil {
+					return nil, err
+				}
+				return val, nil
 			}
 		}
 		f.mmapReadFallbackReadAt.Add(1)
@@ -504,7 +532,14 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		f.remapToFileSize()
 		if val, err, ok := f.readViaMmapView(ptr, verifyCRC); ok {
 			f.mmapReadHits.Add(1)
-			return val, err
+			if err != nil {
+				return nil, err
+			}
+			val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, val, nil)
+			if err != nil {
+				return nil, err
+			}
+			return val, nil
 		}
 	} else {
 		f.mmapReadMissDeadMappingCap.Add(1)
@@ -525,19 +560,40 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 	}
 	if val, usedDst, err, ok := f.readViaMmapViewTo(ptr, verifyCRC, dst); ok {
 		f.mmapReadHits.Add(1)
-		return val, usedDst, err
+		if err != nil {
+			return nil, false, err
+		}
+		val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, val, dst)
+		if err != nil {
+			return nil, false, err
+		}
+		return val, compactUsedDst || usedDst, nil
 	}
 	if !f.usesPersistentMmap() {
 		if f.tryEnableSealedLazyMmap() {
 			if val, usedDst, err, ok := f.readViaMmapViewTo(ptr, verifyCRC, dst); ok {
 				f.mmapReadHits.Add(1)
-				return val, usedDst, err
+				if err != nil {
+					return nil, false, err
+				}
+				val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, val, dst)
+				if err != nil {
+					return nil, false, err
+				}
+				return val, compactUsedDst || usedDst, nil
 			}
 		}
 		f.mmapReadFallbackReadAt.Add(1)
 		if !verifyCRC {
 			if val, usedDst, err, ok := f.readGroupedCompressedFromFileTo(ptr, dst); ok {
-				return val, usedDst, err
+				if err != nil {
+					return nil, false, err
+				}
+				val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, val, dst)
+				if err != nil {
+					return nil, false, err
+				}
+				return val, compactUsedDst || usedDst, nil
 			}
 		}
 		return ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
@@ -549,7 +605,14 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 		f.remapToFileSize()
 		if val, usedDst, err, ok := f.readViaMmapViewTo(ptr, verifyCRC, dst); ok {
 			f.mmapReadHits.Add(1)
-			return val, usedDst, err
+			if err != nil {
+				return nil, false, err
+			}
+			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, val, dst)
+			if err != nil {
+				return nil, false, err
+			}
+			return val, compactUsedDst || usedDst, nil
 		}
 	} else {
 		f.mmapReadMissDeadMappingCap.Add(1)
@@ -557,7 +620,14 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 	f.mmapReadFallbackReadAt.Add(1)
 	if !verifyCRC {
 		if val, usedDst, err, ok := f.readGroupedCompressedFromFileTo(ptr, dst); ok {
-			return val, usedDst, err
+			if err != nil {
+				return nil, false, err
+			}
+			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, val, dst)
+			if err != nil {
+				return nil, false, err
+			}
+			return val, compactUsedDst || usedDst, nil
 		}
 	}
 	return ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
@@ -720,6 +790,17 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 	}
 	if err := f.ensureCurrentWritableReadable(); err != nil {
 		return nil, err
+	}
+	if isLeafLogFileID(f.ID) {
+		f.mmapReadFallbackReadAt.Add(1)
+		val, err := ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+		if err != nil {
+			return nil, err
+		}
+		oldLen := len(dst)
+		dst = grow(dst, len(val))
+		copy(dst[oldLen:], val)
+		return dst, nil
 	}
 	if val, err, ok := f.readViaMmapAppend(ptr, verifyCRC, dst); ok {
 		f.mmapReadHits.Add(1)
@@ -885,10 +966,14 @@ func (f *File) appendPayloadFromFile(dst []byte, off int64, payloadLen int) ([]b
 		return nil, err
 	}
 	if f.templateLookup == nil || !templ.IsEncodedPayload(payload) {
-		return dst, nil
+		return appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], payload)
 	}
 	encoded := append([]byte(nil), payload...)
-	return appendDecodedTemplatePayload(dst[:oldLen], encoded, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+	decoded, err := appendDecodedTemplatePayload(dst[:oldLen], encoded, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+	if err != nil {
+		return nil, err
+	}
+	return appendMaybeDecodeLeafLogPayload(f.ID, decoded[:oldLen], decoded[oldLen:])
 }
 
 // Set is an immutable snapshot of value-log files for snapshot isolation.

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -113,6 +113,13 @@ type File struct {
 	mmapReadFallbackReadAt atomic.Uint64
 }
 
+func (f *File) allowsCompactLeafPayload() bool {
+	if f == nil {
+		return false
+	}
+	return allowsCompactLeafLogPayload(f.ID, f.Path)
+}
+
 func openFile(path string, id uint32, dictLookup DictLookup, templateLookup TemplateLookup, templateOpts templ.DecodeOptions, templateCache *templateDefCache) (*File, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -463,7 +470,7 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, val, nil)
+		val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -479,7 +486,7 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, val, nil)
+			val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -502,7 +509,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, val, nil)
+		val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -515,7 +522,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 				if err != nil {
 					return nil, err
 				}
-				val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, val, nil)
+				val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
 				if err != nil {
 					return nil, err
 				}
@@ -535,7 +542,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, val, nil)
+			val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -563,7 +570,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 		if err != nil {
 			return nil, false, err
 		}
-		val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, val, dst)
+		val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
 		if err != nil {
 			return nil, false, err
 		}
@@ -576,7 +583,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 				if err != nil {
 					return nil, false, err
 				}
-				val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, val, dst)
+				val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
 				if err != nil {
 					return nil, false, err
 				}
@@ -589,7 +596,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 				if err != nil {
 					return nil, false, err
 				}
-				val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, val, dst)
+				val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
 				if err != nil {
 					return nil, false, err
 				}
@@ -608,7 +615,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 			if err != nil {
 				return nil, false, err
 			}
-			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, val, dst)
+			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
 			if err != nil {
 				return nil, false, err
 			}
@@ -623,7 +630,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 			if err != nil {
 				return nil, false, err
 			}
-			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, val, dst)
+			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
 			if err != nil {
 				return nil, false, err
 			}
@@ -955,14 +962,14 @@ func (f *File) appendPayloadFromFile(dst []byte, off int64, payloadLen int) ([]b
 		return nil, err
 	}
 	if f.templateLookup == nil || !templ.IsEncodedPayload(payload) {
-		return appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], payload)
+		return appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], payload)
 	}
 	encoded := append([]byte(nil), payload...)
 	decoded, err := appendDecodedTemplatePayload(dst[:oldLen], encoded, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
 	if err != nil {
 		return nil, err
 	}
-	return appendMaybeDecodeLeafLogPayload(f.ID, decoded[:oldLen], decoded[oldLen:])
+	return appendMaybeDecodeLeafLogPayload(f.ID, f.Path, decoded[:oldLen], decoded[oldLen:])
 }
 
 // Set is an immutable snapshot of value-log files for snapshot isolation.

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -470,7 +470,7 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+		val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -486,7 +486,7 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+			val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -509,7 +509,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+		val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -522,7 +522,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 				if err != nil {
 					return nil, err
 				}
-				val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+				val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
 				if err != nil {
 					return nil, err
 				}
@@ -542,7 +542,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			val, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+			val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -570,11 +570,14 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 		if err != nil {
 			return nil, false, err
 		}
-		val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+		val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
 		if err != nil {
 			return nil, false, err
 		}
-		return val, compactUsedDst || usedDst, nil
+		if compactDecoded {
+			return val, compactUsedDst, nil
+		}
+		return val, usedDst, nil
 	}
 	if !f.usesPersistentMmap() {
 		if f.tryEnableSealedLazyMmap() {
@@ -583,11 +586,14 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 				if err != nil {
 					return nil, false, err
 				}
-				val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+				val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
 				if err != nil {
 					return nil, false, err
 				}
-				return val, compactUsedDst || usedDst, nil
+				if compactDecoded {
+					return val, compactUsedDst, nil
+				}
+				return val, usedDst, nil
 			}
 		}
 		f.mmapReadFallbackReadAt.Add(1)
@@ -596,11 +602,14 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 				if err != nil {
 					return nil, false, err
 				}
-				val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+				val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
 				if err != nil {
 					return nil, false, err
 				}
-				return val, compactUsedDst || usedDst, nil
+				if compactDecoded {
+					return val, compactUsedDst, nil
+				}
+				return val, usedDst, nil
 			}
 		}
 		return ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
@@ -615,11 +624,14 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 			if err != nil {
 				return nil, false, err
 			}
-			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+			val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
 			if err != nil {
 				return nil, false, err
 			}
-			return val, compactUsedDst || usedDst, nil
+			if compactDecoded {
+				return val, compactUsedDst, nil
+			}
+			return val, usedDst, nil
 		}
 	} else {
 		f.mmapReadMissDeadMappingCap.Add(1)
@@ -630,11 +642,14 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 			if err != nil {
 				return nil, false, err
 			}
-			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+			val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
 			if err != nil {
 				return nil, false, err
 			}
-			return val, compactUsedDst || usedDst, nil
+			if compactDecoded {
+				return val, compactUsedDst, nil
+			}
+			return val, usedDst, nil
 		}
 	}
 	return ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -791,17 +791,6 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 	if err := f.ensureCurrentWritableReadable(); err != nil {
 		return nil, err
 	}
-	if isLeafLogFileID(f.ID) {
-		f.mmapReadFallbackReadAt.Add(1)
-		val, err := ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
-		if err != nil {
-			return nil, err
-		}
-		oldLen := len(dst)
-		dst = grow(dst, len(val))
-		copy(dst[oldLen:], val)
-		return dst, nil
-	}
 	if val, err, ok := f.readViaMmapAppend(ptr, verifyCRC, dst); ok {
 		f.mmapReadHits.Add(1)
 		return val, err

--- a/TreeDB/internal/valuelog/reader.go
+++ b/TreeDB/internal/valuelog/reader.go
@@ -296,6 +296,13 @@ func (r *Reader) ReadNext() (uint64, []byte, page.ValuePtr, error) {
 			Length: recordLen,
 			FileID: r.fileID,
 		}
+		if r.fileID == 0 {
+			return rid, payload, ptr, nil
+		}
+		payload, _, err := maybeDecodeLeafLogPayloadTo(r.fileID, payload, nil)
+		if err != nil {
+			return 0, nil, page.ValuePtr{}, err
+		}
 		return rid, payload, ptr, nil
 	}
 
@@ -357,6 +364,10 @@ func (r *Reader) ReadNext() (uint64, []byte, page.ValuePtr, error) {
 					return 0, nil, page.ValuePtr{}, decErr
 				}
 				val = decoded
+			}
+			val, _, err = maybeDecodeLeafLogPayloadTo(r.fileID, val, nil)
+			if err != nil {
+				return 0, nil, page.ValuePtr{}, err
 			}
 		}
 		r.pending = append(r.pending, frameEntry{rid: frameRID, value: val, ptr: ptr})
@@ -810,7 +821,15 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 				if err != nil {
 					return nil, err
 				}
+				decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, decoded, nil)
+				if err != nil {
+					return nil, err
+				}
 				return decoded, nil
+			}
+			val, _, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, val, nil)
+			if err != nil {
+				return nil, err
 			}
 			return val, nil
 		}
@@ -826,7 +845,15 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 			return nil, ErrCorrupt
 		}
 	}
-	return decodeRecord(header[:], payload, ptr, false, dictLookup, templateLookup, templateCache, templateOpts)
+	val, err := decodeRecord(header[:], payload, ptr, false, dictLookup, templateLookup, templateCache, templateOpts)
+	if err != nil {
+		return nil, err
+	}
+	val, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, val, nil)
+	if err != nil {
+		return nil, err
+	}
+	return val, nil
 }
 
 // ReadAtWithDictTo is ReadAtWithDict with caller-provided decode storage.
@@ -961,9 +988,17 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 				if err != nil {
 					return nil, false, err
 				}
+				decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, decoded, nil)
+				if err != nil {
+					return nil, false, err
+				}
 				return decoded, false, nil
 			}
-			return val, usedDst, nil
+			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, val, dst)
+			if err != nil {
+				return nil, false, err
+			}
+			return val, compactUsedDst || usedDst, nil
 		}
 	}
 
@@ -994,9 +1029,17 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 			if err != nil {
 				return nil, false, err
 			}
+			decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, decoded, nil)
+			if err != nil {
+				return nil, false, err
+			}
 			return decoded, false, nil
 		}
-		return payload, usedDst, nil
+		payload, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, payload, dst)
+		if err != nil {
+			return nil, false, err
+		}
+		return payload, compactUsedDst || usedDst, nil
 	}
 
 	payloadScratch := getDecodeScratch(int(valueLen))
@@ -1017,12 +1060,17 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 		putDecodeScratch(payloadScratch)
 		return nil, false, err
 	}
+	val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, val, dst)
+	if err != nil {
+		putDecodeScratch(payloadScratch)
+		return nil, false, err
+	}
 	// Safe to return payload scratch to the pool whenever the returned slice
 	// does not alias the payload buffer backed by payloadScratch.
-	if usedDst || !sliceAliasesBytes(payload, val) {
+	if compactUsedDst || usedDst || !sliceAliasesBytes(payload, val) {
 		putDecodeScratch(payloadScratch)
 	}
-	return val, usedDst, nil
+	return val, compactUsedDst || usedDst, nil
 }
 
 func decodeRecord(header []byte, payload []byte, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions) ([]byte, error) {

--- a/TreeDB/internal/valuelog/reader.go
+++ b/TreeDB/internal/valuelog/reader.go
@@ -299,7 +299,7 @@ func (r *Reader) ReadNext() (uint64, []byte, page.ValuePtr, error) {
 		if r.fileID == 0 {
 			return rid, payload, ptr, nil
 		}
-		payload, _, err := maybeDecodeLeafLogPayloadTo(r.fileID, r.f.Name(), payload, nil)
+		payload, _, _, err := maybeDecodeLeafLogPayloadTo(r.fileID, r.f.Name(), payload, nil)
 		if err != nil {
 			return 0, nil, page.ValuePtr{}, err
 		}
@@ -365,7 +365,7 @@ func (r *Reader) ReadNext() (uint64, []byte, page.ValuePtr, error) {
 				}
 				val = decoded
 			}
-			val, _, err = maybeDecodeLeafLogPayloadTo(r.fileID, r.f.Name(), val, nil)
+			val, _, _, err = maybeDecodeLeafLogPayloadTo(r.fileID, r.f.Name(), val, nil)
 			if err != nil {
 				return 0, nil, page.ValuePtr{}, err
 			}
@@ -821,13 +821,13 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 				if err != nil {
 					return nil, err
 				}
-				decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
+				decoded, _, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
 				if err != nil {
 					return nil, err
 				}
 				return decoded, nil
 			}
-			val, _, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, nil)
+			val, _, _, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -849,7 +849,7 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 	if err != nil {
 		return nil, err
 	}
-	val, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, nil)
+	val, _, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -988,17 +988,20 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 				if err != nil {
 					return nil, false, err
 				}
-				decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
+				decoded, _, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
 				if err != nil {
 					return nil, false, err
 				}
 				return decoded, false, nil
 			}
-			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, dst)
+			val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, dst)
 			if err != nil {
 				return nil, false, err
 			}
-			return val, compactUsedDst || usedDst, nil
+			if compactDecoded {
+				return val, compactUsedDst, nil
+			}
+			return val, usedDst, nil
 		}
 	}
 
@@ -1029,17 +1032,20 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 			if err != nil {
 				return nil, false, err
 			}
-			decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
+			decoded, _, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
 			if err != nil {
 				return nil, false, err
 			}
 			return decoded, false, nil
 		}
-		payload, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), payload, dst)
+		payload, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), payload, dst)
 		if err != nil {
 			return nil, false, err
 		}
-		return payload, compactUsedDst || usedDst, nil
+		if compactDecoded {
+			return payload, compactUsedDst, nil
+		}
+		return payload, usedDst, nil
 	}
 
 	payloadScratch := getDecodeScratch(int(valueLen))
@@ -1060,17 +1066,21 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 		putDecodeScratch(payloadScratch)
 		return nil, false, err
 	}
-	val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, dst)
+	val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, dst)
 	if err != nil {
 		putDecodeScratch(payloadScratch)
 		return nil, false, err
 	}
 	// Safe to return payload scratch to the pool whenever the returned slice
 	// does not alias the payload buffer backed by payloadScratch.
-	if compactUsedDst || usedDst || !sliceAliasesBytes(payload, val) {
+	finalUsedDst := usedDst
+	if compactDecoded {
+		finalUsedDst = compactUsedDst
+	}
+	if finalUsedDst || !sliceAliasesBytes(payload, val) {
 		putDecodeScratch(payloadScratch)
 	}
-	return val, compactUsedDst || usedDst, nil
+	return val, finalUsedDst, nil
 }
 
 func decodeRecord(header []byte, payload []byte, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions) ([]byte, error) {

--- a/TreeDB/internal/valuelog/reader.go
+++ b/TreeDB/internal/valuelog/reader.go
@@ -299,7 +299,7 @@ func (r *Reader) ReadNext() (uint64, []byte, page.ValuePtr, error) {
 		if r.fileID == 0 {
 			return rid, payload, ptr, nil
 		}
-		payload, _, err := maybeDecodeLeafLogPayloadTo(r.fileID, payload, nil)
+		payload, _, err := maybeDecodeLeafLogPayloadTo(r.fileID, r.f.Name(), payload, nil)
 		if err != nil {
 			return 0, nil, page.ValuePtr{}, err
 		}
@@ -365,7 +365,7 @@ func (r *Reader) ReadNext() (uint64, []byte, page.ValuePtr, error) {
 				}
 				val = decoded
 			}
-			val, _, err = maybeDecodeLeafLogPayloadTo(r.fileID, val, nil)
+			val, _, err = maybeDecodeLeafLogPayloadTo(r.fileID, r.f.Name(), val, nil)
 			if err != nil {
 				return 0, nil, page.ValuePtr{}, err
 			}
@@ -821,13 +821,13 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 				if err != nil {
 					return nil, err
 				}
-				decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, decoded, nil)
+				decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
 				if err != nil {
 					return nil, err
 				}
 				return decoded, nil
 			}
-			val, _, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, val, nil)
+			val, _, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -849,7 +849,7 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 	if err != nil {
 		return nil, err
 	}
-	val, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, val, nil)
+	val, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -988,13 +988,13 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 				if err != nil {
 					return nil, false, err
 				}
-				decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, decoded, nil)
+				decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
 				if err != nil {
 					return nil, false, err
 				}
 				return decoded, false, nil
 			}
-			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, val, dst)
+			val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, dst)
 			if err != nil {
 				return nil, false, err
 			}
@@ -1029,13 +1029,13 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 			if err != nil {
 				return nil, false, err
 			}
-			decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, decoded, nil)
+			decoded, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
 			if err != nil {
 				return nil, false, err
 			}
 			return decoded, false, nil
 		}
-		payload, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, payload, dst)
+		payload, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), payload, dst)
 		if err != nil {
 			return nil, false, err
 		}
@@ -1060,7 +1060,7 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 		putDecodeScratch(payloadScratch)
 		return nil, false, err
 	}
-	val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, val, dst)
+	val, compactUsedDst, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, dst)
 	if err != nil {
 		putDecodeScratch(payloadScratch)
 		return nil, false, err

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1013,7 +1013,12 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 
 	if flags&recordFlagGrouped == 0 {
+		oldLen := len(dst)
 		dst, err := appendDecodedTemplatePayload(dst, payload, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+		if err != nil {
+			return nil, err, true
+		}
+		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1064,7 +1069,12 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 					return nil, ErrCorrupt, true
 				}
 				var err error
+				oldLen := len(dst)
 				dst, err = appendDecodedTemplatePayload(dst, payload[cPrefixLen+int(valStart):cPrefixLen+int(valEnd)], f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+				if err != nil {
+					return nil, err, true
+				}
+				dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:])
 				if err != nil {
 					return nil, err, true
 				}
@@ -1109,7 +1119,12 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		f.cacheMu.Unlock()
 
 		var err error
+		oldLen := len(dst)
 		dst, err = appendDecodedTemplatePayload(dst, payload[prefixLen+int(valStart):prefixLen+int(valEnd)], f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+		if err != nil {
+			return nil, err, true
+		}
+		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1131,7 +1146,12 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		if err != nil {
 			return nil, err, true
 		}
+		oldLen := len(dst)
 		dst, err := appendDecodedTemplatePayload(dst, cachedVal, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+		if err != nil {
+			return nil, err, true
+		}
+		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1194,7 +1214,11 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		f.setCacheRawLocked(nil, false)
 		f.cacheStart.Store(start)
 		f.cacheMu.Unlock()
-		return dst[:oldLen+int(rawLen)], nil, true
+		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:oldLen+int(rawLen)])
+		if err != nil {
+			return nil, err, true
+		}
+		return dst, nil, true
 	}
 	cacheableRaw := false
 	f.cacheMu.Lock()
@@ -1254,6 +1278,10 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 	if len(dst) < oldLen {
 		return nil, ErrCorrupt, true
+	}
+	dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:])
+	if err != nil {
+		return nil, err, true
 	}
 	return dst, nil, true
 }

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1018,7 +1018,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		if err != nil {
 			return nil, err, true
 		}
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:])
+		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1074,7 +1074,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 				if err != nil {
 					return nil, err, true
 				}
-				dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:])
+				dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
 				if err != nil {
 					return nil, err, true
 				}
@@ -1124,7 +1124,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		if err != nil {
 			return nil, err, true
 		}
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:])
+		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1147,11 +1147,11 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 			return nil, err, true
 		}
 		oldLen := len(dst)
-		dst, err := appendDecodedTemplatePayload(dst, cachedVal, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+		dst, err = appendDecodedTemplatePayload(dst, cachedVal, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
 		if err != nil {
 			return nil, err, true
 		}
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:])
+		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1214,7 +1214,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		f.setCacheRawLocked(nil, false)
 		f.cacheStart.Store(start)
 		f.cacheMu.Unlock()
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:oldLen+int(rawLen)])
+		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:oldLen+int(rawLen)])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1279,7 +1279,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	if len(dst) < oldLen {
 		return nil, ErrCorrupt, true
 	}
-	dst, err = appendMaybeDecodeLeafLogPayload(f.ID, dst[:oldLen], dst[oldLen:])
+	dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
 	if err != nil {
 		return nil, err, true
 	}

--- a/TreeDB/node/leaf_page_live_bounds_test.go
+++ b/TreeDB/node/leaf_page_live_bounds_test.go
@@ -1,0 +1,55 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func buildSparseLeafPageForBoundsTest(t *testing.T) []byte {
+	t.Helper()
+	buf := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(buf, page.PageTypeLeaf, BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+		PackedValuePtr:        true,
+	})
+	b.SetPageID(9)
+	for i := 0; i < 3; i++ {
+		if err := b.AddLeafEntry([]byte("celestia-key-"+string(rune('a'+i))), []byte("value"), FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry(%d): %v", i, err)
+		}
+	}
+	b.FinishNoNode()
+	return buf
+}
+
+func TestLeafPageLiveBounds_SparseLeaf(t *testing.T) {
+	leaf := buildSparseLeafPageForBoundsTest(t)
+
+	prefixLen, suffixLen, err := LeafPageLiveBounds(leaf)
+	if err != nil {
+		t.Fatalf("LeafPageLiveBounds: %v", err)
+	}
+	if prefixLen < NodeHeaderSize {
+		t.Fatalf("prefixLen=%d want >= %d", prefixLen, NodeHeaderSize)
+	}
+	if suffixLen <= 0 {
+		t.Fatalf("suffixLen=%d want > 0", suffixLen)
+	}
+	if prefixLen+suffixLen >= page.PageSize {
+		t.Fatalf("prefix+suffix=%d want < %d", prefixLen+suffixLen, page.PageSize)
+	}
+}
+
+func TestLeafPageLiveBounds_RejectsNonLeaf(t *testing.T) {
+	buf := make([]byte, page.PageSize)
+	n := NewNode(buf)
+	n.SetType(page.PageTypeInternal)
+	n.SetCount(0)
+	n.UpdateChecksum()
+
+	if _, _, err := LeafPageLiveBounds(buf); err != ErrInvalidType {
+		t.Fatalf("LeafPageLiveBounds(non-leaf) err=%v want %v", err, ErrInvalidType)
+	}
+}

--- a/TreeDB/node/leaf_page_live_bounds_test.go
+++ b/TreeDB/node/leaf_page_live_bounds_test.go
@@ -53,3 +53,13 @@ func TestLeafPageLiveBounds_RejectsNonLeaf(t *testing.T) {
 		t.Fatalf("LeafPageLiveBounds(non-leaf) err=%v want %v", err, ErrInvalidType)
 	}
 }
+
+func TestLeafPageLiveBounds_RejectsCorruptDirectoryLayout(t *testing.T) {
+	leaf := buildSparseLeafPageForBoundsTest(t)
+	n := NewNodeView(leaf)
+	n.SetCount(uint16(page.PageSize))
+
+	if _, _, err := LeafPageLiveBounds(leaf); err != ErrCorruptedNode {
+		t.Fatalf("LeafPageLiveBounds(corrupt-count) err=%v want %v", err, ErrCorruptedNode)
+	}
+}

--- a/TreeDB/node/node.go
+++ b/TreeDB/node/node.go
@@ -417,6 +417,9 @@ func (n *Node) liveByteBounds() (dirEnd, heapStart int, ok bool) {
 			return 0, 0, false
 		}
 		heapStart = int(getUint16(n.data[valDirStart : valDirStart+2]))
+		if heapStart < dirEnd || heapStart > len(n.data) {
+			return 0, 0, false
+		}
 		return dirEnd, heapStart, true
 	}
 	if n.Type() == page.PageTypeLeaf && n.leafColumnarV2() && !n.leafPrefixCompressed() {
@@ -425,6 +428,9 @@ func (n *Node) liveByteBounds() (dirEnd, heapStart int, ok bool) {
 			return 0, 0, false
 		}
 		heapStart = int(getUint16(n.data[valDirStart : valDirStart+2]))
+		if heapStart < dirEnd || heapStart > len(n.data) {
+			return 0, 0, false
+		}
 		return dirEnd, heapStart, true
 	}
 	for i := uint16(0); i < count; i++ {
@@ -433,6 +439,12 @@ func (n *Node) liveByteBounds() (dirEnd, heapStart int, ok bool) {
 			return 0, 0, false
 		}
 		off := getUint16(n.data[dirOff : dirOff+DirectoryEntrySize])
+		if off == 0 {
+			continue
+		}
+		if int(off) < dirEnd || int(off) > len(n.data) {
+			return 0, 0, false
+		}
 		if int(off) < heapStart && off != 0 {
 			heapStart = int(off)
 		}

--- a/TreeDB/node/node.go
+++ b/TreeDB/node/node.go
@@ -385,18 +385,27 @@ func (n *Node) FreeSpace() int {
 func (n *Node) liveByteBounds() (dirEnd, heapStart int, ok bool) {
 	count := n.Count()
 	dirEnd = NodeHeaderSize + int(count)*DirectoryEntrySize
+	if dirEnd < NodeHeaderSize || dirEnd > len(n.data) {
+		return 0, 0, false
+	}
 	if n.Type() == page.PageTypeLeaf && n.leafColumnar() && n.leafPrefixCompressed() && n.leafPrefixV2() {
 		// Combined columnar+prefix leaves use top-level metadata columns:
 		// KeyOff[u16], ValOff[u16], Flags[u8], PrefixLen[u16].
 		dirEnd += int(count) * DirectoryEntrySize
 		dirEnd += int(count)
 		dirEnd += int(count) * DirectoryEntrySize
+		if dirEnd < NodeHeaderSize || dirEnd > len(n.data) {
+			return 0, 0, false
+		}
 	}
 	if n.Type() == page.PageTypeLeaf && n.leafColumnarV2() && !n.leafPrefixCompressed() {
 		// Columnar v2 leaves store additional per-entry metadata immediately after
 		// the key directory: ValOff (u16) + Flags (u8).
 		dirEnd += int(count) * DirectoryEntrySize
 		dirEnd += int(count)
+		if dirEnd < NodeHeaderSize || dirEnd > len(n.data) {
+			return 0, 0, false
+		}
 	}
 	heapStart = int(page.PageSize)
 	if count == 0 {
@@ -419,7 +428,11 @@ func (n *Node) liveByteBounds() (dirEnd, heapStart int, ok bool) {
 		return dirEnd, heapStart, true
 	}
 	for i := uint16(0); i < count; i++ {
-		off := getUint16(n.data[NodeHeaderSize+int(i)*2:])
+		dirOff := NodeHeaderSize + int(i)*DirectoryEntrySize
+		if dirOff+DirectoryEntrySize > len(n.data) {
+			return 0, 0, false
+		}
+		off := getUint16(n.data[dirOff : dirOff+DirectoryEntrySize])
 		if int(off) < heapStart && off != 0 {
 			heapStart = int(off)
 		}

--- a/TreeDB/node/node.go
+++ b/TreeDB/node/node.go
@@ -375,9 +375,16 @@ func (n *Node) setOffset(index uint16, offset uint16) {
 // FreeSpace returns the number of bytes available for new items.
 // Free space is the gap between the end of the Directory and the start of the Heap.
 func (n *Node) FreeSpace() int {
-	// Directory End = Header + Count * 2
+	dirEnd, heapStart, ok := n.liveByteBounds()
+	if !ok {
+		return 0
+	}
+	return heapStart - dirEnd
+}
+
+func (n *Node) liveByteBounds() (dirEnd, heapStart int, ok bool) {
 	count := n.Count()
-	dirEnd := NodeHeaderSize + int(count)*DirectoryEntrySize
+	dirEnd = NodeHeaderSize + int(count)*DirectoryEntrySize
 	if n.Type() == page.PageTypeLeaf && n.leafColumnar() && n.leafPrefixCompressed() && n.leafPrefixV2() {
 		// Combined columnar+prefix leaves use top-level metadata columns:
 		// KeyOff[u16], ValOff[u16], Flags[u8], PrefixLen[u16].
@@ -391,63 +398,49 @@ func (n *Node) FreeSpace() int {
 		dirEnd += int(count) * DirectoryEntrySize
 		dirEnd += int(count)
 	}
-
-	// Heap Start = Minimum offset of all items, or PageSize if empty.
-	// To find Heap Start efficiently without scanning all offsets:
-	// 1. Maintain a "HeapStart" in the header? No, standard header doesn't have it.
-	// 2. Scan all offsets? Slow O(N).
-	// 3. Assume entries are added sequentially?
-	//    If we implement "Append only" or "Sorted Insert", we can track it.
-	//    But standard slotted pages usually compact or track the free pointer.
-	//    Wait, checking `specs/spec.md`:
-	//    "Directory (Top): Array of Offsets (uint16) growing downward."
-	//    "Heap (Bottom): Data growing upward."
-	//    It DOES NOT mention a "FreePtr".
-	//    However, usually in Slotted Pages, we just check the offsets.
-	//    Optimization: If we keep the items sorted by offset in the heap?
-	//    No, usually items are sorted by Key in the Directory (logical order),
-	//    but physical order in Heap can be anything (usually append-only).
-	//    So to find the "Heap Top" (lowest used address), we usually need to know it.
-	//    OR we scan.
-	//    Since `Count` is small (max ~200-300 items per 4KB page), scanning is fast enough?
-	//    Actually, we can just find the min offset.
-
-	heapStart := int(page.PageSize)
-	if count > 0 {
-		if n.Type() == page.PageTypeLeaf && n.leafColumnar() && n.leafPrefixCompressed() && n.leafPrefixV2() {
-			valDirStart := NodeHeaderSize + int(count)*DirectoryEntrySize
-			if valDirStart+2 > len(n.data) {
-				return 0
-			}
-			heapStart = int(getUint16(n.data[valDirStart : valDirStart+2]))
-			return heapStart - dirEnd
+	heapStart = int(page.PageSize)
+	if count == 0 {
+		return dirEnd, heapStart, true
+	}
+	if n.Type() == page.PageTypeLeaf && n.leafColumnar() && n.leafPrefixCompressed() && n.leafPrefixV2() {
+		valDirStart := NodeHeaderSize + int(count)*DirectoryEntrySize
+		if valDirStart+2 > len(n.data) {
+			return 0, 0, false
 		}
-		if n.Type() == page.PageTypeLeaf && n.leafColumnarV2() && !n.leafPrefixCompressed() {
-			// The lowest used offset is ValOff[0] (start of the value blob).
-			valDirStart := NodeHeaderSize + int(count)*DirectoryEntrySize
-			if valDirStart+2 > len(n.data) {
-				return 0
-			}
-			heapStart = int(getUint16(n.data[valDirStart : valDirStart+2]))
-			return heapStart - dirEnd
+		heapStart = int(getUint16(n.data[valDirStart : valDirStart+2]))
+		return dirEnd, heapStart, true
+	}
+	if n.Type() == page.PageTypeLeaf && n.leafColumnarV2() && !n.leafPrefixCompressed() {
+		valDirStart := NodeHeaderSize + int(count)*DirectoryEntrySize
+		if valDirStart+2 > len(n.data) {
+			return 0, 0, false
 		}
-
-		// Scan offsets to find the lowest one.
-		// This is O(N). Is there a better way?
-		// Most implementations store "FreePtr" or "HeapOffset" in the header or special slot.
-		// The provided header `PageHeader` has `Flags` and `Count`, but no `HeapOffset`.
-		// Unless `Flags` is used for something else?
-		// Spec says `Flags` is Node Type.
-		// So we must compute it or store it elsewhere.
-		// Wait, if we compact on every write, or keep heap contiguous?
-		// Let's assume we scan for now.
-		for i := uint16(0); i < count; i++ {
-			off := getUint16(n.data[NodeHeaderSize+int(i)*2:])
-			if int(off) < heapStart && off != 0 { // 0 checks for safety
-				heapStart = int(off)
-			}
+		heapStart = int(getUint16(n.data[valDirStart : valDirStart+2]))
+		return dirEnd, heapStart, true
+	}
+	for i := uint16(0); i < count; i++ {
+		off := getUint16(n.data[NodeHeaderSize+int(i)*2:])
+		if int(off) < heapStart && off != 0 {
+			heapStart = int(off)
 		}
 	}
+	return dirEnd, heapStart, true
+}
 
-	return heapStart - dirEnd
+// LeafPageLiveBounds reports the live prefix and suffix lengths for a leaf page.
+// Bytes between the prefix and suffix are free gap bytes that can be elided when
+// persisting a canonical external representation.
+func LeafPageLiveBounds(data []byte) (prefixLen, suffixLen int, err error) {
+	if len(data) != page.PageSize {
+		return 0, 0, ErrCorruptedNode
+	}
+	n := NewNodeView(data)
+	if n.Type() != page.PageTypeLeaf {
+		return 0, 0, ErrInvalidType
+	}
+	dirEnd, heapStart, ok := n.liveByteBounds()
+	if !ok || dirEnd < NodeHeaderSize || heapStart < dirEnd || heapStart > len(data) {
+		return 0, 0, ErrCorruptedNode
+	}
+	return dirEnd, len(data) - heapStart, nil
 }

--- a/docs/benchmarks/LEAF_VLOG_COMPACT_PAYLOAD_20260417.md
+++ b/docs/benchmarks/LEAF_VLOG_COMPACT_PAYLOAD_20260417.md
@@ -1,0 +1,110 @@
+# Leaf VLog Compact Payload Validation
+
+## Format
+
+Reserved `leaf_vlog` records no longer need to persist the whole raw `4096`-byte
+leaf page image.
+
+For a slotted leaf page, the live bytes are already split into two contiguous
+regions:
+
+- a live prefix at the front of the page: header + key/value offset directories +
+  top-level leaf metadata
+- a live suffix at the back of the page: the packed heap payloads
+
+The middle gap is free space. The compact payload stores:
+
+- `prefix_len`: number of live bytes from the start of the page up to the first
+  free-gap byte
+- `suffix_len`: number of live bytes from the end of the page back to the first
+  heap byte
+- `prefix bytes`
+- `suffix bytes`
+
+On read, TreeDB reconstructs a full `4096`-byte page by copying the prefix,
+copying the suffix at the end, and zero-filling the middle gap.
+
+This is intentionally scoped to the reserved split `leaf_vlog` path only. Raw
+lane-`0` leaf-page logging remains readable and unchanged.
+
+## Local Validation
+
+Targeted local coverage passed:
+
+- compact payload encode/decode round-trips
+- aliased decode buffers do not corrupt compact payloads
+- `Manager`, `Set`, and caching protected read paths all reconstruct full pages
+- reopen / rewrite / maintenance regression tests for leaf refs remain green
+- lane-`0` rewrite-writer leaf pages remain readable without the compact format
+
+## Celestia Control vs Candidate
+
+Control: `main` at `c77306fb`
+Candidate: `codex/leaf-vlog-compact-pages` on top of `f6648019`
+
+Each run used:
+
+- `run_celestia.sh`
+- `POST_SYNC_DWELL_SECONDS=900`
+- profile `fast` or `wal_on_fast`
+- offline `treemap vlog-rewrite -rw` on the resulting `application.db`
+
+### Raw Results
+
+| profile | variant | final height | sync s | dwell s | total s | max RSS GiB | dwell app bytes | dwell leaf bytes | dwell value bytes | rewrite s | post-rewrite app bytes | post-rewrite leaf bytes | post-rewrite value bytes |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| fast | control | 10700468 | 300 | 901 | 1201 | 13.125 | 2770968832 | 2511152494 | 194377257 | 46.43 | 2205846052 | 2154880692 | 11185567 |
+| fast | candidate | 10700687 | 316 | 900 | 1216 | 9.775 | 2692090902 | 2433055884 | 195660321 | 32.88 | 2314709750 | 2264568499 | 10852821 |
+| wal_on_fast | control | 10700906 | 353 | 900 | 1253 | 13.744 | 2749236665 | 2477668157 | 207651640 | 43.97 | 2211808519 | 2160776000 | 11219923 |
+| wal_on_fast | candidate | 10701119 | 308 | 901 | 1209 | 9.891 | 2568728819 | 2338264533 | 162876471 | 29.96 | 2225966375 | 2177699867 | 9764478 |
+
+### Direct Deltas
+
+`fast` candidate vs control:
+
+- height: `+219`
+- sync time: `+16s`
+- dwell-end `application.db`: `-78,877,930 B`
+- dwell-end `leaf_vlog`: `-78,096,610 B`
+- max RSS: `-3.35 GiB`
+- rewrite time: `-13.55s`
+- post-rewrite `application.db`: `+108,863,698 B`
+
+`wal_on_fast` candidate vs control:
+
+- height: `+213`
+- sync time: `-45s`
+- dwell-end `application.db`: `-180,507,846 B`
+- dwell-end `leaf_vlog`: `-139,403,624 B`
+- dwell-end `value_vlog`: `-44,775,169 B`
+- max RSS: `-3.85 GiB`
+- rewrite time: `-14.01s`
+- post-rewrite `application.db`: `+14,157,856 B`
+
+## Interpretation
+
+The compact leaf payload clearly improves the live / post-dwell shape.
+
+- Both profiles ended the `900s` dwell with materially smaller `application.db`
+  and `leaf_vlog`.
+- Both profiles also cut peak RSS by roughly `3.3` to `3.9 GiB`.
+- `wal_on_fast` improved both dwell-end size and total runtime meaningfully.
+
+The offline rewrite comparison is more nuanced.
+
+- The candidate rewrites faster in both profiles.
+- The post-rewrite sizes are close, with candidate slightly larger:
+  - `fast`: about `+109 MB`
+  - `wal_on_fast`: about `+14 MB`
+- Those rewrite runs are not at identical final heights; candidate ended
+  `~200` blocks higher in both profiles.
+
+That shape is still coherent with the design:
+
+- this change removes persisted free-gap bytes from the live split `leaf_vlog`
+  format
+- offline rewrite already rebuilds and densifies pages aggressively, so the
+  additional benefit after a full rewrite is expected to shrink
+
+So the main success condition for this sprint is live / dwell storage shape, and
+the candidate wins there in both profiles, especially `wal_on_fast`.


### PR DESCRIPTION
## Summary

Compact sparse reserved `leaf_vlog` pages by storing only the live front and back regions instead of the full raw `4096` bytes.

The new on-disk payload is:

- `prefix_len`
- `suffix_len`
- live prefix bytes
- live suffix bytes

Read paths reconstruct a full `4096`-byte page by zero-filling the middle gap. This is intentionally scoped to the reserved split `leaf_vlog` path only; lane-`0` / generic value-log behavior stays readable and unchanged.

## Implementation

- add `node.LeafPageLiveBounds` to compute the persisted live prefix/suffix bounds for leaf pages
- add compact leaf payload encode/decode in `internal/valuelog`
- compact reserved-leaf writes in:
  - caching leaf page log
  - rewrite writer when targeting the reserved leaf log
- decode compact payloads in live manager, snapshot/set, mmap, append, and fallback read paths
- fix an aliasing bug in decode-to-dst paths where the compact payload could be zeroed before reconstruction
- keep lane-`0` leaf-page logging readable and unmodified by the compact format
- add a benchmark note with control/candidate Celestia results

## Local Validation

Passed targeted coverage for:

- compact payload encode/decode round-trips
- aliased decode buffer regression
- manager/set/caching protected read paths
- rewrite/open tests
- reopen / maintenance leafref regression tests

Command used:

```bash
GOWORK=off go test ./TreeDB/node ./TreeDB/internal/valuelog ./TreeDB/caching ./TreeDB/db -run 'Test(LeafPageLiveBounds_|MaybeCompactLeafLogPayload_|DecodeCompactLeafLogPayloadTo_AliasedDstRoundTrips|ManagerReadUnsafeTo_DecodesCompactLeafPayload|ManagerReadUnsafe_DecodesCompactLeafPayload|ManagerReadUnsafeAppend_DecodesCompactLeafPayload|SetReadUnsafe_DecodesCompactLeafPayload|CachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload|SplitValueLogOwnership_LeafRefStateReaderDecodesCompactLeafPages|SplitValueLogOwnership_PointerProjectionIteratorDecodesCompactLeafPages|CachedRewriteLeafRefs_RemainReopenableAfterLaterCheckpoint|CachedGenerationalMaintenance_LeafRefsRemainReopenable|CachedGenerationalMaintenance_LeafRefsBackgroundReopenable_WALOn|CachedRepeatedRewriteVacuumLeafRefsRemainReopenable|CachedRepeatedRewriteVacuumLeafRefsRemainReopenable_WALOn|ValueLogRewriteOffline_PreservesLeafPagesInValueLogFormatConfig|RewriteWriter_LeafPagesUseConfiguredLeafLogDir|RewriteWriter_AppendLeafPageLane0KeepsRawLeafPayload|Open_.*|OpenReadOnly_.*|ValueLogRewrite(Offline_.*|Online_UsesBlockCompressionWhenEnabled)|LeafPageBlockCodecFromOptions_.*)' -count=1
```

## Celestia Validation

Detailed note: `docs/benchmarks/LEAF_VLOG_COMPACT_PAYLOAD_20260417.md`

### Dwell-end results

| profile | variant | height | total s | max RSS GiB | app bytes | leaf bytes | value bytes |
|---|---:|---:|---:|---:|---:|---:|---:|
| fast | control | 10700468 | 1201 | 13.125 | 2770968832 | 2511152494 | 194377257 |
| fast | candidate | 10700687 | 1216 | 9.775 | 2692090902 | 2433055884 | 195660321 |
| wal_on_fast | control | 10700906 | 1253 | 13.744 | 2749236665 | 2477668157 | 207651640 |
| wal_on_fast | candidate | 10701119 | 1209 | 9.891 | 2568728819 | 2338264533 | 162876471 |

### Post-rewrite results

| profile | variant | rewrite s | app bytes | leaf bytes | value bytes |
|---|---:|---:|---:|---:|---:|
| fast | control | 46.43 | 2205846052 | 2154880692 | 11185567 |
| fast | candidate | 32.88 | 2314709750 | 2264568499 | 10852821 |
| wal_on_fast | control | 43.97 | 2211808519 | 2160776000 | 11219923 |
| wal_on_fast | candidate | 29.96 | 2225966375 | 2177699867 | 9764478 |

## Interpretation

The main success signal for this sprint is the live / dwell shape, not the fully compacted rewrite floor.

- `fast`: candidate ends dwell about `78.9 MB` smaller on `application.db` and about `78.1 MB` smaller on `leaf_vlog`, while cutting peak RSS by about `3.35 GiB`
- `wal_on_fast`: candidate ends dwell about `180.5 MB` smaller on `application.db`, about `139.4 MB` smaller on `leaf_vlog`, about `44.8 MB` smaller on `value_vlog`, and cuts peak RSS by about `3.85 GiB`
- candidate rewrites are faster in both profiles
- post-rewrite sizes are close; candidate is slightly larger, but those runs ended about `200` blocks higher in both profiles

That matches the design goal: remove persisted free-gap bytes from the live split `leaf_vlog` format without requiring a full rewrite to see the win.
