### PR TITLE
Predict append-only growth from live entry density

### DIFF
--- a/TreeDB/caching/append_only_hint_test.go
+++ b/TreeDB/caching/append_only_hint_test.go
@@ -1,9 +1,12 @@
 package caching
 
 import (
+	"encoding/binary"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func TestAppendOnlyEntryHint_AdaptiveDecayAndCapacityClamp(t *testing.T) {
@@ -120,5 +123,30 @@ func TestAppendOnlyEntryHint_CapacityTracksPressureScaledMutableThreshold(t *tes
 
 	if !(critical < high && high < normal) {
 		t.Fatalf("expected stricter caps under pressure: normal=%d high=%d critical=%d", normal, high, critical)
+	}
+}
+
+func TestAppendOnlyPredictiveHintUpdatesSharedEntryHint(t *testing.T) {
+	db := &DB{backend: NewMockBackend()}
+	const capacity = 128 << 10
+
+	before := db.appendOnlyEntryHintEntries()
+	raw, err := db.newMutableMemtableWithCapacityMode(capacity, memtable.ModeAppendOnly)
+	if err != nil {
+		t.Fatalf("newMutableMemtableWithCapacityMode: %v", err)
+	}
+	mt, ok := raw.(*memtable.AppendOnly)
+	if !ok {
+		t.Fatalf("expected append-only memtable, got %T", raw)
+	}
+
+	for i := 0; i < 1<<10; i++ {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(i+1))
+		mt.Delete(key[:])
+	}
+
+	if got := int(db.appendOnlyEntryHint.Load()); got <= before {
+		t.Fatalf("shared entry hint=%d want > %d after predictive observation", got, before)
 	}
 }

--- a/TreeDB/caching/append_only_hint_test.go
+++ b/TreeDB/caching/append_only_hint_test.go
@@ -150,3 +150,31 @@ func TestAppendOnlyPredictiveHintUpdatesSharedEntryHint(t *testing.T) {
 		t.Fatalf("shared entry hint=%d want > %d after predictive observation", got, before)
 	}
 }
+
+func TestAppendOnlyOpenSeedsPredictiveHintOnInitialMutables(t *testing.T) {
+	backend := NewMockBackend()
+	db, err := Open(t.TempDir(), backend, Options{
+		AllowUnsafe:    true,
+		DisableWAL:     true,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+		FlushThreshold: 128 << 10,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mt, ok := db.mutableShards[0].mem.(*memtable.AppendOnly)
+	if !ok {
+		t.Fatalf("initial mutable type=%T want *memtable.AppendOnly", db.mutableShards[0].mem)
+	}
+	for i := 0; i < 1<<10; i++ {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(i+1))
+		mt.Delete(key[:])
+	}
+	if got := int(db.appendOnlyEntryHint.Load()); got == 0 {
+		t.Fatalf("expected initial mutable predictive observation")
+	}
+}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7738,12 +7738,14 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 		if mt := db.popAppendOnlyMemLease(); mt != nil {
 			db.appendOnlyMemLeaseHitTotal.Add(1)
 			mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
+			mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
 			return mt, nil
 		}
 		if v := db.appendOnlyMemPool.Get(); v != nil {
 			if mt, ok := v.(*memtable.AppendOnly); ok && mt != nil {
 				db.appendOnlyMemPoolHitTotal.Add(1)
 				mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
+				mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
 				return mt, nil
 			}
 		}
@@ -7754,7 +7756,9 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 			db.appendOnlyMemNewAllocQueueBytes.Add(uint64(backlog))
 		}
 		db.appendOnlyMemNewAllocTotal.Add(1)
-		return memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimate, entryHint), nil
+		mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimate, entryHint)
+		mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
+		return mt, nil
 	}
 	return memtable.NewWithCapacityModeAndIndexer(capacity, mode, db.hashSortedIndexer)
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7738,14 +7738,14 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 		if mt := db.popAppendOnlyMemLease(); mt != nil {
 			db.appendOnlyMemLeaseHitTotal.Add(1)
 			mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
-			mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
+			db.setAppendOnlyPredictiveGrowthHint(mt, capacity)
 			return mt, nil
 		}
 		if v := db.appendOnlyMemPool.Get(); v != nil {
 			if mt, ok := v.(*memtable.AppendOnly); ok && mt != nil {
 				db.appendOnlyMemPoolHitTotal.Add(1)
 				mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
-				mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
+				db.setAppendOnlyPredictiveGrowthHint(mt, capacity)
 				return mt, nil
 			}
 		}
