### PR TITLE
Deduplicate repeated append-only inline values

### DIFF
--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -1243,6 +1243,9 @@ func (m *AppendOnly) appendValueBytesLocked(value []byte, borrowed bool) uint32 
 	if idx := m.recentValueIndexLocked(value); idx != 0 {
 		return idx
 	}
+	if len(m.values) == 0 {
+		return m.appendValueLockedSmall(appendOnlyArenaStringCopy(&m.valueArena, value))
+	}
 	return m.appendValueLocked(appendOnlyArenaStringCopy(&m.valueArena, value))
 }
 
@@ -1258,11 +1261,27 @@ func (m *AppendOnly) recentValueIndexLocked(value []byte) uint32 {
 }
 
 func (m *AppendOnly) appendValueLocked(value string) uint32 {
+	return m.appendValueLockedWithPolicy(value, true)
+}
+
+func (m *AppendOnly) appendValueLockedSmall(value string) uint32 {
+	return m.appendValueLockedWithPolicy(value, false)
+}
+
+func (m *AppendOnly) appendValueLockedWithPolicy(value string, useEntryCapHint bool) uint32 {
 	if len(m.values) == cap(m.values) {
 		nextCap := appendOnlyMinInitialEntries
 		if cap(m.values) > 0 {
 			nextCap = appendOnlyNextCapacity(cap(m.values))
-		} else if len(m.values) == m.count-1 {
+			if useEntryCapHint {
+				if entriesCap := cap(m.entries); entriesCap > nextCap {
+					if entriesCap > appendOnlyResetDropThresholdEntries {
+						entriesCap = appendOnlyResetDropThresholdEntries
+					}
+					nextCap = entriesCap
+				}
+			}
+		} else if useEntryCapHint && len(m.values) == m.count-1 {
 			if entriesCap := cap(m.entries); entriesCap > nextCap {
 				if entriesCap > appendOnlyResetDropThresholdEntries {
 					entriesCap = appendOnlyResetDropThresholdEntries

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -44,6 +44,7 @@ const (
 	appendOnlyResetDropThresholdEntries     = 1 << 15
 	appendOnlyAggressiveGrowCutoff          = appendOnlyResetDropThresholdEntries * 2
 	appendOnlyPredictHintMinEntries         = 1 << 10
+	appendOnlyRecentValueDedupeMaxLen       = 256
 )
 
 var appendOnlyEntryPool sync.Pool
@@ -570,6 +571,21 @@ func appendOnlyArenaStringCopy(arena *appendOnlyValueArena, src []byte) string {
 	return appendOnlyStringFromBytes(buf)
 }
 
+func appendOnlyStringEqualBytes(s string, b []byte) bool {
+	if len(s) != len(b) {
+		return false
+	}
+	if len(b) == 0 {
+		return true
+	}
+	// Cheaply reject non-matches before comparing the full payload. This keeps
+	// the repeated-value fast path cheap for random small values.
+	if s[0] != b[0] || s[len(s)-1] != b[len(b)-1] {
+		return false
+	}
+	return bytes.Equal(appendOnlyValueStringBytes(s), b)
+}
+
 func (m *AppendOnly) appendOnlyEntryKey(ent *appendOnlyEntry) []byte {
 	if m == nil {
 		return appendOnlyEntryKeyFromKeys(ent, nil)
@@ -1080,8 +1096,6 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	ent := &m.entries[idx]
 	ent.keyIndex = 0
 	ent.payloadIndex = 0
-	payloadValue := ""
-	payloadPtr := page.ValuePtr{}
 	if len(key) == 0 {
 		appendOnlyEntrySetKeyIndex(ent, m.appendKeyLocked(""))
 	} else if len(key) <= appendOnlyInlineKeyLen {
@@ -1093,31 +1107,26 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		appendOnlyEntrySetKeyIndex(ent, m.appendKeyLocked(appendOnlyArenaStringCopy(&m.valueArena, key)))
 	}
 	appendOnlyEntrySetFlags(ent, flags)
-	if steal {
-		payloadValue = appendOnlyStringFromBytes(value)
-	} else {
+	payloadValueLen := 0
+	if flags&node.FlagTombstone != 0 {
+		m.deleteCount++
+	} else if flags&node.FlagPointer != 0 {
+		payloadValue := ""
 		if len(value) > 0 {
-			if borrowValue {
+			payloadValueLen = len(value)
+			if steal || borrowValue {
 				payloadValue = appendOnlyStringFromBytes(value)
 			} else {
 				payloadValue = appendOnlyArenaStringCopy(&m.valueArena, value)
 			}
 		}
-	}
-	if flags&node.FlagPointer != 0 {
-		payloadPtr = ptr
-	}
-	if flags&node.FlagTombstone != 0 {
-		m.deleteCount++
-		payloadValue = ""
-		payloadPtr = page.ValuePtr{}
-	} else if flags&node.FlagPointer != 0 {
-		appendOnlyEntrySetPayloadIndex(ent, m.appendPtrPayloadLocked(payloadValue, payloadPtr))
-	} else if payloadValue != "" {
-		appendOnlyEntrySetPayloadIndex(ent, m.appendValueLocked(payloadValue))
+		appendOnlyEntrySetPayloadIndex(ent, m.appendPtrPayloadLocked(payloadValue, ptr))
+	} else if len(value) > 0 {
+		payloadValueLen = len(value)
+		appendOnlyEntrySetPayloadIndex(ent, m.appendValueBytesLocked(value, steal || borrowValue))
 	}
 	k := m.appendOnlyEntryKey(ent)
-	m.sizeBytes += int64(len(k) + entryValueSize(flags, len(payloadValue)))
+	m.sizeBytes += int64(len(k) + entryValueSize(flags, payloadValueLen))
 	if appendOnlyShouldPredictHint(m.count) {
 		m.maybeRaisePredictedGrowthHintLocked(&observeEvent)
 	}
@@ -1186,8 +1195,6 @@ func (m *AppendOnly) appendEntryTrustedOrderedLocked(key, value []byte, ptr page
 	ent := &m.entries[idx]
 	ent.keyIndex = 0
 	ent.payloadIndex = 0
-	payloadValue := ""
-	payloadPtr := page.ValuePtr{}
 	if len(key) == 0 {
 		appendOnlyEntrySetKeyIndex(ent, m.appendKeyLocked(""))
 	} else if len(key) <= appendOnlyInlineKeyLen {
@@ -1199,34 +1206,55 @@ func (m *AppendOnly) appendEntryTrustedOrderedLocked(key, value []byte, ptr page
 		appendOnlyEntrySetKeyIndex(ent, m.appendKeyLocked(appendOnlyArenaStringCopy(&m.valueArena, key)))
 	}
 	appendOnlyEntrySetFlags(ent, flags)
-	if steal {
-		payloadValue = appendOnlyStringFromBytes(value)
-	} else if len(value) > 0 {
-		if borrowValue {
-			payloadValue = appendOnlyStringFromBytes(value)
-		} else {
-			payloadValue = appendOnlyArenaStringCopy(&m.valueArena, value)
-		}
-	}
-	if flags&node.FlagPointer != 0 {
-		payloadPtr = ptr
-	}
+	payloadValueLen := 0
 	if flags&node.FlagTombstone != 0 {
 		m.deleteCount++
-		payloadValue = ""
-		payloadPtr = page.ValuePtr{}
 	} else if flags&node.FlagPointer != 0 {
-		appendOnlyEntrySetPayloadIndex(ent, m.appendPtrPayloadLocked(payloadValue, payloadPtr))
-	} else if payloadValue != "" {
-		appendOnlyEntrySetPayloadIndex(ent, m.appendValueLocked(payloadValue))
+		payloadValue := ""
+		if len(value) > 0 {
+			payloadValueLen = len(value)
+			if steal || borrowValue {
+				payloadValue = appendOnlyStringFromBytes(value)
+			} else {
+				payloadValue = appendOnlyArenaStringCopy(&m.valueArena, value)
+			}
+		}
+		appendOnlyEntrySetPayloadIndex(ent, m.appendPtrPayloadLocked(payloadValue, ptr))
+	} else if len(value) > 0 {
+		payloadValueLen = len(value)
+		appendOnlyEntrySetPayloadIndex(ent, m.appendValueBytesLocked(value, steal || borrowValue))
 	}
-	m.sizeBytes += int64(len(key) + entryValueSize(flags, len(payloadValue)))
+	m.sizeBytes += int64(len(key) + entryValueSize(flags, payloadValueLen))
 	if appendOnlyShouldPredictHint(m.count) {
 		m.maybeRaisePredictedGrowthHintLocked(&observeEvent)
 	}
 	m.lastIdx = idx
 	m.hasLast = true
 	return observeEvent
+}
+
+func (m *AppendOnly) appendValueBytesLocked(value []byte, borrowed bool) uint32 {
+	if len(value) == 0 {
+		return 0
+	}
+	if borrowed {
+		return m.appendValueLocked(appendOnlyStringFromBytes(value))
+	}
+	if idx := m.recentValueIndexLocked(value); idx != 0 {
+		return idx
+	}
+	return m.appendValueLocked(appendOnlyArenaStringCopy(&m.valueArena, value))
+}
+
+func (m *AppendOnly) recentValueIndexLocked(value []byte) uint32 {
+	if len(value) == 0 || len(value) > appendOnlyRecentValueDedupeMaxLen || len(m.values) == 0 {
+		return 0
+	}
+	idx := len(m.values) - 1
+	if appendOnlyStringEqualBytes(m.values[idx], value) {
+		return uint32(idx + 1)
+	}
+	return 0
 }
 
 func (m *AppendOnly) appendValueLocked(value string) uint32 {

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -147,6 +147,59 @@ func TestAppendOnlyCRUD(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyRepeatedSmallValueReusesPayloadCopy(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	value1 := []byte("same repeated value")
+	value2 := []byte("same repeated value")
+
+	m.Set([]byte("k1"), value1)
+	value1[0] = 'X'
+	m.Set([]byte("k2"), value2)
+	value2[0] = 'Y'
+
+	if got := len(m.values); got != 1 {
+		t.Fatalf("values=%d want=1", got)
+	}
+	if m.entries[0].payloadIndex == 0 || m.entries[0].payloadIndex != m.entries[1].payloadIndex {
+		t.Fatalf("payload indices=(%d,%d), want shared non-zero index", m.entries[0].payloadIndex, m.entries[1].payloadIndex)
+	}
+	for _, key := range []string{"k1", "k2"} {
+		got, deleted, ok := m.Get([]byte(key))
+		if !ok || deleted || string(got) != "same repeated value" {
+			t.Fatalf("Get(%s)=(%q,%v,%v), want same repeated value,false,true", key, string(got), deleted, ok)
+		}
+	}
+
+	it := m.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	for _, key := range []string{"k1", "k2"} {
+		if !it.Valid() || string(it.Key()) != key {
+			t.Fatalf("iterator key=%q valid=%v, want %s", string(it.Key()), it.Valid(), key)
+		}
+		if got := string(it.Value()); got != "same repeated value" {
+			t.Fatalf("iterator value for %s=%q, want same repeated value", key, got)
+		}
+		it.Next()
+	}
+	if it.Valid() {
+		t.Fatal("iterator should be exhausted")
+	}
+}
+
+func TestAppendOnlyDifferentSmallValuesKeepSeparatePayloads(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+
+	m.Set([]byte("k1"), []byte("first value"))
+	m.Set([]byte("k2"), []byte("second value"))
+
+	if got := len(m.values); got != 2 {
+		t.Fatalf("values=%d want=2", got)
+	}
+	if m.entries[0].payloadIndex == m.entries[1].payloadIndex {
+		t.Fatalf("payload indices=(%d,%d), want distinct indices", m.entries[0].payloadIndex, m.entries[1].payloadIndex)
+	}
+}
+
 func TestAppendOnlyApplyBorrowValueSortedBatch_CopiesKeysBorrowsValues(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	key := []byte("k-short")

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -160,6 +160,9 @@ func TestAppendOnlyRepeatedSmallValueReusesPayloadCopy(t *testing.T) {
 	if got := len(m.values); got != 1 {
 		t.Fatalf("values=%d want=1", got)
 	}
+	if got := cap(m.values); got > appendOnlyMinInitialEntries {
+		t.Fatalf("value cap=%d want <=%d for single repeated payload", got, appendOnlyMinInitialEntries)
+	}
 	if m.entries[0].payloadIndex == 0 || m.entries[0].payloadIndex != m.entries[1].payloadIndex {
 		t.Fatalf("payload indices=(%d,%d), want shared non-zero index", m.entries[0].payloadIndex, m.entries[1].payloadIndex)
 	}
@@ -383,7 +386,7 @@ func TestAppendOnlyApplyBorrowValueSortedBatchIndicesTrusted_FallsBackWhenBatchS
 	}
 }
 
-func TestAppendOnlyFirstPayloadUsesDenseEntryCapacityFloor(t *testing.T) {
+func TestAppendOnlyFirstPayloadKeepsValueSideBufferSmall(t *testing.T) {
 	m := &AppendOnly{
 		entries: make([]appendOnlyEntry, 1024),
 		ordered: true,
@@ -392,11 +395,30 @@ func TestAppendOnlyFirstPayloadUsesDenseEntryCapacityFloor(t *testing.T) {
 
 	m.Set([]byte("k-short"), []byte("value"))
 
-	if got := cap(m.values); got != cap(m.entries) {
-		t.Fatalf("value cap=%d want entry cap=%d", got, cap(m.entries))
+	if got := cap(m.values); got != appendOnlyMinInitialEntries {
+		t.Fatalf("value cap=%d want %d", got, appendOnlyMinInitialEntries)
 	}
 	if got := len(m.values); got != 1 {
 		t.Fatalf("value len=%d want=1", got)
+	}
+}
+
+func TestAppendOnlyDistinctPayloadsGrowValueSideBufferToDenseFloor(t *testing.T) {
+	m := &AppendOnly{
+		entries: make([]appendOnlyEntry, 1024),
+		ordered: true,
+		lastIdx: -1,
+	}
+
+	for i := 0; i <= appendOnlyMinInitialEntries; i++ {
+		m.Set([]byte(fmt.Sprintf("k%03d", i)), []byte(fmt.Sprintf("value-%03d", i)))
+	}
+
+	if got := cap(m.values); got != cap(m.entries) {
+		t.Fatalf("value cap=%d want entry cap=%d", got, cap(m.entries))
+	}
+	if got := len(m.values); got != appendOnlyMinInitialEntries+1 {
+		t.Fatalf("value len=%d want=%d", got, appendOnlyMinInitialEntries+1)
 	}
 }
 


### PR DESCRIPTION
## Summary
- reuse the most recent small inline append-only value payload when a subsequent copied value has identical bytes
- keep a one-value append-only side buffer small, while growing back to the dense entry-capacity floor after many distinct payloads
- keep borrowed/steal ownership semantics unchanged
- add coverage for shared payload indices, caller mutation safety, iterator reads, distinct values, and side-buffer growth policy

## Validation
- go test ./TreeDB/internal/memtable ./TreeDB/caching ./TreeDB/zipper ./cmd/unified_bench ./kvstore/adapters/treedb
- ./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_repeated_value_dedupe_densefix_batch_small_seq_tYyebp -test batch_small_seq
  - Batch Small Seq: 14,217,422 ops/s
  - alloc_space: 435.96MB total, getAppendOnlyValueArenaChunk 7.22MB
  - prior same-stack baseline before this PR: 11,942,524 ops/s, 1,448.18MB total alloc_space, getAppendOnlyValueArenaChunk 900.28MB
- ./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_repeated_value_dedupe_batch_delete_HbvVnc -test batch_delete
  - Batch Delete: 25,240,399 ops/s (recent same-stack confirmation was ~25.64M; within run noise)
- ./bin/unified-bench -dbs treedb -profile fast -keys 1000000 -val-pattern random -profile-dir /tmp/pr_repeated_value_dedupe_densefix_random_smoke_5OiBEn -test batch_small_seq
  - random-value smoke: 10,735,022 ops/s
