### PR TITLE
tools: add kept collection load fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ HASHDB_DIR := HashDB
 TREEDB_DIR := TreeDB
 UNIFIED_BENCH_DIR := cmd/unified_bench
 BENCHPROF_DIR := cmd/benchprof
+COLLECTION_LOAD_FIXTURE_DIR := cmd/collection_load_fixture
 BIN_DIR := bin
 
 BENCH_KEYCOUNTS ?= 1,10,100,1000,10000,100000,1000000
@@ -27,6 +28,7 @@ help:
 	@echo "  make benchmark-all  - run HashDB redis-benchmark suite (legacy)"
 	@echo "  make unified-bench  - build unified bench binary"
 	@echo "  make benchprof      - build profile analyzer binary"
+	@echo "  make collection-load-fixture - build kept TreeDB collection load fixture"
 	@echo "  make clean          - remove ./$(BIN_DIR) and temp dirs"
 
 .PHONY: fmt
@@ -84,8 +86,8 @@ deps:
 docs-check:
 	bash ./scripts/docs_check.sh
 
-.PHONY: build build-hashdb build-treedb treemap treemap-bin unified-bench benchprof
-build: build-hashdb build-treedb unified-bench benchprof
+.PHONY: build build-hashdb build-treedb treemap treemap-bin unified-bench benchprof collection-load-fixture
+build: build-hashdb build-treedb unified-bench benchprof collection-load-fixture
 
 build-hashdb:
 	mkdir -p $(BIN_DIR)
@@ -115,6 +117,10 @@ unified-bench:
 benchprof:
 	mkdir -p $(BIN_DIR)
 	cd $(BENCHPROF_DIR) && go build -o ../../$(BIN_DIR)/benchprof .
+
+collection-load-fixture:
+	mkdir -p $(BIN_DIR)
+	cd $(COLLECTION_LOAD_FIXTURE_DIR) && go build -o ../../$(BIN_DIR)/collection-load-fixture .
 
 .PHONY: bench bench-readme
 bench: unified-bench

