### PR TITLE
[codex] add treedb single-key update API

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -19298,29 +19298,53 @@ func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error 
 	}
 	db.waitForCheckpoint()
 
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	for {
+		unlock := db.lockUpdateKey(key)
+		old, err := db.getForUpdate(key)
+		unlock()
+		if err != nil {
+			return err
+		}
+		observed := cloneUpdateValue(old)
 
-	old, err := db.getForUpdate(key)
-	if err != nil {
-		return err
-	}
-	result, err := fn(old)
-	if err != nil {
-		return err
-	}
-	switch result.Op {
-	case backenddb.UpdateNoop:
-		return nil
-	case backenddb.UpdateSet:
-		if result.Value == nil {
+		result, err := fn(old)
+		if err != nil {
+			return err
+		}
+		if result.Op == backenddb.UpdateSet && result.Value == nil {
 			return ErrValueNil
 		}
-		return db.set(key, result.Value, syncWrite)
-	case backenddb.UpdateDelete:
-		return db.delete(key, syncWrite)
-	default:
-		return fmt.Errorf("treedb: unknown update op %d", result.Op)
+		if result.Op != backenddb.UpdateNoop && result.Op != backenddb.UpdateSet && result.Op != backenddb.UpdateDelete {
+			return fmt.Errorf("treedb: unknown update op %d", result.Op)
+		}
+
+		unlock = db.lockUpdateKey(key)
+		latest, err := db.getForUpdate(key)
+		if err != nil {
+			unlock()
+			return err
+		}
+		if !sameUpdateValue(observed, latest) {
+			unlock()
+			continue
+		}
+
+		switch result.Op {
+		case backenddb.UpdateNoop:
+			unlock()
+			return nil
+		case backenddb.UpdateSet:
+			err = db.set(key, result.Value, syncWrite)
+			unlock()
+			return err
+		case backenddb.UpdateDelete:
+			err = db.delete(key, syncWrite)
+			unlock()
+			return err
+		default:
+			unlock()
+			return fmt.Errorf("treedb: unknown update op %d", result.Op)
+		}
 	}
 }
 
@@ -19334,6 +19358,20 @@ func (db *DB) getForUpdate(key []byte) ([]byte, error) {
 		return nil, err
 	}
 	return old[:len(old):len(old)], nil
+}
+
+func cloneUpdateValue(value []byte) []byte {
+	if value == nil {
+		return nil
+	}
+	return append([]byte{}, value...)
+}
+
+func sameUpdateValue(a, b []byte) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	return bytes.Equal(a, b)
 }
 
 func (db *DB) flushAllMemtablesForSync(sync bool) error {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -19301,7 +19301,7 @@ func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error 
 	unlock := db.lockUpdateKey(key)
 	defer unlock()
 
-	old, err := db.Get(key)
+	old, err := db.getForUpdate(key)
 	if err != nil {
 		return err
 	}
@@ -19322,6 +19322,18 @@ func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error 
 	default:
 		return fmt.Errorf("treedb: unknown update op %d", result.Op)
 	}
+}
+
+func (db *DB) getForUpdate(key []byte) ([]byte, error) {
+	dst := make([]byte, 0)
+	old, err := db.GetAppend(key, dst)
+	if err == tree.ErrKeyNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return old[:len(old):len(old)], nil
 }
 
 func (db *DB) flushAllMemtablesForSync(sync bool) error {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/internal/compression"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/keyupdate"
 	"github.com/snissn/gomap/TreeDB/internal/limits"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/merging"
@@ -6134,12 +6135,13 @@ type memtableViewLifecycleTelemetry struct {
 }
 
 type DB struct {
-	mu      sync.RWMutex
-	flushMu sync.Mutex
-	writeMu sync.RWMutex
-	statsMu sync.Mutex // Re-introduce global statsMu for isolation
-	bpMu    sync.Mutex
-	bpCond  *sync.Cond
+	mu          sync.RWMutex
+	flushMu     sync.Mutex
+	writeMu     sync.RWMutex
+	updateLocks keyupdate.Locks
+	statsMu     sync.Mutex // Re-introduce global statsMu for isolation
+	bpMu        sync.Mutex
+	bpCond      *sync.Cond
 
 	// Commit workers removed; backend commits are synchronous.
 
@@ -19257,6 +19259,8 @@ func (db *DB) Set(key, value []byte) error {
 		return ErrValueNil
 	}
 	db.waitForCheckpoint()
+	unlock := db.lockUpdateKey(key)
+	defer unlock()
 	return db.set(key, value, false)
 }
 
@@ -19268,7 +19272,56 @@ func (db *DB) SetSync(key, value []byte) error {
 		return ErrValueNil
 	}
 	db.waitForCheckpoint()
+	unlock := db.lockUpdateKey(key)
+	defer unlock()
 	return db.set(key, value, true)
+}
+
+// Update applies fn to the current value for key and writes the returned
+// mutation without forcing an fsync boundary.
+func (db *DB) Update(key []byte, fn backenddb.UpdateFunc) error {
+	return db.update(key, fn, false)
+}
+
+// UpdateSync applies fn to the current value for key and writes the returned
+// mutation with a sync durability boundary.
+func (db *DB) UpdateSync(key []byte, fn backenddb.UpdateFunc) error {
+	return db.update(key, fn, true)
+}
+
+func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error {
+	if len(key) == 0 {
+		return ErrKeyEmpty
+	}
+	if fn == nil {
+		return backenddb.ErrNilUpdateFunc
+	}
+	db.waitForCheckpoint()
+
+	unlock := db.lockUpdateKey(key)
+	defer unlock()
+
+	old, err := db.Get(key)
+	if err != nil {
+		return err
+	}
+	result, err := fn(old)
+	if err != nil {
+		return err
+	}
+	switch result.Op {
+	case backenddb.UpdateNoop:
+		return nil
+	case backenddb.UpdateSet:
+		if result.Value == nil {
+			return ErrValueNil
+		}
+		return db.set(key, result.Value, syncWrite)
+	case backenddb.UpdateDelete:
+		return db.delete(key, syncWrite)
+	default:
+		return fmt.Errorf("treedb: unknown update op %d", result.Op)
+	}
 }
 
 func (db *DB) flushAllMemtablesForSync(sync bool) error {
@@ -19509,6 +19562,8 @@ func (db *DB) Delete(key []byte) error {
 		return ErrKeyEmpty
 	}
 	db.waitForCheckpoint()
+	unlock := db.lockUpdateKey(key)
+	defer unlock()
 	return db.delete(key, false)
 }
 
