### PR TITLE
[codex] Use outer-leaf dicts on live leaf_vlog writes

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24784,6 +24784,13 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_dict.last_publish_unix_nano"] = fmt.Sprintf("%d", db.valueLogDictLastPublishUnixNano.Load())
 	stats["treedb.cache.vlog_dict.last_k_update_unix_nano"] = fmt.Sprintf("%d", db.valueLogDictLastKUpdateUnixNano.Load())
 	stats["treedb.cache.vlog_dict.current_k"] = fmt.Sprintf("%d", db.valueLogDictCurrentK.Load())
+	for class := 0; class < vlogDictClassCount; class++ {
+		suffix := vlogDictClassSuffix(vlogDictClass(class))
+		stats["treedb.cache.vlog_dict.last_applied_dict_id."+suffix] = fmt.Sprintf("%d", db.valueLogDictLastAppliedDictIDByClass[class].Load())
+		stats["treedb.cache.vlog_dict.last_applied_dict_hash."+suffix] = fmt.Sprintf("%x", db.valueLogDictLastAppliedDictHashByClass[class].Load())
+		stats["treedb.cache.vlog_dict.current_k."+suffix] = fmt.Sprintf("%d", db.valueLogDictCurrentKByClass[class].Load())
+		stats["treedb.cache.vlog_dict.cached_current_id."+suffix] = fmt.Sprintf("%d", db.dictCurrentCachedByClass[class].Load())
+	}
 	db.valueLogDictBytesMu.Lock()
 	stats["treedb.cache.vlog_dict.cached_dict_id"] = fmt.Sprintf("%d", db.valueLogDictBytesID)
 	stats["treedb.cache.vlog_dict.cached_dict_bytes"] = fmt.Sprintf("%d", len(db.valueLogDictBytes))
@@ -24836,11 +24843,14 @@ func (db *DB) Stats() map[string]string {
 		payloadSplitSnap   vlogPayloadSplitSnapshot
 		outerLeafCodecSnap vlogOuterLeafCodecSnapshot
 	)
