### PR TITLE
Trim leaf-log scratch and batch bookkeeping churn

### DIFF
--- a/TreeDB/caching/batch_arena_ownership_test.go
+++ b/TreeDB/caching/batch_arena_ownership_test.go
@@ -60,6 +60,30 @@ func TestBatchReset_DoesNotCorruptPriorBorrowedWrites(t *testing.T) {
 	}
 }
 
+func TestBatchResetClearsRetainedMemtableSliceBackingArrays(t *testing.T) {
+	mt1 := memtable.NewAppendOnlyWithCapacity(0)
+	mt2 := memtable.NewAppendOnlyWithCapacity(0)
+	b := &Batch{
+		retainMainMems: []memtable.Table{mt1},
+		ptrTouchedMems: []memtable.Table{mt2},
+	}
+
+	b.Reset()
+
+	if got := len(b.retainMainMems); got != 0 {
+		t.Fatalf("retainMainMems len=%d want=0", got)
+	}
+	if got := len(b.ptrTouchedMems); got != 0 {
+		t.Fatalf("ptrTouchedMems len=%d want=0", got)
+	}
+	if full := b.retainMainMems[:cap(b.retainMainMems)]; len(full) > 0 && full[0] != nil {
+		t.Fatalf("retainMainMems backing array still references %T", full[0])
+	}
+	if full := b.ptrTouchedMems[:cap(b.ptrTouchedMems)]; len(full) > 0 && full[0] != nil {
+		t.Fatalf("ptrTouchedMems backing array still references %T", full[0])
+	}
+}
+
 func TestBatchArenaLeases_CopiedMemtablesMatchOwnershipMode(t *testing.T) {
 	cases := []struct {
 		mode       string

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7359,6 +7359,18 @@ func memtableBatchDelete(mt memtable.Table, useSteal bool, key []byte) {
 	mt.Delete(key)
 }
 
+func appendUniqueTouchedMem(dst []memtable.Table, mt memtable.Table) []memtable.Table {
+	if mt == nil {
+		return dst
+	}
+	for i := range dst {
+		if dst[i] == mt {
+			return dst
+		}
+	}
+	return append(dst, mt)
+}
+
 // memtableBatchSet applies a cached batch write while preserving the ownership
 // rules selected by cachedBatchWriteUsesSteal. Pointer entries may still keep
 // inline bytes in memtables that do not use value-log pointers internally.
@@ -25754,6 +25766,8 @@ type Batch struct {
 	shardCnts          []int
 	shardEntries       [][]batch.Entry
 	shardIdxSets       [][]int
+	retainMainMems     []memtable.Table
+	ptrTouchedMems     []memtable.Table
 	maxEntries         int
 
 	closed bool
@@ -26197,6 +26211,12 @@ func (b *Batch) Reset() {
 	}
 	if b.shardIdxSets != nil {
 		b.shardIdxSets = b.shardIdxSets[:0]
+	}
+	if b.retainMainMems != nil {
+		b.retainMainMems = b.retainMainMems[:0]
+	}
+	if b.ptrTouchedMems != nil {
+		b.ptrTouchedMems = b.ptrTouchedMems[:0]
 	}
 	b.recycleCopyArenaChunks()
 	b.recyclePtrCopyArenaChunks()
@@ -27140,8 +27160,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		}
 		shardAdds[idx] += add
 	}
-	retainMainMems := make([]memtable.Table, 0, shardCount)
-	retainMainSeen := make(map[memtable.Table]struct{}, shardCount)
+	retainMainMems := b.retainMainMems[:0]
 	for i, add := range shardAdds {
 		if add == 0 {
 			continue
@@ -27549,10 +27568,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				batchArenaStealSuppressedDeferredEntriesTotal.Add(uint64(len(idxs)))
 			}
 			if useSteal && cachedBatchWriteNeedsBatchArenaRetention(shard.mem) {
-				if _, ok := retainMainSeen[shard.mem]; !ok {
-					retainMainSeen[shard.mem] = struct{}{}
-					retainMainMems = append(retainMainMems, shard.mem)
-				}
+				retainMainMems = appendUniqueTouchedMem(retainMainMems, shard.mem)
 			}
 			if b.streamEligible {
 				first := b.entries[idxs[0]].Key
@@ -27624,10 +27640,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				batchArenaStealSuppressedDeferredEntriesTotal.Add(uint64(len(entries)))
 			}
 			if useSteal && cachedBatchWriteNeedsBatchArenaRetention(shard.mem) {
-				if _, ok := retainMainSeen[shard.mem]; !ok {
-					retainMainSeen[shard.mem] = struct{}{}
-					retainMainMems = append(retainMainMems, shard.mem)
-				}
+				retainMainMems = appendUniqueTouchedMem(retainMainMems, shard.mem)
 			}
 			storeInlinePtrValues := !b.db.memtableValueLogPointers
 			if useStream && useSteal {
@@ -27668,10 +27681,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 						}
 						memtableBatchSet(shard.mem, useSteal, allowBatchArenaBorrow, storeInlinePtrValues, op)
 						if borrowed {
-							if _, ok := retainMainSeen[shard.mem]; !ok {
-								retainMainSeen[shard.mem] = struct{}{}
-								retainMainMems = append(retainMainMems, shard.mem)
-							}
+							retainMainMems = appendUniqueTouchedMem(retainMainMems, shard.mem)
 						}
 					}
 					if useStream {
@@ -27698,6 +27708,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			shard.mu.Unlock()
 		}
 	}
