### PR TITLE
collections: add benchmark harness suite

### DIFF
--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -330,6 +330,7 @@ func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
 	}
 
 	end := time.Now()
+	writerDocsAtEnd := writerDocs.Load()
 	b.StopTimer()
 	stop.Store(true)
 	wg.Wait()
@@ -340,7 +341,7 @@ func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
 	default:
 	}
 	if elapsed > 0 {
-		b.ReportMetric(float64(writerDocs.Load())/elapsed.Seconds(), "writer_docs/sec")
+		b.ReportMetric(float64(writerDocsAtEnd)/elapsed.Seconds(), "writer_docs/sec")
 	}
 }
 

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -306,25 +306,42 @@ func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
 		}
 	}()
 
+	readerStride := runtime.GOMAXPROCS(0)
+	if readerStride <= 0 {
+		readerStride = 1
+	}
+	var readerOffsets atomic.Uint64
+	nextReaderStart := func(limit int) int {
+		if limit <= 0 {
+			return 0
+		}
+		spacing := limit / readerStride
+		if spacing <= 0 {
+			spacing = 1
+		}
+		readerID := int(readerOffsets.Add(1) - 1)
+		return (readerID * spacing) % limit
+	}
+
 	if secondaryRead {
 		b.RunParallel(func(pb *testing.PB) {
-			i := 0
+			i := nextReaderStart(seedDocs)
 			for pb.Next() {
 				email := fmt.Sprintf("user-%09d@example.com", i%seedDocs)
 				if _, err := collection.FindByIndex("email_idx", email); err != nil {
 					b.Errorf("mixed secondary read: %v", err)
 				}
-				i += runtime.GOMAXPROCS(0)
+				i += readerStride
 			}
 		})
 	} else {
 		b.RunParallel(func(pb *testing.PB) {
-			i := 0
+			i := nextReaderStart(len(ids))
 			for pb.Next() {
 				if _, err := collection.Get(ids[i%len(ids)]); err != nil {
 					b.Errorf("mixed primary read: %v", err)
 				}
-				i += runtime.GOMAXPROCS(0)
+				i += readerStride
 			}
 		})
 	}

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -261,8 +261,8 @@ func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
 	b.ReportAllocs()
 	b.ReportMetric(float64(seedDocs), "seed_docs")
 	b.ReportMetric(float64(writeBatchSize), "writer_docs/batch")
-	start := time.Now()
 	b.ResetTimer()
+	start := time.Now()
 
 	go func() {
 		defer wg.Done()
@@ -329,10 +329,11 @@ func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
 		})
 	}
 
+	end := time.Now()
 	b.StopTimer()
 	stop.Store(true)
 	wg.Wait()
-	elapsed := time.Since(start)
+	elapsed := end.Sub(start)
 	select {
 	case err := <-errCh:
 		b.Fatalf("mixed writer: %v", err)

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -346,11 +346,10 @@ func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
 		})
 	}
 
-	end := time.Now()
-	writerDocsAtEnd := writerDocs.Load()
 	b.StopTimer()
 	stop.Store(true)
 	wg.Wait()
+	end := time.Now()
 	elapsed := end.Sub(start)
 	select {
 	case err := <-errCh:
@@ -358,7 +357,7 @@ func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
 	default:
 	}
 	if elapsed > 0 {
-		b.ReportMetric(float64(writerDocsAtEnd)/elapsed.Seconds(), "writer_docs/sec")
+		b.ReportMetric(float64(writerDocs.Load())/elapsed.Seconds(), "writer_docs/sec")
 	}
 }
 

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -1,0 +1,352 @@
+package collections_test
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+const (
+	defaultCollectionMixedSeedDocs       = 4096
+	defaultCollectionMixedWriteBatchSize = 128
+)
+
+func collectionShapeIndexes(indexCount int) []collections.IndexDefinition {
+	switch indexCount {
+	case 0:
+		return nil
+	case 1:
+		return []collections.IndexDefinition{{Name: "email_idx", Field: "email", Unique: true}}
+	case 2:
+		return []collections.IndexDefinition{
+			{Name: "email_idx", Field: "email", Unique: true},
+			{Name: "city_idx", Field: "city"},
+		}
+	case 3:
+		return []collections.IndexDefinition{
+			{Name: "email_idx", Field: "email", Unique: true},
+			{Name: "city_idx", Field: "city"},
+			{Name: "name_idx", Field: "name"},
+		}
+	default:
+		panic(fmt.Sprintf("unsupported collection benchmark index count %d", indexCount))
+	}
+}
+
+func collectionSingleStringIndexes(indexCount int) []collections.IndexDefinition {
+	switch indexCount {
+	case 0:
+		return nil
+	case 1:
+		return []collections.IndexDefinition{{Name: "value_idx", Field: "value", Unique: true}}
+	default:
+		panic(fmt.Sprintf("unsupported single-string benchmark index count %d", indexCount))
+	}
+}
+
+func benchmarkSingleStringDocument(n int) []byte {
+	out := make([]byte, 0, len(`{"value":"value-000000000"}`))
+	out = append(out, `{"value":"value-`...)
+	out = appendZeroPaddedInt(out, n, 9)
+	out = append(out, `"}`...)
+	return out
+}
+
+func benchmarkSingleStringDocumentBatch(tb testing.TB, start, count int) ([][]byte, [][]byte) {
+	tb.Helper()
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		docNum := start + i
+		ids[i] = benchmarkDocumentID(docNum)
+		docs[i] = benchmarkSingleStringDocument(docNum)
+	}
+	return ids, docs
+}
+
+func benchmarkCollectionShapeInsertBatch(b *testing.B, indexCount int, checkpoint bool) {
+	backend, collection := openBenchmarkCollection(b, fmt.Sprintf("bench_shape_insert_%d", indexCount), collectionShapeIndexes(indexCount)...)
+	targetBatchSize := benchmarkBatchSize(b)
+	startKeyFallback, startPrefixFallback := benchmarkNativeProbeFallbackCounters(b, backend)
+	var insertElapsed time.Duration
+	var syncElapsed time.Duration
+
+	metricName := "target_docs/batch"
+	if checkpoint {
+		metricName = "target_docs/checkpoint"
+	}
+	b.ReportAllocs()
+	b.ReportMetric(float64(targetBatchSize), metricName)
+	b.ReportMetric(float64(indexCount), "indexes/doc")
+	b.ResetTimer()
+	for inserted := 0; inserted < b.N; {
+		b.StopTimer()
+		batchSize := targetBatchSize
+		if remaining := b.N - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		ids, docs := benchmarkDocumentBatch(b, inserted, batchSize, true)
+		b.StartTimer()
+
+		insertStart := time.Now()
+		if _, err := collection.InsertBatch(ids, docs); err != nil {
+			b.Fatalf("shape insert batch indexes=%d: %v", indexCount, err)
+		}
+		insertElapsed += time.Since(insertStart)
+		if checkpoint {
+			syncStart := time.Now()
+			benchmarkSyncBoundary(b, backend)
+			syncElapsed += time.Since(syncStart)
+		}
+		inserted += batchSize
+	}
+	b.StopTimer()
+	if checkpoint {
+		benchmarkReportCheckpointSplit(b, b.N, insertElapsed, syncElapsed)
+	}
+	benchmarkReportNativeProbeFallbackDeltas(b, backend, startKeyFallback, startPrefixFallback)
+}
+
+func BenchmarkCollectionShapeInsertBatch(b *testing.B) {
+	for _, indexCount := range []int{0, 1, 2, 3} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkCollectionShapeInsertBatch(b, indexCount, false)
+		})
+	}
+}
+
+func BenchmarkCollectionShapeInsertBatchCheckpoint(b *testing.B) {
+	for _, indexCount := range []int{0, 1, 2, 3} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkCollectionShapeInsertBatch(b, indexCount, true)
+		})
+	}
+}
+
+func benchmarkCollectionShapeSingleStringInsertBatch(b *testing.B, indexCount int, checkpoint bool) {
+	if benchmarkCollectionDocumentFormat(b) != collections.DocumentFormatJSON {
+		b.Skip("single-string shape benchmark uses JSON documents")
+	}
+	backend, collection := openBenchmarkCollection(b, fmt.Sprintf("bench_shape_single_string_%d", indexCount), collectionSingleStringIndexes(indexCount)...)
+	targetBatchSize := benchmarkBatchSize(b)
+	startKeyFallback, startPrefixFallback := benchmarkNativeProbeFallbackCounters(b, backend)
+	var insertElapsed time.Duration
+	var syncElapsed time.Duration
+
+	metricName := "target_docs/batch"
+	if checkpoint {
+		metricName = "target_docs/checkpoint"
+	}
+	b.ReportAllocs()
+	b.ReportMetric(float64(targetBatchSize), metricName)
+	b.ReportMetric(float64(indexCount), "indexes/doc")
+	b.ResetTimer()
+	for inserted := 0; inserted < b.N; {
+		b.StopTimer()
+		batchSize := targetBatchSize
+		if remaining := b.N - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		ids, docs := benchmarkSingleStringDocumentBatch(b, inserted, batchSize)
+		b.StartTimer()
+
+		insertStart := time.Now()
+		if _, err := collection.InsertBatch(ids, docs); err != nil {
+			b.Fatalf("single-string insert batch indexes=%d: %v", indexCount, err)
+		}
+		insertElapsed += time.Since(insertStart)
+		if checkpoint {
+			syncStart := time.Now()
+			benchmarkSyncBoundary(b, backend)
+			syncElapsed += time.Since(syncStart)
+		}
+		inserted += batchSize
+	}
+	b.StopTimer()
+	if checkpoint {
+		benchmarkReportCheckpointSplit(b, b.N, insertElapsed, syncElapsed)
+	}
+	benchmarkReportNativeProbeFallbackDeltas(b, backend, startKeyFallback, startPrefixFallback)
+}
+
+func BenchmarkCollectionShapeInsertBatchSingleStringJSON(b *testing.B) {
+	for _, indexCount := range []int{0, 1} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkCollectionShapeSingleStringInsertBatch(b, indexCount, false)
+		})
+	}
+}
+
+func BenchmarkCollectionShapeInsertBatchCheckpointSingleStringJSON(b *testing.B) {
+	for _, indexCount := range []int{0, 1} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkCollectionShapeSingleStringInsertBatch(b, indexCount, true)
+		})
+	}
+}
+
+func benchmarkCollectionShapeReadPrimary(b *testing.B, indexCount int, parallel bool) {
+	backend, collection := openBenchmarkCollection(b, fmt.Sprintf("bench_shape_read_%d", indexCount), collectionShapeIndexes(indexCount)...)
+	ids := seedBenchmarkCollection(b, collection, 0, collectionBenchSeedDocs, true)
+	benchmarkSyncBoundary(b, backend)
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(indexCount), "indexes/doc")
+	b.ResetTimer()
+	if parallel {
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				if _, err := collection.Get(ids[i%len(ids)]); err != nil {
+					b.Errorf("shape parallel primary read indexes=%d: %v", indexCount, err)
+				}
+				i++
+			}
+		})
+		return
+	}
+	for i := 0; i < b.N; i++ {
+		if _, err := collection.Get(ids[i%len(ids)]); err != nil {
+			b.Fatalf("shape primary read indexes=%d: %v", indexCount, err)
+		}
+	}
+}
+
+func BenchmarkCollectionShapeReadPrimary(b *testing.B) {
+	for _, indexCount := range []int{0, 2} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkCollectionShapeReadPrimary(b, indexCount, false)
+		})
+	}
+}
+
+func BenchmarkCollectionShapeReadPrimaryParallel(b *testing.B) {
+	for _, indexCount := range []int{0, 2} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkCollectionShapeReadPrimary(b, indexCount, true)
+		})
+	}
+}
+
+func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
+	indexes := collectionShapeIndexes(2)
+	backend, collection := openBenchmarkCollection(b, "bench_shape_mixed_read_write", indexes...)
+	seedDocs := benchmarkIntEnv(b, "TREEDB_COLLECTION_MIXED_SEED_DOCS", defaultCollectionMixedSeedDocs)
+	if seedDocs <= 0 {
+		seedDocs = defaultCollectionMixedSeedDocs
+	}
+	ids := seedBenchmarkCollection(b, collection, 0, seedDocs, true)
+	benchmarkSyncBoundary(b, backend)
+
+	writeBatchSize := benchmarkIntEnv(b, "TREEDB_COLLECTION_MIXED_WRITE_BATCH_SIZE", defaultCollectionMixedWriteBatchSize)
+	if writeBatchSize <= 0 {
+		writeBatchSize = defaultCollectionMixedWriteBatchSize
+	}
+	if maxBatch := benchmarkBatchSize(b); writeBatchSize > maxBatch {
+		writeBatchSize = maxBatch
+	}
+
+	var stop atomic.Bool
+	var writerDocs atomic.Uint64
+	errCh := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	documentFormat := benchmarkCollectionDocumentFormat(b)
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(seedDocs), "seed_docs")
+	b.ReportMetric(float64(writeBatchSize), "writer_docs/batch")
+	start := time.Now()
+	b.ResetTimer()
+
+	go func() {
+		defer wg.Done()
+		var templateEncoder collections.TemplateV1Encoder
+		for next := 1_000_000; !stop.Load(); next += writeBatchSize {
+			ids := make([][]byte, writeBatchSize)
+			docs := make([][]byte, writeBatchSize)
+			for i := 0; i < writeBatchSize; i++ {
+				docNum := next + i
+				ids[i] = benchmarkDocumentID(docNum)
+				if documentFormat == collections.DocumentFormatTemplateV1 {
+					doc, err := templateEncoder.EncodeDocument(
+						[]string{"name", "email", "city", "pad"},
+						[]any{
+							fmt.Sprintf("user-%09d", docNum),
+							fmt.Sprintf("user-%09d@example.com", docNum),
+							fmt.Sprintf("city-%02d", docNum%collectionBenchCities),
+							collectionBenchIndexedPad,
+						},
+					)
+					if err != nil {
+						select {
+						case errCh <- err:
+						default:
+						}
+						return
+					}
+					docs[i] = doc
+				} else {
+					docs[i] = benchmarkIndexedDocument(docNum)
+				}
+			}
+			if _, err := collection.InsertBatch(ids, docs); err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+				return
+			}
+			writerDocs.Add(uint64(writeBatchSize))
+		}
+	}()
+
+	if secondaryRead {
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				email := fmt.Sprintf("user-%09d@example.com", i%seedDocs)
+				if _, err := collection.FindByIndex("email_idx", email); err != nil {
+					b.Errorf("mixed secondary read: %v", err)
+				}
+				i += runtime.GOMAXPROCS(0)
+			}
+		})
+	} else {
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				if _, err := collection.Get(ids[i%len(ids)]); err != nil {
+					b.Errorf("mixed primary read: %v", err)
+				}
+				i += runtime.GOMAXPROCS(0)
+			}
+		})
+	}
+
+	b.StopTimer()
+	stop.Store(true)
+	wg.Wait()
+	elapsed := time.Since(start)
+	select {
+	case err := <-errCh:
+		b.Fatalf("mixed writer: %v", err)
+	default:
+	}
+	if elapsed > 0 {
+		b.ReportMetric(float64(writerDocs.Load())/elapsed.Seconds(), "writer_docs/sec")
+	}
+}
+
+func BenchmarkCollectionMixedReadWritePrimary(b *testing.B) {
+	benchmarkCollectionMixedReadWrite(b, false)
+}
+
+func BenchmarkCollectionMixedReadWriteSecondaryUnique(b *testing.B) {
+	benchmarkCollectionMixedReadWrite(b, true)
+}

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -235,13 +235,24 @@ func BenchmarkCollectionShapeReadPrimaryParallel(b *testing.B) {
 
 func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
 	indexes := collectionShapeIndexes(2)
-	backend, collection := openBenchmarkCollection(b, "bench_shape_mixed_read_write", indexes...)
+	collectionName := "bench_shape_mixed_read_write"
+	backend, seedCollection := openBenchmarkCollection(b, collectionName, indexes...)
 	seedDocs := benchmarkIntEnv(b, "TREEDB_COLLECTION_MIXED_SEED_DOCS", defaultCollectionMixedSeedDocs)
 	if seedDocs <= 0 {
 		seedDocs = defaultCollectionMixedSeedDocs
 	}
-	ids := seedBenchmarkCollection(b, collection, 0, seedDocs, true)
+	ids := seedBenchmarkCollection(b, seedCollection, 0, seedDocs, true)
 	benchmarkSyncBoundary(b, backend)
+
+	manager := collections.NewCollectionManager(backend)
+	readerCollection, err := manager.OpenCollection(collectionName)
+	if err != nil {
+		b.Fatalf("open mixed reader collection: %v", err)
+	}
+	writerCollection, err := manager.OpenCollection(collectionName)
+	if err != nil {
+		b.Fatalf("open mixed writer collection: %v", err)
+	}
 
 	writeBatchSize := benchmarkIntEnv(b, "TREEDB_COLLECTION_MIXED_WRITE_BATCH_SIZE", defaultCollectionMixedWriteBatchSize)
 	if writeBatchSize <= 0 {
@@ -295,7 +306,7 @@ func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
 					docs[i] = benchmarkIndexedDocument(docNum)
 				}
 			}
