### PR TITLE
[codex] Reduce append-only flush-build churn

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -10522,17 +10522,18 @@ func estimateUnitRunEntries(unitRuns [][][]batch.Entry, floor int) int {
 	return total
 }
 
-func collectOpsInto(mem memtable.Table, dst []batch.Entry) (int, error) {
+func collectOpsInto(mem memtable.Table, dst []batch.Entry) (int, int, error) {
 	if mem == nil {
-		return 0, errors.New("cachingdb: nil memtable")
+		return 0, 0, errors.New("cachingdb: nil memtable")
 	}
 	iter := mem.NewIterator(nil, nil)
 	defer func() { _ = iter.Close() }()
 
 	i := 0
+	deleteOps := 0
 	for iter.Valid() {
 		if i >= len(dst) {
-			return 0, fmt.Errorf("cachingdb: collectOpsInto overflow (have=%d need>=%d)", len(dst), i+1)
+			return 0, 0, fmt.Errorf("cachingdb: collectOpsInto overflow (have=%d need>=%d)", len(dst), i+1)
 		}
 		val, ptr, flags := iter.UnsafeEntry()
 		if flags&node.FlagTombstone != 0 {
@@ -10540,6 +10541,7 @@ func collectOpsInto(mem memtable.Table, dst []batch.Entry) (int, error) {
 				Type: batch.OpDelete,
 				Key:  iter.UnsafeKey(),
 			}
+			deleteOps++
 		} else if flags&node.FlagPointer != 0 {
 			dst[i] = batch.Entry{
 				Type:     batch.OpPut,
@@ -10558,9 +10560,9 @@ func collectOpsInto(mem memtable.Table, dst []batch.Entry) (int, error) {
 		iter.Next()
 	}
 	if err := iter.Error(); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	return i, nil
+	return i, deleteOps, nil
 }
 
 type opRunIter struct {
@@ -10699,26 +10701,39 @@ func buildOpRuns(mem memtable.Table, chunkCap int) ([][]batch.Entry, int, error)
 	if chunkCap <= 0 {
 		chunkCap = 8192
 	}
+	if _, ok := mem.(*memtable.AppendOnly); ok && stableUnsafeIteratorSlices(mem) {
+		totalOps := mem.Len()
+		if totalOps == 0 {
+			return nil, 0, nil
+		}
+		runs := getEntryRuns(1)
+		ops := getEntrySlice(totalOps)
+		ops = ops[:totalOps]
+		count, deleteOps, err := collectOpsInto(mem, ops)
+		if err != nil {
+			putEntrySlice(ops)
+			putEntryRuns(runs)
+			return nil, 0, err
+		}
+		runs = append(runs, ops[:count])
+		return runs, deleteOps, nil
+	}
 	iter := mem.NewIterator(nil, nil)
 	runsCap := mem.Len()/chunkCap + 1
 	runs := getEntryRuns(runsCap)
 	deleteOps := 0
 	ops := getEntrySlice(chunkCap)
 	ops = ops[:0]
-	stableUnsafe := stableUnsafeIteratorSlices(mem)
 	for iter.Valid() {
 		val, ptr, flags := iter.UnsafeEntry()
-		key := iter.UnsafeKey()
-		if !stableUnsafe {
-			key = append([]byte(nil), key...)
-		}
+		key := append([]byte(nil), iter.UnsafeKey()...)
 		if flags&node.FlagTombstone != 0 {
 			ops = append(ops, batch.Entry{Type: batch.OpDelete, Key: key})
 			deleteOps++
 		} else if flags&node.FlagPointer != 0 {
 			ops = append(ops, batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true})
 		} else {
-			if !stableUnsafe && val != nil {
+			if val != nil {
 				val = append([]byte(nil), val...)
 			}
 			ops = append(ops, batch.Entry{Type: batch.OpPut, Key: key, Value: val})

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -233,6 +233,40 @@ func TestBuildOpRunsChunking(t *testing.T) {
 	}
 }
 
+func TestBuildOpRunsStableUnsafeSingleRun(t *testing.T) {
+	mt := memtable.NewAppendOnlyWithCapacity(0)
+	var key [8]byte
+	const entryCount = 257
+	for i := 0; i < entryCount; i++ {
+		binary.BigEndian.PutUint64(key[:], uint64(i))
+		mt.Set(key[:], []byte{byte(i + 1)})
+	}
+	binary.BigEndian.PutUint64(key[:], uint64(7))
+	mt.Delete(key[:])
+	mt.Freeze()
+
+	runs, deleteOps, err := buildOpRuns(mt, 2)
+	if err != nil {
+		t.Fatalf("buildOpRuns: %v", err)
+	}
+	defer func() {
+		for _, run := range runs {
+			putEntrySlice(run)
+		}
+		putEntryRuns(runs)
+	}()
+
+	if deleteOps != 1 {
+		t.Fatalf("deleteOps=%d want=1", deleteOps)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("run count=%d want=1 for stable append-only memtable", len(runs))
+	}
+	if got := len(runs[0]); got != entryCount {
+		t.Fatalf("run len=%d want=%d", got, entryCount)
+	}
+}
+
 func TestFlushDeferredValueLogUnitsPointerOnly(t *testing.T) {
 	mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
 	if err != nil {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -421,6 +421,20 @@ func appendOnlyNextCapacity(current int) int {
 	return next
 }
 
+func appendOnlyReserveCapacity(current, needed int) int {
+	if needed <= current {
+		return current
+	}
+	next := current
+	if next < appendOnlyMinInitialEntries {
+		next = appendOnlyMinInitialEntries
+	}
+	for next < needed {
+		next = appendOnlyNextCapacity(next)
+	}
+	return next
+}
+
 func appendOnlyKeyString(key []byte) string {
 	if len(key) == 0 {
 		return ""
@@ -543,12 +557,7 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 
 func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) {
 	if m.count == len(m.entries) {
-		nextCap := appendOnlyNextCapacity(len(m.entries))
-		prev := m.entries
-		grown := getAppendOnlyEntries(nextCap)
-		copy(grown, m.entries[:m.count])
-		m.entries = grown
-		putAppendOnlyEntries(prev)
+		m.reserveEntriesLocked(1)
 	}
 	idx := m.count
 	m.count++
@@ -614,6 +623,22 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		m.updateLatestIndexLocked(k, idx)
 	}
 	m.clearSnapshotLocked()
+}
+
+func (m *AppendOnly) reserveEntriesLocked(additional int) {
+	if additional <= 0 {
+		return
+	}
+	needed := m.count + additional
+	if needed <= len(m.entries) {
+		return
+	}
+	nextCap := appendOnlyReserveCapacity(len(m.entries), needed)
+	prev := m.entries
+	grown := getAppendOnlyEntries(nextCap)
+	copy(grown, m.entries[:m.count])
+	m.entries = grown
+	putAppendOnlyEntries(prev)
 }
 
 func (m *AppendOnly) Set(key, value []byte) {
@@ -687,6 +712,7 @@ func (m *AppendOnly) ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKe
 
 func (m *AppendOnly) applyStealBatch(entries []batchpkg.Entry, onKey func(key []byte)) {
 	m.mu.Lock()
+	m.reserveEntriesLocked(len(entries))
 	for i := range entries {
 		op := entries[i]
 		switch {

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -1,6 +1,7 @@
 package memtable
 
 import (
+	"encoding/binary"
 	"sync"
 	"testing"
 	"time"
@@ -213,6 +214,39 @@ func TestAppendOnlyResetReusesEntryBuffers(t *testing.T) {
 		t.Fatalf("expected value buffer capacity reuse across reset")
 	}
 	_ = valBufPtr
+}
+
+func TestAppendOnlyReserveEntriesPreventsMidAppendGrowth(t *testing.T) {
+	m := &AppendOnly{
+		entries:        getAppendOnlyEntries(appendOnlyMinInitialEntries),
+		baseEntriesLen: appendOnlyMinInitialEntries,
+		ordered:        true,
+		lastIdx:        -1,
+	}
+
+	for i := 0; i < appendOnlyMinInitialEntries-8; i++ {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(i))
+		m.Set(key[:], []byte("v"))
+	}
+
+	const additional = 400
+	m.mu.Lock()
+	m.reserveEntriesLocked(additional)
+	m.mu.Unlock()
+	reservedCap := len(m.entries)
+	if reservedCap < m.count+additional {
+		t.Fatalf("reserved cap=%d want >= %d", reservedCap, m.count+additional)
+	}
+
+	for i := 0; i < additional; i++ {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(appendOnlyMinInitialEntries+i))
+		m.Set(key[:], []byte("v"))
+		if got := len(m.entries); got != reservedCap {
+			t.Fatalf("entries len changed during reserved append: got=%d want=%d", got, reservedCap)
+		}
+	}
 }
 
 func TestAppendOnlySetCopiesIntoArenaForNonSteal(t *testing.T) {


### PR DESCRIPTION
## What changed

This follow-on to #980 narrows the next write-path optimization to two things:

- keep append-only batch growth local to the memtable implementation instead of inflating the cached DB's global append-only entry hint from the batch path
- make `buildOpRuns` use one exact-sized run for frozen append-only memtables with stable unsafe iterator slices, instead of chunking them into many `[]batch.Entry` slices

## Why

After #980 removed live compact leaf payload work from foreground writes, the next write-side profile said the remaining steady-state allocator hot paths were:

- `caching.getEntrySlice` from `buildOpRuns` / `flushLaneOnce`
- append-only mutable growth/reset work

The first reserve-only attempt regressed because it pushed `observeAppendOnlyMutableEntries(...)` into the batch write path and over-inflated append-only preallocation. This change removes that bad part and keeps the improvement that actually matches the profile: reduce flush-build slice churn for append-only memtables.

## Impact

Fresh serial runs from a rebuilt `./bin/unified-bench`:

Baseline from #980:
- `Sequential Write`: `1,989,342`
- `Random Write`: `1,416,863`
- `Dataset Write (Random)`: `530,065`
- `Dataset Write (Sorted)`: `1,298,519`
- `Batch Write`: `3,667,682`
- `Batch Write (Steady)`: `914,985`

This branch:
- `Sequential Write`: `2,047,917`
- `Random Write`: `1,632,642`
- `Dataset Write (Random)`: `517,307`
- `Dataset Write (Sorted)`: `1,394,662`
- `Batch Write`: `3,426,461`
- `Batch Write (Steady)`: `992,180`
- second clean `Batch Write (Steady)` rerun: `964,561`

The important signal is the settled path:
- `Batch Write (Steady)` is back above the #980 baseline by about `5.4%` to `8.4%`
- `Random Write` improved by about `15.2%`

Fresh profile capture:
- profiles dir: `/tmp/gomap_writeprof_buildruns_AwzPja`
- `batch_write_steady` alloc-space `caching.getEntrySlice`: `26.86% -> 3.43%`

That means the old flush-build slice hotspot materially moved down.

## Validation

- `GOWORK=off go test ./TreeDB/internal/memtable -count=1`
- `GOWORK=off go test ./TreeDB/caching -count=1`
- `GOWORK=off make unified-bench`
- `./bin/unified-bench -dbs treedb -keys 1000000 -test sequential_write,random_write,dataset_write_random,dataset_write_sorted,batch_write -progress=false`
- `./bin/unified-bench -dbs treedb -keys 1000000 -test batch_write_steady -progress=false`
- `./bin/unified-bench -dbs treedb -keys 1000000 -test batch_write_steady -progress=false`
- `./bin/unified-bench -dbs treedb -keys 1000000 -test random_write,batch_write,batch_write_steady -profile-dir /tmp/gomap_writeprof_buildruns_AwzPja -progress=false`
- `./bin/benchprof -profiles-dir /tmp/gomap_writeprof_buildruns_AwzPja`
