### PR TITLE
TreeDB: apply low-risk allocation fixes from PR 1046

### DIFF
--- a/TreeDB/caching/batch_rid_buffer_test.go
+++ b/TreeDB/caching/batch_rid_buffer_test.go
@@ -1,0 +1,81 @@
+package caching
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func testBatchRIDKey(i int) []byte {
+	var key [8]byte
+	binary.BigEndian.PutUint64(key[:], uint64(i+1))
+	return key[:]
+}
+
+func TestBatchWriteRegularRIDBufferOnlyForValueLogPointers(t *testing.T) {
+	tests := []struct {
+		name          string
+		ptrThreshold  int
+		wantRIDBuffer bool
+	}{
+		{
+			name:          "inline_wal_records",
+			ptrThreshold:  1 << 20,
+			wantRIDBuffer: false,
+		},
+		{
+			name:          "value_log_pointer_records",
+			ptrThreshold:  1,
+			wantRIDBuffer: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, err := Open(t.TempDir(), NewMockBackend(), Options{
+				AllowUnsafe:              true,
+				RelaxedSync:              true,
+				MemtableMode:             "btree",
+				MemtableShards:           1,
+				FlushThreshold:           1 << 30,
+				ValueLogPointerThreshold: tt.ptrThreshold,
+			})
+			if err != nil {
+				t.Fatalf("open: %v", err)
+			}
+			defer db.Close()
+
+			b := db.NewBatch()
+			value := bytes.Repeat([]byte{0x42}, 128)
+			for i := 0; i < 4; i++ {
+				if err := b.Set(testBatchRIDKey(i), value); err != nil {
+					t.Fatalf("set %d: %v", i, err)
+				}
+			}
+			if err := b.Write(); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			if got := cap(b.ridBuf) > 0; got != tt.wantRIDBuffer {
+				t.Fatalf("rid buffer allocated=%t want %t", got, tt.wantRIDBuffer)
+			}
+			if tt.wantRIDBuffer {
+				firstCap := cap(b.ridBuf)
+				for i := 0; i < 4; i++ {
+					if err := b.Set(testBatchRIDKey(16+i), value); err != nil {
+						t.Fatalf("second set %d: %v", i, err)
+					}
+				}
+				if err := b.Write(); err != nil {
+					t.Fatalf("second write: %v", err)
+				}
+				if got := cap(b.ridBuf); got != firstCap {
+					t.Fatalf("rid buffer cap after reuse=%d want %d", got, firstCap)
+				}
+			}
+			if err := b.Close(); err != nil {
+				t.Fatalf("close batch: %v", err)
+			}
+		})
+	}
+}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -19296,11 +19296,12 @@ func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error 
 	if fn == nil {
 		return backenddb.ErrNilUpdateFunc
 	}
+	stableKey := cloneUpdateKey(key)
 	db.waitForCheckpoint()
 
 	for {
-		unlock := db.lockUpdateKey(key)
-		old, err := db.getForUpdate(key)
+		unlock := db.lockUpdateKey(stableKey)
+		old, err := db.getForUpdate(stableKey)
 		unlock()
 		if err != nil {
 			return err
@@ -19318,8 +19319,8 @@ func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error 
 			return fmt.Errorf("treedb: unknown update op %d", result.Op)
 		}
 
-		unlock = db.lockUpdateKey(key)
-		latest, err := db.getForUpdate(key)
+		unlock = db.lockUpdateKey(stableKey)
+		latest, err := db.getForUpdate(stableKey)
 		if err != nil {
 			unlock()
 			return err
@@ -19334,11 +19335,11 @@ func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error 
 			unlock()
 			return nil
 		case backenddb.UpdateSet:
-			err = db.set(key, result.Value, syncWrite)
+			err = db.set(stableKey, result.Value, syncWrite)
 			unlock()
 			return err
 		case backenddb.UpdateDelete:
-			err = db.delete(key, syncWrite)
+			err = db.delete(stableKey, syncWrite)
 			unlock()
 			return err
 		default:
@@ -19346,6 +19347,10 @@ func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error 
 			return fmt.Errorf("treedb: unknown update op %d", result.Op)
 		}
 	}