@@ -20120,7 +20175,16 @@ func (db *DB) DeleteSync(key []byte) error {
 		return ErrKeyEmpty
 	}
 	db.waitForCheckpoint()
+	unlock := db.lockUpdateKey(key)
+	defer unlock()
 	return db.delete(key, true)
+}
+
+func (db *DB) lockUpdateKey(key []byte) func() {
+	if db == nil {
+		return func() {}
+	}
+	return db.updateLocks.Lock(key)
 }
 
 func (db *DB) delete(key []byte, sync bool) error {

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -338,34 +338,44 @@ func (db *DB) Has(key []byte) (bool, error) {
 
 // Set sets the value for a key.
 func (db *DB) Set(key, value []byte) error {
-	if handled, err := db.writeViaCommitCombiner(key, value, false, false); handled {
+	unlock := db.lockUpdateKey(key)
+	defer unlock()
+	return db.setPoint(key, value, false)
+}
+
+func (db *DB) setPoint(key, value []byte, sync bool) error {
+	if handled, err := db.writeViaCommitCombiner(key, value, false, sync); handled {
 		return err
 	}
-	return db.writeSingleKV(key, value, false, false)
+	return db.writeSingleKV(key, value, false, sync)
 }
 
 // SetSync sets the value and syncs to disk.
 func (db *DB) SetSync(key, value []byte) error {
-	if handled, err := db.writeViaCommitCombiner(key, value, false, true); handled {
-		return err
-	}
-	return db.writeSingleKV(key, value, false, true)
+	unlock := db.lockUpdateKey(key)
+	defer unlock()
+	return db.setPoint(key, value, true)
 }
 
 // Delete removes a key.
 func (db *DB) Delete(key []byte) error {
-	if handled, err := db.writeViaCommitCombiner(key, nil, true, false); handled {
+	unlock := db.lockUpdateKey(key)
+	defer unlock()
+	return db.deletePoint(key, false)
+}
+
+func (db *DB) deletePoint(key []byte, sync bool) error {
+	if handled, err := db.writeViaCommitCombiner(key, nil, true, sync); handled {
 		return err
 	}
-	return db.writeSingleKV(key, nil, true, false)
+	return db.writeSingleKV(key, nil, true, sync)
 }
 
 // DeleteSync removes a key and syncs.
 func (db *DB) DeleteSync(key []byte) error {
-	if handled, err := db.writeViaCommitCombiner(key, nil, true, true); handled {
-		return err
-	}
-	return db.writeSingleKV(key, nil, true, true)
+	unlock := db.lockUpdateKey(key)
+	defer unlock()
+	return db.deletePoint(key, true)
 }
 
 // DBIterator wraps tree.Iterator and holds a Snapshot.

--- a/TreeDB/db/closed_db_public_methods_test.go
+++ b/TreeDB/db/closed_db_public_methods_test.go
@@ -228,6 +228,28 @@ func TestClosedDB_DeleteSync(t *testing.T) {
 	})
 }
 
+func TestClosedDB_Update(t *testing.T) {
+	runClosedDBMethod(t, "Update", func(d *DB) {
+		err := d.Update([]byte("k"), func([]byte) (UpdateResult, error) {
+			return SetUpdate([]byte("v")), nil
+		})
+		if !errors.Is(err, ErrClosed) {
+			t.Fatalf("Update err=%v want %v", err, ErrClosed)
+		}
+	})
+}
+
+func TestClosedDB_UpdateSync(t *testing.T) {
+	runClosedDBMethod(t, "UpdateSync", func(d *DB) {
+		err := d.UpdateSync([]byte("k"), func([]byte) (UpdateResult, error) {
+			return SetUpdate([]byte("v")), nil
+		})
+		if !errors.Is(err, ErrClosed) {
+			t.Fatalf("UpdateSync err=%v want %v", err, ErrClosed)
+		}
+	})
+}
+
 func TestClosedDB_Iterator(t *testing.T) {
 	runClosedDBMethod(t, "Iterator", func(d *DB) {
 		it, err := d.Iterator(nil, nil)

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -15,6 +15,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
 	"github.com/snissn/gomap/TreeDB/internal/bulk"
 	"github.com/snissn/gomap/TreeDB/internal/compression"
+	"github.com/snissn/gomap/TreeDB/internal/keyupdate"
 	"github.com/snissn/gomap/TreeDB/internal/lockfile"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/lifecycle"
@@ -117,6 +118,7 @@ type DB struct {
 	mu               sync.RWMutex
 	writeMu          sync.RWMutex
 	commitMu         sync.Mutex
+	updateLocks      keyupdate.Locks
 	maintenanceMu    sync.Mutex
 	combineMu        sync.RWMutex
 	combineReqCh     chan *commitCombineReq

--- a/TreeDB/db/update.go
+++ b/TreeDB/db/update.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 
@@ -48,7 +49,8 @@ func NoopUpdate() UpdateResult {
 }
 
 // UpdateFunc transforms the current value for a key into a mutation. The old
-// value is nil when the key is absent and is a safe copy when present.
+// value is nil when the key is absent and is a safe copy when present. The
+// callback may be retried if the key changes before the mutation commits.
 type UpdateFunc func(old []byte) (UpdateResult, error)
 
 // Update applies fn to the current value for key and writes the returned
@@ -77,29 +79,53 @@ func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
 		return ErrReadOnly
 	}
 
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	for {
+		unlock := db.lockUpdateKey(key)
+		old, err := db.getForUpdate(key)
+		unlock()
+		if err != nil {
+			return err
+		}
+		observed := cloneUpdateValue(old)
 
-	old, err := db.getForUpdate(key)
-	if err != nil {
-		return err
-	}
-	result, err := fn(old)
-	if err != nil {
-		return err
-	}
-	switch result.Op {
-	case UpdateNoop:
-		return nil
-	case UpdateSet:
-		if result.Value == nil {
+		result, err := fn(old)
+		if err != nil {
+			return err
+		}
+		if result.Op == UpdateSet && result.Value == nil {
 			return ErrUpdateValueNil
 		}
-		return db.setPoint(key, result.Value, syncWrite)
-	case UpdateDelete:
-		return db.deletePoint(key, syncWrite)
-	default:
-		return fmt.Errorf("treedb: unknown update op %d", result.Op)
+		if result.Op != UpdateNoop && result.Op != UpdateSet && result.Op != UpdateDelete {
+			return fmt.Errorf("treedb: unknown update op %d", result.Op)
+		}
+
+		unlock = db.lockUpdateKey(key)
+		latest, err := db.getForUpdate(key)
+		if err != nil {
+			unlock()
+			return err
+		}
+		if !sameUpdateValue(observed, latest) {
+			unlock()
+			continue
+		}
+
+		switch result.Op {
+		case UpdateNoop:
+			unlock()
+			return nil
+		case UpdateSet:
+			err = db.setPoint(key, result.Value, syncWrite)
+			unlock()
+			return err
+		case UpdateDelete:
+			err = db.deletePoint(key, syncWrite)
+			unlock()
+			return err
+		default:
+			unlock()
+			return fmt.Errorf("treedb: unknown update op %d", result.Op)
+		}
 	}
 }
 
@@ -120,4 +146,18 @@ func (db *DB) getForUpdate(key []byte) ([]byte, error) {
 		return nil, err
 	}
 	return old[:len(old):len(old)], nil
+}
+
+func cloneUpdateValue(value []byte) []byte {
+	if value == nil {
+		return nil
+	}
+	return append([]byte{}, value...)
+}
+
+func sameUpdateValue(a, b []byte) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	return bytes.Equal(a, b)
 }

--- a/TreeDB/db/update.go
+++ b/TreeDB/db/update.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 // ErrNilUpdateFunc indicates a nil callback was passed to Update.
@@ -79,7 +80,7 @@ func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
 	unlock := db.lockUpdateKey(key)
 	defer unlock()
 
-	old, err := db.Get(key)
+	old, err := db.getForUpdate(key)
 	if err != nil {
 		return err
 	}
@@ -107,4 +108,16 @@ func (db *DB) lockUpdateKey(key []byte) func() {
 		return func() {}
 	}
 	return db.updateLocks.Lock(key)
+}
+
+func (db *DB) getForUpdate(key []byte) ([]byte, error) {
+	dst := make([]byte, 0)
+	old, err := db.GetAppend(key, dst)
+	if err == tree.ErrKeyNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return old[:len(old):len(old)], nil
 }

--- a/TreeDB/db/update.go
+++ b/TreeDB/db/update.go
@@ -1,0 +1,110 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+)
+
+// ErrNilUpdateFunc indicates a nil callback was passed to Update.
+var ErrNilUpdateFunc = errors.New("treedb: nil update function")
+
+// ErrUpdateValueNil indicates an Update callback requested Set with a nil value.
+var ErrUpdateValueNil = errors.New("value cannot be nil")
+
+// UpdateOp describes the write produced by an Update callback.
+type UpdateOp uint8
+
+const (
+	// UpdateNoop leaves the key unchanged.
+	UpdateNoop UpdateOp = iota
+	// UpdateSet replaces the key with Value.
+	UpdateSet
+	// UpdateDelete removes the key.
+	UpdateDelete
+)
+
+// UpdateResult is returned by an Update callback.
+type UpdateResult struct {
+	Op    UpdateOp
+	Value []byte
+}
+
+// SetUpdate returns an Update result that replaces the key with value.
+func SetUpdate(value []byte) UpdateResult {
+	return UpdateResult{Op: UpdateSet, Value: value}
+}
+
+// DeleteUpdate returns an Update result that removes the key.
+func DeleteUpdate() UpdateResult {
+	return UpdateResult{Op: UpdateDelete}
+}
+
+// NoopUpdate returns an Update result that leaves the key unchanged.
+func NoopUpdate() UpdateResult {
+	return UpdateResult{Op: UpdateNoop}
+}
+
+// UpdateFunc transforms the current value for a key into a mutation. The old
+// value is nil when the key is absent and is a safe copy when present.
+type UpdateFunc func(old []byte) (UpdateResult, error)
+
+// Update applies fn to the current value for key and writes the returned
+// mutation without forcing an fsync boundary.
+func (db *DB) Update(key []byte, fn UpdateFunc) error {
+	return db.update(key, fn, false)
+}
+
+// UpdateSync applies fn to the current value for key and writes the returned
+// mutation with a sync durability boundary.
+func (db *DB) UpdateSync(key []byte, fn UpdateFunc) error {
+	return db.update(key, fn, true)
+}
+
+func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
+	if db == nil {
+		return ErrClosed
+	}
+	if len(key) == 0 {
+		return batchpkg.ErrKeyEmpty
+	}
+	if fn == nil {
+		return ErrNilUpdateFunc
+	}
+	if db.readOnly {
+		return ErrReadOnly
+	}
+
+	unlock := db.lockUpdateKey(key)
+	defer unlock()
+
+	old, err := db.Get(key)
+	if err != nil {
+		return err
+	}
+	result, err := fn(old)
+	if err != nil {
+		return err
+	}
+	switch result.Op {
+	case UpdateNoop:
+		return nil
+	case UpdateSet:
+		if result.Value == nil {
+			return ErrUpdateValueNil
+		}
+		return db.setPoint(key, result.Value, syncWrite)
+	case UpdateDelete:
+		return db.deletePoint(key, syncWrite)
+	default:
+		return fmt.Errorf("treedb: unknown update op %d", result.Op)
+	}
+}
+
+func (db *DB) lockUpdateKey(key []byte) func() {
+	if db == nil {
+		return func() {}
+	}
+	return db.updateLocks.Lock(key)
+}

--- a/TreeDB/db/update_test.go
+++ b/TreeDB/db/update_test.go
@@ -2,9 +2,11 @@ package db
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestUpdateConcurrentCounterNoLostUpdates(t *testing.T) {
@@ -98,5 +100,62 @@ func TestUpdatePreservesEmptyValuePresence(t *testing.T) {
 	}
 	if !bytes.Equal(got, []byte("present-empty")) {
 		t.Fatalf("value got=%q want present-empty", got)
+	}
+}
+
+func TestUpdateCallbackCanReenterSameKeyWithoutDeadlock(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	key := []byte("reentrant")
+	if err := d.Set(key, []byte("seed")); err != nil {
+		t.Fatalf("Set seed: %v", err)
+	}
+
+	done := make(chan error, 1)
+	calls := 0
+	go func() {
+		done <- d.Update(key, func(old []byte) (UpdateResult, error) {
+			calls++
+			switch string(old) {
+			case "seed":
+				if err := d.Update(key, func(innerOld []byte) (UpdateResult, error) {
+					if !bytes.Equal(innerOld, []byte("seed")) {
+						return UpdateResult{}, fmt.Errorf("inner old = %q, want seed", innerOld)
+					}
+					return SetUpdate([]byte("inner")), nil
+				}); err != nil {
+					return UpdateResult{}, err
+				}
+				return NoopUpdate(), nil
+			case "inner":
+				return SetUpdate([]byte("outer")), nil
+			default:
+				return UpdateResult{}, fmt.Errorf("outer old = %q, want seed or inner", old)
+			}
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Update deadlocked during reentrant same-key callback")
+	}
+
+	if calls != 2 {
+		t.Fatalf("outer callback calls=%d want 2", calls)
+	}
+	got, err := d.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, []byte("outer")) {
+		t.Fatalf("value got=%q want outer", got)
 	}
 }

--- a/TreeDB/db/update_test.go
+++ b/TreeDB/db/update_test.go
@@ -1,0 +1,70 @@
+package db
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+)
+
+func TestUpdateConcurrentCounterNoLostUpdates(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	const (
+		workers    = 32
+		increments = 10
+	)
+	key := []byte("counter")
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < increments; j++ {
+				if err := d.Update(key, func(old []byte) (UpdateResult, error) {
+					n := 0
+					if old != nil {
+						parsed, err := strconv.Atoi(string(old))
+						if err != nil {
+							return UpdateResult{}, err
+						}
+						n = parsed
+					}
+					return SetUpdate([]byte(strconv.Itoa(n + 1))), nil
+				}); err != nil {
+					errs <- err
+					return
+				}
+			}
+			errs <- nil
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+	}
+	got, err := d.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	n, err := strconv.Atoi(string(got))
+	if err != nil {
+		t.Fatalf("parse counter %q: %v", got, err)
+	}
+	if want := workers * increments; n != want {
+		t.Fatalf("counter=%d want=%d", n, want)
+	}
+}

