### PR TITLE
Stream stable BTree flush runs

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -11740,11 +11740,6 @@ func stableFlushStreamingPlan(units []flushUnit, totalLen int) (int, bool) {
 	if !stableFlushStreamingSources(units) {
 		return 0, false
 	}
-	for i := range units {
-		if _, isBTree := units[i].mem.(*memtable.BTree); isBTree {
-			return 0, false
-		}
-	}
 	deleteOps, ok := flushStreamingDeleteOps(units, totalLen)
 	if !ok {
 		return 0, false

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -1035,7 +1035,7 @@ func TestFlushLaneOnce_FallsBackFromPointerViewForUnstableIterators(t *testing.T
 }
 
 func TestFlushLaneOnce_DeleteHeavyParallelStreamsWithoutEntryRuns(t *testing.T) {
-	for _, mode := range []string{"append_only", "hash_sorted"} {
+	for _, mode := range []string{"append_only", "hash_sorted", "btree"} {
 		t.Run(mode, func(t *testing.T) {
 			testFlushLaneOnceDeleteHeavyParallelStreamsWithoutEntryRuns(t, mode)
 		})
@@ -1104,13 +1104,15 @@ func TestFlushStreamingDeleteOps(t *testing.T) {
 	if deleteOps, ok := deleteHeavyStreamingDeleteOps([]flushUnit{{mem: btree}}, btree.Len()); !ok || deleteOps != 3 {
 		t.Fatalf("BTree deleteHeavyStreamingDeleteOps=(%d,%t), want (3,true)", deleteOps, ok)
 	}
-	if _, ok := stableFlushStreamingPlan([]flushUnit{{mem: btree}}, btree.Len()); ok {
-		t.Fatal("BTree generic stable plan should stay materialized; delete-heavy path handles BTree separately")
+	if planDeleteOps, ok := stableFlushStreamingPlan([]flushUnit{{mem: btree}}, btree.Len()); !ok {
+		t.Fatal("expected BTree memtable to qualify for stable streaming plan")
+	} else if planDeleteOps != 3 {
+		t.Fatalf("BTree stable plan deleteOps=%d want=3", planDeleteOps)
 	}
 }
 
 func TestFlushLaneOnce_StableParallelStreamsWithoutEntryRuns(t *testing.T) {
-	for _, mode := range []string{"append_only", "hash_sorted"} {
+	for _, mode := range []string{"append_only", "hash_sorted", "btree"} {
 		t.Run(mode, func(t *testing.T) {
 			testFlushLaneOnceStableParallelStreamsWithoutEntryRuns(t, mode)
 		})


### PR DESCRIPTION
## Summary
- Allow BTree memtables to use the existing stable parallel flush streaming path instead of materializing batch.Entry runs.
- Expand flush streaming tests so BTree is covered for generic stable streaming and delete-heavy streaming.

## Validation
- go test -count=1 ./TreeDB/caching -run 'TestFlushLaneOnce_(StableParallelStreamsWithoutEntryRuns|DeleteHeavyParallelStreamsWithoutEntryRuns)|TestFlushStreamingDeleteOps'
- go test -count=1 ./TreeDB/internal/memtable ./TreeDB/caching ./cmd/unified_bench
- make unified-bench

## Profile check
Base: origin/codex/btree-direct-leaf-split at /tmp/profile_btree_stream_base_Bp5uB2
Current: codex/btree-stable-flush-streaming at /tmp/profile_btree_stream_current_fcep2K

Command:
./bin/unified-bench -dbs treedb -profile fast -keys 1000000 -treedb-memtable-mode btree -test batch_random -profile-dir <dir> -progress=false -gc-between-tests

Result:
- Throughput: 2,774,056 ops/sec base vs 2,744,515 ops/sec current (neutral/noisy)
- alloc_space: 179.53 MB base vs 146.79 MB current
- getEntrySlice: 35.04 MB base vs absent from current top allocators