### PR TITLE
vlog-rewrite: avoid RID reuse in lane-hint fast path

### DIFF
--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1542,7 +1542,6 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	defer releaseSet()
 	files := db.valueOnlyValueLogFiles(set.Files)
 	if len(files) == 0 {
-		set = nil
 		return stats, nil
 	}
 	oldValueIDs := make(map[uint32]struct{}, len(files))
@@ -1599,7 +1598,6 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		if rewritePlanNeedsLiveEstimate(opts) {
 			liveByID, err = db.estimateValueLogLiveBytesBySegment(ctx)
 			if err != nil {
-				releaseSet()
 				return stats, err
 			}
 		}
@@ -1629,7 +1627,6 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	}
 	if restrictSource && sourceSegmentCount == 0 {
 		// No source segments selected: this rewrite pass is a no-op.
-		set = nil
 		stats.SegmentsAfter = stats.SegmentsBefore
 		stats.BytesAfter = stats.BytesBefore
 		return stats, nil
@@ -1656,7 +1653,6 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 					}
 					needSegScan = false
 				} else {
-					set = nil
 					return stats, statErr
 				}
 			}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1522,26 +1522,24 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	// path. Fall back to a refresh if the manager has not yet discovered any
 	// segments (or if another process created segments on disk).
 	set := db.valueLogManager.CurrentSetNoRefresh()
-	if set == nil || len(set.Files) == 0 {
+	releaseSet := func() {
 		if set != nil {
 			_ = db.valueLogManager.Release(set)
+			set = nil
 		}
+	}
+	if set == nil || len(set.Files) == 0 {
+		releaseSet()
 		if err := db.valueLogManager.Refresh(); err != nil {
 			return stats, err
 		}
 		set = db.valueLogManager.CurrentSetNoRefresh()
 	}
 	if set == nil || len(set.Files) == 0 {
-		if set != nil {
-			_ = db.valueLogManager.Release(set)
-		}
+		releaseSet()
 		return stats, nil
 	}
-	defer func() {
-		if set != nil {
-			_ = db.valueLogManager.Release(set)
-		}
-	}()
+	defer releaseSet()
 	files := db.valueOnlyValueLogFiles(set.Files)
 	if len(files) == 0 {
 		set = nil
@@ -1601,7 +1599,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		if rewritePlanNeedsLiveEstimate(opts) {
 			liveByID, err = db.estimateValueLogLiveBytesBySegment(ctx)
 			if err != nil {
-				_ = db.valueLogManager.Release(set)
+				releaseSet()
 				return stats, err
 			}
 		}
@@ -1667,16 +1665,16 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	if !needSegScan && opts.ReserveRIDs == nil {
 		segments, err = listValueLogSegments(db.dir)
 		if err != nil {
-			set = nil
+			releaseSet()
 			return stats, fmt.Errorf("list value-log segments for rewrite rid selection in %s: %w", db.dir, err)
 		}
 		nextRID, err = rewriteRIDStartScanner(segments)
 		if err != nil {
-			set = nil
+			releaseSet()
 			return stats, err
 		}
 	}
-	set = nil
+	releaseSet()
 	if needSegScan {
 		segments, err = rewriteWALSegmentsLister(db.dir)
 		if err != nil {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1662,7 +1662,13 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		}
 	}
 	if !needSegScan && opts.ReserveRIDs == nil {
-		nextRID, err = nextRewriteRIDStartFromSet(set)
+		segments, err = listValueLogSegments(db.dir)
+		if err != nil {
+			_ = db.valueLogManager.Release(set)
+			set = nil
+			return stats, err
+		}
+		nextRID, err = rewriteRIDStartScanner(segments)
 		if err != nil {
 			_ = db.valueLogManager.Release(set)
 			set = nil

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1539,9 +1539,9 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		releaseSet()
 		return stats, nil
 	}
-	defer releaseSet()
 	files := db.valueOnlyValueLogFiles(set.Files)
 	if len(files) == 0 {
+		releaseSet()
 		return stats, nil
 	}
 	oldValueIDs := make(map[uint32]struct{}, len(files))
@@ -1598,6 +1598,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		if rewritePlanNeedsLiveEstimate(opts) {
 			liveByID, err = db.estimateValueLogLiveBytesBySegment(ctx)
 			if err != nil {
+				releaseSet()
 				return stats, err
 			}
 		}
@@ -1627,6 +1628,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	}
 	if restrictSource && sourceSegmentCount == 0 {
 		// No source segments selected: this rewrite pass is a no-op.
+		releaseSet()
 		stats.SegmentsAfter = stats.SegmentsBefore
 		stats.BytesAfter = stats.BytesBefore
 		return stats, nil
@@ -1653,6 +1655,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 					}
 					needSegScan = false
 				} else {
+					releaseSet()
 					return stats, statErr
 				}
 			}
