### PR TITLE
Batch contended leaf-log appends

### DIFF
--- a/TreeDB/caching/lane.go
+++ b/TreeDB/caching/lane.go
@@ -82,6 +82,9 @@ type lane struct {
 	vlogQueueDriftLastDepth        int
 	vlogQueueDriftLastAtNs         int64
 	vlogQueueDriftCurrentNs        uint64
+	leafAppendMu                   sync.Mutex
+	leafAppendDraining             bool
+	leafAppendQueue                []*leafPageAppendRequest
 	vlogDirty                      atomic.Bool
 	vlogSyncPending                atomic.Bool
 	backendReadDirtySeq            atomic.Uint64

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -16,11 +16,27 @@ type cachingLeafPageLog struct {
 
 var _ backenddb.LeafPageLog = (*cachingLeafPageLog)(nil)
 
+const leafPageAppendBatchMax = 512
+
 var preparedLeafPageRecordPool = sync.Pool{
 	New: func() any {
 		buf := make([]byte, 0, valuelog.HeaderSize+valuelog.FrameHeaderSize+16+page.PageSize)
 		return &buf
 	},
+}
+
+type leafPageAppendRequest struct {
+	raw        []byte
+	ptrLength  uint32
+	stats      valuelog.FrameStats
+	compacted  bool
+	payloadLen int
+
+	wg         sync.WaitGroup
+	ptr        page.ValuePtr
+	retainPath string
+	totalBytes int64
+	err        error
 }
 
 func newCachingLeafPageLog(db *DB, l *lane) backenddb.LeafPageLog {
@@ -64,6 +80,10 @@ func (db *DB) noteLeafGenerationRecordLength(ptr page.ValuePtr) {
 // preparing the record and returns with the mutex unlocked.
 func (db *DB) appendPreparedLeafPageValueLog(l *lane, rid uint64, leafPage []byte) (page.ValuePtr, string, valuelog.FrameStats, bool, int, int64, error) {
 	l.vlogMu.Unlock()
+	return db.appendPreparedLeafPageValueLogQueued(l, rid, leafPage)
+}
+
+func (db *DB) appendPreparedLeafPageValueLogQueued(l *lane, rid uint64, leafPage []byte) (page.ValuePtr, string, valuelog.FrameStats, bool, int, int64, error) {
 	bufp := getPreparedLeafPageRecordBuffer()
 	raw, stats, compacted, ptrLength, err := valuelog.PrepareCompactLeafPageRecord((*bufp)[:0], rid, leafPage)
 	if err != nil {
@@ -72,24 +92,94 @@ func (db *DB) appendPreparedLeafPageValueLog(l *lane, rid uint64, leafPage []byt
 	}
 	payloadLen := stats.RawPayloadBytes
 
-	l.vlogMu.Lock()
-	defer func() {
-		putPreparedLeafPageRecordBuffer(bufp)
-	}()
+	req := &leafPageAppendRequest{
+		raw:        raw,
+		ptrLength:  ptrLength,
+		stats:      stats,
+		compacted:  compacted,
+		payloadLen: payloadLen,
+	}
+	req.wg.Add(1)
 
+	leader := false
+	l.leafAppendMu.Lock()
+	if !l.leafAppendDraining {
+		l.leafAppendDraining = true
+		leader = true
+	}
+	l.leafAppendQueue = append(l.leafAppendQueue, req)
+	l.leafAppendMu.Unlock()
+
+	if leader {
+		db.drainPreparedLeafPageValueLogQueue(l)
+	}
+
+	req.wg.Wait()
+	putPreparedLeafPageRecordBuffer(bufp)
+	if req.err != nil {
+		return page.ValuePtr{}, "", valuelog.FrameStats{}, false, 0, 0, req.err
+	}
+	return req.ptr, req.retainPath, req.stats, req.compacted, req.payloadLen, req.totalBytes, nil
+}
+
+// drainPreparedLeafPageValueLogQueue lets one contended caller append several
+// already-encoded leaf records under a single vlogMu acquisition.
+func (db *DB) drainPreparedLeafPageValueLogQueue(l *lane) {
+	batch := make([]*leafPageAppendRequest, 0, leafPageAppendBatchMax)
+	for {
+		batch = batch[:0]
+
+		l.vlogMu.Lock()
+		l.leafAppendMu.Lock()
+		if len(l.leafAppendQueue) == 0 {
+			l.leafAppendDraining = false
+			l.leafAppendMu.Unlock()
+			l.vlogMu.Unlock()
+			return
+		}
+		n := len(l.leafAppendQueue)
+		if n > leafPageAppendBatchMax {
+			n = leafPageAppendBatchMax
+		}
+		queue := l.leafAppendQueue
+		batch = append(batch, queue[:n]...)
+		copy(queue, queue[n:])
+		clear(queue[len(queue)-n:])
+		l.leafAppendQueue = queue[:len(queue)-n]
+		l.leafAppendMu.Unlock()
+
+		retainPaths := db.appendPreparedLeafPageValueLogBatchMuHeld(l, batch, nil)
+		if db.testBeforeVlogUnlock != nil {
+			db.testBeforeVlogUnlock(int(l.id))
+		}
+		l.vlogMu.Unlock()
+
+		for _, path := range retainPaths {
+			db.markValueLogRetain(path)
+		}
+		for i := range batch {
+			batch[i].wg.Done()
+		}
+	}
+}
+
+func (db *DB) appendPreparedLeafPageValueLogBatchMuHeld(l *lane, batch []*leafPageAppendRequest, retainPaths []string) []string {
+	if len(batch) == 0 {
+		return retainPaths
+	}
 	w, ok := l.vlog.(*valuelog.Writer)
 	if !ok || w == nil {
-		l.vlogMu.Unlock()
-		return page.ValuePtr{}, "", valuelog.FrameStats{}, false, 0, 0, errWALUnavailable
+		finishLeafPageAppendBatch(batch, errWALUnavailable)
+		return retainPaths
 	}
 	if rotateErr := db.rotateValueLogForMaxSegmentMuHeld(l, w); rotateErr != nil {
-		l.vlogMu.Unlock()
-		return page.ValuePtr{}, "", valuelog.FrameStats{}, false, 0, 0, rotateErr
+		finishLeafPageAppendBatch(batch, rotateErr)
+		return retainPaths
 	}
 	w, ok = l.vlog.(*valuelog.Writer)
 	if !ok || w == nil {
-		l.vlogMu.Unlock()
-		return page.ValuePtr{}, "", valuelog.FrameStats{}, false, 0, 0, errWALUnavailable
+		finishLeafPageAppendBatch(batch, errWALUnavailable)
+		return retainPaths
 	}
 	if l.vlogCaps.writer != w {
 		l.vlogCaps = computeVlogWriterCaps(w)
@@ -97,20 +187,62 @@ func (db *DB) appendPreparedLeafPageValueLog(l *lane, rid uint64, leafPage []byt
 	db.setVlogWriterMode(l, w, vlogWriteOff, db.valueLogBlockCodec)
 
 	startSize := w.Size()
-	ptr, err := w.AppendRawRecordBuffered(raw, ptrLength)
 	flushedBoundary := false
-	if err == nil && db.shouldFlushDeferredValueLogValue(vlogWriteOff, leafPage) {
+	noteRetainPath := func() {
+		if l.vlogPath == "" || l.vlogPath == l.vlogRetainedPath {
+			return
+		}
+		l.vlogRetainedPath = l.vlogPath
+		retainPaths = append(retainPaths, l.vlogPath)
+	}
+	var err error
+	for _, req := range batch {
+		if req == nil {
+			continue
+		}
+		if rotateErr := db.rotateValueLogForMaxSegmentMuHeld(l, w); rotateErr != nil {
+			err = rotateErr
+			finishLeafPageAppendBatch(batch, err)
+			break
+		}
+		next, ok := l.vlog.(*valuelog.Writer)
+		if !ok || next == nil {
+			err = errWALUnavailable
+			finishLeafPageAppendBatch(batch, err)
+			break
+		}
+		if next != w {
+			w = next
+			if l.vlogCaps.writer != w {
+				l.vlogCaps = computeVlogWriterCaps(w)
+			}
+			db.setVlogWriterMode(l, w, vlogWriteOff, db.valueLogBlockCodec)
+		}
+		before := w.Size()
+		req.ptr, err = w.AppendRawRecordBuffered(req.raw, req.ptrLength)
+		if err != nil {
+			finishLeafPageAppendBatch(batch, err)
+			break
+		}
+		req.totalBytes = w.Size() - before
+		noteRetainPath()
+		if db.shouldFlushDeferredValueLogValue(vlogWriteOff, req.raw) {
+			flushedBoundary = true
+		}
+	}
+	if err == nil && flushedBoundary {
 		err = w.Flush()
-		flushedBoundary = err == nil
+		if err != nil {
+			for i := range batch {
+				if batch[i] != nil && batch[i].err == nil {
+					batch[i].err = err
+				}
+			}
+		}
 	}
 	totalBytes := int64(0)
 	if err == nil {
 		totalBytes = w.Size() - startSize
-	}
-	retainPath := ""
-	if l.vlogPath != "" && l.vlogPath != l.vlogRetainedPath {
-		l.vlogRetainedPath = l.vlogPath
-		retainPath = l.vlogPath
 	}
 	if err == nil {
 		db.markLaneValueLogBoundary(l, totalBytes, flushedBoundary, false)
@@ -118,14 +250,19 @@ func (db *DB) appendPreparedLeafPageValueLog(l *lane, rid uint64, leafPage []byt
 			l.backendReadDirtySeq.Add(1)
 		}
 	}
-	if db.testBeforeVlogUnlock != nil {
-		db.testBeforeVlogUnlock(int(l.id))
+	return retainPaths
+}
+
+func finishLeafPageAppendBatch(batch []*leafPageAppendRequest, err error) {
+	for i := range batch {
+		if batch[i] == nil {
+			continue
+		}
+		batch[i].ptr = page.ValuePtr{}
+		batch[i].retainPath = ""
+		batch[i].totalBytes = 0
+		batch[i].err = err
 	}
-	l.vlogMu.Unlock()
-	if err != nil {
-		return page.ValuePtr{}, "", valuelog.FrameStats{}, false, 0, 0, err
-	}
-	return ptr, retainPath, stats, compacted, payloadLen, totalBytes, nil
 }
 
 func (db *DB) observeLeafPageValueLogAppend(l *lane, ptr page.ValuePtr, retainPath string, stats valuelog.FrameStats, compacted bool, finalWriteMode vlogCompressionWriteMode, finalBlockCodec valuelog.BlockCodec, payloadLen int, totalBytes int64, probeCompression bool, selectorStart time.Time) (page.ValuePtr, string, error) {

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -186,7 +186,7 @@ func (db *DB) appendPreparedLeafPageValueLogBatchMuHeld(l *lane, batch []*leafPa
 	}
 	db.setVlogWriterMode(l, w, vlogWriteOff, db.valueLogBlockCodec)
 
-	startSize := w.Size()
+	totalBytes := int64(0)
 	flushedBoundary := false
 	noteRetainPath := func() {
 		if l.vlogPath == "" || l.vlogPath == l.vlogRetainedPath {
@@ -225,6 +225,10 @@ func (db *DB) appendPreparedLeafPageValueLogBatchMuHeld(l *lane, batch []*leafPa
 			break
 		}
 		req.totalBytes = w.Size() - before
+		if req.totalBytes > 0 {
+			totalBytes += req.totalBytes
+			l.vlogLiveBytes.Add(req.totalBytes)
+		}
 		noteRetainPath()
 		if db.shouldFlushDeferredValueLogValue(vlogWriteOff, req.raw) {
 			flushedBoundary = true
@@ -239,10 +243,6 @@ func (db *DB) appendPreparedLeafPageValueLogBatchMuHeld(l *lane, batch []*leafPa
 				}
 			}
 		}
-	}
-	totalBytes := int64(0)
-	if err == nil {
-		totalBytes = w.Size() - startSize
 	}
 	if err == nil {
 		db.markLaneValueLogBoundary(l, totalBytes, flushedBoundary, false)
@@ -265,8 +265,8 @@ func finishLeafPageAppendBatch(batch []*leafPageAppendRequest, err error) {
 	}
 }
 
-func (db *DB) observeLeafPageValueLogAppend(l *lane, ptr page.ValuePtr, retainPath string, stats valuelog.FrameStats, compacted bool, finalWriteMode vlogCompressionWriteMode, finalBlockCodec valuelog.BlockCodec, payloadLen int, totalBytes int64, probeCompression bool, selectorStart time.Time) (page.ValuePtr, string, error) {
-	if totalBytes > 0 {
+func (db *DB) observeLeafPageValueLogAppend(l *lane, ptr page.ValuePtr, retainPath string, stats valuelog.FrameStats, compacted bool, finalWriteMode vlogCompressionWriteMode, finalBlockCodec valuelog.BlockCodec, payloadLen int, totalBytes int64, accountLiveBytes bool, probeCompression bool, selectorStart time.Time) (page.ValuePtr, string, error) {
+	if accountLiveBytes && totalBytes > 0 {
 		l.vlogLiveBytes.Add(totalBytes)
 	}
 	db.valueLogDictFrames.total.Add(1)
@@ -376,7 +376,7 @@ func (db *DB) appendLeafPageValueLog(l *lane, rid uint64, leafPage []byte) (page
 		if err != nil {
 			return page.ValuePtr{}, "", err
 		}
-		return db.observeLeafPageValueLogAppend(l, ptr, retainPath, stats, compacted, finalWriteMode, finalBlockCodec, payloadLen, totalBytes, probeCompression, selectorStart)
+		return db.observeLeafPageValueLogAppend(l, ptr, retainPath, stats, compacted, finalWriteMode, finalBlockCodec, payloadLen, totalBytes, false, probeCompression, selectorStart)
 	}
 	db.setVlogWriterMode(l, w, finalWriteMode, finalBlockCodec)
 	startSize := w.Size()
@@ -408,7 +408,7 @@ func (db *DB) appendLeafPageValueLog(l *lane, rid uint64, leafPage []byte) (page
 	if err != nil {
 		return page.ValuePtr{}, "", err
 	}
-	return db.observeLeafPageValueLogAppend(l, ptr, retainPath, stats, compacted, finalWriteMode, finalBlockCodec, payloadLen, totalBytes, probeCompression, selectorStart)
+	return db.observeLeafPageValueLogAppend(l, ptr, retainPath, stats, compacted, finalWriteMode, finalBlockCodec, payloadLen, totalBytes, true, probeCompression, selectorStart)
 }
 
 func (l *cachingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
@@ -250,4 +252,113 @@ func TestDB_AppendPreparedLeafPageValueLog_AppendsAndReturnsUnlocked(t *testing.
 		t.Fatalf("ReadUnsafe: %v", err)
 	}
 	requireLeafLogTestPagesEqual(t, leafPage, got)
+}
+
+func TestDB_AppendPreparedLeafPageValueLog_BatchesQueuedPreparedAppends(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := valuelog.EncodeFileID(uint32(leafLogLaneID), 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	leafDir := filepath.Join(dir, "leaf_vlog")
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", leafDir, err)
+	}
+	path := filepath.Join(leafDir, "value-l255-000001.log")
+	writer, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() {
+		if writer != nil {
+			_ = writer.Close()
+		}
+	}()
+
+	db := &DB{
+		closeCh:                 make(chan struct{}),
+		valueLogCompressionMode: uint8(vlogCompressionOff),
+	}
+	var preUnlockHooks atomic.Int32
+	db.testBeforeVlogUnlock = func(laneID int) {
+		if laneID == leafLogLaneID {
+			preUnlockHooks.Add(1)
+		}
+	}
+
+	leaf := lane{id: leafLogLaneID, vlog: writer}
+	leafPage := buildSparseLeafPageForLeafLogTest(t)
+	const requests = 8
+	ptrs := make([]page.ValuePtr, requests)
+	errs := make(chan error, requests)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	leaf.vlogMu.Lock()
+	for i := 0; i < requests; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			ptr, _, _, _, _, _, err := db.appendPreparedLeafPageValueLogQueued(&leaf, uint64(i+1), leafPage)
+			ptrs[i] = ptr
+			errs <- err
+		}(i)
+	}
+	close(start)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		leaf.leafAppendMu.Lock()
+		queued := len(leaf.leafAppendQueue)
+		draining := leaf.leafAppendDraining
+		leaf.leafAppendMu.Unlock()
+		if queued == requests && draining {
+			break
+		}
+		if time.Now().After(deadline) {
+			leaf.vlogMu.Unlock()
+			t.Fatalf("queued prepared appends=%d draining=%v want %d queued and draining", queued, draining, requests)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	leaf.vlogMu.Unlock()
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("appendPreparedLeafPageValueLogQueued: %v", err)
+		}
+	}
+	if got := preUnlockHooks.Load(); got != 1 {
+		t.Fatalf("pre-unlock hooks=%d want 1 batched writer lock", got)
+	}
+	if got := leaf.backendReadDirtySeq.Load(); got != 1 {
+		t.Fatalf("backendReadDirtySeq=%d want 1 batched boundary", got)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	writer = nil
+
+	mgr, err := valuelog.NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	if err := mgr.RegisterSegment(path, fileID); err != nil {
+		t.Fatalf("RegisterSegment(%q): %v", path, err)
+	}
+	for i, ptr := range ptrs {
+		if ptr.FileID == 0 {
+			t.Fatalf("ptr[%d] is empty", i)
+		}
+		got, err := mgr.ReadUnsafe(ptr)
+		if err != nil {
+			t.Fatalf("ReadUnsafe(%d): %v", i, err)
+		}
+		requireLeafLogTestPagesEqual(t, leafPage, got)
+	}
 }

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -362,3 +362,108 @@ func TestDB_AppendPreparedLeafPageValueLog_BatchesQueuedPreparedAppends(t *testi
 		requireLeafLogTestPagesEqual(t, leafPage, got)
 	}
 }
+
+func TestDB_AppendPreparedLeafPageValueLog_BatchRotationMarksDirtyBoundary(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := valuelog.EncodeFileID(uint32(leafLogLaneID), 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	leafDir := filepath.Join(dir, "leaf_vlog")
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", leafDir, err)
+	}
+	path := filepath.Join(leafDir, "value-l255-000001.log")
+	writer, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() {
+		if writer != nil {
+			_ = writer.Close()
+		}
+	}()
+	if _, err := writer.Append(0, nil, 99, bytes.Repeat([]byte("seed"), 32<<10)); err != nil {
+		t.Fatalf("seed append: %v", err)
+	}
+	startSize := writer.Size()
+
+	db := &DB{
+		closeCh:                 make(chan struct{}),
+		valueLogCompressionMode: uint8(vlogCompressionOff),
+		valueLogDir:             leafDir,
+		valueLogMaxSegmentBytes: startSize + 1,
+	}
+	leaf := lane{id: leafLogLaneID, vlog: writer, vlogSeq: 1, vlogPath: path}
+	leafPage := buildSparseLeafPageForLeafLogTest(t)
+
+	const requests = 2
+	ptrs := make([]page.ValuePtr, requests)
+	totalBytes := make([]int64, requests)
+	errs := make(chan error, requests)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	leaf.vlogMu.Lock()
+	for i := 0; i < requests; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			ptr, _, _, _, _, bytesWritten, err := db.appendPreparedLeafPageValueLogQueued(&leaf, uint64(i+1), leafPage)
+			ptrs[i] = ptr
+			totalBytes[i] = bytesWritten
+			errs <- err
+		}(i)
+	}
+	close(start)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		leaf.leafAppendMu.Lock()
+		queued := len(leaf.leafAppendQueue)
+		draining := leaf.leafAppendDraining
+		leaf.leafAppendMu.Unlock()
+		if queued == requests && draining {
+			break
+		}
+		if time.Now().After(deadline) {
+			leaf.vlogMu.Unlock()
+			t.Fatalf("queued prepared appends=%d draining=%v want %d queued and draining", queued, draining, requests)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	leaf.vlogMu.Unlock()
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("appendPreparedLeafPageValueLogQueued: %v", err)
+		}
+	}
+	if ptrs[0].FileID == ptrs[1].FileID {
+		t.Fatalf("expected queued batch to rotate between records, got file_id=%d", ptrs[0].FileID)
+	}
+	if totalBytes[0] <= 0 || totalBytes[1] <= 0 {
+		t.Fatalf("totalBytes=%v want both > 0", totalBytes)
+	}
+	currentSegmentBytes := int64(0)
+	for i, ptr := range ptrs {
+		if ptr.FileID != fileID {
+			currentSegmentBytes = totalBytes[i]
+		}
+	}
+	if currentSegmentBytes <= 0 {
+		t.Fatalf("did not find current-segment bytes, ptrs=%+v totalBytes=%v firstFileID=%d", ptrs, totalBytes, fileID)
+	}
+	if got := leaf.backendReadDirtySeq.Load(); got != 1 {
+		t.Fatalf("backendReadDirtySeq=%d want 1 after rotating batch", got)
+	}
+	if !leaf.vlogDirty.Load() {
+		t.Fatal("vlogDirty=false want true after rotating batch")
+	}
+	if got := leaf.vlogLiveBytes.Load(); got != currentSegmentBytes {
+		t.Fatalf("current segment live bytes=%d want current request bytes %d", got, currentSegmentBytes)
+	}
+}


### PR DESCRIPTION
## Summary
- add a per-leaf-log prepared append queue for contended raw leaf-page writes
- let one contended caller drain queued prepared records under a single vlogMu acquisition
- add a forced-contention test that verifies queued appends drain as one writer-lock batch and round-trip from leaf_vlog

## Validation
- go test -count=1 ./TreeDB/caching ./TreeDB/internal/valuelog ./TreeDB/page ./TreeDB/zipper
- go test -race -count=1 ./TreeDB/caching -run TestDB_AppendPreparedLeafPageValueLog_BatchesQueuedPreparedAppends
- ./bin/unified-bench -dbs treedb -profile fast -keys 1000000 -treedb-memtable-mode btree -profile-dir /tmp/profile_leaf_batch_first6_LhVB9d -progress=false -test sequential_write,random_write,dataset_write_random,dataset_write_sorted,batch_write,batch_write_steady

## Benchmark Notes
First-six BTree run on this branch: sequential_write 5,048,061; random_write 1,676,575; dataset_write_random 1,348,156; dataset_write_sorted 3,510,603; batch_write 14,306,118; batch_write_steady 1,218,360. The comparable #1041 run had batch_write_steady 1,109,210.

Targeted batch_write_steady-only run: /tmp/profile_leaf_batch_steady_pW9EEr at 3,733,349 ops/s; mutex profile no longer shows appendLeafPageValueLog in the top contended path for that isolated test.