### PR TITLE
Use direct BTree leaf split insert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	gonum.org/v1/plot v0.16.0
 )
 
-replace github.com/tidwall/btree => github.com/snissn/tidwall-btree v0.0.0-20260424143640-2c9ca68b9023
+replace github.com/tidwall/btree => github.com/snissn/tidwall-btree v0.0.0-20260424182822-a686a2602ef3
 
 require (
 	codeberg.org/go-fonts/liberation v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/snissn/compress v1.18.2-snissn.0.0.20260204222835-33fc0851d88e h1:l7jLklDDpTMHvsUEmzIudcHa3AF+c8eKNmsiyL4k5lw=
 github.com/snissn/compress v1.18.2-snissn.0.0.20260204222835-33fc0851d88e/go.mod h1:p4xiZN07JMUF5xuybNGkG+pozT12MAblxCx36z+PIYM=
-github.com/snissn/tidwall-btree v0.0.0-20260424143640-2c9ca68b9023 h1:CS56D2PrzWJfiBO7RtdBazVmcqKH/5tUXi1BEGvNo54=
-github.com/snissn/tidwall-btree v0.0.0-20260424143640-2c9ca68b9023/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
+github.com/snissn/tidwall-btree v0.0.0-20260424182822-a686a2602ef3 h1:5vdZVtYxBG84dOLlH3NmHGwR3tFE61O0iQfDvyWurgE=
+github.com/snissn/tidwall-btree v0.0.0-20260424182822-a686a2602ef3/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=


### PR DESCRIPTION
## Summary
- update the TreeDB BTree memtable dependency to snissn/tidwall-btree `a686a26`
- pulls in direct full-leaf split+insert from tidwall-btree PR #5

## Validation
- `go test -count=1 ./TreeDB/internal/memtable ./TreeDB/caching ./cmd/unified_bench`
- `./bin/unified-bench -dbs treedb -profile fast -keys 1000000 -treedb-memtable-mode btree -test random_write,dataset_write_random,batch_write,batch_random,batch_delete,batch_small_seq,random_delete -profile-dir /tmp/profile_btree_directsplit_pseudo_write_YqEX2h -progress=false -gc-between-tests`

## Profile signal
Paired against the previous pinned fork pseudo-version on the same 1M write-heavy subset:
- `random_write`: `1,755,686` -> `1,859,992`
- `dataset_write_random`: `1,270,540` -> `1,417,532`
- `batch_write`: `14,310,605` -> `15,192,470`
- `batch_random`: `2,436,162` -> `2,843,341`
- `batch_delete`: `2,583,548` -> `2,664,159`
- `batch_small_seq`: `11,618,034` -> `12,354,087`
- `random_delete`: `1,767,560` -> `1,830,001`
- `batch_random alloc_space`: about `181MB` -> `165MB`
