### PR TITLE
Stream stable flush sources without entry runs

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -11646,7 +11646,30 @@ func stableIteratorKey(iter iterator.UnsafeIterator, stableUnsafe bool) []byte {
 	return iter.UnsafeKey()
 }
 
-func deleteHeavyStreamingDeleteOps(units []flushUnit, totalLen int) (int, bool) {
+func stableFlushStreamingSources(units []flushUnit) bool {
+	if len(units) == 0 {
+		return false
+	}
+	for i := range units {
+		if units[i].mem == nil || !stableUnsafeIteratorSlices(units[i].mem) {
+			return false
+		}
+	}
+	return true
+}
+
+func stableFlushStreamingPlan(units []flushUnit, totalLen int) (int, bool) {
+	if !stableFlushStreamingSources(units) {
+		return 0, false
+	}
+	deleteOps, ok := flushStreamingDeleteOps(units, totalLen)
+	if !ok {
+		return 0, false
+	}
+	return deleteOps, true
+}
+
+func flushStreamingDeleteOps(units []flushUnit, totalLen int) (int, bool) {
 	if len(units) == 0 || totalLen <= 0 {
 		return 0, false
 	}
@@ -11665,6 +11688,19 @@ func deleteHeavyStreamingDeleteOps(units []flushUnit, totalLen int) (int, bool) 
 			deleteOps = totalLen
 			break
 		}
+	}
+	// OperationMix may include superseded append-log entries; the cap planner is
+	// bounded by iterator-visible ops.
+	if deleteOps > totalLen {
+		deleteOps = totalLen
+	}
+	return deleteOps, true
+}
+
+func deleteHeavyStreamingDeleteOps(units []flushUnit, totalLen int) (int, bool) {
+	deleteOps, ok := flushStreamingDeleteOps(units, totalLen)
+	if !ok {
+		return 0, false
 	}
 	return deleteOps, deleteOps >= (totalLen+3)/4
 }
@@ -22312,6 +22348,11 @@ func (db *DB) flushLaneOnce(sync bool, laneID int) bool {
 		if deleteOps, ok := deleteHeavyStreamingDeleteOps(units, totalLen); ok {
 			streamSources = true
 			backendEntriesCap = db.flushBackendEntriesCapForOps(totalLen, deleteOps, sync)
+		} else if deleteOps, ok := stableFlushStreamingPlan(units, totalLen); ok {
+			streamSources = true
+			if deleteOps > 0 {
+				backendEntriesCap = db.flushBackendEntriesCapForOps(totalLen, deleteOps, sync)
+			}
 		}
 
 		var unitRuns [][][]batch.Entry

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -1019,6 +1019,140 @@ func TestFlushLaneOnce_DeleteHeavyParallelStreamsWithoutEntryRuns(t *testing.T) 
 	}
 }
 