@@ -1667,7 +1670,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		nextRID, err = rewriteRIDStartScanner(segments)
 		if err != nil {
 			releaseSet()
-			return stats, err
+			return stats, fmt.Errorf("scan rewrite rid start in %s: %w", db.dir, err)
 		}
 	}
 	releaseSet()
@@ -1686,7 +1689,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	if opts.ReserveRIDs == nil && nextRID == 0 {
 		nextRID, err = rewriteRIDStartScanner(segments)
 		if err != nil {
-			return stats, err
+			return stats, fmt.Errorf("scan rewrite rid start in %s: %w", db.dir, err)
 		}
 	}
 	ridAlloc := newRewriteRIDAllocator(nextRID, opts.ReserveRIDs)

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1537,9 +1537,14 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		}
 		return stats, nil
 	}
+	defer func() {
+		if set != nil {
+			_ = db.valueLogManager.Release(set)
+		}
+	}()
 	files := db.valueOnlyValueLogFiles(set.Files)
 	if len(files) == 0 {
-		_ = db.valueLogManager.Release(set)
+		set = nil
 		return stats, nil
 	}
 	oldValueIDs := make(map[uint32]struct{}, len(files))
@@ -1626,7 +1631,6 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	}
 	if restrictSource && sourceSegmentCount == 0 {
 		// No source segments selected: this rewrite pass is a no-op.
-		_ = db.valueLogManager.Release(set)
 		set = nil
 		stats.SegmentsAfter = stats.SegmentsBefore
 		stats.BytesAfter = stats.BytesBefore
@@ -1654,7 +1658,6 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 					}
 					needSegScan = false
 				} else {
-					_ = db.valueLogManager.Release(set)
 					set = nil
 					return stats, statErr
 				}
@@ -1664,18 +1667,15 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	if !needSegScan && opts.ReserveRIDs == nil {
 		segments, err = listValueLogSegments(db.dir)
 		if err != nil {
-			_ = db.valueLogManager.Release(set)
 			set = nil
-			return stats, err
+			return stats, fmt.Errorf("list value-log segments for rewrite rid selection in %s: %w", db.dir, err)
 		}
 		nextRID, err = rewriteRIDStartScanner(segments)
 		if err != nil {
-			_ = db.valueLogManager.Release(set)
 			set = nil
 			return stats, err
 		}
 	}
