### PR TITLE
TreeDB: reuse repeated inline values in BTree memtables

### DIFF
--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -15,7 +15,7 @@ import (
 const btreeDefaultDegree = 32
 const btreeUseLoadFastPath = false
 const btreeArenaChunkSize = 1 << 20
-const btreeInlineValueDedupeMax = 1 << 20
+const btreeInlineValueDedupeMax = btreeArenaChunkSize
 
 type btreeEntry struct {
 	value []byte // inline bytes (if pointer, may store inline tail bytes)
@@ -86,7 +86,7 @@ func (m *BTree) ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKey fun
 	m.applyStealSortedBatch(entries, nil, onKey)
 }
 
-func (m *BTree) ApplyStealSortedBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, onKey func(key []byte)) {
+func (m *BTree) applyStealSortedBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, onKey func(key []byte)) {
 	m.applyStealSortedBatch(entries, idxs, onKey)
 }
 

--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -1,6 +1,7 @@
 package memtable
 
 import (
+	"bytes"
 	"strings"
 	"sync"
 
@@ -14,6 +15,7 @@ import (
 const btreeDefaultDegree = 32
 const btreeUseLoadFastPath = false
 const btreeArenaChunkSize = 1 << 20
+const btreeInlineValueDedupeMax = 1 << 20
 
 type btreeEntry struct {
 	value []byte // inline bytes (if pointer, may store inline tail bytes)
@@ -60,13 +62,14 @@ func normalizeBTreeEntryFlags(flags byte) byte {
 }
 
 type BTree struct {
-	mu        sync.RWMutex
-	tree      *btree.Map[string, btreeEntry]
-	sizeBytes int64
-	arena     *btreeArena
-	lastKey   string
-	hasLast   bool
-	degree    int
+	mu         sync.RWMutex
+	tree       *btree.Map[string, btreeEntry]
+	sizeBytes  int64
+	arena      *btreeArena
+	lastKey    string
+	hasLast    bool
+	degree     int
+	lastInline []byte
 }
 
 func (*BTree) StableUnsafeIteratorSlices() bool { return true }
@@ -76,65 +79,42 @@ func NewBTree() *BTree {
 }
 
 func (m *BTree) ApplyStealSortedBatch(entries []batchpkg.Entry, onKey func(key []byte)) {
+	m.applyStealSortedBatch(entries, nil, onKey)
+}
+
+func (m *BTree) ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKey func(key []byte)) {
+	m.applyStealSortedBatch(entries, nil, onKey)
+}
+
+func (m *BTree) ApplyStealSortedBatchIndicesTrusted(entries []batchpkg.Entry, idxs []int, onKey func(key []byte)) {
+	m.applyStealSortedBatch(entries, idxs, onKey)
+}
+
+func (m *BTree) applyStealSortedBatch(entries []batchpkg.Entry, idxs []int, onKey func(key []byte)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for _, op := range entries {
+	apply := func(op batchpkg.Entry) {
+		if op.Key == nil {
+			return
+		}
 		keyStr := bytesToStringNoCopy(op.Key)
-		var prev btreeEntry
-		var replaced bool
-
-		if op.Type == batchpkg.OpDelete {
-			entry := btreeEntry{flags: node.FlagTombstone}
-			if m.hasLast && keyStr > m.lastKey {
-				prev, replaced = m.tree.Load(keyStr, entry)
-			} else {
-				prev, replaced = m.tree.Set(keyStr, entry)
-			}
-			if replaced {
-				if prev.flags&node.FlagTombstone == 0 {
-					m.sizeBytes -= int64(btreeEntryPayloadSize(prev.flags, prev.value))
-				}
-			} else {
-				m.sizeBytes += int64(len(op.Key))
-			}
-		} else if op.IsPtr {
-			entry := btreeEntry{value: canonicalizeBTreePointerValue(node.FlagPointer, op.Value), ptr: op.ValuePtr, flags: node.FlagPointer}
-			if m.hasLast && keyStr > m.lastKey {
-				prev, replaced = m.tree.Load(keyStr, entry)
-			} else {
-				prev, replaced = m.tree.Set(keyStr, entry)
-			}
-			newSize := btreeEntryPayloadSize(entry.flags, entry.value)
-			if replaced {
-				oldSize := btreeEntryPayloadSize(prev.flags, prev.value)
-				m.sizeBytes += int64(newSize - oldSize)
-			} else {
-				m.sizeBytes += int64(len(op.Key) + newSize)
-			}
-		} else {
-			entry := btreeEntry{value: canonicalizeBTreeInlineValue(op.Value), flags: node.FlagInline}
-			if m.hasLast && keyStr > m.lastKey {
-				prev, replaced = m.tree.Load(keyStr, entry)
-			} else {
-				prev, replaced = m.tree.Set(keyStr, entry)
-			}
-			newSize := btreeEntryPayloadSize(entry.flags, entry.value)
-			if replaced {
-				oldSize := btreeEntryPayloadSize(prev.flags, prev.value)
-				m.sizeBytes += int64(newSize - oldSize)
-			} else {
-				m.sizeBytes += int64(len(op.Key) + newSize)
-			}
-		}
-
-		if !m.hasLast || keyStr > m.lastKey {
-			m.lastKey = keyStr
-			m.hasLast = true
-		}
+		entry := btreeEntryFromBatchOp(op)
+		prev, replaced := m.setMaybeSortedLoadLocked(keyStr, entry)
+		m.recordSetLocked(keyStr, len(op.Key), entry, prev, replaced)
 		if onKey != nil {
 			onKey(op.Key)
 		}
+	}
+
+	if idxs == nil {
+		for _, op := range entries {
+			apply(op)
+		}
+		return
+	}
+	for _, idx := range idxs {
+		apply(entries[idx])
 	}
 }
 
@@ -160,6 +140,7 @@ func (m *BTree) Reset() {
 	m.sizeBytes = 0
 	m.lastKey = ""
 	m.hasLast = false
+	m.lastInline = nil
 	if m.arena != nil {
 		m.arena.resetKeepFirstChunk()
 	}
@@ -185,24 +166,11 @@ func (m *BTree) PutWithCallback(key, value []byte, cb func(k, v []byte) error) e
 	defer m.mu.Unlock()
 
 	keyStored := m.arena.Copy(key)
-	valStored := []byte(nil)
-	if len(value) > 0 {
-		valStored = m.arena.Copy(value)
-	}
+	valStored := m.copyInlineValueLocked(canonicalizeBTreeInlineValue(value))
 	keyStr := bytesToStringNoCopy(keyStored)
 	entry := btreeEntry{value: valStored, flags: node.FlagInline}
 	prev, replaced := m.setMaybeLoadLocked(keyStr, entry)
-	newSize := btreeEntryPayloadSize(entry.flags, entry.value)
-	if replaced {
-		oldSize := btreeEntryPayloadSize(prev.flags, prev.value)
-		m.sizeBytes += int64(newSize - oldSize)
-		return nil
-	}
-	m.sizeBytes += int64(len(keyStored) + newSize)
-	if !m.hasLast || keyStr > m.lastKey {
-		m.lastKey = keyStr
-		m.hasLast = true
-	}
+	m.recordSetLocked(keyStr, len(keyStored), entry, prev, replaced)
 	return nil
 }
 
@@ -232,22 +200,10 @@ func (m *BTree) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
 		}
 	default:
 		value = canonicalizeBTreeInlineValue(value)
-		if len(value) > 0 {
-			entry.value = m.arena.Copy(value)
-		}
+		entry.value = m.copyInlineValueLocked(value)
 	}
 	prev, replaced := m.setMaybeLoadLocked(keyStr, entry)
-	newSize := btreeEntryPayloadSize(entry.flags, entry.value)
-	if replaced {
-		oldSize := btreeEntryPayloadSize(prev.flags, prev.value)
-		m.sizeBytes += int64(newSize - oldSize)
-		return
-	}
-	m.sizeBytes += int64(len(keyCopy) + newSize)
-	if !m.hasLast || keyStr > m.lastKey {
-		m.lastKey = keyStr
-		m.hasLast = true
-	}
+	m.recordSetLocked(keyStr, len(keyCopy), entry, prev, replaced)
 }
 
 func (m *BTree) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) {
@@ -271,17 +227,7 @@ func (m *BTree) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) 
 		entry.value = canonicalizeBTreeInlineValue(value)
 	}
 	prev, replaced := m.setMaybeLoadLocked(keyStr, entry)
