### PR TITLE
Consolidate append-only batch_delete allocation wins

### DIFF
--- a/TreeDB/caching/append_only_hint_test.go
+++ b/TreeDB/caching/append_only_hint_test.go
@@ -1,9 +1,12 @@
 package caching
 
 import (
+	"encoding/binary"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func TestAppendOnlyEntryHint_AdaptiveDecayAndCapacityClamp(t *testing.T) {
@@ -120,5 +123,30 @@ func TestAppendOnlyEntryHint_CapacityTracksPressureScaledMutableThreshold(t *tes
 
 	if !(critical < high && high < normal) {
 		t.Fatalf("expected stricter caps under pressure: normal=%d high=%d critical=%d", normal, high, critical)
+	}
+}
+
+func TestAppendOnlyPredictiveHintUpdatesSharedEntryHint(t *testing.T) {
+	db := &DB{backend: NewMockBackend()}
+	const capacity = 128 << 10
+
+	before := db.appendOnlyEntryHintEntries()
+	raw, err := db.newMutableMemtableWithCapacityMode(capacity, memtable.ModeAppendOnly)
+	if err != nil {
+		t.Fatalf("newMutableMemtableWithCapacityMode: %v", err)
+	}
+	mt, ok := raw.(*memtable.AppendOnly)
+	if !ok {
+		t.Fatalf("expected append-only memtable, got %T", raw)
+	}
+
+	for i := 0; i < 1<<10; i++ {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(i+1))
+		mt.Delete(key[:])
+	}
+
+	if got := int(db.appendOnlyEntryHint.Load()); got <= before {
+		t.Fatalf("shared entry hint=%d want > %d after predictive observation", got, before)
 	}
 }

--- a/TreeDB/caching/batch_arena_ownership_test.go
+++ b/TreeDB/caching/batch_arena_ownership_test.go
@@ -60,6 +60,30 @@ func TestBatchReset_DoesNotCorruptPriorBorrowedWrites(t *testing.T) {
 	}
 }
 
+func TestBatchResetClearsRetainedMemtableSliceBackingArrays(t *testing.T) {
+	mt1 := memtable.NewAppendOnlyWithCapacity(0)
+	mt2 := memtable.NewAppendOnlyWithCapacity(0)
+	b := &Batch{
+		retainMainMems: []memtable.Table{mt1},
+		ptrTouchedMems: []memtable.Table{mt2},
+	}
+
+	b.Reset()
+
+	if got := len(b.retainMainMems); got != 0 {
+		t.Fatalf("retainMainMems len=%d want=0", got)
+	}
+	if got := len(b.ptrTouchedMems); got != 0 {
+		t.Fatalf("ptrTouchedMems len=%d want=0", got)
+	}
+	if full := b.retainMainMems[:cap(b.retainMainMems)]; len(full) > 0 && full[0] != nil {
+		t.Fatalf("retainMainMems backing array still references %T", full[0])
+	}
+	if full := b.ptrTouchedMems[:cap(b.ptrTouchedMems)]; len(full) > 0 && full[0] != nil {
+		t.Fatalf("ptrTouchedMems backing array still references %T", full[0])
+	}
+}
+
 func TestBatchArenaLeases_CopiedMemtablesMatchOwnershipMode(t *testing.T) {
 	cases := []struct {
 		mode       string

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7738,12 +7738,14 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 		if mt := db.popAppendOnlyMemLease(); mt != nil {
 			db.appendOnlyMemLeaseHitTotal.Add(1)
 			mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
+			mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
 			return mt, nil
 		}
 		if v := db.appendOnlyMemPool.Get(); v != nil {
 			if mt, ok := v.(*memtable.AppendOnly); ok && mt != nil {
 				db.appendOnlyMemPoolHitTotal.Add(1)
 				mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
+				mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
 				return mt, nil
 			}
 		}
@@ -7754,7 +7756,9 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 			db.appendOnlyMemNewAllocQueueBytes.Add(uint64(backlog))
 		}
 		db.appendOnlyMemNewAllocTotal.Add(1)
-		return memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimate, entryHint), nil
+		mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimate, entryHint)
+		mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
+		return mt, nil
 	}
 	return memtable.NewWithCapacityModeAndIndexer(capacity, mode, db.hashSortedIndexer)
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7750,14 +7750,14 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 		if mt := db.popAppendOnlyMemLease(); mt != nil {
 			db.appendOnlyMemLeaseHitTotal.Add(1)
 			mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
-			mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
+			mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
 			return mt, nil
 		}
 		if v := db.appendOnlyMemPool.Get(); v != nil {
 			if mt, ok := v.(*memtable.AppendOnly); ok && mt != nil {
 				db.appendOnlyMemPoolHitTotal.Add(1)
 				mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
-				mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
+				mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
 				return mt, nil
 			}
 		}
@@ -7769,7 +7769,7 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 		}
 		db.appendOnlyMemNewAllocTotal.Add(1)
 		mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimate, entryHint)
-		mt.SetPredictiveGrowthHint(capacity, db.observeAppendOnlyMutableEntries)
+		mt.SetPredictiveGrowthHint(capacity, &db.appendOnlyEntryHint, db.observeAppendOnlyMutableEntries)
 		return mt, nil
 	}
 	return memtable.NewWithCapacityModeAndIndexer(capacity, mode, db.hashSortedIndexer)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7594,10 +7594,11 @@ func (db *DB) recycleMemtables(mems []memtable.Table) {
 	resetCapacity := db.checkpointRotateCapacity()
 	estimate := appendOnlyEstimatedBytesPerEntryDefault
 	appendOnlyResetCapacity := db.appendOnlyMemtableCapacityHint(resetCapacity, estimate)
+	entryHint := db.appendOnlyEntryHintEntries()
 	for _, mt := range mems {
 		switch typed := mt.(type) {
 		case *memtable.AppendOnly:
-			typed.ResetWithCapacityHard(appendOnlyResetCapacity, estimate)
+			typed.ResetWithCapacityHardAndEntryHint(appendOnlyResetCapacity, estimate, entryHint)
 			db.releaseAppendOnlyDirectArenaLeaseForMemtable(typed)
 			if !db.putAppendOnlyMemLease(typed) {
 				db.appendOnlyMemPool.Put(typed)
@@ -7630,9 +7631,10 @@ func (db *DB) trimAppendOnlyMemLeases(maxLeases int, resetCapacity int) {
 		return
 	}
 	effectiveResetCapacity := db.appendOnlyMemtableCapacityHint(resetCapacity, appendOnlyEstimatedBytesPerEntryDefault)
+	entryHint := db.appendOnlyEntryHintEntries()
 	for i := range dropped {
 		if dropped[i] != nil {
-			dropped[i].ResetWithCapacityHard(effectiveResetCapacity, appendOnlyEstimatedBytesPerEntryDefault)
+			dropped[i].ResetWithCapacityHardAndEntryHint(effectiveResetCapacity, appendOnlyEstimatedBytesPerEntryDefault, entryHint)
 			db.releaseAppendOnlyDirectArenaLeaseForMemtable(dropped[i])
 			db.appendOnlyMemPool.Put(dropped[i])
 		}
@@ -7732,15 +7734,16 @@ func (db *DB) trimRetainedArenasAfterFlush(checkpoint bool) {
 func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mode) (memtable.Table, error) {
 	if db != nil && mode == memtable.ModeAppendOnly {
 		estimate := appendOnlyEstimatedBytesPerEntryDefault
+		entryHint := db.appendOnlyEntryHintEntries()
 		if mt := db.popAppendOnlyMemLease(); mt != nil {
 			db.appendOnlyMemLeaseHitTotal.Add(1)
-			mt.ResetWithCapacity(capacity, estimate)
+			mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
 			return mt, nil
 		}
 		if v := db.appendOnlyMemPool.Get(); v != nil {
 			if mt, ok := v.(*memtable.AppendOnly); ok && mt != nil {
 				db.appendOnlyMemPoolHitTotal.Add(1)
-				mt.ResetWithCapacity(capacity, estimate)
+				mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
 				return mt, nil
 			}
 		}
@@ -7751,7 +7754,7 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 			db.appendOnlyMemNewAllocQueueBytes.Add(uint64(backlog))
 		}
 		db.appendOnlyMemNewAllocTotal.Add(1)
-		return memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, estimate), nil
+		return memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimate, entryHint), nil
 	}
 	return memtable.NewWithCapacityModeAndIndexer(capacity, mode, db.hashSortedIndexer)
 }
@@ -25826,6 +25829,17 @@ func (db *DB) observeAppendOnlyMutableEntries(entries int) {
 			return
 		}
 	}
+}
+
+func (db *DB) appendOnlyEntryHintEntries() int {
+	if db == nil {
+		return 0
+	}
+	hint := int(db.appendOnlyEntryHint.Load())
+	if hint <= 0 {
+		return 0
+	}
+	return clampAppendOnlyEntryHint(hint)
 }
 
 func appendOnlyEntriesToCapacity(entries, estimatedBytesPerEntry int) int {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7359,6 +7359,18 @@ func memtableBatchDelete(mt memtable.Table, useSteal bool, key []byte) {
 	mt.Delete(key)
 }
 
+func appendUniqueTouchedMem(dst []memtable.Table, mt memtable.Table) []memtable.Table {
+	if mt == nil {
+		return dst
+	}
+	for i := range dst {
+		if dst[i] == mt {
+			return dst
+		}
+	}
+	return append(dst, mt)
+}
+
 // memtableBatchSet applies a cached batch write while preserving the ownership
 // rules selected by cachedBatchWriteUsesSteal. Pointer entries may still keep
 // inline bytes in memtables that do not use value-log pointers internally.
@@ -25761,6 +25773,8 @@ type Batch struct {
 	shardCnts          []int
 	shardEntries       [][]batch.Entry
 	shardIdxSets       [][]int
+	retainMainMems     []memtable.Table
+	ptrTouchedMems     []memtable.Table
 	maxEntries         int
 
 	closed bool
@@ -26215,6 +26229,12 @@ func (b *Batch) Reset() {
 	}
 	if b.shardIdxSets != nil {
 		b.shardIdxSets = b.shardIdxSets[:0]
+	}
+	if b.retainMainMems != nil {
+		b.retainMainMems = b.retainMainMems[:0]
+	}
+	if b.ptrTouchedMems != nil {
+		b.ptrTouchedMems = b.ptrTouchedMems[:0]
 	}
 	b.recycleCopyArenaChunks()
 	b.recyclePtrCopyArenaChunks()
@@ -27158,8 +27178,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		}
 		shardAdds[idx] += add
 	}
-	retainMainMems := make([]memtable.Table, 0, shardCount)
-	retainMainSeen := make(map[memtable.Table]struct{}, shardCount)
+	retainMainMems := b.retainMainMems[:0]
 	for i, add := range shardAdds {
 		if add == 0 {
 			continue
@@ -27567,10 +27586,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				batchArenaStealSuppressedDeferredEntriesTotal.Add(uint64(len(idxs)))
 			}
 			if useSteal && cachedBatchWriteNeedsBatchArenaRetention(shard.mem) {
-				if _, ok := retainMainSeen[shard.mem]; !ok {
-					retainMainSeen[shard.mem] = struct{}{}
-					retainMainMems = append(retainMainMems, shard.mem)
-				}
+				retainMainMems = appendUniqueTouchedMem(retainMainMems, shard.mem)
 			}
 			if b.streamEligible {
 				first := b.entries[idxs[0]].Key
@@ -27642,10 +27658,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				batchArenaStealSuppressedDeferredEntriesTotal.Add(uint64(len(entries)))
 			}
 			if useSteal && cachedBatchWriteNeedsBatchArenaRetention(shard.mem) {
-				if _, ok := retainMainSeen[shard.mem]; !ok {
-					retainMainSeen[shard.mem] = struct{}{}
-					retainMainMems = append(retainMainMems, shard.mem)
-				}
+				retainMainMems = appendUniqueTouchedMem(retainMainMems, shard.mem)
 			}
 			storeInlinePtrValues := !b.db.memtableValueLogPointers
 			if useStream && useSteal {
@@ -27686,10 +27699,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 						}
 						memtableBatchSet(shard.mem, useSteal, allowBatchArenaBorrow, storeInlinePtrValues, op)
 						if borrowed {
-							if _, ok := retainMainSeen[shard.mem]; !ok {
-								retainMainSeen[shard.mem] = struct{}{}
-								retainMainMems = append(retainMainMems, shard.mem)
-							}
+							retainMainMems = appendUniqueTouchedMem(retainMainMems, shard.mem)
 						}
 					}
 					if useStream {
@@ -27716,6 +27726,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			shard.mu.Unlock()
 		}
 	}
