### PR TITLE
[codex] Add minimal Mongo gateway server loop

### DIFF
--- a/TreeDB/mongo_gateway/PLAN.md
+++ b/TreeDB/mongo_gateway/PLAN.md
@@ -296,6 +296,8 @@ Metrics to record for every run:
       operators, and BSON types.
 - [x] Prototype the small TreeDB-owned wire layer with OP_QUERY handshake,
       OP_REPLY handshake response, and OP_MSG command request/response tests.
+- [x] Prototype a minimal gateway server loop that answers `OP_QUERY`
+      `hello` / `isMaster` and `OP_MSG` `ping` without collection storage.
 - [ ] Define the initial BSON-to-TreeDB document encoding.
 - [ ] Define canonical `_id` primary-key encoding, generated ObjectId behavior,
       and `_id` immutability tests.
@@ -332,3 +334,7 @@ Metrics to record for every run:
   builds OP_REPLY responses, parses/builds single-body OP_MSG messages, rejects
   checksum-bearing and document-sequence OP_MSGs until needed, and uses the
   official driver v2 `bson.Raw` type for BSON document validation.
+- 2026-04-28: Added a minimal `mongogateway.Server` that serves one message or
+  a connection loop, responds to legacy `OP_QUERY` handshake requests with
+  `OP_REPLY`, responds to `OP_MSG` `ping` with an `OP_MSG` reply, and rejects
+  compressed messages until compression is implemented.

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -31,6 +31,16 @@ func NewServer() *Server {
 }
 
 func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -41,6 +51,9 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		if err := s.ServeOne(conn); err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
+			}
+			if ctx.Err() != nil && errors.Is(err, net.ErrClosed) {
+				return ctx.Err()
 			}
 			return err
 		}

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -31,6 +31,8 @@ func NewServer() *Server {
 }
 
 func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
