### PR TITLE
caching: stop read-only traffic from blocking retained value-log prune

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -5122,7 +5122,7 @@ func (db *DB) waitForRetainedValueLogPruneQuietOrForce(quietWindow time.Duration
 		if db.retainedPruneForceRequested.Swap(false) {
 			return true
 		}
-		if db.foregroundActivityQuietFor(time.Now(), quietWindow, vlogForegroundReadQuietWindow) {
+		if db.foregroundVlogMaintenanceQuietFor(time.Now(), quietWindow) {
 			// Re-check immediately before returning so force requests racing with
 			// the quiet-window transition are not dropped.
 			if db.retainedPruneForceRequested.Swap(false) {
@@ -9402,6 +9402,13 @@ func (db *DB) foregroundActivityQuietFor(now time.Time, writeQuietWindow, readQu
 	return db.foregroundWriteQuietFor(now, writeQuietWindow) && db.foregroundReadQuietFor(now, readQuietWindow)
 }
 
+func (db *DB) foregroundVlogMaintenanceQuietFor(now time.Time, quietWindow time.Duration) bool {
+	if db == nil {
+		return true
+	}
+	return db.foregroundWriteQuietFor(now, quietWindow)
+}
+
 func (db *DB) foregroundWriteQuiet(now time.Time) bool {
 	return db.foregroundWriteQuietFor(now, vlogForegroundQuietWindow)
 }
@@ -9471,7 +9478,7 @@ func (db *DB) waitForForegroundMaintenanceQuietWindow(quietWindow time.Duration)
 	ticker := time.NewTicker(foregroundMaintenancePollInterval())
 	defer ticker.Stop()
 	for {
-		if db.closing.Load() || db.foregroundActivityQuietFor(time.Now(), quietWindow, vlogForegroundReadQuietWindow) {
+		if db.closing.Load() || db.foregroundVlogMaintenanceQuietFor(time.Now(), quietWindow) {
 			return
 		}
 		select {
@@ -14139,7 +14146,7 @@ func (db *DB) maybeRunPeriodicVlogGenerationMaintenance(runGC bool) bool {
 	// to both rewrite and periodic GC ticks; otherwise runGC ticks can still
 	// issue expensive full scans every interval during restore-heavy sync phases.
 	now := time.Now()
-	quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
+	quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow)
 	leafPackAdmission := db.foregroundLeafPackAdmission(now)
 	if !quiet && !leafPackAdmission.allowed &&
 		!db.vlogGenerationCheckpointKickPending.Load() &&
@@ -15707,7 +15714,7 @@ func (db *DB) scheduleVlogGenerationCheckpointKickHotNoDebtWake() {
 		if db.closing.Load() {
 			return
 		}
-		if !db.foregroundActivityQuietFor(time.Now(), vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow) {
+		if !db.foregroundVlogMaintenanceQuietFor(time.Now(), vlogGenerationMaintenanceQuietWindow) {
 			return
 		}
 		db.vlogGenerationCheckpointKickHotNoDebtWakeRuns.Add(1)
@@ -15988,7 +15995,7 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 		}
 	}()
 	now := time.Now()
-	quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
+	quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow)
 	leafPackAdmission := db.foregroundLeafPackAdmission(now)
 	rewriteQueue, err := db.currentVlogGenerationRewriteQueue()
 	if err != nil {
@@ -18046,7 +18053,7 @@ func (db *DB) maybeKickVlogGenerationMaintenanceAfterCheckpoint() {
 		rewriteQueueLen = len(rewriteQueue)
 	}
 	if envBool(envEnableVlogGenerationCheckpointKickHotDebtOnly) && !rewriteDisabled {
-		quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
+		quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow)
 		if !quiet && rewriteQueueLen == 0 && !db.vlogGenerationDeferredMaintenanceDue(now) {
 			db.vlogGenerationCheckpointKickSkippedHotNoDebt.Add(1)
 			db.scheduleVlogGenerationCheckpointKickHotNoDebtWake()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -9402,13 +9402,13 @@ func (db *DB) foregroundActivityQuietFor(now time.Time, writeQuietWindow, readQu
 	return db.foregroundWriteQuietFor(now, writeQuietWindow) && db.foregroundReadQuietFor(now, readQuietWindow)
 }
 
+// foregroundVlogMaintenanceQuietFor is the retained-prune-specific quiet check:
+// it only yields to recent foreground writes. Read traffic and active iterators
+// still gate other maintenance paths through foregroundActivityQuietFor.
 func (db *DB) foregroundVlogMaintenanceQuietFor(now time.Time, quietWindow time.Duration) bool {
 	if db == nil {
 		return false
 	}
-	// Retained value-log prune waiting yields only to recent foreground writes.
-	// Read-only traffic and active iterators still gate admission through the
-	// broader foreground-activity checks used by other maintenance paths.
 	return db.foregroundWriteQuietFor(now, quietWindow)
 }
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -9404,7 +9404,7 @@ func (db *DB) foregroundActivityQuietFor(now time.Time, writeQuietWindow, readQu
 
 func (db *DB) foregroundVlogMaintenanceQuietFor(now time.Time, quietWindow time.Duration) bool {
 	if db == nil {
-		return true
+		return false
 	}
 	return db.foregroundWriteQuietFor(now, quietWindow)
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -9478,7 +9478,7 @@ func (db *DB) waitForForegroundMaintenanceQuietWindow(quietWindow time.Duration)
 	ticker := time.NewTicker(foregroundMaintenancePollInterval())
 	defer ticker.Stop()
 	for {
-		if db.closing.Load() || db.foregroundVlogMaintenanceQuietFor(time.Now(), quietWindow) {
+		if db.closing.Load() || db.foregroundActivityQuietFor(time.Now(), quietWindow, vlogForegroundReadQuietWindow) {
 			return
 		}
 		select {
@@ -14146,7 +14146,7 @@ func (db *DB) maybeRunPeriodicVlogGenerationMaintenance(runGC bool) bool {
 	// to both rewrite and periodic GC ticks; otherwise runGC ticks can still
 	// issue expensive full scans every interval during restore-heavy sync phases.
 	now := time.Now()
-	quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow)
+	quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
 	leafPackAdmission := db.foregroundLeafPackAdmission(now)
 	if !quiet && !leafPackAdmission.allowed &&
 		!db.vlogGenerationCheckpointKickPending.Load() &&
@@ -15714,7 +15714,7 @@ func (db *DB) scheduleVlogGenerationCheckpointKickHotNoDebtWake() {
 		if db.closing.Load() {
 			return
 		}
-		if !db.foregroundVlogMaintenanceQuietFor(time.Now(), vlogGenerationMaintenanceQuietWindow) {
+		if !db.foregroundActivityQuietFor(time.Now(), vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow) {
 			return
 		}
 		db.vlogGenerationCheckpointKickHotNoDebtWakeRuns.Add(1)
@@ -15995,7 +15995,7 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 		}
 	}()
 	now := time.Now()
-	quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow)
+	quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
 	leafPackAdmission := db.foregroundLeafPackAdmission(now)
 	rewriteQueue, err := db.currentVlogGenerationRewriteQueue()
 	if err != nil {
@@ -18053,7 +18053,7 @@ func (db *DB) maybeKickVlogGenerationMaintenanceAfterCheckpoint() {
 		rewriteQueueLen = len(rewriteQueue)
 	}
 	if envBool(envEnableVlogGenerationCheckpointKickHotDebtOnly) && !rewriteDisabled {
-		quiet := db.foregroundVlogMaintenanceQuietFor(now, vlogGenerationMaintenanceQuietWindow)
+		quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
 		if !quiet && rewriteQueueLen == 0 && !db.vlogGenerationDeferredMaintenanceDue(now) {
 			db.vlogGenerationCheckpointKickSkippedHotNoDebt.Add(1)
 			db.scheduleVlogGenerationCheckpointKickHotNoDebtWake()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -9404,7 +9404,9 @@ func (db *DB) foregroundActivityQuietFor(now time.Time, writeQuietWindow, readQu
 
 // foregroundVlogMaintenanceQuietFor is the retained-prune-specific quiet check:
 // it only yields to recent foreground writes. Read traffic and active iterators
-// still gate other maintenance paths through foregroundActivityQuietFor.
+// still gate other maintenance paths through foregroundActivityQuietFor. A nil
+// receiver intentionally fails closed so retained-prune callers do not treat
+// programmer error as a quiet window.
 func (db *DB) foregroundVlogMaintenanceQuietFor(now time.Time, quietWindow time.Duration) bool {
 	if db == nil {
 		return false

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -9406,6 +9406,9 @@ func (db *DB) foregroundVlogMaintenanceQuietFor(now time.Time, quietWindow time.
 	if db == nil {
 		return false
 	}
+	// Retained value-log prune waiting yields only to recent foreground writes.
+	// Read-only traffic and active iterators still gate admission through the
+	// broader foreground-activity checks used by other maintenance paths.
 	return db.foregroundWriteQuietFor(now, quietWindow)
 }
 

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -307,7 +307,7 @@ func TestWrapForegroundIterator_AvoidsDoubleWrapAndCloseIsIdempotent(t *testing.
 }
 
 func TestForegroundReadQuietFor_DoesNotDependOnActiveIterators(t *testing.T) {
-	db := &DB{closeCh: make(chan struct{})}
+	db := foregroundQuietTestDB()
 	now := time.Unix(1_700_000_000, 0)
 	quietWindow := 200 * time.Millisecond
 
@@ -323,8 +323,12 @@ func TestForegroundReadQuietFor_DoesNotDependOnActiveIterators(t *testing.T) {
 	}
 }
 
+func foregroundQuietTestDB() *DB {
+	return &DB{closeCh: make(chan struct{})}
+}
+
 func TestForegroundVlogMaintenanceQuietFor_IgnoresReadTraffic(t *testing.T) {
-	db := &DB{closeCh: make(chan struct{})}
+	db := foregroundQuietTestDB()
 	now := time.Unix(1_700_000_000, 0)
 	quietWindow := 200 * time.Millisecond
 

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -323,6 +323,25 @@ func TestForegroundReadQuietFor_DoesNotDependOnActiveIterators(t *testing.T) {
 	}
 }
 
+func TestForegroundVlogMaintenanceQuietFor_IgnoresReadTraffic(t *testing.T) {
+	db := &DB{closeCh: make(chan struct{})}
+	now := time.Unix(1_700_000_000, 0)
+	quietWindow := 200 * time.Millisecond
+
+	db.activeForegroundIterators.Store(1)
+	db.lastForegroundReadUnixNano.Store(now.UnixNano())
+	db.lastForegroundWriteUnixNano.Store(now.Add(-2 * quietWindow).UnixNano())
+
+	if !db.foregroundVlogMaintenanceQuietFor(now, quietWindow) {
+		t.Fatalf("foregroundVlogMaintenanceQuietFor=false want true when writes are quiet")
+	}
+
+	db.lastForegroundWriteUnixNano.Store(now.Add(-quietWindow / 2).UnixNano())
+	if db.foregroundVlogMaintenanceQuietFor(now, quietWindow) {
+		t.Fatalf("foregroundVlogMaintenanceQuietFor=true want false when writes are recent")
+	}
+}
+
 func TestForegroundMaintenanceContext_CancelsOnGetUnsafe(t *testing.T) {
 	backend := NewMockBackend()
 	backend.data["k"] = []byte("value")


### PR DESCRIPTION
### Motivation
- Retained value-log prune was waiting on full foreground quiet, so sustained reads or open iterators could keep closed retained segments around indefinitely even when there were no foreground writes.
- That is a narrower problem than the original draft claimed. Periodic rewrite/GC admission should still respect the existing read-quiet gate.

### Description
- Keep `foregroundVlogMaintenanceQuietFor(...)` as a write-only quiet check for retained-prune waiting.
- Continue using full foreground activity quiet for periodic value-log rewrite/GC admission, checkpoint-kick hot-debt wakeups, and other scheduler paths.
- Preserve the merged `#1003` behavior: read traffic no longer cancels maintenance once it is running, but it still gates admission.

### Testing
- `GOWORK=off go test ./TreeDB/caching -run 'TestForeground(ReadQuietFor_DoesNotDependOnActiveIterators|VlogMaintenanceQuietFor_IgnoresReadTraffic)|TestBackendMaintenance_DoesNotBlockOnRetainedValueLogPruneQuietWindow|TestVlogGenerationMaintenance_SkipsDuringRecentForegroundReads|TestCheckpoint_KickHotDebtOnlyWakeRunsAfterForegroundQuiets' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewritePlan_DoesNotCancelWhenForegroundReadsResume|VlogGenerationRewritePlan_ForegroundReadsStillRunForcedGC)$' -count=1`
