### PR TITLE
Use append-only entry hints for recycled mutables

### DIFF
--- a/TreeDB/caching/append_only_hint_test.go
+++ b/TreeDB/caching/append_only_hint_test.go
@@ -1,9 +1,13 @@
 package caching
 
 import (
+	"fmt"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func TestAppendOnlyEntryHint_AdaptiveDecayAndCapacityClamp(t *testing.T) {
@@ -53,6 +57,31 @@ func TestAppendOnlyEntriesToCapacity_OverflowSafe(t *testing.T) {
 	if got := appendOnlyEntriesToCapacity(0, appendOnlyEstimatedBytesPerEntryDefault); got != 0 {
 		t.Fatalf("zero entries capacity=%d want 0", got)
 	}
+}
+
+func TestTrimAppendOnlyMemLeasesIgnoresStaleEntryHint(t *testing.T) {
+	var cache DB
+	cache.appendOnlyEntryHint.Store(2048)
+
+	mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(4<<10, appendOnlyEstimatedBytesPerEntryDefault)
+	for i := 0; i < 2048; i++ {
+		mt.Delete([]byte(fmt.Sprintf("trim-key-%08d", i)))
+	}
+	grownCap := appendOnlyEntriesCapForTest(mt)
+	if grownCap < 2048 {
+		t.Fatalf("test setup cap(entries)=%d want >=2048", grownCap)
+	}
+
+	cache.appendOnlyMemLeases = []*memtable.AppendOnly{mt}
+	cache.trimAppendOnlyMemLeases(0, 4<<10)
+
+	if got := appendOnlyEntriesCapForTest(mt); got >= grownCap {
+		t.Fatalf("trim retained stale hinted cap(entries)=%d, before=%d", got, grownCap)
+	}
+}
+
+func appendOnlyEntriesCapForTest(mt *memtable.AppendOnly) int {
+	return reflect.ValueOf(mt).Elem().FieldByName("entries").Cap()
 }
 
 func TestAppendOnlyEntryHint_CapacityTracksPressureScaledMutableThreshold(t *testing.T) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -25802,14 +25802,18 @@ func (db *DB) NewBatchWithSize(size int) *Batch {
 	}
 }
 
-func clampAppendOnlyEntryHint(entries int) int {
-	if entries < appendOnlyEntryHintMinEntries {
+func clampAppendOnlyEntryHint64(entries int64) int {
+	if entries < int64(appendOnlyEntryHintMinEntries) {
 		return appendOnlyEntryHintMinEntries
 	}
-	if entries > appendOnlyEntryHintMaxEntries {
+	if entries > int64(appendOnlyEntryHintMaxEntries) {
 		return appendOnlyEntryHintMaxEntries
 	}
-	return entries
+	return int(entries)
+}
+
+func clampAppendOnlyEntryHint(entries int) int {
+	return clampAppendOnlyEntryHint64(int64(entries))
 }
 
 func (db *DB) observeAppendOnlyMutableEntries(entries int) {
@@ -25817,24 +25821,27 @@ func (db *DB) observeAppendOnlyMutableEntries(entries int) {
 		return
 	}
 	n := clampAppendOnlyEntryHint(entries)
+	n64 := int64(n)
 	for {
-		old := int(db.appendOnlyEntryHint.Load())
-		next := n
+		old32 := db.appendOnlyEntryHint.Load()
+		old := int64(old32)
+		next := n64
 		if old > 0 {
-			if n > old {
+			if n64 > old {
 				// Grow faster so sustained larger mutables avoid repeated regrowth.
-				next = (old*3 + n + 1) / 4
+				next = (old*3 + n64 + 1) / 4
 			} else {
 				// Decay to recent smaller mutables to avoid pinning high-water entry
 				// slices through rotate/checkpoint-heavy workloads.
-				next = (old*7 + n + 3) / 8
+				next = (old*7 + n64 + 3) / 8
 			}
 		}
-		next = clampAppendOnlyEntryHint(next)
+		nextClamped := clampAppendOnlyEntryHint64(next)
+		next = int64(nextClamped)
 		if next == old {
 			return
 		}
-		if db.appendOnlyEntryHint.CompareAndSwap(int32(old), int32(next)) {
+		if db.appendOnlyEntryHint.CompareAndSwap(old32, int32(nextClamped)) {
 			return
 		}
 	}
@@ -25844,11 +25851,11 @@ func (db *DB) appendOnlyEntryHintEntries() int {
 	if db == nil {
 		return 0
 	}
-	hint := int(db.appendOnlyEntryHint.Load())
+	hint := db.appendOnlyEntryHint.Load()
 	if hint <= 0 {
 		return 0
 	}
-	return clampAppendOnlyEntryHint(hint)
+	return clampAppendOnlyEntryHint64(int64(hint))
 }
 
 func appendOnlyEntriesToCapacity(entries, estimatedBytesPerEntry int) int {
@@ -25878,12 +25885,13 @@ func (db *DB) appendOnlyMemtableCapacityHint(capacity, estimatedBytesPerEntry in
 			capacity = effectiveCap
 		}
 	}
-	hintEntries := int(db.appendOnlyEntryHint.Load())
+	hintEntries32 := db.appendOnlyEntryHint.Load()
+	hintEntries := int64(hintEntries32)
 	if hintEntries <= 0 {
 		return capacity
 	}
-	hintEntries = clampAppendOnlyEntryHint(hintEntries)
-	hintCapacity := appendOnlyEntriesToCapacity(hintEntries, estimatedBytesPerEntry)
+	hintEntriesClamped := clampAppendOnlyEntryHint64(hintEntries)
+	hintCapacity := appendOnlyEntriesToCapacity(hintEntriesClamped, estimatedBytesPerEntry)
 	if hintCapacity < minMemtablePrealloc {
 		hintCapacity = minMemtablePrealloc
 	}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7594,10 +7594,11 @@ func (db *DB) recycleMemtables(mems []memtable.Table) {
 	resetCapacity := db.checkpointRotateCapacity()
 	estimate := appendOnlyEstimatedBytesPerEntryDefault
 	appendOnlyResetCapacity := db.appendOnlyMemtableCapacityHint(resetCapacity, estimate)
+	entryHint := db.appendOnlyEntryHintEntries()
 	for _, mt := range mems {
 		switch typed := mt.(type) {
 		case *memtable.AppendOnly:
-			typed.ResetWithCapacityHard(appendOnlyResetCapacity, estimate)
+			typed.ResetWithCapacityHardAndEntryHint(appendOnlyResetCapacity, estimate, entryHint)
 			db.releaseAppendOnlyDirectArenaLeaseForMemtable(typed)
 			if !db.putAppendOnlyMemLease(typed) {
 				db.appendOnlyMemPool.Put(typed)
@@ -7630,9 +7631,10 @@ func (db *DB) trimAppendOnlyMemLeases(maxLeases int, resetCapacity int) {
 		return
 	}
 	effectiveResetCapacity := db.appendOnlyMemtableCapacityHint(resetCapacity, appendOnlyEstimatedBytesPerEntryDefault)
+	entryHint := db.appendOnlyEntryHintEntries()
 	for i := range dropped {
 		if dropped[i] != nil {
-			dropped[i].ResetWithCapacityHard(effectiveResetCapacity, appendOnlyEstimatedBytesPerEntryDefault)
+			dropped[i].ResetWithCapacityHardAndEntryHint(effectiveResetCapacity, appendOnlyEstimatedBytesPerEntryDefault, entryHint)
 			db.releaseAppendOnlyDirectArenaLeaseForMemtable(dropped[i])
 			db.appendOnlyMemPool.Put(dropped[i])
 		}
@@ -7732,15 +7734,16 @@ func (db *DB) trimRetainedArenasAfterFlush(checkpoint bool) {
 func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mode) (memtable.Table, error) {
 	if db != nil && mode == memtable.ModeAppendOnly {
 		estimate := appendOnlyEstimatedBytesPerEntryDefault
+		entryHint := db.appendOnlyEntryHintEntries()
 		if mt := db.popAppendOnlyMemLease(); mt != nil {
 			db.appendOnlyMemLeaseHitTotal.Add(1)
-			mt.ResetWithCapacity(capacity, estimate)
+			mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
 			return mt, nil
 		}
 		if v := db.appendOnlyMemPool.Get(); v != nil {
 			if mt, ok := v.(*memtable.AppendOnly); ok && mt != nil {
 				db.appendOnlyMemPoolHitTotal.Add(1)
-				mt.ResetWithCapacity(capacity, estimate)
+				mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
 				return mt, nil
 			}
 		}
@@ -7751,7 +7754,7 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 			db.appendOnlyMemNewAllocQueueBytes.Add(uint64(backlog))
 		}
 		db.appendOnlyMemNewAllocTotal.Add(1)
-		return memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, estimate), nil
+		return memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimate, entryHint), nil
 	}
 	return memtable.NewWithCapacityModeAndIndexer(capacity, mode, db.hashSortedIndexer)
 }
@@ -25826,6 +25829,17 @@ func (db *DB) observeAppendOnlyMutableEntries(entries int) {
 			return
 		}
 	}
+}
+
+func (db *DB) appendOnlyEntryHintEntries() int {
+	if db == nil {
+		return 0
+	}
+	hint := int(db.appendOnlyEntryHint.Load())
+	if hint <= 0 {
+		return 0
+	}
+	return clampAppendOnlyEntryHint(hint)
 }
 
 func appendOnlyEntriesToCapacity(entries, estimatedBytesPerEntry int) int {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7631,10 +7631,9 @@ func (db *DB) trimAppendOnlyMemLeases(maxLeases int, resetCapacity int) {
 		return
 	}
 	effectiveResetCapacity := db.appendOnlyMemtableCapacityHint(resetCapacity, appendOnlyEstimatedBytesPerEntryDefault)
-	entryHint := db.appendOnlyEntryHintEntries()
 	for i := range dropped {
 		if dropped[i] != nil {
-			dropped[i].ResetWithCapacityHardAndEntryHint(effectiveResetCapacity, appendOnlyEstimatedBytesPerEntryDefault, entryHint)
+			dropped[i].ResetWithCapacityHard(effectiveResetCapacity, appendOnlyEstimatedBytesPerEntryDefault)
 			db.releaseAppendOnlyDirectArenaLeaseForMemtable(dropped[i])
 			db.appendOnlyMemPool.Put(dropped[i])
 		}

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -206,12 +206,33 @@ func appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry int) i
 	return n
 }
 
+func appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint int) int {
+	n := appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
+	if entryHint <= 0 {
+		return n
+	}
+	if entryHint < appendOnlyMinInitialEntries {
+		entryHint = appendOnlyMinInitialEntries
+	}
+	if entryHint > appendOnlyMaxInitialEntries {
+		entryHint = appendOnlyMaxInitialEntries
+	}
+	if entryHint > n {
+		n = entryHint
+	}
+	return n
+}
+
 func NewAppendOnlyWithCapacity(capacity int) *AppendOnly {
 	return NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, appendOnlyEstimatedBytesPerEntryPointer)
 }
 
 func NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, estimatedBytesPerEntry int) *AppendOnly {
-	n := appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
+	return NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedBytesPerEntry, 0)
+}
+
+func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedBytesPerEntry, entryHint int) *AppendOnly {
+	n := appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint)
 	return &AppendOnly{
 		entries:        getAppendOnlyEntries(n),
 		baseEntriesLen: n,
@@ -893,7 +914,7 @@ func (m *AppendOnly) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.waitIteratorLeasesLocked()
-	m.resetLockedWithPolicy(0, 0, true)
+	m.resetLockedWithPolicy(0, 0, 0, true)
 }
 
 // ResetWithCapacity resets the memtable and, when needed, shrinks retained
@@ -903,11 +924,18 @@ func (m *AppendOnly) ResetWithCapacity(capacity, estimatedBytesPerEntry int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.waitIteratorLeasesLocked()
-	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, true)
+	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, 0, true)
+}
+
+func (m *AppendOnly) ResetWithCapacityAndEntryHint(capacity, estimatedBytesPerEntry, entryHint int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.waitIteratorLeasesLocked()
+	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, entryHint, true)
 }
 
 func (m *AppendOnly) resetLocked(capacity, estimatedBytesPerEntry int) {
-	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, true)
+	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, 0, true)
 }
 
 // ResetWithCapacityHard resets and clamps retained internal buffers to the
