### PR TITLE
[codex] improve TreeDB valuelog compact leaf reads

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24698,6 +24698,46 @@ func (db *DB) Stats() map[string]string {
 	if growStats.RequestedBytesTotal > 0 {
 		stats["treedb.cache.vlog_decode_buffer_grow.overalloc_ratio"] = fmt.Sprintf("%.6f", float64(growStats.AllocatedBytesTotal)/float64(growStats.RequestedBytesTotal))
 	}
+	readInst := valuelog.ReadInstrumentationStatsSnapshot()
+	stats["treedb.cache.vlog_compact_leaf_decode.calls_total"] = fmt.Sprintf("%d", readInst.CompactLeafDecodeCallsTotal)
+	stats["treedb.cache.vlog_compact_leaf_decode.bytes_total"] = fmt.Sprintf("%d", readInst.CompactLeafDecodeBytesTotal)
+	stats["treedb.cache.vlog_compact_leaf_decode.append_direct.calls_total"] = fmt.Sprintf("%d", readInst.CompactLeafAppendDirectCallsTotal)
+	stats["treedb.cache.vlog_compact_leaf_decode.append_direct.bytes_total"] = fmt.Sprintf("%d", readInst.CompactLeafAppendDirectBytesTotal)
+	stats["treedb.cache.vlog_compact_leaf_decode.append_scratch.calls_total"] = fmt.Sprintf("%d", readInst.CompactLeafAppendScratchCallsTotal)
+	stats["treedb.cache.vlog_compact_leaf_decode.append_scratch.bytes_total"] = fmt.Sprintf("%d", readInst.CompactLeafAppendScratchBytesTotal)
+	stats["treedb.cache.vlog_decode_scratch.global_small_hits_total"] = fmt.Sprintf("%d", readInst.DecodeScratchGlobalSmallHitsTotal)
+	stats["treedb.cache.vlog_decode_scratch.global_small_misses_total"] = fmt.Sprintf("%d", readInst.DecodeScratchGlobalSmallMissesTotal)
+	stats["treedb.cache.vlog_decode_scratch.global_large_hits_total"] = fmt.Sprintf("%d", readInst.DecodeScratchGlobalLargeHitsTotal)
+	stats["treedb.cache.vlog_decode_scratch.global_large_misses_total"] = fmt.Sprintf("%d", readInst.DecodeScratchGlobalLargeMissesTotal)
+	stats["treedb.cache.vlog_decode_scratch.global_oversize_misses_total"] = fmt.Sprintf("%d", readInst.DecodeScratchGlobalOversizeMissesTotal)
+	stats["treedb.cache.vlog_decode_scratch.file_hits_total"] = fmt.Sprintf("%d", readInst.DecodeScratchFileHitsTotal)
+	stats["treedb.cache.vlog_decode_scratch.file_misses_total"] = fmt.Sprintf("%d", readInst.DecodeScratchFileMissesTotal)
+	stats["treedb.cache.vlog_decode_scratch.small_puts_total"] = fmt.Sprintf("%d", readInst.DecodeScratchSmallPutsTotal)
+	stats["treedb.cache.vlog_decode_scratch.large_puts_total"] = fmt.Sprintf("%d", readInst.DecodeScratchLargePutsTotal)
+	stats["treedb.cache.vlog_decode_scratch.file_puts_total"] = fmt.Sprintf("%d", readInst.DecodeScratchFilePutsTotal)
+	stats["treedb.cache.vlog_decode_scratch.drops_total"] = fmt.Sprintf("%d", readInst.DecodeScratchDropsTotal)
+	stats["treedb.cache.vlog_read_unsafe_append.calls_total"] = fmt.Sprintf("%d", readInst.ReadUnsafeAppendCallsTotal)
+	stats["treedb.cache.vlog_read_append.calls_total"] = fmt.Sprintf("%d", readInst.ReadAppendCallsTotal)
+	stats["treedb.cache.vlog_read_append.bytes_total"] = fmt.Sprintf("%d", readInst.ReadAppendBytesTotal)
+	stats["treedb.cache.vlog_read_append.latency_ns_total"] = fmt.Sprintf("%d", readInst.ReadAppendLatencyNsTotal)
+	stats["treedb.cache.vlog_read_append.mmap.calls_total"] = fmt.Sprintf("%d", readInst.ReadAppendMmapCallsTotal)
+	stats["treedb.cache.vlog_read_append.mmap.bytes_total"] = fmt.Sprintf("%d", readInst.ReadAppendMmapBytesTotal)
+	stats["treedb.cache.vlog_read_append.mmap.latency_ns_total"] = fmt.Sprintf("%d", readInst.ReadAppendMmapLatencyNsTotal)
+	stats["treedb.cache.vlog_read_append.file.calls_total"] = fmt.Sprintf("%d", readInst.ReadAppendFileCallsTotal)
+	stats["treedb.cache.vlog_read_append.file.bytes_total"] = fmt.Sprintf("%d", readInst.ReadAppendFileBytesTotal)
+	stats["treedb.cache.vlog_read_append.file.latency_ns_total"] = fmt.Sprintf("%d", readInst.ReadAppendFileLatencyNsTotal)
+	if readInst.ReadAppendCallsTotal > 0 {
+		stats["treedb.cache.vlog_read_append.avg_latency_us"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendLatencyNsTotal)/float64(readInst.ReadAppendCallsTotal)/1000.0)
+		stats["treedb.cache.vlog_read_append.avg_bytes_per_call"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendBytesTotal)/float64(readInst.ReadAppendCallsTotal))
+	}
+	if readInst.ReadAppendMmapCallsTotal > 0 {
+		stats["treedb.cache.vlog_read_append.mmap.avg_latency_us"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendMmapLatencyNsTotal)/float64(readInst.ReadAppendMmapCallsTotal)/1000.0)
+		stats["treedb.cache.vlog_read_append.mmap.avg_bytes_per_call"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendMmapBytesTotal)/float64(readInst.ReadAppendMmapCallsTotal))
+	}
+	if readInst.ReadAppendFileCallsTotal > 0 {
+		stats["treedb.cache.vlog_read_append.file.avg_latency_us"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendFileLatencyNsTotal)/float64(readInst.ReadAppendFileCallsTotal)/1000.0)
+		stats["treedb.cache.vlog_read_append.file.avg_bytes_per_call"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendFileBytesTotal)/float64(readInst.ReadAppendFileCallsTotal))
+	}
 	cacheVlogMmap := cacheVlogMmapStatsSnapshot(db.valueLogReader)
 	if db.valueLogReader != nil {
 		remaps, deadMappings := db.valueLogReader.RemapStats()

--- a/TreeDB/caching/expvar_stats.go
+++ b/TreeDB/caching/expvar_stats.go
@@ -136,6 +136,10 @@ func selectTreeDBExpvarStats(stats map[string]string) map[string]any {
 			strings.HasPrefix(k, "treedb.vlog.mmap") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_mmap.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_decode_buffer_grow.") ||
+			strings.HasPrefix(k, "treedb.cache.vlog_compact_leaf_decode.") ||
+			strings.HasPrefix(k, "treedb.cache.vlog_decode_scratch.") ||
+			strings.HasPrefix(k, "treedb.cache.vlog_read_append.") ||
+			strings.HasPrefix(k, "treedb.cache.vlog_read_unsafe_append.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_write_mode.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_payload_split.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_auto.") ||

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -566,6 +566,46 @@ func (db *DB) Stats() map[string]string {
 	if growStats.RequestedBytesTotal > 0 {
 		stats["treedb.vlog.decode_buffer_grow.overalloc_ratio"] = fmt.Sprintf("%.6f", float64(growStats.AllocatedBytesTotal)/float64(growStats.RequestedBytesTotal))
 	}
+	readInst := valuelog.ReadInstrumentationStatsSnapshot()
+	stats["treedb.vlog.compact_leaf_decode.calls_total"] = fmt.Sprintf("%d", readInst.CompactLeafDecodeCallsTotal)
+	stats["treedb.vlog.compact_leaf_decode.bytes_total"] = fmt.Sprintf("%d", readInst.CompactLeafDecodeBytesTotal)
+	stats["treedb.vlog.compact_leaf_decode.append_direct.calls_total"] = fmt.Sprintf("%d", readInst.CompactLeafAppendDirectCallsTotal)
+	stats["treedb.vlog.compact_leaf_decode.append_direct.bytes_total"] = fmt.Sprintf("%d", readInst.CompactLeafAppendDirectBytesTotal)
+	stats["treedb.vlog.compact_leaf_decode.append_scratch.calls_total"] = fmt.Sprintf("%d", readInst.CompactLeafAppendScratchCallsTotal)
+	stats["treedb.vlog.compact_leaf_decode.append_scratch.bytes_total"] = fmt.Sprintf("%d", readInst.CompactLeafAppendScratchBytesTotal)
+	stats["treedb.vlog.decode_scratch.global_small_hits_total"] = fmt.Sprintf("%d", readInst.DecodeScratchGlobalSmallHitsTotal)
+	stats["treedb.vlog.decode_scratch.global_small_misses_total"] = fmt.Sprintf("%d", readInst.DecodeScratchGlobalSmallMissesTotal)
+	stats["treedb.vlog.decode_scratch.global_large_hits_total"] = fmt.Sprintf("%d", readInst.DecodeScratchGlobalLargeHitsTotal)
+	stats["treedb.vlog.decode_scratch.global_large_misses_total"] = fmt.Sprintf("%d", readInst.DecodeScratchGlobalLargeMissesTotal)
+	stats["treedb.vlog.decode_scratch.global_oversize_misses_total"] = fmt.Sprintf("%d", readInst.DecodeScratchGlobalOversizeMissesTotal)
+	stats["treedb.vlog.decode_scratch.file_hits_total"] = fmt.Sprintf("%d", readInst.DecodeScratchFileHitsTotal)
+	stats["treedb.vlog.decode_scratch.file_misses_total"] = fmt.Sprintf("%d", readInst.DecodeScratchFileMissesTotal)
+	stats["treedb.vlog.decode_scratch.small_puts_total"] = fmt.Sprintf("%d", readInst.DecodeScratchSmallPutsTotal)
+	stats["treedb.vlog.decode_scratch.large_puts_total"] = fmt.Sprintf("%d", readInst.DecodeScratchLargePutsTotal)
+	stats["treedb.vlog.decode_scratch.file_puts_total"] = fmt.Sprintf("%d", readInst.DecodeScratchFilePutsTotal)
+	stats["treedb.vlog.decode_scratch.drops_total"] = fmt.Sprintf("%d", readInst.DecodeScratchDropsTotal)
+	stats["treedb.vlog.read_unsafe_append.calls_total"] = fmt.Sprintf("%d", readInst.ReadUnsafeAppendCallsTotal)
+	stats["treedb.vlog.read_append.calls_total"] = fmt.Sprintf("%d", readInst.ReadAppendCallsTotal)
+	stats["treedb.vlog.read_append.bytes_total"] = fmt.Sprintf("%d", readInst.ReadAppendBytesTotal)
+	stats["treedb.vlog.read_append.latency_ns_total"] = fmt.Sprintf("%d", readInst.ReadAppendLatencyNsTotal)
+	stats["treedb.vlog.read_append.mmap.calls_total"] = fmt.Sprintf("%d", readInst.ReadAppendMmapCallsTotal)
+	stats["treedb.vlog.read_append.mmap.bytes_total"] = fmt.Sprintf("%d", readInst.ReadAppendMmapBytesTotal)
+	stats["treedb.vlog.read_append.mmap.latency_ns_total"] = fmt.Sprintf("%d", readInst.ReadAppendMmapLatencyNsTotal)
+	stats["treedb.vlog.read_append.file.calls_total"] = fmt.Sprintf("%d", readInst.ReadAppendFileCallsTotal)
+	stats["treedb.vlog.read_append.file.bytes_total"] = fmt.Sprintf("%d", readInst.ReadAppendFileBytesTotal)
+	stats["treedb.vlog.read_append.file.latency_ns_total"] = fmt.Sprintf("%d", readInst.ReadAppendFileLatencyNsTotal)
+	if readInst.ReadAppendCallsTotal > 0 {
+		stats["treedb.vlog.read_append.avg_latency_us"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendLatencyNsTotal)/float64(readInst.ReadAppendCallsTotal)/1000.0)
+		stats["treedb.vlog.read_append.avg_bytes_per_call"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendBytesTotal)/float64(readInst.ReadAppendCallsTotal))
+	}
+	if readInst.ReadAppendMmapCallsTotal > 0 {
+		stats["treedb.vlog.read_append.mmap.avg_latency_us"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendMmapLatencyNsTotal)/float64(readInst.ReadAppendMmapCallsTotal)/1000.0)
+		stats["treedb.vlog.read_append.mmap.avg_bytes_per_call"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendMmapBytesTotal)/float64(readInst.ReadAppendMmapCallsTotal))
+	}
+	if readInst.ReadAppendFileCallsTotal > 0 {
+		stats["treedb.vlog.read_append.file.avg_latency_us"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendFileLatencyNsTotal)/float64(readInst.ReadAppendFileCallsTotal)/1000.0)
+		stats["treedb.vlog.read_append.file.avg_bytes_per_call"] = fmt.Sprintf("%.3f", float64(readInst.ReadAppendFileBytesTotal)/float64(readInst.ReadAppendFileCallsTotal))
+	}
 	readPathStats := tree.ReadPathStatsSnapshot()
 	stats["treedb.process.read_path.backend_tree.get_append_inline_hits_total"] = fmt.Sprintf("%d", readPathStats.GetAppendInlineHitsTotal)
 	stats["treedb.process.read_path.backend_tree.get_append_inline_bytes_total"] = fmt.Sprintf("%d", readPathStats.GetAppendInlineBytesTotal)

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -76,20 +76,8 @@ func decodeCompactLeafLogPayloadTo(payload, dst []byte) ([]byte, bool, bool, err
 	if gapStart, gapEnd := prefixLen, page.PageSize-suffixLen; gapStart < gapEnd {
 		clear(out[gapStart:gapEnd])
 	}
+	noteCompactLeafDecode(len(out))
 	return out, usedDst, true, nil
-}
-
-func decodedLeafLogPayloadAppendLen(fileID uint32, path string, payloadLen int) int {
-	if payloadLen <= 0 {
-		return payloadLen
-	}
-	if !allowsCompactLeafLogPayload(fileID, path) {
-		return payloadLen
-	}
-	if payloadLen < page.PageSize {
-		return page.PageSize
-	}
-	return payloadLen
 }
 
 func allowsCompactLeafLogPayload(fileID uint32, path string) bool {
@@ -123,21 +111,48 @@ func appendMaybeDecodeLeafLogPayload(fileID uint32, path string, dst, payload []
 		}
 		return append(dst, payload...), nil
 	}