+	defer conn.Close()
+
 	done := make(chan struct{})
 	defer close(done)
 	go func() {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -1,0 +1,157 @@
+package mongogateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+const (
+	defaultMaxBSONObjectSize = 16 * 1024 * 1024
+	defaultMaxWriteBatchSize = 100_000
+)
+
+type Server struct {
+	MaxMessageLength int32
+
+	nextResponseID atomic.Int32
+}
+
+func NewServer() *Server {
+	s := &Server{MaxMessageLength: wire.DefaultMaxMessageLength}
+	s.nextResponseID.Store(1)
+	return s
+}
+
+func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err := s.ServeOne(conn); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func (s *Server) ServeOne(rw io.ReadWriter) error {
+	h, body, err := wire.ReadMessage(rw, s.maxMessageLength())
+	if err != nil {
+		return err
+	}
+	response, err := s.handleMessage(h, body)
+	if err != nil {
+		return err
+	}
+	_, err = rw.Write(response)
+	return err
+}
+
+func (s *Server) handleMessage(h wire.Header, body []byte) ([]byte, error) {
+	switch h.OpCode {
+	case wire.OpQuery:
+		return s.handleQuery(h, body)
+	case wire.OpMsg:
+		return s.handleMsg(h, body)
+	case wire.OpCompressed:
+		return nil, fmt.Errorf("%w: OP_COMPRESSED", wire.ErrUnsupported)
+	default:
+		return nil, fmt.Errorf("%w: opcode %d", wire.ErrUnsupported, h.OpCode)
+	}
+}
+
+func (s *Server) handleQuery(h wire.Header, body []byte) ([]byte, error) {
+	q, err := wire.ParseQuery(body)
+	if err != nil {
+		return nil, err
+	}
+	name, err := wire.CommandName(q.Query)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := s.commandResponse(name)
+	if err != nil {
+		return nil, err
+	}
+	return wire.AppendReplyMessage(nil, s.nextID(), h.RequestID, 0, 0, 0, response)
+}
+
+func (s *Server) handleMsg(h wire.Header, body []byte) ([]byte, error) {
+	msg, err := wire.ParseMsg(body)
+	if err != nil {
+		return nil, err
+	}
+	name, err := wire.CommandName(msg.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := s.commandResponse(name)
+	if err != nil {
+		return nil, err
+	}
+	return wire.AppendMsgMessage(nil, s.nextID(), h.RequestID, 0, response)
+}
+
+func (s *Server) commandResponse(name string) (wire.Document, error) {
+	switch name {
+	case "hello", "isMaster", "ismaster":
+		return marshalDocument(helloResponse(s.maxMessageLength()))
+	case "ping":
+		return marshalDocument(bson.D{{Key: "ok", Value: 1.0}})
+	default:
+		return marshalDocument(bson.D{
+			{Key: "ok", Value: 0.0},
+			{Key: "errmsg", Value: "unsupported MongoDB gateway command: " + name},
+			{Key: "code", Value: int32(59)},
+			{Key: "codeName", Value: "CommandNotFound"},
+		})
+	}
+}
+
+func helloResponse(maxMessageLength int32) bson.D {
+	return bson.D{
+		{Key: "ok", Value: 1.0},
+		{Key: "isWritablePrimary", Value: true},
+		{Key: "helloOk", Value: true},
+		{Key: "minWireVersion", Value: int32(0)},
+		{Key: "maxWireVersion", Value: int32(21)},
+		{Key: "maxBsonObjectSize", Value: int32(defaultMaxBSONObjectSize)},
+		{Key: "maxMessageSizeBytes", Value: maxMessageLength},
+		{Key: "maxWriteBatchSize", Value: int32(defaultMaxWriteBatchSize)},
+		{Key: "localTime", Value: time.Now().UTC()},
+	}
+}
+
+func marshalDocument(doc bson.D) (wire.Document, error) {
+	raw, err := bson.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+	return wire.Document(raw), nil
+}
+
+func (s *Server) maxMessageLength() int32 {
+	if s.MaxMessageLength <= 0 {
+		return wire.DefaultMaxMessageLength
+	}
+	return s.MaxMessageLength
+}
+
+func (s *Server) nextID() int32 {
+	return s.nextResponseID.Add(1)
+}

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -26,7 +26,7 @@ type Server struct {
 
 func NewServer() *Server {
 	s := &Server{MaxMessageLength: wire.DefaultMaxMessageLength}
-	s.nextResponseID.Store(1)
+	s.nextResponseID.Store(0)
 	return s
 }
 
@@ -140,6 +140,8 @@ func helloResponse(maxMessageLength int32) bson.D {
 	return bson.D{
 		{Key: "ok", Value: 1.0},
 		{Key: "isWritablePrimary", Value: true},
+		{Key: "ismaster", Value: true},
+		{Key: "secondary", Value: false},
 		{Key: "helloOk", Value: true},
 		{Key: "minWireVersion", Value: int32(0)},
 		{Key: "maxWireVersion", Value: int32(21)},

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -54,7 +54,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
-			if ctx.Err() != nil && errors.Is(err, net.ErrClosed) {
+			if ctx.Err() != nil && (errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe)) {
 				return ctx.Err()
 			}
 			return err
@@ -71,8 +71,7 @@ func (s *Server) ServeOne(rw io.ReadWriter) error {
 	if err != nil {
 		return err
 	}
-	_, err = rw.Write(response)
-	return err
+	return writeFull(rw, response)
 }
 
 func (s *Server) handleMessage(h wire.Header, body []byte) ([]byte, error) {
@@ -162,8 +161,25 @@ func marshalDocument(doc bson.D) (wire.Document, error) {
 	return wire.Document(raw), nil
 }
 
+func writeFull(w io.Writer, p []byte) error {
+	for len(p) > 0 {
+		n, err := w.Write(p)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+		p = p[n:]
+	}
+	return nil
+}
+
 func (s *Server) maxMessageLength() int32 {
 	if s.MaxMessageLength <= 0 {
+		return wire.DefaultMaxMessageLength
+	}
+	if s.MaxMessageLength > wire.DefaultMaxMessageLength {
 		return wire.DefaultMaxMessageLength
 	}
 	return s.MaxMessageLength

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -26,6 +26,23 @@ func (rw *readWriter) Write(p []byte) (int, error) {
 	return rw.w.Write(p)
 }
 
+type partialReadWriter struct {
+	r        io.Reader
+	w        bytes.Buffer
+	maxWrite int
+}
+
+func (rw *partialReadWriter) Read(p []byte) (int, error) {
+	return rw.r.Read(p)
+}
+
+func (rw *partialReadWriter) Write(p []byte) (int, error) {
+	if len(p) > rw.maxWrite {
+		p = p[:rw.maxWrite]
+	}
+	return rw.w.Write(p)
+}
+
 func TestServerHandlesQueryHello(t *testing.T) {
 	queryDoc := mustDocument(t, bson.D{
 		{Key: "isMaster", Value: int32(1)},
@@ -91,6 +108,35 @@ func TestServerHandlesMsgPing(t *testing.T) {
 	assertOK(t, msg.Body)
 }
 
+func TestServerHandlesPartialWrites(t *testing.T) {
+	commandDoc := mustDocument(t, bson.D{
+		{Key: "ping", Value: int32(1)},
+		{Key: "$db", Value: "admin"},
+	})
+	req, err := wire.AppendMsgMessage(nil, 201, 0, 0, commandDoc)
+	if err != nil {
+		t.Fatalf("AppendMsgMessage: %v", err)
+	}
+	rw := &partialReadWriter{r: bytes.NewReader(req), maxWrite: 5}
+
+	if err := NewServer().ServeOne(rw); err != nil {
+		t.Fatalf("ServeOne: %v", err)
+	}
+
+	h, body, err := wire.ReadMessage(bytes.NewReader(rw.w.Bytes()), 0)
+	if err != nil {
+		t.Fatalf("ReadMessage response: %v", err)
+	}
+	if h.OpCode != wire.OpMsg || h.ResponseTo != 201 {
+		t.Fatalf("response header=%+v", h)
+	}
+	msg, err := wire.ParseMsg(body)
+	if err != nil {
+		t.Fatalf("ParseMsg: %v", err)
+	}
+	assertOK(t, msg.Body)
+}
+
 func TestServerRejectsCompressedMessages(t *testing.T) {
 	req, err := wire.AppendMessage(nil, 300, 0, wire.OpCompressed, nil)
 	if err != nil {
@@ -125,6 +171,13 @@ func TestServeConnCancellationInterruptsRead(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("ServeConn did not return after context cancellation")
+	}
+}
+
+func TestServerMaxMessageLengthClampsToWireLimit(t *testing.T) {
+	server := &Server{MaxMessageLength: wire.DefaultMaxMessageLength + 1}
+	if got := server.maxMessageLength(); got != wire.DefaultMaxMessageLength {
+		t.Fatalf("maxMessageLength=%d want %d", got, wire.DefaultMaxMessageLength)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1,0 +1,132 @@
+package mongogateway
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type readWriter struct {
+	r io.Reader
+	w bytes.Buffer
+}
+
+func (rw *readWriter) Read(p []byte) (int, error) {
+	return rw.r.Read(p)
+}
+
+func (rw *readWriter) Write(p []byte) (int, error) {
+	return rw.w.Write(p)
+}
+
+func TestServerHandlesQueryHello(t *testing.T) {
+	queryDoc := mustDocument(t, bson.D{
+		{Key: "isMaster", Value: int32(1)},
+		{Key: "helloOk", Value: true},
+		{Key: "$db", Value: "admin"},
+	})
+	req, err := wire.AppendQueryMessage(nil, 100, 0, 0, "admin.$cmd", 0, -1, queryDoc, nil)
+	if err != nil {
+		t.Fatalf("AppendQueryMessage: %v", err)
+	}
+	rw := &readWriter{r: bytes.NewReader(req)}
+
+	if err := NewServer().ServeOne(rw); err != nil {
+		t.Fatalf("ServeOne: %v", err)
+	}
+
+	h, body, err := wire.ReadMessage(bytes.NewReader(rw.w.Bytes()), 0)
+	if err != nil {
+		t.Fatalf("ReadMessage response: %v", err)
+	}
+	if h.OpCode != wire.OpReply || h.ResponseTo != 100 {
+		t.Fatalf("response header=%+v", h)
+	}
+	reply, err := wire.ParseReply(body)
+	if err != nil {
+		t.Fatalf("ParseReply: %v", err)
+	}
+	if len(reply.Documents) != 1 {
+		t.Fatalf("reply document count=%d want 1", len(reply.Documents))
+	}
+	assertOK(t, reply.Documents[0])
+	assertBool(t, reply.Documents[0], "helloOk", true)
+}
+
+func TestServerHandlesMsgPing(t *testing.T) {
+	commandDoc := mustDocument(t, bson.D{
+		{Key: "ping", Value: int32(1)},
+		{Key: "$db", Value: "admin"},
+	})
+	req, err := wire.AppendMsgMessage(nil, 200, 0, 0, commandDoc)
+	if err != nil {
+		t.Fatalf("AppendMsgMessage: %v", err)
+	}
+	rw := &readWriter{r: bytes.NewReader(req)}
+
+	if err := NewServer().ServeOne(rw); err != nil {
+		t.Fatalf("ServeOne: %v", err)
+	}
+
+	h, body, err := wire.ReadMessage(bytes.NewReader(rw.w.Bytes()), 0)
+	if err != nil {
+		t.Fatalf("ReadMessage response: %v", err)
+	}
+	if h.OpCode != wire.OpMsg || h.ResponseTo != 200 {
+		t.Fatalf("response header=%+v", h)
+	}
+	msg, err := wire.ParseMsg(body)
+	if err != nil {
+		t.Fatalf("ParseMsg: %v", err)
+	}
+	assertOK(t, msg.Body)
+}
+
+func TestServerRejectsCompressedMessages(t *testing.T) {
+	req, err := wire.AppendMessage(nil, 300, 0, wire.OpCompressed, nil)
+	if err != nil {
+		t.Fatalf("AppendMessage: %v", err)
+	}
+	rw := &readWriter{r: bytes.NewReader(req)}
+
+	err = NewServer().ServeOne(rw)
+	if !errors.Is(err, wire.ErrUnsupported) {
+		t.Fatalf("ServeOne err=%v want ErrUnsupported", err)
+	}
+	if rw.w.Len() != 0 {
+		t.Fatalf("unexpected response bytes=%d", rw.w.Len())
+	}
+}
+
+func mustDocument(tb testing.TB, doc bson.D) wire.Document {
+	tb.Helper()
+	raw, err := bson.Marshal(doc)
+	if err != nil {
+		tb.Fatalf("marshal BSON document: %v", err)
+	}
+	return wire.Document(raw)
+}
+
+func assertOK(tb testing.TB, doc wire.Document) {
+	tb.Helper()
+	raw := bson.Raw(doc)
+	value := raw.Lookup("ok")
+	ok, okType := value.DoubleOK()
+	if !okType || ok != 1.0 {
+		tb.Fatalf("ok=%v typeOK=%v want 1.0", ok, okType)
+	}
+}
+
+func assertBool(tb testing.TB, doc wire.Document, key string, want bool) {
+	tb.Helper()
+	raw := bson.Raw(doc)
+	value := raw.Lookup(key)
+	got, ok := value.BooleanOK()
+	if !ok || got != want {
+		tb.Fatalf("%s=%v typeOK=%v want %v", key, got, ok, want)
+	}
+}

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -2,9 +2,12 @@ package mongogateway
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -99,6 +102,27 @@ func TestServerRejectsCompressedMessages(t *testing.T) {
 	}
 	if rw.w.Len() != 0 {
 		t.Fatalf("unexpected response bytes=%d", rw.w.Len())
+	}
+}
+
+func TestServeConnCancellationInterruptsRead(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- NewServer().ServeConn(ctx, serverConn)
+	}()
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ServeConn err=%v want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ServeConn did not return after context cancellation")
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -46,7 +46,7 @@ func TestServerHandlesQueryHello(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadMessage response: %v", err)
 	}
-	if h.OpCode != wire.OpReply || h.ResponseTo != 100 {
+	if h.OpCode != wire.OpReply || h.RequestID != 1 || h.ResponseTo != 100 {
 		t.Fatalf("response header=%+v", h)
 	}
 	reply, err := wire.ParseReply(body)
@@ -58,6 +58,8 @@ func TestServerHandlesQueryHello(t *testing.T) {
 	}
 	assertOK(t, reply.Documents[0])
 	assertBool(t, reply.Documents[0], "helloOk", true)
+	assertBool(t, reply.Documents[0], "ismaster", true)
+	assertBool(t, reply.Documents[0], "secondary", false)
 }
 
 func TestServerHandlesMsgPing(t *testing.T) {
@@ -79,7 +81,7 @@ func TestServerHandlesMsgPing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadMessage response: %v", err)
 	}
-	if h.OpCode != wire.OpMsg || h.ResponseTo != 200 {
+	if h.OpCode != wire.OpMsg || h.RequestID != 1 || h.ResponseTo != 200 {
 		t.Fatalf("response header=%+v", h)
 	}
 	msg, err := wire.ParseMsg(body)


### PR DESCRIPTION
## Summary

- add `mongogateway.Server` with a one-message handler and connection loop
- respond to legacy `OP_QUERY` `hello` / `isMaster` with `OP_REPLY`
- respond to `OP_MSG` `ping` with an `OP_MSG` reply
- reject `OP_COMPRESSED` until compression is implemented
- update the Mongo gateway plan todo/work log for the server-loop prototype

## Validation

- GOWORK=off go test ./TreeDB/mongo_gateway/... -count=1
- GOWORK=off go test ./... -count=1