@@ -916,14 +944,23 @@ func (m *AppendOnly) ResetWithCapacityHard(capacity, estimatedBytesPerEntry int)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.waitIteratorLeasesLocked()
-	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, false)
+	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, 0, false)
 }
 
-func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int, retainObserved bool) {
+func (m *AppendOnly) ResetWithCapacityHardAndEntryHint(capacity, estimatedBytesPerEntry, entryHint int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.waitIteratorLeasesLocked()
+	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, entryHint, false)
+}
+
+func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, entryHint int, retainObserved bool) {
 	desiredEntries := m.baseEntriesLen
 	if capacity > 0 {
-		desiredEntries = appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
+		desiredEntries = appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint)
 		m.baseEntriesLen = desiredEntries
+	} else if entryHint > 0 {
+		desiredEntries = appendOnlyInitialEntriesForCapacityAndHint(defaultMemtableCapacity, estimatedBytesPerEntry, entryHint)
 	}
 	if desiredEntries <= 0 {
 		desiredEntries = appendOnlyMinInitialEntries

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -66,6 +66,7 @@ type AppendOnly struct {
 
 	entries        []appendOnlyEntry
 	baseEntriesLen int
+	growEntriesLen int
 	latest         map[string]int
 	latest64       map[uint64]int
 	snapshot       []*appendOnlyEntry
@@ -206,8 +207,11 @@ func appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry int) i
 	return n
 }
 