+	if !HasCompactLeafLogPayload(payload) {
+		if len(payload) == 0 {
+			return dst, nil
+		}
+		if cap(dst) >= len(dst)+len(payload) && sliceAliasesBytes(dst[:cap(dst)], payload) {
+			return dst[:len(dst)+len(payload)], nil
+		}
+		return append(dst, payload...), nil
+	}
 	oldLen := len(dst)
-	dst = grow(dst, decodedLeafLogPayloadAppendLen(fileID, path, len(payload)))
-	out, usedDst, decoded, err := decodeCompactLeafLogPayloadTo(payload, dst[oldLen:oldLen])
+	if cap(dst)-oldLen >= page.PageSize {
+		out, usedDst, decoded, err := decodeCompactLeafLogPayloadTo(payload, dst[oldLen:oldLen])
+		if err != nil {
+			return nil, err
+		}
+		if decoded {
+			noteCompactLeafAppendDirectDecode(len(out))
+			if usedDst {
+				return dst[:oldLen+len(out)], nil
+			}
+			return append(dst, out...), nil
+		}
+		return append(dst, payload...), nil
+	}
+	scratch := getDecodeScratch(page.PageSize)
+	out, _, decoded, err := decodeCompactLeafLogPayloadTo(payload, scratch[:0])
 	if err != nil {
+		putDecodeScratch(scratch)
 		return nil, err
 	}
 	if decoded {
-		if usedDst {
-			return dst[:oldLen+len(out)], nil
-		}
-		copy(dst[oldLen:], out)
-		return dst[:oldLen+len(out)], nil
+		noteCompactLeafAppendScratchDecode(len(out))
+		dst = append(dst, out...)
+		putDecodeScratch(scratch)
+		return dst, nil
 	}