-	_ = db.valueLogManager.Release(set)
 	set = nil
 	if needSegScan {
 		segments, err = rewriteWALSegmentsLister(db.dir)

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -3457,6 +3457,10 @@ func TestValueLogRewriteOnline_WithoutReserveRIDs_FastPathStillScansRIDStart(t *
 	if err != nil {
 		t.Fatalf("nextRewriteRIDStart: %v", err)
 	}
+	allocatedRID := nextRID - 1
+	if allocatedRID != 315_001 {
+		t.Fatalf("allocated rewrite RID=%d want 315001", allocatedRID)
+	}
 	if nextRID != 315_002 {
 		t.Fatalf("next RID after rewrite=%d want 315002", nextRID)
 	}

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -3397,7 +3397,7 @@ func TestValueLogRewriteOnline_WithoutReserveRIDs_UsesRIDStartScanner(t *testing
 	}
 }
 
-func TestValueLogRewriteOnline_WithoutReserveRIDs_UsesSetRIDFastPathWhenLaneHintIsClean(t *testing.T) {
+func TestValueLogRewriteOnline_WithoutReserveRIDs_FastPathStillScansRIDStart(t *testing.T) {
 	dir := t.TempDir()
 
 	db, err := Open(Options{Dir: dir})
@@ -3422,7 +3422,7 @@ func TestValueLogRewriteOnline_WithoutReserveRIDs_UsesSetRIDFastPathWhenLaneHint
 	ridStartScanCalls := 0
 	rewriteRIDStartScanner = func([]logSegment) (uint64, error) {
 		ridStartScanCalls++
-		return 0, fmt.Errorf("unexpected rid-start scan")
+		return 315_001, nil
 	}
 	t.Cleanup(func() { rewriteRIDStartScanner = origRIDStartScanner })
 	origWALLister := rewriteWALSegmentsLister
@@ -3443,8 +3443,8 @@ func TestValueLogRewriteOnline_WithoutReserveRIDs_UsesSetRIDFastPathWhenLaneHint
 	if stats.RecordsCopied != 1 {
 		t.Fatalf("expected one copied record, got %d", stats.RecordsCopied)
 	}
-	if ridStartScanCalls != 0 {
-		t.Fatalf("expected no rid-start scan calls, got %d", ridStartScanCalls)
+	if ridStartScanCalls != 1 {
+		t.Fatalf("expected one rid-start scan call, got %d", ridStartScanCalls)
 	}
 	if walScanCalls != 0 {
 		t.Fatalf("expected no wal segment scan calls, got %d", walScanCalls)

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -3449,6 +3449,17 @@ func TestValueLogRewriteOnline_WithoutReserveRIDs_FastPathStillScansRIDStart(t *
 	if walScanCalls != 0 {
 		t.Fatalf("expected no wal segment scan calls, got %d", walScanCalls)
 	}
+	segments, err := listValueLogSegments(dir)
+	if err != nil {
+		t.Fatalf("listValueLogSegments: %v", err)
+	}
+	nextRID, err := nextRewriteRIDStart(segments)
+	if err != nil {
+		t.Fatalf("nextRewriteRIDStart: %v", err)
+	}
+	if nextRID != 315_002 {
+		t.Fatalf("next RID after rewrite=%d want 315002", nextRID)
+	}
 }
 
 func TestValueLogRewriteOnline_LeafLogReservedLaneHintFallsBackToScan(t *testing.T) {


### PR DESCRIPTION
### Motivation
- The lane-hint fast path in `ValueLogRewriteOnline` computed the next RID from the value-log manager's current set, which excludes zombie segments still present on disk and can cause RID reuse and WAL recovery failures.
- Preserve the optimization that skips a full WAL scan while ensuring on-disk zombie value-log segments are considered when selecting the next RID.

### Description
- When `RewriteLaneHint` indicates the lane-hint fast path and `ReserveRIDs` is not provided, `ValueLogRewriteOnline` now calls `listValueLogSegments(db.dir)` and computes `nextRID` with `rewriteRIDStartScanner(segments)` instead of deriving it from the in-memory `set` only (file: `TreeDB/db/vlog_rewrite.go`).
- The change keeps the fast path that avoids scanning WAL segments while ensuring any zombie value-log files on disk influence RID allocation and prevent RID reuse.
- Updated the fast-path unit test to expect that the RID-start scan still runs (`TestValueLogRewriteOnline_WithoutReserveRIDs_FastPathStillScansRIDStart`) and adapted the test stubs accordingly (file: `TreeDB/db/vlog_rewrite_test.go`).

### Testing
- Ran `go test ./TreeDB/db -run 'TestValueLogRewriteOnline_WithoutReserveRIDs_(UsesRIDStartScanner|FastPathStillScansRIDStart)' -count=1` and the tests passed.
- Ran `go test ./TreeDB/db -run 'TestNextRewriteRIDStartFromSet' -count=1` and the test passed.
- Changes were limited to `TreeDB/db/vlog_rewrite.go` and `TreeDB/db/vlog_rewrite_test.go` and validated by the updated unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c1f481248322b4841d9bad37f880)