### PR TITLE
test: gate native probe fallback evidence (Refs #768)

### DIFF
--- a/TreeDB/collections/bench_test.go
+++ b/TreeDB/collections/bench_test.go
@@ -82,6 +82,50 @@ func benchmarkCollectionStoragePolicy(tb testing.TB) (dataOuter, indexOuter bool
 	return dataOuter, indexOuter
 }
 
+func benchmarkStatUint64(tb testing.TB, stats map[string]string, key string) uint64 {
+	tb.Helper()
+
+	raw, ok := stats[key]
+	if !ok {
+		tb.Fatalf("missing benchmark stat %q", key)
+	}
+	n, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		tb.Fatalf("parse benchmark stat %q=%q: %v", key, raw, err)
+	}
+	return n
+}
+
+func benchmarkNativeProbeFallbackCounters(tb testing.TB, backend *backenddb.DB) (key, prefix uint64) {
+	tb.Helper()
+
+	stats := backend.Stats()
+	return benchmarkStatUint64(tb, stats, "treedb.native_fastpath.per_item_key_probe_fallback_count"),
+		benchmarkStatUint64(tb, stats, "treedb.native_fastpath.per_item_prefix_probe_fallback_count")
+}
+
+func benchmarkReportNativeProbeFallbackDeltas(b *testing.B, backend *backenddb.DB, startKey, startPrefix uint64) {
+	b.Helper()
+
+	endKey, endPrefix := benchmarkNativeProbeFallbackCounters(b, backend)
+	if endKey < startKey {
+		b.Fatalf("per_item_key_probe_fallback_count moved backwards: start=%d end=%d", startKey, endKey)
+	}
+	if endPrefix < startPrefix {
+		b.Fatalf("per_item_prefix_probe_fallback_count moved backwards: start=%d end=%d", startPrefix, endPrefix)
+	}
+	keyDelta := endKey - startKey
+	prefixDelta := endPrefix - startPrefix
+	b.ReportMetric(float64(keyDelta), "per_item_key_probe_fallback_count")
+	b.ReportMetric(float64(prefixDelta), "per_item_prefix_probe_fallback_count")
+	if keyDelta != 0 {
+		b.Fatalf("per_item_key_probe_fallback_count=%d want 0", keyDelta)
+	}
+	if prefixDelta != 0 {
+		b.Fatalf("per_item_prefix_probe_fallback_count=%d want 0", prefixDelta)
+	}
+}
+
 func TestBenchmarkCollectionStoragePolicyDefaultsProductionMainline(t *testing.T) {
 	t.Setenv("TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG", "")
 	t.Setenv("TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG", "")
@@ -246,8 +290,9 @@ func BenchmarkCollectionInsertProvidedID(b *testing.B) {
 }
 
 func BenchmarkCollectionInsertBatchProvidedID(b *testing.B) {
-	_, collection := openBenchmarkCollection(b, "bench_insert_batch_provided")
+	backend, collection := openBenchmarkCollection(b, "bench_insert_batch_provided")
 	targetBatchSize := benchmarkBatchSize(b)
+	startKeyFallback, startPrefixFallback := benchmarkNativeProbeFallbackCounters(b, backend)
 
 	b.ReportAllocs()
 	b.ReportMetric(float64(targetBatchSize), "target_docs/batch")
@@ -266,6 +311,8 @@ func BenchmarkCollectionInsertBatchProvidedID(b *testing.B) {
 		}
 		inserted += batchSize
 	}
+	b.StopTimer()
+	benchmarkReportNativeProbeFallbackDeltas(b, backend, startKeyFallback, startPrefixFallback)
 }
 
 func BenchmarkCollectionGetByID(b *testing.B) {
@@ -328,8 +375,9 @@ func BenchmarkCollectionInsertWithSecondaryIndexes(b *testing.B) {
 }
 
 func BenchmarkCollectionInsertBatchWithSecondaryIndexes(b *testing.B) {
-	_, collection := openBenchmarkCollection(b, "bench_insert_batch_secondary", secondaryIndexes()...)
+	backend, collection := openBenchmarkCollection(b, "bench_insert_batch_secondary", secondaryIndexes()...)
 	targetBatchSize := benchmarkBatchSize(b)
+	startKeyFallback, startPrefixFallback := benchmarkNativeProbeFallbackCounters(b, backend)
 
 	b.ReportAllocs()
 	b.ReportMetric(float64(targetBatchSize), "target_docs/batch")
@@ -348,11 +396,14 @@ func BenchmarkCollectionInsertBatchWithSecondaryIndexes(b *testing.B) {
 		}
 		inserted += batchSize
 	}
+	b.StopTimer()
+	benchmarkReportNativeProbeFallbackDeltas(b, backend, startKeyFallback, startPrefixFallback)
 }
 
 func BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes(b *testing.B) {
 	backend, collection := openBenchmarkCollection(b, "bench_insert_batch_checkpoint_secondary", secondaryIndexes()...)
 	targetBatchSize := benchmarkBatchSize(b)
+	startKeyFallback, startPrefixFallback := benchmarkNativeProbeFallbackCounters(b, backend)
 
 	b.ReportAllocs()
 	b.ReportMetric(float64(targetBatchSize), "target_docs/checkpoint")
@@ -372,6 +423,8 @@ func BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes(b *testing.B) 
 		benchmarkSyncBoundary(b, backend)
 		inserted += batchSize
 	}