-	nextLen := oldLen + len(payload)
-	dst = dst[:nextLen]
-	copy(dst[oldLen:], payload)
-	return dst, nil
+	putDecodeScratch(scratch)
+	if len(payload) == 0 {
+		return dst, nil
+	}
+	if cap(dst) >= len(dst)+len(payload) && sliceAliasesBytes(dst[:cap(dst)], payload) {
+		return dst[:len(dst)+len(payload)], nil
+	}
+	return append(dst, payload...), nil
 }

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -59,21 +59,37 @@ func decodeCompactLeafLogPayloadTo(payload, dst []byte) ([]byte, bool, bool, err
 	if compactLeafPagePayloadHeaderSize+prefixLen+suffixLen != len(payload) {
 		return nil, false, true, ErrCorrupt
 	}
-	if cap(dst) >= page.PageSize && sliceAliasesBytes(dst[:cap(dst)], payload) {
-		payload = append([]byte(nil), payload...)
-	}
 	out := dst
 	usedDst := false
 	if cap(out) >= page.PageSize {
 		out = out[:page.PageSize]
-		clear(out)
 		usedDst = true
 	} else {
 		out = make([]byte, page.PageSize)
 	}
-	copy(out[:prefixLen], payload[compactLeafPagePayloadHeaderSize:compactLeafPagePayloadHeaderSize+prefixLen])
-	copy(out[page.PageSize-suffixLen:], payload[compactLeafPagePayloadHeaderSize+prefixLen:])
+	prefix := payload[compactLeafPagePayloadHeaderSize : compactLeafPagePayloadHeaderSize+prefixLen]
+	suffix := payload[compactLeafPagePayloadHeaderSize+prefixLen:]
+	if suffixLen > 0 {
+		copy(out[page.PageSize-suffixLen:], suffix)
+	}
+	copy(out[:prefixLen], prefix)
+	if gapStart, gapEnd := prefixLen, page.PageSize-suffixLen; gapStart < gapEnd {
+		clear(out[gapStart:gapEnd])
+	}
 	return out, usedDst, true, nil
+}
+
+func decodedLeafLogPayloadAppendLen(fileID uint32, path string, payloadLen int) int {
+	if payloadLen <= 0 {
+		return payloadLen
+	}
+	if !allowsCompactLeafLogPayload(fileID, path) {
+		return payloadLen
+	}
+	if payloadLen < page.PageSize {
+		return page.PageSize
+	}
+	return payloadLen
 }
 
 func allowsCompactLeafLogPayload(fileID uint32, path string) bool {
@@ -107,18 +123,21 @@ func appendMaybeDecodeLeafLogPayload(fileID uint32, path string, dst, payload []
 		}
 		return append(dst, payload...), nil
 	}
