### PR TITLE
Avoid full-page leaf payload compaction copies

### DIFF
--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -33,17 +33,15 @@ func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
 	}
 
 	suffixStart := len(leafPage) - suffixLen
-	var canonical [page.PageSize]byte
-	copy(canonical[:prefixLen], leafPage[:prefixLen])
-	copy(canonical[suffixStart:], leafPage[suffixStart:])
-	page.UpdateChecksum(canonical[:])
-
 	payload := make([]byte, compactLen)
 	copy(payload[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:])
 	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic):len(compactLeafPagePayloadMagic)+2], uint16(prefixLen))
 	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic)+2:compactLeafPagePayloadHeaderSize], uint16(suffixLen))
-	copy(payload[compactLeafPagePayloadHeaderSize:compactLeafPagePayloadHeaderSize+prefixLen], canonical[:prefixLen])
-	copy(payload[compactLeafPagePayloadHeaderSize+prefixLen:], canonical[suffixStart:])
+	prefixDst := payload[compactLeafPagePayloadHeaderSize : compactLeafPagePayloadHeaderSize+prefixLen]
+	suffixDst := payload[compactLeafPagePayloadHeaderSize+prefixLen:]
+	copy(prefixDst, leafPage[:prefixLen])
+	copy(suffixDst, leafPage[suffixStart:])
+	page.UpdateChecksumPrefixSuffix(prefixDst, suffixDst, page.PageSize)
 	return payload, true, nil
 }
 

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -110,6 +110,26 @@ func TestMaybeCompactLeafLogPayload_SparseLeafRoundTrips(t *testing.T) {
 	requireLeafPagesLogicallyEqual(t, leaf, decoded)
 }
 
