### PR TITLE
Preallocate live leaf length indexes

### DIFF
--- a/TreeDB/db/leaf_generation_record_length_index.go
+++ b/TreeDB/db/leaf_generation_record_length_index.go
@@ -19,6 +19,10 @@ const (
 	leafGenerationRecordLengthIndexMagic      = "TLGI"
 	leafGenerationRecordLengthIndexVersion    = 1
 	leafGenerationRecordLengthIndexSuffix     = ".lenidx"
+	// Live leaf-log writers add records in offset order. Preallocating one
+	// modest segment's worth of record metadata avoids repeated growth while
+	// keeping retained per-file index memory bounded.
+	leafGenerationRecordLengthIndexLiveInitialCap = 4096
 )
 
 type leafGenerationRecordLengthIndex struct {
@@ -66,6 +70,13 @@ func (idx *leafGenerationRecordLengthIndex) clone() *leafGenerationRecordLengthI
 	return &leafGenerationRecordLengthIndex{
 		offsets: append([]uint32(nil), idx.offsets...),
 		lengths: append([]uint32(nil), idx.lengths...),
+	}
+}
+
+func newLiveLeafGenerationRecordLengthIndex() *leafGenerationRecordLengthIndex {
+	return &leafGenerationRecordLengthIndex{
+		offsets: make([]uint32, 0, leafGenerationRecordLengthIndexLiveInitialCap),
+		lengths: make([]uint32, 0, leafGenerationRecordLengthIndexLiveInitialCap),
 	}
 }
 
@@ -316,7 +327,7 @@ func (db *DB) noteLeafGenerationRecordLengthRaw(rawFileID uint32, offset uint64,
 	}
 	idx := db.leafGenerationRecordLengthByFile[rawFileID]
 	if idx == nil {
-		idx = &leafGenerationRecordLengthIndex{}
+		idx = newLiveLeafGenerationRecordLengthIndex()
 		db.leafGenerationRecordLengthByFile[rawFileID] = idx
 	}
 	idx.add(offset, recordLen)

