### PR TITLE
Compact append-only entry layout

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7738,14 +7738,14 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 		if mt := db.popAppendOnlyMemLease(); mt != nil {
 			db.appendOnlyMemLeaseHitTotal.Add(1)
 			mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
-			mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
+			mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
 			return mt, nil
 		}
 		if v := db.appendOnlyMemPool.Get(); v != nil {
 			if mt, ok := v.(*memtable.AppendOnly); ok && mt != nil {
 				db.appendOnlyMemPoolHitTotal.Add(1)
 				mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
-				mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
+				mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
 				return mt, nil
 			}
 		}
@@ -7757,7 +7757,7 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 		}
 		db.appendOnlyMemNewAllocTotal.Add(1)
 		mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimate, entryHint)
-		mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
+		mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
 		return mt, nil
 	}
 	return memtable.NewWithCapacityModeAndIndexer(capacity, mode, db.hashSortedIndexer)

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -59,6 +59,7 @@ type appendOnlyEntry struct {
 	inlineKey    [appendOnlyInlineKeyLen]byte
 	keyIndex     uint32
 	payloadIndex uint32
+	inlineKeyLen uint8
 	flags        byte
 }
 
@@ -378,7 +379,7 @@ func appendOnlyEntryKeyFromKeys(ent *appendOnlyEntry, keys []string) []byte {
 		return nil
 	}
 	if ent.flags&appendOnlyEntryFlagKeyInline != 0 {
-		return ent.inlineKey[:]
+		return ent.inlineKey[:int(ent.inlineKeyLen)]
 	}
 	if ent.keyIndex == 0 {
 		return nil
@@ -776,10 +777,12 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	ent.flags = flags
 	ent.keyIndex = 0
 	ent.payloadIndex = 0
+	ent.inlineKeyLen = 0
 	payloadValue := ""
 	payloadPtr := page.ValuePtr{}
-	if len(key) == appendOnlyInlineKeyLen {
+	if len(key) <= appendOnlyInlineKeyLen {
 		copy(ent.inlineKey[:], key)
+		ent.inlineKeyLen = uint8(len(key))
 		ent.flags |= appendOnlyEntryFlagKeyInline
 	} else if steal {
 		m.keys = append(m.keys, appendOnlyStringFromBytes(key))
@@ -1192,6 +1195,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		ent.flags = 0
 		ent.keyIndex = 0
 		ent.payloadIndex = 0
+		ent.inlineKeyLen = 0
 	}
 	clear(m.keys)
 	m.keys = m.keys[:0]

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -172,9 +172,11 @@ func getAppendOnlyKeysFromPool(length int, pool *sync.Pool, maxCap int) []string
 	}
 	if v := pool.Get(); v != nil {
 		if keys, ok := v.([]string); ok && cap(keys) >= length {
-			out := keys[:length]
-			clear(out)
-			return out
+			if cap(keys) <= appendOnlyMaxReuseEntries(length) {
+				out := keys[:length]
+				clear(out)
+				return out
+			}
 		}
 	}
 	return make([]string, length)
@@ -208,9 +210,11 @@ func getAppendOnlyPayloadsFromPool(length int, pool *sync.Pool, maxCap int) []ap
 	}
 	if v := pool.Get(); v != nil {
 		if payloads, ok := v.([]appendOnlyPayload); ok && cap(payloads) >= length {
-			out := payloads[:length]
-			clear(out)
-			return out
+			if cap(payloads) <= appendOnlyMaxReuseEntries(length) {
+				out := payloads[:length]
+				clear(out)
+				return out
+			}
 		}
 	}
 	return make([]appendOnlyPayload, length)
@@ -1449,16 +1453,31 @@ func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntr
 	return entries, keys, payloads
 }
 
