### PR TITLE
Adapt BTree split capacity for random inserts

### DIFF
--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -22,6 +22,8 @@ const btreeArenaPoolMinShift = 16
 const btreeArenaPoolMaxShift = 20
 const btreeArenaPoolClassCount = btreeArenaPoolMaxShift - btreeArenaPoolMinShift + 1
 const btreeArenaPoolBudgetBytes = 64 << 20
+const btreeAdaptiveBothSplitMinEntries = 512
+const btreeAdaptiveBothSplitMinNonAppend = 64
 
 var btreeArenaChunkPools [btreeArenaPoolClassCount]sync.Pool
 var btreeArenaPoolBytes atomic.Int64
@@ -85,15 +87,17 @@ func normalizeBTreeEntryFlags(flags byte) byte {
 }
 
 type BTree struct {
-	mu          sync.RWMutex
-	tree        *btree.Map[string, btreeEntry]
-	sizeBytes   int64
-	arena       *btreeArena
-	lastKey     string
-	hasLast     bool
-	degree      int
-	lastInline  []byte
-	deleteCount int
+	mu                           sync.RWMutex
+	tree                         *btree.Map[string, btreeEntry]
+	sizeBytes                    int64
+	arena                        *btreeArena
+	lastKey                      string
+	hasLast                      bool
+	degree                       int
+	lastInline                   []byte
+	deleteCount                  int
+	nonAppendSetCount            int
+	reuseBothSplitInsertCapacity bool
 }
 
 func (*BTree) StableUnsafeIteratorSlices() bool { return true }
