### PR TITLE
collections: trim unused preflight allocations

### DIFF
--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -138,6 +138,56 @@ func TestCollectionInsertBatchBridge_ReturnedIDsAndDocumentsAreOwned(t *testing.
 	}
 }
 
+func TestCollectionInsertBatchBridge_IndexedReturnedIDsAreOwned(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	inputID := []byte("u1")
+	inputDocument := []byte(`{"email":"ada@example.com","city":"hnl"}`)
+	ids, err := col.InsertBatch(
+		[][]byte{inputID},
+		[][]byte{inputDocument},
+	)
+	if err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	inputID[0] = 'x'
+	inputDocument[10] = 'x'
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("returned ids=%q want owned u1", ids)
+	}
+
+	ids[0][0] = 'z'
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get original id after mutating returned id: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("original id value=%q want %q", got, want)
+	}
+	if got, err := col.Get([]byte("z1")); err != nil || got != nil {
+		t.Fatalf("mutated returned id lookup got=%q err=%v want missing", got, err)
+	}
+}
+
 func TestCollectionSingleInsertBufferedNoIndexReadsBeforeFlush(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/overhead_bench_test.go
+++ b/TreeDB/collections/overhead_bench_test.go
@@ -243,14 +243,13 @@ func overheadBenchPlanIndexedPrecomputedState(
 			}
 		}
 	}