+	b.retainMainMems = retainMainMems
 
 	// 3. Threshold Check
 	if b.db.mutableBytes.Load() > b.db.mutableFlushThreshold() {
@@ -27710,9 +27721,8 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	b.updateBatchCopyHint()
 	mainChunks := b.drainCopyArenaChunks()
 	retainPtrArena := false
-	ptrTouchedMems := make([]memtable.Table, 0, len(b.ptrValueIdxs))
+	ptrTouchedMems := b.ptrTouchedMems[:0]
 	if allowBatchArenaBorrow && len(b.ptrValueIdxs) > 0 {
-		seenPtrMems := make(map[memtable.Table]struct{}, len(b.ptrValueIdxs))
 		for _, idx := range b.ptrValueIdxs {
 			if idx < 0 || idx >= len(b.entries) || idx >= len(shardIdxs) {
 				b.db.writeMu.RUnlock()
@@ -27731,13 +27741,10 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			if mt == nil {
 				continue
 			}
-			if _, ok := seenPtrMems[mt]; ok {
-				continue
-			}
-			seenPtrMems[mt] = struct{}{}
-			ptrTouchedMems = append(ptrTouchedMems, mt)
+			ptrTouchedMems = appendUniqueTouchedMem(ptrTouchedMems, mt)
 		}
 	}
+	b.ptrTouchedMems = ptrTouchedMems
 	if b.ptrValueIdxs != nil {
 		b.ptrValueIdxs = b.ptrValueIdxs[:0]
 	}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -26212,12 +26212,7 @@ func (b *Batch) Reset() {
 	if b.shardIdxSets != nil {
 		b.shardIdxSets = b.shardIdxSets[:0]
 	}
-	if b.retainMainMems != nil {
-		b.retainMainMems = b.retainMainMems[:0]
-	}
-	if b.ptrTouchedMems != nil {
-		b.ptrTouchedMems = b.ptrTouchedMems[:0]
-	}
+	b.clearRetainedMemtableSlices()
 	b.recycleCopyArenaChunks()
 	b.recyclePtrCopyArenaChunks()
 	if b.arenaInFlightBytes > 0 {
@@ -26237,6 +26232,22 @@ func (b *Batch) Reset() {
 	b.maxEntries = 0
 	if b.ptrValueIdxs != nil {
 		b.ptrValueIdxs = b.ptrValueIdxs[:0]
+	}
+}
+
+func (b *Batch) clearRetainedMemtableSlices() {
+	if b == nil {
+		return
+	}
+	if b.retainMainMems != nil {
+		full := b.retainMainMems[:cap(b.retainMainMems)]
+		clear(full)
+		b.retainMainMems = b.retainMainMems[:0]
+	}
+	if b.ptrTouchedMems != nil {
+		full := b.ptrTouchedMems[:cap(b.ptrTouchedMems)]
+		clear(full)
+		b.ptrTouchedMems = b.ptrTouchedMems[:0]
 	}
 }
 
@@ -27750,11 +27761,15 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	}
 	ptrChunks := b.drainPtrCopyArenaChunks()
 	b.db.retainBatchArenaChunksForMemtables(mainChunks, retainMainMems)
+	clear(retainMainMems)
+	b.retainMainMems = retainMainMems[:0]
 	if retainPtrArena {
 		b.db.retainBatchArenaChunksForMemtables(ptrChunks, ptrTouchedMems)
 	} else {
 		putBatchArenas(ptrChunks)
 	}
+	clear(ptrTouchedMems)
+	b.ptrTouchedMems = ptrTouchedMems[:0]
 	b.db.writeMu.RUnlock()
 
 	if needRotate {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7363,6 +7363,8 @@ func appendUniqueTouchedMem(dst []memtable.Table, mt memtable.Table) []memtable.
 	if mt == nil {
 		return dst
 	}
+	// The touched set is bounded by mutable shard count in this write path, so a
+	// short slice scan avoids adding a per-batch map to the hot path.
 	for i := range dst {
 		if dst[i] == mt {
 			return dst
@@ -27746,6 +27748,9 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	if allowBatchArenaBorrow && len(b.ptrValueIdxs) > 0 {
 		for _, idx := range b.ptrValueIdxs {
 			if idx < 0 || idx >= len(b.entries) || idx >= len(shardIdxs) {
+				b.retainMainMems = retainMainMems
+				b.ptrTouchedMems = ptrTouchedMems
+				b.clearRetainedMemtableSlices()
 				b.db.writeMu.RUnlock()
 				return fmt.Errorf("cachingdb: ptr value entry index %d out of range", idx)
 			}
@@ -27755,6 +27760,9 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			retainPtrArena = true
 			shardIdx := shardIdxs[idx]
 			if shardIdx < 0 || shardIdx >= len(b.db.mutableShards) {
+				b.retainMainMems = retainMainMems
+				b.ptrTouchedMems = ptrTouchedMems
+				b.clearRetainedMemtableSlices()
 				b.db.writeMu.RUnlock()
 				return fmt.Errorf("cachingdb: ptr value shard index %d out of range for entry %d", shardIdx, idx)
 			}

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -1,6 +1,8 @@
 package caching
 
 import (
+	"sync"
+
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -10,6 +12,8 @@ type cachingLeafPageLog struct {
 	db   *DB
 	lane *lane
 }
+
+var compactLeafPayloadScratchPool sync.Pool
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLog)(nil)
 
@@ -30,9 +34,22 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	if l == nil || l.db == nil || l.lane == nil {
 		return page.LeafLogPtr{}, errWALUnavailable
 	}
-	encodedLeafPage, _, err := valuelog.MaybeCompactLeafLogPayload(leafPage)
+	scratch := compactLeafPayloadScratchPool.Get()
+	var payloadScratch []byte
+	if b, ok := scratch.([]byte); ok {
+		payloadScratch = b[:0]
+	}
+	encodedLeafPage, compacted, err := valuelog.MaybeCompactLeafLogPayloadTo(payloadScratch, leafPage)
 	if err != nil {
+		if payloadScratch != nil {
+			compactLeafPayloadScratchPool.Put(payloadScratch[:0])
+		}
 		return page.LeafLogPtr{}, err
+	}
+	if compacted {
+		defer compactLeafPayloadScratchPool.Put(encodedLeafPage[:0])
+	} else if payloadScratch != nil {
+		compactLeafPayloadScratchPool.Put(payloadScratch[:0])
 	}
 	rid := l.db.nextRID.Add(1)
 	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -46,13 +46,15 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 		}
 		return page.LeafLogPtr{}, err
 	}
+	releaseScratch := payloadScratch
 	if compacted {
-		defer compactLeafPayloadScratchPool.Put(encodedLeafPage[:0])
-	} else if payloadScratch != nil {
-		compactLeafPayloadScratchPool.Put(payloadScratch[:0])
+		releaseScratch = encodedLeafPage
 	}
 	rid := l.db.nextRID.Add(1)
 	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
+	if releaseScratch != nil {
+		compactLeafPayloadScratchPool.Put(releaseScratch[:0])
+	}
 	if retainPath != "" {
 		l.db.markValueLogRetain(retainPath)
 	}

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -13,7 +13,13 @@ type cachingLeafPageLog struct {
 	lane *lane
 }
 
-var compactLeafPayloadScratchPool sync.Pool
+const compactLeafPayloadScratchMaxCap = page.PageSize
+
+var compactLeafPayloadScratchPool = sync.Pool{
+	New: func() any {
+		return make([]byte, 0)
+	},
+}
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLog)(nil)
 
@@ -34,27 +40,17 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	if l == nil || l.db == nil || l.lane == nil {
 		return page.LeafLogPtr{}, errWALUnavailable
 	}
-	scratch := compactLeafPayloadScratchPool.Get()
-	var payloadScratch []byte
-	if b, ok := scratch.([]byte); ok {
-		payloadScratch = b[:0]
-	}
+	payloadScratch := getCompactLeafPayloadScratch()
 	encodedLeafPage, compacted, err := valuelog.MaybeCompactLeafLogPayloadTo(payloadScratch, leafPage)
 	if err != nil {
-		if payloadScratch != nil {
-			compactLeafPayloadScratchPool.Put(payloadScratch[:0])
-		}
+		releaseCompactLeafPayloadScratch(payloadScratch, nil, false)
 		return page.LeafLogPtr{}, err
 	}
-	releaseScratch := payloadScratch
-	if compacted {
-		releaseScratch = encodedLeafPage
-	}
 	rid := l.db.nextRID.Add(1)
+	// appendValueLogOneInternal writes/copies value before returning; release the
+	// pooled scratch only after that synchronous append completes.
 	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
-	if releaseScratch != nil {
-		compactLeafPayloadScratchPool.Put(releaseScratch[:0])
-	}
+	releaseCompactLeafPayloadScratch(payloadScratch, encodedLeafPage, compacted)
 	if retainPath != "" {
 		l.db.markValueLogRetain(retainPath)
 	}
@@ -67,6 +63,40 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	}
 	l.db.noteLeafGenerationRecordLength(ptr)
 	return leafPtr, nil
+}
+
+func getCompactLeafPayloadScratch() []byte {
+	scratch := compactLeafPayloadScratchPool.Get()
+	if b, ok := scratch.([]byte); ok {
+		return b[:0]
+	}
+	if scratch != nil {
+		compactLeafPayloadScratchPool.Put(scratch)
+	}
+	return nil
+}
+
+func releaseCompactLeafPayloadScratch(payloadScratch, encodedLeafPage []byte, compacted bool) {
+	putCompactLeafPayloadScratch(payloadScratch)
+	if compacted && encodedLeafPage != nil && !sameSliceBacking(payloadScratch, encodedLeafPage) {
+		putCompactLeafPayloadScratch(encodedLeafPage)
+	}
+}
+
+func putCompactLeafPayloadScratch(buf []byte) {
+	if buf == nil || cap(buf) == 0 || cap(buf) > compactLeafPayloadScratchMaxCap {
+		return
+	}
+	compactLeafPayloadScratchPool.Put(buf[:0])
+}
+
+func sameSliceBacking(a, b []byte) bool {
+	if cap(a) == 0 || cap(b) == 0 {
+		return false
+	}
+	aFull := a[:cap(a)]
+	bFull := b[:cap(b)]
+	return &aFull[0] == &bFull[0]
 }
 
 func (l *cachingLeafPageLog) Flush() error {

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -20,6 +20,10 @@ func HasCompactLeafLogPayload(payload []byte) bool {
 }
 
 func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
+	return MaybeCompactLeafLogPayloadTo(nil, leafPage)
+}
+
+func MaybeCompactLeafLogPayloadTo(dst, leafPage []byte) ([]byte, bool, error) {
 	if len(leafPage) != page.PageSize {
 		return leafPage, false, nil
 	}
@@ -33,7 +37,12 @@ func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
 	}
 
 	suffixStart := len(leafPage) - suffixLen
-	payload := make([]byte, compactLen)
+	var payload []byte
+	if cap(dst) >= compactLen {
+		payload = dst[:compactLen]
+	} else {
+		payload = make([]byte, compactLen)
+	}
 	copy(payload[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:])
 	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic):len(compactLeafPagePayloadMagic)+2], uint16(prefixLen))
 	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic)+2:compactLeafPagePayloadHeaderSize], uint16(suffixLen))

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -130,6 +130,30 @@ func TestMaybeCompactLeafLogPayload_SparseLeafAllocatesOnlyPayload(t *testing.T)
 	}
 }
 
