### PR TITLE
[codex] valuelog: reuse grouped compressed file read scratch

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -112,6 +112,10 @@ through `wal/` even when WAL is off.
 
 Details: `docs/TREEDB_WRITE_PATHS.md`.
 
+If you are integrating TreeDB behind a Cosmos/Comet-style wrapper, use
+`TreeDB/integration/kvstoreadapter` to standardize profile/env/default handling
+instead of re-copying the open-path glue in each downstream repo.
+
 ## Leaf Pages in the Value Log
 
 `Options.IndexOuterLeavesInValueLog` stores the B+Tree **leaf pages** (the 4096B

--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -102,8 +102,8 @@ db, err := treedb.Open(opts)
 Profiles are intended to make intent explicit:
 
 - `ProfileDurable`: safest defaults (recommended).
-- `ProfileFast`: relax durability/integrity knobs for throughput and enables leaf pages in the value log + index optimizations (`LeafPrefixCompression`, `IndexColumnarLeaves`, `IndexPackedValuePtr`).
-- `ProfileWALOnFast`: fast ingest profile that keeps WAL on, relaxes durability checks, and enables the same leaf-vlog + index optimizations.
+- `ProfileFast`: relax durability/integrity knobs for throughput, enables leaf pages in the value log + index optimizations (`LeafPrefixCompression`, `IndexColumnarLeaves`, `IndexPackedValuePtr`), and pins the current run_celestia-style value-log compression defaults (`auto` + balanced policy + snappy block codec + medium autotune).
+- `ProfileWALOnFast`: fast ingest profile that keeps WAL on, relaxes durability checks, and enables the same leaf-vlog, index optimization, and value-log compression defaults.
 - `ProfileBench`: deterministic benchmarking profile (not production); includes `ProfileFast` index optimizations.
 
 Note: WAL-off is selected via `opts.Durability = treedb.DurabilityWALOffRelaxed`.

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -22570,17 +22570,26 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 			return nil, err
 		}
 		val, err := db.backend.Get(key)
+		if err == tree.ErrKeyNotFound {
+			return nil, nil
+		}
 		if err == nil && val != nil {
 			maybeRecordDBGetCallerSample(len(val))
 		}
 		return val, err
 	}
