### PR TITLE
collections: add value-log trainer benchmark matrix

### DIFF
--- a/TreeDB/collections/bench_test.go
+++ b/TreeDB/collections/bench_test.go
@@ -54,6 +54,30 @@ func benchmarkTreeDBProfile(b *testing.B) treedb.Profile {
 	}
 }
 
+func benchmarkValueLogDictTrainerMode(tb testing.TB) string {
+	tb.Helper()
+
+	raw := strings.ToLower(strings.TrimSpace(os.Getenv("TREEDB_COLLECTION_VLOG_DICT_TRAINER")))
+	switch raw {
+	case "", "default", "profile/default", "enabled", "on", "true", "1":
+		return "enabled"
+	case "disabled", "off", "false", "0":
+		return "disabled"
+	default:
+		tb.Fatalf("unsupported TREEDB_COLLECTION_VLOG_DICT_TRAINER=%q", os.Getenv("TREEDB_COLLECTION_VLOG_DICT_TRAINER"))
+		return "enabled"
+	}
+}
+
+func applyBenchmarkValueLogDictTrainerMode(tb testing.TB, opts *treedb.Options) {
+	tb.Helper()
+
+	switch benchmarkValueLogDictTrainerMode(tb) {
+	case "disabled":
+		opts.ValueLog.DictTrain.TrainBytes = -1
+	}
+}
+
 func benchmarkBoolEnv(tb testing.TB, name string, def bool) bool {
 	tb.Helper()
 
@@ -185,11 +209,35 @@ func TestBenchmarkCollectionChunkSizeEnv(t *testing.T) {
 	}
 }
 
