### PR TITLE
caching: disable arena borrowing for SetView/DeleteView batches

### DIFF
--- a/TreeDB/caching/batch_arena_ownership_test.go
+++ b/TreeDB/caching/batch_arena_ownership_test.go
@@ -457,3 +457,43 @@ func TestBatchArenaLeases_NotNeededForPointerWritesOnCopiedMemtables(t *testing.
 		})
 	}
 }
+
+func TestBatchSetView_MutationAfterWriteDoesNotCorruptStoredValue(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir, NewMockBackend(), Options{
+		AllowUnsafe:    true,
+		DisableWAL:     true,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+		FlushThreshold: 1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	key := []byte("setview-key")
+	buf := bytes.Repeat([]byte("1"), 32)
+	want := bytes.Clone(buf)
+
+	b := db.NewBatchWithSize(1)
+	defer func() { _ = b.Close() }()
+	if err := b.SetView(key, buf); err != nil {
+		t.Fatalf("set view: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	for i := range buf {
+		buf[i] = '2'
+	}
+
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("value mutated after write: got=%q want=%q", got, want)
+	}
+}

--- a/TreeDB/caching/batch_arena_ownership_test.go
+++ b/TreeDB/caching/batch_arena_ownership_test.go
@@ -475,6 +475,7 @@ func TestBatchSetView_MutationAfterWriteDoesNotCorruptStoredValue(t *testing.T) 
 	key := []byte("setview-key")
 	buf := bytes.Repeat([]byte("1"), 32)
 	want := bytes.Clone(buf)
+	blockedBefore := batchArenaBorrowViewOpsBlockedTotal.Load()
 
 	b := db.NewBatchWithSize(1)
 	defer func() { _ = b.Close() }()
@@ -495,5 +496,12 @@ func TestBatchSetView_MutationAfterWriteDoesNotCorruptStoredValue(t *testing.T) 
 	}
 	if !bytes.Equal(got, want) {
 		t.Fatalf("value mutated after write: got=%q want=%q", got, want)
+	}
+	if got := batchArenaBorrowViewOpsBlockedTotal.Load(); got <= blockedBefore {
+		t.Fatalf("borrow_view_ops_blocked_total=%d before=%d want increased", got, blockedBefore)
+	}
+	stats := db.Stats()
+	if got := stats["treedb.cache.batch_arena.borrow_view_ops_blocked_total"]; got == "0" {
+		t.Fatalf("cache borrow_view_ops_blocked_total=%q want >0", got)
 	}
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -96,6 +96,7 @@ var batchArenaPoolSkipZeroBudgetTotal atomic.Uint64
 var batchArenaPoolDropBytesTotal atomic.Uint64
 var batchArenaPoolDropHardCapBytesTotal atomic.Uint64
 var batchArenaBorrowBlockedTotal atomic.Uint64
+var batchArenaBorrowViewOpsBlockedTotal atomic.Uint64
 var batchArenaBorrowPreflightBlockedTotal atomic.Uint64
 var batchArenaBorrowPreflightBlockedBytesTotal atomic.Uint64
 var batchArenaStealSuppressedDeferredTotal atomic.Uint64
@@ -23364,6 +23365,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.batch_arena.pool_drop_bytes_total"] = fmt.Sprintf("%d", batchArenaPoolDropBytesTotal.Load())
 	stats["treedb.cache.batch_arena.pool_drop_hard_cap_bytes_total"] = fmt.Sprintf("%d", batchArenaPoolDropHardCapBytesTotal.Load())
 	stats["treedb.cache.batch_arena.borrow_blocked_total"] = fmt.Sprintf("%d", batchArenaBorrowBlockedTotal.Load())
+	stats["treedb.cache.batch_arena.borrow_view_ops_blocked_total"] = fmt.Sprintf("%d", batchArenaBorrowViewOpsBlockedTotal.Load())
 	stats["treedb.cache.batch_arena.borrow_preflight_blocked_total"] = fmt.Sprintf("%d", batchArenaBorrowPreflightBlockedTotal.Load())
 	stats["treedb.cache.batch_arena.borrow_preflight_blocked_bytes_total"] = fmt.Sprintf("%d", batchArenaBorrowPreflightBlockedBytesTotal.Load())
 	stats["treedb.cache.batch_arena.steal_suppressed_deferred_total"] = fmt.Sprintf("%d", batchArenaStealSuppressedDeferredTotal.Load())
