### PR TITLE
Stream delete-heavy flush merges

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -11405,11 +11405,12 @@ func (it *opRunIter) Key() []byte {
 func (*opRunIter) Close() error { return nil }
 
 type iteratorOpSource struct {
-	iter iterator.UnsafeIterator
+	iter         iterator.UnsafeIterator
+	stableUnsafe bool
 }
 
-func newIteratorOpSource(iter iterator.UnsafeIterator) *iteratorOpSource {
-	return &iteratorOpSource{iter: iter}
+func newIteratorOpSource(iter iterator.UnsafeIterator, stableUnsafe bool) *iteratorOpSource {
+	return &iteratorOpSource{iter: iter, stableUnsafe: stableUnsafe}
 }
 
 func (it *iteratorOpSource) Valid() bool {
@@ -11428,13 +11429,20 @@ func (it *iteratorOpSource) Entry() batch.Entry {
 		return batch.Entry{}
 	}
 	val, ptr, flags := it.iter.UnsafeEntry()
+	key := stableIteratorKey(it.iter, it.stableUnsafe)
+	if !it.stableUnsafe {
+		key = append([]byte(nil), key...)
+		if val != nil {
+			val = append([]byte(nil), val...)
+		}
+	}
 	switch {
 	case flags&node.FlagTombstone != 0:
-		return batch.Entry{Type: batch.OpDelete, Key: it.iter.UnsafeKey()}
+		return batch.Entry{Type: batch.OpDelete, Key: key}
 	case flags&node.FlagPointer != 0:
-		return batch.Entry{Type: batch.OpPut, Key: it.iter.UnsafeKey(), ValuePtr: ptr, IsPtr: true}
+		return batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true}
 	default:
-		return batch.Entry{Type: batch.OpPut, Key: it.iter.UnsafeKey(), Value: val}
+		return batch.Entry{Type: batch.OpPut, Key: key, Value: val}
 	}
 }
 
@@ -11442,14 +11450,22 @@ func (it *iteratorOpSource) Key() []byte {
 	if it == nil || it.iter == nil || !it.iter.Valid() {
 		return nil
 	}
-	return it.iter.UnsafeKey()
+	key := stableIteratorKey(it.iter, it.stableUnsafe)
+	if !it.stableUnsafe {
+		key = append([]byte(nil), key...)
+	}
+	return key
 }
 
 func (it *iteratorOpSource) Close() error {
 	if it == nil || it.iter == nil {
 		return nil
 	}
-	err := it.iter.Close()
+	err := it.iter.Error()
+	cerr := it.iter.Close()
+	if err == nil {
+		err = cerr
+	}
 	it.iter = nil
 	return err
 }
@@ -11613,6 +11629,29 @@ func stableIteratorKey(iter iterator.UnsafeIterator, stableUnsafe bool) []byte {
 		}
 	}
 	return iter.UnsafeKey()
+}
+
+func deleteHeavyStreamingDeleteOps(units []flushUnit, totalLen int) (int, bool) {
+	if len(units) == 0 || totalLen <= 0 {
+		return 0, false
+	}
+	deleteOps := 0
+	for i := range units {
+		provider, ok := units[i].mem.(memtable.OperationMixProvider)
+		if !ok {
+			return 0, false
+		}
+		mix := provider.OperationMix()
+		if mix.Deletes <= 0 {
+			continue
+		}
+		deleteOps += mix.Deletes
+		if deleteOps < 0 {
+			deleteOps = totalLen
+			break
+		}
+	}
+	return deleteOps, deleteOps >= (totalLen+3)/4
 }
 
 func closeOpMergeSources(sources []opMergeSource) error {
@@ -22254,18 +22293,25 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			err       error
 		}
 