--- a/cmd/collection_load_fixture/README.md
+++ b/cmd/collection_load_fixture/README.md
@@ -1,0 +1,53 @@
+# collection-load-fixture
+
+`collection-load-fixture` creates and keeps an inspectable TreeDB collection
+database using the same indexed document shape as
+`BenchmarkCollectionShapeInsertBatch`.
+
+Build:
+
+```sh
+make collection-load-fixture
+```
+
+Default load shape:
+
+- `template-v1` documents
+- two secondary indexes: unique `email_idx` and non-unique `city_idx`
+- collection data/index-state outer leaves in the value log
+- secondary-index outer leaves in the value log
+- `fast` TreeDB profile
+- final checkpoint and reopen verification
+
+Example:
+
+```sh
+./bin/collection-load-fixture \
+  -dir /tmp/treedb_two_index_template_v1_index_vlog \
+  -reset \
+  -docs 1000000 \
+  -batch-size 8000
+```
+
+If `-dir` is omitted, the tool creates a kept OS temp directory and prints the
+path. It never deletes the loaded database unless `-reset` is explicitly passed
+for a named `-dir`.
+
+Useful variants:
+
+```sh
+# JSON documents with the same two-index shape.
+./bin/collection-load-fixture -format json -dir /tmp/treedb_two_index_json_index_vlog -reset
+
+# Disable secondary-index value-log outer leaves.
+./bin/collection-load-fixture -index-outer-leaves-in-vlog=false -dir /tmp/treedb_two_index_template_v1_fast_index -reset
+
+# Generate machine-readable output and optional profiles.
+./bin/collection-load-fixture \
+  -json \
+  -cpuprofile /tmp/collection_fixture_cpu.pprof \
+  -memprofile /tmp/collection_fixture_heap.pprof
+
+# Compact the value log after loading, then report before/after disk usage.
+./bin/collection-load-fixture -vlog-rewrite -dir /tmp/treedb_fixture_rewritten -reset
+```

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -796,11 +797,12 @@ func verifyReopen(cfg config) (int, error) {
 		if len(got) == 0 {
 			return 0, fmt.Errorf("reopen verify get %s returned an empty document", id)
 		}
-		if cfg.DocumentFormat == collections.DocumentFormatJSON {
-			want := indexedJSONDocument(n)
-			if !bytes.Equal(got, want) {
-				return 0, fmt.Errorf("reopen verify get %s returned unexpected JSON document", id)
-			}
+		want, err := expectedStoredDocument(cfg.DocumentFormat, n)
+		if err != nil {
+			return 0, fmt.Errorf("reopen verify expected document %s: %w", id, err)
+		}
+		if !bytes.Equal(got, want) {
+			return 0, fmt.Errorf("reopen verify get %s returned unexpected document content", id)
 		}
 		if cfg.IndexCount >= 1 {
 			email := fmt.Sprintf("user-%09d@example.com", n)
@@ -822,8 +824,67 @@ func verifyReopen(cfg config) (int, error) {
 				return 0, fmt.Errorf("reopen verify city index %s did not include %s", city, id)
 			}
 		}
+		if cfg.IndexCount >= 3 {
+			name := fmt.Sprintf("user-%09d", n)
+			ids, err := collection.FindByIndex("name_idx", name)
+			if err != nil {
+				return 0, fmt.Errorf("reopen verify name index %s: %w", name, err)
+			}
+			if !containsDocumentID(ids, id) {
+				return 0, fmt.Errorf("reopen verify name index %s did not include %s", name, id)
+			}
+		}
 	}
 	return len(samples), nil
+}
+
+func expectedStoredDocument(format collections.DocumentFormat, n int) ([]byte, error) {
+	if format == collections.DocumentFormatJSON {
+		return indexedJSONDocument(n), nil
+	}
+	doc, err := document(format, &collections.TemplateV1Encoder{}, n)
+	if err != nil {
+		return nil, err
+	}
+	return templateV1StoredDocument(doc)
+}
+
+func templateV1StoredDocument(raw []byte) ([]byte, error) {
+	const (
+		inputMagic  = "TD1I"
+		storedMagic = "TD1D"
+	)
+	if bytes.HasPrefix(raw, []byte(storedMagic)) {
+		return raw, nil
+	}
+	if !bytes.HasPrefix(raw, []byte(inputMagic)) {
+		return nil, errors.New("template-v1 document is missing input envelope")
+	}
+	pos := len(inputMagic)
+	templateCount, n := binary.Uvarint(raw[pos:])
+	if n <= 0 {
+		return nil, errors.New("template-v1 document has malformed template count")
+	}
+	pos += n
+	for i := uint64(0); i < templateCount; i++ {
+		if len(raw)-pos < 32 {
+			return nil, errors.New("template-v1 document has malformed template id")
+		}
+		pos += 32
+		recordLen, n := binary.Uvarint(raw[pos:])
+		if n <= 0 {
+			return nil, errors.New("template-v1 document has malformed template length")
+		}
+		pos += n
+		if recordLen > uint64(len(raw)-pos) {
+			return nil, errors.New("template-v1 document has truncated template record")
+		}
+		pos += int(recordLen)
+	}
+	if !bytes.HasPrefix(raw[pos:], []byte(storedMagic)) {
+		return nil, errors.New("template-v1 document is missing stored payload")
+	}
+	return raw[pos:], nil
 }
 
 func containsDocumentID(ids [][]byte, want []byte) bool {

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -1,0 +1,1012 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	defaultDocs              = 1_000_000
+	defaultBatchSize         = 8_000
+	defaultCollectionName    = "bench_shape_insert_2"
+	collectionFixtureCities  = 64
+	collectionFixturePad     = "01234567890123456789"
+	maxFixtureTopFileEntries = 20
+)
+
+type config struct {
+	Dir                        string
+	Reset                      bool
+	Docs                       int
+	BatchSize                  int
+	Collection                 string
+	DocumentFormat             collections.DocumentFormat
+	IndexCount                 int
+	Profile                    treedb.Profile
+	DataOuterLeavesInValueLog  bool
+	IndexOuterLeavesInValueLog bool
+	ChunkSize                  int64
+	PagerSyncConcurrency       int
+	Checkpoint                 bool
+	CheckpointEachBatch        bool
+	ReopenVerify               bool
+	VerifySamples              int
+	ValueLogRewrite            bool
+	ValueLogGC                 bool
+	Progress                   bool
+	JSONOutput                 bool
+	CPUProfile                 string
+	MemProfile                 string
+	createdTempDir             bool
+}
+
+type timingSummary struct {
+	Seconds   float64 `json:"seconds"`
+	SecPerOp  float64 `json:"sec_per_op,omitempty"`
+	OpsPerSec float64 `json:"ops_per_sec,omitempty"`
+}
+
+type diskUsageSummary struct {
+	TotalBytes  uint64        `json:"total_bytes"`
+	BytesPerDoc float64       `json:"bytes_per_doc,omitempty"`
+	FileCount   int           `json:"file_count"`
+	TopFiles    []fileSummary `json:"top_files,omitempty"`
+}
+
+type fileSummary struct {
+	Path  string `json:"path"`
+	Bytes uint64 `json:"bytes"`
+}
+
+type insertPhaseSummary struct {
+	Documents                     int                   `json:"documents"`
+	Indexes                       int                   `json:"indexes"`
+	Runs                          int                   `json:"runs"`
+	PrepareDocumentsNSPerDoc      float64               `json:"prepare_documents_ns_per_doc,omitempty"`
+	IndexStateExtractionNSPerDoc  float64               `json:"index_state_extraction_ns_per_doc,omitempty"`
+	DuplicatePreflightNSPerDoc    float64               `json:"duplicate_preflight_ns_per_doc,omitempty"`
+	UniquePreflightNSPerDoc       float64               `json:"unique_preflight_ns_per_doc,omitempty"`
+	TemplateRunBuildNSPerDoc      float64               `json:"template_run_build_ns_per_doc,omitempty"`
+	PrimaryRunBuildNSPerDoc       float64               `json:"primary_run_build_ns_per_doc,omitempty"`
+	IndexStateRunBuildNSPerDoc    float64               `json:"index_state_run_build_ns_per_doc,omitempty"`
+	SecondaryRunBuildNSPerDoc     float64               `json:"secondary_run_build_ns_per_doc,omitempty"`
+	PublishNSPerDoc               float64               `json:"publish_ns_per_doc,omitempty"`
+	SecondaryEntriesPerDoc        float64               `json:"secondary_entries_per_doc,omitempty"`
+	SecondaryKeyBytesPerDoc       float64               `json:"secondary_key_bytes_per_doc,omitempty"`
+	SecondarySortedRunsPerBatch   float64               `json:"secondary_sorted_runs_per_batch,omitempty"`
+	SecondaryUnsortedRunsPerBatch float64               `json:"secondary_unsorted_runs_per_batch,omitempty"`
+	SecondaryRuns                 []secondaryRunSummary `json:"secondary_runs,omitempty"`
+}
+
+type secondaryRunSummary struct {
+	IndexName      string  `json:"index_name"`
+	Runs           int     `json:"runs"`
+	Entries        int     `json:"entries"`
+	KeyBytes       int     `json:"key_bytes"`
+	SortedRuns     int     `json:"sorted_runs"`
+	UnsortedRuns   int     `json:"unsorted_runs"`
+	BuildNSPerDoc  float64 `json:"build_ns_per_doc,omitempty"`
+	EntriesPerDoc  float64 `json:"entries_per_doc,omitempty"`
+	KeyBytesPerDoc float64 `json:"key_bytes_per_doc,omitempty"`
+}
+
+type rewriteSummary struct {
+	Enabled               bool          `json:"enabled"`
+	RewriteTiming         timingSummary `json:"rewrite_timing,omitempty"`
+	GCTiming              timingSummary `json:"gc_timing,omitempty"`
+	DiskBytesBefore       uint64        `json:"disk_bytes_before,omitempty"`
+	DiskBytesAfterRewrite uint64        `json:"disk_bytes_after_rewrite,omitempty"`
+	DiskBytesAfterGC      uint64        `json:"disk_bytes_after_gc,omitempty"`
+	SegmentsBefore        int           `json:"segments_before,omitempty"`
+	SegmentsAfter         int           `json:"segments_after,omitempty"`
+	RecordsCopied         int           `json:"records_copied,omitempty"`
+	ValueRecordsCopied    int           `json:"value_records_copied,omitempty"`
+	ValueBytesCopied      int64         `json:"value_bytes_copied,omitempty"`
+	TemplateRecordsKept   int           `json:"template_records_kept,omitempty"`
+	GCSegmentsDeleted     int           `json:"gc_segments_deleted,omitempty"`
+	GCBytesDeleted        int64         `json:"gc_bytes_deleted,omitempty"`
+}
+
+type verifySummary struct {
+	Enabled bool `json:"enabled"`
+	Samples int  `json:"samples,omitempty"`
+}
+
+type loadSummary struct {
+	GeneratedAt                string             `json:"generated_at"`
+	Dir                        string             `json:"dir"`
+	CreatedTempDir             bool               `json:"created_temp_dir,omitempty"`
+	Collection                 string             `json:"collection"`
+	DocumentFormat             string             `json:"document_format"`
+	Profile                    string             `json:"profile"`
+	Docs                       int                `json:"docs"`
+	BatchSize                  int                `json:"batch_size"`
+	Batches                    int                `json:"batches"`
+	IndexCount                 int                `json:"index_count"`
+	DataOuterLeavesInValueLog  bool               `json:"data_outer_leaves_in_value_log"`
+	IndexOuterLeavesInValueLog bool               `json:"index_outer_leaves_in_value_log"`
+	ChunkSize                  int64              `json:"chunk_size,omitempty"`
+	PagerSyncConcurrency       int                `json:"pager_sync_concurrency,omitempty"`
+	WallTiming                 timingSummary      `json:"wall_timing"`
+	GenerationTiming           timingSummary      `json:"generation_timing"`
+	InsertTiming               timingSummary      `json:"insert_timing"`
+	CheckpointTiming           timingSummary      `json:"checkpoint_timing,omitempty"`
+	InsertPhases               insertPhaseSummary `json:"insert_phases"`
+	DiskUsageBeforeMaintenance diskUsageSummary   `json:"disk_usage_before_maintenance"`
+	DiskUsageFinal             diskUsageSummary   `json:"disk_usage_final"`
+	Rewrite                    rewriteSummary     `json:"rewrite,omitempty"`
+	Verify                     verifySummary      `json:"verify"`
+	CPUProfile                 string             `json:"cpu_profile,omitempty"`
+	MemProfile                 string             `json:"mem_profile,omitempty"`
+	GoVersion                  string             `json:"go_version"`
+	GOOS                       string             `json:"goos"`
+	GOARCH                     string             `json:"goarch"`
+}
+
+func main() {
+	cfg, err := parseConfig(os.Args[1:], os.Stderr)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		fmt.Fprintf(os.Stderr, "collection-load-fixture: %v\n", err)
+		os.Exit(2)
+	}
+	summary, err := runFixture(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collection-load-fixture: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg.JSONOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(summary); err != nil {
+			fmt.Fprintf(os.Stderr, "collection-load-fixture: write json summary: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	printHumanSummary(os.Stdout, summary)
+}
+
+func parseConfig(args []string, output io.Writer) (config, error) {
+	cfg := config{
+		Docs:                       defaultDocs,
+		BatchSize:                  defaultBatchSize,
+		Collection:                 defaultCollectionName,
+		DocumentFormat:             collections.DocumentFormatTemplateV1,
+		IndexCount:                 2,
+		Profile:                    treedb.ProfileFast,
+		DataOuterLeavesInValueLog:  true,
+		IndexOuterLeavesInValueLog: true,
+		Checkpoint:                 true,
+		ReopenVerify:               true,
+		VerifySamples:              8,
+		ValueLogGC:                 true,
+		Progress:                   true,
+	}
+	var documentFormat string
+	var profile string
+	fs := flag.NewFlagSet("collection-load-fixture", flag.ContinueOnError)
+	if output == nil {
+		output = io.Discard
+	}
+	fs.SetOutput(output)
+	fs.StringVar(&cfg.Dir, "dir", "", "directory to create and keep; empty creates a kept OS temp directory")
+	fs.BoolVar(&cfg.Reset, "reset", false, "remove -dir before loading; ignored when -dir is empty")
+	fs.IntVar(&cfg.Docs, "docs", cfg.Docs, "number of documents to insert")
+	fs.IntVar(&cfg.BatchSize, "batch-size", cfg.BatchSize, "documents per InsertBatch call")
+	fs.StringVar(&cfg.Collection, "collection", cfg.Collection, "collection name")
+	fs.StringVar(&documentFormat, "format", string(cfg.DocumentFormat), "document format: json or template-v1")
+	fs.IntVar(&cfg.IndexCount, "indexes", cfg.IndexCount, "secondary index count for the benchmark shape: 0, 1, 2, or 3")
+	fs.StringVar(&profile, "profile", string(cfg.Profile), "TreeDB profile: fast, wal_on_fast, durable, or bench")
+	fs.BoolVar(&cfg.DataOuterLeavesInValueLog, "data-outer-leaves-in-vlog", cfg.DataOuterLeavesInValueLog, "store collection primary/index-state outer leaves through the value log")
+	fs.BoolVar(&cfg.IndexOuterLeavesInValueLog, "index-outer-leaves-in-vlog", cfg.IndexOuterLeavesInValueLog, "store secondary-index outer leaves through the value log")
+	fs.Int64Var(&cfg.ChunkSize, "chunk-size", 0, "override TreeDB pager chunk size in bytes")
+	fs.IntVar(&cfg.PagerSyncConcurrency, "pager-sync-concurrency", 0, "override TreeDB pager sync concurrency")
+	fs.BoolVar(&cfg.Checkpoint, "checkpoint", cfg.Checkpoint, "checkpoint after loading")
+	fs.BoolVar(&cfg.CheckpointEachBatch, "checkpoint-each-batch", false, "checkpoint after every batch")
+	fs.BoolVar(&cfg.ReopenVerify, "reopen-verify", cfg.ReopenVerify, "close, reopen, and verify sampled primary/index reads")
+	fs.IntVar(&cfg.VerifySamples, "verify-samples", cfg.VerifySamples, "sample count for -reopen-verify")
+	fs.BoolVar(&cfg.ValueLogRewrite, "vlog-rewrite", false, "run TreeDB online value-log rewrite after loading")
+	fs.BoolVar(&cfg.ValueLogGC, "vlog-gc", cfg.ValueLogGC, "run value-log GC after -vlog-rewrite")
+	fs.BoolVar(&cfg.Progress, "progress", cfg.Progress, "print load progress to stderr")
+	fs.BoolVar(&cfg.JSONOutput, "json", false, "print summary as JSON")
+	fs.StringVar(&cfg.CPUProfile, "cpuprofile", "", "write CPU profile to this path")
+	fs.StringVar(&cfg.MemProfile, "memprofile", "", "write heap profile to this path")
+	if err := fs.Parse(args); err != nil {
+		return cfg, err
+	}
+	if fs.NArg() != 0 {
+		return cfg, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	parsedFormat, err := parseDocumentFormat(documentFormat)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.DocumentFormat = parsedFormat
+	parsedProfile, err := parseProfile(profile)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Profile = parsedProfile
+	if cfg.Docs <= 0 {
+		return cfg, fmt.Errorf("-docs must be > 0")
+	}
+	if cfg.BatchSize <= 0 {
+		return cfg, fmt.Errorf("-batch-size must be > 0")
+	}
+	if cfg.IndexCount < 0 || cfg.IndexCount > 3 {
+		return cfg, fmt.Errorf("-indexes must be 0, 1, 2, or 3")
+	}
+	if strings.TrimSpace(cfg.Collection) == "" {
+		return cfg, fmt.Errorf("-collection cannot be empty")
+	}
+	if cfg.ChunkSize < 0 {
+		return cfg, fmt.Errorf("-chunk-size must be >= 0")
+	}
+	if cfg.PagerSyncConcurrency < 0 {
+		return cfg, fmt.Errorf("-pager-sync-concurrency must be >= 0")
+	}
+	if cfg.VerifySamples < 0 {
+		return cfg, fmt.Errorf("-verify-samples must be >= 0")
+	}
+	return cfg, nil
+}
+
+func parseDocumentFormat(raw string) (collections.DocumentFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "json":
+		return collections.DocumentFormatJSON, nil
+	case string(collections.DocumentFormatTemplateV1):
+		return collections.DocumentFormatTemplateV1, nil
+	case "":
+		return "", fmt.Errorf("-format cannot be empty; use json or template-v1")
+	default:
+		return "", fmt.Errorf("unsupported -format %q", raw)
+	}
+}
+
+func parseProfile(raw string) (treedb.Profile, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "fast", "production_fast", "backend_direct_fast", "backend_direct", "cached":
+		return treedb.ProfileFast, nil
+	case "wal_on_fast", "production_wal_on_fast", "backend_direct_wal_on_fast":
+		return treedb.ProfileWALOnFast, nil
+	case "durable":
+		return treedb.ProfileDurable, nil
+	case "bench":
+		return treedb.ProfileBench, nil
+	default:
+		return "", fmt.Errorf("unsupported -profile %q", raw)
+	}
+}
+
+func runFixture(cfg config) (loadSummary, error) {
+	dir, createdTempDir, err := prepareFixtureDir(cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	cfg.Dir = dir
+	cfg.createdTempDir = createdTempDir
+
+	stopCPU, err := startCPUProfile(cfg.CPUProfile)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	defer stopCPU()
+
+	backend, cleanup, err := openBackend(cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+
+	closed := false
+	defer func() {
+		if !closed {
+			_ = cleanup()
+		}
+	}()
+
+	collection, err := createFixtureCollection(backend, cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+
+	var insertStats collections.CollectionInsertStats
+	secondaryRuns := make(map[string]*secondaryRunSummary)
+	var generationElapsed time.Duration
+	var insertElapsed time.Duration
+	var checkpointElapsed time.Duration
+	wallStart := time.Now()
+	batches := 0
+	lastProgress := time.Now()
+
+	for inserted := 0; inserted < cfg.Docs; {
+		batchSize := cfg.BatchSize
+		if remaining := cfg.Docs - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		genStart := time.Now()
+		ids, docs, err := documentBatch(cfg.DocumentFormat, inserted, batchSize)
+		if err != nil {
+			return loadSummary{}, err
+		}
+		generationElapsed += time.Since(genStart)
+
+		insertStart := time.Now()
+		if _, err := collection.InsertBatch(ids, docs); err != nil {
+			return loadSummary{}, fmt.Errorf("insert batch starting at document %d: %w", inserted, err)
+		}
+		insertElapsed += time.Since(insertStart)
+		stats := collection.LastInsertStats()
+		addInsertStats(&insertStats, stats)
+		addSecondaryRuns(secondaryRuns, stats.SecondaryRuns)
+		batches++
+		inserted += batchSize
+
+		if cfg.CheckpointEachBatch {
+			checkpointStart := time.Now()
+			if err := backend.Checkpoint(); err != nil {
+				return loadSummary{}, fmt.Errorf("checkpoint after batch %d: %w", batches, err)
+			}
+			checkpointElapsed += time.Since(checkpointStart)
+		}
+		if cfg.Progress && time.Since(lastProgress) >= time.Second {
+			fmt.Fprintf(os.Stderr, "inserted %d/%d documents into %s\n", inserted, cfg.Docs, cfg.Dir)
+			lastProgress = time.Now()
+		}
+	}
+
+	if err := collection.Flush(); err != nil {
+		return loadSummary{}, fmt.Errorf("flush collection: %w", err)
+	}
+	if cfg.Checkpoint {
+		checkpointStart := time.Now()
+		if err := backend.Checkpoint(); err != nil {
+			return loadSummary{}, fmt.Errorf("final checkpoint: %w", err)
+		}
+		checkpointElapsed += time.Since(checkpointStart)
+	}
+
+	beforeMaintenance, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	rewrite, err := maybeRewriteValueLog(cfg, backend, beforeMaintenance.TotalBytes)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	wallElapsed := time.Since(wallStart)
+
+	if err := cleanup(); err != nil {
+		closed = true
+		return loadSummary{}, fmt.Errorf("close backend: %w", err)
+	}
+	closed = true
+
+	verify := verifySummary{Enabled: cfg.ReopenVerify}
+	if cfg.ReopenVerify {
+		samples, err := verifyReopen(cfg)
+		if err != nil {
+			return loadSummary{}, err
+		}
+		verify.Samples = samples
+	}
+
+	finalUsage, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	if err := writeMemProfile(cfg.MemProfile); err != nil {
+		return loadSummary{}, err
+	}
+
+	return loadSummary{
+		GeneratedAt:                time.Now().UTC().Format(time.RFC3339),
+		Dir:                        cfg.Dir,
+		CreatedTempDir:             cfg.createdTempDir,
+		Collection:                 cfg.Collection,
+		DocumentFormat:             string(cfg.DocumentFormat),
+		Profile:                    string(cfg.Profile),
+		Docs:                       cfg.Docs,
+		BatchSize:                  cfg.BatchSize,
+		Batches:                    batches,
+		IndexCount:                 cfg.IndexCount,
+		DataOuterLeavesInValueLog:  cfg.DataOuterLeavesInValueLog,
+		IndexOuterLeavesInValueLog: cfg.IndexOuterLeavesInValueLog,
+		ChunkSize:                  cfg.ChunkSize,
+		PagerSyncConcurrency:       cfg.PagerSyncConcurrency,
+		WallTiming:                 timing(wallElapsed, cfg.Docs),
+		GenerationTiming:           timing(generationElapsed, cfg.Docs),
+		InsertTiming:               timing(insertElapsed, cfg.Docs),
+		CheckpointTiming:           timing(checkpointElapsed, cfg.Docs),
+		InsertPhases:               summarizeInsertPhases(insertStats, secondaryRuns, cfg.Docs, batches),
+		DiskUsageBeforeMaintenance: beforeMaintenance,
+		DiskUsageFinal:             finalUsage,
+		Rewrite:                    rewrite,
+		Verify:                     verify,
+		CPUProfile:                 cfg.CPUProfile,
+		MemProfile:                 cfg.MemProfile,
+		GoVersion:                  runtime.Version(),
+		GOOS:                       runtime.GOOS,
+		GOARCH:                     runtime.GOARCH,
+	}, nil
+}
+
+func prepareFixtureDir(cfg config) (string, bool, error) {
+	if strings.TrimSpace(cfg.Dir) == "" {
+		dir, err := os.MkdirTemp("", "treedb_collection_fixture_")
+		if err != nil {
+			return "", false, fmt.Errorf("create temp fixture dir: %w", err)
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return "", false, err
+		}
+		return abs, true, nil
+	}
+	dir, err := filepath.Abs(cfg.Dir)
+	if err != nil {
+		return "", false, err
+	}
+	if cfg.Reset {
+		if err := os.RemoveAll(dir); err != nil {
+			return "", false, fmt.Errorf("reset fixture dir %s: %w", dir, err)
+		}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", false, fmt.Errorf("create fixture dir %s: %w", dir, err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", false, fmt.Errorf("read fixture dir %s: %w", dir, err)
+	}
+	if len(entries) != 0 {
+		return "", false, fmt.Errorf("fixture dir %s is not empty; choose an empty dir or pass -reset", dir)
+	}
+	return dir, false, nil
+}
+
+func openBackend(cfg config) (*backenddb.DB, func() error, error) {
+	opts := treedb.OptionsFor(cfg.Profile, cfg.Dir)
+	opts.IndexOuterLeavesInValueLog = cfg.DataOuterLeavesInValueLog || cfg.IndexOuterLeavesInValueLog
+	opts.IndexInternalBaseDelta = !opts.IndexOuterLeavesInValueLog
+	if cfg.ChunkSize > 0 {
+		opts.ChunkSize = cfg.ChunkSize
+	}
+	if cfg.PagerSyncConcurrency > 0 {
+		opts.PagerSyncConcurrency = cfg.PagerSyncConcurrency
+	}
+	open := treedb.OpenBackend
+	if opts.IndexOuterLeavesInValueLog {
+		open = treedb.OpenBackendWithCachedLeafLog
+	}
+	backend, cleanup, err := open(opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open backend: %w", err)
+	}
+	return backend, cleanup, nil
+}
+
+func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Collection, error) {
+	manager := collections.NewCollectionManager(backend)
+	indexes := collectionShapeIndexes(cfg.IndexCount)
+	for i := range indexes {
+		indexes[i].StoragePolicy = rootStoragePolicy(cfg.IndexOuterLeavesInValueLog)
+	}
+	_, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: cfg.Collection,
+		Options: collections.CollectionOptions{
+			DocumentFormat:          cfg.DocumentFormat,
+			DataRootStoragePolicy:   rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+			IndexStateStoragePolicy: rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+		},
+		Indexes: indexes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create collection: %w", err)
+	}
+	collection, err := manager.OpenCollection(cfg.Collection)
+	if err != nil {
+		return nil, fmt.Errorf("open collection: %w", err)
+	}
+	return collection, nil
+}
+
+func rootStoragePolicy(outerLeavesInValueLog bool) collections.RootStoragePolicy {
+	if outerLeavesInValueLog {
+		return collections.RootStorageCompressed
+	}
+	return collections.RootStorageFast
+}
+
+func collectionShapeIndexes(indexCount int) []collections.IndexDefinition {
+	switch indexCount {
+	case 0:
+		return nil
+	case 1:
+		return []collections.IndexDefinition{{Name: "email_idx", Field: "email", Unique: true}}
+	case 2:
+		return []collections.IndexDefinition{
+			{Name: "email_idx", Field: "email", Unique: true},
+			{Name: "city_idx", Field: "city"},
+		}
+	case 3:
+		return []collections.IndexDefinition{
+			{Name: "email_idx", Field: "email", Unique: true},
+			{Name: "city_idx", Field: "city"},
+			{Name: "name_idx", Field: "name"},
+		}
+	default:
+		panic(fmt.Sprintf("unsupported index count %d", indexCount))
+	}
+}
+
+func documentBatch(format collections.DocumentFormat, start, count int) ([][]byte, [][]byte, error) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	var templateEncoder collections.TemplateV1Encoder
+	for i := 0; i < count; i++ {
+		docNum := start + i
+		ids[i] = documentID(docNum)
+		doc, err := document(format, &templateEncoder, docNum)
+		if err != nil {
+			return nil, nil, err
+		}
+		docs[i] = doc
+	}
+	return ids, docs, nil
+}
+
+func document(format collections.DocumentFormat, encoder *collections.TemplateV1Encoder, n int) ([]byte, error) {
+	if format == collections.DocumentFormatTemplateV1 {
+		if encoder == nil {
+			encoder = &collections.TemplateV1Encoder{}
+		}
+		return encoder.EncodeDocument(
+			[]string{"name", "email", "city", "pad"},
+			[]any{
+				fmt.Sprintf("user-%09d", n),
+				fmt.Sprintf("user-%09d@example.com", n),
+				fmt.Sprintf("city-%02d", n%collectionFixtureCities),
+				collectionFixturePad,
+			},
+		)
+	}
+	return indexedJSONDocument(n), nil
+}
+
+func documentID(n int) []byte {
+	out := make([]byte, 0, len("u-")+9)
+	out = append(out, "u-"...)
+	return appendZeroPaddedInt(out, n, 9)
+}
+
+func indexedJSONDocument(n int) []byte {
+	out := make([]byte, 0, 112)
+	out = append(out, `{"name":"user-`...)
+	out = appendZeroPaddedInt(out, n, 9)
+	out = append(out, `","email":"user-`...)
+	out = appendZeroPaddedInt(out, n, 9)
+	out = append(out, `@example.com","city":"city-`...)
+	out = appendZeroPaddedInt(out, n%collectionFixtureCities, 2)
+	out = append(out, `","pad":"`...)
+	out = append(out, collectionFixturePad...)
+	out = append(out, `"}`...)
+	return out
+}
+
+func appendZeroPaddedInt(dst []byte, n, width int) []byte {
+	var scratch [20]byte
+	pos := len(scratch)
+	if n == 0 {
+		pos--
+		scratch[pos] = '0'
+	} else {
+		for n > 0 {
+			pos--
+			scratch[pos] = byte('0' + n%10)
+			n /= 10
+		}
+	}
+	for pad := width - (len(scratch) - pos); pad > 0; pad-- {
+		dst = append(dst, '0')
+	}
+	return append(dst, scratch[pos:]...)
+}
+
+func addInsertStats(dst *collections.CollectionInsertStats, src collections.CollectionInsertStats) {
+	dst.Documents += src.Documents
+	dst.Indexes += src.Indexes
+	dst.Runs += src.Runs
+	dst.PrepareDocuments += src.PrepareDocuments
+	dst.IndexStateExtraction += src.IndexStateExtraction
+	dst.DuplicateDocumentPreflight += src.DuplicateDocumentPreflight
+	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
+	dst.TemplateRunBuild += src.TemplateRunBuild
+	dst.PrimaryRunBuild += src.PrimaryRunBuild
+	dst.IndexStateRunBuild += src.IndexStateRunBuild
+	dst.SecondaryRunBuild += src.SecondaryRunBuild
+	dst.Publish += src.Publish
+	dst.SecondaryEntries += src.SecondaryEntries
+	dst.SecondaryKeyBytes += src.SecondaryKeyBytes
+	dst.SecondarySortedRuns += src.SecondarySortedRuns
+	dst.SecondaryUnsortedRuns += src.SecondaryUnsortedRuns
+}
+
+func addSecondaryRuns(dst map[string]*secondaryRunSummary, runs []collections.CollectionSecondaryRunStats) {
+	for _, run := range runs {
+		entry := dst[run.IndexName]
+		if entry == nil {
+			entry = &secondaryRunSummary{IndexName: run.IndexName}
+			dst[run.IndexName] = entry
+		}
+		entry.Runs++
+		entry.Entries += run.Entries
+		entry.KeyBytes += run.KeyBytes
+		if run.AlreadySorted {
+			entry.SortedRuns++
+		} else {
+			entry.UnsortedRuns++
+		}
+		entry.BuildNSPerDoc += float64(run.Build.Nanoseconds())
+	}
+}
+
+func summarizeInsertPhases(stats collections.CollectionInsertStats, secondaryRuns map[string]*secondaryRunSummary, docs, batches int) insertPhaseSummary {
+	out := insertPhaseSummary{
+		Documents: stats.Documents,
+		Indexes:   stats.Indexes,
+		Runs:      stats.Runs,
+	}
+	nsPerDoc := func(d time.Duration) float64 {
+		if docs <= 0 || d <= 0 {
+			return 0
+		}
+		return float64(d.Nanoseconds()) / float64(docs)
+	}
+	perDocInt := func(v int) float64 {
+		if docs <= 0 || v <= 0 {
+			return 0
+		}
+		return float64(v) / float64(docs)
+	}
+	perBatchInt := func(v int) float64 {
+		if batches <= 0 || v <= 0 {
+			return 0
+		}
+		return float64(v) / float64(batches)
+	}
+	out.PrepareDocumentsNSPerDoc = nsPerDoc(stats.PrepareDocuments)
+	out.IndexStateExtractionNSPerDoc = nsPerDoc(stats.IndexStateExtraction)
+	out.DuplicatePreflightNSPerDoc = nsPerDoc(stats.DuplicateDocumentPreflight)
+	out.UniquePreflightNSPerDoc = nsPerDoc(stats.UniqueIndexPreflight)
+	out.TemplateRunBuildNSPerDoc = nsPerDoc(stats.TemplateRunBuild)
+	out.PrimaryRunBuildNSPerDoc = nsPerDoc(stats.PrimaryRunBuild)
+	out.IndexStateRunBuildNSPerDoc = nsPerDoc(stats.IndexStateRunBuild)
+	out.SecondaryRunBuildNSPerDoc = nsPerDoc(stats.SecondaryRunBuild)
+	out.PublishNSPerDoc = nsPerDoc(stats.Publish)
+	out.SecondaryEntriesPerDoc = perDocInt(stats.SecondaryEntries)
+	out.SecondaryKeyBytesPerDoc = perDocInt(stats.SecondaryKeyBytes)
+	out.SecondarySortedRunsPerBatch = perBatchInt(stats.SecondarySortedRuns)
+	out.SecondaryUnsortedRunsPerBatch = perBatchInt(stats.SecondaryUnsortedRuns)
+
+	keys := make([]string, 0, len(secondaryRuns))
+	for key := range secondaryRuns {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		run := *secondaryRuns[key]
+		if docs > 0 {
+			run.BuildNSPerDoc /= float64(docs)
+			run.EntriesPerDoc = float64(run.Entries) / float64(docs)
+			run.KeyBytesPerDoc = float64(run.KeyBytes) / float64(docs)
+		}
+		out.SecondaryRuns = append(out.SecondaryRuns, run)
+	}
+	return out
+}
+
+func maybeRewriteValueLog(cfg config, backend *backenddb.DB, beforeBytes uint64) (rewriteSummary, error) {
+	out := rewriteSummary{Enabled: cfg.ValueLogRewrite}
+	if !cfg.ValueLogRewrite {
+		return out, nil
+	}
+	out.DiskBytesBefore = beforeBytes
+	rewriteStart := time.Now()
+	rewriteStats, err := backend.ValueLogRewriteOnline(context.Background(), backenddb.ValueLogRewriteOnlineOptions{})
+	if err != nil {
+		return out, fmt.Errorf("value-log rewrite: %w", err)
+	}
+	out.RewriteTiming = timing(time.Since(rewriteStart), 1)
+	if err := backend.Checkpoint(); err != nil {
+		return out, fmt.Errorf("checkpoint after value-log rewrite: %w", err)
+	}
+	afterRewrite, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return out, err
+	}
+	out.DiskBytesAfterRewrite = afterRewrite.TotalBytes
+	out.SegmentsBefore = int(rewriteStats.SegmentsBefore)
+	out.SegmentsAfter = int(rewriteStats.SegmentsAfter)
+	out.RecordsCopied = int(rewriteStats.RecordsCopied)
+	out.ValueRecordsCopied = int(rewriteStats.ValueRecordsCopied)
+	out.ValueBytesCopied = rewriteStats.ValueBytesCopied
+	out.TemplateRecordsKept = int(rewriteStats.TemplateRecordsKept)
+
+	if cfg.ValueLogGC {
+		gcStart := time.Now()
+		gcStats, err := backend.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{})
+		if err != nil {
+			return out, fmt.Errorf("value-log GC after rewrite: %w", err)
+		}
+		out.GCTiming = timing(time.Since(gcStart), 1)
+		if err := backend.Checkpoint(); err != nil {
+			return out, fmt.Errorf("checkpoint after value-log GC: %w", err)
+		}
+		afterGC, err := directoryUsage(cfg.Dir, cfg.Docs)
+		if err != nil {
+			return out, err
+		}
+		out.DiskBytesAfterGC = afterGC.TotalBytes
+		out.GCSegmentsDeleted = int(gcStats.SegmentsDeleted)
+		out.GCBytesDeleted = gcStats.BytesDeleted
+	}
+	return out, nil
+}
+
+func verifyReopen(cfg config) (int, error) {
+	backend, cleanup, err := openBackend(cfg)
+	if err != nil {
+		return 0, fmt.Errorf("reopen verify open: %w", err)
+	}
+	defer func() { _ = cleanup() }()
+	manager := collections.NewCollectionManager(backend)
+	collection, err := manager.OpenCollection(cfg.Collection)
+	if err != nil {
+		return 0, fmt.Errorf("reopen verify open collection: %w", err)
+	}
+	samples := sampleDocumentNumbers(cfg.Docs, cfg.VerifySamples)
+	for _, n := range samples {
+		id := documentID(n)
+		got, err := collection.Get(id)
+		if err != nil {
+			return 0, fmt.Errorf("reopen verify get %s: %w", id, err)
+		}
+		if len(got) == 0 {
+			return 0, fmt.Errorf("reopen verify get %s returned an empty document", id)
+		}
+		if cfg.DocumentFormat == collections.DocumentFormatJSON {
+			want := indexedJSONDocument(n)
+			if !bytes.Equal(got, want) {
+				return 0, fmt.Errorf("reopen verify get %s returned unexpected JSON document", id)
+			}
+		}
+		if cfg.IndexCount >= 1 {
+			email := fmt.Sprintf("user-%09d@example.com", n)
+			ids, err := collection.FindByIndex("email_idx", email)
+			if err != nil {
+				return 0, fmt.Errorf("reopen verify email index %s: %w", email, err)
+			}
+			if len(ids) != 1 || !bytes.Equal(ids[0], id) {
+				return 0, fmt.Errorf("reopen verify email index %s returned %q, want %s", email, ids, id)
+			}
+		}
+		if cfg.IndexCount >= 2 {
+			city := fmt.Sprintf("city-%02d", n%collectionFixtureCities)
+			ids, err := collection.FindByIndex("city_idx", city)
+			if err != nil {
+				return 0, fmt.Errorf("reopen verify city index %s: %w", city, err)
+			}
+			if len(ids) == 0 {
+				return 0, fmt.Errorf("reopen verify city index %s returned no rows", city)
+			}
+		}
+	}
+	return len(samples), nil
+}
+
+func sampleDocumentNumbers(docs, sampleCount int) []int {
+	if docs <= 0 || sampleCount <= 0 {
+		return nil
+	}
+	if sampleCount > docs {
+		sampleCount = docs
+	}
+	seen := make(map[int]struct{}, sampleCount)
+	out := make([]int, 0, sampleCount)
+	for i := 0; i < sampleCount; i++ {
+		var n int
+		if sampleCount == 1 {
+			n = 0
+		} else {
+			n = i * (docs - 1) / (sampleCount - 1)
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}
+
+func directoryUsage(root string, docs int) (diskUsageSummary, error) {
+	var total uint64
+	var fileCount int
+	files := make([]fileSummary, 0, maxFixtureTopFileEntries)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() || info.Size() <= 0 {
+			return nil
+		}
+		size := uint64(info.Size())
+		total += size
+		fileCount++
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			rel = path
+		}
+		files = append(files, fileSummary{Path: rel, Bytes: size})
+		return nil
+	})
+	if err != nil {
+		return diskUsageSummary{}, fmt.Errorf("disk usage for %s: %w", root, err)
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].Bytes == files[j].Bytes {
+			return files[i].Path < files[j].Path
+		}
+		return files[i].Bytes > files[j].Bytes
+	})
+	if len(files) > maxFixtureTopFileEntries {
+		files = files[:maxFixtureTopFileEntries]
+	}
+	out := diskUsageSummary{TotalBytes: total, FileCount: fileCount, TopFiles: files}
+	if docs > 0 {
+		out.BytesPerDoc = float64(total) / float64(docs)
+	}
+	return out, nil
+}
+
+func timing(d time.Duration, ops int) timingSummary {
+	out := timingSummary{Seconds: d.Seconds()}
+	if ops > 0 && d > 0 {
+		out.SecPerOp = d.Seconds() / float64(ops)
+		out.OpsPerSec = float64(ops) / d.Seconds()
+	}
+	return out
+}
+
+func startCPUProfile(path string) (func(), error) {
+	if strings.TrimSpace(path) == "" {
+		return func() {}, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create CPU profile dir: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("create CPU profile: %w", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("start CPU profile: %w", err)
+	}
+	stopped := false
+	return func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		pprof.StopCPUProfile()
+		_ = f.Close()
+	}, nil
+}
+
+func writeMemProfile(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create heap profile dir: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create heap profile: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	runtime.GC()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		return fmt.Errorf("write heap profile: %w", err)
+	}
+	return nil
+}
+
+func printHumanSummary(w io.Writer, summary loadSummary) {
+	fmt.Fprintf(w, "TreeDB collection load fixture\n")
+	fmt.Fprintf(w, "dir: %s\n", summary.Dir)
+	fmt.Fprintf(w, "collection: %s\n", summary.Collection)
+	fmt.Fprintf(w, "shape: format=%s indexes=%d data_outer_leaves_in_vlog=%t index_outer_leaves_in_vlog=%t profile=%s\n",
+		summary.DocumentFormat, summary.IndexCount, summary.DataOuterLeavesInValueLog, summary.IndexOuterLeavesInValueLog, summary.Profile)
+	fmt.Fprintf(w, "loaded: docs=%d batches=%d batch_size=%d\n", summary.Docs, summary.Batches, summary.BatchSize)
+	printTiming(w, "wall", summary.WallTiming)
+	printTiming(w, "document generation", summary.GenerationTiming)
+	printTiming(w, "insert", summary.InsertTiming)
+	if summary.CheckpointTiming.Seconds > 0 {
+		printTiming(w, "checkpoint", summary.CheckpointTiming)
+	}
+	fmt.Fprintf(w, "disk before maintenance: %s total, %.2f bytes/doc, %d files\n",
+		humanBytes(summary.DiskUsageBeforeMaintenance.TotalBytes), summary.DiskUsageBeforeMaintenance.BytesPerDoc, summary.DiskUsageBeforeMaintenance.FileCount)
+	if summary.Rewrite.Enabled {
+		fmt.Fprintf(w, "vlog rewrite: before=%s after_rewrite=%s after_gc=%s copied_records=%d copied_value_bytes=%s\n",
+			humanBytes(summary.Rewrite.DiskBytesBefore),
+			humanBytes(summary.Rewrite.DiskBytesAfterRewrite),
+			humanBytes(summary.Rewrite.DiskBytesAfterGC),
+			summary.Rewrite.RecordsCopied,
+			humanBytes(uint64(max(summary.Rewrite.ValueBytesCopied, 0))))
+	}
+	fmt.Fprintf(w, "disk final: %s total, %.2f bytes/doc, %d files\n",
+		humanBytes(summary.DiskUsageFinal.TotalBytes), summary.DiskUsageFinal.BytesPerDoc, summary.DiskUsageFinal.FileCount)
+	if summary.Verify.Enabled {
+		fmt.Fprintf(w, "reopen verify: %d sampled primary/index reads passed\n", summary.Verify.Samples)
+	}
+	if len(summary.DiskUsageFinal.TopFiles) > 0 {
+		fmt.Fprintf(w, "largest files:\n")
+		for _, file := range summary.DiskUsageFinal.TopFiles {
+			fmt.Fprintf(w, "  %12s  %s\n", humanBytes(file.Bytes), file.Path)
+		}
+	}
+	if summary.CPUProfile != "" {
+		fmt.Fprintf(w, "cpu profile: %s\n", summary.CPUProfile)
+	}
+	if summary.MemProfile != "" {
+		fmt.Fprintf(w, "heap profile: %s\n", summary.MemProfile)
+	}
+}
+
+func printTiming(w io.Writer, label string, t timingSummary) {
+	fmt.Fprintf(w, "%s: %.3fs, %.9f sec/op, %.0f ops/sec\n", label, t.Seconds, t.SecPerOp, t.OpsPerSec)
+}
+
+func humanBytes(n uint64) string {
+	const unit = 1024
+	if n < unit {
+		return strconv.FormatUint(n, 10) + " B"
+	}
+	div, exp := uint64(unit), 0
+	for value := n / unit; value >= unit; value /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -818,12 +818,21 @@ func verifyReopen(cfg config) (int, error) {
 			if err != nil {
 				return 0, fmt.Errorf("reopen verify city index %s: %w", city, err)
 			}
-			if len(ids) == 0 {
-				return 0, fmt.Errorf("reopen verify city index %s returned no rows", city)
+			if !containsDocumentID(ids, id) {
+				return 0, fmt.Errorf("reopen verify city index %s did not include %s", city, id)
 			}
 		}
 	}
 	return len(samples), nil
+}
+
+func containsDocumentID(ids [][]byte, want []byte) bool {
+	for _, id := range ids {
+		if bytes.Equal(id, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func sampleDocumentNumbers(docs, sampleCount int) []int {

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -1,0 +1,1010 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	defaultDocs              = 1_000_000
+	defaultBatchSize         = 8_000
+	defaultCollectionName    = "bench_shape_insert_2"
+	collectionFixtureCities  = 64
+	collectionFixturePad     = "01234567890123456789"
+	maxFixtureTopFileEntries = 20
+)
+
+type config struct {
+	Dir                        string
+	Reset                      bool
+	Docs                       int
+	BatchSize                  int
+	Collection                 string
+	DocumentFormat             collections.DocumentFormat
+	IndexCount                 int
+	Profile                    treedb.Profile
+	DataOuterLeavesInValueLog  bool
+	IndexOuterLeavesInValueLog bool
+	ChunkSize                  int64
+	PagerSyncConcurrency       int
+	Checkpoint                 bool
+	CheckpointEachBatch        bool
+	ReopenVerify               bool
+	VerifySamples              int
+	ValueLogRewrite            bool
+	ValueLogGC                 bool
+	Progress                   bool
+	JSONOutput                 bool
+	CPUProfile                 string
+	MemProfile                 string
+	createdTempDir             bool
+}
+
+type timingSummary struct {
+	Seconds   float64 `json:"seconds"`
+	SecPerOp  float64 `json:"sec_per_op,omitempty"`
+	OpsPerSec float64 `json:"ops_per_sec,omitempty"`
+}
+
+type diskUsageSummary struct {
+	TotalBytes  uint64        `json:"total_bytes"`
+	BytesPerDoc float64       `json:"bytes_per_doc,omitempty"`
+	FileCount   int           `json:"file_count"`
+	TopFiles    []fileSummary `json:"top_files,omitempty"`
+}
+
+type fileSummary struct {
+	Path  string `json:"path"`
+	Bytes uint64 `json:"bytes"`
+}
+
+type insertPhaseSummary struct {
+	Documents                     int                   `json:"documents"`
+	Indexes                       int                   `json:"indexes"`
+	Runs                          int                   `json:"runs"`
+	PrepareDocumentsNSPerDoc      float64               `json:"prepare_documents_ns_per_doc,omitempty"`
+	IndexStateExtractionNSPerDoc  float64               `json:"index_state_extraction_ns_per_doc,omitempty"`
+	DuplicatePreflightNSPerDoc    float64               `json:"duplicate_preflight_ns_per_doc,omitempty"`
+	UniquePreflightNSPerDoc       float64               `json:"unique_preflight_ns_per_doc,omitempty"`
+	TemplateRunBuildNSPerDoc      float64               `json:"template_run_build_ns_per_doc,omitempty"`
+	PrimaryRunBuildNSPerDoc       float64               `json:"primary_run_build_ns_per_doc,omitempty"`
+	IndexStateRunBuildNSPerDoc    float64               `json:"index_state_run_build_ns_per_doc,omitempty"`
+	SecondaryRunBuildNSPerDoc     float64               `json:"secondary_run_build_ns_per_doc,omitempty"`
+	PublishNSPerDoc               float64               `json:"publish_ns_per_doc,omitempty"`
+	SecondaryEntriesPerDoc        float64               `json:"secondary_entries_per_doc,omitempty"`
+	SecondaryKeyBytesPerDoc       float64               `json:"secondary_key_bytes_per_doc,omitempty"`
+	SecondarySortedRunsPerBatch   float64               `json:"secondary_sorted_runs_per_batch,omitempty"`
+	SecondaryUnsortedRunsPerBatch float64               `json:"secondary_unsorted_runs_per_batch,omitempty"`
+	SecondaryRuns                 []secondaryRunSummary `json:"secondary_runs,omitempty"`
+}
+
+type secondaryRunSummary struct {
+	IndexName      string  `json:"index_name"`
+	Runs           int     `json:"runs"`
+	Entries        int     `json:"entries"`
+	KeyBytes       int     `json:"key_bytes"`
+	SortedRuns     int     `json:"sorted_runs"`
+	UnsortedRuns   int     `json:"unsorted_runs"`
+	BuildNSPerDoc  float64 `json:"build_ns_per_doc,omitempty"`
+	EntriesPerDoc  float64 `json:"entries_per_doc,omitempty"`
+	KeyBytesPerDoc float64 `json:"key_bytes_per_doc,omitempty"`
+}
+
+type rewriteSummary struct {
+	Enabled               bool          `json:"enabled"`
+	RewriteTiming         timingSummary `json:"rewrite_timing,omitempty"`
+	GCTiming              timingSummary `json:"gc_timing,omitempty"`
+	DiskBytesBefore       uint64        `json:"disk_bytes_before,omitempty"`
+	DiskBytesAfterRewrite uint64        `json:"disk_bytes_after_rewrite,omitempty"`
+	DiskBytesAfterGC      uint64        `json:"disk_bytes_after_gc,omitempty"`
+	SegmentsBefore        int           `json:"segments_before,omitempty"`
+	SegmentsAfter         int           `json:"segments_after,omitempty"`
+	RecordsCopied         int           `json:"records_copied,omitempty"`
+	ValueRecordsCopied    int           `json:"value_records_copied,omitempty"`
+	ValueBytesCopied      int64         `json:"value_bytes_copied,omitempty"`
+	TemplateRecordsKept   int           `json:"template_records_kept,omitempty"`
+	GCSegmentsDeleted     int           `json:"gc_segments_deleted,omitempty"`
+	GCBytesDeleted        int64         `json:"gc_bytes_deleted,omitempty"`
+}
+
+type verifySummary struct {
+	Enabled bool `json:"enabled"`
+	Samples int  `json:"samples,omitempty"`
+}
+
+type loadSummary struct {
+	GeneratedAt                string             `json:"generated_at"`
+	Dir                        string             `json:"dir"`
+	CreatedTempDir             bool               `json:"created_temp_dir,omitempty"`
+	Collection                 string             `json:"collection"`
+	DocumentFormat             string             `json:"document_format"`
+	Profile                    string             `json:"profile"`
+	Docs                       int                `json:"docs"`
+	BatchSize                  int                `json:"batch_size"`
+	Batches                    int                `json:"batches"`
+	IndexCount                 int                `json:"index_count"`
+	DataOuterLeavesInValueLog  bool               `json:"data_outer_leaves_in_value_log"`
+	IndexOuterLeavesInValueLog bool               `json:"index_outer_leaves_in_value_log"`
+	ChunkSize                  int64              `json:"chunk_size,omitempty"`
+	PagerSyncConcurrency       int                `json:"pager_sync_concurrency,omitempty"`
+	WallTiming                 timingSummary      `json:"wall_timing"`
+	GenerationTiming           timingSummary      `json:"generation_timing"`
+	InsertTiming               timingSummary      `json:"insert_timing"`
+	CheckpointTiming           timingSummary      `json:"checkpoint_timing,omitempty"`
+	InsertPhases               insertPhaseSummary `json:"insert_phases"`
+	DiskUsageBeforeMaintenance diskUsageSummary   `json:"disk_usage_before_maintenance"`
+	DiskUsageFinal             diskUsageSummary   `json:"disk_usage_final"`
+	Rewrite                    rewriteSummary     `json:"rewrite,omitempty"`
+	Verify                     verifySummary      `json:"verify"`
+	CPUProfile                 string             `json:"cpu_profile,omitempty"`
+	MemProfile                 string             `json:"mem_profile,omitempty"`
+	GoVersion                  string             `json:"go_version"`
+	GOOS                       string             `json:"goos"`
+	GOARCH                     string             `json:"goarch"`
+}
+
+func main() {
+	cfg, err := parseConfig(os.Args[1:], os.Stderr)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		fmt.Fprintf(os.Stderr, "collection-load-fixture: %v\n", err)
+		os.Exit(2)
+	}
+	summary, err := runFixture(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collection-load-fixture: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg.JSONOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(summary); err != nil {
+			fmt.Fprintf(os.Stderr, "collection-load-fixture: write json summary: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	printHumanSummary(os.Stdout, summary)
+}
+
+func parseConfig(args []string, output io.Writer) (config, error) {
+	cfg := config{
+		Docs:                       defaultDocs,
+		BatchSize:                  defaultBatchSize,
+		Collection:                 defaultCollectionName,
+		DocumentFormat:             collections.DocumentFormatTemplateV1,
+		IndexCount:                 2,
+		Profile:                    treedb.ProfileFast,
+		DataOuterLeavesInValueLog:  true,
+		IndexOuterLeavesInValueLog: true,
+		Checkpoint:                 true,
+		ReopenVerify:               true,
+		VerifySamples:              8,
+		ValueLogGC:                 true,
+		Progress:                   true,
+	}
+	var documentFormat string
+	var profile string
+	fs := flag.NewFlagSet("collection-load-fixture", flag.ContinueOnError)
+	if output == nil {
+		output = io.Discard
+	}
+	fs.SetOutput(output)
+	fs.StringVar(&cfg.Dir, "dir", "", "directory to create and keep; empty creates a kept OS temp directory")
+	fs.BoolVar(&cfg.Reset, "reset", false, "remove -dir before loading; ignored when -dir is empty")
+	fs.IntVar(&cfg.Docs, "docs", cfg.Docs, "number of documents to insert")
+	fs.IntVar(&cfg.BatchSize, "batch-size", cfg.BatchSize, "documents per InsertBatch call")
+	fs.StringVar(&cfg.Collection, "collection", cfg.Collection, "collection name")
+	fs.StringVar(&documentFormat, "format", string(cfg.DocumentFormat), "document format: json or template-v1")
+	fs.IntVar(&cfg.IndexCount, "indexes", cfg.IndexCount, "secondary index count for the benchmark shape: 0, 1, 2, or 3")
+	fs.StringVar(&profile, "profile", string(cfg.Profile), "TreeDB profile: fast, wal_on_fast, durable, or bench")
+	fs.BoolVar(&cfg.DataOuterLeavesInValueLog, "data-outer-leaves-in-vlog", cfg.DataOuterLeavesInValueLog, "store collection primary/index-state outer leaves through the value log")
+	fs.BoolVar(&cfg.IndexOuterLeavesInValueLog, "index-outer-leaves-in-vlog", cfg.IndexOuterLeavesInValueLog, "store secondary-index outer leaves through the value log")
+	fs.Int64Var(&cfg.ChunkSize, "chunk-size", 0, "override TreeDB pager chunk size in bytes")
+	fs.IntVar(&cfg.PagerSyncConcurrency, "pager-sync-concurrency", 0, "override TreeDB pager sync concurrency")
+	fs.BoolVar(&cfg.Checkpoint, "checkpoint", cfg.Checkpoint, "checkpoint after loading")
+	fs.BoolVar(&cfg.CheckpointEachBatch, "checkpoint-each-batch", false, "checkpoint after every batch")
+	fs.BoolVar(&cfg.ReopenVerify, "reopen-verify", cfg.ReopenVerify, "close, reopen, and verify sampled primary/index reads")
+	fs.IntVar(&cfg.VerifySamples, "verify-samples", cfg.VerifySamples, "sample count for -reopen-verify")
+	fs.BoolVar(&cfg.ValueLogRewrite, "vlog-rewrite", false, "run TreeDB online value-log rewrite after loading")
+	fs.BoolVar(&cfg.ValueLogGC, "vlog-gc", cfg.ValueLogGC, "run value-log GC after -vlog-rewrite")
+	fs.BoolVar(&cfg.Progress, "progress", cfg.Progress, "print load progress to stderr")
+	fs.BoolVar(&cfg.JSONOutput, "json", false, "print summary as JSON")
+	fs.StringVar(&cfg.CPUProfile, "cpuprofile", "", "write CPU profile to this path")
+	fs.StringVar(&cfg.MemProfile, "memprofile", "", "write heap profile to this path")
+	if err := fs.Parse(args); err != nil {
+		return cfg, err
+	}
+	if fs.NArg() != 0 {
+		return cfg, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	parsedFormat, err := parseDocumentFormat(documentFormat)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.DocumentFormat = parsedFormat
+	parsedProfile, err := parseProfile(profile)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Profile = parsedProfile
+	if cfg.Docs <= 0 {
+		return cfg, fmt.Errorf("-docs must be > 0")
+	}
+	if cfg.BatchSize <= 0 {
+		return cfg, fmt.Errorf("-batch-size must be > 0")
+	}
+	if cfg.IndexCount < 0 || cfg.IndexCount > 3 {
+		return cfg, fmt.Errorf("-indexes must be 0, 1, 2, or 3")
+	}
+	if strings.TrimSpace(cfg.Collection) == "" {
+		return cfg, fmt.Errorf("-collection cannot be empty")
+	}
+	if cfg.ChunkSize < 0 {
+		return cfg, fmt.Errorf("-chunk-size must be >= 0")
+	}
+	if cfg.PagerSyncConcurrency < 0 {
+		return cfg, fmt.Errorf("-pager-sync-concurrency must be >= 0")
+	}
+	if cfg.VerifySamples < 0 {
+		return cfg, fmt.Errorf("-verify-samples must be >= 0")
+	}
+	return cfg, nil
+}
+
+func parseDocumentFormat(raw string) (collections.DocumentFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "json":
+		return collections.DocumentFormatJSON, nil
+	case string(collections.DocumentFormatTemplateV1):
+		return collections.DocumentFormatTemplateV1, nil
+	default:
+		return "", fmt.Errorf("unsupported -format %q", raw)
+	}
+}
+
+func parseProfile(raw string) (treedb.Profile, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "fast", "production_fast", "backend_direct_fast", "backend_direct", "cached":
+		return treedb.ProfileFast, nil
+	case "wal_on_fast", "production_wal_on_fast", "backend_direct_wal_on_fast":
+		return treedb.ProfileWALOnFast, nil
+	case "durable":
+		return treedb.ProfileDurable, nil
+	case "bench":
+		return treedb.ProfileBench, nil
+	default:
+		return "", fmt.Errorf("unsupported -profile %q", raw)
+	}
+}
+
+func runFixture(cfg config) (loadSummary, error) {
+	dir, createdTempDir, err := prepareFixtureDir(cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	cfg.Dir = dir
+	cfg.createdTempDir = createdTempDir
+
+	stopCPU, err := startCPUProfile(cfg.CPUProfile)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	defer stopCPU()
+
+	backend, cleanup, err := openBackend(cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+
+	closed := false
+	defer func() {
+		if !closed {
+			_ = cleanup()
+		}
+	}()
+
+	collection, err := createFixtureCollection(backend, cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+
+	var insertStats collections.CollectionInsertStats
+	secondaryRuns := make(map[string]*secondaryRunSummary)
+	var generationElapsed time.Duration
+	var insertElapsed time.Duration
+	var checkpointElapsed time.Duration
+	wallStart := time.Now()
+	batches := 0
+	lastProgress := time.Now()
+
+	for inserted := 0; inserted < cfg.Docs; {
+		batchSize := cfg.BatchSize
+		if remaining := cfg.Docs - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		genStart := time.Now()
+		ids, docs, err := documentBatch(cfg.DocumentFormat, inserted, batchSize)
+		if err != nil {
+			return loadSummary{}, err
+		}
+		generationElapsed += time.Since(genStart)
+
+		insertStart := time.Now()
+		if _, err := collection.InsertBatch(ids, docs); err != nil {
+			return loadSummary{}, fmt.Errorf("insert batch starting at document %d: %w", inserted, err)
+		}
+		insertElapsed += time.Since(insertStart)
+		stats := collection.LastInsertStats()
+		addInsertStats(&insertStats, stats)
+		addSecondaryRuns(secondaryRuns, stats.SecondaryRuns)
+		batches++
+		inserted += batchSize
+
+		if cfg.CheckpointEachBatch {
+			checkpointStart := time.Now()
+			if err := backend.Checkpoint(); err != nil {
+				return loadSummary{}, fmt.Errorf("checkpoint after batch %d: %w", batches, err)
+			}
+			checkpointElapsed += time.Since(checkpointStart)
+		}
+		if cfg.Progress && time.Since(lastProgress) >= time.Second {
+			fmt.Fprintf(os.Stderr, "inserted %d/%d documents into %s\n", inserted, cfg.Docs, cfg.Dir)
+			lastProgress = time.Now()
+		}
+	}
+
+	if err := collection.Flush(); err != nil {
+		return loadSummary{}, fmt.Errorf("flush collection: %w", err)
+	}
+	if cfg.Checkpoint {
+		checkpointStart := time.Now()
+		if err := backend.Checkpoint(); err != nil {
+			return loadSummary{}, fmt.Errorf("final checkpoint: %w", err)
+		}
+		checkpointElapsed += time.Since(checkpointStart)
+	}
+
+	beforeMaintenance, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	rewrite, err := maybeRewriteValueLog(cfg, backend, beforeMaintenance.TotalBytes)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	wallElapsed := time.Since(wallStart)
+
+	if err := cleanup(); err != nil {
+		closed = true
+		return loadSummary{}, fmt.Errorf("close backend: %w", err)
+	}
+	closed = true
+
+	verify := verifySummary{Enabled: cfg.ReopenVerify}
+	if cfg.ReopenVerify {
+		samples, err := verifyReopen(cfg)
+		if err != nil {
+			return loadSummary{}, err
+		}
+		verify.Samples = samples
+	}
+
+	finalUsage, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	if err := writeMemProfile(cfg.MemProfile); err != nil {
+		return loadSummary{}, err
+	}
+
+	return loadSummary{
+		GeneratedAt:                time.Now().UTC().Format(time.RFC3339),
+		Dir:                        cfg.Dir,
+		CreatedTempDir:             cfg.createdTempDir,
+		Collection:                 cfg.Collection,
+		DocumentFormat:             string(cfg.DocumentFormat),
+		Profile:                    string(cfg.Profile),
+		Docs:                       cfg.Docs,
+		BatchSize:                  cfg.BatchSize,
+		Batches:                    batches,
+		IndexCount:                 cfg.IndexCount,
+		DataOuterLeavesInValueLog:  cfg.DataOuterLeavesInValueLog,
+		IndexOuterLeavesInValueLog: cfg.IndexOuterLeavesInValueLog,
+		ChunkSize:                  cfg.ChunkSize,
+		PagerSyncConcurrency:       cfg.PagerSyncConcurrency,
+		WallTiming:                 timing(wallElapsed, cfg.Docs),
+		GenerationTiming:           timing(generationElapsed, cfg.Docs),
+		InsertTiming:               timing(insertElapsed, cfg.Docs),
+		CheckpointTiming:           timing(checkpointElapsed, cfg.Docs),
+		InsertPhases:               summarizeInsertPhases(insertStats, secondaryRuns, cfg.Docs, batches),
+		DiskUsageBeforeMaintenance: beforeMaintenance,
+		DiskUsageFinal:             finalUsage,
+		Rewrite:                    rewrite,
+		Verify:                     verify,
+		CPUProfile:                 cfg.CPUProfile,
+		MemProfile:                 cfg.MemProfile,
+		GoVersion:                  runtime.Version(),
+		GOOS:                       runtime.GOOS,
+		GOARCH:                     runtime.GOARCH,
+	}, nil
+}
+
+func prepareFixtureDir(cfg config) (string, bool, error) {
+	if strings.TrimSpace(cfg.Dir) == "" {
+		dir, err := os.MkdirTemp("", "treedb_collection_fixture_")
+		if err != nil {
+			return "", false, fmt.Errorf("create temp fixture dir: %w", err)
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return "", false, err
+		}
+		return abs, true, nil
+	}
+	dir, err := filepath.Abs(cfg.Dir)
+	if err != nil {
+		return "", false, err
+	}
+	if cfg.Reset {
+		if err := os.RemoveAll(dir); err != nil {
+			return "", false, fmt.Errorf("reset fixture dir %s: %w", dir, err)
+		}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", false, fmt.Errorf("create fixture dir %s: %w", dir, err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", false, fmt.Errorf("read fixture dir %s: %w", dir, err)
+	}
+	if len(entries) != 0 {
+		return "", false, fmt.Errorf("fixture dir %s is not empty; choose an empty dir or pass -reset", dir)
+	}
+	return dir, false, nil
+}
+
+func openBackend(cfg config) (*backenddb.DB, func() error, error) {
+	opts := treedb.OptionsFor(cfg.Profile, cfg.Dir)
+	opts.IndexOuterLeavesInValueLog = cfg.DataOuterLeavesInValueLog || cfg.IndexOuterLeavesInValueLog
+	opts.IndexInternalBaseDelta = !opts.IndexOuterLeavesInValueLog
+	if cfg.ChunkSize > 0 {
+		opts.ChunkSize = cfg.ChunkSize
+	}
+	if cfg.PagerSyncConcurrency > 0 {
+		opts.PagerSyncConcurrency = cfg.PagerSyncConcurrency
+	}
+	open := treedb.OpenBackend
+	if opts.IndexOuterLeavesInValueLog {
+		open = treedb.OpenBackendWithCachedLeafLog
+	}
+	backend, cleanup, err := open(opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open backend: %w", err)
+	}
+	return backend, cleanup, nil
+}
+
+func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Collection, error) {
+	manager := collections.NewCollectionManager(backend)
+	indexes := collectionShapeIndexes(cfg.IndexCount)
+	for i := range indexes {
+		indexes[i].StoragePolicy = rootStoragePolicy(cfg.IndexOuterLeavesInValueLog)
+	}
+	_, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: cfg.Collection,
+		Options: collections.CollectionOptions{
+			DocumentFormat:          cfg.DocumentFormat,
+			DataRootStoragePolicy:   rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+			IndexStateStoragePolicy: rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+		},
+		Indexes: indexes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create collection: %w", err)
+	}
+	collection, err := manager.OpenCollection(cfg.Collection)
+	if err != nil {
+		return nil, fmt.Errorf("open collection: %w", err)
+	}
+	return collection, nil
+}
+
+func rootStoragePolicy(outerLeavesInValueLog bool) collections.RootStoragePolicy {
+	if outerLeavesInValueLog {
+		return collections.RootStorageCompressed
+	}
+	return collections.RootStorageFast
+}
+
+func collectionShapeIndexes(indexCount int) []collections.IndexDefinition {
+	switch indexCount {
+	case 0:
+		return nil
+	case 1:
+		return []collections.IndexDefinition{{Name: "email_idx", Field: "email", Unique: true}}
+	case 2:
+		return []collections.IndexDefinition{
+			{Name: "email_idx", Field: "email", Unique: true},
+			{Name: "city_idx", Field: "city"},
+		}
+	case 3:
+		return []collections.IndexDefinition{
+			{Name: "email_idx", Field: "email", Unique: true},
+			{Name: "city_idx", Field: "city"},
+			{Name: "name_idx", Field: "name"},
+		}
+	default:
+		panic(fmt.Sprintf("unsupported index count %d", indexCount))
+	}
+}
+
+func documentBatch(format collections.DocumentFormat, start, count int) ([][]byte, [][]byte, error) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	var templateEncoder collections.TemplateV1Encoder
+	for i := 0; i < count; i++ {
+		docNum := start + i
+		ids[i] = documentID(docNum)
+		doc, err := document(format, &templateEncoder, docNum)
+		if err != nil {
+			return nil, nil, err
+		}
+		docs[i] = doc
+	}
+	return ids, docs, nil
+}
+
+func document(format collections.DocumentFormat, encoder *collections.TemplateV1Encoder, n int) ([]byte, error) {
+	if format == collections.DocumentFormatTemplateV1 {
+		if encoder == nil {
+			encoder = &collections.TemplateV1Encoder{}
+		}
+		return encoder.EncodeDocument(
+			[]string{"name", "email", "city", "pad"},
+			[]any{
+				fmt.Sprintf("user-%09d", n),
+				fmt.Sprintf("user-%09d@example.com", n),
+				fmt.Sprintf("city-%02d", n%collectionFixtureCities),
+				collectionFixturePad,
+			},
+		)
+	}
+	return indexedJSONDocument(n), nil
+}
+
+func documentID(n int) []byte {
+	out := make([]byte, 0, len("u-")+9)
+	out = append(out, "u-"...)
+	return appendZeroPaddedInt(out, n, 9)
+}
+
+func indexedJSONDocument(n int) []byte {
+	out := make([]byte, 0, 112)
+	out = append(out, `{"name":"user-`...)
+	out = appendZeroPaddedInt(out, n, 9)
+	out = append(out, `","email":"user-`...)
+	out = appendZeroPaddedInt(out, n, 9)
+	out = append(out, `@example.com","city":"city-`...)
+	out = appendZeroPaddedInt(out, n%collectionFixtureCities, 2)
+	out = append(out, `","pad":"`...)
+	out = append(out, collectionFixturePad...)
+	out = append(out, `"}`...)
+	return out
+}
+
+func appendZeroPaddedInt(dst []byte, n, width int) []byte {
+	var scratch [20]byte
+	pos := len(scratch)
+	if n == 0 {
+		pos--
+		scratch[pos] = '0'
+	} else {
+		for n > 0 {
+			pos--
+			scratch[pos] = byte('0' + n%10)
+			n /= 10
+		}
+	}
+	for pad := width - (len(scratch) - pos); pad > 0; pad-- {
+		dst = append(dst, '0')
+	}
+	return append(dst, scratch[pos:]...)
+}
+
+func addInsertStats(dst *collections.CollectionInsertStats, src collections.CollectionInsertStats) {
+	dst.Documents += src.Documents
+	dst.Indexes += src.Indexes
+	dst.Runs += src.Runs
+	dst.PrepareDocuments += src.PrepareDocuments
+	dst.IndexStateExtraction += src.IndexStateExtraction
+	dst.DuplicateDocumentPreflight += src.DuplicateDocumentPreflight
+	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
+	dst.TemplateRunBuild += src.TemplateRunBuild
+	dst.PrimaryRunBuild += src.PrimaryRunBuild
+	dst.IndexStateRunBuild += src.IndexStateRunBuild
+	dst.SecondaryRunBuild += src.SecondaryRunBuild
+	dst.Publish += src.Publish
+	dst.SecondaryEntries += src.SecondaryEntries
+	dst.SecondaryKeyBytes += src.SecondaryKeyBytes
+	dst.SecondarySortedRuns += src.SecondarySortedRuns
+	dst.SecondaryUnsortedRuns += src.SecondaryUnsortedRuns
+}
+
+func addSecondaryRuns(dst map[string]*secondaryRunSummary, runs []collections.CollectionSecondaryRunStats) {
+	for _, run := range runs {
+		entry := dst[run.IndexName]
+		if entry == nil {
+			entry = &secondaryRunSummary{IndexName: run.IndexName}
+			dst[run.IndexName] = entry
+		}
+		entry.Runs++
+		entry.Entries += run.Entries
+		entry.KeyBytes += run.KeyBytes
+		if run.AlreadySorted {
+			entry.SortedRuns++
+		} else {
+			entry.UnsortedRuns++
+		}
+		entry.BuildNSPerDoc += float64(run.Build.Nanoseconds())
+	}
+}
+
+func summarizeInsertPhases(stats collections.CollectionInsertStats, secondaryRuns map[string]*secondaryRunSummary, docs, batches int) insertPhaseSummary {
+	out := insertPhaseSummary{
+		Documents: stats.Documents,
+		Indexes:   stats.Indexes,
+		Runs:      stats.Runs,
+	}
+	nsPerDoc := func(d time.Duration) float64 {
+		if docs <= 0 || d <= 0 {
+			return 0
+		}
+		return float64(d.Nanoseconds()) / float64(docs)
+	}
+	perDocInt := func(v int) float64 {
+		if docs <= 0 || v <= 0 {
+			return 0
+		}
+		return float64(v) / float64(docs)
+	}
+	perBatchInt := func(v int) float64 {
+		if batches <= 0 || v <= 0 {
+			return 0
+		}
+		return float64(v) / float64(batches)
+	}
+	out.PrepareDocumentsNSPerDoc = nsPerDoc(stats.PrepareDocuments)
+	out.IndexStateExtractionNSPerDoc = nsPerDoc(stats.IndexStateExtraction)
+	out.DuplicatePreflightNSPerDoc = nsPerDoc(stats.DuplicateDocumentPreflight)
+	out.UniquePreflightNSPerDoc = nsPerDoc(stats.UniqueIndexPreflight)
+	out.TemplateRunBuildNSPerDoc = nsPerDoc(stats.TemplateRunBuild)
+	out.PrimaryRunBuildNSPerDoc = nsPerDoc(stats.PrimaryRunBuild)
+	out.IndexStateRunBuildNSPerDoc = nsPerDoc(stats.IndexStateRunBuild)
+	out.SecondaryRunBuildNSPerDoc = nsPerDoc(stats.SecondaryRunBuild)
+	out.PublishNSPerDoc = nsPerDoc(stats.Publish)
+	out.SecondaryEntriesPerDoc = perDocInt(stats.SecondaryEntries)
+	out.SecondaryKeyBytesPerDoc = perDocInt(stats.SecondaryKeyBytes)
+	out.SecondarySortedRunsPerBatch = perBatchInt(stats.SecondarySortedRuns)
+	out.SecondaryUnsortedRunsPerBatch = perBatchInt(stats.SecondaryUnsortedRuns)
+
+	keys := make([]string, 0, len(secondaryRuns))
+	for key := range secondaryRuns {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		run := *secondaryRuns[key]
+		if docs > 0 {
+			run.BuildNSPerDoc /= float64(docs)
+			run.EntriesPerDoc = float64(run.Entries) / float64(docs)
+			run.KeyBytesPerDoc = float64(run.KeyBytes) / float64(docs)
+		}
+		out.SecondaryRuns = append(out.SecondaryRuns, run)
+	}
+	return out
+}
+
+func maybeRewriteValueLog(cfg config, backend *backenddb.DB, beforeBytes uint64) (rewriteSummary, error) {
+	out := rewriteSummary{Enabled: cfg.ValueLogRewrite}
+	if !cfg.ValueLogRewrite {
+		return out, nil
+	}
+	out.DiskBytesBefore = beforeBytes
+	rewriteStart := time.Now()
+	rewriteStats, err := backend.ValueLogRewriteOnline(context.Background(), backenddb.ValueLogRewriteOnlineOptions{})
+	if err != nil {
+		return out, fmt.Errorf("value-log rewrite: %w", err)
+	}
+	out.RewriteTiming = timing(time.Since(rewriteStart), 1)
+	if err := backend.Checkpoint(); err != nil {
+		return out, fmt.Errorf("checkpoint after value-log rewrite: %w", err)
+	}
+	afterRewrite, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return out, err
+	}
+	out.DiskBytesAfterRewrite = afterRewrite.TotalBytes
+	out.SegmentsBefore = int(rewriteStats.SegmentsBefore)
+	out.SegmentsAfter = int(rewriteStats.SegmentsAfter)
+	out.RecordsCopied = int(rewriteStats.RecordsCopied)
+	out.ValueRecordsCopied = int(rewriteStats.ValueRecordsCopied)
+	out.ValueBytesCopied = rewriteStats.ValueBytesCopied
+	out.TemplateRecordsKept = int(rewriteStats.TemplateRecordsKept)
+
+	if cfg.ValueLogGC {
+		gcStart := time.Now()
+		gcStats, err := backend.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{})
+		if err != nil {
+			return out, fmt.Errorf("value-log GC after rewrite: %w", err)
+		}
+		out.GCTiming = timing(time.Since(gcStart), 1)
+		if err := backend.Checkpoint(); err != nil {
+			return out, fmt.Errorf("checkpoint after value-log GC: %w", err)
+		}
+		afterGC, err := directoryUsage(cfg.Dir, cfg.Docs)
+		if err != nil {
+			return out, err
+		}
+		out.DiskBytesAfterGC = afterGC.TotalBytes
+		out.GCSegmentsDeleted = int(gcStats.SegmentsDeleted)
+		out.GCBytesDeleted = gcStats.BytesDeleted
+	}
+	return out, nil
+}
+
+func verifyReopen(cfg config) (int, error) {
+	backend, cleanup, err := openBackend(cfg)
+	if err != nil {
+		return 0, fmt.Errorf("reopen verify open: %w", err)
+	}
+	defer func() { _ = cleanup() }()
+	manager := collections.NewCollectionManager(backend)
+	collection, err := manager.OpenCollection(cfg.Collection)
+	if err != nil {
+		return 0, fmt.Errorf("reopen verify open collection: %w", err)
+	}
+	samples := sampleDocumentNumbers(cfg.Docs, cfg.VerifySamples)
+	for _, n := range samples {
+		id := documentID(n)
+		got, err := collection.Get(id)
+		if err != nil {
+			return 0, fmt.Errorf("reopen verify get %s: %w", id, err)
+		}
+		if len(got) == 0 {
+			return 0, fmt.Errorf("reopen verify get %s returned an empty document", id)
+		}
+		if cfg.DocumentFormat == collections.DocumentFormatJSON {
+			want := indexedJSONDocument(n)
+			if !bytes.Equal(got, want) {
+				return 0, fmt.Errorf("reopen verify get %s returned unexpected JSON document", id)
+			}
+		}
+		if cfg.IndexCount >= 1 {
+			email := fmt.Sprintf("user-%09d@example.com", n)
+			ids, err := collection.FindByIndex("email_idx", email)
+			if err != nil {
+				return 0, fmt.Errorf("reopen verify email index %s: %w", email, err)
+			}
+			if len(ids) != 1 || !bytes.Equal(ids[0], id) {
+				return 0, fmt.Errorf("reopen verify email index %s returned %q, want %s", email, ids, id)
+			}
+		}
+		if cfg.IndexCount >= 2 {
+			city := fmt.Sprintf("city-%02d", n%collectionFixtureCities)
+			ids, err := collection.FindByIndex("city_idx", city)
+			if err != nil {
+				return 0, fmt.Errorf("reopen verify city index %s: %w", city, err)
+			}
+			if len(ids) == 0 {
+				return 0, fmt.Errorf("reopen verify city index %s returned no rows", city)
+			}
+		}
+	}
+	return len(samples), nil
+}
+
+func sampleDocumentNumbers(docs, sampleCount int) []int {
+	if docs <= 0 || sampleCount <= 0 {
+		return nil
+	}
+	if sampleCount > docs {
+		sampleCount = docs
+	}
+	seen := make(map[int]struct{}, sampleCount)
+	out := make([]int, 0, sampleCount)
+	for i := 0; i < sampleCount; i++ {
+		var n int
+		if sampleCount == 1 {
+			n = 0
+		} else {
+			n = i * (docs - 1) / (sampleCount - 1)
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}
+
+func directoryUsage(root string, docs int) (diskUsageSummary, error) {
+	var total uint64
+	var fileCount int
+	files := make([]fileSummary, 0, maxFixtureTopFileEntries)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() || info.Size() <= 0 {
+			return nil
+		}
+		size := uint64(info.Size())
+		total += size
+		fileCount++
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			rel = path
+		}
+		files = append(files, fileSummary{Path: rel, Bytes: size})
+		return nil
+	})
+	if err != nil {
+		return diskUsageSummary{}, fmt.Errorf("disk usage for %s: %w", root, err)
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].Bytes == files[j].Bytes {
+			return files[i].Path < files[j].Path
+		}
+		return files[i].Bytes > files[j].Bytes
+	})
+	if len(files) > maxFixtureTopFileEntries {
+		files = files[:maxFixtureTopFileEntries]
+	}
+	out := diskUsageSummary{TotalBytes: total, FileCount: fileCount, TopFiles: files}
+	if docs > 0 {
+		out.BytesPerDoc = float64(total) / float64(docs)
+	}
+	return out, nil
+}
+
+func timing(d time.Duration, ops int) timingSummary {
+	out := timingSummary{Seconds: d.Seconds()}
+	if ops > 0 && d > 0 {
+		out.SecPerOp = d.Seconds() / float64(ops)
+		out.OpsPerSec = float64(ops) / d.Seconds()
+	}
+	return out
+}
+
+func startCPUProfile(path string) (func(), error) {
+	if strings.TrimSpace(path) == "" {
+		return func() {}, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create CPU profile dir: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("create CPU profile: %w", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("start CPU profile: %w", err)
+	}
+	stopped := false
+	return func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		pprof.StopCPUProfile()
+		_ = f.Close()
+	}, nil
+}
+
+func writeMemProfile(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create heap profile dir: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create heap profile: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	runtime.GC()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		return fmt.Errorf("write heap profile: %w", err)
+	}
+	return nil
+}
+
+func printHumanSummary(w io.Writer, summary loadSummary) {
+	fmt.Fprintf(w, "TreeDB collection load fixture\n")
+	fmt.Fprintf(w, "dir: %s\n", summary.Dir)
+	fmt.Fprintf(w, "collection: %s\n", summary.Collection)
+	fmt.Fprintf(w, "shape: format=%s indexes=%d data_outer_leaves_in_vlog=%t index_outer_leaves_in_vlog=%t profile=%s\n",
+		summary.DocumentFormat, summary.IndexCount, summary.DataOuterLeavesInValueLog, summary.IndexOuterLeavesInValueLog, summary.Profile)
+	fmt.Fprintf(w, "loaded: docs=%d batches=%d batch_size=%d\n", summary.Docs, summary.Batches, summary.BatchSize)
+	printTiming(w, "wall", summary.WallTiming)
+	printTiming(w, "document generation", summary.GenerationTiming)
+	printTiming(w, "insert", summary.InsertTiming)
+	if summary.CheckpointTiming.Seconds > 0 {
+		printTiming(w, "checkpoint", summary.CheckpointTiming)
+	}
+	fmt.Fprintf(w, "disk before maintenance: %s total, %.2f bytes/doc, %d files\n",
+		humanBytes(summary.DiskUsageBeforeMaintenance.TotalBytes), summary.DiskUsageBeforeMaintenance.BytesPerDoc, summary.DiskUsageBeforeMaintenance.FileCount)
+	if summary.Rewrite.Enabled {
+		fmt.Fprintf(w, "vlog rewrite: before=%s after_rewrite=%s after_gc=%s copied_records=%d copied_value_bytes=%s\n",
+			humanBytes(summary.Rewrite.DiskBytesBefore),
+			humanBytes(summary.Rewrite.DiskBytesAfterRewrite),
+			humanBytes(summary.Rewrite.DiskBytesAfterGC),
+			summary.Rewrite.RecordsCopied,
+			humanBytes(uint64(max(summary.Rewrite.ValueBytesCopied, 0))))
+	}
+	fmt.Fprintf(w, "disk final: %s total, %.2f bytes/doc, %d files\n",
+		humanBytes(summary.DiskUsageFinal.TotalBytes), summary.DiskUsageFinal.BytesPerDoc, summary.DiskUsageFinal.FileCount)
+	if summary.Verify.Enabled {
+		fmt.Fprintf(w, "reopen verify: %d sampled primary/index reads passed\n", summary.Verify.Samples)
+	}
+	if len(summary.DiskUsageFinal.TopFiles) > 0 {
+		fmt.Fprintf(w, "largest files:\n")
+		for _, file := range summary.DiskUsageFinal.TopFiles {
+			fmt.Fprintf(w, "  %12s  %s\n", humanBytes(file.Bytes), file.Path)
+		}
+	}
+	if summary.CPUProfile != "" {
+		fmt.Fprintf(w, "cpu profile: %s\n", summary.CPUProfile)
+	}
+	if summary.MemProfile != "" {
+		fmt.Fprintf(w, "heap profile: %s\n", summary.MemProfile)
+	}
+}
+
+func printTiming(w io.Writer, label string, t timingSummary) {
+	fmt.Fprintf(w, "%s: %.3fs, %.9f sec/op, %.0f ops/sec\n", label, t.Seconds, t.SecPerOp, t.OpsPerSec)
+}
+
+func humanBytes(n uint64) string {
+	const unit = 1024
+	if n < unit {
+		return strconv.FormatUint(n, 10) + " B"
+	}
+	div, exp := uint64(unit), 0
+	for value := n / unit; value >= unit; value /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -69,6 +70,30 @@ func TestRunFixtureKeepsTemplateV1TwoIndexDatabase(t *testing.T) {
 	}
 }
 