-	newSize := btreeEntryPayloadSize(entry.flags, entry.value)
-	if replaced {
-		oldSize := btreeEntryPayloadSize(prev.flags, prev.value)
-		m.sizeBytes += int64(newSize - oldSize)
-		return
-	}
-	m.sizeBytes += int64(len(key) + newSize)
-	if !m.hasLast || keyStr > m.lastKey {
-		m.lastKey = keyStr
-		m.hasLast = true
-	}
+	m.recordSetLocked(keyStr, len(key), entry, prev, replaced)
 }
 
 func (m *BTree) Delete(key []byte) {
@@ -305,14 +251,8 @@ func (m *BTree) DeleteWithCallback(key []byte, cb func(k, v []byte) error) error
 	keyStored := m.arena.Copy(key)
 	keyStr := bytesToStringNoCopy(keyStored)
 	entry := btreeEntry{flags: node.FlagTombstone}
-	prev, replaced := m.tree.Set(keyStr, entry)
-	if replaced {
-		if prev.flags&node.FlagTombstone == 0 {
-			m.sizeBytes -= int64(btreeEntryPayloadSize(prev.flags, prev.value))
-		}
-		return nil
-	}
-	m.sizeBytes += int64(len(keyStored))
+	prev, replaced := m.setMaybeLoadLocked(keyStr, entry)
+	m.recordSetLocked(keyStr, len(keyStored), entry, prev, replaced)
 	return nil
 }
 