@@ -7757,10 +7757,17 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 		}
 		db.appendOnlyMemNewAllocTotal.Add(1)
 		mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimate, entryHint)
-		mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
+		db.setAppendOnlyPredictiveGrowthHint(mt, capacity)
 		return mt, nil
 	}
 	return memtable.NewWithCapacityModeAndIndexer(capacity, mode, db.hashSortedIndexer)
+}
+
+func (db *DB) setAppendOnlyPredictiveGrowthHint(mt *memtable.AppendOnly, capacity int) {
+	if db == nil || mt == nil {
+		return
+	}
+	mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
 }
 
 // publishMemtablesLocked publishes a new memtable snapshot.
@@ -8020,6 +8027,9 @@ func (db *DB) resetMutableShardsLocked(nextMode memtable.Mode, reuse bool) error
 		if reuse {
 			if r, ok := any(shard.mem).(interface{ Reset() }); ok {
 				r.Reset()
+				if mt, ok := shard.mem.(*memtable.AppendOnly); ok {
+					db.setAppendOnlyPredictiveGrowthHint(mt, 0)
+				}
 				shard.appendOnlyDirectValueArena.recycleActive()
 				reused = true
 			}
@@ -8918,6 +8928,13 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		flushLaneMu:                          make([]sync.Mutex, len(lanes)),
 	}
 	db.storeMemtableMode(mode)
+	if mode == memtable.ModeAppendOnly {
+		for i := range db.mutableShards {
+			if mt, ok := db.mutableShards[i].mem.(*memtable.AppendOnly); ok {
+				db.setAppendOnlyPredictiveGrowthHint(mt, warmupCap)
+			}
+		}
+	}
 	if opts.IndexOuterLeavesInValueLog {
 		db.leafLog.id = leafLogLaneID
 		db.leafLog.vlogSeq = maxLeafVlogSeq

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7738,14 +7738,14 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 		if mt := db.popAppendOnlyMemLease(); mt != nil {
 			db.appendOnlyMemLeaseHitTotal.Add(1)
 			mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
-			mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
+			mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
 			return mt, nil
 		}
 		if v := db.appendOnlyMemPool.Get(); v != nil {
 			if mt, ok := v.(*memtable.AppendOnly); ok && mt != nil {
 				db.appendOnlyMemPoolHitTotal.Add(1)
 				mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
-				mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
+				mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
 				return mt, nil
 			}
 		}
@@ -7757,7 +7757,7 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 		}
 		db.appendOnlyMemNewAllocTotal.Add(1)
 		mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimate, entryHint)
-		mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
+		mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
 		return mt, nil
 	}
 	return memtable.NewWithCapacityModeAndIndexer(capacity, mode, db.hashSortedIndexer)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8027,7 +8027,7 @@ func (db *DB) resetMutableShardsLocked(nextMode memtable.Mode, reuse bool) error
 			if r, ok := any(shard.mem).(interface{ Reset() }); ok {
 				r.Reset()
 				if mt, ok := shard.mem.(*memtable.AppendOnly); ok {
-					db.setAppendOnlyPredictiveGrowthHint(mt, 0)
+					db.setAppendOnlyPredictiveGrowthHint(mt, db.memtableCap)
 				}
 				shard.appendOnlyDirectValueArena.recycleActive()
 				reused = true

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -273,15 +273,17 @@ func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedByte
 }
 
 // SetPredictiveGrowthHint configures a best-effort growth forecast for future
-// appends. capacityHintBytes is converted to an entry target from the observed
-// average entry size; entryHintSource supplies a shared floor learned from other
+// appends. A positive capacityHintBytes is converted to an entry target from the
+// observed average entry size; a non-positive value disables capacity-based
+// prediction while still allowing entryHintSource and observeEntries to be
+// configured. entryHintSource supplies a shared floor learned from other
 // append-only memtables. observeEntries is called after the memtable mutex is
 // released and must be non-blocking because it can run on the write path.
 func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, entryHintSource *atomic.Int32, observeEntries func(int)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if capacityHintBytes <= 0 {
-		capacityHintBytes = defaultMemtableCapacity
+		capacityHintBytes = 0
 	}
 	m.predictCapacityHintBytes = capacityHintBytes
 	m.predictEntryHintSource = entryHintSource