-	uniqueProbeRuns, err := buildUniqueProbeRuns(uniqueProbes)
-	if err != nil {
+	sortUniqueProbeCandidates(uniqueProbes)
+	if err := rejectDuplicateUniqueProbeCandidates(uniqueProbes); err != nil {
 		return err
 	}
 
 	plan := &insertBatchPlan{
-		resultIDs:       resultIDs,
-		uniqueProbeRuns: uniqueProbeRuns,
+		resultIDs: resultIDs,
 	}
 	if err := planner.emitPrimaryRun(plan, items, primaryOrder); err != nil {
 		return err

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -166,7 +166,7 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	if err := preflight.checkDocumentConflicts(items, primaryOrder, resultIDs); err != nil {
 		return nil, err
 	}
-	uniqueProbeRuns, err := buildUniqueProbeRunsForPreflight(uniqueProbes, preflight)
+	uniqueProbeRuns, err := buildUniqueProbeRunsForPreflightFromSorted(uniqueProbes, preflight)
 	if err != nil {
 		return nil, err
 	}
@@ -192,11 +192,13 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	return plan, nil
 }
 
-func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem, order []int, sortedIDs [][]byte) error {
+func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem, order []int, presortedIDs [][]byte) error {
 	if p.snapshot == nil || p.primaryRootID == 0 {
 		return nil
 	}
-	keys := sortedIDs
+	// sortedItemOrderByKey returns nil only when items are already sorted by ID,
+	// so the caller-owned presortedIDs slice is safe to reuse only in that case.
+	keys := presortedIDs
 	if order != nil || len(keys) != len(items) {
 		keys = make([][]byte, len(items))
 		for i := range items {
@@ -330,7 +332,7 @@ func buildUniqueProbeRuns(candidates []uniqueProbeCandidate) ([]collectionUnique
 	return buildUniqueProbeRunsFromSorted(candidates, nil)
 }
 
-func buildUniqueProbeRunsForPreflight(candidates []uniqueProbeCandidate, preflight insertBatchPreflight) ([]collectionUniqueProbeRun, error) {
+func buildUniqueProbeRunsForPreflightFromSorted(candidates []uniqueProbeCandidate, preflight insertBatchPreflight) ([]collectionUniqueProbeRun, error) {
 	if preflight.snapshot == nil || len(preflight.uniqueIndexRootIDs) == 0 {
 		return nil, nil
 	}

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -159,11 +159,15 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	if err != nil {
 		return nil, err
 	}
-	uniqueProbeRuns, err := buildUniqueProbeRuns(uniqueProbes)
-	if err != nil {
+	sortUniqueProbeCandidates(uniqueProbes)
+	if err := rejectDuplicateUniqueProbeCandidates(uniqueProbes); err != nil {
 		return nil, err
 	}
-	if err := preflight.checkDocumentConflicts(items, primaryOrder); err != nil {
+	if err := preflight.checkDocumentConflicts(items, primaryOrder, resultIDs); err != nil {
+		return nil, err
+	}
+	uniqueProbeRuns, err := buildUniqueProbeRunsForPreflight(uniqueProbes, preflight)
+	if err != nil {
 		return nil, err
 	}
 	if err := preflight.checkUniqueConflicts(uniqueProbeRuns); err != nil {
@@ -188,13 +192,16 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	return plan, nil
 }
 
-func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem, order []int) error {
+func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem, order []int, sortedIDs [][]byte) error {
 	if p.snapshot == nil || p.primaryRootID == 0 {
 		return nil
 	}
-	keys := make([][]byte, len(items))
-	for i := range items {
-		keys[i] = items[orderedItemIndex(order, i)].id
+	keys := sortedIDs
+	if order != nil || len(keys) != len(items) {
+		keys = make([][]byte, len(items))
+		for i := range items {
+			keys[i] = items[orderedItemIndex(order, i)].id
+		}
 	}
 	exists, err := p.snapshot.HasAnySortedAtRoot(p.primaryRootID, keys)
 	if err != nil {
@@ -290,10 +297,7 @@ func (p insertBatchPlanner) planIndexStateAndUniqueProbes(items []insertBatchIte
 	return uniqueProbes, nil
 }
 
-func buildUniqueProbeRuns(candidates []uniqueProbeCandidate) ([]collectionUniqueProbeRun, error) {
-	if len(candidates) == 0 {
-		return nil, nil
-	}
+func sortUniqueProbeCandidates(candidates []uniqueProbeCandidate) {
 	sort.Slice(candidates, func(i, j int) bool {
 		if candidates[i].indexName != candidates[j].indexName {
 			return candidates[i].indexName < candidates[j].indexName
@@ -303,7 +307,42 @@ func buildUniqueProbeRuns(candidates []uniqueProbeCandidate) ([]collectionUnique
 		}
 		return bytes.Compare(candidates[i].documentID, candidates[j].documentID) < 0
 	})
+}
 
+func rejectDuplicateUniqueProbeCandidates(candidates []uniqueProbeCandidate) error {
+	for i := 1; i < len(candidates); i++ {
+		candidate := &candidates[i]
+		prev := &candidates[i-1]
+		if candidate.indexName == prev.indexName &&
+			bytes.Equal(candidate.encodedValue, prev.encodedValue) &&
+			!bytes.Equal(candidate.documentID, prev.documentID) {
+			return fmt.Errorf("collections: unique index %q conflict", candidate.indexName)
+		}
+	}
+	return nil
+}
+
+func buildUniqueProbeRuns(candidates []uniqueProbeCandidate) ([]collectionUniqueProbeRun, error) {
+	sortUniqueProbeCandidates(candidates)
+	if err := rejectDuplicateUniqueProbeCandidates(candidates); err != nil {
+		return nil, err
+	}
+	return buildUniqueProbeRunsFromSorted(candidates, nil)
+}
+
+func buildUniqueProbeRunsForPreflight(candidates []uniqueProbeCandidate, preflight insertBatchPreflight) ([]collectionUniqueProbeRun, error) {
+	if preflight.snapshot == nil || len(preflight.uniqueIndexRootIDs) == 0 {
+		return nil, nil
+	}
+	return buildUniqueProbeRunsFromSorted(candidates, func(indexName string) bool {
+		return preflight.uniqueIndexRootIDs[indexName] != 0
+	})
+}
+
+func buildUniqueProbeRunsFromSorted(candidates []uniqueProbeCandidate, includeIndex func(indexName string) bool) ([]collectionUniqueProbeRun, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
 	runs := make([]collectionUniqueProbeRun, 0)
 	for start := 0; start < len(candidates); {
 		indexName := candidates[start].indexName
@@ -311,17 +350,16 @@ func buildUniqueProbeRuns(candidates []uniqueProbeCandidate) ([]collectionUnique
 		for end < len(candidates) && candidates[end].indexName == indexName {
 			end++
 		}
+		if includeIndex != nil && !includeIndex(indexName) {
+			start = end
+			continue
+		}
 		run := collectionUniqueProbeRun{
 			indexName: indexName,
 			prefixes:  make([][]byte, 0, end-start),
 		}
 		for i := start; i < end; i++ {
 			candidate := &candidates[i]
-			if i > start &&
-				bytes.Equal(candidate.encodedValue, candidates[i-1].encodedValue) &&
-				!bytes.Equal(candidate.documentID, candidates[i-1].documentID) {
-				return nil, fmt.Errorf("collections: unique index %q conflict", candidate.indexName)
-			}
 			if len(run.prefixes) == 0 || !bytes.Equal(candidate.encodedValue, candidates[i-1].encodedValue) {
 				prefix, err := indexValuePrefix(candidate.encodedValue)
 				if err != nil {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -370,7 +370,7 @@ func (p insertBatchPlanner) emitIndexStateRun(plan *insertBatchPlan, items []ins
 		if err != nil {
 			return err
 		}
-		table.SetSteal(bytes.Clone(items[idx].id), raw)
+		table.SetSteal(items[idx].id, raw)
 	}
 	table.Freeze()
 	plan.runs = append(plan.runs, collectionRootRun{

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -68,19 +68,8 @@ func TestInsertBatchPlanner_EmitsRootLocalRunsForPrimaryIndexStateAndSecondaryRo
 	}
 	assertSortedEntries(t, cityEntries)
 
-	if got, want := len(plan.uniqueProbeRuns), 1; got != want {
-		t.Fatalf("unique probe runs=%d want %d", got, want)
-	}
-	if got, want := plan.uniqueProbeRuns[0].indexName, "email"; got != want {
-		t.Fatalf("unique probe index=%q want %q", got, want)
-	}
-	if got, want := len(plan.uniqueProbeRuns[0].prefixes), 2; got != want {
-		t.Fatalf("unique probe prefixes=%d want %d", got, want)
-	}
-	for _, prefix := range plan.uniqueProbeRuns[0].prefixes {
-		if bytes.Contains(prefix, []byte("u1")) || bytes.Contains(prefix, []byte("u2")) {
-			t.Fatalf("unique probe prefix contains a document id: %q", prefix)
-		}
+	if got := len(plan.uniqueProbeRuns); got != 0 {
+		t.Fatalf("unique probe runs=%d want 0 without persisted unique roots", got)
 	}
 }
 
@@ -158,6 +147,53 @@ func TestBuildUniqueProbeRunsMatchesEncodedPrefixOrdering(t *testing.T) {
 	})
 	if !byteMatrixEqual(runs[0].prefixes, want) {
 		t.Fatalf("prefix order mismatch\n got: %q\nwant: %q", runs[0].prefixes, want)
+	}
+}
+
+func TestInsertBatchPlanner_BuildsUniqueProbePrefixesOnlyForPersistedRoots(t *testing.T) {
+	planner := insertBatchPlanner{
+		collection: "users",
+		indexes: []indexDefinition{
+			{name: "email", field: "email", unique: true},
+			{name: "username", field: "username", unique: true},
+		},
+	}
+	probe := &recordingRootSnapshotProbe{}
+	plan, err := planner.planInsertBatchWithPreflight(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com","username":"ada"}`),
+			[]byte(`{"email":"grace@example.com","username":"grace"}`),
+		},
+		insertBatchPreflight{
+			snapshot: probe,
+			uniqueIndexRootIDs: map[string]uint64{
+				"email": 77,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("plan insert batch: %v", err)
+	}
+	if got, want := len(plan.uniqueProbeRuns), 1; got != want {
+		t.Fatalf("unique probe runs=%d want %d", got, want)
+	}
+	if got, want := plan.uniqueProbeRuns[0].indexName, "email"; got != want {
+		t.Fatalf("unique probe index=%q want %q", got, want)
+	}
+	if got, want := len(plan.uniqueProbeRuns[0].prefixes), 2; got != want {
+		t.Fatalf("unique probe prefixes=%d want %d", got, want)
+	}
+	for _, prefix := range plan.uniqueProbeRuns[0].prefixes {
+		if bytes.Contains(prefix, []byte("u1")) || bytes.Contains(prefix, []byte("u2")) {
+			t.Fatalf("unique probe prefix contains a document id: %q", prefix)
+		}
+	}
+	if got, want := probe.hasPrefixesCalls, 1; got != want {
+		t.Fatalf("HasPrefixesAtRoot calls=%d want %d", got, want)
+	}
+	if got, want := probe.lastHasPrefixesRootID, uint64(77); got != want {
+		t.Fatalf("HasPrefixesAtRoot root=%d want %d", got, want)
 	}
 }
 
@@ -314,10 +350,10 @@ func TestInsertBatchPlanner_PreflightUsesRootBatchProbes(t *testing.T) {
 	}
 
 	_, err := planner.planInsertBatchWithPreflight(
-		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte("u2"), []byte("u1")},
 		[][]byte{
-			[]byte(`{"email":"ada@example.com"}`),
 			[]byte(`{"email":"grace@example.com"}`),
+			[]byte(`{"email":"ada@example.com"}`),
 		},
 		insertBatchPreflight{
 			snapshot:      probe,

--- a/cmd/collection_bench_matrix_summary/main.go
+++ b/cmd/collection_bench_matrix_summary/main.go
@@ -206,7 +206,7 @@ func loadBenchmarkReport(path string) (map[string]benchmarkAggregate, error) {
 		return nil, fmt.Errorf("parse report %s: %w", path, err)
 	}
 	if rep.Status != "ok" {
-		return nil, nil
+		return nil, fmt.Errorf("report %s status %q; matrix summary requires ok reports", path, rep.Status)
 	}
 	out := make(map[string]benchmarkAggregate)
 	for _, section := range rep.Sections {

--- a/cmd/collection_bench_matrix_summary/main.go
+++ b/cmd/collection_bench_matrix_summary/main.go
@@ -180,7 +180,7 @@ func buildSummaryRows(rows []matrixRow) ([]summaryRow, error) {
 		for _, name := range benchmarkOrder {
 			benchmark, ok := benchmarks[name]
 			if !ok {
-				continue
+				return nil, fmt.Errorf("report %s missing benchmark %q for matrix cell %q", row.ReportJSONPath, name, row.Cell)
 			}
 			out = append(out, summaryRow{
 				matrixRow:       row,

--- a/cmd/collection_bench_matrix_summary/main.go
+++ b/cmd/collection_bench_matrix_summary/main.go
@@ -1,0 +1,389 @@
+package main
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type config struct {
+	matrixIndexPath string
+	outDir          string
+}
+
+type matrixRow struct {
+	Cell                   string
+	Engine                 string
+	DataOuterLeavesInVLog  string
+	IndexOuterLeavesInVLog string
+	ReportMarkdownPath     string
+	ReportJSONPath         string
+}
+
+type report struct {
+	Status   string `json:"status"`
+	Sections []struct {
+		Benchmarks []benchmarkAggregate `json:"benchmarks"`
+	} `json:"sections"`
+}
+
+type benchmarkAggregate struct {
+	Name            string             `json:"name"`
+	MeanNsPerOp     float64            `json:"mean_ns_per_op"`
+	MeanBytesPerOp  float64            `json:"mean_bytes_per_op"`
+	MeanAllocsPerOp float64            `json:"mean_allocs_per_op"`
+	MeanMetrics     map[string]float64 `json:"mean_metrics,omitempty"`
+}
+
+type summaryRow struct {
+	matrixRow
+	Benchmark       string
+	NsPerOp         float64
+	BytesPerOp      float64
+	AllocsPerOp     float64
+	KeyFallbacks    *float64
+	PrefixFallbacks *float64
+}
+
+var benchmarkOrder = []string{
+	"BenchmarkCollectionOverheadIndexStateJSONExtraction",
+	"BenchmarkCollectionOverheadPlanIndexedPrecomputedState",
+	"BenchmarkCollectionInsertBatchWithSecondaryIndexes",
+	"BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes",
+}
+
+func main() {
+	cfg, err := parseFlags(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collection_bench_matrix_summary: %v\n", err)
+		os.Exit(2)
+	}
+	if err := run(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "collection_bench_matrix_summary: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func parseFlags(args []string) (config, error) {
+	var cfg config
+	fs := flag.NewFlagSet("collection_bench_matrix_summary", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&cfg.matrixIndexPath, "matrix-index", "", "Path to matrix_index.tsv")
+	fs.StringVar(&cfg.outDir, "out-dir", "", "Output directory for summary artifacts")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	if cfg.matrixIndexPath == "" {
+		return config{}, fmt.Errorf("-matrix-index is required")
+	}
+	if cfg.outDir == "" {
+		cfg.outDir = filepath.Dir(cfg.matrixIndexPath)
+	}
+	return cfg, nil
+}
+
+func run(cfg config) error {
+	rows, err := readMatrixIndex(cfg.matrixIndexPath)
+	if err != nil {
+		return err
+	}
+	summaryRows, err := buildSummaryRows(rows)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(cfg.outDir, 0o755); err != nil {
+		return fmt.Errorf("create out dir: %w", err)
+	}
+	tsvPath := filepath.Join(cfg.outDir, "collections_matrix_summary.tsv")
+	if err := os.WriteFile(tsvPath, []byte(renderTSV(summaryRows)), 0o644); err != nil {
+		return fmt.Errorf("write tsv: %w", err)
+	}
+	mdPath := filepath.Join(cfg.outDir, "collections_matrix_summary.md")
+	md, err := renderMarkdown(summaryRows, cfg.outDir)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(mdPath, []byte(md), 0o644); err != nil {
+		return fmt.Errorf("write markdown: %w", err)
+	}
+	fmt.Printf("wrote matrix summary tsv: %s\n", tsvPath)
+	fmt.Printf("wrote matrix summary md:  %s\n", mdPath)
+	return nil
+}
+
+func readMatrixIndex(path string) ([]matrixRow, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open matrix index: %w", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.Comma = '\t'
+	reader.FieldsPerRecord = -1
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("read matrix index: %w", err)
+	}
+	if len(records) == 0 {
+		return nil, fmt.Errorf("matrix index is empty")
+	}
+	header := make(map[string]int, len(records[0]))
+	for i, name := range records[0] {
+		header[name] = i
+	}
+	required := []string{"cell", "engine", "data_outer_leaves_in_vlog", "index_outer_leaves_in_vlog", "report_md", "report_json"}
+	for _, name := range required {
+		if _, ok := header[name]; !ok {
+			return nil, fmt.Errorf("matrix index missing %q column", name)
+		}
+	}
+
+	var rows []matrixRow
+	for _, record := range records[1:] {
+		if len(record) == 0 || strings.TrimSpace(record[0]) == "" {
+			continue
+		}
+		rows = append(rows, matrixRow{
+			Cell:                   field(record, header["cell"]),
+			Engine:                 field(record, header["engine"]),
+			DataOuterLeavesInVLog:  field(record, header["data_outer_leaves_in_vlog"]),
+			IndexOuterLeavesInVLog: field(record, header["index_outer_leaves_in_vlog"]),
+			ReportMarkdownPath:     field(record, header["report_md"]),
+			ReportJSONPath:         field(record, header["report_json"]),
+		})
+	}
+	return rows, nil
+}
+
+func field(record []string, idx int) string {
+	if idx < 0 || idx >= len(record) {
+		return ""
+	}
+	return record[idx]
+}
+
+func buildSummaryRows(rows []matrixRow) ([]summaryRow, error) {
+	out := make([]summaryRow, 0, len(rows)*len(benchmarkOrder))
+	for _, row := range rows {
+		benchmarks, err := loadBenchmarkReport(row.ReportJSONPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range benchmarkOrder {
+			benchmark, ok := benchmarks[name]
+			if !ok {
+				continue
+			}
+			out = append(out, summaryRow{
+				matrixRow:       row,
+				Benchmark:       name,
+				NsPerOp:         benchmark.MeanNsPerOp,
+				BytesPerOp:      benchmark.MeanBytesPerOp,
+				AllocsPerOp:     benchmark.MeanAllocsPerOp,
+				KeyFallbacks:    metricPtr(benchmark.MeanMetrics, "per_item_key_probe_fallback_count"),
+				PrefixFallbacks: metricPtr(benchmark.MeanMetrics, "per_item_prefix_probe_fallback_count"),
+			})
+		}
+	}
+	return out, nil
+}
+
+func loadBenchmarkReport(path string) (map[string]benchmarkAggregate, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read report %s: %w", path, err)
+	}
+	var rep report
+	if err := json.Unmarshal(raw, &rep); err != nil {
+		return nil, fmt.Errorf("parse report %s: %w", path, err)
+	}
+	if rep.Status != "ok" {
+		return nil, nil
+	}
+	out := make(map[string]benchmarkAggregate)
+	for _, section := range rep.Sections {
+		for _, benchmark := range section.Benchmarks {
+			out[benchmark.Name] = benchmark
+		}
+	}
+	return out, nil
+}
+
+func metricPtr(metrics map[string]float64, name string) *float64 {
+	value, ok := metrics[name]
+	if !ok {
+		return nil
+	}
+	return &value
+}
+
+func renderTSV(rows []summaryRow) string {
+	var sb strings.Builder
+	sb.WriteString("cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tbenchmark\tns_per_op\tbytes_per_op\tallocs_per_op\tper_item_key_probe_fallback_count\tper_item_prefix_probe_fallback_count\treport_md\n")
+	for _, row := range rows {
+		sb.WriteString(row.Cell)
+		sb.WriteByte('\t')
+		sb.WriteString(row.Engine)
+		sb.WriteByte('\t')
+		sb.WriteString(row.DataOuterLeavesInVLog)
+		sb.WriteByte('\t')
+		sb.WriteString(row.IndexOuterLeavesInVLog)
+		sb.WriteByte('\t')
+		sb.WriteString(row.Benchmark)
+		sb.WriteByte('\t')
+		sb.WriteString(formatTSVFloat(row.NsPerOp))
+		sb.WriteByte('\t')
+		sb.WriteString(formatTSVFloat(row.BytesPerOp))
+		sb.WriteByte('\t')
+		sb.WriteString(formatTSVFloat(row.AllocsPerOp))
+		sb.WriteByte('\t')
+		sb.WriteString(formatOptionalTSVFloat(row.KeyFallbacks))
+		sb.WriteByte('\t')
+		sb.WriteString(formatOptionalTSVFloat(row.PrefixFallbacks))
+		sb.WriteByte('\t')
+		sb.WriteString(row.ReportMarkdownPath)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func formatOptionalTSVFloat(value *float64) string {
+	if value == nil {
+		return "-"
+	}
+	return formatTSVFloat(*value)
+}
+
+func formatTSVFloat(value float64) string {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return "-"
+	}
+	return strconv.FormatFloat(value, 'f', -1, 64)
+}
+
+func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
+	var sb strings.Builder
+	sb.WriteString("# Collections Benchmark Matrix Summary\n\n")
+	sb.WriteString("| Cell | Engine | Data vlog | Index vlog | Benchmark | ns/op | B/op | allocs/op | Key fallbacks | Prefix fallbacks | Report |\n")
+	sb.WriteString("| --- | --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | --- |\n")
+	for _, row := range rows {
+		reportPath := row.ReportMarkdownPath
+		if rel, err := filepath.Rel(outDir, row.ReportMarkdownPath); err == nil {
+			reportPath = rel
+		}
+		sb.WriteString("| `")
+		sb.WriteString(escapeTableCell(row.Cell))
+		sb.WriteString("` | `")
+		sb.WriteString(escapeTableCell(row.Engine))
+		sb.WriteString("` | `")
+		sb.WriteString(escapeTableCell(row.DataOuterLeavesInVLog))
+		sb.WriteString("` | `")
+		sb.WriteString(escapeTableCell(row.IndexOuterLeavesInVLog))
+		sb.WriteString("` | `")
+		sb.WriteString(escapeTableCell(row.Benchmark))
+		sb.WriteString("` | ")
+		sb.WriteString(formatFloat(row.NsPerOp))
+		sb.WriteString(" | ")
+		sb.WriteString(formatFloat(row.BytesPerOp))
+		sb.WriteString(" | ")
+		sb.WriteString(formatFloat(row.AllocsPerOp))
+		sb.WriteString(" | ")
+		sb.WriteString(formatOptionalFloat(row.KeyFallbacks))
+		sb.WriteString(" | ")
+		sb.WriteString(formatOptionalFloat(row.PrefixFallbacks))
+		sb.WriteString(" | [report](")
+		sb.WriteString(markdownLinkPath(reportPath))
+		sb.WriteString(") |\n")
+	}
+	return sb.String(), nil
+}
+
+func markdownLinkPath(path string) string {
+	return strings.ReplaceAll(path, " ", "%20")
+}
+
+func escapeTableCell(value string) string {
+	return strings.ReplaceAll(value, "|", "\\|")
+}
+
+func formatOptionalFloat(value *float64) string {
+	if value == nil {
+		return "-"
+	}
+	return formatFloat(*value)
+}
+
+func formatFloat(value float64) string {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return "-"
+	}
+	rounded := math.Round(value*100) / 100
+	if math.Abs(rounded-math.Round(rounded)) < 0.005 {
+		return formatIntWithCommas(int64(math.Round(rounded)))
+	}
+	return trimTrailingZeros(formatWithCommas(rounded))
+}
+
+func formatWithCommas(value float64) string {
+	negative := value < 0
+	if negative {
+		value = -value
+	}
+	whole := int64(value)
+	fraction := value - float64(whole)
+	base := formatIntWithCommas(whole)
+	if fraction == 0 {
+		if negative {
+			return "-" + base
+		}
+		return base
+	}
+	text := fmt.Sprintf("%s%.2f", "", fraction)
+	text = strings.TrimPrefix(text, "0")
+	if negative {
+		return "-" + base + text
+	}
+	return base + text
+}
+
+func trimTrailingZeros(value string) string {
+	value = strings.TrimRight(value, "0")
+	value = strings.TrimRight(value, ".")
+	return value
+}
+
+func formatIntWithCommas(value int64) string {
+	negative := value < 0
+	if negative {
+		value = -value
+	}
+	raw := strconv.FormatInt(value, 10)
+	if len(raw) <= 3 {
+		if negative {
+			return "-" + raw
+		}
+		return raw
+	}
+	var parts []string
+	for len(raw) > 3 {
+		parts = append(parts, raw[len(raw)-3:])
+		raw = raw[:len(raw)-3]
+	}
+	parts = append(parts, raw)
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+	result := strings.Join(parts, ",")
+	if negative {
+		return "-" + result
+	}
+	return result
+}

--- a/cmd/collection_bench_matrix_summary/main_test.go
+++ b/cmd/collection_bench_matrix_summary/main_test.go
@@ -87,3 +87,40 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 		t.Fatalf("tsv should not contain comma-formatted numbers:\n%s", gotTSV)
 	}
 }
+
+func TestMatrixSummaryFailsOnUnavailableReport(t *testing.T) {
+	dir := t.TempDir()
+	cellDir := filepath.Join(dir, "production_fast_data_vlog_index_leaf")
+	if err := os.MkdirAll(cellDir, 0o755); err != nil {
+		t.Fatalf("mkdir cell: %v", err)
+	}
+	reportJSON := filepath.Join(cellDir, "collections_report.json")
+	reportMarkdown := filepath.Join(cellDir, "collections_report.md")
+	if err := os.WriteFile(reportMarkdown, []byte("# report\n"), 0o644); err != nil {
+		t.Fatalf("write report md: %v", err)
+	}
+	if err := os.WriteFile(reportJSON, []byte(`{
+  "status": "unavailable",
+  "unavailable_reason": "N/A before harness bring-up",
+  "sections": []
+}`), 0o644); err != nil {
+		t.Fatalf("write report json: %v", err)
+	}
+	indexPath := filepath.Join(dir, "matrix_index.tsv")
+	index := strings.Join([]string{
+		"cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\treport_md\treport_json\tcpu_profile\tmem_profile",
+		"production_fast_data_vlog_index_leaf\tproduction_fast\ttrue\tfalse\t" + reportMarkdown + "\t" + reportJSON + "\t/cpu.pprof\t/mem.pprof",
+		"",
+	}, "\n")
+	if err := os.WriteFile(indexPath, []byte(index), 0o644); err != nil {
+		t.Fatalf("write matrix index: %v", err)
+	}
+
+	err := run(config{matrixIndexPath: indexPath, outDir: dir})
+	if err == nil {
+		t.Fatal("run got nil error for unavailable report")
+	}
+	if !strings.Contains(err.Error(), `status "unavailable"`) {
+		t.Fatalf("error=%q want unavailable status", err)
+	}
+}

--- a/cmd/collection_bench_matrix_summary/main_test.go
+++ b/cmd/collection_bench_matrix_summary/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
+	dir := t.TempDir()
+	cellDir := filepath.Join(dir, "production_fast_data_vlog_index_leaf")
+	if err := os.MkdirAll(cellDir, 0o755); err != nil {
+		t.Fatalf("mkdir cell: %v", err)
+	}
+	reportJSON := filepath.Join(cellDir, "collections_report.json")
+	reportMarkdown := filepath.Join(cellDir, "collections_report.md")
+	if err := os.WriteFile(reportMarkdown, []byte("# report\n"), 0o644); err != nil {
+		t.Fatalf("write report md: %v", err)
+	}
+	if err := os.WriteFile(reportJSON, []byte(`{
+  "status": "ok",
+  "sections": [
+    {
+      "benchmarks": [
+        {
+          "name": "BenchmarkCollectionInsertBatchWithSecondaryIndexes",
+          "mean_ns_per_op": 2812.5,
+          "mean_bytes_per_op": 1980,
+          "mean_allocs_per_op": 30,
+          "mean_metrics": {
+            "per_item_key_probe_fallback_count": 0,
+            "per_item_prefix_probe_fallback_count": 0
+          }
+        },
+        {
+          "name": "BenchmarkCollectionOverheadPlanIndexedPrecomputedState",
+          "mean_ns_per_op": 596.5,
+          "mean_bytes_per_op": 398,
+          "mean_allocs_per_op": 5
+        }
+      ]
+    }
+  ]
+}`), 0o644); err != nil {
+		t.Fatalf("write report json: %v", err)
+	}
+	indexPath := filepath.Join(dir, "matrix_index.tsv")
+	index := strings.Join([]string{
+		"cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\treport_md\treport_json\tcpu_profile\tmem_profile",
+		"production_fast_data_vlog_index_leaf\tproduction_fast\ttrue\tfalse\t" + reportMarkdown + "\t" + reportJSON + "\t/cpu.pprof\t/mem.pprof",
+		"",
+	}, "\n")
+	if err := os.WriteFile(indexPath, []byte(index), 0o644); err != nil {
+		t.Fatalf("write matrix index: %v", err)
+	}
+
+	if err := run(config{matrixIndexPath: indexPath, outDir: dir}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	md, err := os.ReadFile(filepath.Join(dir, "collections_matrix_summary.md"))
+	if err != nil {
+		t.Fatalf("read md: %v", err)
+	}
+	got := string(md)
+	for _, want := range []string{
+		"`production_fast_data_vlog_index_leaf`",
+		"`BenchmarkCollectionInsertBatchWithSecondaryIndexes`",
+		"2,812.5",
+		"30",
+		"0",
+		"[report](production_fast_data_vlog_index_leaf/collections_report.md)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, got)
+		}
+	}
+	tsv, err := os.ReadFile(filepath.Join(dir, "collections_matrix_summary.tsv"))
+	if err != nil {
+		t.Fatalf("read tsv: %v", err)
+	}
+	gotTSV := string(tsv)
+	if !strings.Contains(gotTSV, "BenchmarkCollectionInsertBatchWithSecondaryIndexes\t2812.5\t1980\t30\t0\t0\t") {
+		t.Fatalf("tsv missing raw numeric row:\n%s", gotTSV)
+	}
+	if strings.Contains(gotTSV, "2,812") {
+		t.Fatalf("tsv should not contain comma-formatted numbers:\n%s", gotTSV)
+	}
+}

--- a/cmd/collection_bench_matrix_summary/main_test.go
+++ b/cmd/collection_bench_matrix_summary/main_test.go
@@ -34,10 +34,22 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
           }
         },
         {
+          "name": "BenchmarkCollectionOverheadIndexStateJSONExtraction",
+          "mean_ns_per_op": 1412.5,
+          "mean_bytes_per_op": 872,
+          "mean_allocs_per_op": 24
+        },
+        {
           "name": "BenchmarkCollectionOverheadPlanIndexedPrecomputedState",
           "mean_ns_per_op": 596.5,
           "mean_bytes_per_op": 398,
           "mean_allocs_per_op": 5
+        },
+        {
+          "name": "BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes",
+          "mean_ns_per_op": 4250,
+          "mean_bytes_per_op": 2048,
+          "mean_allocs_per_op": 31
         }
       ]
     }
@@ -122,5 +134,55 @@ func TestMatrixSummaryFailsOnUnavailableReport(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `status "unavailable"`) {
 		t.Fatalf("error=%q want unavailable status", err)
+	}
+}
+
+func TestMatrixSummaryFailsOnMissingExpectedBenchmark(t *testing.T) {
+	dir := t.TempDir()
+	cellDir := filepath.Join(dir, "production_fast_data_vlog_index_leaf")
+	if err := os.MkdirAll(cellDir, 0o755); err != nil {
+		t.Fatalf("mkdir cell: %v", err)
+	}
+	reportJSON := filepath.Join(cellDir, "collections_report.json")
+	reportMarkdown := filepath.Join(cellDir, "collections_report.md")
+	if err := os.WriteFile(reportMarkdown, []byte("# report\n"), 0o644); err != nil {
+		t.Fatalf("write report md: %v", err)
+	}
+	if err := os.WriteFile(reportJSON, []byte(`{
+  "status": "ok",
+  "sections": [
+    {
+      "benchmarks": [
+        {
+          "name": "BenchmarkCollectionInsertBatchWithSecondaryIndexes",
+          "mean_ns_per_op": 2812.5,
+          "mean_bytes_per_op": 1980,
+          "mean_allocs_per_op": 30
+        }
+      ]
+    }
+  ]
+}`), 0o644); err != nil {
+		t.Fatalf("write report json: %v", err)
+	}
+	indexPath := filepath.Join(dir, "matrix_index.tsv")
+	index := strings.Join([]string{
+		"cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\treport_md\treport_json\tcpu_profile\tmem_profile",
+		"production_fast_data_vlog_index_leaf\tproduction_fast\ttrue\tfalse\t" + reportMarkdown + "\t" + reportJSON + "\t/cpu.pprof\t/mem.pprof",
+		"",
+	}, "\n")
+	if err := os.WriteFile(indexPath, []byte(index), 0o644); err != nil {
+		t.Fatalf("write matrix index: %v", err)
+	}
+
+	err := run(config{matrixIndexPath: indexPath, outDir: dir})
+	if err == nil {
+		t.Fatal("run got nil error for missing expected benchmark")
+	}
+	if !strings.Contains(err.Error(), `missing benchmark "BenchmarkCollectionOverheadIndexStateJSONExtraction"`) {
+		t.Fatalf("error=%q want missing benchmark", err)
+	}
+	if !strings.Contains(err.Error(), reportJSON) {
+		t.Fatalf("error=%q want report path", err)
 	}
 }

--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -359,6 +359,7 @@ func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
 		sumBytes   float64
 		sumAllocs  float64
 		sumMetrics map[string]float64
+		metricRuns map[string]int
 		minNs      float64
 		maxNs      float64
 	}
@@ -393,8 +394,10 @@ func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
 		for name, value := range sample.Metrics {
 			if entry.sumMetrics == nil {
 				entry.sumMetrics = make(map[string]float64)
+				entry.metricRuns = make(map[string]int)
 			}
 			entry.sumMetrics[name] += value
+			entry.metricRuns[name]++
 		}
 		if sample.NsPerOp < entry.minNs {
 			entry.minNs = sample.NsPerOp
@@ -414,7 +417,11 @@ func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
 		}
 		meanMetrics := make(map[string]float64, len(entry.sumMetrics))
 		for name, value := range entry.sumMetrics {
-			meanMetrics[name] = value / sampleCount
+			metricCount := entry.metricRuns[name]
+			if metricCount == 0 {
+				continue
+			}
+			meanMetrics[name] = value / float64(metricCount)
 		}
 		if len(meanMetrics) == 0 {
 			meanMetrics = nil

--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -47,25 +47,27 @@ type benchmarkSpec struct {
 }
 
 type benchmarkSample struct {
-	Name        string  `json:"name"`
-	Iterations  int64   `json:"iterations"`
-	NsPerOp     float64 `json:"ns_per_op"`
-	BytesPerOp  float64 `json:"bytes_per_op"`
-	AllocsPerOp float64 `json:"allocs_per_op"`
+	Name        string             `json:"name"`
+	Iterations  int64              `json:"iterations"`
+	NsPerOp     float64            `json:"ns_per_op"`
+	BytesPerOp  float64            `json:"bytes_per_op"`
+	AllocsPerOp float64            `json:"allocs_per_op"`
+	Metrics     map[string]float64 `json:"metrics,omitempty"`
 }
 
 type benchmarkAggregate struct {
-	Name            string            `json:"name"`
-	Section         string            `json:"section"`
-	Description     string            `json:"description"`
-	Samples         int               `json:"samples"`
-	MeanNsPerOp     float64           `json:"mean_ns_per_op"`
-	MinNsPerOp      float64           `json:"min_ns_per_op"`
-	MaxNsPerOp      float64           `json:"max_ns_per_op"`
-	MeanBytesPerOp  float64           `json:"mean_bytes_per_op"`
-	MeanAllocsPerOp float64           `json:"mean_allocs_per_op"`
-	OpsPerSec       float64           `json:"ops_per_sec"`
-	Runs            []benchmarkSample `json:"runs"`
+	Name            string             `json:"name"`
+	Section         string             `json:"section"`
+	Description     string             `json:"description"`
+	Samples         int                `json:"samples"`
+	MeanNsPerOp     float64            `json:"mean_ns_per_op"`
+	MinNsPerOp      float64            `json:"min_ns_per_op"`
+	MaxNsPerOp      float64            `json:"max_ns_per_op"`
+	MeanBytesPerOp  float64            `json:"mean_bytes_per_op"`
+	MeanAllocsPerOp float64            `json:"mean_allocs_per_op"`
+	MeanMetrics     map[string]float64 `json:"mean_metrics,omitempty"`
+	OpsPerSec       float64            `json:"ops_per_sec"`
+	Runs            []benchmarkSample  `json:"runs"`
 }
 
 type reportSection struct {
@@ -338,6 +340,11 @@ func parseBenchmarkLine(line string) (benchmarkSample, bool) {
 			sample.BytesPerOp = value
 		case "allocs/op":
 			sample.AllocsPerOp = value
+		default:
+			if sample.Metrics == nil {
+				sample.Metrics = make(map[string]float64)
+			}
+			sample.Metrics[fields[i+1]] = value
 		}
 	}
 	return sample, true
@@ -345,13 +352,14 @@ func parseBenchmarkLine(line string) (benchmarkSample, bool) {
 
 func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
 	type running struct {
-		spec      benchmarkSpec
-		runs      []benchmarkSample
-		sumNs     float64
-		sumBytes  float64
-		sumAllocs float64
-		minNs     float64
-		maxNs     float64
+		spec       benchmarkSpec
+		runs       []benchmarkSample
+		sumNs      float64
+		sumBytes   float64
+		sumAllocs  float64
+		sumMetrics map[string]float64
+		minNs      float64
+		maxNs      float64
 	}
 
 	specByName := make(map[string]benchmarkSpec, len(benchmarkSpecs))
@@ -381,6 +389,12 @@ func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
 		entry.sumNs += sample.NsPerOp
 		entry.sumBytes += sample.BytesPerOp
 		entry.sumAllocs += sample.AllocsPerOp
+		for name, value := range sample.Metrics {
+			if entry.sumMetrics == nil {
+				entry.sumMetrics = make(map[string]float64)
+			}
+			entry.sumMetrics[name] += value
+		}
 		if sample.NsPerOp < entry.minNs {
 			entry.minNs = sample.NsPerOp
 		}
@@ -397,6 +411,13 @@ func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
 		if meanNs > 0 {
 			opsPerSec = 1e9 / meanNs
 		}
+		meanMetrics := make(map[string]float64, len(entry.sumMetrics))
+		for name, value := range entry.sumMetrics {
+			meanMetrics[name] = value / sampleCount
+		}
+		if len(meanMetrics) == 0 {
+			meanMetrics = nil
+		}
 		result[name] = benchmarkAggregate{
 			Name:            name,
 			Section:         entry.spec.Section,
@@ -407,6 +428,7 @@ func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
 			MaxNsPerOp:      entry.maxNs,
 			MeanBytesPerOp:  entry.sumBytes / sampleCount,
 			MeanAllocsPerOp: entry.sumAllocs / sampleCount,
+			MeanMetrics:     meanMetrics,
 			OpsPerSec:       opsPerSec,
 			Runs:            entry.runs,
 		}
@@ -502,9 +524,21 @@ func renderMarkdown(rep *report) string {
 	}
 
 	for _, section := range rep.Sections {
+		metricColumns := benchmarkMetricColumns(section.Benchmarks)
 		sb.WriteString(fmt.Sprintf("## %s\n\n", section.Title))
-		sb.WriteString("| Benchmark | Description | Samples | Ops/sec | ns/op | B/op | allocs/op |\n")
-		sb.WriteString("| --- | --- | ---: | ---: | ---: | ---: | ---: |\n")
+		sb.WriteString("| Benchmark | Description | Samples | Ops/sec | ns/op | B/op | allocs/op")
+		for _, metric := range metricColumns {
+			sb.WriteString(" | ")
+			sb.WriteString("`")
+			sb.WriteString(metric)
+			sb.WriteString("`")
+		}
+		sb.WriteString(" |\n")
+		sb.WriteString("| --- | --- | ---: | ---: | ---: | ---: | ---:")
+		for range metricColumns {
+			sb.WriteString(" | ---:")
+		}
+		sb.WriteString(" |\n")
 		for _, benchmark := range section.Benchmarks {
 			sb.WriteString("| ")
 			sb.WriteString(fmt.Sprintf("`%s`", benchmark.Name))
@@ -520,11 +554,54 @@ func renderMarkdown(rep *report) string {
 			sb.WriteString(formatFloat(benchmark.MeanBytesPerOp))
 			sb.WriteString(" | ")
 			sb.WriteString(formatFloat(benchmark.MeanAllocsPerOp))
+			for _, metric := range metricColumns {
+				sb.WriteString(" | ")
+				value, ok := benchmark.MeanMetrics[metric]
+				if ok {
+					sb.WriteString(formatFloat(value))
+				} else {
+					sb.WriteString("-")
+				}
+			}
 			sb.WriteString(" |\n")
 		}
 		sb.WriteString("\n")
 	}
 	return sb.String()
+}
+
+func benchmarkMetricColumns(benchmarks []benchmarkAggregate) []string {
+	seen := make(map[string]struct{})
+	for _, benchmark := range benchmarks {
+		for name := range benchmark.MeanMetrics {
+			seen[name] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	preferred := []string{
+		"target_docs/batch",
+		"target_docs/checkpoint",
+		"indexes/doc",
+		"per_item_key_probe_fallback_count",
+		"per_item_prefix_probe_fallback_count",
+		"warm_native_apply",
+		"warm_rebuild_fallback",
+	}
+	out := make([]string, 0, len(seen))
+	for _, name := range preferred {
+		if _, ok := seen[name]; ok {
+			out = append(out, name)
+			delete(seen, name)
+		}
+	}
+	rest := make([]string, 0, len(seen))
+	for name := range seen {
+		rest = append(rest, name)
+	}
+	sort.Strings(rest)
+	return append(out, rest...)
 }
 
 func escapeTableCell(value string) string {

--- a/cmd/collection_bench_report/main_test.go
+++ b/cmd/collection_bench_report/main_test.go
@@ -55,6 +55,7 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	input := strings.NewReader(strings.Join([]string{
 		`{"Action":"output","Output":"BenchmarkCollectionInsertProvidedID-12\t1000\t2000 ns/op\t128 B/op\t4 allocs/op\n"}`,
 		`{"Action":"output","Output":"BenchmarkCollectionInsertProvidedID-12\t900\t2200 ns/op\t136 B/op\t5 allocs/op\n"}`,
+		`{"Action":"output","Output":"BenchmarkCollectionInsertBatchWithSecondaryIndexes-12\t700\t3200 ns/op\t256 B/op\t7 allocs/op\t8000 target_docs/batch\t0 per_item_key_probe_fallback_count\t0 per_item_prefix_probe_fallback_count\n"}`,
 		`{"Action":"output","Output":"BenchmarkSecondaryLookupNonUnique-12\t5000\t450 ns/op\t96 B/op\t2 allocs/op\n"}`,
 		`{"Action":"output","Output":"BenchmarkCollectionDeleteWithSecondaryIndexes-12\t"}`,
 		`{"Action":"output","Output":"123\t9000 ns/op\t512 B/op\t8 allocs/op\n"}`,
@@ -65,7 +66,7 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseBenchmarkSamples: %v", err)
 	}
-	if got, want := len(samples), 4; got != want {
+	if got, want := len(samples), 5; got != want {
 		t.Fatalf("len(samples)=%d want %d", got, want)
 	}
 
@@ -76,6 +77,13 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	}
 	if got, want := insert.MeanNsPerOp, 2100.0; got != want {
 		t.Fatalf("insert mean ns/op=%v want %v", got, want)
+	}
+	indexedBatch := aggregates["BenchmarkCollectionInsertBatchWithSecondaryIndexes"]
+	if got, want := indexedBatch.MeanMetrics["target_docs/batch"], 8000.0; got != want {
+		t.Fatalf("indexed batch target_docs/batch=%v want %v", got, want)
+	}
+	if got, want := indexedBatch.MeanMetrics["per_item_key_probe_fallback_count"], 0.0; got != want {
+		t.Fatalf("indexed batch per_item_key_probe_fallback_count=%v want %v", got, want)
 	}
 
 	rep := &report{
@@ -109,6 +117,15 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	}
 	if !strings.Contains(md, "`BenchmarkSecondaryLookupNonUnique`") {
 		t.Fatalf("markdown missing secondary benchmark row:\n%s", md)
+	}
+	if !strings.Contains(md, "`target_docs/batch`") {
+		t.Fatalf("markdown missing custom metric column:\n%s", md)
+	}
+	if !strings.Contains(md, "`per_item_key_probe_fallback_count`") {
+		t.Fatalf("markdown missing native fallback metric column:\n%s", md)
+	}
+	if !strings.Contains(md, "`BenchmarkCollectionInsertBatchWithSecondaryIndexes`") {
+		t.Fatalf("markdown missing indexed batch benchmark row:\n%s", md)
 	}
 }
 

--- a/cmd/collection_bench_report/main_test.go
+++ b/cmd/collection_bench_report/main_test.go
@@ -130,6 +130,34 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	}
 }
 
+func TestAggregateSamplesAveragesMetricsOverReportingSamples(t *testing.T) {
+	aggregates := aggregateSamples([]benchmarkSample{
+		{
+			Name:    "BenchmarkCollectionInsertBatchWithSecondaryIndexes",
+			NsPerOp: 1000,
+			Metrics: map[string]float64{
+				"conditionally_reported": 10,
+				"shared":                 2,
+			},
+		},
+		{
+			Name:    "BenchmarkCollectionInsertBatchWithSecondaryIndexes",
+			NsPerOp: 3000,
+			Metrics: map[string]float64{
+				"shared": 4,
+			},
+		},
+	})
+
+	got := aggregates["BenchmarkCollectionInsertBatchWithSecondaryIndexes"].MeanMetrics
+	if got["conditionally_reported"] != 10 {
+		t.Fatalf("conditionally_reported=%v want 10", got["conditionally_reported"])
+	}
+	if got["shared"] != 3 {
+		t.Fatalf("shared=%v want 3", got["shared"])
+	}
+}
+
 func TestBuildReportUnavailable(t *testing.T) {
 	rep, err := buildReport(config{
 		outDir:            t.TempDir(),

--- a/scripts/bench_collections_matrix.sh
+++ b/scripts/bench_collections_matrix.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+OUT_DIR="${OUT_DIR:-$(mktemp -d /tmp/gomap_collections_matrix_XXXXXX)}"
+MATRIX="${TREEDB_COLLECTION_MATRIX:-production}"
+PATH_LABEL="${TREEDB_COLLECTION_PATH_LABEL:-native-fastpath}"
+COUNT="${COUNT:-1}"
+BENCHTIME="${BENCHTIME:-1s}"
+BATCH_SIZE="${TREEDB_COLLECTION_BENCH_BATCH_SIZE:-8000}"
+BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertBatchWithSecondaryIndexes|CollectionInsertBatchCheckpointWithSecondaryIndexes|CollectionOverheadIndexStateJSONExtraction|CollectionOverheadPlanIndexedPrecomputedState)$}"
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+COMMIT="$(git rev-parse --short HEAD)"
+WORKTREE="$ROOT"
+
+case "$MATRIX" in
+  production)
+    MATRIX_ROWS=(
+      "production_fast_data_vlog_index_leaf production_fast true false"
+      "production_fast_data_vlog_index_vlog production_fast true true"
+      "production_wal_on_fast_data_vlog_index_leaf production_wal_on_fast true false"
+      "production_wal_on_fast_data_vlog_index_vlog production_wal_on_fast true true"
+    )
+    ;;
+  full)
+    MATRIX_ROWS=(
+      "production_fast_data_leaf_index_leaf production_fast false false"
+      "production_fast_data_leaf_index_vlog production_fast false true"
+      "production_fast_data_vlog_index_leaf production_fast true false"
+      "production_fast_data_vlog_index_vlog production_fast true true"
+      "production_wal_on_fast_data_leaf_index_leaf production_wal_on_fast false false"
+      "production_wal_on_fast_data_leaf_index_vlog production_wal_on_fast false true"
+      "production_wal_on_fast_data_vlog_index_leaf production_wal_on_fast true false"
+      "production_wal_on_fast_data_vlog_index_vlog production_wal_on_fast true true"
+    )
+    ;;
+  quick)
+    MATRIX_ROWS=(
+      "production_fast_data_vlog_index_leaf production_fast true false"
+      "production_fast_data_vlog_index_vlog production_fast true true"
+    )
+    ;;
+  *)
+    echo "unknown TREEDB_COLLECTION_MATRIX=$MATRIX (want production, full, or quick)" >&2
+    exit 2
+    ;;
+esac
+
+mkdir -p "$OUT_DIR"
+INDEX_TSV="$OUT_DIR/matrix_index.tsv"
+SUMMARY_MD="$OUT_DIR/README.md"
+
+printf "cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\treport_md\treport_json\tcpu_profile\tmem_profile\n" >"$INDEX_TSV"
+
+echo "running collections benchmark matrix into: $OUT_DIR"
+echo "matrix: $MATRIX"
+echo "execution path: $PATH_LABEL"
+echo "benchmark regex: $BENCH_REGEX"
+echo "benchmark count: $COUNT"
+echo "benchmark time: $BENCHTIME"
+echo "batch size: $BATCH_SIZE"
+
+for row in "${MATRIX_ROWS[@]}"; do
+  read -r cell engine data_outer index_outer <<<"$row"
+  cell_dir="$OUT_DIR/$cell"
+  echo
+  echo "==> $cell"
+  OUT_DIR="$cell_dir" \
+    BENCH_REGEX="$BENCH_REGEX" \
+    COUNT="$COUNT" \
+    BENCHTIME="$BENCHTIME" \
+    TREEDB_COLLECTION_PATH_LABEL="$PATH_LABEL" \
+    TREEDB_COLLECTION_BENCH_ENGINE="$engine" \
+    TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" \
+    TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$data_outer" \
+    TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$index_outer" \
+    scripts/bench_collections_report.sh
+
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "$cell" \
+    "$engine" \
+    "$data_outer" \
+    "$index_outer" \
+    "$cell_dir/collections_report.md" \
+    "$cell_dir/collections_report.json" \
+    "$cell_dir/collections_cpu.pprof" \
+    "$cell_dir/collections_mem.pprof" >>"$INDEX_TSV"
+done
+
+GOWORK=off go run ./cmd/collection_bench_matrix_summary \
+  -matrix-index "$INDEX_TSV" \
+  -out-dir "$OUT_DIR"
+
+cat >"$SUMMARY_MD" <<EOF
+# Collections Benchmark Matrix
+
+- output directory: \`$OUT_DIR\`
+- worktree: \`$WORKTREE\`
+- branch: \`$BRANCH\`
+- commit: \`$COMMIT\`
+- execution path: \`$PATH_LABEL\`
+- matrix: \`$MATRIX\`
+- benchmark regex: \`$BENCH_REGEX\`
+- benchmark count: \`$COUNT\`
+- benchmark time: \`$BENCHTIME\`
+- collection batch size: \`$BATCH_SIZE\`
+- matrix index: \`$INDEX_TSV\`
+- matrix summary markdown: \`$OUT_DIR/collections_matrix_summary.md\`
+- matrix summary tsv: \`$OUT_DIR/collections_matrix_summary.tsv\`
+
+## Cells
+
+| Cell | Engine | Data outer leaves in vlog | Index outer leaves in vlog | Report |
+| --- | --- | --- | --- | --- |
+EOF
+
+for row in "${MATRIX_ROWS[@]}"; do
+  read -r cell engine data_outer index_outer <<<"$row"
+  printf "| \`%s\` | \`%s\` | \`%s\` | \`%s\` | [%s](%s) |\n" \
+    "$cell" \
+    "$engine" \
+    "$data_outer" \
+    "$index_outer" \
+    "$cell" \
+    "$cell/collections_report.md" >>"$SUMMARY_MD"
+done
+
+cat >>"$SUMMARY_MD" <<'EOF'
+
+## Intended 768 Use
+
+The production matrix keeps collection data roots in value-log outer-leaf mode and varies index roots between inline outer leaves and value-log outer leaves. The `production_fast` and `production_wal_on_fast` engines keep the cached no-WAL and WAL-on fast paths visible without changing the collection storage policy.
+
+The focused default benchmark set keeps JSON extraction overhead, non-JSON indexed planning overhead, indexed batch apply, and indexed checkpoint apply in the same artifact so regressions can be separated into JSON cost, planner cost, root publish cost, and durability-boundary cost.
+EOF
+
+echo
+echo "matrix index: $INDEX_TSV"
+echo "matrix readme: $SUMMARY_MD"

--- a/scripts/bench_collections_report.sh
+++ b/scripts/bench_collections_report.sh
@@ -5,7 +5,7 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT"
 
 OUT_DIR="${OUT_DIR:-$(mktemp -d /tmp/gomap_collections_report_XXXXXX)}"
-BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertProvidedID|CollectionInsertBatchProvidedID|CollectionGetByID|CollectionGetByIDParallel|CollectionDeleteByID|CollectionInsertWithSecondaryIndexes|CollectionInsertBatchWithSecondaryIndexes|CollectionInsertBatchCheckpointWithSecondaryIndexes|CollectionDeleteWithSecondaryIndexes|SecondaryLookupUnique|SecondaryLookupNonUnique|SecondaryUpsertFieldChange|CollectionCreateIndexBackfillExistingDocs)}"
+BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertProvidedID|CollectionInsertBatchProvidedID|CollectionGetByID|CollectionGetByIDParallel|CollectionDeleteByID|CollectionInsertWithSecondaryIndexes|CollectionInsertBatchWithSecondaryIndexes|CollectionInsertBatchCheckpointWithSecondaryIndexes|CollectionDeleteWithSecondaryIndexes|SecondaryLookupUnique|SecondaryLookupNonUnique|SecondaryUpsertFieldChange|CollectionCreateIndexBackfillExistingDocs|CollectionOverheadPlanNoIndex|CollectionOverheadPlanIndexed|CollectionOverheadIndexStateJSONExtraction|CollectionOverheadPlanIndexedPrecomputedState)}"
 COUNT="${COUNT:-3}"
 BENCHTIME="${BENCHTIME:-}"
 BENCH_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-production_fast}"
@@ -106,6 +106,7 @@ cat >"$OUT_DIR/README.md" <<EOF
 - index-root outer-leaf override: \`TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=false scripts/bench_collections_report.sh\`
 - batch-size override: \`TREEDB_COLLECTION_BENCH_BATCH_SIZE=8000 scripts/bench_collections_report.sh\`
 - oracle-path override: \`TREEDB_COLLECTION_PATH_LABEL=oracle scripts/bench_collections_report.sh\`
+- production matrix runner: \`TREEDB_COLLECTION_PATH_LABEL=native-fastpath scripts/bench_collections_matrix.sh\`
 EOF
 
 echo "markdown report: $OUT_DIR/collections_report.md"


### PR DESCRIPTION
## Summary
- split in-batch unique conflict validation from persisted unique-root prefix construction
- only build unique prefix probe runs for persisted unique roots
- reuse already-sorted batch IDs for primary preflight conflict probes to avoid a key-slice allocation
- keep JSON extraction/parsing cost isolated; this slice targets non-JSON planner/preflight overhead

## Benchmarks
- `BenchmarkCollectionOverheadPlanIndexedPrecomputedState`: ~560-561 ns/op, 339-341 B/op, 4 allocs/op
- `BenchmarkCollectionInsertBatchWithSecondaryIndexes`: ~2897-2914 ns/op, 1928-1932 B/op, 30 allocs/op, fallback counters 0
- `BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes`: ~10211-10475 ns/op, 1969-1989 B/op, 30 allocs/op, fallback counters 0
- production matrix smoke (`TREEDB_COLLECTION_MATRIX=production`) passed; data_vlog/index_leaf production_fast precomputed planner was 561 ns/op, 341 B/op, 4 allocs/op

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestInsertBatchPlanner|TestBuildUniqueProbeRuns|TestCollectionInsertBatchBridge' -count=1`\n- `GOWORK=off go test ./TreeDB/collections ./cmd/collection_bench_report ./cmd/collection_bench_matrix_summary -count=1`\n- `git diff --check`\n- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionOverheadPlanIndexedPrecomputedState$|BenchmarkCollectionInsertBatchWithSecondaryIndexes$|BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes$' -benchmem -benchtime=2s -count=3`\n- `OUT_DIR=/tmp/gomap_r10_matrix_smoke TREEDB_COLLECTION_MATRIX=production TREEDB_COLLECTION_PATH_LABEL=native-fastpath COUNT=1 BENCHTIME=1s scripts/bench_collections_matrix.sh`