-func appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint int) int {
-	n := appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
+func appendOnlyGrowthEntriesForHint(baseEntries, entryHint int) int {
+	n := baseEntries
+	if n < appendOnlyMinInitialEntries {
+		n = appendOnlyMinInitialEntries
+	}
 	if entryHint <= 0 {
 		return n
 	}
@@ -232,10 +236,12 @@ func NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, estimatedBytesPerEnt
 }
 
 func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedBytesPerEntry, entryHint int) *AppendOnly {
-	n := appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint)
+	baseEntries := appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
+	growEntries := appendOnlyGrowthEntriesForHint(baseEntries, entryHint)
 	return &AppendOnly{
-		entries:        getAppendOnlyEntries(n),
-		baseEntriesLen: n,
+		entries:        getAppendOnlyEntries(growEntries),
+		baseEntriesLen: baseEntries,
+		growEntriesLen: growEntries,
 		count:          0,
 		ordered:        true,
 		hasLast:        false,
@@ -565,6 +571,9 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) {
 	if m.count == len(m.entries) {
 		nextCap := appendOnlyNextCapacity(len(m.entries))
+		if nextCap < m.growEntriesLen {
+			nextCap = m.growEntriesLen
+		}
 		prev := m.entries
 		grown := getAppendOnlyEntries(nextCap)
 		copy(grown, m.entries[:m.count])
@@ -957,17 +966,20 @@ func (m *AppendOnly) ResetWithCapacityHardAndEntryHint(capacity, estimatedBytesP
 func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, entryHint int, retainObserved bool) {
 	desiredEntries := m.baseEntriesLen
 	if capacity > 0 {
-		desiredEntries = appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint)
+		desiredEntries = appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
 		m.baseEntriesLen = desiredEntries
-	} else if entryHint > 0 {
-		desiredEntries = appendOnlyInitialEntriesForCapacityAndHint(defaultMemtableCapacity, estimatedBytesPerEntry, entryHint)
 	}
 	if desiredEntries <= 0 {
 		desiredEntries = appendOnlyMinInitialEntries
+		m.baseEntriesLen = desiredEntries
 	}
+	// Hints should improve the next growth jump and warm-retention ceiling, but
+	// reset itself must not allocate just to satisfy the hint.
+	growthEntries := appendOnlyGrowthEntriesForHint(desiredEntries, entryHint)
+	m.growEntriesLen = growthEntries
 
 	oldCount := m.count
-	maxRetainedEntries := appendOnlyMaxReuseEntries(desiredEntries)
+	maxRetainedEntries := appendOnlyMaxReuseEntries(growthEntries)
 	retainedEntries := desiredEntries
 	if retainObserved && oldCount > retainedEntries {
 		retainedEntries = oldCount

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -212,6 +212,9 @@ func appendOnlyGrowthEntriesForHint(baseEntries, entryHint int) int {
 	if n < appendOnlyMinInitialEntries {
 		n = appendOnlyMinInitialEntries
 	}
+	if n > appendOnlyMaxInitialEntries {
+		n = appendOnlyMaxInitialEntries
+	}
 	if entryHint <= 0 {
 		return n
 	}
@@ -235,6 +238,10 @@ func NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, estimatedBytesPerEnt
 	return NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedBytesPerEntry, 0)
 }
 
+// NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint creates an append-only
+// memtable using the capacity-derived baseline plus entryHint as the expected
+// upcoming entry count. The hint does not allocate entries immediately; it only
+// influences the next growth jump and bounded reuse after reset.
 func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedBytesPerEntry, entryHint int) *AppendOnly {
 	baseEntries := appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
 	growEntries := appendOnlyGrowthEntriesForHint(baseEntries, entryHint)
@@ -936,6 +943,10 @@ func (m *AppendOnly) ResetWithCapacity(capacity, estimatedBytesPerEntry int) {
 	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, 0, true)
 }
 
+// ResetWithCapacityAndEntryHint resets the memtable like ResetWithCapacity, but
+// also records entryHint as the expected upcoming entry count. The hint is used
+// to influence the next growth jump and the ceiling for retained buffer reuse.
+// It does not cause reset to allocate entries immediately.
 func (m *AppendOnly) ResetWithCapacityAndEntryHint(capacity, estimatedBytesPerEntry, entryHint int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -956,6 +967,10 @@ func (m *AppendOnly) ResetWithCapacityHard(capacity, estimatedBytesPerEntry int)
 	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, 0, false)
 }
 
