### PR TITLE
Add BTree copy sorted index applier

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -29311,7 +29311,20 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			storeInlinePtrValues := !b.db.memtableValueLogPointers
 			firstKey := b.entries[idxs[0]].Key
 			lastKey := b.entries[idxs[len(idxs)-1]].Key
-			if useStream && useSteal {
+			handledCopyStream := false
+			if useStream && !useSteal {
+				if applier, ok := shard.mem.(memtable.TrustedSortedBatchCopyIndexApplier); ok {
+					applier.ApplyCopySortedBatchIndicesTrusted(b.entries, idxs, storeInlinePtrValues, nil)
+					shard.rng.add(firstKey)
+					if len(idxs) > 1 {
+						shard.rng.add(lastKey)
+					}
+					handledCopyStream = true
+				}
+			}
+			if handledCopyStream {
+				// Applied by a copy-owning sorted index fast path above.
+			} else if useStream && useSteal {
 				if applier, ok := shard.mem.(memtable.TrustedSortedBatchIndexApplier); ok {
 					applier.ApplyStealSortedBatchIndicesTrusted(b.entries, idxs, nil)
 				} else {

--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -104,6 +104,26 @@ func (m *BTree) ApplyStealSortedBatchIndicesTrusted(entries []batchpkg.Entry, id
 	m.applyStealSortedBatch(entries, idxs, onKey)
 }
 
+func (m *BTree) ApplyCopySortedBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, storeInlinePtrValues bool, onKey func(key []byte)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, idx := range idxs {
+		op := entries[idx]
+		if op.Key == nil {
+			continue
+		}
+		keyCopy := m.arena.Copy(op.Key)
+		keyStr := bytesToStringNoCopy(keyCopy)
+		entry := m.btreeEntryCopyFromBatchOpLocked(op, storeInlinePtrValues)
+		prev, replaced := m.setMaybeSortedLoadLocked(keyStr, entry)
+		m.recordSetLocked(keyStr, len(keyCopy), entry, prev, replaced)
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+}
+
 func (m *BTree) applyStealSortedBatch(entries []batchpkg.Entry, idxs []int, onKey func(key []byte)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -129,6 +149,28 @@ func (m *BTree) applyStealSortedBatch(entries []batchpkg.Entry, idxs []int, onKe
 	}
 	for _, idx := range idxs {
 		apply(entries[idx])
+	}
+}
+
+func (m *BTree) btreeEntryCopyFromBatchOpLocked(op batchpkg.Entry, storeInlinePtrValues bool) btreeEntry {
+	switch {
+	case op.Type == batchpkg.OpDelete:
+		return btreeEntry{flags: node.FlagTombstone}
+	case op.IsPtr:
+		value := op.Value
+		if !storeInlinePtrValues {
+			value = nil
+		}
+		return btreeEntry{
+			value: m.copyPointerValueLocked(op.ValuePtr, value),
+			flags: node.FlagPointer,
+		}
+	default:
+		value := canonicalizeBTreeInlineValue(op.Value)
+		return btreeEntry{
+			value: m.copyInlineValueLocked(value),
+			flags: node.FlagInline,
+		}
 	}
 }
 

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -309,6 +309,44 @@ func TestBTreeApplyStealSortedBatchIndicesTrusted(t *testing.T) {
 	}
 }
 
+func TestBTreeApplyCopySortedBatchIndicesTrustedCopiesKeyValue(t *testing.T) {
+	m := NewBTree()
+	key := []byte("a")
+	value := []byte("value-a")
+	entries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: []byte("ignore"), Value: []byte("skip")},
+		{Type: batchpkg.OpPut, Key: key, Value: value},
+		{Type: batchpkg.OpDelete, Key: []byte("b")},
+	}
+
+	var seen []string
+	m.ApplyCopySortedBatchIndicesTrusted(entries, []int{1, 2}, false, func(key []byte) {
+		seen = append(seen, string(key))
+	})
+
+	got, _, _, ok := m.GetEntry([]byte("a"))
+	if !ok || string(got) != "value-a" {
+		t.Fatalf("GetEntry(a)=(%q,%v), want value-a,true", string(got), ok)
+	}
+	if unsafe.SliceData(got) == unsafe.SliceData(value) {
+		t.Fatal("copy sorted batch value aliases caller storage")
+	}
+	key[0] = 'z'
+	value[0] = 'X'
+	if got, _, ok := m.Get([]byte("a")); !ok || string(got) != "value-a" {
+		t.Fatalf("stored entry changed after caller mutation: got=(%q,%v)", string(got), ok)
+	}
+	if _, _, ok := m.Get([]byte("ignore")); ok {
+		t.Fatal("ignored entry was applied")
+	}
+	if got, del, ok := m.Get([]byte("b")); !ok || !del || got != nil {
+		t.Fatalf("Get(b)=(%v,%v,%v), want (nil,true,true)", got, del, ok)
+	}
+	if want := []string{"a", "b"}; !equalStrings(seen, want) {
+		t.Fatalf("onKey saw %v want %v", seen, want)
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -347,6 +347,54 @@ func TestBTreeApplyCopySortedBatchIndicesTrustedCopiesKeyValue(t *testing.T) {
 	}
 }
 
+func TestBTreeApplyCopySortedBatchIndicesTrustedPointerTail(t *testing.T) {
+	ptr := page.ValuePtr{Offset: 7, Length: 11, FileID: 2}
+
+	t.Run("omits inline tail", func(t *testing.T) {
+		m := NewBTree()
+		tail := []byte("tail")
+		entries := []batchpkg.Entry{{
+			Type:     batchpkg.OpPut,
+			Key:      []byte("ptr"),
+			Value:    tail,
+			ValuePtr: ptr,
+			IsPtr:    true,
+		}}
+
+		m.ApplyCopySortedBatchIndicesTrusted(entries, []int{0}, false, nil)
+		got, gotPtr, flags, ok := m.GetEntry([]byte("ptr"))
+		if !ok || got != nil || gotPtr != ptr || flags != node.FlagPointer {
+			t.Fatalf("GetEntry(ptr)=(%v,%+v,%d,%v), want (nil,%+v,%d,true)", got, gotPtr, flags, ok, ptr, node.FlagPointer)
+		}
+	})
+
+	t.Run("copies inline tail", func(t *testing.T) {
+		m := NewBTree()
+		tail := []byte("tail")
+		entries := []batchpkg.Entry{{
+			Type:     batchpkg.OpPut,
+			Key:      []byte("ptr"),
+			Value:    tail,
+			ValuePtr: ptr,
+			IsPtr:    true,
+		}}
+
+		m.ApplyCopySortedBatchIndicesTrusted(entries, []int{0}, true, nil)
+		got, gotPtr, flags, ok := m.GetEntry([]byte("ptr"))
+		if !ok || string(got) != "tail" || gotPtr != ptr || flags != node.FlagPointer {
+			t.Fatalf("GetEntry(ptr)=(%q,%+v,%d,%v), want (tail,%+v,%d,true)", string(got), gotPtr, flags, ok, ptr, node.FlagPointer)
+		}
+		if unsafe.SliceData(got) == unsafe.SliceData(tail) {
+			t.Fatal("copy sorted batch pointer tail aliases caller storage")
+		}
+		tail[0] = 'X'
+		got, gotPtr, flags, ok = m.GetEntry([]byte("ptr"))
+		if !ok || string(got) != "tail" || gotPtr != ptr || flags != node.FlagPointer {
+			t.Fatalf("GetEntry(ptr) after caller mutation=(%q,%+v,%d,%v), want (tail,%+v,%d,true)", string(got), gotPtr, flags, ok, ptr, node.FlagPointer)
+		}
+	})
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/TreeDB/internal/memtable/memtable.go
+++ b/TreeDB/internal/memtable/memtable.go
@@ -144,6 +144,12 @@ type TrustedSortedBatchApplier interface {
 	ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKey func(key []byte))
 }
 
+// TrustedSortedBatchCopyIndexApplier consumes a sorted index list into a shared
+// batch entry slice while copying key/value bytes into memtable-owned storage.
+type TrustedSortedBatchCopyIndexApplier interface {
+	ApplyCopySortedBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, storeInlinePtrValues bool, onKey func(key []byte))
+}
+
 // TrustedSortedBatchBorrowValueApplier is an optional fast path for callers
 // that already guarantee strictly increasing keys and immutable borrowed value
 // slices.

