### PR TITLE
Use right split capacity for BTree memtables

### DIFF
--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -191,7 +191,7 @@ func NewBTreeWithDegree(degree int) *BTree {
 		degree = btreeDefaultDegree
 	}
 	return &BTree{
-		tree:   btree.NewMap[string, btreeEntry](degree),
+		tree:   newBTreeMap(degree),
 		degree: degree,
 		arena: &btreeArena{
 			maxChunkSize:     btreeArenaChunkSize,
@@ -200,13 +200,19 @@ func NewBTreeWithDegree(degree int) *BTree {
 	}
 }
 
+func newBTreeMap(degree int) *btree.Map[string, btreeEntry] {
+	return btree.NewMapWithOptions[string, btreeEntry](degree, btree.MapOptions{
+		ReuseRightSplitCapacity: true,
+	})
+}
+
 // Reset clears all entries while retaining internal allocations.
 func (m *BTree) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if m.tree == nil {
-		m.tree = btree.NewMap[string, btreeEntry](m.degree)
+		m.tree = newBTreeMap(m.degree)
 	} else {
 		m.tree.Clear()
 	}
@@ -434,7 +440,6 @@ func (m *BTree) NewReverseIterator(start, end []byte) iterator.UnsafeIterator {
 			valid = iter.Last()
 		}
 	}
-
 	it := &btreeReverseIterator{
 		iter:     iter,
 		start:    startKey,

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,8 @@ require (
 	gonum.org/v1/plot v0.16.0
 )
 
+replace github.com/tidwall/btree => github.com/snissn/tidwall-btree v0.0.0-20260424113355-de381a45250c
+
 require (
 	codeberg.org/go-fonts/liberation v0.5.0 // indirect
 	codeberg.org/go-latex/latex v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,15 +147,14 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/snissn/compress v1.18.2-snissn.0.0.20260204222835-33fc0851d88e h1:l7jLklDDpTMHvsUEmzIudcHa3AF+c8eKNmsiyL4k5lw=
 github.com/snissn/compress v1.18.2-snissn.0.0.20260204222835-33fc0851d88e/go.mod h1:p4xiZN07JMUF5xuybNGkG+pozT12MAblxCx36z+PIYM=
+github.com/snissn/tidwall-btree v0.0.0-20260424113355-de381a45250c h1:vt1vnxx8RRHum2z+UzOeuoO0PVt8BrkPOjSGfxW87jw=
+github.com/snissn/tidwall-btree v0.0.0-20260424113355-de381a45250c/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tidwall/assert v0.1.0 h1:aWcKyRBUAdLoVebxo95N7+YZVTFF/ASTr7BN4sLP6XI=
 github.com/tidwall/assert v0.1.0/go.mod h1:QLYtGyeqse53vuELQheYl9dngGCJQ+mTtlxcktb+Kj8=
-github.com/tidwall/btree v1.1.0/go.mod h1:TzIRzen6yHbibdSfK6t8QimqbUnoxUSrZfeW7Uob0q4=
-github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
-github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/tidwall/buntdb v1.3.2 h1:qd+IpdEGs0pZci37G4jF51+fSKlkuUTMXuHhXL1AkKg=
 github.com/tidwall/buntdb v1.3.2/go.mod h1:lZZrZUWzlyDJKlLQ6DKAy53LnG7m5kHyrEHvvcDmBpU=
 github.com/tidwall/gjson v1.12.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=


### PR DESCRIPTION
## Summary
- pin the snissn tidwall-btree fork containing `MapOptions.ReuseRightSplitCapacity`
- construct BTree memtable maps with that option enabled
- keeps the narrower right-split capacity optimization, without the rejected node-reuse or sorted-tail experiments

## Validation
- `go test -count=1 ./TreeDB/internal/memtable ./TreeDB/caching ./cmd/unified_bench`
- `go test -race -count=1 ./TreeDB/internal/memtable`
- `go test -race -count=1 ./TreeDB/caching`
- `go test ./...` in `/Users/michaelseiler/dev/snissn/tidwall-btree`

## Profile
Command:
```sh
/tmp/unified-bench-btree-rightsplit-confirm -dbs treedb -profile fast -keys 1000000 -treedb-memtable-mode btree -test batch_write,batch_write_steady,batch_random,batch_small_seq,random_delete,batch_delete,dataset_write_sorted,sequential_write -profile-dir /tmp/profile_btree_rightsplit_confirm_1m_gyF3zZ
```

Results:
- batch_write: 4,042,482
- batch_write_steady: 2,022,385
- batch_random: 2,854,730
- batch_small_seq: 11,506,586
- random_delete: 1,673,962
- batch_delete: 2,015,737
- dataset_write_sorted: 3,670,211
- sequential_write: 3,683,272

Allocation check: `batch_small_seq` alloc_space was 86.00MB in `/tmp/profile_btree_rightsplit_confirm_1m_gyF3zZ`, down from 138.69MB in the #1034 comparison profile.

Depends on snissn/tidwall-btree#2.