@@ -741,6 +681,61 @@ func (m *BTree) setMaybeLoadLocked(key string, entry btreeEntry) (btreeEntry, bo
 		return m.tree.Load(key, entry)
 	}
 	return m.tree.Set(key, entry)
+}
+
+func (m *BTree) setMaybeSortedLoadLocked(key string, entry btreeEntry) (btreeEntry, bool) {
+	if m.hasLast && key > m.lastKey {
+		return m.tree.Load(key, entry)
+	}
+	return m.tree.Set(key, entry)
+}
+
+func (m *BTree) copyInlineValueLocked(value []byte) []byte {
+	if len(value) == 0 {
+		return nil
+	}
+	if len(value) <= btreeInlineValueDedupeMax && bytes.Equal(value, m.lastInline) {
+		return m.lastInline
+	}
+	stored := m.arena.Copy(value)
+	if len(stored) <= btreeInlineValueDedupeMax {
+		m.lastInline = stored
+	} else {
+		m.lastInline = nil
+	}
+	return stored
+}
+
+func btreeEntryFromBatchOp(op batchpkg.Entry) btreeEntry {
+	switch {
+	case op.Type == batchpkg.OpDelete:
+		return btreeEntry{flags: node.FlagTombstone}
+	case op.IsPtr:
+		return btreeEntry{
+			value: canonicalizeBTreePointerValue(node.FlagPointer, op.Value),
+			ptr:   op.ValuePtr,
+			flags: node.FlagPointer,
+		}
+	default:
+		return btreeEntry{
+			value: canonicalizeBTreeInlineValue(op.Value),
+			flags: node.FlagInline,
+		}
+	}
+}
+
+func (m *BTree) recordSetLocked(key string, keyLen int, entry, prev btreeEntry, replaced bool) {
+	newSize := btreeEntryPayloadSize(entry.flags, entry.value)
+	if replaced {
+		oldSize := btreeEntryPayloadSize(prev.flags, prev.value)
+		m.sizeBytes += int64(newSize - oldSize)
+	} else {
+		m.sizeBytes += int64(keyLen + newSize)
+	}
+	if !m.hasLast || key > m.lastKey {
+		m.lastKey = key
+		m.hasLast = true
+	}
 }
 
 type btreeArena struct {

--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -114,6 +114,9 @@ func (m *BTree) applyStealSortedBatch(entries []batchpkg.Entry, idxs []int, onKe
 		return
 	}
 	for _, idx := range idxs {
+		if idx < 0 || idx >= len(entries) {
+			panic("memtable: trusted sorted batch index out of range")
+		}
 		apply(entries[idx])
 	}
 }

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -295,6 +295,20 @@ func TestBTreeApplyStealSortedBatchIndicesTrusted(t *testing.T) {
 	}
 }
 
