### PR TITLE
Adapt BTree arena chunk growth

### DIFF
--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -183,7 +183,7 @@ func NewBTreeWithDegree(degree int) *BTree {
 		tree:   btree.NewMap[string, btreeEntry](degree),
 		degree: degree,
 		arena: &btreeArena{
-			chunkSize:        btreeArenaChunkSize,
+			maxChunkSize:     btreeArenaChunkSize,
 			initialChunkSize: btreeArenaInitialChunkSize,
 		},
 	}
@@ -785,7 +785,7 @@ func (m *BTree) recordSetLocked(key string, keyLen int, entry, prev btreeEntry, 
 }
 
 type btreeArena struct {
-	chunkSize        int
+	maxChunkSize     int
 	initialChunkSize int
 	chunks           [][]byte
 	offset           int
@@ -800,7 +800,7 @@ func (a *btreeArena) resetKeepFirstChunk() {
 		return
 	}
 	first := a.chunks[0]
-	first = first[:len(first)]
+	first = first[:cap(first)]
 	a.chunks = a.chunks[:1]
 	a.chunks[0] = first
 	a.offset = 0
@@ -832,7 +832,7 @@ func (a *btreeArena) currentChunk(n int) []byte {
 	if len(a.chunks) == 0 {
 		size := a.initialChunkSize
 		if size <= 0 {
-			size = a.chunkSize
+			size = a.maxChunkSize
 		}
 		if size < n {
 			size = n
@@ -846,11 +846,11 @@ func (a *btreeArena) currentChunk(n int) []byte {
 		return chunk
 	}
 	size := len(chunk) * 2
-	if max := a.chunkSize; max > 0 && size > max {
+	if max := a.maxChunkSize; max > 0 && size > max {
 		size = max
 	}
 	if size <= 0 {
-		size = a.chunkSize
+		size = a.maxChunkSize
 	}
 	if size < n {
 		size = n

--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -15,6 +15,7 @@ import (
 const btreeDefaultDegree = 32
 const btreeUseLoadFastPath = false
 const btreeArenaChunkSize = 1 << 20
+const btreeArenaInitialChunkSize = 64 << 10
 const btreeInlineValueDedupeMax = 1 << 20
 
 type btreeEntry struct {
@@ -182,7 +183,8 @@ func NewBTreeWithDegree(degree int) *BTree {
 		tree:   btree.NewMap[string, btreeEntry](degree),
 		degree: degree,
 		arena: &btreeArena{
-			chunkSize: btreeArenaChunkSize,
+			chunkSize:        btreeArenaChunkSize,
+			initialChunkSize: btreeArenaInitialChunkSize,
 		},
 	}
 }
@@ -783,9 +785,10 @@ func (m *BTree) recordSetLocked(key string, keyLen int, entry, prev btreeEntry, 
 }
 
 type btreeArena struct {
-	chunkSize int
-	chunks    [][]byte
-	offset    int
+	chunkSize        int
+	initialChunkSize int
+	chunks           [][]byte
+	offset           int
 }
 
 func (a *btreeArena) resetKeepFirstChunk() {
@@ -827,7 +830,10 @@ func (a *btreeArena) currentChunk(n int) []byte {
 		return make([]byte, n)
 	}
 	if len(a.chunks) == 0 {
-		size := a.chunkSize
+		size := a.initialChunkSize
+		if size <= 0 {
+			size = a.chunkSize
+		}
 		if size < n {
 			size = n
 		}
@@ -839,7 +845,13 @@ func (a *btreeArena) currentChunk(n int) []byte {
 	if a.offset+n <= len(chunk) {
 		return chunk
 	}
-	size := a.chunkSize
+	size := len(chunk) * 2
+	if max := a.chunkSize; max > 0 && size > max {
+		size = max
+	}
+	if size <= 0 {
+		size = a.chunkSize
+	}
 	if size < n {
 		size = n
 	}

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -215,6 +215,87 @@ func TestBTreeSetEntryDedupesRepeatedCopiedInlineValues(t *testing.T) {
 	}
 }
 
+func TestBTreeArenaUsesSmallInitialChunkThenGrows(t *testing.T) {
+	a := &btreeArena{
+		chunkSize:        256,
+		initialChunkSize: 32,
+	}
+
+	if got := len(a.Copy(make([]byte, 8))); got != 8 {
+		t.Fatalf("first copy len=%d want 8", got)
+	}
+	if got := arenaChunkSizes(a); !equalInts(got, []int{32}) {
+		t.Fatalf("chunks after first copy=%v want [32]", got)
+	}
+
+	a.Copy(make([]byte, 25))
+	if got := arenaChunkSizes(a); !equalInts(got, []int{32, 64}) {
+		t.Fatalf("chunks after second copy=%v want [32 64]", got)
+	}
+
+	a.Copy(make([]byte, 50))
+	if got := arenaChunkSizes(a); !equalInts(got, []int{32, 64, 128}) {
+		t.Fatalf("chunks after third copy=%v want [32 64 128]", got)
+	}
+
+	a.Copy(make([]byte, 100))
+	if got := arenaChunkSizes(a); !equalInts(got, []int{32, 64, 128, 256}) {
+		t.Fatalf("chunks after capped growth=%v want [32 64 128 256]", got)
+	}
+}
+
+func TestBTreeArenaLargeAllocationCanExceedInitialChunk(t *testing.T) {
+	a := &btreeArena{
+		chunkSize:        256,
+		initialChunkSize: 32,
+	}
+
+	got := a.Copy(make([]byte, 96))
+	if len(got) != 96 {
+		t.Fatalf("large copy len=%d want 96", len(got))
+	}
+	if sizes := arenaChunkSizes(a); !equalInts(sizes, []int{96}) {
+		t.Fatalf("chunks=%v want [96]", sizes)
+	}
+
+	got = a.Copy(make([]byte, 300))
+	if len(got) != 300 {
+		t.Fatalf("oversized copy len=%d want 300", len(got))
+	}
+	if sizes := arenaChunkSizes(a); !equalInts(sizes, []int{96, 300}) {
+		t.Fatalf("chunks=%v want [96 300]", sizes)
+	}
+}
+
+func TestBTreeResetKeepsFirstArenaChunk(t *testing.T) {
+	m := NewBTree()
+	m.Set([]byte("key"), []byte("value"))
+	if len(m.arena.chunks) != 1 {
+		t.Fatalf("chunks after first set=%d want 1", len(m.arena.chunks))
+	}
+	first := &m.arena.chunks[0][0]
+	if got := len(m.arena.chunks[0]); got != btreeArenaInitialChunkSize {
+		t.Fatalf("first chunk size=%d want %d", got, btreeArenaInitialChunkSize)
+	}
+	if m.arena.offset == 0 {
+		t.Fatal("arena offset is zero after set")
+	}
+
+	m.Reset()
+	if len(m.arena.chunks) != 1 {
+		t.Fatalf("chunks after reset=%d want 1", len(m.arena.chunks))
+	}
+	if got := len(m.arena.chunks[0]); got != btreeArenaInitialChunkSize {
+		t.Fatalf("retained chunk size=%d want %d", got, btreeArenaInitialChunkSize)
+	}
+	if got := &m.arena.chunks[0][0]; got != first {
+		t.Fatal("reset did not retain first arena chunk")
+	}
+	if got := m.arena.offset; got != 0 {
+		t.Fatalf("offset after reset=%d want 0", got)
+	}
+}
+
 func TestBTreeIteratorUnsafeEntry_ForInlinePointerAndTombstone(t *testing.T) {
 	ptrWant := page.ValuePtr{Offset: 99, Length: 123, FileID: 7}
 	m := NewBTree()
@@ -405,4 +486,24 @@ func equalStrings(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func arenaChunkSizes(a *btreeArena) []int {
+	sizes := make([]int, len(a.chunks))
+	for i, chunk := range a.chunks {
+		sizes[i] = len(chunk)
+	}
+	return sizes
 }

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -217,7 +217,7 @@ func TestBTreeSetEntryDedupesRepeatedCopiedInlineValues(t *testing.T) {
 
 func TestBTreeArenaUsesSmallInitialChunkThenGrows(t *testing.T) {
 	a := &btreeArena{
-		chunkSize:        256,
+		maxChunkSize:     256,
 		initialChunkSize: 32,
 	}
 
@@ -246,7 +246,7 @@ func TestBTreeArenaUsesSmallInitialChunkThenGrows(t *testing.T) {
 
 func TestBTreeArenaLargeAllocationCanExceedInitialChunk(t *testing.T) {
 	a := &btreeArena{
-		chunkSize:        256,
+		maxChunkSize:     256,
 		initialChunkSize: 32,
 	}
 


### PR DESCRIPTION
## Summary
- start BTree arena allocation with a smaller 64 KiB first chunk
- grow arena chunks geometrically up to the existing 1 MiB cap
- cover first allocation, growth, oversized allocation, and reset reuse behavior

## Validation
- go test ./TreeDB/internal/memtable ./TreeDB/caching
- paired 1M BTree profile on stack base codex/btree-copy-index-applier:
  - baseline: /tmp/profile_btree_arena_baseline_1m_06fOg9
  - patched: /tmp/profile_btree_adaptive_arena_1m_dqFIK0
  - batch_small_seq: 10,260,422 -> 11,153,080; alloc_space 170.48MB -> 140.75MB
  - batch_delete: 1,528,492 -> 1,838,205; alloc_space 186.26MB -> 47.00MB
  - other profiled tests were roughly flat to modestly positive, with batch_write within noise at 4,128,451 -> 4,061,272

## Notes
- A direct origin/main-only version was evaluated separately and was not opened because the throughput signal was mixed before the copy-index path lands. This PR is intentionally stacked where the oversized first chunk shows up materially.