### PR TITLE
Delay append-only latest-index rebuild

### DIFF
--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -601,13 +601,12 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 			return
 		}
 		m.ordered = false
-		// Once order breaks, invalidate the cached snapshot state and
-		// materialize the latest-key index immediately so subsequent unordered
-		// appends can maintain it incrementally instead of forcing the next
-		// iterator/lookup to rebuild the full map from scratch.
-		// rebuildLatestIndexLocked clears the cached snapshot as part of the
-		// transition.
-		m.rebuildLatestIndexLocked()
+		// Defer latest-key index materialization until a lookup/iterator actually
+		// needs it. Random-write/delete workloads can otherwise spend a
+		// disproportionate amount of time and memory maintaining a large
+		// latest-key map that is never queried on the hot path.
+		m.latestDirty = true
+		m.clearSnapshotLocked()
 		return
 	}
 	if !m.latestDirty {

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -324,15 +324,15 @@ func TestAppendOnlyResetRetainedArenaBounded(t *testing.T) {
 	}
 }
 
-func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
+func TestAppendOnlyUnorderedAppendDefersLatestIndexUntilIterator(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	m.Set([]byte("b"), []byte("v1"))
 	m.Set([]byte("a"), []byte("v2")) // force unordered path
 	if m.ordered {
 		t.Fatalf("expected unordered memtable")
 	}
-	if m.latestDirty {
-		t.Fatalf("expected latest index to stay clean after order break")
+	if !m.latestDirty {
+		t.Fatalf("expected latest index to stay dirty until an iterator needs it")
 	}
 
 	it := m.NewIterator(nil, nil)
@@ -391,8 +391,8 @@ func TestAppendOnlyUnorderedReverseIteratorDoesNotCacheSharedSnapshot(t *testing
 	if m.ordered {
 		t.Fatalf("expected unordered memtable")
 	}
-	if m.latestDirty {
-		t.Fatalf("expected latest index to stay clean after order break")
+	if !m.latestDirty {
+		t.Fatalf("expected latest index to stay dirty until a reverse iterator needs it")
 	}
 
 	it := m.NewReverseIterator(nil, nil)

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -143,6 +143,39 @@ func TestAppendOnlyIteratorSortedLatest(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyDefersLatestIndexUntilLookup(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+
+	var k2 [8]byte
+	var k1 [8]byte
+	binary.BigEndian.PutUint64(k2[:], 2)
+	binary.BigEndian.PutUint64(k1[:], 1)
+
+	m.Set(k2[:], []byte("v2"))
+	m.Set(k1[:], []byte("v1"))
+
+	if m.ordered {
+		t.Fatalf("expected out-of-order append to mark memtable unordered")
+	}
+	if !m.latestDirty {
+		t.Fatalf("expected latest index to remain dirty until a lookup needs it")
+	}
+	if len(m.latest) != 0 || len(m.latest64) != 0 {
+		t.Fatalf("expected no latest index materialized yet; latest=%d latest64=%d", len(m.latest), len(m.latest64))
+	}
+
+	val, del, ok := m.Get(k1[:])
+	if !ok || del || string(val) != "v1" {
+		t.Fatalf("Get(k1) = (%q,%v,%v), want (v1,false,true)", string(val), del, ok)
+	}
+	if m.latestDirty {
+		t.Fatalf("expected lookup to rebuild the latest index")
+	}
+	if len(m.latest64) != 2 {
+		t.Fatalf("latest64 size = %d, want 2", len(m.latest64))
+	}
+}
+
 func TestAppendOnlyResetClearsLatestIndex(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	m.Set([]byte("k1"), []byte("v1"))
@@ -360,22 +393,18 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 			if ordered {
 				t.Fatalf("expected memtable to become unordered")
 			}
-			if dirty {
-				t.Fatalf("expected latest index to stay clean after order break")
+			if !dirty {
+				t.Fatalf("expected latest index to stay dirty after order break")
 			}
 			m.mu.RLock()
 			latestSizeBeforeGet := kk.latestSize(m)
 			idxBeforeGet, okBeforeGet := kk.latestIdx(m, lo)
-			countBeforeGet := m.count
 			m.mu.RUnlock()
-			if latestSizeBeforeGet < 2 {
-				t.Fatalf("expected latest index to be materialized on order break, size=%d", latestSizeBeforeGet)
+			if latestSizeBeforeGet != 0 {
+				t.Fatalf("expected no latest index materialized before first point read, size=%d", latestSizeBeforeGet)
 			}
-			if !okBeforeGet {
-				t.Fatalf("expected latest index lookup to succeed immediately after order break")
-			}
-			if idxBeforeGet != countBeforeGet-1 {
-				t.Fatalf("latest index before Get=%d want %d", idxBeforeGet, countBeforeGet-1)
+			if okBeforeGet {
+				t.Fatalf("expected latest index lookup to miss before first point read, got idx=%d", idxBeforeGet)
 			}
 
 			if got, del, ok := m.Get(lo); !ok || del || string(got) != "lo" {


### PR DESCRIPTION
## Summary
- defer append-only latest-index rebuild until an unordered lookup or iterator actually needs it
- stop materializing the latest-key map on the first out-of-order append
- keep the append-only tests with the change

## Validation
- `go test ./TreeDB/internal/memtable`
- exact benchmark: `./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_append_only_lazy_1776901162 -test batch_delete`
- `Batch Delete: 14,131,322`