+func TestMaybeCompactLeafLogPayloadTo_SparseLeafReusesDstWithoutAllocations(t *testing.T) {
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	dst := make([]byte, 0, page.PageSize)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		payload, compacted, err := MaybeCompactLeafLogPayloadTo(dst, leaf)
+		if err != nil {
+			t.Fatalf("MaybeCompactLeafLogPayloadTo: %v", err)
+		}
+		if !compacted {
+			t.Fatalf("expected sparse leaf page to compact")
+		}
+		if len(payload) >= len(leaf) {
+			t.Fatalf("payload len=%d want < %d", len(payload), len(leaf))
+		}
+		if len(payload) > 0 && &payload[0] != &dst[:cap(dst)][0] {
+			t.Fatalf("expected compact payload to reuse dst backing storage")
+		}
+	})
+	if allocs > 0 {
+		t.Fatalf("allocs/run=%f want 0", allocs)
+	}
+}
+
 func TestDecodeCompactLeafLogPayloadTo_AliasedDstRoundTrips(t *testing.T) {
 	leaf := buildSparseLeafPageForPayloadTest(t)
 


### PR DESCRIPTION
## Summary
- reuse compact leaf payload scratch across `AppendLeafPage` writes instead of allocating a fresh payload buffer on each compacted page
- release compact-payload scratch without a per-call `defer` on the hot append path
- replace per-batch touched-mem maps with reused slices in `Batch.writeRegular`

## Validation
- `go test ./TreeDB/caching ./TreeDB/internal/valuelog`
- fresh-built exact benchmark on top of `codex/compact-leaf-payload-allocs`:
  - `go build -o /tmp/unified-bench-leafbatch ./cmd/unified_bench`
  - `/tmp/unified-bench-leafbatch -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_leaf_batch_allocs_jfrFYX -test batch_delete`
  - `Batch Delete: 4,101,674`
  - `alloc_space: 3.29GB` vs `3.67GB` on the current `#1014` exact profile
  - `MaybeCompactLeafLogPayload` dropped out of the top alloc-space entries on this run