### PR TITLE
Rewrite collection leaf refs during generation pack

### DIFF
--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -171,7 +171,10 @@ func (db *DB) LeafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	}
 
 	prePrune := manifest.clone()
-	manifest, pruned, filesDeleted := pruneDeletedLeafGenerationRecords(manifest, filePaths)
+	manifest, pruned, filesDeleted, err := db.pruneDeletedLeafGenerationRecords(manifest, filePaths)
+	if err != nil {
+		return stats, err
+	}
 	if !pruned {
 		return stats, nil
 	}
@@ -189,7 +192,10 @@ func collectLiveLeafGenerationIDs(ctx context.Context, snap *Snapshot) (map[uint
 	if snap == nil || snap.db == nil {
 		return live, nil
 	}
-	scan, err := snap.db.leafGenerationLiveStatsForSnapshot(ctx, snap)
+	// GC deletion must not trust cached subtree/live reachability. A stale cache
+	// can turn a live generation into a deletion candidate, while a fresh scan is
+	// maintenance-only work outside the write/read happy path.
+	scan, err := snap.db.leafGenerationLiveStatsForSnapshotUncached(ctx, snap)
 	if err != nil {
 		return nil, err
 	}
@@ -257,9 +263,9 @@ func leafGenerationRecordBytesTotal(gen leafGenerationRecord, filePaths map[uint
 	return total
 }
 
-func pruneDeletedLeafGenerationRecords(manifest *leafGenerationManifest, filePaths map[uint32]string) (*leafGenerationManifest, bool, int) {
+func (db *DB) pruneDeletedLeafGenerationRecords(manifest *leafGenerationManifest, filePaths map[uint32]string) (*leafGenerationManifest, bool, int, error) {
 	if manifest == nil {
-		return nil, false, 0
+		return nil, false, 0, nil
 	}
 	kept := manifest.Generations[:0]
 	pruned := false
@@ -269,14 +275,36 @@ func pruneDeletedLeafGenerationRecords(manifest *leafGenerationManifest, filePat
 			kept = append(kept, gen)
 			continue
 		}
+		if err := db.removeLeafGenerationRecordLengthIndexes(gen.FileIDs); err != nil {
+			return manifest, false, 0, err
+		}
 		pruned = true
 		filesDeleted += len(gen.FileIDs)
 	}
 	if !pruned {
-		return manifest, false, 0
+		return manifest, false, 0, nil
 	}
 	manifest.Generations = kept
-	return manifest, true, filesDeleted
+	return manifest, true, filesDeleted, nil
+}
+
+func (db *DB) removeLeafGenerationRecordLengthIndexes(fileIDs []uint32) error {
+	if db == nil || len(fileIDs) == 0 {
+		return nil
+	}
+	for _, fileID := range fileIDs {
+		if fileID == 0 {
+			continue
+		}
+		path := leafGenerationRecordLengthIndexPath(db.dir, fileID)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove leaf generation record-length index %d (%s): %w", fileID, path, err)
+		}
+		db.leafGenerationRecordLengthMu.Lock()
+		delete(db.leafGenerationRecordLengthByFile, fileID)
+		db.leafGenerationRecordLengthMu.Unlock()
+	}
+	return nil
 }
 
 func leafGenerationFilesMissing(fileIDs []uint32, filePaths map[uint32]string) bool {

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -267,25 +267,34 @@ func (db *DB) pruneDeletedLeafGenerationRecords(manifest *leafGenerationManifest
 	if manifest == nil {
 		return nil, false, 0, nil
 	}
-	kept := manifest.Generations[:0]
+	prune := make([]bool, len(manifest.Generations))
 	pruned := false
+	prunedRecords := 0
 	filesDeleted := 0
-	for _, gen := range manifest.Generations {
+	for i, gen := range manifest.Generations {
 		if gen.State != leafGenerationStateDeleted || !leafGenerationFilesMissing(gen.FileIDs, filePaths) {
-			kept = append(kept, gen)
 			continue
 		}
 		if err := db.removeLeafGenerationRecordLengthIndexes(gen.FileIDs); err != nil {
 			return manifest, false, 0, err
 		}
+		prune[i] = true
 		pruned = true
+		prunedRecords++
 		filesDeleted += len(gen.FileIDs)
 	}
 	if !pruned {
 		return manifest, false, 0, nil
 	}
-	manifest.Generations = kept
-	return manifest, true, filesDeleted, nil
+	kept := make([]leafGenerationRecord, 0, len(manifest.Generations)-prunedRecords)
+	for i, gen := range manifest.Generations {
+		if !prune[i] {
+			kept = append(kept, gen)
+		}
+	}
+	next := *manifest
+	next.Generations = kept
+	return &next, true, filesDeleted, nil
 }
 
 func (db *DB) removeLeafGenerationRecordLengthIndexes(fileIDs []uint32) error {

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -271,17 +271,16 @@ func (db *DB) pruneDeletedLeafGenerationRecords(manifest *leafGenerationManifest
 	pruned := false
 	prunedRecords := 0
 	filesDeleted := 0
+	var prunedFileIDs []uint32
 	for i, gen := range manifest.Generations {
 		if gen.State != leafGenerationStateDeleted || !leafGenerationFilesMissing(gen.FileIDs, filePaths) {
 			continue
-		}
-		if err := db.removeLeafGenerationRecordLengthIndexes(gen.FileIDs); err != nil {
-			return manifest, false, 0, err
 		}
 		prune[i] = true
 		pruned = true
 		prunedRecords++
 		filesDeleted += len(gen.FileIDs)
+		prunedFileIDs = append(prunedFileIDs, gen.FileIDs...)
 	}
 	if !pruned {
 		return manifest, false, 0, nil
@@ -294,6 +293,9 @@ func (db *DB) pruneDeletedLeafGenerationRecords(manifest *leafGenerationManifest
 	}
 	next := *manifest
 	next.Generations = kept
+	if err := db.removeLeafGenerationRecordLengthIndexes(prunedFileIDs); err != nil {
+		return manifest, false, 0, err
+	}
 	return &next, true, filesDeleted, nil
 }
 
@@ -301,19 +303,21 @@ func (db *DB) removeLeafGenerationRecordLengthIndexes(fileIDs []uint32) error {
 	if db == nil || len(fileIDs) == 0 {
 		return nil
 	}
+	var errs []error
 	for _, fileID := range fileIDs {
 		if fileID == 0 {
 			continue
 		}
 		path := leafGenerationRecordLengthIndexPath(db.dir, fileID)
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove leaf generation record-length index %d (%s): %w", fileID, path, err)
+			errs = append(errs, fmt.Errorf("remove leaf generation record-length index %d (%s): %w", fileID, path, err))
+			continue
 		}
 		db.leafGenerationRecordLengthMu.Lock()
 		delete(db.leafGenerationRecordLengthByFile, fileID)
 		db.leafGenerationRecordLengthMu.Unlock()
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func leafGenerationFilesMissing(fileIDs []uint32, filePaths map[uint32]string) bool {

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -267,35 +267,32 @@ func (db *DB) pruneDeletedLeafGenerationRecords(manifest *leafGenerationManifest
 	if manifest == nil {
 		return nil, false, 0, nil
 	}
-	prune := make([]bool, len(manifest.Generations))
 	pruned := false
-	prunedRecords := 0
 	filesDeleted := 0
 	var prunedFileIDs []uint32
-	for i, gen := range manifest.Generations {
+	for _, gen := range manifest.Generations {
 		if gen.State != leafGenerationStateDeleted || !leafGenerationFilesMissing(gen.FileIDs, filePaths) {
 			continue
 		}
-		prune[i] = true
 		pruned = true
-		prunedRecords++
 		filesDeleted += len(gen.FileIDs)
 		prunedFileIDs = append(prunedFileIDs, gen.FileIDs...)
 	}
 	if !pruned {
 		return manifest, false, 0, nil
 	}
-	kept := make([]leafGenerationRecord, 0, len(manifest.Generations)-prunedRecords)
-	for i, gen := range manifest.Generations {
-		if !prune[i] {
-			kept = append(kept, gen)
-		}
-	}
-	next := *manifest
-	next.Generations = kept
 	if err := db.removeLeafGenerationRecordLengthIndexes(prunedFileIDs); err != nil {
 		return manifest, false, 0, err
 	}
+	next := *manifest
+	kept := next.Generations[:0]
+	for _, gen := range next.Generations {
+		if gen.State == leafGenerationStateDeleted && leafGenerationFilesMissing(gen.FileIDs, filePaths) {
+			continue
+		}
+		kept = append(kept, gen)
+	}
+	next.Generations = kept
 	return &next, true, filesDeleted, nil
 }
 

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -173,7 +173,7 @@ func (db *DB) LeafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	prePrune := manifest.clone()
 	manifest, pruned, filesDeleted, err := db.pruneDeletedLeafGenerationRecords(manifest, filePaths)
 	if err != nil {
-		return stats, err
+		return stats, fmt.Errorf("leaf generation gc: prune deleted generation records: %w", err)
 	}
 	if !pruned {
 		return stats, nil

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -141,6 +141,7 @@ func TestLeafGenerationGC_DeletesFullyDeadGeneration(t *testing.T) {
 	writeLeafGenerationKeys(t, db, "k", 64, 'a')
 	path1, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
 	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	indexPath1 := leafGenerationRecordLengthIndexPath(db.dir, rawFileID1)
 	if _, err := os.Stat(path1); err != nil {
 		t.Fatalf("stat first leaf segment: %v", err)
 	}
@@ -186,8 +187,14 @@ func TestLeafGenerationGC_DeletesFullyDeadGeneration(t *testing.T) {
 	if err := waitForPathRemoval(path1, 5*time.Second); err != nil {
 		t.Fatalf("waitForPathRemoval(%s): %v", path1, err)
 	}
+	if err := waitForPathRemoval(indexPath1, 5*time.Second); err != nil {
+		t.Fatalf("waitForPathRemoval(%s): %v", indexPath1, err)
+	}
 	if _, err := os.Stat(path1); !os.IsNotExist(err) {
 		t.Fatalf("expected first leaf segment removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(indexPath1); !os.IsNotExist(err) {
+		t.Fatalf("expected first leaf segment record-length index removed, stat err=%v", err)
 	}
 	if _, err := os.Stat(path2); err != nil {
 		t.Fatalf("expected second leaf segment to remain, stat err=%v", err)
@@ -201,6 +208,53 @@ func TestLeafGenerationGC_DeletesFullyDeadGeneration(t *testing.T) {
 	if got, want := remaining.FileIDs[0], rawFileID2; got != want {
 		t.Fatalf("remaining generation fileID=%d, want %d", got, want)
 	}
+}
+
+func TestLeafGenerationGC_IgnoresStaleReachabilityCache(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "k", 512, 'a')
+	path1, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "z", 1, 'z')
+
+	manifestBefore := loadLeafGenerationManifestOrFatal(t, db.dir)
+	gen1 := findLeafGenerationByFileID(t, manifestBefore, rawFileID1)
+	if got, want := gen1.State, leafGenerationStateSealed; got != want {
+		t.Fatalf("generation1 state=%q, want %q", got, want)
+	}
+	state := db.state.Load()
+	cacheKey, ok := leafGenerationLiveStatsKeyForState(state)
+	if !ok {
+		t.Fatal("expected cacheable leaf-generation state")
+	}
+
+	db.leafGenerationLiveStatsMu.Lock()
+	db.leafGenerationLiveStatsCache = leafGenerationLiveStatsCache{
+		key:   cacheKey,
+		stats: leafGenerationLiveScanStats{Generations: map[uint64]leafGenerationLiveTotals{}},
+		ok:    true,
+	}
+	db.leafGenerationLiveStatsMu.Unlock()
+
+	stats, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC: %v", err)
+	}
+	if got := stats.GenerationsLive; got == 0 {
+		t.Fatalf("GenerationsLive=%d, want stale cache ignored (stats=%+v)", got, stats)
+	}
+	if got := stats.GenerationsDeleted; got != 0 {
+		t.Fatalf("GenerationsDeleted=%d, want 0 for live generation (stats=%+v)", got, stats)
+	}
+	if _, err := os.Stat(path1); err != nil {
+		t.Fatalf("expected live first leaf segment to remain: %v", err)
+	}
+	expectLeafGenerationValue(t, db, leafGenerationKey("k", 0), 'a')
+	expectLeafGenerationValue(t, db, leafGenerationKey("k", 511), 'a')
 }
 
 func TestLeafGenerationGC_RetiresPinnedGenerationUntilSnapshotCloses(t *testing.T) {

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -173,7 +173,7 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 	stats.InternalPagesVisited = rewriteStats.InternalPagesVisited
 	stats.SubtreesPruned = rewriteStats.SubtreesPruned
 	if err != nil {
-		return stats, err
+		return stats, fmt.Errorf("leaf generation pack: rewrite leaf refs: %w", err)
 	}
 	createdIDs, err := writer.createdFileIDs()
 	if err != nil {

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -16,7 +16,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/zipper"
 )
 
-const leafRefRewriteMapInitCap = 128    // initial map capacity for small leafref rewrite batches
+const leafRefRewriteMapInitCap = 128    // initial map capacity for small leaf-ref rewrite batches
 const leafRefRewriteInlineChildCap = 64 // stack-backed child-id scratch for common small internal nodes
 const leafRefRewriteInlineRemapCap = 8  // inline remap cache before promoting to map
 
@@ -273,7 +273,7 @@ func (c *leafRefRewriteCtx) appendLeafPage(leafPage []byte) (page.LeafLogPtr, er
 func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 
 	if c == nil {
-		return id, false, errors.New("vlog-rewrite: nil leafref rewrite ctx")
+		return id, false, errors.New("vlog-rewrite: nil leaf-ref rewrite ctx")
 	}
 	if c.ctx != nil {
 		if err := c.ctx.Err(); err != nil {
@@ -483,6 +483,9 @@ func (c *leafRefRewriteCtx) applySystemRootCollectionRootReplacements(rootID uin
 			return rootID, false, err
 		}
 	}
+	// For this collections-only maintenance path, cancellation during Apply is
+	// observed by the leaf page appender before each rewritten outer leaf is
+	// persisted.
 	newRoot, retired, _, err := c.zipper.Apply(rootID, delta)
 	if err != nil {
 		return rootID, false, err

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -246,10 +246,16 @@ func (c *leafRefRewriteCtx) appendLeafPage(leafPage []byte) (page.LeafLogPtr, er
 	if c == nil || c.writer == nil || c.ridAlloc == nil {
 		return page.LeafLogPtr{}, errors.New("vlog-rewrite: missing leaf-ref rewrite appender state")
 	}
+	if len(leafPage) != page.PageSize {
+		return page.LeafLogPtr{}, fmt.Errorf("vlog-rewrite: leaf page has invalid size: got=%dB want=%dB", len(leafPage), page.PageSize)
+	}
 	if c.ctx != nil {
 		if err := c.ctx.Err(); err != nil {
 			return page.LeafLogPtr{}, err
 		}
+	}
+	if c.maxCopiedBytes > 0 && c.copiedBytes >= c.maxCopiedBytes && c.copied > 0 {
+		return page.LeafLogPtr{}, fmt.Errorf("vlog-rewrite: leaf-ref copy budget exhausted: copied=%dB max=%dB", c.copiedBytes, c.maxCopiedBytes)
 	}
 	rid, err := c.ridAlloc.Next()
 	if err != nil {
@@ -309,9 +315,6 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 		leafPage, err := c.readLeafPage(ptr.ValuePtr())
 		if err != nil {
 			return id, false, err
-		}
-		if len(leafPage) != page.PageSize {
-			return id, false, fmt.Errorf("vlog-rewrite: leaf page has invalid size: got=%dB want=%dB", len(leafPage), page.PageSize)
 		}
 		leafLogPtr, err := c.appendLeafPage(leafPage)
 		if err != nil {

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
-	"github.com/snissn/gomap/TreeDB/internal/bulk"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/pager"
 	"github.com/snissn/gomap/TreeDB/tree"
+	"github.com/snissn/gomap/TreeDB/zipper"
 )
 
 const leafRefRewriteMapInitCap = 128    // initial map capacity for small leafref rewrite batches
@@ -55,6 +56,7 @@ type leafRefRewriteCtx struct {
 
 	writer   *rewriteWriter
 	ridAlloc *rewriteRIDAllocator
+	zipper   *zipper.Zipper
 
 	sourceIDs            map[uint32]struct{}
 	sourceChunks         map[valueLogChunkKey]ValueLogRewritePlanChunk
@@ -432,180 +434,42 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 	}
 }
 
-func (c *leafRefRewriteCtx) rebuildSystemRootWithCollectionRootReplacements(rootID uint64, replacements []vacuumCollectionRootReplacement) (uint64, error) {
+func (c *leafRefRewriteCtx) applySystemRootCollectionRootReplacements(rootID uint64, replacements []vacuumCollectionRootReplacement) (uint64, bool, error) {
 	if c == nil {
-		return rootID, errors.New("vlog-rewrite: nil leafref rewrite ctx")
+		return rootID, false, errors.New("vlog-rewrite: nil leafref rewrite ctx")
 	}
 	if len(replacements) == 0 {
-		return rootID, nil
+		return rootID, false, nil
 	}
 	if c.db == nil {
-		return rootID, errors.New("vlog-rewrite: missing db")
+		return rootID, false, errors.New("vlog-rewrite: missing db")
 	}
-	if c.pager == nil || c.alloc == nil || c.writer == nil {
-		return rootID, errors.New("vlog-rewrite: missing system root rebuild state")
+	if c.zipper == nil {
+		return rootID, false, errors.New("vlog-rewrite: missing system root zipper")
 	}
 	if rootID == 0 {
-		return 0, nil
+		return 0, false, nil
 	}
 	if c.ctx != nil {
 		if err := c.ctx.Err(); err != nil {
-			return rootID, err
+			return rootID, false, err
 		}
 	}
 
-	tr := tree.New(c.pager, c.leafReader, rootID)
-	retired, err := tr.CollectPageIDs()
-	if err != nil {
-		return rootID, err
-	}
-	if c.ctx != nil {
-		if err := c.ctx.Err(); err != nil {
-			return rootID, err
+	delta := batch.Acquire(c.db.valueLogManager, c.db.InlineThreshold())
+	defer batch.Release(delta)
+	delta.Reserve(len(replacements))
+	for _, replacement := range replacements {
+		if err := delta.Set(replacement.key, replacement.value); err != nil {
+			return rootID, false, err
 		}
 	}
-	var iter iteratorWithEntry = tr.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-	iter = &vacuumSystemRootRewriteIterator{
-		base:         iter,
-		replacements: replacements,
-	}
-	iter = &contextIteratorWithEntry{ctx: c.ctx, base: iter}
-
-	newRoot, err := bulk.BuildWithOptions(iter, c.alloc, c.pager, bulk.BuildOptions{
-		LeafPrefixCompression: c.db.leafPrefixCompression,
-		LeafColumnar:          c.db.indexColumnarLeaves,
-		PackedValuePtr:        c.db.indexPackedValuePtr,
-		InternalBaseDelta:     c.db.indexInternalBaseDelta && !c.db.indexOuterLeavesInValueLog,
-		LeafPageLog:           &leafRefRewritePageAppender{ctx: c},
-	})
-	if iterErr := iter.Error(); iterErr != nil {
-		err = errors.Join(err, iterErr)
-	}
-	if closeErr := iter.Close(); closeErr != nil {
-		err = errors.Join(err, closeErr)
-	}
+	newRoot, retired, _, err := c.zipper.Apply(rootID, delta)
 	if err != nil {
-		return rootID, err
+		return rootID, false, err
 	}
 	c.retired = append(c.retired, retired...)
-	return newRoot, nil
-}
-
-type contextIteratorWithEntry struct {
-	ctx  context.Context
-	base iteratorWithEntry
-	err  error
-}
-
-func (it *contextIteratorWithEntry) contextErr() error {
-	if it == nil {
-		return nil
-	}
-	if it.err != nil {
-		return it.err
-	}
-	if it.ctx != nil {
-		it.err = it.ctx.Err()
-	}
-	return it.err
-}
-
-func (it *contextIteratorWithEntry) Valid() bool {
-	if it == nil || it.base == nil || it.contextErr() != nil {
-		return false
-	}
-	return it.base.Valid()
-}
-
-func (it *contextIteratorWithEntry) Next() {
-	if it == nil || it.base == nil || it.contextErr() != nil {
-		return
-	}
-	it.base.Next()
-}
-
-func (it *contextIteratorWithEntry) UnsafeKey() []byte {
-	if it == nil || it.base == nil {
-		return nil
-	}
-	return it.base.UnsafeKey()
-}
-
-func (it *contextIteratorWithEntry) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
-	if it == nil || it.base == nil {
-		return nil, page.ValuePtr{}, node.FlagInline
-	}
-	return it.base.UnsafeEntry()
-}
-
-func (it *contextIteratorWithEntry) IsDeleted() bool {
-	return it != nil && it.base != nil && it.base.IsDeleted()
-}
-
-func (it *contextIteratorWithEntry) UnsafeValue() []byte {
-	if it == nil || it.base == nil {
-		return nil
-	}
-	return it.base.UnsafeValue()
-}
-
-func (it *contextIteratorWithEntry) Key() []byte {
-	if it == nil || it.base == nil {
-		return nil
-	}
-	return it.base.Key()
-}
-
-func (it *contextIteratorWithEntry) Value() []byte {
-	if it == nil || it.base == nil {
-		return nil
-	}
-	return it.base.Value()
-}
-
-func (it *contextIteratorWithEntry) KeyCopy(dst []byte) []byte {
-	if it == nil || it.base == nil {
-		return dst
-	}
-	return it.base.KeyCopy(dst)
-}
-
-func (it *contextIteratorWithEntry) ValueCopy(dst []byte) []byte {
-	if it == nil || it.base == nil {
-		return dst
-	}
-	return it.base.ValueCopy(dst)
-}
-
-func (it *contextIteratorWithEntry) Error() error {
-	if err := it.contextErr(); err != nil {
-		return err
-	}
-	if it == nil || it.base == nil {
-		return nil
-	}
-	return it.base.Error()
-}
-
-func (it *contextIteratorWithEntry) Close() error {
-	if it == nil || it.base == nil {
-		return nil
-	}
-	return it.base.Close()
-}
-
-func (it *contextIteratorWithEntry) Domain() (start, end []byte) {
-	if it == nil || it.base == nil {
-		return nil, nil
-	}
-	return it.base.Domain()
-}
-
-func (it *contextIteratorWithEntry) Seek(key []byte) {
-	if it == nil || it.base == nil || it.contextErr() != nil {
-		return
-	}
-	it.base.Seek(key)
+	return newRoot, newRoot != rootID || len(retired) > 0, nil
 }
 
 func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, ridAlloc *rewriteRIDAllocator, sourceIDs map[uint32]struct{}, sourceChunks map[valueLogChunkKey]ValueLogRewritePlanChunk, sourceChunkBytes int64, singleSourceID uint32, hasSingleSourceID bool, maxCopiedBytes int64, sync bool, runStats *leafRefRewriteRunStats) (copied int, copiedBytes int64, err error) {
@@ -703,6 +567,12 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		useSubtreeStatsPrune: len(sourceGenerationIDs) > 0,
 		maxCopiedBytes:       maxCopiedBytes,
 	}
+	leafCtx.zipper = idx.zipper.CloneWithAllocator(tracker)
+	leafCtx.zipper.SetOuterLeavesInValueLog(db.indexOuterLeavesInValueLog)
+	leafCtx.zipper.SetIndexInternalBaseDelta(db.indexInternalBaseDelta && !db.indexOuterLeavesInValueLog)
+	if db.indexOuterLeavesInValueLog {
+		leafCtx.zipper.SetLeafPageLog(&leafRefRewritePageAppender{ctx: leafCtx})
+	}
 	if runStats != nil {
 		defer func() {
 			runStats.InternalPagesVisited = leafCtx.internalVisited
@@ -730,17 +600,17 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		newSysRoot uint64
 		sysChanged bool
 	)
+	newSysRoot, sysChanged, err = leafCtx.rewriteNode(sysRoot)
+	if err != nil {
+		return 0, 0, fmt.Errorf("vlog-rewrite: rewrite system leaf root: %w", err)
+	}
 	if len(collectionRootReplacements) > 0 {
-		newSysRoot, err = leafCtx.rebuildSystemRootWithCollectionRootReplacements(sysRoot, collectionRootReplacements)
+		replacedSysRoot, replacementChanged, err := leafCtx.applySystemRootCollectionRootReplacements(newSysRoot, collectionRootReplacements)
 		if err != nil {
-			return 0, 0, fmt.Errorf("vlog-rewrite: rewrite system leaf root with collection descriptors: %w", err)
+			return 0, 0, fmt.Errorf("vlog-rewrite: rewrite system collection descriptors: %w", err)
 		}
-		sysChanged = true
-	} else {
-		newSysRoot, sysChanged, err = leafCtx.rewriteNode(sysRoot)
-		if err != nil {
-			return 0, 0, fmt.Errorf("vlog-rewrite: rewrite system leaf root: %w", err)
-		}
+		newSysRoot = replacedSysRoot
+		sysChanged = sysChanged || replacementChanged
 	}
 	newRoot, userChanged, err := leafCtx.rewriteNode(rootID)
 	if err != nil {

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
+	"github.com/snissn/gomap/TreeDB/internal/bulk"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -404,6 +405,51 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 	}
 }
 
+func (c *leafRefRewriteCtx) rebuildSystemRootWithCollectionRootReplacements(rootID uint64, replacements []vacuumCollectionRootReplacement) (uint64, error) {
+	if c == nil {
+		return rootID, errors.New("vlog-rewrite: nil leafref rewrite ctx")
+	}
+	if len(replacements) == 0 {
+		return rootID, nil
+	}
+	if c.db == nil {
+		return rootID, errors.New("vlog-rewrite: missing db")
+	}
+	if c.pager == nil || c.alloc == nil || c.writer == nil {
+		return rootID, errors.New("vlog-rewrite: missing system root rebuild state")
+	}
+	if rootID == 0 {
+		return 0, nil
+	}
+
+	tr := tree.New(c.pager, c.leafReader, rootID)
+	retired, err := tr.CollectPageIDs()
+	if err != nil {
+		return rootID, err
+	}
+	var iter iteratorWithEntry = tr.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+	if len(replacements) > 0 {
+		iter = &vacuumSystemRootRewriteIterator{
+			base:         iter,
+			replacements: replacements,
+		}
+	}
+	defer func() { _ = iter.Close() }()
+
+	newRoot, err := bulk.BuildWithOptions(iter, c.alloc, c.pager, bulk.BuildOptions{
+		LeafPrefixCompression: c.db.leafPrefixCompression,
+		LeafColumnar:          c.db.indexColumnarLeaves,
+		PackedValuePtr:        c.db.indexPackedValuePtr,
+		InternalBaseDelta:     c.db.indexInternalBaseDelta && !c.db.indexOuterLeavesInValueLog,
+		LeafPageLog:           c.writer,
+	})
+	if err != nil {
+		return rootID, err
+	}
+	c.retired = append(c.retired, retired...)
+	return newRoot, nil
+}
+
 func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, ridAlloc *rewriteRIDAllocator, sourceIDs map[uint32]struct{}, sourceChunks map[valueLogChunkKey]ValueLogRewritePlanChunk, sourceChunkBytes int64, singleSourceID uint32, hasSingleSourceID bool, maxCopiedBytes int64, sync bool, runStats *leafRefRewriteRunStats) (copied int, copiedBytes int64, err error) {
 	if db == nil {
 		return 0, 0, fmt.Errorf("missing db")
@@ -510,13 +556,37 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		leafCtx.leafScratch = make([]byte, 0, page.PageSize)
 	}
 
-	newSysRoot, sysChanged, err := leafCtx.rewriteNode(sysRoot)
+	descriptors, err := vacuumCollectCollectionRootDescriptors(idx.pager, &snap.reader, sysRoot)
+	if err != nil {
+		return 0, 0, fmt.Errorf("vlog-rewrite: collect collection root descriptors: %w", err)
+	}
+	collectionRootReplacements, err := vacuumRewriteCollectionRootDescriptors(descriptors, func(descriptor vacuumCollectionRootDescriptor) (uint64, error) {
+		newRoot, _, err := leafCtx.rewriteNode(descriptor.rootID)
+		return newRoot, err
+	}, "vlog-rewrite: rewrite collection leaf root")
 	if err != nil {
 		return 0, 0, err
 	}
+
+	var (
+		newSysRoot uint64
+		sysChanged bool
+	)
+	if len(collectionRootReplacements) > 0 {
+		newSysRoot, err = leafCtx.rebuildSystemRootWithCollectionRootReplacements(sysRoot, collectionRootReplacements)
+		if err != nil {
+			return 0, 0, fmt.Errorf("vlog-rewrite: rewrite system leaf root with collection descriptors: %w", err)
+		}
+		sysChanged = true
+	} else {
+		newSysRoot, sysChanged, err = leafCtx.rewriteNode(sysRoot)
+		if err != nil {
+			return 0, 0, fmt.Errorf("vlog-rewrite: rewrite system leaf root: %w", err)
+		}
+	}
 	newRoot, userChanged, err := leafCtx.rewriteNode(rootID)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("vlog-rewrite: rewrite user leaf root: %w", err)
 	}
 	if !sysChanged && !userChanged {
 		return 0, 0, nil
@@ -526,20 +596,20 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 	// refs that point at them.
 	if sync {
 		if err := writer.Sync(); err != nil {
-			return 0, 0, err
+			return 0, 0, fmt.Errorf("vlog-rewrite: sync rewritten leaf refs: %w", err)
 		}
 	} else {
 		if err := writer.Flush(); err != nil {
-			return 0, 0, err
+			return 0, 0, fmt.Errorf("vlog-rewrite: flush rewritten leaf refs: %w", err)
 		}
 	}
 	createdIDs, err := writer.createdFileIDs()
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("vlog-rewrite: list created leaf ref files: %w", err)
 	}
 	createdSegments, err := writer.createdSegmentsSnapshot()
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("vlog-rewrite: snapshot created leaf ref segments: %w", err)
 	}
 	cleanupCreatedSegments := func(baseErr error) (int, int64, error) {
 		closeErr := writer.Close()
@@ -555,7 +625,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		// filesystem rescan in leafref-heavy rewrite paths.
 		for _, seg := range createdSegments {
 			if err := db.valueLogManager.RegisterSegment(seg.path, seg.fileID); err != nil {
-				return cleanupCreatedSegments(err)
+				return cleanupCreatedSegments(fmt.Errorf("vlog-rewrite: register rewritten leaf segment %d: %w", seg.fileID, err))
 			}
 		}
 	}
@@ -565,7 +635,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		stagedManifest := db.leafGenerationManifest.clone()
 		rawFileIDs, changed, err := noteCreatedLeafGenerationFileIDsInManifest(stagedManifest, snap.state.CommitSeq+1, createdIDs)
 		if err != nil {
-			return 0, 0, err
+			return 0, 0, fmt.Errorf("vlog-rewrite: update leaf generation manifest: %w", err)
 		}
 		if changed {
 			leafManifest = stagedManifest
@@ -575,9 +645,9 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 
 	if err := db.finalizeCommit(newRoot, newSysRoot, leafCtx.retired, sync, adaptive.Metrics{}, createdIDs, false, nil, leafManifest, leafManifestRawFileIDs); err != nil {
 		if finalizeCommitErrorAllowsCreatedSegmentCleanup(err) {
-			return cleanupCreatedSegments(err)
+			return cleanupCreatedSegments(fmt.Errorf("vlog-rewrite: finalize rewritten leaf refs: %w", err))
 		}
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("vlog-rewrite: finalize rewritten leaf refs: %w", err)
 	}
 	db.invalidateLeafGenerationSubtreeStats(tracker.Pages())
 	tracker = nil

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -460,7 +460,17 @@ func (c *leafRefRewriteCtx) applySystemRootCollectionRootReplacements(rootID uin
 	defer batch.Release(delta)
 	delta.Reserve(len(replacements))
 	for _, replacement := range replacements {
+		if c.ctx != nil {
+			if err := c.ctx.Err(); err != nil {
+				return rootID, false, err
+			}
+		}
 		if err := delta.Set(replacement.key, replacement.value); err != nil {
+			return rootID, false, err
+		}
+	}
+	if c.ctx != nil {
+		if err := c.ctx.Err(); err != nil {
 			return rootID, false, err
 		}
 	}
@@ -584,7 +594,7 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		leafCtx.leafScratch = make([]byte, 0, page.PageSize)
 	}
 
-	descriptors, err := vacuumCollectCollectionRootDescriptors(idx.pager, &snap.reader, sysRoot)
+	descriptors, err := vacuumCollectCollectionRootDescriptorsWithContext(ctx, idx.pager, &snap.reader, sysRoot)
 	if err != nil {
 		return 0, 0, fmt.Errorf("vlog-rewrite: collect collection root descriptors: %w", err)
 	}

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -459,7 +459,13 @@ func (c *leafRefRewriteCtx) applySystemRootCollectionRootReplacements(rootID uin
 		}
 	}
 
-	delta := batch.Acquire(c.db.valueLogManager, c.db.InlineThreshold())
+	inlineThreshold := c.db.InlineThreshold()
+	for _, replacement := range replacements {
+		if len(replacement.value) > inlineThreshold {
+			inlineThreshold = len(replacement.value)
+		}
+	}
+	delta := batch.Acquire(c.db.valueLogManager, inlineThreshold)
 	defer batch.Release(delta)
 	delta.Reserve(len(replacements))
 	for _, replacement := range replacements {
@@ -618,6 +624,11 @@ func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, 
 		return 0, 0, fmt.Errorf("vlog-rewrite: rewrite system leaf root: %w", err)
 	}
 	if len(collectionRootReplacements) > 0 {
+		if sysChanged {
+			if err := writer.Flush(); err != nil {
+				return 0, 0, fmt.Errorf("vlog-rewrite: flush rewritten system leaf root: %w", err)
+			}
+		}
 		replacedSysRoot, replacementChanged, err := leafCtx.applySystemRootCollectionRootReplacements(newSysRoot, collectionRootReplacements)
 		if err != nil {
 			return 0, 0, fmt.Errorf("vlog-rewrite: rewrite system collection descriptors: %w", err)

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -87,20 +87,10 @@ type leafRefRewritePageAppender struct {
 }
 
 func (a *leafRefRewritePageAppender) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
-	if a == nil || a.ctx == nil || a.ctx.writer == nil || a.ctx.ridAlloc == nil {
+	if a == nil || a.ctx == nil {
 		return page.LeafLogPtr{}, errors.New("vlog-rewrite: missing leaf-ref rewrite appender state")
 	}
-	rid, err := a.ctx.ridAlloc.Next()
-	if err != nil {
-		return page.LeafLogPtr{}, err
-	}
-	ptr, err := a.ctx.writer.appendLeafPageWithRID(rid, leafPage)
-	if err != nil {
-		return page.LeafLogPtr{}, err
-	}
-	a.ctx.copied++
-	a.ctx.copiedBytes += int64(len(leafPage))
-	return ptr, nil
+	return a.ctx.appendLeafPage(leafPage)
 }
 
 type leafRefRewriteRunStats struct {
@@ -250,6 +240,28 @@ func (c *leafRefRewriteCtx) subtreeMayContainRewriteSource(pageID uint64) bool {
 	return false
 }
 
+func (c *leafRefRewriteCtx) appendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
+	if c == nil || c.writer == nil || c.ridAlloc == nil {
+		return page.LeafLogPtr{}, errors.New("vlog-rewrite: missing leaf-ref rewrite appender state")
+	}
+	if c.ctx != nil {
+		if err := c.ctx.Err(); err != nil {
+			return page.LeafLogPtr{}, err
+		}
+	}
+	rid, err := c.ridAlloc.Next()
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	ptr, err := c.writer.appendLeafPageWithRID(rid, leafPage)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	c.copied++
+	c.copiedBytes += int64(len(leafPage))
+	return ptr, nil
+}
+
 func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 
 	if c == nil {
@@ -299,11 +311,7 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 		if len(leafPage) != page.PageSize {
 			return id, false, fmt.Errorf("vlog-rewrite: leaf page has invalid size: got=%dB want=%dB", len(leafPage), page.PageSize)
 		}
-		rid, err := c.ridAlloc.Next()
-		if err != nil {
-			return id, false, err
-		}
-		leafLogPtr, err := c.writer.appendLeafPageWithRID(rid, leafPage)
+		leafLogPtr, err := c.appendLeafPage(leafPage)
 		if err != nil {
 			return id, false, err
 		}
@@ -312,8 +320,6 @@ func (c *leafRefRewriteCtx) rewriteNode(id uint64) (uint64, bool, error) {
 			return id, false, err
 		}
 		c.storeLeafRemap(id, leafID)
-		c.copied++
-		c.copiedBytes += int64(len(leafPage))
 		return leafID, true, nil
 	}
 
@@ -459,14 +465,11 @@ func (c *leafRefRewriteCtx) rebuildSystemRootWithCollectionRootReplacements(root
 		}
 	}
 	var iter iteratorWithEntry = tr.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-	if len(replacements) > 0 {
-		iter = &vacuumSystemRootRewriteIterator{
-			base:         iter,
-			replacements: replacements,
-		}
+	iter = &vacuumSystemRootRewriteIterator{
+		base:         iter,
+		replacements: replacements,
 	}
 	iter = &contextIteratorWithEntry{ctx: c.ctx, base: iter}
-	defer func() { _ = iter.Close() }()
 
 	newRoot, err := bulk.BuildWithOptions(iter, c.alloc, c.pager, bulk.BuildOptions{
 		LeafPrefixCompression: c.db.leafPrefixCompression,
@@ -475,6 +478,12 @@ func (c *leafRefRewriteCtx) rebuildSystemRootWithCollectionRootReplacements(root
 		InternalBaseDelta:     c.db.indexInternalBaseDelta && !c.db.indexOuterLeavesInValueLog,
 		LeafPageLog:           &leafRefRewritePageAppender{ctx: c},
 	})
+	if iterErr := iter.Error(); iterErr != nil {
+		err = errors.Join(err, iterErr)
+	}
+	if closeErr := iter.Close(); closeErr != nil {
+		err = errors.Join(err, closeErr)
+	}
 	if err != nil {
 		return rootID, err
 	}

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -82,6 +82,27 @@ type leafRefRewriteCtx struct {
 	readRefreshRetried bool
 }
 
+type leafRefRewritePageAppender struct {
+	ctx *leafRefRewriteCtx
+}
+
+func (a *leafRefRewritePageAppender) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
+	if a == nil || a.ctx == nil || a.ctx.writer == nil || a.ctx.ridAlloc == nil {
+		return page.LeafLogPtr{}, errors.New("vlog-rewrite: missing leaf-ref rewrite appender state")
+	}
+	rid, err := a.ctx.ridAlloc.Next()
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	ptr, err := a.ctx.writer.appendLeafPageWithRID(rid, leafPage)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	a.ctx.copied++
+	a.ctx.copiedBytes += int64(len(leafPage))
+	return ptr, nil
+}
+
 type leafRefRewriteRunStats struct {
 	InternalPagesVisited int
 	SubtreesPruned       int
@@ -441,7 +462,7 @@ func (c *leafRefRewriteCtx) rebuildSystemRootWithCollectionRootReplacements(root
 		LeafColumnar:          c.db.indexColumnarLeaves,
 		PackedValuePtr:        c.db.indexPackedValuePtr,
 		InternalBaseDelta:     c.db.indexInternalBaseDelta && !c.db.indexOuterLeavesInValueLog,
-		LeafPageLog:           c.writer,
+		LeafPageLog:           &leafRefRewritePageAppender{ctx: c},
 	})
 	if err != nil {
 		return rootID, err

--- a/TreeDB/db/leaf_generation_pack_rewrite.go
+++ b/TreeDB/db/leaf_generation_pack_rewrite.go
@@ -442,11 +442,21 @@ func (c *leafRefRewriteCtx) rebuildSystemRootWithCollectionRootReplacements(root
 	if rootID == 0 {
 		return 0, nil
 	}
+	if c.ctx != nil {
+		if err := c.ctx.Err(); err != nil {
+			return rootID, err
+		}
+	}
 
 	tr := tree.New(c.pager, c.leafReader, rootID)
 	retired, err := tr.CollectPageIDs()
 	if err != nil {
 		return rootID, err
+	}
+	if c.ctx != nil {
+		if err := c.ctx.Err(); err != nil {
+			return rootID, err
+		}
 	}
 	var iter iteratorWithEntry = tr.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
 	if len(replacements) > 0 {
@@ -455,6 +465,7 @@ func (c *leafRefRewriteCtx) rebuildSystemRootWithCollectionRootReplacements(root
 			replacements: replacements,
 		}
 	}
+	iter = &contextIteratorWithEntry{ctx: c.ctx, base: iter}
 	defer func() { _ = iter.Close() }()
 
 	newRoot, err := bulk.BuildWithOptions(iter, c.alloc, c.pager, bulk.BuildOptions{
@@ -469,6 +480,123 @@ func (c *leafRefRewriteCtx) rebuildSystemRootWithCollectionRootReplacements(root
 	}
 	c.retired = append(c.retired, retired...)
 	return newRoot, nil
+}
+
+type contextIteratorWithEntry struct {
+	ctx  context.Context
+	base iteratorWithEntry
+	err  error
+}
+
+func (it *contextIteratorWithEntry) contextErr() error {
+	if it == nil {
+		return nil
+	}
+	if it.err != nil {
+		return it.err
+	}
+	if it.ctx != nil {
+		it.err = it.ctx.Err()
+	}
+	return it.err
+}
+
+func (it *contextIteratorWithEntry) Valid() bool {
+	if it == nil || it.base == nil || it.contextErr() != nil {
+		return false
+	}
+	return it.base.Valid()
+}
+
+func (it *contextIteratorWithEntry) Next() {
+	if it == nil || it.base == nil || it.contextErr() != nil {
+		return
+	}
+	it.base.Next()
+}
+
+func (it *contextIteratorWithEntry) UnsafeKey() []byte {
+	if it == nil || it.base == nil {
+		return nil
+	}
+	return it.base.UnsafeKey()
+}
+
+func (it *contextIteratorWithEntry) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	if it == nil || it.base == nil {
+		return nil, page.ValuePtr{}, node.FlagInline
+	}
+	return it.base.UnsafeEntry()
+}
+
+func (it *contextIteratorWithEntry) IsDeleted() bool {
+	return it != nil && it.base != nil && it.base.IsDeleted()
+}
+
+func (it *contextIteratorWithEntry) UnsafeValue() []byte {
+	if it == nil || it.base == nil {
+		return nil
+	}
+	return it.base.UnsafeValue()
+}
+
+func (it *contextIteratorWithEntry) Key() []byte {
+	if it == nil || it.base == nil {
+		return nil
+	}
+	return it.base.Key()
+}
+
+func (it *contextIteratorWithEntry) Value() []byte {
+	if it == nil || it.base == nil {
+		return nil
+	}
+	return it.base.Value()
+}
+
+func (it *contextIteratorWithEntry) KeyCopy(dst []byte) []byte {
+	if it == nil || it.base == nil {
+		return dst
+	}
+	return it.base.KeyCopy(dst)
+}
+
+func (it *contextIteratorWithEntry) ValueCopy(dst []byte) []byte {
+	if it == nil || it.base == nil {
+		return dst
+	}
+	return it.base.ValueCopy(dst)
+}
+
+func (it *contextIteratorWithEntry) Error() error {
+	if err := it.contextErr(); err != nil {
+		return err
+	}
+	if it == nil || it.base == nil {
+		return nil
+	}
+	return it.base.Error()
+}
+
+func (it *contextIteratorWithEntry) Close() error {
+	if it == nil || it.base == nil {
+		return nil
+	}
+	return it.base.Close()
+}
+
+func (it *contextIteratorWithEntry) Domain() (start, end []byte) {
+	if it == nil || it.base == nil {
+		return nil, nil
+	}
+	return it.base.Domain()
+}
+
+func (it *contextIteratorWithEntry) Seek(key []byte) {
+	if it == nil || it.base == nil || it.contextErr() != nil {
+		return
+	}
+	it.base.Seek(key)
 }
 
 func (db *DB) rewriteLeafRefsOnline(ctx context.Context, writer *rewriteWriter, ridAlloc *rewriteRIDAllocator, sourceIDs map[uint32]struct{}, sourceChunks map[valueLogChunkKey]ValueLogRewritePlanChunk, sourceChunkBytes int64, singleSourceID uint32, hasSingleSourceID bool, maxCopiedBytes int64, sync bool, runStats *leafRefRewriteRunStats) (copied int, copiedBytes int64, err error) {

--- a/TreeDB/db/leaf_generation_pack_test.go
+++ b/TreeDB/db/leaf_generation_pack_test.go
@@ -534,16 +534,27 @@ func TestLeafGenerationPack_RewritesCollectionLeafRefRoot(t *testing.T) {
 	if _, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{Force: true}); err != nil {
 		t.Fatalf("LeafGenerationPlan before pack: %v", err)
 	}
+	nextRID := uint64(10_000)
+	reservedRIDs := 0
 	stats, err := db.LeafGenerationPack(context.Background(), LeafGenerationPackOptions{
 		GenerationIDs: []uint64{gen.GenerationID},
 		Sync:          true,
 		Force:         true,
+		ReserveRIDs: func(count int) (uint64, error) {
+			start := nextRID
+			nextRID += uint64(count)
+			reservedRIDs += count
+			return start, nil
+		},
 	})
 	if err != nil {
 		t.Fatalf("LeafGenerationPack: %v", err)
 	}
-	if got := stats.LeafPagesCopied; got == 0 {
-		t.Fatalf("LeafPagesCopied=%d, want > 0", got)
+	if got := stats.LeafPagesCopied; got < 2 {
+		t.Fatalf("LeafPagesCopied=%d, want >= 2 for collection and system roots", got)
+	}
+	if reservedRIDs < stats.LeafPagesCopied {
+		t.Fatalf("ReserveRIDs reserved %d records, want at least LeafPagesCopied=%d", reservedRIDs, stats.LeafPagesCopied)
 	}
 
 	newRoot := readCollectionRootID(t, db, descriptorKey)

--- a/TreeDB/db/leaf_generation_pack_test.go
+++ b/TreeDB/db/leaf_generation_pack_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -587,6 +588,56 @@ func TestLeafGenerationPack_RewritesCollectionLeafRefRoot(t *testing.T) {
 	}
 	if err := waitForPathRemoval(oldLeafPath, 5*time.Second); err != nil {
 		t.Fatalf("waitForPathRemoval(%s): %v", oldLeafPath, err)
+	}
+}
+
+func TestLeafRefRewriteCtx_CollectionDescriptorDeltaIgnoresDurableInlineThreshold(t *testing.T) {
+	db, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	const descriptorKey = "collections/root/pack/users/primary"
+	if err := db.Set([]byte(descriptorKey), encodeMaintenanceRootID(101)); err != nil {
+		t.Fatalf("seed descriptor: %v", err)
+	}
+	state := db.State()
+	if state == nil {
+		t.Fatal("expected state")
+	}
+	rootID := state.SystemRootPageID
+	idx := db.idx.Load()
+	if idx == nil || idx.zipper == nil {
+		t.Fatal("expected zipper")
+	}
+
+	db.policy.InlineThreshold = 1
+	ctx := &leafRefRewriteCtx{
+		ctx:    context.Background(),
+		db:     db,
+		zipper: idx.zipper,
+	}
+	newRoot, changed, err := ctx.applySystemRootCollectionRootReplacements(rootID, []vacuumCollectionRootReplacement{{
+		key:   []byte(descriptorKey),
+		value: encodeMaintenanceRootID(202),
+	}})
+	if err != nil {
+		t.Fatalf("applySystemRootCollectionRootReplacements: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed=false want true")
+	}
+	if err := leafLog.Flush(); err != nil {
+		t.Fatalf("flush leaf log: %v", err)
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer snap.Close()
+	got, err := snap.GetAtRoot(newRoot, []byte(descriptorKey))
+	if err != nil {
+		t.Fatalf("read rewritten descriptor: %v", err)
+	}
+	if gotID := binary.BigEndian.Uint64(got); gotID != 202 {
+		t.Fatalf("descriptor root=%d want 202", gotID)
 	}
 }
 

--- a/TreeDB/db/leaf_generation_pack_test.go
+++ b/TreeDB/db/leaf_generation_pack_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -491,6 +492,89 @@ func TestLeafGenerationPack_MovesSparseSealedGeneration(t *testing.T) {
 	}
 	if err := waitForPathRemoval(path1, 5*time.Second); err != nil {
 		t.Fatalf("waitForPathRemoval(%s): %v", path1, err)
+	}
+}
+
+func TestLeafGenerationPack_RewritesCollectionLeafRefRoot(t *testing.T) {
+	db, leafLog, dir := openLeafGenerationPackTestDB(t)
+
+	const descriptorKey = "collections/root/pack/users/primary"
+	const docKey = "doc/collection"
+	docValue := bytes.Repeat([]byte("collection-leaf-pack|"), 16)
+	_, rootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenRawMemtable(t, docKey, docValue).NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			return nil, fmt.Errorf("rootIDs=%d want 1", len(rootIDs))
+		}
+		return mustFrozenRawMemtable(t, descriptorKey, encodeMaintenanceRootID(rootIDs[0])).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish collection leaf-ref root: %v", err)
+	}
+	oldRoot := rootIDs[0]
+	oldLeafPtr, ok := page.DecodeLeafRef(oldRoot)
+	if !ok {
+		t.Fatalf("collection root=%d want leaf ref", oldRoot)
+	}
+	oldLeafPath := leafLogSegmentPath(t, dir, oldLeafPtr.FileID)
+	rawFileID := page.ValueLogSegmentID(oldLeafPtr.FileID)
+	if err := leafLog.Sync(); err != nil {
+		t.Fatalf("sync leaf log: %v", err)
+	}
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotate leaf log: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "pack-after", 1, 'z')
+
+	manifest := loadLeafGenerationManifestOrFatal(t, dir)
+	gen := findLeafGenerationByFileID(t, manifest, rawFileID)
+	if _, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{Force: true}); err != nil {
+		t.Fatalf("LeafGenerationPlan before pack: %v", err)
+	}
+	stats, err := db.LeafGenerationPack(context.Background(), LeafGenerationPackOptions{
+		GenerationIDs: []uint64{gen.GenerationID},
+		Sync:          true,
+		Force:         true,
+	})
+	if err != nil {
+		t.Fatalf("LeafGenerationPack: %v", err)
+	}
+	if got := stats.LeafPagesCopied; got == 0 {
+		t.Fatalf("LeafPagesCopied=%d, want > 0", got)
+	}
+
+	newRoot := readCollectionRootID(t, db, descriptorKey)
+	if newRoot == oldRoot {
+		t.Fatalf("collection descriptor still points at old leaf-ref root %d", oldRoot)
+	}
+	newLeafPtr, ok := page.DecodeLeafRef(newRoot)
+	if !ok {
+		t.Fatalf("rewritten collection root=%d want leaf ref", newRoot)
+	}
+	if newLeafPtr.FileID == oldLeafPtr.FileID && newLeafPtr.Offset == oldLeafPtr.Offset {
+		t.Fatalf("collection leaf ref was not moved: %v", newLeafPtr)
+	}
+	got := readCollectionRootValue(t, db, descriptorKey, []byte(docKey))
+	if !bytes.Equal(got, docValue) {
+		t.Fatalf("collection value mismatch after pack")
+	}
+
+	planAfter, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{Force: true})
+	if err != nil {
+		t.Fatalf("LeafGenerationPlan after pack: %v", err)
+	}
+	entryAfter := findLeafGenerationPlanEntry(t, planAfter, gen.GenerationID)
+	if got := entryAfter.BytesLive; got != 0 {
+		t.Fatalf("generation %d BytesLive=%d, want 0 after collection pack", gen.GenerationID, got)
+	}
+	if _, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{}); err != nil {
+		t.Fatalf("LeafGenerationGC: %v", err)
+	}
+	if err := waitForPathRemoval(oldLeafPath, 5*time.Second); err != nil {
+		t.Fatalf("waitForPathRemoval(%s): %v", oldLeafPath, err)
 	}
 }
 

--- a/TreeDB/db/leaf_generation_pack_test.go
+++ b/TreeDB/db/leaf_generation_pack_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -589,6 +590,111 @@ func TestLeafGenerationPack_RewritesCollectionLeafRefRoot(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationPack_RewritesCollectionInternalRootsBeforeGC(t *testing.T) {
+	db, leafLog, dir := openLeafGenerationPackTestDB(t)
+
+	descriptorKeys := []string{
+		"collections/root/pack/users/primary",
+		"collections/root/pack/users/index-state",
+		"collections/root/pack/users/email_idx",
+		"collections/root/pack/users/city_idx",
+	}
+	inputs := []OrderedRootPublishInput{
+		{BaseRoot: 0, Iter: collectionPackTable(t, "doc", 0, 4096, 'a').NewIterator(nil, nil), StoragePolicy: OrderedRootStorageValueLogLeaves},
+		{BaseRoot: 0, Iter: collectionPackTable(t, "state", 0, 4096, 's').NewIterator(nil, nil), StoragePolicy: OrderedRootStorageValueLogLeaves},
+		{BaseRoot: 0, Iter: collectionPackTable(t, "email", 0, 4096, 'e').NewIterator(nil, nil), StoragePolicy: OrderedRootStorageValueLogLeaves},
+		{BaseRoot: 0, Iter: collectionPackTable(t, "city", 0, 4096, 'c').NewIterator(nil, nil), StoragePolicy: OrderedRootStorageValueLogLeaves},
+	}
+	_, rootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder(inputs, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return collectionPackDescriptorIterator(t, descriptorKeys, rootIDs), nil
+	})
+	if err != nil {
+		t.Fatalf("publish collection roots: %v", err)
+	}
+	if len(rootIDs) != len(descriptorKeys) {
+		t.Fatalf("rootIDs=%d want %d", len(rootIDs), len(descriptorKeys))
+	}
+	oldLeafPath, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	oldLeafIndexPath := leafGenerationRecordLengthIndexPath(dir, rawFileID1)
+	if err := leafLog.Sync(); err != nil {
+		t.Fatalf("sync leaf log: %v", err)
+	}
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotate leaf log: %v", err)
+	}
+
+	_, updatedRootIDs, err := db.PublishOrderedRootDeltaGroupWithSystemBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot:      rootIDs[0],
+		Iter:          collectionPackTable(t, "doc", 0, 512, 'b').NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}}, func(updatedRootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(updatedRootIDs) != 1 {
+			return nil, fmt.Errorf("updatedRootIDs=%d want 1", len(updatedRootIDs))
+		}
+		nextRootIDs := append([]uint64(nil), rootIDs...)
+		nextRootIDs[0] = updatedRootIDs[0]
+		return collectionPackDescriptorIterator(t, descriptorKeys, nextRootIDs), nil
+	})
+	if err != nil {
+		t.Fatalf("publish collection root delta: %v", err)
+	}
+	rootIDs[0] = updatedRootIDs[0]
+
+	manifest := loadLeafGenerationManifestOrFatal(t, dir)
+	gen := findLeafGenerationByFileID(t, manifest, rawFileID1)
+	planBefore, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{Force: true})
+	if err != nil {
+		t.Fatalf("LeafGenerationPlan before pack: %v", err)
+	}
+	entryBefore := findLeafGenerationPlanEntry(t, planBefore, gen.GenerationID)
+	if got := entryBefore.LivePages; got < 16 {
+		t.Fatalf("generation %d LivePages=%d, want many live collection leaves before pack (entry=%+v)", gen.GenerationID, got, entryBefore)
+	}
+	if got := entryBefore.BytesLive; got <= 16*1024 {
+		t.Fatalf("generation %d BytesLive=%d, want >16KiB before pack (entry=%+v)", gen.GenerationID, got, entryBefore)
+	}
+	if got := entryBefore.BytesDead; got <= 0 {
+		t.Fatalf("generation %d BytesDead=%d, want >0 before pack (entry=%+v)", gen.GenerationID, got, entryBefore)
+	}
+
+	stats, err := db.LeafGenerationPack(context.Background(), LeafGenerationPackOptions{
+		GenerationIDs: []uint64{gen.GenerationID},
+		Sync:          true,
+		Force:         true,
+	})
+	if err != nil {
+		t.Fatalf("LeafGenerationPack: %v", err)
+	}
+	if got := stats.LeafPagesCopied; got < entryBefore.LivePages {
+		t.Fatalf("LeafPagesCopied=%d, want at least live collection pages %d", got, entryBefore.LivePages)
+	}
+	planAfter, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{Force: true})
+	if err != nil {
+		t.Fatalf("LeafGenerationPlan after pack: %v", err)
+	}
+	entryAfter := findLeafGenerationPlanEntry(t, planAfter, gen.GenerationID)
+	if got := entryAfter.BytesLive; got != 0 {
+		t.Fatalf("generation %d BytesLive=%d, want 0 after pack", gen.GenerationID, got)
+	}
+
+	if _, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{}); err != nil {
+		t.Fatalf("LeafGenerationGC: %v", err)
+	}
+	if err := waitForPathRemoval(oldLeafPath, 5*time.Second); err != nil {
+		t.Fatalf("waitForPathRemoval(%s): %v", oldLeafPath, err)
+	}
+	if err := waitForPathRemoval(oldLeafIndexPath, 5*time.Second); err != nil {
+		t.Fatalf("waitForPathRemoval(%s): %v", oldLeafIndexPath, err)
+	}
+
+	expectCollectionPackValue(t, db, descriptorKeys[0], "doc-0000", 'b')
+	expectCollectionPackValue(t, db, descriptorKeys[0], "doc-2048", 'a')
+	expectCollectionPackValue(t, db, descriptorKeys[1], "state-2048", 's')
+	expectCollectionPackValue(t, db, descriptorKeys[2], "email-2048", 'e')
+	expectCollectionPackValue(t, db, descriptorKeys[3], "city-2048", 'c')
+}
+
 func TestLeafGenerationPack_PrunesCachedSubtreesOutsideSelection(t *testing.T) {
 	db, leafLog, dir := openLeafGenerationPackTestDB(t)
 
@@ -679,6 +785,36 @@ func TestLeafGenerationPack_RejectsDenseGenerationByDefault(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "selection admission=reclaim_per_copy_too_low") {
 		t.Fatalf("dense generation error=%v, want reclaim_per_copy_too_low", err)
+	}
+}
+
+func collectionPackTable(t *testing.T, keyPrefix string, start, count int, fill byte) memtable.Table {
+	t.Helper()
+	kvs := make([]any, 0, count*2)
+	for i := 0; i < count; i++ {
+		kvs = append(kvs, fmt.Sprintf("%s-%04d", keyPrefix, start+i), bytes.Repeat([]byte{fill}, 32))
+	}
+	return mustFrozenRawMemtable(t, kvs...)
+}
+
+func collectionPackDescriptorIterator(t *testing.T, descriptorKeys []string, rootIDs []uint64) iterator.UnsafeIterator {
+	t.Helper()
+	if len(descriptorKeys) != len(rootIDs) {
+		t.Fatalf("descriptorKeys=%d rootIDs=%d", len(descriptorKeys), len(rootIDs))
+	}
+	kvs := make([]any, 0, len(descriptorKeys)*2)
+	for i, key := range descriptorKeys {
+		kvs = append(kvs, key, encodeMaintenanceRootID(rootIDs[i]))
+	}
+	return mustFrozenRawMemtable(t, kvs...).NewIterator(nil, nil)
+}
+
+func expectCollectionPackValue(t *testing.T, db *DB, descriptorKey, key string, fill byte) {
+	t.Helper()
+	got := readCollectionRootValue(t, db, descriptorKey, []byte(key))
+	want := bytes.Repeat([]byte{fill}, 32)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("collection root %q key %q=%x, want %x", descriptorKey, key, got, want)
 	}
 }
 

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -106,6 +106,10 @@ type leafGenerationScanContext struct {
 	lastFileState *leafGenerationScanFileState
 }
 
+type leafGenerationLiveStatsScanOptions struct {
+	DisableCache bool
+}
+
 var leafGenerationLiveScanHook struct {
 	mu sync.Mutex
 	fn func()
@@ -551,6 +555,11 @@ func (db *DB) leafGenerationLiveStatsForSnapshot(ctx context.Context, snap *Snap
 	return stats, nil
 }
 
+func (db *DB) leafGenerationLiveStatsForSnapshotUncached(ctx context.Context, snap *Snapshot) (leafGenerationLiveScanStats, error) {
+	runLeafGenerationLiveScanHook()
+	return db.scanLeafGenerationLiveStatsWithOptions(ctx, snap, leafGenerationLiveStatsScanOptions{DisableCache: true})
+}
+
 func (db *DB) scanLeafGenerationPtrTotals(scan *leafGenerationScanContext, dst leafGenerationSubtreeStats, ptr page.LeafLogPtr) (leafGenerationSubtreeStats, error) {
 	if scan == nil {
 		return dst, fmt.Errorf("leaf generation plan: missing scan context")
@@ -655,6 +664,10 @@ func (db *DB) scanLeafGenerationSubtreeStats(ctx context.Context, scan *leafGene
 }
 
 func (db *DB) scanLeafGenerationLiveStats(ctx context.Context, snap *Snapshot) (leafGenerationLiveScanStats, error) {
+	return db.scanLeafGenerationLiveStatsWithOptions(ctx, snap, leafGenerationLiveStatsScanOptions{})
+}
+
+func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *Snapshot, opts leafGenerationLiveStatsScanOptions) (leafGenerationLiveScanStats, error) {
 	stats := leafGenerationLiveScanStats{
 		Generations: make(map[uint64]leafGenerationLiveTotals),
 	}
@@ -702,7 +715,7 @@ func (db *DB) scanLeafGenerationLiveStats(ctx context.Context, snap *Snapshot) (
 		verify:        verify,
 		fileStateByID: fileStateByID,
 		memo:          make(map[uint64]leafGenerationSubtreeStats, 64),
-		cacheEnabled:  !verifyAlways,
+		cacheEnabled:  !opts.DisableCache && !verifyAlways,
 	}
 	roots, err := maintenanceRootsForSnapshot(snap)
 	if err != nil {

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -650,8 +650,8 @@ func TestLeafGenerationPlan_CachesLiveStatsPerPublishedState(t *testing.T) {
 	if err := snap.Close(); err != nil {
 		t.Fatalf("close snapshot: %v", err)
 	}
-	if got, want := counter.Load(), uint64(1); got != want {
-		t.Fatalf("scan count after gc helper reuse=%d, want %d", got, want)
+	if got, want := counter.Load(), uint64(2); got != want {
+		t.Fatalf("scan count after uncached gc helper=%d, want %d", got, want)
 	}
 
 	if err := db.Commit(rootBefore); err != nil {
@@ -670,7 +670,7 @@ func TestLeafGenerationPlan_CachesLiveStatsPerPublishedState(t *testing.T) {
 	if _, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{}); err != nil {
 		t.Fatalf("LeafGenerationPlan after same-root commit: %v", err)
 	}
-	if got, want := counter.Load(), uint64(2); got != want {
+	if got, want := counter.Load(), uint64(3); got != want {
 		t.Fatalf("scan count after same-root commit=%d, want %d", got, want)
 	}
 
@@ -685,7 +685,7 @@ func TestLeafGenerationPlan_CachesLiveStatsPerPublishedState(t *testing.T) {
 	if _, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{}); err != nil {
 		t.Fatalf("LeafGenerationPlan after root change: %v", err)
 	}
-	if got, want := counter.Load(), uint64(3); got != want {
+	if got, want := counter.Load(), uint64(4); got != want {
 		t.Fatalf("scan count after root change=%d, want %d", got, want)
 	}
 }

--- a/TreeDB/db/vacuum_collection_roots.go
+++ b/TreeDB/db/vacuum_collection_roots.go
@@ -56,20 +56,21 @@ func vacuumCollectionRootDescriptorPrefixEnd() []byte {
 }
 
 func vacuumCollectCollectionRootDescriptors(p *pager.Pager, reader tree.SlabReader, systemRootID uint64) ([]vacuumCollectionRootDescriptor, error) {
-	return vacuumCollectCollectionRootDescriptorsWithContext(nil, p, reader, systemRootID)
+	return vacuumCollectCollectionRootDescriptorsWithContext(context.Background(), p, reader, systemRootID)
 }
 
 func vacuumCollectCollectionRootDescriptorsWithContext(ctx context.Context, p *pager.Pager, reader tree.SlabReader, systemRootID uint64) ([]vacuumCollectionRootDescriptor, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if p == nil {
 		return nil, errors.New("vacuum: missing pager")
 	}
 	if systemRootID == 0 {
 		return nil, nil
 	}
-	if ctx != nil {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	it := tree.New(p, reader, systemRootID).IteratorWithOptions(vacuumCollectionRootDescriptorPrefixBytes, vacuumCollectionRootDescriptorPrefixEnd(), tree.IteratorOptions{
@@ -80,10 +81,8 @@ func vacuumCollectCollectionRootDescriptorsWithContext(ctx context.Context, p *p
 	var out []vacuumCollectionRootDescriptor
 	var pointerScratch []byte
 	for it.Valid() {
-		if ctx != nil {
-			if err := ctx.Err(); err != nil {
-				return nil, err
-			}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 		key := it.UnsafeKey()
 		if !bytes.HasPrefix(key, vacuumCollectionRootDescriptorPrefixBytes) {

--- a/TreeDB/db/vacuum_collection_roots.go
+++ b/TreeDB/db/vacuum_collection_roots.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -55,11 +56,20 @@ func vacuumCollectionRootDescriptorPrefixEnd() []byte {
 }
 
 func vacuumCollectCollectionRootDescriptors(p *pager.Pager, reader tree.SlabReader, systemRootID uint64) ([]vacuumCollectionRootDescriptor, error) {
+	return vacuumCollectCollectionRootDescriptorsWithContext(nil, p, reader, systemRootID)
+}
+
+func vacuumCollectCollectionRootDescriptorsWithContext(ctx context.Context, p *pager.Pager, reader tree.SlabReader, systemRootID uint64) ([]vacuumCollectionRootDescriptor, error) {
 	if p == nil {
 		return nil, errors.New("vacuum: missing pager")
 	}
 	if systemRootID == 0 {
 		return nil, nil
+	}
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 	}
 
 	it := tree.New(p, reader, systemRootID).IteratorWithOptions(vacuumCollectionRootDescriptorPrefixBytes, vacuumCollectionRootDescriptorPrefixEnd(), tree.IteratorOptions{
@@ -70,6 +80,11 @@ func vacuumCollectCollectionRootDescriptors(p *pager.Pager, reader tree.SlabRead
 	var out []vacuumCollectionRootDescriptor
 	var pointerScratch []byte
 	for it.Valid() {
+		if ctx != nil {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		key := it.UnsafeKey()
 		if !bytes.HasPrefix(key, vacuumCollectionRootDescriptorPrefixBytes) {
 			break


### PR DESCRIPTION
## Summary

Follow-up to #1082. This makes the online leaf-generation pack path collection-aware for roots referenced from `collections/root/...` system descriptors.

- scans collection root descriptors from the snapshot system root during `rewriteLeafRefsOnline`
- rewrites collection roots through the same LeafRef rewrite context used for user/system roots
- rebuilds the system root with updated collection root descriptor values directly into the pack writer, avoiding reads from unflushed rewrite output
- keeps descriptor failures wrapped with `vlog-rewrite` context
- adds a regression that packs a sealed collection leaf generation, verifies the descriptor points at the moved LeafRef root, verifies the old generation has zero live bytes, and runs leaf-generation GC to remove the old file

## Validation

- `go test ./TreeDB/db -run 'TestLeafGenerationPack_RewritesCollectionLeafRefRoot|TestValueLogRewriteOffline_RewritesCollectionLeafRefRootWithPagerDefault' -count=1`
- `go test ./TreeDB/db -run 'TestLeafGenerationPack_(RewritesCollectionLeafRefRoot|MovesSparseSealedGeneration|PrunesCachedSubtreesOutsideSelection|ForceAllowsDenseGeneration)|TestLeafGenerationPackRunOnce' -count=1`
- `go test ./TreeDB/db -count=1`
