### PR TITLE
Make value-log maintenance collection-aware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ HASHDB_DIR := HashDB
 TREEDB_DIR := TreeDB
 UNIFIED_BENCH_DIR := cmd/unified_bench
 BENCHPROF_DIR := cmd/benchprof
+COLLECTION_LOAD_FIXTURE_DIR := cmd/collection_load_fixture
 BIN_DIR := bin
 
 BENCH_KEYCOUNTS ?= 1,10,100,1000,10000,100000,1000000
@@ -27,6 +28,7 @@ help:
 	@echo "  make benchmark-all  - run HashDB redis-benchmark suite (legacy)"
 	@echo "  make unified-bench  - build unified bench binary"
 	@echo "  make benchprof      - build profile analyzer binary"
+	@echo "  make collection-load-fixture - build kept TreeDB collection load fixture"
 	@echo "  make clean          - remove ./$(BIN_DIR) and temp dirs"
 
 .PHONY: fmt
@@ -84,8 +86,8 @@ deps:
 docs-check:
 	bash ./scripts/docs_check.sh
 
-.PHONY: build build-hashdb build-treedb treemap treemap-bin unified-bench benchprof
-build: build-hashdb build-treedb unified-bench benchprof
+.PHONY: build build-hashdb build-treedb treemap treemap-bin unified-bench benchprof collection-load-fixture
+build: build-hashdb build-treedb unified-bench benchprof collection-load-fixture
 
 build-hashdb:
 	mkdir -p $(BIN_DIR)
@@ -115,6 +117,10 @@ unified-bench:
 benchprof:
 	mkdir -p $(BIN_DIR)
 	cd $(BENCHPROF_DIR) && go build -o ../../$(BIN_DIR)/benchprof .
+
+collection-load-fixture:
+	mkdir -p $(BIN_DIR)
+	cd $(COLLECTION_LOAD_FIXTURE_DIR) && go build -o ../../$(BIN_DIR)/collection-load-fixture .
 
 .PHONY: bench bench-readme
 bench: unified-bench

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -576,15 +576,12 @@ func (db *DB) Stats() map[string]string {
 	writeLeafGenerationMetrics(stats, db.collectLeafGenerationMetrics(state.ValueLogSet, snap.leafGenerationPinnedIDs))
 
 	stats["treedb.pages.total"] = fmt.Sprintf("%d", idx.pager.PageCount())
-	if fs, err := idx.allocator.Stats(idx.pager.PageCount()); err == nil {
-		stats["treedb.freelist.reclaimable_pages"] = fmt.Sprintf("%d", fs.ReclaimablePages())
-		stats["treedb.freelist.alloc_pages_total"] = fmt.Sprintf("%d", fs.AllocPages)
-		stats["treedb.freelist.append_alloc_pages_total"] = fmt.Sprintf("%d", fs.AppendAllocPages)
-		stats["treedb.freelist.reuse_alloc_pages_total"] = fmt.Sprintf("%d", fs.ReuseAllocPages)
-		stats["treedb.freelist.free_pages_total"] = fmt.Sprintf("%d", fs.FreePages)
-	} else {
-		stats["treedb.freelist.error"] = err.Error()
-	}
+	fs := idx.allocator.Counters()
+	stats["treedb.freelist.head"] = fmt.Sprintf("%d", fs.Head)
+	stats["treedb.freelist.alloc_pages_total"] = fmt.Sprintf("%d", fs.AllocPages)
+	stats["treedb.freelist.append_alloc_pages_total"] = fmt.Sprintf("%d", fs.AppendAllocPages)
+	stats["treedb.freelist.reuse_alloc_pages_total"] = fmt.Sprintf("%d", fs.ReuseAllocPages)
+	stats["treedb.freelist.free_pages_total"] = fmt.Sprintf("%d", fs.FreePages)
 	graveyard := idx.graveyard.Stats()
 	stats["treedb.graveyard.batches"] = fmt.Sprintf("%d", graveyard.Batches)
 	stats["treedb.graveyard.pages"] = fmt.Sprintf("%d", graveyard.Pages)

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -568,10 +568,26 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.commit_seq"] = fmt.Sprintf("%d", state.CommitSeq)
 	stats["treedb.root_page"] = fmt.Sprintf("%d", state.RootPageID)
 	stats["treedb.system_root_page"] = fmt.Sprintf("%d", state.SystemRootPageID)
+	stats["treedb.keep_recent"] = fmt.Sprintf("%d", db.keepRecent)
+	stats["treedb.prefer_append_alloc"] = fmt.Sprintf("%t", db.preferAppendAlloc)
+	stats["treedb.freelist_region_pages"] = fmt.Sprintf("%d", db.freelistRegionPages)
+	stats["treedb.freelist_region_radius"] = fmt.Sprintf("%d", db.freelistRegionRadius)
 
 	writeLeafGenerationMetrics(stats, db.collectLeafGenerationMetrics(state.ValueLogSet, snap.leafGenerationPinnedIDs))
 
 	stats["treedb.pages.total"] = fmt.Sprintf("%d", idx.pager.PageCount())
+	if fs, err := idx.allocator.Stats(idx.pager.PageCount()); err == nil {
+		stats["treedb.freelist.reclaimable_pages"] = fmt.Sprintf("%d", fs.ReclaimablePages())
+		stats["treedb.freelist.alloc_pages_total"] = fmt.Sprintf("%d", fs.AllocPages)
+		stats["treedb.freelist.append_alloc_pages_total"] = fmt.Sprintf("%d", fs.AppendAllocPages)
+		stats["treedb.freelist.reuse_alloc_pages_total"] = fmt.Sprintf("%d", fs.ReuseAllocPages)
+		stats["treedb.freelist.free_pages_total"] = fmt.Sprintf("%d", fs.FreePages)
+	} else {
+		stats["treedb.freelist.error"] = err.Error()
+	}
+	graveyard := idx.graveyard.Stats()
+	stats["treedb.graveyard.batches"] = fmt.Sprintf("%d", graveyard.Batches)
+	stats["treedb.graveyard.pages"] = fmt.Sprintf("%d", graveyard.Pages)
 	// PR1 generational scaffolding (backend/read-only path). Cached mode exports
 	// richer live counters; backend path reports stable defaults.
 	stats["treedb.vlog_generation.enabled"] = "false"

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -30,7 +30,7 @@ import (
 const (
 	MetaPage0ID = 0
 	MetaPage1ID = 1
-	KeepRecent  = 10000
+	KeepRecent  = 1
 
 	closeSnapshotDrainTimeout = 10 * time.Second
 	closeSnapshotDrainSleep   = 500 * time.Microsecond
@@ -593,7 +593,7 @@ type Options struct {
 	//
 	// Values <= 0 use a default of 64KiB.
 	TemplateDBChunkSize int64
-	KeepRecent          uint64 // Default 10000
+	KeepRecent          uint64 // Default 1
 	// PagerSyncConcurrency controls how many goroutines may msync dirty chunks
 	// in parallel during Sync. Values <= 0 use the default (1).
 	PagerSyncConcurrency int
@@ -1025,7 +1025,7 @@ func Open(opts Options) (*DB, error) {
 		opts.ChunkSize = defaultChunkSize
 	}
 	if opts.KeepRecent == 0 {
-		opts.KeepRecent = 10000
+		opts.KeepRecent = KeepRecent
 	}
 	if opts.LeafFillTargetPPM == 0 {
 		opts.LeafFillTargetPPM = 1_000_000

--- a/TreeDB/db/fragmentation.go
+++ b/TreeDB/db/fragmentation.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 // FragmentationReport returns best-effort structural stats about the user index
@@ -106,6 +107,10 @@ func (db *DB) FragmentationReport() (map[string]string, error) {
 
 	fs, err := idx.allocator.Stats(totalPages)
 	out["treedb.freelist.head"] = fmt.Sprintf("%d", fs.Head)
+	out["treedb.freelist.alloc_pages_total"] = fmt.Sprintf("%d", fs.AllocPages)
+	out["treedb.freelist.append_alloc_pages_total"] = fmt.Sprintf("%d", fs.AppendAllocPages)
+	out["treedb.freelist.reuse_alloc_pages_total"] = fmt.Sprintf("%d", fs.ReuseAllocPages)
+	out["treedb.freelist.free_pages_total"] = fmt.Sprintf("%d", fs.FreePages)
 	if fs.Head != 0 && totalPages > 0 {
 		if err != nil {
 			out["treedb.freelist.error"] = err.Error()
@@ -117,7 +122,107 @@ func (db *DB) FragmentationReport() (map[string]string, error) {
 		}
 	}
 
+	graveyard := idx.graveyard.Stats()
+	out["treedb.graveyard.batches"] = fmt.Sprintf("%d", graveyard.Batches)
+	out["treedb.graveyard.pages"] = fmt.Sprintf("%d", graveyard.Pages)
+	out["treedb.graveyard.min_seq"] = fmt.Sprintf("%d", graveyard.MinSeq)
+	out["treedb.graveyard.max_seq"] = fmt.Sprintf("%d", graveyard.MaxSeq)
+
+	if collection, err := collectionRootFragmentationStats(idx, snap.state); err != nil {
+		out["treedb.collection_roots.error"] = err.Error()
+	} else {
+		collection.into(out)
+	}
+
 	return out, nil
+}
+
+type collectionRootFragmentation struct {
+	roots            uint64
+	leafRefRoots     uint64
+	pagerRoots       uint64
+	pages            uint64
+	leafPages        uint64
+	internalPages    uint64
+	uniquePageIDs    map[uint64]struct{}
+	duplicatePages   uint64
+	minPageID        uint64
+	maxPageID        uint64
+	hasPagerBackedID bool
+}
+
+func collectionRootFragmentationStats(idx *indexGen, state *DBState) (collectionRootFragmentation, error) {
+	out := collectionRootFragmentation{uniquePageIDs: make(map[uint64]struct{})}
+	if idx == nil || idx.pager == nil || state == nil || state.SystemRootPageID == 0 {
+		return out, nil
+	}
+	reader := newValueReader(state.ValueLogSet)
+	descriptors, err := vacuumCollectCollectionRootDescriptors(idx.pager, reader, state.SystemRootPageID)
+	if err != nil {
+		return out, err
+	}
+	out.roots = uint64(len(descriptors))
+	for _, descriptor := range descriptors {
+		rootID := descriptor.rootID
+		if rootID == 0 {
+			continue
+		}
+		if _, ok := page.DecodeLeafRef(rootID); ok {
+			out.leafRefRoots++
+			continue
+		}
+		out.pagerRoots++
+		tr := tree.New(idx.pager, reader, rootID)
+		if err := tr.WalkPages(func(pageID uint64, n node.Node) error {
+			if _, seen := out.uniquePageIDs[pageID]; seen {
+				out.duplicatePages++
+				return nil
+			}
+			out.uniquePageIDs[pageID] = struct{}{}
+			out.pages++
+			if !out.hasPagerBackedID {
+				out.minPageID = pageID
+				out.maxPageID = pageID
+				out.hasPagerBackedID = true
+			} else {
+				if pageID < out.minPageID {
+					out.minPageID = pageID
+				}
+				if pageID > out.maxPageID {
+					out.maxPageID = pageID
+				}
+			}
+			switch n.Type() {
+			case page.PageTypeLeaf:
+				out.leafPages++
+			case page.PageTypeInternal:
+				out.internalPages++
+			}
+			return nil
+		}); err != nil {
+			return out, err
+		}
+	}
+	return out, nil
+}
+
+func (c collectionRootFragmentation) into(out map[string]string) {
+	out["treedb.collection_roots.count"] = fmt.Sprintf("%d", c.roots)
+	out["treedb.collection_roots.leafref_roots"] = fmt.Sprintf("%d", c.leafRefRoots)
+	out["treedb.collection_roots.pager_roots"] = fmt.Sprintf("%d", c.pagerRoots)
+	out["treedb.collection_roots.pages"] = fmt.Sprintf("%d", c.pages)
+	out["treedb.collection_roots.pages.leaf"] = fmt.Sprintf("%d", c.leafPages)
+	out["treedb.collection_roots.pages.internal"] = fmt.Sprintf("%d", c.internalPages)
+	out["treedb.collection_roots.pages.duplicate_refs"] = fmt.Sprintf("%d", c.duplicatePages)
+	if c.hasPagerBackedID {
+		out["treedb.collection_roots.pages.min"] = fmt.Sprintf("%d", c.minPageID)
+		out["treedb.collection_roots.pages.max"] = fmt.Sprintf("%d", c.maxPageID)
+		span := (c.maxPageID - c.minPageID) + 1
+		out["treedb.collection_roots.pages.span"] = fmt.Sprintf("%d", span)
+		if c.pages > 0 {
+			out["treedb.collection_roots.pages.span_ratio_ppm"] = fmt.Sprintf("%d", (span*1_000_000)/c.pages)
+		}
+	}
 }
 
 type fillStats struct {

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -704,10 +704,12 @@ func (db *DB) scanLeafGenerationLiveStats(ctx context.Context, snap *Snapshot) (
 		memo:          make(map[uint64]leafGenerationSubtreeStats, 64),
 		cacheEnabled:  !verifyAlways,
 	}
-	for _, rootID := range []uint64{snap.state.RootPageID, snap.state.SystemRootPageID} {
-		if rootID == 0 {
-			continue
-		}
+	roots, err := maintenanceRootsForSnapshot(snap)
+	if err != nil {
+		return leafGenerationLiveScanStats{}, err
+	}
+	for _, root := range roots {
+		rootID := root.rootID
 		if page.IsLeafRefID(rootID) {
 			var err error
 			stats.Generations, err = db.scanLeafGenerationPtrTotals(scan, stats.Generations, page.DecodeLeafRefID(rootID))

--- a/TreeDB/db/maintenance_roots.go
+++ b/TreeDB/db/maintenance_roots.go
@@ -10,9 +10,10 @@ import (
 const collectionRootDescriptorPrefix = vacuumCollectionRootDescriptorPrefix
 
 var collectionRootDescriptorPrefixBytes = vacuumCollectionRootDescriptorPrefixBytes
+var collectionRootDescriptorPrefixEndBytes = vacuumCollectionRootDescriptorPrefixEnd()
 
 func collectionRootDescriptorPrefixEnd() []byte {
-	return vacuumCollectionRootDescriptorPrefixEnd()
+	return collectionRootDescriptorPrefixEndBytes
 }
 
 type maintenanceRootKind uint8

--- a/TreeDB/db/maintenance_roots.go
+++ b/TreeDB/db/maintenance_roots.go
@@ -1,0 +1,80 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/pager"
+	"github.com/snissn/gomap/TreeDB/tree"
+)
+
+const collectionRootDescriptorPrefix = vacuumCollectionRootDescriptorPrefix
+
+var collectionRootDescriptorPrefixBytes = vacuumCollectionRootDescriptorPrefixBytes
+
+func collectionRootDescriptorPrefixEnd() []byte {
+	return vacuumCollectionRootDescriptorPrefixEnd()
+}
+
+type maintenanceRootKind uint8
+
+const (
+	maintenanceRootUser maintenanceRootKind = iota
+	maintenanceRootSystem
+	maintenanceRootCollection
+)
+
+type maintenanceRoot struct {
+	kind          maintenanceRootKind
+	rootID        uint64
+	descriptorKey []byte
+}
+
+func maintenanceRootsForSnapshot(snap *Snapshot) ([]maintenanceRoot, error) {
+	if snap == nil || snap.state == nil || snap.idx == nil || snap.idx.pager == nil {
+		return nil, fmt.Errorf("maintenance roots: missing snapshot state")
+	}
+	return collectMaintenanceRoots(snap.idx.pager, &snap.reader, snap.state)
+}
+
+func collectMaintenanceRoots(p *pager.Pager, reader tree.SlabReader, state *DBState) ([]maintenanceRoot, error) {
+	if state == nil {
+		return nil, fmt.Errorf("maintenance roots: missing db state")
+	}
+	roots := make([]maintenanceRoot, 0, 2)
+	var seen map[uint64]struct{}
+	addRoot := func(kind maintenanceRootKind, rootID uint64, descriptorKey []byte) {
+		if rootID == 0 {
+			return
+		}
+		if seen == nil {
+			seen = make(map[uint64]struct{}, 4)
+		}
+		if _, ok := seen[rootID]; ok {
+			return
+		}
+		seen[rootID] = struct{}{}
+		root := maintenanceRoot{
+			kind:   kind,
+			rootID: rootID,
+		}
+		if len(descriptorKey) > 0 {
+			root.descriptorKey = append([]byte(nil), descriptorKey...)
+		}
+		roots = append(roots, root)
+	}
+
+	addRoot(maintenanceRootUser, state.RootPageID, nil)
+	addRoot(maintenanceRootSystem, state.SystemRootPageID, nil)
+	if state.SystemRootPageID == 0 {
+		return roots, nil
+	}
+
+	descriptors, err := vacuumCollectCollectionRootDescriptors(p, reader, state.SystemRootPageID)
+	if err != nil {
+		return nil, fmt.Errorf("maintenance roots: collect collection root descriptors: %w", err)
+	}
+	for _, descriptor := range descriptors {
+		addRoot(maintenanceRootCollection, descriptor.rootID, descriptor.key)
+	}
+	return roots, nil
+}

--- a/TreeDB/db/maintenance_roots_test.go
+++ b/TreeDB/db/maintenance_roots_test.go
@@ -1,0 +1,330 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+const maintenanceTestCollectionRootKey = "collections/root/users/primary"
+
+func TestMaintenanceRoots_NoCollectionsIncludesUserAndSystem(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if err := d.Set([]byte("user/a"), []byte("uv")); err != nil {
+		t.Fatalf("set user key: %v", err)
+	}
+	if _, err := d.PublishSystemRootIterator(mustFrozenSystemMemtable(t, "sys/a", "sv").NewIterator(nil, nil)); err != nil {
+		t.Fatalf("publish system root: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil || snap.state == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	roots, err := maintenanceRootsForSnapshot(snap)
+	if err != nil {
+		t.Fatalf("maintenanceRootsForSnapshot: %v", err)
+	}
+	requireMaintenanceRoot(t, roots, maintenanceRootUser, snap.state.RootPageID)
+	requireMaintenanceRoot(t, roots, maintenanceRootSystem, snap.state.SystemRootPageID)
+	requireMaintenanceRootCount(t, roots, maintenanceRootCollection, 0)
+}
+
+func TestMaintenanceRoots_IncludesPointerBackedCollectionDescriptor(t *testing.T) {
+	opts := vacuumPointerDescriptorOptions(t.TempDir())
+	d := openVacuumPointerDescriptorFixture(t, opts)
+	defer func() { _ = d.Close() }()
+
+	snap := d.AcquireSnapshot()
+	if snap == nil || snap.state == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	descriptorValue, err := snap.GetAtRoot(snap.state.SystemRootPageID, []byte(maintenanceTestCollectionRootKey))
+	if err != nil {
+		t.Fatalf("read descriptor: %v", err)
+	}
+	rootID := binary.BigEndian.Uint64(descriptorValue)
+	roots, err := maintenanceRootsForSnapshot(snap)
+	if err != nil {
+		t.Fatalf("maintenanceRootsForSnapshot: %v", err)
+	}
+	root := requireMaintenanceRoot(t, roots, maintenanceRootCollection, rootID)
+	if !bytes.Equal(root.descriptorKey, []byte(maintenanceTestCollectionRootKey)) {
+		t.Fatalf("descriptor key=%q want %q", string(root.descriptorKey), maintenanceTestCollectionRootKey)
+	}
+}
+
+func TestMaintenanceRoots_DeduplicatesCollectionRootDescriptors(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	_, rootIDs, err := d.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemMemtable(t, "doc/u1", "document").NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStoragePagerLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenRawMemtable(t,
+			maintenanceTestCollectionRootKey, encodeMaintenanceRootID(rootIDs[0]),
+			"collections/root/users/by-email", encodeMaintenanceRootID(rootIDs[0]),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish roots: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs=%d want 1", len(rootIDs))
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil || snap.state == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	roots, err := maintenanceRootsForSnapshot(snap)
+	if err != nil {
+		t.Fatalf("maintenanceRootsForSnapshot: %v", err)
+	}
+	requireMaintenanceRoot(t, roots, maintenanceRootCollection, rootIDs[0])
+	requireMaintenanceRootCount(t, roots, maintenanceRootCollection, 1)
+}
+
+func TestMaintenanceRoots_MalformedCollectionDescriptorFails(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if _, err := d.PublishSystemRootIterator(mustFrozenRawMemtable(t, maintenanceTestCollectionRootKey, []byte("bad")).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("publish malformed descriptor: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil || snap.state == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	if _, err := maintenanceRootsForSnapshot(snap); err == nil {
+		t.Fatal("maintenanceRootsForSnapshot succeeded with malformed collection descriptor")
+	}
+}
+
+func TestValueLogGC_KeepsSegmentReferencedOnlyByCollectionRoot(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	unreferenced := appendPointersInNewSegment(t, dir, 0, 1, 10_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("unreferenced|"), 64)
+	})[0]
+	referenced := appendPointersInNewSegment(t, dir, 0, 2, 20_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("collection-live|"), 64)
+	})[0]
+	appendPointersInNewSegment(t, dir, 0, 3, 30_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("active-head|"), 64)
+	})
+	referencedID := referenced.FileID
+	unreferencedPath := valueLogSegmentPath(t, dir, unreferenced.FileID)
+	referencedPath := valueLogSegmentPath(t, dir, referencedID)
+
+	publishCollectionPointerRoot(t, d, maintenanceTestCollectionRootKey, referenced)
+
+	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if stats.SegmentsDeleted == 0 {
+		t.Fatalf("expected GC to delete an unreferenced segment, stats=%+v", stats)
+	}
+	if _, err := os.Stat(unreferencedPath); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected unreferenced segment to be removed, err=%v", err)
+	}
+	if _, err := os.Stat(referencedPath); err != nil {
+		t.Fatalf("expected collection-referenced segment %d to remain: %v", referencedID, err)
+	}
+}
+
+func TestValueLogRewritePlanningCountsCollectionRootPointers(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	referenced := appendPointersInNewSegment(t, dir, 0, 1, 10_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("collection-live|"), 64)
+	})[0]
+	publishCollectionPointerRoot(t, d, maintenanceTestCollectionRootKey, referenced)
+
+	liveByID, err := d.estimateValueLogLiveBytesBySegment(context.Background())
+	if err != nil {
+		t.Fatalf("estimateValueLogLiveBytesBySegment: %v", err)
+	}
+	if got := liveByID[referenced.FileID]; got <= 0 {
+		t.Fatalf("live bytes for collection-referenced file %d = %d, want > 0", referenced.FileID, got)
+	}
+
+	liveByChunk, err := d.estimateValueLogLiveBytesByChunk(context.Background(), 16<<20)
+	if err != nil {
+		t.Fatalf("estimateValueLogLiveBytesByChunk: %v", err)
+	}
+	found := false
+	for key, bytesLive := range liveByChunk {
+		if key.fileID == referenced.FileID && bytesLive > 0 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("collection-referenced file %d missing from chunk live-byte estimate: %+v", referenced.FileID, liveByChunk)
+	}
+}
+
+func TestLeafGenerationLiveStatsCountsCollectionLeafRefRoot(t *testing.T) {
+	d, _ := openLeafGenerationGCTestDB(t)
+
+	_, rootIDs, err := d.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemMemtable(t, "doc/u1", "document").NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenRawMemtable(t, maintenanceTestCollectionRootKey, encodeMaintenanceRootID(rootIDs[0])).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish collection leaf-ref root: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs=%d want 1", len(rootIDs))
+	}
+	if _, ok := page.DecodeLeafRef(rootIDs[0]); !ok {
+		t.Fatalf("rootID=%d want leaf-ref root", rootIDs[0])
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil || snap.state == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	if snap.state.LeafGenerations == nil {
+		t.Fatal("expected leaf-generation view")
+	}
+
+	stats, err := d.scanLeafGenerationLiveStats(context.Background(), snap)
+	if err != nil {
+		t.Fatalf("scanLeafGenerationLiveStats: %v", err)
+	}
+	livePages := 0
+	for _, totals := range stats.Generations {
+		livePages += totals.LivePages
+	}
+	if livePages == 0 {
+		t.Fatalf("collection leaf-ref root was not counted in live stats: %+v", stats.Generations)
+	}
+}
+
+func mustFrozenRawMemtable(tb testing.TB, kvs ...any) memtable.Table {
+	tb.Helper()
+	mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		tb.Fatalf("new memtable: %v", err)
+	}
+	for i := 0; i+1 < len(kvs); i += 2 {
+		key, ok := kvs[i].(string)
+		if !ok {
+			tb.Fatalf("key %d has type %T, want string", i, kvs[i])
+		}
+		var value []byte
+		switch v := kvs[i+1].(type) {
+		case string:
+			value = []byte(v)
+		case []byte:
+			value = v
+		default:
+			tb.Fatalf("value %d has type %T, want string or []byte", i+1, kvs[i+1])
+		}
+		mt.Set([]byte(key), value)
+	}
+	mt.Freeze()
+	return mt
+}
+
+func encodeMaintenanceRootID(rootID uint64) []byte {
+	out := make([]byte, 8)
+	binary.BigEndian.PutUint64(out, rootID)
+	return out
+}
+
+func publishCollectionPointerRoot(tb testing.TB, d *DB, descriptorKey string, ptr page.ValuePtr) uint64 {
+	tb.Helper()
+	_, rootIDs, err := d.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemPointerMemtable(tb, "doc/p", ptr).NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStoragePagerLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenRawMemtable(tb, descriptorKey, encodeMaintenanceRootID(rootIDs[0])).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		tb.Fatalf("publish collection pointer root: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		tb.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+	}
+	return rootIDs[0]
+}
+
+func requireMaintenanceRoot(tb testing.TB, roots []maintenanceRoot, kind maintenanceRootKind, rootID uint64) maintenanceRoot {
+	tb.Helper()
+	for _, root := range roots {
+		if root.kind == kind && root.rootID == rootID {
+			return root
+		}
+	}
+	tb.Fatalf("missing maintenance root kind=%d rootID=%d in %+v", kind, rootID, roots)
+	return maintenanceRoot{}
+}
+
+func requireMaintenanceRootCount(tb testing.TB, roots []maintenanceRoot, kind maintenanceRootKind, want int) {
+	tb.Helper()
+	got := 0
+	for _, root := range roots {
+		if root.kind == kind {
+			got++
+		}
+	}
+	if got != want {
+		tb.Fatalf("maintenance root count kind=%d got=%d want=%d roots=%+v", kind, got, want, roots)
+	}
+}
+
+func valueLogSegmentPath(tb testing.TB, dir string, fileID uint32) string {
+	tb.Helper()
+	lane, seq := valuelog.DecodeFileID(fileID)
+	return filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+}

--- a/TreeDB/db/maintenance_roots_test.go
+++ b/TreeDB/db/maintenance_roots_test.go
@@ -170,6 +170,55 @@ func TestValueLogGC_KeepsSegmentReferencedOnlyByCollectionRoot(t *testing.T) {
 	}
 }
 
+func TestValueLogGC_KeepsSegmentMadeReachableBySystemDescriptorOnly(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	unreferenced := appendPointersInNewSegment(t, dir, 0, 1, 10_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("unreferenced|"), 64)
+	})[0]
+	referenced := appendPointersInNewSegment(t, dir, 0, 2, 20_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("descriptor-live|"), 64)
+	})[0]
+	appendPointersInNewSegment(t, dir, 0, 3, 30_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("active-head|"), 64)
+	})
+	unreferencedPath := valueLogSegmentPath(t, dir, unreferenced.FileID)
+	referencedPath := valueLogSegmentPath(t, dir, referenced.FileID)
+
+	collectionRoot, err := d.PublishOrderedRootIterator(0, mustFrozenSystemPointerMemtable(t, "doc/p", referenced).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish unattached collection root: %v", err)
+	}
+	if _, err := d.referencedValueLogSegments(context.Background()); err != nil {
+		t.Fatalf("prime value-log ref tracker: %v", err)
+	}
+	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); !ok {
+		t.Fatal("expected primed value-log ref tracker")
+	}
+	if _, err := d.PublishSystemRootIterator(mustFrozenRawMemtable(t, maintenanceTestCollectionRootKey, encodeMaintenanceRootID(collectionRoot)).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("publish system descriptor: %v", err)
+	}
+
+	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if stats.SegmentsDeleted == 0 {
+		t.Fatalf("expected GC to delete an unreferenced segment, stats=%+v", stats)
+	}
+	if _, err := os.Stat(unreferencedPath); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected unreferenced segment to be removed, err=%v", err)
+	}
+	if _, err := os.Stat(referencedPath); err != nil {
+		t.Fatalf("expected descriptor-referenced segment %d to remain: %v", referenced.FileID, err)
+	}
+}
+
 func TestValueLogRewritePlanningCountsCollectionRootPointers(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/maintenance_roots_test.go
+++ b/TreeDB/db/maintenance_roots_test.go
@@ -219,6 +219,63 @@ func TestValueLogGC_KeepsSegmentMadeReachableBySystemDescriptorOnly(t *testing.T
 	}
 }
 
+func TestValueLogGC_KeepsSegmentMadeReachableByDeltaGroupSystemDescriptorOnly(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	unreferenced := appendPointersInNewSegment(t, dir, 0, 1, 80_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("delta-group-unreferenced|"), 64)
+	})[0]
+	referenced := appendPointersInNewSegment(t, dir, 0, 2, 90_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("delta-group-descriptor-live|"), 64)
+	})[0]
+	appendPointersInNewSegment(t, dir, 0, 3, 100_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("active-head|"), 64)
+	})
+	unreferencedPath := valueLogSegmentPath(t, dir, unreferenced.FileID)
+	referencedPath := valueLogSegmentPath(t, dir, referenced.FileID)
+
+	collectionRoot, err := d.PublishOrderedRootIterator(0, mustFrozenSystemPointerMemtable(t, "doc/p", referenced).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish unattached collection root: %v", err)
+	}
+	if _, err := d.referencedValueLogSegments(context.Background()); err != nil {
+		t.Fatalf("prime value-log ref tracker: %v", err)
+	}
+	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); !ok {
+		t.Fatal("expected primed value-log ref tracker")
+	}
+	if _, _, err := d.PublishOrderedRootDeltaGroupWithSystemBuilder(nil, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 0 {
+			return nil, fmt.Errorf("rootIDs=%d want 0", len(rootIDs))
+		}
+		return mustFrozenRawMemtable(t, maintenanceTestCollectionRootKey, encodeMaintenanceRootID(collectionRoot)).NewIterator(nil, nil), nil
+	}); err != nil {
+		t.Fatalf("publish system descriptor via delta group builder: %v", err)
+	}
+	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); ok {
+		t.Fatal("expected delta group descriptor publish to invalidate value-log ref tracker")
+	}
+
+	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if stats.SegmentsDeleted == 0 {
+		t.Fatalf("expected GC to delete an unreferenced segment, stats=%+v", stats)
+	}
+	if _, err := os.Stat(unreferencedPath); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected unreferenced segment to be removed, err=%v", err)
+	}
+	if _, err := os.Stat(referencedPath); err != nil {
+		t.Fatalf("expected delta-group descriptor-referenced segment %d to remain: %v", referenced.FileID, err)
+	}
+}
+
 func TestValueLogGC_RemovesSegmentAfterSystemDescriptorRemoval(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})