-			if _, err := collection.InsertBatch(ids, docs); err != nil {
+			if _, err := writerCollection.InsertBatch(ids, docs); err != nil {
 				select {
 				case errCh <- err:
 				default:
@@ -328,7 +339,7 @@ func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
 			i := nextReaderStart(seedDocs)
 			for pb.Next() {
 				email := fmt.Sprintf("user-%09d@example.com", i%seedDocs)
-				if _, err := collection.FindByIndex("email_idx", email); err != nil {
+				if _, err := readerCollection.FindByIndex("email_idx", email); err != nil {
 					b.Errorf("mixed secondary read: %v", err)
 				}
 				i += readerStride
@@ -338,7 +349,7 @@ func benchmarkCollectionMixedReadWrite(b *testing.B, secondaryRead bool) {
 		b.RunParallel(func(pb *testing.PB) {
 			i := nextReaderStart(len(ids))
 			for pb.Next() {
-				if _, err := collection.Get(ids[i%len(ids)]); err != nil {
+				if _, err := readerCollection.Get(ids[i%len(ids)]); err != nil {
 					b.Errorf("mixed primary read: %v", err)
 				}
 				i += readerStride

--- a/TreeDB/collections/sqlite_bench_test.go
+++ b/TreeDB/collections/sqlite_bench_test.go
@@ -276,7 +276,6 @@ func checkpointSQLiteWAL(tb testing.TB, db *sql.DB) {
 }
 
 func TestSQLiteBenchmarkSchemaExtractsIndexedFields(t *testing.T) {
-	t.Setenv("TREEDB_COLLECTION_DOCUMENT_FORMAT", "template-v1")
 	db := openBenchmarkSQLiteDB(t, "schema_extract")
 	ids, docs := benchmarkSQLiteDocumentBatch(t, 0, 1)
 	insertSQLiteDocumentBatch(t, db, ids, docs)

--- a/TreeDB/collections/sqlite_bench_test.go
+++ b/TreeDB/collections/sqlite_bench_test.go
@@ -5,8 +5,10 @@ package collections_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,17 +23,36 @@ const (
 func openBenchmarkSQLiteDB(tb testing.TB, name string) *sql.DB {
 	tb.Helper()
 
+	return openBenchmarkSQLiteJSONShapeDB(tb, name, 2)
+}
+
+func openBenchmarkSQLiteNativeColumnsDB(tb testing.TB, name string) *sql.DB {
+	tb.Helper()
+
+	return openBenchmarkSQLiteNativeColumnsShapeDB(tb, name, 2)
+}
+
+func openBenchmarkSQLiteJSONShapeDB(tb testing.TB, name string, indexCount int) *sql.DB {
+	tb.Helper()
+
 	db := openBenchmarkSQLiteBaseDB(tb, name)
-	for _, stmt := range []string{
-		`CREATE TABLE documents (
-			id TEXT PRIMARY KEY,
-			document TEXT NOT NULL,
-			email TEXT GENERATED ALWAYS AS (json_extract(document, '$.email')) STORED,
-			city TEXT GENERATED ALWAYS AS (json_extract(document, '$.city')) STORED
-		) WITHOUT ROWID`,
-		`CREATE UNIQUE INDEX documents_email_idx ON documents(email)`,
-		`CREATE INDEX documents_city_idx ON documents(city)`,
-	} {
+	columns := []string{
+		"id TEXT PRIMARY KEY",
+		"document TEXT NOT NULL",
+	}
+	if indexCount >= 1 {
+		columns = append(columns, "email TEXT GENERATED ALWAYS AS (json_extract(document, '$.email')) STORED")
+	}
+	if indexCount >= 2 {
+		columns = append(columns, "city TEXT GENERATED ALWAYS AS (json_extract(document, '$.city')) STORED")
+	}
+	if indexCount >= 3 {
+		columns = append(columns, "name TEXT GENERATED ALWAYS AS (json_extract(document, '$.name')) STORED")
+	}
+	stmts := append([]string{
+		"CREATE TABLE documents (" + strings.Join(columns, ", ") + ") WITHOUT ROWID",
+	}, sqliteShapeIndexStatements(indexCount)...)
+	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
 			tb.Fatalf("sqlite setup %q: %v", stmt, err)
 		}
@@ -39,11 +60,11 @@ func openBenchmarkSQLiteDB(tb testing.TB, name string) *sql.DB {
 	return db
 }
 
-func openBenchmarkSQLiteNativeColumnsDB(tb testing.TB, name string) *sql.DB {
+func openBenchmarkSQLiteNativeColumnsShapeDB(tb testing.TB, name string, indexCount int) *sql.DB {
 	tb.Helper()
 
 	db := openBenchmarkSQLiteBaseDB(tb, name)
-	for _, stmt := range []string{
+	stmts := append([]string{
 		`CREATE TABLE documents (
 			id TEXT PRIMARY KEY,
 			name TEXT NOT NULL,
@@ -51,14 +72,35 @@ func openBenchmarkSQLiteNativeColumnsDB(tb testing.TB, name string) *sql.DB {
 			city TEXT NOT NULL,
 			pad TEXT NOT NULL
 		) WITHOUT ROWID`,
-		`CREATE UNIQUE INDEX documents_email_idx ON documents(email)`,
-		`CREATE INDEX documents_city_idx ON documents(city)`,
-	} {
+	}, sqliteShapeIndexStatements(indexCount)...)
+	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
 			tb.Fatalf("sqlite native-columns setup %q: %v", stmt, err)
 		}
 	}
 	return db
+}
+
+func sqliteShapeIndexStatements(indexCount int) []string {
+	switch indexCount {
+	case 0:
+		return nil
+	case 1:
+		return []string{`CREATE UNIQUE INDEX documents_email_idx ON documents(email)`}
+	case 2:
+		return []string{
+			`CREATE UNIQUE INDEX documents_email_idx ON documents(email)`,
+			`CREATE INDEX documents_city_idx ON documents(city)`,
+		}
+	case 3:
+		return []string{
+			`CREATE UNIQUE INDEX documents_email_idx ON documents(email)`,
+			`CREATE INDEX documents_city_idx ON documents(city)`,
+			`CREATE INDEX documents_name_idx ON documents(name)`,
+		}
+	default:
+		panic(fmt.Sprintf("unsupported sqlite benchmark index count %d", indexCount))
+	}
 }
 
 func openBenchmarkSQLiteBaseDB(tb testing.TB, name string) *sql.DB {
@@ -381,4 +423,310 @@ func BenchmarkSQLiteNativeColumnsInsertBatchCheckpointWithSecondaryIndexes(b *te
 	}
 	b.StopTimer()
 	benchmarkReportCheckpointSplit(b, b.N, insertElapsed, syncElapsed)
+}
+
+func benchmarkSQLiteShapeInsertBatchJSON(b *testing.B, indexCount int, checkpoint bool) {
+	db := openBenchmarkSQLiteJSONShapeDB(b, fmt.Sprintf("bench_shape_json_%d", indexCount), indexCount)
+	targetBatchSize := benchmarkBatchSize(b)
+	var insertElapsed time.Duration
+	var syncElapsed time.Duration
+
+	metricName := "target_docs/batch"
+	if checkpoint {
+		metricName = "target_docs/checkpoint"
+	}
+	b.ReportAllocs()
+	b.ReportMetric(float64(indexCount), "indexes/doc")
+	b.ReportMetric(float64(targetBatchSize), metricName)
+	b.ResetTimer()
+	for inserted := 0; inserted < b.N; {
+		b.StopTimer()
+		batchSize := targetBatchSize
+		if remaining := b.N - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		ids, docs := benchmarkSQLiteDocumentBatch(b, inserted, batchSize)
+		b.StartTimer()
+
+		insertStart := time.Now()
+		insertSQLiteDocumentBatch(b, db, ids, docs)
+		insertElapsed += time.Since(insertStart)
+		if checkpoint {
+			syncStart := time.Now()
+			checkpointSQLiteWAL(b, db)
+			syncElapsed += time.Since(syncStart)
+		}
+		inserted += batchSize
+	}
+	b.StopTimer()
+	if checkpoint {
+		benchmarkReportCheckpointSplit(b, b.N, insertElapsed, syncElapsed)
+	}
+}
+
+func benchmarkSQLiteShapeInsertBatchNativeColumns(b *testing.B, indexCount int, checkpoint bool) {
+	db := openBenchmarkSQLiteNativeColumnsShapeDB(b, fmt.Sprintf("bench_shape_native_%d", indexCount), indexCount)
+	targetBatchSize := benchmarkBatchSize(b)
+	var insertElapsed time.Duration
+	var syncElapsed time.Duration
+
+	metricName := "target_docs/batch"
+	if checkpoint {
+		metricName = "target_docs/checkpoint"
+	}
+	b.ReportAllocs()
+	b.ReportMetric(float64(indexCount), "indexes/doc")
+	b.ReportMetric(float64(targetBatchSize), metricName)
+	b.ResetTimer()
+	for inserted := 0; inserted < b.N; {
+		b.StopTimer()
+		batchSize := targetBatchSize
+		if remaining := b.N - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		docs := benchmarkSQLiteNativeColumnsDocumentBatch(b, inserted, batchSize)
+		b.StartTimer()
+
+		insertStart := time.Now()
+		insertSQLiteNativeColumnsDocumentBatch(b, db, docs)
+		insertElapsed += time.Since(insertStart)
+		if checkpoint {
+			syncStart := time.Now()
+			checkpointSQLiteWAL(b, db)
+			syncElapsed += time.Since(syncStart)
+		}
+		inserted += batchSize
+	}
+	b.StopTimer()
+	if checkpoint {
+		benchmarkReportCheckpointSplit(b, b.N, insertElapsed, syncElapsed)
+	}
+}
+
+func BenchmarkSQLiteShapeInsertBatchJSON(b *testing.B) {
+	for _, indexCount := range []int{0, 1, 2, 3} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeInsertBatchJSON(b, indexCount, false)
+		})
+	}
+}
+
+func BenchmarkSQLiteShapeInsertBatchCheckpointJSON(b *testing.B) {
+	for _, indexCount := range []int{0, 1, 2, 3} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeInsertBatchJSON(b, indexCount, true)
+		})
+	}
+}
+
+func BenchmarkSQLiteShapeInsertBatchNativeColumns(b *testing.B) {
+	for _, indexCount := range []int{0, 1, 2, 3} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeInsertBatchNativeColumns(b, indexCount, false)
+		})
+	}
+}
+
+func BenchmarkSQLiteShapeInsertBatchCheckpointNativeColumns(b *testing.B) {
+	for _, indexCount := range []int{0, 1, 2, 3} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeInsertBatchNativeColumns(b, indexCount, true)
+		})
+	}
+}
+
+func seedBenchmarkSQLiteJSON(b *testing.B, db *sql.DB, count int) []string {
+	b.Helper()
+
+	targetBatchSize := benchmarkBatchSize(b)
+	allIDs := make([]string, 0, count)
+	for inserted := 0; inserted < count; inserted += targetBatchSize {
+		batchSize := targetBatchSize
+		if remaining := count - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		ids, docs := benchmarkSQLiteDocumentBatch(b, inserted, batchSize)
+		insertSQLiteDocumentBatch(b, db, ids, docs)
+		allIDs = append(allIDs, ids...)
+	}
+	return allIDs
+}
+
+func seedBenchmarkSQLiteNativeColumns(b *testing.B, db *sql.DB, count int) []benchmarkSQLiteNativeColumnsDocument {
+	b.Helper()
+
+	targetBatchSize := benchmarkBatchSize(b)
+	allDocs := make([]benchmarkSQLiteNativeColumnsDocument, 0, count)
+	for inserted := 0; inserted < count; inserted += targetBatchSize {
+		batchSize := targetBatchSize
+		if remaining := count - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		docs := benchmarkSQLiteNativeColumnsDocumentBatch(b, inserted, batchSize)
+		insertSQLiteNativeColumnsDocumentBatch(b, db, docs)
+		allDocs = append(allDocs, docs...)
+	}
+	return allDocs
+}
+
+func benchmarkSQLiteShapeReadPrimaryJSON(b *testing.B, indexCount int) {
+	db := openBenchmarkSQLiteJSONShapeDB(b, fmt.Sprintf("bench_shape_read_json_%d", indexCount), indexCount)
+	ids := seedBenchmarkSQLiteJSON(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	stmt, err := db.Prepare(`SELECT document FROM documents WHERE id = ?`)
+	if err != nil {
+		b.Fatalf("sqlite prepare primary JSON read: %v", err)
+	}
+	defer stmt.Close()
+
+	var doc string
+	b.ReportAllocs()
+	b.ReportMetric(float64(indexCount), "indexes/doc")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := stmt.QueryRow(ids[i%len(ids)]).Scan(&doc); err != nil {
+			b.Fatalf("sqlite primary JSON read: %v", err)
+		}
+	}
+}
+
+func benchmarkSQLiteShapeReadPrimaryNativeColumns(b *testing.B, indexCount int) {
+	db := openBenchmarkSQLiteNativeColumnsShapeDB(b, fmt.Sprintf("bench_shape_read_native_%d", indexCount), indexCount)
+	docs := seedBenchmarkSQLiteNativeColumns(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	stmt, err := db.Prepare(`SELECT name, email, city, pad FROM documents WHERE id = ?`)
+	if err != nil {
+		b.Fatalf("sqlite prepare primary native read: %v", err)
+	}
+	defer stmt.Close()
+
+	var name, email, city, pad string
+	b.ReportAllocs()
+	b.ReportMetric(float64(indexCount), "indexes/doc")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := stmt.QueryRow(docs[i%len(docs)].id).Scan(&name, &email, &city, &pad); err != nil {
+			b.Fatalf("sqlite primary native read: %v", err)
+		}
+	}
+}
+
+func BenchmarkSQLiteShapeReadPrimaryJSON(b *testing.B) {
+	for _, indexCount := range []int{0, 2} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeReadPrimaryJSON(b, indexCount)
+		})
+	}
+}
+
+func BenchmarkSQLiteShapeReadPrimaryNativeColumns(b *testing.B) {
+	for _, indexCount := range []int{0, 2} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeReadPrimaryNativeColumns(b, indexCount)
+		})
+	}
+}
+
+func benchmarkSQLiteShapeSecondaryLookupJSON(b *testing.B, unique bool) {
+	db := openBenchmarkSQLiteJSONShapeDB(b, "bench_shape_secondary_json", 2)
+	seedBenchmarkSQLiteJSON(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	query := `SELECT id FROM documents WHERE email = ?`
+	if !unique {
+		query = `SELECT id FROM documents WHERE city = ?`
+	}
+	stmt, err := db.Prepare(query)
+	if err != nil {
+		b.Fatalf("sqlite prepare secondary JSON lookup: %v", err)
+	}
+	defer stmt.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if unique {
+			email := benchmarkSQLiteUserEmail(i % collectionBenchSeedDocs)
+			var id string
+			if err := stmt.QueryRow(email).Scan(&id); err != nil {
+				b.Fatalf("sqlite unique JSON lookup: %v", err)
+			}
+			continue
+		}
+		city := benchmarkSQLiteCity(i)
+		rows, err := stmt.Query(city)
+		if err != nil {
+			b.Fatalf("sqlite nonunique JSON lookup: %v", err)
+		}
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				_ = rows.Close()
+				b.Fatalf("sqlite nonunique JSON scan: %v", err)
+			}
+		}
+		if err := rows.Close(); err != nil {
+			b.Fatalf("sqlite nonunique JSON close: %v", err)
+		}
+	}
+}
+
+func benchmarkSQLiteShapeSecondaryLookupNativeColumns(b *testing.B, unique bool) {
+	db := openBenchmarkSQLiteNativeColumnsShapeDB(b, "bench_shape_secondary_native", 2)
+	seedBenchmarkSQLiteNativeColumns(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	query := `SELECT id FROM documents WHERE email = ?`
+	if !unique {
+		query = `SELECT id FROM documents WHERE city = ?`
+	}
+	stmt, err := db.Prepare(query)
+	if err != nil {
+		b.Fatalf("sqlite prepare secondary native lookup: %v", err)
+	}
+	defer stmt.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if unique {
+			email := benchmarkSQLiteUserEmail(i % collectionBenchSeedDocs)
+			var id string
+			if err := stmt.QueryRow(email).Scan(&id); err != nil {
+				b.Fatalf("sqlite unique native lookup: %v", err)
+			}
+			continue
+		}
+		city := benchmarkSQLiteCity(i)
+		rows, err := stmt.Query(city)
+		if err != nil {
+			b.Fatalf("sqlite nonunique native lookup: %v", err)
+		}
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				_ = rows.Close()
+				b.Fatalf("sqlite nonunique native scan: %v", err)
+			}
+		}
+		if err := rows.Close(); err != nil {
+			b.Fatalf("sqlite nonunique native close: %v", err)
+		}
+	}
+}
+
+func BenchmarkSQLiteShapeSecondaryLookupJSON(b *testing.B) {
+	b.Run("unique", func(b *testing.B) {
+		benchmarkSQLiteShapeSecondaryLookupJSON(b, true)
+	})
+	b.Run("non_unique", func(b *testing.B) {
+		benchmarkSQLiteShapeSecondaryLookupJSON(b, false)
+	})
+}
+
+func BenchmarkSQLiteShapeSecondaryLookupNativeColumns(b *testing.B) {
+	b.Run("unique", func(b *testing.B) {
+		benchmarkSQLiteShapeSecondaryLookupNativeColumns(b, true)
+	})
+	b.Run("non_unique", func(b *testing.B) {
+		benchmarkSQLiteShapeSecondaryLookupNativeColumns(b, false)
+	})
 }

--- a/TreeDB/collections/sqlite_bench_test.go
+++ b/TreeDB/collections/sqlite_bench_test.go
@@ -448,13 +448,15 @@ func benchmarkSQLiteShapeInsertBatchJSON(b *testing.B, indexCount int, checkpoin
 		ids, docs := benchmarkSQLiteDocumentBatch(b, inserted, batchSize)
 		b.StartTimer()
 
-		insertStart := time.Now()
-		insertSQLiteDocumentBatch(b, db, ids, docs)
-		insertElapsed += time.Since(insertStart)
 		if checkpoint {
+			insertStart := time.Now()
+			insertSQLiteDocumentBatch(b, db, ids, docs)
+			insertElapsed += time.Since(insertStart)
 			syncStart := time.Now()
 			checkpointSQLiteWAL(b, db)
 			syncElapsed += time.Since(syncStart)
+		} else {
+			insertSQLiteDocumentBatch(b, db, ids, docs)
 		}
 		inserted += batchSize
 	}
@@ -487,13 +489,15 @@ func benchmarkSQLiteShapeInsertBatchNativeColumns(b *testing.B, indexCount int, 
 		docs := benchmarkSQLiteNativeColumnsDocumentBatch(b, inserted, batchSize)
 		b.StartTimer()
 
-		insertStart := time.Now()
-		insertSQLiteNativeColumnsDocumentBatch(b, db, docs)
-		insertElapsed += time.Since(insertStart)
 		if checkpoint {
+			insertStart := time.Now()
+			insertSQLiteNativeColumnsDocumentBatch(b, db, docs)
+			insertElapsed += time.Since(insertStart)
 			syncStart := time.Now()
 			checkpointSQLiteWAL(b, db)
 			syncElapsed += time.Since(syncStart)
+		} else {
+			insertSQLiteNativeColumnsDocumentBatch(b, db, docs)
 		}
 		inserted += batchSize
 	}
@@ -664,6 +668,10 @@ func benchmarkSQLiteShapeSecondaryLookupJSON(b *testing.B, unique bool) {
 				b.Fatalf("sqlite nonunique JSON scan: %v", err)
 			}
 		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			b.Fatalf("sqlite nonunique JSON rows: %v", err)
+		}
 		if err := rows.Close(); err != nil {
 			b.Fatalf("sqlite nonunique JSON close: %v", err)
 		}