-	val, found, err := db.getMemtable(key)
+	scratch := getOwnedReadScratch()
+	defer putOwnedReadScratch(scratch)
+
+	val, found, err := db.getMemtableAppend(key, scratch.buf[:0])
 	if err != nil {
+		if err == tree.ErrKeyNotFound {
+			return nil, nil
+		}
 		return nil, err
 	}
 	if found {
-		if val == nil {
+		if len(val) == 0 {
 			return nil, nil
 		}
 		cpy := make([]byte, len(val))
@@ -22591,6 +22600,9 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 		return nil, err
 	}
 	val, err = db.backend.Get(key)
+	if err == tree.ErrKeyNotFound {
+		return nil, nil
+	}
 	if err == nil && val != nil {
 		maybeRecordDBGetCallerSample(len(val))
 	}

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"errors"
+	"sync"
 	"sync/atomic"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -29,6 +30,33 @@ type Snapshot struct {
 	backend *backenddb.Snapshot
 
 	closed atomic.Bool
+}
+
+type ownedReadScratch struct {
+	buf []byte
+}
+
+var ownedReadScratchPool = sync.Pool{
+	New: func() any {
+		return &ownedReadScratch{buf: make([]byte, 0, page.PageSize)}
+	},
+}
+
+func getOwnedReadScratch() *ownedReadScratch {
+	scratch, _ := ownedReadScratchPool.Get().(*ownedReadScratch)
+	if scratch == nil || cap(scratch.buf) != page.PageSize {
+		return &ownedReadScratch{buf: make([]byte, 0, page.PageSize)}
+	}
+	scratch.buf = scratch.buf[:0]
+	return scratch
+}
+
+func putOwnedReadScratch(scratch *ownedReadScratch) {
+	if scratch == nil || cap(scratch.buf) != page.PageSize {
+		return
+	}
+	scratch.buf = scratch.buf[:0]
+	ownedReadScratchPool.Put(scratch)
 }
 
 type backendSnapshotProvider interface {
@@ -216,15 +244,58 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 }
 
 func (s *Snapshot) Get(key []byte) ([]byte, error) {
-	out, err := s.GetAppend(key, nil)
+	val, ptr, flags, found := s.lookupQueueEntry(key)
+	if found {
+		if flags&node.FlagTombstone != 0 {
+			return nil, tree.ErrKeyNotFound
+		}
+		if flags&node.FlagPointer != 0 {
+			if s.db == nil {
+				return nil, errors.New("caching snapshot: value-log reader unavailable")
+			}
+			scratch := getOwnedReadScratch()
+			defer putOwnedReadScratch(scratch)
+
+			out, err := s.db.readValueLogAppend(key, ptr, scratch.buf[:0])
+			if err != nil {
+				return nil, err
+			}
+			snapshotReadQueuePointerHitsTotal.Add(1)
+			if len(out) == 0 {
+				return nil, nil
+			}
+			snapshotReadQueuePointerBytesTotal.Add(uint64(len(out)))
+			owned := make([]byte, len(out))
+			copy(owned, out)
+			return owned, nil
+		}
+		snapshotReadQueueInlineHitsTotal.Add(1)
+		if len(val) == 0 {
+			return nil, nil
+		}
+		snapshotReadQueueInlineBytesTotal.Add(uint64(len(val)))
+		owned := make([]byte, len(val))
+		copy(owned, val)
+		return owned, nil
+	}
+
+	if s == nil || s.backend == nil || s.db == nil {
+		return nil, tree.ErrKeyNotFound
+	}
+	if err := s.db.flushValueLogForBackendRead(); err != nil {
+		return nil, err
+	}
+	out, err := s.backend.Get(key)
 	if err != nil {
 		return nil, err
 	}
+	snapshotReadBackendHitsTotal.Add(1)
 	if len(out) == 0 {
-		return out, nil
+		return nil, nil
 	}
+	snapshotReadBackendBytesTotal.Add(uint64(len(out)))
 	maybeRecordSnapshotGetCallerSample(len(out))
-	return out[:len(out):len(out)], nil
+	return out, nil
 }
 
 func (s *Snapshot) GetUnsafe(key []byte) ([]byte, error) {

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -119,8 +119,8 @@ These bound uncheckpointed log growth in long-running workloads.
 Profiles map high-level intent to durability/integrity bundles:
 
 - `ProfileDurable`: durable mode + checksum verification.
-- `ProfileFast`: WAL off relaxed + checksum skip + index optimization bundle.
-- `ProfileWALOnFast`: WAL on relaxed + checksum skip + same index bundle.
+- `ProfileFast`: WAL off relaxed + checksum skip + index optimization bundle + the current run_celestia value-log compression defaults (`auto` / balanced / snappy / medium autotune).
+- `ProfileWALOnFast`: WAL on relaxed + checksum skip + the same index + value-log compression bundle.
 - `ProfileBench`: fast profile plus disabled background checkpoint/prune triggers for determinism.
 
 ## 9. Required Invariants

--- a/TreeDB/integration/kvstoreadapter/open.go
+++ b/TreeDB/integration/kvstoreadapter/open.go
@@ -89,11 +89,23 @@ func ParseProfile(raw string, fallback treedb.Profile) treedb.Profile {
 // ResolveOptions converts downstream wrapper defaults and standard TREEDB_*
 // environment overrides into TreeDB Options.
 func ResolveOptions(cfg OpenConfig) (treedb.Options, string, error) {
+	parentDir := strings.TrimSpace(cfg.ParentDir)
+	if parentDir == "" {
+		return treedb.Options{}, "", fmt.Errorf("parent directory must be non-empty")
+	}
+	name := strings.TrimSpace(cfg.Name)
+	if name == "" {
+		return treedb.Options{}, "", fmt.Errorf("database name must be non-empty")
+	}
+	if name == "." || name == ".." || strings.Contains(name, "/") || strings.Contains(name, "\\") {
+		return treedb.Options{}, "", fmt.Errorf("database name must not contain path separators")
+	}
+
 	suffix := cfg.DBFileSuffix
 	if suffix == "" {
 		suffix = ".db"
 	}
-	dbPath := filepath.Join(cfg.ParentDir, cfg.Name+suffix)
+	dbPath := filepath.Join(parentDir, name+suffix)
 	if err := os.MkdirAll(dbPath, 0o755); err != nil {
 		return treedb.Options{}, "", fmt.Errorf("error creating treedb directory: %w", err)
 	}
@@ -123,7 +135,7 @@ func ResolveOptions(cfg OpenConfig) (treedb.Options, string, error) {
 	if memtableModeEnvKey == "" {
 		memtableModeEnvKey = EnvMemtableMode
 	}
-	defaultMemtableMode := strings.TrimSpace(cfg.DefaultMemtableMode)
+	defaultMemtableMode := strings.ToLower(strings.TrimSpace(cfg.DefaultMemtableMode))
 	if defaultMemtableMode == "" {
 		profileMemtableMode := strings.TrimSpace(opts.MemtableMode)
 		if cfg.DefaultAdaptiveMemtableBase != "" &&

--- a/TreeDB/integration/kvstoreadapter/open.go
+++ b/TreeDB/integration/kvstoreadapter/open.go
@@ -101,14 +101,14 @@ func ResolveOptions(cfg OpenConfig) (treedb.Options, string, error) {
 		return treedb.Options{}, "", fmt.Errorf("database name must not contain path separators")
 	}
 
-	suffix := cfg.DBFileSuffix
+	suffix := strings.TrimSpace(cfg.DBFileSuffix)
 	if suffix == "" {
 		suffix = ".db"
 	}
-	dbPath := filepath.Join(parentDir, name+suffix)
-	if err := os.MkdirAll(dbPath, 0o755); err != nil {
-		return treedb.Options{}, "", fmt.Errorf("error creating treedb directory: %w", err)
+	if suffix == "." || suffix == ".." || strings.Contains(suffix, "/") || strings.Contains(suffix, "\\") || strings.Contains(suffix, "..") {
+		return treedb.Options{}, "", fmt.Errorf("database file suffix must be a simple suffix without path separators or traversal")
 	}
+	dbPath := filepath.Join(parentDir, name+suffix)
 
 	profileEnvKey := cfg.ProfileEnvKey
 	if profileEnvKey == "" {
@@ -158,6 +158,9 @@ func Open(cfg OpenConfig) (*Opened, error) {
 	opts, dbPath, err := ResolveOptions(cfg)
 	if err != nil {
 		return nil, err
+	}
+	if err := os.MkdirAll(dbPath, 0o755); err != nil {
+		return nil, fmt.Errorf("error creating treedb directory: %w", err)
 	}
 	tdb, err := treedb.Open(opts)
 	if err != nil {

--- a/TreeDB/integration/kvstoreadapter/open.go
+++ b/TreeDB/integration/kvstoreadapter/open.go
@@ -1,0 +1,168 @@
+package kvstoreadapter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	treedbadapter "github.com/snissn/gomap/kvstore/adapters/treedb"
+)
+
+const (
+	// EnvOpenProfile selects the TreeDB profile for downstream wrappers.
+	EnvOpenProfile = "TREEDB_OPEN_PROFILE"
+	// EnvKeepRecent overrides the wrapper's KeepRecent default.
+	EnvKeepRecent = "TREEDB_KEEP_RECENT"
+	// EnvMemtableMode overrides the wrapper's memtable mode.
+	EnvMemtableMode = "TREEDB_MEMTABLE_MODE"
+)
+
+// OpenConfig standardizes the common "TreeDB behind a kvstore-style wrapper"
+// open path used by downstream integrations such as cosmos-db/cometbft-db.
+//
+// The intended usage is:
+//  1. Pick a TreeDB profile.
+//  2. Optionally pin a small KeepRecent window.
+//  3. Optionally allow an integration-specific memtable default/override.
+//  4. Open TreeDB and wrap it with the canonical kvstore adapter.
+type OpenConfig struct {
+	ParentDir string
+	Name      string
+
+	// AdapterName controls kvstore-facing Name() output.
+	AdapterName string
+	// DBFileSuffix defaults to ".db".
+	DBFileSuffix string
+	// DefaultProfile defaults to treedb.ProfileWALOnFast.
+	DefaultProfile treedb.Profile
+	// DefaultKeepRecent is applied when the env override is unset.
+	DefaultKeepRecent uint64
+
+	// DefaultMemtableMode applies when the env override is unset.
+	DefaultMemtableMode string
+	// DefaultAdaptiveMemtableBase maps an empty/adaptive profile default to
+	// adaptive:<base> when DefaultMemtableMode is unset.
+	DefaultAdaptiveMemtableBase string
+
+	// Environment keys default to the standard TREEDB_* names when empty.
+	ProfileEnvKey      string
+	KeepRecentEnvKey   string
+	MemtableModeEnvKey string
+
+	// ReadWorkers overrides adapter read worker count when > 0.
+	ReadWorkers int
+}
+
+// Opened is the standardized result returned to downstream wrappers.
+type Opened struct {
+	Path    string
+	Options treedb.Options
+	DB      *treedb.DB
+	KV      *treedbadapter.DB
+}
+
+// ParseProfile parses the common downstream profile vocabulary and falls back
+// to fallback for empty or unknown values.
+func ParseProfile(raw string, fallback treedb.Profile) treedb.Profile {
+	if fallback == "" {
+		fallback = treedb.ProfileWALOnFast
+	}
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return fallback
+	case "fast":
+		return treedb.ProfileFast
+	case "wal_on_fast", "walonfast":
+		return treedb.ProfileWALOnFast
+	case "durable":
+		return treedb.ProfileDurable
+	case "bench":
+		return treedb.ProfileBench
+	default:
+		return fallback
+	}
+}
+
+// ResolveOptions converts downstream wrapper defaults and standard TREEDB_*
+// environment overrides into TreeDB Options.
+func ResolveOptions(cfg OpenConfig) (treedb.Options, string, error) {
+	suffix := cfg.DBFileSuffix
+	if suffix == "" {
+		suffix = ".db"
+	}
+	dbPath := filepath.Join(cfg.ParentDir, cfg.Name+suffix)
+	if err := os.MkdirAll(dbPath, 0o755); err != nil {
+		return treedb.Options{}, "", fmt.Errorf("error creating treedb directory: %w", err)
+	}
+
+	profileEnvKey := cfg.ProfileEnvKey
+	if profileEnvKey == "" {
+		profileEnvKey = EnvOpenProfile
+	}
+	profile := ParseProfile(os.Getenv(profileEnvKey), cfg.DefaultProfile)
+	opts := treedb.OptionsFor(profile, dbPath)
+
+	keepRecentEnvKey := cfg.KeepRecentEnvKey
+	if keepRecentEnvKey == "" {
+		keepRecentEnvKey = EnvKeepRecent
+	}
+	if raw := strings.TrimSpace(os.Getenv(keepRecentEnvKey)); raw != "" {
+		keepRecent, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			return treedb.Options{}, "", fmt.Errorf("invalid %s=%q: %w", keepRecentEnvKey, raw, err)
+		}
+		opts.KeepRecent = keepRecent
+	} else if cfg.DefaultKeepRecent != 0 {
+		opts.KeepRecent = cfg.DefaultKeepRecent
+	}
+
+	memtableModeEnvKey := cfg.MemtableModeEnvKey
+	if memtableModeEnvKey == "" {
+		memtableModeEnvKey = EnvMemtableMode
+	}
+	defaultMemtableMode := strings.TrimSpace(cfg.DefaultMemtableMode)
+	if defaultMemtableMode == "" {
+		profileMemtableMode := strings.TrimSpace(opts.MemtableMode)
+		if cfg.DefaultAdaptiveMemtableBase != "" &&
+			(profileMemtableMode == "" || strings.EqualFold(profileMemtableMode, "adaptive")) {
+			defaultMemtableMode = "adaptive:" + strings.ToLower(strings.TrimSpace(cfg.DefaultAdaptiveMemtableBase))
+		}
+	}
+	if raw := strings.TrimSpace(os.Getenv(memtableModeEnvKey)); raw != "" {
+		opts.MemtableMode = strings.ToLower(raw)
+	} else if defaultMemtableMode != "" {
+		opts.MemtableMode = defaultMemtableMode
+	}
+
+	return opts, dbPath, nil
+}
+
+// Open resolves standardized wrapper options, opens TreeDB, and returns the
+// canonical kvstore adapter.
+func Open(cfg OpenConfig) (*Opened, error) {
+	opts, dbPath, err := ResolveOptions(cfg)
+	if err != nil {
+		return nil, err
+	}
+	tdb, err := treedb.Open(opts)
+	if err != nil {
+		return nil, err
+	}
+	adapterName := cfg.AdapterName
+	if adapterName == "" {
+		adapterName = "TreeDB"
+	}
+	kv := treedbadapter.WrapNamed(tdb, adapterName)
+	if cfg.ReadWorkers > 0 {
+		kv.SetReadWorkers(cfg.ReadWorkers)
+	}
+	return &Opened{
+		Path:    dbPath,
+		Options: opts,
+		DB:      tdb,
+		KV:      kv,
+	}, nil
+}

--- a/TreeDB/integration/kvstoreadapter/open_test.go
+++ b/TreeDB/integration/kvstoreadapter/open_test.go
@@ -132,11 +132,34 @@ func TestResolveOptionsRejectsInvalidPathInputs(t *testing.T) {
 			Name:           `bad\name`,
 			DefaultProfile: treedb.ProfileWALOnFast,
 		},
+		{
+			ParentDir:      t.TempDir(),
+			Name:           "application",
+			DBFileSuffix:   "../bad",
+			DefaultProfile: treedb.ProfileWALOnFast,
+		},
 	}
 	for _, cfg := range cases {
 		if _, _, err := ResolveOptions(cfg); err == nil {
 			t.Fatalf("expected ResolveOptions error for cfg=%+v", cfg)
 		}
+	}
+}
+
+func TestResolveOptionsIsSideEffectFreeOnError(t *testing.T) {
+	t.Setenv(EnvKeepRecent, "not-a-number")
+
+	parentDir := t.TempDir()
+	dbPath := filepath.Join(parentDir, "application.db")
+	if _, _, err := ResolveOptions(OpenConfig{
+		ParentDir:      parentDir,
+		Name:           "application",
+		DefaultProfile: treedb.ProfileWALOnFast,
+	}); err == nil {
+		t.Fatal("expected invalid keep recent error")
+	}
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Fatalf("ResolveOptions created %q on error, stat err=%v", dbPath, err)
 	}
 }
 

--- a/TreeDB/integration/kvstoreadapter/open_test.go
+++ b/TreeDB/integration/kvstoreadapter/open_test.go
@@ -1,0 +1,120 @@
+package kvstoreadapter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+func TestParseProfileUsesStandardNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw      string
+		fallback treedb.Profile
+		want     treedb.Profile
+	}{
+		{raw: "", fallback: treedb.ProfileWALOnFast, want: treedb.ProfileWALOnFast},
+		{raw: "fast", fallback: treedb.ProfileDurable, want: treedb.ProfileFast},
+		{raw: "walonfast", fallback: treedb.ProfileDurable, want: treedb.ProfileWALOnFast},
+		{raw: "durable", fallback: treedb.ProfileFast, want: treedb.ProfileDurable},
+		{raw: "bench", fallback: treedb.ProfileFast, want: treedb.ProfileBench},
+		{raw: "unknown", fallback: treedb.ProfileFast, want: treedb.ProfileFast},
+	}
+	for _, tc := range cases {
+		if got := ParseProfile(tc.raw, tc.fallback); got != tc.want {
+			t.Fatalf("ParseProfile(%q, %q) = %q, want %q", tc.raw, tc.fallback, got, tc.want)
+		}
+	}
+}
+
+func TestResolveOptionsAppliesDefaultsAndEnvOverrides(t *testing.T) {
+	t.Setenv(EnvOpenProfile, "fast")
+	t.Setenv(EnvKeepRecent, "7")
+	t.Setenv(EnvMemtableMode, "skiplist")
+
+	opts, path, err := ResolveOptions(OpenConfig{
+		ParentDir:                   t.TempDir(),
+		Name:                        "application",
+		DefaultProfile:              treedb.ProfileDurable,
+		DefaultKeepRecent:           1,
+		DefaultAdaptiveMemtableBase: "hash_sorted",
+	})
+	if err != nil {
+		t.Fatalf("ResolveOptions error: %v", err)
+	}
+	if path != filepath.Join(opts.Dir) {
+		t.Fatalf("path %q != opts.Dir %q", path, opts.Dir)
+	}
+	if opts.Durability != treedb.DurabilityWALOffRelaxed {
+		t.Fatalf("Durability = %v, want fast WAL-off relaxed", opts.Durability)
+	}
+	if opts.KeepRecent != 7 {
+		t.Fatalf("KeepRecent = %d, want 7", opts.KeepRecent)
+	}
+	if opts.MemtableMode != "skiplist" {
+		t.Fatalf("MemtableMode = %q, want skiplist", opts.MemtableMode)
+	}
+}
+
+func TestResolveOptionsAppliesAdaptiveMemtableFallback(t *testing.T) {
+	t.Parallel()
+
+	opts, _, err := ResolveOptions(OpenConfig{
+		ParentDir:                   t.TempDir(),
+		Name:                        "application",
+		DefaultProfile:              treedb.ProfileWALOnFast,
+		DefaultKeepRecent:           1,
+		DefaultAdaptiveMemtableBase: "hash_sorted",
+	})
+	if err != nil {
+		t.Fatalf("ResolveOptions error: %v", err)
+	}
+	if opts.KeepRecent != 1 {
+		t.Fatalf("KeepRecent = %d, want 1", opts.KeepRecent)
+	}
+	if opts.MemtableMode != "adaptive:hash_sorted" {
+		t.Fatalf("MemtableMode = %q, want adaptive:hash_sorted", opts.MemtableMode)
+	}
+}
+
+func TestResolveOptionsRejectsInvalidKeepRecent(t *testing.T) {
+	t.Setenv(EnvKeepRecent, "not-a-number")
+	if _, _, err := ResolveOptions(OpenConfig{
+		ParentDir:      t.TempDir(),
+		Name:           "application",
+		DefaultProfile: treedb.ProfileWALOnFast,
+	}); err == nil {
+		t.Fatal("expected invalid keep recent error")
+	}
+}
+
+func TestOpenReturnsDBAndNamedAdapter(t *testing.T) {
+	t.Parallel()
+
+	parentDir := t.TempDir()
+	opened, err := Open(OpenConfig{
+		ParentDir:         parentDir,
+		Name:              "application",
+		AdapterName:       "TreeDB Test",
+		DefaultProfile:    treedb.ProfileFast,
+		DefaultKeepRecent: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = opened.DB.Close()
+	})
+	if opened.DB == nil || opened.KV == nil {
+		t.Fatal("expected DB and KV adapter")
+	}
+	if opened.KV.Name() != "TreeDB Test" {
+		t.Fatalf("adapter name = %q, want %q", opened.KV.Name(), "TreeDB Test")
+	}
+	if _, err := os.Stat(opened.Path); err != nil {
+		t.Fatalf("stat opened path: %v", err)
+	}
+}

--- a/TreeDB/integration/kvstoreadapter/open_test.go
+++ b/TreeDB/integration/kvstoreadapter/open_test.go
@@ -80,6 +80,23 @@ func TestResolveOptionsAppliesAdaptiveMemtableFallback(t *testing.T) {
 	}
 }
 
+func TestResolveOptionsNormalizesDefaultMemtableMode(t *testing.T) {
+	t.Parallel()
+
+	opts, _, err := ResolveOptions(OpenConfig{
+		ParentDir:           t.TempDir(),
+		Name:                "application",
+		DefaultProfile:      treedb.ProfileWALOnFast,
+		DefaultMemtableMode: "SkipList",
+	})
+	if err != nil {
+		t.Fatalf("ResolveOptions error: %v", err)
+	}
+	if opts.MemtableMode != "skiplist" {
+		t.Fatalf("MemtableMode = %q, want skiplist", opts.MemtableMode)
+	}
+}
+
 func TestResolveOptionsRejectsInvalidKeepRecent(t *testing.T) {
 	t.Setenv(EnvKeepRecent, "not-a-number")
 	if _, _, err := ResolveOptions(OpenConfig{
@@ -88,6 +105,38 @@ func TestResolveOptionsRejectsInvalidKeepRecent(t *testing.T) {
 		DefaultProfile: treedb.ProfileWALOnFast,
 	}); err == nil {
 		t.Fatal("expected invalid keep recent error")
+	}
+}
+
+func TestResolveOptionsRejectsInvalidPathInputs(t *testing.T) {
+	t.Parallel()
+
+	cases := []OpenConfig{
+		{
+			ParentDir:      "",
+			Name:           "application",
+			DefaultProfile: treedb.ProfileWALOnFast,
+		},
+		{
+			ParentDir:      t.TempDir(),
+			Name:           "",
+			DefaultProfile: treedb.ProfileWALOnFast,
+		},
+		{
+			ParentDir:      t.TempDir(),
+			Name:           "bad/name",
+			DefaultProfile: treedb.ProfileWALOnFast,
+		},
+		{
+			ParentDir:      t.TempDir(),
+			Name:           `bad\name`,
+			DefaultProfile: treedb.ProfileWALOnFast,
+		},
+	}
+	for _, cfg := range cases {
+		if _, _, err := ResolveOptions(cfg); err == nil {
+			t.Fatalf("expected ResolveOptions error for cfg=%+v", cfg)
+		}
 	}
 }
 

--- a/TreeDB/internal/commitlog/commitlog_test.go
+++ b/TreeDB/internal/commitlog/commitlog_test.go
@@ -162,6 +162,47 @@ func TestCommitLogWriteReadBatchCompressed(t *testing.T) {
 	}
 }
 
+func TestCommitLogWriter_LazyCompressionEncoder(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: true})
+	if err != nil {
+		t.Fatalf("NewWriterWithOptions: %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	if writer.enc != nil {
+		t.Fatalf("encoder should be lazy and remain nil until compression is needed")
+	}
+
+	small := []Record{{
+		Op:    OpSetInline,
+		Key:   []byte("k"),
+		Value: bytes.Repeat([]byte("x"), 1024),
+		Seq:   1,
+	}}
+	if err := writer.AppendBatch(small); err != nil {
+		t.Fatalf("AppendBatch(small): %v", err)
+	}
+	if writer.enc != nil {
+		t.Fatalf("small payload should not initialize compression encoder")
+	}
+
+	large := []Record{{
+		Op:    OpSetInline,
+		Key:   []byte("big"),
+		Value: bytes.Repeat([]byte("A"), defaultCompressMinLen),
+		Seq:   2,
+	}}
+	if err := writer.AppendBatch(large); err != nil {
+		t.Fatalf("AppendBatch(large): %v", err)
+	}
+	if writer.enc == nil {
+		t.Fatalf("large payload should initialize compression encoder")
+	}
+}
+
 func TestCommitLogCorruptCRC(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "commit.log")

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -72,19 +72,6 @@ func NewWriterWithOptions(path string, opts Options) (*Writer, error) {
 		_ = f.Close()
 		return nil, err
 	}
