### PR TITLE
caching: arm WAL-on value-log scheduler on steady phase

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -14028,14 +14028,14 @@ func (db *DB) startVlogGenerationLoop() {
 		return
 	}
 	if !db.disableJournal {
-		// WAL-on profiles must explicitly re-arm the periodic scheduler after the
-		// caller transitions out of restore/catch-up. Starting the loop during Open
-		// races with callers that immediately move maintenance phase away from the
-		// default steady state.
+		// WAL-on profiles start with the periodic scheduler disabled and re-enable
+		// it only after the caller transitions back to steady phase. The loop still
+		// starts here so later steady-phase arming never needs to spawn a new
+		// goroutine during runtime or shutdown.
 		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerDisabled)
-		return
+	} else {
+		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
 	}
-	db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
 	db.wg.Add(1)
 	go db.vlogGenerationLoop()
 }
@@ -14059,16 +14059,7 @@ func (db *DB) maybeArmWALOnVlogGenerationLoopForSteadyPhase() {
 	if db.suppressBackgroundVlogGenerationForMaintenancePhase() {
 		return
 	}
-	if !db.vlogGenerationSchedulerState.CompareAndSwap(vlogGenerationSchedulerDisabled, vlogGenerationSchedulerIdle) {
-		return
-	}
-	if db.closing.Load() {
-		db.vlogGenerationSchedulerState.CompareAndSwap(vlogGenerationSchedulerIdle, vlogGenerationSchedulerDisabled)
-		return
-	}
-	db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
-	db.wg.Add(1)
-	go db.vlogGenerationLoop()
+	db.vlogGenerationSchedulerState.CompareAndSwap(vlogGenerationSchedulerDisabled, vlogGenerationSchedulerIdle)
 }
 
 func (db *DB) vlogGenerationLoop() {
@@ -14082,6 +14073,9 @@ func (db *DB) vlogGenerationLoop() {
 			return
 		case <-ticker.C:
 			ticks++
+			if db.vlogGenerationSchedulerState.Load() == vlogGenerationSchedulerDisabled {
+				continue
+			}
 			db.maybeRunPeriodicVlogGenerationMaintenance(ticks%vlogGenerationGCEvery == 0)
 		}
 	}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -14041,7 +14041,7 @@ func (db *DB) startVlogGenerationLoop() {
 }
 
 func (db *DB) maybeArmWALOnVlogGenerationLoopForSteadyPhase() {
-	if db == nil || db.disableJournal {
+	if db == nil || db.disableJournal || db.closing.Load() {
 		return
 	}
 	if envBool(envDisableVlogGenerationLoop) {
@@ -14060,6 +14060,10 @@ func (db *DB) maybeArmWALOnVlogGenerationLoopForSteadyPhase() {
 		return
 	}
 	if !db.vlogGenerationSchedulerState.CompareAndSwap(vlogGenerationSchedulerDisabled, vlogGenerationSchedulerIdle) {
+		return
+	}
+	if db.closing.Load() {
+		db.vlogGenerationSchedulerState.CompareAndSwap(vlogGenerationSchedulerIdle, vlogGenerationSchedulerDisabled)
 		return
 	}
 	db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -14027,12 +14027,6 @@ func (db *DB) startVlogGenerationLoop() {
 		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerDisabled)
 		return
 	}
-	if !db.disableJournal {
-		// WAL-on profiles keep generational maintenance off the periodic path to
-		// avoid restore/catch-up races that can diverge post-snapshot state.
-		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerDisabled)
-		return
-	}
 	db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
 	db.wg.Add(1)
 	go db.vlogGenerationLoop()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -14027,6 +14027,41 @@ func (db *DB) startVlogGenerationLoop() {
 		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerDisabled)
 		return
 	}