--- a/TreeDB/internal/memtable/memtable.go
+++ b/TreeDB/internal/memtable/memtable.go
@@ -145,7 +145,9 @@ type TrustedSortedBatchApplier interface {
 }
 
 // TrustedSortedBatchCopyIndexApplier consumes a sorted index list into a shared
-// batch entry slice while copying key/value bytes into memtable-owned storage.
+// batch entry slice while copying keys into memtable-owned storage. Pointer
+// ValuePtr bytes are always copied, and inline tail bytes for pointer entries
+// are copied only when storeInlinePtrValues is true.
 type TrustedSortedBatchCopyIndexApplier interface {
 	ApplyCopySortedBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, storeInlinePtrValues bool, onKey func(key []byte))
 }


### PR DESCRIPTION
## Summary
- add a copy-owning sorted index applier interface for memtables
- implement it for BTree so sorted stream writes can avoid per-shard batch.Entry materialization without borrowing batch arenas
- use the BTree copy applier when steal is suppressed, preserving deferred-pressure safety while keeping a one-lock sorted ingest path

## Validation
- go test ./TreeDB/internal/memtable ./TreeDB/caching
- go test ./TreeDB/...
- ./bin/unified-bench -dbs treedb -profile fast -treedb-memtable-mode btree -keys 1000000 -profile-dir /tmp/profile_btree_copy_index_applier_targeted_1m_repeat_6Suqbb -test sequential_write,dataset_write_sorted,batch_write,batch_write_steady,batch_random,batch_delete,batch_small_seq,random_delete

## Benchmark Notes
Compared with compact-entry profile /tmp/profile_btree_compact_entry_targeted_1m_9KodFc:
- batch_write: 8.01M -> 13.21M
- batch_small_seq: 6.81M -> 10.67M
- batch_random: 1.51M -> 2.94M on repeat run
- batch_delete roughly neutral: 2.75M -> 2.76M
- batch_write_steady full-run remains in the same range but noisy; standalone targeted run was 3.24M