-	for i := range db.lanes {
-		laneSnap := snapshotLaneVlogWriteMode(&db.lanes[i])
-		kindSnap := snapshotLaneVlogPayloadKind(&db.lanes[i])
-		splitSnap := snapshotLaneVlogPayloadSplit(&db.lanes[i])
-		outerCodecSnap := snapshotLaneVlogOuterLeafCodec(&db.lanes[i])
+	accumulateLaneVlogStats := func(l *lane) {
+		if l == nil {
+			return
+		}
+		laneSnap := snapshotLaneVlogWriteMode(l)
+		kindSnap := snapshotLaneVlogPayloadKind(l)
+		splitSnap := snapshotLaneVlogPayloadSplit(l)
+		outerCodecSnap := snapshotLaneVlogOuterLeafCodec(l)
 		for mode := 0; mode < vlogCompressionWriteModeCount; mode++ {
 			writeSnap.RawBytes[mode] += laneSnap.RawBytes[mode]
 			writeSnap.StoredBytes[mode] += laneSnap.StoredBytes[mode]
@@ -24866,6 +24876,12 @@ func (db *DB) Stats() map[string]string {
 			outerLeafCodecSnap.StoredBytes[kind] += outerCodecSnap.StoredBytes[kind]
 			outerLeafCodecSnap.Frames[kind] += outerCodecSnap.Frames[kind]
 		}
+	}
+	for i := range db.lanes {
+		accumulateLaneVlogStats(&db.lanes[i])
+	}
+	if db.indexOuterLeavesInValueLog {
+		accumulateLaneVlogStats(&db.leafLog)
 	}
 	for mode := 0; mode < vlogCompressionWriteModeCount; mode++ {
 		suffix := vlogWriteModeSuffix(vlogCompressionWriteMode(mode))
@@ -24918,10 +24934,9 @@ func (db *DB) Stats() map[string]string {
 	}
 	if normalizeVlogCompressionMode(db.valueLogCompressionMode) == vlogCompressionAuto {
 		var autoSnap vlogCompressionSelectorStats
-		for i := range db.lanes {
-			selector := db.lanes[i].vlogCompressionSelector
+		accumulateSelectorStats := func(selector *vlogCompressionSelector) {
 			if selector == nil {
-				continue
+				return
 			}
 			snap := selector.snapshot()
 			for c := 0; c < vlogAutoCandidateCount; c++ {
@@ -24938,6 +24953,12 @@ func (db *DB) Stats() map[string]string {
 			autoSnap.holdEnters += snap.holdEnters
 			autoSnap.holdExits += snap.holdExits
 			autoSnap.bypassBytes += snap.bypassBytes
+		}
+		for i := range db.lanes {
+			accumulateSelectorStats(db.lanes[i].vlogCompressionSelector)
+		}
+		if db.indexOuterLeavesInValueLog {
+			accumulateSelectorStats(db.leafLog.vlogCompressionSelector)
 		}
 		var totalAutoFrames uint64
 		for c := 0; c < vlogAutoCandidateCount; c++ {

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -1,6 +1,8 @@
 package caching
 
 import (
+	"context"
+
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -34,8 +36,15 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	if err != nil {
 		return page.LeafLogPtr{}, err
 	}
+	dictID := uint64(0)
+	if l.db.dictStore != nil && l.db.valueLogDictAllowOuterLeaf() {
+		dictID, err = l.db.currentDictIDForClass(context.Background(), vlogDictClassOuterLeaf)
+		if err != nil {
+			return page.LeafLogPtr{}, err
+		}
+	}
 	rid := l.db.nextRID.Add(1)
-	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
+	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, dictID, nil, rid, encodedLeafPage, journalDurabilityNone, false)
 	if retainPath != "" {
 		l.db.markValueLogRetain(retainPath)
 	}

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -1,13 +1,21 @@
 package caching
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/compression"
+	"github.com/snissn/gomap/TreeDB/internal/dictdb"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -119,6 +127,25 @@ func buildSparseLeafPageForLeafLogTest(t *testing.T) []byte {
 	return buf
 }
 
+func buildOuterLeafDictTrainingPageForLeafLogTest(t *testing.T, seed int) []byte {
+	t.Helper()
+	buf := make([]byte, page.PageSize)
+	b := node.NewBuilderWithOptions(buf, page.PageTypeLeaf, node.BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+		PackedValuePtr:        true,
+	})
+	for i := 0; i < 24; i++ {
+		key := []byte(fmt.Sprintf("namespace/%02d/account/%03d/slot/%02d", seed%17, i, seed%5))
+		value := bytes.Repeat([]byte(fmt.Sprintf("value-block-%02d-", (seed+i)%23)), 8)
+		if err := b.AddLeafEntry(key, value[:96], node.FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry(seed=%d, entry=%d): %v", seed, i, err)
+		}
+	}
+	b.FinishNoNode()
+	return buf
+}
+
 func TestCachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := valuelog.EncodeFileID(uint32(leafLogLaneID), 1)
@@ -150,5 +177,121 @@ func TestCachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload(t *testing.T
 	}
 	if info.Size() >= int64(valuelog.HeaderSize+page.PageSize) {
 		t.Fatalf("file size=%d want compact leaf payload smaller than raw %d", info.Size(), valuelog.HeaderSize+page.PageSize)
+	}
+}
+
+func TestCachingLeafPageLog_AppendLeafPageUsesOuterLeafDictFramesInAutoBalancedSplitMode(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: filepath.Join(dir, "maindb")})
+	if err != nil {
+		t.Fatalf("backenddb.Open: %v", err)
+	}
+	opts := Options{
+		AllowUnsafe:                true,
+		DisableWAL:                 true,
+		RelaxedSync:                true,
+		IndexOuterLeavesInValueLog: true,
+		ValueLogCompression:        uint8(vlogCompressionAuto),
+		ValueLogAutoPolicy:         uint8(vlogAutoBalanced),
+		ValueLogDictClassMode:      uint8(vlogDictClassModeSplitOuterLeaf),
+		ValueLogCompressionAutotune: valuelog.AutotuneOptions{
+			Mode: valuelog.AutotuneOff,
+		},
+		ValueLogDictAdaptiveRatio: -1,
+		ValueLogDictTrain: compression.TrainConfig{
+			TrainBytes:   32 << 10,
+			MinRecords:   8,
+			SampleStride: 1,
+		},
+	}
+	db, err := Open(dir, backend, opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store, err := dictdb.Open(filepath.Join(dir, "dictdb"), backenddb.Options{Dir: filepath.Join(dir, "dictdb")})
+	if err != nil {
+		t.Fatalf("dictdb.Open: %v", err)
+	}
+	db.SetDictStore(store)
+
+	leafLog := newCachingLeafPageLog(db, &db.leafLog)
+	for i := 0; i < 512; i++ {
+		if _, err := leafLog.AppendLeafPage(buildOuterLeafDictTrainingPageForLeafLogTest(t, i)); err != nil {
+			t.Fatalf("AppendLeafPage(train %d): %v", i, err)
+		}
+	}
+	if err := leafLog.Flush(); err != nil {
+		t.Fatalf("Flush(train): %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	var outerDictID uint64
+	for time.Now().Before(deadline) {
+		stats := db.Stats()
+		rawOuterDictID := stats["treedb.cache.vlog_dict.last_applied_dict_id.outer_leaf"]
+		if rawOuterDictID != "" {
+			parsed, parseErr := strconv.ParseUint(rawOuterDictID, 10, 64)
+			if parseErr != nil {
+				t.Fatalf("parse outer leaf dict id %q: %v", rawOuterDictID, parseErr)
+			}
+			if parsed > 0 {
+				outerDictID = parsed
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if outerDictID == 0 {
+		stats := db.Stats()
+		outerTrainerStats := db.valueLogDictTrainerByClass[vlogDictClassOuterLeaf].Stats()
+		t.Fatalf("expected outer-leaf dict publish, got outer_leaf dict id=%q frames.dict=%q trainer=%+v",
+			stats["treedb.cache.vlog_dict.last_applied_dict_id.outer_leaf"],
+			stats["treedb.cache.vlog_auto.frames.dict"],
+			outerTrainerStats)
+	}
+	if useRawPages, ok, err := store.GetLeafPayloadMode(context.Background(), outerDictID); err != nil {
+		t.Fatalf("GetLeafPayloadMode: %v", err)
+	} else if !ok {
+		t.Fatalf("expected outer-leaf dict payload mode for dict %d", outerDictID)
+	} else if useRawPages {
+		t.Fatalf("expected live outer-leaf dict %d to target compact payloads", outerDictID)
+	}
+	resolveProbePage, _, err := valuelog.MaybeCompactLeafLogPayload(buildOuterLeafDictTrainingPageForLeafLogTest(t, 4096))
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload(resolve probe): %v", err)
+	}
+	chosenMode, chosenCodec, chosenProbe := db.resolveVlogWriteMode(&db.leafLog, outerDictID, len(resolveProbePage), len(resolveProbePage), true)
+
+	for i := 0; i < 256; i++ {
+		if _, err := leafLog.AppendLeafPage(buildOuterLeafDictTrainingPageForLeafLogTest(t, 1024+i)); err != nil {
+			t.Fatalf("AppendLeafPage(dict %d): %v", i, err)
+		}
+	}
+	if err := leafLog.Flush(); err != nil {
+		t.Fatalf("Flush(dict): %v", err)
+	}
+
+	stats := db.Stats()
+	rawDictFrames := stats["treedb.cache.vlog_auto.frames.dict"]
+	dictFrames, err := strconv.ParseUint(rawDictFrames, 10, 64)
+	if err != nil {
+		t.Fatalf("parse frames.dict %q: %v", rawDictFrames, err)
+	}
+	if dictFrames == 0 {
+		t.Fatalf("expected live leaf-log appends to emit dict frames, got outer_leaf dict id=%q cached_current=%q frames.dict=%q frames.off=%q block_lz4=%q block_snappy=%q chosen_mode=%v chosen_codec=%v chosen_probe=%t",
+			stats["treedb.cache.vlog_dict.last_applied_dict_id.outer_leaf"],
+			stats["treedb.cache.vlog_dict.cached_current_id.outer_leaf"],
+			rawDictFrames,
+			stats["treedb.cache.vlog_auto.frames.off"],
+			stats["treedb.cache.vlog_auto.frames.block_lz4"],
+			stats["treedb.cache.vlog_auto.frames.block_snappy"],
+			chosenMode,
+			chosenCodec,
+			chosenProbe)
+	}
+	if got := stats["treedb.cache.vlog_dict.cached_current_id.outer_leaf"]; got != strconv.FormatUint(outerDictID, 10) {
+		t.Fatalf("cached outer_leaf current id=%q want %d", got, outerDictID)
 	}
 }

--- a/TreeDB/caching/vlog_compression_regression_test.go
+++ b/TreeDB/caching/vlog_compression_regression_test.go
@@ -61,6 +61,7 @@ func TestResolveVlogWriteMode_DictAggressiveSizeLargeOuterLeafPayloadCanUseDict(
 		valueLogAutoPolicy:         uint8(vlogAutoSize),
 		valueLogBlockCodec:         valuelog.BlockCodecLZ4,
 		valueLogAutotuneOptions:    valuelog.AutotuneOptions{Mode: valuelog.AutotuneAggressive},
+		valueLogDictClassMode:      uint8(vlogDictClassModeSplitOuterLeaf),
 		indexOuterLeavesInValueLog: true,
 	}
 

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -1495,12 +1495,20 @@ func (db *DB) vlogSelectorEnabled(mode vlogCompressionMode) bool {
 
 func (db *DB) resolveVlogWriteMode(l *lane, dictID uint64, rawPayloadBytes, unitPayloadBytes int, outerLeafPayload bool) (vlogCompressionWriteMode, valuelog.BlockCodec, bool) {
 	mode := normalizeVlogCompressionMode(db.valueLogCompressionMode)
+	preferLiveOuterLeafDict := dictID != 0 &&
+		outerLeafPayload &&
+		l != nil &&
+		l.id == leafLogLaneID &&
+		db.valueLogDictAllowOuterLeaf()
 	switch mode {
 	case vlogCompressionOff:
 		return vlogWriteOff, db.valueLogBlockCodec, false
 	case vlogCompressionBlock:
 		return vlogWriteBlock, db.valueLogBlockCodec, false
 	case vlogCompressionDict:
+		if preferLiveOuterLeafDict {
+			return vlogWriteDict, db.valueLogBlockCodec, false
+		}
 		if unitPayloadBytes <= 0 {
 			unitPayloadBytes = rawPayloadBytes
 		}
@@ -1537,6 +1545,9 @@ func (db *DB) resolveVlogWriteMode(l *lane, dictID uint64, rawPayloadBytes, unit
 		return vlogWriteDict, db.valueLogBlockCodec, false
 	default:
 		// Default/unset compression behavior follows auto mode.
+		if preferLiveOuterLeafDict {
+			return vlogWriteDict, db.valueLogBlockCodec, false
+		}
 		if unitPayloadBytes <= 0 {
 			unitPayloadBytes = rawPayloadBytes
 		}

--- a/TreeDB/caching/vlog_compression_selector_test.go
+++ b/TreeDB/caching/vlog_compression_selector_test.go
@@ -762,6 +762,21 @@ func TestResolveVlogWriteMode_LargePayloadBalancedBypassesSelectorToConfiguredBl
 	}
 }
 
+func TestResolveVlogWriteMode_OuterLeafDictUsesDictOnLeafLaneInBalancedAuto(t *testing.T) {
+	db := &DB{
+		valueLogCompressionMode:    uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:         uint8(vlogAutoBalanced),
+		valueLogBlockCodec:         valuelog.BlockCodecSnappy,
+		indexOuterLeavesInValueLog: true,
+		valueLogDictClassMode:      uint8(vlogDictClassModeSplitOuterLeaf),
+	}
+	l := &lane{id: leafLogLaneID, vlogCompressionSelector: newVlogCompressionSelector(vlogAutoBalanced, 0, 0)}
+	mode, codec, probe := db.resolveVlogWriteMode(l, 9, 2048, 2048, true)
+	if mode != vlogWriteDict || codec != valuelog.BlockCodecSnappy || probe {
+		t.Fatalf("expected live outer-leaf dict write to stay on dict mode, got mode=%v codec=%v probe=%t", mode, codec, probe)
+	}
+}
+
 func TestResolveVlogWriteMode_LargePayloadBalancedUsesObservedBetterBlockCodec(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionAuto),

--- a/TreeDB/caching/vlog_dict.go
+++ b/TreeDB/caching/vlog_dict.go
@@ -135,6 +135,10 @@ type dictStoreWriter interface {
 	SetCurrent(context.Context, uint64) error
 }
 
+type dictStoreLeafPayloadModeSetter interface {
+	SetLeafPayloadMode(context.Context, uint64, bool) error
+}
+
 type dictStoreK interface {
 	SetK(context.Context, uint64, int) error
 	GetK(context.Context, uint64) (int, error)
@@ -230,17 +234,21 @@ func (db *DB) valueLogDictAllowOuterLeaf() bool {
 	if db == nil || !db.indexOuterLeavesInValueLog {
 		return false
 	}
-	// Keep default behavior conservative: only permit outer-leaf dict writes on
-	// explicitly size-biased runs.
-	if normalizeVlogAutoPolicy(db.valueLogAutoPolicy) != vlogAutoSize {
+	// Outer-leaf payloads benefit from a dedicated dictionary stream. Keep this
+	// gated on split class mode so single-value traffic does not lose its own
+	// trainer/current state, but allow balanced auto mode to participate instead
+	// of requiring an explicitly size-biased profile.
+	if db.dictClassMode() != vlogDictClassModeSplitOuterLeaf {
 		return false
 	}
+	policy := normalizeVlogAutoPolicy(db.valueLogAutoPolicy)
 	switch normalizeVlogCompressionMode(db.valueLogCompressionMode) {
 	case vlogCompressionDict:
 		// Require autotune to be enabled so poor dict fits can back off.
-		return db.valueLogAutotuneOptions.Mode != valuelog.AutotuneOff
+		return db.valueLogAutotuneOptions.Mode != valuelog.AutotuneOff &&
+			(policy == vlogAutoSize || policy == vlogAutoBalanced)
 	case vlogCompressionAuto:
-		return true
+		return policy == vlogAutoSize || policy == vlogAutoBalanced
 	default:
 		return false
 	}
@@ -1169,6 +1177,14 @@ func (db *DB) applyValueLogDictProfileForClass(class vlogDictClass) {
 	if ks, ok := store.(dictStoreK); ok {
 		if err := ks.SetK(ctx, dictID, profileK); err != nil {
 			db.reportError(err)
+		}
+	}
+	if class == vlogDictClassOuterLeaf {
+		if modeSetter, ok := store.(dictStoreLeafPayloadModeSetter); ok {
+			if err := modeSetter.SetLeafPayloadMode(ctx, dictID, false); err != nil {
+				db.reportError(err)
+				return
+			}
 		}
 	}
 	db.valueLogDictLastAppliedDictHashByClass[class].Store(profile.DictHash)

--- a/TreeDB/caching/vlog_dict_classifier_test.go
+++ b/TreeDB/caching/vlog_dict_classifier_test.go
@@ -188,6 +188,7 @@ func TestValueLogDictClassifierBypass_AllowsOuterLeafPagesForDictSizeAggressive(
 	db := &DB{
 		valueLogCompressionMode:             uint8(vlogCompressionDict),
 		valueLogAutoPolicy:                  uint8(vlogAutoSize),
+		valueLogDictClassMode:               uint8(vlogDictClassModeSplitOuterLeaf),
 		valueLogAutotuneOptions:             valuelog.AutotuneOptions{Mode: valuelog.AutotuneAggressive},
 		indexOuterLeavesInValueLog:          true,
 		valueLogDictIncompressibleHoldBytes: 256 << 10,
@@ -206,6 +207,7 @@ func TestValueLogDictClassifierBypass_AllowsOuterLeafPagesForDictSizeMedium(t *t
 	db := &DB{
 		valueLogCompressionMode:             uint8(vlogCompressionDict),
 		valueLogAutoPolicy:                  uint8(vlogAutoSize),
+		valueLogDictClassMode:               uint8(vlogDictClassModeSplitOuterLeaf),
 		valueLogAutotuneOptions:             valuelog.AutotuneOptions{Mode: valuelog.AutotuneMedium},
 		indexOuterLeavesInValueLog:          true,
 		valueLogDictIncompressibleHoldBytes: 256 << 10,
@@ -224,6 +226,7 @@ func TestValueLogDictClassifierBypass_AllowsOuterLeafPagesForAutoSize(t *testing
 	db := &DB{
 		valueLogCompressionMode:             uint8(vlogCompressionAuto),
 		valueLogAutoPolicy:                  uint8(vlogAutoSize),
+		valueLogDictClassMode:               uint8(vlogDictClassModeSplitOuterLeaf),
 		valueLogAutotuneOptions:             valuelog.AutotuneOptions{Mode: valuelog.AutotuneMedium},
 		indexOuterLeavesInValueLog:          true,
 		valueLogDictIncompressibleHoldBytes: 256 << 10,
@@ -238,10 +241,30 @@ func TestValueLogDictClassifierBypass_AllowsOuterLeafPagesForAutoSize(t *testing
 	}
 }
 
+func TestValueLogDictClassifierBypass_AllowsOuterLeafPagesForAutoBalancedSplitMode(t *testing.T) {
+	db := &DB{
+		valueLogCompressionMode:             uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:                  uint8(vlogAutoBalanced),
+		valueLogDictClassMode:               uint8(vlogDictClassModeSplitOuterLeaf),
+		valueLogAutotuneOptions:             valuelog.AutotuneOptions{Mode: valuelog.AutotuneMedium},
+		indexOuterLeavesInValueLog:          true,
+		valueLogDictIncompressibleHoldBytes: 256 << 10,
+		valueLogDictMetricsPauseBytes:       1 << 20,
+	}
+	pageValue := markOuterLeafMagic(bytes.Repeat([]byte("a"), 4096))
+	if db.valueLogDictClassifierBypass(pageValue, false) {
+		t.Fatalf("expected outer-leaf page value to stay on dict path in auto+balanced+split mode")
+	}
+	if hold := db.valueLogDictIncompressibleHoldRemaining.Load(); hold != 0 {
+		t.Fatalf("expected no incompressible hold for compressible outer-leaf page sample, hold=%d", hold)
+	}
+}
+
 func TestValueLogDictClassifierBypass_AllowsOuterLeafHighEntropyForAutoSize(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode:             uint8(vlogCompressionAuto),
 		valueLogAutoPolicy:                  uint8(vlogAutoSize),
+		valueLogDictClassMode:               uint8(vlogDictClassModeSplitOuterLeaf),
 		valueLogAutotuneOptions:             valuelog.AutotuneOptions{Mode: valuelog.AutotuneMedium},
 		indexOuterLeavesInValueLog:          true,
 		valueLogDictIncompressibleHoldBytes: 256 << 10,
@@ -608,6 +631,7 @@ func TestShouldBypassValueLogDictForRecords_OuterLeafPagesAllowedForDictSizeAggr
 	db := &DB{
 		valueLogCompressionMode:             uint8(vlogCompressionDict),
 		valueLogAutoPolicy:                  uint8(vlogAutoSize),
+		valueLogDictClassMode:               uint8(vlogDictClassModeSplitOuterLeaf),
 		valueLogAutotuneOptions:             valuelog.AutotuneOptions{Mode: valuelog.AutotuneAggressive},
 		indexOuterLeavesInValueLog:          true,
 		valueLogDictIncompressibleHoldBytes: 256 << 10,
@@ -629,6 +653,7 @@ func TestShouldBypassValueLogDictForRecords_OuterLeafPagesAllowedForAutoSize(t *
 	db := &DB{
 		valueLogCompressionMode:             uint8(vlogCompressionAuto),
 		valueLogAutoPolicy:                  uint8(vlogAutoSize),
+		valueLogDictClassMode:               uint8(vlogDictClassModeSplitOuterLeaf),
 		valueLogAutotuneOptions:             valuelog.AutotuneOptions{Mode: valuelog.AutotuneMedium},
 		indexOuterLeavesInValueLog:          true,
 		valueLogDictIncompressibleHoldBytes: 256 << 10,
@@ -637,6 +662,25 @@ func TestShouldBypassValueLogDictForRecords_OuterLeafPagesAllowedForAutoSize(t *
 	records := markOuterLeafMagicRecords(highEntropyValueLogRecords(8, 4096))
 	if db.shouldBypassValueLogDictForRecords(records, false) {
 		t.Fatalf("expected outer-leaf record batch to stay on dict path in auto+size mode")
+	}
+	if hold := db.valueLogDictIncompressibleHoldRemaining.Load(); hold != 0 {
+		t.Fatalf("expected no incompressible hold for outer-leaf record batch, hold=%d", hold)
+	}
+}
+
+func TestShouldBypassValueLogDictForRecords_OuterLeafPagesAllowedForAutoBalancedSplitMode(t *testing.T) {
+	db := &DB{
+		valueLogCompressionMode:             uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:                  uint8(vlogAutoBalanced),
+		valueLogDictClassMode:               uint8(vlogDictClassModeSplitOuterLeaf),
+		valueLogAutotuneOptions:             valuelog.AutotuneOptions{Mode: valuelog.AutotuneMedium},
+		indexOuterLeavesInValueLog:          true,
+		valueLogDictIncompressibleHoldBytes: 256 << 10,
+		valueLogDictMetricsPauseBytes:       1 << 20,
+	}
+	records := markOuterLeafMagicRecords(highEntropyValueLogRecords(8, 4096))
+	if db.shouldBypassValueLogDictForRecords(records, false) {
+		t.Fatalf("expected outer-leaf record batch to stay on dict path in auto+balanced+split mode")
 	}
 	if hold := db.valueLogDictIncompressibleHoldRemaining.Load(); hold != 0 {
 		t.Fatalf("expected no incompressible hold for outer-leaf record batch, hold=%d", hold)

--- a/TreeDB/profiles.go
+++ b/TreeDB/profiles.go
@@ -145,6 +145,7 @@ func applyFastProfile(opts *Options) {
 	opts.Durability = DurabilityWALOffRelaxed
 	opts.ValueLog.ReadIntegrity = IntegritySkipChecksums
 	opts.IndexOuterLeavesInValueLog = true
+	opts.ValueLog.DictClassMode = ValueLogDictClassSplitOuterLeaf
 	if opts.ValueLog.DictIncompressibleHoldBytes == 0 {
 		opts.ValueLog.DictIncompressibleHoldBytes = 64 << 20
 	}
@@ -164,6 +165,7 @@ func applyWALOnFastProfile(opts *Options) {
 	opts.Durability = DurabilityWALOnRelaxed
 	opts.ValueLog.ReadIntegrity = IntegritySkipChecksums
 	opts.IndexOuterLeavesInValueLog = true
+	opts.ValueLog.DictClassMode = ValueLogDictClassSplitOuterLeaf
 	if opts.ValueLog.DictIncompressibleHoldBytes == 0 {
 		opts.ValueLog.DictIncompressibleHoldBytes = 64 << 20
 	}

--- a/TreeDB/profiles_test.go
+++ b/TreeDB/profiles_test.go
@@ -43,6 +43,9 @@ func TestApplyProfile_FastSetsPolicyBools(t *testing.T) {
 	if opts.IndexInternalBaseDelta {
 		t.Fatalf("expected IndexInternalBaseDelta=false for fast profile (incompatible with outer leaves in value log)")
 	}
+	if opts.ValueLog.DictClassMode != ValueLogDictClassSplitOuterLeaf {
+		t.Fatalf("expected DictClassMode=split_outer_leaf for fast profile, got %v", opts.ValueLog.DictClassMode)
+	}
 }
 
 func TestApplyProfile_WALOnFastKeepsWALOn(t *testing.T) {
@@ -75,6 +78,9 @@ func TestApplyProfile_WALOnFastKeepsWALOn(t *testing.T) {
 	}
 	if opts.IndexInternalBaseDelta {
 		t.Fatalf("expected IndexInternalBaseDelta=false for wal_on_fast profile (incompatible with outer leaves in value log)")
+	}
+	if opts.ValueLog.DictClassMode != ValueLogDictClassSplitOuterLeaf {
+		t.Fatalf("expected DictClassMode=split_outer_leaf for wal_on_fast profile, got %v", opts.ValueLog.DictClassMode)
 	}
 }
 


### PR DESCRIPTION
## What changed

This makes live split `leaf_vlog` writes eligible to use the dedicated `outer_leaf` dictionary path instead of always forcing block compression on the foreground write path.

The branch does three things:
- wires live `AppendLeafPage` writes to look up and pass the current `outer_leaf` dict ID when split outer-leaf dict mode is enabled
- teaches live leaf-lane auto/dict selection to prefer the dedicated outer-leaf dict once one exists
- exposes the reserved leaf-log lane in the cache-layer stats so live dict usage is actually visible in runtime metrics

It also updates the `fast` and `wal_on_fast` profiles to use split outer-leaf dict mode and adds end-to-end tests around live outer-leaf dict publication and selection.

## Why it changed

Recent Celestia control runs on `main` showed a large post-dwell to post-offline-rewrite size gap:
- `fast`: `2536171948 -> 2096276342` bytes (`-439895606`)
- `wal_on_fast`: `2585213462 -> 2117928675` bytes (`-467284787`)

The important finding was that this gap was not mainly a leaf-pack reclaim problem.

On both profiles, the largest pre-rewrite `leaf_vlog` files were:
- `grouped_k1`
- `dict_frames=0`
- `block_frames=all`
- `block_codec=snappy`

After offline rewrite on the same DBs, the largest rewritten `leaf_vlog` files became:
- `grouped_k1`
- `dict_frames=all`
- `block_frames=0`

So rewrite is already using dict compression for outer-leaf payloads, while the live dwell path was not. The root cause in the code was straightforward: live `AppendLeafPage` writes were always calling into the value-log writer with `dictID=0`, and the live selector still preferred block mode on the reserved leaf lane even after a dedicated outer-leaf dict existed.

## Impact

This is aimed at closing the dwell-to-rewrite size gap by making the live path use the same dedicated outer-leaf dict machinery that rewrite already benefits from.

It does not change the generic index outer-log format. It only changes the split `leaf_vlog` path for outer-leaf payloads.

## Validation

Local validation completed:
- `GOWORK=off go test ./TreeDB/caching -run 'Test(CachingLeafPageLog_AppendLeafPageUsesOuterLeafDictFramesInAutoBalancedSplitMode|ResolveVlogWriteMode_OuterLeafDictUsesDictOnLeafLaneInBalancedAuto|CachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload|ValueLogDictClassifierBypass_AllowsOuterLeafPagesForAutoBalancedSplitMode|ShouldBypassValueLogDictForRecords_OuterLeafPagesAllowedForAutoBalancedSplitMode)$' -count=1`
- `GOWORK=off go test ./TreeDB/caching -count=1`
- `GOWORK=off go test ./TreeDB -run 'Test(ApplyProfile_(FastSetsPolicyBools|WALOnFastKeepsWALOn)|ValueLogCompressionAuto_DefaultsToDictTrainingAndProbesDict|DictDB_DoesNotInheritOuterLeavesInValueLog)$' -count=1`

Control analysis on recent `main` runs is complete and is the reason for this PR.

A full live `run_celestia + 900s dwell` validation from this branch is currently running and will be attached to this PR once it finishes.