+func TestBTreeApplyStealSortedBatchIndicesTrustedPanicsOnBadIndex(t *testing.T) {
+	m := NewBTree()
+	entries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: []byte("a"), Value: []byte("va")},
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for out-of-range trusted batch index")
+		}
+	}()
+	m.applyStealSortedBatchIndicesTrusted(entries, []int{1}, nil)
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -271,7 +271,7 @@ func TestBTreeApplyStealSortedBatchIndicesTrusted(t *testing.T) {
 	}
 
 	var seen []string
-	m.ApplyStealSortedBatchIndicesTrusted(entries, []int{1, 2, 3}, func(key []byte) {
+	m.applyStealSortedBatchIndicesTrusted(entries, []int{1, 2, 3}, func(key []byte) {
 		seen = append(seen, string(key))
 	})
 

--- a/TreeDB/internal/memtable/btree_test.go
+++ b/TreeDB/internal/memtable/btree_test.go
@@ -180,6 +180,27 @@ func TestBTreeInlineEmptySliceCanonicalizesToNil(t *testing.T) {
 	})
 }
 
+func TestBTreeSetEntryDedupesRepeatedCopiedInlineValues(t *testing.T) {
+	m := NewBTree()
+	value := []byte("same-value")
+
+	m.SetEntry([]byte("a"), value, page.ValuePtr{}, node.FlagInline)
+	value[0] = 'X'
+	m.SetEntry([]byte("b"), []byte("same-value"), page.ValuePtr{}, node.FlagInline)
+
+	gotA, _, _, ok := m.GetEntry([]byte("a"))
+	if !ok || string(gotA) != "same-value" {
+		t.Fatalf("GetEntry(a)=(%q,%v), want same-value,true", string(gotA), ok)
+	}
+	gotB, _, _, ok := m.GetEntry([]byte("b"))
+	if !ok || string(gotB) != "same-value" {
+		t.Fatalf("GetEntry(b)=(%q,%v), want same-value,true", string(gotB), ok)
+	}
+	if len(gotA) == 0 || len(gotB) == 0 || &gotA[0] != &gotB[0] {
+		t.Fatal("repeated copied inline values did not share BTree-owned storage")
+	}
+}
+
 func TestBTreeIteratorUnsafeEntry_ForInlinePointerAndTombstone(t *testing.T) {
 	ptrWant := page.ValuePtr{Offset: 99, Length: 123, FileID: 7}
 	m := NewBTree()
@@ -237,4 +258,51 @@ func TestBTreeIteratorUnsafeEntry_ForInlinePointerAndTombstone(t *testing.T) {
 
 	assertIter(t, "forward", m.NewIterator(nil, nil), []string{"a-inline", "b-pointer", "c-tomb"})
 	assertIter(t, "reverse", m.NewReverseIterator(nil, nil), []string{"c-tomb", "b-pointer", "a-inline"})
+}
+
+func TestBTreeApplyStealSortedBatchIndicesTrusted(t *testing.T) {
+	m := NewBTree()
+	ptr := page.ValuePtr{Offset: 7, Length: 11, FileID: 2}
+	entries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: []byte("ignore"), Value: []byte("skip")},
+		{Type: batchpkg.OpPut, Key: []byte("a"), Value: []byte("va")},
+		{Type: batchpkg.OpDelete, Key: []byte("b")},
+		{Type: batchpkg.OpPut, Key: []byte("c"), Value: []byte("tail"), ValuePtr: ptr, IsPtr: true},
+	}
+
+	var seen []string
+	m.ApplyStealSortedBatchIndicesTrusted(entries, []int{1, 2, 3}, func(key []byte) {
+		seen = append(seen, string(key))
+	})
+
+	if got, del, ok := m.Get([]byte("a")); !ok || del || string(got) != "va" {
+		t.Fatalf("Get(a)=(%q,%v,%v), want (va,false,true)", string(got), del, ok)
+	}
+	if got, del, ok := m.Get([]byte("b")); !ok || !del || got != nil {
+		t.Fatalf("Get(b)=(%v,%v,%v), want (nil,true,true)", got, del, ok)
+	}
+	if got, gotPtr, flags, ok := m.GetEntry([]byte("c")); !ok || string(got) != "tail" || gotPtr != ptr || flags != node.FlagPointer {
+		t.Fatalf("GetEntry(c)=(%q,%+v,%d,%v), want (tail,%+v,%d,true)", string(got), gotPtr, flags, ok, ptr, node.FlagPointer)
+	}
+	if _, _, ok := m.Get([]byte("ignore")); ok {
+		t.Fatal("ignored entry was applied")
+	}
+	if want := []string{"a", "b", "c"}; !equalStrings(seen, want) {
+		t.Fatalf("onKey saw %v want %v", seen, want)
+	}
+	if got := m.Len(); got != 3 {
+		t.Fatalf("Len()=%d want 3", got)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary

This is the additive stack head I would carry forward from the PR #1046 optimization chain. It builds on #1049 and adds the repeated inline-value optimization for the BTree memtable.

The selected stack is intentionally conservative:

- included: low-risk decode/classification/WAL-buffer/update-key fixes from #1049
- included: repeated inline-value reuse in the BTree memtable
- excluded: sealed-leaf mmap cap and broader arena/layout changes
- excluded: compact BTree entry layout for now because it regressed `batch_write_steady` in the settled unified-bench run

## Validation

Targeted tests:

- `go test -count=1 ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/caching`
- `go test -count=1 ./TreeDB/internal/memtable ./TreeDB/caching`

Unified bench, main vs this stack head:

- default profile: broadly positive; examples: seq +10.9%, random_write +28.7%, batch_write +13.8%, random_read +8.0%, full_scan +7.3%
- settled profile: broadly positive; examples: seq +18.5%, random_write +25.5%, dataset_random +20.8%, random_read +39.5%, prefix_scan +38.7%
- full-suite `batch_random` looked noisy in the settled run, but an isolated serial rerun was main 1,151,032 ops/s vs candidate 1,172,413 ops/s (+1.9%)

Celestia validation, main adapters, 15-minute dwell:

- `fast`: candidate synced 2s faster (302s vs 304s) and 65 extra blocks; app bytes were +42MB absolute but slightly better per synced block; max RSS was higher (+1.86GB). Pair was marked invalid by the block-drift gate.
- `wal_on_fast`: candidate was 9s slower (404s vs 395s) and 55 extra blocks; app bytes were +296MB absolute / +78KB per synced block; max RSS was lower (-704MB). Pair was marked invalid by the block-drift gate.
- dwell samples were mixed: `fast` retained higher candidate RSS/HWM; `wal_on_fast` retained lower candidate HWM but app size remained higher. Treat Celestia as directional, not proof of a clean runtime win.

## Merge posture

This is a candidate stack, not an auto-merge. The unified-bench data supports carrying it forward; the Celestia data is mixed/noisy but does not reproduce the broad PR #1046 no-go profile. The next review gate should be CI, AI review comments, and human approval.
