### PR TITLE
Prepare contended leaf-log appends outside writer lock

### DIFF
--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -1,6 +1,7 @@
 package caching
 
 import (
+	"sync"
 	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -15,8 +16,38 @@ type cachingLeafPageLog struct {
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLog)(nil)
 
+var preparedLeafPageRecordPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, 0, valuelog.HeaderSize+valuelog.FrameHeaderSize+16+page.PageSize)
+		return &buf
+	},
+}
+
 func newCachingLeafPageLog(db *DB, l *lane) backenddb.LeafPageLog {
 	return &cachingLeafPageLog{db: db, lane: l}
+}
+
+func getPreparedLeafPageRecordBuffer() *[]byte {
+	buf, _ := preparedLeafPageRecordPool.Get().(*[]byte)
+	if buf == nil {
+		b := make([]byte, 0, valuelog.HeaderSize+valuelog.FrameHeaderSize+16+page.PageSize)
+		return &b
+	}
+	return buf
+}
+
+func putPreparedLeafPageRecordBuffer(buf *[]byte) {
+	if buf == nil {
+		return
+	}
+	const maxKeep = 64 << 10
+	if cap(*buf) > maxKeep {
+		b := make([]byte, 0, valuelog.HeaderSize+valuelog.FrameHeaderSize+16+page.PageSize)
+		*buf = b
+	} else {
+		*buf = (*buf)[:0]
+	}
+	preparedLeafPageRecordPool.Put(buf)
 }
 
 func (db *DB) noteLeafGenerationRecordLength(ptr page.ValuePtr) {
@@ -28,80 +59,47 @@ func (db *DB) noteLeafGenerationRecordLength(ptr page.ValuePtr) {
 	}
 }
 