+func appendOnlyOrderedIteratorInlineKeys(entries []appendOnlyEntry) [][]byte {
+	var inlineKeys [][]byte
+	for i := range entries {
+		if entries[i].inlineKeyLen == 0 {
+			continue
+		}
+		if inlineKeys == nil {
+			inlineKeys = make([][]byte, len(entries))
+		}
+		inlineKeys[i] = cloneBytes(entries[i].inlineKey[:int(entries[i].inlineKeyLen)])
+	}
+	return inlineKeys
+}
+
 func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 	m.mu.RLock()
 	if m.ordered {
 		entries := m.entries[:m.count]
 		it := &appendOnlyIterator{
-			entries: entries,
-			start:   start,
-			end:     end,
-			mu:      &m.mu,
-			owner:   m,
+			entries:    entries,
+			inlineKeys: appendOnlyOrderedIteratorInlineKeys(entries),
+			start:      start,
+			end:        end,
+			mu:         &m.mu,
+			owner:      m,
 		}
 		if start != nil {
 			it.Seek(start)
@@ -1513,12 +1532,13 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 	if m.ordered {
 		entries := m.entries[:m.count]
 		it := &appendOnlyIterator{
-			entries: entries,
-			start:   start,
-			end:     end,
-			mu:      &m.mu,
-			owner:   m,
-			reverse: true,
+			entries:    entries,
+			inlineKeys: appendOnlyOrderedIteratorInlineKeys(entries),
+			start:      start,
+			end:        end,
+			mu:         &m.mu,
+			owner:      m,
+			reverse:    true,
 		}
 		it.seekToReverseEnd(end)
 		return it
@@ -1565,6 +1585,7 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 type appendOnlyIterator struct {
 	entries         []appendOnlyEntry
 	keys            []string
+	inlineKeys      [][]byte
 	payloads        []appendOnlyPayload
 	entryPtrs       []*appendOnlyEntry
 	idx             int
@@ -1711,6 +1732,9 @@ func (it *appendOnlyIterator) UnsafeKey() []byte {
 	if ent == nil || !it.validIndex() {
 		return nil
 	}
+	if it.inlineKeys != nil && it.idx >= 0 && it.idx < len(it.inlineKeys) && it.inlineKeys[it.idx] != nil {
+		return it.inlineKeys[it.idx]
+	}
 	return it.keyForEntry(ent)
 }
 
@@ -1795,6 +1819,7 @@ func (it *appendOnlyIterator) Close() error {
 	it.owner = nil
 	it.entries = nil
 	it.keys = nil
+	it.inlineKeys = nil
 	it.payloads = nil
 	it.entryPtrs = nil
 	return nil

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -45,14 +45,14 @@ var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
 
 type appendOnlyEntry struct {
-	key        []byte
-	value      []byte
-	ptr        page.ValuePtr
-	inlineKey  [appendOnlyInlineKeyLen]byte
-	flags      byte
-	keyInline  bool
-	valueOwned bool
+	key       []byte
+	value     string
+	ptr       page.ValuePtr
+	inlineKey [appendOnlyInlineKeyLen]byte
+	flags     byte
 }
+
+const appendOnlyEntryFlagKeyInline = 0x80
 
 type appendOnlyValueArena struct {
 	chunks    [][]byte
@@ -277,10 +277,24 @@ func appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
 	if ent == nil {
 		return nil
 	}
-	if ent.keyInline {
+	if ent.flags&appendOnlyEntryFlagKeyInline != 0 {
 		return ent.inlineKey[:]
 	}
 	return ent.key
+}
+
+func appendOnlyEntryValue(ent *appendOnlyEntry) []byte {
+	if ent == nil || len(ent.value) == 0 {
+		return nil
+	}
+	return unsafe.Slice(unsafe.StringData(ent.value), len(ent.value))
+}
+
+func appendOnlyStringFromBytes(src []byte) string {
+	if len(src) == 0 {
+		return ""
+	}
+	return unsafe.String(&src[0], len(src))
 }
 
 func cloneBytes(src []byte) []byte {
@@ -484,7 +498,7 @@ func appendOnlyKeyU64(key []byte) (uint64, bool) {
 	return binary.BigEndian.Uint64(key), true
 }
 
-func entryValueSize(flags byte, value []byte) int {
+func entryValueSize(flags byte, value string) int {
 	if flags&node.FlagPointer != 0 {
 		return page.ValuePtrSize + len(value)
 	}
@@ -629,34 +643,31 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	ent := &m.entries[idx]
 	ent.ptr = ptr
 	ent.flags = flags
-	ent.keyInline = false
-	ent.valueOwned = false
 	if steal {
 		ent.key = key
-		ent.value = value
+		ent.value = appendOnlyStringFromBytes(value)
 	} else {
 		if len(key) == appendOnlyInlineKeyLen {
 			copy(ent.inlineKey[:], key)
-			ent.keyInline = true
+			ent.flags |= appendOnlyEntryFlagKeyInline
 			ent.key = nil
 		} else {
 			ent.key = cloneOrReuseBytes(ent.key, key, appendOnlyReusableKeyMaxCap)
 		}
 		if len(value) > 0 {
 			if borrowValue {
-				ent.value = value
+				ent.value = appendOnlyStringFromBytes(value)
 			} else {
-				ent.value = m.valueArena.alloc(len(value))
-				copy(ent.value, value)
-				ent.valueOwned = true
+				buf := m.valueArena.alloc(len(value))
+				copy(buf, value)
+				ent.value = appendOnlyStringFromBytes(buf)
 			}
 		} else {
-			ent.value = nil
+			ent.value = ""
 		}
 	}
 	if flags&node.FlagTombstone != 0 {
-		ent.value = nil
-		ent.valueOwned = false
+		ent.value = ""
 		ent.ptr = page.ValuePtr{}
 	}
 	k := appendOnlyEntryKey(ent)
@@ -804,7 +815,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 		m.mu.RLock()
 		if ent := m.orderedLookupEntryLocked(key); ent != nil {
 			deleted := ent.flags&node.FlagTombstone != 0
-			val := ent.value
+			val := appendOnlyEntryValue(ent)
 			m.mu.RUnlock()
 			if deleted {
 				return nil, true, true
@@ -822,7 +833,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
-						val := ent.value
+						val := appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
 						if deleted {
 							return nil, true, true
@@ -836,7 +847,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
-						val := ent.value
+						val := appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
 						if deleted {
 							return nil, true, true
@@ -863,9 +874,9 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 	for {
 		m.mu.RLock()
 		if ent := m.orderedLookupEntryLocked(key); ent != nil {
-			val := ent.value
+			val := appendOnlyEntryValue(ent)
 			ptr := ent.ptr
-			flags := ent.flags
+			flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 			m.mu.RUnlock()
 			return val, ptr, flags, true
 		}
@@ -879,9 +890,9 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 				if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
-						val := ent.value
+						val := appendOnlyEntryValue(ent)
 						ptr := ent.ptr
-						flags := ent.flags
+						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 						m.mu.RUnlock()
 						return val, ptr, flags, true
 					}
@@ -891,9 +902,9 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
-						val := ent.value
+						val := appendOnlyEntryValue(ent)
 						ptr := ent.ptr
-						flags := ent.flags
+						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 						m.mu.RUnlock()
 						return val, ptr, flags, true
 					}
@@ -1038,14 +1049,12 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		ent := &m.entries[i]
 		ent.ptr = page.ValuePtr{}
 		ent.flags = 0
-		ent.keyInline = false
-		ent.valueOwned = false
 		if cap(ent.key) > appendOnlyReusableKeyMaxCap {
 			ent.key = nil
 		} else if ent.key != nil {
 			ent.key = ent.key[:0]
 		}
-		ent.value = nil
+		ent.value = ""
 	}
 	m.valueArena.reset()
 	if !retainObserved {
@@ -1395,7 +1404,7 @@ func (it *appendOnlyIterator) UnsafeValue() []byte {
 	if ent.flags&node.FlagTombstone != 0 {
 		return nil
 	}
-	return ent.value
+	return appendOnlyEntryValue(ent)
 }
 
 func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
@@ -1403,7 +1412,7 @@ func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	if ent == nil || !it.validIndex() {
 		return nil, page.ValuePtr{}, 0
 	}
-	return ent.value, ent.ptr, ent.flags
+	return appendOnlyEntryValue(ent), ent.ptr, ent.flags &^ appendOnlyEntryFlagKeyInline
 }
 
 func (it *appendOnlyIterator) IsDeleted() bool {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -6,6 +6,7 @@ import (
 	"math/bits"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
@@ -97,6 +98,7 @@ type AppendOnly struct {
 	lastIdx     int
 
 	predictCapacityHintBytes int
+	predictEntryHintSource   *atomic.Int32
 	observeEntries           func(int)
 
 	iteratorLeaseMu   sync.Mutex
@@ -364,13 +366,19 @@ func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedByte
 	}
 }
 
-func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, observeEntries func(int)) {
+func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, entryHintSource *atomic.Int32, observeEntries func(int)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if capacityHintBytes <= 0 {
 		capacityHintBytes = defaultMemtableCapacity
 	}
 	m.predictCapacityHintBytes = capacityHintBytes
+	m.predictEntryHintSource = entryHintSource
+	if entryHintSource != nil {
+		if shared := appendOnlyClampRetainedEntries(int(entryHintSource.Load())); shared > m.growEntriesLen {
+			m.growEntriesLen = shared
+		}
+	}
 	m.observeEntries = observeEntries
 }
 
@@ -761,6 +769,11 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 
 func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) {
 	if m.count == len(m.entries) {
+		if m.predictEntryHintSource != nil {
+			if shared := appendOnlyClampRetainedEntries(int(m.predictEntryHintSource.Load())); shared > m.growEntriesLen {
+				m.growEntriesLen = shared
+			}
+		}
 		nextCap := appendOnlyNextCapacity(len(m.entries))
 		if nextCap < m.growEntriesLen {
 			nextCap = m.growEntriesLen
@@ -770,6 +783,9 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		copy(grown, m.entries[:m.count])
 		m.entries = grown
 		putAppendOnlyEntries(prev)
+		if observe := m.observeEntries; observe != nil {
+			observe(nextCap)
+		}
 	}
 	idx := m.count
 	m.count++
@@ -1235,6 +1251,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	m.hasLast = false
 	m.lastIdx = -1
 	m.predictCapacityHintBytes = 0
+	m.predictEntryHintSource = nil
 	m.observeEntries = nil
 
 	// If the entry slice grew far beyond the configured baseline, shrink it.

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -23,7 +23,9 @@ const (
 	appendOnlyMaxInitialEntries             = 1 << 20
 	appendOnlyInlineKeyLen                  = 8
 	appendOnlyEntryPoolMaxCap               = 1 << 20
+	appendOnlyPayloadPoolMaxCap             = 1 << 20
 	appendOnlyIteratorPoolMaxCap            = 1 << 20
+	appendOnlyIteratorPayloadPoolMaxCap     = 1 << 20
 	appendOnlyIteratorPtrPoolMaxCap         = 1 << 20
 	appendOnlyValueArenaMinShift            = 12
 	appendOnlyValueArenaMaxShift            = 20
@@ -39,16 +41,21 @@ const (
 )
 
 var appendOnlyEntryPool sync.Pool
+var appendOnlyPayloadPool sync.Pool
 var appendOnlyIteratorPool sync.Pool
+var appendOnlyIteratorPayloadPool sync.Pool
 var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
 
+type appendOnlyPayload struct {
+	value string
+	ptr   page.ValuePtr
+}
 type appendOnlyEntry struct {
-	key       string
-	value     string
-	ptr       page.ValuePtr
-	inlineKey [appendOnlyInlineKeyLen]byte
-	flags     byte
+	key          string
+	payloadIndex uint32
+	inlineKey    [appendOnlyInlineKeyLen]byte
+	flags        byte
 }
 
 const appendOnlyEntryFlagKeyInline = 0x80
@@ -65,6 +72,7 @@ type AppendOnly struct {
 	mu sync.RWMutex
 
 	entries        []appendOnlyEntry
+	payloads       []appendOnlyPayload
 	baseEntriesLen int
 	growEntriesLen int
 	latest         map[string]int
@@ -143,6 +151,37 @@ func putAppendOnlyEntries(entries []appendOnlyEntry) {
 	appendOnlyEntryPool.Put(full[:0])
 }
 
+func getAppendOnlyPayloadsFromPool(length int, pool *sync.Pool) []appendOnlyPayload {
+	if length < 0 {
+		length = 0
+	}
+	if length > appendOnlyPayloadPoolMaxCap {
+		return make([]appendOnlyPayload, length)
+	}
+	if pool == nil {
+		return make([]appendOnlyPayload, length)
+	}
+	if v := pool.Get(); v != nil {
+		if payloads, ok := v.([]appendOnlyPayload); ok && cap(payloads) >= length {
+			return payloads[:length]
+		}
+	}
+	return make([]appendOnlyPayload, length)
+}
+
+func getAppendOnlyPayloads(length int) []appendOnlyPayload {
+	return getAppendOnlyPayloadsFromPool(length, &appendOnlyPayloadPool)
+}
+
+func putAppendOnlyPayloads(payloads []appendOnlyPayload) {
+	if payloads == nil || cap(payloads) == 0 || cap(payloads) > appendOnlyPayloadPoolMaxCap {
+		return
+	}
+	full := payloads[:cap(payloads)]
+	clear(full)
+	appendOnlyPayloadPool.Put(full[:0])
+}
+
 func getAppendOnlyIteratorEntries(length int) []appendOnlyEntry {
 	if length < 0 {
 		length = 0
@@ -166,6 +205,19 @@ func putAppendOnlyIteratorEntries(entries []appendOnlyEntry) {
 	}
 	clear(entries)
 	appendOnlyIteratorPool.Put(entries[:0])
+}
+
+func getAppendOnlyIteratorPayloads(length int) []appendOnlyPayload {
+	return getAppendOnlyPayloadsFromPool(length, &appendOnlyIteratorPayloadPool)
+}
+
+func putAppendOnlyIteratorPayloads(payloads []appendOnlyPayload) {
+	if payloads == nil || cap(payloads) == 0 || cap(payloads) > appendOnlyIteratorPayloadPoolMaxCap {
+		return
+	}
+	full := payloads[:cap(payloads)]
+	clear(full)
+	appendOnlyIteratorPayloadPool.Put(full[:0])
 }
 
 func getAppendOnlyIteratorPtrs(length int) []*appendOnlyEntry {
@@ -285,11 +337,11 @@ func appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
 	return unsafe.Slice(unsafe.StringData(ent.key), len(ent.key))
 }
 
-func appendOnlyEntryValue(ent *appendOnlyEntry) []byte {
-	if ent == nil || len(ent.value) == 0 {
+func appendOnlyPayloadValue(payload *appendOnlyPayload) []byte {
+	if payload == nil || len(payload.value) == 0 {
 		return nil
 	}
-	return unsafe.Slice(unsafe.StringData(ent.value), len(ent.value))
+	return unsafe.Slice(unsafe.StringData(payload.value), len(payload.value))
 }
 
 func appendOnlyStringFromBytes(src []byte) string {
@@ -315,6 +367,28 @@ func appendOnlyArenaStringCopy(arena *appendOnlyValueArena, src []byte) string {
 	buf := arena.alloc(len(src))
 	copy(buf, src)
 	return appendOnlyStringFromBytes(buf)
+}
+
+func (m *AppendOnly) appendOnlyPayload(ent *appendOnlyEntry) *appendOnlyPayload {
+	if m == nil || ent == nil || ent.payloadIndex == 0 {
+		return nil
+	}
+	idx := int(ent.payloadIndex - 1)
+	if idx < 0 || idx >= len(m.payloads) {
+		return nil
+	}
+	return &m.payloads[idx]
+}
+
+func (m *AppendOnly) appendOnlyEntryValue(ent *appendOnlyEntry) []byte {
+	return appendOnlyPayloadValue(m.appendOnlyPayload(ent))
+}
+
+func (m *AppendOnly) appendOnlyEntryPtr(ent *appendOnlyEntry) page.ValuePtr {
+	if payload := m.appendOnlyPayload(ent); payload != nil {
+		return payload.ptr
+	}
+	return page.ValuePtr{}
 }
 
 func appendOnlyValueArenaClassForLen(length int) (idx int, classCap int, ok bool) {
@@ -492,14 +566,14 @@ func appendOnlyKeyU64(key []byte) (uint64, bool) {
 	return binary.BigEndian.Uint64(key), true
 }
 
-func entryValueSize(flags byte, value string) int {
+func entryValueSize(flags byte, valueLen int) int {
 	if flags&node.FlagPointer != 0 {
-		return page.ValuePtrSize + len(value)
+		return page.ValuePtrSize + valueLen
 	}
 	if flags&node.FlagTombstone != 0 {
 		return 0
 	}
-	return len(value)
+	return valueLen
 }
 
 func appendOnlyShouldPredictHint(count int) bool {
@@ -635,8 +709,10 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	idx := m.count
 	m.count++
 	ent := &m.entries[idx]
-	ent.ptr = ptr
 	ent.flags = flags
+	ent.payloadIndex = 0
+	payloadValue := ""
+	payloadPtr := page.ValuePtr{}
 	if len(key) == appendOnlyInlineKeyLen {
 		copy(ent.inlineKey[:], key)
 		ent.flags |= appendOnlyEntryFlagKeyInline
@@ -647,24 +723,31 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		ent.key = appendOnlyArenaStringCopy(&m.valueArena, key)
 	}
 	if steal {
-		ent.value = appendOnlyStringFromBytes(value)
+		payloadValue = appendOnlyStringFromBytes(value)
 	} else {
 		if len(value) > 0 {
 			if borrowValue {
-				ent.value = appendOnlyStringFromBytes(value)
+				payloadValue = appendOnlyStringFromBytes(value)
 			} else {
-				ent.value = appendOnlyArenaStringCopy(&m.valueArena, value)
+				payloadValue = appendOnlyArenaStringCopy(&m.valueArena, value)
 			}
-		} else {
-			ent.value = ""
 		}
 	}
+	if flags&node.FlagPointer != 0 {
+		payloadPtr = ptr
+	}
 	if flags&node.FlagTombstone != 0 {
-		ent.value = ""
-		ent.ptr = page.ValuePtr{}
+		payloadValue = ""
+		payloadPtr = page.ValuePtr{}
+	} else if payloadValue != "" || payloadPtr != (page.ValuePtr{}) {
+		m.payloads = append(m.payloads, appendOnlyPayload{
+			value: payloadValue,
+			ptr:   payloadPtr,
+		})
+		ent.payloadIndex = uint32(len(m.payloads))
 	}
 	k := appendOnlyEntryKey(ent)
-	m.sizeBytes += int64(len(k) + entryValueSize(flags, ent.value))
+	m.sizeBytes += int64(len(k) + entryValueSize(flags, len(payloadValue)))
 	if appendOnlyShouldPredictHint(m.count) {
 		m.maybeRaisePredictedGrowthHintLocked()
 	}
@@ -808,7 +891,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 		m.mu.RLock()
 		if ent := m.orderedLookupEntryLocked(key); ent != nil {
 			deleted := ent.flags&node.FlagTombstone != 0
-			val := appendOnlyEntryValue(ent)
+			val := m.appendOnlyEntryValue(ent)
 			m.mu.RUnlock()
 			if deleted {
 				return nil, true, true
@@ -826,7 +909,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
-						val := appendOnlyEntryValue(ent)
+						val := m.appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
 						if deleted {
 							return nil, true, true
@@ -840,7 +923,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
-						val := appendOnlyEntryValue(ent)
+						val := m.appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
 						if deleted {
 							return nil, true, true
@@ -867,8 +950,8 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 	for {
 		m.mu.RLock()
 		if ent := m.orderedLookupEntryLocked(key); ent != nil {
-			val := appendOnlyEntryValue(ent)
-			ptr := ent.ptr
+			val := m.appendOnlyEntryValue(ent)
+			ptr := m.appendOnlyEntryPtr(ent)
 			flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 			m.mu.RUnlock()
 			return val, ptr, flags, true
@@ -883,8 +966,8 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 				if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
-						val := appendOnlyEntryValue(ent)
-						ptr := ent.ptr
+						val := m.appendOnlyEntryValue(ent)
+						ptr := m.appendOnlyEntryPtr(ent)
 						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 						m.mu.RUnlock()
 						return val, ptr, flags, true
@@ -895,8 +978,8 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
-						val := appendOnlyEntryValue(ent)
-						ptr := ent.ptr
+						val := m.appendOnlyEntryValue(ent)
+						ptr := m.appendOnlyEntryPtr(ent)
 						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 						m.mu.RUnlock()
 						return val, ptr, flags, true
@@ -1040,11 +1123,12 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	}
 	for i := 0; i < m.count; i++ {
 		ent := &m.entries[i]
-		ent.ptr = page.ValuePtr{}
 		ent.flags = 0
 		ent.key = ""
-		ent.value = ""
+		ent.payloadIndex = 0
 	}
+	clear(m.payloads)
+	m.payloads = m.payloads[:0]
 	m.valueArena.reset()
 	if !retainObserved {
 		m.valueArena.dropRetained()
@@ -1139,20 +1223,34 @@ func (m *AppendOnly) buildSortedLatestSnapshotLocked() []*appendOnlyEntry {
 	return snapshot
 }
 
-func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() []appendOnlyEntry {
+func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntry, []appendOnlyPayload) {
 	if m.count == 0 {
 		m.clearSnapshotLocked()
-		return getAppendOnlyIteratorEntries(0)
+		return getAppendOnlyIteratorEntries(0), getAppendOnlyIteratorPayloads(0)
 	}
 	indices := m.buildSortedLatestIndicesLocked()
 	active := m.entries[:m.count]
 	entries := getAppendOnlyIteratorEntries(len(indices))
+	payloadCount := 0
+	for _, idx := range indices {
+		if active[idx].payloadIndex != 0 {
+			payloadCount++
+		}
+	}
+	payloads := getAppendOnlyIteratorPayloads(payloadCount)
+	nextPayload := 0
 	for i, idx := range indices {
-		entries[i] = active[idx]
+		ent := active[idx]
+		if ent.payloadIndex != 0 {
+			payloads[nextPayload] = m.payloads[ent.payloadIndex-1]
+			ent.payloadIndex = uint32(nextPayload + 1)
+			nextPayload++
+		}
+		entries[i] = ent
 	}
 	m.indexBuf = indices[:0]
 	m.clearSnapshotLocked()
-	return entries
+	return entries, payloads
 }
 
 func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
@@ -1164,6 +1262,7 @@ func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 			start:   start,
 			end:     end,
 			mu:      &m.mu,
+			owner:   m,
 		}
 		if start != nil {
 			it.Seek(start)
@@ -1184,6 +1283,7 @@ func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 			entryPtrs:       snapshotPtrs,
 			start:           start,
 			end:             end,
+			owner:           m,
 			pooledEntryPtrs: false,
 			leaseOwner:      m,
 			leaseHeld:       true,
@@ -1194,11 +1294,12 @@ func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 		}
 		return it
 	}
-	entries := m.buildMutableSortedIteratorEntriesLocked()
+	entries, payloads := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		payloads:      payloads,
 		start:         start,
 		end:           end,
 		pooledEntries: true,
@@ -1219,6 +1320,7 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 			start:   start,
 			end:     end,
 			mu:      &m.mu,
+			owner:   m,
 			reverse: true,
 		}
 		it.seekToReverseEnd(end)
@@ -1238,6 +1340,7 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 			entryPtrs:       snapshotPtrs,
 			start:           start,
 			end:             end,
+			owner:           m,
 			pooledEntryPtrs: false,
 			leaseOwner:      m,
 			leaseHeld:       true,
@@ -1246,11 +1349,12 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 		it.seekToReverseEnd(end)
 		return it
 	}
-	entries := m.buildMutableSortedIteratorEntriesLocked()
+	entries, payloads := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		payloads:      payloads,
 		start:         start,
 		end:           end,
 		pooledEntries: true,
@@ -1262,11 +1366,13 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 
 type appendOnlyIterator struct {
 	entries         []appendOnlyEntry
+	payloads        []appendOnlyPayload
 	entryPtrs       []*appendOnlyEntry
 	idx             int
 	start           []byte
 	end             []byte
 	mu              *sync.RWMutex
+	owner           *AppendOnly
 	pooledEntries   bool
 	pooledEntryPtrs bool
 	leaseOwner      *AppendOnly
@@ -1295,6 +1401,20 @@ func (it *appendOnlyIterator) entryAt(idx int) *appendOnlyEntry {
 		return nil
 	}
 	return &it.entries[idx]
+}
+
+func (it *appendOnlyIterator) payloadForEntry(ent *appendOnlyEntry) *appendOnlyPayload {
+	if ent == nil || ent.payloadIndex == 0 {
+		return nil
+	}
+	if it.owner != nil {
+		return it.owner.appendOnlyPayload(ent)
+	}
+	idx := int(ent.payloadIndex - 1)
+	if idx < 0 || idx >= len(it.payloads) {
+		return nil
+	}
+	return &it.payloads[idx]
 }
 
 func (it *appendOnlyIterator) validIndex() bool {
@@ -1393,7 +1513,7 @@ func (it *appendOnlyIterator) UnsafeValue() []byte {
 	if ent.flags&node.FlagTombstone != 0 {
 		return nil
 	}
-	return appendOnlyEntryValue(ent)
+	return appendOnlyPayloadValue(it.payloadForEntry(ent))
 }
 
 func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
@@ -1401,7 +1521,12 @@ func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	if ent == nil || !it.validIndex() {
 		return nil, page.ValuePtr{}, 0
 	}
-	return appendOnlyEntryValue(ent), ent.ptr, ent.flags &^ appendOnlyEntryFlagKeyInline
+	payload := it.payloadForEntry(ent)
+	ptr := page.ValuePtr{}
+	if payload != nil {
+		ptr = payload.ptr
+	}
+	return appendOnlyPayloadValue(payload), ptr, ent.flags &^ appendOnlyEntryFlagKeyInline
 }
 
 func (it *appendOnlyIterator) IsDeleted() bool {
@@ -1445,6 +1570,7 @@ func (it *appendOnlyIterator) Close() error {
 	}
 	if it.pooledEntries {
 		putAppendOnlyIteratorEntries(it.entries)
+		putAppendOnlyIteratorPayloads(it.payloads)
 		it.pooledEntries = false
 	}
 	if it.pooledEntryPtrs {
@@ -1456,7 +1582,9 @@ func (it *appendOnlyIterator) Close() error {
 		it.leaseHeld = false
 	}
 	it.leaseOwner = nil
+	it.owner = nil
 	it.entries = nil
+	it.payloads = nil
 	it.entryPtrs = nil
 	return nil
 }

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -25,7 +25,6 @@ const (
 	appendOnlyEntryPoolMaxCap               = 1 << 20
 	appendOnlyIteratorPoolMaxCap            = 1 << 20
 	appendOnlyIteratorPtrPoolMaxCap         = 1 << 20
-	appendOnlyReusableKeyMaxCap             = 1 << 10
 	appendOnlyValueArenaMinShift            = 12
 	appendOnlyValueArenaMaxShift            = 20
 	appendOnlyValueArenaClassCount          = appendOnlyValueArenaMaxShift - appendOnlyValueArenaMinShift + 1
@@ -45,7 +44,7 @@ var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
 
 type appendOnlyEntry struct {
-	key       []byte
+	key       string
 	value     string
 	ptr       page.ValuePtr
 	inlineKey [appendOnlyInlineKeyLen]byte
@@ -280,7 +279,10 @@ func appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
 	if ent.flags&appendOnlyEntryFlagKeyInline != 0 {
 		return ent.inlineKey[:]
 	}
-	return ent.key
+	if len(ent.key) == 0 {
+		return nil
+	}
+	return unsafe.Slice(unsafe.StringData(ent.key), len(ent.key))
 }
 
 func appendOnlyEntryValue(ent *appendOnlyEntry) []byte {
@@ -306,21 +308,13 @@ func cloneBytes(src []byte) []byte {
 	return dst
 }
 
-func cloneOrReuseBytes(dst, src []byte, maxCap int) []byte {
+func appendOnlyArenaStringCopy(arena *appendOnlyValueArena, src []byte) string {
 	if len(src) == 0 {
-		return nil
+		return ""
 	}
-	if maxCap <= 0 {
-		maxCap = len(src)
-	}
-	if cap(dst) >= len(src) && cap(dst) <= maxCap {
-		out := dst[:len(src)]
-		copy(out, src)
-		return out
-	}
-	out := make([]byte, len(src))
-	copy(out, src)
-	return out
+	buf := arena.alloc(len(src))
+	copy(buf, src)
+	return appendOnlyStringFromBytes(buf)
 }
 
 func appendOnlyValueArenaClassForLen(length int) (idx int, classCap int, ok bool) {
@@ -643,24 +637,23 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	ent := &m.entries[idx]
 	ent.ptr = ptr
 	ent.flags = flags
+	if len(key) == appendOnlyInlineKeyLen {
+		copy(ent.inlineKey[:], key)
+		ent.flags |= appendOnlyEntryFlagKeyInline
+		ent.key = ""
+	} else if steal {
+		ent.key = appendOnlyStringFromBytes(key)
+	} else {
+		ent.key = appendOnlyArenaStringCopy(&m.valueArena, key)
+	}
 	if steal {
-		ent.key = key
 		ent.value = appendOnlyStringFromBytes(value)
 	} else {
-		if len(key) == appendOnlyInlineKeyLen {
-			copy(ent.inlineKey[:], key)
-			ent.flags |= appendOnlyEntryFlagKeyInline
-			ent.key = nil
-		} else {
-			ent.key = cloneOrReuseBytes(ent.key, key, appendOnlyReusableKeyMaxCap)
-		}
 		if len(value) > 0 {
 			if borrowValue {
 				ent.value = appendOnlyStringFromBytes(value)
 			} else {
-				buf := m.valueArena.alloc(len(value))
-				copy(buf, value)
-				ent.value = appendOnlyStringFromBytes(buf)
+				ent.value = appendOnlyArenaStringCopy(&m.valueArena, value)
 			}
 		} else {
 			ent.value = ""
@@ -1049,11 +1042,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		ent := &m.entries[i]
 		ent.ptr = page.ValuePtr{}
 		ent.flags = 0
-		if cap(ent.key) > appendOnlyReusableKeyMaxCap {
-			ent.key = nil
-		} else if ent.key != nil {
-			ent.key = ent.key[:0]
-		}
+		ent.key = ""
 		ent.value = ""
 	}
 	m.valueArena.reset()

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -64,6 +64,12 @@ type appendOnlyEntry struct {
 	flags        byte
 }
 
+type appendOnlyIteratorInlineKey struct {
+	idx    int
+	length uint8
+	key    [appendOnlyInlineKeyLen]byte
+}
+
 type appendOnlyValueArena struct {
 	chunks    [][]byte
 	retained  [][]byte
@@ -639,15 +645,28 @@ func appendOnlyNextCapacity(current int) int {
 	return next
 }
 
-func appendOnlyKeyString(key []byte) string {
-	return string(key)
-}
-
 func appendOnlyLookupKeyString(key []byte) string {
 	if len(key) == 0 {
 		return ""
 	}
 	return unsafe.String(unsafe.SliceData(key), len(key))
+}
+
+func (m *AppendOnly) appendOnlyEntryMapKey(ent *appendOnlyEntry) string {
+	if m == nil || ent == nil {
+		return ""
+	}
+	if ent.inlineKeyLen != 0 {
+		return string(ent.inlineKey[:int(ent.inlineKeyLen)])
+	}
+	if ent.keyIndex == 0 {
+		return ""
+	}
+	idx := int(ent.keyIndex - 1)
+	if idx < 0 || idx >= len(m.keys) {
+		return ""
+	}
+	return m.keys[idx]
 }
 
 func appendOnlyKeyU64(key []byte) (uint64, bool) {
@@ -787,7 +806,7 @@ func (m *AppendOnly) rebuildLatestIndexLocked() {
 		if m.latest == nil {
 			m.latest = make(map[string]int, reserve)
 		}
-		m.latest[appendOnlyKeyString(k)] = i
+		m.latest[m.appendOnlyEntryMapKey(&active[i])] = i
 	}
 	m.latestDirty = false
 	m.clearSnapshotLocked()
@@ -807,7 +826,7 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 	if m.latest == nil {
 		m.latest = make(map[string]int, 1)
 	}
-	m.latest[appendOnlyKeyString(key)] = idx
+	m.latest[m.appendOnlyEntryMapKey(&m.entries[idx])] = idx
 }
 
 func (m *AppendOnly) appendKeyLocked(key string) uint32 {
@@ -1406,32 +1425,43 @@ func (m *AppendOnly) buildSortedLatestSnapshotLocked() []*appendOnlyEntry {
 	return snapshot
 }
 
-func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntry, []string, []appendOnlyPayload) {
+func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntry, []string, []appendOnlyPayload, []byte) {
 	if m.count == 0 {
 		m.clearSnapshotLocked()
-		return getAppendOnlyIteratorEntries(0), getAppendOnlyIteratorKeys(0), getAppendOnlyIteratorPayloads(0)
+		return getAppendOnlyIteratorEntries(0), getAppendOnlyIteratorKeys(0), getAppendOnlyIteratorPayloads(0), nil
 	}
 	indices := m.buildSortedLatestIndicesLocked()
 	active := m.entries[:m.count]
 	entries := getAppendOnlyIteratorEntries(len(indices))
 	keyCount := 0
 	payloadCount := 0
+	inlineKeyBytes := 0
 	for _, idx := range indices {
 		if active[idx].inlineKeyLen != 0 || active[idx].keyIndex != 0 {
 			keyCount++
 		}
+		inlineKeyBytes += int(active[idx].inlineKeyLen)
 		if active[idx].payloadIndex != 0 {
 			payloadCount++
 		}
 	}
 	keys := getAppendOnlyIteratorKeys(keyCount)
 	payloads := getAppendOnlyIteratorPayloads(payloadCount)
+	var keyBytes []byte
+	if inlineKeyBytes > 0 {
+		keyBytes = make([]byte, inlineKeyBytes)
+	}
 	nextKey := 0
+	nextKeyByte := 0
 	nextPayload := 0
 	for i, idx := range indices {
 		ent := active[idx]
 		if ent.inlineKeyLen != 0 {
-			keys[nextKey] = appendOnlyArenaStringCopy(&m.valueArena, ent.inlineKey[:int(ent.inlineKeyLen)])
+			inlineLen := int(ent.inlineKeyLen)
+			next := nextKeyByte + inlineLen
+			copy(keyBytes[nextKeyByte:next], ent.inlineKey[:inlineLen])
+			keys[nextKey] = appendOnlyStringFromBytes(keyBytes[nextKeyByte:next])
+			nextKeyByte = next
 			ent.inlineKey = [appendOnlyInlineKeyLen]byte{}
 			ent.inlineKeyLen = 0
 			ent.keyIndex = uint32(nextKey + 1)
@@ -1450,19 +1480,30 @@ func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntr
 	}
 	m.indexBuf = indices[:0]
 	m.clearSnapshotLocked()
-	return entries, keys, payloads
+	return entries, keys, payloads, keyBytes
 }
 
-func appendOnlyOrderedIteratorInlineKeys(entries []appendOnlyEntry) [][]byte {
-	var inlineKeys [][]byte
+func appendOnlyOrderedIteratorInlineKeys(entries []appendOnlyEntry) []appendOnlyIteratorInlineKey {
+	inlineCount := 0
 	for i := range entries {
-		if entries[i].inlineKeyLen == 0 {
+		if entries[i].inlineKeyLen != 0 {
+			inlineCount++
+		}
+	}
+	if inlineCount == 0 {
+		return nil
+	}
+	inlineKeys := make([]appendOnlyIteratorInlineKey, 0, inlineCount)
+	for i := range entries {
+		inlineLen := entries[i].inlineKeyLen
+		if inlineLen == 0 {
 			continue
 		}
-		if inlineKeys == nil {
-			inlineKeys = make([][]byte, len(entries))
-		}
-		inlineKeys[i] = cloneBytes(entries[i].inlineKey[:int(entries[i].inlineKeyLen)])
+		inlineKeys = append(inlineKeys, appendOnlyIteratorInlineKey{
+			idx:    i,
+			length: inlineLen,
+		})
+		copy(inlineKeys[len(inlineKeys)-1].key[:], entries[i].inlineKey[:int(inlineLen)])
 	}
 	return inlineKeys
 }
@@ -1509,12 +1550,13 @@ func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 		}
 		return it
 	}
-	entries, keys, payloads := m.buildMutableSortedIteratorEntriesLocked()
+	entries, keys, payloads, keyBytes := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
 		keys:          keys,
+		keyBytes:      keyBytes,
 		payloads:      payloads,
 		start:         start,
 		end:           end,
@@ -1566,12 +1608,13 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 		it.seekToReverseEnd(end)
 		return it
 	}
-	entries, keys, payloads := m.buildMutableSortedIteratorEntriesLocked()
+	entries, keys, payloads, keyBytes := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
 		keys:          keys,
+		keyBytes:      keyBytes,
 		payloads:      payloads,
 		start:         start,
 		end:           end,
@@ -1585,7 +1628,8 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 type appendOnlyIterator struct {
 	entries         []appendOnlyEntry
 	keys            []string
-	inlineKeys      [][]byte
+	keyBytes        []byte
+	inlineKeys      []appendOnlyIteratorInlineKey
 	payloads        []appendOnlyPayload
 	entryPtrs       []*appendOnlyEntry
 	idx             int
@@ -1645,6 +1689,20 @@ func (it *appendOnlyIterator) keyForEntry(ent *appendOnlyEntry) []byte {
 		return it.owner.appendOnlyEntryKey(ent)
 	}
 	return appendOnlyEntryKeyFromKeys(ent, it.keys)
+}
+
+func (it *appendOnlyIterator) inlineKeyForIndex(idx int) []byte {
+	if len(it.inlineKeys) == 0 {
+		return nil
+	}
+	pos := sort.Search(len(it.inlineKeys), func(i int) bool {
+		return it.inlineKeys[i].idx >= idx
+	})
+	if pos >= len(it.inlineKeys) || it.inlineKeys[pos].idx != idx {
+		return nil
+	}
+	inlineKey := &it.inlineKeys[pos]
+	return inlineKey.key[:int(inlineKey.length)]
 }
 
 func (it *appendOnlyIterator) validIndex() bool {
@@ -1732,8 +1790,8 @@ func (it *appendOnlyIterator) UnsafeKey() []byte {
 	if ent == nil || !it.validIndex() {
 		return nil
 	}
-	if it.inlineKeys != nil && it.idx >= 0 && it.idx < len(it.inlineKeys) && it.inlineKeys[it.idx] != nil {
-		return it.inlineKeys[it.idx]
+	if inlineKey := it.inlineKeyForIndex(it.idx); inlineKey != nil {
+		return inlineKey
 	}
 	return it.keyForEntry(ent)
 }
@@ -1819,6 +1877,7 @@ func (it *appendOnlyIterator) Close() error {
 	it.owner = nil
 	it.entries = nil
 	it.keys = nil
+	it.keyBytes = nil
 	it.inlineKeys = nil
 	it.payloads = nil
 	it.entryPtrs = nil

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -639,6 +639,13 @@ func appendOnlyKeyString(key []byte) string {
 	return string(key)
 }
 
+func appendOnlyLookupKeyString(key []byte) string {
+	if len(key) == 0 {
+		return ""
+	}
+	return unsafe.String(unsafe.SliceData(key), len(key))
+}
+
 func appendOnlyKeyU64(key []byte) (uint64, bool) {
 	if len(key) != appendOnlyInlineKeyLen {
 		return 0, false
@@ -799,6 +806,44 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 	m.latest[appendOnlyKeyString(key)] = idx
 }
 
+func (m *AppendOnly) appendKeyLocked(key string) uint32 {
+	if len(m.keys) == cap(m.keys) {
+		nextCap := appendOnlyMinInitialEntries
+		if cap(m.keys) > 0 {
+			nextCap = appendOnlyNextCapacity(cap(m.keys))
+		}
+		if nextCap < len(m.keys)+1 {
+			nextCap = len(m.keys) + 1
+		}
+		prev := m.keys
+		grown := getAppendOnlyKeys(nextCap)
+		copy(grown, prev)
+		m.keys = grown[:len(prev)]
+		putAppendOnlyKeys(prev)
+	}
+	m.keys = append(m.keys, key)
+	return uint32(len(m.keys))
+}
+
+func (m *AppendOnly) appendPayloadLocked(payload appendOnlyPayload) uint32 {
+	if len(m.payloads) == cap(m.payloads) {
+		nextCap := appendOnlyMinInitialEntries
+		if cap(m.payloads) > 0 {
+			nextCap = appendOnlyNextCapacity(cap(m.payloads))
+		}
+		if nextCap < len(m.payloads)+1 {
+			nextCap = len(m.payloads) + 1
+		}
+		prev := m.payloads
+		grown := getAppendOnlyPayloads(nextCap)
+		copy(grown, prev)
+		m.payloads = grown[:len(prev)]
+		putAppendOnlyPayloads(prev)
+	}
+	m.payloads = append(m.payloads, payload)
+	return uint32(len(m.payloads))
+}
+
 func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) appendOnlyObserveEvent {
 	var observeEvent appendOnlyObserveEvent
 	grewEntries := false
@@ -835,11 +880,9 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		copy(ent.inlineKey[:], key)
 		ent.inlineKeyLen = uint8(len(key))
 	} else if steal {
-		m.keys = append(m.keys, appendOnlyStringFromBytes(key))
-		ent.keyIndex = uint32(len(m.keys))
+		ent.keyIndex = m.appendKeyLocked(appendOnlyStringFromBytes(key))
 	} else {
-		m.keys = append(m.keys, appendOnlyArenaStringCopy(&m.valueArena, key))
-		ent.keyIndex = uint32(len(m.keys))
+		ent.keyIndex = m.appendKeyLocked(appendOnlyArenaStringCopy(&m.valueArena, key))
 	}
 	if steal {
 		payloadValue = appendOnlyStringFromBytes(value)
@@ -859,11 +902,10 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		payloadValue = ""
 		payloadPtr = page.ValuePtr{}
 	} else if payloadValue != "" || payloadPtr != (page.ValuePtr{}) {
-		m.payloads = append(m.payloads, appendOnlyPayload{
+		ent.payloadIndex = m.appendPayloadLocked(appendOnlyPayload{
 			value: payloadValue,
 			ptr:   payloadPtr,
 		})
-		ent.payloadIndex = uint32(len(m.payloads))
 	}
 	k := m.appendOnlyEntryKey(ent)
 	m.sizeBytes += int64(len(k) + entryValueSize(flags, len(payloadValue)))
@@ -1046,7 +1088,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 				}
 			}
 			if m.latest != nil {
-				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
+				if idx, ok := m.latest[appendOnlyLookupKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
@@ -1102,7 +1144,7 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 				}
 			}
 			if m.latest != nil {
-				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
+				if idx, ok := m.latest[appendOnlyLookupKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						val := m.appendOnlyEntryValue(ent)
@@ -1371,7 +1413,7 @@ func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntr
 	keyCount := 0
 	payloadCount := 0
 	for _, idx := range indices {
-		if active[idx].keyIndex != 0 {
+		if active[idx].inlineKeyLen != 0 || active[idx].keyIndex != 0 {
 			keyCount++
 		}
 		if active[idx].payloadIndex != 0 {
@@ -1384,7 +1426,13 @@ func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntr
 	nextPayload := 0
 	for i, idx := range indices {
 		ent := active[idx]
-		if ent.keyIndex != 0 {
+		if ent.inlineKeyLen != 0 {
+			keys[nextKey] = appendOnlyArenaStringCopy(&m.valueArena, ent.inlineKey[:int(ent.inlineKeyLen)])
+			ent.inlineKey = [appendOnlyInlineKeyLen]byte{}
+			ent.inlineKeyLen = 0
+			ent.keyIndex = uint32(nextKey + 1)
+			nextKey++
+		} else if ent.keyIndex != 0 {
 			keys[nextKey] = m.keys[ent.keyIndex-1]
 			ent.keyIndex = uint32(nextKey + 1)
 			nextKey++

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -1498,42 +1498,16 @@ func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntr
 	return entries, keys, payloads, keyBytes
 }
 
-func appendOnlyOrderedIteratorInlineKeys(entries []appendOnlyEntry) []appendOnlyIteratorInlineKey {
-	inlineCount := 0
-	for i := range entries {
-		if entries[i].inlineKeyLen != 0 {
-			inlineCount++
-		}
-	}
-	if inlineCount == 0 {
-		return nil
-	}
-	inlineKeys := make([]appendOnlyIteratorInlineKey, 0, inlineCount)
-	for i := range entries {
-		inlineLen := entries[i].inlineKeyLen
-		if inlineLen == 0 {
-			continue
-		}
-		inlineKeys = append(inlineKeys, appendOnlyIteratorInlineKey{
-			idx:    i,
-			length: inlineLen,
-		})
-		copy(inlineKeys[len(inlineKeys)-1].key[:], entries[i].inlineKey[:int(inlineLen)])
-	}
-	return inlineKeys
-}
-
 func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 	m.mu.RLock()
 	if m.ordered {
 		entries := m.entries[:m.count]
 		it := &appendOnlyIterator{
-			entries:    entries,
-			inlineKeys: appendOnlyOrderedIteratorInlineKeys(entries),
-			start:      start,
-			end:        end,
-			mu:         &m.mu,
-			owner:      m,
+			entries: entries,
+			start:   start,
+			end:     end,
+			mu:      &m.mu,
+			owner:   m,
 		}
 		if start != nil {
 			it.Seek(start)
@@ -1589,13 +1563,12 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 	if m.ordered {
 		entries := m.entries[:m.count]
 		it := &appendOnlyIterator{
-			entries:    entries,
-			inlineKeys: appendOnlyOrderedIteratorInlineKeys(entries),
-			start:      start,
-			end:        end,
-			mu:         &m.mu,
-			owner:      m,
-			reverse:    true,
+			entries: entries,
+			start:   start,
+			end:     end,
+			mu:      &m.mu,
+			owner:   m,
+			reverse: true,
 		}
 		it.seekToReverseEnd(end)
 		return it
@@ -1644,9 +1617,10 @@ type appendOnlyIterator struct {
 	entries         []appendOnlyEntry
 	keys            []string
 	keyBytes        []byte
-	inlineKeys      []appendOnlyIteratorInlineKey
 	payloads        []appendOnlyPayload
 	entryPtrs       []*appendOnlyEntry
+	inlineKeys      []appendOnlyIteratorInlineKey
+	inlineKeyIndex  map[int]int
 	idx             int
 	start           []byte
 	end             []byte
@@ -1706,18 +1680,46 @@ func (it *appendOnlyIterator) keyForEntry(ent *appendOnlyEntry) []byte {
 	return appendOnlyEntryKeyFromKeys(ent, it.keys)
 }
 
-func (it *appendOnlyIterator) inlineKeyForIndex(idx int) []byte {
-	if len(it.inlineKeys) == 0 {
+func (it *appendOnlyIterator) inlineKeyForEntry(idx int, ent *appendOnlyEntry) []byte {
+	if ent == nil || ent.inlineKeyLen == 0 {
 		return nil
 	}
-	pos := sort.Search(len(it.inlineKeys), func(i int) bool {
-		return it.inlineKeys[i].idx >= idx
+	inlineLen := int(ent.inlineKeyLen)
+	if n := len(it.inlineKeys); n > 0 {
+		last := &it.inlineKeys[n-1]
+		if last.idx == idx {
+			return last.key[:int(last.length)]
+		}
+	}
+	if it.inlineKeyIndex != nil {
+		if pos, ok := it.inlineKeyIndex[idx]; ok {
+			inlineKey := &it.inlineKeys[pos]
+			return inlineKey.key[:int(inlineKey.length)]
+		}
+	} else {
+		for i := len(it.inlineKeys) - 1; i >= 0; i-- {
+			if it.inlineKeys[i].idx == idx {
+				inlineKey := &it.inlineKeys[i]
+				return inlineKey.key[:int(inlineKey.length)]
+			}
+		}
+		if len(it.inlineKeys) >= 8 {
+			it.inlineKeyIndex = make(map[int]int, len(it.inlineKeys)+1)
+			for i := range it.inlineKeys {
+				it.inlineKeyIndex[it.inlineKeys[i].idx] = i
+			}
+		}
+	}
+	it.inlineKeys = append(it.inlineKeys, appendOnlyIteratorInlineKey{
+		idx:    idx,
+		length: ent.inlineKeyLen,
 	})
-	if pos >= len(it.inlineKeys) || it.inlineKeys[pos].idx != idx {
-		return nil
+	copy(it.inlineKeys[len(it.inlineKeys)-1].key[:], ent.inlineKey[:inlineLen])
+	if it.inlineKeyIndex != nil {
+		it.inlineKeyIndex[idx] = len(it.inlineKeys) - 1
 	}
-	inlineKey := &it.inlineKeys[pos]
-	return inlineKey.key[:int(inlineKey.length)]
+	inlineKey := &it.inlineKeys[len(it.inlineKeys)-1]
+	return inlineKey.key[:inlineLen]
 }
 
 func (it *appendOnlyIterator) validIndex() bool {
@@ -1805,7 +1807,7 @@ func (it *appendOnlyIterator) UnsafeKey() []byte {
 	if ent == nil || !it.validIndex() {
 		return nil
 	}
-	if inlineKey := it.inlineKeyForIndex(it.idx); inlineKey != nil {
+	if inlineKey := it.inlineKeyForEntry(it.idx, ent); inlineKey != nil {
 		return inlineKey
 	}
 	return it.keyForEntry(ent)
@@ -1894,6 +1896,7 @@ func (it *appendOnlyIterator) Close() error {
 	it.keys = nil
 	it.keyBytes = nil
 	it.inlineKeys = nil
+	it.inlineKeyIndex = nil
 	it.payloads = nil
 	it.entryPtrs = nil
 	return nil

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -23,8 +23,10 @@ const (
 	appendOnlyMaxInitialEntries             = 1 << 20
 	appendOnlyInlineKeyLen                  = 8
 	appendOnlyEntryPoolMaxCap               = 1 << 20
+	appendOnlyKeyPoolMaxCap                 = 1 << 20
 	appendOnlyPayloadPoolMaxCap             = 1 << 20
 	appendOnlyIteratorPoolMaxCap            = 1 << 20
+	appendOnlyIteratorKeyPoolMaxCap         = 1 << 20
 	appendOnlyIteratorPayloadPoolMaxCap     = 1 << 20
 	appendOnlyIteratorPtrPoolMaxCap         = 1 << 20
 	appendOnlyValueArenaMinShift            = 12
@@ -41,8 +43,10 @@ const (
 )
 
 var appendOnlyEntryPool sync.Pool
+var appendOnlyKeyPool sync.Pool
 var appendOnlyPayloadPool sync.Pool
 var appendOnlyIteratorPool sync.Pool
+var appendOnlyIteratorKeyPool sync.Pool
 var appendOnlyIteratorPayloadPool sync.Pool
 var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
@@ -52,9 +56,9 @@ type appendOnlyPayload struct {
 	ptr   page.ValuePtr
 }
 type appendOnlyEntry struct {
-	key          string
-	payloadIndex uint32
 	inlineKey    [appendOnlyInlineKeyLen]byte
+	keyIndex     uint32
+	payloadIndex uint32
 	flags        byte
 }
 
@@ -72,6 +76,7 @@ type AppendOnly struct {
 	mu sync.RWMutex
 
 	entries        []appendOnlyEntry
+	keys           []string
 	payloads       []appendOnlyPayload
 	baseEntriesLen int
 	growEntriesLen int
@@ -151,6 +156,37 @@ func putAppendOnlyEntries(entries []appendOnlyEntry) {
 	appendOnlyEntryPool.Put(full[:0])
 }
 
+func getAppendOnlyKeysFromPool(length int, pool *sync.Pool) []string {
+	if length < 0 {
+		length = 0
+	}
+	if length > appendOnlyKeyPoolMaxCap {
+		return make([]string, length)
+	}
+	if pool == nil {
+		return make([]string, length)
+	}
+	if v := pool.Get(); v != nil {
+		if keys, ok := v.([]string); ok && cap(keys) >= length {
+			return keys[:length]
+		}
+	}
+	return make([]string, length)
+}
+
+func getAppendOnlyKeys(length int) []string {
+	return getAppendOnlyKeysFromPool(length, &appendOnlyKeyPool)
+}
+
+func putAppendOnlyKeys(keys []string) {
+	if keys == nil || cap(keys) == 0 || cap(keys) > appendOnlyKeyPoolMaxCap {
+		return
+	}
+	full := keys[:cap(keys)]
+	clear(full)
+	appendOnlyKeyPool.Put(full[:0])
+}
+
 func getAppendOnlyPayloadsFromPool(length int, pool *sync.Pool) []appendOnlyPayload {
 	if length < 0 {
 		length = 0
@@ -205,6 +241,19 @@ func putAppendOnlyIteratorEntries(entries []appendOnlyEntry) {
 	}
 	clear(entries)
 	appendOnlyIteratorPool.Put(entries[:0])
+}
+
+func getAppendOnlyIteratorKeys(length int) []string {
+	return getAppendOnlyKeysFromPool(length, &appendOnlyIteratorKeyPool)
+}
+
+func putAppendOnlyIteratorKeys(keys []string) {
+	if keys == nil || cap(keys) == 0 || cap(keys) > appendOnlyIteratorKeyPoolMaxCap {
+		return
+	}
+	full := keys[:cap(keys)]
+	clear(full)
+	appendOnlyIteratorKeyPool.Put(full[:0])
 }
 
 func getAppendOnlyIteratorPayloads(length int) []appendOnlyPayload {
@@ -324,17 +373,25 @@ func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, observeEntri
 	m.observeEntries = observeEntries
 }
 
-func appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
+func appendOnlyEntryKeyFromKeys(ent *appendOnlyEntry, keys []string) []byte {
 	if ent == nil {
 		return nil
 	}
 	if ent.flags&appendOnlyEntryFlagKeyInline != 0 {
 		return ent.inlineKey[:]
 	}
-	if len(ent.key) == 0 {
+	if ent.keyIndex == 0 {
 		return nil
 	}
-	return unsafe.Slice(unsafe.StringData(ent.key), len(ent.key))
+	idx := int(ent.keyIndex - 1)
+	if idx < 0 || idx >= len(keys) {
+		return nil
+	}
+	key := keys[idx]
+	if len(key) == 0 {
+		return nil
+	}
+	return unsafe.Slice(unsafe.StringData(key), len(key))
 }
 
 func appendOnlyPayloadValue(payload *appendOnlyPayload) []byte {
@@ -367,6 +424,13 @@ func appendOnlyArenaStringCopy(arena *appendOnlyValueArena, src []byte) string {
 	buf := arena.alloc(len(src))
 	copy(buf, src)
 	return appendOnlyStringFromBytes(buf)
+}
+
+func (m *AppendOnly) appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
+	if m == nil {
+		return appendOnlyEntryKeyFromKeys(ent, nil)
+	}
+	return appendOnlyEntryKeyFromKeys(ent, m.keys)
 }
 
 func (m *AppendOnly) appendOnlyPayload(ent *appendOnlyEntry) *appendOnlyPayload {
@@ -632,8 +696,8 @@ func (m *AppendOnly) buildSortedLatestIndicesLocked() []int {
 	active := m.entries[:m.count]
 	sort.Slice(indices, func(i, j int) bool {
 		return bytes.Compare(
-			appendOnlyEntryKey(&active[indices[i]]),
-			appendOnlyEntryKey(&active[indices[j]]),
+			m.appendOnlyEntryKey(&active[indices[i]]),
+			m.appendOnlyEntryKey(&active[indices[j]]),
 		) < 0
 	})
 	return indices
@@ -660,7 +724,7 @@ func (m *AppendOnly) rebuildLatestIndexLocked() {
 	reserve := m.count
 	active := m.entries[:m.count]
 	for i := range active {
-		k := appendOnlyEntryKey(&active[i])
+		k := m.appendOnlyEntryKey(&active[i])
 		if k64, ok := appendOnlyKeyU64(k); ok {
 			if m.latest64 == nil {
 				m.latest64 = make(map[uint64]int, reserve)
@@ -710,17 +774,19 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	m.count++
 	ent := &m.entries[idx]
 	ent.flags = flags
+	ent.keyIndex = 0
 	ent.payloadIndex = 0
 	payloadValue := ""
 	payloadPtr := page.ValuePtr{}
 	if len(key) == appendOnlyInlineKeyLen {
 		copy(ent.inlineKey[:], key)
 		ent.flags |= appendOnlyEntryFlagKeyInline
-		ent.key = ""
 	} else if steal {
-		ent.key = appendOnlyStringFromBytes(key)
+		m.keys = append(m.keys, appendOnlyStringFromBytes(key))
+		ent.keyIndex = uint32(len(m.keys))
 	} else {
-		ent.key = appendOnlyArenaStringCopy(&m.valueArena, key)
+		m.keys = append(m.keys, appendOnlyArenaStringCopy(&m.valueArena, key))
+		ent.keyIndex = uint32(len(m.keys))
 	}
 	if steal {
 		payloadValue = appendOnlyStringFromBytes(value)
@@ -746,7 +812,7 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		})
 		ent.payloadIndex = uint32(len(m.payloads))
 	}
-	k := appendOnlyEntryKey(ent)
+	k := m.appendOnlyEntryKey(ent)
 	m.sizeBytes += int64(len(k) + entryValueSize(flags, len(payloadValue)))
 	if appendOnlyShouldPredictHint(m.count) {
 		m.maybeRaisePredictedGrowthHintLocked()
@@ -758,7 +824,7 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		return
 	}
 	if m.ordered {
-		prev := appendOnlyEntryKey(&m.entries[m.lastIdx])
+		prev := m.appendOnlyEntryKey(&m.entries[m.lastIdx])
 		cmp := bytes.Compare(k, prev)
 		if cmp > 0 {
 			m.lastIdx = idx
@@ -874,13 +940,13 @@ func (m *AppendOnly) orderedLookupEntryLocked(key []byte) *appendOnlyEntry {
 	}
 	active := m.entries[:m.count]
 	idx := sort.Search(len(active), func(i int) bool {
-		return bytes.Compare(appendOnlyEntryKey(&active[i]), key) >= 0
+		return bytes.Compare(m.appendOnlyEntryKey(&active[i]), key) >= 0
 	})
 	if idx >= len(active) {
 		return nil
 	}
 	ent := &active[idx]
-	if !bytes.Equal(appendOnlyEntryKey(ent), key) {
+	if !bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 		return nil
 	}
 	return ent
@@ -907,7 +973,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 			if k64, ok := appendOnlyKeyU64(key); ok && m.latest64 != nil {
 				if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
-					if bytes.Equal(appendOnlyEntryKey(ent), key) {
+					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
 						val := m.appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
@@ -921,7 +987,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 			if m.latest != nil {
 				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
-					if bytes.Equal(appendOnlyEntryKey(ent), key) {
+					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
 						val := m.appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
@@ -965,7 +1031,7 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 			if k64, ok := appendOnlyKeyU64(key); ok && m.latest64 != nil {
 				if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
-					if bytes.Equal(appendOnlyEntryKey(ent), key) {
+					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						val := m.appendOnlyEntryValue(ent)
 						ptr := m.appendOnlyEntryPtr(ent)
 						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
@@ -977,7 +1043,7 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 			if m.latest != nil {
 				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
-					if bytes.Equal(appendOnlyEntryKey(ent), key) {
+					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						val := m.appendOnlyEntryValue(ent)
 						ptr := m.appendOnlyEntryPtr(ent)
 						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
@@ -1124,9 +1190,11 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	for i := 0; i < m.count; i++ {
 		ent := &m.entries[i]
 		ent.flags = 0
-		ent.key = ""
+		ent.keyIndex = 0
 		ent.payloadIndex = 0
 	}
+	clear(m.keys)
+	m.keys = m.keys[:0]
 	clear(m.payloads)
 	m.payloads = m.payloads[:0]
 	m.valueArena.reset()
@@ -1223,24 +1291,35 @@ func (m *AppendOnly) buildSortedLatestSnapshotLocked() []*appendOnlyEntry {
 	return snapshot
 }
 
-func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntry, []appendOnlyPayload) {
+func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntry, []string, []appendOnlyPayload) {
 	if m.count == 0 {
 		m.clearSnapshotLocked()
-		return getAppendOnlyIteratorEntries(0), getAppendOnlyIteratorPayloads(0)
+		return getAppendOnlyIteratorEntries(0), getAppendOnlyIteratorKeys(0), getAppendOnlyIteratorPayloads(0)
 	}
 	indices := m.buildSortedLatestIndicesLocked()
 	active := m.entries[:m.count]
 	entries := getAppendOnlyIteratorEntries(len(indices))
+	keyCount := 0
 	payloadCount := 0
 	for _, idx := range indices {
+		if active[idx].keyIndex != 0 {
+			keyCount++
+		}
 		if active[idx].payloadIndex != 0 {
 			payloadCount++
 		}
 	}
+	keys := getAppendOnlyIteratorKeys(keyCount)
 	payloads := getAppendOnlyIteratorPayloads(payloadCount)
+	nextKey := 0
 	nextPayload := 0
 	for i, idx := range indices {
 		ent := active[idx]
+		if ent.keyIndex != 0 {
+			keys[nextKey] = m.keys[ent.keyIndex-1]
+			ent.keyIndex = uint32(nextKey + 1)
+			nextKey++
+		}
 		if ent.payloadIndex != 0 {
 			payloads[nextPayload] = m.payloads[ent.payloadIndex-1]
 			ent.payloadIndex = uint32(nextPayload + 1)
@@ -1250,7 +1329,7 @@ func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntr
 	}
 	m.indexBuf = indices[:0]
 	m.clearSnapshotLocked()
-	return entries, payloads
+	return entries, keys, payloads
 }
 
 func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
@@ -1294,11 +1373,12 @@ func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 		}
 		return it
 	}
-	entries, payloads := m.buildMutableSortedIteratorEntriesLocked()
+	entries, keys, payloads := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		keys:          keys,
 		payloads:      payloads,
 		start:         start,
 		end:           end,
@@ -1349,11 +1429,12 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 		it.seekToReverseEnd(end)
 		return it
 	}
-	entries, payloads := m.buildMutableSortedIteratorEntriesLocked()
+	entries, keys, payloads := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		keys:          keys,
 		payloads:      payloads,
 		start:         start,
 		end:           end,
@@ -1366,6 +1447,7 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 
 type appendOnlyIterator struct {
 	entries         []appendOnlyEntry
+	keys            []string
 	payloads        []appendOnlyPayload
 	entryPtrs       []*appendOnlyEntry
 	idx             int
@@ -1417,6 +1499,16 @@ func (it *appendOnlyIterator) payloadForEntry(ent *appendOnlyEntry) *appendOnlyP
 	return &it.payloads[idx]
 }
 
+func (it *appendOnlyIterator) keyForEntry(ent *appendOnlyEntry) []byte {
+	if ent == nil {
+		return nil
+	}
+	if it.owner != nil {
+		return it.owner.appendOnlyEntryKey(ent)
+	}
+	return appendOnlyEntryKeyFromKeys(ent, it.keys)
+}
+
 func (it *appendOnlyIterator) validIndex() bool {
 	if it.idx < 0 || it.idx >= it.len() {
 		return false
@@ -1425,10 +1517,10 @@ func (it *appendOnlyIterator) validIndex() bool {
 	if ent == nil {
 		return false
 	}
-	if it.start != nil && bytes.Compare(appendOnlyEntryKey(ent), it.start) < 0 {
+	if it.start != nil && bytes.Compare(it.keyForEntry(ent), it.start) < 0 {
 		return false
 	}
-	if it.end != nil && bytes.Compare(appendOnlyEntryKey(ent), it.end) >= 0 {
+	if it.end != nil && bytes.Compare(it.keyForEntry(ent), it.end) >= 0 {
 		return false
 	}
 	return true
@@ -1455,7 +1547,7 @@ func (it *appendOnlyIterator) Seek(key []byte) {
 			if ent == nil {
 				return true
 			}
-			return bytes.Compare(appendOnlyEntryKey(ent), key) >= 0
+			return bytes.Compare(it.keyForEntry(ent), key) >= 0
 		})
 		return
 	}
@@ -1472,7 +1564,7 @@ func (it *appendOnlyIterator) Seek(key []byte) {
 		if ent == nil {
 			return true
 		}
-		return bytes.Compare(appendOnlyEntryKey(ent), key) > 0
+		return bytes.Compare(it.keyForEntry(ent), key) > 0
 	})
 	it.idx = pos - 1
 }
@@ -1492,7 +1584,7 @@ func (it *appendOnlyIterator) seekToReverseEnd(end []byte) {
 		if ent == nil {
 			return true
 		}
-		return bytes.Compare(appendOnlyEntryKey(ent), end) >= 0
+		return bytes.Compare(it.keyForEntry(ent), end) >= 0
 	})
 	it.idx = pos - 1
 }
@@ -1502,7 +1594,7 @@ func (it *appendOnlyIterator) UnsafeKey() []byte {
 	if ent == nil || !it.validIndex() {
 		return nil
 	}
-	return appendOnlyEntryKey(ent)
+	return it.keyForEntry(ent)
 }
 
 func (it *appendOnlyIterator) UnsafeValue() []byte {
@@ -1570,6 +1662,7 @@ func (it *appendOnlyIterator) Close() error {
 	}
 	if it.pooledEntries {
 		putAppendOnlyIteratorEntries(it.entries)
+		putAppendOnlyIteratorKeys(it.keys)
 		putAppendOnlyIteratorPayloads(it.payloads)
 		it.pooledEntries = false
 	}
@@ -1584,6 +1677,7 @@ func (it *appendOnlyIterator) Close() error {
 	it.leaseOwner = nil
 	it.owner = nil
 	it.entries = nil
+	it.keys = nil
 	it.payloads = nil
 	it.entryPtrs = nil
 	return nil

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -64,10 +64,15 @@ type appendOnlyEntry struct {
 	flags        byte
 }
 
-type appendOnlyIteratorInlineKey struct {
-	idx    int
-	length uint8
+type appendOnlyInlineMapKey struct {
 	key    [appendOnlyInlineKeyLen]byte
+	length uint8
+}
+
+type appendOnlyIteratorKeyRef struct {
+	idx    int
+	offset int
+	length int
 }
 
 type appendOnlyValueArena struct {
@@ -87,6 +92,7 @@ type AppendOnly struct {
 	baseEntriesLen int
 	growEntriesLen int
 	latest         map[string]int
+	latestInline   map[appendOnlyInlineMapKey]int
 	latest64       map[uint64]int
 	snapshot       []*appendOnlyEntry
 	indexBuf       []int
@@ -163,29 +169,42 @@ func putAppendOnlyEntries(entries []appendOnlyEntry) {
 	appendOnlyEntryPool.Put(full[:0])
 }
 
-func getAppendOnlyKeysFromPool(length int, pool *sync.Pool, maxCap int) []string {
+func getAppendOnlySliceFromPool[T any](length int, pool *sync.Pool, maxCap, defaultMaxCap int) []T {
 	if length < 0 {
 		length = 0
 	}
 	if maxCap <= 0 {
-		maxCap = appendOnlyKeyPoolMaxCap
+		maxCap = defaultMaxCap
 	}
 	if length > maxCap {
-		return make([]string, length)
+		return make([]T, length)
 	}
 	if pool == nil {
-		return make([]string, length)
+		return make([]T, length)
 	}
 	if v := pool.Get(); v != nil {
-		if keys, ok := v.([]string); ok && cap(keys) >= length {
-			if cap(keys) <= appendOnlyMaxReuseEntries(length) {
-				out := keys[:length]
+		if items, ok := v.([]T); ok && cap(items) >= length {
+			if cap(items) <= appendOnlyMaxReuseEntries(length) {
+				out := items[:length]
 				clear(out)
 				return out
 			}
 		}
 	}
-	return make([]string, length)
+	return make([]T, length)
+}
+
+func putAppendOnlySliceToPool[T any](items []T, pool *sync.Pool, maxCap int) {
+	if items == nil || cap(items) == 0 || cap(items) > maxCap {
+		return
+	}
+	full := items[:cap(items)]
+	clear(full)
+	pool.Put(full[:0])
+}
+
+func getAppendOnlyKeysFromPool(length int, pool *sync.Pool, maxCap int) []string {
+	return getAppendOnlySliceFromPool[string](length, pool, maxCap, appendOnlyKeyPoolMaxCap)
 }
 
 func getAppendOnlyKeys(length int) []string {
@@ -193,37 +212,11 @@ func getAppendOnlyKeys(length int) []string {
 }
 
 func putAppendOnlyKeys(keys []string) {
-	if keys == nil || cap(keys) == 0 || cap(keys) > appendOnlyKeyPoolMaxCap {
-		return
-	}
-	full := keys[:cap(keys)]
-	clear(full)
-	appendOnlyKeyPool.Put(full[:0])
+	putAppendOnlySliceToPool(keys, &appendOnlyKeyPool, appendOnlyKeyPoolMaxCap)
 }
 
 func getAppendOnlyPayloadsFromPool(length int, pool *sync.Pool, maxCap int) []appendOnlyPayload {
-	if length < 0 {
-		length = 0
-	}
-	if maxCap <= 0 {
-		maxCap = appendOnlyPayloadPoolMaxCap
-	}
-	if length > maxCap {
-		return make([]appendOnlyPayload, length)
-	}
-	if pool == nil {
-		return make([]appendOnlyPayload, length)
-	}
-	if v := pool.Get(); v != nil {
-		if payloads, ok := v.([]appendOnlyPayload); ok && cap(payloads) >= length {
-			if cap(payloads) <= appendOnlyMaxReuseEntries(length) {
-				out := payloads[:length]
-				clear(out)
-				return out
-			}
-		}
-	}
-	return make([]appendOnlyPayload, length)
+	return getAppendOnlySliceFromPool[appendOnlyPayload](length, pool, maxCap, appendOnlyPayloadPoolMaxCap)
 }
 
 func getAppendOnlyPayloads(length int) []appendOnlyPayload {
@@ -231,12 +224,7 @@ func getAppendOnlyPayloads(length int) []appendOnlyPayload {
 }
 
 func putAppendOnlyPayloads(payloads []appendOnlyPayload) {
-	if payloads == nil || cap(payloads) == 0 || cap(payloads) > appendOnlyPayloadPoolMaxCap {
-		return
-	}
-	full := payloads[:cap(payloads)]
-	clear(full)
-	appendOnlyPayloadPool.Put(full[:0])
+	putAppendOnlySliceToPool(payloads, &appendOnlyPayloadPool, appendOnlyPayloadPoolMaxCap)
 }
 
 func getAppendOnlyIteratorEntries(length int) []appendOnlyEntry {
@@ -269,12 +257,7 @@ func getAppendOnlyIteratorKeys(length int) []string {
 }
 
 func putAppendOnlyIteratorKeys(keys []string) {
-	if keys == nil || cap(keys) == 0 || cap(keys) > appendOnlyIteratorKeyPoolMaxCap {
-		return
-	}
-	full := keys[:cap(keys)]
-	clear(full)
-	appendOnlyIteratorKeyPool.Put(full[:0])
+	putAppendOnlySliceToPool(keys, &appendOnlyIteratorKeyPool, appendOnlyIteratorKeyPoolMaxCap)
 }
 
 func getAppendOnlyIteratorPayloads(length int) []appendOnlyPayload {
@@ -282,12 +265,7 @@ func getAppendOnlyIteratorPayloads(length int) []appendOnlyPayload {
 }
 
 func putAppendOnlyIteratorPayloads(payloads []appendOnlyPayload) {
-	if payloads == nil || cap(payloads) == 0 || cap(payloads) > appendOnlyIteratorPayloadPoolMaxCap {
-		return
-	}
-	full := payloads[:cap(payloads)]
-	clear(full)
-	appendOnlyIteratorPayloadPool.Put(full[:0])
+	putAppendOnlySliceToPool(payloads, &appendOnlyIteratorPayloadPool, appendOnlyIteratorPayloadPoolMaxCap)
 }
 
 func getAppendOnlyIteratorPtrs(length int) []*appendOnlyEntry {
@@ -661,6 +639,30 @@ func appendOnlyLookupKeyString(key []byte) string {
 	return unsafe.String(unsafe.SliceData(key), len(key))
 }
 
+func appendOnlyInlineMapKeyFromBytes(key []byte) (appendOnlyInlineMapKey, bool) {
+	if len(key) > appendOnlyInlineKeyLen {
+		return appendOnlyInlineMapKey{}, false
+	}
+	var mapKey appendOnlyInlineMapKey
+	mapKey.length = uint8(len(key))
+	copy(mapKey.key[:], key)
+	return mapKey, true
+}
+
+func appendOnlyInlineMapKeyFromEntry(ent *appendOnlyEntry) (appendOnlyInlineMapKey, bool) {
+	if ent == nil || ent.keyIndex != 0 {
+		return appendOnlyInlineMapKey{}, false
+	}
+	inlineLen := int(ent.inlineKeyLen)
+	if inlineLen < 0 || inlineLen > appendOnlyInlineKeyLen {
+		return appendOnlyInlineMapKey{}, false
+	}
+	var mapKey appendOnlyInlineMapKey
+	mapKey.length = ent.inlineKeyLen
+	copy(mapKey.key[:], ent.inlineKey[:inlineLen])
+	return mapKey, true
+}
+
 func (m *AppendOnly) appendOnlyEntryMapKey(ent *appendOnlyEntry) string {
 	if m == nil || ent == nil {
 		return ""
@@ -756,14 +758,14 @@ func (m *AppendOnly) buildSortedLatestIndicesLocked() []int {
 	if m.count == 0 || m.ordered {
 		return nil
 	}
-	if m.latestDirty || (len(m.latest) == 0 && len(m.latest64) == 0) {
+	if m.latestDirty || (len(m.latest) == 0 && len(m.latestInline) == 0 && len(m.latest64) == 0) {
 		m.rebuildLatestIndexLocked()
 	}
 	// The returned slice aliases m.indexBuf scratch storage. It is only valid
 	// while m.mu is held and may be overwritten by the next call. When
 	// m.count == 0 or m.ordered is true, this helper returns nil, which callers
 	// may treat as "no indices" (equivalent to an empty result).
-	need := len(m.latest) + len(m.latest64)
+	need := len(m.latest) + len(m.latestInline) + len(m.latest64)
 	if cap(m.indexBuf) < need {
 		m.indexBuf = make([]int, 0, need)
 	} else {
@@ -771,6 +773,9 @@ func (m *AppendOnly) buildSortedLatestIndicesLocked() []int {
 	}
 	indices := m.indexBuf
 	for _, idx := range m.latest {
+		indices = append(indices, idx)
+	}
+	for _, idx := range m.latestInline {
 		indices = append(indices, idx)
 	}
 	for _, idx := range m.latest64 {
@@ -791,6 +796,9 @@ func (m *AppendOnly) rebuildLatestIndexLocked() {
 		if m.latest != nil {
 			clear(m.latest)
 		}
+		if m.latestInline != nil {
+			clear(m.latestInline)
+		}
 		if m.latest64 != nil {
 			clear(m.latest64)
 		}
@@ -801,12 +809,29 @@ func (m *AppendOnly) rebuildLatestIndexLocked() {
 	if m.latest != nil {
 		clear(m.latest)
 	}
+	if m.latestInline != nil {
+		clear(m.latestInline)
+	}
 	if m.latest64 != nil {
 		clear(m.latest64)
 	}
 	reserve := m.count
 	active := m.entries[:m.count]
 	for i := range active {
+		if inlineKey, ok := appendOnlyInlineMapKeyFromEntry(&active[i]); ok {
+			if inlineKey.length == appendOnlyInlineKeyLen {
+				if m.latest64 == nil {
+					m.latest64 = make(map[uint64]int, reserve)
+				}
+				m.latest64[binary.BigEndian.Uint64(inlineKey.key[:])] = i
+				continue
+			}
+			if m.latestInline == nil {
+				m.latestInline = make(map[appendOnlyInlineMapKey]int, reserve)
+			}
+			m.latestInline[inlineKey] = i
+			continue
+		}
 		k := m.appendOnlyEntryKey(&active[i])
 		if k64, ok := appendOnlyKeyU64(k); ok {
 			if m.latest64 == nil {
@@ -833,6 +858,13 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 			m.latest64 = make(map[uint64]int, 1)
 		}
 		m.latest64[k64] = idx
+		return
+	}
+	if inlineKey, ok := appendOnlyInlineMapKeyFromBytes(key); ok {
+		if m.latestInline == nil {
+			m.latestInline = make(map[appendOnlyInlineMapKey]int, 1)
+		}
+		m.latestInline[inlineKey] = idx
 		return
 	}
 	if m.latest == nil {
@@ -1122,6 +1154,20 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 					}
 				}
 			}
+			if inlineKey, ok := appendOnlyInlineMapKeyFromBytes(key); ok && m.latestInline != nil {
+				if idx, ok := m.latestInline[inlineKey]; ok && idx >= 0 && idx < m.count {
+					ent := &m.entries[idx]
+					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
+						deleted := ent.flags&node.FlagTombstone != 0
+						val := m.appendOnlyEntryValue(ent)
+						m.mu.RUnlock()
+						if deleted {
+							return nil, true, true
+						}
+						return val, false, true
+					}
+				}
+			}
 			if m.latest != nil {
 				if idx, ok := m.latest[appendOnlyLookupKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
@@ -1168,6 +1214,18 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 		if !m.latestDirty {
 			if k64, ok := appendOnlyKeyU64(key); ok && m.latest64 != nil {
 				if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
+					ent := &m.entries[idx]
+					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
+						val := m.appendOnlyEntryValue(ent)
+						ptr := m.appendOnlyEntryPtr(ent)
+						flags := ent.flags
+						m.mu.RUnlock()
+						return val, ptr, flags, true
+					}
+				}
+			}
+			if inlineKey, ok := appendOnlyInlineMapKeyFromBytes(key); ok && m.latestInline != nil {
+				if idx, ok := m.latestInline[inlineKey]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						val := m.appendOnlyEntryValue(ent)
@@ -1362,9 +1420,11 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	// after one-off spikes.
 	if !retainObserved || (oldCount > 0 && oldCount >= appendOnlyResetDropThresholdEntries) {
 		m.latest = nil
+		m.latestInline = nil
 		m.latest64 = nil
 	} else {
 		clear(m.latest)
+		clear(m.latestInline)
 		clear(m.latest64)
 	}
 	// Snapshot/index buffers are only needed for unordered memtables; drop large
@@ -1624,8 +1684,8 @@ type appendOnlyIterator struct {
 	keyBytes        []byte
 	payloads        []appendOnlyPayload
 	entryPtrs       []*appendOnlyEntry
-	inlineKeys      []appendOnlyIteratorInlineKey
-	inlineKeyIndex  map[int]int
+	keyRefs         []appendOnlyIteratorKeyRef
+	keyRefIndex     map[int]int
 	idx             int
 	start           []byte
 	end             []byte
@@ -1685,46 +1745,54 @@ func (it *appendOnlyIterator) keyForEntry(ent *appendOnlyEntry) []byte {
 	return appendOnlyEntryKeyFromKeys(ent, it.keys)
 }
 
-func (it *appendOnlyIterator) inlineKeyForEntry(idx int, ent *appendOnlyEntry) []byte {
-	if ent == nil || ent.inlineKeyLen == 0 {
-		return nil
-	}
-	inlineLen := int(ent.inlineKeyLen)
-	if n := len(it.inlineKeys); n > 0 {
-		last := &it.inlineKeys[n-1]
+func (it *appendOnlyIterator) cachedStableKeyForIndex(idx int) ([]byte, bool) {
+	if n := len(it.keyRefs); n > 0 {
+		last := &it.keyRefs[n-1]
 		if last.idx == idx {
-			return last.key[:int(last.length)]
+			return it.keyBytes[last.offset : last.offset+last.length], true
 		}
 	}
-	if it.inlineKeyIndex != nil {
-		if pos, ok := it.inlineKeyIndex[idx]; ok {
-			inlineKey := &it.inlineKeys[pos]
-			return inlineKey.key[:int(inlineKey.length)]
+	if it.keyRefIndex != nil {
+		if pos, ok := it.keyRefIndex[idx]; ok {
+			ref := &it.keyRefs[pos]
+			return it.keyBytes[ref.offset : ref.offset+ref.length], true
 		}
 	} else {
-		for i := len(it.inlineKeys) - 1; i >= 0; i-- {
-			if it.inlineKeys[i].idx == idx {
-				inlineKey := &it.inlineKeys[i]
-				return inlineKey.key[:int(inlineKey.length)]
+		for i := len(it.keyRefs) - 1; i >= 0; i-- {
+			if it.keyRefs[i].idx == idx {
+				ref := &it.keyRefs[i]
+				return it.keyBytes[ref.offset : ref.offset+ref.length], true
 			}
 		}
-		if len(it.inlineKeys) >= 8 {
-			it.inlineKeyIndex = make(map[int]int, len(it.inlineKeys)+1)
-			for i := range it.inlineKeys {
-				it.inlineKeyIndex[it.inlineKeys[i].idx] = i
+		if len(it.keyRefs) >= 8 {
+			it.keyRefIndex = make(map[int]int, len(it.keyRefs)+1)
+			for i := range it.keyRefs {
+				it.keyRefIndex[it.keyRefs[i].idx] = i
 			}
 		}
 	}
-	it.inlineKeys = append(it.inlineKeys, appendOnlyIteratorInlineKey{
+	return nil, false
+}
+
+func (it *appendOnlyIterator) stableKeyForEntry(idx int, ent *appendOnlyEntry) []byte {
+	if ent == nil {
+		return nil
+	}
+	if cached, ok := it.cachedStableKeyForIndex(idx); ok {
+		return cached
+	}
+	key := it.keyForEntry(ent)
+	offset := len(it.keyBytes)
+	it.keyBytes = append(it.keyBytes, key...)
+	it.keyRefs = append(it.keyRefs, appendOnlyIteratorKeyRef{
 		idx:    idx,
-		length: ent.inlineKeyLen,
+		offset: offset,
+		length: len(key),
 	})
-	copy(it.inlineKeys[len(it.inlineKeys)-1].key[:], ent.inlineKey[:inlineLen])
-	if it.inlineKeyIndex != nil {
-		it.inlineKeyIndex[idx] = len(it.inlineKeys) - 1
+	if it.keyRefIndex != nil {
+		it.keyRefIndex[idx] = len(it.keyRefs) - 1
 	}
-	inlineKey := &it.inlineKeys[len(it.inlineKeys)-1]
-	return inlineKey.key[:inlineLen]
+	return it.keyBytes[offset : offset+len(key)]
 }
 
 func (it *appendOnlyIterator) validIndex() bool {
@@ -1812,10 +1880,7 @@ func (it *appendOnlyIterator) UnsafeKey() []byte {
 	if ent == nil || !it.validIndex() {
 		return nil
 	}
-	if inlineKey := it.inlineKeyForEntry(it.idx, ent); inlineKey != nil {
-		return inlineKey
-	}
-	return it.keyForEntry(ent)
+	return it.stableKeyForEntry(it.idx, ent)
 }
 
 func (it *appendOnlyIterator) UnsafeValue() []byte {
@@ -1900,8 +1965,8 @@ func (it *appendOnlyIterator) Close() error {
 	it.entries = nil
 	it.keys = nil
 	it.keyBytes = nil
-	it.inlineKeys = nil
-	it.inlineKeyIndex = nil
+	it.keyRefs = nil
+	it.keyRefIndex = nil
 	it.payloads = nil
 	it.entryPtrs = nil
 	return nil

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -13,14 +13,14 @@ import (
 func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
 	entries[0].key = []byte("k0")
-	entries[0].value = []byte("v0")
+	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
 	entries[1].key = []byte("k1")
-	entries[1].value = []byte("v1")
+	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	putAppendOnlyEntries(entries)
 
 	for i := range entries {
-		if entries[i].key != nil || entries[i].value != nil {
+		if entries[i].key != nil || entries[i].value != "" {
 			t.Fatalf("entry %d still retains references after put: %+v", i, entries[i])
 		}
 	}
@@ -29,9 +29,9 @@ func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
 	entries[0].key = []byte("k0")
-	entries[0].value = []byte("v0")
+	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
 	entries[1].key = []byte("k1")
-	entries[1].value = []byte("v1")
+	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	it := &appendOnlyIterator{
 		entries:       entries,
@@ -42,7 +42,7 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	}
 
 	for i := range entries {
-		if entries[i].key != nil || entries[i].value != nil {
+		if entries[i].key != nil || entries[i].value != "" {
 			t.Fatalf("entry %d still retains references after close: %+v", i, entries[i])
 		}
 	}
@@ -56,8 +56,8 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledPointerEntries(t *testing.T) {
 	entries := []*appendOnlyEntry{
-		{key: []byte("k0"), value: []byte("v0")},
-		{key: []byte("k1"), value: []byte("v1")},
+		{key: []byte("k0"), value: appendOnlyStringFromBytes([]byte("v0"))},
+		{key: []byte("k1"), value: appendOnlyStringFromBytes([]byte("v1"))},
 	}
 	it := &appendOnlyIterator{
 		entryPtrs:       entries,
@@ -197,7 +197,8 @@ func TestAppendOnlyResetReusesEntryBuffers(t *testing.T) {
 		t.Fatalf("count=%d want=1", m.count)
 	}
 	keyBufPtr := &m.entries[0].key[0]
-	valBufPtr := &m.entries[0].value[0]
+	firstVal := appendOnlyEntryValue(&m.entries[0])
+	valBufPtr := &firstVal[0]
 
 	m.Reset()
 	key2 := []byte("long-key-02")
@@ -209,8 +210,9 @@ func TestAppendOnlyResetReusesEntryBuffers(t *testing.T) {
 	if &m.entries[0].key[0] != keyBufPtr {
 		t.Fatalf("expected key buffer reuse across reset")
 	}
-	if m.entries[0].value == nil || cap(m.entries[0].value) < len(val2) {
-		t.Fatalf("expected value buffer capacity reuse across reset")
+	nextVal := appendOnlyEntryValue(&m.entries[0])
+	if len(nextVal) != len(val2) {
+		t.Fatalf("value len after reset=%d want=%d", len(nextVal), len(val2))
 	}
 	_ = valBufPtr
 }
@@ -225,13 +227,11 @@ func TestAppendOnlySetCopiesIntoArenaForNonSteal(t *testing.T) {
 		t.Fatalf("count=%d want=1", m.count)
 	}
 	ent := &m.entries[0]
-	if !ent.valueOwned {
-		t.Fatalf("expected non-steal set to mark valueOwned")
+	val := appendOnlyEntryValue(ent)
+	if len(val) != len(src) {
+		t.Fatalf("entry value len=%d want=%d", len(val), len(src))
 	}
-	if len(ent.value) != len(src) {
-		t.Fatalf("entry value len=%d want=%d", len(ent.value), len(src))
-	}
-	if &ent.value[0] == &src[0] {
+	if &val[0] == &src[0] {
 		t.Fatalf("entry value unexpectedly aliases caller buffer")
 	}
 	src[0] = 'X'
@@ -297,10 +297,11 @@ func TestAppendOnlyResetRetainsArenaChunksForReuse(t *testing.T) {
 	}
 
 	m.Set([]byte("z"), make([]byte, 1024))
-	if m.count != 1 || len(m.entries[0].value) == 0 {
+	if m.count != 1 || len(appendOnlyEntryValue(&m.entries[0])) == 0 {
 		t.Fatalf("expected first post-reset set to allocate value from arena")
 	}
-	ptr := uintptr(unsafe.Pointer(&m.entries[0].value[0]))
+	postResetValue := appendOnlyEntryValue(&m.entries[0])
+	ptr := uintptr(unsafe.Pointer(&postResetValue[0]))
 	if _, ok := seen[ptr]; !ok {
 		t.Fatalf("post-reset value buffer did not reuse retained arena chunk")
 	}

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -12,16 +12,31 @@ import (
 
 func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
-	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
+	entries[0].keyIndex = 1
 	entries[0].payloadIndex = 1
-	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
+	entries[1].keyIndex = 2
 	entries[1].payloadIndex = 2
 
 	putAppendOnlyEntries(entries)
 
 	for i := range entries {
-		if entries[i].key != "" || entries[i].payloadIndex != 0 {
+		if entries[i].keyIndex != 0 || entries[i].payloadIndex != 0 {
 			t.Fatalf("entry %d still retains references after put: %+v", i, entries[i])
+		}
+	}
+}
+
+func TestPutAppendOnlyKeysClearsReferences(t *testing.T) {
+	keys := []string{
+		appendOnlyStringFromBytes([]byte("k0")),
+		appendOnlyStringFromBytes([]byte("k1")),
+	}
+
+	putAppendOnlyKeys(keys)
+
+	for i := range keys {
+		if keys[i] != "" {
+			t.Fatalf("key %d still retains references after put: %q", i, keys[i])
 		}
 	}
 }
@@ -44,16 +59,21 @@ func TestPutAppendOnlyPayloadsClearsReferences(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
-	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
+	entries[0].keyIndex = 1
 	entries[0].payloadIndex = 1
-	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
+	entries[1].keyIndex = 2
 	entries[1].payloadIndex = 2
+	keys := []string{
+		appendOnlyStringFromBytes([]byte("k0")),
+		appendOnlyStringFromBytes([]byte("k1")),
+	}
 	payloads := make([]appendOnlyPayload, 2)
 	payloads[0].value = appendOnlyStringFromBytes([]byte("v0"))
 	payloads[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		keys:          keys,
 		payloads:      payloads,
 		pooledEntries: true,
 	}
@@ -62,8 +82,13 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	}
 
 	for i := range entries {
-		if entries[i].key != "" || entries[i].payloadIndex != 0 {
+		if entries[i].keyIndex != 0 || entries[i].payloadIndex != 0 {
 			t.Fatalf("entry %d still retains references after close: %+v", i, entries[i])
+		}
+	}
+	for i := range keys {
+		if keys[i] != "" {
+			t.Fatalf("key %d still retains references after close: %q", i, keys[i])
 		}
 	}
 	for i := range payloads {
@@ -73,6 +98,9 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	}
 	if it.entries != nil {
 		t.Fatalf("iterator entries not cleared on close")
+	}
+	if it.keys != nil {
+		t.Fatalf("iterator keys not cleared on close")
 	}
 	if it.payloads != nil {
 		t.Fatalf("iterator payloads not cleared on close")
@@ -84,8 +112,8 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledPointerEntries(t *testing.T) {
 	entries := []*appendOnlyEntry{
-		{key: appendOnlyStringFromBytes([]byte("k0"))},
-		{key: appendOnlyStringFromBytes([]byte("k1"))},
+		{flags: appendOnlyEntryFlagKeyInline},
+		{flags: appendOnlyEntryFlagKeyInline},
 	}
 	it := &appendOnlyIterator{
 		entryPtrs:       entries,
@@ -217,8 +245,8 @@ func TestAppendOnlyFrozenUnorderedIteratorBlocksResetUntilClose(t *testing.T) {
 }
 
 func TestAppendOnlyEntryStructSizeBound(t *testing.T) {
-	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 32 {
-		t.Fatalf("appendOnlyEntry size=%d want <= 32", got)
+	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 20 {
+		t.Fatalf("appendOnlyEntry size=%d want <= 20", got)
 	}
 }
 
@@ -231,7 +259,7 @@ func TestAppendOnlySetCopiesNonInlineKeyIntoArena(t *testing.T) {
 	if m.count != 1 {
 		t.Fatalf("count=%d want=1", m.count)
 	}
-	storedKey := appendOnlyEntryKey(&m.entries[0])
+	storedKey := m.appendOnlyEntryKey(&m.entries[0])
 	if string(storedKey) != string(lookupKey) {
 		t.Fatalf("stored key=%q want=%q", storedKey, lookupKey)
 	}
@@ -349,7 +377,7 @@ func TestAppendOnlyResetRetainsArenaChunksForReuse(t *testing.T) {
 	if m.count != 1 || len(m.appendOnlyEntryValue(&m.entries[0])) == 0 {
 		t.Fatalf("expected first post-reset set to allocate value from arena")
 	}
-	postResetKeyBuf := appendOnlyEntryKey(&m.entries[0])
+	postResetKeyBuf := m.appendOnlyEntryKey(&m.entries[0])
 	postResetValue := m.appendOnlyEntryValue(&m.entries[0])
 	if len(postResetKeyBuf) == 0 {
 		t.Fatalf("expected non-inline key to be retained after reset")

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -572,7 +572,7 @@ func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
 	if m.snapCount != 0 {
 		t.Fatalf("expected mutable unordered iterator to keep shared snapshot uncached after rebuild; got snapCount=%d", m.snapCount)
 	}
-	idx, ok := m.latest[appendOnlyKeyString([]byte("b"))]
+	idx, ok := m.latest["b"]
 	if !ok {
 		t.Fatalf("missing latest index entry for key b")
 	}

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -572,7 +572,11 @@ func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
 	if m.snapCount != 0 {
 		t.Fatalf("expected mutable unordered iterator to keep shared snapshot uncached after rebuild; got snapCount=%d", m.snapCount)
 	}
-	idx, ok := m.latest["b"]
+	inlineKey, ok := appendOnlyInlineMapKeyFromBytes([]byte("b"))
+	if !ok {
+		t.Fatalf("test key did not fit inline latest index")
+	}
+	idx, ok := m.latestInline[inlineKey]
 	if !ok {
 		t.Fatalf("missing latest index entry for key b")
 	}

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -101,6 +101,18 @@ func TestGetAppendOnlyKeysFromPoolRespectsMaxCap(t *testing.T) {
 	}
 }
 
+func TestGetAppendOnlyKeysFromPoolRejectsOversizedReuse(t *testing.T) {
+	var pool sync.Pool
+	pool.New = func() any {
+		return make([]string, 0, appendOnlyMaxReuseEntries(1)+1)
+	}
+
+	keys := getAppendOnlyKeysFromPool(1, &pool, appendOnlyKeyPoolMaxCap)
+	if cap(keys) > appendOnlyMaxReuseEntries(1) {
+		t.Fatalf("cap(keys)=%d want <=%d", cap(keys), appendOnlyMaxReuseEntries(1))
+	}
+}
+
 func TestGetAppendOnlyPayloadsFromPoolRespectsMaxCap(t *testing.T) {
 	var pool sync.Pool
 	gets := 0
@@ -115,6 +127,18 @@ func TestGetAppendOnlyPayloadsFromPoolRespectsMaxCap(t *testing.T) {
 	}
 	if len(payloads) != 2 {
 		t.Fatalf("len(payloads)=%d want=2", len(payloads))
+	}
+}
+
+func TestGetAppendOnlyPayloadsFromPoolRejectsOversizedReuse(t *testing.T) {
+	var pool sync.Pool
+	pool.New = func() any {
+		return make([]appendOnlyPayload, 0, appendOnlyMaxReuseEntries(1)+1)
+	}
+
+	payloads := getAppendOnlyPayloadsFromPool(1, &pool, appendOnlyPayloadPoolMaxCap)
+	if cap(payloads) > appendOnlyMaxReuseEntries(1) {
+		t.Fatalf("cap(payloads)=%d want <=%d", cap(payloads), appendOnlyMaxReuseEntries(1))
 	}
 }
 

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -277,6 +277,35 @@ func TestAppendOnlySetCopiesNonInlineKeyIntoArena(t *testing.T) {
 	}
 }
 
+func TestAppendOnlySetInlinesShortKey(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	key := []byte("short")
+	lookupKey := cloneBytes(key)
+	m.Set(key, []byte("v"))
+
+	if m.count != 1 {
+		t.Fatalf("count=%d want=1", m.count)
+	}
+	ent := &m.entries[0]
+	if ent.flags&appendOnlyEntryFlagKeyInline == 0 {
+		t.Fatalf("expected short key to be stored inline")
+	}
+	if ent.inlineKeyLen != uint8(len(lookupKey)) {
+		t.Fatalf("inline key len=%d want=%d", ent.inlineKeyLen, len(lookupKey))
+	}
+	if ent.keyIndex != 0 {
+		t.Fatalf("short inline key should not allocate a key slot; keyIndex=%d", ent.keyIndex)
+	}
+	storedKey := m.appendOnlyEntryKey(ent)
+	if string(storedKey) != string(lookupKey) {
+		t.Fatalf("stored key=%q want=%q", storedKey, lookupKey)
+	}
+	key[0] = 'X'
+	if string(m.appendOnlyEntryKey(ent)) != string(lookupKey) {
+		t.Fatalf("inline key changed after caller mutation: got=%q want=%q", m.appendOnlyEntryKey(ent), lookupKey)
+	}
+}
+
 func TestAppendOnlySetCopiesIntoArenaForNonSteal(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	key := []byte("long-key-arena")

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -13,15 +13,31 @@ import (
 func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
 	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
-	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
+	entries[0].payloadIndex = 1
 	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
-	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
+	entries[1].payloadIndex = 2
 
 	putAppendOnlyEntries(entries)
 
 	for i := range entries {
-		if entries[i].key != "" || entries[i].value != "" {
+		if entries[i].key != "" || entries[i].payloadIndex != 0 {
 			t.Fatalf("entry %d still retains references after put: %+v", i, entries[i])
+		}
+	}
+}
+
+func TestPutAppendOnlyPayloadsClearsReferences(t *testing.T) {
+	payloads := make([]appendOnlyPayload, 2)
+	payloads[0].value = appendOnlyStringFromBytes([]byte("v0"))
+	payloads[0].ptr = page.ValuePtr{Offset: 1, Length: 2, FileID: 3}
+	payloads[1].value = appendOnlyStringFromBytes([]byte("v1"))
+	payloads[1].ptr = page.ValuePtr{Offset: 4, Length: 5, FileID: 6}
+
+	putAppendOnlyPayloads(payloads)
+
+	for i := range payloads {
+		if payloads[i].value != "" || payloads[i].ptr != (page.ValuePtr{}) {
+			t.Fatalf("payload %d still retains references after put: %+v", i, payloads[i])
 		}
 	}
 }
@@ -29,12 +45,16 @@ func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
 	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
-	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
+	entries[0].payloadIndex = 1
 	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
-	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
+	entries[1].payloadIndex = 2
+	payloads := make([]appendOnlyPayload, 2)
+	payloads[0].value = appendOnlyStringFromBytes([]byte("v0"))
+	payloads[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		payloads:      payloads,
 		pooledEntries: true,
 	}
 	if err := it.Close(); err != nil {
@@ -42,12 +62,20 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	}
 
 	for i := range entries {
-		if entries[i].key != "" || entries[i].value != "" {
+		if entries[i].key != "" || entries[i].payloadIndex != 0 {
 			t.Fatalf("entry %d still retains references after close: %+v", i, entries[i])
+		}
+	}
+	for i := range payloads {
+		if payloads[i].value != "" || payloads[i].ptr != (page.ValuePtr{}) {
+			t.Fatalf("payload %d still retains references after close: %+v", i, payloads[i])
 		}
 	}
 	if it.entries != nil {
 		t.Fatalf("iterator entries not cleared on close")
+	}
+	if it.payloads != nil {
+		t.Fatalf("iterator payloads not cleared on close")
 	}
 	if it.pooledEntries {
 		t.Fatalf("pooledEntries flag not cleared on close")
@@ -56,8 +84,8 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledPointerEntries(t *testing.T) {
 	entries := []*appendOnlyEntry{
-		{key: appendOnlyStringFromBytes([]byte("k0")), value: appendOnlyStringFromBytes([]byte("v0"))},
-		{key: appendOnlyStringFromBytes([]byte("k1")), value: appendOnlyStringFromBytes([]byte("v1"))},
+		{key: appendOnlyStringFromBytes([]byte("k0"))},
+		{key: appendOnlyStringFromBytes([]byte("k1"))},
 	}
 	it := &appendOnlyIterator{
 		entryPtrs:       entries,
@@ -189,8 +217,8 @@ func TestAppendOnlyFrozenUnorderedIteratorBlocksResetUntilClose(t *testing.T) {
 }
 
 func TestAppendOnlyEntryStructSizeBound(t *testing.T) {
-	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 64 {
-		t.Fatalf("appendOnlyEntry size=%d want <= 64", got)
+	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 32 {
+		t.Fatalf("appendOnlyEntry size=%d want <= 32", got)
 	}
 }
 
@@ -231,7 +259,7 @@ func TestAppendOnlySetCopiesIntoArenaForNonSteal(t *testing.T) {
 		t.Fatalf("count=%d want=1", m.count)
 	}
 	ent := &m.entries[0]
-	val := appendOnlyEntryValue(ent)
+	val := m.appendOnlyEntryValue(ent)
 	if len(val) != len(src) {
 		t.Fatalf("entry value len=%d want=%d", len(val), len(src))
 	}
@@ -318,11 +346,11 @@ func TestAppendOnlyResetRetainsArenaChunksForReuse(t *testing.T) {
 
 	postResetKey := []byte("post-reset-long-key")
 	m.Set(postResetKey, make([]byte, 1024))
-	if m.count != 1 || len(appendOnlyEntryValue(&m.entries[0])) == 0 {
+	if m.count != 1 || len(m.appendOnlyEntryValue(&m.entries[0])) == 0 {
 		t.Fatalf("expected first post-reset set to allocate value from arena")
 	}
 	postResetKeyBuf := appendOnlyEntryKey(&m.entries[0])
-	postResetValue := appendOnlyEntryValue(&m.entries[0])
+	postResetValue := m.appendOnlyEntryValue(&m.entries[0])
 	if len(postResetKeyBuf) == 0 {
 		t.Fatalf("expected non-inline key to be retained after reset")
 	}

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -12,15 +12,15 @@ import (
 
 func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
-	entries[0].key = []byte("k0")
+	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
 	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
-	entries[1].key = []byte("k1")
+	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
 	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	putAppendOnlyEntries(entries)
 
 	for i := range entries {
-		if entries[i].key != nil || entries[i].value != "" {
+		if entries[i].key != "" || entries[i].value != "" {
 			t.Fatalf("entry %d still retains references after put: %+v", i, entries[i])
 		}
 	}
@@ -28,9 +28,9 @@ func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
-	entries[0].key = []byte("k0")
+	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
 	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
-	entries[1].key = []byte("k1")
+	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
 	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	it := &appendOnlyIterator{
@@ -42,7 +42,7 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	}
 
 	for i := range entries {
-		if entries[i].key != nil || entries[i].value != "" {
+		if entries[i].key != "" || entries[i].value != "" {
 			t.Fatalf("entry %d still retains references after close: %+v", i, entries[i])
 		}
 	}
@@ -56,8 +56,8 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledPointerEntries(t *testing.T) {
 	entries := []*appendOnlyEntry{
-		{key: []byte("k0"), value: appendOnlyStringFromBytes([]byte("v0"))},
-		{key: []byte("k1"), value: appendOnlyStringFromBytes([]byte("v1"))},
+		{key: appendOnlyStringFromBytes([]byte("k0")), value: appendOnlyStringFromBytes([]byte("v0"))},
+		{key: appendOnlyStringFromBytes([]byte("k1")), value: appendOnlyStringFromBytes([]byte("v1"))},
 	}
 	it := &appendOnlyIterator{
 		entryPtrs:       entries,
@@ -188,33 +188,37 @@ func TestAppendOnlyFrozenUnorderedIteratorBlocksResetUntilClose(t *testing.T) {
 	}
 }
 
-func TestAppendOnlyResetReusesEntryBuffers(t *testing.T) {
+func TestAppendOnlyEntryStructSizeBound(t *testing.T) {
+	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 64 {
+		t.Fatalf("appendOnlyEntry size=%d want <= 64", got)
+	}
+}
+
+func TestAppendOnlySetCopiesNonInlineKeyIntoArena(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	key1 := []byte("long-key-01")
+	lookupKey := cloneBytes(key1)
 	val1 := []byte("value-aaaaaa")
 	m.Set(key1, val1)
 	if m.count != 1 {
 		t.Fatalf("count=%d want=1", m.count)
 	}
-	keyBufPtr := &m.entries[0].key[0]
-	firstVal := appendOnlyEntryValue(&m.entries[0])
-	valBufPtr := &firstVal[0]
+	storedKey := appendOnlyEntryKey(&m.entries[0])
+	if string(storedKey) != string(lookupKey) {
+		t.Fatalf("stored key=%q want=%q", storedKey, lookupKey)
+	}
+	if unsafe.SliceData(storedKey) == unsafe.SliceData(key1) {
+		t.Fatalf("stored key unexpectedly aliases caller buffer")
+	}
+	key1[0] = 'X'
 
-	m.Reset()
-	key2 := []byte("long-key-02")
-	val2 := []byte("value-bbbbbb")
-	m.Set(key2, val2)
-	if m.count != 1 {
-		t.Fatalf("count after reset=%d want=1", m.count)
+	got, tombstone, ok := m.Get(lookupKey)
+	if !ok || tombstone {
+		t.Fatalf("Get(%q) = ok=%v tombstone=%v; want ok=true tombstone=false", lookupKey, ok, tombstone)
 	}
-	if &m.entries[0].key[0] != keyBufPtr {
-		t.Fatalf("expected key buffer reuse across reset")
+	if string(got) != string(val1) {
+		t.Fatalf("stored value changed after source key mutation: got=%q want=%q", got, val1)
 	}
-	nextVal := appendOnlyEntryValue(&m.entries[0])
-	if len(nextVal) != len(val2) {
-		t.Fatalf("value len after reset=%d want=%d", len(nextVal), len(val2))
-	}
-	_ = valBufPtr
 }
 
 func TestAppendOnlySetCopiesIntoArenaForNonSteal(t *testing.T) {
@@ -282,10 +286,26 @@ func TestAppendOnlyResetRetainsArenaChunksForReuse(t *testing.T) {
 	if len(m.valueArena.chunks) == 0 {
 		t.Fatalf("expected populated arena chunks before reset")
 	}
-	seen := make(map[uintptr]struct{}, len(m.valueArena.chunks))
+	type chunkSpan struct {
+		start uintptr
+		end   uintptr
+	}
+	seen := make([]chunkSpan, 0, len(m.valueArena.chunks))
 	for _, chunk := range m.valueArena.chunks {
 		full := chunk[:cap(chunk)]
-		seen[uintptr(unsafe.Pointer(&full[0]))] = struct{}{}
+		start := uintptr(unsafe.Pointer(&full[0]))
+		seen = append(seen, chunkSpan{
+			start: start,
+			end:   start + uintptr(len(full)),
+		})
+	}
+	inRetainedChunk := func(ptr uintptr) bool {
+		for _, span := range seen {
+			if ptr >= span.start && ptr < span.end {
+				return true
+			}
+		}
+		return false
 	}
 
 	m.Reset()
@@ -296,13 +316,22 @@ func TestAppendOnlyResetRetainsArenaChunksForReuse(t *testing.T) {
 		t.Fatalf("expected retained arena bytes > 0")
 	}
 
-	m.Set([]byte("z"), make([]byte, 1024))
+	postResetKey := []byte("post-reset-long-key")
+	m.Set(postResetKey, make([]byte, 1024))
 	if m.count != 1 || len(appendOnlyEntryValue(&m.entries[0])) == 0 {
 		t.Fatalf("expected first post-reset set to allocate value from arena")
 	}
+	postResetKeyBuf := appendOnlyEntryKey(&m.entries[0])
 	postResetValue := appendOnlyEntryValue(&m.entries[0])
+	if len(postResetKeyBuf) == 0 {
+		t.Fatalf("expected non-inline key to be retained after reset")
+	}
+	keyPtr := uintptr(unsafe.Pointer(unsafe.SliceData(postResetKeyBuf)))
 	ptr := uintptr(unsafe.Pointer(&postResetValue[0]))
-	if _, ok := seen[ptr]; !ok {
+	if !inRetainedChunk(keyPtr) {
+		t.Fatalf("post-reset key buffer did not reuse retained arena chunk")
+	}
+	if !inRetainedChunk(ptr) {
 		t.Fatalf("post-reset value buffer did not reuse retained arena chunk")
 	}
 }

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -2,6 +2,7 @@ package memtable
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/node"
@@ -162,7 +163,7 @@ func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) 
 
 	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
 	var observed int
-	mt.SetPredictiveGrowthHint(capacityBytes, func(entries int) {
+	mt.SetPredictiveGrowthHint(capacityBytes, nil, func(entries int) {
 		if entries > observed {
 			observed = entries
 		}
@@ -181,5 +182,27 @@ func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) 
 	}
 	if got := cap(mt.entries); got != base {
 		t.Fatalf("predictive hint should not allocate immediately: cap(entries)=%d want=%d", got, base)
+	}
+}
+
+func TestAppendOnlySharedPredictiveHintRaisesGrowthFloorBeforeLocalPrediction(t *testing.T) {
+	const (
+		capacityBytes          = 128 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	sharedHint := atomic.Int32{}
+	sharedHint.Store(int32(base * 8))
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	mt.SetPredictiveGrowthHint(capacityBytes, &sharedHint, nil)
+
+	for i := 0; i < base+1; i++ {
+		key := []byte(fmt.Sprintf("s%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+	if got := cap(mt.entries); got < int(sharedHint.Load()) {
+		t.Fatalf("cap(entries)=%d want >= %d", got, sharedHint.Load())
 	}
 }

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -534,13 +534,6 @@ func TestAppendOnlyOrderedIteratorShortInlineKeyStableAfterCloseAndGrowth(t *tes
 	m.Set([]byte("long-growth-key"), []byte("growth"))
 
 	it := m.NewIterator(nil, nil)
-	internalIt, ok := it.(*appendOnlyIterator)
-	if !ok {
-		t.Fatalf("iterator type %T, want *appendOnlyIterator", it)
-	}
-	if got := len(internalIt.inlineKeys); got != 1 {
-		t.Fatalf("ordered iterator inline key copies=%d want 1 sparse copy", got)
-	}
 	if !it.Valid() {
 		t.Fatal("iterator unexpectedly invalid")
 	}

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -502,6 +502,27 @@ func TestAppendOnlyLatestIndexShortInlineKeysSurviveEntryGrowth(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyMutableIteratorShortInlineKeyStableAfterClose(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	m.Set([]byte("b"), []byte("first"))
+	m.Set([]byte("a"), []byte("target"))
+
+	it := m.NewIterator(nil, nil)
+	if !it.Valid() {
+		t.Fatal("iterator unexpectedly invalid")
+	}
+	key := it.UnsafeKey()
+	if got := string(key); got != "a" {
+		t.Fatalf("iterator key=%q want a", got)
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := string(key); got != "a" {
+		t.Fatalf("iterator key after close=%q want a", got)
+	}
+}
+
 var appendOnlyGetBenchSink []byte
 var appendOnlyGetBenchSinkBool bool
 

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -523,6 +523,34 @@ func TestAppendOnlyMutableIteratorShortInlineKeyStableAfterClose(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyOrderedIteratorShortInlineKeyStableAfterCloseAndGrowth(t *testing.T) {
+	m := NewAppendOnlyWithCapacityEstimatedEntryBytes(
+		appendOnlyMinInitialEntries*appendOnlyEstimatedBytesPerEntryPointer,
+		appendOnlyEstimatedBytesPerEntryPointer,
+	)
+	m.Set([]byte("a"), []byte("target"))
+
+	it := m.NewIterator(nil, nil)
+	if !it.Valid() {
+		t.Fatal("iterator unexpectedly invalid")
+	}
+	key := it.UnsafeKey()
+	if got := string(key); got != "a" {
+		t.Fatalf("iterator key=%q want a", got)
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	for i := 0; i < appendOnlyMinInitialEntries; i++ {
+		growthKey := []byte(fmt.Sprintf("long-growth-key-%08d", i))
+		m.Set(growthKey, []byte("growth"))
+	}
+	if got := string(key); got != "a" {
+		t.Fatalf("iterator key after close+growth=%q want a", got)
+	}
+}
+
 var appendOnlyGetBenchSink []byte
 var appendOnlyGetBenchSinkBool bool
 

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -318,15 +318,35 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 		latestSize func(m *AppendOnly) int
 	}{
 		{
-			name: "non-8-byte",
+			name: "short-inline",
 			makeKey: func(v uint64) []byte {
 				return []byte{byte('a' + v)}
+			},
+			latestIdx: func(m *AppendOnly, key []byte) (int, bool) {
+				inlineKey, ok := appendOnlyInlineMapKeyFromBytes(key)
+				if !ok || m.latestInline == nil {
+					return 0, false
+				}
+				idx, ok := m.latestInline[inlineKey]
+				return idx, ok
+			},
+			latestSize: func(m *AppendOnly) int {
+				if m.latestInline == nil {
+					return 0
+				}
+				return len(m.latestInline)
+			},
+		},
+		{
+			name: "long-string",
+			makeKey: func(v uint64) []byte {
+				return []byte(fmt.Sprintf("long-key-%08d", v))
 			},
 			latestIdx: func(m *AppendOnly, key []byte) (int, bool) {
 				if m.latest == nil {
 					return 0, false
 				}
-				idx, ok := m.latest[string(key)]
+				idx, ok := m.latest[appendOnlyLookupKeyString(key)]
 				return idx, ok
 			},
 			latestSize: func(m *AppendOnly) int {
@@ -554,6 +574,36 @@ func TestAppendOnlyOrderedIteratorShortInlineKeyStableAfterCloseAndGrowth(t *tes
 	}
 }
 
+func TestAppendOnlyIteratorLongKeyDoesNotExposeIndexStorage(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	const (
+		targetKey = "long-key-a"
+		otherKey  = "long-key-b"
+	)
+	m.Set([]byte(otherKey), []byte("other"))
+	m.Set([]byte(targetKey), []byte("target")) // force unordered latest-index path
+
+	it := m.NewIterator(nil, nil)
+	if !it.Valid() {
+		t.Fatal("iterator unexpectedly invalid")
+	}
+	key := it.UnsafeKey()
+	if got := string(key); got != targetKey {
+		t.Fatalf("iterator key=%q want %q", got, targetKey)
+	}
+	key[0] = 'X'
+	if err := it.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got, del, ok := m.Get([]byte(targetKey)); !ok || del || string(got) != "target" {
+		t.Fatalf("Get(%q) after iterator key mutation = (%q,%v,%v), want (target,false,true)", targetKey, got, del, ok)
+	}
+	if _, _, ok := m.Get([]byte("Xong-key-a")); ok {
+		t.Fatalf("mutating iterator key created lookup hit for corrupted key")
+	}
+}
+
 var appendOnlyGetBenchSink []byte
 var appendOnlyGetBenchSinkBool bool
 
@@ -578,6 +628,7 @@ func benchmarkAppendOnlyGetOrderedVsReverseScan(b *testing.B, count int) {
 	reverse.ordered = false
 	reverse.latestDirty = true
 	clear(reverse.latest)
+	clear(reverse.latestInline)
 	clear(reverse.latest64)
 	reverse.mu.Unlock()
 

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -329,7 +329,7 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 				if m.latest == nil {
 					return 0, false
 				}
-				idx, ok := m.latest[appendOnlyKeyString(key)]
+				idx, ok := m.latest[string(key)]
 				return idx, ok
 			},
 			latestSize: func(m *AppendOnly) int {
@@ -506,8 +506,13 @@ func TestAppendOnlyMutableIteratorShortInlineKeyStableAfterClose(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	m.Set([]byte("b"), []byte("first"))
 	m.Set([]byte("a"), []byte("target"))
+	arenaChunks := len(m.valueArena.chunks)
+	arenaPos := m.valueArena.curPos
 
 	it := m.NewIterator(nil, nil)
+	if len(m.valueArena.chunks) != arenaChunks || m.valueArena.curPos != arenaPos {
+		t.Fatalf("mutable iterator copied inline keys into memtable arena")
+	}
 	if !it.Valid() {
 		t.Fatal("iterator unexpectedly invalid")
 	}
@@ -529,8 +534,16 @@ func TestAppendOnlyOrderedIteratorShortInlineKeyStableAfterCloseAndGrowth(t *tes
 		appendOnlyEstimatedBytesPerEntryPointer,
 	)
 	m.Set([]byte("a"), []byte("target"))
+	m.Set([]byte("long-growth-key"), []byte("growth"))
 
 	it := m.NewIterator(nil, nil)
+	internalIt, ok := it.(*appendOnlyIterator)
+	if !ok {
+		t.Fatalf("iterator type %T, want *appendOnlyIterator", it)
+	}
+	if got := len(internalIt.inlineKeys); got != 1 {
+		t.Fatalf("ordered iterator inline key copies=%d want 1 sparse copy", got)
+	}
 	if !it.Valid() {
 		t.Fatal("iterator unexpectedly invalid")
 	}


### PR DESCRIPTION
## Summary
- shrink the base append-only entry representation so tombstone-heavy workloads stop paying for full value metadata in every slot
- split payloads and long-key storage out of the hot entry slice, while inlining keys up to 8 bytes
- extend the pool/iterator tests to cover payload clearing, key clearing, and short-key inlining

## Validation
- `go test ./TreeDB/internal/memtable ./TreeDB/caching ./TreeDB/page ./TreeDB/internal/valuelog ./cmd/unified_bench`
- `go test ./TreeDB -run ReopenVerify`
- `go test ./TreeDB/db -run ValueLogGC`
- fresh-built exact benchmark on top of `codex/append-only-predictive-growth-hint`:
  - `go build -o /tmp/unified-bench-compact ./cmd/unified_bench`
  - `/tmp/unified-bench-compact -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_append_only_compact_entry_vjSkKt -test batch_delete`
  - `Batch Delete: 4,876,512`
  - `alloc_space: 2.60GB` vs `3.92GB` on the predictive-growth base branch