@@ -308,6 +365,57 @@ func TestValueLogGC_RemovesSegmentAfterGroupedSystemDescriptorRemoval(t *testing
 	}
 	if _, err := os.Stat(referencedPath); err == nil || !os.IsNotExist(err) {
 		t.Fatalf("expected grouped removed-descriptor segment to be deleted, err=%v", err)
+	}
+}
+
+func TestValueLogGC_RemovesSegmentAfterDeltaGroupSystemDescriptorRemoval(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	referenced := appendPointersInNewSegment(t, dir, 0, 1, 110_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("delta-group-removed-descriptor-live|"), 64)
+	})[0]
+	appendPointersInNewSegment(t, dir, 0, 2, 120_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("active-head|"), 64)
+	})
+	referencedPath := valueLogSegmentPath(t, dir, referenced.FileID)
+
+	collectionRoot := publishCollectionPointerRoot(t, d, maintenanceTestCollectionRootKey, referenced)
+	refs, err := d.referencedValueLogSegments(context.Background())
+	if err != nil {
+		t.Fatalf("prime value-log ref tracker: %v", err)
+	}
+	if _, ok := refs[referenced.FileID]; !ok {
+		t.Fatalf("expected primed refs to include descriptor-referenced segment %d", referenced.FileID)
+	}
+	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); !ok {
+		t.Fatal("expected primed value-log ref tracker")
+	}
+	if _, _, err := d.PublishOrderedRootDeltaGroupWithSystemBuilder(nil, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 0 {
+			return nil, fmt.Errorf("rootIDs=%d want 0", len(rootIDs))
+		}
+		return mustFrozenRawMemtable(t, "sys/after", encodeMaintenanceRootID(collectionRoot)).NewIterator(nil, nil), nil
+	}); err != nil {
+		t.Fatalf("remove collection descriptor via delta group builder: %v", err)
+	}
+	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); ok {
+		t.Fatal("expected delta group descriptor removal to invalidate value-log ref tracker")
+	}
+
+	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if stats.SegmentsDeleted == 0 {
+		t.Fatalf("expected GC to delete delta group removed-descriptor segment, stats=%+v", stats)
+	}
+	if _, err := os.Stat(referencedPath); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected delta group removed-descriptor segment to be deleted, err=%v", err)
 	}
 }
 

--- a/TreeDB/db/maintenance_roots_test.go
+++ b/TreeDB/db/maintenance_roots_test.go
@@ -266,6 +266,64 @@ func TestValueLogRefTracker_PreservesFastPathForUnchangedCollectionDescriptors(t
 	}
 }
 
+func TestValueLogRefTracker_PreservesFastPathForCollectionDescriptorRepresentationChange(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	referenced := appendPointersInNewSegment(t, dir, 0, 1, 45_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("representation-change-live|"), 64)
+	})[0]
+	collectionRoot, err := d.PublishOrderedRootIterator(0, mustFrozenSystemPointerMemtable(t, "doc/p", referenced).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish collection root: %v", err)
+	}
+	descriptorPtr := appendPointersInNewSegment(t, dir, 0, 2, 46_000, 1, func(int) []byte {
+		return encodeMaintenanceRootID(collectionRoot)
+	})[0]
+	if _, err := d.PublishSystemRootIterator(mustFrozenSystemPointerMemtable(t, maintenanceTestCollectionRootKey, descriptorPtr).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("publish pointer-backed system descriptor: %v", err)
+	}
+	if _, err := d.referencedValueLogSegments(context.Background()); err != nil {
+		t.Fatalf("prime value-log ref tracker: %v", err)
+	}
+	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); !ok {
+		t.Fatal("expected primed value-log ref tracker")
+	}
+
+	if _, err := d.PublishSystemRootIterator(mustFrozenRawMemtable(t,
+		maintenanceTestCollectionRootKey, encodeMaintenanceRootID(collectionRoot),
+		"sys/changed", "value",
+	).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("publish inline system descriptor: %v", err)
+	}
+	seq := d.currentCommitSeq()
+	incRefs, ok := d.valueLogRefTracker.referencedSet(seq)
+	if !ok {
+		t.Fatal("expected descriptor representation change to preserve value-log ref tracker")
+	}
+	fullCounts, fullSeq, err := d.scanValueLogRefCounts(context.Background())
+	if err != nil {
+		t.Fatalf("scanValueLogRefCounts: %v", err)
+	}
+	if fullSeq != seq {
+		t.Fatalf("scan seq mismatch: got=%d want=%d", fullSeq, seq)
+	}
+	fullRefs := valueLogRefSetFromCounts(fullCounts)
+	if !reflect.DeepEqual(incRefs, fullRefs) {
+		t.Fatalf("incremental/full-scan mismatch: incremental=%v full=%v", incRefs, fullRefs)
+	}
+	if _, ok := incRefs[referenced.FileID]; !ok {
+		t.Fatalf("expected collection-referenced segment %d to remain tracked", referenced.FileID)
+	}
+	if _, ok := incRefs[descriptorPtr.FileID]; ok {
+		t.Fatalf("descriptor pointer segment %d remained tracked after inline rewrite", descriptorPtr.FileID)
+	}
+}
+
 func TestValueLogGC_KeepsSegmentMadeReachableByDeltaGroupSystemDescriptorOnly(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/maintenance_roots_test.go
+++ b/TreeDB/db/maintenance_roots_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
@@ -216,6 +217,52 @@ func TestValueLogGC_KeepsSegmentMadeReachableBySystemDescriptorOnly(t *testing.T
 	}
 	if _, err := os.Stat(referencedPath); err != nil {
 		t.Fatalf("expected descriptor-referenced segment %d to remain: %v", referenced.FileID, err)
+	}
+}
+
+func TestValueLogRefTracker_PreservesFastPathForUnchangedCollectionDescriptors(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	referenced := appendPointersInNewSegment(t, dir, 0, 1, 35_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("unchanged-descriptor-live|"), 64)
+	})[0]
+	collectionRoot := publishCollectionPointerRoot(t, d, maintenanceTestCollectionRootKey, referenced)
+	if _, err := d.referencedValueLogSegments(context.Background()); err != nil {
+		t.Fatalf("prime value-log ref tracker: %v", err)
+	}
+	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); !ok {
+		t.Fatal("expected primed value-log ref tracker")
+	}
+
+	if _, err := d.PublishSystemRootIterator(mustFrozenRawMemtable(t,
+		maintenanceTestCollectionRootKey, encodeMaintenanceRootID(collectionRoot),
+		"sys/unchanged", "value",
+	).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("publish unchanged collection descriptor: %v", err)
+	}
+	seq := d.currentCommitSeq()
+	incRefs, ok := d.valueLogRefTracker.referencedSet(seq)
+	if !ok {
+		t.Fatal("expected unchanged descriptor publish to preserve value-log ref tracker")
+	}
+	if _, ok := incRefs[referenced.FileID]; !ok {
+		t.Fatalf("expected incremental refs to include descriptor-referenced segment %d", referenced.FileID)
+	}
+	fullCounts, fullSeq, err := d.scanValueLogRefCounts(context.Background())
+	if err != nil {
+		t.Fatalf("scanValueLogRefCounts: %v", err)
+	}
+	if fullSeq != seq {
+		t.Fatalf("scan seq mismatch: got=%d want=%d", fullSeq, seq)
+	}
+	fullRefs := valueLogRefSetFromCounts(fullCounts)
+	if !reflect.DeepEqual(incRefs, fullRefs) {
+		t.Fatalf("incremental/full-scan mismatch: incremental=%v full=%v", incRefs, fullRefs)
 	}
 }
 

--- a/TreeDB/db/maintenance_roots_test.go
+++ b/TreeDB/db/maintenance_roots_test.go
@@ -219,6 +219,98 @@ func TestValueLogGC_KeepsSegmentMadeReachableBySystemDescriptorOnly(t *testing.T
 	}
 }
 
