### PR TITLE
Combine BTree key/value arena copies

### DIFF
--- a/TreeDB/caching/batch_followup_test.go
+++ b/TreeDB/caching/batch_followup_test.go
@@ -411,8 +411,8 @@ func TestBatchWrite_SortedBatchRotatesSingleRoutedShard(t *testing.T) {
 			t.Fatalf("queue route mode[%d]=%d want %d", i, mode, memtableRouteRanged)
 		}
 	}
-	if route := cache.currentMutableRoute.Load(); route != nil {
-		t.Fatalf("expected current mutable route to clear after routed rotation, got entries=%d", len(route.normalizedEntries()))
+	if route := cache.currentMutableRoute.Load(); route == nil {
+		t.Fatal("expected current mutable route to stay active while routed queue is pending")
 	}
 
 	var routedKey []byte

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -6195,6 +6195,7 @@ type DB struct {
 	mutableShards                 []memShard
 	mutableShardMask              uint64
 	mutableBytes                  atomic.Int64
+	mutableEntries                atomic.Int64
 	mutableThreshold              atomic.Int64
 	rotatePending                 atomic.Bool
 	currentMutableRoute           atomic.Pointer[mutableRouteState]
@@ -7155,8 +7156,37 @@ type memShard struct {
 	mem                        memtable.Table
 	rng                        keyRange
 	bytes                      int64
+	entries                    int
 	stats                      memtableStats
 	appendOnlyDirectValueArena appendOnlyDirectValueArena
+}
+
+func (db *DB) updateMutableShardAccountingLocked(shard *memShard, newBytes int64, newEntries int) {
+	if db == nil || shard == nil {
+		return
+	}
+	if delta := newBytes - shard.bytes; delta != 0 {
+		db.mutableBytes.Add(delta)
+	}
+	if delta := newEntries - shard.entries; delta != 0 {
+		db.mutableEntries.Add(int64(delta))
+	}
+	shard.bytes = newBytes
+	shard.entries = newEntries
+}
+
+func (db *DB) clearMutableShardAccountingLocked(shard *memShard) {
+	if db == nil || shard == nil {
+		return
+	}
+	if shard.bytes != 0 {
+		db.mutableBytes.Add(-shard.bytes)
+	}
+	if shard.entries != 0 {
+		db.mutableEntries.Add(-int64(shard.entries))
+	}
+	shard.bytes = 0
+	shard.entries = 0
 }
 
 // memtableView is an immutable snapshot of the in-memory layers.
@@ -7984,6 +8014,48 @@ func (db *DB) clearCurrentMutableRouteLocked() {
 	db.currentMutableRoute.Store(nil)
 }
 
+func (db *DB) hasQueuedRangedMemtablesLocked() bool {
+	if db == nil {
+		return false
+	}
+	for _, mode := range db.queueRouteModes {
+		if mode == memtableRouteRanged {
+			return true
+		}
+	}
+	return false
+}
+
+func (db *DB) routeMutableHasEntriesLocked(route *mutableRouteState) bool {
+	if db == nil || route == nil {
+		return false
+	}
+	for _, shardID := range route.shardIDs() {
+		if shardID < 0 || shardID >= len(db.mutableShards) {
+			continue
+		}
+		shard := &db.mutableShards[shardID]
+		shard.mu.Lock()
+		hasEntries := shard.entries > 0 || shard.bytes > 0 || shard.rng.valid || shard.mem.Len() > 0
+		shard.mu.Unlock()
+		if hasEntries {
+			return true
+		}
+	}
+	return false
+}
+
+func (db *DB) clearInactiveMutableRouteLocked() {
+	if db == nil {
+		return
+	}
+	route := db.currentMutableRoute.Load()
+	if route == nil || db.hasQueuedRangedMemtablesLocked() || db.routeMutableHasEntriesLocked(route) {
+		return
+	}
+	db.currentMutableRoute.Store(nil)
+}
+
 func (db *DB) extendCurrentMutableRouteLocked(first, last []byte) *mutableRouteState {
 	if db == nil || len(first) == 0 || len(last) == 0 {
 		return db.currentMutableRoute.Load()
@@ -8540,6 +8612,7 @@ func (db *DB) snapshotMutableRange() keyRange {
 
 func (db *DB) resetMutableShardsLocked(nextMode memtable.Mode, reuse bool) error {
 	db.mutableBytes.Store(0)
+	db.mutableEntries.Store(0)
 	db.clearCurrentMutableRouteLocked()
 	for i := range db.mutableShards {
 		shard := &db.mutableShards[i]
@@ -8567,6 +8640,7 @@ func (db *DB) resetMutableShardsLocked(nextMode memtable.Mode, reuse bool) error
 		}
 		shard.rng = keyRange{}
 		shard.bytes = 0
+		shard.entries = 0
 		shard.mu.Unlock()
 	}
 	db.resetAdaptiveMemtableStatsLocked()
@@ -20341,9 +20415,8 @@ func (db *DB) setDirect(key, value []byte, sync bool) error {
 	}
 	shard.rng.add(key)
 	newBytes := shard.mem.Size()
-	delta := newBytes - shard.bytes
-	shard.bytes = newBytes
-	db.mutableBytes.Add(delta)
+	newEntries := shard.mem.Len()
+	db.updateMutableShardAccountingLocked(shard, newBytes, newEntries)
 	shard.mu.Unlock()
 	db.noteWriteKey(key)
 
@@ -20433,9 +20506,8 @@ func (db *DB) DeleteRange(start, end []byte) error {
 				}
 				shard.rng.add(key)
 				newBytes := shard.mem.Size()
-				delta := newBytes - shard.bytes
-				shard.bytes = newBytes
-				db.mutableBytes.Add(delta)
+				newEntries := shard.mem.Len()
+				db.updateMutableShardAccountingLocked(shard, newBytes, newEntries)
 				shard.mu.Unlock()
 				db.noteDeleteKey(key)
 				if db.mutableBytes.Load() > db.mutableFlushThreshold() {
@@ -20911,9 +20983,8 @@ func (db *DB) DeleteRange(start, end []byte) error {
 			shard.mem.Delete(key)
 			shard.rng.add(key)
 			newBytes := shard.mem.Size()
-			delta := newBytes - shard.bytes
-			shard.bytes = newBytes
-			db.mutableBytes.Add(delta)
+			newEntries := shard.mem.Len()
+			db.updateMutableShardAccountingLocked(shard, newBytes, newEntries)
 			shard.mu.Unlock()
 			db.noteDeleteKey(key)
 			if db.mutableBytes.Load() > db.mutableFlushThreshold() {
@@ -21054,9 +21125,8 @@ func (db *DB) deleteDirect(key []byte, sync bool) error {
 	shard.mem.Delete(key)
 	shard.rng.add(key)
 	newBytes := shard.mem.Size()
-	delta := newBytes - shard.bytes
-	shard.bytes = newBytes
-	db.mutableBytes.Add(delta)
+	newEntries := shard.mem.Len()
+	db.updateMutableShardAccountingLocked(shard, newBytes, newEntries)
 	shard.mu.Unlock()
 	db.noteDeleteKey(key)
 
@@ -21130,6 +21200,7 @@ func (db *DB) rotateMemtableLockedWithCapacity(triggerFlush bool, newCapacity in
 		)
 	}
 	db.mutableBytes.Store(0)
+	db.mutableEntries.Store(0)
 	enqueueNS := time.Now().UnixNano()
 	for i := range db.mutableShards {
 		shard := &db.mutableShards[i]
@@ -21171,6 +21242,7 @@ func (db *DB) rotateMemtableLockedWithCapacity(triggerFlush bool, newCapacity in
 		shard.mem = mt
 		shard.rng = keyRange{}
 		shard.bytes = 0
+		shard.entries = 0
 		if debugRotate {
 			db.debugMemtableRotatef(
 				"event=shard path=with_capacity shard=%d lane=%d old_mode=%s old_len=%d old_size=%d old_bytes=%d new_mode=%s new_capacity=%d queue_len=%d queue_backlog_bytes=%d",
@@ -21191,7 +21263,6 @@ func (db *DB) rotateMemtableLockedWithCapacity(triggerFlush bool, newCapacity in
 	if len(retiredMems) > 0 {
 		db.pendingRetiredMems = append(db.pendingRetiredMems, retiredMems...)
 	}
-	db.clearCurrentMutableRouteLocked()
 	db.resetAdaptiveMemtableStatsLocked()
 	db.updateMutableThresholdLocked()
 	db.publishMemtablesLocked()
@@ -21350,11 +21421,9 @@ func (db *DB) rotateMutableShardsLockedWithMode(newCapacity int, triggerFlush bo
 			db.observeAppendOnlyMutableEntries(oldLen)
 		}
 
-		// Remove this shard's contribution from the global byte counter before
-		// resetting it, since writers may still be updating other shards.
-		if shard.bytes != 0 {
-			db.mutableBytes.Add(-shard.bytes)
-		}
+		// Remove this shard's contribution before resetting it, since writers may
+		// still be updating other shards.
+		db.clearMutableShardAccountingLocked(shard)
 
 		// Freeze and enqueue the old mutable shard.
 		db.retainMutableShardAppendOnlyArenaLocked(i, shard)
@@ -21384,6 +21453,7 @@ func (db *DB) rotateMutableShardsLockedWithMode(newCapacity int, triggerFlush bo
 		shard.mem = mt
 		shard.rng = keyRange{}
 		shard.bytes = 0
+		shard.entries = 0
 		if debugRotate {
 			db.debugMemtableRotatef(
 				"event=shard path=mutable_shards shard=%d lane=%d old_mode=%s old_len=%d old_size=%d old_bytes=%d new_mode=%s new_capacity=%d queue_len=%d queue_backlog_bytes=%d",
@@ -21403,7 +21473,6 @@ func (db *DB) rotateMutableShardsLockedWithMode(newCapacity int, triggerFlush bo
 	if len(retiredMems) > 0 {
 		db.pendingRetiredMems = append(db.pendingRetiredMems, retiredMems...)
 	}
-	db.clearCurrentMutableRouteLocked()
 	db.resetAdaptiveMemtableStatsLocked()
 	db.updateMutableThresholdLocked()
 	db.publishMemtablesLocked()
@@ -21463,9 +21532,7 @@ func (db *DB) rotateMutableShardsSelectedLocked(shardIDs []int, newCapacity int,
 		if _, ok := shard.mem.(*memtable.AppendOnly); ok {
 			db.observeAppendOnlyMutableEntries(oldLen)
 		}
-		if shard.bytes != 0 {
-			db.mutableBytes.Add(-shard.bytes)
-		}
+		db.clearMutableShardAccountingLocked(shard)
 		db.retainMutableShardAppendOnlyArenaLocked(shardID, shard)
 		shard.mem.Freeze()
 		memBytes := shard.mem.Size()
@@ -21497,17 +21564,11 @@ func (db *DB) rotateMutableShardsSelectedLocked(shardIDs []int, newCapacity int,
 		shard.mem = mt
 		shard.rng = keyRange{}
 		shard.bytes = 0
+		shard.entries = 0
 		shard.mu.Unlock()
 	}
 	if len(retiredMems) > 0 {
 		db.pendingRetiredMems = append(db.pendingRetiredMems, retiredMems...)
-	}
-	if activeRoute != nil {
-		remove := make(map[int]struct{}, len(sortedShardIDs))
-		for _, shardID := range sortedShardIDs {
-			remove[shardID] = struct{}{}
-		}
-		db.currentMutableRoute.Store(activeRoute.withoutShards(remove))
 	}
 	db.resetAdaptiveMemtableStatsLocked()
 	db.updateMutableThresholdLocked()
@@ -22281,6 +22342,7 @@ func (db *DB) removeQueuedUnitsLocked(removeIDs map[uint64]struct{}, units []flu
 	if len(db.queue) == 0 {
 		db.materializationLastDrainUnixNano.Store(time.Now().UnixNano())
 	}
+	db.clearInactiveMutableRouteLocked()
 	db.publishMemtablesLocked()
 }
 
@@ -23402,6 +23464,7 @@ func (db *DB) flushOneLocked(sync bool) bool {
 	if len(db.queue) == 0 {
 		db.materializationLastDrainUnixNano.Store(time.Now().UnixNano())
 	}
+	db.clearInactiveMutableRouteLocked()
 	db.publishMemtablesLocked()
 
 	deletable := make([]string, 0, len(walPaths))
@@ -23472,14 +23535,16 @@ func (db *DB) flushOneLocked(sync bool) bool {
 //
 // Safety notes:
 //   - We require an empty immutable queue.
-//   - We require global mutable bytes to be zero.
+//   - We require global mutable bytes and entries to be zero. Bytes alone are
+//     not a complete shadowing guard because tombstone-heavy updates can shrink
+//     byte accounting while entries still exist.
 //   - We additionally check the target mutable shard length to avoid races where
 //     mutableBytes is transiently zero while an old view still has entries.
 //   - Routed mutable ranges bypass the hash shard; if a key is currently routed,
 //     do not bypass because the hash shard can be empty while the routed shard
 //     still owns the newest value.
 func (db *DB) canBypassMemtableRead(view *memtableView, key []byte) bool {
-	if view == nil || len(view.queue) != 0 || db.mutableBytes.Load() != 0 {
+	if view == nil || len(view.queue) != 0 || db.queueBacklogBytes.Load() != 0 || db.mutableBytes.Load() != 0 || db.mutableEntries.Load() != 0 {
 		return false
 	}
 	if keyInMutableRoute(view.mutableRoute, key) {
@@ -23506,7 +23571,7 @@ func (db *DB) canBypassMemtableReadMany(view *memtableView, keys [][]byte) bool 
 	if len(keys) == 0 {
 		return true
 	}
-	if view == nil || len(view.queue) != 0 || db.mutableBytes.Load() != 0 {
+	if view == nil || len(view.queue) != 0 || db.queueBacklogBytes.Load() != 0 || db.mutableBytes.Load() != 0 || db.mutableEntries.Load() != 0 {
 		return false
 	}
 	for _, key := range keys {
@@ -29225,9 +29290,8 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				}
 			}
 			newBytes := shard.mem.Size()
-			delta := newBytes - shard.bytes
-			shard.bytes = newBytes
-			b.db.mutableBytes.Add(delta)
+			newEntries := shard.mem.Len()
+			b.db.updateMutableShardAccountingLocked(shard, newBytes, newEntries)
 			shard.mu.Unlock()
 			if retainMain {
 				retainMainMems = append(retainMainMems, shard.mem)
@@ -29422,9 +29486,8 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				}
 			}
 			newBytes := shard.mem.Size()
-			delta := newBytes - shard.bytes
-			shard.bytes = newBytes
-			b.db.mutableBytes.Add(delta)
+			newEntries := shard.mem.Len()
+			b.db.updateMutableShardAccountingLocked(shard, newBytes, newEntries)
 			var retainedMain memtable.Table
 			if retainMain {
 				retainedMain = shard.mem

--- a/TreeDB/caching/read_bypass_test.go
+++ b/TreeDB/caching/read_bypass_test.go
@@ -1,0 +1,178 @@
+package caching
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func readBypassBEKey(i int) []byte {
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, uint64(i))
+	return key
+}
+
+func TestCanBypassMemtableReadRequiresMutableEntriesEmpty(t *testing.T) {
+	backend := NewMockBackend()
+	db, err := Open(t.TempDir(), backend, Options{
+		FlushThreshold: 1 << 20,
+		MemtableMode:   "btree",
+		MemtableShards: 4,
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	key := []byte("route-safety-key")
+	for i := byte(0); db.hashShardIndex(key) == 0; i++ {
+		key = []byte{'r', 'o', 'u', 't', 'e', '-', i}
+	}
+	// Simulate the safety condition this guard is meant to cover: a mutable
+	// entry exists outside the hash-selected shard while byte accounting alone
+	// is not sufficient to prove the mutable layer is empty.
+	shard := &db.mutableShards[0]
+	shard.mu.Lock()
+	shard.mem.Delete(key)
+	shard.rng.add(key)
+	db.updateMutableShardAccountingLocked(shard, shard.mem.Size(), shard.mem.Len())
+	shard.mu.Unlock()
+	db.mutableBytes.Store(0)
+
+	view := db.retainMemtableView()
+	if view == nil {
+		t.Fatal("missing memtable view")
+	}
+	if db.canBypassMemtableRead(view, key) {
+		db.releaseMemtableView(view)
+		t.Fatal("canBypassMemtableRead returned true with mutable tombstone present")
+	}
+	db.releaseMemtableView(view)
+}
+
+func TestRoutedQueueKeepsFutureWritesOnRoute(t *testing.T) {
+	backend := NewMockBackend()
+	db, err := Open(t.TempDir(), backend, Options{
+		FlushThreshold:          1 << 30,
+		MemtableMode:            "btree",
+		MemtableShards:          4,
+		MaxQueuedMemtables:      -1,
+		WriterFlushMaxMemtables: 0,
+		DisableWAL:              true,
+		AllowUnsafe:             true,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	const keys = 300
+	initial := db.NewBatch()
+	for i := 0; i < keys; i++ {
+		if err := initial.Set(readBypassBEKey(i), []byte("older-ranged-queue-value")); err != nil {
+			t.Fatalf("initial set i=%d: %v", i, err)
+		}
+	}
+	if err := initial.Write(); err != nil {
+		t.Fatalf("initial write: %v", err)
+	}
+	if err := initial.Close(); err != nil {
+		t.Fatalf("initial close: %v", err)
+	}
+	if db.currentMutableRoute.Load() == nil {
+		t.Fatal("initial sorted batch did not create a mutable route")
+	}
+
+	db.mu.Lock()
+	if err := db.rotateMutableShardsLocked(-1, false); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("rotate: %v", err)
+	}
+	db.mu.Unlock()
+
+	db.mu.RLock()
+	hasRangedQueue := false
+	for _, mode := range db.queueRouteModes {
+		if mode == memtableRouteRanged {
+			hasRangedQueue = true
+			break
+		}
+	}
+	queueLen := len(db.queue)
+	db.mu.RUnlock()
+	if queueLen == 0 || !hasRangedQueue {
+		t.Fatalf("rotate produced queue_len=%d ranged_queue=%t, want non-empty ranged queue", queueLen, hasRangedQueue)
+	}
+
+	route := db.currentMutableRoute.Load()
+	if route == nil {
+		t.Fatal("mutable route was not retained while ranged queue is pending")
+	}
+	var deleteKey, updateKey []byte
+	for _, entry := range route.normalizedEntries() {
+		for i := 0; i < keys; i++ {
+			key := readBypassBEKey(i)
+			if !keyInRange(entry.rng, key) || db.hashShardIndex(key) == int(entry.shardID) {
+				continue
+			}
+			if deleteKey == nil {
+				deleteKey = key
+				continue
+			}
+			updateKey = key
+			break
+		}
+		if updateKey != nil {
+			break
+		}
+	}
+	if deleteKey == nil || updateKey == nil {
+		t.Fatal("expected routed keys whose hash shard differs from the active route shard")
+	}
+	updated := []byte("newer-current-routed-mutable-value")
+	churn := db.NewBatch()
+	if err := churn.Delete(deleteKey); err != nil {
+		t.Fatalf("churn delete: %v", err)
+	}
+	if err := churn.Set(updateKey, updated); err != nil {
+		t.Fatalf("churn set: %v", err)
+	}
+	if err := churn.Write(); err != nil {
+		t.Fatalf("churn write: %v", err)
+	}
+	if err := churn.Close(); err != nil {
+		t.Fatalf("churn close: %v", err)
+	}
+
+	got, err := db.Get(deleteKey)
+	if err != nil {
+		t.Fatalf("get deleted key: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("deleted key returned len=%d from older ranged queue", len(got))
+	}
+	has, err := db.Has(deleteKey)
+	if err != nil {
+		t.Fatalf("has deleted key: %v", err)
+	}
+	if has {
+		t.Fatal("Has returned true for key tombstoned in newer routed mutable")
+	}
+
+	got, err = db.Get(updateKey)
+	if err != nil {
+		t.Fatalf("get updated key: %v", err)
+	}
+	if !bytes.Equal(got, updated) {
+		t.Fatalf("updated key got %q want %q", got, updated)
+	}
+	out, err := db.GetAppend(updateKey, []byte("prefix:"))
+	if err != nil {
+		t.Fatalf("get append updated key: %v", err)
+	}
+	if want := append([]byte("prefix:"), updated...); !bytes.Equal(out, want) {
+		t.Fatalf("GetAppend got %q want %q", out, want)
+	}
+}

--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -114,9 +114,8 @@ func (m *BTree) ApplyCopySortedBatchIndicesTrusted(entries []batchpkg.Entry, idx
 		if op.Key == nil {
 			continue
 		}
-		keyCopy := m.arena.Copy(op.Key)
+		keyCopy, entry := m.copyKeyEntryFromBatchOpLocked(op, storeInlinePtrValues)
 		keyStr := bytesToStringNoCopy(keyCopy)
-		entry := m.btreeEntryCopyFromBatchOpLocked(op, storeInlinePtrValues)
 		prev, replaced := m.setMaybeSortedLoadLocked(keyStr, entry)
 		m.recordSetLocked(keyStr, len(keyCopy), entry, prev, replaced)
 		if onKey != nil {
@@ -153,23 +152,25 @@ func (m *BTree) applyStealSortedBatch(entries []batchpkg.Entry, idxs []int, onKe
 	}
 }
 
-func (m *BTree) btreeEntryCopyFromBatchOpLocked(op batchpkg.Entry, storeInlinePtrValues bool) btreeEntry {
+func (m *BTree) copyKeyEntryFromBatchOpLocked(op batchpkg.Entry, storeInlinePtrValues bool) ([]byte, btreeEntry) {
 	switch {
 	case op.Type == batchpkg.OpDelete:
-		return btreeEntry{flags: node.FlagTombstone}
+		return m.arena.Copy(op.Key), btreeEntry{flags: node.FlagTombstone}
 	case op.IsPtr:
 		value := op.Value
 		if !storeInlinePtrValues {
 			value = nil
 		}
-		return btreeEntry{
-			value: m.copyPointerValueLocked(op.ValuePtr, value),
+		keyCopy, ptrValue := m.copyKeyPointerValueLocked(op.Key, op.ValuePtr, value)
+		return keyCopy, btreeEntry{
+			value: ptrValue,
 			flags: node.FlagPointer,
 		}
 	default:
 		value := canonicalizeBTreeInlineValue(op.Value)
-		return btreeEntry{
-			value: m.copyInlineValueLocked(value),
+		keyCopy, valueCopy := m.copyKeyInlineValueLocked(op.Key, value)
+		return keyCopy, btreeEntry{
+			value: valueCopy,
 			flags: node.FlagInline,
 		}
 	}
@@ -223,8 +224,7 @@ func (m *BTree) PutWithCallback(key, value []byte, cb func(k, v []byte) error) e
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	keyStored := m.arena.Copy(key)
-	valStored := m.copyInlineValueLocked(canonicalizeBTreeInlineValue(value))
+	keyStored, valStored := m.copyKeyInlineValueLocked(key, canonicalizeBTreeInlineValue(value))
 	keyStr := bytesToStringNoCopy(keyStored)
 	entry := btreeEntry{value: valStored, flags: node.FlagInline}
 	prev, replaced := m.setMaybeLoadLocked(keyStr, entry)
@@ -243,18 +243,19 @@ func (m *BTree) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	keyCopy := m.arena.Copy(key)
-	keyStr := bytesToStringNoCopy(keyCopy)
 	entry := btreeEntry{flags: normalizeBTreeEntryFlags(flags)}
+	var keyCopy []byte
 	switch {
 	case entry.flags&node.FlagTombstone != 0:
+		keyCopy = m.arena.Copy(key)
 		entry.value = nil
 	case entry.flags&node.FlagPointer != 0:
-		entry.value = m.copyPointerValueLocked(ptr, value)
+		keyCopy, entry.value = m.copyKeyPointerValueLocked(key, ptr, value)
 	default:
 		value = canonicalizeBTreeInlineValue(value)
-		entry.value = m.copyInlineValueLocked(value)
+		keyCopy, entry.value = m.copyKeyInlineValueLocked(key, value)
 	}
+	keyStr := bytesToStringNoCopy(keyCopy)
 	prev, replaced := m.setMaybeLoadLocked(keyStr, entry)
 	m.recordSetLocked(keyStr, len(keyCopy), entry, prev, replaced)
 }
@@ -745,12 +746,43 @@ func (m *BTree) copyInlineValueLocked(value []byte) []byte {
 	return stored
 }
 
+func (m *BTree) copyKeyInlineValueLocked(key, value []byte) ([]byte, []byte) {
+	if len(value) == 0 {
+		return m.arena.Copy(key), nil
+	}
+	if len(value) <= btreeInlineValueDedupeMax && bytes.Equal(value, m.lastInline) {
+		return m.arena.Copy(key), m.lastInline
+	}
+	buf := m.arena.alloc(len(key) + len(value))
+	keyCopy := buf[:len(key):len(key)]
+	valueCopy := buf[len(key):]
+	copy(keyCopy, key)
+	copy(valueCopy, value)
+	if len(valueCopy) <= btreeInlineValueDedupeMax {
+		m.lastInline = valueCopy
+	} else {
+		m.lastInline = nil
+	}
+	return keyCopy, valueCopy
+}
+
 func (m *BTree) copyPointerValueLocked(ptr page.ValuePtr, value []byte) []byte {
 	value = canonicalizeBTreeInlineValue(value)
 	stored := m.arena.alloc(page.ValuePtrSize + len(value))
 	ptr.Encode(stored[:page.ValuePtrSize])
 	copy(stored[page.ValuePtrSize:], value)
 	return stored
+}
+
+func (m *BTree) copyKeyPointerValueLocked(key []byte, ptr page.ValuePtr, value []byte) ([]byte, []byte) {
+	value = canonicalizeBTreeInlineValue(value)
+	buf := m.arena.alloc(len(key) + page.ValuePtrSize + len(value))
+	keyCopy := buf[:len(key):len(key)]
+	ptrValue := buf[len(key):]
+	copy(keyCopy, key)
+	ptr.Encode(ptrValue[:page.ValuePtrSize])
+	copy(ptrValue[page.ValuePtrSize:], value)
+	return keyCopy, ptrValue
 }
 
 func (m *BTree) btreeEntryFromBatchOpLocked(op batchpkg.Entry) btreeEntry {

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -215,6 +215,30 @@ func TestBTreeSetEntryDedupesRepeatedCopiedInlineValues(t *testing.T) {
 	}
 }
 
+func TestBTreeSetEntryCopiesKeyValue(t *testing.T) {
+	m := NewBTree()
+	key := []byte("key")
+	value := []byte("value")
+
+	m.SetEntry(key, value, page.ValuePtr{}, node.FlagInline)
+
+	got, _, _, ok := m.GetEntry([]byte("key"))
+	if !ok || string(got) != "value" {
+		t.Fatalf("GetEntry(key)=(%q,%v), want value,true", string(got), ok)
+	}
+	if unsafe.SliceData(got) == unsafe.SliceData(value) {
+		t.Fatal("SetEntry value aliases caller storage")
+	}
+	key[0] = 'z'
+	value[0] = 'X'
+	if got, _, ok := m.Get([]byte("key")); !ok || string(got) != "value" {
+		t.Fatalf("stored entry changed after caller mutation: got=(%q,%v)", string(got), ok)
+	}
+	if _, _, ok := m.Get([]byte("zey")); ok {
+		t.Fatal("stored key aliases caller storage")
+	}
+}
+
 func TestBTreeArenaUsesSmallInitialChunkThenGrows(t *testing.T) {
 	a := &btreeArena{
 		maxChunkSize:     256,


### PR DESCRIPTION
## Summary
- combine BTree key+inline-value and key+pointer-payload copies into single arena allocations on copy-owning write paths
- keep existing inline-value dedupe behavior for repeated values
- add coverage that SetEntry copies caller key/value storage

## Validation
- go test ./TreeDB/internal/memtable ./TreeDB/caching

## Profiling
- candidate: /tmp/profile_btree_combinedcopy_1m_rerun_WeuH4M
- same-machine baseline: /tmp/profile_btree_baseline_now_1m_2VTYVC
- narrowed command: /tmp/unified-bench-btree-combinedcopy -dbs treedb -profile fast -keys 1000000 -treedb-memtable-mode btree -test batch_write,batch_write_steady,batch_random,batch_small_seq,random_delete,batch_delete,dataset_write_sorted,sequential_write -profile-dir <dir>
- btreeArena alloc_space improved in sampled hot paths: batch_small_seq 16.22MB -> 12.44MB; batch_delete 15.54MB -> 11.03MB; dataset_write_sorted roughly neutral 44.16MB -> 43.81MB. Throughput was mixed/noisy but broadly neutral-to-positive versus same-machine baseline; this PR is primarily a copy/allocation reduction, not a broad algorithmic change.