+	if !db.disableJournal {
+		// WAL-on profiles must explicitly re-arm the periodic scheduler after the
+		// caller transitions out of restore/catch-up. Starting the loop during Open
+		// races with callers that immediately move maintenance phase away from the
+		// default steady state.
+		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerDisabled)
+		return
+	}
+	db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
+	db.wg.Add(1)
+	go db.vlogGenerationLoop()
+}
+
+func (db *DB) maybeArmWALOnVlogGenerationLoopForSteadyPhase() {
+	if db == nil || db.disableJournal {
+		return
+	}
+	if envBool(envDisableVlogGenerationLoop) {
+		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerDisabled)
+		return
+	}
+	if db.valueLogGenerationPolicy != uint8(backenddb.ValueLogGenerationHotWarmCold) {
+		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerDisabled)
+		return
+	}
+	if _, ok := db.backend.(backendValueLogRewriter); !ok {
+		db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerDisabled)
+		return
+	}
+	if db.suppressBackgroundVlogGenerationForMaintenancePhase() {
+		return
+	}
+	if !db.vlogGenerationSchedulerState.CompareAndSwap(vlogGenerationSchedulerDisabled, vlogGenerationSchedulerIdle) {
+		return
+	}
 	db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerIdle)
 	db.wg.Add(1)
 	go db.vlogGenerationLoop()
@@ -17912,6 +17947,7 @@ func (db *DB) SetMaintenancePhase(phase MaintenancePhase) {
 	}
 	db.debugVlogMaintf("maintenance_phase_change from=%s to=%s", maintenancePhaseString(uint32(prev)), maintenancePhaseString(uint32(phase)))
 	if phase == MaintenancePhaseSteady {
+		db.maybeArmWALOnVlogGenerationLoopForSteadyPhase()
 		db.scheduleDueVlogGenerationDeferredMaintenance()
 		db.schedulePendingVlogGenerationCheckpointKick()
 	}

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -815,6 +815,36 @@ func TestSetMaintenancePhase_WALOnSteadyArmsScheduler(t *testing.T) {
 	}
 }
 