+func TestValueLogGC_RemovesSegmentAfterSystemDescriptorRemoval(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	referenced := appendPointersInNewSegment(t, dir, 0, 1, 40_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("removed-descriptor-live|"), 64)
+	})[0]
+	appendPointersInNewSegment(t, dir, 0, 2, 50_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("active-head|"), 64)
+	})
+	referencedPath := valueLogSegmentPath(t, dir, referenced.FileID)
+
+	collectionRoot := publishCollectionPointerRoot(t, d, maintenanceTestCollectionRootKey, referenced)
+	refs, err := d.referencedValueLogSegments(context.Background())
+	if err != nil {
+		t.Fatalf("prime value-log ref tracker: %v", err)
+	}
+	if _, ok := refs[referenced.FileID]; !ok {
+		t.Fatalf("expected primed refs to include descriptor-referenced segment %d", referenced.FileID)
+	}
+	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); !ok {
+		t.Fatal("expected primed value-log ref tracker")
+	}
+	if _, err := d.PublishSystemRootIterator(mustFrozenRawMemtable(t, "sys/after", encodeMaintenanceRootID(collectionRoot)).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("remove collection descriptor: %v", err)
+	}
+	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); ok {
+		t.Fatal("expected descriptor removal to invalidate value-log ref tracker")
+	}
+
+	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if stats.SegmentsDeleted == 0 {
+		t.Fatalf("expected GC to delete removed-descriptor segment, stats=%+v", stats)
+	}
+	if _, err := os.Stat(referencedPath); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected removed-descriptor segment to be deleted, err=%v", err)
+	}
+}
+
+func TestValueLogGC_RemovesSegmentAfterGroupedSystemDescriptorRemoval(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	referenced := appendPointersInNewSegment(t, dir, 0, 1, 60_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("grouped-removed-descriptor-live|"), 64)
+	})[0]
+	appendPointersInNewSegment(t, dir, 0, 2, 70_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("active-head|"), 64)
+	})
+	referencedPath := valueLogSegmentPath(t, dir, referenced.FileID)
+
+	collectionRoot := publishCollectionPointerRoot(t, d, maintenanceTestCollectionRootKey, referenced)
+	refs, err := d.referencedValueLogSegments(context.Background())
+	if err != nil {
+		t.Fatalf("prime value-log ref tracker: %v", err)
+	}
+	if _, ok := refs[referenced.FileID]; !ok {
+		t.Fatalf("expected primed refs to include descriptor-referenced segment %d", referenced.FileID)
+	}
+	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); !ok {
+		t.Fatal("expected primed value-log ref tracker")
+	}
+	if _, _, err := d.PublishOrderedRootGroup(mustFrozenRawMemtable(t, "sys/after", encodeMaintenanceRootID(collectionRoot)).NewIterator(nil, nil), nil); err != nil {
+		t.Fatalf("remove collection descriptor via grouped system publish: %v", err)
+	}
+	if _, ok := d.valueLogRefTracker.referencedSet(d.currentCommitSeq()); ok {
+		t.Fatal("expected grouped descriptor removal to invalidate value-log ref tracker")
+	}
+
+	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if stats.SegmentsDeleted == 0 {
+		t.Fatalf("expected GC to delete grouped removed-descriptor segment, stats=%+v", stats)
+	}
+	if _, err := os.Stat(referencedPath); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected grouped removed-descriptor segment to be deleted, err=%v", err)
+	}
+}
+
 func TestValueLogRewritePlanningCountsCollectionRootPointers(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -34,11 +34,12 @@ const (
 var orderedRootDeltaBatchInlineThreshold = int(^uint(0) >> 1)
 
 type orderedRootPublishStats struct {
-	warmAttempts            uint64
-	warmNativeApplyAttempts uint64
-	warmRebuildFallbacks    uint64
-	warmPreservedPages      uint64
-	warmRewrittenPages      uint64
+	warmAttempts                           uint64
+	warmNativeApplyAttempts                uint64
+	warmRebuildFallbacks                   uint64
+	warmPreservedPages                     uint64
+	warmRewrittenPages                     uint64
+	collectionRootDescriptorTargetContains bool
 }
 
 type orderedRootPublishOptions struct {
@@ -202,6 +203,15 @@ func materializeOrderedRootTable(iter iterator.UnsafeIterator) (memtable.Table, 
 	}
 	table.Freeze()
 	return table, nil
+}
+
+func orderedRootTableContainsCollectionRootDescriptor(table memtable.Table) (bool, error) {
+	iter := table.NewIterator(collectionRootDescriptorPrefixBytes, collectionRootDescriptorPrefixEnd())
+	defer func() { _ = iter.Close() }()
+	if iter.Valid() && bytes.HasPrefix(iter.UnsafeKey(), collectionRootDescriptorPrefixBytes) {
+		return true, nil
+	}
+	return false, iter.Error()
 }
 
 func orderedRootEntryEqual(baseIter, targetIter iterator.UnsafeIterator) bool {
@@ -488,6 +498,12 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 			err = materializeErr
 			return
 		}
+		if trackValueLogRefs {
+			stats.collectionRootDescriptorTargetContains, err = orderedRootTableContainsCollectionRootDescriptor(targetTable)
+			if err != nil {
+				return
+			}
+		}
 		if !hasExistingEntries {
 			if trackValueLogRefs {
 				vlogRefDelta, err = collectValueLogRefDeltaFromIterator(targetTable.NewIterator(nil, nil))
@@ -559,6 +575,10 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 			targetTable, materializeErr := materializeOrderedRootTable(iter)
 			if materializeErr != nil {
 				err = materializeErr
+				return
+			}
+			stats.collectionRootDescriptorTargetContains, err = orderedRootTableContainsCollectionRootDescriptor(targetTable)
+			if err != nil {
 				return
 			}
 			vlogRefDelta, err = collectValueLogRefDeltaFromIterator(targetTable.NewIterator(nil, nil))
@@ -965,7 +985,18 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
 	}
 
-	if vlogRefDelta == nil {
+	forceRefTrackerRebuild := len(ordered) > 0 && systemStats.collectionRootDescriptorTargetContains
+	if forceRefTrackerRebuild {
+		// A non-system root became reachable from a collection descriptor. The
+		// system-root ref delta alone is not an exact commit delta for those
+		// newly reachable roots, so force the tracker to rebuild from the full
+		// maintenance root set.
+		if vlogRefDelta != nil {
+			releaseValueLogRefDelta(vlogRefDelta)
+		}
+		vlogRefDelta = nil
+	}
+	if vlogRefDelta == nil && !forceRefTrackerRebuild {
 		vlogRefDelta = db.newNoopValueLogRefDeltaIfTrackable(baseSeq)
 	}
 	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil); err != nil {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -207,10 +207,11 @@ func materializeOrderedRootTable(iter iterator.UnsafeIterator) (memtable.Table, 
 }
 
 type orderedRootCollectionDescriptorEntry struct {
-	key   []byte
-	val   []byte
-	ptr   page.ValuePtr
-	flags byte
+	key        []byte
+	val        []byte
+	ptr        page.ValuePtr
+	flags      byte
+	valueKnown bool
 }
 
 func orderedRootTableCollectionRootDescriptorEntries(table memtable.Table) ([]orderedRootCollectionDescriptorEntry, error) {
@@ -230,12 +231,16 @@ func orderedRootIteratorCollectionRootDescriptorEntries(iter iterator.UnsafeIter
 			break
 		}
 		val, ptr, flags := iter.UnsafeEntry()
-		entry := orderedRootCollectionDescriptorEntry{
-			key:   append([]byte(nil), key...),
-			ptr:   ptr,
-			flags: flags,
+		if flags&node.FlagPointer != 0 && val == nil {
+			val = iter.UnsafeValue()
 		}
-		if flags&node.FlagPointer == 0 {
+		entry := orderedRootCollectionDescriptorEntry{
+			key:        append([]byte(nil), key...),
+			ptr:        ptr,
+			flags:      flags,
+			valueKnown: flags&node.FlagPointer == 0 || val != nil,
+		}
+		if entry.valueKnown {
 			entry.val = append([]byte(nil), val...)
 		}
 		out = append(out, entry)
@@ -249,16 +254,19 @@ func orderedRootCollectionRootDescriptorEntriesEqual(a, b []orderedRootCollectio
 		return false
 	}
 	for i := range a {
-		if !bytes.Equal(a[i].key, b[i].key) || a[i].flags != b[i].flags {
+		if !bytes.Equal(a[i].key, b[i].key) {
 			return false
 		}
-		if a[i].flags&node.FlagPointer != 0 {
-			if a[i].ptr != b[i].ptr {
+		if a[i].valueKnown && b[i].valueKnown {
+			if !bytes.Equal(a[i].val, b[i].val) {
 				return false
 			}
 			continue
 		}
-		if !bytes.Equal(a[i].val, b[i].val) {
+		if a[i].flags != b[i].flags {
+			return false
+		}
+		if a[i].flags&node.FlagPointer != 0 && a[i].ptr != b[i].ptr {
 			return false
 		}
 	}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -34,13 +34,13 @@ const (
 var orderedRootDeltaBatchInlineThreshold = int(^uint(0) >> 1)
 
 type orderedRootPublishStats struct {
-	warmAttempts                           uint64
-	warmNativeApplyAttempts                uint64
-	warmRebuildFallbacks                   uint64
-	warmPreservedPages                     uint64
-	warmRewrittenPages                     uint64
-	collectionRootDescriptorBaseContains   bool
-	collectionRootDescriptorTargetContains bool
+	warmAttempts                          uint64
+	warmNativeApplyAttempts               uint64
+	warmRebuildFallbacks                  uint64
+	warmPreservedPages                    uint64
+	warmRewrittenPages                    uint64
+	collectionRootDescriptorBaseEntries   []orderedRootCollectionDescriptorEntry
+	collectionRootDescriptorTargetEntries []orderedRootCollectionDescriptorEntry
 }
 
 type orderedRootPublishOptions struct {
@@ -206,24 +206,67 @@ func materializeOrderedRootTable(iter iterator.UnsafeIterator) (memtable.Table, 
 	return table, nil
 }
 
-func orderedRootTableContainsCollectionRootDescriptor(table memtable.Table) (bool, error) {
-	iter := table.NewIterator(collectionRootDescriptorPrefixBytes, collectionRootDescriptorPrefixEnd())
-	defer func() { _ = iter.Close() }()
-	return orderedRootIteratorContainsCollectionRootDescriptor(iter)
+type orderedRootCollectionDescriptorEntry struct {
+	key   []byte
+	val   []byte
+	ptr   page.ValuePtr
+	flags byte
 }
 
-func orderedRootIteratorContainsCollectionRootDescriptor(iter iterator.UnsafeIterator) (bool, error) {
+func orderedRootTableCollectionRootDescriptorEntries(table memtable.Table) ([]orderedRootCollectionDescriptorEntry, error) {
+	iter := table.NewIterator(collectionRootDescriptorPrefixBytes, collectionRootDescriptorPrefixEnd())
+	defer func() { _ = iter.Close() }()
+	return orderedRootIteratorCollectionRootDescriptorEntries(iter)
+}
+
+func orderedRootIteratorCollectionRootDescriptorEntries(iter iterator.UnsafeIterator) ([]orderedRootCollectionDescriptorEntry, error) {
 	if iter == nil {
-		return false, nil
+		return nil, nil
 	}
-	if iter.Valid() && bytes.HasPrefix(iter.UnsafeKey(), collectionRootDescriptorPrefixBytes) {
-		return true, nil
+	var out []orderedRootCollectionDescriptorEntry
+	for iter.Valid() {
+		key := iter.UnsafeKey()
+		if !bytes.HasPrefix(key, collectionRootDescriptorPrefixBytes) {
+			break
+		}
+		val, ptr, flags := iter.UnsafeEntry()
+		entry := orderedRootCollectionDescriptorEntry{
+			key:   append([]byte(nil), key...),
+			ptr:   ptr,
+			flags: flags,
+		}
+		if flags&node.FlagPointer == 0 {
+			entry.val = append([]byte(nil), val...)
+		}
+		out = append(out, entry)
+		iter.Next()
 	}
-	return false, iter.Error()
+	return out, iter.Error()
+}
+
+func orderedRootCollectionRootDescriptorEntriesEqual(a, b []orderedRootCollectionDescriptorEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !bytes.Equal(a[i].key, b[i].key) || a[i].flags != b[i].flags {
+			return false
+		}
+		if a[i].flags&node.FlagPointer != 0 {
+			if a[i].ptr != b[i].ptr {
+				return false
+			}
+			continue
+		}
+		if !bytes.Equal(a[i].val, b[i].val) {
+			return false
+		}
+	}
+	return true
 }
 
 func (s orderedRootPublishStats) collectionRootDescriptorReachabilityMayChange() bool {
-	return s.collectionRootDescriptorBaseContains || s.collectionRootDescriptorTargetContains
+	return !orderedRootCollectionRootDescriptorEntriesEqual(s.collectionRootDescriptorBaseEntries, s.collectionRootDescriptorTargetEntries)
 }
 
 func orderedRootEntryEqual(baseIter, targetIter iterator.UnsafeIterator) bool {
@@ -497,7 +540,7 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 		}
 		if trackValueLogRefs {
 			baseDescriptorIter := rootTree.Iterator(collectionRootDescriptorPrefixBytes, collectionRootDescriptorPrefixEnd())
-			stats.collectionRootDescriptorBaseContains, err = orderedRootIteratorContainsCollectionRootDescriptor(baseDescriptorIter)
+			stats.collectionRootDescriptorBaseEntries, err = orderedRootIteratorCollectionRootDescriptorEntries(baseDescriptorIter)
 			_ = baseDescriptorIter.Close()
 			if err != nil {
 				return
@@ -519,7 +562,7 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 			return
 		}
 		if trackValueLogRefs {
-			stats.collectionRootDescriptorTargetContains, err = orderedRootTableContainsCollectionRootDescriptor(targetTable)
+			stats.collectionRootDescriptorTargetEntries, err = orderedRootTableCollectionRootDescriptorEntries(targetTable)
 			if err != nil {
 				return
 			}
@@ -597,7 +640,7 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 				err = materializeErr
 				return
 			}
-			stats.collectionRootDescriptorTargetContains, err = orderedRootTableContainsCollectionRootDescriptor(targetTable)
+			stats.collectionRootDescriptorTargetEntries, err = orderedRootTableCollectionRootDescriptorEntries(targetTable)
 			if err != nil {
 				return
 			}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -39,6 +39,7 @@ type orderedRootPublishStats struct {
 	warmRebuildFallbacks                   uint64
 	warmPreservedPages                     uint64
 	warmRewrittenPages                     uint64
+	collectionRootDescriptorBaseContains   bool
 	collectionRootDescriptorTargetContains bool
 }
 
@@ -208,10 +209,21 @@ func materializeOrderedRootTable(iter iterator.UnsafeIterator) (memtable.Table, 
 func orderedRootTableContainsCollectionRootDescriptor(table memtable.Table) (bool, error) {
 	iter := table.NewIterator(collectionRootDescriptorPrefixBytes, collectionRootDescriptorPrefixEnd())
 	defer func() { _ = iter.Close() }()
+	return orderedRootIteratorContainsCollectionRootDescriptor(iter)
+}
+
+func orderedRootIteratorContainsCollectionRootDescriptor(iter iterator.UnsafeIterator) (bool, error) {
+	if iter == nil {
+		return false, nil
+	}
 	if iter.Valid() && bytes.HasPrefix(iter.UnsafeKey(), collectionRootDescriptorPrefixBytes) {
 		return true, nil
 	}
 	return false, iter.Error()
+}
+
+func (s orderedRootPublishStats) collectionRootDescriptorReachabilityMayChange() bool {
+	return s.collectionRootDescriptorBaseContains || s.collectionRootDescriptorTargetContains
 }
 
 func orderedRootEntryEqual(baseIter, targetIter iterator.UnsafeIterator) bool {
@@ -482,6 +494,14 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 		rootTree := tree.New(idx.pager, newValueReader(state.ValueLogSet), baseRoot)
 		collectBasePageIDs := func() ([]uint64, error) {
 			return rootTree.CollectPageIDs()
+		}
+		if trackValueLogRefs {
+			baseDescriptorIter := rootTree.Iterator(collectionRootDescriptorPrefixBytes, collectionRootDescriptorPrefixEnd())
+			stats.collectionRootDescriptorBaseContains, err = orderedRootIteratorContainsCollectionRootDescriptor(baseDescriptorIter)
+			_ = baseDescriptorIter.Close()
+			if err != nil {
+				return
+			}
 		}
 
 		baseProbe := rootTree.Iterator(nil, nil)
@@ -985,7 +1005,7 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
 	}
 
-	forceRefTrackerRebuild := systemStats.collectionRootDescriptorTargetContains
+	forceRefTrackerRebuild := systemStats.collectionRootDescriptorReachabilityMayChange()
 	if forceRefTrackerRebuild {
 		// Collection descriptors make non-system roots part of value-log
 		// reachability. The system-root ref delta alone is not an exact commit

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -985,11 +985,11 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
 	}
 
-	forceRefTrackerRebuild := len(ordered) > 0 && systemStats.collectionRootDescriptorTargetContains
+	forceRefTrackerRebuild := systemStats.collectionRootDescriptorTargetContains
 	if forceRefTrackerRebuild {
-		// A non-system root became reachable from a collection descriptor. The
-		// system-root ref delta alone is not an exact commit delta for those
-		// newly reachable roots, so force the tracker to rebuild from the full
+		// Collection descriptors make non-system roots part of value-log
+		// reachability. The system-root ref delta alone is not an exact commit
+		// delta for those roots, so force the tracker to rebuild from the full
 		// maintenance root set.
 		if vlogRefDelta != nil {
 			releaseValueLogRefDelta(vlogRefDelta)

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -789,7 +789,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	if iter == nil {
 		return 0, nil, errors.New("nil system root iterator")
 	}
-	rootID, rootRetired, metrics, _, refDelta, err := db.publishOrderedRootIterator(baseSystemRoot, iter, systemOpts, true)
+	rootID, rootRetired, metrics, publishStats, refDelta, err := db.publishOrderedRootIterator(baseSystemRoot, iter, systemOpts, true)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -797,9 +797,12 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	retired = append(retired, rootRetired...)
 	mergeOrderedRootPublishMetrics(&merged, metrics)
 	vlogRefDelta := refDelta
-	if len(ordered) > 0 {
+	forceRefTrackerRebuild := publishStats.collectionRootDescriptorReachabilityMayChange()
+	if len(ordered) > 0 || forceRefTrackerRebuild {
 		// Non-system roots were applied from deltas, so this commit has no
-		// exact value-log ref delta for their pointer changes. Keep GC
+		// exact value-log ref delta for their pointer changes. Collection
+		// descriptors also make non-system roots part of reachability, and the
+		// system-root ref delta is not exact for those roots. Keep GC
 		// reachability conservative by invalidating the tracker after commit.
 		if vlogRefDelta != nil {
 			releaseValueLogRefDelta(vlogRefDelta)
@@ -820,7 +823,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
 	}
 
-	if len(ordered) == 0 && vlogRefDelta == nil {
+	if len(ordered) == 0 && !forceRefTrackerRebuild && vlogRefDelta == nil {
 		vlogRefDelta = db.newNoopValueLogRefDeltaIfTrackable(baseSeq)
 	}
 	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil); err != nil {

--- a/TreeDB/db/system_root_publish.go
+++ b/TreeDB/db/system_root_publish.go
@@ -87,6 +87,12 @@ func (db *DB) PublishSystemRootIterator(iter iterator.UnsafeIterator) (uint64, e
 	db.systemRootWarmPublishRebuildFallbacks.Add(publishStats.warmRebuildFallbacks)
 	db.systemRootWarmPreservedPages.Add(publishStats.warmPreservedPages)
 	db.systemRootWarmRewrittenPages.Add(publishStats.warmRewrittenPages)
+	if publishStats.collectionRootDescriptorTargetContains {
+		if vlogRefDelta != nil {
+			releaseValueLogRefDelta(vlogRefDelta)
+		}
+		vlogRefDelta = nil
+	}
 
 	db.mu.Lock()
 	curUserRoot := db.meta.UserRootPageID

--- a/TreeDB/db/system_root_publish.go
+++ b/TreeDB/db/system_root_publish.go
@@ -87,7 +87,7 @@ func (db *DB) PublishSystemRootIterator(iter iterator.UnsafeIterator) (uint64, e
 	db.systemRootWarmPublishRebuildFallbacks.Add(publishStats.warmRebuildFallbacks)
 	db.systemRootWarmPreservedPages.Add(publishStats.warmPreservedPages)
 	db.systemRootWarmRewrittenPages.Add(publishStats.warmRewrittenPages)
-	if publishStats.collectionRootDescriptorTargetContains {
+	if publishStats.collectionRootDescriptorReachabilityMayChange() {
 		if vlogRefDelta != nil {
 			releaseValueLogRefDelta(vlogRefDelta)
 		}

--- a/TreeDB/db/vacuum_collection_roots.go
+++ b/TreeDB/db/vacuum_collection_roots.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/snissn/gomap/TreeDB/internal/bulk"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
@@ -16,18 +17,32 @@ import (
 
 const vacuumCollectionRootDescriptorPrefix = "collections/root/"
 
+var vacuumCollectionRootDescriptorPrefixBytes = []byte(vacuumCollectionRootDescriptorPrefix)
+
 type vacuumCollectionRootDescriptor struct {
 	key    []byte
 	rootID uint64
+}
+
+type vacuumCollectionRootReplacement struct {
+	key   []byte
+	value []byte
 }
 
 type vacuumAllocator interface {
 	Alloc(hint uint64) (uint64, error)
 }
 
+type vacuumUnsafeToReader interface {
+	ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]byte, bool, error)
+}
+
+type vacuumUnsafeAppendReader interface {
+	ReadUnsafeAppend(ptr page.ValuePtr, dst []byte) ([]byte, error)
+}
+
 func vacuumCollectionRootDescriptorPrefixEnd() []byte {
-	prefix := []byte(vacuumCollectionRootDescriptorPrefix)
-	out := append([]byte(nil), prefix...)
+	out := append([]byte(nil), vacuumCollectionRootDescriptorPrefixBytes...)
 	for i := len(out) - 1; i >= 0; i-- {
 		if out[i] != 0xff {
 			out[i]++
@@ -45,21 +60,23 @@ func vacuumCollectCollectionRootDescriptors(p *pager.Pager, reader tree.SlabRead
 		return nil, nil
 	}
 
-	start := []byte(vacuumCollectionRootDescriptorPrefix)
-	it := tree.New(p, reader, systemRootID).IteratorWithOptions(start, vacuumCollectionRootDescriptorPrefixEnd(), tree.IteratorOptions{
+	it := tree.New(p, reader, systemRootID).IteratorWithOptions(vacuumCollectionRootDescriptorPrefixBytes, vacuumCollectionRootDescriptorPrefixEnd(), tree.IteratorOptions{
 		Mode: tree.IteratorModePointerProjection,
 	})
 	defer func() { _ = it.Close() }()
 
 	var out []vacuumCollectionRootDescriptor
+	var pointerScratch []byte
 	for it.Valid() {
 		key := it.UnsafeKey()
-		if !bytes.HasPrefix(key, start) {
+		if !bytes.HasPrefix(key, vacuumCollectionRootDescriptorPrefixBytes) {
 			break
 		}
-		val, _, flags := it.UnsafeEntry()
-		if flags&node.FlagPointer != 0 {
-			return nil, fmt.Errorf("vacuum: collection root descriptor %q is pointer-backed", string(key))
+		val, ptr, flags := it.UnsafeEntry()
+		var err error
+		val, pointerScratch, err = vacuumCollectionRootDescriptorValue(reader, key, val, ptr, flags, pointerScratch)
+		if err != nil {
+			return nil, err
 		}
 		if len(val) != 8 {
 			return nil, fmt.Errorf("vacuum: collection root descriptor %q has malformed root id length %d", string(key), len(val))
@@ -76,13 +93,44 @@ func vacuumCollectCollectionRootDescriptors(p *pager.Pager, reader tree.SlabRead
 	return out, nil
 }
 
-func vacuumRewriteCollectionRoots(oldPager *pager.Pager, reader tree.SlabReader, systemRootID uint64, alloc vacuumAllocator, newPager *pager.Pager) (map[string][]byte, error) {
+func vacuumCollectionRootDescriptorValue(reader tree.SlabReader, key []byte, val []byte, ptr page.ValuePtr, flags byte, scratch []byte) ([]byte, []byte, error) {
+	if flags&node.FlagPointer == 0 {
+		return val, scratch, nil
+	}
+	if reader == nil {
+		return nil, scratch, fmt.Errorf("vacuum: collection root descriptor %q is pointer-backed without value reader", string(key))
+	}
+	if toReader, ok := reader.(vacuumUnsafeToReader); ok {
+		resolved, usedDst, err := toReader.ReadUnsafeTo(ptr, scratch[:0])
+		if err != nil {
+			return nil, scratch, fmt.Errorf("vacuum: read pointer-backed collection root descriptor %q: %w", string(key), err)
+		}
+		if usedDst {
+			scratch = resolved
+		}
+		return resolved, scratch, nil
+	}
+	if appender, ok := reader.(vacuumUnsafeAppendReader); ok {
+		resolved, err := appender.ReadUnsafeAppend(ptr, scratch[:0])
+		if err != nil {
+			return nil, scratch, fmt.Errorf("vacuum: read pointer-backed collection root descriptor %q: %w", string(key), err)
+		}
+		return resolved, resolved, nil
+	}
+	resolved, err := reader.ReadUnsafe(ptr)
+	if err != nil {
+		return nil, scratch, fmt.Errorf("vacuum: read pointer-backed collection root descriptor %q: %w", string(key), err)
+	}
+	return resolved, scratch, nil
+}
+
+func vacuumRewriteCollectionRoots(oldPager *pager.Pager, reader tree.SlabReader, systemRootID uint64, alloc vacuumAllocator, newPager *pager.Pager) ([]vacuumCollectionRootReplacement, error) {
 	descriptors, err := vacuumCollectCollectionRootDescriptors(oldPager, reader, systemRootID)
 	if err != nil || len(descriptors) == 0 {
 		return nil, err
 	}
 
-	replacements := make(map[string][]byte, len(descriptors))
+	replacements := make([]vacuumCollectionRootReplacement, 0, len(descriptors))
 	rootRemap := make(map[uint64]uint64, len(descriptors))
 	for _, descriptor := range descriptors {
 		oldRoot := descriptor.rootID
@@ -101,12 +149,18 @@ func vacuumRewriteCollectionRoots(oldPager *pager.Pager, reader tree.SlabReader,
 		if newRoot != oldRoot {
 			encoded := make([]byte, 8)
 			binary.BigEndian.PutUint64(encoded, newRoot)
-			replacements[string(descriptor.key)] = encoded
+			replacements = append(replacements, vacuumCollectionRootReplacement{
+				key:   descriptor.key,
+				value: encoded,
+			})
 		}
 	}
 	if len(replacements) == 0 {
 		return nil, nil
 	}
+	sort.Slice(replacements, func(i, j int) bool {
+		return bytes.Compare(replacements[i].key, replacements[j].key) < 0
+	})
 	return replacements, nil
 }
 
@@ -190,7 +244,7 @@ func vacuumCollectLeafRefChildrenIfComplete(p *pager.Pager, rootID uint64) ([]va
 	return out, true, nil
 }
 
-func vacuumBuildSystemRoot(oldPager *pager.Pager, reader tree.SlabReader, systemRootID uint64, alloc vacuumAllocator, newPager *pager.Pager, opts bulk.BuildOptions, replacements map[string][]byte) (uint64, error) {
+func vacuumBuildSystemRoot(oldPager *pager.Pager, reader tree.SlabReader, systemRootID uint64, alloc vacuumAllocator, newPager *pager.Pager, opts bulk.BuildOptions, replacements []vacuumCollectionRootReplacement) (uint64, error) {
 	sysIter := tree.New(oldPager, reader, systemRootID).IteratorWithOptions(nil, nil, tree.IteratorOptions{
 		Mode: tree.IteratorModePointerProjection,
 	})
@@ -207,7 +261,7 @@ func vacuumBuildSystemRoot(oldPager *pager.Pager, reader tree.SlabReader, system
 
 type vacuumSystemRootRewriteIterator struct {
 	base         iterator.UnsafeIterator
-	replacements map[string][]byte
+	replacements []vacuumCollectionRootReplacement
 }
 
 func (it *vacuumSystemRootRewriteIterator) Valid() bool {
@@ -226,8 +280,17 @@ func (it *vacuumSystemRootRewriteIterator) replacement() ([]byte, bool) {
 	if it == nil || it.base == nil || len(it.replacements) == 0 || !it.base.Valid() {
 		return nil, false
 	}
-	val, ok := it.replacements[string(it.base.UnsafeKey())]
-	return val, ok
+	key := it.base.UnsafeKey()
+	if !bytes.HasPrefix(key, vacuumCollectionRootDescriptorPrefixBytes) {
+		return nil, false
+	}
+	idx := sort.Search(len(it.replacements), func(i int) bool {
+		return bytes.Compare(it.replacements[i].key, key) >= 0
+	})
+	if idx >= len(it.replacements) || !bytes.Equal(it.replacements[idx].key, key) {
+		return nil, false
+	}
+	return it.replacements[idx].value, true
 }
 
 func (it *vacuumSystemRootRewriteIterator) UnsafeKey() []byte {

--- a/TreeDB/db/vacuum_collection_roots.go
+++ b/TreeDB/db/vacuum_collection_roots.go
@@ -1,0 +1,292 @@
+package db
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/bulk"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
+	"github.com/snissn/gomap/TreeDB/tree"
+)
+
+const vacuumCollectionRootDescriptorPrefix = "collections/root/"
+
+type vacuumCollectionRootDescriptor struct {
+	key    []byte
+	rootID uint64
+}
+
+type vacuumAllocator interface {
+	Alloc(hint uint64) (uint64, error)
+}
+
+func vacuumCollectionRootDescriptorPrefixEnd() []byte {
+	prefix := []byte(vacuumCollectionRootDescriptorPrefix)
+	out := append([]byte(nil), prefix...)
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i] != 0xff {
+			out[i]++
+			return out[:i+1]
+		}
+	}
+	return nil
+}
+
+func vacuumCollectCollectionRootDescriptors(p *pager.Pager, reader tree.SlabReader, systemRootID uint64) ([]vacuumCollectionRootDescriptor, error) {
+	if p == nil {
+		return nil, errors.New("vacuum: missing pager")
+	}
+	if systemRootID == 0 {
+		return nil, nil
+	}
+
+	start := []byte(vacuumCollectionRootDescriptorPrefix)
+	it := tree.New(p, reader, systemRootID).IteratorWithOptions(start, vacuumCollectionRootDescriptorPrefixEnd(), tree.IteratorOptions{
+		Mode: tree.IteratorModePointerProjection,
+	})
+	defer func() { _ = it.Close() }()
+
+	var out []vacuumCollectionRootDescriptor
+	for it.Valid() {
+		key := it.UnsafeKey()
+		if !bytes.HasPrefix(key, start) {
+			break
+		}
+		val, _, flags := it.UnsafeEntry()
+		if flags&node.FlagPointer != 0 {
+			return nil, fmt.Errorf("vacuum: collection root descriptor %q is pointer-backed", string(key))
+		}
+		if len(val) != 8 {
+			return nil, fmt.Errorf("vacuum: collection root descriptor %q has malformed root id length %d", string(key), len(val))
+		}
+		out = append(out, vacuumCollectionRootDescriptor{
+			key:    append([]byte(nil), key...),
+			rootID: binary.BigEndian.Uint64(val),
+		})
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func vacuumRewriteCollectionRoots(oldPager *pager.Pager, reader tree.SlabReader, systemRootID uint64, alloc vacuumAllocator, newPager *pager.Pager) (map[string][]byte, error) {
+	descriptors, err := vacuumCollectCollectionRootDescriptors(oldPager, reader, systemRootID)
+	if err != nil || len(descriptors) == 0 {
+		return nil, err
+	}
+
+	replacements := make(map[string][]byte, len(descriptors))
+	rootRemap := make(map[uint64]uint64, len(descriptors))
+	for _, descriptor := range descriptors {
+		oldRoot := descriptor.rootID
+		newRoot := oldRoot
+		if oldRoot != 0 {
+			if existing, ok := rootRemap[oldRoot]; ok {
+				newRoot = existing
+			} else {
+				newRoot, err = vacuumCopyCollectionRoot(oldPager, oldRoot, alloc, newPager)
+				if err != nil {
+					return nil, fmt.Errorf("vacuum: copy collection root %q: %w", string(descriptor.key), err)
+				}
+				rootRemap[oldRoot] = newRoot
+			}
+		}
+		if newRoot != oldRoot {
+			encoded := make([]byte, 8)
+			binary.BigEndian.PutUint64(encoded, newRoot)
+			replacements[string(descriptor.key)] = encoded
+		}
+	}
+	if len(replacements) == 0 {
+		return nil, nil
+	}
+	return replacements, nil
+}
+
+func vacuumCopyCollectionRoot(oldPager *pager.Pager, rootID uint64, alloc vacuumAllocator, newPager *pager.Pager) (uint64, error) {
+	if rootID == 0 {
+		return 0, nil
+	}
+	if _, ok := page.DecodeLeafRef(rootID); ok {
+		return rootID, nil
+	}
+	if oldPager == nil || newPager == nil || alloc == nil {
+		return 0, errors.New("vacuum: missing pager/allocator")
+	}
+
+	children, allLeafRefs, err := vacuumCollectLeafRefChildrenIfComplete(oldPager, rootID)
+	if err != nil {
+		return 0, err
+	}
+	if allLeafRefs {
+		return vacuumBuildInternalTreeFromChildren(newPager, alloc, children, false)
+	}
+	return vacuumClonePagerTreeWithLeafRefs(oldPager, rootID, alloc, newPager)
+}
+
+func vacuumCollectLeafRefChildrenIfComplete(p *pager.Pager, rootID uint64) ([]vacuumLeafChild, bool, error) {
+	if p == nil {
+		return nil, false, errors.New("vacuum: missing pager")
+	}
+	if rootID == 0 {
+		return nil, false, errors.New("vacuum: missing root id")
+	}
+	if _, ok := page.DecodeLeafRef(rootID); ok {
+		return nil, true, nil
+	}
+
+	out := make([]vacuumLeafChild, 0, 1024)
+	var walk func(uint64) (bool, error)
+	walk = func(id uint64) (bool, error) {
+		if _, ok := page.DecodeLeafRef(id); ok {
+			return true, nil
+		}
+		data, err := p.Get(id)
+		if err != nil {
+			return false, err
+		}
+		n := node.NewNode(data)
+		switch n.Type() {
+		case page.PageTypeInternal:
+			count := n.Count()
+			for i := uint16(0); i < count; i++ {
+				keyView, childID, err := n.GetInternalEntryView(i)
+				if err != nil {
+					return false, err
+				}
+				if _, ok := page.DecodeLeafRef(childID); ok {
+					out = append(out, vacuumLeafChild{
+						key:     append([]byte(nil), keyView...),
+						childID: childID,
+					})
+					continue
+				}
+				allLeafRefs, err := walk(childID)
+				if err != nil || !allLeafRefs {
+					return allLeafRefs, err
+				}
+			}
+			return true, nil
+		case page.PageTypeLeaf:
+			return false, nil
+		default:
+			return false, fmt.Errorf("vacuum: unexpected page type %d at page %d", n.Type(), id)
+		}
+	}
+	allLeafRefs, err := walk(rootID)
+	if err != nil || !allLeafRefs {
+		return nil, allLeafRefs, err
+	}
+	if len(out) == 0 {
+		return nil, false, nil
+	}
+	return out, true, nil
+}
+
+func vacuumBuildSystemRoot(oldPager *pager.Pager, reader tree.SlabReader, systemRootID uint64, alloc vacuumAllocator, newPager *pager.Pager, opts bulk.BuildOptions, replacements map[string][]byte) (uint64, error) {
+	sysIter := tree.New(oldPager, reader, systemRootID).IteratorWithOptions(nil, nil, tree.IteratorOptions{
+		Mode: tree.IteratorModePointerProjection,
+	})
+	if len(replacements) > 0 {
+		sysIter = &vacuumSystemRootRewriteIterator{
+			base:         sysIter,
+			replacements: replacements,
+		}
+	}
+	sysRoot, err := bulk.BuildWithOptions(sysIter, alloc, newPager, opts)
+	_ = sysIter.Close()
+	return sysRoot, err
+}
+
+type vacuumSystemRootRewriteIterator struct {
+	base         iterator.UnsafeIterator
+	replacements map[string][]byte
+}
+
+func (it *vacuumSystemRootRewriteIterator) Valid() bool {
+	return it != nil && it.base != nil && it.base.Valid()
+}
+
+func (it *vacuumSystemRootRewriteIterator) Next() {
+	it.base.Next()
+}
+
+func (it *vacuumSystemRootRewriteIterator) Seek(key []byte) {
+	it.base.Seek(key)
+}
+
+func (it *vacuumSystemRootRewriteIterator) replacement() ([]byte, bool) {
+	if it == nil || it.base == nil || len(it.replacements) == 0 || !it.base.Valid() {
+		return nil, false
+	}
+	val, ok := it.replacements[string(it.base.UnsafeKey())]
+	return val, ok
+}
+
+func (it *vacuumSystemRootRewriteIterator) UnsafeKey() []byte {
+	return it.base.UnsafeKey()
+}
+
+func (it *vacuumSystemRootRewriteIterator) UnsafeValue() []byte {
+	if val, ok := it.replacement(); ok {
+		return val
+	}
+	return it.base.UnsafeValue()
+}
+
+func (it *vacuumSystemRootRewriteIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	if val, ok := it.replacement(); ok {
+		return val, page.ValuePtr{}, node.FlagInline
+	}
+	return it.base.UnsafeEntry()
+}
+
+func (it *vacuumSystemRootRewriteIterator) Key() []byte {
+	return it.UnsafeKey()
+}
+
+func (it *vacuumSystemRootRewriteIterator) Value() []byte {
+	return it.UnsafeValue()
+}
+
+func (it *vacuumSystemRootRewriteIterator) KeyCopy(dst []byte) []byte {
+	key := it.UnsafeKey()
+	if key == nil {
+		return nil
+	}
+	return append(dst[:0], key...)
+}
+
+func (it *vacuumSystemRootRewriteIterator) ValueCopy(dst []byte) []byte {
+	val := it.UnsafeValue()
+	if val == nil {
+		return nil
+	}
+	return append(dst[:0], val...)
+}
+
+func (it *vacuumSystemRootRewriteIterator) IsDeleted() bool {
+	return it.base.IsDeleted()
+}
+
+func (it *vacuumSystemRootRewriteIterator) Error() error {
+	return it.base.Error()
+}
+
+func (it *vacuumSystemRootRewriteIterator) Close() error {
+	if it == nil || it.base == nil {
+		return nil
+	}
+	return it.base.Close()
+}
+
+func (it *vacuumSystemRootRewriteIterator) Domain() (start, end []byte) {
+	return it.base.Domain()
+}

--- a/TreeDB/db/vacuum_collection_roots_test.go
+++ b/TreeDB/db/vacuum_collection_roots_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"runtime"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
@@ -40,6 +41,10 @@ func TestVacuumIndexOffline_PreservesPointerBackedCollectionRootDescriptor(t *te
 }
 
 func TestVacuumIndexOnline_PreservesPointerBackedCollectionRootDescriptor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
+
 	dir := t.TempDir()
 	opts := vacuumPointerDescriptorOptions(dir)
 	d := openVacuumPointerDescriptorFixture(t, opts)

--- a/TreeDB/db/vacuum_collection_roots_test.go
+++ b/TreeDB/db/vacuum_collection_roots_test.go
@@ -18,7 +18,7 @@ const (
 	vacuumTestDocumentValue     = "document"
 )
 
-func TestVacuumIndexOffline_PreservesPointerBackedCollectionRootDescriptor(t *testing.T) {
+func TestVacuumIndexOffline_PreservesCollectionRootFromPointerBackedDescriptor(t *testing.T) {
 	dir := t.TempDir()
 	opts := vacuumPointerDescriptorOptions(dir)
 	d := openVacuumPointerDescriptorFixture(t, opts)
@@ -40,7 +40,7 @@ func TestVacuumIndexOffline_PreservesPointerBackedCollectionRootDescriptor(t *te
 	verifyVacuumCollectionRootDescriptor(t, reopened, vacuumTestCollectionRootKey)
 }
 
-func TestVacuumIndexOnline_PreservesPointerBackedCollectionRootDescriptor(t *testing.T) {
+func TestVacuumIndexOnline_PreservesCollectionRootFromPointerBackedDescriptor(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("online vacuum unsupported on windows")
 	}

--- a/TreeDB/db/vacuum_collection_roots_test.go
+++ b/TreeDB/db/vacuum_collection_roots_test.go
@@ -1,0 +1,157 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+const (
+	vacuumTestCollectionRootKey = "collections/root/users/primary"
+	vacuumTestDocumentKey       = "doc/u1"
+	vacuumTestDocumentValue     = "document"
+)
+
+func TestVacuumIndexOffline_PreservesPointerBackedCollectionRootDescriptor(t *testing.T) {
+	dir := t.TempDir()
+	opts := vacuumPointerDescriptorOptions(dir)
+	d := openVacuumPointerDescriptorFixture(t, opts)
+	assertVacuumCollectionRootDescriptorPointerBacked(t, d, vacuumTestCollectionRootKey)
+	verifyVacuumCollectionRootDescriptor(t, d, vacuumTestCollectionRootKey)
+	if err := d.Close(); err != nil {
+		t.Fatalf("close before vacuum: %v", err)
+	}
+
+	if err := VacuumIndexOffline(opts); err != nil {
+		t.Fatalf("vacuum offline: %v", err)
+	}
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen after vacuum: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	verifyVacuumCollectionRootDescriptor(t, reopened, vacuumTestCollectionRootKey)
+}
+
+func TestVacuumIndexOnline_PreservesPointerBackedCollectionRootDescriptor(t *testing.T) {
+	dir := t.TempDir()
+	opts := vacuumPointerDescriptorOptions(dir)
+	d := openVacuumPointerDescriptorFixture(t, opts)
+	defer func() { _ = d.Close() }()
+	assertVacuumCollectionRootDescriptorPointerBacked(t, d, vacuumTestCollectionRootKey)
+	verifyVacuumCollectionRootDescriptor(t, d, vacuumTestCollectionRootKey)
+
+	if err := d.VacuumIndexOnline(context.Background()); err != nil {
+		t.Fatalf("vacuum online: %v", err)
+	}
+	verifyVacuumCollectionRootDescriptor(t, d, vacuumTestCollectionRootKey)
+}
+
+func vacuumPointerDescriptorOptions(dir string) Options {
+	return Options{
+		Dir:        dir,
+		ChunkSize:  64 << 10,
+		KeepRecent: 1,
+		ValueLog: ValueLogOptions{
+			ForcePointers:    true,
+			PointerThreshold: 1,
+		},
+	}
+}
+
+func openVacuumPointerDescriptorFixture(t *testing.T, opts Options) *DB {
+	t.Helper()
+	d, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open fixture db: %v", err)
+	}
+
+	_, rootIDs, err := d.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemMemtable(t, vacuumTestDocumentKey, vacuumTestDocumentValue).NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStoragePagerLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		ptr := appendCollectionRootDescriptorPointer(t, opts.Dir, rootIDs[0])
+		return mustFrozenSystemPointerMemtable(t, vacuumTestCollectionRootKey, ptr).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("publish fixture collection root: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		_ = d.Close()
+		t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+	}
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("checkpoint fixture db: %v", err)
+	}
+	return d
+}
+
+func appendCollectionRootDescriptorPointer(t *testing.T, dir string, rootID uint64) page.ValuePtr {
+	t.Helper()
+	var encoded [8]byte
+	binary.BigEndian.PutUint64(encoded[:], rootID)
+	return appendPointersInNewSegment(t, dir, 0, 91, 910_000, 1, func(int) []byte {
+		return encoded[:]
+	})[0]
+}
+
+func assertVacuumCollectionRootDescriptorPointerBacked(t *testing.T, d *DB, key string) {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil || snap.state == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	it, err := snap.IteratorAtRootWithOptions(snap.state.SystemRootPageID, []byte(key), nil, IteratorOptions{
+		Mode: IteratorModePointerProjection,
+	})
+	if err != nil {
+		t.Fatalf("descriptor iterator: %v", err)
+	}
+	defer func() { _ = it.Close() }()
+	if !it.Valid() || !bytes.Equal(it.UnsafeKey(), []byte(key)) {
+		t.Fatalf("descriptor %q not found", key)
+	}
+	_, _, flags := it.UnsafeEntry()
+	if flags&node.FlagPointer == 0 {
+		t.Fatalf("descriptor %q was not pointer-backed; flags=%#x", key, flags)
+	}
+}
+
+func verifyVacuumCollectionRootDescriptor(t *testing.T, d *DB, key string) {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil || snap.state == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	descriptorValue, err := snap.GetAtRoot(snap.state.SystemRootPageID, []byte(key))
+	if err != nil {
+		t.Fatalf("read descriptor %q: %v", key, err)
+	}
+	if len(descriptorValue) != 8 {
+		t.Fatalf("descriptor %q value length=%d want 8", key, len(descriptorValue))
+	}
+	rootID := binary.BigEndian.Uint64(descriptorValue)
+	if rootID == 0 {
+		t.Fatalf("descriptor %q has zero root", key)
+	}
+	entry, err := snap.GetEntryAtRoot(rootID, []byte(vacuumTestDocumentKey))
+	if err != nil {
+		t.Fatalf("read collection root document: %v", err)
+	}
+	if got := string(entry.Value); got != vacuumTestDocumentValue {
+		t.Fatalf("document value=%q want %q", got, vacuumTestDocumentValue)
+	}
+}

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -97,30 +97,31 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 	}
 
 	alloc := &pagerAllocator{p: newPager}
+	reader := newValueReader(state.ValueLogSet)
 
-	sysIter := tree.New(d.Pager(), newValueReader(state.ValueLogSet), state.SystemRootPageID).
-		IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-	sysRoot, err := bulk.BuildWithOptions(sysIter, alloc, newPager, bulk.BuildOptions{
-		LeafPrefixCompression: opts.LeafPrefixCompression,
-		LeafColumnar:          opts.IndexColumnarLeaves,
-		PackedValuePtr:        opts.IndexPackedValuePtr,
-		InternalBaseDelta:     opts.IndexInternalBaseDelta,
-	})
-	_ = sysIter.Close()
+	collectionRootReplacements, err := vacuumRewriteCollectionRoots(d.Pager(), reader, state.SystemRootPageID, alloc, newPager)
 	if err != nil {
 		_ = newPager.Close()
 		_ = d.Close()
 		return err
 	}
 
-	userIter := tree.New(d.Pager(), newValueReader(state.ValueLogSet), state.RootPageID).
-		IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-	userRoot, err := bulk.BuildWithOptions(userIter, alloc, newPager, bulk.BuildOptions{
+	buildOpts := bulk.BuildOptions{
 		LeafPrefixCompression: opts.LeafPrefixCompression,
 		LeafColumnar:          opts.IndexColumnarLeaves,
 		PackedValuePtr:        opts.IndexPackedValuePtr,
 		InternalBaseDelta:     opts.IndexInternalBaseDelta,
-	})
+	}
+	sysRoot, err := vacuumBuildSystemRoot(d.Pager(), reader, state.SystemRootPageID, alloc, newPager, buildOpts, collectionRootReplacements)
+	if err != nil {
+		_ = newPager.Close()
+		_ = d.Close()
+		return err
+	}
+
+	userIter := tree.New(d.Pager(), reader, state.RootPageID).
+		IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+	userRoot, err := bulk.BuildWithOptions(userIter, alloc, newPager, buildOpts)
 	_ = userIter.Close()
 	if err != nil {
 		_ = newPager.Close()

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -394,19 +394,29 @@ func (db *DB) VacuumIndexOnline(ctx context.Context) error {
 			return errors.New("vacuum: missing db state")
 		}
 
+		reader := newValueReader(state.ValueLogSet)
+		collectionRootReplacements, err := vacuumRewriteCollectionRoots(oldGen.pager, reader, state.SystemRootPageID, newAlloc, newPager)
+		if err != nil {
+			db.writeMu.Unlock()
+			cleanupNewPager()
+			return err
+		}
+		if err := checkGrowth(); err != nil {
+			db.writeMu.Unlock()
+			cleanupNewPager()
+			return err
+		}
+
 		var newSysRoot uint64
-		if db.indexOuterLeavesInValueLog {
+		if db.indexOuterLeavesInValueLog && len(collectionRootReplacements) == 0 {
 			newSysRoot, err = vacuumClonePagerTreeWithLeafRefs(oldGen.pager, state.SystemRootPageID, newAlloc, newPager)
 		} else {
-			sysIter := tree.New(oldGen.pager, newValueReader(state.ValueLogSet), state.SystemRootPageID).
-				IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-			newSysRoot, err = bulk.BuildWithOptions(sysIter, newAlloc, newPager, bulk.BuildOptions{
+			newSysRoot, err = vacuumBuildSystemRoot(oldGen.pager, reader, state.SystemRootPageID, newAlloc, newPager, bulk.BuildOptions{
 				LeafPrefixCompression: db.leafPrefixCompression,
 				LeafColumnar:          db.indexColumnarLeaves,
 				PackedValuePtr:        db.indexPackedValuePtr,
 				InternalBaseDelta:     db.indexInternalBaseDelta,
-			})
-			_ = sysIter.Close()
+			}, collectionRootReplacements)
 		}
 		if err != nil {
 			db.writeMu.Unlock()

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -25,12 +25,13 @@ const (
 	valueLogRefCountsFileName = "vlog_ref_counts.meta"
 	// valueLogRefCountsVersion is the on-disk version for vlog_ref_counts.meta.
 	//
-	// Version 4 tracks only value_vlog references reachable from logical
-	// value pointers. leaf_vlog reachability is owned by leaf-generation GC and
-	// intentionally excluded here. Older metadata is intentionally treated as
-	// stale/corrupt and rebuilt from a full scan. TreeDB is still pre-alpha, so
-	// we do not preserve old vlog_ref_counts.meta encodings yet.
-	valueLogRefCountsVersion = uint32(4)
+	// Version 5 tracks value_vlog references reachable from the user tree,
+	// system tree, and collection root trees. leaf_vlog reachability is owned by
+	// leaf-generation GC and intentionally excluded here. Older metadata is
+	// intentionally treated as stale/corrupt and rebuilt from a full scan.
+	// TreeDB is still pre-alpha, so we do not preserve old
+	// vlog_ref_counts.meta encodings yet.
+	valueLogRefCountsVersion = uint32(5)
 )
 
 var (
@@ -452,22 +453,21 @@ func (db *DB) scanValueLogRefCounts(ctx context.Context) (map[uint32]uint64, uin
 	commitSeq := snap.state.CommitSeq
 	counts := make(map[uint32]uint64)
 
-	userIter := snap.tree.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-	if err := collectValueLogRefCounts(ctx, db, userIter, counts); err != nil {
-		_ = userIter.Close()
+	roots, err := maintenanceRootsForSnapshot(snap)
+	if err != nil {
 		_ = snap.Close()
 		return nil, 0, err
 	}
-	_ = userIter.Close()
-
-	sysIter := tree.New(snap.idx.pager, newValueReader(snap.state.ValueLogSet), snap.state.SystemRootPageID).
-		IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-	if err := collectValueLogRefCounts(ctx, db, sysIter, counts); err != nil {
-		_ = sysIter.Close()
-		_ = snap.Close()
-		return nil, 0, err
+	for _, root := range roots {
+		iter := tree.New(snap.idx.pager, &snap.reader, root.rootID).
+			IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+		if err := collectValueLogRefCounts(ctx, db, iter, counts); err != nil {
+			_ = iter.Close()
+			_ = snap.Close()
+			return nil, 0, err
+		}
+		_ = iter.Close()
 	}
-	_ = sysIter.Close()
 
 	if err := snap.Close(); err != nil {
 		return nil, 0, err

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -459,8 +459,7 @@ func (db *DB) scanValueLogRefCounts(ctx context.Context) (map[uint32]uint64, uin
 		return nil, 0, err
 	}
 	for _, root := range roots {
-		iter := tree.New(snap.idx.pager, &snap.reader, root.rootID).
-			IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+		iter := scanValueLogRefCountRootIterator(snap, root)
 		if err := collectValueLogRefCounts(ctx, db, iter, counts); err != nil {
 			_ = iter.Close()
 			_ = snap.Close()
@@ -473,6 +472,14 @@ func (db *DB) scanValueLogRefCounts(ctx context.Context) (map[uint32]uint64, uin
 		return nil, 0, err
 	}
 	return counts, commitSeq, nil
+}
+
+func scanValueLogRefCountRootIterator(snap *Snapshot, root maintenanceRoot) iterator.UnsafeIterator {
+	opts := tree.IteratorOptions{Mode: tree.IteratorModePointerProjection}
+	if snap != nil && root.kind == maintenanceRootUser && root.rootID == snap.treeRoot {
+		return snap.tree.IteratorWithOptions(nil, nil, opts)
+	}
+	return tree.New(snap.idx.pager, &snap.reader, root.rootID).IteratorWithOptions(nil, nil, opts)
 }
 
 func collectValueLogRefCounts(ctx context.Context, db *DB, it iterator.UnsafeIterator, refs map[uint32]uint64) error {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -532,15 +532,16 @@ func trainRewriteLeafDictFromLiveLeafRefs(d *DB, state *DBState, cfg compression
 	if d == nil || state == nil || d.valueLogManager == nil {
 		return nil, nil
 	}
-	roots := make([]uint64, 0, 2)
-	if state.RootPageID != 0 {
-		roots = append(roots, state.RootPageID)
+	maintenanceRoots, err := collectMaintenanceRoots(d.Pager(), newValueReader(state.ValueLogSet), state)
+	if err != nil {
+		return nil, err
 	}
-	if state.SystemRootPageID != 0 {
-		roots = append(roots, state.SystemRootPageID)
-	}
-	if len(roots) == 0 {
+	if len(maintenanceRoots) == 0 {
 		return nil, nil
+	}
+	roots := make([]uint64, 0, len(maintenanceRoots))
+	for _, root := range maintenanceRoots {
+		roots = append(roots, root.rootID)
 	}
 	targetBytes := rewriteLeafDictTrainBytes(cfg)
 	minRecords := rewriteLeafDictMinRecords(cfg)
@@ -1128,20 +1129,19 @@ func (db *DB) estimateValueLogLiveBytesBySegment(ctx context.Context) (_ map[uin
 		// workloads will vastly over-count live bytes and mask stale segments.
 		var seenGroupedRecords map[groupedRecordKey]struct{}
 
-		userIter := snap.tree.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-		if err := db.collectValueLogLiveBytes(ctx, userIter, liveByID, &seenGroupedRecords, snap.state.ValueLogSet); err != nil {
-			_ = userIter.Close()
+		roots, err := maintenanceRootsForSnapshot(snap)
+		if err != nil {
 			return nil, err
 		}
-		_ = userIter.Close()
-
-		sysIter := tree.New(snap.idx.pager, newValueReader(snap.state.ValueLogSet), snap.state.SystemRootPageID).
-			IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-		if err := db.collectValueLogLiveBytes(ctx, sysIter, liveByID, &seenGroupedRecords, snap.state.ValueLogSet); err != nil {
-			_ = sysIter.Close()
-			return nil, err
+		for _, root := range roots {
+			iter := tree.New(snap.idx.pager, &snap.reader, root.rootID).
+				IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+			if err := db.collectValueLogLiveBytes(ctx, iter, liveByID, &seenGroupedRecords, snap.state.ValueLogSet); err != nil {
+				_ = iter.Close()
+				return nil, err
+			}
+			_ = iter.Close()
 		}
-		_ = sysIter.Close()
 
 		if cacheable {
 			db.storeCachedValueLogLiveBytes(cacheKey, liveByID)

--- a/TreeDB/db/vlog_rewrite_chunk_plan.go
+++ b/TreeDB/db/vlog_rewrite_chunk_plan.go
@@ -154,20 +154,19 @@ func (db *DB) estimateValueLogLiveBytesByChunk(ctx context.Context, chunkBytes i
 		liveByChunk := make(map[valueLogChunkKey]int64)
 		var seenGroupedRecords map[groupedRecordKey]struct{}
 
-		userIter := snap.tree.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-		if err := db.collectValueLogLiveBytesByChunk(ctx, userIter, liveByChunk, &seenGroupedRecords, snap.state.ValueLogSet, chunkBytes); err != nil {
-			_ = userIter.Close()
+		roots, err := maintenanceRootsForSnapshot(snap)
+		if err != nil {
 			return nil, err
 		}
-		_ = userIter.Close()
-
-		sysIter := tree.New(snap.idx.pager, newValueReader(snap.state.ValueLogSet), snap.state.SystemRootPageID).
-			IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-		if err := db.collectValueLogLiveBytesByChunk(ctx, sysIter, liveByChunk, &seenGroupedRecords, snap.state.ValueLogSet, chunkBytes); err != nil {
-			_ = sysIter.Close()
-			return nil, err
+		for _, root := range roots {
+			iter := tree.New(snap.idx.pager, &snap.reader, root.rootID).
+				IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+			if err := db.collectValueLogLiveBytesByChunk(ctx, iter, liveByChunk, &seenGroupedRecords, snap.state.ValueLogSet, chunkBytes); err != nil {
+				_ = iter.Close()
+				return nil, err
+			}
+			_ = iter.Close()
 		}
-		_ = sysIter.Close()
 
 		return liveByChunk, nil
 	}

--- a/TreeDB/docs/spec/value-log-lifecycle.md
+++ b/TreeDB/docs/spec/value-log-lifecycle.md
@@ -25,7 +25,9 @@ Reachability is defined by pointer references found in index trees.
 `ValueLogGC` computes this by scanning:
 
 - user tree,
-- system tree.
+- system tree,
+- collection root trees referenced by system-tree descriptors under
+  `collections/root/...`.
 
 Entries with `node.FlagPointer` and `IsValueLogFileID(ptr.FileID)` mark a segment as referenced.
 

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -20,6 +20,8 @@ type Allocator struct {
 	regionPages  uint64
 	regionRadius int
 
+	stats Stats
+
 	// preferAppend makes Alloc ignore the freelist and allocate new pages by
 	// extending the file. This improves locality at the cost of reclaiming space
 	// later via vacuum.
@@ -52,9 +54,13 @@ var TestHookFreeBeforeChecksum func()
 
 // Stats reports freelist metadata under the allocator lock.
 type Stats struct {
-	Head    uint64
-	Pages   uint64
-	FreeIDs uint64
+	Head             uint64
+	Pages            uint64
+	FreeIDs          uint64
+	AllocPages       uint64
+	AppendAllocPages uint64
+	ReuseAllocPages  uint64
+	FreePages        uint64
 }
 
 // ReclaimablePages returns the total number of reclaimable pages tracked in the freelist.
@@ -127,11 +133,14 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 	ids := make([]uint64, 0, count)
 	for len(ids) < count {
 		if a.preferAppend || a.head == 0 {
-			id, err := a.pager.Alloc(count - len(ids))
+			allocCount := count - len(ids)
+			id, err := a.pager.Alloc(allocCount)
 			if err != nil {
 				return ids, err
 			}
-			for i := 0; i < count-len(ids); i++ {
+			a.stats.AllocPages += uint64(allocCount)
+			a.stats.AppendAllocPages += uint64(allocCount)
+			for i := 0; i < allocCount; i++ {
 				ids = append(ids, id+uint64(i))
 			}
 			a.lastAlloc = ids[len(ids)-1]
@@ -158,6 +167,8 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 			a.head = next
 			a.pager.MarkUnverified(recycled)
 			a.lastAlloc = recycled
+			a.stats.AllocPages++
+			a.stats.ReuseAllocPages++
 			ids = append(ids, recycled)
 			continue
 		}
@@ -168,6 +179,8 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 			clearFreelistIDAt(data, idx)
 			a.pager.MarkUnverified(id)
 			a.lastAlloc = id
+			a.stats.AllocPages++
+			a.stats.ReuseAllocPages++
 			ids = append(ids, id)
 			countFree--
 		}
@@ -183,6 +196,8 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 		id, err := a.pager.Alloc(1)
 		if err == nil {
 			a.lastAlloc = id
+			a.stats.AllocPages++
+			a.stats.AppendAllocPages++
 		}
 		return id, err
 	}
@@ -191,6 +206,8 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 		id, err := a.pager.Alloc(1)
 		if err == nil {
 			a.lastAlloc = id
+			a.stats.AllocPages++
+			a.stats.AppendAllocPages++
 		}
 		return id, err
 	}
@@ -245,6 +262,8 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 
 				a.pager.MarkUnverified(id)
 				a.lastAlloc = id
+				a.stats.AllocPages++
+				a.stats.ReuseAllocPages++
 				return id, nil
 			}
 		}
@@ -256,6 +275,8 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 
 		a.pager.MarkUnverified(id)
 		a.lastAlloc = id
+		a.stats.AllocPages++
+		a.stats.ReuseAllocPages++
 		return id, nil
 	}
 
@@ -266,6 +287,8 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 
 	a.pager.MarkUnverified(recycled)
 	a.lastAlloc = recycled
+	a.stats.AllocPages++
+	a.stats.ReuseAllocPages++
 	return recycled, nil
 }
 
@@ -290,7 +313,11 @@ func (a *Allocator) Free(id uint64) error {
 
 	if a.head == 0 {
 		// Start new list with this page
-		return a.initHead(id, 0)
+		if err := a.initHead(id, 0); err != nil {
+			return err
+		}
+		a.stats.FreePages++
+		return nil
 	}
 
 	// Load Head
@@ -316,12 +343,17 @@ func (a *Allocator) Free(id uint64) error {
 			TestHookFreeBeforeChecksum()
 		}
 		n.UpdateChecksum()
+		a.stats.FreePages++
 		return nil
 	}
 
 	// Head is full.
 	// Use `id` as NEW Head.
-	return a.initHead(id, a.head)
+	if err := a.initHead(id, a.head); err != nil {
+		return err
+	}
+	a.stats.FreePages++
+	return nil
 }
 
 func (a *Allocator) initHead(id, next uint64) error {
@@ -352,7 +384,12 @@ func (a *Allocator) initHead(id, next uint64) error {
 func (a *Allocator) Stats(pageLimit uint64) (Stats, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return readStatsLocked(a.pager, a.head, pageLimit)
+	out, err := readStatsLocked(a.pager, a.head, pageLimit)
+	out.AllocPages = a.stats.AllocPages
+	out.AppendAllocPages = a.stats.AppendAllocPages
+	out.ReuseAllocPages = a.stats.ReuseAllocPages
+	out.FreePages = a.stats.FreePages
+	return out, err
 }
 
 func readStatsLocked(p *pager.Pager, head uint64, pageLimit uint64) (Stats, error) {

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -392,6 +392,20 @@ func (a *Allocator) Stats(pageLimit uint64) (Stats, error) {
 	return out, err
 }
 
+// Counters reports cheap in-memory allocator counters without walking freelist
+// pages. Use Stats when callers explicitly need on-disk reclaimable page counts.
+func (a *Allocator) Counters() Stats {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return Stats{
+		Head:             a.head,
+		AllocPages:       a.stats.AllocPages,
+		AppendAllocPages: a.stats.AppendAllocPages,
+		ReuseAllocPages:  a.stats.ReuseAllocPages,
+		FreePages:        a.stats.FreePages,
+	}
+}
+
 func readStatsLocked(p *pager.Pager, head uint64, pageLimit uint64) (Stats, error) {
 	out := Stats{Head: head}
 	if head == 0 || pageLimit == 0 {

--- a/TreeDB/lifecycle/graveyard.go
+++ b/TreeDB/lifecycle/graveyard.go
@@ -21,6 +21,13 @@ type Graveyard struct {
 	retiredPages []batch // Ordered by CommitSeq
 }
 
+type GraveyardStats struct {
+	Batches uint64
+	Pages   uint64
+	MinSeq  uint64
+	MaxSeq  uint64
+}
+
 func NewGraveyard() *Graveyard {
 	return &Graveyard{
 		retiredPages: make([]batch, 0, 64),
@@ -168,4 +175,19 @@ func (g *Graveyard) Reinsert(seq uint64, pages []uint64) {
 		g.retiredPages = append(g.retiredPages[:insertIdx+1], g.retiredPages[insertIdx:]...)
 		g.retiredPages[insertIdx] = val
 	}
+}
+
+func (g *Graveyard) Stats() GraveyardStats {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	out := GraveyardStats{Batches: uint64(len(g.retiredPages))}
+	for i, b := range g.retiredPages {
+		if i == 0 {
+			out.MinSeq = b.seq
+		}
+		out.MaxSeq = b.seq
+		out.Pages += uint64(len(b.ids))
+	}
+	return out
 }

--- a/TreeDB/profiles.go
+++ b/TreeDB/profiles.go
@@ -93,8 +93,8 @@ const fastProfileChunkSize = 4 << 20
 //
 // The returned Options still follow TreeDB's normal defaulting rules for fields
 // left as zero values unless the selected profile intentionally owns that knob
-// (e.g. fast profiles set ChunkSize; KeepRecent and backpressure thresholds
-// still use normal defaults).
+// (e.g. fast profiles set ChunkSize; KeepRecent, allocator policy, and
+// backpressure thresholds still use normal defaults).
 func OptionsFor(profile Profile, dir string) Options {
 	opts := Options{Dir: dir}
 	ApplyProfile(&opts, profile)
@@ -187,11 +187,6 @@ func applyFastProfile(opts *Options) {
 		opts.ValueLog.DictProbeIntervalBytes = 32 << 20
 	}
 
-	// Prefer appending new pages for throughput under churn unless caller opted
-	// out. This can trade disk growth for write speed.
-	if !opts.PreferAppendAlloc {
-		opts.PreferAppendAlloc = true
-	}
 	applyIndexOptimizationsProfile(opts)
 }
 
@@ -208,8 +203,6 @@ func applyWALOnFastProfile(opts *Options) {
 		opts.ValueLog.DictProbeIntervalBytes = 32 << 20
 	}
 
-	// Prefer appending new pages for throughput under churn.
-	opts.PreferAppendAlloc = true
 	applyIndexOptimizationsProfile(opts)
 }
 

--- a/TreeDB/profiles_test.go
+++ b/TreeDB/profiles_test.go
@@ -25,8 +25,8 @@ func TestApplyProfile_FastSetsPolicyBools(t *testing.T) {
 	if !opts.IndexOuterLeavesInValueLog {
 		t.Fatalf("expected IndexOuterLeavesInValueLog=true for fast profile")
 	}
-	if !opts.PreferAppendAlloc {
-		t.Fatalf("expected PreferAppendAlloc=true for fast profile")
+	if opts.PreferAppendAlloc {
+		t.Fatalf("expected PreferAppendAlloc=false for fast profile")
 	}
 	if opts.ValueLog.Compression != ValueLogCompressionAuto {
 		t.Fatalf("expected ValueLog.Compression=ValueLogCompressionAuto for fast profile, got %v", opts.ValueLog.Compression)
@@ -82,8 +82,8 @@ func TestApplyProfile_WALOnFastKeepsWALOn(t *testing.T) {
 	if !opts.IndexOuterLeavesInValueLog {
 		t.Fatalf("expected IndexOuterLeavesInValueLog=true for wal_on_fast profile")
 	}
-	if !opts.PreferAppendAlloc {
-		t.Fatalf("expected PreferAppendAlloc=true for wal_on_fast profile")
+	if opts.PreferAppendAlloc {
+		t.Fatalf("expected PreferAppendAlloc=false for wal_on_fast profile")
 	}
 	if opts.ValueLog.Compression != ValueLogCompressionAuto {
 		t.Fatalf("expected ValueLog.Compression=ValueLogCompressionAuto for wal_on_fast profile, got %v", opts.ValueLog.Compression)

--- a/cmd/collection_load_fixture/README.md
+++ b/cmd/collection_load_fixture/README.md
@@ -1,0 +1,53 @@
+# collection-load-fixture
+
+`collection-load-fixture` creates and keeps an inspectable TreeDB collection
+database using the same indexed document shape as
+`BenchmarkCollectionShapeInsertBatch`.
+
+Build:
+
+```sh
+make collection-load-fixture
+```
+
+Default load shape:
+
+- `template-v1` documents
+- two secondary indexes: unique `email_idx` and non-unique `city_idx`
+- collection data/index-state outer leaves in the value log
+- secondary-index outer leaves in the value log
+- `fast` TreeDB profile
+- final checkpoint and reopen verification
+
+Example:
+
+```sh
+./bin/collection-load-fixture \
+  -dir /tmp/treedb_two_index_template_v1_index_vlog \
+  -reset \
+  -docs 1000000 \
+  -batch-size 8000
+```
+
+If `-dir` is omitted, the tool creates a kept OS temp directory and prints the
+path. It never deletes the loaded database unless `-reset` is explicitly passed
+for a named `-dir`.
+
+Useful variants:
+
+```sh
+# JSON documents with the same two-index shape.
+./bin/collection-load-fixture -format json -dir /tmp/treedb_two_index_json_index_vlog -reset
+
+# Disable secondary-index value-log outer leaves.
+./bin/collection-load-fixture -index-outer-leaves-in-vlog=false -dir /tmp/treedb_two_index_template_v1_fast_index -reset
+
+# Generate machine-readable output and optional profiles.
+./bin/collection-load-fixture \
+  -json \
+  -cpuprofile /tmp/collection_fixture_cpu.pprof \
+  -memprofile /tmp/collection_fixture_heap.pprof
+
+# Compact the value log after loading, then report before/after disk usage.
+./bin/collection-load-fixture -vlog-rewrite -dir /tmp/treedb_fixture_rewritten -reset
+```

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -796,11 +797,12 @@ func verifyReopen(cfg config) (int, error) {
 		if len(got) == 0 {
 			return 0, fmt.Errorf("reopen verify get %s returned an empty document", id)
 		}
-		if cfg.DocumentFormat == collections.DocumentFormatJSON {
-			want := indexedJSONDocument(n)
-			if !bytes.Equal(got, want) {
-				return 0, fmt.Errorf("reopen verify get %s returned unexpected JSON document", id)
-			}
+		want, err := expectedStoredDocument(cfg.DocumentFormat, n)
+		if err != nil {
+			return 0, fmt.Errorf("reopen verify expected document %s: %w", id, err)
+		}
+		if !bytes.Equal(got, want) {
+			return 0, fmt.Errorf("reopen verify get %s returned unexpected document content", id)
 		}
 		if cfg.IndexCount >= 1 {
 			email := fmt.Sprintf("user-%09d@example.com", n)
@@ -822,8 +824,67 @@ func verifyReopen(cfg config) (int, error) {
 				return 0, fmt.Errorf("reopen verify city index %s did not include %s", city, id)
 			}
 		}
+		if cfg.IndexCount >= 3 {
+			name := fmt.Sprintf("user-%09d", n)
+			ids, err := collection.FindByIndex("name_idx", name)
+			if err != nil {
+				return 0, fmt.Errorf("reopen verify name index %s: %w", name, err)
+			}
+			if !containsDocumentID(ids, id) {
+				return 0, fmt.Errorf("reopen verify name index %s did not include %s", name, id)
+			}
+		}
 	}
 	return len(samples), nil
+}
+
+func expectedStoredDocument(format collections.DocumentFormat, n int) ([]byte, error) {
+	if format == collections.DocumentFormatJSON {
+		return indexedJSONDocument(n), nil
+	}
+	doc, err := document(format, &collections.TemplateV1Encoder{}, n)
+	if err != nil {
+		return nil, err
+	}
+	return templateV1StoredDocument(doc)
+}
+
+func templateV1StoredDocument(raw []byte) ([]byte, error) {
+	const (
+		inputMagic  = "TD1I"
+		storedMagic = "TD1D"
+	)
+	if bytes.HasPrefix(raw, []byte(storedMagic)) {
+		return raw, nil
+	}
+	if !bytes.HasPrefix(raw, []byte(inputMagic)) {
+		return nil, errors.New("template-v1 document is missing input envelope")
+	}
+	pos := len(inputMagic)
+	templateCount, n := binary.Uvarint(raw[pos:])
+	if n <= 0 {
+		return nil, errors.New("template-v1 document has malformed template count")
+	}
+	pos += n
+	for i := uint64(0); i < templateCount; i++ {
+		if len(raw)-pos < 32 {
+			return nil, errors.New("template-v1 document has malformed template id")
+		}
+		pos += 32
+		recordLen, n := binary.Uvarint(raw[pos:])
+		if n <= 0 {
+			return nil, errors.New("template-v1 document has malformed template length")
+		}
+		pos += n
+		if recordLen > uint64(len(raw)-pos) {
+			return nil, errors.New("template-v1 document has truncated template record")
+		}
+		pos += int(recordLen)
+	}
+	if !bytes.HasPrefix(raw[pos:], []byte(storedMagic)) {
+		return nil, errors.New("template-v1 document is missing stored payload")
+	}
+	return raw[pos:], nil
 }
 
 func containsDocumentID(ids [][]byte, want []byte) bool {

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -1,0 +1,1012 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	defaultDocs              = 1_000_000
+	defaultBatchSize         = 8_000
+	defaultCollectionName    = "bench_shape_insert_2"
+	collectionFixtureCities  = 64
+	collectionFixturePad     = "01234567890123456789"
+	maxFixtureTopFileEntries = 20
+)
+
+type config struct {
+	Dir                        string
+	Reset                      bool
+	Docs                       int
+	BatchSize                  int
+	Collection                 string
+	DocumentFormat             collections.DocumentFormat
+	IndexCount                 int
+	Profile                    treedb.Profile
+	DataOuterLeavesInValueLog  bool
+	IndexOuterLeavesInValueLog bool
+	ChunkSize                  int64
+	PagerSyncConcurrency       int
+	Checkpoint                 bool
+	CheckpointEachBatch        bool
+	ReopenVerify               bool
+	VerifySamples              int
+	ValueLogRewrite            bool
+	ValueLogGC                 bool
+	Progress                   bool
+	JSONOutput                 bool
+	CPUProfile                 string
+	MemProfile                 string
+	createdTempDir             bool
+}
+
+type timingSummary struct {
+	Seconds   float64 `json:"seconds"`
+	SecPerOp  float64 `json:"sec_per_op,omitempty"`
+	OpsPerSec float64 `json:"ops_per_sec,omitempty"`
+}
+
+type diskUsageSummary struct {
+	TotalBytes  uint64        `json:"total_bytes"`
+	BytesPerDoc float64       `json:"bytes_per_doc,omitempty"`
+	FileCount   int           `json:"file_count"`
+	TopFiles    []fileSummary `json:"top_files,omitempty"`
+}
+
+type fileSummary struct {
+	Path  string `json:"path"`
+	Bytes uint64 `json:"bytes"`
+}
+
+type insertPhaseSummary struct {
+	Documents                     int                   `json:"documents"`
+	Indexes                       int                   `json:"indexes"`
+	Runs                          int                   `json:"runs"`
+	PrepareDocumentsNSPerDoc      float64               `json:"prepare_documents_ns_per_doc,omitempty"`
+	IndexStateExtractionNSPerDoc  float64               `json:"index_state_extraction_ns_per_doc,omitempty"`
+	DuplicatePreflightNSPerDoc    float64               `json:"duplicate_preflight_ns_per_doc,omitempty"`
+	UniquePreflightNSPerDoc       float64               `json:"unique_preflight_ns_per_doc,omitempty"`
+	TemplateRunBuildNSPerDoc      float64               `json:"template_run_build_ns_per_doc,omitempty"`
+	PrimaryRunBuildNSPerDoc       float64               `json:"primary_run_build_ns_per_doc,omitempty"`
+	IndexStateRunBuildNSPerDoc    float64               `json:"index_state_run_build_ns_per_doc,omitempty"`
+	SecondaryRunBuildNSPerDoc     float64               `json:"secondary_run_build_ns_per_doc,omitempty"`
+	PublishNSPerDoc               float64               `json:"publish_ns_per_doc,omitempty"`
+	SecondaryEntriesPerDoc        float64               `json:"secondary_entries_per_doc,omitempty"`
+	SecondaryKeyBytesPerDoc       float64               `json:"secondary_key_bytes_per_doc,omitempty"`
+	SecondarySortedRunsPerBatch   float64               `json:"secondary_sorted_runs_per_batch,omitempty"`
+	SecondaryUnsortedRunsPerBatch float64               `json:"secondary_unsorted_runs_per_batch,omitempty"`
+	SecondaryRuns                 []secondaryRunSummary `json:"secondary_runs,omitempty"`
+}
+
+type secondaryRunSummary struct {
+	IndexName      string  `json:"index_name"`
+	Runs           int     `json:"runs"`
+	Entries        int     `json:"entries"`
+	KeyBytes       int     `json:"key_bytes"`
+	SortedRuns     int     `json:"sorted_runs"`
+	UnsortedRuns   int     `json:"unsorted_runs"`
+	BuildNSPerDoc  float64 `json:"build_ns_per_doc,omitempty"`
+	EntriesPerDoc  float64 `json:"entries_per_doc,omitempty"`
+	KeyBytesPerDoc float64 `json:"key_bytes_per_doc,omitempty"`
+}
+
+type rewriteSummary struct {
+	Enabled               bool          `json:"enabled"`
+	RewriteTiming         timingSummary `json:"rewrite_timing,omitempty"`
+	GCTiming              timingSummary `json:"gc_timing,omitempty"`
+	DiskBytesBefore       uint64        `json:"disk_bytes_before,omitempty"`
+	DiskBytesAfterRewrite uint64        `json:"disk_bytes_after_rewrite,omitempty"`
+	DiskBytesAfterGC      uint64        `json:"disk_bytes_after_gc,omitempty"`
+	SegmentsBefore        int           `json:"segments_before,omitempty"`
+	SegmentsAfter         int           `json:"segments_after,omitempty"`
+	RecordsCopied         int           `json:"records_copied,omitempty"`
+	ValueRecordsCopied    int           `json:"value_records_copied,omitempty"`
+	ValueBytesCopied      int64         `json:"value_bytes_copied,omitempty"`
+	TemplateRecordsKept   int           `json:"template_records_kept,omitempty"`
+	GCSegmentsDeleted     int           `json:"gc_segments_deleted,omitempty"`
+	GCBytesDeleted        int64         `json:"gc_bytes_deleted,omitempty"`
+}
+
+type verifySummary struct {
+	Enabled bool `json:"enabled"`
+	Samples int  `json:"samples,omitempty"`
+}
+
+type loadSummary struct {
+	GeneratedAt                string             `json:"generated_at"`
+	Dir                        string             `json:"dir"`
+	CreatedTempDir             bool               `json:"created_temp_dir,omitempty"`
+	Collection                 string             `json:"collection"`
+	DocumentFormat             string             `json:"document_format"`
+	Profile                    string             `json:"profile"`
+	Docs                       int                `json:"docs"`
+	BatchSize                  int                `json:"batch_size"`
+	Batches                    int                `json:"batches"`
+	IndexCount                 int                `json:"index_count"`
+	DataOuterLeavesInValueLog  bool               `json:"data_outer_leaves_in_value_log"`
+	IndexOuterLeavesInValueLog bool               `json:"index_outer_leaves_in_value_log"`
+	ChunkSize                  int64              `json:"chunk_size,omitempty"`
+	PagerSyncConcurrency       int                `json:"pager_sync_concurrency,omitempty"`
+	WallTiming                 timingSummary      `json:"wall_timing"`
+	GenerationTiming           timingSummary      `json:"generation_timing"`
+	InsertTiming               timingSummary      `json:"insert_timing"`
+	CheckpointTiming           timingSummary      `json:"checkpoint_timing,omitempty"`
+	InsertPhases               insertPhaseSummary `json:"insert_phases"`
+	DiskUsageBeforeMaintenance diskUsageSummary   `json:"disk_usage_before_maintenance"`
+	DiskUsageFinal             diskUsageSummary   `json:"disk_usage_final"`
+	Rewrite                    rewriteSummary     `json:"rewrite,omitempty"`
+	Verify                     verifySummary      `json:"verify"`
+	CPUProfile                 string             `json:"cpu_profile,omitempty"`
+	MemProfile                 string             `json:"mem_profile,omitempty"`
+	GoVersion                  string             `json:"go_version"`
+	GOOS                       string             `json:"goos"`
+	GOARCH                     string             `json:"goarch"`
+}
+
+func main() {
+	cfg, err := parseConfig(os.Args[1:], os.Stderr)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		fmt.Fprintf(os.Stderr, "collection-load-fixture: %v\n", err)
+		os.Exit(2)
+	}
+	summary, err := runFixture(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collection-load-fixture: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg.JSONOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(summary); err != nil {
+			fmt.Fprintf(os.Stderr, "collection-load-fixture: write json summary: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	printHumanSummary(os.Stdout, summary)
+}
+
+func parseConfig(args []string, output io.Writer) (config, error) {
+	cfg := config{
+		Docs:                       defaultDocs,
+		BatchSize:                  defaultBatchSize,
+		Collection:                 defaultCollectionName,
+		DocumentFormat:             collections.DocumentFormatTemplateV1,
+		IndexCount:                 2,
+		Profile:                    treedb.ProfileFast,
+		DataOuterLeavesInValueLog:  true,
+		IndexOuterLeavesInValueLog: true,
+		Checkpoint:                 true,
+		ReopenVerify:               true,
+		VerifySamples:              8,
+		ValueLogGC:                 true,
+		Progress:                   true,
+	}
+	var documentFormat string
+	var profile string
+	fs := flag.NewFlagSet("collection-load-fixture", flag.ContinueOnError)
+	if output == nil {
+		output = io.Discard
+	}
+	fs.SetOutput(output)
+	fs.StringVar(&cfg.Dir, "dir", "", "directory to create and keep; empty creates a kept OS temp directory")
+	fs.BoolVar(&cfg.Reset, "reset", false, "remove -dir before loading; ignored when -dir is empty")
+	fs.IntVar(&cfg.Docs, "docs", cfg.Docs, "number of documents to insert")
+	fs.IntVar(&cfg.BatchSize, "batch-size", cfg.BatchSize, "documents per InsertBatch call")
+	fs.StringVar(&cfg.Collection, "collection", cfg.Collection, "collection name")
+	fs.StringVar(&documentFormat, "format", string(cfg.DocumentFormat), "document format: json or template-v1")
+	fs.IntVar(&cfg.IndexCount, "indexes", cfg.IndexCount, "secondary index count for the benchmark shape: 0, 1, 2, or 3")
+	fs.StringVar(&profile, "profile", string(cfg.Profile), "TreeDB profile: fast, wal_on_fast, durable, or bench")
+	fs.BoolVar(&cfg.DataOuterLeavesInValueLog, "data-outer-leaves-in-vlog", cfg.DataOuterLeavesInValueLog, "store collection primary/index-state outer leaves through the value log")
+	fs.BoolVar(&cfg.IndexOuterLeavesInValueLog, "index-outer-leaves-in-vlog", cfg.IndexOuterLeavesInValueLog, "store secondary-index outer leaves through the value log")
+	fs.Int64Var(&cfg.ChunkSize, "chunk-size", 0, "override TreeDB pager chunk size in bytes")
+	fs.IntVar(&cfg.PagerSyncConcurrency, "pager-sync-concurrency", 0, "override TreeDB pager sync concurrency")
+	fs.BoolVar(&cfg.Checkpoint, "checkpoint", cfg.Checkpoint, "checkpoint after loading")
+	fs.BoolVar(&cfg.CheckpointEachBatch, "checkpoint-each-batch", false, "checkpoint after every batch")
+	fs.BoolVar(&cfg.ReopenVerify, "reopen-verify", cfg.ReopenVerify, "close, reopen, and verify sampled primary/index reads")
+	fs.IntVar(&cfg.VerifySamples, "verify-samples", cfg.VerifySamples, "sample count for -reopen-verify")
+	fs.BoolVar(&cfg.ValueLogRewrite, "vlog-rewrite", false, "run TreeDB online value-log rewrite after loading")
+	fs.BoolVar(&cfg.ValueLogGC, "vlog-gc", cfg.ValueLogGC, "run value-log GC after -vlog-rewrite")
+	fs.BoolVar(&cfg.Progress, "progress", cfg.Progress, "print load progress to stderr")
+	fs.BoolVar(&cfg.JSONOutput, "json", false, "print summary as JSON")
+	fs.StringVar(&cfg.CPUProfile, "cpuprofile", "", "write CPU profile to this path")
+	fs.StringVar(&cfg.MemProfile, "memprofile", "", "write heap profile to this path")
+	if err := fs.Parse(args); err != nil {
+		return cfg, err
+	}
+	if fs.NArg() != 0 {
+		return cfg, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	parsedFormat, err := parseDocumentFormat(documentFormat)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.DocumentFormat = parsedFormat
+	parsedProfile, err := parseProfile(profile)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Profile = parsedProfile
+	if cfg.Docs <= 0 {
+		return cfg, fmt.Errorf("-docs must be > 0")
+	}
+	if cfg.BatchSize <= 0 {
+		return cfg, fmt.Errorf("-batch-size must be > 0")
+	}
+	if cfg.IndexCount < 0 || cfg.IndexCount > 3 {
+		return cfg, fmt.Errorf("-indexes must be 0, 1, 2, or 3")
+	}
+	if strings.TrimSpace(cfg.Collection) == "" {
+		return cfg, fmt.Errorf("-collection cannot be empty")
+	}
+	if cfg.ChunkSize < 0 {
+		return cfg, fmt.Errorf("-chunk-size must be >= 0")
+	}
+	if cfg.PagerSyncConcurrency < 0 {
+		return cfg, fmt.Errorf("-pager-sync-concurrency must be >= 0")
+	}
+	if cfg.VerifySamples < 0 {
+		return cfg, fmt.Errorf("-verify-samples must be >= 0")
+	}
+	return cfg, nil
+}
+
+func parseDocumentFormat(raw string) (collections.DocumentFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "json":
+		return collections.DocumentFormatJSON, nil
+	case string(collections.DocumentFormatTemplateV1):
+		return collections.DocumentFormatTemplateV1, nil
+	case "":
+		return "", fmt.Errorf("-format cannot be empty; use json or template-v1")
+	default:
+		return "", fmt.Errorf("unsupported -format %q", raw)
+	}
+}
+
+func parseProfile(raw string) (treedb.Profile, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "fast", "production_fast", "backend_direct_fast", "backend_direct", "cached":
+		return treedb.ProfileFast, nil
+	case "wal_on_fast", "production_wal_on_fast", "backend_direct_wal_on_fast":
+		return treedb.ProfileWALOnFast, nil
+	case "durable":
+		return treedb.ProfileDurable, nil
+	case "bench":
+		return treedb.ProfileBench, nil
+	default:
+		return "", fmt.Errorf("unsupported -profile %q", raw)
+	}
+}
+
+func runFixture(cfg config) (loadSummary, error) {
+	dir, createdTempDir, err := prepareFixtureDir(cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	cfg.Dir = dir
+	cfg.createdTempDir = createdTempDir
+
+	stopCPU, err := startCPUProfile(cfg.CPUProfile)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	defer stopCPU()
+
+	backend, cleanup, err := openBackend(cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+
+	closed := false
+	defer func() {
+		if !closed {
+			_ = cleanup()
+		}
+	}()
+
+	collection, err := createFixtureCollection(backend, cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+
+	var insertStats collections.CollectionInsertStats
+	secondaryRuns := make(map[string]*secondaryRunSummary)
+	var generationElapsed time.Duration
+	var insertElapsed time.Duration
+	var checkpointElapsed time.Duration
+	wallStart := time.Now()
+	batches := 0
+	lastProgress := time.Now()
+
+	for inserted := 0; inserted < cfg.Docs; {
+		batchSize := cfg.BatchSize
+		if remaining := cfg.Docs - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		genStart := time.Now()
+		ids, docs, err := documentBatch(cfg.DocumentFormat, inserted, batchSize)
+		if err != nil {
+			return loadSummary{}, err
+		}
+		generationElapsed += time.Since(genStart)
+
+		insertStart := time.Now()
+		if _, err := collection.InsertBatch(ids, docs); err != nil {
+			return loadSummary{}, fmt.Errorf("insert batch starting at document %d: %w", inserted, err)
+		}
+		insertElapsed += time.Since(insertStart)
+		stats := collection.LastInsertStats()
+		addInsertStats(&insertStats, stats)
+		addSecondaryRuns(secondaryRuns, stats.SecondaryRuns)
+		batches++
+		inserted += batchSize
+
+		if cfg.CheckpointEachBatch {
+			checkpointStart := time.Now()
+			if err := backend.Checkpoint(); err != nil {
+				return loadSummary{}, fmt.Errorf("checkpoint after batch %d: %w", batches, err)
+			}
+			checkpointElapsed += time.Since(checkpointStart)
+		}
+		if cfg.Progress && time.Since(lastProgress) >= time.Second {
+			fmt.Fprintf(os.Stderr, "inserted %d/%d documents into %s\n", inserted, cfg.Docs, cfg.Dir)
+			lastProgress = time.Now()
+		}
+	}
+
+	if err := collection.Flush(); err != nil {
+		return loadSummary{}, fmt.Errorf("flush collection: %w", err)
+	}
+	if cfg.Checkpoint {
+		checkpointStart := time.Now()
+		if err := backend.Checkpoint(); err != nil {
+			return loadSummary{}, fmt.Errorf("final checkpoint: %w", err)
+		}
+		checkpointElapsed += time.Since(checkpointStart)
+	}
+
+	beforeMaintenance, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	rewrite, err := maybeRewriteValueLog(cfg, backend, beforeMaintenance.TotalBytes)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	wallElapsed := time.Since(wallStart)
+
+	if err := cleanup(); err != nil {
+		closed = true
+		return loadSummary{}, fmt.Errorf("close backend: %w", err)
+	}
+	closed = true
+
+	verify := verifySummary{Enabled: cfg.ReopenVerify}
+	if cfg.ReopenVerify {
+		samples, err := verifyReopen(cfg)
+		if err != nil {
+			return loadSummary{}, err
+		}
+		verify.Samples = samples
+	}
+
+	finalUsage, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	if err := writeMemProfile(cfg.MemProfile); err != nil {
+		return loadSummary{}, err
+	}
+
+	return loadSummary{
+		GeneratedAt:                time.Now().UTC().Format(time.RFC3339),
+		Dir:                        cfg.Dir,
+		CreatedTempDir:             cfg.createdTempDir,
+		Collection:                 cfg.Collection,
+		DocumentFormat:             string(cfg.DocumentFormat),
+		Profile:                    string(cfg.Profile),
+		Docs:                       cfg.Docs,
+		BatchSize:                  cfg.BatchSize,
+		Batches:                    batches,
+		IndexCount:                 cfg.IndexCount,
+		DataOuterLeavesInValueLog:  cfg.DataOuterLeavesInValueLog,
+		IndexOuterLeavesInValueLog: cfg.IndexOuterLeavesInValueLog,
+		ChunkSize:                  cfg.ChunkSize,
+		PagerSyncConcurrency:       cfg.PagerSyncConcurrency,
+		WallTiming:                 timing(wallElapsed, cfg.Docs),
+		GenerationTiming:           timing(generationElapsed, cfg.Docs),
+		InsertTiming:               timing(insertElapsed, cfg.Docs),
+		CheckpointTiming:           timing(checkpointElapsed, cfg.Docs),
+		InsertPhases:               summarizeInsertPhases(insertStats, secondaryRuns, cfg.Docs, batches),
+		DiskUsageBeforeMaintenance: beforeMaintenance,
+		DiskUsageFinal:             finalUsage,
+		Rewrite:                    rewrite,
+		Verify:                     verify,
+		CPUProfile:                 cfg.CPUProfile,
+		MemProfile:                 cfg.MemProfile,
+		GoVersion:                  runtime.Version(),
+		GOOS:                       runtime.GOOS,
+		GOARCH:                     runtime.GOARCH,
+	}, nil
+}
+
+func prepareFixtureDir(cfg config) (string, bool, error) {
+	if strings.TrimSpace(cfg.Dir) == "" {
+		dir, err := os.MkdirTemp("", "treedb_collection_fixture_")
+		if err != nil {
+			return "", false, fmt.Errorf("create temp fixture dir: %w", err)
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return "", false, err
+		}
+		return abs, true, nil
+	}
+	dir, err := filepath.Abs(cfg.Dir)
+	if err != nil {
+		return "", false, err
+	}
+	if cfg.Reset {
+		if err := os.RemoveAll(dir); err != nil {
+			return "", false, fmt.Errorf("reset fixture dir %s: %w", dir, err)
+		}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", false, fmt.Errorf("create fixture dir %s: %w", dir, err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", false, fmt.Errorf("read fixture dir %s: %w", dir, err)
+	}
+	if len(entries) != 0 {
+		return "", false, fmt.Errorf("fixture dir %s is not empty; choose an empty dir or pass -reset", dir)
+	}
+	return dir, false, nil
+}
+
+func openBackend(cfg config) (*backenddb.DB, func() error, error) {
+	opts := treedb.OptionsFor(cfg.Profile, cfg.Dir)
+	opts.IndexOuterLeavesInValueLog = cfg.DataOuterLeavesInValueLog || cfg.IndexOuterLeavesInValueLog
+	opts.IndexInternalBaseDelta = !opts.IndexOuterLeavesInValueLog
+	if cfg.ChunkSize > 0 {
+		opts.ChunkSize = cfg.ChunkSize
+	}
+	if cfg.PagerSyncConcurrency > 0 {
+		opts.PagerSyncConcurrency = cfg.PagerSyncConcurrency
+	}
+	open := treedb.OpenBackend
+	if opts.IndexOuterLeavesInValueLog {
+		open = treedb.OpenBackendWithCachedLeafLog
+	}
+	backend, cleanup, err := open(opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open backend: %w", err)
+	}
+	return backend, cleanup, nil
+}
+
+func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Collection, error) {
+	manager := collections.NewCollectionManager(backend)
+	indexes := collectionShapeIndexes(cfg.IndexCount)
+	for i := range indexes {
+		indexes[i].StoragePolicy = rootStoragePolicy(cfg.IndexOuterLeavesInValueLog)
+	}
+	_, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: cfg.Collection,
+		Options: collections.CollectionOptions{
+			DocumentFormat:          cfg.DocumentFormat,
+			DataRootStoragePolicy:   rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+			IndexStateStoragePolicy: rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+		},
+		Indexes: indexes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create collection: %w", err)
+	}
+	collection, err := manager.OpenCollection(cfg.Collection)
+	if err != nil {
+		return nil, fmt.Errorf("open collection: %w", err)
+	}
+	return collection, nil
+}
+
+func rootStoragePolicy(outerLeavesInValueLog bool) collections.RootStoragePolicy {
+	if outerLeavesInValueLog {
+		return collections.RootStorageCompressed
+	}
+	return collections.RootStorageFast
+}
+
+func collectionShapeIndexes(indexCount int) []collections.IndexDefinition {
+	switch indexCount {
+	case 0:
+		return nil
+	case 1:
+		return []collections.IndexDefinition{{Name: "email_idx", Field: "email", Unique: true}}
+	case 2:
+		return []collections.IndexDefinition{
+			{Name: "email_idx", Field: "email", Unique: true},
+			{Name: "city_idx", Field: "city"},
+		}
+	case 3:
+		return []collections.IndexDefinition{
+			{Name: "email_idx", Field: "email", Unique: true},
+			{Name: "city_idx", Field: "city"},
+			{Name: "name_idx", Field: "name"},
+		}
+	default:
+		panic(fmt.Sprintf("unsupported index count %d", indexCount))
+	}
+}
+
+func documentBatch(format collections.DocumentFormat, start, count int) ([][]byte, [][]byte, error) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	var templateEncoder collections.TemplateV1Encoder
+	for i := 0; i < count; i++ {
+		docNum := start + i
+		ids[i] = documentID(docNum)
+		doc, err := document(format, &templateEncoder, docNum)
+		if err != nil {
+			return nil, nil, err
+		}
+		docs[i] = doc
+	}
+	return ids, docs, nil
+}
+
+func document(format collections.DocumentFormat, encoder *collections.TemplateV1Encoder, n int) ([]byte, error) {
+	if format == collections.DocumentFormatTemplateV1 {
+		if encoder == nil {
+			encoder = &collections.TemplateV1Encoder{}
+		}
+		return encoder.EncodeDocument(
+			[]string{"name", "email", "city", "pad"},
+			[]any{
+				fmt.Sprintf("user-%09d", n),
+				fmt.Sprintf("user-%09d@example.com", n),
+				fmt.Sprintf("city-%02d", n%collectionFixtureCities),
+				collectionFixturePad,
+			},
+		)
+	}
+	return indexedJSONDocument(n), nil
+}
+
+func documentID(n int) []byte {
+	out := make([]byte, 0, len("u-")+9)
+	out = append(out, "u-"...)
+	return appendZeroPaddedInt(out, n, 9)
+}
+
+func indexedJSONDocument(n int) []byte {
+	out := make([]byte, 0, 112)
+	out = append(out, `{"name":"user-`...)
+	out = appendZeroPaddedInt(out, n, 9)
+	out = append(out, `","email":"user-`...)
+	out = appendZeroPaddedInt(out, n, 9)
+	out = append(out, `@example.com","city":"city-`...)
+	out = appendZeroPaddedInt(out, n%collectionFixtureCities, 2)
+	out = append(out, `","pad":"`...)
+	out = append(out, collectionFixturePad...)
+	out = append(out, `"}`...)
+	return out
+}
+
+func appendZeroPaddedInt(dst []byte, n, width int) []byte {
+	var scratch [20]byte
+	pos := len(scratch)
+	if n == 0 {
+		pos--
+		scratch[pos] = '0'
+	} else {
+		for n > 0 {
+			pos--
+			scratch[pos] = byte('0' + n%10)
+			n /= 10
+		}
+	}
+	for pad := width - (len(scratch) - pos); pad > 0; pad-- {
+		dst = append(dst, '0')
+	}
+	return append(dst, scratch[pos:]...)
+}
+
+func addInsertStats(dst *collections.CollectionInsertStats, src collections.CollectionInsertStats) {
+	dst.Documents += src.Documents
+	dst.Indexes += src.Indexes
+	dst.Runs += src.Runs
+	dst.PrepareDocuments += src.PrepareDocuments
+	dst.IndexStateExtraction += src.IndexStateExtraction
+	dst.DuplicateDocumentPreflight += src.DuplicateDocumentPreflight
+	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
+	dst.TemplateRunBuild += src.TemplateRunBuild
+	dst.PrimaryRunBuild += src.PrimaryRunBuild
+	dst.IndexStateRunBuild += src.IndexStateRunBuild
+	dst.SecondaryRunBuild += src.SecondaryRunBuild
+	dst.Publish += src.Publish
+	dst.SecondaryEntries += src.SecondaryEntries
+	dst.SecondaryKeyBytes += src.SecondaryKeyBytes
+	dst.SecondarySortedRuns += src.SecondarySortedRuns
+	dst.SecondaryUnsortedRuns += src.SecondaryUnsortedRuns
+}
+
+func addSecondaryRuns(dst map[string]*secondaryRunSummary, runs []collections.CollectionSecondaryRunStats) {
+	for _, run := range runs {
+		entry := dst[run.IndexName]
+		if entry == nil {
+			entry = &secondaryRunSummary{IndexName: run.IndexName}
+			dst[run.IndexName] = entry
+		}
+		entry.Runs++
+		entry.Entries += run.Entries
+		entry.KeyBytes += run.KeyBytes
+		if run.AlreadySorted {
+			entry.SortedRuns++
+		} else {
+			entry.UnsortedRuns++
+		}
+		entry.BuildNSPerDoc += float64(run.Build.Nanoseconds())
+	}
+}
+
+func summarizeInsertPhases(stats collections.CollectionInsertStats, secondaryRuns map[string]*secondaryRunSummary, docs, batches int) insertPhaseSummary {
+	out := insertPhaseSummary{
+		Documents: stats.Documents,
+		Indexes:   stats.Indexes,
+		Runs:      stats.Runs,
+	}
+	nsPerDoc := func(d time.Duration) float64 {
+		if docs <= 0 || d <= 0 {
+			return 0
+		}
+		return float64(d.Nanoseconds()) / float64(docs)
+	}
+	perDocInt := func(v int) float64 {
+		if docs <= 0 || v <= 0 {
+			return 0
+		}
+		return float64(v) / float64(docs)
+	}
+	perBatchInt := func(v int) float64 {
+		if batches <= 0 || v <= 0 {
+			return 0
+		}
+		return float64(v) / float64(batches)
+	}
+	out.PrepareDocumentsNSPerDoc = nsPerDoc(stats.PrepareDocuments)
+	out.IndexStateExtractionNSPerDoc = nsPerDoc(stats.IndexStateExtraction)
+	out.DuplicatePreflightNSPerDoc = nsPerDoc(stats.DuplicateDocumentPreflight)
+	out.UniquePreflightNSPerDoc = nsPerDoc(stats.UniqueIndexPreflight)
+	out.TemplateRunBuildNSPerDoc = nsPerDoc(stats.TemplateRunBuild)
+	out.PrimaryRunBuildNSPerDoc = nsPerDoc(stats.PrimaryRunBuild)
+	out.IndexStateRunBuildNSPerDoc = nsPerDoc(stats.IndexStateRunBuild)
+	out.SecondaryRunBuildNSPerDoc = nsPerDoc(stats.SecondaryRunBuild)
+	out.PublishNSPerDoc = nsPerDoc(stats.Publish)
+	out.SecondaryEntriesPerDoc = perDocInt(stats.SecondaryEntries)
+	out.SecondaryKeyBytesPerDoc = perDocInt(stats.SecondaryKeyBytes)
+	out.SecondarySortedRunsPerBatch = perBatchInt(stats.SecondarySortedRuns)
+	out.SecondaryUnsortedRunsPerBatch = perBatchInt(stats.SecondaryUnsortedRuns)
+
+	keys := make([]string, 0, len(secondaryRuns))
+	for key := range secondaryRuns {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		run := *secondaryRuns[key]
+		if docs > 0 {
+			run.BuildNSPerDoc /= float64(docs)
+			run.EntriesPerDoc = float64(run.Entries) / float64(docs)
+			run.KeyBytesPerDoc = float64(run.KeyBytes) / float64(docs)
+		}
+		out.SecondaryRuns = append(out.SecondaryRuns, run)
+	}
+	return out
+}
+
+func maybeRewriteValueLog(cfg config, backend *backenddb.DB, beforeBytes uint64) (rewriteSummary, error) {
+	out := rewriteSummary{Enabled: cfg.ValueLogRewrite}
+	if !cfg.ValueLogRewrite {
+		return out, nil
+	}
+	out.DiskBytesBefore = beforeBytes
+	rewriteStart := time.Now()
+	rewriteStats, err := backend.ValueLogRewriteOnline(context.Background(), backenddb.ValueLogRewriteOnlineOptions{})
+	if err != nil {
+		return out, fmt.Errorf("value-log rewrite: %w", err)
+	}
+	out.RewriteTiming = timing(time.Since(rewriteStart), 1)
+	if err := backend.Checkpoint(); err != nil {
+		return out, fmt.Errorf("checkpoint after value-log rewrite: %w", err)
+	}
+	afterRewrite, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return out, err
+	}
+	out.DiskBytesAfterRewrite = afterRewrite.TotalBytes
+	out.SegmentsBefore = int(rewriteStats.SegmentsBefore)
+	out.SegmentsAfter = int(rewriteStats.SegmentsAfter)
+	out.RecordsCopied = int(rewriteStats.RecordsCopied)
+	out.ValueRecordsCopied = int(rewriteStats.ValueRecordsCopied)
+	out.ValueBytesCopied = rewriteStats.ValueBytesCopied
+	out.TemplateRecordsKept = int(rewriteStats.TemplateRecordsKept)
+
+	if cfg.ValueLogGC {
+		gcStart := time.Now()
+		gcStats, err := backend.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{})
+		if err != nil {
+			return out, fmt.Errorf("value-log GC after rewrite: %w", err)
+		}
+		out.GCTiming = timing(time.Since(gcStart), 1)
+		if err := backend.Checkpoint(); err != nil {
+			return out, fmt.Errorf("checkpoint after value-log GC: %w", err)
+		}
+		afterGC, err := directoryUsage(cfg.Dir, cfg.Docs)
+		if err != nil {
+			return out, err
+		}
+		out.DiskBytesAfterGC = afterGC.TotalBytes
+		out.GCSegmentsDeleted = int(gcStats.SegmentsDeleted)
+		out.GCBytesDeleted = gcStats.BytesDeleted
+	}
+	return out, nil
+}
+
+func verifyReopen(cfg config) (int, error) {
+	backend, cleanup, err := openBackend(cfg)
+	if err != nil {
+		return 0, fmt.Errorf("reopen verify open: %w", err)
+	}
+	defer func() { _ = cleanup() }()
+	manager := collections.NewCollectionManager(backend)
+	collection, err := manager.OpenCollection(cfg.Collection)
+	if err != nil {
+		return 0, fmt.Errorf("reopen verify open collection: %w", err)
+	}
+	samples := sampleDocumentNumbers(cfg.Docs, cfg.VerifySamples)
+	for _, n := range samples {
+		id := documentID(n)
+		got, err := collection.Get(id)
+		if err != nil {
+			return 0, fmt.Errorf("reopen verify get %s: %w", id, err)
+		}
+		if len(got) == 0 {
+			return 0, fmt.Errorf("reopen verify get %s returned an empty document", id)
+		}
+		if cfg.DocumentFormat == collections.DocumentFormatJSON {
+			want := indexedJSONDocument(n)
+			if !bytes.Equal(got, want) {
+				return 0, fmt.Errorf("reopen verify get %s returned unexpected JSON document", id)
+			}
+		}
+		if cfg.IndexCount >= 1 {
+			email := fmt.Sprintf("user-%09d@example.com", n)
+			ids, err := collection.FindByIndex("email_idx", email)
+			if err != nil {
+				return 0, fmt.Errorf("reopen verify email index %s: %w", email, err)
+			}
+			if len(ids) != 1 || !bytes.Equal(ids[0], id) {
+				return 0, fmt.Errorf("reopen verify email index %s returned %q, want %s", email, ids, id)
+			}
+		}
+		if cfg.IndexCount >= 2 {
+			city := fmt.Sprintf("city-%02d", n%collectionFixtureCities)
+			ids, err := collection.FindByIndex("city_idx", city)
+			if err != nil {
+				return 0, fmt.Errorf("reopen verify city index %s: %w", city, err)
+			}
+			if len(ids) == 0 {
+				return 0, fmt.Errorf("reopen verify city index %s returned no rows", city)
+			}
+		}
+	}
+	return len(samples), nil
+}
+
+func sampleDocumentNumbers(docs, sampleCount int) []int {
+	if docs <= 0 || sampleCount <= 0 {
+		return nil
+	}
+	if sampleCount > docs {
+		sampleCount = docs
+	}
+	seen := make(map[int]struct{}, sampleCount)
+	out := make([]int, 0, sampleCount)
+	for i := 0; i < sampleCount; i++ {
+		var n int
+		if sampleCount == 1 {
+			n = 0
+		} else {
+			n = i * (docs - 1) / (sampleCount - 1)
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}
+
+func directoryUsage(root string, docs int) (diskUsageSummary, error) {
+	var total uint64
+	var fileCount int
+	files := make([]fileSummary, 0, maxFixtureTopFileEntries)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() || info.Size() <= 0 {
+			return nil
+		}
+		size := uint64(info.Size())
+		total += size
+		fileCount++
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			rel = path
+		}
+		files = append(files, fileSummary{Path: rel, Bytes: size})
+		return nil
+	})
+	if err != nil {
+		return diskUsageSummary{}, fmt.Errorf("disk usage for %s: %w", root, err)
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].Bytes == files[j].Bytes {
+			return files[i].Path < files[j].Path
+		}
+		return files[i].Bytes > files[j].Bytes
+	})
+	if len(files) > maxFixtureTopFileEntries {
+		files = files[:maxFixtureTopFileEntries]
+	}
+	out := diskUsageSummary{TotalBytes: total, FileCount: fileCount, TopFiles: files}
+	if docs > 0 {
+		out.BytesPerDoc = float64(total) / float64(docs)
+	}
+	return out, nil
+}
+
+func timing(d time.Duration, ops int) timingSummary {
+	out := timingSummary{Seconds: d.Seconds()}
+	if ops > 0 && d > 0 {
+		out.SecPerOp = d.Seconds() / float64(ops)
+		out.OpsPerSec = float64(ops) / d.Seconds()
+	}
+	return out
+}
+
+func startCPUProfile(path string) (func(), error) {
+	if strings.TrimSpace(path) == "" {
+		return func() {}, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create CPU profile dir: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("create CPU profile: %w", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("start CPU profile: %w", err)
+	}
+	stopped := false
+	return func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		pprof.StopCPUProfile()
+		_ = f.Close()
+	}, nil
+}
+
+func writeMemProfile(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create heap profile dir: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create heap profile: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	runtime.GC()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		return fmt.Errorf("write heap profile: %w", err)
+	}
+	return nil
+}
+
+func printHumanSummary(w io.Writer, summary loadSummary) {
+	fmt.Fprintf(w, "TreeDB collection load fixture\n")
+	fmt.Fprintf(w, "dir: %s\n", summary.Dir)
+	fmt.Fprintf(w, "collection: %s\n", summary.Collection)
+	fmt.Fprintf(w, "shape: format=%s indexes=%d data_outer_leaves_in_vlog=%t index_outer_leaves_in_vlog=%t profile=%s\n",
+		summary.DocumentFormat, summary.IndexCount, summary.DataOuterLeavesInValueLog, summary.IndexOuterLeavesInValueLog, summary.Profile)
+	fmt.Fprintf(w, "loaded: docs=%d batches=%d batch_size=%d\n", summary.Docs, summary.Batches, summary.BatchSize)
+	printTiming(w, "wall", summary.WallTiming)
+	printTiming(w, "document generation", summary.GenerationTiming)
+	printTiming(w, "insert", summary.InsertTiming)
+	if summary.CheckpointTiming.Seconds > 0 {
+		printTiming(w, "checkpoint", summary.CheckpointTiming)
+	}
+	fmt.Fprintf(w, "disk before maintenance: %s total, %.2f bytes/doc, %d files\n",
+		humanBytes(summary.DiskUsageBeforeMaintenance.TotalBytes), summary.DiskUsageBeforeMaintenance.BytesPerDoc, summary.DiskUsageBeforeMaintenance.FileCount)
+	if summary.Rewrite.Enabled {
+		fmt.Fprintf(w, "vlog rewrite: before=%s after_rewrite=%s after_gc=%s copied_records=%d copied_value_bytes=%s\n",
+			humanBytes(summary.Rewrite.DiskBytesBefore),
+			humanBytes(summary.Rewrite.DiskBytesAfterRewrite),
+			humanBytes(summary.Rewrite.DiskBytesAfterGC),
+			summary.Rewrite.RecordsCopied,
+			humanBytes(uint64(max(summary.Rewrite.ValueBytesCopied, 0))))
+	}
+	fmt.Fprintf(w, "disk final: %s total, %.2f bytes/doc, %d files\n",
+		humanBytes(summary.DiskUsageFinal.TotalBytes), summary.DiskUsageFinal.BytesPerDoc, summary.DiskUsageFinal.FileCount)
+	if summary.Verify.Enabled {
+		fmt.Fprintf(w, "reopen verify: %d sampled primary/index reads passed\n", summary.Verify.Samples)
+	}
+	if len(summary.DiskUsageFinal.TopFiles) > 0 {
+		fmt.Fprintf(w, "largest files:\n")
+		for _, file := range summary.DiskUsageFinal.TopFiles {
+			fmt.Fprintf(w, "  %12s  %s\n", humanBytes(file.Bytes), file.Path)
+		}
+	}
+	if summary.CPUProfile != "" {
+		fmt.Fprintf(w, "cpu profile: %s\n", summary.CPUProfile)
+	}
+	if summary.MemProfile != "" {
+		fmt.Fprintf(w, "heap profile: %s\n", summary.MemProfile)
+	}
+}
+
+func printTiming(w io.Writer, label string, t timingSummary) {
+	fmt.Fprintf(w, "%s: %.3fs, %.9f sec/op, %.0f ops/sec\n", label, t.Seconds, t.SecPerOp, t.OpsPerSec)
+}
+
+func humanBytes(n uint64) string {
+	const unit = 1024
+	if n < unit {
+		return strconv.FormatUint(n, 10) + " B"
+	}
+	div, exp := uint64(unit), 0
+	for value := n / unit; value >= unit; value /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -818,12 +818,21 @@ func verifyReopen(cfg config) (int, error) {
 			if err != nil {
 				return 0, fmt.Errorf("reopen verify city index %s: %w", city, err)
 			}
-			if len(ids) == 0 {
-				return 0, fmt.Errorf("reopen verify city index %s returned no rows", city)
+			if !containsDocumentID(ids, id) {
+				return 0, fmt.Errorf("reopen verify city index %s did not include %s", city, id)
 			}
 		}
 	}
 	return len(samples), nil
+}
+
+func containsDocumentID(ids [][]byte, want []byte) bool {
+	for _, id := range ids {
+		if bytes.Equal(id, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func sampleDocumentNumbers(docs, sampleCount int) []int {

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -1,0 +1,1010 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	defaultDocs              = 1_000_000
+	defaultBatchSize         = 8_000
+	defaultCollectionName    = "bench_shape_insert_2"
+	collectionFixtureCities  = 64
+	collectionFixturePad     = "01234567890123456789"
+	maxFixtureTopFileEntries = 20
+)
+
+type config struct {
+	Dir                        string
+	Reset                      bool
+	Docs                       int
+	BatchSize                  int
+	Collection                 string
+	DocumentFormat             collections.DocumentFormat
+	IndexCount                 int
+	Profile                    treedb.Profile
+	DataOuterLeavesInValueLog  bool
+	IndexOuterLeavesInValueLog bool
+	ChunkSize                  int64
+	PagerSyncConcurrency       int
+	Checkpoint                 bool
+	CheckpointEachBatch        bool
+	ReopenVerify               bool
+	VerifySamples              int
+	ValueLogRewrite            bool
+	ValueLogGC                 bool
+	Progress                   bool
+	JSONOutput                 bool
+	CPUProfile                 string
+	MemProfile                 string
+	createdTempDir             bool
+}
+
+type timingSummary struct {
+	Seconds   float64 `json:"seconds"`
+	SecPerOp  float64 `json:"sec_per_op,omitempty"`
+	OpsPerSec float64 `json:"ops_per_sec,omitempty"`
+}
+
+type diskUsageSummary struct {
+	TotalBytes  uint64        `json:"total_bytes"`
+	BytesPerDoc float64       `json:"bytes_per_doc,omitempty"`
+	FileCount   int           `json:"file_count"`
+	TopFiles    []fileSummary `json:"top_files,omitempty"`
+}
+
+type fileSummary struct {
+	Path  string `json:"path"`
+	Bytes uint64 `json:"bytes"`
+}
+
+type insertPhaseSummary struct {
+	Documents                     int                   `json:"documents"`
+	Indexes                       int                   `json:"indexes"`
+	Runs                          int                   `json:"runs"`
+	PrepareDocumentsNSPerDoc      float64               `json:"prepare_documents_ns_per_doc,omitempty"`
+	IndexStateExtractionNSPerDoc  float64               `json:"index_state_extraction_ns_per_doc,omitempty"`
+	DuplicatePreflightNSPerDoc    float64               `json:"duplicate_preflight_ns_per_doc,omitempty"`
+	UniquePreflightNSPerDoc       float64               `json:"unique_preflight_ns_per_doc,omitempty"`
+	TemplateRunBuildNSPerDoc      float64               `json:"template_run_build_ns_per_doc,omitempty"`
+	PrimaryRunBuildNSPerDoc       float64               `json:"primary_run_build_ns_per_doc,omitempty"`
+	IndexStateRunBuildNSPerDoc    float64               `json:"index_state_run_build_ns_per_doc,omitempty"`
+	SecondaryRunBuildNSPerDoc     float64               `json:"secondary_run_build_ns_per_doc,omitempty"`
+	PublishNSPerDoc               float64               `json:"publish_ns_per_doc,omitempty"`
+	SecondaryEntriesPerDoc        float64               `json:"secondary_entries_per_doc,omitempty"`
+	SecondaryKeyBytesPerDoc       float64               `json:"secondary_key_bytes_per_doc,omitempty"`
+	SecondarySortedRunsPerBatch   float64               `json:"secondary_sorted_runs_per_batch,omitempty"`
+	SecondaryUnsortedRunsPerBatch float64               `json:"secondary_unsorted_runs_per_batch,omitempty"`
+	SecondaryRuns                 []secondaryRunSummary `json:"secondary_runs,omitempty"`
+}
+
+type secondaryRunSummary struct {
+	IndexName      string  `json:"index_name"`
+	Runs           int     `json:"runs"`
+	Entries        int     `json:"entries"`
+	KeyBytes       int     `json:"key_bytes"`
+	SortedRuns     int     `json:"sorted_runs"`
+	UnsortedRuns   int     `json:"unsorted_runs"`
+	BuildNSPerDoc  float64 `json:"build_ns_per_doc,omitempty"`
+	EntriesPerDoc  float64 `json:"entries_per_doc,omitempty"`
+	KeyBytesPerDoc float64 `json:"key_bytes_per_doc,omitempty"`
+}
+
+type rewriteSummary struct {
+	Enabled               bool          `json:"enabled"`
+	RewriteTiming         timingSummary `json:"rewrite_timing,omitempty"`
+	GCTiming              timingSummary `json:"gc_timing,omitempty"`
+	DiskBytesBefore       uint64        `json:"disk_bytes_before,omitempty"`
+	DiskBytesAfterRewrite uint64        `json:"disk_bytes_after_rewrite,omitempty"`
+	DiskBytesAfterGC      uint64        `json:"disk_bytes_after_gc,omitempty"`
+	SegmentsBefore        int           `json:"segments_before,omitempty"`
+	SegmentsAfter         int           `json:"segments_after,omitempty"`
+	RecordsCopied         int           `json:"records_copied,omitempty"`
+	ValueRecordsCopied    int           `json:"value_records_copied,omitempty"`
+	ValueBytesCopied      int64         `json:"value_bytes_copied,omitempty"`
+	TemplateRecordsKept   int           `json:"template_records_kept,omitempty"`
+	GCSegmentsDeleted     int           `json:"gc_segments_deleted,omitempty"`
+	GCBytesDeleted        int64         `json:"gc_bytes_deleted,omitempty"`
+}
+
+type verifySummary struct {
+	Enabled bool `json:"enabled"`
+	Samples int  `json:"samples,omitempty"`
+}
+
+type loadSummary struct {
+	GeneratedAt                string             `json:"generated_at"`
+	Dir                        string             `json:"dir"`
+	CreatedTempDir             bool               `json:"created_temp_dir,omitempty"`
+	Collection                 string             `json:"collection"`
+	DocumentFormat             string             `json:"document_format"`
+	Profile                    string             `json:"profile"`
+	Docs                       int                `json:"docs"`
+	BatchSize                  int                `json:"batch_size"`
+	Batches                    int                `json:"batches"`
+	IndexCount                 int                `json:"index_count"`
+	DataOuterLeavesInValueLog  bool               `json:"data_outer_leaves_in_value_log"`
+	IndexOuterLeavesInValueLog bool               `json:"index_outer_leaves_in_value_log"`
+	ChunkSize                  int64              `json:"chunk_size,omitempty"`
+	PagerSyncConcurrency       int                `json:"pager_sync_concurrency,omitempty"`
+	WallTiming                 timingSummary      `json:"wall_timing"`
+	GenerationTiming           timingSummary      `json:"generation_timing"`
+	InsertTiming               timingSummary      `json:"insert_timing"`
+	CheckpointTiming           timingSummary      `json:"checkpoint_timing,omitempty"`
+	InsertPhases               insertPhaseSummary `json:"insert_phases"`
+	DiskUsageBeforeMaintenance diskUsageSummary   `json:"disk_usage_before_maintenance"`
+	DiskUsageFinal             diskUsageSummary   `json:"disk_usage_final"`
+	Rewrite                    rewriteSummary     `json:"rewrite,omitempty"`
+	Verify                     verifySummary      `json:"verify"`
+	CPUProfile                 string             `json:"cpu_profile,omitempty"`
+	MemProfile                 string             `json:"mem_profile,omitempty"`
+	GoVersion                  string             `json:"go_version"`
+	GOOS                       string             `json:"goos"`
+	GOARCH                     string             `json:"goarch"`
+}
+
+func main() {
+	cfg, err := parseConfig(os.Args[1:], os.Stderr)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		fmt.Fprintf(os.Stderr, "collection-load-fixture: %v\n", err)
+		os.Exit(2)
+	}
+	summary, err := runFixture(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collection-load-fixture: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg.JSONOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(summary); err != nil {
+			fmt.Fprintf(os.Stderr, "collection-load-fixture: write json summary: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	printHumanSummary(os.Stdout, summary)
+}
+
+func parseConfig(args []string, output io.Writer) (config, error) {
+	cfg := config{
+		Docs:                       defaultDocs,
+		BatchSize:                  defaultBatchSize,
+		Collection:                 defaultCollectionName,
+		DocumentFormat:             collections.DocumentFormatTemplateV1,
+		IndexCount:                 2,
+		Profile:                    treedb.ProfileFast,
+		DataOuterLeavesInValueLog:  true,
+		IndexOuterLeavesInValueLog: true,
+		Checkpoint:                 true,
+		ReopenVerify:               true,
+		VerifySamples:              8,
+		ValueLogGC:                 true,
+		Progress:                   true,
+	}
+	var documentFormat string
+	var profile string
+	fs := flag.NewFlagSet("collection-load-fixture", flag.ContinueOnError)
+	if output == nil {
+		output = io.Discard
+	}
+	fs.SetOutput(output)
+	fs.StringVar(&cfg.Dir, "dir", "", "directory to create and keep; empty creates a kept OS temp directory")
+	fs.BoolVar(&cfg.Reset, "reset", false, "remove -dir before loading; ignored when -dir is empty")
+	fs.IntVar(&cfg.Docs, "docs", cfg.Docs, "number of documents to insert")
+	fs.IntVar(&cfg.BatchSize, "batch-size", cfg.BatchSize, "documents per InsertBatch call")
+	fs.StringVar(&cfg.Collection, "collection", cfg.Collection, "collection name")
+	fs.StringVar(&documentFormat, "format", string(cfg.DocumentFormat), "document format: json or template-v1")
+	fs.IntVar(&cfg.IndexCount, "indexes", cfg.IndexCount, "secondary index count for the benchmark shape: 0, 1, 2, or 3")
+	fs.StringVar(&profile, "profile", string(cfg.Profile), "TreeDB profile: fast, wal_on_fast, durable, or bench")
+	fs.BoolVar(&cfg.DataOuterLeavesInValueLog, "data-outer-leaves-in-vlog", cfg.DataOuterLeavesInValueLog, "store collection primary/index-state outer leaves through the value log")
+	fs.BoolVar(&cfg.IndexOuterLeavesInValueLog, "index-outer-leaves-in-vlog", cfg.IndexOuterLeavesInValueLog, "store secondary-index outer leaves through the value log")
+	fs.Int64Var(&cfg.ChunkSize, "chunk-size", 0, "override TreeDB pager chunk size in bytes")
+	fs.IntVar(&cfg.PagerSyncConcurrency, "pager-sync-concurrency", 0, "override TreeDB pager sync concurrency")
+	fs.BoolVar(&cfg.Checkpoint, "checkpoint", cfg.Checkpoint, "checkpoint after loading")
+	fs.BoolVar(&cfg.CheckpointEachBatch, "checkpoint-each-batch", false, "checkpoint after every batch")
+	fs.BoolVar(&cfg.ReopenVerify, "reopen-verify", cfg.ReopenVerify, "close, reopen, and verify sampled primary/index reads")
+	fs.IntVar(&cfg.VerifySamples, "verify-samples", cfg.VerifySamples, "sample count for -reopen-verify")
+	fs.BoolVar(&cfg.ValueLogRewrite, "vlog-rewrite", false, "run TreeDB online value-log rewrite after loading")
+	fs.BoolVar(&cfg.ValueLogGC, "vlog-gc", cfg.ValueLogGC, "run value-log GC after -vlog-rewrite")
+	fs.BoolVar(&cfg.Progress, "progress", cfg.Progress, "print load progress to stderr")
+	fs.BoolVar(&cfg.JSONOutput, "json", false, "print summary as JSON")
+	fs.StringVar(&cfg.CPUProfile, "cpuprofile", "", "write CPU profile to this path")
+	fs.StringVar(&cfg.MemProfile, "memprofile", "", "write heap profile to this path")
+	if err := fs.Parse(args); err != nil {
+		return cfg, err
+	}
+	if fs.NArg() != 0 {
+		return cfg, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	parsedFormat, err := parseDocumentFormat(documentFormat)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.DocumentFormat = parsedFormat
+	parsedProfile, err := parseProfile(profile)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Profile = parsedProfile
+	if cfg.Docs <= 0 {
+		return cfg, fmt.Errorf("-docs must be > 0")
+	}
+	if cfg.BatchSize <= 0 {
+		return cfg, fmt.Errorf("-batch-size must be > 0")
+	}
+	if cfg.IndexCount < 0 || cfg.IndexCount > 3 {
+		return cfg, fmt.Errorf("-indexes must be 0, 1, 2, or 3")
+	}
+	if strings.TrimSpace(cfg.Collection) == "" {
+		return cfg, fmt.Errorf("-collection cannot be empty")
+	}
+	if cfg.ChunkSize < 0 {
+		return cfg, fmt.Errorf("-chunk-size must be >= 0")
+	}
+	if cfg.PagerSyncConcurrency < 0 {
+		return cfg, fmt.Errorf("-pager-sync-concurrency must be >= 0")
+	}
+	if cfg.VerifySamples < 0 {
+		return cfg, fmt.Errorf("-verify-samples must be >= 0")
+	}
+	return cfg, nil
+}
+
+func parseDocumentFormat(raw string) (collections.DocumentFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "json":
+		return collections.DocumentFormatJSON, nil
+	case string(collections.DocumentFormatTemplateV1):
+		return collections.DocumentFormatTemplateV1, nil
+	default:
+		return "", fmt.Errorf("unsupported -format %q", raw)
+	}
+}
+
+func parseProfile(raw string) (treedb.Profile, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "fast", "production_fast", "backend_direct_fast", "backend_direct", "cached":
+		return treedb.ProfileFast, nil
+	case "wal_on_fast", "production_wal_on_fast", "backend_direct_wal_on_fast":
+		return treedb.ProfileWALOnFast, nil
+	case "durable":
+		return treedb.ProfileDurable, nil
+	case "bench":
+		return treedb.ProfileBench, nil
+	default:
+		return "", fmt.Errorf("unsupported -profile %q", raw)
+	}
+}
+
+func runFixture(cfg config) (loadSummary, error) {
+	dir, createdTempDir, err := prepareFixtureDir(cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	cfg.Dir = dir
+	cfg.createdTempDir = createdTempDir
+
+	stopCPU, err := startCPUProfile(cfg.CPUProfile)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	defer stopCPU()
+
+	backend, cleanup, err := openBackend(cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+
+	closed := false
+	defer func() {
+		if !closed {
+			_ = cleanup()
+		}
+	}()
+
+	collection, err := createFixtureCollection(backend, cfg)
+	if err != nil {
+		return loadSummary{}, err
+	}
+
+	var insertStats collections.CollectionInsertStats
+	secondaryRuns := make(map[string]*secondaryRunSummary)
+	var generationElapsed time.Duration
+	var insertElapsed time.Duration
+	var checkpointElapsed time.Duration
+	wallStart := time.Now()
+	batches := 0
+	lastProgress := time.Now()
+
+	for inserted := 0; inserted < cfg.Docs; {
+		batchSize := cfg.BatchSize
+		if remaining := cfg.Docs - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		genStart := time.Now()
+		ids, docs, err := documentBatch(cfg.DocumentFormat, inserted, batchSize)
+		if err != nil {
+			return loadSummary{}, err
+		}
+		generationElapsed += time.Since(genStart)
+
+		insertStart := time.Now()
+		if _, err := collection.InsertBatch(ids, docs); err != nil {
+			return loadSummary{}, fmt.Errorf("insert batch starting at document %d: %w", inserted, err)
+		}
+		insertElapsed += time.Since(insertStart)
+		stats := collection.LastInsertStats()
+		addInsertStats(&insertStats, stats)
+		addSecondaryRuns(secondaryRuns, stats.SecondaryRuns)
+		batches++
+		inserted += batchSize
+
+		if cfg.CheckpointEachBatch {
+			checkpointStart := time.Now()
+			if err := backend.Checkpoint(); err != nil {
+				return loadSummary{}, fmt.Errorf("checkpoint after batch %d: %w", batches, err)
+			}
+			checkpointElapsed += time.Since(checkpointStart)
+		}
+		if cfg.Progress && time.Since(lastProgress) >= time.Second {
+			fmt.Fprintf(os.Stderr, "inserted %d/%d documents into %s\n", inserted, cfg.Docs, cfg.Dir)
+			lastProgress = time.Now()
+		}
+	}
+
+	if err := collection.Flush(); err != nil {
+		return loadSummary{}, fmt.Errorf("flush collection: %w", err)
+	}
+	if cfg.Checkpoint {
+		checkpointStart := time.Now()
+		if err := backend.Checkpoint(); err != nil {
+			return loadSummary{}, fmt.Errorf("final checkpoint: %w", err)
+		}
+		checkpointElapsed += time.Since(checkpointStart)
+	}
+
+	beforeMaintenance, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	rewrite, err := maybeRewriteValueLog(cfg, backend, beforeMaintenance.TotalBytes)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	wallElapsed := time.Since(wallStart)
+
+	if err := cleanup(); err != nil {
+		closed = true
+		return loadSummary{}, fmt.Errorf("close backend: %w", err)
+	}
+	closed = true
+
+	verify := verifySummary{Enabled: cfg.ReopenVerify}
+	if cfg.ReopenVerify {
+		samples, err := verifyReopen(cfg)
+		if err != nil {
+			return loadSummary{}, err
+		}
+		verify.Samples = samples
+	}
+
+	finalUsage, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return loadSummary{}, err
+	}
+	if err := writeMemProfile(cfg.MemProfile); err != nil {
+		return loadSummary{}, err
+	}
+
+	return loadSummary{
+		GeneratedAt:                time.Now().UTC().Format(time.RFC3339),
+		Dir:                        cfg.Dir,
+		CreatedTempDir:             cfg.createdTempDir,
+		Collection:                 cfg.Collection,
+		DocumentFormat:             string(cfg.DocumentFormat),
+		Profile:                    string(cfg.Profile),
+		Docs:                       cfg.Docs,
+		BatchSize:                  cfg.BatchSize,
+		Batches:                    batches,
+		IndexCount:                 cfg.IndexCount,
+		DataOuterLeavesInValueLog:  cfg.DataOuterLeavesInValueLog,
+		IndexOuterLeavesInValueLog: cfg.IndexOuterLeavesInValueLog,
+		ChunkSize:                  cfg.ChunkSize,
+		PagerSyncConcurrency:       cfg.PagerSyncConcurrency,
+		WallTiming:                 timing(wallElapsed, cfg.Docs),
+		GenerationTiming:           timing(generationElapsed, cfg.Docs),
+		InsertTiming:               timing(insertElapsed, cfg.Docs),
+		CheckpointTiming:           timing(checkpointElapsed, cfg.Docs),
+		InsertPhases:               summarizeInsertPhases(insertStats, secondaryRuns, cfg.Docs, batches),
+		DiskUsageBeforeMaintenance: beforeMaintenance,
+		DiskUsageFinal:             finalUsage,
+		Rewrite:                    rewrite,
+		Verify:                     verify,
+		CPUProfile:                 cfg.CPUProfile,
+		MemProfile:                 cfg.MemProfile,
+		GoVersion:                  runtime.Version(),
+		GOOS:                       runtime.GOOS,
+		GOARCH:                     runtime.GOARCH,
+	}, nil
+}
+
+func prepareFixtureDir(cfg config) (string, bool, error) {
+	if strings.TrimSpace(cfg.Dir) == "" {
+		dir, err := os.MkdirTemp("", "treedb_collection_fixture_")
+		if err != nil {
+			return "", false, fmt.Errorf("create temp fixture dir: %w", err)
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return "", false, err
+		}
+		return abs, true, nil
+	}
+	dir, err := filepath.Abs(cfg.Dir)
+	if err != nil {
+		return "", false, err
+	}
+	if cfg.Reset {
+		if err := os.RemoveAll(dir); err != nil {
+			return "", false, fmt.Errorf("reset fixture dir %s: %w", dir, err)
+		}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", false, fmt.Errorf("create fixture dir %s: %w", dir, err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", false, fmt.Errorf("read fixture dir %s: %w", dir, err)
+	}
+	if len(entries) != 0 {
+		return "", false, fmt.Errorf("fixture dir %s is not empty; choose an empty dir or pass -reset", dir)
+	}
+	return dir, false, nil
+}
+
+func openBackend(cfg config) (*backenddb.DB, func() error, error) {
+	opts := treedb.OptionsFor(cfg.Profile, cfg.Dir)
+	opts.IndexOuterLeavesInValueLog = cfg.DataOuterLeavesInValueLog || cfg.IndexOuterLeavesInValueLog
+	opts.IndexInternalBaseDelta = !opts.IndexOuterLeavesInValueLog
+	if cfg.ChunkSize > 0 {
+		opts.ChunkSize = cfg.ChunkSize
+	}
+	if cfg.PagerSyncConcurrency > 0 {
+		opts.PagerSyncConcurrency = cfg.PagerSyncConcurrency
+	}
+	open := treedb.OpenBackend
+	if opts.IndexOuterLeavesInValueLog {
+		open = treedb.OpenBackendWithCachedLeafLog
+	}
+	backend, cleanup, err := open(opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open backend: %w", err)
+	}
+	return backend, cleanup, nil
+}
+
+func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Collection, error) {
+	manager := collections.NewCollectionManager(backend)
+	indexes := collectionShapeIndexes(cfg.IndexCount)
+	for i := range indexes {
+		indexes[i].StoragePolicy = rootStoragePolicy(cfg.IndexOuterLeavesInValueLog)
+	}
+	_, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: cfg.Collection,
+		Options: collections.CollectionOptions{
+			DocumentFormat:          cfg.DocumentFormat,
+			DataRootStoragePolicy:   rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+			IndexStateStoragePolicy: rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+		},
+		Indexes: indexes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create collection: %w", err)
+	}
+	collection, err := manager.OpenCollection(cfg.Collection)
+	if err != nil {
+		return nil, fmt.Errorf("open collection: %w", err)
+	}
+	return collection, nil
+}
+
+func rootStoragePolicy(outerLeavesInValueLog bool) collections.RootStoragePolicy {
+	if outerLeavesInValueLog {
+		return collections.RootStorageCompressed
+	}
+	return collections.RootStorageFast
+}
+
+func collectionShapeIndexes(indexCount int) []collections.IndexDefinition {
+	switch indexCount {
+	case 0:
+		return nil
+	case 1:
+		return []collections.IndexDefinition{{Name: "email_idx", Field: "email", Unique: true}}
+	case 2:
+		return []collections.IndexDefinition{
+			{Name: "email_idx", Field: "email", Unique: true},
+			{Name: "city_idx", Field: "city"},
+		}
+	case 3:
+		return []collections.IndexDefinition{
+			{Name: "email_idx", Field: "email", Unique: true},
+			{Name: "city_idx", Field: "city"},
+			{Name: "name_idx", Field: "name"},
+		}
+	default:
+		panic(fmt.Sprintf("unsupported index count %d", indexCount))
+	}
+}
+
+func documentBatch(format collections.DocumentFormat, start, count int) ([][]byte, [][]byte, error) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	var templateEncoder collections.TemplateV1Encoder
+	for i := 0; i < count; i++ {
+		docNum := start + i
+		ids[i] = documentID(docNum)
+		doc, err := document(format, &templateEncoder, docNum)
+		if err != nil {
+			return nil, nil, err
+		}
+		docs[i] = doc
+	}
+	return ids, docs, nil
+}
+
+func document(format collections.DocumentFormat, encoder *collections.TemplateV1Encoder, n int) ([]byte, error) {
+	if format == collections.DocumentFormatTemplateV1 {
+		if encoder == nil {
+			encoder = &collections.TemplateV1Encoder{}
+		}
+		return encoder.EncodeDocument(
+			[]string{"name", "email", "city", "pad"},
+			[]any{
+				fmt.Sprintf("user-%09d", n),
+				fmt.Sprintf("user-%09d@example.com", n),
+				fmt.Sprintf("city-%02d", n%collectionFixtureCities),
+				collectionFixturePad,
+			},
+		)
+	}
+	return indexedJSONDocument(n), nil
+}
+
+func documentID(n int) []byte {
+	out := make([]byte, 0, len("u-")+9)
+	out = append(out, "u-"...)
+	return appendZeroPaddedInt(out, n, 9)
+}
+
+func indexedJSONDocument(n int) []byte {
+	out := make([]byte, 0, 112)
+	out = append(out, `{"name":"user-`...)
+	out = appendZeroPaddedInt(out, n, 9)
+	out = append(out, `","email":"user-`...)
+	out = appendZeroPaddedInt(out, n, 9)
+	out = append(out, `@example.com","city":"city-`...)
+	out = appendZeroPaddedInt(out, n%collectionFixtureCities, 2)
+	out = append(out, `","pad":"`...)
+	out = append(out, collectionFixturePad...)
+	out = append(out, `"}`...)
+	return out
+}
+
+func appendZeroPaddedInt(dst []byte, n, width int) []byte {
+	var scratch [20]byte
+	pos := len(scratch)
+	if n == 0 {
+		pos--
+		scratch[pos] = '0'
+	} else {
+		for n > 0 {
+			pos--
+			scratch[pos] = byte('0' + n%10)
+			n /= 10
+		}
+	}
+	for pad := width - (len(scratch) - pos); pad > 0; pad-- {
+		dst = append(dst, '0')
+	}
+	return append(dst, scratch[pos:]...)
+}
+
+func addInsertStats(dst *collections.CollectionInsertStats, src collections.CollectionInsertStats) {
+	dst.Documents += src.Documents
+	dst.Indexes += src.Indexes
+	dst.Runs += src.Runs
+	dst.PrepareDocuments += src.PrepareDocuments
+	dst.IndexStateExtraction += src.IndexStateExtraction
+	dst.DuplicateDocumentPreflight += src.DuplicateDocumentPreflight
+	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
+	dst.TemplateRunBuild += src.TemplateRunBuild
+	dst.PrimaryRunBuild += src.PrimaryRunBuild
+	dst.IndexStateRunBuild += src.IndexStateRunBuild
+	dst.SecondaryRunBuild += src.SecondaryRunBuild
+	dst.Publish += src.Publish
+	dst.SecondaryEntries += src.SecondaryEntries
+	dst.SecondaryKeyBytes += src.SecondaryKeyBytes
+	dst.SecondarySortedRuns += src.SecondarySortedRuns
+	dst.SecondaryUnsortedRuns += src.SecondaryUnsortedRuns
+}
+
+func addSecondaryRuns(dst map[string]*secondaryRunSummary, runs []collections.CollectionSecondaryRunStats) {
+	for _, run := range runs {
+		entry := dst[run.IndexName]
+		if entry == nil {
+			entry = &secondaryRunSummary{IndexName: run.IndexName}
+			dst[run.IndexName] = entry
+		}
+		entry.Runs++
+		entry.Entries += run.Entries
+		entry.KeyBytes += run.KeyBytes
+		if run.AlreadySorted {
+			entry.SortedRuns++
+		} else {
+			entry.UnsortedRuns++
+		}
+		entry.BuildNSPerDoc += float64(run.Build.Nanoseconds())
+	}
+}
+
+func summarizeInsertPhases(stats collections.CollectionInsertStats, secondaryRuns map[string]*secondaryRunSummary, docs, batches int) insertPhaseSummary {
+	out := insertPhaseSummary{
+		Documents: stats.Documents,
+		Indexes:   stats.Indexes,
+		Runs:      stats.Runs,
+	}
+	nsPerDoc := func(d time.Duration) float64 {
+		if docs <= 0 || d <= 0 {
+			return 0
+		}
+		return float64(d.Nanoseconds()) / float64(docs)
+	}
+	perDocInt := func(v int) float64 {
+		if docs <= 0 || v <= 0 {
+			return 0
+		}
+		return float64(v) / float64(docs)
+	}
+	perBatchInt := func(v int) float64 {
+		if batches <= 0 || v <= 0 {
+			return 0
+		}
+		return float64(v) / float64(batches)
+	}
+	out.PrepareDocumentsNSPerDoc = nsPerDoc(stats.PrepareDocuments)
+	out.IndexStateExtractionNSPerDoc = nsPerDoc(stats.IndexStateExtraction)
+	out.DuplicatePreflightNSPerDoc = nsPerDoc(stats.DuplicateDocumentPreflight)
+	out.UniquePreflightNSPerDoc = nsPerDoc(stats.UniqueIndexPreflight)
+	out.TemplateRunBuildNSPerDoc = nsPerDoc(stats.TemplateRunBuild)
+	out.PrimaryRunBuildNSPerDoc = nsPerDoc(stats.PrimaryRunBuild)
+	out.IndexStateRunBuildNSPerDoc = nsPerDoc(stats.IndexStateRunBuild)
+	out.SecondaryRunBuildNSPerDoc = nsPerDoc(stats.SecondaryRunBuild)
+	out.PublishNSPerDoc = nsPerDoc(stats.Publish)
+	out.SecondaryEntriesPerDoc = perDocInt(stats.SecondaryEntries)
+	out.SecondaryKeyBytesPerDoc = perDocInt(stats.SecondaryKeyBytes)
+	out.SecondarySortedRunsPerBatch = perBatchInt(stats.SecondarySortedRuns)
+	out.SecondaryUnsortedRunsPerBatch = perBatchInt(stats.SecondaryUnsortedRuns)
+
+	keys := make([]string, 0, len(secondaryRuns))
+	for key := range secondaryRuns {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		run := *secondaryRuns[key]
+		if docs > 0 {
+			run.BuildNSPerDoc /= float64(docs)
+			run.EntriesPerDoc = float64(run.Entries) / float64(docs)
+			run.KeyBytesPerDoc = float64(run.KeyBytes) / float64(docs)
+		}
+		out.SecondaryRuns = append(out.SecondaryRuns, run)
+	}
+	return out
+}
+
+func maybeRewriteValueLog(cfg config, backend *backenddb.DB, beforeBytes uint64) (rewriteSummary, error) {
+	out := rewriteSummary{Enabled: cfg.ValueLogRewrite}
+	if !cfg.ValueLogRewrite {
+		return out, nil
+	}
+	out.DiskBytesBefore = beforeBytes
+	rewriteStart := time.Now()
+	rewriteStats, err := backend.ValueLogRewriteOnline(context.Background(), backenddb.ValueLogRewriteOnlineOptions{})
+	if err != nil {
+		return out, fmt.Errorf("value-log rewrite: %w", err)
+	}
+	out.RewriteTiming = timing(time.Since(rewriteStart), 1)
+	if err := backend.Checkpoint(); err != nil {
+		return out, fmt.Errorf("checkpoint after value-log rewrite: %w", err)
+	}
+	afterRewrite, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return out, err
+	}
+	out.DiskBytesAfterRewrite = afterRewrite.TotalBytes
+	out.SegmentsBefore = int(rewriteStats.SegmentsBefore)
+	out.SegmentsAfter = int(rewriteStats.SegmentsAfter)
+	out.RecordsCopied = int(rewriteStats.RecordsCopied)
+	out.ValueRecordsCopied = int(rewriteStats.ValueRecordsCopied)
+	out.ValueBytesCopied = rewriteStats.ValueBytesCopied
+	out.TemplateRecordsKept = int(rewriteStats.TemplateRecordsKept)
+
+	if cfg.ValueLogGC {
+		gcStart := time.Now()
+		gcStats, err := backend.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{})
+		if err != nil {
+			return out, fmt.Errorf("value-log GC after rewrite: %w", err)
+		}
+		out.GCTiming = timing(time.Since(gcStart), 1)
+		if err := backend.Checkpoint(); err != nil {
+			return out, fmt.Errorf("checkpoint after value-log GC: %w", err)
+		}
+		afterGC, err := directoryUsage(cfg.Dir, cfg.Docs)
+		if err != nil {
+			return out, err
+		}
+		out.DiskBytesAfterGC = afterGC.TotalBytes
+		out.GCSegmentsDeleted = int(gcStats.SegmentsDeleted)
+		out.GCBytesDeleted = gcStats.BytesDeleted
+	}
+	return out, nil
+}
+
+func verifyReopen(cfg config) (int, error) {
+	backend, cleanup, err := openBackend(cfg)
+	if err != nil {
+		return 0, fmt.Errorf("reopen verify open: %w", err)
+	}
+	defer func() { _ = cleanup() }()
+	manager := collections.NewCollectionManager(backend)
+	collection, err := manager.OpenCollection(cfg.Collection)
+	if err != nil {
+		return 0, fmt.Errorf("reopen verify open collection: %w", err)
+	}
+	samples := sampleDocumentNumbers(cfg.Docs, cfg.VerifySamples)
+	for _, n := range samples {
+		id := documentID(n)
+		got, err := collection.Get(id)
+		if err != nil {
+			return 0, fmt.Errorf("reopen verify get %s: %w", id, err)
+		}
+		if len(got) == 0 {
+			return 0, fmt.Errorf("reopen verify get %s returned an empty document", id)
+		}
+		if cfg.DocumentFormat == collections.DocumentFormatJSON {
+			want := indexedJSONDocument(n)
+			if !bytes.Equal(got, want) {
+				return 0, fmt.Errorf("reopen verify get %s returned unexpected JSON document", id)
+			}
+		}
+		if cfg.IndexCount >= 1 {
+			email := fmt.Sprintf("user-%09d@example.com", n)
+			ids, err := collection.FindByIndex("email_idx", email)
+			if err != nil {
+				return 0, fmt.Errorf("reopen verify email index %s: %w", email, err)
+			}
+			if len(ids) != 1 || !bytes.Equal(ids[0], id) {
+				return 0, fmt.Errorf("reopen verify email index %s returned %q, want %s", email, ids, id)
+			}
+		}
+		if cfg.IndexCount >= 2 {
+			city := fmt.Sprintf("city-%02d", n%collectionFixtureCities)
+			ids, err := collection.FindByIndex("city_idx", city)
+			if err != nil {
+				return 0, fmt.Errorf("reopen verify city index %s: %w", city, err)
+			}
+			if len(ids) == 0 {
+				return 0, fmt.Errorf("reopen verify city index %s returned no rows", city)
+			}
+		}
+	}
+	return len(samples), nil
+}
+
+func sampleDocumentNumbers(docs, sampleCount int) []int {
+	if docs <= 0 || sampleCount <= 0 {
+		return nil
+	}
+	if sampleCount > docs {
+		sampleCount = docs
+	}
+	seen := make(map[int]struct{}, sampleCount)
+	out := make([]int, 0, sampleCount)
+	for i := 0; i < sampleCount; i++ {
+		var n int
+		if sampleCount == 1 {
+			n = 0
+		} else {
+			n = i * (docs - 1) / (sampleCount - 1)
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}
+
+func directoryUsage(root string, docs int) (diskUsageSummary, error) {
+	var total uint64
+	var fileCount int
+	files := make([]fileSummary, 0, maxFixtureTopFileEntries)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() || info.Size() <= 0 {
+			return nil
+		}
+		size := uint64(info.Size())
+		total += size
+		fileCount++
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			rel = path
+		}
+		files = append(files, fileSummary{Path: rel, Bytes: size})
+		return nil
+	})
+	if err != nil {
+		return diskUsageSummary{}, fmt.Errorf("disk usage for %s: %w", root, err)
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].Bytes == files[j].Bytes {
+			return files[i].Path < files[j].Path
+		}
+		return files[i].Bytes > files[j].Bytes
+	})
+	if len(files) > maxFixtureTopFileEntries {
+		files = files[:maxFixtureTopFileEntries]
+	}
+	out := diskUsageSummary{TotalBytes: total, FileCount: fileCount, TopFiles: files}
+	if docs > 0 {
+		out.BytesPerDoc = float64(total) / float64(docs)
+	}
+	return out, nil
+}
+
+func timing(d time.Duration, ops int) timingSummary {
+	out := timingSummary{Seconds: d.Seconds()}
+	if ops > 0 && d > 0 {
+		out.SecPerOp = d.Seconds() / float64(ops)
+		out.OpsPerSec = float64(ops) / d.Seconds()
+	}
+	return out
+}
+
+func startCPUProfile(path string) (func(), error) {
+	if strings.TrimSpace(path) == "" {
+		return func() {}, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create CPU profile dir: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("create CPU profile: %w", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("start CPU profile: %w", err)
+	}
+	stopped := false
+	return func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		pprof.StopCPUProfile()
+		_ = f.Close()
+	}, nil
+}
+
+func writeMemProfile(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create heap profile dir: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create heap profile: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	runtime.GC()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		return fmt.Errorf("write heap profile: %w", err)
+	}
+	return nil
+}
+
+func printHumanSummary(w io.Writer, summary loadSummary) {
+	fmt.Fprintf(w, "TreeDB collection load fixture\n")
+	fmt.Fprintf(w, "dir: %s\n", summary.Dir)
+	fmt.Fprintf(w, "collection: %s\n", summary.Collection)
+	fmt.Fprintf(w, "shape: format=%s indexes=%d data_outer_leaves_in_vlog=%t index_outer_leaves_in_vlog=%t profile=%s\n",
+		summary.DocumentFormat, summary.IndexCount, summary.DataOuterLeavesInValueLog, summary.IndexOuterLeavesInValueLog, summary.Profile)
+	fmt.Fprintf(w, "loaded: docs=%d batches=%d batch_size=%d\n", summary.Docs, summary.Batches, summary.BatchSize)
+	printTiming(w, "wall", summary.WallTiming)
+	printTiming(w, "document generation", summary.GenerationTiming)
+	printTiming(w, "insert", summary.InsertTiming)
+	if summary.CheckpointTiming.Seconds > 0 {
+		printTiming(w, "checkpoint", summary.CheckpointTiming)
+	}
+	fmt.Fprintf(w, "disk before maintenance: %s total, %.2f bytes/doc, %d files\n",
+		humanBytes(summary.DiskUsageBeforeMaintenance.TotalBytes), summary.DiskUsageBeforeMaintenance.BytesPerDoc, summary.DiskUsageBeforeMaintenance.FileCount)
+	if summary.Rewrite.Enabled {
+		fmt.Fprintf(w, "vlog rewrite: before=%s after_rewrite=%s after_gc=%s copied_records=%d copied_value_bytes=%s\n",
+			humanBytes(summary.Rewrite.DiskBytesBefore),
+			humanBytes(summary.Rewrite.DiskBytesAfterRewrite),
+			humanBytes(summary.Rewrite.DiskBytesAfterGC),
+			summary.Rewrite.RecordsCopied,
+			humanBytes(uint64(max(summary.Rewrite.ValueBytesCopied, 0))))
+	}
+	fmt.Fprintf(w, "disk final: %s total, %.2f bytes/doc, %d files\n",
+		humanBytes(summary.DiskUsageFinal.TotalBytes), summary.DiskUsageFinal.BytesPerDoc, summary.DiskUsageFinal.FileCount)
+	if summary.Verify.Enabled {
+		fmt.Fprintf(w, "reopen verify: %d sampled primary/index reads passed\n", summary.Verify.Samples)
+	}
+	if len(summary.DiskUsageFinal.TopFiles) > 0 {
+		fmt.Fprintf(w, "largest files:\n")
+		for _, file := range summary.DiskUsageFinal.TopFiles {
+			fmt.Fprintf(w, "  %12s  %s\n", humanBytes(file.Bytes), file.Path)
+		}
+	}
+	if summary.CPUProfile != "" {
+		fmt.Fprintf(w, "cpu profile: %s\n", summary.CPUProfile)
+	}
+	if summary.MemProfile != "" {
+		fmt.Fprintf(w, "heap profile: %s\n", summary.MemProfile)
+	}
+}
+
+func printTiming(w io.Writer, label string, t timingSummary) {
+	fmt.Fprintf(w, "%s: %.3fs, %.9f sec/op, %.0f ops/sec\n", label, t.Seconds, t.SecPerOp, t.OpsPerSec)
+}
+
+func humanBytes(n uint64) string {
+	const unit = 1024
+	if n < unit {
+		return strconv.FormatUint(n, 10) + " B"
+	}
+	div, exp := uint64(unit), 0
+	for value := n / unit; value >= unit; value /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -28,6 +28,9 @@ const (
 	defaultDocs              = 1_000_000
 	defaultBatchSize         = 8_000
 	defaultCollectionName    = "bench_shape_insert_2"
+	indexVacuumModeNone      = "none"
+	indexVacuumModeOnline    = "online"
+	indexVacuumModeOffline   = "offline"
 	collectionFixtureCities  = 64
 	collectionFixturePad     = "01234567890123456789"
 	maxFixtureTopFileEntries = 20
@@ -45,13 +48,20 @@ type config struct {
 	DataOuterLeavesInValueLog  bool
 	IndexOuterLeavesInValueLog bool
 	ChunkSize                  int64
+	KeepRecent                 uint64
+	PreferAppendAlloc          bool
 	PagerSyncConcurrency       int
+	DisableBackgroundPrune     bool
+	PruneInterval              time.Duration
+	PruneMaxPages              int
+	PruneMaxDuration           time.Duration
 	Checkpoint                 bool
 	CheckpointEachBatch        bool
 	ReopenVerify               bool
 	VerifySamples              int
 	ValueLogRewrite            bool
 	ValueLogGC                 bool
+	IndexVacuum                string
 	Progress                   bool
 	JSONOutput                 bool
 	CPUProfile                 string
@@ -126,40 +136,85 @@ type rewriteSummary struct {
 	GCBytesDeleted        int64         `json:"gc_bytes_deleted,omitempty"`
 }
 
+type indexStorageSummary struct {
+	IndexDBBytes                uint64 `json:"index_db_bytes,omitempty"`
+	PagesTotal                  uint64 `json:"pages_total,omitempty"`
+	KeepRecent                  uint64 `json:"keep_recent,omitempty"`
+	PreferAppendAlloc           bool   `json:"prefer_append_alloc"`
+	FreelistReclaimablePages    uint64 `json:"freelist_reclaimable_pages,omitempty"`
+	FreelistAllocPagesTotal     uint64 `json:"freelist_alloc_pages_total,omitempty"`
+	FreelistAppendPagesTotal    uint64 `json:"freelist_append_pages_total,omitempty"`
+	FreelistReusePagesTotal     uint64 `json:"freelist_reuse_pages_total,omitempty"`
+	FreelistFreePagesTotal      uint64 `json:"freelist_free_pages_total,omitempty"`
+	GraveyardBatches            uint64 `json:"graveyard_batches,omitempty"`
+	GraveyardPages              uint64 `json:"graveyard_pages,omitempty"`
+	CollectionRoots             uint64 `json:"collection_roots,omitempty"`
+	CollectionLeafRefRoots      uint64 `json:"collection_leafref_roots,omitempty"`
+	CollectionPagerRoots        uint64 `json:"collection_pager_roots,omitempty"`
+	CollectionRootPages         uint64 `json:"collection_root_pages,omitempty"`
+	CollectionRootLeafPages     uint64 `json:"collection_root_leaf_pages,omitempty"`
+	CollectionRootInternalPages uint64 `json:"collection_root_internal_pages,omitempty"`
+	CollectionRootDuplicateRefs uint64 `json:"collection_root_duplicate_refs,omitempty"`
+	PruneEnabled                bool   `json:"prune_enabled"`
+	PruneRuns                   uint64 `json:"prune_runs,omitempty"`
+	PrunePagesFreed             uint64 `json:"prune_pages_freed,omitempty"`
+}
+
+type indexVacuumSummary struct {
+	Mode               string              `json:"mode"`
+	Enabled            bool                `json:"enabled"`
+	Timing             timingSummary       `json:"timing,omitempty"`
+	DiskBytesBefore    uint64              `json:"disk_bytes_before,omitempty"`
+	DiskBytesAfter     uint64              `json:"disk_bytes_after,omitempty"`
+	IndexDBBytesBefore uint64              `json:"index_db_bytes_before,omitempty"`
+	IndexDBBytesAfter  uint64              `json:"index_db_bytes_after,omitempty"`
+	StorageBefore      indexStorageSummary `json:"storage_before,omitempty"`
+	StorageAfter       indexStorageSummary `json:"storage_after,omitempty"`
+}
+
 type verifySummary struct {
 	Enabled bool `json:"enabled"`
 	Samples int  `json:"samples,omitempty"`
 }
 
 type loadSummary struct {
-	GeneratedAt                string             `json:"generated_at"`
-	Dir                        string             `json:"dir"`
-	CreatedTempDir             bool               `json:"created_temp_dir,omitempty"`
-	Collection                 string             `json:"collection"`
-	DocumentFormat             string             `json:"document_format"`
-	Profile                    string             `json:"profile"`
-	Docs                       int                `json:"docs"`
-	BatchSize                  int                `json:"batch_size"`
-	Batches                    int                `json:"batches"`
-	IndexCount                 int                `json:"index_count"`
-	DataOuterLeavesInValueLog  bool               `json:"data_outer_leaves_in_value_log"`
-	IndexOuterLeavesInValueLog bool               `json:"index_outer_leaves_in_value_log"`
-	ChunkSize                  int64              `json:"chunk_size,omitempty"`
-	PagerSyncConcurrency       int                `json:"pager_sync_concurrency,omitempty"`
-	WallTiming                 timingSummary      `json:"wall_timing"`
-	GenerationTiming           timingSummary      `json:"generation_timing"`
-	InsertTiming               timingSummary      `json:"insert_timing"`
-	CheckpointTiming           timingSummary      `json:"checkpoint_timing,omitempty"`
-	InsertPhases               insertPhaseSummary `json:"insert_phases"`
-	DiskUsageBeforeMaintenance diskUsageSummary   `json:"disk_usage_before_maintenance"`
-	DiskUsageFinal             diskUsageSummary   `json:"disk_usage_final"`
-	Rewrite                    rewriteSummary     `json:"rewrite,omitempty"`
-	Verify                     verifySummary      `json:"verify"`
-	CPUProfile                 string             `json:"cpu_profile,omitempty"`
-	MemProfile                 string             `json:"mem_profile,omitempty"`
-	GoVersion                  string             `json:"go_version"`
-	GOOS                       string             `json:"goos"`
-	GOARCH                     string             `json:"goarch"`
+	GeneratedAt                   string              `json:"generated_at"`
+	Dir                           string              `json:"dir"`
+	CreatedTempDir                bool                `json:"created_temp_dir,omitempty"`
+	Collection                    string              `json:"collection"`
+	DocumentFormat                string              `json:"document_format"`
+	Profile                       string              `json:"profile"`
+	Docs                          int                 `json:"docs"`
+	BatchSize                     int                 `json:"batch_size"`
+	Batches                       int                 `json:"batches"`
+	IndexCount                    int                 `json:"index_count"`
+	DataOuterLeavesInValueLog     bool                `json:"data_outer_leaves_in_value_log"`
+	IndexOuterLeavesInValueLog    bool                `json:"index_outer_leaves_in_value_log"`
+	ChunkSize                     int64               `json:"chunk_size,omitempty"`
+	KeepRecent                    uint64              `json:"keep_recent"`
+	PreferAppendAlloc             bool                `json:"prefer_append_alloc"`
+	PagerSyncConcurrency          int                 `json:"pager_sync_concurrency,omitempty"`
+	DisableBackgroundPrune        bool                `json:"disable_background_prune,omitempty"`
+	PruneInterval                 string              `json:"prune_interval,omitempty"`
+	PruneMaxPages                 int                 `json:"prune_max_pages,omitempty"`
+	PruneMaxDuration              string              `json:"prune_max_duration,omitempty"`
+	WallTiming                    timingSummary       `json:"wall_timing"`
+	GenerationTiming              timingSummary       `json:"generation_timing"`
+	InsertTiming                  timingSummary       `json:"insert_timing"`
+	CheckpointTiming              timingSummary       `json:"checkpoint_timing,omitempty"`
+	InsertPhases                  insertPhaseSummary  `json:"insert_phases"`
+	IndexStorageBeforeMaintenance indexStorageSummary `json:"index_storage_before_maintenance"`
+	DiskUsageBeforeMaintenance    diskUsageSummary    `json:"disk_usage_before_maintenance"`
+	DiskUsageFinal                diskUsageSummary    `json:"disk_usage_final"`
+	Rewrite                       rewriteSummary      `json:"rewrite,omitempty"`
+	IndexVacuum                   indexVacuumSummary  `json:"index_vacuum,omitempty"`
+	IndexStorageFinal             indexStorageSummary `json:"index_storage_final"`
+	Verify                        verifySummary       `json:"verify"`
+	CPUProfile                    string              `json:"cpu_profile,omitempty"`
+	MemProfile                    string              `json:"mem_profile,omitempty"`
+	GoVersion                     string              `json:"go_version"`
+	GOOS                          string              `json:"goos"`
+	GOARCH                        string              `json:"goarch"`
 }
 
 func main() {
@@ -198,10 +253,13 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 		Profile:                    treedb.ProfileFast,
 		DataOuterLeavesInValueLog:  true,
 		IndexOuterLeavesInValueLog: true,
+		KeepRecent:                 1,
+		PreferAppendAlloc:          false,
 		Checkpoint:                 true,
 		ReopenVerify:               true,
 		VerifySamples:              8,
 		ValueLogGC:                 true,
+		IndexVacuum:                indexVacuumModeNone,
 		Progress:                   true,
 	}
 	var documentFormat string
@@ -222,13 +280,20 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	fs.BoolVar(&cfg.DataOuterLeavesInValueLog, "data-outer-leaves-in-vlog", cfg.DataOuterLeavesInValueLog, "store collection primary/index-state outer leaves through the value log")
 	fs.BoolVar(&cfg.IndexOuterLeavesInValueLog, "index-outer-leaves-in-vlog", cfg.IndexOuterLeavesInValueLog, "store secondary-index outer leaves through the value log")
 	fs.Int64Var(&cfg.ChunkSize, "chunk-size", 0, "override TreeDB pager chunk size in bytes")
+	fs.Uint64Var(&cfg.KeepRecent, "keep-recent", cfg.KeepRecent, "TreeDB index page versions to retain before page reuse")
+	fs.BoolVar(&cfg.PreferAppendAlloc, "prefer-append-alloc", cfg.PreferAppendAlloc, "append new index pages instead of reusing the freelist")
 	fs.IntVar(&cfg.PagerSyncConcurrency, "pager-sync-concurrency", 0, "override TreeDB pager sync concurrency")
+	fs.BoolVar(&cfg.DisableBackgroundPrune, "disable-background-prune", false, "disable background page pruning and prune on the commit path")
+	fs.DurationVar(&cfg.PruneInterval, "prune-interval", 0, "TreeDB background prune interval (0 uses engine default)")
+	fs.IntVar(&cfg.PruneMaxPages, "prune-max-pages", 0, "TreeDB max pages freed per prune tick (0 uses engine default; <0 unlimited)")
+	fs.DurationVar(&cfg.PruneMaxDuration, "prune-max-duration", 0, "TreeDB max prune duration per tick (0 uses engine default; <0 unlimited)")
 	fs.BoolVar(&cfg.Checkpoint, "checkpoint", cfg.Checkpoint, "checkpoint after loading")
 	fs.BoolVar(&cfg.CheckpointEachBatch, "checkpoint-each-batch", false, "checkpoint after every batch")
 	fs.BoolVar(&cfg.ReopenVerify, "reopen-verify", cfg.ReopenVerify, "close, reopen, and verify sampled primary/index reads")
 	fs.IntVar(&cfg.VerifySamples, "verify-samples", cfg.VerifySamples, "sample count for -reopen-verify")
 	fs.BoolVar(&cfg.ValueLogRewrite, "vlog-rewrite", false, "run TreeDB online value-log rewrite after loading")
 	fs.BoolVar(&cfg.ValueLogGC, "vlog-gc", cfg.ValueLogGC, "run value-log GC after -vlog-rewrite")
+	fs.StringVar(&cfg.IndexVacuum, "index-vacuum", cfg.IndexVacuum, "run index vacuum after loading: none, online, or offline")
 	fs.BoolVar(&cfg.Progress, "progress", cfg.Progress, "print load progress to stderr")
 	fs.BoolVar(&cfg.JSONOutput, "json", false, "print summary as JSON")
 	fs.StringVar(&cfg.CPUProfile, "cpuprofile", "", "write CPU profile to this path")
@@ -264,11 +329,25 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	if cfg.ChunkSize < 0 {
 		return cfg, fmt.Errorf("-chunk-size must be >= 0")
 	}
+	if cfg.KeepRecent == 0 {
+		return cfg, fmt.Errorf("-keep-recent must be > 0")
+	}
 	if cfg.PagerSyncConcurrency < 0 {
 		return cfg, fmt.Errorf("-pager-sync-concurrency must be >= 0")
 	}
+	if cfg.PruneInterval < 0 {
+		return cfg, fmt.Errorf("-prune-interval must be >= 0")
+	}
 	if cfg.VerifySamples < 0 {
 		return cfg, fmt.Errorf("-verify-samples must be >= 0")
+	}
+	cfg.IndexVacuum = strings.ToLower(strings.TrimSpace(cfg.IndexVacuum))
+	switch cfg.IndexVacuum {
+	case "", indexVacuumModeNone:
+		cfg.IndexVacuum = indexVacuumModeNone
+	case indexVacuumModeOnline, indexVacuumModeOffline:
+	default:
+		return cfg, fmt.Errorf("unsupported -index-vacuum %q; use none, online, or offline", cfg.IndexVacuum)
 	}
 	return cfg, nil
 }
@@ -388,6 +467,10 @@ func runFixture(cfg config) (loadSummary, error) {
 		checkpointElapsed += time.Since(checkpointStart)
 	}
 
+	beforeIndexStorage, err := captureIndexStorageSummary(cfg, backend)
+	if err != nil {
+		return loadSummary{}, err
+	}
 	beforeMaintenance, err := directoryUsage(cfg.Dir, cfg.Docs)
 	if err != nil {
 		return loadSummary{}, err
@@ -396,13 +479,19 @@ func runFixture(cfg config) (loadSummary, error) {
 	if err != nil {
 		return loadSummary{}, err
 	}
+	indexVacuum, finalIndexStorage, err := maybeVacuumIndex(cfg, backend, cleanup, &closed)
+	if err != nil {
+		return loadSummary{}, err
+	}
 	wallElapsed := time.Since(wallStart)
 
-	if err := cleanup(); err != nil {
+	if !closed {
+		if err := cleanup(); err != nil {
+			closed = true
+			return loadSummary{}, fmt.Errorf("close backend: %w", err)
+		}
 		closed = true
-		return loadSummary{}, fmt.Errorf("close backend: %w", err)
 	}
-	closed = true
 
 	verify := verifySummary{Enabled: cfg.ReopenVerify}
 	if cfg.ReopenVerify {
@@ -422,34 +511,43 @@ func runFixture(cfg config) (loadSummary, error) {
 	}
 
 	return loadSummary{
-		GeneratedAt:                time.Now().UTC().Format(time.RFC3339),
-		Dir:                        cfg.Dir,
-		CreatedTempDir:             cfg.createdTempDir,
-		Collection:                 cfg.Collection,
-		DocumentFormat:             string(cfg.DocumentFormat),
-		Profile:                    string(cfg.Profile),
-		Docs:                       cfg.Docs,
-		BatchSize:                  cfg.BatchSize,
-		Batches:                    batches,
-		IndexCount:                 cfg.IndexCount,
-		DataOuterLeavesInValueLog:  cfg.DataOuterLeavesInValueLog,
-		IndexOuterLeavesInValueLog: cfg.IndexOuterLeavesInValueLog,
-		ChunkSize:                  cfg.ChunkSize,
-		PagerSyncConcurrency:       cfg.PagerSyncConcurrency,
-		WallTiming:                 timing(wallElapsed, cfg.Docs),
-		GenerationTiming:           timing(generationElapsed, cfg.Docs),
-		InsertTiming:               timing(insertElapsed, cfg.Docs),
-		CheckpointTiming:           timing(checkpointElapsed, cfg.Docs),
-		InsertPhases:               summarizeInsertPhases(insertStats, secondaryRuns, cfg.Docs, batches),
-		DiskUsageBeforeMaintenance: beforeMaintenance,
-		DiskUsageFinal:             finalUsage,
-		Rewrite:                    rewrite,
-		Verify:                     verify,
-		CPUProfile:                 cfg.CPUProfile,
-		MemProfile:                 cfg.MemProfile,
-		GoVersion:                  runtime.Version(),
-		GOOS:                       runtime.GOOS,
-		GOARCH:                     runtime.GOARCH,
+		GeneratedAt:                   time.Now().UTC().Format(time.RFC3339),
+		Dir:                           cfg.Dir,
+		CreatedTempDir:                cfg.createdTempDir,
+		Collection:                    cfg.Collection,
+		DocumentFormat:                string(cfg.DocumentFormat),
+		Profile:                       string(cfg.Profile),
+		Docs:                          cfg.Docs,
+		BatchSize:                     cfg.BatchSize,
+		Batches:                       batches,
+		IndexCount:                    cfg.IndexCount,
+		DataOuterLeavesInValueLog:     cfg.DataOuterLeavesInValueLog,
+		IndexOuterLeavesInValueLog:    cfg.IndexOuterLeavesInValueLog,
+		ChunkSize:                     cfg.ChunkSize,
+		KeepRecent:                    cfg.KeepRecent,
+		PreferAppendAlloc:             cfg.PreferAppendAlloc,
+		PagerSyncConcurrency:          cfg.PagerSyncConcurrency,
+		DisableBackgroundPrune:        cfg.DisableBackgroundPrune,
+		PruneInterval:                 durationString(cfg.PruneInterval),
+		PruneMaxPages:                 cfg.PruneMaxPages,
+		PruneMaxDuration:              durationString(cfg.PruneMaxDuration),
+		WallTiming:                    timing(wallElapsed, cfg.Docs),
+		GenerationTiming:              timing(generationElapsed, cfg.Docs),
+		InsertTiming:                  timing(insertElapsed, cfg.Docs),
+		CheckpointTiming:              timing(checkpointElapsed, cfg.Docs),
+		InsertPhases:                  summarizeInsertPhases(insertStats, secondaryRuns, cfg.Docs, batches),
+		IndexStorageBeforeMaintenance: beforeIndexStorage,
+		DiskUsageBeforeMaintenance:    beforeMaintenance,
+		DiskUsageFinal:                finalUsage,
+		Rewrite:                       rewrite,
+		IndexVacuum:                   indexVacuum,
+		IndexStorageFinal:             finalIndexStorage,
+		Verify:                        verify,
+		CPUProfile:                    cfg.CPUProfile,
+		MemProfile:                    cfg.MemProfile,
+		GoVersion:                     runtime.Version(),
+		GOOS:                          runtime.GOOS,
+		GOARCH:                        runtime.GOARCH,
 	}, nil
 }
 
@@ -491,11 +589,23 @@ func openBackend(cfg config) (*backenddb.DB, func() error, error) {
 	opts := treedb.OptionsFor(cfg.Profile, cfg.Dir)
 	opts.IndexOuterLeavesInValueLog = cfg.DataOuterLeavesInValueLog || cfg.IndexOuterLeavesInValueLog
 	opts.IndexInternalBaseDelta = !opts.IndexOuterLeavesInValueLog
+	opts.KeepRecent = cfg.KeepRecent
+	opts.PreferAppendAlloc = cfg.PreferAppendAlloc
+	opts.DisableBackgroundPrune = cfg.DisableBackgroundPrune
 	if cfg.ChunkSize > 0 {
 		opts.ChunkSize = cfg.ChunkSize
 	}
 	if cfg.PagerSyncConcurrency > 0 {
 		opts.PagerSyncConcurrency = cfg.PagerSyncConcurrency
+	}
+	if cfg.PruneInterval > 0 {
+		opts.PruneInterval = cfg.PruneInterval
+	}
+	if cfg.PruneMaxPages != 0 {
+		opts.PruneMaxPages = cfg.PruneMaxPages
+	}
+	if cfg.PruneMaxDuration != 0 {
+		opts.PruneMaxDuration = cfg.PruneMaxDuration
 	}
 	open := treedb.OpenBackend
 	if opts.IndexOuterLeavesInValueLog {
@@ -776,6 +886,179 @@ func maybeRewriteValueLog(cfg config, backend *backenddb.DB, beforeBytes uint64)
 	return out, nil
 }
 
+func maybeVacuumIndex(cfg config, backend *backenddb.DB, cleanup func() error, closed *bool) (indexVacuumSummary, indexStorageSummary, error) {
+	out := indexVacuumSummary{
+		Mode:    cfg.IndexVacuum,
+		Enabled: cfg.IndexVacuum != indexVacuumModeNone,
+	}
+	if cfg.IndexVacuum == indexVacuumModeNone {
+		finalStorage, err := captureIndexStorageSummary(cfg, backend)
+		return out, finalStorage, err
+	}
+
+	beforeDisk, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return out, indexStorageSummary{}, err
+	}
+	beforeStorage, err := captureIndexStorageSummary(cfg, backend)
+	if err != nil {
+		return out, indexStorageSummary{}, err
+	}
+	out.DiskBytesBefore = beforeDisk.TotalBytes
+	out.IndexDBBytesBefore = beforeStorage.IndexDBBytes
+	out.StorageBefore = beforeStorage
+
+	start := time.Now()
+	switch cfg.IndexVacuum {
+	case indexVacuumModeOnline:
+		if err := backend.VacuumIndexOnline(context.Background()); err != nil {
+			return out, indexStorageSummary{}, fmt.Errorf("index vacuum online: %w", err)
+		}
+		if err := backend.Checkpoint(); err != nil {
+			return out, indexStorageSummary{}, fmt.Errorf("checkpoint after online index vacuum: %w", err)
+		}
+	case indexVacuumModeOffline:
+		if cleanup == nil || closed == nil {
+			return out, indexStorageSummary{}, errors.New("offline index vacuum requires backend cleanup state")
+		}
+		if err := cleanup(); err != nil {
+			*closed = true
+			return out, indexStorageSummary{}, fmt.Errorf("close backend before offline index vacuum: %w", err)
+		}
+		*closed = true
+		opts := treedb.Options{
+			Dir:        cfg.Dir,
+			KeepRecent: cfg.KeepRecent,
+		}
+		if cfg.ChunkSize > 0 {
+			opts.ChunkSize = cfg.ChunkSize
+		}
+		if err := treedb.VacuumIndexOffline(opts); err != nil {
+			return out, indexStorageSummary{}, fmt.Errorf("index vacuum offline: %w", err)
+		}
+	default:
+		return out, indexStorageSummary{}, fmt.Errorf("unsupported index vacuum mode %q", cfg.IndexVacuum)
+	}
+	out.Timing = timing(time.Since(start), 1)
+
+	var afterStorage indexStorageSummary
+	if cfg.IndexVacuum == indexVacuumModeOffline {
+		afterStorage, err = captureIndexStorageSummaryReopen(cfg)
+	} else {
+		afterStorage, err = captureIndexStorageSummary(cfg, backend)
+	}
+	if err != nil {
+		return out, indexStorageSummary{}, err
+	}
+	afterDisk, err := directoryUsage(cfg.Dir, cfg.Docs)
+	if err != nil {
+		return out, indexStorageSummary{}, err
+	}
+	out.DiskBytesAfter = afterDisk.TotalBytes
+	out.IndexDBBytesAfter = afterStorage.IndexDBBytes
+	out.StorageAfter = afterStorage
+	return out, afterStorage, nil
+}
+
+func captureIndexStorageSummaryReopen(cfg config) (indexStorageSummary, error) {
+	backend, cleanup, err := openBackend(cfg)
+	if err != nil {
+		return indexStorageSummary{}, fmt.Errorf("capture index storage reopen: %w", err)
+	}
+	defer func() { _ = cleanup() }()
+	return captureIndexStorageSummary(cfg, backend)
+}
+
+func captureIndexStorageSummary(cfg config, backend *backenddb.DB) (indexStorageSummary, error) {
+	if backend == nil {
+		return indexStorageSummary{}, errors.New("capture index storage: missing backend")
+	}
+	stats := backend.Stats()
+	frag, err := backend.FragmentationReport()
+	if err != nil {
+		return indexStorageSummary{}, fmt.Errorf("fragmentation report: %w", err)
+	}
+	merged := make(map[string]string, len(stats)+len(frag))
+	for k, v := range frag {
+		merged[k] = v
+	}
+	for k, v := range stats {
+		merged[k] = v
+	}
+
+	indexBytes, err := indexDBSize(cfg.Dir)
+	if err != nil {
+		return indexStorageSummary{}, err
+	}
+
+	return indexStorageSummary{
+		IndexDBBytes:                indexBytes,
+		PagesTotal:                  statUint(merged, "treedb.pages.total"),
+		KeepRecent:                  statUint(merged, "treedb.keep_recent"),
+		PreferAppendAlloc:           statBool(merged, "treedb.prefer_append_alloc"),
+		FreelistReclaimablePages:    statUint(merged, "treedb.freelist.reclaimable_pages"),
+		FreelistAllocPagesTotal:     statUint(merged, "treedb.freelist.alloc_pages_total"),
+		FreelistAppendPagesTotal:    statUint(merged, "treedb.freelist.append_alloc_pages_total"),
+		FreelistReusePagesTotal:     statUint(merged, "treedb.freelist.reuse_alloc_pages_total"),
+		FreelistFreePagesTotal:      statUint(merged, "treedb.freelist.free_pages_total"),
+		GraveyardBatches:            statUint(merged, "treedb.graveyard.batches"),
+		GraveyardPages:              statUint(merged, "treedb.graveyard.pages"),
+		CollectionRoots:             statUint(merged, "treedb.collection_roots.count"),
+		CollectionLeafRefRoots:      statUint(merged, "treedb.collection_roots.leafref_roots"),
+		CollectionPagerRoots:        statUint(merged, "treedb.collection_roots.pager_roots"),
+		CollectionRootPages:         statUint(merged, "treedb.collection_roots.pages"),
+		CollectionRootLeafPages:     statUint(merged, "treedb.collection_roots.pages.leaf"),
+		CollectionRootInternalPages: statUint(merged, "treedb.collection_roots.pages.internal"),
+		CollectionRootDuplicateRefs: statUint(merged, "treedb.collection_roots.pages.duplicate_refs"),
+		PruneEnabled:                statBool(merged, "treedb.prune.enabled"),
+		PruneRuns:                   statUint(merged, "treedb.prune.runs"),
+		PrunePagesFreed:             statUint(merged, "treedb.prune.pages_freed"),
+	}, nil
+}
+
+func indexDBSize(root string) (uint64, error) {
+	for _, path := range []string{
+		filepath.Join(root, "maindb", "index.db"),
+		filepath.Join(root, "index.db"),
+	} {
+		info, err := os.Stat(path)
+		if err == nil {
+			if !info.Mode().IsRegular() {
+				return 0, fmt.Errorf("%s is not a regular file", path)
+			}
+			return uint64(info.Size()), nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return 0, fmt.Errorf("stat index.db %s: %w", path, err)
+		}
+	}
+	return 0, fmt.Errorf("index.db not found under %s", root)
+}
+
+func statUint(stats map[string]string, key string) uint64 {
+	raw := strings.TrimSpace(stats[key])
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func statBool(stats map[string]string, key string) bool {
+	raw := strings.TrimSpace(stats[key])
+	if raw == "" {
+		return false
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false
+	}
+	return v
+}
+
 func verifyReopen(cfg config) (int, error) {
 	backend, cleanup, err := openBackend(cfg)
 	if err != nil {
@@ -977,6 +1260,13 @@ func timing(d time.Duration, ops int) timingSummary {
 	return out
 }
 
+func durationString(d time.Duration) string {
+	if d == 0 {
+		return ""
+	}
+	return d.String()
+}
+
 func startCPUProfile(path string) (func(), error) {
 	if strings.TrimSpace(path) == "" {
 		return func() {}, nil
@@ -1028,6 +1318,8 @@ func printHumanSummary(w io.Writer, summary loadSummary) {
 	fmt.Fprintf(w, "collection: %s\n", summary.Collection)
 	fmt.Fprintf(w, "shape: format=%s indexes=%d data_outer_leaves_in_vlog=%t index_outer_leaves_in_vlog=%t profile=%s\n",
 		summary.DocumentFormat, summary.IndexCount, summary.DataOuterLeavesInValueLog, summary.IndexOuterLeavesInValueLog, summary.Profile)
+	fmt.Fprintf(w, "index policy: keep_recent=%d prefer_append_alloc=%t background_prune=%t\n",
+		summary.KeepRecent, summary.PreferAppendAlloc, !summary.DisableBackgroundPrune)
 	fmt.Fprintf(w, "loaded: docs=%d batches=%d batch_size=%d\n", summary.Docs, summary.Batches, summary.BatchSize)
 	printTiming(w, "wall", summary.WallTiming)
 	printTiming(w, "document generation", summary.GenerationTiming)
@@ -1035,6 +1327,7 @@ func printHumanSummary(w io.Writer, summary loadSummary) {
 	if summary.CheckpointTiming.Seconds > 0 {
 		printTiming(w, "checkpoint", summary.CheckpointTiming)
 	}
+	printIndexStorageSummary(w, "index before maintenance", summary.IndexStorageBeforeMaintenance)
 	fmt.Fprintf(w, "disk before maintenance: %s total, %.2f bytes/doc, %d files\n",
 		humanBytes(summary.DiskUsageBeforeMaintenance.TotalBytes), summary.DiskUsageBeforeMaintenance.BytesPerDoc, summary.DiskUsageBeforeMaintenance.FileCount)
 	if summary.Rewrite.Enabled {
@@ -1045,6 +1338,16 @@ func printHumanSummary(w io.Writer, summary loadSummary) {
 			summary.Rewrite.RecordsCopied,
 			humanBytes(uint64(max(summary.Rewrite.ValueBytesCopied, 0))))
 	}
+	if summary.IndexVacuum.Enabled {
+		fmt.Fprintf(w, "index vacuum %s: before=%s after=%s index.db_before=%s index.db_after=%s\n",
+			summary.IndexVacuum.Mode,
+			humanBytes(summary.IndexVacuum.DiskBytesBefore),
+			humanBytes(summary.IndexVacuum.DiskBytesAfter),
+			humanBytes(summary.IndexVacuum.IndexDBBytesBefore),
+			humanBytes(summary.IndexVacuum.IndexDBBytesAfter))
+		printTiming(w, "index vacuum", summary.IndexVacuum.Timing)
+	}
+	printIndexStorageSummary(w, "index final", summary.IndexStorageFinal)
 	fmt.Fprintf(w, "disk final: %s total, %.2f bytes/doc, %d files\n",
 		humanBytes(summary.DiskUsageFinal.TotalBytes), summary.DiskUsageFinal.BytesPerDoc, summary.DiskUsageFinal.FileCount)
 	if summary.Verify.Enabled {
@@ -1062,6 +1365,22 @@ func printHumanSummary(w io.Writer, summary loadSummary) {
 	if summary.MemProfile != "" {
 		fmt.Fprintf(w, "heap profile: %s\n", summary.MemProfile)
 	}
+}
+
+func printIndexStorageSummary(w io.Writer, label string, s indexStorageSummary) {
+	if s.IndexDBBytes == 0 && s.PagesTotal == 0 {
+		return
+	}
+	fmt.Fprintf(w, "%s: index.db=%s pages=%d collection_root_pages=%d freelist_reclaimable=%d graveyard_pages=%d append_alloc=%d reuse_alloc=%d prune_freed=%d\n",
+		label,
+		humanBytes(s.IndexDBBytes),
+		s.PagesTotal,
+		s.CollectionRootPages,
+		s.FreelistReclaimablePages,
+		s.GraveyardPages,
+		s.FreelistAppendPagesTotal,
+		s.FreelistReusePagesTotal,
+		s.PrunePagesFreed)
 }
 
 func printTiming(w io.Writer, label string, t timingSummary) {

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
@@ -169,6 +170,9 @@ func TestVacuumIndexOfflinePreservesTemplateV1TwoIndexDatabase(t *testing.T) {
 }
 
 func TestVacuumIndexOnlinePreservesTemplateV1TwoIndexDatabase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum unsupported on windows")
+	}
 	if testing.Short() {
 		t.Skip("loads a large enough fixture to exercise multi-batch collection roots")
 	}

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -69,6 +70,30 @@ func TestRunFixtureKeepsTemplateV1TwoIndexDatabase(t *testing.T) {
 	}
 }
 
+func TestRunFixtureKeepsTemplateV1ThreeIndexDatabase(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "fixture")
+	cfg, err := parseConfig([]string{
+		"-dir", dir,
+		"-docs", "16",
+		"-batch-size", "5",
+		"-indexes", "3",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	summary, err := runFixture(cfg)
+	if err != nil {
+		t.Fatalf("run fixture: %v", err)
+	}
+	if summary.IndexCount != 3 {
+		t.Fatalf("index count=%d want 3", summary.IndexCount)
+	}
+	if summary.Verify.Samples == 0 {
+		t.Fatal("expected reopen verification samples")
+	}
+}
+
 func TestRunFixtureRejectsNonEmptyDirectoryUnlessReset(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "sentinel"), []byte("x"), 0o644); err != nil {
@@ -90,5 +115,30 @@ func TestContainsDocumentID(t *testing.T) {
 	}
 	if containsDocumentID(ids, []byte("u-000000002")) {
 		t.Fatal("unexpected non-matching id")
+	}
+}
+
+func TestTemplateV1StoredDocumentExtractsInputEnvelope(t *testing.T) {
+	var encoder collections.TemplateV1Encoder
+	raw, err := document(collections.DocumentFormatTemplateV1, &encoder, 7)
+	if err != nil {
+		t.Fatalf("document: %v", err)
+	}
+	stored, err := templateV1StoredDocument(raw)
+	if err != nil {
+		t.Fatalf("stored document: %v", err)
+	}
+	if !bytes.HasPrefix(stored, []byte("TD1D")) {
+		t.Fatalf("stored document prefix=%q want TD1D", string(stored[:4]))
+	}
+	if bytes.HasPrefix(stored, []byte("TD1I")) {
+		t.Fatal("expected template-v1 input envelope to be stripped")
+	}
+	again, err := templateV1StoredDocument(stored)
+	if err != nil {
+		t.Fatalf("stored document idempotence: %v", err)
+	}
+	if !bytes.Equal(again, stored) {
+		t.Fatal("stored document conversion changed an already-stored payload")
 	}
 }

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
+	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
 )
 
@@ -30,11 +32,26 @@ func TestParseConfigDefaultsToInspectableTwoIndexTemplateFixture(t *testing.T) {
 	if !cfg.Checkpoint || !cfg.ReopenVerify {
 		t.Fatalf("checkpoint=%t reopen_verify=%t want both true", cfg.Checkpoint, cfg.ReopenVerify)
 	}
+	if cfg.KeepRecent != 1 {
+		t.Fatalf("keep_recent=%d want 1", cfg.KeepRecent)
+	}
+	if cfg.PreferAppendAlloc {
+		t.Fatal("expected prefer append allocation to be disabled by default")
+	}
+	if cfg.IndexVacuum != indexVacuumModeNone {
+		t.Fatalf("index vacuum mode=%q want none", cfg.IndexVacuum)
+	}
 }
 
 func TestParseConfigRejectsExplicitEmptyFormat(t *testing.T) {
 	if _, err := parseConfig([]string{"-format", ""}, io.Discard); err == nil {
 		t.Fatal("expected explicit empty -format to fail")
+	}
+}
+
+func TestParseConfigRejectsInvalidIndexVacuumMode(t *testing.T) {
+	if _, err := parseConfig([]string{"-index-vacuum", "sometimes"}, io.Discard); err == nil {
+		t.Fatal("expected invalid -index-vacuum to fail")
 	}
 }
 
@@ -65,6 +82,9 @@ func TestRunFixtureKeepsTemplateV1TwoIndexDatabase(t *testing.T) {
 	if summary.DiskUsageFinal.TotalBytes == 0 {
 		t.Fatal("expected final disk usage")
 	}
+	if summary.IndexStorageFinal.IndexDBBytes == 0 {
+		t.Fatal("expected final index storage summary")
+	}
 	if _, err := os.Stat(filepath.Join(dir, "maindb", "index.db")); err != nil {
 		t.Fatalf("expected kept maindb/index.db: %v", err)
 	}
@@ -91,6 +111,100 @@ func TestRunFixtureKeepsTemplateV1ThreeIndexDatabase(t *testing.T) {
 	}
 	if summary.Verify.Samples == 0 {
 		t.Fatal("expected reopen verification samples")
+	}
+}
+
+func TestVacuumIndexOfflinePreservesTemplateV1TwoIndexDatabase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("loads a large enough fixture to exercise multi-batch collection roots")
+	}
+
+	dir := filepath.Join(t.TempDir(), "fixture")
+	cfg, err := parseConfig([]string{
+		"-dir", dir,
+		"-docs", "100000",
+		"-batch-size", "80",
+		"-verify-samples", "16",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+
+	summary, err := runFixture(cfg)
+	if err != nil {
+		t.Fatalf("run fixture: %v", err)
+	}
+	if summary.IndexCount != 2 {
+		t.Fatalf("index count=%d want 2", summary.IndexCount)
+	}
+
+	indexPath := filepath.Join(dir, "maindb", "index.db")
+	beforeVacuum := regularFileSize(t, indexPath)
+	if beforeVacuum == 0 {
+		t.Fatal("expected non-empty index.db before vacuum")
+	}
+
+	if samples, err := verifyReopen(cfg); err != nil {
+		t.Fatalf("pre-vacuum smoke verify: %v", err)
+	} else if samples == 0 {
+		t.Fatal("expected pre-vacuum smoke verification samples")
+	}
+
+	if err := treedb.VacuumIndexOffline(treedb.Options{Dir: dir}); err != nil {
+		t.Fatalf("vacuum index offline: %v", err)
+	}
+
+	afterVacuum := regularFileSize(t, indexPath)
+	if afterVacuum == 0 {
+		t.Fatal("expected non-empty index.db after vacuum")
+	}
+	t.Logf("index.db vacuum size: before=%d after=%d", beforeVacuum, afterVacuum)
+
+	if samples, err := verifyReopen(cfg); err != nil {
+		t.Fatalf("post-vacuum smoke verify: %v", err)
+	} else if samples == 0 {
+		t.Fatal("expected post-vacuum smoke verification samples")
+	}
+}
+
+func TestVacuumIndexOnlinePreservesTemplateV1TwoIndexDatabase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("loads a large enough fixture to exercise multi-batch collection roots")
+	}
+
+	dir := filepath.Join(t.TempDir(), "fixture")
+	cfg, err := parseConfig([]string{
+		"-dir", dir,
+		"-docs", "100000",
+		"-batch-size", "80",
+		"-verify-samples", "16",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+
+	if _, err := runFixture(cfg); err != nil {
+		t.Fatalf("run fixture: %v", err)
+	}
+
+	backend, cleanup, err := openBackend(cfg)
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	if err := backend.VacuumIndexOnline(context.Background()); err != nil {
+		_ = cleanup()
+		t.Fatalf("vacuum index online: %v", err)
+	}
+	if err := cleanup(); err != nil {
+		t.Fatalf("close backend: %v", err)
+	}
+
+	if samples, err := verifyReopen(cfg); err != nil {
+		t.Fatalf("post-online-vacuum smoke verify: %v", err)
+	} else if samples == 0 {
+		t.Fatal("expected post-online-vacuum smoke verification samples")
 	}
 }
 
@@ -141,4 +255,16 @@ func TestTemplateV1StoredDocumentExtractsInputEnvelope(t *testing.T) {
 	if !bytes.Equal(again, stored) {
 		t.Fatal("stored document conversion changed an already-stored payload")
 	}
+}
+
+func regularFileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("%s is not a regular file", path)
+	}
+	return info.Size()
 }

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -82,3 +82,13 @@ func TestRunFixtureRejectsNonEmptyDirectoryUnlessReset(t *testing.T) {
 		t.Fatal("expected non-empty fixture dir to fail without -reset")
 	}
 }
+
+func TestContainsDocumentID(t *testing.T) {
+	ids := [][]byte{[]byte("u-000000001"), []byte("u-000000064")}
+	if !containsDocumentID(ids, []byte("u-000000064")) {
+		t.Fatal("expected matching id")
+	}
+	if containsDocumentID(ids, []byte("u-000000002")) {
+		t.Fatal("unexpected non-matching id")
+	}
+}

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+func TestParseConfigDefaultsToInspectableTwoIndexTemplateFixture(t *testing.T) {
+	cfg, err := parseConfig(nil, io.Discard)
+	if err != nil {
+		t.Fatalf("parse defaults: %v", err)
+	}
+	if cfg.DocumentFormat != collections.DocumentFormatTemplateV1 {
+		t.Fatalf("document format=%q want template-v1", cfg.DocumentFormat)
+	}
+	if cfg.IndexCount != 2 {
+		t.Fatalf("index count=%d want 2", cfg.IndexCount)
+	}
+	if !cfg.DataOuterLeavesInValueLog {
+		t.Fatal("expected data outer leaves in value log by default")
+	}
+	if !cfg.IndexOuterLeavesInValueLog {
+		t.Fatal("expected index outer leaves in value log by default")
+	}
+	if !cfg.Checkpoint || !cfg.ReopenVerify {
+		t.Fatalf("checkpoint=%t reopen_verify=%t want both true", cfg.Checkpoint, cfg.ReopenVerify)
+	}
+}
+
+func TestRunFixtureKeepsTemplateV1TwoIndexDatabase(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "fixture")
+	cfg, err := parseConfig([]string{
+		"-dir", dir,
+		"-docs", "24",
+		"-batch-size", "7",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	summary, err := runFixture(cfg)
+	if err != nil {
+		t.Fatalf("run fixture: %v", err)
+	}
+	if summary.Dir != dir {
+		t.Fatalf("dir=%q want %q", summary.Dir, dir)
+	}
+	if summary.Docs != 24 || summary.Batches != 4 {
+		t.Fatalf("docs=%d batches=%d want docs=24 batches=4", summary.Docs, summary.Batches)
+	}
+	if summary.Verify.Samples == 0 {
+		t.Fatal("expected reopen verification samples")
+	}
+	if summary.DiskUsageFinal.TotalBytes == 0 {
+		t.Fatal("expected final disk usage")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "maindb", "index.db")); err != nil {
+		t.Fatalf("expected kept maindb/index.db: %v", err)
+	}
+}
+
+func TestRunFixtureRejectsNonEmptyDirectoryUnlessReset(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "sentinel"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	cfg, err := parseConfig([]string{"-dir", dir, "-docs", "1", "-progress=false"}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if _, err := runFixture(cfg); err == nil {
+		t.Fatal("expected non-empty fixture dir to fail without -reset")
+	}
+}

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+func TestParseConfigDefaultsToInspectableTwoIndexTemplateFixture(t *testing.T) {
+	cfg, err := parseConfig(nil, io.Discard)
+	if err != nil {
+		t.Fatalf("parse defaults: %v", err)
+	}
+	if cfg.DocumentFormat != collections.DocumentFormatTemplateV1 {
+		t.Fatalf("document format=%q want template-v1", cfg.DocumentFormat)
+	}
+	if cfg.IndexCount != 2 {
+		t.Fatalf("index count=%d want 2", cfg.IndexCount)
+	}
+	if !cfg.DataOuterLeavesInValueLog {
+		t.Fatal("expected data outer leaves in value log by default")
+	}
+	if !cfg.IndexOuterLeavesInValueLog {
+		t.Fatal("expected index outer leaves in value log by default")
+	}
+	if !cfg.Checkpoint || !cfg.ReopenVerify {
+		t.Fatalf("checkpoint=%t reopen_verify=%t want both true", cfg.Checkpoint, cfg.ReopenVerify)
+	}
+}
+
+func TestParseConfigRejectsExplicitEmptyFormat(t *testing.T) {
+	if _, err := parseConfig([]string{"-format", ""}, io.Discard); err == nil {
+		t.Fatal("expected explicit empty -format to fail")
+	}
+}
+
+func TestRunFixtureKeepsTemplateV1TwoIndexDatabase(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "fixture")
+	cfg, err := parseConfig([]string{
+		"-dir", dir,
+		"-docs", "24",
+		"-batch-size", "7",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	summary, err := runFixture(cfg)
+	if err != nil {
+		t.Fatalf("run fixture: %v", err)
+	}
+	if summary.Dir != dir {
+		t.Fatalf("dir=%q want %q", summary.Dir, dir)
+	}
+	if summary.Docs != 24 || summary.Batches != 4 {
+		t.Fatalf("docs=%d batches=%d want docs=24 batches=4", summary.Docs, summary.Batches)
+	}
+	if summary.Verify.Samples == 0 {
+		t.Fatal("expected reopen verification samples")
+	}
+	if summary.DiskUsageFinal.TotalBytes == 0 {
+		t.Fatal("expected final disk usage")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "maindb", "index.db")); err != nil {
+		t.Fatalf("expected kept maindb/index.db: %v", err)
+	}
+}
+
+func TestRunFixtureRejectsNonEmptyDirectoryUnlessReset(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "sentinel"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	cfg, err := parseConfig([]string{"-dir", dir, "-docs", "1", "-progress=false"}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if _, err := runFixture(cfg); err == nil {
+		t.Fatal("expected non-empty fixture dir to fail without -reset")
+	}
+}

--- a/cmd/unified_bench/profiles.go
+++ b/cmd/unified_bench/profiles.go
@@ -64,11 +64,11 @@ func init() {
 
 	profiles = map[string]Profile{
 		"fast": {
-			Description: "Maximize throughput: disables fsync for supported DBs; for TreeDB this mirrors treedb.ProfileFast (WAL off, relaxed read integrity, append-friendly index allocation, Celestia-aligned auto/snappy/balanced value-log compression). UNSAFE for production data.",
+			Description: "Maximize throughput: disables fsync for supported DBs; for TreeDB this mirrors treedb.ProfileFast (WAL off, relaxed read integrity, normal page reuse, Celestia-aligned auto/snappy/balanced value-log compression). UNSAFE for production data.",
 			Apply:       applyFast,
 		},
 		"wal_on_fast": {
-			Description: "TreeDB fast WAL-on profile: mirrors treedb.ProfileWALOnFast (WAL on, relaxed sync/read integrity, append-friendly index allocation, Celestia-aligned auto/snappy/balanced value-log compression).",
+			Description: "TreeDB fast WAL-on profile: mirrors treedb.ProfileWALOnFast (WAL on, relaxed sync/read integrity, normal page reuse, Celestia-aligned auto/snappy/balanced value-log compression).",
 			Apply:       applyWALOnFast,
 		},
 		"unsafe": { // Alias for fast

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -314,8 +314,8 @@ func TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations(t *testing.T) {
 	if got := *treedbVlogDictProbeIntervalBytes; got != 32<<20 {
 		t.Fatalf("expected fast profile to set treedb-vlog-dict-probe-interval-bytes=32MiB, got %d", got)
 	}
-	if !*treedbPreferAppendAlloc {
-		t.Fatalf("expected fast profile to set treedb-prefer-append-alloc")
+	if *treedbPreferAppendAlloc {
+		t.Fatalf("expected fast profile to leave treedb-prefer-append-alloc=false")
 	}
 	if !*treedbDisableWAL {
 		t.Fatalf("expected fast profile to disable WAL")
@@ -349,8 +349,8 @@ func TestApplyProfile_FastAndWALOnFastEnableIndexOptimizations(t *testing.T) {
 	if got := *treedbVlogDictProbeIntervalBytes; got != 32<<20 {
 		t.Fatalf("expected wal_on_fast profile to set treedb-vlog-dict-probe-interval-bytes=32MiB, got %d", got)
 	}
-	if !*treedbPreferAppendAlloc {
-		t.Fatalf("expected wal_on_fast profile to set treedb-prefer-append-alloc")
+	if *treedbPreferAppendAlloc {
+		t.Fatalf("expected wal_on_fast profile to leave treedb-prefer-append-alloc=false")
 	}
 	if *treedbDisableWAL {
 		t.Fatalf("expected wal_on_fast profile to keep WAL enabled")

--- a/docs/TREEDB_PROFILES.md
+++ b/docs/TREEDB_PROFILES.md
@@ -87,7 +87,7 @@ Behavior:
 - Disables or relaxes safety knobs:
   - `Durability = DurabilityWALOffRelaxed` (WAL off + relaxed sync)
   - `ValueLog.ReadIntegrity = IntegritySkipChecksums`
-- Prefers append allocation for throughput under churn (`PreferAppendAlloc=true`)
+- Uses normal page reuse (`PreferAppendAlloc=false` by default)
 - Enables leaf pages in the value log (`IndexOuterLeavesInValueLog = true`)
 - Enables index optimization bundle:
   - `LeafPrefixCompression = true`
@@ -122,7 +122,7 @@ Behavior:
 - Keeps WAL on while relaxing durability checks:
   - `Durability = DurabilityWALOnRelaxed`
   - `ValueLog.ReadIntegrity = IntegritySkipChecksums`
-- Prefers append allocation (`PreferAppendAlloc=true`)
+- Uses normal page reuse (`PreferAppendAlloc=false` by default)
 - Enables the same index optimization bundle as `ProfileFast`.
 - Enables the same Celestia-style value-log compression defaults as
   `ProfileFast`.

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -296,7 +296,7 @@ without a separate offline tool. These hooks execute inline during shutdown.
 TreeDB exposes a few knobs that directly influence page-ID locality and index
 fragmentation under churn:
 
-- `Options.PreferAppendAlloc` (default: false in durable profile, true in fast)
+- `Options.PreferAppendAlloc` (default: false)
   - Bypasses freelist reuse and appends new pages to preserve scan locality.
   - Trades disk growth for better sequential layout; vacuum reclaims space later.
 - `Options.FreelistRegionPages` + `Options.FreelistRegionRadius`


### PR DESCRIPTION
## Summary

This is the first stacked value-log maintenance PR on top of #1079.

It adds a shared maintenance root closure for:

- user root
- system root
- collection roots referenced by `collections/root/...` descriptors

Then it uses that root closure for:

- `ValueLogGC` full reference scans
- value-log rewrite live-byte planning by segment
- value-log rewrite live-byte planning by chunk
- rewrite leaf-dictionary training from live LeafRefs
- leaf-generation live stats scanning

It also fixes a ref-tracker safety gap in grouped ordered-root publishes: when a grouped publish makes non-system roots reachable through collection root descriptors, the system-root ref delta is not an exact value-log ref delta, so the incremental tracker is forced to rebuild from the full maintenance root set. Generic non-collection ordered-root groups still preserve the no-op tracker fast path.

`vlog_ref_counts.meta` version is bumped from 4 to 5 because persisted counters now include collection-root reachability.

## Tests

Targeted and package tests:

```text
go test ./TreeDB/db -run 'TestMaintenanceRoots|TestValueLogGC_KeepsSegmentReferencedOnlyByCollectionRoot|TestValueLogRewritePlanningCountsCollectionRootPointers|TestLeafGenerationLiveStatsCountsCollectionLeafRefRoot|TestValueLogGC_IncrementalParityWithFullScan|TestValueLogRewritePlan' -count=1
ok   github.com/snissn/gomap/TreeDB/db 0.836s

go test ./TreeDB/db -run 'TestPublishOrderedRootGroup_SystemWarmApplyUpdatesValueLogRefTrackerInline|TestPublishOrderedRootGroup_NonSystemWarmApplyPreservesValueLogRefTracker|TestValueLogGC_KeepsSegmentReferencedOnlyByCollectionRoot|TestValueLogRewritePlanningCountsCollectionRootPointers|TestLeafGenerationLiveStatsCountsCollectionLeafRefRoot' -count=1
ok   github.com/snissn/gomap/TreeDB/db 0.766s

go test ./TreeDB/db -count=1
ok   github.com/snissn/gomap/TreeDB/db 73.419s

go test ./TreeDB/collections -count=1
ok   github.com/snissn/gomap/TreeDB/collections 2.227s

go test ./TreeDB/docs/... -count=1
ok   github.com/snissn/gomap/TreeDB/docs 0.505s
```

Collection load fixture smokes, 100k docs, template-v1, 2 indexes, data/index outer leaves in value log:

```text
batch-size=16000
run_dir=/tmp/treedb_vlog_maint_smoke_bs16000_1777413967
insert_timing.ops_per_sec=796,833.917
insert_timing.sec_per_op=0.00000125496666
disk_usage_final.total_bytes=10,700,194
disk_usage_final.bytes_per_doc=107.00194
verify.enabled=true verify.samples=8

batch-size=800
run_dir=/tmp/treedb_vlog_maint_smoke_bs800_1777413977
insert_timing.ops_per_sec=343,708.558
insert_timing.sec_per_op=0.00000290944167
disk_usage_final.total_bytes=18,452,455
disk_usage_final.bytes_per_doc=184.52455
verify.enabled=true verify.samples=8
```

Raw TreeDB non-collections sanity anchors with `-profile-dir`:

```text
fast artifact dir: /tmp/gomap_vlog_maint_raw_fast_GwX43s
sequential_write=4,456,162 ops/sec
random_write=4,223,560 ops/sec
batch_write=14,445,909 ops/sec
random_read=462,725 ops/sec
random_read_parallel_acquire_snapshot=752,728 ops/sec
full_scan=6,067,234 ops/sec
prefix_scan=5,113,563 ops/sec

wal_on_fast artifact dir: /tmp/gomap_vlog_maint_raw_wal_on_fast_BdbwUP
sequential_write=1,882,148 ops/sec
random_write=2,068,160 ops/sec
batch_write=7,611,943 ops/sec
random_read=496,443 ops/sec
random_read_parallel_acquire_snapshot=829,875 ops/sec
full_scan=5,462,172 ops/sec
prefix_scan=8,016,032 ops/sec
```

## Notes

This PR does not implement collection-aware offline/online value-log rewrite execution yet. It makes the shared root closure and planning/GC/leaf-generation scans safe first, which should be the base for the offline rewrite PR.
