### PR TITLE
db: harden rewrite RID start scan against corrupted segments

### DIFF
--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2165,17 +2165,26 @@ func scanValueLogFileMaxRID(seg *valuelog.File) (uint64, error) {
 	if seg == nil {
 		return 0, nil
 	}
-	path := seg.Path
-	if path == "" && seg.File != nil {
-		path = seg.File.Name()
-	}
-	if path == "" {
-		return 0, nil
-	}
 	const ridScanReaderBufferSize = 64 << 10
-	reader, err := valuelog.NewReaderWithBufferSize(path, seg.ID, ridScanReaderBufferSize)
-	if err != nil {
-		return 0, err
+	var (
+		reader *valuelog.Reader
+		err    error
+	)
+	if seg.File != nil {
+		reader = valuelog.NewReaderFromFileWithBufferSize(seg.File, seg.ID, ridScanReaderBufferSize)
+	}
+	if reader == nil {
+		path := seg.Path
+		if path == "" && seg.File != nil {
+			path = seg.File.Name()
+		}
+		if path == "" {
+			return 0, nil
+		}
+		reader, err = valuelog.NewReaderWithBufferSize(path, seg.ID, ridScanReaderBufferSize)
+		if err != nil {
+			return 0, err
+		}
 	}
 	defer func() { _ = reader.Close() }()
 
@@ -2189,7 +2198,7 @@ func scanValueLogFileMaxRID(seg *valuelog.File) (uint64, error) {
 			}
 			continue
 		}
-		if isTruncatedLogError(err) {
+		if errors.Is(err, io.EOF) || isTruncatedLogError(err) {
 			break
 		}
 		return 0, err

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2165,100 +2165,34 @@ func scanValueLogFileMaxRID(seg *valuelog.File) (uint64, error) {
 	if seg == nil {
 		return 0, nil
 	}
-	f := seg.File
-	closeAfter := false
-	if f == nil && seg.Path != "" {
-		var err error
-		f, err = os.Open(seg.Path)
-		if err != nil {
-			return 0, err
-		}
-		closeAfter = true
+	path := seg.Path
+	if path == "" && seg.File != nil {
+		path = seg.File.Name()
 	}
-	if f == nil {
+	if path == "" {
 		return 0, nil
 	}
-	if closeAfter {
-		defer func() { _ = f.Close() }()
-	}
-	info, err := f.Stat()
+	const ridScanReaderBufferSize = 64 << 10
+	reader, err := valuelog.NewReaderWithBufferSize(path, seg.ID, ridScanReaderBufferSize)
 	if err != nil {
 		return 0, err
 	}
-	size := info.Size()
-	if size < int64(valuelog.HeaderSize) {
-		return 0, nil
-	}
+	defer func() { _ = reader.Close() }()
 
-	const recordFlagGrouped byte = 1 << 0
-	const maxFrameRIDBytes = valuelog.MaxFrameK * 8
-
-	var (
-		header      [valuelog.HeaderSize]byte
-		frameHeader [valuelog.FrameHeaderSize]byte
-		frameRIDs   [maxFrameRIDBytes]byte
-		off         int64
-		maxRID      uint64
-	)
-	for off+int64(valuelog.HeaderSize) <= size {
-		if _, err := f.ReadAt(header[:], off); err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-				break
+	reader.DisableValueDecode()
+	maxRID := uint64(0)
+	for {
+		rid, _, err := reader.ReadNextMeta()
+		if err == nil {
+			if rid > maxRID {
+				maxRID = rid
 			}
-			return 0, err
+			continue
 		}
-		if header[4] != valuelog.Version {
-			return 0, valuelog.ErrCorrupt
-		}
-		rid := binary.LittleEndian.Uint64(header[8:16])
-		if rid > maxRID {
-			maxRID = rid
-		}
-		bodyLen := int64(binary.LittleEndian.Uint32(header[16:20]))
-		recordEnd := off + int64(valuelog.HeaderSize) + bodyLen
-		if recordEnd > size {
-			// Best-effort scan: tolerate truncated trailing records.
+		if isTruncatedLogError(err) {
 			break
 		}
-		if header[5]&recordFlagGrouped != 0 {
-			if bodyLen < int64(valuelog.FrameHeaderSize) {
-				break
-			}
-			frameOff := off + int64(valuelog.HeaderSize)
-			if _, err := f.ReadAt(frameHeader[:], frameOff); err != nil {
-				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-					break
-				}
-				return 0, err
-			}
-			if frameHeader[0] != valuelog.FrameVersion {
-				return 0, valuelog.ErrCorrupt
-			}
-			k := int(frameHeader[2])
-			if k <= 0 || k > valuelog.MaxFrameK {
-				return 0, valuelog.ErrCorrupt
-			}
-			ridBytes := k * 8
-			if bodyLen < int64(valuelog.FrameHeaderSize+ridBytes) {
-				break
-			}
-			if _, err := f.ReadAt(frameRIDs[:ridBytes], frameOff+int64(valuelog.FrameHeaderSize)); err != nil {
-				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-					break
-				}
-				return 0, err
-			}
-			for i := 0; i < k; i++ {
-				frameRID := binary.LittleEndian.Uint64(frameRIDs[i*8 : (i+1)*8])
-				if frameRID == 0 {
-					return 0, valuelog.ErrCorrupt
-				}
-				if frameRID > maxRID {
-					maxRID = frameRID
-				}
-			}
-		}
-		off = recordEnd
+		return 0, err
 	}
 	return maxRID, nil
 }

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -767,15 +767,25 @@ func TestNextRewriteRIDStartFromSet_ErrorsOnCorruptMidFileRecord(t *testing.T) {
 		t.Fatalf("Append(first): %v", err)
 	}
 
+	const (
+		crcStart     = 0
+		versionOff   = 4
+		flagsOff     = 5
+		ridStart     = 8
+		ridEnd       = 16
+		bodyLenStart = 16
+		bodyLenEnd   = 20
+	)
+
 	// Corrupt grouped record: grouped flag set but body too short for frame header.
 	rawRecord := make([]byte, valuelog.HeaderSize+1)
-	rawRecord[4] = valuelog.Version
-	rawRecord[5] = 1 << 0
-	binary.LittleEndian.PutUint64(rawRecord[8:16], 20)
-	binary.LittleEndian.PutUint32(rawRecord[16:20], 1)
+	rawRecord[versionOff] = valuelog.Version
+	rawRecord[flagsOff] = 1 << 0
+	binary.LittleEndian.PutUint64(rawRecord[ridStart:ridEnd], 20)
+	binary.LittleEndian.PutUint32(rawRecord[bodyLenStart:bodyLenEnd], 1)
 	rawRecord[valuelog.HeaderSize] = 0xff
-	binary.LittleEndian.PutUint32(rawRecord[0:4], crc32.ChecksumIEEE(rawRecord[4:]))
-	if _, err := w.AppendRawRecord(rawRecord, uint32(len(rawRecord)-4)); err != nil {
+	binary.LittleEndian.PutUint32(rawRecord[crcStart:versionOff], crc32.ChecksumIEEE(rawRecord[versionOff:]))
+	if _, err := w.AppendRawRecord(rawRecord, uint32(len(rawRecord)-versionOff)); err != nil {
 		t.Fatalf("AppendRawRecord(corrupt grouped): %v", err)
 	}
 	if _, err := w.Append(0, nil, 200, bytes.Repeat([]byte("b"), 64)); err != nil {

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -751,6 +751,55 @@ func TestNextRewriteRIDStartFromSet_MatchesSegmentScanner(t *testing.T) {
 	}
 }
 
+func TestNextRewriteRIDStartFromSet_ErrorsOnCorruptMidFileRecord(t *testing.T) {
+	dir := t.TempDir()
+
+	fileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID(0,1): %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+	w, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter(path): %v", err)
+	}
+	if _, err := w.Append(0, nil, 11, bytes.Repeat([]byte("a"), 64)); err != nil {
+		t.Fatalf("Append(first): %v", err)
+	}
+
+	// Corrupt grouped record: grouped flag set but body too short for frame header.
+	rawRecord := make([]byte, valuelog.HeaderSize+1)
+	rawRecord[4] = valuelog.Version
+	rawRecord[5] = 1 << 0
+	binary.LittleEndian.PutUint64(rawRecord[8:16], 20)
+	binary.LittleEndian.PutUint32(rawRecord[16:20], 1)
+	rawRecord[valuelog.HeaderSize] = 0xff
+	binary.LittleEndian.PutUint32(rawRecord[0:4], crc32.ChecksumIEEE(rawRecord[4:]))
+	if _, err := w.AppendRawRecord(rawRecord, uint32(len(rawRecord)-4)); err != nil {
+		t.Fatalf("AppendRawRecord(corrupt grouped): %v", err)
+	}
+	if _, err := w.Append(0, nil, 200, bytes.Repeat([]byte("b"), 64)); err != nil {
+		t.Fatalf("Append(last): %v", err)
+	}
+	closeNoErr(t, w)
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open(path): %v", err)
+	}
+	defer closeNoErr(t, f)
+
+	set := &valuelog.Set{
+		Files: map[uint32]*valuelog.File{
+			fileID: {ID: fileID, Path: path, File: f},
+		},
+	}
+	_, err = nextRewriteRIDStartFromSet(set)
+	if !errors.Is(err, valuelog.ErrCorrupt) {
+		t.Fatalf("nextRewriteRIDStartFromSet error=%v want ErrCorrupt", err)
+	}
+}
+
 func TestValueLogRewrite_HealthMetadata_PreservedAcrossReopen(t *testing.T) {
 	dir := t.TempDir()
 

--- a/TreeDB/internal/valuelog/reader.go
+++ b/TreeDB/internal/valuelog/reader.go
@@ -173,6 +173,7 @@ func sliceAliasesBytes(buf, candidate []byte) bool {
 
 type Reader struct {
 	f                  *os.File
+	closeFn            func() error
 	r                  *bufio.Reader
 	pos                int64
 	fileID             uint32
@@ -215,11 +216,32 @@ func NewReaderWithBufferSize(path string, fileID uint32, bufferSize int) (*Reade
 	}
 	return &Reader{
 		f:            f,
+		closeFn:      f.Close,
 		r:            bufio.NewReaderSize(f, bufferSize),
 		fileID:       fileID,
 		verifies:     true,
 		decodeValues: true,
 	}, nil
+}
+
+// NewReaderFromFileWithBufferSize creates a metadata/value reader from an
+// already-open segment handle without taking ownership of that file. The file
+// is read via a section reader so the caller's current offset is not disturbed.
+func NewReaderFromFileWithBufferSize(f *os.File, fileID uint32, bufferSize int) *Reader {
+	if f == nil {
+		return nil
+	}
+	if bufferSize <= 0 {
+		bufferSize = defaultBufferSize
+	}
+	sr := io.NewSectionReader(f, 0, 1<<63-1)
+	return &Reader{
+		f:            f,
+		r:            bufio.NewReaderSize(sr, bufferSize),
+		fileID:       fileID,
+		verifies:     true,
+		decodeValues: true,
+	}
 }
 
 func (r *Reader) DisableChecksum() {
@@ -604,10 +626,10 @@ func (r *Reader) discardNUpdateSum(n int, sum uint32) (uint32, error) {
 }
 
 func (r *Reader) Close() error {
-	if r == nil || r.f == nil {
+	if r == nil || r.closeFn == nil {
 		return nil
 	}
-	return r.f.Close()
+	return r.closeFn()
 }
 
 func decodeFramePayload(header FrameHeader, payload []byte, dictLookup DictLookup, rawLen uint32) ([]byte, error) {


### PR DESCRIPTION
### Motivation
- The previous segment-scanner read raw headers and grouped-frame RID lists without full record integrity validation, allowing malformed grouped records to prematurely stop scanning and undercount the maximum RID for a segment. 
- An undercounted max RID can allow the rewrite allocator to reuse RIDs that still exist later in the file, risking duplicate RIDs and recovery/integrity failures.

### Description
- Replace the raw header/frame parsing in `scanValueLogFileMaxRID` with the validated path `valuelog.Reader.ReadNextMeta()` so RID discovery enforces record-level integrity checks (including CRC and grouped-frame validation) and follows the same parsing used for normal reads.
- Preserve existing behavior for truncated tails by treating truncated-log errors as a terminal break (`isTruncatedLogError`) rather than a hard failure.
- Add a regression test `TestNextRewriteRIDStartFromSet_ErrorsOnCorruptMidFileRecord` that writes a valid record, a malformed grouped record, then a later higher-RID record and asserts that `nextRewriteRIDStartFromSet` returns `valuelog.ErrCorrupt`.
- Files changed: `TreeDB/db/vlog_rewrite.go` and `TreeDB/db/vlog_rewrite_test.go`.

### Testing
- Ran `go test ./TreeDB/db -run 'TestNextRewriteRIDStartFromSet_(ScansAllFiles|IgnoresMissingPathEntries|MatchesSegmentScanner|ErrorsOnCorruptMidFileRecord)' -count=1` and the tests passed (`ok`).
- The new regression test `TestNextRewriteRIDStartFromSet_ErrorsOnCorruptMidFileRecord` was added and exercised successfully. }

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c0af3c24832290c2e464e1e8ff20)