### PR TITLE
Apply append-only entry hints to new mutables

### DIFF
--- a/TreeDB/caching/append_only_hint_test.go
+++ b/TreeDB/caching/append_only_hint_test.go
@@ -81,6 +81,32 @@ func TestTrimAppendOnlyMemLeasesIgnoresStaleEntryHint(t *testing.T) {
 	}
 }
 
+func TestNewAppendOnlyMutableUsesLearnedEntryHintCapacity(t *testing.T) {
+	db := &DB{backend: NewMockBackend()}
+	const (
+		requestedCap = 4 << 20
+		hintEntries  = 4096
+	)
+	db.appendOnlyEntryHint.Store(hintEntries)
+
+	raw, err := db.newMutableMemtableWithCapacityMode(requestedCap, memtable.ModeAppendOnly)
+	if err != nil {
+		t.Fatalf("newMutableMemtableWithCapacityMode: %v", err)
+	}
+	mt, ok := raw.(*memtable.AppendOnly)
+	if !ok {
+		t.Fatalf("expected append-only memtable, got %T", raw)
+	}
+
+	if got := appendOnlyEntriesLenForTest(mt); got != hintEntries {
+		t.Fatalf("entry len=%d want learned hint=%d", got, hintEntries)
+	}
+}
+
+func appendOnlyEntriesLenForTest(mt *memtable.AppendOnly) int {
+	return reflect.ValueOf(mt).Elem().FieldByName("entries").Len()
+}
+
 func appendOnlyEntriesCapForTest(mt *memtable.AppendOnly) int {
 	return reflect.ValueOf(mt).Elem().FieldByName("entries").Cap()
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7861,16 +7861,17 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 	if db != nil && mode == memtable.ModeAppendOnly {
 		estimate := appendOnlyEstimatedBytesPerEntryDefault
 		entryHint := db.appendOnlyEntryHintEntries()
+		resetCapacity := db.appendOnlyMemtableCapacityHint(capacity, estimate)
 		if mt := db.popAppendOnlyMemLease(); mt != nil {
 			db.appendOnlyMemLeaseHitTotal.Add(1)
-			mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
+			mt.ResetWithCapacityAndEntryHint(resetCapacity, estimate, entryHint)
 			db.setAppendOnlyPredictiveGrowthHint(mt, capacity)
 			return mt, nil
 		}
 		if v := db.appendOnlyMemPool.Get(); v != nil {
 			if mt, ok := v.(*memtable.AppendOnly); ok && mt != nil {
 				db.appendOnlyMemPoolHitTotal.Add(1)
-				mt.ResetWithCapacityAndEntryHint(capacity, estimate, entryHint)
+				mt.ResetWithCapacityAndEntryHint(resetCapacity, estimate, entryHint)
 				db.setAppendOnlyPredictiveGrowthHint(mt, capacity)
 				return mt, nil
 			}
@@ -7882,7 +7883,7 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 			db.appendOnlyMemNewAllocQueueBytes.Add(uint64(backlog))
 		}
 		db.appendOnlyMemNewAllocTotal.Add(1)
-		mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(capacity, estimate, entryHint)
+		mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytesAndHint(resetCapacity, estimate, entryHint)
 		db.setAppendOnlyPredictiveGrowthHint(mt, capacity)
 		return mt, nil
 	}


### PR DESCRIPTION
## Summary
- applies the learned append-only entry-count capacity hint when allocating fresh mutable append-only memtables
- keeps the original requested capacity as the predictive growth target, so the smaller initial slice can still grow to the full flush threshold when the workload requires it
- adds coverage that a learned entry hint changes the new mutable entry-slice length

## Validation
- `go test ./TreeDB/internal/memtable ./TreeDB/caching ./cmd/unified_bench ./kvstore/adapters/treedb`
- `./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_append_only_entry_hint_batch_small_seq_2C2137 -test batch_small_seq` -> 14,641,362 ops/s; alloc_space 322.37MB; `getAppendOnlyEntriesFromPool` 194.99MB with new mutable allocation down to 118.18MB
- `./bin/unified-bench -dbs treedb -profile fast -keys 10000000 -profile-dir /tmp/pr_append_only_entry_hint_batch_delete_KMBtI8 -test batch_delete` -> 25,179,810 ops/s
- `./bin/unified-bench -dbs treedb -profile fast -keys 1000000 -val-pattern random -profile-dir /tmp/pr_append_only_entry_hint_random_smoke_rerun_N9z7yl -test batch_small_seq` -> 10,881,087 ops/s

## Baseline context
The parent #1026 removed `caching.getEntrySlice` and had batch_small_seq alloc_space around 346-361MB in local profile runs. This PR lowers that to 322.37MB by reducing fresh mutable entry-slice over-allocation after the workload shape is learned. Throughput remains in the same local noisy band.