### PR TITLE
treedb: keep write gate on forced retained prune

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4889,13 +4889,6 @@ func (db *DB) pruneRetainedValueLogsWithObserved(force bool, observedSourceIDs m
 	}
 
 	live, err := db.collectValueLogLiveIDsUntil(db.lastForegroundWriteUnixNano.Load())
-	if err != nil && force && errors.Is(err, errForegroundWritesResumed) {
-		out.RetriedWithoutWriteGate = true
-		live, err = db.collectValueLogLiveIDsUntil(0)
-		if err == nil {
-			out.RetrySucceeded = true
-		}
-	}
 	if err != nil {
 		if errors.Is(err, errForegroundWritesResumed) {
 			out.AbortedForegroundWrites = true

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4888,7 +4888,7 @@ func (db *DB) pruneRetainedValueLogsWithObserved(force bool, observedSourceIDs m
 		return out
 	}
 
-	live, err := db.collectValueLogLiveIDsUntil(db.lastForegroundWriteUnixNano.Load())
+	liveIDs, err := db.collectValueLogLiveIDsUntil(db.lastForegroundWriteUnixNano.Load())
 	if err != nil {
 		if errors.Is(err, errForegroundWritesResumed) {
 			out.AbortedForegroundWrites = true
@@ -4917,7 +4917,7 @@ func (db *DB) pruneRetainedValueLogsWithObserved(force bool, observedSourceIDs m
 			}
 			continue
 		}
-		if _, ok := live[id]; ok {
+		if _, ok := liveIDs[id]; ok {
 			out.LiveSkippedSegments++
 			if size > 0 {
 				out.LiveSkippedBytes += size

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -2285,7 +2285,7 @@ func TestRetainedValueLogPrune_AbortsWhenForegroundWritesResume(t *testing.T) {
 	}
 }
 
-func TestRetainedValueLogPruneForce_RetriesAfterForegroundWritesResume(t *testing.T) {
+func TestRetainedValueLogPruneForce_AbortsWhenForegroundWritesResume(t *testing.T) {
 	dir := t.TempDir()
 	backend := NewMockBackend()
 	backend.iteratorStartedCh = make(chan struct{})
@@ -2346,21 +2346,21 @@ func TestRetainedValueLogPruneForce_RetriesAfterForegroundWritesResume(t *testin
 	close(backend.iteratorBlockCh)
 	cache.waitForRetainedValueLogPrune()
 
-	if cache.valueLogRetained(retainedPath) {
-		t.Fatalf("retained path still marked after forced retry prune")
+	if !cache.valueLogRetained(retainedPath) {
+		t.Fatalf("retained path unmarked after forced prune abort")
 	}
 	stats := cache.Stats()
 	if got := stats["treedb.cache.vlog_retained_prune.forced_runs"]; got != "1" {
 		t.Fatalf("forced_runs=%q want 1", got)
 	}
-	if got := stats["treedb.cache.vlog_retained_prune.foreground_abort_runs"]; got != "0" {
-		t.Fatalf("foreground_abort_runs=%q want 0", got)
+	if got := stats["treedb.cache.vlog_retained_prune.foreground_abort_runs"]; got != "1" {
+		t.Fatalf("foreground_abort_runs=%q want 1", got)
 	}
-	if got := stats["treedb.cache.vlog_retained_prune.write_gate_retries"]; got != "1" {
-		t.Fatalf("write_gate_retries=%q want 1", got)
+	if got := stats["treedb.cache.vlog_retained_prune.write_gate_retries"]; got != "0" {
+		t.Fatalf("write_gate_retries=%q want 0", got)
 	}
-	if got := stats["treedb.cache.vlog_retained_prune.write_gate_retry_successes"]; got != "1" {
-		t.Fatalf("write_gate_retry_successes=%q want 1", got)
+	if got := stats["treedb.cache.vlog_retained_prune.write_gate_retry_successes"]; got != "0" {
+		t.Fatalf("write_gate_retry_successes=%q want 0", got)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Forced retained-prune previously retried the live-ID scan with `lastWrite=0`, which disabled the foreground write gate and could miss pointer-based writes that happened after the scan snapshot, risking deletion of still-referenced value-log segments.
- The intent is to preserve value-log pointer reachability correctness by requiring a write-quiet window for live-ID collection instead of scanning while foreground writes are active.

### Description

- Removed the forced-retry path that re-ran `collectValueLogLiveIDsUntil(0)` when `collectValueLogLiveIDsUntil(lastWrite)` returned `errForegroundWritesResumed` in `TreeDB/caching/db.go` so forced prune now aborts on resumed foreground writes like the non-forced path.
- Updated the retained-prune force test in `TreeDB/caching/db_test.go` to assert the safe abort behavior and to expect `foreground_abort_runs=1` and zero retry metrics instead of expecting a retry and success.
- Files changed: `TreeDB/caching/db.go`, `TreeDB/caching/db_test.go`.

### Testing

- Ran `go test ./TreeDB/caching -run 'TestRetainedValueLogPrune(Force_AbortsWhenForegroundWritesResume|_AbortsWhenForegroundWritesResume)' -count=1`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c3a547fc8322afef93e7fa95df2f)