+func TestMaybeCompactLeafLogPayload_SparseLeafAllocatesOnlyPayload(t *testing.T) {
+	leaf := buildSparseLeafPageForPayloadTest(t)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+		if err != nil {
+			t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+		}
+		if !compacted {
+			t.Fatalf("expected sparse leaf page to compact")
+		}
+		if len(payload) >= len(leaf) {
+			t.Fatalf("payload len=%d want < %d", len(payload), len(leaf))
+		}
+	})
+	if allocs > 1.1 {
+		t.Fatalf("allocs/run=%f want <= 1.1", allocs)
+	}
+}
+
 func TestDecodeCompactLeafLogPayloadTo_AliasedDstRoundTrips(t *testing.T) {
 	leaf := buildSparseLeafPageForPayloadTest(t)
 

--- a/TreeDB/page/page.go
+++ b/TreeDB/page/page.go
@@ -69,6 +69,7 @@ type ValuePtr struct {
 // CRC32C Table using Castagnoli polynomial.
 var crcTable = crc32.MakeTable(crc32.Castagnoli)
 var checksumZeroField = [4]byte{}
+var checksumZeroChunk = [256]byte{}
 
 // Checksum returns the CRC32C checksum of data.
 func Checksum(data []byte) uint32 {
@@ -102,6 +103,53 @@ func UpdateChecksum(data []byte) uint32 {
 	data[11] = 0
 	sum := crc32.Checksum(data, crcTable)
 	binary.LittleEndian.PutUint32(data[8:12], sum)
+	return sum
+}
+
+func updateChecksumZeros(sum uint32, count int) uint32 {
+	for count > 0 {
+		n := count
+		if n > len(checksumZeroChunk) {
+			n = len(checksumZeroChunk)
+		}
+		sum = crc32.Update(sum, crcTable, checksumZeroChunk[:n])
+		count -= n
+	}
+	return sum
+}
+
+func updateChecksumSegment(sum uint32, segment []byte, segmentStart, maskStart, maskEnd int) uint32 {
+	segEnd := segmentStart + len(segment)
+	if segEnd <= maskStart || segmentStart >= maskEnd {
+		return crc32.Update(sum, crcTable, segment)
+	}
+	if segmentStart < maskStart {
+		sum = crc32.Update(sum, crcTable, segment[:maskStart-segmentStart])
+	}
+	overlapStart := max(segmentStart, maskStart)
+	overlapEnd := min(segEnd, maskEnd)
+	sum = updateChecksumZeros(sum, overlapEnd-overlapStart)
+	if overlapEnd < segEnd {
+		sum = crc32.Update(sum, crcTable, segment[overlapEnd-segmentStart:])
+	}
+	return sum
+}
+
+// UpdateChecksumPrefixSuffix computes CRC32C for a page represented by a
+// prefix segment at offset 0, a zero-filled middle gap, and a suffix segment at
+// the end of the page. Checksum bytes 8-11 are treated as zero, and when the
+// prefix covers them the computed checksum is written back into prefix[8:12].
+func UpdateChecksumPrefixSuffix(prefix, suffix []byte, totalLen int) uint32 {
+	if totalLen < PageHeaderSize || len(prefix)+len(suffix) > totalLen {
+		return 0
+	}
+	suffixStart := totalLen - len(suffix)
+	sum := updateChecksumSegment(0, prefix, 0, 8, 12)
+	sum = updateChecksumZeros(sum, suffixStart-len(prefix))
+	sum = updateChecksumSegment(sum, suffix, suffixStart, 8, 12)
+	if len(prefix) >= 12 {
+		binary.LittleEndian.PutUint32(prefix[8:12], sum)
+	}
 	return sum
 }
 

--- a/TreeDB/page/page_test.go
+++ b/TreeDB/page/page_test.go
@@ -131,6 +131,36 @@ func TestUpdateChecksum(t *testing.T) {
 	}
 }
 
+func TestUpdateChecksumPrefixSuffixMatchesFullPage(t *testing.T) {
+	full := make([]byte, PageSize)
+	for i := range full {
+		full[i] = byte((i * 17) & 0xff)
+	}
+	prefixLen := 320
+	suffixLen := 192
+	suffixStart := len(full) - suffixLen
+
+	canonical := make([]byte, len(full))
+	copy(canonical[:prefixLen], full[:prefixLen])
+	copy(canonical[suffixStart:], full[suffixStart:])
+	want := UpdateChecksum(canonical)
+
+	prefix := append([]byte(nil), full[:prefixLen]...)
+	suffix := append([]byte(nil), full[suffixStart:]...)
+	got := UpdateChecksumPrefixSuffix(prefix, suffix, len(full))
+	if got != want {
+		t.Fatalf("UpdateChecksumPrefixSuffix returned 0x%x, want 0x%x", got, want)
+	}
+	if binary.LittleEndian.Uint32(prefix[8:12]) != want {
+		t.Fatalf("prefix checksum field = 0x%x, want 0x%x", binary.LittleEndian.Uint32(prefix[8:12]), want)
+	}
+	copy(canonical[:prefixLen], prefix)
+	copy(canonical[suffixStart:], suffix)
+	if !VerifyChecksumNonMutating(canonical) {
+		t.Fatalf("sparse checksum should verify after prefix/suffix update")
+	}
+}
+
 func TestUnsafeCastHeader(t *testing.T) {
 	// Note: This test assumes LittleEndian machine.
 	// If running on BigEndian, this test might fail or require adjustment if UnsafeCastHeader is used.


### PR DESCRIPTION
## Summary
- stop building a full 4KiB canonical page inside `MaybeCompactLeafLogPayload`
- compute the page checksum directly from the compact payload prefix and suffix segments
- add checksum parity and allocation regression coverage for sparse leaf payloads

## Validation
- `go test ./TreeDB/page ./TreeDB/internal/valuelog`
- exact benchmark: `./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_compact_leaf_payload_1776902063 -test batch_delete`
- `Batch Delete: 4,351,462`
- alloc space on that run: `3.67GB` total, with `MaybeCompactLeafLogPayload` down to `552.15MB` from `1.42GB` on the original exact profile