### PR TITLE
[codex] Add frozen leaf logical rebuild harness

### DIFF
--- a/TreeDB/cmd/treemap/leaf_generation_logical_rebuild.go
+++ b/TreeDB/cmd/treemap/leaf_generation_logical_rebuild.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+type leafGenerationLogicalRebuildDiskUsage struct {
+	ApplicationDBBytes int64 `json:"application_db_bytes"`
+	MainDBBytes        int64 `json:"maindb_bytes"`
+	IndexDBBytes       int64 `json:"index_db_bytes"`
+	LeafVLogBytes      int64 `json:"leaf_vlog_bytes"`
+	ValueVLogBytes     int64 `json:"value_vlog_bytes"`
+	DictDBBytes        int64 `json:"dictdb_bytes"`
+}
+
+type leafGenerationLogicalRebuildBenchSummary struct {
+	Dir                 string                                   `json:"dir"`
+	StartedAtUTC        string                                   `json:"started_at_utc"`
+	ElapsedMilliseconds int64                                    `json:"elapsed_ms"`
+	Before              leafGenerationLogicalRebuildDiskUsage    `json:"before"`
+	After               leafGenerationLogicalRebuildDiskUsage    `json:"after"`
+	LeafFloorBytes      int64                                    `json:"leaf_floor_bytes,omitempty"`
+	LeafGapBeforeBytes  int64                                    `json:"leaf_gap_before_bytes,omitempty"`
+	LeafGapAfterBytes   int64                                    `json:"leaf_gap_after_bytes,omitempty"`
+	Stats               treedb.LeafGenerationLogicalRebuildStats `json:"stats"`
+}
+
+func runLeafGenerationLogicalRebuildBench(dir string, args []string) {
+	fs := flag.NewFlagSet("leafgen-logical-rebuild-bench", flag.ExitOnError)
+	rw := fs.Bool("rw", false, "Open read-write (required)")
+	jsonOut := fs.Bool("json", false, "Emit JSON instead of human-readable text")
+	leafFloorBytes := fs.Int64("leaf-floor-bytes", 0, "Optional offline-rewrite leaf_vlog byte floor for leaf-gap reporting")
+	_ = fs.Parse(args)
+
+	if !*rw {
+		fatalf("leafgen-logical-rebuild-bench requires -rw")
+	}
+
+	rootDir := resolveTreeDBRootDir(dir)
+	before, err := leafGenerationLogicalRebuildDiskUsageForRoot(rootDir)
+	if err != nil {
+		fatalf("disk usage before rebuild: %v", err)
+	}
+	started := time.Now()
+	stats, err := treedb.LeafGenerationLogicalRebuildOffline(treedb.Options{Dir: dir})
+	if err != nil {
+		fatalf("LeafGenerationLogicalRebuildOffline error: %v", err)
+	}
+	after, err := leafGenerationLogicalRebuildDiskUsageForRoot(rootDir)
+	if err != nil {
+		fatalf("disk usage after rebuild: %v", err)
+	}
+
+	summary := leafGenerationLogicalRebuildBenchSummary{
+		Dir:                 rootDir,
+		StartedAtUTC:        started.UTC().Format(time.RFC3339),
+		ElapsedMilliseconds: time.Since(started).Milliseconds(),
+		Before:              before,
+		After:               after,
+		LeafFloorBytes:      *leafFloorBytes,
+		Stats:               stats,
+	}
+	if *leafFloorBytes > 0 {
+		summary.LeafGapBeforeBytes = before.LeafVLogBytes - *leafFloorBytes
+		summary.LeafGapAfterBytes = after.LeafVLogBytes - *leafFloorBytes
+	}
+
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(summary); err != nil {
+			fatalf("encode logical rebuild json: %v", err)
+		}
+		return
+	}
+
+	fmt.Printf(
+		"leafgen-logical-rebuild-bench: app_before=%d app_after=%d leaf_before=%d leaf_after=%d index_before=%d index_after=%d elapsed_ms=%d dict_id=%d raw_pages=%t created_leaf_files=%v\n",
+		summary.Before.ApplicationDBBytes,
+		summary.After.ApplicationDBBytes,
+		summary.Before.LeafVLogBytes,
+		summary.After.LeafVLogBytes,
+		summary.Before.IndexDBBytes,
+		summary.After.IndexDBBytes,
+		summary.ElapsedMilliseconds,
+		stats.LeafDictID,
+		stats.LeafDictUseRawPages,
+		stats.CreatedLeafFileIDs,
+	)
+	if *leafFloorBytes > 0 {
+		fmt.Printf(
+			"leafgen-logical-rebuild-gap: floor=%d gap_before=%d gap_after=%d gap_closed=%d\n",
+			*leafFloorBytes,
+			summary.LeafGapBeforeBytes,
+			summary.LeafGapAfterBytes,
+			summary.LeafGapBeforeBytes-summary.LeafGapAfterBytes,
+		)
+	}
+}
+
+func leafGenerationLogicalRebuildDiskUsageForRoot(rootDir string) (leafGenerationLogicalRebuildDiskUsage, error) {
+	rootDir = resolveTreeDBRootDir(rootDir)
+	paths := map[string]string{
+		"application": rootDir,
+		"maindb":      filepath.Join(rootDir, "maindb"),
+		"index":       filepath.Join(rootDir, "maindb", "index.db"),
+		"leaf":        filepath.Join(rootDir, "maindb", "leaf_vlog"),
+		"value":       filepath.Join(rootDir, "maindb", "value_vlog"),
+		"dict":        filepath.Join(rootDir, "dictdb"),
+	}
+	sizes := make(map[string]int64, len(paths))
+	for key, path := range paths {
+		n, err := logicalRebuildRecursivePathSize(path)
+		if err != nil {
+			return leafGenerationLogicalRebuildDiskUsage{}, err
+		}
+		sizes[key] = n
+	}
+	return leafGenerationLogicalRebuildDiskUsage{
+		ApplicationDBBytes: sizes["application"],
+		MainDBBytes:        sizes["maindb"],
+		IndexDBBytes:       sizes["index"],
+		LeafVLogBytes:      sizes["leaf"],
+		ValueVLogBytes:     sizes["value"],
+		DictDBBytes:        sizes["dict"],
+	}, nil
+}
+
+func logicalRebuildRecursivePathSize(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if !info.IsDir() {
+		return info.Size(), nil
+	}
+	var total int64
+	err = filepath.WalkDir(path, func(_ string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return total, nil
+}

--- a/TreeDB/cmd/treemap/leaf_generation_test.go
+++ b/TreeDB/cmd/treemap/leaf_generation_test.go
@@ -35,3 +35,9 @@ func TestUsageTextMentionsLeafGenerationGC(t *testing.T) {
 		t.Fatalf("usageText missing leafgen-gc command: %q", got)
 	}
 }
+
+func TestUsageTextMentionsLeafGenerationLogicalRebuildBench(t *testing.T) {
+	if got := usageText; !strings.Contains(got, "leafgen-logical-rebuild-bench") {
+		t.Fatalf("usageText missing leafgen-logical-rebuild-bench command: %q", got)
+	}
+}

--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -46,6 +46,8 @@ Commands:
   leafgen-plan    Print explicit leaf-generation pack plan
   leafgen-pack    Pack sealed leaf generations by id (requires -rw)
   leafgen-gc      Delete fully unreachable sealed leaf generations (requires -rw)
+  leafgen-logical-rebuild-bench
+                  Rebuild outer-leaf pages logically on a frozen DB copy (requires -rw)
   get             Get a single key
   keys            List keys in a range/prefix
   scan            Scan keys and values in a range/prefix (requires -allow-values)
@@ -110,6 +112,8 @@ func main() {
 		runLeafGenerationPack(dir, args)
 	case "leafgen-gc":
 		runLeafGenerationGC(dir, args)
+	case "leafgen-logical-rebuild-bench":
+		runLeafGenerationLogicalRebuildBench(dir, args)
 	case "get":
 		runGet(dir, args)
 	case "keys":

--- a/TreeDB/db/leaf_generation_logical_rebuild.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild.go
@@ -1,0 +1,419 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/snissn/gomap/TreeDB/internal/bulk"
+	"github.com/snissn/gomap/TreeDB/internal/lockfile"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
+	"github.com/snissn/gomap/TreeDB/tree"
+)
+
+// LeafGenerationLogicalRebuildStats summarizes a frozen leaf-only logical
+// rebuild. The rebuild rewrites outer-leaf pages and index.db, but preserves
+// existing value-log pointers.
+type LeafGenerationLogicalRebuildStats struct {
+	CommitSeqBefore uint64
+	CommitSeqAfter  uint64
+
+	LeafFilesBefore int
+	LeafFilesAfter  int
+	LeafBytesBefore int64
+	LeafBytesAfter  int64
+
+	IndexBytesBefore int64
+	IndexBytesAfter  int64
+
+	RecordsCopied int
+
+	LeafDictID          uint64
+	LeafDictUseRawPages bool
+	CreatedLeafFileIDs  []uint32
+}
+
+// LeafGenerationLogicalRebuildOffline rebuilds the user+system trees from a
+// pointer-projection iterator into a fresh index and fresh outer-leaf value-log
+// directory, then swaps them in under the offline lock. It intentionally leaves
+// value_vlog untouched.
+func LeafGenerationLogicalRebuildOffline(opts Options) (LeafGenerationLogicalRebuildStats, error) {
+	var stats LeafGenerationLogicalRebuildStats
+	if opts.Dir == "" {
+		return stats, errors.New("db dir required")
+	}
+	if err := applyFormatConfigForMaintenance(&opts); err != nil {
+		return stats, err
+	}
+	if !opts.IndexOuterLeavesInValueLog {
+		return stats, fmt.Errorf("leaf logical rebuild requires index_outer_leaves_in_vlog")
+	}
+	if opts.ChunkSize == 0 {
+		opts.ChunkSize = defaultChunkSize
+	}
+	opts.DisableBackgroundPrune = true
+	opts.ReadOnly = true
+
+	lock, err := lockfile.Acquire(filepath.Join(opts.Dir, "LOCK"))
+	if err != nil {
+		return stats, err
+	}
+	defer func() { _ = lock.Close() }()
+
+	if err := recoverIndexSwap(opts.Dir); err != nil {
+		return stats, err
+	}
+
+	walSegments, err := listWALSegments(opts.Dir)
+	if err != nil {
+		return stats, err
+	}
+	for _, seg := range walSegments {
+		if seg.valueLog {
+			continue
+		}
+		return stats, fmt.Errorf("leaf logical rebuild requires a clean commitlog; found %s", filepath.Base(seg.path))
+	}
+
+	segments, err := listValueLogSegments(opts.Dir)
+	if err != nil {
+		return stats, err
+	}
+
+	layout := resolveStorageLayout(opts.Dir)
+	indexPath := filepath.Join(opts.Dir, indexFileName)
+	newIndexPath := filepath.Join(opts.Dir, indexNewFileName)
+	bakIndexPath := filepath.Join(opts.Dir, indexBakFileName)
+	readyPath := filepath.Join(opts.Dir, indexReadyFileName)
+	leafDir := layout.leafVLogDir
+	newLeafDir := leafDir + ".new"
+	bakLeafDir := leafDir + ".bak"
+
+	stats.LeafFilesBefore, stats.LeafBytesBefore, err = leafGenerationLogicalRebuildLeafDirStats(leafDir)
+	if err != nil {
+		return stats, err
+	}
+	stats.IndexBytesBefore, err = leafGenerationLogicalRebuildPathSize(indexPath)
+	if err != nil {
+		return stats, err
+	}
+
+	_ = os.Remove(newIndexPath)
+	_ = os.Remove(readyPath)
+	_ = os.RemoveAll(newLeafDir)
+	_ = os.RemoveAll(bakLeafDir)
+	if err := os.MkdirAll(newLeafDir, 0o700); err != nil {
+		return stats, err
+	}
+
+	d, err := openReadOnlyNoLock(opts)
+	if err != nil {
+		_ = os.RemoveAll(newLeafDir)
+		return stats, err
+	}
+	closeDB := true
+	defer func() {
+		if closeDB {
+			_ = d.Close()
+		}
+	}()
+
+	state := d.State()
+	if state == nil {
+		return stats, fmt.Errorf("leaf logical rebuild: missing db state")
+	}
+	stats.CommitSeqBefore = state.CommitSeq
+	if state.ValueLogSet != nil {
+		d.valueLogManager.Acquire(state.ValueLogSet)
+		defer d.valueLogManager.Release(state.ValueLogSet)
+	}
+
+	leafStartSeq := maxRewriteLaneSeq(segments, rewriteLeafLogLaneID)
+	lane, startSeq := chooseRewriteLane(segments, rewriteLeafLogLaneID)
+	nextRID, err := rewriteRIDStartScanner(segments)
+	if err != nil {
+		return stats, err
+	}
+	maxBytes := opts.WALMaxSegmentBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultValueLogRewriteSegmentBytes
+	}
+	if opts.IndexPackedValuePtr || opts.IndexOuterLeavesInValueLog {
+		const packedMax = int64(^uint32(0)) - 4
+		if maxBytes > packedMax {
+			maxBytes = packedMax
+		}
+	}
+
+	writer := newRewriteWriter(layout.valueVLogDir, lane, startSeq, maxBytes)
+	writerOpen := true
+	defer func() {
+		if writerOpen {
+			_ = writer.Close()
+		}
+	}()
+	writer.ConfigureLeafLog(newLeafDir, rewriteLeafLogLaneID, leafStartSeq)
+	writer.nextRID = nextRID
+	writer.SetKeepPolicy(0, 0, 0)
+	writer.SetTemplateCompression(opts.ValueLog.TemplateMode, opts.ValueLog.TemplateConfig, opts.ValueLog.TemplateStore)
+	compressionMode := opts.ValueLog.Compression
+	if compressionMode == 0 {
+		compressionMode = ValueLogCompressionAuto
+	}
+	writer.blockCompression = compressionMode != ValueLogCompressionOff
+	writer.blockCodec = valuelogBlockCodecFromDB(opts.ValueLog.BlockCodec)
+	writer.leafBlockCodec = leafPageBlockCodecFromOptions(compressionMode, opts.ValueLog.AutoPolicy, opts.ValueLog.BlockCodec, opts.IndexOuterLeavesInValueLog)
+	if writer.blockCompression {
+		leafDictID, leafDictBytes, leafDictUseRawPages, err := prepareRewriteLeafDict(d, state, opts.ValueLog.DictCurrentForClass, opts.ValueLog.DictLeafPayloadMode, opts.ValueLog.DictLookup, opts.ValueLog.DictPut, opts.ValueLog.DictSetCurrentForClass, opts.ValueLog.DictSetLeafPayloadMode, opts.ValueLog.DictTrain)
+		if err != nil {
+			return stats, err
+		}
+		if leafDictID != 0 && len(leafDictBytes) > 0 {
+			writer.SetLeafDictMode(leafDictID, leafDictBytes, leafDictUseRawPages)
+			stats.LeafDictID = leafDictID
+			stats.LeafDictUseRawPages = leafDictUseRawPages
+		}
+	}
+
+	newPager, err := pager.Open(newIndexPath, opts.ChunkSize)
+	if err != nil {
+		return stats, err
+	}
+	pagerOpen := true
+	defer func() {
+		if pagerOpen {
+			_ = newPager.Close()
+		}
+	}()
+	if _, err := newPager.Alloc(2); err != nil {
+		return stats, err
+	}
+	alloc := &pagerAllocator{p: newPager}
+
+	buildTree := func(root uint64) (uint64, error) {
+		iter := tree.New(d.Pager(), newValueReader(state.ValueLogSet), root).
+			IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+		buildOpts := bulk.BuildOptions{
+			LeafPrefixCompression: opts.LeafPrefixCompression,
+			LeafColumnar:          opts.IndexColumnarLeaves,
+			PackedValuePtr:        opts.IndexPackedValuePtr,
+			InternalBaseDelta:     opts.IndexInternalBaseDelta,
+			LeafPageLog:           writer,
+		}
+		newRoot, err := bulk.BuildWithOptions(iter, alloc, newPager, buildOpts)
+		_ = iter.Close()
+		if err != nil {
+			return 0, err
+		}
+		if err := writer.flushPendingDictBatch(); err != nil {
+			return 0, err
+		}
+		stats.RecordsCopied = writer.records
+		return newRoot, nil
+	}
+
+	sysRoot, err := buildTree(state.SystemRootPageID)
+	if err != nil {
+		return stats, err
+	}
+	userRoot, err := buildTree(state.RootPageID)
+	if err != nil {
+		return stats, err
+	}
+
+	meta := d.meta
+	meta.CommitSeq++
+	meta.UserRootPageID = userRoot
+	meta.SystemRootPageID = sysRoot
+	meta.FreelistHeadID = 0
+	meta.TotalPages = newPager.PageCount()
+	stats.CommitSeqAfter = meta.CommitSeq
+
+	if err := writeMetaToPager(newPager, MetaPage0ID, meta); err != nil {
+		return stats, err
+	}
+	if err := writeMetaToPager(newPager, MetaPage1ID, meta); err != nil {
+		return stats, err
+	}
+	if err := newPager.Sync(); err != nil {
+		return stats, err
+	}
+	if err := writer.Sync(); err != nil {
+		return stats, err
+	}
+
+	manifest, err := bootstrapLeafGenerationManifestFromDir(newLeafDir, meta.CommitSeq)
+	if err != nil {
+		return stats, err
+	}
+	if err := saveLeafGenerationManifest(newLeafDir, manifest); err != nil {
+		return stats, err
+	}
+	if err := saveLeafGenerationLogicalRebuildRecordLengthIndexes(newLeafDir, manifest); err != nil {
+		return stats, err
+	}
+
+	if err := os.WriteFile(readyPath, []byte("ready\n"), 0o644); err != nil {
+		return stats, err
+	}
+	if runtime.GOOS != "windows" {
+		if dir, err := os.Open(opts.Dir); err == nil {
+			_ = dir.Sync()
+			_ = dir.Close()
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return stats, err
+	}
+	writerOpen = false
+	if err := newPager.Close(); err != nil {
+		return stats, err
+	}
+	pagerOpen = false
+	if err := d.Close(); err != nil {
+		return stats, err
+	}
+	closeDB = false
+
+	if err := swapLeafGenerationLogicalRebuildArtifacts(indexPath, newIndexPath, bakIndexPath, leafDir, newLeafDir, bakLeafDir); err != nil {
+		return stats, err
+	}
+	_ = os.Remove(readyPath)
+	if runtime.GOOS != "windows" {
+		if dir, err := os.Open(opts.Dir); err == nil {
+			_ = dir.Sync()
+			_ = dir.Close()
+		}
+	}
+
+	stats.CreatedLeafFileIDs = leafGenerationLogicalRebuildCreatedFileIDs(manifest)
+	stats.LeafFilesAfter, stats.LeafBytesAfter, err = leafGenerationLogicalRebuildLeafDirStats(leafDir)
+	if err != nil {
+		return stats, err
+	}
+	stats.IndexBytesAfter, err = leafGenerationLogicalRebuildPathSize(indexPath)
+	if err != nil {
+		return stats, err
+	}
+	return stats, nil
+}
+
+func swapLeafGenerationLogicalRebuildArtifacts(indexPath, newIndexPath, bakIndexPath, leafDir, newLeafDir, bakLeafDir string) error {
+	_ = os.Remove(bakIndexPath)
+	_ = os.RemoveAll(bakLeafDir)
+
+	if err := os.Rename(indexPath, bakIndexPath); err != nil {
+		return err
+	}
+	indexRenamed := true
+	if err := os.Rename(leafDir, bakLeafDir); err != nil {
+		_ = os.Rename(bakIndexPath, indexPath)
+		return err
+	}
+	leafRenamed := true
+
+	if err := os.Rename(newIndexPath, indexPath); err != nil {
+		if leafRenamed {
+			_ = os.Rename(bakLeafDir, leafDir)
+		}
+		if indexRenamed {
+			_ = os.Rename(bakIndexPath, indexPath)
+		}
+		return err
+	}
+	if err := os.Rename(newLeafDir, leafDir); err != nil {
+		_ = os.Remove(indexPath)
+		if indexRenamed {
+			_ = os.Rename(bakIndexPath, indexPath)
+		}
+		if leafRenamed {
+			_ = os.Rename(bakLeafDir, leafDir)
+		}
+		return err
+	}
+
+	_ = os.Remove(bakIndexPath)
+	_ = os.RemoveAll(bakLeafDir)
+	return nil
+}
+
+func leafGenerationLogicalRebuildCreatedFileIDs(manifest *leafGenerationManifest) []uint32 {
+	if manifest == nil {
+		return nil
+	}
+	var ids []uint32
+	for _, gen := range manifest.Generations {
+		ids = append(ids, gen.FileIDs...)
+	}
+	ids = dedupeLeafGenerationRawFileIDs(ids)
+	return ids
+}
+
+func leafGenerationLogicalRebuildLeafDirStats(leafDir string) (int, int64, error) {
+	files, err := listLeafGenerationBootstrapFiles(leafDir)
+	if err != nil {
+		return 0, 0, err
+	}
+	size, err := leafGenerationLogicalRebuildPathSize(leafDir)
+	if err != nil {
+		return 0, 0, err
+	}
+	return len(files), size, nil
+}
+
+func leafGenerationLogicalRebuildPathSize(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if !info.IsDir() {
+		return info.Size(), nil
+	}
+	var total int64
+	err = filepath.WalkDir(path, func(_ string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+func saveLeafGenerationLogicalRebuildRecordLengthIndexes(leafDir string, manifest *leafGenerationManifest) error {
+	if manifest == nil {
+		return nil
+	}
+	rawFileIDs := leafGenerationLogicalRebuildCreatedFileIDs(manifest)
+	for _, rawFileID := range rawFileIDs {
+		lane, seq := valuelog.DecodeFileID(page.ValueLogFileID(rawFileID))
+		path := filepath.Join(leafDir, fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+		idx, err := scanLeafGenerationRecordLengthIndexPath(path, page.ValueLogFileID(rawFileID))
+		if err != nil {
+			return err
+		}
+		if err := saveLeafGenerationRecordLengthIndexFile(path+leafGenerationRecordLengthIndexSuffix, rawFileID, idx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/TreeDB/db/leaf_generation_logical_rebuild_test.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_test.go
@@ -1,0 +1,99 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/compress/zstd"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+)
+
+func TestLeafGenerationLogicalRebuildOffline_UsesCurrentOuterLeafDictForSplitLeafLog(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{
+		Dir:                        dir,
+		Durability:                 DurabilityWALOffRelaxed,
+		IndexOuterLeavesInValueLog: true,
+		ValueLog: ValueLogOptions{
+			Compression:      ValueLogCompressionBlock,
+			BlockCodec:       ValueLogBlockLZ4,
+			PointerThreshold: 4096,
+		},
+	}
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	leafLog := &rewriteTestLeafPageLog{db: db, dir: dir}
+	db.SetLeafPageLog(leafLog)
+	for i := 0; i < 256; i++ {
+		key := []byte(fmt.Sprintf("leaf-logical-dict-%04d", i))
+		val := bytes.Repeat([]byte(fmt.Sprintf("leaf-logical-%02d|", i%32)), 2)
+		if err := db.Set(key, val); err != nil {
+			_ = leafLog.Close()
+			_ = db.Close()
+			t.Fatalf("set %q: %v", key, err)
+		}
+	}
+	if err := leafLog.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("close leaf log: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	leafA, _, err := valuelog.MaybeCompactLeafLogPayload(buildRewriteLeafPageFixture(t, "logical-a"))
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload(a): %v", err)
+	}
+	leafB, _, err := valuelog.MaybeCompactLeafLogPayload(buildRewriteLeafPageFixture(t, "logical-b"))
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload(b): %v", err)
+	}
+	leafC, _, err := valuelog.MaybeCompactLeafLogPayload(buildRewriteLeafPageFixture(t, "logical-c"))
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload(c): %v", err)
+	}
+	dictID := uint64(902311)
+	dict, err := zstd.BuildDict(zstd.BuildDictOptions{
+		ID:       uint32(dictID),
+		Contents: [][]byte{leafA, leafB, leafC},
+		History:  append([]byte(nil), leafA...),
+		Offsets:  [3]int{1, 4, 8},
+		Level:    zstd.SpeedFastest,
+	})
+	if err != nil {
+		t.Fatalf("BuildDict: %v", err)
+	}
+
+	rebuildOpts := opts
+	rebuildOpts.ValueLog.DictLookup = func(id uint64) ([]byte, error) {
+		if id != dictID {
+			return nil, valuelog.ErrMissingDict
+		}
+		return dict, nil
+	}
+	rebuildOpts.ValueLog.DictCurrentForClass = func(_ context.Context, class string) (uint64, error) {
+		if class == "outer_leaf" {
+			return dictID, nil
+		}
+		return 0, nil
+	}
+	stats, err := LeafGenerationLogicalRebuildOffline(rebuildOpts)
+	if err != nil {
+		t.Fatalf("LeafGenerationLogicalRebuildOffline: %v", err)
+	}
+	if stats.LeafDictID != dictID {
+		t.Fatalf("logical rebuild leaf dict id=%d want=%d", stats.LeafDictID, dictID)
+	}
+
+	leafDir := filepath.Join(dir, "leaf_vlog")
+	frameHeader := readFirstRewriteFrameHeaderForLane(t, leafDir, rewriteLeafLogLaneID)
+	if frameHeader.DictID != dictID {
+		t.Fatalf("logical rebuild leaf dict id=%d want=%d", frameHeader.DictID, dictID)
+	}
+}

--- a/TreeDB/leaf_generation_logical_rebuild.go
+++ b/TreeDB/leaf_generation_logical_rebuild.go
@@ -1,0 +1,39 @@
+package treedb
+
+import treedbdb "github.com/snissn/gomap/TreeDB/db"
+
+// LeafGenerationLogicalRebuildStats summarizes a frozen leaf-only logical
+// rebuild that rewrites outer-leaf pages and swaps a fresh index.
+type LeafGenerationLogicalRebuildStats = treedbdb.LeafGenerationLogicalRebuildStats
+
+// LeafGenerationLogicalRebuildOffline rebuilds outer-leaf pages logically into
+// a fresh leaf_vlog directory and swaps it with a fresh index.db under the
+// offline DB lock. Value-log pointers remain unchanged.
+func LeafGenerationLogicalRebuildOffline(opts Options) (LeafGenerationLogicalRebuildStats, error) {
+	layout, err := resolveOpenDirLayout(opts.Dir, opts.DisableSideStores)
+	if err != nil {
+		return LeafGenerationLogicalRebuildStats{}, err
+	}
+	opts.Dir = layout.mainDir
+	opts.DisableSideStores = layout.disableSideStores
+
+	if !opts.IgnoreFormatConfig {
+		if cfg, ok, err := treedbdb.LoadFormatConfig(layout.mainDir); err != nil {
+			return LeafGenerationLogicalRebuildStats{}, err
+		} else if ok {
+			cfg.ApplyToOptions(&opts)
+		}
+	}
+
+	sideCleanup, err := wireSideStoreLookups(layout.rootDir, &opts)
+	if err != nil {
+		return LeafGenerationLogicalRebuildStats{}, err
+	}
+	defer func() { _ = sideCleanup() }()
+
+	stats, err := treedbdb.LeafGenerationLogicalRebuildOffline(opts)
+	if err != nil {
+		return LeafGenerationLogicalRebuildStats{}, err
+	}
+	return LeafGenerationLogicalRebuildStats(stats), nil
+}

--- a/TreeDB/maintenance_leaf_vlog_test.go
+++ b/TreeDB/maintenance_leaf_vlog_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"testing"
 	"time"
 
@@ -427,6 +428,80 @@ func TestValueLogRewriteOffline_LeafPagesInValueLog_PreservesLeafRefRoot_WhenVal
 	}
 }
 
+func TestLeafGenerationLogicalRebuildOffline_ReopenParityPreservesValueLogSegments(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.Options{
+		Dir:                        dir,
+		Durability:                 treedb.DurabilityWALOffRelaxed,
+		IndexOuterLeavesInValueLog: true,
+		ValueLog: treedb.ValueLogOptions{
+			PointerThreshold: 1,
+		},
+	}
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	for i := 0; i < 256; i++ {
+		key := []byte(fmt.Sprintf("leaf-logical-%04d", i))
+		val := bytes.Repeat([]byte{byte(i % 251)}, 2*1024)
+		if err := db.Set(key, val); err != nil {
+			_ = db.Close()
+			t.Fatalf("set %q: %v", string(key), err)
+		}
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("checkpoint before close: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	mainDir := filepath.Dir(mainIndexPath(dir))
+	leafBefore := mustGlobBaseNames(t, filepath.Join(mainDir, "leaf_vlog", "value-l*.log"))
+	valueBefore := mustGlobBaseNames(t, filepath.Join(mainDir, "value_vlog", "value-l*.log"))
+	if len(leafBefore) == 0 {
+		t.Fatalf("expected leaf_vlog files before logical rebuild")
+	}
+
+	stats, err := treedb.LeafGenerationLogicalRebuildOffline(treedb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("LeafGenerationLogicalRebuildOffline: %v", err)
+	}
+	if stats.RecordsCopied == 0 {
+		t.Fatalf("expected logical rebuild to copy records, stats=%+v", stats)
+	}
+
+	leafAfter := mustGlobBaseNames(t, filepath.Join(mainDir, "leaf_vlog", "value-l*.log"))
+	valueAfter := mustGlobBaseNames(t, filepath.Join(mainDir, "value_vlog", "value-l*.log"))
+	if len(leafAfter) == 0 {
+		t.Fatalf("expected leaf_vlog files after logical rebuild")
+	}
+	if sameStringSlices(leafBefore, leafAfter) {
+		t.Fatalf("expected rebuilt leaf_vlog files to differ; before=%v after=%v", leafBefore, leafAfter)
+	}
+	if !sameStringSlices(valueBefore, valueAfter) {
+		t.Fatalf("expected value_vlog files to remain unchanged; before=%v after=%v", valueBefore, valueAfter)
+	}
+
+	reopen, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopen.Close()
+
+	got, err := reopen.Get([]byte("leaf-logical-0010"))
+	if err != nil {
+		t.Fatalf("get after reopen: %v", err)
+	}
+	want := bytes.Repeat([]byte{10}, 2*1024)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("value mismatch after reopen: got=%dB want=%dB", len(got), len(want))
+	}
+}
+
 func TestLeafGenerationGC_BackendOpenWithoutFlag_PreservesLeafRefs(t *testing.T) {
 	dir := t.TempDir()
 	const (
@@ -508,4 +583,30 @@ func TestLeafGenerationGC_BackendOpenWithoutFlag_PreservesLeafRefs(t *testing.T)
 	if len(got) != valSize {
 		t.Fatalf("expected %dB value after gc, got %dB", valSize, len(got))
 	}
+}
+
+func mustGlobBaseNames(t *testing.T, pattern string) []string {
+	t.Helper()
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %q: %v", pattern, err)
+	}
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		out = append(out, filepath.Base(path))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sameStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/docs/benchmarks/FROZEN_LEAF_LOGICAL_REBUILD_20260417.md
+++ b/docs/benchmarks/FROZEN_LEAF_LOGICAL_REBUILD_20260417.md
@@ -1,0 +1,94 @@
+# Frozen Leaf Logical Rebuild Harness
+
+This note measures a frozen, leaf-only logical rebuild against the same
+Celestia-shaped post-dwell source that the earlier transcode harness used.
+
+## Source
+
+- Source DB: `/home/mikers/.celestia-app-mainnet-treedb-20260417111043/data/application.db`
+- Source copy strategy: hardlinked clone on the same filesystem
+
+## Commands
+
+Build branch binary:
+
+```bash
+GOWORK=off go build -o /tmp/gomap_leaf_logical_rebuild_bin/treemap ./TreeDB/cmd/treemap
+```
+
+Leaf-only logical rebuild on a frozen clone:
+
+```bash
+/tmp/gomap_leaf_logical_rebuild_bin/treemap \
+  leafgen-logical-rebuild-bench /tmp/leaf_logical_rebuild_hardlink/application.db \
+  -rw -json -leaf-floor-bytes 2139653385
+```
+
+Full offline rewrite floor on a separate frozen clone:
+
+```bash
+/tmp/gomap_leaf_logical_rebuild_bin/treemap \
+  vlog-rewrite /tmp/leaf_logical_rewrite_floor/application.db -rw
+```
+
+## Results
+
+Source before logical rebuild:
+
+- `application.db`: `2,576,582,655`
+- `index.db`: `61,341,696`
+- `leaf_vlog`: `2,345,168,025`
+- `value_vlog`: `169,695,667`
+
+Frozen logical rebuild:
+
+- elapsed: `44.48s`
+- `application.db`: `2,332,080,023`
+- `index.db`: `39,321,600`
+- `leaf_vlog`: `2,122,685,489`
+- `value_vlog`: `169,695,667`
+- `CommitSeq`: `3118 -> 3119`
+- `LeafFiles`: `71 -> 16`
+- `RecordsCopied`: `978,406`
+- `LeafDictID`: `15208934947383264178`
+- `LeafDictUseRawPages`: `false`
+
+Exact full offline rewrite floor on the same source:
+
+- `application.db`: `2,190,316,098`
+- `index.db`: `39,321,600`
+- `leaf_vlog`: `2,139,653,385`
+- `value_vlog`: `10,948,411`
+- `vlog-rewrite`: `segments_before=83 segments_after=17 bytes_before=2490028712 bytes_after=2125746336 records=1000483`
+
+## Gap Closure
+
+Leaf-only gap against the exact full-rewrite floor:
+
+- leaf gap before: `2,345,168,025 - 2,139,653,385 = 205,514,640`
+- leaf gap after: `2,122,685,489 - 2,139,653,385 = -16,967,896`
+- leaf gap closed: `222,482,536`
+
+Interpretation:
+
+- The logical rebuild closes the leaf-side gap completely on this frozen source.
+- It lands about `17.0 MB` smaller than the matching full offline rewrite
+  `leaf_vlog`.
+- The remaining overall `application.db` gap is outside the leaf subsystem:
+  primarily `value_vlog` and a small `dictdb` delta.
+
+## Comparison To Page-Copy Transcode
+
+Earlier frozen transcode best result on the same source left:
+
+- `leaf_vlog`: `2,225,095,409`
+- remaining leaf gap: `85,641,440`
+
+Logical rebuild improves from that to:
+
+- `leaf_vlog`: `2,122,685,489`
+- remaining leaf gap: `-16,967,896`
+
+So the logical rebuild recovers about `102.4 MB` beyond the best page-copy
+transcode path, which matches the earlier hypothesis that the remaining gap was
+mostly page-layout / repacking, not dict selection.


### PR DESCRIPTION
## What changed

This adds a frozen `leaf_vlog` logical rebuild path and a focused `treemap` harness for it.

- adds `LeafGenerationLogicalRebuildOffline`, an offline leaf-only rebuild that:
  - rebuilds user + system trees from pointer projection
  - writes fresh outer-leaf pages through the existing rewrite leaf writer + dict path
  - preserves existing `value_vlog` pointers
  - swaps a fresh `index.db` and fresh `leaf_vlog` directory under the offline lock
- adds `treemap leafgen-logical-rebuild-bench`
- adds reopen-parity and dict-path coverage
- records the measured result in `docs/benchmarks/FROZEN_LEAF_LOGICAL_REBUILD_20260417.md`

## Why it changed

The earlier frozen transcode harness proved that page-copy transcode could only close part of the `leaf_vlog` gap. The remaining gap was structural: offline rewrite rebuilds leaf pages logically, while online/frozen transcode only republishes existing page boundaries.

This PR builds the harness that reproduces the leaf-side behavior of offline rewrite without touching `value_vlog`.

## Impact

On the frozen Celestia-shaped source `/home/mikers/.celestia-app-mainnet-treedb-20260417111043/data/application.db`:

- source `leaf_vlog`: `2,345,168,025`
- logical rebuild `leaf_vlog`: `2,122,685,489`
- exact full offline rewrite floor `leaf_vlog`: `2,139,653,385`

So the logical rebuild:
- closes the leaf gap completely
- lands about `16.97 MB` smaller than the matching full offline rewrite `leaf_vlog`
- improves by about `102.4 MB` beyond the best page-copy transcode result on the same source

The remaining overall `application.db` gap after the logical rebuild is outside the leaf subsystem and is mainly `value_vlog`.

## Root cause

The missing win was not dict selection. It was page layout. Offline rewrite rebuilds fresh outer-leaf pages from logical entries; the existing online/frozen maintenance paths only recompressed existing leaf pages.

## Validation

- `GOWORK=off go build -o /tmp/gomap_leaf_logical_rebuild_bin/treemap ./TreeDB/cmd/treemap`
- `GOWORK=off go test ./TreeDB/db ./TreeDB ./TreeDB/cmd/treemap -run 'Test(LeafGenerationLogicalRebuildOffline|UsageTextMentionsLeafGenerationLogicalRebuildBench)' -count=1`
- `treemap leafgen-logical-rebuild-bench /tmp/leaf_logical_rebuild_hardlink/application.db -rw -json -leaf-floor-bytes 2139653385`
- `treemap vlog-rewrite /tmp/leaf_logical_rewrite_floor/application.db -rw`
