### PR TITLE
Fix leaf-pack maintenance durability by syncing before GC

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -22832,7 +22832,9 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 		remainingBytesToCopy := maxBytesToCopy
 		for remainingGenerations > 0 && remainingBytesToCopy > 0 {
 			stats, runErr := runner.LeafGenerationPackRunOnce(ctx, backenddb.LeafGenerationPackFromPlanOptions{
-				Sync:                       false,
+				// Pack maintenance runs GC immediately after successful pack runs.
+				// Keep pack writes durable before GC can retire older generations.
+				Sync:                       true,
 				MinPublishedAgeCommits:     minPublishedAgeCommits,
 				MinCandidateGenerations:    minCandidateGenerations,
 				MinReclaimPerByteCopiedPPM: minReclaimPerByteCopiedPPM,

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1958,6 +1958,9 @@ func TestLeafGenerationPackMaintenance_RunsWithDefaultBounds(t *testing.T) {
 	if opts.MinReclaimPerByteCopiedPPM != leafGenerationPackMaintenanceDefaultMinReclaimPerByteCopiedPPM {
 		t.Fatalf("MinReclaimPerByteCopiedPPM=%d want %d", opts.MinReclaimPerByteCopiedPPM, leafGenerationPackMaintenanceDefaultMinReclaimPerByteCopiedPPM)
 	}
+	if !opts.Sync {
+		t.Fatal("expected leaf pack maintenance to run with Sync=true")
+	}
 	if got := db.vlogGenerationLeafPackRuns.Load(); got != 1 {
 		t.Fatalf("leaf pack runs=%d want 1", got)
 	}
@@ -2018,6 +2021,11 @@ func TestLeafGenerationPackMaintenance_LoopsWithinBudgetAndRunsLeafGC(t *testing
 	}
 	if history[1].MaxGenerations != 1 || history[1].MaxBytesToCopy != 40 {
 		t.Fatalf("second bounds=(%d,%d) want (1,40)", history[1].MaxGenerations, history[1].MaxBytesToCopy)
+	}
+	for i := range history {
+		if !history[i].Sync {
+			t.Fatalf("history[%d].Sync=false want true", i)
+		}
 	}
 	gcStats, gcCalls := recorder.recordedLeafGC()
 	if gcCalls != 2 {


### PR DESCRIPTION
### Motivation
- Leaf-pack maintenance performed `LeafGenerationPackRunOnce` with `Sync=false` and immediately ran `LeafGenerationGC`, creating a crash window where GC could retire prior generations before packed data was durably written, risking permanent data loss. 
- The change ensures packed leaf-log records are made durable before GC can mark older generations deleted.

### Description
- Changed the maintenance invocation to call `LeafGenerationPackRunOnce` with `Sync: true` so pack writes are durable before subsequent GC. (`TreeDB/caching/db.go`)
- Added assertions in scheduler tests to verify the maintenance calls pass `Sync=true` for both single-run and multi-run loop paths. (`TreeDB/caching/vlog_generation_scheduler_test.go`)
- Commit message: `caching: sync leaf pack maintenance before GC`.

### Testing
- Ran `go test ./TreeDB/caching -run 'TestLeafGenerationPackMaintenance_(UsesConfiguredBudgetAndRecordsRunStats|LoopsWithinBudgetAndRunsLeafGC)' -count=1` and it passed. 
- Ran `go test ./TreeDB/caching -run TestLeafGenerationPackMaintenance_ -count=1` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1378f2e1c8322a5ee33232cd6ba96)