@@ -541,6 +543,9 @@ func (e *appendOnlyObserveEvent) recordEvent(other appendOnlyObserveEvent) {
 
 func (e appendOnlyObserveEvent) emit() {
 	if e.observe != nil && e.entries > 0 {
+		defer func() {
+			_ = recover()
+		}()
 		e.observe(e.entries)
 	}
 }
@@ -553,7 +558,7 @@ func (m *AppendOnly) maybeRaisePredictedGrowthHintLocked(event *appendOnlyObserv
 	if avgBytesPerEntry <= 0 {
 		avgBytesPerEntry = 1
 	}
-	predictedEntries := appendOnlyClampRetainedEntries(m.predictCapacityHintBytes / avgBytesPerEntry)
+	predictedEntries := appendOnlyClampRetainedEntries(1 + (m.predictCapacityHintBytes-1)/avgBytesPerEntry)
 	if predictedEntries <= m.growEntriesLen {
 		return
 	}

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -265,6 +265,11 @@ func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedByte
 	}
 }
 
+// SetPredictiveGrowthHint configures a best-effort growth forecast for future
+// appends. capacityHintBytes is converted to an entry target from the observed
+// average entry size; entryHintSource supplies a shared floor learned from other
+// append-only memtables. observeEntries is called after the memtable mutex is
+// released and must be non-blocking because it can run on the write path.
 func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, entryHintSource *atomic.Int32, observeEntries func(int)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -503,10 +508,37 @@ func entryValueSize(flags byte, value []byte) int {
 }
 
 func appendOnlyShouldPredictHint(count int) bool {
-	return count >= appendOnlyPredictHintMinEntries && bits.OnesCount(uint(count)) == 1
+	return count >= appendOnlyPredictHintMinEntries && count&(count-1) == 0
 }
 