@@ -23433,6 +23435,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.process.batch_arena.pool_drop_bytes_total"] = fmt.Sprintf("%d", batchArenaPoolDropBytesTotal.Load())
 	stats["treedb.process.batch_arena.pool_drop_hard_cap_bytes_total"] = fmt.Sprintf("%d", batchArenaPoolDropHardCapBytesTotal.Load())
 	stats["treedb.process.batch_arena.borrow_blocked_total"] = fmt.Sprintf("%d", batchArenaBorrowBlockedTotal.Load())
+	stats["treedb.process.batch_arena.borrow_view_ops_blocked_total"] = fmt.Sprintf("%d", batchArenaBorrowViewOpsBlockedTotal.Load())
 	stats["treedb.process.batch_arena.borrow_preflight_blocked_total"] = fmt.Sprintf("%d", batchArenaBorrowPreflightBlockedTotal.Load())
 	stats["treedb.process.batch_arena.borrow_preflight_blocked_bytes_total"] = fmt.Sprintf("%d", batchArenaBorrowPreflightBlockedBytesTotal.Load())
 	stats["treedb.process.batch_arena.steal_suppressed_deferred_total"] = fmt.Sprintf("%d", batchArenaStealSuppressedDeferredTotal.Load())
@@ -25648,7 +25651,9 @@ type Batch struct {
 	shardIdxSets       [][]int
 	maxEntries         int
 
-	closed         bool
+	closed bool
+	// SetView/DeleteView keep caller-owned bytes until Write/Close, so memtables
+	// must not borrow the batch arena when any view op is present.
 	hasViewOps     bool
 	streamEligible bool
 	streamTried    bool
@@ -27055,6 +27060,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	// those slices into memtables.
 	if b.hasViewOps {
 		allowBatchArenaBorrow = false
+		batchArenaBorrowViewOpsBlockedTotal.Add(1)
 	}
 	if !allowBatchArenaBorrow {
 		batchArenaBorrowBlockedTotal.Add(1)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -25649,6 +25649,7 @@ type Batch struct {
 	maxEntries         int
 
 	closed         bool
+	hasViewOps     bool
 	streamEligible bool
 	streamTried    bool
 	firstKey       []byte
@@ -26099,6 +26100,7 @@ func (b *Batch) Reset() {
 	b.walBuf = b.walBuf[:0]
 	b.streamEligible = true
 	b.streamTried = false
+	b.hasViewOps = false
 	b.firstKey = nil
 	b.lastKey = nil
 	b.batchRange = keyRange{}
@@ -26558,6 +26560,7 @@ func (b *Batch) SetView(key, value []byte) error {
 		Key:   key,
 		Value: value,
 	})
+	b.hasViewOps = true
 	b.noteEntryAppend()
 	b.size += len(key) + len(value)
 
@@ -26639,6 +26642,7 @@ func (b *Batch) DeleteView(key []byte) error {
 		Type: batch.OpDelete,
 		Key:  key,
 	})
+	b.hasViewOps = true
 	b.noteEntryAppend()
 	b.size += len(key)
 
@@ -27046,6 +27050,12 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		prospectiveRetainBytes,
 		b.db.currentBatchArenaRetainedHardCapEffectiveBytes(),
 	)
+	// SetView/DeleteView callers provide externally-owned slices that are only
+	// guaranteed immutable until Write/Close returns. Do not retain or steal
+	// those slices into memtables.
+	if b.hasViewOps {
+		allowBatchArenaBorrow = false
+	}
 	if !allowBatchArenaBorrow {
 		batchArenaBorrowBlockedTotal.Add(1)
 		if preflightBlocked {


### PR DESCRIPTION
### Motivation
- `SetView`/`DeleteView` store caller-owned slices that are only immutable until `Write`/`Close`, but cached-batch borrow/steal paths could retain those slices in memtables and allow post-write mutation to corrupt stored data.

### Description
- Add a `hasViewOps` flag to `Batch` and clear it in `Batch.Reset` to track presence of `SetView`/`DeleteView` entries.
- Mark view-based operations by setting `hasViewOps` in `Batch.SetView` and `Batch.DeleteView` so ownership-sensitive behavior is known at write time.
- Prevent arena borrowing/steal for writes that contain view ops by forcing `allowBatchArenaBorrow = false` in the regular write path when `hasViewOps` is set, ensuring values are copied into memtables rather than retained.
- Add a regression test `TestBatchSetView_MutationAfterWriteDoesNotCorruptStoredValue` to verify mutating the original `SetView` buffer after `Write` does not change stored data.

### Testing
- Ran `go test ./TreeDB/caching -run 'TestBatchSetView_MutationAfterWriteDoesNotCorruptStoredValue|TestBatchArenaLeases_NotNeededForPointerWritesOnCopiedMemtables'` and it passed.
- Ran `go test ./TreeDB/internal/memtable -run TestAppendOnly` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c50a065483229b4716dc160d4942)