### PR TITLE
[codex] back off repeated empty leaf-pack plans

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1935,6 +1935,9 @@ const (
 	leafGenerationPackMaintenanceDefaultWriteBurstGrace            = 250 * time.Millisecond
 	leafGenerationPackMaintenanceDefaultMaxForegroundQueue         = 2
 	leafGenerationPackMaintenanceDefaultMinReclaimPerByteCopiedPPM = 250000
+	leafGenerationPackNoCandidateBackoffBase                       = 5 * time.Second
+	leafGenerationPackNoCandidateBackoffMax                        = 30 * time.Second
+	leafGenerationPackNoCandidateSkipReason                        = "plan_admission:no_candidates"
 	maxMemtablePrealloc                                            = 256 << 20
 	appendOnlyEntryHintMinEntries                                  = 128
 	appendOnlyEntryHintMaxEntries                                  = 1 << 20
@@ -6624,6 +6627,7 @@ type DB struct {
 	vlogGenerationLeafPackSkipWriteBurst                         atomic.Uint64
 	vlogGenerationLeafPackSkipQueuePressure                      atomic.Uint64
 	vlogGenerationLeafPackSkipForegroundIterators                atomic.Uint64
+	vlogGenerationLeafPackSkipNoCandidateBackoff                 atomic.Uint64
 	vlogGenerationLeafPackErrors                                 atomic.Uint64
 	vlogGenerationLeafPackCanceled                               atomic.Uint64
 	vlogGenerationLeafPackDeadline                               atomic.Uint64
@@ -6653,6 +6657,8 @@ type DB struct {
 	vlogGenerationLeafPackGCLastDeletedBytes                     atomic.Int64
 	vlogGenerationLeafPackLastReclaimedBytes                     atomic.Int64
 	vlogGenerationLeafPackLastUnixNano                           atomic.Int64
+	vlogGenerationLeafPackNoCandidateBackoffUntilUnixNano        atomic.Int64
+	vlogGenerationLeafPackConsecutiveNoCandidate                 atomic.Uint64
 	vlogGenerationLeafPackCanceledLastNS                         atomic.Int64
 	vlogGenerationLeafPackDeadlineLastNS                         atomic.Int64
 	vlogGenerationLeafPackLastSkipReason                         atomic.Value // string
@@ -14832,6 +14838,59 @@ func (db *DB) observeVlogGenerationLeafPackAdmissionSkip(reason string) {
 	db.storeVlogGenerationLeafPackLastSkipReason(reason)
 }
 
+func leafGenerationPackNoCandidateBackoffDuration(consecutive uint64) time.Duration {
+	if consecutive <= 1 {
+		return leafGenerationPackNoCandidateBackoffBase
+	}
+	dur := leafGenerationPackNoCandidateBackoffBase
+	for i := uint64(1); i < consecutive && dur < leafGenerationPackNoCandidateBackoffMax; i++ {
+		dur *= 2
+		if dur >= leafGenerationPackNoCandidateBackoffMax {
+			return leafGenerationPackNoCandidateBackoffMax
+		}
+	}
+	if dur < leafGenerationPackNoCandidateBackoffBase {
+		return leafGenerationPackNoCandidateBackoffBase
+	}
+	if dur > leafGenerationPackNoCandidateBackoffMax {
+		return leafGenerationPackNoCandidateBackoffMax
+	}
+	return dur
+}
+
+func (db *DB) observeVlogGenerationLeafPackNoCandidate(now time.Time) {
+	if db == nil {
+		return
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	consecutive := db.vlogGenerationLeafPackConsecutiveNoCandidate.Add(1)
+	db.vlogGenerationLeafPackNoCandidateBackoffUntilUnixNano.Store(now.Add(leafGenerationPackNoCandidateBackoffDuration(consecutive)).UnixNano())
+}
+
+func (db *DB) clearVlogGenerationLeafPackNoCandidateBackoff() {
+	if db == nil {
+		return
+	}
+	db.vlogGenerationLeafPackConsecutiveNoCandidate.Store(0)
+	db.vlogGenerationLeafPackNoCandidateBackoffUntilUnixNano.Store(0)
+}
+
+func (db *DB) vlogGenerationLeafPackNoCandidateBackoffActive(now time.Time) bool {
+	if db == nil {
+		return false
+	}
+	untilNS := db.vlogGenerationLeafPackNoCandidateBackoffUntilUnixNano.Load()
+	if untilNS <= 0 {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return now.Before(time.Unix(0, untilNS))
+}
+
 func leafGenerationPackMaintenanceTimeout() time.Duration {
 	timeoutSeconds := envUint64(envLeafGenerationPackMaintenanceTimeoutSeconds, uint64(leafGenerationPackMaintenanceDefaultTimeout/time.Second))
 	if timeoutSeconds == 0 {
@@ -22792,6 +22851,11 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 			return false, false, nil
 		}
 	}
+	if db.vlogGenerationLeafPackNoCandidateBackoffActive(time.Now()) {
+		db.vlogGenerationLeafPackSkipNoCandidateBackoff.Add(1)
+		db.storeVlogGenerationLeafPackLastSkipReason("no_candidate_backoff")
+		return false, false, nil
+	}
 
 	maxGenerations := int(envUint64(envLeafGenerationPackMaintenanceMaxGenerations, leafGenerationPackMaintenanceDefaultMaxGenerations))
 	if maxGenerations <= 0 {
@@ -22884,6 +22948,11 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 			}
 			if !stats.Ran {
 				if !ran {
+					if stats.SkipReason == leafGenerationPackNoCandidateSkipReason {
+						db.observeVlogGenerationLeafPackNoCandidate(time.Now())
+					} else {
+						db.clearVlogGenerationLeafPackNoCandidateBackoff()
+					}
 					db.storeVlogGenerationLeafPackLastSkipReason(stats.SkipReason)
 				}
 				return nil
@@ -22903,6 +22972,7 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 			if stats.Pack.BytesCopied > 0 {
 				db.vlogGenerationLeafPackBytesCopied.Add(uint64(stats.Pack.BytesCopied))
 			}
+			db.clearVlogGenerationLeafPackNoCandidateBackoff()
 			db.vlogGenerationLeafPackLastUnixNano.Store(time.Now().UnixNano())
 			db.storeVlogGenerationLeafPackLastSkipReason("")
 
@@ -24166,6 +24236,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_generation.leaf_pack.skip.write_burst"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackSkipWriteBurst.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.skip.queue_pressure"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackSkipQueuePressure.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.skip.foreground_iterators"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackSkipForegroundIterators.Load())
+	stats["treedb.cache.vlog_generation.leaf_pack.skip.no_candidate_backoff"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackSkipNoCandidateBackoff.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.errors"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackErrors.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.canceled"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackCanceled.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.deadline"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackDeadline.Load())
@@ -24179,6 +24250,8 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_generation.leaf_pack.selection.generations"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackSelectionGenerations.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.last_wall_ms"] = fmt.Sprintf("%.3f", float64(db.vlogGenerationLeafPackLastWallNanos.Load())/float64(time.Millisecond))
 	stats["treedb.cache.vlog_generation.leaf_pack.min_interval_ms"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceMinInterval.Milliseconds())
+	stats["treedb.cache.vlog_generation.leaf_pack.no_candidate_backoff.base_ms"] = fmt.Sprintf("%d", leafGenerationPackNoCandidateBackoffBase.Milliseconds())
+	stats["treedb.cache.vlog_generation.leaf_pack.no_candidate_backoff.max_ms"] = fmt.Sprintf("%d", leafGenerationPackNoCandidateBackoffMax.Milliseconds())
 	stats["treedb.cache.vlog_generation.leaf_pack.timeout_ms"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceTimeout().Milliseconds())
 	stats["treedb.cache.vlog_generation.leaf_pack.write_burst_grace_ms"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceWriteBurstGrace().Milliseconds())
 	stats["treedb.cache.vlog_generation.leaf_pack.max_foreground_queue"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceMaxForegroundQueue())
@@ -24205,6 +24278,8 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_generation.leaf_pack.gc.last_deleted_bytes"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackGCLastDeletedBytes.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.stop.low_yield"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackStopLowYield.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.last_unix_nano"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackLastUnixNano.Load())
+	stats["treedb.cache.vlog_generation.leaf_pack.no_candidate_backoff.until_unix_nano"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackNoCandidateBackoffUntilUnixNano.Load())
+	stats["treedb.cache.vlog_generation.leaf_pack.no_candidate_backoff.consecutive"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackConsecutiveNoCandidate.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.canceled_last_unix_nano"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackCanceledLastNS.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.deadline_last_unix_nano"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackDeadlineLastNS.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.last_skip_reason"] = atomicValueString(&db.vlogGenerationLeafPackLastSkipReason)

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -2429,6 +2429,95 @@ func TestVlogGenerationMaintenance_PeriodicPassSkipsLeafPackOnForegroundIterator
 	}
 }
 
+func TestVlogGenerationMaintenance_PeriodicPassBacksOffLeafPackNoCandidates(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+	t.Setenv(envEnableLeafGenerationPackMaintenance, "1")
+	recorder := &leafPackMaintenanceRecordingBackend{
+		DB:   mustOpenLeafPackBackend(t),
+		resp: backenddb.LeafGenerationPackRunOnceStats{SkipReason: leafGenerationPackNoCandidateSkipReason},
+	}
+	db, cleanup := openLeafPackMaintenanceTestDB(t, recorder)
+	defer cleanup()
+
+	if ran := db.maybeRunPeriodicVlogGenerationMaintenance(false); !ran {
+		t.Fatal("expected first periodic maintenance pass to run")
+	}
+	_, calls, _, _ := recorder.recordedLeafPack()
+	if calls != 1 {
+		t.Fatalf("leaf pack calls after first pass=%d want 1", calls)
+	}
+	if got := db.vlogGenerationLeafPackAttempts.Load(); got != 1 {
+		t.Fatalf("leaf pack attempts after first pass=%d want 1", got)
+	}
+	if got := db.vlogGenerationLeafPackConsecutiveNoCandidate.Load(); got != 1 {
+		t.Fatalf("leaf pack consecutive no-candidate=%d want 1", got)
+	}
+	if got := db.Stats()["treedb.cache.vlog_generation.leaf_pack.last_skip_reason"]; got != leafGenerationPackNoCandidateSkipReason {
+		t.Fatalf("last_skip_reason after first pass=%q want %q", got, leafGenerationPackNoCandidateSkipReason)
+	}
+
+	if ran := db.maybeRunPeriodicVlogGenerationMaintenance(false); !ran {
+		t.Fatal("expected second periodic maintenance pass to acquire and noop under backoff")
+	}
+	_, calls, _, _ = recorder.recordedLeafPack()
+	if calls != 1 {
+		t.Fatalf("leaf pack calls after immediate retry=%d want 1", calls)
+	}
+	if got := db.vlogGenerationLeafPackAttempts.Load(); got != 1 {
+		t.Fatalf("leaf pack attempts after immediate retry=%d want 1", got)
+	}
+	if got := db.vlogGenerationLeafPackSkipNoCandidateBackoff.Load(); got != 1 {
+		t.Fatalf("leaf pack no-candidate backoff skips=%d want 1", got)
+	}
+	if got := db.vlogGenerationMaintenancePassNoop.Load(); got == 0 {
+		t.Fatal("expected noop maintenance pass to be recorded during no-candidate backoff")
+	}
+	if got := db.Stats()["treedb.cache.vlog_generation.leaf_pack.last_skip_reason"]; got != "no_candidate_backoff" {
+		t.Fatalf("last_skip_reason after immediate retry=%q want no_candidate_backoff", got)
+	}
+}
+
+func TestVlogGenerationMaintenance_PeriodicPassLeafPackBackoffExpiresAndRuns(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+	t.Setenv(envEnableLeafGenerationPackMaintenance, "1")
+	recorder := &leafPackMaintenanceRecordingBackend{
+		DB: mustOpenLeafPackBackend(t),
+		responses: []backenddb.LeafGenerationPackRunOnceStats{
+			{SkipReason: leafGenerationPackNoCandidateSkipReason},
+			leafPackWindowExhaustingStats(10, 1024, 4096),
+		},
+		leafGCResp: backenddb.LeafGenerationGCStats{GenerationsEligible: 1, GenerationsDeleted: 1, FilesDeleted: 1},
+	}
+	db, cleanup := openLeafPackMaintenanceTestDB(t, recorder)
+	defer cleanup()
+
+	if ran := db.maybeRunPeriodicVlogGenerationMaintenance(false); !ran {
+		t.Fatal("expected first periodic maintenance pass to run")
+	}
+	db.vlogGenerationLeafPackNoCandidateBackoffUntilUnixNano.Store(time.Now().Add(-time.Second).UnixNano())
+
+	if ran := db.maybeRunPeriodicVlogGenerationMaintenance(false); !ran {
+		t.Fatal("expected second periodic maintenance pass to run after expiring no-candidate backoff")
+	}
+
+	_, calls, _, _ := recorder.recordedLeafPack()
+	if calls != 2 {
+		t.Fatalf("leaf pack calls after expired backoff=%d want 2", calls)
+	}
+	if got := db.vlogGenerationLeafPackRuns.Load(); got != 1 {
+		t.Fatalf("leaf pack runs=%d want 1", got)
+	}
+	if got := db.vlogGenerationLeafPackConsecutiveNoCandidate.Load(); got != 0 {
+		t.Fatalf("leaf pack consecutive no-candidate after success=%d want 0", got)
+	}
+	if got := db.vlogGenerationLeafPackNoCandidateBackoffUntilUnixNano.Load(); got != 0 {
+		t.Fatalf("leaf pack no-candidate backoff until=%d want 0 after success", got)
+	}
+	if got := db.Stats()["treedb.cache.vlog_generation.leaf_pack.last_skip_reason"]; got != "" {
+		t.Fatalf("last_skip_reason after successful run=%q want empty", got)
+	}
+}
+
 func TestVlogGenerationMaintenance_LeafPackUsesConfiguredPolicy(t *testing.T) {
 	prepareDirectSchedulerTest(t)
 	t.Setenv(envEnableLeafGenerationPackMaintenance, "1")


### PR DESCRIPTION
## Summary

This PR adds a leaf-pack-specific cooldown for repeated `plan_admission:no_candidates` outcomes in the cached TreeDB maintenance scheduler.

The narrow goal is to stop paying for the same empty leaf-pack planner result on every periodic tick during sync, while keeping maintenance automatic and without adding any external pause/resume control.

This PR does **not** claim that leaf-pack is currently producing useful dwell-time work on this workload. In both the branch and clean-`main` controls below, leaf-pack never found a runnable candidate.

## What Changed

Instead of re-entering `LeafGenerationPackRunOnce` on every periodic maintenance tick and rediscovering the same empty result, TreeDB now:

- records consecutive empty leaf-pack planner outcomes
- applies a bounded exponential backoff for that specific case (`5s` up to `30s`)
- resets the cooldown on a successful leaf-pack run or a different skip outcome
- exports stats for the new behavior so `run_celestia` captures it

The scope is intentionally narrow:

- no external pause/resume signal
- no global maintenance suppression
- no rewrite scheduler change
- no GC scheduler change

## Root Cause

`maybeRunLeafGenerationPackMaintenance` had a min-interval gate for successful runs, but no memory of repeated admitted empty plans.

That meant the periodic scheduler could do this forever:

1. pass foreground admission
2. call into `LeafGenerationPackRunOnce`
3. get `plan_admission:no_candidates`
4. forget immediately
5. try again on the next tick

This patch adds the missing memory for that exact failure mode.

## Pre-Existing Signal

The motivating control was a real `run_celestia` `fast`, zero-dwell, frozen-target run on clean `main`:

- sync: `303s`
- max RSS: `12,614,892 kB`
- `leaf_pack.attempts=210`
- `leaf_pack.runs=0`
- `leaf_pack.skips=210`
- `leaf_pack.last_skip_reason=plan_admission:no_candidates`

A second control with leaf-pack disabled entirely (`TREEDB_ENABLE_LEAF_GENERATION_PACK_MAINTENANCE=0`) showed the problem space was real:

- sync: `291s`
- max RSS: `9,694,204 kB`
- `leaf_pack.attempts=0`

That does **not** mean “disable leaf-pack.” It means the base scheduler was spending real work on empty leaf-pack planning during sync.

## What This PR Proves

### Zero-Dwell `fast` Sync

Fresh live comparison:

- clean `main`
  - sync: `303s`
  - max RSS: `12,614,892 kB`
  - `application.db`: `4,811,246,077`
  - `leaf_pack.attempts=210`
  - `leaf_pack.runs=0`

- this branch
  - sync: `291s`
  - max RSS: `10,724,360 kB`
  - `application.db`: `4,828,726,731`
  - `leaf_pack.attempts=12`
  - `leaf_pack.runs=0`
  - `leaf_pack.skip.no_candidate_backoff=216`

So on the narrow sync-stage problem, this branch appears to help materially:

- sync improved by `12s`
- max RSS dropped by about `1.89 GB`
- empty leaf-pack backend calls dropped from `210` to `12`

This is the strongest evidence in favor of the patch.

## What This PR Does Not Prove

### Dwell End-State Win

Fresh frozen-target `fast + 900s dwell` comparison:

- clean `main`
  - sync: `291s`
  - total: `1191s`
  - max RSS: `9,854,552 kB`
  - `application.db`: `2,610,168,284`
  - `leaf_vlog`: `2,385,987,829`
  - `leaf_pack.attempts=948`
  - `leaf_pack.runs=0`

- this branch
  - sync: `336s`
  - total: `1237s`
  - max RSS: `11,821,924 kB`
  - `application.db`: `2,801,865,908`
  - `leaf_vlog`: `2,552,097,664`
  - `leaf_pack.attempts=42`
  - `leaf_pack.runs=0`
  - `leaf_pack.skip.no_candidate_backoff=942`

So the branch should **not** be described as a general dwell improvement. It is not.

What this comparison does show is narrower:

- the branch did **not** suppress profitable leaf-pack work that `main` was doing, because `main` also had `0` leaf-pack runs
- instead, `main` spent the dwell window hammering the same empty leaf-pack result much more aggressively

That preserves the key invariant for this patch, but it is not an overall end-state win.

## Interpretation

The evidence supports this claim:

- leaf-pack empty-plan retries during sync are real waste
- a bounded internal cooldown reduces that waste substantially

The evidence does **not** yet support this stronger claim:

- this patch is a full end-to-end performance win across sync + dwell + final size

So this PR should be reviewed as a **targeted sync-stage scheduler optimization**, not as a final leaf-pack policy win.

## Validation

Tests:

- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationMaintenance_PeriodicPassBacksOffLeafPackNoCandidates|VlogGenerationMaintenance_PeriodicPassLeafPackBackoffExpiresAndRuns|VlogGenerationMaintenance_PeriodicPassRunsLeafPackWhenEnabled|VlogGenerationMaintenance_PeriodicPassRunsLeafPackUnderSteadyForegroundActivity|VlogGenerationMaintenance_PeriodicPassSkipsLeafPackOnWriteBurst|VlogGenerationMaintenance_PeriodicPassSkipsLeafPackOnQueuePressure|VlogGenerationMaintenance_PeriodicPassSkipsLeafPackOnForegroundIterators|VlogGenerationMaintenance_LeafPackUsesConfiguredPolicy)$' -count=1`
- `GOWORK=off go test ./TreeDB/caching -count=1`

Live benchmarking:

- zero-dwell `run_celestia` `fast` on branch vs clean `main`
- zero-dwell `run_celestia` `fast` on clean `main` with leaf-pack disabled
- `fast + 900s dwell` on branch vs clean `main`