-	out, _, decoded, err := decodeCompactLeafLogPayloadTo(payload, nil)
+	oldLen := len(dst)
+	dst = grow(dst, decodedLeafLogPayloadAppendLen(fileID, path, len(payload)))
+	out, usedDst, decoded, err := decodeCompactLeafLogPayloadTo(payload, dst[oldLen:oldLen])
 	if err != nil {
 		return nil, err
 	}
 	if decoded {
-		return append(dst, out...), nil
+		if usedDst {
+			return dst[:oldLen+len(out)], nil
+		}
+		copy(dst[oldLen:], out)
+		return dst[:oldLen+len(out)], nil
 	}
-	if len(payload) == 0 {
-		return dst, nil
-	}
-	if cap(dst) >= len(dst)+len(payload) && sliceAliasesBytes(dst[:cap(dst)], payload) {
-		return dst[:len(dst)+len(payload)], nil
-	}
-	return append(dst, payload...), nil
+	nextLen := oldLen + len(payload)
+	dst = dst[:nextLen]
+	copy(dst[oldLen:], payload)
+	return dst, nil
 }

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -220,8 +220,10 @@ func (f *File) takeDecodeScratch(minCap int) []byte {
 	f.decodeScratch = nil
 	f.cacheMu.Unlock()
 	if cap(scratch) >= minCap {
+		noteDecodeScratchFileHit()
 		return scratch[:0]
 	}
+	noteDecodeScratchFileMiss()
 	if scratch != nil {
 		putDecodeScratch(scratch)
 	}
@@ -241,12 +243,14 @@ func (f *File) releaseDecodeScratch(buf []byte) {
 	if cap(f.decodeScratch) == 0 {
 		f.decodeScratch = buf
 		f.cacheMu.Unlock()
+		noteDecodeScratchFilePut()
 		return
 	}
 	if cap(buf) > cap(f.decodeScratch) {
 		old := f.decodeScratch
 		f.decodeScratch = buf
 		f.cacheMu.Unlock()
+		noteDecodeScratchFilePut()
 		putDecodeScratch(old)
 		return
 	}
@@ -806,20 +810,33 @@ func (f *File) readGroupedCompressedFromFileTo(ptr page.ValuePtr, dst []byte) ([
 	return out, false, nil, true
 }
 
-func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte, error) {
+func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) (out []byte, err error) {
 	if f == nil || f.File == nil {
 		return nil, errors.New("valuelog: nil file")
 	}
+	start := time.Now()
+	startLen := len(dst)
+	path := readAppendPathUnknown
+	defer func() {
+		bytesReturned := 0
+		if err == nil && len(out) >= startLen {
+			bytesReturned = len(out) - startLen
+		}
+		noteReadAppend(path, bytesReturned, time.Since(start))
+	}()
 	if err := f.ensureCurrentWritableReadable(); err != nil {
 		return nil, err
 	}
 	if val, err, ok := f.readViaMmapAppend(ptr, verifyCRC, dst); ok {
 		f.mmapReadHits.Add(1)
-		return val, err
+		path = readAppendPathMmap
+		out = val
+		return out, err
 	}
 	// Fast path (bench/unsafe reads): grouped + uncompressed + no CRC.
 	if !verifyCRC && page.ValuePtrIsGrouped(ptr) && ptr.Offset >= 4 {
 		f.mmapReadFallbackReadAt.Add(1)
+		path = readAppendPathFile
 		start := int64(ptr.Offset - 4)
 
 		// Read header to discover the frame length/flags.
@@ -859,7 +876,8 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 					return nil, ErrCorrupt
 				}
 
-				return f.appendPayloadFromFile(dst, frameOff+int64(prefixLen)+int64(valStart), int(valEnd-valStart))
+				out, err = f.appendPayloadFromFile(dst, frameOff+int64(prefixLen)+int64(valStart), int(valEnd-valStart))
+				return out, err
 			}
 			f.cacheMu.Unlock()
 		}
@@ -880,7 +898,8 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 		if fFlags&FrameFlagCompressed != 0 {
 			// Fallback to the full decoder path. Prefer decode-to-tail so hot
 			// append callers can reuse dst capacity and avoid per-read allocs.
-			return f.appendDecodedRecordTo(ptr, verifyCRC, dst)
+			out, err = f.appendDecodedRecordTo(ptr, verifyCRC, dst)
+			return out, err
 		}
 		ridBytes := k * 8
 		offsetBytes := (k + 1) * 4
@@ -933,12 +952,15 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 		f.cacheStart.Store(start)
 		f.cacheMu.Unlock()
 
-		return f.appendPayloadFromFile(dst, frameOff+int64(prefixLen)+int64(valStart), int(valEnd-valStart))
+		out, err = f.appendPayloadFromFile(dst, frameOff+int64(prefixLen)+int64(valStart), int(valEnd-valStart))
+		return out, err
 	}
 
 	// Slow path: use existing decoder and append.
 	f.mmapReadFallbackReadAt.Add(1)
