### PR TITLE
collections: optimize template-v1 encoding and prepare

### DIFF
--- a/TreeDB/collections/overhead_bench_test.go
+++ b/TreeDB/collections/overhead_bench_test.go
@@ -15,6 +15,35 @@ const (
 
 var overheadBenchPayload = []byte(`{"name":"ada","city":"hnl","email":"ada@example.com","pad":"0123456789012345678901234567890123456789"}`)
 
+var templateV1BenchmarkSink []byte
+
+func BenchmarkTemplateV1EncodeDocument(b *testing.B) {
+	fields := []string{"name", "email", "city", "pad"}
+	values := []any{"ada", "ada@example.com", "hnl", "0123456789012345678901234567890123456789"}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		doc, err := EncodeTemplateV1Document(fields, values)
+		if err != nil {
+			b.Fatalf("encode template-v1 document: %v", err)
+		}
+		templateV1BenchmarkSink = doc
+	}
+}
+
+func BenchmarkTemplateV1EncoderEncodeDocumentRepeatedShape(b *testing.B) {
+	fields := []string{"name", "email", "city", "pad"}
+	values := []any{"ada", "ada@example.com", "hnl", "0123456789012345678901234567890123456789"}
+	var encoder TemplateV1Encoder
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		doc, err := encoder.EncodeDocument(fields, values)
+		if err != nil {
+			b.Fatalf("encode template-v1 document: %v", err)
+		}
+		templateV1BenchmarkSink = doc
+	}
+}
+
 func overheadBenchBatchSize(b *testing.B) int {
 	b.Helper()
 
@@ -268,7 +297,7 @@ func BenchmarkCollectionOverheadIndexStateTemplateV1Extraction(b *testing.B) {
 		}
 		storedDocs[i] = stored
 		for _, record := range records {
-			if err := resolver.addRecord(record); err != nil {
+			if _, err := resolver.addRecord(record); err != nil {
 				b.Fatalf("add template-v1 record: %v", err)
 			}
 		}

--- a/TreeDB/collections/template_v1.go
+++ b/TreeDB/collections/template_v1.go
@@ -126,17 +126,21 @@ func prepareTemplateV1InsertDocuments(documents [][]byte, fallback templateV1Res
 	prepared := make([][]byte, len(documents))
 	records := make([]templateV1Record, 0)
 	resolver := &templateV1MemoryResolver{}
-	totalStoredBytes := 0
 	for i, document := range documents {
 		stored, docRecords, err := parseTemplateV1InsertDocument(document)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		totalStoredBytes += len(stored)
+		// Keep compact stored bytes borrowed like JSON documents; publish consumes
+		// the prepared batch synchronously before InsertBatch returns.
 		prepared[i] = stored
 		for _, record := range docRecords {
-			if err := resolver.addRecord(record); err != nil {
+			added, err := resolver.addRecord(record)
+			if err != nil {
 				return nil, nil, nil, err
+			}
+			if !added {
+				continue
 			}
 			publish, err := shouldPublishTemplateV1Record(record, fallback)
 			if err != nil {
@@ -147,17 +151,17 @@ func prepareTemplateV1InsertDocuments(documents [][]byte, fallback templateV1Res
 			}
 		}
 	}
-	arena := make([]byte, 0, totalStoredBytes)
-	for i, stored := range prepared {
-		start := len(arena)
-		arena = append(arena, stored...)
-		prepared[i] = arena[start:len(arena):len(arena)]
-	}
 	if fallback == nil {
 		if err := validateTemplateV1PreparedDocuments(prepared, resolver); err != nil {
 			return nil, nil, nil, err
 		}
 		return prepared, records, resolver, nil
+	}
+	if len(resolver.templates) == 0 {
+		if err := validateTemplateV1PreparedDocuments(prepared, fallback); err != nil {
+			return nil, nil, nil, err
+		}
+		return prepared, records, fallback, nil
 	}
 	composite := &templateV1CompositeResolver{memory: resolver, fallback: fallback}
 	if err := validateTemplateV1PreparedDocuments(prepared, composite); err != nil {
@@ -268,19 +272,19 @@ func validateTemplateV1StoredDocumentTemplates(document []byte, resolver templat
 	return nil
 }
 
-func (r *templateV1MemoryResolver) addRecord(record templateV1Record) error {
+func (r *templateV1MemoryResolver) addRecord(record templateV1Record) (bool, error) {
 	if r.templates == nil {
 		r.templates = make(map[string]*templateV1Template)
 	}
 	key := string(record.id[:])
 	if existing := r.templates[key]; existing != nil {
 		if !equalStringSlices(existing.fields, record.tpl.fields) {
-			return errors.New("collections: template-v1 template id collision")
+			return false, errors.New("collections: template-v1 template id collision")
 		}
-		return nil
+		return false, nil
 	}
 	r.templates[key] = record.tpl
-	return nil
+	return true, nil
 }
 
 func (r *templateV1MemoryResolver) lookupTemplateV1(id [32]byte) (*templateV1Template, error) {
@@ -363,17 +367,7 @@ func dedupeTemplateV1Records(records []templateV1Record) ([]templateV1Record, er
 }
 
 func EncodeTemplateV1Document(fields []string, values []any) ([]byte, error) {
-	if len(fields) != len(values) {
-		return nil, errors.New("collections: template-v1 field/value length mismatch")
-	}
-	obj := make(map[string]any, len(fields))
-	for i, field := range fields {
-		if _, exists := obj[field]; exists {
-			return nil, fmt.Errorf("collections: duplicate template-v1 field %q", field)
-		}
-		obj[field] = values[i]
-	}
-	return encodeTemplateV1ObjectMap(obj)
+	return encodeTemplateV1FieldsWithRecordFilter(fields, values, nil)
 }
 
 type TemplateV1Encoder struct {
@@ -385,20 +379,10 @@ func (e *TemplateV1Encoder) Reset() {
 }
 
 func (e *TemplateV1Encoder) EncodeDocument(fields []string, values []any) ([]byte, error) {
-	if len(fields) != len(values) {
-		return nil, errors.New("collections: template-v1 field/value length mismatch")
-	}
-	obj := make(map[string]any, len(fields))
-	for i, field := range fields {
-		if _, exists := obj[field]; exists {
-			return nil, fmt.Errorf("collections: duplicate template-v1 field %q", field)
+	return encodeTemplateV1FieldsWithRecordFilter(fields, values, func(record templateV1Record) bool {
+		if e.emitted == nil {
+			e.emitted = make(map[string]struct{})
 		}
-		obj[field] = values[i]
-	}
-	if e.emitted == nil {
-		e.emitted = make(map[string]struct{})
-	}
-	return encodeTemplateV1ObjectMapWithRecordFilter(obj, func(record templateV1Record) bool {
 		key := string(record.id[:])
 		if _, exists := e.emitted[key]; exists {
 			return false
@@ -421,26 +405,74 @@ func EncodeTemplateV1DocumentJSON(raw []byte) ([]byte, error) {
 }
 
 func encodeTemplateV1ObjectMap(obj map[string]any) ([]byte, error) {
-	return encodeTemplateV1ObjectMapWithRecordFilter(obj, func(templateV1Record) bool { return true })
+	return encodeTemplateV1ObjectMapWithRecordFilter(obj, nil)
 }
 
 func encodeTemplateV1ObjectMapWithRecordFilter(obj map[string]any, includeRecord func(templateV1Record) bool) ([]byte, error) {
-	state := &templateV1BuildState{records: make(map[string]templateV1Record)}
+	var state templateV1BuildState
 	root, err := state.encodeObject(obj)
 	if err != nil {
 		return nil, err
 	}
-	records := make([]templateV1Record, 0, len(state.records))
-	for _, record := range state.records {
-		if includeRecord == nil || includeRecord(record) {
-			records = append(records, record)
+	return encodeTemplateV1RootWithRecords(root, &state, includeRecord)
+}
+
+func encodeTemplateV1FieldsWithRecordFilter(fields []string, values []any, includeRecord func(templateV1Record) bool) ([]byte, error) {
+	if len(fields) != len(values) {
+		return nil, errors.New("collections: template-v1 field/value length mismatch")
+	}
+	var state templateV1BuildState
+	root, err := state.encodeFields(fields, values)
+	if err != nil {
+		return nil, err
+	}
+	return encodeTemplateV1RootWithRecords(root, &state, includeRecord)
+}
+
+func encodeTemplateV1RootWithRecords(root []byte, state *templateV1BuildState, includeRecord func(templateV1Record) bool) ([]byte, error) {
+	if state == nil || !state.hasRecord {
+		return root, nil
+	}
+	if len(state.records) == 0 {
+		record := state.firstRecord
+		if includeRecord != nil && !includeRecord(record) {
+			return root, nil
 		}
+		return encodeTemplateV1RootWithSingleRecord(root, record), nil
+	}
+
+	var stackRecords [4]templateV1Record
+	records := stackRecords[:0]
+	records = append(records, state.firstRecord)
+	records = append(records, state.records...)
+	if includeRecord != nil {
+		selected := records[:0]
+		for _, record := range records {
+			if includeRecord(record) {
+				selected = append(selected, record)
+			}
+		}
+		records = selected
 	}
 	sortTemplateV1Records(records)
 	if len(records) == 0 {
 		return root, nil
 	}
+	return encodeTemplateV1RootWithRecordSlice(root, records), nil
+}
 
+func encodeTemplateV1RootWithSingleRecord(root []byte, record templateV1Record) []byte {
+	out := make([]byte, 0, len(templateV1InputMagic)+binary.MaxVarintLen64+32+binary.MaxVarintLen64+len(record.raw)+len(root))
+	out = append(out, templateV1InputMagic...)
+	out = binary.AppendUvarint(out, 1)
+	out = append(out, record.id[:]...)
+	out = binary.AppendUvarint(out, uint64(len(record.raw)))
+	out = append(out, record.raw...)
+	out = append(out, root...)
+	return out
+}
+
+func encodeTemplateV1RootWithRecordSlice(root []byte, records []templateV1Record) []byte {
 	out := make([]byte, 0, len(templateV1InputMagic)+len(root)+len(records)*48)
 	out = append(out, templateV1InputMagic...)
 	out = binary.AppendUvarint(out, uint64(len(records)))
@@ -450,11 +482,81 @@ func encodeTemplateV1ObjectMapWithRecordFilter(obj map[string]any, includeRecord
 		out = append(out, record.raw...)
 	}
 	out = append(out, root...)
-	return out, nil
+	return out
 }
 
 type templateV1BuildState struct {
-	records map[string]templateV1Record
+	firstRecord templateV1Record
+	hasRecord   bool
+	records     []templateV1Record
+}
+
+func (s *templateV1BuildState) addRecord(record templateV1Record) {
+	if !s.hasRecord {
+		s.firstRecord = record
+		s.hasRecord = true
+		return
+	}
+	if s.firstRecord.id == record.id {
+		return
+	}
+	for _, existing := range s.records {
+		if existing.id == record.id {
+			return
+		}
+	}
+	s.records = append(s.records, record)
+}
+
+func (s *templateV1BuildState) encodeFields(fields []string, values []any) ([]byte, error) {
+	var stackOrder [16]int
+	order := stackOrder[:0]
+	if len(fields) <= len(stackOrder) {
+		order = stackOrder[:len(fields)]
+	} else {
+		order = make([]int, len(fields))
+	}
+	for i := range order {
+		order[i] = i
+	}
+	sort.Slice(order, func(i, j int) bool {
+		return fields[order[i]] < fields[order[j]]
+	})
+
+	var stackFields [16]string
+	sortedFields := stackFields[:0]
+	if len(fields) <= len(stackFields) {
+		sortedFields = stackFields[:len(fields)]
+	} else {
+		sortedFields = make([]string, len(fields))
+	}
+	for sortedPos, sourcePos := range order {
+		field := fields[sourcePos]
+		if err := validateTemplateV1FieldName(field); err != nil {
+			return nil, err
+		}
+		if sortedPos > 0 && sortedFields[sortedPos-1] == field {
+			return nil, fmt.Errorf("collections: duplicate template-v1 field %q", field)
+		}
+		sortedFields[sortedPos] = field
+	}
+
+	record, err := buildTemplateV1Record(sortedFields)
+	if err != nil {
+		return nil, err
+	}
+	s.addRecord(record)
+	out := make([]byte, 0, len(templateV1StoredMagic)+32+len(fields)*8)
+	out = append(out, templateV1StoredMagic...)
+	out = append(out, record.id[:]...)
+	for _, sourcePos := range order {
+		field := fields[sourcePos]
+		out, err = s.appendValue(out, values[sourcePos])
+		if err != nil {
+			return nil, fmt.Errorf("collections: template-v1 field %q: %w", field, err)
+		}
+	}
+	return out, nil
 }
 
 func (s *templateV1BuildState) encodeObject(obj map[string]any) ([]byte, error) {
@@ -470,7 +572,7 @@ func (s *templateV1BuildState) encodeObject(obj map[string]any) ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
-	s.records[string(record.id[:])] = record
+	s.addRecord(record)
 	out := make([]byte, 0, len(templateV1StoredMagic)+32+len(fields)*8)
 	out = append(out, templateV1StoredMagic...)
 	out = append(out, record.id[:]...)
@@ -496,7 +598,7 @@ func (s *templateV1BuildState) appendObjectValue(dst []byte, obj map[string]any)
 	if err != nil {
 		return nil, err
 	}
-	s.records[string(record.id[:])] = record
+	s.addRecord(record)
 	dst = append(dst, templateV1KindObject)
 	dst = append(dst, record.id[:]...)
 	for _, field := range fields {
@@ -579,11 +681,9 @@ func buildTemplateV1Record(fields []string) (templateV1Record, error) {
 		raw = append(raw, field...)
 	}
 	id := sha256.Sum256(raw)
-	copiedFields := append([]string(nil), fields...)
 	return templateV1Record{
 		id:  id,
 		raw: raw,
-		tpl: &templateV1Template{id: id, fields: copiedFields},
 	}, nil
 }
 

--- a/TreeDB/collections/template_v1_test.go
+++ b/TreeDB/collections/template_v1_test.go
@@ -16,6 +16,15 @@ func mustTemplateV1Document(t *testing.T, fields []string, values []any) []byte 
 	return doc
 }
 
+func TestEncodeTemplateV1DocumentRejectsInvalidFieldSlices(t *testing.T) {
+	if _, err := EncodeTemplateV1Document([]string{"email", "email"}, []any{"ada@example.com", "grace@example.com"}); err == nil {
+		t.Fatal("expected duplicate field error")
+	}
+	if _, err := EncodeTemplateV1Document([]string{"email"}, []any{}); err == nil {
+		t.Fatal("expected field/value length mismatch error")
+	}
+}
+
 func TestTemplateV1CollectionInsertBatchIndexesAndTemplateRoot(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -363,6 +372,37 @@ func TestPrepareTemplateV1InsertDocumentsSkipsFallbackTemplateRecord(t *testing.
 	}
 }
 
+type countingMissingTemplateV1Resolver struct {
+	lookups int
+}
+
+func (r *countingMissingTemplateV1Resolver) lookupTemplateV1([32]byte) (*templateV1Template, error) {
+	r.lookups++
+	return nil, errTemplateV1TemplateNotFound
+}
+
+func TestPrepareTemplateV1InsertDocumentsDedupesBatchTemplateRecords(t *testing.T) {
+	doc1, err := EncodeTemplateV1Document([]string{"email", "city"}, []any{"ada@example.com", "hnl"})
+	if err != nil {
+		t.Fatalf("encode doc1: %v", err)
+	}
+	doc2, err := EncodeTemplateV1Document([]string{"email", "city"}, []any{"grace@example.com", "sea"})
+	if err != nil {
+		t.Fatalf("encode doc2: %v", err)
+	}
+	fallback := &countingMissingTemplateV1Resolver{}
+	_, records, _, err := prepareTemplateV1InsertDocuments([][]byte{doc1, doc2}, fallback)
+	if err != nil {
+		t.Fatalf("prepare duplicate template records: %v", err)
+	}
+	if got, want := len(records), 1; got != want {
+		t.Fatalf("publish records=%d want %d", got, want)
+	}
+	if got, want := fallback.lookups, 1; got != want {
+		t.Fatalf("fallback lookups=%d want %d", got, want)
+	}
+}
+
 func TestTemplateV1CompactDocumentRequiresKnownTemplate(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -558,7 +598,7 @@ func TestTemplateV1NestedIndexExtraction(t *testing.T) {
 	}
 	resolver := &templateV1MemoryResolver{}
 	for _, record := range records {
-		if err := resolver.addRecord(record); err != nil {
+		if _, err := resolver.addRecord(record); err != nil {
 			t.Fatalf("add template record: %v", err)
 		}
 	}
@@ -593,7 +633,7 @@ func TestTemplateV1RootIndexExtraction(t *testing.T) {
 	}
 	resolver := &templateV1MemoryResolver{}
 	for _, record := range records {
-		if err := resolver.addRecord(record); err != nil {
+		if _, err := resolver.addRecord(record); err != nil {
 			t.Fatalf("add template record: %v", err)
 		}
 	}

--- a/docs/benchmarks/collections_template_v1_stack_pr1074_2026-04-27.md
+++ b/docs/benchmarks/collections_template_v1_stack_pr1074_2026-04-27.md
@@ -1,0 +1,234 @@
+# Collections Template-v1 Stack Benchmark Report
+
+Run date: 2026-04-27 HST / 2026-04-28 UTC
+
+This run was captured on branch `opt/template-v1-collection-optimizations` at
+commit `4f3a9fcf22`. The PR stack already includes PR 1072 through merge commit
+`169acfd3b68fa887bb70542435d282d2d4563bf6`; that merge is an ancestor of the
+current PR 1074 head.
+
+## Executive Summary
+
+TreeDB collections are ahead of SQLite on the indexed document workloads in this
+run. The two-index template-v1 insert path is `943.70 ns/doc`
+(`1,059,659 docs/sec`), compared with SQLite JSON at `2,567.00 ns/doc`
+(`389,560 docs/sec`) and SQLite native columns at `2,361.67 ns/doc`
+(`423,430 docs/sec`). With checkpointing, template-v1 is `1,552.00 ns/doc`
+(`644,330 docs/sec`) versus SQLite JSON at `3,062.33 ns/doc`
+(`326,548 docs/sec`) and SQLite native columns at `2,654.00 ns/doc`
+(`376,790 docs/sec`).
+
+Template-v1 is doing the job it was meant to do: it cuts indexed extraction and
+read materialization overhead versus JSON. Two-index primary reads improve from
+`1,706.33 ns/op` (`586,052 ops/sec`, `8,482 B/op`, `4 allocs/op`) for JSON to
+`1,286.67 ns/op` (`777,202 ops/sec`, `4,816.7 B/op`, `3 allocs/op`) for
+template-v1. The isolated index-state extraction probe improves from
+`274.07 ns/op` (`3,648,747 ops/sec`) for JSON to `111.80 ns/op`
+(`8,944,544 ops/sec`) for template-v1.
+
+The biggest remaining indexed-write cost is no longer document parsing. For the
+two-index template-v1 insert path, publish/root merge is `568.93 ns/doc`
+(`1,757,675 docs/sec`), secondary run construction is `158.90 ns/doc`
+(`6,293,266 docs/sec`), index-state extraction is `81.22 ns/doc`
+(`12,312,238 docs/sec`), and prepare is `38.14 ns/doc`
+(`26,216,901 docs/sec`). With checkpointing, publish rises to `684.37 ns/doc`
+(`1,461,205 docs/sec`) and sync adds `494.73 ns/doc`
+(`2,021,291 docs/sec`). The next material gains are therefore in publish/index
+write amplification, secondary run construction, and the read buffer path.
+
+Disk usage is competitive. At two indexes, TreeDB template-v1 reports
+`155.93 B/doc`, TreeDB JSON reports `153.70 B/doc`, SQLite JSON reports
+`262.23 B/doc`, and SQLite native columns report `175.73 B/doc`. The TreeDB
+index delta dominates total storage: the template-v1 zero-index row is only
+`27.64 B/doc`, while the derived two-index component is `128.29 B/doc`.
+
+The raw TreeDB engine is not the current ceiling for collections. The unified
+bench anchors report raw TreeDB `batch_write` at `66.72 ns/op`
+(`14,988,385 ops/sec`) for `fast` and `151.93 ns/op`
+(`6,582,069 ops/sec`) for `wal_on_fast`, well above the collection two-index
+template-v1 insert rate. The indexed collection path is spending its budget in
+collection/index coordination and backend publish work, not raw B-tree ingest.
+
+## Run Context
+
+Command:
+
+```sh
+scripts/bench_collections_harness.sh \
+  --out /tmp/gomap_collections_1074_20260427_194034 \
+  --count 3 \
+  --benchtime 1s \
+  --batch-size 8000 \
+  --include-sqlite \
+  --include-unified \
+  --unified-keys 100000
+```
+
+Harness artifacts generated:
+
+- Matrix summary: `/tmp/gomap_collections_1074_20260427_194034/collections_matrix_summary.md`
+- Matrix HTML: `/tmp/gomap_collections_1074_20260427_194034/collections_matrix_summary.html`
+- Disk TSV: `/tmp/gomap_collections_1074_20260427_194034/collections_disk_usage_summary.tsv`
+- TreeDB JSON report and pprof: `/tmp/gomap_collections_1074_20260427_194034/collections_json_shapes/`
+- TreeDB template-v1 report and pprof: `/tmp/gomap_collections_1074_20260427_194034/collections_template_v1_shapes/`
+- SQLite report and pprof: `/tmp/gomap_collections_1074_20260427_194034/sqlite_wal_normal_shapes/`
+- Unified `fast` profile-dir: `/tmp/gomap_collections_1074_20260427_194034/unified_fast/`
+- Unified `wal_on_fast` profile-dir: `/tmp/gomap_collections_1074_20260427_194034/unified_wal_on_fast/`
+
+The generated reports include adjacent throughput columns for latency columns,
+and the unified profile dirs include CPU, allocation, block, mutex, checkpoint
+CPU, and trace artifacts.
+
+## Headline Throughput
+
+| Workload | ns/op or ns/doc | Ops/sec or docs/sec | B/op | allocs/op | Disk B/doc |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| TreeDB JSON insert, 2 indexes | 1,039.67 | 961,847 | 811.7 | 0 | 153.70 |
+| TreeDB template-v1 insert, 2 indexes | 943.70 | 1,059,659 | 1,061.7 | 0 | 155.93 |
+| SQLite JSON insert, 2 indexes | 2,567.00 | 389,560 | 192 | 7 | 262.23 |
+| SQLite native insert, 2 indexes | 2,361.67 | 423,430 | 368 | 10 | 175.73 |
+| TreeDB JSON checkpoint insert, 2 indexes | 1,644.33 | 608,149 | 854 | 0 | 154.00 |
+| TreeDB template-v1 checkpoint insert, 2 indexes | 1,552.00 | 644,330 | 1,023.7 | 0 | 153.73 |
+| SQLite JSON checkpoint insert, 2 indexes | 3,062.33 | 326,548 | 192 | 7 | 262.33 |
+| SQLite native checkpoint insert, 2 indexes | 2,654.00 | 376,790 | 368 | 10 | 175.73 |
+| TreeDB JSON primary read, 2 indexes | 1,706.33 | 586,052 | 8,482 | 4 | - |
+| TreeDB template-v1 primary read, 2 indexes | 1,286.67 | 777,202 | 4,816.7 | 3 | - |
+| SQLite JSON primary read, 2 indexes | 2,110.67 | 473,784 | 632 | 18 | - |
+| SQLite native primary read, 2 indexes | 2,782.33 | 359,411 | 856 | 33 | - |
+| TreeDB JSON unique secondary lookup | 1,172.00 | 853,242 | 407 | 10 | - |
+| TreeDB template-v1 unique secondary lookup | 1,160.00 | 862,069 | 642.7 | 10 | - |
+| SQLite JSON unique secondary lookup | 2,285.00 | 437,637 | 576 | 20 | - |
+| SQLite native unique secondary lookup | 2,066.33 | 483,949 | 576 | 20 | - |
+| TreeDB JSON nonunique secondary lookup | 3,816.33 | 262,032 | 5,522 | 79 | - |
+| TreeDB template-v1 nonunique secondary lookup | 3,771.00 | 265,182 | 5,463.3 | 79 | - |
+| SQLite JSON nonunique secondary lookup | 25,328.67 | 39,481 | 3,552 | 208 | - |
+| SQLite native nonunique secondary lookup | 14,672.67 | 68,154 | 3,552 | 208 | - |
+
+## Disk Usage Matrix
+
+Disk rows are generated from the harness matrix summary. Collection/index splits
+use the zero-index delta where the engine does not expose an exact object split.
+
+| Engine/format | Indexes/doc | Total B/doc | Collection B/doc | Index B/doc |
+| --- | ---: | ---: | ---: | ---: |
+| TreeDB JSON | 0 | 28.95 | 28.95 | 0.00 |
+| TreeDB JSON | 1 | 78.87 | 28.95 | 49.92 |
+| TreeDB JSON | 2 | 153.70 | 28.95 | 124.75 |
+| TreeDB JSON | 3 | 183.80 | 28.95 | 154.85 |
+| TreeDB template-v1 | 0 | 27.64 | 27.64 | 0.00 |
+| TreeDB template-v1 | 1 | 77.98 | 27.64 | 50.34 |
+| TreeDB template-v1 | 2 | 155.93 | 27.64 | 128.29 |
+| TreeDB template-v1 | 3 | 182.90 | 27.64 | 155.26 |
+| SQLite JSON | 0 | 146.30 | 146.30 | 0.00 |
+| SQLite JSON | 1 | 227.30 | 146.30 | 81.00 |
+| SQLite JSON | 2 | 262.23 | 146.30 | 115.93 |
+| SQLite JSON | 3 | 306.90 | 146.30 | 160.60 |
+| SQLite native | 0 | 100.00 | 100.00 | 0.00 |
+| SQLite native | 1 | 148.90 | 100.00 | 48.90 |
+| SQLite native | 2 | 175.73 | 100.00 | 75.73 |
+| SQLite native | 3 | 211.40 | 100.00 | 111.40 |
+
+The single-string JSON collection shape remains a useful lower-bound sanity
+check: no-index bulk insert is `143.53 ns/doc` (`6,967,023 docs/sec`) and
+`13.62 B/doc`; one indexed string value is `475.97 ns/doc`
+(`2,100,987 docs/sec`) and `50.53 B/doc`.
+
+## Template-v1 Phase Breakdown
+
+| Phase | 2-index bulk ns/doc | 2-index bulk docs/sec | 2-index checkpoint ns/doc | 2-index checkpoint docs/sec |
+| --- | ---: | ---: | ---: | ---: |
+| Total operation | 943.70 | 1,059,659 | 1,552.00 | 644,330 |
+| Insert phase | - | - | 1,057.00 | 946,074 |
+| Sync phase | - | - | 494.73 | 2,021,291 |
+| Prepare documents | 38.14 | 26,216,901 | 38.10 | 26,249,016 |
+| Index-state extraction | 81.22 | 12,312,238 | 82.78 | 12,079,726 |
+| Duplicate preflight | 7.94 | 125,928,724 | 7.80 | 128,166,788 |
+| Unique preflight | 22.67 | 44,111,160 | 22.79 | 43,878,894 |
+| Primary run build | 8.79 | 113,787,218 | 8.95 | 111,777,637 |
+| Index-state run build | 39.26 | 25,469,055 | 39.34 | 25,419,420 |
+| Secondary runs build | 158.90 | 6,293,266 | 156.47 | 6,391,138 |
+| Publish root group | 568.93 | 1,757,675 | 684.37 | 1,461,205 |
+
+The two-index template-v1 shape built one sorted secondary run and one unsorted
+secondary run per batch, with `63 secondary_key_bytes/doc`. The three-index
+shape built two sorted runs and one unsorted run per batch, with
+`92 secondary_key_bytes/doc`.
+
+## Planning Diagnostics
+
+| Cell | Benchmark | ns/op | Ops/sec | B/op | allocs/op |
+| --- | --- | ---: | ---: | ---: | ---: |
+| TreeDB JSON cell | JSON index-state extraction | 271.20 | 3,687,316 | 144 | 3 |
+| TreeDB JSON cell | Template-v1 index-state extraction | 120.30 | 8,312,552 | 144 | 3 |
+| TreeDB JSON cell | Indexed JSON planner | 486.30 | 2,056,344 | 486.7 | 0 |
+| TreeDB JSON cell | Indexed template-v1 planner | 355.63 | 2,811,885 | 513.3 | 0 |
+| TreeDB JSON cell | Precomputed-state planner | 253.97 | 3,937,525 | 343.3 | 0 |
+| TreeDB JSON cell | No-index planner | 32.52 | 30,750,308 | 117.3 | 0 |
+| TreeDB template-v1 cell | JSON index-state extraction | 274.07 | 3,648,747 | 144 | 3 |
+| TreeDB template-v1 cell | Template-v1 index-state extraction | 111.80 | 8,944,544 | 144 | 3 |
+| TreeDB template-v1 cell | Indexed JSON planner | 479.83 | 2,084,057 | 484.7 | 0 |
+| TreeDB template-v1 cell | Indexed template-v1 planner | 354.70 | 2,819,284 | 512.3 | 0 |
+| TreeDB template-v1 cell | Precomputed-state planner | 252.63 | 3,958,306 | 342.3 | 0 |
+| TreeDB template-v1 cell | No-index planner | 32.39 | 30,873,726 | 115.3 | 0 |
+
+## Unified TreeDB Raw Engine Anchors
+
+Unified bench used `keys=100000`, `valsize=128`, `batchsize=8000`,
+`key_shape=be8`, `val_pattern=zero`, and TreeDB only.
+
+| Profile | Test | ns/op | Ops/sec |
+| --- | --- | ---: | ---: |
+| fast | Sequential write | 296.56 | 3,372,051 |
+| fast | Random write | 231.02 | 4,328,637 |
+| fast | Batch write | 66.72 | 14,988,385 |
+| fast | Batch random | 155.74 | 6,420,752 |
+| fast | Random read | 2,917.37 | 342,774 |
+| fast | Random read parallel snapshot/key | 1,293.98 | 772,812 |
+| fast | Full scan | 188.58 | 5,302,717 |
+| fast | Prefix scan | 368.86 | 2,711,037 |
+| wal_on_fast | Sequential write | 414.05 | 2,415,148 |
+| wal_on_fast | Random write | 436.74 | 2,289,703 |
+| wal_on_fast | Batch write | 151.93 | 6,582,069 |
+| wal_on_fast | Batch random | 232.16 | 4,307,305 |
+| wal_on_fast | Random read | 3,057.58 | 327,056 |
+| wal_on_fast | Random read parallel snapshot/key | 1,327.16 | 753,489 |
+| wal_on_fast | Full scan | 191.20 | 5,230,229 |
+| wal_on_fast | Prefix scan | 217.22 | 4,603,610 |
+
+## Profile Observations
+
+The whole-cell CPU profiles include benchmark setup and multiple benchmark
+shapes, so they are directional rather than a focused steady-state profile.
+Still, they match the phase counters:
+
+- Template-v1 CPU top includes `readViaMmapView`, `Tree.loadNodeViewWithLoadKind`,
+  `Builder.AddInternalChild`, `templateV1BuildState.encodeFields`,
+  `Collection.catalogForSnapshot`, and `Collection.FindByIndex`.
+- Template-v1 alloc top is dominated by `readViaMmapView` with `132,884 MB`
+  flat (`39.41%`) and `Collection.Get` with `151,700 MB` cumulative. This
+  reinforces the `GetInto` or owned-buffer read fast-path target.
+- Insert allocation still includes collection planner work:
+  `planInsertBatchWithPreflight` is `49,966 MB` cumulative, `encodeFields` is
+  `26,213 MB` cumulative, and `emitSecondaryRuns` is `6,908 MB` cumulative.
+- Compression/dictionary setup appears in the whole-cell allocation profile
+  (`BuildDict`, `ensureHist`, and trainer paths), so future lower-noise runs
+  should separate warm-up from steady-state.
+
+## Next Optimization Targets
+
+1. Add focused 10s+ phase profiles for `BenchmarkCollectionShapeInsertBatch/indexes_2`,
+   `BenchmarkCollectionShapeInsertBatchCheckpoint/indexes_2`,
+   `BenchmarkCollectionShapeReadPrimary/indexes_2`, and
+   `BenchmarkCollectionMixedReadWritePrimary`.
+2. Attack read allocation first. The current primary read path is still
+   `4,816.7 B/op` and `3 allocs/op` for template-v1, and whole-cell allocs
+   point at `readViaMmapView` and `Collection.Get`.
+3. Reduce index-state/write amplification. The two-index template-v1 disk delta
+   is `128.29 index B/doc` versus `27.64 collection B/doc`, and publish is the
+   largest phase timer.
+4. Optimize secondary run construction for the common sorted-index case. The
+   phase counter is `158.90 ns/doc` (`6,293,266 docs/sec`) for two-index bulk
+   inserts and the harness now reports sorted versus unsorted run counts.
+5. Separate compression/dictionary warm-up from steady-state results with
+   pre-warmed DBs, compression/dictionary toggles, and longer steady-state
+   windows, then include vlog rewrite/vacuum scenarios in the same harness.


### PR DESCRIPTION
Follow-on stacked on #1073 (`bench/collections-insert-phases`).

## Summary
- Avoid the template-v1 prepare arena copy and borrow compact stored document bytes through synchronous publish, matching the JSON document path.
- Deduplicate in-batch template records before fallback preflight so repeated shapes perform one fallback lookup and publish one record.
- Encode field-slice template-v1 documents directly instead of building a map first, with a single-record fast path for flat documents.
- Add encoder microbenchmarks and targeted tests for invalid field slices and in-batch template dedupe.

## Validation
- `GOWORK=off go test -count=1 ./TreeDB/collections`
- `git diff --check`
- `GOWORK=off go test -run '^$' -bench 'BenchmarkTemplateV1(EncodeDocument|EncoderEncodeDocumentRepeatedShape)$' -benchmem -count=5 ./TreeDB/collections`
- `GOWORK=off go test -run '^$' -bench 'BenchmarkCollectionOverhead(PlanIndexedTemplateV1|IndexStateTemplateV1Extraction)$' -benchmem -count=8 ./TreeDB/collections`
- `TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 TREEDB_COLLECTION_BENCH_BATCH_SIZE=8000 GOWORK=off go test -run '^$' -bench '^BenchmarkCollectionShapeInsertBatch$/^indexes_2$' -benchmem -count=5 ./TreeDB/collections`

## Local Benchmarks
Apple M3, lower is better.

- `BenchmarkTemplateV1EncodeDocument`: 372-383 ns/op, 648 B/op, 7 allocs/op.
- `BenchmarkTemplateV1EncoderEncodeDocumentRepeatedShape`: 359-394 ns/op, 488 B/op, 7 allocs/op.
- `BenchmarkCollectionOverheadPlanIndexedTemplateV1`: 353-365 ns/op, 511-518 B/op, 0 allocs/op.
- `BenchmarkCollectionOverheadIndexStateTemplateV1Extraction`: 111-116 ns/op, 144 B/op, 3 allocs/op.
- Template-v1 `BenchmarkCollectionShapeInsertBatch/indexes_2`, batch 8000: 927-957 ns/op, prepare 36.9-38.2 ns/doc, 1022-1144 B/op, 0 allocs/op.

Against the earlier local #1073 spot checks, the main intended movement is lower prepare cost and lower template-v1 indexed planning bytes: planning was around 622-627 B/op before this branch and is around 511-518 B/op here; the focused insert-shape prepare phase moved from roughly mid-40s ns/doc to high-30s ns/doc.