+func TestStableFlushStreamingSources(t *testing.T) {
+	appendOnly := memtable.NewAppendOnlyWithCapacity(0)
+	hashSorted, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("NewWithCapacityMode: %v", err)
+	}
+	btree, err := memtable.NewWithCapacityMode(0, memtable.ModeBTree)
+	if err != nil {
+		t.Fatalf("NewWithCapacityMode btree: %v", err)
+	}
+
+	if !stableFlushStreamingSources([]flushUnit{{mem: appendOnly}, {mem: hashSorted}, {mem: btree}}) {
+		t.Fatal("expected stable memtables to qualify for streaming")
+	}
+	if stableFlushStreamingSources(nil) {
+		t.Fatal("nil unit list should not qualify for streaming")
+	}
+	if stableFlushStreamingSources([]flushUnit{{mem: nil}}) {
+		t.Fatal("nil memtable should not qualify for streaming")
+	}
+	if stableFlushStreamingSources([]flushUnit{{mem: unstableIteratorMemtable{Table: appendOnly}}}) {
+		t.Fatal("unstable iterator memtable should not qualify for streaming")
+	}
+}
+
+func TestFlushStreamingDeleteOps(t *testing.T) {
+	mt := memtable.NewAppendOnlyWithCapacity(0)
+	mt.Set([]byte("a"), []byte("va"))
+	mt.Delete([]byte("b"))
+	mt.Freeze()
+
+	deleteOps, ok := flushStreamingDeleteOps([]flushUnit{{mem: mt}}, mt.Len())
+	if !ok {
+		t.Fatal("expected append-only memtable to report delete mix")
+	}
+	if deleteOps != 1 {
+		t.Fatalf("deleteOps=%d want=1", deleteOps)
+	}
+	if planDeleteOps, ok := stableFlushStreamingPlan([]flushUnit{{mem: mt}}, mt.Len()); !ok {
+		t.Fatal("expected append-only memtable to qualify for stable streaming plan")
+	} else if planDeleteOps != deleteOps {
+		t.Fatalf("stable plan deleteOps=%d want=%d", planDeleteOps, deleteOps)
+	}
+
+	if _, ok := flushStreamingDeleteOps([]flushUnit{{mem: unstableIteratorMemtable{Table: mt}}}, mt.Len()); ok {
+		t.Fatal("unstable wrapper without operation mix should not report delete mix")
+	}
+	btree, err := memtable.NewWithCapacityMode(0, memtable.ModeBTree)
+	if err != nil {
+		t.Fatalf("NewWithCapacityMode btree: %v", err)
+	}
+	btree.Set([]byte("a"), []byte("va"))
+	btree.Freeze()
+	if _, ok := stableFlushStreamingPlan([]flushUnit{{mem: btree}}, btree.Len()); ok {
+		t.Fatal("stable memtable without operation mix should stay on materialized path")
+	}
+}
+
+func TestFlushLaneOnce_StableParallelStreamsWithoutEntryRuns(t *testing.T) {
+	for _, mode := range []string{"append_only", "hash_sorted"} {
+		t.Run(mode, func(t *testing.T) {
+			testFlushLaneOnceStableParallelStreamsWithoutEntryRuns(t, mode)
+		})
+	}
+}
+
+func testFlushLaneOnceStableParallelStreamsWithoutEntryRuns(t *testing.T, mode string) {
+	t.Helper()
+	lockEntrySlicePoolStateForTest(t)
+
+	dir := t.TempDir()
+	backend := &viewCountingBackend{MockBackend: NewMockBackend()}
+	db, err := Open(dir, backend, Options{
+		FlushThreshold:         1 << 60,
+		MemtableShards:         1,
+		MemtableMode:           mode,
+		MaxQueuedMemtables:     -1,
+		FlushBuildConcurrency:  2,
+		FlushBuildMinEntries:   1,
+		FlushBuildMinUnits:     2,
+		FlushBuildChunkCap:     2,
+		FlushBackendMaxEntries: -1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	oldProcs := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(oldProcs)
+
+	const (
+		unitCount      = 2
+		entriesPerUnit = 4
+	)
+	for unit := 0; unit < unitCount; unit++ {
+		for i := 0; i < entriesPerUnit; i++ {
+			key := []byte{byte('a' + unit), byte('0' + i)}
+			if err := db.Set(key, []byte("value")); err != nil {
+				t.Fatalf("Set unit %d entry %d: %v", unit, i, err)
+			}
+		}
+		db.mu.Lock()
+		if err := db.rotateMemtableLocked(false); err != nil {
+			db.mu.Unlock()
+			t.Fatalf("rotateMemtableLocked unit %d: %v", unit, err)
+		}
+		db.mu.Unlock()
+	}
+
+	beforeGets := entrySliceFreshAllocTotal.Load() + entrySliceLeaseHitTotal.Load() + entrySlicePoolHitTotal.Load()
+	if !db.flushLaneOnce(false, 0) {
+		t.Fatal("flushLaneOnce returned false")
+	}
+	afterGets := entrySliceFreshAllocTotal.Load() + entrySliceLeaseHitTotal.Load() + entrySlicePoolHitTotal.Load()
+	if afterGets != beforeGets {
+		t.Fatalf("entry slice gets changed by stable streaming flush: before=%d after=%d", beforeGets, afterGets)
+	}
+
+	setCalls, setViewCalls, deleteCalls, deleteViewCalls := backend.totals()
+	if setCalls != 0 {
+		t.Fatalf("backend Set calls=%d, want 0", setCalls)
+	}
+	if deleteCalls != 0 {
+		t.Fatalf("backend Delete calls=%d, want 0", deleteCalls)
+	}
+	if setViewCalls != unitCount*entriesPerUnit {
+		t.Fatalf("backend SetView calls=%d want=%d", setViewCalls, unitCount*entriesPerUnit)
+	}
+	if deleteViewCalls != 0 {
+		t.Fatalf("backend DeleteView calls=%d, want 0", deleteViewCalls)
+	}
+}
+
 func testFlushLaneOnceDeleteHeavyParallelStreamsWithoutEntryRuns(t *testing.T, mode string) {
 	t.Helper()
 	lockEntrySlicePoolStateForTest(t)


### PR DESCRIPTION
## Summary
- streams parallel flush sources directly when every queued memtable has stable unsafe iterator slices and known operation-mix accounting
- preserves existing delete-heavy streaming and backend batch-cap sizing semantics
- keeps stable-but-mix-unknown memtables on the materialized buildOpRuns path
- adds tests that stable append-only/hash-sorted parallel flushes avoid entry-run slice allocation and still use backend view methods

## Validation
- `go test ./TreeDB/internal/memtable ./TreeDB/caching ./cmd/unified_bench ./kvstore/adapters/treedb`
- `./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_stream_stable_final_batch_small_seq_rerun_w3LwzS -test batch_small_seq` -> 14,693,611 ops/s; alloc_space 360.74MB; `caching.getEntrySlice` absent from alloc top
- earlier same-commit profile `/tmp/pr_stream_stable_final_batch_small_seq_jQjtDc` -> 13,981,977 ops/s; alloc_space 346.15MB; `caching.getEntrySlice` absent from alloc top
- `./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_stream_stable_batch_delete_rerun_9aI5Vm -test batch_delete` -> 25,401,925 ops/s
- `./bin/unified-bench -dbs treedb -profile fast -keys 1000000 -val-pattern random -profile-dir /tmp/pr_stream_stable_random_smoke_C8so2T -test batch_small_seq` -> 11,144,850 ops/s

## Baseline context
Previous #1025 batch_small_seq profile was 14,217,422 ops/s with alloc_space 435.96MB and `caching.getEntrySlice` at 83.22MB. This PR removes that allocation from the top profile; throughput is noisy but does not show a repeatable regression in the local runs.