### PR TITLE
Limit near-pure delete flush apply passes

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7091,21 +7091,20 @@ func (db *DB) flushBackendEntriesCapForOps(totalOps int, deleteOps int, sync boo
 	// Each commit re-writes leaf pages (copying surviving values), so repeated
 	// commits amplify work dramatically when deletes touch a large fraction of the
 	// keyspace. Favor fewer commits in that case.
-	nearPureDeleteMaxEntries := 0
 	if maxBatches > 0 && deleteOps > 0 && totalOps > 0 {
 		switch {
 		case deleteOps >= totalOps-totalOps/10:
-			// Near-pure delete flushes rewrite most touched leaves on every
-			// intermediate commit. Keep enough chunking to bound backend batch
-			// memory, but avoid repeatedly applying the same broad keyspace churn.
-			if maxBatches > 2 {
-				maxBatches = 2
-			}
+			// Near-pure delete flushes rewrite most touched leaves on every commit.
+			// Use two passes only while the resulting batch cap stays within a
+			// bounded multiple of the configured per-batch cap; larger flushes keep
+			// the existing four-pass delete-heavy behavior instead of trading away
+			// memory headroom for fewer applies.
 			maxInt := int(^uint(0) >> 1)
-			if capEntries > maxInt/4 {
-				nearPureDeleteMaxEntries = maxInt
-			} else {
-				nearPureDeleteMaxEntries = capEntries * 4
+			twoPassBounded := capEntries > maxInt/8 || totalOps <= capEntries*8
+			if twoPassBounded && maxBatches > 2 {
+				maxBatches = 2
+			} else if maxBatches > 4 {
+				maxBatches = 4
 			}
 		case deleteOps >= (totalOps+3)/4:
 			if maxBatches > 4 {
@@ -7125,9 +7124,6 @@ func (db *DB) flushBackendEntriesCapForOps(totalOps int, deleteOps int, sync boo
 				capEntries = 1
 			}
 		}
-	}
-	if nearPureDeleteMaxEntries > 0 && capEntries > nearPureDeleteMaxEntries {
-		capEntries = nearPureDeleteMaxEntries
 	}
 	return capEntries
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7092,9 +7092,18 @@ func (db *DB) flushBackendEntriesCapForOps(totalOps int, deleteOps int, sync boo
 	// commits amplify work dramatically when deletes touch a large fraction of the
 	// keyspace. Favor fewer commits in that case.
 	if maxBatches > 0 && deleteOps > 0 && totalOps > 0 {
-		// Deterministic "delete-heavy" trigger: deletes are at least 25% of ops.
-		if deleteOps*4 >= totalOps && maxBatches > 4 {
-			maxBatches = 4
+		switch {
+		case deleteOps >= totalOps-totalOps/10:
+			// Near-pure delete flushes rewrite most touched leaves on every
+			// intermediate commit. Keep enough chunking to bound backend batch
+			// memory, but avoid repeatedly applying the same broad keyspace churn.
+			if maxBatches > 2 {
+				maxBatches = 2
+			}
+		case deleteOps >= (totalOps+3)/4:
+			if maxBatches > 4 {
+				maxBatches = 4
+			}
 		}
 	}
 	if maxBatches > 0 {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7091,6 +7091,7 @@ func (db *DB) flushBackendEntriesCapForOps(totalOps int, deleteOps int, sync boo
 	// Each commit re-writes leaf pages (copying surviving values), so repeated
 	// commits amplify work dramatically when deletes touch a large fraction of the
 	// keyspace. Favor fewer commits in that case.
+	nearPureDeleteMaxEntries := 0
 	if maxBatches > 0 && deleteOps > 0 && totalOps > 0 {
 		switch {
 		case deleteOps >= totalOps-totalOps/10:
@@ -7099,6 +7100,12 @@ func (db *DB) flushBackendEntriesCapForOps(totalOps int, deleteOps int, sync boo
 			// memory, but avoid repeatedly applying the same broad keyspace churn.
 			if maxBatches > 2 {
 				maxBatches = 2
+			}
+			maxInt := int(^uint(0) >> 1)
+			if capEntries > maxInt/4 {
+				nearPureDeleteMaxEntries = maxInt
+			} else {
+				nearPureDeleteMaxEntries = capEntries * 4
 			}
 		case deleteOps >= (totalOps+3)/4:
 			if maxBatches > 4 {
@@ -7118,6 +7125,9 @@ func (db *DB) flushBackendEntriesCapForOps(totalOps int, deleteOps int, sync boo
 				capEntries = 1
 			}
 		}
+	}
+	if nearPureDeleteMaxEntries > 0 && capEntries > nearPureDeleteMaxEntries {
+		capEntries = nearPureDeleteMaxEntries
 	}
 	return capEntries
 }

--- a/TreeDB/caching/flush_batch_size_test.go
+++ b/TreeDB/caching/flush_batch_size_test.go
@@ -91,8 +91,8 @@ func TestFlushBackendEntriesCapForOpsReducesNearPureDeletePasses(t *testing.T) {
 	if got := db.flushBackendEntriesCapForOps(700, 630, false); got != 350 {
 		t.Fatalf("bounded near-pure delete cap=%d want 350", got)
 	}
-	if got := db.flushBackendEntriesCapForOps(10_000, 9_000, false); got != 400 {
-		t.Fatalf("large near-pure delete cap=%d want 400", got)
+	if got := db.flushBackendEntriesCapForOps(10_000, 9_000, false); got != 2_500 {
+		t.Fatalf("large near-pure delete cap=%d want 2500", got)
 	}
 	if got := db.flushBackendEntriesCapForOps(10_000, 2_500, false); got != 2_500 {
 		t.Fatalf("delete-heavy cap=%d want 2500", got)

--- a/TreeDB/caching/flush_batch_size_test.go
+++ b/TreeDB/caching/flush_batch_size_test.go
@@ -88,8 +88,11 @@ func TestFlushBackendEntriesCapForOpsReducesNearPureDeletePasses(t *testing.T) {
 		flushBackendMaxBatches: 32,
 	}
 
-	if got := db.flushBackendEntriesCapForOps(10_000, 9_000, false); got != 5_000 {
-		t.Fatalf("near-pure delete cap=%d want 5000", got)
+	if got := db.flushBackendEntriesCapForOps(700, 630, false); got != 350 {
+		t.Fatalf("bounded near-pure delete cap=%d want 350", got)
+	}
+	if got := db.flushBackendEntriesCapForOps(10_000, 9_000, false); got != 400 {
+		t.Fatalf("large near-pure delete cap=%d want 400", got)
 	}
 	if got := db.flushBackendEntriesCapForOps(10_000, 2_500, false); got != 2_500 {
 		t.Fatalf("delete-heavy cap=%d want 2500", got)

--- a/TreeDB/caching/flush_batch_size_test.go
+++ b/TreeDB/caching/flush_batch_size_test.go
@@ -82,6 +82,23 @@ func TestFlushCapsBackendBatchSizeHint(t *testing.T) {
 	}
 }
 
+func TestFlushBackendEntriesCapForOpsReducesNearPureDeletePasses(t *testing.T) {
+	db := &DB{
+		flushBackendMaxEntries: 100,
+		flushBackendMaxBatches: 32,
+	}
+
+	if got := db.flushBackendEntriesCapForOps(10_000, 9_000, false); got != 5_000 {
+		t.Fatalf("near-pure delete cap=%d want 5000", got)
+	}
+	if got := db.flushBackendEntriesCapForOps(10_000, 2_500, false); got != 2_500 {
+		t.Fatalf("delete-heavy cap=%d want 2500", got)
+	}
+	if got := db.flushBackendEntriesCapForOps(10_000, 2_499, false); got != 313 {
+		t.Fatalf("non-delete-heavy cap=%d want 313", got)
+	}
+}
+
 func TestWaitForStopSelfHealsStaleBacklogBytes(t *testing.T) {
 	dir := t.TempDir()
 	backend := NewMockBackend()


### PR DESCRIPTION
## Summary
- cap near-pure delete flushes to 2 backend apply passes only when that keeps the computed batch cap within 4x configured FlushBackendMaxEntries
- fall back to the existing 4-pass delete-heavy cap for larger near-pure flushes, preserving FlushBackendMaxBatches semantics
- add direct cap-math coverage for bounded two-pass, large-flush fallback, existing delete-heavy, and non-delete-heavy cases

## Validation
- go test ./TreeDB/internal/valuelog ./TreeDB/caching ./TreeDB/internal/memtable ./TreeDB/zipper ./cmd/unified_bench ./kvstore/adapters/treedb
- ./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_delete_heavy_apply_cap_conditional_batch_delete_TnE6Al -test batch_delete: 25,637,314 ops/s, alloc_space 474.64 MiB, leaf_vlog 1.1 GiB

Notes:
- Earlier unbounded two-pass candidate sampled at 24.38M/24.31M ops/s with alloc_space 403.15/398.17 MiB, but was rejected because backend Reserve could scale toward totalOps/2.
- Earlier final-clamp candidate sampled at 24.62M ops/s and 352.34 MiB alloc_space, but was rejected because it could violate max-batch cap semantics.
- Rejected all-delete flush iterator because duplicate tombstones inflated backend/zipper work and regressed to 2,739,695 ops/s.
