### PR TITLE
[codex] Add online leaf logical rebuild run

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1905,6 +1905,13 @@ const (
 	envLeafGenerationPackMaintenanceWriteBurstGraceMillis      = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_WRITE_BURST_GRACE_MS"
 	envLeafGenerationPackMaintenanceMaxForegroundQueue         = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_FOREGROUND_QUEUE"
 	envLeafGenerationPackMaintenanceMinReclaimPerByteCopiedPPM = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_RECLAIM_PER_BYTE_COPIED_PPM"
+	// Experimental online logical outer-leaf rebuild hook. Disabled by default
+	// until live dwell behavior is validated.
+	envEnableLeafGenerationLogicalRebuildMaintenance           = "TREEDB_ENABLE_LEAF_GENERATION_LOGICAL_REBUILD_MAINTENANCE"
+	envLeafGenerationLogicalRebuildMaintenanceClusterFilesMax  = "TREEDB_LEAF_GENERATION_LOGICAL_REBUILD_MAINTENANCE_CLUSTER_FILES_MAX"
+	envLeafGenerationLogicalRebuildMaintenanceCandidateTryMax  = "TREEDB_LEAF_GENERATION_LOGICAL_REBUILD_MAINTENANCE_CANDIDATE_TRY_MAX"
+	envLeafGenerationLogicalRebuildMaintenancePilotSamplePages = "TREEDB_LEAF_GENERATION_LOGICAL_REBUILD_MAINTENANCE_PILOT_SAMPLE_PAGES"
+	envLeafGenerationLogicalRebuildMaintenanceTimeoutSeconds   = "TREEDB_LEAF_GENERATION_LOGICAL_REBUILD_MAINTENANCE_TIMEOUT_SECONDS"
 	// Optional rewrite debt-drain caps for controlled online experiments.
 	envVlogGenerationRewriteResumeMaxSegments         = "TREEDB_VLOG_GENERATION_REWRITE_RESUME_MAX_SEGMENTS"
 	envVlogGenerationRewriteDebtDrainMaxSegments      = "TREEDB_VLOG_GENERATION_REWRITE_DEBT_DRAIN_MAX_SEGMENTS"
@@ -1935,6 +1942,10 @@ const (
 	leafGenerationPackMaintenanceDefaultWriteBurstGrace            = 250 * time.Millisecond
 	leafGenerationPackMaintenanceDefaultMaxForegroundQueue         = 2
 	leafGenerationPackMaintenanceDefaultMinReclaimPerByteCopiedPPM = 250000
+	leafGenerationLogicalRebuildMaintenanceDefaultClusterFilesMax  = 8
+	leafGenerationLogicalRebuildMaintenanceDefaultCandidateTryMax  = 4
+	leafGenerationLogicalRebuildMaintenanceDefaultPilotSamplePages = 192
+	leafGenerationLogicalRebuildMaintenanceDefaultTimeout          = 45 * time.Second
 	maxMemtablePrealloc                                            = 256 << 20
 	appendOnlyEntryHintMinEntries                                  = 128
 	appendOnlyEntryHintMaxEntries                                  = 1 << 20
@@ -5799,6 +5810,10 @@ type backendLeafGenerationPackRunner interface {
 	LeafGenerationPackRunOnce(ctx context.Context, opts backenddb.LeafGenerationPackFromPlanOptions) (backenddb.LeafGenerationPackRunOnceStats, error)
 }
 
+type backendLeafGenerationLogicalRebuildRunner interface {
+	LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts backenddb.LeafGenerationLogicalRebuildRunOnceOptions) (backenddb.LeafGenerationLogicalRebuildRunOnceStats, error)
+}
+
 type backendLeafGenerationGCRunner interface {
 	LeafGenerationGC(ctx context.Context, opts backenddb.LeafGenerationGCOptions) (backenddb.LeafGenerationGCStats, error)
 }
@@ -6610,12 +6625,55 @@ type DB struct {
 	vlogGenerationMaintenancePassNoop                            atomic.Uint64
 	vlogGenerationMaintenancePassWithRewrite                     atomic.Uint64
 	vlogGenerationMaintenancePassWithGC                          atomic.Uint64
+	vlogGenerationMaintenancePassWithLeafLogicalRebuild          atomic.Uint64
 	vlogGenerationMaintenancePassWithLeafPack                    atomic.Uint64
 	vlogGenerationMaintenanceAcquiredBySource                    [vlogGenerationMaintenanceSourceCount]atomic.Uint64
 	vlogGenerationMaintenancePassNoopBySource                    [vlogGenerationMaintenanceSourceCount]atomic.Uint64
 	vlogGenerationMaintenancePassWithRewriteBySource             [vlogGenerationMaintenanceSourceCount]atomic.Uint64
 	vlogGenerationMaintenancePassWithGCBySource                  [vlogGenerationMaintenanceSourceCount]atomic.Uint64
+	vlogGenerationMaintenancePassWithLeafLogicalRebuildBySource  [vlogGenerationMaintenanceSourceCount]atomic.Uint64
 	vlogGenerationMaintenancePassWithLeafPackBySource            [vlogGenerationMaintenanceSourceCount]atomic.Uint64
+	vlogGenerationLeafLogicalRebuildAttempts                     atomic.Uint64
+	vlogGenerationLeafLogicalRebuildAdmitted                     atomic.Uint64
+	vlogGenerationLeafLogicalRebuildRuns                         atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSkips                        atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSkipMinInterval              atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSkipWriteBurst               atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSkipQueuePressure            atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSkipForegroundIterators      atomic.Uint64
+	vlogGenerationLeafLogicalRebuildErrors                       atomic.Uint64
+	vlogGenerationLeafLogicalRebuildCanceled                     atomic.Uint64
+	vlogGenerationLeafLogicalRebuildDeadline                     atomic.Uint64
+	vlogGenerationLeafLogicalRebuildCampaignMaxPublishedCommit   atomic.Uint64
+	vlogGenerationLeafLogicalRebuildBytesCopied                  atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSourceLeafBytes              atomic.Uint64
+	vlogGenerationLeafLogicalRebuildLeafGCDeletedBytes           atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSelectionRuns                atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSelectionSourceFiles         atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSelectionSourcePages         atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSelectionReplacementPages    atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSelectionCandidateAttempts   atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSelectionCatchupPasses       atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSelectionCatchupKeys         atomic.Uint64
+	vlogGenerationLeafLogicalRebuildSelectionCutoverKeys         atomic.Uint64
+	vlogGenerationLeafLogicalRebuildLastWallNanos                atomic.Uint64
+	vlogGenerationLeafLogicalRebuildLastBytesCopied              atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastSourceLeafBytes          atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastLeafGCDeletedBytes       atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastSelectionRuns            atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastSelectionSourceFiles     atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastSelectionSourcePages     atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastReplacementPages         atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastCandidateAttempts        atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastCatchupPasses            atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastCatchupKeys              atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastCutoverKeys              atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastSelectedRawFileID        atomic.Uint64
+	vlogGenerationLeafLogicalRebuildLastSelectedGenerationID     atomic.Uint64
+	vlogGenerationLeafLogicalRebuildLastUnixNano                 atomic.Int64
+	vlogGenerationLeafLogicalRebuildCanceledLastNS               atomic.Int64
+	vlogGenerationLeafLogicalRebuildDeadlineLastNS               atomic.Int64
+	vlogGenerationLeafLogicalRebuildLastSkipReason               atomic.Value // string
 	vlogGenerationLeafPackAttempts                               atomic.Uint64
 	vlogGenerationLeafPackAdmitted                               atomic.Uint64
 	vlogGenerationLeafPackRuns                                   atomic.Uint64
@@ -6856,6 +6914,7 @@ const (
 	vlogGenerationReasonPeriodicGC
 	vlogGenerationReasonPostRewriteVacuum
 	vlogGenerationReasonRewriteResume
+	vlogGenerationReasonLeafLogicalRebuild
 	vlogGenerationReasonLeafPack
 )
 
@@ -6864,6 +6923,7 @@ const (
 	vlogGenerationGCEvery                    = 5
 	vlogGenerationGCMinBytes                 = int64(1 << 20)
 	vlogGenerationRewriteMinInterval         = 30 * time.Second
+	leafGenerationLogicalRebuildMinInterval  = 30 * time.Second
 	leafGenerationPackMaintenanceMinInterval = 30 * time.Second
 	// Rewrite staging uses a two-pass confirm flow: the first pass stages a plan,
 	// then a later pass re-plans and executes only if a stable subset persists.
@@ -9797,6 +9857,8 @@ func vlogGenerationReasonString(v uint32) string {
 		return "post_rewrite_vacuum"
 	case vlogGenerationReasonRewriteResume:
 		return "rewrite_resume"
+	case vlogGenerationReasonLeafLogicalRebuild:
+		return "leaf_logical_rebuild"
 	case vlogGenerationReasonLeafPack:
 		return "leaf_pack"
 	default:
@@ -14832,10 +14894,43 @@ func (db *DB) observeVlogGenerationLeafPackAdmissionSkip(reason string) {
 	db.storeVlogGenerationLeafPackLastSkipReason(reason)
 }
 
+func (db *DB) storeVlogGenerationLeafLogicalRebuildLastSkipReason(reason string) {
+	if db == nil {
+		return
+	}
+	db.vlogGenerationLeafLogicalRebuildLastSkipReason.Store(reason)
+}
+
+func (db *DB) observeVlogGenerationLeafLogicalRebuildAdmissionSkip(reason string) {
+	if db == nil || reason == "" {
+		return
+	}
+	if !envBool(envEnableLeafGenerationLogicalRebuildMaintenance) || !db.indexOuterLeavesInValueLog {
+		return
+	}
+	switch reason {
+	case "write_burst":
+		db.vlogGenerationLeafLogicalRebuildSkipWriteBurst.Add(1)
+	case "queue_pressure":
+		db.vlogGenerationLeafLogicalRebuildSkipQueuePressure.Add(1)
+	case "foreground_iterators":
+		db.vlogGenerationLeafLogicalRebuildSkipForegroundIterators.Add(1)
+	}
+	db.storeVlogGenerationLeafLogicalRebuildLastSkipReason(reason)
+}
+
 func leafGenerationPackMaintenanceTimeout() time.Duration {
 	timeoutSeconds := envUint64(envLeafGenerationPackMaintenanceTimeoutSeconds, uint64(leafGenerationPackMaintenanceDefaultTimeout/time.Second))
 	if timeoutSeconds == 0 {
 		return leafGenerationPackMaintenanceDefaultTimeout
+	}
+	return time.Duration(timeoutSeconds) * time.Second
+}
+
+func leafGenerationLogicalRebuildMaintenanceTimeout() time.Duration {
+	timeoutSeconds := envUint64(envLeafGenerationLogicalRebuildMaintenanceTimeoutSeconds, uint64(leafGenerationLogicalRebuildMaintenanceDefaultTimeout/time.Second))
+	if timeoutSeconds == 0 {
+		return leafGenerationLogicalRebuildMaintenanceDefaultTimeout
 	}
 	return time.Duration(timeoutSeconds) * time.Second
 }
@@ -14856,6 +14951,24 @@ func (db *DB) observeVlogGenerationLeafPackDeadline() {
 	db.vlogGenerationLeafPackDeadline.Add(1)
 	db.vlogGenerationLeafPackDeadlineLastNS.Store(time.Now().UnixNano())
 	db.storeVlogGenerationLeafPackLastSkipReason("deadline_exceeded")
+}
+
+func (db *DB) observeVlogGenerationLeafLogicalRebuildCanceled() {
+	if db == nil {
+		return
+	}
+	db.vlogGenerationLeafLogicalRebuildCanceled.Add(1)
+	db.vlogGenerationLeafLogicalRebuildCanceledLastNS.Store(time.Now().UnixNano())
+	db.storeVlogGenerationLeafLogicalRebuildLastSkipReason("context_canceled")
+}
+
+func (db *DB) observeVlogGenerationLeafLogicalRebuildDeadline() {
+	if db == nil {
+		return
+	}
+	db.vlogGenerationLeafLogicalRebuildDeadline.Add(1)
+	db.vlogGenerationLeafLogicalRebuildDeadlineLastNS.Store(time.Now().UnixNano())
+	db.storeVlogGenerationLeafLogicalRebuildLastSkipReason("deadline_exceeded")
 }
 
 func (db *DB) vlogGenerationRewritePlanBackoffActive(now time.Time) bool {
@@ -15828,9 +15941,11 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 	db.vlogGenerationMaintenanceAcquired.Add(1)
 	rewriteRunsBefore := db.vlogGenerationRewriteRuns.Load()
 	gcRunsBefore := db.vlogGenerationGCRuns.Load()
+	leafLogicalRebuildRunsBefore := db.vlogGenerationLeafLogicalRebuildRuns.Load()
 	leafPackRunsBefore := db.vlogGenerationLeafPackRuns.Load()
 	rewriteAttempted := false
 	gcAttempted := false
+	leafLogicalRebuildAttempted := false
 	leafPackAttempted := false
 	activeSource := vlogGenerationMaintenanceDebugSource(opts)
 	activeSourceIdx := vlogGenerationMaintenanceSourceIndex(activeSource)
@@ -15861,9 +15976,11 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 		db.observeVlogGenerationMaintenancePassDuration(passDur)
 		rewriteRan := db.vlogGenerationRewriteRuns.Load() > rewriteRunsBefore
 		gcRan := db.vlogGenerationGCRuns.Load() > gcRunsBefore
+		leafLogicalRebuildRan := db.vlogGenerationLeafLogicalRebuildRuns.Load() > leafLogicalRebuildRunsBefore
 		leafPackRan := db.vlogGenerationLeafPackRuns.Load() > leafPackRunsBefore
 		rewritePass := rewriteRan || rewriteAttempted
 		gcPass := gcRan || gcAttempted
+		leafLogicalRebuildPass := leafLogicalRebuildRan || leafLogicalRebuildAttempted
 		leafPackPass := leafPackRan || leafPackAttempted
 		if rewritePass {
 			db.vlogGenerationMaintenancePassWithRewrite.Add(1)
@@ -15873,11 +15990,15 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 			db.vlogGenerationMaintenancePassWithGC.Add(1)
 			db.vlogGenerationMaintenancePassWithGCBySource[activeSourceIdx].Add(1)
 		}
+		if leafLogicalRebuildPass {
+			db.vlogGenerationMaintenancePassWithLeafLogicalRebuild.Add(1)
+			db.vlogGenerationMaintenancePassWithLeafLogicalRebuildBySource[activeSourceIdx].Add(1)
+		}
 		if leafPackPass {
 			db.vlogGenerationMaintenancePassWithLeafPack.Add(1)
 			db.vlogGenerationMaintenancePassWithLeafPackBySource[activeSourceIdx].Add(1)
 		}
-		if !rewritePass && !gcPass && !leafPackPass {
+		if !rewritePass && !gcPass && !leafLogicalRebuildPass && !leafPackPass {
 			db.vlogGenerationMaintenancePassNoop.Add(1)
 			db.vlogGenerationMaintenancePassNoopBySource[activeSourceIdx].Add(1)
 		}
@@ -17630,6 +17751,31 @@ planned:
 		return
 	}
 	if leafPackRan {
+		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
+		return
+	}
+
+	leafLogicalRebuildAttempted, leafLogicalRebuildRan, err := db.maybeRunLeafGenerationLogicalRebuildMaintenance(runGC, quiet, leafPackAdmission, opts)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			db.observeVlogGenerationLeafLogicalRebuildCanceled()
+			db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
+			return
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			db.observeVlogGenerationLeafLogicalRebuildDeadline()
+			db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
+			return
+		}
+		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerError)
+		db.vlogGenerationLeafLogicalRebuildErrors.Add(1)
+		db.storeVlogGenerationLeafLogicalRebuildLastSkipReason("error")
+		if db.notifyError != nil {
+			db.notifyError(fmt.Errorf("cachingdb: %w", err))
+		}
+		return
+	}
+	if leafLogicalRebuildRan {
 		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
 		return
 	}
@@ -23003,6 +23149,171 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 	return attempted, false, nil
 }
 
+func (db *DB) maybeRunLeafGenerationLogicalRebuildMaintenance(runGC bool, quiet bool, admission leafGenerationPackMaintenanceAdmission, opts vlogGenerationMaintenanceOptions) (attempted bool, ran bool, err error) {
+	if db == nil || db.closing.Load() {
+		return false, false, nil
+	}
+	if !envBool(envEnableLeafGenerationLogicalRebuildMaintenance) {
+		return false, false, nil
+	}
+	if !db.indexOuterLeavesInValueLog {
+		return false, false, nil
+	}
+	if runGC || opts.bypassQuiet {
+		return false, false, nil
+	}
+	if !quiet && !admission.allowed {
+		db.observeVlogGenerationLeafLogicalRebuildAdmissionSkip(admission.reason)
+		return false, false, nil
+	}
+	runner, ok := db.backend.(backendLeafGenerationLogicalRebuildRunner)
+	if !ok {
+		return false, false, nil
+	}
+	gcRunner, _ := db.backend.(backendLeafGenerationGCRunner)
+	lastRunNS := db.vlogGenerationLeafLogicalRebuildLastUnixNano.Load()
+	if lastRunNS > 0 {
+		if since := time.Since(time.Unix(0, lastRunNS)); since >= 0 && since < leafGenerationLogicalRebuildMinInterval {
+			db.vlogGenerationLeafLogicalRebuildSkipMinInterval.Add(1)
+			db.storeVlogGenerationLeafLogicalRebuildLastSkipReason("min_interval")
+			return false, false, nil
+		}
+	}
+
+	clusterFilesMax := loadPositiveIntEnvDefault(envLeafGenerationLogicalRebuildMaintenanceClusterFilesMax, leafGenerationLogicalRebuildMaintenanceDefaultClusterFilesMax)
+	candidateTryMax := loadPositiveIntEnvDefault(envLeafGenerationLogicalRebuildMaintenanceCandidateTryMax, leafGenerationLogicalRebuildMaintenanceDefaultCandidateTryMax)
+	pilotSamplePages := loadPositiveIntEnvDefault(envLeafGenerationLogicalRebuildMaintenancePilotSamplePages, leafGenerationLogicalRebuildMaintenanceDefaultPilotSamplePages)
+	timeout := leafGenerationLogicalRebuildMaintenanceTimeout()
+
+	db.vlogGenerationLeafLogicalRebuildAttempts.Add(1)
+	db.vlogGenerationLeafLogicalRebuildAdmitted.Add(1)
+	attempted = true
+	db.vlogGenerationLastReason.Store(vlogGenerationReasonLeafLogicalRebuild)
+	db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerRunning)
+
+	err = db.runWithBackendMaintenanceOptions(backendMaintenanceOptions{
+		skipCheckpoint:        opts.skipCheckpoint,
+		skipRetainedPruneWait: opts.skipRetainedPruneWait,
+	}, func() error {
+		ctx, cancel := db.leafGenerationPackMaintenanceContext(timeout)
+		defer cancel()
+
+		runOpts := backenddb.LeafGenerationLogicalRebuildRunOnceOptions{
+			MaxPublishedCommitSeq: db.vlogGenerationLeafLogicalRebuildCampaignMaxPublishedCommit.Load(),
+			ClusterFilesMax:       clusterFilesMax,
+			CandidateTryMax:       candidateTryMax,
+			PilotSamplePages:      pilotSamplePages,
+			Sync:                  false,
+		}
+		stats, runErr := runner.LeafGenerationLogicalRebuildRunOnce(ctx, runOpts)
+		if runErr != nil {
+			if errors.Is(runErr, backenddb.ErrLeafGenerationLogicalRebuildNoCandidate) {
+				db.storeVlogGenerationLeafLogicalRebuildLastSkipReason("no_candidate")
+				return nil
+			}
+			return runErr
+		}
+		if stats.CommitSeqBefore > 0 {
+			db.vlogGenerationLeafLogicalRebuildCampaignMaxPublishedCommit.CompareAndSwap(0, stats.CommitSeqBefore)
+		}
+		if len(stats.RetiredGenerationIDs) == 0 || len(stats.CreatedFileIDs) == 0 {
+			db.storeVlogGenerationLeafLogicalRebuildLastSkipReason("no_publish")
+			return nil
+		}
+
+		ran = true
+		db.vlogGenerationLeafLogicalRebuildRuns.Add(1)
+		if stats.BytesCopied > 0 {
+			db.vlogGenerationLeafLogicalRebuildBytesCopied.Add(uint64(stats.BytesCopied))
+		}
+		if stats.SourceLeafBytes > 0 {
+			db.vlogGenerationLeafLogicalRebuildSourceLeafBytes.Add(uint64(stats.SourceLeafBytes))
+		}
+		if stats.SelectedRunCount > 0 {
+			db.vlogGenerationLeafLogicalRebuildSelectionRuns.Add(uint64(stats.SelectedRunCount))
+		}
+		if stats.SelectedSourceFiles > 0 {
+			db.vlogGenerationLeafLogicalRebuildSelectionSourceFiles.Add(uint64(stats.SelectedSourceFiles))
+		}
+		if stats.SourceLeafPages > 0 {
+			db.vlogGenerationLeafLogicalRebuildSelectionSourcePages.Add(uint64(stats.SourceLeafPages))
+		}
+		if stats.ReplacementLeafPages > 0 {
+			db.vlogGenerationLeafLogicalRebuildSelectionReplacementPages.Add(uint64(stats.ReplacementLeafPages))
+		}
+		if stats.CandidateAttempts > 0 {
+			db.vlogGenerationLeafLogicalRebuildSelectionCandidateAttempts.Add(uint64(stats.CandidateAttempts))
+		}
+		if stats.CatchupPasses > 0 {
+			db.vlogGenerationLeafLogicalRebuildSelectionCatchupPasses.Add(uint64(stats.CatchupPasses))
+		}
+		if stats.CatchupKeys > 0 {
+			db.vlogGenerationLeafLogicalRebuildSelectionCatchupKeys.Add(uint64(stats.CatchupKeys))
+		}
+		if stats.FinalCutoverKeys > 0 {
+			db.vlogGenerationLeafLogicalRebuildSelectionCutoverKeys.Add(uint64(stats.FinalCutoverKeys))
+		}
+		lastWallNanos := stats.WallTimeNanos
+		if lastWallNanos < 0 {
+			lastWallNanos = 0
+		}
+		db.vlogGenerationLeafLogicalRebuildLastWallNanos.Store(uint64(lastWallNanos))
+		db.vlogGenerationLeafLogicalRebuildLastBytesCopied.Store(stats.BytesCopied)
+		db.vlogGenerationLeafLogicalRebuildLastSourceLeafBytes.Store(stats.SourceLeafBytes)
+		db.vlogGenerationLeafLogicalRebuildLastSelectionRuns.Store(int64(stats.SelectedRunCount))
+		db.vlogGenerationLeafLogicalRebuildLastSelectionSourceFiles.Store(int64(stats.SelectedSourceFiles))
+		db.vlogGenerationLeafLogicalRebuildLastSelectionSourcePages.Store(int64(stats.SourceLeafPages))
+		db.vlogGenerationLeafLogicalRebuildLastReplacementPages.Store(int64(stats.ReplacementLeafPages))
+		db.vlogGenerationLeafLogicalRebuildLastCandidateAttempts.Store(int64(stats.CandidateAttempts))
+		db.vlogGenerationLeafLogicalRebuildLastCatchupPasses.Store(int64(stats.CatchupPasses))
+		db.vlogGenerationLeafLogicalRebuildLastCatchupKeys.Store(int64(stats.CatchupKeys))
+		db.vlogGenerationLeafLogicalRebuildLastCutoverKeys.Store(int64(stats.FinalCutoverKeys))
+		db.vlogGenerationLeafLogicalRebuildLastSelectedRawFileID.Store(uint64(stats.SelectedRawFileID))
+		db.vlogGenerationLeafLogicalRebuildLastSelectedGenerationID.Store(stats.SelectedGenerationID)
+		db.vlogGenerationLeafLogicalRebuildLastUnixNano.Store(time.Now().UnixNano())
+		db.storeVlogGenerationLeafLogicalRebuildLastSkipReason("")
+
+		if gcRunner != nil {
+			gcStats, gcErr := gcRunner.LeafGenerationGC(ctx, backenddb.LeafGenerationGCOptions{})
+			if gcErr != nil {
+				return gcErr
+			}
+			if gcStats.BytesDeleted > 0 {
+				db.vlogGenerationLeafLogicalRebuildLeafGCDeletedBytes.Add(uint64(gcStats.BytesDeleted))
+			}
+			db.vlogGenerationLeafLogicalRebuildLastLeafGCDeletedBytes.Store(gcStats.BytesDeleted)
+		}
+
+		db.debugVlogMaintf(
+			"leaf_logical_rebuild_done generation=%d raw_file=%d source_files=%d runs=%d source_pages=%d replacement_pages=%d source_bytes=%d bytes_copied=%d catchup_passes=%d cutover_keys=%d campaign_max_published=%d wall_ms=%.3f",
+			stats.SelectedGenerationID,
+			stats.SelectedRawFileID,
+			stats.SelectedSourceFiles,
+			stats.SelectedRunCount,
+			stats.SourceLeafPages,
+			stats.ReplacementLeafPages,
+			stats.SourceLeafBytes,
+			stats.BytesCopied,
+			stats.CatchupPasses,
+			stats.FinalCutoverKeys,
+			db.vlogGenerationLeafLogicalRebuildCampaignMaxPublishedCommit.Load(),
+			float64(lastWallNanos)/float64(time.Millisecond),
+		)
+		return nil
+	})
+	if err != nil {
+		return attempted, false, fmt.Errorf("leaf generation logical rebuild maintenance: %w", err)
+	}
+
+	if ran {
+		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
+		return attempted, true, nil
+	}
+	db.vlogGenerationLeafLogicalRebuildSkips.Add(1)
+	db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
+	return attempted, false, nil
+}
+
 func (db *DB) Stats() map[string]string {
 	stats := db.backend.Stats()
 	if stats == nil {
@@ -24134,6 +24445,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_generation.maintenance.passes.noop"] = fmt.Sprintf("%d", db.vlogGenerationMaintenancePassNoop.Load())
 	stats["treedb.cache.vlog_generation.maintenance.passes.with_rewrite"] = fmt.Sprintf("%d", db.vlogGenerationMaintenancePassWithRewrite.Load())
 	stats["treedb.cache.vlog_generation.maintenance.passes.with_gc"] = fmt.Sprintf("%d", db.vlogGenerationMaintenancePassWithGC.Load())
+	stats["treedb.cache.vlog_generation.maintenance.passes.with_leaf_logical_rebuild"] = fmt.Sprintf("%d", db.vlogGenerationMaintenancePassWithLeafLogicalRebuild.Load())
 	stats["treedb.cache.vlog_generation.maintenance.passes.with_leaf_pack"] = fmt.Sprintf("%d", db.vlogGenerationMaintenancePassWithLeafPack.Load())
 	for sourceIdx := 0; sourceIdx < vlogGenerationMaintenanceSourceCount; sourceIdx++ {
 		source := vlogGenerationMaintenanceSourceLabel(sourceIdx)
@@ -24153,11 +24465,56 @@ func (db *DB) Stats() map[string]string {
 			"%d",
 			db.vlogGenerationMaintenancePassWithGCBySource[sourceIdx].Load(),
 		)
+		stats["treedb.cache.vlog_generation.maintenance.passes.with_leaf_logical_rebuild.source."+source] = fmt.Sprintf(
+			"%d",
+			db.vlogGenerationMaintenancePassWithLeafLogicalRebuildBySource[sourceIdx].Load(),
+		)
 		stats["treedb.cache.vlog_generation.maintenance.passes.with_leaf_pack.source."+source] = fmt.Sprintf(
 			"%d",
 			db.vlogGenerationMaintenancePassWithLeafPackBySource[sourceIdx].Load(),
 		)
 	}
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.attempts"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildAttempts.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.admitted"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildAdmitted.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.runs"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildRuns.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.skips"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSkips.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.skip.min_interval"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSkipMinInterval.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.skip.write_burst"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSkipWriteBurst.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.skip.queue_pressure"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSkipQueuePressure.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.skip.foreground_iterators"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSkipForegroundIterators.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.errors"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildErrors.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.canceled"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildCanceled.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.deadline"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildDeadline.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.campaign_max_published_commit_seq"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildCampaignMaxPublishedCommit.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.bytes_copied"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildBytesCopied.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.source_leaf_bytes"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSourceLeafBytes.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.gc.deleted_bytes"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLeafGCDeletedBytes.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.selection.runs"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSelectionRuns.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.selection.source_files"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSelectionSourceFiles.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.selection.source_pages"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSelectionSourcePages.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.selection.replacement_pages"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSelectionReplacementPages.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.selection.candidate_attempts"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSelectionCandidateAttempts.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.selection.catchup_passes"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSelectionCatchupPasses.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.selection.catchup_keys"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSelectionCatchupKeys.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.selection.cutover_keys"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildSelectionCutoverKeys.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_wall_ms"] = fmt.Sprintf("%.3f", float64(db.vlogGenerationLeafLogicalRebuildLastWallNanos.Load())/float64(time.Millisecond))
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_bytes_copied"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastBytesCopied.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_source_leaf_bytes"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastSourceLeafBytes.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_gc_deleted_bytes"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastLeafGCDeletedBytes.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_selection.runs"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastSelectionRuns.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_selection.source_files"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastSelectionSourceFiles.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_selection.source_pages"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastSelectionSourcePages.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_selection.replacement_pages"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastReplacementPages.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_selection.candidate_attempts"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastCandidateAttempts.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_selection.catchup_passes"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastCatchupPasses.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_selection.catchup_keys"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastCatchupKeys.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_selection.cutover_keys"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastCutoverKeys.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_selected_raw_file_id"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastSelectedRawFileID.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_selected_generation_id"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastSelectedGenerationID.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_skip_reason"] = atomicValueString(&db.vlogGenerationLeafLogicalRebuildLastSkipReason)
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.last_unix_nano"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildLastUnixNano.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.canceled_last_unix_nano"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildCanceledLastNS.Load())
+	stats["treedb.cache.vlog_generation.leaf_logical_rebuild.deadline_last_unix_nano"] = fmt.Sprintf("%d", db.vlogGenerationLeafLogicalRebuildDeadlineLastNS.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.attempts"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackAttempts.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.admitted"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackAdmitted.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.runs"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackRuns.Load())

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -23204,6 +23204,7 @@ func (db *DB) maybeRunLeafGenerationLogicalRebuildMaintenance(runGC bool, quiet 
 			CandidateTryMax:       candidateTryMax,
 			PilotSamplePages:      pilotSamplePages,
 			Sync:                  false,
+			ReserveRIDs:           db.ReserveValueLogRIDs,
 		}
 		stats, runErr := runner.LeafGenerationLogicalRebuildRunOnce(ctx, runOpts)
 		if runErr != nil {

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1576,6 +1576,13 @@ type leafPackMaintenanceRecordingBackend struct {
 	entered           chan struct{}
 	release           chan struct{}
 	blockUntilCtxDone bool
+	logicalCalls      int
+	logicalOpts       backenddb.LeafGenerationLogicalRebuildRunOnceOptions
+	logicalOptsHist   []backenddb.LeafGenerationLogicalRebuildRunOnceOptions
+	logicalResp       backenddb.LeafGenerationLogicalRebuildRunOnceStats
+	logicalErr        error
+	logicalHasDL      bool
+	logicalDeadline   time.Time
 }
 
 func (b *leafPackMaintenanceRecordingBackend) LeafGenerationPackRunOnce(ctx context.Context, opts backenddb.LeafGenerationPackFromPlanOptions) (backenddb.LeafGenerationPackRunOnceStats, error) {
@@ -1639,6 +1646,16 @@ func (b *leafPackMaintenanceRecordingBackend) LeafGenerationGC(ctx context.Conte
 	return stats, b.leafGCErr
 }
 
+func (b *leafPackMaintenanceRecordingBackend) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts backenddb.LeafGenerationLogicalRebuildRunOnceOptions) (backenddb.LeafGenerationLogicalRebuildRunOnceStats, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.logicalCalls++
+	b.logicalOpts = opts
+	b.logicalOptsHist = append(b.logicalOptsHist, opts)
+	b.logicalDeadline, b.logicalHasDL = ctx.Deadline()
+	return b.logicalResp, b.logicalErr
+}
+
 func (b *leafPackMaintenanceRecordingBackend) recordedLeafPack() (backenddb.LeafGenerationPackFromPlanOptions, int, bool, time.Time) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -1665,6 +1682,12 @@ func (b *leafPackMaintenanceRecordingBackend) recordedLeafGC() (backenddb.LeafGe
 		stats = b.leafGCResponses[idx]
 	}
 	return stats, b.leafGCCalls
+}
+
+func (b *leafPackMaintenanceRecordingBackend) recordedLeafLogicalRebuild() (backenddb.LeafGenerationLogicalRebuildRunOnceOptions, int, bool, time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.logicalOpts, b.logicalCalls, b.logicalHasDL, b.logicalDeadline
 }
 
 func mustLeafPackTempDir(t *testing.T, prefix string) string {
@@ -1966,6 +1989,93 @@ func TestLeafGenerationPackMaintenance_RunsWithDefaultBounds(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationLogicalRebuildMaintenance_RequiresExplicitEnv(t *testing.T) {
+	recorder := &leafPackMaintenanceRecordingBackend{
+		DB: mustOpenLeafPackBackend(t),
+		logicalResp: backenddb.LeafGenerationLogicalRebuildRunOnceStats{
+			CommitSeqBefore:      10,
+			SelectedGenerationID: 7,
+			SelectedRawFileID:    42,
+			CreatedFileIDs:       []uint32{9001},
+			RetiredGenerationIDs: []uint64{7},
+		},
+	}
+	db, cleanup := openLeafPackMaintenanceTestDB(t, recorder)
+	defer cleanup()
+
+	attempted, ran, err := db.maybeRunLeafGenerationLogicalRebuildMaintenance(false, true, leafGenerationPackMaintenanceAdmission{allowed: true}, vlogGenerationMaintenanceOptions{skipCheckpoint: true})
+	if err != nil {
+		t.Fatalf("maybeRunLeafGenerationLogicalRebuildMaintenance: %v", err)
+	}
+	if attempted || ran {
+		t.Fatalf("attempted=%t ran=%t want false/false", attempted, ran)
+	}
+	if _, calls, _, _ := recorder.recordedLeafLogicalRebuild(); calls != 0 {
+		t.Fatalf("logical rebuild calls=%d want 0", calls)
+	}
+}
+
+func TestLeafGenerationLogicalRebuildMaintenance_RunsWithDefaultBounds(t *testing.T) {
+	t.Setenv(envEnableLeafGenerationLogicalRebuildMaintenance, "1")
+	recorder := &leafPackMaintenanceRecordingBackend{
+		DB: mustOpenLeafPackBackend(t),
+		logicalResp: backenddb.LeafGenerationLogicalRebuildRunOnceStats{
+			CommitSeqBefore:      3118,
+			SelectedGenerationID: 17,
+			SelectedRawFileID:    88,
+			SelectedSourceFiles:  3,
+			SelectedRunCount:     5,
+			SourceLeafPages:      144,
+			SourceLeafBytes:      65536,
+			ReplacementLeafPages: 120,
+			BytesCopied:          54321,
+			CandidateAttempts:    2,
+			CatchupPasses:        1,
+			CatchupKeys:          12,
+			FinalCutoverKeys:     3,
+			WallTimeNanos:        (21 * time.Millisecond).Nanoseconds(),
+			CreatedFileIDs:       []uint32{701, 702},
+			RetiredGenerationIDs: []uint64{17},
+		},
+		leafGCResp: backenddb.LeafGenerationGCStats{GenerationsDeleted: 1, FilesDeleted: 2, BytesDeleted: 4096},
+	}
+	db, cleanup := openLeafPackMaintenanceTestDB(t, recorder)
+	defer cleanup()
+
+	attempted, ran, err := db.maybeRunLeafGenerationLogicalRebuildMaintenance(false, true, leafGenerationPackMaintenanceAdmission{allowed: true}, vlogGenerationMaintenanceOptions{skipCheckpoint: true})
+	if err != nil {
+		t.Fatalf("maybeRunLeafGenerationLogicalRebuildMaintenance: %v", err)
+	}
+	if !attempted || !ran {
+		t.Fatalf("attempted=%t ran=%t want true/true", attempted, ran)
+	}
+	opts, calls, hasDeadline, _ := recorder.recordedLeafLogicalRebuild()
+	if calls != 1 {
+		t.Fatalf("logical rebuild calls=%d want 1", calls)
+	}
+	if !hasDeadline {
+		t.Fatal("expected logical rebuild maintenance deadline")
+	}
+	if opts.ClusterFilesMax != leafGenerationLogicalRebuildMaintenanceDefaultClusterFilesMax {
+		t.Fatalf("ClusterFilesMax=%d want %d", opts.ClusterFilesMax, leafGenerationLogicalRebuildMaintenanceDefaultClusterFilesMax)
+	}
+	if opts.CandidateTryMax != leafGenerationLogicalRebuildMaintenanceDefaultCandidateTryMax {
+		t.Fatalf("CandidateTryMax=%d want %d", opts.CandidateTryMax, leafGenerationLogicalRebuildMaintenanceDefaultCandidateTryMax)
+	}
+	if opts.PilotSamplePages != leafGenerationLogicalRebuildMaintenanceDefaultPilotSamplePages {
+		t.Fatalf("PilotSamplePages=%d want %d", opts.PilotSamplePages, leafGenerationLogicalRebuildMaintenanceDefaultPilotSamplePages)
+	}
+	if got := db.vlogGenerationLeafLogicalRebuildRuns.Load(); got != 1 {
+		t.Fatalf("logical rebuild runs=%d want 1", got)
+	}
+	if got := db.vlogGenerationLeafLogicalRebuildCampaignMaxPublishedCommit.Load(); got != 3118 {
+		t.Fatalf("campaign max published commit seq=%d want 3118", got)
+	}
+	if got := db.vlogGenerationLeafLogicalRebuildLeafGCDeletedBytes.Load(); got != 4096 {
+		t.Fatalf("logical rebuild leaf gc deleted bytes=%d want 4096", got)
+	}
+}
+
 func TestLeafGenerationPackMaintenance_PassesReserveRIDs(t *testing.T) {
 	t.Setenv(envEnableLeafGenerationPackMaintenance, "1")
 	recorder := &leafPackMaintenanceRecordingBackend{
@@ -2249,6 +2359,60 @@ func TestVlogGenerationMaintenance_PeriodicPassRunsLeafPackWhenEnabled(t *testin
 	}
 	if got := db.vlogGenerationLeafPackRuns.Load(); got != 1 {
 		t.Fatalf("leaf pack runs=%d want 1", got)
+	}
+}
+
+func TestVlogGenerationMaintenance_PeriodicPassRunsLeafLogicalRebuildWhenEnabled(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+	t.Setenv(envEnableLeafGenerationLogicalRebuildMaintenance, "1")
+	recorder := &leafPackMaintenanceRecordingBackend{
+		DB: mustOpenLeafPackBackend(t),
+		logicalResp: backenddb.LeafGenerationLogicalRebuildRunOnceStats{
+			CommitSeqBefore:      3118,
+			SelectedGenerationID: 55,
+			SelectedRawFileID:    144,
+			SelectedSourceFiles:  2,
+			SelectedRunCount:     3,
+			SourceLeafPages:      80,
+			SourceLeafBytes:      32768,
+			ReplacementLeafPages: 60,
+			BytesCopied:          12345,
+			CandidateAttempts:    1,
+			CreatedFileIDs:       []uint32{3001},
+			RetiredGenerationIDs: []uint64{55},
+			WallTimeNanos:        (14 * time.Millisecond).Nanoseconds(),
+		},
+		leafGCResp: backenddb.LeafGenerationGCStats{GenerationsEligible: 1, GenerationsDeleted: 1, FilesDeleted: 1, BytesDeleted: 2048},
+	}
+	db, cleanup := openLeafPackMaintenanceTestDB(t, recorder)
+	defer cleanup()
+
+	db.maybeRunVlogGenerationMaintenanceWithOptions(false, vlogGenerationMaintenanceOptions{})
+
+	opts, calls, hasDeadline, deadline := recorder.recordedLeafLogicalRebuild()
+	if calls != 1 {
+		t.Fatalf("logical rebuild calls=%d want 1", calls)
+	}
+	if opts.ClusterFilesMax != leafGenerationLogicalRebuildMaintenanceDefaultClusterFilesMax {
+		t.Fatalf("ClusterFilesMax=%d want %d", opts.ClusterFilesMax, leafGenerationLogicalRebuildMaintenanceDefaultClusterFilesMax)
+	}
+	if opts.CandidateTryMax != leafGenerationLogicalRebuildMaintenanceDefaultCandidateTryMax {
+		t.Fatalf("CandidateTryMax=%d want %d", opts.CandidateTryMax, leafGenerationLogicalRebuildMaintenanceDefaultCandidateTryMax)
+	}
+	if !hasDeadline {
+		t.Fatal("expected logical rebuild maintenance context deadline to be set")
+	}
+	if ttl := time.Until(deadline); ttl < 40*time.Second || ttl > 46*time.Second {
+		t.Fatalf("deadline ttl=%s want around 45s", ttl)
+	}
+	if got := db.vlogGenerationMaintenancePassWithLeafLogicalRebuild.Load(); got != 1 {
+		t.Fatalf("maintenance leaf logical rebuild passes=%d want 1", got)
+	}
+	if got := db.vlogGenerationLeafLogicalRebuildRuns.Load(); got != 1 {
+		t.Fatalf("leaf logical rebuild runs=%d want 1", got)
+	}
+	if got := db.vlogGenerationLeafLogicalRebuildCampaignMaxPublishedCommit.Load(); got != 3118 {
+		t.Fatalf("campaign max published commit seq=%d want 3118", got)
 	}
 }
 

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -2065,6 +2065,20 @@ func TestLeafGenerationLogicalRebuildMaintenance_RunsWithDefaultBounds(t *testin
 	if opts.PilotSamplePages != leafGenerationLogicalRebuildMaintenanceDefaultPilotSamplePages {
 		t.Fatalf("PilotSamplePages=%d want %d", opts.PilotSamplePages, leafGenerationLogicalRebuildMaintenanceDefaultPilotSamplePages)
 	}
+	if opts.ReserveRIDs == nil {
+		t.Fatal("expected ReserveRIDs to be passed to logical rebuild maintenance")
+	}
+	before := db.nextRID.Load()
+	start, err := opts.ReserveRIDs(3)
+	if err != nil {
+		t.Fatalf("ReserveRIDs(3): %v", err)
+	}
+	if got, want := start, before+1; got != want {
+		t.Fatalf("ReserveRIDs start=%d want %d", got, want)
+	}
+	if got, want := db.nextRID.Load(), before+3; got != want {
+		t.Fatalf("nextRID after ReserveRIDs=%d want %d", got, want)
+	}
 	if got := db.vlogGenerationLeafLogicalRebuildRuns.Load(); got != 1 {
 		t.Fatalf("logical rebuild runs=%d want 1", got)
 	}

--- a/TreeDB/cmd/treemap/leaf_generation_logical_rebuild_online.go
+++ b/TreeDB/cmd/treemap/leaf_generation_logical_rebuild_online.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+type leafGenerationLogicalRebuildRunSummary struct {
+	Dir                 string                                          `json:"dir"`
+	StartedAtUTC        string                                          `json:"started_at_utc"`
+	ElapsedMilliseconds int64                                           `json:"elapsed_ms"`
+	Before              leafGenerationLogicalRebuildDiskUsage           `json:"before"`
+	After               leafGenerationLogicalRebuildDiskUsage           `json:"after"`
+	Stats               treedb.LeafGenerationLogicalRebuildRunOnceStats `json:"stats"`
+}
+
+func runLeafGenerationLogicalRebuildRun(dir string, args []string) {
+	fs := flag.NewFlagSet("leafgen-logical-rebuild-run", flag.ExitOnError)
+	rw := fs.Bool("rw", false, "Open read-write (required)")
+	jsonOut := fs.Bool("json", false, "Emit JSON instead of human-readable text")
+	rawFileID := fs.Uint("raw-file-id", 0, "Optional raw sealed leaf file ID to rebuild (0=auto-select)")
+	maxPublishedCommitSeq := fs.Uint64("max-published-commit-seq", 0, "Optional maximum published commit sequence to consider (0=no limit)")
+	syncOut := fs.Bool("sync", true, "Sync created leaf segments before publishing")
+	_ = fs.Parse(args)
+
+	if !*rw {
+		fatalf("leafgen-logical-rebuild-run requires -rw")
+	}
+
+	rootDir := resolveTreeDBRootDir(dir)
+	before, err := leafGenerationLogicalRebuildDiskUsageForRoot(rootDir)
+	if err != nil {
+		fatalf("disk usage before logical rebuild run: %v", err)
+	}
+	db := openTreeDB(dir, true)
+	defer closeTreeDB(db)
+
+	started := time.Now()
+	stats, err := db.LeafGenerationLogicalRebuildRunOnce(context.Background(), treedb.LeafGenerationLogicalRebuildRunOnceOptions{
+		RawFileID:             uint32(*rawFileID),
+		MaxPublishedCommitSeq: *maxPublishedCommitSeq,
+		Sync:                  *syncOut,
+	})
+	if err != nil {
+		fatalf("LeafGenerationLogicalRebuildRunOnce error: %v", err)
+	}
+	after, err := leafGenerationLogicalRebuildDiskUsageForRoot(rootDir)
+	if err != nil {
+		fatalf("disk usage after logical rebuild run: %v", err)
+	}
+
+	summary := leafGenerationLogicalRebuildRunSummary{
+		Dir:                 rootDir,
+		StartedAtUTC:        started.UTC().Format(time.RFC3339),
+		ElapsedMilliseconds: time.Since(started).Milliseconds(),
+		Before:              before,
+		After:               after,
+		Stats:               stats,
+	}
+
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(summary); err != nil {
+			fatalf("encode logical rebuild run json: %v", err)
+		}
+		return
+	}
+
+	fmt.Printf(
+		"leafgen-logical-rebuild-run: raw_file=%d generation=%d leaf_before=%d leaf_after=%d app_before=%d app_after=%d runs=%d source_pages=%d replacement_pages=%d created=%v retired=%v catchup_passes=%d catchup_keys=%d cutover_keys=%d elapsed_ms=%d\n",
+		stats.SelectedRawFileID,
+		stats.SelectedGenerationID,
+		summary.Before.LeafVLogBytes,
+		summary.After.LeafVLogBytes,
+		summary.Before.ApplicationDBBytes,
+		summary.After.ApplicationDBBytes,
+		stats.SelectedRunCount,
+		stats.SourceLeafPages,
+		stats.ReplacementLeafPages,
+		stats.CreatedFileIDs,
+		stats.RetiredGenerationIDs,
+		stats.CatchupPasses,
+		stats.CatchupKeys,
+		stats.FinalCutoverKeys,
+		summary.ElapsedMilliseconds,
+	)
+}

--- a/TreeDB/cmd/treemap/leaf_generation_logical_rebuild_online.go
+++ b/TreeDB/cmd/treemap/leaf_generation_logical_rebuild_online.go
@@ -26,7 +26,7 @@ func runLeafGenerationLogicalRebuildRun(dir string, args []string) {
 	jsonOut := fs.Bool("json", false, "Emit JSON instead of human-readable text")
 	rawFileID := fs.Uint("raw-file-id", 0, "Optional raw sealed leaf file ID to rebuild (0=auto-select)")
 	maxPublishedCommitSeq := fs.Uint64("max-published-commit-seq", 0, "Optional maximum published commit sequence to consider (0=no limit)")
-	clusterFilesMax := fs.Int("cluster-files-max", 4, "Maximum fully-covered sealed source files to include in one contiguous rebuild window")
+	clusterFilesMax := fs.Int("cluster-files-max", 4, "Maximum fully-covered sealed source files to include in a rebuild run")
 	candidateTryMax := fs.Int("candidate-try-max", 8, "Maximum candidate units to try before stopping")
 	syncOut := fs.Bool("sync", true, "Sync created leaf segments before publishing")
 	_ = fs.Parse(args)

--- a/TreeDB/cmd/treemap/leaf_generation_logical_rebuild_online.go
+++ b/TreeDB/cmd/treemap/leaf_generation_logical_rebuild_online.go
@@ -26,6 +26,8 @@ func runLeafGenerationLogicalRebuildRun(dir string, args []string) {
 	jsonOut := fs.Bool("json", false, "Emit JSON instead of human-readable text")
 	rawFileID := fs.Uint("raw-file-id", 0, "Optional raw sealed leaf file ID to rebuild (0=auto-select)")
 	maxPublishedCommitSeq := fs.Uint64("max-published-commit-seq", 0, "Optional maximum published commit sequence to consider (0=no limit)")
+	clusterFilesMax := fs.Int("cluster-files-max", 4, "Maximum fully-covered sealed source files to include in one contiguous rebuild window")
+	candidateTryMax := fs.Int("candidate-try-max", 8, "Maximum candidate units to try before stopping")
 	syncOut := fs.Bool("sync", true, "Sync created leaf segments before publishing")
 	_ = fs.Parse(args)
 
@@ -45,6 +47,8 @@ func runLeafGenerationLogicalRebuildRun(dir string, args []string) {
 	stats, err := db.LeafGenerationLogicalRebuildRunOnce(context.Background(), treedb.LeafGenerationLogicalRebuildRunOnceOptions{
 		RawFileID:             uint32(*rawFileID),
 		MaxPublishedCommitSeq: *maxPublishedCommitSeq,
+		ClusterFilesMax:       *clusterFilesMax,
+		CandidateTryMax:       *candidateTryMax,
 		Sync:                  *syncOut,
 	})
 	if err != nil {

--- a/TreeDB/cmd/treemap/leaf_generation_test.go
+++ b/TreeDB/cmd/treemap/leaf_generation_test.go
@@ -41,3 +41,9 @@ func TestUsageTextMentionsLeafGenerationLogicalRebuildBench(t *testing.T) {
 		t.Fatalf("usageText missing leafgen-logical-rebuild-bench command: %q", got)
 	}
 }
+
+func TestUsageTextMentionsLeafGenerationLogicalRebuildRun(t *testing.T) {
+	if got := usageText; !strings.Contains(got, "leafgen-logical-rebuild-run") {
+		t.Fatalf("usageText missing leafgen-logical-rebuild-run command: %q", got)
+	}
+}

--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -46,6 +46,8 @@ Commands:
   leafgen-plan    Print explicit leaf-generation pack plan
   leafgen-pack    Pack sealed leaf generations by id (requires -rw)
   leafgen-gc      Delete fully unreachable sealed leaf generations (requires -rw)
+  leafgen-logical-rebuild-run
+                  Rebuild one eligible sealed leaf run online (requires -rw)
   leafgen-logical-rebuild-bench
                   Rebuild outer-leaf pages logically on a frozen DB copy (requires -rw)
   get             Get a single key
@@ -112,6 +114,8 @@ func main() {
 		runLeafGenerationPack(dir, args)
 	case "leafgen-gc":
 		runLeafGenerationGC(dir, args)
+	case "leafgen-logical-rebuild-run":
+		runLeafGenerationLogicalRebuildRun(dir, args)
 	case "leafgen-logical-rebuild-bench":
 		runLeafGenerationLogicalRebuildBench(dir, args)
 	case "get":

--- a/TreeDB/db/closed_db_public_methods_test.go
+++ b/TreeDB/db/closed_db_public_methods_test.go
@@ -117,6 +117,12 @@ func TestClosedDB_VacuumIndexOnline(t *testing.T) {
 	})
 }
 
+func TestClosedDB_LeafGenerationLogicalRebuildRunOnce(t *testing.T) {
+	runClosedDBMethod(t, "LeafGenerationLogicalRebuildRunOnce", func(d *DB) {
+		_, _ = d.LeafGenerationLogicalRebuildRunOnce(context.Background(), LeafGenerationLogicalRebuildRunOnceOptions{})
+	})
+}
+
 func TestClosedDB_ValueLogRewriteOnline(t *testing.T) {
 	runClosedDBMethod(t, "ValueLogRewriteOnline", func(d *DB) {
 		_, _ = d.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{})

--- a/TreeDB/db/leaf_generation_logical_rebuild_online.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_online.go
@@ -34,6 +34,7 @@ type LeafGenerationLogicalRebuildRunOnceOptions struct {
 	CatchupPassesMax      int
 	CutoverMaxKeys        int
 	CutoverMaxDefers      int
+	ReserveRIDs           func(count int) (start uint64, err error)
 }
 
 type LeafGenerationLogicalRebuildRunOnceStats struct {
@@ -173,11 +174,17 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 	bakPath := filepath.Join(db.dir, indexBakFileName)
 	readyPath := filepath.Join(db.dir, indexReadyFileName)
 
+	db.vacuum.Start()
+	defer db.vacuum.Stop()
+
 	baseSnap := db.AcquireSnapshot()
-	if baseSnap == nil || baseSnap.idx == nil || baseSnap.state == nil || baseSnap.state.LeafGenerations == nil {
+	if baseSnap == nil {
 		return stats, fmt.Errorf("leaf logical rebuild: missing snapshot state")
 	}
 	defer func() { _ = baseSnap.Close() }()
+	if baseSnap.idx == nil || baseSnap.state == nil || baseSnap.state.LeafGenerations == nil {
+		return stats, fmt.Errorf("leaf logical rebuild: missing snapshot state")
+	}
 	stats.CommitSeqBefore = baseSnap.state.CommitSeq
 
 	candidates, baseChildren, err := db.selectLeafGenerationLogicalRebuildCandidates(baseSnap, opts.RawFileID, opts.MaxPublishedCommitSeq, opts.ClusterFilesMax)
@@ -199,6 +206,7 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 	sort.Ints(widths)
 
 	attempts := 0
+	var selected *leafLogicalRebuildCandidate
 	for _, width := range widths {
 		group := grouped[width]
 		limit := len(group)
@@ -214,27 +222,30 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 			if !estimate.admit() {
 				continue
 			}
-			stats, err = db.tryLeafGenerationLogicalRebuildCandidate(
-				ctx,
-				opts,
-				baseSnap,
-				baseChildren,
-				group[i],
-				indexPath,
-				newPath,
-				bakPath,
-				readyPath,
-			)
-			if err == nil {
-				stats.CandidateAttempts = attempts
-				return stats, nil
-			}
-			if !errors.Is(err, ErrLeafGenerationLogicalRebuildNoCandidate) {
-				return stats, err
-			}
+			candidate := group[i]
+			selected = &candidate
+			break
+		}
+		if selected != nil {
+			break
 		}
 	}
-	return stats, ErrLeafGenerationLogicalRebuildNoCandidate
+	if selected == nil {
+		return stats, ErrLeafGenerationLogicalRebuildNoCandidate
+	}
+	stats, err = db.tryLeafGenerationLogicalRebuildCandidate(
+		ctx,
+		opts,
+		baseSnap,
+		baseChildren,
+		*selected,
+		indexPath,
+		newPath,
+		bakPath,
+		readyPath,
+	)
+	stats.CandidateAttempts = attempts
+	return stats, err
 }
 
 func (e leafLogicalRebuildPilotEstimate) admit() bool {
@@ -377,7 +388,10 @@ func (db *DB) tryLeafGenerationLogicalRebuildCandidate(
 		return stats, fmt.Errorf("leaf logical rebuild: value-log set unavailable")
 	}
 	leafStartSeq := maxRewriteLaneSeqFromSet(set, rewriteLeafLogLaneID)
-	nextRID, err := nextRewriteRIDStartFromSet(set)
+	nextRID := uint64(0)
+	if opts.ReserveRIDs == nil {
+		nextRID, err = nextRewriteRIDStartFromSet(set)
+	}
 	_ = db.valueLogManager.Release(set)
 	if err != nil {
 		return stats, err
@@ -390,6 +404,7 @@ func (db *DB) tryLeafGenerationLogicalRebuildCandidate(
 	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
 	writer.leafBlockCodec = leafPageBlockCodecFromOptions(db.valueLogCompression, db.valueLogAutoPolicy, db.valueLogBlockCodec, db.indexOuterLeavesInValueLog)
 	writer.nextRID = nextRID
+	writer.ridAlloc = newRewriteRIDAllocator(nextRID, opts.ReserveRIDs)
 	writerOpen := true
 	published := false
 	cleanupCreated := func(baseErr error) error {
@@ -433,9 +448,6 @@ func (db *DB) tryLeafGenerationLogicalRebuildCandidate(
 		}
 	}
 	newZ.SetLeafPageLog(writer)
-
-	db.vacuum.Start()
-	defer db.vacuum.Stop()
 
 	runBuilds, recordsCopied, err := db.buildLogicalRebuildRuns(baseSnap, baseChildren, candidate, writer)
 	if err != nil {
@@ -547,7 +559,7 @@ func (db *DB) tryLeafGenerationLogicalRebuildCandidate(
 			db.writeMu.Unlock()
 			return stats, err
 		}
-		createdTotalBytes, err := leafGenerationLogicalRebuildCreatedLogBytes(createdSegments)
+		createdTotalBytes, err := leafGenerationLogicalRebuildCreatedTotalBytes(createdSegments)
 		if err != nil {
 			db.writeMu.Unlock()
 			return stats, err

--- a/TreeDB/db/leaf_generation_logical_rebuild_online.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_online.go
@@ -1,0 +1,810 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/freelist"
+	"github.com/snissn/gomap/TreeDB/internal/bulk"
+	"github.com/snissn/gomap/TreeDB/internal/compression"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
+	"github.com/snissn/gomap/TreeDB/tree"
+	"github.com/snissn/gomap/TreeDB/zipper"
+)
+
+var ErrLeafGenerationLogicalRebuildNoCandidate = errors.New("leaf logical rebuild: no eligible sealed single-file candidate")
+
+type LeafGenerationLogicalRebuildRunOnceOptions struct {
+	RawFileID             uint32
+	MaxPublishedCommitSeq uint64
+	Sync                  bool
+	CatchupPassesMax      int
+	CutoverMaxKeys        int
+	CutoverMaxDefers      int
+}
+
+type LeafGenerationLogicalRebuildRunOnceStats struct {
+	CommitSeqBefore uint64
+	CommitSeqAfter  uint64
+
+	SelectedGenerationID uint64
+	SelectedRawFileID    uint32
+	SelectedFileID       uint32
+	SelectedRunCount     int
+	SourceLeafPages      int
+	SourceLeafBytes      int64
+
+	ReplacementLeafPages int
+	RecordsCopied        int
+	BytesCopied          int64
+
+	CreatedFileIDs       []uint32
+	RetiredGenerationIDs []uint64
+
+	CatchupPasses    int
+	CatchupKeys      int
+	FinalCutoverKeys int
+	CutoverDefers    int
+
+	WallTimeNanos int64
+}
+
+type leafLogicalRebuildCandidate struct {
+	generationID uint64
+	rawFileID    uint32
+	fileID       uint32
+	runRanges    [][2]int
+	sourcePages  int
+	sourceBytes  int64
+}
+
+type leafLogicalRebuildRunBuild struct {
+	startIndex  int
+	endIndex    int
+	startKey    []byte
+	endKey      []byte
+	replacement []vacuumLeafChild
+}
+
+func normalizeLeafGenerationLogicalRebuildRunOnceOptions(opts LeafGenerationLogicalRebuildRunOnceOptions) LeafGenerationLogicalRebuildRunOnceOptions {
+	if opts.CatchupPassesMax <= 0 {
+		opts.CatchupPassesMax = vacuumCatchupPassesMax
+	}
+	if opts.CutoverMaxKeys <= 0 {
+		opts.CutoverMaxKeys = vacuumCutoverMaxKeys
+	}
+	if opts.CutoverMaxDefers <= 0 {
+		opts.CutoverMaxDefers = vacuumCutoverMaxDefers
+	}
+	return opts
+}
+
+func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts LeafGenerationLogicalRebuildRunOnceOptions) (stats LeafGenerationLogicalRebuildRunOnceStats, err error) {
+	if db == nil {
+		return stats, fmt.Errorf("missing db")
+	}
+	if db.readOnly {
+		return stats, ErrReadOnly
+	}
+	if !db.indexOuterLeavesInValueLog {
+		return stats, nil
+	}
+	if db.valueLogManager == nil {
+		return stats, fmt.Errorf("leaf logical rebuild: value log manager unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if runtime.GOOS == "windows" {
+		return stats, ErrVacuumUnsupported
+	}
+	opts = normalizeLeafGenerationLogicalRebuildRunOnceOptions(opts)
+
+	started := time.Now()
+	defer func() {
+		stats.WallTimeNanos = time.Since(started).Nanoseconds()
+	}()
+
+	db.maintenanceMu.Lock()
+	defer db.maintenanceMu.Unlock()
+	if !db.vacuumInProgress.CompareAndSwap(false, true) {
+		return stats, ErrVacuumInProgress
+	}
+	defer db.vacuumInProgress.Store(false)
+
+	if err := ctx.Err(); err != nil {
+		return stats, err
+	}
+	if err := db.publishValueLogSetNoRefresh(); err != nil {
+		return stats, err
+	}
+
+	indexPath := filepath.Join(db.dir, indexFileName)
+	newPath := filepath.Join(db.dir, indexNewFileName)
+	bakPath := filepath.Join(db.dir, indexBakFileName)
+	readyPath := filepath.Join(db.dir, indexReadyFileName)
+	_ = os.Remove(newPath)
+	_ = os.Remove(readyPath)
+
+	newPager, err := pager.Open(newPath, db.chunkSize)
+	if err != nil {
+		return stats, err
+	}
+	pagerOpen := true
+	cleanupNewPager := func() {
+		if pagerOpen {
+			_ = newPager.Close()
+		}
+		_ = os.Remove(newPath)
+		_ = os.Remove(readyPath)
+	}
+	defer func() {
+		if err != nil {
+			cleanupNewPager()
+		}
+	}()
+
+	if _, err = newPager.Alloc(2); err != nil {
+		return stats, err
+	}
+	newAlloc := freelist.New(newPager, 0)
+	newAlloc.SetPreferAppend(db.preferAppendAlloc)
+	newAlloc.SetFreelistRegion(db.freelistRegionPages, db.freelistRegionRadius)
+
+	newZ := zipper.New(newPager, newAlloc)
+	newZ.SetFillTargets(db.leafFillTargetPPM, db.internalFillTargetPPM)
+	newZ.SetPiggybackCompaction(db.piggybackCompaction)
+	newZ.SetLeafPrefixCompression(db.leafPrefixCompression)
+	newZ.SetIndexColumnarLeaves(db.indexColumnarLeaves)
+	newZ.SetIndexPackedValuePtr(db.indexPackedValuePtr)
+	newZ.SetIndexInternalBaseDelta(db.indexInternalBaseDelta)
+	newZ.SetAdaptiveLeafEncoding(db.indexAdaptiveLeafEncoding)
+	newZ.SetMaintenanceOpsPerCoalesce(db.maintenanceOpsPerCoalesce)
+	newZ.SetLeafPageReader(db.valueLogManager)
+	newZ.SetOuterLeavesInValueLog(db.indexOuterLeavesInValueLog)
+	db.idxMu.Lock()
+	parallelMergePressureSource := db.zipperParallelMergeSource
+	db.idxMu.Unlock()
+	newZ.SetParallelMergePressureSource(parallelMergePressureSource)
+
+	set := db.valueLogManager.CurrentSetNoRefresh()
+	if set == nil || len(set.Files) == 0 {
+		if set != nil {
+			_ = db.valueLogManager.Release(set)
+		}
+		if err := db.valueLogManager.Refresh(); err != nil {
+			return stats, err
+		}
+		set = db.valueLogManager.CurrentSetNoRefresh()
+	}
+	if set == nil {
+		return stats, fmt.Errorf("leaf logical rebuild: value-log set unavailable")
+	}
+	leafStartSeq := maxRewriteLaneSeqFromSet(set, rewriteLeafLogLaneID)
+	nextRID, err := nextRewriteRIDStartFromSet(set)
+	_ = db.valueLogManager.Release(set)
+	if err != nil {
+		return stats, err
+	}
+
+	layout := resolveStorageLayout(db.dir)
+	writer := newRewriteWriter(layout.valueVLogDir, 0, 0, 0)
+	writer.ConfigureLeafLog(layout.leafVLogDir, rewriteLeafLogLaneID, leafStartSeq)
+	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
+	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
+	writer.leafBlockCodec = leafPageBlockCodecFromOptions(db.valueLogCompression, db.valueLogAutoPolicy, db.valueLogBlockCodec, db.indexOuterLeavesInValueLog)
+	writer.nextRID = nextRID
+	writerOpen := true
+	cleanupCreated := func(baseErr error) error {
+		closeErr := error(nil)
+		if writerOpen {
+			closeErr = writer.Close()
+			writerOpen = false
+		}
+		createdSegments, segErr := writer.createdSegmentsSnapshot()
+		if segErr != nil {
+			return errors.Join(baseErr, closeErr, segErr)
+		}
+		cleanupErr := db.cleanupRewriteCreatedSegments(createdSegments)
+		return errors.Join(baseErr, closeErr, cleanupErr)
+	}
+	defer func() {
+		if err != nil {
+			err = cleanupCreated(err)
+		} else if writerOpen {
+			_ = writer.Close()
+		}
+	}()
+
+	if writer.blockCompression {
+		state := db.state.Load()
+		if state != nil {
+			leafDictID, leafDictBytes, leafDictUseRawPages, dictErr := prepareRewriteLeafDict(db, state, db.valueLogDictCurrentForClass, db.valueLogDictLeafPayloadMode, db.valueLogDictLookup, db.valueLogDictPut, db.valueLogDictSetCurrentForClass, db.valueLogDictSetLeafPayloadMode, compression.TrainConfig{})
+			if dictErr != nil {
+				return stats, dictErr
+			}
+			if leafDictID != 0 && len(leafDictBytes) > 0 {
+				writer.SetLeafDictMode(leafDictID, leafDictBytes, leafDictUseRawPages)
+			}
+		}
+	}
+	newZ.SetLeafPageLog(writer)
+
+	db.vacuum.Start()
+	defer db.vacuum.Stop()
+
+	baseSnap := db.AcquireSnapshot()
+	if baseSnap == nil || baseSnap.idx == nil || baseSnap.state == nil || baseSnap.state.LeafGenerations == nil {
+		closeRewriteSnapshot(&err, baseSnap)
+		return stats, fmt.Errorf("leaf logical rebuild: missing snapshot state")
+	}
+	stats.CommitSeqBefore = baseSnap.state.CommitSeq
+
+	candidate, baseChildren, err := db.selectLeafGenerationLogicalRebuildCandidate(baseSnap, opts.RawFileID, opts.MaxPublishedCommitSeq)
+	if err != nil {
+		closeRewriteSnapshot(&err, baseSnap)
+		return stats, err
+	}
+	stats.SelectedGenerationID = candidate.generationID
+	stats.SelectedRawFileID = candidate.rawFileID
+	stats.SelectedFileID = candidate.fileID
+	stats.SelectedRunCount = len(candidate.runRanges)
+	stats.SourceLeafPages = candidate.sourcePages
+	stats.SourceLeafBytes = candidate.sourceBytes
+	stats.BytesCopied = candidate.sourceBytes
+
+	runBuilds, recordsCopied, err := db.buildLogicalRebuildRuns(baseSnap, candidate, writer)
+	if err != nil {
+		closeRewriteSnapshot(&err, baseSnap)
+		return stats, err
+	}
+	stats.RecordsCopied = recordsCopied
+
+	modifiedChildren := append([]vacuumLeafChild(nil), baseChildren...)
+	shift := 0
+	for _, runBuild := range runBuilds {
+		startIndex := runBuild.startIndex + shift
+		endIndex := runBuild.endIndex + shift
+		beforeLen := endIndex - startIndex + 1
+		modifiedChildren = slices.Replace(modifiedChildren, startIndex, endIndex+1, runBuild.replacement...)
+		shift += len(runBuild.replacement) - beforeLen
+		stats.ReplacementLeafPages += len(runBuild.replacement)
+	}
+
+	newRoot, err := leafGenerationLogicalRebuildRootFromChildren(newPager, newAlloc, modifiedChildren, db.indexInternalBaseDelta)
+	_ = baseSnap.Close()
+	baseSnap = nil
+	if err != nil {
+		return stats, err
+	}
+
+	applyCatchup := func(opsMap map[string]batch.Entry) error {
+		var retired []uint64
+		newRoot, retired, err = db.applyVacuumDelta(newRoot, opsMap, newZ, nil)
+		if err != nil {
+			return err
+		}
+		for _, id := range retired {
+			_ = newAlloc.Free(id)
+		}
+		return nil
+	}
+
+	for pass := 0; pass < opts.CatchupPassesMax; pass++ {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		opsMap := db.vacuum.Drain()
+		if len(opsMap) == 0 {
+			break
+		}
+		stats.CatchupPasses++
+		stats.CatchupKeys += len(opsMap)
+		if err := applyCatchup(opsMap); err != nil {
+			return stats, err
+		}
+		if err := writer.Flush(); err != nil {
+			return stats, err
+		}
+		if len(opsMap) <= vacuumCatchupKeyTarget {
+			break
+		}
+	}
+
+	defers := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+
+		db.writeMu.Lock()
+		db.vacuum.Stop()
+		finalOps := db.vacuum.Drain()
+		stats.FinalCutoverKeys = len(finalOps)
+		if len(finalOps) > opts.CutoverMaxKeys && defers < opts.CutoverMaxDefers {
+			db.vacuum.Start()
+			db.writeMu.Unlock()
+			defers++
+			stats.CutoverDefers++
+			if err := applyCatchup(finalOps); err != nil {
+				return stats, err
+			}
+			if err := writer.Flush(); err != nil {
+				return stats, err
+			}
+			continue
+		}
+		if len(finalOps) > 0 {
+			if err := applyCatchup(finalOps); err != nil {
+				db.writeMu.Unlock()
+				return stats, err
+			}
+		}
+
+		if err := writer.Sync(); err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		createdSegments, err := writer.createdSegmentsSnapshot()
+		if err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		createdLeafBytes, err := leafGenerationLogicalRebuildCreatedBytes(createdSegments)
+		if err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		if createdLeafBytes >= candidate.sourceBytes {
+			db.writeMu.Unlock()
+			if cleanupErr := cleanupCreated(nil); cleanupErr != nil {
+				return stats, cleanupErr
+			}
+			return stats, ErrLeafGenerationLogicalRebuildNoCandidate
+		}
+		createdIDs, err := writer.createdFileIDs()
+		if err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		for _, seg := range createdSegments {
+			if err := db.valueLogManager.RegisterSegment(seg.path, seg.fileID); err != nil {
+				db.writeMu.Unlock()
+				return stats, cleanupCreated(err)
+			}
+		}
+
+		db.mu.RLock()
+		oldGen := db.idx.Load()
+		state := db.state.Load()
+		baseMeta := db.meta
+		currentManifest := db.leafGenerationManifest
+		db.mu.RUnlock()
+		if oldGen == nil || state == nil || currentManifest == nil {
+			db.writeMu.Unlock()
+			return stats, fmt.Errorf("leaf logical rebuild: missing db state")
+		}
+
+		newSysRoot, err := vacuumClonePagerTreeWithLeafRefs(oldGen.pager, state.SystemRootPageID, newAlloc, newPager)
+		if err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+
+		nextMeta := baseMeta
+		nextMeta.CommitSeq++
+		nextMeta.UserRootPageID = newRoot
+		nextMeta.SystemRootPageID = newSysRoot
+		nextMeta.FreelistHeadID = newAlloc.Head()
+		nextMeta.TotalPages = newPager.PageCount()
+		stats.CommitSeqAfter = nextMeta.CommitSeq
+
+		stagedManifest := currentManifest.clone()
+		rawCreated, changed, err := noteCreatedLeafGenerationFileIDsInManifest(stagedManifest, nextMeta.CommitSeq, createdIDs)
+		if err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		if !changed {
+			db.writeMu.Unlock()
+			return stats, fmt.Errorf("leaf logical rebuild: created no new leaf generations")
+		}
+		retiredGenerationIDs, err := retireWholeLeafGenerationInManifest(stagedManifest, candidate.generationID, nextMeta.CommitSeq)
+		if err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		stats.RetiredGenerationIDs = append(stats.RetiredGenerationIDs[:0], retiredGenerationIDs...)
+
+		if err := writeMetaToPager(newPager, MetaPage0ID, nextMeta); err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		if err := writeMetaToPager(newPager, MetaPage1ID, nextMeta); err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		if err := newPager.Sync(); err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		if err := os.WriteFile(readyPath, []byte("ready\n"), 0o644); err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		if runtime.GOOS != "windows" {
+			if dir, err := os.Open(db.dir); err == nil {
+				_ = dir.Sync()
+				_ = dir.Close()
+			}
+		}
+
+		_ = os.Remove(bakPath)
+		if err := os.Rename(indexPath, bakPath); err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		if err := os.Rename(newPath, indexPath); err != nil {
+			_ = os.Rename(bakPath, indexPath)
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		_ = os.Remove(readyPath)
+		_ = os.Remove(bakPath)
+		if runtime.GOOS != "windows" {
+			if dir, err := os.Open(db.dir); err == nil {
+				_ = dir.Sync()
+				_ = dir.Close()
+			}
+		}
+
+		newZ.SetLeafPageReader(db.valueLogManager)
+		newZ.SetLeafPageLog(db.leafPageLog)
+		newZ.SetOuterLeavesInValueLog(db.indexOuterLeavesInValueLog)
+
+		newGen := newIndexGen(db.nextIndexID(), newPager, newAlloc, newZ)
+		db.trackIndex(newGen)
+
+		var oldState *DBState
+		db.mu.Lock()
+		oldState = db.state.Load()
+		db.idx.Store(newGen)
+		db.meta = nextMeta
+		db.metaPageID = MetaPage0ID
+		db.leafGenerationManifest = stagedManifest
+		newState := &DBState{
+			CommitSeq:                  nextMeta.CommitSeq,
+			RootPageID:                 nextMeta.UserRootPageID,
+			SystemRootPageID:           nextMeta.SystemRootPageID,
+			ValueLogSet:                db.valueLogManager.CurrentSetNoRefresh(),
+			LeafGenerations:            newLeafGenerationView(stagedManifest),
+			LeafGenerationStateVersion: db.leafGenerationStateVersion + 1,
+		}
+		db.leafGenerationStateVersion++
+		db.state.Store(newState)
+		db.publishSnapshotView(newGen, newState, db.valueLogManager)
+		db.mu.Unlock()
+		db.clearLeafGenerationReachabilityCaches()
+		db.writeMu.Unlock()
+
+		if oldState != nil {
+			_ = db.valueLogManager.Release(oldState.ValueLogSet)
+		}
+		db.releaseIndex(oldGen)
+		pagerOpen = false
+
+		if err := db.persistLeafGenerationManifestAndRecordLengthIndexes(stagedManifest, rawCreated); err != nil {
+			return stats, err
+		}
+		writerOpen = false
+		_ = writer.Close()
+		stats.CreatedFileIDs = append([]uint32(nil), createdIDs...)
+		return stats, nil
+	}
+}
+
+func retireWholeLeafGenerationInManifest(manifest *leafGenerationManifest, generationID, commitSeq uint64) ([]uint64, error) {
+	if manifest == nil || generationID == 0 || commitSeq == 0 {
+		return nil, nil
+	}
+	for i := range manifest.Generations {
+		gen := &manifest.Generations[i]
+		if gen.GenerationID != generationID {
+			continue
+		}
+		if gen.State != leafGenerationStateSealed {
+			return nil, fmt.Errorf("leaf logical rebuild: generation %d state=%q, want %q", generationID, gen.State, leafGenerationStateSealed)
+		}
+		gen.State = leafGenerationStateRetiring
+		if commitSeq > gen.RetiredCommitSeq {
+			gen.RetiredCommitSeq = commitSeq
+		}
+		return []uint64{generationID}, nil
+	}
+	return nil, fmt.Errorf("leaf logical rebuild: generation %d not found", generationID)
+}
+
+func (db *DB) selectLeafGenerationLogicalRebuildCandidate(snap *Snapshot, requestedRawFileID uint32, maxPublishedCommitSeq uint64) (leafLogicalRebuildCandidate, []vacuumLeafChild, error) {
+	var zero leafLogicalRebuildCandidate
+	if snap == nil || snap.idx == nil || snap.state == nil || snap.state.LeafGenerations == nil {
+		return zero, nil, fmt.Errorf("leaf logical rebuild: missing snapshot state")
+	}
+	rootID := snap.state.RootPageID
+	var children []vacuumLeafChild
+	if _, ok := page.DecodeLeafRef(rootID); ok {
+		children = []vacuumLeafChild{{key: []byte{}, childID: rootID}}
+	} else {
+		var err error
+		children, err = vacuumCollectLeafRefChildren(snap.idx.pager, rootID)
+		if err != nil {
+			return zero, nil, err
+		}
+	}
+	if len(children) == 0 {
+		return zero, nil, ErrLeafGenerationLogicalRebuildNoCandidate
+	}
+
+	type fileAccum struct {
+		generationID uint64
+		runRanges    [][2]int
+		sourcePages  int
+		sourceBytes  int64
+	}
+	accumByRaw := make(map[uint32]*fileAccum)
+	view := snap.state.LeafGenerations
+	manifestByGen := make(map[uint64]leafGenerationRecord, len(db.leafGenerationManifest.Generations))
+	if db.leafGenerationManifest != nil {
+		for _, gen := range db.leafGenerationManifest.Generations {
+			manifestByGen[gen.GenerationID] = gen
+		}
+	}
+
+	currentRaw := uint32(0)
+	runStart := -1
+	finishRun := func(end int) {
+		if runStart < 0 || currentRaw == 0 {
+			runStart = -1
+			currentRaw = 0
+			return
+		}
+		accum := accumByRaw[currentRaw]
+		if accum != nil {
+			accum.runRanges = append(accum.runRanges, [2]int{runStart, end})
+		}
+		runStart = -1
+		currentRaw = 0
+	}
+
+	for i, child := range children {
+		ptr, ok := page.DecodeLeafRef(child.childID)
+		if !ok {
+			return zero, nil, fmt.Errorf("leaf logical rebuild: child %d is not a leaf ref", i)
+		}
+		rawFileID := page.ValueLogSegmentID(ptr.ValueLogFileID())
+		generationID := view.FileToGeneration[rawFileID]
+		gen, ok := manifestByGen[generationID]
+		if !ok || gen.State != leafGenerationStateSealed || len(gen.FileIDs) != 1 {
+			if rawFileID == currentRaw {
+				finishRun(i - 1)
+			}
+			continue
+		}
+		if maxPublishedCommitSeq != 0 && gen.PublishedCommitSeq > maxPublishedCommitSeq {
+			if rawFileID == currentRaw {
+				finishRun(i - 1)
+			}
+			continue
+		}
+		if requestedRawFileID != 0 && rawFileID != requestedRawFileID {
+			if rawFileID == currentRaw {
+				finishRun(i - 1)
+			}
+			continue
+		}
+		accum := accumByRaw[rawFileID]
+		if accum == nil {
+			accum = &fileAccum{
+				generationID: generationID,
+				sourceBytes:  leafGenerationLogicalRebuildFileSize(db.dir, rawFileID),
+			}
+			accumByRaw[rawFileID] = accum
+		}
+		accum.sourcePages++
+		if currentRaw != rawFileID {
+			if currentRaw != 0 {
+				finishRun(i - 1)
+			}
+			currentRaw = rawFileID
+			runStart = i
+		}
+	}
+	if currentRaw != 0 {
+		finishRun(len(children) - 1)
+	}
+
+	best := zero
+	bestPages := -1
+	bestBytes := int64(-1)
+	for rawFileID, accum := range accumByRaw {
+		if accum == nil || len(accum.runRanges) == 0 || accum.sourcePages == 0 {
+			continue
+		}
+		if accum.sourcePages > bestPages || (accum.sourcePages == bestPages && accum.sourceBytes > bestBytes) {
+			best = leafLogicalRebuildCandidate{
+				generationID: accum.generationID,
+				rawFileID:    rawFileID,
+				fileID:       page.ValueLogFileID(rawFileID),
+				runRanges:    append([][2]int(nil), accum.runRanges...),
+				sourcePages:  accum.sourcePages,
+				sourceBytes:  accum.sourceBytes,
+			}
+			bestPages = accum.sourcePages
+			bestBytes = accum.sourceBytes
+		}
+	}
+	if best.rawFileID == 0 {
+		return zero, nil, ErrLeafGenerationLogicalRebuildNoCandidate
+	}
+	return best, children, nil
+}
+
+func leafGenerationLogicalRebuildFileSize(dir string, rawFileID uint32) int64 {
+	if dir == "" || rawFileID == 0 {
+		return 0
+	}
+	path := leafGenerationFallbackPath(dir, rawFileID)
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
+func leafGenerationLogicalRebuildCreatedBytes(segments []rewriteCreatedSegment) (int64, error) {
+	var total int64
+	for _, seg := range segments {
+		if seg.path == "" {
+			continue
+		}
+		info, err := os.Stat(seg.path)
+		if err != nil {
+			return 0, err
+		}
+		total += info.Size()
+	}
+	return total, nil
+}
+
+func (db *DB) buildLogicalRebuildRuns(baseSnap *Snapshot, candidate leafLogicalRebuildCandidate, writer *rewriteWriter) ([]leafLogicalRebuildRunBuild, int, error) {
+	if baseSnap == nil || baseSnap.idx == nil {
+		return nil, 0, fmt.Errorf("leaf logical rebuild: missing base snapshot")
+	}
+	if len(candidate.runRanges) == 0 {
+		return nil, 0, fmt.Errorf("leaf logical rebuild: candidate has no runs")
+	}
+	rootID := baseSnap.state.RootPageID
+	var baseChildren []vacuumLeafChild
+	if _, ok := page.DecodeLeafRef(rootID); ok {
+		baseChildren = []vacuumLeafChild{{key: []byte{}, childID: rootID}}
+	} else {
+		var err error
+		baseChildren, err = vacuumCollectLeafRefChildren(baseSnap.idx.pager, rootID)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	out := make([]leafLogicalRebuildRunBuild, 0, len(candidate.runRanges))
+	totalRecords := 0
+	for _, rr := range candidate.runRanges {
+		startIndex := rr[0]
+		endIndex := rr[1]
+		startKey, endKey := leafGenerationLogicalRebuildRunBounds(baseChildren, startIndex, endIndex)
+		tempPath, err := leafGenerationLogicalRebuildTempPagerPath()
+		if err != nil {
+			return nil, 0, err
+		}
+		tempPager, err := pager.Open(tempPath, db.chunkSize)
+		if err != nil {
+			_ = os.Remove(tempPath)
+			return nil, 0, err
+		}
+		if _, err := tempPager.Alloc(2); err != nil {
+			_ = tempPager.Close()
+			_ = os.Remove(tempPath)
+			return nil, 0, err
+		}
+		alloc := &pagerAllocator{p: tempPager}
+		beforeRecords := writer.records
+		iter := baseSnap.tree.IteratorWithOptions(startKey, endKey, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+		buildOpts := bulk.BuildOptions{
+			LeafPrefixCompression: db.leafPrefixCompression,
+			LeafColumnar:          db.indexColumnarLeaves,
+			PackedValuePtr:        db.indexPackedValuePtr,
+			InternalBaseDelta:     db.indexInternalBaseDelta,
+			LeafPageLog:           writer,
+		}
+		rootID, err := bulk.BuildWithOptions(iter, alloc, tempPager, buildOpts)
+		_ = iter.Close()
+		if err != nil {
+			_ = tempPager.Close()
+			_ = os.Remove(tempPath)
+			return nil, 0, err
+		}
+		if err := writer.flushPendingDictBatch(); err != nil {
+			_ = tempPager.Close()
+			_ = os.Remove(tempPath)
+			return nil, 0, err
+		}
+		children, err := leafGenerationLogicalRebuildChildrenForRoot(tempPager, rootID, startKey)
+		if err != nil {
+			_ = tempPager.Close()
+			_ = os.Remove(tempPath)
+			return nil, 0, err
+		}
+		out = append(out, leafLogicalRebuildRunBuild{
+			startIndex:  startIndex,
+			endIndex:    endIndex,
+			startKey:    append([]byte(nil), startKey...),
+			endKey:      append([]byte(nil), endKey...),
+			replacement: children,
+		})
+		totalRecords += writer.records - beforeRecords
+		_ = tempPager.Close()
+		_ = os.Remove(tempPath)
+	}
+	return out, totalRecords, nil
+}
+
+func leafGenerationLogicalRebuildRunBounds(children []vacuumLeafChild, startIndex, endIndex int) ([]byte, []byte) {
+	if startIndex < 0 || startIndex >= len(children) {
+		return nil, nil
+	}
+	startKey := append([]byte(nil), children[startIndex].key...)
+	if endIndex+1 < len(children) {
+		return startKey, append([]byte(nil), children[endIndex+1].key...)
+	}
+	return startKey, nil
+}
+
+func leafGenerationLogicalRebuildTempPagerPath() (string, error) {
+	f, err := os.CreateTemp("", "treedb-leaf-logical-run-*.index")
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
+}
+
+func leafGenerationLogicalRebuildChildrenForRoot(p *pager.Pager, rootID uint64, startKey []byte) ([]vacuumLeafChild, error) {
+	if _, ok := page.DecodeLeafRef(rootID); ok {
+		return []vacuumLeafChild{{
+			key:     append([]byte(nil), startKey...),
+			childID: rootID,
+		}}, nil
+	}
+	return vacuumCollectLeafRefChildren(p, rootID)
+}
+
+func leafGenerationLogicalRebuildRootFromChildren(p *pager.Pager, alloc interface {
+	Alloc(hint uint64) (uint64, error)
+}, children []vacuumLeafChild, internalBaseDelta bool) (uint64, error) {
+	if len(children) == 0 {
+		return 0, fmt.Errorf("leaf logical rebuild: no replacement children")
+	}
+	if len(children) == 1 {
+		return children[0].childID, nil
+	}
+	return vacuumBuildInternalTreeFromChildren(p, alloc, children, internalBaseDelta)
+}

--- a/TreeDB/db/leaf_generation_logical_rebuild_online.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_online.go
@@ -391,6 +391,7 @@ func (db *DB) tryLeafGenerationLogicalRebuildCandidate(
 	writer.leafBlockCodec = leafPageBlockCodecFromOptions(db.valueLogCompression, db.valueLogAutoPolicy, db.valueLogBlockCodec, db.indexOuterLeavesInValueLog)
 	writer.nextRID = nextRID
 	writerOpen := true
+	published := false
 	cleanupCreated := func(baseErr error) error {
 		closeErr := error(nil)
 		if writerOpen {
@@ -406,7 +407,14 @@ func (db *DB) tryLeafGenerationLogicalRebuildCandidate(
 	}
 	defer func() {
 		if err != nil {
-			err = cleanupCreated(err)
+			if published {
+				if writerOpen {
+					err = errors.Join(err, writer.Close())
+					writerOpen = false
+				}
+			} else {
+				err = cleanupCreated(err)
+			}
 		} else if writerOpen {
 			_ = writer.Close()
 		}
@@ -513,9 +521,16 @@ func (db *DB) tryLeafGenerationLogicalRebuildCandidate(
 			}
 		}
 
-		if err := writer.Sync(); err != nil {
-			db.writeMu.Unlock()
-			return stats, err
+		if opts.Sync {
+			if err := writer.Sync(); err != nil {
+				db.writeMu.Unlock()
+				return stats, err
+			}
+		} else {
+			if err := writer.Flush(); err != nil {
+				db.writeMu.Unlock()
+				return stats, err
+			}
 		}
 		createdSegments, err := writer.createdSegmentsSnapshot()
 		if err != nil {
@@ -532,7 +547,7 @@ func (db *DB) tryLeafGenerationLogicalRebuildCandidate(
 			db.writeMu.Unlock()
 			return stats, err
 		}
-		createdTotalBytes, err := leafGenerationLogicalRebuildCreatedTotalBytes(createdSegments)
+		createdTotalBytes, err := leafGenerationLogicalRebuildCreatedLogBytes(createdSegments)
 		if err != nil {
 			db.writeMu.Unlock()
 			return stats, err
@@ -662,6 +677,7 @@ func (db *DB) tryLeafGenerationLogicalRebuildCandidate(
 		db.state.Store(newState)
 		db.publishSnapshotView(newGen, newState, db.valueLogManager)
 		db.mu.Unlock()
+		published = true
 		db.clearLeafGenerationReachabilityCaches()
 		db.writeMu.Unlock()
 
@@ -743,7 +759,11 @@ func (db *DB) selectLeafGenerationLogicalRebuildCandidates(snap *Snapshot, reque
 	accumByRaw := make(map[uint32]*leafLogicalRebuildSource)
 	orderedRaw := make([]uint32, 0, 64)
 	view := snap.state.LeafGenerations
-	manifestByGen := make(map[uint64]leafGenerationRecord, len(db.leafGenerationManifest.Generations))
+	manifestCapacity := 0
+	if db.leafGenerationManifest != nil {
+		manifestCapacity = len(db.leafGenerationManifest.Generations)
+	}
+	manifestByGen := make(map[uint64]leafGenerationRecord, manifestCapacity)
 	if db.leafGenerationManifest != nil {
 		for _, gen := range db.leafGenerationManifest.Generations {
 			manifestByGen[gen.GenerationID] = gen
@@ -1064,6 +1084,21 @@ func leafGenerationLogicalRebuildCreatedTotalBytes(segments []rewriteCreatedSegm
 			return 0, err
 		}
 		total += leafGenerationRecordLengthIndexEncodedSize(idx)
+	}
+	return total, nil
+}
+
+func leafGenerationLogicalRebuildCreatedLogBytes(segments []rewriteCreatedSegment) (int64, error) {
+	var total int64
+	for _, seg := range segments {
+		if seg.path == "" {
+			continue
+		}
+		info, err := os.Stat(seg.path)
+		if err != nil {
+			return 0, err
+		}
+		total += info.Size()
 	}
 	return total, nil
 }

--- a/TreeDB/db/leaf_generation_logical_rebuild_online.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_online.go
@@ -98,12 +98,12 @@ type leafLogicalRebuildRunBuild struct {
 }
 
 type leafLogicalRebuildPilotEstimate struct {
-	sourceTotalBytes    int64
-	samplePages         int
-	sampleSourceBytes   int64
-	sampleCreatedBytes  int64
+	sourceTotalBytes      int64
+	samplePages           int
+	sampleSourceBytes     int64
+	sampleCreatedBytes    int64
 	estimatedCreatedBytes int64
-	minSavingsBytes     int64
+	minSavingsBytes       int64
 }
 
 func normalizeLeafGenerationLogicalRebuildRunOnceOptions(opts LeafGenerationLogicalRebuildRunOnceOptions) LeafGenerationLogicalRebuildRunOnceOptions {

--- a/TreeDB/db/leaf_generation_logical_rebuild_online.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_online.go
@@ -8,23 +8,27 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sort"
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/freelist"
 	"github.com/snissn/gomap/TreeDB/internal/bulk"
 	"github.com/snissn/gomap/TreeDB/internal/compression"
+	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/pager"
 	"github.com/snissn/gomap/TreeDB/tree"
 	"github.com/snissn/gomap/TreeDB/zipper"
 )
 
-var ErrLeafGenerationLogicalRebuildNoCandidate = errors.New("leaf logical rebuild: no eligible sealed single-file candidate")
+var ErrLeafGenerationLogicalRebuildNoCandidate = errors.New("leaf logical rebuild: no eligible sealed incremental candidate")
 
 type LeafGenerationLogicalRebuildRunOnceOptions struct {
 	RawFileID             uint32
 	MaxPublishedCommitSeq uint64
+	ClusterFilesMax       int
+	CandidateTryMax       int
 	Sync                  bool
 	CatchupPassesMax      int
 	CutoverMaxKeys        int
@@ -35,12 +39,16 @@ type LeafGenerationLogicalRebuildRunOnceStats struct {
 	CommitSeqBefore uint64
 	CommitSeqAfter  uint64
 
-	SelectedGenerationID uint64
-	SelectedRawFileID    uint32
-	SelectedFileID       uint32
-	SelectedRunCount     int
-	SourceLeafPages      int
-	SourceLeafBytes      int64
+	SelectedGenerationID  uint64
+	SelectedRawFileID     uint32
+	SelectedFileID        uint32
+	SelectedGenerationIDs []uint64
+	SelectedRawFileIDs    []uint32
+	SelectedFileIDs       []uint32
+	SelectedSourceFiles   int
+	SelectedRunCount      int
+	SourceLeafPages       int
+	SourceLeafBytes       int64
 
 	ReplacementLeafPages int
 	RecordsCopied        int
@@ -49,21 +57,33 @@ type LeafGenerationLogicalRebuildRunOnceStats struct {
 	CreatedFileIDs       []uint32
 	RetiredGenerationIDs []uint64
 
-	CatchupPasses    int
-	CatchupKeys      int
-	FinalCutoverKeys int
-	CutoverDefers    int
+	CandidateAttempts int
+	CatchupPasses     int
+	CatchupKeys       int
+	FinalCutoverKeys  int
+	CutoverDefers     int
 
 	WallTimeNanos int64
 }
 
-type leafLogicalRebuildCandidate struct {
+type leafLogicalRebuildSource struct {
 	generationID uint64
 	rawFileID    uint32
 	fileID       uint32
-	runRanges    [][2]int
+	firstIndex   int
+	lastIndex    int
 	sourcePages  int
 	sourceBytes  int64
+	retireable   bool
+}
+
+type leafLogicalRebuildCandidate struct {
+	generationIDs []uint64
+	rawFileIDs    []uint32
+	fileIDs       []uint32
+	runRanges     [][2]int
+	sourcePages   int
+	sourceBytes   int64
 }
 
 type leafLogicalRebuildRunBuild struct {
@@ -75,6 +95,12 @@ type leafLogicalRebuildRunBuild struct {
 }
 
 func normalizeLeafGenerationLogicalRebuildRunOnceOptions(opts LeafGenerationLogicalRebuildRunOnceOptions) LeafGenerationLogicalRebuildRunOnceOptions {
+	if opts.ClusterFilesMax <= 0 {
+		opts.ClusterFilesMax = 4
+	}
+	if opts.CandidateTryMax <= 0 {
+		opts.CandidateTryMax = 8
+	}
 	if opts.CatchupPassesMax <= 0 {
 		opts.CatchupPassesMax = vacuumCatchupPassesMax
 	}
@@ -131,9 +157,100 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 	newPath := filepath.Join(db.dir, indexNewFileName)
 	bakPath := filepath.Join(db.dir, indexBakFileName)
 	readyPath := filepath.Join(db.dir, indexReadyFileName)
+
+	baseSnap := db.AcquireSnapshot()
+	if baseSnap == nil || baseSnap.idx == nil || baseSnap.state == nil || baseSnap.state.LeafGenerations == nil {
+		return stats, fmt.Errorf("leaf logical rebuild: missing snapshot state")
+	}
+	defer func() { _ = baseSnap.Close() }()
+	stats.CommitSeqBefore = baseSnap.state.CommitSeq
+
+	candidates, baseChildren, err := db.selectLeafGenerationLogicalRebuildCandidates(baseSnap, opts.RawFileID, opts.MaxPublishedCommitSeq, opts.ClusterFilesMax)
+	if err != nil {
+		return stats, err
+	}
+	if len(candidates) == 0 {
+		return stats, ErrLeafGenerationLogicalRebuildNoCandidate
+	}
+	grouped := make(map[int][]leafLogicalRebuildCandidate)
+	widths := make([]int, 0, 8)
+	for _, candidate := range candidates {
+		width := len(candidate.rawFileIDs)
+		if _, ok := grouped[width]; !ok {
+			widths = append(widths, width)
+		}
+		grouped[width] = append(grouped[width], candidate)
+	}
+	sort.Ints(widths)
+
+	attempts := 0
+	for _, width := range widths {
+		group := grouped[width]
+		limit := len(group)
+		if opts.CandidateTryMax > 0 && limit > opts.CandidateTryMax {
+			limit = opts.CandidateTryMax
+		}
+		for i := 0; i < limit; i++ {
+			attempts++
+			stats, err = db.tryLeafGenerationLogicalRebuildCandidate(
+				ctx,
+				opts,
+				baseSnap,
+				baseChildren,
+				group[i],
+				indexPath,
+				newPath,
+				bakPath,
+				readyPath,
+			)
+			if err == nil {
+				stats.CandidateAttempts = attempts
+				return stats, nil
+			}
+			if !errors.Is(err, ErrLeafGenerationLogicalRebuildNoCandidate) {
+				return stats, err
+			}
+		}
+	}
+	return stats, ErrLeafGenerationLogicalRebuildNoCandidate
+}
+
+func (db *DB) tryLeafGenerationLogicalRebuildCandidate(
+	ctx context.Context,
+	opts LeafGenerationLogicalRebuildRunOnceOptions,
+	baseSnap *Snapshot,
+	baseChildren []vacuumLeafChild,
+	candidate leafLogicalRebuildCandidate,
+	indexPath, newPath, bakPath, readyPath string,
+) (stats LeafGenerationLogicalRebuildRunOnceStats, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return stats, err
+	}
+
+	stats.CommitSeqBefore = baseSnap.state.CommitSeq
+	if len(candidate.generationIDs) > 0 {
+		stats.SelectedGenerationID = candidate.generationIDs[0]
+		stats.SelectedGenerationIDs = append([]uint64(nil), candidate.generationIDs...)
+	}
+	if len(candidate.rawFileIDs) > 0 {
+		stats.SelectedRawFileID = candidate.rawFileIDs[0]
+		stats.SelectedRawFileIDs = append([]uint32(nil), candidate.rawFileIDs...)
+	}
+	if len(candidate.fileIDs) > 0 {
+		stats.SelectedFileID = candidate.fileIDs[0]
+		stats.SelectedFileIDs = append([]uint32(nil), candidate.fileIDs...)
+	}
+	stats.SelectedSourceFiles = len(candidate.rawFileIDs)
+	stats.SelectedRunCount = len(candidate.runRanges)
+	stats.SourceLeafPages = candidate.sourcePages
+	stats.SourceLeafBytes = candidate.sourceBytes
+	stats.BytesCopied = candidate.sourceBytes
+
 	_ = os.Remove(newPath)
 	_ = os.Remove(readyPath)
-
 	newPager, err := pager.Open(newPath, db.chunkSize)
 	if err != nil {
 		return stats, err
@@ -151,7 +268,6 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 			cleanupNewPager()
 		}
 	}()
-
 	if _, err = newPager.Alloc(2); err != nil {
 		return stats, err
 	}
@@ -241,29 +357,8 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 	db.vacuum.Start()
 	defer db.vacuum.Stop()
 
-	baseSnap := db.AcquireSnapshot()
-	if baseSnap == nil || baseSnap.idx == nil || baseSnap.state == nil || baseSnap.state.LeafGenerations == nil {
-		closeRewriteSnapshot(&err, baseSnap)
-		return stats, fmt.Errorf("leaf logical rebuild: missing snapshot state")
-	}
-	stats.CommitSeqBefore = baseSnap.state.CommitSeq
-
-	candidate, baseChildren, err := db.selectLeafGenerationLogicalRebuildCandidate(baseSnap, opts.RawFileID, opts.MaxPublishedCommitSeq)
+	runBuilds, recordsCopied, err := db.buildLogicalRebuildRuns(baseSnap, baseChildren, candidate, writer)
 	if err != nil {
-		closeRewriteSnapshot(&err, baseSnap)
-		return stats, err
-	}
-	stats.SelectedGenerationID = candidate.generationID
-	stats.SelectedRawFileID = candidate.rawFileID
-	stats.SelectedFileID = candidate.fileID
-	stats.SelectedRunCount = len(candidate.runRanges)
-	stats.SourceLeafPages = candidate.sourcePages
-	stats.SourceLeafBytes = candidate.sourceBytes
-	stats.BytesCopied = candidate.sourceBytes
-
-	runBuilds, recordsCopied, err := db.buildLogicalRebuildRuns(baseSnap, candidate, writer)
-	if err != nil {
-		closeRewriteSnapshot(&err, baseSnap)
 		return stats, err
 	}
 	stats.RecordsCopied = recordsCopied
@@ -280,8 +375,6 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 	}
 
 	newRoot, err := leafGenerationLogicalRebuildRootFromChildren(newPager, newAlloc, modifiedChildren, db.indexInternalBaseDelta)
-	_ = baseSnap.Close()
-	baseSnap = nil
 	if err != nil {
 		return stats, err
 	}
@@ -324,7 +417,6 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 		if err := ctx.Err(); err != nil {
 			return stats, err
 		}
-
 		db.writeMu.Lock()
 		db.vacuum.Stop()
 		finalOps := db.vacuum.Drain()
@@ -358,22 +450,28 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 			db.writeMu.Unlock()
 			return stats, err
 		}
-		createdLeafBytes, err := leafGenerationLogicalRebuildCreatedBytes(createdSegments)
+		createdIDs, err := writer.createdFileIDs()
 		if err != nil {
 			db.writeMu.Unlock()
 			return stats, err
 		}
-		if createdLeafBytes >= candidate.sourceBytes {
+		sourceTotalBytes, err := leafGenerationLogicalRebuildSourceTotalBytes(db.dir, candidate.rawFileIDs)
+		if err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		createdTotalBytes, err := leafGenerationLogicalRebuildCreatedTotalBytes(createdSegments)
+		if err != nil {
+			db.writeMu.Unlock()
+			return stats, err
+		}
+		minSavingsBytes := max(int64(1<<20), sourceTotalBytes/100)
+		if createdTotalBytes > sourceTotalBytes-minSavingsBytes {
 			db.writeMu.Unlock()
 			if cleanupErr := cleanupCreated(nil); cleanupErr != nil {
 				return stats, cleanupErr
 			}
 			return stats, ErrLeafGenerationLogicalRebuildNoCandidate
-		}
-		createdIDs, err := writer.createdFileIDs()
-		if err != nil {
-			db.writeMu.Unlock()
-			return stats, err
 		}
 		for _, seg := range createdSegments {
 			if err := db.valueLogManager.RegisterSegment(seg.path, seg.fileID); err != nil {
@@ -417,7 +515,7 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 			db.writeMu.Unlock()
 			return stats, fmt.Errorf("leaf logical rebuild: created no new leaf generations")
 		}
-		retiredGenerationIDs, err := retireWholeLeafGenerationInManifest(stagedManifest, candidate.generationID, nextMeta.CommitSeq)
+		retiredGenerationIDs, err := retireLeafGenerationsInManifest(stagedManifest, candidate.generationIDs, nextMeta.CommitSeq)
 		if err != nil {
 			db.writeMu.Unlock()
 			return stats, err
@@ -511,6 +609,21 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 	}
 }
 
+func retireLeafGenerationsInManifest(manifest *leafGenerationManifest, generationIDs []uint64, commitSeq uint64) ([]uint64, error) {
+	if len(generationIDs) == 0 {
+		return nil, nil
+	}
+	retired := make([]uint64, 0, len(generationIDs))
+	for _, generationID := range generationIDs {
+		genRetired, err := retireWholeLeafGenerationInManifest(manifest, generationID, commitSeq)
+		if err != nil {
+			return nil, err
+		}
+		retired = append(retired, genRetired...)
+	}
+	return retired, nil
+}
+
 func retireWholeLeafGenerationInManifest(manifest *leafGenerationManifest, generationID, commitSeq uint64) ([]uint64, error) {
 	if manifest == nil || generationID == 0 || commitSeq == 0 {
 		return nil, nil
@@ -532,10 +645,9 @@ func retireWholeLeafGenerationInManifest(manifest *leafGenerationManifest, gener
 	return nil, fmt.Errorf("leaf logical rebuild: generation %d not found", generationID)
 }
 
-func (db *DB) selectLeafGenerationLogicalRebuildCandidate(snap *Snapshot, requestedRawFileID uint32, maxPublishedCommitSeq uint64) (leafLogicalRebuildCandidate, []vacuumLeafChild, error) {
-	var zero leafLogicalRebuildCandidate
+func (db *DB) selectLeafGenerationLogicalRebuildCandidates(snap *Snapshot, requestedRawFileID uint32, maxPublishedCommitSeq uint64, clusterFilesMax int) ([]leafLogicalRebuildCandidate, []vacuumLeafChild, error) {
 	if snap == nil || snap.idx == nil || snap.state == nil || snap.state.LeafGenerations == nil {
-		return zero, nil, fmt.Errorf("leaf logical rebuild: missing snapshot state")
+		return nil, nil, fmt.Errorf("leaf logical rebuild: missing snapshot state")
 	}
 	rootID := snap.state.RootPageID
 	var children []vacuumLeafChild
@@ -545,20 +657,19 @@ func (db *DB) selectLeafGenerationLogicalRebuildCandidate(snap *Snapshot, reques
 		var err error
 		children, err = vacuumCollectLeafRefChildren(snap.idx.pager, rootID)
 		if err != nil {
-			return zero, nil, err
+			return nil, nil, err
 		}
 	}
 	if len(children) == 0 {
-		return zero, nil, ErrLeafGenerationLogicalRebuildNoCandidate
+		return nil, nil, ErrLeafGenerationLogicalRebuildNoCandidate
+	}
+	systemRawFileIDs, err := leafGenerationLogicalRebuildRootRawFileIDs(snap.idx.pager, snap.state.SystemRootPageID)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	type fileAccum struct {
-		generationID uint64
-		runRanges    [][2]int
-		sourcePages  int
-		sourceBytes  int64
-	}
-	accumByRaw := make(map[uint32]*fileAccum)
+	accumByRaw := make(map[uint32]*leafLogicalRebuildSource)
+	orderedRaw := make([]uint32, 0, 64)
 	view := snap.state.LeafGenerations
 	manifestByGen := make(map[uint64]leafGenerationRecord, len(db.leafGenerationManifest.Generations))
 	if db.leafGenerationManifest != nil {
@@ -567,93 +678,231 @@ func (db *DB) selectLeafGenerationLogicalRebuildCandidate(snap *Snapshot, reques
 		}
 	}
 
-	currentRaw := uint32(0)
-	runStart := -1
-	finishRun := func(end int) {
-		if runStart < 0 || currentRaw == 0 {
-			runStart = -1
-			currentRaw = 0
-			return
-		}
-		accum := accumByRaw[currentRaw]
-		if accum != nil {
-			accum.runRanges = append(accum.runRanges, [2]int{runStart, end})
-		}
-		runStart = -1
-		currentRaw = 0
-	}
-
 	for i, child := range children {
 		ptr, ok := page.DecodeLeafRef(child.childID)
 		if !ok {
-			return zero, nil, fmt.Errorf("leaf logical rebuild: child %d is not a leaf ref", i)
+			return nil, nil, fmt.Errorf("leaf logical rebuild: child %d is not a leaf ref", i)
 		}
 		rawFileID := page.ValueLogSegmentID(ptr.ValueLogFileID())
 		generationID := view.FileToGeneration[rawFileID]
 		gen, ok := manifestByGen[generationID]
-		if !ok || gen.State != leafGenerationStateSealed || len(gen.FileIDs) != 1 {
-			if rawFileID == currentRaw {
-				finishRun(i - 1)
-			}
-			continue
-		}
-		if maxPublishedCommitSeq != 0 && gen.PublishedCommitSeq > maxPublishedCommitSeq {
-			if rawFileID == currentRaw {
-				finishRun(i - 1)
-			}
-			continue
-		}
-		if requestedRawFileID != 0 && rawFileID != requestedRawFileID {
-			if rawFileID == currentRaw {
-				finishRun(i - 1)
-			}
-			continue
-		}
 		accum := accumByRaw[rawFileID]
 		if accum == nil {
-			accum = &fileAccum{
+			accum = &leafLogicalRebuildSource{
 				generationID: generationID,
+				rawFileID:    rawFileID,
+				fileID:       page.ValueLogFileID(rawFileID),
+				firstIndex:   i,
+				lastIndex:    i,
 				sourceBytes:  leafGenerationLogicalRebuildFileSize(db.dir, rawFileID),
 			}
 			accumByRaw[rawFileID] = accum
+			orderedRaw = append(orderedRaw, rawFileID)
 		}
+		accum.lastIndex = i
 		accum.sourcePages++
-		if currentRaw != rawFileID {
-			if currentRaw != 0 {
-				finishRun(i - 1)
-			}
-			currentRaw = rawFileID
-			runStart = i
-		}
-	}
-	if currentRaw != 0 {
-		finishRun(len(children) - 1)
-	}
-
-	best := zero
-	bestPages := -1
-	bestBytes := int64(-1)
-	for rawFileID, accum := range accumByRaw {
-		if accum == nil || len(accum.runRanges) == 0 || accum.sourcePages == 0 {
+		if _, blocked := systemRawFileIDs[rawFileID]; blocked {
 			continue
 		}
-		if accum.sourcePages > bestPages || (accum.sourcePages == bestPages && accum.sourceBytes > bestBytes) {
-			best = leafLogicalRebuildCandidate{
-				generationID: accum.generationID,
-				rawFileID:    rawFileID,
-				fileID:       page.ValueLogFileID(rawFileID),
-				runRanges:    append([][2]int(nil), accum.runRanges...),
-				sourcePages:  accum.sourcePages,
-				sourceBytes:  accum.sourceBytes,
-			}
-			bestPages = accum.sourcePages
-			bestBytes = accum.sourceBytes
+		if !ok || gen.State != leafGenerationStateSealed || len(gen.FileIDs) != 1 {
+			continue
+		}
+		if maxPublishedCommitSeq != 0 && gen.PublishedCommitSeq > maxPublishedCommitSeq {
+			continue
+		}
+		if requestedRawFileID != 0 && rawFileID != requestedRawFileID {
+			continue
+		}
+		accum.retireable = true
+	}
+
+	allSources := make([]leafLogicalRebuildSource, 0, len(orderedRaw))
+	eligibleSources := make([]leafLogicalRebuildSource, 0, len(orderedRaw))
+	for _, rawFileID := range orderedRaw {
+		accum := accumByRaw[rawFileID]
+		if accum == nil || accum.sourcePages == 0 || accum.firstIndex > accum.lastIndex {
+			continue
+		}
+		allSources = append(allSources, *accum)
+		if accum.retireable {
+			eligibleSources = append(eligibleSources, *accum)
 		}
 	}
-	if best.rawFileID == 0 {
-		return zero, nil, ErrLeafGenerationLogicalRebuildNoCandidate
+	candidates := buildLeafGenerationLogicalRebuildCandidates(allSources, eligibleSources, clusterFilesMax)
+	if len(candidates) == 0 {
+		return nil, nil, ErrLeafGenerationLogicalRebuildNoCandidate
 	}
-	return best, children, nil
+	return candidates, children, nil
+}
+
+func buildLeafGenerationLogicalRebuildCandidates(allSources, eligibleSources []leafLogicalRebuildSource, clusterFilesMax int) []leafLogicalRebuildCandidate {
+	if len(allSources) == 0 || len(eligibleSources) == 0 {
+		return nil
+	}
+	if clusterFilesMax <= 0 {
+		clusterFilesMax = len(eligibleSources)
+	}
+	sourceByRaw := make(map[uint32]leafLogicalRebuildSource, len(allSources))
+	for _, src := range allSources {
+		sourceByRaw[src.rawFileID] = src
+	}
+	type windowKey struct {
+		start int
+		end   int
+	}
+	seen := make(map[windowKey]struct{}, len(allSources))
+	out := make([]leafLogicalRebuildCandidate, 0, len(eligibleSources))
+	for i := range eligibleSources {
+		start := eligibleSources[i].firstIndex
+		end := eligibleSources[i].lastIndex
+		for j := i; j < len(eligibleSources); j++ {
+			if eligibleSources[j].firstIndex < start {
+				start = eligibleSources[j].firstIndex
+			}
+			if eligibleSources[j].lastIndex > end {
+				end = eligibleSources[j].lastIndex
+			}
+			key := windowKey{start: start, end: end}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+
+			retireableRawFileIDs := make([]uint32, 0, clusterFilesMax)
+			sourcePages := 0
+			sourceBytes := int64(0)
+			for _, src := range allSources {
+				if src.lastIndex < start || src.firstIndex > end {
+					continue
+				}
+				if !src.retireable || src.firstIndex < start || src.lastIndex > end {
+					continue
+				}
+				retireableRawFileIDs = append(retireableRawFileIDs, src.rawFileID)
+				sourcePages += src.sourcePages
+				sourceBytes += src.sourceBytes
+			}
+			if len(retireableRawFileIDs) == 0 {
+				continue
+			}
+			if len(retireableRawFileIDs) > clusterFilesMax {
+				break
+			}
+
+			slices.Sort(retireableRawFileIDs)
+			generationIDs := make([]uint64, 0, len(retireableRawFileIDs))
+			fileIDs := make([]uint32, 0, len(retireableRawFileIDs))
+			for _, rawFileID := range retireableRawFileIDs {
+				src := sourceByRaw[rawFileID]
+				generationIDs = append(generationIDs, src.generationID)
+				fileIDs = append(fileIDs, src.fileID)
+			}
+			out = append(out, leafLogicalRebuildCandidate{
+				generationIDs: generationIDs,
+				rawFileIDs:    retireableRawFileIDs,
+				fileIDs:       fileIDs,
+				runRanges:     [][2]int{{start, end}},
+				sourcePages:   sourcePages,
+				sourceBytes:   sourceBytes,
+			})
+		}
+	}
+	slices.SortFunc(out, func(a, b leafLogicalRebuildCandidate) int {
+		if len(a.rawFileIDs) != len(b.rawFileIDs) {
+			if len(a.rawFileIDs) < len(b.rawFileIDs) {
+				return -1
+			}
+			return 1
+		}
+		aDensity := float64(a.sourceBytes)
+		if a.sourcePages > 0 {
+			aDensity /= float64(a.sourcePages)
+		}
+		bDensity := float64(b.sourceBytes)
+		if b.sourcePages > 0 {
+			bDensity /= float64(b.sourcePages)
+		}
+		if aDensity != bDensity {
+			if aDensity > bDensity {
+				return -1
+			}
+			return 1
+		}
+		if a.sourceBytes != b.sourceBytes {
+			if a.sourceBytes > b.sourceBytes {
+				return -1
+			}
+			return 1
+		}
+		if a.sourcePages != b.sourcePages {
+			if a.sourcePages > b.sourcePages {
+				return -1
+			}
+			return 1
+		}
+		aStart, aEnd := a.runRanges[0][0], a.runRanges[0][1]
+		bStart, bEnd := b.runRanges[0][0], b.runRanges[0][1]
+		if (aEnd - aStart) != (bEnd - bStart) {
+			if (aEnd - aStart) > (bEnd - bStart) {
+				return -1
+			}
+			return 1
+		}
+		return 0
+	})
+	return out
+}
+
+func leafGenerationLogicalRebuildRootRawFileIDs(p *pager.Pager, rootID uint64) (map[uint32]struct{}, error) {
+	out := make(map[uint32]struct{})
+	if p == nil || rootID == 0 {
+		return out, nil
+	}
+	if _, ok := page.DecodeLeafRef(rootID); ok {
+		out[page.ValueLogSegmentID(page.DecodeLeafRefID(rootID).ValueLogFileID())] = struct{}{}
+		return out, nil
+	}
+	visited := make(map[uint64]struct{}, 128)
+	var walk func(uint64) error
+	walk = func(id uint64) error {
+		if id == 0 {
+			return nil
+		}
+		if _, ok := page.DecodeLeafRef(id); ok {
+			out[page.ValueLogSegmentID(page.DecodeLeafRefID(id).ValueLogFileID())] = struct{}{}
+			return nil
+		}
+		if _, seen := visited[id]; seen {
+			return nil
+		}
+		visited[id] = struct{}{}
+		data, err := p.Get(id)
+		if err != nil {
+			return err
+		}
+		n := node.NewNode(data)
+		switch n.Type() {
+		case page.PageTypeInternal:
+			count := n.Count()
+			for i := uint16(0); i < count; i++ {
+				_, childID, err := n.GetInternalEntryView(i)
+				if err != nil {
+					return err
+				}
+				if err := walk(childID); err != nil {
+					return err
+				}
+			}
+		case page.PageTypeLeaf:
+			// Pager-backed leaves in the System tree do not contribute outer-leaf
+			// leafref files, so there is nothing to record here.
+		}
+		return nil
+	}
+	if err := walk(rootID); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func leafGenerationLogicalRebuildFileSize(dir string, rawFileID uint32) int64 {
@@ -668,7 +917,26 @@ func leafGenerationLogicalRebuildFileSize(dir string, rawFileID uint32) int64 {
 	return info.Size()
 }
 
-func leafGenerationLogicalRebuildCreatedBytes(segments []rewriteCreatedSegment) (int64, error) {
+func leafGenerationLogicalRebuildSourceTotalBytes(rootDir string, rawFileIDs []uint32) (int64, error) {
+	var total int64
+	for _, rawFileID := range rawFileIDs {
+		logPath := leafGenerationFallbackPath(rootDir, rawFileID)
+		if info, err := os.Stat(logPath); err == nil {
+			total += info.Size()
+		} else if !os.IsNotExist(err) {
+			return 0, err
+		}
+		idxPath := leafGenerationRecordLengthIndexPath(rootDir, rawFileID)
+		if info, err := os.Stat(idxPath); err == nil {
+			total += info.Size()
+		} else if !os.IsNotExist(err) {
+			return 0, err
+		}
+	}
+	return total, nil
+}
+
+func leafGenerationLogicalRebuildCreatedTotalBytes(segments []rewriteCreatedSegment) (int64, error) {
 	var total int64
 	for _, seg := range segments {
 		if seg.path == "" {
@@ -679,27 +947,31 @@ func leafGenerationLogicalRebuildCreatedBytes(segments []rewriteCreatedSegment) 
 			return 0, err
 		}
 		total += info.Size()
+		idx, err := scanLeafGenerationRecordLengthIndexPath(seg.path, seg.fileID)
+		if err != nil {
+			return 0, err
+		}
+		total += leafGenerationRecordLengthIndexEncodedSize(idx)
 	}
 	return total, nil
 }
 
-func (db *DB) buildLogicalRebuildRuns(baseSnap *Snapshot, candidate leafLogicalRebuildCandidate, writer *rewriteWriter) ([]leafLogicalRebuildRunBuild, int, error) {
+func leafGenerationRecordLengthIndexEncodedSize(idx *leafGenerationRecordLengthIndex) int64 {
+	if idx == nil {
+		return 16
+	}
+	return int64(16 + idx.len()*8)
+}
+
+func (db *DB) buildLogicalRebuildRuns(baseSnap *Snapshot, baseChildren []vacuumLeafChild, candidate leafLogicalRebuildCandidate, writer *rewriteWriter) ([]leafLogicalRebuildRunBuild, int, error) {
 	if baseSnap == nil || baseSnap.idx == nil {
 		return nil, 0, fmt.Errorf("leaf logical rebuild: missing base snapshot")
 	}
 	if len(candidate.runRanges) == 0 {
 		return nil, 0, fmt.Errorf("leaf logical rebuild: candidate has no runs")
 	}
-	rootID := baseSnap.state.RootPageID
-	var baseChildren []vacuumLeafChild
-	if _, ok := page.DecodeLeafRef(rootID); ok {
-		baseChildren = []vacuumLeafChild{{key: []byte{}, childID: rootID}}
-	} else {
-		var err error
-		baseChildren, err = vacuumCollectLeafRefChildren(baseSnap.idx.pager, rootID)
-		if err != nil {
-			return nil, 0, err
-		}
+	if len(baseChildren) == 0 {
+		return nil, 0, fmt.Errorf("leaf logical rebuild: missing base frontier")
 	}
 	out := make([]leafLogicalRebuildRunBuild, 0, len(candidate.runRanges))
 	totalRecords := 0

--- a/TreeDB/db/leaf_generation_logical_rebuild_online.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_online.go
@@ -29,6 +29,7 @@ type LeafGenerationLogicalRebuildRunOnceOptions struct {
 	MaxPublishedCommitSeq uint64
 	ClusterFilesMax       int
 	CandidateTryMax       int
+	PilotSamplePages      int
 	Sync                  bool
 	CatchupPassesMax      int
 	CutoverMaxKeys        int
@@ -72,6 +73,7 @@ type leafLogicalRebuildSource struct {
 	fileID       uint32
 	firstIndex   int
 	lastIndex    int
+	ranges       [][2]int
 	sourcePages  int
 	sourceBytes  int64
 	retireable   bool
@@ -82,6 +84,7 @@ type leafLogicalRebuildCandidate struct {
 	rawFileIDs    []uint32
 	fileIDs       []uint32
 	runRanges     [][2]int
+	windowPages   int
 	sourcePages   int
 	sourceBytes   int64
 }
@@ -94,12 +97,24 @@ type leafLogicalRebuildRunBuild struct {
 	replacement []vacuumLeafChild
 }
 
+type leafLogicalRebuildPilotEstimate struct {
+	sourceTotalBytes    int64
+	samplePages         int
+	sampleSourceBytes   int64
+	sampleCreatedBytes  int64
+	estimatedCreatedBytes int64
+	minSavingsBytes     int64
+}
+
 func normalizeLeafGenerationLogicalRebuildRunOnceOptions(opts LeafGenerationLogicalRebuildRunOnceOptions) LeafGenerationLogicalRebuildRunOnceOptions {
 	if opts.ClusterFilesMax <= 0 {
 		opts.ClusterFilesMax = 4
 	}
 	if opts.CandidateTryMax <= 0 {
 		opts.CandidateTryMax = 8
+	}
+	if opts.PilotSamplePages <= 0 {
+		opts.PilotSamplePages = 192
 	}
 	if opts.CatchupPassesMax <= 0 {
 		opts.CatchupPassesMax = vacuumCatchupPassesMax
@@ -192,6 +207,13 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 		}
 		for i := 0; i < limit; i++ {
 			attempts++
+			estimate, err := db.estimateLeafGenerationLogicalRebuildCandidate(baseSnap, baseChildren, group[i], opts.PilotSamplePages)
+			if err != nil {
+				return stats, err
+			}
+			if !estimate.admit() {
+				continue
+			}
 			stats, err = db.tryLeafGenerationLogicalRebuildCandidate(
 				ctx,
 				opts,
@@ -213,6 +235,56 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 		}
 	}
 	return stats, ErrLeafGenerationLogicalRebuildNoCandidate
+}
+
+func (e leafLogicalRebuildPilotEstimate) admit() bool {
+	if e.sourceTotalBytes == 0 || e.sampleSourceBytes == 0 || e.sampleCreatedBytes == 0 {
+		return false
+	}
+	return e.estimatedCreatedBytes <= e.sourceTotalBytes-e.minSavingsBytes
+}
+
+func (db *DB) estimateLeafGenerationLogicalRebuildCandidate(baseSnap *Snapshot, baseChildren []vacuumLeafChild, candidate leafLogicalRebuildCandidate, pilotSamplePages int) (leafLogicalRebuildPilotEstimate, error) {
+	var estimate leafLogicalRebuildPilotEstimate
+	if baseSnap == nil || baseSnap.state == nil {
+		return estimate, fmt.Errorf("leaf logical rebuild: missing base snapshot")
+	}
+	if len(candidate.runRanges) == 0 || candidate.windowPages == 0 {
+		return estimate, nil
+	}
+	sourceTotalBytes, err := leafGenerationLogicalRebuildSourceTotalBytes(db.dir, candidate.rawFileIDs)
+	if err != nil {
+		return estimate, err
+	}
+	estimate.sourceTotalBytes = sourceTotalBytes
+	estimate.minSavingsBytes = max(int64(1<<20), sourceTotalBytes/100)
+	sampleRanges := leafGenerationLogicalRebuildSampleRanges(candidate.runRanges, pilotSamplePages)
+	if len(sampleRanges) == 0 {
+		return estimate, nil
+	}
+	sampleSourceBytes, err := db.leafGenerationLogicalRebuildSampleSourceBytes(baseSnap, baseChildren, sampleRanges)
+	if err != nil {
+		return estimate, err
+	}
+	estimate.sampleSourceBytes = sampleSourceBytes
+	for _, rr := range sampleRanges {
+		estimate.samplePages += rr[1] - rr[0] + 1
+	}
+	if sampleSourceBytes == 0 {
+		return estimate, nil
+	}
+	sampleCreatedBytes, err := db.pilotLeafGenerationLogicalRebuildCandidate(baseSnap, baseChildren, sampleRanges)
+	if err != nil {
+		return estimate, err
+	}
+	estimate.sampleCreatedBytes = sampleCreatedBytes
+	if sampleCreatedBytes == 0 {
+		return estimate, nil
+	}
+	if estimate.samplePages > 0 {
+		estimate.estimatedCreatedBytes = int64(float64(candidate.windowPages) * (float64(sampleCreatedBytes) / float64(estimate.samplePages)))
+	}
+	return estimate, nil
 }
 
 func (db *DB) tryLeafGenerationLogicalRebuildCandidate(
@@ -694,10 +766,18 @@ func (db *DB) selectLeafGenerationLogicalRebuildCandidates(snap *Snapshot, reque
 				fileID:       page.ValueLogFileID(rawFileID),
 				firstIndex:   i,
 				lastIndex:    i,
+				ranges:       [][2]int{{i, i}},
 				sourceBytes:  leafGenerationLogicalRebuildFileSize(db.dir, rawFileID),
 			}
 			accumByRaw[rawFileID] = accum
 			orderedRaw = append(orderedRaw, rawFileID)
+		} else {
+			lastRange := &accum.ranges[len(accum.ranges)-1]
+			if i <= lastRange[1]+1 {
+				lastRange[1] = i
+			} else {
+				accum.ranges = append(accum.ranges, [2]int{i, i})
+			}
 		}
 		accum.lastIndex = i
 		accum.sourcePages++
@@ -742,66 +822,44 @@ func buildLeafGenerationLogicalRebuildCandidates(allSources, eligibleSources []l
 	if clusterFilesMax <= 0 {
 		clusterFilesMax = len(eligibleSources)
 	}
-	sourceByRaw := make(map[uint32]leafLogicalRebuildSource, len(allSources))
-	for _, src := range allSources {
-		sourceByRaw[src.rawFileID] = src
-	}
-	type windowKey struct {
-		start int
-		end   int
-	}
+	type windowKey string
 	seen := make(map[windowKey]struct{}, len(allSources))
 	out := make([]leafLogicalRebuildCandidate, 0, len(eligibleSources))
 	for i := range eligibleSources {
-		start := eligibleSources[i].firstIndex
-		end := eligibleSources[i].lastIndex
+		generationIDs := make([]uint64, 0, clusterFilesMax)
+		rawFileIDs := make([]uint32, 0, clusterFilesMax)
+		fileIDs := make([]uint32, 0, clusterFilesMax)
+		runRanges := make([][2]int, 0, clusterFilesMax)
+		sourcePages := 0
+		sourceBytes := int64(0)
 		for j := i; j < len(eligibleSources); j++ {
-			if eligibleSources[j].firstIndex < start {
-				start = eligibleSources[j].firstIndex
+			src := eligibleSources[j]
+			generationIDs = append(generationIDs, src.generationID)
+			rawFileIDs = append(rawFileIDs, src.rawFileID)
+			fileIDs = append(fileIDs, src.fileID)
+			runRanges = append(runRanges, src.ranges...)
+			sourcePages += src.sourcePages
+			sourceBytes += src.sourceBytes
+			if len(rawFileIDs) > clusterFilesMax {
+				break
 			}
-			if eligibleSources[j].lastIndex > end {
-				end = eligibleSources[j].lastIndex
+			mergedRanges := mergeLeafLogicalRebuildRanges(runRanges)
+			if len(mergedRanges) == 0 {
+				continue
 			}
-			key := windowKey{start: start, end: end}
+			sortedRaw := append([]uint32(nil), rawFileIDs...)
+			slices.Sort(sortedRaw)
+			key := windowKey(leafLogicalRebuildWindowKey(sortedRaw, mergedRanges))
 			if _, ok := seen[key]; ok {
 				continue
 			}
 			seen[key] = struct{}{}
-
-			retireableRawFileIDs := make([]uint32, 0, clusterFilesMax)
-			sourcePages := 0
-			sourceBytes := int64(0)
-			for _, src := range allSources {
-				if src.lastIndex < start || src.firstIndex > end {
-					continue
-				}
-				if !src.retireable || src.firstIndex < start || src.lastIndex > end {
-					continue
-				}
-				retireableRawFileIDs = append(retireableRawFileIDs, src.rawFileID)
-				sourcePages += src.sourcePages
-				sourceBytes += src.sourceBytes
-			}
-			if len(retireableRawFileIDs) == 0 {
-				continue
-			}
-			if len(retireableRawFileIDs) > clusterFilesMax {
-				break
-			}
-
-			slices.Sort(retireableRawFileIDs)
-			generationIDs := make([]uint64, 0, len(retireableRawFileIDs))
-			fileIDs := make([]uint32, 0, len(retireableRawFileIDs))
-			for _, rawFileID := range retireableRawFileIDs {
-				src := sourceByRaw[rawFileID]
-				generationIDs = append(generationIDs, src.generationID)
-				fileIDs = append(fileIDs, src.fileID)
-			}
 			out = append(out, leafLogicalRebuildCandidate{
-				generationIDs: generationIDs,
-				rawFileIDs:    retireableRawFileIDs,
-				fileIDs:       fileIDs,
-				runRanges:     [][2]int{{start, end}},
+				generationIDs: append([]uint64(nil), generationIDs...),
+				rawFileIDs:    sortedRaw,
+				fileIDs:       append([]uint32(nil), fileIDs...),
+				runRanges:     mergedRanges,
+				windowPages:   leafLogicalRebuildRangePages(mergedRanges),
 				sourcePages:   sourcePages,
 				sourceBytes:   sourceBytes,
 			})
@@ -814,13 +872,19 @@ func buildLeafGenerationLogicalRebuildCandidates(allSources, eligibleSources []l
 			}
 			return 1
 		}
+		if len(a.runRanges) != len(b.runRanges) {
+			if len(a.runRanges) < len(b.runRanges) {
+				return -1
+			}
+			return 1
+		}
 		aDensity := float64(a.sourceBytes)
-		if a.sourcePages > 0 {
-			aDensity /= float64(a.sourcePages)
+		if a.windowPages > 0 {
+			aDensity /= float64(a.windowPages)
 		}
 		bDensity := float64(b.sourceBytes)
-		if b.sourcePages > 0 {
-			bDensity /= float64(b.sourcePages)
+		if b.windowPages > 0 {
+			bDensity /= float64(b.windowPages)
 		}
 		if aDensity != bDensity {
 			if aDensity > bDensity {
@@ -840,10 +904,8 @@ func buildLeafGenerationLogicalRebuildCandidates(allSources, eligibleSources []l
 			}
 			return 1
 		}
-		aStart, aEnd := a.runRanges[0][0], a.runRanges[0][1]
-		bStart, bEnd := b.runRanges[0][0], b.runRanges[0][1]
-		if (aEnd - aStart) != (bEnd - bStart) {
-			if (aEnd - aStart) > (bEnd - bStart) {
+		if a.windowPages != b.windowPages {
+			if a.windowPages < b.windowPages {
 				return -1
 			}
 			return 1
@@ -851,6 +913,56 @@ func buildLeafGenerationLogicalRebuildCandidates(allSources, eligibleSources []l
 		return 0
 	})
 	return out
+}
+
+func mergeLeafLogicalRebuildRanges(in [][2]int) [][2]int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := append([][2]int(nil), in...)
+	slices.SortFunc(out, func(a, b [2]int) int {
+		if a[0] < b[0] {
+			return -1
+		}
+		if a[0] > b[0] {
+			return 1
+		}
+		if a[1] < b[1] {
+			return -1
+		}
+		if a[1] > b[1] {
+			return 1
+		}
+		return 0
+	})
+	merged := out[:0]
+	for _, rr := range out {
+		if len(merged) == 0 {
+			merged = append(merged, rr)
+			continue
+		}
+		last := &merged[len(merged)-1]
+		if rr[0] <= last[1]+1 {
+			if rr[1] > last[1] {
+				last[1] = rr[1]
+			}
+			continue
+		}
+		merged = append(merged, rr)
+	}
+	return merged
+}
+
+func leafLogicalRebuildRangePages(runRanges [][2]int) int {
+	total := 0
+	for _, rr := range runRanges {
+		total += rr[1] - rr[0] + 1
+	}
+	return total
+}
+
+func leafLogicalRebuildWindowKey(rawFileIDs []uint32, runRanges [][2]int) string {
+	return fmt.Sprintf("%v:%v", rawFileIDs, runRanges)
 }
 
 func leafGenerationLogicalRebuildRootRawFileIDs(p *pager.Pager, rootID uint64) (map[uint32]struct{}, error) {
@@ -961,6 +1073,157 @@ func leafGenerationRecordLengthIndexEncodedSize(idx *leafGenerationRecordLengthI
 		return 16
 	}
 	return int64(16 + idx.len()*8)
+}
+
+func leafGenerationLogicalRebuildSampleRanges(runRanges [][2]int, maxPages int) [][2]int {
+	if maxPages <= 0 || len(runRanges) == 0 {
+		return nil
+	}
+	totalPages := 0
+	for _, rr := range runRanges {
+		totalPages += rr[1] - rr[0] + 1
+	}
+	if totalPages == 0 {
+		return nil
+	}
+	if totalPages <= maxPages {
+		return append([][2]int(nil), runRanges...)
+	}
+	slicesN := 3
+	perSlice := max(1, maxPages/slicesN)
+	out := make([][2]int, 0, slicesN)
+	first := runRanges[0]
+	out = append(out, [2]int{first[0], min(first[1], first[0]+perSlice-1)})
+	midRR := runRanges[len(runRanges)/2]
+	midStart := midRR[0] + max(0, (midRR[1]-midRR[0]+1-perSlice)/2)
+	out = append(out, [2]int{midStart, min(midRR[1], midStart+perSlice-1)})
+	last := runRanges[len(runRanges)-1]
+	lastEnd := last[1]
+	lastStart := max(last[0], lastEnd-perSlice+1)
+	out = append(out, [2]int{lastStart, lastEnd})
+	slices.SortFunc(out, func(a, b [2]int) int {
+		if a[0] < b[0] {
+			return -1
+		}
+		if a[0] > b[0] {
+			return 1
+		}
+		if a[1] < b[1] {
+			return -1
+		}
+		if a[1] > b[1] {
+			return 1
+		}
+		return 0
+	})
+	merged := out[:0]
+	for _, rr := range out {
+		if len(merged) == 0 {
+			merged = append(merged, rr)
+			continue
+		}
+		last := &merged[len(merged)-1]
+		if rr[0] <= last[1]+1 {
+			if rr[1] > last[1] {
+				last[1] = rr[1]
+			}
+			continue
+		}
+		merged = append(merged, rr)
+	}
+	return merged
+}
+
+func (db *DB) leafGenerationLogicalRebuildSampleSourceBytes(baseSnap *Snapshot, baseChildren []vacuumLeafChild, sampleRanges [][2]int) (int64, error) {
+	if db == nil || baseSnap == nil || baseSnap.state == nil || baseSnap.state.LeafGenerations == nil {
+		return 0, fmt.Errorf("leaf logical rebuild: missing sample state")
+	}
+	var total int64
+	for _, rr := range sampleRanges {
+		for i := rr[0]; i <= rr[1]; i++ {
+			if i < 0 || i >= len(baseChildren) {
+				continue
+			}
+			ptr, ok := page.DecodeLeafRef(baseChildren[i].childID)
+			if !ok {
+				continue
+			}
+			length, ok, err := db.leafGenerationRecordLengthForPlan(ptr, baseSnap.state.ValueLogSet, baseSnap.state.LeafGenerations)
+			if err != nil {
+				return 0, err
+			}
+			if !ok {
+				continue
+			}
+			total += int64(length)
+		}
+	}
+	return total, nil
+}
+
+func (db *DB) pilotLeafGenerationLogicalRebuildCandidate(baseSnap *Snapshot, baseChildren []vacuumLeafChild, sampleRanges [][2]int) (int64, error) {
+	if db == nil || baseSnap == nil {
+		return 0, fmt.Errorf("leaf logical rebuild: missing pilot state")
+	}
+	set := db.valueLogManager.CurrentSetNoRefresh()
+	if set == nil || len(set.Files) == 0 {
+		if set != nil {
+			_ = db.valueLogManager.Release(set)
+		}
+		if err := db.valueLogManager.Refresh(); err != nil {
+			return 0, err
+		}
+		set = db.valueLogManager.CurrentSetNoRefresh()
+	}
+	if set == nil {
+		return 0, fmt.Errorf("leaf logical rebuild: value-log set unavailable")
+	}
+	leafStartSeq := maxRewriteLaneSeqFromSet(set, rewriteLeafLogLaneID)
+	nextRID, err := nextRewriteRIDStartFromSet(set)
+	_ = db.valueLogManager.Release(set)
+	if err != nil {
+		return 0, err
+	}
+
+	tempLeafDir, err := os.MkdirTemp("", "treedb-leaf-logical-pilot-*")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = os.RemoveAll(tempLeafDir) }()
+
+	writer := newRewriteWriter(tempLeafDir, 0, 0, 0)
+	writer.ConfigureLeafLog(tempLeafDir, rewriteLeafLogLaneID, leafStartSeq)
+	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
+	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
+	writer.leafBlockCodec = leafPageBlockCodecFromOptions(db.valueLogCompression, db.valueLogAutoPolicy, db.valueLogBlockCodec, db.indexOuterLeavesInValueLog)
+	writer.nextRID = nextRID
+	defer func() { _ = writer.Close() }()
+
+	if writer.blockCompression {
+		state := db.state.Load()
+		if state != nil {
+			leafDictID, leafDictBytes, leafDictUseRawPages, dictErr := prepareRewriteLeafDict(db, state, db.valueLogDictCurrentForClass, db.valueLogDictLeafPayloadMode, db.valueLogDictLookup, db.valueLogDictPut, db.valueLogDictSetCurrentForClass, db.valueLogDictSetLeafPayloadMode, compression.TrainConfig{})
+			if dictErr != nil {
+				return 0, dictErr
+			}
+			if leafDictID != 0 && len(leafDictBytes) > 0 {
+				writer.SetLeafDictMode(leafDictID, leafDictBytes, leafDictUseRawPages)
+			}
+		}
+	}
+
+	sampleCandidate := leafLogicalRebuildCandidate{runRanges: sampleRanges}
+	if _, _, err := db.buildLogicalRebuildRuns(baseSnap, baseChildren, sampleCandidate, writer); err != nil {
+		return 0, err
+	}
+	if err := writer.Flush(); err != nil {
+		return 0, err
+	}
+	segments, err := writer.createdSegmentsSnapshot()
+	if err != nil {
+		return 0, err
+	}
+	return leafGenerationLogicalRebuildCreatedTotalBytes(segments)
 }
 
 func (db *DB) buildLogicalRebuildRuns(baseSnap *Snapshot, baseChildren []vacuumLeafChild, candidate leafLogicalRebuildCandidate, writer *rewriteWriter) ([]leafLogicalRebuildRunBuild, int, error) {

--- a/TreeDB/db/leaf_generation_logical_rebuild_online_test.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_online_test.go
@@ -1,0 +1,170 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func openLeafGenerationLogicalRebuildOnlineTestDB(t *testing.T, maxLeafSegmentBytes int64) (*DB, *rewriteWriter, string) {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                        dir,
+		Durability:                 DurabilityWALOffRelaxed,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		LeafPrefixCompression:      true,
+		IndexColumnarLeaves:        true,
+		IndexPackedValuePtr:        true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, maxLeafSegmentBytes)
+	leafLog.ConfigureLeafLog(LeafLogDirPath(dir), rewriteLeafLogLaneID, 0)
+	db.SetLeafPageLog(leafLog)
+	t.Cleanup(func() { closeNoErr(t, leafLog) })
+	t.Cleanup(func() { closeNoErr(t, db) })
+	return db, leafLog, dir
+}
+
+func TestLeafGenerationLogicalRebuildRunOnce_NoCandidate(t *testing.T) {
+	db, _, _ := openLeafGenerationLogicalRebuildOnlineTestDB(t, 1024)
+	writeLeafGenerationKeys(t, db, "k", 32, 'a')
+
+	_, err := db.LeafGenerationLogicalRebuildRunOnce(context.Background(), LeafGenerationLogicalRebuildRunOnceOptions{Sync: true})
+	if !errors.Is(err, ErrLeafGenerationLogicalRebuildNoCandidate) {
+		t.Fatalf("LeafGenerationLogicalRebuildRunOnce err=%v, want %v", err, ErrLeafGenerationLogicalRebuildNoCandidate)
+	}
+}
+
+func TestLeafGenerationLogicalRebuildRunOnce_RetiresSelectedGenerationAndPreservesSnapshot(t *testing.T) {
+	db, leafLog, dir := openLeafGenerationLogicalRebuildOnlineTestDB(t, 64<<20)
+	writeLeafGenerationKeyRange(t, db, "k", 0, 256, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, db, "k", 256, 256, 'b')
+
+	baseSnap := db.AcquireSnapshot()
+	candidate, _, err := db.selectLeafGenerationLogicalRebuildCandidate(baseSnap, 0, 0)
+	if err != nil {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("selectLeafGenerationLogicalRebuildCandidate: %v", err)
+	}
+	publishedCommitSeq := uint64(0)
+	for _, gen := range db.leafGenerationManifest.Generations {
+		if gen.GenerationID == candidate.generationID {
+			publishedCommitSeq = gen.PublishedCommitSeq
+			break
+		}
+	}
+	if publishedCommitSeq == 0 {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("missing published commit seq for generation %d", candidate.generationID)
+	}
+	if _, _, err := db.selectLeafGenerationLogicalRebuildCandidate(baseSnap, candidate.rawFileID, publishedCommitSeq-1); !errors.Is(err, ErrLeafGenerationLogicalRebuildNoCandidate) {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("selectLeafGenerationLogicalRebuildCandidate older watermark err=%v, want %v", err, ErrLeafGenerationLogicalRebuildNoCandidate)
+	}
+
+	keyBefore := leafGenerationKey("k", 17)
+	snapValue, err := baseSnap.Get(keyBefore)
+	if err != nil {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("snapshot Get before rebuild: %v", err)
+	}
+	wantValue := bytes.Repeat([]byte{'a'}, 32)
+	if !bytes.Equal(snapValue, wantValue) {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("snapshot value before rebuild=%x, want %x", snapValue, wantValue)
+	}
+
+	stats, err := db.LeafGenerationLogicalRebuildRunOnce(context.Background(), LeafGenerationLogicalRebuildRunOnceOptions{
+		RawFileID: candidate.rawFileID,
+		Sync:      true,
+	})
+	if err != nil {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("LeafGenerationLogicalRebuildRunOnce: %v", err)
+	}
+	if got, want := stats.SelectedRawFileID, candidate.rawFileID; got != want {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("SelectedRawFileID=%d, want %d", got, want)
+	}
+	if len(stats.CreatedFileIDs) == 0 {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("CreatedFileIDs empty in stats=%+v", stats)
+	}
+	if got, want := stats.RetiredGenerationIDs, []uint64{candidate.generationID}; len(got) != len(want) || got[0] != want[0] {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("RetiredGenerationIDs=%v, want %v", got, want)
+	}
+
+	manifestAfter := loadLeafGenerationManifestOrFatal(t, dir)
+	retired := findLeafGenerationByFileID(t, manifestAfter, candidate.rawFileID)
+	if got, want := retired.State, leafGenerationStateRetiring; got != want {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("retired generation state=%q, want %q", got, want)
+	}
+
+	got, err := db.Get(keyBefore)
+	if err != nil {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("db.Get after rebuild: %v", err)
+	}
+	if !bytes.Equal(got, wantValue) {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("db.Get after rebuild=%x, want %x", got, wantValue)
+	}
+
+	snapValue, err = baseSnap.Get(keyBefore)
+	if err != nil {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("snapshot Get after rebuild: %v", err)
+	}
+	if !bytes.Equal(snapValue, wantValue) {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("snapshot value after rebuild=%x, want %x", snapValue, wantValue)
+	}
+
+	gcStatsPinned, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})
+	if err != nil {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("LeafGenerationGC while snapshot pinned: %v", err)
+	}
+	if gcStatsPinned.GenerationsDeleted != 0 {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("GenerationsDeleted while pinned=%d, want 0", gcStatsPinned.GenerationsDeleted)
+	}
+	manifestPinned := loadLeafGenerationManifestOrFatal(t, dir)
+	pinnedGen := findLeafGenerationByFileID(t, manifestPinned, candidate.rawFileID)
+	if got, want := pinnedGen.State, leafGenerationStateRetiring; got != want {
+		closeNoErr(t, baseSnap)
+		t.Fatalf("pinned generation state=%q, want %q", got, want)
+	}
+
+	closeNoErr(t, baseSnap)
+
+	gcStatsDeleted, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC after snapshot close: %v", err)
+	}
+	if gcStatsDeleted.GenerationsDeleted == 0 {
+		t.Fatalf("GenerationsDeleted=%d, want > 0", gcStatsDeleted.GenerationsDeleted)
+	}
+	if _, err := os.Stat(leafGenerationFallbackPath(dir, candidate.rawFileID)); !os.IsNotExist(err) {
+		t.Fatalf("source leaf file still present after GC: err=%v", err)
+	}
+
+	for _, fileID := range stats.CreatedFileIDs {
+		if !page.IsValueLogFileID(fileID) {
+			t.Fatalf("created file id %d missing value-log bit", fileID)
+		}
+	}
+}

--- a/TreeDB/db/leaf_generation_logical_rebuild_online_test.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_online_test.go
@@ -43,11 +43,11 @@ func TestLeafGenerationLogicalRebuildRunOnce_NoCandidate(t *testing.T) {
 	}
 }
 
-func TestBuildLeafGenerationLogicalRebuildCandidates_ExpandsToClosedContiguousWindow(t *testing.T) {
+func TestBuildLeafGenerationLogicalRebuildCandidates_UsesEligibleRunUnion(t *testing.T) {
 	allSources := []leafLogicalRebuildSource{
-		{generationID: 11, rawFileID: 101, fileID: page.ValueLogFileID(101), firstIndex: 0, lastIndex: 2, sourcePages: 2, sourceBytes: 200, retireable: true},
-		{generationID: 12, rawFileID: 102, fileID: page.ValueLogFileID(102), firstIndex: 1, lastIndex: 3, sourcePages: 2, sourceBytes: 180, retireable: true},
-		{generationID: 13, rawFileID: 103, fileID: page.ValueLogFileID(103), firstIndex: 4, lastIndex: 5, sourcePages: 2, sourceBytes: 160},
+		{generationID: 11, rawFileID: 101, fileID: page.ValueLogFileID(101), firstIndex: 0, lastIndex: 11, ranges: [][2]int{{0, 1}, {10, 11}}, sourcePages: 4, sourceBytes: 200, retireable: true},
+		{generationID: 12, rawFileID: 102, fileID: page.ValueLogFileID(102), firstIndex: 3, lastIndex: 4, ranges: [][2]int{{3, 4}}, sourcePages: 2, sourceBytes: 180, retireable: true},
+		{generationID: 13, rawFileID: 103, fileID: page.ValueLogFileID(103), firstIndex: 6, lastIndex: 8, ranges: [][2]int{{6, 8}}, sourcePages: 3, sourceBytes: 160},
 	}
 	eligibleSources := allSources[:2]
 
@@ -57,23 +57,48 @@ func TestBuildLeafGenerationLogicalRebuildCandidates_ExpandsToClosedContiguousWi
 	}
 	found := false
 	for _, got := range candidates {
-		if len(got.runRanges) != 1 {
-			t.Fatalf("runRanges=%v, want single contiguous range", got.runRanges)
-		}
-		if got.runRanges[0] != ([2]int{0, 3}) {
+		if len(got.rawFileIDs) != 2 {
 			continue
 		}
-		if len(got.rawFileIDs) != 2 {
-			t.Fatalf("rawFileIDs=%v, want 2-file window", got.rawFileIDs)
+		if len(got.runRanges) != 3 {
+			t.Fatalf("runRanges=%v, want three disjoint slices", got.runRanges)
+		}
+		if got.runRanges[0] != ([2]int{0, 1}) || got.runRanges[1] != ([2]int{3, 4}) || got.runRanges[2] != ([2]int{10, 11}) {
+			continue
 		}
 		if got.sourceBytes != 380 {
 			t.Fatalf("sourceBytes=%d, want 380", got.sourceBytes)
+		}
+		if got.windowPages != 6 {
+			t.Fatalf("windowPages=%d, want 6", got.windowPages)
 		}
 		found = true
 		break
 	}
 	if !found {
-		t.Fatalf("missing expected [0 3] two-file candidate in %v", candidates)
+		t.Fatalf("missing expected disjoint two-file candidate in %v", candidates)
+	}
+}
+
+func TestLeafGenerationLogicalRebuildSampleRanges_PicksBoundedSlices(t *testing.T) {
+	const maxPages = 96
+	got := leafGenerationLogicalRebuildSampleRanges([][2]int{{0, 299}}, maxPages)
+	if len(got) == 0 {
+		t.Fatalf("sample ranges empty")
+	}
+	total := 0
+	for _, rr := range got {
+		total += rr[1] - rr[0] + 1
+	}
+	if total > maxPages {
+		t.Fatalf("sampled pages=%d, want <= %d", total, maxPages)
+	}
+	if got[0][0] != 0 {
+		t.Fatalf("first sample=%v, want to include start", got[0])
+	}
+	last := got[len(got)-1]
+	if last[1] != 299 {
+		t.Fatalf("last sample=%v, want to include end", last)
 	}
 }
 

--- a/TreeDB/db/leaf_generation_logical_rebuild_online_test.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_online_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/page"
@@ -34,6 +35,9 @@ func openLeafGenerationLogicalRebuildOnlineTestDB(t *testing.T, maxLeafSegmentBy
 }
 
 func TestLeafGenerationLogicalRebuildRunOnce_NoCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online leaf logical rebuild not supported on windows")
+	}
 	db, _, _ := openLeafGenerationLogicalRebuildOnlineTestDB(t, 1024)
 	writeLeafGenerationKeys(t, db, "k", 32, 'a')
 
@@ -103,15 +107,20 @@ func TestLeafGenerationLogicalRebuildSampleRanges_PicksBoundedSlices(t *testing.
 }
 
 func TestLeafGenerationLogicalRebuildRunOnce_RetiresSelectedGenerationAndPreservesSnapshot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online leaf logical rebuild not supported on windows")
+	}
 	db, leafLog, dir := openLeafGenerationLogicalRebuildOnlineTestDB(t, 64<<20)
-	writeLeafGenerationKeyRange(t, db, "k", 0, 256, 'a')
+	for _, fill := range []byte("abcdefghijklmnop") {
+		writeLeafGenerationKeyRange(t, db, "k", 0, 4096, fill)
+	}
 	if err := leafLog.rotateLeaf(); err != nil {
 		t.Fatalf("rotateLeaf: %v", err)
 	}
-	writeLeafGenerationKeyRange(t, db, "k", 256, 256, 'b')
+	writeLeafGenerationKeyRange(t, db, "k", 4096, 512, 'z')
 
 	baseSnap := db.AcquireSnapshot()
-	candidates, _, err := db.selectLeafGenerationLogicalRebuildCandidates(baseSnap, 0, 0, 4)
+	candidates, _, err := db.selectLeafGenerationLogicalRebuildCandidates(baseSnap, 0, 0, 1)
 	if err != nil {
 		closeNoErr(t, baseSnap)
 		t.Fatalf("selectLeafGenerationLogicalRebuildCandidates: %v", err)
@@ -139,15 +148,17 @@ func TestLeafGenerationLogicalRebuildRunOnce_RetiresSelectedGenerationAndPreserv
 		closeNoErr(t, baseSnap)
 		t.Fatalf("snapshot Get before rebuild: %v", err)
 	}
-	wantValue := bytes.Repeat([]byte{'a'}, 32)
+	wantValue := bytes.Repeat([]byte{'p'}, 32)
 	if !bytes.Equal(snapValue, wantValue) {
 		closeNoErr(t, baseSnap)
 		t.Fatalf("snapshot value before rebuild=%x, want %x", snapValue, wantValue)
 	}
 
 	stats, err := db.LeafGenerationLogicalRebuildRunOnce(context.Background(), LeafGenerationLogicalRebuildRunOnceOptions{
-		RawFileID: candidate.rawFileIDs[0],
-		Sync:      true,
+		RawFileID:       candidate.rawFileIDs[0],
+		ClusterFilesMax: 1,
+		CandidateTryMax: 1,
+		Sync:            true,
 	})
 	if err != nil {
 		closeNoErr(t, baseSnap)

--- a/TreeDB/db/leaf_generation_logical_rebuild_online_test.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_online_test.go
@@ -154,15 +154,27 @@ func TestLeafGenerationLogicalRebuildRunOnce_RetiresSelectedGenerationAndPreserv
 		t.Fatalf("snapshot value before rebuild=%x, want %x", snapValue, wantValue)
 	}
 
+	reserveCalls := 0
 	stats, err := db.LeafGenerationLogicalRebuildRunOnce(context.Background(), LeafGenerationLogicalRebuildRunOnceOptions{
 		RawFileID:       candidate.rawFileIDs[0],
 		ClusterFilesMax: 1,
 		CandidateTryMax: 1,
 		Sync:            true,
+		ReserveRIDs: func(count int) (uint64, error) {
+			reserveCalls++
+			if count <= 0 {
+				t.Fatalf("ReserveRIDs count=%d want > 0", count)
+			}
+			return 5000 + uint64(reserveCalls), nil
+		},
 	})
 	if err != nil {
 		closeNoErr(t, baseSnap)
 		t.Fatalf("LeafGenerationLogicalRebuildRunOnce: %v", err)
+	}
+	if reserveCalls == 0 {
+		closeNoErr(t, baseSnap)
+		t.Fatal("expected ReserveRIDs to be used during logical rebuild")
 	}
 	if got, want := stats.SelectedRawFileID, candidate.rawFileIDs[0]; got != want {
 		closeNoErr(t, baseSnap)

--- a/TreeDB/db/leaf_generation_logical_rebuild_online_test.go
+++ b/TreeDB/db/leaf_generation_logical_rebuild_online_test.go
@@ -43,6 +43,40 @@ func TestLeafGenerationLogicalRebuildRunOnce_NoCandidate(t *testing.T) {
 	}
 }
 
+func TestBuildLeafGenerationLogicalRebuildCandidates_ExpandsToClosedContiguousWindow(t *testing.T) {
+	allSources := []leafLogicalRebuildSource{
+		{generationID: 11, rawFileID: 101, fileID: page.ValueLogFileID(101), firstIndex: 0, lastIndex: 2, sourcePages: 2, sourceBytes: 200, retireable: true},
+		{generationID: 12, rawFileID: 102, fileID: page.ValueLogFileID(102), firstIndex: 1, lastIndex: 3, sourcePages: 2, sourceBytes: 180, retireable: true},
+		{generationID: 13, rawFileID: 103, fileID: page.ValueLogFileID(103), firstIndex: 4, lastIndex: 5, sourcePages: 2, sourceBytes: 160},
+	}
+	eligibleSources := allSources[:2]
+
+	candidates := buildLeafGenerationLogicalRebuildCandidates(allSources, eligibleSources, 2)
+	if len(candidates) == 0 {
+		t.Fatalf("buildLeafGenerationLogicalRebuildCandidates returned no candidates")
+	}
+	found := false
+	for _, got := range candidates {
+		if len(got.runRanges) != 1 {
+			t.Fatalf("runRanges=%v, want single contiguous range", got.runRanges)
+		}
+		if got.runRanges[0] != ([2]int{0, 3}) {
+			continue
+		}
+		if len(got.rawFileIDs) != 2 {
+			t.Fatalf("rawFileIDs=%v, want 2-file window", got.rawFileIDs)
+		}
+		if got.sourceBytes != 380 {
+			t.Fatalf("sourceBytes=%d, want 380", got.sourceBytes)
+		}
+		found = true
+		break
+	}
+	if !found {
+		t.Fatalf("missing expected [0 3] two-file candidate in %v", candidates)
+	}
+}
+
 func TestLeafGenerationLogicalRebuildRunOnce_RetiresSelectedGenerationAndPreservesSnapshot(t *testing.T) {
 	db, leafLog, dir := openLeafGenerationLogicalRebuildOnlineTestDB(t, 64<<20)
 	writeLeafGenerationKeyRange(t, db, "k", 0, 256, 'a')
@@ -52,25 +86,26 @@ func TestLeafGenerationLogicalRebuildRunOnce_RetiresSelectedGenerationAndPreserv
 	writeLeafGenerationKeyRange(t, db, "k", 256, 256, 'b')
 
 	baseSnap := db.AcquireSnapshot()
-	candidate, _, err := db.selectLeafGenerationLogicalRebuildCandidate(baseSnap, 0, 0)
+	candidates, _, err := db.selectLeafGenerationLogicalRebuildCandidates(baseSnap, 0, 0, 4)
 	if err != nil {
 		closeNoErr(t, baseSnap)
-		t.Fatalf("selectLeafGenerationLogicalRebuildCandidate: %v", err)
+		t.Fatalf("selectLeafGenerationLogicalRebuildCandidates: %v", err)
 	}
+	candidate := candidates[0]
 	publishedCommitSeq := uint64(0)
 	for _, gen := range db.leafGenerationManifest.Generations {
-		if gen.GenerationID == candidate.generationID {
+		if gen.GenerationID == candidate.generationIDs[0] {
 			publishedCommitSeq = gen.PublishedCommitSeq
 			break
 		}
 	}
 	if publishedCommitSeq == 0 {
 		closeNoErr(t, baseSnap)
-		t.Fatalf("missing published commit seq for generation %d", candidate.generationID)
+		t.Fatalf("missing published commit seq for generation %d", candidate.generationIDs[0])
 	}
-	if _, _, err := db.selectLeafGenerationLogicalRebuildCandidate(baseSnap, candidate.rawFileID, publishedCommitSeq-1); !errors.Is(err, ErrLeafGenerationLogicalRebuildNoCandidate) {
+	if _, _, err := db.selectLeafGenerationLogicalRebuildCandidates(baseSnap, candidate.rawFileIDs[0], publishedCommitSeq-1, 1); !errors.Is(err, ErrLeafGenerationLogicalRebuildNoCandidate) {
 		closeNoErr(t, baseSnap)
-		t.Fatalf("selectLeafGenerationLogicalRebuildCandidate older watermark err=%v, want %v", err, ErrLeafGenerationLogicalRebuildNoCandidate)
+		t.Fatalf("selectLeafGenerationLogicalRebuildCandidates older watermark err=%v, want %v", err, ErrLeafGenerationLogicalRebuildNoCandidate)
 	}
 
 	keyBefore := leafGenerationKey("k", 17)
@@ -86,14 +121,14 @@ func TestLeafGenerationLogicalRebuildRunOnce_RetiresSelectedGenerationAndPreserv
 	}
 
 	stats, err := db.LeafGenerationLogicalRebuildRunOnce(context.Background(), LeafGenerationLogicalRebuildRunOnceOptions{
-		RawFileID: candidate.rawFileID,
+		RawFileID: candidate.rawFileIDs[0],
 		Sync:      true,
 	})
 	if err != nil {
 		closeNoErr(t, baseSnap)
 		t.Fatalf("LeafGenerationLogicalRebuildRunOnce: %v", err)
 	}
-	if got, want := stats.SelectedRawFileID, candidate.rawFileID; got != want {
+	if got, want := stats.SelectedRawFileID, candidate.rawFileIDs[0]; got != want {
 		closeNoErr(t, baseSnap)
 		t.Fatalf("SelectedRawFileID=%d, want %d", got, want)
 	}
@@ -101,13 +136,13 @@ func TestLeafGenerationLogicalRebuildRunOnce_RetiresSelectedGenerationAndPreserv
 		closeNoErr(t, baseSnap)
 		t.Fatalf("CreatedFileIDs empty in stats=%+v", stats)
 	}
-	if got, want := stats.RetiredGenerationIDs, []uint64{candidate.generationID}; len(got) != len(want) || got[0] != want[0] {
+	if got, want := stats.RetiredGenerationIDs, []uint64{candidate.generationIDs[0]}; len(got) != len(want) || got[0] != want[0] {
 		closeNoErr(t, baseSnap)
 		t.Fatalf("RetiredGenerationIDs=%v, want %v", got, want)
 	}
 
 	manifestAfter := loadLeafGenerationManifestOrFatal(t, dir)
-	retired := findLeafGenerationByFileID(t, manifestAfter, candidate.rawFileID)
+	retired := findLeafGenerationByFileID(t, manifestAfter, candidate.rawFileIDs[0])
 	if got, want := retired.State, leafGenerationStateRetiring; got != want {
 		closeNoErr(t, baseSnap)
 		t.Fatalf("retired generation state=%q, want %q", got, want)
@@ -143,7 +178,7 @@ func TestLeafGenerationLogicalRebuildRunOnce_RetiresSelectedGenerationAndPreserv
 		t.Fatalf("GenerationsDeleted while pinned=%d, want 0", gcStatsPinned.GenerationsDeleted)
 	}
 	manifestPinned := loadLeafGenerationManifestOrFatal(t, dir)
-	pinnedGen := findLeafGenerationByFileID(t, manifestPinned, candidate.rawFileID)
+	pinnedGen := findLeafGenerationByFileID(t, manifestPinned, candidate.rawFileIDs[0])
 	if got, want := pinnedGen.State, leafGenerationStateRetiring; got != want {
 		closeNoErr(t, baseSnap)
 		t.Fatalf("pinned generation state=%q, want %q", got, want)
@@ -158,7 +193,7 @@ func TestLeafGenerationLogicalRebuildRunOnce_RetiresSelectedGenerationAndPreserv
 	if gcStatsDeleted.GenerationsDeleted == 0 {
 		t.Fatalf("GenerationsDeleted=%d, want > 0", gcStatsDeleted.GenerationsDeleted)
 	}
-	if _, err := os.Stat(leafGenerationFallbackPath(dir, candidate.rawFileID)); !os.IsNotExist(err) {
+	if _, err := os.Stat(leafGenerationFallbackPath(dir, candidate.rawFileIDs[0])); !os.IsNotExist(err) {
 		t.Fatalf("source leaf file still present after GC: err=%v", err)
 	}
 

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2841,6 +2841,7 @@ type rewriteWriter struct {
 	leafLane uint32
 	leafSeq  uint32
 	nextRID  uint64
+	ridAlloc *rewriteRIDAllocator
 	// currentPath/currentFileID cache the active writer segment identity so
 	// CurrentValueLogSegment can avoid per-call path/fileID recomputation.
 	currentPath       string
@@ -3014,6 +3015,13 @@ func (w *rewriteWriter) flushPendingDictBatch() error {
 func (w *rewriteWriter) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if w == nil {
 		return page.LeafLogPtr{}, errors.New("vlog-rewrite: nil writer")
+	}
+	if w.ridAlloc != nil {
+		rid, err := w.ridAlloc.Next()
+		if err != nil {
+			return page.LeafLogPtr{}, err
+		}
+		return w.appendLeafPageWithRID(rid, leafPage)
 	}
 	if w.nextRID == 0 {
 		w.nextRID = 1

--- a/TreeDB/leaf_generation_logical_rebuild.go
+++ b/TreeDB/leaf_generation_logical_rebuild.go
@@ -1,10 +1,26 @@
 package treedb
 
-import treedbdb "github.com/snissn/gomap/TreeDB/db"
+import (
+	"context"
+
+	treedbdb "github.com/snissn/gomap/TreeDB/db"
+)
 
 // LeafGenerationLogicalRebuildStats summarizes a frozen leaf-only logical
 // rebuild that rewrites outer-leaf pages and swaps a fresh index.
 type LeafGenerationLogicalRebuildStats = treedbdb.LeafGenerationLogicalRebuildStats
+
+// ErrLeafGenerationLogicalRebuildNoCandidate reports that no eligible sealed
+// single-file leaf run was available for an online rebuild pass.
+var ErrLeafGenerationLogicalRebuildNoCandidate = treedbdb.ErrLeafGenerationLogicalRebuildNoCandidate
+
+// LeafGenerationLogicalRebuildRunOnceOptions controls one incremental online
+// logical rebuild pass over a single eligible sealed leaf file.
+type LeafGenerationLogicalRebuildRunOnceOptions = treedbdb.LeafGenerationLogicalRebuildRunOnceOptions
+
+// LeafGenerationLogicalRebuildRunOnceStats summarizes one incremental online
+// logical rebuild pass.
+type LeafGenerationLogicalRebuildRunOnceStats = treedbdb.LeafGenerationLogicalRebuildRunOnceStats
 
 // LeafGenerationLogicalRebuildOffline rebuilds outer-leaf pages logically into
 // a fresh leaf_vlog directory and swaps it with a fresh index.db under the
@@ -36,4 +52,34 @@ func LeafGenerationLogicalRebuildOffline(opts Options) (LeafGenerationLogicalReb
 		return LeafGenerationLogicalRebuildStats{}, err
 	}
 	return LeafGenerationLogicalRebuildStats(stats), nil
+}
+
+// LeafGenerationLogicalRebuildRunOnce performs one incremental online logical
+// rebuild pass against an eligible sealed single-file leaf run.
+//
+// In cached mode, this first checkpoints so the backend matches the durable
+// tree before the online maintenance pass begins.
+func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts LeafGenerationLogicalRebuildRunOnceOptions) (LeafGenerationLogicalRebuildRunOnceStats, error) {
+	var out LeafGenerationLogicalRebuildRunOnceStats
+	if err := db.ensureOpen(); err != nil {
+		return out, err
+	}
+	if db.backend == nil {
+		return out, ErrClosed
+	}
+	_, finishMaintenance := db.beginFullScanMaintenance("leaf-logical-rebuild")
+	success := false
+	defer func() { finishMaintenance(success) }()
+
+	if db.cached != nil {
+		if err := db.Checkpoint(); err != nil {
+			return out, err
+		}
+	}
+	stats, err := db.backend.LeafGenerationLogicalRebuildRunOnce(ctx, treedbdb.LeafGenerationLogicalRebuildRunOnceOptions(opts))
+	if err != nil {
+		return out, err
+	}
+	success = true
+	return LeafGenerationLogicalRebuildRunOnceStats(stats), nil
 }

--- a/TreeDB/leaf_generation_logical_rebuild.go
+++ b/TreeDB/leaf_generation_logical_rebuild.go
@@ -76,7 +76,11 @@ func (db *DB) LeafGenerationLogicalRebuildRunOnce(ctx context.Context, opts Leaf
 			return out, err
 		}
 	}
-	stats, err := db.backend.LeafGenerationLogicalRebuildRunOnce(ctx, treedbdb.LeafGenerationLogicalRebuildRunOnceOptions(opts))
+	backendOpts := treedbdb.LeafGenerationLogicalRebuildRunOnceOptions(opts)
+	if db.cached != nil {
+		backendOpts.ReserveRIDs = db.cached.ReserveValueLogRIDs
+	}
+	stats, err := db.backend.LeafGenerationLogicalRebuildRunOnce(ctx, backendOpts)
 	if err != nil {
 		return out, err
 	}

--- a/docs/benchmarks/ONLINE_LEAF_LOGICAL_REBUILD_20260417.md
+++ b/docs/benchmarks/ONLINE_LEAF_LOGICAL_REBUILD_20260417.md
@@ -1,0 +1,142 @@
+# Online Leaf Logical Rebuild
+
+This note measures the manual online incremental logical rebuild operator added
+on `codex/online-leaf-logical-rebuild`.
+
+## Goal
+
+Take the frozen logical rebuild proof from `#986` and turn it into a bounded
+online-style operator that:
+
+- rebuilds one sealed outer-leaf candidate at a time
+- publishes through the vacuum-style index cutover path
+- makes durable incremental progress
+- stops instead of publishing a regression
+
+## Command
+
+Binary:
+
+```bash
+GOWORK=off go build -o /tmp/treemap-online-leaf ./TreeDB/cmd/treemap
+```
+
+Campaign on a frozen copy of a recent `main wal_on_fast` post-dwell DB:
+
+```bash
+/tmp/treemap-online-leaf leafgen-logical-rebuild-run \
+  /tmp/online_leaf_rebuild_watermark_gate_1776482663 \
+  -rw \
+  -json \
+  -max-published-commit-seq 3118
+```
+
+After each successful run:
+
+```bash
+/tmp/treemap-online-leaf leafgen-gc /tmp/online_leaf_rebuild_watermark_gate_1776482663 -rw -json
+```
+
+The `3118` watermark pins candidate selection to the original sealed generation
+population from the source DB, so the campaign does not immediately start
+rewriting its own outputs.
+
+## Source
+
+Frozen source copy from:
+
+```text
+/home/mikers/.celestia-app-mainnet-treedb-20260417111043/data/application.db
+```
+
+Measured working copy:
+
+```text
+/tmp/online_leaf_rebuild_watermark_gate_1776482663
+```
+
+Offline rewrite leaf floor for the same source, from `#986`:
+
+- `leaf_vlog = 2,139,653,385`
+
+## Result
+
+Before campaign:
+
+- `application.db = 2,576,631,807`
+- `leaf_vlog = 2,345,184,409`
+- `index.db = 61,341,696`
+- `value_vlog = 169,699,763`
+
+After 3 successful runs plus GC after each run:
+
+- `application.db = 2,557,070,258`
+- `leaf_vlog = 2,332,962,892`
+- `index.db = 54,001,664`
+- `value_vlog = 169,699,763`
+
+Net improvement:
+
+- `application.db`: `-19,561,549`
+- `leaf_vlog`: `-12,221,517`
+- `index.db`: `-7,340,032`
+- `value_vlog`: unchanged
+
+Leaf gap against the matching offline rewrite floor:
+
+- before: `205,531,024`
+- after: `193,309,507`
+- closed: `12,221,517` (`5.95%`)
+
+## Successful Runs
+
+Run 1:
+
+- generation `149`
+- raw file `2139095189`
+- source leaf pages `73,675`
+- source bytes `131,137,625`
+- replacement leaf pages `67,559`
+
+Run 2:
+
+- generation `151`
+- raw file `2139095191`
+- source leaf pages `59,395`
+- source bytes `59,827,719`
+- replacement leaf pages `46,881`
+
+Run 3:
+
+- generation `147`
+- raw file `2139095187`
+- source leaf pages `48,221`
+- source bytes `76,769,028`
+- replacement leaf pages `45,270`
+
+Run 4:
+
+- stopped with `leaf logical rebuild: no eligible sealed single-file candidate`
+- this is the intended gated behavior for v1: once the remaining original
+  candidates fail the size-improvement check, the operator stops instead of
+  publishing a larger replacement
+
+## Interpretation
+
+This branch proves three things:
+
+1. The online operator can make real durable incremental progress on the real
+   Celestia-shaped sealed population.
+2. The vacuum-coupled publish path works for this leaf-only logical rebuild.
+3. A hard size gate is required. Without it, the campaign eventually starts
+   publishing larger rebuilt files.
+
+This is not yet a high-closure maintenance system. It is a safe bounded online
+primitive with real positive progress and a clear stop condition.
+
+The next likely improvement is candidate quality, not more cutover work:
+
+- broader candidate search within the same watermark
+- better predicted-bytes-saved admission before rebuild
+- possibly candidate grouping beyond a single sealed file where the live refs
+  are too fragmented for a single-file rebuild to recover much density

--- a/docs/benchmarks/ONLINE_LEAF_LOGICAL_REBUILD_20260417.md
+++ b/docs/benchmarks/ONLINE_LEAF_LOGICAL_REBUILD_20260417.md
@@ -1,17 +1,19 @@
 # Online Leaf Logical Rebuild
 
 This note measures the manual online incremental logical rebuild operator added
-on `codex/online-leaf-logical-rebuild`.
+on `codex/online-leaf-logical-rebuild`, including the later planner/admission
+iterations after the initial clustered-file prototype.
 
 ## Goal
 
 Take the frozen logical rebuild proof from `#986` and turn it into a bounded
 online-style operator that:
 
-- rebuilds one sealed outer-leaf candidate at a time
+- rebuilds one bounded contiguous outer-leaf window at a time
 - publishes through the vacuum-style index cutover path
 - makes durable incremental progress
-- stops instead of publishing a regression
+- stops instead of publishing a regression or spending unbounded time searching
+  wide low-yield clusters
 
 ## Command
 
@@ -21,20 +23,23 @@ Binary:
 GOWORK=off go build -o /tmp/treemap-online-leaf ./TreeDB/cmd/treemap
 ```
 
-Campaign on a frozen copy of a recent `main wal_on_fast` post-dwell DB:
+Conservative campaign on a frozen copy of a recent `main wal_on_fast`
+post-dwell DB:
 
 ```bash
 /tmp/treemap-online-leaf leafgen-logical-rebuild-run \
-  /tmp/online_leaf_rebuild_watermark_gate_1776482663 \
+  /tmp/online_leaf_rebuild_ranked_try1_1776487209 \
   -rw \
   -json \
-  -max-published-commit-seq 3118
+  -max-published-commit-seq 3118 \
+  -cluster-files-max 8 \
+  -candidate-try-max 1
 ```
 
 After each successful run:
 
 ```bash
-/tmp/treemap-online-leaf leafgen-gc /tmp/online_leaf_rebuild_watermark_gate_1776482663 -rw -json
+/tmp/treemap-online-leaf leafgen-gc /tmp/online_leaf_rebuild_ranked_try1_1776487209 -rw -json
 ```
 
 The `3118` watermark pins candidate selection to the original sealed generation
@@ -52,7 +57,7 @@ Frozen source copy from:
 Measured working copy:
 
 ```text
-/tmp/online_leaf_rebuild_watermark_gate_1776482663
+/tmp/online_leaf_rebuild_ranked_try1_1776487209
 ```
 
 Offline rewrite leaf floor for the same source, from `#986`:
@@ -68,75 +73,80 @@ Before campaign:
 - `index.db = 61,341,696`
 - `value_vlog = 169,699,763`
 
-After 3 successful runs plus GC after each run:
+After 1 successful run plus GC:
 
-- `application.db = 2,557,070,258`
-- `leaf_vlog = 2,332,962,892`
-- `index.db = 54,001,664`
+- `application.db = 2,562,828,875`
+- `leaf_vlog = 2,337,671,285`
+- `index.db = 55,050,240`
 - `value_vlog = 169,699,763`
 
 Net improvement:
 
-- `application.db`: `-19,561,549`
-- `leaf_vlog`: `-12,221,517`
-- `index.db`: `-7,340,032`
+- `application.db`: `-13,802,932`
+- `leaf_vlog`: `-7,513,124`
+- `index.db`: `-6,291,456`
 - `value_vlog`: unchanged
 
 Leaf gap against the matching offline rewrite floor:
 
 - before: `205,531,024`
-- after: `193,309,507`
-- closed: `12,221,517` (`5.95%`)
+- after: `198,017,900`
+- closed: `7,513,124` (`3.66%`)
 
-## Successful Runs
+## Successful Run
 
 Run 1:
 
-- generation `149`
-- raw file `2139095189`
-- source leaf pages `73,675`
-- source bytes `131,137,625`
-- replacement leaf pages `67,559`
+- generation `52`
+- raw file `2139095092`
+- source leaf pages `8,308`
+- source bytes `33,555,865`
+- replacement leaf pages `8,458`
+- elapsed: `4.17s`
 
 Run 2:
 
-- generation `151`
-- raw file `2139095191`
-- source leaf pages `59,395`
-- source bytes `59,827,719`
-- replacement leaf pages `46,881`
+- stopped with `leaf logical rebuild: no eligible sealed incremental candidate`
+- this is with `candidate-try-max=1`, so the operator refused to spend more
+  rebuild work on lower-ranked same-width candidates once the top-ranked
+  width tiers had no publishable winner
 
-Run 3:
+## Planner Iterations
 
-- generation `147`
-- raw file `2139095187`
-- source leaf pages `48,221`
-- source bytes `76,769,028`
-- replacement leaf pages `45,270`
+The earlier clustered prototype was not a good admission policy:
 
-Run 4:
+- scattered 4-file clusters produced tens of thousands of disjoint run slices
+- later runs could regress `leaf_vlog` after GC even when the local `.log` gate
+  passed
+- larger `candidate-try-max` values reintroduced long rebuild-and-reject search
 
-- stopped with `leaf logical rebuild: no eligible sealed single-file candidate`
-- this is the intended gated behavior for v1: once the remaining original
-  candidates fail the size-improvement check, the operator stops instead of
-  publishing a larger replacement
+The current manual operator now does three things differently:
+
+1. candidate windows are ranked narrow-first
+2. within a width tier, ranking prefers higher bytes-per-page density
+3. publish gating uses total leaf footprint, including `.lenidx`, not only the
+   raw `.log` byte size
 
 ## Interpretation
 
-This branch proves three things:
+This branch now proves four things:
 
 1. The online operator can make real durable incremental progress on the real
    Celestia-shaped sealed population.
 2. The vacuum-coupled publish path works for this leaf-only logical rebuild.
-3. A hard size gate is required. Without it, the campaign eventually starts
-   publishing larger rebuilt files.
+3. A hard total-byte gate is required. The earlier `.log`-only gate was too
+   weak and allowed flat or regressive clustered publishes.
+4. Candidate search cost is now the dominant issue. `candidate-try-max=1`
+   gives a fast safe positive step; larger search budgets start paying a lot of
+   rebuild work just to discover that most remaining candidates are not worth
+   publishing.
 
-This is not yet a high-closure maintenance system. It is a safe bounded online
-primitive with real positive progress and a clear stop condition.
+This is still not a high-closure maintenance system. It is a safer manual
+online primitive with one clear positive incremental step and a tighter
+admission policy.
 
-The next likely improvement is candidate quality, not more cutover work:
+The next likely improvement is a better pre-rebuild planner:
 
-- broader candidate search within the same watermark
-- better predicted-bytes-saved admission before rebuild
-- possibly candidate grouping beyond a single sealed file where the live refs
-  are too fragmented for a single-file rebuild to recover much density
+- expose candidate windows without rebuilding them
+- estimate total bytes saved before invoking `bulk.BuildWithOptions(...)`
+- only spend rebuild work on candidates with a strong expected total-byte win

--- a/docs/benchmarks/ONLINE_LEAF_LOGICAL_REBUILD_20260417.md
+++ b/docs/benchmarks/ONLINE_LEAF_LOGICAL_REBUILD_20260417.md
@@ -1,19 +1,19 @@
 # Online Leaf Logical Rebuild
 
 This note measures the manual online incremental logical rebuild operator added
-on `codex/online-leaf-logical-rebuild`, including the later planner/admission
-iterations after the initial clustered-file prototype.
+on `codex/online-leaf-logical-rebuild`, including the planner iterations after
+the initial clustered-file prototype.
 
 ## Goal
 
 Take the frozen logical rebuild proof from `#986` and turn it into a bounded
 online-style operator that:
 
-- rebuilds one bounded contiguous outer-leaf window at a time
+- rebuilds one bounded outer-leaf candidate at a time
 - publishes through the vacuum-style index cutover path
 - makes durable incremental progress
 - stops instead of publishing a regression or spending unbounded time searching
-  wide low-yield clusters
+  low-yield candidates
 
 ## Command
 
@@ -23,23 +23,21 @@ Binary:
 GOWORK=off go build -o /tmp/treemap-online-leaf ./TreeDB/cmd/treemap
 ```
 
-Conservative campaign on a frozen copy of a recent `main wal_on_fast`
-post-dwell DB:
+Bounded campaign on a frozen copy of a recent `main wal_on_fast` post-dwell DB:
 
 ```bash
-/tmp/treemap-online-leaf leafgen-logical-rebuild-run \
-  /tmp/online_leaf_rebuild_ranked_try1_1776487209 \
-  -rw \
-  -json \
-  -max-published-commit-seq 3118 \
-  -cluster-files-max 8 \
-  -candidate-try-max 1
-```
-
-After each successful run:
-
-```bash
-/tmp/treemap-online-leaf leafgen-gc /tmp/online_leaf_rebuild_ranked_try1_1776487209 -rw -json
+for run in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  /tmp/treemap-online-leaf leafgen-logical-rebuild-run \
+    /tmp/online_leaf_rebuild_ranges_1776489806 \
+    -rw \
+    -json \
+    -max-published-commit-seq 3118 \
+    -cluster-files-max 8 \
+    -candidate-try-max 4 >> /tmp/online_leaf_rebuild_ranges_1776489806/campaign.jsonl \
+  && /tmp/treemap-online-leaf leafgen-gc /tmp/online_leaf_rebuild_ranges_1776489806 -rw -json \
+    >> /tmp/online_leaf_rebuild_ranges_1776489806/campaign.jsonl \
+  || break
+done
 ```
 
 The `3118` watermark pins candidate selection to the original sealed generation
@@ -57,7 +55,7 @@ Frozen source copy from:
 Measured working copy:
 
 ```text
-/tmp/online_leaf_rebuild_ranked_try1_1776487209
+/tmp/online_leaf_rebuild_ranges_1776489806
 ```
 
 Offline rewrite leaf floor for the same source, from `#986`:
@@ -71,82 +69,105 @@ Before campaign:
 - `application.db = 2,576,631,807`
 - `leaf_vlog = 2,345,184,409`
 - `index.db = 61,341,696`
-- `value_vlog = 169,699,763`
+- `value_vlog = 169,695,667`
 
-After 1 successful run plus GC:
+After 12 successful runs plus GC:
 
-- `application.db = 2,562,828,875`
-- `leaf_vlog = 2,337,671,285`
-- `index.db = 55,050,240`
-- `value_vlog = 169,699,763`
+- `application.db = 2,521,680,293`
+- `leaf_vlog = 2,298,855,009`
+- `index.db = 52,690,944`
+- `value_vlog = 169,695,667`
 
 Net improvement:
 
-- `application.db`: `-13,802,932`
-- `leaf_vlog`: `-7,513,124`
-- `index.db`: `-6,291,456`
+- `application.db`: `-54,951,514`
+- `leaf_vlog`: `-46,329,400`
+- `index.db`: `-8,650,752`
 - `value_vlog`: unchanged
 
 Leaf gap against the matching offline rewrite floor:
 
 - before: `205,531,024`
-- after: `198,017,900`
-- closed: `7,513,124` (`3.66%`)
+- after: `159,201,624`
+- closed: `46,329,400` (`22.54%`)
 
-## Successful Run
+Compared to the earlier safe-but-weak online planner result on the same source:
 
-Run 1:
+- old planner closed `7,513,124` of leaf gap (`3.66%`)
+- current planner closes `46,329,400` of leaf gap (`22.54%`)
+- improvement over the old planner: `+38,816,276` leaf bytes
 
-- generation `52`
-- raw file `2139095092`
-- source leaf pages `8,308`
-- source bytes `33,555,865`
-- replacement leaf pages `8,458`
-- elapsed: `4.17s`
+## Campaign Shape
 
-Run 2:
+The campaign stayed incremental all the way through 12 bounded runs:
 
-- stopped with `leaf logical rebuild: no eligible sealed incremental candidate`
-- this is with `candidate-try-max=1`, so the operator refused to spend more
-  rebuild work on lower-ranked same-width candidates once the top-ranked
-  width tiers had no publishable winner
+- runs `1-5` found smaller single-, two-, and three-generation candidates
+- runs `6-12` continued making progress with wider three- and four-generation
+  candidates
+- every successful run was followed by `leafgen-gc`, and the post-GC DB stayed
+  smaller after each publish
+
+Largest later successful candidates:
+
+- run `10`
+  - generations: `185, 19, 30, 31`
+  - source files: `4`
+  - source bytes: `106,454,649`
+  - replacement pages: `43,604`
+  - elapsed: `35.27s`
+- run `11`
+  - generations: `33, 34, 35, 110`
+  - source files: `4`
+  - source bytes: `108,591,276`
+  - replacement pages: `45,270`
+  - elapsed: `35.98s`
+- run `12`
+  - generations: `28, 29, 49`
+  - source files: `3`
+  - source bytes: `100,666,724`
+  - replacement pages: `34,383`
+  - elapsed: `34.50s`
 
 ## Planner Iterations
 
-The earlier clustered prototype was not a good admission policy:
+The initial online planner had two structural problems:
 
-- scattered 4-file clusters produced tens of thousands of disjoint run slices
-- later runs could regress `leaf_vlog` after GC even when the local `.log` gate
-  passed
-- larger `candidate-try-max` values reintroduced long rebuild-and-reject search
+1. it collapsed each source file to one `firstIndex..lastIndex` span, which
+   forced rebuilds across bridge pages between disjoint live runs
+2. it had no cheap pre-rebuild estimate, so larger search budgets could spend a
+   lot of time doing full logical rebuilds only to reject them at publish time
 
-The current manual operator now does three things differently:
+The current manual operator now does four things differently:
 
-1. candidate windows are ranked narrow-first
-2. within a width tier, ranking prefers higher bytes-per-page density
-3. publish gating uses total leaf footprint, including `.lenidx`, not only the
-   raw `.log` byte size
+1. candidate groups are still ranked narrow-first
+2. within a width tier, ranking prefers higher retireable-bytes per rebuilt page
+3. each sealed file contributes the union of its live contiguous ranges rather
+   than one giant bridged span
+4. a pilot rebuild estimate samples bounded ranges before the full rebuild and
+   skips candidates that are unlikely to clear the total-byte savings gate
 
 ## Interpretation
 
-This branch now proves four things:
+This branch now proves five things:
 
 1. The online operator can make real durable incremental progress on the real
    Celestia-shaped sealed population.
 2. The vacuum-coupled publish path works for this leaf-only logical rebuild.
-3. A hard total-byte gate is required. The earlier `.log`-only gate was too
-   weak and allowed flat or regressive clustered publishes.
-4. Candidate search cost is now the dominant issue. `candidate-try-max=1`
-   gives a fast safe positive step; larger search budgets start paying a lot of
-   rebuild work just to discover that most remaining candidates are not worth
-   publishing.
+3. The pre-rebuild planner matters more than the cutover path now. The jump
+   from `3.66%` to `22.54%` leaf-gap closure came from better candidate
+   modeling, not from changing the publish mechanism.
+4. A hard total-byte gate is still required. The operator remains safe because
+   it only publishes candidates that leave the DB smaller after GC.
+5. The online path is still materially below the frozen logical rebuild ceiling.
+   It now closes a meaningful fraction of the leaf gap, but not enough to claim
+   parity with offline rewrite.
 
-This is still not a high-closure maintenance system. It is a safer manual
-online primitive with one clear positive incremental step and a tighter
-admission policy.
+This is now a real online primitive, not just a one-shot proof. But it is still
+not the final maintenance design.
 
-The next likely improvement is a better pre-rebuild planner:
+The next likely improvement is not more cutover work. It is one of:
 
-- expose candidate windows without rebuilding them
-- estimate total bytes saved before invoking `bulk.BuildWithOptions(...)`
-- only spend rebuild work on candidates with a strong expected total-byte win
+- better grouping of multi-generation candidates before pilot rebuild
+- stronger stop conditions based on marginal savings per run
+- eventually, scheduler integration after the manual operator is judged good
+  enough to automate


### PR DESCRIPTION
## What changed

This adds a manual online-style outer-leaf logical rebuild operator on top of the frozen harness work in `#986`.

The new path:
- plans one eligible sealed single-file outer-leaf candidate at a time
- rebuilds that candidate logically, not by page-copy transcode
- uses the vacuum-style index cutover path to publish a new root and retire the old leaf generation
- exposes a manual `treemap leafgen-logical-rebuild-run` command
- records the real-source measurement in `docs/benchmarks/ONLINE_LEAF_LOGICAL_REBUILD_20260417.md`

## Why it changed

The frozen harness in `#986` proved that logical rebuild is the right compression shape for outer leaves.

The next missing step was a bounded online primitive that can make durable incremental progress without a whole-store offline rewrite.

This PR builds that first primitive and adds a hard size gate so it stops instead of publishing a larger rebuilt leaf file.

## Impact

This is a manual operator, not a scheduler-integrated maintenance path yet.

It is intentionally narrow:
- sealed single-file generations only
- incremental one-run publication
- vacuum-coupled cutover
- stop on no-savings

On a recent frozen `main wal_on_fast` post-dwell DB copy, the gated campaign produced 3 successful runs and then stopped cleanly at the first non-improving candidate:
- `application.db`: `2,576,631,807 -> 2,557,070,258` (`-19,561,549`)
- `leaf_vlog`: `2,345,184,409 -> 2,332,962,892` (`-12,221,517`)
- matching offline rewrite leaf floor: `2,139,653,385`
- leaf gap closed: `12,221,517` (`5.95%`)

## Root cause

Page-copy transcode could not reproduce offline rewrite savings because it preserved existing leaf page boundaries.

Logical rebuild fixes that by rebuilding fresh outer-leaf pages from logical entries, then publishing them through the normal snapshot-safe state transition path.

## Validation

- `GOWORK=off go test ./TreeDB/db -run 'Test(LeafGenerationLogicalRebuildRunOnce_|ClosedDB_LeafGenerationLogicalRebuildRunOnce)$' -count=1`
- `GOWORK=off go test ./TreeDB/cmd/treemap -run 'TestUsageTextMentionsLeafGenerationLogicalRebuild(Run|Bench)$' -count=1`
- `GOWORK=off go test ./TreeDB -run '^$' -count=1`
- real frozen-copy campaign documented in `docs/benchmarks/ONLINE_LEAF_LOGICAL_REBUILD_20260417.md`
