### PR TITLE
caching: disable periodic value-log generation scheduler in WAL-on profiles

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -14034,10 +14034,12 @@ func (db *DB) startVlogGenerationLoop() {
 		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerDisabled)
 		return
 	}
-	// Keep the scheduler alive in both WAL-off and WAL-on cached profiles. The
-	// restore/catch-up phase gate, WAL-on checkpoint-kick suppression, WAL-on
-	// periodic runGC suppression, and the quiet/economics checks decide whether
-	// any actual maintenance work is safe to do.
+	if !db.disableJournal {
+		// WAL-on profiles keep generational maintenance off the periodic path to
+		// avoid restore/catch-up races that can diverge post-snapshot state.
+		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerDisabled)
+		return
+	}
 	db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
 	db.wg.Add(1)
 	go db.vlogGenerationLoop()

--- a/TreeDB/caching/vlog_generation_leafref_reopen_test.go
+++ b/TreeDB/caching/vlog_generation_leafref_reopen_test.go
@@ -863,8 +863,8 @@ func TestCachedGenerationalMaintenance_BackgroundSchedulerIdle_WALOn(t *testing.
 		writeBatch(fmt.Sprintf("seed-%02d", i), 384)
 	}
 
-	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerIdle {
-		t.Fatalf("scheduler state=%d want idle", got)
+	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerDisabled {
+		t.Fatalf("scheduler state=%d want disabled", got)
 	}
 
 	if err := db.checkpointForBackendMaintenance(); err != nil {

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -754,7 +754,7 @@ func TestMaybeRunVlogGenerationMaintenanceWithOptions_TracksWalOnPeriodicSkip(t 
 	}
 }
 
-func TestStartVlogGenerationLoop_WALOnStartsIdle(t *testing.T) {
+func TestStartVlogGenerationLoop_WALOnDisabled(t *testing.T) {
 	t.Setenv(envDisableVlogGenerationCheckpointKick, "1")
 
 	dir := t.TempDir()
@@ -776,17 +776,8 @@ func TestStartVlogGenerationLoop_WALOnStartsIdle(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerIdle {
-		t.Fatalf("scheduler state=%d want=%d", got, vlogGenerationSchedulerIdle)
-	}
-
-	db.SetMaintenancePhase(MaintenancePhaseRestore)
-	if ran := db.maybeRunPeriodicVlogGenerationMaintenance(false); ran {
-		t.Fatal("periodic maintenance unexpectedly ran during restore in WAL-on profile")
-	}
-	db.maybeRunVlogGenerationMaintenanceWithOptions(false, vlogGenerationMaintenanceOptions{})
-	if got := db.vlogGenerationMaintenanceSkipPhase.Load(); got == 0 {
-		t.Fatal("expected maintenance phase skip to be recorded for WAL-on profile")
+	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerDisabled {
+		t.Fatalf("scheduler state=%d want=%d", got, vlogGenerationSchedulerDisabled)
 	}
 }
 

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -165,6 +165,8 @@ func disableVlogGenerationLoop(t *testing.T) {
 func prepareDirectSchedulerTest(t *testing.T) {
 	t.Helper()
 	disableVlogGenerationLoop(t)
+	// Direct scheduler tests drive maintenance explicitly and should not arm the
+	// checkpoint-kick path during Open, even if the scheduler itself is disabled.
 	t.Setenv(envDisableVlogGenerationCheckpointKick, "1")
 }
 
@@ -755,6 +757,8 @@ func TestMaybeRunVlogGenerationMaintenanceWithOptions_TracksWalOnPeriodicSkip(t 
 }
 
 func TestStartVlogGenerationLoop_WALOnDisabled(t *testing.T) {
+	// Keep checkpoint-kick inert so this test only exercises the periodic
+	// scheduler state and direct maintenance gating under WAL-on.
 	t.Setenv(envDisableVlogGenerationCheckpointKick, "1")
 
 	dir := t.TempDir()
@@ -778,6 +782,30 @@ func TestStartVlogGenerationLoop_WALOnDisabled(t *testing.T) {
 
 	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerDisabled {
 		t.Fatalf("scheduler state=%d want=%d", got, vlogGenerationSchedulerDisabled)
+	}
+
+	db.SetMaintenancePhase(MaintenancePhaseRestore)
+	db.maybeRunVlogGenerationMaintenanceWithOptions(false, vlogGenerationMaintenanceOptions{})
+	if got, want := db.vlogGenerationMaintenanceAttempts.Load(), uint64(1); got != want {
+		t.Fatalf("maintenance attempts after restore-phase request=%d want=%d", got, want)
+	}
+	if got := db.vlogGenerationMaintenanceAcquired.Load(); got != 0 {
+		t.Fatalf("maintenance acquired during restore-phase request=%d want=0", got)
+	}
+	if got := db.vlogGenerationMaintenanceSkipWALOnPeriodic.Load(); got != 0 {
+		t.Fatalf("maintenance wal-on periodic skips after restore-phase request=%d want=0", got)
+	}
+
+	db.SetMaintenancePhase(MaintenancePhaseSteady)
+	db.maybeRunVlogGenerationMaintenanceWithOptions(true, vlogGenerationMaintenanceOptions{})
+	if got, want := db.vlogGenerationMaintenanceAttempts.Load(), uint64(2); got != want {
+		t.Fatalf("maintenance attempts after periodic request=%d want=%d", got, want)
+	}
+	if got, want := db.vlogGenerationMaintenanceSkipWALOnPeriodic.Load(), uint64(1); got != want {
+		t.Fatalf("maintenance wal-on periodic skips=%d want=%d", got, want)
+	}
+	if got := db.vlogGenerationMaintenanceAcquired.Load(); got != 0 {
+		t.Fatalf("maintenance acquired=%d want=0", got)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Recent changes started the periodic value-log generation scheduler even when WAL (journal) is enabled, which allows background rewrite/leaf-pack maintenance to run during WAL-on restore/catch-up and can cause post-snapshot state divergence. 
- The scheduler should remain disabled for WAL-on (journal-enabled) cached profiles to avoid unsafe background work unless explicitly allowed by maintenance phase or other explicit gates.

### Description
- Restored the WAL-on guard in `startVlogGenerationLoop` so the periodic scheduler is not started when `db.disableJournal` is `false`; the scheduler still starts for WAL-off profiles when other policy/backend gates pass (file: `TreeDB/caching/db.go`).
- Updated the corresponding test to reflect the intended behavior by renaming and changing the assertion to expect the scheduler to be `vlogGenerationSchedulerDisabled` for WAL-on opens (file: `TreeDB/caching/vlog_generation_scheduler_test.go`).
- No other behavior paths were changed; checkpoint-kick and `maybeRunVlogGenerationMaintenanceWithOptions` WAL-on suppressions remain as before.

### Testing
- Ran targeted unit tests: `go test ./TreeDB/caching -run 'TestStartVlogGenerationLoop_WALOnDisabled|TestMaybeRunVlogGenerationMaintenanceWithOptions_TracksWalOnPeriodicSkip' -count=1` and they passed (`ok github.com/snissn/gomap/TreeDB/caching`).
- Existing scheduler-related unit coverage remains in place and the modified test now asserts the safer WAL-on behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c0ab43948322b8d336dd7a10c533)