### PR TITLE
[codex] Transcode sealed leaf-pack generations

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1896,15 +1896,16 @@ const (
 	envDisableVlogGenerationCheckpointKick = "TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK"
 	// Experimental immutable-leaf maintenance hook. Disabled by default until
 	// the cached scheduler policy and dwell behavior are validated.
-	envEnableLeafGenerationPackMaintenance                     = "TREEDB_ENABLE_LEAF_GENERATION_PACK_MAINTENANCE"
-	envLeafGenerationPackMaintenanceMaxBytesToCopy             = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_BYTES_TO_COPY"
-	envLeafGenerationPackMaintenanceMaxGenerations             = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_GENERATIONS"
-	envLeafGenerationPackMaintenanceMinPublishedAgeSeq         = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_PUBLISHED_AGE_COMMITS"
-	envLeafGenerationPackMaintenanceMinCandidateGenerations    = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_CANDIDATE_GENERATIONS"
-	envLeafGenerationPackMaintenanceTimeoutSeconds             = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_TIMEOUT_SECONDS"
-	envLeafGenerationPackMaintenanceWriteBurstGraceMillis      = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_WRITE_BURST_GRACE_MS"
-	envLeafGenerationPackMaintenanceMaxForegroundQueue         = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_FOREGROUND_QUEUE"
-	envLeafGenerationPackMaintenanceMinReclaimPerByteCopiedPPM = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_RECLAIM_PER_BYTE_COPIED_PPM"
+	envEnableLeafGenerationPackMaintenance                       = "TREEDB_ENABLE_LEAF_GENERATION_PACK_MAINTENANCE"
+	envLeafGenerationPackMaintenanceMaxBytesToCopy               = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_BYTES_TO_COPY"
+	envLeafGenerationPackMaintenanceMaxGenerations               = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_GENERATIONS"
+	envLeafGenerationPackMaintenanceMinPublishedAgeSeq           = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_PUBLISHED_AGE_COMMITS"
+	envLeafGenerationPackMaintenanceMinCandidateGenerations      = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_CANDIDATE_GENERATIONS"
+	envLeafGenerationPackMaintenanceTimeoutSeconds               = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_TIMEOUT_SECONDS"
+	envLeafGenerationPackMaintenanceWriteBurstGraceMillis        = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_WRITE_BURST_GRACE_MS"
+	envLeafGenerationPackMaintenanceMaxForegroundQueue           = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_FOREGROUND_QUEUE"
+	envLeafGenerationPackMaintenanceMinReclaimPerByteCopiedPPM   = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_RECLAIM_PER_BYTE_COPIED_PPM"
+	envLeafGenerationPackMaintenanceMinTranscodePerByteCopiedPPM = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_TRANSCODE_SAVED_PER_BYTE_COPIED_PPM"
 	// Optional rewrite debt-drain caps for controlled online experiments.
 	envVlogGenerationRewriteResumeMaxSegments         = "TREEDB_VLOG_GENERATION_REWRITE_RESUME_MAX_SEGMENTS"
 	envVlogGenerationRewriteDebtDrainMaxSegments      = "TREEDB_VLOG_GENERATION_REWRITE_DEBT_DRAIN_MAX_SEGMENTS"
@@ -1925,34 +1926,35 @@ const (
 	// contention during early state-sync.
 	envEnableVlogGenerationPreCheckpointRewrite = "TREEDB_ENABLE_VLOG_GENERATION_PRECHECKPOINT_REWRITE"
 	// Diagnostic toggle for WAL-off checkpoint-time sparse-index vacuum.
-	envDisableCheckpointAutoVacuum                                 = "TREEDB_DISABLE_CHECKPOINT_AUTO_VACUUM"
-	minMemtablePrealloc                                            = 64 * 1024
-	leafGenerationPackMaintenanceDefaultMaxBytesToCopy             = 256 << 20
-	leafGenerationPackMaintenanceDefaultMaxGenerations             = 8
-	leafGenerationPackMaintenanceDefaultMinPublishedAgeSeq         = 1
-	leafGenerationPackMaintenanceDefaultMinCandidateGenerations    = 2
-	leafGenerationPackMaintenanceDefaultTimeout                    = 30 * time.Second
-	leafGenerationPackMaintenanceDefaultWriteBurstGrace            = 250 * time.Millisecond
-	leafGenerationPackMaintenanceDefaultMaxForegroundQueue         = 2
-	leafGenerationPackMaintenanceDefaultMinReclaimPerByteCopiedPPM = 250000
-	maxMemtablePrealloc                                            = 256 << 20
-	appendOnlyEntryHintMinEntries                                  = 128
-	appendOnlyEntryHintMaxEntries                                  = 1 << 20
-	adaptiveMinWrites                                              = 1024
-	adaptiveSequentialWritePct                                     = 0.85
-	adaptiveRangeIteratorPct                                       = 0.40
-	adaptiveOverwriteWritePct                                      = 0.25
-	adaptiveBTreeMinIteratorSamplesDefault                         = 0
-	adaptiveWarmupBytes                                            = 16 * 1024 * 1024
-	maxMemtableBytesPerShard                                       = int64(3 << 30)
-	maxOuterLeafArenaPoolCap                                       = 16 << 20
-	outerLeafBlobRefStackScratchCap                                = 256
-	maxOuterLeafEncoderRawScratchCap                               = 2 << 20
-	maxOuterLeafEncoderEncScratchCap                               = 2 << 20
-	maxOuterLeafEncoderRestartsCap                                 = 1 << 15
-	maxVlogPreparedBodyPoolCap                                     = 8 << 20
-	maxVlogPreparedFramesPoolCap                                   = 1 << 14
-	maxVlogDictPrepareResultsPoolCap                               = 1 << 14
+	envDisableCheckpointAutoVacuum                                   = "TREEDB_DISABLE_CHECKPOINT_AUTO_VACUUM"
+	minMemtablePrealloc                                              = 64 * 1024
+	leafGenerationPackMaintenanceDefaultMaxBytesToCopy               = 256 << 20
+	leafGenerationPackMaintenanceDefaultMaxGenerations               = 8
+	leafGenerationPackMaintenanceDefaultMinPublishedAgeSeq           = 1
+	leafGenerationPackMaintenanceDefaultMinCandidateGenerations      = 2
+	leafGenerationPackMaintenanceDefaultTimeout                      = 30 * time.Second
+	leafGenerationPackMaintenanceDefaultWriteBurstGrace              = 250 * time.Millisecond
+	leafGenerationPackMaintenanceDefaultMaxForegroundQueue           = 2
+	leafGenerationPackMaintenanceDefaultMinReclaimPerByteCopiedPPM   = 250000
+	leafGenerationPackMaintenanceDefaultMinTranscodePerByteCopiedPPM = 50000
+	maxMemtablePrealloc                                              = 256 << 20
+	appendOnlyEntryHintMinEntries                                    = 128
+	appendOnlyEntryHintMaxEntries                                    = 1 << 20
+	adaptiveMinWrites                                                = 1024
+	adaptiveSequentialWritePct                                       = 0.85
+	adaptiveRangeIteratorPct                                         = 0.40
+	adaptiveOverwriteWritePct                                        = 0.25
+	adaptiveBTreeMinIteratorSamplesDefault                           = 0
+	adaptiveWarmupBytes                                              = 16 * 1024 * 1024
+	maxMemtableBytesPerShard                                         = int64(3 << 30)
+	maxOuterLeafArenaPoolCap                                         = 16 << 20
+	outerLeafBlobRefStackScratchCap                                  = 256
+	maxOuterLeafEncoderRawScratchCap                                 = 2 << 20
+	maxOuterLeafEncoderEncScratchCap                                 = 2 << 20
+	maxOuterLeafEncoderRestartsCap                                   = 1 << 15
+	maxVlogPreparedBodyPoolCap                                       = 8 << 20
+	maxVlogPreparedFramesPoolCap                                     = 1 << 14
+	maxVlogDictPrepareResultsPoolCap                                 = 1 << 14
 )
 
 // SetIteratorDebug toggles attaching debug metadata to iterators returned by
@@ -6656,6 +6658,7 @@ type DB struct {
 	vlogGenerationLeafPackCanceledLastNS                         atomic.Int64
 	vlogGenerationLeafPackDeadlineLastNS                         atomic.Int64
 	vlogGenerationLeafPackLastSkipReason                         atomic.Value // string
+	vlogGenerationLeafPackLastSelectionMode                      atomic.Value // string
 	vlogGenerationRewriteRunsBySource                            [vlogGenerationMaintenanceSourceCount]atomic.Uint64
 	vlogGenerationRewriteBudgetConsumedBySource                  [vlogGenerationMaintenanceSourceCount]atomic.Uint64
 	vlogGenerationRewriteSourceBytesRequestedBySource            [vlogGenerationMaintenanceSourceCount]atomic.Uint64
@@ -9396,6 +9399,10 @@ func leafGenerationPackMaintenanceMaxForegroundQueue() int {
 
 func leafGenerationPackMaintenanceMinReclaimPerByteCopiedPPM() int {
 	return int(loadUintEnvDefault(envLeafGenerationPackMaintenanceMinReclaimPerByteCopiedPPM, leafGenerationPackMaintenanceDefaultMinReclaimPerByteCopiedPPM))
+}
+
+func leafGenerationPackMaintenanceMinTranscodePerByteCopiedPPM() int {
+	return int(loadUintEnvDefault(envLeafGenerationPackMaintenanceMinTranscodePerByteCopiedPPM, leafGenerationPackMaintenanceDefaultMinTranscodePerByteCopiedPPM))
 }
 
 func leafGenerationPackReclaimPerByteCopiedPPM(reclaimedBytes, copiedBytes int64) int64 {
@@ -14812,6 +14819,13 @@ func (db *DB) storeVlogGenerationLeafPackLastSkipReason(reason string) {
 		return
 	}
 	db.vlogGenerationLeafPackLastSkipReason.Store(reason)
+}
+
+func (db *DB) storeVlogGenerationLeafPackLastSelectionMode(mode string) {
+	if db == nil {
+		return
+	}
+	db.vlogGenerationLeafPackLastSelectionMode.Store(mode)
 }
 
 func (db *DB) observeVlogGenerationLeafPackAdmissionSkip(reason string) {
@@ -22804,6 +22818,7 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 	minPublishedAgeCommits := envUint64(envLeafGenerationPackMaintenanceMinPublishedAgeSeq, leafGenerationPackMaintenanceDefaultMinPublishedAgeSeq)
 	minCandidateGenerations := loadPositiveIntEnvDefault(envLeafGenerationPackMaintenanceMinCandidateGenerations, leafGenerationPackMaintenanceDefaultMinCandidateGenerations)
 	minReclaimPerByteCopiedPPM := leafGenerationPackMaintenanceMinReclaimPerByteCopiedPPM()
+	minTranscodePerByteCopiedPPM := leafGenerationPackMaintenanceMinTranscodePerByteCopiedPPM()
 	timeout := leafGenerationPackMaintenanceTimeout()
 
 	db.vlogGenerationLeafPackAttempts.Add(1)
@@ -22842,13 +22857,14 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 		remainingBytesToCopy := maxBytesToCopy
 		for remainingGenerations > 0 && remainingBytesToCopy > 0 {
 			stats, runErr := runner.LeafGenerationPackRunOnce(ctx, backenddb.LeafGenerationPackFromPlanOptions{
-				Sync:                       false,
-				MinPublishedAgeCommits:     minPublishedAgeCommits,
-				MinCandidateGenerations:    minCandidateGenerations,
-				MinReclaimPerByteCopiedPPM: minReclaimPerByteCopiedPPM,
-				MaxGenerations:             remainingGenerations,
-				MaxBytesToCopy:             remainingBytesToCopy,
-				ReserveRIDs:                db.ReserveValueLogRIDs,
+				Sync:                         false,
+				MinPublishedAgeCommits:       minPublishedAgeCommits,
+				MinCandidateGenerations:      minCandidateGenerations,
+				MinReclaimPerByteCopiedPPM:   minReclaimPerByteCopiedPPM,
+				MinTranscodePerByteCopiedPPM: minTranscodePerByteCopiedPPM,
+				MaxGenerations:               remainingGenerations,
+				MaxBytesToCopy:               remainingBytesToCopy,
+				ReserveRIDs:                  db.ReserveValueLogRIDs,
 			})
 			if runErr != nil {
 				return runErr
@@ -22866,6 +22882,7 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 			db.vlogGenerationLeafPackLastSelectionBytesDead.Store(stats.Selection.BytesDead)
 			db.vlogGenerationLeafPackLastSelectionGenerations.Store(int64(len(stats.Selection.GenerationIDs)))
 			db.vlogGenerationLeafPackLastBytesCopied.Store(stats.Pack.BytesCopied)
+			db.storeVlogGenerationLeafPackLastSelectionMode(stats.Selection.Mode)
 
 			if stats.Selection.ExpectedReclaimBytes > 0 {
 				db.vlogGenerationLeafPackExpectedReclaimBytes.Add(uint64(stats.Selection.ExpectedReclaimBytes))
@@ -22885,6 +22902,7 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 			if !stats.Ran {
 				if !ran {
 					db.storeVlogGenerationLeafPackLastSkipReason(stats.SkipReason)
+					db.storeVlogGenerationLeafPackLastSelectionMode(stats.Selection.Mode)
 				}
 				return nil
 			}
@@ -22993,8 +23011,9 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 
 	db.vlogGenerationLeafPackSkips.Add(1)
 	db.debugVlogMaintf(
-		"leaf_pack_skip reason=%s generations=%d bytes_to_copy=%d expected_reclaim_bytes=%d",
+		"leaf_pack_skip reason=%s mode=%s generations=%d bytes_to_copy=%d expected_reclaim_bytes=%d",
 		lastStats.SkipReason,
+		lastStats.Selection.Mode,
 		len(lastStats.Selection.GenerationIDs),
 		lastStats.Selection.BytesToCopy,
 		lastStats.Selection.ExpectedReclaimBytes,
@@ -24186,11 +24205,13 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_generation.leaf_pack.max_bytes_to_copy"] = fmt.Sprintf("%d", int64(envUint64(envLeafGenerationPackMaintenanceMaxBytesToCopy, leafGenerationPackMaintenanceDefaultMaxBytesToCopy)))
 	stats["treedb.cache.vlog_generation.leaf_pack.min_candidate_generations"] = fmt.Sprintf("%d", loadPositiveIntEnvDefault(envLeafGenerationPackMaintenanceMinCandidateGenerations, leafGenerationPackMaintenanceDefaultMinCandidateGenerations))
 	stats["treedb.cache.vlog_generation.leaf_pack.min_reclaim_per_byte_copied_ppm"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceMinReclaimPerByteCopiedPPM())
+	stats["treedb.cache.vlog_generation.leaf_pack.min_transcode_saved_per_byte_copied_ppm"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceMinTranscodePerByteCopiedPPM())
 	stats["treedb.cache.vlog_generation.leaf_pack.last_expected_reclaim_bytes"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackLastExpectedReclaimBytes.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.last_expected_reclaim_per_byte_copied_ppm"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackLastExpectedReclaimPerByteCopiedPPM.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.last_selection.bytes_to_copy"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackLastSelectionBytesToCopy.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.last_selection.bytes_dead"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackLastSelectionBytesDead.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.last_selection.generations"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackLastSelectionGenerations.Load())
+	stats["treedb.cache.vlog_generation.leaf_pack.last_selection.mode"] = atomicValueString(&db.vlogGenerationLeafPackLastSelectionMode)
 	stats["treedb.cache.vlog_generation.leaf_pack.last_bytes_copied"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackLastBytesCopied.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.last_attributed_reclaim_bytes"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackLastReclaimedBytes.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.last_attributed_reclaim_per_byte_copied_ppm"] = fmt.Sprintf("%d", leafGenerationPackReclaimPerByteCopiedPPM(db.vlogGenerationLeafPackLastReclaimedBytes.Load(), db.vlogGenerationLeafPackLastBytesCopied.Load()))

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/internal/compression"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -161,6 +162,27 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 	writer.ConfigureLeafLog(layout.leafVLogDir, rewriteLeafLogLaneID, leafStartSeq)
 	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
 	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
+	if writer.blockCompression {
+		if state := db.state.Load(); state != nil {
+			leafDictID, leafDictBytes, leafDictUseRawPages, err := leafGenerationPackPrepareLeafDict(
+				db,
+				state,
+				db.valueLogDictCurrentForClass,
+				db.valueLogDictLeafPayloadMode,
+				db.valueLogDictLookup,
+				db.valueLogDictPut,
+				db.valueLogDictSetCurrentForClass,
+				db.valueLogDictSetLeafPayloadMode,
+				compression.TrainConfig{},
+			)
+			if err != nil {
+				return stats, err
+			}
+			if leafDictID != 0 && len(leafDictBytes) > 0 {
+				writer.SetLeafDictMode(leafDictID, leafDictBytes, leafDictUseRawPages)
+			}
+		}
+	}
 	defer func() { _ = writer.Close() }()
 
 	sourceValueIDs := make(map[uint32]struct{}, len(rawSourceIDs))

--- a/TreeDB/db/leaf_generation_pack_from_plan.go
+++ b/TreeDB/db/leaf_generation_pack_from_plan.go
@@ -1,20 +1,24 @@
 package db
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // LeafGenerationPackFromPlanOptions combines planner thresholds, bounded
 // selection limits, and pack execution settings for the manual from-plan path.
 type LeafGenerationPackFromPlanOptions struct {
-	Sync                       bool
-	Force                      bool
-	MinPublishedAgeCommits     uint64
-	MinCandidateGenerations    int
-	MinExpectedReclaimBytes    int64
-	MinExpectedReclaimRatioPPM int
-	MinReclaimPerByteCopiedPPM int
-	MaxGenerations             int
-	MaxBytesToCopy             int64
-	ReserveRIDs                func(count int) (start uint64, err error)
+	Sync                         bool
+	Force                        bool
+	MinPublishedAgeCommits       uint64
+	MinCandidateGenerations      int
+	MinExpectedReclaimBytes      int64
+	MinExpectedReclaimRatioPPM   int
+	MinReclaimPerByteCopiedPPM   int
+	MinTranscodePerByteCopiedPPM int
+	MaxGenerations               int
+	MaxBytesToCopy               int64
+	ReserveRIDs                  func(count int) (start uint64, err error)
 }
 
 func leafGenerationPackFromPlanPlanOptions(opts LeafGenerationPackFromPlanOptions) LeafGenerationPlanOptions {
@@ -46,16 +50,31 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 	if err != nil {
 		return LeafGenerationPackStats{}, err
 	}
-	selection, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
-		Force:                      opts.Force,
-		MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
-		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
-		MaxGenerations:             opts.MaxGenerations,
-		MaxBytesToCopy:             opts.MaxBytesToCopy,
-		MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
-	})
-	if err != nil {
-		return LeafGenerationPackStats{}, err
+	var (
+		selection    LeafGenerationPackSelection
+		selectionErr error
+	)
+	if plan.Admission == leafGenerationPlanAdmissionEligible {
+		selection, selectionErr = SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
+			Force:                      opts.Force,
+			MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
+			MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
+			MaxGenerations:             opts.MaxGenerations,
+			MaxBytesToCopy:             opts.MaxBytesToCopy,
+			MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
+		})
+	}
+	if len(selection.GenerationIDs) == 0 {
+		selection, err = leafGenerationPackSelectTranscode(db, ctx, plan, opts)
+		if err != nil {
+			if selectionErr != nil {
+				return LeafGenerationPackStats{}, selectionErr
+			}
+			if plan.Admission != leafGenerationPlanAdmissionEligible {
+				return LeafGenerationPackStats{}, fmt.Errorf("leaf generation pack selection: plan admission=%s", plan.Admission)
+			}
+			return LeafGenerationPackStats{}, err
+		}
 	}
 	return db.leafGenerationPackSelected(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs), selectedLeafGenerationPackPlan(selection))
 }

--- a/TreeDB/db/leaf_generation_pack_run_once.go
+++ b/TreeDB/db/leaf_generation_pack_run_once.go
@@ -24,23 +24,37 @@ func (db *DB) LeafGenerationPackRunOnce(ctx context.Context, opts LeafGeneration
 		return stats, err
 	}
 	stats.Plan = plan
-	if plan.Admission != leafGenerationPlanAdmissionEligible {
-		stats.SkipReason = fmt.Sprintf("plan_admission:%s", plan.Admission)
-		return stats, nil
+	var selection LeafGenerationPackSelection
+	baseSkipReason := ""
+	if plan.Admission == leafGenerationPlanAdmissionEligible {
+		selection, err = SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
+			MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
+			MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
+			MaxGenerations:             opts.MaxGenerations,
+			MaxBytesToCopy:             opts.MaxBytesToCopy,
+			MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
+		})
+		if err == nil {
+			stats.Selection = selection
+		} else {
+			baseSkipReason = fmt.Sprintf("selection:%v", err)
+		}
+	} else {
+		baseSkipReason = fmt.Sprintf("plan_admission:%s", plan.Admission)
 	}
-	selection, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
-		MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
-		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
-		MaxGenerations:             opts.MaxGenerations,
-		MaxBytesToCopy:             opts.MaxBytesToCopy,
-		MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
-	})
-	if err != nil {
-		stats.SkipReason = fmt.Sprintf("selection:%v", err)
-		return stats, nil
+	if len(stats.Selection.GenerationIDs) == 0 {
+		transcodeSelection, transcodeErr := leafGenerationPackSelectTranscode(db, ctx, plan, opts)
+		if transcodeErr != nil {
+			if baseSkipReason != "" {
+				stats.SkipReason = baseSkipReason
+			} else {
+				stats.SkipReason = fmt.Sprintf("transcode:%v", transcodeErr)
+			}
+			return stats, nil
+		}
+		stats.Selection = transcodeSelection
 	}
-	stats.Selection = selection
-	packStats, err := db.leafGenerationPackSelected(ctx, leafGenerationPackFromPlanPackOptions(opts, selection.GenerationIDs), selectedLeafGenerationPackPlan(selection))
+	packStats, err := db.leafGenerationPackSelected(ctx, leafGenerationPackFromPlanPackOptions(opts, stats.Selection.GenerationIDs), selectedLeafGenerationPackPlan(stats.Selection))
 	if err != nil {
 		return stats, err
 	}

--- a/TreeDB/db/leaf_generation_pack_run_once_test.go
+++ b/TreeDB/db/leaf_generation_pack_run_once_test.go
@@ -179,6 +179,76 @@ func TestLeafGenerationPackRunOnce_CallsLeafGenerationPlanOnce(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationPackRunOnce_UsesTranscodeFallbackWhenPlanHasNoDeadBytes(t *testing.T) {
+	db, leafLog, dir := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "k", 32768, 'a')
+	path1, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, db, "k", 0, 1, 'b')
+
+	manifestBefore := loadLeafGenerationManifestOrFatal(t, dir)
+	gen1 := findLeafGenerationByFileID(t, manifestBefore, rawFileID1)
+
+	prev := leafGenerationPackSelectTranscode
+	leafGenerationPackSelectTranscode = func(_ *DB, _ context.Context, plan LeafGenerationPlan, _ LeafGenerationPackFromPlanOptions) (LeafGenerationPackSelection, error) {
+		if got, want := plan.Admission, leafGenerationPlanAdmissionEligible; got != want {
+			t.Fatalf("plan admission=%q want %q", got, want)
+		}
+		return LeafGenerationPackSelection{
+			Mode:          leafGenerationPackSelectionModeTranscode,
+			GenerationIDs: []uint64{gen1.GenerationID},
+			Generations: []LeafGenerationPlanGeneration{
+				{GenerationID: gen1.GenerationID, BytesTotal: 4096, BytesLive: 3584, BytesDead: 512, BytesToCopy: 4096, LivePages: 1},
+			},
+			BytesTotal:                         4096,
+			BytesLive:                          3584,
+			BytesDead:                          512,
+			BytesToCopy:                        4096,
+			LivePages:                          1,
+			ExpectedReclaimBytes:               512,
+			ExpectedReclaimRatioPPM:            ratioPPM(512, 4096),
+			ExpectedReclaimPerByteCopiedPPM:    ratioPPM(512, 4096),
+			ExpectedBytesAfter:                 3584,
+			ExpectedBytesSaved:                 512,
+			ExpectedBytesSavedRatioPPM:         ratioPPM(512, 4096),
+			ExpectedBytesSavedPerByteCopiedPPM: ratioPPM(512, 4096),
+		}, nil
+	}
+	defer func() {
+		leafGenerationPackSelectTranscode = prev
+	}()
+
+	stats, err := db.LeafGenerationPackRunOnce(context.Background(), LeafGenerationPackFromPlanOptions{
+		MaxGenerations:             1,
+		MinReclaimPerByteCopiedPPM: 900000,
+		Sync:                       true,
+	})
+	if err != nil {
+		t.Fatalf("LeafGenerationPackRunOnce: %v", err)
+	}
+	if !stats.Ran {
+		t.Fatalf("expected transcode fallback to run, skip_reason=%q", stats.SkipReason)
+	}
+	if got, want := stats.Selection.Mode, leafGenerationPackSelectionModeTranscode; got != want {
+		t.Fatalf("Selection.Mode=%q want %q", got, want)
+	}
+	if got, want := stats.Selection.GenerationIDs, []uint64{gen1.GenerationID}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("Selection.GenerationIDs=%v want %v", got, want)
+	}
+	expectLeafGenerationValue(t, db, leafGenerationKey("k", 0), 'b')
+	expectLeafGenerationValue(t, db, leafGenerationKey("k", 1), 'a')
+	if _, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{}); err != nil {
+		t.Fatalf("LeafGenerationGC after transcode fallback: %v", err)
+	}
+	if err := waitForPathRemoval(path1, 5*time.Second); err != nil {
+		t.Fatalf("waitForPathRemoval(%s): %v", path1, err)
+	}
+}
+
 func TestLeafGenerationPackFromPlan_ForceBypassesSelectionThresholds(t *testing.T) {
 	db, leafLog, _ := openLeafGenerationPackTestDB(t)
 

--- a/TreeDB/db/leaf_generation_pack_select.go
+++ b/TreeDB/db/leaf_generation_pack_select.go
@@ -18,16 +18,21 @@ type LeafGenerationPackSelectOptions struct {
 
 // LeafGenerationPackSelection summarizes a bounded subset of pack candidates.
 type LeafGenerationPackSelection struct {
-	GenerationIDs                   []uint64
-	Generations                     []LeafGenerationPlanGeneration
-	BytesTotal                      int64
-	BytesLive                       int64
-	BytesDead                       int64
-	BytesToCopy                     int64
-	LivePages                       int
-	ExpectedReclaimBytes            int64
-	ExpectedReclaimRatioPPM         int
-	ExpectedReclaimPerByteCopiedPPM int
+	Mode                               string
+	GenerationIDs                      []uint64
+	Generations                        []LeafGenerationPlanGeneration
+	BytesTotal                         int64
+	BytesLive                          int64
+	BytesDead                          int64
+	BytesToCopy                        int64
+	LivePages                          int
+	ExpectedReclaimBytes               int64
+	ExpectedReclaimRatioPPM            int
+	ExpectedReclaimPerByteCopiedPPM    int
+	ExpectedBytesAfter                 int64
+	ExpectedBytesSaved                 int64
+	ExpectedBytesSavedRatioPPM         int
+	ExpectedBytesSavedPerByteCopiedPPM int
 }
 
 type leafGenerationPackSelectionState struct {
@@ -197,6 +202,13 @@ func finalizeLeafGenerationPackSelection(out LeafGenerationPackSelection, opts L
 	out.ExpectedReclaimBytes = out.BytesDead
 	out.ExpectedReclaimRatioPPM = ratioPPM(out.BytesDead, out.BytesTotal)
 	out.ExpectedReclaimPerByteCopiedPPM = ratioPPM(out.BytesDead, out.BytesToCopy)
+	if out.Mode == "" {
+		out.Mode = leafGenerationPackSelectionModeReclaim
+	}
+	out.ExpectedBytesAfter = out.BytesLive
+	out.ExpectedBytesSaved = out.ExpectedReclaimBytes
+	out.ExpectedBytesSavedRatioPPM = out.ExpectedReclaimRatioPPM
+	out.ExpectedBytesSavedPerByteCopiedPPM = out.ExpectedReclaimPerByteCopiedPPM
 	return out, nil
 }
 

--- a/TreeDB/db/leaf_generation_pack_select_test.go
+++ b/TreeDB/db/leaf_generation_pack_select_test.go
@@ -208,3 +208,32 @@ func TestSelectLeafGenerationPackCandidates_MaxBytesOnlyUsesGreedySelection(t *t
 		t.Fatalf("GenerationIDs=%v, want %v", got, want)
 	}
 }
+
+func TestBuildLeafGenerationPackTranscodePlan_UsesEstimatedSavings(t *testing.T) {
+	gens := []LeafGenerationPlanGeneration{
+		{GenerationID: 41, State: leafGenerationStateSealed, BytesLive: 1000, BytesToCopy: 1000, LivePages: 4},
+		{GenerationID: 42, State: leafGenerationStateSealed, BytesLive: 800, BytesToCopy: 800, LivePages: 3},
+	}
+	plan, err := buildLeafGenerationPackTranscodePlan(gens, map[uint64]leafGenerationPackTranscodeEstimate{
+		41: {SamplePages: 4, EstimatedBytesAfter: 700, ExpectedSavedBytes: 300},
+		42: {SamplePages: 3, EstimatedBytesAfter: 760, ExpectedSavedBytes: 40},
+	}, LeafGenerationPackFromPlanOptions{MinCandidateGenerations: 2})
+	if err != nil {
+		t.Fatalf("buildLeafGenerationPackTranscodePlan: %v", err)
+	}
+	if got, want := len(plan.Candidates), 2; got != want {
+		t.Fatalf("len(Candidates)=%d want %d", got, want)
+	}
+	if got, want := plan.CandidateGenerationIDs, []uint64{41, 42}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("CandidateGenerationIDs=%v want %v", got, want)
+	}
+	if got, want := plan.CandidateBytesDead, int64(340); got != want {
+		t.Fatalf("CandidateBytesDead=%d want %d", got, want)
+	}
+	if got, want := plan.CandidateBytesLive, int64(1460); got != want {
+		t.Fatalf("CandidateBytesLive=%d want %d", got, want)
+	}
+	if got, want := plan.ExpectedReclaimPerByteCopiedPPM, ratioPPM(340, 1800); got != want {
+		t.Fatalf("ExpectedReclaimPerByteCopiedPPM=%d want %d", got, want)
+	}
+}

--- a/TreeDB/db/leaf_generation_pack_transcode.go
+++ b/TreeDB/db/leaf_generation_pack_transcode.go
@@ -1,0 +1,288 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/compression"
+	"github.com/snissn/gomap/TreeDB/internal/leafrefscan"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+const (
+	leafGenerationPackSelectionModeReclaim   = "reclaim"
+	leafGenerationPackSelectionModeTranscode = "transcode"
+
+	leafGenerationPackDefaultMinTranscodePerByteCopiedPPM = 50_000
+	leafGenerationPackTranscodeSamplePagesPerGeneration   = 16
+)
+
+var errLeafGenerationPackEnoughTranscodeSamples = errors.New("leaf generation pack: enough transcode samples")
+
+var leafGenerationPackSelectTranscode = func(db *DB, ctx context.Context, plan LeafGenerationPlan, opts LeafGenerationPackFromPlanOptions) (LeafGenerationPackSelection, error) {
+	return db.selectLeafGenerationPackTranscodeCandidates(ctx, plan, opts)
+}
+
+var leafGenerationPackPrepareLeafDict = prepareRewriteLeafDict
+
+type leafGenerationPackTranscodeEstimate struct {
+	SamplePages               int
+	SampleCurrentBytes        int64
+	SampleEstimatedBytesAfter int64
+	EstimatedBytesAfter       int64
+	ExpectedSavedBytes        int64
+}
+
+func (db *DB) selectLeafGenerationPackTranscodeCandidates(ctx context.Context, plan LeafGenerationPlan, opts LeafGenerationPackFromPlanOptions) (LeafGenerationPackSelection, error) {
+	candidates := filterLeafGenerationPackTranscodeCandidates(plan.Generations, opts)
+	if len(candidates) == 0 {
+		return LeafGenerationPackSelection{}, fmt.Errorf("leaf generation pack transcode selection: no sealed live generations are eligible")
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil || snap.state == nil || snap.idx == nil {
+		return LeafGenerationPackSelection{}, fmt.Errorf("leaf generation pack transcode selection: snapshot unavailable")
+	}
+	defer func() { _ = snap.Close() }()
+
+	dictID, dictBytes, useRawPages, err := leafGenerationPackPrepareLeafDict(
+		db,
+		snap.state,
+		db.valueLogDictCurrentForClass,
+		db.valueLogDictLeafPayloadMode,
+		db.valueLogDictLookup,
+		db.valueLogDictPut,
+		db.valueLogDictSetCurrentForClass,
+		db.valueLogDictSetLeafPayloadMode,
+		compression.TrainConfig{},
+	)
+	if err != nil {
+		return LeafGenerationPackSelection{}, fmt.Errorf("leaf generation pack transcode selection: prepare leaf dict: %w", err)
+	}
+	if dictID == 0 || len(dictBytes) == 0 {
+		return LeafGenerationPackSelection{}, fmt.Errorf("leaf generation pack transcode selection: outer-leaf dict unavailable")
+	}
+
+	estimates, err := db.estimateLeafGenerationPackTranscodeSavings(ctx, snap, candidates, dictID, dictBytes, useRawPages)
+	if err != nil {
+		return LeafGenerationPackSelection{}, err
+	}
+	transcodePlan, err := buildLeafGenerationPackTranscodePlan(candidates, estimates, opts)
+	if err != nil {
+		return LeafGenerationPackSelection{}, err
+	}
+
+	minTranscodePerCopyPPM := opts.MinTranscodePerByteCopiedPPM
+	if minTranscodePerCopyPPM <= 0 {
+		minTranscodePerCopyPPM = leafGenerationPackDefaultMinTranscodePerByteCopiedPPM
+	}
+	selection, err := SelectLeafGenerationPackCandidates(transcodePlan, LeafGenerationPackSelectOptions{
+		Force:                      opts.Force,
+		MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
+		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
+		MaxGenerations:             opts.MaxGenerations,
+		MaxBytesToCopy:             opts.MaxBytesToCopy,
+		MinReclaimPerByteCopiedPPM: minTranscodePerCopyPPM,
+	})
+	if err != nil {
+		return LeafGenerationPackSelection{}, fmt.Errorf("leaf generation pack transcode selection: %w", err)
+	}
+	selection.Mode = leafGenerationPackSelectionModeTranscode
+	return selection, nil
+}
+
+func filterLeafGenerationPackTranscodeCandidates(gens []LeafGenerationPlanGeneration, opts LeafGenerationPackFromPlanOptions) []LeafGenerationPlanGeneration {
+	out := make([]LeafGenerationPlanGeneration, 0, len(gens))
+	for _, gen := range gens {
+		switch gen.State {
+		case leafGenerationStateWritable, leafGenerationStateRetiring, leafGenerationStateDeleted:
+			continue
+		}
+		if gen.BytesLive <= 0 || gen.LivePages <= 0 {
+			continue
+		}
+		if !opts.Force && opts.MinPublishedAgeCommits > 0 && gen.AgeCommits < opts.MinPublishedAgeCommits {
+			continue
+		}
+		out = append(out, gen)
+	}
+	return out
+}
+
+func buildLeafGenerationPackTranscodePlan(gens []LeafGenerationPlanGeneration, estimates map[uint64]leafGenerationPackTranscodeEstimate, opts LeafGenerationPackFromPlanOptions) (LeafGenerationPlan, error) {
+	plan := LeafGenerationPlan{Admission: leafGenerationPlanAdmissionEligible}
+	for _, gen := range gens {
+		estimate, ok := estimates[gen.GenerationID]
+		if !ok || estimate.ExpectedSavedBytes <= 0 {
+			continue
+		}
+		candidate := gen
+		candidate.BytesTotal = gen.BytesLive
+		candidate.BytesLive = estimate.EstimatedBytesAfter
+		candidate.BytesDead = estimate.ExpectedSavedBytes
+		candidate.BytesToCopy = gen.BytesLive
+		candidate.Eligible = true
+		candidate.SkipReason = ""
+		plan.Candidates = append(plan.Candidates, candidate)
+	}
+	if len(plan.Candidates) == 0 {
+		return plan, fmt.Errorf("leaf generation pack transcode selection: sampled generations did not predict any size win")
+	}
+	if !opts.Force && opts.MinCandidateGenerations > 0 && len(plan.Candidates) < opts.MinCandidateGenerations {
+		return plan, fmt.Errorf("leaf generation pack transcode selection: only %d candidate generations satisfy transcode economics (need >= %d)", len(plan.Candidates), opts.MinCandidateGenerations)
+	}
+	rankLeafGenerationPlanCandidates(plan.Candidates)
+	plan.CandidateGenerationIDs = make([]uint64, 0, len(plan.Candidates))
+	for _, gen := range plan.Candidates {
+		plan.CandidateGenerationIDs = append(plan.CandidateGenerationIDs, gen.GenerationID)
+		plan.CandidateBytesTotal += gen.BytesTotal
+		plan.CandidateBytesLive += gen.BytesLive
+		plan.CandidateBytesDead += gen.BytesDead
+		plan.CandidateBytesToCopy += gen.BytesToCopy
+		plan.CandidateLivePages += gen.LivePages
+	}
+	plan.ExpectedReclaimBytes = plan.CandidateBytesDead
+	plan.ExpectedReclaimRatioPPM = ratioPPM(plan.CandidateBytesDead, plan.CandidateBytesTotal)
+	plan.ExpectedReclaimPerByteCopiedPPM = ratioPPM(plan.CandidateBytesDead, plan.CandidateBytesToCopy)
+	return plan, nil
+}
+
+func (db *DB) estimateLeafGenerationPackTranscodeSavings(ctx context.Context, snap *Snapshot, candidates []LeafGenerationPlanGeneration, dictID uint64, dict []byte, useRawPages bool) (map[uint64]leafGenerationPackTranscodeEstimate, error) {
+	if db == nil || snap == nil || snap.state == nil || snap.state.LeafGenerations == nil || snap.state.ValueLogSet == nil {
+		return nil, fmt.Errorf("leaf generation pack transcode selection: snapshot state unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	quotas := make(map[uint64]int, len(candidates))
+	candidateByID := make(map[uint64]LeafGenerationPlanGeneration, len(candidates))
+	remaining := 0
+	for _, gen := range candidates {
+		quota := gen.LivePages
+		if quota > leafGenerationPackTranscodeSamplePagesPerGeneration {
+			quota = leafGenerationPackTranscodeSamplePagesPerGeneration
+		}
+		if quota <= 0 {
+			continue
+		}
+		candidateByID[gen.GenerationID] = gen
+		quotas[gen.GenerationID] = quota
+		remaining += quota
+	}
+	if remaining == 0 {
+		return map[uint64]leafGenerationPackTranscodeEstimate{}, nil
+	}
+
+	verifyAlways := snap.idx.pager.VerifyOnRead()
+	verify := func(pageID uint64, n node.Node) error {
+		if verifyAlways || !snap.idx.pager.IsVerified(pageID) {
+			if !n.VerifyChecksum() {
+				return fmt.Errorf("leaf generation pack transcode selection: checksum mismatch on page %d", pageID)
+			}
+			if !verifyAlways {
+				snap.idx.pager.MarkVerified(pageID)
+			}
+		}
+		return nil
+	}
+	roots := make([]uint64, 0, 2)
+	if snap.state.RootPageID != 0 {
+		roots = append(roots, snap.state.RootPageID)
+	}
+	if snap.state.SystemRootPageID != 0 {
+		roots = append(roots, snap.state.SystemRootPageID)
+	}
+	if len(roots) == 0 {
+		return map[uint64]leafGenerationPackTranscodeEstimate{}, nil
+	}
+
+	preparer := valuelog.NewFramePreparer()
+	records := [1]valuelog.Record{{RID: 1}}
+	bodyScratch := make([]byte, 0, page.PageSize)
+	leafScratch := make([]byte, 0, page.PageSize)
+	estimates := make(map[uint64]leafGenerationPackTranscodeEstimate, len(candidates))
+	view := snap.state.LeafGenerations
+
+	visit := func(ptr page.LeafLogPtr) error {
+		genID, ok := view.FileToGeneration[ptr.FileID]
+		if !ok {
+			return nil
+		}
+		quota := quotas[genID]
+		if quota <= 0 {
+			return nil
+		}
+		currentLen, _, err := db.leafGenerationRecordLengthForPlan(ptr, snap.state.ValueLogSet, view)
+		if err != nil {
+			return err
+		}
+		leafPage, usedScratch, err := snap.state.ValueLogSet.ReadUnsafeTo(ptr.ValuePtr(), leafScratch[:0])
+		if err != nil {
+			return err
+		}
+		if usedScratch {
+			if cap(leafPage) > rewriteReadScratchMaxCap {
+				leafScratch = nil
+			} else {
+				leafScratch = leafPage[:0]
+			}
+		}
+		payload := leafPage
+		if !useRawPages {
+			payload, _, err = valuelog.MaybeCompactLeafLogPayload(leafPage)
+			if err != nil {
+				return err
+			}
+		}
+		records[0].Value = payload
+		body, _, err := preparer.PrepareFrameInto(bodyScratch[:0], dictID, dict, records[:])
+		if err != nil {
+			return err
+		}
+		if cap(body) > rewriteReadScratchMaxCap {
+			bodyScratch = nil
+		} else {
+			bodyScratch = body[:0]
+		}
+		estimate := estimates[genID]
+		estimate.SamplePages++
+		estimate.SampleCurrentBytes += int64(currentLen)
+		estimate.SampleEstimatedBytesAfter += int64((valuelog.HeaderSize - 4) + len(body))
+		estimates[genID] = estimate
+		quota--
+		quotas[genID] = quota
+		remaining--
+		if remaining <= 0 {
+			return errLeafGenerationPackEnoughTranscodeSamples
+		}
+		return nil
+	}
+	if err := leafrefscan.WalkRoots(ctx, roots, snap.idx.pager.Get, verify, visit); err != nil && !errors.Is(err, errLeafGenerationPackEnoughTranscodeSamples) {
+		return nil, err
+	}
+
+	for genID, estimate := range estimates {
+		gen := candidateByID[genID]
+		if estimate.SampleCurrentBytes <= 0 || gen.BytesLive <= 0 {
+			delete(estimates, genID)
+			continue
+		}
+		estimatedAfter := (gen.BytesLive * estimate.SampleEstimatedBytesAfter) / estimate.SampleCurrentBytes
+		if estimatedAfter < 0 {
+			estimatedAfter = 0
+		}
+		if estimatedAfter > gen.BytesLive {
+			estimatedAfter = gen.BytesLive
+		}
+		estimate.EstimatedBytesAfter = estimatedAfter
+		estimate.ExpectedSavedBytes = gen.BytesLive - estimatedAfter
+		if estimate.ExpectedSavedBytes <= 0 {
+			delete(estimates, genID)
+			continue
+		}
+		estimates[genID] = estimate
+	}
+	return estimates, nil
+}

--- a/docs/benchmarks/LEAF_PACK_OUTER_LEAF_TRANSCODE_20260417.md
+++ b/docs/benchmarks/LEAF_PACK_OUTER_LEAF_TRANSCODE_20260417.md
@@ -1,0 +1,85 @@
+## Leaf-Pack Maintenance: Sealed Outer-Leaf Dict Transcode
+
+This note captures the first maintenance-only attempt to close the gap between:
+
+- post-`run_celestia + 900s dwell` on-disk bytes
+- post-offline-`treemap vlog-rewrite -rw` bytes
+
+The branch keeps the hot first-write path cheap and only allows outer-leaf dict
+compression from sealed leaf-pack maintenance.
+
+### Control Runs
+
+Recent `main` controls from `/tmp/leaf_rewrite_gap_analysis`:
+
+| Profile | Dwell-end `application.db` | Post-rewrite `application.db` | Gap |
+| --- | ---: | ---: | ---: |
+| `fast` | `2,536,171,948` | `2,096,276,342` | `439,895,606` |
+| `wal_on_fast` | `2,585,213,462` | `2,117,928,675` | `467,284,787` |
+
+### Candidate Runs
+
+Candidate branch: maintenance-only sealed outer-leaf transcode.
+
+`wal_on_fast`
+
+- sync: `317s`
+- total: `1217s`
+- max RSS: `12,053,748 kB`
+- dwell-end `application.db`: `2,406,264,420`
+- dwell-end `maindb/index.db`: `66,584,576`
+- dwell-end `maindb/leaf_vlog`: `2,173,456,227`
+- dwell-end `maindb/value_vlog`: `166,024,395`
+- post-rewrite `application.db`: `2,135,297,434`
+- post-rewrite `maindb/index.db`: `38,535,168`
+- post-rewrite `maindb/leaf_vlog`: `2,086,182,002`
+- post-rewrite `maindb/value_vlog`: `10,183,468`
+- rewrite elapsed: `42.40s`
+- rewrite max RSS: `200,332 kB`
+
+`fast`
+
+- sync: `305s`
+- total: `1205s`
+- max RSS: `10,349,620 kB`
+- dwell-end `application.db`: `2,462,549,256`
+- dwell-end `maindb/index.db`: `63,963,136`
+- dwell-end `maindb/leaf_vlog`: `2,229,472,757`
+- dwell-end `maindb/value_vlog`: `168,906,592`
+- post-rewrite `application.db`: `2,155,783,009`
+- post-rewrite `maindb/index.db`: `38,797,312`
+- post-rewrite `maindb/leaf_vlog`: `2,106,225,474`
+- post-rewrite `maindb/value_vlog`: `10,363,427`
+- rewrite elapsed: `43.10s`
+- rewrite max RSS: `202,240 kB`
+
+### Gap Reduction
+
+| Profile | Control Gap | Candidate Gap | Reduction |
+| --- | ---: | ---: | ---: |
+| `fast` | `439,895,606` | `306,766,247` | `133,129,359` |
+| `wal_on_fast` | `467,284,787` | `270,966,986` | `196,317,801` |
+
+### Notes
+
+- `wal_on_fast` is the clearest signal because it finished at the same height as
+  the recent `main` control.
+- The `fast` candidate finished `222` blocks higher than the earlier `main`
+  control, so its absolute end-state comparison is directionally useful but not
+  perfectly apples-to-apples.
+- Late dwell samples show leaf-pack switching into transcode mode:
+  - `wal_on_fast`: `debug_vars_8..12` show `last_selection.mode=transcode`
+  - `fast`: `debug_vars_11..13` show `last_selection.mode=transcode`
+- Final live dict-frame share increased materially during dwell:
+  - `wal_on_fast`: `treedb.cache.vlog_auto.frames_frac.dict=0.419404`
+  - `fast`: `treedb.cache.vlog_auto.frames_frac.dict=0.675012`
+
+### Interpretation
+
+- This branch materially closes the dwell-to-rewrite gap, especially for
+  `wal_on_fast`.
+- The remaining gap is still large, so this is not a full replacement for
+  offline rewrite.
+- `wal_on_fast` is already a strong candidate for merge review.
+- `fast` is also directionally positive, but its absolute comparison should be
+  read with the height mismatch caveat above.


### PR DESCRIPTION
## What changed

This branch keeps the hot first-write path cheap and adds a maintenance-only fallback that can transcode sealed outer-leaf generations with the existing outer-leaf dict pipeline when reclaim-based leaf-pack selection no longer finds good candidates.

The main pieces are:
- add a sealed-generation transcode planner and estimator in `TreeDB/db/leaf_generation_pack_transcode.go`
- let leaf-pack reuse that synthetic plan as a fallback after normal reclaim selection
- surface the selection mode and transcode threshold in TreeDB stats
- keep pack output on the rewrite-time outer-leaf dict path when block compression is enabled
- add targeted tests and a benchmark note with the live `run_celestia` results

## Why

Recent `main` controls showed a large dwell-to-offline-rewrite gap:
- `main fast`: `2,536,171,948 -> 2,096,276,342`, gap `439,895,606`
- `main wal_on_fast`: `2,585,213,462 -> 2,117,928,675`, gap `467,284,787`

Earlier investigation showed that offline rewrite was already getting much better outer-leaf compression shape than live maintenance, but enabling dict compression on the hot first-write path was too expensive. The goal here is to move that work into sealed background maintenance instead.

## Results

### `wal_on_fast` candidate

- sync: `317s`
- total: `1217s`
- max RSS: `12,053,748 kB`
- dwell-end `application.db`: `2,406,264,420`
- post-rewrite `application.db`: `2,135,297,434`
- dwell-to-rewrite gap: `270,966,986`

Compared to recent `main wal_on_fast`:
- dwell-end `application.db`: improved by `178,949,042`
- dwell-to-rewrite gap: reduced by `196,317,801`

Subcomponents:
- dwell-end `maindb/leaf_vlog`: `2,173,456,227`
- post-rewrite `maindb/leaf_vlog`: `2,086,182,002`
- `leaf_vlog` gap: `87,274,225` vs `283,075,238` on `main`

### `fast` candidate

- sync: `305s`
- total: `1205s`
- max RSS: `10,349,620 kB`
- dwell-end `application.db`: `2,462,549,256`
- post-rewrite `application.db`: `2,155,783,009`
- dwell-to-rewrite gap: `306,766,247`

Compared to recent `main fast`:
- dwell-end `application.db`: improved by `73,622,692`
- dwell-to-rewrite gap: reduced by `133,129,359`

Caveat:
- this candidate finished `222` blocks higher than the earlier `main fast` control, so the `fast` comparison is directionally useful but not perfectly apples-to-apples

### Dwell behavior

Late dwell samples show leaf-pack switching into transcode mode:
- `wal_on_fast`: `debug_vars_8..12` show `last_selection.mode=transcode`
- `fast`: `debug_vars_11..13` show `last_selection.mode=transcode`

Final live dict-frame share during dwell:
- `wal_on_fast`: `treedb.cache.vlog_auto.frames_frac.dict=0.419404`
- `fast`: `treedb.cache.vlog_auto.frames_frac.dict=0.675012`

## Validation

Local tests:
- `GOWORK=off go test ./TreeDB/db ./TreeDB/caching -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'Test(LeafGenerationPackRunOnce|LeafGenerationPackFromPlan|SelectLeafGenerationPackCandidates|BuildLeafGenerationPackTranscodePlan)' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestLeafGenerationPackMaintenance_' -count=1`
- `GOWORK=off go test ./TreeDB/cmd/treemap -count=1`
- `GOWORK=off go test ./TreeDB/internal/valuelog -count=1`

Live measurements:
- `run_celestia.sh` with `TREEDB_OPEN_PROFILE=wal_on_fast POST_SYNC_DWELL_SECONDS=900`
- `run_celestia.sh` with `TREEDB_OPEN_PROFILE=fast POST_SYNC_DWELL_SECONDS=900`
- cloned each post-dwell `application.db` and ran `treemap vlog-rewrite -rw` for direct gap comparison

Benchmark note:
- `docs/benchmarks/LEAF_PACK_OUTER_LEAF_TRANSCODE_20260417.md`
