### PR TITLE
caching: seed next RID from all value-log segments on open

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8383,7 +8383,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	// Cached value-log RIDs remain globally unique across reopen/rewrite cycles.
 	// Until we persist nextRID separately, opening must recover the max on-disk
 	// RID here rather than risk reusing low RIDs after a clean reopen.
-	maxExistingRID, err := maxValueLogRIDFromSegments(tailValueLogSegmentsByLane(segments))
+	maxExistingRID, err := maxValueLogRIDFromSegments(segments)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -162,6 +162,52 @@ func TestTailValueLogSegmentsByLane(t *testing.T) {
 	}
 }
 
+func TestOpenSeedsRIDFromAllValueLogSegments(t *testing.T) {
+	dir := t.TempDir()
+	valueDir := filepath.Join(dir, "value_vlog")
+	if err := os.MkdirAll(valueDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	writeSegment := func(seq int, rid uint64) {
+		fileID, err := valuelog.EncodeFileID(0, uint32(seq))
+		if err != nil {
+			t.Fatalf("EncodeFileID(%d): %v", seq, err)
+		}
+		path := filepath.Join(valueDir, valueLogName(0, seq))
+		w, err := valuelog.NewWriter(path, fileID)
+		if err != nil {
+			t.Fatalf("NewWriter(%d): %v", seq, err)
+		}
+		if _, err := w.Append(0, nil, rid, []byte("v")); err != nil {
+			_ = w.Close()
+			t.Fatalf("Append(%d): %v", rid, err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("Close(%d): %v", seq, err)
+		}
+	}
+
+	// Older segment contains a higher RID than the newest segment.
+	writeSegment(1, 100)
+	writeSegment(2, 10)
+
+	backend := NewMockBackend()
+	db, err := Open(dir, backend, Options{
+		DisableWAL:  true,
+		RelaxedSync: true,
+		AllowUnsafe: true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if got := db.nextRID.Load(); got != 100 {
+		t.Fatalf("nextRID=%d want 100", got)
+	}
+}
+
 func TestIteratorTracksActiveForegroundIterators(t *testing.T) {
 	dir := t.TempDir()
 	backend, err := db.Open(db.Options{Dir: dir})

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -170,6 +170,7 @@ func TestOpenSeedsRIDFromAllValueLogSegments(t *testing.T) {
 	}
 
 	writeSegment := func(seq int, rid uint64) {
+		t.Helper()
 		fileID, err := valuelog.EncodeFileID(0, uint32(seq))
 		if err != nil {
 			t.Fatalf("EncodeFileID(%d): %v", seq, err)
@@ -189,7 +190,8 @@ func TestOpenSeedsRIDFromAllValueLogSegments(t *testing.T) {
 	}
 
 	// Older segment contains a higher RID than the newest segment.
-	writeSegment(1, 100)
+	const expectedMaxRID = uint64(100)
+	writeSegment(1, expectedMaxRID)
 	writeSegment(2, 10)
 
 	backend := NewMockBackend()
@@ -203,8 +205,8 @@ func TestOpenSeedsRIDFromAllValueLogSegments(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
-	if got := db.nextRID.Load(); got != 100 {
-		t.Fatalf("nextRID=%d want 100", got)
+	if got := db.nextRID.Load(); got != expectedMaxRID {
+		t.Fatalf("nextRID=%d want %d", got, expectedMaxRID)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Opening the DB previously seeded `nextRID` by scanning only per-lane tail value-log segments, which can miss a higher RID stored in an older segment due to out-of-order writes and segment rotation, risking RID reuse and recovery corruption. 

### Description
- Change `Open()` to call `maxValueLogRIDFromSegments(segments)` (scan all discovered segments) instead of `maxValueLogRIDFromSegments(tailValueLogSegmentsByLane(segments))`. 
- Add `TestOpenSeedsRIDFromAllValueLogSegments` which writes two value-log segments where an older segment contains a higher RID than a newer segment and asserts `db.nextRID` is seeded to the true maximum. 
- Keep existing `TestTailValueLogSegmentsByLane` to validate the tail-seg selection utility still behaves as expected.

### Testing
- Ran `go test ./TreeDB/caching -run 'Test(OpenSeedsRIDFromAllValueLogSegments|TailValueLogSegmentsByLane)' -count=1` and both tests passed. 
- Ran `go test ./TreeDB/caching -run TestMaxValueLogRIDFromSegments_IgnoresSegmentRemovedAfterScan -count=1` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e718cff24c83229fc3d76673fd5162)