-	var enc *zstd.Encoder
-	if opts.Compress {
-		enc, err = zstd.NewWriter(nil,
-			zstd.WithEncoderLevel(zstd.SpeedFastest),
-			zstd.WithEncoderConcurrency(1),
-			zstd.WithEncoderCRC(false),
-			zstd.WithNoEntropyCompression(true),
-		)
-		if err != nil {
-			_ = f.Close()
-			return nil, err
-		}
-	}
 	return &Writer{
 		f:              f,
 		bw:             bufio.NewWriterSize(f, defaultBufferSize),
@@ -92,9 +79,29 @@ func NewWriterWithOptions(path string, opts Options) (*Writer, error) {
 		size:           info.Size(),
 		maxSegmentSize: normalizeMaxSegmentSize(opts.MaxSegmentSize),
 		compress:       opts.Compress,
-		enc:            enc,
 		syncFn:         func(file *os.File) error { return file.Sync() },
 	}, nil
+}
+
+func newEncoder() (*zstd.Encoder, error) {
+	return zstd.NewWriter(nil,
+		zstd.WithEncoderLevel(zstd.SpeedFastest),
+		zstd.WithEncoderConcurrency(1),
+		zstd.WithEncoderCRC(false),
+		zstd.WithNoEntropyCompression(true),
+	)
+}
+
+func (w *Writer) ensureEncoder() error {
+	if w == nil || !w.compress || w.enc != nil {
+		return nil
+	}
+	enc, err := newEncoder()
+	if err != nil {
+		return err
+	}
+	w.enc = enc
+	return nil
 }
 
 // RotateTo flushes and closes the current file, then opens (or creates) the
@@ -297,7 +304,10 @@ func (w *Writer) writeSegment(payload []byte) error {
 	wantCRC := crc.Checksum(payload)
 	rawLenPrefix := w.rawLenPrefix[:]
 
-	if w.compress && w.enc != nil && len(payload) >= defaultCompressMinLen {
+	if w.compress && len(payload) >= defaultCompressMinLen {
+		if err := w.ensureEncoder(); err != nil {
+			return err
+		}
 		encDst := w.encScratch[:0]
 		encoded := w.enc.EncodeAll(payload, encDst)
 		// Only keep compressed bytes when it is a strict size win even after

--- a/TreeDB/internal/commitlog/writer_bench_test.go
+++ b/TreeDB/internal/commitlog/writer_bench_test.go
@@ -1,0 +1,59 @@
+package commitlog
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkWriterAppendBatchCompressedSmall(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "commit.log")
+	w, err := NewWriterWithOptions(path, Options{Compress: true})
+	if err != nil {
+		b.Fatalf("NewWriterWithOptions: %v", err)
+	}
+	b.Cleanup(func() { _ = w.Close() })
+
+	records := []Record{{
+		Op:    OpSetInline,
+		Key:   []byte("k"),
+		Value: bytes.Repeat([]byte("x"), 1024),
+		Seq:   1,
+	}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		records[0].Seq = uint64(i + 1)
+		if err := w.AppendBatch(records); err != nil {
+			b.Fatalf("AppendBatch: %v", err)
+		}
+	}
+}
+
+func BenchmarkWriterAppendBatchCompressedLarge(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "commit.log")
+	w, err := NewWriterWithOptions(path, Options{Compress: true})
+	if err != nil {
+		b.Fatalf("NewWriterWithOptions: %v", err)
+	}
+	b.Cleanup(func() { _ = w.Close() })
+
+	records := []Record{{
+		Op:    OpSetInline,
+		Key:   []byte("k"),
+		Value: bytes.Repeat([]byte("A"), defaultCompressMinLen),
+		Seq:   1,
+	}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		records[0].Seq = uint64(i + 1)
+		if err := w.AppendBatch(records); err != nil {
+			b.Fatalf("AppendBatch: %v", err)
+		}
+	}
+}

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -93,6 +93,12 @@ func appendCompactLeafLogPayload(dst, payload []byte) ([]byte, error) {
 		return nil, err
 	}
 	if !decoded {
+		if len(payload) == 0 {
+			return dst, nil
+		}
+		if cap(dst) >= len(dst)+len(payload) && sliceAliasesBytes(dst[:cap(dst)], payload) {
+			return dst[:len(dst)+len(payload)], nil
+		}
 		return append(dst, payload...), nil
 	}
 

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -47,17 +47,28 @@ func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
 	return payload, true, nil
 }
 