+}
+
+func cloneUpdateKey(key []byte) []byte {
+	return append([]byte{}, key...)
 }
 
 func (db *DB) getForUpdate(key []byte) ([]byte, error) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -25871,6 +25871,7 @@ type Batch struct {
 	ptrCopyBytes       int
 	arenaInFlightBytes int64
 	ptrValueIdxs       []int
+	ridBuf             []uint64
 	walBuf             []logRecord
 	shardIdxs          []int
 	eligibleIdxs       []int
@@ -26331,6 +26332,9 @@ func (b *Batch) Reset() {
 		b.copyArenaCap = b.db.batchCopyArenaInitCap(0)
 	}
 	b.size = 0
+	if b.ridBuf != nil {
+		b.ridBuf = b.ridBuf[:0]
+	}
 	b.walBuf = b.walBuf[:0]
 	b.streamEligible = true
 	b.streamTried = false
@@ -27391,8 +27395,14 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		if durability == journalDurabilitySync {
 			defer b.db.releaseLaneSync(lane)
 		}
-		if !b.db.disableJournal {
-			rids = make([]uint64, len(b.entries))
+		if !b.db.disableJournal && allowPointers {
+			if cap(b.ridBuf) < len(b.entries) {
+				b.ridBuf = make([]uint64, len(b.entries))
+			} else {
+				b.ridBuf = b.ridBuf[:len(b.entries)]
+				clear(b.ridBuf)
+			}
+			rids = b.ridBuf
 		}
 	}
 
@@ -28353,6 +28363,7 @@ func (b *Batch) Close() error {
 	b.recycleCopyArenaChunks()
 	b.recyclePtrCopyArenaChunks()
 	b.entries = nil
+	b.ridBuf = nil
 	b.walBuf = nil
 	b.shardIdxs = nil
 	b.eligibleIdxs = nil

--- a/TreeDB/db/update.go
+++ b/TreeDB/db/update.go
@@ -13,7 +13,7 @@ import (
 var ErrNilUpdateFunc = errors.New("treedb: nil update function")
 
 // ErrUpdateValueNil indicates an Update callback requested Set with a nil value.
-var ErrUpdateValueNil = errors.New("value cannot be nil")
+var ErrUpdateValueNil = errors.New("treedb: value cannot be nil")
 
 // UpdateOp describes the write produced by an Update callback.
 type UpdateOp uint8
@@ -78,10 +78,11 @@ func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
 	if db.readOnly {
 		return ErrReadOnly
 	}
+	stableKey := cloneUpdateKey(key)
 
 	for {
-		unlock := db.lockUpdateKey(key)
-		old, err := db.getForUpdate(key)
+		unlock := db.lockUpdateKey(stableKey)
+		old, err := db.getForUpdate(stableKey)
 		unlock()
 		if err != nil {
 			return err
@@ -99,8 +100,8 @@ func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
 			return fmt.Errorf("treedb: unknown update op %d", result.Op)
 		}
 
-		unlock = db.lockUpdateKey(key)
-		latest, err := db.getForUpdate(key)
+		unlock = db.lockUpdateKey(stableKey)
+		latest, err := db.getForUpdate(stableKey)
 		if err != nil {
 			unlock()
 			return err
@@ -115,11 +116,11 @@ func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
 			unlock()
 			return nil
 		case UpdateSet:
-			err = db.setPoint(key, result.Value, syncWrite)
+			err = db.setPoint(stableKey, result.Value, syncWrite)
 			unlock()
 			return err
 		case UpdateDelete:
-			err = db.deletePoint(key, syncWrite)
+			err = db.deletePoint(stableKey, syncWrite)
 			unlock()
 			return err
 		default:
@@ -127,6 +128,10 @@ func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
 			return fmt.Errorf("treedb: unknown update op %d", result.Op)
 		}
 	}
+}
+
+func cloneUpdateKey(key []byte) []byte {
+	return append([]byte{}, key...)
 }
 
 func (db *DB) lockUpdateKey(key []byte) func() {

--- a/TreeDB/db/update_test.go
+++ b/TreeDB/db/update_test.go
@@ -103,6 +103,52 @@ func TestUpdatePreservesEmptyValuePresence(t *testing.T) {
 	}
 }
 
+func TestUpdateUsesStableKeyAcrossCallback(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	key := []byte("alpha")
+	if err := d.Set(key, []byte("seed")); err != nil {
+		t.Fatalf("Set alpha: %v", err)
+	}
+	if err := d.Set([]byte("omega"), []byte("other")); err != nil {
+		t.Fatalf("Set omega: %v", err)
+	}
+
+	calls := 0
+	if err := d.Update(key, func(old []byte) (UpdateResult, error) {
+		calls++
+		if calls != 1 {
+			return UpdateResult{}, fmt.Errorf("callback retried against mutated key with old=%q", old)
+		}
+		if !bytes.Equal(old, []byte("seed")) {
+			return UpdateResult{}, fmt.Errorf("old=%q want seed", old)
+		}
+		copy(key, []byte("omega"))
+		return SetUpdate([]byte("updated")), nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	got, err := d.Get([]byte("alpha"))
+	if err != nil {
+		t.Fatalf("Get alpha: %v", err)
+	}
+	if !bytes.Equal(got, []byte("updated")) {
+		t.Fatalf("alpha got=%q want updated", got)
+	}
+	got, err = d.Get([]byte("omega"))
+	if err != nil {
+		t.Fatalf("Get omega: %v", err)
+	}
+	if !bytes.Equal(got, []byte("other")) {
+		t.Fatalf("omega got=%q want other", got)
+	}
+}
+
 func TestUpdateCallbackCanReenterSameKeyWithoutDeadlock(t *testing.T) {
 	d, err := Open(Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -70,21 +70,25 @@ func decodeCompactLeafLogPayloadTo(payload, dst []byte) ([]byte, bool, bool, err
 		}
 		return payload, false, false, nil
 	}
-	if cap(dst) >= page.PageSize && sliceAliasesBytes(dst[:cap(dst)], payload) {
-		payload = append([]byte(nil), payload...)
-	}
 	out := dst
 	usedDst := false
 	if cap(out) >= page.PageSize {
 		out = out[:page.PageSize]
-		clear(out)
 		usedDst = true
 	} else {
 		out = make([]byte, page.PageSize)
 	}
-	copy(out[:prefixLen], payload[compactLeafPagePayloadHeaderSize:compactLeafPagePayloadHeaderSize+prefixLen])
-	copy(out[page.PageSize-suffixLen:], payload[compactLeafPagePayloadHeaderSize+prefixLen:])
+	decodeCompactLeafLogPayloadInto(out, payload, prefixLen, suffixLen)
 	return out, usedDst, true, nil
+}
+
+func decodeCompactLeafLogPayloadInto(out, payload []byte, prefixLen, suffixLen int) {
+	src := payload[compactLeafPagePayloadHeaderSize:]
+	copy(out[:prefixLen], src[:prefixLen])
+	if suffixLen > 0 {
+		copy(out[page.PageSize-suffixLen:], src[prefixLen:prefixLen+suffixLen])
+	}
+	clear(out[prefixLen : page.PageSize-suffixLen])
 }
 
 func appendCompactLeafLogPayload(dst, payload []byte) ([]byte, error) {

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -120,7 +120,11 @@ func allowsCompactLeafLogPayload(fileID uint32, path string) bool {
 }
 
 func maybeDecodeLeafLogPayloadTo(fileID uint32, path string, payload, dst []byte) ([]byte, bool, bool, error) {
-	if !allowsCompactLeafLogPayload(fileID, path) {
+	return maybeDecodeLeafLogPayloadAllowed(allowsCompactLeafLogPayload(fileID, path), payload, dst)
+}
+
+func maybeDecodeLeafLogPayloadAllowed(allowCompact bool, payload, dst []byte) ([]byte, bool, bool, error) {
+	if !allowCompact {
 		return payload, false, false, nil
 	}
 	out, usedDst, decoded, err := decodeCompactLeafLogPayloadTo(payload, dst)
@@ -134,7 +138,11 @@ func maybeDecodeLeafLogPayloadTo(fileID uint32, path string, payload, dst []byte
 }
 
 func appendMaybeDecodeLeafLogPayload(fileID uint32, path string, dst, payload []byte) ([]byte, error) {
-	if !allowsCompactLeafLogPayload(fileID, path) {
+	return appendMaybeDecodeLeafLogPayloadAllowed(allowsCompactLeafLogPayload(fileID, path), dst, payload)
+}
+
+func appendMaybeDecodeLeafLogPayloadAllowed(allowCompact bool, dst, payload []byte) ([]byte, error) {
+	if !allowCompact {
 		if len(payload) == 0 {
 			return dst, nil
 		}

--- a/TreeDB/internal/valuelog/leaf_page_payload_bench_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_bench_test.go
@@ -111,4 +111,20 @@ func BenchmarkDecodeCompactLeafLogPayloadTo(b *testing.B) {
 			leafPagePayloadBenchSink = out
 		}
 	})
+
+	b.Run("aliased_dst", func(b *testing.B) {
+		dst := make([]byte, page.PageSize)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			copy(dst, payload)
+			out, _, decoded, err := decodeCompactLeafLogPayloadTo(dst[:len(payload)], dst[:0])
+			if err != nil {
+				b.Fatalf("decodeCompactLeafLogPayloadTo: %v", err)
+			}
+			if !decoded {
+				b.Fatal("expected compact payload to decode")
+			}
+			leafPagePayloadBenchSink = out
+		}
+	})
 }

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -142,6 +142,39 @@ func TestDecodeCompactLeafLogPayloadTo_AliasedDstRoundTrips(t *testing.T) {
 	requireLeafPagesLogicallyEqual(t, leaf, decoded)
 }
 
+func TestDecodeCompactLeafLogPayloadTo_AliasedDstDoesNotAllocate(t *testing.T) {
+	leaf := buildSparseLeafPageForPayloadTest(t)
+
+	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+	}
+	if !compacted {
+		t.Fatalf("expected sparse leaf page to compact")
+	}
+
+	buf := make([]byte, page.PageSize)
+	var decoded []byte
+	allocs := testing.AllocsPerRun(100, func() {
+		copy(buf, payload)
+		out, usedDst, decodedFlag, err := decodeCompactLeafLogPayloadTo(buf[:len(payload)], buf[:0])
+		if err != nil {
+			t.Fatalf("decodeCompactLeafLogPayloadTo: %v", err)
+		}
+		if !decodedFlag {
+			t.Fatalf("expected compact payload to decode")
+		}
+		if !usedDst {
+			t.Fatalf("expected decode to reuse aliased dst")
+		}
+		decoded = out
+	})
+	if allocs != 0 {
+		t.Fatalf("aliased decode allocations=%v want 0", allocs)
+	}
+	requireLeafPagesLogicallyEqual(t, leaf, decoded)
+}
+
 func TestMaybeCompactLeafLogPayload_PassthroughNonPagePayload(t *testing.T) {
 	raw := []byte("not-a-leaf-page")
 	payload, compacted, err := MaybeCompactLeafLogPayload(raw)

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -59,6 +59,10 @@ type File struct {
 	templateLookup     TemplateLookup
 	templateDecodeOpts templ.DecodeOptions
 	templateDefCache   *templateDefCache
+	// compactLeafPayload is immutable after open and keeps hot read paths from
+	// re-parsing the segment path to classify leaf-log files.
+	compactLeafPayloadKnown bool
+	compactLeafPayload      bool
 
 	cacheMu    sync.Mutex
 	cacheStart atomic.Int64
@@ -117,6 +121,9 @@ func (f *File) allowsCompactLeafPayload() bool {
 	if f == nil {
 		return false
 	}
+	if f.compactLeafPayloadKnown {
+		return f.compactLeafPayload
+	}
 	return allowsCompactLeafLogPayload(f.ID, f.Path)
 }
 
@@ -133,6 +140,8 @@ func openFile(path string, id uint32, dictLookup DictLookup, templateLookup Temp
 		templateLookup:           templateLookup,
 		templateDecodeOpts:       templateOpts,
 		templateDefCache:         templateCache,
+		compactLeafPayloadKnown:  true,
+		compactLeafPayload:       allowsCompactLeafLogPayload(id, path),
 		groupedFrameCacheEntries: defaultGroupedFrameCacheEntries,
 		groupedFrameCacheMaxRaw:  defaultGroupedFrameCacheMaxRawBytes,
 	}
@@ -470,7 +479,7 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+		val, _, _, err = maybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), val, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -486,7 +495,7 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+			val, _, _, err = maybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -509,7 +518,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+		val, _, _, err = maybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), val, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -522,7 +531,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 				if err != nil {
 					return nil, err
 				}
-				val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+				val, _, _, err = maybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), val, nil)
 				if err != nil {
 					return nil, err
 				}
@@ -542,7 +551,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+			val, _, _, err = maybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -570,7 +579,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 		if err != nil {
 			return nil, false, err
 		}
-		val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+		val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), val, dst)
 		if err != nil {
 			return nil, false, err
 		}
@@ -586,7 +595,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 				if err != nil {
 					return nil, false, err
 				}
-				val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+				val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), val, dst)
 				if err != nil {
 					return nil, false, err
 				}
