### PR TITLE
Reuse batch_delete benchmark batches

### DIFF
--- a/cmd/unified_bench/batch_delete_test.go
+++ b/cmd/unified_bench/batch_delete_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/snissn/gomap/kvstore"
@@ -107,6 +108,40 @@ func (b *batchDeleteFallbackBatch) Close() error {
 	return nil
 }
 
+type batchDeleteErrorDB struct {
+	batch *batchDeleteErrorBatch
+}
+
+func (d *batchDeleteErrorDB) Name() string                   { return "BatchDeleteError" }
+func (d *batchDeleteErrorDB) Close() error                   { return nil }
+func (d *batchDeleteErrorDB) Get(key []byte) ([]byte, error) { return nil, nil }
+func (d *batchDeleteErrorDB) Delete(key []byte) error        { return nil }
+func (d *batchDeleteErrorDB) Set(key, value []byte) error    { return nil }
+func (d *batchDeleteErrorDB) NewBatch() (kvstore.Batch, error) {
+	return d.NewBatchWithSize(0)
+}
+func (d *batchDeleteErrorDB) NewBatchWithSize(size int) (kvstore.Batch, error) {
+	d.batch = &batchDeleteErrorBatch{}
+	return d.batch, nil
+}
+
+type batchDeleteErrorBatch struct {
+	deleteCalls int
+	closeCalls  int
+}
+
+func (b *batchDeleteErrorBatch) Set(key, value []byte) error { return nil }
+func (b *batchDeleteErrorBatch) Delete(key []byte) error {
+	b.deleteCalls++
+	return errors.New("delete failed")
+}
+func (b *batchDeleteErrorBatch) Commit() error     { return nil }
+func (b *batchDeleteErrorBatch) CommitSync() error { return b.Commit() }
+func (b *batchDeleteErrorBatch) Close() error {
+	b.closeCalls++
+	return nil
+}
+
 func TestRunBenchmark_BatchDelete_ReusesResettableDeleteViewBatch(t *testing.T) {
 	const dbName = "batch_delete_fast_path_mock"
 	var db *batchDeleteFastPathDB
@@ -165,6 +200,40 @@ func TestRunBenchmark_BatchDelete_ReusesResettableDeleteViewBatch(t *testing.T) 
 		t.Fatalf("Reset calls=%d want=%d", got, want)
 	}
 	if got, want := b.closeCalls, 1; got != want {
+		t.Fatalf("Close calls=%d want=%d", got, want)
+	}
+}
+
+func TestRunBenchmark_BatchDelete_ClosesOnceOnDeleteError(t *testing.T) {
+	const dbName = "batch_delete_error_mock"
+	var db *batchDeleteErrorDB
+	RegisterHiddenDB(dbName, func(_ string) (kvstore.DB, error) {
+		db = &batchDeleteErrorDB{}
+		return db, nil
+	})
+
+	_, err := runBenchmark(BenchConfig{
+		Keys:         1,
+		ValueSize:    16,
+		BatchSize:    1,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       dbName,
+		TestsArg:     "batch_delete",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+	})
+	if err == nil {
+		t.Fatal("expected batch_delete error")
+	}
+	if db == nil || db.batch == nil {
+		t.Fatal("expected failing batch to be created")
+	}
+	if got, want := db.batch.deleteCalls, 1; got != want {
+		t.Fatalf("Delete calls=%d want=%d", got, want)
+	}
+	if got, want := db.batch.closeCalls, 1; got != want {
 		t.Fatalf("Close calls=%d want=%d", got, want)
 	}
 }

--- a/cmd/unified_bench/batch_delete_test.go
+++ b/cmd/unified_bench/batch_delete_test.go
@@ -2,10 +2,24 @@ package main
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/snissn/gomap/kvstore"
 )
