### PR TITLE
Optimize adaptive append-only batch workloads

### DIFF
--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -371,8 +371,9 @@ func (b *Batch) SetView(key, value []byte) error {
 	return nil
 }
 
-// SetStealView records a Put without copying key/value bytes and allows higher
-// layers to retain those slices beyond the batch lifetime.
+// SetStealView records a Put without copying key/value bytes. This in-memory
+// batch implementation treats it the same as SetView: callers must keep
+// key/value immutable until the batch is committed or closed.
 func (b *Batch) SetStealView(key, value []byte) error {
 	return b.SetView(key, value)
 }

--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -371,6 +371,12 @@ func (b *Batch) SetView(key, value []byte) error {
 	return nil
 }
 
+// SetStealView records a Put without copying key/value bytes and allows higher
+// layers to retain those slices beyond the batch lifetime.
+func (b *Batch) SetStealView(key, value []byte) error {
+	return b.SetView(key, value)
+}
+
 // Set adds or replaces a key/value operation.
 func (b *Batch) Set(key, value []byte) error {
 	if err := b.ensureOpen(); err != nil {

--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -371,9 +371,12 @@ func (b *Batch) SetView(key, value []byte) error {
 	return nil
 }
 
-// SetStealView records a Put without copying key/value bytes. This in-memory
-// batch implementation treats it the same as SetView: callers must keep
-// key/value immutable until the batch is committed or closed.
+// SetStealView records a Put without copying key/value bytes. Callers must
+// treat key/value as transferred to the batch and must not mutate or reuse them
+// after this call, because other batch implementations may retain the provided
+// slices beyond Write/WriteSync or Close. This in-memory batch currently
+// delegates to SetView internally, but callers must not rely on that weaker
+// lifetime.
 func (b *Batch) SetStealView(key, value []byte) error {
 	return b.SetView(key, value)
 }

--- a/TreeDB/caching/batch_arena_ownership_test.go
+++ b/TreeDB/caching/batch_arena_ownership_test.go
@@ -3,11 +3,19 @@ package caching
 import (
 	"bytes"
 	"testing"
+	"unsafe"
 
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 )
+
+func batchArenaChunkPtr(buf []byte) unsafe.Pointer {
+	if cap(buf) == 0 {
+		return nil
+	}
+	return unsafe.Pointer(unsafe.SliceData(buf[:1]))
+}
 
 func TestBatchReset_DoesNotCorruptPriorBorrowedWrites(t *testing.T) {
 	for _, mode := range []string{"append_only", "hash_sorted"} {
@@ -57,6 +65,63 @@ func TestBatchReset_DoesNotCorruptPriorBorrowedWrites(t *testing.T) {
 				t.Fatalf("first value corrupted: got=%x want=%x", got, firstVal)
 			}
 		})
+	}
+}
+
+func TestBatchReset_RetainsOwnedCopyArenaForReuse(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir, NewMockBackend(), Options{
+		AllowUnsafe:    true,
+		DisableWAL:     true,
+		MemtableMode:   "hash_sorted",
+		MemtableShards: 1,
+		FlushThreshold: 1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	b := db.NewBatchWithSize(1)
+	value := bytes.Repeat([]byte{0x5A}, 64)
+	if err := b.Set([]byte("k1"), value); err != nil {
+		t.Fatalf("set first: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write first: %v", err)
+	}
+	if got := len(b.copyArenaChunks); got != 1 {
+		t.Fatalf("copyArenaChunks after first write=%d want 1", got)
+	}
+	if cap(b.copyArena) == 0 {
+		t.Fatal("expected retained copy arena after first write")
+	}
+	firstChunkPtr := batchArenaChunkPtr(b.copyArena)
+	if firstChunkPtr == nil {
+		t.Fatal("expected stable retained arena pointer after first write")
+	}
+
+	if err := b.Set([]byte("k2"), value); err != nil {
+		t.Fatalf("set second: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write second: %v", err)
+	}
+	if got := len(b.copyArenaChunks); got != 1 {
+		t.Fatalf("copyArenaChunks after second write=%d want 1", got)
+	}
+	if got := batchArenaChunkPtr(b.copyArena); got != firstChunkPtr {
+		t.Fatalf("copy arena chunk pointer changed across reset reuse: before=%p after=%p", firstChunkPtr, got)
+	}
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if b.copyArena != nil {
+		t.Fatal("expected copyArena to drain on close")
+	}
+	if len(b.copyArenaChunks) != 0 {
+		t.Fatalf("copyArenaChunks after close=%d want 0", len(b.copyArenaChunks))
 	}
 }
 
@@ -503,5 +568,53 @@ func TestBatchSetView_MutationAfterWriteDoesNotCorruptStoredValue(t *testing.T) 
 	stats := db.Stats()
 	if got := stats["treedb.cache.batch_arena.borrow_view_ops_blocked_total"]; got == "0" {
 		t.Fatalf("cache borrow_view_ops_blocked_total=%q want >0", got)
+	}
+}
+
+func TestBatchSetStealView_AvoidsBatchArenaAndWritesValue(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir, NewMockBackend(), Options{
+		AllowUnsafe:    true,
+		DisableWAL:     true,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+		FlushThreshold: 1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	key := []byte("setsteal-key")
+	value := bytes.Repeat([]byte("s"), 32)
+
+	blockedBefore := batchArenaBorrowViewOpsBlockedTotal.Load()
+	b := db.NewBatchWithSize(1)
+	defer func() { _ = b.Close() }()
+	if err := b.SetStealView(key, value); err != nil {
+		t.Fatalf("set steal view: %v", err)
+	}
+	if got := len(b.copyArenaChunks); got != 0 {
+		t.Fatalf("copyArenaChunks before write=%d want 0", got)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := len(b.copyArenaChunks); got != 0 {
+		t.Fatalf("copyArenaChunks after write=%d want 0", got)
+	}
+	if got := db.batchArenaLeaseBytes.Load(); got != 0 {
+		t.Fatalf("batchArenaLeaseBytes=%d want 0", got)
+	}
+	if got := batchArenaBorrowViewOpsBlockedTotal.Load(); got != blockedBefore {
+		t.Fatalf("borrow_view_ops_blocked_total=%d before=%d want unchanged", got, blockedBefore)
+	}
+
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Fatalf("value mismatch: got=%q want=%q", got, value)
 	}
 }

--- a/TreeDB/caching/batch_followup_test.go
+++ b/TreeDB/caching/batch_followup_test.go
@@ -2,12 +2,19 @@ package caching
 
 import (
 	"bytes"
+	"encoding/binary"
 	"path/filepath"
 	"strconv"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/db"
 )
+
+func batchFollowupBE8Key(i uint64) []byte {
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, i)
+	return key
+}
 
 func statUint64Followup(t *testing.T, stats map[string]string, key string) uint64 {
 	t.Helper()
@@ -115,6 +122,75 @@ func TestBatchWrite_DeleteOnlyFastPath_SortedAndUnsorted(t *testing.T) {
 	t.Run("unsorted", func(t *testing.T) { run(t, []string{"b", "a"}) })
 }
 
+func TestBatchWrite_DeleteOnlyEmptyDBNoOp_WALOff(t *testing.T) {
+	run := func(t *testing.T, useView bool) {
+		t.Helper()
+		dir := t.TempDir()
+		backend := NewMockBackend()
+		cache, err := Open(dir, backend, Options{
+			DisableWAL:     true,
+			AllowUnsafe:    true,
+			FlushThreshold: 1 << 20,
+		})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		defer cache.Close()
+
+		b := cache.NewBatch()
+		for _, key := range []string{"k3", "k1", "k2"} {
+			var err error
+			if useView {
+				err = b.DeleteView([]byte(key))
+			} else {
+				err = b.Delete([]byte(key))
+			}
+			if err != nil {
+				_ = b.Close()
+				t.Fatalf("Delete(%q): %v", key, err)
+			}
+		}
+		if err := b.Write(); err != nil {
+			_ = b.Close()
+			t.Fatalf("Write: %v", err)
+		}
+		_ = b.Close()
+
+		if got := backend.writeCalls; got != 0 {
+			t.Fatalf("backend write calls=%d want 0", got)
+		}
+		if got := cache.mutableBytes.Load(); got != 0 {
+			t.Fatalf("mutableBytes=%d want 0", got)
+		}
+
+		cache.mu.RLock()
+		queueLen := len(cache.queue)
+		backendRangeKnown := cache.backendRangeKnown
+		backendRangeValid := cache.backendRange.valid
+		cache.mu.RUnlock()
+
+		if queueLen != 0 {
+			t.Fatalf("queue len=%d want 0", queueLen)
+		}
+		if !backendRangeKnown || backendRangeValid {
+			t.Fatalf("backend range known=%t valid=%t want known empty backend", backendRangeKnown, backendRangeValid)
+		}
+
+		for i := range cache.mutableShards {
+			shard := &cache.mutableShards[i]
+			shard.mu.Lock()
+			got := shard.mem.Len()
+			shard.mu.Unlock()
+			if got != 0 {
+				t.Fatalf("mutable shard %d len=%d want 0", i, got)
+			}
+		}
+	}
+
+	t.Run("delete", func(t *testing.T) { run(t, false) })
+	t.Run("delete_view", func(t *testing.T) { run(t, true) })
+}
+
 func TestBatchWrite_DeleteOnlyFastPath_WALOnWritesDeleteOpsOnly(t *testing.T) {
 	dir := t.TempDir()
 	backend, err := db.Open(db.Options{Dir: dir})
@@ -151,5 +227,172 @@ func TestBatchWrite_DeleteOnlyFastPath_WALOnWritesDeleteOpsOnly(t *testing.T) {
 	}
 	if deleteOps != 3 {
 		t.Fatalf("delete ops=%d want 3", deleteOps)
+	}
+}
+
+func TestBatchWrite_SortedBatchCreatesSingleMutableRoute(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	cache, err := Open(dir, backend, Options{
+		AllowUnsafe:                true,
+		DisableWAL:                 true,
+		RelaxedSync:                true,
+		MemtableMode:               "append_only",
+		MemtableShards:             8,
+		FlushThreshold:             1 << 30,
+		IndexOuterLeavesInValueLog: true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer cache.Close()
+
+	b := cache.NewBatchWithSize(512)
+	defer func() { _ = b.Close() }()
+	for i := uint64(0); i < 512; i++ {
+		key := batchFollowupBE8Key(i)
+		value := append([]byte("v-"), key...)
+		if err := b.Set(key, value); err != nil {
+			t.Fatalf("Set(%d): %v", i, err)
+		}
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	route := cache.currentMutableRoute.Load()
+	if route == nil {
+		t.Fatal("expected current mutable route after sorted batch")
+	}
+	routeEntries := route.normalizedEntries()
+	if len(routeEntries) != 1 {
+		t.Fatalf("route entries=%d want 1", len(routeEntries))
+	}
+
+	var crossShardKey []byte
+	crossShardRoute := -1
+	for _, entry := range routeEntries {
+		for i := uint64(0); i < 512; i++ {
+			key := batchFollowupBE8Key(i)
+			if !keyInRange(entry.rng, key) {
+				continue
+			}
+			if cache.hashShardIndex(key) != int(entry.shardID) {
+				crossShardKey = key
+				crossShardRoute = int(entry.shardID)
+				break
+			}
+		}
+		if crossShardKey != nil {
+			break
+		}
+	}
+	if crossShardKey == nil {
+		t.Fatal("expected at least one routed key whose hash shard differs from route shard")
+	}
+
+	if got := cache.shardIndexForWrite(crossShardKey); got != crossShardRoute {
+		t.Fatalf("shardIndexForWrite=%d want route shard %d", got, crossShardRoute)
+	}
+	if _, _, found := cache.mutableShards[cache.hashShardIndex(crossShardKey)].mem.Get(crossShardKey); found {
+		t.Fatal("hashed shard unexpectedly owns routed key")
+	}
+	if _, _, found := cache.mutableShards[crossShardRoute].mem.Get(crossShardKey); !found {
+		t.Fatal("route shard does not own routed key")
+	}
+
+	got, err := cache.Get(crossShardKey)
+	if err != nil {
+		t.Fatalf("Get(routed): %v", err)
+	}
+	if want := append([]byte("v-"), crossShardKey...); !bytes.Equal(got, want) {
+		t.Fatalf("Get(routed)=%q want %q", got, want)
+	}
+}
+
+func TestBatchWrite_SortedBatchRotatesSingleRoutedShard(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	cache, err := Open(dir, backend, Options{
+		AllowUnsafe:                true,
+		DisableWAL:                 true,
+		RelaxedSync:                true,
+		MemtableMode:               "append_only",
+		MemtableShards:             8,
+		FlushThreshold:             1 << 10,
+		IndexOuterLeavesInValueLog: true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer cache.Close()
+
+	b := cache.NewBatchWithSize(512)
+	defer func() { _ = b.Close() }()
+	value := bytes.Repeat([]byte("x"), 128)
+	for i := uint64(0); i < 512; i++ {
+		key := batchFollowupBE8Key(i)
+		if err := b.Set(key, value); err != nil {
+			t.Fatalf("Set(%d): %v", i, err)
+		}
+	}
+	origFlushCh := cache.flushCh
+	cache.flushCh = nil
+	defer func() { cache.flushCh = origFlushCh }()
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	cache.mu.RLock()
+	queueLen := len(cache.queue)
+	queueShardIDs := append([]uint16(nil), cache.queueShardIDs...)
+	queueRouteModes := append([]uint8(nil), cache.queueRouteModes...)
+	cache.mu.RUnlock()
+
+	if queueLen != 1 {
+		t.Fatalf("queue len=%d want 1", queueLen)
+	}
+	if len(queueRouteModes) != queueLen {
+		t.Fatalf("queue route modes len=%d want %d", len(queueRouteModes), queueLen)
+	}
+	for i, mode := range queueRouteModes {
+		if mode != memtableRouteRanged {
+			t.Fatalf("queue route mode[%d]=%d want %d", i, mode, memtableRouteRanged)
+		}
+	}
+	if route := cache.currentMutableRoute.Load(); route != nil {
+		t.Fatalf("expected current mutable route to clear after routed rotation, got entries=%d", len(route.normalizedEntries()))
+	}
+
+	var routedKey []byte
+	for _, queuedShardID := range queueShardIDs {
+		queuedShard := int(queuedShardID)
+		for i := uint64(0); i < 512; i++ {
+			key := batchFollowupBE8Key(i)
+			if cache.hashShardIndex(key) != queuedShard {
+				routedKey = key
+				break
+			}
+		}
+		if routedKey != nil {
+			break
+		}
+	}
+	if routedKey == nil {
+		t.Fatal("expected queued routed key whose hash shard differs from queued shard")
+	}
+
+	got, err := cache.Get(routedKey)
+	if err != nil {
+		t.Fatalf("Get(queued routed): %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Fatalf("Get(queued routed) len=%d want %d", len(got), len(value))
 	}
 }

--- a/TreeDB/caching/batch_followup_test.go
+++ b/TreeDB/caching/batch_followup_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func batchFollowupBE8Key(i uint64) []byte {
@@ -442,5 +443,103 @@ func TestBatchWrite_SortedBatchRotatesSingleRoutedShard(t *testing.T) {
 	}
 	if !bytes.Equal(got, value) {
 		t.Fatalf("Get(queued routed) len=%d want %d", len(got), len(value))
+	}
+}
+
+func TestFlushOneLockedDequeuesQueueRouteModes(t *testing.T) {
+	backend := NewMockBackend()
+	cache, err := Open(t.TempDir(), backend, Options{
+		AllowUnsafe:        true,
+		DisableWAL:         true,
+		RelaxedSync:        true,
+		MemtableMode:       "append_only",
+		MemtableShards:     8,
+		FlushThreshold:     1 << 30,
+		MaxQueuedMemtables: -1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer cache.Close()
+
+	cache.flushMu.Lock()
+	defer cache.flushMu.Unlock()
+
+	first, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("new first memtable: %v", err)
+	}
+	second, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("new second memtable: %v", err)
+	}
+
+	first.Set([]byte("hashed-first"), []byte("hashed-value"))
+
+	const routedShard = 3
+	var routedKey []byte
+	for i := uint64(0); ; i++ {
+		key := batchFollowupBE8Key(i)
+		if cache.hashShardIndex(key) != routedShard {
+			routedKey = key
+			break
+		}
+	}
+	value := bytes.Repeat([]byte("x"), 128)
+	second.Set(routedKey, value)
+	first.Freeze()
+	second.Freeze()
+
+	routedRange := keyRange{}
+	routedRange.add(routedKey)
+
+	cache.mu.Lock()
+	cache.queue = []memtable.Table{first, second}
+	cache.queueShardIDs = []uint16{0, routedShard}
+	cache.queueRouteModes = []uint8{memtableRouteHashed, memtableRouteRanged}
+	cache.queueLaneIDs = []uint16{0, 0}
+	cache.queueIDs = []uint64{1, 2}
+	cache.queueEnqueueNS = []int64{time.Now().UnixNano(), time.Now().UnixNano()}
+	cache.queueRanges = []keyRange{{}, routedRange}
+	cache.queueWALPaths = nil
+	cache.queueValueLogPaths = nil
+	cache.queueBacklogBytes.Store(first.Size() + second.Size())
+	cache.publishMemtablesLocked()
+	if len(cache.queue) != 2 {
+		cache.mu.Unlock()
+		t.Fatalf("queue len before flush=%d want 2", len(cache.queue))
+	}
+	if len(cache.queueRouteModes) != len(cache.queue) {
+		cache.mu.Unlock()
+		t.Fatalf("queue route modes len=%d want %d", len(cache.queueRouteModes), len(cache.queue))
+	}
+	if cache.queueRouteModes[0] != memtableRouteHashed || cache.queueRouteModes[1] != memtableRouteRanged {
+		modes := append([]uint8(nil), cache.queueRouteModes...)
+		cache.mu.Unlock()
+		t.Fatalf("queue route modes before flush=%v want [%d %d]", modes, memtableRouteHashed, memtableRouteRanged)
+	}
+	cache.mu.Unlock()
+
+	if !cache.flushOneLocked(false) {
+		t.Fatal("flushOneLocked returned false")
+	}
+
+	cache.mu.RLock()
+	queueLen := len(cache.queue)
+	queueRouteModes := append([]uint8(nil), cache.queueRouteModes...)
+	cache.mu.RUnlock()
+	if queueLen != 1 {
+		t.Fatalf("queue len after one flush=%d want 1", queueLen)
+	}
+	if len(queueRouteModes) != 1 || queueRouteModes[0] != memtableRouteRanged {
+		t.Fatalf("queue route modes after one flush=%v want [%d]", queueRouteModes, memtableRouteRanged)
+	}
+
+	got, err := cache.Get(routedKey)
+	if err != nil {
+		t.Fatalf("Get(routed after one flush): %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Fatalf("Get(routed after one flush) len=%d want %d", len(got), len(value))
 	}
 }

--- a/TreeDB/caching/batch_followup_test.go
+++ b/TreeDB/caching/batch_followup_test.go
@@ -342,9 +342,8 @@ func TestBatchWrite_SortedBatchRotatesSingleRoutedShard(t *testing.T) {
 			t.Fatalf("Set(%d): %v", i, err)
 		}
 	}
-	origFlushCh := cache.flushCh
-	cache.flushCh = nil
-	defer func() { cache.flushCh = origFlushCh }()
+	cache.flushMu.Lock()
+	defer cache.flushMu.Unlock()
 	if err := b.WriteSync(); err != nil {
 		t.Fatalf("Write: %v", err)
 	}

--- a/TreeDB/caching/batch_followup_test.go
+++ b/TreeDB/caching/batch_followup_test.go
@@ -218,16 +218,12 @@ func TestBatchWrite_DeleteOnlyEmptyDBNoOp_LockOrder(t *testing.T) {
 		done <- b.Write()
 	}()
 
-	heldWriteMu := false
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if cache.writeMu.TryLock() {
-			cache.writeMu.Unlock()
-			time.Sleep(time.Millisecond)
-			continue
-		}
-		heldWriteMu = true
-		break
+	// Give the writer goroutine a brief chance to reach any attempted writeMu
+	// acquisition. The success path should not wait for the full blocked write.
+	time.Sleep(10 * time.Millisecond)
+	heldWriteMu := !cache.writeMu.TryLock()
+	if !heldWriteMu {
+		cache.writeMu.Unlock()
 	}
 	cache.flushMu.Unlock()
 

--- a/TreeDB/caching/batch_followup_test.go
+++ b/TreeDB/caching/batch_followup_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/db"
 )
@@ -189,6 +190,54 @@ func TestBatchWrite_DeleteOnlyEmptyDBNoOp_WALOff(t *testing.T) {
 
 	t.Run("delete", func(t *testing.T) { run(t, false) })
 	t.Run("delete_view", func(t *testing.T) { run(t, true) })
+}
+
+func TestBatchWrite_DeleteOnlyEmptyDBNoOp_LockOrder(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+	cache, err := Open(dir, backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer cache.Close()
+
+	b := cache.NewBatch()
+	if err := b.Delete([]byte("missing")); err != nil {
+		_ = b.Close()
+		t.Fatalf("Delete: %v", err)
+	}
+
+	cache.flushMu.Lock()
+	done := make(chan error, 1)
+	go func() {
+		done <- b.Write()
+	}()
+
+	heldWriteMu := false
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if cache.writeMu.TryLock() {
+			cache.writeMu.Unlock()
+			time.Sleep(time.Millisecond)
+			continue
+		}
+		heldWriteMu = true
+		break
+	}
+	cache.flushMu.Unlock()
+
+	if err := <-done; err != nil {
+		_ = b.Close()
+		t.Fatalf("Write: %v", err)
+	}
+	_ = b.Close()
+	if heldWriteMu {
+		t.Fatalf("delete-only empty DB fast path acquired writeMu before flushMu")
+	}
 }
 
 func TestBatchWrite_DeleteOnlyFastPath_WALOnWritesDeleteOpsOnly(t *testing.T) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1940,7 +1940,9 @@ const (
 	appendOnlyEntryHintMinEntries                                  = 128
 	appendOnlyEntryHintMaxEntries                                  = 1 << 20
 	adaptiveMinWrites                                              = 1024
+	adaptiveTailSequentialWriteMin                                 = 8 * adaptiveMinWrites
 	adaptiveSequentialWritePct                                     = 0.85
+	adaptiveDeleteWritePct                                         = 0.50
 	adaptiveRangeIteratorPct                                       = 0.40
 	adaptiveOverwriteWritePct                                      = 0.25
 	adaptiveBTreeMinIteratorSamplesDefault                         = 0
@@ -2808,6 +2810,10 @@ type backendBatchReserveHint interface {
 	Reserve(int)
 }
 
+type backendBatchResetter interface {
+	Reset()
+}
+
 type backendBatchSetViewer interface {
 	SetView(key, value []byte) error
 }
@@ -2831,6 +2837,23 @@ func reserveBackendBatchOps(backendBatch batch.Interface, n int) {
 	if r, ok := backendBatch.(backendBatchReserveHint); ok {
 		r.Reserve(n)
 	}
+}
+
+func (db *DB) recycleBackendBatch(backendBatch *batch.Interface, sizeHint, reserveHint int) error {
+	if db == nil || backendBatch == nil || *backendBatch == nil {
+		return errors.New("cachingdb: missing backend batch")
+	}
+	if r, ok := (*backendBatch).(backendBatchResetter); ok {
+		r.Reset()
+		return nil
+	}
+	if err := (*backendBatch).Close(); err != nil {
+		return err
+	}
+	next := db.newBackendBatchWithSize(sizeHint)
+	reserveBackendBatchOps(next, reserveHint)
+	*backendBatch = next
+	return nil
 }
 
 func (db *DB) flushDeferredValueLogMemtable(
@@ -3079,12 +3102,12 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 		if len(unitRuns[i]) == 0 {
 			continue
 		}
-		it := newOpRunIter(unitRuns[i])
-		if !it.Valid() {
+		source := newOpRunIter(unitRuns[i])
+		if !source.Valid() {
 			continue
 		}
 		priority := len(unitRuns) - 1 - i
-		heap = append(heap, opMergeItem{iter: it, priority: priority, key: it.Key()})
+		heap = append(heap, opMergeItem{source: source, priority: priority, key: source.Key()})
 	}
 	for i := len(heap)/2 - 1; i >= 0; i-- {
 		(&heap).down(i, len(heap))
@@ -3231,9 +3254,9 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 			if next != nil && bytes.Equal(next.key, currentKey) {
 				shadowed := heap.pop()
 				shadowedOps++
-				shadowed.iter.Next()
-				if shadowed.iter.Valid() {
-					shadowed.key = shadowed.iter.Key()
+				shadowed.source.Next()
+				if shadowed.source.Valid() {
+					shadowed.key = shadowed.source.Key()
 					heap.push(shadowed)
 				}
 				continue
@@ -3241,7 +3264,7 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 			break
 		}
 
-		entry := top.iter.Entry()
+		entry := top.source.Entry()
 		switch {
 		case entry.Type == batch.OpDelete:
 			if err := flushInlinePointerGroup(); err != nil {
@@ -3294,9 +3317,9 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 			}
 		}
 
-		top.iter.Next()
-		if top.iter.Valid() {
-			top.key = top.iter.Key()
+		top.source.Next()
+		if top.source.Valid() {
+			top.key = top.source.Key()
 			heap.push(top)
 		}
 	}
@@ -5685,15 +5708,33 @@ func hashKey(key []byte) uint64 {
 	return xxhash.Sum64(key)
 }
 
-func (db *DB) shardIndex(key []byte) int {
+func (db *DB) hashShardIndex(key []byte) int {
 	if len(db.mutableShards) <= 1 {
 		return 0
 	}
 	return int(hashKey(key) & db.mutableShardMask)
 }
 
+func (db *DB) shardIndex(key []byte) int {
+	return db.hashShardIndex(key)
+}
+
 func (db *DB) shardForKey(key []byte) *memShard {
-	return &db.mutableShards[db.shardIndex(key)]
+	return &db.mutableShards[db.hashShardIndex(key)]
+}
+
+func (db *DB) shardIndexForWrite(key []byte) int {
+	if len(db.mutableShards) <= 1 {
+		return 0
+	}
+	if shardID, ok := mutableRouteShardForWrite(db.currentMutableRoute.Load(), key); ok {
+		return shardID
+	}
+	return db.hashShardIndex(key)
+}
+
+func (db *DB) shardForWriteKey(key []byte) *memShard {
+	return &db.mutableShards[db.shardIndexForWrite(key)]
 }
 
 func (db *DB) laneForShardIndex(shardID int) int {
@@ -6155,8 +6196,10 @@ type DB struct {
 	mutableBytes                  atomic.Int64
 	mutableThreshold              atomic.Int64
 	rotatePending                 atomic.Bool
+	currentMutableRoute           atomic.Pointer[mutableRouteState]
 	queue                         []memtable.Table
 	queueShardIDs                 []uint16
+	queueRouteModes               []uint8
 	queueLaneIDs                  []uint16
 	queueIDs                      []uint64
 	queueEnqueueNS                []int64
@@ -7075,6 +7118,22 @@ type keyRange struct {
 	max   []byte
 }
 
+const (
+	memtableRouteHashed uint8 = iota
+	memtableRouteRanged
+)
+
+type mutableRouteEntry struct {
+	shardID uint16
+	rng     keyRange
+}
+
+type mutableRouteState struct {
+	shardID uint16
+	rng     keyRange
+	entries []mutableRouteEntry
+}
+
 type memShard struct {
 	mu                         sync.Mutex
 	mem                        memtable.Table
@@ -7090,7 +7149,9 @@ type memtableView struct {
 	mutables                 []memtable.Table
 	queue                    []memtable.Table
 	queueShardIDs            []uint16
+	queueRouteModes          []uint8
 	queueRanges              []keyRange
+	mutableRoute             *mutableRouteState
 	refs                     atomic.Int64
 	retiredMems              []memtable.Table
 	deferredRetiredMemtables atomic.Int64
@@ -7392,6 +7453,56 @@ func memtableBatchSet(mt memtable.Table, useSteal bool, allowBorrow bool, storeI
 		}
 	}
 	mt.Set(op.Key, op.Value)
+}
+
+func memtableBatchBorrowsValues(mt memtable.Table, allowBorrow bool, storeInlinePtrValues bool, entries []batch.Entry) bool {
+	if !allowBorrow || len(entries) == 0 {
+		return false
+	}
+	if _, ok := mt.(memtable.ValueBorrower); !ok {
+		return false
+	}
+	for i := range entries {
+		op := entries[i]
+		if op.Type == batch.OpDelete {
+			continue
+		}
+		if op.IsPtr {
+			if storeInlinePtrValues && len(op.Value) > 0 {
+				return true
+			}
+			continue
+		}
+		if len(op.Value) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func memtableBatchBorrowsValuesIdxs(mt memtable.Table, allowBorrow bool, storeInlinePtrValues bool, entries []batch.Entry, idxs []int) bool {
+	if !allowBorrow || len(idxs) == 0 {
+		return false
+	}
+	if _, ok := mt.(memtable.ValueBorrower); !ok {
+		return false
+	}
+	for _, idx := range idxs {
+		op := entries[idx]
+		if op.Type == batch.OpDelete {
+			continue
+		}
+		if op.IsPtr {
+			if storeInlinePtrValues && len(op.Value) > 0 {
+				return true
+			}
+			continue
+		}
+		if len(op.Value) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func getBatchArenaLease(refs int, chunks [][]byte) *batchArenaLease {
@@ -7784,11 +7895,17 @@ func (db *DB) publishMemtablesLocked() {
 		copy(qs, db.queueShardIDs)
 		view.queueShardIDs = qs
 	}
+	if len(db.queueRouteModes) > 0 {
+		qm := make([]uint8, len(db.queueRouteModes))
+		copy(qm, db.queueRouteModes)
+		view.queueRouteModes = qm
+	}
 	if len(db.queueRanges) > 0 {
 		qr := make([]keyRange, len(db.queueRanges))
 		copy(qr, db.queueRanges)
 		view.queueRanges = qr
 	}
+	view.mutableRoute = cloneMutableRoute(db.currentMutableRoute.Load())
 	view.refs.Store(1)
 	retired := db.pendingRetiredMems
 	db.pendingRetiredMems = nil
@@ -7819,12 +7936,201 @@ func (db *DB) ensureQueueLaneIDsLocked() {
 	db.queueLaneIDs = append(db.queueLaneIDs, make([]uint16, missing)...)
 }
 
+func (db *DB) setCurrentMutableRouteLocked(shardID int, rng keyRange) {
+	if db == nil {
+		return
+	}
+	if shardID < 0 || shardID >= len(db.mutableShards) || !rng.valid {
+		db.currentMutableRoute.Store(nil)
+		return
+	}
+	rng = cloneRange(rng)
+	db.currentMutableRoute.Store(&mutableRouteState{
+		shardID: uint16(shardID),
+		rng:     cloneRange(rng),
+		entries: []mutableRouteEntry{{
+			shardID: uint16(shardID),
+			rng:     rng,
+		}},
+	})
+}
+
+func (db *DB) clearCurrentMutableRouteLocked() {
+	if db == nil {
+		return
+	}
+	db.currentMutableRoute.Store(nil)
+}
+
+func (db *DB) extendCurrentMutableRouteLocked(first, last []byte) *mutableRouteState {
+	if db == nil || len(first) == 0 || len(last) == 0 {
+		return db.currentMutableRoute.Load()
+	}
+	route := cloneMutableRoute(db.currentMutableRoute.Load())
+	if route == nil {
+		return nil
+	}
+	rng := keyRange{}
+	rng.add(first)
+	rng.add(last)
+	route = route.withEntryRange(int(route.shardID), rng)
+	db.currentMutableRoute.Store(route)
+	return route
+}
+
+func (db *DB) pickMutableRouteShardsLocked(target int, avoid map[int]struct{}) []int {
+	if target <= 0 || len(db.mutableShards) == 0 {
+		return nil
+	}
+	if target > len(db.mutableShards) {
+		target = len(db.mutableShards)
+	}
+	type shardUsage struct {
+		idx   int
+		bytes int64
+	}
+	usages := make([]shardUsage, 0, len(db.mutableShards))
+	for i := range db.mutableShards {
+		if _, skip := avoid[i]; skip {
+			continue
+		}
+		shard := &db.mutableShards[i]
+		shard.mu.Lock()
+		bytes := shard.bytes
+		shard.mu.Unlock()
+		usages = append(usages, shardUsage{idx: i, bytes: bytes})
+	}
+	sort.Slice(usages, func(i, j int) bool {
+		if usages[i].bytes == usages[j].bytes {
+			return usages[i].idx < usages[j].idx
+		}
+		return usages[i].bytes < usages[j].bytes
+	})
+	out := make([]int, 0, target)
+	for _, usage := range usages {
+		out = append(out, usage.idx)
+		if len(out) == target {
+			break
+		}
+	}
+	return out
+}
+
+func (db *DB) mutableRouteShardTargetLocked(entryCount int) int {
+	if len(db.mutableShards) <= 1 {
+		return len(db.mutableShards)
+	}
+	return 1
+}
+
+func (db *DB) canStartMutableRouteSetLocked() bool {
+	if db == nil {
+		return false
+	}
+	return len(db.queue) == 0 && db.queueBacklogBytes.Load() == 0
+}
+
+func routeEntriesForSortedBatch(entries []batch.Entry, shardIDs []int) []mutableRouteEntry {
+	if len(entries) == 0 || len(shardIDs) == 0 {
+		return nil
+	}
+	if len(shardIDs) > len(entries) {
+		shardIDs = shardIDs[:len(entries)]
+	}
+	out := make([]mutableRouteEntry, 0, len(shardIDs))
+	n := len(entries)
+	for i, shardID := range shardIDs {
+		start := (i * n) / len(shardIDs)
+		end := ((i + 1) * n) / len(shardIDs)
+		if start >= end {
+			continue
+		}
+		rng := keyRange{}
+		rng.add(entries[start].Key)
+		rng.add(entries[end-1].Key)
+		if !rng.valid {
+			continue
+		}
+		out = append(out, mutableRouteEntry{
+			shardID: uint16(shardID),
+			rng:     cloneRange(rng),
+		})
+	}
+	return out
+}
+
+func (db *DB) ensureMutableRouteForSortedBatchLocked(entries []batch.Entry) (bool, error) {
+	if db == nil || len(entries) == 0 || len(db.mutableShards) == 0 {
+		return false, nil
+	}
+	firstKey := entries[0].Key
+	lastKey := entries[len(entries)-1].Key
+	if len(firstKey) == 0 || len(lastKey) == 0 {
+		return false, nil
+	}
+	route := cloneMutableRoute(db.currentMutableRoute.Load())
+	if route == nil && !db.canStartMutableRouteSetLocked() {
+		return false, nil
+	}
+	target := db.mutableRouteShardTargetLocked(len(entries))
+	if target <= 0 {
+		return false, nil
+	}
+	shardIDs := route.shardIDs()
+	if len(shardIDs) > target {
+		shardIDs = append([]int(nil), shardIDs[:target]...)
+	}
+	if len(shardIDs) < target {
+		avoid := make(map[int]struct{}, len(shardIDs))
+		for _, shardID := range shardIDs {
+			avoid[shardID] = struct{}{}
+		}
+		shardIDs = append(shardIDs, db.pickMutableRouteShardsLocked(target-len(shardIDs), avoid)...)
+	}
+	if len(shardIDs) == 0 {
+		return false, nil
+	}
+	for _, shardID := range shardIDs {
+		if shardID < 0 || shardID >= len(db.mutableShards) {
+			continue
+		}
+		shard := &db.mutableShards[shardID]
+		shard.mu.Lock()
+		occupied := shard.bytes > 0 || shard.rng.valid || shard.mem.Len() > 0
+		shard.mu.Unlock()
+		if occupied && (route == nil || !route.hasShard(shardID)) {
+			if err := db.rotateMutableShardsSelectedLocked([]int{shardID}, -1, true, nil); err != nil {
+				return false, err
+			}
+		}
+	}
+	route = cloneMutableRoute(db.currentMutableRoute.Load())
+	if route == nil {
+		route = &mutableRouteState{}
+	}
+	for _, entry := range routeEntriesForSortedBatch(entries, shardIDs) {
+		route = route.withEntryRange(int(entry.shardID), entry.rng)
+	}
+	db.currentMutableRoute.Store(route)
+	db.publishMemtablesLocked()
+	return true, nil
+}
+
+func queueRouteModeForMutableRoute(route *mutableRouteState, shardID int) uint8 {
+	if route != nil && route.hasShard(shardID) {
+		return memtableRouteRanged
+	}
+	return memtableRouteHashed
+}
+
 type memtableStats struct {
 	writes          atomic.Uint64
 	seqWrites       atomic.Uint64
 	overwriteWrites atomic.Uint64
+	deleteWrites    atomic.Uint64
 	iterators       atomic.Uint64
 	rangeIters      atomic.Uint64
+	currentSeqRun   atomic.Uint64
 	lastKeyMu       sync.Mutex
 	lastKey         []byte
 	hasLastKey      bool
@@ -7837,6 +8143,8 @@ const (
 	adaptiveDecisionBTreeRange
 	adaptiveDecisionBTreeBlockedMinIters
 	adaptiveDecisionAppendSequential
+	adaptiveDecisionAppendDeletes
+	adaptiveDecisionAppendWriteHeavy
 	adaptiveDecisionHashMixed
 )
 
@@ -7850,6 +8158,10 @@ func adaptiveDecisionReasonString(v uint32) string {
 		return "btree_blocked_min_iters"
 	case adaptiveDecisionAppendSequential:
 		return "append_sequential"
+	case adaptiveDecisionAppendDeletes:
+		return "append_deletes"
+	case adaptiveDecisionAppendWriteHeavy:
+		return "append_write_heavy"
 	case adaptiveDecisionHashMixed:
 		return "hash_mixed"
 	default:
@@ -7987,6 +8299,199 @@ func cloneRange(r keyRange) keyRange {
 	return r
 }
 
+func (route *mutableRouteState) normalizedEntries() []mutableRouteEntry {
+	if route == nil {
+		return nil
+	}
+	if len(route.entries) > 0 {
+		return route.entries
+	}
+	if !route.rng.valid {
+		return nil
+	}
+	return []mutableRouteEntry{{
+		shardID: route.shardID,
+		rng:     route.rng,
+	}}
+}
+
+func (route *mutableRouteState) shardIDs() []int {
+	entries := route.normalizedEntries()
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]int, 0, len(entries))
+	for _, entry := range entries {
+		shardID := int(entry.shardID)
+		seen := false
+		for _, existing := range out {
+			if existing == shardID {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			out = append(out, shardID)
+		}
+	}
+	return out
+}
+
+func (route *mutableRouteState) hasShard(shardID int) bool {
+	for _, entry := range route.normalizedEntries() {
+		if int(entry.shardID) == shardID {
+			return true
+		}
+	}
+	return false
+}
+
+func (route *mutableRouteState) withEntryRange(shardID int, rng keyRange) *mutableRouteState {
+	if shardID < 0 || !rng.valid {
+		return route
+	}
+	if route == nil {
+		route = &mutableRouteState{}
+	}
+	entries := route.normalizedEntries()
+	next := &mutableRouteState{}
+	next.entries = make([]mutableRouteEntry, 0, len(entries)+1)
+	merged := cloneRange(rng)
+	for _, entry := range entries {
+		if int(entry.shardID) == shardID {
+			merged.add(entry.rng.min)
+			merged.add(entry.rng.max)
+			continue
+		}
+		next.entries = append(next.entries, mutableRouteEntry{
+			shardID: entry.shardID,
+			rng:     cloneRange(entry.rng),
+		})
+	}
+	next.entries = append(next.entries, mutableRouteEntry{
+		shardID: uint16(shardID),
+		rng:     cloneRange(merged),
+	})
+	for i, entry := range next.entries {
+		if i == 0 {
+			next.rng = cloneRange(entry.rng)
+		} else {
+			next.rng.add(entry.rng.min)
+			next.rng.add(entry.rng.max)
+		}
+	}
+	last := next.entries[len(next.entries)-1]
+	next.shardID = last.shardID
+	return next
+}
+
+func (route *mutableRouteState) withoutShards(shardIDs map[int]struct{}) *mutableRouteState {
+	if route == nil || len(shardIDs) == 0 {
+		return route
+	}
+	entries := route.normalizedEntries()
+	if len(entries) == 0 {
+		return nil
+	}
+	next := &mutableRouteState{entries: make([]mutableRouteEntry, 0, len(entries))}
+	for _, entry := range entries {
+		if _, remove := shardIDs[int(entry.shardID)]; remove {
+			continue
+		}
+		next.entries = append(next.entries, mutableRouteEntry{
+			shardID: entry.shardID,
+			rng:     cloneRange(entry.rng),
+		})
+	}
+	if len(next.entries) == 0 {
+		return nil
+	}
+	for i, entry := range next.entries {
+		if i == 0 {
+			next.rng = cloneRange(entry.rng)
+		} else {
+			next.rng.add(entry.rng.min)
+			next.rng.add(entry.rng.max)
+		}
+	}
+	next.shardID = next.entries[len(next.entries)-1].shardID
+	return next
+}
+
+func cloneMutableRoute(route *mutableRouteState) *mutableRouteState {
+	if route == nil {
+		return nil
+	}
+	cloned := &mutableRouteState{
+		shardID: route.shardID,
+		rng:     cloneRange(route.rng),
+	}
+	if len(route.entries) > 0 {
+		cloned.entries = make([]mutableRouteEntry, len(route.entries))
+		for i := range route.entries {
+			cloned.entries[i] = mutableRouteEntry{
+				shardID: route.entries[i].shardID,
+				rng:     cloneRange(route.entries[i].rng),
+			}
+		}
+	}
+	if !cloned.rng.valid {
+		return nil
+	}
+	return cloned
+}
+
+func keyInRange(r keyRange, key []byte) bool {
+	if !r.valid {
+		return false
+	}
+	if r.min != nil && bytes.Compare(key, r.min) < 0 {
+		return false
+	}
+	if r.max != nil && bytes.Compare(key, r.max) > 0 {
+		return false
+	}
+	return true
+}
+
+func keyInMutableRoute(route *mutableRouteState, key []byte) bool {
+	return forEachMutableRouteShardForKey(route, key, func(int) bool {
+		return true
+	})
+}
+
+func forEachMutableRouteShardForKey(route *mutableRouteState, key []byte, visit func(int) bool) bool {
+	entries := route.normalizedEntries()
+	for i := len(entries) - 1; i >= 0; i-- {
+		entry := entries[i]
+		if !keyInRange(entry.rng, key) {
+			continue
+		}
+		if visit(int(entry.shardID)) {
+			return true
+		}
+	}
+	return false
+}
+
+func mutableRouteShardForWrite(route *mutableRouteState, key []byte) (int, bool) {
+	var shardID int
+	found := forEachMutableRouteShardForKey(route, key, func(idx int) bool {
+		shardID = idx
+		return true
+	})
+	return shardID, found
+}
+
+func containsShardID(shardIDs []int, shardID int) bool {
+	for _, idx := range shardIDs {
+		if idx == shardID {
+			return true
+		}
+	}
+	return false
+}
+
 func (db *DB) snapshotMutableRange() keyRange {
 	var out keyRange
 	for i := range db.mutableShards {
@@ -8013,6 +8518,7 @@ func (db *DB) snapshotMutableRange() keyRange {
 
 func (db *DB) resetMutableShardsLocked(nextMode memtable.Mode, reuse bool) error {
 	db.mutableBytes.Store(0)
+	db.clearCurrentMutableRouteLocked()
 	for i := range db.mutableShards {
 		shard := &db.mutableShards[i]
 		shard.mu.Lock()
@@ -8038,65 +8544,139 @@ func (db *DB) resetMutableShardsLocked(nextMode memtable.Mode, reuse bool) error
 		shard.bytes = 0
 		shard.mu.Unlock()
 	}
-	db.memtableStats.writes.Store(0)
-	db.memtableStats.seqWrites.Store(0)
-	db.memtableStats.overwriteWrites.Store(0)
-	db.memtableStats.iterators.Store(0)
-	db.memtableStats.rangeIters.Store(0)
-	db.memtableStats.lastKeyMu.Lock()
-	db.memtableStats.hasLastKey = false
-	db.memtableStats.lastKeyMu.Unlock()
+	db.resetAdaptiveMemtableStatsLocked()
 	db.updateAdaptiveObservationLocked()
 	db.updateMutableThresholdLocked()
 	db.publishMemtablesLocked()
 	return nil
 }
 
+func (db *DB) resetAdaptiveMemtableStatsLocked() {
+	db.memtableStats.writes.Store(0)
+	db.memtableStats.seqWrites.Store(0)
+	db.memtableStats.overwriteWrites.Store(0)
+	db.memtableStats.deleteWrites.Store(0)
+	db.memtableStats.iterators.Store(0)
+	db.memtableStats.rangeIters.Store(0)
+	db.memtableStats.currentSeqRun.Store(0)
+	db.memtableStats.lastKeyMu.Lock()
+	db.memtableStats.hasLastKey = false
+	db.memtableStats.lastKeyMu.Unlock()
+}
+
 func (db *DB) noteWriteKey(key []byte) {
+	db.noteWriteKeyKind(key, false)
+}
+
+func (db *DB) noteDeleteKey(key []byte) {
+	db.noteWriteKeyKind(key, true)
+}
+
+func (db *DB) noteDeleteBatch(count int) {
+	db.noteWriteBatchWithDeletes(count, count)
+}
+
+func (db *DB) noteWriteBatchWithDeletes(count, deleteCount int) {
+	if !db.memtableAdaptive || !db.memtableAdaptiveObserve.Load() || count <= 0 {
+		return
+	}
+	if deleteCount < 0 {
+		deleteCount = 0
+	}
+	if deleteCount > count {
+		deleteCount = count
+	}
+	stats := &db.memtableStats
+	stats.writes.Add(uint64(count))
+	if deleteCount > 0 {
+		stats.deleteWrites.Add(uint64(deleteCount))
+	}
+	stats.lastKeyMu.Lock()
+	stats.hasLastKey = false
+	stats.lastKeyMu.Unlock()
+	stats.currentSeqRun.Store(0)
+}
+
+func (db *DB) noteWriteKeyKind(key []byte, delete bool) {
 	if !db.memtableAdaptive || !db.memtableAdaptiveObserve.Load() {
 		return
 	}
 	stats := &db.memtableStats
 	stats.writes.Add(1)
+	if delete {
+		stats.deleteWrites.Add(1)
+	}
 	if len(key) == 0 {
 		stats.lastKeyMu.Lock()
 		stats.hasLastKey = false
 		stats.lastKeyMu.Unlock()
+		stats.currentSeqRun.Store(0)
 		return
 	}
 	stats.lastKeyMu.Lock()
 	defer stats.lastKeyMu.Unlock()
+	curRun := uint64(1)
 	if stats.hasLastKey {
 		if bytes.Equal(stats.lastKey, key) {
 			stats.overwriteWrites.Add(1)
 		} else if bytes.Compare(stats.lastKey, key) < 0 {
 			stats.seqWrites.Add(1)
+			curRun = stats.currentSeqRun.Load() + 1
 		}
 	}
 	stats.lastKey = append(stats.lastKey[:0], key...)
 	stats.hasLastKey = true
+	stats.currentSeqRun.Store(curRun)
 }
 
 // noteWriteSortedRun records a strictly increasing key run in one shot.
 func (db *DB) noteWriteSortedRun(first, last []byte, count int) {
+	db.noteWriteSortedRunWithDeletes(first, last, count, 0)
+}
+
+func (db *DB) noteDeleteSortedRun(first, last []byte, count int) {
+	db.noteWriteSortedRunWithDeletes(first, last, count, count)
+}
+
+func (db *DB) noteWriteSortedRunKind(first, last []byte, count int, delete bool) {
+	deleteCount := 0
+	if delete {
+		deleteCount = count
+	}
+	db.noteWriteSortedRunWithDeletes(first, last, count, deleteCount)
+}
+
+func (db *DB) noteWriteSortedRunWithDeletes(first, last []byte, count, deleteCount int) {
 	if !db.memtableAdaptive || !db.memtableAdaptiveObserve.Load() || count <= 0 {
 		return
 	}
+	if deleteCount < 0 {
+		deleteCount = 0
+	}
+	if deleteCount > count {
+		deleteCount = count
+	}
 	stats := &db.memtableStats
 	stats.writes.Add(uint64(count))
+	if deleteCount > 0 {
+		stats.deleteWrites.Add(uint64(deleteCount))
+	}
 	if len(last) == 0 {
 		stats.lastKeyMu.Lock()
 		stats.hasLastKey = false
 		stats.lastKeyMu.Unlock()
+		stats.currentSeqRun.Store(0)
 		return
 	}
 	seqAdds := uint64(0)
+	currentRun := uint64(count)
 	if count > 1 {
 		seqAdds += uint64(count - 1)
 	}
 	stats.lastKeyMu.Lock()
 	if len(first) > 0 && stats.hasLastKey && bytes.Compare(stats.lastKey, first) < 0 {
 		seqAdds++
+		currentRun = stats.currentSeqRun.Load() + uint64(count)
 	}
 	stats.lastKey = append(stats.lastKey[:0], last...)
 	stats.hasLastKey = true
@@ -8104,6 +8684,66 @@ func (db *DB) noteWriteSortedRun(first, last []byte, count int) {
 	if seqAdds > 0 {
 		stats.seqWrites.Add(seqAdds)
 	}
+	stats.currentSeqRun.Store(currentRun)
+}
+
+func (db *DB) shouldRotateForTailSequentialRecovery() bool {
+	if db == nil || !db.memtableAdaptive {
+		return false
+	}
+	writes := db.memtableStats.writes.Load()
+	if writes < adaptiveMinWrites {
+		return false
+	}
+	currentSeqRun := db.memtableStats.currentSeqRun.Load()
+	if currentSeqRun < adaptiveMinWrites {
+		return false
+	}
+	overwriteWrites := db.memtableStats.overwriteWrites.Load()
+	if overwriteWrites == 0 {
+		return true
+	}
+	return float64(overwriteWrites)/float64(writes) < adaptiveOverwriteWritePct
+}
+
+func (db *DB) shouldRotateForDeleteHeavyRecovery() bool {
+	if db == nil || !db.memtableAdaptive {
+		return false
+	}
+	if db.currentMemtableMode() == memtable.ModeAppendOnly {
+		return false
+	}
+	writes := db.memtableStats.writes.Load()
+	if writes < adaptiveMinWrites {
+		return false
+	}
+	deleteWrites := db.memtableStats.deleteWrites.Load()
+	if deleteWrites == 0 {
+		return false
+	}
+	return float64(deleteWrites)/float64(writes) >= adaptiveDeleteWritePct
+}
+
+func (db *DB) mutableNeedsSequentialRecovery() bool {
+	if db == nil {
+		return false
+	}
+	for i := range db.mutableShards {
+		shard := &db.mutableShards[i]
+		shard.mu.Lock()
+		needsRecovery := false
+		switch mt := shard.mem.(type) {
+		case *memtable.AppendOnly:
+			needsRecovery = !mt.Ordered()
+		default:
+			needsRecovery = true
+		}
+		shard.mu.Unlock()
+		if needsRecovery {
+			return true
+		}
+	}
+	return false
 }
 
 func (db *DB) noteIterator(start, end []byte) {
@@ -8177,7 +8817,7 @@ func (db *DB) noteAdaptiveMemtableDecision(
 		db.memtableAdaptiveDecisionBTreeTotal.Add(1)
 	case adaptiveDecisionBTreeBlockedMinIters:
 		db.memtableAdaptiveDecisionBTreeBlockedMinItersTotal.Add(1)
-	case adaptiveDecisionAppendSequential:
+	case adaptiveDecisionAppendSequential, adaptiveDecisionAppendDeletes, adaptiveDecisionAppendWriteHeavy:
 		db.memtableAdaptiveDecisionAppendTotal.Add(1)
 	case adaptiveDecisionHashMixed:
 		db.memtableAdaptiveDecisionHashTotal.Add(1)
@@ -8189,8 +8829,10 @@ func (db *DB) chooseAdaptiveMemtableModeLocked() memtable.Mode {
 	writes := db.memtableStats.writes.Load()
 	seqWrites := db.memtableStats.seqWrites.Load()
 	overwriteWrites := db.memtableStats.overwriteWrites.Load()
+	deleteWrites := db.memtableStats.deleteWrites.Load()
 	iters := db.memtableStats.iterators.Load()
 	rangeIters := db.memtableStats.rangeIters.Load()
+	currentSeqRun := db.memtableStats.currentSeqRun.Load()
 
 	// Default to configured mode if not enough data
 	if writes < adaptiveMinWrites {
@@ -8201,6 +8843,7 @@ func (db *DB) chooseAdaptiveMemtableModeLocked() memtable.Mode {
 
 	seqWritePct := float64(seqWrites) / float64(writes)
 	overwriteWritePct := float64(overwriteWrites) / float64(writes)
+	deleteWritePct := float64(deleteWrites) / float64(writes)
 	rangeIterPct := 0.0
 	if iters > 0 {
 		rangeIterPct = float64(rangeIters) / float64(iters)
@@ -8218,13 +8861,30 @@ func (db *DB) chooseAdaptiveMemtableModeLocked() memtable.Mode {
 		}
 	}
 
-	// 2) Mostly increasing writes with low overwrite pressure favor append-only.
-	if seqWritePct >= adaptiveSequentialWritePct && overwriteWritePct < adaptiveOverwriteWritePct {
+	// 2) Tombstone-heavy writes are append-friendly. Hash-sorted coalescing helps
+	// overwrite-heavy puts, but delete-heavy batches are cheaper as append-only
+	// tombstones and can be deduplicated at flush boundaries.
+	if deleteWritePct >= adaptiveDeleteWritePct {
+		db.noteAdaptiveMemtableDecision(memtable.ModeAppendOnly, adaptiveDecisionAppendDeletes, writes, seqWrites, overwriteWrites, iters, rangeIters, rangeIterPct)
+		return memtable.ModeAppendOnly
+	}
+
+	// 3) Write-heavy, low-overwrite traffic is append-friendly even when keys are
+	// not sequential. Hash-sorted coalescing only pays for itself once overwrites
+	// are common or reads/iterators are actively shaping the workload.
+	if iters == 0 && overwriteWritePct < adaptiveOverwriteWritePct {
+		db.noteAdaptiveMemtableDecision(memtable.ModeAppendOnly, adaptiveDecisionAppendWriteHeavy, writes, seqWrites, overwriteWrites, iters, rangeIters, rangeIterPct)
+		return memtable.ModeAppendOnly
+	}
+
+	// 4) Mostly increasing writes with low overwrite pressure favor append-only.
+	if (seqWritePct >= adaptiveSequentialWritePct || currentSeqRun >= adaptiveTailSequentialWriteMin) &&
+		overwriteWritePct < adaptiveOverwriteWritePct {
 		db.noteAdaptiveMemtableDecision(memtable.ModeAppendOnly, adaptiveDecisionAppendSequential, writes, seqWrites, overwriteWrites, iters, rangeIters, rangeIterPct)
 		return memtable.ModeAppendOnly
 	}
 
-	// 3) Overwrite-heavy or mixed-write traffic defaults to hash-sorted.
+	// 5) Overwrite-heavy or read-shaped mixed-write traffic defaults to hash-sorted.
 	if btreeBlockedByMinIters {
 		db.noteAdaptiveMemtableDecision(memtable.ModeHashSorted, adaptiveDecisionBTreeBlockedMinIters, writes, seqWrites, overwriteWrites, iters, rangeIters, rangeIterPct)
 		return memtable.ModeHashSorted
@@ -8234,11 +8894,23 @@ func (db *DB) chooseAdaptiveMemtableModeLocked() memtable.Mode {
 }
 
 func (db *DB) updateAdaptiveObservationLocked() {
-	observe := db.memtableAdaptive
-	if observe && !db.memtableWarmupActive && db.currentMemtableMode() == memtable.ModeAppendOnly {
-		observe = false
+	// Keep observing across every adaptive memtable mode so the next rotation is
+	// driven by the immediately preceding workload instead of stale history from
+	// before append-only became active.
+	db.memtableAdaptiveObserve.Store(db.memtableAdaptive)
+}
+
+func (db *DB) prepareNextMemtableModeLocked(forcedMode *memtable.Mode) {
+	if forcedMode != nil {
+		db.storeMemtableMode(*forcedMode)
+		db.updateAdaptiveObservationLocked()
+	} else if db.memtableAdaptive {
+		db.applyAdaptiveMemtableModeLocked()
 	}
-	db.memtableAdaptiveObserve.Store(observe)
+	if db.memtableWarmupActive {
+		db.memtableWarmupActive = false
+		db.updateAdaptiveObservationLocked()
+	}
 }
 
 func (db *DB) applyAdaptiveMemtableModeLocked() memtable.Mode {
@@ -10709,8 +11381,68 @@ func (it *opRunIter) Key() []byte {
 	return it.runs[it.runIdx][it.idx].Key
 }
 
+func (*opRunIter) Close() error { return nil }
+
+type iteratorOpSource struct {
+	iter iterator.UnsafeIterator
+}
+
+func newIteratorOpSource(iter iterator.UnsafeIterator) *iteratorOpSource {
+	return &iteratorOpSource{iter: iter}
+}
+
+func (it *iteratorOpSource) Valid() bool {
+	return it != nil && it.iter != nil && it.iter.Valid()
+}
+
+func (it *iteratorOpSource) Next() {
+	if it == nil || it.iter == nil {
+		return
+	}
+	it.iter.Next()
+}
+
+func (it *iteratorOpSource) Entry() batch.Entry {
+	if it == nil || it.iter == nil || !it.iter.Valid() {
+		return batch.Entry{}
+	}
+	val, ptr, flags := it.iter.UnsafeEntry()
+	switch {
+	case flags&node.FlagTombstone != 0:
+		return batch.Entry{Type: batch.OpDelete, Key: it.iter.UnsafeKey()}
+	case flags&node.FlagPointer != 0:
+		return batch.Entry{Type: batch.OpPut, Key: it.iter.UnsafeKey(), ValuePtr: ptr, IsPtr: true}
+	default:
+		return batch.Entry{Type: batch.OpPut, Key: it.iter.UnsafeKey(), Value: val}
+	}
+}
+
+func (it *iteratorOpSource) Key() []byte {
+	if it == nil || it.iter == nil || !it.iter.Valid() {
+		return nil
+	}
+	return it.iter.UnsafeKey()
+}
+
+func (it *iteratorOpSource) Close() error {
+	if it == nil || it.iter == nil {
+		return nil
+	}
+	err := it.iter.Close()
+	it.iter = nil
+	return err
+}
+
+type opMergeSource interface {
+	Valid() bool
+	Next()
+	Entry() batch.Entry
+	Key() []byte
+	Close() error
+}
+
 type opMergeItem struct {
-	iter     *opRunIter
+	source   opMergeSource
 	priority int
 	key      []byte
 }
@@ -10851,6 +11583,19 @@ func stableUnsafeIteratorSlices(mem memtable.Table) bool {
 		return stable.StableUnsafeIteratorSlices()
 	}
 	return false
+}
+
+func closeOpMergeSources(sources []opMergeSource) error {
+	var firstErr error
+	for _, source := range sources {
+		if source == nil {
+			continue
+		}
+		if err := source.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 type walFastItem struct {
@@ -11068,7 +11813,7 @@ func (db *DB) enqueueDomainIngress(op domainIngressOp, key, value []byte, sync b
 		sync:  sync,
 		done:  make(chan error, 1),
 	}
-	shardID := db.shardIndex(key)
+	shardID := db.hashShardIndex(key)
 	workerID := shardID % len(db.domainIngressCh)
 	ch := db.domainIngressCh[workerID]
 	select {
@@ -19342,8 +20087,8 @@ func (db *DB) setDirect(key, value []byte, sync bool) error {
 	var retainPath string
 	usePointer := false
 	debugPtr := db.debugFlushPointers
-
-	shard := db.shardForKey(key)
+	shardIdx := db.shardIndexForWrite(key)
+	shard := &db.mutableShards[shardIdx]
 
 	durability := journalDurabilityNone
 	if sync {
@@ -19385,7 +20130,7 @@ func (db *DB) setDirect(key, value []byte, sync bool) error {
 
 	var lane *lane
 	if allowPointers || !db.disableJournal {
-		l, err := db.pickLane(durability == journalDurabilitySync, db.laneForShardIndex(db.shardIndex(key)))
+		l, err := db.pickLane(durability == journalDurabilitySync, db.laneForShardIndex(shardIdx))
 		if err != nil {
 			db.writeMu.RUnlock()
 			return err
@@ -19496,7 +20241,7 @@ func (db *DB) setDirect(key, value []byte, sync bool) error {
 	}
 
 	if needRotate {
-		if err := db.maybeRotateMemtable(true); err != nil {
+		if err := db.maybeRotateMutableShards(true, []int{shardIdx}); err != nil {
 			return err
 		}
 	}
@@ -19550,7 +20295,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 				return ErrMemtableFull
 			}
 			for {
-				shard := db.shardForKey(key)
+				shard := db.shardForWriteKey(key)
 				shard.mu.Lock()
 				if db.shardExceedsLimit(shard, int64(len(key))) {
 					shard.mu.Unlock()
@@ -19572,7 +20317,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 				shard.bytes = newBytes
 				db.mutableBytes.Add(delta)
 				shard.mu.Unlock()
-				db.noteWriteKey(key)
+				db.noteDeleteKey(key)
 				if db.mutableBytes.Load() > db.mutableFlushThreshold() {
 					db.mu.Lock()
 					if db.mutableBytes.Load() > db.mutableFlushThreshold() {
@@ -19616,7 +20361,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 					db.mu.Unlock()
 				}
 			}
-			shard := db.shardForKey(key)
+			shard := db.shardForWriteKey(key)
 			shard.mu.Lock()
 			exceeds := db.shardExceedsLimit(shard, int64(len(key)))
 			shard.mu.Unlock()
@@ -19776,6 +20521,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 			db.queueRetiredMemtablesLocked(db.queue)
 			db.queue = nil
 			db.queueShardIDs = nil
+			db.queueRouteModes = nil
 			db.queueLaneIDs = nil
 			db.queueIDs = nil
 			db.queueEnqueueNS = nil
@@ -19838,6 +20584,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 			db.queueRetiredMemtablesLocked(db.queue)
 			db.queue = nil
 			db.queueShardIDs = nil
+			db.queueRouteModes = nil
 			db.queueLaneIDs = nil
 			db.queueIDs = nil
 			db.queueEnqueueNS = nil
@@ -19908,6 +20655,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 			db.ensureQueueLaneIDsLocked()
 			dstQueue := db.queue[:0]
 			dstShardIDs := db.queueShardIDs[:0]
+			dstRouteModes := db.queueRouteModes[:0]
 			dstLaneIDs := db.queueLaneIDs[:0]
 			dstIDs := db.queueIDs[:0]
 			dstEnqueueNS := db.queueEnqueueNS[:0]
@@ -19929,6 +20677,11 @@ func (db *DB) DeleteRange(start, end []byte) error {
 					dstShardIDs = append(dstShardIDs, db.queueShardIDs[i])
 				} else {
 					dstShardIDs = append(dstShardIDs, 0)
+				}
+				if i < len(db.queueRouteModes) {
+					dstRouteModes = append(dstRouteModes, db.queueRouteModes[i])
+				} else {
+					dstRouteModes = append(dstRouteModes, memtableRouteHashed)
 				}
 				if i < len(db.queueLaneIDs) {
 					dstLaneIDs = append(dstLaneIDs, db.queueLaneIDs[i])
@@ -19959,6 +20712,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 			}
 			db.queue = dstQueue
 			db.queueShardIDs = dstShardIDs
+			db.queueRouteModes = dstRouteModes
 			db.queueLaneIDs = dstLaneIDs
 			db.queueIDs = dstIDs
 			db.queueEnqueueNS = dstEnqueueNS
@@ -20028,7 +20782,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 
 		db.mu.Lock()
 		applyDelete := func(key []byte) error {
-			shard := db.shardForKey(key)
+			shard := db.shardForWriteKey(key)
 			shard.mu.Lock()
 			if db.shardExceedsLimit(shard, int64(len(key))) {
 				shard.mu.Unlock()
@@ -20041,6 +20795,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 			shard.bytes = newBytes
 			db.mutableBytes.Add(delta)
 			shard.mu.Unlock()
+			db.noteDeleteKey(key)
 			if db.mutableBytes.Load() > db.mutableFlushThreshold() {
 				if err := db.rotateMemtableLocked(true); err != nil {
 					return err
@@ -20141,8 +20896,8 @@ func (db *DB) deleteDirect(key []byte, sync bool) error {
 	db.writeMu.RLock()
 	needRotate := false
 	needSyncBarrier := false
-
-	shard := db.shardForKey(key)
+	shardIdx := db.shardIndexForWrite(key)
+	shard := &db.mutableShards[shardIdx]
 	shard.mu.Lock()
 	if db.shardExceedsLimit(shard, int64(len(key))) {
 		shard.mu.Unlock()
@@ -20160,7 +20915,7 @@ func (db *DB) deleteDirect(key []byte, sync bool) error {
 				durability = journalDurabilitySync
 			}
 		}
-		lane, err := db.pickLane(durability == journalDurabilitySync, db.laneForShardIndex(db.shardIndex(key)))
+		lane, err := db.pickLane(durability == journalDurabilitySync, db.laneForShardIndex(shardIdx))
 		if err != nil {
 			db.writeMu.RUnlock()
 			return err
@@ -20183,7 +20938,7 @@ func (db *DB) deleteDirect(key []byte, sync bool) error {
 	shard.bytes = newBytes
 	db.mutableBytes.Add(delta)
 	shard.mu.Unlock()
-	db.noteWriteKey(key)
+	db.noteDeleteKey(key)
 
 	// 3. Threshold
 	if db.mutableBytes.Load() > db.mutableFlushThreshold() {
@@ -20195,7 +20950,7 @@ func (db *DB) deleteDirect(key []byte, sync bool) error {
 	db.writeMu.RUnlock()
 
 	if needRotate {
-		if err := db.maybeRotateMemtable(true); err != nil {
+		if err := db.maybeRotateMutableShards(true, []int{shardIdx}); err != nil {
 			return err
 		}
 	}
@@ -20241,13 +20996,8 @@ func (db *DB) rotateMemtableLockedWithCapacity(triggerFlush bool, newCapacity in
 	if newCapacity < 0 {
 		newCapacity = db.memtableCap
 	}
-	if db.memtableAdaptive {
-		db.applyAdaptiveMemtableModeLocked()
-	}
-	if db.memtableWarmupActive {
-		db.memtableWarmupActive = false
-		db.updateAdaptiveObservationLocked()
-	}
+	db.prepareNextMemtableModeLocked(nil)
+	activeRoute := cloneMutableRoute(db.currentMutableRoute.Load())
 	if debugRotate {
 		db.debugMemtableRotatef(
 			"event=start path=with_capacity trigger_flush=%t new_capacity=%d mode=%s mutable_bytes=%d queue_len=%d queue_backlog_bytes=%d",
@@ -20270,6 +21020,9 @@ func (db *DB) rotateMemtableLockedWithCapacity(triggerFlush bool, newCapacity in
 			oldMode = debugMemtableModeLabel(shard.mem)
 		}
 		oldShardBytes := shard.bytes
+		if _, ok := shard.mem.(*memtable.AppendOnly); ok {
+			db.observeAppendOnlyMutableEntries(oldLen)
+		}
 		db.retainMutableShardAppendOnlyArenaLocked(i, shard)
 		shard.mem.Freeze()
 		memBytes := shard.mem.Size()
@@ -20278,6 +21031,7 @@ func (db *DB) rotateMemtableLockedWithCapacity(triggerFlush bool, newCapacity in
 		if enqueueShard {
 			db.queue = append(db.queue, shard.mem)
 			db.queueShardIDs = append(db.queueShardIDs, uint16(i))
+			db.queueRouteModes = append(db.queueRouteModes, queueRouteModeForMutableRoute(activeRoute, i))
 			db.queueLaneIDs = append(db.queueLaneIDs, uint16(queueLaneID))
 			db.queueIDs = append(db.queueIDs, db.nextQueueID.Add(1))
 			db.queueEnqueueNS = append(db.queueEnqueueNS, enqueueNS)
@@ -20317,6 +21071,8 @@ func (db *DB) rotateMemtableLockedWithCapacity(triggerFlush bool, newCapacity in
 	if len(retiredMems) > 0 {
 		db.pendingRetiredMems = append(db.pendingRetiredMems, retiredMems...)
 	}
+	db.clearCurrentMutableRouteLocked()
+	db.resetAdaptiveMemtableStatsLocked()
 	db.updateMutableThresholdLocked()
 	db.publishMemtablesLocked()
 	if debugRotate {
@@ -20401,6 +21157,19 @@ func (db *DB) maybeRotateMemtable(triggerFlush bool) error {
 	return db.rotateMemtableIfNeeded(triggerFlush)
 }
 
+func (db *DB) forceRotateMemtableToMode(triggerFlush bool, mode memtable.Mode) error {
+	if db == nil {
+		return nil
+	}
+	if !db.rotatePending.CompareAndSwap(false, true) {
+		return nil
+	}
+	defer db.rotatePending.Store(false)
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return db.rotateMutableShardsLockedWithMode(-1, triggerFlush, &mode)
+}
+
 // rotateMutableShardsLocked rotates the current mutable shards into the queue
 // while holding db.mu (write) and the affected shard locks.
 //
@@ -20408,18 +21177,17 @@ func (db *DB) maybeRotateMemtable(triggerFlush bool) error {
 // for establishing durable boundaries and trimming old segments. This avoids
 // requiring a global writer barrier around WAL rotation.
 func (db *DB) rotateMutableShardsLocked(newCapacity int, triggerFlush bool) error {
+	return db.rotateMutableShardsLockedWithMode(newCapacity, triggerFlush, nil)
+}
+
+func (db *DB) rotateMutableShardsLockedWithMode(newCapacity int, triggerFlush bool, forcedMode *memtable.Mode) error {
 	debugRotate := debugMemtableRotateOn()
 	retiredMems := make([]memtable.Table, 0, len(db.mutableShards))
 	if newCapacity < 0 {
 		newCapacity = db.memtableCap
 	}
-	if db.memtableAdaptive {
-		db.applyAdaptiveMemtableModeLocked()
-	}
-	if db.memtableWarmupActive {
-		db.memtableWarmupActive = false
-		db.updateAdaptiveObservationLocked()
-	}
+	db.prepareNextMemtableModeLocked(forcedMode)
+	activeRoute := cloneMutableRoute(db.currentMutableRoute.Load())
 	var walPaths []string
 	if !db.disableJournal {
 		walPaths = db.currentWALPaths()
@@ -20457,10 +21225,10 @@ func (db *DB) rotateMutableShardsLocked(newCapacity int, triggerFlush bool) erro
 		if debugRotate {
 			oldMode = debugMemtableModeLabel(shard.mem)
 		}
+		oldShardBytes := shard.bytes
 		if _, ok := shard.mem.(*memtable.AppendOnly); ok {
 			db.observeAppendOnlyMutableEntries(oldLen)
 		}
-		oldShardBytes := shard.bytes
 
 		// Remove this shard's contribution from the global byte counter before
 		// resetting it, since writers may still be updating other shards.
@@ -20477,6 +21245,7 @@ func (db *DB) rotateMutableShardsLocked(newCapacity int, triggerFlush bool) erro
 		if enqueueShard {
 			db.queue = append(db.queue, shard.mem)
 			db.queueShardIDs = append(db.queueShardIDs, uint16(i))
+			db.queueRouteModes = append(db.queueRouteModes, queueRouteModeForMutableRoute(activeRoute, i))
 			db.queueLaneIDs = append(db.queueLaneIDs, uint16(queueLaneID))
 			db.queueIDs = append(db.queueIDs, db.nextQueueID.Add(1))
 			db.queueEnqueueNS = append(db.queueEnqueueNS, enqueueNS)
@@ -20514,7 +21283,8 @@ func (db *DB) rotateMutableShardsLocked(newCapacity int, triggerFlush bool) erro
 	if len(retiredMems) > 0 {
 		db.pendingRetiredMems = append(db.pendingRetiredMems, retiredMems...)
 	}
-
+	db.clearCurrentMutableRouteLocked()
+	db.resetAdaptiveMemtableStatsLocked()
 	db.updateMutableThresholdLocked()
 	db.publishMemtablesLocked()
 	if debugRotate {
@@ -20537,6 +21307,177 @@ func (db *DB) rotateMutableShardsLocked(newCapacity int, triggerFlush bool) erro
 	db.bpCond.Broadcast()
 	db.bpMu.Unlock()
 	return nil
+}
+
+func (db *DB) rotateMutableShardsSelectedLocked(shardIDs []int, newCapacity int, triggerFlush bool, forcedMode *memtable.Mode) error {
+	if len(shardIDs) == 0 {
+		return nil
+	}
+	if newCapacity < 0 {
+		newCapacity = db.memtableCap
+	}
+	db.prepareNextMemtableModeLocked(forcedMode)
+	nextMode := db.currentMemtableMode()
+	activeRoute := cloneMutableRoute(db.currentMutableRoute.Load())
+	retiredMems := make([]memtable.Table, 0, len(shardIDs))
+	enqueueNS := time.Now().UnixNano()
+	sortedShardIDs := append([]int(nil), shardIDs...)
+	sort.Ints(sortedShardIDs)
+	writeAt := 0
+	for _, shardID := range sortedShardIDs {
+		if shardID < 0 || shardID >= len(db.mutableShards) {
+			continue
+		}
+		if writeAt > 0 && sortedShardIDs[writeAt-1] == shardID {
+			continue
+		}
+		sortedShardIDs[writeAt] = shardID
+		writeAt++
+	}
+	sortedShardIDs = sortedShardIDs[:writeAt]
+
+	for _, shardID := range sortedShardIDs {
+		shard := &db.mutableShards[shardID]
+		shard.mu.Lock()
+		oldLen := shard.mem.Len()
+		if _, ok := shard.mem.(*memtable.AppendOnly); ok {
+			db.observeAppendOnlyMutableEntries(oldLen)
+		}
+		if shard.bytes != 0 {
+			db.mutableBytes.Add(-shard.bytes)
+		}
+		db.retainMutableShardAppendOnlyArenaLocked(shardID, shard)
+		shard.mem.Freeze()
+		memBytes := shard.mem.Size()
+		queueLaneID := db.laneForShardIndex(shardID)
+		enqueueShard := memBytes > 0 || oldLen > 0
+		if enqueueShard {
+			db.queue = append(db.queue, shard.mem)
+			db.queueShardIDs = append(db.queueShardIDs, uint16(shardID))
+			db.queueRouteModes = append(db.queueRouteModes, queueRouteModeForMutableRoute(activeRoute, shardID))
+			db.queueLaneIDs = append(db.queueLaneIDs, uint16(queueLaneID))
+			db.queueIDs = append(db.queueIDs, db.nextQueueID.Add(1))
+			db.queueEnqueueNS = append(db.queueEnqueueNS, enqueueNS)
+			db.queueBacklogBytes.Add(memBytes)
+			db.queueRanges = append(db.queueRanges, shard.rng)
+			db.queueWALPaths = append(db.queueWALPaths, db.currentWALPaths())
+			if db.valueLogEnabled() {
+				db.queueValueLogPaths = append(db.queueValueLogPaths, db.currentValueLogPaths())
+			} else {
+				db.queueValueLogPaths = append(db.queueValueLogPaths, nil)
+			}
+		} else {
+			retiredMems = append(retiredMems, shard.mem)
+		}
+		mt, err := db.newMutableMemtableWithCapacityMode(newCapacity, nextMode)
+		if err != nil {
+			shard.mu.Unlock()
+			return err
+		}
+		shard.mem = mt
+		shard.rng = keyRange{}
+		shard.bytes = 0
+		shard.mu.Unlock()
+	}
+	if len(retiredMems) > 0 {
+		db.pendingRetiredMems = append(db.pendingRetiredMems, retiredMems...)
+	}
+	if activeRoute != nil {
+		remove := make(map[int]struct{}, len(sortedShardIDs))
+		for _, shardID := range sortedShardIDs {
+			remove[shardID] = struct{}{}
+		}
+		db.currentMutableRoute.Store(activeRoute.withoutShards(remove))
+	}
+	db.resetAdaptiveMemtableStatsLocked()
+	db.updateMutableThresholdLocked()
+	db.publishMemtablesLocked()
+	if triggerFlush {
+		select {
+		case db.flushCh <- struct{}{}:
+		default:
+		}
+	}
+	db.bpMu.Lock()
+	db.bpCond.Broadcast()
+	db.bpMu.Unlock()
+	return nil
+}
+
+func (db *DB) selectMutableShardsToRotateLocked(candidates []int) []int {
+	threshold := db.mutableFlushThreshold()
+	totalBytes := db.mutableBytes.Load()
+	if totalBytes <= threshold {
+		return nil
+	}
+	type shardUsage struct {
+		idx   int
+		bytes int64
+	}
+	var usages []shardUsage
+	seen := make(map[int]struct{}, len(candidates))
+	addUsage := func(idx int) {
+		if idx < 0 || idx >= len(db.mutableShards) {
+			return
+		}
+		if _, ok := seen[idx]; ok {
+			return
+		}
+		seen[idx] = struct{}{}
+		shard := &db.mutableShards[idx]
+		shard.mu.Lock()
+		bytes := shard.bytes
+		shard.mu.Unlock()
+		if bytes <= 0 {
+			return
+		}
+		usages = append(usages, shardUsage{idx: idx, bytes: bytes})
+	}
+	for _, idx := range candidates {
+		addUsage(idx)
+	}
+	for idx := range db.mutableShards {
+		addUsage(idx)
+	}
+	if len(usages) == 0 {
+		return nil
+	}
+	sort.Slice(usages, func(i, j int) bool {
+		if usages[i].bytes == usages[j].bytes {
+			return usages[i].idx < usages[j].idx
+		}
+		return usages[i].bytes > usages[j].bytes
+	})
+	remaining := totalBytes
+	selected := make([]int, 0, len(usages))
+	for _, usage := range usages {
+		selected = append(selected, usage.idx)
+		remaining -= usage.bytes
+		if remaining <= threshold {
+			break
+		}
+	}
+	return selected
+}
+
+func (db *DB) maybeRotateMutableShards(triggerFlush bool, candidates []int) error {
+	if db.mutableBytes.Load() <= db.mutableFlushThreshold() {
+		return nil
+	}
+	if !db.rotatePending.CompareAndSwap(false, true) {
+		return nil
+	}
+	defer db.rotatePending.Store(false)
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	if db.mutableBytes.Load() <= db.mutableFlushThreshold() {
+		return nil
+	}
+	selected := db.selectMutableShardsToRotateLocked(candidates)
+	if len(selected) == 0 {
+		return nil
+	}
+	return db.rotateMutableShardsSelectedLocked(selected, -1, triggerFlush, nil)
 }
 
 func (db *DB) cleanupLaneWALWriters(l *lane) {
@@ -21157,6 +22098,7 @@ func (db *DB) removeQueuedUnitsLocked(removeIDs map[uint64]struct{}, units []flu
 
 	dstQueue := db.queue[:0]
 	dstShardIDs := db.queueShardIDs[:0]
+	dstRouteModes := db.queueRouteModes[:0]
 	dstLaneIDs := db.queueLaneIDs[:0]
 	dstIDs := db.queueIDs[:0]
 	dstEnqueueNS := db.queueEnqueueNS[:0]
@@ -21176,6 +22118,11 @@ func (db *DB) removeQueuedUnitsLocked(removeIDs map[uint64]struct{}, units []flu
 		dstQueue = append(dstQueue, mem)
 		if i < len(db.queueShardIDs) {
 			dstShardIDs = append(dstShardIDs, db.queueShardIDs[i])
+		}
+		if i < len(db.queueRouteModes) {
+			dstRouteModes = append(dstRouteModes, db.queueRouteModes[i])
+		} else {
+			dstRouteModes = append(dstRouteModes, memtableRouteHashed)
 		}
 		if i < len(db.queueLaneIDs) {
 			dstLaneIDs = append(dstLaneIDs, db.queueLaneIDs[i])
@@ -21203,6 +22150,7 @@ func (db *DB) removeQueuedUnitsLocked(removeIDs map[uint64]struct{}, units []flu
 
 	db.queue = dstQueue
 	db.queueShardIDs = dstShardIDs
+	db.queueRouteModes = dstRouteModes
 	db.queueLaneIDs = dstLaneIDs
 	db.queueIDs = dstIDs
 	db.queueEnqueueNS = dstEnqueueNS
@@ -21269,71 +22217,12 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 		if chunkCap < 0 {
 			chunkCap = 8192
 		}
-
 		type buildResult struct {
 			idx       int
 			runs      [][]batch.Entry
 			deleteOps int
 			err       error
 		}
-
-		jobs := make(chan int, len(units))
-		results := make(chan buildResult, len(units))
-		closeCh := db.closeCh
-
-		for i := range units {
-			jobs <- i
-		}
-		close(jobs)
-
-		workers := db.flushBuildConcurrency
-		if workers <= 0 {
-			workers = 1
-		}
-		if db.flushBuildAutoConcurrency && totalLen > 0 {
-			// Small inline-heavy entries are typically memory-copy bound; high
-			// worker counts can over-parallelize and add scheduler overhead.
-			// Keep wider concurrency for larger entries where per-entry work is
-			// heavier (pointer/value encoding and compression).
-			bytesPerEntry := totalBytes / int64(totalLen)
-			switch {
-			case bytesPerEntry <= 64:
-				if workers > 4 {
-					workers = 4
-				}
-			case bytesPerEntry <= 256:
-				if workers > 6 {
-					workers = 6
-				}
-			}
-		}
-		if workers > len(units) {
-			workers = len(units)
-		}
-
-		done := make(chan struct{}, workers)
-		for w := 0; w < workers; w++ {
-			go func() {
-				defer func() { done <- struct{}{} }()
-				for idx := range jobs {
-					select {
-					case <-closeCh:
-						results <- buildResult{idx: idx, err: errDBClosing}
-						continue
-					default:
-					}
-					runs, deleteOps, err := buildOpRuns(units[idx].mem, chunkCap)
-					results <- buildResult{idx: idx, runs: runs, deleteOps: deleteOps, err: err}
-				}
-			}()
-		}
-
-		go func() {
-			for i := 0; i < workers; i++ {
-				<-done
-			}
-			close(results)
-		}()
 
 		unitRuns := getUnitRuns(len(units))
 		defer func() {
@@ -21346,41 +22235,104 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			putUnitRuns(unitRuns)
 		}()
 		unitDeleteOps := make([]int, len(units))
-		failed := false
-		for res := range results {
-			if res.err != nil {
-				if !failed {
-					db.reportError(fmt.Errorf("cachingdb: flush build failed: %w", res.err))
+		{
+			jobs := make(chan int, len(units))
+			results := make(chan buildResult, len(units))
+			closeCh := db.closeCh
+
+			for i := range units {
+				jobs <- i
+			}
+			close(jobs)
+
+			workers := db.flushBuildConcurrency
+			if workers <= 0 {
+				workers = 1
+			}
+			if db.flushBuildAutoConcurrency && totalLen > 0 {
+				// Small inline-heavy entries are typically memory-copy bound; high
+				// worker counts can over-parallelize and add scheduler overhead.
+				// Keep wider concurrency for larger entries where per-entry work is
+				// heavier (pointer/value encoding and compression).
+				bytesPerEntry := totalBytes / int64(totalLen)
+				switch {
+				case bytesPerEntry <= 64:
+					if workers > 4 {
+						workers = 4
+					}
+				case bytesPerEntry <= 256:
+					if workers > 6 {
+						workers = 6
+					}
 				}
-				failed = true
-				for _, run := range res.runs {
-					putEntrySlice(run)
+			}
+			if workers > len(units) {
+				workers = len(units)
+			}
+
+			done := make(chan struct{}, workers)
+			for w := 0; w < workers; w++ {
+				go func() {
+					defer func() { done <- struct{}{} }()
+					for idx := range jobs {
+						select {
+						case <-closeCh:
+							results <- buildResult{idx: idx, err: errDBClosing}
+							continue
+						default:
+						}
+						runs, deleteOps, err := buildOpRuns(units[idx].mem, chunkCap)
+						results <- buildResult{idx: idx, runs: runs, deleteOps: deleteOps, err: err}
+					}
+				}()
+			}
+
+			go func() {
+				for i := 0; i < workers; i++ {
+					<-done
 				}
-				putEntryRuns(res.runs)
-				continue
+				close(results)
+			}()
+
+			failed := false
+			for res := range results {
+				if res.err != nil {
+					if !failed {
+						db.reportError(fmt.Errorf("cachingdb: flush build failed: %w", res.err))
+					}
+					failed = true
+					for _, run := range res.runs {
+						putEntrySlice(run)
+					}
+					putEntryRuns(res.runs)
+					continue
+				}
+				if failed {
+					for _, run := range res.runs {
+						putEntrySlice(run)
+					}
+					putEntryRuns(res.runs)
+					continue
+				}
+				unitRuns[res.idx] = res.runs
+				unitDeleteOps[res.idx] = res.deleteOps
 			}
 			if failed {
-				for _, run := range res.runs {
-					putEntrySlice(run)
-				}
-				putEntryRuns(res.runs)
-				continue
+				return false
 			}
-			unitRuns[res.idx] = res.runs
-			unitDeleteOps[res.idx] = res.deleteOps
-		}
-		if failed {
-			return false
 		}
 
 		// Adaptive micro-batching: delete-heavy flushes are expensive to apply in
 		// many intermediate commits (each commit re-writes leaf pages, copying
-		// surviving values). Count deletes and tighten the commit cap in that case.
+		// surviving values). Build runs for every unit so this decision sees the
+		// actual tombstone mix instead of the pre-dedup append-only entry count.
 		deleteOps := 0
 		for _, n := range unitDeleteOps {
 			deleteOps += n
 		}
-		backendEntriesCap = db.flushBackendEntriesCapForOps(totalLen, deleteOps, sync)
+		if deleteOps > 0 {
+			backendEntriesCap = db.flushBackendEntriesCapForOps(totalLen, deleteOps, sync)
+		}
 
 		reserveChunkOps := totalLen
 		if reserveChunkOps > backendEntriesCap {
@@ -21400,6 +22352,12 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 		psv, _ := backendBatch.(backendBatchPointerSetterView)
 		ps, _ := backendBatch.(backendBatchPointerSetter)
 		var single [1]batch.Entry
+		reloadBackendBatchMethods := func() {
+			sv, _ = backendBatch.(backendBatchSetViewer)
+			dv, _ = backendBatch.(backendBatchDeleteViewer)
+			psv, _ = backendBatch.(backendBatchPointerSetterView)
+			ps, _ = backendBatch.(backendBatchPointerSetter)
+		}
 
 		// Best-effort: ensure value-log bytes are flushed before we start committing
 		// pointers into the index when we expect to emit multiple backend commits.
@@ -21422,33 +22380,35 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			// the flush. Write the intermediate chunks without fsync to avoid
 			// repeated pager sync work.
 			err := backendBatch.Write()
-			cerr := backendBatch.Close()
-			if err == nil {
-				err = cerr
-			}
 			if err != nil {
 				return err
 			}
-			backendBatch = db.newBackendBatchWithSize(sizeHint)
-			reserveBackendBatchOps(backendBatch, reserveChunkOps)
-			sv, _ = backendBatch.(backendBatchSetViewer)
-			dv, _ = backendBatch.(backendBatchDeleteViewer)
-			psv, _ = backendBatch.(backendBatchPointerSetterView)
-			ps, _ = backendBatch.(backendBatchPointerSetter)
+			if err := db.recycleBackendBatch(&backendBatch, sizeHint, reserveChunkOps); err != nil {
+				return err
+			}
+			reloadBackendBatchMethods()
 			backendPendingOps = 0
 			return nil
 		}
 
-		heap := getOpMergeHeap(len(unitRuns))
+		heap := getOpMergeHeap(len(units))
 		defer func() { putOpMergeHeap(heap) }()
-		for i := range unitRuns {
+		sources := make([]opMergeSource, 0, len(units))
+		sourcesClosed := false
+		defer func() {
+			if !sourcesClosed {
+				_ = closeOpMergeSources(sources)
+			}
+		}()
+		for i := range units {
+			priority := len(units) - 1 - i
 			if len(unitRuns[i]) == 0 {
 				continue
 			}
-			it := newOpRunIter(unitRuns[i])
-			if it.Valid() {
-				priority := len(unitRuns) - 1 - i
-				heap = append(heap, opMergeItem{iter: it, priority: priority, key: it.Key()})
+			source := newOpRunIter(unitRuns[i])
+			if source.Valid() {
+				sources = append(sources, source)
+				heap = append(heap, opMergeItem{source: source, priority: priority, key: source.Key()})
 			}
 		}
 		for i := len(heap)/2 - 1; i >= 0; i-- {
@@ -21466,9 +22426,9 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 				if next != nil && bytes.Equal(next.key, currentKey) {
 					shadowed := heap.pop()
 					shadowedOps++
-					shadowed.iter.Next()
-					if shadowed.iter.Valid() {
-						shadowed.key = shadowed.iter.Key()
+					shadowed.source.Next()
+					if shadowed.source.Valid() {
+						shadowed.key = shadowed.source.Key()
 						heap.push(shadowed)
 					}
 					continue
@@ -21476,7 +22436,7 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 				break
 			}
 
-			entry := top.iter.Entry()
+			entry := top.source.Entry()
 			var (
 				err     error
 				applied bool
@@ -21522,12 +22482,18 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 				}
 			}
 
-			top.iter.Next()
-			if top.iter.Valid() {
-				top.key = top.iter.Key()
+			top.source.Next()
+			if top.source.Valid() {
+				top.key = top.source.Key()
 				heap.push(top)
 			}
 		}
+		if err := closeOpMergeSources(sources); err != nil {
+			db.reportError(fmt.Errorf("cachingdb: flush failed (iter close): %w", err))
+			_ = backendBatch.Close()
+			return false
+		}
+		sourcesClosed = true
 		if shadowedOps > 0 {
 			flushMergeShadowedOpsTotal.Add(uint64(shadowedOps))
 			flushMergeParallelShadowedOpsTotal.Add(uint64(shadowedOps))
@@ -21679,6 +22645,12 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 		psv, _ := backendBatch.(backendBatchPointerSetterView)
 		ps, _ := backendBatch.(backendBatchPointerSetter)
 		var single [1]batch.Entry
+		reloadBackendBatchMethods := func() {
+			sv, _ = backendBatch.(backendBatchSetViewer)
+			dv, _ = backendBatch.(backendBatchDeleteViewer)
+			psv, _ = backendBatch.(backendBatchPointerSetterView)
+			ps, _ = backendBatch.(backendBatchPointerSetter)
+		}
 
 		// Best-effort: ensure value-log bytes are flushed before we start committing
 		// pointers into the index when we expect to emit multiple backend commits.
@@ -21703,19 +22675,13 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			// the flush. Write the intermediate chunks without fsync to avoid
 			// repeated pager sync work.
 			err := backendBatch.Write()
-			cerr := backendBatch.Close()
-			if err == nil {
-				err = cerr
-			}
 			if err != nil {
 				return err
 			}
-			backendBatch = db.newBackendBatchWithSize(sizeHint)
-			reserveBackendBatchOps(backendBatch, reserveChunkOps)
-			sv, _ = backendBatch.(backendBatchSetViewer)
-			dv, _ = backendBatch.(backendBatchDeleteViewer)
-			psv, _ = backendBatch.(backendBatchPointerSetterView)
-			ps, _ = backendBatch.(backendBatchPointerSetter)
+			if err := db.recycleBackendBatch(&backendBatch, sizeHint, reserveChunkOps); err != nil {
+				return err
+			}
+			reloadBackendBatchMethods()
 			backendPendingOps = 0
 			return nil
 		}
@@ -22067,6 +23033,12 @@ func (db *DB) flushOneLocked(sync bool) bool {
 			psv, _ := backendBatch.(backendBatchPointerSetterView)
 			ps, _ := backendBatch.(backendBatchPointerSetter)
 			var single [1]batch.Entry
+			reloadBackendBatchMethods := func() {
+				sv, _ = backendBatch.(backendBatchSetViewer)
+				dv, _ = backendBatch.(backendBatchDeleteViewer)
+				psv, _ = backendBatch.(backendBatchPointerSetterView)
+				ps, _ = backendBatch.(backendBatchPointerSetter)
+			}
 
 			flushBackendChunk := func() error {
 				if !chunkBackend || backendPendingOps < backendEntriesCap {
@@ -22078,20 +23050,14 @@ func (db *DB) flushOneLocked(sync bool) bool {
 				// repeated pager sync work.
 				db.backendWriteBatchesTotal.Add(1)
 				err := backendBatch.Write()
-				cerr := backendBatch.Close()
-				if err == nil {
-					err = cerr
-				}
 				durBackendWrite += time.Since(tw)
 				if err != nil {
 					return err
 				}
-				backendBatch = db.newBackendBatchWithSize(sizeHint)
-				reserveBackendBatchOps(backendBatch, reserveChunkOps)
-				sv, _ = backendBatch.(backendBatchSetViewer)
-				dv, _ = backendBatch.(backendBatchDeleteViewer)
-				psv, _ = backendBatch.(backendBatchPointerSetterView)
-				ps, _ = backendBatch.(backendBatchPointerSetter)
+				if err := db.recycleBackendBatch(&backendBatch, sizeHint, reserveChunkOps); err != nil {
+					return err
+				}
+				reloadBackendBatchMethods()
 				backendPendingOps = 0
 				return nil
 			}
@@ -22369,7 +23335,7 @@ func (db *DB) canBypassMemtableRead(view *memtableView, key []byte) bool {
 	if len(view.mutables) == 0 {
 		return true
 	}
-	idx := db.shardIndex(key)
+	idx := db.hashShardIndex(key)
 	if idx >= len(view.mutables) {
 		return true
 	}
@@ -22399,7 +23365,7 @@ func (db *DB) canBypassMemtableReadMany(view *memtableView, keys [][]byte) bool 
 	if n <= 64 {
 		var checkedBits uint64
 		for _, key := range keys {
-			idx := db.shardIndex(key)
+			idx := db.hashShardIndex(key)
 			if idx >= n {
 				continue
 			}
@@ -22418,7 +23384,7 @@ func (db *DB) canBypassMemtableReadMany(view *memtableView, keys [][]byte) bool 
 
 	checked := make([]bool, n)
 	for _, key := range keys {
-		idx := db.shardIndex(key)
+		idx := db.hashShardIndex(key)
 		if idx >= n || checked[idx] {
 			continue
 		}
@@ -22437,14 +23403,20 @@ func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
 		defer db.releaseMemtableView(view)
 	}
 	var (
-		mutables      []memtable.Table
-		queue         []memtable.Table
-		queueShardIDs []uint16
+		mutables        []memtable.Table
+		queue           []memtable.Table
+		queueShardIDs   []uint16
+		queueRouteModes []uint8
+		queueRanges     []keyRange
+		mutableRoute    *mutableRouteState
 	)
 	if view != nil {
 		mutables = view.mutables
 		queue = view.queue
 		queueShardIDs = view.queueShardIDs
+		queueRouteModes = view.queueRouteModes
+		queueRanges = view.queueRanges
+		mutableRoute = view.mutableRoute
 	} else {
 		// Defensive fallback: should not happen after Open(), but keep safe
 		// behavior for zero-value DBs and tests.
@@ -22457,6 +23429,9 @@ func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
 		}
 		queue = append([]memtable.Table(nil), db.queue...)
 		queueShardIDs = append([]uint16(nil), db.queueShardIDs...)
+		queueRouteModes = append([]uint8(nil), db.queueRouteModes...)
+		queueRanges = append([]keyRange(nil), db.queueRanges...)
+		mutableRoute = cloneMutableRoute(db.currentMutableRoute.Load())
 		db.mu.RUnlock()
 	}
 
@@ -22464,41 +23439,78 @@ func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
 		return nil, false, nil
 	}
 
-	// check mutable
+	hashIdx := 0
 	if len(mutables) > 0 {
-		idx := db.shardIndex(key)
-		if idx < len(mutables) && mutables[idx] != nil {
-			val, ptr, flags, found := mutables[idx].GetEntry(key)
-			if found {
-				if flags&node.FlagTombstone != 0 {
-					return nil, true, nil
-				}
-				if flags&node.FlagPointer != 0 {
-					if val == nil {
-						readVal, err := db.readValueLog(key, ptr)
-						if err != nil {
-							return nil, true, err
-						}
-						return readVal, true, nil
-					}
-					return val, true, nil
-				}
+		hashIdx = db.hashShardIndex(key)
+	}
+
+	checkMutable := func(idx int) ([]byte, bool, error) {
+		if idx < 0 || idx >= len(mutables) || mutables[idx] == nil {
+			return nil, false, nil
+		}
+		val, ptr, flags, found := mutables[idx].GetEntry(key)
+		if found {
+			if flags&node.FlagTombstone != 0 {
+				return nil, true, nil
+			}
+			if flags&node.FlagPointer != 0 {
 				if val == nil {
-					return []byte{}, true, nil
+					readVal, err := db.readValueLog(key, ptr)
+					if err != nil {
+						return nil, true, err
+					}
+					return readVal, true, nil
 				}
 				return val, true, nil
 			}
+			if val == nil {
+				return []byte{}, true, nil
+			}
+			return val, true, nil
+		}
+		return nil, false, nil
+	}
+
+	checkedHashMutable := false
+	if len(mutables) > 0 {
+		var (
+			routeVal   []byte
+			routeFound bool
+			routeErr   error
+		)
+		forEachMutableRouteShardForKey(mutableRoute, key, func(idx int) bool {
+			if idx == hashIdx {
+				checkedHashMutable = true
+			}
+			routeVal, routeFound, routeErr = checkMutable(idx)
+			return routeErr != nil || routeFound
+		})
+		if routeErr != nil || routeFound {
+			return routeVal, routeFound, routeErr
+		}
+	}
+	if len(mutables) > 0 && !checkedHashMutable {
+		val, found, err := checkMutable(hashIdx)
+		if err != nil || found {
+			return val, found, err
 		}
 	}
 
 	// check queue backwards (newest first)
-	shardIdx := 0
-	if len(mutables) > 0 {
-		shardIdx = db.shardIndex(key)
-	}
 	for i := len(queue) - 1; i >= 0; i-- {
-		if len(queueShardIDs) > i && int(queueShardIDs[i]) != shardIdx {
-			continue
+		routeMode := memtableRouteHashed
+		if len(queueRouteModes) > i {
+			routeMode = queueRouteModes[i]
+		}
+		switch routeMode {
+		case memtableRouteRanged:
+			if len(queueRanges) > i && !keyInRange(queueRanges[i], key) {
+				continue
+			}
+		default:
+			if len(queueShardIDs) > i && int(queueShardIDs[i]) != hashIdx {
+				continue
+			}
 		}
 		val, ptr, flags, found := queue[i].GetEntry(key)
 		if found {
@@ -22530,14 +23542,20 @@ func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
 		defer db.releaseMemtableView(view)
 	}
 	var (
-		mutables      []memtable.Table
-		queue         []memtable.Table
-		queueShardIDs []uint16
+		mutables        []memtable.Table
+		queue           []memtable.Table
+		queueShardIDs   []uint16
+		queueRouteModes []uint8
+		queueRanges     []keyRange
+		mutableRoute    *mutableRouteState
 	)
 	if view != nil {
 		mutables = view.mutables
 		queue = view.queue
 		queueShardIDs = view.queueShardIDs
+		queueRouteModes = view.queueRouteModes
+		queueRanges = view.queueRanges
+		mutableRoute = view.mutableRoute
 	} else {
 		db.mu.RLock()
 		if len(db.mutableShards) > 0 {
@@ -22548,6 +23566,9 @@ func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
 		}
 		queue = append([]memtable.Table(nil), db.queue...)
 		queueShardIDs = append([]uint16(nil), db.queueShardIDs...)
+		queueRouteModes = append([]uint8(nil), db.queueRouteModes...)
+		queueRanges = append([]keyRange(nil), db.queueRanges...)
+		mutableRoute = cloneMutableRoute(db.currentMutableRoute.Load())
 		db.mu.RUnlock()
 	}
 
@@ -22555,41 +23576,77 @@ func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
 		return dst, false, nil
 	}
 
-	// check mutable
+	hashIdx := 0
 	if len(mutables) > 0 {
-		idx := db.shardIndex(key)
-		if idx < len(mutables) && mutables[idx] != nil {
-			val, ptr, flags, found := mutables[idx].GetEntry(key)
-			if found {
-				if flags&node.FlagTombstone != 0 {
-					return dst, true, tree.ErrKeyNotFound
-				}
-				if flags&node.FlagPointer != 0 {
-					if val == nil {
-						out, err := db.readValueLogAppend(key, ptr, dst)
-						if err != nil {
-							return dst, true, err
-						}
-						return out, true, nil
-					}
-					return append(dst, val...), true, nil
-				}
+		hashIdx = db.hashShardIndex(key)
+	}
+
+	checkMutableAppend := func(idx int) ([]byte, bool, error) {
+		if idx < 0 || idx >= len(mutables) || mutables[idx] == nil {
+			return dst, false, nil
+		}
+		val, ptr, flags, found := mutables[idx].GetEntry(key)
+		if found {
+			if flags&node.FlagTombstone != 0 {
+				return dst, true, tree.ErrKeyNotFound
+			}
+			if flags&node.FlagPointer != 0 {
 				if val == nil {
-					return dst, true, nil
+					out, err := db.readValueLogAppend(key, ptr, dst)
+					if err != nil {
+						return dst, true, err
+					}
+					return out, true, nil
 				}
 				return append(dst, val...), true, nil
 			}
+			if val == nil {
+				return dst, true, nil
+			}
+			return append(dst, val...), true, nil
+		}
+		return dst, false, nil
+	}
+
+	checkedHashMutable := false
+	if len(mutables) > 0 {
+		var (
+			routeOut   []byte
+			routeFound bool
+			routeErr   error
+		)
+		forEachMutableRouteShardForKey(mutableRoute, key, func(idx int) bool {
+			if idx == hashIdx {
+				checkedHashMutable = true
+			}
+			routeOut, routeFound, routeErr = checkMutableAppend(idx)
+			return routeErr != nil || routeFound
+		})
+		if routeErr != nil || routeFound {
+			return routeOut, routeFound, routeErr
+		}
+	}
+	if len(mutables) > 0 && !checkedHashMutable {
+		out, found, err := checkMutableAppend(hashIdx)
+		if err != nil || found {
+			return out, found, err
 		}
 	}
 
-	// check queue backwards (newest first)
-	shardIdx := 0
-	if len(mutables) > 0 {
-		shardIdx = db.shardIndex(key)
-	}
 	for i := len(queue) - 1; i >= 0; i-- {
-		if len(queueShardIDs) > i && int(queueShardIDs[i]) != shardIdx {
-			continue
+		routeMode := memtableRouteHashed
+		if len(queueRouteModes) > i {
+			routeMode = queueRouteModes[i]
+		}
+		switch routeMode {
+		case memtableRouteRanged:
+			if len(queueRanges) > i && !keyInRange(queueRanges[i], key) {
+				continue
+			}
+		default:
+			if len(queueShardIDs) > i && int(queueShardIDs[i]) != hashIdx {
+				continue
+			}
 		}
 		val, ptr, flags, found := queue[i].GetEntry(key)
 		if found {
@@ -22825,14 +23882,20 @@ func (db *DB) Has(key []byte) (bool, error) {
 		defer db.releaseMemtableView(view)
 	}
 	var (
-		mutables      []memtable.Table
-		queue         []memtable.Table
-		queueShardIDs []uint16
+		mutables        []memtable.Table
+		queue           []memtable.Table
+		queueShardIDs   []uint16
+		queueRouteModes []uint8
+		queueRanges     []keyRange
+		mutableRoute    *mutableRouteState
 	)
 	if view != nil {
 		mutables = view.mutables
 		queue = view.queue
 		queueShardIDs = view.queueShardIDs
+		queueRouteModes = view.queueRouteModes
+		queueRanges = view.queueRanges
+		mutableRoute = view.mutableRoute
 	} else {
 		db.mu.RLock()
 		if len(db.mutableShards) > 0 {
@@ -22843,26 +23906,66 @@ func (db *DB) Has(key []byte) (bool, error) {
 		}
 		queue = append([]memtable.Table(nil), db.queue...)
 		queueShardIDs = append([]uint16(nil), db.queueShardIDs...)
+		queueRouteModes = append([]uint8(nil), db.queueRouteModes...)
+		queueRanges = append([]keyRange(nil), db.queueRanges...)
+		mutableRoute = cloneMutableRoute(db.currentMutableRoute.Load())
 		db.mu.RUnlock()
 	}
 
+	hashIdx := 0
 	if len(mutables) > 0 {
-		idx := db.shardIndex(key)
-		if idx < len(mutables) && mutables[idx] != nil {
-			_, deleted, found := mutables[idx].Get(key)
-			if found {
-				return !deleted, nil
+		hashIdx = db.hashShardIndex(key)
+	}
+
+	checkMutableHas := func(idx int) (bool, bool) {
+		if idx < 0 || idx >= len(mutables) || mutables[idx] == nil {
+			return false, false
+		}
+		_, deleted, found := mutables[idx].Get(key)
+		if found {
+			return !deleted, true
+		}
+		return false, false
+	}
+
+	checkedHashMutable := false
+	if len(mutables) > 0 {
+		var (
+			routeHas   bool
+			routeFound bool
+		)
+		forEachMutableRouteShardForKey(mutableRoute, key, func(idx int) bool {
+			if idx == hashIdx {
+				checkedHashMutable = true
 			}
+			routeHas, routeFound = checkMutableHas(idx)
+			return routeFound
+		})
+		if routeFound {
+			return routeHas, nil
+		}
+	}
+	if len(mutables) > 0 && !checkedHashMutable {
+		has, found := checkMutableHas(hashIdx)
+		if found {
+			return has, nil
 		}
 	}
 
-	idx := 0
-	if len(mutables) > 0 {
-		idx = db.shardIndex(key)
-	}
 	for i := len(queue) - 1; i >= 0; i-- {
-		if len(queueShardIDs) > i && int(queueShardIDs[i]) != idx {
-			continue
+		routeMode := memtableRouteHashed
+		if len(queueRouteModes) > i {
+			routeMode = queueRouteModes[i]
+		}
+		switch routeMode {
+		case memtableRouteRanged:
+			if len(queueRanges) > i && !keyInRange(queueRanges[i], key) {
+				continue
+			}
+		default:
+			if len(queueShardIDs) > i && int(queueShardIDs[i]) != hashIdx {
+				continue
+			}
 		}
 		_, deleted, found := queue[i].Get(key)
 		if found {
@@ -23336,8 +24439,10 @@ func (db *DB) Stats() map[string]string {
 	memWrites := db.memtableStats.writes.Load()
 	memSeqWrites := db.memtableStats.seqWrites.Load()
 	memOverwriteWrites := db.memtableStats.overwriteWrites.Load()
+	memDeleteWrites := db.memtableStats.deleteWrites.Load()
 	memIters := db.memtableStats.iterators.Load()
 	memRangeIters := db.memtableStats.rangeIters.Load()
+	memCurrentSeqRun := db.memtableStats.currentSeqRun.Load()
 	memAdaptiveDecisionTotal := db.memtableAdaptiveDecisionTotal.Load()
 	memAdaptiveDecisionReason := db.memtableAdaptiveDecisionReason.Load()
 	memAdaptiveDecisionMode := db.memtableAdaptiveDecisionMode.Load()
@@ -23370,12 +24475,15 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.memtable_stats.writes"] = fmt.Sprintf("%d", memWrites)
 	stats["treedb.cache.memtable_stats.seq_writes"] = fmt.Sprintf("%d", memSeqWrites)
 	stats["treedb.cache.memtable_stats.overwrite_writes"] = fmt.Sprintf("%d", memOverwriteWrites)
+	stats["treedb.cache.memtable_stats.delete_writes"] = fmt.Sprintf("%d", memDeleteWrites)
 	if memWrites > 0 {
 		stats["treedb.cache.memtable_stats.seq_write_pct"] = fmt.Sprintf("%.4f", float64(memSeqWrites)/float64(memWrites))
 		stats["treedb.cache.memtable_stats.overwrite_write_pct"] = fmt.Sprintf("%.4f", float64(memOverwriteWrites)/float64(memWrites))
+		stats["treedb.cache.memtable_stats.delete_write_pct"] = fmt.Sprintf("%.4f", float64(memDeleteWrites)/float64(memWrites))
 	}
 	stats["treedb.cache.memtable_stats.iterators"] = fmt.Sprintf("%d", memIters)
 	stats["treedb.cache.memtable_stats.range_iterators"] = fmt.Sprintf("%d", memRangeIters)
+	stats["treedb.cache.memtable_stats.current_seq_run"] = fmt.Sprintf("%d", memCurrentSeqRun)
 	if memIters > 0 {
 		stats["treedb.cache.memtable_stats.range_iter_pct"] = fmt.Sprintf("%.4f", float64(memRangeIters)/float64(memIters))
 	}
@@ -25761,6 +26869,8 @@ type Batch struct {
 	shardCnts          []int
 	shardEntries       [][]batch.Entry
 	shardIdxSets       [][]int
+	retainMainMems     []memtable.Table
+	ptrTouchedMems     []memtable.Table
 	maxEntries         int
 
 	closed bool
@@ -26216,9 +27326,18 @@ func (b *Batch) Reset() {
 	if b.shardIdxSets != nil {
 		b.shardIdxSets = b.shardIdxSets[:0]
 	}
-	b.recycleCopyArenaChunks()
+	if b.retainMainMems != nil {
+		b.retainMainMems = b.retainMainMems[:0]
+	}
+	if b.ptrTouchedMems != nil {
+		b.ptrTouchedMems = b.ptrTouchedMems[:0]
+	}
+	retainedCopyArena := b.retainCopyArenaChunkOnReset()
+	if !retainedCopyArena {
+		b.recycleCopyArenaChunks()
+	}
 	b.recyclePtrCopyArenaChunks()
-	if b.arenaInFlightBytes > 0 {
+	if !retainedCopyArena && b.arenaInFlightBytes > 0 {
 		b.subArenaInFlightBytes(b.arenaInFlightBytes)
 	}
 	if b.db != nil {
@@ -26286,6 +27405,82 @@ func (b *Batch) recycleCopyArenaChunks() {
 		return
 	}
 	putBatchArenas(chunks)
+}
+
+func (b *Batch) retainCopyArenaChunkOnReset() bool {
+	if b == nil || len(b.copyArenaChunks) == 0 || cap(b.copyArena) == 0 {
+		return false
+	}
+	maxRetain := batchCopyArenaMaxRetain
+	if maxChunk := currentBatchCopyArenaMaxChunk(); maxChunk > 0 && maxChunk < maxRetain {
+		maxRetain = maxChunk
+	}
+	if cap(b.copyArena) > maxRetain {
+		return false
+	}
+	if b.db != nil {
+		b.db.noteBatchArenaChunkFinalize(batchArenaKindMain, len(b.copyArena), cap(b.copyArena))
+	}
+	last := len(b.copyArenaChunks) - 1
+	retained := b.copyArenaChunks[last]
+	if cap(retained) == 0 {
+		retained = b.copyArena[:0]
+	} else {
+		retained = retained[:0]
+	}
+	var droppedBytes int64
+	for i := range b.copyArenaChunks {
+		if i == last {
+			continue
+		}
+		if chunk := b.copyArenaChunks[i]; chunk != nil {
+			droppedBytes += int64(cap(chunk))
+			putBatchArena(chunk)
+			b.copyArenaChunks[i] = nil
+		}
+	}
+	if droppedBytes > 0 {
+		b.subArenaInFlightBytes(droppedBytes)
+	}
+	b.copyArenaChunks[0] = retained
+	for i := 1; i < len(b.copyArenaChunks); i++ {
+		b.copyArenaChunks[i] = nil
+	}
+	b.copyArenaChunks = b.copyArenaChunks[:1]
+	b.copyArena = retained
+	b.copyBytes = 0
+	return true
+}
+
+func (b *Batch) reclaimOwnedCopyArenaChunks(chunks [][]byte) {
+	if b == nil || len(chunks) == 0 {
+		return
+	}
+	maxRetain := batchCopyArenaMaxRetain
+	if maxChunk := currentBatchCopyArenaMaxChunk(); maxChunk > 0 && maxChunk < maxRetain {
+		maxRetain = maxChunk
+	}
+	last := len(chunks) - 1
+	retained := chunks[last]
+	if cap(retained) == 0 || cap(retained) > maxRetain {
+		putBatchArenas(chunks)
+		return
+	}
+	for i := 0; i < last; i++ {
+		if chunks[i] != nil {
+			putBatchArena(chunks[i])
+			chunks[i] = nil
+		}
+	}
+	retained = retained[:0]
+	chunks[0] = retained
+	for i := 1; i < len(chunks); i++ {
+		chunks[i] = nil
+	}
+	b.copyArena = retained
+	b.copyArenaChunks = chunks[:1]
+	b.copyBytes = 0
+	b.addArenaInFlightBytes(cap(retained))
 }
 
 func (b *Batch) drainPtrCopyArenaChunks() [][]byte {
@@ -26696,6 +27891,54 @@ func (b *Batch) SetView(key, value []byte) error {
 	return nil
 }
 
+// SetStealView records a Put without copying key/value bytes and permits the
+// DB to retain those slices beyond the batch lifetime.
+func (b *Batch) SetStealView(key, value []byte) error {
+	if b.closed {
+		return ErrBatchClosed
+	}
+	if len(key) == 0 {
+		return ErrKeyEmpty
+	}
+	if value == nil {
+		return ErrValueNil
+	}
+
+	if b.backend != nil {
+		b.batchRange.add(key)
+		b.size += len(key) + len(value)
+		if ssv, ok := b.backend.(interface{ SetStealView(key, value []byte) error }); ok {
+			return ssv.SetStealView(key, value)
+		}
+		if sv, ok := b.backend.(interface{ SetView(key, value []byte) error }); ok {
+			return sv.SetView(key, value)
+		}
+		return b.backend.Set(key, value)
+	}
+
+	if b.streamEligible {
+		if b.firstKey == nil {
+			b.firstKey = key
+			b.lastKey = key
+		} else {
+			if bytes.Compare(key, b.lastKey) <= 0 {
+				b.streamEligible = false
+			}
+			b.lastKey = key
+		}
+	}
+	b.entries = append(b.entries, batch.Entry{
+		Type:  batch.OpPut,
+		Key:   key,
+		Value: value,
+	})
+	b.noteEntryAppend()
+	b.size += len(key) + len(value)
+
+	b.maybeSwitchToStreaming()
+	return nil
+}
+
 func (b *Batch) Delete(key []byte) error {
 	if b.closed {
 		return ErrBatchClosed
@@ -26957,11 +28200,98 @@ func (b *Batch) WriteSync() error {
 	return b.write(true)
 }
 
+func (b *Batch) isDeleteOnly() bool {
+	if b == nil || len(b.entries) == 0 {
+		return false
+	}
+	for i := range b.entries {
+		if b.entries[i].Type != batch.OpDelete {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *Batch) trySkipDeleteOnlyWriteOnEmptyDB() (bool, error) {
+	if b == nil || b.db == nil || !b.db.disableJournal || b.backend != nil || !b.isDeleteOnly() {
+		return false, nil
+	}
+
+	// When WAL is disabled and there is no durable or in-memory state, delete-only
+	// batches against missing keys are true no-ops. Validate backend emptiness under
+	// flush exclusion so direct backend bypass writes cannot race this check.
+	if b.db.mutableBytes.Load() != 0 {
+		return false, nil
+	}
+	b.db.mu.RLock()
+	if len(b.db.queue) != 0 || (b.db.backendRangeKnown && b.db.backendRange.valid) {
+		b.db.mu.RUnlock()
+		return false, nil
+	}
+	cachedEmpty := b.db.backendRangeKnown
+	b.db.mu.RUnlock()
+
+	b.db.writeMu.Lock()
+	defer b.db.writeMu.Unlock()
+	b.db.flushMu.Lock()
+	defer b.db.flushMu.Unlock()
+
+	if b.db.mutableBytes.Load() != 0 {
+		return false, nil
+	}
+	b.db.mu.Lock()
+	queueLen := len(b.db.queue)
+	known := b.db.backendRangeKnown
+	actualBackendRange := b.db.backendRange
+	b.db.mu.Unlock()
+
+	if queueLen != 0 || (known && actualBackendRange.valid) {
+		return false, nil
+	}
+	if !known && !cachedEmpty {
+		var err error
+		actualBackendRange, known, err = b.db.computeBackendRange()
+		if err != nil {
+			return false, err
+		}
+
+		b.db.mu.Lock()
+		if known {
+			b.db.backendRangeKnown = true
+			b.db.backendRange = keyRange{}
+			if actualBackendRange.valid {
+				b.db.backendRange.add(actualBackendRange.min)
+				b.db.backendRange.add(actualBackendRange.max)
+			}
+		} else {
+			b.db.backendRangeKnown = false
+			b.db.backendRange = keyRange{}
+		}
+		queueLen = len(b.db.queue)
+		b.db.mu.Unlock()
+	}
+
+	if !known || actualBackendRange.valid || queueLen != 0 || b.db.mutableBytes.Load() != 0 {
+		return false, nil
+	}
+
+	b.updateBatchEntryHint()
+	b.updateBatchCopyHint()
+	b.Reset()
+	return true, nil
+}
+
 func (b *Batch) write(sync bool) error {
 	if b.closed {
 		return ErrBatchClosed
 	}
 	b.db.waitForCheckpoint()
+
+	if ok, err := b.trySkipDeleteOnlyWriteOnEmptyDB(); err != nil {
+		return err
+	} else if ok {
+		return nil
+	}
 
 	if b.backend != nil {
 		var err error
@@ -27111,8 +28441,44 @@ func (b *Batch) tryWriteWALOffStreamBypass(sync bool) (bool, error) {
 }
 
 func (b *Batch) writeRegular(syncWrite bool) error {
-	b.db.writeMu.RLock()
+	routeSortedBatch := false
+	if b.db != nil &&
+		len(b.db.mutableShards) > 1 &&
+		b.streamEligible &&
+		!b.hasViewOps &&
+		len(b.entries) >= 256 {
+		routeSortedBatch = true
+		for i := range b.entries {
+			if b.entries[i].Type != batch.OpPut {
+				routeSortedBatch = false
+				break
+			}
+		}
+	}
+
+	if routeSortedBatch {
+		b.db.writeMu.Lock()
+	} else {
+		b.db.writeMu.RLock()
+	}
+	unlockWrite := func() {
+		if routeSortedBatch {
+			b.db.writeMu.Unlock()
+		} else {
+			b.db.writeMu.RUnlock()
+		}
+	}
+	if routeSortedBatch {
+		b.db.mu.Lock()
+		_, err := b.db.ensureMutableRouteForSortedBatchLocked(b.entries)
+		b.db.mu.Unlock()
+		if err != nil {
+			unlockWrite()
+			return err
+		}
+	}
 	needRotate := false
+	needForcedRotate := false
 	needSyncBarrier := false
 
 	// 1. Memtable capacity pre-check
@@ -27134,6 +28500,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		clear(shardCounts)
 	}
 	b.shardCnts = shardCounts
+	touchedShardIdxs := make([]int, 0, shardCount)
 
 	shardIdxs := b.shardIdxs
 	if cap(shardIdxs) < len(b.entries) {
@@ -27143,14 +28510,20 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		shardIdxs = shardIdxs[:len(b.entries)]
 	}
 	b.shardIdxs = shardIdxs
+	deleteCount := 0
 	allDeletes := true
 	for i := range b.entries {
 		op := &b.entries[i]
-		if op.Type != batch.OpDelete {
+		if op.Type == batch.OpDelete {
+			deleteCount++
+		} else {
 			allDeletes = false
 		}
-		idx := b.db.shardIndex(op.Key)
+		idx := b.db.shardIndexForWrite(op.Key)
 		shardIdxs[i] = idx
+		if shardCounts[idx] == 0 {
+			touchedShardIdxs = append(touchedShardIdxs, idx)
+		}
 		shardCounts[idx]++
 		add := int64(len(op.Key))
 		if op.Type == batch.OpPut {
@@ -27158,8 +28531,20 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		}
 		shardAdds[idx] += add
 	}
-	retainMainMems := make([]memtable.Table, 0, shardCount)
-	retainMainSeen := make(map[memtable.Table]struct{}, shardCount)
+	retainMainMems := b.retainMainMems
+	if cap(retainMainMems) < shardCount {
+		retainMainMems = make([]memtable.Table, 0, shardCount)
+	} else {
+		retainMainMems = retainMainMems[:0]
+	}
+	globalSortedRun := b.streamEligible && len(b.entries) > 0
+	var globalSortedFirst, globalSortedLast []byte
+	globalSortedCount := 0
+	if globalSortedRun {
+		globalSortedFirst = b.entries[0].Key
+		globalSortedLast = b.entries[len(b.entries)-1].Key
+		globalSortedCount = len(b.entries)
+	}
 	for i, add := range shardAdds {
 		if add == 0 {
 			continue
@@ -27169,7 +28554,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		over := b.db.shardExceedsLimit(shard, add)
 		shard.mu.Unlock()
 		if over {
-			b.db.writeMu.RUnlock()
+			unlockWrite()
 			return ErrMemtableFull
 		}
 	}
@@ -27278,7 +28663,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	if needLaneForPointers || needLaneForJournal {
 		l, err := b.db.pickLane(durability == journalDurabilitySync, -1)
 		if err != nil {
-			b.db.writeMu.RUnlock()
+			unlockWrite()
 			return err
 		}
 		lane = l
@@ -27375,7 +28760,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			for _, laneID := range activeLaneIDs {
 				lb := &laneBatches[laneID]
 				if lb.err != nil {
-					b.db.writeMu.RUnlock()
+					unlockWrite()
 					return lb.err
 				}
 			}
@@ -27424,13 +28809,13 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			)
 			valueRecords, groups, outerArena, buildErr := b.db.buildOuterLeafValueRecords(keys, values)
 			if buildErr != nil {
-				b.db.writeMu.RUnlock()
+				unlockWrite()
 				return buildErr
 			}
 			if len(valueRecords) == 0 {
 				putValueLogRecordsNoClear(valueRecords)
 				putOuterLeafArena(outerArena)
-				b.db.writeMu.RUnlock()
+				unlockWrite()
 				return fmt.Errorf("cachingdb: empty value-log record set for %d eligible ops", eligibleCount)
 			}
 			defer putValueLogRecordsNoClear(valueRecords)
@@ -27442,7 +28827,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				if rids != nil {
 					group := groups[i]
 					if group.start < 0 || group.end < group.start || group.end > len(eligibleIdxs) {
-						b.db.writeMu.RUnlock()
+						unlockWrite()
 						return fmt.Errorf("cachingdb: value-log group out of range [%d,%d) len=%d", group.start, group.end, len(eligibleIdxs))
 					}
 					for srcPos := group.start; srcPos < group.end; srcPos++ {
@@ -27453,12 +28838,12 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			}
 			ptrs, buildErr = b.db.appendValueLogForRecords(lane, valueRecords, durability)
 			if buildErr != nil {
-				b.db.writeMu.RUnlock()
+				unlockWrite()
 				return buildErr
 			}
 			if len(ptrs) != len(groups) {
 				putValueLogPtrs(ptrs)
-				b.db.writeMu.RUnlock()
+				unlockWrite()
 				return fmt.Errorf("cachingdb: value-log pointer group count mismatch expected=%d got=%d", len(groups), len(ptrs))
 			}
 			defer putValueLogPtrs(ptrs)
@@ -27468,7 +28853,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				ptr := ptrs[i]
 				group := groups[i]
 				if group.start < 0 || group.end < group.start || group.end > len(eligibleIdxs) {
-					b.db.writeMu.RUnlock()
+					unlockWrite()
 					return fmt.Errorf("cachingdb: value-log pointer group out of range [%d,%d) len=%d", group.start, group.end, len(eligibleIdxs))
 				}
 				for srcPos := group.start; srcPos < group.end; srcPos++ {
@@ -27512,7 +28897,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		}
 		b.walBuf = records
 		if err := b.db.appendWAL(lane, records, durability); err != nil {
-			b.db.writeMu.RUnlock()
+			unlockWrite()
 			return err
 		}
 	}
@@ -27560,6 +28945,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			}
 			shard := &b.db.mutableShards[i]
 			shard.mu.Lock()
+			retainMain := false
 			useSteal, stealSuppressedDeferred := cachedBatchWriteUseSteal(b.db, shard.mem)
 			useSteal = allowBatchArenaBorrow && useSteal
 			if stealSuppressedDeferred && allowBatchArenaBorrow {
@@ -27567,10 +28953,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				batchArenaStealSuppressedDeferredEntriesTotal.Add(uint64(len(idxs)))
 			}
 			if useSteal && cachedBatchWriteNeedsBatchArenaRetention(shard.mem) {
-				if _, ok := retainMainSeen[shard.mem]; !ok {
-					retainMainSeen[shard.mem] = struct{}{}
-					retainMainMems = append(retainMainMems, shard.mem)
-				}
+				retainMain = true
 			}
 			if b.streamEligible {
 				first := b.entries[idxs[0]].Key
@@ -27584,13 +28967,11 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				if len(idxs) > 1 {
 					shard.rng.add(last)
 				}
-				b.db.noteWriteSortedRun(first, last, len(idxs))
 			} else {
 				for _, entryIdx := range idxs {
 					key := b.entries[entryIdx].Key
 					memtableBatchDelete(shard.mem, useSteal, key)
 					shard.rng.add(key)
-					b.db.noteWriteKey(key)
 				}
 			}
 			newBytes := shard.mem.Size()
@@ -27598,78 +28979,148 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			shard.bytes = newBytes
 			b.db.mutableBytes.Add(delta)
 			shard.mu.Unlock()
+			if retainMain {
+				retainMainMems = append(retainMainMems, shard.mem)
+			}
 		}
 	} else {
-		shardEntries := b.shardEntries
-		if cap(shardEntries) < shardCount {
-			shardEntries = make([][]batch.Entry, shardCount)
+		shardIdxSets := b.shardIdxSets
+		if cap(shardIdxSets) < shardCount {
+			shardIdxSets = make([][]int, shardCount)
 		} else {
-			shardEntries = shardEntries[:shardCount]
-			for i := range shardEntries {
-				shardEntries[i] = shardEntries[i][:0]
+			shardIdxSets = shardIdxSets[:shardCount]
+			for i := range shardIdxSets {
+				shardIdxSets[i] = shardIdxSets[i][:0]
 			}
 		}
-		b.shardEntries = shardEntries
+		b.shardIdxSets = shardIdxSets
 		for i, count := range shardCounts {
-			if count > 0 {
-				entries := shardEntries[i]
-				if cap(entries) < count {
-					entries = b.db.getBatchShardEntries(count)
-				} else {
-					entries = entries[:0]
-				}
-				shardEntries[i] = entries
+			if count <= 0 {
+				continue
 			}
+			idxs := shardIdxSets[i]
+			if cap(idxs) < count {
+				idxs = b.db.getBatchIntSlice(count)
+			} else {
+				idxs = idxs[:0]
+			}
+			shardIdxSets[i] = idxs
 		}
-		for i, op := range b.entries {
+		for i := range b.entries {
 			idx := shardIdxs[i]
-			shardEntries[idx] = append(shardEntries[idx], op)
+			shardIdxSets[idx] = append(shardIdxSets[idx], i)
+		}
+
+		shardEntries := b.shardEntries
+		shardEntriesInit := false
+		materializeShardEntries := func(shardID int, idxs []int) []batch.Entry {
+			if !shardEntriesInit {
+				if cap(shardEntries) < shardCount {
+					shardEntries = make([][]batch.Entry, shardCount)
+				} else {
+					shardEntries = shardEntries[:shardCount]
+					for i := range shardEntries {
+						shardEntries[i] = shardEntries[i][:0]
+					}
+				}
+				shardEntriesInit = true
+				b.shardEntries = shardEntries
+			}
+			entries := shardEntries[shardID]
+			if cap(entries) < len(idxs) {
+				entries = b.db.getBatchShardEntries(len(idxs))
+			} else {
+				entries = entries[:0]
+			}
+			for _, entryIdx := range idxs {
+				entries = append(entries, b.entries[entryIdx])
+			}
+			shardEntries[shardID] = entries
+			return entries
 		}
 
 		// 3. Memtable Update
-		for i := range shardEntries {
-			entries := shardEntries[i]
-			if len(entries) == 0 {
+		for i := range shardIdxSets {
+			idxs := shardIdxSets[i]
+			if len(idxs) == 0 {
 				continue
 			}
 			shard := &b.db.mutableShards[i]
 			shard.mu.Lock()
+			retainMain := false
 			useStream := b.streamEligible
 			useSteal, stealSuppressedDeferred := cachedBatchWriteUseSteal(b.db, shard.mem)
 			useSteal = allowBatchArenaBorrow && useSteal
 			if stealSuppressedDeferred && allowBatchArenaBorrow {
 				batchArenaStealSuppressedDeferredTotal.Add(1)
-				batchArenaStealSuppressedDeferredEntriesTotal.Add(uint64(len(entries)))
+				batchArenaStealSuppressedDeferredEntriesTotal.Add(uint64(len(idxs)))
 			}
 			if useSteal && cachedBatchWriteNeedsBatchArenaRetention(shard.mem) {
-				if _, ok := retainMainSeen[shard.mem]; !ok {
-					retainMainSeen[shard.mem] = struct{}{}
-					retainMainMems = append(retainMainMems, shard.mem)
-				}
+				retainMain = true
 			}
 			storeInlinePtrValues := !b.db.memtableValueLogPointers
+			firstKey := b.entries[idxs[0]].Key
+			lastKey := b.entries[idxs[len(idxs)-1]].Key
 			if useStream && useSteal {
-				if applier, ok := shard.mem.(memtable.TrustedSortedBatchApplier); ok {
-					applier.ApplyStealSortedBatchTrusted(entries, nil)
-				} else if applier, ok := shard.mem.(memtable.SortedBatchApplier); ok {
-					applier.ApplyStealSortedBatch(entries, nil)
+				if applier, ok := shard.mem.(memtable.TrustedSortedBatchIndexApplier); ok {
+					applier.ApplyStealSortedBatchIndicesTrusted(b.entries, idxs, nil)
 				} else {
-					for _, op := range entries {
-						if op.Type == batch.OpDelete {
-							memtableBatchDelete(shard.mem, true, op.Key)
-						} else {
-							memtableBatchSet(shard.mem, true, allowBatchArenaBorrow, storeInlinePtrValues, op)
+					entries := materializeShardEntries(i, idxs)
+					if applier, ok := shard.mem.(memtable.TrustedSortedBatchApplier); ok {
+						applier.ApplyStealSortedBatchTrusted(entries, nil)
+					} else if applier, ok := shard.mem.(memtable.SortedBatchApplier); ok {
+						applier.ApplyStealSortedBatch(entries, nil)
+					} else {
+						for _, op := range entries {
+							if op.Type == batch.OpDelete {
+								memtableBatchDelete(shard.mem, true, op.Key)
+							} else {
+								memtableBatchSet(shard.mem, true, allowBatchArenaBorrow, storeInlinePtrValues, op)
+							}
 						}
 					}
 				}
-				first := entries[0].Key
-				last := entries[len(entries)-1].Key
-				shard.rng.add(first)
-				if len(entries) > 1 {
-					shard.rng.add(last)
+				shard.rng.add(firstKey)
+				if len(idxs) > 1 {
+					shard.rng.add(lastKey)
 				}
-				b.db.noteWriteSortedRun(first, last, len(entries))
+			} else if useStream && allowBatchArenaBorrow {
+				borrowedValues := false
+				if applier, ok := shard.mem.(memtable.TrustedSortedBatchBorrowValueIndexApplier); ok {
+					borrowedValues = memtableBatchBorrowsValuesIdxs(shard.mem, true, storeInlinePtrValues, b.entries, idxs)
+					applier.ApplyBorrowValueSortedBatchIndicesTrusted(b.entries, idxs, storeInlinePtrValues, nil)
+				} else if applier, ok := shard.mem.(memtable.SortedBatchBorrowValueApplier); ok {
+					entries := materializeShardEntries(i, idxs)
+					borrowedValues = memtableBatchBorrowsValues(shard.mem, true, storeInlinePtrValues, entries)
+					applier.ApplyBorrowValueSortedBatch(entries, storeInlinePtrValues, nil)
+				} else {
+					entries := materializeShardEntries(i, idxs)
+					if applier, ok := shard.mem.(memtable.TrustedSortedBatchBorrowValueApplier); ok {
+						borrowedValues = memtableBatchBorrowsValues(shard.mem, true, storeInlinePtrValues, entries)
+						applier.ApplyBorrowValueSortedBatchTrusted(entries, storeInlinePtrValues, nil)
+					} else if applier, ok := shard.mem.(memtable.SortedBatchBorrowValueApplier); ok {
+						borrowedValues = memtableBatchBorrowsValues(shard.mem, true, storeInlinePtrValues, entries)
+						applier.ApplyBorrowValueSortedBatch(entries, storeInlinePtrValues, nil)
+					} else {
+						for _, op := range entries {
+							if op.Type == batch.OpDelete {
+								memtableBatchDelete(shard.mem, false, op.Key)
+							} else {
+								memtableBatchSet(shard.mem, false, true, storeInlinePtrValues, op)
+							}
+						}
+						borrowedValues = memtableBatchBorrowsValues(shard.mem, true, storeInlinePtrValues, entries)
+					}
+				}
+				if borrowedValues {
+					retainMain = true
+				}
+				shard.rng.add(firstKey)
+				if len(idxs) > 1 {
+					shard.rng.add(lastKey)
+				}
 			} else {
+				entries := materializeShardEntries(i, idxs)
 				for _, op := range entries {
 					if op.Type == batch.OpDelete {
 						memtableBatchDelete(shard.mem, useSteal, op.Key)
@@ -27686,10 +29137,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 						}
 						memtableBatchSet(shard.mem, useSteal, allowBatchArenaBorrow, storeInlinePtrValues, op)
 						if borrowed {
-							if _, ok := retainMainSeen[shard.mem]; !ok {
-								retainMainSeen[shard.mem] = struct{}{}
-								retainMainMems = append(retainMainMems, shard.mem)
-							}
+							retainMain = true
 						}
 					}
 					if useStream {
@@ -27697,16 +29145,17 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 						continue
 					}
 					shard.rng.add(op.Key)
-					b.db.noteWriteKey(op.Key)
+					if op.Type == batch.OpDelete {
+						b.db.noteDeleteKey(op.Key)
+					} else {
+						b.db.noteWriteKey(op.Key)
+					}
 				}
 				if useStream {
-					first := entries[0].Key
-					last := entries[len(entries)-1].Key
-					shard.rng.add(first)
-					if len(entries) > 1 {
-						shard.rng.add(last)
+					shard.rng.add(firstKey)
+					if len(idxs) > 1 {
+						shard.rng.add(lastKey)
 					}
-					b.db.noteWriteSortedRun(first, last, len(entries))
 				}
 			}
 			newBytes := shard.mem.Size()
@@ -27714,7 +29163,20 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			shard.bytes = newBytes
 			b.db.mutableBytes.Add(delta)
 			shard.mu.Unlock()
+			if retainMain {
+				retainMainMems = append(retainMainMems, shard.mem)
+			}
 		}
+	}
+	if globalSortedRun {
+		b.db.noteWriteSortedRunWithDeletes(globalSortedFirst, globalSortedLast, globalSortedCount, deleteCount)
+	} else if allDeletes {
+		b.db.noteDeleteBatch(len(b.entries))
+	}
+	if b.db.shouldRotateForDeleteHeavyRecovery() {
+		needForcedRotate = true
+	} else if globalSortedRun && b.db.shouldRotateForTailSequentialRecovery() && b.db.mutableNeedsSequentialRecovery() {
+		needForcedRotate = true
 	}
 
 	// 3. Threshold Check
@@ -27728,12 +29190,17 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	b.updateBatchCopyHint()
 	mainChunks := b.drainCopyArenaChunks()
 	retainPtrArena := false
-	ptrTouchedMems := make([]memtable.Table, 0, len(b.ptrValueIdxs))
+	ptrTouchedMems := b.ptrTouchedMems
+	if cap(ptrTouchedMems) < len(b.ptrValueIdxs) {
+		ptrTouchedMems = make([]memtable.Table, 0, len(b.ptrValueIdxs))
+	} else {
+		ptrTouchedMems = ptrTouchedMems[:0]
+	}
 	if allowBatchArenaBorrow && len(b.ptrValueIdxs) > 0 {
 		seenPtrMems := make(map[memtable.Table]struct{}, len(b.ptrValueIdxs))
 		for _, idx := range b.ptrValueIdxs {
 			if idx < 0 || idx >= len(b.entries) || idx >= len(shardIdxs) {
-				b.db.writeMu.RUnlock()
+				unlockWrite()
 				return fmt.Errorf("cachingdb: ptr value entry index %d out of range", idx)
 			}
 			if b.entries[idx].Value == nil {
@@ -27742,7 +29209,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			retainPtrArena = true
 			shardIdx := shardIdxs[idx]
 			if shardIdx < 0 || shardIdx >= len(b.db.mutableShards) {
-				b.db.writeMu.RUnlock()
+				unlockWrite()
 				return fmt.Errorf("cachingdb: ptr value shard index %d out of range for entry %d", shardIdx, idx)
 			}
 			mt := b.db.mutableShards[shardIdx].mem
@@ -27756,21 +29223,37 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			ptrTouchedMems = append(ptrTouchedMems, mt)
 		}
 	}
+	b.retainMainMems = retainMainMems
+	b.ptrTouchedMems = ptrTouchedMems
 	if b.ptrValueIdxs != nil {
 		b.ptrValueIdxs = b.ptrValueIdxs[:0]
 	}
 	ptrChunks := b.drainPtrCopyArenaChunks()
-	b.db.retainBatchArenaChunksForMemtables(mainChunks, retainMainMems)
+	if len(retainMainMems) > 0 {
+		b.db.retainBatchArenaChunksForMemtables(mainChunks, retainMainMems)
+	} else {
+		b.reclaimOwnedCopyArenaChunks(mainChunks)
+	}
 	if retainPtrArena {
 		b.db.retainBatchArenaChunksForMemtables(ptrChunks, ptrTouchedMems)
 	} else {
 		putBatchArenas(ptrChunks)
 	}
-	b.db.writeMu.RUnlock()
+	unlockWrite()
 
-	if needRotate {
-		if err := b.db.maybeRotateMemtable(true); err != nil {
+	if needForcedRotate {
+		if err := b.db.forceRotateMemtableToMode(true, memtable.ModeAppendOnly); err != nil {
 			return err
+		}
+	} else if needRotate {
+		if b.db.currentMutableRoute.Load() != nil || len(touchedShardIdxs) <= 1 {
+			if err := b.db.maybeRotateMutableShards(true, touchedShardIdxs); err != nil {
+				return err
+			}
+		} else {
+			if err := b.db.maybeRotateMemtable(true); err != nil {
+				return err
+			}
 		}
 	}
 	if needSyncBarrier {
@@ -28057,11 +29540,13 @@ func (b *Batch) writeBypass(sync bool) (err error) {
 	mutableRange := b.db.snapshotMutableRange()
 
 	var (
-		mutables      []memtable.Table
-		queue         []memtable.Table
-		queueShardIDs []uint16
-		queueRanges   []keyRange
-		overlaps      bool
+		mutables        []memtable.Table
+		queue           []memtable.Table
+		queueShardIDs   []uint16
+		queueRouteModes []uint8
+		queueRanges     []keyRange
+		mutableRoute    *mutableRouteState
+		overlaps        bool
 	)
 	view := b.db.retainMemtableView()
 	if view != nil {
@@ -28074,7 +29559,9 @@ func (b *Batch) writeBypass(sync bool) (err error) {
 		mutables = view.mutables
 		queue = view.queue
 		queueShardIDs = view.queueShardIDs
+		queueRouteModes = view.queueRouteModes
 		queueRanges = view.queueRanges
+		mutableRoute = view.mutableRoute
 	} else {
 		// Defensive fallback: should not happen after Open(), but keep safe
 		// behavior for zero-value DBs and tests.
@@ -28090,9 +29577,13 @@ func (b *Batch) writeBypass(sync bool) (err error) {
 		if len(b.db.queueShardIDs) > 0 {
 			queueShardIDs = append([]uint16(nil), b.db.queueShardIDs...)
 		}
+		if len(b.db.queueRouteModes) > 0 {
+			queueRouteModes = append([]uint8(nil), b.db.queueRouteModes...)
+		}
 		if len(b.db.queueRanges) > 0 {
 			queueRanges = append([]keyRange(nil), b.db.queueRanges...)
 		}
+		mutableRoute = cloneMutableRoute(b.db.currentMutableRoute.Load())
 	}
 	b.db.mu.RUnlock()
 
@@ -28113,18 +29604,45 @@ func (b *Batch) writeBypass(sync bool) (err error) {
 		// Slow path: verify no individual key exists in memory (handles sparse overlap).
 		for _, op := range b.entries {
 			key := op.Key
+			hashIdx := 0
 			if len(mutables) > 0 {
-				idx := b.db.shardIndex(key)
-				if idx < len(mutables) && mutables[idx] != nil {
-					if _, _, found := mutables[idx].Get(key); found {
+				hashIdx = b.db.hashShardIndex(key)
+			}
+			checkedHashMutable := false
+			if len(mutables) > 0 {
+				routeFound := false
+				forEachMutableRouteShardForKey(mutableRoute, key, func(idx int) bool {
+					if idx == hashIdx {
+						checkedHashMutable = true
+					}
+					if idx >= 0 && idx < len(mutables) && mutables[idx] != nil {
+						_, _, routeFound = mutables[idx].Get(key)
+					}
+					return routeFound
+				})
+				if routeFound {
+					return b.writeRegular(sync)
+				}
+			}
+			if len(mutables) > 0 && !checkedHashMutable {
+				if hashIdx < len(mutables) && mutables[hashIdx] != nil {
+					if _, _, found := mutables[hashIdx].Get(key); found {
 						return b.writeRegular(sync)
 					}
 				}
 			}
 			for i := len(queue) - 1; i >= 0; i-- {
-				if len(queueShardIDs) > i && len(mutables) > 0 {
-					idx := b.db.shardIndex(key)
-					if int(queueShardIDs[i]) != idx {
+				routeMode := memtableRouteHashed
+				if len(queueRouteModes) > i {
+					routeMode = queueRouteModes[i]
+				}
+				switch routeMode {
+				case memtableRouteRanged:
+					if len(queueRanges) > i && !keyInRange(queueRanges[i], key) {
+						continue
+					}
+				default:
+					if len(queueShardIDs) > i && int(queueShardIDs[i]) != hashIdx {
 						continue
 					}
 				}
@@ -28254,6 +29772,8 @@ func (b *Batch) Close() error {
 	b.shardCnts = nil
 	b.shardEntries = nil
 	b.shardIdxSets = nil
+	b.retainMainMems = nil
+	b.ptrTouchedMems = nil
 	b.firstKey = nil
 	b.lastKey = nil
 	b.ptrValueIdxs = nil

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -29237,9 +29237,13 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			delta := newBytes - shard.bytes
 			shard.bytes = newBytes
 			b.db.mutableBytes.Add(delta)
-			shard.mu.Unlock()
+			var retainedMain memtable.Table
 			if retainMain {
-				retainMainMems = append(retainMainMems, shard.mem)
+				retainedMain = shard.mem
+			}
+			shard.mu.Unlock()
+			if retainedMain != nil {
+				retainMainMems = append(retainMainMems, retainedMain)
 			}
 		}
 	}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -23344,8 +23344,14 @@ func (db *DB) flushOneLocked(sync bool) bool {
 //   - We require global mutable bytes to be zero.
 //   - We additionally check the target mutable shard length to avoid races where
 //     mutableBytes is transiently zero while an old view still has entries.
+//   - Routed mutable ranges bypass the hash shard; if a key is currently routed,
+//     do not bypass because the hash shard can be empty while the routed shard
+//     still owns the newest value.
 func (db *DB) canBypassMemtableRead(view *memtableView, key []byte) bool {
 	if view == nil || len(view.queue) != 0 || db.mutableBytes.Load() != 0 {
+		return false
+	}
+	if keyInMutableRoute(view.mutableRoute, key) {
 		return false
 	}
 	if len(view.mutables) == 0 {
@@ -23371,6 +23377,11 @@ func (db *DB) canBypassMemtableReadMany(view *memtableView, keys [][]byte) bool 
 	}
 	if view == nil || len(view.queue) != 0 || db.mutableBytes.Load() != 0 {
 		return false
+	}
+	for _, key := range keys {
+		if keyInMutableRoute(view.mutableRoute, key) {
+			return false
+		}
 	}
 	n := len(view.mutables)
 	if n == 0 {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -23249,6 +23249,9 @@ func (db *DB) flushOneLocked(sync bool) bool {
 	if len(db.queueShardIDs) > 0 {
 		db.queueShardIDs = db.queueShardIDs[1:]
 	}
+	if len(db.queueRouteModes) > 0 {
+		db.queueRouteModes = db.queueRouteModes[1:]
+	}
 	if len(db.queueLaneIDs) > 0 {
 		db.queueLaneIDs = db.queueLaneIDs[1:]
 	}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -27930,8 +27930,12 @@ func (b *Batch) SetView(key, value []byte) error {
 	return nil
 }
 
-// SetStealView records a Put without copying key/value bytes and permits the
-// DB to retain those slices beyond the batch lifetime.
+// SetStealView records a Put without copying key/value bytes. Unlike SetView,
+// the DB may retain key/value references beyond Write or Close.
+//
+// Callers must treat key/value as transferred and immutable after this call:
+// do not mutate, reuse, or repurpose their backing arrays in any way that
+// could affect stored data.
 func (b *Batch) SetStealView(key, value []byte) error {
 	if b.closed {
 		return ErrBatchClosed
@@ -28270,10 +28274,10 @@ func (b *Batch) trySkipDeleteOnlyWriteOnEmptyDB() (bool, error) {
 	cachedEmpty := b.db.backendRangeKnown
 	b.db.mu.RUnlock()
 
-	b.db.writeMu.Lock()
-	defer b.db.writeMu.Unlock()
 	b.db.flushMu.Lock()
 	defer b.db.flushMu.Unlock()
+	b.db.writeMu.Lock()
+	defer b.db.writeMu.Unlock()
 
 	if b.db.mutableBytes.Load() != 0 {
 		return false, nil

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -23487,6 +23487,47 @@ func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
 		return nil, false, nil
 	}
 
+	checkQueue := func(rangedOnly bool) ([]byte, bool, error) {
+		for i := len(queue) - 1; i >= 0; i-- {
+			routeMode := memtableRouteHashed
+			if len(queueRouteModes) > i {
+				routeMode = queueRouteModes[i]
+			}
+			isRanged := routeMode == memtableRouteRanged
+			if rangedOnly != isRanged {
+				continue
+			}
+			if isRanged {
+				if len(queueRanges) > i && !keyInRange(queueRanges[i], key) {
+					continue
+				}
+			} else if len(queueShardIDs) > i && int(queueShardIDs[i]) != hashIdx {
+				continue
+			}
+			val, ptr, flags, found := queue[i].GetEntry(key)
+			if found {
+				if flags&node.FlagTombstone != 0 {
+					return nil, true, nil
+				}
+				if flags&node.FlagPointer != 0 {
+					if val == nil {
+						readVal, err := db.readValueLog(key, ptr)
+						if err != nil {
+							return nil, true, err
+						}
+						return readVal, true, nil
+					}
+					return val, true, nil
+				}
+				if val == nil {
+					return []byte{}, true, nil
+				}
+				return val, true, nil
+			}
+		}
+		return nil, false, nil
+	}
+
 	checkedHashMutable := false
 	if len(mutables) > 0 {
 		var (
@@ -23505,51 +23546,16 @@ func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
 			return routeVal, routeFound, routeErr
 		}
 	}
+	if val, found, err := checkQueue(true); err != nil || found {
+		return val, found, err
+	}
 	if len(mutables) > 0 && !checkedHashMutable {
 		val, found, err := checkMutable(hashIdx)
 		if err != nil || found {
 			return val, found, err
 		}
 	}
-
-	// check queue backwards (newest first)
-	for i := len(queue) - 1; i >= 0; i-- {
-		routeMode := memtableRouteHashed
-		if len(queueRouteModes) > i {
-			routeMode = queueRouteModes[i]
-		}
-		switch routeMode {
-		case memtableRouteRanged:
-			if len(queueRanges) > i && !keyInRange(queueRanges[i], key) {
-				continue
-			}
-		default:
-			if len(queueShardIDs) > i && int(queueShardIDs[i]) != hashIdx {
-				continue
-			}
-		}
-		val, ptr, flags, found := queue[i].GetEntry(key)
-		if found {
-			if flags&node.FlagTombstone != 0 {
-				return nil, true, nil
-			}
-			if flags&node.FlagPointer != 0 {
-				if val == nil {
-					readVal, err := db.readValueLog(key, ptr)
-					if err != nil {
-						return nil, true, err
-					}
-					return readVal, true, nil
-				}
-				return val, true, nil
-			}
-			if val == nil {
-				return []byte{}, true, nil
-			}
-			return val, true, nil
-		}
-	}
-	return nil, false, nil
+	return checkQueue(false)
 }
 
 func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
@@ -23624,6 +23630,47 @@ func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
 		return dst, false, nil
 	}
 
+	checkQueueAppend := func(rangedOnly bool) ([]byte, bool, error) {
+		for i := len(queue) - 1; i >= 0; i-- {
+			routeMode := memtableRouteHashed
+			if len(queueRouteModes) > i {
+				routeMode = queueRouteModes[i]
+			}
+			isRanged := routeMode == memtableRouteRanged
+			if rangedOnly != isRanged {
+				continue
+			}
+			if isRanged {
+				if len(queueRanges) > i && !keyInRange(queueRanges[i], key) {
+					continue
+				}
+			} else if len(queueShardIDs) > i && int(queueShardIDs[i]) != hashIdx {
+				continue
+			}
+			val, ptr, flags, found := queue[i].GetEntry(key)
+			if found {
+				if flags&node.FlagTombstone != 0 {
+					return dst, true, tree.ErrKeyNotFound
+				}
+				if flags&node.FlagPointer != 0 {
+					if val == nil {
+						out, err := db.readValueLogAppend(key, ptr, dst)
+						if err != nil {
+							return dst, true, err
+						}
+						return out, true, nil
+					}
+					return append(dst, val...), true, nil
+				}
+				if val == nil {
+					return dst, true, nil
+				}
+				return append(dst, val...), true, nil
+			}
+		}
+		return dst, false, nil
+	}
+
 	checkedHashMutable := false
 	if len(mutables) > 0 {
 		var (
@@ -23642,50 +23689,16 @@ func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
 			return routeOut, routeFound, routeErr
 		}
 	}
+	if out, found, err := checkQueueAppend(true); err != nil || found {
+		return out, found, err
+	}
 	if len(mutables) > 0 && !checkedHashMutable {
 		out, found, err := checkMutableAppend(hashIdx)
 		if err != nil || found {
 			return out, found, err
 		}
 	}
-
-	for i := len(queue) - 1; i >= 0; i-- {
-		routeMode := memtableRouteHashed
-		if len(queueRouteModes) > i {
-			routeMode = queueRouteModes[i]
-		}
-		switch routeMode {
-		case memtableRouteRanged:
-			if len(queueRanges) > i && !keyInRange(queueRanges[i], key) {
-				continue
-			}
-		default:
-			if len(queueShardIDs) > i && int(queueShardIDs[i]) != hashIdx {
-				continue
-			}
-		}
-		val, ptr, flags, found := queue[i].GetEntry(key)
-		if found {
-			if flags&node.FlagTombstone != 0 {
-				return dst, true, tree.ErrKeyNotFound
-			}
-			if flags&node.FlagPointer != 0 {
-				if val == nil {
-					out, err := db.readValueLogAppend(key, ptr, dst)
-					if err != nil {
-						return dst, true, err
-					}
-					return out, true, nil
-				}
-				return append(dst, val...), true, nil
-			}
-			if val == nil {
-				return dst, true, nil
-			}
-			return append(dst, val...), true, nil
-		}
-	}
-	return dst, false, nil
+	return checkQueueAppend(false)
 }
 
 type backendManyGetter interface {
@@ -23944,6 +23957,31 @@ func (db *DB) Has(key []byte) (bool, error) {
 		return false, false
 	}
 
+	checkQueueHas := func(rangedOnly bool) (bool, bool) {
+		for i := len(queue) - 1; i >= 0; i-- {
+			routeMode := memtableRouteHashed
+			if len(queueRouteModes) > i {
+				routeMode = queueRouteModes[i]
+			}
+			isRanged := routeMode == memtableRouteRanged
+			if rangedOnly != isRanged {
+				continue
+			}
+			if isRanged {
+				if len(queueRanges) > i && !keyInRange(queueRanges[i], key) {
+					continue
+				}
+			} else if len(queueShardIDs) > i && int(queueShardIDs[i]) != hashIdx {
+				continue
+			}
+			_, deleted, found := queue[i].Get(key)
+			if found {
+				return !deleted, true
+			}
+		}
+		return false, false
+	}
+
 	checkedHashMutable := false
 	if len(mutables) > 0 {
 		var (
@@ -23961,32 +23999,17 @@ func (db *DB) Has(key []byte) (bool, error) {
 			return routeHas, nil
 		}
 	}
+	if has, found := checkQueueHas(true); found {
+		return has, nil
+	}
 	if len(mutables) > 0 && !checkedHashMutable {
 		has, found := checkMutableHas(hashIdx)
 		if found {
 			return has, nil
 		}
 	}
-
-	for i := len(queue) - 1; i >= 0; i-- {
-		routeMode := memtableRouteHashed
-		if len(queueRouteModes) > i {
-			routeMode = queueRouteModes[i]
-		}
-		switch routeMode {
-		case memtableRouteRanged:
-			if len(queueRanges) > i && !keyInRange(queueRanges[i], key) {
-				continue
-			}
-		default:
-			if len(queueShardIDs) > i && int(queueShardIDs[i]) != hashIdx {
-				continue
-			}
-		}
-		_, deleted, found := queue[i].Get(key)
-		if found {
-			return !deleted, nil
-		}
+	if has, found := checkQueueHas(false); found {
+		return has, nil
 	}
 
 	return db.backend.Has(key)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2860,6 +2860,7 @@ func (db *DB) flushDeferredValueLogMemtable(
 	iter iterator.UnsafeIterator,
 	backendBatch batch.Interface,
 	memLen int,
+	stableUnsafe bool,
 	sync bool,
 	laneID int,
 ) (int, error) {
@@ -2912,7 +2913,7 @@ func (db *DB) flushDeferredValueLogMemtable(
 	}
 
 	for iter.Valid() {
-		key := iter.UnsafeKey()
+		key := stableIteratorKey(iter, stableUnsafe)
 		if iter.IsDeleted() {
 			var err error
 			if dv != nil {
@@ -9819,6 +9820,7 @@ func (job flushBuildJob) run(closeCh <-chan struct{}) {
 	}
 
 	iter := job.mem.NewIterator(nil, nil)
+	stableUnsafe := stableUnsafeIteratorSlices(job.mem)
 
 	send := func(ops []batch.Entry) bool {
 		for {
@@ -9837,22 +9839,23 @@ func (job flushBuildJob) run(closeCh <-chan struct{}) {
 	ops = ops[:0]
 	for iter.Valid() {
 		val, ptr, flags := iter.UnsafeEntry()
+		key := stableIteratorKey(iter, stableUnsafe)
 		if flags&node.FlagTombstone != 0 {
 			ops = append(ops, batch.Entry{
 				Type: batch.OpDelete,
-				Key:  iter.UnsafeKey(),
+				Key:  key,
 			})
 		} else if flags&node.FlagPointer != 0 {
 			ops = append(ops, batch.Entry{
 				Type:     batch.OpPut,
-				Key:      iter.UnsafeKey(),
+				Key:      key,
 				ValuePtr: ptr,
 				IsPtr:    true,
 			})
 		} else {
 			ops = append(ops, batch.Entry{
 				Type:  batch.OpPut,
-				Key:   iter.UnsafeKey(),
+				Key:   key,
 				Value: val,
 			})
 		}
@@ -11310,6 +11313,7 @@ func collectOpsInto(mem memtable.Table, dst []batch.Entry) (int, error) {
 		return 0, errors.New("cachingdb: nil memtable")
 	}
 	iter := mem.NewIterator(nil, nil)
+	stableUnsafe := stableUnsafeIteratorSlices(mem)
 	defer func() { _ = iter.Close() }()
 
 	i := 0
@@ -11318,22 +11322,23 @@ func collectOpsInto(mem memtable.Table, dst []batch.Entry) (int, error) {
 			return 0, fmt.Errorf("cachingdb: collectOpsInto overflow (have=%d need>=%d)", len(dst), i+1)
 		}
 		val, ptr, flags := iter.UnsafeEntry()
+		key := stableIteratorKey(iter, stableUnsafe)
 		if flags&node.FlagTombstone != 0 {
 			dst[i] = batch.Entry{
 				Type: batch.OpDelete,
-				Key:  iter.UnsafeKey(),
+				Key:  key,
 			}
 		} else if flags&node.FlagPointer != 0 {
 			dst[i] = batch.Entry{
 				Type:     batch.OpPut,
-				Key:      iter.UnsafeKey(),
+				Key:      key,
 				ValuePtr: ptr,
 				IsPtr:    true,
 			}
 		} else {
 			dst[i] = batch.Entry{
 				Type:  batch.OpPut,
-				Key:   iter.UnsafeKey(),
+				Key:   key,
 				Value: val,
 			}
 		}
@@ -11551,7 +11556,7 @@ func buildOpRuns(mem memtable.Table, chunkCap int) ([][]batch.Entry, int, error)
 	stableUnsafe := stableUnsafeIteratorSlices(mem)
 	for iter.Valid() {
 		val, ptr, flags := iter.UnsafeEntry()
-		key := iter.UnsafeKey()
+		key := stableIteratorKey(iter, stableUnsafe)
 		if !stableUnsafe {
 			key = append([]byte(nil), key...)
 		}
@@ -11599,6 +11604,15 @@ func stableUnsafeIteratorSlices(mem memtable.Table) bool {
 		return stable.StableUnsafeIteratorSlices()
 	}
 	return false
+}
+
+func stableIteratorKey(iter iterator.UnsafeIterator, stableUnsafe bool) []byte {
+	if stableUnsafe {
+		if stableKey, ok := iter.(iterator.StableKeyViewIterator); ok {
+			return stableKey.UnsafeStableKey()
+		}
+	}
+	return iter.UnsafeKey()
 }
 
 func closeOpMergeSources(sources []opMergeSource) error {
@@ -22705,7 +22719,7 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			stableUnsafe := stableUnsafeIteratorSlices(unit.mem)
 			iter := unit.mem.NewIterator(nil, nil)
 			for iter.Valid() {
-				key := iter.UnsafeKey()
+				key := stableIteratorKey(iter, stableUnsafe)
 				val, ptr, flags := iter.UnsafeEntry()
 				if flags&node.FlagTombstone != 0 {
 					var err error
@@ -22994,12 +23008,13 @@ func (db *DB) flushOneLocked(sync bool) bool {
 		reserveBackendBatchOps(backendBatch, reserveChunkOps)
 		vlogFlushed := false
 		backendPendingOps := 0
+		stableUnsafe := stableUnsafeIteratorSlices(mem)
 		iter := mem.NewIterator(nil, nil) // Returns iterator.UnsafeIterator
 
 		if db.deferredValueLogEnabled() {
 			t0 := time.Now()
 			var err error
-			backendPendingOps, err = db.flushDeferredValueLogMemtable(iter, backendBatch, memLen, sync, laneID)
+			backendPendingOps, err = db.flushDeferredValueLogMemtable(iter, backendBatch, memLen, stableUnsafe, sync, laneID)
 			if err != nil {
 				db.reportError(fmt.Errorf("cachingdb: flush failed (defer vlog): %w", err))
 				_ = iter.Close()
@@ -23078,9 +23093,8 @@ func (db *DB) flushOneLocked(sync bool) bool {
 				return nil
 			}
 
-			stableUnsafe := stableUnsafeIteratorSlices(mem)
 			for iter.Valid() {
-				key := iter.UnsafeKey()
+				key := stableIteratorKey(iter, stableUnsafe)
 				val, ptr, flags := iter.UnsafeEntry()
 				if flags&node.FlagTombstone != 0 {
 					var err error

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -129,6 +129,7 @@ func (b *pointerBatch) Close() error {
 
 func (b *pointerBatch) Reset() {
 	b.resetCalls++
+	clear(b.entries)
 	b.entries = b.entries[:0]
 }
 

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -14,9 +14,14 @@ import (
 )
 
 type pointerBatch struct {
+	backend             *viewCountingBackend
 	entries             []batch.Entry
 	reserveCalls        int
 	lastReserve         int
+	resetCalls          int
+	writeCalls          int
+	writeSyncCalls      int
+	closeCalls          int
 	setCalls            int
 	setViewCalls        int
 	deleteCalls         int
@@ -31,7 +36,7 @@ type viewCountingBackend struct {
 }
 
 func (b *viewCountingBackend) NewBatch() batch.Interface {
-	pb := &pointerBatch{}
+	pb := &pointerBatch{backend: b}
 	b.batches = append(b.batches, pb)
 	return pb
 }
@@ -107,11 +112,25 @@ func (b *pointerBatch) SetOps(ops []batch.Entry) error {
 	return nil
 }
 
-func (b *pointerBatch) Write() error { return nil }
+func (b *pointerBatch) Write() error {
+	b.writeCalls++
+	return nil
+}
 
-func (b *pointerBatch) WriteSync() error { return nil }
+func (b *pointerBatch) WriteSync() error {
+	b.writeSyncCalls++
+	return nil
+}
 
-func (b *pointerBatch) Close() error { return nil }
+func (b *pointerBatch) Close() error {
+	b.closeCalls++
+	return nil
+}
+
+func (b *pointerBatch) Reset() {
+	b.resetCalls++
+	b.entries = b.entries[:0]
+}
 
 func (b *pointerBatch) Replay(fn func(batch.Entry) error) error {
 	for _, e := range b.entries {
@@ -160,14 +179,14 @@ func TestPutUnitRunsClearsReferences(t *testing.T) {
 func TestPutOpMergeHeapClearsReferences(t *testing.T) {
 	h := make(opMergeHeap, 1, 2)
 	h[0] = opMergeItem{
-		iter:     &opRunIter{valid: true},
+		source:   &opRunIter{valid: true},
 		priority: 7,
 		key:      []byte("k"),
 	}
 
 	putOpMergeHeap(h)
 
-	if h[0].iter != nil || h[0].priority != 0 || h[0].key != nil {
+	if h[0].source != nil || h[0].priority != 0 || h[0].key != nil {
 		t.Fatalf("heap item not cleared: %+v", h[0])
 	}
 }
@@ -988,6 +1007,66 @@ func TestFlushLaneOnce_FallsBackFromPointerViewForUnstableIterators(t *testing.T
 	}
 	if setPointerCalls != 1 {
 		t.Fatalf("backend SetPointer calls=%d, want 1", setPointerCalls)
+	}
+}
+
+func TestFlushLaneOnce_ReusesResettableBackendBatchAcrossChunks(t *testing.T) {
+	dir := t.TempDir()
+	backend := &viewCountingBackend{MockBackend: NewMockBackend()}
+	db, err := Open(dir, backend, Options{
+		FlushThreshold:         1 << 60,
+		MemtableShards:         1,
+		MemtableMode:           "hash_sorted",
+		MaxQueuedMemtables:     -1,
+		AllowUnsafe:            true,
+		FlushBackendMaxEntries: 2,
+		FlushBuildConcurrency:  2,
+		FlushBuildMinEntries:   1,
+		FlushBuildMinUnits:     2,
+		FlushBuildChunkCap:     2,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	oldProcs := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(oldProcs)
+
+	for unit := 0; unit < 3; unit++ {
+		for i := 0; i < 2; i++ {
+			key := []byte{byte('a' + unit), byte('0' + i)}
+			if err := db.Set(key, []byte("value")); err != nil {
+				t.Fatalf("Set unit %d entry %d: %v", unit, i, err)
+			}
+		}
+		db.mu.Lock()
+		if err := db.rotateMemtableLocked(false); err != nil {
+			db.mu.Unlock()
+			t.Fatalf("rotateMemtableLocked unit %d: %v", unit, err)
+		}
+		db.mu.Unlock()
+	}
+
+	if !db.flushLaneOnce(false, 0) {
+		t.Fatal("flushLaneOnce returned false")
+	}
+
+	if got := len(backend.batches); got != 1 {
+		t.Fatalf("backend batch creations=%d want 1", got)
+	}
+	pb := backend.batches[0]
+	if got := pb.writeCalls; got < 3 {
+		t.Fatalf("backend batch writes=%d want >=3 for chunked flush", got)
+	}
+	if got := pb.resetCalls; got < 2 {
+		t.Fatalf("backend batch resets=%d want >=2 after intermediate chunk commits", got)
+	}
+	if got := pb.closeCalls; got != 1 {
+		t.Fatalf("backend batch closes=%d want 1", got)
+	}
+	if got := pb.reserveCalls; got != 1 {
+		t.Fatalf("backend batch reserveCalls=%d want 1", got)
 	}
 }
 

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -383,7 +383,7 @@ func TestFlushDeferredValueLogMemtableReservesBackendBatch(t *testing.T) {
 	db := &DB{valueLogThreshold: page.DefaultInlineThreshold}
 	const reserveHint = 7
 
-	if emitted, err := db.flushDeferredValueLogMemtable(iter, backendBatch, reserveHint, false, 0); err != nil {
+	if emitted, err := db.flushDeferredValueLogMemtable(iter, backendBatch, reserveHint, stableUnsafeIteratorSlices(mt), false, 0); err != nil {
 		_ = iter.Close()
 		t.Fatalf("flushDeferredValueLogMemtable: %v", err)
 	} else if emitted != 2 {

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -1,6 +1,8 @@
 package caching
 
 import (
+	"time"
+
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -26,16 +28,144 @@ func (db *DB) noteLeafGenerationRecordLength(ptr page.ValuePtr) {
 	}
 }
 
+func (db *DB) appendLeafPageValueLog(l *lane, rid uint64, leafPage []byte) (page.ValuePtr, string, error) {
+	if !db.splitValueLogEnabled() {
+		return page.ValuePtr{}, "", errWALUnavailable
+	}
+	if l == nil {
+		return page.ValuePtr{}, "", errWALUnavailable
+	}
+	select {
+	case <-db.closeCh:
+		return page.ValuePtr{}, "", errWALClosed
+	default:
+	}
+
+	selectorStart := time.Now()
+	l.vlogMu.Lock()
+	w := l.vlog
+	if w == nil {
+		l.vlogMu.Unlock()
+		return page.ValuePtr{}, "", errWALUnavailable
+	}
+	if rotateErr := db.rotateValueLogForMaxSegmentMuHeld(l, w); rotateErr != nil {
+		l.vlogMu.Unlock()
+		return page.ValuePtr{}, "", rotateErr
+	}
+	w = l.vlog
+	if w == nil {
+		l.vlogMu.Unlock()
+		return page.ValuePtr{}, "", errWALUnavailable
+	}
+	if l.vlogCaps.writer != w {
+		l.vlogCaps = computeVlogWriterCaps(w)
+	}
+
+	concrete, ok := w.(*valuelog.Writer)
+	if !ok || db.valueLogTemplateEnabled {
+		l.vlogMu.Unlock()
+		encodedLeafPage, _, err := valuelog.MaybeCompactLeafLogPayload(leafPage)
+		if err != nil {
+			return page.ValuePtr{}, "", err
+		}
+		return db.appendValueLogOneInternal(l, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
+	}
+
+	payloadLen, compacted, err := valuelog.CompactLeafLogPayloadLen(leafPage)
+	if err != nil {
+		l.vlogMu.Unlock()
+		return page.ValuePtr{}, "", err
+	}
+	writeMode, blockCodec, probeCompression := db.resolveVlogWriteMode(l, 0, payloadLen, payloadLen, compacted)
+	if writeMode == vlogWriteBlock {
+		if codec, ok := db.preferLeafPageBlockCodec(l, payloadLen, blockCodec); ok {
+			blockCodec = codec
+		} else {
+			compressionMode := normalizeVlogCompressionMode(db.valueLogCompressionMode)
+			if (compressionMode == vlogCompressionAuto || compressionMode == vlogCompressionDefault) &&
+				normalizeVlogAutoPolicy(db.valueLogAutoPolicy) != vlogAutoThroughput &&
+				payloadLen >= 2048 {
+				blockCodec = chooseLargePayloadNoDictBlockCodec(l, db.valueLogBlockCodec)
+			}
+		}
+	}
+	finalWriteMode := vlogWriteOff
+	if writeMode == vlogWriteBlock {
+		finalWriteMode = vlogWriteBlock
+	}
+	finalBlockCodec := db.valueLogBlockCodec
+	if finalWriteMode == vlogWriteBlock {
+		finalBlockCodec = blockCodec
+	}
+	db.setVlogWriterMode(l, w, finalWriteMode, finalBlockCodec)
+	startSize := w.Size()
+	ptr, stats, compacted, err := concrete.AppendCompactLeafPage(rid, leafPage)
+	flushedBoundary := false
+	if err == nil && db.shouldFlushDeferredValueLogValue(finalWriteMode, leafPage) {
+		err = w.Flush()
+		flushedBoundary = err == nil
+	}
+	totalBytes := int64(0)
+	if err == nil {
+		totalBytes = w.Size() - startSize
+	}
+	retainPath := ""
+	if l.vlogPath != "" && l.vlogPath != l.vlogRetainedPath {
+		l.vlogRetainedPath = l.vlogPath
+		retainPath = l.vlogPath
+	}
+	if err == nil {
+		db.markLaneValueLogBoundary(l, totalBytes, flushedBoundary, false)
+		if !flushedBoundary && totalBytes > 0 {
+			l.backendReadDirtySeq.Add(1)
+		}
+	}
+	if db.testBeforeVlogUnlock != nil {
+		db.testBeforeVlogUnlock(int(l.id))
+	}
+	l.vlogMu.Unlock()
+	if err != nil {
+		return page.ValuePtr{}, "", err
+	}
+	if totalBytes > 0 {
+		l.vlogLiveBytes.Add(totalBytes)
+	}
+	db.valueLogDictFrames.total.Add(1)
+	if stats.Attempted {
+		db.valueLogDictFrames.attempted.Add(1)
+	}
+	if stats.Kept {
+		db.valueLogDictFrames.kept.Add(1)
+	}
+	storedForSelector := stats.StoredPayloadBytes
+	if storedForSelector <= 0 || (finalWriteMode == vlogWriteBlock && !stats.Attempted && storedForSelector == payloadLen && totalBytes > 0) {
+		if totalBytes > 0 {
+			storedForSelector = int(totalBytes)
+		} else {
+			storedForSelector = payloadLen
+		}
+	}
+	payloadKind := vlogPayloadKindSingleValue
+	if compacted {
+		payloadKind = vlogPayloadKindOuterLeaf
+	}
+	recordLaneVlogPayloadKindObservation(l, payloadKind, payloadLen, storedForSelector)
+	if payloadKind == vlogPayloadKindOuterLeaf {
+		recordLaneVlogPayloadSplitObservation(l, vlogPayloadSplitOuterLeaf, payloadLen, storedForSelector, 1)
+		recordLaneVlogOuterLeafCodecObservation(l, vlogOuterLeafCodecLegacyPage, payloadLen, storedForSelector)
+	} else {
+		recordLaneVlogPayloadSplitObservation(l, vlogPayloadSplitSingleValue, payloadLen, storedForSelector, 1)
+	}
+	db.observeVlogWriteMode(l, finalWriteMode, finalBlockCodec, payloadLen, payloadLen, storedForSelector, probeCompression, time.Since(selectorStart).Nanoseconds())
+	return ptr, retainPath, nil
+}
+
 func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if l == nil || l.db == nil || l.lane == nil {
 		return page.LeafLogPtr{}, errWALUnavailable
 	}
-	encodedLeafPage, _, err := valuelog.MaybeCompactLeafLogPayload(leafPage)
-	if err != nil {
-		return page.LeafLogPtr{}, err
-	}
 	rid := l.db.nextRID.Add(1)
-	ptr, retainPath, err := l.db.appendValueLogOneInternal(l.lane, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
+	ptr, retainPath, err := l.db.appendLeafPageValueLog(l.lane, rid, leafPage)
 	if retainPath != "" {
 		l.db.markValueLogRetain(retainPath)
 	}

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -41,8 +41,8 @@ func (db *DB) appendLeafPageValueLog(l *lane, rid uint64, leafPage []byte) (page
 	default:
 	}
 
-	selectorStart := time.Now()
 	l.vlogMu.Lock()
+	selectorStart := time.Now()
 	w := l.vlog
 	if w == nil {
 		l.vlogMu.Unlock()

--- a/TreeDB/caching/memtable_adaptive_test.go
+++ b/TreeDB/caching/memtable_adaptive_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func TestAdaptiveMemtableMode_SwitchesAfterWarmupRotation(t *testing.T) {
@@ -59,8 +61,8 @@ func TestAdaptiveMemtableMode_SwitchesAfterWarmupRotation(t *testing.T) {
 	if got := stats["treedb.cache.memtable_warmup_active"]; got != "false" {
 		t.Fatalf("expected warmup to be finished after rotation, got %q", got)
 	}
-	if got := stats["treedb.cache.memtable_mode"]; got != "hash_sorted" {
-		t.Fatalf("expected memtable mode to switch to hash_sorted after warmup rotation, got %q", got)
+	if got := stats["treedb.cache.memtable_mode"]; got != "append_only" {
+		t.Fatalf("expected low-overwrite warmup workload to switch to append_only after warmup rotation, got %q", got)
 	}
 }
 
@@ -109,6 +111,279 @@ func TestAdaptiveMemtableMode_SequentialWritesSwitchToAppendOnly(t *testing.T) {
 	}
 }
 
+func TestAdaptiveMemtableMode_AppendOnlyRemainsObservableAfterWarmup(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+
+	db, err := Open(dir, backend, Options{
+		AllowUnsafe:              true,
+		DisableWAL:               true,
+		FlushThreshold:           1 << 30,
+		MemtableMode:             "adaptive",
+		MemtableShards:           1,
+		ValueLogPointerThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	value := make([]byte, 8<<10)
+	writeSequential := func(start, count int) {
+		t.Helper()
+		for i := 0; i < count; i++ {
+			var key [16]byte
+			binary.BigEndian.PutUint64(key[8:16], uint64(start+i))
+			if err := db.Set(key[:], value); err != nil {
+				t.Fatalf("Set(%d): %v", start+i, err)
+			}
+		}
+	}
+
+	writeSequential(0, adaptiveMinWrites*2+600)
+
+	stats := db.Stats()
+	if got := stats["treedb.cache.memtable_warmup_active"]; got != "false" {
+		t.Fatalf("expected warmup to be finished after initial sequential phase, got %q", got)
+	}
+	if got := stats["treedb.cache.memtable_mode"]; got != "append_only" {
+		t.Fatalf("expected append_only after initial sequential phase, got %q", got)
+	}
+	if !db.memtableAdaptiveObserve.Load() {
+		t.Fatalf("expected adaptive observation to remain enabled after switching to append_only")
+	}
+
+	beforeWrites := db.memtableStats.writes.Load()
+	beforeSeqWrites := db.memtableStats.seqWrites.Load()
+
+	writeSequential(adaptiveMinWrites*2+600, 256)
+
+	if got := db.memtableStats.writes.Load(); got <= beforeWrites {
+		t.Fatalf("writes did not grow after append_only became active: before=%d after=%d", beforeWrites, got)
+	}
+	if got := db.memtableStats.seqWrites.Load(); got <= beforeSeqWrites {
+		t.Fatalf("seqWrites did not grow after append_only became active: before=%d after=%d", beforeSeqWrites, got)
+	}
+}
+
+func TestAdaptiveMemtableMode_RotationResetsObservedStats(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+
+	db, err := Open(dir, backend, Options{
+		AllowUnsafe:              true,
+		DisableWAL:               true,
+		FlushThreshold:           1 << 30,
+		MemtableMode:             "adaptive",
+		MemtableShards:           1,
+		ValueLogPointerThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	value := make([]byte, 32)
+	for i := 0; i < 64; i++ {
+		var key [16]byte
+		binary.BigEndian.PutUint64(key[8:16], uint64(i))
+		if err := db.Set(key[:], value); err != nil {
+			t.Fatalf("Set(%d): %v", i, err)
+		}
+	}
+
+	if got := db.memtableStats.writes.Load(); got == 0 {
+		t.Fatalf("expected writes to be observed before rotation")
+	}
+
+	db.mu.Lock()
+	if err := db.rotateMemtableLockedWithCapacity(false, db.memtableCap); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("rotateMemtableLockedWithCapacity: %v", err)
+	}
+	db.mu.Unlock()
+
+	if got := db.memtableStats.writes.Load(); got != 0 {
+		t.Fatalf("writes=%d want 0 after rotation", got)
+	}
+	if got := db.memtableStats.seqWrites.Load(); got != 0 {
+		t.Fatalf("seqWrites=%d want 0 after rotation", got)
+	}
+	if got := db.memtableStats.overwriteWrites.Load(); got != 0 {
+		t.Fatalf("overwriteWrites=%d want 0 after rotation", got)
+	}
+}
+
+func TestAdaptiveMemtableMode_RecentSequentialWritesWinWithinOneMutable(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+
+	db, err := Open(dir, backend, Options{
+		AllowUnsafe:              true,
+		DisableWAL:               true,
+		FlushThreshold:           1 << 30,
+		MemtableMode:             "adaptive",
+		MemtableShards:           1,
+		ValueLogPointerThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	value := []byte("v")
+	for i := adaptiveTailSequentialWriteMin - 1; i >= 0; i-- {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(i))
+		if err := db.Set(key[:], value); err != nil {
+			t.Fatalf("descending Set(%d): %v", i, err)
+		}
+	}
+	for i := 0; i < adaptiveTailSequentialWriteMin; i++ {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(adaptiveTailSequentialWriteMin+i+1))
+		if err := db.Set(key[:], value); err != nil {
+			t.Fatalf("sequential Set(%d): %v", adaptiveTailSequentialWriteMin+i+1, err)
+		}
+	}
+
+	db.mu.Lock()
+	if err := db.rotateMemtableLockedWithCapacity(false, db.memtableCap); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("rotateMemtableLockedWithCapacity: %v", err)
+	}
+	db.mu.Unlock()
+
+	stats := db.Stats()
+	if got := stats["treedb.cache.memtable_mode"]; got != "append_only" {
+		t.Fatalf("expected recent sequential writes to drive append_only, got %q", got)
+	}
+}
+
+func TestAdaptiveMemtableMode_SharedSortedBatchStatsAcrossShards(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+
+	db, err := Open(dir, backend, Options{
+		AllowUnsafe:              true,
+		DisableWAL:               true,
+		FlushThreshold:           1 << 30,
+		MemtableMode:             "adaptive",
+		MemtableShards:           16,
+		ValueLogPointerThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	value := []byte("v")
+	batchSize := 100
+	total := adaptiveTailSequentialWriteMin * 2
+	for start := 0; start < total; start += batchSize {
+		b := db.NewBatch()
+		for i := start; i < start+batchSize && i < total; i++ {
+			var key [8]byte
+			binary.BigEndian.PutUint64(key[:], uint64(i))
+			if err := b.Set(key[:], value); err != nil {
+				_ = b.Close()
+				t.Fatalf("Batch.Set(%d): %v", i, err)
+			}
+		}
+		if err := b.Write(); err != nil {
+			_ = b.Close()
+			t.Fatalf("Batch.Write(%d): %v", start, err)
+		}
+		if err := b.Close(); err != nil {
+			t.Fatalf("Batch.Close(%d): %v", start, err)
+		}
+	}
+
+	db.mu.Lock()
+	if err := db.rotateMemtableLockedWithCapacity(false, db.memtableCap); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("rotateMemtableLockedWithCapacity: %v", err)
+	}
+	db.mu.Unlock()
+
+	stats := db.Stats()
+	if got := stats["treedb.cache.memtable_mode"]; got != "append_only" {
+		t.Fatalf("expected sharded sorted batches to drive append_only, got %q", got)
+	}
+}
+
+func TestAdaptiveMemtableMode_TailSequentialBatchesRotateUnorderedAppendOnly(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+
+	db, err := Open(dir, backend, Options{
+		AllowUnsafe:              true,
+		DisableWAL:               true,
+		FlushThreshold:           1 << 30,
+		MemtableMode:             "adaptive:append_only",
+		MemtableShards:           1,
+		ValueLogPointerThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	value := []byte("v")
+	for i := adaptiveMinWrites * 2; i > 0; i-- {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(i))
+		if err := db.Set(key[:], value); err != nil {
+			t.Fatalf("descending Set(%d): %v", i, err)
+		}
+	}
+
+	db.mutableShards[0].mu.Lock()
+	before, ok := db.mutableShards[0].mem.(*memtable.AppendOnly)
+	db.mutableShards[0].mu.Unlock()
+	if !ok {
+		t.Fatalf("expected append_only mutable before recovery, got %T", db.mutableShards[0].mem)
+	}
+	if before.Ordered() {
+		t.Fatalf("expected descending phase to leave append_only mutable unordered")
+	}
+
+	const batchSize = 100
+	startKey := adaptiveMinWrites * 4
+	total := adaptiveMinWrites * 2
+	for start := startKey; start < startKey+total; start += batchSize {
+		b := db.NewBatch()
+		for i := start; i < start+batchSize && i < startKey+total; i++ {
+			var key [8]byte
+			binary.BigEndian.PutUint64(key[:], uint64(i))
+			if err := b.Set(key[:], value); err != nil {
+				_ = b.Close()
+				t.Fatalf("Batch.Set(%d): %v", i, err)
+			}
+		}
+		if err := b.Write(); err != nil {
+			_ = b.Close()
+			t.Fatalf("Batch.Write(%d): %v", start, err)
+		}
+		if err := b.Close(); err != nil {
+			t.Fatalf("Batch.Close(%d): %v", start, err)
+		}
+	}
+
+	db.mutableShards[0].mu.Lock()
+	after, ok := db.mutableShards[0].mem.(*memtable.AppendOnly)
+	db.mutableShards[0].mu.Unlock()
+	if !ok {
+		t.Fatalf("expected append_only mutable after recovery, got %T", db.mutableShards[0].mem)
+	}
+	if !after.Ordered() {
+		t.Fatalf("expected tail-sequential recovery to rotate to an ordered append_only mutable")
+	}
+	if got := db.memtableStats.currentSeqRun.Load(); got == 0 {
+		t.Fatalf("expected sequential run stats to continue after recovery rotation")
+	}
+}
+
 func TestAdaptiveMemtableMode_DefaultAdaptiveStartsWarmup(t *testing.T) {
 	dir := t.TempDir()
 	backend := NewMockBackend()
@@ -154,23 +429,16 @@ func TestAdaptiveMemtableMode_DefaultAdaptiveOverwriteHeavySwitchesToHashSorted(
 
 	b := db.NewBatch()
 	defer b.Close()
-	rng := rand.New(rand.NewSource(1))
 	const uniqueKeys = adaptiveMinWrites + 1200
 	value := make([]byte, 8<<10) // 8KiB
 	keys := make([][16]byte, uniqueKeys)
 
 	for i := 0; i < uniqueKeys; i++ {
-		binary.BigEndian.PutUint64(keys[i][0:8], rng.Uint64())
+		binary.BigEndian.PutUint64(keys[i][0:8], uint64(i))
 		binary.BigEndian.PutUint64(keys[i][8:16], uint64(i))
 		if err := b.Set(keys[i][:], value); err != nil {
 			t.Fatalf("Batch.Set(first %d): %v", i, err)
 		}
-	}
-	for i := range keys {
-		j := rng.Intn(uniqueKeys)
-		keys[i], keys[j] = keys[j], keys[i]
-	}
-	for i := 0; i < uniqueKeys; i++ {
 		if err := b.Set(keys[i][:], value); err != nil {
 			t.Fatalf("Batch.Set(overwrite %d): %v", i, err)
 		}

--- a/TreeDB/caching/point_read_shard_queue_test.go
+++ b/TreeDB/caching/point_read_shard_queue_test.go
@@ -303,3 +303,190 @@ func TestPointReads_EmptyMemtableBypassGuardChecksMutableLen(t *testing.T) {
 		t.Fatalf("expected memtable GetEntry to be consulted by GetAppend")
 	}
 }
+
+func TestPointReads_CurrentMutableRouteUsesRangedShard(t *testing.T) {
+	const shards = 8
+	const routeShard = 3
+
+	db := &DB{
+		backend:          panicBackend{},
+		mutableShards:    make([]memShard, shards),
+		mutableShardMask: shards - 1,
+	}
+
+	var key [8]byte
+	for i := uint64(0); ; i++ {
+		binary.BigEndian.PutUint64(key[:], i)
+		if db.shardIndex(key[:]) != routeShard {
+			break
+		}
+	}
+	wantKey := append([]byte(nil), key[:]...)
+
+	mutables := make([]memtable.Table, shards)
+	tables := make([]*countingTable, shards)
+	for shard := 0; shard < shards; shard++ {
+		mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+		if err != nil {
+			t.Fatalf("new memtable: %v", err)
+		}
+		ct := &countingTable{inner: mt}
+		mutables[shard] = ct
+		tables[shard] = ct
+	}
+	mutables[routeShard].SetEntry(wantKey, []byte("routed"), page.ValuePtr{}, node.FlagInline)
+
+	rng := keyRange{}
+	rng.add(wantKey)
+	db.memtables.Store(&memtableView{
+		mutables: mutables,
+		mutableRoute: &mutableRouteState{
+			shardID: routeShard,
+			rng:     rng,
+		},
+	})
+	db.mutableBytes.Store(1)
+
+	val, found, err := db.getMemtable(wantKey)
+	if err != nil {
+		t.Fatalf("getMemtable: %v", err)
+	}
+	if !found || string(val) != "routed" {
+		t.Fatalf("unexpected routed get: found=%v val=%q", found, string(val))
+	}
+
+	for shard := 0; shard < shards; shard++ {
+		calls := tables[shard].getEntryCalls
+		if shard == routeShard {
+			if calls == 0 {
+				t.Fatalf("expected routed shard GetEntry calls > 0, got %d", calls)
+			}
+			continue
+		}
+		if calls != 0 {
+			t.Fatalf("expected non-routed shard %d GetEntry calls = 0, got %d", shard, calls)
+		}
+	}
+}
+
+func TestPointReads_CurrentMutableRouteSetProbesNewestMatchFirst(t *testing.T) {
+	const shards = 8
+	const oldShard = 1
+	const newShard = 3
+
+	db := &DB{
+		backend:          panicBackend{},
+		mutableShards:    make([]memShard, shards),
+		mutableShardMask: shards - 1,
+	}
+
+	var rawKey [8]byte
+	binary.BigEndian.PutUint64(rawKey[:], 42)
+	key := append([]byte(nil), rawKey[:]...)
+
+	mutables := make([]memtable.Table, shards)
+	for shard := 0; shard < shards; shard++ {
+		mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+		if err != nil {
+			t.Fatalf("new memtable: %v", err)
+		}
+		mutables[shard] = mt
+	}
+	mutables[oldShard].SetEntry(key, []byte("old"), page.ValuePtr{}, node.FlagInline)
+	mutables[newShard].SetEntry(key, []byte("new"), page.ValuePtr{}, node.FlagInline)
+
+	rng := keyRange{}
+	rng.add(key)
+	db.memtables.Store(&memtableView{
+		mutables: mutables,
+		mutableRoute: &mutableRouteState{
+			shardID: newShard,
+			rng:     cloneRange(rng),
+			entries: []mutableRouteEntry{
+				{shardID: oldShard, rng: cloneRange(rng)},
+				{shardID: newShard, rng: cloneRange(rng)},
+			},
+		},
+	})
+	db.mutableBytes.Store(1)
+
+	val, found, err := db.getMemtable(key)
+	if err != nil {
+		t.Fatalf("getMemtable: %v", err)
+	}
+	if !found || string(val) != "new" {
+		t.Fatalf("unexpected route-set get: found=%v val=%q", found, string(val))
+	}
+}
+
+func TestPointReads_RangedQueueUsesQueueRangeNotHashShard(t *testing.T) {
+	const shards = 8
+	const routeShard = 6
+
+	db := &DB{
+		backend:          panicBackend{},
+		mutableShards:    make([]memShard, shards),
+		mutableShardMask: shards - 1,
+	}
+
+	var key [8]byte
+	for i := uint64(0); ; i++ {
+		binary.BigEndian.PutUint64(key[:], i)
+		if db.shardIndex(key[:]) != routeShard {
+			break
+		}
+	}
+	wantKey := append([]byte(nil), key[:]...)
+
+	queue := make([]memtable.Table, 0, shards)
+	queueShardIDs := make([]uint16, 0, shards)
+	queueRouteModes := make([]uint8, 0, shards)
+	queueRanges := make([]keyRange, 0, shards)
+	tables := make([]*countingTable, 0, shards)
+
+	for shard := 0; shard < shards; shard++ {
+		mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+		if err != nil {
+			t.Fatalf("new memtable: %v", err)
+		}
+		ct := &countingTable{inner: mt}
+		queue = append(queue, ct)
+		queueShardIDs = append(queueShardIDs, uint16(shard))
+		queueRouteModes = append(queueRouteModes, memtableRouteHashed)
+		queueRanges = append(queueRanges, keyRange{})
+		tables = append(tables, ct)
+	}
+
+	queue[routeShard].SetEntry(wantKey, []byte("queued-routed"), page.ValuePtr{}, node.FlagInline)
+	queueRouteModes[routeShard] = memtableRouteRanged
+	queueRanges[routeShard].add(wantKey)
+
+	db.memtables.Store(&memtableView{
+		mutables:        make([]memtable.Table, shards),
+		queue:           queue,
+		queueShardIDs:   queueShardIDs,
+		queueRouteModes: queueRouteModes,
+		queueRanges:     queueRanges,
+	})
+
+	val, found, err := db.getMemtable(wantKey)
+	if err != nil {
+		t.Fatalf("getMemtable: %v", err)
+	}
+	if !found || string(val) != "queued-routed" {
+		t.Fatalf("unexpected queued routed get: found=%v val=%q", found, string(val))
+	}
+
+	for shard := 0; shard < shards; shard++ {
+		calls := tables[shard].getEntryCalls
+		if shard == routeShard {
+			if calls == 0 {
+				t.Fatalf("expected ranged queue shard GetEntry calls > 0, got %d", calls)
+			}
+			continue
+		}
+		if calls != 0 {
+			t.Fatalf("expected non-ranged queue shard %d GetEntry calls = 0, got %d", shard, calls)
+		}
+	}
+}

--- a/TreeDB/caching/point_read_shard_queue_test.go
+++ b/TreeDB/caching/point_read_shard_queue_test.go
@@ -304,6 +304,72 @@ func TestPointReads_EmptyMemtableBypassGuardChecksMutableLen(t *testing.T) {
 	}
 }
 
+func TestPointReads_EmptyMemtableBypassGuardChecksRoutedMutable(t *testing.T) {
+	const shards = 8
+	const routeShard = 3
+
+	db := &DB{
+		backend:          panicBackend{},
+		mutableShards:    make([]memShard, shards),
+		mutableShardMask: shards - 1,
+	}
+
+	var key [8]byte
+	for i := uint64(0); ; i++ {
+		binary.BigEndian.PutUint64(key[:], i)
+		if db.hashShardIndex(key[:]) != routeShard {
+			break
+		}
+	}
+	wantKey := append([]byte(nil), key[:]...)
+
+	mutables := make([]memtable.Table, shards)
+	tables := make([]*countingTable, shards)
+	for shard := 0; shard < shards; shard++ {
+		mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+		if err != nil {
+			t.Fatalf("new memtable: %v", err)
+		}
+		ct := &countingTable{inner: mt}
+		mutables[shard] = ct
+		tables[shard] = ct
+	}
+	mutables[routeShard].SetEntry(wantKey, []byte("routed"), page.ValuePtr{}, node.FlagInline)
+
+	rng := keyRange{}
+	rng.add(wantKey)
+	db.memtables.Store(&memtableView{
+		mutables: mutables,
+		mutableRoute: &mutableRouteState{
+			shardID: routeShard,
+			rng:     rng,
+		},
+	})
+
+	got, err := db.Get(wantKey)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "routed" {
+		t.Fatalf("Get=%q want routed", got)
+	}
+	if calls := tables[routeShard].getEntryCalls; calls == 0 {
+		t.Fatalf("expected routed shard GetEntry calls > 0")
+	}
+	callsAfterGet := tables[routeShard].getEntryCalls
+
+	gotMany, err := db.GetMany([][]byte{wantKey})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+	if len(gotMany) != 1 || string(gotMany[0]) != "routed" {
+		t.Fatalf("GetMany=%q want routed", gotMany)
+	}
+	if calls := tables[routeShard].getEntryCalls; calls <= callsAfterGet {
+		t.Fatalf("expected routed shard GetEntry calls to increase after GetMany")
+	}
+}
+
 func TestPointReads_CurrentMutableRouteUsesRangedShard(t *testing.T) {
 	const shards = 8
 	const routeShard = 3

--- a/TreeDB/caching/point_read_shard_queue_test.go
+++ b/TreeDB/caching/point_read_shard_queue_test.go
@@ -490,3 +490,70 @@ func TestPointReads_RangedQueueUsesQueueRangeNotHashShard(t *testing.T) {
 		}
 	}
 }
+
+func TestPointReads_RangedQueueShadowsHashMutableFallback(t *testing.T) {
+	const shards = 8
+
+	db := &DB{
+		backend:          panicBackend{},
+		mutableShards:    make([]memShard, shards),
+		mutableShardMask: shards - 1,
+	}
+
+	var rawKey [8]byte
+	binary.BigEndian.PutUint64(rawKey[:], 42)
+	key := append([]byte(nil), rawKey[:]...)
+	hashShard := db.shardIndex(key)
+	routeShard := (hashShard + 1) % shards
+
+	mutables := make([]memtable.Table, shards)
+	for shard := 0; shard < shards; shard++ {
+		mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+		if err != nil {
+			t.Fatalf("new mutable memtable: %v", err)
+		}
+		mutables[shard] = mt
+	}
+	mutables[hashShard].SetEntry(key, []byte("stale-hash"), page.ValuePtr{}, node.FlagInline)
+
+	routed, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("new routed queue memtable: %v", err)
+	}
+	routed.Delete(key)
+	rng := keyRange{}
+	rng.add(key)
+
+	db.memtables.Store(&memtableView{
+		mutables:        mutables,
+		queue:           []memtable.Table{routed},
+		queueShardIDs:   []uint16{uint16(routeShard)},
+		queueRouteModes: []uint8{memtableRouteRanged},
+		queueRanges:     []keyRange{rng},
+	})
+	db.mutableBytes.Store(1)
+
+	val, found, err := db.getMemtable(key)
+	if err != nil {
+		t.Fatalf("getMemtable: %v", err)
+	}
+	if !found || val != nil {
+		t.Fatalf("getMemtable = (%q,%v), want ranged queue tombstone", string(val), found)
+	}
+
+	out, found, err := db.getMemtableAppend(key, []byte("prefix:"))
+	if !found || err == nil {
+		t.Fatalf("getMemtableAppend found=%v err=%v, want ranged queue tombstone error", found, err)
+	}
+	if string(out) != "prefix:" {
+		t.Fatalf("getMemtableAppend mutated dst on tombstone: %q", out)
+	}
+
+	has, err := db.Has(key)
+	if err != nil {
+		t.Fatalf("Has: %v", err)
+	}
+	if has {
+		t.Fatalf("Has returned true from stale hash mutable; want ranged queue tombstone")
+	}
+}

--- a/TreeDB/caching/stats_test.go
+++ b/TreeDB/caching/stats_test.go
@@ -1,6 +1,7 @@
 package caching
 
 import (
+	"encoding/binary"
 	"math/rand"
 	"sync"
 	"testing"
@@ -58,6 +59,11 @@ func TestAtomicStats(t *testing.T) {
 	expectedIters := uint64(workers * iterations)
 	if got := db.memtableStats.iterators.Load(); got != expectedIters {
 		t.Errorf("concurrent iterators = %d, want %d", got, expectedIters)
+	}
+
+	db.noteDeleteKey([]byte("delete-key"))
+	if got := db.memtableStats.deleteWrites.Load(); got != 1 {
+		t.Errorf("delete writes = %d, want 1", got)
 	}
 }
 
@@ -143,6 +149,35 @@ func TestChooseAdaptiveMode(t *testing.T) {
 	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeHashSorted {
 		t.Errorf("overwrite mode = %v, want %v", got, memtable.ModeHashSorted)
 	}
+
+	// 5. Delete-heavy traffic -> AppendOnly. Tombstones are cheap to append and
+	// can be coalesced during flush; hash-sorted insertion is wasted churn here.
+	db.memtableStats.writes.Store(adaptiveMinWrites)
+	db.memtableStats.seqWrites.Store(0)
+	db.memtableStats.overwriteWrites.Store(0)
+	db.memtableStats.deleteWrites.Store(adaptiveMinWrites)
+	db.memtableStats.iterators.Store(0)
+	db.memtableStats.rangeIters.Store(0)
+	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeAppendOnly {
+		t.Errorf("delete-heavy mode = %v, want %v", got, memtable.ModeAppendOnly)
+	}
+	if got := adaptiveDecisionReasonString(db.memtableAdaptiveDecisionReason.Load()); got != "append_deletes" {
+		t.Errorf("delete-heavy reason=%q want append_deletes", got)
+	}
+
+	// 6. Low-overwrite write-heavy traffic -> AppendOnly even when not sequential.
+	db.memtableStats.writes.Store(adaptiveMinWrites)
+	db.memtableStats.seqWrites.Store(0)
+	db.memtableStats.overwriteWrites.Store(0)
+	db.memtableStats.deleteWrites.Store(0)
+	db.memtableStats.iterators.Store(0)
+	db.memtableStats.rangeIters.Store(0)
+	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeAppendOnly {
+		t.Errorf("write-heavy mode = %v, want %v", got, memtable.ModeAppendOnly)
+	}
+	if got := adaptiveDecisionReasonString(db.memtableAdaptiveDecisionReason.Load()); got != "append_write_heavy" {
+		t.Errorf("write-heavy reason=%q want append_write_heavy", got)
+	}
 }
 
 func TestChooseAdaptiveMode_BTreeMinIteratorSamplesOverride(t *testing.T) {
@@ -178,6 +213,64 @@ func TestChooseAdaptiveMode_BTreeMinIteratorSamplesOverride(t *testing.T) {
 	}
 }
 
+func TestAdaptiveObservationContinuesInAppendOnly(t *testing.T) {
+	db := newAdaptiveStatsDB(memtable.ModeAppendOnly)
+	db.memtableWarmupActive = false
+
+	db.updateAdaptiveObservationLocked()
+	if !db.memtableAdaptiveObserve.Load() {
+		t.Fatalf("expected adaptive observation to remain enabled in append_only mode")
+	}
+
+	db.noteWriteKey([]byte("a"))
+	db.noteWriteKey([]byte("b"))
+	db.noteIterator([]byte("a"), []byte("c"))
+
+	if got := db.memtableStats.writes.Load(); got != 2 {
+		t.Fatalf("writes=%d want 2", got)
+	}
+	if got := db.memtableStats.seqWrites.Load(); got != 1 {
+		t.Fatalf("seqWrites=%d want 1", got)
+	}
+	if got := db.memtableStats.iterators.Load(); got != 1 {
+		t.Fatalf("iterators=%d want 1", got)
+	}
+	if got := db.memtableStats.rangeIters.Load(); got != 1 {
+		t.Fatalf("rangeIters=%d want 1", got)
+	}
+}
+
+func TestChooseAdaptiveMode_LowOverwriteMixedWritesPreferAppendOnly(t *testing.T) {
+	db := newAdaptiveStatsDB(memtable.ModeAppendOnly)
+
+	for i := adaptiveTailSequentialWriteMin - 1; i >= 0; i-- {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(i))
+		db.noteWriteKey(key[:])
+	}
+	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeAppendOnly {
+		t.Fatalf("descending low-overwrite phase mode=%v want %v", got, memtable.ModeAppendOnly)
+	}
+}
+
+func TestShouldRotateForDeleteHeavyRecovery(t *testing.T) {
+	db := newAdaptiveStatsDB(memtable.ModeHashSorted)
+	for i := 0; i < adaptiveMinWrites; i++ {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(i))
+		db.noteDeleteKey(key[:])
+	}
+
+	if !db.shouldRotateForDeleteHeavyRecovery() {
+		t.Fatal("expected delete-heavy adaptive stats to request append-only recovery from hash_sorted")
+	}
+
+	db.storeMemtableMode(memtable.ModeAppendOnly)
+	if db.shouldRotateForDeleteHeavyRecovery() {
+		t.Fatal("did not expect delete-heavy recovery when already in append_only mode")
+	}
+}
+
 func TestNoteWriteSortedRunMatchesPerKey_NoPrior(t *testing.T) {
 	perKey := newAdaptiveStatsDB(0)
 	perKey.noteWriteKey([]byte("a"))
@@ -188,6 +281,55 @@ func TestNoteWriteSortedRunMatchesPerKey_NoPrior(t *testing.T) {
 	run.noteWriteSortedRun([]byte("a"), []byte("c"), 3)
 
 	assertStatsEquivalent(t, perKey, run)
+}
+
+func TestNoteDeleteSortedRunMatchesPerKey(t *testing.T) {
+	perKey := newAdaptiveStatsDB(0)
+	perKey.noteDeleteKey([]byte("a"))
+	perKey.noteDeleteKey([]byte("b"))
+	perKey.noteDeleteKey([]byte("c"))
+
+	run := newAdaptiveStatsDB(0)
+	run.noteDeleteSortedRun([]byte("a"), []byte("c"), 3)
+
+	assertStatsEquivalent(t, perKey, run)
+}
+
+func TestNoteDeleteBatchRecordsDeleteCountWithoutOrderTracking(t *testing.T) {
+	db := newAdaptiveStatsDB(0)
+	db.noteWriteKey([]byte("prior"))
+	db.noteDeleteBatch(7)
+
+	if got := db.memtableStats.writes.Load(); got != 8 {
+		t.Fatalf("writes=%d want 8", got)
+	}
+	if got := db.memtableStats.deleteWrites.Load(); got != 7 {
+		t.Fatalf("deleteWrites=%d want 7", got)
+	}
+	if got := db.memtableStats.currentSeqRun.Load(); got != 0 {
+		t.Fatalf("currentSeqRun=%d want 0", got)
+	}
+	db.memtableStats.lastKeyMu.Lock()
+	hasLast := db.memtableStats.hasLastKey
+	db.memtableStats.lastKeyMu.Unlock()
+	if hasLast {
+		t.Fatal("expected aggregate delete batch to clear last-key tracking")
+	}
+}
+
+func TestNoteWriteSortedRunWithDeletesRecordsMixedDeleteCount(t *testing.T) {
+	db := newAdaptiveStatsDB(0)
+	db.noteWriteSortedRunWithDeletes([]byte("a"), []byte("d"), 4, 2)
+
+	if got := db.memtableStats.writes.Load(); got != 4 {
+		t.Fatalf("writes=%d want 4", got)
+	}
+	if got := db.memtableStats.deleteWrites.Load(); got != 2 {
+		t.Fatalf("deleteWrites=%d want 2", got)
+	}
+	if got := db.memtableStats.seqWrites.Load(); got != 3 {
+		t.Fatalf("seqWrites=%d want 3", got)
+	}
 }
 
 func TestNoteWriteSortedRunMatchesPerKey_WithPriorSmaller(t *testing.T) {
@@ -228,6 +370,12 @@ func assertStatsEquivalent(t *testing.T, want, got *DB) {
 	}
 	if w, g := want.memtableStats.overwriteWrites.Load(), got.memtableStats.overwriteWrites.Load(); w != g {
 		t.Fatalf("overwriteWrites mismatch: want=%d got=%d", w, g)
+	}
+	if w, g := want.memtableStats.deleteWrites.Load(), got.memtableStats.deleteWrites.Load(); w != g {
+		t.Fatalf("deleteWrites mismatch: want=%d got=%d", w, g)
+	}
+	if w, g := want.memtableStats.currentSeqRun.Load(), got.memtableStats.currentSeqRun.Load(); w != g {
+		t.Fatalf("currentSeqRun mismatch: want=%d got=%d", w, g)
 	}
 
 	want.memtableStats.lastKeyMu.Lock()

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -105,6 +105,12 @@ func (b *Batch) SetView(key, value []byte) error {
 	return b.batch.SetView(key, value)
 }
 
+// SetStealView records a Put without copying key/value bytes and permits
+// higher layers to retain those slices beyond the batch lifetime.
+func (b *Batch) SetStealView(key, value []byte) error {
+	return b.batch.SetStealView(key, value)
+}
+
 func (b *Batch) Delete(key []byte) error {
 	return b.batch.Delete(key)
 }

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -105,8 +105,14 @@ func (b *Batch) SetView(key, value []byte) error {
 	return b.batch.SetView(key, value)
 }
 
-// SetStealView records a Put without copying key/value bytes and permits
-// higher layers to retain those slices beyond the batch lifetime.
+// SetStealView records a Put without copying key/value bytes. Unlike SetView,
+// the underlying DB may retain key/value references beyond Write or Close.
+//
+// Callers must treat key/value as transferred and immutable after this call:
+// do not mutate, reuse, or repurpose their backing arrays in any way that
+// could affect stored data. Implementations that cannot retain the slices may
+// fall back to SetView/Set, but callers must still honor the stronger
+// SetStealView ownership contract.
 func (b *Batch) SetStealView(key, value []byte) error {
 	return b.batch.SetStealView(key, value)
 }

--- a/TreeDB/internal/iterator/iterator.go
+++ b/TreeDB/internal/iterator/iterator.go
@@ -25,3 +25,10 @@ type UnsafeIterator interface {
 	Close() error
 	Domain() (start, end []byte)
 }
+
+// StableKeyViewIterator is an internal fast-path extension for callers that
+// already know the iterator's backing table provides stable immutable storage.
+// The returned key is not defensively copied and must not be mutated.
+type StableKeyViewIterator interface {
+	UnsafeStableKey() []byte
+}

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -56,6 +56,7 @@ var appendOnlyIteratorValuePool sync.Pool
 var appendOnlyIteratorPtrPayloadPool sync.Pool
 var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
+var appendOnlyEmptyKey = make([]byte, 0)
 
 type appendOnlyPointerPayload struct {
 	value string
@@ -572,7 +573,7 @@ func appendOnlyEntryKeyFromKeys(ent *appendOnlyEntry, keys []string) []byte {
 	}
 	key := keys[idx]
 	if len(key) == 0 {
-		return nil
+		return appendOnlyEmptyKey
 	}
 	return unsafe.Slice(unsafe.StringData(key), len(key))
 }
@@ -1064,7 +1065,9 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	ent.payloadIndex = 0
 	payloadValue := ""
 	payloadPtr := page.ValuePtr{}
-	if len(key) <= appendOnlyInlineKeyLen {
+	if len(key) == 0 {
+		appendOnlyEntrySetKeyIndex(ent, m.appendKeyLocked(""))
+	} else if len(key) <= appendOnlyInlineKeyLen {
 		copy(ent.inlineKey[:], key)
 		appendOnlyEntrySetInlineKeyLen(ent, len(key))
 	} else if steal {
@@ -1167,7 +1170,9 @@ func (m *AppendOnly) appendEntryTrustedOrderedLocked(key, value []byte, ptr page
 	ent.payloadIndex = 0
 	payloadValue := ""
 	payloadPtr := page.ValuePtr{}
-	if len(key) <= appendOnlyInlineKeyLen {
+	if len(key) == 0 {
+		appendOnlyEntrySetKeyIndex(ent, m.appendKeyLocked(""))
+	} else if len(key) <= appendOnlyInlineKeyLen {
 		copy(ent.inlineKey[:], key)
 		appendOnlyEntrySetInlineKeyLen(ent, len(key))
 	} else if steal {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -69,12 +69,10 @@ type appendOnlyEntry struct {
 }
 
 const (
-	appendOnlyEntryInlineLenShift = 28
-	appendOnlyEntryInlineLenMask  = uint32(0xF) << appendOnlyEntryInlineLenShift
-	appendOnlyEntryKeyIndexMask   = ^appendOnlyEntryInlineLenMask
-	appendOnlyEntryFlagsShift     = 24
-	appendOnlyEntryFlagsMask      = uint32(0xFF) << appendOnlyEntryFlagsShift
-	appendOnlyEntryPayloadIdxMask = ^appendOnlyEntryFlagsMask
+	appendOnlyEntryInlineLenShift  = 28
+	appendOnlyEntryInlineLenMask   = uint32(0xF) << appendOnlyEntryInlineLenShift
+	appendOnlyEntryKeyIndexMask    = ^appendOnlyEntryInlineLenMask
+	appendOnlyEntryInlineFlagsMask = uint32(0xFF)
 )
 
 func appendOnlyEntryInlineKeyLen(ent *appendOnlyEntry) int {
@@ -96,6 +94,9 @@ func appendOnlyEntryKeyIndex(ent *appendOnlyEntry) uint32 {
 	if ent == nil {
 		return 0
 	}
+	if appendOnlyEntryInlineKeyLen(ent) != 0 {
+		return 0
+	}
 	return ent.keyIndex & appendOnlyEntryKeyIndexMask
 }
 
@@ -113,32 +114,41 @@ func appendOnlyEntryFlags(ent *appendOnlyEntry) byte {
 	if ent == nil {
 		return 0
 	}
-	return byte((ent.payloadIndex & appendOnlyEntryFlagsMask) >> appendOnlyEntryFlagsShift)
+	if appendOnlyEntryInlineKeyLen(ent) != 0 {
+		return byte(ent.keyIndex & appendOnlyEntryInlineFlagsMask)
+	}
+	if appendOnlyEntryKeyIndex(ent) != 0 {
+		return ent.inlineKey[0]
+	}
+	return 0
 }
 
 func appendOnlyEntrySetFlags(ent *appendOnlyEntry, flags byte) {
 	if ent == nil {
 		return
 	}
-	ent.payloadIndex = (ent.payloadIndex & appendOnlyEntryPayloadIdxMask) |
-		(uint32(flags) << appendOnlyEntryFlagsShift)
+	if appendOnlyEntryInlineKeyLen(ent) != 0 {
+		ent.keyIndex = (ent.keyIndex &^ appendOnlyEntryInlineFlagsMask) | uint32(flags)
+		return
+	}
+	if appendOnlyEntryKeyIndex(ent) != 0 {
+		ent.inlineKey[0] = flags
+		return
+	}
 }
 
 func appendOnlyEntryPayloadIndex(ent *appendOnlyEntry) uint32 {
 	if ent == nil {
 		return 0
 	}
-	return ent.payloadIndex & appendOnlyEntryPayloadIdxMask
+	return ent.payloadIndex
 }
 
 func appendOnlyEntrySetPayloadIndex(ent *appendOnlyEntry, idx uint32) {
 	if ent == nil {
 		return
 	}
-	if idx > appendOnlyEntryPayloadIdxMask {
-		panic("appendOnlyEntry payload index overflow")
-	}
-	ent.payloadIndex = (ent.payloadIndex & appendOnlyEntryFlagsMask) | idx
+	ent.payloadIndex = idx
 }
 
 type appendOnlyValueArena struct {
@@ -604,13 +614,12 @@ func (m *AppendOnly) appendOnlyEntryValue(ent *appendOnlyEntry) []byte {
 	if m == nil || ent == nil {
 		return nil
 	}
-	payloadMeta := ent.payloadIndex
-	payloadIndex := payloadMeta & appendOnlyEntryPayloadIdxMask
+	payloadIndex := ent.payloadIndex
 	if payloadIndex == 0 {
 		return nil
 	}
 	idx := int(payloadIndex - 1)
-	if byte(payloadMeta>>appendOnlyEntryFlagsShift)&node.FlagPointer != 0 {
+	if appendOnlyEntryFlags(ent)&node.FlagPointer != 0 {
 		if idx < 0 || idx >= len(m.ptrPayloads) {
 			return nil
 		}
@@ -626,11 +635,10 @@ func (m *AppendOnly) appendOnlyEntryPtr(ent *appendOnlyEntry) page.ValuePtr {
 	if m == nil || ent == nil {
 		return page.ValuePtr{}
 	}
-	payloadMeta := ent.payloadIndex
-	if byte(payloadMeta>>appendOnlyEntryFlagsShift)&node.FlagPointer == 0 {
+	if appendOnlyEntryFlags(ent)&node.FlagPointer == 0 {
 		return page.ValuePtr{}
 	}
-	payloadIndex := payloadMeta & appendOnlyEntryPayloadIdxMask
+	payloadIndex := ent.payloadIndex
 	if payloadIndex == 0 {
 		return page.ValuePtr{}
 	}
@@ -1034,7 +1042,6 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	ent := &m.entries[idx]
 	ent.keyIndex = 0
 	ent.payloadIndex = 0
-	appendOnlyEntrySetFlags(ent, flags)
 	payloadValue := ""
 	payloadPtr := page.ValuePtr{}
 	if len(key) <= appendOnlyInlineKeyLen {
@@ -1045,6 +1052,7 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	} else {
 		appendOnlyEntrySetKeyIndex(ent, m.appendKeyLocked(appendOnlyArenaStringCopy(&m.valueArena, key)))
 	}
+	appendOnlyEntrySetFlags(ent, flags)
 	if steal {
 		payloadValue = appendOnlyStringFromBytes(value)
 	} else {
@@ -1137,7 +1145,6 @@ func (m *AppendOnly) appendEntryTrustedOrderedLocked(key, value []byte, ptr page
 	ent := &m.entries[idx]
 	ent.keyIndex = 0
 	ent.payloadIndex = 0
-	appendOnlyEntrySetFlags(ent, flags)
 	payloadValue := ""
 	payloadPtr := page.ValuePtr{}
 	if len(key) <= appendOnlyInlineKeyLen {
@@ -1148,6 +1155,7 @@ func (m *AppendOnly) appendEntryTrustedOrderedLocked(key, value []byte, ptr page
 	} else {
 		appendOnlyEntrySetKeyIndex(ent, m.appendKeyLocked(appendOnlyArenaStringCopy(&m.valueArena, key)))
 	}
+	appendOnlyEntrySetFlags(ent, flags)
 	if steal {
 		payloadValue = appendOnlyStringFromBytes(value)
 	} else if len(value) > 0 {
@@ -1849,12 +1857,14 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		m.keys = m.keys[:0]
 	}
 	if !retainObserved || cap(m.values) > maxRetainedEntries {
+		putAppendOnlyValues(m.values)
 		m.values = nil
 	} else {
 		clear(m.values)
 		m.values = m.values[:0]
 	}
 	if !retainObserved || cap(m.ptrPayloads) > maxRetainedEntries {
+		putAppendOnlyPtrPayloads(m.ptrPayloads)
 		m.ptrPayloads = nil
 	} else {
 		clear(m.ptrPayloads)
@@ -2030,8 +2040,8 @@ func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntr
 		if appendOnlyEntryInlineKeyLen(&active[idx]) != 0 || active[idx].keyIndex&appendOnlyEntryKeyIndexMask != 0 {
 			keyCount++
 		}
-		if active[idx].payloadIndex&appendOnlyEntryPayloadIdxMask != 0 {
-			if byte(active[idx].payloadIndex>>appendOnlyEntryFlagsShift)&node.FlagPointer != 0 {
+		if active[idx].payloadIndex != 0 {
+			if appendOnlyEntryFlags(&active[idx])&node.FlagPointer != 0 {
 				ptrPayloadCount++
 			} else {
 				valueCount++
@@ -2047,18 +2057,20 @@ func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntr
 	for i, idx := range indices {
 		ent := active[idx]
 		if inlineLen := appendOnlyEntryInlineKeyLen(&ent); inlineLen != 0 {
+			flags := appendOnlyEntryFlags(&ent)
 			keys[nextKey] = appendOnlyArenaStringCopy(&m.valueArena, ent.inlineKey[:inlineLen])
 			ent.inlineKey = [appendOnlyInlineKeyLen]byte{}
 			appendOnlyEntrySetInlineKeyLen(&ent, 0)
 			appendOnlyEntrySetKeyIndex(&ent, uint32(nextKey+1))
+			appendOnlyEntrySetFlags(&ent, flags)
 			nextKey++
 		} else if keyIndex := ent.keyIndex & appendOnlyEntryKeyIndexMask; keyIndex != 0 {
 			keys[nextKey] = m.keys[keyIndex-1]
 			appendOnlyEntrySetKeyIndex(&ent, uint32(nextKey+1))
 			nextKey++
 		}
-		if payloadIndex := ent.payloadIndex & appendOnlyEntryPayloadIdxMask; payloadIndex != 0 {
-			if byte(ent.payloadIndex>>appendOnlyEntryFlagsShift)&node.FlagPointer != 0 {
+		if payloadIndex := ent.payloadIndex; payloadIndex != 0 {
+			if appendOnlyEntryFlags(&ent)&node.FlagPointer != 0 {
 				ptrPayloads[nextPtrPayload] = m.ptrPayloads[payloadIndex-1]
 				appendOnlyEntrySetPayloadIndex(&ent, uint32(nextPtrPayload+1))
 				nextPtrPayload++
@@ -2355,14 +2367,14 @@ func (it *appendOnlyIterator) UnsafeValue() []byte {
 	if ent == nil || !it.validIndex() {
 		return nil
 	}
-	flags := byte(ent.payloadIndex >> appendOnlyEntryFlagsShift)
+	flags := appendOnlyEntryFlags(ent)
 	if flags&node.FlagTombstone != 0 {
 		return nil
 	}
 	if it.owner != nil {
 		return it.owner.appendOnlyEntryValue(ent)
 	}
-	idx := int((ent.payloadIndex & appendOnlyEntryPayloadIdxMask) - 1)
+	idx := int(ent.payloadIndex - 1)
 	if idx < 0 {
 		return nil
 	}
@@ -2386,8 +2398,8 @@ func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	if it.owner != nil {
 		return it.owner.appendOnlyEntryValue(ent), it.owner.appendOnlyEntryPtr(ent), appendOnlyEntryFlags(ent)
 	}
-	flags := byte(ent.payloadIndex >> appendOnlyEntryFlagsShift)
-	idx := int((ent.payloadIndex & appendOnlyEntryPayloadIdxMask) - 1)
+	flags := appendOnlyEntryFlags(ent)
+	idx := int(ent.payloadIndex - 1)
 	if idx < 0 {
 		return nil, page.ValuePtr{}, flags
 	}
@@ -2409,7 +2421,7 @@ func (it *appendOnlyIterator) IsDeleted() bool {
 	if ent == nil || !it.validIndex() {
 		return false
 	}
-	return byte(ent.payloadIndex>>appendOnlyEntryFlagsShift)&node.FlagTombstone != 0
+	return appendOnlyEntryFlags(ent)&node.FlagTombstone != 0
 }
 
 func (it *appendOnlyIterator) Key() []byte {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -1842,10 +1842,18 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		clear(m.keys)
 		m.keys = m.keys[:0]
 	}
-	clear(m.values)
-	m.values = m.values[:0]
-	clear(m.ptrPayloads)
-	m.ptrPayloads = m.ptrPayloads[:0]
+	if !retainObserved || cap(m.values) > maxRetainedEntries {
+		m.values = nil
+	} else {
+		clear(m.values)
+		m.values = m.values[:0]
+	}
+	if !retainObserved || cap(m.ptrPayloads) > maxRetainedEntries {
+		m.ptrPayloads = nil
+	} else {
+		clear(m.ptrPayloads)
+		m.ptrPayloads = m.ptrPayloads[:0]
+	}
 	m.valueArena.reset()
 	if !retainObserved {
 		m.valueArena.dropRetained()

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -25,15 +25,18 @@ const (
 	appendOnlyInlineKeyLen                  = 8
 	appendOnlyEntryPoolMaxCap               = 1 << 20
 	appendOnlyKeyPoolMaxCap                 = 1 << 20
-	appendOnlyPayloadPoolMaxCap             = 1 << 20
+	appendOnlyValuePoolMaxCap               = 1 << 20
+	appendOnlyPtrPayloadPoolMaxCap          = 1 << 20
 	appendOnlyIteratorPoolMaxCap            = 1 << 20
 	appendOnlyIteratorKeyPoolMaxCap         = 1 << 20
-	appendOnlyIteratorPayloadPoolMaxCap     = 1 << 20
+	appendOnlyIteratorValuePoolMaxCap       = 1 << 20
+	appendOnlyIteratorPtrPayloadPoolMaxCap  = 1 << 20
 	appendOnlyIteratorPtrPoolMaxCap         = 1 << 20
 	appendOnlyValueArenaMinShift            = 12
 	appendOnlyValueArenaMaxShift            = 20
 	appendOnlyValueArenaClassCount          = appendOnlyValueArenaMaxShift - appendOnlyValueArenaMinShift + 1
 	appendOnlyValueArenaDefaultChunk        = 32 << 10
+	appendOnlyValueArenaGrowthMaxChunk      = 64 << 10
 	appendOnlyValueArenaPoolMaxCap          = 1 << appendOnlyValueArenaMaxShift
 	appendOnlyValueArenaRetainMaxCap        = 4 << 20
 	appendOnlyValueArenaRetainChunks        = 128
@@ -45,26 +48,98 @@ const (
 
 var appendOnlyEntryPool sync.Pool
 var appendOnlyKeyPool sync.Pool
-var appendOnlyPayloadPool sync.Pool
+var appendOnlyValuePool sync.Pool
+var appendOnlyPtrPayloadPool sync.Pool
 var appendOnlyIteratorPool sync.Pool
 var appendOnlyIteratorKeyPool sync.Pool
-var appendOnlyIteratorPayloadPool sync.Pool
+var appendOnlyIteratorValuePool sync.Pool
+var appendOnlyIteratorPtrPayloadPool sync.Pool
 var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
 
-type appendOnlyPayload struct {
+type appendOnlyPointerPayload struct {
 	value string
 	ptr   page.ValuePtr
 }
+
 type appendOnlyEntry struct {
 	inlineKey    [appendOnlyInlineKeyLen]byte
 	keyIndex     uint32
 	payloadIndex uint32
-	inlineKeyLen uint8
-	flags        byte
 }
 
-const appendOnlyEntryFlagKeyInline = 0x80
+const (
+	appendOnlyEntryInlineLenShift = 28
+	appendOnlyEntryInlineLenMask  = uint32(0xF) << appendOnlyEntryInlineLenShift
+	appendOnlyEntryKeyIndexMask   = ^appendOnlyEntryInlineLenMask
+	appendOnlyEntryFlagsShift     = 30
+	appendOnlyEntryFlagsMask      = uint32(0x3) << appendOnlyEntryFlagsShift
+	appendOnlyEntryPayloadIdxMask = ^appendOnlyEntryFlagsMask
+)
+
+func appendOnlyEntryInlineKeyLen(ent *appendOnlyEntry) int {
+	if ent == nil {
+		return 0
+	}
+	return int((ent.keyIndex & appendOnlyEntryInlineLenMask) >> appendOnlyEntryInlineLenShift)
+}
+
+func appendOnlyEntrySetInlineKeyLen(ent *appendOnlyEntry, length int) {
+	if ent == nil {
+		return
+	}
+	ent.keyIndex = (ent.keyIndex & appendOnlyEntryKeyIndexMask) |
+		(uint32(length&0xF) << appendOnlyEntryInlineLenShift)
+}
+
+func appendOnlyEntryKeyIndex(ent *appendOnlyEntry) uint32 {
+	if ent == nil {
+		return 0
+	}
+	return ent.keyIndex & appendOnlyEntryKeyIndexMask
+}
+
+func appendOnlyEntrySetKeyIndex(ent *appendOnlyEntry, idx uint32) {
+	if ent == nil {
+		return
+	}
+	if idx > appendOnlyEntryKeyIndexMask {
+		panic("appendOnlyEntry key index overflow")
+	}
+	ent.keyIndex = (ent.keyIndex & appendOnlyEntryInlineLenMask) | idx
+}
+
+func appendOnlyEntryFlags(ent *appendOnlyEntry) byte {
+	if ent == nil {
+		return 0
+	}
+	return byte((ent.payloadIndex & appendOnlyEntryFlagsMask) >> appendOnlyEntryFlagsShift)
+}
+
+func appendOnlyEntrySetFlags(ent *appendOnlyEntry, flags byte) {
+	if ent == nil {
+		return
+	}
+	ent.payloadIndex = (ent.payloadIndex & appendOnlyEntryPayloadIdxMask) |
+		(uint32(flags&0x3) << appendOnlyEntryFlagsShift)
+}
+
+func appendOnlyEntryPayloadIndex(ent *appendOnlyEntry) uint32 {
+	if ent == nil {
+		return 0
+	}
+	return ent.payloadIndex & appendOnlyEntryPayloadIdxMask
+}
+
+func appendOnlyEntrySetPayloadIndex(ent *appendOnlyEntry, idx uint32) {
+	if ent == nil {
+		return
+	}
+	if idx > appendOnlyEntryPayloadIdxMask {
+		panic("appendOnlyEntry payload index overflow")
+	}
+	ent.payloadIndex = (ent.payloadIndex & appendOnlyEntryFlagsMask) | idx
+}
 
 type appendOnlyValueArena struct {
 	chunks    [][]byte
@@ -79,7 +154,8 @@ type AppendOnly struct {
 
 	entries        []appendOnlyEntry
 	keys           []string
-	payloads       []appendOnlyPayload
+	values         []string
+	ptrPayloads    []appendOnlyPointerPayload
 	baseEntriesLen int
 	growEntriesLen int
 	latest         map[string]int
@@ -107,6 +183,16 @@ type AppendOnly struct {
 }
 
 func (*AppendOnly) StableUnsafeIteratorSlices() bool { return true }
+
+func (m *AppendOnly) Ordered() bool {
+	if m == nil {
+		return true
+	}
+	m.mu.RLock()
+	ordered := m.ordered
+	m.mu.RUnlock()
+	return ordered
+}
 
 func appendOnlyMaxReuseEntries(length int) int {
 	maxReuse := appendOnlyEntryPoolMaxCap
@@ -190,35 +276,66 @@ func putAppendOnlyKeys(keys []string) {
 	appendOnlyKeyPool.Put(full[:0])
 }
 
-func getAppendOnlyPayloadsFromPool(length int, pool *sync.Pool) []appendOnlyPayload {
+func getAppendOnlyValuesFromPool(length int, pool *sync.Pool) []string {
 	if length < 0 {
 		length = 0
 	}
-	if length > appendOnlyPayloadPoolMaxCap {
-		return make([]appendOnlyPayload, length)
+	if length > appendOnlyValuePoolMaxCap {
+		return make([]string, length)
 	}
 	if pool == nil {
-		return make([]appendOnlyPayload, length)
+		return make([]string, length)
 	}
 	if v := pool.Get(); v != nil {
-		if payloads, ok := v.([]appendOnlyPayload); ok && cap(payloads) >= length {
+		if values, ok := v.([]string); ok && cap(values) >= length {
+			return values[:length]
+		}
+	}
+	return make([]string, length)
+}
+
+func getAppendOnlyValues(length int) []string {
+	return getAppendOnlyValuesFromPool(length, &appendOnlyValuePool)
+}
+
+func putAppendOnlyValues(values []string) {
+	if values == nil || cap(values) == 0 || cap(values) > appendOnlyValuePoolMaxCap {
+		return
+	}
+	full := values[:cap(values)]
+	clear(full)
+	appendOnlyValuePool.Put(full[:0])
+}
+
+func getAppendOnlyPtrPayloadsFromPool(length int, pool *sync.Pool) []appendOnlyPointerPayload {
+	if length < 0 {
+		length = 0
+	}
+	if length > appendOnlyPtrPayloadPoolMaxCap {
+		return make([]appendOnlyPointerPayload, length)
+	}
+	if pool == nil {
+		return make([]appendOnlyPointerPayload, length)
+	}
+	if v := pool.Get(); v != nil {
+		if payloads, ok := v.([]appendOnlyPointerPayload); ok && cap(payloads) >= length {
 			return payloads[:length]
 		}
 	}
-	return make([]appendOnlyPayload, length)
+	return make([]appendOnlyPointerPayload, length)
 }
 
-func getAppendOnlyPayloads(length int) []appendOnlyPayload {
-	return getAppendOnlyPayloadsFromPool(length, &appendOnlyPayloadPool)
+func getAppendOnlyPtrPayloads(length int) []appendOnlyPointerPayload {
+	return getAppendOnlyPtrPayloadsFromPool(length, &appendOnlyPtrPayloadPool)
 }
 
-func putAppendOnlyPayloads(payloads []appendOnlyPayload) {
-	if payloads == nil || cap(payloads) == 0 || cap(payloads) > appendOnlyPayloadPoolMaxCap {
+func putAppendOnlyPtrPayloads(payloads []appendOnlyPointerPayload) {
+	if payloads == nil || cap(payloads) == 0 || cap(payloads) > appendOnlyPtrPayloadPoolMaxCap {
 		return
 	}
 	full := payloads[:cap(payloads)]
 	clear(full)
-	appendOnlyPayloadPool.Put(full[:0])
+	appendOnlyPtrPayloadPool.Put(full[:0])
 }
 
 func getAppendOnlyIteratorEntries(length int) []appendOnlyEntry {
@@ -259,17 +376,30 @@ func putAppendOnlyIteratorKeys(keys []string) {
 	appendOnlyIteratorKeyPool.Put(full[:0])
 }
 
-func getAppendOnlyIteratorPayloads(length int) []appendOnlyPayload {
-	return getAppendOnlyPayloadsFromPool(length, &appendOnlyIteratorPayloadPool)
+func getAppendOnlyIteratorValues(length int) []string {
+	return getAppendOnlyValuesFromPool(length, &appendOnlyIteratorValuePool)
 }
 
-func putAppendOnlyIteratorPayloads(payloads []appendOnlyPayload) {
-	if payloads == nil || cap(payloads) == 0 || cap(payloads) > appendOnlyIteratorPayloadPoolMaxCap {
+func putAppendOnlyIteratorValues(values []string) {
+	if values == nil || cap(values) == 0 || cap(values) > appendOnlyIteratorValuePoolMaxCap {
+		return
+	}
+	full := values[:cap(values)]
+	clear(full)
+	appendOnlyIteratorValuePool.Put(full[:0])
+}
+
+func getAppendOnlyIteratorPtrPayloads(length int) []appendOnlyPointerPayload {
+	return getAppendOnlyPtrPayloadsFromPool(length, &appendOnlyIteratorPtrPayloadPool)
+}
+
+func putAppendOnlyIteratorPtrPayloads(payloads []appendOnlyPointerPayload) {
+	if payloads == nil || cap(payloads) == 0 || cap(payloads) > appendOnlyIteratorPtrPayloadPoolMaxCap {
 		return
 	}
 	full := payloads[:cap(payloads)]
 	clear(full)
-	appendOnlyIteratorPayloadPool.Put(full[:0])
+	appendOnlyIteratorPtrPayloadPool.Put(full[:0])
 }
 
 func getAppendOnlyIteratorPtrs(length int) []*appendOnlyEntry {
@@ -386,13 +516,15 @@ func appendOnlyEntryKeyFromKeys(ent *appendOnlyEntry, keys []string) []byte {
 	if ent == nil {
 		return nil
 	}
-	if ent.flags&appendOnlyEntryFlagKeyInline != 0 {
-		return ent.inlineKey[:int(ent.inlineKeyLen)]
+	inlineLen := int(ent.keyIndex >> appendOnlyEntryInlineLenShift)
+	if inlineLen != 0 {
+		return ent.inlineKey[:inlineLen]
 	}
-	if ent.keyIndex == 0 {
+	keyIndex := ent.keyIndex & appendOnlyEntryKeyIndexMask
+	if keyIndex == 0 {
 		return nil
 	}
-	idx := int(ent.keyIndex - 1)
+	idx := int(keyIndex - 1)
 	if idx < 0 || idx >= len(keys) {
 		return nil
 	}
@@ -403,11 +535,11 @@ func appendOnlyEntryKeyFromKeys(ent *appendOnlyEntry, keys []string) []byte {
 	return unsafe.Slice(unsafe.StringData(key), len(key))
 }
 
-func appendOnlyPayloadValue(payload *appendOnlyPayload) []byte {
-	if payload == nil || len(payload.value) == 0 {
+func appendOnlyValueStringBytes(value string) []byte {
+	if len(value) == 0 {
 		return nil
 	}
-	return unsafe.Slice(unsafe.StringData(payload.value), len(payload.value))
+	return unsafe.Slice(unsafe.StringData(value), len(value))
 }
 
 func appendOnlyStringFromBytes(src []byte) string {
@@ -442,24 +574,43 @@ func (m *AppendOnly) appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
 	return appendOnlyEntryKeyFromKeys(ent, m.keys)
 }
 
-func (m *AppendOnly) appendOnlyPayload(ent *appendOnlyEntry) *appendOnlyPayload {
-	if m == nil || ent == nil || ent.payloadIndex == 0 {
-		return nil
-	}
-	idx := int(ent.payloadIndex - 1)
-	if idx < 0 || idx >= len(m.payloads) {
-		return nil
-	}
-	return &m.payloads[idx]
-}
-
 func (m *AppendOnly) appendOnlyEntryValue(ent *appendOnlyEntry) []byte {
-	return appendOnlyPayloadValue(m.appendOnlyPayload(ent))
+	if m == nil || ent == nil {
+		return nil
+	}
+	payloadMeta := ent.payloadIndex
+	payloadIndex := payloadMeta & appendOnlyEntryPayloadIdxMask
+	if payloadIndex == 0 {
+		return nil
+	}
+	idx := int(payloadIndex - 1)
+	if byte(payloadMeta>>appendOnlyEntryFlagsShift)&node.FlagPointer != 0 {
+		if idx < 0 || idx >= len(m.ptrPayloads) {
+			return nil
+		}
+		return appendOnlyValueStringBytes(m.ptrPayloads[idx].value)
+	}
+	if idx < 0 || idx >= len(m.values) {
+		return nil
+	}
+	return appendOnlyValueStringBytes(m.values[idx])
 }
 
 func (m *AppendOnly) appendOnlyEntryPtr(ent *appendOnlyEntry) page.ValuePtr {
-	if payload := m.appendOnlyPayload(ent); payload != nil {
-		return payload.ptr
+	if m == nil || ent == nil {
+		return page.ValuePtr{}
+	}
+	payloadMeta := ent.payloadIndex
+	if byte(payloadMeta>>appendOnlyEntryFlagsShift)&node.FlagPointer == 0 {
+		return page.ValuePtr{}
+	}
+	payloadIndex := payloadMeta & appendOnlyEntryPayloadIdxMask
+	if payloadIndex == 0 {
+		return page.ValuePtr{}
+	}
+	idx := int(payloadIndex - 1)
+	if idx >= 0 && idx < len(m.ptrPayloads) {
+		return m.ptrPayloads[idx].ptr
 	}
 	return page.ValuePtr{}
 }
@@ -570,9 +721,28 @@ func (a *appendOnlyValueArena) alloc(length int) []byte {
 		return nil
 	}
 	if a.cur == nil || cap(a.cur)-a.curPos < length {
-		chunk := a.popRetained(length)
+		chunkCap := length
+		if chunkCap < appendOnlyValueArenaDefaultChunk {
+			chunkCap = appendOnlyValueArenaDefaultChunk
+		}
+		if n := len(a.chunks); n > 0 {
+			prevCap := cap(a.chunks[n-1])
+			if prevCap > chunkCap {
+				chunkCap = prevCap
+			}
+			if prevCap < appendOnlyValueArenaGrowthMaxChunk {
+				grownCap := prevCap << 1
+				if grownCap > appendOnlyValueArenaGrowthMaxChunk {
+					grownCap = appendOnlyValueArenaGrowthMaxChunk
+				}
+				if grownCap > chunkCap {
+					chunkCap = grownCap
+				}
+			}
+		}
+		chunk := a.popRetained(chunkCap)
 		if chunk == nil {
-			chunk = getAppendOnlyValueArenaChunk(length)
+			chunk = getAppendOnlyValueArenaChunk(chunkCap)
 		}
 		a.chunks = append(a.chunks, chunk)
 		a.cur = chunk[:cap(chunk)]
@@ -611,11 +781,6 @@ func appendOnlyNextCapacity(current int) int {
 		return appendOnlyMinInitialEntries
 	}
 	next := current * 2
-	// Entry-heavy write paths can spend a disproportionate amount of time
-	// copying entry arrays during growth, even when values themselves are
-	// borrowed from batch arenas or stored inline. Grow more aggressively up to
-	// the retained warm-reset window, then fall back to 2x to keep expansion
-	// bounded once the memtable is already large.
 	if current < appendOnlyAggressiveGrowCutoff {
 		next = current * 4
 	}
@@ -790,22 +955,20 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	idx := m.count
 	m.count++
 	ent := &m.entries[idx]
-	ent.flags = flags
 	ent.keyIndex = 0
 	ent.payloadIndex = 0
-	ent.inlineKeyLen = 0
+	appendOnlyEntrySetFlags(ent, flags)
 	payloadValue := ""
 	payloadPtr := page.ValuePtr{}
 	if len(key) <= appendOnlyInlineKeyLen {
 		copy(ent.inlineKey[:], key)
-		ent.inlineKeyLen = uint8(len(key))
-		ent.flags |= appendOnlyEntryFlagKeyInline
+		appendOnlyEntrySetInlineKeyLen(ent, len(key))
 	} else if steal {
 		m.keys = append(m.keys, appendOnlyStringFromBytes(key))
-		ent.keyIndex = uint32(len(m.keys))
+		appendOnlyEntrySetKeyIndex(ent, uint32(len(m.keys)))
 	} else {
 		m.keys = append(m.keys, appendOnlyArenaStringCopy(&m.valueArena, key))
-		ent.keyIndex = uint32(len(m.keys))
+		appendOnlyEntrySetKeyIndex(ent, uint32(len(m.keys)))
 	}
 	if steal {
 		payloadValue = appendOnlyStringFromBytes(value)
@@ -824,12 +987,10 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	if flags&node.FlagTombstone != 0 {
 		payloadValue = ""
 		payloadPtr = page.ValuePtr{}
-	} else if payloadValue != "" || payloadPtr != (page.ValuePtr{}) {
-		m.payloads = append(m.payloads, appendOnlyPayload{
-			value: payloadValue,
-			ptr:   payloadPtr,
-		})
-		ent.payloadIndex = uint32(len(m.payloads))
+	} else if flags&node.FlagPointer != 0 {
+		appendOnlyEntrySetPayloadIndex(ent, m.appendPtrPayloadLocked(payloadValue, payloadPtr))
+	} else if payloadValue != "" {
+		appendOnlyEntrySetPayloadIndex(ent, m.appendValueLocked(payloadValue))
 	}
 	k := m.appendOnlyEntryKey(ent)
 	m.sizeBytes += int64(len(k) + entryValueSize(flags, len(payloadValue)))
@@ -850,19 +1011,140 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 			return
 		}
 		m.ordered = false
-		// Once order breaks, invalidate the cached snapshot state and
-		// materialize the latest-key index immediately so subsequent unordered
-		// appends can maintain it incrementally instead of forcing the next
-		// iterator/lookup to rebuild the full map from scratch.
-		// rebuildLatestIndexLocked clears the cached snapshot as part of the
-		// transition.
-		m.rebuildLatestIndexLocked()
+		// Keep the write path purely append-only. The latest-key index is only
+		// materialized if a read or iterator needs the unordered view.
+		m.latestDirty = true
+		m.clearSnapshotLocked()
 		return
 	}
 	if !m.latestDirty {
 		m.updateLatestIndexLocked(k, idx)
 	}
 	m.clearSnapshotLocked()
+}
+
+func (m *AppendOnly) canAppendTrustedOrderedBatchLocked(firstKey []byte) bool {
+	if !m.ordered {
+		return false
+	}
+	if !m.hasLast {
+		return true
+	}
+	return bytes.Compare(firstKey, m.appendOnlyEntryKey(&m.entries[m.lastIdx])) > 0
+}
+
+func (m *AppendOnly) appendEntryTrustedOrderedLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) {
+	if m.count == len(m.entries) {
+		if m.predictEntryHintSource != nil {
+			if shared := appendOnlyClampRetainedEntries(int(m.predictEntryHintSource.Load())); shared > m.growEntriesLen {
+				m.growEntriesLen = shared
+			}
+		}
+		nextCap := appendOnlyNextCapacity(len(m.entries))
+		if nextCap < m.growEntriesLen {
+			nextCap = m.growEntriesLen
+		}
+		prev := m.entries
+		grown := getAppendOnlyEntries(nextCap)
+		copy(grown, m.entries[:m.count])
+		m.entries = grown
+		putAppendOnlyEntries(prev)
+		if observe := m.observeEntries; observe != nil {
+			observe(nextCap)
+		}
+	}
+	idx := m.count
+	m.count++
+	ent := &m.entries[idx]
+	ent.keyIndex = 0
+	ent.payloadIndex = 0
+	appendOnlyEntrySetFlags(ent, flags)
+	payloadValue := ""
+	payloadPtr := page.ValuePtr{}
+	if len(key) <= appendOnlyInlineKeyLen {
+		copy(ent.inlineKey[:], key)
+		appendOnlyEntrySetInlineKeyLen(ent, len(key))
+	} else if steal {
+		m.keys = append(m.keys, appendOnlyStringFromBytes(key))
+		appendOnlyEntrySetKeyIndex(ent, uint32(len(m.keys)))
+	} else {
+		m.keys = append(m.keys, appendOnlyArenaStringCopy(&m.valueArena, key))
+		appendOnlyEntrySetKeyIndex(ent, uint32(len(m.keys)))
+	}
+	if steal {
+		payloadValue = appendOnlyStringFromBytes(value)
+	} else if len(value) > 0 {
+		if borrowValue {
+			payloadValue = appendOnlyStringFromBytes(value)
+		} else {
+			payloadValue = appendOnlyArenaStringCopy(&m.valueArena, value)
+		}
+	}
+	if flags&node.FlagPointer != 0 {
+		payloadPtr = ptr
+	}
+	if flags&node.FlagTombstone != 0 {
+		payloadValue = ""
+		payloadPtr = page.ValuePtr{}
+	} else if flags&node.FlagPointer != 0 {
+		appendOnlyEntrySetPayloadIndex(ent, m.appendPtrPayloadLocked(payloadValue, payloadPtr))
+	} else if payloadValue != "" {
+		appendOnlyEntrySetPayloadIndex(ent, m.appendValueLocked(payloadValue))
+	}
+	m.sizeBytes += int64(len(key) + entryValueSize(flags, len(payloadValue)))
+	if appendOnlyShouldPredictHint(m.count) {
+		m.maybeRaisePredictedGrowthHintLocked()
+	}
+	m.lastIdx = idx
+	m.hasLast = true
+}
+
+func (m *AppendOnly) appendValueLocked(value string) uint32 {
+	if len(m.values) == cap(m.values) {
+		nextCap := appendOnlyMinInitialEntries
+		if cap(m.values) > 0 {
+			nextCap = appendOnlyNextCapacity(cap(m.values))
+		} else if len(m.values) == m.count-1 {
+			if entriesCap := cap(m.entries); entriesCap > nextCap {
+				if entriesCap > appendOnlyResetDropThresholdEntries {
+					entriesCap = appendOnlyResetDropThresholdEntries
+				}
+				nextCap = entriesCap
+			}
+		}
+		if nextCap < len(m.values)+1 {
+			nextCap = len(m.values) + 1
+		}
+		prev := m.values
+		grown := getAppendOnlyValues(nextCap)
+		copy(grown, prev)
+		m.values = grown[:len(prev)]
+		putAppendOnlyValues(prev)
+	}
+	m.values = append(m.values, value)
+	return uint32(len(m.values))
+}
+
+func (m *AppendOnly) appendPtrPayloadLocked(value string, ptr page.ValuePtr) uint32 {
+	if len(m.ptrPayloads) == cap(m.ptrPayloads) {
+		nextCap := appendOnlyMinInitialEntries
+		if cap(m.ptrPayloads) > 0 {
+			nextCap = appendOnlyNextCapacity(cap(m.ptrPayloads))
+		}
+		if nextCap < len(m.ptrPayloads)+1 {
+			nextCap = len(m.ptrPayloads) + 1
+		}
+		prev := m.ptrPayloads
+		grown := getAppendOnlyPtrPayloads(nextCap)
+		copy(grown, prev)
+		m.ptrPayloads = grown[:len(prev)]
+		putAppendOnlyPtrPayloads(prev)
+	}
+	m.ptrPayloads = append(m.ptrPayloads, appendOnlyPointerPayload{
+		value: value,
+		ptr:   ptr,
+	})
+	return uint32(len(m.ptrPayloads))
 }
 
 func (m *AppendOnly) Set(key, value []byte) {
@@ -931,7 +1213,23 @@ func (m *AppendOnly) ApplyStealSortedBatch(entries []batchpkg.Entry, onKey func(
 }
 
 func (m *AppendOnly) ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKey func(key []byte)) {
-	m.applyStealBatch(entries, onKey)
+	m.applyStealBatchTrusted(entries, onKey)
+}
+
+func (m *AppendOnly) ApplyBorrowValueSortedBatch(entries []batchpkg.Entry, storeInlinePtrValues bool, onKey func(key []byte)) {
+	m.applyBorrowValueBatch(entries, storeInlinePtrValues, onKey)
+}
+
+func (m *AppendOnly) ApplyBorrowValueSortedBatchTrusted(entries []batchpkg.Entry, storeInlinePtrValues bool, onKey func(key []byte)) {
+	m.applyBorrowValueBatchTrusted(entries, storeInlinePtrValues, onKey)
+}
+
+func (m *AppendOnly) ApplyStealSortedBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, onKey func(key []byte)) {
+	m.applyStealBatchIndicesTrusted(entries, idxs, onKey)
+}
+
+func (m *AppendOnly) ApplyBorrowValueSortedBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, storeInlinePtrValues bool, onKey func(key []byte)) {
+	m.applyBorrowValueBatchIndicesTrusted(entries, idxs, storeInlinePtrValues, onKey)
 }
 
 func (m *AppendOnly) applyStealBatch(entries []batchpkg.Entry, onKey func(key []byte)) {
@@ -945,6 +1243,235 @@ func (m *AppendOnly) applyStealBatch(entries []batchpkg.Entry, onKey func(key []
 			m.appendEntryLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
 		default:
 			m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+		}
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	m.mu.Unlock()
+}
+
+func (m *AppendOnly) applyStealBatchTrusted(entries []batchpkg.Entry, onKey func(key []byte)) {
+	m.mu.Lock()
+	if len(entries) > 0 && m.canAppendTrustedOrderedBatchLocked(entries[0].Key) {
+		for i := range entries {
+			op := entries[i]
+			switch {
+			case op.Type == batchpkg.OpDelete:
+				m.appendEntryTrustedOrderedLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+			case op.IsPtr:
+				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
+			default:
+				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+			}
+			if onKey != nil {
+				onKey(op.Key)
+			}
+		}
+		m.mu.Unlock()
+		return
+	}
+	for i := range entries {
+		op := entries[i]
+		switch {
+		case op.Type == batchpkg.OpDelete:
+			m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+		case op.IsPtr:
+			m.appendEntryLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
+		default:
+			m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+		}
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	m.mu.Unlock()
+}
+
+func (m *AppendOnly) applyStealBatchIndices(entries []batchpkg.Entry, idxs []int, onKey func(key []byte)) {
+	m.mu.Lock()
+	for _, idx := range idxs {
+		op := entries[idx]
+		switch {
+		case op.Type == batchpkg.OpDelete:
+			m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+		case op.IsPtr:
+			m.appendEntryLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
+		default:
+			m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+		}
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	m.mu.Unlock()
+}
+
+func (m *AppendOnly) applyStealBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, onKey func(key []byte)) {
+	m.mu.Lock()
+	if len(idxs) > 0 && m.canAppendTrustedOrderedBatchLocked(entries[idxs[0]].Key) {
+		for _, idx := range idxs {
+			op := entries[idx]
+			switch {
+			case op.Type == batchpkg.OpDelete:
+				m.appendEntryTrustedOrderedLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+			case op.IsPtr:
+				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
+			default:
+				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+			}
+			if onKey != nil {
+				onKey(op.Key)
+			}
+		}
+		m.mu.Unlock()
+		return
+	}
+	for _, idx := range idxs {
+		op := entries[idx]
+		switch {
+		case op.Type == batchpkg.OpDelete:
+			m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+		case op.IsPtr:
+			m.appendEntryLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
+		default:
+			m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+		}
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	m.mu.Unlock()
+}
+
+func (m *AppendOnly) applyBorrowValueBatch(entries []batchpkg.Entry, storeInlinePtrValues bool, onKey func(key []byte)) {
+	m.mu.Lock()
+	for i := range entries {
+		op := entries[i]
+		switch {
+		case op.Type == batchpkg.OpDelete:
+			m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, false, false)
+		case op.IsPtr:
+			memVal := []byte(nil)
+			if storeInlinePtrValues {
+				memVal = op.Value
+			}
+			m.appendEntryLocked(op.Key, memVal, op.ValuePtr, node.FlagPointer, false, len(memVal) > 0)
+		default:
+			m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, false, len(op.Value) > 0)
+		}
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	m.mu.Unlock()
+}
+
+func (m *AppendOnly) applyBorrowValueBatchTrusted(entries []batchpkg.Entry, storeInlinePtrValues bool, onKey func(key []byte)) {
+	m.mu.Lock()
+	if len(entries) > 0 && m.canAppendTrustedOrderedBatchLocked(entries[0].Key) {
+		for i := range entries {
+			op := entries[i]
+			switch {
+			case op.Type == batchpkg.OpDelete:
+				m.appendEntryTrustedOrderedLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, false, false)
+			case op.IsPtr:
+				memVal := []byte(nil)
+				if storeInlinePtrValues {
+					memVal = op.Value
+				}
+				m.appendEntryTrustedOrderedLocked(op.Key, memVal, op.ValuePtr, node.FlagPointer, false, len(memVal) > 0)
+			default:
+				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, false, len(op.Value) > 0)
+			}
+			if onKey != nil {
+				onKey(op.Key)
+			}
+		}
+		m.mu.Unlock()
+		return
+	}
+	for i := range entries {
+		op := entries[i]
+		switch {
+		case op.Type == batchpkg.OpDelete:
+			m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, false, false)
+		case op.IsPtr:
+			memVal := []byte(nil)
+			if storeInlinePtrValues {
+				memVal = op.Value
+			}
+			m.appendEntryLocked(op.Key, memVal, op.ValuePtr, node.FlagPointer, false, len(memVal) > 0)
+		default:
+			m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, false, len(op.Value) > 0)
+		}
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	m.mu.Unlock()
+}
+
+func (m *AppendOnly) applyBorrowValueBatchIndices(entries []batchpkg.Entry, idxs []int, storeInlinePtrValues bool, onKey func(key []byte)) {
+	m.mu.Lock()
+	for _, idx := range idxs {
+		op := entries[idx]
+		switch {
+		case op.Type == batchpkg.OpDelete:
+			m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, false, false)
+		case op.IsPtr:
+			memVal := []byte(nil)
+			if storeInlinePtrValues {
+				memVal = op.Value
+			}
+			m.appendEntryLocked(op.Key, memVal, op.ValuePtr, node.FlagPointer, false, len(memVal) > 0)
+		default:
+			m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, false, len(op.Value) > 0)
+		}
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	m.mu.Unlock()
+}
+
+func (m *AppendOnly) applyBorrowValueBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, storeInlinePtrValues bool, onKey func(key []byte)) {
+	m.mu.Lock()
+	if len(idxs) > 0 && m.canAppendTrustedOrderedBatchLocked(entries[idxs[0]].Key) {
+		for _, idx := range idxs {
+			op := entries[idx]
+			switch {
+			case op.Type == batchpkg.OpDelete:
+				m.appendEntryTrustedOrderedLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, false, false)
+			case op.IsPtr:
+				memVal := []byte(nil)
+				if storeInlinePtrValues {
+					memVal = op.Value
+				}
+				m.appendEntryTrustedOrderedLocked(op.Key, memVal, op.ValuePtr, node.FlagPointer, false, len(memVal) > 0)
+			default:
+				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, false, len(op.Value) > 0)
+			}
+			if onKey != nil {
+				onKey(op.Key)
+			}
+		}
+		m.mu.Unlock()
+		return
+	}
+	for _, idx := range idxs {
+		op := entries[idx]
+		switch {
+		case op.Type == batchpkg.OpDelete:
+			m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, false, false)
+		case op.IsPtr:
+			memVal := []byte(nil)
+			if storeInlinePtrValues {
+				memVal = op.Value
+			}
+			m.appendEntryLocked(op.Key, memVal, op.ValuePtr, node.FlagPointer, false, len(memVal) > 0)
+		default:
+			m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, false, len(op.Value) > 0)
 		}
 		if onKey != nil {
 			onKey(op.Key)
@@ -975,7 +1502,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 	for {
 		m.mu.RLock()
 		if ent := m.orderedLookupEntryLocked(key); ent != nil {
-			deleted := ent.flags&node.FlagTombstone != 0
+			deleted := appendOnlyEntryFlags(ent)&node.FlagTombstone != 0
 			val := m.appendOnlyEntryValue(ent)
 			m.mu.RUnlock()
 			if deleted {
@@ -993,7 +1520,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 				if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
-						deleted := ent.flags&node.FlagTombstone != 0
+						deleted := appendOnlyEntryFlags(ent)&node.FlagTombstone != 0
 						val := m.appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
 						if deleted {
@@ -1007,7 +1534,7 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 				if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
 					ent := &m.entries[idx]
 					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
-						deleted := ent.flags&node.FlagTombstone != 0
+						deleted := appendOnlyEntryFlags(ent)&node.FlagTombstone != 0
 						val := m.appendOnlyEntryValue(ent)
 						m.mu.RUnlock()
 						if deleted {
@@ -1037,7 +1564,7 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 		if ent := m.orderedLookupEntryLocked(key); ent != nil {
 			val := m.appendOnlyEntryValue(ent)
 			ptr := m.appendOnlyEntryPtr(ent)
-			flags := ent.flags &^ appendOnlyEntryFlagKeyInline
+			flags := appendOnlyEntryFlags(ent)
 			m.mu.RUnlock()
 			return val, ptr, flags, true
 		}
@@ -1053,7 +1580,7 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						val := m.appendOnlyEntryValue(ent)
 						ptr := m.appendOnlyEntryPtr(ent)
-						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
+						flags := appendOnlyEntryFlags(ent)
 						m.mu.RUnlock()
 						return val, ptr, flags, true
 					}
@@ -1065,7 +1592,7 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 					if bytes.Equal(m.appendOnlyEntryKey(ent), key) {
 						val := m.appendOnlyEntryValue(ent)
 						ptr := m.appendOnlyEntryPtr(ent)
-						flags := ent.flags &^ appendOnlyEntryFlagKeyInline
+						flags := appendOnlyEntryFlags(ent)
 						m.mu.RUnlock()
 						return val, ptr, flags, true
 					}
@@ -1198,6 +1725,8 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	m.growEntriesLen = growthEntries
 
 	oldCount := m.count
+	oldValueCount := len(m.values)
+	oldPtrPayloadCount := len(m.ptrPayloads)
 	maxRetainedEntries := appendOnlyMaxReuseEntries(growthEntries)
 	retainedEntries := desiredEntries
 	if retainObserved && oldCount > retainedEntries {
@@ -1207,16 +1736,14 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		}
 	}
 	for i := 0; i < m.count; i++ {
-		ent := &m.entries[i]
-		ent.flags = 0
-		ent.keyIndex = 0
-		ent.payloadIndex = 0
-		ent.inlineKeyLen = 0
+		m.entries[i] = appendOnlyEntry{}
 	}
 	clear(m.keys)
 	m.keys = m.keys[:0]
-	clear(m.payloads)
-	m.payloads = m.payloads[:0]
+	clear(m.values)
+	m.values = m.values[:0]
+	clear(m.ptrPayloads)
+	m.ptrPayloads = m.ptrPayloads[:0]
 	m.valueArena.reset()
 	if !retainObserved {
 		m.valueArena.dropRetained()
@@ -1261,18 +1788,46 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 	// still-bounded mutable memtable.
 	if cap(m.entries) > maxRetainedEntries {
 		m.replaceEntriesSlice(retainedEntries)
-		return
-	}
-	if cap(m.entries) < retainedEntries {
+	} else if cap(m.entries) < retainedEntries {
 		m.replaceEntriesSlice(retainedEntries)
+	} else {
+		reuseEntries := retainedEntries
+		if cap(m.entries) <= maxRetainedEntries && cap(m.entries) > reuseEntries {
+			reuseEntries = cap(m.entries)
+		}
+		if len(m.entries) != reuseEntries {
+			m.entries = m.entries[:reuseEntries]
+		}
+	}
+	maxRetainedValues := maxRetainedEntries
+	retainedValues := 0
+	if retainObserved && oldValueCount > 0 {
+		retainedValues = oldValueCount
+		if retainedValues > maxRetainedValues {
+			retainedValues = maxRetainedValues
+		}
+	}
+	if cap(m.values) > maxRetainedValues {
+		m.replaceValuesSlice(retainedValues)
+	} else if cap(m.values) < retainedValues {
+		m.replaceValuesSlice(retainedValues)
+	}
+
+	maxRetainedPtrPayloads := maxRetainedEntries
+	retainedPtrPayloads := 0
+	if retainObserved && oldPtrPayloadCount > 0 {
+		retainedPtrPayloads = oldPtrPayloadCount
+		if retainedPtrPayloads > maxRetainedPtrPayloads {
+			retainedPtrPayloads = maxRetainedPtrPayloads
+		}
+	}
+	if cap(m.ptrPayloads) > maxRetainedPtrPayloads {
+		m.replacePtrPayloadsSlice(retainedPtrPayloads)
 		return
 	}
-	reuseEntries := retainedEntries
-	if cap(m.entries) <= maxRetainedEntries && cap(m.entries) > reuseEntries {
-		reuseEntries = cap(m.entries)
-	}
-	if len(m.entries) != reuseEntries {
-		m.entries = m.entries[:reuseEntries]
+	if cap(m.ptrPayloads) < retainedPtrPayloads {
+		m.replacePtrPayloadsSlice(retainedPtrPayloads)
+		return
 	}
 }
 
@@ -1283,6 +1838,26 @@ func (m *AppendOnly) replaceEntriesSlice(length int) {
 	prev := m.entries
 	m.entries = getAppendOnlyEntries(length)
 	putAppendOnlyEntries(prev)
+}
+
+func (m *AppendOnly) replaceValuesSlice(length int) {
+	if length < 0 {
+		length = 0
+	}
+	prev := m.values
+	m.values = getAppendOnlyValues(length)
+	m.values = m.values[:0]
+	putAppendOnlyValues(prev)
+}
+
+func (m *AppendOnly) replacePtrPayloadsSlice(length int) {
+	if length < 0 {
+		length = 0
+	}
+	prev := m.ptrPayloads
+	m.ptrPayloads = getAppendOnlyPtrPayloads(length)
+	m.ptrPayloads = m.ptrPayloads[:0]
+	putAppendOnlyPtrPayloads(prev)
 }
 
 func (m *AppendOnly) buildSortedLatestSnapshotLocked() []*appendOnlyEntry {
@@ -1312,45 +1887,58 @@ func (m *AppendOnly) buildSortedLatestSnapshotLocked() []*appendOnlyEntry {
 	return snapshot
 }
 
-func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntry, []string, []appendOnlyPayload) {
+func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() ([]appendOnlyEntry, []string, []string, []appendOnlyPointerPayload) {
 	if m.count == 0 {
 		m.clearSnapshotLocked()
-		return getAppendOnlyIteratorEntries(0), getAppendOnlyIteratorKeys(0), getAppendOnlyIteratorPayloads(0)
+		return getAppendOnlyIteratorEntries(0), getAppendOnlyIteratorKeys(0), getAppendOnlyIteratorValues(0), getAppendOnlyIteratorPtrPayloads(0)
 	}
 	indices := m.buildSortedLatestIndicesLocked()
 	active := m.entries[:m.count]
 	entries := getAppendOnlyIteratorEntries(len(indices))
 	keyCount := 0
-	payloadCount := 0
+	valueCount := 0
+	ptrPayloadCount := 0
 	for _, idx := range indices {
-		if active[idx].keyIndex != 0 {
+		if active[idx].keyIndex&appendOnlyEntryKeyIndexMask != 0 {
 			keyCount++
 		}
-		if active[idx].payloadIndex != 0 {
-			payloadCount++
+		if active[idx].payloadIndex&appendOnlyEntryPayloadIdxMask != 0 {
+			if byte(active[idx].payloadIndex>>appendOnlyEntryFlagsShift)&node.FlagPointer != 0 {
+				ptrPayloadCount++
+			} else {
+				valueCount++
+			}
 		}
 	}
 	keys := getAppendOnlyIteratorKeys(keyCount)
-	payloads := getAppendOnlyIteratorPayloads(payloadCount)
+	values := getAppendOnlyIteratorValues(valueCount)
+	ptrPayloads := getAppendOnlyIteratorPtrPayloads(ptrPayloadCount)
 	nextKey := 0
-	nextPayload := 0
+	nextValue := 0
+	nextPtrPayload := 0
 	for i, idx := range indices {
 		ent := active[idx]
-		if ent.keyIndex != 0 {
-			keys[nextKey] = m.keys[ent.keyIndex-1]
-			ent.keyIndex = uint32(nextKey + 1)
+		if keyIndex := ent.keyIndex & appendOnlyEntryKeyIndexMask; keyIndex != 0 {
+			keys[nextKey] = m.keys[keyIndex-1]
+			appendOnlyEntrySetKeyIndex(&ent, uint32(nextKey+1))
 			nextKey++
 		}
-		if ent.payloadIndex != 0 {
-			payloads[nextPayload] = m.payloads[ent.payloadIndex-1]
-			ent.payloadIndex = uint32(nextPayload + 1)
-			nextPayload++
+		if payloadIndex := ent.payloadIndex & appendOnlyEntryPayloadIdxMask; payloadIndex != 0 {
+			if byte(ent.payloadIndex>>appendOnlyEntryFlagsShift)&node.FlagPointer != 0 {
+				ptrPayloads[nextPtrPayload] = m.ptrPayloads[payloadIndex-1]
+				appendOnlyEntrySetPayloadIndex(&ent, uint32(nextPtrPayload+1))
+				nextPtrPayload++
+			} else {
+				values[nextValue] = m.values[payloadIndex-1]
+				appendOnlyEntrySetPayloadIndex(&ent, uint32(nextValue+1))
+				nextValue++
+			}
 		}
 		entries[i] = ent
 	}
 	m.indexBuf = indices[:0]
 	m.clearSnapshotLocked()
-	return entries, keys, payloads
+	return entries, keys, values, ptrPayloads
 }
 
 func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
@@ -1394,13 +1982,14 @@ func (m *AppendOnly) NewIterator(start, end []byte) iterator.UnsafeIterator {
 		}
 		return it
 	}
-	entries, keys, payloads := m.buildMutableSortedIteratorEntriesLocked()
+	entries, keys, values, ptrPayloads := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
 		keys:          keys,
-		payloads:      payloads,
+		values:        values,
+		ptrPayloads:   ptrPayloads,
 		start:         start,
 		end:           end,
 		pooledEntries: true,
@@ -1450,13 +2039,14 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 		it.seekToReverseEnd(end)
 		return it
 	}
-	entries, keys, payloads := m.buildMutableSortedIteratorEntriesLocked()
+	entries, keys, values, ptrPayloads := m.buildMutableSortedIteratorEntriesLocked()
 	m.mu.Unlock()
 
 	it := &appendOnlyIterator{
 		entries:       entries,
 		keys:          keys,
-		payloads:      payloads,
+		values:        values,
+		ptrPayloads:   ptrPayloads,
 		start:         start,
 		end:           end,
 		pooledEntries: true,
@@ -1469,7 +2059,8 @@ func (m *AppendOnly) NewReverseIterator(start, end []byte) iterator.UnsafeIterat
 type appendOnlyIterator struct {
 	entries         []appendOnlyEntry
 	keys            []string
-	payloads        []appendOnlyPayload
+	values          []string
+	ptrPayloads     []appendOnlyPointerPayload
 	entryPtrs       []*appendOnlyEntry
 	idx             int
 	start           []byte
@@ -1504,20 +2095,6 @@ func (it *appendOnlyIterator) entryAt(idx int) *appendOnlyEntry {
 		return nil
 	}
 	return &it.entries[idx]
-}
-
-func (it *appendOnlyIterator) payloadForEntry(ent *appendOnlyEntry) *appendOnlyPayload {
-	if ent == nil || ent.payloadIndex == 0 {
-		return nil
-	}
-	if it.owner != nil {
-		return it.owner.appendOnlyPayload(ent)
-	}
-	idx := int(ent.payloadIndex - 1)
-	if idx < 0 || idx >= len(it.payloads) {
-		return nil
-	}
-	return &it.payloads[idx]
 }
 
 func (it *appendOnlyIterator) keyForEntry(ent *appendOnlyEntry) []byte {
@@ -1623,10 +2200,27 @@ func (it *appendOnlyIterator) UnsafeValue() []byte {
 	if ent == nil || !it.validIndex() {
 		return nil
 	}
-	if ent.flags&node.FlagTombstone != 0 {
+	flags := byte(ent.payloadIndex >> appendOnlyEntryFlagsShift)
+	if flags&node.FlagTombstone != 0 {
 		return nil
 	}
-	return appendOnlyPayloadValue(it.payloadForEntry(ent))
+	if it.owner != nil {
+		return it.owner.appendOnlyEntryValue(ent)
+	}
+	idx := int((ent.payloadIndex & appendOnlyEntryPayloadIdxMask) - 1)
+	if idx < 0 {
+		return nil
+	}
+	if flags&node.FlagPointer != 0 {
+		if idx >= len(it.ptrPayloads) {
+			return nil
+		}
+		return appendOnlyValueStringBytes(it.ptrPayloads[idx].value)
+	}
+	if idx >= len(it.values) {
+		return nil
+	}
+	return appendOnlyValueStringBytes(it.values[idx])
 }
 
 func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
@@ -1634,12 +2228,25 @@ func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	if ent == nil || !it.validIndex() {
 		return nil, page.ValuePtr{}, 0
 	}
-	payload := it.payloadForEntry(ent)
-	ptr := page.ValuePtr{}
-	if payload != nil {
-		ptr = payload.ptr
+	if it.owner != nil {
+		return it.owner.appendOnlyEntryValue(ent), it.owner.appendOnlyEntryPtr(ent), appendOnlyEntryFlags(ent)
 	}
-	return appendOnlyPayloadValue(payload), ptr, ent.flags &^ appendOnlyEntryFlagKeyInline
+	flags := byte(ent.payloadIndex >> appendOnlyEntryFlagsShift)
+	idx := int((ent.payloadIndex & appendOnlyEntryPayloadIdxMask) - 1)
+	if idx < 0 {
+		return nil, page.ValuePtr{}, flags
+	}
+	if flags&node.FlagPointer != 0 {
+		if idx >= len(it.ptrPayloads) {
+			return nil, page.ValuePtr{}, flags
+		}
+		payload := it.ptrPayloads[idx]
+		return appendOnlyValueStringBytes(payload.value), payload.ptr, flags
+	}
+	if idx >= len(it.values) {
+		return nil, page.ValuePtr{}, flags
+	}
+	return appendOnlyValueStringBytes(it.values[idx]), page.ValuePtr{}, flags
 }
 
 func (it *appendOnlyIterator) IsDeleted() bool {
@@ -1647,7 +2254,7 @@ func (it *appendOnlyIterator) IsDeleted() bool {
 	if ent == nil || !it.validIndex() {
 		return false
 	}
-	return ent.flags&node.FlagTombstone != 0
+	return byte(ent.payloadIndex>>appendOnlyEntryFlagsShift)&node.FlagTombstone != 0
 }
 
 func (it *appendOnlyIterator) Key() []byte {
@@ -1684,7 +2291,8 @@ func (it *appendOnlyIterator) Close() error {
 	if it.pooledEntries {
 		putAppendOnlyIteratorEntries(it.entries)
 		putAppendOnlyIteratorKeys(it.keys)
-		putAppendOnlyIteratorPayloads(it.payloads)
+		putAppendOnlyIteratorValues(it.values)
+		putAppendOnlyIteratorPtrPayloads(it.ptrPayloads)
 		it.pooledEntries = false
 	}
 	if it.pooledEntryPtrs {
@@ -1699,7 +2307,8 @@ func (it *appendOnlyIterator) Close() error {
 	it.owner = nil
 	it.entries = nil
 	it.keys = nil
-	it.payloads = nil
+	it.values = nil
+	it.ptrPayloads = nil
 	it.entryPtrs = nil
 	return nil
 }

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -72,8 +72,8 @@ const (
 	appendOnlyEntryInlineLenShift = 28
 	appendOnlyEntryInlineLenMask  = uint32(0xF) << appendOnlyEntryInlineLenShift
 	appendOnlyEntryKeyIndexMask   = ^appendOnlyEntryInlineLenMask
-	appendOnlyEntryFlagsShift     = 30
-	appendOnlyEntryFlagsMask      = uint32(0x3) << appendOnlyEntryFlagsShift
+	appendOnlyEntryFlagsShift     = 24
+	appendOnlyEntryFlagsMask      = uint32(0xFF) << appendOnlyEntryFlagsShift
 	appendOnlyEntryPayloadIdxMask = ^appendOnlyEntryFlagsMask
 )
 
@@ -121,7 +121,7 @@ func appendOnlyEntrySetFlags(ent *appendOnlyEntry, flags byte) {
 		return
 	}
 	ent.payloadIndex = (ent.payloadIndex & appendOnlyEntryPayloadIdxMask) |
-		(uint32(flags&0x3) << appendOnlyEntryFlagsShift)
+		(uint32(flags) << appendOnlyEntryFlagsShift)
 }
 
 func appendOnlyEntryPayloadIndex(ent *appendOnlyEntry) uint32 {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -2487,6 +2487,18 @@ func (it *appendOnlyIterator) UnsafeKey() []byte {
 	return it.stableKeyForEntry(it.idx, ent)
 }
 
+func (it *appendOnlyIterator) UnsafeStableKey() []byte {
+	ent := it.entryAt(it.idx)
+	if ent == nil || !it.validIndex() {
+		return nil
+	}
+	key := it.keyForEntry(ent)
+	if len(key) == 0 {
+		return appendOnlyEmptyKey
+	}
+	return key
+}
+
 func (it *appendOnlyIterator) UnsafeValue() []byte {
 	ent := it.entryAt(it.idx)
 	if ent == nil || !it.validIndex() {

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -265,9 +265,17 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 }
 
 func TestAppendOnlyIteratorCloseClearsPooledPointerEntries(t *testing.T) {
+	entry0 := &appendOnlyEntry{}
+	appendOnlyEntrySetKeyIndex(entry0, 1)
+	appendOnlyEntrySetPayloadIndex(entry0, 1)
+	appendOnlyEntrySetFlags(entry0, node.FlagPointer)
+	entry1 := &appendOnlyEntry{}
+	appendOnlyEntrySetKeyIndex(entry1, 2)
+	appendOnlyEntrySetPayloadIndex(entry1, 2)
+	appendOnlyEntrySetFlags(entry1, node.FlagTombstone)
 	entries := []*appendOnlyEntry{
-		{},
-		{},
+		entry0,
+		entry1,
 	}
 	it := &appendOnlyIterator{
 		entryPtrs:       entries,

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -12,15 +12,15 @@ import (
 
 func TestPutAppendOnlyEntriesClearsReferences(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
-	entries[0].keyIndex = 1
-	entries[0].payloadIndex = 1
-	entries[1].keyIndex = 2
-	entries[1].payloadIndex = 2
+	appendOnlyEntrySetKeyIndex(&entries[0], 1)
+	appendOnlyEntrySetPayloadIndex(&entries[0], 1)
+	appendOnlyEntrySetKeyIndex(&entries[1], 2)
+	appendOnlyEntrySetPayloadIndex(&entries[1], 2)
 
 	putAppendOnlyEntries(entries)
 
 	for i := range entries {
-		if entries[i].keyIndex != 0 || entries[i].payloadIndex != 0 {
+		if appendOnlyEntryKeyIndex(&entries[i]) != 0 || appendOnlyEntryPayloadIndex(&entries[i]) != 0 {
 			t.Fatalf("entry %d still retains references after put: %+v", i, entries[i])
 		}
 	}
@@ -41,40 +41,60 @@ func TestPutAppendOnlyKeysClearsReferences(t *testing.T) {
 	}
 }
 
-func TestPutAppendOnlyPayloadsClearsReferences(t *testing.T) {
-	payloads := make([]appendOnlyPayload, 2)
+func TestPutAppendOnlyValuesClearsReferences(t *testing.T) {
+	values := []string{
+		appendOnlyStringFromBytes([]byte("v0")),
+		appendOnlyStringFromBytes([]byte("v1")),
+	}
+
+	putAppendOnlyValues(values)
+
+	for i := range values {
+		if values[i] != "" {
+			t.Fatalf("value %d still retains references after put: %q", i, values[i])
+		}
+	}
+}
+
+func TestPutAppendOnlyPtrPayloadsClearsReferences(t *testing.T) {
+	payloads := make([]appendOnlyPointerPayload, 2)
 	payloads[0].value = appendOnlyStringFromBytes([]byte("v0"))
 	payloads[0].ptr = page.ValuePtr{Offset: 1, Length: 2, FileID: 3}
 	payloads[1].value = appendOnlyStringFromBytes([]byte("v1"))
 	payloads[1].ptr = page.ValuePtr{Offset: 4, Length: 5, FileID: 6}
 
-	putAppendOnlyPayloads(payloads)
+	putAppendOnlyPtrPayloads(payloads)
 
 	for i := range payloads {
 		if payloads[i].value != "" || payloads[i].ptr != (page.ValuePtr{}) {
-			t.Fatalf("payload %d still retains references after put: %+v", i, payloads[i])
+			t.Fatalf("ptr payload %d still retains references after put: %+v", i, payloads[i])
 		}
 	}
 }
 
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
-	entries[0].keyIndex = 1
-	entries[0].payloadIndex = 1
-	entries[1].keyIndex = 2
-	entries[1].payloadIndex = 2
+	appendOnlyEntrySetKeyIndex(&entries[0], 1)
+	appendOnlyEntrySetPayloadIndex(&entries[0], 1)
+	appendOnlyEntrySetKeyIndex(&entries[1], 2)
+	appendOnlyEntrySetPayloadIndex(&entries[1], 2)
 	keys := []string{
 		appendOnlyStringFromBytes([]byte("k0")),
 		appendOnlyStringFromBytes([]byte("k1")),
 	}
-	payloads := make([]appendOnlyPayload, 2)
-	payloads[0].value = appendOnlyStringFromBytes([]byte("v0"))
-	payloads[1].value = appendOnlyStringFromBytes([]byte("v1"))
+	values := []string{
+		appendOnlyStringFromBytes([]byte("v0")),
+		appendOnlyStringFromBytes([]byte("v1")),
+	}
+	ptrPayloads := []appendOnlyPointerPayload{
+		{value: appendOnlyStringFromBytes([]byte("pv0")), ptr: page.ValuePtr{Offset: 7, Length: 8, FileID: 9}},
+	}
 
 	it := &appendOnlyIterator{
 		entries:       entries,
 		keys:          keys,
-		payloads:      payloads,
+		values:        values,
+		ptrPayloads:   ptrPayloads,
 		pooledEntries: true,
 	}
 	if err := it.Close(); err != nil {
@@ -82,7 +102,7 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	}
 
 	for i := range entries {
-		if entries[i].keyIndex != 0 || entries[i].payloadIndex != 0 {
+		if appendOnlyEntryKeyIndex(&entries[i]) != 0 || appendOnlyEntryPayloadIndex(&entries[i]) != 0 {
 			t.Fatalf("entry %d still retains references after close: %+v", i, entries[i])
 		}
 	}
@@ -91,9 +111,14 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 			t.Fatalf("key %d still retains references after close: %q", i, keys[i])
 		}
 	}
-	for i := range payloads {
-		if payloads[i].value != "" || payloads[i].ptr != (page.ValuePtr{}) {
-			t.Fatalf("payload %d still retains references after close: %+v", i, payloads[i])
+	for i := range values {
+		if values[i] != "" {
+			t.Fatalf("value %d still retains references after close: %q", i, values[i])
+		}
+	}
+	for i := range ptrPayloads {
+		if ptrPayloads[i].value != "" || ptrPayloads[i].ptr != (page.ValuePtr{}) {
+			t.Fatalf("ptr payload %d still retains references after close: %+v", i, ptrPayloads[i])
 		}
 	}
 	if it.entries != nil {
@@ -102,8 +127,11 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	if it.keys != nil {
 		t.Fatalf("iterator keys not cleared on close")
 	}
-	if it.payloads != nil {
-		t.Fatalf("iterator payloads not cleared on close")
+	if it.values != nil {
+		t.Fatalf("iterator values not cleared on close")
+	}
+	if it.ptrPayloads != nil {
+		t.Fatalf("iterator ptr payloads not cleared on close")
 	}
 	if it.pooledEntries {
 		t.Fatalf("pooledEntries flag not cleared on close")
@@ -112,8 +140,8 @@ func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 
 func TestAppendOnlyIteratorCloseClearsPooledPointerEntries(t *testing.T) {
 	entries := []*appendOnlyEntry{
-		{flags: appendOnlyEntryFlagKeyInline},
-		{flags: appendOnlyEntryFlagKeyInline},
+		{},
+		{},
 	}
 	it := &appendOnlyIterator{
 		entryPtrs:       entries,
@@ -245,8 +273,8 @@ func TestAppendOnlyFrozenUnorderedIteratorBlocksResetUntilClose(t *testing.T) {
 }
 
 func TestAppendOnlyEntryStructSizeBound(t *testing.T) {
-	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 20 {
-		t.Fatalf("appendOnlyEntry size=%d want <= 20", got)
+	if got := unsafe.Sizeof(appendOnlyEntry{}); got > 16 {
+		t.Fatalf("appendOnlyEntry size=%d want <= 16", got)
 	}
 }
 
@@ -287,14 +315,14 @@ func TestAppendOnlySetInlinesShortKey(t *testing.T) {
 		t.Fatalf("count=%d want=1", m.count)
 	}
 	ent := &m.entries[0]
-	if ent.flags&appendOnlyEntryFlagKeyInline == 0 {
+	if appendOnlyEntryInlineKeyLen(ent) == 0 {
 		t.Fatalf("expected short key to be stored inline")
 	}
-	if ent.inlineKeyLen != uint8(len(lookupKey)) {
-		t.Fatalf("inline key len=%d want=%d", ent.inlineKeyLen, len(lookupKey))
+	if got := appendOnlyEntryInlineKeyLen(ent); got != len(lookupKey) {
+		t.Fatalf("inline key len=%d want=%d", got, len(lookupKey))
 	}
-	if ent.keyIndex != 0 {
-		t.Fatalf("short inline key should not allocate a key slot; keyIndex=%d", ent.keyIndex)
+	if got := appendOnlyEntryKeyIndex(ent); got != 0 {
+		t.Fatalf("short inline key should not allocate a key slot; keyIndex=%d", got)
 	}
 	storedKey := m.appendOnlyEntryKey(ent)
 	if string(storedKey) != string(lookupKey) {
@@ -439,15 +467,43 @@ func TestAppendOnlyResetRetainedArenaBounded(t *testing.T) {
 	}
 }
 
-func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
+func TestAppendOnlyValueArenaChunksGrowBounded(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	key := []byte("k")
+	val := make([]byte, 2048)
+	for i := 0; i < 128; i++ {
+		key[0] = byte('a' + byte(i%26))
+		val[0] = byte(i)
+		m.Set(key, val)
+	}
+	if len(m.valueArena.chunks) < 2 {
+		t.Fatalf("expected multiple arena chunks, got=%d", len(m.valueArena.chunks))
+	}
+	prevCap := 0
+	for i, chunk := range m.valueArena.chunks {
+		c := cap(chunk)
+		if c < appendOnlyValueArenaDefaultChunk {
+			t.Fatalf("chunk %d cap=%d want >= %d", i, c, appendOnlyValueArenaDefaultChunk)
+		}
+		if c > appendOnlyValueArenaGrowthMaxChunk {
+			t.Fatalf("chunk %d cap=%d want <= %d", i, c, appendOnlyValueArenaGrowthMaxChunk)
+		}
+		if prevCap > c {
+			t.Fatalf("chunk %d cap=%d regressed from %d", i, c, prevCap)
+		}
+		prevCap = c
+	}
+}
+
+func TestAppendOnlyUnorderedAppendBuildsLatestIndexLazily(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	m.Set([]byte("b"), []byte("v1"))
 	m.Set([]byte("a"), []byte("v2")) // force unordered path
 	if m.ordered {
 		t.Fatalf("expected unordered memtable")
 	}
-	if m.latestDirty {
-		t.Fatalf("expected latest index to stay clean after order break")
+	if !m.latestDirty {
+		t.Fatalf("expected latest index to be dirty after order break")
 	}
 
 	it := m.NewIterator(nil, nil)
@@ -466,7 +522,7 @@ func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
 
 	m.Set([]byte("b"), []byte("v3"))
 	if m.latestDirty {
-		t.Fatalf("expected unordered append to keep latest index clean")
+		t.Fatalf("expected unordered append to keep latest index clean after iterator rebuild")
 	}
 	if m.snapCount != 0 {
 		t.Fatalf("expected snapshot invalidation after append; got snapCount=%d", m.snapCount)
@@ -506,8 +562,8 @@ func TestAppendOnlyUnorderedReverseIteratorDoesNotCacheSharedSnapshot(t *testing
 	if m.ordered {
 		t.Fatalf("expected unordered memtable")
 	}
-	if m.latestDirty {
-		t.Fatalf("expected latest index to stay clean after order break")
+	if !m.latestDirty {
+		t.Fatalf("expected latest index to be dirty after order break")
 	}
 
 	it := m.NewReverseIterator(nil, nil)
@@ -526,7 +582,7 @@ func TestAppendOnlyUnorderedReverseIteratorDoesNotCacheSharedSnapshot(t *testing
 
 	m.Set([]byte("b"), []byte("v3"))
 	if m.latestDirty {
-		t.Fatalf("expected unordered append to keep latest index clean")
+		t.Fatalf("expected unordered append to keep latest index clean after reverse iterator rebuild")
 	}
 	if m.snapCount != 0 {
 		t.Fatalf("expected snapshot invalidation after append; got snapCount=%d", m.snapCount)

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -35,6 +35,24 @@ func TestAppendOnlyNextCapacityGrowthPolicy(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyEntryPayloadIndexAllowsLargeSideBuffers(t *testing.T) {
+	var ent appendOnlyEntry
+	const payloadIndex = uint32(1<<31 | 12345)
+	const flags = node.FlagPointer | byte(0x40)
+
+	appendOnlyEntrySetPayloadIndex(&ent, payloadIndex)
+	copy(ent.inlineKey[:], []byte("long-key"))
+	appendOnlyEntrySetKeyIndex(&ent, 1)
+	appendOnlyEntrySetFlags(&ent, flags)
+
+	if got := appendOnlyEntryPayloadIndex(&ent); got != payloadIndex {
+		t.Fatalf("payload index=%d want=%d", got, payloadIndex)
+	}
+	if got := appendOnlyEntryFlags(&ent); got != flags {
+		t.Fatalf("flags=%d want=%d", got, flags)
+	}
+}
+
 func TestAppendOnlyInlineGrowthSkipsIntermediateDoublingBelowCutoff(t *testing.T) {
 	mt := &AppendOnly{
 		entries:        make([]appendOnlyEntry, appendOnlyMinInitialEntries),

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -346,6 +346,60 @@ func TestAppendOnlyIteratorSortedLatest(t *testing.T) {
 	}
 }
 
+func TestAppendOnlySetEntryPreservesExtraFlagBits(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	ptr := page.ValuePtr{Offset: 7, Length: 11, FileID: 3}
+	const extra = byte(0x40)
+
+	m.SetEntry([]byte("b-ptr"), []byte("tail"), ptr, node.FlagPointer|extra)
+	m.SetEntrySteal([]byte("a-del"), nil, page.ValuePtr{}, node.FlagTombstone|extra)
+
+	_, gotPtr, flags, ok := m.GetEntry([]byte("b-ptr"))
+	if !ok {
+		t.Fatalf("GetEntry(ptr) missing")
+	}
+	if gotPtr != ptr {
+		t.Fatalf("ptr=%+v want=%+v", gotPtr, ptr)
+	}
+	if flags != node.FlagPointer|extra {
+		t.Fatalf("ptr flags=%#x want=%#x", flags, node.FlagPointer|extra)
+	}
+
+	_, _, flags, ok = m.GetEntry([]byte("a-del"))
+	if !ok {
+		t.Fatalf("GetEntry(del) missing")
+	}
+	if flags != node.FlagTombstone|extra {
+		t.Fatalf("del flags=%#x want=%#x", flags, node.FlagTombstone|extra)
+	}
+
+	it := m.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	seen := 0
+	for ; it.Valid(); it.Next() {
+		key := string(it.UnsafeKey())
+		_, gotPtr, gotFlags := it.UnsafeEntry()
+		switch key {
+		case "a-del":
+			if gotFlags != node.FlagTombstone|extra {
+				t.Fatalf("iterator del flags=%#x want=%#x", gotFlags, node.FlagTombstone|extra)
+			}
+			seen++
+		case "b-ptr":
+			if gotPtr != ptr {
+				t.Fatalf("iterator ptr=%+v want=%+v", gotPtr, ptr)
+			}
+			if gotFlags != node.FlagPointer|extra {
+				t.Fatalf("iterator ptr flags=%#x want=%#x", gotFlags, node.FlagPointer|extra)
+			}
+			seen++
+		}
+	}
+	if seen != 2 {
+		t.Fatalf("iterator saw %d flagged entries, want 2", seen)
+	}
+}
+
 func TestAppendOnlyResetClearsLatestIndex(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	m.Set([]byte("k1"), []byte("v1"))

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -752,6 +752,57 @@ func TestAppendOnlyGet_EmptyKey_IncrementalLatestIndex(t *testing.T) {
 	if got, ptr, flags, ok := m.GetEntry([]byte{}); !ok || string(got) != "empty" || ptr != (page.ValuePtr{}) || flags != node.FlagInline {
 		t.Fatalf("GetEntry(empty key) = (%q,%+v,%d,%v), want (empty,zero,%d,true)", string(got), ptr, flags, ok, node.FlagInline)
 	}
+
+	m.Delete([]byte{})
+	if got, del, ok := m.Get([]byte{}); !ok || !del || got != nil {
+		t.Fatalf("Get(empty key after delete) = (%v,%v,%v), want (nil,true,true)", got, del, ok)
+	}
+	if got, ptr, flags, ok := m.GetEntry([]byte{}); !ok || got != nil || ptr != (page.ValuePtr{}) || flags != node.FlagTombstone {
+		t.Fatalf("GetEntry(empty key after delete) = (%v,%+v,%d,%v), want (nil,zero,%d,true)", got, ptr, flags, ok, node.FlagTombstone)
+	}
+	m.mu.RLock()
+	ent := &m.entries[m.count-1]
+	inlineLen := appendOnlyEntryInlineKeyLen(ent)
+	keyIndex := appendOnlyEntryKeyIndex(ent)
+	encodedKey := m.appendOnlyEntryKey(ent)
+	m.mu.RUnlock()
+	if inlineLen != 0 || keyIndex == 0 {
+		t.Fatalf("empty key entry encoding inlineLen=%d keyIndex=%d, want side-key encoding", inlineLen, keyIndex)
+	}
+	if encodedKey == nil || len(encodedKey) != 0 {
+		t.Fatalf("encoded empty key = %v len=%d, want non-nil empty key", encodedKey, len(encodedKey))
+	}
+}
+
+func TestAppendOnlyApplyBorrowValueSortedBatchTrusted_EmptyKeyPointer(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	ptr := page.ValuePtr{Offset: 7, Length: 11, FileID: 3}
+
+	m.ApplyBorrowValueSortedBatchTrusted([]batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: []byte{}, Value: []byte("empty-ptr"), IsPtr: true, ValuePtr: ptr},
+		{Type: batchpkg.OpPut, Key: []byte("a"), Value: []byte("a")},
+	}, true, nil)
+
+	if !m.ordered {
+		t.Fatal("expected empty-key trusted batch to stay ordered")
+	}
+	got, gotPtr, flags, ok := m.GetEntry([]byte{})
+	if !ok || string(got) != "empty-ptr" || gotPtr != ptr || flags != node.FlagPointer {
+		t.Fatalf("GetEntry(empty key pointer) = (%q,%+v,%d,%v), want (empty-ptr,%+v,%d,true)", string(got), gotPtr, flags, ok, ptr, node.FlagPointer)
+	}
+
+	it := m.NewIterator(nil, nil)
+	defer it.Close()
+	if !it.Valid() {
+		t.Fatal("expected iterator to start at empty key")
+	}
+	if gotKey := it.UnsafeKey(); gotKey == nil || len(gotKey) != 0 {
+		t.Fatalf("iterator empty key = %v len=%d, want non-nil empty key", gotKey, len(gotKey))
+	}
+	got, gotPtr, flags = it.UnsafeEntry()
+	if string(got) != "empty-ptr" || gotPtr != ptr || flags != node.FlagPointer {
+		t.Fatalf("iterator empty entry = (%q,%+v,%d), want (empty-ptr,%+v,%d)", string(got), gotPtr, flags, ptr, node.FlagPointer)
+	}
 }
 
 func TestAppendOnlyLatestIndexShortInlineKeysSurviveEntryGrowth(t *testing.T) {

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/binary"
 	"testing"
 	"time"
+	"unsafe"
 
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -107,6 +109,206 @@ func TestAppendOnlyCRUD(t *testing.T) {
 	val, del, ok = m.Get([]byte("k2"))
 	if !ok || !del || val != nil {
 		t.Fatalf("Get(k2) = (%v,%v,%v), want (nil,true,true)", val, del, ok)
+	}
+}
+
+func TestAppendOnlyApplyBorrowValueSortedBatch_CopiesKeysBorrowsValues(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	key := []byte("k-short")
+	value := []byte("borrowed-value")
+
+	m.ApplyBorrowValueSortedBatch([]batchpkg.Entry{{
+		Type:  batchpkg.OpPut,
+		Key:   key,
+		Value: value,
+	}}, false, nil)
+
+	if m.count != 1 {
+		t.Fatalf("count=%d want=1", m.count)
+	}
+	ent := &m.entries[0]
+	got := m.appendOnlyEntryValue(ent)
+	if len(got) != len(value) {
+		t.Fatalf("value len=%d want=%d", len(got), len(value))
+	}
+	if unsafe.SliceData(got) != unsafe.SliceData(value) {
+		t.Fatal("expected borrowed value storage to alias caller slice")
+	}
+	if len(m.valueArena.chunks) != 0 {
+		t.Fatalf("valueArena chunks=%d want=0 for inline borrowed value", len(m.valueArena.chunks))
+	}
+
+	key[0] = 'z'
+	if gotKey := string(m.appendOnlyEntryKey(ent)); gotKey != "k-short" {
+		t.Fatalf("stored key changed after caller mutation: got=%q want=%q", gotKey, "k-short")
+	}
+	gotValue, deleted, ok := m.Get([]byte("k-short"))
+	if !ok || deleted || string(gotValue) != "borrowed-value" {
+		t.Fatalf("Get(k-short)=(%q,%v,%v) want=(borrowed-value,false,true)", string(gotValue), deleted, ok)
+	}
+}
+
+func TestAppendOnlyApplyBorrowValueSortedBatchTrusted_PreservesOrderedFastPath(t *testing.T) {
+	m := NewAppendOnlyWithCapacityEstimatedEntryBytes(appendOnlyMinInitialEntries*appendOnlyEstimatedBytesPerEntryPointer, appendOnlyEstimatedBytesPerEntryPointer)
+	entries := make([]batchpkg.Entry, appendOnlyMinInitialEntries*4)
+	value := []byte("borrowed-value")
+	callbacks := 0
+	for i := range entries {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(i+1))
+		entries[i] = batchpkg.Entry{Type: batchpkg.OpPut, Key: append([]byte(nil), key[:]...), Value: value}
+	}
+
+	m.ApplyBorrowValueSortedBatchTrusted(entries, false, func(key []byte) {
+		callbacks++
+	})
+
+	if callbacks != len(entries) {
+		t.Fatalf("callbacks=%d want=%d", callbacks, len(entries))
+	}
+	if !m.ordered {
+		t.Fatal("expected ordered append-only memtable after trusted sorted batch")
+	}
+	if !m.hasLast || m.lastIdx != len(entries)-1 {
+		t.Fatalf("last state hasLast=%v lastIdx=%d want lastIdx=%d", m.hasLast, m.lastIdx, len(entries)-1)
+	}
+	if m.count != len(entries) {
+		t.Fatalf("count=%d want=%d", m.count, len(entries))
+	}
+	if m.latest != nil || m.latest64 != nil {
+		t.Fatalf("trusted ordered batch should not materialize latest maps: latest=%v latest64=%v", m.latest != nil, m.latest64 != nil)
+	}
+
+	lastKey := entries[len(entries)-1].Key
+	got, deleted, ok := m.Get(lastKey)
+	if !ok || deleted || string(got) != string(value) {
+		t.Fatalf("Get(last)=(%q,%v,%v) want=(%q,false,true)", string(got), deleted, ok, string(value))
+	}
+}
+
+func TestAppendOnlyApplyBorrowValueSortedBatchIndicesTrusted_PreservesOrderedFastPath(t *testing.T) {
+	m := NewAppendOnlyWithCapacityEstimatedEntryBytes(appendOnlyMinInitialEntries*appendOnlyEstimatedBytesPerEntryPointer, appendOnlyEstimatedBytesPerEntryPointer)
+	entries := make([]batchpkg.Entry, appendOnlyMinInitialEntries*4)
+	value := []byte("borrowed-value")
+	idxs := make([]int, 0, len(entries)/2)
+	callbacks := 0
+	lastSelected := -1
+	for i := range entries {
+		var key [8]byte
+		binary.BigEndian.PutUint64(key[:], uint64(i+1))
+		entries[i] = batchpkg.Entry{Type: batchpkg.OpPut, Key: append([]byte(nil), key[:]...), Value: value}
+		if i%2 == 0 {
+			idxs = append(idxs, i)
+			lastSelected = i
+		}
+	}
+
+	m.ApplyBorrowValueSortedBatchIndicesTrusted(entries, idxs, false, func(key []byte) {
+		callbacks++
+	})
+
+	if callbacks != len(idxs) {
+		t.Fatalf("callbacks=%d want=%d", callbacks, len(idxs))
+	}
+	if !m.ordered {
+		t.Fatal("expected ordered append-only memtable after trusted sorted batch indices")
+	}
+	if !m.hasLast || m.lastIdx != len(idxs)-1 {
+		t.Fatalf("last state hasLast=%v lastIdx=%d want lastIdx=%d", m.hasLast, m.lastIdx, len(idxs)-1)
+	}
+	if m.count != len(idxs) {
+		t.Fatalf("count=%d want=%d", m.count, len(idxs))
+	}
+	lastKey := entries[lastSelected].Key
+	got, deleted, ok := m.Get(lastKey)
+	if !ok || deleted || string(got) != string(value) {
+		t.Fatalf("Get(lastSelected)=(%q,%v,%v) want=(%q,false,true)", string(got), deleted, ok, string(value))
+	}
+}
+
+func TestAppendOnlyApplyBorrowValueSortedBatchTrusted_FallsBackWhenBatchStartsBeforeLastKey(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	var highKey [8]byte
+	binary.BigEndian.PutUint64(highKey[:], 10)
+	m.Set(highKey[:], []byte("ten"))
+
+	var keyOne [8]byte
+	var keyTwo [8]byte
+	binary.BigEndian.PutUint64(keyOne[:], 1)
+	binary.BigEndian.PutUint64(keyTwo[:], 2)
+	m.ApplyBorrowValueSortedBatchTrusted([]batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: keyOne[:], Value: []byte("one")},
+		{Type: batchpkg.OpPut, Key: keyTwo[:], Value: []byte("two")},
+	}, false, nil)
+
+	if m.ordered {
+		t.Fatal("expected fallback trusted batch to mark memtable unordered")
+	}
+	if !m.latestDirty {
+		t.Fatal("expected unordered fallback to defer latest index materialization")
+	}
+	if m.latest != nil || m.latest64 != nil {
+		t.Fatal("expected unordered fallback to keep latest index unmaterialized before read")
+	}
+
+	if got, deleted, ok := m.Get(keyOne[:]); !ok || deleted || string(got) != "one" {
+		t.Fatalf("Get(keyOne)=(%q,%v,%v) want=(one,false,true)", string(got), deleted, ok)
+	}
+	if m.latestDirty {
+		t.Fatal("expected first point read to materialize latest index")
+	}
+	if got, deleted, ok := m.Get(highKey[:]); !ok || deleted || string(got) != "ten" {
+		t.Fatalf("Get(highKey)=(%q,%v,%v) want=(ten,false,true)", string(got), deleted, ok)
+	}
+}
+
+func TestAppendOnlyApplyBorrowValueSortedBatchIndicesTrusted_FallsBackWhenBatchStartsBeforeLastKey(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	var highKey [8]byte
+	binary.BigEndian.PutUint64(highKey[:], 10)
+	m.Set(highKey[:], []byte("ten"))
+
+	entries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: func() []byte { var k [8]byte; binary.BigEndian.PutUint64(k[:], 1); return append([]byte(nil), k[:]...) }(), Value: []byte("one")},
+		{Type: batchpkg.OpPut, Key: func() []byte { var k [8]byte; binary.BigEndian.PutUint64(k[:], 2); return append([]byte(nil), k[:]...) }(), Value: []byte("two")},
+	}
+	m.ApplyBorrowValueSortedBatchIndicesTrusted(entries, []int{0, 1}, false, nil)
+
+	if m.ordered {
+		t.Fatal("expected fallback trusted batch indices to mark memtable unordered")
+	}
+	if !m.latestDirty {
+		t.Fatal("expected unordered fallback to defer latest index materialization")
+	}
+	if m.latest != nil || m.latest64 != nil {
+		t.Fatal("expected unordered fallback to keep latest index unmaterialized before read")
+	}
+
+	if got, deleted, ok := m.Get(entries[0].Key); !ok || deleted || string(got) != "one" {
+		t.Fatalf("Get(entries[0])=(%q,%v,%v) want=(one,false,true)", string(got), deleted, ok)
+	}
+	if m.latestDirty {
+		t.Fatal("expected first point read to materialize latest index")
+	}
+	if got, deleted, ok := m.Get(highKey[:]); !ok || deleted || string(got) != "ten" {
+		t.Fatalf("Get(highKey)=(%q,%v,%v) want=(ten,false,true)", string(got), deleted, ok)
+	}
+}
+
+func TestAppendOnlyFirstPayloadUsesDenseEntryCapacityFloor(t *testing.T) {
+	m := &AppendOnly{
+		entries: make([]appendOnlyEntry, 1024),
+		ordered: true,
+		lastIdx: -1,
+	}
+
+	m.Set([]byte("k-short"), []byte("value"))
+
+	if got := cap(m.values); got != cap(m.entries) {
+		t.Fatalf("value cap=%d want entry cap=%d", got, cap(m.entries))
+	}
+	if got := len(m.values); got != 1 {
+		t.Fatalf("value len=%d want=1", got)
 	}
 }
 
@@ -361,22 +563,22 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 			if ordered {
 				t.Fatalf("expected memtable to become unordered")
 			}
-			if dirty {
-				t.Fatalf("expected latest index to stay clean after order break")
+			if !dirty {
+				t.Fatalf("expected latest index to be dirty after order break")
 			}
 			m.mu.RLock()
 			latestSizeBeforeGet := kk.latestSize(m)
-			idxBeforeGet, okBeforeGet := kk.latestIdx(m, lo)
+			_, okBeforeGet := kk.latestIdx(m, lo)
 			countBeforeGet := m.count
 			m.mu.RUnlock()
-			if latestSizeBeforeGet < 2 {
-				t.Fatalf("expected latest index to be materialized on order break, size=%d", latestSizeBeforeGet)
+			if latestSizeBeforeGet != 0 {
+				t.Fatalf("expected latest index to remain unmaterialized on order break, size=%d", latestSizeBeforeGet)
 			}
-			if !okBeforeGet {
-				t.Fatalf("expected latest index lookup to succeed immediately after order break")
+			if okBeforeGet {
+				t.Fatalf("expected latest index lookup to miss before first read")
 			}
-			if idxBeforeGet != countBeforeGet-1 {
-				t.Fatalf("latest index before Get=%d want %d", idxBeforeGet, countBeforeGet-1)
+			if countBeforeGet != 2 {
+				t.Fatalf("count before Get=%d want 2", countBeforeGet)
 			}
 
 			if got, del, ok := m.Get(lo); !ok || del || string(got) != "lo" {

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -929,6 +929,38 @@ func TestAppendOnlyIteratorLongKeyDoesNotExposeIndexStorage(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyIteratorUnsafeStableKeyUsesTrustedNoCopyView(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	const (
+		targetKey = "long-key-a"
+		otherKey  = "long-key-b"
+	)
+	m.Set([]byte(otherKey), []byte("other"))
+	m.Set([]byte(targetKey), []byte("target")) // force unordered latest-index path
+
+	it := m.NewIterator(nil, nil)
+	stableIt, ok := it.(interface{ UnsafeStableKey() []byte })
+	if !ok {
+		t.Fatal("append-only iterator does not expose trusted stable key view")
+	}
+	if !it.Valid() {
+		t.Fatal("iterator unexpectedly invalid")
+	}
+	key := stableIt.UnsafeStableKey()
+	if got := string(key); got != targetKey {
+		t.Fatalf("stable iterator key=%q want %q", got, targetKey)
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := string(key); got != targetKey {
+		t.Fatalf("stable iterator key after close=%q want %q", got, targetKey)
+	}
+	if got, del, ok := m.Get([]byte(targetKey)); !ok || del || string(got) != "target" {
+		t.Fatalf("Get(%q) after stable key view = (%q,%v,%v), want (target,false,true)", targetKey, got, del, ok)
+	}
+}
+
 var appendOnlyGetBenchSink []byte
 var appendOnlyGetBenchSinkBool bool
 

--- a/TreeDB/internal/memtable/memtable.go
+++ b/TreeDB/internal/memtable/memtable.go
@@ -87,6 +87,18 @@ type SortedBatchApplier interface {
 	ApplyStealSortedBatch(entries []batchpkg.Entry, onKey func(key []byte))
 }
 
+// SortedBatchBorrowValueApplier is an optional fast path for applying a
+// strictly-increasing batch under a single memtable lock while borrowing value
+// slices from the caller. Keys must still be copied into memtable-owned
+// storage.
+//
+// Callers should only use this when they know the entries are already in
+// increasing key order and the borrowed values will remain immutable for the
+// memtable lifetime.
+type SortedBatchBorrowValueApplier interface {
+	ApplyBorrowValueSortedBatch(entries []batchpkg.Entry, storeInlinePtrValues bool, onKey func(key []byte))
+}
+
 // ValueBorrower marks memtables that can safely retain caller-owned value
 // slices while still copying keys into their own storage.
 //
@@ -115,6 +127,29 @@ type StableUnsafeIteratorTable interface {
 // writes partitioned by shard while preserving source order).
 type TrustedSortedBatchApplier interface {
 	ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKey func(key []byte))
+}
+
+// TrustedSortedBatchBorrowValueApplier is an optional fast path for callers
+// that already guarantee strictly increasing keys and immutable borrowed value
+// slices.
+type TrustedSortedBatchBorrowValueApplier interface {
+	ApplyBorrowValueSortedBatchTrusted(entries []batchpkg.Entry, storeInlinePtrValues bool, onKey func(key []byte))
+}
+
+// TrustedSortedBatchIndexApplier is an optional fast path for callers that
+// already guarantee strictly increasing keys and can provide a sorted index
+// list into a shared batch entry slice. This avoids materializing per-shard
+// []batch.Entry views when the memtable can consume the original batch slice
+// directly.
+type TrustedSortedBatchIndexApplier interface {
+	ApplyStealSortedBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, onKey func(key []byte))
+}
+
+// TrustedSortedBatchBorrowValueIndexApplier is like
+// TrustedSortedBatchBorrowValueApplier but consumes a sorted index list into a
+// shared batch entry slice.
+type TrustedSortedBatchBorrowValueIndexApplier interface {
+	ApplyBorrowValueSortedBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, storeInlinePtrValues bool, onKey func(key []byte))
 }
 
 type Memtable struct {

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -3,6 +3,7 @@ package valuelog
 import (
 	"bytes"
 	"encoding/binary"
+	"hash/crc32"
 	"path/filepath"
 
 	"github.com/snissn/gomap/TreeDB/node"
@@ -10,6 +11,8 @@ import (
 )
 
 var compactLeafPagePayloadMagic = [8]byte{0x8a, 'L', 'F', 'P', 'G', 0x01, 0x91, 0x3c}
+var compactLeafPagePayloadCRCTable = crc32.MakeTable(crc32.Castagnoli)
+var compactLeafPagePayloadChecksumZeros [1024]byte
 
 const compactLeafPagePayloadHeaderSize = len(compactLeafPagePayloadMagic) + 4
 const compactLeafPagePayloadDirName = "leaf_vlog"
@@ -39,6 +42,30 @@ func compactLeafPagePayloadLen(prefixLen, suffixLen int) int {
 	return compactLeafPagePayloadHeaderSize + prefixLen + suffixLen
 }
 
+func compactLeafCanonicalChecksum(leafPage []byte, prefixLen, suffixStart, suffixLen int) uint32 {
+	if len(leafPage) < page.PageHeaderSize {
+		return 0
+	}
+	sum := crc32.Update(0, compactLeafPagePayloadCRCTable, leafPage[:8])
+	sum = crc32.Update(sum, compactLeafPagePayloadCRCTable, compactLeafPagePayloadChecksumZeros[:4])
+	if prefixLen > 12 {
+		sum = crc32.Update(sum, compactLeafPagePayloadCRCTable, leafPage[12:prefixLen])
+	}
+	gapLen := page.PageSize - prefixLen - suffixLen
+	for gapLen > 0 {
+		n := len(compactLeafPagePayloadChecksumZeros)
+		if n > gapLen {
+			n = gapLen
+		}
+		sum = crc32.Update(sum, compactLeafPagePayloadCRCTable, compactLeafPagePayloadChecksumZeros[:n])
+		gapLen -= n
+	}
+	if suffixLen > 0 {
+		sum = crc32.Update(sum, compactLeafPagePayloadCRCTable, leafPage[suffixStart:suffixStart+suffixLen])
+	}
+	return sum
+}
+
 // CompactLeafLogPayloadLen reports the payload length that
 // MaybeCompactLeafLogPayload would produce without materializing the payload.
 // When compaction is not beneficial, it returns len(leafPage) and compacted=false.
@@ -59,7 +86,7 @@ func encodeCompactLeafLogPayload(dst, leafPage []byte, prefixLen, suffixStart, s
 	binary.LittleEndian.PutUint16(dst[len(compactLeafPagePayloadMagic)+2:compactLeafPagePayloadHeaderSize], uint16(suffixLen))
 
 	payload := dst[compactLeafPagePayloadHeaderSize:]
-	sum := page.CalculateChecksum(leafPage)
+	sum := compactLeafCanonicalChecksum(leafPage, prefixLen, suffixStart, suffixLen)
 
 	copy(payload[:8], leafPage[:8])
 	binary.LittleEndian.PutUint32(payload[8:12], sum)

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -22,7 +22,7 @@ func HasCompactLeafLogPayload(payload []byte) bool {
 		bytes.Equal(payload[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:])
 }
 
-func compactLeafLogPayloadBounds(leafPage []byte) (prefixLen, suffixStart, suffixLen int, ok bool, err error) {
+func compactLeafPageLivePayloadBounds(leafPage []byte) (prefixLen, suffixStart, suffixLen int, ok bool, err error) {
 	if len(leafPage) != page.PageSize {
 		return 0, 0, 0, false, nil
 	}
@@ -70,7 +70,7 @@ func compactLeafCanonicalChecksum(leafPage []byte, prefixLen, suffixStart, suffi
 // MaybeCompactLeafLogPayload would produce without materializing the payload.
 // When compaction is not beneficial, it returns len(leafPage) and compacted=false.
 func CompactLeafLogPayloadLen(leafPage []byte) (payloadLen int, compacted bool, err error) {
-	prefixLen, _, suffixLen, ok, err := compactLeafLogPayloadBounds(leafPage)
+	prefixLen, _, suffixLen, ok, err := compactLeafPageLivePayloadBounds(leafPage)
 	if err != nil {
 		return 0, false, err
 	}
@@ -97,7 +97,7 @@ func encodeCompactLeafLogPayload(dst, leafPage []byte, prefixLen, suffixStart, s
 }
 
 func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
-	prefixLen, suffixStart, suffixLen, ok, err := compactLeafLogPayloadBounds(leafPage)
+	prefixLen, suffixStart, suffixLen, ok, err := compactLeafPageLivePayloadBounds(leafPage)
 	if err != nil {
 		return nil, false, err
 	}

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -46,10 +46,11 @@ func compactLeafCanonicalChecksum(leafPage []byte, prefixLen, suffixStart, suffi
 	if len(leafPage) < page.PageHeaderSize {
 		return 0
 	}
-	sum := crc32.Update(0, compactLeafPagePayloadCRCTable, leafPage[:8])
-	sum = crc32.Update(sum, compactLeafPagePayloadCRCTable, compactLeafPagePayloadChecksumZeros[:4])
-	if prefixLen > 12 {
-		sum = crc32.Update(sum, compactLeafPagePayloadCRCTable, leafPage[12:prefixLen])
+	checksumEnd := page.PageChecksumOffset + page.PageChecksumSize
+	sum := crc32.Update(0, compactLeafPagePayloadCRCTable, leafPage[:page.PageChecksumOffset])
+	sum = crc32.Update(sum, compactLeafPagePayloadCRCTable, compactLeafPagePayloadChecksumZeros[:page.PageChecksumSize])
+	if prefixLen > checksumEnd {
+		sum = crc32.Update(sum, compactLeafPagePayloadCRCTable, leafPage[checksumEnd:prefixLen])
 	}
 	gapLen := page.PageSize - prefixLen - suffixLen
 	for gapLen > 0 {
@@ -88,10 +89,11 @@ func encodeCompactLeafLogPayload(dst, leafPage []byte, prefixLen, suffixStart, s
 	payload := dst[compactLeafPagePayloadHeaderSize:]
 	sum := compactLeafCanonicalChecksum(leafPage, prefixLen, suffixStart, suffixLen)
 
-	copy(payload[:8], leafPage[:8])
-	binary.LittleEndian.PutUint32(payload[8:12], sum)
-	if prefixLen > 12 {
-		copy(payload[12:prefixLen], leafPage[12:prefixLen])
+	checksumEnd := page.PageChecksumOffset + page.PageChecksumSize
+	copy(payload[:page.PageChecksumOffset], leafPage[:page.PageChecksumOffset])
+	binary.LittleEndian.PutUint32(payload[page.PageChecksumOffset:checksumEnd], sum)
+	if prefixLen > checksumEnd {
+		copy(payload[checksumEnd:prefixLen], leafPage[checksumEnd:prefixLen])
 	}
 	copy(payload[prefixLen:], leafPage[suffixStart:])
 }

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -19,31 +19,66 @@ func HasCompactLeafLogPayload(payload []byte) bool {
 		bytes.Equal(payload[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:])
 }
 
-func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
+func compactLeafLogPayloadBounds(leafPage []byte) (prefixLen, suffixStart, suffixLen int, ok bool, err error) {
 	if len(leafPage) != page.PageSize {
-		return leafPage, false, nil
+		return 0, 0, 0, false, nil
 	}
-	prefixLen, suffixLen, err := node.LeafPageLiveBounds(leafPage)
+	prefixLen, suffixLen, err = node.LeafPageLiveBounds(leafPage)
 	if err != nil {
-		return leafPage, false, nil
+		return 0, 0, 0, false, nil
 	}
-	compactLen := compactLeafPagePayloadHeaderSize + prefixLen + suffixLen
+	compactLen := compactLeafPagePayloadLen(prefixLen, suffixLen)
 	if compactLen >= len(leafPage) {
+		return 0, 0, 0, false, nil
+	}
+	suffixStart = len(leafPage) - suffixLen
+	return prefixLen, suffixStart, suffixLen, true, nil
+}
+
+func compactLeafPagePayloadLen(prefixLen, suffixLen int) int {
+	return compactLeafPagePayloadHeaderSize + prefixLen + suffixLen
+}
+
+// CompactLeafLogPayloadLen reports the payload length that
+// MaybeCompactLeafLogPayload would produce without materializing the payload.
+// When compaction is not beneficial, it returns len(leafPage) and compacted=false.
+func CompactLeafLogPayloadLen(leafPage []byte) (payloadLen int, compacted bool, err error) {
+	prefixLen, _, suffixLen, ok, err := compactLeafLogPayloadBounds(leafPage)
+	if err != nil {
+		return 0, false, err
+	}
+	if !ok {
+		return len(leafPage), false, nil
+	}
+	return compactLeafPagePayloadLen(prefixLen, suffixLen), true, nil
+}
+
+func encodeCompactLeafLogPayload(dst, leafPage []byte, prefixLen, suffixStart, suffixLen int) {
+	copy(dst[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:])
+	binary.LittleEndian.PutUint16(dst[len(compactLeafPagePayloadMagic):len(compactLeafPagePayloadMagic)+2], uint16(prefixLen))
+	binary.LittleEndian.PutUint16(dst[len(compactLeafPagePayloadMagic)+2:compactLeafPagePayloadHeaderSize], uint16(suffixLen))
+
+	payload := dst[compactLeafPagePayloadHeaderSize:]
+	sum := page.CalculateChecksum(leafPage)
+
+	copy(payload[:8], leafPage[:8])
+	binary.LittleEndian.PutUint32(payload[8:12], sum)
+	if prefixLen > 12 {
+		copy(payload[12:prefixLen], leafPage[12:prefixLen])
+	}
+	copy(payload[prefixLen:], leafPage[suffixStart:])
+}
+
+func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
+	prefixLen, suffixStart, suffixLen, ok, err := compactLeafLogPayloadBounds(leafPage)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
 		return leafPage, false, nil
 	}
-
-	suffixStart := len(leafPage) - suffixLen
-	var canonical [page.PageSize]byte
-	copy(canonical[:prefixLen], leafPage[:prefixLen])
-	copy(canonical[suffixStart:], leafPage[suffixStart:])
-	page.UpdateChecksum(canonical[:])
-
-	payload := make([]byte, compactLen)
-	copy(payload[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:])
-	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic):len(compactLeafPagePayloadMagic)+2], uint16(prefixLen))
-	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic)+2:compactLeafPagePayloadHeaderSize], uint16(suffixLen))
-	copy(payload[compactLeafPagePayloadHeaderSize:compactLeafPagePayloadHeaderSize+prefixLen], canonical[:prefixLen])
-	copy(payload[compactLeafPagePayloadHeaderSize+prefixLen:], canonical[suffixStart:])
+	payload := make([]byte, compactLeafPagePayloadLen(prefixLen, suffixLen))
+	encodeCompactLeafLogPayload(payload, leafPage, prefixLen, suffixStart, suffixLen)
 	return payload, true, nil
 }
 

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -242,6 +242,47 @@ func TestManagerReadUnsafe_DecodesCompactLeafPayload(t *testing.T) {
 	requireLeafPagesLogicallyEqual(t, leaf, got)
 }
 
+func TestWriterAppendCompactLeafPage_BlockCompressionRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := compactLeafPayloadTestPath(t, dir, 1)
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	w.SetBlockCompression(BlockCodecSnappy, true)
+
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	ptr, stats, compacted, err := w.AppendCompactLeafPage(1, leaf)
+	if err != nil {
+		t.Fatalf("AppendCompactLeafPage: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	if stats.RawPayloadBytes <= 0 {
+		t.Fatalf("stats.RawPayloadBytes=%d want > 0", stats.RawPayloadBytes)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	mgr := newLeafPayloadTestManager(t, dir, path, fileID)
+	defer func() { _ = mgr.Close() }()
+
+	got, err := mgr.ReadUnsafe(ptr)
+	if err != nil {
+		t.Fatalf("ReadUnsafe: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("ReadUnsafe len=%d want %d", len(got), page.PageSize)
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, got)
+}
+
 func TestSetReadUnsafe_DecodesCompactLeafPayload(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -110,6 +110,40 @@ func TestMaybeCompactLeafLogPayload_SparseLeafRoundTrips(t *testing.T) {
 	requireLeafPagesLogicallyEqual(t, leaf, decoded)
 }
 
+func TestMaybeCompactLeafLogPayload_DirtyFreeGapUsesCanonicalChecksum(t *testing.T) {
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	prefixLen, suffixLen, err := node.LeafPageLiveBounds(leaf)
+	if err != nil {
+		t.Fatalf("LeafPageLiveBounds: %v", err)
+	}
+	suffixStart := len(leaf) - suffixLen
+	if prefixLen >= suffixStart {
+		t.Fatalf("leaf has no free gap: prefix=%d suffixStart=%d", prefixLen, suffixStart)
+	}
+	for i := prefixLen; i < suffixStart; i++ {
+		leaf[i] = byte(0x80 + i%64)
+	}
+
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	decoded, _, decodedFlag, err := decodeCompactLeafLogPayloadTo(payload, nil)
+	if err != nil {
+		t.Fatalf("decodeCompactLeafLogPayloadTo: %v", err)
+	}
+	if !decodedFlag {
+		t.Fatalf("expected compact payload to decode")
+	}
+	if !page.VerifyChecksumNonMutating(decoded) {
+		t.Fatalf("decoded canonical page checksum mismatch")
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, decoded)
+}
+
 func TestDecodeCompactLeafLogPayloadTo_AliasedDstRoundTrips(t *testing.T) {
 	leaf := buildSparseLeafPageForPayloadTest(t)
 

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -917,6 +917,143 @@ func (w *Writer) Append(dictID uint64, dict []byte, rid uint64, value []byte) (p
 	return ptrs[0], nil
 }
 
+// AppendCompactLeafPage appends a compact split-leaf payload directly from the
+// source page when compaction is beneficial, avoiding a transient merged
+// payload allocation. When the page does not benefit from compaction, it falls
+// back to a normal raw append.
+func (w *Writer) AppendCompactLeafPage(rid uint64, leafPage []byte) (page.ValuePtr, FrameStats, bool, error) {
+	if w == nil {
+		return page.ValuePtr{}, FrameStats{}, false, errors.New("valuelog: nil writer")
+	}
+	if rid == 0 {
+		return page.ValuePtr{}, FrameStats{}, false, errors.New("valuelog: missing rid")
+	}
+	prefixLen, suffixStart, suffixLen, compacted, err := compactLeafLogPayloadBounds(leafPage)
+	if err != nil {
+		return page.ValuePtr{}, FrameStats{}, false, err
+	}
+	payloadLen := len(leafPage)
+	if compacted {
+		payloadLen = compactLeafPagePayloadLen(prefixLen, suffixLen)
+	}
+	if w.blockCompression {
+		var (
+			rec [1]Record
+			dst [1]page.ValuePtr
+		)
+		if compacted {
+			if cap(w.rawScratch) < payloadLen {
+				w.rawScratch = make([]byte, payloadLen)
+			}
+			payload := w.rawScratch[:payloadLen]
+			encodeCompactLeafLogPayload(payload, leafPage, prefixLen, suffixStart, suffixLen)
+			rec[0] = Record{RID: rid, Value: payload}
+		} else {
+			rec[0] = Record{RID: rid, Value: leafPage}
+		}
+		ptrs, stats, appendErr := w.appendBlockFrameWithStats(rec[:], payloadLen, dst[:])
+		if appendErr != nil {
+			return page.ValuePtr{}, FrameStats{}, compacted, appendErr
+		}
+		if len(ptrs) != 1 {
+			return page.ValuePtr{}, FrameStats{}, compacted, ErrCorrupt
+		}
+		return ptrs[0], stats, compacted, nil
+	}
+	if !compacted {
+		ptr, appendErr := w.Append(0, nil, rid, leafPage)
+		if appendErr != nil {
+			return page.ValuePtr{}, FrameStats{}, false, appendErr
+		}
+		return ptr, FrameStats{Records: 1, RawPayloadBytes: len(leafPage), StoredPayloadBytes: len(leafPage), Kept: false}, false, nil
+	}
+
+	bodyLen := uint32(FrameHeaderSize + 8 + 8 + payloadLen)
+	if recordSizeExceedsMax(bodyLen) {
+		return page.ValuePtr{}, FrameStats{}, false, ErrRecordTooLarge
+	}
+
+	recordLen := HeaderSize + int(bodyLen)
+	start := w.size
+	max := w.appendMax
+	if max <= 0 {
+		max = defaultBufferSize
+	}
+	recordLenHint := uint32(headerWithoutCRC) + bodyLen
+	if recordLenHint > page.ValuePtrGroupedMaxRecordLen {
+		recordLenHint = 0
+	}
+
+	writeRecord := func(buf []byte) {
+		buf[4] = Version
+		buf[5] = recordFlagGrouped
+		buf[6] = 0
+		buf[7] = 0
+		binary.LittleEndian.PutUint64(buf[8:16], 0)
+		binary.LittleEndian.PutUint32(buf[16:20], bodyLen)
+
+		off := HeaderSize
+		buf[off] = FrameVersion
+		buf[off+1] = 0
+		buf[off+2] = 1
+		buf[off+3] = 0
+		binary.LittleEndian.PutUint64(buf[off+4:off+12], 0)
+		off += FrameHeaderSize
+
+		binary.LittleEndian.PutUint64(buf[off:off+8], rid)
+		off += 8
+		binary.LittleEndian.PutUint32(buf[off:off+4], 0)
+		binary.LittleEndian.PutUint32(buf[off+4:off+8], uint32(payloadLen))
+		off += 8
+		encodeCompactLeafLogPayload(buf[off:off+payloadLen], leafPage, prefixLen, suffixStart, suffixLen)
+
+		sum := crc.ChecksumParts(buf[4:HeaderSize], buf[HeaderSize:])
+		binary.LittleEndian.PutUint32(buf[0:4], sum)
+	}
+
+	if w.f != nil && recordLen <= max {
+		if len(w.appendBuf)+recordLen > max {
+			if err := w.flushAppendBuf(); err != nil {
+				return page.ValuePtr{}, FrameStats{}, false, err
+			}
+		}
+		if cap(w.appendBuf) < max {
+			w.appendBuf = make([]byte, len(w.appendBuf), max)
+		}
+		base := len(w.appendBuf)
+		w.appendBuf = w.appendBuf[:base+recordLen]
+		buf := w.appendBuf[base : base+recordLen]
+		writeRecord(buf)
+		w.size += int64(recordLen)
+
+		if len(w.appendBuf) >= max {
+			if err := w.flushAppendBuf(); err != nil {
+				return page.ValuePtr{}, FrameStats{}, false, err
+			}
+		}
+		return page.ValuePtr{
+			Offset: uint64(start + 4),
+			Length: page.ValuePtrMarkGrouped(recordLenHint, 0),
+			FileID: w.fileID,
+		}, FrameStats{Records: 1, RawPayloadBytes: payloadLen, StoredPayloadBytes: payloadLen, Kept: false}, true, nil
+	}
+
+	if cap(w.scratch) < recordLen {
+		w.scratch = make([]byte, recordLen)
+	}
+	buf := w.scratch[:recordLen]
+	writeRecord(buf)
+	if err := w.writeBytes(buf); err != nil {
+		return page.ValuePtr{}, FrameStats{}, false, err
+	}
+	w.size += int64(recordLen)
+	return page.ValuePtr{
+		Offset: uint64(start + 4),
+		Length: page.ValuePtrMarkGrouped(recordLenHint, 0),
+		FileID: w.fileID,
+	}, FrameStats{Records: 1, RawPayloadBytes: payloadLen, StoredPayloadBytes: payloadLen, Kept: false}, true, nil
+}
+
 func (w *Writer) AppendOneFrameWithStats(dictID uint64, dict []byte, rid uint64, value []byte) (page.ValuePtr, FrameStats, error) {
 	if w == nil {
 		return page.ValuePtr{}, FrameStats{}, errors.New("valuelog: nil writer")

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -928,7 +928,7 @@ func (w *Writer) AppendCompactLeafPage(rid uint64, leafPage []byte) (page.ValueP
 	if rid == 0 {
 		return page.ValuePtr{}, FrameStats{}, false, errors.New("valuelog: missing rid")
 	}
-	prefixLen, suffixStart, suffixLen, compacted, err := compactLeafLogPayloadBounds(leafPage)
+	prefixLen, suffixStart, suffixLen, compacted, err := compactLeafPageLivePayloadBounds(leafPage)
 	if err != nil {
 		return page.ValuePtr{}, FrameStats{}, false, err
 	}

--- a/TreeDB/page/layout_assert.go
+++ b/TreeDB/page/layout_assert.go
@@ -18,8 +18,8 @@ var (
 	// PageHeader field offsets: 0, 8, 12, 14.
 	_ [int(unsafe.Offsetof(PageHeader{}.PageID)) - 0]byte
 	_ [0 - int(unsafe.Offsetof(PageHeader{}.PageID))]byte
-	_ [int(unsafe.Offsetof(PageHeader{}.Checksum)) - 8]byte
-	_ [8 - int(unsafe.Offsetof(PageHeader{}.Checksum))]byte
+	_ [int(unsafe.Offsetof(PageHeader{}.Checksum)) - PageChecksumOffset]byte
+	_ [PageChecksumOffset - int(unsafe.Offsetof(PageHeader{}.Checksum))]byte
 	_ [int(unsafe.Offsetof(PageHeader{}.Flags)) - 12]byte
 	_ [12 - int(unsafe.Offsetof(PageHeader{}.Flags))]byte
 	_ [int(unsafe.Offsetof(PageHeader{}.Count)) - 14]byte

--- a/TreeDB/page/page.go
+++ b/TreeDB/page/page.go
@@ -19,6 +19,13 @@ const (
 	// PageHeaderSize is the size of the PageHeader struct.
 	PageHeaderSize = 16
 
+	// PageChecksumOffset is the byte offset of PageHeader.Checksum within a
+	// serialized page header.
+	PageChecksumOffset = 8
+
+	// PageChecksumSize is the serialized size of PageHeader.Checksum.
+	PageChecksumSize = 4
+
 	// ValuePtrSize is the size of the ValuePtr struct.
 	ValuePtrSize = 16
 
@@ -68,51 +75,48 @@ type ValuePtr struct {
 
 // CRC32C Table using Castagnoli polynomial.
 var crcTable = crc32.MakeTable(crc32.Castagnoli)
-var checksumZeroField = [4]byte{}
+var checksumZeroField = [PageChecksumSize]byte{}
 
 // Checksum returns the CRC32C checksum of data.
 func Checksum(data []byte) uint32 {
 	return crc32.Checksum(data, crcTable)
 }
 
-// CalculateChecksum computes the checksum of the page data,
-// treating checksum bytes 8-11 (data[8:12]) as zero.
+// CalculateChecksum computes the checksum of the page data, treating the page
+// checksum field bytes as zero.
 func CalculateChecksum(data []byte) uint32 {
 	if len(data) < PageHeaderSize {
 		return 0
 	}
-	// CRC over bytes 0-7, then the zeroed checksum field (bytes 8-11), then the rest.
-	sum := crc32.Update(0, crcTable, data[0:8])
+	checksumEnd := PageChecksumOffset + PageChecksumSize
+	sum := crc32.Update(0, crcTable, data[:PageChecksumOffset])
 	sum = crc32.Update(sum, crcTable, checksumZeroField[:])
-	sum = crc32.Update(sum, crcTable, data[12:])
+	sum = crc32.Update(sum, crcTable, data[checksumEnd:])
 	return sum
 }
 
-// UpdateChecksum computes CRC32C for the page while treating checksum bytes
-// 8-11 (data[8:12]) as zero, then writes the computed checksum back into the
+// UpdateChecksum computes CRC32C for the page while treating the page checksum
+// field bytes as zero, then writes the computed checksum back into the
 // page header.
 // It mutates data in-place and returns the computed checksum.
 func UpdateChecksum(data []byte) uint32 {
 	if len(data) < PageHeaderSize {
 		return 0
 	}
-	data[8] = 0
-	data[9] = 0
-	data[10] = 0
-	data[11] = 0
+	clear(data[PageChecksumOffset : PageChecksumOffset+PageChecksumSize])
 	sum := crc32.Checksum(data, crcTable)
-	binary.LittleEndian.PutUint32(data[8:12], sum)
+	binary.LittleEndian.PutUint32(data[PageChecksumOffset:PageChecksumOffset+PageChecksumSize], sum)
 	return sum
 }
 
 // VerifyChecksumNonMutating verifies that the page checksum matches the data,
-// assuming checksum bytes 8-11 (data[8:12]) are zero for the calculation.
+// assuming the page checksum field bytes are zero for the calculation.
 // It avoids modifying the underlying buffer.
 func VerifyChecksumNonMutating(data []byte) bool {
 	if len(data) < PageHeaderSize {
 		return false
 	}
-	stored := binary.LittleEndian.Uint32(data[8:12])
+	stored := binary.LittleEndian.Uint32(data[PageChecksumOffset : PageChecksumOffset+PageChecksumSize])
 	computed := CalculateChecksum(data)
 	return stored == computed
 }
@@ -126,7 +130,7 @@ func (h *PageHeader) Encode(buf []byte) {
 		return
 	}
 	binary.LittleEndian.PutUint64(buf[0:8], h.PageID)
-	binary.LittleEndian.PutUint32(buf[8:12], h.Checksum)
+	binary.LittleEndian.PutUint32(buf[PageChecksumOffset:PageChecksumOffset+PageChecksumSize], h.Checksum)
 	binary.LittleEndian.PutUint16(buf[12:14], h.Flags)
 	binary.LittleEndian.PutUint16(buf[14:16], h.Count)
 }
@@ -141,7 +145,7 @@ func DecodeHeader(buf []byte) PageHeader {
 	}
 	return PageHeader{
 		PageID:   binary.LittleEndian.Uint64(buf[0:8]),
-		Checksum: binary.LittleEndian.Uint32(buf[8:12]),
+		Checksum: binary.LittleEndian.Uint32(buf[PageChecksumOffset : PageChecksumOffset+PageChecksumSize]),
 		Flags:    binary.LittleEndian.Uint16(buf[12:14]),
 		Count:    binary.LittleEndian.Uint16(buf[14:16]),
 	}

--- a/cmd/unified_bench/batch_small_seq_test.go
+++ b/cmd/unified_bench/batch_small_seq_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/snissn/gomap/kvstore"
+)
+
+type batchSmallSeqTrackingDB struct {
+	batch *batchSmallSeqTrackingBatch
+}
+
+func (d *batchSmallSeqTrackingDB) Name() string { return "BatchSmallSeqTracking" }
+func (d *batchSmallSeqTrackingDB) Close() error { return nil }
+func (d *batchSmallSeqTrackingDB) Get(key []byte) ([]byte, error) {
+	return nil, nil
+}
+func (d *batchSmallSeqTrackingDB) Set(key, value []byte) error { return nil }
+func (d *batchSmallSeqTrackingDB) Delete(key []byte) error     { return nil }
+func (d *batchSmallSeqTrackingDB) Checkpoint() error           { return nil }
+
+func (d *batchSmallSeqTrackingDB) NewBatch() (kvstore.Batch, error) {
+	return d.NewBatchWithSize(0)
+}
+
+func (d *batchSmallSeqTrackingDB) NewBatchWithSize(size int) (kvstore.Batch, error) {
+	if d.batch == nil {
+		d.batch = &batchSmallSeqTrackingBatch{}
+	} else {
+		d.batch.Reset()
+	}
+	return d.batch, nil
+}
+
+type batchSmallSeqTrackingBatch struct {
+	setCalls          atomic.Int64
+	setViewCalls      atomic.Int64
+	setStealViewCalls atomic.Int64
+	commitCalls       atomic.Int64
+}
+
+func (b *batchSmallSeqTrackingBatch) Set(key, value []byte) error {
+	b.setCalls.Add(1)
+	return nil
+}
+
+func (b *batchSmallSeqTrackingBatch) SetView(key, value []byte) error {
+	b.setViewCalls.Add(1)
+	return nil
+}
+
+func (b *batchSmallSeqTrackingBatch) SetStealView(key, value []byte) error {
+	b.setStealViewCalls.Add(1)
+	return nil
+}
+
+func (b *batchSmallSeqTrackingBatch) Delete(key []byte) error { return nil }
+
+func (b *batchSmallSeqTrackingBatch) Commit() error {
+	b.commitCalls.Add(1)
+	return nil
+}
+
+func (b *batchSmallSeqTrackingBatch) CommitSync() error {
+	return b.Commit()
+}
+
+func (b *batchSmallSeqTrackingBatch) Close() error { return nil }
+
+func (b *batchSmallSeqTrackingBatch) Reset() {}
+
+func TestBatchSmallSeqPrefersSetStealView(t *testing.T) {
+	const dbName = "batch_small_seq_tracking"
+	var dbRef atomic.Pointer[batchSmallSeqTrackingDB]
+	RegisterHiddenDB(dbName, func(dir string) (kvstore.DB, error) {
+		db := &batchSmallSeqTrackingDB{}
+		dbRef.Store(db)
+		return db, nil
+	})
+
+	_, err := runBenchmark(BenchConfig{
+		Keys:         64,
+		ValueSize:    16,
+		BatchSize:    8,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       dbName,
+		TestsArg:     "batch_small_seq",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark(batch_small_seq): %v", err)
+	}
+
+	db := dbRef.Load()
+	if db == nil || db.batch == nil {
+		t.Fatal("tracking batch was not created")
+	}
+	if got := db.batch.setStealViewCalls.Load(); got != 64 {
+		t.Fatalf("batch_small_seq used SetStealView %d times; want 64", got)
+	}
+	if got := db.batch.setViewCalls.Load(); got != 0 {
+		t.Fatalf("batch_small_seq used SetView %d times; want 0", got)
+	}
+	if got := db.batch.setCalls.Load(); got != 0 {
+		t.Fatalf("batch_small_seq used Set %d times; want 0", got)
+	}
+	if got := db.batch.commitCalls.Load(); got == 0 {
+		t.Fatal("batch_small_seq did not commit any batches")
+	}
+}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -2825,16 +2825,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if end > total {
 					end = total
 				}
-				if setStealView != nil {
+				if setStealView != nil && precomputeKeys {
 					for j := i; j < end; j++ {
-						var keyView []byte
-						if precomputeKeys {
-							keyView = keyBytes[j*8 : (j+1)*8]
-						} else {
-							var key [8]byte
-							encodeKey(key[:], uint64(j))
-							keyView = key[:]
-						}
+						keyView := keyBytes[j*8 : (j+1)*8]
 						value := values[valPos%len(values)]
 						valPos++
 						if err := setStealView(keyView, value); err != nil {

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -2003,6 +2003,14 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				encodeKey(keyBytes[j*8:(j+1)*8], uint64(j+cfg.Keys))
 			}
 		}
+		var batchKeyBytes []byte
+		batchKeySlab := func(entries int) []byte {
+			need := entries * 8
+			if cap(batchKeyBytes) < need {
+				batchKeyBytes = make([]byte, need)
+			}
+			return batchKeyBytes[:need]
+		}
 		type batcherWithSize interface {
 			NewBatchWithSize(size int) (kvstore.Batch, error)
 		}
@@ -2131,8 +2139,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 						}
 					} else {
 						// SetView is zero-copy: keep keys in a stable owned slab until commit.
-						need := (end - i) * 8
-						keysView := make([]byte, need)
+						keysView := batchKeySlab(end - i)
 						for j := i; j < end; j++ {
 							off := (j - i) * 8
 							keyView := keysView[off : off+8]
@@ -2227,9 +2234,8 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					}
 				} else {
 					// Keep the zero-copy SetView path for large key counts by using
-					// one owned key slab per batch (stable beyond Commit()).
-					need := (end - i) * 8
-					keysView := make([]byte, need)
+					// one reused owned key slab per batch (stable until Commit()).
+					keysView := batchKeySlab(end - i)
 					for j := i; j < end; j++ {
 						off := (j - i) * 8
 						keyView := keysView[off : off+8]
@@ -2753,6 +2759,14 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					encodeKey(keyBytes[j*8:(j+1)*8], uint64(j))
 				}
 			}
+			var batchKeyBytes []byte
+			batchKeySlab := func(entries int) []byte {
+				need := entries * 8
+				if cap(batchKeyBytes) < need {
+					batchKeyBytes = make([]byte, need)
+				}
+				return batchKeyBytes[:need]
+			}
 			type batcherWithSize interface {
 				NewBatchWithSize(size int) (kvstore.Batch, error)
 			}
@@ -2849,7 +2863,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 						}
 					} else {
 						// SetView is zero-copy: keep keys in a stable owned slab until commit.
-						keysView := make([]byte, (end-i)*8)
+						keysView := batchKeySlab(end - i)
 						for j := i; j < end; j++ {
 							off := (j - i) * 8
 							keyView := keysView[off : off+8]

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -111,6 +111,22 @@ type DBInstance struct {
 	Dir     string
 }
 
+type batcherWithSize interface {
+	NewBatchWithSize(size int) (kvstore.Batch, error)
+}
+
+type batchSetView interface {
+	SetView(key, value []byte) error
+}
+
+type batchDeleteView interface {
+	DeleteView(key []byte) error
+}
+
+type resettableBatch interface {
+	Reset()
+}
+
 type BenchConfig struct {
 	Keys          int
 	KeyShape      string
@@ -2014,15 +2030,6 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			}
 			return batchKeyBytes[:need]
 		}
-		type batcherWithSize interface {
-			NewBatchWithSize(size int) (kvstore.Batch, error)
-		}
-		type batchSetView interface {
-			SetView(key, value []byte) error
-		}
-		type resettableBatch interface {
-			Reset()
-		}
 		var (
 			batch      kvstore.Batch
 			setView    func(key, value []byte) error
@@ -2640,15 +2647,6 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			start := time.Now()
 			pc := newPeriodicCheckpoint(cfg)
 			perOpBytes := int64(8)
-			type batcherWithSize interface {
-				NewBatchWithSize(size int) (kvstore.Batch, error)
-			}
-			type batchDeleteView interface {
-				DeleteView(key []byte) error
-			}
-			type resettableBatch interface {
-				Reset()
-			}
 			var (
 				batch      kvstore.Batch
 				deleteView func(key []byte) error
@@ -2769,15 +2767,6 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					batchKeyBytes = make([]byte, need)
 				}
 				return batchKeyBytes[:need]
-			}
-			type batcherWithSize interface {
-				NewBatchWithSize(size int) (kvstore.Batch, error)
-			}
-			type batchSetView interface {
-				SetView(key, value []byte) error
-			}
-			type resettableBatch interface {
-				Reset()
 			}
 			var (
 				batch      kvstore.Batch

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -1098,6 +1098,9 @@ func printTreeDBCacheStats(w io.Writer, inst *DBInstance, prefix string) {
 	keys := []string{
 		"treedb.cache.memtable_mode",
 		"treedb.cache.memtable_mode_config",
+		"treedb.cache.memtable_stats.current_seq_run",
+		"treedb.cache.memtable_stats.delete_writes",
+		"treedb.cache.memtable_stats.delete_write_pct",
 		"treedb.cache.queue_len",
 		"treedb.cache.queue_backlog_bytes",
 		"treedb.cache.flush_threshold_bytes",
@@ -2628,6 +2631,45 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			start := time.Now()
 			pc := newPeriodicCheckpoint(cfg)
 			perOpBytes := int64(8)
+			type batcherWithSize interface {
+				NewBatchWithSize(size int) (kvstore.Batch, error)
+			}
+			type batchDeleteView interface {
+				DeleteView(key []byte) error
+			}
+			type resettableBatch interface {
+				Reset()
+			}
+			var (
+				batch      kvstore.Batch
+				deleteView func(key []byte) error
+				resetBatch func()
+			)
+			openBatch := func() error {
+				var err error
+				if bs, ok := batcher.(batcherWithSize); ok {
+					batch, err = bs.NewBatchWithSize(batchSize)
+				} else {
+					batch, err = batcher.NewBatch()
+				}
+				if err != nil {
+					return err
+				}
+				deleteView = nil
+				if dv, ok := batch.(batchDeleteView); ok {
+					deleteView = dv.DeleteView
+				}
+				resetBatch = nil
+				if rb, ok := batch.(resettableBatch); ok {
+					resetBatch = rb.Reset
+				}
+				return nil
+			}
+			defer func() {
+				if batch != nil {
+					_ = batch.Close()
+				}
+			}()
 
 			for i := 0; i < total; i += batchSize {
 				if i&8191 == 0 {
@@ -2635,9 +2677,20 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 						return 0, err
 					}
 				}
-				batch, err := batcher.NewBatch()
-				if err != nil {
-					return 0, fmt.Errorf("batch_delete: new batch: %w", err)
+				if batch == nil {
+					if err := openBatch(); err != nil {
+						return 0, fmt.Errorf("batch_delete: new batch: %w", err)
+					}
+				} else if resetBatch != nil {
+					resetBatch()
+				} else {
+					if err := batch.Close(); err != nil {
+						return 0, fmt.Errorf("batch_delete: close: %w", err)
+					}
+					batch = nil
+					if err := openBatch(); err != nil {
+						return 0, fmt.Errorf("batch_delete: new batch: %w", err)
+					}
 				}
 
 				end := i + batchSize
@@ -2647,17 +2700,24 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				for j := i; j < end; j++ {
 					offset := j * keySize
 					key := allKeys[offset : offset+keySize]
-					if err := batch.Delete(key); err != nil {
-						_ = batch.Close()
+					var err error
+					if deleteView != nil {
+						err = deleteView(key)
+					} else {
+						err = batch.Delete(key)
+					}
+					if err != nil {
 						return 0, fmt.Errorf("batch_delete: delete: %w", err)
 					}
 				}
 				if err := batch.Commit(); err != nil {
-					_ = batch.Close()
 					return 0, fmt.Errorf("batch_delete: commit: %w", err)
 				}
-				if err := batch.Close(); err != nil {
-					return 0, fmt.Errorf("batch_delete: close: %w", err)
+				if resetBatch == nil {
+					if err := batch.Close(); err != nil {
+						return 0, fmt.Errorf("batch_delete: close: %w", err)
+					}
+					batch = nil
 				}
 				if err := pc.Add(db, end-i, int64(end-i)*perOpBytes); err != nil {
 					return 0, fmt.Errorf("batch_delete checkpoint: %w", err)
@@ -2679,8 +2739,65 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			perOpBytes := int64(8 + cfg.ValueSize)
 			total := cfg.Keys
 			batchSize := 100 // Pathological: small enough to hurt if not buffered, sequential to trigger streaming
-			var k [8]byte
 			valPos := 0
+			// Keep the precomputed-key optimization bounded so very large runs do
+			// not retain a huge contiguous key buffer for the whole benchmark.
+			const maxPrecomputedKeyBytes = 128 << 20 // 128 MiB
+			precomputeKeys := total > 0 && total <= maxPrecomputedKeyBytes/8
+			var keyBytes []byte
+			if precomputeKeys {
+				keyBytes = make([]byte, total*8)
+				for j := 0; j < total; j++ {
+					encodeKey(keyBytes[j*8:(j+1)*8], uint64(j))
+				}
+			}
+			type batcherWithSize interface {
+				NewBatchWithSize(size int) (kvstore.Batch, error)
+			}
+			type batchSetStealView interface {
+				SetStealView(key, value []byte) error
+			}
+			type batchSetView interface {
+				SetView(key, value []byte) error
+			}
+			type resettableBatch interface {
+				Reset()
+			}
+			var (
+				batch        kvstore.Batch
+				setStealView func(key, value []byte) error
+				setView      func(key, value []byte) error
+				resetBatch   func()
+			)
+			openBatch := func() error {
+				var err error
+				if bs, ok := batcher.(batcherWithSize); ok {
+					batch, err = bs.NewBatchWithSize(batchSize)
+				} else {
+					batch, err = batcher.NewBatch()
+				}
+				if err != nil {
+					return err
+				}
+				setStealView = nil
+				if ssv, ok := batch.(batchSetStealView); ok {
+					setStealView = ssv.SetStealView
+				}
+				setView = nil
+				if sv, ok := batch.(batchSetView); ok {
+					setView = sv.SetView
+				}
+				resetBatch = nil
+				if rb, ok := batch.(resettableBatch); ok {
+					resetBatch = rb.Reset
+				}
+				return nil
+			}
+			defer func() {
+				if batch != nil {
+					_ = batch.Close()
+				}
+			}()
 
 			for i := 0; i < total; i += batchSize {
 				if i&8191 == 0 {
@@ -2688,30 +2805,91 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 						return 0, err
 					}
 				}
-				batch, err := batcher.NewBatch()
-				if err != nil {
-					return 0, fmt.Errorf("batch_small_seq: new batch: %w", err)
+				if batch == nil {
+					if err := openBatch(); err != nil {
+						return 0, fmt.Errorf("batch_small_seq: new batch: %w", err)
+					}
+				} else if resetBatch != nil {
+					resetBatch()
+				} else {
+					if err := batch.Close(); err != nil {
+						return 0, fmt.Errorf("batch_small_seq: close: %w", err)
+					}
+					batch = nil
+					if err := openBatch(); err != nil {
+						return 0, fmt.Errorf("batch_small_seq: new batch: %w", err)
+					}
 				}
 
 				end := i + batchSize
 				if end > total {
 					end = total
 				}
-				for j := i; j < end; j++ {
-					encodeKey(k[:], uint64(j)) // Sequential
-					value := values[valPos%len(values)]
-					valPos++
-					if err := batch.Set(k[:], value); err != nil {
-						_ = batch.Close()
-						return 0, fmt.Errorf("batch_small_seq: set: %w", err)
+				if setStealView != nil {
+					for j := i; j < end; j++ {
+						var keyView []byte
+						if precomputeKeys {
+							keyView = keyBytes[j*8 : (j+1)*8]
+						} else {
+							var key [8]byte
+							encodeKey(key[:], uint64(j))
+							keyView = key[:]
+						}
+						value := values[valPos%len(values)]
+						valPos++
+						if err := setStealView(keyView, value); err != nil {
+							return 0, fmt.Errorf("batch_small_seq: set: %w", err)
+						}
+					}
+				} else if setView != nil {
+					if precomputeKeys {
+						for j := i; j < end; j++ {
+							keyView := keyBytes[j*8 : (j+1)*8]
+							value := values[valPos%len(values)]
+							valPos++
+							if err := setView(keyView, value); err != nil {
+								return 0, fmt.Errorf("batch_small_seq: set: %w", err)
+							}
+						}
+					} else {
+						// SetView is zero-copy: keep keys in a stable owned slab until commit.
+						keysView := make([]byte, (end-i)*8)
+						for j := i; j < end; j++ {
+							off := (j - i) * 8
+							keyView := keysView[off : off+8]
+							encodeKey(keyView, uint64(j))
+							value := values[valPos%len(values)]
+							valPos++
+							if err := setView(keyView, value); err != nil {
+								return 0, fmt.Errorf("batch_small_seq: set: %w", err)
+							}
+						}
+					}
+				} else {
+					for j := i; j < end; j++ {
+						var keyView []byte
+						if precomputeKeys {
+							keyView = keyBytes[j*8 : (j+1)*8]
+						} else {
+							var key [8]byte
+							encodeKey(key[:], uint64(j))
+							keyView = key[:]
+						}
+						value := values[valPos%len(values)]
+						valPos++
+						if err := batch.Set(keyView, value); err != nil {
+							return 0, fmt.Errorf("batch_small_seq: set: %w", err)
+						}
 					}
 				}
 				if err := batch.Commit(); err != nil {
-					_ = batch.Close()
 					return 0, fmt.Errorf("batch_small_seq: commit: %w", err)
 				}
-				if err := batch.Close(); err != nil {
-					return 0, fmt.Errorf("batch_small_seq: close: %w", err)
+				if resetBatch == nil {
+					if err := batch.Close(); err != nil {
+						return 0, fmt.Errorf("batch_small_seq: close: %w", err)
+					}
+					batch = nil
 				}
 				if err := pc.Add(db, end-i, int64(end-i)*perOpBytes); err != nil {
 					return 0, fmt.Errorf("batch_small_seq checkpoint: %w", err)
@@ -4037,6 +4215,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				printTreeDBCacheStats(os.Stderr, inst, "post-"+testName+" treedb.cache")
 			}
 		}
+		// Test functions can retain large dead setup buffers (for example the
+		// precomputed key slabs used by batch benchmarks). Reclaim them before the
+		// next test starts so cross-test throughput reflects DB state, not stale
+		// harness heap pressure.
+		runtime.GC()
 	}
 
 	// Final clear of live table

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -2684,10 +2684,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				} else if resetBatch != nil {
 					resetBatch()
 				} else {
-					if err := batch.Close(); err != nil {
-						return 0, fmt.Errorf("batch_delete: close: %w", err)
-					}
+					closeErr := batch.Close()
 					batch = nil
+					if closeErr != nil {
+						return 0, fmt.Errorf("batch_delete: close: %w", closeErr)
+					}
 					if err := openBatch(); err != nil {
 						return 0, fmt.Errorf("batch_delete: new batch: %w", err)
 					}
@@ -2714,10 +2715,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					return 0, fmt.Errorf("batch_delete: commit: %w", err)
 				}
 				if resetBatch == nil {
-					if err := batch.Close(); err != nil {
-						return 0, fmt.Errorf("batch_delete: close: %w", err)
-					}
+					closeErr := batch.Close()
 					batch = nil
+					if closeErr != nil {
+						return 0, fmt.Errorf("batch_delete: close: %w", closeErr)
+					}
 				}
 				if err := pc.Add(db, end-i, int64(end-i)*perOpBytes); err != nil {
 					return 0, fmt.Errorf("batch_delete checkpoint: %w", err)
@@ -2812,10 +2814,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				} else if resetBatch != nil {
 					resetBatch()
 				} else {
-					if err := batch.Close(); err != nil {
-						return 0, fmt.Errorf("batch_small_seq: close: %w", err)
-					}
+					closeErr := batch.Close()
 					batch = nil
+					if closeErr != nil {
+						return 0, fmt.Errorf("batch_small_seq: close: %w", closeErr)
+					}
 					if err := openBatch(); err != nil {
 						return 0, fmt.Errorf("batch_small_seq: new batch: %w", err)
 					}
@@ -2879,10 +2882,11 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					return 0, fmt.Errorf("batch_small_seq: commit: %w", err)
 				}
 				if resetBatch == nil {
-					if err := batch.Close(); err != nil {
-						return 0, fmt.Errorf("batch_small_seq: close: %w", err)
-					}
+					closeErr := batch.Close()
 					batch = nil
+					if closeErr != nil {
+						return 0, fmt.Errorf("batch_small_seq: close: %w", closeErr)
+					}
 				}
 				if err := pc.Add(db, end-i, int64(end-i)*perOpBytes); err != nil {
 					return 0, fmt.Errorf("batch_small_seq checkpoint: %w", err)

--- a/kvstore/adapters/treedb/treedb.go
+++ b/kvstore/adapters/treedb/treedb.go
@@ -383,8 +383,15 @@ func (b *batch) SetView(key, value []byte) error {
 	return b.b.Set(key, value)
 }
 
-// SetStealView records a Put without copying key/value bytes and allows TreeDB
-// to retain those slices beyond the batch lifetime when supported.
+// SetStealView records a Put without copying key/value bytes. Unlike SetView,
+// TreeDB may retain key/value references beyond Commit or Close when the
+// wrapped batch supports that optimization.
+//
+// Callers must treat key/value as transferred and immutable after this call:
+// do not mutate, reuse, or repurpose their backing arrays in any way that
+// could affect stored data. If the wrapped batch lacks SetStealView, this
+// adapter falls back to SetView/Set, but callers must still honor the stronger
+// SetStealView ownership contract.
 func (b *batch) SetStealView(key, value []byte) error {
 	if b.setSteal != nil {
 		return b.setSteal.SetStealView(key, value)

--- a/kvstore/adapters/treedb/treedb.go
+++ b/kvstore/adapters/treedb/treedb.go
@@ -316,6 +316,9 @@ func (d *DB) NewBatch() (kvstore.Batch, error) {
 		return nil, kvstore.ErrUnsupported
 	}
 	wrapped := &batch{b: b}
+	if ssv, ok := b.(batchSetStealViewer); ok {
+		wrapped.setSteal = ssv
+	}
 	if sv, ok := b.(batchSetViewer); ok {
 		wrapped.setView = sv
 	}
@@ -331,6 +334,9 @@ func (d *DB) NewBatchWithSize(size int) (kvstore.Batch, error) {
 		return nil, kvstore.ErrUnsupported
 	}
 	wrapped := &batch{b: b}
+	if ssv, ok := b.(batchSetStealViewer); ok {
+		wrapped.setSteal = ssv
+	}
 	if sv, ok := b.(batchSetViewer); ok {
 		wrapped.setView = sv
 	}
@@ -338,6 +344,10 @@ func (d *DB) NewBatchWithSize(size int) (kvstore.Batch, error) {
 		wrapped.deleteView = dv
 	}
 	return wrapped, nil
+}
+
+type batchSetStealViewer interface {
+	SetStealView(key, value []byte) error
 }
 
 type batchSetViewer interface {
@@ -350,6 +360,7 @@ type batchDeleteViewer interface {
 
 type batch struct {
 	b          treedb.Batch
+	setSteal   batchSetStealViewer
 	setView    batchSetViewer
 	deleteView batchDeleteViewer
 }
@@ -366,6 +377,18 @@ func (b *batch) Delete(key []byte) error {
 // underlying TreeDB batch. Callers must treat key/value as immutable until
 // Commit/CommitSync/Close.
 func (b *batch) SetView(key, value []byte) error {
+	if b.setView != nil {
+		return b.setView.SetView(key, value)
+	}
+	return b.b.Set(key, value)
+}
+
+// SetStealView records a Put without copying key/value bytes and allows TreeDB
+// to retain those slices beyond the batch lifetime when supported.
+func (b *batch) SetStealView(key, value []byte) error {
+	if b.setSteal != nil {
+		return b.setSteal.SetStealView(key, value)
+	}
 	if b.setView != nil {
 		return b.setView.SetView(key, value)
 	}

--- a/kvstore/adapters/treedb/treedb_batch_view_test.go
+++ b/kvstore/adapters/treedb/treedb_batch_view_test.go
@@ -30,10 +30,17 @@ func (s *stubBatch) GetByteSize() (int, error)                { return 0, nil }
 
 type stubBatchWithView struct {
 	stubBatch
-	setViewCalls    int
-	deleteViewCalls int
-	setViewErr      error
-	deleteViewErr   error
+	setStealViewCalls int
+	setViewCalls      int
+	deleteViewCalls   int
+	setStealViewErr   error
+	setViewErr        error
+	deleteViewErr     error
+}
+
+func (s *stubBatchWithView) SetStealView(_, _ []byte) error {
+	s.setStealViewCalls++
+	return s.setStealViewErr
 }
 
 func (s *stubBatchWithView) SetView(_, _ []byte) error {
@@ -49,14 +56,17 @@ func (s *stubBatchWithView) DeleteView(_ []byte) error {
 func TestBatchSetDeleteViewFallback(t *testing.T) {
 	base := &stubBatch{}
 	wrapped := &batch{b: base}
+	if err := wrapped.SetStealView([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("set steal view fallback: %v", err)
+	}
 	if err := wrapped.SetView([]byte("k"), []byte("v")); err != nil {
 		t.Fatalf("set view fallback: %v", err)
 	}
 	if err := wrapped.DeleteView([]byte("k")); err != nil {
 		t.Fatalf("delete view fallback: %v", err)
 	}
-	if base.setCalls != 1 {
-		t.Fatalf("expected set fallback call count=1, got=%d", base.setCalls)
+	if base.setCalls != 2 {
+		t.Fatalf("expected set fallback call count=2, got=%d", base.setCalls)
 	}
 	if base.deleteCalls != 1 {
 		t.Fatalf("expected delete fallback call count=1, got=%d", base.deleteCalls)
@@ -67,14 +77,21 @@ func TestBatchSetDeleteViewUseOptionalInterfaces(t *testing.T) {
 	base := &stubBatchWithView{}
 	wrapped := &batch{
 		b:          base,
+		setSteal:   base,
 		setView:    base,
 		deleteView: base,
+	}
+	if err := wrapped.SetStealView([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("set steal view: %v", err)
 	}
 	if err := wrapped.SetView([]byte("k"), []byte("v")); err != nil {
 		t.Fatalf("set view: %v", err)
 	}
 	if err := wrapped.DeleteView([]byte("k")); err != nil {
 		t.Fatalf("delete view: %v", err)
+	}
+	if base.setStealViewCalls != 1 {
+		t.Fatalf("expected set steal view call count=1, got=%d", base.setStealViewCalls)
 	}
 	if base.setViewCalls != 1 {
 		t.Fatalf("expected set view call count=1, got=%d", base.setViewCalls)
@@ -92,13 +109,18 @@ func TestBatchSetDeleteViewUseOptionalInterfaces(t *testing.T) {
 
 func TestBatchSetDeleteViewPropagateOptionalErrors(t *testing.T) {
 	base := &stubBatchWithView{
-		setViewErr:    errors.New("set-view-failed"),
-		deleteViewErr: errors.New("delete-view-failed"),
+		setStealViewErr: errors.New("set-steal-view-failed"),
+		setViewErr:      errors.New("set-view-failed"),
+		deleteViewErr:   errors.New("delete-view-failed"),
 	}
 	wrapped := &batch{
 		b:          base,
+		setSteal:   base,
 		setView:    base,
 		deleteView: base,
+	}
+	if err := wrapped.SetStealView([]byte("k"), []byte("v")); err == nil || err.Error() != "set-steal-view-failed" {
+		t.Fatalf("expected set steal view error propagation, got=%v", err)
 	}
 	if err := wrapped.SetView([]byte("k"), []byte("v")); err == nil || err.Error() != "set-view-failed" {
 		t.Fatalf("expected set view error propagation, got=%v", err)


### PR DESCRIPTION
## Summary
- keep append-only latest-index rebuild lazy so write-heavy unordered batches do not materialize read indexes
- add delete-aware adaptive memtable accounting and aggregate delete-only batch observation
- keep low-overwrite write-heavy adaptive workloads on append_only while preserving hash_sorted for observed overwrite-heavy cases
- reuse benchmark batch/view paths and add coverage for batch_small_seq view usage

## Validation
- go test ./...
- /tmp/unified-bench-adaptive-delete -dbs treedb -profile fast -keys 10000000 -test batch_delete -progress=false -profile-dir /tmp/pr_adaptive_delete_10m_tf7asE => 25,379,028 ops/s
- fixed append_only comparison on same binary => 26,622,645 ops/s
- adaptive no-profile rerun => 25,644,105 ops/s
- batch_small_seq 1M check => 18,036,040 ops/s

## Notes
Stacked on #1017 (`codex/append-only-compact-entry-layout`) to keep the current milestone reviewable instead of leaving it as local follow-up state.