-	return f.appendDecodedRecordTo(ptr, verifyCRC, dst)
+	path = readAppendPathFile
+	out, err = f.appendDecodedRecordTo(ptr, verifyCRC, dst)
+	return out, err
 }
 
 func (f *File) appendDecodedRecordTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte, error) {
@@ -965,14 +987,14 @@ func (f *File) appendDecodedRecordTo(ptr page.ValuePtr, verifyCRC bool, dst []by
 }
 
 func (f *File) ReadUnsafeAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte, error) {
+	noteReadUnsafeAppendCall()
 	return f.ReadAppend(ptr, verifyCRC, dst)
 }
 
 func (f *File) appendPayloadFromFile(dst []byte, off int64, payloadLen int) ([]byte, error) {
 	oldLen := len(dst)
-	reserveLen := decodedLeafLogPayloadAppendLen(f.ID, f.Path, payloadLen)
-	noteGrowReadAppendPayload(reserveLen)
-	dst = grow(dst, reserveLen)
+	noteGrowReadAppendPayload(payloadLen)
+	dst = grow(dst, payloadLen)
 	payload := dst[oldLen : oldLen+payloadLen]
 	if _, err := f.File.ReadAt(payload, off); err != nil {
 		return nil, err

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -970,8 +970,9 @@ func (f *File) ReadUnsafeAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) (
 
 func (f *File) appendPayloadFromFile(dst []byte, off int64, payloadLen int) ([]byte, error) {
 	oldLen := len(dst)
-	noteGrowReadAppendPayload(payloadLen)
-	dst = grow(dst, payloadLen)
+	reserveLen := decodedLeafLogPayloadAppendLen(f.ID, f.Path, payloadLen)
+	noteGrowReadAppendPayload(reserveLen)
+	dst = grow(dst, reserveLen)
 	payload := dst[oldLen : oldLen+payloadLen]
 	if _, err := f.File.ReadAt(payload, off); err != nil {
 		return nil, err

--- a/TreeDB/internal/valuelog/read_instrumentation.go
+++ b/TreeDB/internal/valuelog/read_instrumentation.go
@@ -1,0 +1,169 @@
+package valuelog
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type ReadInstrumentationStats struct {
+	CompactLeafDecodeCallsTotal            uint64
+	CompactLeafDecodeBytesTotal            uint64
+	CompactLeafAppendDirectCallsTotal      uint64
+	CompactLeafAppendDirectBytesTotal      uint64
+	CompactLeafAppendScratchCallsTotal     uint64
+	CompactLeafAppendScratchBytesTotal     uint64
+	DecodeScratchGlobalSmallHitsTotal      uint64
+	DecodeScratchGlobalSmallMissesTotal    uint64
+	DecodeScratchGlobalLargeHitsTotal      uint64
+	DecodeScratchGlobalLargeMissesTotal    uint64
+	DecodeScratchGlobalOversizeMissesTotal uint64
+	DecodeScratchFileHitsTotal             uint64
+	DecodeScratchFileMissesTotal           uint64
+	DecodeScratchSmallPutsTotal            uint64
+	DecodeScratchLargePutsTotal            uint64
+	DecodeScratchFilePutsTotal             uint64
+	DecodeScratchDropsTotal                uint64
+	ReadUnsafeAppendCallsTotal             uint64
+	ReadAppendCallsTotal                   uint64
+	ReadAppendBytesTotal                   uint64
+	ReadAppendLatencyNsTotal               uint64
+	ReadAppendMmapCallsTotal               uint64
+	ReadAppendMmapBytesTotal               uint64
+	ReadAppendMmapLatencyNsTotal           uint64
+	ReadAppendFileCallsTotal               uint64
+	ReadAppendFileBytesTotal               uint64
+	ReadAppendFileLatencyNsTotal           uint64
+}
+
+type readAppendPath uint8
+
+const (
+	readAppendPathUnknown readAppendPath = iota
+	readAppendPathMmap
+	readAppendPathFile
+)
+
+var compactLeafDecodeCallsTotal atomic.Uint64
+var compactLeafDecodeBytesTotal atomic.Uint64
+var compactLeafAppendDirectCallsTotal atomic.Uint64
+var compactLeafAppendDirectBytesTotal atomic.Uint64
+var compactLeafAppendScratchCallsTotal atomic.Uint64
+var compactLeafAppendScratchBytesTotal atomic.Uint64
+var decodeScratchGlobalSmallHitsTotal atomic.Uint64
+var decodeScratchGlobalSmallMissesTotal atomic.Uint64
+var decodeScratchGlobalLargeHitsTotal atomic.Uint64
+var decodeScratchGlobalLargeMissesTotal atomic.Uint64
+var decodeScratchGlobalOversizeMissesTotal atomic.Uint64
+var decodeScratchFileHitsTotal atomic.Uint64
+var decodeScratchFileMissesTotal atomic.Uint64
+var decodeScratchSmallPutsTotal atomic.Uint64
+var decodeScratchLargePutsTotal atomic.Uint64
+var decodeScratchFilePutsTotal atomic.Uint64
+var decodeScratchDropsTotal atomic.Uint64
+var readUnsafeAppendCallsTotal atomic.Uint64
+var readAppendCallsTotal atomic.Uint64
+var readAppendBytesTotal atomic.Uint64
+var readAppendLatencyNsTotal atomic.Uint64
+var readAppendMmapCallsTotal atomic.Uint64
+var readAppendMmapBytesTotal atomic.Uint64
+var readAppendMmapLatencyNsTotal atomic.Uint64
+var readAppendFileCallsTotal atomic.Uint64
+var readAppendFileBytesTotal atomic.Uint64
+var readAppendFileLatencyNsTotal atomic.Uint64
+
+func ReadInstrumentationStatsSnapshot() ReadInstrumentationStats {
+	return ReadInstrumentationStats{
+		CompactLeafDecodeCallsTotal:            compactLeafDecodeCallsTotal.Load(),
+		CompactLeafDecodeBytesTotal:            compactLeafDecodeBytesTotal.Load(),
+		CompactLeafAppendDirectCallsTotal:      compactLeafAppendDirectCallsTotal.Load(),
+		CompactLeafAppendDirectBytesTotal:      compactLeafAppendDirectBytesTotal.Load(),
+		CompactLeafAppendScratchCallsTotal:     compactLeafAppendScratchCallsTotal.Load(),
+		CompactLeafAppendScratchBytesTotal:     compactLeafAppendScratchBytesTotal.Load(),
+		DecodeScratchGlobalSmallHitsTotal:      decodeScratchGlobalSmallHitsTotal.Load(),
+		DecodeScratchGlobalSmallMissesTotal:    decodeScratchGlobalSmallMissesTotal.Load(),
+		DecodeScratchGlobalLargeHitsTotal:      decodeScratchGlobalLargeHitsTotal.Load(),
+		DecodeScratchGlobalLargeMissesTotal:    decodeScratchGlobalLargeMissesTotal.Load(),
+		DecodeScratchGlobalOversizeMissesTotal: decodeScratchGlobalOversizeMissesTotal.Load(),
+		DecodeScratchFileHitsTotal:             decodeScratchFileHitsTotal.Load(),
+		DecodeScratchFileMissesTotal:           decodeScratchFileMissesTotal.Load(),
+		DecodeScratchSmallPutsTotal:            decodeScratchSmallPutsTotal.Load(),
+		DecodeScratchLargePutsTotal:            decodeScratchLargePutsTotal.Load(),
+		DecodeScratchFilePutsTotal:             decodeScratchFilePutsTotal.Load(),
+		DecodeScratchDropsTotal:                decodeScratchDropsTotal.Load(),
+		ReadUnsafeAppendCallsTotal:             readUnsafeAppendCallsTotal.Load(),
+		ReadAppendCallsTotal:                   readAppendCallsTotal.Load(),
+		ReadAppendBytesTotal:                   readAppendBytesTotal.Load(),
+		ReadAppendLatencyNsTotal:               readAppendLatencyNsTotal.Load(),
+		ReadAppendMmapCallsTotal:               readAppendMmapCallsTotal.Load(),
+		ReadAppendMmapBytesTotal:               readAppendMmapBytesTotal.Load(),
+		ReadAppendMmapLatencyNsTotal:           readAppendMmapLatencyNsTotal.Load(),
+		ReadAppendFileCallsTotal:               readAppendFileCallsTotal.Load(),
+		ReadAppendFileBytesTotal:               readAppendFileBytesTotal.Load(),
+		ReadAppendFileLatencyNsTotal:           readAppendFileLatencyNsTotal.Load(),
+	}
+}
+
+func noteCompactLeafDecode(decodedBytes int) {
+	if decodedBytes <= 0 {
+		return
+	}
+	compactLeafDecodeCallsTotal.Add(1)
+	compactLeafDecodeBytesTotal.Add(uint64(decodedBytes))
+}
+
+func noteCompactLeafAppendDirectDecode(decodedBytes int) {
+	if decodedBytes <= 0 {
+		return
+	}
+	compactLeafAppendDirectCallsTotal.Add(1)
+	compactLeafAppendDirectBytesTotal.Add(uint64(decodedBytes))
+}
+
+func noteCompactLeafAppendScratchDecode(decodedBytes int) {
+	if decodedBytes <= 0 {
+		return
+	}
+	compactLeafAppendScratchCallsTotal.Add(1)
+	compactLeafAppendScratchBytesTotal.Add(uint64(decodedBytes))
+}
+
+func noteDecodeScratchGlobalSmallHit()     { decodeScratchGlobalSmallHitsTotal.Add(1) }
+func noteDecodeScratchGlobalSmallMiss()    { decodeScratchGlobalSmallMissesTotal.Add(1) }
+func noteDecodeScratchGlobalLargeHit()     { decodeScratchGlobalLargeHitsTotal.Add(1) }
+func noteDecodeScratchGlobalLargeMiss()    { decodeScratchGlobalLargeMissesTotal.Add(1) }
+func noteDecodeScratchGlobalOversizeMiss() { decodeScratchGlobalOversizeMissesTotal.Add(1) }
+func noteDecodeScratchFileHit()            { decodeScratchFileHitsTotal.Add(1) }
+func noteDecodeScratchFileMiss()           { decodeScratchFileMissesTotal.Add(1) }
+func noteDecodeScratchSmallPut()           { decodeScratchSmallPutsTotal.Add(1) }
+func noteDecodeScratchLargePut()           { decodeScratchLargePutsTotal.Add(1) }
+func noteDecodeScratchFilePut()            { decodeScratchFilePutsTotal.Add(1) }
+func noteDecodeScratchDrop()               { decodeScratchDropsTotal.Add(1) }
+func noteReadUnsafeAppendCall()            { readUnsafeAppendCallsTotal.Add(1) }
+
+func noteReadAppend(path readAppendPath, bytesReturned int, dur time.Duration) {
+	readAppendCallsTotal.Add(1)
+	if bytesReturned > 0 {
+		readAppendBytesTotal.Add(uint64(bytesReturned))
+	}
+	if dur > 0 {
+		readAppendLatencyNsTotal.Add(uint64(dur))
+	}
+	switch path {
+	case readAppendPathMmap:
+		readAppendMmapCallsTotal.Add(1)
+		if bytesReturned > 0 {
+			readAppendMmapBytesTotal.Add(uint64(bytesReturned))
+		}
+		if dur > 0 {
+			readAppendMmapLatencyNsTotal.Add(uint64(dur))
+		}
+	case readAppendPathFile:
+		readAppendFileCallsTotal.Add(1)
+		if bytesReturned > 0 {
+			readAppendFileBytesTotal.Add(uint64(bytesReturned))
+		}
+		if dur > 0 {
+			readAppendFileLatencyNsTotal.Add(uint64(dur))
+		}
+	}
+}

--- a/TreeDB/internal/valuelog/read_instrumentation_test.go
+++ b/TreeDB/internal/valuelog/read_instrumentation_test.go
@@ -1,0 +1,179 @@
+package valuelog
+
+import (
+	"os"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func diffReadInstrumentationStats(after, before ReadInstrumentationStats) ReadInstrumentationStats {
+	return ReadInstrumentationStats{
+		CompactLeafDecodeCallsTotal:            after.CompactLeafDecodeCallsTotal - before.CompactLeafDecodeCallsTotal,
+		CompactLeafDecodeBytesTotal:            after.CompactLeafDecodeBytesTotal - before.CompactLeafDecodeBytesTotal,
+		CompactLeafAppendDirectCallsTotal:      after.CompactLeafAppendDirectCallsTotal - before.CompactLeafAppendDirectCallsTotal,
+		CompactLeafAppendDirectBytesTotal:      after.CompactLeafAppendDirectBytesTotal - before.CompactLeafAppendDirectBytesTotal,
+		CompactLeafAppendScratchCallsTotal:     after.CompactLeafAppendScratchCallsTotal - before.CompactLeafAppendScratchCallsTotal,
+		CompactLeafAppendScratchBytesTotal:     after.CompactLeafAppendScratchBytesTotal - before.CompactLeafAppendScratchBytesTotal,
+		DecodeScratchGlobalSmallHitsTotal:      after.DecodeScratchGlobalSmallHitsTotal - before.DecodeScratchGlobalSmallHitsTotal,
+		DecodeScratchGlobalSmallMissesTotal:    after.DecodeScratchGlobalSmallMissesTotal - before.DecodeScratchGlobalSmallMissesTotal,
+		DecodeScratchGlobalLargeHitsTotal:      after.DecodeScratchGlobalLargeHitsTotal - before.DecodeScratchGlobalLargeHitsTotal,
+		DecodeScratchGlobalLargeMissesTotal:    after.DecodeScratchGlobalLargeMissesTotal - before.DecodeScratchGlobalLargeMissesTotal,
+		DecodeScratchGlobalOversizeMissesTotal: after.DecodeScratchGlobalOversizeMissesTotal - before.DecodeScratchGlobalOversizeMissesTotal,
+		DecodeScratchFileHitsTotal:             after.DecodeScratchFileHitsTotal - before.DecodeScratchFileHitsTotal,
+		DecodeScratchFileMissesTotal:           after.DecodeScratchFileMissesTotal - before.DecodeScratchFileMissesTotal,
+		DecodeScratchSmallPutsTotal:            after.DecodeScratchSmallPutsTotal - before.DecodeScratchSmallPutsTotal,
+		DecodeScratchLargePutsTotal:            after.DecodeScratchLargePutsTotal - before.DecodeScratchLargePutsTotal,
+		DecodeScratchFilePutsTotal:             after.DecodeScratchFilePutsTotal - before.DecodeScratchFilePutsTotal,
+		DecodeScratchDropsTotal:                after.DecodeScratchDropsTotal - before.DecodeScratchDropsTotal,
+		ReadUnsafeAppendCallsTotal:             after.ReadUnsafeAppendCallsTotal - before.ReadUnsafeAppendCallsTotal,
+		ReadAppendCallsTotal:                   after.ReadAppendCallsTotal - before.ReadAppendCallsTotal,
+		ReadAppendBytesTotal:                   after.ReadAppendBytesTotal - before.ReadAppendBytesTotal,
+		ReadAppendLatencyNsTotal:               after.ReadAppendLatencyNsTotal - before.ReadAppendLatencyNsTotal,
+		ReadAppendMmapCallsTotal:               after.ReadAppendMmapCallsTotal - before.ReadAppendMmapCallsTotal,
+		ReadAppendMmapBytesTotal:               after.ReadAppendMmapBytesTotal - before.ReadAppendMmapBytesTotal,
+		ReadAppendMmapLatencyNsTotal:           after.ReadAppendMmapLatencyNsTotal - before.ReadAppendMmapLatencyNsTotal,
+		ReadAppendFileCallsTotal:               after.ReadAppendFileCallsTotal - before.ReadAppendFileCallsTotal,
+		ReadAppendFileBytesTotal:               after.ReadAppendFileBytesTotal - before.ReadAppendFileBytesTotal,
+		ReadAppendFileLatencyNsTotal:           after.ReadAppendFileLatencyNsTotal - before.ReadAppendFileLatencyNsTotal,
+	}
+}
+
+func TestReadInstrumentation_CompactLeafAppendDecodePaths(t *testing.T) {
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := compactLeafPayloadTestPath(t, t.TempDir(), 1)
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected compact payload")
+	}
+
+	before := ReadInstrumentationStatsSnapshot()
+	got, err := appendMaybeDecodeLeafLogPayload(fileID, path, make([]byte, 0, page.PageSize), payload)
+	if err != nil {
+		t.Fatalf("appendMaybeDecodeLeafLogPayload direct: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("direct decode len=%d want %d", len(got), page.PageSize)
+	}
+	after := ReadInstrumentationStatsSnapshot()
+	delta := diffReadInstrumentationStats(after, before)
+	if delta.CompactLeafDecodeCallsTotal != 1 || delta.CompactLeafDecodeBytesTotal != page.PageSize {
+		t.Fatalf("direct compact decode delta=%+v", delta)
+	}
+	if delta.CompactLeafAppendDirectCallsTotal != 1 || delta.CompactLeafAppendDirectBytesTotal != page.PageSize {
+		t.Fatalf("direct append decode delta=%+v", delta)
+	}
+	if delta.CompactLeafAppendScratchCallsTotal != 0 {
+		t.Fatalf("unexpected scratch decode delta=%+v", delta)
+	}
+
+	before = ReadInstrumentationStatsSnapshot()
+	got, err = appendMaybeDecodeLeafLogPayload(fileID, path, nil, payload)
+	if err != nil {
+		t.Fatalf("appendMaybeDecodeLeafLogPayload scratch: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("scratch decode len=%d want %d", len(got), page.PageSize)
+	}
+	after = ReadInstrumentationStatsSnapshot()
+	delta = diffReadInstrumentationStats(after, before)
+	if delta.CompactLeafDecodeCallsTotal != 1 || delta.CompactLeafDecodeBytesTotal != page.PageSize {
+		t.Fatalf("scratch compact decode delta=%+v", delta)
+	}
+	if delta.CompactLeafAppendScratchCallsTotal != 1 || delta.CompactLeafAppendScratchBytesTotal != page.PageSize {
+		t.Fatalf("scratch append decode delta=%+v", delta)
+	}
+}
+
+func TestReadInstrumentation_FileDecodeScratchHitsAndMisses(t *testing.T) {
+	f := &File{}
+	before := ReadInstrumentationStatsSnapshot()
+	buf := f.takeDecodeScratch(1024)
+	if cap(buf) < 1024 {
+		t.Fatalf("cap(buf)=%d want >=1024", cap(buf))
+	}
+	f.releaseDecodeScratch(buf)
+	buf = f.takeDecodeScratch(1024)
+	if cap(buf) < 1024 {
+		t.Fatalf("cap(buf)=%d want >=1024 on second take", cap(buf))
+	}
+	f.releaseDecodeScratch(buf)
+	after := ReadInstrumentationStatsSnapshot()
+	delta := diffReadInstrumentationStats(after, before)
+	if delta.DecodeScratchFileMissesTotal != 1 || delta.DecodeScratchFileHitsTotal != 1 {
+		t.Fatalf("file scratch delta=%+v want one miss and one hit", delta)
+	}
+	if delta.DecodeScratchFilePutsTotal != 2 {
+		t.Fatalf("file scratch puts=%d want 2", delta.DecodeScratchFilePutsTotal)
+	}
+}
+
+func TestReadInstrumentation_ReadUnsafeAppendPathCounters(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := compactLeafPayloadTestPath(t, dir, 1)
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected compact payload")
+	}
+	ptr, err := w.Append(0, nil, 1, payload)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	mgr := newLeafPayloadTestManager(t, dir, path, fileID)
+	defer func() { _ = mgr.Close() }()
+	f := mgr.files[fileID]
+	if f == nil {
+		t.Fatalf("manager missing file %d", fileID)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	f.mmapData.Store(data)
+
+	before := ReadInstrumentationStatsSnapshot()
+	got, err := mgr.ReadUnsafeAppend(ptr, make([]byte, 0, page.PageSize))
+	if err != nil {
+		t.Fatalf("ReadUnsafeAppend: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("ReadUnsafeAppend len=%d want %d", len(got), page.PageSize)
+	}
+	after := ReadInstrumentationStatsSnapshot()
+	delta := diffReadInstrumentationStats(after, before)
+	if delta.ReadUnsafeAppendCallsTotal != 1 {
+		t.Fatalf("ReadUnsafeAppend calls=%d want 1", delta.ReadUnsafeAppendCallsTotal)
+	}
+	if delta.ReadAppendCallsTotal != 1 || delta.ReadAppendMmapCallsTotal != 1 || delta.ReadAppendFileCallsTotal != 0 {
+		t.Fatalf("unexpected ReadAppend path delta=%+v", delta)
+	}
+	if delta.ReadAppendBytesTotal != page.PageSize || delta.ReadAppendMmapBytesTotal != page.PageSize {
+		t.Fatalf("unexpected ReadAppend bytes delta=%+v", delta)
+	}
+	if delta.ReadAppendLatencyNsTotal == 0 || delta.ReadAppendMmapLatencyNsTotal == 0 {
+		t.Fatalf("expected non-zero latency delta=%+v", delta)
+	}
+}

--- a/TreeDB/internal/valuelog/reader.go
+++ b/TreeDB/internal/valuelog/reader.go
@@ -93,14 +93,17 @@ func getDecodeScratch(minCap int) []byte {
 		if minCap <= maxLargeDecodeScratchKeep {
 			select {
 			case buf := <-largeDecodeScratchPool:
+				noteDecodeScratchGlobalLargeHit()
 				if cap(buf) < minCap {
 					buf = make([]byte, 0, minCap)
 				}
 				return buf[:0]
 			default:
+				noteDecodeScratchGlobalLargeMiss()
 				return make([]byte, 0, minCap)
 			}
 		}
+		noteDecodeScratchGlobalOversizeMiss()
 		return make([]byte, 0, minCap)
 	}
 	var buf []byte
@@ -110,6 +113,11 @@ func getDecodeScratch(minCap int) []byte {
 			h.buf = nil
 			decodeScratchHolderPool.Put(h)
 		}
+	}
+	if cap(buf) > 0 {
+		noteDecodeScratchGlobalSmallHit()
+	} else {
+		noteDecodeScratchGlobalSmallMiss()
 	}
 	if cap(buf) < minCap {
 		capHint := minCap
@@ -131,6 +139,7 @@ func putDecodeScratch(buf []byte) {
 	}
 	buf = buf[:0]
 	if c <= maxDecodeScratchKeep {
+		noteDecodeScratchSmallPut()
 		h, _ := decodeScratchHolderPool.Get().(*decodeScratchHolder)
 		if h == nil {
 			h = &decodeScratchHolder{}
@@ -142,10 +151,13 @@ func putDecodeScratch(buf []byte) {
 	if c <= maxLargeDecodeScratchKeep {
 		select {
 		case largeDecodeScratchPool <- buf:
+			noteDecodeScratchLargePut()
 		default:
+			noteDecodeScratchDrop()
 		}
 		return
 	}
+	noteDecodeScratchDrop()
 }
 
 func sliceDataPtr(b []byte) (uintptr, bool) {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1191,9 +1191,8 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	// to avoid a decode-scratch allocation + extra copy.
 	if f.templateLookup == nil && k == 1 && subIndex == 0 && valStart == 0 && valEnd == rawLen {
 		oldLen := len(dst)
-		reserveLen := decodedLeafLogPayloadAppendLen(f.ID, f.Path, int(rawLen))
-		noteGrowReadAppendCurrentMmapDirectDecode(reserveLen)
-		dst = grow(dst, reserveLen)
+		noteGrowReadAppendCurrentMmapDirectDecode(int(rawLen))
+		dst = grow(dst, int(rawLen))
 		out, err := decodeFramePayloadTo(frame, payload[prefixLen:], f.dictLookup, rawLen, dst[oldLen:oldLen])
 		if err != nil {
 			return nil, err, true

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1191,8 +1191,9 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	// to avoid a decode-scratch allocation + extra copy.
 	if f.templateLookup == nil && k == 1 && subIndex == 0 && valStart == 0 && valEnd == rawLen {
 		oldLen := len(dst)
-		noteGrowReadAppendCurrentMmapDirectDecode(int(rawLen))
-		dst = grow(dst, int(rawLen))
+		reserveLen := decodedLeafLogPayloadAppendLen(f.ID, f.Path, int(rawLen))
+		noteGrowReadAppendCurrentMmapDirectDecode(reserveLen)
+		dst = grow(dst, reserveLen)
 		out, err := decodeFramePayloadTo(frame, payload[prefixLen:], f.dictLookup, rawLen, dst[oldLen:oldLen])
 		if err != nil {
 			return nil, err, true


### PR DESCRIPTION
## What changed

This branch improves the TreeDB compact-leaf read path and adds targeted valuelog read instrumentation.

The functional change keeps compact leaf payload reads on a cheaper path:
- reuse destination capacity when it already exists
- otherwise decode into scratch and append without growing retained slices to full page size
- keep file-local scratch reuse for grouped/frame decode paths

The instrumentation change adds counters for:
- compact-leaf decode bytes and direct-vs-scratch decode counts
- scratch-buffer hits/misses and puts
- `ReadAppend` / `ReadUnsafeAppend` calls, bytes, and latency
- mmap-vs-file read-path totals

Those counters are exported through TreeDB stats and the cached expvar allowlist so `run_celestia` heap/RSS captures can correlate TreeDB read behavior with the RSS crest.

## Why it changed

The original compact-leaf read optimization removed a clear decode allocation hotspot, but earlier live measurements showed noisy RSS behavior. The next step needed better evidence, not more blind buffer tuning.

This PR keeps the read-path win and adds the telemetry needed to answer:
- whether the branch is still paying a TreeDB memory-retention cost
- or whether the remaining RSS behavior is mostly phase overlap outside the decode path

## Impact

Expected impact:
- modest sync/read-path improvement on Celestia restore workloads
- lower compact-leaf decode allocation pressure
- better diagnostics for future TreeDB restore optimization work

This is an incremental optimization, not a format or policy change.

## Validation

Local validation:
- `GOWORK=off go test ./TreeDB/internal/valuelog -count=1`
- `GOWORK=off go test ./TreeDB/db -run '^$' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run '^$' -count=1`

Live `run_celestia` zero-dwell `fast` runs:
- branch: `/home/mikers/.celestia-app-mainnet-treedb-20260418173038`
  - sync `292s`
  - max RSS `12,447,772 kB`
- fresh true-main control: `/home/mikers/.celestia-app-mainnet-treedb-20260418173646`
  - sync `303s`
  - max RSS `12,614,892 kB`

The fresh paired run did not reproduce the earlier branch-2 RSS regression; branch 2 was slightly faster and slightly lower on peak RSS in that pair.
