### PR TITLE
Deduplicate repeated batch values

### DIFF
--- a/TreeDB/caching/batch_arena_ownership_test.go
+++ b/TreeDB/caching/batch_arena_ownership_test.go
@@ -17,6 +17,64 @@ func batchArenaChunkPtr(buf []byte) unsafe.Pointer {
 	return unsafe.Pointer(unsafe.SliceData(buf[:1]))
 }
 
+func batchSlicePtr(buf []byte) unsafe.Pointer {
+	if len(buf) == 0 {
+		return nil
+	}
+	return unsafe.Pointer(unsafe.SliceData(buf))
+}
+
+func TestBatchSetDedupesRepeatedCopiedValues(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir, NewMockBackend(), Options{
+		AllowUnsafe:    true,
+		DisableWAL:     true,
+		MemtableMode:   "btree",
+		MemtableShards: 1,
+		FlushThreshold: 1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	value := bytes.Repeat([]byte{0x11}, 128)
+	sameValue := bytes.Clone(value)
+	otherValue := bytes.Repeat([]byte{0x22}, 128)
+
+	b := db.NewBatchWithSize(3)
+	defer func() { _ = b.Close() }()
+	if err := b.Set([]byte("a"), value); err != nil {
+		t.Fatalf("set a: %v", err)
+	}
+	value[0] = 0xff
+	if err := b.Set([]byte("b"), sameValue); err != nil {
+		t.Fatalf("set b: %v", err)
+	}
+	if err := b.Set([]byte("c"), otherValue); err != nil {
+		t.Fatalf("set c: %v", err)
+	}
+
+	if got, want := len(b.entries), 3; got != want {
+		t.Fatalf("entries=%d want=%d", got, want)
+	}
+	if !bytes.Equal(b.entries[0].Value, sameValue) || !bytes.Equal(b.entries[1].Value, sameValue) {
+		t.Fatalf("deduped values changed: got %x and %x want %x", b.entries[0].Value, b.entries[1].Value, sameValue)
+	}
+	if batchSlicePtr(b.entries[0].Value) != batchSlicePtr(b.entries[1].Value) {
+		t.Fatal("repeated copied values do not share the batch-owned value slice")
+	}
+	if batchSlicePtr(b.entries[0].Key) == batchSlicePtr(b.entries[1].Key) {
+		t.Fatal("distinct keys unexpectedly share storage")
+	}
+	if batchSlicePtr(b.entries[1].Value) == batchSlicePtr(b.entries[2].Value) {
+		t.Fatal("different values unexpectedly share storage")
+	}
+	if got, want := b.copyBytes, len("a")+len(sameValue)+len("b")+len("c")+len(otherValue); got != want {
+		t.Fatalf("copyBytes=%d want=%d", got, want)
+	}
+}
+
 func TestBatchReset_DoesNotCorruptPriorBorrowedWrites(t *testing.T) {
 	for _, mode := range []string{"append_only", "hash_sorted"} {
 		t.Run(mode, func(t *testing.T) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -27051,6 +27051,7 @@ type Batch struct {
 	ptrCopyArena       []byte
 	ptrCopyArenaChunks [][]byte
 	ptrCopyBytes       int
+	lastCopiedValue    []byte
 	arenaInFlightBytes int64
 	ptrValueIdxs       []int
 	walBuf             []logRecord
@@ -27549,6 +27550,7 @@ func (b *Batch) Reset() {
 	b.hasViewOps = false
 	b.firstKey = nil
 	b.lastKey = nil
+	b.lastCopiedValue = nil
 	b.batchRange = keyRange{}
 	b.maxEntries = 0
 	if b.ptrValueIdxs != nil {
@@ -27592,6 +27594,7 @@ func (b *Batch) drainCopyArenaChunks() [][]byte {
 	b.copyArenaChunks = nil
 	b.copyArena = nil
 	b.copyBytes = 0
+	b.lastCopiedValue = nil
 	return chunks
 }
 
@@ -27648,6 +27651,7 @@ func (b *Batch) retainCopyArenaChunkOnReset() bool {
 	b.copyArenaChunks = b.copyArenaChunks[:1]
 	b.copyArena = retained
 	b.copyBytes = 0
+	b.lastCopiedValue = nil
 	return true
 }
 
@@ -27679,6 +27683,7 @@ func (b *Batch) reclaimOwnedCopyArenaChunks(chunks [][]byte) {
 	b.copyArena = retained
 	b.copyArenaChunks = chunks[:1]
 	b.copyBytes = 0
+	b.lastCopiedValue = nil
 	b.addArenaInFlightBytes(cap(retained))
 }
 
@@ -27817,8 +27822,12 @@ func (b *Batch) cloneValue(value []byte) []byte {
 	if len(value) > 0 {
 		batchArenaCopyValueBytesTotal.Add(uint64(len(value)))
 	}
+	if val, ok := b.reuseLastCopiedValue(value); ok {
+		return val
+	}
 	dst := b.arenaCopy(len(value))
 	copy(dst, value)
+	b.rememberLastCopiedValue(dst)
 	return dst
 }
 
@@ -27827,12 +27836,46 @@ func (b *Batch) cloneKeyValue(key, value []byte) ([]byte, []byte) {
 	if n := len(key) + len(value); n > 0 {
 		batchArenaCopyKeyValueBytesTotal.Add(uint64(n))
 	}
+	if valCopy, ok := b.reuseLastCopiedValue(value); ok {
+		keyCopy := b.arenaCopy(len(key))
+		copy(keyCopy, key)
+		return keyCopy, valCopy
+	}
 	buf := b.arenaCopy(len(key) + len(value))
 	keyCopy := buf[:len(key):len(key)]
 	copy(keyCopy, key)
 	valCopy := buf[len(key):]
 	copy(valCopy, value)
+	b.rememberLastCopiedValue(valCopy)
 	return keyCopy, valCopy
+}
+
+func (b *Batch) reuseLastCopiedValue(value []byte) ([]byte, bool) {
+	if b == nil || len(value) == 0 || len(value) > batchCopyValueDedupeMax {
+		return nil, false
+	}
+	last := b.lastCopiedValue
+	if len(last) != len(value) {
+		return nil, false
+	}
+	if len(value) > 1 && (last[0] != value[0] || last[len(last)-1] != value[len(value)-1]) {
+		return nil, false
+	}
+	if !bytes.Equal(last, value) {
+		return nil, false
+	}
+	return last, true
+}
+
+func (b *Batch) rememberLastCopiedValue(value []byte) {
+	if b == nil {
+		return
+	}
+	if len(value) == 0 || len(value) > batchCopyValueDedupeMax {
+		b.lastCopiedValue = nil
+		return
+	}
+	b.lastCopiedValue = value
 }
 
 func (b *Batch) clonePtrValue(value []byte) []byte {
@@ -27913,6 +27956,9 @@ func (b *Batch) releaseCompactedBatchArenaTail(kind batchArenaKind, chunks *[][]
 	if b.db != nil {
 		b.db.noteBatchArenaChunkFinalize(kind, used, classCap)
 		b.db.noteBatchArenaTailCompact(copiedBytes, classCap)
+	}
+	if kind == batchArenaKindMain {
+		b.lastCopiedValue = nil
 	}
 	*arena = nil
 }
@@ -28282,6 +28328,7 @@ const (
 	batchCopyArenaUnsizedInit   = 8 << 10
 	batchCopyArenaBytesPerEntry = 192
 	batchCopyArenaInitMax       = 2 << 20
+	batchCopyValueDedupeMax     = 1 << 20
 	// Keep retained batch-copy chunks bounded to 1MiB. Larger chunks are often
 	// underfilled in restore-heavy traffic and can disproportionately inflate
 	// peak RSS when multiple memtable views pin retired arenas.
@@ -29983,6 +30030,7 @@ func (b *Batch) Close() error {
 	b.ptrTouchedMems = nil
 	b.firstKey = nil
 	b.lastKey = nil
+	b.lastCopiedValue = nil
 	b.ptrValueIdxs = nil
 	return nil
 }


### PR DESCRIPTION
## Summary
- reuse the last owned batch value slice when subsequent copied batch values are byte-identical
- keep keys independently owned and clear the cached value whenever batch arena ownership changes
- add ownership coverage for repeated value dedupe, source mutation, and non-identical values

## Validation
- go test ./TreeDB/caching ./TreeDB/internal/memtable
- ./bin/unified-bench -dbs treedb -profile fast -treedb-memtable-mode btree -keys 1000000 -profile-dir /tmp/profile_btree_batch_value_dedupe_targeted_1m_0UNYId -test sequential_write,dataset_write_sorted,batch_write,batch_write_steady,batch_random,batch_delete,batch_small_seq,random_delete

## Profile Notes
- batch_random improved to 1,665,008 ops/s in the target run
- batch_random alloc_space dropped to 251.87MB; getBatchArena dropped to 6.38MB from the prior ~148MB hotspot