-func (m *AppendOnly) maybeRaisePredictedGrowthHintLocked() {
+type appendOnlyObserveEvent struct {
+	entries int
+	observe func(int)
+}
+
+func (e *appendOnlyObserveEvent) record(observe func(int), entries int) {
+	if observe == nil || entries <= 0 {
+		return
+	}
+	if e.observe == nil {
+		e.observe = observe
+	}
+	if entries > e.entries {
+		e.entries = entries
+	}
+}
+
+func (e *appendOnlyObserveEvent) recordEvent(other appendOnlyObserveEvent) {
+	e.record(other.observe, other.entries)
+}
+
+func (e appendOnlyObserveEvent) emit() {
+	if e.observe != nil && e.entries > 0 {
+		e.observe(e.entries)
+	}
+}
+
+func (m *AppendOnly) maybeRaisePredictedGrowthHintLocked(event *appendOnlyObserveEvent) {
 	if m.predictCapacityHintBytes <= 0 || m.count <= 0 || m.sizeBytes <= 0 {
 		return
 	}
@@ -519,9 +551,7 @@ func (m *AppendOnly) maybeRaisePredictedGrowthHintLocked() {
 		return
 	}
 	m.growEntriesLen = predictedEntries
-	if observe := m.observeEntries; observe != nil {
-		observe(predictedEntries)
-	}
+	event.record(m.observeEntries, predictedEntries)
 }
 
 func (m *AppendOnly) clearSnapshotLocked() {
@@ -620,7 +650,8 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 	m.latest[appendOnlyKeyString(key)] = idx
 }
 
-func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) {
+func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) appendOnlyObserveEvent {
+	var observeEvent appendOnlyObserveEvent
 	if m.count == len(m.entries) {
 		if m.predictEntryHintSource != nil {
 			if shared := appendOnlyClampRetainedEntries(int(m.predictEntryHintSource.Load())); shared > m.growEntriesLen {
@@ -636,9 +667,7 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		copy(grown, m.entries[:m.count])
 		m.entries = grown
 		putAppendOnlyEntries(prev)
-		if observe := m.observeEntries; observe != nil {
-			observe(nextCap)
-		}
+		observeEvent.record(m.observeEntries, nextCap)
 	}
 	idx := m.count
 	m.count++
@@ -678,20 +707,20 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	k := appendOnlyEntryKey(ent)
 	m.sizeBytes += int64(len(k) + entryValueSize(flags, ent.value))
 	if appendOnlyShouldPredictHint(m.count) {
-		m.maybeRaisePredictedGrowthHintLocked()
+		m.maybeRaisePredictedGrowthHintLocked(&observeEvent)
 	}
 
 	if !m.hasLast {
 		m.lastIdx = idx
 		m.hasLast = true
-		return
+		return observeEvent
 	}
 	if m.ordered {
 		prev := appendOnlyEntryKey(&m.entries[m.lastIdx])
 		cmp := bytes.Compare(k, prev)
 		if cmp > 0 {
 			m.lastIdx = idx
-			return
+			return observeEvent
 		}
 		m.ordered = false
 		// Once order breaks, invalidate the cached snapshot state and
@@ -701,12 +730,13 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		// rebuildLatestIndexLocked clears the cached snapshot as part of the
 		// transition.
 		m.rebuildLatestIndexLocked()
-		return
+		return observeEvent
 	}
 	if !m.latestDirty {
 		m.updateLatestIndexLocked(k, idx)
 	}
 	m.clearSnapshotLocked()
+	return observeEvent
 }
 
 func (m *AppendOnly) Set(key, value []byte) {
@@ -719,20 +749,23 @@ func (m *AppendOnly) SetSteal(key, value []byte) {
 
 func (m *AppendOnly) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
 	m.mu.Lock()
-	m.appendEntryLocked(key, value, ptr, flags, false, false)
+	observeEvent := m.appendEntryLocked(key, value, ptr, flags, false, false)
 	m.mu.Unlock()
+	observeEvent.emit()
 }
 
 func (m *AppendOnly) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) {
 	m.mu.Lock()
-	m.appendEntryLocked(key, value, ptr, flags, true, false)
+	observeEvent := m.appendEntryLocked(key, value, ptr, flags, true, false)
 	m.mu.Unlock()
+	observeEvent.emit()
 }
 
 func (m *AppendOnly) SetEntryBorrowValue(key, value []byte, ptr page.ValuePtr, flags byte) {
 	m.mu.Lock()
-	m.appendEntryLocked(key, value, ptr, flags, false, true)
+	observeEvent := m.appendEntryLocked(key, value, ptr, flags, false, true)
 	m.mu.Unlock()
+	observeEvent.emit()
 }
 
 func (m *AppendOnly) Delete(key []byte) {
@@ -752,8 +785,9 @@ func (m *AppendOnly) PutWithCallback(key, value []byte, cb func(k, v []byte) err
 		}
 	}
 	m.mu.Lock()
-	m.appendEntryLocked(k, v, page.ValuePtr{}, node.FlagInline, true, false)
+	observeEvent := m.appendEntryLocked(k, v, page.ValuePtr{}, node.FlagInline, true, false)
 	m.mu.Unlock()
+	observeEvent.emit()
 	return nil
 }
 
@@ -765,8 +799,9 @@ func (m *AppendOnly) DeleteWithCallback(key []byte, cb func(k, v []byte) error) 
 		}
 	}
 	m.mu.Lock()
-	m.appendEntryLocked(k, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+	observeEvent := m.appendEntryLocked(k, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
 	m.mu.Unlock()
+	observeEvent.emit()
 	return nil
 }
 
@@ -780,21 +815,23 @@ func (m *AppendOnly) ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKe
 
 func (m *AppendOnly) applyStealBatch(entries []batchpkg.Entry, onKey func(key []byte)) {
 	m.mu.Lock()
+	var observeEvent appendOnlyObserveEvent
 	for i := range entries {
 		op := entries[i]
 		switch {
 		case op.Type == batchpkg.OpDelete:
-			m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+			observeEvent.recordEvent(m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false))
 		case op.IsPtr:
-			m.appendEntryLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
+			observeEvent.recordEvent(m.appendEntryLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false))
 		default:
-			m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+			observeEvent.recordEvent(m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false))
 		}
 		if onKey != nil {
 			onKey(op.Key)
 		}
 	}
 	m.mu.Unlock()