-func decodeCompactLeafLogPayloadTo(payload, dst []byte) ([]byte, bool, bool, error) {
+func compactLeafLogPayloadBounds(payload []byte) (prefixLen, suffixLen int, decoded bool, err error) {
 	if !HasCompactLeafLogPayload(payload) {
-		return payload, false, false, nil
+		return 0, 0, false, nil
 	}
-	prefixLen := int(binary.LittleEndian.Uint16(payload[len(compactLeafPagePayloadMagic) : len(compactLeafPagePayloadMagic)+2]))
-	suffixLen := int(binary.LittleEndian.Uint16(payload[len(compactLeafPagePayloadMagic)+2 : compactLeafPagePayloadHeaderSize]))
+	prefixLen = int(binary.LittleEndian.Uint16(payload[len(compactLeafPagePayloadMagic) : len(compactLeafPagePayloadMagic)+2]))
+	suffixLen = int(binary.LittleEndian.Uint16(payload[len(compactLeafPagePayloadMagic)+2 : compactLeafPagePayloadHeaderSize]))
 	if prefixLen < node.NodeHeaderSize || prefixLen+suffixLen > page.PageSize {
-		return nil, false, true, ErrCorrupt
+		return 0, 0, true, ErrCorrupt
 	}
 	if compactLeafPagePayloadHeaderSize+prefixLen+suffixLen != len(payload) {
-		return nil, false, true, ErrCorrupt
+		return 0, 0, true, ErrCorrupt
+	}
+	return prefixLen, suffixLen, true, nil
+}
+
+func decodeCompactLeafLogPayloadTo(payload, dst []byte) ([]byte, bool, bool, error) {
+	prefixLen, suffixLen, decoded, err := compactLeafLogPayloadBounds(payload)
+	if err != nil || !decoded {
+		if err != nil {
+			return nil, false, decoded, err
+		}
+		return payload, false, false, nil
 	}
 	if cap(dst) >= page.PageSize && sliceAliasesBytes(dst[:cap(dst)], payload) {
 		payload = append([]byte(nil), payload...)
@@ -74,6 +85,21 @@ func decodeCompactLeafLogPayloadTo(payload, dst []byte) ([]byte, bool, bool, err
 	copy(out[:prefixLen], payload[compactLeafPagePayloadHeaderSize:compactLeafPagePayloadHeaderSize+prefixLen])
 	copy(out[page.PageSize-suffixLen:], payload[compactLeafPagePayloadHeaderSize+prefixLen:])
 	return out, usedDst, true, nil
+}
+
+func appendCompactLeafLogPayload(dst, payload []byte) ([]byte, error) {
+	prefixLen, suffixLen, decoded, err := compactLeafLogPayloadBounds(payload)
+	if err != nil {
+		return nil, err
+	}
+	if !decoded {
+		return append(dst, payload...), nil
+	}
+
+	var expanded [page.PageSize]byte
+	copy(expanded[:prefixLen], payload[compactLeafPagePayloadHeaderSize:compactLeafPagePayloadHeaderSize+prefixLen])
+	copy(expanded[page.PageSize-suffixLen:], payload[compactLeafPagePayloadHeaderSize+prefixLen:])
+	return append(dst, expanded[:]...), nil
 }
 
 func allowsCompactLeafLogPayload(fileID uint32, path string) bool {
@@ -107,18 +133,5 @@ func appendMaybeDecodeLeafLogPayload(fileID uint32, path string, dst, payload []
 		}
 		return append(dst, payload...), nil
 	}
-	out, _, decoded, err := decodeCompactLeafLogPayloadTo(payload, nil)
-	if err != nil {
-		return nil, err
-	}
-	if decoded {
-		return append(dst, out...), nil
-	}
-	if len(payload) == 0 {
-		return dst, nil
-	}
-	if cap(dst) >= len(dst)+len(payload) && sliceAliasesBytes(dst[:cap(dst)], payload) {
-		return dst[:len(dst)+len(payload)], nil
-	}
-	return append(dst, payload...), nil
+	return appendCompactLeafLogPayload(dst, payload)
 }

--- a/TreeDB/internal/valuelog/leaf_page_payload_bench_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_bench_test.go
@@ -1,0 +1,114 @@
+package valuelog
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+var leafPagePayloadBenchSink []byte
+
+func buildSparseLeafPageForPayloadBench(b *testing.B) []byte {
+	b.Helper()
+	buf := make([]byte, page.PageSize)
+	builder := node.NewBuilderWithOptions(buf, page.PageTypeLeaf, node.BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+		PackedValuePtr:        true,
+	})
+	builder.SetPageID(17)
+	for i := 0; i < 4; i++ {
+		if err := builder.AddLeafEntry(
+			[]byte(fmt.Sprintf("celestia/outer/leaf/key/%02d", i)),
+			[]byte("value"),
+			node.FlagInline,
+			page.ValuePtr{},
+		); err != nil {
+			b.Fatalf("AddLeafEntry(%d): %v", i, err)
+		}
+	}
+	builder.FinishNoNode()
+	return buf
+}
+
+func compactLeafPayloadBenchmarkFixture(b *testing.B) (uint32, string, []byte) {
+	b.Helper()
+	leaf := buildSparseLeafPageForPayloadBench(b)
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		b.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		b.Fatal("expected sparse leaf fixture to compact")
+	}
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		b.Fatalf("EncodeFileID: %v", err)
+	}
+	path := filepath.Join("bench", compactLeafPagePayloadDirName, "value-l255-000001.log")
+	return fileID, path, payload
+}
+
+func BenchmarkAppendMaybeDecodeLeafLogPayload(b *testing.B) {
+	fileID, path, payload := compactLeafPayloadBenchmarkFixture(b)
+
+	b.Run("fresh_dst", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			out, err := appendMaybeDecodeLeafLogPayload(fileID, path, nil, payload)
+			if err != nil {
+				b.Fatalf("appendMaybeDecodeLeafLogPayload: %v", err)
+			}
+			leafPagePayloadBenchSink = out
+		}
+	})
+
+	b.Run("reused_dst", func(b *testing.B) {
+		dst := make([]byte, 0, page.PageSize)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			dst = dst[:0]
+			out, err := appendMaybeDecodeLeafLogPayload(fileID, path, dst, payload)
+			if err != nil {
+				b.Fatalf("appendMaybeDecodeLeafLogPayload: %v", err)
+			}
+			leafPagePayloadBenchSink = out
+		}
+	})
+}
+
+func BenchmarkDecodeCompactLeafLogPayloadTo(b *testing.B) {
+	_, _, payload := compactLeafPayloadBenchmarkFixture(b)
+
+	b.Run("fresh_dst", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			out, _, decoded, err := decodeCompactLeafLogPayloadTo(payload, nil)
+			if err != nil {
+				b.Fatalf("decodeCompactLeafLogPayloadTo: %v", err)
+			}
+			if !decoded {
+				b.Fatal("expected compact payload to decode")
+			}
+			leafPagePayloadBenchSink = out
+		}
+	})
+
+	b.Run("reused_dst", func(b *testing.B) {
+		dst := make([]byte, 0, page.PageSize)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			out, _, decoded, err := decodeCompactLeafLogPayloadTo(payload, dst[:0])
+			if err != nil {
+				b.Fatalf("decodeCompactLeafLogPayloadTo: %v", err)
+			}
+			if !decoded {
+				b.Fatal("expected compact payload to decode")
+			}
+			leafPagePayloadBenchSink = out
+		}
+	})
+}

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -722,16 +722,17 @@ func (f *File) readGroupedCompressedFromFileTo(ptr page.ValuePtr, dst []byte) ([
 		return nil, false, ErrCorrupt, true
 	}
 
-	payload := make([]byte, int(valueLen))
-	if _, err := f.File.ReadAt(payload, start+HeaderSize); err != nil {
+	off := FrameHeaderSize + ridBytes
+	const maxPrefixLen = FrameHeaderSize + (MaxFrameK * 8) + ((MaxFrameK + 1) * 4)
+	var prefix [maxPrefixLen]byte
+	if _, err := f.File.ReadAt(prefix[:prefixLen], frameOff); err != nil {
 		return nil, false, err, true
 	}
 
-	off := FrameHeaderSize + ridBytes
 	var offsets [MaxFrameK + 1]uint32
 	prev := uint32(0)
 	for i := 0; i < k+1; i++ {
-		cur := binary.LittleEndian.Uint32(payload[off : off+4])
+		cur := binary.LittleEndian.Uint32(prefix[off : off+4])
 		if cur < prev {
 			return nil, false, ErrCorrupt, true
 		}
@@ -757,9 +758,21 @@ func (f *File) readGroupedCompressedFromFileTo(ptr page.ValuePtr, dst []byte) ([
 		DictID:   binary.LittleEndian.Uint64(frameHeader[4:12]),
 	}
 
+	framePayloadLen := int(valueLen) - prefixLen
+	if framePayloadLen < 0 {
+		return nil, false, ErrCorrupt, true
+	}
+	payloadScratch := getDecodeScratch(framePayloadLen)
+	framePayload := payloadScratch[:framePayloadLen]
+	if _, err := f.File.ReadAt(framePayload, frameOff+int64(prefixLen)); err != nil {
+		putDecodeScratch(payloadScratch)
+		return nil, false, err, true
+	}
+
 	raw := f.takeDecodeScratch(int(rawLen))
 	pooledRaw := true
-	raw, err := decodeFramePayloadTo(frame, payload[prefixLen:], f.dictLookup, rawLen, raw)
+	raw, err := decodeFramePayloadTo(frame, framePayload, f.dictLookup, rawLen, raw)
+	putDecodeScratch(payloadScratch)
 	if err != nil {
 		if pooledRaw {
 			f.releaseDecodeScratch(raw)

--- a/TreeDB/internal/valuelog/read_grouped_compressed_file_test.go
+++ b/TreeDB/internal/valuelog/read_grouped_compressed_file_test.go
@@ -1,0 +1,156 @@
+package valuelog
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+	templ "github.com/snissn/gomap/TreeDB/template"
+)
+
+func openGroupedCompressedFileReadFallbackFixture(tb testing.TB) (*File, []page.ValuePtr, [][]byte) {
+	tb.Helper()
+
+	dir := tb.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		tb.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		tb.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+
+	records := make([]Record, 8)
+	want := make([][]byte, len(records))
+	for i := range records {
+		v := make([]byte, 32<<10)
+		copy(v, []byte(fmt.Sprintf("record-%02d:", i)))
+		for j := 32; j < len(v); j++ {
+			v[j] = 'x'
+		}
+		records[i] = Record{RID: uint64(i + 1), Value: v}
+		want[i] = append([]byte(nil), v...)
+	}
+
+	ptrScratch := make([]page.ValuePtr, len(records))
+	ptrs, stats, err := writer.AppendFrameWithStatsInto(0, nil, records, ptrScratch)
+	if err != nil {
+		_ = writer.Close()
+		tb.Fatalf("append frame: %v", err)
+	}
+	if !stats.Kept {
+		_ = writer.Close()
+		tb.Fatalf("expected block-compressed frame to be kept")
+	}
+	if err := writer.Close(); err != nil {
+		tb.Fatalf("close writer: %v", err)
+	}
+
+	f, err := openFile(path, fileID, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		tb.Fatalf("open file: %v", err)
+	}
+	tb.Cleanup(func() { _ = f.Close() })
+	f.setGroupedFrameCacheEntries(0)
+
+	return f, ptrs, want
+}
+
+func TestFileReadGroupedCompressedFromFileTo_UsesDstWithCacheDisabled(t *testing.T) {
+	f, ptrs, want := openGroupedCompressedFileReadFallbackFixture(t)
+
+	dst := make([]byte, 0, len(want[0]))
+	dstBacking := dst[:1]
+	got, usedDst, err, ok := f.readGroupedCompressedFromFileTo(ptrs[0], dst)
+	if err != nil {
+		t.Fatalf("readGroupedCompressedFromFileTo: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected grouped compressed fast path")
+	}
+	if !usedDst {
+		t.Fatalf("expected usedDst=true")
+	}
+	if len(got) != len(want[0]) {
+		t.Fatalf("got len=%d want=%d", len(got), len(want[0]))
+	}
+	if &got[0] != &dstBacking[0] {
+		t.Fatalf("expected returned slice to be backed by dst")
+	}
+	if !bytes.Equal(got, want[0]) {
+		t.Fatalf("value mismatch")
+	}
+}
+
+func TestFileReadGroupedCompressedFromFileTo_ReadNilDstWithCacheDisabled(t *testing.T) {
+	f, ptrs, want := openGroupedCompressedFileReadFallbackFixture(t)
+
+	got, usedDst, err, ok := f.readGroupedCompressedFromFileTo(ptrs[0], nil)
+	if err != nil {
+		t.Fatalf("readGroupedCompressedFromFileTo: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected grouped compressed fast path")
+	}
+	if usedDst {
+		t.Fatalf("expected usedDst=false")
+	}
+	if len(got) != len(want[0]) {
+		t.Fatalf("got len=%d want=%d", len(got), len(want[0]))
+	}
+	if cap(got) != len(got) {
+		t.Fatalf("expected tight copy for nil dst (cap=%d len=%d)", cap(got), len(got))
+	}
+	if !bytes.Equal(got, want[0]) {
+		t.Fatalf("value mismatch")
+	}
+}
+
+func BenchmarkFileReadGroupedCompressedFromFileTo(b *testing.B) {
+	f, ptrs, want := openGroupedCompressedFileReadFallbackFixture(b)
+
+	b.Run("nil_dst", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			got, usedDst, err, ok := f.readGroupedCompressedFromFileTo(ptrs[i%len(ptrs)], nil)
+			if err != nil {
+				b.Fatalf("readGroupedCompressedFromFileTo: %v", err)
+			}
+			if !ok {
+				b.Fatal("expected grouped compressed fast path")
+			}
+			if usedDst {
+				b.Fatal("expected usedDst=false")
+			}
+			if len(got) != len(want[0]) {
+				b.Fatalf("got len=%d want=%d", len(got), len(want[0]))
+			}
+		}
+	})
+
+	b.Run("reused_dst", func(b *testing.B) {
+		dst := make([]byte, 0, len(want[0]))
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			got, usedDst, err, ok := f.readGroupedCompressedFromFileTo(ptrs[i%len(ptrs)], dst[:0])
+			if err != nil {
+				b.Fatalf("readGroupedCompressedFromFileTo: %v", err)
+			}
+			if !ok {
+				b.Fatal("expected grouped compressed fast path")
+			}
+			if !usedDst {
+				b.Fatal("expected usedDst=true")
+			}
+			if len(got) != len(want[0]) {
+				b.Fatalf("got len=%d want=%d", len(got), len(want[0]))
+			}
+		}
+	})
+}

--- a/TreeDB/profiles.go
+++ b/TreeDB/profiles.go
@@ -62,6 +62,10 @@ const (
 	//   - you are exploring performance limits, and crashes/corruption detection
 	//     are acceptable trade-offs.
 	//
+	// It also pins the current run_celestia-style value-log compression policy:
+	// auto compression, balanced auto policy, snappy block fallback, and medium
+	// autotune.
+	//
 	// Background maintenance is left enabled by default; it is generally helpful
 	// for keeping the index compact and read-friendly.
 	ProfileFast Profile = "fast"
@@ -70,6 +74,7 @@ const (
 	// write-heavy benchmarks and ingest workloads.
 	//
 	// It keeps WAL enabled but disables fsync and value-log read checksums.
+	// It also pins the same value-log compression policy as ProfileFast.
 	ProfileWALOnFast Profile = "wal_on_fast"
 
 	// ProfileBench is a "fast + deterministic" profile intended specifically for
@@ -141,10 +146,20 @@ func applyIndexOptimizationsProfile(opts *Options) {
 	}
 }
 
+func applyRunCelestiaVLogCompressionProfile(opts *Options) {
+	if opts.ValueLog.Compression == 0 {
+		opts.ValueLog.Compression = ValueLogCompressionAuto
+	}
+	if opts.ValueLog.CompressionAutotune.Mode == AutotuneUnset {
+		opts.ValueLog.CompressionAutotune.Mode = AutotuneMedium
+	}
+}
+
 func applyFastProfile(opts *Options) {
 	opts.Durability = DurabilityWALOffRelaxed
 	opts.ValueLog.ReadIntegrity = IntegritySkipChecksums
 	opts.IndexOuterLeavesInValueLog = true
+	applyRunCelestiaVLogCompressionProfile(opts)
 	if opts.ValueLog.DictIncompressibleHoldBytes == 0 {
 		opts.ValueLog.DictIncompressibleHoldBytes = 64 << 20
 	}
@@ -164,6 +179,7 @@ func applyWALOnFastProfile(opts *Options) {
 	opts.Durability = DurabilityWALOnRelaxed
 	opts.ValueLog.ReadIntegrity = IntegritySkipChecksums
 	opts.IndexOuterLeavesInValueLog = true
+	applyRunCelestiaVLogCompressionProfile(opts)
 	if opts.ValueLog.DictIncompressibleHoldBytes == 0 {
 		opts.ValueLog.DictIncompressibleHoldBytes = 64 << 20
 	}

--- a/TreeDB/profiles.go
+++ b/TreeDB/profiles.go
@@ -150,6 +150,12 @@ func applyRunCelestiaVLogCompressionProfile(opts *Options) {
 	if opts.ValueLog.Compression == 0 {
 		opts.ValueLog.Compression = ValueLogCompressionAuto
 	}
+	if opts.ValueLog.BlockCodec == 0 {
+		opts.ValueLog.BlockCodec = ValueLogBlockSnappy
+	}
+	if opts.ValueLog.AutoPolicy == 0 {
+		opts.ValueLog.AutoPolicy = ValueLogAutoBalanced
+	}
 	if opts.ValueLog.CompressionAutotune.Mode == AutotuneUnset {
 		opts.ValueLog.CompressionAutotune.Mode = AutotuneMedium
 	}

--- a/TreeDB/profiles_test.go
+++ b/TreeDB/profiles_test.go
@@ -28,6 +28,24 @@ func TestApplyProfile_FastSetsPolicyBools(t *testing.T) {
 	if !opts.PreferAppendAlloc {
 		t.Fatalf("expected PreferAppendAlloc=true for fast profile")
 	}
+	if opts.ValueLog.Compression != ValueLogCompressionAuto {
+		t.Fatalf("expected ValueLog.Compression=ValueLogCompressionAuto for fast profile, got %v", opts.ValueLog.Compression)
+	}
+	if opts.ValueLog.BlockCodec != ValueLogBlockSnappy {
+		t.Fatalf("expected ValueLog.BlockCodec=ValueLogBlockSnappy for fast profile, got %v", opts.ValueLog.BlockCodec)
+	}
+	if opts.ValueLog.AutoPolicy != ValueLogAutoBalanced {
+		t.Fatalf("expected ValueLog.AutoPolicy=ValueLogAutoBalanced for fast profile, got %v", opts.ValueLog.AutoPolicy)
+	}
+	if opts.ValueLog.CompressionAutotune.Mode != AutotuneMedium {
+		t.Fatalf("expected ValueLog.CompressionAutotune.Mode=AutotuneMedium for fast profile, got %v", opts.ValueLog.CompressionAutotune.Mode)
+	}
+	if opts.ValueLog.DictIncompressibleHoldBytes != 64<<20 {
+		t.Fatalf("expected DictIncompressibleHoldBytes=64MiB for fast profile, got %d", opts.ValueLog.DictIncompressibleHoldBytes)
+	}
+	if opts.ValueLog.DictProbeIntervalBytes != 32<<20 {
+		t.Fatalf("expected DictProbeIntervalBytes=32MiB for fast profile, got %d", opts.ValueLog.DictProbeIntervalBytes)
+	}
 	if opts.ValueLog.ForcePointers {
 		t.Fatalf("expected ValueLog.ForcePointers=false for fast profile")
 	}
@@ -60,6 +78,24 @@ func TestApplyProfile_WALOnFastKeepsWALOn(t *testing.T) {
 	}
 	if !opts.PreferAppendAlloc {
 		t.Fatalf("expected PreferAppendAlloc=true for wal_on_fast profile")
+	}
+	if opts.ValueLog.Compression != ValueLogCompressionAuto {
+		t.Fatalf("expected ValueLog.Compression=ValueLogCompressionAuto for wal_on_fast profile, got %v", opts.ValueLog.Compression)
+	}
+	if opts.ValueLog.BlockCodec != ValueLogBlockSnappy {
+		t.Fatalf("expected ValueLog.BlockCodec=ValueLogBlockSnappy for wal_on_fast profile, got %v", opts.ValueLog.BlockCodec)
+	}
+	if opts.ValueLog.AutoPolicy != ValueLogAutoBalanced {
+		t.Fatalf("expected ValueLog.AutoPolicy=ValueLogAutoBalanced for wal_on_fast profile, got %v", opts.ValueLog.AutoPolicy)
+	}
+	if opts.ValueLog.CompressionAutotune.Mode != AutotuneMedium {
+		t.Fatalf("expected ValueLog.CompressionAutotune.Mode=AutotuneMedium for wal_on_fast profile, got %v", opts.ValueLog.CompressionAutotune.Mode)
+	}
+	if opts.ValueLog.DictIncompressibleHoldBytes != 64<<20 {
+		t.Fatalf("expected DictIncompressibleHoldBytes=64MiB for wal_on_fast profile, got %d", opts.ValueLog.DictIncompressibleHoldBytes)
+	}
+	if opts.ValueLog.DictProbeIntervalBytes != 32<<20 {
+		t.Fatalf("expected DictProbeIntervalBytes=32MiB for wal_on_fast profile, got %d", opts.ValueLog.DictProbeIntervalBytes)
 	}
 	if opts.ValueLog.ForcePointers {
 		t.Fatalf("expected ValueLog.ForcePointers=false for wal_on_fast profile")
@@ -169,6 +205,29 @@ func TestApplyProfile_PreservesNegativeDictHoldProbeValues(t *testing.T) {
 			}
 			if opts.ValueLog.DictProbeIntervalBytes != -1 {
 				t.Fatalf("DictProbeIntervalBytes overridden: got %d", opts.ValueLog.DictProbeIntervalBytes)
+			}
+		})
+	}
+}
+
+func TestApplyProfile_PreservesExplicitVLogCompressionOverrides(t *testing.T) {
+	for _, profile := range []Profile{ProfileFast, ProfileWALOnFast} {
+		t.Run(string(profile), func(t *testing.T) {
+			opts := Options{
+				ValueLog: ValueLogOptions{
+					Compression: ValueLogCompressionBlock,
+					CompressionAutotune: AutotuneOptions{
+						Mode: AutotuneAggressive,
+					},
+				},
+			}
+			ApplyProfile(&opts, profile)
+
+			if opts.ValueLog.Compression != ValueLogCompressionBlock {
+				t.Fatalf("ValueLog.Compression overridden: got %v", opts.ValueLog.Compression)
+			}
+			if opts.ValueLog.CompressionAutotune.Mode != AutotuneAggressive {
+				t.Fatalf("ValueLog.CompressionAutotune overridden: got %v", opts.ValueLog.CompressionAutotune.Mode)
 			}
 		})
 	}

--- a/TreeDB/profiles_test.go
+++ b/TreeDB/profiles_test.go
@@ -216,6 +216,8 @@ func TestApplyProfile_PreservesExplicitVLogCompressionOverrides(t *testing.T) {
 			opts := Options{
 				ValueLog: ValueLogOptions{
 					Compression: ValueLogCompressionBlock,
+					BlockCodec:  ValueLogBlockLZ4,
+					AutoPolicy:  ValueLogAutoSize,
 					CompressionAutotune: AutotuneOptions{
 						Mode: AutotuneAggressive,
 					},
@@ -225,6 +227,12 @@ func TestApplyProfile_PreservesExplicitVLogCompressionOverrides(t *testing.T) {
 
 			if opts.ValueLog.Compression != ValueLogCompressionBlock {
 				t.Fatalf("ValueLog.Compression overridden: got %v", opts.ValueLog.Compression)
+			}
+			if opts.ValueLog.BlockCodec != ValueLogBlockLZ4 {
+				t.Fatalf("ValueLog.BlockCodec overridden: got %v", opts.ValueLog.BlockCodec)
+			}
+			if opts.ValueLog.AutoPolicy != ValueLogAutoSize {
+				t.Fatalf("ValueLog.AutoPolicy overridden: got %v", opts.ValueLog.AutoPolicy)
 			}
 			if opts.ValueLog.CompressionAutotune.Mode != AutotuneAggressive {
 				t.Fatalf("ValueLog.CompressionAutotune overridden: got %v", opts.ValueLog.CompressionAutotune.Mode)

--- a/TreeDB/snapshot_read_bench_test.go
+++ b/TreeDB/snapshot_read_bench_test.go
@@ -1,0 +1,157 @@
+package treedb
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+)
+
+var snapshotReadBenchSink []byte
+
+func openSnapshotValueLogBenchDB(b *testing.B) (*DB, [][]byte) {
+	b.Helper()
+
+	opts := Options{
+		Dir:                        b.TempDir(),
+		KeepRecent:                 10_000,
+		IndexOuterLeavesInValueLog: true,
+		LeafPrefixCompression:      true,
+		IndexColumnarLeaves:        true,
+		IndexPackedValuePtr:        true,
+	}
+	opts.ValueLog.PointerThreshold = 1
+
+	db, err := Open(opts)
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+
+	const (
+		keyCount  = 32_768
+		batchSize = 512
+		valueSize = 256
+	)
+	keys := make([][]byte, keyCount)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("celestia/snapshot/get/key/%08d", i))
+	}
+	value := make([]byte, valueSize)
+	for i := range value {
+		value[i] = byte(i)
+	}
+
+	for base := 0; base < keyCount; base += batchSize {
+		batch := db.NewBatch()
+		limit := base + batchSize
+		if limit > keyCount {
+			limit = keyCount
+		}
+		for i := base; i < limit; i++ {
+			var seq [8]byte
+			binary.BigEndian.PutUint64(seq[:], uint64(i))
+			copy(value[len(value)-len(seq):], seq[:])
+			if err := batch.Set(keys[i], value); err != nil {
+				_ = batch.Close()
+				_ = db.Close()
+				b.Fatalf("batch.Set(%d): %v", i, err)
+			}
+		}
+		if err := batch.WriteSync(); err != nil {
+			_ = batch.Close()
+			_ = db.Close()
+			b.Fatalf("batch.WriteSync(%d): %v", base, err)
+		}
+		if err := batch.Close(); err != nil {
+			_ = db.Close()
+			b.Fatalf("batch.Close(%d): %v", base, err)
+		}
+	}
+
+	return db, keys
+}
+
+func BenchmarkSnapshotValueLogGet(b *testing.B) {
+	db, keys := openSnapshotValueLogBenchDB(b)
+	defer func() { _ = db.Close() }()
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		b.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+
+	b.Run("Get", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			out, err := snap.Get(keys[i%len(keys)])
+			if err != nil {
+				b.Fatalf("Snapshot.Get: %v", err)
+			}
+			snapshotReadBenchSink = out
+		}
+	})
+
+	b.Run("GetAppend", func(b *testing.B) {
+		dst := make([]byte, 0, 512)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			dst = dst[:0]
+			out, err := snap.GetAppend(keys[i%len(keys)], dst)
+			if err != nil {
+				b.Fatalf("Snapshot.GetAppend: %v", err)
+			}
+			snapshotReadBenchSink = out
+		}
+	})
+
+	b.Run("GetUnsafe", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			out, err := snap.GetUnsafe(keys[i%len(keys)])
+			if err != nil {
+				b.Fatalf("Snapshot.GetUnsafe: %v", err)
+			}
+			snapshotReadBenchSink = out
+		}
+	})
+}
+
+func BenchmarkDBValueLogGet(b *testing.B) {
+	db, keys := openSnapshotValueLogBenchDB(b)
+	defer func() { _ = db.Close() }()
+
+	b.Run("Get", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			out, err := db.Get(keys[i%len(keys)])
+			if err != nil {
+				b.Fatalf("DB.Get: %v", err)
+			}
+			snapshotReadBenchSink = out
+		}
+	})
+
+	b.Run("GetAppend", func(b *testing.B) {
+		dst := make([]byte, 0, 512)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			dst = dst[:0]
+			out, err := db.GetAppend(keys[i%len(keys)], dst)
+			if err != nil {
+				b.Fatalf("DB.GetAppend: %v", err)
+			}
+			snapshotReadBenchSink = out
+		}
+	})
+
+	b.Run("GetUnsafe", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			out, err := db.GetUnsafe(keys[i%len(keys)])
+			if err != nil {
+				b.Fatalf("DB.GetUnsafe: %v", err)
+			}
+			snapshotReadBenchSink = out
+		}
+	})
+}

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -96,7 +96,7 @@ GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -p 1 . \
 - `-treedb-vlog-auto-policy` TreeDB: value-log auto policy (`balanced|throughput|size`)
 - `-treedb-vlog-generation-policy` TreeDB: generation policy (`default|off|hot_warm_cold`)
 
