### PR TITLE
TreeDB: enforce sealed mmap byte cap for demoted segments

### DIFF
--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1877,7 +1877,7 @@ func (m *Manager) allowDemotedCurrentMmapLocked(target *File, nextCurrentID uint
 	targetData, _ := target.mmapData.Load().([]byte)
 	targetMapped := len(targetData) > 0
 	for _, f := range m.files {
-		if f == nil || f.ID == nextCurrentID || f.currentWritable.Load() {
+		if f == nil || f == target || f.ID == nextCurrentID || f.currentWritable.Load() {
 			continue
 		}
 		if isLeafLogFileID(f.ID) != targetIsLeaf {
@@ -1890,7 +1890,11 @@ func (m *Manager) allowDemotedCurrentMmapLocked(target *File, nextCurrentID uint
 		mappedSealed++
 		mappedSealedBytes += uint64(len(data))
 	}
-	if mappedSealed > maxSegments {
+	projectedMappedSealed := mappedSealed
+	if targetMapped {
+		projectedMappedSealed++
+	}
+	if projectedMappedSealed > maxSegments {
 		return false
 	}
 	if maxBytes > 0 {
@@ -1907,16 +1911,7 @@ func (m *Manager) allowDemotedCurrentMmapLocked(target *File, nextCurrentID uint
 		}
 		limit := uint64(maxBytes)
 		if targetMapped {
-			currentBytes := uint64(len(targetData))
-			if targetBytes > currentBytes {
-				projected := targetBytes
-				if mappedSealedBytes > currentBytes {
-					projected += mappedSealedBytes - currentBytes
-				}
-				if projected > limit {
-					return false
-				}
-			} else if mappedSealedBytes > limit {
+			if mappedSealedBytes+targetBytes > limit {
 				return false
 			}
 		} else if mappedSealedBytes+targetBytes > limit {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1874,6 +1874,8 @@ func (m *Manager) allowDemotedCurrentMmapLocked(target *File, nextCurrentID uint
 	}
 	mappedSealed := 0
 	var mappedSealedBytes uint64
+	targetData, _ := target.mmapData.Load().([]byte)
+	targetMapped := len(targetData) > 0
 	for _, f := range m.files {
 		if f == nil || f.ID == nextCurrentID || f.currentWritable.Load() {
 			continue
@@ -1891,8 +1893,35 @@ func (m *Manager) allowDemotedCurrentMmapLocked(target *File, nextCurrentID uint
 	if mappedSealed > maxSegments {
 		return false
 	}
-	if maxBytes > 0 && mappedSealedBytes > uint64(maxBytes) {
-		return false
+	if maxBytes > 0 {
+		targetBytes := uint64(len(targetData))
+		if known := target.fileSize.Load(); known > int64(targetBytes) {
+			targetBytes = uint64(known)
+		} else if target.File != nil {
+			if info, err := target.File.Stat(); err == nil {
+				if sz := info.Size(); sz > int64(targetBytes) {
+					targetBytes = uint64(sz)
+					target.fileSize.Store(sz)
+				}
+			}
+		}
+		limit := uint64(maxBytes)
+		if targetMapped {
+			currentBytes := uint64(len(targetData))
+			if targetBytes > currentBytes {
+				projected := targetBytes
+				if mappedSealedBytes > currentBytes {
+					projected += mappedSealedBytes - currentBytes
+				}
+				if projected > limit {
+					return false
+				}
+			} else if mappedSealedBytes > limit {
+				return false
+			}
+		} else if mappedSealedBytes+targetBytes > limit {
+			return false
+		}
 	}
 	return true
 }

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -777,6 +777,7 @@ func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenFileGrewPastSealedB
 	if err := mgr.PromoteCurrentWritable(id2); err != nil {
 		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
 	}
+	waitForRemapIdle(t, f1)
 	if data, _ := f1.mmapData.Load().([]byte); len(data) != 0 {
 		t.Fatalf("expected demoted id1 mapping to retire once sealed file size exceeds byte cap, len=%d", len(data))
 	}

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -715,6 +715,76 @@ func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlready
 	}
 }
 
+func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenFileGrewPastSealedBytesBudget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	var files []*File
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMappedLeafSealedBudget(t, 2)
+	withMappedLeafSealedBytesBudget(t, 512)
+	t.Cleanup(func() {
+		waitForRemapIdle(t, files...)
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	})
+
+	dir := t.TempDir()
+	id1, ptr1 := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 1, 1, bytes.Repeat([]byte("a"), 64))
+	id2, _ := writeTestSegmentWithPtr(t, dir, ReservedLeafLogLaneID, 2, 2, bytes.Repeat([]byte("b"), 64))
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+
+	for _, id := range []uint32{id1, id2} {
+		if err := mgr.RegisterSegment(segmentPathForID(dir, id), id); err != nil {
+			t.Fatalf("RegisterSegment(%d): %v", id, err)
+		}
+	}
+	if err := mgr.PromoteCurrentWritable(id1); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id1): %v", err)
+	}
+	if _, err := mgr.ReadUnsafe(ptr1); err != nil {
+		t.Fatalf("ReadUnsafe(ptr1): %v", err)
+	}
+
+	path1 := segmentPathForID(dir, id1)
+	expand, err := os.OpenFile(path1, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		t.Fatalf("OpenFile(path1 append): %v", err)
+	}
+	if _, err := expand.Write(bytes.Repeat([]byte("x"), 4096)); err != nil {
+		_ = expand.Close()
+		t.Fatalf("append(path1): %v", err)
+	}
+	if err := expand.Close(); err != nil {
+		t.Fatalf("Close(path1 append): %v", err)
+	}
+
+	f1 := mgr.files[id1]
+	f2 := mgr.files[id2]
+	files = []*File{f1, f2}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) == 0 {
+		t.Fatalf("expected id1 mmap to be active before demotion")
+	}
+
+	if err := mgr.PromoteCurrentWritable(id2); err != nil {
+		t.Fatalf("PromoteCurrentWritable(id2): %v", err)
+	}
+	if data, _ := f1.mmapData.Load().([]byte); len(data) != 0 {
+		t.Fatalf("expected demoted id1 mapping to retire once sealed file size exceeds byte cap, len=%d", len(data))
+	}
+	if dead := f1.deadMappingsCount.Load(); dead == 0 {
+		t.Fatalf("expected demoted id1 mapping to be retained in deadMappings after retirement")
+	}
+}
+
 func TestManagerPromoteCurrentWritable_DeadMappingCapKeepsDemotedLeafMapped(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")


### PR DESCRIPTION
### Motivation
- Demoting a currently-writable segment retained its carryover mmap without accounting for the demoted file's final sealed/on-disk size, allowing later remaps to grow mappings beyond configured `MaxMapped*` byte caps and risk address-space or mapping-count exhaustion.

### Description
- Update `allowDemotedCurrentMmapLocked` to compute a demoted segment's projected sealed size using the current mapped length, the `fileSize` hint, and a `File.Stat()` when needed, and to retire the carryover mmap if keeping it would exceed the sealed-byte budget while preserving the existing count-budget and next-current exclusion logic.
- Preserve existing behavior for segment-count budgeting and excluding the upcoming current segment from the sealed budget.
- Add regression test `TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenFileGrewPastSealedBytesBudget` to `TreeDB/internal/valuelog/manager_test.go` that grows a mapped current segment on disk before demotion and verifies the mapping is retired when the sealed-bytes cap would be exceeded.
- Modified files: `TreeDB/internal/valuelog/manager.go` and `TreeDB/internal/valuelog/manager_test.go`.

### Testing
- Ran `go test ./TreeDB/internal/valuelog -run 'TestManagerPromoteCurrentWritable_(RetiresDemotedLeafWhenFileGrewPastSealedBytesBudget|RetiresDemotedLeafWhenSealedBudgetAlreadyFull|ExcludesNextCurrentFromSealedBudget)$'` and the tests passed.
- Ran `go test ./TreeDB/internal/valuelog -run TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenFileGrewPastSealedBytesBudget$` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6bf04b9108322bd3cf2a556ab0b45)