### PR TITLE
collections: arena encode index values

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1550,7 +1550,7 @@ func (c *Collection) FindByIndex(indexName, value string) ([][]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, prefix, err := appendIndexValuePrefixSlice(arena, encoded)
+	arena, prefix, err := appendIndexValuePrefixSlice(arena, encoded)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1545,11 +1545,12 @@ func (c *Collection) FindByIndex(indexName, value string) ([][]byte, error) {
 	if rootID == 0 {
 		return nil, nil
 	}
-	encoded, err := encodeIndexScalar(value)
+	var arena []byte
+	arena, encoded, err := appendIndexScalar(arena, value)
 	if err != nil {
 		return nil, err
 	}
-	prefix, err := indexValuePrefix(encoded)
+	_, prefix, err := appendIndexValuePrefixSlice(arena, encoded)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -94,6 +94,10 @@ type uniqueProbeCandidate struct {
 type documentIndexState map[string][][]byte
 type orderedDocumentIndexState [][][]byte
 
+type indexEncodeArena struct {
+	buf []byte
+}
+
 type groupedRootPublisher interface {
 	PublishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordered []backenddb.OrderedRootPublishInput) (uint64, []uint64, error)
 }
@@ -299,8 +303,9 @@ func (p insertBatchPlanner) planIndexStateAndUniqueProbes(items []insertBatchIte
 		return nil, nil
 	}
 	uniqueProbes := make([]uniqueProbeCandidate, 0, len(items))
+	encoder := indexEncodeArena{buf: make([]byte, 0, estimateBatchIndexEncodeArenaBytes(items, len(runtimes)))}
 	for i := range items {
-		state, err := orderedIndexStateForDocument(items[i].document, runtimes, p.options)
+		state, err := orderedIndexStateForDocumentWithArena(items[i].document, runtimes, p.options, &encoder)
 		if err != nil {
 			return nil, err
 		}
@@ -354,6 +359,14 @@ func buildUniqueProbeRuns(candidates []uniqueProbeCandidate) ([]collectionUnique
 	return buildUniqueProbeRunsFromSorted(candidates, nil)
 }
 
+func estimateUniqueProbePrefixBytes(candidates []uniqueProbeCandidate) int {
+	total := 0
+	for _, candidate := range candidates {
+		total += 2 + len(candidate.encodedValue)
+	}
+	return total
+}
+
 func buildUniqueProbeRunsForPreflightFromSorted(candidates []uniqueProbeCandidate, preflight insertBatchPreflight) ([]collectionUniqueProbeRun, error) {
 	if preflight.snapshot == nil || len(preflight.uniqueIndexRootIDs) == 0 {
 		return nil, nil
@@ -368,6 +381,7 @@ func buildUniqueProbeRunsFromSorted(candidates []uniqueProbeCandidate, includeIn
 		return nil, nil
 	}
 	runs := make([]collectionUniqueProbeRun, 0)
+	prefixArena := make([]byte, 0, estimateUniqueProbePrefixBytes(candidates))
 	for start := 0; start < len(candidates); {
 		indexName := candidates[start].indexName
 		end := start + 1
@@ -385,7 +399,9 @@ func buildUniqueProbeRunsFromSorted(candidates []uniqueProbeCandidate, includeIn
 		for i := start; i < end; i++ {
 			candidate := &candidates[i]
 			if len(run.prefixes) == 0 || !bytes.Equal(candidate.encodedValue, candidates[i-1].encodedValue) {
-				prefix, err := indexValuePrefix(candidate.encodedValue)
+				var prefix []byte
+				var err error
+				prefixArena, prefix, err = appendIndexValuePrefixSlice(prefixArena, candidate.encodedValue)
 				if err != nil {
 					return nil, err
 				}
@@ -655,8 +671,16 @@ func indexStateForDocument(document []byte, runtimes []indexRuntime, opts collec
 }
 
 func orderedIndexStateForDocument(document []byte, runtimes []indexRuntime, opts collectionOptions) (orderedDocumentIndexState, error) {
+	encoder := indexEncodeArena{buf: make([]byte, 0, estimateDocumentIndexEncodeArenaBytes(len(runtimes)))}
+	return orderedIndexStateForDocumentWithArena(document, runtimes, opts, &encoder)
+}
+
+func orderedIndexStateForDocumentWithArena(document []byte, runtimes []indexRuntime, opts collectionOptions, encoder *indexEncodeArena) (orderedDocumentIndexState, error) {
 	if len(runtimes) == 0 {
 		return nil, nil
+	}
+	if encoder == nil {
+		encoder = &indexEncodeArena{buf: make([]byte, 0, estimateDocumentIndexEncodeArenaBytes(len(runtimes)))}
 	}
 	var decoded any
 	if err := json.Unmarshal(document, &decoded); err != nil {
@@ -678,7 +702,9 @@ func orderedIndexStateForDocument(document []byte, runtimes []indexRuntime, opts
 		}
 		encoded := make([][]byte, 0, len(values))
 		for _, scalar := range values {
-			next, err := encodeIndexScalar(scalar)
+			var next []byte
+			var err error
+			encoder.buf, next, err = appendIndexScalar(encoder.buf, scalar)
 			if err != nil {
 				return nil, err
 			}
@@ -690,6 +716,26 @@ func orderedIndexStateForDocument(document []byte, runtimes []indexRuntime, opts
 		}
 	}
 	return state, nil
+}
+
+func estimateDocumentIndexEncodeArenaBytes(runtimeCount int) int {
+	if runtimeCount <= 0 {
+		return 0
+	}
+	const encodedScalarGuess = 20
+	return runtimeCount * encodedScalarGuess
+}
+
+func estimateBatchIndexEncodeArenaBytes(items []insertBatchItem, runtimeCount int) int {
+	if len(items) == 0 || runtimeCount <= 0 {
+		return 0
+	}
+	total := len(items) * estimateDocumentIndexEncodeArenaBytes(runtimeCount)
+	const maxInitialArenaBytes = 4 << 20
+	if total > maxInitialArenaBytes {
+		return maxInitialArenaBytes
+	}
+	return total
 }
 
 func documentIndexStateFromOrdered(state orderedDocumentIndexState, runtimes []indexRuntime) documentIndexState {
@@ -982,24 +1028,31 @@ func extractIndexPathValue(document any, path []string) (any, bool) {
 }
 
 func encodeIndexScalar(value any) ([]byte, error) {
+	_, encoded, err := appendIndexScalar(nil, value)
+	return encoded, err
+}
+
+func appendIndexScalar(dst []byte, value any) ([]byte, []byte, error) {
+	start := len(dst)
 	switch v := value.(type) {
 	case string:
-		out := make([]byte, 0, 2+len(v))
-		out = append(out, "s:"...)
-		out = append(out, v...)
-		return out, nil
+		dst = append(dst, "s:"...)
+		dst = append(dst, v...)
 	case bool:
 		if v {
-			return []byte("b:1"), nil
+			dst = append(dst, "b:1"...)
+		} else {
+			dst = append(dst, "b:0"...)
 		}
-		return []byte("b:0"), nil
 	case float64:
-		return []byte("n:" + strconv.FormatFloat(v, 'g', -1, 64)), nil
+		dst = append(dst, "n:"...)
+		dst = strconv.AppendFloat(dst, v, 'g', -1, 64)
 	case nil:
-		return []byte("z:"), nil
+		dst = append(dst, "z:"...)
 	default:
-		return nil, fmt.Errorf("collections: unsupported indexed value type %T", value)
+		return dst, nil, fmt.Errorf("collections: unsupported indexed value type %T", value)
 	}
+	return dst, dst[start:len(dst):len(dst)], nil
 }
 
 func indexEntryKey(encodedValue, documentID []byte) ([]byte, error) {
@@ -1022,7 +1075,8 @@ func appendIndexEntryKey(dst, encodedValue, documentID []byte) ([]byte, []byte, 
 }
 
 func indexValuePrefix(encodedValue []byte) ([]byte, error) {
-	return appendIndexValuePrefix(make([]byte, 0, 2+len(encodedValue)), encodedValue)
+	_, prefix, err := appendIndexValuePrefixSlice(make([]byte, 0, 2+len(encodedValue)), encodedValue)
+	return prefix, err
 }
 
 func compareIndexValuePrefixEncoded(a, b []byte) int {
@@ -1049,6 +1103,15 @@ func appendIndexValuePrefix(out []byte, encodedValue []byte) ([]byte, error) {
 	out = binary.BigEndian.AppendUint16(out, uint16(len(encodedValue)))
 	out = append(out, encodedValue...)
 	return out, nil
+}
+
+func appendIndexValuePrefixSlice(dst []byte, encodedValue []byte) ([]byte, []byte, error) {
+	start := len(dst)
+	next, err := appendIndexValuePrefix(dst, encodedValue)
+	if err != nil {
+		return next, nil, err
+	}
+	return next, next[start:len(next):len(next)], nil
 }
 
 func prefixEnd(prefix []byte) []byte {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -19,6 +19,17 @@ import (
 
 const documentIndexStateVersion = 1
 
+const (
+	// Most benchmarked scalar index values are short strings ("city-00",
+	// emails, booleans, or numeric tags). This is only an initial arena hint;
+	// larger values still append correctly and grow the arena as needed.
+	indexEncodeArenaScalarGuessBytes = 20
+	// Keep the speculative batch arena bounded. If a batch needs more encoded
+	// value bytes, append growth preserves earlier slices and avoids a large
+	// upfront allocation.
+	indexEncodeArenaMaxInitialBytes = 4 << 20
+)
+
 type collectionRootKind uint8
 
 const (
@@ -362,7 +373,11 @@ func buildUniqueProbeRuns(candidates []uniqueProbeCandidate) ([]collectionUnique
 func estimateUniqueProbePrefixBytes(candidates []uniqueProbeCandidate) int {
 	total := 0
 	for _, candidate := range candidates {
-		total += 2 + len(candidate.encodedValue)
+		add := 2 + len(candidate.encodedValue)
+		if add > indexEncodeArenaMaxInitialBytes-total {
+			return indexEncodeArenaMaxInitialBytes
+		}
+		total += add
 	}
 	return total
 }
@@ -722,20 +737,24 @@ func estimateDocumentIndexEncodeArenaBytes(runtimeCount int) int {
 	if runtimeCount <= 0 {
 		return 0
 	}
-	const encodedScalarGuess = 20
-	return runtimeCount * encodedScalarGuess
+	if runtimeCount > indexEncodeArenaMaxInitialBytes/indexEncodeArenaScalarGuessBytes {
+		return indexEncodeArenaMaxInitialBytes
+	}
+	return runtimeCount * indexEncodeArenaScalarGuessBytes
 }
 
 func estimateBatchIndexEncodeArenaBytes(items []insertBatchItem, runtimeCount int) int {
 	if len(items) == 0 || runtimeCount <= 0 {
 		return 0
 	}
-	total := len(items) * estimateDocumentIndexEncodeArenaBytes(runtimeCount)
-	const maxInitialArenaBytes = 4 << 20
-	if total > maxInitialArenaBytes {
-		return maxInitialArenaBytes
+	perDocument := estimateDocumentIndexEncodeArenaBytes(runtimeCount)
+	if perDocument == 0 {
+		return 0
 	}
-	return total
+	if len(items) > indexEncodeArenaMaxInitialBytes/perDocument {
+		return indexEncodeArenaMaxInitialBytes
+	}
+	return len(items) * perDocument
 }
 
 func documentIndexStateFromOrdered(state orderedDocumentIndexState, runtimes []indexRuntime) documentIndexState {

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -120,6 +120,38 @@ func TestEncodeNormalizedDocumentIndexStateMatchesConservativeEncoder(t *testing
 	}
 }
 
+func TestAppendIndexScalarEncodesIntoArena(t *testing.T) {
+	var arena []byte
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{name: "string", value: "ada", want: "s:ada"},
+		{name: "bool true", value: true, want: "b:1"},
+		{name: "bool false", value: false, want: "b:0"},
+		{name: "number", value: float64(42.5), want: "n:42.5"},
+		{name: "null", value: nil, want: "z:"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(arena)
+			var encoded []byte
+			var err error
+			arena, encoded, err = appendIndexScalar(arena, tc.value)
+			if err != nil {
+				t.Fatalf("append index scalar: %v", err)
+			}
+			if got := string(encoded); got != tc.want {
+				t.Fatalf("encoded=%q want %q", got, tc.want)
+			}
+			if !bytes.Equal(encoded, arena[before:]) {
+				t.Fatalf("encoded slice is not backed by arena tail")
+			}
+		})
+	}
+}
+
 func TestBuildUniqueProbeRunsMatchesEncodedPrefixOrdering(t *testing.T) {
 	candidates := []uniqueProbeCandidate{
 		{indexName: "email", encodedValue: []byte("s:zz"), documentID: []byte("u3")},


### PR DESCRIPTION
## Summary

Adds append-style index encoders and planner-owned arenas for collection secondary-index planning:

- adds `appendIndexScalar` and `appendIndexValuePrefixSlice` helpers
- encodes per-batch indexed scalar values into an `indexEncodeArena` instead of allocating one small `[]byte` per scalar
- builds unique-probe prefixes from a shared prefix arena
- keeps public helper behavior intact for one-off callers; `FindByIndex` now uses the append helpers for its scalar+prefix path

This intentionally leaves JSON extraction quarantined. The pprof object top after this change is still dominated by `encoding/json` and normalization/single-value state shape, not scalar encoding.

## Validation

- `GOWORK=off go test ./TreeDB/collections`
- `OUT_DIR=/tmp/gomap_768_append_encoding_r2_20260427_100007 TREEDB_COLLECTION_PATH_LABEL=native-fastpath TREEDB_COLLECTION_BENCH_ENGINE=production_fast TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=true TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=true COUNT=3 BENCHTIME=1s BENCH_REGEX='Benchmark(CollectionInsertBatchWithSecondaryIndexes|CollectionInsertBatchCheckpointWithSecondaryIndexes|CollectionOverheadIndexStateJSONExtraction|CollectionOverheadPlanIndexedPrecomputedState)$' scripts/bench_collections_report.sh`

Compared with the same mainline index-vlog shape from the trainer harness run:

| Row | Mainline | This PR |
| --- | ---: | ---: |
| JSON extraction allocs/op | 24 | 23 |
| JSON extraction B/op | 872 | 872 |
| Bulk indexed insert allocs/op | 25 | 22 |
| Checkpointed indexed insert allocs/op | 25 | 22 |
| Bulk indexed insert throughput | 362,889 docs/sec | 363,813 docs/sec |
| Checkpointed indexed insert throughput | 246,488 docs/sec | 243,546 docs/sec |

Fallback counters remained zero in the timed insert rows.

Refs #768.