-### TreeDB Advanced / Expert Knobs
+### TreeDB Advanced Tuning
 
 These are mainly for experiments and should usually be left at engine defaults:
 

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -61,8 +61,8 @@ GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -p 1 . \
 - `-profile` benchmark profile preset (see `cmd/unified_bench/profiles.go`):
   - `balanced` (default)
   - `durable` (strict durability)
-  - `fast` (max throughput; TreeDB WAL off + throughput-biased vlog auto policy; unsafe)
-  - `wal_on_fast` (TreeDB WAL on + relaxed durability + throughput-biased vlog auto policy; unsafe)
+  - `fast` (max throughput; TreeDB mirrors `treedb.ProfileFast`, including Celestia-aligned auto/snappy/balanced value-log compression; unsafe)
+  - `wal_on_fast` (TreeDB mirrors `treedb.ProfileWALOnFast`, including the same compression defaults with WAL on; unsafe)
 - `-dbs` (`all` or CSV): `hashdb,btree,treedb,badger,leveldb`
 - `-test` (`all` or CSV): see list above
 - `-keys` number of keys (default 100000)
@@ -79,8 +79,37 @@ GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -p 1 . \
 - `-range-span` number of keys per range (default 100)
 - `-leveldb-block-compression` LevelDB: block compression mode (`default|on|off|both`)
 - `-leveldb-block-size` LevelDB: table block size in bytes (default 4096)
+
+### TreeDB Main Knobs
+
 - `-treedb-chunk-size` TreeDB: pager chunk size in bytes (default `256KiB`)
-- `-treedb-flush-threshold` TreeDB (cached) flush threshold in bytes (default 64MB)
+- `-treedb-flush-threshold` TreeDB (cached): flush threshold in bytes (default 64MB)
+- `-treedb-maintenance-mode` TreeDB maintenance preset (`normal|bench`)
+- `-treedb-memtable-mode` TreeDB memtable implementation override
+- `-treedb-index-optimizations` TreeDB profile-style index optimization bundle
+- `-treedb-index-outer-leaves-in-vlog` TreeDB: store outer leaves in `leaf_vlog`
+- `-treedb-prefer-append-alloc` TreeDB: prefer append allocation over freelist reuse
+- `-treedb-force-value-pointers` TreeDB: force all values into the value log
+- `-treedb-value-log-threshold` TreeDB: inline-vs-pointer threshold
+- `-treedb-vlog-compression` TreeDB: value-log compression mode (`default|off|block|dict|auto`)
+- `-treedb-vlog-block-codec` TreeDB: block codec (`snappy|lz4`)
+- `-treedb-vlog-auto-policy` TreeDB: value-log auto policy (`balanced|throughput|size`)
+- `-treedb-vlog-generation-policy` TreeDB: generation policy (`default|off|hot_warm_cold`)
+
+### TreeDB Advanced / Expert Knobs
+
+These are mainly for experiments and should usually be left at engine defaults:
+
+- `-treedb-vlog-compression-autotune`
+- `-treedb-vlog-dict-*`
+- `-treedb-vlog-rewrite-*`
+- `-treedb-flush-build-*`
+- `-treedb-max-queued-memtables`, `-treedb-slowdown-backlog-seconds`, `-treedb-stop-backlog-seconds`
+
+Use `./bin/unified-bench -h` for the full grouped TreeDB advanced flag list.
+
+### Additional Common Flags
+
 - `-treedb-max-queued-memtables` TreeDB (cached) max queued immutable memtables before applying backpressure flush (`0`=default, `<0`=disable)
 - `-treedb-slowdown-backlog-seconds` TreeDB (cached) start backpressure when queued backlog exceeds this many seconds of flush work
 - `-treedb-stop-backlog-seconds` TreeDB (cached) block writers when queued backlog exceeds this many seconds of flush work
@@ -94,7 +123,6 @@ GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -p 1 . \
 - `-treedb-bg-vacuum-span-ppm` TreeDB: background index vacuum span ratio threshold (ppm), `0`=default
 - `-treedb-allow-unsafe` TreeDB: allow unsafe durability/integrity options (required for unsafe toggles)
 - `-treedb-vlog-dict` TreeDB: value-log dict compression mode (`default|on|off|both`)