-func (db *DB) appendLeafPageValueLog(l *lane, rid uint64, leafPage []byte) (page.ValuePtr, string, error) {
-	if !db.splitValueLogEnabled() {
-		return page.ValuePtr{}, "", errWALUnavailable
+// appendPreparedLeafPageValueLog appends a raw leaf-page record that was encoded
+// outside vlogMu. The caller must hold l.vlogMu; this helper releases it while
+// preparing the record and returns with the mutex unlocked.
+func (db *DB) appendPreparedLeafPageValueLog(l *lane, rid uint64, leafPage []byte) (page.ValuePtr, string, valuelog.FrameStats, bool, int, int64, error) {
+	l.vlogMu.Unlock()
+	bufp := getPreparedLeafPageRecordBuffer()
+	raw, stats, compacted, ptrLength, err := valuelog.PrepareCompactLeafPageRecord((*bufp)[:0], rid, leafPage)
+	if err != nil {
+		putPreparedLeafPageRecordBuffer(bufp)
+		return page.ValuePtr{}, "", valuelog.FrameStats{}, false, 0, 0, err
 	}
-	if l == nil {
-		return page.ValuePtr{}, "", errWALUnavailable
-	}
-	select {
-	case <-db.closeCh:
-		return page.ValuePtr{}, "", errWALClosed
-	default:
-	}
+	payloadLen := stats.RawPayloadBytes
 
 	l.vlogMu.Lock()
-	selectorStart := time.Now()
-	w := l.vlog
-	if w == nil {
+	defer func() {
+		putPreparedLeafPageRecordBuffer(bufp)
+	}()
+
+	w, ok := l.vlog.(*valuelog.Writer)
+	if !ok || w == nil {
 		l.vlogMu.Unlock()
-		return page.ValuePtr{}, "", errWALUnavailable
+		return page.ValuePtr{}, "", valuelog.FrameStats{}, false, 0, 0, errWALUnavailable
 	}
 	if rotateErr := db.rotateValueLogForMaxSegmentMuHeld(l, w); rotateErr != nil {
 		l.vlogMu.Unlock()
-		return page.ValuePtr{}, "", rotateErr
+		return page.ValuePtr{}, "", valuelog.FrameStats{}, false, 0, 0, rotateErr
 	}
-	w = l.vlog
-	if w == nil {
+	w, ok = l.vlog.(*valuelog.Writer)
+	if !ok || w == nil {
 		l.vlogMu.Unlock()
-		return page.ValuePtr{}, "", errWALUnavailable
+		return page.ValuePtr{}, "", valuelog.FrameStats{}, false, 0, 0, errWALUnavailable
 	}
 	if l.vlogCaps.writer != w {
 		l.vlogCaps = computeVlogWriterCaps(w)
 	}
+	db.setVlogWriterMode(l, w, vlogWriteOff, db.valueLogBlockCodec)
 
-	concrete, ok := w.(*valuelog.Writer)
-	if !ok || db.valueLogTemplateEnabled {
-		l.vlogMu.Unlock()
-		encodedLeafPage, _, err := valuelog.MaybeCompactLeafLogPayload(leafPage)
-		if err != nil {
-			return page.ValuePtr{}, "", err
-		}
-		return db.appendValueLogOneInternal(l, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
-	}
-
-	payloadLen, compacted, err := valuelog.CompactLeafLogPayloadLen(leafPage)
-	if err != nil {
-		l.vlogMu.Unlock()
-		return page.ValuePtr{}, "", err
-	}
-	writeMode, blockCodec, probeCompression := db.resolveVlogWriteMode(l, 0, payloadLen, payloadLen, compacted)
-	if writeMode == vlogWriteBlock {
-		if codec, ok := db.preferLeafPageBlockCodec(l, payloadLen, blockCodec); ok {
-			blockCodec = codec
-		} else {
-			compressionMode := normalizeVlogCompressionMode(db.valueLogCompressionMode)
-			if (compressionMode == vlogCompressionAuto || compressionMode == vlogCompressionDefault) &&
-				normalizeVlogAutoPolicy(db.valueLogAutoPolicy) != vlogAutoThroughput &&
-				payloadLen >= 2048 {
-				blockCodec = chooseLargePayloadNoDictBlockCodec(l, db.valueLogBlockCodec)
-			}
-		}
-	}
-	finalWriteMode := vlogWriteOff
-	if writeMode == vlogWriteBlock {
-		finalWriteMode = vlogWriteBlock
-	}
-	finalBlockCodec := db.valueLogBlockCodec
-	if finalWriteMode == vlogWriteBlock {
-		finalBlockCodec = blockCodec
-	}
-	db.setVlogWriterMode(l, w, finalWriteMode, finalBlockCodec)
 	startSize := w.Size()
-	ptr, stats, compacted, err := concrete.AppendCompactLeafPage(rid, leafPage)
+	ptr, err := w.AppendRawRecordBuffered(raw, ptrLength)
 	flushedBoundary := false
-	if err == nil && db.shouldFlushDeferredValueLogValue(finalWriteMode, leafPage) {
+	if err == nil && db.shouldFlushDeferredValueLogValue(vlogWriteOff, leafPage) {
 		err = w.Flush()
 		flushedBoundary = err == nil
 	}
@@ -125,8 +123,12 @@ func (db *DB) appendLeafPageValueLog(l *lane, rid uint64, leafPage []byte) (page
 	}
 	l.vlogMu.Unlock()
 	if err != nil {
-		return page.ValuePtr{}, "", err
+		return page.ValuePtr{}, "", valuelog.FrameStats{}, false, 0, 0, err
 	}
+	return ptr, retainPath, stats, compacted, payloadLen, totalBytes, nil
+}
+
+func (db *DB) observeLeafPageValueLogAppend(l *lane, ptr page.ValuePtr, retainPath string, stats valuelog.FrameStats, compacted bool, finalWriteMode vlogCompressionWriteMode, finalBlockCodec valuelog.BlockCodec, payloadLen int, totalBytes int64, probeCompression bool, selectorStart time.Time) (page.ValuePtr, string, error) {
 	if totalBytes > 0 {
 		l.vlogLiveBytes.Add(totalBytes)
 	}
@@ -158,6 +160,118 @@ func (db *DB) appendLeafPageValueLog(l *lane, rid uint64, leafPage []byte) (page
 	}
 	db.observeVlogWriteMode(l, finalWriteMode, finalBlockCodec, payloadLen, payloadLen, storedForSelector, probeCompression, time.Since(selectorStart).Nanoseconds())
 	return ptr, retainPath, nil
+}
+
+func (db *DB) appendLeafPageValueLog(l *lane, rid uint64, leafPage []byte) (page.ValuePtr, string, error) {
+	if !db.splitValueLogEnabled() {
+		return page.ValuePtr{}, "", errWALUnavailable
+	}
+	if l == nil {
+		return page.ValuePtr{}, "", errWALUnavailable
+	}
+	select {
+	case <-db.closeCh:
+		return page.ValuePtr{}, "", errWALClosed
+	default:
+	}
+
+	selectorStart := time.Now()
+	payloadLen, compacted, err := valuelog.CompactLeafLogPayloadLen(leafPage)
+	if err != nil {
+		return page.ValuePtr{}, "", err
+	}
+	locked := l.vlogMu.TryLock()
+	contended := !locked
+	if contended {
+		l.vlogMu.Lock()
+	}
+	w := l.vlog
+	if w == nil {
+		l.vlogMu.Unlock()
+		return page.ValuePtr{}, "", errWALUnavailable
+	}
+	if rotateErr := db.rotateValueLogForMaxSegmentMuHeld(l, w); rotateErr != nil {
+		l.vlogMu.Unlock()
+		return page.ValuePtr{}, "", rotateErr
+	}
+	w = l.vlog
+	if w == nil {
+		l.vlogMu.Unlock()
+		return page.ValuePtr{}, "", errWALUnavailable
+	}
+	if l.vlogCaps.writer != w {
+		l.vlogCaps = computeVlogWriterCaps(w)
+	}
+
+	concrete, ok := w.(*valuelog.Writer)
+	if !ok || db.valueLogTemplateEnabled {
+		l.vlogMu.Unlock()
+		encodedLeafPage, _, err := valuelog.MaybeCompactLeafLogPayload(leafPage)
+		if err != nil {
+			return page.ValuePtr{}, "", err
+		}
+		return db.appendValueLogOneInternal(l, 0, nil, rid, encodedLeafPage, journalDurabilityNone, false)
+	}
+
+	writeMode, blockCodec, probeCompression := db.resolveVlogWriteMode(l, 0, payloadLen, payloadLen, compacted)
+	if writeMode == vlogWriteBlock {
+		if codec, ok := db.preferLeafPageBlockCodec(l, payloadLen, blockCodec); ok {
+			blockCodec = codec
+		} else {
+			compressionMode := normalizeVlogCompressionMode(db.valueLogCompressionMode)
+			if (compressionMode == vlogCompressionAuto || compressionMode == vlogCompressionDefault) &&
+				normalizeVlogAutoPolicy(db.valueLogAutoPolicy) != vlogAutoThroughput &&
+				payloadLen >= 2048 {
+				blockCodec = chooseLargePayloadNoDictBlockCodec(l, db.valueLogBlockCodec)
+			}
+		}
+	}
+	finalWriteMode := vlogWriteOff
+	if writeMode == vlogWriteBlock {
+		finalWriteMode = vlogWriteBlock
+	}
+	finalBlockCodec := db.valueLogBlockCodec
+	if finalWriteMode == vlogWriteBlock {
+		finalBlockCodec = blockCodec
+	}
+	if contended && finalWriteMode == vlogWriteOff {
+		ptr, retainPath, stats, compacted, payloadLen, totalBytes, err := db.appendPreparedLeafPageValueLog(l, rid, leafPage)
+		if err != nil {
+			return page.ValuePtr{}, "", err
+		}
+		return db.observeLeafPageValueLogAppend(l, ptr, retainPath, stats, compacted, finalWriteMode, finalBlockCodec, payloadLen, totalBytes, probeCompression, selectorStart)
+	}
+	db.setVlogWriterMode(l, w, finalWriteMode, finalBlockCodec)
+	startSize := w.Size()
+	ptr, stats, compacted, err := concrete.AppendCompactLeafPage(rid, leafPage)
+	flushedBoundary := false
+	if err == nil && db.shouldFlushDeferredValueLogValue(finalWriteMode, leafPage) {
+		err = w.Flush()
+		flushedBoundary = err == nil
+	}
+	totalBytes := int64(0)
+	if err == nil {
+		totalBytes = w.Size() - startSize
+	}
+	retainPath := ""
+	if l.vlogPath != "" && l.vlogPath != l.vlogRetainedPath {
+		l.vlogRetainedPath = l.vlogPath
+		retainPath = l.vlogPath
+	}
+	if err == nil {
+		db.markLaneValueLogBoundary(l, totalBytes, flushedBoundary, false)
+		if !flushedBoundary && totalBytes > 0 {
+			l.backendReadDirtySeq.Add(1)
+		}
+	}
+	if db.testBeforeVlogUnlock != nil {
+		db.testBeforeVlogUnlock(int(l.id))
+	}
+	l.vlogMu.Unlock()
+	if err != nil {
+		return page.ValuePtr{}, "", err
+	}
+	return db.observeLeafPageValueLogAppend(l, ptr, retainPath, stats, compacted, finalWriteMode, finalBlockCodec, payloadLen, totalBytes, probeCompression, selectorStart)
 }
 
 func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -1,6 +1,7 @@
 package caching
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -119,6 +120,31 @@ func buildSparseLeafPageForLeafLogTest(t *testing.T) []byte {
 	return buf
 }
 
+func requireLeafLogTestPagesEqual(t *testing.T, want, got []byte) {
+	t.Helper()
+	wantNode := node.NewNodeView(want)
+	gotNode := node.NewNodeView(got)
+	if wantNode.Type() != gotNode.Type() {
+		t.Fatalf("page types differ: got=%d want=%d", gotNode.Type(), wantNode.Type())
+	}
+	if wantNode.Count() != gotNode.Count() {
+		t.Fatalf("page counts differ: got=%d want=%d", gotNode.Count(), wantNode.Count())
+	}
+	for i := uint16(0); i < wantNode.Count(); i++ {
+		wantKey, wantVal, wantPtr, wantFlags, err := wantNode.GetLeafEntryView(i)
+		if err != nil {
+			t.Fatalf("want GetLeafEntryView(%d): %v", i, err)
+		}
+		gotKey, gotVal, gotPtr, gotFlags, err := gotNode.GetLeafEntryView(i)
+		if err != nil {
+			t.Fatalf("got GetLeafEntryView(%d): %v", i, err)
+		}
+		if !bytes.Equal(gotKey, wantKey) || !bytes.Equal(gotVal, wantVal) || gotPtr != wantPtr || gotFlags != wantFlags {
+			t.Fatalf("leaf entry %d mismatch", i)
+		}
+	}
+}
+
 func TestCachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := valuelog.EncodeFileID(uint32(leafLogLaneID), 1)
@@ -151,4 +177,77 @@ func TestCachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload(t *testing.T
 	if info.Size() >= int64(valuelog.HeaderSize+page.PageSize) {
 		t.Fatalf("file size=%d want compact leaf payload smaller than raw %d", info.Size(), valuelog.HeaderSize+page.PageSize)
 	}
+}
+
+func TestDB_AppendPreparedLeafPageValueLog_AppendsAndReturnsUnlocked(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := valuelog.EncodeFileID(uint32(leafLogLaneID), 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	leafDir := filepath.Join(dir, "leaf_vlog")
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", leafDir, err)
+	}
+	path := filepath.Join(leafDir, "value-l255-000001.log")
+	writer, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() {
+		if writer != nil {
+			_ = writer.Close()
+		}
+	}()
+
+	db := &DB{
+		closeCh:                 make(chan struct{}),
+		valueLogCompressionMode: uint8(vlogCompressionOff),
+	}
+	leaf := lane{id: leafLogLaneID, vlog: writer}
+	leafPage := buildSparseLeafPageForLeafLogTest(t)
+
+	leaf.vlogMu.Lock()
+	ptr, retainPath, stats, compacted, payloadLen, totalBytes, err := db.appendPreparedLeafPageValueLog(&leaf, 1, leafPage)
+	if err != nil {
+		t.Fatalf("appendPreparedLeafPageValueLog: %v", err)
+	}
+	if !leaf.vlogMu.TryLock() {
+		t.Fatalf("appendPreparedLeafPageValueLog returned with vlogMu locked")
+	}
+	leaf.vlogMu.Unlock()
+	if retainPath != "" {
+		t.Fatalf("retainPath=%q want empty", retainPath)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	if payloadLen != stats.RawPayloadBytes || payloadLen >= len(leafPage) {
+		t.Fatalf("payloadLen=%d stats.RawPayloadBytes=%d raw=%d", payloadLen, stats.RawPayloadBytes, len(leafPage))
+	}
+	if totalBytes <= 0 {
+		t.Fatalf("totalBytes=%d want > 0", totalBytes)
+	}
+	if got := leaf.backendReadDirtySeq.Load(); got != 1 {
+		t.Fatalf("backendReadDirtySeq=%d want 1", got)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	writer = nil
+
+	mgr, err := valuelog.NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	if err := mgr.RegisterSegment(path, fileID); err != nil {
+		t.Fatalf("RegisterSegment(%q): %v", path, err)
+	}
+	got, err := mgr.ReadUnsafe(ptr)
+	if err != nil {
+		t.Fatalf("ReadUnsafe: %v", err)
+	}
+	requireLeafLogTestPagesEqual(t, leafPage, got)
 }

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -3,9 +3,11 @@ package valuelog
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"hash/crc32"
 	"path/filepath"
 
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -109,6 +111,69 @@ func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
 	payload := make([]byte, compactLeafPagePayloadLen(prefixLen, suffixLen))
 	encodeCompactLeafLogPayload(payload, leafPage, prefixLen, suffixStart, suffixLen)
 	return payload, true, nil
+}
+
+// PrepareCompactLeafPageRecord builds the raw K=1 value-log record used for an
+// outer leaf page. It lets callers do the page compaction, copy and CRC work
+// before taking the writer mutex; the returned length is ready to store in a
+// ValuePtr.
+func PrepareCompactLeafPageRecord(dst []byte, rid uint64, leafPage []byte) ([]byte, FrameStats, bool, uint32, error) {
+	if rid == 0 {
+		return nil, FrameStats{}, false, 0, errors.New("valuelog: missing rid")
+	}
+	prefixLen, suffixStart, suffixLen, compacted, err := compactLeafPageLivePayloadBounds(leafPage)
+	if err != nil {
+		return nil, FrameStats{}, false, 0, err
+	}
+	payloadLen := len(leafPage)
+	if compacted {
+		payloadLen = compactLeafPagePayloadLen(prefixLen, suffixLen)
+	}
+	bodyLen := uint32(FrameHeaderSize + 8 + 8 + payloadLen)
+	if recordSizeExceedsMax(bodyLen) {
+		return nil, FrameStats{}, false, 0, ErrRecordTooLarge
+	}
+	recordLen := HeaderSize + int(bodyLen)
+	if cap(dst) < recordLen {
+		dst = make([]byte, recordLen)
+	} else {
+		dst = dst[:recordLen]
+	}
+
+	dst[4] = Version
+	dst[5] = recordFlagGrouped
+	dst[6] = 0
+	dst[7] = 0
+	binary.LittleEndian.PutUint64(dst[8:16], 0)
+	binary.LittleEndian.PutUint32(dst[16:20], bodyLen)
+
+	off := HeaderSize
+	dst[off] = FrameVersion
+	dst[off+1] = 0
+	dst[off+2] = 1
+	dst[off+3] = 0
+	binary.LittleEndian.PutUint64(dst[off+4:off+12], 0)
+	off += FrameHeaderSize
+
+	binary.LittleEndian.PutUint64(dst[off:off+8], rid)
+	off += 8
+	binary.LittleEndian.PutUint32(dst[off:off+4], 0)
+	binary.LittleEndian.PutUint32(dst[off+4:off+8], uint32(payloadLen))
+	off += 8
+
+	if compacted {
+		encodeCompactLeafLogPayload(dst[off:off+payloadLen], leafPage, prefixLen, suffixStart, suffixLen)
+	} else {
+		copy(dst[off:], leafPage)
+	}
+	sum := crc.ChecksumParts(dst[4:HeaderSize], dst[HeaderSize:])
+	binary.LittleEndian.PutUint32(dst[0:4], sum)
+
+	recordLenHint := uint32(headerWithoutCRC) + bodyLen
+	if recordLenHint > page.ValuePtrGroupedMaxRecordLen {
+		recordLenHint = 0
+	}
+	return dst, FrameStats{Records: 1, RawPayloadBytes: payloadLen, StoredPayloadBytes: payloadLen, Kept: false}, compacted, page.ValuePtrMarkGrouped(recordLenHint, 0), nil
 }
 
 func compactLeafLogPayloadBounds(payload []byte) (prefixLen, suffixLen int, decoded bool, err error) {

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -350,6 +350,53 @@ func TestWriterAppendCompactLeafPage_BlockCompressionRoundTrips(t *testing.T) {
 	requireLeafPagesLogicallyEqual(t, leaf, got)
 }
 
+func TestPrepareCompactLeafPageRecord_BufferedAppendRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := compactLeafPayloadTestPath(t, dir, 1)
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	leaf := buildSparseLeafPageForPayloadTest(t)
+	raw, stats, compacted, ptrLength, err := PrepareCompactLeafPageRecord(nil, 1, leaf)
+	if err != nil {
+		t.Fatalf("PrepareCompactLeafPageRecord: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+	if stats.RawPayloadBytes <= 0 || stats.RawPayloadBytes >= len(leaf) {
+		t.Fatalf("stats.RawPayloadBytes=%d want compact payload smaller than %d", stats.RawPayloadBytes, len(leaf))
+	}
+	ptr, err := w.AppendRawRecordBuffered(raw, ptrLength)
+	if err != nil {
+		t.Fatalf("AppendRawRecordBuffered: %v", err)
+	}
+	if got := page.ValuePtrRecordLength(ptr); got == 0 || got != uint32(len(raw)-4) {
+		t.Fatalf("record length hint=%d want %d", got, len(raw)-4)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	mgr := newLeafPayloadTestManager(t, dir, path, fileID)
+	defer func() { _ = mgr.Close() }()
+
+	got, err := mgr.ReadUnsafe(ptr)
+	if err != nil {
+		t.Fatalf("ReadUnsafe: %v", err)
+	}
+	if len(got) != page.PageSize {
+		t.Fatalf("ReadUnsafe len=%d want %d", len(got), page.PageSize)
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, got)
+}
+
 func TestSetReadUnsafe_DecodesCompactLeafPayload(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := EncodeFileID(ReservedLeafLogLaneID, 1)

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -1101,6 +1101,32 @@ func (w *Writer) AppendRawRecord(raw []byte, length uint32) (page.ValuePtr, erro
 	}, nil
 }
 
+// AppendRawRecordBuffered appends a pre-encoded raw value-log record through the
+// writer append buffer. This keeps syscall coalescing for records prepared
+// outside the writer's critical section.
+func (w *Writer) AppendRawRecordBuffered(raw []byte, length uint32) (page.ValuePtr, error) {
+	if w == nil {
+		return page.ValuePtr{}, errors.New("valuelog: nil writer")
+	}
+	if len(raw) < 4 {
+		return page.ValuePtr{}, errors.New("valuelog: empty record")
+	}
+	expected := uint32(len(raw) - 4)
+	if !page.ValuePtrRecordLengthHintMatches(page.ValuePtr{Length: length}, expected) {
+		return page.ValuePtr{}, errors.New("valuelog: raw record size mismatch")
+	}
+	start := w.size
+	if err := w.writeBytesBuffered(raw); err != nil {
+		return page.ValuePtr{}, err
+	}
+	w.size += int64(len(raw))
+	return page.ValuePtr{
+		Offset: uint64(start + 4),
+		Length: length,
+		FileID: w.fileID,
+	}, nil
+}
+
 func (w *Writer) AppendFrame(dictID uint64, dict []byte, records []Record) ([]page.ValuePtr, error) {
 	ptrs, _, err := w.AppendFrameWithStats(dictID, dict, records)
 	return ptrs, err


### PR DESCRIPTION
## Summary

- Adds a prepared raw compact leaf-page record path for contended leaf-log appends.
- Keeps the uncontended append path direct, but when `vlogMu` contention is observed and the selected final write mode is raw/off, releases `vlogMu`, prepares the compact K=1 record outside the critical section, then reacquires and appends the prebuilt record through the writer append buffer.
- Adds valuelog coverage for prepared compact leaf records plus caching-layer coverage that the prepared helper appends correctly, returns with `vlogMu` unlocked, and round-trips through a real `leaf_vlog` segment.

## Validation

- `go test -count=1 ./TreeDB/internal/valuelog ./TreeDB/caching ./TreeDB/db ./TreeDB/zipper ./TreeDB/internal/memtable`
- `go test -count=1 ./TreeDB/caching -run 'Test(DB_AppendPreparedLeafPageValueLog_AppendsAndReturnsUnlocked|CachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload|CachingLeafPageLog_SyncRespectsRelaxedSync|RoutedQueueKeepsFutureWritesOnRoute|CanBypassMemtableReadRequiresMutableEntriesEmpty)' -v`
- `go test -count=1 ./TreeDB/internal/valuelog -run 'Test(PrepareCompactLeafPageRecord_BufferedAppendRoundTrips|WriterAppendCompactLeafPage_BlockCompressionRoundTrips|MaybeCompactLeafLogPayload_SparseLeafRoundTrips)' -v`
- `git diff --check`

## Profiling

First-six write profile on this branch:

`./bin/unified-bench -dbs treedb -profile fast -keys 1000000 -treedb-memtable-mode btree -profile-dir /tmp/profile_leafprep_first6_I798sS -progress=false -test sequential_write,random_write,dataset_write_random,dataset_write_sorted,batch_write,batch_write_steady`

- `batch_write_steady`: 1,109,210 ops/sec, up from 789,221 in the matching #1040 first-six run.

Full 1M suite on this branch:

`./bin/unified-bench -dbs treedb -profile fast -keys 1000000 -treedb-memtable-mode btree -profile-dir /tmp/profile_leafprep_full_stQem1 -progress=false -treedb-cache-stats-after-tests`

- `batch_write_steady`: 1,096,722 ops/sec, up from 756,275 in `/tmp/profile_1040_final_4vGtsL`.
- mmap fallback remained zero: `treedb.vlog.mmap_read.fallback_readat=0`.