@@ -602,7 +611,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 				if err != nil {
 					return nil, false, err
 				}
-				val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+				val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), val, dst)
 				if err != nil {
 					return nil, false, err
 				}
@@ -624,7 +633,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 			if err != nil {
 				return nil, false, err
 			}
-			val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+			val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), val, dst)
 			if err != nil {
 				return nil, false, err
 			}
@@ -642,7 +651,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 			if err != nil {
 				return nil, false, err
 			}
-			val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+			val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), val, dst)
 			if err != nil {
 				return nil, false, err
 			}
@@ -996,14 +1005,14 @@ func (f *File) appendPayloadFromFile(dst []byte, off int64, payloadLen int) ([]b
 		return nil, err
 	}
 	if f.templateLookup == nil || !templ.IsEncodedPayload(payload) {
-		return appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], payload)
+		return appendMaybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), dst[:oldLen], payload)
 	}
 	encoded := append([]byte(nil), payload...)
 	decoded, err := appendDecodedTemplatePayload(dst[:oldLen], encoded, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
 	if err != nil {
 		return nil, err
 	}
-	return appendMaybeDecodeLeafLogPayload(f.ID, f.Path, decoded[:oldLen], decoded[oldLen:])
+	return appendMaybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), decoded[:oldLen], decoded[oldLen:])
 }
 
 // Set is an immutable snapshot of value-log files for snapshot isolation.

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -92,6 +92,43 @@ func withMaxDeadMappings(t *testing.T, max int) {
 	})
 }
 
