### PR TITLE
[codex] Keep live leaf-log pages raw

### DIFF
--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -30,12 +30,8 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	if l == nil || l.db == nil || l.lane == nil {
 		return page.LeafLogPtr{}, errWALUnavailable
 	}
-	encodedLeafPage, _, err := valuelog.MaybeCompactLeafLogPayload(leafPage)
-	if err != nil {
-		return page.LeafLogPtr{}, err
-	}
 	rid := l.db.nextRID.Add(1)
-	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
+	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, leafPage, journalDurabilityNone, false)
 	if retainPath != "" {
 		l.db.markValueLogRetain(retainPath)
 	}

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -1,8 +1,8 @@
 package caching
 
 import (
+	"bytes"
 	"errors"
-	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -119,7 +119,7 @@ func buildSparseLeafPageForLeafLogTest(t *testing.T) []byte {
 	return buf
 }
 
-func TestCachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload(t *testing.T) {
+func TestCachingLeafPageLog_AppendLeafPageKeepsRawLeafPayload(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := valuelog.EncodeFileID(uint32(leafLogLaneID), 1)
 	if err != nil {
@@ -144,11 +144,20 @@ func TestCachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload(t *testing.T
 		t.Fatalf("Close writer: %v", err)
 	}
 	writer = nil
-	info, err := os.Stat(path)
+	reader, err := valuelog.NewReader(path, 0)
 	if err != nil {
-		t.Fatalf("Stat(%q): %v", path, err)
+		t.Fatalf("NewReader(%q): %v", path, err)
 	}
-	if info.Size() >= int64(valuelog.HeaderSize+page.PageSize) {
-		t.Fatalf("file size=%d want compact leaf payload smaller than raw %d", info.Size(), valuelog.HeaderSize+page.PageSize)
+	defer func() { _ = reader.Close() }()
+	_, payload, _, err := reader.ReadNext()
+	if err != nil {
+		t.Fatalf("ReadNext: %v", err)
+	}
+	if valuelog.HasCompactLeafLogPayload(payload) {
+		t.Fatal("expected live leaf payload to stay raw, got compact payload marker")
+	}
+	want := buildSparseLeafPageForLeafLogTest(t)
+	if !bytes.Equal(payload, want) {
+		t.Fatalf("stored payload mismatch: got len=%d want len=%d", len(payload), len(want))
 	}
 }


### PR DESCRIPTION
## Summary

Keep live split `leaf_vlog` writes as raw 4KiB leaf pages instead of compacting them through `MaybeCompactLeafLogPayload` on the foreground write path.

## Root Cause

The live compact-leaf path was showing up as the dominant write-side allocation tax in unified-bench:

- `MaybeCompactLeafLogPayload`
- `decodeCompactLeafLogPayloadTo`

That cost was hitting foreground writes before the bytes ever reached rewrite/pack, and it was especially visible in `batch_write_steady`.

## What Changed

- `TreeDB/caching/leaf_page_log.go`
  - `AppendLeafPage` now passes the raw page bytes into the live value-log append path.
  - rewrite/pack/offline paths are unchanged.
- `TreeDB/caching/leaf_page_log_test.go`
  - updated coverage to assert the live path stores a raw leaf payload rather than a compact-payload envelope.

## Validation

Targeted tests:

- `GOWORK=off go test ./TreeDB/caching -run 'TestCachingLeafPageLog_(AppendLeafPageKeepsRawLeafPayload|AppendLeafPageReturnsAppendError|SyncRespectsRelaxedSync)$' -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'TestRewriteWriter_AppendLeafPage(UsesLeafDictWhenConfigured|Lane0KeepsRawLeafPayload|SkipsLeafDictWhenCompressionDisabled)$' -count=1`

Benchmark sanity reruns with rebuilt `./bin/unified-bench`:

- `./bin/unified-bench -dbs treedb -keys 1000000 -test sequential_write,random_write,dataset_write_random,dataset_write_sorted,batch_write -progress=false`
- `./bin/unified-bench -dbs treedb -keys 1000000 -test batch_write_steady -progress=false`

Controlled A/B from the earlier gated experiment on the same code path:

- `Random Write`: `1,372,959 -> 1,431,088` (`+4.2%`)
- `Batch Write`: `3,705,718 -> 3,989,030` (`+7.6%`)
- `Batch Write (Steady)`: `869,136 -> 1,023,517` (`+17.8%`)
- `leaf_vlog` end size during the five-test write run: `271 MiB -> 240 MiB`
- `leaf_vlog` end size during `batch_write_steady`: `17 MiB -> 15 MiB`

## Current Post-Change Bottlenecks

Fresh rebuilt profile set:

- profiles dir: `/tmp/gomap_writeprof_post_disable_rebuilt_wuYs8G`

After removing the live compact-payload path, the remaining write hotspots shift to the places we expected:

- `TreeDB/internal/memtable.getAppendOnlyEntriesFromPool`
- `TreeDB/internal/memtable.(*AppendOnly).rebuildLatestIndexLocked`
- `TreeDB/internal/memtable.(*AppendOnly).buildSortedLatestIndicesLocked`
- `TreeDB/internal/memtable.(*AppendOnly).buildSortedLatestSnapshotLocked`
- `TreeDB/caching.getEntrySlice`
- `TreeDB/caching.(*DB).flushLaneOnce`
- `TreeDB/zipper.(*Zipper).mergeInternal`
- WAL / codec work on the write path

So this PR removes the proven foreground compaction tax and leaves the next write sprint focused on memtable allocation/index maintenance plus flush/merge cadence.