--- a/TreeDB/db/leaf_generation_record_length_index.go
+++ b/TreeDB/db/leaf_generation_record_length_index.go
@@ -167,15 +167,29 @@ func (idx *leafGenerationRecordLengthIndex) add(offset uint64, length uint32) bo
 }
 
 func (idx *leafGenerationRecordLengthIndex) reserveLiveAppendCapacity(nextLen int) {
-	if idx == nil || nextLen <= cap(idx.offsets) && nextLen <= cap(idx.lengths) {
+	if idx == nil || nextLen <= leafGenerationRecordLengthIndexLivePreallocTrigger {
 		return
 	}
-	target := nextLen
-	if nextLen > leafGenerationRecordLengthIndexLivePreallocTrigger && target < leafGenerationRecordLengthIndexLivePreallocCap {
-		target = leafGenerationRecordLengthIndexLivePreallocCap
-	}
-	if target <= cap(idx.offsets) && target <= cap(idx.lengths) {
+	if nextLen <= cap(idx.offsets) && nextLen <= cap(idx.lengths) {
 		return
+	}
+	current := cap(idx.offsets)
+	if cap(idx.lengths) > current {
+		current = cap(idx.lengths)
+	}
+	target := leafGenerationRecordLengthIndexLivePreallocCap
+	if current > 0 {
+		maxInt := int(^uint(0) >> 1)
+		grown := nextLen
+		if current <= maxInt/2 {
+			grown = current * 2
+		}
+		if target < grown {
+			target = grown
+		}
+	}
+	if target < nextLen {
+		target = nextLen
 	}
 	offsets := make([]uint32, len(idx.offsets), target)
 	copy(offsets, idx.offsets)

--- a/TreeDB/db/leaf_generation_record_length_index.go
+++ b/TreeDB/db/leaf_generation_record_length_index.go
@@ -19,10 +19,12 @@ const (
 	leafGenerationRecordLengthIndexMagic      = "TLGI"
 	leafGenerationRecordLengthIndexVersion    = 1
 	leafGenerationRecordLengthIndexSuffix     = ".lenidx"
-	// Live leaf-log writers add records in offset order. Preallocating one
-	// modest segment's worth of record metadata avoids repeated growth while
-	// keeping retained per-file index memory bounded.
-	leafGenerationRecordLengthIndexLiveInitialCap = 4096
+	// Live leaf-log writers add records in offset order. Avoid a large first-use
+	// allocation because many small rotated files can keep their cached indexes
+	// for process lifetime; grow to one modest segment's worth only after the file
+	// has enough records to prove it is not a tiny segment.
+	leafGenerationRecordLengthIndexLivePreallocTrigger = 64
+	leafGenerationRecordLengthIndexLivePreallocCap     = 4096
 )
 
 type leafGenerationRecordLengthIndex struct {
@@ -74,10 +76,7 @@ func (idx *leafGenerationRecordLengthIndex) clone() *leafGenerationRecordLengthI
 }
 
 func newLiveLeafGenerationRecordLengthIndex() *leafGenerationRecordLengthIndex {
-	return &leafGenerationRecordLengthIndex{
-		offsets: make([]uint32, 0, leafGenerationRecordLengthIndexLiveInitialCap),
-		lengths: make([]uint32, 0, leafGenerationRecordLengthIndexLiveInitialCap),
-	}
+	return &leafGenerationRecordLengthIndex{}
 }
 
 func (idx *leafGenerationRecordLengthIndex) lookup(offset uint64) (uint32, bool) {
@@ -142,6 +141,7 @@ func (idx *leafGenerationRecordLengthIndex) add(offset uint64, length uint32) bo
 	off32 := uint32(offset)
 	n := len(idx.offsets)
 	if n == 0 || idx.offsets[n-1] < off32 {
+		idx.reserveLiveAppendCapacity(n + 1)
 		idx.offsets = append(idx.offsets, off32)
 		idx.lengths = append(idx.lengths, length)
 		return true
@@ -156,6 +156,7 @@ func (idx *leafGenerationRecordLengthIndex) add(offset uint64, length uint32) bo
 		idx.lengths[i] = length
 		return true
 	}
+	idx.reserveLiveAppendCapacity(n + 1)
 	idx.offsets = append(idx.offsets, 0)
 	copy(idx.offsets[i+1:], idx.offsets[i:])
 	idx.offsets[i] = off32
@@ -163,6 +164,25 @@ func (idx *leafGenerationRecordLengthIndex) add(offset uint64, length uint32) bo
 	copy(idx.lengths[i+1:], idx.lengths[i:])
 	idx.lengths[i] = length
 	return true
+}
+
+func (idx *leafGenerationRecordLengthIndex) reserveLiveAppendCapacity(nextLen int) {
+	if idx == nil || nextLen <= cap(idx.offsets) && nextLen <= cap(idx.lengths) {
+		return
+	}
+	target := nextLen
+	if nextLen > leafGenerationRecordLengthIndexLivePreallocTrigger && target < leafGenerationRecordLengthIndexLivePreallocCap {
+		target = leafGenerationRecordLengthIndexLivePreallocCap
+	}
+	if target <= cap(idx.offsets) && target <= cap(idx.lengths) {
+		return
+	}
+	offsets := make([]uint32, len(idx.offsets), target)
+	copy(offsets, idx.offsets)
+	lengths := make([]uint32, len(idx.lengths), target)
+	copy(lengths, idx.lengths)
+	idx.offsets = offsets
+	idx.lengths = lengths
 }
 
 func leafGenerationRecordLengthIndexPath(rootDir string, rawFileID uint32) string {

--- a/TreeDB/db/leaf_generation_record_length_index_test.go
+++ b/TreeDB/db/leaf_generation_record_length_index_test.go
@@ -63,7 +63,7 @@ func TestLeafGenerationRecordLengthIndex_NoteRawAllowsOffsetZero(t *testing.T) {
 	}
 }
 
-func TestLeafGenerationRecordLengthIndex_NoteRawPreallocatesLiveIndex(t *testing.T) {
+func TestLeafGenerationRecordLengthIndex_NoteRawStartsSmallForTinyLiveIndex(t *testing.T) {
 	db := &DB{}
 	db.noteLeafGenerationRecordLengthRaw(11, 4, 96)
 
@@ -73,13 +73,36 @@ func TestLeafGenerationRecordLengthIndex_NoteRawPreallocatesLiveIndex(t *testing
 	if idx == nil {
 		t.Fatal("expected live record-length index")
 	}
-	if got, wantMin := cap(idx.offsets), leafGenerationRecordLengthIndexLiveInitialCap; got < wantMin {
-		t.Fatalf("offset capacity=%d want >= %d", got, wantMin)
+	if got, wantMax := cap(idx.offsets), leafGenerationRecordLengthIndexLivePreallocTrigger; got > wantMax {
+		t.Fatalf("offset capacity=%d want <= %d for tiny live index", got, wantMax)
 	}
-	if got, wantMin := cap(idx.lengths), leafGenerationRecordLengthIndexLiveInitialCap; got < wantMin {
-		t.Fatalf("length capacity=%d want >= %d", got, wantMin)
+	if got, wantMax := cap(idx.lengths), leafGenerationRecordLengthIndexLivePreallocTrigger; got > wantMax {
+		t.Fatalf("length capacity=%d want <= %d for tiny live index", got, wantMax)
 	}
 	if got, ok := idx.lookup(4); !ok || got != 96 {
 		t.Fatalf("lookup(4)=(%d,%v), want (96,true)", got, ok)
+	}
+}
+
+func TestLeafGenerationRecordLengthIndex_NoteRawPreallocatesAfterSustainedUse(t *testing.T) {
+	db := &DB{}
+	for i := 0; i < leafGenerationRecordLengthIndexLivePreallocTrigger+1; i++ {
+		db.noteLeafGenerationRecordLengthRaw(12, uint64(i*128), 96)
+	}
+
+	db.leafGenerationRecordLengthMu.RLock()
+	idx := db.leafGenerationRecordLengthByFile[12]
+	db.leafGenerationRecordLengthMu.RUnlock()
+	if idx == nil {
+		t.Fatal("expected live record-length index")
+	}
+	if got, wantMin := cap(idx.offsets), leafGenerationRecordLengthIndexLivePreallocCap; got < wantMin {
+		t.Fatalf("offset capacity=%d want >= %d", got, wantMin)
+	}
+	if got, wantMin := cap(idx.lengths), leafGenerationRecordLengthIndexLivePreallocCap; got < wantMin {
+		t.Fatalf("length capacity=%d want >= %d", got, wantMin)
+	}
+	if got, ok := idx.lookup(uint64(leafGenerationRecordLengthIndexLivePreallocTrigger * 128)); !ok || got != 96 {
+		t.Fatalf("lookup(last)=(%d,%v), want (96,true)", got, ok)
 	}
 }

--- a/TreeDB/db/leaf_generation_record_length_index_test.go
+++ b/TreeDB/db/leaf_generation_record_length_index_test.go
@@ -106,3 +106,49 @@ func TestLeafGenerationRecordLengthIndex_NoteRawPreallocatesAfterSustainedUse(t 
 		t.Fatalf("lookup(last)=(%d,%v), want (96,true)", got, ok)
 	}
 }
+
+func TestLeafGenerationRecordLengthIndex_ReserveSkipsTinyGrowth(t *testing.T) {
+	idx := &leafGenerationRecordLengthIndex{
+		offsets: make([]uint32, 4, 4),
+		lengths: make([]uint32, 4, 4),
+	}
+	offsetPtr := &idx.offsets[0]
+	lengthPtr := &idx.lengths[0]
+
+	idx.reserveLiveAppendCapacity(5)
+	if got, want := cap(idx.offsets), 4; got != want {
+		t.Fatalf("offset capacity after tiny reserve=%d want %d", got, want)
+	}
+	if got, want := cap(idx.lengths), 4; got != want {
+		t.Fatalf("length capacity after tiny reserve=%d want %d", got, want)
+	}
+	if &idx.offsets[0] != offsetPtr {
+		t.Fatal("tiny reserve reallocated offsets")
+	}
+	if &idx.lengths[0] != lengthPtr {
+		t.Fatal("tiny reserve reallocated lengths")
+	}
+
+	idx.reserveLiveAppendCapacity(leafGenerationRecordLengthIndexLivePreallocTrigger + 1)
+	if got, wantMin := cap(idx.offsets), leafGenerationRecordLengthIndexLivePreallocCap; got < wantMin {
+		t.Fatalf("offset capacity after sustained reserve=%d want >= %d", got, wantMin)
+	}
+	if got, wantMin := cap(idx.lengths), leafGenerationRecordLengthIndexLivePreallocCap; got < wantMin {
+		t.Fatalf("length capacity after sustained reserve=%d want >= %d", got, wantMin)
+	}
+}
+
+func TestLeafGenerationRecordLengthIndex_ReserveGrowsGeometricallyAfterPrealloc(t *testing.T) {
+	idx := &leafGenerationRecordLengthIndex{
+		offsets: make([]uint32, leafGenerationRecordLengthIndexLivePreallocCap, leafGenerationRecordLengthIndexLivePreallocCap),
+		lengths: make([]uint32, leafGenerationRecordLengthIndexLivePreallocCap, leafGenerationRecordLengthIndexLivePreallocCap),
+	}
+
+	idx.reserveLiveAppendCapacity(leafGenerationRecordLengthIndexLivePreallocCap + 1)
+	if got, wantMin := cap(idx.offsets), leafGenerationRecordLengthIndexLivePreallocCap*2; got < wantMin {
+		t.Fatalf("offset capacity after full prealloc reserve=%d want >= %d", got, wantMin)
+	}
+	if got, wantMin := cap(idx.lengths), leafGenerationRecordLengthIndexLivePreallocCap*2; got < wantMin {
+		t.Fatalf("length capacity after full prealloc reserve=%d want >= %d", got, wantMin)
+	}
+}

--- a/TreeDB/db/leaf_generation_record_length_index_test.go
+++ b/TreeDB/db/leaf_generation_record_length_index_test.go
@@ -62,3 +62,24 @@ func TestLeafGenerationRecordLengthIndex_NoteRawAllowsOffsetZero(t *testing.T) {
 		t.Fatalf("lookup(0)=(%d,%v), want (64,true)", got, ok)
 	}
 }
+
+func TestLeafGenerationRecordLengthIndex_NoteRawPreallocatesLiveIndex(t *testing.T) {
+	db := &DB{}
+	db.noteLeafGenerationRecordLengthRaw(11, 4, 96)
+
+	db.leafGenerationRecordLengthMu.RLock()
+	idx := db.leafGenerationRecordLengthByFile[11]
+	db.leafGenerationRecordLengthMu.RUnlock()
+	if idx == nil {
+		t.Fatal("expected live record-length index")
+	}
+	if got, wantMin := cap(idx.offsets), leafGenerationRecordLengthIndexLiveInitialCap; got < wantMin {
+		t.Fatalf("offset capacity=%d want >= %d", got, wantMin)
+	}
+	if got, wantMin := cap(idx.lengths), leafGenerationRecordLengthIndexLiveInitialCap; got < wantMin {
+		t.Fatalf("length capacity=%d want >= %d", got, wantMin)
+	}
+	if got, ok := idx.lookup(4); !ok || got != 96 {
+		t.Fatalf("lookup(4)=(%d,%v), want (96,true)", got, ok)
+	}
+}


### PR DESCRIPTION
Preallocates the live leaf-generation record-length index used while appending leaf-log records. This avoids repeated slice growth for normal live leaf-log segments while bounding retained memory to a modest per-file cap.\n\nValidation:\n- go test -count=1 ./TreeDB/db\n- go test -count=1 ./TreeDB/caching\n- go build -o bin/unified-bench ./cmd/unified_bench\n- batch_write_steady profile: /tmp/profile_lenidx_prealloc_steady_6bGRDV\n\nProfile note:\n- In the steady write profile, leafGenerationRecordLengthIndex.add alloc_space dropped from about 2.81MB on #1043 isolated steady to 0.59MB with this patch. This is allocation hygiene, not a claimed throughput win.