+func TestOpenFileCachesCompactLeafPayloadClassification(t *testing.T) {
+	root := t.TempDir()
+	leafDir := filepath.Join(root, compactLeafPagePayloadDirName)
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll leaf: %v", err)
+	}
+	leafPath := filepath.Join(leafDir, "value-l255-000001.log")
+	if err := os.WriteFile(leafPath, nil, 0o644); err != nil {
+		t.Fatalf("WriteFile leaf: %v", err)
+	}
+	leafFile, err := openFile(leafPath, mustEncodeFileID(t, ReservedLeafLogLaneID, 1), nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile leaf: %v", err)
+	}
+	defer func() { _ = leafFile.Close() }()
+	if !leafFile.compactLeafPayloadKnown || !leafFile.compactLeafPayload || !leafFile.allowsCompactLeafPayload() {
+		t.Fatalf("expected leaf-log file to cache compact payload allowance")
+	}
+
+	valueDir := filepath.Join(root, "value_vlog")
+	if err := os.MkdirAll(valueDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll value: %v", err)
+	}
+	valuePath := filepath.Join(valueDir, "value-l0-000001.log")
+	if err := os.WriteFile(valuePath, nil, 0o644); err != nil {
+		t.Fatalf("WriteFile value: %v", err)
+	}
+	valueFile, err := openFile(valuePath, mustEncodeFileID(t, 0, 1), nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile value: %v", err)
+	}
+	defer func() { _ = valueFile.Close() }()
+	if !valueFile.compactLeafPayloadKnown || valueFile.compactLeafPayload || valueFile.allowsCompactLeafPayload() {
+		t.Fatalf("expected value-log file to cache compact payload disallowance")
+	}
+}
+
 func TestManagerMmapReadStatsAggregatesCounters(t *testing.T) {
 	mgr := &Manager{
 		files: map[uint32]*File{

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1018,7 +1018,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		if err != nil {
 			return nil, err, true
 		}
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
+		dst, err = appendMaybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1074,7 +1074,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 				if err != nil {
 					return nil, err, true
 				}
-				dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
+				dst, err = appendMaybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), dst[:oldLen], dst[oldLen:])
 				if err != nil {
 					return nil, err, true
 				}
@@ -1124,7 +1124,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		if err != nil {
 			return nil, err, true
 		}
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
+		dst, err = appendMaybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1151,7 +1151,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		if err != nil {
 			return nil, err, true
 		}
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
+		dst, err = appendMaybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1214,7 +1214,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		f.setCacheRawLocked(nil, false)
 		f.cacheStart.Store(start)
 		f.cacheMu.Unlock()
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:oldLen+int(rawLen)])
+		dst, err = appendMaybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), dst[:oldLen], dst[oldLen:oldLen+int(rawLen)])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1279,7 +1279,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	if len(dst) < oldLen {
 		return nil, ErrCorrupt, true
 	}