+func TestSetMaintenancePhase_WALOnSteadyDoesNotArmSchedulerWhileClosing(t *testing.T) {
+	t.Setenv(envDisableVlogGenerationCheckpointKick, "1")
+
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+
+	db, err := Open(dir, backend, Options{
+		AllowUnsafe:                      true,
+		DisableWAL:                       false,
+		JournalLanes:                     1,
+		ValueLogGenerationPolicy:         uint8(backenddb.ValueLogGenerationHotWarmCold),
+		ValueLogRewriteTriggerTotalBytes: 1,
+		ForceValueLogPointers:            true,
+	})
+	if err != nil {
+		t.Fatalf("open cachingdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	db.SetMaintenancePhase(MaintenancePhaseRestore)
+	db.closing.Store(true)
+	db.SetMaintenancePhase(MaintenancePhaseSteady)
+	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerDisabled {
+		t.Fatalf("scheduler state while closing=%d want disabled", got)
+	}
+}
+
 func TestMaybeRunVlogGenerationMaintenanceWithOptions_TracksCollision(t *testing.T) {
 	db := &DB{valueLogGenerationPolicy: uint8(backenddb.ValueLogGenerationHotWarmCold)}
 	db.vlogGenerationMaintenanceActive.Store(true)

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -756,7 +756,7 @@ func TestMaybeRunVlogGenerationMaintenanceWithOptions_TracksWalOnPeriodicSkip(t 
 	}
 }
 
-func TestStartVlogGenerationLoop_WALOnStartsScheduler(t *testing.T) {
+func TestSetMaintenancePhase_WALOnSteadyArmsScheduler(t *testing.T) {
 	// Keep checkpoint-kick inert so this test only exercises the periodic
 	// scheduler state and direct maintenance gating under WAL-on.
 	t.Setenv(envDisableVlogGenerationCheckpointKick, "1")
@@ -780,11 +780,14 @@ func TestStartVlogGenerationLoop_WALOnStartsScheduler(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerIdle {
-		t.Fatalf("scheduler state=%d want=%d", got, vlogGenerationSchedulerIdle)
+	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerDisabled {
+		t.Fatalf("scheduler state=%d want disabled", got)
 	}
 
 	db.SetMaintenancePhase(MaintenancePhaseRestore)
+	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerDisabled {
+		t.Fatalf("scheduler state after restore=%d want disabled", got)
+	}
 	db.maybeRunVlogGenerationMaintenanceWithOptions(false, vlogGenerationMaintenanceOptions{})
 	if got, want := db.vlogGenerationMaintenanceAttempts.Load(), uint64(1); got != want {
 		t.Fatalf("maintenance attempts after restore-phase request=%d want=%d", got, want)
@@ -797,6 +800,9 @@ func TestStartVlogGenerationLoop_WALOnStartsScheduler(t *testing.T) {
 	}
 
 	db.SetMaintenancePhase(MaintenancePhaseSteady)
+	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerIdle {
+		t.Fatalf("scheduler state after steady=%d want=%d", got, vlogGenerationSchedulerIdle)
+	}
 	db.maybeRunVlogGenerationMaintenanceWithOptions(true, vlogGenerationMaintenanceOptions{})
 	if got, want := db.vlogGenerationMaintenanceAttempts.Load(), uint64(2); got != want {
 		t.Fatalf("maintenance attempts after periodic request=%d want=%d", got, want)

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -756,7 +756,7 @@ func TestMaybeRunVlogGenerationMaintenanceWithOptions_TracksWalOnPeriodicSkip(t 
 	}
 }
 
-func TestStartVlogGenerationLoop_WALOnDisabled(t *testing.T) {
+func TestStartVlogGenerationLoop_WALOnStartsScheduler(t *testing.T) {
 	// Keep checkpoint-kick inert so this test only exercises the periodic
 	// scheduler state and direct maintenance gating under WAL-on.
 	t.Setenv(envDisableVlogGenerationCheckpointKick, "1")
@@ -780,8 +780,8 @@ func TestStartVlogGenerationLoop_WALOnDisabled(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerDisabled {
-		t.Fatalf("scheduler state=%d want=%d", got, vlogGenerationSchedulerDisabled)
+	if got := db.vlogGenerationSchedulerState.Load(); got != vlogGenerationSchedulerIdle {
+		t.Fatalf("scheduler state=%d want=%d", got, vlogGenerationSchedulerIdle)
 	}
 
 	db.SetMaintenancePhase(MaintenancePhaseRestore)


### PR DESCRIPTION
### Motivation
- `#995` correctly disabled the WAL-on periodic generation scheduler during `Open()`, but that also meant WAL-on users had no automatic path to resume background value-log maintenance after restore/catch-up.
- The original draft PR went too far by starting the periodic loop unconditionally during `Open()`, which reintroduced the WAL-on restore/catch-up race the merged fix was protecting.

### Description
- Keep the WAL-on startup guard in `startVlogGenerationLoop()` so background generation maintenance stays disabled during `Open()`.
- Arm the periodic generation loop for WAL-on only when the caller explicitly transitions back to `MaintenancePhaseSteady`.
- Add scheduler coverage that verifies WAL-on stays disabled at open, remains disabled in restore, and becomes idle only after the explicit steady transition.

### Testing
- `GOWORK=off go test ./TreeDB/caching -run 'Test(SetMaintenancePhase_WALOnSteadyArmsScheduler|CachedGenerationalMaintenance_BackgroundSchedulerIdle_WALOn|VlogGenerationMaintenance_PeriodicGCSkipsInWALOnMode|Checkpoint_DoesNotKickVlogGenerationRewrite_WALOn)$' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'Test(MaybeRunVlogGenerationMaintenanceWithOptions_TracksWalOnPeriodicSkip|Checkpoint_KickSkipsWhenMaintenancePhaseNonSteady|VlogGenerationMaintenance_PeriodicSkipsWhenMaintenancePhaseNonSteady)$' -count=1`
