### PR TITLE
batch: reject oversized values before arena copy

### DIFF
--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -380,6 +380,12 @@ func (b *Batch) Set(key, value []byte) error {
 		return ErrKeyEmpty
 	}
 
+	// Enforce inline threshold before copying into the arena so rejected values
+	// do not consume batch-retained memory.
+	if len(value) > b.inlineThresholdForKey(key) {
+		return ErrValueTooLarge
+	}
+
 	// Copy key/value to ensure immutability (reduce per-entry allocations by
 	// copying into a per-batch arena).
 	k, valCopy := b.arenaCopyPair(key, value)
@@ -389,10 +395,6 @@ func (b *Batch) Set(key, value []byte) error {
 		Key:  k,
 	}
 
-	// Check threshold
-	if len(value) > b.inlineThresholdForKey(key) {
-		return ErrValueTooLarge
-	}
 	// Store inline
 	entry.Value = valCopy
 

--- a/TreeDB/batch/batch_arena_test.go
+++ b/TreeDB/batch/batch_arena_test.go
@@ -118,3 +118,28 @@ func TestBatchEnsureArenaChunk_GeometricGrowth(t *testing.T) {
 		t.Fatalf("third chunk cap=%d want=%d", got, want)
 	}
 }
+
+func TestBatchSet_OversizedValueDoesNotGrowArena(t *testing.T) {
+	b := New(newMapValueReader(), 4)
+	t.Cleanup(func() { _ = b.Close() })
+
+	if err := b.Set([]byte("k"), []byte("ok")); err != nil {
+		t.Fatalf("warm Set: %v", err)
+	}
+	chunksBefore := len(b.arenaChunks)
+	lastLenBefore := len(b.arenaChunks[chunksBefore-1])
+
+	if err := b.Set([]byte("k2"), bytes.Repeat([]byte("x"), 5)); err != ErrValueTooLarge {
+		t.Fatalf("Set oversized err=%v want=%v", err, ErrValueTooLarge)
+	}
+
+	if got := len(b.entries); got != 1 {
+		t.Fatalf("entries len=%d want=1", got)
+	}
+	if got := len(b.arenaChunks); got != chunksBefore {
+		t.Fatalf("arena chunk count=%d want=%d", got, chunksBefore)
+	}
+	if got := len(b.arenaChunks[chunksBefore-1]); got != lastLenBefore {
+		t.Fatalf("arena chunk len=%d want=%d", got, lastLenBefore)
+	}
+}

--- a/TreeDB/batch/batch_arena_test.go
+++ b/TreeDB/batch/batch_arena_test.go
@@ -122,14 +122,16 @@ func TestBatchEnsureArenaChunk_GeometricGrowth(t *testing.T) {
 func TestBatchSet_OversizedValueDoesNotGrowArena(t *testing.T) {
 	b := New(newMapValueReader(), 4)
 	t.Cleanup(func() { _ = b.Close() })
+	key := []byte("k2")
 
 	if err := b.Set([]byte("k"), []byte("ok")); err != nil {
 		t.Fatalf("warm Set: %v", err)
 	}
 	chunksBefore := len(b.arenaChunks)
 	lastLenBefore := len(b.arenaChunks[chunksBefore-1])
+	oversizedValue := bytes.Repeat([]byte("x"), b.inlineThresholdForKey(key)+1)
 
-	if err := b.Set([]byte("k2"), bytes.Repeat([]byte("x"), 5)); err != ErrValueTooLarge {
+	if err := b.Set(key, oversizedValue); err != ErrValueTooLarge {
 		t.Fatalf("Set oversized err=%v want=%v", err, ErrValueTooLarge)
 	}
 


### PR DESCRIPTION
### Motivation

- Prevent a DoS/OOM vector where `Batch.Set` copied oversized values into the batch arena before rejecting them, causing retained arena memory to grow even when `ErrValueTooLarge` is returned.

### Description

- Move the inline-threshold check in `Batch.Set` before the call to `arenaCopyPair` so oversized values are rejected without allocating/copying into arena chunks.
- Preserve existing semantics for accepted values (they are still copied into the per-batch arena for immutability).
- Add a regression test `TestBatchSet_OversizedValueDoesNotGrowArena` in `TreeDB/batch/batch_arena_test.go` that verifies rejected oversized writes do not append entries or grow `arenaChunks`.
- Files changed: `TreeDB/batch/batch.go`, `TreeDB/batch/batch_arena_test.go`.

### Testing

- Ran `go test ./TreeDB/batch` and the package tests succeeded (including the new `TestBatchSet_OversizedValueDoesNotGrowArena`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e717d8f4208322b7c6ed0bb04603d5)