+	b.StopTimer()
+	benchmarkReportNativeProbeFallbackDeltas(b, backend, startKeyFallback, startPrefixFallback)
 }
 
 func BenchmarkCollectionDeleteWithSecondaryIndexes(b *testing.B) {

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -691,6 +691,13 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.publish.system_root.warm_rebuild_fallbacks"] = fmt.Sprintf("%d", warmPublishStats.warmRebuildFallbacks)
 	stats["treedb.publish.system_root.warm_preserved_pages"] = fmt.Sprintf("%d", warmPublishStats.warmPreservedPages)
 	stats["treedb.publish.system_root.warm_rewritten_pages"] = fmt.Sprintf("%d", warmPublishStats.warmRewrittenPages)
+	rootProbeStats := db.rootProbeStatsSnapshot()
+	stats["treedb.root_probe.has_any_sorted.fallback_calls"] = fmt.Sprintf("%d", rootProbeStats.keyFallbackCalls)
+	stats["treedb.root_probe.has_any_sorted.fallback_items"] = fmt.Sprintf("%d", rootProbeStats.keyFallbackItems)
+	stats["treedb.root_probe.has_prefixes.fallback_calls"] = fmt.Sprintf("%d", rootProbeStats.prefixFallbackCalls)
+	stats["treedb.root_probe.has_prefixes.fallback_items"] = fmt.Sprintf("%d", rootProbeStats.prefixFallbackItems)
+	stats["treedb.native_fastpath.per_item_key_probe_fallback_count"] = fmt.Sprintf("%d", rootProbeStats.keyFallbackItems)
+	stats["treedb.native_fastpath.per_item_prefix_probe_fallback_count"] = fmt.Sprintf("%d", rootProbeStats.prefixFallbackItems)
 
 	pruneStatsInto(stats, &db.pruner)
 

--- a/TreeDB/db/api_test.go
+++ b/TreeDB/db/api_test.go
@@ -284,6 +284,18 @@ func TestStatsIncludesWatermarkLagDriftMetric(t *testing.T) {
 	if _, ok := stats["treedb.publish.system_root.warm_rebuild_fallbacks"]; !ok {
 		t.Fatalf("missing treedb.publish.system_root.warm_rebuild_fallbacks")
 	}
+	if _, ok := stats["treedb.root_probe.has_any_sorted.fallback_items"]; !ok {
+		t.Fatalf("missing treedb.root_probe.has_any_sorted.fallback_items")
+	}
+	if _, ok := stats["treedb.root_probe.has_prefixes.fallback_items"]; !ok {
+		t.Fatalf("missing treedb.root_probe.has_prefixes.fallback_items")
+	}
+	if _, ok := stats["treedb.native_fastpath.per_item_key_probe_fallback_count"]; !ok {
+		t.Fatalf("missing treedb.native_fastpath.per_item_key_probe_fallback_count")
+	}
+	if _, ok := stats["treedb.native_fastpath.per_item_prefix_probe_fallback_count"]; !ok {
+		t.Fatalf("missing treedb.native_fastpath.per_item_prefix_probe_fallback_count")
+	}
 	if _, ok := stats["treedb.process.read_path.backend_tree.get_append_inline_hits_total"]; !ok {
 		t.Fatalf("missing treedb.process.read_path.backend_tree.get_append_inline_hits_total")
 	}

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -174,6 +174,11 @@ type DB struct {
 	systemRootWarmPreservedPages          atomic.Uint64
 	systemRootWarmRewrittenPages          atomic.Uint64
 
+	rootProbeKeyFallbackCalls    atomic.Uint64
+	rootProbeKeyFallbackItems    atomic.Uint64
+	rootProbePrefixFallbackCalls atomic.Uint64
+	rootProbePrefixFallbackItems atomic.Uint64
+
 	// testFailFinalizeCommit forces finalizeCommitLocked to fail before writing
 	// the next meta page. Used by crash-safety tests.
 	testFailFinalizeCommit        atomic.Bool

--- a/TreeDB/db/root_probe_stats.go
+++ b/TreeDB/db/root_probe_stats.go
@@ -1,0 +1,38 @@
+package db
+
+import "github.com/snissn/gomap/TreeDB/tree"
+
+type rootProbeStats struct {
+	keyFallbackCalls    uint64
+	keyFallbackItems    uint64
+	prefixFallbackCalls uint64
+	prefixFallbackItems uint64
+}
+
+func (db *DB) noteRootProbeKeyFallback(stats tree.ProbeFallbackStats) {
+	if db == nil || stats.FallbackCalls == 0 {
+		return
+	}
+	db.rootProbeKeyFallbackCalls.Add(stats.FallbackCalls)
+	db.rootProbeKeyFallbackItems.Add(stats.FallbackItems)
+}
+
+func (db *DB) noteRootProbePrefixFallback(stats tree.ProbeFallbackStats) {
+	if db == nil || stats.FallbackCalls == 0 {
+		return
+	}
+	db.rootProbePrefixFallbackCalls.Add(stats.FallbackCalls)
+	db.rootProbePrefixFallbackItems.Add(stats.FallbackItems)
+}
+
+func (db *DB) rootProbeStatsSnapshot() rootProbeStats {
+	if db == nil {
+		return rootProbeStats{}
+	}
+	return rootProbeStats{
+		keyFallbackCalls:    db.rootProbeKeyFallbackCalls.Load(),
+		keyFallbackItems:    db.rootProbeKeyFallbackItems.Load(),
+		prefixFallbackCalls: db.rootProbePrefixFallbackCalls.Load(),
+		prefixFallbackItems: db.rootProbePrefixFallbackItems.Load(),
+	}
+}

--- a/TreeDB/db/root_snapshot.go
+++ b/TreeDB/db/root_snapshot.go
@@ -65,7 +65,7 @@ func (s *Snapshot) HasAnySortedAtRoot(rootID uint64, keys [][]byte) (bool, error
 		return false, err
 	}
 	ok, stats, err := tr.HasAnySortedWithStats(keys)
-	if stats.FallbackCalls != 0 && s != nil {
+	if stats.FallbackCalls != 0 {
 		s.db.noteRootProbeKeyFallback(stats)
 	}
 	return ok, err
@@ -84,7 +84,7 @@ func (s *Snapshot) HasPrefixesAtRoot(rootID uint64, prefixes [][]byte) ([]bool, 
 		return nil, err
 	}
 	out, stats, err := tr.HasPrefixesWithStats(prefixes)
-	if stats.FallbackCalls != 0 && s != nil {
+	if stats.FallbackCalls != 0 {
 		s.db.noteRootProbePrefixFallback(stats)
 	}
 	return out, err

--- a/TreeDB/db/root_snapshot.go
+++ b/TreeDB/db/root_snapshot.go
@@ -64,7 +64,11 @@ func (s *Snapshot) HasAnySortedAtRoot(rootID uint64, keys [][]byte) (bool, error
 	if err != nil {
 		return false, err
 	}
-	return tr.HasAnySorted(keys)
+	ok, stats, err := tr.HasAnySortedWithStats(keys)
+	if stats.FallbackCalls != 0 && s != nil {
+		s.db.noteRootProbeKeyFallback(stats)
+	}
+	return ok, err
 }
 
 func (s *Snapshot) HasPrefixesAtRoot(rootID uint64, prefixes [][]byte) ([]bool, error) {
@@ -79,5 +83,9 @@ func (s *Snapshot) HasPrefixesAtRoot(rootID uint64, prefixes [][]byte) ([]bool, 
 	if err != nil {
 		return nil, err
 	}
-	return tr.HasPrefixes(prefixes)
+	out, stats, err := tr.HasPrefixesWithStats(prefixes)
+	if stats.FallbackCalls != 0 && s != nil {
+		s.db.noteRootProbePrefixFallback(stats)
+	}
+	return out, err
 }

--- a/TreeDB/db/snapshot_probe_test.go
+++ b/TreeDB/db/snapshot_probe_test.go
@@ -206,13 +206,14 @@ func TestSnapshot_HasAnySortedAtRootRecordsPerItemFallback(t *testing.T) {
 
 	got, err := snap.HasAnySortedAtRoot(rootIDs[0], [][]byte{
 		[]byte("sys/0000/missing"),
+		[]byte("sys/1050"),
 		[]byte("sys/9999"),
 	})
 	if err != nil {
 		t.Fatalf("HasAnySortedAtRoot: %v", err)
 	}
-	if got {
-		t.Fatalf("HasAnySortedAtRoot got true want false")
+	if !got {
+		t.Fatalf("HasAnySortedAtRoot got false want true")
 	}
 
 	after := db.rootProbeStatsSnapshot()

--- a/TreeDB/db/snapshot_probe_test.go
+++ b/TreeDB/db/snapshot_probe_test.go
@@ -239,6 +239,53 @@ func TestSnapshot_HasAnySortedAtRootRecordsPerItemFallback(t *testing.T) {
 	}
 }
 
+func TestSnapshot_HasAnySortedAtRootFallbackDedupesDuplicateKeys(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, rootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{{
+		Iter: mustFrozenSystemMemtable(t, systemRangeKVs(1100, nil)...).NewIterator(nil, nil),
+	}})
+	if err != nil {
+		t.Fatalf("publish root: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("root IDs len=%d want 1", len(rootIDs))
+	}
+
+	before := db.rootProbeStatsSnapshot()
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+
+	got, err := snap.HasAnySortedAtRoot(rootIDs[0], [][]byte{
+		[]byte("sys/0000/missing"),
+		[]byte("sys/1050/missing"),
+		[]byte("sys/1050/missing"),
+		[]byte("sys/1051"),
+	})
+	if err != nil {
+		t.Fatalf("HasAnySortedAtRoot: %v", err)
+	}
+	if !got {
+		t.Fatalf("HasAnySortedAtRoot got false want true")
+	}
+
+	after := db.rootProbeStatsSnapshot()
+	if delta := after.keyFallbackCalls - before.keyFallbackCalls; delta != 1 {
+		t.Fatalf("key fallback calls delta=%d want 1", delta)
+	}
+	if delta := after.keyFallbackItems - before.keyFallbackItems; delta != 2 {
+		t.Fatalf("key fallback items delta=%d want 2", delta)
+	}
+}
+
 func TestSnapshotRootProbesSkipTombstones(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})

--- a/TreeDB/db/snapshot_probe_test.go
+++ b/TreeDB/db/snapshot_probe_test.go
@@ -178,3 +178,59 @@ func TestSnapshot_HasManyAtRootAndHasPrefixesAtRoot(t *testing.T) {
 		t.Fatalf("HasPrefixesAtRoot missing root mismatch: got=%v want=%v", missingRootHasPrefixes, want)
 	}
 }
+
+func TestSnapshot_HasAnySortedAtRootRecordsPerItemFallback(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, rootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{{
+		Iter: mustFrozenSystemMemtable(t, systemRangeKVs(1100, nil)...).NewIterator(nil, nil),
+	}})
+	if err != nil {
+		t.Fatalf("publish root: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("root IDs len=%d want 1", len(rootIDs))
+	}
+
+	before := db.rootProbeStatsSnapshot()
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+
+	got, err := snap.HasAnySortedAtRoot(rootIDs[0], [][]byte{
+		[]byte("sys/0000/missing"),
+		[]byte("sys/9999"),
+	})
+	if err != nil {
+		t.Fatalf("HasAnySortedAtRoot: %v", err)
+	}
+	if got {
+		t.Fatalf("HasAnySortedAtRoot got true want false")
+	}
+
+	after := db.rootProbeStatsSnapshot()
+	if delta := after.keyFallbackCalls - before.keyFallbackCalls; delta != 1 {
+		t.Fatalf("key fallback calls delta=%d want 1", delta)
+	}
+	if delta := after.keyFallbackItems - before.keyFallbackItems; delta != 1 {
+		t.Fatalf("key fallback items delta=%d want 1", delta)
+	}
+	if delta := after.prefixFallbackItems - before.prefixFallbackItems; delta != 0 {
+		t.Fatalf("prefix fallback items delta=%d want 0", delta)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.native_fastpath.per_item_key_probe_fallback_count"]; got != "1" {
+		t.Fatalf("per_item_key_probe_fallback_count=%q want 1", got)
+	}
+	if got := stats["treedb.native_fastpath.per_item_prefix_probe_fallback_count"]; got != "0" {
+		t.Fatalf("per_item_prefix_probe_fallback_count=%q want 0", got)
+	}
+}

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -799,14 +799,19 @@ fallback:
 		return false, stats, nil
 	}
 	stats.FallbackCalls = 1
-	for ; targetIdx < len(keys); targetIdx++ {
+	for targetIdx < len(keys) {
+		target := keys[targetIdx]
 		stats.FallbackItems++
-		ok, err := t.Has(keys[targetIdx])
+		ok, err := t.Has(target)
 		if err != nil {
 			return false, stats, err
 		}
 		if ok {
 			return true, stats, nil
+		}
+		targetIdx++
+		for targetIdx < len(keys) && compareTreeKey(keys[targetIdx], target) == 0 {
+			targetIdx++
 		}
 	}
 	return false, stats, nil

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -33,6 +33,11 @@ type ReadPathStats struct {
 	GetAppendPointerBytesTotal uint64
 }
 
+type ProbeFallbackStats struct {
+	FallbackCalls uint64
+	FallbackItems uint64
+}
+
 var treeGetAppendInlineHitsTotal atomic.Uint64
 var treeGetAppendInlineBytesTotal atomic.Uint64
 var treeGetAppendPointerHitsTotal atomic.Uint64
@@ -729,12 +734,18 @@ func (t *Tree) HasMany(keys [][]byte) ([]bool, error) {
 }
 
 func (t *Tree) HasAnySorted(keys [][]byte) (bool, error) {
+	ok, _, err := t.HasAnySortedWithStats(keys)
+	return ok, err
+}
+
+func (t *Tree) HasAnySortedWithStats(keys [][]byte) (bool, ProbeFallbackStats, error) {
+	var stats ProbeFallbackStats
 	if len(keys) == 0 {
-		return false, nil
+		return false, stats, nil
 	}
 	for i := 1; i < len(keys); i++ {
 		if compareTreeKey(keys[i-1], keys[i]) > 0 {
-			return false, errors.New("keys must be sorted")
+			return false, stats, errors.New("keys must be sorted")
 		}
 	}
 
@@ -751,14 +762,14 @@ func (t *Tree) HasAnySorted(keys [][]byte) (bool, error) {
 	for targetIdx < len(keys) {
 		if !it.Valid() {
 			if err := it.Error(); err != nil {
-				return false, err
+				return false, stats, err
 			}
-			return false, nil
+			return false, stats, nil
 		}
 		curr := it.UnsafeKey()
 		switch cmp := compareTreeKey(curr, keys[targetIdx]); {
 		case cmp == 0:
-			return true, it.Error()
+			return true, stats, it.Error()
 		case cmp < 0:
 			scanned++
 			if scanned > scanLimit {
@@ -775,27 +786,35 @@ func (t *Tree) HasAnySorted(keys [][]byte) (bool, error) {
 
 fallback:
 	if err := it.Error(); err != nil {
-		return false, err
+		return false, stats, err
 	}
 	if !limitExceeded {
-		return false, nil
+		return false, stats, nil
 	}
+	stats.FallbackCalls = 1
+	stats.FallbackItems = uint64(len(keys) - targetIdx)
 	for ; targetIdx < len(keys); targetIdx++ {
 		ok, err := t.Has(keys[targetIdx])
 		if err != nil {
-			return false, err
+			return false, stats, err
 		}
 		if ok {
-			return true, nil
+			return true, stats, nil
 		}
 	}
-	return false, nil
+	return false, stats, nil
 }
 
 func (t *Tree) HasPrefixes(prefixes [][]byte) ([]bool, error) {
+	out, _, err := t.HasPrefixesWithStats(prefixes)
+	return out, err
+}
+
+func (t *Tree) HasPrefixesWithStats(prefixes [][]byte) ([]bool, ProbeFallbackStats, error) {
+	var stats ProbeFallbackStats
 	out := make([]bool, len(prefixes))
 	if len(prefixes) == 0 {
-		return out, nil
+		return out, stats, nil
 	}
 
 	type prefixProbeRef struct {
@@ -823,9 +842,9 @@ func (t *Tree) HasPrefixes(prefixes [][]byte) ([]bool, error) {
 		for {
 			if !it.Valid() {
 				if err := it.Error(); err != nil {
-					return nil, err
+					return nil, stats, err
 				}
-				return out, nil
+				return out, stats, nil
 			}
 			curr := it.UnsafeKey()
 			if compareTreeKey(curr, prefix) < 0 {
@@ -849,7 +868,7 @@ func (t *Tree) HasPrefixes(prefixes [][]byte) ([]bool, error) {
 		start = end
 	}
 	if err := it.Error(); err != nil {
-		return nil, err
+		return nil, stats, err
 	}
-	return out, nil
+	return out, stats, nil
 }

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -792,8 +792,8 @@ fallback:
 		return false, stats, nil
 	}
 	stats.FallbackCalls = 1
-	stats.FallbackItems = uint64(len(keys) - targetIdx)
 	for ; targetIdx < len(keys); targetIdx++ {
+		stats.FallbackItems++
 		ok, err := t.Has(keys[targetIdx])
 		if err != nil {
 			return false, stats, err


### PR DESCRIPTION
## Summary

Follow-up to #1047 for the remaining issue #768 counter/evidence items.

- Adds backend-level accounting for sorted root probe fallback paths.
- Exposes native fast-path counter aliases for per-item key/prefix probe fallback deltas.
- Makes the targeted collection batch benchmarks report and fail on non-zero probe fallback deltas.
- Adds regression coverage proving the key fallback counter increments when the low-level scan-limit fallback is actually used.

## Evidence

Raw TreeDB anchors, `IndexOuterLeavesInValueLog=true`:

- fast: `/tmp/gomap_r8_counter_raw_fast_outer_true_CyVbUD`
- wal_on_fast: `/tmp/gomap_r8_counter_raw_wal_outer_true_UcGqVc`

Probe microbenches:

- `/tmp/gomap_r8_counter_probe_microbenches.txt`

Collection storage matrix with counter gates:

- `/tmp/gomap_r8_counter_collection_matrix_171650`
- production-mainline repeat: `/tmp/gomap_r8_counter_collection_prod_default_count2.txt`

All targeted collection cells reported:

- `per_item_key_probe_fallback_count = 0`
- `per_item_prefix_probe_fallback_count = 0`

## Validation

- `git diff --check`
- `GOWORK=off go test ./TreeDB/tree ./TreeDB/db ./TreeDB/collections -run 'TestSnapshot_HasAnySortedAtRootRecordsPerItemFallback|TestStatsIncludesWatermarkLagDriftMetric|TestBenchmarkCollectionStoragePolicyDefaultsProductionMainline' -count=1`
- `GOWORK=off go test ./TreeDB/db ./TreeDB/tree ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestRootDomainProbeStats|TestGetMany_' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionInsertBatchProvidedID$|BenchmarkCollectionInsertBatchWithSecondaryIndexes$|BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes$' -benchtime=1s -count=1`
- `GOWORK=off go test ./TreeDB ./TreeDB/caching ./TreeDB/db -run '^$' -bench 'BenchmarkSnapshotHasMany|BenchmarkGetMany_PublishedRootPointShards|BenchmarkRootDomainSnapshotPrefixIterator|BenchmarkPublishSystemRootIterator_WarmSparseDelta' -benchtime=1s -count=1`