+func TestRunFixtureKeepsTemplateV1ThreeIndexDatabase(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "fixture")
+	cfg, err := parseConfig([]string{
+		"-dir", dir,
+		"-docs", "16",
+		"-batch-size", "5",
+		"-indexes", "3",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	summary, err := runFixture(cfg)
+	if err != nil {
+		t.Fatalf("run fixture: %v", err)
+	}
+	if summary.IndexCount != 3 {
+		t.Fatalf("index count=%d want 3", summary.IndexCount)
+	}
+	if summary.Verify.Samples == 0 {
+		t.Fatal("expected reopen verification samples")
+	}
+}
+
 func TestRunFixtureRejectsNonEmptyDirectoryUnlessReset(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "sentinel"), []byte("x"), 0o644); err != nil {
@@ -90,5 +115,30 @@ func TestContainsDocumentID(t *testing.T) {
 	}
 	if containsDocumentID(ids, []byte("u-000000002")) {
 		t.Fatal("unexpected non-matching id")
+	}
+}
+
+func TestTemplateV1StoredDocumentExtractsInputEnvelope(t *testing.T) {
+	var encoder collections.TemplateV1Encoder
+	raw, err := document(collections.DocumentFormatTemplateV1, &encoder, 7)
+	if err != nil {
+		t.Fatalf("document: %v", err)
+	}
+	stored, err := templateV1StoredDocument(raw)
+	if err != nil {
+		t.Fatalf("stored document: %v", err)
+	}
+	if !bytes.HasPrefix(stored, []byte("TD1D")) {
+		t.Fatalf("stored document prefix=%q want TD1D", string(stored[:4]))
+	}
+	if bytes.HasPrefix(stored, []byte("TD1I")) {
+		t.Fatal("expected template-v1 input envelope to be stripped")
+	}
+	again, err := templateV1StoredDocument(stored)
+	if err != nil {
+		t.Fatalf("stored document idempotence: %v", err)
+	}
+	if !bytes.Equal(again, stored) {
+		t.Fatal("stored document conversion changed an already-stored payload")
 	}
 }

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -82,3 +82,13 @@ func TestRunFixtureRejectsNonEmptyDirectoryUnlessReset(t *testing.T) {
 		t.Fatal("expected non-empty fixture dir to fail without -reset")
 	}
 }