+	observeEvent.emit()
 }
 
 func (m *AppendOnly) orderedLookupEntryLocked(key []byte) *appendOnlyEntry {
@@ -1096,9 +1133,6 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	m.frozen = false
 	m.hasLast = false
 	m.lastIdx = -1
-	m.predictCapacityHintBytes = 0
-	m.predictEntryHintSource = nil
-	m.observeEntries = nil
 
 	// If the entry slice grew far beyond the configured baseline, shrink it.
 	// This avoids permanently ratcheting heap high-water when a workload briefly

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -6,6 +6,7 @@ import (
 	"math/bits"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
@@ -84,6 +85,7 @@ type AppendOnly struct {
 	lastIdx     int
 
 	predictCapacityHintBytes int
+	predictEntryHintSource   *atomic.Int32
 	observeEntries           func(int)
 
 	iteratorLeaseMu   sync.Mutex
@@ -263,13 +265,19 @@ func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedByte
 	}
 }
 
-func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, observeEntries func(int)) {
+func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, entryHintSource *atomic.Int32, observeEntries func(int)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if capacityHintBytes <= 0 {
 		capacityHintBytes = defaultMemtableCapacity
 	}
 	m.predictCapacityHintBytes = capacityHintBytes
+	m.predictEntryHintSource = entryHintSource
+	if entryHintSource != nil {
+		if shared := appendOnlyClampRetainedEntries(int(entryHintSource.Load())); shared > m.growEntriesLen {
+			m.growEntriesLen = shared
+		}
+	}
 	m.observeEntries = observeEntries
 }
 
