### PR TITLE
collections: fast path single index values

### DIFF
--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -28,6 +28,10 @@ const (
 	// value bytes, append growth preserves earlier slices and avoids a large
 	// upfront allocation.
 	indexEncodeArenaMaxInitialBytes = 4 << 20
+	// One-value index states share a planner-owned [][]byte backing array.
+	// 128K slice headers is enough for the current native benchmark batches
+	// while keeping speculative header memory around 3 MiB on 64-bit platforms.
+	indexEncodeArenaMaxInitialValueRefs = 128 << 10
 )
 
 type collectionRootKind uint8
@@ -801,12 +805,13 @@ func estimateBatchIndexValueRefCount(items []insertBatchItem, runtimeCount int) 
 	if len(items) == 0 || runtimeCount <= 0 {
 		return 0
 	}
-	total := len(items) * runtimeCount
-	const maxInitialRefs = 1 << 20
-	if total > maxInitialRefs {
-		return maxInitialRefs
+	if runtimeCount > indexEncodeArenaMaxInitialValueRefs {
+		return indexEncodeArenaMaxInitialValueRefs
 	}
-	return total
+	if len(items) > indexEncodeArenaMaxInitialValueRefs/runtimeCount {
+		return indexEncodeArenaMaxInitialValueRefs
+	}
+	return len(items) * runtimeCount
 }
 
 func documentIndexStateFromOrdered(state orderedDocumentIndexState, runtimes []indexRuntime) documentIndexState {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -95,7 +95,8 @@ type documentIndexState map[string][][]byte
 type orderedDocumentIndexState [][][]byte
 
 type indexEncodeArena struct {
-	buf []byte
+	buf       []byte
+	valueRefs [][]byte
 }
 
 type groupedRootPublisher interface {
@@ -303,7 +304,10 @@ func (p insertBatchPlanner) planIndexStateAndUniqueProbes(items []insertBatchIte
 		return nil, nil
 	}
 	uniqueProbes := make([]uniqueProbeCandidate, 0, len(items))
-	encoder := indexEncodeArena{buf: make([]byte, 0, estimateBatchIndexEncodeArenaBytes(items, len(runtimes)))}
+	encoder := indexEncodeArena{
+		buf:       make([]byte, 0, estimateBatchIndexEncodeArenaBytes(items, len(runtimes))),
+		valueRefs: make([][]byte, 0, estimateBatchIndexValueRefCount(items, len(runtimes))),
+	}
 	for i := range items {
 		state, err := orderedIndexStateForDocumentWithArena(items[i].document, runtimes, p.options, &encoder)
 		if err != nil {
@@ -671,7 +675,10 @@ func indexStateForDocument(document []byte, runtimes []indexRuntime, opts collec
 }
 
 func orderedIndexStateForDocument(document []byte, runtimes []indexRuntime, opts collectionOptions) (orderedDocumentIndexState, error) {
-	encoder := indexEncodeArena{buf: make([]byte, 0, estimateDocumentIndexEncodeArenaBytes(len(runtimes)))}
+	encoder := indexEncodeArena{
+		buf:       make([]byte, 0, estimateDocumentIndexEncodeArenaBytes(len(runtimes))),
+		valueRefs: make([][]byte, 0, len(runtimes)),
+	}
 	return orderedIndexStateForDocumentWithArena(document, runtimes, opts, &encoder)
 }
 
@@ -680,7 +687,10 @@ func orderedIndexStateForDocumentWithArena(document []byte, runtimes []indexRunt
 		return nil, nil
 	}
 	if encoder == nil {
-		encoder = &indexEncodeArena{buf: make([]byte, 0, estimateDocumentIndexEncodeArenaBytes(len(runtimes)))}
+		encoder = &indexEncodeArena{
+			buf:       make([]byte, 0, estimateDocumentIndexEncodeArenaBytes(len(runtimes))),
+			valueRefs: make([][]byte, 0, len(runtimes)),
+		}
 	}
 	var decoded any
 	if err := json.Unmarshal(document, &decoded); err != nil {
@@ -696,26 +706,56 @@ func orderedIndexStateForDocumentWithArena(document []byte, runtimes []indexRunt
 		if !found || value == nil {
 			continue
 		}
-		values, err := normalizeIndexValues(value, runtime.def.multiKey, opts.allowArrayValuesInIndex)
+
+		if arr, ok := value.([]any); ok {
+			if !runtime.def.multiKey && !opts.allowArrayValuesInIndex {
+				return nil, errors.New("collections: array value not allowed for index")
+			}
+			switch len(arr) {
+			case 0:
+				continue
+			case 1:
+				var next []byte
+				var err error
+				encoder.buf, next, err = appendIndexScalar(encoder.buf, arr[0])
+				if err != nil {
+					return nil, err
+				}
+				state[runtimeIdx] = encoder.appendSingleValueRef(next)
+				continue
+			}
+			encoded := make([][]byte, 0, len(arr))
+			for _, scalar := range arr {
+				var next []byte
+				var err error
+				encoder.buf, next, err = appendIndexScalar(encoder.buf, scalar)
+				if err != nil {
+					return nil, err
+				}
+				encoded = append(encoded, next)
+			}
+			encoded = normalizeOwnedEncodedIndexValues(encoded)
+			if len(encoded) > 0 {
+				state[runtimeIdx] = encoded
+			}
+			continue
+		}
+
+		var next []byte
+		var err error
+		encoder.buf, next, err = appendIndexScalar(encoder.buf, value)
 		if err != nil {
 			return nil, err
 		}
-		encoded := make([][]byte, 0, len(values))
-		for _, scalar := range values {
-			var next []byte
-			var err error
-			encoder.buf, next, err = appendIndexScalar(encoder.buf, scalar)
-			if err != nil {
-				return nil, err
-			}
-			encoded = append(encoded, next)
-		}
-		encoded = normalizeOwnedEncodedIndexValues(encoded)
-		if len(encoded) > 0 {
-			state[runtimeIdx] = encoded
-		}
+		state[runtimeIdx] = encoder.appendSingleValueRef(next)
 	}
 	return state, nil
+}
+
+func (a *indexEncodeArena) appendSingleValueRef(value []byte) [][]byte {
+	start := len(a.valueRefs)
+	a.valueRefs = append(a.valueRefs, value)
+	return a.valueRefs[start:len(a.valueRefs):len(a.valueRefs)]
 }
 
 func estimateDocumentIndexEncodeArenaBytes(runtimeCount int) int {
@@ -734,6 +774,18 @@ func estimateBatchIndexEncodeArenaBytes(items []insertBatchItem, runtimeCount in
 	const maxInitialArenaBytes = 4 << 20
 	if total > maxInitialArenaBytes {
 		return maxInitialArenaBytes
+	}
+	return total
+}
+
+func estimateBatchIndexValueRefCount(items []insertBatchItem, runtimeCount int) int {
+	if len(items) == 0 || runtimeCount <= 0 {
+		return 0
+	}
+	total := len(items) * runtimeCount
+	const maxInitialRefs = 1 << 20
+	if total > maxInitialRefs {
+		return maxInitialRefs
 	}
 	return total
 }
@@ -952,8 +1004,8 @@ func normalizeEncodedIndexValues(values [][]byte) [][]byte {
 
 func normalizeOwnedEncodedIndexValues(values [][]byte) [][]byte {
 	values = filterEmptyEncodedIndexValues(values)
-	if len(values) == 0 {
-		return nil
+	if len(values) <= 1 {
+		return values
 	}
 	sort.Slice(values, func(i, j int) bool {
 		return bytes.Compare(values[i], values[j]) < 0
@@ -983,19 +1035,6 @@ func filterEmptyEncodedIndexValues(values [][]byte) [][]byte {
 		return nil
 	}
 	return out
-}
-
-func normalizeIndexValues(value any, multiKey, allowArray bool) ([]any, error) {
-	if arr, ok := value.([]any); ok {
-		if !multiKey && !allowArray {
-			return nil, errors.New("collections: array value not allowed for index")
-		}
-		if len(arr) == 0 {
-			return nil, nil
-		}
-		return arr, nil
-	}
-	return []any{value}, nil
 }
 
 func splitIndexPath(path string) []string {

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -152,6 +152,40 @@ func TestAppendIndexScalarEncodesIntoArena(t *testing.T) {
 	}
 }
 
+func TestOrderedIndexStateForDocumentHandlesScalarAndArrayValues(t *testing.T) {
+	scalarRuntime := []indexRuntime{{
+		def:  indexDefinition{name: "email", field: "email"},
+		path: []string{"email"},
+	}}
+	scalarState, err := orderedIndexStateForDocument([]byte(`{"email":"ada@example.com"}`), scalarRuntime, collectionOptions{})
+	if err != nil {
+		t.Fatalf("scalar index state: %v", err)
+	}
+	if got, want := scalarState.valuesAt(0), [][]byte{[]byte("s:ada@example.com")}; !byteMatrixEqual(got, want) {
+		t.Fatalf("scalar values=%q want %q", got, want)
+	}
+
+	arrayRuntime := []indexRuntime{{
+		def:  indexDefinition{name: "tags", field: "tags", multiKey: true},
+		path: []string{"tags"},
+	}}
+	arrayState, err := orderedIndexStateForDocument([]byte(`{"tags":["b","a","a"]}`), arrayRuntime, collectionOptions{})
+	if err != nil {
+		t.Fatalf("array index state: %v", err)
+	}
+	if got, want := arrayState.valuesAt(0), [][]byte{[]byte("s:a"), []byte("s:b")}; !byteMatrixEqual(got, want) {
+		t.Fatalf("array values=%q want %q", got, want)
+	}
+
+	_, err = orderedIndexStateForDocument([]byte(`{"tags":["a"]}`), []indexRuntime{{
+		def:  indexDefinition{name: "tags", field: "tags"},
+		path: []string{"tags"},
+	}}, collectionOptions{})
+	if err == nil || !strings.Contains(err.Error(), "array value not allowed") {
+		t.Fatalf("err=%v want array value not allowed", err)
+	}
+}
+
 func TestBuildUniqueProbeRunsMatchesEncodedPrefixOrdering(t *testing.T) {
 	candidates := []uniqueProbeCandidate{
 		{indexName: "email", encodedValue: []byte("s:zz"), documentID: []byte("u3")},


### PR DESCRIPTION
## Summary

Stacks on #1065 and removes the remaining one-value index-state allocation path:

- scalar index values bypass the old `[]any{value}` normalization path
- scalar and one-element array values use an arena-backed one-value `[][]byte` reference
- batch planning preallocates those one-value refs in the planner arena
- multikey arrays still take the sorted/deduped path

This keeps JSON parsing quarantined. After this patch, the object profile no longer shows scalar encoding, `normalizeOwnedEncodedIndexValues`, or one-value ref helpers as the dominant non-JSON object source; remaining object pressure is mostly `encoding/json` plus the ordered-state shape.

## Validation

- `GOWORK=off go test ./TreeDB/collections`
- `OUT_DIR=/tmp/gomap_768_single_fastpath_r2_20260427_100428 TREEDB_COLLECTION_PATH_LABEL=native-fastpath TREEDB_COLLECTION_BENCH_ENGINE=production_fast TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=true TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=true COUNT=3 BENCHTIME=1s BENCH_REGEX='Benchmark(CollectionInsertBatchWithSecondaryIndexes|CollectionInsertBatchCheckpointWithSecondaryIndexes|CollectionOverheadIndexStateJSONExtraction|CollectionOverheadPlanIndexedPrecomputedState)$' scripts/bench_collections_report.sh`

Compared with #1065:

| Row | #1065 | This PR |
| --- | ---: | ---: |
| JSON extraction allocs/op | 23 | 20 |
| JSON extraction B/op | 872 | 824 |
| Bulk indexed insert allocs/op | 22 | 18 |
| Checkpointed indexed insert allocs/op | 22 | 18 |
| Bulk indexed insert throughput | 363,813 docs/sec | 381,825 docs/sec |
| Checkpointed indexed insert throughput | 243,546 docs/sec | 257,843 docs/sec |

Fallback counters remained zero in the timed insert rows.

Refs #768.