### PR TITLE
[codex] Stabilize hash-sorted mutable reuse

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -170,6 +170,8 @@ var appendOnlyDirectArenaFreshAllocChunksTotal atomic.Uint64
 var appendOnlyDirectArenaFreshAllocBytesTotal atomic.Uint64
 var appendOnlyMemNewAllocWithQueueTotal atomic.Uint64
 var appendOnlyMemNewAllocQueueBytesSum atomic.Uint64
+var hashSortedMemNewAllocWithQueueTotal atomic.Uint64
+var hashSortedMemNewAllocQueueBytesSum atomic.Uint64
 
 var poolPressureNow = time.Now
 var poolPressureReadMemStats = runtime.ReadMemStats
@@ -1936,6 +1938,9 @@ const (
 	leafGenerationPackMaintenanceDefaultMaxForegroundQueue         = 2
 	leafGenerationPackMaintenanceDefaultMinReclaimPerByteCopiedPPM = 250000
 	maxMemtablePrealloc                                            = 256 << 20
+	hashSortedEstimatedBytesPerEntryDefault                        = 64
+	hashSortedEntryHintMinEntries                                  = 128
+	hashSortedEntryHintMaxEntries                                  = 1 << 20
 	appendOnlyEntryHintMinEntries                                  = 128
 	appendOnlyEntryHintMaxEntries                                  = 1 << 20
 	adaptiveMinWrites                                              = 1024
@@ -6134,6 +6139,7 @@ type DB struct {
 	queueIDs                      []uint64
 	queueEnqueueNS                []int64
 	nextQueueID                   atomic.Uint64
+	hashSortedEntryHint           atomic.Int32
 	appendOnlyEntryHint           atomic.Int32
 	batchEntryHint                atomic.Int32
 	batchCopyBytesHint            atomic.Int32
@@ -6162,6 +6168,14 @@ type DB struct {
 	// Readers load it atomically to avoid holding db.mu around memtable access.
 	memtables                        atomic.Pointer[memtableView]
 	hashSortedIndexer                *memtable.HashSortedIndexer
+	hashSortedMemPool                sync.Pool
+	hashSortedMemLeaseMu             sync.Mutex
+	hashSortedMemLeases              []*memtable.HashSorted
+	hashSortedMemLeaseHitTotal       atomic.Uint64
+	hashSortedMemPoolHitTotal        atomic.Uint64
+	hashSortedMemNewAllocTotal       atomic.Uint64
+	hashSortedMemNewAllocWithQueue   atomic.Uint64
+	hashSortedMemNewAllocQueueBytes  atomic.Uint64
 	appendOnlyMemPool                sync.Pool
 	appendOnlyMemLeaseMu             sync.Mutex
 	appendOnlyMemLeases              []*memtable.AppendOnly
@@ -7081,6 +7095,13 @@ const appendOnlyEstimatedBytesPerEntryDefault = 96
 // and increases allocation churn.
 const maxAppendOnlyMemLeases = 32
 
+const maxHashSortedMemLeases = 32
+
+const (
+	postFlushHashSortedMemLeaseKeep      = 24
+	postCheckpointHashSortedMemLeaseKeep = 8
+)
+
 func updateInt64Max(dst *atomic.Int64, value int64) {
 	for {
 		cur := dst.Load()
@@ -7547,6 +7568,22 @@ func (db *DB) popAppendOnlyMemLease() *memtable.AppendOnly {
 	return mt
 }
 
+func (db *DB) popHashSortedMemLease() *memtable.HashSorted {
+	if db == nil {
+		return nil
+	}
+	db.hashSortedMemLeaseMu.Lock()
+	defer db.hashSortedMemLeaseMu.Unlock()
+	n := len(db.hashSortedMemLeases)
+	if n == 0 {
+		return nil
+	}
+	mt := db.hashSortedMemLeases[n-1]
+	db.hashSortedMemLeases[n-1] = nil
+	db.hashSortedMemLeases = db.hashSortedMemLeases[:n-1]
+	return mt
+}
+
 func (db *DB) putAppendOnlyMemLease(mt *memtable.AppendOnly) bool {
 	if db == nil || mt == nil {
 		return false
@@ -7560,15 +7597,35 @@ func (db *DB) putAppendOnlyMemLease(mt *memtable.AppendOnly) bool {
 	return true
 }
 
+func (db *DB) putHashSortedMemLease(mt *memtable.HashSorted) bool {
+	if db == nil || mt == nil {
+		return false
+	}
+	db.hashSortedMemLeaseMu.Lock()
+	defer db.hashSortedMemLeaseMu.Unlock()
+	if len(db.hashSortedMemLeases) >= maxHashSortedMemLeases {
+		return false
+	}
+	db.hashSortedMemLeases = append(db.hashSortedMemLeases, mt)
+	return true
+}
+
 func (db *DB) recycleMemtables(mems []memtable.Table) {
 	if db == nil || len(mems) == 0 {
 		return
 	}
 	resetCapacity := db.checkpointRotateCapacity()
+	hashSortedResetCapacity := db.hashSortedMemtableCapacityHint(resetCapacity)
 	estimate := appendOnlyEstimatedBytesPerEntryDefault
 	appendOnlyResetCapacity := db.appendOnlyMemtableCapacityHint(resetCapacity, estimate)
 	for _, mt := range mems {
 		switch typed := mt.(type) {
+		case *memtable.HashSorted:
+			typed.Reset()
+			if !db.putHashSortedMemLease(typed) {
+				typed.ResetWithCapacity(hashSortedResetCapacity)
+				db.hashSortedMemPool.Put(typed)
+			}
 		case *memtable.AppendOnly:
 			typed.ResetWithCapacityHard(appendOnlyResetCapacity, estimate)
 			db.releaseAppendOnlyDirectArenaLeaseForMemtable(typed)
@@ -7608,6 +7665,37 @@ func (db *DB) trimAppendOnlyMemLeases(maxLeases int, resetCapacity int) {
 			dropped[i].ResetWithCapacityHard(effectiveResetCapacity, appendOnlyEstimatedBytesPerEntryDefault)
 			db.releaseAppendOnlyDirectArenaLeaseForMemtable(dropped[i])
 			db.appendOnlyMemPool.Put(dropped[i])
+		}
+	}
+}
+
+func (db *DB) trimHashSortedMemLeases(maxLeases int, resetCapacity int) {
+	if db == nil {
+		return
+	}
+	if maxLeases < 0 {
+		maxLeases = 0
+	}
+	var dropped []*memtable.HashSorted
+	db.hashSortedMemLeaseMu.Lock()
+	if n := len(db.hashSortedMemLeases); n > maxLeases {
+		drop := n - maxLeases
+		dropped = append(dropped, db.hashSortedMemLeases[:drop]...)
+		copy(db.hashSortedMemLeases, db.hashSortedMemLeases[drop:])
+		for i := n - drop; i < n; i++ {
+			db.hashSortedMemLeases[i] = nil
+		}
+		db.hashSortedMemLeases = db.hashSortedMemLeases[:n-drop]
+	}
+	db.hashSortedMemLeaseMu.Unlock()
+
+	if len(dropped) == 0 {
+		return
+	}
+	for i := range dropped {
+		if dropped[i] != nil {
+			dropped[i].ResetWithCapacity(resetCapacity)
+			db.hashSortedMemPool.Put(dropped[i])
 		}
 	}
 }
@@ -7670,11 +7758,13 @@ func (db *DB) trimRetainedArenasAfterFlush(checkpoint bool) {
 	batchTarget := postFlushBatchArenaTargetBytes
 	entryTarget := postFlushEntrySliceTargetBytes
 	leaseKeepPerBucket := postFlushEntrySliceLeaseKeepPerBucket
+	hashSortedLeaseKeep := postFlushHashSortedMemLeaseKeep
 	appendOnlyLeaseKeep := postFlushAppendOnlyMemLeaseKeep
 	if checkpoint {
 		batchTarget = postCheckpointBatchArenaTargetBytes
 		entryTarget = postCheckpointEntrySliceTargetBytes
 		leaseKeepPerBucket = postCheckpointEntrySliceLeaseKeepPerBucket
+		hashSortedLeaseKeep = postCheckpointHashSortedMemLeaseKeep
 		appendOnlyLeaseKeep = postCheckpointAppendOnlyMemLeaseKeep
 	}
 	if budget := currentBatchArenaRetentionBudgetBytes(); budget >= 0 && budget < batchTarget {
@@ -7699,10 +7789,33 @@ func (db *DB) trimRetainedArenasAfterFlush(checkpoint bool) {
 	}
 
 	db.trimMutableShardAppendOnlyDirectArenas(checkpoint)
+	db.trimHashSortedMemLeases(hashSortedLeaseKeep, db.checkpointRotateCapacity())
 	db.trimAppendOnlyMemLeases(appendOnlyLeaseKeep, db.checkpointRotateCapacity())
 }
 
 func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mode) (memtable.Table, error) {
+	if db != nil && mode == memtable.ModeHashSorted {
+		capacity = db.hashSortedMemtableCapacityHint(capacity)
+		if mt := db.popHashSortedMemLease(); mt != nil {
+			db.hashSortedMemLeaseHitTotal.Add(1)
+			return mt, nil
+		}
+		if v := db.hashSortedMemPool.Get(); v != nil {
+			if mt, ok := v.(*memtable.HashSorted); ok && mt != nil {
+				db.hashSortedMemPoolHitTotal.Add(1)
+				mt.ResetWithCapacity(capacity)
+				return mt, nil
+			}
+		}
+		if backlog := db.queueBacklogBytes.Load(); backlog > 0 {
+			hashSortedMemNewAllocWithQueueTotal.Add(1)
+			hashSortedMemNewAllocQueueBytesSum.Add(uint64(backlog))
+			db.hashSortedMemNewAllocWithQueue.Add(1)
+			db.hashSortedMemNewAllocQueueBytes.Add(uint64(backlog))
+		}
+		db.hashSortedMemNewAllocTotal.Add(1)
+		return memtable.NewHashSortedWithCapacityAndIndexer(capacity, db.hashSortedIndexer), nil
+	}
 	if db != nil && mode == memtable.ModeAppendOnly {
 		estimate := appendOnlyEstimatedBytesPerEntryDefault
 		if mt := db.popAppendOnlyMemLease(); mt != nil {
@@ -10701,7 +10814,7 @@ func buildOpRuns(mem memtable.Table, chunkCap int) ([][]batch.Entry, int, error)
 	if chunkCap <= 0 {
 		chunkCap = 8192
 	}
-	if _, ok := mem.(*memtable.AppendOnly); ok && stableUnsafeIteratorSlices(mem) {
+	if stableUnsafeIteratorSlices(mem) {
 		totalOps := mem.Len()
 		if totalOps == 0 {
 			return nil, 0, nil
@@ -20361,6 +20474,9 @@ func (db *DB) rotateMutableShardsLocked(newCapacity int, triggerFlush bool) erro
 		if debugRotate {
 			oldMode = debugMemtableModeLabel(shard.mem)
 		}
+		if _, ok := shard.mem.(*memtable.HashSorted); ok {
+			db.observeHashSortedMutableEntries(oldLen)
+		}
 		if _, ok := shard.mem.(*memtable.AppendOnly); ok {
 			db.observeAppendOnlyMutableEntries(oldLen)
 		}
@@ -23596,13 +23712,34 @@ func (db *DB) Stats() map[string]string {
 	if mergeParallelAppliedOpsTotal > 0 {
 		stats["treedb.process.flush_merge.parallel.shadowed_per_applied"] = fmt.Sprintf("%.6f", float64(mergeParallelShadowedOpsTotal)/float64(mergeParallelAppliedOpsTotal))
 	}
+	hashSortedEntryHint := int(db.hashSortedEntryHint.Load())
+	hashSortedHintCapacity := hashSortedEntriesToCapacity(hashSortedEntryHint)
 	appendOnlyEntryHint := int(db.appendOnlyEntryHint.Load())
 	appendOnlyHintCapacity := appendOnlyEntriesToCapacity(appendOnlyEntryHint, appendOnlyEstimatedBytesPerEntryDefault)
+	hashSortedMemLeaseHitTotal := db.hashSortedMemLeaseHitTotal.Load()
+	hashSortedMemPoolHitTotal := db.hashSortedMemPoolHitTotal.Load()
+	hashSortedMemNewAllocTotal := db.hashSortedMemNewAllocTotal.Load()
+	hashSortedMemNewAllocWithQueue := db.hashSortedMemNewAllocWithQueue.Load()
+	hashSortedMemNewAllocQueueBytes := db.hashSortedMemNewAllocQueueBytes.Load()
 	appendOnlyMemLeaseHitTotal := db.appendOnlyMemLeaseHitTotal.Load()
 	appendOnlyMemPoolHitTotal := db.appendOnlyMemPoolHitTotal.Load()
 	appendOnlyMemNewAllocTotal := db.appendOnlyMemNewAllocTotal.Load()
 	appendOnlyMemNewAllocWithQueue := db.appendOnlyMemNewAllocWithQueue.Load()
 	appendOnlyMemNewAllocQueueBytes := db.appendOnlyMemNewAllocQueueBytes.Load()
+	stats["treedb.cache.hash_sorted.entry_hint_entries"] = fmt.Sprintf("%d", hashSortedEntryHint)
+	stats["treedb.cache.hash_sorted.entry_hint_capacity_bytes"] = fmt.Sprintf("%d", hashSortedHintCapacity)
+	stats["treedb.cache.hash_sorted.mutable_from_lease_total"] = fmt.Sprintf("%d", hashSortedMemLeaseHitTotal)
+	stats["treedb.cache.hash_sorted.mutable_from_pool_total"] = fmt.Sprintf("%d", hashSortedMemPoolHitTotal)
+	stats["treedb.cache.hash_sorted.mutable_new_alloc_total"] = fmt.Sprintf("%d", hashSortedMemNewAllocTotal)
+	stats["treedb.cache.hash_sorted.mutable_new_alloc_with_queue_total"] = fmt.Sprintf("%d", hashSortedMemNewAllocWithQueue)
+	stats["treedb.cache.hash_sorted.mutable_new_alloc_queue_bytes_sum"] = fmt.Sprintf("%d", hashSortedMemNewAllocQueueBytes)
+	stats["treedb.process.hash_sorted.entry_hint_entries"] = fmt.Sprintf("%d", hashSortedEntryHint)
+	stats["treedb.process.hash_sorted.entry_hint_capacity_bytes"] = fmt.Sprintf("%d", hashSortedHintCapacity)
+	stats["treedb.process.hash_sorted.mutable_from_lease_total"] = fmt.Sprintf("%d", hashSortedMemLeaseHitTotal)
+	stats["treedb.process.hash_sorted.mutable_from_pool_total"] = fmt.Sprintf("%d", hashSortedMemPoolHitTotal)
+	stats["treedb.process.hash_sorted.mutable_new_alloc_total"] = fmt.Sprintf("%d", hashSortedMemNewAllocTotal)
+	stats["treedb.process.hash_sorted.mutable_new_alloc_with_queue_total"] = fmt.Sprintf("%d", hashSortedMemNewAllocWithQueueTotal.Load())
+	stats["treedb.process.hash_sorted.mutable_new_alloc_queue_bytes_sum"] = fmt.Sprintf("%d", hashSortedMemNewAllocQueueBytesSum.Load())
 	stats["treedb.cache.append_only.entry_hint_entries"] = fmt.Sprintf("%d", appendOnlyEntryHint)
 	stats["treedb.cache.append_only.entry_hint_capacity_bytes"] = fmt.Sprintf("%d", appendOnlyHintCapacity)
 	stats["treedb.cache.append_only.mutable_from_lease_total"] = fmt.Sprintf("%d", appendOnlyMemLeaseHitTotal)
@@ -25704,6 +25841,41 @@ func clampAppendOnlyEntryHint(entries int) int {
 	return entries
 }
 
+func clampHashSortedEntryHint(entries int) int {
+	if entries < hashSortedEntryHintMinEntries {
+		return hashSortedEntryHintMinEntries
+	}
+	if entries > hashSortedEntryHintMaxEntries {
+		return hashSortedEntryHintMaxEntries
+	}
+	return entries
+}
+
+func (db *DB) observeHashSortedMutableEntries(entries int) {
+	if db == nil {
+		return
+	}
+	n := clampHashSortedEntryHint(entries)
+	for {
+		old := int(db.hashSortedEntryHint.Load())
+		next := n
+		if old > 0 {
+			if n > old {
+				next = (old*3 + n + 1) / 4
+			} else {
+				next = (old*7 + n + 3) / 8
+			}
+		}
+		next = clampHashSortedEntryHint(next)
+		if next == old {
+			return
+		}
+		if db.hashSortedEntryHint.CompareAndSwap(int32(old), int32(next)) {
+			return
+		}
+	}
+}
+
 func (db *DB) observeAppendOnlyMutableEntries(entries int) {
 	if db == nil {
 		return
@@ -25744,6 +25916,44 @@ func appendOnlyEntriesToCapacity(entries, estimatedBytesPerEntry int) int {
 		return maxInt
 	}
 	return entries * estimatedBytesPerEntry
+}
+
+func hashSortedEntriesToCapacity(entries int) int {
+	if entries <= 0 {
+		return 0
+	}
+	maxInt := int(^uint(0) >> 1)
+	if entries > maxInt/hashSortedEstimatedBytesPerEntryDefault {
+		return maxInt
+	}
+	return entries * hashSortedEstimatedBytesPerEntryDefault
+}
+
+func (db *DB) hashSortedMemtableCapacityHint(capacity int) int {
+	if db == nil || capacity <= 0 {
+		return capacity
+	}
+	if threshold := db.mutableFlushThreshold(); threshold > 0 {
+		if effectiveCap := memtableCapacity(threshold); effectiveCap > 0 && effectiveCap < capacity {
+			capacity = effectiveCap
+		}
+	}
+	hintEntries := int(db.hashSortedEntryHint.Load())
+	if hintEntries <= 0 {
+		return capacity
+	}
+	hintEntries = clampHashSortedEntryHint(hintEntries)
+	hintCapacity := hashSortedEntriesToCapacity(hintEntries)
+	if hintCapacity < minMemtablePrealloc {
+		hintCapacity = minMemtablePrealloc
+	}
+	if hintCapacity > capacity {
+		hintCapacity = capacity
+	}
+	if hintCapacity <= 0 {
+		return capacity
+	}
+	return hintCapacity
 }
 
 func (db *DB) appendOnlyMemtableCapacityHint(capacity, estimatedBytesPerEntry int) int {

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -187,7 +187,7 @@ func TestBuildOpRunsChunking(t *testing.T) {
 		putEntrySlice(make([]batch.Entry, 0, classCap))
 	}
 
-	mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	base, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
 	if err != nil {
 		t.Fatalf("NewWithCapacityMode: %v", err)
 	}
@@ -195,11 +195,12 @@ func TestBuildOpRunsChunking(t *testing.T) {
 	entryCount := classCap*2 + 3
 	for i := 0; i < entryCount; i++ {
 		binary.BigEndian.PutUint64(key[:], uint64(i))
-		mt.Set(key[:], []byte{byte(i + 1)})
+		base.Set(key[:], []byte{byte(i + 1)})
 	}
 	binary.BigEndian.PutUint64(key[:], uint64(2))
-	mt.Delete(key[:])
-	mt.Freeze()
+	base.Delete(key[:])
+	base.Freeze()
+	mt := unstableIteratorMemtable{Table: base}
 
 	runs, deleteOps, err := buildOpRuns(mt, chunkCap)
 	if err != nil {
@@ -233,7 +234,7 @@ func TestBuildOpRunsChunking(t *testing.T) {
 	}
 }
 
-func TestBuildOpRunsStableUnsafeSingleRun(t *testing.T) {
+func TestBuildOpRunsStableUnsafeSingleRun_AppendOnly(t *testing.T) {
 	mt := memtable.NewAppendOnlyWithCapacity(0)
 	var key [8]byte
 	const entryCount = 257
@@ -261,6 +262,40 @@ func TestBuildOpRunsStableUnsafeSingleRun(t *testing.T) {
 	}
 	if len(runs) != 1 {
 		t.Fatalf("run count=%d want=1 for stable append-only memtable", len(runs))
+	}
+	if got := len(runs[0]); got != entryCount {
+		t.Fatalf("run len=%d want=%d", got, entryCount)
+	}
+}
+
+func TestBuildOpRunsStableUnsafeSingleRun_HashSorted(t *testing.T) {
+	mt := memtable.NewHashSorted()
+	var key [8]byte
+	const entryCount = 257
+	for i := 0; i < entryCount; i++ {
+		binary.BigEndian.PutUint64(key[:], uint64(i))
+		mt.Set(key[:], []byte{byte(i + 1)})
+	}
+	binary.BigEndian.PutUint64(key[:], uint64(7))
+	mt.Delete(key[:])
+	mt.Freeze()
+
+	runs, deleteOps, err := buildOpRuns(mt, 2)
+	if err != nil {
+		t.Fatalf("buildOpRuns: %v", err)
+	}
+	defer func() {
+		for _, run := range runs {
+			putEntrySlice(run)
+		}
+		putEntryRuns(runs)
+	}()
+
+	if deleteOps != 1 {
+		t.Fatalf("deleteOps=%d want=1", deleteOps)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("run count=%d want=1 for stable hash-sorted memtable", len(runs))
 	}
 	if got := len(runs[0]); got != entryCount {
 		t.Fatalf("run len=%d want=%d", got, entryCount)
@@ -876,6 +911,25 @@ func TestAppendOnlyMemtableLeaseReuse(t *testing.T) {
 	}
 	if gotAppendOnly != mt {
 		t.Fatalf("expected leased append-only memtable reuse")
+	}
+}
+
+func TestHashSortedMemtableLeaseReuse(t *testing.T) {
+	db := &DB{}
+	mt := memtable.NewHashSortedWithCapacityAndIndexer(4096, nil)
+
+	db.recycleMemtables([]memtable.Table{mt})
+
+	got, err := db.newMutableMemtableWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("newMutableMemtableWithCapacityMode: %v", err)
+	}
+	gotHashSorted, ok := got.(*memtable.HashSorted)
+	if !ok {
+		t.Fatalf("expected hash-sorted memtable, got %T", got)
+	}
+	if gotHashSorted != mt {
+		t.Fatalf("expected leased hash-sorted memtable reuse")
 	}
 }
 

--- a/TreeDB/caching/memory_stats_test.go
+++ b/TreeDB/caching/memory_stats_test.go
@@ -115,9 +115,19 @@ func TestProcessMemoryStatsIncludeRuntimeBreakdown(t *testing.T) {
 		"treedb.process.read_path.db_get_caller.samples_total",
 		"treedb.process.read_path.snapshot_get_caller.sample_mod",
 		"treedb.process.read_path.snapshot_get_caller.samples_total",
+		"treedb.cache.hash_sorted.entry_hint_entries",
+		"treedb.cache.hash_sorted.entry_hint_capacity_bytes",
+		"treedb.cache.hash_sorted.mutable_from_lease_total",
+		"treedb.cache.hash_sorted.mutable_from_pool_total",
+		"treedb.cache.hash_sorted.mutable_new_alloc_total",
 		"treedb.cache.append_only.mutable_from_lease_total",
 		"treedb.cache.append_only.mutable_from_pool_total",
 		"treedb.cache.append_only.mutable_new_alloc_total",
+		"treedb.process.hash_sorted.entry_hint_entries",
+		"treedb.process.hash_sorted.entry_hint_capacity_bytes",
+		"treedb.process.hash_sorted.mutable_from_lease_total",
+		"treedb.process.hash_sorted.mutable_from_pool_total",
+		"treedb.process.hash_sorted.mutable_new_alloc_total",
 		"treedb.process.append_only.mutable_from_lease_total",
 		"treedb.process.append_only.mutable_from_pool_total",
 		"treedb.process.append_only.mutable_new_alloc_total",
@@ -130,6 +140,15 @@ func TestProcessMemoryStatsIncludeRuntimeBreakdown(t *testing.T) {
 
 	if got := mustStatInt64(t, stats, "treedb.process.memory.queue_backlog_bytes"); got != mustStatInt64(t, stats, "treedb.cache.queue_backlog_bytes") {
 		t.Fatalf("queue_backlog mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.queue_backlog_bytes"))
+	}
+	if got := mustStatInt64(t, stats, "treedb.process.hash_sorted.mutable_from_lease_total"); got != mustStatInt64(t, stats, "treedb.cache.hash_sorted.mutable_from_lease_total") {
+		t.Fatalf("hash_sorted lease source mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.hash_sorted.mutable_from_lease_total"))
+	}
+	if got := mustStatInt64(t, stats, "treedb.process.hash_sorted.mutable_from_pool_total"); got != mustStatInt64(t, stats, "treedb.cache.hash_sorted.mutable_from_pool_total") {
+		t.Fatalf("hash_sorted pool source mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.hash_sorted.mutable_from_pool_total"))
+	}
+	if got := mustStatInt64(t, stats, "treedb.process.hash_sorted.mutable_new_alloc_total"); got != mustStatInt64(t, stats, "treedb.cache.hash_sorted.mutable_new_alloc_total") {
+		t.Fatalf("hash_sorted new source mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.hash_sorted.mutable_new_alloc_total"))
 	}
 	if got := mustStatInt64(t, stats, "treedb.process.append_only.mutable_from_lease_total"); got != mustStatInt64(t, stats, "treedb.cache.append_only.mutable_from_lease_total") {
 		t.Fatalf("append_only lease source mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.append_only.mutable_from_lease_total"))

--- a/TreeDB/caching/retained_arena_trim_test.go
+++ b/TreeDB/caching/retained_arena_trim_test.go
@@ -69,3 +69,48 @@ func TestTrimAppendOnlyMemLeases_DroppedLeasesReturnToPool(t *testing.T) {
 		t.Fatalf("expected trimmed append-only leases to be returned to mem pool")
 	}
 }
+
+func TestTrimRetainedArenasAfterFlush_CheckpointPathTrimsHashSortedLeases(t *testing.T) {
+	var db DB
+
+	leaseCount := postCheckpointHashSortedMemLeaseKeep + 6
+	for i := 0; i < leaseCount; i++ {
+		mt := memtable.NewHashSortedWithCapacityAndIndexer(4<<20, nil)
+		db.hashSortedMemLeases = append(db.hashSortedMemLeases, mt)
+	}
+
+	db.trimRetainedArenasAfterFlush(true)
+
+	if got := len(db.hashSortedMemLeases); got > postCheckpointHashSortedMemLeaseKeep {
+		t.Fatalf("hash-sorted mem leases=%d want <= %d", got, postCheckpointHashSortedMemLeaseKeep)
+	}
+}
+
+func TestTrimHashSortedMemLeases_DroppedLeasesReturnToPool(t *testing.T) {
+	var db DB
+
+	keep := 2
+	leaseCount := keep + 6
+	for i := 0; i < leaseCount; i++ {
+		mt := memtable.NewHashSortedWithCapacityAndIndexer(4<<20, nil)
+		db.hashSortedMemLeases = append(db.hashSortedMemLeases, mt)
+	}
+
+	db.trimHashSortedMemLeases(keep, 4<<20)
+
+	if got := len(db.hashSortedMemLeases); got != keep {
+		t.Fatalf("hash-sorted mem leases=%d want %d", got, keep)
+	}
+
+	reused := 0
+	for i := 0; i < leaseCount-keep; i++ {
+		if v := db.hashSortedMemPool.Get(); v != nil {
+			if _, ok := v.(*memtable.HashSorted); ok {
+				reused++
+			}
+		}
+	}
+	if reused == 0 {
+		t.Fatalf("expected trimmed hash-sorted leases to be returned to mem pool")
+	}
+}

--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -25,6 +25,8 @@ const (
 	hashSortedEstimatedBytesPerEntry = 64
 	hashSortedMinInitialEntries      = 128
 	hashSortedMaxInitialEntries      = 1 << 20
+	hashSortedReuseOversizeFactor    = 4
+	hashSortedArenaRetainMaxCap      = 4 << 20
 )
 
 func hashEntryValueSize(flags byte, value []byte) int {
@@ -79,6 +81,7 @@ type HashSorted struct {
 	mu          sync.RWMutex
 	items       map[string]uint32
 	entries     []hashEntry
+	baseEntries int
 	sizeBytes   int64
 	maxKey      string
 	hasMaxKey   bool
@@ -132,6 +135,7 @@ func NewHashSortedWithCapacityAndIndexer(capacity int, indexer *HashSortedIndexe
 	m := &HashSorted{
 		items:       make(map[string]uint32, initialEntries),
 		entries:     make([]hashEntry, 0, initialEntries),
+		baseEntries: initialEntries,
 		sortedValid: true,
 		indexer:     indexer,
 	}
@@ -169,8 +173,53 @@ func (a *hashArena) resetKeepFirstChunk() {
 	a.nextCap = cap(first) * 2
 }
 
+func (a *hashArena) resetKeepFirstChunkWithin(maxCap int) {
+	if maxCap > 0 && len(a.chunks) > 0 && cap(a.chunks[0]) > maxCap {
+		a.chunks = nil
+		a.cur = nil
+		a.off = 0
+		a.nextCap = 0
+		return
+	}
+	a.resetKeepFirstChunk()
+}
+
 // Reset clears all entries while retaining internal allocations.
 func (m *HashSorted) Reset() {
+	m.ResetWithCapacity(0)
+}
+
+func hashSortedMaxReuseEntries(base int) int {
+	if base <= 0 {
+		return hashSortedMaxInitialEntries
+	}
+	maxReuse := base * hashSortedReuseOversizeFactor
+	if maxReuse < hashSortedMinInitialEntries {
+		maxReuse = hashSortedMinInitialEntries
+	}
+	if maxReuse > hashSortedMaxInitialEntries {
+		maxReuse = hashSortedMaxInitialEntries
+	}
+	return maxReuse
+}
+
+func hashSortedArenaRetainCap(capacity int) int {
+	if capacity <= 0 {
+		return hashSortedArenaRetainMaxCap
+	}
+	retain := capacity / 2
+	if retain < 64*1024 {
+		retain = 64 * 1024
+	}
+	if retain > hashSortedArenaRetainMaxCap {
+		retain = hashSortedArenaRetainMaxCap
+	}
+	return retain
+}
+
+// ResetWithCapacity clears all entries while shrinking oversized retained
+// buffers toward the provided capacity-derived baseline.
+func (m *HashSorted) ResetWithCapacity(capacity int) {
 	// Reset can be used to reuse the same memtable instance for full clears.
 	// Because incremental indexing is asynchronous, wait for in-flight chunks to
 	// finish before reusing the arena memory.
@@ -185,27 +234,78 @@ func (m *HashSorted) Reset() {
 	m.index.wait(target)
 
 	m.mu.Lock()
-
-	clear(m.items)
-	for i := range m.entries {
-		m.entries[i] = hashEntry{}
+	oldEntriesCap := cap(m.entries)
+	oldCount := len(m.entries)
+	targetEntries := 0
+	maxReuseEntries := hashSortedMaxInitialEntries
+	if capacity > 0 {
+		targetEntries = hashSortedInitialEntries(capacity)
+		if targetEntries > 0 {
+			m.baseEntries = targetEntries
+			maxReuseEntries = hashSortedMaxReuseEntries(targetEntries)
+		}
 	}
-	m.entries = m.entries[:0]
+	if targetEntries > 0 {
+		switch {
+		case oldEntriesCap > maxReuseEntries:
+			m.entries = make([]hashEntry, 0, targetEntries)
+		case oldEntriesCap < targetEntries:
+			m.entries = make([]hashEntry, 0, targetEntries)
+		default:
+			clear(m.entries)
+			m.entries = m.entries[:0]
+		}
+		if m.items == nil || oldCount > maxReuseEntries || oldEntriesCap < targetEntries {
+			m.items = make(map[string]uint32, targetEntries)
+		} else {
+			clear(m.items)
+		}
+		if cap(m.sortedKeys) > maxReuseEntries || cap(m.sortedKeys) < targetEntries {
+			m.sortedKeys = make([]string, 0, targetEntries)
+		} else {
+			clear(m.sortedKeys)
+			m.sortedKeys = m.sortedKeys[:0]
+		}
+		if cap(m.sortedDel) > maxReuseEntries || cap(m.sortedDel) < targetEntries {
+			m.sortedDel = make([]bool, 0, targetEntries)
+		} else {
+			clear(m.sortedDel)
+			m.sortedDel = m.sortedDel[:0]
+		}
+		if cap(m.pendingKeys) > maxReuseEntries || cap(m.pendingKeys) < targetEntries {
+			m.pendingKeys = nil
+		} else {
+			clear(m.pendingKeys)
+			m.pendingKeys = m.pendingKeys[:0]
+		}
+	} else {
+		clear(m.items)
+		clear(m.entries)
+		m.entries = m.entries[:0]
+		clear(m.sortedKeys)
+		m.sortedKeys = m.sortedKeys[:0]
+		clear(m.sortedDel)
+		m.sortedDel = m.sortedDel[:0]
+		clear(m.pendingKeys)
+		m.pendingKeys = m.pendingKeys[:0]
+	}
+
 	m.sizeBytes = 0
-	m.sortedKeys = m.sortedKeys[:0]
-	m.sortedDel = m.sortedDel[:0]
 	m.sortedValid = true
 	m.frozen = false
 	m.hasDeletes = false
 	m.maxKey = ""
 	m.hasMaxKey = false
-	m.pendingKeys = nil
 	m.pendingBytes = 0
 	m.nextSeq = 0
 	m.index.reset()
 	m.finalizeOnce = sync.Once{}
 	m.finalizeDone = nil
-	m.arena.resetKeepFirstChunk()
+	if capacity > 0 {
+		m.arena.resetKeepFirstChunkWithin(hashSortedArenaRetainCap(capacity))
+	} else {
+		m.arena.resetKeepFirstChunk()
+	}
 	m.mu.Unlock()
 }
 

--- a/TreeDB/internal/memtable/hash_sorted_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/hash_sorted_reset_shrink_test.go
@@ -1,0 +1,92 @@
+package memtable
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestHashSortedResetWithCapacity_ShrinksEntriesAfterSpike(t *testing.T) {
+	const capacityBytes = 4 << 10
+
+	mt := NewHashSortedWithCapacityAndIndexer(capacityBytes, nil)
+	base := hashSortedInitialEntries(capacityBytes)
+	if base <= 0 {
+		t.Fatalf("expected base entry count > 0, got %d", base)
+	}
+
+	for i := 0; i < base*12; i++ {
+		mt.Set([]byte(fmt.Sprintf("k%08d", i)), []byte("value"))
+	}
+	if got := cap(mt.entries); got <= hashSortedMaxReuseEntries(base) {
+		t.Fatalf("test setup did not grow enough: cap(entries)=%d want>%d", got, hashSortedMaxReuseEntries(base))
+	}
+
+	mt.ResetWithCapacity(capacityBytes)
+
+	if got := cap(mt.entries); got != base {
+		t.Fatalf("cap(entries)=%d want=%d", got, base)
+	}
+	if got := len(mt.entries); got != 0 {
+		t.Fatalf("len(entries)=%d want=0", got)
+	}
+	if got := len(mt.items); got != 0 {
+		t.Fatalf("len(items)=%d want=0", got)
+	}
+}
+
+func TestHashSortedResetWithCapacity_RetainsEntriesWithinBound(t *testing.T) {
+	const capacityBytes = 4 << 10
+
+	mt := NewHashSortedWithCapacityAndIndexer(capacityBytes, nil)
+	base := hashSortedInitialEntries(capacityBytes)
+	if base <= 0 {
+		t.Fatalf("expected base entry count > 0, got %d", base)
+	}
+
+	steadyEntries := base * 2
+	for i := 0; i < steadyEntries; i++ {
+		mt.Set([]byte(fmt.Sprintf("k%08d", i)), []byte("value"))
+	}
+	capBeforeReset := cap(mt.entries)
+	if capBeforeReset < steadyEntries {
+		t.Fatalf("test setup did not grow enough: cap(entries)=%d want>=%d", capBeforeReset, steadyEntries)
+	}
+	if capBeforeReset > hashSortedMaxReuseEntries(base) {
+		t.Fatalf("test setup grew beyond reuse bound: cap(entries)=%d want<=%d", capBeforeReset, hashSortedMaxReuseEntries(base))
+	}
+
+	mt.ResetWithCapacity(capacityBytes)
+
+	if got := cap(mt.entries); got != capBeforeReset {
+		t.Fatalf("cap(entries)=%d want=%d", got, capBeforeReset)
+	}
+
+	for i := 0; i < steadyEntries; i++ {
+		mt.Set([]byte(fmt.Sprintf("n%08d", i)), []byte("value"))
+	}
+	if got := cap(mt.entries); got != capBeforeReset {
+		t.Fatalf("entries regrew after warm reset: cap(entries)=%d want=%d", got, capBeforeReset)
+	}
+}
+
+func TestHashSortedResetWithCapacity_DropsOversizedFirstArenaChunk(t *testing.T) {
+	const capacityBytes = 4 << 10
+
+	mt := NewHashSortedWithCapacityAndIndexer(capacityBytes, nil)
+	buf := mt.arena.alloc(hashSortedArenaRetainMaxCap * 2)
+	if cap(buf) <= hashSortedArenaRetainCap(capacityBytes) {
+		t.Fatalf("test setup did not allocate oversized first chunk: cap=%d want>%d", cap(buf), hashSortedArenaRetainCap(capacityBytes))
+	}
+	if len(mt.arena.chunks) != 1 {
+		t.Fatalf("expected one arena chunk, got %d", len(mt.arena.chunks))
+	}
+
+	mt.ResetWithCapacity(capacityBytes)
+
+	if len(mt.arena.chunks) != 0 {
+		t.Fatalf("retained oversized first chunk after reset: chunks=%d", len(mt.arena.chunks))
+	}
+	if mt.arena.cur != nil || mt.arena.off != 0 || mt.arena.nextCap != 0 {
+		t.Fatalf("expected arena fully dropped after oversized reset: cur=%v off=%d nextCap=%d", mt.arena.cur != nil, mt.arena.off, mt.arena.nextCap)
+	}
+}


### PR DESCRIPTION
## What changed

This follow-on stacks on `#981` and tightens the remaining hash-sorted mutable churn on the write path.

It does three things:
- extends the stable `buildOpRuns` single-run fast path to any memtable with stable unsafe iterator slices, including `HashSorted`
- adds bounded `HashSorted.ResetWithCapacity(...)` behavior so oversized retained entry/index/arena buffers shrink back toward a capacity-derived baseline
- adds DB-side hash-sorted mutable lease reuse, trimming, and stats so hot recycled mutables can stay warm while checkpoint/trim paths still bound retained state

## Why it changed

After `#981`, `getEntrySlice` stopped being the main write-path allocator. The next allocator was the hash-sorted mutable path itself:
- `NewHashSortedWithCapacityAndIndexer`
- `HashSorted.ResetWithCapacity`
- `hashArena.alloc`
- `HashSorted.setEntryLocked`

The goal of this PR is to reduce rotation/reset churn without committing yet to deeper production-shaped validation.

## Impact

Local `unified-bench` write-path runs on this branch moved in the right direction:
- `Sequential Write`: `1,989,342 -> 2,071,745`
- `Random Write`: `1,416,863 -> 1,646,382`
- `Batch Write (Steady)`: still in the same variance band, with reruns at `928,232` and `984,851`

The main value of the branch is that it narrows the remaining bottleneck further. The next allocator hotspot is now more clearly the hash-sorted mutation path itself, not `getEntrySlice` churn.

## Root cause

Hash-sorted mutables were still paying too much for:
- repeated flush-build slice chunking despite stable iterator-backed storage
- repeated reset/regrow cycles after rotation/checkpoint
- weak visibility into whether mutable reuse was actually happening

## Validation

- `GOWORK=off go test ./TreeDB/internal/memtable -count=1`
- `GOWORK=off go test ./TreeDB/caching -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'Test(TrimRetainedArenasAfterFlush_CheckpointPathTrims(HashSortedLeases|AppendOnlyCaches)|Trim(HashSorted|AppendOnly)MemLeases_DroppedLeasesReturnToPool|ProcessMemoryStatsIncludeRuntimeBreakdown|HashSortedMemtableLeaseReuse|AppendOnlyMemtableLeaseReuse)$' -count=1`
- `./bin/unified-bench -dbs treedb -keys 1000000 -test sequential_write,random_write,dataset_write_random,dataset_write_sorted,batch_write -progress=false`
- `./bin/unified-bench -dbs treedb -keys 1000000 -test batch_write_steady -progress=false`

## Notes

This is intentionally still a draft. I have not yet done deep `run_celestia` / max-RSS validation on this branch, and I do not want to stack more work on top of it until that happens.