@@ -221,6 +225,9 @@ func (m *BTree) Reset() {
 	m.hasLast = false
 	m.lastInline = nil
 	m.deleteCount = 0
+	m.nonAppendSetCount = 0
+	m.reuseBothSplitInsertCapacity = false
+	m.tree.SetReuseBothSplitInsertCapacity(false)
 	if m.arena != nil {
 		m.arena.resetKeepFirstChunk()
 	}
@@ -746,17 +753,31 @@ func (it *btreeReverseIterator) refresh() {
 }
 
 func (m *BTree) setMaybeLoadLocked(key string, entry btreeEntry) (btreeEntry, bool) {
-	if m.hasLast && key > m.lastKey {
+	if !m.hasLast || key > m.lastKey {
 		return m.tree.Load(key, entry)
 	}
+	m.noteNonAppendSetLocked()
 	return m.tree.Set(key, entry)
 }
 
 func (m *BTree) setMaybeSortedLoadLocked(key string, entry btreeEntry) (btreeEntry, bool) {
-	if m.hasLast && key > m.lastKey {
+	if !m.hasLast || key > m.lastKey {
 		return m.tree.Load(key, entry)
 	}
+	m.noteNonAppendSetLocked()
 	return m.tree.Set(key, entry)
+}
+
+func (m *BTree) noteNonAppendSetLocked() {
+	if m.reuseBothSplitInsertCapacity || m.tree.Len() < btreeAdaptiveBothSplitMinEntries {
+		return
+	}
+	m.nonAppendSetCount++
+	if m.nonAppendSetCount < btreeAdaptiveBothSplitMinNonAppend {
+		return
+	}
+	m.reuseBothSplitInsertCapacity = true
+	m.tree.SetReuseBothSplitInsertCapacity(true)
 }
 
 func (m *BTree) copyInlineValueLocked(value []byte) []byte {

--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -756,19 +756,25 @@ func (m *BTree) setMaybeLoadLocked(key string, entry btreeEntry) (btreeEntry, bo
 	if !m.hasLast || key > m.lastKey {
 		return m.tree.Load(key, entry)
 	}
-	m.noteNonAppendSetLocked()
-	return m.tree.Set(key, entry)
+	prev, replaced := m.tree.Set(key, entry)
+	if !replaced {
+		m.noteNonAppendInsertLocked()
+	}
+	return prev, replaced
 }
 
 func (m *BTree) setMaybeSortedLoadLocked(key string, entry btreeEntry) (btreeEntry, bool) {
 	if !m.hasLast || key > m.lastKey {
 		return m.tree.Load(key, entry)
 	}
-	m.noteNonAppendSetLocked()
-	return m.tree.Set(key, entry)
+	prev, replaced := m.tree.Set(key, entry)
+	if !replaced {
+		m.noteNonAppendInsertLocked()
+	}
+	return prev, replaced
 }
 
-func (m *BTree) noteNonAppendSetLocked() {
+func (m *BTree) noteNonAppendInsertLocked() {
 	if m.reuseBothSplitInsertCapacity || m.tree.Len() < btreeAdaptiveBothSplitMinEntries {
 		return
 	}

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -144,6 +144,46 @@ func TestBTreeSetEntryAppendFastPathMixedUpdates(t *testing.T) {
 	}
 }
 
+func TestBTreeAdaptiveBothSplitCapacityEnablesForNonAppendInserts(t *testing.T) {
+	m := NewBTreeWithDegree(2)
+	key := func(i int) []byte {
+		return []byte{byte(i >> 8), byte(i)}
+	}
+
+	for i := 0; i < btreeAdaptiveBothSplitMinEntries; i++ {
+		m.Set(key(2048+i*2), []byte{byte(i)})
+	}
+	if m.reuseBothSplitInsertCapacity {
+		t.Fatal("adaptive split sibling capacity enabled during append-only load")
+	}
+
+	for i := 0; i < btreeAdaptiveBothSplitMinNonAppend; i++ {
+		m.Set(key(i*2+1), []byte{byte(i)})
+	}
+	if !m.reuseBothSplitInsertCapacity {
+		t.Fatal("adaptive split sibling capacity did not enable after non-append inserts")
+	}
+
+	m.Reset()
+	if m.reuseBothSplitInsertCapacity || m.nonAppendSetCount != 0 {
+		t.Fatalf("adaptive state after reset enabled=%v nonAppend=%d, want false,0", m.reuseBothSplitInsertCapacity, m.nonAppendSetCount)
+	}
+}
+
+func TestBTreeAdaptiveBothSplitCapacityStaysDisabledForAppendOnly(t *testing.T) {
+	m := NewBTreeWithDegree(2)
+	key := func(i int) []byte {
+		return []byte{byte(i >> 8), byte(i)}
+	}
+
+	for i := 0; i < btreeAdaptiveBothSplitMinEntries+btreeAdaptiveBothSplitMinNonAppend+128; i++ {
+		m.Set(key(i), []byte{byte(i)})
+	}
+	if m.reuseBothSplitInsertCapacity {
+		t.Fatal("adaptive split sibling capacity enabled for append-only inserts")
+	}
+}
+
 func TestBTreePointerEmptySliceCanonicalizesToNil(t *testing.T) {
 	ptr := page.ValuePtr{Offset: 21, Length: 34, FileID: 5}
 

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -184,6 +184,31 @@ func TestBTreeAdaptiveBothSplitCapacityStaysDisabledForAppendOnly(t *testing.T) 
 	}
 }
 
+func TestBTreeAdaptiveBothSplitCapacityIgnoresNonAppendReplacements(t *testing.T) {
+	m := NewBTreeWithDegree(2)
+	key := func(i int) []byte {
+		return []byte{byte(i >> 8), byte(i)}
+	}
+
+	for i := 0; i < btreeAdaptiveBothSplitMinEntries; i++ {
+		m.Set(key(2048+i*2), []byte{byte(i)})
+	}
+	existingLowKey := key(2048)
+	for i := 0; i < btreeAdaptiveBothSplitMinNonAppend*2; i++ {
+		m.Set(existingLowKey, []byte{byte(i)})
+	}
+	if m.reuseBothSplitInsertCapacity || m.nonAppendSetCount != 0 {
+		t.Fatalf("adaptive state after replacements enabled=%v nonAppend=%d, want false,0", m.reuseBothSplitInsertCapacity, m.nonAppendSetCount)
+	}
+
+	for i := 0; i < btreeAdaptiveBothSplitMinNonAppend; i++ {
+		m.Set(key(i*2+1), []byte{byte(i)})
+	}
+	if !m.reuseBothSplitInsertCapacity {
+		t.Fatal("adaptive split sibling capacity did not enable after true non-append inserts")
+	}
+}
+
 func TestBTreePointerEmptySliceCanonicalizesToNil(t *testing.T) {
 	ptr := page.ValuePtr{Offset: 21, Length: 34, FileID: 5}
 

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	gonum.org/v1/plot v0.16.0
 )
 
-replace github.com/tidwall/btree => github.com/snissn/tidwall-btree v0.0.0-20260424182822-a686a2602ef3
+replace github.com/tidwall/btree => github.com/snissn/tidwall-btree v0.0.0-20260425000122-ae56bc3ce28e
 
 require (
 	codeberg.org/go-fonts/liberation v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/snissn/compress v1.18.2-snissn.0.0.20260204222835-33fc0851d88e h1:l7j
 github.com/snissn/compress v1.18.2-snissn.0.0.20260204222835-33fc0851d88e/go.mod h1:p4xiZN07JMUF5xuybNGkG+pozT12MAblxCx36z+PIYM=
 github.com/snissn/tidwall-btree v0.0.0-20260424182822-a686a2602ef3 h1:5vdZVtYxBG84dOLlH3NmHGwR3tFE61O0iQfDvyWurgE=
 github.com/snissn/tidwall-btree v0.0.0-20260424182822-a686a2602ef3/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
+github.com/snissn/tidwall-btree v0.0.0-20260425000122-ae56bc3ce28e h1:Ebvlf1n568bldiC2vKVZKhzAlQdWVFtaWGiyiNXShn8=
+github.com/snissn/tidwall-btree v0.0.0-20260425000122-ae56bc3ce28e/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=


### PR DESCRIPTION
Adds an adaptive BTree memtable gate that enables the new tidwall-btree split sibling capacity option only after observing repeated non-append inserts. This targets random/mixed insert leaf growth allocations without applying the wider split policy to append-only/sorted fills.\n\nDependency:\n- tidwall-btree PR: https://github.com/snissn/tidwall-btree/pull/6\n\nValidation:\n- go test -count=1 ./TreeDB/internal/memtable\n- go test -count=1 ./TreeDB/caching\n- go build -o bin/unified-bench ./cmd/unified_bench\n- random_write isolated: 1,864,983 ops/s, profile /tmp/profile_btree_adaptive_split_random_only_kGmbLI\n- batch_write_steady isolated: 3,738,914 ops/s, profile /tmp/profile_btree_adaptive_split_steady_only_NFekfJ\n- all-tests repeat: /tmp/profile_btree_adaptive_split_all_repeat_ZVE7NQ