### PR TITLE
tests: follow up merged AI review cleanups

### DIFF
--- a/TreeDB/caching/batch_unsynced_vlog_flush_test.go
+++ b/TreeDB/caching/batch_unsynced_vlog_flush_test.go
@@ -84,10 +84,8 @@ func waitForLaneVlogDirtyState(t *testing.T, db *DB, laneID int, wantDirty bool)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if wantDirty {
-		t.Fatalf("lane %d never became dirty after %s", laneID, waitFor)
-	}
-	t.Fatalf("lane %d remained dirty waiting for value-log flush after %s", laneID, waitFor)
+	gotDirty := db.lanes[laneID].vlogDirty.Load()
+	t.Fatalf("lane %d vlogDirty=%t want %t after %s", laneID, gotDirty, wantDirty, waitFor)
 }
 
 func TestProfileFast_BatchWriteFlushesPointerValueLogBeforeMetadataSync(t *testing.T) {

--- a/TreeDB/caching/batch_unsynced_vlog_flush_test.go
+++ b/TreeDB/caching/batch_unsynced_vlog_flush_test.go
@@ -69,7 +69,7 @@ func findKeysForDistinctLanes(t *testing.T, db *DB, wantedLanes, perLane int) []
 	return keys
 }
 
-func waitForLaneVlogClean(t *testing.T, db *DB, laneID int) {
+func waitForLaneVlogDirtyState(t *testing.T, db *DB, laneID int, wantDirty bool) {
 	t.Helper()
 	waitFor := 2 * time.Second
 	if ddl, ok := t.Deadline(); ok {
@@ -79,30 +79,15 @@ func waitForLaneVlogClean(t *testing.T, db *DB, laneID int) {
 	}
 	deadline := time.Now().Add(waitFor)
 	for time.Now().Before(deadline) {
-		if !db.lanes[laneID].vlogDirty.Load() {
+		if db.lanes[laneID].vlogDirty.Load() == wantDirty {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+	if wantDirty {
+		t.Fatalf("lane %d never became dirty after %s", laneID, waitFor)
 	}
 	t.Fatalf("lane %d remained dirty waiting for value-log flush after %s", laneID, waitFor)
-}
-
-func waitForLaneVlogDirty(t *testing.T, db *DB, laneID int) {
-	t.Helper()
-	waitFor := 2 * time.Second
-	if ddl, ok := t.Deadline(); ok {
-		if remaining := time.Until(ddl) / 10; remaining > 0 && remaining < waitFor {
-			waitFor = remaining
-		}
-	}
-	deadline := time.Now().Add(waitFor)
-	for time.Now().Before(deadline) {
-		if db.lanes[laneID].vlogDirty.Load() {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("lane %d never became dirty after %s", laneID, waitFor)
 }
 
 func TestProfileFast_BatchWriteFlushesPointerValueLogBeforeMetadataSync(t *testing.T) {
@@ -159,7 +144,7 @@ func TestProfileFast_BatchWriteFlushesPointerValueLogBeforeMetadataSync(t *testi
 		t.Fatalf("close unsynced batch: %v", err)
 	}
 
-	waitForLaneVlogClean(t, db, 0)
+	waitForLaneVlogDirtyState(t, db, 0, false)
 
 	meta := db.NewBatch()
 	if err := meta.Set(rootKey, rootValue); err != nil {
@@ -251,12 +236,12 @@ func TestCheckpoint_SyncsFlushedValueLogBytesInStrictMode(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 
-	waitForLaneVlogDirty(t, db, 0)
+	waitForLaneVlogDirtyState(t, db, 0, true)
 
 	if err := db.Checkpoint(); err != nil {
 		t.Fatalf("checkpoint: %v", err)
 	}
-	waitForLaneVlogClean(t, db, 0)
+	waitForLaneVlogDirtyState(t, db, 0, false)
 	if db.hasDirtyValueLogLanes() {
 		t.Fatalf("expected checkpoint to clear pending strict-sync value-log state")
 	}
@@ -297,7 +282,7 @@ func TestCheckpoint_SyncsFlushBarrierValueLogBytesInStrictMode(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 
-	waitForLaneVlogDirty(t, db, 0)
+	waitForLaneVlogDirtyState(t, db, 0, true)
 	if err := db.flushValueLogLane(&db.lanes[0]); err != nil {
 		t.Fatalf("flushValueLogLane: %v", err)
 	}
@@ -363,7 +348,7 @@ func TestProfileFast_BatchWriteFlushesPointerValueLogAcrossMultipleLanes(t *test
 
 	activeLanes := 0
 	for i := range db.lanes {
-		waitForLaneVlogClean(t, db, i)
+		waitForLaneVlogDirtyState(t, db, i, false)
 		if db.lanes[i].vlogLiveBytes.Load() > 0 {
 			activeLanes++
 		}

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -212,6 +212,8 @@ func TestOpenSeedsRIDFromAllValueLogSegments(t *testing.T) {
 
 func foregroundMaintenanceCancelWait(t *testing.T) time.Duration {
 	t.Helper()
+	// Give maintenance cancellation several poll intervals to fire, but clamp the
+	// wait to a small floor and at most a fraction of the remaining test budget.
 	waitFor := 5 * foregroundMaintenancePollInterval()
 	if waitFor < 50*time.Millisecond {
 		waitFor = 50 * time.Millisecond

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -182,7 +182,7 @@ func TestOpenSeedsRIDFromAllValueLogSegments(t *testing.T) {
 		}
 		if _, err := w.Append(0, nil, rid, []byte("v")); err != nil {
 			_ = w.Close()
-			t.Fatalf("Append(%d): %v", rid, err)
+			t.Fatalf("Append(seq=%d rid=%d): %v", seq, rid, err)
 		}
 		if err := w.Close(); err != nil {
 			t.Fatalf("Close(%d): %v", seq, err)
@@ -208,6 +208,20 @@ func TestOpenSeedsRIDFromAllValueLogSegments(t *testing.T) {
 	if got := db.nextRID.Load(); got != expectedMaxRID {
 		t.Fatalf("nextRID=%d want %d", got, expectedMaxRID)
 	}
+}
+
+func foregroundMaintenanceCancelWait(t *testing.T) time.Duration {
+	t.Helper()
+	waitFor := 5 * foregroundMaintenancePollInterval()
+	if waitFor < 50*time.Millisecond {
+		waitFor = 50 * time.Millisecond
+	}
+	if ddl, ok := t.Deadline(); ok {
+		if remaining := time.Until(ddl) / 10; remaining > 0 && remaining < waitFor {
+			waitFor = remaining
+		}
+	}
+	return waitFor
 }
 
 func TestIteratorTracksActiveForegroundIterators(t *testing.T) {
@@ -339,7 +353,7 @@ func TestForegroundMaintenanceContext_CancelsOnGetUnsafe(t *testing.T) {
 
 	select {
 	case <-ctx.Done():
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(foregroundMaintenanceCancelWait(t)):
 		t.Fatalf("foreground maintenance context did not cancel after GetUnsafe")
 	}
 }
@@ -354,7 +368,7 @@ func TestForegroundMaintenanceContext_CancelsOnActiveIterator(t *testing.T) {
 
 	select {
 	case <-ctx.Done():
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(foregroundMaintenanceCancelWait(t)):
 		t.Fatalf("foreground maintenance context did not cancel with active iterator")
 	}
 }
@@ -380,7 +394,7 @@ func TestForegroundVlogMaintenanceContext_CancelsOnFirstWriteAfterOpen(t *testin
 
 	select {
 	case <-ctx.Done():
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(foregroundMaintenanceCancelWait(t)):
 		t.Fatalf("value-log maintenance context did not cancel after first foreground write")
 	}
 }

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -19,9 +19,10 @@ import (
 type blockingRewritePlannerBackend struct {
 	*backenddb.DB
 
-	startOnce sync.Once
-	planStart chan struct{}
-	planBlock chan struct{}
+	startOnce       sync.Once
+	planUnblockOnce sync.Once
+	planStart       chan struct{}
+	planBlock       chan struct{}
 
 	mu            sync.Mutex
 	rewriteCalls  int
@@ -245,6 +246,12 @@ func (b *blockingRewritePlannerBackend) recordedPlanOutcomes() (completed int, c
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.planCompleted, b.planCanceled
+}
+
+func (b *blockingRewritePlannerBackend) unblockPlan() {
+	b.planUnblockOnce.Do(func() {
+		close(b.planBlock)
+	})
 }
 
 type timedRewritePlannerBackend struct {
@@ -8779,7 +8786,7 @@ func TestVlogGenerationRewritePlan_RunsOutsideMaintenanceBarrier(t *testing.T) {
 		t.Fatalf("waitForCheckpoint blocked while rewrite planning was in progress")
 	}
 
-	close(blocking.planBlock)
+	blocking.unblockPlan()
 
 	select {
 	case <-doneMaintenance:
@@ -8869,7 +8876,7 @@ func TestVlogGenerationMaintenance_BypassQuietPlannerNotCanceledByForegroundActi
 	// Hold the planner past the 100ms foreground-cancel polling cadence to
 	// ensure bypass-quiet planning is not canceled by foreground activity.
 	time.Sleep(250 * time.Millisecond)
-	close(blocking.planBlock)
+	blocking.unblockPlan()
 
 	select {
 	case <-doneMaintenance:
@@ -9537,7 +9544,7 @@ func TestVlogGenerationRewritePlan_DoesNotCancelWhenForegroundReadsResume(t *tes
 	}
 
 	db.noteRead()
-	close(blocking.planBlock)
+	blocking.unblockPlan()
 
 	select {
 	case <-doneMaintenance:
@@ -9613,7 +9620,7 @@ func TestVlogGenerationRewritePlan_ForegroundReadsStillRunForcedGC(t *testing.T)
 
 	// Resume foreground read activity while a forced-GC maintenance pass is active.
 	db.noteRead()
-	close(blocking.planBlock)
+	blocking.unblockPlan()
 
 	select {
 	case <-doneMaintenance:


### PR DESCRIPTION
## Summary
- fold in still-actionable AI review follow-ups from the merged security PR stack
- deduplicate the lane dirty/clean polling helper used by the strict value-log sync tests
- harden scheduler and maintenance tests by using idempotent planner unblocking and poll-interval-derived cancellation waits
- improve the RID seeding helper failure message with both segment seq and RID context

## Review-thread follow-up covered here
- `#1001`: factor the duplicated lane dirty/clean waiting helpers into one helper
- `#1003`: make the maintenance cancellation wait derive from `foregroundMaintenancePollInterval()` and make planner unblocking idempotent in scheduler tests
- `#1004`: improve the value-log segment test helper error context

No additional actionable AI-review cleanup remained for `#999`, `#1000`, or `#1002` on current `main`.

## Validation
- `GOWORK=off go test ./TreeDB/caching -run 'Test(ProfileFast_BatchWriteFlushesPointerValueLog(BeforeMetadataSync|AcrossMultipleLanes)|Checkpoint_Syncs(FlushedValueLogBytesInStrictMode|FlushBarrierValueLogBytesInStrictMode))$' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'Test(ForegroundMaintenanceContext_CancelsOn(GetUnsafe|ActiveIterator)|ForegroundVlogMaintenanceResumedSince_FirstWriteAfterZeroBaseline|ForegroundVlogMaintenanceContext_CancelsOnFirstWriteAfterOpen|OpenSeedsRIDFromAllValueLogSegments)$' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'Test(VlogGenerationRewritePlan_RunsOutsideMaintenanceBarrier|VlogGenerationMaintenance_BypassQuietPlannerNotCanceledByForegroundActivity|VlogGenerationRewritePlan_DoesNotCancelWhenForegroundReadsResume|VlogGenerationRewritePlan_ForegroundReadsStillRunForcedGC)$' -count=1`