+func TestBenchmarkValueLogDictTrainerModeEnv(t *testing.T) {
+	t.Setenv("TREEDB_COLLECTION_VLOG_DICT_TRAINER", "")
+	if got := benchmarkValueLogDictTrainerMode(t); got != "enabled" {
+		t.Fatalf("default trainer mode=%q want enabled", got)
+	}
+	t.Setenv("TREEDB_COLLECTION_VLOG_DICT_TRAINER", "disabled")
+	if got := benchmarkValueLogDictTrainerMode(t); got != "disabled" {
+		t.Fatalf("disabled trainer mode=%q want disabled", got)
+	}
+}
+
+func TestApplyBenchmarkValueLogDictTrainerModeDisablesTraining(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileFast, t.TempDir())
+	if opts.ValueLog.DictTrain.TrainBytes < 0 {
+		t.Fatalf("fast profile unexpectedly disables dict training: %d", opts.ValueLog.DictTrain.TrainBytes)
+	}
+	t.Setenv("TREEDB_COLLECTION_VLOG_DICT_TRAINER", "disabled")
+	applyBenchmarkValueLogDictTrainerMode(t, &opts)
+	if got := opts.ValueLog.DictTrain.TrainBytes; got != -1 {
+		t.Fatalf("DictTrain.TrainBytes=%d want -1", got)
+	}
+}
+
 func openBenchmarkBackend(b *testing.B, dir string) (*backenddb.DB, func() error) {
 	b.Helper()
 
 	dataOuter, indexOuter := benchmarkCollectionStoragePolicy(b)
 	opts := treedb.OptionsFor(benchmarkTreeDBProfile(b), dir)
+	applyBenchmarkValueLogDictTrainerMode(b, &opts)
 	opts.IndexOuterLeavesInValueLog = dataOuter || indexOuter
 	opts.IndexInternalBaseDelta = !opts.IndexOuterLeavesInValueLog
 	if chunkSize := benchmarkInt64Env(b, "TREEDB_COLLECTION_CHUNK_SIZE", 0); chunkSize > 0 {

--- a/cmd/collection_bench_matrix_summary/main.go
+++ b/cmd/collection_bench_matrix_summary/main.go
@@ -25,6 +25,7 @@ type matrixRow struct {
 	IndexOuterLeavesInVLog string
 	PagerChunkSize         string
 	PagerSyncConcurrency   string
+	VLogDictTrainer        string
 	ReportMarkdownPath     string
 	ReportJSONPath         string
 }
@@ -179,6 +180,10 @@ func readMatrixIndex(path string) ([]matrixRow, error) {
 		if len(record) == 0 || strings.TrimSpace(record[0]) == "" {
 			continue
 		}
+		vlogDictTrainer := "unknown"
+		if idx, ok := header["vlog_dict_trainer"]; ok {
+			vlogDictTrainer = field(record, idx)
+		}
 		rows = append(rows, matrixRow{
 			Cell:                   field(record, header["cell"]),
 			Engine:                 field(record, header["engine"]),
@@ -186,6 +191,7 @@ func readMatrixIndex(path string) ([]matrixRow, error) {
 			IndexOuterLeavesInVLog: field(record, header["index_outer_leaves_in_vlog"]),
 			PagerChunkSize:         field(record, header["pager_chunk_size"]),
 			PagerSyncConcurrency:   field(record, header["pager_sync_concurrency"]),
+			VLogDictTrainer:        vlogDictTrainer,
 			ReportMarkdownPath:     field(record, header["report_md"]),
 			ReportJSONPath:         field(record, header["report_json"]),
 		})
@@ -281,7 +287,7 @@ func metricPtr(metrics map[string]float64, name string) *float64 {
 
 func renderTSV(rows []summaryRow) string {
 	var sb strings.Builder
-	sb.WriteString("cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tbenchmark\tns_per_op\tbytes_per_op\tallocs_per_op\tinsert_ns/doc\tsync_ns/doc\tper_item_key_probe_fallback_count\tper_item_prefix_probe_fallback_count\treport_md\n")
+	sb.WriteString("cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tvlog_dict_trainer\tbenchmark\tns_per_op\tbytes_per_op\tallocs_per_op\tinsert_ns/doc\tsync_ns/doc\tper_item_key_probe_fallback_count\tper_item_prefix_probe_fallback_count\treport_md\n")
 	for _, row := range rows {
 		sb.WriteString(row.Cell)
 		sb.WriteByte('\t')
@@ -294,6 +300,8 @@ func renderTSV(rows []summaryRow) string {
 		sb.WriteString(row.PagerChunkSize)
 		sb.WriteByte('\t')
 		sb.WriteString(row.PagerSyncConcurrency)
+		sb.WriteByte('\t')
+		sb.WriteString(row.VLogDictTrainer)
 		sb.WriteByte('\t')
 		sb.WriteString(row.Benchmark)
 		sb.WriteByte('\t')
@@ -319,7 +327,7 @@ func renderTSV(rows []summaryRow) string {
 
 func renderUserStoryTSV(rows []userStoryRow) string {
 	var sb strings.Builder
-	sb.WriteString("cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tstory\tbenchmark\tdocs_per_batch\tdocs_per_sec\tms_per_batch\tinsert_ms_per_batch\tsync_ms_per_batch\tbatches_per_sec\tns_per_doc\treport_md\n")
+	sb.WriteString("cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tvlog_dict_trainer\tstory\tbenchmark\tdocs_per_batch\tdocs_per_sec\tms_per_batch\tinsert_ms_per_batch\tsync_ms_per_batch\tbatches_per_sec\tns_per_doc\treport_md\n")
 	for _, row := range rows {
 		sb.WriteString(row.Cell)
 		sb.WriteByte('\t')
@@ -332,6 +340,8 @@ func renderUserStoryTSV(rows []userStoryRow) string {
 		sb.WriteString(row.PagerChunkSize)
 		sb.WriteByte('\t')
 		sb.WriteString(row.PagerSyncConcurrency)
+		sb.WriteByte('\t')
+		sb.WriteString(row.VLogDictTrainer)
 		sb.WriteByte('\t')
 		sb.WriteString(row.Story)
 		sb.WriteByte('\t')
@@ -386,8 +396,8 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 	if len(userStoryRows) > 0 {
 		sb.WriteString("## User-Facing Throughput\n\n")
 		sb.WriteString("Batch benchmark ops are documents, so this section reports the indexed ingest story as docs/sec, batch latency, and batches/sec. Diagnostic JSON/planner rows are separated below.\n\n")
-		sb.WriteString("| Cell | Engine | Data vlog | Index vlog | Pager chunk | Pager sync | Story | Docs/batch | Docs/sec | ms/batch | insert ms/batch | sync ms/batch | batches/sec | ns/doc | Report |\n")
-		sb.WriteString("| --- | --- | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
+		sb.WriteString("| Cell | Engine | Data vlog | Index vlog | Pager chunk | Pager sync | VLog dict trainer | Story | Docs/batch | Docs/sec | ms/batch | insert ms/batch | sync ms/batch | batches/sec | ns/doc | Report |\n")
+		sb.WriteString("| --- | --- | ---: | ---: | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
 		for _, row := range userStoryRows {
 			reportPath := relativeReportPath(outDir, row.ReportMarkdownPath)
 			sb.WriteString("| `")
@@ -404,6 +414,9 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 			sb.WriteString("` | ")
 			sb.WriteString("`")
 			sb.WriteString(escapeTableCell(row.PagerSyncConcurrency))
+			sb.WriteString("` | ")
+			sb.WriteString("`")
+			sb.WriteString(escapeTableCell(row.VLogDictTrainer))
 			sb.WriteString("` | ")
 			sb.WriteString(escapeTableCell(row.Story))
 			sb.WriteString(" | ")
@@ -430,8 +443,8 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 	if len(diagnosticRows) > 0 {
 		sb.WriteString("## Diagnostic Rows\n\n")
 		sb.WriteString("These rows are not user stories. They isolate JSON/data extraction and non-JSON planner cost so future optimization can quarantine JSON work separately from TreeDB publish/index maintenance.\n\n")
-		sb.WriteString("| Cell | Engine | Pager chunk | Pager sync | Diagnostic | ns/doc | B/doc | allocs/doc | Report |\n")
-		sb.WriteString("| --- | --- | --- | --- | --- | ---: | ---: | ---: | --- |\n")
+		sb.WriteString("| Cell | Engine | Pager chunk | Pager sync | VLog dict trainer | Diagnostic | ns/doc | B/doc | allocs/doc | Report |\n")
+		sb.WriteString("| --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- |\n")
 		for _, row := range diagnosticRows {
 			reportPath := relativeReportPath(outDir, row.ReportMarkdownPath)
 			sb.WriteString("| `")
@@ -442,6 +455,8 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 			sb.WriteString(escapeTableCell(row.PagerChunkSize))
 			sb.WriteString("` | `")
 			sb.WriteString(escapeTableCell(row.PagerSyncConcurrency))
+			sb.WriteString("` | `")
+			sb.WriteString(escapeTableCell(row.VLogDictTrainer))
 			sb.WriteString("` | `")
 			sb.WriteString(escapeTableCell(row.Benchmark))
 			sb.WriteString("` | ")
@@ -457,8 +472,8 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 		sb.WriteString("\n")
 	}
 	sb.WriteString("## Raw Matrix\n\n")
-	sb.WriteString("| Cell | Engine | Data vlog | Index vlog | Pager chunk | Pager sync | Benchmark | ns/op | B/op | allocs/op | insert ns/doc | sync ns/doc | Key fallbacks | Prefix fallbacks | Report |\n")
-	sb.WriteString("| --- | --- | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
+	sb.WriteString("| Cell | Engine | Data vlog | Index vlog | Pager chunk | Pager sync | VLog dict trainer | Benchmark | ns/op | B/op | allocs/op | insert ns/doc | sync ns/doc | Key fallbacks | Prefix fallbacks | Report |\n")
+	sb.WriteString("| --- | --- | ---: | ---: | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
 	for _, row := range rows {
 		reportPath := relativeReportPath(outDir, row.ReportMarkdownPath)
 		sb.WriteString("| `")
@@ -473,6 +488,8 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 		sb.WriteString(escapeTableCell(row.PagerChunkSize))
 		sb.WriteString("` | `")
 		sb.WriteString(escapeTableCell(row.PagerSyncConcurrency))
+		sb.WriteString("` | `")
+		sb.WriteString(escapeTableCell(row.VLogDictTrainer))
 		sb.WriteString("` | `")
 		sb.WriteString(escapeTableCell(row.Benchmark))
 		sb.WriteString("` | ")

--- a/cmd/collection_bench_matrix_summary/main.go
+++ b/cmd/collection_bench_matrix_summary/main.go
@@ -180,21 +180,24 @@ func readMatrixIndex(path string) ([]matrixRow, error) {
 		if len(record) == 0 || strings.TrimSpace(record[0]) == "" {
 			continue
 		}
-		vlogDictTrainer := "enabled"
-		if idx, ok := header["vlog_dict_trainer"]; ok {
-			vlogDictTrainer = field(record, idx)
-		}
-		rows = append(rows, matrixRow{
+		row := matrixRow{
 			Cell:                   field(record, header["cell"]),
 			Engine:                 field(record, header["engine"]),
 			DataOuterLeavesInVLog:  field(record, header["data_outer_leaves_in_vlog"]),
 			IndexOuterLeavesInVLog: field(record, header["index_outer_leaves_in_vlog"]),
 			PagerChunkSize:         field(record, header["pager_chunk_size"]),
 			PagerSyncConcurrency:   field(record, header["pager_sync_concurrency"]),
-			VLogDictTrainer:        vlogDictTrainer,
 			ReportMarkdownPath:     field(record, header["report_md"]),
 			ReportJSONPath:         field(record, header["report_json"]),
-		})
+		}
+		if idx, ok := header["vlog_dict_trainer"]; ok {
+			row.VLogDictTrainer = field(record, idx)
+		} else if isSQLiteMatrixRow(row) {
+			row.VLogDictTrainer = "-"
+		} else {
+			row.VLogDictTrainer = "enabled"
+		}
+		rows = append(rows, row)
 	}
 	return rows, nil
 }

--- a/cmd/collection_bench_matrix_summary/main.go
+++ b/cmd/collection_bench_matrix_summary/main.go
@@ -180,7 +180,7 @@ func readMatrixIndex(path string) ([]matrixRow, error) {
 		if len(record) == 0 || strings.TrimSpace(record[0]) == "" {
 			continue
 		}
-		vlogDictTrainer := "unknown"
+		vlogDictTrainer := "enabled"
 		if idx, ok := header["vlog_dict_trainer"]; ok {
 			vlogDictTrainer = field(record, idx)
 		}

--- a/cmd/collection_bench_matrix_summary/main_test.go
+++ b/cmd/collection_bench_matrix_summary/main_test.go
@@ -190,6 +190,34 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 	}
 }
 
+func TestReadMatrixIndexDefaultsLegacyTrainerColumn(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(dir, "matrix_index.tsv")
+	index := strings.Join([]string{
+		"cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\treport_md\treport_json\tcpu_profile\tmem_profile",
+		"production_fast_data_vlog_index_leaf\tproduction_fast\ttrue\tfalse\tprofile/default\tprofile/default\t/treedb.md\t/treedb.json\t/cpu.pprof\t/mem.pprof",
+		"sqlite_wal_custom\twal_custom\t-\t-\t-\t-\t/sqlite.md\t/sqlite.json\t/sqlite-cpu.pprof\t/sqlite-mem.pprof",
+		"",
+	}, "\n")
+	if err := os.WriteFile(indexPath, []byte(index), 0o644); err != nil {
+		t.Fatalf("write matrix index: %v", err)
+	}
+
+	rows, err := readMatrixIndex(indexPath)
+	if err != nil {
+		t.Fatalf("read matrix index: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows=%d want 2", len(rows))
+	}
+	if rows[0].VLogDictTrainer != "enabled" {
+		t.Fatalf("treedb legacy trainer default=%q want enabled", rows[0].VLogDictTrainer)
+	}
+	if rows[1].VLogDictTrainer != "-" {
+		t.Fatalf("sqlite legacy trainer default=%q want -", rows[1].VLogDictTrainer)
+	}
+}
+
 func TestMatrixSummaryFailsOnUnavailableReport(t *testing.T) {
 	dir := t.TempDir()
 	cellDir := filepath.Join(dir, "production_fast_data_vlog_index_leaf")

--- a/cmd/collection_bench_matrix_summary/main_test.go
+++ b/cmd/collection_bench_matrix_summary/main_test.go
@@ -107,9 +107,9 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 	}
 	indexPath := filepath.Join(dir, "matrix_index.tsv")
 	index := strings.Join([]string{
-		"cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\treport_md\treport_json\tcpu_profile\tmem_profile",
-		"production_fast_data_vlog_index_leaf\tproduction_fast\ttrue\tfalse\tprofile/default\tprofile/default\t" + reportMarkdown + "\t" + reportJSON + "\t/cpu.pprof\t/mem.pprof",
-		sqliteCell + "\twal_custom\t-\t-\t-\t-\t" + sqliteReportMarkdown + "\t" + sqliteReportJSON + "\t/sqlite-cpu.pprof\t/sqlite-mem.pprof",
+		"cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tvlog_dict_trainer\treport_md\treport_json\tcpu_profile\tmem_profile",
+		"production_fast_data_vlog_index_leaf\tproduction_fast\ttrue\tfalse\tprofile/default\tprofile/default\tenabled\t" + reportMarkdown + "\t" + reportJSON + "\t/cpu.pprof\t/mem.pprof",
+		sqliteCell + "\twal_custom\t-\t-\t-\t-\t-\t" + sqliteReportMarkdown + "\t" + sqliteReportJSON + "\t/sqlite-cpu.pprof\t/sqlite-mem.pprof",
 		"",
 	}, "\n")
 	if err := os.WriteFile(indexPath, []byte(index), 0o644); err != nil {
@@ -134,7 +134,9 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 		"sync ms/batch",
 		"Pager chunk",
 		"Pager sync",
+		"VLog dict trainer",
 		"`profile/default`",
+		"`enabled`",
 		"64",
 		"44",
 		"44.44",
@@ -160,13 +162,13 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 		t.Fatalf("read tsv: %v", err)
 	}
 	gotTSV := string(tsv)
-	if !strings.Contains(gotTSV, "profile/default\tprofile/default\tBenchmarkCollectionInsertBatchWithSecondaryIndexes\t2812.5\t1980\t30\t-\t-\t0\t0\t") {
+	if !strings.Contains(gotTSV, "profile/default\tprofile/default\tenabled\tBenchmarkCollectionInsertBatchWithSecondaryIndexes\t2812.5\t1980\t30\t-\t-\t0\t0\t") {
 		t.Fatalf("tsv missing raw numeric row:\n%s", gotTSV)
 	}
-	if !strings.Contains(gotTSV, "-\t-\tBenchmarkSQLiteInsertBatchWithSecondaryIndexes\t4100\t2048\t32\t-\t-\t") {
+	if !strings.Contains(gotTSV, "-\t-\t-\tBenchmarkSQLiteInsertBatchWithSecondaryIndexes\t4100\t2048\t32\t-\t-\t") {
 		t.Fatalf("tsv missing sqlite numeric row:\n%s", gotTSV)
 	}
-	if !strings.Contains(gotTSV, "profile/default\tprofile/default\tBenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes\t8000\t2000\t30\t2500\t5500\t0\t0\t") {
+	if !strings.Contains(gotTSV, "profile/default\tprofile/default\tenabled\tBenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes\t8000\t2000\t30\t2500\t5500\t0\t0\t") {
 		t.Fatalf("tsv missing checkpoint split row:\n%s", gotTSV)
 	}
 	if strings.Contains(gotTSV, "2,812") {
@@ -177,13 +179,13 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 		t.Fatalf("read user story tsv: %v", err)
 	}
 	gotUserStoryTSV := string(userStoryTSV)
-	if !strings.Contains(gotUserStoryTSV, "profile/default\tprofile/default\tbulk indexed insert\tBenchmarkCollectionInsertBatchWithSecondaryIndexes\t8000\t355555.55555555556\t22.5\t-\t-\t44.44444444444444\t2812.5\t") {
+	if !strings.Contains(gotUserStoryTSV, "profile/default\tprofile/default\tenabled\tbulk indexed insert\tBenchmarkCollectionInsertBatchWithSecondaryIndexes\t8000\t355555.55555555556\t22.5\t-\t-\t44.44444444444444\t2812.5\t") {
 		t.Fatalf("user story tsv missing collection throughput row:\n%s", gotUserStoryTSV)
 	}
-	if !strings.Contains(gotUserStoryTSV, "profile/default\tprofile/default\tcheckpointed indexed insert\tBenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes\t8000\t125000\t64\t20\t44\t15.625\t8000\t") {
+	if !strings.Contains(gotUserStoryTSV, "profile/default\tprofile/default\tenabled\tcheckpointed indexed insert\tBenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes\t8000\t125000\t64\t20\t44\t15.625\t8000\t") {
 		t.Fatalf("user story tsv missing checkpoint split row:\n%s", gotUserStoryTSV)
 	}
-	if !strings.Contains(gotUserStoryTSV, "-\t-\tbulk indexed insert\tBenchmarkSQLiteInsertBatchWithSecondaryIndexes\t8000\t243902.43902439025\t32.8\t-\t-\t30.48780487804878\t4100\t") {
+	if !strings.Contains(gotUserStoryTSV, "-\t-\t-\tbulk indexed insert\tBenchmarkSQLiteInsertBatchWithSecondaryIndexes\t8000\t243902.43902439025\t32.8\t-\t-\t30.48780487804878\t4100\t") {
 		t.Fatalf("user story tsv missing sqlite throughput row:\n%s", gotUserStoryTSV)
 	}
 }
@@ -208,8 +210,8 @@ func TestMatrixSummaryFailsOnUnavailableReport(t *testing.T) {
 	}
 	indexPath := filepath.Join(dir, "matrix_index.tsv")
 	index := strings.Join([]string{
-		"cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\treport_md\treport_json\tcpu_profile\tmem_profile",
-		"production_fast_data_vlog_index_leaf\tproduction_fast\ttrue\tfalse\tprofile/default\tprofile/default\t" + reportMarkdown + "\t" + reportJSON + "\t/cpu.pprof\t/mem.pprof",
+		"cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tvlog_dict_trainer\treport_md\treport_json\tcpu_profile\tmem_profile",
+		"production_fast_data_vlog_index_leaf\tproduction_fast\ttrue\tfalse\tprofile/default\tprofile/default\tenabled\t" + reportMarkdown + "\t" + reportJSON + "\t/cpu.pprof\t/mem.pprof",
 		"",
 	}, "\n")
 	if err := os.WriteFile(indexPath, []byte(index), 0o644); err != nil {
@@ -255,8 +257,8 @@ func TestMatrixSummaryFailsOnMissingExpectedBenchmark(t *testing.T) {
 	}
 	indexPath := filepath.Join(dir, "matrix_index.tsv")
 	index := strings.Join([]string{
-		"cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\treport_md\treport_json\tcpu_profile\tmem_profile",
-		"production_fast_data_vlog_index_leaf\tproduction_fast\ttrue\tfalse\tprofile/default\tprofile/default\t" + reportMarkdown + "\t" + reportJSON + "\t/cpu.pprof\t/mem.pprof",
+		"cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tvlog_dict_trainer\treport_md\treport_json\tcpu_profile\tmem_profile",
+		"production_fast_data_vlog_index_leaf\tproduction_fast\ttrue\tfalse\tprofile/default\tprofile/default\tenabled\t" + reportMarkdown + "\t" + reportJSON + "\t/cpu.pprof\t/mem.pprof",
 		"",
 	}, "\n")
 	if err := os.WriteFile(indexPath, []byte(index), 0o644); err != nil {

--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -34,6 +34,7 @@ type config struct {
 	storagePolicy        string
 	pagerChunkSize       string
 	pagerSyncConcurrency string
+	vlogDictTrainer      string
 	collectionBatchSize  int
 	unavailableReason    string
 }
@@ -87,6 +88,7 @@ type report struct {
 	StoragePolicy        string          `json:"storage_policy,omitempty"`
 	PagerChunkSize       string          `json:"pager_chunk_size,omitempty"`
 	PagerSyncConcurrency string          `json:"pager_sync_concurrency,omitempty"`
+	VLogDictTrainer      string          `json:"vlog_dict_trainer,omitempty"`
 	Worktree             string          `json:"worktree,omitempty"`
 	Branch               string          `json:"branch,omitempty"`
 	Commit               string          `json:"commit,omitempty"`
@@ -195,6 +197,7 @@ func parseFlagsFrom(args []string) (config, error) {
 	fs.StringVar(&cfg.storagePolicy, "storage-policy", "", "Optional collection root storage-policy label to include in report metadata")
 	fs.StringVar(&cfg.pagerChunkSize, "pager-chunk-size", "", "Optional pager chunk size label to include in report metadata")
 	fs.StringVar(&cfg.pagerSyncConcurrency, "pager-sync-concurrency", "", "Optional pager sync concurrency label to include in report metadata")
+	fs.StringVar(&cfg.vlogDictTrainer, "vlog-dict-trainer", "", "Optional value-log dict trainer label to include in report metadata")
 	fs.IntVar(&cfg.collectionBatchSize, "collection-batch-size", 0, "Optional collection benchmark batch size to include in report metadata")
 	fs.StringVar(&cfg.unavailableReason, "unavailable-reason", "", "Emit an explicit unavailable report instead of parsing benchmark input")
 	if err := fs.Parse(args); err != nil {
@@ -233,6 +236,7 @@ func buildReport(cfg config) (*report, error) {
 			StoragePolicy:        cfg.storagePolicy,
 			PagerChunkSize:       cfg.pagerChunkSize,
 			PagerSyncConcurrency: cfg.pagerSyncConcurrency,
+			VLogDictTrainer:      cfg.vlogDictTrainer,
 			Worktree:             cfg.worktree,
 			Branch:               cfg.branch,
 			Commit:               cfg.commit,
@@ -268,6 +272,7 @@ func buildReport(cfg config) (*report, error) {
 		StoragePolicy:        cfg.storagePolicy,
 		PagerChunkSize:       cfg.pagerChunkSize,
 		PagerSyncConcurrency: cfg.pagerSyncConcurrency,
+		VLogDictTrainer:      cfg.vlogDictTrainer,
 		Worktree:             cfg.worktree,
 		Branch:               cfg.branch,
 		Commit:               cfg.commit,
@@ -520,6 +525,9 @@ func renderMarkdown(rep *report) string {
 	}
 	if rep.PagerSyncConcurrency != "" {
 		sb.WriteString(fmt.Sprintf("- pager sync concurrency: `%s`\n", rep.PagerSyncConcurrency))
+	}
+	if rep.VLogDictTrainer != "" {
+		sb.WriteString(fmt.Sprintf("- value-log dict trainer: `%s`\n", rep.VLogDictTrainer))
 	}
 	if rep.Worktree != "" {
 		sb.WriteString(fmt.Sprintf("- worktree: `%s`\n", rep.Worktree))

--- a/cmd/collection_bench_report/main_test.go
+++ b/cmd/collection_bench_report/main_test.go
@@ -116,6 +116,7 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 		StoragePolicy:        "data_outer=true,index_outer=false",
 		PagerChunkSize:       "profile/default",
 		PagerSyncConcurrency: "profile/default",
+		VLogDictTrainer:      "enabled",
 		Worktree:             "/tmp/oracle",
 		Branch:               "pr/oracle",
 		Commit:               "deadbeef",
@@ -141,6 +142,9 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	}
 	if !strings.Contains(md, "- pager sync concurrency: `profile/default`") {
 		t.Fatalf("markdown missing pager sync concurrency:\n%s", md)
+	}
+	if !strings.Contains(md, "- value-log dict trainer: `enabled`") {
+		t.Fatalf("markdown missing value-log dict trainer:\n%s", md)
 	}
 	if !strings.Contains(md, "## Document Path") {
 		t.Fatalf("markdown missing document section:\n%s", md)

--- a/scripts/bench_collections_matrix.sh
+++ b/scripts/bench_collections_matrix.sh
@@ -18,6 +18,8 @@ if [[ "$PAGER_SYNC_CONCURRENCY" == "0" ]]; then
   PAGER_SYNC_CONCURRENCY=""
 fi
 PAGER_SYNC_CONCURRENCY_LABEL="${PAGER_SYNC_CONCURRENCY:-profile/default}"
+VLOG_DICT_TRAINER="$(printf '%s' "${TREEDB_COLLECTION_VLOG_DICT_TRAINER:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+VLOG_DICT_TRAINER_LABEL="${VLOG_DICT_TRAINER:-enabled}"
 BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertBatchWithSecondaryIndexes|CollectionInsertBatchCheckpointWithSecondaryIndexes|CollectionOverheadIndexStateJSONExtraction|CollectionOverheadPlanIndexedPrecomputedState)$}"
 INCLUDE_SQLITE="${TREEDB_COLLECTION_INCLUDE_SQLITE:-false}"
 SQLITE_ENGINE="${TREEDB_COLLECTION_SQLITE_ENGINE:-sqlite_wal_normal}"
@@ -87,8 +89,16 @@ case "$MATRIX" in
       PATH_LABEL="sqlite"
     fi
     ;;
+  trainer)
+    MATRIX_ROWS=(
+      "production_fast_data_vlog_index_leaf_trainer_enabled production_fast true false enabled"
+      "production_fast_data_vlog_index_leaf_trainer_disabled production_fast true false disabled"
+      "production_fast_data_vlog_index_vlog_trainer_enabled production_fast true true enabled"
+      "production_fast_data_vlog_index_vlog_trainer_disabled production_fast true true disabled"
+    )
+    ;;
   *)
-    echo "unknown TREEDB_COLLECTION_MATRIX=$MATRIX (want production, full, quick, or sqlite)" >&2
+    echo "unknown TREEDB_COLLECTION_MATRIX=$MATRIX (want production, full, quick, trainer, or sqlite)" >&2
     exit 2
     ;;
 esac
@@ -98,8 +108,8 @@ INDEX_TSV="$OUT_DIR/matrix_index.tsv"
 PROFILE_INDEX_TSV="$OUT_DIR/profile_index.tsv"
 SUMMARY_MD="$OUT_DIR/README.md"
 
-printf "cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\treport_md\treport_json\tcpu_profile\tmem_profile\n" >"$INDEX_TSV"
-printf "cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tbenchmark\tcpu_profile_mode\treport_md\treport_json\tcpu_profile\tmem_profile\tcpu_top\tmem_top\n" >"$PROFILE_INDEX_TSV"
+printf "cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tvlog_dict_trainer\treport_md\treport_json\tcpu_profile\tmem_profile\n" >"$INDEX_TSV"
+printf "cell\tengine\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tvlog_dict_trainer\tbenchmark\tcpu_profile_mode\treport_md\treport_json\tcpu_profile\tmem_profile\tcpu_top\tmem_top\n" >"$PROFILE_INDEX_TSV"
 
 echo "running collections benchmark matrix into: $OUT_DIR"
 echo "matrix: $MATRIX"
@@ -110,6 +120,7 @@ echo "benchmark time: $BENCHTIME"
 echo "batch size: $BATCH_SIZE"
 echo "pager chunk size: $CHUNK_SIZE_LABEL"
 echo "pager sync concurrency: $PAGER_SYNC_CONCURRENCY_LABEL"
+echo "value-log dict trainer: $VLOG_DICT_TRAINER_LABEL"
 echo "profile bench captures: $PROFILE_BENCHES"
 if is_true "$PROFILE_BENCHES"; then
   echo "profile benchmark list: $PROFILE_BENCH_LIST"
@@ -148,9 +159,13 @@ run_profile_benches() {
   local go_tags=${7:-}
   local cgo_enabled=${8:-}
   local pager_sync_concurrency_label=${9:-$PAGER_SYNC_CONCURRENCY_LABEL}
+  local trainer_label=${10:-$VLOG_DICT_TRAINER_LABEL}
   local pager_chunk_size_label="$CHUNK_SIZE_LABEL"
+  local trainer_env="$trainer_label"
   if [[ "$pager_sync_concurrency_label" == "-" ]]; then
     pager_chunk_size_label="-"
+    trainer_label="-"
+    trainer_env=""
   fi
   local benches=()
 
@@ -172,6 +187,7 @@ run_profile_benches() {
       "TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=$data_outer"
       "TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=$index_outer"
       "TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY=$PAGER_SYNC_CONCURRENCY"
+      "TREEDB_COLLECTION_VLOG_DICT_TRAINER=$trainer_env"
     )
     if [[ -n "$go_tags" ]]; then
       env_args+=("GO_TEST_TAGS=$go_tags")
@@ -183,13 +199,14 @@ run_profile_benches() {
     echo "==> $cell profile $bench"
     env "${env_args[@]}" scripts/bench_collections_report.sh
 
-    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
       "$cell" \
       "$engine" \
       "$data_outer" \
       "$index_outer" \
       "$pager_chunk_size_label" \
       "$pager_sync_concurrency_label" \
+      "$trainer_label" \
       "$bench" \
       "whole_go_test_process" \
       "$profile_dir/collections_report.md" \
@@ -208,7 +225,12 @@ run_timed_profile_benches() {
   local index_outer=$4
   local path_label=$5
   local bench_list=$6
+  local trainer_label=${7:-$VLOG_DICT_TRAINER_LABEL}
+  local trainer_env="$trainer_label"
   local benches=()
+  if [[ "$trainer_label" == "-" ]]; then
+    trainer_env=""
+  fi
 
   read -r -a benches <<<"$bench_list"
   for bench in "${benches[@]}"; do
@@ -229,18 +251,20 @@ run_timed_profile_benches() {
       "TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=$data_outer"
       "TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=$index_outer"
       "TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY=$PAGER_SYNC_CONCURRENCY"
+      "TREEDB_COLLECTION_VLOG_DICT_TRAINER=$trainer_env"
     )
     echo
     echo "==> $cell timed CPU profile $bench"
     env "${env_args[@]}" scripts/bench_collections_report.sh
 
-    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
       "$cell" \
       "$engine" \
       "$data_outer" \
       "$index_outer" \
       "$CHUNK_SIZE_LABEL" \
       "$PAGER_SYNC_CONCURRENCY_LABEL" \
+      "$trainer_label" \
       "$bench" \
       "timed_benchmark_window" \
       "$profile_dir/collections_report.md" \
@@ -253,7 +277,8 @@ run_timed_profile_benches() {
 }
 
 for row in "${MATRIX_ROWS[@]}"; do
-  read -r cell engine data_outer index_outer <<<"$row"
+  read -r cell engine data_outer index_outer row_trainer <<<"$row"
+  row_trainer="${row_trainer:-$VLOG_DICT_TRAINER_LABEL}"
   cell_dir="$OUT_DIR/$cell"
   echo
   echo "==> $cell"
@@ -268,25 +293,27 @@ for row in "${MATRIX_ROWS[@]}"; do
     TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$data_outer" \
     TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$index_outer" \
     TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY="$PAGER_SYNC_CONCURRENCY" \
+    TREEDB_COLLECTION_VLOG_DICT_TRAINER="$row_trainer" \
     scripts/bench_collections_report.sh
 
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
     "$cell" \
     "$engine" \
     "$data_outer" \
     "$index_outer" \
     "$CHUNK_SIZE_LABEL" \
     "$PAGER_SYNC_CONCURRENCY_LABEL" \
+    "$row_trainer" \
     "$cell_dir/collections_report.md" \
     "$cell_dir/collections_report.json" \
     "$cell_dir/collections_cpu.pprof" \
     "$cell_dir/collections_mem.pprof" >>"$INDEX_TSV"
 
   if is_true "$PROFILE_BENCHES"; then
-    run_profile_benches "$cell" "$engine" "$data_outer" "$index_outer" "$PATH_LABEL" "$PROFILE_BENCH_LIST"
+    run_profile_benches "$cell" "$engine" "$data_outer" "$index_outer" "$PATH_LABEL" "$PROFILE_BENCH_LIST" "" "" "$PAGER_SYNC_CONCURRENCY_LABEL" "$row_trainer"
   fi
   if is_true "$TIMED_PROFILE_BENCHES"; then
-    run_timed_profile_benches "$cell" "$engine" "$data_outer" "$index_outer" "$PATH_LABEL" "$TIMED_PROFILE_BENCH_LIST"
+    run_timed_profile_benches "$cell" "$engine" "$data_outer" "$index_outer" "$PATH_LABEL" "$TIMED_PROFILE_BENCH_LIST" "$row_trainer"
   fi
 done
 
@@ -306,13 +333,15 @@ if is_true "$INCLUDE_SQLITE"; then
     TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="-" \
     TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="-" \
     TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY="" \
+    TREEDB_COLLECTION_VLOG_DICT_TRAINER="" \
     GO_TEST_TAGS="sqlite_bench" \
     CGO_ENABLED="$SQLITE_CGO_ENABLED" \
     scripts/bench_collections_report.sh
 
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
     "$cell" \
     "$SQLITE_ENGINE" \
+    "-" \
     "-" \
     "-" \
     "-" \
@@ -323,7 +352,7 @@ if is_true "$INCLUDE_SQLITE"; then
     "$cell_dir/collections_mem.pprof" >>"$INDEX_TSV"
 
   if is_true "$PROFILE_BENCHES"; then
-    run_profile_benches "$cell" "$SQLITE_ENGINE" "-" "-" "sqlite" "$SQLITE_PROFILE_BENCH_LIST" "sqlite_bench" "$SQLITE_CGO_ENABLED" "-"
+    run_profile_benches "$cell" "$SQLITE_ENGINE" "-" "-" "sqlite" "$SQLITE_PROFILE_BENCH_LIST" "sqlite_bench" "$SQLITE_CGO_ENABLED" "-" "-"
   fi
 fi
 
@@ -346,6 +375,7 @@ cat >"$SUMMARY_MD" <<EOF
 - collection batch size: \`$BATCH_SIZE\`
 - pager chunk size: \`$CHUNK_SIZE_LABEL\`
 - pager sync concurrency: \`$PAGER_SYNC_CONCURRENCY_LABEL\`
+- value-log dict trainer: \`$VLOG_DICT_TRAINER_LABEL\`
 - focused profile captures: \`$PROFILE_BENCHES\`
 - focused profile count: \`$PROFILE_COUNT\`
 - focused profile benchmark time: \`$PROFILE_BENCHTIME\`
@@ -362,25 +392,28 @@ cat >"$SUMMARY_MD" <<EOF
 
 ## Cells
 
-| Cell | Engine | Data outer leaves in vlog | Index outer leaves in vlog | Report |
-| --- | --- | --- | --- | --- |
+| Cell | Engine | Data outer leaves in vlog | Index outer leaves in vlog | VLog dict trainer | Report |
+| --- | --- | --- | --- | --- | --- |
 EOF
 
 for row in "${MATRIX_ROWS[@]}"; do
-  read -r cell engine data_outer index_outer <<<"$row"
-  printf "| \`%s\` | \`%s\` | \`%s\` | \`%s\` | [%s](%s) |\n" \
+  read -r cell engine data_outer index_outer row_trainer <<<"$row"
+  row_trainer="${row_trainer:-$VLOG_DICT_TRAINER_LABEL}"
+  printf "| \`%s\` | \`%s\` | \`%s\` | \`%s\` | \`%s\` | [%s](%s) |\n" \
     "$cell" \
     "$engine" \
     "$data_outer" \
     "$index_outer" \
+    "$row_trainer" \
     "$cell" \
     "$cell/collections_report.md" >>"$SUMMARY_MD"
 done
 
 if is_true "$INCLUDE_SQLITE"; then
-  printf "| \`%s\` | \`%s\` | \`%s\` | \`%s\` | [%s](%s) |\n" \
+  printf "| \`%s\` | \`%s\` | \`%s\` | \`%s\` | \`%s\` | [%s](%s) |\n" \
     "$SQLITE_CELL" \
     "$SQLITE_ENGINE" \
+    "-" \
     "-" \
     "-" \
     "$SQLITE_CELL" \
@@ -398,6 +431,8 @@ The focused default benchmark set keeps JSON extraction overhead, non-JSON index
 Set `TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY=N` to compare pager sync parallelism on checkpoint-heavy rows. Leaving it unset uses the selected TreeDB profile default.
 
 Set `TREEDB_COLLECTION_CHUNK_SIZE=N` to compare pager mmap chunk-size granularity on checkpoint-heavy rows. Leaving it unset uses the selected TreeDB profile/default chunk size. This is useful when the checkpoint split points at dirty-page `msync` cost rather than JSON extraction or collection planning.
+
+Set `TREEDB_COLLECTION_MATRIX=trainer` to run paired production-fast cells with value-log dictionary training enabled and disabled. The disabled cells pass `TREEDB_COLLECTION_VLOG_DICT_TRAINER=disabled`, which leaves the profile's value-log compression policy intact but sets `ValueLog.DictTrain.TrainBytes=-1` so background trainer allocation pressure can be evaluated separately from JSON extraction and collection planner cost.
 
 Set `TREEDB_COLLECTION_PROFILE_BENCHES=true` to add per-benchmark profile bundles for indexed ingest and checkpointed indexed ingest. `profile_index.tsv` lists the report, CPU profile mode, CPU profile, allocation profile, and pprof top files for each focused capture. These `go test` profiles cover the whole benchmark process; timed benchmark rows remain the source of truth, and pprof top output should be read as coarse attribution because setup or off-timer document generation can appear.
 

--- a/scripts/bench_collections_matrix.sh
+++ b/scripts/bench_collections_matrix.sh
@@ -18,8 +18,21 @@ if [[ "$PAGER_SYNC_CONCURRENCY" == "0" ]]; then
   PAGER_SYNC_CONCURRENCY=""
 fi
 PAGER_SYNC_CONCURRENCY_LABEL="${PAGER_SYNC_CONCURRENCY:-profile/default}"
-VLOG_DICT_TRAINER="$(printf '%s' "${TREEDB_COLLECTION_VLOG_DICT_TRAINER:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-VLOG_DICT_TRAINER_LABEL="${VLOG_DICT_TRAINER:-enabled}"
+VLOG_DICT_TRAINER_RAW="$(printf '%s' "${TREEDB_COLLECTION_VLOG_DICT_TRAINER:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+case "$(printf '%s' "$VLOG_DICT_TRAINER_RAW" | tr '[:upper:]' '[:lower:]')" in
+  ""|default|profile/default|enabled|on|true|1)
+    VLOG_DICT_TRAINER="enabled"
+    VLOG_DICT_TRAINER_LABEL="enabled"
+    ;;
+  disabled|off|false|0)
+    VLOG_DICT_TRAINER="disabled"
+    VLOG_DICT_TRAINER_LABEL="disabled"
+    ;;
+  *)
+    VLOG_DICT_TRAINER="$VLOG_DICT_TRAINER_RAW"
+    VLOG_DICT_TRAINER_LABEL="$VLOG_DICT_TRAINER_RAW"
+    ;;
+esac
 BENCH_REGEX="${BENCH_REGEX:-Benchmark(CollectionInsertBatchWithSecondaryIndexes|CollectionInsertBatchCheckpointWithSecondaryIndexes|CollectionOverheadIndexStateJSONExtraction|CollectionOverheadPlanIndexedPrecomputedState)$}"
 INCLUDE_SQLITE="${TREEDB_COLLECTION_INCLUDE_SQLITE:-false}"
 SQLITE_ENGINE="${TREEDB_COLLECTION_SQLITE_ENGINE:-sqlite_wal_normal}"
@@ -120,7 +133,11 @@ echo "benchmark time: $BENCHTIME"
 echo "batch size: $BATCH_SIZE"
 echo "pager chunk size: $CHUNK_SIZE_LABEL"
 echo "pager sync concurrency: $PAGER_SYNC_CONCURRENCY_LABEL"
-echo "value-log dict trainer: $VLOG_DICT_TRAINER_LABEL"
+if [[ "$MATRIX" == "trainer" ]]; then
+  echo "default value-log dict trainer: mixed(enabled,disabled)"
+else
+  echo "default value-log dict trainer: $VLOG_DICT_TRAINER_LABEL"
+fi
 echo "profile bench captures: $PROFILE_BENCHES"
 if is_true "$PROFILE_BENCHES"; then
   echo "profile benchmark list: $PROFILE_BENCH_LIST"
@@ -375,7 +392,7 @@ cat >"$SUMMARY_MD" <<EOF
 - collection batch size: \`$BATCH_SIZE\`
 - pager chunk size: \`$CHUNK_SIZE_LABEL\`
 - pager sync concurrency: \`$PAGER_SYNC_CONCURRENCY_LABEL\`
-- value-log dict trainer: \`$VLOG_DICT_TRAINER_LABEL\`
+- default value-log dict trainer: \`$(if [[ "$MATRIX" == "trainer" ]]; then echo "mixed(enabled,disabled)"; else echo "$VLOG_DICT_TRAINER_LABEL"; fi)\`
 - focused profile captures: \`$PROFILE_BENCHES\`
 - focused profile count: \`$PROFILE_COUNT\`
 - focused profile benchmark time: \`$PROFILE_BENCHTIME\`

--- a/scripts/bench_collections_report.sh
+++ b/scripts/bench_collections_report.sh
@@ -19,9 +19,12 @@ if [[ "$PAGER_SYNC_CONCURRENCY" == "0" ]]; then
   PAGER_SYNC_CONCURRENCY=""
 fi
 PAGER_SYNC_CONCURRENCY_LABEL="${PAGER_SYNC_CONCURRENCY:-profile/default}"
+VLOG_DICT_TRAINER="$(printf '%s' "${TREEDB_COLLECTION_VLOG_DICT_TRAINER:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+VLOG_DICT_TRAINER_LABEL="${VLOG_DICT_TRAINER:-enabled}"
 if [[ "$DATA_OUTER" == "-" && "$INDEX_OUTER" == "-" ]]; then
   CHUNK_SIZE_LABEL="-"
   PAGER_SYNC_CONCURRENCY_LABEL="-"
+  VLOG_DICT_TRAINER_LABEL="-"
 fi
 GO_TEST_TAGS="${GO_TEST_TAGS:-}"
 TIMED_CPU_PROFILE="${TREEDB_COLLECTION_TIMED_CPU_PROFILE:-false}"
@@ -98,6 +101,7 @@ echo "collection batch size: $BATCH_SIZE"
 echo "storage policy: $STORAGE_POLICY_LABEL"
 echo "pager chunk size: $CHUNK_SIZE_LABEL"
 echo "pager sync concurrency: $PAGER_SYNC_CONCURRENCY_LABEL"
+echo "value-log dict trainer: $VLOG_DICT_TRAINER_LABEL"
 echo "execution path: $PATH_LABEL"
 echo "cpu profile mode: $(is_true "$TIMED_CPU_PROFILE" && echo "timed benchmark window" || echo "whole go test process")"
 if [[ -n "$GO_TEST_TAGS" ]]; then
@@ -121,12 +125,13 @@ if [[ ! -d "$ROOT/TreeDB/collections" ]]; then
     -storage-policy "$STORAGE_POLICY_LABEL" \
     -pager-chunk-size "$CHUNK_SIZE_LABEL" \
     -pager-sync-concurrency "$PAGER_SYNC_CONCURRENCY_LABEL" \
+    -vlog-dict-trainer "$VLOG_DICT_TRAINER_LABEL" \
     -collection-batch-size "$BATCH_SIZE" \
     -bench-pattern "$BENCH_REGEX" \
     -count "$COUNT" \
     -unavailable-reason "N/A before R0 harness bring-up"
 else
-  TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$DATA_OUTER" TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$INDEX_OUTER" TREEDB_COLLECTION_CHUNK_SIZE="$CHUNK_SIZE" TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY="$PAGER_SYNC_CONCURRENCY" GOWORK=off "${cmd[@]}" | tee "$RAW_JSON"
+  TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$DATA_OUTER" TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$INDEX_OUTER" TREEDB_COLLECTION_CHUNK_SIZE="$CHUNK_SIZE" TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY="$PAGER_SYNC_CONCURRENCY" TREEDB_COLLECTION_VLOG_DICT_TRAINER="$VLOG_DICT_TRAINER" GOWORK=off "${cmd[@]}" | tee "$RAW_JSON"
 
   if is_true "$TIMED_CPU_PROFILE" && [[ ! -s "$CPU_PROFILE" ]]; then
     echo "timed CPU profile was requested but no profile was written to $CPU_PROFILE; use a timed-profile benchmark" >&2
@@ -147,6 +152,7 @@ else
     -storage-policy "$STORAGE_POLICY_LABEL" \
     -pager-chunk-size "$CHUNK_SIZE_LABEL" \
     -pager-sync-concurrency "$PAGER_SYNC_CONCURRENCY_LABEL" \
+    -vlog-dict-trainer "$VLOG_DICT_TRAINER_LABEL" \
     -collection-batch-size "$BATCH_SIZE" \
     -bench-pattern "$BENCH_REGEX" \
     -count "$COUNT"
@@ -187,6 +193,7 @@ cat >"$OUT_DIR/README.md" <<EOF
 - storage policy: \`$STORAGE_POLICY_LABEL\`
 - pager chunk size: \`$CHUNK_SIZE_LABEL\`
 - pager sync concurrency: \`$PAGER_SYNC_CONCURRENCY_LABEL\`
+- value-log dict trainer: \`$VLOG_DICT_TRAINER_LABEL\`
 - collection batch size: \`$BATCH_SIZE\`
 - benchmark regex: \`$BENCH_REGEX\`
 - benchmark count: \`$COUNT\`
@@ -202,6 +209,7 @@ $ARTIFACT_LINES
 - index-root outer-leaf override: \`TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=true scripts/bench_collections_report.sh\`
 - pager chunk size override: \`TREEDB_COLLECTION_CHUNK_SIZE=65536 scripts/bench_collections_report.sh\`
 - pager sync concurrency override: \`TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY=4 scripts/bench_collections_report.sh\`
+- value-log dict trainer override: \`TREEDB_COLLECTION_VLOG_DICT_TRAINER=disabled scripts/bench_collections_report.sh\`
 - batch-size override: \`TREEDB_COLLECTION_BENCH_BATCH_SIZE=8000 scripts/bench_collections_report.sh\`
 - oracle-path override: \`TREEDB_COLLECTION_PATH_LABEL=oracle scripts/bench_collections_report.sh\`
 - production matrix runner: \`TREEDB_COLLECTION_PATH_LABEL=native-fastpath scripts/bench_collections_matrix.sh\`

--- a/scripts/bench_collections_report.sh
+++ b/scripts/bench_collections_report.sh
@@ -19,8 +19,21 @@ if [[ "$PAGER_SYNC_CONCURRENCY" == "0" ]]; then
   PAGER_SYNC_CONCURRENCY=""
 fi
 PAGER_SYNC_CONCURRENCY_LABEL="${PAGER_SYNC_CONCURRENCY:-profile/default}"
-VLOG_DICT_TRAINER="$(printf '%s' "${TREEDB_COLLECTION_VLOG_DICT_TRAINER:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-VLOG_DICT_TRAINER_LABEL="${VLOG_DICT_TRAINER:-enabled}"
+VLOG_DICT_TRAINER_RAW="$(printf '%s' "${TREEDB_COLLECTION_VLOG_DICT_TRAINER:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+case "$(printf '%s' "$VLOG_DICT_TRAINER_RAW" | tr '[:upper:]' '[:lower:]')" in
+  ""|default|profile/default|enabled|on|true|1)
+    VLOG_DICT_TRAINER="enabled"
+    VLOG_DICT_TRAINER_LABEL="enabled"
+    ;;
+  disabled|off|false|0)
+    VLOG_DICT_TRAINER="disabled"
+    VLOG_DICT_TRAINER_LABEL="disabled"
+    ;;
+  *)
+    VLOG_DICT_TRAINER="$VLOG_DICT_TRAINER_RAW"
+    VLOG_DICT_TRAINER_LABEL="$VLOG_DICT_TRAINER_RAW"
+    ;;
+esac
 if [[ "$DATA_OUTER" == "-" && "$INDEX_OUTER" == "-" ]]; then
   CHUNK_SIZE_LABEL="-"
   PAGER_SYNC_CONCURRENCY_LABEL="-"


### PR DESCRIPTION
## Summary

Adds a benchmark-only value-log dictionary trainer toggle for the collections harness:

- `TREEDB_COLLECTION_VLOG_DICT_TRAINER=disabled` applies the selected TreeDB profile, then sets `ValueLog.DictTrain.TrainBytes=-1`.
- `TREEDB_COLLECTION_MATRIX=trainer` runs paired production-fast cells for data-vlog roots with index leaf and index vlog modes.
- benchmark reports, matrix summaries, and user-story TSVs now include a `vlog_dict_trainer` column so trainer-on/off throughput is explicit.

This keeps JSON extraction quarantined and measures whether background trainer allocation pressure is affecting effective indexed-ingest throughput.

## Validation

- `GOWORK=off go test ./TreeDB/collections ./cmd/collection_bench_report ./cmd/collection_bench_matrix_summary`
- `OUT_DIR=/tmp/gomap_768_trainer_compare_20260427_095416 TREEDB_COLLECTION_MATRIX=trainer COUNT=3 BENCHTIME=1s TREEDB_COLLECTION_PATH_LABEL=native-fastpath scripts/bench_collections_matrix.sh`

Trainer-matrix result, docs/sec from `collections_user_story_summary.tsv`:

| Cell | Trainer | Bulk indexed insert | Checkpointed indexed insert |
| --- | ---: | ---: | ---: |
| data_vlog/index_leaf | enabled | 400,481 docs/sec | 220,637 docs/sec |
| data_vlog/index_leaf | disabled | 398,724 docs/sec | 218,436 docs/sec |
| data_vlog/index_vlog | enabled | 362,889 docs/sec | 246,488 docs/sec |
| data_vlog/index_vlog | disabled | 362,582 docs/sec | 243,329 docs/sec |

Throughput did not materially improve with trainer disabled in this run. The index-vlog rows did isolate trainer-related byte allocation pressure: bulk B/op dropped from ~2,595 to ~1,621 and checkpointed B/op from ~3,122 to ~1,649 when training was disabled.

Refs #768.