--- a/TreeDB/db/update_test.go
+++ b/TreeDB/db/update_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"strconv"
 	"sync"
 	"testing"
@@ -66,5 +67,36 @@ func TestUpdateConcurrentCounterNoLostUpdates(t *testing.T) {
 	}
 	if want := workers * increments; n != want {
 		t.Fatalf("counter=%d want=%d", n, want)
+	}
+}
+
+func TestUpdatePreservesEmptyValuePresence(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	key := []byte("empty")
+	if err := d.Set(key, []byte{}); err != nil {
+		t.Fatalf("Set empty: %v", err)
+	}
+	if err := d.Update(key, func(old []byte) (UpdateResult, error) {
+		if old == nil {
+			t.Fatalf("old = nil, want non-nil empty slice for present empty value")
+		}
+		if len(old) != 0 {
+			t.Fatalf("old len=%d, want 0", len(old))
+		}
+		return SetUpdate([]byte("present-empty")), nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, err := d.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, []byte("present-empty")) {
+		t.Fatalf("value got=%q want present-empty", got)
 	}
 }

--- a/TreeDB/docs/spec/concurrency-paradigms.md
+++ b/TreeDB/docs/spec/concurrency-paradigms.md
@@ -86,6 +86,7 @@ Mechanisms:
 - mutexes/RWMutex/condvars for critical sections and barriers.
 
 Key lock families:
+- public DB: `updateLocks[]` for single-key `Update`/`UpdateSync` read-modify-write serialization,
 - cached DB global: `mu`, `writeMu`, `flushMu`, `checkpointMu`, `laneMu`, `bpMu`,
 - cached per shard/lane: shard `mu`, lane `walMu`, lane `vlogMu`, `flushLaneMu[]`, `walFastMu`,
 - backend DB: `mu`, `writeMu`, `commitMu`, `idxMu`, plus worker-local mutexes.
@@ -187,6 +188,28 @@ Workers:
 - background index vacuum (public wrapper),
 - dictionary profile application loop.
 
+### 3.11 Public single-key update serialization
+
+Mechanism:
+- `DB.Update` and `DB.UpdateSync` hash the requested key into a fixed set of
+  per-handle mutex stripes before running the public `Get` + callback +
+  `Set`/`Delete` sequence.
+
+Effects:
+- concurrent logical updates to the same key on the same `DB` handle are
+  serialized,
+- callers can implement conflict-safe single-key mutations, such as
+  set-membership add/remove, without an external global lock,
+- unrelated keys usually proceed independently, subject to stripe collisions and
+  the lower cached/backend write-path locks.
+
+Limits:
+- this is not a multi-key transaction mechanism,
+- direct `Set`/`Delete` calls remain unconditional writes and are not
+  compare-and-swap checked against concurrent `Update` callbacks,
+- the update callback runs while the stripe lock is held and should not recurse
+  into `Update` for the same key/stripe.
+
 ## 4. Lock and Barrier Topology
 
 ### 4.1 Cached layer lock roles
@@ -208,6 +231,8 @@ Workers:
 ### 4.2 Lock-order constraints that must hold
 
 Current order constraints:
+- public `Update`/`UpdateSync` take an update stripe lock before entering public
+  read/write APIs; lower layers must not call back into public update locks.
 - `flushMu` before `checkpointMu` when both are needed.
 - `Checkpoint` acquires `flushMu` then `writeMu`.
 - `Close` mirrors `flushMu` then `writeMu` to avoid deadlock with auto-checkpoint.
@@ -443,6 +468,7 @@ A compatible implementation SHOULD preserve:
 ## 10. Existing Concurrency-Relevant Tests
 
 Representative coverage includes:
+- `TreeDB/update_test.go`,
 - `TreeDB/db/concurrent_write_test.go`,
 - `TreeDB/db/race_test.go`,
 - `TreeDB/db/vacuum_panic_test.go`,

--- a/TreeDB/docs/spec/concurrency-paradigms.md
+++ b/TreeDB/docs/spec/concurrency-paradigms.md
@@ -86,7 +86,8 @@ Mechanisms:
 - mutexes/RWMutex/condvars for critical sections and barriers.
 
 Key lock families:
-- public DB: `updateLocks[]` for single-key `Update`/`UpdateSync` read-modify-write serialization,
+- cached and backend DB: `updateLocks[]` for single-key `Update`/`UpdateSync`
+  read-modify-write serialization,
 - cached DB global: `mu`, `writeMu`, `flushMu`, `checkpointMu`, `laneMu`, `bpMu`,
 - cached per shard/lane: shard `mu`, lane `walMu`, lane `vlogMu`, `flushLaneMu[]`, `walFastMu`,
 - backend DB: `mu`, `writeMu`, `commitMu`, `idxMu`, plus worker-local mutexes.
@@ -188,16 +189,18 @@ Workers:
 - background index vacuum (public wrapper),
 - dictionary profile application loop.
 
-### 3.11 Public single-key update serialization
+### 3.11 Single-key update serialization
 
 Mechanism:
-- `DB.Update` and `DB.UpdateSync` hash the requested key into a fixed set of
-  per-handle mutex stripes before running the public `Get` + callback +
-  `Set`/`Delete` sequence.
+- cached and backend `DB.Update`/`DB.UpdateSync` hash the requested key into a
+  fixed set of per-handle mutex stripes before running the `Get` + callback +
+  point-write sequence.
 
 Effects:
 - concurrent logical updates to the same key on the same `DB` handle are
   serialized,
+- point `Set`/`SetSync`/`Delete`/`DeleteSync` calls use the same single-key
+  coordinator on the same handle,
 - callers can implement conflict-safe single-key mutations, such as
   set-membership add/remove, without an external global lock,
 - unrelated keys usually proceed independently, subject to stripe collisions and
@@ -205,8 +208,8 @@ Effects:
 
 Limits:
 - this is not a multi-key transaction mechanism,
-- direct `Set`/`Delete` calls remain unconditional writes and are not
-  compare-and-swap checked against concurrent `Update` callbacks,
+- point `Set`/`Delete` calls remain unconditional writes,
+- batch writes do not acquire the single-key update coordinator,
 - the update callback runs while the stripe lock is held and should not recurse
   into `Update` for the same key/stripe.
 
@@ -231,8 +234,8 @@ Limits:
 ### 4.2 Lock-order constraints that must hold
 
 Current order constraints:
-- public `Update`/`UpdateSync` take an update stripe lock before entering public
-  read/write APIs; lower layers must not call back into public update locks.
+- cached/backend `Update`/`UpdateSync` and point writes take an update stripe
+  lock before entering lower write paths.
 - `flushMu` before `checkpointMu` when both are needed.
 - `Checkpoint` acquires `flushMu` then `writeMu`.
 - `Close` mirrors `flushMu` then `writeMu` to avoid deadlock with auto-checkpoint.

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -39,6 +39,16 @@ When the cached layer is enabled (default `treedb.Open` behavior):
 
 - `Set`, `Delete` are non-sync writes.
 - `SetSync`, `DeleteSync` request sync durability boundary subject to durability mode.
+- `Update`, `UpdateSync` are single-key read-modify-write helpers. The callback
+  receives the current value as a safe copy, or `nil` when the key is absent, and
+  returns `Set`, `Delete`, or `Noop` intent through `UpdateResult`.
+- Concurrent `Update`/`UpdateSync` calls for the same key on the same `DB`
+  handle are serialized around the read-modify-write sequence. This prevents
+  lost updates for logical single-key mutations such as set-membership updates
+  when all competing writers use the update primitive.
+- Direct `Set`/`SetSync`/`Delete`/`DeleteSync` calls are still unconditional
+  writes; they are not compare-and-swap checked against concurrent `Update`
+  callbacks. Multi-key atomicity remains outside this contract.
 
 ### 3.2 Batches
 

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -42,13 +42,13 @@ When the cached layer is enabled (default `treedb.Open` behavior):
 - `Update`, `UpdateSync` are single-key read-modify-write helpers. The callback
   receives the current value as a safe copy, or `nil` when the key is absent, and
   returns `Set`, `Delete`, or `Noop` intent through `UpdateResult`.
-- Concurrent `Update`/`UpdateSync` calls for the same key on the same `DB`
-  handle are serialized around the read-modify-write sequence. This prevents
-  lost updates for logical single-key mutations such as set-membership updates
-  when all competing writers use the update primitive.
-- Direct `Set`/`SetSync`/`Delete`/`DeleteSync` calls are still unconditional
-  writes; they are not compare-and-swap checked against concurrent `Update`
-  callbacks. Multi-key atomicity remains outside this contract.
+- Concurrent `Update`/`UpdateSync` calls for the same key on the same cached or
+  backend `DB` handle are serialized around the read-modify-write sequence. This
+  prevents lost updates for logical single-key mutations such as set-membership
+  updates when competing writers use the update primitive.
+- Point `Set`/`SetSync`/`Delete`/`DeleteSync` calls participate in the same
+  single-key serialization on the same handle, but they remain unconditional
+  writes. Batch writes and multi-key atomicity remain outside this contract.
 
 ### 3.2 Batches
 

--- a/TreeDB/internal/keyupdate/locks.go
+++ b/TreeDB/internal/keyupdate/locks.go
@@ -1,0 +1,24 @@
+package keyupdate
+
+import (
+	"sync"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+const stripes = 256
+
+// Locks coordinates single-key read-modify-write operations. The zero value is
+// ready for use.
+type Locks struct {
+	stripes [stripes]sync.Mutex
+}
+
+// Lock locks the stripe for key and returns its unlock function. Hash collisions
+// only reduce concurrency; they do not affect correctness.
+func (l *Locks) Lock(key []byte) func() {
+	idx := xxhash.Sum64(key) & (stripes - 1)
+	mu := &l.stripes[idx]
+	mu.Lock()
+	return mu.Unlock
+}

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -112,7 +112,8 @@ func NoopUpdate() UpdateResult {
 }
 
 // UpdateFunc transforms the current value for a key into a mutation. The old
-// value is nil when the key is absent and is a safe copy when present.
+// value is nil when the key is absent and is a safe copy when present. The
+// callback may be retried if the key changes before the mutation commits.
 type UpdateFunc = db.UpdateFunc
 
 // DB is the public TreeDB handle (cached mode by default; read-only opens skip caching).
@@ -1420,12 +1421,11 @@ func (db *DB) SetSync(key, value []byte) error {
 // Update applies fn to the current value for key and writes the returned
 // mutation without forcing an fsync boundary.
 //
-// Concurrent Update calls for the same key on the same DB handle are serialized
-// around the read-modify-write sequence, so callbacks observe prior committed
-// Update results and do not lose each other's changes. Point Set/Delete calls on
-// the same handle participate in the same single-key serialization but remain
-// unconditional writes. The callback runs while the key update lock is held, so
-// it should avoid long-running work or recursive Update calls for the same key.
+// Concurrent Update calls for the same key on the same DB handle do not lose
+// each other's changes: if the key changes while fn is running, Update retries
+// with the newer value. Point Set/Delete calls on the same handle participate in
+// the same single-key commit serialization but remain unconditional writes.
+// Because fn may be retried, it should avoid externally visible side effects.
 func (db *DB) Update(key []byte, fn UpdateFunc) error {
 	if err := db.ensureOpen(); err != nil {
 		return err
@@ -1441,9 +1441,9 @@ func (db *DB) Update(key []byte, fn UpdateFunc) error {
 // DurabilityWALOffRelaxed enabled, Sync operations are crash-consistent only
 // (no fsync) and may not survive power loss.
 //
-// Concurrent UpdateSync/Update calls for the same key on the same DB handle are
-// serialized around the read-modify-write sequence. The callback runs while the
-// key update lock is held.
+// Concurrent UpdateSync/Update calls for the same key on the same DB handle do
+// not lose each other's changes. Because fn may be retried, it should avoid
+// externally visible side effects.
 func (db *DB) UpdateSync(key []byte, fn UpdateFunc) error {
 	if err := db.ensureOpen(); err != nil {
 		return err

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -81,6 +81,45 @@ type getManyPlanner interface {
 	GetManyParallelPlan(keyCount int) (workers int, parallel bool)
 }
 
+// UpdateOp describes the write produced by an Update callback.
+type UpdateOp uint8
+
+const (
+	// UpdateNoop leaves the key unchanged.
+	UpdateNoop UpdateOp = iota
+	// UpdateSet replaces the key with Value.
+	UpdateSet
+	// UpdateDelete removes the key.
+	UpdateDelete
+)
+
+// UpdateResult is returned by an Update callback.
+type UpdateResult struct {
+	Op    UpdateOp
+	Value []byte
+}
+
+// SetUpdate returns an Update result that replaces the key with value.
+func SetUpdate(value []byte) UpdateResult {
+	return UpdateResult{Op: UpdateSet, Value: value}
+}
+
+// DeleteUpdate returns an Update result that removes the key.
+func DeleteUpdate() UpdateResult {
+	return UpdateResult{Op: UpdateDelete}
+}
+
+// NoopUpdate returns an Update result that leaves the key unchanged.
+func NoopUpdate() UpdateResult {
+	return UpdateResult{Op: UpdateNoop}
+}
+
+// UpdateFunc transforms the current value for a key into a mutation. The old
+// value is nil when the key is absent and is a safe copy when present.
+type UpdateFunc func(old []byte) (UpdateResult, error)
+
+const updateLockStripes = 256
+
 // DB is the public TreeDB handle (cached mode by default; read-only opens skip caching).
 type DB struct {
 	cached         *caching.DB
@@ -94,6 +133,7 @@ type DB struct {
 	bgErr          error
 	durabilityMode string
 	dir            string
+	updateLocks    [updateLockStripes]sync.Mutex
 	maintenance    maintenanceCoordinator
 }
 
@@ -1381,6 +1421,88 @@ func (db *DB) SetSync(key, value []byte) error {
 		return db.cached.SetSync(key, value)
 	}
 	return db.backend.SetSync(key, value)
+}
+
+// Update applies fn to the current value for key and writes the returned
+// mutation without forcing an fsync boundary.
+//
+// Concurrent Update calls for the same key on the same DB handle are serialized
+// around the read-modify-write sequence, so callbacks observe prior committed
+// Update results and do not lose each other's changes. Direct Set/Delete calls
+// remain unconditional writes and are not coordinated with this logical update
+// contract. The callback runs while the key update lock is held, so it should
+// avoid long-running work or recursive Update calls for the same key.
+func (db *DB) Update(key []byte, fn UpdateFunc) error {
+	return db.update(key, fn, false)
+}
+
+// UpdateSync applies fn to the current value for key and writes the returned
+// mutation with a sync durability boundary. With DurabilityWALOnRelaxed or
+// DurabilityWALOffRelaxed enabled, Sync operations are crash-consistent only
+// (no fsync) and may not survive power loss.
+//
+// Concurrent UpdateSync/Update calls for the same key on the same DB handle are
+// serialized around the read-modify-write sequence. The callback runs while the
+// key update lock is held.
+func (db *DB) UpdateSync(key []byte, fn UpdateFunc) error {
+	return db.update(key, fn, true)
+}
+
+func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
+	if err := db.ensureOpen(); err != nil {
+		return err
+	}
+	if len(key) == 0 {
+		return caching.ErrKeyEmpty
+	}
+	if fn == nil {
+		return errors.New("treedb: nil update function")
+	}
+
+	lock := db.updateLock(key)
+	lock.Lock()
+	defer lock.Unlock()
+
+	old, err := db.Get(key)
+	if err != nil {
+		return err
+	}
+	result, err := fn(old)
+	if err != nil {
+		return err
+	}
+	switch result.Op {
+	case UpdateNoop:
+		return nil
+	case UpdateSet:
+		if result.Value == nil {
+			return caching.ErrValueNil
+		}
+		if syncWrite {
+			return db.SetSync(key, result.Value)
+		}
+		return db.Set(key, result.Value)
+	case UpdateDelete:
+		if syncWrite {
+			return db.DeleteSync(key)
+		}
+		return db.Delete(key)
+	default:
+		return fmt.Errorf("treedb: unknown update op %d", result.Op)
+	}
+}
+
+func (db *DB) updateLock(key []byte) *sync.Mutex {
+	return &db.updateLocks[updateLockIndex(key)]
+}
+
+func updateLockIndex(key []byte) uint32 {
+	h := uint32(2166136261)
+	for _, b := range key {
+		h ^= uint32(b)
+		h *= 16777619
+	}
+	return h & (updateLockStripes - 1)
 }
 
 // Delete removes a key without forcing an fsync boundary.

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -82,43 +82,38 @@ type getManyPlanner interface {
 }
 
 // UpdateOp describes the write produced by an Update callback.
-type UpdateOp uint8
+type UpdateOp = db.UpdateOp
 
 const (
 	// UpdateNoop leaves the key unchanged.
-	UpdateNoop UpdateOp = iota
+	UpdateNoop = db.UpdateNoop
 	// UpdateSet replaces the key with Value.
-	UpdateSet
+	UpdateSet = db.UpdateSet
 	// UpdateDelete removes the key.
-	UpdateDelete
+	UpdateDelete = db.UpdateDelete
 )
 
 // UpdateResult is returned by an Update callback.
-type UpdateResult struct {
-	Op    UpdateOp
-	Value []byte
-}
+type UpdateResult = db.UpdateResult
 
 // SetUpdate returns an Update result that replaces the key with value.
 func SetUpdate(value []byte) UpdateResult {
-	return UpdateResult{Op: UpdateSet, Value: value}
+	return db.SetUpdate(value)
 }
 
 // DeleteUpdate returns an Update result that removes the key.
 func DeleteUpdate() UpdateResult {
-	return UpdateResult{Op: UpdateDelete}
+	return db.DeleteUpdate()
 }
 
 // NoopUpdate returns an Update result that leaves the key unchanged.
 func NoopUpdate() UpdateResult {
-	return UpdateResult{Op: UpdateNoop}
+	return db.NoopUpdate()
 }
 
 // UpdateFunc transforms the current value for a key into a mutation. The old
 // value is nil when the key is absent and is a safe copy when present.
-type UpdateFunc func(old []byte) (UpdateResult, error)
-
-const updateLockStripes = 256
+type UpdateFunc = db.UpdateFunc
 
 // DB is the public TreeDB handle (cached mode by default; read-only opens skip caching).
 type DB struct {
@@ -133,7 +128,6 @@ type DB struct {
 	bgErr          error
 	durabilityMode string
 	dir            string
-	updateLocks    [updateLockStripes]sync.Mutex
 	maintenance    maintenanceCoordinator
 }
 
@@ -1428,12 +1422,18 @@ func (db *DB) SetSync(key, value []byte) error {
 //
 // Concurrent Update calls for the same key on the same DB handle are serialized
 // around the read-modify-write sequence, so callbacks observe prior committed
-// Update results and do not lose each other's changes. Direct Set/Delete calls
-// remain unconditional writes and are not coordinated with this logical update
-// contract. The callback runs while the key update lock is held, so it should
-// avoid long-running work or recursive Update calls for the same key.
+// Update results and do not lose each other's changes. Point Set/Delete calls on
+// the same handle participate in the same single-key serialization but remain
+// unconditional writes. The callback runs while the key update lock is held, so
+// it should avoid long-running work or recursive Update calls for the same key.
 func (db *DB) Update(key []byte, fn UpdateFunc) error {
-	return db.update(key, fn, false)
+	if err := db.ensureOpen(); err != nil {
+		return err
+	}
+	if db.cached != nil {
+		return db.cached.Update(key, fn)
+	}
+	return db.backend.Update(key, fn)
 }
 
 // UpdateSync applies fn to the current value for key and writes the returned
@@ -1445,64 +1445,13 @@ func (db *DB) Update(key []byte, fn UpdateFunc) error {
 // serialized around the read-modify-write sequence. The callback runs while the
 // key update lock is held.
 func (db *DB) UpdateSync(key []byte, fn UpdateFunc) error {
-	return db.update(key, fn, true)
-}
-
-func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
 	if err := db.ensureOpen(); err != nil {
 		return err
 	}
-	if len(key) == 0 {
-		return caching.ErrKeyEmpty
+	if db.cached != nil {
+		return db.cached.UpdateSync(key, fn)
 	}
-	if fn == nil {
-		return errors.New("treedb: nil update function")
-	}
-
-	lock := db.updateLock(key)
-	lock.Lock()
-	defer lock.Unlock()
-
-	old, err := db.Get(key)
-	if err != nil {
-		return err
-	}
-	result, err := fn(old)
-	if err != nil {
-		return err
-	}
-	switch result.Op {
-	case UpdateNoop:
-		return nil
-	case UpdateSet:
-		if result.Value == nil {
-			return caching.ErrValueNil
-		}
-		if syncWrite {
-			return db.SetSync(key, result.Value)
-		}
-		return db.Set(key, result.Value)
-	case UpdateDelete:
-		if syncWrite {
-			return db.DeleteSync(key)
-		}
-		return db.Delete(key)
-	default:
-		return fmt.Errorf("treedb: unknown update op %d", result.Op)
-	}
-}
-
-func (db *DB) updateLock(key []byte) *sync.Mutex {
-	return &db.updateLocks[updateLockIndex(key)]
-}
-
-func updateLockIndex(key []byte) uint32 {
-	h := uint32(2166136261)
-	for _, b := range key {
-		h ^= uint32(b)
-		h *= 16777619
-	}
-	return h & (updateLockStripes - 1)
+	return db.backend.UpdateSync(key, fn)
 }
 
 // Delete removes a key without forcing an fsync boundary.

--- a/TreeDB/update_test.go
+++ b/TreeDB/update_test.go
@@ -150,6 +150,38 @@ func TestUpdateSetDeleteNoop(t *testing.T) {
 	}
 }
 
+func TestUpdatePreservesEmptyValuePresence(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileFast, t.TempDir())
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	key := []byte("empty")
+	if err := db.Set(key, []byte{}); err != nil {
+		t.Fatalf("Set empty: %v", err)
+	}
+	if err := db.Update(key, func(old []byte) (treedb.UpdateResult, error) {
+		if old == nil {
+			t.Fatalf("old = nil, want non-nil empty slice for present empty value")
+		}
+		if len(old) != 0 {
+			t.Fatalf("old len=%d, want 0", len(old))
+		}
+		return treedb.SetUpdate([]byte("present-empty")), nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, []byte("present-empty")) {
+		t.Fatalf("value got=%q want present-empty", got)
+	}
+}
+
 func TestUpdateSyncPointerValuePersistsAfterCheckpointReopen(t *testing.T) {
 	dir := t.TempDir()
 	opts := treedb.OptionsFor(treedb.ProfileFast, dir)

--- a/TreeDB/update_test.go
+++ b/TreeDB/update_test.go
@@ -1,0 +1,194 @@
+package treedb_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+func TestUpdateConcurrentSetMembershipNoLostUpdates(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileFast, t.TempDir())
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	const workers = 64
+	key := []byte("members")
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			member := fmt.Sprintf("member-%02d", i)
+			errs <- db.Update(key, func(old []byte) (treedb.UpdateResult, error) {
+				members := make(map[string]struct{}, workers)
+				if old != nil {
+					var existing []string
+					if err := json.Unmarshal(old, &existing); err != nil {
+						return treedb.UpdateResult{}, err
+					}
+					for _, name := range existing {
+						members[name] = struct{}{}
+					}
+				}
+				members[member] = struct{}{}
+
+				next := make([]string, 0, len(members))
+				for name := range members {
+					next = append(next, name)
+				}
+				sort.Strings(next)
+				encoded, err := json.Marshal(next)
+				if err != nil {
+					return treedb.UpdateResult{}, err
+				}
+				return treedb.SetUpdate(encoded), nil
+			})
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+	}
+
+	raw, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	var got []string
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal members: %v", err)
+	}
+	if len(got) != workers {
+		t.Fatalf("member count mismatch got=%d want=%d members=%v", len(got), workers, got)
+	}
+	for i, member := range got {
+		want := fmt.Sprintf("member-%02d", i)
+		if member != want {
+			t.Fatalf("member[%d] = %q, want %q", i, member, want)
+		}
+	}
+}
+
+func TestUpdateSetDeleteNoop(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileFast, t.TempDir())
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	key := []byte("key")
+	if err := db.Set(key, []byte("seed")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if err := db.Update(key, func(old []byte) (treedb.UpdateResult, error) {
+		if !bytes.Equal(old, []byte("seed")) {
+			t.Fatalf("noop old = %q, want seed", old)
+		}
+		old[0] = 'X'
+		return treedb.NoopUpdate(), nil
+	}); err != nil {
+		t.Fatalf("noop Update: %v", err)
+	}
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("Get after noop: %v", err)
+	}
+	if !bytes.Equal(got, []byte("seed")) {
+		t.Fatalf("noop changed value got=%q want seed", got)
+	}
+
+	if err := db.Update(key, func(old []byte) (treedb.UpdateResult, error) {
+		if !bytes.Equal(old, []byte("seed")) {
+			t.Fatalf("delete old = %q, want seed", old)
+		}
+		return treedb.DeleteUpdate(), nil
+	}); err != nil {
+		t.Fatalf("delete Update: %v", err)
+	}
+	got, err = db.Get(key)
+	if err != nil {
+		t.Fatalf("Get after delete: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("delete left value %q", got)
+	}
+
+	if err := db.Update(key, func(old []byte) (treedb.UpdateResult, error) {
+		if old != nil {
+			t.Fatalf("set old = %q, want nil", old)
+		}
+		return treedb.SetUpdate([]byte("restored")), nil
+	}); err != nil {
+		t.Fatalf("set Update: %v", err)
+	}
+	got, err = db.Get(key)
+	if err != nil {
+		t.Fatalf("Get after set: %v", err)
+	}
+	if !bytes.Equal(got, []byte("restored")) {
+		t.Fatalf("set value got=%q want restored", got)
+	}
+}
+
+func TestUpdateSyncPointerValuePersistsAfterCheckpointReopen(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileFast, dir)
+	opts.ValueLog.ForcePointers = true
+	opts.ValueLog.PointerThreshold = 1
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	key := []byte("large")
+	value := bytes.Repeat([]byte("value-log-update-"), 256)
+	if err := db.UpdateSync(key, func(old []byte) (treedb.UpdateResult, error) {
+		if old != nil {
+			t.Fatalf("initial old = %q, want nil", old)
+		}
+		return treedb.SetUpdate(value), nil
+	}); err != nil {
+		t.Fatalf("UpdateSync: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db, err = treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer db.Close()
+
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("Get after reopen: %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Fatalf("reopen value mismatch got_len=%d want_len=%d", len(got), len(value))
+	}
+}

--- a/TreeDB/update_test.go
+++ b/TreeDB/update_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"time"
 
 	treedb "github.com/snissn/gomap/TreeDB"
 )
@@ -179,6 +180,64 @@ func TestUpdatePreservesEmptyValuePresence(t *testing.T) {
 	}
 	if !bytes.Equal(got, []byte("present-empty")) {
 		t.Fatalf("value got=%q want present-empty", got)
+	}
+}
+
+func TestUpdateCallbackCanReenterSameKeyWithoutDeadlock(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileFast, t.TempDir())
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	key := []byte("reentrant")
+	if err := db.Set(key, []byte("seed")); err != nil {
+		t.Fatalf("Set seed: %v", err)
+	}
+
+	done := make(chan error, 1)
+	calls := 0
+	go func() {
+		done <- db.Update(key, func(old []byte) (treedb.UpdateResult, error) {
+			calls++
+			switch string(old) {
+			case "seed":
+				if err := db.Update(key, func(innerOld []byte) (treedb.UpdateResult, error) {
+					if !bytes.Equal(innerOld, []byte("seed")) {
+						return treedb.UpdateResult{}, fmt.Errorf("inner old = %q, want seed", innerOld)
+					}
+					return treedb.SetUpdate([]byte("inner")), nil
+				}); err != nil {
+					return treedb.UpdateResult{}, err
+				}
+				return treedb.NoopUpdate(), nil
+			case "inner":
+				return treedb.SetUpdate([]byte("outer")), nil
+			default:
+				return treedb.UpdateResult{}, fmt.Errorf("outer old = %q, want seed or inner", old)
+			}
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Update deadlocked during reentrant same-key callback")
+	}
+
+	if calls != 2 {
+		t.Fatalf("outer callback calls=%d want 2", calls)
+	}
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, []byte("outer")) {
+		t.Fatalf("value got=%q want outer", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a single-key `Update` / `UpdateSync` read-modify-write primitive at the backend and cached DB layers
- expose the same primitive from the public `treedb.DB` wrapper by delegation/type aliases
- coordinate same-key `Update` callbacks and point `Set` / `Delete` calls through a shared lower-layer key-update lock set
- use the existing `xxhash` key hash path for lock striping instead of an ad hoc public-wrapper hash
- document the single-key contract and explicitly leave batch writes / multi-key atomicity outside this PR

Closes #939.

## Notes

This is intentionally still a single-key primitive, not a multi-key transaction system. Point `Set` / `Delete` calls on the same handle participate in the same single-key coordinator, but batch writes remain outside this contract.

## Validation

- `go test ./TreeDB ./TreeDB/db -run 'TestUpdate|TestClosedDB_Update' -count=1`
- `go test ./TreeDB ./TreeDB/db -count=1`
- `go test -race ./TreeDB -run TestUpdateConcurrentSetMembershipNoLostUpdates -count=1`
- `git diff --check`