@@ -706,6 +714,10 @@ func benchmarkSQLiteShapeSecondaryLookupNativeColumns(b *testing.B, unique bool)
 				_ = rows.Close()
 				b.Fatalf("sqlite nonunique native scan: %v", err)
 			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			b.Fatalf("sqlite nonunique native rows: %v", err)
 		}
 		if err := rows.Close(); err != nil {
 			b.Fatalf("sqlite nonunique native close: %v", err)

--- a/TreeDB/collections/sqlite_bench_test.go
+++ b/TreeDB/collections/sqlite_bench_test.go
@@ -5,8 +5,10 @@ package collections_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,17 +23,36 @@ const (
 func openBenchmarkSQLiteDB(tb testing.TB, name string) *sql.DB {
 	tb.Helper()
 
+	return openBenchmarkSQLiteJSONShapeDB(tb, name, 2)
+}
+
+func openBenchmarkSQLiteNativeColumnsDB(tb testing.TB, name string) *sql.DB {
+	tb.Helper()
+
+	return openBenchmarkSQLiteNativeColumnsShapeDB(tb, name, 2)
+}
+
+func openBenchmarkSQLiteJSONShapeDB(tb testing.TB, name string, indexCount int) *sql.DB {
+	tb.Helper()
+
 	db := openBenchmarkSQLiteBaseDB(tb, name)
-	for _, stmt := range []string{
-		`CREATE TABLE documents (
-			id TEXT PRIMARY KEY,
-			document TEXT NOT NULL,
-			email TEXT GENERATED ALWAYS AS (json_extract(document, '$.email')) STORED,
-			city TEXT GENERATED ALWAYS AS (json_extract(document, '$.city')) STORED
-		) WITHOUT ROWID`,
-		`CREATE UNIQUE INDEX documents_email_idx ON documents(email)`,
-		`CREATE INDEX documents_city_idx ON documents(city)`,
-	} {
+	columns := []string{
+		"id TEXT PRIMARY KEY",
+		"document TEXT NOT NULL",
+	}
+	if indexCount >= 1 {
+		columns = append(columns, "email TEXT GENERATED ALWAYS AS (json_extract(document, '$.email')) STORED")
+	}
+	if indexCount >= 2 {
+		columns = append(columns, "city TEXT GENERATED ALWAYS AS (json_extract(document, '$.city')) STORED")
+	}
+	if indexCount >= 3 {
+		columns = append(columns, "name TEXT GENERATED ALWAYS AS (json_extract(document, '$.name')) STORED")
+	}
+	stmts := append([]string{
+		"CREATE TABLE documents (" + strings.Join(columns, ", ") + ") WITHOUT ROWID",
+	}, sqliteShapeIndexStatements(indexCount)...)
+	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
 			tb.Fatalf("sqlite setup %q: %v", stmt, err)
 		}
@@ -39,11 +60,11 @@ func openBenchmarkSQLiteDB(tb testing.TB, name string) *sql.DB {
 	return db
 }
 
-func openBenchmarkSQLiteNativeColumnsDB(tb testing.TB, name string) *sql.DB {
+func openBenchmarkSQLiteNativeColumnsShapeDB(tb testing.TB, name string, indexCount int) *sql.DB {
 	tb.Helper()
 
 	db := openBenchmarkSQLiteBaseDB(tb, name)
-	for _, stmt := range []string{
+	stmts := append([]string{
 		`CREATE TABLE documents (
 			id TEXT PRIMARY KEY,
 			name TEXT NOT NULL,
@@ -51,14 +72,35 @@ func openBenchmarkSQLiteNativeColumnsDB(tb testing.TB, name string) *sql.DB {
 			city TEXT NOT NULL,
 			pad TEXT NOT NULL
 		) WITHOUT ROWID`,
-		`CREATE UNIQUE INDEX documents_email_idx ON documents(email)`,
-		`CREATE INDEX documents_city_idx ON documents(city)`,
-	} {
+	}, sqliteShapeIndexStatements(indexCount)...)
+	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
 			tb.Fatalf("sqlite native-columns setup %q: %v", stmt, err)
 		}
 	}
 	return db
+}
+
+func sqliteShapeIndexStatements(indexCount int) []string {
+	switch indexCount {
+	case 0:
+		return nil
+	case 1:
+		return []string{`CREATE UNIQUE INDEX documents_email_idx ON documents(email)`}
+	case 2:
+		return []string{
+			`CREATE UNIQUE INDEX documents_email_idx ON documents(email)`,
+			`CREATE INDEX documents_city_idx ON documents(city)`,
+		}
+	case 3:
+		return []string{
+			`CREATE UNIQUE INDEX documents_email_idx ON documents(email)`,
+			`CREATE INDEX documents_city_idx ON documents(city)`,
+			`CREATE INDEX documents_name_idx ON documents(name)`,
+		}
+	default:
+		panic(fmt.Sprintf("unsupported sqlite benchmark index count %d", indexCount))
+	}
 }
 
 func openBenchmarkSQLiteBaseDB(tb testing.TB, name string) *sql.DB {
@@ -382,4 +424,310 @@ func BenchmarkSQLiteNativeColumnsInsertBatchCheckpointWithSecondaryIndexes(b *te
 	}
 	b.StopTimer()
 	benchmarkReportCheckpointSplit(b, b.N, insertElapsed, syncElapsed)
+}
+
+func benchmarkSQLiteShapeInsertBatchJSON(b *testing.B, indexCount int, checkpoint bool) {
+	db := openBenchmarkSQLiteJSONShapeDB(b, fmt.Sprintf("bench_shape_json_%d", indexCount), indexCount)
+	targetBatchSize := benchmarkBatchSize(b)
+	var insertElapsed time.Duration
+	var syncElapsed time.Duration
+
+	metricName := "target_docs/batch"
+	if checkpoint {
+		metricName = "target_docs/checkpoint"
+	}
+	b.ReportAllocs()
+	b.ReportMetric(float64(indexCount), "indexes/doc")
+	b.ReportMetric(float64(targetBatchSize), metricName)
+	b.ResetTimer()
+	for inserted := 0; inserted < b.N; {
+		b.StopTimer()
+		batchSize := targetBatchSize
+		if remaining := b.N - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		ids, docs := benchmarkSQLiteDocumentBatch(b, inserted, batchSize)
+		b.StartTimer()
+
+		insertStart := time.Now()
+		insertSQLiteDocumentBatch(b, db, ids, docs)
+		insertElapsed += time.Since(insertStart)
+		if checkpoint {
+			syncStart := time.Now()
+			checkpointSQLiteWAL(b, db)
+			syncElapsed += time.Since(syncStart)
+		}
+		inserted += batchSize
+	}
+	b.StopTimer()
+	if checkpoint {
+		benchmarkReportCheckpointSplit(b, b.N, insertElapsed, syncElapsed)
+	}
+}
+
+func benchmarkSQLiteShapeInsertBatchNativeColumns(b *testing.B, indexCount int, checkpoint bool) {
+	db := openBenchmarkSQLiteNativeColumnsShapeDB(b, fmt.Sprintf("bench_shape_native_%d", indexCount), indexCount)
+	targetBatchSize := benchmarkBatchSize(b)
+	var insertElapsed time.Duration
+	var syncElapsed time.Duration
+
+	metricName := "target_docs/batch"
+	if checkpoint {
+		metricName = "target_docs/checkpoint"
+	}
+	b.ReportAllocs()
+	b.ReportMetric(float64(indexCount), "indexes/doc")
+	b.ReportMetric(float64(targetBatchSize), metricName)
+	b.ResetTimer()
+	for inserted := 0; inserted < b.N; {
+		b.StopTimer()
+		batchSize := targetBatchSize
+		if remaining := b.N - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		docs := benchmarkSQLiteNativeColumnsDocumentBatch(b, inserted, batchSize)
+		b.StartTimer()
+
+		insertStart := time.Now()
+		insertSQLiteNativeColumnsDocumentBatch(b, db, docs)
+		insertElapsed += time.Since(insertStart)
+		if checkpoint {
+			syncStart := time.Now()
+			checkpointSQLiteWAL(b, db)
+			syncElapsed += time.Since(syncStart)
+		}
+		inserted += batchSize
+	}
+	b.StopTimer()
+	if checkpoint {
+		benchmarkReportCheckpointSplit(b, b.N, insertElapsed, syncElapsed)
+	}
+}
+
+func BenchmarkSQLiteShapeInsertBatchJSON(b *testing.B) {
+	for _, indexCount := range []int{0, 1, 2, 3} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeInsertBatchJSON(b, indexCount, false)
+		})
+	}
+}
+
+func BenchmarkSQLiteShapeInsertBatchCheckpointJSON(b *testing.B) {
+	for _, indexCount := range []int{0, 1, 2, 3} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeInsertBatchJSON(b, indexCount, true)
+		})
+	}
+}
+
+func BenchmarkSQLiteShapeInsertBatchNativeColumns(b *testing.B) {
+	for _, indexCount := range []int{0, 1, 2, 3} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeInsertBatchNativeColumns(b, indexCount, false)
+		})
+	}
+}
+
+func BenchmarkSQLiteShapeInsertBatchCheckpointNativeColumns(b *testing.B) {
+	for _, indexCount := range []int{0, 1, 2, 3} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeInsertBatchNativeColumns(b, indexCount, true)
+		})
+	}
+}
+
+func seedBenchmarkSQLiteJSON(b *testing.B, db *sql.DB, count int) []string {
+	b.Helper()
+
+	targetBatchSize := benchmarkBatchSize(b)
+	allIDs := make([]string, 0, count)
+	for inserted := 0; inserted < count; inserted += targetBatchSize {
+		batchSize := targetBatchSize
+		if remaining := count - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		ids, docs := benchmarkSQLiteDocumentBatch(b, inserted, batchSize)
+		insertSQLiteDocumentBatch(b, db, ids, docs)
+		allIDs = append(allIDs, ids...)
+	}
+	return allIDs
+}
+
+func seedBenchmarkSQLiteNativeColumns(b *testing.B, db *sql.DB, count int) []benchmarkSQLiteNativeColumnsDocument {
+	b.Helper()
+
+	targetBatchSize := benchmarkBatchSize(b)
+	allDocs := make([]benchmarkSQLiteNativeColumnsDocument, 0, count)
+	for inserted := 0; inserted < count; inserted += targetBatchSize {
+		batchSize := targetBatchSize
+		if remaining := count - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		docs := benchmarkSQLiteNativeColumnsDocumentBatch(b, inserted, batchSize)
+		insertSQLiteNativeColumnsDocumentBatch(b, db, docs)
+		allDocs = append(allDocs, docs...)
+	}
+	return allDocs
+}
+
+func benchmarkSQLiteShapeReadPrimaryJSON(b *testing.B, indexCount int) {
+	db := openBenchmarkSQLiteJSONShapeDB(b, fmt.Sprintf("bench_shape_read_json_%d", indexCount), indexCount)
+	ids := seedBenchmarkSQLiteJSON(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	stmt, err := db.Prepare(`SELECT document FROM documents WHERE id = ?`)
+	if err != nil {
+		b.Fatalf("sqlite prepare primary JSON read: %v", err)
+	}
+	defer stmt.Close()
+
+	var doc string
+	b.ReportAllocs()
+	b.ReportMetric(float64(indexCount), "indexes/doc")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := stmt.QueryRow(ids[i%len(ids)]).Scan(&doc); err != nil {
+			b.Fatalf("sqlite primary JSON read: %v", err)
+		}
+	}
+}
+
+func benchmarkSQLiteShapeReadPrimaryNativeColumns(b *testing.B, indexCount int) {
+	db := openBenchmarkSQLiteNativeColumnsShapeDB(b, fmt.Sprintf("bench_shape_read_native_%d", indexCount), indexCount)
+	docs := seedBenchmarkSQLiteNativeColumns(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	stmt, err := db.Prepare(`SELECT name, email, city, pad FROM documents WHERE id = ?`)
+	if err != nil {
+		b.Fatalf("sqlite prepare primary native read: %v", err)
+	}
+	defer stmt.Close()
+
+	var name, email, city, pad string
+	b.ReportAllocs()
+	b.ReportMetric(float64(indexCount), "indexes/doc")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := stmt.QueryRow(docs[i%len(docs)].id).Scan(&name, &email, &city, &pad); err != nil {
+			b.Fatalf("sqlite primary native read: %v", err)
+		}
+	}
+}
+
+func BenchmarkSQLiteShapeReadPrimaryJSON(b *testing.B) {
+	for _, indexCount := range []int{0, 2} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeReadPrimaryJSON(b, indexCount)
+		})
+	}
+}
+
+func BenchmarkSQLiteShapeReadPrimaryNativeColumns(b *testing.B) {
+	for _, indexCount := range []int{0, 2} {
+		b.Run(fmt.Sprintf("indexes_%d", indexCount), func(b *testing.B) {
+			benchmarkSQLiteShapeReadPrimaryNativeColumns(b, indexCount)
+		})
+	}
+}
+
+func benchmarkSQLiteShapeSecondaryLookupJSON(b *testing.B, unique bool) {
+	db := openBenchmarkSQLiteJSONShapeDB(b, "bench_shape_secondary_json", 2)
+	seedBenchmarkSQLiteJSON(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	query := `SELECT id FROM documents WHERE email = ?`
+	if !unique {
+		query = `SELECT id FROM documents WHERE city = ?`
+	}
+	stmt, err := db.Prepare(query)
+	if err != nil {
+		b.Fatalf("sqlite prepare secondary JSON lookup: %v", err)
+	}
+	defer stmt.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if unique {
+			email := benchmarkSQLiteUserEmail(i % collectionBenchSeedDocs)
+			var id string
+			if err := stmt.QueryRow(email).Scan(&id); err != nil {
+				b.Fatalf("sqlite unique JSON lookup: %v", err)
+			}
+			continue
+		}
+		city := benchmarkSQLiteCity(i)
+		rows, err := stmt.Query(city)
+		if err != nil {
+			b.Fatalf("sqlite nonunique JSON lookup: %v", err)
+		}
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				_ = rows.Close()
+				b.Fatalf("sqlite nonunique JSON scan: %v", err)
+			}
+		}
+		if err := rows.Close(); err != nil {
+			b.Fatalf("sqlite nonunique JSON close: %v", err)
+		}
+	}
+}
+
+func benchmarkSQLiteShapeSecondaryLookupNativeColumns(b *testing.B, unique bool) {
+	db := openBenchmarkSQLiteNativeColumnsShapeDB(b, "bench_shape_secondary_native", 2)
+	seedBenchmarkSQLiteNativeColumns(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	query := `SELECT id FROM documents WHERE email = ?`
+	if !unique {
+		query = `SELECT id FROM documents WHERE city = ?`
+	}
+	stmt, err := db.Prepare(query)
+	if err != nil {
+		b.Fatalf("sqlite prepare secondary native lookup: %v", err)
+	}
+	defer stmt.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if unique {
+			email := benchmarkSQLiteUserEmail(i % collectionBenchSeedDocs)
+			var id string
+			if err := stmt.QueryRow(email).Scan(&id); err != nil {
+				b.Fatalf("sqlite unique native lookup: %v", err)
+			}
+			continue
+		}
+		city := benchmarkSQLiteCity(i)
+		rows, err := stmt.Query(city)
+		if err != nil {
+			b.Fatalf("sqlite nonunique native lookup: %v", err)
+		}
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				_ = rows.Close()
+				b.Fatalf("sqlite nonunique native scan: %v", err)
+			}
+		}
+		if err := rows.Close(); err != nil {
+			b.Fatalf("sqlite nonunique native close: %v", err)
+		}
+	}
+}
+
+func BenchmarkSQLiteShapeSecondaryLookupJSON(b *testing.B) {
+	b.Run("unique", func(b *testing.B) {
+		benchmarkSQLiteShapeSecondaryLookupJSON(b, true)
+	})
+	b.Run("non_unique", func(b *testing.B) {
+		benchmarkSQLiteShapeSecondaryLookupJSON(b, false)
+	})
+}
+
+func BenchmarkSQLiteShapeSecondaryLookupNativeColumns(b *testing.B) {
+	b.Run("unique", func(b *testing.B) {
+		benchmarkSQLiteShapeSecondaryLookupNativeColumns(b, true)
+	})
+	b.Run("non_unique", func(b *testing.B) {
+		benchmarkSQLiteShapeSecondaryLookupNativeColumns(b, false)
+	})
 }

