### PR TITLE
caching: stop read-only traffic from suppressing value-log maintenance

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4304,7 +4304,7 @@ func (db *DB) foregroundWritesResumedSince(lastWrite int64) bool {
 	}
 	current := db.lastForegroundWriteUnixNano.Load()
 	if lastWrite <= 0 {
-		return current > 0
+		return false
 	}
 	return current > lastWrite
 }
@@ -9491,6 +9491,9 @@ func (db *DB) foregroundActivityResumedSince(lastActivity int64) bool {
 func (db *DB) foregroundVlogMaintenanceResumedSince(lastWrite int64) bool {
 	if db == nil {
 		return false
+	}
+	if lastWrite <= 0 {
+		return db.lastForegroundWriteUnixNano.Load() > 0
 	}
 	return db.foregroundWritesResumedSince(lastWrite)
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -9368,7 +9368,11 @@ func (db *DB) foregroundActivityQuietFor(now time.Time, writeQuietWindow, readQu
 	if db == nil {
 		return true
 	}
-	return db.foregroundWriteQuietFor(now, writeQuietWindow) && db.foregroundReadQuietFor(now, readQuietWindow)
+	// Value-log maintenance must not be suppressible by read-only traffic.
+	// Keep write quiet-window gating for foreground write latency protection and
+	// leave read quiet-window tracking available for diagnostics/observability.
+	_ = readQuietWindow
+	return db.foregroundWriteQuietFor(now, writeQuietWindow)
 }
 
 func (db *DB) foregroundWriteQuiet(now time.Time) bool {
@@ -9471,10 +9475,10 @@ func (db *DB) foregroundActivityResumedSince(lastActivity int64) bool {
 	if db == nil {
 		return false
 	}
-	if db.activeForegroundIterators.Load() > 0 {
-		return true
-	}
-	return db.lastForegroundActivityUnixNano() > lastActivity
+	// Treat write resumption as the only maintenance-cancel signal so read-only
+	// clients (including long-lived iterators) cannot indefinitely defer
+	// maintenance passes.
+	return db.foregroundWritesResumedSince(lastActivity)
 }
 
 func (db *DB) foregroundWriteResumeContext(lastWrite int64, timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -5088,7 +5088,7 @@ func (db *DB) waitForRetainedValueLogPruneQuietOrForce(quietWindow time.Duration
 		if db.retainedPruneForceRequested.Swap(false) {
 			return true
 		}
-		if db.foregroundVlogMaintenanceQuietFor(time.Now(), quietWindow, vlogForegroundReadQuietWindow) {
+		if db.foregroundActivityQuietFor(time.Now(), quietWindow, vlogForegroundReadQuietWindow) {
 			// Re-check immediately before returning so force requests racing with
 			// the quiet-window transition are not dropped.
 			if db.retainedPruneForceRequested.Swap(false) {
@@ -9371,17 +9371,6 @@ func (db *DB) foregroundActivityQuietFor(now time.Time, writeQuietWindow, readQu
 	return db.foregroundWriteQuietFor(now, writeQuietWindow) && db.foregroundReadQuietFor(now, readQuietWindow)
 }
 
-func (db *DB) foregroundVlogMaintenanceQuietFor(now time.Time, writeQuietWindow, readQuietWindow time.Duration) bool {
-	if db == nil {
-		return true
-	}
-	// Value-log maintenance should only yield to foreground writes. Keep the
-	// read quiet-window parameter so call sites share the same knobs without
-	// letting read-only traffic suppress maintenance indefinitely.
-	_ = readQuietWindow
-	return db.foregroundWriteQuietFor(now, writeQuietWindow)
-}
-
 func (db *DB) foregroundWriteQuiet(now time.Time) bool {
 	return db.foregroundWriteQuietFor(now, vlogForegroundQuietWindow)
 }
@@ -9451,7 +9440,7 @@ func (db *DB) waitForForegroundMaintenanceQuietWindow(quietWindow time.Duration)
 	ticker := time.NewTicker(foregroundMaintenancePollInterval())
 	defer ticker.Stop()
 	for {
-		if db.closing.Load() || db.foregroundVlogMaintenanceQuietFor(time.Now(), quietWindow, vlogForegroundReadQuietWindow) {
+		if db.closing.Load() || db.foregroundActivityQuietFor(time.Now(), quietWindow, vlogForegroundReadQuietWindow) {
 			return
 		}
 		select {
@@ -14133,7 +14122,7 @@ func (db *DB) maybeRunPeriodicVlogGenerationMaintenance(runGC bool) bool {
 	// to both rewrite and periodic GC ticks; otherwise runGC ticks can still
 	// issue expensive full scans every interval during restore-heavy sync phases.
 	now := time.Now()
-	quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
+	quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
 	leafPackAdmission := db.foregroundLeafPackAdmission(now)
 	if !quiet && !leafPackAdmission.allowed &&
 		!db.vlogGenerationCheckpointKickPending.Load() &&
@@ -15701,7 +15690,7 @@ func (db *DB) scheduleVlogGenerationCheckpointKickHotNoDebtWake() {
 		if db.closing.Load() {
 			return
 		}
-		if !db.foregroundVlogMaintenanceQuietFor(time.Now(), vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow) {
+		if !db.foregroundActivityQuietFor(time.Now(), vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow) {
 			return
 		}
 		db.vlogGenerationCheckpointKickHotNoDebtWakeRuns.Add(1)
@@ -15982,7 +15971,7 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 		}
 	}()
 	now := time.Now()
-	quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
+	quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
 	leafPackAdmission := db.foregroundLeafPackAdmission(now)
 	rewriteQueue, err := db.currentVlogGenerationRewriteQueue()
 	if err != nil {
@@ -18040,7 +18029,7 @@ func (db *DB) maybeKickVlogGenerationMaintenanceAfterCheckpoint() {
 		rewriteQueueLen = len(rewriteQueue)
 	}
 	if envBool(envEnableVlogGenerationCheckpointKickHotDebtOnly) && !rewriteDisabled {
-		quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
+		quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
 		if !quiet && rewriteQueueLen == 0 && !db.vlogGenerationDeferredMaintenanceDue(now) {
 			db.vlogGenerationCheckpointKickSkippedHotNoDebt.Add(1)
 			db.scheduleVlogGenerationCheckpointKickHotNoDebtWake()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4302,10 +4302,10 @@ func (db *DB) foregroundWritesResumedSince(lastWrite int64) bool {
 	if db == nil {
 		return false
 	}
-	if lastWrite <= 0 {
-		return false
-	}
 	current := db.lastForegroundWriteUnixNano.Load()
+	if lastWrite <= 0 {
+		return current > 0
+	}
 	return current > lastWrite
 }
 
@@ -5088,7 +5088,7 @@ func (db *DB) waitForRetainedValueLogPruneQuietOrForce(quietWindow time.Duration
 		if db.retainedPruneForceRequested.Swap(false) {
 			return true
 		}
-		if db.foregroundActivityQuietFor(time.Now(), quietWindow, vlogForegroundReadQuietWindow) {
+		if db.foregroundVlogMaintenanceQuietFor(time.Now(), quietWindow, vlogForegroundReadQuietWindow) {
 			// Re-check immediately before returning so force requests racing with
 			// the quiet-window transition are not dropped.
 			if db.retainedPruneForceRequested.Swap(false) {
@@ -9368,9 +9368,16 @@ func (db *DB) foregroundActivityQuietFor(now time.Time, writeQuietWindow, readQu
 	if db == nil {
 		return true
 	}
-	// Value-log maintenance must not be suppressible by read-only traffic.
-	// Keep write quiet-window gating for foreground write latency protection and
-	// leave read quiet-window tracking available for diagnostics/observability.
+	return db.foregroundWriteQuietFor(now, writeQuietWindow) && db.foregroundReadQuietFor(now, readQuietWindow)
+}
+
+func (db *DB) foregroundVlogMaintenanceQuietFor(now time.Time, writeQuietWindow, readQuietWindow time.Duration) bool {
+	if db == nil {
+		return true
+	}
+	// Value-log maintenance should only yield to foreground writes. Keep the
+	// read quiet-window parameter so call sites share the same knobs without
+	// letting read-only traffic suppress maintenance indefinitely.
 	_ = readQuietWindow
 	return db.foregroundWriteQuietFor(now, writeQuietWindow)
 }
@@ -9444,7 +9451,7 @@ func (db *DB) waitForForegroundMaintenanceQuietWindow(quietWindow time.Duration)
 	ticker := time.NewTicker(foregroundMaintenancePollInterval())
 	defer ticker.Stop()
 	for {
-		if db.closing.Load() || db.foregroundActivityQuietFor(time.Now(), quietWindow, vlogForegroundReadQuietWindow) {
+		if db.closing.Load() || db.foregroundVlogMaintenanceQuietFor(time.Now(), quietWindow, vlogForegroundReadQuietWindow) {
 			return
 		}
 		select {
@@ -9475,10 +9482,17 @@ func (db *DB) foregroundActivityResumedSince(lastActivity int64) bool {
 	if db == nil {
 		return false
 	}
-	// Treat write resumption as the only maintenance-cancel signal so read-only
-	// clients (including long-lived iterators) cannot indefinitely defer
-	// maintenance passes.
-	return db.foregroundWritesResumedSince(lastActivity)
+	if db.activeForegroundIterators.Load() > 0 {
+		return true
+	}
+	return db.lastForegroundActivityUnixNano() > lastActivity
+}
+
+func (db *DB) foregroundVlogMaintenanceResumedSince(lastWrite int64) bool {
+	if db == nil {
+		return false
+	}
+	return db.foregroundWritesResumedSince(lastWrite)
 }
 
 func (db *DB) foregroundWriteResumeContext(lastWrite int64, timeout time.Duration) (context.Context, context.CancelFunc) {
@@ -9564,6 +9578,48 @@ func (db *DB) foregroundMaintenanceContext(timeout time.Duration) (context.Conte
 	return db.foregroundMaintenanceContextWithResumeGrace(timeout, 0)
 }
 
+func (db *DB) foregroundVlogMaintenanceContextWithResumeGrace(timeout, resumeGrace time.Duration) (context.Context, context.CancelFunc) {
+	if db == nil {
+		if timeout > 0 {
+			return context.WithTimeout(context.Background(), timeout)
+		}
+		return context.WithCancel(context.Background())
+	}
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), timeout)
+	} else {
+		ctx, cancel = context.WithCancel(context.Background())
+	}
+	lastWrite := db.lastForegroundWriteUnixNano.Load()
+	startedAt := time.Now()
+	go func(lastWrite int64) {
+		ticker := time.NewTicker(foregroundMaintenancePollInterval())
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-db.closeCh:
+				cancel()
+				return
+			case <-ticker.C:
+				if resumeGrace > 0 && time.Since(startedAt) < resumeGrace {
+					continue
+				}
+				if db.foregroundVlogMaintenanceResumedSince(lastWrite) {
+					cancel()
+					return
+				}
+			}
+		}
+	}(lastWrite)
+	return ctx, cancel
+}
+
 func (db *DB) vlogGenerationMaintenanceContext(timeout time.Duration, opts vlogGenerationMaintenanceOptions) (context.Context, context.CancelFunc) {
 	// Checkpoint-kick maintenance is an explicit caller opt-in to run outside the
 	// quiet-window gate. Keep this context timeout-bounded, but do not
@@ -9589,7 +9645,7 @@ func (db *DB) vlogGenerationMaintenanceContext(timeout time.Duration, opts vlogG
 		}()
 		return ctx, cancel
 	}
-	return db.foregroundMaintenanceContext(timeout)
+	return db.foregroundVlogMaintenanceContextWithResumeGrace(timeout, 0)
 }
 
 func (db *DB) leafGenerationPackMaintenanceContext(timeout time.Duration) (context.Context, context.CancelFunc) {
@@ -9625,7 +9681,7 @@ func (db *DB) vlogGenerationRewritePlanContext(timeout time.Duration, opts vlogG
 		}
 		return context.WithCancel(context.Background())
 	}
-	return db.foregroundMaintenanceContextWithResumeGrace(timeout, vlogGenerationRewritePlanResumeGrace)
+	return db.foregroundVlogMaintenanceContextWithResumeGrace(timeout, vlogGenerationRewritePlanResumeGrace)
 }
 
 func (db *DB) noteWrite() {
@@ -14074,7 +14130,7 @@ func (db *DB) maybeRunPeriodicVlogGenerationMaintenance(runGC bool) bool {
 	// to both rewrite and periodic GC ticks; otherwise runGC ticks can still
 	// issue expensive full scans every interval during restore-heavy sync phases.
 	now := time.Now()
-	quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
+	quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
 	leafPackAdmission := db.foregroundLeafPackAdmission(now)
 	if !quiet && !leafPackAdmission.allowed &&
 		!db.vlogGenerationCheckpointKickPending.Load() &&
@@ -15642,7 +15698,7 @@ func (db *DB) scheduleVlogGenerationCheckpointKickHotNoDebtWake() {
 		if db.closing.Load() {
 			return
 		}
-		if !db.foregroundActivityQuietFor(time.Now(), vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow) {
+		if !db.foregroundVlogMaintenanceQuietFor(time.Now(), vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow) {
 			return
 		}
 		db.vlogGenerationCheckpointKickHotNoDebtWakeRuns.Add(1)
@@ -15923,7 +15979,7 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 		}
 	}()
 	now := time.Now()
-	quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
+	quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
 	leafPackAdmission := db.foregroundLeafPackAdmission(now)
 	rewriteQueue, err := db.currentVlogGenerationRewriteQueue()
 	if err != nil {
@@ -17981,7 +18037,7 @@ func (db *DB) maybeKickVlogGenerationMaintenanceAfterCheckpoint() {
 		rewriteQueueLen = len(rewriteQueue)
 	}
 	if envBool(envEnableVlogGenerationCheckpointKickHotDebtOnly) && !rewriteDisabled {
-		quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
+		quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
 		if !quiet && rewriteQueueLen == 0 && !db.vlogGenerationDeferredMaintenanceDue(now) {
 			db.vlogGenerationCheckpointKickSkippedHotNoDebt.Add(1)
 			db.scheduleVlogGenerationCheckpointKickHotNoDebtWake()

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -294,14 +294,14 @@ func TestForegroundMaintenanceContext_CancelsOnActiveIterator(t *testing.T) {
 	}
 }
 
-func TestForegroundWritesResumedSince_FirstWriteAfterZeroBaseline(t *testing.T) {
+func TestForegroundVlogMaintenanceResumedSince_FirstWriteAfterZeroBaseline(t *testing.T) {
 	db := &DB{}
-	if db.foregroundWritesResumedSince(0) {
+	if db.foregroundVlogMaintenanceResumedSince(0) {
 		t.Fatalf("expected zero baseline with no writes to remain idle")
 	}
 	now := time.Unix(1_700_000_000, 0).UnixNano()
 	db.lastForegroundWriteUnixNano.Store(now)
-	if !db.foregroundWritesResumedSince(0) {
+	if !db.foregroundVlogMaintenanceResumedSince(0) {
 		t.Fatalf("expected first foreground write after open to count as resumed")
 	}
 }

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -294,6 +294,47 @@ func TestForegroundMaintenanceContext_CancelsOnActiveIterator(t *testing.T) {
 	}
 }
 
+func TestForegroundWritesResumedSince_FirstWriteAfterZeroBaseline(t *testing.T) {
+	db := &DB{}
+	if db.foregroundWritesResumedSince(0) {
+		t.Fatalf("expected zero baseline with no writes to remain idle")
+	}
+	now := time.Unix(1_700_000_000, 0).UnixNano()
+	db.lastForegroundWriteUnixNano.Store(now)
+	if !db.foregroundWritesResumedSince(0) {
+		t.Fatalf("expected first foreground write after open to count as resumed")
+	}
+}
+
+func TestForegroundVlogMaintenanceQuietFor_IgnoresReadOnlyTraffic(t *testing.T) {
+	db := &DB{}
+	now := time.Unix(1_700_000_100, 0)
+	db.lastForegroundWriteUnixNano.Store(now.Add(-2 * time.Second).UnixNano())
+	db.lastForegroundReadUnixNano.Store(now.UnixNano())
+	db.activeForegroundIterators.Store(1)
+
+	if db.foregroundActivityQuietFor(now, time.Second, time.Second) {
+		t.Fatalf("expected generic activity quiet check to remain blocked by read-only activity")
+	}
+	if !db.foregroundVlogMaintenanceQuietFor(now, time.Second, time.Second) {
+		t.Fatalf("expected value-log maintenance quiet check to ignore read-only activity")
+	}
+}
+
+func TestForegroundVlogMaintenanceContext_CancelsOnFirstWriteAfterOpen(t *testing.T) {
+	db := &DB{closeCh: make(chan struct{})}
+	ctx, cancel := db.foregroundVlogMaintenanceContextWithResumeGrace(250*time.Millisecond, 0)
+	defer cancel()
+
+	db.lastForegroundWriteUnixNano.Store(time.Unix(1_700_000_200, 0).UnixNano())
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("value-log maintenance context did not cancel after first foreground write")
+	}
+}
+
 func countSnapshotLeafEntries(t *testing.T, snap *db.Snapshot) int {
 	t.Helper()
 	if snap == nil {

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -306,21 +306,6 @@ func TestForegroundVlogMaintenanceResumedSince_FirstWriteAfterZeroBaseline(t *te
 	}
 }
 
-func TestForegroundVlogMaintenanceQuietFor_IgnoresReadOnlyTraffic(t *testing.T) {
-	db := &DB{}
-	now := time.Unix(1_700_000_100, 0)
-	db.lastForegroundWriteUnixNano.Store(now.Add(-2 * time.Second).UnixNano())
-	db.lastForegroundReadUnixNano.Store(now.UnixNano())
-	db.activeForegroundIterators.Store(1)
-
-	if db.foregroundActivityQuietFor(now, time.Second, time.Second) {
-		t.Fatalf("expected generic activity quiet check to remain blocked by read-only activity")
-	}
-	if !db.foregroundVlogMaintenanceQuietFor(now, time.Second, time.Second) {
-		t.Fatalf("expected value-log maintenance quiet check to ignore read-only activity")
-	}
-}
-
 func TestForegroundVlogMaintenanceContext_CancelsOnFirstWriteAfterOpen(t *testing.T) {
 	db := &DB{closeCh: make(chan struct{})}
 	ctx, cancel := db.foregroundVlogMaintenanceContextWithResumeGrace(250*time.Millisecond, 0)

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -9478,7 +9478,7 @@ func TestVlogGenerationRewritePlan_CancelBackoffExpires(t *testing.T) {
 	}
 }
 
-func TestVlogGenerationRewritePlan_CancelsWhenForegroundReadsResume(t *testing.T) {
+func TestVlogGenerationRewritePlan_DoesNotCancelWhenForegroundReadsResume(t *testing.T) {
 	prepareDirectSchedulerTest(t)
 
 	dir := t.TempDir()
@@ -9537,22 +9537,23 @@ func TestVlogGenerationRewritePlan_CancelsWhenForegroundReadsResume(t *testing.T
 	}
 
 	db.noteRead()
+	close(blocking.planBlock)
 
 	select {
 	case <-doneMaintenance:
 	case <-time.After(wait):
-		t.Fatalf("maintenance did not cancel after foreground reads resumed")
+		t.Fatalf("maintenance did not complete after foreground reads resumed")
 	}
 
-	if got := db.vlogGenerationLastRewritePlanUnixNano.Load(); got != 0 {
-		t.Fatalf("last rewrite plan timestamp=%d want=0 after cancellation", got)
+	if got := db.vlogGenerationRewritePlanCanceled.Load(); got != 0 {
+		t.Fatalf("plan canceled=%d want=0", got)
 	}
 	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerIdle {
 		t.Fatalf("scheduler state=%d want=%d", got, vlogGenerationSchedulerIdle)
 	}
 }
 
-func TestVlogGenerationRewritePlan_CancelStillRunsForcedGC(t *testing.T) {
+func TestVlogGenerationRewritePlan_ForegroundReadsStillRunForcedGC(t *testing.T) {
 	prepareDirectSchedulerTest(t)
 
 	dir := t.TempDir()
@@ -9610,17 +9611,18 @@ func TestVlogGenerationRewritePlan_CancelStillRunsForcedGC(t *testing.T) {
 		t.Fatalf("rewrite plan did not start")
 	}
 
-	// Resume foreground activity so rewrite planning is canceled.
+	// Resume foreground read activity while a forced-GC maintenance pass is active.
 	db.noteRead()
+	close(blocking.planBlock)
 
 	select {
 	case <-doneMaintenance:
 	case <-time.After(wait):
-		t.Fatalf("maintenance did not finish after rewrite-plan cancellation")
+		t.Fatalf("maintenance did not finish while foreground reads were active")
 	}
 
 	if got := db.vlogGenerationGCRuns.Load(); got == 0 {
-		t.Fatalf("expected forced GC path to run after rewrite-plan cancellation")
+		t.Fatalf("expected forced GC path to run while foreground reads were active")
 	}
 	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerIdle {
 		t.Fatalf("scheduler state=%d want=%d", got, vlogGenerationSchedulerIdle)


### PR DESCRIPTION
### Motivation

- Foreground read tracking and open iterators were gating background value-log maintenance, allowing untrusted read-only clients to indefinitely defer GC/rewrite and cause disk growth and potential denial-of-service. 

### Description

- Make maintenance quiet-window gating depend on foreground write quietness only by changing `foregroundActivityQuietFor` to ignore the read-quiet window while preserving read tracking for observability (`TreeDB/caching/db.go`).
- Treat resumed foreground *writes* as the only signal to cancel or preempt maintenance by changing `foregroundActivityResumedSince` to call `foregroundWritesResumedSince` (`TreeDB/caching/db.go`).
- Update scheduler tests to assert that foreground reads do not cancel rewrite planning and that forced GC still runs while reads are active, and adjust expectations accordingly (`TreeDB/caching/vlog_generation_scheduler_test.go`).

### Testing

- Ran targeted unit tests with `go test ./TreeDB/caching -run 'TestVlogGenerationRewritePlan_DoesNotCancelWhenForegroundReadsResume|TestVlogGenerationRewritePlan_ForegroundReadsStillRunForcedGC|TestBackendMaintenance_DoesNotBlockOnRetainedValueLogPruneQuietWindow|TestVlogGenerationMaintenance_PeriodicPassSkipsLeafPackOnForegroundIterators' -count=1`, and they passed.
- Ran additional related scheduler/retained-prune tests exercised during development and they passed (`go test ./TreeDB/caching -run 'TestRetainedValueLogPruneForce_PreemptsQuietWait|TestVlogGenerationMaintenance_PeriodicLeafPackDoesNotBlockOnScheduledRetainedPruneQuietWait|TestVlogGenerationMaintenance_PeriodicPassSkipsLeafPackOnForegroundIterators' -count=1`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71d5054f08322b896d02fad727606)