+
+func registerHiddenDBForTest(t *testing.T, name string, factory DBFactory) {
+	t.Helper()
+	prev, hadPrev := dbFactories[name]
+	RegisterHiddenDB(name, factory)
+	t.Cleanup(func() {
+		if hadPrev {
+			dbFactories[name] = prev
+			return
+		}
+		delete(dbFactories, name)
+	})
+}
 
 type batchDeleteFastPathDB struct {
 	newBatchCalls         int
@@ -142,10 +156,21 @@ func (b *batchDeleteErrorBatch) Close() error {
 	return nil
 }
 
+type batchDeleteNilBatchDB struct{}
+
+func (d *batchDeleteNilBatchDB) Name() string                   { return "BatchDeleteNilBatch" }
+func (d *batchDeleteNilBatchDB) Close() error                   { return nil }
+func (d *batchDeleteNilBatchDB) Get(key []byte) ([]byte, error) { return nil, nil }
+func (d *batchDeleteNilBatchDB) Delete(key []byte) error        { return nil }
+func (d *batchDeleteNilBatchDB) Set(key, value []byte) error    { return nil }
+func (d *batchDeleteNilBatchDB) NewBatch() (kvstore.Batch, error) {
+	return nil, nil
+}
+
 func TestRunBenchmark_BatchDelete_ReusesResettableDeleteViewBatch(t *testing.T) {
 	const dbName = "batch_delete_fast_path_mock"
 	var db *batchDeleteFastPathDB
-	RegisterHiddenDB(dbName, func(_ string) (kvstore.DB, error) {
+	registerHiddenDBForTest(t, dbName, func(_ string) (kvstore.DB, error) {
 		db = &batchDeleteFastPathDB{}
 		return db, nil
 	})
@@ -207,7 +232,7 @@ func TestRunBenchmark_BatchDelete_ReusesResettableDeleteViewBatch(t *testing.T) 
 func TestRunBenchmark_BatchDelete_ClosesOnceOnDeleteError(t *testing.T) {
 	const dbName = "batch_delete_error_mock"
 	var db *batchDeleteErrorDB
-	RegisterHiddenDB(dbName, func(_ string) (kvstore.DB, error) {
+	registerHiddenDBForTest(t, dbName, func(_ string) (kvstore.DB, error) {
 		db = &batchDeleteErrorDB{}
 		return db, nil
 	})
@@ -241,7 +266,7 @@ func TestRunBenchmark_BatchDelete_ClosesOnceOnDeleteError(t *testing.T) {
 func TestRunBenchmark_BatchDelete_FallsBackWithoutDeleteViewOrReset(t *testing.T) {
 	const dbName = "batch_delete_fallback_mock"
 	var db *batchDeleteFallbackDB
-	RegisterHiddenDB(dbName, func(_ string) (kvstore.DB, error) {
+	registerHiddenDBForTest(t, dbName, func(_ string) (kvstore.DB, error) {
 		db = &batchDeleteFallbackDB{}
 		return db, nil
 	})
@@ -289,5 +314,31 @@ func TestRunBenchmark_BatchDelete_FallsBackWithoutDeleteViewOrReset(t *testing.T
 		if got, want := b.closeCalls, 1; got != want {
 			t.Fatalf("batch %d Close calls=%d want=%d", i, got, want)
 		}
+	}
+}
+
+func TestRunBenchmark_BatchDelete_NilBatchReturnsError(t *testing.T) {
+	const dbName = "batch_delete_nil_batch_mock"
+	registerHiddenDBForTest(t, dbName, func(_ string) (kvstore.DB, error) {
+		return &batchDeleteNilBatchDB{}, nil
+	})
+
+	_, err := runBenchmark(BenchConfig{
+		Keys:         1,
+		ValueSize:    16,
+		BatchSize:    1,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       dbName,
+		TestsArg:     "batch_delete",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+	})
+	if err == nil {
+		t.Fatal("expected nil batch error")
+	}
+	if !strings.Contains(err.Error(), "new batch returned nil") {
+		t.Fatalf("error=%q want nil batch message", err)
 	}
 }

--- a/cmd/unified_bench/batch_delete_test.go
+++ b/cmd/unified_bench/batch_delete_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/kvstore"
+)
+
+type batchDeleteFastPathDB struct {
+	newBatchCalls         int
+	newBatchWithSizeCalls int
+	setCalls              int
+	batches               []*batchDeleteFastPathBatch
+}
+
+func (d *batchDeleteFastPathDB) Name() string                   { return "BatchDeleteFastPath" }
+func (d *batchDeleteFastPathDB) Close() error                   { return nil }
+func (d *batchDeleteFastPathDB) Get(key []byte) ([]byte, error) { return nil, nil }
+func (d *batchDeleteFastPathDB) Delete(key []byte) error        { return nil }
+func (d *batchDeleteFastPathDB) Set(key, value []byte) error    { d.setCalls++; return nil }
+func (d *batchDeleteFastPathDB) NewBatch() (kvstore.Batch, error) {
+	d.newBatchCalls++
+	return d.newTrackedBatch(), nil
+}
+func (d *batchDeleteFastPathDB) newTrackedBatch() *batchDeleteFastPathBatch {
+	b := &batchDeleteFastPathBatch{}
+	d.batches = append(d.batches, b)
+	return b
+}
+
+func (d *batchDeleteFastPathDB) NewBatchWithSize(size int) (kvstore.Batch, error) {
+	d.newBatchWithSizeCalls++
+	b := d.newTrackedBatch()
+	b.sizeHint = size
+	return b, nil
+}
+
+type batchDeleteFastPathBatch struct {
+	sizeHint        int
+	deleteCalls     int
+	deleteViewCalls int
+	commitCalls     int
+	resetCalls      int
+	closeCalls      int
+}
+
+func (b *batchDeleteFastPathBatch) Set(key, value []byte) error { return nil }
+func (b *batchDeleteFastPathBatch) Delete(key []byte) error {
+	b.deleteCalls++
+	return nil
+}
+func (b *batchDeleteFastPathBatch) DeleteView(key []byte) error {
+	b.deleteViewCalls++
+	return nil
+}
+func (b *batchDeleteFastPathBatch) Commit() error {
+	b.commitCalls++
+	return nil
+}
+func (b *batchDeleteFastPathBatch) CommitSync() error { return b.Commit() }
+func (b *batchDeleteFastPathBatch) Close() error {
+	b.closeCalls++
+	return nil
+}
+func (b *batchDeleteFastPathBatch) Reset() { b.resetCalls++ }
+
+type batchDeleteFallbackDB struct {
+	newBatchWithSizeCalls int
+	setCalls              int
+	batches               []*batchDeleteFallbackBatch
+}
+
+func (d *batchDeleteFallbackDB) Name() string                   { return "BatchDeleteFallback" }
+func (d *batchDeleteFallbackDB) Close() error                   { return nil }
+func (d *batchDeleteFallbackDB) Get(key []byte) ([]byte, error) { return nil, nil }
+func (d *batchDeleteFallbackDB) Delete(key []byte) error        { return nil }
+func (d *batchDeleteFallbackDB) Set(key, value []byte) error    { d.setCalls++; return nil }
+func (d *batchDeleteFallbackDB) NewBatch() (kvstore.Batch, error) {
+	return d.NewBatchWithSize(0)
+}
+func (d *batchDeleteFallbackDB) NewBatchWithSize(size int) (kvstore.Batch, error) {
+	d.newBatchWithSizeCalls++
+	b := &batchDeleteFallbackBatch{sizeHint: size}
+	d.batches = append(d.batches, b)
+	return b, nil
+}
+
+type batchDeleteFallbackBatch struct {
+	sizeHint    int
+	deleteCalls int
+	commitCalls int
+	closeCalls  int
+}
+
+func (b *batchDeleteFallbackBatch) Set(key, value []byte) error { return nil }
+func (b *batchDeleteFallbackBatch) Delete(key []byte) error {
+	b.deleteCalls++
+	return nil
+}
+func (b *batchDeleteFallbackBatch) Commit() error {
+	b.commitCalls++
+	return nil
+}
+func (b *batchDeleteFallbackBatch) CommitSync() error { return b.Commit() }
+func (b *batchDeleteFallbackBatch) Close() error {
+	b.closeCalls++
+	return nil
+}
+
+func TestRunBenchmark_BatchDelete_ReusesResettableDeleteViewBatch(t *testing.T) {
+	const dbName = "batch_delete_fast_path_mock"
+	var db *batchDeleteFastPathDB
+	RegisterHiddenDB(dbName, func(_ string) (kvstore.DB, error) {
+		db = &batchDeleteFastPathDB{}
+		return db, nil
+	})
+
+	run, err := runBenchmark(BenchConfig{
+		Keys:         5,
+		ValueSize:    16,
+		BatchSize:    2,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       dbName,
+		TestsArg:     "batch_delete",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	if got := run.Results["batch_delete"]["BatchDeleteFastPath"]; got <= 0 {
+		t.Fatalf("batch_delete result=%v want > 0", got)
+	}
+	if db == nil {
+		t.Fatal("expected db to be initialized")
+	}
+	if got, want := db.setCalls, 5; got != want {
+		t.Fatalf("preload Set calls=%d want=%d", got, want)
+	}
+	if got, want := db.newBatchCalls, 0; got != want {
+		t.Fatalf("NewBatch calls=%d want=%d", got, want)
+	}
+	if got, want := db.newBatchWithSizeCalls, 1; got != want {
+		t.Fatalf("NewBatchWithSize calls=%d want=%d", got, want)
+	}
+	if got, want := len(db.batches), 1; got != want {
+		t.Fatalf("batch instances=%d want=%d", got, want)
+	}
+	b := db.batches[0]
+	if got, want := b.sizeHint, 2; got != want {
+		t.Fatalf("size hint=%d want=%d", got, want)
+	}
+	if got, want := b.deleteViewCalls, 5; got != want {
+		t.Fatalf("DeleteView calls=%d want=%d", got, want)
+	}
+	if got, want := b.deleteCalls, 0; got != want {
+		t.Fatalf("Delete calls=%d want=%d", got, want)
+	}
+	if got, want := b.commitCalls, 3; got != want {
+		t.Fatalf("Commit calls=%d want=%d", got, want)
+	}
+	if got, want := b.resetCalls, 2; got != want {
+		t.Fatalf("Reset calls=%d want=%d", got, want)
+	}
+	if got, want := b.closeCalls, 1; got != want {
+		t.Fatalf("Close calls=%d want=%d", got, want)
+	}
+}
+
+func TestRunBenchmark_BatchDelete_FallsBackWithoutDeleteViewOrReset(t *testing.T) {
+	const dbName = "batch_delete_fallback_mock"
+	var db *batchDeleteFallbackDB
+	RegisterHiddenDB(dbName, func(_ string) (kvstore.DB, error) {
+		db = &batchDeleteFallbackDB{}
+		return db, nil
+	})
+
+	run, err := runBenchmark(BenchConfig{
+		Keys:         5,
+		ValueSize:    16,
+		BatchSize:    2,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       dbName,
+		TestsArg:     "batch_delete",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	if got := run.Results["batch_delete"]["BatchDeleteFallback"]; got <= 0 {
+		t.Fatalf("batch_delete result=%v want > 0", got)
+	}
+	if db == nil {
+		t.Fatal("expected db to be initialized")
+	}
+	if got, want := db.setCalls, 5; got != want {
+		t.Fatalf("preload Set calls=%d want=%d", got, want)
+	}
+	if got, want := db.newBatchWithSizeCalls, 3; got != want {
+		t.Fatalf("NewBatchWithSize calls=%d want=%d", got, want)
+	}
+	if got, want := len(db.batches), 3; got != want {
+		t.Fatalf("batch instances=%d want=%d", got, want)
+	}
+	for i, b := range db.batches {
+		if got, want := b.sizeHint, 2; got != want {
+			t.Fatalf("batch %d size hint=%d want=%d", i, got, want)
+		}
+		if got := b.deleteCalls; got == 0 {
+			t.Fatalf("batch %d Delete calls=%d want > 0", i, got)
+		}
+		if got, want := b.commitCalls, 1; got != want {
+			t.Fatalf("batch %d Commit calls=%d want=%d", i, got, want)
+		}
+		if got, want := b.closeCalls, 1; got != want {
+			t.Fatalf("batch %d Close calls=%d want=%d", i, got, want)
+		}
+	}
+}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -2636,6 +2636,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if err != nil {
 					return err
 				}
+				if batch == nil {
+					return fmt.Errorf("batch_delete: new batch returned nil")
+				}
 				deleteOp = batch.Delete
 				if dv, ok := batch.(batchDeleteView); ok {
 					deleteOp = dv.DeleteView

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -2646,10 +2646,18 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				}
 				return nil
 			}
-			defer func() {
-				if batch != nil {
-					_ = batch.Close()
+			closeBatch := func() error {
+				if batch == nil {
+					return nil
 				}
+				b := batch
+				batch = nil
+				deleteOp = nil
+				resetBatch = nil
+				return b.Close()
+			}
+			defer func() {
+				_ = closeBatch()
 			}()
 
 			const keySize = 8
@@ -2681,10 +2689,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				} else if resetBatch != nil {
 					resetBatch()
 				} else {
-					if err := batch.Close(); err != nil {
+					if err := closeBatch(); err != nil {
 						return 0, fmt.Errorf("batch_delete: close: %w", err)
 					}
-					batch = nil
 					if err := openBatch(); err != nil {
 						return 0, fmt.Errorf("batch_delete: new batch: %w", err)
 					}
@@ -2698,19 +2705,18 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					offset := j * keySize
 					key := allKeys[offset : offset+keySize]
 					if err := deleteOp(key); err != nil {
-						_ = batch.Close()
+						_ = closeBatch()
 						return 0, fmt.Errorf("batch_delete: delete: %w", err)
 					}
 				}
 				if err := batch.Commit(); err != nil {
-					_ = batch.Close()
+					_ = closeBatch()
 					return 0, fmt.Errorf("batch_delete: commit: %w", err)
 				}
 				if resetBatch == nil {
-					if err := batch.Close(); err != nil {
+					if err := closeBatch(); err != nil {
 						return 0, fmt.Errorf("batch_delete: close: %w", err)
 					}
-					batch = nil
 				}
 				if err := pc.Add(db, end-i, int64(end-i)*perOpBytes); err != nil {
 					return 0, fmt.Errorf("batch_delete checkpoint: %w", err)

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -2612,6 +2612,45 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			}
 			total := cfg.Keys
 			batchSize := cfg.BatchSize
+			type batcherWithSize interface {
+				NewBatchWithSize(size int) (kvstore.Batch, error)
+			}
+			type batchDeleteView interface {
+				DeleteView(key []byte) error
+			}
+			type resettableBatch interface {
+				Reset()
+			}
+			var (
+				batch      kvstore.Batch
+				deleteOp   func(key []byte) error
+				resetBatch func()
+			)
+			openBatch := func() error {
+				var err error
+				if bs, ok := batcher.(batcherWithSize); ok {
+					batch, err = bs.NewBatchWithSize(batchSize)
+				} else {
+					batch, err = batcher.NewBatch()
+				}
+				if err != nil {
+					return err
+				}
+				deleteOp = batch.Delete
+				if dv, ok := batch.(batchDeleteView); ok {
+					deleteOp = dv.DeleteView
+				}
+				resetBatch = nil
+				if rb, ok := batch.(resettableBatch); ok {
+					resetBatch = rb.Reset
+				}
+				return nil
+			}
+			defer func() {
+				if batch != nil {
+					_ = batch.Close()
+				}
+			}()
 
 			const keySize = 8
 			allKeys := make([]byte, total*keySize)
@@ -2635,9 +2674,20 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 						return 0, err
 					}
 				}
-				batch, err := batcher.NewBatch()
-				if err != nil {
-					return 0, fmt.Errorf("batch_delete: new batch: %w", err)
+				if batch == nil {
+					if err := openBatch(); err != nil {
+						return 0, fmt.Errorf("batch_delete: new batch: %w", err)
+					}
+				} else if resetBatch != nil {
+					resetBatch()
+				} else {
+					if err := batch.Close(); err != nil {
+						return 0, fmt.Errorf("batch_delete: close: %w", err)
+					}
+					batch = nil
+					if err := openBatch(); err != nil {
+						return 0, fmt.Errorf("batch_delete: new batch: %w", err)
+					}
 				}
 
 				end := i + batchSize
@@ -2647,7 +2697,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				for j := i; j < end; j++ {
 					offset := j * keySize
 					key := allKeys[offset : offset+keySize]
-					if err := batch.Delete(key); err != nil {
+					if err := deleteOp(key); err != nil {
 						_ = batch.Close()
 						return 0, fmt.Errorf("batch_delete: delete: %w", err)
 					}
@@ -2656,8 +2706,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					_ = batch.Close()
 					return 0, fmt.Errorf("batch_delete: commit: %w", err)
 				}
-				if err := batch.Close(); err != nil {
-					return 0, fmt.Errorf("batch_delete: close: %w", err)
+				if resetBatch == nil {
+					if err := batch.Close(); err != nil {
+						return 0, fmt.Errorf("batch_delete: close: %w", err)
+					}
+					batch = nil
 				}
 				if err := pc.Add(db, end-i, int64(end-i)*perOpBytes); err != nil {
 					return 0, fmt.Errorf("batch_delete checkpoint: %w", err)


### PR DESCRIPTION
## Summary
- reuse `batch_delete` batches with `NewBatchWithSize` and `Reset` when the backend supports it
- prefer `DeleteView` in the benchmark harness to avoid extra key copies
- add dedicated `batch_delete` tests for both the fast path and fallback path

## Validation
- `go test ./cmd/unified_bench`
- exact benchmark: `./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_batch_delete_reuse_1776901194 -test batch_delete`
- `Batch Delete: 3,609,197`