+	b.retainMainMems = retainMainMems
 
 	// 3. Threshold Check
 	if b.db.mutableBytes.Load() > b.db.mutableFlushThreshold() {
@@ -27728,9 +27739,8 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	b.updateBatchCopyHint()
 	mainChunks := b.drainCopyArenaChunks()
 	retainPtrArena := false
-	ptrTouchedMems := make([]memtable.Table, 0, len(b.ptrValueIdxs))
+	ptrTouchedMems := b.ptrTouchedMems[:0]
 	if allowBatchArenaBorrow && len(b.ptrValueIdxs) > 0 {
-		seenPtrMems := make(map[memtable.Table]struct{}, len(b.ptrValueIdxs))
 		for _, idx := range b.ptrValueIdxs {
 			if idx < 0 || idx >= len(b.entries) || idx >= len(shardIdxs) {
 				b.db.writeMu.RUnlock()
@@ -27749,13 +27759,10 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			if mt == nil {
 				continue
 			}
-			if _, ok := seenPtrMems[mt]; ok {
-				continue
-			}
-			seenPtrMems[mt] = struct{}{}
-			ptrTouchedMems = append(ptrTouchedMems, mt)
+			ptrTouchedMems = appendUniqueTouchedMem(ptrTouchedMems, mt)
 		}
 	}
+	b.ptrTouchedMems = ptrTouchedMems
 	if b.ptrValueIdxs != nil {
 		b.ptrValueIdxs = b.ptrValueIdxs[:0]
 	}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -26230,12 +26230,7 @@ func (b *Batch) Reset() {
 	if b.shardIdxSets != nil {
 		b.shardIdxSets = b.shardIdxSets[:0]
 	}
-	if b.retainMainMems != nil {
-		b.retainMainMems = b.retainMainMems[:0]
-	}
-	if b.ptrTouchedMems != nil {
-		b.ptrTouchedMems = b.ptrTouchedMems[:0]
-	}
+	b.clearRetainedMemtableSlices()
 	b.recycleCopyArenaChunks()
 	b.recyclePtrCopyArenaChunks()
 	if b.arenaInFlightBytes > 0 {
@@ -26255,6 +26250,22 @@ func (b *Batch) Reset() {
 	b.maxEntries = 0
 	if b.ptrValueIdxs != nil {
 		b.ptrValueIdxs = b.ptrValueIdxs[:0]
+	}
+}
+
+func (b *Batch) clearRetainedMemtableSlices() {
+	if b == nil {
+		return
+	}
+	if b.retainMainMems != nil {
+		full := b.retainMainMems[:cap(b.retainMainMems)]
+		clear(full)
+		b.retainMainMems = b.retainMainMems[:0]
+	}
+	if b.ptrTouchedMems != nil {
+		full := b.ptrTouchedMems[:cap(b.ptrTouchedMems)]
+		clear(full)
+		b.ptrTouchedMems = b.ptrTouchedMems[:0]
 	}
 }
 
@@ -27768,11 +27779,15 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	}
 	ptrChunks := b.drainPtrCopyArenaChunks()
 	b.db.retainBatchArenaChunksForMemtables(mainChunks, retainMainMems)
+	clear(retainMainMems)
+	b.retainMainMems = retainMainMems[:0]
 	if retainPtrArena {
 		b.db.retainBatchArenaChunksForMemtables(ptrChunks, ptrTouchedMems)
 	} else {
 		putBatchArenas(ptrChunks)
 	}
+	clear(ptrTouchedMems)
+	b.ptrTouchedMems = ptrTouchedMems[:0]
 	b.db.writeMu.RUnlock()
 
 	if needRotate {

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"sync"
+	"unsafe"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
@@ -13,7 +14,13 @@ type cachingLeafPageLog struct {
 	lane *lane
 }
 
-var compactLeafPayloadScratchPool sync.Pool
+const compactLeafPayloadScratchMaxCap = page.PageSize
+
+var compactLeafPayloadScratchPool = sync.Pool{
+	New: func() any {
+		return make([]byte, 0)
+	},
+}
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLog)(nil)
 
@@ -34,19 +41,15 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	if l == nil || l.db == nil || l.lane == nil {
 		return page.LeafLogPtr{}, errWALUnavailable
 	}
-	scratch := compactLeafPayloadScratchPool.Get()
-	var payloadScratch []byte
-	if b, ok := scratch.([]byte); ok {
-		payloadScratch = b[:0]
-	}
+	payloadScratch := getCompactLeafPayloadScratch()
 	encodedLeafPage, compacted, err := valuelog.MaybeCompactLeafLogPayloadTo(payloadScratch, leafPage)
 	if err != nil {
-		if payloadScratch != nil {
-			compactLeafPayloadScratchPool.Put(payloadScratch[:0])
-		}
+		releaseCompactLeafPayloadScratch(payloadScratch, nil, false)
 		return page.LeafLogPtr{}, err
 	}
 	rid := l.db.nextRID.Add(1)
+	// appendValueLogOneInternal writes/copies value before returning; release the
+	// pooled scratch only after that synchronous append completes.
 	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
 	releaseCompactLeafPayloadScratch(payloadScratch, encodedLeafPage, compacted)
 	if retainPath != "" {
@@ -63,22 +66,47 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	return leafPtr, nil
 }
 
-func releaseCompactLeafPayloadScratch(payloadScratch, encodedLeafPage []byte, compacted bool) {
-	if payloadScratch != nil {
-		compactLeafPayloadScratchPool.Put(payloadScratch[:0])
+func getCompactLeafPayloadScratch() []byte {
+	scratch := compactLeafPayloadScratchPool.Get()
+	if b, ok := scratch.([]byte); ok {
+		return b[:0]
 	}
+	if scratch != nil {
+		compactLeafPayloadScratchPool.Put(scratch)
+	}
+	return nil
+}
+
+func releaseCompactLeafPayloadScratch(payloadScratch, encodedLeafPage []byte, compacted bool) {
+	putCompactLeafPayloadScratch(payloadScratch)
 	if compacted && encodedLeafPage != nil && !sameSliceBacking(payloadScratch, encodedLeafPage) {
-		compactLeafPayloadScratchPool.Put(encodedLeafPage[:0])
+		putCompactLeafPayloadScratch(encodedLeafPage)
 	}
 }
 
+func putCompactLeafPayloadScratch(buf []byte) {
+	if buf == nil || cap(buf) == 0 || cap(buf) > compactLeafPayloadScratchMaxCap {
+		return
+	}
+	compactLeafPayloadScratchPool.Put(buf[:0])
+}
+
 func sameSliceBacking(a, b []byte) bool {
-	if cap(a) == 0 || cap(b) == 0 {
+	aStart, aEnd, aOK := sliceBackingRange(a)
+	bStart, bEnd, bOK := sliceBackingRange(b)
+	if !aOK || !bOK {
 		return false
 	}
-	aFull := a[:cap(a)]
-	bFull := b[:cap(b)]
-	return &aFull[0] == &bFull[0]
+	return aStart < bEnd && bStart < aEnd
+}
+
+func sliceBackingRange(b []byte) (start, end uintptr, ok bool) {
+	if cap(b) == 0 {
+		return 0, 0, false
+	}
+	full := b[:cap(b)]
+	start = uintptr(unsafe.Pointer(&full[0]))
+	return start, start + uintptr(cap(full)), true
 }
 
 func (l *cachingLeafPageLog) Flush() error {

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -46,15 +46,9 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 		}
 		return page.LeafLogPtr{}, err
 	}
-	releaseScratch := payloadScratch
-	if compacted {
-		releaseScratch = encodedLeafPage
-	}
 	rid := l.db.nextRID.Add(1)
 	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
-	if releaseScratch != nil {
-		compactLeafPayloadScratchPool.Put(releaseScratch[:0])
-	}
+	releaseCompactLeafPayloadScratch(payloadScratch, encodedLeafPage, compacted)
 	if retainPath != "" {
 		l.db.markValueLogRetain(retainPath)
 	}
@@ -67,6 +61,24 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	}
 	l.db.noteLeafGenerationRecordLength(ptr)
 	return leafPtr, nil
+}
+
+func releaseCompactLeafPayloadScratch(payloadScratch, encodedLeafPage []byte, compacted bool) {
+	if payloadScratch != nil {
+		compactLeafPayloadScratchPool.Put(payloadScratch[:0])
+	}
+	if compacted && encodedLeafPage != nil && !sameSliceBacking(payloadScratch, encodedLeafPage) {
+		compactLeafPayloadScratchPool.Put(encodedLeafPage[:0])
+	}
+}
+
+func sameSliceBacking(a, b []byte) bool {
+	if cap(a) == 0 || cap(b) == 0 {
+		return false
+	}
+	aFull := a[:cap(a)]
+	bFull := b[:cap(b)]
+	return &aFull[0] == &bFull[0]
 }
 
 func (l *cachingLeafPageLog) Flush() error {

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -1,6 +1,8 @@
 package caching
 
 import (
+	"sync"
+
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -10,6 +12,8 @@ type cachingLeafPageLog struct {
 	db   *DB
 	lane *lane
 }
+
+var compactLeafPayloadScratchPool sync.Pool
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLog)(nil)
 
@@ -30,9 +34,22 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 	if l == nil || l.db == nil || l.lane == nil {
 		return page.LeafLogPtr{}, errWALUnavailable
 	}
-	encodedLeafPage, _, err := valuelog.MaybeCompactLeafLogPayload(leafPage)
+	scratch := compactLeafPayloadScratchPool.Get()
+	var payloadScratch []byte
+	if b, ok := scratch.([]byte); ok {
+		payloadScratch = b[:0]
+	}
+	encodedLeafPage, compacted, err := valuelog.MaybeCompactLeafLogPayloadTo(payloadScratch, leafPage)
 	if err != nil {
+		if payloadScratch != nil {
+			compactLeafPayloadScratchPool.Put(payloadScratch[:0])
+		}
 		return page.LeafLogPtr{}, err
+	}
+	if compacted {
+		defer compactLeafPayloadScratchPool.Put(encodedLeafPage[:0])
+	} else if payloadScratch != nil {
+		compactLeafPayloadScratchPool.Put(payloadScratch[:0])
 	}
 	rid := l.db.nextRID.Add(1)
 	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -46,13 +46,15 @@ func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, e
 		}
 		return page.LeafLogPtr{}, err
 	}
+	releaseScratch := payloadScratch
 	if compacted {
-		defer compactLeafPayloadScratchPool.Put(encodedLeafPage[:0])
-	} else if payloadScratch != nil {
-		compactLeafPayloadScratchPool.Put(payloadScratch[:0])
+		releaseScratch = encodedLeafPage
 	}
 	rid := l.db.nextRID.Add(1)
 	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
+	if releaseScratch != nil {
+		compactLeafPayloadScratchPool.Put(releaseScratch[:0])
+	}
 	if retainPath != "" {
 		l.db.markValueLogRetain(retainPath)
 	}

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -1212,10 +1212,20 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		ent.payloadIndex = 0
 		ent.inlineKeyLen = 0
 	}
-	clear(m.keys)
-	m.keys = m.keys[:0]
-	clear(m.payloads)
-	m.payloads = m.payloads[:0]
+	if !retainObserved || cap(m.keys) > maxRetainedEntries {
+		putAppendOnlyKeys(m.keys)
+		m.keys = nil
+	} else {
+		clear(m.keys)
+		m.keys = m.keys[:0]
+	}
+	if !retainObserved || cap(m.payloads) > maxRetainedEntries {
+		putAppendOnlyPayloads(m.payloads)
+		m.payloads = nil
+	} else {
+		clear(m.payloads)
+		m.payloads = m.payloads[:0]
+	}
 	m.valueArena.reset()
 	if !retainObserved {
 		m.valueArena.dropRetained()

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -59,6 +59,7 @@ type appendOnlyEntry struct {
 	inlineKey    [appendOnlyInlineKeyLen]byte
 	keyIndex     uint32
 	payloadIndex uint32
+	inlineKeyLen uint8
 	flags        byte
 }
 
@@ -378,7 +379,7 @@ func appendOnlyEntryKeyFromKeys(ent *appendOnlyEntry, keys []string) []byte {
 		return nil
 	}
 	if ent.flags&appendOnlyEntryFlagKeyInline != 0 {
-		return ent.inlineKey[:]
+		return ent.inlineKey[:int(ent.inlineKeyLen)]
 	}
 	if ent.keyIndex == 0 {
 		return nil
@@ -776,10 +777,12 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	ent.flags = flags
 	ent.keyIndex = 0
 	ent.payloadIndex = 0
+	ent.inlineKeyLen = 0
 	payloadValue := ""
 	payloadPtr := page.ValuePtr{}
-	if len(key) == appendOnlyInlineKeyLen {
+	if len(key) <= appendOnlyInlineKeyLen {
 		copy(ent.inlineKey[:], key)
+		ent.inlineKeyLen = uint8(len(key))
 		ent.flags |= appendOnlyEntryFlagKeyInline
 	} else if steal {
 		m.keys = append(m.keys, appendOnlyStringFromBytes(key))
@@ -1192,6 +1195,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		ent.flags = 0
 		ent.keyIndex = 0
 		ent.payloadIndex = 0
+		ent.inlineKeyLen = 0
 	}
 	clear(m.keys)
 	m.keys = m.keys[:0]

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -629,6 +629,13 @@ func appendOnlyKeyString(key []byte) string {
 	return string(key)
 }
 
+func appendOnlyLookupKeyString(key []byte) string {
+	if len(key) == 0 {
+		return ""
+	}
+	return unsafe.String(unsafe.SliceData(key), len(key))
+}
+
 func appendOnlyKeyU64(key []byte) (uint64, bool) {
 	if len(key) != appendOnlyInlineKeyLen {
 		return 0, false
@@ -1000,7 +1007,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 				}
 			}
 			if m.latest != nil {
-				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
+				if idx, ok := m.latest[appendOnlyLookupKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
@@ -1056,7 +1063,7 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 				}
 			}
 			if m.latest != nil {
-				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
+				if idx, ok := m.latest[appendOnlyLookupKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						val := m.appendOnlyEntryValue(ent)

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -206,12 +206,33 @@ func appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry int) i
 	return n
 }
 
+func appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint int) int {
+	n := appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
+	if entryHint <= 0 {
+		return n
+	}
+	if entryHint < appendOnlyMinInitialEntries {
+		entryHint = appendOnlyMinInitialEntries
+	}
+	if entryHint > appendOnlyMaxInitialEntries {
+		entryHint = appendOnlyMaxInitialEntries
+	}
+	if entryHint > n {
+		n = entryHint
+	}
+	return n
+}
+
 func NewAppendOnlyWithCapacity(capacity int) *AppendOnly {
 	return NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, appendOnlyEstimatedBytesPerEntryPointer)
 }
 
 func NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, estimatedBytesPerEntry int) *AppendOnly {
-	n := appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
+	return NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedBytesPerEntry, 0)
+}
+
+func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedBytesPerEntry, entryHint int) *AppendOnly {
+	n := appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint)
 	return &AppendOnly{
 		entries:        getAppendOnlyEntries(n),
 		baseEntriesLen: n,
@@ -893,7 +914,7 @@ func (m *AppendOnly) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.waitIteratorLeasesLocked()
-	m.resetLockedWithPolicy(0, 0, true)
+	m.resetLockedWithPolicy(0, 0, 0, true)
 }
 
 // ResetWithCapacity resets the memtable and, when needed, shrinks retained
@@ -903,11 +924,18 @@ func (m *AppendOnly) ResetWithCapacity(capacity, estimatedBytesPerEntry int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.waitIteratorLeasesLocked()
-	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, true)
+	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, 0, true)
+}
+
+func (m *AppendOnly) ResetWithCapacityAndEntryHint(capacity, estimatedBytesPerEntry, entryHint int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.waitIteratorLeasesLocked()
+	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, entryHint, true)
 }
 
 func (m *AppendOnly) resetLocked(capacity, estimatedBytesPerEntry int) {
-	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, true)
+	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, 0, true)
 }
 
 // ResetWithCapacityHard resets and clamps retained internal buffers to the
@@ -916,14 +944,23 @@ func (m *AppendOnly) ResetWithCapacityHard(capacity, estimatedBytesPerEntry int)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.waitIteratorLeasesLocked()
-	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, false)
+	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, 0, false)
 }
 
-func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int, retainObserved bool) {
+func (m *AppendOnly) ResetWithCapacityHardAndEntryHint(capacity, estimatedBytesPerEntry, entryHint int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.waitIteratorLeasesLocked()
+	m.resetLockedWithPolicy(capacity, estimatedBytesPerEntry, entryHint, false)
+}
+
+func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, entryHint int, retainObserved bool) {
 	desiredEntries := m.baseEntriesLen
 	if capacity > 0 {
-		desiredEntries = appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
+		desiredEntries = appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint)
 		m.baseEntriesLen = desiredEntries
+	} else if entryHint > 0 {
+		desiredEntries = appendOnlyInitialEntriesForCapacityAndHint(defaultMemtableCapacity, estimatedBytesPerEntry, entryHint)
 	}
 	if desiredEntries <= 0 {
 		desiredEntries = appendOnlyMinInitialEntries

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -834,13 +834,12 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 			return
 		}
 		m.ordered = false
-		// Once order breaks, invalidate the cached snapshot state and
-		// materialize the latest-key index immediately so subsequent unordered
-		// appends can maintain it incrementally instead of forcing the next
-		// iterator/lookup to rebuild the full map from scratch.
-		// rebuildLatestIndexLocked clears the cached snapshot as part of the
-		// transition.
-		m.rebuildLatestIndexLocked()
+		// Defer latest-key index materialization until a lookup/iterator actually
+		// needs it. Random-write/delete workloads can otherwise spend a
+		// disproportionate amount of time and memory maintaining a large
+		// latest-key map that is never queried on the hot path.
+		m.latestDirty = true
+		m.clearSnapshotLocked()
 		return
 	}
 	if !m.latestDirty {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -6,6 +6,7 @@ import (
 	"math/bits"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
@@ -97,6 +98,7 @@ type AppendOnly struct {
 	lastIdx     int
 
 	predictCapacityHintBytes int
+	predictEntryHintSource   *atomic.Int32
 	observeEntries           func(int)
 
 	iteratorLeaseMu   sync.Mutex
@@ -364,13 +366,19 @@ func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedByte
 	}
 }
 
-func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, observeEntries func(int)) {
+func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, entryHintSource *atomic.Int32, observeEntries func(int)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if capacityHintBytes <= 0 {
 		capacityHintBytes = defaultMemtableCapacity
 	}
 	m.predictCapacityHintBytes = capacityHintBytes
+	m.predictEntryHintSource = entryHintSource
+	if entryHintSource != nil {
+		if shared := appendOnlyClampRetainedEntries(int(entryHintSource.Load())); shared > m.growEntriesLen {
+			m.growEntriesLen = shared
+		}
+	}
 	m.observeEntries = observeEntries
 }
 