+// ResetWithCapacityHardAndEntryHint resets the memtable like
+// ResetWithCapacityHard, but records entryHint as the expected upcoming entry
+// count for the next growth jump. The hint does not allocate entries during
+// reset and hard reset still drops observed spike retention.
 func (m *AppendOnly) ResetWithCapacityHardAndEntryHint(capacity, estimatedBytesPerEntry, entryHint int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -239,7 +239,7 @@ func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedByte
 	baseEntries := appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
 	growEntries := appendOnlyGrowthEntriesForHint(baseEntries, entryHint)
 	return &AppendOnly{
-		entries:        getAppendOnlyEntries(growEntries),
+		entries:        getAppendOnlyEntries(baseEntries),
 		baseEntriesLen: baseEntries,
 		growEntriesLen: growEntries,
 		count:          0,

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -91,8 +91,8 @@ func TestAppendOnlyNewWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *te
 	if got := len(mt.entries); got != base {
 		t.Fatalf("initial len(entries)=%d want=%d", got, base)
 	}
-	if got := cap(mt.entries); got != base {
-		t.Fatalf("initial cap(entries)=%d want=%d", got, base)
+	if got := cap(mt.entries); got >= entryHint {
+		t.Fatalf("initial cap(entries)=%d want <%d before append-driven growth", got, entryHint)
 	}
 	if got := mt.growEntriesLen; got < entryHint {
 		t.Fatalf("growEntriesLen=%d want >=%d", got, entryHint)
@@ -116,8 +116,11 @@ func TestAppendOnlyResetWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *
 	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
 	entryHint := base * 16
 	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
-	if got := cap(mt.entries); got != base {
-		t.Fatalf("initial cap(entries)=%d want=%d", got, base)
+	if got := len(mt.entries); got != base {
+		t.Fatalf("initial len(entries)=%d want=%d", got, base)
+	}
+	if got := cap(mt.entries); got >= entryHint {
+		t.Fatalf("initial cap(entries)=%d want <%d before append-driven growth", got, entryHint)
 	}
 
 	allocs := testing.AllocsPerRun(1000, func() {
@@ -129,8 +132,8 @@ func TestAppendOnlyResetWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *
 	if got := len(mt.entries); got != base {
 		t.Fatalf("reset len(entries)=%d want=%d", got, base)
 	}
-	if got := cap(mt.entries); got != base {
-		t.Fatalf("reset cap(entries)=%d want=%d", got, base)
+	if got := cap(mt.entries); got >= entryHint {
+		t.Fatalf("reset cap(entries)=%d want <%d before append-driven growth", got, entryHint)
 	}
 	if got := mt.growEntriesLen; got < entryHint {
 		t.Fatalf("growEntriesLen=%d want >=%d", got, entryHint)

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -79,7 +79,7 @@ func TestAppendOnlyResetWithCapacity_RetainsObservedEntriesWithinBound(t *testin
 	}
 }
 
-func TestAppendOnlyNewWithCapacityAndEntryHint_PreallocatesHintedEntries(t *testing.T) {
+func TestAppendOnlyNewWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *testing.T) {
 	const (
 		capacityBytes          = 4 << 10
 		estimatedBytesPerEntry = 96
@@ -88,20 +88,22 @@ func TestAppendOnlyNewWithCapacityAndEntryHint_PreallocatesHintedEntries(t *test
 	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
 	entryHint := base * 16
 	mt := NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacityBytes, estimatedBytesPerEntry, entryHint)
-	if got := len(mt.entries); got < entryHint {
-		t.Fatalf("initial len(entries)=%d want>=%d", got, entryHint)
+	if got := len(mt.entries); got != base {
+		t.Fatalf("initial len(entries)=%d want=%d", got, base)
 	}
-	if got := cap(mt.entries); got < entryHint {
-		t.Fatalf("initial cap(entries)=%d want>=%d", got, entryHint)
+	if got := cap(mt.entries); got != base {
+		t.Fatalf("initial cap(entries)=%d want=%d", got, base)
+	}
+	if got := mt.growEntriesLen; got < entryHint {
+		t.Fatalf("growEntriesLen=%d want >=%d", got, entryHint)
 	}
 
-	capBefore := cap(mt.entries)
-	for i := 0; i < entryHint; i++ {
+	for i := 0; i <= base; i++ {
 		key := []byte(fmt.Sprintf("h%08d", i))
 		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
 	}
-	if got := cap(mt.entries); got != capBefore {
-		t.Fatalf("hinted constructor regrew entries: cap(entries)=%d want=%d", got, capBefore)
+	if got := cap(mt.entries); got < entryHint {
+		t.Fatalf("cap(entries) after first growth=%d want >=%d", got, entryHint)
 	}
 }
 

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -79,7 +79,7 @@ func TestAppendOnlyResetWithCapacity_RetainsObservedEntriesWithinBound(t *testin
 	}
 }
 
-func TestAppendOnlyResetWithCapacityAndEntryHint_PreallocatesHintedEntries(t *testing.T) {
+func TestAppendOnlyNewWithCapacityAndEntryHint_PreallocatesHintedEntries(t *testing.T) {
 	const (
 		capacityBytes          = 4 << 10
 		estimatedBytesPerEntry = 96
@@ -103,21 +103,48 @@ func TestAppendOnlyResetWithCapacityAndEntryHint_PreallocatesHintedEntries(t *te
 	if got := cap(mt.entries); got != capBefore {
 		t.Fatalf("hinted constructor regrew entries: cap(entries)=%d want=%d", got, capBefore)
 	}
+}
 
-	mt.ResetWithCapacityAndEntryHint(capacityBytes, estimatedBytesPerEntry, entryHint)
-	if got := len(mt.entries); got < entryHint {
-		t.Fatalf("reset len(entries)=%d want>=%d", got, entryHint)
-	}
-	if got := cap(mt.entries); got < entryHint {
-		t.Fatalf("reset cap(entries)=%d want>=%d", got, entryHint)
+func TestAppendOnlyResetWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *testing.T) {
+	const (
+		capacityBytes          = 4 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	entryHint := base * 16
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	if got := cap(mt.entries); got != base {
+		t.Fatalf("initial cap(entries)=%d want=%d", got, base)
 	}
 
-	capAfterReset := cap(mt.entries)
+	allocs := testing.AllocsPerRun(1000, func() {
+		mt.ResetWithCapacityAndEntryHint(capacityBytes, estimatedBytesPerEntry, entryHint)
+	})
+	if allocs > 0 {
+		t.Fatalf("reset allocs/run=%f want 0", allocs)
+	}
+	if got := len(mt.entries); got != base {
+		t.Fatalf("reset len(entries)=%d want=%d", got, base)
+	}
+	if got := cap(mt.entries); got != base {
+		t.Fatalf("reset cap(entries)=%d want=%d", got, base)
+	}
+	if got := mt.growEntriesLen; got < entryHint {
+		t.Fatalf("growEntriesLen=%d want >=%d", got, entryHint)
+	}
+
 	for i := 0; i < entryHint; i++ {
 		key := []byte(fmt.Sprintf("r%08d", i))
 		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
 	}
-	if got := cap(mt.entries); got != capAfterReset {
-		t.Fatalf("hinted reset regrew entries: cap(entries)=%d want=%d", got, capAfterReset)
+	capAfterGrowth := cap(mt.entries)
+	if capAfterGrowth < entryHint {
+		t.Fatalf("grown cap(entries)=%d want >=%d", capAfterGrowth, entryHint)
+	}
+
+	mt.ResetWithCapacityAndEntryHint(capacityBytes, estimatedBytesPerEntry, entryHint)
+	if got := cap(mt.entries); got != capAfterGrowth {
+		t.Fatalf("warm hinted cap(entries)=%d want=%d", got, capAfterGrowth)
 	}
 }

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -78,3 +78,46 @@ func TestAppendOnlyResetWithCapacity_RetainsObservedEntriesWithinBound(t *testin
 		t.Fatalf("entries regrew after warm reset: cap(entries)=%d want=%d", got, capBeforeReset)
 	}
 }
+
+func TestAppendOnlyResetWithCapacityAndEntryHint_PreallocatesHintedEntries(t *testing.T) {
+	const (
+		capacityBytes          = 4 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	entryHint := base * 16
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacityBytes, estimatedBytesPerEntry, entryHint)
+	if got := len(mt.entries); got < entryHint {
+		t.Fatalf("initial len(entries)=%d want>=%d", got, entryHint)
+	}
+	if got := cap(mt.entries); got < entryHint {
+		t.Fatalf("initial cap(entries)=%d want>=%d", got, entryHint)
+	}
+
+	capBefore := cap(mt.entries)
+	for i := 0; i < entryHint; i++ {
+		key := []byte(fmt.Sprintf("h%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+	if got := cap(mt.entries); got != capBefore {
+		t.Fatalf("hinted constructor regrew entries: cap(entries)=%d want=%d", got, capBefore)
+	}
+
+	mt.ResetWithCapacityAndEntryHint(capacityBytes, estimatedBytesPerEntry, entryHint)
+	if got := len(mt.entries); got < entryHint {
+		t.Fatalf("reset len(entries)=%d want>=%d", got, entryHint)
+	}
+	if got := cap(mt.entries); got < entryHint {
+		t.Fatalf("reset cap(entries)=%d want>=%d", got, entryHint)
+	}
+
+	capAfterReset := cap(mt.entries)
+	for i := 0; i < entryHint; i++ {
+		key := []byte(fmt.Sprintf("r%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+	if got := cap(mt.entries); got != capAfterReset {
+		t.Fatalf("hinted reset regrew entries: cap(entries)=%d want=%d", got, capAfterReset)
+	}
+}

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -91,9 +91,6 @@ func TestAppendOnlyNewWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *te
 	if got := len(mt.entries); got != base {
 		t.Fatalf("initial len(entries)=%d want=%d", got, base)
 	}
-	if got := cap(mt.entries); got >= entryHint {
-		t.Fatalf("initial cap(entries)=%d want <%d before append-driven growth", got, entryHint)
-	}
 	if got := mt.growEntriesLen; got < entryHint {
 		t.Fatalf("growEntriesLen=%d want >=%d", got, entryHint)
 	}
@@ -119,9 +116,6 @@ func TestAppendOnlyResetWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *
 	if got := len(mt.entries); got != base {
 		t.Fatalf("initial len(entries)=%d want=%d", got, base)
 	}
-	if got := cap(mt.entries); got >= entryHint {
-		t.Fatalf("initial cap(entries)=%d want <%d before append-driven growth", got, entryHint)
-	}
 
 	allocs := testing.AllocsPerRun(1000, func() {
 		mt.ResetWithCapacityAndEntryHint(capacityBytes, estimatedBytesPerEntry, entryHint)
@@ -131,9 +125,6 @@ func TestAppendOnlyResetWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *
 	}
 	if got := len(mt.entries); got != base {
 		t.Fatalf("reset len(entries)=%d want=%d", got, base)
-	}
-	if got := cap(mt.entries); got >= entryHint {
-		t.Fatalf("reset cap(entries)=%d want <%d before append-driven growth", got, entryHint)
 	}
 	if got := mt.growEntriesLen; got < entryHint {
 		t.Fatalf("growEntriesLen=%d want >=%d", got, entryHint)

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -96,8 +96,11 @@ func TestAppendOnlyEntryHintDoesNotRaiseInitialCapacityBeyondBudget(t *testing.T
 	hint := appendOnlyMaxInitialEntries
 
 	m := NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, appendOnlyEstimatedBytesPerEntryPointer, hint)
-	if got := cap(m.entries); got != appendOnlyMinInitialEntries {
-		t.Fatalf("initial cap(entries)=%d want %d", got, appendOnlyMinInitialEntries)
+	if got := len(m.entries); got != appendOnlyMinInitialEntries {
+		t.Fatalf("initial len(entries)=%d want %d", got, appendOnlyMinInitialEntries)
+	}
+	if got := cap(m.entries); got >= hint {
+		t.Fatalf("initial cap(entries)=%d want < hint %d", got, hint)
 	}
 	if got := m.baseEntriesLen; got != appendOnlyMinInitialEntries {
 		t.Fatalf("baseEntriesLen=%d want %d", got, appendOnlyMinInitialEntries)

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -91,6 +91,22 @@ func TestAppendOnlyInitialEntriesForCapacity(t *testing.T) {
 	})
 }
 
+func TestAppendOnlyEntryHintDoesNotRaiseInitialCapacityBeyondBudget(t *testing.T) {
+	capacity := appendOnlyMinInitialEntries * appendOnlyEstimatedBytesPerEntryPointer
+	hint := appendOnlyMaxInitialEntries
+
+	m := NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, appendOnlyEstimatedBytesPerEntryPointer, hint)
+	if got := cap(m.entries); got != appendOnlyMinInitialEntries {
+		t.Fatalf("initial cap(entries)=%d want %d", got, appendOnlyMinInitialEntries)
+	}
+	if got := m.baseEntriesLen; got != appendOnlyMinInitialEntries {
+		t.Fatalf("baseEntriesLen=%d want %d", got, appendOnlyMinInitialEntries)
+	}
+	if got := m.growEntriesLen; got != hint {
+		t.Fatalf("growEntriesLen=%d want hint floor %d", got, hint)
+	}
+}
+
 func TestAppendOnlyCRUD(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -99,9 +99,6 @@ func TestAppendOnlyEntryHintDoesNotRaiseInitialCapacityBeyondBudget(t *testing.T
 	if got := len(m.entries); got != appendOnlyMinInitialEntries {
 		t.Fatalf("initial len(entries)=%d want %d", got, appendOnlyMinInitialEntries)
 	}
-	if got := cap(m.entries); got >= hint {
-		t.Fatalf("initial cap(entries)=%d want < hint %d", got, hint)
-	}
 	if got := m.baseEntriesLen; got != appendOnlyMinInitialEntries {
 		t.Fatalf("baseEntriesLen=%d want %d", got, appendOnlyMinInitialEntries)
 	}

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -36,6 +36,7 @@ func TestAppendOnlyInlineGrowthSkipsIntermediateDoublingBelowCutoff(t *testing.T
 	mt := &AppendOnly{
 		entries:        make([]appendOnlyEntry, appendOnlyMinInitialEntries),
 		baseEntriesLen: appendOnlyMinInitialEntries,
+		growEntriesLen: appendOnlyMinInitialEntries,
 		ordered:        true,
 		lastIdx:        -1,
 	}


### PR DESCRIPTION
## Summary
- thread the existing append-only entry hint through new and recycled append-only mutable memtables
- keep recycled mutables sized for recent tiny-entry workloads instead of falling back to the byte-only baseline
- add regression coverage that hinted construction and reset avoid regrowth across repeated fills

## Validation
- `go test ./TreeDB/internal/memtable ./TreeDB/caching`
- exact benchmark: `./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_append_only_entry_hint_1776902033 -test batch_delete`
- `Batch Delete: 3,802,949`