-		unitRuns := getUnitRuns(len(units))
-		defer func() {
-			for i := range unitRuns {
-				for _, run := range unitRuns[i] {
-					putEntrySlice(run)
+		streamSources := false
+		if deleteOps, ok := deleteHeavyStreamingDeleteOps(units, totalLen); ok {
+			streamSources = true
+			backendEntriesCap = db.flushBackendEntriesCapForOps(totalLen, deleteOps, sync)
+		}
+
+		var unitRuns [][][]batch.Entry
+		if !streamSources {
+			unitRuns = getUnitRuns(len(units))
+			defer func() {
+				for i := range unitRuns {
+					for _, run := range unitRuns[i] {
+						putEntrySlice(run)
+					}
+					putEntryRuns(unitRuns[i])
 				}
-				putEntryRuns(unitRuns[i])
-			}
-			putUnitRuns(unitRuns)
-		}()
-		unitDeleteOps := make([]int, len(units))
-		{
+				putUnitRuns(unitRuns)
+			}()
+			unitDeleteOps := make([]int, len(units))
 			jobs := make(chan int, len(units))
 			results := make(chan buildResult, len(units))
 			closeCh := db.closeCh
@@ -22350,18 +22396,18 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 			if failed {
 				return false
 			}
-		}
 
-		// Adaptive micro-batching: delete-heavy flushes are expensive to apply in
-		// many intermediate commits (each commit re-writes leaf pages, copying
-		// surviving values). Build runs for every unit so this decision sees the
-		// actual tombstone mix instead of the pre-dedup append-only entry count.
-		deleteOps := 0
-		for _, n := range unitDeleteOps {
-			deleteOps += n
-		}
-		if deleteOps > 0 {
-			backendEntriesCap = db.flushBackendEntriesCapForOps(totalLen, deleteOps, sync)
+			// Adaptive micro-batching: delete-heavy flushes are expensive to apply
+			// in many intermediate commits (each commit re-writes leaf pages,
+			// copying surviving values). The materialized path counts the actual
+			// iterator-visible tombstone mix while building runs.
+			deleteOps := 0
+			for _, n := range unitDeleteOps {
+				deleteOps += n
+			}
+			if deleteOps > 0 {
+				backendEntriesCap = db.flushBackendEntriesCapForOps(totalLen, deleteOps, sync)
+			}
 		}
 
 		reserveChunkOps := totalLen
@@ -22432,13 +22478,25 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 		}()
 		for i := range units {
 			priority := len(units) - 1 - i
-			if len(unitRuns[i]) == 0 {
-				continue
+			var source opMergeSource
+			if streamSources {
+				iter := units[i].mem.NewIterator(nil, nil)
+				source = newIteratorOpSource(iter, stableUnsafeIteratorSlices(units[i].mem))
+			} else {
+				if len(unitRuns[i]) == 0 {
+					continue
+				}
+				source = newOpRunIter(unitRuns[i])
 			}
-			source := newOpRunIter(unitRuns[i])
 			if source.Valid() {
 				sources = append(sources, source)
 				heap = append(heap, opMergeItem{source: source, priority: priority, key: source.Key()})
+				continue
+			}
+			if err := source.Close(); err != nil {
+				db.reportError(fmt.Errorf("cachingdb: flush failed (iter close): %w", err))
+				_ = backendBatch.Close()
+				return false
 			}
 		}
 		for i := len(heap)/2 - 1; i >= 0; i-- {

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -1011,6 +1011,72 @@ func TestFlushLaneOnce_FallsBackFromPointerViewForUnstableIterators(t *testing.T
 	}
 }
 
+func TestFlushLaneOnce_DeleteHeavyParallelStreamsWithoutEntryRuns(t *testing.T) {
+	for _, mode := range []string{"append_only", "hash_sorted"} {
+		t.Run(mode, func(t *testing.T) {
+			testFlushLaneOnceDeleteHeavyParallelStreamsWithoutEntryRuns(t, mode)
+		})
+	}
+}
+
+func testFlushLaneOnceDeleteHeavyParallelStreamsWithoutEntryRuns(t *testing.T, mode string) {
+	t.Helper()
+	lockEntrySlicePoolStateForTest(t)
+
+	dir := t.TempDir()
+	backend := &viewCountingBackend{MockBackend: NewMockBackend()}
+	db, err := Open(dir, backend, Options{
+		FlushThreshold:         1 << 60,
+		MemtableShards:         1,
+		MemtableMode:           mode,
+		MaxQueuedMemtables:     -1,
+		FlushBuildConcurrency:  2,
+		FlushBuildMinEntries:   1,
+		FlushBuildMinUnits:     2,
+		FlushBuildChunkCap:     2,
+		FlushBackendMaxEntries: -1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	oldProcs := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(oldProcs)
+
+	for unit := 0; unit < 2; unit++ {
+		for i := 0; i < 4; i++ {
+			key := []byte{byte('z' - i), byte('0' + unit)}
+			if err := db.Delete(key); err != nil {
+				t.Fatalf("Delete unit %d entry %d: %v", unit, i, err)
+			}
+		}
+		db.mu.Lock()
+		if err := db.rotateMemtableLocked(false); err != nil {
+			db.mu.Unlock()
+			t.Fatalf("rotateMemtableLocked unit %d: %v", unit, err)
+		}
+		db.mu.Unlock()
+	}
+
+	beforeGets := entrySliceFreshAllocTotal.Load() + entrySliceLeaseHitTotal.Load() + entrySlicePoolHitTotal.Load()
+	if !db.flushLaneOnce(false, 0) {
+		t.Fatal("flushLaneOnce returned false")
+	}
+	afterGets := entrySliceFreshAllocTotal.Load() + entrySliceLeaseHitTotal.Load() + entrySlicePoolHitTotal.Load()
+	if afterGets != beforeGets {
+		t.Fatalf("entry slice gets changed by delete-heavy streaming flush: before=%d after=%d", beforeGets, afterGets)
+	}
+
+	_, _, deleteCalls, deleteViewCalls := backend.totals()
+	if deleteCalls != 0 {
+		t.Fatalf("backend Delete calls=%d, want 0", deleteCalls)
+	}
+	if deleteViewCalls != 8 {
+		t.Fatalf("backend DeleteView calls=%d, want 8", deleteViewCalls)
+	}
+}
+
 func TestFlushLaneOnce_ReusesResettableBackendBatchAcrossChunks(t *testing.T) {
 	dir := t.TempDir()
 	backend := &viewCountingBackend{MockBackend: NewMockBackend()}

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -190,6 +190,7 @@ type AppendOnly struct {
 	indexBuf       []int
 	valueArena     appendOnlyValueArena
 	count          int
+	deleteCount    int
 	snapCount      int
 	sizeBytes      int64
 
@@ -1107,6 +1108,7 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		payloadPtr = ptr
 	}
 	if flags&node.FlagTombstone != 0 {
+		m.deleteCount++
 		payloadValue = ""
 		payloadPtr = page.ValuePtr{}
 	} else if flags&node.FlagPointer != 0 {
@@ -1210,6 +1212,7 @@ func (m *AppendOnly) appendEntryTrustedOrderedLocked(key, value []byte, ptr page
 		payloadPtr = ptr
 	}
 	if flags&node.FlagTombstone != 0 {
+		m.deleteCount++
 		payloadValue = ""
 		payloadPtr = page.ValuePtr{}
 	} else if flags&node.FlagPointer != 0 {
@@ -1802,6 +1805,15 @@ func (m *AppendOnly) Len() int {
 	return m.count
 }
 
+func (m *AppendOnly) OperationMix() OperationMix {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return OperationMix{
+		Entries: m.count,
+		Deletes: m.deleteCount,
+	}
+}
+
 func (m *AppendOnly) Freeze() {
 	m.mu.Lock()
 	if m.frozen {
@@ -1974,6 +1986,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry, ent
 		m.indexBuf = m.indexBuf[:0]
 	}
 	m.count = 0
+	m.deleteCount = 0
 	m.sizeBytes = 0
 	m.ordered = true
 	m.latestDirty = false

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -824,3 +824,21 @@ func TestBuildSortedLatestIndicesLockedRetainsGrownIndexBuf(t *testing.T) {
 		t.Fatal("indexBuf does not retain grown indices backing array")
 	}
 }
+
+func TestAppendOnlyOperationMixTracksDeleteEntries(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	m.Set([]byte("k1"), []byte("v1"))
+	m.Delete([]byte("k2"))
+	m.Delete([]byte("k1"))
+
+	mix := m.OperationMix()
+	if mix.Entries != 3 || mix.Deletes != 2 {
+		t.Fatalf("operation mix=(entries=%d deletes=%d), want (3,2)", mix.Entries, mix.Deletes)
+	}
+
+	m.Reset()
+	mix = m.OperationMix()
+	if mix.Entries != 0 || mix.Deletes != 0 {
+		t.Fatalf("operation mix after reset=(entries=%d deletes=%d), want (0,0)", mix.Entries, mix.Deletes)
+	}
+}

--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -87,6 +87,7 @@ type HashSorted struct {
 	sortedValid bool
 	frozen      bool
 	hasDeletes  bool
+	deleteCount int
 	arena       hashArena
 
 	// Incremental ordering:
@@ -197,6 +198,7 @@ func (m *HashSorted) Reset() {
 	m.sortedValid = true
 	m.frozen = false
 	m.hasDeletes = false
+	m.deleteCount = 0
 	m.maxKey = ""
 	m.hasMaxKey = false
 	m.pendingKeys = nil
@@ -350,6 +352,9 @@ func (m *HashSorted) PutWithCallback(key, value []byte, cb func(k, v []byte) err
 			}
 		}
 		oldLen := hashEntryValueSize(ent.flags, ent.value)
+		if ent.flags&node.FlagTombstone != 0 {
+			m.deleteCount--
+		}
 		ent.value = valCopy
 		ent.ptr = page.ValuePtr{}
 		ent.flags = node.FlagInline
@@ -415,6 +420,7 @@ func (m *HashSorted) DeleteWithCallback(key []byte, cb func(k, v []byte) error) 
 			ent.value = nil
 			ent.ptr = page.ValuePtr{}
 			ent.flags = node.FlagTombstone
+			m.deleteCount++
 		}
 		m.mu.Unlock()
 		return nil
@@ -430,6 +436,7 @@ func (m *HashSorted) DeleteWithCallback(key []byte, cb func(k, v []byte) error) 
 	keyStored := bytesToStringNoCopy(keyCopy)
 	m.entries = append(m.entries, hashEntry{flags: node.FlagTombstone})
 	m.items[keyStored] = uint32(len(m.entries) - 1)
+	m.deleteCount++
 	m.sizeBytes += int64(len(keyCopy))
 	m.updateMaxKeyLocked(keyStored)
 	chunk, seq = m.noteNewKeyLocked(keyStored)
@@ -509,6 +516,15 @@ func (m *HashSorted) Len() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return len(m.items)
+}
+
+func (m *HashSorted) OperationMix() OperationMix {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return OperationMix{
+		Entries: len(m.items),
+		Deletes: m.deleteCount,
+	}
 }
 
 func (m *HashSorted) Freeze() {
@@ -897,6 +913,7 @@ func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags 
 	keyLookup := bytesToStringNoCopy(key)
 	if ent, ok := m.entryForWriteLocked(keyLookup); ok {
 		oldLen := hashEntryValueSize(ent.flags, ent.value)
+		oldDeleted := ent.flags&node.FlagTombstone != 0
 		ent.value = m.encodeEntryValueLocked(value, ptr, flags, steal)
 		if flags&node.FlagPointer != 0 {
 			ent.ptr = ptr
@@ -907,6 +924,13 @@ func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags 
 		m.sizeBytes += int64(hashEntryValueSize(ent.flags, ent.value) - oldLen)
 		if flags&node.FlagTombstone != 0 {
 			m.hasDeletes = true
+		}
+		newDeleted := flags&node.FlagTombstone != 0
+		switch {
+		case !oldDeleted && newDeleted:
+			m.deleteCount++
+		case oldDeleted && !newDeleted:
+			m.deleteCount--
 		}
 		return nil, 0
 	}
@@ -928,6 +952,7 @@ func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags 
 	m.sizeBytes += int64(len(keyCopy) + hashEntryValueSize(flags, valCopy))
 	if flags&node.FlagTombstone != 0 {
 		m.hasDeletes = true
+		m.deleteCount++
 	}
 	m.updateMaxKeyLocked(keyStored)
 	return m.noteNewKeyLocked(keyStored)
@@ -960,6 +985,7 @@ func (m *HashSorted) setEntryNewStealNoChunkLocked(op batchpkg.Entry) (string, i
 	m.sizeBytes += int64(len(op.Key) + hashEntryValueSize(flags, val))
 	if flags&node.FlagTombstone != 0 {
 		m.hasDeletes = true
+		m.deleteCount++
 	}
 	// The fast path is append-only and entries are strictly increasing.
 	m.maxKey = keyStored

--- a/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
+++ b/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
@@ -55,3 +55,27 @@ func TestHashSortedApplyStealSortedBatch_DuplicateKeyForcesFallback(t *testing.T
 		t.Fatalf("len=%d want 2", got)
 	}
 }
+
+func TestHashSortedOperationMixTracksCurrentDeletes(t *testing.T) {
+	m := NewHashSorted()
+	m.Set([]byte("k1"), []byte("v1"))
+	m.Delete([]byte("k2"))
+	m.Delete([]byte("k1"))
+
+	mix := m.OperationMix()
+	if mix.Entries != 2 || mix.Deletes != 2 {
+		t.Fatalf("operation mix=(entries=%d deletes=%d), want (2,2)", mix.Entries, mix.Deletes)
+	}
+
+	m.Set([]byte("k1"), []byte("v2"))
+	mix = m.OperationMix()
+	if mix.Entries != 2 || mix.Deletes != 1 {
+		t.Fatalf("operation mix after put=(entries=%d deletes=%d), want (2,1)", mix.Entries, mix.Deletes)
+	}
+
+	m.Reset()
+	mix = m.OperationMix()
+	if mix.Entries != 0 || mix.Deletes != 0 {
+		t.Fatalf("operation mix after reset=(entries=%d deletes=%d), want (0,0)", mix.Entries, mix.Deletes)
+	}
+}

--- a/TreeDB/internal/memtable/memtable.go
+++ b/TreeDB/internal/memtable/memtable.go
@@ -122,6 +122,21 @@ type StableUnsafeIteratorTable interface {
 	StableUnsafeIteratorSlices() bool
 }
 
+// OperationMix describes the operation mix currently retained by a memtable.
+// It is a performance-planning hint, not a correctness contract: implementations
+// may count superseded append-log entries when their iterators later collapse
+// multiple writes to the latest value for a key.
+type OperationMix struct {
+	Entries int
+	Deletes int
+}
+
+// OperationMixProvider marks memtables that can report their write-buffer
+// operation mix without forcing an iterator materialization pass.
+type OperationMixProvider interface {
+	OperationMix() OperationMix
+}
+
 // TrustedSortedBatchApplier is an optional fast path for callers that already
 // guarantee strictly increasing keys (for example, stream-qualified batch
 // writes partitioned by shard while preserving source order).


### PR DESCRIPTION
## Summary
- add memtable operation-mix hints for append-only and hash-sorted memtables
- stream delete-heavy parallel flush merges directly from iterators instead of materializing entry-run slices
- keep the existing materialized path for mixed/non-provider memtables

## Validation
- go test ./TreeDB/internal/valuelog ./TreeDB/caching ./TreeDB/internal/memtable ./TreeDB/zipper ./cmd/unified_bench ./kvstore/adapters/treedb
- ./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_delete_stream_final_batch_delete_lxRTN9 -test batch_delete

## Profile notes
- final local 10M batch_delete run: 24,506,378 ops/s
- alloc profile no longer shows getEntrySlice in the top allocators for that run
- main remaining targets are append-only entry storage, append-only latest-index/snapshot construction, and zipper/leaf-log write amplification
- tried extending the mix hint to BTree, but that produced a severe local regression, so this PR intentionally limits the streaming path to append-only and hash-sorted providers
