### PR TITLE
Decode compact leaf payloads without aliased dst copies

### DIFF
--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -134,21 +134,25 @@ func decodeCompactLeafLogPayloadTo(payload, dst []byte) ([]byte, bool, bool, err
 		}
 		return payload, false, false, nil
 	}
-	if cap(dst) >= page.PageSize && sliceAliasesBytes(dst[:cap(dst)], payload) {
-		payload = append([]byte(nil), payload...)
-	}
 	out := dst
 	usedDst := false
 	if cap(out) >= page.PageSize {
 		out = out[:page.PageSize]
-		clear(out)
 		usedDst = true
 	} else {
 		out = make([]byte, page.PageSize)
 	}
-	copy(out[:prefixLen], payload[compactLeafPagePayloadHeaderSize:compactLeafPagePayloadHeaderSize+prefixLen])
-	copy(out[page.PageSize-suffixLen:], payload[compactLeafPagePayloadHeaderSize+prefixLen:])
+	decodeCompactLeafLogPayloadInto(out, payload, prefixLen, suffixLen)
 	return out, usedDst, true, nil
+}
+
+func decodeCompactLeafLogPayloadInto(out, payload []byte, prefixLen, suffixLen int) {
+	src := payload[compactLeafPagePayloadHeaderSize:]
+	copy(out[:prefixLen], src[:prefixLen])
+	if suffixLen > 0 {
+		copy(out[page.PageSize-suffixLen:], src[prefixLen:prefixLen+suffixLen])
+	}
+	clear(out[prefixLen : page.PageSize-suffixLen])
 }
 
 func appendCompactLeafLogPayload(dst, payload []byte) ([]byte, error) {

--- a/TreeDB/internal/valuelog/leaf_page_payload_bench_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_bench_test.go
@@ -111,4 +111,20 @@ func BenchmarkDecodeCompactLeafLogPayloadTo(b *testing.B) {
 			leafPagePayloadBenchSink = out
 		}
 	})
+
+	b.Run("aliased_dst", func(b *testing.B) {
+		dst := make([]byte, page.PageSize)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			copy(dst, payload)
+			out, _, decoded, err := decodeCompactLeafLogPayloadTo(dst[:len(payload)], dst[:0])
+			if err != nil {
+				b.Fatalf("decodeCompactLeafLogPayloadTo: %v", err)
+			}
+			if !decoded {
+				b.Fatal("expected compact payload to decode")
+			}
+			leafPagePayloadBenchSink = out
+		}
+	})
 }

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -176,6 +176,39 @@ func TestDecodeCompactLeafLogPayloadTo_AliasedDstRoundTrips(t *testing.T) {
 	requireLeafPagesLogicallyEqual(t, leaf, decoded)
 }
 
+func TestDecodeCompactLeafLogPayloadTo_AliasedDstDoesNotAllocate(t *testing.T) {
+	leaf := buildSparseLeafPageForPayloadTest(t)
+
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+
+	buf := make([]byte, page.PageSize)
+	var decoded []byte
+	allocs := testing.AllocsPerRun(100, func() {
+		copy(buf, payload)
+		out, usedDst, decodedFlag, err := decodeCompactLeafLogPayloadTo(buf[:len(payload)], buf[:0])
+		if err != nil {
+			t.Fatalf("decodeCompactLeafLogPayloadTo: %v", err)
+		}
+		if !decodedFlag {
+			t.Fatalf("expected compact payload to decode")
+		}
+		if !usedDst {
+			t.Fatalf("expected decode to reuse aliased dst")
+		}
+		decoded = out
+	})
+	if allocs != 0 {
+		t.Fatalf("aliased decode allocations=%v want 0", allocs)
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, decoded)
+}
+
 func TestMaybeCompactLeafLogPayload_PassthroughNonPagePayload(t *testing.T) {
 	raw := []byte("not-a-leaf-page")
 	payload, compacted, err := MaybeCompactLeafLogPayload(raw)


### PR DESCRIPTION
## Summary

- Decode compact leaf-log payloads directly into the caller-provided page buffer even when the compact source payload aliases that destination buffer.
- Remove the defensive `append([]byte(nil), payload...)` allocation in the aliased `ReadUnsafeTo` path.
- Add a regression test proving aliased compact decode reuses dst with zero allocations, plus an `aliased_dst` benchmark variant.

## Validation

- `go test ./TreeDB/internal/valuelog ./TreeDB/caching ./TreeDB/zipper ./cmd/unified_bench ./kvstore/adapters/treedb`
- `go test ./TreeDB/internal/valuelog -run '^$' -bench BenchmarkDecodeCompactLeafLogPayloadTo -benchmem`

Benchmark result on local M3:

```text
BenchmarkDecodeCompactLeafLogPayloadTo/fresh_dst-8          320.6 ns/op   4096 B/op   1 allocs/op
BenchmarkDecodeCompactLeafLogPayloadTo/reused_dst-8          58.96 ns/op     0 B/op   0 allocs/op
BenchmarkDecodeCompactLeafLogPayloadTo/aliased_dst-8         60.63 ns/op     0 B/op   0 allocs/op
```

10M batch_delete profile command:

```sh
./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir "$OUT" -test batch_delete
```

Profile comparison against #1020 head before this PR:

- Before: `/tmp/pr1020_fixed_batch_delete_PUYFFP`, `23,335,959` ops/s, alloc_space `840.39MB`; `decodeCompactLeafLogPayloadTo` allocated `217.28MB`.
- After: `/tmp/pr1020_leaf_decode_fix_Bbe74O`, `24,124,994` ops/s, alloc_space `459.54MB`; `decodeCompactLeafLogPayloadTo` no longer appears as an allocator.