--- a/cmd/collection_bench_matrix_summary/main.go
+++ b/cmd/collection_bench_matrix_summary/main.go
@@ -417,7 +417,7 @@ func metricPtr(metrics map[string]float64, name string) *float64 {
 
 func renderTSV(rows []summaryRow) string {
 	var sb strings.Builder
-	sb.WriteString("cell\tengine\tdocument_format\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tbenchmark\tns_per_op\tbytes_per_op\tallocs_per_op\tinsert_ns/doc\tsync_ns/doc\tper_item_key_probe_fallback_count\tper_item_prefix_probe_fallback_count\treport_md\n")
+	sb.WriteString("cell\tengine\tdocument_format\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tbenchmark\tns_per_op\tops_per_sec\tbytes_per_op\tallocs_per_op\tinsert_ns/doc\tinsert_docs_per_sec\tsync_ns/doc\tsync_docs_per_sec\tper_item_key_probe_fallback_count\tper_item_prefix_probe_fallback_count\treport_md\n")
 	for _, row := range rows {
 		sb.WriteString(row.Cell)
 		sb.WriteByte('\t')
@@ -437,13 +437,19 @@ func renderTSV(rows []summaryRow) string {
 		sb.WriteByte('\t')
 		sb.WriteString(formatTSVFloat(row.NsPerOp))
 		sb.WriteByte('\t')
+		sb.WriteString(formatTSVFloat(opsPerSecFromNs(row.NsPerOp)))
+		sb.WriteByte('\t')
 		sb.WriteString(formatTSVFloat(row.BytesPerOp))
 		sb.WriteByte('\t')
 		sb.WriteString(formatTSVFloat(row.AllocsPerOp))
 		sb.WriteByte('\t')
 		sb.WriteString(formatOptionalTSVFloat(row.InsertNsPerDoc))
 		sb.WriteByte('\t')
+		sb.WriteString(formatOptionalTSVFloat(optionalOpsPerSecFromNs(row.InsertNsPerDoc)))
+		sb.WriteByte('\t')
 		sb.WriteString(formatOptionalTSVFloat(row.SyncNsPerDoc))
+		sb.WriteByte('\t')
+		sb.WriteString(formatOptionalTSVFloat(optionalOpsPerSecFromNs(row.SyncNsPerDoc)))
 		sb.WriteByte('\t')
 		sb.WriteString(formatOptionalTSVFloat(row.KeyFallbacks))
 		sb.WriteByte('\t')
@@ -457,7 +463,7 @@ func renderTSV(rows []summaryRow) string {
 
 func renderUserStoryTSV(rows []userStoryRow) string {
 	var sb strings.Builder
-	sb.WriteString("cell\tengine\tdocument_format\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tstory\tbenchmark\tdocs_per_batch\tdocs_per_sec\tms_per_batch\tinsert_ms_per_batch\tsync_ms_per_batch\tbatches_per_sec\tns_per_doc\treport_md\n")
+	sb.WriteString("cell\tengine\tdocument_format\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tstory\tbenchmark\tdocs_per_batch\tns_per_doc\tdocs_per_sec\tms_per_batch\tinsert_ms_per_batch\tsync_ms_per_batch\tbatches_per_sec\treport_md\n")
 	for _, row := range rows {
 		sb.WriteString(row.Cell)
 		sb.WriteByte('\t')
@@ -479,6 +485,8 @@ func renderUserStoryTSV(rows []userStoryRow) string {
 		sb.WriteByte('\t')
 		sb.WriteString(strconv.Itoa(row.CollectionBatchSize))
 		sb.WriteByte('\t')
+		sb.WriteString(formatTSVFloat(row.NsPerOp))
+		sb.WriteByte('\t')
 		sb.WriteString(formatTSVFloat(row.DocsPerSec))
 		sb.WriteByte('\t')
 		sb.WriteString(formatTSVFloat(row.MSPerBatch))
@@ -488,8 +496,6 @@ func renderUserStoryTSV(rows []userStoryRow) string {
 		sb.WriteString(formatOptionalTSVFloat(optionalMetricPerBatchMS(row.SyncNsPerDoc, row.CollectionBatchSize)))
 		sb.WriteByte('\t')
 		sb.WriteString(formatTSVFloat(row.BatchesSec))
-		sb.WriteByte('\t')
-		sb.WriteString(formatTSVFloat(row.NsPerOp))
 		sb.WriteByte('\t')
 		sb.WriteString(row.ReportMarkdownPath)
 		sb.WriteByte('\n')
@@ -502,6 +508,21 @@ func optionalMetricPerBatchMS(nsPerDoc *float64, batchSize int) *float64 {
 		return nil
 	}
 	value := *nsPerDoc * float64(batchSize) / 1e6
+	return &value
+}
+
+func opsPerSecFromNs(nsPerOp float64) float64 {
+	if nsPerOp <= 0 {
+		return math.NaN()
+	}
+	return 1e9 / nsPerOp
+}
+
+func optionalOpsPerSecFromNs(nsPerOp *float64) *float64 {
+	if nsPerOp == nil || *nsPerOp <= 0 {
+		return nil
+	}
+	value := 1e9 / *nsPerOp
 	return &value
 }
 
@@ -526,7 +547,7 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 	if len(userStoryRows) > 0 {
 		sb.WriteString("## User-Facing Throughput\n\n")
 		sb.WriteString("Batch benchmark ops are documents, so this section reports the indexed ingest story as docs/sec, batch latency, and batches/sec. Diagnostic JSON/planner rows are separated below.\n\n")
-		sb.WriteString("| Cell | Engine | Format | Data vlog | Index vlog | Pager chunk | Pager sync | Story | Docs/batch | Docs/sec | ms/batch | insert ms/batch | sync ms/batch | batches/sec | ns/doc | Report |\n")
+		sb.WriteString("| Cell | Engine | Format | Data vlog | Index vlog | Pager chunk | Pager sync | Story | Docs/batch | ns/doc | Docs/sec | ms/batch | insert ms/batch | sync ms/batch | batches/sec | Report |\n")
 		sb.WriteString("| --- | --- | --- | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
 		for _, row := range userStoryRows {
 			reportPath := relativeReportPath(outDir, row.ReportMarkdownPath)
@@ -551,6 +572,8 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 			sb.WriteString(" | ")
 			sb.WriteString(formatIntWithCommas(int64(row.CollectionBatchSize)))
 			sb.WriteString(" | ")
+			sb.WriteString(formatFloat(row.NsPerOp))
+			sb.WriteString(" | ")
 			sb.WriteString(formatThroughput(row.DocsPerSec))
 			sb.WriteString(" | ")
 			sb.WriteString(formatFloat(row.MSPerBatch))
@@ -560,8 +583,6 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 			sb.WriteString(formatOptionalFloat(optionalMetricPerBatchMS(row.SyncNsPerDoc, row.CollectionBatchSize)))
 			sb.WriteString(" | ")
 			sb.WriteString(formatFloat(row.BatchesSec))
-			sb.WriteString(" | ")
-			sb.WriteString(formatFloat(row.NsPerOp))
 			sb.WriteString(" | [report](")
 			sb.WriteString(markdownLinkPath(reportPath))
 			sb.WriteString(") |\n")
@@ -572,8 +593,8 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 	if len(diagnosticRows) > 0 {
 		sb.WriteString("## Diagnostic Rows\n\n")
 		sb.WriteString("These rows are not user stories. They isolate JSON/data extraction and non-JSON planner cost so future optimization can quarantine JSON work separately from TreeDB publish/index maintenance.\n\n")
-		sb.WriteString("| Cell | Engine | Format | Pager chunk | Pager sync | Diagnostic | ns/doc | B/doc | allocs/doc | Report |\n")
-		sb.WriteString("| --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- |\n")
+		sb.WriteString("| Cell | Engine | Format | Pager chunk | Pager sync | Diagnostic | ns/doc | ops/sec | B/doc | allocs/doc | Report |\n")
+		sb.WriteString("| --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | --- |\n")
 		for _, row := range diagnosticRows {
 			reportPath := relativeReportPath(outDir, row.ReportMarkdownPath)
 			sb.WriteString("| `")
@@ -591,6 +612,8 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 			sb.WriteString("` | ")
 			sb.WriteString(formatFloat(row.NsPerOp))
 			sb.WriteString(" | ")
+			sb.WriteString(formatThroughput(opsPerSecFromNs(row.NsPerOp)))
+			sb.WriteString(" | ")
 			sb.WriteString(formatFloat(row.BytesPerOp))
 			sb.WriteString(" | ")
 			sb.WriteString(formatFloat(row.AllocsPerOp))
@@ -601,8 +624,8 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 		sb.WriteString("\n")
 	}
 	sb.WriteString("## Raw Matrix\n\n")
-	sb.WriteString("| Cell | Engine | Format | Data vlog | Index vlog | Pager chunk | Pager sync | Benchmark | ns/op | B/op | allocs/op | insert ns/doc | sync ns/doc | Key fallbacks | Prefix fallbacks | Report |\n")
-	sb.WriteString("| --- | --- | --- | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
+	sb.WriteString("| Cell | Engine | Format | Data vlog | Index vlog | Pager chunk | Pager sync | Benchmark | ns/op | ops/sec | B/op | allocs/op | insert ns/doc | insert docs/sec | sync ns/doc | sync docs/sec | Key fallbacks | Prefix fallbacks | Report |\n")
+	sb.WriteString("| --- | --- | --- | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
 	for _, row := range rows {
 		reportPath := relativeReportPath(outDir, row.ReportMarkdownPath)
 		sb.WriteString("| `")
@@ -624,13 +647,19 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 		sb.WriteString("` | ")
 		sb.WriteString(formatFloat(row.NsPerOp))
 		sb.WriteString(" | ")
+		sb.WriteString(formatThroughput(opsPerSecFromNs(row.NsPerOp)))
+		sb.WriteString(" | ")
 		sb.WriteString(formatFloat(row.BytesPerOp))
 		sb.WriteString(" | ")
 		sb.WriteString(formatFloat(row.AllocsPerOp))
 		sb.WriteString(" | ")
 		sb.WriteString(formatOptionalFloat(row.InsertNsPerDoc))
 		sb.WriteString(" | ")
+		sb.WriteString(formatOptionalFloat(optionalOpsPerSecFromNs(row.InsertNsPerDoc)))
+		sb.WriteString(" | ")
 		sb.WriteString(formatOptionalFloat(row.SyncNsPerDoc))
+		sb.WriteString(" | ")
+		sb.WriteString(formatOptionalFloat(optionalOpsPerSecFromNs(row.SyncNsPerDoc)))
 		sb.WriteString(" | ")
 		sb.WriteString(formatOptionalFloat(row.KeyFallbacks))
 		sb.WriteString(" | ")

--- a/cmd/collection_bench_matrix_summary/main.go
+++ b/cmd/collection_bench_matrix_summary/main.go
@@ -182,7 +182,7 @@ func run(cfg config) error {
 	fmt.Printf("wrote matrix summary tsv: %s\n", tsvPath)
 	fmt.Printf("wrote user story tsv:     %s\n", userStoryPath)
 	fmt.Printf("wrote matrix summary md:  %s\n", mdPath)
-	fmt.Printf("wrote matrix summary html:%s\n", htmlPath)
+	fmt.Printf("wrote matrix summary html: %s\n", htmlPath)
 	return nil
 }
 
@@ -375,7 +375,9 @@ func isSQLiteMatrixRow(row matrixRow) bool {
 }
 
 func documentFormatForBenchmark(format, benchmark string) string {
-	if strings.HasPrefix(benchmark, "BenchmarkSQLiteNativeColumns") {
+	base := benchmarkBaseName(benchmark)
+	if strings.HasPrefix(base, "BenchmarkSQLiteNativeColumns") ||
+		(strings.HasPrefix(base, "BenchmarkSQLiteShape") && strings.Contains(base, "NativeColumns")) {
 		return "native-columns"
 	}
 	if strings.TrimSpace(format) == "" {

--- a/cmd/collection_bench_matrix_summary/main.go
+++ b/cmd/collection_bench_matrix_summary/main.go
@@ -63,6 +63,7 @@ type summaryRow struct {
 	CollectionBatchSize int
 	InsertNsPerDoc      *float64
 	SyncNsPerDoc        *float64
+	WriterDocsPerSec    *float64
 	KeyFallbacks        *float64
 	PrefixFallbacks     *float64
 }
@@ -336,6 +337,7 @@ func buildSummaryRow(row matrixRow, collectionBatchSize int, name string, benchm
 		CollectionBatchSize: collectionBatchSize,
 		InsertNsPerDoc:      metricPtr(benchmark.MeanMetrics, "insert_ns/doc"),
 		SyncNsPerDoc:        metricPtr(benchmark.MeanMetrics, "sync_ns/doc"),
+		WriterDocsPerSec:    metricPtr(benchmark.MeanMetrics, "writer_docs/sec"),
 		KeyFallbacks:        metricPtr(benchmark.MeanMetrics, "per_item_key_probe_fallback_count"),
 		PrefixFallbacks:     metricPtr(benchmark.MeanMetrics, "per_item_prefix_probe_fallback_count"),
 	}
@@ -417,7 +419,7 @@ func metricPtr(metrics map[string]float64, name string) *float64 {
 
 func renderTSV(rows []summaryRow) string {
 	var sb strings.Builder
-	sb.WriteString("cell\tengine\tdocument_format\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tbenchmark\tns_per_op\tops_per_sec\tbytes_per_op\tallocs_per_op\tinsert_ns/doc\tinsert_docs_per_sec\tsync_ns/doc\tsync_docs_per_sec\tper_item_key_probe_fallback_count\tper_item_prefix_probe_fallback_count\treport_md\n")
+	sb.WriteString("cell\tengine\tdocument_format\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tbenchmark\tns_per_op\tops_per_sec\tbytes_per_op\tallocs_per_op\tinsert_ns/doc\tinsert_docs_per_sec\tsync_ns/doc\tsync_docs_per_sec\twriter_docs/sec\tper_item_key_probe_fallback_count\tper_item_prefix_probe_fallback_count\treport_md\n")
 	for _, row := range rows {
 		sb.WriteString(row.Cell)
 		sb.WriteByte('\t')
@@ -450,6 +452,8 @@ func renderTSV(rows []summaryRow) string {
 		sb.WriteString(formatOptionalTSVFloat(row.SyncNsPerDoc))
 		sb.WriteByte('\t')
 		sb.WriteString(formatOptionalTSVFloat(optionalOpsPerSecFromNs(row.SyncNsPerDoc)))
+		sb.WriteByte('\t')
+		sb.WriteString(formatOptionalTSVFloat(row.WriterDocsPerSec))
 		sb.WriteByte('\t')
 		sb.WriteString(formatOptionalTSVFloat(row.KeyFallbacks))
 		sb.WriteByte('\t')
@@ -624,8 +628,8 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 		sb.WriteString("\n")
 	}
 	sb.WriteString("## Raw Matrix\n\n")
-	sb.WriteString("| Cell | Engine | Format | Data vlog | Index vlog | Pager chunk | Pager sync | Benchmark | ns/op | ops/sec | B/op | allocs/op | insert ns/doc | insert docs/sec | sync ns/doc | sync docs/sec | Key fallbacks | Prefix fallbacks | Report |\n")
-	sb.WriteString("| --- | --- | --- | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
+	sb.WriteString("| Cell | Engine | Format | Data vlog | Index vlog | Pager chunk | Pager sync | Benchmark | ns/op | ops/sec | B/op | allocs/op | insert ns/doc | insert docs/sec | sync ns/doc | sync docs/sec | writer docs/sec | Key fallbacks | Prefix fallbacks | Report |\n")
+	sb.WriteString("| --- | --- | --- | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
 	for _, row := range rows {
 		reportPath := relativeReportPath(outDir, row.ReportMarkdownPath)
 		sb.WriteString("| `")
@@ -660,6 +664,8 @@ func renderMarkdown(rows []summaryRow, outDir string) (string, error) {
 		sb.WriteString(formatOptionalFloat(row.SyncNsPerDoc))
 		sb.WriteString(" | ")
 		sb.WriteString(formatOptionalFloat(optionalOpsPerSecFromNs(row.SyncNsPerDoc)))
+		sb.WriteString(" | ")
+		sb.WriteString(formatOptionalFloat(row.WriterDocsPerSec))
 		sb.WriteString(" | ")
 		sb.WriteString(formatOptionalFloat(row.KeyFallbacks))
 		sb.WriteString(" | ")

--- a/cmd/collection_bench_matrix_summary/main.go
+++ b/cmd/collection_bench_matrix_summary/main.go
@@ -1,21 +1,28 @@
 package main
 
 import (
+	"bytes"
 	"encoding/csv"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"html/template"
 	"io"
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
 )
 
 type config struct {
-	matrixIndexPath string
-	outDir          string
+	matrixIndexPath     string
+	outDir              string
+	availableBenchmarks bool
 }
 
 type matrixRow struct {
@@ -79,14 +86,30 @@ var benchmarkOrder = []string{
 	"BenchmarkCollectionOverheadIndexStateTemplateV1Extraction",
 	"BenchmarkCollectionOverheadPlanIndexedTemplateV1",
 	"BenchmarkCollectionOverheadPlanIndexedPrecomputedState",
+	"BenchmarkCollectionShapeInsertBatch",
+	"BenchmarkCollectionShapeInsertBatchSingleStringJSON",
 	"BenchmarkCollectionInsertBatchWithSecondaryIndexes",
+	"BenchmarkCollectionShapeInsertBatchCheckpoint",
+	"BenchmarkCollectionShapeInsertBatchCheckpointSingleStringJSON",
 	"BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes",
 	"BenchmarkCollectionTimedProfileInsertBatchWithSecondaryIndexes",
 	"BenchmarkCollectionTimedProfileInsertBatchCheckpointWithSecondaryIndexes",
+	"BenchmarkCollectionShapeReadPrimary",
+	"BenchmarkCollectionShapeReadPrimaryParallel",
+	"BenchmarkCollectionMixedReadWritePrimary",
+	"BenchmarkCollectionMixedReadWriteSecondaryUnique",
+	"BenchmarkSQLiteShapeInsertBatchJSON",
+	"BenchmarkSQLiteShapeInsertBatchNativeColumns",
 	"BenchmarkSQLiteInsertBatchWithSecondaryIndexes",
 	"BenchmarkSQLiteInsertBatchCheckpointWithSecondaryIndexes",
 	"BenchmarkSQLiteNativeColumnsInsertBatchWithSecondaryIndexes",
 	"BenchmarkSQLiteNativeColumnsInsertBatchCheckpointWithSecondaryIndexes",
+	"BenchmarkSQLiteShapeInsertBatchCheckpointJSON",
+	"BenchmarkSQLiteShapeInsertBatchCheckpointNativeColumns",
+	"BenchmarkSQLiteShapeReadPrimaryJSON",
+	"BenchmarkSQLiteShapeReadPrimaryNativeColumns",
+	"BenchmarkSQLiteShapeSecondaryLookupJSON",
+	"BenchmarkSQLiteShapeSecondaryLookupNativeColumns",
 }
 
 func main() {
@@ -107,6 +130,7 @@ func parseFlags(args []string) (config, error) {
 	fs.SetOutput(io.Discard)
 	fs.StringVar(&cfg.matrixIndexPath, "matrix-index", "", "Path to matrix_index.tsv")
 	fs.StringVar(&cfg.outDir, "out-dir", "", "Output directory for summary artifacts")
+	fs.BoolVar(&cfg.availableBenchmarks, "available-benchmarks", false, "Summarize all benchmark rows present in each report instead of requiring the default production benchmark set")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
 	}
@@ -124,7 +148,7 @@ func run(cfg config) error {
 	if err != nil {
 		return err
 	}
-	summaryRows, err := buildSummaryRows(rows)
+	summaryRows, err := buildSummaryRows(rows, cfg.availableBenchmarks)
 	if err != nil {
 		return err
 	}
@@ -147,9 +171,18 @@ func run(cfg config) error {
 	if err := os.WriteFile(mdPath, []byte(md), 0o644); err != nil {
 		return fmt.Errorf("write markdown: %w", err)
 	}
+	htmlPath := filepath.Join(cfg.outDir, "collections_matrix_summary.html")
+	htmlDoc, err := markdownToHTMLDoc(md)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(htmlPath, htmlDoc, 0o644); err != nil {
+		return fmt.Errorf("write html: %w", err)
+	}
 	fmt.Printf("wrote matrix summary tsv: %s\n", tsvPath)
 	fmt.Printf("wrote user story tsv:     %s\n", userStoryPath)
 	fmt.Printf("wrote matrix summary md:  %s\n", mdPath)
+	fmt.Printf("wrote matrix summary html:%s\n", htmlPath)
 	return nil
 }
 
@@ -216,7 +249,7 @@ func field(record []string, idx int) string {
 	return record[idx]
 }
 
-func buildSummaryRows(rows []matrixRow) ([]summaryRow, error) {
+func buildSummaryRows(rows []matrixRow, availableBenchmarks bool) ([]summaryRow, error) {
 	out := make([]summaryRow, 0, len(rows)*len(benchmarkOrder))
 	for _, row := range rows {
 		report, err := loadBenchmarkReport(row.ReportJSONPath)
@@ -228,6 +261,13 @@ func buildSummaryRows(rows []matrixRow) ([]summaryRow, error) {
 			if strings.TrimSpace(row.DocumentFormat) == "" {
 				row.DocumentFormat = "json"
 			}
+		}
+		if availableBenchmarks {
+			for _, name := range availableBenchmarkNames(report.Benchmarks) {
+				benchmark := report.Benchmarks[name]
+				out = append(out, buildSummaryRow(row, report.CollectionBatchSize, name, benchmark))
+			}
+			continue
 		}
 		for _, name := range requiredBenchmarkNames(row) {
 			benchmark, ok := report.Benchmarks[name]
@@ -245,6 +285,43 @@ func buildSummaryRows(rows []matrixRow) ([]summaryRow, error) {
 		}
 	}
 	return out, nil
+}
+
+func availableBenchmarkNames(benchmarks map[string]benchmarkAggregate) []string {
+	names := make([]string, 0, len(benchmarks))
+	for name := range benchmarks {
+		names = append(names, name)
+	}
+	order := make(map[string]int, len(benchmarkOrder))
+	for i, name := range benchmarkOrder {
+		order[name] = i
+	}
+	sortBenchmarkNames(names, order)
+	return names
+}
+
+func sortBenchmarkNames(names []string, order map[string]int) {
+	sort.Slice(names, func(i, j int) bool {
+		leftBase := benchmarkBaseName(names[i])
+		rightBase := benchmarkBaseName(names[j])
+		leftOrder, leftOK := order[leftBase]
+		rightOrder, rightOK := order[rightBase]
+		switch {
+		case leftOK && rightOK && leftOrder != rightOrder:
+			return leftOrder < rightOrder
+		case leftOK != rightOK:
+			return leftOK
+		default:
+			return names[i] < names[j]
+		}
+	})
+}
+
+func benchmarkBaseName(name string) string {
+	if slash := strings.IndexByte(name, '/'); slash > 0 {
+		return name[:slash]
+	}
+	return name
 }
 
 func buildSummaryRow(row matrixRow, collectionBatchSize int, name string, benchmark benchmarkAggregate) summaryRow {
@@ -591,16 +668,24 @@ func buildUserStoryRows(rows []summaryRow) []userStoryRow {
 }
 
 func userStoryLabel(benchmark string) (string, bool) {
-	switch benchmark {
+	switch benchmarkBaseName(benchmark) {
 	case "BenchmarkCollectionInsertBatchWithSecondaryIndexes",
 		"BenchmarkCollectionTimedProfileInsertBatchWithSecondaryIndexes",
+		"BenchmarkCollectionShapeInsertBatch",
+		"BenchmarkCollectionShapeInsertBatchSingleStringJSON",
 		"BenchmarkSQLiteInsertBatchWithSecondaryIndexes",
-		"BenchmarkSQLiteNativeColumnsInsertBatchWithSecondaryIndexes":
+		"BenchmarkSQLiteNativeColumnsInsertBatchWithSecondaryIndexes",
+		"BenchmarkSQLiteShapeInsertBatchJSON",
+		"BenchmarkSQLiteShapeInsertBatchNativeColumns":
 		return "bulk indexed insert", true
 	case "BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes",
 		"BenchmarkCollectionTimedProfileInsertBatchCheckpointWithSecondaryIndexes",
+		"BenchmarkCollectionShapeInsertBatchCheckpoint",
+		"BenchmarkCollectionShapeInsertBatchCheckpointSingleStringJSON",
 		"BenchmarkSQLiteInsertBatchCheckpointWithSecondaryIndexes",
-		"BenchmarkSQLiteNativeColumnsInsertBatchCheckpointWithSecondaryIndexes":
+		"BenchmarkSQLiteNativeColumnsInsertBatchCheckpointWithSecondaryIndexes",
+		"BenchmarkSQLiteShapeInsertBatchCheckpointJSON",
+		"BenchmarkSQLiteShapeInsertBatchCheckpointNativeColumns":
 		return "checkpointed indexed insert", true
 	default:
 		return "", false
@@ -618,7 +703,7 @@ func buildDiagnosticRows(rows []summaryRow) []summaryRow {
 }
 
 func isDiagnosticBenchmark(benchmark string) bool {
-	switch benchmark {
+	switch benchmarkBaseName(benchmark) {
 	case "BenchmarkCollectionOverheadIndexStateJSONExtraction",
 		"BenchmarkCollectionOverheadIndexStateTemplateV1Extraction",
 		"BenchmarkCollectionOverheadPlanIndexedTemplateV1",
@@ -627,6 +712,39 @@ func isDiagnosticBenchmark(benchmark string) bool {
 	default:
 		return false
 	}
+}
+
+func markdownToHTMLDoc(markdown string) ([]byte, error) {
+	var body bytes.Buffer
+	md := goldmark.New(goldmark.WithExtensions(extension.GFM))
+	if err := md.Convert([]byte(markdown), &body); err != nil {
+		return nil, fmt.Errorf("render markdown: %w", err)
+	}
+	const pageTmpl = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Collections Benchmark Matrix</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem auto; max-width: 1280px; padding: 0 1rem; line-height: 1.5; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #d0d7de; padding: 0.45rem 0.65rem; vertical-align: top; }
+    th { background: #f6f8fa; text-align: left; }
+    code { background: #f6f8fa; padding: 0.1rem 0.25rem; border-radius: 4px; }
+  </style>
+</head>
+<body>{{.Body}}</body>
+</html>`
+	tmpl, err := template.New("page").Parse(pageTmpl)
+	if err != nil {
+		return nil, err
+	}
+	var doc bytes.Buffer
+	if err := tmpl.Execute(&doc, struct{ Body template.HTML }{Body: template.HTML(body.String())}); err != nil {
+		return nil, err
+	}
+	return doc.Bytes(), nil
 }
 
 func markdownLinkPath(path string) string {

--- a/cmd/collection_bench_matrix_summary/main.go
+++ b/cmd/collection_bench_matrix_summary/main.go
@@ -419,7 +419,7 @@ func metricPtr(metrics map[string]float64, name string) *float64 {
 
 func renderTSV(rows []summaryRow) string {
 	var sb strings.Builder
-	sb.WriteString("cell\tengine\tdocument_format\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tbenchmark\tns_per_op\tops_per_sec\tbytes_per_op\tallocs_per_op\tinsert_ns/doc\tinsert_docs_per_sec\tsync_ns/doc\tsync_docs_per_sec\twriter_docs/sec\tper_item_key_probe_fallback_count\tper_item_prefix_probe_fallback_count\treport_md\n")
+	sb.WriteString("cell\tengine\tdocument_format\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\tbenchmark\tns_per_op\tops_per_sec\tbytes_per_op\tallocs_per_op\tinsert_ns/doc\tinsert_docs_per_sec\tsync_ns/doc\tsync_docs_per_sec\twriter_docs_per_sec\tper_item_key_probe_fallback_count\tper_item_prefix_probe_fallback_count\treport_md\n")
 	for _, row := range rows {
 		sb.WriteString(row.Cell)
 		sb.WriteByte('\t')

--- a/cmd/collection_bench_matrix_summary/main_test.go
+++ b/cmd/collection_bench_matrix_summary/main_test.go
@@ -174,11 +174,13 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 		"44",
 		"44.44",
 		"## Diagnostic Rows",
+		"| Cell | Engine | Format | Pager chunk | Pager sync | Diagnostic | ns/doc | ops/sec | B/doc | allocs/doc | Report |",
 		"These rows are not user stories.",
 		"`BenchmarkCollectionOverheadIndexStateJSONExtraction`",
 		"`BenchmarkCollectionOverheadIndexStateTemplateV1Extraction`",
 		"`BenchmarkCollectionOverheadPlanIndexedTemplateV1`",
 		"## Raw Matrix",
+		"| Cell | Engine | Format | Data vlog | Index vlog | Pager chunk | Pager sync | Benchmark | ns/op | ops/sec | B/op | allocs/op | insert ns/doc | insert docs/sec | sync ns/doc | sync docs/sec | Key fallbacks | Prefix fallbacks | Report |",
 		"`production_fast_data_vlog_index_leaf`",
 		"`BenchmarkCollectionInsertBatchWithSecondaryIndexes`",
 		"`BenchmarkSQLiteInsertBatchWithSecondaryIndexes`",
@@ -199,16 +201,16 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 		t.Fatalf("read tsv: %v", err)
 	}
 	gotTSV := string(tsv)
-	if !strings.Contains(gotTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tBenchmarkCollectionInsertBatchWithSecondaryIndexes\t2812.5\t1980\t30\t-\t-\t0\t0\t") {
+	if !strings.Contains(gotTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tBenchmarkCollectionInsertBatchWithSecondaryIndexes\t2812.5\t355555.55555555556\t1980\t30\t-\t-\t-\t-\t0\t0\t") {
 		t.Fatalf("tsv missing raw numeric row:\n%s", gotTSV)
 	}
-	if !strings.Contains(gotTSV, "json\t-\t-\t-\t-\tBenchmarkSQLiteInsertBatchWithSecondaryIndexes\t4100\t2048\t32\t-\t-\t") {
+	if !strings.Contains(gotTSV, "json\t-\t-\t-\t-\tBenchmarkSQLiteInsertBatchWithSecondaryIndexes\t4100\t243902.43902439025\t2048\t32\t-\t-\t-\t-\t") {
 		t.Fatalf("tsv missing sqlite numeric row:\n%s", gotTSV)
 	}
-	if !strings.Contains(gotTSV, "native-columns\t-\t-\t-\t-\tBenchmarkSQLiteNativeColumnsInsertBatchWithSecondaryIndexes\t3000\t1500\t25\t-\t-\t") {
+	if !strings.Contains(gotTSV, "native-columns\t-\t-\t-\t-\tBenchmarkSQLiteNativeColumnsInsertBatchWithSecondaryIndexes\t3000\t333333.3333333333\t1500\t25\t-\t-\t-\t-\t") {
 		t.Fatalf("tsv missing sqlite native-columns numeric row:\n%s", gotTSV)
 	}
-	if !strings.Contains(gotTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tBenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes\t8000\t2000\t30\t2500\t5500\t0\t0\t") {
+	if !strings.Contains(gotTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tBenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes\t8000\t125000\t2000\t30\t2500\t400000\t5500\t181818.18181818182\t0\t0\t") {
 		t.Fatalf("tsv missing checkpoint split row:\n%s", gotTSV)
 	}
 	if strings.Contains(gotTSV, "2,812") {
@@ -219,19 +221,19 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 		t.Fatalf("read user story tsv: %v", err)
 	}
 	gotUserStoryTSV := string(userStoryTSV)
-	if !strings.Contains(gotUserStoryTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tbulk indexed insert\tBenchmarkCollectionInsertBatchWithSecondaryIndexes\t8000\t355555.55555555556\t22.5\t-\t-\t44.44444444444444\t2812.5\t") {
+	if !strings.Contains(gotUserStoryTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tbulk indexed insert\tBenchmarkCollectionInsertBatchWithSecondaryIndexes\t8000\t2812.5\t355555.55555555556\t22.5\t-\t-\t44.44444444444444\t") {
 		t.Fatalf("user story tsv missing collection throughput row:\n%s", gotUserStoryTSV)
 	}
-	if !strings.Contains(gotUserStoryTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tcheckpointed indexed insert\tBenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes\t8000\t125000\t64\t20\t44\t15.625\t8000\t") {
+	if !strings.Contains(gotUserStoryTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tcheckpointed indexed insert\tBenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes\t8000\t8000\t125000\t64\t20\t44\t15.625\t") {
 		t.Fatalf("user story tsv missing checkpoint split row:\n%s", gotUserStoryTSV)
 	}
-	if !strings.Contains(gotUserStoryTSV, "json\t-\t-\t-\t-\tbulk indexed insert\tBenchmarkSQLiteInsertBatchWithSecondaryIndexes\t8000\t243902.43902439025\t32.8\t-\t-\t30.48780487804878\t4100\t") {
+	if !strings.Contains(gotUserStoryTSV, "json\t-\t-\t-\t-\tbulk indexed insert\tBenchmarkSQLiteInsertBatchWithSecondaryIndexes\t8000\t4100\t243902.43902439025\t32.8\t-\t-\t30.48780487804878\t") {
 		t.Fatalf("user story tsv missing sqlite throughput row:\n%s", gotUserStoryTSV)
 	}
-	if !strings.Contains(gotUserStoryTSV, "native-columns\t-\t-\t-\t-\tbulk indexed insert\tBenchmarkSQLiteNativeColumnsInsertBatchWithSecondaryIndexes\t8000\t333333.3333333333\t24\t-\t-\t41.666666666666664\t3000\t") {
+	if !strings.Contains(gotUserStoryTSV, "native-columns\t-\t-\t-\t-\tbulk indexed insert\tBenchmarkSQLiteNativeColumnsInsertBatchWithSecondaryIndexes\t8000\t3000\t333333.3333333333\t24\t-\t-\t41.666666666666664\t") {
 		t.Fatalf("user story tsv missing sqlite native-columns throughput row:\n%s", gotUserStoryTSV)
 	}
-	if !strings.Contains(gotUserStoryTSV, "native-columns\t-\t-\t-\t-\tcheckpointed indexed insert\tBenchmarkSQLiteNativeColumnsInsertBatchCheckpointWithSecondaryIndexes\t8000\t142857.14285714287\t56\t16\t40\t17.857142857142858\t7000\t") {
+	if !strings.Contains(gotUserStoryTSV, "native-columns\t-\t-\t-\t-\tcheckpointed indexed insert\tBenchmarkSQLiteNativeColumnsInsertBatchCheckpointWithSecondaryIndexes\t8000\t7000\t142857.14285714287\t56\t16\t40\t17.857142857142858\t") {
 		t.Fatalf("user story tsv missing sqlite native-columns checkpoint row:\n%s", gotUserStoryTSV)
 	}
 }

--- a/cmd/collection_bench_matrix_summary/main_test.go
+++ b/cmd/collection_bench_matrix_summary/main_test.go
@@ -212,6 +212,9 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 		t.Fatalf("read tsv: %v", err)
 	}
 	gotTSV := string(tsv)
+	if !strings.Contains(gotTSV, "writer_docs_per_sec") || strings.Contains(strings.SplitN(gotTSV, "\n", 2)[0], "writer_docs/sec") {
+		t.Fatalf("tsv should use normalized writer throughput column:\n%s", gotTSV)
+	}
 	if !strings.Contains(gotTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tBenchmarkCollectionInsertBatchWithSecondaryIndexes\t2812.5\t355555.55555555556\t1980\t30\t-\t-\t-\t-\t-\t0\t0\t") {
 		t.Fatalf("tsv missing raw numeric row:\n%s", gotTSV)
 	}

--- a/cmd/collection_bench_matrix_summary/main_test.go
+++ b/cmd/collection_bench_matrix_summary/main_test.go
@@ -308,8 +308,9 @@ func TestDocumentFormatForSQLiteShapeNativeColumns(t *testing.T) {
 		"BenchmarkSQLiteShapeReadPrimaryNativeColumns/indexes_2",
 		"BenchmarkSQLiteShapeSecondaryLookupNativeColumns/unique",
 	} {
-		if got := documentFormatForBenchmark("json", benchmark); got != "native-columns" {
-			t.Fatalf("documentFormatForBenchmark(%q)=%q want native-columns", benchmark, got)
+		defaultFormat := "json"
+		if got := documentFormatForBenchmark(defaultFormat, benchmark); got != "native-columns" {
+			t.Fatalf("documentFormatForBenchmark(%q, %q)=%q want native-columns", defaultFormat, benchmark, got)
 		}
 	}
 }

--- a/cmd/collection_bench_matrix_summary/main_test.go
+++ b/cmd/collection_bench_matrix_summary/main_test.go
@@ -299,6 +299,19 @@ func TestMatrixSummaryAllowsLegacySQLiteReportsWithoutNativeColumns(t *testing.T
 	}
 }
 
+func TestDocumentFormatForSQLiteShapeNativeColumns(t *testing.T) {
+	for _, benchmark := range []string{
+		"BenchmarkSQLiteShapeInsertBatchNativeColumns/indexes_2",
+		"BenchmarkSQLiteShapeInsertBatchCheckpointNativeColumns/indexes_2",
+		"BenchmarkSQLiteShapeReadPrimaryNativeColumns/indexes_2",
+		"BenchmarkSQLiteShapeSecondaryLookupNativeColumns/unique",
+	} {
+		if got := documentFormatForBenchmark("json", benchmark); got != "native-columns" {
+			t.Fatalf("documentFormatForBenchmark(%q)=%q want native-columns", benchmark, got)
+		}
+	}
+}
+
 func TestMatrixSummaryFailsOnUnavailableReport(t *testing.T) {
 	dir := t.TempDir()
 	cellDir := filepath.Join(dir, "production_fast_data_vlog_index_leaf")

--- a/cmd/collection_bench_matrix_summary/main_test.go
+++ b/cmd/collection_bench_matrix_summary/main_test.go
@@ -60,6 +60,15 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
           "mean_allocs_per_op": 5
         },
         {
+          "name": "BenchmarkCollectionMixedReadWritePrimary",
+          "mean_ns_per_op": 1000,
+          "mean_bytes_per_op": 512,
+          "mean_allocs_per_op": 5,
+          "mean_metrics": {
+            "writer_docs/sec": 12345
+          }
+        },
+        {
           "name": "BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes",
           "mean_ns_per_op": 8000,
           "mean_bytes_per_op": 2000,
@@ -149,7 +158,7 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 		t.Fatalf("write matrix index: %v", err)
 	}
 
-	if err := run(config{matrixIndexPath: indexPath, outDir: dir}); err != nil {
+	if err := run(config{matrixIndexPath: indexPath, outDir: dir, availableBenchmarks: true}); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 	md, err := os.ReadFile(filepath.Join(dir, "collections_matrix_summary.md"))
@@ -180,12 +189,14 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 		"`BenchmarkCollectionOverheadIndexStateTemplateV1Extraction`",
 		"`BenchmarkCollectionOverheadPlanIndexedTemplateV1`",
 		"## Raw Matrix",
-		"| Cell | Engine | Format | Data vlog | Index vlog | Pager chunk | Pager sync | Benchmark | ns/op | ops/sec | B/op | allocs/op | insert ns/doc | insert docs/sec | sync ns/doc | sync docs/sec | Key fallbacks | Prefix fallbacks | Report |",
+		"| Cell | Engine | Format | Data vlog | Index vlog | Pager chunk | Pager sync | Benchmark | ns/op | ops/sec | B/op | allocs/op | insert ns/doc | insert docs/sec | sync ns/doc | sync docs/sec | writer docs/sec | Key fallbacks | Prefix fallbacks | Report |",
 		"`production_fast_data_vlog_index_leaf`",
 		"`BenchmarkCollectionInsertBatchWithSecondaryIndexes`",
+		"`BenchmarkCollectionMixedReadWritePrimary`",
 		"`BenchmarkSQLiteInsertBatchWithSecondaryIndexes`",
 		"`BenchmarkSQLiteNativeColumnsInsertBatchWithSecondaryIndexes`",
 		"`native-columns`",
+		"12,345",
 		"2,812.5",
 		"30",
 		"0",
@@ -201,16 +212,19 @@ func TestMatrixSummaryRendersBenchmarkMetrics(t *testing.T) {
 		t.Fatalf("read tsv: %v", err)
 	}
 	gotTSV := string(tsv)
-	if !strings.Contains(gotTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tBenchmarkCollectionInsertBatchWithSecondaryIndexes\t2812.5\t355555.55555555556\t1980\t30\t-\t-\t-\t-\t0\t0\t") {
+	if !strings.Contains(gotTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tBenchmarkCollectionInsertBatchWithSecondaryIndexes\t2812.5\t355555.55555555556\t1980\t30\t-\t-\t-\t-\t-\t0\t0\t") {
 		t.Fatalf("tsv missing raw numeric row:\n%s", gotTSV)
 	}
-	if !strings.Contains(gotTSV, "json\t-\t-\t-\t-\tBenchmarkSQLiteInsertBatchWithSecondaryIndexes\t4100\t243902.43902439025\t2048\t32\t-\t-\t-\t-\t") {
+	if !strings.Contains(gotTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tBenchmarkCollectionMixedReadWritePrimary\t1000\t1000000\t512\t5\t-\t-\t-\t-\t12345\t-\t-\t") {
+		t.Fatalf("tsv missing mixed writer throughput row:\n%s", gotTSV)
+	}
+	if !strings.Contains(gotTSV, "json\t-\t-\t-\t-\tBenchmarkSQLiteInsertBatchWithSecondaryIndexes\t4100\t243902.43902439025\t2048\t32\t-\t-\t-\t-\t-\t-\t-\t") {
 		t.Fatalf("tsv missing sqlite numeric row:\n%s", gotTSV)
 	}
-	if !strings.Contains(gotTSV, "native-columns\t-\t-\t-\t-\tBenchmarkSQLiteNativeColumnsInsertBatchWithSecondaryIndexes\t3000\t333333.3333333333\t1500\t25\t-\t-\t-\t-\t") {
+	if !strings.Contains(gotTSV, "native-columns\t-\t-\t-\t-\tBenchmarkSQLiteNativeColumnsInsertBatchWithSecondaryIndexes\t3000\t333333.3333333333\t1500\t25\t-\t-\t-\t-\t-\t-\t-\t") {
 		t.Fatalf("tsv missing sqlite native-columns numeric row:\n%s", gotTSV)
 	}
-	if !strings.Contains(gotTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tBenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes\t8000\t125000\t2000\t30\t2500\t400000\t5500\t181818.18181818182\t0\t0\t") {
+	if !strings.Contains(gotTSV, "template-v1\ttrue\tfalse\tprofile/default\tprofile/default\tBenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes\t8000\t125000\t2000\t30\t2500\t400000\t5500\t181818.18181818182\t-\t0\t0\t") {
 		t.Fatalf("tsv missing checkpoint split row:\n%s", gotTSV)
 	}
 	if strings.Contains(gotTSV, "2,812") {

--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -99,6 +99,12 @@ type report struct {
 	Sections             []reportSection `json:"sections"`
 }
 
+type metricDisplayColumn struct {
+	Label      string
+	Source     string
+	Throughput bool
+}
+
 var benchmarkSpecs = []benchmarkSpec{
 	{Name: "BenchmarkCollectionInsertProvidedID", Section: "Document Path", Description: "Insert documents with caller-provided IDs into the primary collection root."},
 	{Name: "BenchmarkCollectionInsertBatchProvidedID", Section: "Batch Ingest Path", Description: "Insert documents with caller-provided IDs through the collection batch API; ops/sec is documents/sec."},
@@ -586,7 +592,7 @@ func renderMarkdown(rep *report) string {
 	if rep.RawJSONPath != "" {
 		sb.WriteString(fmt.Sprintf("- raw benchmark json: `%s`\n", rep.RawJSONPath))
 	}
-	sb.WriteString("- ops/sec is derived from the mean `ns/op` across captured benchmark runs\n\n")
+	sb.WriteString("- throughput columns are derived from adjacent latency columns as `1e9/ns`\n\n")
 
 	if rep.Status == "unavailable" {
 		sb.WriteString("## Availability\n\n")
@@ -596,13 +602,13 @@ func renderMarkdown(rep *report) string {
 	}
 
 	for _, section := range rep.Sections {
-		metricColumns := benchmarkMetricColumns(section.Benchmarks)
+		metricColumns := benchmarkMetricDisplayColumns(benchmarkMetricColumns(section.Benchmarks))
 		sb.WriteString(fmt.Sprintf("## %s\n\n", section.Title))
-		sb.WriteString("| Benchmark | Description | Samples | Ops/sec | ns/op | B/op | allocs/op")
+		sb.WriteString("| Benchmark | Description | Samples | ns/op | Ops/sec | B/op | allocs/op")
 		for _, metric := range metricColumns {
 			sb.WriteString(" | ")
 			sb.WriteString("`")
-			sb.WriteString(metric)
+			sb.WriteString(metric.Label)
 			sb.WriteString("`")
 		}
 		sb.WriteString(" |\n")
@@ -619,16 +625,16 @@ func renderMarkdown(rep *report) string {
 			sb.WriteString(" | ")
 			sb.WriteString(strconv.Itoa(benchmark.Samples))
 			sb.WriteString(" | ")
-			sb.WriteString(formatFloat(benchmark.OpsPerSec))
-			sb.WriteString(" | ")
 			sb.WriteString(formatFloat(benchmark.MeanNsPerOp))
+			sb.WriteString(" | ")
+			sb.WriteString(formatFloat(benchmark.OpsPerSec))
 			sb.WriteString(" | ")
 			sb.WriteString(formatFloat(benchmark.MeanBytesPerOp))
 			sb.WriteString(" | ")
 			sb.WriteString(formatFloat(benchmark.MeanAllocsPerOp))
 			for _, metric := range metricColumns {
 				sb.WriteString(" | ")
-				value, ok := benchmark.MeanMetrics[metric]
+				value, ok := metricDisplayValue(benchmark.MeanMetrics, metric)
 				if ok {
 					sb.WriteString(formatFloat(value))
 				} else {
@@ -679,6 +685,49 @@ func benchmarkMetricColumns(benchmarks []benchmarkAggregate) []string {
 	}
 	sort.Strings(rest)
 	return append(out, rest...)
+}
+
+func benchmarkMetricDisplayColumns(metrics []string) []metricDisplayColumn {
+	out := make([]metricDisplayColumn, 0, len(metrics))
+	for _, metric := range metrics {
+		out = append(out, metricDisplayColumn{
+			Label:  metric,
+			Source: metric,
+		})
+		if throughputLabel, ok := throughputMetricLabel(metric); ok {
+			out = append(out, metricDisplayColumn{
+				Label:      throughputLabel,
+				Source:     metric,
+				Throughput: true,
+			})
+		}
+	}
+	return out
+}
+
+func throughputMetricLabel(metric string) (string, bool) {
+	switch metric {
+	case "insert_ns/doc":
+		return "insert_docs/sec", true
+	case "sync_ns/doc":
+		return "sync_docs/sec", true
+	default:
+		return "", false
+	}
+}
+
+func metricDisplayValue(metrics map[string]float64, column metricDisplayColumn) (float64, bool) {
+	value, ok := metrics[column.Source]
+	if !ok {
+		return 0, false
+	}
+	if !column.Throughput {
+		return value, true
+	}
+	if value <= 0 {
+		return 0, false
+	}
+	return 1e9 / value, true
 }
 
 func escapeTableCell(value string) string {

--- a/cmd/collection_bench_report/main.go
+++ b/cmd/collection_bench_report/main.go
@@ -108,13 +108,29 @@ var benchmarkSpecs = []benchmarkSpec{
 	{Name: "BenchmarkCollectionInsertWithSecondaryIndexes", Section: "Document Path", Description: "Insert documents while maintaining both unique and non-unique secondary indexes."},
 	{Name: "BenchmarkCollectionInsertBatchWithSecondaryIndexes", Section: "Batch Ingest Path", Description: "Batch insert documents while maintaining unique and non-unique secondary indexes; ops/sec is documents/sec."},
 	{Name: "BenchmarkCollectionInsertBatchCheckpointWithSecondaryIndexes", Section: "Batch Ingest Path", Description: "Batch insert indexed documents and force a sync boundary after each batch; ops/sec is documents/sec."},
+	{Name: "BenchmarkCollectionShapeInsertBatch", Section: "Batch Ingest Path", Description: "Batch insert collection documents while sweeping secondary index count; ops/sec is documents/sec."},
+	{Name: "BenchmarkCollectionShapeInsertBatchCheckpoint", Section: "Batch Ingest Path", Description: "Batch insert collection documents while sweeping secondary index count and forcing a sync boundary after each batch; ops/sec is documents/sec."},
+	{Name: "BenchmarkCollectionShapeInsertBatchSingleStringJSON", Section: "Batch Ingest Path", Description: "Batch insert minimal single-string JSON documents with zero or one secondary index; ops/sec is documents/sec."},
+	{Name: "BenchmarkCollectionShapeInsertBatchCheckpointSingleStringJSON", Section: "Batch Ingest Path", Description: "Batch insert minimal single-string JSON documents with zero or one secondary index and force a sync boundary after each batch; ops/sec is documents/sec."},
 	{Name: "BenchmarkCollectionTimedProfileInsertBatchWithSecondaryIndexes", Section: "Batch Ingest Path", Description: "Batch insert indexed documents with setup excluded from the optional timed CPU profile; ops/sec is documents/sec."},
 	{Name: "BenchmarkCollectionTimedProfileInsertBatchCheckpointWithSecondaryIndexes", Section: "Batch Ingest Path", Description: "Batch insert indexed documents and force a sync boundary after each batch with setup excluded from the optional timed CPU profile; ops/sec is documents/sec."},
 	{Name: "BenchmarkSQLiteInsertBatchWithSecondaryIndexes", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL batch insert using a JSON document column, stored generated columns, and unique/non-unique secondary indexes; ops/sec is documents/sec."},
 	{Name: "BenchmarkSQLiteInsertBatchCheckpointWithSecondaryIndexes", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL JSON-document batch insert with an explicit WAL checkpoint after each batch; ops/sec is documents/sec."},
 	{Name: "BenchmarkSQLiteNativeColumnsInsertBatchWithSecondaryIndexes", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL batch insert using native columns and unique/non-unique secondary indexes, with no JSON extraction during insert; ops/sec is documents/sec."},
 	{Name: "BenchmarkSQLiteNativeColumnsInsertBatchCheckpointWithSecondaryIndexes", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL native-column batch insert with an explicit WAL checkpoint after each batch; ops/sec is documents/sec."},
+	{Name: "BenchmarkSQLiteShapeInsertBatchJSON", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL batch insert using a JSON document column while sweeping secondary index count; ops/sec is documents/sec."},
+	{Name: "BenchmarkSQLiteShapeInsertBatchCheckpointJSON", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL JSON-document batch insert while sweeping secondary index count and checkpointing after each batch; ops/sec is documents/sec."},
+	{Name: "BenchmarkSQLiteShapeInsertBatchNativeColumns", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL batch insert using native columns while sweeping secondary index count; ops/sec is documents/sec."},
+	{Name: "BenchmarkSQLiteShapeInsertBatchCheckpointNativeColumns", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL native-column batch insert while sweeping secondary index count and checkpointing after each batch; ops/sec is documents/sec."},
+	{Name: "BenchmarkSQLiteShapeReadPrimaryJSON", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL primary-key reads from the JSON-document table."},
+	{Name: "BenchmarkSQLiteShapeReadPrimaryNativeColumns", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL primary-key reads from the native-column table."},
+	{Name: "BenchmarkSQLiteShapeSecondaryLookupJSON", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL secondary-index lookups from the JSON-document table."},
+	{Name: "BenchmarkSQLiteShapeSecondaryLookupNativeColumns", Section: "SQLite Comparison", Description: "SQLite WAL/NORMAL secondary-index lookups from the native-column table."},
 	{Name: "BenchmarkCollectionDeleteWithSecondaryIndexes", Section: "Document Path", Description: "Delete documents while removing postings from unique and non-unique secondary indexes."},
+	{Name: "BenchmarkCollectionShapeReadPrimary", Section: "Document Path", Description: "Lookup documents by primary `_id` while sweeping collection index shape."},
+	{Name: "BenchmarkCollectionShapeReadPrimaryParallel", Section: "Document Path", Description: "Parallel lookup of documents by primary `_id` while sweeping collection index shape."},
+	{Name: "BenchmarkCollectionMixedReadWritePrimary", Section: "Document Path", Description: "Parallel primary-key readers while a writer concurrently inserts indexed documents."},
+	{Name: "BenchmarkCollectionMixedReadWriteSecondaryUnique", Section: "Document Path", Description: "Parallel unique secondary-index readers while a writer concurrently inserts indexed documents."},
 	{Name: "BenchmarkSecondaryLookupUnique", Section: "Secondary Index Path", Description: "Resolve a unique secondary index lookup to document IDs."},
 	{Name: "BenchmarkSecondaryLookupNonUnique", Section: "Secondary Index Path", Description: "Resolve a non-unique secondary index lookup that returns multiple document IDs."},
 	{Name: "BenchmarkSecondaryUpsertFieldChange", Section: "Secondary Index Path", Description: "Rewrite a document so an indexed field changes and postings move to the new value."},
@@ -396,7 +412,7 @@ func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
 	for _, sample := range samples {
 		entry := runningByName[sample.Name]
 		if entry == nil {
-			spec := specByName[sample.Name]
+			spec := benchmarkSpecForName(specByName, sample.Name)
 			if spec.Name == "" {
 				spec = benchmarkSpec{
 					Name:        sample.Name,
@@ -467,6 +483,19 @@ func aggregateSamples(samples []benchmarkSample) map[string]benchmarkAggregate {
 	return result
 }
 
+func benchmarkSpecForName(specByName map[string]benchmarkSpec, name string) benchmarkSpec {
+	if spec := specByName[name]; spec.Name != "" {
+		return spec
+	}
+	if slash := strings.IndexByte(name, '/'); slash > 0 {
+		if spec := specByName[name[:slash]]; spec.Name != "" {
+			spec.Name = name
+			return spec
+		}
+	}
+	return benchmarkSpec{}
+}
+
 func buildSections(aggregates map[string]benchmarkAggregate) []reportSection {
 	sectionOrder := []string{"Document Path", "Batch Ingest Path", "SQLite Comparison", "Secondary Index Path", "Overhead Breakdown", "Maintenance", "Other"}
 	sections := make(map[string][]benchmarkAggregate, len(sectionOrder))
@@ -481,16 +510,19 @@ func buildSections(aggregates map[string]benchmarkAggregate) []reportSection {
 		seen[aggregate.Name] = struct{}{}
 	}
 
-	var other []benchmarkAggregate
 	for name, aggregate := range aggregates {
 		if _, ok := seen[name]; ok {
 			continue
 		}
-		other = append(other, aggregate)
+		section := aggregate.Section
+		if strings.TrimSpace(section) == "" {
+			section = "Other"
+		}
+		sections[section] = append(sections[section], aggregate)
 	}
-	sort.Slice(other, func(i, j int) bool { return other[i].Name < other[j].Name })
-	if len(other) > 0 {
-		sections["Other"] = append(sections["Other"], other...)
+	for section, benchmarks := range sections {
+		sort.SliceStable(benchmarks, func(i, j int) bool { return benchmarks[i].Name < benchmarks[j].Name })
+		sections[section] = benchmarks
 	}
 
 	var out []reportSection
@@ -626,6 +658,9 @@ func benchmarkMetricColumns(benchmarks []benchmarkAggregate) []string {
 		"insert_ns/doc",
 		"sync_ns/doc",
 		"indexes/doc",
+		"seed_docs",
+		"writer_docs/batch",
+		"writer_docs/sec",
 		"per_item_key_probe_fallback_count",
 		"per_item_prefix_probe_fallback_count",
 		"warm_native_apply",

--- a/cmd/collection_bench_report/main_test.go
+++ b/cmd/collection_bench_report/main_test.go
@@ -139,8 +139,14 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	if !strings.Contains(md, "- collection batch size: `8000`") {
 		t.Fatalf("markdown missing collection batch size:\n%s", md)
 	}
+	if !strings.Contains(md, "- throughput columns are derived from adjacent latency columns as `1e9/ns`") {
+		t.Fatalf("markdown missing throughput derivation note:\n%s", md)
+	}
 	if !strings.Contains(md, "- storage policy: `data_outer=true,index_outer=false`") {
 		t.Fatalf("markdown missing storage policy:\n%s", md)
+	}
+	if !strings.Contains(md, "| Benchmark | Description | Samples | ns/op | Ops/sec | B/op | allocs/op") {
+		t.Fatalf("markdown missing adjacent latency/throughput header:\n%s", md)
 	}
 	if !strings.Contains(md, "- pager chunk size: `profile/default`") {
 		t.Fatalf("markdown missing pager chunk size:\n%s", md)
@@ -159,6 +165,12 @@ func TestBuildReportAndRenderMarkdown(t *testing.T) {
 	}
 	if !strings.Contains(md, "`insert_ns/doc`") || !strings.Contains(md, "`sync_ns/doc`") {
 		t.Fatalf("markdown missing checkpoint split metric columns:\n%s", md)
+	}
+	if !strings.Contains(md, "`insert_docs/sec`") || !strings.Contains(md, "`sync_docs/sec`") {
+		t.Fatalf("markdown missing checkpoint split throughput columns:\n%s", md)
+	}
+	if !strings.Contains(md, "400,000") || !strings.Contains(md, "181,818.18") {
+		t.Fatalf("markdown missing checkpoint split throughput values:\n%s", md)
 	}
 	if !strings.Contains(md, "`per_item_key_probe_fallback_count`") {
 		t.Fatalf("markdown missing native fallback metric column:\n%s", md)

--- a/docs/benchmarks/collections_harness.md
+++ b/docs/benchmarks/collections_harness.md
@@ -1,0 +1,75 @@
+# Collections Benchmark Harness
+
+`scripts/bench_collections_harness.sh` is the single entrypoint for collection
+shape benchmarking and periodic sanity comparisons.
+
+## Quick Run
+
+```bash
+scripts/bench_collections_harness.sh \
+  --out /tmp/gomap_collections_harness \
+  --count 3 \
+  --benchtime 1s \
+  --batch-size 8000
+```
+
+The default run captures:
+
+- JSON collection shape benchmarks.
+- `template-v1` collection shape benchmarks.
+- per-cell `collections_report.{json,md,html}`.
+- per-cell `collections_cpu.pprof`, `collections_mem.pprof`, and pprof top text.
+- top-level `collections_matrix_summary.{tsv,md,html}`.
+- top-level `collections_user_story_summary.tsv`.
+
+## Optional Baselines
+
+Add SQLite parity rows:
+
+```bash
+scripts/bench_collections_harness.sh \
+  --out /tmp/gomap_collections_harness \
+  --include-sqlite
+```
+
+SQLite runs require CGO and a C compiler. The SQLite cell includes JSON
+generated-column and native-column variants for insert, checkpoint, read, and
+secondary lookup shapes.
+
+Add raw TreeDB `unified_bench` anchors:
+
+```bash
+scripts/bench_collections_harness.sh \
+  --out /tmp/gomap_collections_harness \
+  --include-unified \
+  --unified-keys 100000
+```
+
+The unified anchors run TreeDB `fast` and `wal_on_fast` with `-profile-dir`, so
+each anchor emits `benchprof_results.{json,md}` plus `insights.{json,md,html}`
+and per-test pprof artifacts.
+
+## Focused Profiles
+
+```bash
+scripts/bench_collections_harness.sh \
+  --out /tmp/gomap_collections_harness \
+  --profile-benches \
+  --timed-profiles
+```
+
+`--profile-benches` captures whole-process Go test CPU/allocation profiles for
+focused benchmark rows. `--timed-profiles` captures timed-window collection CPU
+profiles for the existing fixed-document indexed insert/checkpoint benchmarks.
+
+## Useful Overrides
+
+- `TREEDB_COLLECTION_HARNESS_JSON_REGEX`
+- `TREEDB_COLLECTION_HARNESS_TEMPLATE_REGEX`
+- `TREEDB_COLLECTION_HARNESS_SQLITE_REGEX`
+- `TREEDB_COLLECTION_HARNESS_UNIFIED_TESTS`
+- `TREEDB_COLLECTION_HARNESS_PROFILE_BENCH_LIST`
+- `TREEDB_COLLECTION_HARNESS_TIMED_PROFILE_DOCS`
+
+The default collection storage policy remains production-oriented:
+`data_outer=true,index_outer=false`.

--- a/scripts/bench_collections_harness.sh
+++ b/scripts/bench_collections_harness.sh
@@ -12,6 +12,13 @@ BENCH_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-production_fast}"
 PATH_LABEL="${TREEDB_COLLECTION_PATH_LABEL:-native-fastpath}"
 DATA_OUTER="${TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG:-true}"
 INDEX_OUTER="${TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG:-false}"
+CHUNK_SIZE="$(printf '%s' "${TREEDB_COLLECTION_CHUNK_SIZE:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+CHUNK_SIZE_LABEL="${CHUNK_SIZE:-profile/default}"
+PAGER_SYNC_CONCURRENCY="$(printf '%s' "${TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+if [[ "$PAGER_SYNC_CONCURRENCY" == "0" ]]; then
+  PAGER_SYNC_CONCURRENCY=""
+fi
+PAGER_SYNC_CONCURRENCY_LABEL="${PAGER_SYNC_CONCURRENCY:-profile/default}"
 INCLUDE_SQLITE="${TREEDB_COLLECTION_HARNESS_INCLUDE_SQLITE:-false}"
 INCLUDE_UNIFIED="${TREEDB_COLLECTION_HARNESS_INCLUDE_UNIFIED:-false}"
 PROFILE_BENCHES="${TREEDB_COLLECTION_HARNESS_PROFILE_BENCHES:-false}"
@@ -136,6 +143,8 @@ echo "engine: $BENCH_ENGINE"
 echo "count: $COUNT"
 echo "benchtime: $BENCHTIME"
 echo "batch size: $BATCH_SIZE"
+echo "pager chunk size: $CHUNK_SIZE_LABEL"
+echo "pager sync concurrency: $PAGER_SYNC_CONCURRENCY_LABEL"
 echo "include sqlite: $INCLUDE_SQLITE"
 echo "include unified: $INCLUDE_UNIFIED"
 
@@ -155,13 +164,15 @@ run_collection_cell() {
     TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" \
     TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" \
     TREEDB_COLLECTION_DOCUMENT_FORMAT="$document_format" \
+    TREEDB_COLLECTION_CHUNK_SIZE="$CHUNK_SIZE" \
     TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$DATA_OUTER" \
     TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$INDEX_OUTER" \
+    TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY="$PAGER_SYNC_CONCURRENCY" \
     scripts/bench_collections_report.sh
 
   printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
     "$cell" "$BENCH_ENGINE" "$document_format" "$DATA_OUTER" "$INDEX_OUTER" \
-    "profile/default" "profile/default" \
+    "$CHUNK_SIZE_LABEL" "$PAGER_SYNC_CONCURRENCY_LABEL" \
     "$cell_dir/collections_report.md" \
     "$cell_dir/collections_report.json" \
     "$cell_dir/collections_cpu.pprof" \
@@ -185,8 +196,10 @@ run_profile_cell_benches() {
       TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" \
       TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" \
       TREEDB_COLLECTION_DOCUMENT_FORMAT="$document_format" \
+      TREEDB_COLLECTION_CHUNK_SIZE="$CHUNK_SIZE" \
       TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$DATA_OUTER" \
       TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$INDEX_OUTER" \
+      TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY="$PAGER_SYNC_CONCURRENCY" \
       scripts/bench_collections_report.sh
     printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
       "$cell" "$BENCH_ENGINE" "$document_format" "$bench" "whole_go_test_process" \
@@ -217,8 +230,10 @@ run_timed_profile_cell_benches() {
       TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" \
       TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" \
       TREEDB_COLLECTION_DOCUMENT_FORMAT="$document_format" \
+      TREEDB_COLLECTION_CHUNK_SIZE="$CHUNK_SIZE" \
       TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$DATA_OUTER" \
       TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$INDEX_OUTER" \
+      TREEDB_COLLECTION_PAGER_SYNC_CONCURRENCY="$PAGER_SYNC_CONCURRENCY" \
       scripts/bench_collections_report.sh
     printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
       "$cell" "$BENCH_ENGINE" "$document_format" "$bench" "timed_benchmark_window" \
@@ -334,6 +349,8 @@ cat >"$OUT_DIR/README.md" <<EOF
 - benchmark count: \`$COUNT\`
 - benchmark time: \`$BENCHTIME\`
 - collection batch size: \`$BATCH_SIZE\`
+- pager chunk size: \`$CHUNK_SIZE_LABEL\`
+- pager sync concurrency: \`$PAGER_SYNC_CONCURRENCY_LABEL\`
 - include sqlite: \`$INCLUDE_SQLITE\`
 - include unified bench: \`$INCLUDE_UNIFIED\`
 - profile benches: \`$PROFILE_BENCHES\`

--- a/scripts/bench_collections_harness.sh
+++ b/scripts/bench_collections_harness.sh
@@ -366,6 +366,8 @@ cat >"$OUT_DIR/README.md" <<EOF
 - profile index: \`$PROFILE_INDEX_TSV\`
 - unified index: \`$UNIFIED_INDEX_TSV\`
 
+Latency columns in the generated reports include adjacent throughput columns, for example \`ns/op\` with \`ops/sec\` and \`insert ns/doc\` with \`insert docs/sec\`.
+
 ## Cells
 
 - JSON collection shapes: \`$OUT_DIR/collections_json_shapes/collections_report.md\`

--- a/scripts/bench_collections_harness.sh
+++ b/scripts/bench_collections_harness.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+OUT_DIR="${OUT_DIR:-$(mktemp -d /tmp/gomap_collections_harness_XXXXXX)}"
+COUNT="${COUNT:-1}"
+BENCHTIME="${BENCHTIME:-1s}"
+BATCH_SIZE="${TREEDB_COLLECTION_BENCH_BATCH_SIZE:-8000}"
+BENCH_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-production_fast}"
+PATH_LABEL="${TREEDB_COLLECTION_PATH_LABEL:-native-fastpath}"
+DATA_OUTER="${TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG:-true}"
+INDEX_OUTER="${TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG:-false}"
+INCLUDE_SQLITE="${TREEDB_COLLECTION_HARNESS_INCLUDE_SQLITE:-false}"
+INCLUDE_UNIFIED="${TREEDB_COLLECTION_HARNESS_INCLUDE_UNIFIED:-false}"
+PROFILE_BENCHES="${TREEDB_COLLECTION_HARNESS_PROFILE_BENCHES:-false}"
+TIMED_PROFILE_BENCHES="${TREEDB_COLLECTION_HARNESS_TIMED_PROFILE_BENCHES:-false}"
+SQLITE_CGO_ENABLED="${TREEDB_COLLECTION_SQLITE_CGO_ENABLED:-1}"
+UNIFIED_KEYS="${TREEDB_COLLECTION_HARNESS_UNIFIED_KEYS:-100000}"
+UNIFIED_VALSIZE="${TREEDB_COLLECTION_HARNESS_UNIFIED_VALSIZE:-128}"
+UNIFIED_TESTS="${TREEDB_COLLECTION_HARNESS_UNIFIED_TESTS:-sequential_write,random_write,batch_write,batch_random,random_read,random_read_parallel_acquire_snapshot,full_scan,prefix_scan}"
+COLLECTION_JSON_REGEX="${TREEDB_COLLECTION_HARNESS_JSON_REGEX:-Benchmark(CollectionShapeInsertBatch|CollectionShapeInsertBatchCheckpoint|CollectionShapeInsertBatchSingleStringJSON|CollectionShapeInsertBatchCheckpointSingleStringJSON|CollectionShapeReadPrimary|CollectionShapeReadPrimaryParallel|CollectionMixedReadWritePrimary|CollectionMixedReadWriteSecondaryUnique|SecondaryLookupUnique|SecondaryLookupNonUnique|CollectionOverheadPlanNoIndex|CollectionOverheadPlanIndexed|CollectionOverheadPlanIndexedTemplateV1|CollectionOverheadIndexStateJSONExtraction|CollectionOverheadIndexStateTemplateV1Extraction|CollectionOverheadPlanIndexedPrecomputedState)$}"
+COLLECTION_TEMPLATE_REGEX="${TREEDB_COLLECTION_HARNESS_TEMPLATE_REGEX:-Benchmark(CollectionShapeInsertBatch|CollectionShapeInsertBatchCheckpoint|CollectionShapeReadPrimary|CollectionShapeReadPrimaryParallel|CollectionMixedReadWritePrimary|CollectionMixedReadWriteSecondaryUnique|SecondaryLookupUnique|SecondaryLookupNonUnique|CollectionOverheadPlanNoIndex|CollectionOverheadPlanIndexed|CollectionOverheadPlanIndexedTemplateV1|CollectionOverheadIndexStateJSONExtraction|CollectionOverheadIndexStateTemplateV1Extraction|CollectionOverheadPlanIndexedPrecomputedState)$}"
+SQLITE_REGEX="${TREEDB_COLLECTION_HARNESS_SQLITE_REGEX:-BenchmarkSQLite(ShapeInsertBatchJSON|ShapeInsertBatchCheckpointJSON|ShapeInsertBatchNativeColumns|ShapeInsertBatchCheckpointNativeColumns|ShapeReadPrimaryJSON|ShapeReadPrimaryNativeColumns|ShapeSecondaryLookupJSON|ShapeSecondaryLookupNativeColumns|InsertBatchWithSecondaryIndexes|InsertBatchCheckpointWithSecondaryIndexes|NativeColumnsInsertBatchWithSecondaryIndexes|NativeColumnsInsertBatchCheckpointWithSecondaryIndexes)$}"
+PROFILE_BENCH_LIST="${TREEDB_COLLECTION_HARNESS_PROFILE_BENCH_LIST:-BenchmarkCollectionShapeInsertBatch/indexes_2 BenchmarkCollectionShapeInsertBatchCheckpoint/indexes_2 BenchmarkCollectionMixedReadWritePrimary}"
+TIMED_PROFILE_BENCH_LIST="${TREEDB_COLLECTION_HARNESS_TIMED_PROFILE_BENCH_LIST:-BenchmarkCollectionTimedProfileInsertBatchWithSecondaryIndexes BenchmarkCollectionTimedProfileInsertBatchCheckpointWithSecondaryIndexes}"
+PROFILE_COUNT="${TREEDB_COLLECTION_HARNESS_PROFILE_COUNT:-1}"
+PROFILE_BENCHTIME="${TREEDB_COLLECTION_HARNESS_PROFILE_BENCHTIME:-}"
+TIMED_PROFILE_DOCS="${TREEDB_COLLECTION_HARNESS_TIMED_PROFILE_DOCS:-240000}"
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+COMMIT="$(git rev-parse --short HEAD)"
+WORKTREE="$ROOT"
+
+usage() {
+  cat <<'EOF'
+usage: scripts/bench_collections_harness.sh [options]
+
+Options:
+  --out DIR              Output directory.
+  --count N              go test benchmark count.
+  --benchtime VALUE      go test -benchtime value.
+  --batch-size N         Collection and unified bench batch size.
+  --engine NAME          Collection TreeDB profile/engine label.
+  --include-sqlite       Include SQLite JSON/native-column parity benches.
+  --include-unified      Include raw TreeDB unified_bench profile-dir anchors.
+  --profile-benches      Add focused whole-process pprof bundles.
+  --timed-profiles       Add timed-window collection CPU pprof bundles.
+  --unified-keys N       Key count for unified_bench anchors.
+  --help                 Show this help.
+
+Environment variables with the TREEDB_COLLECTION_HARNESS_* prefix can override
+the benchmark regexes, unified bench tests, profile lists, and profile sizes.
+EOF
+}
+
+is_true() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|y|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --count)
+      COUNT="$2"
+      shift 2
+      ;;
+    --benchtime)
+      BENCHTIME="$2"
+      shift 2
+      ;;
+    --batch-size)
+      BATCH_SIZE="$2"
+      shift 2
+      ;;
+    --engine)
+      BENCH_ENGINE="$2"
+      shift 2
+      ;;
+    --include-sqlite)
+      INCLUDE_SQLITE=true
+      shift
+      ;;
+    --include-unified)
+      INCLUDE_UNIFIED=true
+      shift
+      ;;
+    --profile-benches)
+      PROFILE_BENCHES=true
+      shift
+      ;;
+    --timed-profiles)
+      TIMED_PROFILE_BENCHES=true
+      shift
+      ;;
+    --unified-keys)
+      UNIFIED_KEYS="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$PROFILE_BENCHTIME" ]]; then
+  PROFILE_BENCHTIME="$BENCHTIME"
+fi
+
+mkdir -p "$OUT_DIR"
+INDEX_TSV="$OUT_DIR/harness_matrix_index.tsv"
+PROFILE_INDEX_TSV="$OUT_DIR/harness_profile_index.tsv"
+UNIFIED_INDEX_TSV="$OUT_DIR/harness_unified_index.tsv"
+
+printf "cell\tengine\tdocument_format\tdata_outer_leaves_in_vlog\tindex_outer_leaves_in_vlog\tpager_chunk_size\tpager_sync_concurrency\treport_md\treport_json\tcpu_profile\tmem_profile\n" >"$INDEX_TSV"
+printf "cell\tengine\tdocument_format\tbenchmark\tcpu_profile_mode\treport_md\treport_json\tcpu_profile\tmem_profile\tcpu_top\tmem_top\n" >"$PROFILE_INDEX_TSV"
+printf "cell\tprofile\tkeys\tvalsize\tbatchsize\ttests\tprofile_dir\tbenchprof_md\tinsights_md\tinsights_html\n" >"$UNIFIED_INDEX_TSV"
+
+echo "running collections harness into: $OUT_DIR"
+echo "worktree: $WORKTREE"
+echo "branch: $BRANCH"
+echo "commit: $COMMIT"
+echo "engine: $BENCH_ENGINE"
+echo "count: $COUNT"
+echo "benchtime: $BENCHTIME"
+echo "batch size: $BATCH_SIZE"
+echo "include sqlite: $INCLUDE_SQLITE"
+echo "include unified: $INCLUDE_UNIFIED"
+
+run_collection_cell() {
+  local cell=$1
+  local document_format=$2
+  local regex=$3
+  local cell_dir="$OUT_DIR/$cell"
+
+  echo
+  echo "==> collection cell $cell"
+  OUT_DIR="$cell_dir" \
+    BENCH_REGEX="$regex" \
+    COUNT="$COUNT" \
+    BENCHTIME="$BENCHTIME" \
+    TREEDB_COLLECTION_PATH_LABEL="$PATH_LABEL" \
+    TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" \
+    TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" \
+    TREEDB_COLLECTION_DOCUMENT_FORMAT="$document_format" \
+    TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$DATA_OUTER" \
+    TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$INDEX_OUTER" \
+    scripts/bench_collections_report.sh
+
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "$cell" "$BENCH_ENGINE" "$document_format" "$DATA_OUTER" "$INDEX_OUTER" \
+    "profile/default" "profile/default" \
+    "$cell_dir/collections_report.md" \
+    "$cell_dir/collections_report.json" \
+    "$cell_dir/collections_cpu.pprof" \
+    "$cell_dir/collections_mem.pprof" >>"$INDEX_TSV"
+}
+
+run_profile_cell_benches() {
+  local cell=$1
+  local document_format=$2
+  local benches=()
+  read -r -a benches <<<"$PROFILE_BENCH_LIST"
+  for bench in "${benches[@]}"; do
+    local profile_dir="$OUT_DIR/$cell/profiles/$(printf '%s' "$bench" | tr '/ ' '__')"
+    echo
+    echo "==> profile $cell $bench"
+    OUT_DIR="$profile_dir" \
+      BENCH_REGEX="^${bench}$" \
+      COUNT="$PROFILE_COUNT" \
+      BENCHTIME="$PROFILE_BENCHTIME" \
+      TREEDB_COLLECTION_PATH_LABEL="$PATH_LABEL" \
+      TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" \
+      TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" \
+      TREEDB_COLLECTION_DOCUMENT_FORMAT="$document_format" \
+      TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$DATA_OUTER" \
+      TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$INDEX_OUTER" \
+      scripts/bench_collections_report.sh
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+      "$cell" "$BENCH_ENGINE" "$document_format" "$bench" "whole_go_test_process" \
+      "$profile_dir/collections_report.md" \
+      "$profile_dir/collections_report.json" \
+      "$profile_dir/collections_cpu.pprof" \
+      "$profile_dir/collections_mem.pprof" \
+      "$profile_dir/collections_cpu_top.txt" \
+      "$profile_dir/collections_mem_top.txt" >>"$PROFILE_INDEX_TSV"
+  done
+}
+
+run_timed_profile_cell_benches() {
+  local cell=$1
+  local document_format=$2
+  local benches=()
+  read -r -a benches <<<"$TIMED_PROFILE_BENCH_LIST"
+  for bench in "${benches[@]}"; do
+    local profile_dir="$OUT_DIR/$cell/timed_profiles/$bench"
+    echo
+    echo "==> timed profile $cell $bench"
+    OUT_DIR="$profile_dir" \
+      BENCH_REGEX="^${bench}$" \
+      COUNT=1 \
+      BENCHTIME="${TIMED_PROFILE_DOCS}x" \
+      TREEDB_COLLECTION_TIMED_CPU_PROFILE=true \
+      TREEDB_COLLECTION_PATH_LABEL="$PATH_LABEL" \
+      TREEDB_COLLECTION_BENCH_ENGINE="$BENCH_ENGINE" \
+      TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" \
+      TREEDB_COLLECTION_DOCUMENT_FORMAT="$document_format" \
+      TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$DATA_OUTER" \
+      TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$INDEX_OUTER" \
+      scripts/bench_collections_report.sh
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+      "$cell" "$BENCH_ENGINE" "$document_format" "$bench" "timed_benchmark_window" \
+      "$profile_dir/collections_report.md" \
+      "$profile_dir/collections_report.json" \
+      "$profile_dir/collections_cpu.pprof" \
+      "$profile_dir/collections_mem.pprof" \
+      "$profile_dir/collections_cpu_top.txt" \
+      "$profile_dir/collections_mem_top.txt" >>"$PROFILE_INDEX_TSV"
+  done
+}
+
+run_sqlite_cell() {
+  if ! is_true "$SQLITE_CGO_ENABLED"; then
+    echo "SQLite harness requires CGO; set TREEDB_COLLECTION_SQLITE_CGO_ENABLED=1 or omit --include-sqlite" >&2
+    exit 2
+  fi
+  if ! command -v cc >/dev/null 2>&1 && ! command -v gcc >/dev/null 2>&1 && ! command -v clang >/dev/null 2>&1; then
+    echo "SQLite harness requires a C compiler for github.com/mattn/go-sqlite3" >&2
+    exit 2
+  fi
+
+  local cell="sqlite_wal_normal_shapes"
+  local cell_dir="$OUT_DIR/$cell"
+  echo
+  echo "==> sqlite cell $cell"
+  OUT_DIR="$cell_dir" \
+    BENCH_REGEX="$SQLITE_REGEX" \
+    COUNT="$COUNT" \
+    BENCHTIME="$BENCHTIME" \
+    TREEDB_COLLECTION_PATH_LABEL="sqlite" \
+    TREEDB_COLLECTION_BENCH_ENGINE="sqlite_wal_normal" \
+    TREEDB_COLLECTION_BENCH_BATCH_SIZE="$BATCH_SIZE" \
+    TREEDB_COLLECTION_DOCUMENT_FORMAT="json" \
+    TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="-" \
+    TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="-" \
+    GO_TEST_TAGS="sqlite_bench" \
+    CGO_ENABLED="$SQLITE_CGO_ENABLED" \
+    scripts/bench_collections_report.sh
+
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "$cell" "sqlite_wal_normal" "json" "-" "-" "-" "-" \
+    "$cell_dir/collections_report.md" \
+    "$cell_dir/collections_report.json" \
+    "$cell_dir/collections_cpu.pprof" \
+    "$cell_dir/collections_mem.pprof" >>"$INDEX_TSV"
+}
+
+run_unified_anchor() {
+  local profile=$1
+  local cell="unified_${profile}"
+  local profile_dir="$OUT_DIR/$cell"
+  mkdir -p "$profile_dir"
+  echo
+  echo "==> unified bench $profile"
+  GOWORK=off go run ./cmd/unified_bench \
+    -dbs treedb \
+    -profile "$profile" \
+    -path-label "$PATH_LABEL" \
+    -keys "$UNIFIED_KEYS" \
+    -valsize "$UNIFIED_VALSIZE" \
+    -batchsize "$BATCH_SIZE" \
+    -test "$UNIFIED_TESTS" \
+    -checkpoint-between-tests \
+    -read-require-hit \
+    -profile-dir "$profile_dir" \
+    -format markdown \
+    -progress=false | tee "$profile_dir/unified_bench_stdout.md"
+
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "$cell" "$profile" "$UNIFIED_KEYS" "$UNIFIED_VALSIZE" "$BATCH_SIZE" "$UNIFIED_TESTS" \
+    "$profile_dir" \
+    "$profile_dir/benchprof_results.md" \
+    "$profile_dir/insights.md" \
+    "$profile_dir/insights.html" >>"$UNIFIED_INDEX_TSV"
+}
+
+run_collection_cell "collections_json_shapes" "json" "$COLLECTION_JSON_REGEX"
+run_collection_cell "collections_template_v1_shapes" "template-v1" "$COLLECTION_TEMPLATE_REGEX"
+
+if is_true "$PROFILE_BENCHES"; then
+  run_profile_cell_benches "collections_json_shapes" "json"
+  run_profile_cell_benches "collections_template_v1_shapes" "template-v1"
+fi
+
+if is_true "$TIMED_PROFILE_BENCHES"; then
+  run_timed_profile_cell_benches "collections_json_shapes" "json"
+  run_timed_profile_cell_benches "collections_template_v1_shapes" "template-v1"
+fi
+
+if is_true "$INCLUDE_SQLITE"; then
+  run_sqlite_cell
+fi
+
+GOWORK=off go run ./cmd/collection_bench_matrix_summary \
+  -matrix-index "$INDEX_TSV" \
+  -out-dir "$OUT_DIR" \
+  -available-benchmarks
+
+if is_true "$INCLUDE_UNIFIED"; then
+  run_unified_anchor "fast"
+  run_unified_anchor "wal_on_fast"
+fi
+
+cat >"$OUT_DIR/README.md" <<EOF
+# Collections Benchmark Harness
+
+- output directory: \`$OUT_DIR\`
+- worktree: \`$WORKTREE\`
+- branch: \`$BRANCH\`
+- commit: \`$COMMIT\`
+- benchmark engine: \`$BENCH_ENGINE\`
+- benchmark count: \`$COUNT\`
+- benchmark time: \`$BENCHTIME\`
+- collection batch size: \`$BATCH_SIZE\`
+- include sqlite: \`$INCLUDE_SQLITE\`
+- include unified bench: \`$INCLUDE_UNIFIED\`
+- profile benches: \`$PROFILE_BENCHES\`
+- timed profile benches: \`$TIMED_PROFILE_BENCHES\`
+
+## Summary Artifacts
+
+- collection matrix index: \`$INDEX_TSV\`
+- collection matrix summary: \`$OUT_DIR/collections_matrix_summary.md\`
+- collection matrix summary html: \`$OUT_DIR/collections_matrix_summary.html\`
+- collection matrix summary tsv: \`$OUT_DIR/collections_matrix_summary.tsv\`
+- user-story throughput tsv: \`$OUT_DIR/collections_user_story_summary.tsv\`
+- profile index: \`$PROFILE_INDEX_TSV\`
+- unified index: \`$UNIFIED_INDEX_TSV\`
+
+## Cells
+
+- JSON collection shapes: \`$OUT_DIR/collections_json_shapes/collections_report.md\`
+- template-v1 collection shapes: \`$OUT_DIR/collections_template_v1_shapes/collections_report.md\`
+EOF
+
+if is_true "$INCLUDE_SQLITE"; then
+  echo "- SQLite shape parity: \`$OUT_DIR/sqlite_wal_normal_shapes/collections_report.md\`" >>"$OUT_DIR/README.md"
+fi
+if is_true "$INCLUDE_UNIFIED"; then
+  cat >>"$OUT_DIR/README.md" <<EOF
+- unified fast benchprof: \`$OUT_DIR/unified_fast/benchprof_results.md\`
+- unified fast insights: \`$OUT_DIR/unified_fast/insights.md\`
+- unified WAL-on-fast benchprof: \`$OUT_DIR/unified_wal_on_fast/benchprof_results.md\`
+- unified WAL-on-fast insights: \`$OUT_DIR/unified_wal_on_fast/insights.md\`
+EOF
+fi
+
+echo
+echo "harness readme: $OUT_DIR/README.md"
+echo "matrix summary: $OUT_DIR/collections_matrix_summary.md"
+echo "matrix html:    $OUT_DIR/collections_matrix_summary.html"

--- a/scripts/bench_collections_harness.sh
+++ b/scripts/bench_collections_harness.sh
@@ -271,7 +271,7 @@ run_sqlite_cell() {
     TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="-" \
     TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="-" \
     GO_TEST_TAGS="sqlite_bench" \
-    CGO_ENABLED="$SQLITE_CGO_ENABLED" \
+    CGO_ENABLED=1 \
     scripts/bench_collections_report.sh
 
   printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \

--- a/scripts/bench_collections_harness.sh
+++ b/scripts/bench_collections_harness.sh
@@ -135,6 +135,27 @@ printf "cell\tengine\tdocument_format\tdata_outer_leaves_in_vlog\tindex_outer_le
 printf "cell\tengine\tdocument_format\tbenchmark\tcpu_profile_mode\treport_md\treport_json\tcpu_profile\tmem_profile\tcpu_top\tmem_top\n" >"$PROFILE_INDEX_TSV"
 printf "cell\tprofile\tkeys\tvalsize\tbatchsize\ttests\tprofile_dir\tbenchprof_md\tinsights_md\tinsights_html\n" >"$UNIFIED_INDEX_TSV"
 
+regex_escape_segment() {
+  printf '%s' "$1" | sed -e 's/[][\\.^$*+?{}()|]/\\&/g'
+}
+
+bench_regex_for_go_test() {
+  local bench=$1
+  local out=""
+  local parts=()
+  local part
+  local escaped
+  IFS='/' read -r -a parts <<<"$bench"
+  for part in "${parts[@]}"; do
+    escaped=$(regex_escape_segment "$part")
+    if [[ -n "$out" ]]; then
+      out+="/"
+    fi
+    out+="^${escaped}$"
+  done
+  printf '%s' "$out"
+}
+
 echo "running collections harness into: $OUT_DIR"
 echo "worktree: $WORKTREE"
 echo "branch: $BRANCH"
@@ -186,10 +207,12 @@ run_profile_cell_benches() {
   read -r -a benches <<<"$PROFILE_BENCH_LIST"
   for bench in "${benches[@]}"; do
     local profile_dir="$OUT_DIR/$cell/profiles/$(printf '%s' "$bench" | tr '/ ' '__')"
+    local bench_regex
+    bench_regex=$(bench_regex_for_go_test "$bench")
     echo
     echo "==> profile $cell $bench"
     OUT_DIR="$profile_dir" \
-      BENCH_REGEX="^${bench}$" \
+      BENCH_REGEX="$bench_regex" \
       COUNT="$PROFILE_COUNT" \
       BENCHTIME="$PROFILE_BENCHTIME" \
       TREEDB_COLLECTION_PATH_LABEL="$PATH_LABEL" \
@@ -219,10 +242,12 @@ run_timed_profile_cell_benches() {
   read -r -a benches <<<"$TIMED_PROFILE_BENCH_LIST"
   for bench in "${benches[@]}"; do
     local profile_dir="$OUT_DIR/$cell/timed_profiles/$bench"
+    local bench_regex
+    bench_regex=$(bench_regex_for_go_test "$bench")
     echo
     echo "==> timed profile $cell $bench"
     OUT_DIR="$profile_dir" \
-      BENCH_REGEX="^${bench}$" \
+      BENCH_REGEX="$bench_regex" \
       COUNT=1 \
       BENCHTIME="${TIMED_PROFILE_DOCS}x" \
       TREEDB_COLLECTION_TIMED_CPU_PROFILE=true \


### PR DESCRIPTION
Stacked on #1068.

## Summary
- adds a single `scripts/bench_collections_harness.sh` entrypoint for collection shape sweeps, optional SQLite parity runs, optional raw TreeDB unified-bench anchors, and focused pprof capture
- adds collection shape/mixed read-write benchmarks and SQLite JSON/native-column parity shape benchmarks
- expands collection report and matrix summary output with detailed markdown/html/json/tsv artifacts
- documents the harness in `docs/benchmarks/collections_harness.md`
- report/matrix output now pairs latency with throughput: `ns/op` with `ops/sec`, `ns/doc` with `docs/sec`, split checkpoint `insert/sync` docs/sec, and mixed-writer docs/sec

## Local validation
- `GOWORK=off go test ./cmd/collection_bench_report ./cmd/collection_bench_matrix_summary`
- `GOWORK=off go test ./TreeDB/collections`
- `CGO_ENABLED=1 GOWORK=off go test -tags sqlite_bench ./TreeDB/collections`
- `GOWORK=off go test ./cmd/unified_bench ./cmd/benchprof`
- smoke harness with SQLite parity
- smoke harness with unified-bench anchors
- smoke harness with focused pprof capture
- focused profile-regex smoke confirming `BenchmarkCollectionShapeInsertBatch/indexes_2` does not also run checkpoint siblings

## Full local bench/profile run

Run directory: `/tmp/gomap_harness_targets_20260427_151350`

Command:

```sh
scripts/bench_collections_harness.sh \
  --out /tmp/gomap_harness_targets_20260427_151350 \
  --count 3 \
  --benchtime 500ms \
  --batch-size 8000 \
  --include-sqlite \
  --include-unified \
  --profile-benches \
  --timed-profiles
```

Primary generated artifacts:
- `collections_matrix_summary.{md,html,tsv}`
- `collections_user_story_summary.tsv`
- `harness_matrix_index.tsv`
- `harness_profile_index.tsv`
- `harness_unified_index.tsv`
- `collections_json_shapes/collections_report.{json,md,html}`
- `collections_template_v1_shapes/collections_report.{json,md,html}`
- `sqlite_wal_normal_shapes/collections_report.{json,md,html}`
- `unified_fast/benchprof_results.{json,md}` plus `insights.{md,html}`
- `unified_wal_on_fast/benchprof_results.{json,md}` plus `insights.{md,html}`
- `next_targets.md`

Profile coverage generated by the harness:
- collection whole-process CPU/mem pprof for JSON and template-v1 cells
- focused collection CPU/mem pprof for `BenchmarkCollectionShapeInsertBatch/indexes_2`, `BenchmarkCollectionShapeInsertBatchCheckpoint/indexes_2`, and `BenchmarkCollectionMixedReadWritePrimary` for both JSON and template-v1
- timed benchmark-window CPU/mem pprof for `BenchmarkCollectionTimedProfileInsertBatchWithSecondaryIndexes` and `BenchmarkCollectionTimedProfileInsertBatchCheckpointWithSecondaryIndexes` for both JSON and template-v1
- SQLite parity CPU/mem pprof for the SQLite cell
- unified `fast` and `wal_on_fast` pprof sets for `sequential_write`, `random_write`, `batch_write`, `batch_random`, `random_read`, `random_read_parallel_acquire_snapshot`, `full_scan`, and `prefix_scan`, including CPU, allocs, checkpoint CPU, block, mutex, and trace artifacts

## Benchmark readout

Template-v1 collection insert, no checkpoint:

| Shape | ns/doc | docs/sec | B/doc | allocs/doc |
| --- | ---: | ---: | ---: | ---: |
| 0 indexes | 262.8 | 3,805,658 | 360.7 | 0 |
| 1 index | 601.3 | 1,663,156 | 1,047.0 | 0 |
| 2 indexes | 947.4 | 1,055,483 | 1,424.0 | 0 |
| 3 indexes | 1,092.0 | 915,751 | 1,546.7 | 0 |

Template-v1 collection insert with checkpoint:

| Shape | total ns/doc | docs/sec | insert ns/doc | insert docs/sec | sync ns/doc | sync docs/sec |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 0 indexes | 601.9 | 1,661,406 | 268.2 | 3,728,097 | 333.6 | 2,997,602 |
| 1 index | 1,067.7 | 936,622 | 672.3 | 1,487,505 | 395.5 | 2,528,232 |
| 2 indexes | 1,528.7 | 654,165 | 1,089.0 | 918,274 | 439.4 | 2,275,831 |
| 3 indexes | 1,688.3 | 592,300 | 1,227.7 | 814,553 | 460.6 | 2,171,081 |

JSON collection insert, no checkpoint:

| Shape | ns/doc | docs/sec | B/doc | allocs/doc |
| --- | ---: | ---: | ---: | ---: |
| 0 indexes | 212.6 | 4,703,669 | 245.0 | 0 |
| 1 index | 681.3 | 1,467,854 | 691.7 | 0 |
| 2 indexes | 1,010.3 | 989,772 | 810.7 | 0 |
| 3 indexes | 1,154.0 | 866,551 | 983.7 | 0 |

SQLite parity:

| Shape | JSON ns/doc | JSON docs/sec | Native columns ns/doc | Native columns docs/sec |
| --- | ---: | ---: | ---: | ---: |
| 0 indexes insert | 972.6 | 1,028,207 | 1,187.7 | 841,987 |
| 1 index insert | 1,651.7 | 605,449 | 1,516.0 | 659,631 |
| 2 indexes insert | 2,416.0 | 413,907 | 2,179.3 | 458,856 |
| 3 indexes insert | 2,901.7 | 344,630 | 2,579.0 | 387,747 |
| 2 indexes checkpoint | 2,997.0 | 333,667 | 2,627.7 | 380,566 |

Reads and lookups:

| Benchmark | ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| JSON primary read, 0 indexes | 1,730.7 | 577,812 | 8,482 | 4 |
| JSON primary read, 2 indexes | 1,684.0 | 593,824 | 8,482 | 4 |
| template-v1 primary read, 0 indexes | 1,324.3 | 755,097 | 5,127.7 | 3 |
| template-v1 primary read, 2 indexes | 1,318.0 | 758,725 | 5,100 | 3 |
| TreeDB unique secondary lookup | 1,182.3 | 845,785 | 832.3 | 10 |
| TreeDB nonunique secondary lookup | 3,745.7 | 266,975 | 6,117.7 | 79 |
| SQLite JSON unique secondary lookup | 2,315.0 | 431,965 | 576 | 20 |
| SQLite JSON nonunique secondary lookup | 25,496.7 | 39,221 | 3,552 | 208 |
| SQLite native unique secondary lookup | 2,107.3 | 474,533 | 576 | 20 |
| SQLite native nonunique secondary lookup | 14,868.3 | 67,257 | 3,552 | 208 |

Raw TreeDB anchors from unified bench, keys=100,000, values=128, batch=8,000. Values are ops/sec:

| Profile | Batch write | Batch random | Random read | Parallel random read | Full scan | Prefix scan |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| fast | 14,890,554 | 6,095,749 | 333,976 | 776,014 | 4,930,992 | 5,338,078 |
| wal_on_fast | 6,881,740 | 3,793,351 | 285,253 | 799,052 | 4,363,581 | 2,524,177 |

## Profile/target interpretation

The raw engine is not the immediate ceiling for indexed collection writes. Raw `fast` batch write is about 14.9M ops/sec and `wal_on_fast` is about 6.9M ops/sec, while the 2-index template-v1 collection shape is about 1.06M docs/sec without checkpoint and 654k docs/sec with checkpoint.

The largest collection-write cost is index/root maintenance. Template-v1 no-checkpoint insert moves from 262.8 ns/doc and 3.81M docs/sec with no index to 947.4 ns/doc and 1.06M docs/sec with two indexes. Checkpointed two-index insert spends about 1,089 ns/doc before sync and 439 ns/doc in sync, so the variable index cost is mostly in planning/run building/publish rather than checkpoint itself.

Template-v1 extraction helps, but it is not the main remaining bottleneck. Isolated extraction is about 274 ns/doc / 3.65M ops/sec for JSON and 112 ns/doc / 8.89M ops/sec for template-v1. That 162 ns/doc delta is meaningful, but smaller than the roughly 685 ns/doc spread between zero-index and two-index template-v1 insert.

This does not look like a simple coordination-lock problem between collection and index. The code path is a planned multi-root write: `Collection.InsertBatch` builds primary, template/index-state, and secondary runs, then calls `PublishOrderedRootDeltaGroupWithSystemDeltaBuilder`. The likely issue is write amplification across roots plus per-root merge/page-build cost, with unique preflight and index-state work layered on top.

Reads are already competitive with SQLite in this shape, but they allocate heavily. Template-v1 primary read is about 1.3 us/op / 759k ops/sec and 5 KB/op; JSON primary read is about 1.7 us/op / 594k ops/sec and 8.5 KB/op. Focused mixed read/write allocation profiles point at value-log `readViaMmapView` and `Collection.Get` returning an owned clone, which is a separate read-side target from insert indexing.

## Next optimization targets

1. Add phase timers and counters inside collection insert: `prepareInsertDocuments`, index-state extraction, duplicate/unique preflight, primary run build, index-state run build, each secondary run build, and `PublishOrderedRootDeltaGroupWithSystemDeltaBuilder`.
2. Re-run lower-noise focused profiles at 10s+ for `BenchmarkCollectionShapeInsertBatch/indexes_2`, `BenchmarkCollectionShapeInsertBatchCheckpoint/indexes_2`, `BenchmarkCollectionShapeReadPrimary/indexes_2`, and `BenchmarkCollectionMixedReadWritePrimary`.
3. Attack read allocation first with an internal `GetInto` or owned-buffer fast path, plus an audit of `readViaMmapView` and grouped-frame decode/copy behavior.
4. Reduce index-state/write amplification by evaluating whether compact index-state can live alongside primary records or be skipped when index values are cheaply recomputable from template-v1/native records.
5. Optimize secondary run construction by adding counters for sorted vs unsorted paths and bytes built per index, then evaluating fused or streaming run construction for common sorted unique indexes.
6. Separate dictionary/compression warm-up from steady-state results with harness options for compression/dict disabled, pre-warmed DBs, and longer steady-state windows.
7. Add read-transaction and batch-read shapes to isolate snapshot/catalog overhead from tree/value-log read overhead.
8. Keep SQLite as a sanity baseline, not the target ceiling: TreeDB indexed collection writes are faster than SQLite in these insert shapes, and secondary lookup is much faster for nonunique lookup.

Relevant code paths:
- `TreeDB/collections/api.go`: `Collection.InsertBatch`, `Collection.Get`
- `TreeDB/collections/planner.go`: `planInsertBatchWithPreflight`, `planIndexStateAndUniqueProbes`, `emitSecondaryRuns`
- `TreeDB/db/ordered_root_publish.go`: `PublishOrderedRootDeltaGroupWithSystemDeltaBuilder`
- `TreeDB/internal/valuelog/reader_mmap.go`: `readViaMmapView`
