### PR TITLE
Use BTree Load for append-ordered memtable sets

### DIFF
--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -15,7 +15,6 @@ import (
 )
 
 const btreeDefaultDegree = 32
-const btreeUseLoadFastPath = false
 const btreeArenaChunkSize = 1 << 20
 const btreeArenaInitialChunkSize = 64 << 10
 const btreeInlineValueDedupeMax = 1 << 20
@@ -747,7 +746,7 @@ func (it *btreeReverseIterator) refresh() {
 }
 
 func (m *BTree) setMaybeLoadLocked(key string, entry btreeEntry) (btreeEntry, bool) {
-	if btreeUseLoadFastPath && m.hasLast && key > m.lastKey {
+	if m.hasLast && key > m.lastKey {
 		return m.tree.Load(key, entry)
 	}
 	return m.tree.Set(key, entry)

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -113,6 +113,37 @@ func TestBTreeSetEntryPreservesExtraFlagBits(t *testing.T) {
 	}
 }
 
+func TestBTreeSetEntryAppendFastPathMixedUpdates(t *testing.T) {
+	m := NewBTreeWithDegree(2)
+	key := func(i int) []byte {
+		return []byte{byte(i >> 8), byte(i)}
+	}
+
+	for i := 0; i < 128; i++ {
+		m.Set(key(i), []byte{byte(i)})
+	}
+	m.Set(key(64), []byte("overwrite"))
+	m.Delete(key(127))
+	m.Set(key(128), []byte("new-max"))
+	m.Set(key(1), []byte("low-overwrite"))
+
+	if got := m.Len(); got != 129 {
+		t.Fatalf("Len()=%d want 129", got)
+	}
+	if got, del, ok := m.Get(key(64)); !ok || del || string(got) != "overwrite" {
+		t.Fatalf("Get(64)=(%q,%v,%v), want overwrite,false,true", string(got), del, ok)
+	}
+	if got, del, ok := m.Get(key(127)); !ok || !del || got != nil {
+		t.Fatalf("Get(127)=(%v,%v,%v), want nil,true,true", got, del, ok)
+	}
+	if got, del, ok := m.Get(key(128)); !ok || del || string(got) != "new-max" {
+		t.Fatalf("Get(128)=(%q,%v,%v), want new-max,false,true", string(got), del, ok)
+	}
+	if got, del, ok := m.Get(key(1)); !ok || del || string(got) != "low-overwrite" {
+		t.Fatalf("Get(1)=(%q,%v,%v), want low-overwrite,false,true", string(got), del, ok)
+	}
+}
+
 func TestBTreePointerEmptySliceCanonicalizesToNil(t *testing.T) {
 	ptr := page.ValuePtr{Offset: 21, Length: 34, FileID: 5}
 


### PR DESCRIPTION
## Summary
- remove the disabled BTree Load guard and use Load whenever the incoming key is greater than the memtable's recorded max key
- keep all non-append-ordered writes on Set, so overwrites/deletes below max still take the general path
- add mixed update coverage for ascending inserts, overwrites below max, max tombstones, and a new max key

## Validation
- go test -count=1 ./TreeDB/internal/memtable ./TreeDB/caching ./cmd/unified_bench

## Benchmark signal
Using freshly built binaries with -dbs treedb -profile fast -keys 1000000 -treedb-memtable-mode btree and test subset batch_write,batch_write_steady,batch_random,batch_small_seq,random_delete,batch_delete,dataset_write_sorted,sequential_write:

Baseline split-direct profile: /tmp/profile_btree_splitdirect_subset1m_u2ngOP
- batch_write 4,141,205
- batch_write_steady 1,924,218
- batch_random 2,929,981
- batch_small_seq 11,334,624
- random_delete 1,711,912
- batch_delete 2,057,202
- dataset_write_sorted 3,553,347
- sequential_write 3,282,754

Patched profile: /tmp/profile_btree_loadfast_subset1m_pYN223
- batch_write 4,218,133
- batch_write_steady 2,022,239
- batch_random 2,964,930
- batch_small_seq 11,222,054
- random_delete 1,684,007
- batch_delete 2,036,067
- dataset_write_sorted 4,400,138
- sequential_write 3,784,267