### PR TITLE
Use pending-insert split capacity for BTree memtables

### DIFF
--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -202,7 +202,8 @@ func NewBTreeWithDegree(degree int) *BTree {
 
 func newBTreeMap(degree int) *btree.Map[string, btreeEntry] {
 	return btree.NewMapWithOptions[string, btreeEntry](degree, btree.MapOptions{
-		ReuseRightSplitCapacity: true,
+		ReuseRightSplitCapacity:  true,
+		ReuseSplitInsertCapacity: true,
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	gonum.org/v1/plot v0.16.0
 )
 
-replace github.com/tidwall/btree => github.com/snissn/tidwall-btree v0.0.0-20260424113355-de381a45250c
+replace github.com/tidwall/btree => github.com/snissn/tidwall-btree v0.0.0-20260424143640-2c9ca68b9023
 
 require (
 	codeberg.org/go-fonts/liberation v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/snissn/compress v1.18.2-snissn.0.0.20260204222835-33fc0851d88e h1:l7jLklDDpTMHvsUEmzIudcHa3AF+c8eKNmsiyL4k5lw=
 github.com/snissn/compress v1.18.2-snissn.0.0.20260204222835-33fc0851d88e/go.mod h1:p4xiZN07JMUF5xuybNGkG+pozT12MAblxCx36z+PIYM=
-github.com/snissn/tidwall-btree v0.0.0-20260424113355-de381a45250c h1:vt1vnxx8RRHum2z+UzOeuoO0PVt8BrkPOjSGfxW87jw=
-github.com/snissn/tidwall-btree v0.0.0-20260424113355-de381a45250c/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
+github.com/snissn/tidwall-btree v0.0.0-20260424143640-2c9ca68b9023 h1:CS56D2PrzWJfiBO7RtdBazVmcqKH/5tUXi1BEGvNo54=
+github.com/snissn/tidwall-btree v0.0.0-20260424143640-2c9ca68b9023/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=


### PR DESCRIPTION
## Summary\n- bump the snissn/tidwall-btree fork to the split-insert capacity commit from snissn/tidwall-btree#3\n- enable ReuseSplitInsertCapacity for TreeDB BTree memtables alongside the existing right-split capacity option\n\n## Validation\n- go test -count=1 ./TreeDB/internal/memtable ./TreeDB/caching ./cmd/unified_bench\n- go test -race -count=1 ./TreeDB/internal/memtable\n- go test -race -count=1 ./TreeDB/caching\n\n## Profile notes\nFresh binary: /tmp/unified-bench-btree-splitdirect\nCombined 1M profile dir: /tmp/profile_btree_splitdirect_1m_hioyqa\nCompared to the previous right-split 1M profile, the combined run improved batch_write, batch_write_steady, batch_random, random_delete, batch_delete, and sequential_write; batch_small_seq and dataset_write_sorted were close in the combined run and improved in isolated confirmation runs.