-- `-treedb-vlog-auto-policy` TreeDB: value-log auto policy (`balanced|throughput|size`)
 - `-treedb-vlog-rewrite-min-segment-age-ms` TreeDB: minimum source segment age for online generational rewrite (`0`=default)
 - `-treedb-vlog-dict-frame-encode-level` TreeDB: dict frame zstd encoder level (`engine|fastest|default|better|best|all|<int>`)
 - `-treedb-vlog-dict-frame-entropy` TreeDB: dict frame entropy mode (`engine|on|off|both`)

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -89,7 +89,7 @@ var (
 	treedbVlogDictMinSavingsRatio         = flag.Float64("treedb-vlog-dict-min-savings-ratio", 0, "TreeDB: value-log dict min payload savings ratio (0=default)")
 	treedbVlogDictK                       = flag.Int("treedb-vlog-dict-k", 0, "TreeDB: value-log dict frame grouping K (records/frame, 0=default)")
 	treedbVlogDictClassMode               = flag.String("treedb-vlog-dict-class-mode", "single", "TreeDB: value-log dict class mode (single|split_outer_leaf)")
-	treedbVlogCompressionAutotune         = flag.String("treedb-vlog-compression-autotune", "off", "TreeDB: value-log compression autotune mode (off|medium|aggressive|default)")
+	treedbVlogCompressionAutotune         = flag.String("treedb-vlog-compression-autotune", "default", "TreeDB: value-log compression autotune mode (default|off|medium|aggressive)")
 	treedbVlogDictFrameEncodeLevel        = flag.String("treedb-vlog-dict-frame-encode-level", "engine", "TreeDB: zstd encoder level for dict-compressed value-log frames (engine|fastest|default|better|best|all|<int>)")
 	treedbVlogDictFrameEntropyMode        = flag.String("treedb-vlog-dict-frame-entropy", "engine", "TreeDB: dict-frame entropy mode (engine|on|off|both). Controls WithNoEntropyCompression.")
 	treedbVlogDictMode                    = flag.String("treedb-vlog-dict", "default", "TreeDB: value-log dict compression mode for unified_bench (default|on|off|both). Overrides dict/compression settings for TreeDB benchmarks.")
@@ -350,6 +350,11 @@ func (r treeDBOptionsReport) formatText(indent string) string {
 	lines = append(lines, fmt.Sprintf("vlog.compression=%s", formatTreeDBVlogCompression(r.opts.ValueLog.Compression)))
 	lines = append(lines, fmt.Sprintf("vlog.block_codec=%s", formatTreeDBVlogBlockCodec(r.opts.ValueLog.BlockCodec)))
 	lines = append(lines, fmt.Sprintf("vlog.auto_policy=%s", formatTreeDBVlogAutoPolicy(r.opts.ValueLog.AutoPolicy)))
+	if mode := r.opts.ValueLog.CompressionAutotune.Mode; mode == treedb.AutotuneUnset {
+		lines = append(lines, "vlog.compression_autotune=default (effective=medium)")
+	} else {
+		lines = append(lines, fmt.Sprintf("vlog.compression_autotune=%s", formatTreeDBVlogCompressionAutotune(mode)))
+	}
 	lines = append(lines, fmt.Sprintf("vlog.dict_class_mode=%s", formatTreeDBVlogDictClassMode(r.opts.ValueLog.DictClassMode)))
 	lines = append(lines, fmt.Sprintf("vlog.generation_policy=%s", formatTreeDBVlogGenerationPolicy(r.opts.ValueLog.Generational.Policy)))
 	lines = append(lines, fmt.Sprintf("vlog.generation_hot_segment_bytes=%d", r.opts.ValueLog.Generational.HotSegmentTargetBytes))
@@ -449,6 +454,13 @@ func formatTreeDBVlogCompression(mode treedb.ValueLogCompressionMode) string {
 	}
 }
 
+func formatTreeDBVlogCompressionFlagValue(mode treedb.ValueLogCompressionMode) string {
+	if mode == 0 {
+		return "default"
+	}
+	return formatTreeDBVlogCompression(mode)
+}
+
 func formatTreeDBVlogBlockCodec(codec treedb.ValueLogBlockCodec) string {
 	switch codec {
 	case treedb.ValueLogBlockSnappy:
@@ -470,6 +482,21 @@ func formatTreeDBVlogAutoPolicy(policy treedb.ValueLogAutoPolicy) string {
 		return "size"
 	default:
 		return fmt.Sprintf("auto_policy_%d", policy)
+	}
+}
+
+func formatTreeDBVlogCompressionAutotune(mode treedb.AutotuneMode) string {
+	switch mode {
+	case treedb.AutotuneUnset:
+		return "default"
+	case treedb.AutotuneOff:
+		return "off"
+	case treedb.AutotuneMedium:
+		return "medium"
+	case treedb.AutotuneAggressive:
+		return "aggressive"
+	default:
+		return fmt.Sprintf("autotune_%d", mode)
 	}
 }
 

--- a/cmd/unified_bench/adapter_treedb_vlog_test.go
+++ b/cmd/unified_bench/adapter_treedb_vlog_test.go
@@ -28,8 +28,9 @@ func TestBuildTreeDBOptions_DefaultVlogCompressionAuto(t *testing.T) {
 	defer restoreTreeDBFlagState(saved)
 
 	*treedbVlogCompression = "default"
+	*treedbVlogCompressionAutotune = "default"
 
-	opts, _, err := buildTreeDBOptions("")
+	opts, rep, err := buildTreeDBOptions("")
 	if err != nil {
 		t.Fatalf("buildTreeDBOptions: %v", err)
 	}
@@ -38,6 +39,12 @@ func TestBuildTreeDBOptions_DefaultVlogCompressionAuto(t *testing.T) {
 	}
 	if opts.ValueLog.AutoPolicy != treedb.ValueLogAutoBalanced {
 		t.Fatalf("unexpected default auto policy: %v", opts.ValueLog.AutoPolicy)
+	}
+	if opts.ValueLog.CompressionAutotune.Mode != treedb.AutotuneUnset {
+		t.Fatalf("unexpected default autotune mode: %v", opts.ValueLog.CompressionAutotune.Mode)
+	}
+	if got := rep.formatText(""); !strings.Contains(got, "vlog.compression_autotune=default (effective=medium)") {
+		t.Fatalf("resolved options missing default autotune note: %q", got)
 	}
 }
 

--- a/cmd/unified_bench/profiles.go
+++ b/cmd/unified_bench/profiles.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	treedb "github.com/snissn/gomap/TreeDB"
 )
 
 var (
@@ -22,13 +24,8 @@ var profiles map[string]Profile
 func init() {
 	applyFast := func(isSet map[string]bool) {
 		// TreeDB
-		setBoolIfUnset("treedb-disable-wal", true, isSet, treedbDisableWAL)
-		setBoolIfUnset("treedb-relaxed-sync", true, isSet, treedbRelaxedSync)
-		setBoolIfUnset("treedb-disable-read-checksum", true, isSet, treedbDisableReadChecksum)
+		applyTreeDBProfileIfUnset(treedb.ProfileFast, isSet)
 		setBoolIfUnset("treedb-allow-unsafe", true, isSet, treedbAllowUnsafe)
-		setBoolIfUnset("treedb-index-optimizations", true, isSet, treedbIndexOptimizations)
-		setStringIfUnset("treedb-vlog-auto-policy", "throughput", isSet, treedbVlogAutoPolicy)
-		setStringIfUnset("treedb-vlog-compression-autotune", "medium", isSet, treedbVlogCompressionAutotune)
 
 		// Badger
 		setBoolIfUnset("badger-nosync", true, isSet, badgerNoSync)
@@ -52,13 +49,8 @@ func init() {
 
 	applyWALOnFast := func(isSet map[string]bool) {
 		// TreeDB: keep WAL enabled, but relax durability and read integrity.
-		setBoolIfUnset("treedb-disable-wal", false, isSet, treedbDisableWAL)
-		setBoolIfUnset("treedb-relaxed-sync", true, isSet, treedbRelaxedSync)
-		setBoolIfUnset("treedb-disable-read-checksum", true, isSet, treedbDisableReadChecksum)
+		applyTreeDBProfileIfUnset(treedb.ProfileWALOnFast, isSet)
 		setBoolIfUnset("treedb-allow-unsafe", true, isSet, treedbAllowUnsafe)
-		setBoolIfUnset("treedb-index-optimizations", true, isSet, treedbIndexOptimizations)
-		setStringIfUnset("treedb-vlog-auto-policy", "throughput", isSet, treedbVlogAutoPolicy)
-		setStringIfUnset("treedb-vlog-compression-autotune", "medium", isSet, treedbVlogCompressionAutotune)
 
 		// Other DBs: match "fast" behavior (nosync).
 		setBoolIfUnset("badger-nosync", true, isSet, badgerNoSync)
@@ -72,11 +64,11 @@ func init() {
 
 	profiles = map[string]Profile{
 		"fast": {
-			Description: "Maximize throughput: disables fsync for supported DBs; for TreeDB also disables WAL, enables -treedb-index-optimizations, and sets throughput-biased value-log auto policy. UNSAFE for production data.",
+			Description: "Maximize throughput: disables fsync for supported DBs; for TreeDB this mirrors treedb.ProfileFast (WAL off, relaxed read integrity, append-friendly index allocation, Celestia-aligned auto/snappy/balanced value-log compression). UNSAFE for production data.",
 			Apply:       applyFast,
 		},
 		"wal_on_fast": {
-			Description: "TreeDB fast WAL-on profile: relaxed durability + disabled read checksums (WAL on, fsync/checksums off), enables -treedb-index-optimizations, and sets throughput-biased value-log auto policy.",
+			Description: "TreeDB fast WAL-on profile: mirrors treedb.ProfileWALOnFast (WAL on, relaxed sync/read integrity, append-friendly index allocation, Celestia-aligned auto/snappy/balanced value-log compression).",
 			Apply:       applyWALOnFast,
 		},
 		"unsafe": { // Alias for fast
@@ -120,6 +112,36 @@ func init() {
 	}
 }
 
+func applyTreeDBProfileIfUnset(profile treedb.Profile, isSet map[string]bool) {
+	opts := treedb.OptionsFor(profile, "")
+
+	switch opts.Durability {
+	case treedb.DurabilityWALOffRelaxed:
+		setBoolIfUnset("treedb-disable-wal", true, isSet, treedbDisableWAL)
+		setBoolIfUnset("treedb-relaxed-sync", true, isSet, treedbRelaxedSync)
+	case treedb.DurabilityWALOnRelaxed:
+		setBoolIfUnset("treedb-disable-wal", false, isSet, treedbDisableWAL)
+		setBoolIfUnset("treedb-relaxed-sync", true, isSet, treedbRelaxedSync)
+	default:
+		setBoolIfUnset("treedb-disable-wal", false, isSet, treedbDisableWAL)
+		setBoolIfUnset("treedb-relaxed-sync", false, isSet, treedbRelaxedSync)
+	}
+	setBoolIfUnset("treedb-disable-read-checksum", opts.ValueLog.ReadIntegrity == treedb.IntegritySkipChecksums, isSet, treedbDisableReadChecksum)
+	setBoolIfUnset("treedb-index-optimizations",
+		opts.LeafPrefixCompression && opts.IndexColumnarLeaves && opts.IndexPackedValuePtr,
+		isSet,
+		treedbIndexOptimizations,
+	)
+	setBoolIfUnset("treedb-index-outer-leaves-in-vlog", opts.IndexOuterLeavesInValueLog, isSet, treedbIndexOuterLeavesInVlog)
+	setBoolIfUnset("treedb-prefer-append-alloc", opts.PreferAppendAlloc, isSet, treedbPreferAppendAlloc)
+	setStringIfUnset("treedb-vlog-compression", formatTreeDBVlogCompressionFlagValue(opts.ValueLog.Compression), isSet, treedbVlogCompression)
+	setStringIfUnset("treedb-vlog-block-codec", formatTreeDBVlogBlockCodec(opts.ValueLog.BlockCodec), isSet, treedbVlogBlockCodec)
+	setStringIfUnset("treedb-vlog-auto-policy", formatTreeDBVlogAutoPolicy(opts.ValueLog.AutoPolicy), isSet, treedbVlogAutoPolicy)
+	setStringIfUnset("treedb-vlog-compression-autotune", formatTreeDBVlogCompressionAutotune(opts.ValueLog.CompressionAutotune.Mode), isSet, treedbVlogCompressionAutotune)
+	setIntIfUnset("treedb-vlog-dict-incompressible-hold-bytes", opts.ValueLog.DictIncompressibleHoldBytes, isSet, treedbVlogDictIncompressibleHoldBytes)
+	setIntIfUnset("treedb-vlog-dict-probe-interval-bytes", opts.ValueLog.DictProbeIntervalBytes, isSet, treedbVlogDictProbeIntervalBytes)
+}
+
 func setBoolIfUnset(name string, val bool, isSet map[string]bool, target *bool) {
 	if !isSet[name] {
 		*target = val
@@ -156,7 +178,38 @@ func applyProfile(name string, isSet map[string]bool) error {
 	return nil
 }
 
+func stderrSupportsANSI() bool {
+	if fi, err := os.Stderr.Stat(); err == nil {
+		return (fi.Mode()&os.ModeCharDevice) != 0 && strings.ToLower(strings.TrimSpace(os.Getenv("TERM"))) != "dumb"
+	}
+	return false
+}
+
+func styleUsageText(text string, bold bool) string {
+	if !bold {
+		return text
+	}
+	return "\x1b[1m" + text + "\x1b[0m"
+}
+
+func treeDBUsageGroup(name string) string {
+	switch name {
+	case "treedb-disable-wal", "treedb-relaxed-sync", "treedb-disable-read-checksum", "treedb-allow-unsafe":
+		return "TreeDB Unsafe Knobs"
+	case "treedb-vlog-compression", "treedb-vlog-block-codec", "treedb-vlog-auto-policy", "treedb-vlog-generation-policy",
+		"treedb-vlog-compression-autotune", "treedb-vlog-dict-class-mode", "treedb-vlog-rewrite-after-run":
+		return "TreeDB Compression Knobs"
+	case "treedb-flush-threshold", "treedb-chunk-size", "treedb-maintenance-mode", "treedb-memtable-mode",
+		"treedb-index-optimizations", "treedb-index-outer-leaves-in-vlog", "treedb-prefer-append-alloc",
+		"treedb-force-value-pointers", "treedb-value-log-threshold", "treedb-disable-piggyback-compaction":
+		return "TreeDB Main Knobs"
+	default:
+		return "TreeDB Advanced Tuning"
+	}
+}
+
 func customUsage() {
+	useANSI := stderrSupportsANSI()
 	fmt.Fprintf(os.Stderr, "Usage: %s [flags]\n\n", os.Args[0])
 	fmt.Fprintf(os.Stderr, "Unified Benchmark Runner for GoMap DBs\n\n")
 	fmt.Fprintf(os.Stderr, "Profiles (-profile):\n")
@@ -169,15 +222,19 @@ func customUsage() {
 		fmt.Fprintf(os.Stderr, "  %-10s %s\n", k, profiles[k].Description)
 	}
 	fmt.Fprintf(os.Stderr, "\n")
+	fmt.Fprintf(os.Stderr, "TreeDB flags are grouped into main knobs, compression knobs, advanced tuning, and unsafe knobs.\n")
+	fmt.Fprintf(os.Stderr, "In most runs, start with -profile plus the TreeDB main knobs and leave advanced tuning alone.\n\n")
 
 	// Group flags
 	groups := map[string][]*flag.Flag{
-		"General":         {},
-		"Workload":        {},
-		"Tuning":          {},
-		"TreeDB Specific": {},
-		"Profiling":       {},
-		"Safety/Limits":   {},
+		"General":                  {},
+		"Workload":                 {},
+		"TreeDB Main Knobs":        {},
+		"TreeDB Compression Knobs": {},
+		"TreeDB Advanced Tuning":   {},
+		"TreeDB Unsafe Knobs":      {},
+		"Profiling":                {},
+		"Safety/Limits":            {},
 	}
 
 	flag.VisitAll(func(f *flag.Flag) {
@@ -186,7 +243,8 @@ func customUsage() {
 			return
 		}
 		if strings.HasPrefix(f.Name, "treedb-") {
-			groups["TreeDB Specific"] = append(groups["TreeDB Specific"], f)
+			groupName := treeDBUsageGroup(f.Name)
+			groups[groupName] = append(groups[groupName], f)
 		} else if strings.Contains(f.Name, "profile") || f.Name == "trace" {
 			groups["Profiling"] = append(groups["Profiling"], f)
 		} else if strings.HasPrefix(f.Name, "max-") || strings.HasPrefix(f.Name, "checkpoint-") {
@@ -198,18 +256,18 @@ func customUsage() {
 		}
 	})
 
-	groupOrder := []string{"General", "Workload", "Tuning", "TreeDB Specific", "Safety/Limits", "Profiling"}
+	groupOrder := []string{"General", "Workload", "TreeDB Main Knobs", "TreeDB Compression Knobs", "TreeDB Advanced Tuning", "TreeDB Unsafe Knobs", "Safety/Limits", "Profiling"}
 	for _, gName := range groupOrder {
 		flags := groups[gName]
 		if len(flags) == 0 {
 			continue
 		}
-		fmt.Fprintf(os.Stderr, "%s Flags:\n", gName)
+		fmt.Fprintf(os.Stderr, "%s:\n", styleUsageText(gName, useANSI))
 		// Sort flags in group
 		sort.Slice(flags, func(i, j int) bool { return flags[i].Name < flags[j].Name })
 		for _, f := range flags {
 			// standard flag print
-			s := fmt.Sprintf("  -%s", f.Name) // Two spaces as indent
+			s := fmt.Sprintf("  %s", styleUsageText("-"+f.Name, useANSI)) // Two spaces as indent
 			name, usage := flag.UnquoteUsage(f)
 			if len(name) > 0 {
 				s += " " + name

--- a/cmd/unified_bench/profiles.go
+++ b/cmd/unified_bench/profiles.go
@@ -134,12 +134,20 @@ func applyTreeDBProfileIfUnset(profile treedb.Profile, isSet map[string]bool) {
 	)
 	setBoolIfUnset("treedb-index-outer-leaves-in-vlog", opts.IndexOuterLeavesInValueLog, isSet, treedbIndexOuterLeavesInVlog)
 	setBoolIfUnset("treedb-prefer-append-alloc", opts.PreferAppendAlloc, isSet, treedbPreferAppendAlloc)
-	setStringIfUnset("treedb-vlog-compression", formatTreeDBVlogCompressionFlagValue(opts.ValueLog.Compression), isSet, treedbVlogCompression)
+	profileCompression := formatTreeDBProfileVlogCompressionFlagValue(opts.ValueLog.Compression)
+	setStringIfUnset("treedb-vlog-compression", profileCompression, isSet, treedbVlogCompression)
 	setStringIfUnset("treedb-vlog-block-codec", formatTreeDBVlogBlockCodec(opts.ValueLog.BlockCodec), isSet, treedbVlogBlockCodec)
 	setStringIfUnset("treedb-vlog-auto-policy", formatTreeDBVlogAutoPolicy(opts.ValueLog.AutoPolicy), isSet, treedbVlogAutoPolicy)
 	setStringIfUnset("treedb-vlog-compression-autotune", formatTreeDBVlogCompressionAutotune(opts.ValueLog.CompressionAutotune.Mode), isSet, treedbVlogCompressionAutotune)
 	setIntIfUnset("treedb-vlog-dict-incompressible-hold-bytes", opts.ValueLog.DictIncompressibleHoldBytes, isSet, treedbVlogDictIncompressibleHoldBytes)
 	setIntIfUnset("treedb-vlog-dict-probe-interval-bytes", opts.ValueLog.DictProbeIntervalBytes, isSet, treedbVlogDictProbeIntervalBytes)
+}
+
+func formatTreeDBProfileVlogCompressionFlagValue(mode treedb.ValueLogCompressionMode) string {
+	if mode == treedb.ValueLogCompressionAuto {
+		return "default"
+	}
+	return formatTreeDBVlogCompressionFlagValue(mode)
 }
 
 func setBoolIfUnset(name string, val bool, isSet map[string]bool, target *bool) {

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -296,8 +296,8 @@ func TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations(t *testing.T) {
 	if !*treedbIndexOptimizations {
 		t.Fatalf("expected fast profile to set treedb-index-optimizations")
 	}
-	if got := *treedbVlogCompression; got != "auto" {
-		t.Fatalf("expected fast profile to set treedb-vlog-compression=auto, got %q", got)
+	if got := *treedbVlogCompression; got != "default" {
+		t.Fatalf("expected fast profile to keep treedb-vlog-compression on the default path, got %q", got)
 	}
 	if got := *treedbVlogBlockCodec; got != "snappy" {
 		t.Fatalf("expected fast profile to set treedb-vlog-block-codec=snappy, got %q", got)
@@ -331,8 +331,8 @@ func TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations(t *testing.T) {
 	if !*treedbIndexOptimizations {
 		t.Fatalf("expected wal_on_fast profile to set treedb-index-optimizations")
 	}
-	if got := *treedbVlogCompression; got != "auto" {
-		t.Fatalf("expected wal_on_fast profile to set treedb-vlog-compression=auto, got %q", got)
+	if got := *treedbVlogCompression; got != "default" {
+		t.Fatalf("expected wal_on_fast profile to keep treedb-vlog-compression on the default path, got %q", got)
 	}
 	if got := *treedbVlogBlockCodec; got != "snappy" {
 		t.Fatalf("expected wal_on_fast profile to set treedb-vlog-block-codec=snappy, got %q", got)
@@ -360,6 +360,31 @@ func TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations(t *testing.T) {
 	}
 	if !*treedbDisableReadChecksum {
 		t.Fatalf("expected wal_on_fast profile to disable read checksum")
+	}
+}
+
+func TestApplyProfile_FastKeepsImplicitCompressionPathForAutotuneOff(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	if err := applyProfile("fast", map[string]bool{}); err != nil {
+		t.Fatalf("applyProfile fast: %v", err)
+	}
+	*treedbVlogCompressionAutotune = "off"
+
+	opts, _, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions: %v", err)
+	}
+	if opts.ValueLog.Compression != treedb.ValueLogCompressionAuto {
+		t.Fatalf("ValueLog.Compression = %v, want auto", opts.ValueLog.Compression)
+	}
+	if opts.ValueLog.CompressionAutotune.Mode != treedb.AutotuneOff {
+		t.Fatalf("CompressionAutotune.Mode = %v, want off", opts.ValueLog.CompressionAutotune.Mode)
+	}
+	if opts.ValueLog.DictTrain.TrainBytes != -1 {
+		t.Fatalf("DictTrain.TrainBytes = %d, want -1 when autotune=off", opts.ValueLog.DictTrain.TrainBytes)
 	}
 }
 

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -150,15 +150,20 @@ func TestBuildTreeDBOptions_MaintenanceModeBenchDisablesBackgroundLoops(t *testi
 type savedTreeDBFlagState struct {
 	indexOptimizations      bool
 	indexOuterLeavesInVlog  bool
+	preferAppendAlloc       bool
 	forcePointers           bool
 	leafPrefix              bool
 	columnarLeaves          bool
 	packedValuePtr          bool
 	internalBaseDelta       bool
 	chunkSize               int64
+	vlogCompression         string
+	vlogBlockCodec          string
 	vlogAutoPolicy          string
 	vlogDictClassMode       string
 	vlogCompressionAutotune string
+	vlogDictHoldBytes       int
+	vlogDictProbeBytes      int
 	vlogGenerationPolicy    string
 	vlogGenHotBytes         int64
 	vlogGenWarmBytes        int64
@@ -183,15 +188,20 @@ func saveTreeDBFlagState() savedTreeDBFlagState {
 	return savedTreeDBFlagState{
 		indexOptimizations:      *treedbIndexOptimizations,
 		indexOuterLeavesInVlog:  *treedbIndexOuterLeavesInVlog,
+		preferAppendAlloc:       *treedbPreferAppendAlloc,
 		forcePointers:           *treedbForceValuePointers,
 		leafPrefix:              *treedbLeafPrefixCompression,
 		columnarLeaves:          *treedbIndexColumnarLeaves,
 		packedValuePtr:          *treedbIndexPackedValuePtr,
 		internalBaseDelta:       *treedbIndexInternalBaseDelta,
 		chunkSize:               *treedbChunkSize,
+		vlogCompression:         *treedbVlogCompression,
+		vlogBlockCodec:          *treedbVlogBlockCodec,
 		vlogAutoPolicy:          *treedbVlogAutoPolicy,
 		vlogDictClassMode:       *treedbVlogDictClassMode,
 		vlogCompressionAutotune: *treedbVlogCompressionAutotune,
+		vlogDictHoldBytes:       *treedbVlogDictIncompressibleHoldBytes,
+		vlogDictProbeBytes:      *treedbVlogDictProbeIntervalBytes,
 		vlogGenerationPolicy:    *treedbVlogGenerationPolicy,
 		vlogGenHotBytes:         *treedbVlogGenerationHotSegmentBytes,
 		vlogGenWarmBytes:        *treedbVlogGenerationWarmSegmentBytes,
@@ -212,15 +222,20 @@ func saveTreeDBFlagState() savedTreeDBFlagState {
 func restoreTreeDBFlagState(s savedTreeDBFlagState) {
 	*treedbIndexOptimizations = s.indexOptimizations
 	*treedbIndexOuterLeavesInVlog = s.indexOuterLeavesInVlog
+	*treedbPreferAppendAlloc = s.preferAppendAlloc
 	*treedbForceValuePointers = s.forcePointers
 	*treedbLeafPrefixCompression = s.leafPrefix
 	*treedbIndexColumnarLeaves = s.columnarLeaves
 	*treedbIndexPackedValuePtr = s.packedValuePtr
 	*treedbIndexInternalBaseDelta = s.internalBaseDelta
 	*treedbChunkSize = s.chunkSize
+	*treedbVlogCompression = s.vlogCompression
+	*treedbVlogBlockCodec = s.vlogBlockCodec
 	*treedbVlogAutoPolicy = s.vlogAutoPolicy
 	*treedbVlogDictClassMode = s.vlogDictClassMode
 	*treedbVlogCompressionAutotune = s.vlogCompressionAutotune
+	*treedbVlogDictIncompressibleHoldBytes = s.vlogDictHoldBytes
+	*treedbVlogDictProbeIntervalBytes = s.vlogDictProbeBytes
 	*treedbVlogGenerationPolicy = s.vlogGenerationPolicy
 	*treedbVlogGenerationHotSegmentBytes = s.vlogGenHotBytes
 	*treedbVlogGenerationWarmSegmentBytes = s.vlogGenWarmBytes
@@ -240,15 +255,20 @@ func restoreTreeDBFlagState(s savedTreeDBFlagState) {
 func resetTreeDBIndexFlagsForTest() {
 	*treedbIndexOptimizations = false
 	*treedbIndexOuterLeavesInVlog = true
+	*treedbPreferAppendAlloc = false
 	*treedbForceValuePointers = false
 	*treedbLeafPrefixCompression = false
 	*treedbIndexColumnarLeaves = false
 	*treedbIndexPackedValuePtr = false
 	*treedbIndexInternalBaseDelta = false
 	*treedbChunkSize = defaultTreeDBChunkSizeBytes
+	*treedbVlogCompression = "default"
+	*treedbVlogBlockCodec = "snappy"
 	*treedbVlogAutoPolicy = "balanced"
 	*treedbVlogDictClassMode = "single"
-	*treedbVlogCompressionAutotune = "off"
+	*treedbVlogCompressionAutotune = "default"
+	*treedbVlogDictIncompressibleHoldBytes = 0
+	*treedbVlogDictProbeIntervalBytes = 0
 	*treedbVlogGenerationPolicy = "default"
 	*treedbVlogGenerationHotSegmentBytes = 0
 	*treedbVlogGenerationWarmSegmentBytes = 0
@@ -276,11 +296,26 @@ func TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations(t *testing.T) {
 	if !*treedbIndexOptimizations {
 		t.Fatalf("expected fast profile to set treedb-index-optimizations")
 	}
-	if got := *treedbVlogAutoPolicy; got != "throughput" {
-		t.Fatalf("expected fast profile to set treedb-vlog-auto-policy=throughput, got %q", got)
+	if got := *treedbVlogCompression; got != "auto" {
+		t.Fatalf("expected fast profile to set treedb-vlog-compression=auto, got %q", got)
+	}
+	if got := *treedbVlogBlockCodec; got != "snappy" {
+		t.Fatalf("expected fast profile to set treedb-vlog-block-codec=snappy, got %q", got)
+	}
+	if got := *treedbVlogAutoPolicy; got != "balanced" {
+		t.Fatalf("expected fast profile to set treedb-vlog-auto-policy=balanced, got %q", got)
 	}
 	if got := *treedbVlogCompressionAutotune; got != "medium" {
 		t.Fatalf("expected fast profile to set treedb-vlog-compression-autotune=medium, got %q", got)
+	}
+	if got := *treedbVlogDictIncompressibleHoldBytes; got != 64<<20 {
+		t.Fatalf("expected fast profile to set treedb-vlog-dict-incompressible-hold-bytes=64MiB, got %d", got)
+	}
+	if got := *treedbVlogDictProbeIntervalBytes; got != 32<<20 {
+		t.Fatalf("expected fast profile to set treedb-vlog-dict-probe-interval-bytes=32MiB, got %d", got)
+	}
+	if !*treedbPreferAppendAlloc {
+		t.Fatalf("expected fast profile to set treedb-prefer-append-alloc")
 	}
 	if !*treedbDisableWAL {
 		t.Fatalf("expected fast profile to disable WAL")
@@ -296,11 +331,26 @@ func TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations(t *testing.T) {
 	if !*treedbIndexOptimizations {
 		t.Fatalf("expected wal_on_fast profile to set treedb-index-optimizations")
 	}
-	if got := *treedbVlogAutoPolicy; got != "throughput" {
-		t.Fatalf("expected wal_on_fast profile to set treedb-vlog-auto-policy=throughput, got %q", got)
+	if got := *treedbVlogCompression; got != "auto" {
+		t.Fatalf("expected wal_on_fast profile to set treedb-vlog-compression=auto, got %q", got)
+	}
+	if got := *treedbVlogBlockCodec; got != "snappy" {
+		t.Fatalf("expected wal_on_fast profile to set treedb-vlog-block-codec=snappy, got %q", got)
+	}
+	if got := *treedbVlogAutoPolicy; got != "balanced" {
+		t.Fatalf("expected wal_on_fast profile to set treedb-vlog-auto-policy=balanced, got %q", got)
 	}
 	if got := *treedbVlogCompressionAutotune; got != "medium" {
 		t.Fatalf("expected wal_on_fast profile to set treedb-vlog-compression-autotune=medium, got %q", got)
+	}
+	if got := *treedbVlogDictIncompressibleHoldBytes; got != 64<<20 {
+		t.Fatalf("expected wal_on_fast profile to set treedb-vlog-dict-incompressible-hold-bytes=64MiB, got %d", got)
+	}
+	if got := *treedbVlogDictProbeIntervalBytes; got != 32<<20 {
+		t.Fatalf("expected wal_on_fast profile to set treedb-vlog-dict-probe-interval-bytes=32MiB, got %d", got)
+	}
+	if !*treedbPreferAppendAlloc {
+		t.Fatalf("expected wal_on_fast profile to set treedb-prefer-append-alloc")
 	}
 	if *treedbDisableWAL {
 		t.Fatalf("expected wal_on_fast profile to keep WAL enabled")

--- a/cmd/unified_bench/profiles_usage_test.go
+++ b/cmd/unified_bench/profiles_usage_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestTreeDBUsageGroup(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{name: "treedb-flush-threshold", want: "TreeDB Main Knobs"},
+		{name: "treedb-vlog-compression", want: "TreeDB Compression Knobs"},
+		{name: "treedb-vlog-dict-train-bytes", want: "TreeDB Advanced Tuning"},
+		{name: "treedb-disable-wal", want: "TreeDB Unsafe Knobs"},
+	}
+
+	for _, tc := range cases {
+		if got := treeDBUsageGroup(tc.name); got != tc.want {
+			t.Fatalf("treeDBUsageGroup(%q)=%q want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestStyleUsageText(t *testing.T) {
+	if got := styleUsageText("-flag", false); got != "-flag" {
+		t.Fatalf("plain style=%q want %q", got, "-flag")
+	}
+	if got := styleUsageText("-flag", true); got != "\x1b[1m-flag\x1b[0m" {
+		t.Fatalf("bold style=%q", got)
+	}
+}

--- a/docs/TREEDB_PROFILES.md
+++ b/docs/TREEDB_PROFILES.md
@@ -162,9 +162,10 @@ profile.
 ### Downstream wrappers should start from profiles
 
 If you are wrapping TreeDB in another project (for example a cosmos-db or
-cometbft-db adapter), start from `OptionsFor(...)` or `ApplyProfile(...)`
-instead of copying a partial list of low-level defaults. That keeps the
-high-level intent aligned as TreeDB evolves.
+cometbft-db adapter), start from `OptionsFor(...)` / `ApplyProfile(...)` or the
+standard downstream helper in `TreeDB/integration/kvstoreadapter`. That keeps
+the high-level intent aligned as TreeDB evolves and avoids copying profile/env
+parsing glue into each downstream wrapper.
 
 Recommended surface area for most wrappers:
 
@@ -177,6 +178,28 @@ Recommended surface area for most wrappers:
   - index optimization bundle / outer leaves in vlog
 - Keep advanced compression training/autotune/dict knobs as explicit escape
   hatches, not primary tuning inputs
+
+Minimal helper usage:
+
+```go
+import (
+	treedb "github.com/snissn/gomap/TreeDB"
+	treedbkv "github.com/snissn/gomap/TreeDB/integration/kvstoreadapter"
+)
+
+opened, err := treedbkv.Open(treedbkv.OpenConfig{
+	ParentDir:                   dir,
+	Name:                        "application",
+	AdapterName:                 "TreeDB",
+	DefaultProfile:              treedb.ProfileWALOnFast,
+	DefaultKeepRecent:           1,
+	DefaultAdaptiveMemtableBase: "hash_sorted",
+})
+if err != nil {
+	return err
+}
+defer opened.DB.Close()
+```
 
 ### Booleans are not tri-state
 

--- a/docs/TREEDB_PROFILES.md
+++ b/docs/TREEDB_PROFILES.md
@@ -47,6 +47,14 @@ A `Profile` is a named preset for a small set of **policy** knobs:
 - Durability / integrity checks (journal, sync policy, read checksums)
 - Background work (checkpoint / pruning) that can affect latency and
   benchmark stability
+- For `fast` / `wal_on_fast`, the common value-log compression policy used by
+  current `run_celestia` deployments:
+  - `ValueLog.Compression = auto`
+  - `ValueLog.BlockCodec = snappy`
+  - `ValueLog.AutoPolicy = balanced`
+  - `ValueLog.CompressionAutotune = medium`
+  - dict incompressible hold / probe defaults tuned for long-running ingest
+    (`64MiB` / `32MiB`)
 
 Profiles intentionally avoid setting most throughput/capacity knobs (like
 `FlushThreshold`) because those are highly workload dependent.
@@ -86,6 +94,12 @@ Behavior:
   - `IndexColumnarLeaves = true`
   - `IndexPackedValuePtr = true`
   - `IndexInternalBaseDelta = false` (incompatible with leaf refs)
+- Pins the current Celestia-style value-log compression defaults:
+  - `ValueLog.Compression = auto`
+  - `ValueLog.AutoPolicy = balanced`
+  - block codec stays on the default `snappy`
+  - compression autotune defaults to `medium`
+  - dict incompressible hold/probe defaults become `64MiB` / `32MiB`
 - Leaves background maintenance enabled by default.
 
 Notes:
@@ -110,6 +124,8 @@ Behavior:
   - `ValueLog.ReadIntegrity = IntegritySkipChecksums`
 - Prefers append allocation (`PreferAppendAlloc=true`)
 - Enables the same index optimization bundle as `ProfileFast`.
+- Enables the same Celestia-style value-log compression defaults as
+  `ProfileFast`.
 
 Use when you want:
 
@@ -142,6 +158,25 @@ Not recommended for production.
 
 Profiles are just helpers. You can always override any option after applying a
 profile.
+
+### Downstream wrappers should start from profiles
+
+If you are wrapping TreeDB in another project (for example a cosmos-db or
+cometbft-db adapter), start from `OptionsFor(...)` or `ApplyProfile(...)`
+instead of copying a partial list of low-level defaults. That keeps the
+high-level intent aligned as TreeDB evolves.
+
+Recommended surface area for most wrappers:
+
+- Pick a profile first: `durable`, `fast`, or `wal_on_fast`
+- Expose a small set of main knobs:
+  - durability/profile
+  - value-log pointer threshold
+  - value-log compression mode / auto policy
+  - maintenance mode / background rewrite policy
+  - index optimization bundle / outer leaves in vlog
+- Keep advanced compression training/autotune/dict knobs as explicit escape
+  hatches, not primary tuning inputs
 
 ### Booleans are not tri-state
 


### PR DESCRIPTION
## Summary
- avoid allocating a full temporary grouped-frame payload buffer in `readGroupedCompressedFromFileTo`
- read the grouped prefix into fixed-size stack storage and the compressed frame payload into pooled scratch instead
- add focused regression coverage and a path-level benchmark for the grouped-compressed file fallback

## Why
The grouped-compressed file fallback used by `Read` and `ReadUnsafeTo` was still doing a fresh `make([]byte, valueLen)` for the entire on-disk frame payload even though those bytes were only needed long enough to parse offsets and feed the decoder.

This change keeps the same decode/copy semantics, but replaces that temporary full-frame allocation with:
- fixed-size prefix storage for the frame header/rids/offsets
- pooled scratch for only the compressed payload bytes

## Validation
- `GOWORK=off go test ./TreeDB/internal/valuelog -run 'Test(ReadAtWithDictTo_UsesDstForCompressedGroupedSubrecord|FileReadGroupedCompressedFromFileTo_)' -count=1`
- `GOWORK=off go test ./TreeDB/internal/valuelog -run '^$' -bench 'BenchmarkFileReadGroupedCompressedFromFileTo' -benchmem -benchtime=2s -count=1`

Focused path benchmark on the same machine:
- `nil_dst`: `71737 ns/op`, `46336 B/op`, `2 allocs/op` -> `71131 ns/op`, `32885 B/op`, `1 alloc/op`
- `reused_dst`: `68514 ns/op`, `13568 B/op`, `1 alloc/op` -> `67135 ns/op`, `1 B/op`, `0 allocs/op`

Local validation-only `TreeDB` large-value read bench also moved in the right direction:
- `BenchmarkSnapshotValueLogGetLarge/Get`: `424586 ns/op` -> `411274 ns/op`
- `BenchmarkDBValueLogGetLarge/Get`: `426649 ns/op` -> `411197 ns/op`

The root large-value bench file was local validation only and is not part of this PR diff.