@@ -614,6 +622,11 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 
 func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) {
 	if m.count == len(m.entries) {
+		if m.predictEntryHintSource != nil {
+			if shared := appendOnlyClampRetainedEntries(int(m.predictEntryHintSource.Load())); shared > m.growEntriesLen {
+				m.growEntriesLen = shared
+			}
+		}
 		nextCap := appendOnlyNextCapacity(len(m.entries))
 		if nextCap < m.growEntriesLen {
 			nextCap = m.growEntriesLen
@@ -623,6 +636,9 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		copy(grown, m.entries[:m.count])
 		m.entries = grown
 		putAppendOnlyEntries(prev)
+		if observe := m.observeEntries; observe != nil {
+			observe(nextCap)
+		}
 	}
 	idx := m.count
 	m.count++
@@ -1081,6 +1097,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	m.hasLast = false
 	m.lastIdx = -1
 	m.predictCapacityHintBytes = 0
+	m.predictEntryHintSource = nil
 	m.observeEntries = nil
 
 	// If the entry slice grew far beyond the configured baseline, shrink it.

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -36,6 +36,7 @@ const (
 	appendOnlyReuseOversizeFactor           = 4
 	appendOnlyResetDropThresholdEntries     = 1 << 15
 	appendOnlyAggressiveGrowCutoff          = appendOnlyResetDropThresholdEntries * 2
+	appendOnlyPredictHintMinEntries         = 1 << 10
 )
 
 var appendOnlyEntryPool sync.Pool
@@ -81,6 +82,9 @@ type AppendOnly struct {
 	frozen      bool
 	hasLast     bool
 	lastIdx     int
+
+	predictCapacityHintBytes int
+	observeEntries           func(int)
 
 	iteratorLeaseMu   sync.Mutex
 	iteratorLeaseCond *sync.Cond
@@ -212,19 +216,27 @@ func appendOnlyGrowthEntriesForHint(baseEntries, entryHint int) int {
 	if n < appendOnlyMinInitialEntries {
 		n = appendOnlyMinInitialEntries
 	}
+	entryHint = appendOnlyClampRetainedEntries(entryHint)
 	if entryHint <= 0 {
 		return n
-	}
-	if entryHint < appendOnlyMinInitialEntries {
-		entryHint = appendOnlyMinInitialEntries
-	}
-	if entryHint > appendOnlyMaxInitialEntries {
-		entryHint = appendOnlyMaxInitialEntries
 	}
 	if entryHint > n {
 		n = entryHint
 	}
 	return n
+}
+
+func appendOnlyClampRetainedEntries(entries int) int {
+	if entries <= 0 {
+		return 0
+	}
+	if entries < appendOnlyMinInitialEntries {
+		return appendOnlyMinInitialEntries
+	}
+	if entries > appendOnlyMaxInitialEntries {
+		return appendOnlyMaxInitialEntries
+	}
+	return entries
 }
 
 func NewAppendOnlyWithCapacity(capacity int) *AppendOnly {
@@ -249,6 +261,16 @@ func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedByte
 		snapCount:      0,
 		sizeBytes:      0,
 	}
+}
+
+func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, observeEntries func(int)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if capacityHintBytes <= 0 {
+		capacityHintBytes = defaultMemtableCapacity
+	}
+	m.predictCapacityHintBytes = capacityHintBytes
+	m.observeEntries = observeEntries
 }
 
 func appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
@@ -472,6 +494,28 @@ func entryValueSize(flags byte, value []byte) int {
 	return len(value)
 }
 
+func appendOnlyShouldPredictHint(count int) bool {
+	return count >= appendOnlyPredictHintMinEntries && bits.OnesCount(uint(count)) == 1
+}
+
+func (m *AppendOnly) maybeRaisePredictedGrowthHintLocked() {
+	if m.predictCapacityHintBytes <= 0 || m.count <= 0 || m.sizeBytes <= 0 {
+		return
+	}
+	avgBytesPerEntry := int((m.sizeBytes + int64(m.count) - 1) / int64(m.count))
+	if avgBytesPerEntry <= 0 {
+		avgBytesPerEntry = 1
+	}
+	predictedEntries := appendOnlyClampRetainedEntries(m.predictCapacityHintBytes / avgBytesPerEntry)
+	if predictedEntries <= m.growEntriesLen {
+		return
+	}
+	m.growEntriesLen = predictedEntries
+	if observe := m.observeEntries; observe != nil {
+		observe(predictedEntries)
+	}
+}
+
 func (m *AppendOnly) clearSnapshotLocked() {
 	if m.snapshot != nil {
 		m.snapshot = m.snapshot[:0]
@@ -617,6 +661,9 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	}
 	k := appendOnlyEntryKey(ent)
 	m.sizeBytes += int64(len(k) + entryValueSize(flags, ent.value))
+	if appendOnlyShouldPredictHint(m.count) {
+		m.maybeRaisePredictedGrowthHintLocked()
+	}
 
 	if !m.hasLast {
 		m.lastIdx = idx
@@ -1033,6 +1080,8 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	m.frozen = false
 	m.hasLast = false
 	m.lastIdx = -1
+	m.predictCapacityHintBytes = 0
+	m.observeEntries = nil
 
 	// If the entry slice grew far beyond the configured baseline, shrink it.
 	// This avoids permanently ratcheting heap high-water when a workload briefly

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -2,6 +2,7 @@ package memtable
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/node"
@@ -162,7 +163,7 @@ func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) 
 
 	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
 	var observed int
-	mt.SetPredictiveGrowthHint(capacityBytes, func(entries int) {
+	mt.SetPredictiveGrowthHint(capacityBytes, nil, func(entries int) {
 		if entries > observed {
 			observed = entries
 		}
@@ -181,5 +182,27 @@ func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) 
 	}
 	if got := cap(mt.entries); got != base {
 		t.Fatalf("predictive hint should not allocate immediately: cap(entries)=%d want=%d", got, base)
+	}
+}
+
+func TestAppendOnlySharedPredictiveHintRaisesGrowthFloorBeforeLocalPrediction(t *testing.T) {
+	const (
+		capacityBytes          = 128 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	sharedHint := atomic.Int32{}
+	sharedHint.Store(int32(base * 8))
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	mt.SetPredictiveGrowthHint(capacityBytes, &sharedHint, nil)
+
+	for i := 0; i < base+1; i++ {
+		key := []byte(fmt.Sprintf("s%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+	if got := cap(mt.entries); got < int(sharedHint.Load()) {
+		t.Fatalf("cap(entries)=%d want >= %d", got, sharedHint.Load())
 	}
 }

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -187,42 +186,30 @@ func TestAppendOnlyPredictiveGrowthHintSurvivesResetAndObservesAfterUnlock(t *te
 	const capacityBytes = 128 << 10
 
 	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, appendOnlyEstimatedBytesPerEntryPointer)
-	var observed atomic.Int32
+	var observed atomic.Bool
+	var observedAfterUnlock atomic.Bool
 	mt.SetPredictiveGrowthHint(capacityBytes, nil, func(entries int) {
-		if mt.Len() == 0 {
+		if entries <= 0 {
 			return
 		}
-		observed.Store(int32(entries))
+		observed.Store(true)
+		if mt.mu.TryLock() {
+			observedAfterUnlock.Store(true)
+			mt.mu.Unlock()
+		}
 	})
 	mt.Reset()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		limit := cap(mt.entries) + 1
-		for i := 0; i < limit; i++ {
-			key := []byte(fmt.Sprintf("u%08d", i))
-			mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
-		}
-	}()
-
-	timer := time.NewTimer(2 * time.Second)
-	defer func() {
-		if !timer.Stop() {
-			select {
-			case <-timer.C:
-			default:
-			}
-		}
-	}()
-
-	select {
-	case <-done:
-	case <-timer.C:
-		t.Fatal("predictive observer appears to run while append-only lock is held")
+	limit := cap(mt.entries) + 1
+	for i := 0; i < limit; i++ {
+		key := []byte(fmt.Sprintf("u%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
 	}
-	if got := observed.Load(); got == 0 {
+	if !observed.Load() {
 		t.Fatalf("expected predictive observer after reset")
+	}
+	if !observedAfterUnlock.Load() {
+		t.Fatalf("predictive observer ran while append-only lock was held")
 	}
 }
 
@@ -244,6 +231,24 @@ func TestAppendOnlyGrowthObserverRecordsLiveEntries(t *testing.T) {
 	}
 	if got, want := int(observed.Load()), base+1; got != want {
 		t.Fatalf("observed entries=%d want live count %d", got, want)
+	}
+}
+
+func TestAppendOnlyPredictiveGrowthHintZeroCapacityDisablesCapacityPrediction(t *testing.T) {
+	const (
+		capacityBytes          = 128 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	baseGrow := mt.growEntriesLen
+	mt.SetPredictiveGrowthHint(0, nil, nil)
+	for i := 0; i < appendOnlyPredictHintMinEntries; i++ {
+		key := []byte(fmt.Sprintf("z%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+	if got := mt.growEntriesLen; got != baseGrow {
+		t.Fatalf("zero capacity hint changed growEntriesLen=%d want %d", got, baseGrow)
 	}
 }
 

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -206,9 +206,19 @@ func TestAppendOnlyPredictiveGrowthHintSurvivesResetAndObservesAfterUnlock(t *te
 		}
 	}()
 
+	timer := time.NewTimer(2 * time.Second)
+	defer func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}()
+
 	select {
 	case <-done:
-	case <-time.After(2 * time.Second):
+	case <-timer.C:
 		t.Fatal("predictive observer appears to run while append-only lock is held")
 	}
 	if got := observed.Load(); got == 0 {

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -148,3 +148,38 @@ func TestAppendOnlyResetWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *
 		t.Fatalf("warm hinted cap(entries)=%d want=%d", got, capAfterGrowth)
 	}
 }
+
+func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) {
+	const (
+		capacityBytes          = 128 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	if base <= appendOnlyPredictHintMinEntries {
+		t.Fatalf("base=%d want > %d", base, appendOnlyPredictHintMinEntries)
+	}
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	var observed int
+	mt.SetPredictiveGrowthHint(capacityBytes, func(entries int) {
+		if entries > observed {
+			observed = entries
+		}
+	})
+
+	for i := 0; i < appendOnlyPredictHintMinEntries; i++ {
+		key := []byte(fmt.Sprintf("p%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+
+	if got, wantMin := mt.growEntriesLen, base*8; got < wantMin {
+		t.Fatalf("growEntriesLen=%d want >= %d", got, wantMin)
+	}
+	if observed != mt.growEntriesLen {
+		t.Fatalf("observed predicted entries=%d want %d", observed, mt.growEntriesLen)
+	}
+	if got := cap(mt.entries); got != base {
+		t.Fatalf("predictive hint should not allocate immediately: cap(entries)=%d want=%d", got, base)
+	}
+}

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -150,3 +150,38 @@ func TestAppendOnlyResetWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *
 		t.Fatalf("warm hinted cap(entries)=%d want=%d", got, capAfterGrowth)
 	}
 }
+
+func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) {
+	const (
+		capacityBytes          = 128 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	if base <= appendOnlyPredictHintMinEntries {
+		t.Fatalf("base=%d want > %d", base, appendOnlyPredictHintMinEntries)
+	}
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	var observed int
+	mt.SetPredictiveGrowthHint(capacityBytes, func(entries int) {
+		if entries > observed {
+			observed = entries
+		}
+	})
+
+	for i := 0; i < appendOnlyPredictHintMinEntries; i++ {
+		key := []byte(fmt.Sprintf("p%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+
+	if got, wantMin := mt.growEntriesLen, base*8; got < wantMin {
+		t.Fatalf("growEntriesLen=%d want >= %d", got, wantMin)
+	}
+	if observed != mt.growEntriesLen {
+		t.Fatalf("observed predicted entries=%d want %d", observed, mt.growEntriesLen)
+	}
+	if got := cap(mt.entries); got != base {
+		t.Fatalf("predictive hint should not allocate immediately: cap(entries)=%d want=%d", got, base)
+	}
+}

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -184,6 +185,38 @@ func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) 
 	}
 	if got := cap(mt.entries); got != base {
 		t.Fatalf("predictive hint should not allocate immediately: cap(entries)=%d want=%d", got, base)
+	}
+}
+
+func TestAppendOnlyPredictiveGrowthHintSurvivesResetAndObservesAfterUnlock(t *testing.T) {
+	const capacityBytes = 128 << 10
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, appendOnlyEstimatedBytesPerEntryPointer)
+	var observed atomic.Int32
+	mt.SetPredictiveGrowthHint(capacityBytes, nil, func(entries int) {
+		if mt.Len() == 0 {
+			return
+		}
+		observed.Store(int32(entries))
+	})
+	mt.Reset()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < appendOnlyPredictHintMinEntries; i++ {
+			key := []byte(fmt.Sprintf("u%08d", i))
+			mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("predictive observer appears to run while append-only lock is held")
+	}
+	if got := observed.Load(); got == 0 {
+		t.Fatalf("expected predictive observer after reset")
 	}
 }
 

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -2,6 +2,7 @@ package memtable
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/node"
@@ -164,7 +165,7 @@ func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) 
 
 	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
 	var observed int
-	mt.SetPredictiveGrowthHint(capacityBytes, func(entries int) {
+	mt.SetPredictiveGrowthHint(capacityBytes, nil, func(entries int) {
 		if entries > observed {
 			observed = entries
 		}
@@ -183,5 +184,27 @@ func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) 
 	}
 	if got := cap(mt.entries); got != base {
 		t.Fatalf("predictive hint should not allocate immediately: cap(entries)=%d want=%d", got, base)
+	}
+}
+
+func TestAppendOnlySharedPredictiveHintRaisesGrowthFloorBeforeLocalPrediction(t *testing.T) {
+	const (
+		capacityBytes          = 128 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	sharedHint := atomic.Int32{}
+	sharedHint.Store(int32(base * 8))
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	mt.SetPredictiveGrowthHint(capacityBytes, &sharedHint, nil)
+
+	for i := 0; i < base+1; i++ {
+		key := []byte(fmt.Sprintf("s%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+	if got := cap(mt.entries); got < int(sharedHint.Load()) {
+		t.Fatalf("cap(entries)=%d want >= %d", got, sharedHint.Load())
 	}
 }


### PR DESCRIPTION
## Summary
- let live append-only mutables raise their future `growEntriesLen` from observed bytes-per-entry before they hit the expensive regrowth path
- feed the existing shared append-only entry hint from those live observations instead of waiting for rotate/recycle
- add focused coverage that predictive hinting raises the future growth floor without allocating immediately

## Validation
- `go test ./TreeDB/internal/memtable`
- `go test ./TreeDB/caching -run 'TestAppendOnly(EntryHint|PredictiveHint)'`
- fresh-built exact benchmark on top of `codex/append-only-entry-hint`:
  - `go build -o /tmp/unified-bench-predictive ./cmd/unified_bench`
  - `/tmp/unified-bench-predictive -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_append_only_predictive_hint_phHUeU -test batch_delete`
  - `Batch Delete: 4,049,259`
  - `alloc_space: 3.92GB` vs `4.92GB` on the current `#1013` exact profile