### PR TITLE
caching: decouple read-quiet detection from open iterator count

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -9342,9 +9342,6 @@ func (db *DB) foregroundReadQuietFor(now time.Time, quietWindow time.Duration) b
 	if db == nil {
 		return true
 	}
-	if db.activeForegroundIterators.Load() > 0 {
-		return false
-	}
 	last := db.lastForegroundReadUnixNano.Load()
 	if last <= 0 {
 		return true

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -258,6 +258,23 @@ func TestWrapForegroundIterator_AvoidsDoubleWrapAndCloseIsIdempotent(t *testing.
 	}
 }
 
+func TestForegroundReadQuietFor_DoesNotDependOnActiveIterators(t *testing.T) {
+	db := &DB{closeCh: make(chan struct{})}
+	now := time.Now()
+	quietWindow := 200 * time.Millisecond
+
+	db.activeForegroundIterators.Store(1)
+	db.lastForegroundReadUnixNano.Store(now.Add(-2 * quietWindow).UnixNano())
+	if !db.foregroundReadQuietFor(now, quietWindow) {
+		t.Fatalf("foregroundReadQuietFor=false want true when reads are old")
+	}
+
+	db.lastForegroundReadUnixNano.Store(now.Add(-quietWindow / 2).UnixNano())
+	if db.foregroundReadQuietFor(now, quietWindow) {
+		t.Fatalf("foregroundReadQuietFor=true want false when reads are recent")
+	}
+}
+
 func TestForegroundMaintenanceContext_CancelsOnGetUnsafe(t *testing.T) {
 	backend := NewMockBackend()
 	backend.data["k"] = []byte("value")

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -260,7 +260,7 @@ func TestWrapForegroundIterator_AvoidsDoubleWrapAndCloseIsIdempotent(t *testing.
 
 func TestForegroundReadQuietFor_DoesNotDependOnActiveIterators(t *testing.T) {
 	db := &DB{closeCh: make(chan struct{})}
-	now := time.Now()
+	now := time.Unix(1_700_000_000, 0)
 	quietWindow := 200 * time.Millisecond
 
 	db.activeForegroundIterators.Store(1)


### PR DESCRIPTION
### Motivation
- The foreground read-quiet gate previously returned `false` whenever any foreground iterator was open, which could indefinitely block background value-log maintenance if an iterator was long‑lived or leaked, creating an availability DoS risk. 
- The intent is to make read-quiet detection reflect recent read activity timestamps rather than the presence of open iterators so maintenance can make progress despite long-lived iterators.

### Description
- Removed the `activeForegroundIterators` short-circuit from `foregroundReadQuietFor` so read-quiet is determined solely by `lastForegroundReadUnixNano` and the supplied `quietWindow`. 
- Added a regression test `TestForegroundReadQuietFor_DoesNotDependOnActiveIterators` that verifies `foregroundReadQuietFor` returns `true` when reads are old and `false` when reads are recent even when `activeForegroundIterators` is non-zero. 
- Kept existing iterator tracking (`wrapForegroundIterator` / `foregroundTrackedIterator`) unchanged so other admission/skip paths that explicitly check `activeForegroundIterators` continue to work.

### Testing
- Ran `go test ./TreeDB/caching -run 'TestForegroundReadQuietFor_DoesNotDependOnActiveIterators|TestWrapForegroundIterator_AvoidsDoubleWrapAndCloseIsIdempotent|TestIteratorTracksActiveForegroundIterators'` and the tests passed. 
- The change is minimal and focused on scheduler quiet detection and has targeted unit test coverage for the regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7055c09088322bfa2b20194688a00)