@@ -761,6 +769,11 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 
 func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) {
 	if m.count == len(m.entries) {
+		if m.predictEntryHintSource != nil {
+			if shared := appendOnlyClampRetainedEntries(int(m.predictEntryHintSource.Load())); shared > m.growEntriesLen {
+				m.growEntriesLen = shared
+			}
+		}
 		nextCap := appendOnlyNextCapacity(len(m.entries))
 		if nextCap < m.growEntriesLen {
 			nextCap = m.growEntriesLen
@@ -770,6 +783,9 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		copy(grown, m.entries[:m.count])
 		m.entries = grown
 		putAppendOnlyEntries(prev)
+		if observe := m.observeEntries; observe != nil {
+			observe(nextCap)
+		}
 	}
 	idx := m.count
 	m.count++
@@ -1234,6 +1250,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	m.hasLast = false
 	m.lastIdx = -1
 	m.predictCapacityHintBytes = 0
+	m.predictEntryHintSource = nil
 	m.observeEntries = nil
 
 	// If the entry slice grew far beyond the configured baseline, shrink it.

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -45,14 +45,14 @@ var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
 
 type appendOnlyEntry struct {
-	key        []byte
-	value      []byte
-	ptr        page.ValuePtr
-	inlineKey  [appendOnlyInlineKeyLen]byte
-	flags      byte
-	keyInline  bool
-	valueOwned bool
+	key       []byte
+	value     string
+	ptr       page.ValuePtr
+	inlineKey [appendOnlyInlineKeyLen]byte
+	flags     byte
 }
+
+const appendOnlyEntryFlagKeyInline = 0x80
 
 type appendOnlyValueArena struct {
 	chunks    [][]byte
@@ -277,10 +277,24 @@ func appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
 	if ent == nil {
 		return nil
 	}
-	if ent.keyInline {
+	if ent.flags&appendOnlyEntryFlagKeyInline != 0 {
 		return ent.inlineKey[:]
 	}
 	return ent.key
+}
+
+func appendOnlyEntryValue(ent *appendOnlyEntry) []byte {
+	if ent == nil || len(ent.value) == 0 {
+		return nil
+	}
+	return unsafe.Slice(unsafe.StringData(ent.value), len(ent.value))
+}
+
+func appendOnlyStringFromBytes(src []byte) string {
+	if len(src) == 0 {
+		return ""
+	}
+	return unsafe.String(&src[0], len(src))
 }
 
 func cloneBytes(src []byte) []byte {
@@ -484,7 +498,7 @@ func appendOnlyKeyU64(key []byte) (uint64, bool) {
 	return binary.BigEndian.Uint64(key), true
 }
 
-func entryValueSize(flags byte, value []byte) int {
+func entryValueSize(flags byte, value string) int {
 	if flags&node.FlagPointer != 0 {
 		return page.ValuePtrSize + len(value)
 	}
@@ -629,34 +643,31 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	ent := &m.entries[idx]
 	ent.ptr = ptr
 	ent.flags = flags
-	ent.keyInline = false
-	ent.valueOwned = false
 	if steal {
 		ent.key = key
-		ent.value = value
+		ent.value = appendOnlyStringFromBytes(value)
 	} else {
 		if len(key) == appendOnlyInlineKeyLen {
 			copy(ent.inlineKey[:], key)
-			ent.keyInline = true
+			ent.flags |= appendOnlyEntryFlagKeyInline
 			ent.key = nil
 		} else {
 			ent.key = cloneOrReuseBytes(ent.key, key, appendOnlyReusableKeyMaxCap)
 		}
 		if len(value) > 0 {
 			if borrowValue {
-				ent.value = value
+				ent.value = appendOnlyStringFromBytes(value)
 			} else {
-				ent.value = m.valueArena.alloc(len(value))
-				copy(ent.value, value)
-				ent.valueOwned = true
+				buf := m.valueArena.alloc(len(value))
+				copy(buf, value)
+				ent.value = appendOnlyStringFromBytes(buf)
 			}
 		} else {
-			ent.value = nil
+			ent.value = ""
 		}
 	}
 	if flags&node.FlagTombstone != 0 {
-		ent.value = nil
-		ent.valueOwned = false
+		ent.value = ""
 		ent.ptr = page.ValuePtr{}
 	}
 	k := appendOnlyEntryKey(ent)
@@ -804,7 +815,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 		m.mu.RLock()
 		if ent := m.orderedLookupEntryLocked(key); ent != nil {
 			deleted := ent.flags&node.FlagTombstone != 0
-			val := ent.value
+			val := appendOnlyEntryValue(ent)
 			m.mu.RUnlock()
 			if deleted {
 				return nil, true, true
@@ -822,7 +833,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
-						val := ent.value
+						val := appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
 						if deleted {
 							return nil, true, true
@@ -836,7 +847,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
-						val := ent.value
+						val := appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
 						if deleted {
 							return nil, true, true
@@ -863,9 +874,9 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 	for {
 		m.mu.RLock()
 		if ent := m.orderedLookupEntryLocked(key); ent != nil {
-			val := ent.value
+			val := appendOnlyEntryValue(ent)
 			ptr := ent.ptr
-			flags := ent.flags
+			flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 			m.mu.RUnlock()
 			return val, ptr, flags, true
 		}
@@ -879,9 +890,9 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 				if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
-						val := ent.value
+						val := appendOnlyEntryValue(ent)
 						ptr := ent.ptr
-						flags := ent.flags
+						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 						m.mu.RUnlock()
 						return val, ptr, flags, true
 					}
@@ -891,9 +902,9 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
-						val := ent.value
+						val := appendOnlyEntryValue(ent)
 						ptr := ent.ptr
-						flags := ent.flags
+						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 						m.mu.RUnlock()
 						return val, ptr, flags, true
 					}
@@ -1038,14 +1049,12 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		ent := &m.entries[i]
 		ent.ptr = page.ValuePtr{}
 		ent.flags = 0
-		ent.keyInline = false
-		ent.valueOwned = false
 		if cap(ent.key) > appendOnlyReusableKeyMaxCap {
 			ent.key = nil
 		} else if ent.key != nil {
 			ent.key = ent.key[:0]
 		}
-		ent.value = nil
+		ent.value = ""
 	}
 	m.valueArena.reset()
 	if !retainObserved {
@@ -1395,7 +1404,7 @@ func (it *appendOnlyIterator) UnsafeValue() []byte {
 	if ent.flags&node.FlagTombstone != 0 {
 		return nil
 	}
-	return ent.value
+	return appendOnlyEntryValue(ent)
 }
 
 func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
@@ -1403,7 +1412,7 @@ func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	if ent == nil || !it.validIndex() {
 		return nil, page.ValuePtr{}, 0
 	}
-	return ent.value, ent.ptr, ent.flags
+	return appendOnlyEntryValue(ent), ent.ptr, ent.flags &^ appendOnlyEntryFlagKeyInline
 }
 
 func (it *appendOnlyIterator) IsDeleted() bool {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -66,6 +66,7 @@ type AppendOnly struct {
 
 	entries        []appendOnlyEntry
 	baseEntriesLen int
+	growEntriesLen int
 	latest         map[string]int
 	latest64       map[uint64]int
 	snapshot       []*appendOnlyEntry
@@ -206,8 +207,11 @@ func appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry int) i
 	return n
 }
 
-func appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint int) int {
-	n := appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
+func appendOnlyGrowthEntriesForHint(baseEntries, entryHint int) int {
+	n := baseEntries
+	if n < appendOnlyMinInitialEntries {
+		n = appendOnlyMinInitialEntries
+	}
 	if entryHint <= 0 {
 		return n
 	}
@@ -232,10 +236,12 @@ func NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, estimatedBytesPerEnt
 }
 
 func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedBytesPerEntry, entryHint int) *AppendOnly {
-	n := appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint)
+	baseEntries := appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
+	growEntries := appendOnlyGrowthEntriesForHint(baseEntries, entryHint)
 	return &AppendOnly{
-		entries:        getAppendOnlyEntries(n),
-		baseEntriesLen: n,
+		entries:        getAppendOnlyEntries(growEntries),
+		baseEntriesLen: baseEntries,
+		growEntriesLen: growEntries,
 		count:          0,
 		ordered:        true,
 		hasLast:        false,
@@ -565,6 +571,9 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) {
 	if m.count == len(m.entries) {
 		nextCap := appendOnlyNextCapacity(len(m.entries))
+		if nextCap < m.growEntriesLen {
+			nextCap = m.growEntriesLen
+		}
 		prev := m.entries
 		grown := getAppendOnlyEntries(nextCap)
 		copy(grown, m.entries[:m.count])
@@ -957,17 +966,20 @@ func (m *AppendOnly) ResetWithCapacityHardAndEntryHint(capacity, estimatedBytesP
 func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, entryHint int, retainObserved bool) {
 	desiredEntries := m.baseEntriesLen
 	if capacity > 0 {
-		desiredEntries = appendOnlyInitialEntriesForCapacityAndHint(capacity, estimatedBytesPerEntry, entryHint)
+		desiredEntries = appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
 		m.baseEntriesLen = desiredEntries
-	} else if entryHint > 0 {
-		desiredEntries = appendOnlyInitialEntriesForCapacityAndHint(defaultMemtableCapacity, estimatedBytesPerEntry, entryHint)
 	}
 	if desiredEntries <= 0 {
 		desiredEntries = appendOnlyMinInitialEntries
+		m.baseEntriesLen = desiredEntries
 	}
+	// Hints should improve the next growth jump and warm-retention ceiling, but
+	// reset itself must not allocate just to satisfy the hint.
+	growthEntries := appendOnlyGrowthEntriesForHint(desiredEntries, entryHint)
+	m.growEntriesLen = growthEntries
 
 	oldCount := m.count
-	maxRetainedEntries := appendOnlyMaxReuseEntries(desiredEntries)
+	maxRetainedEntries := appendOnlyMaxReuseEntries(growthEntries)
 	retainedEntries := desiredEntries
 	if retainObserved && oldCount > retainedEntries {
 		retainedEntries = oldCount

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -626,10 +626,7 @@ func appendOnlyNextCapacity(current int) int {
 }
 
 func appendOnlyKeyString(key []byte) string {
-	if len(key) == 0 {
-		return ""
-	}
-	return unsafe.String(&key[0], len(key))
+	return string(key)
 }
 
 func appendOnlyKeyU64(key []byte) (uint64, bool) {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -23,7 +23,9 @@ const (
 	appendOnlyMaxInitialEntries             = 1 << 20
 	appendOnlyInlineKeyLen                  = 8
 	appendOnlyEntryPoolMaxCap               = 1 << 20
+	appendOnlyPayloadPoolMaxCap             = 1 << 20
 	appendOnlyIteratorPoolMaxCap            = 1 << 20
+	appendOnlyIteratorPayloadPoolMaxCap     = 1 << 20
 	appendOnlyIteratorPtrPoolMaxCap         = 1 << 20
 	appendOnlyValueArenaMinShift            = 12
 	appendOnlyValueArenaMaxShift            = 20
@@ -39,16 +41,21 @@ const (
 )
 
 var appendOnlyEntryPool sync.Pool
+var appendOnlyPayloadPool sync.Pool
 var appendOnlyIteratorPool sync.Pool
+var appendOnlyIteratorPayloadPool sync.Pool
 var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
 
+type appendOnlyPayload struct {
+	value string
+	ptr   page.ValuePtr
+}
 type appendOnlyEntry struct {
-	key       string
-	value     string
-	ptr       page.ValuePtr
-	inlineKey [appendOnlyInlineKeyLen]byte
-	flags     byte
+	key          string
+	payloadIndex uint32
+	inlineKey    [appendOnlyInlineKeyLen]byte
+	flags        byte
 }
 
 const appendOnlyEntryFlagKeyInline = 0x80
@@ -65,6 +72,7 @@ type AppendOnly struct {
 	mu sync.RWMutex
 
 	entries        []appendOnlyEntry
+	payloads       []appendOnlyPayload
 	baseEntriesLen int
 	growEntriesLen int
 	latest         map[string]int
@@ -143,6 +151,37 @@ func putAppendOnlyEntries(entries []appendOnlyEntry) {
 	appendOnlyEntryPool.Put(full[:0])
 }
 
+func getAppendOnlyPayloadsFromPool(length int, pool *sync.Pool) []appendOnlyPayload {
+	if length < 0 {
+		length = 0
+	}
+	if length > appendOnlyPayloadPoolMaxCap {
+		return make([]appendOnlyPayload, length)
+	}
+	if pool == nil {
+		return make([]appendOnlyPayload, length)
+	}
+	if v := pool.Get(); v != nil {
+		if payloads, ok := v.([]appendOnlyPayload); ok && cap(payloads) >= length {
+			return payloads[:length]
+		}
+	}
+	return make([]appendOnlyPayload, length)
+}
+
+func getAppendOnlyPayloads(length int) []appendOnlyPayload {
+	return getAppendOnlyPayloadsFromPool(length, &appendOnlyPayloadPool)
+}
+
+func putAppendOnlyPayloads(payloads []appendOnlyPayload) {
+	if payloads == nil || cap(payloads) == 0 || cap(payloads) > appendOnlyPayloadPoolMaxCap {
+		return
+	}
+	full := payloads[:cap(payloads)]
+	clear(full)
+	appendOnlyPayloadPool.Put(full[:0])
+}
+
 func getAppendOnlyIteratorEntries(length int) []appendOnlyEntry {
 	if length < 0 {
 		length = 0
@@ -166,6 +205,19 @@ func putAppendOnlyIteratorEntries(entries []appendOnlyEntry) {
 	}
 	clear(entries)
 	appendOnlyIteratorPool.Put(entries[:0])
+}
+
+func getAppendOnlyIteratorPayloads(length int) []appendOnlyPayload {
+	return getAppendOnlyPayloadsFromPool(length, &appendOnlyIteratorPayloadPool)
+}
+
+func putAppendOnlyIteratorPayloads(payloads []appendOnlyPayload) {
+	if payloads == nil || cap(payloads) == 0 || cap(payloads) > appendOnlyIteratorPayloadPoolMaxCap {
+		return
+	}
+	full := payloads[:cap(payloads)]
+	clear(full)
+	appendOnlyIteratorPayloadPool.Put(full[:0])
 }
 
 func getAppendOnlyIteratorPtrs(length int) []*appendOnlyEntry {
@@ -285,11 +337,11 @@ func appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
 	return unsafe.Slice(unsafe.StringData(ent.key), len(ent.key))
 }
 
-func appendOnlyEntryValue(ent *appendOnlyEntry) []byte {
-	if ent == nil || len(ent.value) == 0 {
+func appendOnlyPayloadValue(payload *appendOnlyPayload) []byte {
+	if payload == nil || len(payload.value) == 0 {
 		return nil
 	}
-	return unsafe.Slice(unsafe.StringData(ent.value), len(ent.value))
+	return unsafe.Slice(unsafe.StringData(payload.value), len(payload.value))
 }
 
 func appendOnlyStringFromBytes(src []byte) string {
@@ -315,6 +367,28 @@ func appendOnlyArenaStringCopy(arena *appendOnlyValueArena, src []byte) string {
 	buf := arena.alloc(len(src))
 	copy(buf, src)
 	return appendOnlyStringFromBytes(buf)
+}
+
+func (m *AppendOnly) appendOnlyPayload(ent *appendOnlyEntry) *appendOnlyPayload {
+	if m == nil || ent == nil || ent.payloadIndex == 0 {
+		return nil
+	}
+	idx := int(ent.payloadIndex - 1)
+	if idx < 0 || idx >= len(m.payloads) {
+		return nil
+	}
+	return &m.payloads[idx]
+}
+
+func (m *AppendOnly) appendOnlyEntryValue(ent *appendOnlyEntry) []byte {
+	return appendOnlyPayloadValue(m.appendOnlyPayload(ent))
+}
+
+func (m *AppendOnly) appendOnlyEntryPtr(ent *appendOnlyEntry) page.ValuePtr {
+	if payload := m.appendOnlyPayload(ent); payload != nil {
+		return payload.ptr
+	}
+	return page.ValuePtr{}
 }
 
 func appendOnlyValueArenaClassForLen(length int) (idx int, classCap int, ok bool) {
@@ -492,14 +566,14 @@ func appendOnlyKeyU64(key []byte) (uint64, bool) {
 	return binary.BigEndian.Uint64(key), true
 }
 
-func entryValueSize(flags byte, value string) int {
+func entryValueSize(flags byte, valueLen int) int {
 	if flags&node.FlagPointer != 0 {
-		return page.ValuePtrSize + len(value)
+		return page.ValuePtrSize + valueLen
 	}
 	if flags&node.FlagTombstone != 0 {
 		return 0
 	}
-	return len(value)
+	return valueLen
 }
 
 func appendOnlyShouldPredictHint(count int) bool {
@@ -635,8 +709,10 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	idx := m.count
 	m.count++
 	ent := &m.entries[idx]
-	ent.ptr = ptr
 	ent.flags = flags
+	ent.payloadIndex = 0
+	payloadValue := ""
+	payloadPtr := page.ValuePtr{}
 	if len(key) == appendOnlyInlineKeyLen {
 		copy(ent.inlineKey[:], key)
 		ent.flags |= appendOnlyEntryFlagKeyInline
@@ -647,24 +723,31 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		ent.key = appendOnlyArenaStringCopy(&m.valueArena, key)
 	}
 	if steal {
-		ent.value = appendOnlyStringFromBytes(value)
+		payloadValue = appendOnlyStringFromBytes(value)
 	} else {
 		if len(value) > 0 {
 			if borrowValue {
-				ent.value = appendOnlyStringFromBytes(value)
+				payloadValue = appendOnlyStringFromBytes(value)
 			} else {
-				ent.value = appendOnlyArenaStringCopy(&m.valueArena, value)
+				payloadValue = appendOnlyArenaStringCopy(&m.valueArena, value)
 			}
-		} else {
-			ent.value = ""
 		}
 	}
+	if flags&node.FlagPointer != 0 {
+		payloadPtr = ptr
+	}
 	if flags&node.FlagTombstone != 0 {
-		ent.value = ""
-		ent.ptr = page.ValuePtr{}
+		payloadValue = ""
+		payloadPtr = page.ValuePtr{}
+	} else if payloadValue != "" || payloadPtr != (page.ValuePtr{}) {
+		m.payloads = append(m.payloads, appendOnlyPayload{
+			value: payloadValue,
+			ptr:   payloadPtr,
+		})
+		ent.payloadIndex = uint32(len(m.payloads))
 	}
 	k := appendOnlyEntryKey(ent)
-	m.sizeBytes += int64(len(k) + entryValueSize(flags, ent.value))
+	m.sizeBytes += int64(len(k) + entryValueSize(flags, len(payloadValue)))
 	if appendOnlyShouldPredictHint(m.count) {
 		m.maybeRaisePredictedGrowthHintLocked()
 	}
@@ -808,7 +891,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 		m.mu.RLock()
 		if ent := m.orderedLookupEntryLocked(key); ent != nil {
 			deleted := ent.flags&node.FlagTombstone != 0
-			val := appendOnlyEntryValue(ent)
+			val := m.appendOnlyEntryValue(ent)
 			m.mu.RUnlock()
 			if deleted {
 				return nil, true, true
@@ -826,7 +909,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
-						val := appendOnlyEntryValue(ent)
+						val := m.appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
 						if deleted {
 							return nil, true, true
@@ -840,7 +923,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
-						val := appendOnlyEntryValue(ent)
+						val := m.appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
 						if deleted {
 							return nil, true, true
@@ -867,8 +950,8 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 	for {
 		m.mu.RLock()
 		if ent := m.orderedLookupEntryLocked(key); ent != nil {
-			val := appendOnlyEntryValue(ent)
-			ptr := ent.ptr
+			val := m.appendOnlyEntryValue(ent)
+			ptr := m.appendOnlyEntryPtr(ent)
 			flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 			m.mu.RUnlock()
 			return val, ptr, flags, true
@@ -883,8 +966,8 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 				if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
-						val := appendOnlyEntryValue(ent)
-						ptr := ent.ptr
+						val := m.appendOnlyEntryValue(ent)
+						ptr := m.appendOnlyEntryPtr(ent)
 						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 						m.mu.RUnlock()
 						return val, ptr, flags, true
@@ -895,8 +978,8 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(appendOnlyEntryKey(ent), key) {
-						val := appendOnlyEntryValue(ent)
-						ptr := ent.ptr
+						val := m.appendOnlyEntryValue(ent)
+						ptr := m.appendOnlyEntryPtr(ent)
 						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
 						m.mu.RUnlock()
 						return val, ptr, flags, true
@@ -1040,11 +1123,12 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	}
 	for i := 0; i < m.count; i++ {
 		ent := &m.entries[i]
-		ent.ptr = page.ValuePtr{}
 		ent.flags = 0
 		ent.key = ""
-		ent.value = ""
+		ent.payloadIndex = 0
 	}
+	clear(m.payloads)
+	m.payloads = m.payloads[:0]
 	m.valueArena.reset()
 	if !retainObserved {
 		m.valueArena.dropRetained()
@@ -1139,20 +1223,34 @@ func (m *AppendOnly) buildSortedLatestSnapshotLocked() []*appendOnlyEntry {
 	return snapshot
 }
 
-func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() []appendOnlyEntry {
+func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntry, []appendOnlyPayload) {
 	if m.count == 0 {
 		m.clearSnapshotLocked()
-		return getAppendOnlyIteratorEntries(0)
+		return getAppendOnlyIteratorEntries(0), getAppendOnlyIteratorPayloads(0)
 	}
 	indices := m.buildSortedLatestIndicesLocked()
 	active := m.entries[:m.count]
 	entries := getAppendOnlyIteratorEntries(len(indices))
+	payloadCount := 0
+	for _, idx := range indices {
+		if active[idx].payloadIndex != 0 {
+			payloadCount++
+		}
+	}
+	payloads := getAppendOnlyIteratorPayloads(payloadCount)
+	nextPayload := 0
 	for i, idx := range indices {
-		entries[i] = active[idx]
+		ent := active[idx]
+		if ent.payloadIndex != 0 {
+			payloads[nextPayload] = m.payloads[ent.payloadIndex-1]
+			ent.payloadIndex = uint32(nextPayload + 1)
+			nextPayload++
+		}
+		entries[i] = ent
 	}
 	m.indexBuf = indices[:0]
 	m.clearSnapshotLocked()
-	return entries
+	return entries, payloads
 }
 
 func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
@@ -1164,6 +1262,7 @@ func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 			start:   start,
 			end:     end,
 			mu:      &m.mu,
+			owner:   m,
 		}
 		if start != nil {
 			it.Seek(start)
@@ -1184,6 +1283,7 @@ func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 			entryPtrs:       snapshotPtrs,
 			start:           start,
 			end:             end,
+			owner:           m,
 			pooledEntryPtrs: false,
 			leaseOwner:      m,
 			leaseHeld:       true,
@@ -1194,11 +1294,12 @@ func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 		}
 		return it
 	}
-	entries := m.buildMutableSortedIteratorEntriesLocked()
+	entries, payloads := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		payloads:      payloads,
 		start:         start,
 		end:           end,
 		pooledEntries: true,
@@ -1219,6 +1320,7 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 			start:   start,
 			end:     end,
 			mu:      &m.mu,
+			owner:   m,
 			reverse: true,
 		}
 		it.seekToReverseEnd(end)
@@ -1238,6 +1340,7 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 			entryPtrs:       snapshotPtrs,
 			start:           start,
 			end:             end,
+			owner:           m,
 			pooledEntryPtrs: false,
 			leaseOwner:      m,
 			leaseHeld:       true,
@@ -1246,11 +1349,12 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 		it.seekToReverseEnd(end)
 		return it
 	}
-	entries := m.buildMutableSortedIteratorEntriesLocked()
+	entries, payloads := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		payloads:      payloads,
 		start:         start,
 		end:           end,
 		pooledEntries: true,
@@ -1262,11 +1366,13 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 
 type appendOnlyIterator struct {
 	entries         []appendOnlyEntry
+	payloads        []appendOnlyPayload
 	entryPtrs       []*appendOnlyEntry
 	idx             int
 	start           []byte
 	end             []byte
 	mu              *sync.RWMutex
+	owner           *AppendOnly
 	pooledEntries   bool
 	pooledEntryPtrs bool
 	leaseOwner      *AppendOnly
@@ -1295,6 +1401,20 @@ func (it *appendOnlyIterator) entryAt(idx int) *appendOnlyEntry {
 		return nil
 	}
 	return &it.entries[idx]
+}
+
+func (it *appendOnlyIterator) payloadForEntry(ent *appendOnlyEntry) *appendOnlyPayload {
+	if ent == nil || ent.payloadIndex == 0 {
+		return nil
+	}
+	if it.owner != nil {
+		return it.owner.appendOnlyPayload(ent)
+	}
+	idx := int(ent.payloadIndex - 1)
+	if idx < 0 || idx >= len(it.payloads) {
+		return nil
+	}
+	return &it.payloads[idx]
 }
 
 func (it *appendOnlyIterator) validIndex() bool {
@@ -1393,7 +1513,7 @@ func (it *appendOnlyIterator) UnsafeValue() []byte {
 	if ent.flags&node.FlagTombstone != 0 {
 		return nil
 	}
-	return appendOnlyEntryValue(ent)
+	return appendOnlyPayloadValue(it.payloadForEntry(ent))
 }
 
 func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
@@ -1401,7 +1521,12 @@ func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	if ent == nil || !it.validIndex() {
 		return nil, page.ValuePtr{}, 0
 	}
-	return appendOnlyEntryValue(ent), ent.ptr, ent.flags &^ appendOnlyEntryFlagKeyInline
+	payload := it.payloadForEntry(ent)
+	ptr := page.ValuePtr{}
+	if payload != nil {
+		ptr = payload.ptr
+	}
+	return appendOnlyPayloadValue(payload), ptr, ent.flags &^ appendOnlyEntryFlagKeyInline
 }
 
 func (it *appendOnlyIterator) IsDeleted() bool {
@@ -1445,6 +1570,7 @@ func (it *appendOnlyIterator) Close() error {
 	}
 	if it.pooledEntries {
 		putAppendOnlyIteratorEntries(it.entries)
+		putAppendOnlyIteratorPayloads(it.payloads)
 		it.pooledEntries = false
 	}
 	if it.pooledEntryPtrs {
@@ -1456,7 +1582,9 @@ func (it *appendOnlyIterator) Close() error {
 		it.leaseHeld = false
 	}
 	it.leaseOwner = nil
+	it.owner = nil
 	it.entries = nil
+	it.payloads = nil
 	it.entryPtrs = nil
 	return nil
 }

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -625,15 +625,28 @@ func appendOnlyNextCapacity(current int) int {
 	return next
 }
 
-func appendOnlyKeyString(key []byte) string {
-	return string(key)
-}
-
 func appendOnlyLookupKeyString(key []byte) string {
 	if len(key) == 0 {
 		return ""
 	}
 	return unsafe.String(unsafe.SliceData(key), len(key))
+}
+
+func (m *AppendOnly) appendOnlyEntryMapKey(ent *appendOnlyEntry) string {
+	if m == nil || ent == nil {
+		return ""
+	}
+	if ent.inlineKeyLen != 0 {
+		return string(ent.inlineKey[:int(ent.inlineKeyLen)])
+	}
+	if ent.keyIndex == 0 {
+		return ""
+	}
+	idx := int(ent.keyIndex - 1)
+	if idx < 0 || idx >= len(m.keys) {
+		return ""
+	}
+	return m.keys[idx]
 }
 
 func appendOnlyKeyU64(key []byte) (uint64, bool) {
@@ -748,7 +761,7 @@ func (m *AppendOnly) rebuildLatestIndexLocked() {
 		if m.latest == nil {
 			m.latest = make(map[string]int, reserve)
 		}
-		m.latest[appendOnlyKeyString(k)] = i
+		m.latest[m.appendOnlyEntryMapKey(&active[i])] = i
 	}
 	m.latestDirty = false
 	m.clearSnapshotLocked()
@@ -768,7 +781,7 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 	if m.latest == nil {
 		m.latest = make(map[string]int, 1)
 	}
-	m.latest[appendOnlyKeyString(key)] = idx
+	m.latest[m.appendOnlyEntryMapKey(&m.entries[idx])] = idx
 }
 
 func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -25,7 +25,6 @@ const (
 	appendOnlyEntryPoolMaxCap               = 1 << 20
 	appendOnlyIteratorPoolMaxCap            = 1 << 20
 	appendOnlyIteratorPtrPoolMaxCap         = 1 << 20
-	appendOnlyReusableKeyMaxCap             = 1 << 10
 	appendOnlyValueArenaMinShift            = 12
 	appendOnlyValueArenaMaxShift            = 20
 	appendOnlyValueArenaClassCount          = appendOnlyValueArenaMaxShift - appendOnlyValueArenaMinShift + 1
@@ -45,7 +44,7 @@ var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
 
 type appendOnlyEntry struct {
-	key       []byte
+	key       string
 	value     string
 	ptr       page.ValuePtr
 	inlineKey [appendOnlyInlineKeyLen]byte
@@ -280,7 +279,10 @@ func appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
 	if ent.flags&appendOnlyEntryFlagKeyInline != 0 {
 		return ent.inlineKey[:]
 	}
-	return ent.key
+	if len(ent.key) == 0 {
+		return nil
+	}
+	return unsafe.Slice(unsafe.StringData(ent.key), len(ent.key))
 }
 
 func appendOnlyEntryValue(ent *appendOnlyEntry) []byte {
@@ -306,21 +308,13 @@ func cloneBytes(src []byte) []byte {
 	return dst
 }
 
-func cloneOrReuseBytes(dst, src []byte, maxCap int) []byte {
+func appendOnlyArenaStringCopy(arena *appendOnlyValueArena, src []byte) string {
 	if len(src) == 0 {
-		return nil
+		return ""
 	}
-	if maxCap <= 0 {
-		maxCap = len(src)
-	}
-	if cap(dst) >= len(src) && cap(dst) <= maxCap {
-		out := dst[:len(src)]
-		copy(out, src)
-		return out
-	}
-	out := make([]byte, len(src))
-	copy(out, src)
-	return out
+	buf := arena.alloc(len(src))
+	copy(buf, src)
+	return appendOnlyStringFromBytes(buf)
 }
 
 func appendOnlyValueArenaClassForLen(length int) (idx int, classCap int, ok bool) {
@@ -643,24 +637,23 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	ent := &m.entries[idx]
 	ent.ptr = ptr
 	ent.flags = flags
+	if len(key) == appendOnlyInlineKeyLen {
+		copy(ent.inlineKey[:], key)
+		ent.flags |= appendOnlyEntryFlagKeyInline
+		ent.key = ""
+	} else if steal {
+		ent.key = appendOnlyStringFromBytes(key)
+	} else {
+		ent.key = appendOnlyArenaStringCopy(&m.valueArena, key)
+	}
 	if steal {
-		ent.key = key
 		ent.value = appendOnlyStringFromBytes(value)
 	} else {
-		if len(key) == appendOnlyInlineKeyLen {
-			copy(ent.inlineKey[:], key)
-			ent.flags |= appendOnlyEntryFlagKeyInline
-			ent.key = nil
-		} else {
-			ent.key = cloneOrReuseBytes(ent.key, key, appendOnlyReusableKeyMaxCap)
-		}
 		if len(value) > 0 {
 			if borrowValue {
 				ent.value = appendOnlyStringFromBytes(value)
 			} else {
-				buf := m.valueArena.alloc(len(value))
-				copy(buf, value)
-				ent.value = appendOnlyStringFromBytes(buf)
+				ent.value = appendOnlyArenaStringCopy(&m.valueArena, value)
 			}
 		} else {
 			ent.value = ""
@@ -1049,11 +1042,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		ent := &m.entries[i]
 		ent.ptr = page.ValuePtr{}
 		ent.flags = 0
-		if cap(ent.key) > appendOnlyReusableKeyMaxCap {
-			ent.key = nil
-		} else if ent.key != nil {
-			ent.key = ent.key[:0]
-		}
+		ent.key = ""
 		ent.value = ""
 	}
 	m.valueArena.reset()

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -1217,14 +1217,14 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		ent.inlineKeyLen = 0
 	}
 	if !retainObserved || cap(m.keys) > maxRetainedEntries {
-		putAppendOnlyKeys(m.keys)
+		clear(m.keys)
 		m.keys = nil
 	} else {
 		clear(m.keys)
 		m.keys = m.keys[:0]
 	}
 	if !retainObserved || cap(m.payloads) > maxRetainedEntries {
-		putAppendOnlyPayloads(m.payloads)
+		clear(m.payloads)
 		m.payloads = nil
 	} else {
 		clear(m.payloads)

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -36,6 +36,7 @@ const (
 	appendOnlyReuseOversizeFactor           = 4
 	appendOnlyResetDropThresholdEntries     = 1 << 15
 	appendOnlyAggressiveGrowCutoff          = appendOnlyResetDropThresholdEntries * 2
+	appendOnlyPredictHintMinEntries         = 1 << 10
 )
 
 var appendOnlyEntryPool sync.Pool
@@ -81,6 +82,9 @@ type AppendOnly struct {
 	frozen      bool
 	hasLast     bool
 	lastIdx     int
+
+	predictCapacityHintBytes int
+	observeEntries           func(int)
 
 	iteratorLeaseMu   sync.Mutex
 	iteratorLeaseCond *sync.Cond
@@ -212,19 +216,27 @@ func appendOnlyGrowthEntriesForHint(baseEntries, entryHint int) int {
 	if n < appendOnlyMinInitialEntries {
 		n = appendOnlyMinInitialEntries
 	}
+	entryHint = appendOnlyClampRetainedEntries(entryHint)
 	if entryHint <= 0 {
 		return n
-	}
-	if entryHint < appendOnlyMinInitialEntries {
-		entryHint = appendOnlyMinInitialEntries
-	}
-	if entryHint > appendOnlyMaxInitialEntries {
-		entryHint = appendOnlyMaxInitialEntries
 	}
 	if entryHint > n {
 		n = entryHint
 	}
 	return n
+}
+
+func appendOnlyClampRetainedEntries(entries int) int {
+	if entries <= 0 {
+		return 0
+	}
+	if entries < appendOnlyMinInitialEntries {
+		return appendOnlyMinInitialEntries
+	}
+	if entries > appendOnlyMaxInitialEntries {
+		return appendOnlyMaxInitialEntries
+	}
+	return entries
 }
 
 func NewAppendOnlyWithCapacity(capacity int) *AppendOnly {
@@ -249,6 +261,16 @@ func NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimatedByte
 		snapCount:      0,
 		sizeBytes:      0,
 	}
+}
+
+func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, observeEntries func(int)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if capacityHintBytes <= 0 {
+		capacityHintBytes = defaultMemtableCapacity
+	}
+	m.predictCapacityHintBytes = capacityHintBytes
+	m.observeEntries = observeEntries
 }
 
 func appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
@@ -472,6 +494,28 @@ func entryValueSize(flags byte, value []byte) int {
 	return len(value)
 }
 
+func appendOnlyShouldPredictHint(count int) bool {
+	return count >= appendOnlyPredictHintMinEntries && bits.OnesCount(uint(count)) == 1
+}
+
+func (m *AppendOnly) maybeRaisePredictedGrowthHintLocked() {
+	if m.predictCapacityHintBytes <= 0 || m.count <= 0 || m.sizeBytes <= 0 {
+		return
+	}
+	avgBytesPerEntry := int((m.sizeBytes + int64(m.count) - 1) / int64(m.count))
+	if avgBytesPerEntry <= 0 {
+		avgBytesPerEntry = 1
+	}
+	predictedEntries := appendOnlyClampRetainedEntries(m.predictCapacityHintBytes / avgBytesPerEntry)
+	if predictedEntries <= m.growEntriesLen {
+		return
+	}
+	m.growEntriesLen = predictedEntries
+	if observe := m.observeEntries; observe != nil {
+		observe(predictedEntries)
+	}
+}
+
 func (m *AppendOnly) clearSnapshotLocked() {
 	if m.snapshot != nil {
 		m.snapshot = m.snapshot[:0]
@@ -617,6 +661,9 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	}
 	k := appendOnlyEntryKey(ent)
 	m.sizeBytes += int64(len(k) + entryValueSize(flags, ent.value))
+	if appendOnlyShouldPredictHint(m.count) {
+		m.maybeRaisePredictedGrowthHintLocked()
+	}
 
 	if !m.hasLast {
 		m.lastIdx = idx
@@ -1033,6 +1080,8 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	m.frozen = false
 	m.hasLast = false
 	m.lastIdx = -1
+	m.predictCapacityHintBytes = 0
+	m.observeEntries = nil
 
 	// If the entry slice grew far beyond the configured baseline, shrink it.
 	// This avoids permanently ratcheting heap high-water when a workload briefly

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -23,8 +23,10 @@ const (
 	appendOnlyMaxInitialEntries             = 1 << 20
 	appendOnlyInlineKeyLen                  = 8
 	appendOnlyEntryPoolMaxCap               = 1 << 20
+	appendOnlyKeyPoolMaxCap                 = 1 << 20
 	appendOnlyPayloadPoolMaxCap             = 1 << 20
 	appendOnlyIteratorPoolMaxCap            = 1 << 20
+	appendOnlyIteratorKeyPoolMaxCap         = 1 << 20
 	appendOnlyIteratorPayloadPoolMaxCap     = 1 << 20
 	appendOnlyIteratorPtrPoolMaxCap         = 1 << 20
 	appendOnlyValueArenaMinShift            = 12
@@ -41,8 +43,10 @@ const (
 )
 
 var appendOnlyEntryPool sync.Pool
+var appendOnlyKeyPool sync.Pool
 var appendOnlyPayloadPool sync.Pool
 var appendOnlyIteratorPool sync.Pool
+var appendOnlyIteratorKeyPool sync.Pool
 var appendOnlyIteratorPayloadPool sync.Pool
 var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
@@ -52,9 +56,9 @@ type appendOnlyPayload struct {
 	ptr   page.ValuePtr
 }
 type appendOnlyEntry struct {
-	key          string
-	payloadIndex uint32
 	inlineKey    [appendOnlyInlineKeyLen]byte
+	keyIndex     uint32
+	payloadIndex uint32
 	flags        byte
 }
 
@@ -72,6 +76,7 @@ type AppendOnly struct {
 	mu sync.RWMutex
 
 	entries        []appendOnlyEntry
+	keys           []string
 	payloads       []appendOnlyPayload
 	baseEntriesLen int
 	growEntriesLen int
@@ -151,6 +156,37 @@ func putAppendOnlyEntries(entries []appendOnlyEntry) {
 	appendOnlyEntryPool.Put(full[:0])
 }
 
+func getAppendOnlyKeysFromPool(length int, pool *sync.Pool) []string {
+	if length < 0 {
+		length = 0
+	}
+	if length > appendOnlyKeyPoolMaxCap {
+		return make([]string, length)
+	}
+	if pool == nil {
+		return make([]string, length)
+	}
+	if v := pool.Get(); v != nil {
+		if keys, ok := v.([]string); ok && cap(keys) >= length {
+			return keys[:length]
+		}
+	}
+	return make([]string, length)
+}
+
+func getAppendOnlyKeys(length int) []string {
+	return getAppendOnlyKeysFromPool(length, &appendOnlyKeyPool)
+}
+
+func putAppendOnlyKeys(keys []string) {
+	if keys == nil || cap(keys) == 0 || cap(keys) > appendOnlyKeyPoolMaxCap {
+		return
+	}
+	full := keys[:cap(keys)]
+	clear(full)
+	appendOnlyKeyPool.Put(full[:0])
+}
+
 func getAppendOnlyPayloadsFromPool(length int, pool *sync.Pool) []appendOnlyPayload {
 	if length < 0 {
 		length = 0
@@ -205,6 +241,19 @@ func putAppendOnlyIteratorEntries(entries []appendOnlyEntry) {
 	}
 	clear(entries)
 	appendOnlyIteratorPool.Put(entries[:0])
+}
+
+func getAppendOnlyIteratorKeys(length int) []string {
+	return getAppendOnlyKeysFromPool(length, &appendOnlyIteratorKeyPool)
+}
+
+func putAppendOnlyIteratorKeys(keys []string) {
+	if keys == nil || cap(keys) == 0 || cap(keys) > appendOnlyIteratorKeyPoolMaxCap {
+		return
+	}
+	full := keys[:cap(keys)]
+	clear(full)
+	appendOnlyIteratorKeyPool.Put(full[:0])
 }
 
 func getAppendOnlyIteratorPayloads(length int) []appendOnlyPayload {
@@ -324,17 +373,25 @@ func (m *AppendOnly) SetPredictiveGrowthHint(capacityHintBytes int, observeEntri
 	m.observeEntries = observeEntries
 }
 
-func appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
+func appendOnlyEntryKeyFromKeys(ent *appendOnlyEntry, keys []string) []byte {
 	if ent == nil {
 		return nil
 	}
 	if ent.flags&appendOnlyEntryFlagKeyInline != 0 {
 		return ent.inlineKey[:]
 	}
-	if len(ent.key) == 0 {
+	if ent.keyIndex == 0 {
 		return nil
 	}
-	return unsafe.Slice(unsafe.StringData(ent.key), len(ent.key))
+	idx := int(ent.keyIndex - 1)
+	if idx < 0 || idx >= len(keys) {
+		return nil
+	}
+	key := keys[idx]
+	if len(key) == 0 {
+		return nil
+	}
+	return unsafe.Slice(unsafe.StringData(key), len(key))
 }
 
 func appendOnlyPayloadValue(payload *appendOnlyPayload) []byte {
@@ -367,6 +424,13 @@ func appendOnlyArenaStringCopy(arena *appendOnlyValueArena, src []byte) string {
 	buf := arena.alloc(len(src))
 	copy(buf, src)
 	return appendOnlyStringFromBytes(buf)
+}
+
+func (m *AppendOnly) appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
+	if m == nil {
+		return appendOnlyEntryKeyFromKeys(ent, nil)
+	}
+	return appendOnlyEntryKeyFromKeys(ent, m.keys)
 }
 
 func (m *AppendOnly) appendOnlyPayload(ent *appendOnlyEntry) *appendOnlyPayload {
@@ -632,8 +696,8 @@ func (m *AppendOnly) buildSortedLatestIndicesLocked() []int {
 	active := m.entries[:m.count]
 	sort.Slice(indices, func(i, j int) bool {
 		return bytes.Compare(
-			appendOnlyEntryKey(&active[indices[i]]),
-			appendOnlyEntryKey(&active[indices[j]]),
+			m.appendOnlyEntryKey(&active[indices[i]]),
+			m.appendOnlyEntryKey(&active[indices[j]]),
 		) < 0
 	})
 	return indices
@@ -660,7 +724,7 @@ func (m *AppendOnly) rebuildLatestIndexLocked() {
 	reserve := m.count
 	active := m.entries[:m.count]
 	for i := range active {
-		k := appendOnlyEntryKey(&active[i])
+		k := m.appendOnlyEntryKey(&active[i])
 		if k64, ok := appendOnlyKeyU64(k); ok {
 			if m.latest64 == nil {
 				m.latest64 = make(map[uint64]int, reserve)
@@ -710,17 +774,19 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	m.count++
 	ent := &m.entries[idx]
 	ent.flags = flags
+	ent.keyIndex = 0
 	ent.payloadIndex = 0
 	payloadValue := ""
 	payloadPtr := page.ValuePtr{}
 	if len(key) == appendOnlyInlineKeyLen {
 		copy(ent.inlineKey[:], key)
 		ent.flags |= appendOnlyEntryFlagKeyInline
-		ent.key = ""
 	} else if steal {
-		ent.key = appendOnlyStringFromBytes(key)
+		m.keys = append(m.keys, appendOnlyStringFromBytes(key))
+		ent.keyIndex = uint32(len(m.keys))
 	} else {
-		ent.key = appendOnlyArenaStringCopy(&m.valueArena, key)
+		m.keys = append(m.keys, appendOnlyArenaStringCopy(&m.valueArena, key))
+		ent.keyIndex = uint32(len(m.keys))
 	}
 	if steal {
 		payloadValue = appendOnlyStringFromBytes(value)
@@ -746,7 +812,7 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		})
 		ent.payloadIndex = uint32(len(m.payloads))
 	}
-	k := appendOnlyEntryKey(ent)
+	k := m.appendOnlyEntryKey(ent)
 	m.sizeBytes += int64(len(k) + entryValueSize(flags, len(payloadValue)))
 	if appendOnlyShouldPredictHint(m.count) {
 		m.maybeRaisePredictedGrowthHintLocked()
@@ -758,7 +824,7 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		return
 	}
 	if m.ordered {
-		prev := appendOnlyEntryKey(&m.entries[m.lastIdx])
+		prev := m.appendOnlyEntryKey(&m.entries[m.lastIdx])
 		cmp := bytes.Compare(k, prev)
 		if cmp > 0 {
 			m.lastIdx = idx
@@ -874,13 +940,13 @@ func (m *AppendOnly) orderedLookupEntryLocked(key []byte) *appendOnlyEntry {
 	}
 	active := m.entries[:m.count]
 	idx := sort.Search(len(active), func(i int) bool {
-		return bytes.Compare(appendOnlyEntryKey(&active[i]), key) >= 0
+		return bytes.Compare(m.appendOnlyEntryKey(&active[i]), key) >= 0
 	})
 	if idx >= len(active) {
 		return nil
 	}
 	ent := &active[idx]
-	if !bytes.Equal(appendOnlyEntryKey(ent), key) {
+	if !bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 		return nil
 	}
 	return ent
@@ -907,7 +973,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 			if k64, ok := appendOnlyKeyU64(key); ok && m.latest64 != nil {
 				if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
-					if bytes.Equal(appendOnlyEntryKey(ent), key) {
+					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
 						val := m.appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
@@ -921,7 +987,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 			if m.latest != nil {
 				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
-					if bytes.Equal(appendOnlyEntryKey(ent), key) {
+					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						deleted := ent.flags&node.FlagTombstone != 0
 						val := m.appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
@@ -965,7 +1031,7 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 			if k64, ok := appendOnlyKeyU64(key); ok && m.latest64 != nil {
 				if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
-					if bytes.Equal(appendOnlyEntryKey(ent), key) {
+					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						val := m.appendOnlyEntryValue(ent)
 						ptr := m.appendOnlyEntryPtr(ent)
 						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
@@ -977,7 +1043,7 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 			if m.latest != nil {
 				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
-					if bytes.Equal(appendOnlyEntryKey(ent), key) {
+					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						val := m.appendOnlyEntryValue(ent)
 						ptr := m.appendOnlyEntryPtr(ent)
 						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
@@ -1124,9 +1190,11 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	for i := 0; i < m.count; i++ {
 		ent := &m.entries[i]
 		ent.flags = 0
-		ent.key = ""
+		ent.keyIndex = 0
 		ent.payloadIndex = 0
 	}
+	clear(m.keys)
+	m.keys = m.keys[:0]
 	clear(m.payloads)
 	m.payloads = m.payloads[:0]
 	m.valueArena.reset()
@@ -1223,24 +1291,35 @@ func (m *AppendOnly) buildSortedLatestSnapshotLocked() []*appendOnlyEntry {
 	return snapshot
 }
 
-func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntry, []appendOnlyPayload) {
+func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntry, []string, []appendOnlyPayload) {
 	if m.count == 0 {
 		m.clearSnapshotLocked()
-		return getAppendOnlyIteratorEntries(0), getAppendOnlyIteratorPayloads(0)
+		return getAppendOnlyIteratorEntries(0), getAppendOnlyIteratorKeys(0), getAppendOnlyIteratorPayloads(0)
 	}
 	indices := m.buildSortedLatestIndicesLocked()
 	active := m.entries[:m.count]
 	entries := getAppendOnlyIteratorEntries(len(indices))
+	keyCount := 0
 	payloadCount := 0
 	for _, idx := range indices {
+		if active[idx].keyIndex != 0 {
+			keyCount++
+		}
 		if active[idx].payloadIndex != 0 {
 			payloadCount++
 		}
 	}
+	keys := getAppendOnlyIteratorKeys(keyCount)
 	payloads := getAppendOnlyIteratorPayloads(payloadCount)
+	nextKey := 0
 	nextPayload := 0
 	for i, idx := range indices {
 		ent := active[idx]
+		if ent.keyIndex != 0 {
+			keys[nextKey] = m.keys[ent.keyIndex-1]
+			ent.keyIndex = uint32(nextKey + 1)
+			nextKey++
+		}
 		if ent.payloadIndex != 0 {
 			payloads[nextPayload] = m.payloads[ent.payloadIndex-1]
 			ent.payloadIndex = uint32(nextPayload + 1)
@@ -1250,7 +1329,7 @@ func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntr
 	}
 	m.indexBuf = indices[:0]
 	m.clearSnapshotLocked()
-	return entries, payloads
+	return entries, keys, payloads
 }
 
 func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
@@ -1294,11 +1373,12 @@ func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 		}
 		return it
 	}
-	entries, payloads := m.buildMutableSortedIteratorEntriesLocked()
+	entries, keys, payloads := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		keys:          keys,
 		payloads:      payloads,
 		start:         start,
 		end:           end,
@@ -1349,11 +1429,12 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 		it.seekToReverseEnd(end)
 		return it
 	}
-	entries, payloads := m.buildMutableSortedIteratorEntriesLocked()
+	entries, keys, payloads := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		keys:          keys,
 		payloads:      payloads,
 		start:         start,
 		end:           end,
@@ -1366,6 +1447,7 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 
 type appendOnlyIterator struct {
 	entries         []appendOnlyEntry
+	keys            []string
 	payloads        []appendOnlyPayload
 	entryPtrs       []*appendOnlyEntry
 	idx             int
@@ -1417,6 +1499,16 @@ func (it *appendOnlyIterator) payloadForEntry(ent *appendOnlyEntry) *appendOnlyP
 	return &it.payloads[idx]
 }
 
+func (it *appendOnlyIterator) keyForEntry(ent *appendOnlyEntry) []byte {
+	if ent == nil {
+		return nil
+	}
+	if it.owner != nil {
+		return it.owner.appendOnlyEntryKey(ent)
+	}
+	return appendOnlyEntryKeyFromKeys(ent, it.keys)
+}
+
 func (it *appendOnlyIterator) validIndex() bool {
 	if it.idx < 0 || it.idx >= it.len() {
 		return false
@@ -1425,10 +1517,10 @@ func (it *appendOnlyIterator) validIndex() bool {
 	if ent == nil {
 		return false
 	}
-	if it.start != nil && bytes.Compare(appendOnlyEntryKey(ent), it.start) < 0 {
+	if it.start != nil && bytes.Compare(it.keyForEntry(ent), it.start) < 0 {
 		return false
 	}
-	if it.end != nil && bytes.Compare(appendOnlyEntryKey(ent), it.end) >= 0 {
+	if it.end != nil && bytes.Compare(it.keyForEntry(ent), it.end) >= 0 {
 		return false
 	}
 	return true
@@ -1455,7 +1547,7 @@ func (it *appendOnlyIterator) Seek(key []byte) {
 			if ent == nil {
 				return true
 			}
-			return bytes.Compare(appendOnlyEntryKey(ent), key) >= 0
+			return bytes.Compare(it.keyForEntry(ent), key) >= 0
 		})
 		return
 	}
@@ -1472,7 +1564,7 @@ func (it *appendOnlyIterator) Seek(key []byte) {
 		if ent == nil {
 			return true
 		}
-		return bytes.Compare(appendOnlyEntryKey(ent), key) > 0
+		return bytes.Compare(it.keyForEntry(ent), key) > 0
 	})
 	it.idx = pos - 1
 }
@@ -1492,7 +1584,7 @@ func (it *appendOnlyIterator) seekToReverseEnd(end []byte) {
 		if ent == nil {
 			return true
 		}
-		return bytes.Compare(appendOnlyEntryKey(ent), end) >= 0
+		return bytes.Compare(it.keyForEntry(ent), end) >= 0
 	})
 	it.idx = pos - 1
 }
@@ -1502,7 +1594,7 @@ func (it *appendOnlyIterator) UnsafeKey() []byte {
 	if ent == nil || !it.validIndex() {
 		return nil
 	}
-	return appendOnlyEntryKey(ent)
+	return it.keyForEntry(ent)
 }
 
 func (it *appendOnlyIterator) UnsafeValue() []byte {
@@ -1570,6 +1662,7 @@ func (it *appendOnlyIterator) Close() error {
 	}
 	if it.pooledEntries {
 		putAppendOnlyIteratorEntries(it.entries)
+		putAppendOnlyIteratorKeys(it.keys)
 		putAppendOnlyIteratorPayloads(it.payloads)
 		it.pooledEntries = false
 	}
@@ -1584,6 +1677,7 @@ func (it *appendOnlyIterator) Close() error {
 	it.leaseOwner = nil
 	it.owner = nil
 	it.entries = nil
+	it.keys = nil
 	it.payloads = nil
 	it.entryPtrs = nil
 	return nil

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -439,15 +439,15 @@ func TestAppendOnlyResetRetainedArenaBounded(t *testing.T) {
 	}
 }
 
-func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
+func TestAppendOnlyUnorderedAppendDefersLatestIndexUntilIterator(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	m.Set([]byte("b"), []byte("v1"))
 	m.Set([]byte("a"), []byte("v2")) // force unordered path
 	if m.ordered {
 		t.Fatalf("expected unordered memtable")
 	}
-	if m.latestDirty {
-		t.Fatalf("expected latest index to stay clean after order break")
+	if !m.latestDirty {
+		t.Fatalf("expected latest index to stay dirty until an iterator needs it")
 	}
 
 	it := m.NewIterator(nil, nil)
@@ -506,8 +506,8 @@ func TestAppendOnlyUnorderedReverseIteratorDoesNotCacheSharedSnapshot(t *testing
 	if m.ordered {
 		t.Fatalf("expected unordered memtable")
 	}
-	if m.latestDirty {
-		t.Fatalf("expected latest index to stay clean after order break")
+	if !m.latestDirty {
+		t.Fatalf("expected latest index to stay dirty until a reverse iterator needs it")
 	}
 
 	it := m.NewReverseIterator(nil, nil)

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -13,14 +13,14 @@ import (
 func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
 	entries[0].key = []byte("k0")
-	entries[0].value = []byte("v0")
+	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
 	entries[1].key = []byte("k1")
-	entries[1].value = []byte("v1")
+	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	putAppendOnlyEntries(entries)
 
 	for i := range entries {
-		if entries[i].key != nil || entries[i].value != nil {
+		if entries[i].key != nil || entries[i].value != "" {
 			t.Fatalf("entry %d still retains references after put: %+v", i, entries[i])
 		}
 	}
@@ -29,9 +29,9 @@ func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
 	entries[0].key = []byte("k0")
-	entries[0].value = []byte("v0")
+	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
 	entries[1].key = []byte("k1")
-	entries[1].value = []byte("v1")
+	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	it := &appendOnlyIterator{
 		entries:       entries,
@@ -42,7 +42,7 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	}
 
 	for i := range entries {
-		if entries[i].key != nil || entries[i].value != nil {
+		if entries[i].key != nil || entries[i].value != "" {
 			t.Fatalf("entry %d still retains references after close: %+v", i, entries[i])
 		}
 	}
@@ -56,8 +56,8 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledPointerEntries(t *testing.T) {
 	entries := []*appendOnlyEntry{
-		{key: []byte("k0"), value: []byte("v0")},
-		{key: []byte("k1"), value: []byte("v1")},
+		{key: []byte("k0"), value: appendOnlyStringFromBytes([]byte("v0"))},
+		{key: []byte("k1"), value: appendOnlyStringFromBytes([]byte("v1"))},
 	}
 	it := &appendOnlyIterator{
 		entryPtrs:       entries,
@@ -197,7 +197,8 @@ func TestAppendOnlyResetReusesEntryBuffers(t *testing.T) {
 		t.Fatalf("count=%d want=1", m.count)
 	}
 	keyBufPtr := &m.entries[0].key[0]
-	valBufPtr := &m.entries[0].value[0]
+	firstVal := appendOnlyEntryValue(&m.entries[0])
+	valBufPtr := &firstVal[0]
 
 	m.Reset()
 	key2 := []byte("long-key-02")
@@ -209,8 +210,9 @@ func TestAppendOnlyResetReusesEntryBuffers(t *testing.T) {
 	if &m.entries[0].key[0] != keyBufPtr {
 		t.Fatalf("expected key buffer reuse across reset")
 	}
-	if m.entries[0].value == nil || cap(m.entries[0].value) < len(val2) {
-		t.Fatalf("expected value buffer capacity reuse across reset")
+	nextVal := appendOnlyEntryValue(&m.entries[0])
+	if len(nextVal) != len(val2) {
+		t.Fatalf("value len after reset=%d want=%d", len(nextVal), len(val2))
 	}
 	_ = valBufPtr
 }
@@ -225,13 +227,11 @@ func TestAppendOnlySetCopiesIntoArenaForNonSteal(t *testing.T) {
 		t.Fatalf("count=%d want=1", m.count)
 	}
 	ent := &m.entries[0]
-	if !ent.valueOwned {
-		t.Fatalf("expected non-steal set to mark valueOwned")
+	val := appendOnlyEntryValue(ent)
+	if len(val) != len(src) {
+		t.Fatalf("entry value len=%d want=%d", len(val), len(src))
 	}
-	if len(ent.value) != len(src) {
-		t.Fatalf("entry value len=%d want=%d", len(ent.value), len(src))
-	}
-	if &ent.value[0] == &src[0] {
+	if &val[0] == &src[0] {
 		t.Fatalf("entry value unexpectedly aliases caller buffer")
 	}
 	src[0] = 'X'
@@ -297,10 +297,11 @@ func TestAppendOnlyResetRetainsArenaChunksForReuse(t *testing.T) {
 	}
 
 	m.Set([]byte("z"), make([]byte, 1024))
-	if m.count != 1 || len(m.entries[0].value) == 0 {
+	if m.count != 1 || len(appendOnlyEntryValue(&m.entries[0])) == 0 {
 		t.Fatalf("expected first post-reset set to allocate value from arena")
 	}
-	ptr := uintptr(unsafe.Pointer(&m.entries[0].value[0]))
+	postResetValue := appendOnlyEntryValue(&m.entries[0])
+	ptr := uintptr(unsafe.Pointer(&postResetValue[0]))
 	if _, ok := seen[ptr]; !ok {
 		t.Fatalf("post-reset value buffer did not reuse retained arena chunk")
 	}

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -12,16 +12,31 @@ import (
 
 func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
-	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
+	entries[0].keyIndex = 1
 	entries[0].payloadIndex = 1
-	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
+	entries[1].keyIndex = 2
 	entries[1].payloadIndex = 2
 
 	putAppendOnlyEntries(entries)
 
 	for i := range entries {
-		if entries[i].key != "" || entries[i].payloadIndex != 0 {
+		if entries[i].keyIndex != 0 || entries[i].payloadIndex != 0 {
 			t.Fatalf("entry %d still retains references after put: %+v", i, entries[i])
+		}
+	}
+}
+
+func TestPutAppendOnlyKeysClearsReferences(t *testing.T) {
+	keys := []string{
+		appendOnlyStringFromBytes([]byte("k0")),
+		appendOnlyStringFromBytes([]byte("k1")),
+	}
+
+	putAppendOnlyKeys(keys)
+
+	for i := range keys {
+		if keys[i] != "" {
+			t.Fatalf("key %d still retains references after put: %q", i, keys[i])
 		}
 	}
 }
@@ -44,16 +59,21 @@ func TestPutAppendOnlyPayloadsClearsReferences(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
-	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
+	entries[0].keyIndex = 1
 	entries[0].payloadIndex = 1
-	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
+	entries[1].keyIndex = 2
 	entries[1].payloadIndex = 2
+	keys := []string{
+		appendOnlyStringFromBytes([]byte("k0")),
+		appendOnlyStringFromBytes([]byte("k1")),
+	}
 	payloads := make([]appendOnlyPayload, 2)
 	payloads[0].value = appendOnlyStringFromBytes([]byte("v0"))
 	payloads[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		keys:          keys,
 		payloads:      payloads,
 		pooledEntries: true,
 	}
@@ -62,8 +82,13 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	}
 
 	for i := range entries {
-		if entries[i].key != "" || entries[i].payloadIndex != 0 {
+		if entries[i].keyIndex != 0 || entries[i].payloadIndex != 0 {
 			t.Fatalf("entry %d still retains references after close: %+v", i, entries[i])
+		}
+	}
+	for i := range keys {
+		if keys[i] != "" {
+			t.Fatalf("key %d still retains references after close: %q", i, keys[i])
 		}
 	}
 	for i := range payloads {
@@ -73,6 +98,9 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	}
 	if it.entries != nil {
 		t.Fatalf("iterator entries not cleared on close")
+	}
+	if it.keys != nil {
+		t.Fatalf("iterator keys not cleared on close")
 	}
 	if it.payloads != nil {
 		t.Fatalf("iterator payloads not cleared on close")
@@ -84,8 +112,8 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledPointerEntries(t *testing.T) {
 	entries := []*appendOnlyEntry{
-		{key: appendOnlyStringFromBytes([]byte("k0"))},
-		{key: appendOnlyStringFromBytes([]byte("k1"))},
+		{flags: appendOnlyEntryFlagKeyInline},
+		{flags: appendOnlyEntryFlagKeyInline},
 	}
 	it := &appendOnlyIterator{
 		entryPtrs:       entries,
@@ -217,8 +245,8 @@ func TestAppendOnlyFrozenUnorderedIteratorBlocksResetUntilClose(t *testing.T) {
 }
 
 func TestAppendOnlyEntryStructSizeBound(t *testing.T) {
-	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 32 {
-		t.Fatalf("appendOnlyEntry size=%d want <= 32", got)
+	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 20 {
+		t.Fatalf("appendOnlyEntry size=%d want <= 20", got)
 	}
 }
 
@@ -231,7 +259,7 @@ func TestAppendOnlySetCopiesNonInlineKeyIntoArena(t *testing.T) {
 	if m.count != 1 {
 		t.Fatalf("count=%d want=1", m.count)
 	}
-	storedKey := appendOnlyEntryKey(&m.entries[0])
+	storedKey := m.appendOnlyEntryKey(&m.entries[0])
 	if string(storedKey) != string(lookupKey) {
 		t.Fatalf("stored key=%q want=%q", storedKey, lookupKey)
 	}
@@ -349,7 +377,7 @@ func TestAppendOnlyResetRetainsArenaChunksForReuse(t *testing.T) {
 	if m.count != 1 || len(m.appendOnlyEntryValue(&m.entries[0])) == 0 {
 		t.Fatalf("expected first post-reset set to allocate value from arena")
 	}
-	postResetKeyBuf := appendOnlyEntryKey(&m.entries[0])
+	postResetKeyBuf := m.appendOnlyEntryKey(&m.entries[0])
 	postResetValue := m.appendOnlyEntryValue(&m.entries[0])
 	if len(postResetKeyBuf) == 0 {
 		t.Fatalf("expected non-inline key to be retained after reset")

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -277,6 +277,35 @@ func TestAppendOnlySetCopiesNonInlineKeyIntoArena(t *testing.T) {
 	}
 }
 
+func TestAppendOnlySetInlinesShortKey(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	key := []byte("short")
+	lookupKey := cloneBytes(key)
+	m.Set(key, []byte("v"))
+
+	if m.count != 1 {
+		t.Fatalf("count=%d want=1", m.count)
+	}
+	ent := &m.entries[0]
+	if ent.flags&appendOnlyEntryFlagKeyInline == 0 {
+		t.Fatalf("expected short key to be stored inline")
+	}
+	if ent.inlineKeyLen != uint8(len(lookupKey)) {
+		t.Fatalf("inline key len=%d want=%d", ent.inlineKeyLen, len(lookupKey))
+	}
+	if ent.keyIndex != 0 {
+		t.Fatalf("short inline key should not allocate a key slot; keyIndex=%d", ent.keyIndex)
+	}
+	storedKey := m.appendOnlyEntryKey(ent)
+	if string(storedKey) != string(lookupKey) {
+		t.Fatalf("stored key=%q want=%q", storedKey, lookupKey)
+	}
+	key[0] = 'X'
+	if string(m.appendOnlyEntryKey(ent)) != string(lookupKey) {
+		t.Fatalf("inline key changed after caller mutation: got=%q want=%q", m.appendOnlyEntryKey(ent), lookupKey)
+	}
+}
+
 func TestAppendOnlySetCopiesIntoArenaForNonSteal(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	key := []byte("long-key-arena")

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -13,15 +13,31 @@ import (
 func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
 	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
-	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
+	entries[0].payloadIndex = 1
 	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
-	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
+	entries[1].payloadIndex = 2
 
 	putAppendOnlyEntries(entries)
 
 	for i := range entries {
-		if entries[i].key != "" || entries[i].value != "" {
+		if entries[i].key != "" || entries[i].payloadIndex != 0 {
 			t.Fatalf("entry %d still retains references after put: %+v", i, entries[i])
+		}
+	}
+}
+
+func TestPutAppendOnlyPayloadsClearsReferences(t *testing.T) {
+	payloads := make([]appendOnlyPayload, 2)
+	payloads[0].value = appendOnlyStringFromBytes([]byte("v0"))
+	payloads[0].ptr = page.ValuePtr{Offset: 1, Length: 2, FileID: 3}
+	payloads[1].value = appendOnlyStringFromBytes([]byte("v1"))
+	payloads[1].ptr = page.ValuePtr{Offset: 4, Length: 5, FileID: 6}
+
+	putAppendOnlyPayloads(payloads)
+
+	for i := range payloads {
+		if payloads[i].value != "" || payloads[i].ptr != (page.ValuePtr{}) {
+			t.Fatalf("payload %d still retains references after put: %+v", i, payloads[i])
 		}
 	}
 }
@@ -29,12 +45,16 @@ func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
 	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
-	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
+	entries[0].payloadIndex = 1
 	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
-	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
+	entries[1].payloadIndex = 2
+	payloads := make([]appendOnlyPayload, 2)
+	payloads[0].value = appendOnlyStringFromBytes([]byte("v0"))
+	payloads[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	it := &appendOnlyIterator{
 		entries:       entries,
+		payloads:      payloads,
 		pooledEntries: true,
 	}
 	if err := it.Close(); err != nil {
@@ -42,12 +62,20 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	}
 
 	for i := range entries {
-		if entries[i].key != "" || entries[i].value != "" {
+		if entries[i].key != "" || entries[i].payloadIndex != 0 {
 			t.Fatalf("entry %d still retains references after close: %+v", i, entries[i])
+		}
+	}
+	for i := range payloads {
+		if payloads[i].value != "" || payloads[i].ptr != (page.ValuePtr{}) {
+			t.Fatalf("payload %d still retains references after close: %+v", i, payloads[i])
 		}
 	}
 	if it.entries != nil {
 		t.Fatalf("iterator entries not cleared on close")
+	}
+	if it.payloads != nil {
+		t.Fatalf("iterator payloads not cleared on close")
 	}
 	if it.pooledEntries {
 		t.Fatalf("pooledEntries flag not cleared on close")
@@ -56,8 +84,8 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledPointerEntries(t *testing.T) {
 	entries := []*appendOnlyEntry{
-		{key: appendOnlyStringFromBytes([]byte("k0")), value: appendOnlyStringFromBytes([]byte("v0"))},
-		{key: appendOnlyStringFromBytes([]byte("k1")), value: appendOnlyStringFromBytes([]byte("v1"))},
+		{key: appendOnlyStringFromBytes([]byte("k0"))},
+		{key: appendOnlyStringFromBytes([]byte("k1"))},
 	}
 	it := &appendOnlyIterator{
 		entryPtrs:       entries,
@@ -189,8 +217,8 @@ func TestAppendOnlyFrozenUnorderedIteratorBlocksResetUntilClose(t *testing.T) {
 }
 
 func TestAppendOnlyEntryStructSizeBound(t *testing.T) {
-	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 64 {
-		t.Fatalf("appendOnlyEntry size=%d want <= 64", got)
+	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 32 {
+		t.Fatalf("appendOnlyEntry size=%d want <= 32", got)
 	}
 }
 
@@ -231,7 +259,7 @@ func TestAppendOnlySetCopiesIntoArenaForNonSteal(t *testing.T) {
 		t.Fatalf("count=%d want=1", m.count)
 	}
 	ent := &m.entries[0]
-	val := appendOnlyEntryValue(ent)
+	val := m.appendOnlyEntryValue(ent)
 	if len(val) != len(src) {
 		t.Fatalf("entry value len=%d want=%d", len(val), len(src))
 	}
@@ -318,11 +346,11 @@ func TestAppendOnlyResetRetainsArenaChunksForReuse(t *testing.T) {
 
 	postResetKey := []byte("post-reset-long-key")
 	m.Set(postResetKey, make([]byte, 1024))
-	if m.count != 1 || len(appendOnlyEntryValue(&m.entries[0])) == 0 {
+	if m.count != 1 || len(m.appendOnlyEntryValue(&m.entries[0])) == 0 {
 		t.Fatalf("expected first post-reset set to allocate value from arena")
 	}
 	postResetKeyBuf := appendOnlyEntryKey(&m.entries[0])
-	postResetValue := appendOnlyEntryValue(&m.entries[0])
+	postResetValue := m.appendOnlyEntryValue(&m.entries[0])
 	if len(postResetKeyBuf) == 0 {
 		t.Fatalf("expected non-inline key to be retained after reset")
 	}

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -12,15 +12,15 @@ import (
 
 func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
-	entries[0].key = []byte("k0")
+	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
 	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
-	entries[1].key = []byte("k1")
+	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
 	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	putAppendOnlyEntries(entries)
 
 	for i := range entries {
-		if entries[i].key != nil || entries[i].value != "" {
+		if entries[i].key != "" || entries[i].value != "" {
 			t.Fatalf("entry %d still retains references after put: %+v", i, entries[i])
 		}
 	}
@@ -28,9 +28,9 @@ func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
-	entries[0].key = []byte("k0")
+	entries[0].key = appendOnlyStringFromBytes([]byte("k0"))
 	entries[0].value = appendOnlyStringFromBytes([]byte("v0"))
-	entries[1].key = []byte("k1")
+	entries[1].key = appendOnlyStringFromBytes([]byte("k1"))
 	entries[1].value = appendOnlyStringFromBytes([]byte("v1"))
 
 	it := &appendOnlyIterator{
@@ -42,7 +42,7 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	}
 
 	for i := range entries {
-		if entries[i].key != nil || entries[i].value != "" {
+		if entries[i].key != "" || entries[i].value != "" {
 			t.Fatalf("entry %d still retains references after close: %+v", i, entries[i])
 		}
 	}
@@ -56,8 +56,8 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledPointerEntries(t *testing.T) {
 	entries := []*appendOnlyEntry{
-		{key: []byte("k0"), value: appendOnlyStringFromBytes([]byte("v0"))},
-		{key: []byte("k1"), value: appendOnlyStringFromBytes([]byte("v1"))},
+		{key: appendOnlyStringFromBytes([]byte("k0")), value: appendOnlyStringFromBytes([]byte("v0"))},
+		{key: appendOnlyStringFromBytes([]byte("k1")), value: appendOnlyStringFromBytes([]byte("v1"))},
 	}
 	it := &appendOnlyIterator{
 		entryPtrs:       entries,
@@ -188,33 +188,37 @@ func TestAppendOnlyFrozenUnorderedIteratorBlocksResetUntilClose(t *testing.T) {
 	}
 }
 
-func TestAppendOnlyResetReusesEntryBuffers(t *testing.T) {
+func TestAppendOnlyEntryStructSizeBound(t *testing.T) {
+	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 64 {
+		t.Fatalf("appendOnlyEntry size=%d want <= 64", got)
+	}
+}
+
+func TestAppendOnlySetCopiesNonInlineKeyIntoArena(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	key1 := []byte("long-key-01")
+	lookupKey := cloneBytes(key1)
 	val1 := []byte("value-aaaaaa")
 	m.Set(key1, val1)
 	if m.count != 1 {
 		t.Fatalf("count=%d want=1", m.count)
 	}
-	keyBufPtr := &m.entries[0].key[0]
-	firstVal := appendOnlyEntryValue(&m.entries[0])
-	valBufPtr := &firstVal[0]
+	storedKey := appendOnlyEntryKey(&m.entries[0])
+	if string(storedKey) != string(lookupKey) {
+		t.Fatalf("stored key=%q want=%q", storedKey, lookupKey)
+	}
+	if unsafe.SliceData(storedKey) == unsafe.SliceData(key1) {
+		t.Fatalf("stored key unexpectedly aliases caller buffer")
+	}
+	key1[0] = 'X'
 
-	m.Reset()
-	key2 := []byte("long-key-02")
-	val2 := []byte("value-bbbbbb")
-	m.Set(key2, val2)
-	if m.count != 1 {
-		t.Fatalf("count after reset=%d want=1", m.count)
+	got, tombstone, ok := m.Get(lookupKey)
+	if !ok || tombstone {
+		t.Fatalf("Get(%q) = ok=%v tombstone=%v; want ok=true tombstone=false", lookupKey, ok, tombstone)
 	}
-	if &m.entries[0].key[0] != keyBufPtr {
-		t.Fatalf("expected key buffer reuse across reset")
+	if string(got) != string(val1) {
+		t.Fatalf("stored value changed after source key mutation: got=%q want=%q", got, val1)
 	}
-	nextVal := appendOnlyEntryValue(&m.entries[0])
-	if len(nextVal) != len(val2) {
-		t.Fatalf("value len after reset=%d want=%d", len(nextVal), len(val2))
-	}
-	_ = valBufPtr
 }
 
 func TestAppendOnlySetCopiesIntoArenaForNonSteal(t *testing.T) {
@@ -282,10 +286,26 @@ func TestAppendOnlyResetRetainsArenaChunksForReuse(t *testing.T) {
 	if len(m.valueArena.chunks) == 0 {
 		t.Fatalf("expected populated arena chunks before reset")
 	}
-	seen := make(map[uintptr]struct{}, len(m.valueArena.chunks))
+	type chunkSpan struct {
+		start uintptr
+		end   uintptr
+	}
+	seen := make([]chunkSpan, 0, len(m.valueArena.chunks))
 	for _, chunk := range m.valueArena.chunks {
 		full := chunk[:cap(chunk)]
-		seen[uintptr(unsafe.Pointer(&full[0]))] = struct{}{}
+		start := uintptr(unsafe.Pointer(&full[0]))
+		seen = append(seen, chunkSpan{
+			start: start,
+			end:   start + uintptr(len(full)),
+		})
+	}
+	inRetainedChunk := func(ptr uintptr) bool {
+		for _, span := range seen {
+			if ptr >= span.start && ptr < span.end {
+				return true
+			}
+		}
+		return false
 	}
 
 	m.Reset()
@@ -296,13 +316,22 @@ func TestAppendOnlyResetRetainsArenaChunksForReuse(t *testing.T) {
 		t.Fatalf("expected retained arena bytes > 0")
 	}
 
-	m.Set([]byte("z"), make([]byte, 1024))
+	postResetKey := []byte("post-reset-long-key")
+	m.Set(postResetKey, make([]byte, 1024))
 	if m.count != 1 || len(appendOnlyEntryValue(&m.entries[0])) == 0 {
 		t.Fatalf("expected first post-reset set to allocate value from arena")
 	}
+	postResetKeyBuf := appendOnlyEntryKey(&m.entries[0])
 	postResetValue := appendOnlyEntryValue(&m.entries[0])
+	if len(postResetKeyBuf) == 0 {
+		t.Fatalf("expected non-inline key to be retained after reset")
+	}
+	keyPtr := uintptr(unsafe.Pointer(unsafe.SliceData(postResetKeyBuf)))
 	ptr := uintptr(unsafe.Pointer(&postResetValue[0]))
-	if _, ok := seen[ptr]; !ok {
+	if !inRetainedChunk(keyPtr) {
+		t.Fatalf("post-reset key buffer did not reuse retained arena chunk")
+	}
+	if !inRetainedChunk(ptr) {
 		t.Fatalf("post-reset value buffer did not reuse retained arena chunk")
 	}
 }

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -490,7 +490,7 @@ func TestAppendOnlyUnorderedAppendDefersLatestIndexUntilIterator(t *testing.T) {
 	if m.snapCount != 0 {
 		t.Fatalf("expected mutable unordered iterator to keep shared snapshot uncached after rebuild; got snapCount=%d", m.snapCount)
 	}
-	idx, ok := m.latest[appendOnlyKeyString([]byte("b"))]
+	idx, ok := m.latest["b"]
 	if !ok {
 		t.Fatalf("missing latest index entry for key b")
 	}

--- a/TreeDB/internal/memtable/append_only_reset_hard_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_hard_test.go
@@ -34,3 +34,30 @@ func TestAppendOnlyResetWithCapacityHard_DropsObservedSpike(t *testing.T) {
 		t.Fatalf("hard reset retained bytes=%d want=0", got)
 	}
 }
+
+func TestAppendOnlyResetWithCapacityHard_DropsSideBuffers(t *testing.T) {
+	const (
+		capacityBytes          = 4 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	for i := 0; i < appendOnlyResetDropThresholdEntries; i++ {
+		key := []byte(fmt.Sprintf("long-key-%08d", i))
+		mt.Set(key, []byte("value"))
+	}
+	if cap(mt.keys) == 0 {
+		t.Fatalf("test did not populate key side buffer")
+	}
+	if cap(mt.payloads) == 0 {
+		t.Fatalf("test did not populate payload side buffer")
+	}
+
+	mt.ResetWithCapacityHard(capacityBytes, estimatedBytesPerEntry)
+	if got := cap(mt.keys); got != 0 {
+		t.Fatalf("hard reset cap(keys)=%d want=0", got)
+	}
+	if got := cap(mt.payloads); got != 0 {
+		t.Fatalf("hard reset cap(payloads)=%d want=0", got)
+	}
+}

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -2,6 +2,7 @@ package memtable
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/node"
@@ -162,7 +163,7 @@ func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) 
 
 	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
 	var observed int
-	mt.SetPredictiveGrowthHint(capacityBytes, func(entries int) {
+	mt.SetPredictiveGrowthHint(capacityBytes, nil, func(entries int) {
 		if entries > observed {
 			observed = entries
 		}
@@ -181,5 +182,27 @@ func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) 
 	}
 	if got := cap(mt.entries); got != base {
 		t.Fatalf("predictive hint should not allocate immediately: cap(entries)=%d want=%d", got, base)
+	}
+}
+
+func TestAppendOnlySharedPredictiveHintRaisesGrowthFloorBeforeLocalPrediction(t *testing.T) {
+	const (
+		capacityBytes          = 128 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	sharedHint := atomic.Int32{}
+	sharedHint.Store(int32(base * 8))
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	mt.SetPredictiveGrowthHint(capacityBytes, &sharedHint, nil)
+
+	for i := 0; i < base+1; i++ {
+		key := []byte(fmt.Sprintf("s%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+	if got := cap(mt.entries); got < int(sharedHint.Load()) {
+		t.Fatalf("cap(entries)=%d want >= %d", got, sharedHint.Load())
 	}
 }

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -79,7 +79,7 @@ func TestAppendOnlyResetWithCapacity_RetainsObservedEntriesWithinBound(t *testin
 	}
 }
 
-func TestAppendOnlyResetWithCapacityAndEntryHint_PreallocatesHintedEntries(t *testing.T) {
+func TestAppendOnlyNewWithCapacityAndEntryHint_PreallocatesHintedEntries(t *testing.T) {
 	const (
 		capacityBytes          = 4 << 10
 		estimatedBytesPerEntry = 96
@@ -103,21 +103,48 @@ func TestAppendOnlyResetWithCapacityAndEntryHint_PreallocatesHintedEntries(t *te
 	if got := cap(mt.entries); got != capBefore {
 		t.Fatalf("hinted constructor regrew entries: cap(entries)=%d want=%d", got, capBefore)
 	}
+}
 
-	mt.ResetWithCapacityAndEntryHint(capacityBytes, estimatedBytesPerEntry, entryHint)
-	if got := len(mt.entries); got < entryHint {
-		t.Fatalf("reset len(entries)=%d want>=%d", got, entryHint)
-	}
-	if got := cap(mt.entries); got < entryHint {
-		t.Fatalf("reset cap(entries)=%d want>=%d", got, entryHint)
+func TestAppendOnlyResetWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *testing.T) {
+	const (
+		capacityBytes          = 4 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	entryHint := base * 16
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	if got := cap(mt.entries); got != base {
+		t.Fatalf("initial cap(entries)=%d want=%d", got, base)
 	}
 
-	capAfterReset := cap(mt.entries)
+	allocs := testing.AllocsPerRun(1000, func() {
+		mt.ResetWithCapacityAndEntryHint(capacityBytes, estimatedBytesPerEntry, entryHint)
+	})
+	if allocs > 0 {
+		t.Fatalf("reset allocs/run=%f want 0", allocs)
+	}
+	if got := len(mt.entries); got != base {
+		t.Fatalf("reset len(entries)=%d want=%d", got, base)
+	}
+	if got := cap(mt.entries); got != base {
+		t.Fatalf("reset cap(entries)=%d want=%d", got, base)
+	}
+	if got := mt.growEntriesLen; got < entryHint {
+		t.Fatalf("growEntriesLen=%d want >=%d", got, entryHint)
+	}
+
 	for i := 0; i < entryHint; i++ {
 		key := []byte(fmt.Sprintf("r%08d", i))
 		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
 	}
-	if got := cap(mt.entries); got != capAfterReset {
-		t.Fatalf("hinted reset regrew entries: cap(entries)=%d want=%d", got, capAfterReset)
+	capAfterGrowth := cap(mt.entries)
+	if capAfterGrowth < entryHint {
+		t.Fatalf("grown cap(entries)=%d want >=%d", capAfterGrowth, entryHint)
+	}
+
+	mt.ResetWithCapacityAndEntryHint(capacityBytes, estimatedBytesPerEntry, entryHint)
+	if got := cap(mt.entries); got != capAfterGrowth {
+		t.Fatalf("warm hinted cap(entries)=%d want=%d", got, capAfterGrowth)
 	}
 }

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -148,3 +148,38 @@ func TestAppendOnlyResetWithCapacityAndEntryHint_DefersHintGrowthUntilAppend(t *
 		t.Fatalf("warm hinted cap(entries)=%d want=%d", got, capAfterGrowth)
 	}
 }
+
+func TestAppendOnlyPredictiveGrowthHintRaisesFutureGrowEntriesLen(t *testing.T) {
+	const (
+		capacityBytes          = 128 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	if base <= appendOnlyPredictHintMinEntries {
+		t.Fatalf("base=%d want > %d", base, appendOnlyPredictHintMinEntries)
+	}
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	var observed int
+	mt.SetPredictiveGrowthHint(capacityBytes, func(entries int) {
+		if entries > observed {
+			observed = entries
+		}
+	})
+
+	for i := 0; i < appendOnlyPredictHintMinEntries; i++ {
+		key := []byte(fmt.Sprintf("p%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+
+	if got, wantMin := mt.growEntriesLen, base*8; got < wantMin {
+		t.Fatalf("growEntriesLen=%d want >= %d", got, wantMin)
+	}
+	if observed != mt.growEntriesLen {
+		t.Fatalf("observed predicted entries=%d want %d", observed, mt.growEntriesLen)
+	}
+	if got := cap(mt.entries); got != base {
+		t.Fatalf("predictive hint should not allocate immediately: cap(entries)=%d want=%d", got, base)
+	}
+}

--- a/TreeDB/internal/memtable/append_only_reset_shrink_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_shrink_test.go
@@ -78,3 +78,46 @@ func TestAppendOnlyResetWithCapacity_RetainsObservedEntriesWithinBound(t *testin
 		t.Fatalf("entries regrew after warm reset: cap(entries)=%d want=%d", got, capBeforeReset)
 	}
 }
+
+func TestAppendOnlyResetWithCapacityAndEntryHint_PreallocatesHintedEntries(t *testing.T) {
+	const (
+		capacityBytes          = 4 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	entryHint := base * 16
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacityBytes, estimatedBytesPerEntry, entryHint)
+	if got := len(mt.entries); got < entryHint {
+		t.Fatalf("initial len(entries)=%d want>=%d", got, entryHint)
+	}
+	if got := cap(mt.entries); got < entryHint {
+		t.Fatalf("initial cap(entries)=%d want>=%d", got, entryHint)
+	}
+
+	capBefore := cap(mt.entries)
+	for i := 0; i < entryHint; i++ {
+		key := []byte(fmt.Sprintf("h%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+	if got := cap(mt.entries); got != capBefore {
+		t.Fatalf("hinted constructor regrew entries: cap(entries)=%d want=%d", got, capBefore)
+	}
+
+	mt.ResetWithCapacityAndEntryHint(capacityBytes, estimatedBytesPerEntry, entryHint)
+	if got := len(mt.entries); got < entryHint {
+		t.Fatalf("reset len(entries)=%d want>=%d", got, entryHint)
+	}
+	if got := cap(mt.entries); got < entryHint {
+		t.Fatalf("reset cap(entries)=%d want>=%d", got, entryHint)
+	}
+
+	capAfterReset := cap(mt.entries)
+	for i := 0; i < entryHint; i++ {
+		key := []byte(fmt.Sprintf("r%08d", i))
+		mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+	}
+	if got := cap(mt.entries); got != capAfterReset {
+		t.Fatalf("hinted reset regrew entries: cap(entries)=%d want=%d", got, capAfterReset)
+	}
+}

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -343,7 +343,7 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 				if m.latest == nil {
 					return 0, false
 				}
-				idx, ok := m.latest[appendOnlyKeyString(key)]
+				idx, ok := m.latest[string(key)]
 				return idx, ok
 			},
 			latestSize: func(m *AppendOnly) int {

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -2,6 +2,7 @@ package memtable
 
 import (
 	"encoding/binary"
+	"fmt"
 	"testing"
 	"time"
 
@@ -486,6 +487,28 @@ func TestAppendOnlyGet_EmptyKey_IncrementalLatestIndex(t *testing.T) {
 	}
 	if got, ptr, flags, ok := m.GetEntry([]byte{}); !ok || string(got) != "empty" || ptr != (page.ValuePtr{}) || flags != node.FlagInline {
 		t.Fatalf("GetEntry(empty key) = (%q,%+v,%d,%v), want (empty,zero,%d,true)", string(got), ptr, flags, ok, node.FlagInline)
+	}
+}
+
+func TestAppendOnlyLatestIndexShortInlineKeysSurviveEntryGrowth(t *testing.T) {
+	m := NewAppendOnlyWithCapacityEstimatedEntryBytes(
+		appendOnlyMinInitialEntries*appendOnlyEstimatedBytesPerEntryPointer,
+		appendOnlyEstimatedBytesPerEntryPointer,
+	)
+
+	m.Set([]byte("b"), []byte("first"))
+	m.Set([]byte("a"), []byte("target"))
+	if got, del, ok := m.Get([]byte("a")); !ok || del || string(got) != "target" {
+		t.Fatalf("precondition Get(a) = (%q,%v,%v), want (target,false,true)", string(got), del, ok)
+	}
+
+	for i := 0; i < appendOnlyMinInitialEntries; i++ {
+		key := []byte(fmt.Sprintf("long-growth-key-%08d", i))
+		m.Set(key, []byte("growth"))
+	}
+
+	if got, del, ok := m.Get([]byte("a")); !ok || del || string(got) != "target" {
+		t.Fatalf("Get(a) after growth = (%q,%v,%v), want (target,false,true)", string(got), del, ok)
 	}
 }
 

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -36,6 +36,7 @@ func TestAppendOnlyInlineGrowthSkipsIntermediateDoublingBelowCutoff(t *testing.T
 	mt := &AppendOnly{
 		entries:        make([]appendOnlyEntry, appendOnlyMinInitialEntries),
 		baseEntriesLen: appendOnlyMinInitialEntries,
+		growEntriesLen: appendOnlyMinInitialEntries,
 		ordered:        true,
 		lastIdx:        -1,
 	}

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -144,6 +144,39 @@ func TestAppendOnlyIteratorSortedLatest(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyDefersLatestIndexUntilLookup(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+
+	var k2 [8]byte
+	var k1 [8]byte
+	binary.BigEndian.PutUint64(k2[:], 2)
+	binary.BigEndian.PutUint64(k1[:], 1)
+
+	m.Set(k2[:], []byte("v2"))
+	m.Set(k1[:], []byte("v1"))
+
+	if m.ordered {
+		t.Fatalf("expected out-of-order append to mark memtable unordered")
+	}
+	if !m.latestDirty {
+		t.Fatalf("expected latest index to remain dirty until a lookup needs it")
+	}
+	if len(m.latest) != 0 || len(m.latest64) != 0 {
+		t.Fatalf("expected no latest index materialized yet; latest=%d latest64=%d", len(m.latest), len(m.latest64))
+	}
+
+	val, del, ok := m.Get(k1[:])
+	if !ok || del || string(val) != "v1" {
+		t.Fatalf("Get(k1) = (%q,%v,%v), want (v1,false,true)", string(val), del, ok)
+	}
+	if m.latestDirty {
+		t.Fatalf("expected lookup to rebuild the latest index")
+	}
+	if len(m.latest64) != 2 {
+		t.Fatalf("latest64 size = %d, want 2", len(m.latest64))
+	}
+}
+
 func TestAppendOnlyResetClearsLatestIndex(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	m.Set([]byte("k1"), []byte("v1"))
@@ -361,22 +394,18 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 			if ordered {
 				t.Fatalf("expected memtable to become unordered")
 			}
-			if dirty {
-				t.Fatalf("expected latest index to stay clean after order break")
+			if !dirty {
+				t.Fatalf("expected latest index to stay dirty after order break")
 			}
 			m.mu.RLock()
 			latestSizeBeforeGet := kk.latestSize(m)
 			idxBeforeGet, okBeforeGet := kk.latestIdx(m, lo)
-			countBeforeGet := m.count
 			m.mu.RUnlock()
-			if latestSizeBeforeGet < 2 {
-				t.Fatalf("expected latest index to be materialized on order break, size=%d", latestSizeBeforeGet)
+			if latestSizeBeforeGet != 0 {
+				t.Fatalf("expected no latest index materialized before first point read, size=%d", latestSizeBeforeGet)
 			}
-			if !okBeforeGet {
-				t.Fatalf("expected latest index lookup to succeed immediately after order break")
-			}
-			if idxBeforeGet != countBeforeGet-1 {
-				t.Fatalf("latest index before Get=%d want %d", idxBeforeGet, countBeforeGet-1)
+			if okBeforeGet {
+				t.Fatalf("expected latest index lookup to miss before first point read, got idx=%d", idxBeforeGet)
 			}
 
 			if got, del, ok := m.Get(lo); !ok || del || string(got) != "lo" {

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -20,6 +20,10 @@ func HasCompactLeafLogPayload(payload []byte) bool {
 }
 
 func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
+	return MaybeCompactLeafLogPayloadTo(nil, leafPage)
+}
+
+func MaybeCompactLeafLogPayloadTo(dst, leafPage []byte) ([]byte, bool, error) {
 	if len(leafPage) != page.PageSize {
 		return leafPage, false, nil
 	}
@@ -33,7 +37,12 @@ func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
 	}
 
 	suffixStart := len(leafPage) - suffixLen
-	payload := make([]byte, compactLen)
+	var payload []byte
+	if cap(dst) >= compactLen {
+		payload = dst[:compactLen]
+	} else {
+		payload = make([]byte, compactLen)
+	}
 	copy(payload[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:])
 	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic):len(compactLeafPagePayloadMagic)+2], uint16(prefixLen))
 	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic)+2:compactLeafPagePayloadHeaderSize], uint16(suffixLen))

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -33,17 +33,15 @@ func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
 	}
 
 	suffixStart := len(leafPage) - suffixLen
-	var canonical [page.PageSize]byte
-	copy(canonical[:prefixLen], leafPage[:prefixLen])
-	copy(canonical[suffixStart:], leafPage[suffixStart:])
-	page.UpdateChecksum(canonical[:])
-
 	payload := make([]byte, compactLen)
 	copy(payload[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:])
 	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic):len(compactLeafPagePayloadMagic)+2], uint16(prefixLen))
 	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic)+2:compactLeafPagePayloadHeaderSize], uint16(suffixLen))
-	copy(payload[compactLeafPagePayloadHeaderSize:compactLeafPagePayloadHeaderSize+prefixLen], canonical[:prefixLen])
-	copy(payload[compactLeafPagePayloadHeaderSize+prefixLen:], canonical[suffixStart:])
+	prefixDst := payload[compactLeafPagePayloadHeaderSize : compactLeafPagePayloadHeaderSize+prefixLen]
+	suffixDst := payload[compactLeafPagePayloadHeaderSize+prefixLen:]
+	copy(prefixDst, leafPage[:prefixLen])
+	copy(suffixDst, leafPage[suffixStart:])
+	page.UpdateChecksumPrefixSuffix(prefixDst, suffixDst, page.PageSize)
 	return payload, true, nil
 }
 

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -130,6 +130,30 @@ func TestMaybeCompactLeafLogPayload_SparseLeafAllocatesOnlyPayload(t *testing.T)
 	}
 }
 
+func TestMaybeCompactLeafLogPayloadTo_SparseLeafReusesDstWithoutAllocations(t *testing.T) {
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	dst := make([]byte, 0, page.PageSize)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		payload, compacted, err := MaybeCompactLeafLogPayloadTo(dst, leaf)
+		if err != nil {
+			t.Fatalf("MaybeCompactLeafLogPayloadTo: %v", err)
+		}
+		if !compacted {
+			t.Fatalf("expected sparse leaf page to compact")
+		}
+		if len(payload) >= len(leaf) {
+			t.Fatalf("payload len=%d want < %d", len(payload), len(leaf))
+		}
+		if len(payload) > 0 && &payload[0] != &dst[:cap(dst)][0] {
+			t.Fatalf("expected compact payload to reuse dst backing storage")
+		}
+	})
+	if allocs > 0 {
+		t.Fatalf("allocs/run=%f want 0", allocs)
+	}
+}
+
 func TestDecodeCompactLeafLogPayloadTo_AliasedDstRoundTrips(t *testing.T) {
 	leaf := buildSparseLeafPageForPayloadTest(t)
 

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -110,6 +110,26 @@ func TestMaybeCompactLeafLogPayload_SparseLeafRoundTrips(t *testing.T) {
 	requireLeafPagesLogicallyEqual(t, leaf, decoded)
 }
 
+func TestMaybeCompactLeafLogPayload_SparseLeafAllocatesOnlyPayload(t *testing.T) {
+	leaf := buildSparseLeafPageForPayloadTest(t)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+		if err != nil {
+			t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+		}
+		if !compacted {
+			t.Fatalf("expected sparse leaf page to compact")
+		}
+		if len(payload) >= len(leaf) {
+			t.Fatalf("payload len=%d want < %d", len(payload), len(leaf))
+		}
+	})
+	if allocs > 1.1 {
+		t.Fatalf("allocs/run=%f want <= 1.1", allocs)
+	}
+}
+
 func TestDecodeCompactLeafLogPayloadTo_AliasedDstRoundTrips(t *testing.T) {
 	leaf := buildSparseLeafPageForPayloadTest(t)
 

--- a/TreeDB/page/page.go
+++ b/TreeDB/page/page.go
@@ -69,6 +69,7 @@ type ValuePtr struct {
 // CRC32C Table using Castagnoli polynomial.
 var crcTable = crc32.MakeTable(crc32.Castagnoli)
 var checksumZeroField = [4]byte{}
+var checksumZeroChunk = [256]byte{}
 
 // Checksum returns the CRC32C checksum of data.
 func Checksum(data []byte) uint32 {
@@ -102,6 +103,53 @@ func UpdateChecksum(data []byte) uint32 {
 	data[11] = 0
 	sum := crc32.Checksum(data, crcTable)
 	binary.LittleEndian.PutUint32(data[8:12], sum)
+	return sum
+}
+
+func updateChecksumZeros(sum uint32, count int) uint32 {
+	for count > 0 {
+		n := count
+		if n > len(checksumZeroChunk) {
+			n = len(checksumZeroChunk)
+		}
+		sum = crc32.Update(sum, crcTable, checksumZeroChunk[:n])
+		count -= n
+	}
+	return sum
+}
+
+func updateChecksumSegment(sum uint32, segment []byte, segmentStart, maskStart, maskEnd int) uint32 {
+	segEnd := segmentStart + len(segment)
+	if segEnd <= maskStart || segmentStart >= maskEnd {
+		return crc32.Update(sum, crcTable, segment)
+	}
+	if segmentStart < maskStart {
+		sum = crc32.Update(sum, crcTable, segment[:maskStart-segmentStart])
+	}
+	overlapStart := max(segmentStart, maskStart)
+	overlapEnd := min(segEnd, maskEnd)
+	sum = updateChecksumZeros(sum, overlapEnd-overlapStart)
+	if overlapEnd < segEnd {
+		sum = crc32.Update(sum, crcTable, segment[overlapEnd-segmentStart:])
+	}
+	return sum
+}
+
+// UpdateChecksumPrefixSuffix computes CRC32C for a page represented by a
+// prefix segment at offset 0, a zero-filled middle gap, and a suffix segment at
+// the end of the page. Checksum bytes 8-11 are treated as zero, and when the
+// prefix covers them the computed checksum is written back into prefix[8:12].
+func UpdateChecksumPrefixSuffix(prefix, suffix []byte, totalLen int) uint32 {
+	if totalLen < PageHeaderSize || len(prefix)+len(suffix) > totalLen {
+		return 0
+	}
+	suffixStart := totalLen - len(suffix)
+	sum := updateChecksumSegment(0, prefix, 0, 8, 12)
+	sum = updateChecksumZeros(sum, suffixStart-len(prefix))
+	sum = updateChecksumSegment(sum, suffix, suffixStart, 8, 12)
+	if len(prefix) >= 12 {
+		binary.LittleEndian.PutUint32(prefix[8:12], sum)
+	}
 	return sum
 }
 

--- a/TreeDB/page/page_test.go
+++ b/TreeDB/page/page_test.go
@@ -131,6 +131,36 @@ func TestUpdateChecksum(t *testing.T) {
 	}
 }
 
+func TestUpdateChecksumPrefixSuffixMatchesFullPage(t *testing.T) {
+	full := make([]byte, PageSize)
+	for i := range full {
+		full[i] = byte((i * 17) & 0xff)
+	}
+	prefixLen := 320
+	suffixLen := 192
+	suffixStart := len(full) - suffixLen
+
+	canonical := make([]byte, len(full))
+	copy(canonical[:prefixLen], full[:prefixLen])
+	copy(canonical[suffixStart:], full[suffixStart:])
+	want := UpdateChecksum(canonical)
+
+	prefix := append([]byte(nil), full[:prefixLen]...)
+	suffix := append([]byte(nil), full[suffixStart:]...)
+	got := UpdateChecksumPrefixSuffix(prefix, suffix, len(full))
+	if got != want {
+		t.Fatalf("UpdateChecksumPrefixSuffix returned 0x%x, want 0x%x", got, want)
+	}
+	if binary.LittleEndian.Uint32(prefix[8:12]) != want {
+		t.Fatalf("prefix checksum field = 0x%x, want 0x%x", binary.LittleEndian.Uint32(prefix[8:12]), want)
+	}
+	copy(canonical[:prefixLen], prefix)
+	copy(canonical[suffixStart:], suffix)
+	if !VerifyChecksumNonMutating(canonical) {
+		t.Fatalf("sparse checksum should verify after prefix/suffix update")
+	}
+}
+
 func TestUnsafeCastHeader(t *testing.T) {
 	// Note: This test assumes LittleEndian machine.
 	// If running on BigEndian, this test might fail or require adjustment if UnsafeCastHeader is used.

--- a/cmd/unified_bench/batch_delete_test.go
+++ b/cmd/unified_bench/batch_delete_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/kvstore"
+)
+
+type batchDeleteFastPathDB struct {
+	newBatchCalls         int
+	newBatchWithSizeCalls int
+	setCalls              int
+	batches               []*batchDeleteFastPathBatch
+}
+
+func (d *batchDeleteFastPathDB) Name() string                   { return "BatchDeleteFastPath" }
+func (d *batchDeleteFastPathDB) Close() error                   { return nil }
+func (d *batchDeleteFastPathDB) Get(key []byte) ([]byte, error) { return nil, nil }
+func (d *batchDeleteFastPathDB) Delete(key []byte) error        { return nil }
+func (d *batchDeleteFastPathDB) Set(key, value []byte) error    { d.setCalls++; return nil }
+func (d *batchDeleteFastPathDB) NewBatch() (kvstore.Batch, error) {
+	d.newBatchCalls++
+	return d.newTrackedBatch(), nil
+}
+func (d *batchDeleteFastPathDB) newTrackedBatch() *batchDeleteFastPathBatch {
+	b := &batchDeleteFastPathBatch{}
+	d.batches = append(d.batches, b)
+	return b
+}
+
+func (d *batchDeleteFastPathDB) NewBatchWithSize(size int) (kvstore.Batch, error) {
+	d.newBatchWithSizeCalls++
+	b := d.newTrackedBatch()
+	b.sizeHint = size
+	return b, nil
+}
+
+type batchDeleteFastPathBatch struct {
+	sizeHint        int
+	deleteCalls     int
+	deleteViewCalls int
+	commitCalls     int
+	resetCalls      int
+	closeCalls      int
+}
+
+func (b *batchDeleteFastPathBatch) Set(key, value []byte) error { return nil }
+func (b *batchDeleteFastPathBatch) Delete(key []byte) error {
+	b.deleteCalls++
+	return nil
+}
+func (b *batchDeleteFastPathBatch) DeleteView(key []byte) error {
+	b.deleteViewCalls++
+	return nil
+}
+func (b *batchDeleteFastPathBatch) Commit() error {
+	b.commitCalls++
+	return nil
+}
+func (b *batchDeleteFastPathBatch) CommitSync() error { return b.Commit() }
+func (b *batchDeleteFastPathBatch) Close() error {
+	b.closeCalls++
+	return nil
+}
+func (b *batchDeleteFastPathBatch) Reset() { b.resetCalls++ }
+
+type batchDeleteFallbackDB struct {
+	newBatchWithSizeCalls int
+	setCalls              int
+	batches               []*batchDeleteFallbackBatch
+}
+
+func (d *batchDeleteFallbackDB) Name() string                   { return "BatchDeleteFallback" }
+func (d *batchDeleteFallbackDB) Close() error                   { return nil }
+func (d *batchDeleteFallbackDB) Get(key []byte) ([]byte, error) { return nil, nil }
+func (d *batchDeleteFallbackDB) Delete(key []byte) error        { return nil }
+func (d *batchDeleteFallbackDB) Set(key, value []byte) error    { d.setCalls++; return nil }
+func (d *batchDeleteFallbackDB) NewBatch() (kvstore.Batch, error) {
+	return d.NewBatchWithSize(0)
+}
+func (d *batchDeleteFallbackDB) NewBatchWithSize(size int) (kvstore.Batch, error) {
+	d.newBatchWithSizeCalls++
+	b := &batchDeleteFallbackBatch{sizeHint: size}
+	d.batches = append(d.batches, b)
+	return b, nil
+}
+
+type batchDeleteFallbackBatch struct {
+	sizeHint    int
+	deleteCalls int
+	commitCalls int
+	closeCalls  int
+}
+
+func (b *batchDeleteFallbackBatch) Set(key, value []byte) error { return nil }
+func (b *batchDeleteFallbackBatch) Delete(key []byte) error {
+	b.deleteCalls++
+	return nil
+}
+func (b *batchDeleteFallbackBatch) Commit() error {
+	b.commitCalls++
+	return nil
+}
+func (b *batchDeleteFallbackBatch) CommitSync() error { return b.Commit() }
+func (b *batchDeleteFallbackBatch) Close() error {
+	b.closeCalls++
+	return nil
+}
+
+func TestRunBenchmark_BatchDelete_ReusesResettableDeleteViewBatch(t *testing.T) {
+	const dbName = "batch_delete_fast_path_mock"
+	var db *batchDeleteFastPathDB
+	RegisterHiddenDB(dbName, func(_ string) (kvstore.DB, error) {
+		db = &batchDeleteFastPathDB{}
+		return db, nil
+	})
+
+	run, err := runBenchmark(BenchConfig{
+		Keys:         5,
+		ValueSize:    16,
+		BatchSize:    2,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       dbName,
+		TestsArg:     "batch_delete",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	if got := run.Results["batch_delete"]["BatchDeleteFastPath"]; got <= 0 {
+		t.Fatalf("batch_delete result=%v want > 0", got)
+	}
+	if db == nil {
+		t.Fatal("expected db to be initialized")
+	}
+	if got, want := db.setCalls, 5; got != want {
+		t.Fatalf("preload Set calls=%d want=%d", got, want)
+	}
+	if got, want := db.newBatchCalls, 0; got != want {
+		t.Fatalf("NewBatch calls=%d want=%d", got, want)
+	}
+	if got, want := db.newBatchWithSizeCalls, 1; got != want {
+		t.Fatalf("NewBatchWithSize calls=%d want=%d", got, want)
+	}
+	if got, want := len(db.batches), 1; got != want {
+		t.Fatalf("batch instances=%d want=%d", got, want)
+	}
+	b := db.batches[0]
+	if got, want := b.sizeHint, 2; got != want {
+		t.Fatalf("size hint=%d want=%d", got, want)
+	}
+	if got, want := b.deleteViewCalls, 5; got != want {
+		t.Fatalf("DeleteView calls=%d want=%d", got, want)
+	}
+	if got, want := b.deleteCalls, 0; got != want {
+		t.Fatalf("Delete calls=%d want=%d", got, want)
+	}
+	if got, want := b.commitCalls, 3; got != want {
+		t.Fatalf("Commit calls=%d want=%d", got, want)
+	}
+	if got, want := b.resetCalls, 2; got != want {
+		t.Fatalf("Reset calls=%d want=%d", got, want)
+	}
+	if got, want := b.closeCalls, 1; got != want {
+		t.Fatalf("Close calls=%d want=%d", got, want)
+	}
+}
+
+func TestRunBenchmark_BatchDelete_FallsBackWithoutDeleteViewOrReset(t *testing.T) {
+	const dbName = "batch_delete_fallback_mock"
+	var db *batchDeleteFallbackDB
+	RegisterHiddenDB(dbName, func(_ string) (kvstore.DB, error) {
+		db = &batchDeleteFallbackDB{}
+		return db, nil
+	})
+
+	run, err := runBenchmark(BenchConfig{
+		Keys:         5,
+		ValueSize:    16,
+		BatchSize:    2,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       dbName,
+		TestsArg:     "batch_delete",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	if got := run.Results["batch_delete"]["BatchDeleteFallback"]; got <= 0 {
+		t.Fatalf("batch_delete result=%v want > 0", got)
+	}
+	if db == nil {
+		t.Fatal("expected db to be initialized")
+	}
+	if got, want := db.setCalls, 5; got != want {
+		t.Fatalf("preload Set calls=%d want=%d", got, want)
+	}
+	if got, want := db.newBatchWithSizeCalls, 3; got != want {
+		t.Fatalf("NewBatchWithSize calls=%d want=%d", got, want)
+	}
+	if got, want := len(db.batches), 3; got != want {
+		t.Fatalf("batch instances=%d want=%d", got, want)
+	}
+	for i, b := range db.batches {
+		if got, want := b.sizeHint, 2; got != want {
+			t.Fatalf("batch %d size hint=%d want=%d", i, got, want)
+		}
+		if got := b.deleteCalls; got == 0 {
+			t.Fatalf("batch %d Delete calls=%d want > 0", i, got)
+		}
+		if got, want := b.commitCalls, 1; got != want {
+			t.Fatalf("batch %d Commit calls=%d want=%d", i, got, want)
+		}
+		if got, want := b.closeCalls, 1; got != want {
+			t.Fatalf("batch %d Close calls=%d want=%d", i, got, want)
+		}
+	}
+}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -2636,6 +2636,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if err != nil {
 					return err
 				}
+				if batch == nil {
+					return fmt.Errorf("batch_delete: new batch returned nil")
+				}
 				deleteOp = batch.Delete
 				if dv, ok := batch.(batchDeleteView); ok {
 					deleteOp = dv.DeleteView
@@ -2646,10 +2649,18 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				}
 				return nil
 			}
-			defer func() {
-				if batch != nil {
-					_ = batch.Close()
+			closeBatch := func() error {
+				if batch == nil {
+					return nil
 				}
+				b := batch
+				batch = nil
+				deleteOp = nil
+				resetBatch = nil
+				return b.Close()
+			}
+			defer func() {
+				_ = closeBatch()
 			}()
 
 			const keySize = 8
@@ -2681,10 +2692,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				} else if resetBatch != nil {
 					resetBatch()
 				} else {
-					if err := batch.Close(); err != nil {
+					if err := closeBatch(); err != nil {
 						return 0, fmt.Errorf("batch_delete: close: %w", err)
 					}
-					batch = nil
 					if err := openBatch(); err != nil {
 						return 0, fmt.Errorf("batch_delete: new batch: %w", err)
 					}
@@ -2698,19 +2708,18 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					offset := j * keySize
 					key := allKeys[offset : offset+keySize]
 					if err := deleteOp(key); err != nil {
-						_ = batch.Close()
+						_ = closeBatch()
 						return 0, fmt.Errorf("batch_delete: delete: %w", err)
 					}
 				}
 				if err := batch.Commit(); err != nil {
-					_ = batch.Close()
+					_ = closeBatch()
 					return 0, fmt.Errorf("batch_delete: commit: %w", err)
 				}
 				if resetBatch == nil {
-					if err := batch.Close(); err != nil {
+					if err := closeBatch(); err != nil {
 						return 0, fmt.Errorf("batch_delete: close: %w", err)
 					}
-					batch = nil
 				}
 				if err := pc.Add(db, end-i, int64(end-i)*perOpBytes); err != nil {
 					return 0, fmt.Errorf("batch_delete checkpoint: %w", err)

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -2612,6 +2612,45 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			}
 			total := cfg.Keys
 			batchSize := cfg.BatchSize
+			type batcherWithSize interface {
+				NewBatchWithSize(size int) (kvstore.Batch, error)
+			}
+			type batchDeleteView interface {
+				DeleteView(key []byte) error
+			}
+			type resettableBatch interface {
+				Reset()
+			}
+			var (
+				batch      kvstore.Batch
+				deleteOp   func(key []byte) error
+				resetBatch func()
+			)
+			openBatch := func() error {
+				var err error
+				if bs, ok := batcher.(batcherWithSize); ok {
+					batch, err = bs.NewBatchWithSize(batchSize)
+				} else {
+					batch, err = batcher.NewBatch()
+				}
+				if err != nil {
+					return err
+				}
+				deleteOp = batch.Delete
+				if dv, ok := batch.(batchDeleteView); ok {
+					deleteOp = dv.DeleteView
+				}
+				resetBatch = nil
+				if rb, ok := batch.(resettableBatch); ok {
+					resetBatch = rb.Reset
+				}
+				return nil
+			}
+			defer func() {
+				if batch != nil {
+					_ = batch.Close()
+				}
+			}()
 
 			const keySize = 8
 			allKeys := make([]byte, total*keySize)
@@ -2635,9 +2674,20 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 						return 0, err
 					}
 				}
-				batch, err := batcher.NewBatch()
-				if err != nil {
-					return 0, fmt.Errorf("batch_delete: new batch: %w", err)
+				if batch == nil {
+					if err := openBatch(); err != nil {
+						return 0, fmt.Errorf("batch_delete: new batch: %w", err)
+					}
+				} else if resetBatch != nil {
+					resetBatch()
+				} else {
+					if err := batch.Close(); err != nil {
+						return 0, fmt.Errorf("batch_delete: close: %w", err)
+					}
+					batch = nil
+					if err := openBatch(); err != nil {
+						return 0, fmt.Errorf("batch_delete: new batch: %w", err)
+					}
 				}
 
 				end := i + batchSize
@@ -2647,7 +2697,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				for j := i; j < end; j++ {
 					offset := j * keySize
 					key := allKeys[offset : offset+keySize]
-					if err := batch.Delete(key); err != nil {
+					if err := deleteOp(key); err != nil {
 						_ = batch.Close()
 						return 0, fmt.Errorf("batch_delete: delete: %w", err)
 					}
@@ -2656,8 +2706,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					_ = batch.Close()
 					return 0, fmt.Errorf("batch_delete: commit: %w", err)
 				}
-				if err := batch.Close(); err != nil {
-					return 0, fmt.Errorf("batch_delete: close: %w", err)
+				if resetBatch == nil {
+					if err := batch.Close(); err != nil {
+						return 0, fmt.Errorf("batch_delete: close: %w", err)
+					}
+					batch = nil
 				}
 				if err := pc.Add(db, end-i, int64(end-i)*perOpBytes); err != nil {
 					return 0, fmt.Errorf("batch_delete checkpoint: %w", err)


### PR DESCRIPTION
## Summary
- consolidate the append-only write-path optimization stack onto a direct `main` review branch
- include the append-only entry-hint, predictive growth-floor, compact entry-layout, batch-delete reuse, lazy latest-index, and leaf-payload allocation cleanups
- preserve the shared predictive-hint growth-floor fix that closes the throughput gap observed when reconstructing the stack from split PRs

## Validation
- `go test ./TreeDB/internal/memtable ./TreeDB/caching ./TreeDB/page ./TreeDB/internal/valuelog ./cmd/unified_bench`
- `go test ./TreeDB -run ReopenVerify`
- `go test ./TreeDB/db -run ValueLogGC`
- fresh-built exact benchmark on the consolidated branch:
  - `go build -o /tmp/unified-bench-prchain-confirm-fix ./cmd/unified_bench`
  - `/tmp/unified-bench-prchain-confirm-fix -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_chain_confirm_fix_nPXV6T -test batch_delete`
  - `Batch Delete: 28,216,824`
  - `alloc_space: 548.75MB`
  - `getAppendOnlyEntriesFromPool: 360MB`

## Notes
This is the direct-to-`main` equivalent of the earlier local `ccaea03659` stack, updated with the follow-up shared-hint growth-floor fix (`Share append-only predictive hint growth floor`) that was required to reproduce the old throughput range after splitting the work into reviewable PRs.