-	dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
+	dst, err = appendMaybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), dst[:oldLen], dst[oldLen:])
 	if err != nil {
 		return nil, err, true
 	}

--- a/TreeDB/update_test.go
+++ b/TreeDB/update_test.go
@@ -183,6 +183,53 @@ func TestUpdatePreservesEmptyValuePresence(t *testing.T) {
 	}
 }
 
+func TestUpdateUsesStableKeyAcrossCallback(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileFast, t.TempDir())
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	key := []byte("alpha")
+	if err := db.Set(key, []byte("seed")); err != nil {
+		t.Fatalf("Set alpha: %v", err)
+	}
+	if err := db.Set([]byte("omega"), []byte("other")); err != nil {
+		t.Fatalf("Set omega: %v", err)
+	}
+
+	calls := 0
+	if err := db.Update(key, func(old []byte) (treedb.UpdateResult, error) {
+		calls++
+		if calls != 1 {
+			return treedb.UpdateResult{}, fmt.Errorf("callback retried against mutated key with old=%q", old)
+		}
+		if !bytes.Equal(old, []byte("seed")) {
+			return treedb.UpdateResult{}, fmt.Errorf("old=%q want seed", old)
+		}
+		copy(key, []byte("omega"))
+		return treedb.SetUpdate([]byte("updated")), nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	got, err := db.Get([]byte("alpha"))
+	if err != nil {
+		t.Fatalf("Get alpha: %v", err)
+	}
+	if !bytes.Equal(got, []byte("updated")) {
+		t.Fatalf("alpha got=%q want updated", got)
+	}
+	got, err = db.Get([]byte("omega"))
+	if err != nil {
+		t.Fatalf("Get omega: %v", err)
+	}
+	if !bytes.Equal(got, []byte("other")) {
+		t.Fatalf("omega got=%q want other", got)
+	}
+}
+
 func TestUpdateCallbackCanReenterSameKeyWithoutDeadlock(t *testing.T) {
 	opts := treedb.OptionsFor(treedb.ProfileFast, t.TempDir())
 	db, err := treedb.Open(opts)


### PR DESCRIPTION
## Summary

This is the low-risk base slice reconstructed from the PR #1046 optimization chain. It intentionally keeps only changes that are small, correctness-preserving, and independently testable:

- decode compact leaf payloads into aliased destination storage
- cache leaf-log payload classification
- avoid allocating unused WAL RID batch buffers
- stabilize update callback key lifetimes

This PR intentionally excludes the sealed-leaf mmap cap, broad BTree arena work, and compact-entry layout work. Those are left out of the merge candidate stack unless validated separately.

## Validation

- `go test -count=1 ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/caching`
- Stack-head validation continues in the follow-up PR based on this branch.
