### PR TITLE
Recycle BTree memtable arenas

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -6233,6 +6233,9 @@ type DB struct {
 	// Readers load it atomically to avoid holding db.mu around memtable access.
 	memtables                        atomic.Pointer[memtableView]
 	hashSortedIndexer                *memtable.HashSortedIndexer
+	btreeMemLeaseMu                  sync.Mutex
+	btreeMemLeases                   []*memtable.BTree
+	btreeMemLeaseHitTotal            atomic.Uint64
 	appendOnlyMemPool                sync.Pool
 	appendOnlyMemLeaseMu             sync.Mutex
 	appendOnlyMemLeases              []*memtable.AppendOnly
@@ -7185,6 +7188,11 @@ const appendOnlyEstimatedBytesPerEntryDefault = 96
 // and increases allocation churn.
 const maxAppendOnlyMemLeases = 32
 
+// maxBTreeMemLeases bounds strong references to recycled BTree memtables.
+// Each retained BTree can hold arena chunks, so keep this much smaller than
+// append-only leasing.
+const maxBTreeMemLeases = 8
+
 func updateInt64Max(dst *atomic.Int64, value int64) {
 	for {
 		cur := dst.Load()
@@ -7714,6 +7722,35 @@ func (db *DB) putAppendOnlyMemLease(mt *memtable.AppendOnly) bool {
 	return true
 }
 
+func (db *DB) popBTreeMemLease() *memtable.BTree {
+	if db == nil {
+		return nil
+	}
+	db.btreeMemLeaseMu.Lock()
+	defer db.btreeMemLeaseMu.Unlock()
+	n := len(db.btreeMemLeases)
+	if n == 0 {
+		return nil
+	}
+	mt := db.btreeMemLeases[n-1]
+	db.btreeMemLeases[n-1] = nil
+	db.btreeMemLeases = db.btreeMemLeases[:n-1]
+	return mt
+}
+
+func (db *DB) putBTreeMemLease(mt *memtable.BTree) bool {
+	if db == nil || mt == nil {
+		return false
+	}
+	db.btreeMemLeaseMu.Lock()
+	defer db.btreeMemLeaseMu.Unlock()
+	if len(db.btreeMemLeases) >= maxBTreeMemLeases {
+		return false
+	}
+	db.btreeMemLeases = append(db.btreeMemLeases, mt)
+	return true
+}
+
 func (db *DB) recycleMemtables(mems []memtable.Table) {
 	if db == nil || len(mems) == 0 {
 		return
@@ -7730,6 +7767,9 @@ func (db *DB) recycleMemtables(mems []memtable.Table) {
 			if !db.putAppendOnlyMemLease(typed) {
 				db.appendOnlyMemPool.Put(typed)
 			}
+		case *memtable.BTree:
+			typed.Reset()
+			db.putBTreeMemLease(typed)
 		}
 	}
 }
@@ -7763,6 +7803,33 @@ func (db *DB) trimAppendOnlyMemLeases(maxLeases int, resetCapacity int) {
 			dropped[i].ResetWithCapacityHard(effectiveResetCapacity, appendOnlyEstimatedBytesPerEntryDefault)
 			db.releaseAppendOnlyDirectArenaLeaseForMemtable(dropped[i])
 			db.appendOnlyMemPool.Put(dropped[i])
+		}
+	}
+}
+
+func (db *DB) trimBTreeMemLeases(maxLeases int) {
+	if db == nil {
+		return
+	}
+	if maxLeases < 0 {
+		maxLeases = 0
+	}
+	var dropped []*memtable.BTree
+	db.btreeMemLeaseMu.Lock()
+	if n := len(db.btreeMemLeases); n > maxLeases {
+		drop := n - maxLeases
+		dropped = append(dropped, db.btreeMemLeases[:drop]...)
+		copy(db.btreeMemLeases, db.btreeMemLeases[drop:])
+		for i := n - drop; i < n; i++ {
+			db.btreeMemLeases[i] = nil
+		}
+		db.btreeMemLeases = db.btreeMemLeases[:n-drop]
+	}
+	db.btreeMemLeaseMu.Unlock()
+
+	for i := range dropped {
+		if dropped[i] != nil {
+			dropped[i].Reset()
 		}
 	}
 }
@@ -7826,11 +7893,13 @@ func (db *DB) trimRetainedArenasAfterFlush(checkpoint bool) {
 	entryTarget := postFlushEntrySliceTargetBytes
 	leaseKeepPerBucket := postFlushEntrySliceLeaseKeepPerBucket
 	appendOnlyLeaseKeep := postFlushAppendOnlyMemLeaseKeep
+	btreeLeaseKeep := maxBTreeMemLeases / 2
 	if checkpoint {
 		batchTarget = postCheckpointBatchArenaTargetBytes
 		entryTarget = postCheckpointEntrySliceTargetBytes
 		leaseKeepPerBucket = postCheckpointEntrySliceLeaseKeepPerBucket
 		appendOnlyLeaseKeep = postCheckpointAppendOnlyMemLeaseKeep
+		btreeLeaseKeep = maxBTreeMemLeases / 4
 	}
 	if budget := currentBatchArenaRetentionBudgetBytes(); budget >= 0 && budget < batchTarget {
 		batchTarget = budget
@@ -7855,9 +7924,18 @@ func (db *DB) trimRetainedArenasAfterFlush(checkpoint bool) {
 
 	db.trimMutableShardAppendOnlyDirectArenas(checkpoint)
 	db.trimAppendOnlyMemLeases(appendOnlyLeaseKeep, db.checkpointRotateCapacity())
+	db.trimBTreeMemLeases(btreeLeaseKeep)
 }
 
 func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mode) (memtable.Table, error) {
+	if db != nil && mode == memtable.ModeBTree {
+		if mt := db.popBTreeMemLease(); mt != nil {
+			db.btreeMemLeaseHitTotal.Add(1)
+			mt.Reset()
+			return mt, nil
+		}
+		return memtable.NewBTree(), nil
+	}
 	if db != nil && mode == memtable.ModeAppendOnly {
 		estimate := appendOnlyEstimatedBytesPerEntryDefault
 		entryHint := db.appendOnlyEntryHintEntries()
@@ -11661,6 +11739,11 @@ func stableFlushStreamingSources(units []flushUnit) bool {
 func stableFlushStreamingPlan(units []flushUnit, totalLen int) (int, bool) {
 	if !stableFlushStreamingSources(units) {
 		return 0, false
+	}
+	for i := range units {
+		if _, isBTree := units[i].mem.(*memtable.BTree); isBTree {
+			return 0, false
+		}
 	}
 	deleteOps, ok := flushStreamingDeleteOps(units, totalLen)
 	if !ok {

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -865,6 +865,29 @@ func TestAppendOnlyMemtableLeaseReuse(t *testing.T) {
 	}
 }
 
+func TestBTreeMemtableLeaseReuse(t *testing.T) {
+	db := &DB{}
+	mt := memtable.NewBTree()
+	mt.Set([]byte("key"), []byte("value"))
+
+	db.recycleMemtables([]memtable.Table{mt})
+
+	got, err := db.newMutableMemtableWithCapacityMode(0, memtable.ModeBTree)
+	if err != nil {
+		t.Fatalf("newMutableMemtableWithCapacityMode: %v", err)
+	}
+	gotBTree, ok := got.(*memtable.BTree)
+	if !ok {
+		t.Fatalf("expected BTree memtable, got %T", got)
+	}
+	if gotBTree != mt {
+		t.Fatalf("expected leased BTree memtable reuse")
+	}
+	if _, _, ok := gotBTree.Get([]byte("key")); ok {
+		t.Fatal("leased BTree memtable retained old key")
+	}
+}
+
 func TestFlushLaneOnce_UsesViewMethodsForInlineEntries_SerialAndParallel(t *testing.T) {
 	t.Run("serial", func(t *testing.T) {
 		testFlushLaneOnceUsesViewMethodsForInlineEntries(t, false, true, true)
@@ -1071,9 +1094,18 @@ func TestFlushStreamingDeleteOps(t *testing.T) {
 		t.Fatalf("NewWithCapacityMode btree: %v", err)
 	}
 	btree.Set([]byte("a"), []byte("va"))
+	btree.Delete([]byte("b"))
+	btree.Delete([]byte("c"))
+	btree.Delete([]byte("d"))
 	btree.Freeze()
+	if deleteOps, ok := flushStreamingDeleteOps([]flushUnit{{mem: btree}}, btree.Len()); !ok || deleteOps != 3 {
+		t.Fatalf("BTree flushStreamingDeleteOps=(%d,%t), want (3,true)", deleteOps, ok)
+	}
+	if deleteOps, ok := deleteHeavyStreamingDeleteOps([]flushUnit{{mem: btree}}, btree.Len()); !ok || deleteOps != 3 {
+		t.Fatalf("BTree deleteHeavyStreamingDeleteOps=(%d,%t), want (3,true)", deleteOps, ok)
+	}
 	if _, ok := stableFlushStreamingPlan([]flushUnit{{mem: btree}}, btree.Len()); ok {
-		t.Fatal("stable memtable without operation mix should stay on materialized path")
+		t.Fatal("BTree generic stable plan should stay materialized; delete-heavy path handles BTree separately")
 	}
 }
 

--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -2,8 +2,10 @@ package memtable
 
 import (
 	"bytes"
+	"math/bits"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
@@ -17,6 +19,13 @@ const btreeUseLoadFastPath = false
 const btreeArenaChunkSize = 1 << 20
 const btreeArenaInitialChunkSize = 64 << 10
 const btreeInlineValueDedupeMax = 1 << 20
+const btreeArenaPoolMinShift = 16
+const btreeArenaPoolMaxShift = 20
+const btreeArenaPoolClassCount = btreeArenaPoolMaxShift - btreeArenaPoolMinShift + 1
+const btreeArenaPoolBudgetBytes = 64 << 20
+
+var btreeArenaChunkPools [btreeArenaPoolClassCount]sync.Pool
+var btreeArenaPoolBytes atomic.Int64
 
 type btreeEntry struct {
 	value []byte // inline bytes (if pointer, may store inline tail bytes)
@@ -77,14 +86,15 @@ func normalizeBTreeEntryFlags(flags byte) byte {
 }
 
 type BTree struct {
-	mu         sync.RWMutex
-	tree       *btree.Map[string, btreeEntry]
-	sizeBytes  int64
-	arena      *btreeArena
-	lastKey    string
-	hasLast    bool
-	degree     int
-	lastInline []byte
+	mu          sync.RWMutex
+	tree        *btree.Map[string, btreeEntry]
+	sizeBytes   int64
+	arena       *btreeArena
+	lastKey     string
+	hasLast     bool
+	degree      int
+	lastInline  []byte
+	deleteCount int
 }
 
 func (*BTree) StableUnsafeIteratorSlices() bool { return true }
@@ -195,11 +205,16 @@ func (m *BTree) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.tree = btree.NewMap[string, btreeEntry](m.degree)
+	if m.tree == nil {
+		m.tree = btree.NewMap[string, btreeEntry](m.degree)
+	} else {
+		m.tree.Clear()
+	}
 	m.sizeBytes = 0
 	m.lastKey = ""
 	m.hasLast = false
 	m.lastInline = nil
+	m.deleteCount = 0
 	if m.arena != nil {
 		m.arena.resetKeepFirstChunk()
 	}
@@ -342,6 +357,15 @@ func (m *BTree) Len() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.tree.Len()
+}
+
+func (m *BTree) OperationMix() OperationMix {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return OperationMix{
+		Entries: m.tree.Len(),
+		Deletes: m.deleteCount,
+	}
 }
 
 func (m *BTree) Freeze() {}
@@ -804,11 +828,22 @@ func (m *BTree) btreeEntryFromBatchOpLocked(op batchpkg.Entry) btreeEntry {
 
 func (m *BTree) recordSetLocked(key string, keyLen int, entry, prev btreeEntry, replaced bool) {
 	newSize := btreeEntryPayloadSize(entry.flags, entry.value)
+	newDelete := entry.flags&node.FlagTombstone != 0
 	if replaced {
 		oldSize := btreeEntryPayloadSize(prev.flags, prev.value)
 		m.sizeBytes += int64(newSize - oldSize)
+		oldDelete := prev.flags&node.FlagTombstone != 0
+		switch {
+		case oldDelete && !newDelete:
+			m.deleteCount--
+		case !oldDelete && newDelete:
+			m.deleteCount++
+		}
 	} else {
 		m.sizeBytes += int64(keyLen + newSize)
+		if newDelete {
+			m.deleteCount++
+		}
 	}
 	if !m.hasLast || key > m.lastKey {
 		m.lastKey = key
@@ -833,6 +868,10 @@ func (a *btreeArena) resetKeepFirstChunk() {
 	}
 	first := a.chunks[0]
 	first = first[:cap(first)]
+	for i := 1; i < len(a.chunks); i++ {
+		putBTreeArenaChunk(a.chunks[i])
+		a.chunks[i] = nil
+	}
 	a.chunks = a.chunks[:1]
 	a.chunks[0] = first
 	a.offset = 0
@@ -869,7 +908,7 @@ func (a *btreeArena) currentChunk(n int) []byte {
 		if size < n {
 			size = n
 		}
-		a.chunks = append(a.chunks, make([]byte, size))
+		a.chunks = append(a.chunks, getBTreeArenaChunk(size))
 		a.offset = 0
 		return a.chunks[len(a.chunks)-1]
 	}
@@ -887,7 +926,80 @@ func (a *btreeArena) currentChunk(n int) []byte {
 	if size < n {
 		size = n
 	}
-	a.chunks = append(a.chunks, make([]byte, size))
+	a.chunks = append(a.chunks, getBTreeArenaChunk(size))
 	a.offset = 0
 	return a.chunks[len(a.chunks)-1]
+}
+
+func getBTreeArenaChunk(size int) []byte {
+	if size <= 0 {
+		return nil
+	}
+	idx, classSize, ok := btreeArenaClassForLen(size)
+	if !ok {
+		return make([]byte, size)
+	}
+	if v := btreeArenaChunkPools[idx].Get(); v != nil {
+		if chunk, ok := v.([]byte); ok && cap(chunk) == classSize {
+			if next := btreeArenaPoolBytes.Add(-int64(classSize)); next < 0 {
+				btreeArenaPoolBytes.Store(0)
+			}
+			return chunk[:classSize]
+		}
+	}
+	return make([]byte, classSize)
+}
+
+func putBTreeArenaChunk(chunk []byte) {
+	if chunk == nil {
+		return
+	}
+	idx, ok := btreeArenaClassForCap(cap(chunk))
+	if !ok {
+		return
+	}
+	size := int64(cap(chunk))
+	for {
+		held := btreeArenaPoolBytes.Load()
+		if held+size > btreeArenaPoolBudgetBytes {
+			return
+		}
+		if btreeArenaPoolBytes.CompareAndSwap(held, held+size) {
+			break
+		}
+	}
+	btreeArenaChunkPools[idx].Put(chunk[:0])
+}
+
+func btreeArenaClassForLen(size int) (idx int, classSize int, ok bool) {
+	minSize := 1 << btreeArenaPoolMinShift
+	maxSize := 1 << btreeArenaPoolMaxShift
+	if size < minSize || size > maxSize {
+		return 0, 0, false
+	}
+	classSize = 1 << uint(bits.Len(uint(size-1)))
+	if classSize < minSize {
+		classSize = minSize
+	}
+	if classSize > maxSize {
+		return 0, 0, false
+	}
+	idx = bits.Len(uint(classSize)) - 1 - btreeArenaPoolMinShift
+	if idx < 0 || idx >= btreeArenaPoolClassCount {
+		return 0, 0, false
+	}
+	return idx, classSize, true
+}
+
+func btreeArenaClassForCap(capacity int) (idx int, ok bool) {
+	minSize := 1 << btreeArenaPoolMinShift
+	maxSize := 1 << btreeArenaPoolMaxShift
+	if capacity < minSize || capacity > maxSize || capacity&(capacity-1) != 0 {
+		return 0, false
+	}
+	idx = bits.TrailingZeros(uint(capacity)) - btreeArenaPoolMinShift
+	if idx < 0 || idx >= btreeArenaPoolClassCount {
+		return 0, false
+	}
+	return idx, true
 }

--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -3,6 +3,7 @@ package memtable
 import (
 	"bytes"
 	"math/bits"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -26,6 +27,12 @@ const btreeArenaPoolBudgetBytes = 64 << 20
 
 var btreeArenaChunkPools [btreeArenaPoolClassCount]sync.Pool
 var btreeArenaPoolBytes atomic.Int64
+var btreeArenaPoolLastGC atomic.Uint64
+var btreeArenaPoolNumGC = func() uint64 {
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return uint64(stats.NumGC)
+}
 
 type btreeEntry struct {
 	value []byte // inline bytes (if pointer, may store inline tail bytes)
@@ -940,13 +947,16 @@ func getBTreeArenaChunk(size int) []byte {
 		return make([]byte, size)
 	}
 	if v := btreeArenaChunkPools[idx].Get(); v != nil {
-		if chunk, ok := v.([]byte); ok && cap(chunk) == classSize {
-			if next := btreeArenaPoolBytes.Add(-int64(classSize)); next < 0 {
+		if chunk, ok := v.([]byte); ok {
+			if next := btreeArenaPoolBytes.Add(-int64(cap(chunk))); next < 0 {
 				btreeArenaPoolBytes.Store(0)
 			}
-			return chunk[:classSize]
+			if cap(chunk) == classSize {
+				return chunk[:classSize]
+			}
 		}
 	}
+	maybeResetBTreeArenaPoolBytesAfterGC()
 	return make([]byte, classSize)
 }
 
@@ -959,16 +969,56 @@ func putBTreeArenaChunk(chunk []byte) {
 		return
 	}
 	size := int64(cap(chunk))
+	noteEpoch := false
 	for {
 		held := btreeArenaPoolBytes.Load()
 		if held+size > btreeArenaPoolBudgetBytes {
-			return
+			before := held
+			maybeResetBTreeArenaPoolBytesAfterGC()
+			held = btreeArenaPoolBytes.Load()
+			if held == before || held+size > btreeArenaPoolBudgetBytes {
+				return
+			}
+			continue
 		}
 		if btreeArenaPoolBytes.CompareAndSwap(held, held+size) {
+			noteEpoch = held == 0
 			break
 		}
 	}
+	if noteEpoch {
+		noteBTreeArenaPoolGC(btreeArenaPoolNumGC())
+	}
 	btreeArenaChunkPools[idx].Put(chunk[:0])
+}
+
+func maybeResetBTreeArenaPoolBytesAfterGC() {
+	if btreeArenaPoolBytes.Load() <= 0 {
+		return
+	}
+	numGC := btreeArenaPoolNumGC()
+	last := btreeArenaPoolLastGC.Load()
+	if last == numGC {
+		return
+	}
+	if btreeArenaPoolLastGC.CompareAndSwap(last, numGC) {
+		btreeArenaPoolBytes.Store(0)
+	}
+}
+
+func noteBTreeArenaPoolGC(numGC uint64) {
+	if numGC == 0 {
+		return
+	}
+	for {
+		last := btreeArenaPoolLastGC.Load()
+		if last >= numGC {
+			return
+		}
+		if btreeArenaPoolLastGC.CompareAndSwap(last, numGC) {
+			return
+		}
+	}
 }
 
 func btreeArenaClassForLen(size int) (idx int, classSize int, ok bool) {

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -2,6 +2,7 @@ package memtable
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 	"unsafe"
 
@@ -363,7 +364,7 @@ func TestBTreeArenaPoolClasses(t *testing.T) {
 }
 
 func TestBTreeArenaReusesReleasedChunk(t *testing.T) {
-	btreeArenaPoolBytes.Store(0)
+	resetBTreeArenaPoolForTest(t)
 	a := &btreeArena{
 		maxChunkSize:     btreeArenaChunkSize,
 		initialChunkSize: btreeArenaInitialChunkSize,
@@ -386,6 +387,46 @@ func TestBTreeArenaReusesReleasedChunk(t *testing.T) {
 		t.Fatalf("reused chunk cap=%d want %d", cap(reused), cap(released))
 	}
 	putBTreeArenaChunk(reused)
+}
+
+func TestBTreeArenaPoolAccountingMissResetsAfterGC(t *testing.T) {
+	resetBTreeArenaPoolForTest(t)
+	var fakeNumGC uint64 = 7
+	btreeArenaPoolNumGC = func() uint64 { return fakeNumGC }
+
+	btreeArenaPoolBytes.Store(1234)
+	btreeArenaPoolLastGC.Store(fakeNumGC)
+	fakeNumGC++
+	_ = getBTreeArenaChunk(64 << 10)
+
+	if got := btreeArenaPoolBytes.Load(); got != 0 {
+		t.Fatalf("btreeArenaPoolBytes after GC miss=%d want 0", got)
+	}
+	if got := btreeArenaPoolLastGC.Load(); got != fakeNumGC {
+		t.Fatalf("btreeArenaPoolLastGC=%d want %d", got, fakeNumGC)
+	}
+}
+
+func TestPutBTreeArenaChunkBudgetResetsAfterGC(t *testing.T) {
+	resetBTreeArenaPoolForTest(t)
+	var fakeNumGC uint64 = 11
+	btreeArenaPoolNumGC = func() uint64 { return fakeNumGC }
+
+	_, classSize, ok := btreeArenaClassForLen(64 << 10)
+	if !ok {
+		t.Fatal("btreeArenaClassForLen failed")
+	}
+	btreeArenaPoolBytes.Store(btreeArenaPoolBudgetBytes)
+	btreeArenaPoolLastGC.Store(fakeNumGC)
+	fakeNumGC++
+	putBTreeArenaChunk(make([]byte, classSize))
+
+	if got := btreeArenaPoolBytes.Load(); got != int64(classSize) {
+		t.Fatalf("btreeArenaPoolBytes after GC-aware put=%d want %d", got, classSize)
+	}
+	if got := btreeArenaPoolLastGC.Load(); got != fakeNumGC {
+		t.Fatalf("btreeArenaPoolLastGC=%d want %d", got, fakeNumGC)
+	}
 }
 
 func TestBTreeIteratorUnsafeEntry_ForInlinePointerAndTombstone(t *testing.T) {
@@ -590,6 +631,24 @@ func equalInts(a, b []int) bool {
 		}
 	}
 	return true
+}
+
+func resetBTreeArenaPoolForTest(t *testing.T) {
+	t.Helper()
+	prevNumGC := btreeArenaPoolNumGC
+	for i := range btreeArenaChunkPools {
+		btreeArenaChunkPools[i] = sync.Pool{}
+	}
+	btreeArenaPoolBytes.Store(0)
+	btreeArenaPoolLastGC.Store(0)
+	t.Cleanup(func() {
+		btreeArenaPoolNumGC = prevNumGC
+		for i := range btreeArenaChunkPools {
+			btreeArenaChunkPools[i] = sync.Pool{}
+		}
+		btreeArenaPoolBytes.Store(0)
+		btreeArenaPoolLastGC.Store(0)
+	})
 }
 
 func arenaChunkSizes(a *btreeArena) []int {

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -239,6 +239,28 @@ func TestBTreeSetEntryCopiesKeyValue(t *testing.T) {
 	}
 }
 
+func TestBTreeOperationMixTracksCurrentDeletes(t *testing.T) {
+	m := NewBTree()
+	m.Set([]byte("a"), []byte("va"))
+	m.Delete([]byte("b"))
+	m.Delete([]byte("c"))
+
+	if got := m.OperationMix(); got.Entries != 3 || got.Deletes != 2 {
+		t.Fatalf("OperationMix after inserts=%+v, want entries=3 deletes=2", got)
+	}
+
+	m.Set([]byte("b"), []byte("vb"))
+	m.Delete([]byte("a"))
+	if got := m.OperationMix(); got.Entries != 3 || got.Deletes != 2 {
+		t.Fatalf("OperationMix after replacements=%+v, want entries=3 deletes=2", got)
+	}
+
+	m.Reset()
+	if got := m.OperationMix(); got.Entries != 0 || got.Deletes != 0 {
+		t.Fatalf("OperationMix after reset=%+v, want zero", got)
+	}
+}
+
 func TestBTreeArenaUsesSmallInitialChunkThenGrows(t *testing.T) {
 	a := &btreeArena{
 		maxChunkSize:     256,
@@ -318,6 +340,52 @@ func TestBTreeResetKeepsFirstArenaChunk(t *testing.T) {
 	if got := m.arena.offset; got != 0 {
 		t.Fatalf("offset after reset=%d want 0", got)
 	}
+}
+
+func TestBTreeArenaPoolClasses(t *testing.T) {
+	tests := []struct {
+		size      int
+		classSize int
+		ok        bool
+	}{
+		{size: (64 << 10) - 1, ok: false},
+		{size: 64 << 10, classSize: 64 << 10, ok: true},
+		{size: (64 << 10) + 1, classSize: 128 << 10, ok: true},
+		{size: 1 << 20, classSize: 1 << 20, ok: true},
+		{size: (1 << 20) + 1, ok: false},
+	}
+	for _, tt := range tests {
+		_, gotClass, gotOK := btreeArenaClassForLen(tt.size)
+		if gotOK != tt.ok || gotClass != tt.classSize {
+			t.Fatalf("btreeArenaClassForLen(%d)=(%d,%t), want (%d,%t)", tt.size, gotClass, gotOK, tt.classSize, tt.ok)
+		}
+	}
+}
+
+func TestBTreeArenaReusesReleasedChunk(t *testing.T) {
+	btreeArenaPoolBytes.Store(0)
+	a := &btreeArena{
+		maxChunkSize:     btreeArenaChunkSize,
+		initialChunkSize: btreeArenaInitialChunkSize,
+	}
+	a.Copy(make([]byte, btreeArenaInitialChunkSize))
+	a.Copy(make([]byte, btreeArenaInitialChunkSize+1))
+	if got := len(a.chunks); got != 2 {
+		t.Fatalf("chunks before reset=%d want 2", got)
+	}
+	released := a.chunks[1]
+	a.resetKeepFirstChunk()
+	if got := len(a.chunks); got != 1 {
+		t.Fatalf("chunks after reset=%d want 1", got)
+	}
+	if got := btreeArenaPoolBytes.Load(); got < int64(cap(released)) {
+		t.Fatalf("pooled bytes=%d want at least %d", got, cap(released))
+	}
+	reused := getBTreeArenaChunk(cap(released))
+	if cap(reused) != cap(released) {
+		t.Fatalf("reused chunk cap=%d want %d", cap(reused), cap(released))
+	}
+	putBTreeArenaChunk(reused)
 }
 
 func TestBTreeIteratorUnsafeEntry_ForInlinePointerAndTombstone(t *testing.T) {


### PR DESCRIPTION
## Summary
- recycle retired BTree memtables through a small bounded lease list
- return released BTree arena chunks to bounded size-class pools on reset
- track BTree delete mix so delete-heavy BTree flushes can stream without generic BTree stable streaming

## Validation
- go test -count=1 ./TreeDB/internal/memtable ./TreeDB/caching
- go test -race -count=1 ./TreeDB/internal/memtable
- go test -race -count=1 ./TreeDB/caching

## Profile
Fresh binary: /tmp/unified-bench-btree-opmix-deleteheavy
Profile dir: /tmp/profile_btree_deleteheavy_opmix_1m_VD6xUU
Command: /tmp/unified-bench-btree-opmix-deleteheavy -dbs treedb -profile fast -keys 1000000 -treedb-memtable-mode btree -test batch_write,batch_write_steady,batch_random,batch_small_seq,random_delete,batch_delete,dataset_write_sorted,sequential_write -profile-dir /tmp/profile_btree_deleteheavy_opmix_1m_VD6xUU

Same-machine baseline from codex/btree-combined-entry-copy: /tmp/profile_btree_combinedcopy_current_1m_VCSmZj
- batch_write: 4,077,660 vs 4,081,521 baseline
- batch_write_steady: 2,015,049 vs 2,002,067 baseline
- batch_random: 2,920,410 vs 2,857,823 baseline
- batch_small_seq: 10,307,246 vs 11,152,707 baseline
- random_delete: 1,705,949 vs 1,214,938 baseline
- batch_delete: 2,017,529 vs 1,919,726 baseline
- dataset_write_sorted: 3,633,024 vs 2,181,892 baseline
- sequential_write: 3,721,331 vs 3,483,638 baseline

Note: batch_small_seq regressed in this full ordered run; the other measured tests are neutral-to-positive. I kept the change because the allocation regression in batch_delete was fixed by restricting BTree streaming to delete-heavy flushes only.