+
+func TestContainsDocumentID(t *testing.T) {
+	ids := [][]byte{[]byte("u-000000001"), []byte("u-000000064")}
+	if !containsDocumentID(ids, []byte("u-000000064")) {
+		t.Fatal("expected matching id")
+	}
+	if containsDocumentID(ids, []byte("u-000000002")) {
+		t.Fatal("unexpected non-matching id")
+	}
+}

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+func TestParseConfigDefaultsToInspectableTwoIndexTemplateFixture(t *testing.T) {
+	cfg, err := parseConfig(nil, io.Discard)
+	if err != nil {
+		t.Fatalf("parse defaults: %v", err)
+	}
+	if cfg.DocumentFormat != collections.DocumentFormatTemplateV1 {
+		t.Fatalf("document format=%q want template-v1", cfg.DocumentFormat)
+	}
+	if cfg.IndexCount != 2 {
+		t.Fatalf("index count=%d want 2", cfg.IndexCount)
+	}
+	if !cfg.DataOuterLeavesInValueLog {
+		t.Fatal("expected data outer leaves in value log by default")
+	}
+	if !cfg.IndexOuterLeavesInValueLog {
+		t.Fatal("expected index outer leaves in value log by default")
+	}
+	if !cfg.Checkpoint || !cfg.ReopenVerify {
+		t.Fatalf("checkpoint=%t reopen_verify=%t want both true", cfg.Checkpoint, cfg.ReopenVerify)
+	}
+}
+
+func TestRunFixtureKeepsTemplateV1TwoIndexDatabase(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "fixture")
+	cfg, err := parseConfig([]string{
+		"-dir", dir,
+		"-docs", "24",
+		"-batch-size", "7",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	summary, err := runFixture(cfg)
+	if err != nil {
+		t.Fatalf("run fixture: %v", err)
+	}
+	if summary.Dir != dir {
+		t.Fatalf("dir=%q want %q", summary.Dir, dir)
+	}
+	if summary.Docs != 24 || summary.Batches != 4 {
+		t.Fatalf("docs=%d batches=%d want docs=24 batches=4", summary.Docs, summary.Batches)
+	}
+	if summary.Verify.Samples == 0 {
+		t.Fatal("expected reopen verification samples")
+	}
+	if summary.DiskUsageFinal.TotalBytes == 0 {
+		t.Fatal("expected final disk usage")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "maindb", "index.db")); err != nil {
+		t.Fatalf("expected kept maindb/index.db: %v", err)
+	}
+}
+
+func TestRunFixtureRejectsNonEmptyDirectoryUnlessReset(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "sentinel"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	cfg, err := parseConfig([]string{"-dir", dir, "-docs", "1", "-progress=false"}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if _, err := runFixture(cfg); err == nil {
+		t.Fatal("expected non-empty fixture dir to fail without -reset")
+	}
+}

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+func TestParseConfigDefaultsToInspectableTwoIndexTemplateFixture(t *testing.T) {
+	cfg, err := parseConfig(nil, io.Discard)
+	if err != nil {
+		t.Fatalf("parse defaults: %v", err)
+	}
+	if cfg.DocumentFormat != collections.DocumentFormatTemplateV1 {
+		t.Fatalf("document format=%q want template-v1", cfg.DocumentFormat)
+	}
+	if cfg.IndexCount != 2 {
+		t.Fatalf("index count=%d want 2", cfg.IndexCount)
+	}
+	if !cfg.DataOuterLeavesInValueLog {
+		t.Fatal("expected data outer leaves in value log by default")
+	}
+	if !cfg.IndexOuterLeavesInValueLog {
+		t.Fatal("expected index outer leaves in value log by default")
+	}
+	if !cfg.Checkpoint || !cfg.ReopenVerify {
+		t.Fatalf("checkpoint=%t reopen_verify=%t want both true", cfg.Checkpoint, cfg.ReopenVerify)
+	}
+}
+
+func TestParseConfigRejectsExplicitEmptyFormat(t *testing.T) {
+	if _, err := parseConfig([]string{"-format", ""}, io.Discard); err == nil {
+		t.Fatal("expected explicit empty -format to fail")
+	}
+}
+
+func TestRunFixtureKeepsTemplateV1TwoIndexDatabase(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "fixture")
+	cfg, err := parseConfig([]string{
+		"-dir", dir,
+		"-docs", "24",
+		"-batch-size", "7",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	summary, err := runFixture(cfg)
+	if err != nil {
+		t.Fatalf("run fixture: %v", err)
+	}
+	if summary.Dir != dir {
+		t.Fatalf("dir=%q want %q", summary.Dir, dir)
+	}
+	if summary.Docs != 24 || summary.Batches != 4 {
+		t.Fatalf("docs=%d batches=%d want docs=24 batches=4", summary.Docs, summary.Batches)
+	}
+	if summary.Verify.Samples == 0 {
+		t.Fatal("expected reopen verification samples")
+	}
+	if summary.DiskUsageFinal.TotalBytes == 0 {
+		t.Fatal("expected final disk usage")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "maindb", "index.db")); err != nil {
+		t.Fatalf("expected kept maindb/index.db: %v", err)
+	}
+}
+
+func TestRunFixtureRejectsNonEmptyDirectoryUnlessReset(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "sentinel"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	cfg, err := parseConfig([]string{"-dir", dir, "-docs", "1", "-progress=false"}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if _, err := runFixture(cfg); err == nil {
+		t.Fatal("expected non-empty fixture dir to fail without -reset")
+	}
+}


### PR DESCRIPTION
## Summary
- add `collection-load-fixture`, a kept TreeDB collection loader for inspecting on-disk data after the benchmark-shaped two-index insert path
- default the fixture to the requested shape: `template-v1`, two secondary indexes, collection data/index-state outer leaves in the value log, and secondary-index outer leaves in the value log
- add JSON/human summaries with sec/op and ops/sec, disk usage/top files, reopen verification, optional value-log rewrite/GC, and optional CPU/heap profiles
- add `make collection-load-fixture` and command docs

## Example
```sh
make collection-load-fixture
./bin/collection-load-fixture \
  -dir /tmp/treedb_two_index_template_v1_index_vlog \
  -reset \
  -docs 1000000 \
  -batch-size 8000
```

If `-dir` is omitted, the fixture creates a kept OS temp directory and prints the path.

## Local validation
- `go test ./cmd/collection_load_fixture`
- `make collection-load-fixture`
- `go test ./...`
- `go vet ./...`
- `bash ./scripts/docs_check.sh`
- smoke run: `./bin/collection-load-fixture -dir /tmp/treedb_collection_fixture_smoke -reset -docs 100 -batch-size 20 -progress=false`
