### PR TITLE
feat: finalize native collection fast path (Refs #768)

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -5850,6 +5850,10 @@ type BackendDB interface {
 	Stats() map[string]string
 }
 
+type backendCloseHookRunner interface {
+	RunCloseHooks() error
+}
+
 type backendValueLogRewriter interface {
 	ValueLogRewriteOnline(ctx context.Context, opts backenddb.ValueLogRewriteOnlineOptions) (backenddb.ValueLogRewriteStats, error)
 }
@@ -19131,6 +19135,11 @@ func (db *DB) flushSomeBlocking(sync bool, maxMemtables int, maxDuration time.Du
 
 func (db *DB) Close() error {
 	var errs []error
+	if runner, ok := db.backend.(backendCloseHookRunner); ok {
+		if err := runner.RunCloseHooks(); err != nil {
+			errs = append(errs, err)
+		}
+	}
 	hadMemtables := false
 	db.closing.Store(true)
 	db.clearBackendValueLogReadBarrier()

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -68,6 +68,12 @@ type collectionCatalog struct {
 	roots map[string]uint64
 }
 
+type createIndexBackfillPlan struct {
+	rootNames   []string
+	baseRootIDs map[string]uint64
+	tables      []memtable.Table
+}
+
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
 	return &CollectionManager{db: database}
 }
@@ -174,6 +180,85 @@ func (c *Collection) Meta() CollectionMeta {
 		return CollectionMeta{}
 	}
 	return *c.meta.copy()
+}
+
+func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return nil, errCollectionNotFound
+	}
+
+	baseMeta := catalog.meta
+	c.meta = baseMeta
+	newMeta, normalizedDef, err := addIndexToCollectionMeta(baseMeta, def)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	newRuntime, err := singleIndexRuntime(normalizedDef)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	existingRuntimes, err := (insertBatchPlanner{
+		collection: baseMeta.Name,
+		indexes:    plannerIndexes(baseMeta.Indexes),
+	}).indexRuntimes()
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	plan, err := buildCreateIndexBackfillPlan(snap, catalog, newRuntime, existingRuntimes, collectionOptions{
+		allowArrayValuesInIndex: baseMeta.Options.AllowArrayValuesInIndex,
+	})
+	_ = snap.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(plan.rootNames))
+	defer func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+	}()
+	for i, rootName := range plan.rootNames {
+		iter := plan.tables[i].NewIterator(nil, nil)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot: plan.baseRootIDs[rootName],
+			Iter:     iter,
+		})
+	}
+
+	_, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildSchemaAndRootDescriptorSystemIterator(baseMeta, newMeta, plan.rootNames, plan.baseRootIDs, rootIDs)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(rootIDs) != len(plan.rootNames) {
+		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	c.meta = newMeta
+	return newMeta.copy(), nil
 }
 
 func (c *Collection) Insert(id, document []byte) ([]byte, error) {
@@ -406,6 +491,142 @@ func buildDeleteRootDeltaTable(deleteKeys [][]byte) memtable.Table {
 	return table
 }
 
+func buildCreateIndexBackfillPlan(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	newRuntime indexRuntime,
+	existingRuntimes []indexRuntime,
+	opts collectionOptions,
+) (*createIndexBackfillPlan, error) {
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
+	primaryRootID := catalog.rootID(primaryRootName)
+	plan := &createIndexBackfillPlan{
+		baseRootIDs: make(map[string]uint64, 2),
+	}
+	if primaryRootID == 0 {
+		return plan, nil
+	}
+
+	it, err := snap.IteratorAtRoot(primaryRootID, nil, nil)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return plan, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = it.Close() }()
+
+	indexStateTable := newCollectionRunTable(0)
+	secondaryTable := newCollectionRunTable(0)
+	uniqueProbes := make([]uniqueProbeCandidate, 0)
+	stateRootName := collectionIndexStateRootName(catalog.meta.Name)
+	stateRootID := catalog.rootID(stateRootName)
+	secondaryRootName := collectionSecondaryRootName(catalog.meta.Name, newRuntime.def.name)
+	documentCount := 0
+	secondaryCount := 0
+	for it.Valid() {
+		if it.IsDeleted() {
+			it.Next()
+			continue
+		}
+		documentID := bytes.Clone(it.UnsafeKey())
+		document := it.ValueCopy(nil)
+		if err := it.Error(); err != nil {
+			return nil, err
+		}
+
+		newState, err := indexStateForDocument(document, []indexRuntime{newRuntime}, opts)
+		if err != nil {
+			return nil, err
+		}
+		existingState, err := loadBackfillIndexState(snap, stateRootID, documentID, document, existingRuntimes, opts)
+		if err != nil {
+			return nil, err
+		}
+		merged := cloneDocumentIndexState(existingState)
+		values := newState[newRuntime.def.name]
+		if len(values) > 0 {
+			merged[newRuntime.def.name] = values
+		} else {
+			delete(merged, newRuntime.def.name)
+		}
+		rawState, err := encodeDocumentIndexState(merged)
+		if err != nil {
+			return nil, err
+		}
+		indexStateTable.SetSteal(bytes.Clone(documentID), rawState)
+		documentCount++
+
+		for _, encoded := range values {
+			key, err := indexEntryKey(encoded, documentID)
+			if err != nil {
+				return nil, err
+			}
+			secondaryTable.SetSteal(key, nil)
+			secondaryCount++
+			if !newRuntime.def.unique {
+				continue
+			}
+			prefix, err := indexValuePrefix(encoded)
+			if err != nil {
+				return nil, err
+			}
+			uniqueProbes = append(uniqueProbes, uniqueProbeCandidate{
+				indexName:  newRuntime.def.name,
+				prefix:     prefix,
+				documentID: bytes.Clone(documentID),
+			})
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	if _, err := buildUniqueProbeRuns(uniqueProbes); err != nil {
+		return nil, err
+	}
+	if documentCount > 0 {
+		indexStateTable.Freeze()
+		plan.rootNames = append(plan.rootNames, stateRootName)
+		plan.baseRootIDs[stateRootName] = stateRootID
+		plan.tables = append(plan.tables, indexStateTable)
+	}
+	if secondaryCount > 0 {
+		secondaryTable.Freeze()
+		plan.rootNames = append(plan.rootNames, secondaryRootName)
+		plan.baseRootIDs[secondaryRootName] = catalog.rootID(secondaryRootName)
+		plan.tables = append(plan.tables, secondaryTable)
+	}
+	return plan, nil
+}
+
+func loadBackfillIndexState(snap *backenddb.Snapshot, stateRootID uint64, documentID, document []byte, existingRuntimes []indexRuntime, opts collectionOptions) (documentIndexState, error) {
+	if stateRootID != 0 {
+		entry, err := snap.GetEntryAtRoot(stateRootID, documentID)
+		if err == nil {
+			return decodeDocumentIndexState(entry.Value)
+		}
+		if err != nil && !errors.Is(err, tree.ErrKeyNotFound) {
+			return nil, err
+		}
+	}
+	return indexStateForDocument(document, existingRuntimes, opts)
+}
+
+func cloneDocumentIndexState(state documentIndexState) documentIndexState {
+	out := make(documentIndexState, len(state))
+	for name, values := range state {
+		out[name] = normalizeEncodedIndexValues(values)
+	}
+	return out
+}
+
 func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 	if len(rootIDs) != len(rootNames) {
 		return nil, errors.New("collections: ordered root publish returned unexpected root count")
@@ -428,6 +649,53 @@ func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseR
 		}
 	}
 	updates := make(map[string][]byte, len(rootNames))
+	for i, rootName := range rootNames {
+		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
+	}
+	table, err := buildSystemTargetTable(current, updates)
+	if err != nil {
+		return nil, err
+	}
+	return table.NewIterator(nil, nil), nil
+}
+
+func (c *Collection) buildSchemaAndRootDescriptorSystemIterator(
+	baseMeta CollectionMeta,
+	newMeta CollectionMeta,
+	rootNames []string,
+	baseRootIDs map[string]uint64,
+	rootIDs []uint64,
+) (iterator.UnsafeIterator, error) {
+	if len(rootIDs) != len(rootNames) {
+		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	catalog, err := loadCollectionCatalog(current, baseMeta.Name)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	if !sameCollectionMeta(catalog.meta, baseMeta) {
+		return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", baseMeta.Name)
+	}
+	for _, rootName := range rootNames {
+		if got, want := catalog.rootID(rootName), baseRootIDs[rootName]; got != want {
+			return nil, fmt.Errorf("collections: concurrent root modification detected for %q", rootName)
+		}
+	}
+
+	encodedMeta, err := encodeCollectionMeta(newMeta)
+	if err != nil {
+		return nil, err
+	}
+	updates := make(map[string][]byte, 1+len(rootNames))
+	updates[systemCollectionMetaKey(baseMeta.Name)] = encodedMeta
 	for i, rootName := range rootNames {
 		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
 	}
@@ -711,6 +979,39 @@ func sameCollectionMeta(a, b CollectionMeta) bool {
 		return false
 	}
 	return reflect.DeepEqual(na, nb)
+}
+
+func addIndexToCollectionMeta(meta CollectionMeta, def IndexDefinition) (CollectionMeta, IndexDefinition, error) {
+	if _, ok := findIndex(meta.Indexes, def.Name); ok {
+		return CollectionMeta{}, IndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
+	}
+	candidate := CollectionMeta{
+		Name:    meta.Name,
+		Options: meta.Options,
+		Indexes: append(append([]IndexDefinition(nil), meta.Indexes...), def),
+	}
+	normalized, err := normalizeCollectionMeta(candidate)
+	if err != nil {
+		return CollectionMeta{}, IndexDefinition{}, err
+	}
+	normalizedDef, ok := findIndex(normalized.Indexes, def.Name)
+	if !ok {
+		return CollectionMeta{}, IndexDefinition{}, fmt.Errorf("collections: normalized index %q not found", def.Name)
+	}
+	return normalized, normalizedDef, nil
+}
+
+func singleIndexRuntime(def IndexDefinition) (indexRuntime, error) {
+	runtimes, err := (insertBatchPlanner{
+		indexes: plannerIndexes([]IndexDefinition{def}),
+	}).indexRuntimes()
+	if err != nil {
+		return indexRuntime{}, err
+	}
+	if len(runtimes) != 1 {
+		return indexRuntime{}, errors.New("collections: expected one index runtime")
+	}
+	return runtimes[0], nil
 }
 
 func plannerIndexes(indexes []IndexDefinition) []indexDefinition {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"unicode/utf8"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -32,24 +33,71 @@ const (
 	systemCollectionRootPrefix = "collections/root/"
 )
 
+func backendRootStoragePolicy(policy RootStoragePolicy) (backenddb.OrderedRootStoragePolicy, error) {
+	switch policy {
+	case RootStorageDefault:
+		return backenddb.OrderedRootStorageDefault, nil
+	case RootStorageFast:
+		return backenddb.OrderedRootStoragePagerLeaves, nil
+	case RootStorageCompressed:
+		return backenddb.OrderedRootStorageValueLogLeaves, nil
+	default:
+		return backenddb.OrderedRootStorageDefault, fmt.Errorf("collections: unsupported root storage policy %q", policy)
+	}
+}
+
+func collectionPlannerOptions(meta CollectionMeta) (collectionOptions, error) {
+	dataPolicy, err := backendRootStoragePolicy(meta.Options.DataRootStoragePolicy)
+	if err != nil {
+		return collectionOptions{}, err
+	}
+	indexStatePolicy, err := backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy)
+	if err != nil {
+		return collectionOptions{}, err
+	}
+	return collectionOptions{
+		allowArrayValuesInIndex: meta.Options.AllowArrayValuesInIndex,
+		dataStoragePolicy:       dataPolicy,
+		indexStateStoragePolicy: indexStatePolicy,
+	}, nil
+}
+
 type CollectionManager struct {
-	db *backenddb.DB
+	db              *backenddb.DB
+	closeUnregister func()
+	domainMu        sync.Mutex
+	domains         map[string]*collectionWriteDomain
 }
 
 type Collection struct {
-	db   *backenddb.DB
-	meta CollectionMeta
+	db                *backenddb.DB
+	writeDomain       *collectionWriteDomain
+	meta              CollectionMeta
+	catalogMu         sync.RWMutex
+	catalogSystemRoot uint64
+	catalog           *collectionCatalog
 }
 
+type RootStoragePolicy string
+
+const (
+	RootStorageDefault    RootStoragePolicy = ""
+	RootStorageFast       RootStoragePolicy = "fast"
+	RootStorageCompressed RootStoragePolicy = "compressed"
+)
+
 type CollectionOptions struct {
-	AllowArrayValuesInIndex bool `json:"allow_array_values_in_index,omitempty"`
+	AllowArrayValuesInIndex bool              `json:"allow_array_values_in_index,omitempty"`
+	DataRootStoragePolicy   RootStoragePolicy `json:"data_root_storage_policy,omitempty"`
+	IndexStateStoragePolicy RootStoragePolicy `json:"index_state_storage_policy,omitempty"`
 }
 
 type IndexDefinition struct {
-	Name     string `json:"name"`
-	Field    string `json:"field"`
-	Unique   bool   `json:"unique,omitempty"`
-	MultiKey bool   `json:"multi_key,omitempty"`
+	Name          string            `json:"name"`
+	Field         string            `json:"field"`
+	Unique        bool              `json:"unique,omitempty"`
+	MultiKey      bool              `json:"multi_key,omitempty"`
+	StoragePolicy RootStoragePolicy `json:"storage_policy,omitempty"`
 }
 
 type CollectionMeta struct {
@@ -74,10 +122,84 @@ type createIndexBackfillPlan struct {
 	rootNames   []string
 	baseRootIDs map[string]uint64
 	tables      []memtable.Table
+	policies    []backenddb.OrderedRootStoragePolicy
+}
+
+type noIndexBatchEntry struct {
+	id       []byte
+	document []byte
+}
+
+type collectionWriteDomain struct {
+	mu             sync.RWMutex
+	loaded         bool
+	meta           CollectionMeta
+	catalog        *collectionCatalog
+	baseSystemRoot uint64
+	primaryRoot    uint64
+	storagePolicy  backenddb.OrderedRootStoragePolicy
+	table          memtable.Table
+	count          int
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
-	return &CollectionManager{db: database}
+	manager := &CollectionManager{db: database}
+	if database != nil {
+		manager.closeUnregister = database.RegisterCloseHook(manager.FlushAll)
+	}
+	return manager
+}
+
+func (m *CollectionManager) writeDomainForCollection(name string) *collectionWriteDomain {
+	if m == nil {
+		return nil
+	}
+	m.domainMu.Lock()
+	defer m.domainMu.Unlock()
+	if m.domains == nil {
+		m.domains = make(map[string]*collectionWriteDomain)
+	}
+	if domain := m.domains[name]; domain != nil {
+		return domain
+	}
+	domain := &collectionWriteDomain{}
+	m.domains[name] = domain
+	return domain
+}
+
+// FlushAll publishes buffered writes for every collection opened through this
+// manager. The backend DB also calls this as a close hook while write APIs are
+// still available.
+func (m *CollectionManager) FlushAll() error {
+	if m == nil || m.db == nil {
+		return nil
+	}
+	m.domainMu.Lock()
+	domains := make([]*collectionWriteDomain, 0, len(m.domains))
+	for _, domain := range m.domains {
+		if domain != nil {
+			domains = append(domains, domain)
+		}
+	}
+	m.domainMu.Unlock()
+
+	var errs []error
+	for _, domain := range domains {
+		if err := flushCollectionWriteDomain(m.db, domain); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain) error {
+	if db == nil || domain == nil {
+		return nil
+	}
+	collection := &Collection{db: db, writeDomain: domain}
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	return collection.flushBufferedNoIndexLocked(domain)
 }
 
 func (m *CollectionManager) CreateCollection(meta *CollectionMeta) (*CollectionMeta, error) {
@@ -164,10 +286,13 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 	if catalog == nil {
 		return nil, errCollectionNotFound
 	}
-	return &Collection{
-		db:   m.db,
-		meta: catalog.meta,
-	}, nil
+	collection := &Collection{
+		db:          m.db,
+		writeDomain: m.writeDomainForCollection(catalog.meta.Name),
+		meta:        catalog.meta,
+	}
+	collection.rememberCatalog(snap, catalog)
+	return collection, nil
 }
 
 func (c *Collection) Name() string {
@@ -191,6 +316,9 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 	if c.db == nil {
 		return nil, errors.New("collections: db is nil")
 	}
+	if err := c.flushBufferedNoIndex(); err != nil {
+		return nil, err
+	}
 
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
@@ -208,6 +336,11 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 
 	baseMeta := catalog.meta
 	c.meta = baseMeta
+	baseOptions, err := collectionPlannerOptions(baseMeta)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
 	newMeta, normalizedDef, err := addIndexToCollectionMeta(baseMeta, def)
 	if err != nil {
 		_ = snap.Close()
@@ -226,9 +359,7 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 		_ = snap.Close()
 		return nil, err
 	}
-	plan, err := buildCreateIndexBackfillPlan(snap, catalog, newRuntime, existingRuntimes, collectionOptions{
-		allowArrayValuesInIndex: baseMeta.Options.AllowArrayValuesInIndex,
-	})
+	plan, err := buildCreateIndexBackfillPlan(snap, catalog, newRuntime, existingRuntimes, baseOptions)
 	_ = snap.Close()
 	if err != nil {
 		return nil, err
@@ -240,17 +371,19 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 		for _, it := range iterators {
 			_ = it.Close()
 		}
+		resetCollectionTables(plan.tables)
 	}()
 	for i, rootName := range plan.rootNames {
 		iter := plan.tables[i].NewIterator(nil, nil)
 		iterators = append(iterators, iter)
 		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot: plan.baseRootIDs[rootName],
-			Iter:     iter,
+			BaseRoot:      plan.baseRootIDs[rootName],
+			Iter:          iter,
+			StoragePolicy: plan.policies[i],
 		})
 	}
 
-	_, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildSchemaAndRootDescriptorSystemIterator(baseMeta, newMeta, plan.rootNames, plan.baseRootIDs, rootIDs)
 	})
 	if err != nil {
@@ -260,6 +393,9 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 		return nil, errors.New("collections: ordered root publish returned unexpected root count")
 	}
 	c.meta = newMeta
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, plan.rootNames, rootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	return newMeta.copy(), nil
 }
 
@@ -267,6 +403,276 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 	if c == nil {
 		return nil, errCollectionNil
 	}
+	if c.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
+	if len(c.meta.Indexes) == 0 {
+		return c.insertOneNoIndexBuffered(id, document)
+	}
+	ids, err := c.InsertBatch([][]byte{id}, [][]byte{document})
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) != 1 {
+		return nil, errors.New("collections: insert returned no document id")
+	}
+	return ids[0], nil
+}
+
+// Flush publishes buffered collection-local writes to the backend roots. Single
+// no-index inserts use this boundary to match TreeDB's cached write path while
+// still giving callers an explicit durability/visibility point.
+func (c *Collection) Flush() error {
+	if c == nil {
+		return errCollectionNil
+	}
+	if c.db == nil {
+		return errors.New("collections: db is nil")
+	}
+	return c.flushBufferedNoIndex()
+}
+
+func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, error) {
+	if len(id) == 0 {
+		return nil, errors.New("collections: document id cannot be empty")
+	}
+	domain := c.writeDomain
+	if domain == nil {
+		return c.insertOneNoIndex(id, document)
+	}
+
+	domain.mu.Lock()
+	catalog, plannerOptions, indexed, err := c.ensureWriteDomainLocked(domain)
+	if err != nil {
+		domain.mu.Unlock()
+		return nil, err
+	}
+	if indexed {
+		domain.mu.Unlock()
+		return c.insertOneViaBatch(id, document)
+	}
+	if catalog == nil {
+		domain.mu.Unlock()
+		return nil, errCollectionNotFound
+	}
+	c.meta = catalog.meta
+	if domain.table == nil {
+		domain.table = newCollectionRunTable(0)
+	}
+	if _, _, flags, found := domain.table.GetEntry(id); found && flags&node.FlagTombstone == 0 {
+		domain.mu.Unlock()
+		return nil, errors.New("collections: document already exists")
+	}
+	if domain.primaryRoot != 0 {
+		exists, err := c.persistedDocumentExists(domain.primaryRoot, id)
+		if err != nil {
+			domain.mu.Unlock()
+			return nil, err
+		}
+		if exists {
+			domain.mu.Unlock()
+			return nil, errors.New("collections: document already exists")
+		}
+	}
+	domain.storagePolicy = plannerOptions.dataStoragePolicy
+	domain.table.SetEntry(id, document, page.ValuePtr{}, node.FlagInline)
+	domain.count++
+	resultID := bytes.Clone(id)
+	domain.mu.Unlock()
+	return resultID, nil
+}
+
+func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*collectionCatalog, collectionOptions, bool, error) {
+	if domain == nil {
+		return nil, collectionOptions{}, false, errors.New("collections: missing write domain")
+	}
+	if domain.loaded && domain.count > 0 {
+		options, err := collectionPlannerOptions(domain.meta)
+		if err != nil {
+			return nil, collectionOptions{}, false, err
+		}
+		return domain.catalog, options, len(domain.meta.Indexes) > 0, nil
+	}
+	currentSystemRoot := uint64(0)
+	if state := c.db.State(); state != nil {
+		currentSystemRoot = state.SystemRootPageID
+	}
+	if domain.loaded && domain.count == 0 && domain.baseSystemRoot == currentSystemRoot {
+		options, err := collectionPlannerOptions(domain.meta)
+		if err != nil {
+			return nil, collectionOptions{}, false, err
+		}
+		return domain.catalog, options, len(domain.meta.Indexes) > 0, nil
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, collectionOptions{}, false, backenddb.ErrClosed
+	}
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		_ = snap.Close()
+		return nil, collectionOptions{}, false, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return nil, collectionOptions{}, false, errCollectionNotFound
+	}
+	baseSystemRoot := snapshotSystemRoot(snap)
+	_ = snap.Close()
+
+	options, err := collectionPlannerOptions(catalog.meta)
+	if err != nil {
+		return nil, collectionOptions{}, false, err
+	}
+	rootName := collectionPrimaryRootName(catalog.meta.Name)
+	domain.loaded = true
+	domain.meta = catalog.meta
+	domain.catalog = catalog
+	domain.baseSystemRoot = baseSystemRoot
+	domain.primaryRoot = catalog.rootID(rootName)
+	domain.storagePolicy = options.dataStoragePolicy
+	return catalog, options, len(catalog.meta.Indexes) > 0, nil
+}
+
+func (c *Collection) persistedDocumentExists(rootID uint64, id []byte) (bool, error) {
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return false, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	if _, err := snap.GetEntryAtRoot(rootID, id); err == nil {
+		return true, nil
+	} else if !errors.Is(err, tree.ErrKeyNotFound) {
+		return false, err
+	}
+	return false, nil
+}
+
+func (c *Collection) flushBufferedNoIndex() error {
+	domain := c.writeDomain
+	if domain == nil {
+		return nil
+	}
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	return c.flushBufferedNoIndexLocked(domain)
+}
+
+func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) error {
+	if domain == nil || domain.count == 0 || domain.table == nil {
+		return nil
+	}
+	if domain.catalog == nil {
+		return errCollectionNotFound
+	}
+	meta := domain.meta
+	if len(meta.Indexes) > 0 {
+		return errors.New("collections: buffered no-index writes cannot be flushed into indexed schema")
+	}
+	c.meta = meta
+	rootName := collectionPrimaryRootName(meta.Name)
+	baseRoot := domain.primaryRoot
+	baseSystemRoot := domain.baseSystemRoot
+	baseRootIDs := map[string]uint64{rootName: baseRoot}
+	table := domain.table
+	iter := table.NewIterator(nil, nil)
+
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]backenddb.OrderedRootDeltaPublishInput{{
+		BaseRoot:      baseRoot,
+		Iter:          iter,
+		StoragePolicy: domain.storagePolicy,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+	})
+	_ = iter.Close()
+	if err != nil {
+		return err
+	}
+	if len(rootIDs) != 1 {
+		return errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	catalog := cloneCatalogWithRootUpdates(domain.catalog, meta, []string{rootName}, rootIDs)
+	domain.loaded = true
+	domain.meta = meta
+	domain.catalog = catalog
+	domain.baseSystemRoot = newSystemRoot
+	domain.primaryRoot = rootIDs[0]
+	domain.table = newCollectionRunTable(0)
+	domain.count = 0
+	c.meta = meta
+	c.rememberCatalogAtSystemRoot(newSystemRoot, catalog)
+	resetCollectionRunTable(table)
+	return nil
+}
+
+func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
+	if len(id) == 0 {
+		return nil, errors.New("collections: document id cannot be empty")
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return nil, errCollectionNotFound
+	}
+	c.meta = catalog.meta
+	if len(c.meta.Indexes) > 0 {
+		_ = snap.Close()
+		return c.insertOneViaBatch(id, document)
+	}
+	plannerOptions, err := collectionPlannerOptions(c.meta)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	baseSystemRoot := snapshotSystemRoot(snap)
+
+	rootName := collectionPrimaryRootName(c.meta.Name)
+	baseRoot := catalog.rootID(rootName)
+	if baseRoot != 0 {
+		if _, err := snap.GetEntryAtRoot(baseRoot, id); err == nil {
+			_ = snap.Close()
+			return nil, errors.New("collections: document already exists")
+		} else if !errors.Is(err, tree.ErrKeyNotFound) {
+			_ = snap.Close()
+			return nil, err
+		}
+	}
+	_ = snap.Close()
+
+	resultID := bytes.Clone(id)
+	iter := &systemTargetIterator{entries: []systemTargetEntry{{
+		key:   resultID,
+		value: bytes.Clone(document),
+	}}}
+	defer func() { _ = iter.Close() }()
+
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]backenddb.OrderedRootDeltaPublishInput{{
+		BaseRoot:      baseRoot,
+		Iter:          iter,
+		StoragePolicy: plannerOptions.dataStoragePolicy,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, []string{rootName}, map[string]uint64{rootName: baseRoot}, rootIDs)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(rootIDs) != 1 {
+		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	c.rememberCatalogAtSystemRoot(newSystemRoot, cloneCatalogWithRootUpdates(catalog, c.meta, []string{rootName}, rootIDs))
+	return resultID, nil
+}
+
+func (c *Collection) insertOneViaBatch(id, document []byte) ([]byte, error) {
 	ids, err := c.InsertBatch([][]byte{id}, [][]byte{document})
 	if err != nil {
 		return nil, err
@@ -287,12 +693,15 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	if len(documents) == 0 {
 		return nil, nil
 	}
+	if err := c.flushBufferedNoIndex(); err != nil {
+		return nil, err
+	}
 
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
 		return nil, backenddb.ErrClosed
 	}
-	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	catalog, err := c.catalogForSnapshot(snap)
 	if err != nil {
 		_ = snap.Close()
 		return nil, err
@@ -302,15 +711,23 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 		return nil, errCollectionNotFound
 	}
 	c.meta = catalog.meta
+	plannerOptions, err := collectionPlannerOptions(c.meta)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	baseSystemRoot := snapshotSystemRoot(snap)
+
+	if len(c.meta.Indexes) == 0 {
+		return c.insertBatchNoIndex(catalog, snap, baseSystemRoot, plannerOptions, ids, documents)
+	}
 
 	planner := insertBatchPlanner{
 		collection:     c.meta.Name,
 		primaryRoot:    collectionPrimaryRootName(c.meta.Name),
 		indexStateRoot: collectionIndexStateRootName(c.meta.Name),
 		indexes:        plannerIndexes(c.meta.Indexes),
-		options: collectionOptions{
-			allowArrayValuesInIndex: c.meta.Options.AllowArrayValuesInIndex,
-		},
+		options:        plannerOptions,
 	}
 	plan, err := planner.planInsertBatchWithPreflight(ids, documents, insertBatchPreflight{
 		snapshot:           snap,
@@ -338,13 +755,15 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 		for _, it := range iterators {
 			_ = it.Close()
 		}
+		resetCollectionRunTables(plan.runs)
 	}()
 	for _, run := range plan.runs {
 		iter := run.table.NewIterator(nil, nil)
 		iterators = append(iterators, iter)
 		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot: baseRootIDs[run.name],
-			Iter:     iter,
+			BaseRoot:      baseRootIDs[run.name],
+			Iter:          iter,
+			StoragePolicy: run.storagePolicy,
 		})
 	}
 
@@ -352,8 +771,8 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	for i, run := range plan.runs {
 		rootNames[i] = run.name
 	}
-	_, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemIterator(rootNames, baseRootIDs, rootIDs)
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
 	if err != nil {
 		return nil, err
@@ -361,7 +780,96 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	if len(rootIDs) != len(plan.runs) {
 		return nil, errors.New("collections: ordered root publish returned unexpected root count")
 	}
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	return plan.resultIDs, nil
+}
+
+func (c *Collection) insertBatchNoIndex(
+	catalog *collectionCatalog,
+	snap *backenddb.Snapshot,
+	baseSystemRoot uint64,
+	plannerOptions collectionOptions,
+	ids, documents [][]byte,
+) ([][]byte, error) {
+	if len(ids) != len(documents) {
+		_ = snap.Close()
+		return nil, fmt.Errorf("collections: caller-provided batch ids length mismatch")
+	}
+
+	entries := make([]noIndexBatchEntry, len(documents))
+	resultIDs := make([][]byte, len(documents))
+	for i := range documents {
+		if len(ids[i]) == 0 {
+			_ = snap.Close()
+			return nil, errors.New("collections: document id cannot be empty")
+		}
+		id := bytes.Clone(ids[i])
+		entries[i] = noIndexBatchEntry{
+			id:       id,
+			document: documents[i],
+		}
+		resultIDs[i] = id
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return bytes.Compare(entries[i].id, entries[j].id) < 0
+	})
+	for i := 1; i < len(entries); i++ {
+		if bytes.Equal(entries[i-1].id, entries[i].id) {
+			_ = snap.Close()
+			return nil, errors.New("collections: duplicate document id in batch")
+		}
+	}
+
+	rootName := collectionPrimaryRootName(c.meta.Name)
+	baseRoot := catalog.rootID(rootName)
+	if baseRoot != 0 {
+		keys := make([][]byte, len(entries))
+		for i := range entries {
+			keys[i] = entries[i].id
+		}
+		exists, err := snap.HasAnySortedAtRoot(baseRoot, keys)
+		if err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		if exists {
+			_ = snap.Close()
+			return nil, errors.New("collections: document already exists")
+		}
+	}
+	_ = snap.Close()
+
+	table := newCollectionRunTable(len(entries))
+	for i := range entries {
+		setCollectionRunValue(table, entries[i].id, entries[i].document)
+	}
+	table.Freeze()
+	iter := table.NewIterator(nil, nil)
+	defer func() {
+		_ = iter.Close()
+		resetCollectionRunTable(table)
+	}()
+
+	baseRootIDs := map[string]uint64{rootName: baseRoot}
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]backenddb.OrderedRootDeltaPublishInput{{
+		BaseRoot:      baseRoot,
+		Iter:          iter,
+		StoragePolicy: plannerOptions.dataStoragePolicy,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(rootIDs) != 1 {
+		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, []string{rootName}, rootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return resultIDs, nil
 }
 
 func (c *Collection) Delete(documentID []byte) error {
@@ -374,12 +882,15 @@ func (c *Collection) Delete(documentID []byte) error {
 	if len(documentID) == 0 {
 		return errors.New("collections: document id cannot be empty")
 	}
+	if err := c.flushBufferedNoIndex(); err != nil {
+		return err
+	}
 
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
 		return backenddb.ErrClosed
 	}
-	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	catalog, err := c.catalogForSnapshot(snap)
 	if err != nil {
 		_ = snap.Close()
 		return err
@@ -389,6 +900,12 @@ func (c *Collection) Delete(documentID []byte) error {
 		return errCollectionNotFound
 	}
 	c.meta = catalog.meta
+	plannerOptions, err := collectionPlannerOptions(c.meta)
+	if err != nil {
+		_ = snap.Close()
+		return err
+	}
+	baseSystemRoot := snapshotSystemRoot(snap)
 
 	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
 	if primaryRoot == 0 {
@@ -415,9 +932,7 @@ func (c *Collection) Delete(documentID []byte) error {
 	}
 	var state documentIndexState
 	if len(runtimes) > 0 {
-		state, err = loadDeleteIndexState(snap, catalog, documentID, entry.Value, runtimes, collectionOptions{
-			allowArrayValuesInIndex: c.meta.Options.AllowArrayValuesInIndex,
-		})
+		state, err = loadDeleteIndexState(snap, catalog, documentID, entry.Value, runtimes, plannerOptions)
 		if err != nil {
 			_ = snap.Close()
 			return err
@@ -428,6 +943,7 @@ func (c *Collection) Delete(documentID []byte) error {
 	baseRootIDs := map[string]uint64{
 		rootNames[0]: primaryRoot,
 	}
+	policies := []backenddb.OrderedRootStoragePolicy{plannerOptions.dataStoragePolicy}
 	deltaTables := make([]memtable.Table, 0, 2+len(runtimes))
 	deltaTables = append(deltaTables, buildDeleteRootDeltaTable([][]byte{documentID}))
 
@@ -437,6 +953,7 @@ func (c *Collection) Delete(documentID []byte) error {
 		if stateRootID != 0 {
 			rootNames = append(rootNames, stateRootName)
 			baseRootIDs[stateRootName] = stateRootID
+			policies = append(policies, plannerOptions.indexStateStoragePolicy)
 			deltaTables = append(deltaTables, buildDeleteRootDeltaTable([][]byte{documentID}))
 		}
 		for _, runtime := range runtimes {
@@ -452,6 +969,7 @@ func (c *Collection) Delete(documentID []byte) error {
 			}
 			rootNames = append(rootNames, rootName)
 			baseRootIDs[rootName] = rootID
+			policies = append(policies, runtime.def.storagePolicy)
 			deltaTables = append(deltaTables, buildDeleteRootDeltaTable(deleteKeys))
 		}
 	}
@@ -463,17 +981,19 @@ func (c *Collection) Delete(documentID []byte) error {
 		for _, it := range iterators {
 			_ = it.Close()
 		}
+		resetCollectionTables(deltaTables)
 	}()
 	for i, rootName := range rootNames {
 		iter := deltaTables[i].NewIterator(nil, nil)
 		iterators = append(iterators, iter)
 		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot: baseRootIDs[rootName],
-			Iter:     iter,
+			BaseRoot:      baseRootIDs[rootName],
+			Iter:          iter,
+			StoragePolicy: policies[i],
 		})
 	}
-	_, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemIterator(rootNames, baseRootIDs, rootIDs)
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
 	if err != nil {
 		return err
@@ -481,7 +1001,106 @@ func (c *Collection) Delete(documentID []byte) error {
 	if len(rootIDs) != len(rootNames) {
 		return errors.New("collections: ordered root publish returned unexpected root count")
 	}
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	return nil
+}
+
+func (c *Collection) catalogForSnapshot(snap *backenddb.Snapshot) (*collectionCatalog, error) {
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	systemRoot := snapshotSystemRoot(snap)
+
+	c.catalogMu.RLock()
+	if cached := c.catalog; cached != nil && c.catalogSystemRoot == systemRoot {
+		c.catalogMu.RUnlock()
+		return cached, nil
+	}
+	c.catalogMu.RUnlock()
+
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		return nil, err
+	}
+	c.rememberCatalog(snap, catalog)
+	return catalog, nil
+}
+
+func snapshotSystemRoot(snap *backenddb.Snapshot) uint64 {
+	if snap == nil {
+		return 0
+	}
+	if state := snap.State(); state != nil {
+		return state.SystemRootPageID
+	}
+	return 0
+}
+
+func (c *Collection) rememberCatalog(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+	if c == nil || snap == nil || catalog == nil {
+		return
+	}
+	systemRoot := snapshotSystemRoot(snap)
+	c.catalogMu.Lock()
+	c.catalogSystemRoot = systemRoot
+	c.catalog = catalog
+	c.catalogMu.Unlock()
+}
+
+func (c *Collection) rememberCatalogAtSystemRoot(systemRoot uint64, catalog *collectionCatalog) {
+	if c == nil || catalog == nil {
+		return
+	}
+	c.catalogMu.Lock()
+	c.catalogSystemRoot = systemRoot
+	c.catalog = catalog
+	c.catalogMu.Unlock()
+}
+
+func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collectionCatalog) {
+	if c == nil || catalog == nil || c.writeDomain == nil {
+		return
+	}
+	domain := c.writeDomain
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	if domain.count != 0 {
+		return
+	}
+	options, err := collectionPlannerOptions(catalog.meta)
+	if err != nil {
+		domain.loaded = false
+		return
+	}
+	domain.loaded = true
+	domain.meta = catalog.meta
+	domain.catalog = catalog
+	domain.baseSystemRoot = systemRoot
+	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
+	domain.storagePolicy = options.dataStoragePolicy
+	if domain.table == nil {
+		domain.table = newCollectionRunTable(0)
+	}
+}
+
+func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, rootNames []string, rootIDs []uint64) *collectionCatalog {
+	roots := make(map[string]uint64)
+	if base != nil {
+		for name, rootID := range base.roots {
+			roots[name] = rootID
+		}
+	}
+	for i, name := range rootNames {
+		if i < len(rootIDs) {
+			roots[name] = rootIDs[i]
+		}
+	}
+	return &collectionCatalog{
+		meta:  meta,
+		roots: roots,
+	}
 }
 
 func buildDeleteRootDeltaTable(deleteKeys [][]byte) memtable.Table {
@@ -575,14 +1194,10 @@ func buildCreateIndexBackfillPlan(
 			if !newRuntime.def.unique {
 				continue
 			}
-			prefix, err := indexValuePrefix(encoded)
-			if err != nil {
-				return nil, err
-			}
 			uniqueProbes = append(uniqueProbes, uniqueProbeCandidate{
-				indexName:  newRuntime.def.name,
-				prefix:     prefix,
-				documentID: bytes.Clone(documentID),
+				indexName:    newRuntime.def.name,
+				encodedValue: encoded,
+				documentID:   bytes.Clone(documentID),
 			})
 		}
 		it.Next()
@@ -598,12 +1213,14 @@ func buildCreateIndexBackfillPlan(
 		plan.rootNames = append(plan.rootNames, stateRootName)
 		plan.baseRootIDs[stateRootName] = stateRootID
 		plan.tables = append(plan.tables, indexStateTable)
+		plan.policies = append(plan.policies, opts.indexStateStoragePolicy)
 	}
 	if secondaryCount > 0 {
 		secondaryTable.Freeze()
 		plan.rootNames = append(plan.rootNames, secondaryRootName)
 		plan.baseRootIDs[secondaryRootName] = catalog.rootID(secondaryRootName)
 		plan.tables = append(plan.tables, secondaryTable)
+		plan.policies = append(plan.policies, newRuntime.def.storagePolicy)
 	}
 	return plan, nil
 }
@@ -655,6 +1272,42 @@ func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseR
 		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
 	}
 	return buildSystemTargetIterator(current, updates)
+}
+
+func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	if len(rootIDs) != len(rootNames) {
+		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	currentSystemRoot := uint64(0)
+	if c != nil && c.db != nil {
+		if state := c.db.State(); state != nil {
+			currentSystemRoot = state.SystemRootPageID
+		}
+	}
+	if currentSystemRoot != expectedSystemRoot {
+		current := c.db.AcquireSnapshot()
+		if current == nil {
+			return nil, backenddb.ErrClosed
+		}
+		defer func() { _ = current.Close() }()
+		catalog, err := loadCollectionCatalog(current, c.meta.Name)
+		if err != nil {
+			return nil, err
+		}
+		if catalog == nil {
+			return nil, errCollectionNotFound
+		}
+		for _, rootName := range rootNames {
+			if got, want := catalog.rootID(rootName), baseRootIDs[rootName]; got != want {
+				return nil, fmt.Errorf("collections: concurrent root modification detected for %q", rootName)
+			}
+		}
+	}
+	updates := make(map[string][]byte, len(rootNames))
+	for i, rootName := range rootNames {
+		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
+	}
+	return buildSystemDeltaIterator(updates)
 }
 
 func (c *Collection) buildSchemaAndRootDescriptorSystemIterator(
@@ -740,12 +1393,15 @@ func (c *Collection) Get(documentID []byte) ([]byte, error) {
 	if len(documentID) == 0 {
 		return nil, errors.New("collections: document id cannot be empty")
 	}
+	if value, found := c.getBufferedDocument(documentID); found {
+		return value, nil
+	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
 		return nil, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
-	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	catalog, err := c.catalogForSnapshot(snap)
 	if err != nil {
 		return nil, err
 	}
@@ -766,6 +1422,26 @@ func (c *Collection) Get(documentID []byte) ([]byte, error) {
 	return bytes.Clone(entry.Value), nil
 }
 
+func (c *Collection) getBufferedDocument(documentID []byte) ([]byte, bool) {
+	if c == nil || c.writeDomain == nil {
+		return nil, false
+	}
+	domain := c.writeDomain
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	if domain.count == 0 || domain.table == nil {
+		return nil, false
+	}
+	value, _, flags, found := domain.table.GetEntry(documentID)
+	if !found {
+		return nil, false
+	}
+	if flags&node.FlagTombstone != 0 {
+		return nil, true
+	}
+	return bytes.Clone(value), true
+}
+
 func (c *Collection) FindByIndex(indexName, value string) ([][]byte, error) {
 	if c == nil {
 		return nil, errCollectionNil
@@ -773,12 +1449,15 @@ func (c *Collection) FindByIndex(indexName, value string) ([][]byte, error) {
 	if err := ValidateIndexName(indexName); err != nil {
 		return nil, err
 	}
+	if err := c.flushBufferedNoIndex(); err != nil {
+		return nil, err
+	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
 		return nil, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
-	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	catalog, err := c.catalogForSnapshot(snap)
 	if err != nil {
 		return nil, err
 	}
@@ -962,6 +1641,17 @@ func (it *systemTargetIterator) Domain() (start, end []byte) {
 	return nil, nil
 }
 
+func (it *systemTargetIterator) StableUnsafeIteratorSlices() bool {
+	return true
+}
+
+func (it *systemTargetIterator) Len() int {
+	if it == nil {
+		return 0
+	}
+	return len(it.entries)
+}
+
 func buildSystemTargetIterator(snap *backenddb.Snapshot, updates map[string][]byte) (iterator.UnsafeIterator, error) {
 	updateEntries := make([]systemTargetEntry, 0, len(updates))
 	for key, value := range updates {
@@ -1017,6 +1707,20 @@ func buildSystemTargetIterator(snap *backenddb.Snapshot, updates map[string][]by
 	return &systemTargetIterator{entries: entries}, nil
 }
 
+func buildSystemDeltaIterator(updates map[string][]byte) (iterator.UnsafeIterator, error) {
+	entries := make([]systemTargetEntry, 0, len(updates))
+	for key, value := range updates {
+		entries = append(entries, systemTargetEntry{
+			key:   []byte(key),
+			value: bytes.Clone(value),
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return bytes.Compare(entries[i].key, entries[j].key) < 0
+	})
+	return &systemTargetIterator{entries: entries}, nil
+}
+
 func encodeCollectionMeta(meta CollectionMeta) ([]byte, error) {
 	normalized, err := normalizeCollectionMeta(meta)
 	if err != nil {
@@ -1049,6 +1753,12 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 	if err := ValidateCollectionName(meta.Name); err != nil {
 		return CollectionMeta{}, err
 	}
+	if _, err := backendRootStoragePolicy(meta.Options.DataRootStoragePolicy); err != nil {
+		return CollectionMeta{}, err
+	}
+	if _, err := backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy); err != nil {
+		return CollectionMeta{}, err
+	}
 	indexes := append([]IndexDefinition(nil), meta.Indexes...)
 	sort.SliceStable(indexes, func(i, j int) bool {
 		return indexes[i].Name < indexes[j].Name
@@ -1060,6 +1770,9 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		}
 		if err := ValidateIndexPath(indexes[i].Field); err != nil {
 			return CollectionMeta{}, fmt.Errorf("collections: invalid index %q field: %w", indexes[i].Name, err)
+		}
+		if _, err := backendRootStoragePolicy(indexes[i].StoragePolicy); err != nil {
+			return CollectionMeta{}, err
 		}
 		if _, ok := seen[indexes[i].Name]; ok {
 			return CollectionMeta{}, fmt.Errorf("collections: duplicate index %q", indexes[i].Name)
@@ -1126,11 +1839,13 @@ func singleIndexRuntime(def IndexDefinition) (indexRuntime, error) {
 func plannerIndexes(indexes []IndexDefinition) []indexDefinition {
 	out := make([]indexDefinition, len(indexes))
 	for i, idx := range indexes {
+		policy, _ := backendRootStoragePolicy(idx.StoragePolicy)
 		out[i] = indexDefinition{
-			name:     idx.Name,
-			field:    idx.Field,
-			unique:   idx.Unique,
-			multiKey: idx.MultiKey,
+			name:          idx.Name,
+			field:         idx.Field,
+			unique:        idx.Unique,
+			multiKey:      idx.MultiKey,
+			storagePolicy: policy,
 		}
 	}
 	return out

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1,0 +1,688 @@
+package collections
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/tree"
+)
+
+const collectionMetaVersion = 1
+
+var (
+	errCollectionManagerNil = errors.New("collections: collection manager is nil")
+	errCollectionNil        = errors.New("collections: collection is nil")
+	errCollectionNotFound   = errors.New("collections: collection not found")
+)
+
+const (
+	systemCollectionMetaPrefix = "collections/meta/"
+	systemCollectionRootPrefix = "collections/root/"
+)
+
+type CollectionManager struct {
+	db *backenddb.DB
+}
+
+type Collection struct {
+	db   *backenddb.DB
+	meta CollectionMeta
+}
+
+type CollectionOptions struct {
+	AllowArrayValuesInIndex bool `json:"allow_array_values_in_index,omitempty"`
+}
+
+type IndexDefinition struct {
+	Name     string `json:"name"`
+	Field    string `json:"field"`
+	Unique   bool   `json:"unique,omitempty"`
+	MultiKey bool   `json:"multi_key,omitempty"`
+}
+
+type CollectionMeta struct {
+	Name    string            `json:"name"`
+	Options CollectionOptions `json:"options,omitempty"`
+	Indexes []IndexDefinition `json:"indexes,omitempty"`
+}
+
+type collectionMetaDisk struct {
+	Version int               `json:"version"`
+	Name    string            `json:"name"`
+	Options CollectionOptions `json:"options,omitempty"`
+	Indexes []IndexDefinition `json:"indexes,omitempty"`
+}
+
+type collectionCatalog struct {
+	meta  CollectionMeta
+	roots map[string]uint64
+}
+
+func NewCollectionManager(database *backenddb.DB) *CollectionManager {
+	return &CollectionManager{db: database}
+}
+
+func (m *CollectionManager) CreateCollection(meta *CollectionMeta) (*CollectionMeta, error) {
+	if m == nil {
+		return nil, errCollectionManagerNil
+	}
+	if m.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
+	if meta == nil {
+		return nil, errors.New("collections: nil collection metadata")
+	}
+	normalized, err := normalizeCollectionMeta(*meta)
+	if err != nil {
+		return nil, err
+	}
+
+	snap := m.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	existing, err := loadCollectionCatalog(snap, normalized.Name)
+	_ = snap.Close()
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		if !sameCollectionMeta(existing.meta, normalized) {
+			return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
+		}
+		return existing.meta.copy(), nil
+	}
+
+	encoded, err := encodeCollectionMeta(normalized)
+	if err != nil {
+		return nil, err
+	}
+	_, _, err = m.db.PublishOrderedRootGroupWithSystemBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+		current := m.db.AcquireSnapshot()
+		if current == nil {
+			return nil, backenddb.ErrClosed
+		}
+		defer func() { _ = current.Close() }()
+		existing, err := loadCollectionCatalog(current, normalized.Name)
+		if err != nil {
+			return nil, err
+		}
+		if existing != nil && !sameCollectionMeta(existing.meta, normalized) {
+			return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
+		}
+		table, err := buildSystemTargetTable(current, map[string][]byte{
+			systemCollectionMetaKey(normalized.Name): encoded,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return table.NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return normalized.copy(), nil
+}
+
+func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
+	if m == nil {
+		return nil, errCollectionManagerNil
+	}
+	if m.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
+	if err := ValidateCollectionName(name); err != nil {
+		return nil, err
+	}
+	snap := m.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, name)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	return &Collection{
+		db:   m.db,
+		meta: catalog.meta,
+	}, nil
+}
+
+func (c *Collection) Name() string {
+	if c == nil {
+		return ""
+	}
+	return c.meta.Name
+}
+
+func (c *Collection) Meta() CollectionMeta {
+	if c == nil {
+		return CollectionMeta{}
+	}
+	return *c.meta.copy()
+}
+
+func (c *Collection) Insert(id, document []byte) ([]byte, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	ids, err := c.InsertBatch([][]byte{id}, [][]byte{document})
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) != 1 {
+		return nil, errors.New("collections: insert returned no document id")
+	}
+	return ids[0], nil
+}
+
+func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
+	if len(documents) == 0 {
+		return nil, nil
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return nil, errCollectionNotFound
+	}
+	c.meta = catalog.meta
+
+	planner := insertBatchPlanner{
+		collection:     c.meta.Name,
+		primaryRoot:    collectionPrimaryRootName(c.meta.Name),
+		indexStateRoot: collectionIndexStateRootName(c.meta.Name),
+		indexes:        plannerIndexes(c.meta.Indexes),
+		options: collectionOptions{
+			allowArrayValuesInIndex: c.meta.Options.AllowArrayValuesInIndex,
+		},
+	}
+	plan, err := planner.planInsertBatchWithPreflight(ids, documents, insertBatchPreflight{
+		snapshot:           snap,
+		primaryRootID:      catalog.rootID(collectionPrimaryRootName(c.meta.Name)),
+		uniqueIndexRootIDs: uniqueIndexRootIDs(catalog),
+	})
+	_ = snap.Close()
+	if err != nil {
+		return nil, err
+	}
+	if len(plan.runs) == 0 {
+		return cloneIDBatch(plan.resultIDs), nil
+	}
+
+	ordered := make([]backenddb.OrderedRootPublishInput, 0, len(plan.runs))
+	iterators := make([]iterator.UnsafeIterator, 0, len(plan.runs))
+	defer func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+	}()
+	baseRootIDs := make(map[string]uint64, len(plan.runs))
+	for _, run := range plan.runs {
+		baseRootIDs[run.name] = catalog.rootID(run.name)
+		iter := run.table.NewIterator(nil, nil)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootPublishInput{
+			BaseRoot: baseRootIDs[run.name],
+			Iter:     iter,
+		})
+	}
+
+	_, rootIDs, err := c.db.PublishOrderedRootGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildInsertSystemIterator(plan, baseRootIDs, rootIDs)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(rootIDs) != len(plan.runs) {
+		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	return cloneIDBatch(plan.resultIDs), nil
+}
+
+func (c *Collection) buildInsertSystemIterator(plan *insertBatchPlan, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	if len(rootIDs) != len(plan.runs) {
+		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	catalog, err := loadCollectionCatalog(current, c.meta.Name)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	for _, run := range plan.runs {
+		if got, want := catalog.rootID(run.name), baseRootIDs[run.name]; got != want {
+			return nil, fmt.Errorf("collections: concurrent root modification detected for %q", run.name)
+		}
+	}
+	updates := make(map[string][]byte, len(plan.runs))
+	for i, run := range plan.runs {
+		updates[systemCollectionRootKey(run.name)] = encodeRootID(rootIDs[i])
+	}
+	table, err := buildSystemTargetTable(current, updates)
+	if err != nil {
+		return nil, err
+	}
+	return table.NewIterator(nil, nil), nil
+}
+
+func (c *Collection) Get(documentID []byte) ([]byte, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if len(documentID) == 0 {
+		return nil, errors.New("collections: document id cannot be empty")
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
+	if primaryRoot == 0 {
+		return nil, nil
+	}
+	entry, err := snap.GetEntryAtRoot(primaryRoot, documentID)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return bytes.Clone(entry.Value), nil
+}
+
+func (c *Collection) FindByIndex(indexName, value string) ([][]byte, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if err := ValidateIndexName(indexName); err != nil {
+		return nil, err
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	idx, ok := findIndex(catalog.meta.Indexes, indexName)
+	if !ok {
+		return nil, nil
+	}
+	rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
+	if rootID == 0 {
+		return nil, nil
+	}
+	encoded, err := encodeIndexScalar(value)
+	if err != nil {
+		return nil, err
+	}
+	prefix, err := indexValuePrefix(encoded)
+	if err != nil {
+		return nil, err
+	}
+	it, err := snap.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = it.Close() }()
+	out := make([][]byte, 0, 1)
+	for it.Valid() {
+		key := it.UnsafeKey()
+		if !bytes.HasPrefix(key, prefix) {
+			break
+		}
+		if !it.IsDeleted() {
+			out = append(out, bytes.Clone(key[len(prefix):]))
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCatalog, error) {
+	raw, ok, err := getSystemValue(snap, systemCollectionMetaKey(name))
+	if err != nil || !ok {
+		return nil, err
+	}
+	meta, err := decodeCollectionMeta(raw)
+	if err != nil {
+		return nil, err
+	}
+	roots := make(map[string]uint64)
+	for _, rootName := range collectionRootNames(meta) {
+		rawRoot, ok, err := getSystemValue(snap, systemCollectionRootKey(rootName))
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		rootID, err := decodeRootID(rawRoot)
+		if err != nil {
+			return nil, fmt.Errorf("collections: root %q: %w", rootName, err)
+		}
+		roots[rootName] = rootID
+	}
+	return &collectionCatalog{meta: meta, roots: roots}, nil
+}
+
+func (c *collectionCatalog) rootID(rootName string) uint64 {
+	if c == nil || c.roots == nil {
+		return 0
+	}
+	return c.roots[rootName]
+}
+
+func getSystemValue(snap *backenddb.Snapshot, key string) ([]byte, bool, error) {
+	if snap == nil || snap.State() == nil || snap.State().SystemRootPageID == 0 {
+		return nil, false, nil
+	}
+	entry, err := snap.GetEntryAtRoot(snap.State().SystemRootPageID, []byte(key))
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return bytes.Clone(entry.Value), true, nil
+}
+
+func buildSystemTargetTable(snap *backenddb.Snapshot, updates map[string][]byte) (memtable.Table, error) {
+	table := memtable.NewHashSorted()
+	if snap != nil && snap.State() != nil && snap.State().SystemRootPageID != 0 {
+		it, err := snap.IteratorAtRoot(snap.State().SystemRootPageID, nil, nil)
+		if err != nil && !errors.Is(err, tree.ErrKeyNotFound) {
+			return nil, err
+		}
+		if err == nil {
+			for it.Valid() {
+				if !it.IsDeleted() {
+					table.Set(bytes.Clone(it.UnsafeKey()), bytes.Clone(it.UnsafeValue()))
+				}
+				it.Next()
+			}
+			iterErr := it.Error()
+			_ = it.Close()
+			if iterErr != nil {
+				return nil, iterErr
+			}
+		}
+	}
+	for key, value := range updates {
+		table.Set([]byte(key), bytes.Clone(value))
+	}
+	table.Freeze()
+	return table, nil
+}
+
+func encodeCollectionMeta(meta CollectionMeta) ([]byte, error) {
+	normalized, err := normalizeCollectionMeta(meta)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(collectionMetaDisk{
+		Version: collectionMetaVersion,
+		Name:    normalized.Name,
+		Options: normalized.Options,
+		Indexes: normalized.Indexes,
+	})
+}
+
+func decodeCollectionMeta(raw []byte) (CollectionMeta, error) {
+	var disk collectionMetaDisk
+	if err := json.Unmarshal(raw, &disk); err != nil {
+		return CollectionMeta{}, err
+	}
+	if disk.Version != collectionMetaVersion {
+		return CollectionMeta{}, fmt.Errorf("collections: unsupported collection metadata version %d", disk.Version)
+	}
+	return normalizeCollectionMeta(CollectionMeta{
+		Name:    disk.Name,
+		Options: disk.Options,
+		Indexes: disk.Indexes,
+	})
+}
+
+func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
+	if err := ValidateCollectionName(meta.Name); err != nil {
+		return CollectionMeta{}, err
+	}
+	indexes := append([]IndexDefinition(nil), meta.Indexes...)
+	sort.SliceStable(indexes, func(i, j int) bool {
+		return indexes[i].Name < indexes[j].Name
+	})
+	seen := make(map[string]struct{}, len(indexes))
+	for i := range indexes {
+		if err := ValidateIndexName(indexes[i].Name); err != nil {
+			return CollectionMeta{}, fmt.Errorf("collections: invalid index name %q: %w", indexes[i].Name, err)
+		}
+		if err := ValidateIndexPath(indexes[i].Field); err != nil {
+			return CollectionMeta{}, fmt.Errorf("collections: invalid index %q field: %w", indexes[i].Name, err)
+		}
+		if _, ok := seen[indexes[i].Name]; ok {
+			return CollectionMeta{}, fmt.Errorf("collections: duplicate index %q", indexes[i].Name)
+		}
+		seen[indexes[i].Name] = struct{}{}
+	}
+	meta.Indexes = indexes
+	return meta, nil
+}
+
+func (m CollectionMeta) copy() *CollectionMeta {
+	return &CollectionMeta{
+		Name:    m.Name,
+		Options: m.Options,
+		Indexes: append([]IndexDefinition(nil), m.Indexes...),
+	}
+}
+
+func sameCollectionMeta(a, b CollectionMeta) bool {
+	na, err := normalizeCollectionMeta(a)
+	if err != nil {
+		return false
+	}
+	nb, err := normalizeCollectionMeta(b)
+	if err != nil {
+		return false
+	}
+	return reflect.DeepEqual(na, nb)
+}
+
+func plannerIndexes(indexes []IndexDefinition) []indexDefinition {
+	out := make([]indexDefinition, len(indexes))
+	for i, idx := range indexes {
+		out[i] = indexDefinition{
+			name:     idx.Name,
+			field:    idx.Field,
+			unique:   idx.Unique,
+			multiKey: idx.MultiKey,
+		}
+	}
+	return out
+}
+
+func uniqueIndexRootIDs(catalog *collectionCatalog) map[string]uint64 {
+	if catalog == nil {
+		return nil
+	}
+	out := make(map[string]uint64)
+	for _, idx := range catalog.meta.Indexes {
+		if !idx.Unique {
+			continue
+		}
+		rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
+		if rootID != 0 {
+			out[idx.Name] = rootID
+		}
+	}
+	return out
+}
+
+func findIndex(indexes []IndexDefinition, name string) (IndexDefinition, bool) {
+	for _, idx := range indexes {
+		if idx.Name == name {
+			return idx, true
+		}
+	}
+	return IndexDefinition{}, false
+}
+
+func collectionRootNames(meta CollectionMeta) []string {
+	out := []string{collectionPrimaryRootName(meta.Name)}
+	if len(meta.Indexes) > 0 {
+		out = append(out, collectionIndexStateRootName(meta.Name))
+	}
+	for _, idx := range meta.Indexes {
+		out = append(out, collectionSecondaryRootName(meta.Name, idx.Name))
+	}
+	return out
+}
+
+func collectionPrimaryRootName(collection string) string {
+	return collection + "/primary"
+}
+
+func collectionIndexStateRootName(collection string) string {
+	return collection + "/index-state"
+}
+
+func collectionSecondaryRootName(collection, indexName string) string {
+	return collection + "/index/" + indexName
+}
+
+func systemCollectionMetaKey(collection string) string {
+	return systemCollectionMetaPrefix + collection
+}
+
+func systemCollectionRootKey(rootName string) string {
+	return systemCollectionRootPrefix + rootName
+}
+
+func encodeRootID(rootID uint64) []byte {
+	out := make([]byte, 8)
+	binary.BigEndian.PutUint64(out, rootID)
+	return out
+}
+
+func decodeRootID(raw []byte) (uint64, error) {
+	if len(raw) != 8 {
+		return 0, errors.New("malformed root id")
+	}
+	return binary.BigEndian.Uint64(raw), nil
+}
+
+func cloneIDBatch(ids [][]byte) [][]byte {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([][]byte, len(ids))
+	for i := range ids {
+		out[i] = bytes.Clone(ids[i])
+	}
+	return out
+}
+
+func ValidateCollectionName(name string) error {
+	if len(name) == 0 {
+		return errors.New("collection name cannot be empty")
+	}
+	if len(name) > 128 {
+		return errors.New("collection name too long")
+	}
+	if strings.ContainsAny(name, "\x00/:") {
+		return errors.New("collection name contains reserved punctuation")
+	}
+	if strings.TrimSpace(name) != name {
+		return errors.New("collection name has leading or trailing spaces")
+	}
+	if !utf8.ValidString(name) {
+		return errors.New("collection name invalid utf-8")
+	}
+	return nil
+}
+
+func ValidateIndexName(name string) error {
+	if len(name) == 0 {
+		return errors.New("index name cannot be empty")
+	}
+	if len(name) > 128 {
+		return errors.New("index name too long")
+	}
+	if strings.ContainsAny(name, "\x00/:") {
+		return errors.New("index name contains reserved punctuation")
+	}
+	if strings.TrimSpace(name) != name {
+		return errors.New("index name has leading or trailing spaces")
+	}
+	if !utf8.ValidString(name) {
+		return errors.New("index name invalid utf-8")
+	}
+	return nil
+}
+
+func ValidateIndexPath(path string) error {
+	if len(path) == 0 {
+		return errors.New("path cannot be empty")
+	}
+	if strings.Contains(path, "\x00") {
+		return errors.New("path cannot contain NUL")
+	}
+	if strings.HasPrefix(path, ".") || strings.HasSuffix(path, ".") || strings.Contains(path, "..") {
+		return errors.New("path cannot contain empty segments")
+	}
+	return nil
+}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -486,16 +486,20 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	if domain == nil {
 		return nil, collectionOptions{}, false, errors.New("collections: missing write domain")
 	}
-	if domain.loaded && domain.count > 0 {
-		options, err := collectionPlannerOptions(domain.meta)
-		if err != nil {
-			return nil, collectionOptions{}, false, err
-		}
-		return domain.catalog, options, len(domain.meta.Indexes) > 0, nil
-	}
 	currentSystemRoot := uint64(0)
 	if state := c.db.State(); state != nil {
 		currentSystemRoot = state.SystemRootPageID
+	}
+	if domain.loaded && domain.count > 0 {
+		catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentSystemRoot)
+		if err != nil {
+			return nil, collectionOptions{}, false, err
+		}
+		options, err := collectionPlannerOptions(catalog.meta)
+		if err != nil {
+			return nil, collectionOptions{}, false, err
+		}
+		return catalog, options, len(catalog.meta.Indexes) > 0, nil
 	}
 	if domain.loaded && domain.count == 0 && domain.baseSystemRoot == currentSystemRoot {
 		options, err := collectionPlannerOptions(domain.meta)
@@ -535,6 +539,55 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	return catalog, options, len(catalog.meta.Indexes) > 0, nil
 }
 
+func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWriteDomain, currentSystemRoot uint64) (*collectionCatalog, error) {
+	if c == nil || c.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
+	if domain == nil {
+		return nil, errors.New("collections: missing write domain")
+	}
+	if domain.catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	if domain.baseSystemRoot == currentSystemRoot {
+		return domain.catalog, nil
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	catalog, err := loadCollectionCatalog(snap, domain.meta.Name)
+	baseSystemRoot := snapshotSystemRoot(snap)
+	_ = snap.Close()
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	if !sameCollectionMeta(catalog.meta, domain.meta) {
+		return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", domain.meta.Name)
+	}
+
+	rootName := collectionPrimaryRootName(domain.meta.Name)
+	if rootID := catalog.rootID(rootName); rootID != domain.primaryRoot {
+		return nil, fmt.Errorf("collections: concurrent root modification detected for %q", domain.meta.Name)
+	}
+	options, err := collectionPlannerOptions(catalog.meta)
+	if err != nil {
+		return nil, err
+	}
+	domain.meta = catalog.meta
+	domain.catalog = catalog
+	domain.baseSystemRoot = baseSystemRoot
+	domain.primaryRoot = catalog.rootID(rootName)
+	domain.storagePolicy = options.dataStoragePolicy
+	c.meta = catalog.meta
+	c.rememberCatalogAtSystemRoot(baseSystemRoot, catalog)
+	return catalog, nil
+}
+
 func (c *Collection) persistedDocumentExists(rootID uint64, id []byte) (bool, error) {
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
@@ -566,7 +619,15 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	if domain.catalog == nil {
 		return errCollectionNotFound
 	}
-	meta := domain.meta
+	currentSystemRoot := uint64(0)
+	if state := c.db.State(); state != nil {
+		currentSystemRoot = state.SystemRootPageID
+	}
+	catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentSystemRoot)
+	if err != nil {
+		return err
+	}
+	meta := catalog.meta
 	if len(meta.Indexes) > 0 {
 		return errors.New("collections: buffered no-index writes cannot be flushed into indexed schema")
 	}
@@ -592,16 +653,16 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	if len(rootIDs) != 1 {
 		return errors.New("collections: ordered root publish returned unexpected root count")
 	}
-	catalog := cloneCatalogWithRootUpdates(domain.catalog, meta, []string{rootName}, rootIDs)
+	nextCatalog := cloneCatalogWithRootUpdates(domain.catalog, meta, []string{rootName}, rootIDs)
 	domain.loaded = true
 	domain.meta = meta
-	domain.catalog = catalog
+	domain.catalog = nextCatalog
 	domain.baseSystemRoot = newSystemRoot
 	domain.primaryRoot = rootIDs[0]
 	domain.table = newCollectionRunTable(0)
 	domain.count = 0
 	c.meta = meta
-	c.rememberCatalogAtSystemRoot(newSystemRoot, catalog)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetCollectionRunTable(table)
 	return nil
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -14,6 +14,8 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/tree"
 )
 
@@ -126,13 +128,13 @@ func (m *CollectionManager) CreateCollection(meta *CollectionMeta) (*CollectionM
 		if existing != nil && !sameCollectionMeta(existing.meta, normalized) {
 			return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
 		}
-		table, err := buildSystemTargetTable(current, map[string][]byte{
+		iter, err := buildSystemTargetIterator(current, map[string][]byte{
 			systemCollectionMetaKey(normalized.Name): encoded,
 		})
 		if err != nil {
 			return nil, err
 		}
-		return table.NewIterator(nil, nil), nil
+		return iter, nil
 	})
 	if err != nil {
 		return nil, err
@@ -652,11 +654,7 @@ func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseR
 	for i, rootName := range rootNames {
 		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
 	}
-	table, err := buildSystemTargetTable(current, updates)
-	if err != nil {
-		return nil, err
-	}
-	return table.NewIterator(nil, nil), nil
+	return buildSystemTargetIterator(current, updates)
 }
 
 func (c *Collection) buildSchemaAndRootDescriptorSystemIterator(
@@ -699,11 +697,7 @@ func (c *Collection) buildSchemaAndRootDescriptorSystemIterator(
 	for i, rootName := range rootNames {
 		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
 	}
-	table, err := buildSystemTargetTable(current, updates)
-	if err != nil {
-		return nil, err
-	}
-	return table.NewIterator(nil, nil), nil
+	return buildSystemTargetIterator(current, updates)
 }
 
 func loadDeleteIndexState(snap *backenddb.Snapshot, catalog *collectionCatalog, documentID, document []byte, runtimes []indexRuntime, opts collectionOptions) (documentIndexState, error) {
@@ -880,32 +874,147 @@ func getSystemValue(snap *backenddb.Snapshot, key string) ([]byte, bool, error) 
 	return bytes.Clone(entry.Value), true, nil
 }
 
-func buildSystemTargetTable(snap *backenddb.Snapshot, updates map[string][]byte) (memtable.Table, error) {
-	table := memtable.NewHashSorted()
+type systemTargetEntry struct {
+	key   []byte
+	value []byte
+}
+
+type systemTargetIterator struct {
+	entries []systemTargetEntry
+	idx     int
+}
+
+func (it *systemTargetIterator) Valid() bool {
+	return it != nil && it.idx >= 0 && it.idx < len(it.entries)
+}
+
+func (it *systemTargetIterator) Next() {
+	if it != nil && it.idx < len(it.entries) {
+		it.idx++
+	}
+}
+
+func (it *systemTargetIterator) Seek(key []byte) {
+	if it == nil {
+		return
+	}
+	it.idx = sort.Search(len(it.entries), func(i int) bool {
+		return bytes.Compare(it.entries[i].key, key) >= 0
+	})
+}
+
+func (it *systemTargetIterator) UnsafeKey() []byte {
+	if !it.Valid() {
+		return nil
+	}
+	return it.entries[it.idx].key
+}
+
+func (it *systemTargetIterator) UnsafeValue() []byte {
+	if !it.Valid() {
+		return nil
+	}
+	return it.entries[it.idx].value
+}
+
+func (it *systemTargetIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	if !it.Valid() {
+		return nil, page.ValuePtr{}, node.FlagInline
+	}
+	return it.entries[it.idx].value, page.ValuePtr{}, node.FlagInline
+}
+
+func (it *systemTargetIterator) Key() []byte {
+	return it.UnsafeKey()
+}
+
+func (it *systemTargetIterator) Value() []byte {
+	return it.UnsafeValue()
+}
+
+func (it *systemTargetIterator) KeyCopy(dst []byte) []byte {
+	if !it.Valid() {
+		return dst
+	}
+	return append(dst, it.entries[it.idx].key...)
+}
+
+func (it *systemTargetIterator) ValueCopy(dst []byte) []byte {
+	if !it.Valid() {
+		return dst
+	}
+	return append(dst, it.entries[it.idx].value...)
+}
+
+func (it *systemTargetIterator) IsDeleted() bool {
+	return false
+}
+
+func (it *systemTargetIterator) Error() error {
+	return nil
+}
+
+func (it *systemTargetIterator) Close() error {
+	return nil
+}
+
+func (it *systemTargetIterator) Domain() (start, end []byte) {
+	return nil, nil
+}
+
+func buildSystemTargetIterator(snap *backenddb.Snapshot, updates map[string][]byte) (iterator.UnsafeIterator, error) {
+	updateEntries := make([]systemTargetEntry, 0, len(updates))
+	for key, value := range updates {
+		updateEntries = append(updateEntries, systemTargetEntry{
+			key:   []byte(key),
+			value: bytes.Clone(value),
+		})
+	}
+	sort.Slice(updateEntries, func(i, j int) bool {
+		return bytes.Compare(updateEntries[i].key, updateEntries[j].key) < 0
+	})
+
+	entries := make([]systemTargetEntry, 0, len(updateEntries))
+	updateIdx := 0
 	if snap != nil && snap.State() != nil && snap.State().SystemRootPageID != 0 {
 		it, err := snap.IteratorAtRoot(snap.State().SystemRootPageID, nil, nil)
 		if err != nil && !errors.Is(err, tree.ErrKeyNotFound) {
 			return nil, err
 		}
 		if err == nil {
+			defer func() { _ = it.Close() }()
 			for it.Valid() {
-				if !it.IsDeleted() {
-					table.Set(bytes.Clone(it.UnsafeKey()), bytes.Clone(it.UnsafeValue()))
+				if it.IsDeleted() {
+					it.Next()
+					continue
+				}
+				currKey := it.UnsafeKey()
+				for updateIdx < len(updateEntries) && bytes.Compare(updateEntries[updateIdx].key, currKey) < 0 {
+					entries = append(entries, updateEntries[updateIdx])
+					updateIdx++
+				}
+				if updateIdx < len(updateEntries) && bytes.Equal(updateEntries[updateIdx].key, currKey) {
+					entries = append(entries, updateEntries[updateIdx])
+					updateIdx++
+				} else {
+					entries = append(entries, systemTargetEntry{
+						key:   bytes.Clone(currKey),
+						value: it.ValueCopy(nil),
+					})
 				}
 				it.Next()
 			}
 			iterErr := it.Error()
-			_ = it.Close()
 			if iterErr != nil {
 				return nil, iterErr
 			}
 		}
 	}
-	for key, value := range updates {
-		table.Set([]byte(key), bytes.Clone(value))
+	for updateIdx < len(updateEntries) {
+		entries = append(entries, updateEntries[updateIdx])
+		updateIdx++
 	}
-	table.Freeze()
-	return table, nil
+	return &systemTargetIterator{entries: entries}, nil
 }
 
 func encodeCollectionMeta(meta CollectionMeta) ([]byte, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -558,7 +558,7 @@ func buildCreateIndexBackfillPlan(
 		} else {
 			delete(merged, newRuntime.def.name)
 		}
-		rawState, err := encodeDocumentIndexState(merged)
+		rawState, err := encodeNormalizedDocumentIndexState(merged)
 		if err != nil {
 			return nil, err
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -230,34 +230,43 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 		primaryRootID:      catalog.rootID(collectionPrimaryRootName(c.meta.Name)),
 		uniqueIndexRootIDs: uniqueIndexRootIDs(catalog),
 	})
-	_ = snap.Close()
 	if err != nil {
+		_ = snap.Close()
 		return nil, err
 	}
 	if len(plan.runs) == 0 {
+		_ = snap.Close()
 		return cloneIDBatch(plan.resultIDs), nil
 	}
 
-	ordered := make([]backenddb.OrderedRootPublishInput, 0, len(plan.runs))
+	baseRootIDs := make(map[string]uint64, len(plan.runs))
+	for _, run := range plan.runs {
+		baseRootIDs[run.name] = catalog.rootID(run.name)
+	}
+	_ = snap.Close()
+
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.runs))
 	iterators := make([]iterator.UnsafeIterator, 0, len(plan.runs))
 	defer func() {
 		for _, it := range iterators {
 			_ = it.Close()
 		}
 	}()
-	baseRootIDs := make(map[string]uint64, len(plan.runs))
 	for _, run := range plan.runs {
-		baseRootIDs[run.name] = catalog.rootID(run.name)
 		iter := run.table.NewIterator(nil, nil)
 		iterators = append(iterators, iter)
-		ordered = append(ordered, backenddb.OrderedRootPublishInput{
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
 			BaseRoot: baseRootIDs[run.name],
 			Iter:     iter,
 		})
 	}
 
-	_, rootIDs, err := c.db.PublishOrderedRootGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildInsertSystemIterator(plan, baseRootIDs, rootIDs)
+	rootNames := make([]string, len(plan.runs))
+	for i, run := range plan.runs {
+		rootNames[i] = run.name
+	}
+	_, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemIterator(rootNames, baseRootIDs, rootIDs)
 	})
 	if err != nil {
 		return nil, err
@@ -268,8 +277,137 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	return cloneIDBatch(plan.resultIDs), nil
 }
 
-func (c *Collection) buildInsertSystemIterator(plan *insertBatchPlan, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
-	if len(rootIDs) != len(plan.runs) {
+func (c *Collection) Delete(documentID []byte) error {
+	if c == nil {
+		return errCollectionNil
+	}
+	if c.db == nil {
+		return errors.New("collections: db is nil")
+	}
+	if len(documentID) == 0 {
+		return errors.New("collections: document id cannot be empty")
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return backenddb.ErrClosed
+	}
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		_ = snap.Close()
+		return err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return errCollectionNotFound
+	}
+	c.meta = catalog.meta
+
+	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
+	if primaryRoot == 0 {
+		_ = snap.Close()
+		return nil
+	}
+	entry, err := snap.GetEntryAtRoot(primaryRoot, documentID)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		_ = snap.Close()
+		return nil
+	}
+	if err != nil {
+		_ = snap.Close()
+		return err
+	}
+
+	runtimes, err := (insertBatchPlanner{
+		collection: c.meta.Name,
+		indexes:    plannerIndexes(c.meta.Indexes),
+	}).indexRuntimes()
+	if err != nil {
+		_ = snap.Close()
+		return err
+	}
+	var state documentIndexState
+	if len(runtimes) > 0 {
+		state, err = loadDeleteIndexState(snap, catalog, documentID, entry.Value, runtimes, collectionOptions{
+			allowArrayValuesInIndex: c.meta.Options.AllowArrayValuesInIndex,
+		})
+		if err != nil {
+			_ = snap.Close()
+			return err
+		}
+	}
+
+	rootNames := []string{collectionPrimaryRootName(c.meta.Name)}
+	baseRootIDs := map[string]uint64{
+		rootNames[0]: primaryRoot,
+	}
+	deltaTables := make([]memtable.Table, 0, 2+len(runtimes))
+	deltaTables = append(deltaTables, buildDeleteRootDeltaTable([][]byte{documentID}))
+
+	if len(runtimes) > 0 {
+		stateRootName := collectionIndexStateRootName(c.meta.Name)
+		stateRootID := catalog.rootID(stateRootName)
+		if stateRootID != 0 {
+			rootNames = append(rootNames, stateRootName)
+			baseRootIDs[stateRootName] = stateRootID
+			deltaTables = append(deltaTables, buildDeleteRootDeltaTable([][]byte{documentID}))
+		}
+		for _, runtime := range runtimes {
+			deleteKeys, err := secondaryDeleteKeysForDocument(runtime, state, documentID)
+			if err != nil {
+				_ = snap.Close()
+				return err
+			}
+			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
+			rootID := catalog.rootID(rootName)
+			if rootID == 0 || len(deleteKeys) == 0 {
+				continue
+			}
+			rootNames = append(rootNames, rootName)
+			baseRootIDs[rootName] = rootID
+			deltaTables = append(deltaTables, buildDeleteRootDeltaTable(deleteKeys))
+		}
+	}
+	_ = snap.Close()
+
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	defer func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+	}()
+	for i, rootName := range rootNames {
+		iter := deltaTables[i].NewIterator(nil, nil)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot: baseRootIDs[rootName],
+			Iter:     iter,
+		})
+	}
+	_, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemIterator(rootNames, baseRootIDs, rootIDs)
+	})
+	if err != nil {
+		return err
+	}
+	if len(rootIDs) != len(rootNames) {
+		return errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	return nil
+}
+
+func buildDeleteRootDeltaTable(deleteKeys [][]byte) memtable.Table {
+	table := newCollectionRunTable(len(deleteKeys))
+	for _, key := range deleteKeys {
+		table.DeleteSteal(bytes.Clone(key))
+	}
+	table.Freeze()
+	return table
+}
+
+func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	if len(rootIDs) != len(rootNames) {
 		return nil, errors.New("collections: ordered root publish returned unexpected root count")
 	}
 	current := c.db.AcquireSnapshot()
@@ -284,20 +422,53 @@ func (c *Collection) buildInsertSystemIterator(plan *insertBatchPlan, baseRootID
 	if catalog == nil {
 		return nil, errCollectionNotFound
 	}
-	for _, run := range plan.runs {
-		if got, want := catalog.rootID(run.name), baseRootIDs[run.name]; got != want {
-			return nil, fmt.Errorf("collections: concurrent root modification detected for %q", run.name)
+	for _, rootName := range rootNames {
+		if got, want := catalog.rootID(rootName), baseRootIDs[rootName]; got != want {
+			return nil, fmt.Errorf("collections: concurrent root modification detected for %q", rootName)
 		}
 	}
-	updates := make(map[string][]byte, len(plan.runs))
-	for i, run := range plan.runs {
-		updates[systemCollectionRootKey(run.name)] = encodeRootID(rootIDs[i])
+	updates := make(map[string][]byte, len(rootNames))
+	for i, rootName := range rootNames {
+		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
 	}
 	table, err := buildSystemTargetTable(current, updates)
 	if err != nil {
 		return nil, err
 	}
 	return table.NewIterator(nil, nil), nil
+}
+
+func loadDeleteIndexState(snap *backenddb.Snapshot, catalog *collectionCatalog, documentID, document []byte, runtimes []indexRuntime, opts collectionOptions) (documentIndexState, error) {
+	if catalog == nil || len(runtimes) == 0 {
+		return nil, nil
+	}
+	stateRoot := catalog.rootID(collectionIndexStateRootName(catalog.meta.Name))
+	if stateRoot != 0 {
+		entry, err := snap.GetEntryAtRoot(stateRoot, documentID)
+		if err == nil {
+			return decodeDocumentIndexState(entry.Value)
+		}
+		if err != nil && !errors.Is(err, tree.ErrKeyNotFound) {
+			return nil, err
+		}
+	}
+	return indexStateForDocument(document, runtimes, opts)
+}
+
+func secondaryDeleteKeysForDocument(runtime indexRuntime, state documentIndexState, documentID []byte) ([][]byte, error) {
+	values := state[runtime.def.name]
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make([][]byte, 0, len(values))
+	for _, encoded := range values {
+		key, err := indexEntryKey(encoded, documentID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, key)
+	}
+	return out, nil
 }
 
 func (c *Collection) Get(documentID []byte) ([]byte, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -321,7 +321,7 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	}
 	if len(plan.runs) == 0 {
 		_ = snap.Close()
-		return cloneIDBatch(plan.resultIDs), nil
+		return plan.resultIDs, nil
 	}
 
 	baseRootIDs := make(map[string]uint64, len(plan.runs))
@@ -359,7 +359,7 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	if len(rootIDs) != len(plan.runs) {
 		return nil, errors.New("collections: ordered root publish returned unexpected root count")
 	}
-	return cloneIDBatch(plan.resultIDs), nil
+	return plan.resultIDs, nil
 }
 
 func (c *Collection) Delete(documentID []byte) error {
@@ -1095,17 +1095,6 @@ func decodeRootID(raw []byte) (uint64, error) {
 		return 0, errors.New("malformed root id")
 	}
 	return binary.BigEndian.Uint64(raw), nil
-}
-
-func cloneIDBatch(ids [][]byte) [][]byte {
-	if len(ids) == 0 {
-		return nil
-	}
-	out := make([][]byte, len(ids))
-	for i := range ids {
-		out[i] = bytes.Clone(ids[i])
-	}
-	return out
 }
 
 func ValidateCollectionName(name string) error {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1461,6 +1461,9 @@ func (c *Collection) Get(documentID []byte) ([]byte, error) {
 	if c == nil {
 		return nil, errCollectionNil
 	}
+	if c.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
 	if len(documentID) == 0 {
 		return nil, errors.New("collections: document id cannot be empty")
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1191,6 +1191,7 @@ func buildCreateIndexBackfillPlan(
 	plan := &createIndexBackfillPlan{
 		baseRootIDs: make(map[string]uint64, 2),
 	}
+	plan.baseRootIDs[primaryRootName] = primaryRootID
 	if primaryRootID == 0 {
 		return plan, nil
 	}
@@ -1358,6 +1359,9 @@ func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedSystemRoot u
 		if catalog == nil {
 			return nil, errCollectionNotFound
 		}
+		if !sameCollectionMeta(catalog.meta, c.meta) {
+			return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", c.meta.Name)
+		}
 		for _, rootName := range rootNames {
 			if got, want := catalog.rootID(rootName), baseRootIDs[rootName]; got != want {
 				return nil, fmt.Errorf("collections: concurrent root modification detected for %q", rootName)
@@ -1395,6 +1399,12 @@ func (c *Collection) buildSchemaAndRootDescriptorSystemIterator(
 	}
 	if !sameCollectionMeta(catalog.meta, baseMeta) {
 		return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", baseMeta.Name)
+	}
+	primaryRootName := collectionPrimaryRootName(baseMeta.Name)
+	if baseRootID, ok := baseRootIDs[primaryRootName]; ok {
+		if got := catalog.rootID(primaryRootName); got != baseRootID {
+			return nil, fmt.Errorf("collections: concurrent root modification detected for %q", primaryRootName)
+		}
 	}
 	for _, rootName := range rootNames {
 		if got, want := catalog.rootID(rootName), baseRootIDs[rootName]; got != want {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -146,6 +146,62 @@ func TestCollectionInsertBatchBridge_ReopenUsesPersistedRootDescriptors(t *testi
 	}
 }
 
+func TestCollectionInsertBatchBridge_AppendsWithoutDroppingExistingRoots(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert first batch: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"email":"grace@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert second batch: %v", err)
+	}
+
+	for id, want := range map[string][]byte{
+		"u1": []byte(`{"email":"ada@example.com","city":"hnl"}`),
+		"u2": []byte(`{"email":"grace@example.com","city":"hnl"}`),
+	} {
+		got, err := col.Get([]byte(id))
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("%s=%q want %q", id, got, want)
+		}
+	}
+
+	cityIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city: %v", err)
+	}
+	if len(cityIDs) != 2 || !bytes.Equal(cityIDs[0], []byte("u1")) || !bytes.Equal(cityIDs[1], []byte("u2")) {
+		t.Fatalf("city ids=%q want [u1 u2]", cityIDs)
+	}
+}
+
 func TestCollectionInsertBatchBridge_RejectsPersistedUniqueConflictAtomically(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -259,5 +315,171 @@ func TestCollectionInsertBatchBridge_RejectsDuplicateIDBeforePublish(t *testing.
 	}
 	if got != nil {
 		t.Fatalf("unexpected u1 doc=%q", got)
+	}
+}
+
+func TestCollectionDeleteBridge_RemovesPrimaryAndSecondaryEntries(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com","city":"hnl"}`),
+			[]byte(`{"email":"grace@example.com","city":"hnl"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	if err := col.Delete([]byte("u1")); err != nil {
+		t.Fatalf("delete u1: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get deleted u1: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("deleted u1 still visible: %q", got)
+	}
+	got, err = col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
+	if want := []byte(`{"email":"grace@example.com","city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("u2=%q want %q", got, want)
+	}
+
+	emailIDs, err := col.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find deleted email: %v", err)
+	}
+	if len(emailIDs) != 0 {
+		t.Fatalf("deleted email ids=%q want none", emailIDs)
+	}
+	cityIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city: %v", err)
+	}
+	if len(cityIDs) != 1 || !bytes.Equal(cityIDs[0], []byte("u2")) {
+		t.Fatalf("city ids=%q want [u2]", cityIDs)
+	}
+}
+
+func TestCollectionDeleteBridge_AllowsUniqueValueReuse(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if err := col.Delete([]byte("u1")); err != nil {
+		t.Fatalf("delete u1: %v", err)
+	}
+	if _, err := col.Insert([]byte("u2"), []byte(`{"email":"ada@example.com"}`)); err != nil {
+		t.Fatalf("reuse unique email: %v", err)
+	}
+	ids, err := col.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
+		t.Fatalf("email ids=%q want [u2]", ids)
+	}
+}
+
+func TestCollectionDeleteBridge_ReopenUsesDeletedRootDescriptors(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com"}`),
+			[]byte(`{"email":"grace@example.com"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Delete([]byte("u1")); err != nil {
+		t.Fatalf("delete u1: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	got, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get deleted u1 after reopen: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("deleted u1 visible after reopen: %q", got)
+	}
+	ids, err := reopenedCol.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find deleted email after reopen: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("deleted email ids after reopen=%q want none", ids)
+	}
+	ids, err = reopenedCol.FindByIndex("email", "grace@example.com")
+	if err != nil {
+		t.Fatalf("find remaining email after reopen: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
+		t.Fatalf("remaining email ids=%q want [u2]", ids)
 	}
 }

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1,0 +1,263 @@
+package collections
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionInsertBatchBridge_RoundTripWithSecondaryIndexes(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	meta, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if got, want := meta.Name, "users"; got != want {
+		t.Fatalf("collection name=%q want %q", got, want)
+	}
+
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	ids, err := col.InsertBatch(
+		[][]byte{[]byte("u2"), []byte("u1")},
+		[][]byte{
+			[]byte(`{"email":"grace@example.com","city":"hnl"}`),
+			[]byte(`{"email":"ada@example.com","city":"hnl"}`),
+		},
+	)
+	if err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if len(ids) != 2 || !bytes.Equal(ids[0], []byte("u2")) || !bytes.Equal(ids[1], []byte("u1")) {
+		t.Fatalf("result ids=%q", ids)
+	}
+
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("u1=%q want %q", got, want)
+	}
+
+	emailIDs, err := col.FindByIndex("email", "grace@example.com")
+	if err != nil {
+		t.Fatalf("find email: %v", err)
+	}
+	if len(emailIDs) != 1 || !bytes.Equal(emailIDs[0], []byte("u2")) {
+		t.Fatalf("email ids=%q want u2", emailIDs)
+	}
+
+	cityIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city: %v", err)
+	}
+	if len(cityIDs) != 2 || !bytes.Equal(cityIDs[0], []byte("u1")) || !bytes.Equal(cityIDs[1], []byte("u2")) {
+		t.Fatalf("city ids=%q want [u1 u2]", cityIDs)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	for _, rootName := range []string{
+		collectionPrimaryRootName("users"),
+		collectionIndexStateRootName("users"),
+		collectionSecondaryRootName("users", "email"),
+		collectionSecondaryRootName("users", "city"),
+	} {
+		if got := catalog.rootID(rootName); got == 0 {
+			t.Fatalf("root %q was not persisted", rootName)
+		}
+	}
+}
+
+func TestCollectionInsertBatchBridge_ReopenUsesPersistedRootDescriptors(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection after reopen: %v", err)
+	}
+	got, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get after reopen: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com"}`); !bytes.Equal(got, want) {
+		t.Fatalf("reopen u1=%q want %q", got, want)
+	}
+	ids, err := reopenedCol.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find after reopen: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("reopen email ids=%q want u1", ids)
+	}
+}
+
+func TestCollectionInsertBatchBridge_RejectsPersistedUniqueConflictAtomically(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("seed"), []byte(`{"email":"ada@example.com"}`)); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+
+	_, err = col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com"}`),
+			[]byte(`{"email":"grace@example.com"}`),
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "unique index") {
+		t.Fatalf("err=%v want unique index conflict", err)
+	}
+	for _, id := range [][]byte{[]byte("u1"), []byte("u2")} {
+		got, err := col.Get(id)
+		if err != nil {
+			t.Fatalf("get %q: %v", id, err)
+		}
+		if got != nil {
+			t.Fatalf("unexpected doc %q=%q", id, got)
+		}
+	}
+}
+
+func TestCollectionInsertBatchBridge_RejectsPersistedDocumentIDAtomically(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"seed"}`)); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+
+	_, err = col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"name":"dup"}`), []byte(`{"name":"new"}`)},
+	)
+	if err == nil || !strings.Contains(err.Error(), "document already exists") {
+		t.Fatalf("err=%v want persisted document id conflict", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if want := []byte(`{"name":"seed"}`); !bytes.Equal(got, want) {
+		t.Fatalf("u1=%q want %q", got, want)
+	}
+	got, err = col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("unexpected u2 doc=%q", got)
+	}
+}
+
+func TestCollectionInsertBatchBridge_RejectsDuplicateIDBeforePublish(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	_, err = col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u1")},
+		[][]byte{[]byte(`{"name":"first"}`), []byte(`{"name":"second"}`)},
+	)
+	if err == nil || !strings.Contains(err.Error(), "duplicate document id") {
+		t.Fatalf("err=%v want duplicate document id", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("unexpected u1 doc=%q", got)
+	}
+}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -202,6 +202,256 @@ func TestCollectionInsertBatchBridge_AppendsWithoutDroppingExistingRoots(t *test
 	}
 }
 
+func TestCollectionCreateIndexBackfill_BuildsSecondaryAndIndexState(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2"), []byte("u1")},
+		[][]byte{
+			[]byte(`{"email":"grace@example.com","city":"hnl"}`),
+			[]byte(`{"email":"ada@example.com","city":"hnl"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	meta, err := col.CreateIndex(IndexDefinition{Name: "city", Field: "city"})
+	if err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+	if _, ok := findIndex(meta.Indexes, "city"); !ok {
+		t.Fatalf("created meta missing city index: %+v", meta.Indexes)
+	}
+	if _, ok := findIndex(col.Meta().Indexes, "city"); !ok {
+		t.Fatalf("collection meta missing city index after create: %+v", col.Meta().Indexes)
+	}
+
+	cityIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city: %v", err)
+	}
+	if len(cityIDs) != 2 || !bytes.Equal(cityIDs[0], []byte("u1")) || !bytes.Equal(cityIDs[1], []byte("u2")) {
+		t.Fatalf("city ids=%q want [u1 u2]", cityIDs)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	for _, rootName := range []string{
+		collectionPrimaryRootName("users"),
+		collectionIndexStateRootName("users"),
+		collectionSecondaryRootName("users", "city"),
+	} {
+		if got := catalog.rootID(rootName); got == 0 {
+			t.Fatalf("root %q was not persisted", rootName)
+		}
+	}
+
+	if _, err := col.Insert([]byte("u3"), []byte(`{"email":"katherine@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert after create index: %v", err)
+	}
+	cityIDs, err = col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city after insert: %v", err)
+	}
+	if len(cityIDs) != 3 ||
+		!bytes.Equal(cityIDs[0], []byte("u1")) ||
+		!bytes.Equal(cityIDs[1], []byte("u2")) ||
+		!bytes.Equal(cityIDs[2], []byte("u3")) {
+		t.Fatalf("city ids after insert=%q want [u1 u2 u3]", cityIDs)
+	}
+}
+
+func TestCollectionCreateIndexBackfill_EmptyCollectionUpdatesSchema(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.CreateIndex(IndexDefinition{Name: "city", Field: "city"}); err != nil {
+		t.Fatalf("create index on empty collection: %v", err)
+	}
+	if _, ok := findIndex(col.Meta().Indexes, "city"); !ok {
+		t.Fatalf("collection meta missing city index after empty create: %+v", col.Meta().Indexes)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"city":"hnl"}`)); err != nil {
+		t.Fatalf("insert after empty create index: %v", err)
+	}
+	ids, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city after empty create: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("city ids after empty create=%q want [u1]", ids)
+	}
+}
+
+func TestCollectionCreateIndexBackfill_PreservesExistingIndexState(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com","city":"hnl"}`),
+			[]byte(`{"email":"grace@example.com","city":"sfo"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if _, err := col.CreateIndex(IndexDefinition{Name: "city", Field: "city"}); err != nil {
+		t.Fatalf("create city index: %v", err)
+	}
+	if err := col.Delete([]byte("u1")); err != nil {
+		t.Fatalf("delete u1: %v", err)
+	}
+
+	emailIDs, err := col.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find deleted email: %v", err)
+	}
+	if len(emailIDs) != 0 {
+		t.Fatalf("deleted email ids=%q want none", emailIDs)
+	}
+	cityIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find deleted city: %v", err)
+	}
+	if len(cityIDs) != 0 {
+		t.Fatalf("deleted city ids=%q want none", cityIDs)
+	}
+	if _, err := col.Insert([]byte("u3"), []byte(`{"email":"ada@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("reuse unique email after delete: %v", err)
+	}
+}
+
+func TestCollectionCreateIndexBackfill_ReopenUsesPersistedSchemaAndRoots(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if _, err := col.CreateIndex(IndexDefinition{Name: "email", Field: "email", Unique: true}); err != nil {
+		t.Fatalf("create unique index: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err := reopenedCol.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find email after reopen: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("email ids after reopen=%q want [u1]", ids)
+	}
+	if _, err := reopenedCol.Insert([]byte("u2"), []byte(`{"email":"ada@example.com"}`)); err == nil || !strings.Contains(err.Error(), "unique index") {
+		t.Fatalf("duplicate insert err=%v want unique index conflict", err)
+	}
+}
+
+func TestCollectionCreateIndexBackfill_RejectsUniqueConflictAtomically(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com"}`),
+			[]byte(`{"email":"ada@example.com"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert duplicate documents before unique index: %v", err)
+	}
+
+	_, err = col.CreateIndex(IndexDefinition{Name: "email", Field: "email", Unique: true})
+	if err == nil || !strings.Contains(err.Error(), "unique index") {
+		t.Fatalf("create unique index err=%v want unique index conflict", err)
+	}
+	if _, ok := findIndex(col.Meta().Indexes, "email"); ok {
+		t.Fatalf("collection meta gained failed email index: %+v", col.Meta().Indexes)
+	}
+	ids, err := col.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find failed index: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("failed index visible ids=%q want none", ids)
+	}
+}
+
 func TestCollectionInsertBatchBridge_RejectsPersistedUniqueConflictAtomically(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -93,6 +93,50 @@ func TestCollectionInsertBatchBridge_RoundTripWithSecondaryIndexes(t *testing.T)
 	}
 }
 
+func TestCollectionInsertBatchBridge_ReturnedIDsAndDocumentsAreOwned(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	inputID := []byte("u1")
+	inputDocument := []byte(`{"name":"ada"}`)
+	ids, err := col.InsertBatch(
+		[][]byte{inputID},
+		[][]byte{inputDocument},
+	)
+	if err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	inputID[0] = 'x'
+	inputDocument[9] = 'x'
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("returned ids=%q want owned u1", ids)
+	}
+
+	ids[0][0] = 'z'
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get original id after mutating returned id: %v", err)
+	}
+	if want := []byte(`{"name":"ada"}`); !bytes.Equal(got, want) {
+		t.Fatalf("original id value=%q want %q", got, want)
+	}
+	if got, err := col.Get([]byte("z1")); err != nil || got != nil {
+		t.Fatalf("mutated returned id lookup got=%q err=%v want missing", got, err)
+	}
+}
+
 func TestCollectionInsertBatchBridge_ReopenUsesPersistedRootDescriptors(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -137,6 +138,167 @@ func TestCollectionInsertBatchBridge_ReturnedIDsAndDocumentsAreOwned(t *testing.
 	}
 }
 
+func TestCollectionSingleInsertBufferedNoIndexReadsBeforeFlush(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	writer, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open writer: %v", err)
+	}
+	reader, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+
+	id := []byte("u1")
+	doc := []byte(`{"name":"ada"}`)
+	gotID, err := writer.Insert(id, doc)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	id[0] = 'x'
+	doc[9] = 'x'
+	if !bytes.Equal(gotID, []byte("u1")) {
+		t.Fatalf("returned id=%q want u1", gotID)
+	}
+	gotID[0] = 'z'
+
+	got, err := reader.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("reader get buffered doc: %v", err)
+	}
+	if want := []byte(`{"name":"ada"}`); !bytes.Equal(got, want) {
+		t.Fatalf("buffered doc=%q want %q", got, want)
+	}
+	got[9] = 'x'
+	again, err := writer.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("writer get buffered doc again: %v", err)
+	}
+	if want := []byte(`{"name":"ada"}`); !bytes.Equal(again, want) {
+		t.Fatalf("buffered doc after caller mutation=%q want %q", again, want)
+	}
+}
+
+func TestCollectionSingleInsertBufferedNoIndexFlushPersistsAfterReopen(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"ada"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	got, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get after reopen: %v", err)
+	}
+	if want := []byte(`{"name":"ada"}`); !bytes.Equal(got, want) {
+		t.Fatalf("reopened doc=%q want %q", got, want)
+	}
+}
+
+func TestCollectionSingleInsertBufferedNoIndexCloseFlushes(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"ada"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	got, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get after reopen: %v", err)
+	}
+	if want := []byte(`{"name":"ada"}`); !bytes.Equal(got, want) {
+		t.Fatalf("reopened close-flushed doc=%q want %q", got, want)
+	}
+}
+
+func TestCollectionSingleInsertBufferedNoIndexRejectsBufferedDuplicate(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"ada"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"grace"}`)); err == nil || !strings.Contains(err.Error(), "document already exists") {
+		t.Fatalf("duplicate err=%v want document already exists", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if want := []byte(`{"name":"ada"}`); !bytes.Equal(got, want) {
+		t.Fatalf("u1=%q want %q", got, want)
+	}
+}
+
 func TestCollectionInsertBatchBridge_ReopenUsesPersistedRootDescriptors(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})
@@ -187,6 +349,228 @@ func TestCollectionInsertBatchBridge_ReopenUsesPersistedRootDescriptors(t *testi
 	}
 	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
 		t.Fatalf("reopen email ids=%q want u1", ids)
+	}
+}
+
+func TestCollectionCachedCatalogRefreshesAfterCrossHandleWrite(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	reader, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reader collection: %v", err)
+	}
+	writer, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open writer collection: %v", err)
+	}
+
+	if got, err := reader.Get([]byte("u1")); err != nil || got != nil {
+		t.Fatalf("initial reader get got=%q err=%v want missing", got, err)
+	}
+	if _, err := writer.Insert([]byte("u1"), []byte(`{"name":"ada"}`)); err != nil {
+		t.Fatalf("writer insert: %v", err)
+	}
+	got, err := reader.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("reader get after writer insert: %v", err)
+	}
+	if want := []byte(`{"name":"ada"}`); !bytes.Equal(got, want) {
+		t.Fatalf("reader saw stale catalog value=%q want %q", got, want)
+	}
+}
+
+func TestCollectionSingleInsertMatchesSingleItemBatch(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		indexes []IndexDefinition
+	}{
+		{name: "no_index"},
+		{name: "indexed", indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+			if err != nil {
+				t.Fatalf("open db: %v", err)
+			}
+			defer func() { _ = d.Close() }()
+
+			mgr := NewCollectionManager(d)
+			insertMeta := &CollectionMeta{Name: "insert_users", Indexes: tc.indexes}
+			batchMeta := &CollectionMeta{Name: "batch_users", Indexes: tc.indexes}
+			if _, err := mgr.CreateCollection(insertMeta); err != nil {
+				t.Fatalf("create insert collection: %v", err)
+			}
+			if _, err := mgr.CreateCollection(batchMeta); err != nil {
+				t.Fatalf("create batch collection: %v", err)
+			}
+			insertCol, err := mgr.OpenCollection("insert_users")
+			if err != nil {
+				t.Fatalf("open insert collection: %v", err)
+			}
+			batchCol, err := mgr.OpenCollection("batch_users")
+			if err != nil {
+				t.Fatalf("open batch collection: %v", err)
+			}
+
+			doc := []byte(`{"email":"ada@example.com","city":"hnl"}`)
+			insertID, err := insertCol.Insert([]byte("u1"), doc)
+			if err != nil {
+				t.Fatalf("single insert: %v", err)
+			}
+			batchIDs, err := batchCol.InsertBatch([][]byte{[]byte("u1")}, [][]byte{doc})
+			if err != nil {
+				t.Fatalf("single-item batch insert: %v", err)
+			}
+			if len(batchIDs) != 1 || !bytes.Equal(insertID, batchIDs[0]) {
+				t.Fatalf("ids insert=%q batch=%q", insertID, batchIDs)
+			}
+
+			insertDoc, err := insertCol.Get([]byte("u1"))
+			if err != nil {
+				t.Fatalf("single get: %v", err)
+			}
+			batchDoc, err := batchCol.Get([]byte("u1"))
+			if err != nil {
+				t.Fatalf("batch get: %v", err)
+			}
+			if !bytes.Equal(insertDoc, batchDoc) {
+				t.Fatalf("documents differ: insert=%q batch=%q", insertDoc, batchDoc)
+			}
+			if len(tc.indexes) == 0 {
+				return
+			}
+			insertIDs, err := insertCol.FindByIndex("email", "ada@example.com")
+			if err != nil {
+				t.Fatalf("single find email: %v", err)
+			}
+			batchIndexIDs, err := batchCol.FindByIndex("email", "ada@example.com")
+			if err != nil {
+				t.Fatalf("batch find email: %v", err)
+			}
+			if !reflect.DeepEqual(insertIDs, batchIndexIDs) {
+				t.Fatalf("email ids differ: insert=%q batch=%q", insertIDs, batchIndexIDs)
+			}
+		})
+	}
+}
+
+func TestCollectionSingleInsertRejectsUniqueConflictAtomically(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com"}`)); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+	if _, err := col.Insert([]byte("u2"), []byte(`{"email":"ada@example.com"}`)); err == nil || !strings.Contains(err.Error(), "unique index") {
+		t.Fatalf("duplicate insert err=%v want unique index conflict", err)
+	}
+	got, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get failed insert: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("failed insert left primary doc=%q", got)
+	}
+	ids, err := col.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("email ids=%q want [u1]", ids)
+	}
+}
+
+func TestCollectionSingleDocumentReopenUsesPersistedRootDescriptors(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if _, err := col.Insert([]byte("u2"), []byte(`{"email":"grace@example.com"}`)); err != nil {
+		t.Fatalf("insert u2: %v", err)
+	}
+	if err := col.Delete([]byte("u1")); err != nil {
+		t.Fatalf("delete u1: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	got, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get deleted u1 after reopen: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("deleted u1 visible after reopen: %q", got)
+	}
+	got, err = reopenedCol.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2 after reopen: %v", err)
+	}
+	if want := []byte(`{"email":"grace@example.com"}`); !bytes.Equal(got, want) {
+		t.Fatalf("u2 after reopen=%q want %q", got, want)
+	}
+	ids, err := reopenedCol.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find deleted email after reopen: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("deleted email ids after reopen=%q want none", ids)
+	}
+	ids, err = reopenedCol.FindByIndex("email", "grace@example.com")
+	if err != nil {
+		t.Fatalf("find remaining email after reopen: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
+		t.Fatalf("remaining email ids after reopen=%q want [u2]", ids)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -374,6 +374,140 @@ func TestCollectionSingleInsertBufferedNoIndexRejectsConcurrentPrimaryRootChange
 	}
 }
 
+func TestRootDescriptorDeltaRejectsConcurrentSchemaChange(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	baseSystemRoot := snapshotSystemRoot(snap)
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatal("missing catalog")
+	}
+	baseMeta := catalog.meta
+	col.meta = baseMeta
+	rootName := collectionPrimaryRootName("users")
+	baseRoot := catalog.rootID(rootName)
+
+	indexer, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open indexer: %v", err)
+	}
+	if _, err := indexer.CreateIndex(IndexDefinition{Name: "email", Field: "email"}); err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+
+	iter, err := col.buildRootDescriptorSystemDeltaIterator(
+		baseSystemRoot,
+		[]string{rootName},
+		map[string]uint64{rootName: baseRoot},
+		[]uint64{baseRoot + 1},
+	)
+	if iter != nil {
+		_ = iter.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "concurrent schema modification") {
+		t.Fatalf("system delta err=%v want concurrent schema modification", err)
+	}
+}
+
+func TestCreateIndexSystemIteratorRejectsConcurrentPrimaryRootChange(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush u1: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatal("missing catalog")
+	}
+	baseMeta := catalog.meta
+	newMeta, normalizedDef, err := addIndexToCollectionMeta(baseMeta, IndexDefinition{Name: "email", Field: "email"})
+	if err != nil {
+		t.Fatalf("add index metadata: %v", err)
+	}
+	primaryRootName := collectionPrimaryRootName("users")
+	stateRootName := collectionIndexStateRootName("users")
+	secondaryRootName := collectionSecondaryRootName("users", normalizedDef.Name)
+	baseRootIDs := map[string]uint64{
+		primaryRootName:   catalog.rootID(primaryRootName),
+		stateRootName:     catalog.rootID(stateRootName),
+		secondaryRootName: catalog.rootID(secondaryRootName),
+	}
+
+	other, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open other writer: %v", err)
+	}
+	if _, err := other.Insert([]byte("u2"), []byte(`{"email":"grace@example.com"}`)); err != nil {
+		t.Fatalf("insert u2: %v", err)
+	}
+	if err := other.Flush(); err != nil {
+		t.Fatalf("flush u2: %v", err)
+	}
+
+	rootNames := []string{stateRootName, secondaryRootName}
+	iter, err := col.buildSchemaAndRootDescriptorSystemIterator(
+		baseMeta,
+		newMeta,
+		rootNames,
+		baseRootIDs,
+		[]uint64{baseRootIDs[primaryRootName] + 1, baseRootIDs[primaryRootName] + 2},
+	)
+	if iter != nil {
+		_ = iter.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "concurrent root modification") {
+		t.Fatalf("schema publish err=%v want concurrent root modification", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), primaryRootName) {
+		t.Fatalf("schema publish err=%v want primary root name %q", err, primaryRootName)
+	}
+}
+
 func TestCollectionInsertBatchBridge_ReopenUsesPersistedRootDescriptors(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -299,6 +299,81 @@ func TestCollectionSingleInsertBufferedNoIndexRejectsBufferedDuplicate(t *testin
 	}
 }
 
+func TestCollectionSingleInsertBufferedNoIndexRejectsConcurrentSchemaChange(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	writerMgr := NewCollectionManager(d)
+	if _, err := writerMgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	writer, err := writerMgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open writer: %v", err)
+	}
+	if _, err := writer.Insert([]byte("u1"), []byte(`{"email":"ada@example.com"}`)); err != nil {
+		t.Fatalf("buffer insert: %v", err)
+	}
+
+	indexMgr := NewCollectionManager(d)
+	indexer, err := indexMgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open indexer: %v", err)
+	}
+	if _, err := indexer.CreateIndex(IndexDefinition{Name: "email", Field: "email", Unique: true}); err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+
+	if _, err := writer.Insert([]byte("u2"), []byte(`{"email":"grace@example.com"}`)); err == nil || !strings.Contains(err.Error(), "concurrent schema modification") {
+		t.Fatalf("insert after schema change err=%v want concurrent schema modification", err)
+	}
+	if err := writer.Flush(); err == nil || !strings.Contains(err.Error(), "concurrent schema modification") {
+		t.Fatalf("flush after schema change err=%v want concurrent schema modification", err)
+	}
+}
+
+func TestCollectionSingleInsertBufferedNoIndexRejectsConcurrentPrimaryRootChange(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	leftMgr := NewCollectionManager(d)
+	if _, err := leftMgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	left, err := leftMgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open left writer: %v", err)
+	}
+	if _, err := left.Insert([]byte("u1"), []byte(`{"name":"ada"}`)); err != nil {
+		t.Fatalf("left buffer insert: %v", err)
+	}
+
+	rightMgr := NewCollectionManager(d)
+	right, err := rightMgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open right writer: %v", err)
+	}
+	if _, err := right.Insert([]byte("u2"), []byte(`{"name":"grace"}`)); err != nil {
+		t.Fatalf("right insert: %v", err)
+	}
+	if err := right.Flush(); err != nil {
+		t.Fatalf("right flush: %v", err)
+	}
+
+	if _, err := left.Insert([]byte("u3"), []byte(`{"name":"katherine"}`)); err == nil || !strings.Contains(err.Error(), "concurrent root modification") {
+		t.Fatalf("insert after root change err=%v want concurrent root modification", err)
+	}
+	if err := left.Flush(); err == nil || !strings.Contains(err.Error(), "concurrent root modification") {
+		t.Fatalf("flush after root change err=%v want concurrent root modification", err)
+	}
+}
+
 func TestCollectionInsertBatchBridge_ReopenUsesPersistedRootDescriptors(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9,6 +9,17 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
+func TestCollectionGetNilDBReturnsError(t *testing.T) {
+	col := &Collection{}
+	_, err := col.Get([]byte("u1"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "db is nil") {
+		t.Fatalf("Get nil db error=%v", err)
+	}
+}
+
 func TestCollectionInsertBatchBridge_RoundTripWithSecondaryIndexes(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/bench_test.go
+++ b/TreeDB/collections/bench_test.go
@@ -3,6 +3,7 @@ package collections_test
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -12,13 +13,27 @@ import (
 )
 
 const (
-	collectionBenchBatchSize = 256
-	collectionBenchSeedDocs  = 4096
-	collectionBenchCities    = 64
-	collectionBenchBackfill  = 1024
+	defaultCollectionBenchBatchSize = 8000
+	collectionBenchSeedDocs         = 4096
+	collectionBenchCities           = 64
+	collectionBenchBackfill         = 1024
 )
 
 var collectionBenchPayload = []byte(`{"name":"ada","city":"hnl","email":"ada@example.com","pad":"0123456789012345678901234567890123456789"}`)
+
+func benchmarkBatchSize(b *testing.B) int {
+	b.Helper()
+
+	raw := strings.TrimSpace(os.Getenv("TREEDB_COLLECTION_BENCH_BATCH_SIZE"))
+	if raw == "" {
+		return defaultCollectionBenchBatchSize
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		b.Fatalf("unsupported TREEDB_COLLECTION_BENCH_BATCH_SIZE=%q", raw)
+	}
+	return n
+}
 
 func benchmarkTreeDBProfile(b *testing.B) treedb.Profile {
 	b.Helper()
@@ -123,9 +138,10 @@ func benchmarkDocumentBatch(start, count int, indexed bool) ([][]byte, [][]byte)
 func seedBenchmarkCollection(b *testing.B, collection *collections.Collection, start, count int, indexed bool) [][]byte {
 	b.Helper()
 
+	targetBatchSize := benchmarkBatchSize(b)
 	allIDs := make([][]byte, 0, count)
-	for inserted := 0; inserted < count; inserted += collectionBenchBatchSize {
-		batchSize := collectionBenchBatchSize
+	for inserted := 0; inserted < count; inserted += targetBatchSize {
+		batchSize := targetBatchSize
 		if remaining := count - inserted; remaining < batchSize {
 			batchSize = remaining
 		}
@@ -160,13 +176,14 @@ func BenchmarkCollectionInsertProvidedID(b *testing.B) {
 
 func BenchmarkCollectionInsertBatchProvidedID(b *testing.B) {
 	_, collection := openBenchmarkCollection(b, "bench_insert_batch_provided")
+	targetBatchSize := benchmarkBatchSize(b)
 
 	b.ReportAllocs()
-	b.ReportMetric(float64(collectionBenchBatchSize), "target_docs/batch")
+	b.ReportMetric(float64(targetBatchSize), "target_docs/batch")
 	b.ResetTimer()
 	for inserted := 0; inserted < b.N; {
 		b.StopTimer()
-		batchSize := collectionBenchBatchSize
+		batchSize := targetBatchSize
 		if remaining := b.N - inserted; remaining < batchSize {
 			batchSize = remaining
 		}
@@ -223,13 +240,14 @@ func BenchmarkCollectionInsertWithSecondaryIndexes(b *testing.B) {
 
 func BenchmarkCollectionInsertBatchWithSecondaryIndexes(b *testing.B) {
 	_, collection := openBenchmarkCollection(b, "bench_insert_batch_secondary", secondaryIndexes()...)
+	targetBatchSize := benchmarkBatchSize(b)
 
 	b.ReportAllocs()
-	b.ReportMetric(float64(collectionBenchBatchSize), "target_docs/batch")
+	b.ReportMetric(float64(targetBatchSize), "target_docs/batch")
 	b.ResetTimer()
 	for inserted := 0; inserted < b.N; {
 		b.StopTimer()
-		batchSize := collectionBenchBatchSize
+		batchSize := targetBatchSize
 		if remaining := b.N - inserted; remaining < batchSize {
 			batchSize = remaining
 		}
@@ -245,13 +263,14 @@ func BenchmarkCollectionInsertBatchWithSecondaryIndexes(b *testing.B) {
 
 func BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes(b *testing.B) {
 	backend, collection := openBenchmarkCollection(b, "bench_insert_batch_checkpoint_secondary", secondaryIndexes()...)
+	targetBatchSize := benchmarkBatchSize(b)
 
 	b.ReportAllocs()
-	b.ReportMetric(float64(collectionBenchBatchSize), "target_docs/checkpoint")
+	b.ReportMetric(float64(targetBatchSize), "target_docs/checkpoint")
 	b.ResetTimer()
 	for inserted := 0; inserted < b.N; {
 		b.StopTimer()
-		batchSize := collectionBenchBatchSize
+		batchSize := targetBatchSize
 		if remaining := b.N - inserted; remaining < batchSize {
 			batchSize = remaining
 		}

--- a/TreeDB/collections/bench_test.go
+++ b/TreeDB/collections/bench_test.go
@@ -1,0 +1,361 @@
+package collections_test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	collectionBenchBatchSize = 256
+	collectionBenchSeedDocs  = 4096
+	collectionBenchCities    = 64
+	collectionBenchBackfill  = 1024
+)
+
+var collectionBenchPayload = []byte(`{"name":"ada","city":"hnl","email":"ada@example.com","pad":"0123456789012345678901234567890123456789"}`)
+
+func benchmarkTreeDBProfile(b *testing.B) treedb.Profile {
+	b.Helper()
+
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("TREEDB_COLLECTION_BENCH_ENGINE"))) {
+	case "", "backend_direct_fast", "backend_direct", "cached", "fast":
+		return treedb.ProfileFast
+	case "backend_direct_wal_on_fast", "wal_on_fast":
+		return treedb.ProfileWALOnFast
+	case "durable":
+		return treedb.ProfileDurable
+	case "bench":
+		return treedb.ProfileBench
+	default:
+		b.Fatalf("unsupported TREEDB_COLLECTION_BENCH_ENGINE=%q", os.Getenv("TREEDB_COLLECTION_BENCH_ENGINE"))
+		return treedb.ProfileFast
+	}
+}
+
+func openBenchmarkBackend(b *testing.B, dir string) (*backenddb.DB, func() error) {
+	b.Helper()
+
+	opts := treedb.OptionsFor(benchmarkTreeDBProfile(b), dir)
+	// Native collections currently run on the backend-root API, not the cached
+	// public wrapper. Backend direct opens do not wire the cached leaf-page log
+	// required by IndexOuterLeavesInValueLog, so keep the other fast-profile
+	// knobs while using backend-native leaf storage.
+	opts.IndexOuterLeavesInValueLog = false
+	opts.IndexInternalBaseDelta = true
+	backend, cleanup, err := treedb.OpenBackend(opts)
+	if err != nil {
+		b.Fatalf("open backend: %v", err)
+	}
+	return backend, cleanup
+}
+
+func openBenchmarkCollection(b *testing.B, name string, indexes ...collections.IndexDefinition) (*backenddb.DB, *collections.Collection) {
+	b.Helper()
+
+	backend, cleanup := openBenchmarkBackend(b, b.TempDir())
+	b.Cleanup(func() {
+		if err := cleanup(); err != nil {
+			b.Errorf("close backend: %v", err)
+		}
+	})
+
+	manager := collections.NewCollectionManager(backend)
+	if _, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name:    name,
+		Indexes: indexes,
+	}); err != nil {
+		b.Fatalf("create collection: %v", err)
+	}
+	collection, err := manager.OpenCollection(name)
+	if err != nil {
+		b.Fatalf("open collection: %v", err)
+	}
+	return backend, collection
+}
+
+func benchmarkSyncBoundary(b *testing.B, backend *backenddb.DB) {
+	b.Helper()
+
+	batch := backend.NewBatch()
+	if err := batch.WriteSync(); err != nil {
+		_ = batch.Close()
+		b.Fatalf("sync boundary: %v", err)
+	}
+	if err := batch.Close(); err != nil {
+		b.Fatalf("close sync boundary batch: %v", err)
+	}
+}
+
+func benchmarkDocumentID(n int) []byte {
+	return []byte(fmt.Sprintf("u-%09d", n))
+}
+
+func benchmarkIndexedDocument(n int) []byte {
+	return []byte(fmt.Sprintf(
+		`{"name":"user-%09d","email":"user-%09d@example.com","city":"city-%02d","pad":"01234567890123456789"}`,
+		n,
+		n,
+		n%collectionBenchCities,
+	))
+}
+
+func benchmarkDocumentBatch(start, count int, indexed bool) ([][]byte, [][]byte) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		docNum := start + i
+		ids[i] = benchmarkDocumentID(docNum)
+		if indexed {
+			docs[i] = benchmarkIndexedDocument(docNum)
+		} else {
+			docs[i] = collectionBenchPayload
+		}
+	}
+	return ids, docs
+}
+
+func seedBenchmarkCollection(b *testing.B, collection *collections.Collection, start, count int, indexed bool) [][]byte {
+	b.Helper()
+
+	allIDs := make([][]byte, 0, count)
+	for inserted := 0; inserted < count; inserted += collectionBenchBatchSize {
+		batchSize := collectionBenchBatchSize
+		if remaining := count - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		ids, docs := benchmarkDocumentBatch(start+inserted, batchSize, indexed)
+		if _, err := collection.InsertBatch(ids, docs); err != nil {
+			b.Fatalf("seed insert batch: %v", err)
+		}
+		allIDs = append(allIDs, ids...)
+	}
+	return allIDs
+}
+
+func secondaryIndexes() []collections.IndexDefinition {
+	return []collections.IndexDefinition{
+		{Name: "email_idx", Field: "email", Unique: true},
+		{Name: "city_idx", Field: "city"},
+	}
+}
+
+func BenchmarkCollectionInsertProvidedID(b *testing.B) {
+	_, collection := openBenchmarkCollection(b, "bench_insert_provided")
+	ids, docs := benchmarkDocumentBatch(0, b.N, false)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := collection.Insert(ids[i], docs[i]); err != nil {
+			b.Fatalf("insert: %v", err)
+		}
+	}
+}
+
+func BenchmarkCollectionInsertBatchProvidedID(b *testing.B) {
+	_, collection := openBenchmarkCollection(b, "bench_insert_batch_provided")
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(collectionBenchBatchSize), "target_docs/batch")
+	b.ResetTimer()
+	for inserted := 0; inserted < b.N; {
+		b.StopTimer()
+		batchSize := collectionBenchBatchSize
+		if remaining := b.N - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		ids, docs := benchmarkDocumentBatch(inserted, batchSize, false)
+		b.StartTimer()
+
+		if _, err := collection.InsertBatch(ids, docs); err != nil {
+			b.Fatalf("insert batch: %v", err)
+		}
+		inserted += batchSize
+	}
+}
+
+func BenchmarkCollectionGetByID(b *testing.B) {
+	backend, collection := openBenchmarkCollection(b, "bench_get")
+	ids := seedBenchmarkCollection(b, collection, 0, collectionBenchSeedDocs, false)
+	benchmarkSyncBoundary(b, backend)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := collection.Get(ids[i%len(ids)]); err != nil {
+			b.Fatalf("get: %v", err)
+		}
+	}
+}
+
+func BenchmarkCollectionDeleteByID(b *testing.B) {
+	backend, collection := openBenchmarkCollection(b, "bench_delete")
+	ids := seedBenchmarkCollection(b, collection, 0, b.N, false)
+	benchmarkSyncBoundary(b, backend)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := collection.Delete(ids[i]); err != nil {
+			b.Fatalf("delete: %v", err)
+		}
+	}
+}
+
+func BenchmarkCollectionInsertWithSecondaryIndexes(b *testing.B) {
+	_, collection := openBenchmarkCollection(b, "bench_insert_secondary", secondaryIndexes()...)
+	ids, docs := benchmarkDocumentBatch(0, b.N, true)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := collection.Insert(ids[i], docs[i]); err != nil {
+			b.Fatalf("insert with secondary indexes: %v", err)
+		}
+	}
+}
+
+func BenchmarkCollectionInsertBatchWithSecondaryIndexes(b *testing.B) {
+	_, collection := openBenchmarkCollection(b, "bench_insert_batch_secondary", secondaryIndexes()...)
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(collectionBenchBatchSize), "target_docs/batch")
+	b.ResetTimer()
+	for inserted := 0; inserted < b.N; {
+		b.StopTimer()
+		batchSize := collectionBenchBatchSize
+		if remaining := b.N - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		ids, docs := benchmarkDocumentBatch(inserted, batchSize, true)
+		b.StartTimer()
+
+		if _, err := collection.InsertBatch(ids, docs); err != nil {
+			b.Fatalf("insert batch with secondary indexes: %v", err)
+		}
+		inserted += batchSize
+	}
+}
+
+func BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes(b *testing.B) {
+	backend, collection := openBenchmarkCollection(b, "bench_insert_batch_checkpoint_secondary", secondaryIndexes()...)
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(collectionBenchBatchSize), "target_docs/checkpoint")
+	b.ResetTimer()
+	for inserted := 0; inserted < b.N; {
+		b.StopTimer()
+		batchSize := collectionBenchBatchSize
+		if remaining := b.N - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		ids, docs := benchmarkDocumentBatch(inserted, batchSize, true)
+		b.StartTimer()
+
+		if _, err := collection.InsertBatch(ids, docs); err != nil {
+			b.Fatalf("insert batch with secondary indexes: %v", err)
+		}
+		benchmarkSyncBoundary(b, backend)
+		inserted += batchSize
+	}
+}
+
+func BenchmarkCollectionDeleteWithSecondaryIndexes(b *testing.B) {
+	backend, collection := openBenchmarkCollection(b, "bench_delete_secondary", secondaryIndexes()...)
+	ids := seedBenchmarkCollection(b, collection, 0, b.N, true)
+	benchmarkSyncBoundary(b, backend)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := collection.Delete(ids[i]); err != nil {
+			b.Fatalf("delete with secondary indexes: %v", err)
+		}
+	}
+}
+
+func BenchmarkSecondaryLookupUnique(b *testing.B) {
+	backend, collection := openBenchmarkCollection(
+		b,
+		"bench_secondary_unique",
+		collections.IndexDefinition{Name: "email_idx", Field: "email", Unique: true},
+	)
+	seedBenchmarkCollection(b, collection, 0, collectionBenchSeedDocs, true)
+	benchmarkSyncBoundary(b, backend)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		email := fmt.Sprintf("user-%09d@example.com", i%collectionBenchSeedDocs)
+		if _, err := collection.FindByIndex("email_idx", email); err != nil {
+			b.Fatalf("lookup unique: %v", err)
+		}
+	}
+}
+
+func BenchmarkSecondaryLookupNonUnique(b *testing.B) {
+	backend, collection := openBenchmarkCollection(
+		b,
+		"bench_secondary_non_unique",
+		collections.IndexDefinition{Name: "city_idx", Field: "city"},
+	)
+	seedBenchmarkCollection(b, collection, 0, collectionBenchSeedDocs, true)
+	benchmarkSyncBoundary(b, backend)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		city := fmt.Sprintf("city-%02d", i%collectionBenchCities)
+		if _, err := collection.FindByIndex("city_idx", city); err != nil {
+			b.Fatalf("lookup non-unique: %v", err)
+		}
+	}
+}
+
+func BenchmarkCollectionCreateIndexBackfillExistingDocs(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		dir, err := os.MkdirTemp("", "gomap_collections_backfill_*")
+		if err != nil {
+			b.Fatalf("create temp dir: %v", err)
+		}
+		backend, cleanup := openBenchmarkBackend(b, dir)
+		manager := collections.NewCollectionManager(backend)
+		if _, err := manager.CreateCollection(&collections.CollectionMeta{Name: "bench_backfill"}); err != nil {
+			_ = cleanup()
+			_ = os.RemoveAll(dir)
+			b.Fatalf("create collection: %v", err)
+		}
+		collection, err := manager.OpenCollection("bench_backfill")
+		if err != nil {
+			_ = cleanup()
+			_ = os.RemoveAll(dir)
+			b.Fatalf("open collection: %v", err)
+		}
+		seedBenchmarkCollection(b, collection, 0, collectionBenchBackfill, true)
+		benchmarkSyncBoundary(b, backend)
+		b.StartTimer()
+
+		if _, err := collection.CreateIndex(collections.IndexDefinition{Name: "email_idx", Field: "email", Unique: true}); err != nil {
+			b.Fatalf("create index with backfill: %v", err)
+		}
+
+		b.StopTimer()
+		if err := cleanup(); err != nil {
+			_ = os.RemoveAll(dir)
+			b.Fatalf("close backend: %v", err)
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			b.Fatalf("remove temp dir: %v", err)
+		}
+		b.StartTimer()
+	}
+}

--- a/TreeDB/collections/bench_test.go
+++ b/TreeDB/collections/bench_test.go
@@ -39,9 +39,9 @@ func benchmarkTreeDBProfile(b *testing.B) treedb.Profile {
 	b.Helper()
 
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("TREEDB_COLLECTION_BENCH_ENGINE"))) {
-	case "", "backend_direct_fast", "backend_direct", "cached", "fast":
+	case "", "production_fast", "backend_direct_fast", "backend_direct", "cached", "fast":
 		return treedb.ProfileFast
-	case "backend_direct_wal_on_fast", "wal_on_fast":
+	case "production_wal_on_fast", "backend_direct_wal_on_fast", "wal_on_fast":
 		return treedb.ProfileWALOnFast
 	case "durable":
 		return treedb.ProfileDurable
@@ -53,17 +53,56 @@ func benchmarkTreeDBProfile(b *testing.B) treedb.Profile {
 	}
 }
 
+func benchmarkBoolEnv(tb testing.TB, name string, def bool) bool {
+	tb.Helper()
+
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		tb.Fatalf("unsupported %s=%q", name, raw)
+	}
+	return v
+}
+
+func benchmarkRootStoragePolicy(outerLeavesInVLog bool) collections.RootStoragePolicy {
+	if outerLeavesInVLog {
+		return collections.RootStorageCompressed
+	}
+	return collections.RootStorageFast
+}
+
+func benchmarkCollectionStoragePolicy(tb testing.TB) (dataOuter, indexOuter bool) {
+	tb.Helper()
+
+	dataOuter = benchmarkBoolEnv(tb, "TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG", true)
+	indexOuter = benchmarkBoolEnv(tb, "TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG", false)
+	return dataOuter, indexOuter
+}
+
+func TestBenchmarkCollectionStoragePolicyDefaultsProductionMainline(t *testing.T) {
+	t.Setenv("TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG", "")
+	t.Setenv("TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG", "")
+	dataOuter, indexOuter := benchmarkCollectionStoragePolicy(t)
+	if !dataOuter || indexOuter {
+		t.Fatalf("benchmark storage defaults data_outer=%t index_outer=%t want production-mainline data_outer=true index_outer=false", dataOuter, indexOuter)
+	}
+}
+
 func openBenchmarkBackend(b *testing.B, dir string) (*backenddb.DB, func() error) {
 	b.Helper()
 
+	dataOuter, indexOuter := benchmarkCollectionStoragePolicy(b)
 	opts := treedb.OptionsFor(benchmarkTreeDBProfile(b), dir)
-	// Native collections currently run on the backend-root API, not the cached
-	// public wrapper. Backend direct opens do not wire the cached leaf-page log
-	// required by IndexOuterLeavesInValueLog, so keep the other fast-profile
-	// knobs while using backend-native leaf storage.
-	opts.IndexOuterLeavesInValueLog = false
-	opts.IndexInternalBaseDelta = true
-	backend, cleanup, err := treedb.OpenBackend(opts)
+	opts.IndexOuterLeavesInValueLog = dataOuter || indexOuter
+	opts.IndexInternalBaseDelta = !opts.IndexOuterLeavesInValueLog
+	open := treedb.OpenBackend
+	if opts.IndexOuterLeavesInValueLog {
+		open = treedb.OpenBackendWithCachedLeafLog
+	}
+	backend, cleanup, err := open(opts)
 	if err != nil {
 		b.Fatalf("open backend: %v", err)
 	}
@@ -81,8 +120,16 @@ func openBenchmarkCollection(b *testing.B, name string, indexes ...collections.I
 	})
 
 	manager := collections.NewCollectionManager(backend)
+	dataOuter, indexOuter := benchmarkCollectionStoragePolicy(b)
+	for i := range indexes {
+		indexes[i].StoragePolicy = benchmarkRootStoragePolicy(indexOuter)
+	}
 	if _, err := manager.CreateCollection(&collections.CollectionMeta{
-		Name:    name,
+		Name: name,
+		Options: collections.CollectionOptions{
+			DataRootStoragePolicy:   benchmarkRootStoragePolicy(dataOuter),
+			IndexStateStoragePolicy: benchmarkRootStoragePolicy(dataOuter),
+		},
 		Indexes: indexes,
 	}); err != nil {
 		b.Fatalf("create collection: %v", err)
@@ -107,17 +154,41 @@ func benchmarkSyncBoundary(b *testing.B, backend *backenddb.DB) {
 	}
 }
 
+func appendZeroPaddedInt(dst []byte, n, width int) []byte {
+	var scratch [20]byte
+	pos := len(scratch)
+	if n == 0 {
+		pos--
+		scratch[pos] = '0'
+	} else {
+		for n > 0 {
+			pos--
+			scratch[pos] = byte('0' + n%10)
+			n /= 10
+		}
+	}
+	for pad := width - (len(scratch) - pos); pad > 0; pad-- {
+		dst = append(dst, '0')
+	}
+	return append(dst, scratch[pos:]...)
+}
+
 func benchmarkDocumentID(n int) []byte {
-	return []byte(fmt.Sprintf("u-%09d", n))
+	out := make([]byte, 0, len("u-")+9)
+	out = append(out, "u-"...)
+	return appendZeroPaddedInt(out, n, 9)
 }
 
 func benchmarkIndexedDocument(n int) []byte {
-	return []byte(fmt.Sprintf(
-		`{"name":"user-%09d","email":"user-%09d@example.com","city":"city-%02d","pad":"01234567890123456789"}`,
-		n,
-		n,
-		n%collectionBenchCities,
-	))
+	out := make([]byte, 0, 112)
+	out = append(out, `{"name":"user-`...)
+	out = appendZeroPaddedInt(out, n, 9)
+	out = append(out, `","email":"user-`...)
+	out = appendZeroPaddedInt(out, n, 9)
+	out = append(out, `@example.com","city":"city-`...)
+	out = appendZeroPaddedInt(out, n%collectionBenchCities, 2)
+	out = append(out, `","pad":"01234567890123456789"}`...)
+	return out
 }
 
 func benchmarkDocumentBatch(start, count int, indexed bool) ([][]byte, [][]byte) {
@@ -209,6 +280,24 @@ func BenchmarkCollectionGetByID(b *testing.B) {
 			b.Fatalf("get: %v", err)
 		}
 	}
+}
+
+func BenchmarkCollectionGetByIDParallel(b *testing.B) {
+	backend, collection := openBenchmarkCollection(b, "bench_get_parallel")
+	ids := seedBenchmarkCollection(b, collection, 0, collectionBenchSeedDocs, false)
+	benchmarkSyncBoundary(b, backend)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if _, err := collection.Get(ids[i%len(ids)]); err != nil {
+				b.Errorf("parallel get: %v", err)
+			}
+			i++
+		}
+	})
 }
 
 func BenchmarkCollectionDeleteByID(b *testing.B) {
@@ -348,7 +437,14 @@ func BenchmarkCollectionCreateIndexBackfillExistingDocs(b *testing.B) {
 		}
 		backend, cleanup := openBenchmarkBackend(b, dir)
 		manager := collections.NewCollectionManager(backend)
-		if _, err := manager.CreateCollection(&collections.CollectionMeta{Name: "bench_backfill"}); err != nil {
+		dataOuter, indexOuter := benchmarkCollectionStoragePolicy(b)
+		if _, err := manager.CreateCollection(&collections.CollectionMeta{
+			Name: "bench_backfill",
+			Options: collections.CollectionOptions{
+				DataRootStoragePolicy:   benchmarkRootStoragePolicy(dataOuter),
+				IndexStateStoragePolicy: benchmarkRootStoragePolicy(dataOuter),
+			},
+		}); err != nil {
 			_ = cleanup()
 			_ = os.RemoveAll(dir)
 			b.Fatalf("create collection: %v", err)
@@ -363,7 +459,12 @@ func BenchmarkCollectionCreateIndexBackfillExistingDocs(b *testing.B) {
 		benchmarkSyncBoundary(b, backend)
 		b.StartTimer()
 
-		if _, err := collection.CreateIndex(collections.IndexDefinition{Name: "email_idx", Field: "email", Unique: true}); err != nil {
+		if _, err := collection.CreateIndex(collections.IndexDefinition{
+			Name:          "email_idx",
+			Field:         "email",
+			Unique:        true,
+			StoragePolicy: benchmarkRootStoragePolicy(indexOuter),
+		}); err != nil {
 			b.Fatalf("create index with backfill: %v", err)
 		}
 

--- a/TreeDB/collections/native_default_test.go
+++ b/TreeDB/collections/native_default_test.go
@@ -1,0 +1,37 @@
+package collections
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCollectionsRuntimeHasNoOracleOrTranslationSelectors(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for _, name := range []string{"api.go", "planner.go"} {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		src := string(data)
+		for _, forbidden := range []string{
+			"oracle",
+			"native-fastpath",
+			"TREEDB_COLLECTION_PATH_LABEL",
+			"executionPath",
+			"detached",
+			"overlay",
+			"replay",
+		} {
+			if strings.Contains(src, forbidden) {
+				t.Fatalf("%s contains forbidden runtime selector/translation token %q", name, forbidden)
+			}
+		}
+	}
+}

--- a/TreeDB/collections/overhead_bench_test.go
+++ b/TreeDB/collections/overhead_bench_test.go
@@ -31,16 +31,40 @@ func overheadBenchBatchSize(b *testing.B) int {
 }
 
 func overheadBenchDocumentID(n int) []byte {
-	return []byte(fmt.Sprintf("u-%09d", n))
+	out := make([]byte, 0, len("u-")+9)
+	out = append(out, "u-"...)
+	return appendOverheadBenchZeroPaddedInt(out, n, 9)
 }
 
 func overheadBenchIndexedDocument(n int) []byte {
-	return []byte(fmt.Sprintf(
-		`{"name":"user-%09d","email":"user-%09d@example.com","city":"city-%02d","pad":"01234567890123456789"}`,
-		n,
-		n,
-		n%overheadBenchCities,
-	))
+	out := make([]byte, 0, 112)
+	out = append(out, `{"name":"user-`...)
+	out = appendOverheadBenchZeroPaddedInt(out, n, 9)
+	out = append(out, `","email":"user-`...)
+	out = appendOverheadBenchZeroPaddedInt(out, n, 9)
+	out = append(out, `@example.com","city":"city-`...)
+	out = appendOverheadBenchZeroPaddedInt(out, n%overheadBenchCities, 2)
+	out = append(out, `","pad":"01234567890123456789"}`...)
+	return out
+}
+
+func appendOverheadBenchZeroPaddedInt(dst []byte, n, width int) []byte {
+	var scratch [20]byte
+	pos := len(scratch)
+	if n == 0 {
+		pos--
+		scratch[pos] = '0'
+	} else {
+		for n > 0 {
+			pos--
+			scratch[pos] = byte('0' + n%10)
+			n /= 10
+		}
+	}
+	for pad := width - (len(scratch) - pos); pad > 0; pad-- {
+		dst = append(dst, '0')
+	}
+	return append(dst, scratch[pos:]...)
 }
 
 func overheadBenchDocumentBatch(count int, indexed bool) ([][]byte, [][]byte) {
@@ -80,9 +104,11 @@ func BenchmarkCollectionOverheadPlanNoIndex(b *testing.B) {
 		if remaining := b.N - planned; remaining < n {
 			n = remaining
 		}
-		if _, err := planner.planInsertBatch(ids[:n], docs[:n]); err != nil {
+		plan, err := planner.planInsertBatch(ids[:n], docs[:n])
+		if err != nil {
 			b.Fatalf("plan no-index batch: %v", err)
 		}
+		resetCollectionRunTables(plan.runs)
 		planned += n
 	}
 }
@@ -100,9 +126,11 @@ func BenchmarkCollectionOverheadPlanIndexed(b *testing.B) {
 		if remaining := b.N - planned; remaining < n {
 			n = remaining
 		}
-		if _, err := planner.planInsertBatch(ids[:n], docs[:n]); err != nil {
+		plan, err := planner.planInsertBatch(ids[:n], docs[:n])
+		if err != nil {
 			b.Fatalf("plan indexed batch: %v", err)
 		}
+		resetCollectionRunTables(plan.runs)
 		planned += n
 	}
 }
@@ -207,14 +235,10 @@ func overheadBenchPlanIndexedPrecomputedState(
 				continue
 			}
 			for _, encoded := range items[i].state[runtime.def.name] {
-				prefix, err := indexValuePrefix(encoded)
-				if err != nil {
-					return err
-				}
 				uniqueProbes = append(uniqueProbes, uniqueProbeCandidate{
-					indexName:  runtime.def.name,
-					prefix:     prefix,
-					documentID: items[i].id,
+					indexName:    runtime.def.name,
+					encodedValue: encoded,
+					documentID:   items[i].id,
 				})
 			}
 		}
@@ -231,11 +255,12 @@ func overheadBenchPlanIndexedPrecomputedState(
 	if err := planner.emitPrimaryRun(plan, items, primaryOrder); err != nil {
 		return err
 	}
-	if err := planner.emitIndexStateRun(plan, items); err != nil {
+	if err := planner.emitIndexStateRun(plan, items, runtimes); err != nil {
 		return err
 	}
 	if err := planner.emitSecondaryRuns(plan, items, runtimes); err != nil {
 		return err
 	}
+	resetCollectionRunTables(plan.runs)
 	return nil
 }

--- a/TreeDB/collections/overhead_bench_test.go
+++ b/TreeDB/collections/overhead_bench_test.go
@@ -1,0 +1,241 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	overheadBenchDefaultBatchSize = 8000
+	overheadBenchCities           = 64
+)
+
+var overheadBenchPayload = []byte(`{"name":"ada","city":"hnl","email":"ada@example.com","pad":"0123456789012345678901234567890123456789"}`)
+
+func overheadBenchBatchSize(b *testing.B) int {
+	b.Helper()
+
+	raw := strings.TrimSpace(os.Getenv("TREEDB_COLLECTION_BENCH_BATCH_SIZE"))
+	if raw == "" {
+		return overheadBenchDefaultBatchSize
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		b.Fatalf("unsupported TREEDB_COLLECTION_BENCH_BATCH_SIZE=%q", raw)
+	}
+	return n
+}
+
+func overheadBenchDocumentID(n int) []byte {
+	return []byte(fmt.Sprintf("u-%09d", n))
+}
+
+func overheadBenchIndexedDocument(n int) []byte {
+	return []byte(fmt.Sprintf(
+		`{"name":"user-%09d","email":"user-%09d@example.com","city":"city-%02d","pad":"01234567890123456789"}`,
+		n,
+		n,
+		n%overheadBenchCities,
+	))
+}
+
+func overheadBenchDocumentBatch(count int, indexed bool) ([][]byte, [][]byte) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		ids[i] = overheadBenchDocumentID(i)
+		if indexed {
+			docs[i] = overheadBenchIndexedDocument(i)
+		} else {
+			docs[i] = overheadBenchPayload
+		}
+	}
+	return ids, docs
+}
+
+func overheadBenchIndexedPlanner() insertBatchPlanner {
+	return insertBatchPlanner{
+		collection: "users",
+		indexes: []indexDefinition{
+			{name: "email_idx", field: "email", unique: true},
+			{name: "city_idx", field: "city"},
+		},
+	}
+}
+
+func BenchmarkCollectionOverheadPlanNoIndex(b *testing.B) {
+	batchSize := overheadBenchBatchSize(b)
+	ids, docs := overheadBenchDocumentBatch(batchSize, false)
+	planner := insertBatchPlanner{collection: "users"}
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(batchSize), "target_docs/batch")
+	b.ResetTimer()
+	for planned := 0; planned < b.N; {
+		n := batchSize
+		if remaining := b.N - planned; remaining < n {
+			n = remaining
+		}
+		if _, err := planner.planInsertBatch(ids[:n], docs[:n]); err != nil {
+			b.Fatalf("plan no-index batch: %v", err)
+		}
+		planned += n
+	}
+}
+
+func BenchmarkCollectionOverheadPlanIndexed(b *testing.B) {
+	batchSize := overheadBenchBatchSize(b)
+	ids, docs := overheadBenchDocumentBatch(batchSize, true)
+	planner := overheadBenchIndexedPlanner()
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(batchSize), "target_docs/batch")
+	b.ResetTimer()
+	for planned := 0; planned < b.N; {
+		n := batchSize
+		if remaining := b.N - planned; remaining < n {
+			n = remaining
+		}
+		if _, err := planner.planInsertBatch(ids[:n], docs[:n]); err != nil {
+			b.Fatalf("plan indexed batch: %v", err)
+		}
+		planned += n
+	}
+}
+
+func BenchmarkCollectionOverheadIndexStateJSONExtraction(b *testing.B) {
+	batchSize := overheadBenchBatchSize(b)
+	_, docs := overheadBenchDocumentBatch(batchSize, true)
+	planner := overheadBenchIndexedPlanner()
+	runtimes, err := planner.indexRuntimes()
+	if err != nil {
+		b.Fatalf("index runtimes: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(len(runtimes)), "indexes/doc")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		state, err := indexStateForDocument(docs[i%batchSize], runtimes, collectionOptions{})
+		if err != nil {
+			b.Fatalf("extract index state: %v", err)
+		}
+		if len(state) != len(runtimes) {
+			b.Fatalf("index state len=%d want=%d", len(state), len(runtimes))
+		}
+	}
+}
+
+func BenchmarkCollectionOverheadPlanIndexedPrecomputedState(b *testing.B) {
+	batchSize := overheadBenchBatchSize(b)
+	ids, docs := overheadBenchDocumentBatch(batchSize, true)
+	planner := overheadBenchIndexedPlanner()
+	runtimes, err := planner.indexRuntimes()
+	if err != nil {
+		b.Fatalf("index runtimes: %v", err)
+	}
+	states := make([]documentIndexState, len(docs))
+	for i := range docs {
+		state, err := indexStateForDocument(docs[i], runtimes, collectionOptions{})
+		if err != nil {
+			b.Fatalf("precompute index state: %v", err)
+		}
+		states[i] = state
+	}
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(batchSize), "target_docs/batch")
+	b.ResetTimer()
+	for planned := 0; planned < b.N; {
+		n := batchSize
+		if remaining := b.N - planned; remaining < n {
+			n = remaining
+		}
+		if err := overheadBenchPlanIndexedPrecomputedState(planner, runtimes, ids[:n], docs[:n], states[:n]); err != nil {
+			b.Fatalf("plan indexed precomputed batch: %v", err)
+		}
+		planned += n
+	}
+}
+
+func overheadBenchPlanIndexedPrecomputedState(
+	planner insertBatchPlanner,
+	runtimes []indexRuntime,
+	ids, documents [][]byte,
+	states []documentIndexState,
+) error {
+	if len(ids) != len(documents) || len(ids) != len(states) {
+		return fmt.Errorf("collections: precomputed batch length mismatch")
+	}
+	if planner.primaryRoot == "" {
+		planner.primaryRoot = planner.collection + "/primary"
+	}
+	if planner.indexStateRoot == "" {
+		planner.indexStateRoot = planner.collection + "/index-state"
+	}
+	if planner.buildPrimaryVal == nil {
+		planner.buildPrimaryVal = borrowPrimaryDocument
+	}
+
+	items := make([]insertBatchItem, len(documents))
+	resultIDs := make([][]byte, len(documents))
+	for i := range documents {
+		if len(ids[i]) == 0 {
+			return fmt.Errorf("collections: document id cannot be empty")
+		}
+		id := bytes.Clone(ids[i])
+		items[i] = insertBatchItem{
+			id:       id,
+			document: documents[i],
+			state:    states[i],
+		}
+		resultIDs[i] = id
+	}
+
+	primaryOrder := sortedItemOrderByKey(items, func(item *insertBatchItem) []byte { return item.id })
+	if err := rejectDuplicateDocumentIDs(items, primaryOrder); err != nil {
+		return err
+	}
+	uniqueProbes := make([]uniqueProbeCandidate, 0, len(items))
+	for i := range items {
+		for _, runtime := range runtimes {
+			if !runtime.def.unique {
+				continue
+			}
+			for _, encoded := range items[i].state[runtime.def.name] {
+				prefix, err := indexValuePrefix(encoded)
+				if err != nil {
+					return err
+				}
+				uniqueProbes = append(uniqueProbes, uniqueProbeCandidate{
+					indexName:  runtime.def.name,
+					prefix:     prefix,
+					documentID: items[i].id,
+				})
+			}
+		}
+	}
+	uniqueProbeRuns, err := buildUniqueProbeRuns(uniqueProbes)
+	if err != nil {
+		return err
+	}
+
+	plan := &insertBatchPlan{
+		resultIDs:       resultIDs,
+		uniqueProbeRuns: uniqueProbeRuns,
+	}
+	if err := planner.emitPrimaryRun(plan, items, primaryOrder); err != nil {
+		return err
+	}
+	if err := planner.emitIndexStateRun(plan, items); err != nil {
+		return err
+	}
+	if err := planner.emitSecondaryRuns(plan, items, runtimes); err != nil {
+		return err
+	}
+	return nil
+}

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -352,7 +352,7 @@ func (p insertBatchPlanner) emitIndexStateRun(plan *insertBatchPlan, items []ins
 	order := sortedItemOrderByKey(items, func(item *insertBatchItem) []byte { return item.id })
 	table := newCollectionRunTable(len(items))
 	for _, idx := range order {
-		raw, err := encodeDocumentIndexState(items[idx].state)
+		raw, err := encodeNormalizedDocumentIndexState(items[idx].state)
 		if err != nil {
 			return err
 		}
@@ -448,7 +448,7 @@ func indexStateForDocument(document []byte, runtimes []indexRuntime, opts collec
 			}
 			encoded = append(encoded, next)
 		}
-		encoded = normalizeEncodedIndexValues(encoded)
+		encoded = normalizeOwnedEncodedIndexValues(encoded)
 		if len(encoded) > 0 {
 			state[runtime.def.name] = encoded
 		}
@@ -457,6 +457,14 @@ func indexStateForDocument(document []byte, runtimes []indexRuntime, opts collec
 }
 
 func encodeDocumentIndexState(state documentIndexState) ([]byte, error) {
+	return encodeDocumentIndexStateWithOptions(state, true)
+}
+
+func encodeNormalizedDocumentIndexState(state documentIndexState) ([]byte, error) {
+	return encodeDocumentIndexStateWithOptions(state, false)
+}
+
+func encodeDocumentIndexStateWithOptions(state documentIndexState, normalizeValues bool) ([]byte, error) {
 	if state == nil {
 		state = make(documentIndexState)
 	}
@@ -465,7 +473,16 @@ func encodeDocumentIndexState(state documentIndexState) ([]byte, error) {
 		if indexName == "" {
 			return nil, errors.New("collections: index state name cannot be empty")
 		}
-		state[indexName] = normalizeEncodedIndexValues(values)
+		if normalizeValues {
+			values = normalizeEncodedIndexValues(values)
+		} else {
+			values = filterEmptyEncodedIndexValues(values)
+		}
+		if len(values) == 0 {
+			delete(state, indexName)
+			continue
+		}
+		state[indexName] = values
 		names = append(names, indexName)
 	}
 	sort.Strings(names)
@@ -566,6 +583,41 @@ func normalizeEncodedIndexValues(values [][]byte) [][]byte {
 			continue
 		}
 		out = append(out, value)
+	}
+	return out
+}
+
+func normalizeOwnedEncodedIndexValues(values [][]byte) [][]byte {
+	values = filterEmptyEncodedIndexValues(values)
+	if len(values) == 0 {
+		return nil
+	}
+	sort.Slice(values, func(i, j int) bool {
+		return bytes.Compare(values[i], values[j]) < 0
+	})
+	out := values[:1]
+	for _, value := range values[1:] {
+		if bytes.Equal(value, out[len(out)-1]) {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
+}
+
+func filterEmptyEncodedIndexValues(values [][]byte) [][]byte {
+	if len(values) == 0 {
+		return nil
+	}
+	out := values[:0]
+	for _, value := range values {
+		if len(value) == 0 {
+			continue
+		}
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -491,6 +491,57 @@ func encodeDocumentIndexState(state documentIndexState) ([]byte, error) {
 	return out, nil
 }
 
+func decodeDocumentIndexState(raw []byte) (documentIndexState, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("collections: empty index state")
+	}
+	if raw[0] != documentIndexStateVersion {
+		return nil, fmt.Errorf("collections: unsupported index state version %d", raw[0])
+	}
+	pos := 1
+	if len(raw)-pos < 2 {
+		return nil, errors.New("collections: malformed index state")
+	}
+	count := int(binary.BigEndian.Uint16(raw[pos:]))
+	pos += 2
+	state := make(documentIndexState, count)
+	for i := 0; i < count; i++ {
+		if len(raw)-pos < 2 {
+			return nil, errors.New("collections: malformed index state name length")
+		}
+		nameLen := int(binary.BigEndian.Uint16(raw[pos:]))
+		pos += 2
+		if nameLen == 0 || len(raw)-pos < nameLen {
+			return nil, errors.New("collections: malformed index state name")
+		}
+		name := string(raw[pos : pos+nameLen])
+		pos += nameLen
+		if len(raw)-pos < 2 {
+			return nil, errors.New("collections: malformed index state value count")
+		}
+		valueCount := int(binary.BigEndian.Uint16(raw[pos:]))
+		pos += 2
+		values := make([][]byte, 0, valueCount)
+		for j := 0; j < valueCount; j++ {
+			if len(raw)-pos < 2 {
+				return nil, errors.New("collections: malformed index state value length")
+			}
+			valueLen := int(binary.BigEndian.Uint16(raw[pos:]))
+			pos += 2
+			if valueLen == 0 || len(raw)-pos < valueLen {
+				return nil, errors.New("collections: malformed index state value")
+			}
+			values = append(values, bytes.Clone(raw[pos:pos+valueLen]))
+			pos += valueLen
+		}
+		state[name] = normalizeEncodedIndexValues(values)
+	}
+	if pos != len(raw) {
+		return nil, errors.New("collections: trailing index state bytes")
+	}
+	return state, nil
+}
+
 func normalizeEncodedIndexValues(values [][]byte) [][]byte {
 	if len(values) == 0 {
 		return nil

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -29,13 +29,16 @@ const (
 
 type collectionOptions struct {
 	allowArrayValuesInIndex bool
+	dataStoragePolicy       backenddb.OrderedRootStoragePolicy
+	indexStateStoragePolicy backenddb.OrderedRootStoragePolicy
 }
 
 type indexDefinition struct {
-	name     string
-	field    string
-	unique   bool
-	multiKey bool
+	name          string
+	field         string
+	unique        bool
+	multiKey      bool
+	storagePolicy backenddb.OrderedRootStoragePolicy
 }
 
 type insertBatchPlanner struct {
@@ -59,10 +62,11 @@ type insertBatchPlanStats struct {
 }
 
 type collectionRootRun struct {
-	name      string
-	kind      collectionRootKind
-	indexName string
-	table     memtable.Table
+	name          string
+	kind          collectionRootKind
+	indexName     string
+	table         memtable.Table
+	storagePolicy backenddb.OrderedRootStoragePolicy
 }
 
 type collectionUniqueProbeRun struct {
@@ -82,9 +86,9 @@ type indexRuntime struct {
 }
 
 type uniqueProbeCandidate struct {
-	indexName  string
-	prefix     []byte
-	documentID []byte
+	indexName    string
+	encodedValue []byte
+	documentID   []byte
 }
 
 type documentIndexState map[string][][]byte
@@ -174,7 +178,7 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 		return nil, err
 	}
 	if len(runtimes) > 0 {
-		if err := p.emitIndexStateRun(plan, items); err != nil {
+		if err := p.emitIndexStateRun(plan, items, runtimes); err != nil {
 			return nil, err
 		}
 		if err := p.emitSecondaryRuns(plan, items, runtimes); err != nil {
@@ -188,9 +192,9 @@ func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem, or
 	if p.snapshot == nil || p.primaryRootID == 0 {
 		return nil
 	}
-	keys := make([][]byte, len(order))
-	for i, idx := range order {
-		keys[i] = items[idx].id
+	keys := make([][]byte, len(items))
+	for i := range items {
+		keys[i] = items[orderedItemIndex(order, i)].id
 	}
 	exists, err := p.snapshot.HasAnySortedAtRoot(p.primaryRootID, keys)
 	if err != nil {
@@ -229,8 +233,8 @@ func borrowPrimaryDocument(_, document []byte) ([]byte, error) {
 }
 
 func rejectDuplicateDocumentIDs(items []insertBatchItem, order []int) error {
-	for i := 1; i < len(order); i++ {
-		if bytes.Equal(items[order[i-1]].id, items[order[i]].id) {
+	for i := 1; i < len(items); i++ {
+		if bytes.Equal(items[orderedItemIndex(order, i-1)].id, items[orderedItemIndex(order, i)].id) {
 			return errors.New("collections: duplicate document id in batch")
 		}
 	}
@@ -275,14 +279,10 @@ func (p insertBatchPlanner) planIndexStateAndUniqueProbes(items []insertBatchIte
 				continue
 			}
 			for _, encoded := range state[runtime.def.name] {
-				prefix, err := indexValuePrefix(encoded)
-				if err != nil {
-					return nil, err
-				}
 				uniqueProbes = append(uniqueProbes, uniqueProbeCandidate{
-					indexName:  runtime.def.name,
-					prefix:     prefix,
-					documentID: items[i].id,
+					indexName:    runtime.def.name,
+					encodedValue: encoded,
+					documentID:   items[i].id,
 				})
 			}
 		}
@@ -298,36 +298,48 @@ func buildUniqueProbeRuns(candidates []uniqueProbeCandidate) ([]collectionUnique
 		if candidates[i].indexName != candidates[j].indexName {
 			return candidates[i].indexName < candidates[j].indexName
 		}
-		if cmp := bytes.Compare(candidates[i].prefix, candidates[j].prefix); cmp != 0 {
+		if cmp := compareIndexValuePrefixEncoded(candidates[i].encodedValue, candidates[j].encodedValue); cmp != 0 {
 			return cmp < 0
 		}
 		return bytes.Compare(candidates[i].documentID, candidates[j].documentID) < 0
 	})
 
 	runs := make([]collectionUniqueProbeRun, 0)
-	var cur *collectionUniqueProbeRun
-	for i := range candidates {
-		candidate := &candidates[i]
-		if i > 0 &&
-			candidate.indexName == candidates[i-1].indexName &&
-			bytes.Equal(candidate.prefix, candidates[i-1].prefix) &&
-			!bytes.Equal(candidate.documentID, candidates[i-1].documentID) {
-			return nil, fmt.Errorf("collections: unique index %q conflict", candidate.indexName)
+	for start := 0; start < len(candidates); {
+		indexName := candidates[start].indexName
+		end := start + 1
+		for end < len(candidates) && candidates[end].indexName == indexName {
+			end++
 		}
-		if cur == nil || cur.indexName != candidate.indexName {
-			runs = append(runs, collectionUniqueProbeRun{indexName: candidate.indexName})
-			cur = &runs[len(runs)-1]
+		run := collectionUniqueProbeRun{
+			indexName: indexName,
+			prefixes:  make([][]byte, 0, end-start),
 		}
-		if len(cur.prefixes) == 0 || !bytes.Equal(cur.prefixes[len(cur.prefixes)-1], candidate.prefix) {
-			cur.prefixes = append(cur.prefixes, bytes.Clone(candidate.prefix))
+		for i := start; i < end; i++ {
+			candidate := &candidates[i]
+			if i > start &&
+				bytes.Equal(candidate.encodedValue, candidates[i-1].encodedValue) &&
+				!bytes.Equal(candidate.documentID, candidates[i-1].documentID) {
+				return nil, fmt.Errorf("collections: unique index %q conflict", candidate.indexName)
+			}
+			if len(run.prefixes) == 0 || !bytes.Equal(candidate.encodedValue, candidates[i-1].encodedValue) {
+				prefix, err := indexValuePrefix(candidate.encodedValue)
+				if err != nil {
+					return nil, err
+				}
+				run.prefixes = append(run.prefixes, prefix)
+			}
 		}
+		runs = append(runs, run)
+		start = end
 	}
 	return runs, nil
 }
 
 func (p insertBatchPlanner) emitPrimaryRun(plan *insertBatchPlan, items []insertBatchItem, order []int) error {
 	table := newCollectionRunTable(len(items))
-	for _, idx := range order {
+	for i := range items {
+		idx := orderedItemIndex(order, i)
 		value, err := p.buildPrimaryVal(items[idx].id, items[idx].document)
 		if err != nil {
 			return err
@@ -337,9 +349,10 @@ func (p insertBatchPlanner) emitPrimaryRun(plan *insertBatchPlan, items []insert
 	}
 	table.Freeze()
 	plan.runs = append(plan.runs, collectionRootRun{
-		name:  p.primaryRoot,
-		kind:  collectionRootPrimary,
-		table: table,
+		name:          p.primaryRoot,
+		kind:          collectionRootPrimary,
+		table:         table,
+		storagePolicy: p.options.dataStoragePolicy,
 	})
 	return nil
 }
@@ -348,11 +361,12 @@ func setCollectionRunValue(table memtable.Table, key, value []byte) {
 	table.SetEntrySteal(key, value, page.ValuePtr{}, node.FlagInline)
 }
 
-func (p insertBatchPlanner) emitIndexStateRun(plan *insertBatchPlan, items []insertBatchItem) error {
+func (p insertBatchPlanner) emitIndexStateRun(plan *insertBatchPlan, items []insertBatchItem, runtimes []indexRuntime) error {
 	order := sortedItemOrderByKey(items, func(item *insertBatchItem) []byte { return item.id })
 	table := newCollectionRunTable(len(items))
-	for _, idx := range order {
-		raw, err := encodeNormalizedDocumentIndexState(items[idx].state)
+	for i := range items {
+		idx := orderedItemIndex(order, i)
+		raw, err := encodeRuntimeOrderedDocumentIndexState(items[idx].state, runtimes)
 		if err != nil {
 			return err
 		}
@@ -360,16 +374,46 @@ func (p insertBatchPlanner) emitIndexStateRun(plan *insertBatchPlan, items []ins
 	}
 	table.Freeze()
 	plan.runs = append(plan.runs, collectionRootRun{
-		name:  p.indexStateRoot,
-		kind:  collectionRootIndexState,
-		table: table,
+		name:          p.indexStateRoot,
+		kind:          collectionRootIndexState,
+		table:         table,
+		storagePolicy: p.options.indexStateStoragePolicy,
 	})
 	return nil
 }
 
 func (p insertBatchPlanner) emitSecondaryRuns(plan *insertBatchPlan, items []insertBatchItem, runtimes []indexRuntime) error {
 	for _, runtime := range runtimes {
-		keys := make([][]byte, 0, len(items))
+		entryCount, alreadySorted, err := secondaryEntryOrderStats(items, runtime.def.name)
+		if err != nil {
+			return err
+		}
+		if entryCount == 0 {
+			continue
+		}
+		if alreadySorted {
+			table := newCollectionRunTable(entryCount)
+			for i := range items {
+				for _, encoded := range items[i].state[runtime.def.name] {
+					key, err := indexEntryKey(encoded, items[i].id)
+					if err != nil {
+						return err
+					}
+					table.SetSteal(key, nil)
+				}
+			}
+			table.Freeze()
+			plan.runs = append(plan.runs, collectionRootRun{
+				name:          p.collection + "/index/" + runtime.def.name,
+				kind:          collectionRootSecondary,
+				indexName:     runtime.def.name,
+				table:         table,
+				storagePolicy: runtime.def.storagePolicy,
+			})
+			continue
+		}
+
+		keys := make([][]byte, 0, entryCount)
 		for i := range items {
 			for _, encoded := range items[i].state[runtime.def.name] {
 				key, err := indexEntryKey(encoded, items[i].id)
@@ -391,13 +435,34 @@ func (p insertBatchPlanner) emitSecondaryRuns(plan *insertBatchPlan, items []ins
 		}
 		table.Freeze()
 		plan.runs = append(plan.runs, collectionRootRun{
-			name:      p.collection + "/index/" + runtime.def.name,
-			kind:      collectionRootSecondary,
-			indexName: runtime.def.name,
-			table:     table,
+			name:          p.collection + "/index/" + runtime.def.name,
+			kind:          collectionRootSecondary,
+			indexName:     runtime.def.name,
+			table:         table,
+			storagePolicy: runtime.def.storagePolicy,
 		})
 	}
 	return nil
+}
+
+func secondaryEntryOrderStats(items []insertBatchItem, indexName string) (entryCount int, alreadySorted bool, err error) {
+	alreadySorted = true
+	var lastValue []byte
+	var lastDocumentID []byte
+	for i := range items {
+		for _, encoded := range items[i].state[indexName] {
+			if len(encoded) > 65535 {
+				return 0, false, errors.New("collections: index key too large")
+			}
+			if entryCount > 0 && compareIndexEntryKeyParts(lastValue, lastDocumentID, encoded, items[i].id) > 0 {
+				alreadySorted = false
+			}
+			lastValue = encoded
+			lastDocumentID = items[i].id
+			entryCount++
+		}
+	}
+	return entryCount, alreadySorted, nil
 }
 
 func newCollectionRunTable(entries int) memtable.Table {
@@ -407,15 +472,58 @@ func newCollectionRunTable(entries int) memtable.Table {
 	return memtable.NewAppendOnlyWithEntryCapacity(entries)
 }
 
-func sortedItemOrderByKey(items []insertBatchItem, keyFn func(*insertBatchItem) []byte) []int {
-	order := make([]int, len(items))
-	for i := range order {
-		order[i] = i
+func resetCollectionRunTables(runs []collectionRootRun) {
+	for _, run := range runs {
+		resetCollectionRunTable(run.table)
 	}
-	sort.Slice(order, func(i, j int) bool {
-		return bytes.Compare(keyFn(&items[order[i]]), keyFn(&items[order[j]])) < 0
-	})
-	return order
+}
+
+func resetCollectionTables(tables []memtable.Table) {
+	for _, table := range tables {
+		resetCollectionRunTable(table)
+	}
+}
+
+func resetCollectionRunTable(table memtable.Table) {
+	type releaser interface {
+		Release()
+	}
+	type resetter interface {
+		Reset()
+	}
+	if table == nil {
+		return
+	}
+	if r, ok := table.(releaser); ok {
+		r.Release()
+		return
+	}
+	if r, ok := table.(resetter); ok {
+		r.Reset()
+	}
+}
+
+func sortedItemOrderByKey(items []insertBatchItem, keyFn func(*insertBatchItem) []byte) []int {
+	for i := 1; i < len(items); i++ {
+		if bytes.Compare(keyFn(&items[i-1]), keyFn(&items[i])) > 0 {
+			order := make([]int, len(items))
+			for i := range order {
+				order[i] = i
+			}
+			sort.Slice(order, func(i, j int) bool {
+				return bytes.Compare(keyFn(&items[order[i]]), keyFn(&items[order[j]])) < 0
+			})
+			return order
+		}
+	}
+	return nil
+}
+
+func orderedItemIndex(order []int, pos int) int {
+	if order == nil {
+		return pos
+	}
+	return order[pos]
 }
 
 func indexStateForDocument(document []byte, runtimes []indexRuntime, opts collectionOptions) (documentIndexState, error) {
@@ -464,6 +572,51 @@ func encodeNormalizedDocumentIndexState(state documentIndexState) ([]byte, error
 	return encodeDocumentIndexStateWithOptions(state, false)
 }
 
+func encodeRuntimeOrderedDocumentIndexState(state documentIndexState, runtimes []indexRuntime) ([]byte, error) {
+	if state == nil {
+		state = make(documentIndexState)
+	}
+	count := 0
+	size := 1 + 2
+	for _, runtime := range runtimes {
+		indexName := runtime.def.name
+		values := filterEmptyEncodedIndexValues(state[indexName])
+		if len(values) == 0 {
+			continue
+		}
+		if len(indexName) > 65535 {
+			return nil, errors.New("collections: index state name too long")
+		}
+		size += 2 + len(indexName) + 2
+		for _, value := range values {
+			if len(value) > 65535 {
+				return nil, errors.New("collections: index state value too large")
+			}
+			size += 2 + len(value)
+		}
+		count++
+	}
+
+	out := make([]byte, 0, size)
+	out = append(out, documentIndexStateVersion)
+	out = binary.BigEndian.AppendUint16(out, uint16(count))
+	for _, runtime := range runtimes {
+		indexName := runtime.def.name
+		values := filterEmptyEncodedIndexValues(state[indexName])
+		if len(values) == 0 {
+			continue
+		}
+		out = binary.BigEndian.AppendUint16(out, uint16(len(indexName)))
+		out = append(out, indexName...)
+		out = binary.BigEndian.AppendUint16(out, uint16(len(values)))
+		for _, value := range values {
+			out = binary.BigEndian.AppendUint16(out, uint16(len(value)))
+			out = append(out, value...)
+		}
+	}
+	return out, nil
+}
+
 func encodeDocumentIndexStateWithOptions(state documentIndexState, normalizeValues bool) ([]byte, error) {
 	if state == nil {
 		state = make(documentIndexState)
@@ -487,21 +640,30 @@ func encodeDocumentIndexStateWithOptions(state documentIndexState, normalizeValu
 	}
 	sort.Strings(names)
 
-	out := make([]byte, 0, 32)
-	out = append(out, documentIndexStateVersion)
-	out = binary.BigEndian.AppendUint16(out, uint16(len(names)))
+	size := 1 + 2
 	for _, indexName := range names {
 		values := state[indexName]
 		if len(indexName) > 65535 {
 			return nil, errors.New("collections: index state name too long")
 		}
-		out = binary.BigEndian.AppendUint16(out, uint16(len(indexName)))
-		out = append(out, indexName...)
-		out = binary.BigEndian.AppendUint16(out, uint16(len(values)))
+		size += 2 + len(indexName) + 2
 		for _, value := range values {
 			if len(value) > 65535 {
 				return nil, errors.New("collections: index state value too large")
 			}
+			size += 2 + len(value)
+		}
+	}
+
+	out := make([]byte, 0, size)
+	out = append(out, documentIndexStateVersion)
+	out = binary.BigEndian.AppendUint16(out, uint16(len(names)))
+	for _, indexName := range names {
+		values := state[indexName]
+		out = binary.BigEndian.AppendUint16(out, uint16(len(indexName)))
+		out = append(out, indexName...)
+		out = binary.BigEndian.AppendUint16(out, uint16(len(values)))
+		for _, value := range values {
 			out = binary.BigEndian.AppendUint16(out, uint16(len(value)))
 			out = append(out, value...)
 		}
@@ -667,7 +829,10 @@ func extractIndexPathValue(document any, path []string) (any, bool) {
 func encodeIndexScalar(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case string:
-		return append([]byte("s:"), []byte(v)...), nil
+		out := make([]byte, 0, 2+len(v))
+		out = append(out, "s:"...)
+		out = append(out, v...)
+		return out, nil
 	case bool:
 		if v {
 			return []byte("b:1"), nil
@@ -683,21 +848,40 @@ func encodeIndexScalar(value any) ([]byte, error) {
 }
 
 func indexEntryKey(encodedValue, documentID []byte) ([]byte, error) {
-	prefix, err := indexValuePrefix(encodedValue)
+	key := make([]byte, 0, 2+len(encodedValue)+len(documentID))
+	key, err := appendIndexValuePrefix(key, encodedValue)
 	if err != nil {
 		return nil, err
 	}
-	key := make([]byte, 0, len(prefix)+len(documentID))
-	key = append(key, prefix...)
 	key = append(key, documentID...)
 	return key, nil
 }
 
 func indexValuePrefix(encodedValue []byte) ([]byte, error) {
+	return appendIndexValuePrefix(make([]byte, 0, 2+len(encodedValue)), encodedValue)
+}
+
+func compareIndexValuePrefixEncoded(a, b []byte) int {
+	if len(a) < len(b) {
+		return -1
+	}
+	if len(a) > len(b) {
+		return 1
+	}
+	return bytes.Compare(a, b)
+}
+
+func compareIndexEntryKeyParts(aValue, aDocumentID, bValue, bDocumentID []byte) int {
+	if cmp := compareIndexValuePrefixEncoded(aValue, bValue); cmp != 0 {
+		return cmp
+	}
+	return bytes.Compare(aDocumentID, bDocumentID)
+}
+
+func appendIndexValuePrefix(out []byte, encodedValue []byte) ([]byte, error) {
 	if len(encodedValue) > 65535 {
 		return nil, errors.New("collections: index key too large")
 	}
-	out := make([]byte, 0, 2+len(encodedValue))
 	out = binary.BigEndian.AppendUint16(out, uint16(len(encodedValue)))
 	out = append(out, encodedValue...)
 	return out, nil
@@ -738,8 +922,9 @@ func (plan *insertBatchPlan) publishRootRuns(publisher groupedRootPublisher, bas
 		iter := run.table.NewIterator(nil, nil)
 		iterators = append(iterators, iter)
 		ordered = append(ordered, backenddb.OrderedRootPublishInput{
-			BaseRoot: baseRootIDs[run.name],
-			Iter:     iter,
+			BaseRoot:      baseRootIDs[run.name],
+			Iter:          iter,
+			StoragePolicy: run.storagePolicy,
 		})
 	}
 	_, rootIDs, err := publisher.PublishOrderedRootGroup(nil, ordered)

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -13,6 +13,7 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 const documentIndexStateVersion = 1
@@ -91,7 +92,21 @@ type groupedRootPublisher interface {
 	PublishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordered []backenddb.OrderedRootPublishInput) (uint64, []uint64, error)
 }
 
+type rootSnapshotProbe interface {
+	IteratorAtRoot(rootID uint64, start, end []byte) (iterator.UnsafeIterator, error)
+}
+
+type insertBatchPreflight struct {
+	snapshot           rootSnapshotProbe
+	primaryRootID      uint64
+	uniqueIndexRootIDs map[string]uint64
+}
+
 func (p insertBatchPlanner) planInsertBatch(ids, documents [][]byte) (*insertBatchPlan, error) {
+	return p.planInsertBatchWithPreflight(ids, documents, insertBatchPreflight{})
+}
+
+func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte, preflight insertBatchPreflight) (*insertBatchPlan, error) {
 	if len(documents) == 0 {
 		return &insertBatchPlan{}, nil
 	}
@@ -141,6 +156,12 @@ func (p insertBatchPlanner) planInsertBatch(ids, documents [][]byte) (*insertBat
 	if err != nil {
 		return nil, err
 	}
+	if err := preflight.checkDocumentConflicts(items); err != nil {
+		return nil, err
+	}
+	if err := preflight.checkUniqueConflicts(uniqueProbeRuns); err != nil {
+		return nil, err
+	}
 
 	plan := &insertBatchPlan{
 		resultIDs:       resultIDs,
@@ -158,6 +179,44 @@ func (p insertBatchPlanner) planInsertBatch(ids, documents [][]byte) (*insertBat
 		}
 	}
 	return plan, nil
+}
+
+func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem) error {
+	if p.snapshot == nil || p.primaryRootID == 0 {
+		return nil
+	}
+	for i := range items {
+		exists, err := rootHasExactKey(p.snapshot, p.primaryRootID, items[i].id)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return errors.New("collections: document already exists")
+		}
+	}
+	return nil
+}
+
+func (p insertBatchPreflight) checkUniqueConflicts(runs []collectionUniqueProbeRun) error {
+	if p.snapshot == nil || len(p.uniqueIndexRootIDs) == 0 {
+		return nil
+	}
+	for _, run := range runs {
+		rootID := p.uniqueIndexRootIDs[run.indexName]
+		if rootID == 0 {
+			continue
+		}
+		for _, prefix := range run.prefixes {
+			exists, err := rootHasPrefix(p.snapshot, rootID, prefix)
+			if err != nil {
+				return err
+			}
+			if exists {
+				return fmt.Errorf("collections: unique index %q conflict", run.indexName)
+			}
+		}
+	}
+	return nil
 }
 
 func clonePrimaryDocument(_, document []byte) ([]byte, error) {
@@ -538,6 +597,56 @@ func indexValuePrefix(encodedValue []byte) ([]byte, error) {
 	out = binary.BigEndian.AppendUint16(out, uint16(len(encodedValue)))
 	out = append(out, encodedValue...)
 	return out, nil
+}
+
+func rootHasExactKey(snapshot rootSnapshotProbe, rootID uint64, key []byte) (bool, error) {
+	if snapshot == nil || rootID == 0 {
+		return false, nil
+	}
+	it, err := snapshot.IteratorAtRoot(rootID, key, prefixEnd(key))
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		return false, it.Error()
+	}
+	return bytes.Equal(it.UnsafeKey(), key), it.Error()
+}
+
+func rootHasPrefix(snapshot rootSnapshotProbe, rootID uint64, prefix []byte) (bool, error) {
+	if snapshot == nil || rootID == 0 {
+		return false, nil
+	}
+	it, err := snapshot.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		return false, it.Error()
+	}
+	return true, it.Error()
+}
+
+func prefixEnd(prefix []byte) []byte {
+	if len(prefix) == 0 {
+		return nil
+	}
+	out := bytes.Clone(prefix)
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i] != 0xff {
+			out[i]++
+			return out[:i+1]
+		}
+	}
+	return nil
 }
 
 func (plan *insertBatchPlan) publishRootRuns(publisher groupedRootPublisher, baseRootIDs map[string]uint64) ([]uint64, error) {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -404,7 +404,7 @@ func newCollectionRunTable(entries int) memtable.Table {
 	if entries < 0 {
 		entries = 0
 	}
-	return memtable.NewAppendOnlyWithCapacity(entries * 64)
+	return memtable.NewAppendOnlyWithEntryCapacity(entries)
 }
 
 func sortedItemOrderByKey(items []insertBatchItem, keyFn func(*insertBatchItem) []byte) []int {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -1,0 +1,573 @@
+package collections
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+)
+
+const documentIndexStateVersion = 1
+
+type collectionRootKind uint8
+
+const (
+	collectionRootPrimary collectionRootKind = iota + 1
+	collectionRootIndexState
+	collectionRootSecondary
+)
+
+type collectionOptions struct {
+	allowArrayValuesInIndex bool
+}
+
+type indexDefinition struct {
+	name     string
+	field    string
+	unique   bool
+	multiKey bool
+}
+
+type insertBatchPlanner struct {
+	collection      string
+	primaryRoot     string
+	indexStateRoot  string
+	indexes         []indexDefinition
+	options         collectionOptions
+	buildPrimaryVal func(documentID, document []byte) ([]byte, error)
+}
+
+type insertBatchPlan struct {
+	resultIDs       [][]byte
+	runs            []collectionRootRun
+	uniqueProbeRuns []collectionUniqueProbeRun
+	stats           insertBatchPlanStats
+}
+
+type insertBatchPlanStats struct {
+	payloadBuilds int
+}
+
+type collectionRootRun struct {
+	name      string
+	kind      collectionRootKind
+	indexName string
+	table     memtable.Table
+}
+
+type collectionUniqueProbeRun struct {
+	indexName string
+	prefixes  [][]byte
+}
+
+type insertBatchItem struct {
+	id       []byte
+	document []byte
+	state    documentIndexState
+}
+
+type indexRuntime struct {
+	def  indexDefinition
+	path []string
+}
+
+type uniqueProbeCandidate struct {
+	indexName  string
+	prefix     []byte
+	documentID []byte
+}
+
+type documentIndexState map[string][][]byte
+
+type groupedRootPublisher interface {
+	PublishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordered []backenddb.OrderedRootPublishInput) (uint64, []uint64, error)
+}
+
+func (p insertBatchPlanner) planInsertBatch(ids, documents [][]byte) (*insertBatchPlan, error) {
+	if len(documents) == 0 {
+		return &insertBatchPlan{}, nil
+	}
+	if len(ids) != len(documents) {
+		return nil, fmt.Errorf("collections: caller-provided batch ids length mismatch")
+	}
+	if p.collection == "" {
+		return nil, errors.New("collections: collection name cannot be empty")
+	}
+	if p.primaryRoot == "" {
+		p.primaryRoot = p.collection + "/primary"
+	}
+	if len(p.indexes) > 0 && p.indexStateRoot == "" {
+		p.indexStateRoot = p.collection + "/index-state"
+	}
+	if p.buildPrimaryVal == nil {
+		p.buildPrimaryVal = clonePrimaryDocument
+	}
+
+	items := make([]insertBatchItem, len(documents))
+	resultIDs := make([][]byte, len(documents))
+	for i := range documents {
+		if len(ids[i]) == 0 {
+			return nil, errors.New("collections: document id cannot be empty")
+		}
+		id := bytes.Clone(ids[i])
+		items[i] = insertBatchItem{
+			id:       id,
+			document: documents[i],
+		}
+		resultIDs[i] = bytes.Clone(id)
+	}
+
+	if err := rejectDuplicateDocumentIDs(items); err != nil {
+		return nil, err
+	}
+
+	runtimes, err := p.indexRuntimes()
+	if err != nil {
+		return nil, err
+	}
+	uniqueProbes, err := p.planIndexStateAndUniqueProbes(items, runtimes)
+	if err != nil {
+		return nil, err
+	}
+	uniqueProbeRuns, err := buildUniqueProbeRuns(uniqueProbes)
+	if err != nil {
+		return nil, err
+	}
+
+	plan := &insertBatchPlan{
+		resultIDs:       resultIDs,
+		uniqueProbeRuns: uniqueProbeRuns,
+	}
+	if err := p.emitPrimaryRun(plan, items); err != nil {
+		return nil, err
+	}
+	if len(runtimes) > 0 {
+		if err := p.emitIndexStateRun(plan, items); err != nil {
+			return nil, err
+		}
+		if err := p.emitSecondaryRuns(plan, items, runtimes); err != nil {
+			return nil, err
+		}
+	}
+	return plan, nil
+}
+
+func clonePrimaryDocument(_, document []byte) ([]byte, error) {
+	return bytes.Clone(document), nil
+}
+
+func rejectDuplicateDocumentIDs(items []insertBatchItem) error {
+	order := make([]int, len(items))
+	for i := range order {
+		order[i] = i
+	}
+	sort.Slice(order, func(i, j int) bool {
+		return bytes.Compare(items[order[i]].id, items[order[j]].id) < 0
+	})
+	for i := 1; i < len(order); i++ {
+		if bytes.Equal(items[order[i-1]].id, items[order[i]].id) {
+			return errors.New("collections: duplicate document id in batch")
+		}
+	}
+	return nil
+}
+
+func (p insertBatchPlanner) indexRuntimes() ([]indexRuntime, error) {
+	runtimes := make([]indexRuntime, len(p.indexes))
+	seen := make(map[string]struct{}, len(p.indexes))
+	for i, idx := range p.indexes {
+		if idx.name == "" {
+			return nil, errors.New("collections: index name cannot be empty")
+		}
+		if idx.field == "" {
+			return nil, fmt.Errorf("collections: index %q field cannot be empty", idx.name)
+		}
+		if _, exists := seen[idx.name]; exists {
+			return nil, fmt.Errorf("collections: duplicate index %q", idx.name)
+		}
+		seen[idx.name] = struct{}{}
+		runtimes[i] = indexRuntime{
+			def:  idx,
+			path: splitIndexPath(idx.field),
+		}
+	}
+	return runtimes, nil
+}
+
+func (p insertBatchPlanner) planIndexStateAndUniqueProbes(items []insertBatchItem, runtimes []indexRuntime) ([]uniqueProbeCandidate, error) {
+	if len(runtimes) == 0 {
+		return nil, nil
+	}
+	uniqueProbes := make([]uniqueProbeCandidate, 0, len(items))
+	for i := range items {
+		state, err := indexStateForDocument(items[i].document, runtimes, p.options)
+		if err != nil {
+			return nil, err
+		}
+		items[i].state = state
+		for _, runtime := range runtimes {
+			if !runtime.def.unique {
+				continue
+			}
+			for _, encoded := range state[runtime.def.name] {
+				prefix, err := indexValuePrefix(encoded)
+				if err != nil {
+					return nil, err
+				}
+				uniqueProbes = append(uniqueProbes, uniqueProbeCandidate{
+					indexName:  runtime.def.name,
+					prefix:     prefix,
+					documentID: items[i].id,
+				})
+			}
+		}
+	}
+	return uniqueProbes, nil
+}
+
+func buildUniqueProbeRuns(candidates []uniqueProbeCandidate) ([]collectionUniqueProbeRun, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].indexName != candidates[j].indexName {
+			return candidates[i].indexName < candidates[j].indexName
+		}
+		if cmp := bytes.Compare(candidates[i].prefix, candidates[j].prefix); cmp != 0 {
+			return cmp < 0
+		}
+		return bytes.Compare(candidates[i].documentID, candidates[j].documentID) < 0
+	})
+
+	runs := make([]collectionUniqueProbeRun, 0)
+	var cur *collectionUniqueProbeRun
+	for i := range candidates {
+		candidate := &candidates[i]
+		if i > 0 &&
+			candidate.indexName == candidates[i-1].indexName &&
+			bytes.Equal(candidate.prefix, candidates[i-1].prefix) &&
+			!bytes.Equal(candidate.documentID, candidates[i-1].documentID) {
+			return nil, fmt.Errorf("collections: unique index %q conflict", candidate.indexName)
+		}
+		if cur == nil || cur.indexName != candidate.indexName {
+			runs = append(runs, collectionUniqueProbeRun{indexName: candidate.indexName})
+			cur = &runs[len(runs)-1]
+		}
+		if len(cur.prefixes) == 0 || !bytes.Equal(cur.prefixes[len(cur.prefixes)-1], candidate.prefix) {
+			cur.prefixes = append(cur.prefixes, bytes.Clone(candidate.prefix))
+		}
+	}
+	return runs, nil
+}
+
+func (p insertBatchPlanner) emitPrimaryRun(plan *insertBatchPlan, items []insertBatchItem) error {
+	order := sortedItemOrderByKey(items, func(item *insertBatchItem) []byte { return item.id })
+	table := newCollectionRunTable(len(items))
+	for _, idx := range order {
+		value, err := p.buildPrimaryVal(items[idx].id, items[idx].document)
+		if err != nil {
+			return err
+		}
+		plan.stats.payloadBuilds++
+		table.SetSteal(bytes.Clone(items[idx].id), value)
+	}
+	table.Freeze()
+	plan.runs = append(plan.runs, collectionRootRun{
+		name:  p.primaryRoot,
+		kind:  collectionRootPrimary,
+		table: table,
+	})
+	return nil
+}
+
+func (p insertBatchPlanner) emitIndexStateRun(plan *insertBatchPlan, items []insertBatchItem) error {
+	order := sortedItemOrderByKey(items, func(item *insertBatchItem) []byte { return item.id })
+	table := newCollectionRunTable(len(items))
+	for _, idx := range order {
+		raw, err := encodeDocumentIndexState(items[idx].state)
+		if err != nil {
+			return err
+		}
+		table.SetSteal(bytes.Clone(items[idx].id), raw)
+	}
+	table.Freeze()
+	plan.runs = append(plan.runs, collectionRootRun{
+		name:  p.indexStateRoot,
+		kind:  collectionRootIndexState,
+		table: table,
+	})
+	return nil
+}
+
+func (p insertBatchPlanner) emitSecondaryRuns(plan *insertBatchPlan, items []insertBatchItem, runtimes []indexRuntime) error {
+	for _, runtime := range runtimes {
+		keys := make([][]byte, 0, len(items))
+		for i := range items {
+			for _, encoded := range items[i].state[runtime.def.name] {
+				key, err := indexEntryKey(encoded, items[i].id)
+				if err != nil {
+					return err
+				}
+				keys = append(keys, key)
+			}
+		}
+		if len(keys) == 0 {
+			continue
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			return bytes.Compare(keys[i], keys[j]) < 0
+		})
+		table := newCollectionRunTable(len(keys))
+		for _, key := range keys {
+			table.SetSteal(key, nil)
+		}
+		table.Freeze()
+		plan.runs = append(plan.runs, collectionRootRun{
+			name:      p.collection + "/index/" + runtime.def.name,
+			kind:      collectionRootSecondary,
+			indexName: runtime.def.name,
+			table:     table,
+		})
+	}
+	return nil
+}
+
+func newCollectionRunTable(entries int) memtable.Table {
+	if entries < 0 {
+		entries = 0
+	}
+	return memtable.NewAppendOnlyWithCapacity(entries * 64)
+}
+
+func sortedItemOrderByKey(items []insertBatchItem, keyFn func(*insertBatchItem) []byte) []int {
+	order := make([]int, len(items))
+	for i := range order {
+		order[i] = i
+	}
+	sort.Slice(order, func(i, j int) bool {
+		return bytes.Compare(keyFn(&items[order[i]]), keyFn(&items[order[j]])) < 0
+	})
+	return order
+}
+
+func indexStateForDocument(document []byte, runtimes []indexRuntime, opts collectionOptions) (documentIndexState, error) {
+	if len(runtimes) == 0 {
+		return nil, nil
+	}
+	var decoded any
+	if err := json.Unmarshal(document, &decoded); err != nil {
+		return nil, fmt.Errorf("collections: index extraction requires JSON document: %w", err)
+	}
+	obj, ok := decoded.(map[string]any)
+	if !ok {
+		return nil, errors.New("collections: index extraction requires JSON object document")
+	}
+	state := make(documentIndexState, len(runtimes))
+	for _, runtime := range runtimes {
+		value, found := extractIndexPathValue(obj, runtime.path)
+		if !found || value == nil {
+			continue
+		}
+		values, err := normalizeIndexValues(value, runtime.def.multiKey, opts.allowArrayValuesInIndex)
+		if err != nil {
+			return nil, err
+		}
+		encoded := make([][]byte, 0, len(values))
+		for _, scalar := range values {
+			next, err := encodeIndexScalar(scalar)
+			if err != nil {
+				return nil, err
+			}
+			encoded = append(encoded, next)
+		}
+		encoded = normalizeEncodedIndexValues(encoded)
+		if len(encoded) > 0 {
+			state[runtime.def.name] = encoded
+		}
+	}
+	return state, nil
+}
+
+func encodeDocumentIndexState(state documentIndexState) ([]byte, error) {
+	if state == nil {
+		state = make(documentIndexState)
+	}
+	names := make([]string, 0, len(state))
+	for indexName, values := range state {
+		if indexName == "" {
+			return nil, errors.New("collections: index state name cannot be empty")
+		}
+		state[indexName] = normalizeEncodedIndexValues(values)
+		names = append(names, indexName)
+	}
+	sort.Strings(names)
+
+	out := make([]byte, 0, 32)
+	out = append(out, documentIndexStateVersion)
+	out = binary.BigEndian.AppendUint16(out, uint16(len(names)))
+	for _, indexName := range names {
+		values := state[indexName]
+		if len(indexName) > 65535 {
+			return nil, errors.New("collections: index state name too long")
+		}
+		out = binary.BigEndian.AppendUint16(out, uint16(len(indexName)))
+		out = append(out, indexName...)
+		out = binary.BigEndian.AppendUint16(out, uint16(len(values)))
+		for _, value := range values {
+			if len(value) > 65535 {
+				return nil, errors.New("collections: index state value too large")
+			}
+			out = binary.BigEndian.AppendUint16(out, uint16(len(value)))
+			out = append(out, value...)
+		}
+	}
+	return out, nil
+}
+
+func normalizeEncodedIndexValues(values [][]byte) [][]byte {
+	if len(values) == 0 {
+		return nil
+	}
+	sorted := make([][]byte, 0, len(values))
+	for _, value := range values {
+		if len(value) == 0 {
+			continue
+		}
+		sorted = append(sorted, bytes.Clone(value))
+	}
+	if len(sorted) == 0 {
+		return nil
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return bytes.Compare(sorted[i], sorted[j]) < 0
+	})
+	out := sorted[:1]
+	for _, value := range sorted[1:] {
+		if bytes.Equal(value, out[len(out)-1]) {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
+}
+
+func normalizeIndexValues(value any, multiKey, allowArray bool) ([]any, error) {
+	if arr, ok := value.([]any); ok {
+		if !multiKey && !allowArray {
+			return nil, errors.New("collections: array value not allowed for index")
+		}
+		if len(arr) == 0 {
+			return nil, nil
+		}
+		return arr, nil
+	}
+	return []any{value}, nil
+}
+
+func splitIndexPath(path string) []string {
+	if path == "" {
+		return nil
+	}
+	if !strings.Contains(path, ".") {
+		return []string{path}
+	}
+	return strings.Split(path, ".")
+}
+
+func extractIndexPathValue(document any, path []string) (any, bool) {
+	if len(path) == 0 {
+		return nil, false
+	}
+	current := document
+	for _, segment := range path {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		next, ok := obj[segment]
+		if !ok {
+			return nil, false
+		}
+		current = next
+	}
+	return current, true
+}
+
+func encodeIndexScalar(value any) ([]byte, error) {
+	switch v := value.(type) {
+	case string:
+		return append([]byte("s:"), []byte(v)...), nil
+	case bool:
+		if v {
+			return []byte("b:1"), nil
+		}
+		return []byte("b:0"), nil
+	case float64:
+		return []byte("n:" + strconv.FormatFloat(v, 'g', -1, 64)), nil
+	case nil:
+		return []byte("z:"), nil
+	default:
+		return nil, fmt.Errorf("collections: unsupported indexed value type %T", value)
+	}
+}
+
+func indexEntryKey(encodedValue, documentID []byte) ([]byte, error) {
+	prefix, err := indexValuePrefix(encodedValue)
+	if err != nil {
+		return nil, err
+	}
+	key := make([]byte, 0, len(prefix)+len(documentID))
+	key = append(key, prefix...)
+	key = append(key, documentID...)
+	return key, nil
+}
+
+func indexValuePrefix(encodedValue []byte) ([]byte, error) {
+	if len(encodedValue) > 65535 {
+		return nil, errors.New("collections: index key too large")
+	}
+	out := make([]byte, 0, 2+len(encodedValue))
+	out = binary.BigEndian.AppendUint16(out, uint16(len(encodedValue)))
+	out = append(out, encodedValue...)
+	return out, nil
+}
+
+func (plan *insertBatchPlan) publishRootRuns(publisher groupedRootPublisher, baseRootIDs map[string]uint64) ([]uint64, error) {
+	if plan == nil {
+		return nil, errors.New("collections: nil insert batch plan")
+	}
+	if publisher == nil {
+		return nil, errors.New("collections: nil root publisher")
+	}
+	ordered := make([]backenddb.OrderedRootPublishInput, 0, len(plan.runs))
+	iterators := make([]iterator.UnsafeIterator, 0, len(plan.runs))
+	defer func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+	}()
+	for _, run := range plan.runs {
+		if run.table == nil {
+			return nil, fmt.Errorf("collections: root run %q has nil table", run.name)
+		}
+		iter := run.table.NewIterator(nil, nil)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootPublishInput{
+			BaseRoot: baseRootIDs[run.name],
+			Iter:     iter,
+		})
+	}
+	_, rootIDs, err := publisher.PublishOrderedRootGroup(nil, ordered)
+	if err != nil {
+		return nil, err
+	}
+	return append([]uint64(nil), rootIDs...), nil
+}

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -910,9 +910,12 @@ func (plan *insertBatchPlan) publishRootRuns(publisher groupedRootPublisher, bas
 	}
 	ordered := make([]backenddb.OrderedRootPublishInput, 0, len(plan.runs))
 	iterators := make([]iterator.UnsafeIterator, 0, len(plan.runs))
+	iteratorsOwned := true
 	defer func() {
-		for _, it := range iterators {
-			_ = it.Close()
+		if iteratorsOwned {
+			for _, it := range iterators {
+				_ = it.Close()
+			}
 		}
 	}()
 	for _, run := range plan.runs {
@@ -927,6 +930,8 @@ func (plan *insertBatchPlan) publishRootRuns(publisher groupedRootPublisher, bas
 			StoragePolicy: run.storagePolicy,
 		})
 	}
+	// PublishOrderedRootGroup owns and closes iterators once they are handed off.
+	iteratorsOwned = false
 	_, rootIDs, err := publisher.PublishOrderedRootGroup(nil, ordered)
 	if err != nil {
 		return nil, err

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -13,7 +13,6 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
-	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 const documentIndexStateVersion = 1
@@ -93,7 +92,8 @@ type groupedRootPublisher interface {
 }
 
 type rootSnapshotProbe interface {
-	IteratorAtRoot(rootID uint64, start, end []byte) (iterator.UnsafeIterator, error)
+	HasManyAtRoot(rootID uint64, keys [][]byte) ([]bool, error)
+	HasPrefixesAtRoot(rootID uint64, prefixes [][]byte) ([]bool, error)
 }
 
 type insertBatchPreflight struct {
@@ -185,12 +185,16 @@ func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem) er
 	if p.snapshot == nil || p.primaryRootID == 0 {
 		return nil
 	}
+	keys := make([][]byte, len(items))
 	for i := range items {
-		exists, err := rootHasExactKey(p.snapshot, p.primaryRootID, items[i].id)
-		if err != nil {
-			return err
-		}
-		if exists {
+		keys[i] = items[i].id
+	}
+	exists, err := p.snapshot.HasManyAtRoot(p.primaryRootID, keys)
+	if err != nil {
+		return err
+	}
+	for _, ok := range exists {
+		if ok {
 			return errors.New("collections: document already exists")
 		}
 	}
@@ -206,12 +210,12 @@ func (p insertBatchPreflight) checkUniqueConflicts(runs []collectionUniqueProbeR
 		if rootID == 0 {
 			continue
 		}
-		for _, prefix := range run.prefixes {
-			exists, err := rootHasPrefix(p.snapshot, rootID, prefix)
-			if err != nil {
-				return err
-			}
-			if exists {
+		exists, err := p.snapshot.HasPrefixesAtRoot(rootID, run.prefixes)
+		if err != nil {
+			return err
+		}
+		for _, ok := range exists {
+			if ok {
 				return fmt.Errorf("collections: unique index %q conflict", run.indexName)
 			}
 		}
@@ -648,42 +652,6 @@ func indexValuePrefix(encodedValue []byte) ([]byte, error) {
 	out = binary.BigEndian.AppendUint16(out, uint16(len(encodedValue)))
 	out = append(out, encodedValue...)
 	return out, nil
-}
-
-func rootHasExactKey(snapshot rootSnapshotProbe, rootID uint64, key []byte) (bool, error) {
-	if snapshot == nil || rootID == 0 {
-		return false, nil
-	}
-	it, err := snapshot.IteratorAtRoot(rootID, key, prefixEnd(key))
-	if errors.Is(err, tree.ErrKeyNotFound) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	defer func() { _ = it.Close() }()
-	if !it.Valid() {
-		return false, it.Error()
-	}
-	return bytes.Equal(it.UnsafeKey(), key), it.Error()
-}
-
-func rootHasPrefix(snapshot rootSnapshotProbe, rootID uint64, prefix []byte) (bool, error) {
-	if snapshot == nil || rootID == 0 {
-		return false, nil
-	}
-	it, err := snapshot.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
-	if errors.Is(err, tree.ErrKeyNotFound) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	defer func() { _ = it.Close() }()
-	if !it.Valid() {
-		return false, it.Error()
-	}
-	return true, it.Error()
 }
 
 func prefixEnd(prefix []byte) []byte {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -13,6 +13,8 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 const documentIndexStateVersion = 1
@@ -123,7 +125,7 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 		p.indexStateRoot = p.collection + "/index-state"
 	}
 	if p.buildPrimaryVal == nil {
-		p.buildPrimaryVal = clonePrimaryDocument
+		p.buildPrimaryVal = borrowPrimaryDocument
 	}
 
 	items := make([]insertBatchItem, len(documents))
@@ -137,7 +139,7 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 			id:       id,
 			document: documents[i],
 		}
-		resultIDs[i] = bytes.Clone(id)
+		resultIDs[i] = id
 	}
 
 	if err := rejectDuplicateDocumentIDs(items); err != nil {
@@ -223,8 +225,8 @@ func (p insertBatchPreflight) checkUniqueConflicts(runs []collectionUniqueProbeR
 	return nil
 }
 
-func clonePrimaryDocument(_, document []byte) ([]byte, error) {
-	return bytes.Clone(document), nil
+func borrowPrimaryDocument(_, document []byte) ([]byte, error) {
+	return document, nil
 }
 
 func rejectDuplicateDocumentIDs(items []insertBatchItem) error {
@@ -340,7 +342,7 @@ func (p insertBatchPlanner) emitPrimaryRun(plan *insertBatchPlan, items []insert
 			return err
 		}
 		plan.stats.payloadBuilds++
-		table.SetSteal(bytes.Clone(items[idx].id), value)
+		setCollectionRunValue(table, items[idx].id, value)
 	}
 	table.Freeze()
 	plan.runs = append(plan.runs, collectionRootRun{
@@ -349,6 +351,10 @@ func (p insertBatchPlanner) emitPrimaryRun(plan *insertBatchPlan, items []insert
 		table: table,
 	})
 	return nil
+}
+
+func setCollectionRunValue(table memtable.Table, key, value []byte) {
+	table.SetEntrySteal(key, value, page.ValuePtr{}, node.FlagInline)
 }
 
 func (p insertBatchPlanner) emitIndexStateRun(plan *insertBatchPlan, items []insertBatchItem) error {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -94,7 +94,7 @@ type groupedRootPublisher interface {
 }
 
 type rootSnapshotProbe interface {
-	HasManyAtRoot(rootID uint64, keys [][]byte) ([]bool, error)
+	HasAnySortedAtRoot(rootID uint64, keys [][]byte) (bool, error)
 	HasPrefixesAtRoot(rootID uint64, prefixes [][]byte) ([]bool, error)
 }
 
@@ -142,7 +142,8 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 		resultIDs[i] = id
 	}
 
-	if err := rejectDuplicateDocumentIDs(items); err != nil {
+	primaryOrder := sortedItemOrderByKey(items, func(item *insertBatchItem) []byte { return item.id })
+	if err := rejectDuplicateDocumentIDs(items, primaryOrder); err != nil {
 		return nil, err
 	}
 
@@ -158,7 +159,7 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	if err != nil {
 		return nil, err
 	}
-	if err := preflight.checkDocumentConflicts(items); err != nil {
+	if err := preflight.checkDocumentConflicts(items, primaryOrder); err != nil {
 		return nil, err
 	}
 	if err := preflight.checkUniqueConflicts(uniqueProbeRuns); err != nil {
@@ -169,7 +170,7 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 		resultIDs:       resultIDs,
 		uniqueProbeRuns: uniqueProbeRuns,
 	}
-	if err := p.emitPrimaryRun(plan, items); err != nil {
+	if err := p.emitPrimaryRun(plan, items, primaryOrder); err != nil {
 		return nil, err
 	}
 	if len(runtimes) > 0 {
@@ -183,22 +184,20 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	return plan, nil
 }
 
-func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem) error {
+func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem, order []int) error {
 	if p.snapshot == nil || p.primaryRootID == 0 {
 		return nil
 	}
-	keys := make([][]byte, len(items))
-	for i := range items {
-		keys[i] = items[i].id
+	keys := make([][]byte, len(order))
+	for i, idx := range order {
+		keys[i] = items[idx].id
 	}
-	exists, err := p.snapshot.HasManyAtRoot(p.primaryRootID, keys)
+	exists, err := p.snapshot.HasAnySortedAtRoot(p.primaryRootID, keys)
 	if err != nil {
 		return err
 	}
-	for _, ok := range exists {
-		if ok {
-			return errors.New("collections: document already exists")
-		}
+	if exists {
+		return errors.New("collections: document already exists")
 	}
 	return nil
 }
@@ -229,14 +228,7 @@ func borrowPrimaryDocument(_, document []byte) ([]byte, error) {
 	return document, nil
 }
 
-func rejectDuplicateDocumentIDs(items []insertBatchItem) error {
-	order := make([]int, len(items))
-	for i := range order {
-		order[i] = i
-	}
-	sort.Slice(order, func(i, j int) bool {
-		return bytes.Compare(items[order[i]].id, items[order[j]].id) < 0
-	})
+func rejectDuplicateDocumentIDs(items []insertBatchItem, order []int) error {
 	for i := 1; i < len(order); i++ {
 		if bytes.Equal(items[order[i-1]].id, items[order[i]].id) {
 			return errors.New("collections: duplicate document id in batch")
@@ -333,8 +325,7 @@ func buildUniqueProbeRuns(candidates []uniqueProbeCandidate) ([]collectionUnique
 	return runs, nil
 }
 
-func (p insertBatchPlanner) emitPrimaryRun(plan *insertBatchPlan, items []insertBatchItem) error {
-	order := sortedItemOrderByKey(items, func(item *insertBatchItem) []byte { return item.id })
+func (p insertBatchPlanner) emitPrimaryRun(plan *insertBatchPlan, items []insertBatchItem, order []int) error {
 	table := newCollectionRunTable(len(items))
 	for _, idx := range order {
 		value, err := p.buildPrimaryVal(items[idx].id, items[idx].document)

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -1,0 +1,300 @@
+package collections
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestInsertBatchPlanner_EmitsRootLocalRunsForPrimaryIndexStateAndSecondaryRoots(t *testing.T) {
+	planner := insertBatchPlanner{
+		collection: "users",
+		indexes: []indexDefinition{
+			{name: "email", field: "email", unique: true},
+			{name: "city", field: "city"},
+		},
+	}
+
+	plan, err := planner.planInsertBatch(
+		[][]byte{[]byte("u2"), []byte("u1")},
+		[][]byte{
+			[]byte(`{"email":"grace@example.com","city":"hnl"}`),
+			[]byte(`{"email":"ada@example.com","city":"hnl"}`),
+		},
+	)
+	if err != nil {
+		t.Fatalf("plan insert batch: %v", err)
+	}
+	if got, want := len(plan.runs), 4; got != want {
+		t.Fatalf("runs len=%d want %d", got, want)
+	}
+
+	primary := mustFindRun(t, plan, collectionRootPrimary, "")
+	primaryEntries := collectRunEntries(t, primary)
+	assertEntryKeys(t, primaryEntries, "u1", "u2")
+	if got, want := string(primaryEntries[0].value), `{"email":"ada@example.com","city":"hnl"}`; got != want {
+		t.Fatalf("primary u1 value=%q want %q", got, want)
+	}
+	if got, want := string(primaryEntries[1].value), `{"email":"grace@example.com","city":"hnl"}`; got != want {
+		t.Fatalf("primary u2 value=%q want %q", got, want)
+	}
+
+	state := mustFindRun(t, plan, collectionRootIndexState, "")
+	stateEntries := collectRunEntries(t, state)
+	assertEntryKeys(t, stateEntries, "u1", "u2")
+	for _, entry := range stateEntries {
+		if len(entry.value) == 0 {
+			t.Fatalf("index-state entry for %q is empty", entry.key)
+		}
+	}
+
+	email := mustFindRun(t, plan, collectionRootSecondary, "email")
+	emailEntries := collectRunEntries(t, email)
+	if got, want := len(emailEntries), 2; got != want {
+		t.Fatalf("email index entries=%d want %d", got, want)
+	}
+	assertSortedEntries(t, emailEntries)
+	if !bytes.HasSuffix(emailEntries[0].key, []byte("u1")) || !bytes.HasSuffix(emailEntries[1].key, []byte("u2")) {
+		t.Fatalf("email entries should be value-prefix plus document id, got %q", entryKeys(emailEntries))
+	}
+
+	city := mustFindRun(t, plan, collectionRootSecondary, "city")
+	cityEntries := collectRunEntries(t, city)
+	if got, want := len(cityEntries), 2; got != want {
+		t.Fatalf("city index entries=%d want %d", got, want)
+	}
+	assertSortedEntries(t, cityEntries)
+
+	if got, want := len(plan.uniqueProbeRuns), 1; got != want {
+		t.Fatalf("unique probe runs=%d want %d", got, want)
+	}
+	if got, want := plan.uniqueProbeRuns[0].indexName, "email"; got != want {
+		t.Fatalf("unique probe index=%q want %q", got, want)
+	}
+	if got, want := len(plan.uniqueProbeRuns[0].prefixes), 2; got != want {
+		t.Fatalf("unique probe prefixes=%d want %d", got, want)
+	}
+	for _, prefix := range plan.uniqueProbeRuns[0].prefixes {
+		if bytes.Contains(prefix, []byte("u1")) || bytes.Contains(prefix, []byte("u2")) {
+			t.Fatalf("unique probe prefix contains a document id: %q", prefix)
+		}
+	}
+}
+
+func TestInsertBatchPlanner_PreservesCallerVisibleResultOrdering(t *testing.T) {
+	planner := insertBatchPlanner{collection: "users"}
+	ids := [][]byte{[]byte("u3"), []byte("u1"), []byte("u2")}
+
+	plan, err := planner.planInsertBatch(ids, [][]byte{
+		[]byte(`{"name":"third"}`),
+		[]byte(`{"name":"first"}`),
+		[]byte(`{"name":"second"}`),
+	})
+	if err != nil {
+		t.Fatalf("plan insert batch: %v", err)
+	}
+	if len(plan.resultIDs) != len(ids) {
+		t.Fatalf("result ids len=%d want %d", len(plan.resultIDs), len(ids))
+	}
+	for i := range ids {
+		if !bytes.Equal(plan.resultIDs[i], ids[i]) {
+			t.Fatalf("result id[%d]=%q want %q", i, plan.resultIDs[i], ids[i])
+		}
+	}
+
+	primary := mustFindRun(t, plan, collectionRootPrimary, "")
+	primaryEntries := collectRunEntries(t, primary)
+	assertEntryKeys(t, primaryEntries, "u1", "u2", "u3")
+	if got, want := plan.stats.payloadBuilds, 3; got != want {
+		t.Fatalf("payload builds=%d want %d", got, want)
+	}
+}
+
+func TestInsertBatchPlanner_FailFastDuplicatesBeforePayloadConstruction(t *testing.T) {
+	builds := 0
+	planner := insertBatchPlanner{
+		collection: "users",
+		buildPrimaryVal: func(_, document []byte) ([]byte, error) {
+			builds++
+			return bytes.Clone(document), nil
+		},
+	}
+
+	_, err := planner.planInsertBatch(
+		[][]byte{[]byte("u1"), []byte("u1")},
+		[][]byte{[]byte(`{"email":"a@example.com"}`), []byte(`{"email":"b@example.com"}`)},
+	)
+	if err == nil || !strings.Contains(err.Error(), "duplicate document id") {
+		t.Fatalf("err=%v want duplicate document id", err)
+	}
+	if builds != 0 {
+		t.Fatalf("payload builds=%d want 0", builds)
+	}
+
+	builds = 0
+	planner.indexes = []indexDefinition{{name: "email", field: "email", unique: true}}
+	_, err = planner.planInsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"email":"same@example.com"}`), []byte(`{"email":"same@example.com"}`)},
+	)
+	if err == nil || !strings.Contains(err.Error(), "unique index") {
+		t.Fatalf("err=%v want unique index conflict", err)
+	}
+	if builds != 0 {
+		t.Fatalf("payload builds=%d want 0", builds)
+	}
+}
+
+func TestInsertBatchPlanner_PublishesRunsThroughGroupedOrderedRootPublisher(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	planner := insertBatchPlanner{
+		collection: "users",
+		indexes: []indexDefinition{
+			{name: "email", field: "email", unique: true},
+		},
+	}
+	plan, err := planner.planInsertBatch(
+		[][]byte{[]byte("u2"), []byte("u1")},
+		[][]byte{
+			[]byte(`{"email":"grace@example.com"}`),
+			[]byte(`{"email":"ada@example.com"}`),
+		},
+	)
+	if err != nil {
+		t.Fatalf("plan insert batch: %v", err)
+	}
+
+	rootIDs, err := plan.publishRootRuns(d, nil)
+	if err != nil {
+		t.Fatalf("publish root runs: %v", err)
+	}
+	if got, want := len(rootIDs), len(plan.runs); got != want {
+		t.Fatalf("root IDs len=%d want %d", got, want)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	primaryRoot := rootIDs[mustFindRunIndex(t, plan, collectionRootPrimary, "")]
+	entry, err := snap.GetEntryAtRoot(primaryRoot, []byte("u1"))
+	if err != nil {
+		t.Fatalf("primary u1 lookup: %v", err)
+	}
+	if got, want := string(entry.Value), `{"email":"ada@example.com"}`; got != want {
+		t.Fatalf("primary u1 value=%q want %q", got, want)
+	}
+
+	stateRoot := rootIDs[mustFindRunIndex(t, plan, collectionRootIndexState, "")]
+	stateEntry, err := snap.GetEntryAtRoot(stateRoot, []byte("u2"))
+	if err != nil {
+		t.Fatalf("index-state u2 lookup: %v", err)
+	}
+	if len(stateEntry.Value) == 0 {
+		t.Fatalf("index-state u2 is empty")
+	}
+
+	emailRoot := rootIDs[mustFindRunIndex(t, plan, collectionRootSecondary, "email")]
+	it, err := snap.IteratorAtRoot(emailRoot, nil, nil)
+	if err != nil {
+		t.Fatalf("email index iterator: %v", err)
+	}
+	defer func() { _ = it.Close() }()
+	seen := 0
+	for it.Valid() {
+		seen++
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("email index iterator error: %v", err)
+	}
+	if got, want := seen, 2; got != want {
+		t.Fatalf("email index entries=%d want %d", got, want)
+	}
+}
+
+type runEntry struct {
+	key   []byte
+	value []byte
+}
+
+func mustFindRun(t *testing.T, plan *insertBatchPlan, kind collectionRootKind, indexName string) collectionRootRun {
+	t.Helper()
+	for _, run := range plan.runs {
+		if run.kind == kind && run.indexName == indexName {
+			return run
+		}
+	}
+	t.Fatalf("missing run kind=%d index=%q", kind, indexName)
+	return collectionRootRun{}
+}
+
+func mustFindRunIndex(t *testing.T, plan *insertBatchPlan, kind collectionRootKind, indexName string) int {
+	t.Helper()
+	for i, run := range plan.runs {
+		if run.kind == kind && run.indexName == indexName {
+			return i
+		}
+	}
+	t.Fatalf("missing run kind=%d index=%q", kind, indexName)
+	return -1
+}
+
+func collectRunEntries(t *testing.T, run collectionRootRun) []runEntry {
+	t.Helper()
+	if run.table == nil {
+		t.Fatalf("run %q has nil table", run.name)
+	}
+	it := run.table.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	var entries []runEntry
+	for it.Valid() {
+		entries = append(entries, runEntry{
+			key:   it.KeyCopy(nil),
+			value: it.ValueCopy(nil),
+		})
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterate run %q: %v", run.name, err)
+	}
+	return entries
+}
+
+func assertEntryKeys(t *testing.T, entries []runEntry, want ...string) {
+	t.Helper()
+	if len(entries) != len(want) {
+		t.Fatalf("entries len=%d want %d keys=%q", len(entries), len(want), entryKeys(entries))
+	}
+	for i := range want {
+		if got := string(entries[i].key); got != want[i] {
+			t.Fatalf("entry key[%d]=%q want %q; all keys=%q", i, got, want[i], entryKeys(entries))
+		}
+	}
+}
+
+func assertSortedEntries(t *testing.T, entries []runEntry) {
+	t.Helper()
+	for i := 1; i < len(entries); i++ {
+		if bytes.Compare(entries[i-1].key, entries[i].key) > 0 {
+			t.Fatalf("entries not sorted: %q", entryKeys(entries))
+		}
+	}
+}
+
+func entryKeys(entries []runEntry) [][]byte {
+	keys := make([][]byte, len(entries))
+	for i := range entries {
+		keys[i] = entries[i].key
+	}
+	return keys
+}

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -147,6 +147,109 @@ func TestInsertBatchPlanner_FailFastDuplicatesBeforePayloadConstruction(t *testi
 	}
 }
 
+func TestInsertBatchPlanner_RejectsPersistedDocumentIDBeforePayloadConstruction(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	primary := newCollectionRunTable(1)
+	primary.SetSteal([]byte("u1"), []byte(`{"email":"seed@example.com"}`))
+	primary.Freeze()
+	_, rootIDs, err := d.PublishOrderedRootGroup(nil, []backenddb.OrderedRootPublishInput{{
+		Iter: primary.NewIterator(nil, nil),
+	}})
+	if err != nil {
+		t.Fatalf("publish primary seed: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	builds := 0
+	planner := insertBatchPlanner{
+		collection: "users",
+		buildPrimaryVal: func(_, document []byte) ([]byte, error) {
+			builds++
+			return bytes.Clone(document), nil
+		},
+	}
+	_, err = planner.planInsertBatchWithPreflight(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"email":"dup@example.com"}`), []byte(`{"email":"new@example.com"}`)},
+		insertBatchPreflight{
+			snapshot:      snap,
+			primaryRootID: rootIDs[0],
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "document already exists") {
+		t.Fatalf("err=%v want persisted document conflict", err)
+	}
+	if builds != 0 {
+		t.Fatalf("payload builds=%d want 0", builds)
+	}
+}
+
+func TestInsertBatchPlanner_RejectsPersistedUniqueValueBeforePayloadConstruction(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	seedKey, err := indexEntryKey([]byte("s:seed@example.com"), []byte("seed"))
+	if err != nil {
+		t.Fatalf("seed index key: %v", err)
+	}
+	secondary := newCollectionRunTable(1)
+	secondary.SetSteal(seedKey, nil)
+	secondary.Freeze()
+	_, rootIDs, err := d.PublishOrderedRootGroup(nil, []backenddb.OrderedRootPublishInput{{
+		Iter: secondary.NewIterator(nil, nil),
+	}})
+	if err != nil {
+		t.Fatalf("publish secondary seed: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	builds := 0
+	planner := insertBatchPlanner{
+		collection: "users",
+		indexes: []indexDefinition{
+			{name: "email", field: "email", unique: true},
+		},
+		buildPrimaryVal: func(_, document []byte) ([]byte, error) {
+			builds++
+			return bytes.Clone(document), nil
+		},
+	}
+	_, err = planner.planInsertBatchWithPreflight(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"seed@example.com"}`)},
+		insertBatchPreflight{
+			snapshot: snap,
+			uniqueIndexRootIDs: map[string]uint64{
+				"email": rootIDs[0],
+			},
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "unique index") {
+		t.Fatalf("err=%v want persisted unique conflict", err)
+	}
+	if builds != 0 {
+		t.Fatalf("payload builds=%d want 0", builds)
+	}
+}
+
 func TestInsertBatchPlanner_PublishesRunsThroughGroupedOrderedRootPublisher(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -112,6 +112,24 @@ func TestInsertBatchPlanner_PreservesCallerVisibleResultOrdering(t *testing.T) {
 	}
 }
 
+func TestEncodeNormalizedDocumentIndexStateMatchesConservativeEncoder(t *testing.T) {
+	state := documentIndexState{
+		"city":  {[]byte("s:hnl")},
+		"email": {[]byte("s:ada@example.com")},
+	}
+	want, err := encodeDocumentIndexState(cloneDocumentIndexState(state))
+	if err != nil {
+		t.Fatalf("encode conservative index state: %v", err)
+	}
+	got, err := encodeNormalizedDocumentIndexState(cloneDocumentIndexState(state))
+	if err != nil {
+		t.Fatalf("encode normalized index state: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("normalized encoding mismatch\n got: %x\nwant: %x", got, want)
+	}
+}
+
 func TestInsertBatchPlanner_FailFastDuplicatesBeforePayloadConstruction(t *testing.T) {
 	builds := 0
 	planner := insertBatchPlanner{

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -250,6 +250,60 @@ func TestInsertBatchPlanner_RejectsPersistedUniqueValueBeforePayloadConstruction
 	}
 }
 
+func TestInsertBatchPlanner_PreflightUsesRootBatchProbes(t *testing.T) {
+	probe := &recordingRootSnapshotProbe{}
+	builds := 0
+	planner := insertBatchPlanner{
+		collection: "users",
+		indexes: []indexDefinition{
+			{name: "email", field: "email", unique: true},
+		},
+		buildPrimaryVal: func(_, document []byte) ([]byte, error) {
+			builds++
+			return bytes.Clone(document), nil
+		},
+	}
+
+	_, err := planner.planInsertBatchWithPreflight(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com"}`),
+			[]byte(`{"email":"grace@example.com"}`),
+		},
+		insertBatchPreflight{
+			snapshot:      probe,
+			primaryRootID: 42,
+			uniqueIndexRootIDs: map[string]uint64{
+				"email": 77,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("plan insert batch: %v", err)
+	}
+	if got, want := probe.hasManyCalls, 1; got != want {
+		t.Fatalf("HasManyAtRoot calls=%d want %d", got, want)
+	}
+	if got, want := probe.hasPrefixesCalls, 1; got != want {
+		t.Fatalf("HasPrefixesAtRoot calls=%d want %d", got, want)
+	}
+	if got, want := probe.lastHasManyRootID, uint64(42); got != want {
+		t.Fatalf("HasManyAtRoot root=%d want %d", got, want)
+	}
+	if got, want := probe.lastHasPrefixesRootID, uint64(77); got != want {
+		t.Fatalf("HasPrefixesAtRoot root=%d want %d", got, want)
+	}
+	if got, want := byteMatrixStrings(probe.lastHasManyKeys), []string{"u1", "u2"}; !equalStrings(got, want) {
+		t.Fatalf("HasManyAtRoot keys=%q want %q", got, want)
+	}
+	if got, want := len(probe.lastHasPrefixesPrefixes), 2; got != want {
+		t.Fatalf("HasPrefixesAtRoot prefixes=%d want %d", got, want)
+	}
+	if builds != 2 {
+		t.Fatalf("payload builds=%d want 2", builds)
+	}
+}
+
 func TestInsertBatchPlanner_PublishesRunsThroughGroupedOrderedRootPublisher(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -330,6 +384,29 @@ type runEntry struct {
 	value []byte
 }
 
+type recordingRootSnapshotProbe struct {
+	hasManyCalls            int
+	hasPrefixesCalls        int
+	lastHasManyRootID       uint64
+	lastHasPrefixesRootID   uint64
+	lastHasManyKeys         [][]byte
+	lastHasPrefixesPrefixes [][]byte
+}
+
+func (p *recordingRootSnapshotProbe) HasManyAtRoot(rootID uint64, keys [][]byte) ([]bool, error) {
+	p.hasManyCalls++
+	p.lastHasManyRootID = rootID
+	p.lastHasManyKeys = cloneByteMatrix(keys)
+	return make([]bool, len(keys)), nil
+}
+
+func (p *recordingRootSnapshotProbe) HasPrefixesAtRoot(rootID uint64, prefixes [][]byte) ([]bool, error) {
+	p.hasPrefixesCalls++
+	p.lastHasPrefixesRootID = rootID
+	p.lastHasPrefixesPrefixes = cloneByteMatrix(prefixes)
+	return make([]bool, len(prefixes)), nil
+}
+
 func mustFindRun(t *testing.T, plan *insertBatchPlan, kind collectionRootKind, indexName string) collectionRootRun {
 	t.Helper()
 	for _, run := range plan.runs {
@@ -400,4 +477,32 @@ func entryKeys(entries []runEntry) [][]byte {
 		keys[i] = entries[i].key
 	}
 	return keys
+}
+
+func cloneByteMatrix(in [][]byte) [][]byte {
+	out := make([][]byte, len(in))
+	for i := range in {
+		out[i] = bytes.Clone(in[i])
+	}
+	return out
+}
+
+func byteMatrixStrings(in [][]byte) []string {
+	out := make([]string, len(in))
+	for i := range in {
+		out[i] = string(in[i])
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"sort"
 	"strings"
 	"testing"
 
@@ -127,6 +128,36 @@ func TestEncodeNormalizedDocumentIndexStateMatchesConservativeEncoder(t *testing
 	}
 	if !bytes.Equal(got, want) {
 		t.Fatalf("normalized encoding mismatch\n got: %x\nwant: %x", got, want)
+	}
+}
+
+func TestBuildUniqueProbeRunsMatchesEncodedPrefixOrdering(t *testing.T) {
+	candidates := []uniqueProbeCandidate{
+		{indexName: "email", encodedValue: []byte("s:zz"), documentID: []byte("u3")},
+		{indexName: "email", encodedValue: []byte("s:a"), documentID: []byte("u1")},
+		{indexName: "email", encodedValue: []byte("s:bbbb"), documentID: []byte("u2")},
+	}
+	runs, err := buildUniqueProbeRuns(candidates)
+	if err != nil {
+		t.Fatalf("build unique probe runs: %v", err)
+	}
+	if got, want := len(runs), 1; got != want {
+		t.Fatalf("runs=%d want %d", got, want)
+	}
+
+	want := make([][]byte, 0, len(candidates))
+	for _, candidate := range candidates {
+		prefix, err := indexValuePrefix(candidate.encodedValue)
+		if err != nil {
+			t.Fatalf("index value prefix: %v", err)
+		}
+		want = append(want, prefix)
+	}
+	sort.Slice(want, func(i, j int) bool {
+		return bytes.Compare(want[i], want[j]) < 0
+	})
+	if !byteMatrixEqual(runs[0].prefixes, want) {
+		t.Fatalf("prefix order mismatch\n got: %q\nwant: %q", runs[0].prefixes, want)
 	}
 }
 
@@ -503,6 +534,18 @@ func cloneByteMatrix(in [][]byte) [][]byte {
 		out[i] = bytes.Clone(in[i])
 	}
 	return out
+}
+
+func byteMatrixEqual(a, b [][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !bytes.Equal(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func byteMatrixStrings(in [][]byte) []string {

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -281,20 +281,20 @@ func TestInsertBatchPlanner_PreflightUsesRootBatchProbes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plan insert batch: %v", err)
 	}
-	if got, want := probe.hasManyCalls, 1; got != want {
-		t.Fatalf("HasManyAtRoot calls=%d want %d", got, want)
+	if got, want := probe.hasAnySortedCalls, 1; got != want {
+		t.Fatalf("HasAnySortedAtRoot calls=%d want %d", got, want)
 	}
 	if got, want := probe.hasPrefixesCalls, 1; got != want {
 		t.Fatalf("HasPrefixesAtRoot calls=%d want %d", got, want)
 	}
-	if got, want := probe.lastHasManyRootID, uint64(42); got != want {
-		t.Fatalf("HasManyAtRoot root=%d want %d", got, want)
+	if got, want := probe.lastHasAnySortedRootID, uint64(42); got != want {
+		t.Fatalf("HasAnySortedAtRoot root=%d want %d", got, want)
 	}
 	if got, want := probe.lastHasPrefixesRootID, uint64(77); got != want {
 		t.Fatalf("HasPrefixesAtRoot root=%d want %d", got, want)
 	}
-	if got, want := byteMatrixStrings(probe.lastHasManyKeys), []string{"u1", "u2"}; !equalStrings(got, want) {
-		t.Fatalf("HasManyAtRoot keys=%q want %q", got, want)
+	if got, want := byteMatrixStrings(probe.lastHasAnySortedKeys), []string{"u1", "u2"}; !equalStrings(got, want) {
+		t.Fatalf("HasAnySortedAtRoot keys=%q want %q", got, want)
 	}
 	if got, want := len(probe.lastHasPrefixesPrefixes), 2; got != want {
 		t.Fatalf("HasPrefixesAtRoot prefixes=%d want %d", got, want)
@@ -385,19 +385,19 @@ type runEntry struct {
 }
 
 type recordingRootSnapshotProbe struct {
-	hasManyCalls            int
+	hasAnySortedCalls       int
 	hasPrefixesCalls        int
-	lastHasManyRootID       uint64
+	lastHasAnySortedRootID  uint64
 	lastHasPrefixesRootID   uint64
-	lastHasManyKeys         [][]byte
+	lastHasAnySortedKeys    [][]byte
 	lastHasPrefixesPrefixes [][]byte
 }
 
-func (p *recordingRootSnapshotProbe) HasManyAtRoot(rootID uint64, keys [][]byte) ([]bool, error) {
-	p.hasManyCalls++
-	p.lastHasManyRootID = rootID
-	p.lastHasManyKeys = cloneByteMatrix(keys)
-	return make([]bool, len(keys)), nil
+func (p *recordingRootSnapshotProbe) HasAnySortedAtRoot(rootID uint64, keys [][]byte) (bool, error) {
+	p.hasAnySortedCalls++
+	p.lastHasAnySortedRootID = rootID
+	p.lastHasAnySortedKeys = cloneByteMatrix(keys)
+	return false, nil
 }
 
 func (p *recordingRootSnapshotProbe) HasPrefixesAtRoot(rootID uint64, prefixes [][]byte) ([]bool, error) {

--- a/TreeDB/db/close_hooks_test.go
+++ b/TreeDB/db/close_hooks_test.go
@@ -1,0 +1,40 @@
+package db
+
+import "testing"
+
+func TestRegisterCloseHookAfterRunCloseHooksIsIgnored(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	ran := 0
+	unregister := d.RegisterCloseHook(func() error {
+		ran++
+		return nil
+	})
+	if err := d.RunCloseHooks(); err != nil {
+		t.Fatalf("RunCloseHooks: %v", err)
+	}
+	if ran != 1 {
+		t.Fatalf("close hook ran %d times, want 1", ran)
+	}
+
+	lateRan := false
+	lateUnregister := d.RegisterCloseHook(func() error {
+		lateRan = true
+		return nil
+	})
+	lateUnregister()
+	unregister()
+	if err := d.RunCloseHooks(); err != nil {
+		t.Fatalf("second RunCloseHooks: %v", err)
+	}
+	if lateRan {
+		t.Fatalf("late close hook ran after hook drain started")
+	}
+	if ran != 1 {
+		t.Fatalf("close hook ran %d times after second drain, want 1", ran)
+	}
+}

--- a/TreeDB/db/closed_db_public_methods_test.go
+++ b/TreeDB/db/closed_db_public_methods_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 )
 
 func newClosedDBForPublicMethodTest(t *testing.T) *DB {
@@ -327,6 +329,22 @@ func TestClosedDB_PublishOrderedRootGroup(t *testing.T) {
 		_, _, err := d.PublishOrderedRootGroup(nil, nil)
 		if !errors.Is(err, ErrClosed) {
 			t.Fatalf("PublishOrderedRootGroup err=%v want %v", err, ErrClosed)
+		}
+	})
+}
+
+func TestClosedDB_PublishOrderedRootDeltaGroupWithSystemBuilder(t *testing.T) {
+	runClosedDBMethod(t, "PublishOrderedRootDeltaGroupWithSystemBuilder", func(d *DB) {
+		table := mustFrozenSystemMemtable(t, "root/k", "v")
+		iter := table.NewIterator(nil, nil)
+		defer iter.Close()
+		_, _, err := d.PublishOrderedRootDeltaGroupWithSystemBuilder([]OrderedRootDeltaPublishInput{{
+			Iter: iter,
+		}}, func([]uint64) (iterator.UnsafeIterator, error) {
+			return mustFrozenSystemMemtable(t, "sys/k", "v").NewIterator(nil, nil), nil
+		})
+		if !errors.Is(err, ErrClosed) {
+			t.Fatalf("PublishOrderedRootDeltaGroupWithSystemBuilder err=%v want %v", err, ErrClosed)
 		}
 	})
 }

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -147,6 +147,10 @@ type DB struct {
 	bgErr        error
 	closeHooksMu sync.Mutex
 	closeHooks   []func() error
+	// closeHooksClosed is set when close hook draining begins. Close hooks run
+	// while writes are still available, so registrations after that point would
+	// otherwise be silently lost.
+	closeHooksClosed bool
 
 	leafGenerationLiveStatsMu        sync.RWMutex
 	leafGenerationLiveStatsCache     leafGenerationLiveStatsCache
@@ -1383,7 +1387,7 @@ func (db *DB) RegisterCloseHook(hook func() error) func() {
 		return func() {}
 	}
 	db.closeHooksMu.Lock()
-	if db.closing.Load() {
+	if db.closeHooksClosed || db.closing.Load() {
 		db.closeHooksMu.Unlock()
 		return func() {}
 	}
@@ -1411,6 +1415,11 @@ func (db *DB) RunCloseHooks() error {
 		return nil
 	}
 	db.closeHooksMu.Lock()
+	if db.closeHooksClosed {
+		db.closeHooksMu.Unlock()
+		return nil
+	}
+	db.closeHooksClosed = true
 	hooks := append([]func() error(nil), db.closeHooks...)
 	clear(db.closeHooks)
 	db.closeHooks = nil

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -142,9 +142,11 @@ type DB struct {
 	readRetryRefreshFollowerCount atomic.Uint64
 	readRetryRefreshSkippedEpoch  atomic.Uint64
 
-	notifyError func(error)
-	bgErrMu     sync.Mutex
-	bgErr       error
+	notifyError  func(error)
+	bgErrMu      sync.Mutex
+	bgErr        error
+	closeHooksMu sync.Mutex
+	closeHooks   []func() error
 
 	leafGenerationLiveStatsMu        sync.RWMutex
 	leafGenerationLiveStatsCache     leafGenerationLiveStatsCache
@@ -1374,7 +1376,63 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 	return db, nil
 }
 
+// RegisterCloseHook registers a callback that runs before Close marks the DB as
+// closing, while normal write/publish APIs are still available.
+func (db *DB) RegisterCloseHook(hook func() error) func() {
+	if db == nil || hook == nil {
+		return func() {}
+	}
+	db.closeHooksMu.Lock()
+	if db.closing.Load() {
+		db.closeHooksMu.Unlock()
+		return func() {}
+	}
+	idx := len(db.closeHooks)
+	db.closeHooks = append(db.closeHooks, hook)
+	db.closeHooksMu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			db.closeHooksMu.Lock()
+			if idx >= 0 && idx < len(db.closeHooks) && db.closeHooks[idx] != nil {
+				db.closeHooks[idx] = nil
+			}
+			db.closeHooksMu.Unlock()
+		})
+	}
+}
+
+// RunCloseHooks runs and clears registered close hooks. Wrappers that own a
+// backend DB should call this before they start closing resources required by
+// backend publish APIs.
+func (db *DB) RunCloseHooks() error {
+	if db == nil {
+		return nil
+	}
+	db.closeHooksMu.Lock()
+	hooks := append([]func() error(nil), db.closeHooks...)
+	clear(db.closeHooks)
+	db.closeHooks = nil
+	db.closeHooksMu.Unlock()
+
+	var errs []error
+	for _, hook := range hooks {
+		if hook == nil {
+			continue
+		}
+		if err := hook(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func (db *DB) Close() error {
+	var errs []error
+	if err := db.RunCloseHooks(); err != nil {
+		errs = append(errs, err)
+	}
 	db.closing.Store(true)
 	db.stopCommitCombiner()
 	db.pruner.Stop()
@@ -1390,7 +1448,6 @@ func (db *DB) Close() error {
 	db.lock = nil
 	db.mu.Unlock()
 
-	var errs []error
 	drainDeadline := time.Now().Add(closeSnapshotDrainTimeout)
 	for db.snapshotAcquireInFlight() > 0 {
 		if time.Now().After(drainDeadline) {
@@ -1726,8 +1783,9 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 	}
 
 	// Ensure value-log-backed leaf pages are flushed before we publish an index
-	// commit that references them.
-	if db.indexOuterLeavesInValueLog && db.leafPageLog != nil {
+	// commit that references them. Per-root storage policies can use the leaf
+	// page log even when the DB-level default stores outer leaves in index pages.
+	if db.leafPageLog != nil {
 		if sync {
 			if err := db.leafPageLog.Sync(); err != nil {
 				return post, prePublishErr(err)
@@ -1863,7 +1921,7 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 	if leafPageSegmentRegistered && leafPageSegmentFileID != 0 {
 		db.queueLeafGenerationWritableFileIDAtCommit(leafPageSegmentFileID, nextMeta.CommitSeq)
 	}
-	if db.indexOuterLeavesInValueLog && db.leafPageLog != nil {
+	if db.leafPageLog != nil {
 		stagedLeafManifest, changed, err := db.stagedLeafGenerationManifestWithPending(db.leafGenerationManifest, 0, nextMeta.CommitSeq)
 		if err != nil {
 			db.mu.Unlock()
@@ -1888,7 +1946,7 @@ func (db *DB) finalizeCommitLocked(newRootID uint64, sysRootID uint64, retired [
 	db.publishSnapshotView(idx, newState, db.valueLogManager)
 	post.commitSeq = nextMeta.CommitSeq
 	post.vlogRefDelta = vlogRefDelta
-	if db.indexOuterLeavesInValueLog && db.leafPageLog != nil {
+	if db.leafPageLog != nil {
 		post.drainLeafGenerationPending = true
 	}
 	db.mu.Unlock()

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1,12 +1,10 @@
 package db
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -2069,64 +2067,11 @@ func (s *Snapshot) Has(key []byte) (bool, error) {
 }
 
 func (s *Snapshot) HasMany(keys [][]byte) ([]bool, error) {
-	out := make([]bool, len(keys))
-	for i, key := range keys {
-		ok, err := s.tree.Has(key)
-		if err != nil {
-			return nil, err
-		}
-		out[i] = ok
-	}
-	return out, nil
+	return s.tree.HasMany(keys)
 }
 
 func (s *Snapshot) HasPrefixes(prefixes [][]byte) ([]bool, error) {
-	out := make([]bool, len(prefixes))
-	if len(prefixes) == 0 {
-		return out, nil
-	}
-
-	type prefixProbeRef struct {
-		prefix []byte
-		idx    int
-	}
-	refs := make([]prefixProbeRef, len(prefixes))
-	for i, prefix := range prefixes {
-		refs[i] = prefixProbeRef{prefix: prefix, idx: i}
-	}
-	sort.Slice(refs, func(i, j int) bool {
-		return bytes.Compare(refs[i].prefix, refs[j].prefix) < 0
-	})
-
-	unique := make([][]byte, 0, len(refs))
-	groupStarts := make([]int, 0, len(refs))
-	for i, ref := range refs {
-		if len(unique) == 0 || !bytes.Equal(ref.prefix, unique[len(unique)-1]) {
-			unique = append(unique, ref.prefix)
-			groupStarts = append(groupStarts, i)
-		}
-	}
-
-	for i, prefix := range unique {
-		it := s.tree.IteratorWithOptions(prefix, nil, tree.IteratorOptions{Mode: tree.IteratorModeKeysOnly})
-		ok := it.Valid() && bytes.HasPrefix(it.UnsafeKey(), prefix) && !it.IsDeleted()
-		err := it.Error()
-		_ = it.Close()
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			continue
-		}
-		groupEnd := len(refs)
-		if i+1 < len(groupStarts) {
-			groupEnd = groupStarts[i+1]
-		}
-		for _, ref := range refs[groupStarts[i]:groupEnd] {
-			out[ref.idx] = true
-		}
-	}
-	return out, nil
+	return s.tree.HasPrefixes(prefixes)
 }
 
 // GetEntry returns the persisted leaf entry for key.

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -749,6 +749,15 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	retired = append(retired, rootRetired...)
 	mergeOrderedRootPublishMetrics(&merged, metrics)
 	vlogRefDelta := refDelta
+	if len(ordered) > 0 {
+		// Non-system roots were applied from deltas, so this commit has no
+		// exact value-log ref delta for their pointer changes. Keep GC
+		// reachability conservative by invalidating the tracker after commit.
+		if vlogRefDelta != nil {
+			releaseValueLogRefDelta(vlogRefDelta)
+		}
+		vlogRefDelta = nil
+	}
 	defer func() {
 		if vlogRefDelta != nil {
 			releaseValueLogRefDelta(vlogRefDelta)
@@ -763,7 +772,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
 	}
 
-	if vlogRefDelta == nil {
+	if len(ordered) == 0 && vlogRefDelta == nil {
 		vlogRefDelta = db.newNoopValueLogRefDeltaIfTrackable(baseSeq)
 	}
 	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil); err != nil {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -57,6 +57,14 @@ type OrderedRootDeltaPublishInput struct {
 // PublishOrderedRootGroupWithSystemBuilder.
 type OrderedRootGroupSystemBuilder func(rootIDs []uint64) (iterator.UnsafeIterator, error)
 
+type orderedRootStableUnsafeIterator interface {
+	StableUnsafeIteratorSlices() bool
+}
+
+type orderedRootLenHintIterator interface {
+	Len() int
+}
+
 func selectOrderedRootWarmPublishPlan(hasExistingEntries bool, deltaOps int, maxDeltaOps int) orderedRootPublishPlan {
 	if !hasExistingEntries {
 		return orderedRootPublishPlanColdBuild
@@ -107,26 +115,45 @@ func orderedRootEntryValueLogFileID(iter iterator.UnsafeIterator) (uint32, bool)
 	return ptr.FileID, true
 }
 
-func orderedRootBatchPut(delta *batch.Batch, iter iterator.UnsafeIterator) error {
+func orderedRootBatchPut(delta *batch.Batch, iter iterator.UnsafeIterator, borrowEntryViews bool) error {
 	if delta == nil || iter == nil || !iter.Valid() {
 		return nil
 	}
 	val, ptr, flags := iter.UnsafeEntry()
 	if flags&node.FlagPointer != 0 && page.IsValueLogFileID(ptr.FileID) {
+		if borrowEntryViews {
+			return delta.SetPointerView(iter.UnsafeKey(), ptr)
+		}
 		return delta.SetPointer(iter.UnsafeKey(), ptr)
+	}
+	if borrowEntryViews {
+		return delta.SetView(iter.UnsafeKey(), val)
 	}
 	return delta.Set(iter.UnsafeKey(), val)
 }
 
 func orderedRootDeltaBatchFromIterator(iter iterator.UnsafeIterator) (*batch.Batch, error) {
 	delta := batch.New(nil, page.DefaultInlineThreshold)
+	if hint, ok := iter.(orderedRootLenHintIterator); ok {
+		delta.Reserve(hint.Len())
+	}
+	borrowEntryViews := false
+	if stable, ok := iter.(orderedRootStableUnsafeIterator); ok {
+		borrowEntryViews = stable.StableUnsafeIteratorSlices()
+	}
 	for iter.Valid() {
 		if iter.IsDeleted() {
-			if err := delta.Delete(iter.UnsafeKey()); err != nil {
+			var err error
+			if borrowEntryViews {
+				err = delta.DeleteView(iter.UnsafeKey())
+			} else {
+				err = delta.Delete(iter.UnsafeKey())
+			}
+			if err != nil {
 				_ = delta.Close()
 				return nil, err
 			}
-		} else if err := orderedRootBatchPut(delta, iter); err != nil {
+		} else if err := orderedRootBatchPut(delta, iter, borrowEntryViews); err != nil {
 			_ = delta.Close()
 			return nil, err
 		}
@@ -220,7 +247,7 @@ func buildOrderedRootDeltaBatch(baseIter, targetIter iterator.UnsafeIterator, tr
 					vlogRefDelta.add(fileID, 1)
 				}
 			}
-			if err := orderedRootBatchPut(delta, targetIter); err != nil {
+			if err := orderedRootBatchPut(delta, targetIter, false); err != nil {
 				_ = delta.Close()
 				return nil, 0, nil, err
 			}
@@ -248,7 +275,7 @@ func buildOrderedRootDeltaBatch(baseIter, targetIter iterator.UnsafeIterator, tr
 						vlogRefDelta.add(fileID, 1)
 					}
 				}
-				if err := orderedRootBatchPut(delta, targetIter); err != nil {
+				if err := orderedRootBatchPut(delta, targetIter, false); err != nil {
 					_ = delta.Close()
 					return nil, 0, nil, err
 				}
@@ -265,7 +292,7 @@ func buildOrderedRootDeltaBatch(baseIter, targetIter iterator.UnsafeIterator, tr
 							vlogRefDelta.add(fileID, 1)
 						}
 					}
-					if err := orderedRootBatchPut(delta, targetIter); err != nil {
+					if err := orderedRootBatchPut(delta, targetIter, false); err != nil {
 						_ = delta.Close()
 						return nil, 0, nil, err
 					}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -23,6 +23,8 @@ const (
 	orderedRootPublishPlanWarmNativeApply
 )
 
+var orderedRootDeltaBatchInlineThreshold = int(^uint(0) >> 1)
+
 type orderedRootPublishStats struct {
 	warmAttempts            uint64
 	warmNativeApplyAttempts uint64
@@ -213,7 +215,7 @@ func orderedRootBatchPut(delta *batch.Batch, iter iterator.UnsafeIterator, borro
 }
 
 func orderedRootDeltaBatchFromIterator(iter iterator.UnsafeIterator) (*batch.Batch, error) {
-	delta := batch.New(nil, page.DefaultInlineThreshold)
+	delta := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
 	if hint, ok := iter.(orderedRootLenHintIterator); ok {
 		delta.Reserve(hint.Len())
 	}
@@ -306,7 +308,7 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 }
 
 func buildOrderedRootDeltaBatch(baseIter, targetIter iterator.UnsafeIterator, trackRefs bool) (*batch.Batch, int, *valueLogRefDelta, error) {
-	delta := batch.New(nil, page.DefaultInlineThreshold)
+	delta := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
 	baseValid := baseIter.Valid()
 	targetValid := targetIter.Valid()
 	deltaOps := 0

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -43,6 +43,12 @@ type OrderedRootPublishInput struct {
 	Iter     iterator.UnsafeIterator
 }
 
+// OrderedRootGroupSystemBuilder builds a target system-root iterator after the
+// non-system roots in a group have been built. The rootIDs slice is ordered to
+// match the OrderedRootPublishInput slice passed to
+// PublishOrderedRootGroupWithSystemBuilder.
+type OrderedRootGroupSystemBuilder func(rootIDs []uint64) (iterator.UnsafeIterator, error)
+
 func selectOrderedRootWarmPublishPlan(hasExistingEntries bool, deltaOps int, maxDeltaOps int) orderedRootPublishPlan {
 	if !hasExistingEntries {
 		return orderedRootPublishPlanColdBuild
@@ -439,6 +445,24 @@ func (db *DB) PublishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 // group in one backend commit. Non-system roots are built from ordered
 // iterators and become durable when the grouped commit finalizes.
 func (db *DB) PublishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordered []OrderedRootPublishInput) (uint64, []uint64, error) {
+	return db.publishOrderedRootGroup(systemIter, ordered, nil)
+}
+
+// PublishOrderedRootGroupWithSystemBuilder builds non-system roots first, then
+// calls buildSystemIter with the produced root IDs and commits the system root
+// plus all non-system roots in one backend commit. This is intended for callers
+// whose system descriptors must store the new root IDs produced by the group.
+func (db *DB) PublishOrderedRootGroupWithSystemBuilder(ordered []OrderedRootPublishInput, buildSystemIter OrderedRootGroupSystemBuilder) (uint64, []uint64, error) {
+	if buildSystemIter == nil {
+		return 0, nil, errors.New("nil ordered root group system builder")
+	}
+	return db.publishOrderedRootGroup(nil, ordered, buildSystemIter)
+}
+
+func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordered []OrderedRootPublishInput, buildSystemIter OrderedRootGroupSystemBuilder) (uint64, []uint64, error) {
+	if systemIter != nil && buildSystemIter != nil {
+		return 0, nil, errors.New("ordered root group cannot use both system iterator and system builder")
+	}
 	if db == nil {
 		return 0, nil, ErrClosed
 	}
@@ -492,6 +516,26 @@ func (db *DB) PublishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 		rootIDs[idx] = rootID
 		retired = append(retired, rootRetired...)
 		mergeOrderedRootPublishMetrics(&merged, metrics)
+	}
+
+	if buildSystemIter != nil {
+		builtRootIDs := append([]uint64(nil), rootIDs...)
+		iter, err := buildSystemIter(builtRootIDs)
+		if err != nil {
+			return 0, nil, err
+		}
+		if iter == nil {
+			return 0, nil, errors.New("nil system root iterator")
+		}
+		rootID, rootRetired, metrics, publishStats, refDelta, err := db.publishOrderedRootIterator(baseSystemRoot, iter, opts, true)
+		if err != nil {
+			return 0, nil, err
+		}
+		newSystemRoot = rootID
+		retired = append(retired, rootRetired...)
+		mergeOrderedRootPublishMetrics(&merged, metrics)
+		systemStats = publishStats
+		vlogRefDelta = refDelta
 	}
 
 	db.mu.RLock()

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -771,7 +771,6 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 	db.mu.RLock()
 	userRoot := db.meta.UserRootPageID
 	baseSystemRoot := db.meta.SystemRootPageID
-	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 
 	systemOpts := systemRootOrderedPublishOptions(db)
@@ -815,16 +814,13 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
 	}
 
-	vlogRefDelta := db.newNoopValueLogRefDeltaIfTrackable(baseSeq)
-	defer func() {
-		if vlogRefDelta != nil {
-			releaseValueLogRefDelta(vlogRefDelta)
-		}
-	}()
+	// The system root was applied as a delta, so we do not have an exact
+	// value-log ref delta for system-root pointer changes. Passing nil keeps the
+	// tracker conservative by invalidating it after commit.
+	var vlogRefDelta *valueLogRefDelta
 	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil); err != nil {
 		return 0, nil, err
 	}
-	vlogRefDelta = nil
 	return newSystemRoot, rootIDs, nil
 }
 

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -12,6 +12,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/tree"
+	"github.com/snissn/gomap/TreeDB/zipper"
 )
 
 type orderedRootPublishPlan uint8
@@ -36,19 +37,38 @@ type orderedRootPublishOptions struct {
 	leafColumnar          bool
 	packedValuePtr        bool
 	internalBaseDelta     bool
+	outerLeavesInValueLog bool
+	leafPageLog           bulk.LeafPageAppender
 }
 
+// OrderedRootStoragePolicy selects the physical storage policy for a published
+// ordered root. The zero value keeps the DB-level default.
+type OrderedRootStoragePolicy uint8
+
+const (
+	OrderedRootStorageDefault OrderedRootStoragePolicy = iota
+	// OrderedRootStoragePagerLeaves stores root leaves in index.db pages. It is
+	// the fast index policy and can use internal base-delta child encodings.
+	OrderedRootStoragePagerLeaves
+	// OrderedRootStorageValueLogLeaves stores root leaves as value-log LeafRefs.
+	// It is the compressed policy; internal base-delta is disabled because
+	// LeafRef child IDs use the same child-id space.
+	OrderedRootStorageValueLogLeaves
+)
+
 type OrderedRootPublishInput struct {
-	BaseRoot uint64
-	Iter     iterator.UnsafeIterator
+	BaseRoot      uint64
+	Iter          iterator.UnsafeIterator
+	StoragePolicy OrderedRootStoragePolicy
 }
 
 // OrderedRootDeltaPublishInput describes a sorted root-local mutation stream.
 // Unlike OrderedRootPublishInput, Iter contains only keys changed by this
 // publish; omitted base-root keys are preserved.
 type OrderedRootDeltaPublishInput struct {
-	BaseRoot uint64
-	Iter     iterator.UnsafeIterator
+	BaseRoot      uint64
+	Iter          iterator.UnsafeIterator
+	StoragePolicy OrderedRootStoragePolicy
 }
 
 // OrderedRootGroupSystemBuilder builds a target system-root iterator after the
@@ -75,11 +95,71 @@ func selectOrderedRootWarmPublishPlan(hasExistingEntries bool, deltaOps int, max
 	return orderedRootPublishPlanWarmFallbackRebuild
 }
 
-func materializeOrderedRootTable(iter iterator.UnsafeIterator) (memtable.Table, error) {
-	table, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
-	if err != nil {
-		return nil, err
+func (db *DB) orderedRootPublishOptionsForPolicy(policy OrderedRootStoragePolicy) (orderedRootPublishOptions, error) {
+	opts := systemRootOrderedPublishOptions(db)
+	switch policy {
+	case OrderedRootStorageDefault:
+		return opts, nil
+	case OrderedRootStoragePagerLeaves:
+		opts.outerLeavesInValueLog = false
+		opts.leafPageLog = nil
+		opts.internalBaseDelta = true
+		return opts, nil
+	case OrderedRootStorageValueLogLeaves:
+		opts.outerLeavesInValueLog = true
+		opts.internalBaseDelta = false
+		opts.leafPageLog = db.leafPageLog
+		if opts.leafPageLog == nil {
+			return opts, errors.New("ordered root value-log leaf storage requires a leaf page log")
+		}
+		return opts, nil
+	default:
+		return opts, errors.New("unknown ordered root storage policy")
 	}
+}
+
+func (db *DB) orderedRootZipperForOptions(idx *indexGen, opts orderedRootPublishOptions) (*zipper.Zipper, error) {
+	if idx == nil || idx.zipper == nil {
+		return nil, errors.New("missing index")
+	}
+	if db != nil && db.orderedRootOptionsUseDefaultZipper(opts) {
+		return idx.zipper, nil
+	}
+	z := idx.zipper.CloneWithAllocator(idx.allocator)
+	z.SetOuterLeavesInValueLog(opts.outerLeavesInValueLog)
+	z.SetIndexInternalBaseDelta(opts.internalBaseDelta && !opts.outerLeavesInValueLog)
+	if opts.outerLeavesInValueLog {
+		if opts.leafPageLog == nil {
+			return nil, errors.New("ordered root value-log leaf storage requires a leaf page log")
+		}
+		z.SetLeafPageLog(opts.leafPageLog)
+	}
+	return z, nil
+}
+
+func (db *DB) orderedRootOptionsUseDefaultZipper(opts orderedRootPublishOptions) bool {
+	if db == nil {
+		return false
+	}
+	if opts.leafPrefixCompression != db.leafPrefixCompression ||
+		opts.leafColumnar != db.indexColumnarLeaves ||
+		opts.packedValuePtr != db.indexPackedValuePtr ||
+		opts.outerLeavesInValueLog != db.indexOuterLeavesInValueLog ||
+		(opts.internalBaseDelta && !opts.outerLeavesInValueLog) != db.indexInternalBaseDelta {
+		return false
+	}
+	if opts.outerLeavesInValueLog && opts.leafPageLog != db.leafPageLog {
+		return false
+	}
+	return true
+}
+
+func materializeOrderedRootTable(iter iterator.UnsafeIterator) (memtable.Table, error) {
+	entries := 0
+	if hint, ok := iter.(orderedRootLenHintIterator); ok {
+		entries = hint.Len()
+	}
+	table := memtable.NewAppendOnlyWithEntryCapacity(entries)
 	for iter.Valid() {
 		val, ptr, flags := iter.UnsafeEntry()
 		table.SetEntry(iter.UnsafeKey(), val, ptr, flags)
@@ -205,6 +285,10 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 		err = errors.New("missing index")
 		return
 	}
+	if opts.outerLeavesInValueLog && opts.leafPageLog == nil {
+		err = errors.New("ordered root value-log leaf storage requires a leaf page log")
+		return
+	}
 	delta, err := orderedRootDeltaBatchFromIterator(iter)
 	if err != nil {
 		return 0, nil, metrics, err
@@ -213,7 +297,11 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 	if len(delta.SortedEntries()) == 0 {
 		return baseRoot, nil, metrics, nil
 	}
-	newRoot, retired, metrics, err = idx.zipper.Apply(baseRoot, delta)
+	rootZipper, err := db.orderedRootZipperForOptions(idx, opts)
+	if err != nil {
+		return 0, nil, metrics, err
+	}
+	newRoot, retired, metrics, err = rootZipper.Apply(baseRoot, delta)
 	return
 }
 
@@ -343,13 +431,15 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 
 	newRoot = baseRoot
 	var buildIter iterator.UnsafeIterator
-	trackValueLogRefs = trackValueLogRefs && db.valueLogRefTracker != nil && db.valueLogRefTracker.canTrack(db.currentCommitSeq()) && !db.indexOuterLeavesInValueLog
+	if opts.outerLeavesInValueLog && opts.leafPageLog == nil {
+		err = errors.New("ordered root value-log leaf storage requires a leaf page log")
+		return
+	}
+	trackValueLogRefs = trackValueLogRefs && db.valueLogRefTracker != nil && db.valueLogRefTracker.canTrack(db.currentCommitSeq()) && !opts.outerLeavesInValueLog
 	if baseRoot != 0 {
 		rootTree := tree.New(idx.pager, newValueReader(state.ValueLogSet), baseRoot)
-		pageIDs, collectErr := rootTree.CollectPageIDs()
-		if collectErr != nil {
-			err = collectErr
-			return
+		collectBasePageIDs := func() ([]uint64, error) {
+			return rootTree.CollectPageIDs()
 		}
 
 		baseProbe := rootTree.Iterator(nil, nil)
@@ -373,6 +463,11 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 					return
 				}
 			}
+			pageIDs, collectErr := collectBasePageIDs()
+			if collectErr != nil {
+				err = collectErr
+				return
+			}
 			retired = append(retired, pageIDs...)
 			buildIter = targetTable.NewIterator(nil, nil)
 		} else {
@@ -391,12 +486,21 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 			case orderedRootPublishPlanWarmNativeApply:
 				stats.warmAttempts++
 				stats.warmNativeApplyAttempts++
-				newRoot, retired, metrics, err = idx.zipper.Apply(baseRoot, delta)
+				rootZipper, zipperErr := db.orderedRootZipperForOptions(idx, opts)
+				if zipperErr != nil {
+					err = zipperErr
+					return
+				}
+				newRoot, retired, metrics, err = rootZipper.Apply(baseRoot, delta)
 				if err != nil {
 					return
 				}
-				if len(pageIDs) >= len(retired) {
-					stats.warmPreservedPages = uint64(len(pageIDs) - len(retired))
+				// Avoid a full old-tree page scan on the warm apply path. The
+				// retired page list is exact; preserved pages are tracked as a
+				// lower bound so the public counter still proves warm apply
+				// avoided a full rebuild without making every write walk the root.
+				if newRoot != 0 {
+					stats.warmPreservedPages = 1
 				}
 				stats.warmRewrittenPages = uint64(len(retired))
 				return
@@ -405,6 +509,11 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 				stats.warmRebuildFallbacks++
 				if vlogRefDelta != nil {
 					vlogRefDelta = nil
+				}
+				pageIDs, collectErr := collectBasePageIDs()
+				if collectErr != nil {
+					err = collectErr
+					return
 				}
 				retired = append(retired, pageIDs...)
 				buildIter = targetTable.NewIterator(nil, nil)
@@ -434,11 +543,16 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 		defer buildIter.Close()
 	}
 	if buildIter != nil {
+		var leafPageLog bulk.LeafPageAppender
+		if opts.outerLeavesInValueLog {
+			leafPageLog = opts.leafPageLog
+		}
 		newRoot, err = bulk.BuildWithOptions(buildIter, &pagerAllocator{p: idx.pager}, idx.pager, bulk.BuildOptions{
 			LeafPrefixCompression: opts.leafPrefixCompression,
 			LeafColumnar:          opts.leafColumnar,
 			PackedValuePtr:        opts.packedValuePtr,
-			InternalBaseDelta:     opts.internalBaseDelta,
+			InternalBaseDelta:     opts.internalBaseDelta && !opts.outerLeavesInValueLog,
+			LeafPageLog:           leafPageLog,
 		})
 	}
 	return
@@ -575,11 +689,15 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 
-	opts := systemRootOrderedPublishOptions(db)
+	systemOpts := systemRootOrderedPublishOptions(db)
 	rootIDs := make([]uint64, len(ordered))
 	var retired []uint64
 	var merged adaptive.Metrics
 	for idx := range ordered {
+		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[idx].StoragePolicy)
+		if err != nil {
+			return 0, nil, err
+		}
 		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts)
 		if err != nil {
 			return 0, nil, err
@@ -596,7 +714,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	if iter == nil {
 		return 0, nil, errors.New("nil system root iterator")
 	}
-	rootID, rootRetired, metrics, _, refDelta, err := db.publishOrderedRootIterator(baseSystemRoot, iter, opts, true)
+	rootID, rootRetired, metrics, _, refDelta, err := db.publishOrderedRootIterator(baseSystemRoot, iter, systemOpts, true)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -628,6 +746,88 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	return newSystemRoot, rootIDs, nil
 }
 
+// PublishOrderedRootDeltaGroupWithSystemDeltaBuilder applies root-local
+// mutation streams to non-system roots, then applies a root-local mutation
+// stream to the system root. The system delta should contain only changed
+// system-root entries; omitted system entries are preserved.
+func (db *DB) PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []OrderedRootDeltaPublishInput, buildSystemDeltaIter OrderedRootGroupSystemBuilder) (uint64, []uint64, error) {
+	if buildSystemDeltaIter == nil {
+		return 0, nil, errors.New("nil ordered root group system delta builder")
+	}
+	if db == nil {
+		return 0, nil, ErrClosed
+	}
+	if db.closing.Load() {
+		return 0, nil, ErrClosed
+	}
+
+	db.writeMu.Lock()
+	defer db.writeMu.Unlock()
+
+	if db.readOnly {
+		return 0, nil, ErrReadOnly
+	}
+
+	db.mu.RLock()
+	userRoot := db.meta.UserRootPageID
+	baseSystemRoot := db.meta.SystemRootPageID
+	baseSeq := db.meta.CommitSeq
+	db.mu.RUnlock()
+
+	systemOpts := systemRootOrderedPublishOptions(db)
+	rootIDs := make([]uint64, len(ordered))
+	var retired []uint64
+	var merged adaptive.Metrics
+	for idx := range ordered {
+		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[idx].StoragePolicy)
+		if err != nil {
+			return 0, nil, err
+		}
+		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts)
+		if err != nil {
+			return 0, nil, err
+		}
+		rootIDs[idx] = rootID
+		retired = append(retired, rootRetired...)
+		mergeOrderedRootPublishMetrics(&merged, metrics)
+	}
+
+	iter, err := buildSystemDeltaIter(append([]uint64(nil), rootIDs...))
+	if err != nil {
+		return 0, nil, err
+	}
+	if iter == nil {
+		return 0, nil, errors.New("nil system root delta iterator")
+	}
+	rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(baseSystemRoot, iter, systemOpts)
+	if err != nil {
+		return 0, nil, err
+	}
+	newSystemRoot := rootID
+	retired = append(retired, rootRetired...)
+	mergeOrderedRootPublishMetrics(&merged, metrics)
+
+	db.mu.RLock()
+	curUserRoot := db.meta.UserRootPageID
+	curSystemRoot := db.meta.SystemRootPageID
+	db.mu.RUnlock()
+	if curUserRoot != userRoot || curSystemRoot != baseSystemRoot {
+		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
+	}
+
+	vlogRefDelta := db.newNoopValueLogRefDeltaIfTrackable(baseSeq)
+	defer func() {
+		if vlogRefDelta != nil {
+			releaseValueLogRefDelta(vlogRefDelta)
+		}
+	}()
+	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil); err != nil {
+		return 0, nil, err
+	}
+	vlogRefDelta = nil
+	return newSystemRoot, rootIDs, nil
+}
+
 func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordered []OrderedRootPublishInput, buildSystemIter OrderedRootGroupSystemBuilder) (uint64, []uint64, error) {
 	if systemIter != nil && buildSystemIter != nil {
 		return 0, nil, errors.New("ordered root group cannot use both system iterator and system builder")
@@ -652,7 +852,7 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 
-	opts := systemRootOrderedPublishOptions(db)
+	systemOpts := systemRootOrderedPublishOptions(db)
 	newSystemRoot := baseSystemRoot
 	var retired []uint64
 	var merged adaptive.Metrics
@@ -665,7 +865,7 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 	}()
 
 	if systemIter != nil {
-		rootID, rootRetired, metrics, publishStats, refDelta, err := db.publishOrderedRootIterator(baseSystemRoot, systemIter, opts, true)
+		rootID, rootRetired, metrics, publishStats, refDelta, err := db.publishOrderedRootIterator(baseSystemRoot, systemIter, systemOpts, true)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -678,6 +878,10 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 
 	rootIDs := make([]uint64, len(ordered))
 	for idx := range ordered {
+		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[idx].StoragePolicy)
+		if err != nil {
+			return 0, nil, err
+		}
 		rootID, rootRetired, metrics, _, _, err := db.publishOrderedRootIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts, false)
 		if err != nil {
 			return 0, nil, err
@@ -696,7 +900,7 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 		if iter == nil {
 			return 0, nil, errors.New("nil system root iterator")
 		}
-		rootID, rootRetired, metrics, publishStats, refDelta, err := db.publishOrderedRootIterator(baseSystemRoot, iter, opts, true)
+		rootID, rootRetired, metrics, publishStats, refDelta, err := db.publishOrderedRootIterator(baseSystemRoot, iter, systemOpts, true)
 		if err != nil {
 			return 0, nil, err
 		}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -43,6 +43,14 @@ type OrderedRootPublishInput struct {
 	Iter     iterator.UnsafeIterator
 }
 
+// OrderedRootDeltaPublishInput describes a sorted root-local mutation stream.
+// Unlike OrderedRootPublishInput, Iter contains only keys changed by this
+// publish; omitted base-root keys are preserved.
+type OrderedRootDeltaPublishInput struct {
+	BaseRoot uint64
+	Iter     iterator.UnsafeIterator
+}
+
 // OrderedRootGroupSystemBuilder builds a target system-root iterator after the
 // non-system roots in a group have been built. The rootIDs slice is ordered to
 // match the OrderedRootPublishInput slice passed to
@@ -110,6 +118,27 @@ func orderedRootBatchPut(delta *batch.Batch, iter iterator.UnsafeIterator) error
 	return delta.Set(iter.UnsafeKey(), val)
 }
 
+func orderedRootDeltaBatchFromIterator(iter iterator.UnsafeIterator) (*batch.Batch, error) {
+	delta := batch.New(nil, page.DefaultInlineThreshold)
+	for iter.Valid() {
+		if iter.IsDeleted() {
+			if err := delta.Delete(iter.UnsafeKey()); err != nil {
+				_ = delta.Close()
+				return nil, err
+			}
+		} else if err := orderedRootBatchPut(delta, iter); err != nil {
+			_ = delta.Close()
+			return nil, err
+		}
+		iter.Next()
+	}
+	if err := iter.Error(); err != nil {
+		_ = delta.Close()
+		return nil, err
+	}
+	return delta, nil
+}
+
 func collectValueLogRefDeltaFromIterator(iter iterator.UnsafeIterator) (*valueLogRefDelta, error) {
 	if iter == nil {
 		return nil, nil
@@ -126,6 +155,39 @@ func collectValueLogRefDeltaFromIterator(iter iterator.UnsafeIterator) (*valueLo
 		return nil, err
 	}
 	return delta, nil
+}
+
+func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.UnsafeIterator, opts orderedRootPublishOptions) (newRoot uint64, retired []uint64, metrics adaptive.Metrics, err error) {
+	if db == nil {
+		err = ErrClosed
+		return
+	}
+	if iter == nil {
+		err = errors.New("nil ordered root delta iterator")
+		return
+	}
+
+	if baseRoot == 0 {
+		newRoot, retired, metrics, _, _, err = db.publishOrderedRootIterator(0, iter, opts, false)
+		return
+	}
+	defer iter.Close()
+
+	idx := db.idx.Load()
+	if idx == nil {
+		err = errors.New("missing index")
+		return
+	}
+	delta, err := orderedRootDeltaBatchFromIterator(iter)
+	if err != nil {
+		return 0, nil, metrics, err
+	}
+	defer delta.Close()
+	if len(delta.SortedEntries()) == 0 {
+		return baseRoot, nil, metrics, nil
+	}
+	newRoot, retired, metrics, err = idx.zipper.Apply(baseRoot, delta)
+	return
 }
 
 func buildOrderedRootDeltaBatch(baseIter, targetIter iterator.UnsafeIterator, trackRefs bool) (*batch.Batch, int, *valueLogRefDelta, error) {
@@ -457,6 +519,86 @@ func (db *DB) PublishOrderedRootGroupWithSystemBuilder(ordered []OrderedRootPubl
 		return 0, nil, errors.New("nil ordered root group system builder")
 	}
 	return db.publishOrderedRootGroup(nil, ordered, buildSystemIter)
+}
+
+// PublishOrderedRootDeltaGroupWithSystemBuilder applies root-local mutation
+// streams to non-system roots, then builds and commits a system-root iterator
+// that can persist the produced root IDs in the same backend commit.
+func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRootDeltaPublishInput, buildSystemIter OrderedRootGroupSystemBuilder) (uint64, []uint64, error) {
+	if buildSystemIter == nil {
+		return 0, nil, errors.New("nil ordered root group system builder")
+	}
+	if db == nil {
+		return 0, nil, ErrClosed
+	}
+	if db.closing.Load() {
+		return 0, nil, ErrClosed
+	}
+
+	db.writeMu.Lock()
+	defer db.writeMu.Unlock()
+
+	if db.readOnly {
+		return 0, nil, ErrReadOnly
+	}
+
+	db.mu.RLock()
+	userRoot := db.meta.UserRootPageID
+	baseSystemRoot := db.meta.SystemRootPageID
+	baseSeq := db.meta.CommitSeq
+	db.mu.RUnlock()
+
+	opts := systemRootOrderedPublishOptions(db)
+	rootIDs := make([]uint64, len(ordered))
+	var retired []uint64
+	var merged adaptive.Metrics
+	for idx := range ordered {
+		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts)
+		if err != nil {
+			return 0, nil, err
+		}
+		rootIDs[idx] = rootID
+		retired = append(retired, rootRetired...)
+		mergeOrderedRootPublishMetrics(&merged, metrics)
+	}
+
+	iter, err := buildSystemIter(append([]uint64(nil), rootIDs...))
+	if err != nil {
+		return 0, nil, err
+	}
+	if iter == nil {
+		return 0, nil, errors.New("nil system root iterator")
+	}
+	rootID, rootRetired, metrics, _, refDelta, err := db.publishOrderedRootIterator(baseSystemRoot, iter, opts, true)
+	if err != nil {
+		return 0, nil, err
+	}
+	newSystemRoot := rootID
+	retired = append(retired, rootRetired...)
+	mergeOrderedRootPublishMetrics(&merged, metrics)
+	vlogRefDelta := refDelta
+	defer func() {
+		if vlogRefDelta != nil {
+			releaseValueLogRefDelta(vlogRefDelta)
+		}
+	}()
+
+	db.mu.RLock()
+	curUserRoot := db.meta.UserRootPageID
+	curSystemRoot := db.meta.SystemRootPageID
+	db.mu.RUnlock()
+	if curUserRoot != userRoot || curSystemRoot != baseSystemRoot {
+		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
+	}
+
+	if vlogRefDelta == nil {
+		vlogRefDelta = db.newNoopValueLogRefDeltaIfTrackable(baseSeq)
+	}
+	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil); err != nil {
+		return 0, nil, err
+	}
+	vlogRefDelta = nil
+	return newSystemRoot, rootIDs, nil
 }
 
 func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordered []OrderedRootPublishInput, buildSystemIter OrderedRootGroupSystemBuilder) (uint64, []uint64, error) {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -73,6 +73,28 @@ type OrderedRootDeltaPublishInput struct {
 	StoragePolicy OrderedRootStoragePolicy
 }
 
+func closeUnconsumedOrderedRootPublishIterators(ordered []OrderedRootPublishInput, consumed []bool) {
+	for idx := range ordered {
+		if idx < len(consumed) && consumed[idx] {
+			continue
+		}
+		if ordered[idx].Iter != nil {
+			_ = ordered[idx].Iter.Close()
+		}
+	}
+}
+
+func closeUnconsumedOrderedRootDeltaPublishIterators(ordered []OrderedRootDeltaPublishInput, consumed []bool) {
+	for idx := range ordered {
+		if idx < len(consumed) && consumed[idx] {
+			continue
+		}
+		if ordered[idx].Iter != nil {
+			_ = ordered[idx].Iter.Close()
+		}
+	}
+}
+
 // OrderedRootGroupSystemBuilder builds a target system-root iterator after the
 // non-system roots in a group have been built. The rootIDs slice is ordered to
 // match the OrderedRootPublishInput slice passed to
@@ -693,6 +715,8 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 
 	systemOpts := systemRootOrderedPublishOptions(db)
 	rootIDs := make([]uint64, len(ordered))
+	orderedConsumed := make([]bool, len(ordered))
+	defer closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
 	var retired []uint64
 	var merged adaptive.Metrics
 	for idx := range ordered {
@@ -700,6 +724,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 		if err != nil {
 			return 0, nil, err
 		}
+		orderedConsumed[idx] = true
 		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts)
 		if err != nil {
 			return 0, nil, err
@@ -777,6 +802,8 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 
 	systemOpts := systemRootOrderedPublishOptions(db)
 	rootIDs := make([]uint64, len(ordered))
+	orderedConsumed := make([]bool, len(ordered))
+	defer closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
 	var retired []uint64
 	var merged adaptive.Metrics
 	for idx := range ordered {
@@ -784,6 +811,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 		if err != nil {
 			return 0, nil, err
 		}
+		orderedConsumed[idx] = true
 		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts)
 		if err != nil {
 			return 0, nil, err
@@ -875,11 +903,14 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 	}
 
 	rootIDs := make([]uint64, len(ordered))
+	orderedConsumed := make([]bool, len(ordered))
+	defer closeUnconsumedOrderedRootPublishIterators(ordered, orderedConsumed)
 	for idx := range ordered {
 		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[idx].StoragePolicy)
 		if err != nil {
 			return 0, nil, err
 		}
+		orderedConsumed[idx] = true
 		rootID, rootRetired, metrics, _, _, err := db.publishOrderedRootIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts, false)
 		if err != nil {
 			return 0, nil, err

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -23,6 +23,14 @@ const (
 	orderedRootPublishPlanWarmNativeApply
 )
 
+// orderedRootDeltaBatchInlineThreshold is intentionally not the page/value-log
+// placement threshold. These batches are transient root-local mutation streams
+// consumed by zipper.Apply; they do not decide durable value placement. Large
+// collection documents must remain valid here because the destination ordered
+// root policy decides whether rebuilt leaves live in pager pages or value-log
+// LeafRefs. Pointer entries still flow through SetPointer, and non-stable inline
+// iterators may copy values into this short-lived batch, so callers should keep
+// delta streams bounded rather than using this as a bulk-load accumulator.
 var orderedRootDeltaBatchInlineThreshold = int(^uint(0) >> 1)
 
 type orderedRootPublishStats struct {

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -2,8 +2,12 @@ package db
 
 import (
 	"context"
+	"errors"
 	"reflect"
+	"strconv"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 )
 
 func TestPublishOrderedRootIterator_WarmSparseDelta_PreservesPages(t *testing.T) {
@@ -301,6 +305,144 @@ func TestPublishOrderedRootGroup_PersistsSystemAndOrderedRoots(t *testing.T) {
 	}
 	if got := string(entry.Value); got != "iv" {
 		t.Fatalf("reopen iter value=%q want %q", got, "iv")
+	}
+}
+
+func TestPublishOrderedRootGroupWithSystemBuilder_PersistsSystemDescriptorWithOrderedRootIDs(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Set([]byte("user/a"), []byte("uv")); err != nil {
+		t.Fatalf("set user key: %v", err)
+	}
+	before := db.State()
+	if before == nil {
+		t.Fatal("expected backend state")
+	}
+
+	primaryTable := mustFrozenSystemMemtable(t, "doc/u1", "document")
+	indexTable := mustFrozenSystemMemtable(t, "idx/email/u1", "")
+	var builderRootIDs []uint64
+	newSystemRoot, rootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{
+		{BaseRoot: 0, Iter: primaryTable.NewIterator(nil, nil)},
+		{BaseRoot: 0, Iter: indexTable.NewIterator(nil, nil)},
+	}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		builderRootIDs = append([]uint64(nil), rootIDs...)
+		return mustFrozenSystemMemtable(t,
+			"sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10),
+			"sys/collections/users/email_idx", strconv.FormatUint(rootIDs[1], 10),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish ordered root group with system builder: %v", err)
+	}
+	if len(rootIDs) != 2 {
+		t.Fatalf("rootIDs=%d want 2", len(rootIDs))
+	}
+	if !reflect.DeepEqual(builderRootIDs, rootIDs) {
+		t.Fatalf("builder root IDs=%v want %v", builderRootIDs, rootIDs)
+	}
+	after := db.State()
+	if after == nil {
+		t.Fatal("expected backend state after publish")
+	}
+	if after.RootPageID != before.RootPageID {
+		t.Fatalf("user root changed: got %d want %d", after.RootPageID, before.RootPageID)
+	}
+	if after.SystemRootPageID != newSystemRoot {
+		t.Fatalf("system root changed: got %d want %d", after.SystemRootPageID, newSystemRoot)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer snap.Close()
+	sysEntry, err := snap.GetEntryAtRoot(newSystemRoot, []byte("sys/collections/users/primary"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(system primary descriptor): %v", err)
+	}
+	if got, want := string(sysEntry.Value), strconv.FormatUint(rootIDs[0], 10); got != want {
+		t.Fatalf("primary descriptor root=%q want %q", got, want)
+	}
+	sysEntry, err = snap.GetEntryAtRoot(newSystemRoot, []byte("sys/collections/users/email_idx"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(system index descriptor): %v", err)
+	}
+	if got, want := string(sysEntry.Value), strconv.FormatUint(rootIDs[1], 10); got != want {
+		t.Fatalf("index descriptor root=%q want %q", got, want)
+	}
+	entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte("doc/u1"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(primary): %v", err)
+	}
+	if got := string(entry.Value); got != "document" {
+		t.Fatalf("primary value=%q want %q", got, "document")
+	}
+	entry, err = snap.GetEntryAtRoot(rootIDs[1], []byte("idx/email/u1"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(index): %v", err)
+	}
+	if got := string(entry.Value); got != "" {
+		t.Fatalf("index value=%q want empty", got)
+	}
+}
+
+func TestPublishOrderedRootGroupWithSystemBuilder_ErrorLeavesMetaRootsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Set([]byte("user/a"), []byte("uv")); err != nil {
+		t.Fatalf("set user key: %v", err)
+	}
+	before := db.State()
+	if before == nil {
+		t.Fatal("expected backend state")
+	}
+
+	var builderRootIDs []uint64
+	_, _, err = db.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot: 0,
+		Iter:     mustFrozenSystemMemtable(t, "doc/u1", "document").NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		builderRootIDs = append([]uint64(nil), rootIDs...)
+		return nil, errors.New("system descriptor build failed")
+	})
+	if err == nil {
+		t.Fatal("expected system builder error")
+	}
+	if len(builderRootIDs) != 1 || builderRootIDs[0] == 0 {
+		t.Fatalf("builder root IDs=%v want one non-zero root", builderRootIDs)
+	}
+	after := db.State()
+	if after == nil {
+		t.Fatal("expected backend state after failed publish")
+	}
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("commit seq changed after failed publish: got %d want %d", after.CommitSeq, before.CommitSeq)
+	}
+	if after.RootPageID != before.RootPageID {
+		t.Fatalf("user root changed after failed publish: got %d want %d", after.RootPageID, before.RootPageID)
+	}
+	if after.SystemRootPageID != before.SystemRootPageID {
+		t.Fatalf("system root changed after failed publish: got %d want %d", after.SystemRootPageID, before.SystemRootPageID)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer snap.Close()
+	if _, err := snap.GetEntryAtRoot(after.SystemRootPageID, []byte("sys/collections/users/primary")); err == nil {
+		t.Fatal("unexpected system descriptor after failed publish")
 	}
 }
 

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -1197,6 +1197,64 @@ func TestPublishOrderedRootDeltaGroupWithSystemDeltaBuilder_InvalidatesValueLogR
 	}
 }
 
+func TestPublishOrderedRootDeltaGroupWithSystemBuilder_InvalidatesValueLogRefTrackerForNonSystemDelta(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	livePtr := appendPointersInNewSegment(t, dir, 0, 53, 130_000, 1, func(int) []byte {
+		return []byte("live-user-pointer-before-non-system-delta")
+	})[0]
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("user/live"), livePtr); err != nil {
+		t.Fatalf("SetPointer(user/live): %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write live pointer: %v", err)
+	}
+	_ = b.Close()
+
+	oldPtr := appendPointersInNewSegment(t, dir, 0, 54, 140_000, 1, func(int) []byte {
+		return []byte("old-non-system-delta-pointer")
+	})[0]
+	newPtr := appendPointersInNewSegment(t, dir, 0, 55, 150_000, 1, func(int) []byte {
+		return []byte("new-non-system-delta-pointer")
+	})[0]
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemPointerMemtable(t, "root/p", oldPtr).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish initial non-system root: %v", err)
+	}
+
+	if _, err := db.referencedValueLogSegments(context.Background()); err != nil {
+		t.Fatalf("refresh value-log refs: %v", err)
+	}
+	beforeSeq := db.currentCommitSeq()
+	if _, ok := db.valueLogRefTracker.referencedSet(beforeSeq); !ok {
+		t.Fatalf("expected incremental ref set before non-system delta at seq=%d", beforeSeq)
+	}
+
+	_, _, err = db.PublishOrderedRootDeltaGroupWithSystemBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot: baseRoot,
+		Iter:     mustFrozenSystemPointerMemtable(t, "root/p", newPtr).NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			t.Fatalf("rootIDs len=%d want 1", len(rootIDs))
+		}
+		return mustFrozenSystemMemtable(t, "sys/root", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish non-system delta group: %v", err)
+	}
+
+	afterSeq := db.currentCommitSeq()
+	if refs, ok := db.valueLogRefTracker.referencedSet(afterSeq); ok {
+		t.Fatalf("value-log ref tracker stayed valid after untracked non-system delta: refs=%v", refs)
+	}
+}
+
 func assertValueLogRefTrackerMatchesFullScan(t *testing.T, db *DB) {
 	t.Helper()
 	seq := db.currentCommitSeq()

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func TestPublishOrderedRootIterator_WarmSparseDelta_PreservesPages(t *testing.T) {
@@ -389,6 +390,111 @@ func TestPublishOrderedRootGroupWithSystemBuilder_PersistsSystemDescriptorWithOr
 	}
 	if got := string(entry.Value); got != "" {
 		t.Fatalf("index value=%q want empty", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaGroupWithSystemBuilder_PreservesOmittedBaseEntries(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t,
+		"root/a", "va",
+		"root/b", "vb",
+	).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+
+	delta := mustFrozenSystemMemtable(t,
+		"root/b", "vb2",
+		"root/c", "vc",
+	)
+	newSystemRoot, rootIDs, err := db.PublishOrderedRootDeltaGroupWithSystemBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot: baseRoot,
+		Iter:     delta.NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 || rootIDs[0] == 0 {
+			t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+		}
+		return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish delta group: %v", err)
+	}
+	if newSystemRoot == 0 || len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("newSystemRoot=%d rootIDs=%v", newSystemRoot, rootIDs)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	for key, want := range map[string]string{
+		"root/a": "va",
+		"root/b": "vb2",
+		"root/c": "vc",
+	} {
+		entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte(key))
+		if err != nil {
+			t.Fatalf("GetEntryAtRoot(%s): %v", key, err)
+		}
+		if got := string(entry.Value); got != want {
+			t.Fatalf("%s=%q want %q", key, got, want)
+		}
+	}
+}
+
+func TestPublishOrderedRootDeltaGroupWithSystemBuilder_AppliesDeletes(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t,
+		"root/a", "va",
+		"root/b", "vb",
+	).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+	delta, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("new delta table: %v", err)
+	}
+	delta.Delete([]byte("root/b"))
+	delta.Freeze()
+
+	_, rootIDs, err := db.PublishOrderedRootDeltaGroupWithSystemBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot: baseRoot,
+		Iter:     delta.NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish delta group: %v", err)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte("root/a"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(root/a): %v", err)
+	}
+	if got, want := string(entry.Value), "va"; got != want {
+		t.Fatalf("root/a=%q want %q", got, want)
+	}
+	if _, err := snap.GetEntryAtRoot(rootIDs[0], []byte("root/b")); err == nil {
+		t.Fatal("root/b still exists after delta delete")
 	}
 }
 

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 func TestPublishOrderedRootIterator_WarmSparseDelta_PreservesPages(t *testing.T) {
@@ -496,6 +497,132 @@ func TestPublishOrderedRootDeltaGroupWithSystemBuilder_AppliesDeletes(t *testing
 	if _, err := snap.GetEntryAtRoot(rootIDs[0], []byte("root/b")); err == nil {
 		t.Fatal("root/b still exists after delta delete")
 	}
+}
+
+func TestOrderedRootDeltaBatchFromIterator_StableIteratorUsesViews(t *testing.T) {
+	key := []byte("root/a")
+	value := []byte("value-a")
+	iter := &stableRootDeltaIterator{
+		entries: []stableRootDeltaEntry{{key: key, value: value}},
+	}
+
+	delta, err := orderedRootDeltaBatchFromIterator(iter)
+	if err != nil {
+		t.Fatalf("orderedRootDeltaBatchFromIterator: %v", err)
+	}
+	defer func() { _ = delta.Close() }()
+
+	entries := delta.SortedEntries()
+	if len(entries) != 1 {
+		t.Fatalf("entries len=%d want 1", len(entries))
+	}
+	if got := string(entries[0].Key); got != string(key) {
+		t.Fatalf("key=%q want %q", got, key)
+	}
+	if got := string(entries[0].Value); got != string(value) {
+		t.Fatalf("value=%q want %q", got, value)
+	}
+	if &entries[0].Key[0] != &key[0] {
+		t.Fatal("stable iterator key was copied into batch arena")
+	}
+	if &entries[0].Value[0] != &value[0] {
+		t.Fatal("stable iterator value was copied into batch arena")
+	}
+}
+
+type stableRootDeltaEntry struct {
+	key   []byte
+	value []byte
+}
+
+type stableRootDeltaIterator struct {
+	entries []stableRootDeltaEntry
+	idx     int
+}
+
+func (it *stableRootDeltaIterator) StableUnsafeIteratorSlices() bool { return true }
+
+func (it *stableRootDeltaIterator) Len() int {
+	if it == nil {
+		return 0
+	}
+	return len(it.entries)
+}
+
+func (it *stableRootDeltaIterator) Valid() bool {
+	return it != nil && it.idx >= 0 && it.idx < len(it.entries)
+}
+
+func (it *stableRootDeltaIterator) Next() {
+	if it != nil && it.idx < len(it.entries) {
+		it.idx++
+	}
+}
+
+func (it *stableRootDeltaIterator) Seek(key []byte) {
+	it.idx = len(it.entries)
+	for i := range it.entries {
+		if string(it.entries[i].key) >= string(key) {
+			it.idx = i
+			return
+		}
+	}
+}
+
+func (it *stableRootDeltaIterator) UnsafeKey() []byte {
+	if !it.Valid() {
+		return nil
+	}
+	return it.entries[it.idx].key
+}
+
+func (it *stableRootDeltaIterator) UnsafeValue() []byte {
+	if !it.Valid() {
+		return nil
+	}
+	return it.entries[it.idx].value
+}
+
+func (it *stableRootDeltaIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	return it.UnsafeValue(), page.ValuePtr{}, 0
+}
+
+func (it *stableRootDeltaIterator) Key() []byte {
+	return it.UnsafeKey()
+}
+
+func (it *stableRootDeltaIterator) Value() []byte {
+	return it.UnsafeValue()
+}
+
+func (it *stableRootDeltaIterator) KeyCopy(dst []byte) []byte {
+	if !it.Valid() {
+		return dst
+	}
+	return append(dst, it.entries[it.idx].key...)
+}
+
+func (it *stableRootDeltaIterator) ValueCopy(dst []byte) []byte {
+	if !it.Valid() {
+		return dst
+	}
+	return append(dst, it.entries[it.idx].value...)
+}
+
+func (it *stableRootDeltaIterator) IsDeleted() bool {
+	return false
+}
+
+func (it *stableRootDeltaIterator) Error() error {
+	return nil
+}
+
+func (it *stableRootDeltaIterator) Close() error {
+	return nil
+}
+
+func (it *stableRootDeltaIterator) Domain() (start, end []byte) {
+	return nil, nil
 }
 
 func TestPublishOrderedRootGroupWithSystemBuilder_ErrorLeavesMetaRootsUnchanged(t *testing.T) {

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -990,6 +990,49 @@ func TestPublishOrderedRootGroup_NonSystemWarmApplyPreservesValueLogRefTracker(t
 	assertValueLogRefTrackerMatchesFullScan(t, db)
 }
 
+func TestPublishOrderedRootDeltaGroupWithSystemDeltaBuilder_InvalidatesValueLogRefTracker(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	livePtr := appendPointersInNewSegment(t, dir, 0, 51, 110_000, 1, func(int) []byte {
+		return []byte("live-user-pointer-before-system-delta")
+	})[0]
+	b := db.NewBatch().(*Batch)
+	if err := b.SetPointer([]byte("user/live"), livePtr); err != nil {
+		t.Fatalf("SetPointer(user/live): %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write live pointer: %v", err)
+	}
+	_ = b.Close()
+
+	if _, err := db.referencedValueLogSegments(context.Background()); err != nil {
+		t.Fatalf("refresh value-log refs: %v", err)
+	}
+	beforeSeq := db.currentCommitSeq()
+	if _, ok := db.valueLogRefTracker.referencedSet(beforeSeq); !ok {
+		t.Fatalf("expected incremental ref set before system delta at seq=%d", beforeSeq)
+	}
+
+	systemPtr := appendPointersInNewSegment(t, dir, 0, 52, 120_000, 1, func(int) []byte {
+		return []byte("system-pointer-delta")
+	})[0]
+	if _, _, err := db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemPointerMemtable(t, "sys/p", systemPtr).NewIterator(nil, nil), nil
+	}); err != nil {
+		t.Fatalf("publish system delta group: %v", err)
+	}
+
+	afterSeq := db.currentCommitSeq()
+	if refs, ok := db.valueLogRefTracker.referencedSet(afterSeq); ok {
+		t.Fatalf("value-log ref tracker stayed valid after untracked system delta: refs=%v", refs)
+	}
+}
+
 func assertValueLogRefTrackerMatchesFullScan(t *testing.T, db *DB) {
 	t.Helper()
 	seq := db.currentCommitSeq()

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -310,6 +310,165 @@ func TestPublishOrderedRootGroup_PersistsSystemAndOrderedRoots(t *testing.T) {
 	}
 }
 
+func TestPublishOrderedRootGroup_UsesPerRootStoragePolicy(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 64<<20)
+	db.SetLeafPageLog(leafLog)
+	defer func() {
+		_ = leafLog.Close()
+		_ = db.Close()
+	}()
+
+	compressedTable := mustFrozenSystemMemtable(t, "doc/u1", "document")
+	fastTable := mustFrozenSystemMemtable(t, "idx/email/u1", "")
+	_, rootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{
+		{BaseRoot: 0, Iter: compressedTable.NewIterator(nil, nil), StoragePolicy: OrderedRootStorageValueLogLeaves},
+		{BaseRoot: 0, Iter: fastTable.NewIterator(nil, nil), StoragePolicy: OrderedRootStoragePagerLeaves},
+	})
+	if err != nil {
+		t.Fatalf("publish ordered root group: %v", err)
+	}
+	if len(rootIDs) != 2 {
+		t.Fatalf("rootIDs=%d want 2", len(rootIDs))
+	}
+	if _, ok := page.DecodeLeafRef(rootIDs[0]); !ok {
+		t.Fatalf("compressed root id=%d, want leaf ref", rootIDs[0])
+	}
+	if _, ok := page.DecodeLeafRef(rootIDs[1]); ok {
+		t.Fatalf("fast root id=%d, want pager page", rootIDs[1])
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer snap.Close()
+	entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte("doc/u1"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(compressed): %v", err)
+	}
+	if got := string(entry.Value); got != "document" {
+		t.Fatalf("compressed value=%q want document", got)
+	}
+	entry, err = snap.GetEntryAtRoot(rootIDs[1], []byte("idx/email/u1"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(fast): %v", err)
+	}
+	if got := string(entry.Value); got != "" {
+		t.Fatalf("fast index value=%q want empty", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaGroupWithSystemBuilder_UsesPerRootStoragePolicy(t *testing.T) {
+	t.Run("pager leaves override value-log default", func(t *testing.T) {
+		dir := t.TempDir()
+		db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 64<<20)
+		db.SetLeafPageLog(leafLog)
+		defer func() {
+			_ = leafLog.Close()
+			_ = db.Close()
+		}()
+
+		_, baseRootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{{
+			BaseRoot:      0,
+			Iter:          mustFrozenSystemMemtable(t, "doc/a", "va").NewIterator(nil, nil),
+			StoragePolicy: OrderedRootStoragePagerLeaves,
+		}})
+		if err != nil {
+			t.Fatalf("publish base root: %v", err)
+		}
+
+		_, rootIDs, err := db.PublishOrderedRootDeltaGroupWithSystemBuilder([]OrderedRootDeltaPublishInput{{
+			BaseRoot:      baseRootIDs[0],
+			Iter:          mustFrozenSystemMemtable(t, "doc/b", "vb").NewIterator(nil, nil),
+			StoragePolicy: OrderedRootStoragePagerLeaves,
+		}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return mustFrozenSystemMemtable(t, "sys/root", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+		})
+		if err != nil {
+			t.Fatalf("publish delta root: %v", err)
+		}
+		if _, ok := page.DecodeLeafRef(rootIDs[0]); ok {
+			t.Fatalf("delta root id=%d, want pager page", rootIDs[0])
+		}
+
+		snap := db.AcquireSnapshot()
+		if snap == nil {
+			t.Fatal("expected snapshot")
+		}
+		defer snap.Close()
+		for key, want := range map[string]string{"doc/a": "va", "doc/b": "vb"} {
+			entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte(key))
+			if err != nil {
+				t.Fatalf("GetEntryAtRoot(%s): %v", key, err)
+			}
+			if got := string(entry.Value); got != want {
+				t.Fatalf("%s=%q want %q", key, got, want)
+			}
+		}
+	})
+
+	t.Run("value-log leaves override pager default", func(t *testing.T) {
+		dir := t.TempDir()
+		db, err := Open(Options{Dir: dir})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 64<<20)
+		db.SetLeafPageLog(leafLog)
+		defer func() {
+			_ = leafLog.Close()
+			_ = db.Close()
+		}()
+
+		_, baseRootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{{
+			BaseRoot:      0,
+			Iter:          mustFrozenSystemMemtable(t, "doc/a", "va").NewIterator(nil, nil),
+			StoragePolicy: OrderedRootStorageValueLogLeaves,
+		}})
+		if err != nil {
+			t.Fatalf("publish base root: %v", err)
+		}
+
+		_, rootIDs, err := db.PublishOrderedRootDeltaGroupWithSystemBuilder([]OrderedRootDeltaPublishInput{{
+			BaseRoot:      baseRootIDs[0],
+			Iter:          mustFrozenSystemMemtable(t, "doc/b", "vb").NewIterator(nil, nil),
+			StoragePolicy: OrderedRootStorageValueLogLeaves,
+		}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return mustFrozenSystemMemtable(t, "sys/root", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+		})
+		if err != nil {
+			t.Fatalf("publish delta root: %v", err)
+		}
+		if _, ok := page.DecodeLeafRef(rootIDs[0]); !ok {
+			t.Fatalf("delta root id=%d, want leaf ref", rootIDs[0])
+		}
+
+		snap := db.AcquireSnapshot()
+		if snap == nil {
+			t.Fatal("expected snapshot")
+		}
+		defer snap.Close()
+		for key, want := range map[string]string{"doc/a": "va", "doc/b": "vb"} {
+			entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte(key))
+			if err != nil {
+				t.Fatalf("GetEntryAtRoot(%s): %v", key, err)
+			}
+			if got := string(entry.Value); got != want {
+				t.Fatalf("%s=%q want %q", key, got, want)
+			}
+		}
+	})
+}
+
 func TestPublishOrderedRootGroupWithSystemBuilder_PersistsSystemDescriptorWithOrderedRootIDs(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"reflect"
@@ -655,6 +656,67 @@ func TestPublishOrderedRootDeltaGroupWithSystemBuilder_AppliesDeletes(t *testing
 	}
 	if _, err := snap.GetEntryAtRoot(rootIDs[0], []byte("root/b")); err == nil {
 		t.Fatal("root/b still exists after delta delete")
+	}
+}
+
+func TestPublishOrderedRootDeltaGroupWithSystemBuilder_AcceptsLargeDeltaValueLogLeafValue(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 64<<20)
+	db.SetLeafPageLog(leafLog)
+	defer func() {
+		_ = leafLog.Close()
+		_ = db.Close()
+	}()
+
+	_, baseRootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemMemtable(t, "doc/a", "small").NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}})
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+	if len(baseRootIDs) != 1 {
+		t.Fatalf("base roots=%d want 1", len(baseRootIDs))
+	}
+
+	largeValue := bytes.Repeat([]byte("x"), page.DefaultInlineThreshold+1024)
+	delta, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("new delta table: %v", err)
+	}
+	delta.Set([]byte("doc/large"), largeValue)
+	delta.Freeze()
+
+	_, rootIDs, err := db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot:      baseRootIDs[0],
+		Iter:          delta.NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/root", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish large value delta: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs=%d want 1", len(rootIDs))
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte("doc/large"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(doc/large): %v", err)
+	}
+	if !bytes.Equal(entry.Value, largeValue) {
+		t.Fatalf("large value mismatch: got %d bytes want %d", len(entry.Value), len(largeValue))
 	}
 }
 

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -13,6 +13,38 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
+type closeCountingUnsafeIterator struct {
+	closes int
+}
+
+func (it *closeCountingUnsafeIterator) Valid() bool { return false }
+func (it *closeCountingUnsafeIterator) Next()       {}
+func (it *closeCountingUnsafeIterator) Seek([]byte) {}
+func (it *closeCountingUnsafeIterator) UnsafeKey() []byte {
+	return nil
+}
+func (it *closeCountingUnsafeIterator) UnsafeValue() []byte {
+	return nil
+}
+func (it *closeCountingUnsafeIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	return nil, page.ValuePtr{}, 0
+}
+func (it *closeCountingUnsafeIterator) Key() []byte   { return nil }
+func (it *closeCountingUnsafeIterator) Value() []byte { return nil }
+func (it *closeCountingUnsafeIterator) KeyCopy(dst []byte) []byte {
+	return dst
+}
+func (it *closeCountingUnsafeIterator) ValueCopy(dst []byte) []byte {
+	return dst
+}
+func (it *closeCountingUnsafeIterator) IsDeleted() bool { return false }
+func (it *closeCountingUnsafeIterator) Error() error    { return nil }
+func (it *closeCountingUnsafeIterator) Close() error {
+	it.closes++
+	return nil
+}
+func (it *closeCountingUnsafeIterator) Domain() ([]byte, []byte) { return nil, nil }
+
 func TestPublishOrderedRootIterator_WarmSparseDelta_PreservesPages(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})
@@ -308,6 +340,76 @@ func TestPublishOrderedRootGroup_PersistsSystemAndOrderedRoots(t *testing.T) {
 	}
 	if got := string(entry.Value); got != "iv" {
 		t.Fatalf("reopen iter value=%q want %q", got, "iv")
+	}
+}
+
+func TestPublishOrderedRootGroup_ClosesUnconsumedIteratorsOnPolicyError(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	first := &closeCountingUnsafeIterator{}
+	second := &closeCountingUnsafeIterator{}
+	_, _, err = db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{
+		{Iter: first, StoragePolicy: OrderedRootStoragePolicy(255)},
+		{Iter: second, StoragePolicy: OrderedRootStoragePagerLeaves},
+	})
+	if err == nil {
+		t.Fatal("expected publish error")
+	}
+	if first.closes != 1 {
+		t.Fatalf("first iterator closes=%d want 1", first.closes)
+	}
+	if second.closes != 1 {
+		t.Fatalf("second iterator closes=%d want 1", second.closes)
+	}
+}
+
+func TestPublishOrderedRootDeltaGroups_CloseUnconsumedIteratorsOnPolicyError(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	builderCalled := false
+	buildSystemIter := func([]uint64) (iterator.UnsafeIterator, error) {
+		builderCalled = true
+		return nil, nil
+	}
+	for name, publish := range map[string]func([]OrderedRootDeltaPublishInput) error{
+		"system builder": func(ordered []OrderedRootDeltaPublishInput) error {
+			_, _, err := db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, buildSystemIter)
+			return err
+		},
+		"system delta builder": func(ordered []OrderedRootDeltaPublishInput) error {
+			_, _, err := db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, buildSystemIter)
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			builderCalled = false
+			first := &closeCountingUnsafeIterator{}
+			second := &closeCountingUnsafeIterator{}
+			err := publish([]OrderedRootDeltaPublishInput{
+				{Iter: first, StoragePolicy: OrderedRootStoragePolicy(255)},
+				{Iter: second, StoragePolicy: OrderedRootStoragePagerLeaves},
+			})
+			if err == nil {
+				t.Fatal("expected publish error")
+			}
+			if builderCalled {
+				t.Fatal("system builder should not run after policy error")
+			}
+			if first.closes != 1 {
+				t.Fatalf("first iterator closes=%d want 1", first.closes)
+			}
+			if second.closes != 1 {
+				t.Fatalf("second iterator closes=%d want 1", second.closes)
+			}
+		})
 	}
 }
 

--- a/TreeDB/db/root_snapshot.go
+++ b/TreeDB/db/root_snapshot.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"errors"
+
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/tree"
@@ -34,4 +36,34 @@ func (s *Snapshot) IteratorAtRootWithOptions(rootID uint64, start, end []byte, o
 		return nil, err
 	}
 	return tr.IteratorWithOptions(start, end, opts), nil
+}
+
+func (s *Snapshot) HasManyAtRoot(rootID uint64, keys [][]byte) ([]bool, error) {
+	out := make([]bool, len(keys))
+	if len(keys) == 0 {
+		return out, nil
+	}
+	tr, err := s.treeAtRoot(rootID)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return out, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return tr.HasMany(keys)
+}
+
+func (s *Snapshot) HasPrefixesAtRoot(rootID uint64, prefixes [][]byte) ([]bool, error) {
+	out := make([]bool, len(prefixes))
+	if len(prefixes) == 0 {
+		return out, nil
+	}
+	tr, err := s.treeAtRoot(rootID)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return out, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return tr.HasPrefixes(prefixes)
 }

--- a/TreeDB/db/root_snapshot.go
+++ b/TreeDB/db/root_snapshot.go
@@ -53,6 +53,20 @@ func (s *Snapshot) HasManyAtRoot(rootID uint64, keys [][]byte) ([]bool, error) {
 	return tr.HasMany(keys)
 }
 
+func (s *Snapshot) HasAnySortedAtRoot(rootID uint64, keys [][]byte) (bool, error) {
+	if len(keys) == 0 {
+		return false, nil
+	}
+	tr, err := s.treeAtRoot(rootID)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return tr.HasAnySorted(keys)
+}
+
 func (s *Snapshot) HasPrefixesAtRoot(rootID uint64, prefixes [][]byte) ([]bool, error) {
 	out := make([]bool, len(prefixes))
 	if len(prefixes) == 0 {

--- a/TreeDB/db/snapshot_probe_test.go
+++ b/TreeDB/db/snapshot_probe_test.go
@@ -3,6 +3,9 @@ package db
 import (
 	"reflect"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func TestSnapshot_HasManyAndHasPrefixes(t *testing.T) {
@@ -176,5 +179,83 @@ func TestSnapshot_HasManyAtRootAndHasPrefixesAtRoot(t *testing.T) {
 	}
 	if want := []bool{false}; !reflect.DeepEqual(missingRootHasPrefixes, want) {
 		t.Fatalf("HasPrefixesAtRoot missing root mismatch: got=%v want=%v", missingRootHasPrefixes, want)
+	}
+}
+
+func TestSnapshotRootProbesSkipTombstones(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t,
+		"acct/alice/doc-1", "v1",
+		"acct/alice/doc-2", "v2",
+		"acct/bob/doc-1", "v3",
+	).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+	delta, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("new delta table: %v", err)
+	}
+	delta.Delete([]byte("acct/alice/doc-1"))
+	delta.Delete([]byte("acct/bob/doc-1"))
+	delta.Freeze()
+	_, rootIDs, err := db.PublishOrderedRootDeltaGroupWithSystemBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot: baseRoot,
+		Iter:     delta.NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/probe-root", "updated").NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish delete root: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("root IDs len=%d want 1", len(rootIDs))
+	}
+	rootID := rootIDs[0]
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+
+	hasAnyDeleted, err := snap.HasAnySortedAtRoot(rootID, [][]byte{
+		[]byte("acct/alice/doc-1"),
+		[]byte("acct/bob/doc-1"),
+	})
+	if err != nil {
+		t.Fatalf("HasAnySortedAtRoot deleted keys: %v", err)
+	}
+	if hasAnyDeleted {
+		t.Fatalf("HasAnySortedAtRoot reported tombstoned exact match")
+	}
+
+	hasAnyLive, err := snap.HasAnySortedAtRoot(rootID, [][]byte{
+		[]byte("acct/alice/doc-1"),
+		[]byte("acct/alice/doc-2"),
+	})
+	if err != nil {
+		t.Fatalf("HasAnySortedAtRoot live key: %v", err)
+	}
+	if !hasAnyLive {
+		t.Fatalf("HasAnySortedAtRoot missed visible key after tombstone")
+	}
+
+	hasPrefixes, err := snap.HasPrefixesAtRoot(rootID, [][]byte{
+		[]byte("acct/alice/doc-1"),
+		[]byte("acct/alice/"),
+		[]byte("acct/bob/"),
+	})
+	if err != nil {
+		t.Fatalf("HasPrefixesAtRoot tombstones: %v", err)
+	}
+	if want := []bool{false, true, false}; !reflect.DeepEqual(hasPrefixes, want) {
+		t.Fatalf("HasPrefixesAtRoot tombstone mismatch: got=%v want=%v", hasPrefixes, want)
 	}
 }

--- a/TreeDB/db/snapshot_probe_test.go
+++ b/TreeDB/db/snapshot_probe_test.go
@@ -139,6 +139,21 @@ func TestSnapshot_HasManyAtRootAndHasPrefixesAtRoot(t *testing.T) {
 		t.Fatalf("HasPrefixesAtRoot mismatch: got=%v want=%v", hasPrefixes, want)
 	}
 
+	hasPrefixes, err = snap.HasPrefixesAtRoot(rootIDs[0], [][]byte{
+		[]byte("acct/bob/"),
+		[]byte("acct/alice/doc-1"),
+		[]byte("acct/alice/"),
+		[]byte("acct/alice/"),
+		[]byte("acct/"),
+		[]byte("acct/zoe/"),
+	})
+	if err != nil {
+		t.Fatalf("HasPrefixesAtRoot unordered/duplicate: %v", err)
+	}
+	if want := []bool{true, true, true, true, true, false}; !reflect.DeepEqual(hasPrefixes, want) {
+		t.Fatalf("HasPrefixesAtRoot unordered/duplicate mismatch: got=%v want=%v", hasPrefixes, want)
+	}
+
 	missingRootHasMany, err := snap.HasManyAtRoot(0, [][]byte{[]byte("acct/alice/doc-1")})
 	if err != nil {
 		t.Fatalf("HasManyAtRoot missing root: %v", err)

--- a/TreeDB/db/snapshot_probe_test.go
+++ b/TreeDB/db/snapshot_probe_test.go
@@ -97,6 +97,36 @@ func TestSnapshot_HasManyAtRootAndHasPrefixesAtRoot(t *testing.T) {
 		t.Fatalf("HasManyAtRoot mismatch: got=%v want=%v", hasMany, want)
 	}
 
+	hasAnySorted, err := snap.HasAnySortedAtRoot(rootIDs[0], [][]byte{
+		[]byte("acct/alice/doc-0"),
+		[]byte("acct/bob/doc-1"),
+		[]byte("acct/carol/doc-1"),
+	})
+	if err != nil {
+		t.Fatalf("HasAnySortedAtRoot: %v", err)
+	}
+	if !hasAnySorted {
+		t.Fatalf("HasAnySortedAtRoot got false want true")
+	}
+
+	hasAnySorted, err = snap.HasAnySortedAtRoot(rootIDs[0], [][]byte{
+		[]byte("acct/alice/doc-0"),
+		[]byte("acct/carol/doc-1"),
+	})
+	if err != nil {
+		t.Fatalf("HasAnySortedAtRoot miss: %v", err)
+	}
+	if hasAnySorted {
+		t.Fatalf("HasAnySortedAtRoot miss got true want false")
+	}
+
+	if _, err := snap.HasAnySortedAtRoot(rootIDs[0], [][]byte{
+		[]byte("acct/bob/doc-1"),
+		[]byte("acct/alice/doc-1"),
+	}); err == nil {
+		t.Fatalf("HasAnySortedAtRoot unsorted keys got nil error")
+	}
+
 	hasPrefixes, err := snap.HasPrefixesAtRoot(rootIDs[0], [][]byte{
 		[]byte("acct/alice/"),
 		[]byte("acct/bob/"),
@@ -115,6 +145,14 @@ func TestSnapshot_HasManyAtRootAndHasPrefixesAtRoot(t *testing.T) {
 	}
 	if want := []bool{false}; !reflect.DeepEqual(missingRootHasMany, want) {
 		t.Fatalf("HasManyAtRoot missing root mismatch: got=%v want=%v", missingRootHasMany, want)
+	}
+
+	missingRootHasAnySorted, err := snap.HasAnySortedAtRoot(0, [][]byte{[]byte("acct/alice/doc-1")})
+	if err != nil {
+		t.Fatalf("HasAnySortedAtRoot missing root: %v", err)
+	}
+	if missingRootHasAnySorted {
+		t.Fatalf("HasAnySortedAtRoot missing root got true want false")
 	}
 
 	missingRootHasPrefixes, err := snap.HasPrefixesAtRoot(0, [][]byte{[]byte("acct/alice/")})

--- a/TreeDB/db/snapshot_probe_test.go
+++ b/TreeDB/db/snapshot_probe_test.go
@@ -57,3 +57,71 @@ func TestSnapshot_HasManyAndHasPrefixes(t *testing.T) {
 		t.Fatalf("HasPrefixes mismatch: got=%v want=%v", hasPrefixes, want)
 	}
 }
+
+func TestSnapshot_HasManyAtRootAndHasPrefixesAtRoot(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, rootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{{
+		Iter: mustFrozenSystemMemtable(t,
+			"acct/alice/doc-1", "v1",
+			"acct/bob/doc-1", "v2",
+		).NewIterator(nil, nil),
+	}})
+	if err != nil {
+		t.Fatalf("publish root: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("root IDs len=%d want 1", len(rootIDs))
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+
+	hasMany, err := snap.HasManyAtRoot(rootIDs[0], [][]byte{
+		[]byte("acct/alice/doc-1"),
+		[]byte("acct/bob/doc-1"),
+		[]byte("acct/carol/doc-1"),
+	})
+	if err != nil {
+		t.Fatalf("HasManyAtRoot: %v", err)
+	}
+	if want := []bool{true, true, false}; !reflect.DeepEqual(hasMany, want) {
+		t.Fatalf("HasManyAtRoot mismatch: got=%v want=%v", hasMany, want)
+	}
+
+	hasPrefixes, err := snap.HasPrefixesAtRoot(rootIDs[0], [][]byte{
+		[]byte("acct/alice/"),
+		[]byte("acct/bob/"),
+		[]byte("acct/carol/"),
+	})
+	if err != nil {
+		t.Fatalf("HasPrefixesAtRoot: %v", err)
+	}
+	if want := []bool{true, true, false}; !reflect.DeepEqual(hasPrefixes, want) {
+		t.Fatalf("HasPrefixesAtRoot mismatch: got=%v want=%v", hasPrefixes, want)
+	}
+
+	missingRootHasMany, err := snap.HasManyAtRoot(0, [][]byte{[]byte("acct/alice/doc-1")})
+	if err != nil {
+		t.Fatalf("HasManyAtRoot missing root: %v", err)
+	}
+	if want := []bool{false}; !reflect.DeepEqual(missingRootHasMany, want) {
+		t.Fatalf("HasManyAtRoot missing root mismatch: got=%v want=%v", missingRootHasMany, want)
+	}
+
+	missingRootHasPrefixes, err := snap.HasPrefixesAtRoot(0, [][]byte{[]byte("acct/alice/")})
+	if err != nil {
+		t.Fatalf("HasPrefixesAtRoot missing root: %v", err)
+	}
+	if want := []bool{false}; !reflect.DeepEqual(missingRootHasPrefixes, want) {
+		t.Fatalf("HasPrefixesAtRoot missing root mismatch: got=%v want=%v", missingRootHasPrefixes, want)
+	}
+}

--- a/TreeDB/db/system_root_publish.go
+++ b/TreeDB/db/system_root_publish.go
@@ -43,6 +43,8 @@ func systemRootOrderedPublishOptions(db *DB) orderedRootPublishOptions {
 		leafColumnar:          db.indexColumnarLeaves,
 		packedValuePtr:        db.indexPackedValuePtr,
 		internalBaseDelta:     db.indexInternalBaseDelta,
+		outerLeavesInValueLog: db.indexOuterLeavesInValueLog,
+		leafPageLog:           db.leafPageLog,
 	}
 }
 

--- a/TreeDB/docs/spec/collections-native-fastpath-baseline-template.md
+++ b/TreeDB/docs/spec/collections-native-fastpath-baseline-template.md
@@ -180,6 +180,7 @@ COUNT=1 \
 NATIVE_WORKTREE=/home/mikers/dev/snissn/gomap
 
 TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_fast \
+TREEDB_COLLECTION_BENCH_BATCH_SIZE=8000 \
 BENCHTIME=1s \
 COUNT=1 \
 (cd "$NATIVE_WORKTREE" && git rev-parse HEAD && scripts/bench_collections_report.sh)

--- a/TreeDB/docs/spec/collections-native-fastpath-baseline-template.md
+++ b/TreeDB/docs/spec/collections-native-fastpath-baseline-template.md
@@ -179,7 +179,7 @@ COUNT=1 \
 ```bash
 NATIVE_WORKTREE=/home/mikers/dev/snissn/gomap
 
-TREEDB_COLLECTION_BENCH_ENGINE=cached \
+TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_fast \
 BENCHTIME=1s \
 COUNT=1 \
 (cd "$NATIVE_WORKTREE" && git rev-parse HEAD && scripts/bench_collections_report.sh)

--- a/TreeDB/docs/spec/collections-native-fastpath-execution-playbook.md
+++ b/TreeDB/docs/spec/collections-native-fastpath-execution-playbook.md
@@ -315,7 +315,7 @@ Native-path equivalent:
 ```bash
 NATIVE_WORKTREE=/home/mikers/dev/snissn/gomap
 
-TREEDB_COLLECTION_BENCH_ENGINE=cached \
+TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_fast \
 BENCHTIME=1s \
 COUNT=1 \
 (cd "$NATIVE_WORKTREE" && git rev-parse HEAD && scripts/bench_collections_report.sh) | tee /tmp/native_collection_bench_stdout.txt

--- a/TreeDB/docs/spec/collections-native-fastpath-execution-playbook.md
+++ b/TreeDB/docs/spec/collections-native-fastpath-execution-playbook.md
@@ -316,6 +316,7 @@ Native-path equivalent:
 NATIVE_WORKTREE=/home/mikers/dev/snissn/gomap
 
 TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_fast \
+TREEDB_COLLECTION_BENCH_BATCH_SIZE=8000 \
 BENCHTIME=1s \
 COUNT=1 \
 (cd "$NATIVE_WORKTREE" && git rev-parse HEAD && scripts/bench_collections_report.sh) | tee /tmp/native_collection_bench_stdout.txt

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -127,3 +127,24 @@ When opened read-only:
 - write operations must fail,
 - no mutating recovery steps run,
 - no background maintenance mutates on-disk state.
+
+## 9. Collections Native Fast Path
+
+Collections runtime code uses the native ordered-root publish path as the
+default execution path. The historical oracle branch is an external comparison
+artifact only; it is not a runtime selector or dependency in the collections
+package.
+
+Collection root physical policy is explicit per root:
+
+- document/data roots are the production-mainline roots and benchmark defaults
+  prioritize value-log-backed outer leaves,
+- collection index-state roots follow the collection data-root policy,
+- secondary index roots support both pager-backed fast mode and value-log-backed
+  compressed mode,
+- benchmark artifacts must label the storage-policy cell being measured.
+
+Native collection writes must publish primary, index-state, secondary, and root
+descriptor updates through grouped ordered-root publish primitives. They must not
+route the steady-state runtime path through oracle selectors, detached replay,
+overlay state, or other translation-only hooks.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -134,3 +134,34 @@ Coverage:
   - `TestReverseIterator_IncludesCachedWrites_SnapshotIsolated`
 - `kvstore/adapters/treedb/read_snapshot_cached_writes_test.go`
 - Unified-bench correctness guardrail: `cmd/unified_bench/read_snapshot_guardrail_test.go` and `BenchConfig.ReadRequireHit`
+
+## 11. Collections Native Fast Path
+
+Invariant:
+- Collections use the native ordered-root publish path by default.
+- The runtime collections package has no oracle-path selector and no detached
+  replay or overlay translation hook.
+- Collection benchmark defaults measure the production-mainline storage cell:
+  data roots with outer leaves in the value log and secondary indexes in pager
+  leaves unless explicitly overridden.
+
+Coverage:
+- `TreeDB/collections/native_default_test.go`:
+  - `TestCollectionsRuntimeHasNoOracleOrTranslationSelectors`
+- `TreeDB/collections/bench_test.go`:
+  - `TestBenchmarkCollectionStoragePolicyDefaultsProductionMainline`
+- `TreeDB/db/ordered_root_publish_test.go`:
+  - `TestPublishOrderedRootGroup_UsesPerRootStoragePolicy`
+  - `TestPublishOrderedRootDeltaGroupWithSystemBuilder_UsesPerRootStoragePolicy`
+- `TreeDB/collections/api_test.go`:
+  - `TestCollectionSingleInsertMatchesSingleItemBatch`
+  - `TestCollectionSingleInsertRejectsUniqueConflictAtomically`
+  - `TestCollectionSingleDocumentReopenUsesPersistedRootDescriptors`
+
+Benchmark verification for collection cutover must include the full storage
+matrix:
+
+- `data_outer=true,index_outer=false` (production-mainline priority),
+- `data_outer=true,index_outer=true` (fully compressed),
+- `data_outer=false,index_outer=false` (fast/control),
+- `data_outer=false,index_outer=true` (low-priority compatibility cell).

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -917,6 +917,37 @@ func (m *AppendOnly) Reset() {
 	m.resetLockedWithPolicy(0, 0, true)
 }
 
+// Release returns large internal buffers to package pools when the table is no
+// longer needed. Unlike Reset, it does not retain warm capacity on the table
+// itself, so callers should only use it for short-lived tables they will drop.
+func (m *AppendOnly) Release() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.waitIteratorLeasesLocked()
+
+	entries := m.entries
+	m.entries = nil
+	m.baseEntriesLen = 0
+	m.latest = nil
+	m.latest64 = nil
+	m.snapshot = nil
+	m.indexBuf = nil
+	m.valueArena.reset()
+	m.valueArena.dropRetained()
+	m.count = 0
+	m.snapCount = 0
+	m.sizeBytes = 0
+	m.ordered = true
+	m.latestDirty = false
+	m.frozen = false
+	m.hasLast = false
+	m.lastIdx = -1
+	putAppendOnlyEntries(entries)
+}
+
 // ResetWithCapacity resets the memtable and, when needed, shrinks retained
 // internal buffers toward the capacity-derived baseline. Unlike Reset, callers
 // provide a capacity estimate so post-spike entry retention can decay.

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -206,12 +206,33 @@ func appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry int) i
 	return n
 }
 
+func appendOnlyInitialEntriesForCount(entries int) int {
+	if entries < appendOnlyMinInitialEntries {
+		return appendOnlyMinInitialEntries
+	}
+	if entries > appendOnlyMaxInitialEntries {
+		return appendOnlyMaxInitialEntries
+	}
+	return entries
+}
+
 func NewAppendOnlyWithCapacity(capacity int) *AppendOnly {
 	return NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, appendOnlyEstimatedBytesPerEntryPointer)
 }
 
 func NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, estimatedBytesPerEntry int) *AppendOnly {
 	n := appendOnlyInitialEntriesForCapacity(capacity, estimatedBytesPerEntry)
+	return newAppendOnlyWithInitialEntries(n)
+}
+
+// NewAppendOnlyWithEntryCapacity creates an append-only table sized for an
+// expected entry count instead of a byte-capacity estimate.
+func NewAppendOnlyWithEntryCapacity(entries int) *AppendOnly {
+	n := appendOnlyInitialEntriesForCount(entries)
+	return newAppendOnlyWithInitialEntries(n)
+}
+
+func newAppendOnlyWithInitialEntries(n int) *AppendOnly {
 	return &AppendOnly{
 		entries:        getAppendOnlyEntries(n),
 		baseEntriesLen: n,

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -1185,6 +1185,15 @@ func (it *appendOnlyIterator) len() int {
 	return len(it.entries)
 }
 
+func (it *appendOnlyIterator) Len() int {
+	if it == nil {
+		return 0
+	}
+	return it.len()
+}
+
+func (*appendOnlyIterator) StableUnsafeIteratorSlices() bool { return true }
+
 func (it *appendOnlyIterator) entryAt(idx int) *appendOnlyEntry {
 	if idx < 0 {
 		return nil

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -458,6 +458,36 @@ func TestAppendOnlyResetDoesNotPoolBorrowedValueSlices(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyReleaseDropsOwnedBuffers(t *testing.T) {
+	m := NewAppendOnlyWithEntryCapacity(256)
+	m.SetSteal([]byte("a"), []byte("v1"))
+	m.SetSteal([]byte("b"), []byte("v2"))
+	m.Freeze()
+	it := m.NewIterator(nil, nil)
+	if err := it.Close(); err != nil {
+		t.Fatalf("iterator close: %v", err)
+	}
+
+	m.Release()
+	if m.entries != nil {
+		t.Fatalf("release retained entries with cap=%d", cap(m.entries))
+	}
+	if m.snapshot != nil {
+		t.Fatalf("release retained snapshot with cap=%d", cap(m.snapshot))
+	}
+	if m.indexBuf != nil {
+		t.Fatalf("release retained index buffer with cap=%d", cap(m.indexBuf))
+	}
+	if m.count != 0 || m.sizeBytes != 0 || m.frozen {
+		t.Fatalf("release left table state count=%d size=%d frozen=%t", m.count, m.sizeBytes, m.frozen)
+	}
+
+	m.SetSteal([]byte("c"), []byte("v3"))
+	if value, deleted, ok := m.Get([]byte("c")); !ok || deleted || string(value) != "v3" {
+		t.Fatalf("table not reusable after release: value=%q deleted=%t ok=%t", value, deleted, ok)
+	}
+}
+
 func TestAppendOnlyResetKeepsSnapshotBuffersWarm(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	// Force unordered mode and a non-empty latest snapshot/index buffer.

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -90,6 +90,29 @@ func TestAppendOnlyInitialEntriesForCapacity(t *testing.T) {
 	})
 }
 
+func TestAppendOnlyInitialEntriesForCount(t *testing.T) {
+	t.Run("exact-count", func(t *testing.T) {
+		got := appendOnlyInitialEntriesForCount(200)
+		if got != 200 {
+			t.Fatalf("entry count=%d want=%d", got, 200)
+		}
+	})
+
+	t.Run("minimum-clamp", func(t *testing.T) {
+		got := appendOnlyInitialEntriesForCount(1)
+		if got != appendOnlyMinInitialEntries {
+			t.Fatalf("min clamp entries=%d want=%d", got, appendOnlyMinInitialEntries)
+		}
+	})
+
+	t.Run("maximum-clamp", func(t *testing.T) {
+		got := appendOnlyInitialEntriesForCount(appendOnlyMaxInitialEntries + 1)
+		if got != appendOnlyMaxInitialEntries {
+			t.Fatalf("max clamp entries=%d want=%d", got, appendOnlyMaxInitialEntries)
+		}
+	})
+}
+
 func TestAppendOnlyCRUD(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -33,17 +33,16 @@ func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
 	}
 
 	suffixStart := len(leafPage) - suffixLen
-	var canonical [page.PageSize]byte
-	copy(canonical[:prefixLen], leafPage[:prefixLen])
-	copy(canonical[suffixStart:], leafPage[suffixStart:])
-	page.UpdateChecksum(canonical[:])
-
 	payload := make([]byte, compactLen)
 	copy(payload[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:])
 	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic):len(compactLeafPagePayloadMagic)+2], uint16(prefixLen))
 	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic)+2:compactLeafPagePayloadHeaderSize], uint16(suffixLen))
-	copy(payload[compactLeafPagePayloadHeaderSize:compactLeafPagePayloadHeaderSize+prefixLen], canonical[:prefixLen])
-	copy(payload[compactLeafPagePayloadHeaderSize+prefixLen:], canonical[suffixStart:])
+	prefix := payload[compactLeafPagePayloadHeaderSize : compactLeafPagePayloadHeaderSize+prefixLen]
+	suffix := payload[compactLeafPagePayloadHeaderSize+prefixLen:]
+	copy(prefix, leafPage[:prefixLen])
+	copy(suffix, leafPage[suffixStart:])
+	sum := page.CalculateChecksumWithZeroGap(prefix, page.PageSize-prefixLen-suffixLen, suffix)
+	binary.LittleEndian.PutUint32(prefix[8:12], sum)
 	return payload, true, nil
 }
 

--- a/TreeDB/internal/valuelog/leaf_page_payload_bench_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_bench_test.go
@@ -52,6 +52,21 @@ func compactLeafPayloadBenchmarkFixture(b *testing.B) (uint32, string, []byte) {
 	return fileID, path, payload
 }
 
+func BenchmarkMaybeCompactLeafLogPayload(b *testing.B) {
+	leaf := buildSparseLeafPageForPayloadBench(b)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+		if err != nil {
+			b.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+		}
+		if !compacted {
+			b.Fatal("expected sparse leaf fixture to compact")
+		}
+		leafPagePayloadBenchSink = payload
+	}
+}
+
 func BenchmarkAppendMaybeDecodeLeafLogPayload(b *testing.B) {
 	fileID, path, payload := compactLeafPayloadBenchmarkFixture(b)
 

--- a/TreeDB/open_backend.go
+++ b/TreeDB/open_backend.go
@@ -55,3 +55,19 @@ func OpenBackend(opts Options) (*db.DB, func() error, error) {
 
 	return backend, cleanup, nil
 }
+
+// OpenBackendWithCachedLeafLog opens TreeDB through the cached layer and returns
+// the underlying backend. This is for native-root callers that need backend root
+// APIs while also requiring cached-layer wiring such as the leaf-page value log
+// used by IndexOuterLeavesInValueLog.
+func OpenBackendWithCachedLeafLog(opts Options) (*db.DB, func() error, error) {
+	database, err := Open(opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	if database.backend == nil {
+		_ = database.Close()
+		return nil, nil, db.ErrClosed
+	}
+	return database.backend, database.Close, nil
+}

--- a/TreeDB/page/page.go
+++ b/TreeDB/page/page.go
@@ -93,8 +93,11 @@ func CalculateChecksum(data []byte) uint32 {
 // prefix + zero-filled gap + suffix. The prefix must include the checksum field
 // at bytes 8-11, which is treated as zero.
 func CalculateChecksumWithZeroGap(prefix []byte, gapLen int, suffix []byte) uint32 {
-	if len(prefix) < PageHeaderSize || gapLen < 0 {
-		return 0
+	if len(prefix) < PageHeaderSize {
+		panic("page: checksum zero-gap prefix is shorter than page header")
+	}
+	if gapLen < 0 {
+		panic("page: checksum zero-gap length is negative")
 	}
 	sum := crc32.Update(0, crcTable, prefix[0:8])
 	sum = crc32.Update(sum, crcTable, checksumZeroField[:])

--- a/TreeDB/page/page.go
+++ b/TreeDB/page/page.go
@@ -69,6 +69,7 @@ type ValuePtr struct {
 // CRC32C Table using Castagnoli polynomial.
 var crcTable = crc32.MakeTable(crc32.Castagnoli)
 var checksumZeroField = [4]byte{}
+var checksumZeroBlock = [1024]byte{}
 
 // Checksum returns the CRC32C checksum of data.
 func Checksum(data []byte) uint32 {
@@ -85,6 +86,35 @@ func CalculateChecksum(data []byte) uint32 {
 	sum := crc32.Update(0, crcTable, data[0:8])
 	sum = crc32.Update(sum, crcTable, checksumZeroField[:])
 	sum = crc32.Update(sum, crcTable, data[12:])
+	return sum
+}
+
+// CalculateChecksumWithZeroGap computes the checksum for a logical page made of
+// prefix + zero-filled gap + suffix. The prefix must include the checksum field
+// at bytes 8-11, which is treated as zero.
+func CalculateChecksumWithZeroGap(prefix []byte, gapLen int, suffix []byte) uint32 {
+	if len(prefix) < PageHeaderSize || gapLen < 0 {
+		return 0
+	}
+	sum := crc32.Update(0, crcTable, prefix[0:8])
+	sum = crc32.Update(sum, crcTable, checksumZeroField[:])
+	sum = crc32.Update(sum, crcTable, prefix[12:])
+	sum = updateChecksumZeroes(sum, gapLen)
+	if len(suffix) > 0 {
+		sum = crc32.Update(sum, crcTable, suffix)
+	}
+	return sum
+}
+
+func updateChecksumZeroes(sum uint32, count int) uint32 {
+	for count > 0 {
+		n := count
+		if n > len(checksumZeroBlock) {
+			n = len(checksumZeroBlock)
+		}
+		sum = crc32.Update(sum, crcTable, checksumZeroBlock[:n])
+		count -= n
+	}
 	return sum
 }
 

--- a/TreeDB/page/page_test.go
+++ b/TreeDB/page/page_test.go
@@ -131,6 +131,26 @@ func TestUpdateChecksum(t *testing.T) {
 	}
 }
 
+func TestCalculateChecksumWithZeroGap(t *testing.T) {
+	canonical := make([]byte, PageSize)
+	for i := range canonical {
+		canonical[i] = byte((i*31 + 7) & 0xff)
+	}
+	prefixLen := 96
+	suffixLen := 384
+	gapLen := PageSize - prefixLen - suffixLen
+	for i := prefixLen; i < PageSize-suffixLen; i++ {
+		canonical[i] = 0
+	}
+	binary.LittleEndian.PutUint32(canonical[8:12], 0xdeadbeef)
+
+	want := CalculateChecksum(canonical)
+	got := CalculateChecksumWithZeroGap(canonical[:prefixLen], gapLen, canonical[PageSize-suffixLen:])
+	if got != want {
+		t.Fatalf("CalculateChecksumWithZeroGap=0x%x want 0x%x", got, want)
+	}
+}
+
 func TestUnsafeCastHeader(t *testing.T) {
 	// Note: This test assumes LittleEndian machine.
 	// If running on BigEndian, this test might fail or require adjustment if UnsafeCastHeader is used.

--- a/TreeDB/page/page_test.go
+++ b/TreeDB/page/page_test.go
@@ -151,6 +151,25 @@ func TestCalculateChecksumWithZeroGap(t *testing.T) {
 	}
 }
 
+func TestCalculateChecksumWithZeroGapPanicsOnInvalidInput(t *testing.T) {
+	assertPanic := func(name string, fn func()) {
+		t.Helper()
+		defer func() {
+			if recover() == nil {
+				t.Fatalf("%s did not panic", name)
+			}
+		}()
+		fn()
+	}
+
+	assertPanic("short prefix", func() {
+		_ = CalculateChecksumWithZeroGap(make([]byte, PageHeaderSize-1), 0, nil)
+	})
+	assertPanic("negative gap", func() {
+		_ = CalculateChecksumWithZeroGap(make([]byte, PageHeaderSize), -1, nil)
+	})
+}
+
 func TestUnsafeCastHeader(t *testing.T) {
 	// Note: This test assumes LittleEndian machine.
 	// If running on BigEndian, this test might fail or require adjustment if UnsafeCastHeader is used.

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -998,7 +998,7 @@ func (it *Iterator) Seek(key []byte) {
 }
 
 func (it *Iterator) IsDeleted() bool {
-	return false
+	return it != nil && it.valid && it.flags&node.FlagTombstone != 0
 }
 
 func (it *Iterator) Domain() (start, end []byte) {

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -810,33 +810,46 @@ func (t *Tree) HasPrefixes(prefixes [][]byte) ([]bool, error) {
 		return compareTreeKey(refs[i].prefix, refs[j].prefix) < 0
 	})
 
-	unique := make([][]byte, 0, len(refs))
-	groupStarts := make([]int, 0, len(refs))
-	for i, ref := range refs {
-		if len(unique) == 0 || !bytes.Equal(ref.prefix, unique[len(unique)-1]) {
-			unique = append(unique, ref.prefix)
-			groupStarts = append(groupStarts, i)
+	it := t.IteratorWithOptions(refs[0].prefix, nil, IteratorOptions{Mode: IteratorModeKeysOnly})
+	defer func() { _ = it.Close() }()
+	for start := 0; start < len(refs); {
+		prefix := refs[start].prefix
+		end := start + 1
+		for end < len(refs) && bytes.Equal(refs[end].prefix, prefix) {
+			end++
 		}
-	}
 
-	for i, prefix := range unique {
-		it := t.IteratorWithOptions(prefix, nil, IteratorOptions{Mode: IteratorModeKeysOnly})
-		ok := it.Valid() && bytes.HasPrefix(it.UnsafeKey(), prefix) && !it.IsDeleted()
-		err := it.Error()
-		_ = it.Close()
-		if err != nil {
-			return nil, err
+		found := false
+		for {
+			if !it.Valid() {
+				if err := it.Error(); err != nil {
+					return nil, err
+				}
+				return out, nil
+			}
+			curr := it.UnsafeKey()
+			if compareTreeKey(curr, prefix) < 0 {
+				it.Seek(prefix)
+				continue
+			}
+			if !bytes.HasPrefix(curr, prefix) {
+				break
+			}
+			if !it.IsDeleted() {
+				found = true
+				break
+			}
+			it.Next()
 		}
-		if !ok {
-			continue
+		if found {
+			for _, ref := range refs[start:end] {
+				out[ref.idx] = true
+			}
 		}
-		groupEnd := len(refs)
-		if i+1 < len(groupStarts) {
-			groupEnd = groupStarts[i+1]
-		}
-		for _, ref := range refs[groupStarts[i]:groupEnd] {
-			out[ref.idx] = true
-		}
+		start = end
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -758,7 +758,14 @@ func (t *Tree) HasAnySorted(keys [][]byte) (bool, error) {
 		curr := it.UnsafeKey()
 		switch cmp := compareTreeKey(curr, keys[targetIdx]); {
 		case cmp == 0:
-			return true, it.Error()
+			if !it.IsDeleted() {
+				return true, it.Error()
+			}
+			target := keys[targetIdx]
+			for targetIdx < len(keys) && compareTreeKey(keys[targetIdx], target) == 0 {
+				targetIdx++
+			}
+			it.Next()
 		case cmp < 0:
 			scanned++
 			if scanned > scanLimit {
@@ -819,6 +826,7 @@ func (t *Tree) HasPrefixes(prefixes [][]byte) ([]bool, error) {
 			end++
 		}
 
+		it.Seek(prefix)
 		found := false
 		for {
 			if !it.Valid() {

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 
@@ -713,4 +714,65 @@ func (t *Tree) Has(key []byte) (bool, error) {
 	}
 
 	return false, errors.New("tree too deep")
+}
+
+func (t *Tree) HasMany(keys [][]byte) ([]bool, error) {
+	out := make([]bool, len(keys))
+	for i, key := range keys {
+		ok, err := t.Has(key)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = ok
+	}
+	return out, nil
+}
+
+func (t *Tree) HasPrefixes(prefixes [][]byte) ([]bool, error) {
+	out := make([]bool, len(prefixes))
+	if len(prefixes) == 0 {
+		return out, nil
+	}
+
+	type prefixProbeRef struct {
+		prefix []byte
+		idx    int
+	}
+	refs := make([]prefixProbeRef, len(prefixes))
+	for i, prefix := range prefixes {
+		refs[i] = prefixProbeRef{prefix: prefix, idx: i}
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		return compareTreeKey(refs[i].prefix, refs[j].prefix) < 0
+	})
+
+	unique := make([][]byte, 0, len(refs))
+	groupStarts := make([]int, 0, len(refs))
+	for i, ref := range refs {
+		if len(unique) == 0 || !bytes.Equal(ref.prefix, unique[len(unique)-1]) {
+			unique = append(unique, ref.prefix)
+			groupStarts = append(groupStarts, i)
+		}
+	}
+
+	for i, prefix := range unique {
+		it := t.IteratorWithOptions(prefix, nil, IteratorOptions{Mode: IteratorModeKeysOnly})
+		ok := it.Valid() && bytes.HasPrefix(it.UnsafeKey(), prefix) && !it.IsDeleted()
+		err := it.Error()
+		_ = it.Close()
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		groupEnd := len(refs)
+		if i+1 < len(groupStarts) {
+			groupEnd = groupStarts[i+1]
+		}
+		for _, ref := range refs[groupStarts[i]:groupEnd] {
+			out[ref.idx] = true
+		}
+	}
+	return out, nil
 }

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -728,6 +728,70 @@ func (t *Tree) HasMany(keys [][]byte) ([]bool, error) {
 	return out, nil
 }
 
+func (t *Tree) HasAnySorted(keys [][]byte) (bool, error) {
+	if len(keys) == 0 {
+		return false, nil
+	}
+	for i := 1; i < len(keys); i++ {
+		if compareTreeKey(keys[i-1], keys[i]) > 0 {
+			return false, errors.New("keys must be sorted")
+		}
+	}
+
+	scanLimit := len(keys) * 4
+	if scanLimit < 1024 {
+		scanLimit = 1024
+	}
+
+	it := t.IteratorWithOptions(keys[0], nil, IteratorOptions{Mode: IteratorModeKeysOnly})
+	defer func() { _ = it.Close() }()
+	targetIdx := 0
+	scanned := 0
+	limitExceeded := false
+	for targetIdx < len(keys) {
+		if !it.Valid() {
+			if err := it.Error(); err != nil {
+				return false, err
+			}
+			return false, nil
+		}
+		curr := it.UnsafeKey()
+		switch cmp := compareTreeKey(curr, keys[targetIdx]); {
+		case cmp == 0:
+			return true, it.Error()
+		case cmp < 0:
+			scanned++
+			if scanned > scanLimit {
+				limitExceeded = true
+				goto fallback
+			}
+			it.Next()
+		default:
+			for targetIdx < len(keys) && compareTreeKey(keys[targetIdx], curr) < 0 {
+				targetIdx++
+			}
+		}
+	}
+
+fallback:
+	if err := it.Error(); err != nil {
+		return false, err
+	}
+	if !limitExceeded {
+		return false, nil
+	}
+	for ; targetIdx < len(keys); targetIdx++ {
+		ok, err := t.Has(keys[targetIdx])
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (t *Tree) HasPrefixes(prefixes [][]byte) ([]bool, error) {
 	out := make([]bool, len(prefixes))
 	if len(prefixes) == 0 {

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -734,7 +734,7 @@ func (t *Tree) HasAnySorted(keys [][]byte) (bool, error) {
 	}
 	for i := 1; i < len(keys); i++ {
 		if compareTreeKey(keys[i-1], keys[i]) > 0 {
-			return false, errors.New("keys must be sorted")
+			return false, errors.New("HasAnySorted: keys must be sorted in ascending compareTreeKey order (8-byte keys are compared as big-endian uint64)")
 		}
 	}
 

--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -30,6 +30,7 @@ type config struct {
 	benchPattern        string
 	count               int
 	benchmarkEngine     string
+	storagePolicy       string
 	collectionBatchSize int
 	unavailableReason   string
 }
@@ -78,6 +79,7 @@ type report struct {
 	UnavailableReason   string          `json:"unavailable_reason,omitempty"`
 	ExecutionPath       string          `json:"execution_path,omitempty"`
 	BenchmarkEngine     string          `json:"benchmark_engine,omitempty"`
+	StoragePolicy       string          `json:"storage_policy,omitempty"`
 	Worktree            string          `json:"worktree,omitempty"`
 	Branch              string          `json:"branch,omitempty"`
 	Commit              string          `json:"commit,omitempty"`
@@ -92,6 +94,7 @@ var benchmarkSpecs = []benchmarkSpec{
 	{Name: "BenchmarkCollectionInsertProvidedID", Section: "Document Path", Description: "Insert documents with caller-provided IDs into the primary collection root."},
 	{Name: "BenchmarkCollectionInsertBatchProvidedID", Section: "Batch Ingest Path", Description: "Insert documents with caller-provided IDs through the collection batch API; ops/sec is documents/sec."},
 	{Name: "BenchmarkCollectionGetByID", Section: "Document Path", Description: "Lookup documents by primary `_id` from the dedicated primary root."},
+	{Name: "BenchmarkCollectionGetByIDParallel", Section: "Document Path", Description: "Parallel lookup of documents by primary `_id` from the dedicated primary root."},
 	{Name: "BenchmarkCollectionDeleteByID", Section: "Document Path", Description: "Delete pre-existing documents from the primary root without secondary index maintenance."},
 	{Name: "BenchmarkCollectionInsertWithSecondaryIndexes", Section: "Document Path", Description: "Insert documents while maintaining both unique and non-unique secondary indexes."},
 	{Name: "BenchmarkCollectionInsertBatchWithSecondaryIndexes", Section: "Batch Ingest Path", Description: "Batch insert documents while maintaining unique and non-unique secondary indexes; ops/sec is documents/sec."},
@@ -178,6 +181,7 @@ func parseFlagsFrom(args []string) (config, error) {
 	fs.StringVar(&cfg.benchPattern, "bench-pattern", "", "Optional benchmark regex to include in report metadata")
 	fs.IntVar(&cfg.count, "count", 0, "Optional benchmark count to include in report metadata")
 	fs.StringVar(&cfg.benchmarkEngine, "benchmark-engine", "", "Optional benchmark engine label to include in report metadata")
+	fs.StringVar(&cfg.storagePolicy, "storage-policy", "", "Optional collection root storage-policy label to include in report metadata")
 	fs.IntVar(&cfg.collectionBatchSize, "collection-batch-size", 0, "Optional collection benchmark batch size to include in report metadata")
 	fs.StringVar(&cfg.unavailableReason, "unavailable-reason", "", "Emit an explicit unavailable report instead of parsing benchmark input")
 	if err := fs.Parse(args); err != nil {
@@ -213,6 +217,7 @@ func buildReport(cfg config) (*report, error) {
 			UnavailableReason:   cfg.unavailableReason,
 			ExecutionPath:       cfg.executionPath,
 			BenchmarkEngine:     cfg.benchmarkEngine,
+			StoragePolicy:       cfg.storagePolicy,
 			Worktree:            cfg.worktree,
 			Branch:              cfg.branch,
 			Commit:              cfg.commit,
@@ -245,6 +250,7 @@ func buildReport(cfg config) (*report, error) {
 		Status:              "ok",
 		ExecutionPath:       cfg.executionPath,
 		BenchmarkEngine:     cfg.benchmarkEngine,
+		StoragePolicy:       cfg.storagePolicy,
 		Worktree:            cfg.worktree,
 		Branch:              cfg.branch,
 		Commit:              cfg.commit,
@@ -461,6 +467,9 @@ func renderMarkdown(rep *report) string {
 	}
 	if rep.BenchmarkEngine != "" {
 		sb.WriteString(fmt.Sprintf("- benchmark engine: `%s`\n", rep.BenchmarkEngine))
+	}
+	if rep.StoragePolicy != "" {
+		sb.WriteString(fmt.Sprintf("- storage policy: `%s`\n", rep.StoragePolicy))
 	}
 	if rep.Worktree != "" {
 		sb.WriteString(fmt.Sprintf("- worktree: `%s`\n", rep.Worktree))

--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -21,16 +21,17 @@ import (
 )
 
 type config struct {
-	inputPath         string
-	outDir            string
-	branch            string
-	commit            string
-	worktree          string
-	executionPath     string
-	benchPattern      string
-	count             int
-	benchmarkEngine   string
-	unavailableReason string
+	inputPath           string
+	outDir              string
+	branch              string
+	commit              string
+	worktree            string
+	executionPath       string
+	benchPattern        string
+	count               int
+	benchmarkEngine     string
+	collectionBatchSize int
+	unavailableReason   string
 }
 
 type jsonEvent struct {
@@ -72,18 +73,19 @@ type reportSection struct {
 }
 
 type report struct {
-	GeneratedAt       string          `json:"generated_at"`
-	Status            string          `json:"status"`
-	UnavailableReason string          `json:"unavailable_reason,omitempty"`
-	ExecutionPath     string          `json:"execution_path,omitempty"`
-	BenchmarkEngine   string          `json:"benchmark_engine,omitempty"`
-	Worktree          string          `json:"worktree,omitempty"`
-	Branch            string          `json:"branch,omitempty"`
-	Commit            string          `json:"commit,omitempty"`
-	BenchPattern      string          `json:"bench_pattern,omitempty"`
-	Count             int             `json:"count,omitempty"`
-	RawJSONPath       string          `json:"raw_json_path,omitempty"`
-	Sections          []reportSection `json:"sections"`
+	GeneratedAt         string          `json:"generated_at"`
+	Status              string          `json:"status"`
+	UnavailableReason   string          `json:"unavailable_reason,omitempty"`
+	ExecutionPath       string          `json:"execution_path,omitempty"`
+	BenchmarkEngine     string          `json:"benchmark_engine,omitempty"`
+	Worktree            string          `json:"worktree,omitempty"`
+	Branch              string          `json:"branch,omitempty"`
+	Commit              string          `json:"commit,omitempty"`
+	BenchPattern        string          `json:"bench_pattern,omitempty"`
+	Count               int             `json:"count,omitempty"`
+	CollectionBatchSize int             `json:"collection_batch_size,omitempty"`
+	RawJSONPath         string          `json:"raw_json_path,omitempty"`
+	Sections            []reportSection `json:"sections"`
 }
 
 var benchmarkSpecs = []benchmarkSpec{
@@ -172,6 +174,7 @@ func parseFlagsFrom(args []string) (config, error) {
 	fs.StringVar(&cfg.benchPattern, "bench-pattern", "", "Optional benchmark regex to include in report metadata")
 	fs.IntVar(&cfg.count, "count", 0, "Optional benchmark count to include in report metadata")
 	fs.StringVar(&cfg.benchmarkEngine, "benchmark-engine", "", "Optional benchmark engine label to include in report metadata")
+	fs.IntVar(&cfg.collectionBatchSize, "collection-batch-size", 0, "Optional collection benchmark batch size to include in report metadata")
 	fs.StringVar(&cfg.unavailableReason, "unavailable-reason", "", "Emit an explicit unavailable report instead of parsing benchmark input")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
@@ -201,17 +204,18 @@ func validateExecutionPath(path string) error {
 func buildReport(cfg config) (*report, error) {
 	if cfg.unavailableReason != "" {
 		return &report{
-			GeneratedAt:       time.Now().UTC().Format(time.RFC3339),
-			Status:            "unavailable",
-			UnavailableReason: cfg.unavailableReason,
-			ExecutionPath:     cfg.executionPath,
-			BenchmarkEngine:   cfg.benchmarkEngine,
-			Worktree:          cfg.worktree,
-			Branch:            cfg.branch,
-			Commit:            cfg.commit,
-			BenchPattern:      cfg.benchPattern,
-			Count:             cfg.count,
-			Sections:          nil,
+			GeneratedAt:         time.Now().UTC().Format(time.RFC3339),
+			Status:              "unavailable",
+			UnavailableReason:   cfg.unavailableReason,
+			ExecutionPath:       cfg.executionPath,
+			BenchmarkEngine:     cfg.benchmarkEngine,
+			Worktree:            cfg.worktree,
+			Branch:              cfg.branch,
+			Commit:              cfg.commit,
+			BenchPattern:        cfg.benchPattern,
+			Count:               cfg.count,
+			CollectionBatchSize: cfg.collectionBatchSize,
+			Sections:            nil,
 		}, nil
 	}
 
@@ -233,17 +237,18 @@ func buildReport(cfg config) (*report, error) {
 	sections := buildSections(aggregates)
 
 	return &report{
-		GeneratedAt:     time.Now().UTC().Format(time.RFC3339),
-		Status:          "ok",
-		ExecutionPath:   cfg.executionPath,
-		BenchmarkEngine: cfg.benchmarkEngine,
-		Worktree:        cfg.worktree,
-		Branch:          cfg.branch,
-		Commit:          cfg.commit,
-		BenchPattern:    cfg.benchPattern,
-		Count:           cfg.count,
-		RawJSONPath:     cfg.inputPath,
-		Sections:        sections,
+		GeneratedAt:         time.Now().UTC().Format(time.RFC3339),
+		Status:              "ok",
+		ExecutionPath:       cfg.executionPath,
+		BenchmarkEngine:     cfg.benchmarkEngine,
+		Worktree:            cfg.worktree,
+		Branch:              cfg.branch,
+		Commit:              cfg.commit,
+		BenchPattern:        cfg.benchPattern,
+		Count:               cfg.count,
+		CollectionBatchSize: cfg.collectionBatchSize,
+		RawJSONPath:         cfg.inputPath,
+		Sections:            sections,
 	}, nil
 }
 
@@ -467,6 +472,9 @@ func renderMarkdown(rep *report) string {
 	}
 	if rep.Count > 0 {
 		sb.WriteString(fmt.Sprintf("- benchmark count: `%d`\n", rep.Count))
+	}
+	if rep.CollectionBatchSize > 0 {
+		sb.WriteString(fmt.Sprintf("- collection batch size: `%d`\n", rep.CollectionBatchSize))
 	}
 	if rep.RawJSONPath != "" {
 		sb.WriteString(fmt.Sprintf("- raw benchmark json: `%s`\n", rep.RawJSONPath))

--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -101,6 +101,10 @@ var benchmarkSpecs = []benchmarkSpec{
 	{Name: "BenchmarkSecondaryLookupNonUnique", Section: "Secondary Index Path", Description: "Resolve a non-unique secondary index lookup that returns multiple document IDs."},
 	{Name: "BenchmarkSecondaryUpsertFieldChange", Section: "Secondary Index Path", Description: "Rewrite a document so an indexed field changes and postings move to the new value."},
 	{Name: "BenchmarkCollectionCreateIndexBackfillExistingDocs", Section: "Secondary Index Path", Description: "Build a new secondary index and backfill it from an existing primary collection root."},
+	{Name: "BenchmarkCollectionOverheadPlanNoIndex", Section: "Overhead Breakdown", Description: "Plan a no-index collection batch without publishing it; isolates collection planner overhead from backend root publish."},
+	{Name: "BenchmarkCollectionOverheadPlanIndexed", Section: "Overhead Breakdown", Description: "Plan an indexed collection batch without publishing it; includes JSON index extraction, index-state encoding, and secondary run construction."},
+	{Name: "BenchmarkCollectionOverheadIndexStateJSONExtraction", Section: "Overhead Breakdown", Description: "Extract indexed values from JSON documents and encode index-state values, without planner run construction or backend publish."},
+	{Name: "BenchmarkCollectionOverheadPlanIndexedPrecomputedState", Section: "Overhead Breakdown", Description: "Plan an indexed collection batch using precomputed index state, approximating the non-JSON indexed planner cost."},
 }
 
 var benchmarkNameRE = regexp.MustCompile(`^(Benchmark\S+)-(\d+)$`)
@@ -405,7 +409,7 @@ func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
 }
 
 func buildSections(aggregates map[string]benchmarkAggregate) []reportSection {
-	sectionOrder := []string{"Document Path", "Batch Ingest Path", "Secondary Index Path", "Maintenance", "Other"}
+	sectionOrder := []string{"Document Path", "Batch Ingest Path", "Secondary Index Path", "Overhead Breakdown", "Maintenance", "Other"}
 	sections := make(map[string][]benchmarkAggregate, len(sectionOrder))
 	seen := make(map[string]struct{}, len(aggregates))
 

--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -88,9 +88,12 @@ type report struct {
 
 var benchmarkSpecs = []benchmarkSpec{
 	{Name: "BenchmarkCollectionInsertProvidedID", Section: "Document Path", Description: "Insert documents with caller-provided IDs into the primary collection root."},
+	{Name: "BenchmarkCollectionInsertBatchProvidedID", Section: "Batch Ingest Path", Description: "Insert documents with caller-provided IDs through the collection batch API; ops/sec is documents/sec."},
 	{Name: "BenchmarkCollectionGetByID", Section: "Document Path", Description: "Lookup documents by primary `_id` from the dedicated primary root."},
 	{Name: "BenchmarkCollectionDeleteByID", Section: "Document Path", Description: "Delete pre-existing documents from the primary root without secondary index maintenance."},
 	{Name: "BenchmarkCollectionInsertWithSecondaryIndexes", Section: "Document Path", Description: "Insert documents while maintaining both unique and non-unique secondary indexes."},
+	{Name: "BenchmarkCollectionInsertBatchWithSecondaryIndexes", Section: "Batch Ingest Path", Description: "Batch insert documents while maintaining unique and non-unique secondary indexes; ops/sec is documents/sec."},
+	{Name: "BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes", Section: "Batch Ingest Path", Description: "Batch insert indexed documents and force a sync boundary after each batch; ops/sec is documents/sec."},
 	{Name: "BenchmarkCollectionDeleteWithSecondaryIndexes", Section: "Document Path", Description: "Delete documents while removing postings from unique and non-unique secondary indexes."},
 	{Name: "BenchmarkSecondaryLookupUnique", Section: "Secondary Index Path", Description: "Resolve a unique secondary index lookup to document IDs."},
 	{Name: "BenchmarkSecondaryLookupNonUnique", Section: "Secondary Index Path", Description: "Resolve a non-unique secondary index lookup that returns multiple document IDs."},
@@ -397,7 +400,7 @@ func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
 }
 
 func buildSections(aggregates map[string]benchmarkAggregate) []reportSection {
-	sectionOrder := []string{"Document Path", "Secondary Index Path", "Maintenance", "Other"}
+	sectionOrder := []string{"Document Path", "Batch Ingest Path", "Secondary Index Path", "Maintenance", "Other"}
 	sections := make(map[string][]benchmarkAggregate, len(sectionOrder))
 	seen := make(map[string]struct{}, len(aggregates))
 

--- a/cmd/collection_bench_report/main_test.go
+++ b/cmd/collection_bench_report/main_test.go
@@ -83,6 +83,7 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 		Status:              "ok",
 		ExecutionPath:       "oracle",
 		BenchmarkEngine:     "cached",
+		StoragePolicy:       "data_outer=true,index_outer=false",
 		Worktree:            "/tmp/oracle",
 		Branch:              "pr/oracle",
 		Commit:              "deadbeef",
@@ -99,6 +100,9 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	}
 	if !strings.Contains(md, "- collection batch size: `8000`") {
 		t.Fatalf("markdown missing collection batch size:\n%s", md)
+	}
+	if !strings.Contains(md, "- storage policy: `data_outer=true,index_outer=false`") {
+		t.Fatalf("markdown missing storage policy:\n%s", md)
 	}
 	if !strings.Contains(md, "## Document Path") {
 		t.Fatalf("markdown missing document section:\n%s", md)

--- a/cmd/collection_bench_report/main_test.go
+++ b/cmd/collection_bench_report/main_test.go
@@ -79,15 +79,16 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	}
 
 	rep := &report{
-		GeneratedAt:     "2026-03-05T00:00:00Z",
-		Status:          "ok",
-		ExecutionPath:   "oracle",
-		BenchmarkEngine: "cached",
-		Worktree:        "/tmp/oracle",
-		Branch:          "pr/oracle",
-		Commit:          "deadbeef",
-		RawJSONPath:     "/tmp/collections_bench.json",
-		Sections:        buildSections(aggregates),
+		GeneratedAt:         "2026-03-05T00:00:00Z",
+		Status:              "ok",
+		ExecutionPath:       "oracle",
+		BenchmarkEngine:     "cached",
+		Worktree:            "/tmp/oracle",
+		Branch:              "pr/oracle",
+		Commit:              "deadbeef",
+		CollectionBatchSize: 8000,
+		RawJSONPath:         "/tmp/collections_bench.json",
+		Sections:            buildSections(aggregates),
 	}
 	md := renderMarkdown(rep)
 	if !strings.Contains(md, "- execution path: `oracle`") {
@@ -95,6 +96,9 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	}
 	if !strings.Contains(md, "- worktree: `/tmp/oracle`") {
 		t.Fatalf("markdown missing worktree:\n%s", md)
+	}
+	if !strings.Contains(md, "- collection batch size: `8000`") {
+		t.Fatalf("markdown missing collection batch size:\n%s", md)
 	}
 	if !strings.Contains(md, "## Document Path") {
 		t.Fatalf("markdown missing document section:\n%s", md)

--- a/scripts/bench_collections_report.sh
+++ b/scripts/bench_collections_report.sh
@@ -9,6 +9,7 @@ BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertProvidedID|CollectionInser
 COUNT="${COUNT:-3}"
 BENCHTIME="${BENCHTIME:-}"
 BENCH_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-backend_direct_fast}"
+BATCH_SIZE="${TREEDB_COLLECTION_BENCH_BATCH_SIZE:-8000}"
 PATH_LABEL="${TREEDB_COLLECTION_PATH_LABEL:-}"
 
 RAW_JSON="$OUT_DIR/collections_bench.json"
@@ -37,6 +38,7 @@ fi
 
 echo "running focused collections benchmarks into: $OUT_DIR"
 echo "benchmark engine: $BENCH_ENGINE"
+echo "collection batch size: $BATCH_SIZE"
 echo "execution path: $PATH_LABEL"
 
 if [[ -z "$PATH_LABEL" ]]; then
@@ -52,11 +54,12 @@ if [[ ! -d "$ROOT/TreeDB/collections" ]]; then
     -worktree "$WORKTREE" \
     -execution-path "$PATH_LABEL" \
     -benchmark-engine "$BENCH_ENGINE" \
+    -collection-batch-size "$BATCH_SIZE" \
     -bench-pattern "$BENCH_REGEX" \
     -count "$COUNT" \
     -unavailable-reason "N/A before R0 harness bring-up"
 else
-  TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" GOWORK=off "${cmd[@]}" | tee "$RAW_JSON"
+  TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" GOWORK=off "${cmd[@]}" | tee "$RAW_JSON"
 
   GOWORK=off go run ./cmd/collection_bench_report \
     -in "$RAW_JSON" \
@@ -66,6 +69,7 @@ else
     -worktree "$WORKTREE" \
     -execution-path "$PATH_LABEL" \
     -benchmark-engine "$BENCH_ENGINE" \
+    -collection-batch-size "$BATCH_SIZE" \
     -bench-pattern "$BENCH_REGEX" \
     -count "$COUNT"
 fi
@@ -79,6 +83,7 @@ cat >"$OUT_DIR/README.md" <<EOF
 - commit: \`$COMMIT\`
 - execution path: \`$PATH_LABEL\`
 - benchmark engine: \`$BENCH_ENGINE\`
+- collection batch size: \`$BATCH_SIZE\`
 - benchmark regex: \`$BENCH_REGEX\`
 - benchmark count: \`$COUNT\`
 - raw benchmark json: \`$RAW_JSON\`
@@ -89,6 +94,7 @@ cat >"$OUT_DIR/README.md" <<EOF
 - json report: \`$OUT_DIR/collections_report.json\`
 - backend-direct fast override: \`TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_fast scripts/bench_collections_report.sh\`
 - backend-direct WAL-on-fast override: \`TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_wal_on_fast scripts/bench_collections_report.sh\`
+- batch-size override: \`TREEDB_COLLECTION_BENCH_BATCH_SIZE=8000 scripts/bench_collections_report.sh\`
 - oracle-path override: \`TREEDB_COLLECTION_PATH_LABEL=oracle scripts/bench_collections_report.sh\`
 EOF
 

--- a/scripts/bench_collections_report.sh
+++ b/scripts/bench_collections_report.sh
@@ -119,8 +119,8 @@ $ARTIFACT_LINES
 - production fast override: \`TREEDB_COLLECTION_BENCH_ENGINE=production_fast scripts/bench_collections_report.sh\`
 - production WAL-on-fast override: \`TREEDB_COLLECTION_BENCH_ENGINE=production_wal_on_fast scripts/bench_collections_report.sh\`
 - backend-direct fast/control override: \`TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_fast TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=false TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=false scripts/bench_collections_report.sh\`
-- data-root outer-leaf override: \`TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=true scripts/bench_collections_report.sh\`
-- index-root outer-leaf override: \`TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=false scripts/bench_collections_report.sh\`
+- data-root pager-leaf override: \`TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=false scripts/bench_collections_report.sh\`
+- index-root outer-leaf override: \`TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=true scripts/bench_collections_report.sh\`
 - batch-size override: \`TREEDB_COLLECTION_BENCH_BATCH_SIZE=8000 scripts/bench_collections_report.sh\`
 - oracle-path override: \`TREEDB_COLLECTION_PATH_LABEL=oracle scripts/bench_collections_report.sh\`
 EOF

--- a/scripts/bench_collections_report.sh
+++ b/scripts/bench_collections_report.sh
@@ -5,11 +5,14 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT"
 
 OUT_DIR="${OUT_DIR:-$(mktemp -d /tmp/gomap_collections_report_XXXXXX)}"
-BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertProvidedID|CollectionInsertBatchProvidedID|CollectionGetByID|CollectionDeleteByID|CollectionInsertWithSecondaryIndexes|CollectionInsertBatchWithSecondaryIndexes|CollectionInsertBatchCheckpointWithSecondaryIndexes|CollectionDeleteWithSecondaryIndexes|SecondaryLookupUnique|SecondaryLookupNonUnique|SecondaryUpsertFieldChange|CollectionCreateIndexBackfillExistingDocs)}"
+BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertProvidedID|CollectionInsertBatchProvidedID|CollectionGetByID|CollectionGetByIDParallel|CollectionDeleteByID|CollectionInsertWithSecondaryIndexes|CollectionInsertBatchWithSecondaryIndexes|CollectionInsertBatchCheckpointWithSecondaryIndexes|CollectionDeleteWithSecondaryIndexes|SecondaryLookupUnique|SecondaryLookupNonUnique|SecondaryUpsertFieldChange|CollectionCreateIndexBackfillExistingDocs)}"
 COUNT="${COUNT:-3}"
 BENCHTIME="${BENCHTIME:-}"
-BENCH_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-backend_direct_fast}"
+BENCH_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-production_fast}"
 BATCH_SIZE="${TREEDB_COLLECTION_BENCH_BATCH_SIZE:-8000}"
+DATA_OUTER="${TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG:-true}"
+INDEX_OUTER="${TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG:-false}"
+STORAGE_POLICY_LABEL="data_outer=${DATA_OUTER},index_outer=${INDEX_OUTER}"
 PATH_LABEL="${TREEDB_COLLECTION_PATH_LABEL:-}"
 
 RAW_JSON="$OUT_DIR/collections_bench.json"
@@ -39,6 +42,7 @@ fi
 echo "running focused collections benchmarks into: $OUT_DIR"
 echo "benchmark engine: $BENCH_ENGINE"
 echo "collection batch size: $BATCH_SIZE"
+echo "storage policy: $STORAGE_POLICY_LABEL"
 echo "execution path: $PATH_LABEL"
 
 if [[ -z "$PATH_LABEL" ]]; then
@@ -54,12 +58,13 @@ if [[ ! -d "$ROOT/TreeDB/collections" ]]; then
     -worktree "$WORKTREE" \
     -execution-path "$PATH_LABEL" \
     -benchmark-engine "$BENCH_ENGINE" \
+    -storage-policy "$STORAGE_POLICY_LABEL" \
     -collection-batch-size "$BATCH_SIZE" \
     -bench-pattern "$BENCH_REGEX" \
     -count "$COUNT" \
     -unavailable-reason "N/A before R0 harness bring-up"
 else
-  TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" GOWORK=off "${cmd[@]}" | tee "$RAW_JSON"
+  TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$DATA_OUTER" TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$INDEX_OUTER" GOWORK=off "${cmd[@]}" | tee "$RAW_JSON"
 
   GOWORK=off go run ./cmd/collection_bench_report \
     -in "$RAW_JSON" \
@@ -69,6 +74,7 @@ else
     -worktree "$WORKTREE" \
     -execution-path "$PATH_LABEL" \
     -benchmark-engine "$BENCH_ENGINE" \
+    -storage-policy "$STORAGE_POLICY_LABEL" \
     -collection-batch-size "$BATCH_SIZE" \
     -bench-pattern "$BENCH_REGEX" \
     -count "$COUNT"
@@ -83,6 +89,7 @@ cat >"$OUT_DIR/README.md" <<EOF
 - commit: \`$COMMIT\`
 - execution path: \`$PATH_LABEL\`
 - benchmark engine: \`$BENCH_ENGINE\`
+- storage policy: \`$STORAGE_POLICY_LABEL\`
 - collection batch size: \`$BATCH_SIZE\`
 - benchmark regex: \`$BENCH_REGEX\`
 - benchmark count: \`$COUNT\`
@@ -92,8 +99,11 @@ cat >"$OUT_DIR/README.md" <<EOF
 - markdown report: \`$OUT_DIR/collections_report.md\`
 - html report: \`$OUT_DIR/collections_report.html\`
 - json report: \`$OUT_DIR/collections_report.json\`
-- backend-direct fast override: \`TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_fast scripts/bench_collections_report.sh\`
-- backend-direct WAL-on-fast override: \`TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_wal_on_fast scripts/bench_collections_report.sh\`
+- production fast override: \`TREEDB_COLLECTION_BENCH_ENGINE=production_fast scripts/bench_collections_report.sh\`
+- production WAL-on-fast override: \`TREEDB_COLLECTION_BENCH_ENGINE=production_wal_on_fast scripts/bench_collections_report.sh\`
+- backend-direct fast/control override: \`TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_fast TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=false TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=false scripts/bench_collections_report.sh\`
+- data-root outer-leaf override: \`TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=true scripts/bench_collections_report.sh\`
+- index-root outer-leaf override: \`TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=false scripts/bench_collections_report.sh\`
 - batch-size override: \`TREEDB_COLLECTION_BENCH_BATCH_SIZE=8000 scripts/bench_collections_report.sh\`
 - oracle-path override: \`TREEDB_COLLECTION_PATH_LABEL=oracle scripts/bench_collections_report.sh\`
 EOF

--- a/scripts/bench_collections_report.sh
+++ b/scripts/bench_collections_report.sh
@@ -5,10 +5,10 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT"
 
 OUT_DIR="${OUT_DIR:-$(mktemp -d /tmp/gomap_collections_report_XXXXXX)}"
-BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertProvidedID|CollectionGetByID|CollectionDeleteByID|CollectionInsertWithSecondaryIndexes|CollectionDeleteWithSecondaryIndexes|SecondaryLookupUnique|SecondaryLookupNonUnique|SecondaryUpsertFieldChange|CollectionCreateIndexBackfillExistingDocs)}"
+BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertProvidedID|CollectionInsertBatchProvidedID|CollectionGetByID|CollectionDeleteByID|CollectionInsertWithSecondaryIndexes|CollectionInsertBatchWithSecondaryIndexes|CollectionInsertBatchCheckpointWithSecondaryIndexes|CollectionDeleteWithSecondaryIndexes|SecondaryLookupUnique|SecondaryLookupNonUnique|SecondaryUpsertFieldChange|CollectionCreateIndexBackfillExistingDocs)}"
 COUNT="${COUNT:-3}"
 BENCHTIME="${BENCHTIME:-}"
-BENCH_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-cached}"
+BENCH_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-backend_direct_fast}"
 PATH_LABEL="${TREEDB_COLLECTION_PATH_LABEL:-}"
 
 RAW_JSON="$OUT_DIR/collections_bench.json"
@@ -87,7 +87,8 @@ cat >"$OUT_DIR/README.md" <<EOF
 - markdown report: \`$OUT_DIR/collections_report.md\`
 - html report: \`$OUT_DIR/collections_report.html\`
 - json report: \`$OUT_DIR/collections_report.json\`
-- backend-direct override: \`TREEDB_COLLECTION_BENCH_ENGINE=backend_direct scripts/bench_collections_report.sh\`
+- backend-direct fast override: \`TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_fast scripts/bench_collections_report.sh\`
+- backend-direct WAL-on-fast override: \`TREEDB_COLLECTION_BENCH_ENGINE=backend_direct_wal_on_fast scripts/bench_collections_report.sh\`
 - oracle-path override: \`TREEDB_COLLECTION_PATH_LABEL=oracle scripts/bench_collections_report.sh\`
 EOF
 


### PR DESCRIPTION
Refs #768

## What changed
- Adds the native `TreeDB/collections` fast path over root-local ordered runs for primary roots, index-state roots, and secondary index roots.
- Adds grouped ordered-root publish APIs for atomic non-system root + system descriptor publication.
- Adds native batch planning with sorted/deduped document-ID and unique-index preflight probes.
- Adds native `CreateIndex` backfill and indexed delete coherence.
- Adds per-root collection storage policies:
  - document roots can prioritize compressed production storage (`data_outer=true`),
  - secondary index roots support fast (`index_outer=false`) and compressed (`index_outer=true`) modes.
- Adds shared no-index collection write domains so single-document no-index `Insert` buffers into the collection root domain instead of publishing the primary root and system-root descriptor per document.
- Adds explicit `Collection.Flush()` plus manager/backend close-hook flushing so buffered collection writes persist before backend/cached DB teardown.
- Keeps indexed single-document writes routed through the native batch planner for uniqueness/index correctness.
- Adds focused collection benchmarks, overhead breakdowns, report labeling, and docs/spec verification updates.

## Issue checklist coverage
- Covers R5 batch planner items 55-64.
- Covers R6/R7 single-document/default/cleanup items 65-82, with item 82 resolved by the cached collection root-domain write buffer.
- Items 30 and 38 remain separate raw-anchor/counter evidence follow-ups in the issue checklist; they are not hidden inside this PR.

## Final production-mainline evidence

Final post-lifecycle artifact:
- `/tmp/gomap_collections_r14_final_prod_fast_data_true_index_false`
- engine: `production_fast`
- storage policy: `data_outer=true,index_outer=false`
- count: `1`
- batch size: `8000`

| Benchmark | Result |
| --- | ---: |
| `BenchmarkCollectionInsertProvidedID` | `265.3 ns/op`, `3.77M ops/s`, `299 B/op`, `2 allocs/op` |
| `BenchmarkCollectionInsertBatchProvidedID` | `281.8 ns/doc`, `3.55M docs/s`, `239 B/op`, `1 alloc/op` |
| `BenchmarkCollectionGetByID` | `2377 ns/op`, `420,698 ops/s` |
| `BenchmarkCollectionGetByIDParallel` | `767.0 ns/op`, `1.30M ops/s` |
| `BenchmarkCollectionInsertBatchWithSecondaryIndexes` | `2796 ns/doc`, `357,654 docs/s` |
| `BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes` | `9553 ns/doc`, `104,679 docs/s` |

Additional production matrix artifacts captured before the close-hook lifecycle fix:
- `/tmp/gomap_collections_r14_prod_fast_data_true_index_false`
- `/tmp/gomap_collections_r14_prod_fast_data_true_index_true`
- `/tmp/gomap_collections_r14_prod_wal_data_true_index_false`
- `/tmp/gomap_collections_r14_prod_wal_data_true_index_true`

Key matrix results:
- `production_fast data_outer=true,index_outer=false`: single insert `299.25 ns/op`; no-index batch `290.9 ns/doc`; indexed batch `2889 ns/doc`.
- `production_fast data_outer=true,index_outer=true`: single insert `317.1 ns/op`; no-index batch `339.9 ns/doc`; indexed batch `4189 ns/doc`.
- `production_wal_on_fast data_outer=true,index_outer=false`: single insert `332.4 ns/op`; no-index batch `288.8 ns/doc`; indexed batch `2930 ns/doc`.
- `production_wal_on_fast data_outer=true,index_outer=true`: single insert `336.3 ns/op`; no-index batch `285.5 ns/doc`; indexed batch `3081 ns/doc`.

## Validation
- `git diff --check`
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionSingleInsertBufferedNoIndexCloseFlushes|TestCollectionSingleInsertBufferedNoIndexFlushPersistsAfterReopen' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionInsertProvidedID$|BenchmarkCollectionInsertBatchProvidedID$|BenchmarkCollectionGetByID$' -benchtime=2s -count=2`
  - single insert: `299.4 ns/op`, `295.4 ns/op`, `2 allocs/op`
  - no-index batch: `289.0 ns/doc`, `288.5 ns/doc`
  - get: `2496 ns/op`, `2488 ns/op`
- `GOWORK=off go test ./TreeDB/collections ./TreeDB/caching ./TreeDB/db ./TreeDB/tree ./TreeDB/page ./TreeDB/internal/valuelog ./TreeDB/internal/memtable ./cmd/collection_bench_report -count=1`

## Notes
- JSON/index extraction remains intentionally quarantined for a future value/type/index sprint.
- Indexed single-document buffering is deliberately not folded into the no-index write-domain path; doing that correctly requires transactional unique-index buffering.
