### PR TITLE
Rewrite collection roots during online value-log rewrite

### DIFF
--- a/TreeDB/db/vacuum_collection_roots.go
+++ b/TreeDB/db/vacuum_collection_roots.go
@@ -178,11 +178,9 @@ func vacuumRewriteCollectionRootDescriptors(descriptors []vacuumCollectionRootDe
 			}
 		}
 		if newRoot != oldRoot {
-			encoded := make([]byte, 8)
-			binary.BigEndian.PutUint64(encoded, newRoot)
 			replacements = append(replacements, vacuumCollectionRootReplacement{
 				key:   descriptor.key,
-				value: encoded,
+				value: encodeCollectionRootDescriptorRootID(newRoot),
 			})
 		}
 	}
@@ -193,6 +191,12 @@ func vacuumRewriteCollectionRootDescriptors(descriptors []vacuumCollectionRootDe
 		return bytes.Compare(replacements[i].key, replacements[j].key) < 0
 	})
 	return replacements, nil
+}
+
+func encodeCollectionRootDescriptorRootID(rootID uint64) []byte {
+	encoded := make([]byte, 8)
+	binary.BigEndian.PutUint64(encoded, rootID)
+	return encoded
 }
 
 func vacuumCopyCollectionRoot(oldPager *pager.Pager, rootID uint64, alloc vacuumAllocator, newPager *pager.Pager) (uint64, error) {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2424,16 +2424,16 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 		if err != nil || !ok || collectionRoot == 0 {
 			return err
 		}
-		currentStoragePolicy, err := valueLogRewriteCollectionRootStoragePolicy(idx.pager, collectionRoot)
-		if err != nil {
-			return fmt.Errorf("vlog-rewrite: inspect current collection root %q storage: %w", string(target.descriptorKey), err)
-		}
 		target.rootID = collectionRoot
 		target.descriptorAliases = descriptorAliases
 		target.systemRoot = systemRoot
-		target.storagePolicy = currentStoragePolicy
 	}
 	collectionRoot := target.rootID
+	currentStoragePolicy, err := valueLogRewriteCollectionRootStoragePolicy(idx.pager, collectionRoot)
+	if err != nil {
+		return fmt.Errorf("vlog-rewrite: inspect current collection root %q storage: %w", string(target.descriptorKey), err)
+	}
+	target.storagePolicy = currentStoragePolicy
 	rootOpts, err := db.orderedRootPublishOptionsForPolicy(target.storagePolicy)
 	if err != nil {
 		return err
@@ -2543,7 +2543,7 @@ func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReade
 	aliases := make([][]byte, 0, 1)
 	for _, descriptor := range descriptors {
 		if descriptor.rootID == rootID {
-			aliases = append(aliases, descriptor.key)
+			aliases = append(aliases, append([]byte(nil), descriptor.key...))
 		}
 	}
 	return rootID, aliases, true, nil

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2325,12 +2325,6 @@ func cloneCollectionRootDescriptorAliases(aliases [][]byte) [][]byte {
 	return out
 }
 
-func valueLogRewriteCollectionRootDescriptorAliases(descriptors []vacuumCollectionRootDescriptor, rootID uint64) [][]byte {
-	aliasesByRoot := valueLogRewriteCollectionRootDescriptorAliasMap(descriptors)
-	aliases := cloneCollectionRootDescriptorAliases(aliasesByRoot[rootID])
-	return aliases
-}
-
 func (db *DB) applyRewriteSwapBatch(swaps []rewriteSwap, sync bool) error {
 	if len(swaps) == 0 {
 		return nil
@@ -2372,11 +2366,11 @@ func (db *DB) applyRewriteSwapBatchToSystemRoot(swaps []rewriteSwap, sync bool) 
 	}
 	idx := db.idx.Load()
 	if idx == nil {
-		return fmt.Errorf("vlog-rewrite: collection root: missing index")
+		return fmt.Errorf("vlog-rewrite: system root: missing index")
 	}
 	state := db.state.Load()
 	if state == nil {
-		return fmt.Errorf("vlog-rewrite: collection root: missing backend state")
+		return fmt.Errorf("vlog-rewrite: system root: missing backend state")
 	}
 
 	db.mu.RLock()

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1845,9 +1845,21 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	}
 
 	snap := db.AcquireSnapshot()
-	if snap == nil || snap.state == nil || snap.idx == nil || snap.idx.pager == nil {
+	if snap == nil {
+		closeRewriteSnapshot(&err, snap)
+		return stats, fmt.Errorf("missing snapshot")
+	}
+	if snap.state == nil {
 		closeRewriteSnapshot(&err, snap)
 		return stats, fmt.Errorf("missing snapshot state")
+	}
+	if snap.idx == nil {
+		closeRewriteSnapshot(&err, snap)
+		return stats, fmt.Errorf("missing snapshot index")
+	}
+	if snap.idx.pager == nil {
+		closeRewriteSnapshot(&err, snap)
+		return stats, fmt.Errorf("missing snapshot pager")
 	}
 	roots, err := maintenanceRootsForSnapshot(snap)
 	if err != nil {
@@ -1859,16 +1871,12 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		if root.kind != maintenanceRootCollection || root.rootID == 0 {
 			continue
 		}
-		useLeafLog, err := valueLogRewriteCollectionRootUsesLeafLog(snap.idx.pager, root.rootID)
+		storagePolicy, err := valueLogRewriteCollectionRootStoragePolicy(snap.idx.pager, root.rootID)
 		if err != nil {
 			closeRewriteSnapshot(&err, snap)
 			return stats, fmt.Errorf("vlog-rewrite: inspect collection root %q storage: %w", string(root.descriptorKey), err)
 		}
-		if useLeafLog {
-			rootPolicies[i] = OrderedRootStorageValueLogLeaves
-		} else {
-			rootPolicies[i] = OrderedRootStoragePagerLeaves
-		}
+		rootPolicies[i] = storagePolicy
 	}
 	stopScanning := false
 	scanRoot := func(root maintenanceRoot, storagePolicy OrderedRootStoragePolicy) error {
@@ -2324,7 +2332,7 @@ func (db *DB) applyRewriteSwapBatchToSystemRoot(swaps []rewriteSwap, sync bool) 
 	return nil
 }
 
-func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, storagePolicy OrderedRootStoragePolicy, swaps []rewriteSwap, sync bool) error {
+func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, _ OrderedRootStoragePolicy, swaps []rewriteSwap, sync bool) error {
 	if len(swaps) == 0 {
 		return nil
 	}
@@ -2361,7 +2369,11 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, storag
 	if err != nil || !ok || collectionRoot == 0 {
 		return err
 	}
-	rootOpts, err := db.orderedRootPublishOptionsForPolicy(storagePolicy)
+	currentStoragePolicy, err := valueLogRewriteCollectionRootStoragePolicy(idx.pager, collectionRoot)
+	if err != nil {
+		return fmt.Errorf("vlog-rewrite: inspect current collection root %q storage: %w", string(descriptorKey), err)
+	}
+	rootOpts, err := db.orderedRootPublishOptionsForPolicy(currentStoragePolicy)
 	if err != nil {
 		return err
 	}
@@ -3123,6 +3135,17 @@ func valueLogRewriteCollectionRootUsesLeafLog(oldPager *pager.Pager, rootID uint
 		return false, err
 	}
 	return allLeafRefs, nil
+}
+
+func valueLogRewriteCollectionRootStoragePolicy(oldPager *pager.Pager, rootID uint64) (OrderedRootStoragePolicy, error) {
+	useLeafLog, err := valueLogRewriteCollectionRootUsesLeafLog(oldPager, rootID)
+	if err != nil {
+		return OrderedRootStorageDefault, err
+	}
+	if useLeafLog {
+		return OrderedRootStorageValueLogLeaves, nil
+	}
+	return OrderedRootStoragePagerLeaves, nil
 }
 
 type rewriteCreatedSegment struct {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2267,7 +2267,7 @@ func valueLogRewriteCollectionRootStates(snap *Snapshot, roots []maintenanceRoot
 		return states, nil
 	}
 	var (
-		descriptors       []vacuumCollectionRootDescriptor
+		descriptorAliases map[uint64][][]byte
 		descriptorsLoaded bool
 	)
 	for i, root := range roots {
@@ -2275,18 +2275,18 @@ func valueLogRewriteCollectionRootStates(snap *Snapshot, roots []maintenanceRoot
 			continue
 		}
 		if !descriptorsLoaded {
-			var err error
-			descriptors, err = vacuumCollectCollectionRootDescriptors(snap.idx.pager, &snap.reader, snap.state.SystemRootPageID)
+			descriptors, err := vacuumCollectCollectionRootDescriptors(snap.idx.pager, &snap.reader, snap.state.SystemRootPageID)
 			if err != nil {
 				return nil, fmt.Errorf("vlog-rewrite: collect collection root descriptors: %w", err)
 			}
+			descriptorAliases = valueLogRewriteCollectionRootDescriptorAliasMap(descriptors)
 			descriptorsLoaded = true
 		}
 		storagePolicy, err := valueLogRewriteCollectionRootStoragePolicy(snap.idx.pager, root.rootID)
 		if err != nil {
 			return nil, fmt.Errorf("vlog-rewrite: inspect collection root %q storage: %w", string(root.descriptorKey), err)
 		}
-		aliases := valueLogRewriteCollectionRootDescriptorAliases(descriptors, root.rootID)
+		aliases := cloneCollectionRootDescriptorAliases(descriptorAliases[root.rootID])
 		if len(aliases) == 0 && len(root.descriptorKey) > 0 {
 			aliases = append(aliases, append([]byte(nil), root.descriptorKey...))
 		}
@@ -2301,16 +2301,33 @@ func valueLogRewriteCollectionRootStates(snap *Snapshot, roots []maintenanceRoot
 	return states, nil
 }
 
-func valueLogRewriteCollectionRootDescriptorAliases(descriptors []vacuumCollectionRootDescriptor, rootID uint64) [][]byte {
-	if rootID == 0 {
+func valueLogRewriteCollectionRootDescriptorAliasMap(descriptors []vacuumCollectionRootDescriptor) map[uint64][][]byte {
+	if len(descriptors) == 0 {
 		return nil
 	}
-	var aliases [][]byte
+	aliasesByRoot := make(map[uint64][][]byte)
 	for _, descriptor := range descriptors {
-		if descriptor.rootID == rootID {
-			aliases = append(aliases, append([]byte(nil), descriptor.key...))
+		if descriptor.rootID != 0 {
+			aliasesByRoot[descriptor.rootID] = append(aliasesByRoot[descriptor.rootID], append([]byte(nil), descriptor.key...))
 		}
 	}
+	return aliasesByRoot
+}
+
+func cloneCollectionRootDescriptorAliases(aliases [][]byte) [][]byte {
+	if len(aliases) == 0 {
+		return nil
+	}
+	out := make([][]byte, 0, len(aliases))
+	for _, alias := range aliases {
+		out = append(out, append([]byte(nil), alias...))
+	}
+	return out
+}
+
+func valueLogRewriteCollectionRootDescriptorAliases(descriptors []vacuumCollectionRootDescriptor, rootID uint64) [][]byte {
+	aliasesByRoot := valueLogRewriteCollectionRootDescriptorAliasMap(descriptors)
+	aliases := cloneCollectionRootDescriptorAliases(aliasesByRoot[rootID])
 	return aliases
 }
 
@@ -2355,11 +2372,11 @@ func (db *DB) applyRewriteSwapBatchToSystemRoot(swaps []rewriteSwap, sync bool) 
 	}
 	idx := db.idx.Load()
 	if idx == nil {
-		return fmt.Errorf("missing index")
+		return fmt.Errorf("vlog-rewrite: collection root: missing index")
 	}
 	state := db.state.Load()
 	if state == nil {
-		return fmt.Errorf("missing backend state")
+		return fmt.Errorf("vlog-rewrite: collection root: missing backend state")
 	}
 
 	db.mu.RLock()
@@ -2424,7 +2441,7 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 
 	if target.systemRoot != systemRoot || target.rootID == 0 || len(target.descriptorAliases) == 0 {
 		reader := newValueReader(state.ValueLogSet)
-		collectionRoot, descriptorAliases, ok, err := lookupCollectionRootDescriptorAliases(idx.pager, reader, systemRoot, target.descriptorKey, target.descriptorAliases)
+		collectionRoot, descriptorAliases, ok, err := lookupCollectionRootDescriptorAliases(idx.pager, reader, systemRoot, target.descriptorKey, target.descriptorAliases, target.rootID)
 		if err != nil {
 			return err
 		}
@@ -2528,7 +2545,7 @@ func (db *DB) canTrackRewriteValueLogRefDelta(baseSeq uint64, outerLeavesInValue
 	return db != nil && db.valueLogRefTracker != nil && db.valueLogRefTracker.canTrack(baseSeq) && !outerLeavesInValueLog
 }
 
-func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReader, systemRootID uint64, key []byte, aliasKeys [][]byte) (uint64, [][]byte, bool, error) {
+func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReader, systemRootID uint64, key []byte, aliasKeys [][]byte, preferredRoot uint64) (uint64, [][]byte, bool, error) {
 	if p == nil {
 		return 0, nil, false, errors.New("vlog-rewrite: missing pager")
 	}
@@ -2539,7 +2556,7 @@ func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReade
 	if err != nil {
 		return 0, nil, false, err
 	}
-	var rootID uint64
+	var rootID, firstRoot uint64
 	for _, descriptor := range descriptors {
 		if !collectionRootDescriptorKeyMatches(descriptor.key, key, aliasKeys) {
 			continue
@@ -2547,10 +2564,19 @@ func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReade
 		if descriptor.rootID == 0 {
 			continue
 		}
-		if rootID != 0 && rootID != descriptor.rootID {
-			return 0, nil, false, fmt.Errorf("vlog-rewrite: collection descriptor aliases resolve to conflicting roots %d and %d", rootID, descriptor.rootID)
+		if firstRoot == 0 {
+			firstRoot = descriptor.rootID
 		}
-		rootID = descriptor.rootID
+		if preferredRoot != 0 && descriptor.rootID == preferredRoot {
+			rootID = preferredRoot
+			break
+		}
+		if rootID == 0 && bytes.Equal(descriptor.key, key) {
+			rootID = descriptor.rootID
+		}
+	}
+	if rootID == 0 {
+		rootID = firstRoot
 	}
 	if rootID == 0 {
 		return 0, nil, false, nil

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1854,20 +1854,24 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 
 	snap := db.AcquireSnapshot()
 	if snap == nil {
+		err = fmt.Errorf("missing snapshot")
 		closeRewriteSnapshot(&err, snap)
-		return stats, fmt.Errorf("missing snapshot")
+		return stats, err
 	}
 	if snap.state == nil {
+		err = fmt.Errorf("missing snapshot state")
 		closeRewriteSnapshot(&err, snap)
-		return stats, fmt.Errorf("missing snapshot state")
+		return stats, err
 	}
 	if snap.idx == nil {
+		err = fmt.Errorf("missing snapshot index")
 		closeRewriteSnapshot(&err, snap)
-		return stats, fmt.Errorf("missing snapshot index")
+		return stats, err
 	}
 	if snap.idx.pager == nil {
+		err = fmt.Errorf("missing snapshot pager")
 		closeRewriteSnapshot(&err, snap)
-		return stats, fmt.Errorf("missing snapshot pager")
+		return stats, err
 	}
 	roots, err := maintenanceRootsForSnapshot(snap)
 	if err != nil {
@@ -2463,8 +2467,7 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 		return nil
 	}
 
-	encodedRoot := make([]byte, 8)
-	binary.BigEndian.PutUint64(encodedRoot, newCollectionRoot)
+	encodedRoot := encodeCollectionRootDescriptorRootID(newCollectionRoot)
 	systemDelta := memtable.NewAppendOnlyWithEntryCapacity(len(target.descriptorAliases))
 	for _, aliasKey := range target.descriptorAliases {
 		systemDelta.Set(aliasKey, encodedRoot)

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2423,11 +2423,11 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 	}
 	idx := db.idx.Load()
 	if idx == nil {
-		return fmt.Errorf("missing index")
+		return fmt.Errorf("vlog-rewrite: collection root: missing index")
 	}
 	state := db.state.Load()
 	if state == nil {
-		return fmt.Errorf("missing backend state")
+		return fmt.Errorf("vlog-rewrite: collection root: missing backend state")
 	}
 
 	db.mu.RLock()
@@ -2446,6 +2446,9 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 			return err
 		}
 		if !ok {
+			if target.rootID != 0 {
+				return nil
+			}
 			return fmt.Errorf("vlog-rewrite: collection root descriptor %q not found", string(target.descriptorKey))
 		}
 		if collectionRoot == 0 {
@@ -2556,27 +2559,30 @@ func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReade
 	if err != nil {
 		return 0, nil, false, err
 	}
-	var rootID, firstRoot uint64
+	var rootID, firstMatchedRoot uint64
 	for _, descriptor := range descriptors {
+		if preferredRoot != 0 && descriptor.rootID == preferredRoot {
+			rootID = preferredRoot
+			break
+		}
 		if !collectionRootDescriptorKeyMatches(descriptor.key, key, aliasKeys) {
 			continue
 		}
 		if descriptor.rootID == 0 {
 			continue
 		}
-		if firstRoot == 0 {
-			firstRoot = descriptor.rootID
-		}
-		if preferredRoot != 0 && descriptor.rootID == preferredRoot {
-			rootID = preferredRoot
-			break
+		if firstMatchedRoot == 0 {
+			firstMatchedRoot = descriptor.rootID
 		}
 		if rootID == 0 && bytes.Equal(descriptor.key, key) {
 			rootID = descriptor.rootID
 		}
 	}
 	if rootID == 0 {
-		rootID = firstRoot
+		if preferredRoot != 0 {
+			return 0, nil, false, nil
+		}
+		rootID = firstMatchedRoot
 	}
 	if rootID == 0 {
 		return 0, nil, false, nil

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -18,11 +18,13 @@ import (
 
 	"github.com/snissn/compress/zstd"
 	"github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/internal/adaptive"
 	"github.com/snissn/gomap/TreeDB/internal/bulk"
 	"github.com/snissn/gomap/TreeDB/internal/compression"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/leafrefscan"
 	"github.com/snissn/gomap/TreeDB/internal/lockfile"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/outerleaf"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -1748,7 +1750,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	}
 	selectedSourceBytes := int64(0)
 
-	flushBatch := func() error {
+	flushBatch := func(root maintenanceRoot, storagePolicy OrderedRootStoragePolicy) error {
 		if len(candidates) == 0 {
 			return nil
 		}
@@ -1830,7 +1832,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			lastRegisteredCreatedID = id
 			hasLastRegisteredID = true
 		}
-		if err := db.applyRewriteSwapBatch(swaps, opts.SyncEachBatch); err != nil {
+		if err := db.applyRewriteSwapBatchToMaintenanceRoot(root, storagePolicy, swaps, opts.SyncEachBatch); err != nil {
 			return err
 		}
 		candidates = candidates[:0]
@@ -1843,90 +1845,127 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	}
 
 	snap := db.AcquireSnapshot()
-	if snap == nil || snap.state == nil {
+	if snap == nil || snap.state == nil || snap.idx == nil || snap.idx.pager == nil {
 		closeRewriteSnapshot(&err, snap)
 		return stats, fmt.Errorf("missing snapshot state")
 	}
-	it := snap.tree.IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
-	for ; it.Valid(); it.Next() {
-		if err := ctx.Err(); err != nil {
-			canceledErr = err
-			break
-		}
-		_, oldPtr, flags := it.UnsafeEntry()
-		if flags&node.FlagPointer == 0 || !page.IsValueLogFileID(oldPtr.FileID) {
+	roots, err := maintenanceRootsForSnapshot(snap)
+	if err != nil {
+		closeRewriteSnapshot(&err, snap)
+		return stats, err
+	}
+	rootPolicies := make([]OrderedRootStoragePolicy, len(roots))
+	for i, root := range roots {
+		if root.kind != maintenanceRootCollection || root.rootID == 0 {
 			continue
 		}
-		if restrictSource {
-			if restrictSingleID {
-				if oldPtr.FileID != singleSourceID {
-					continue
-				}
-			} else {
-				if _, ok := sourceIDs[oldPtr.FileID]; !ok {
-					continue
-				}
-			}
-			if sourceChunkSet != nil {
-				ok, chunkErr := rewriteSourceChunkSelected(oldPtr, sourceChunkSet, sourceChunkBytes)
-				if chunkErr != nil {
-					_ = it.Close()
-					closeRewriteSnapshot(&err, snap)
-					return stats, chunkErr
-				}
-				if !ok {
-					continue
-				}
-			}
+		useLeafLog, err := valueLogRewriteCollectionRootUsesLeafLog(snap.idx.pager, root.rootID)
+		if err != nil {
+			closeRewriteSnapshot(&err, snap)
+			return stats, fmt.Errorf("vlog-rewrite: inspect collection root %q storage: %w", string(root.descriptorKey), err)
 		}
-		unsafeKey := it.UnsafeKey()
-		sourceBytes := int64(0)
-		if maxCopiedBytes > 0 {
-			recordLen, err := db.valueLogRecordLengthForRewrite(oldPtr)
-			if err != nil {
-				_ = it.Close()
-				closeRewriteSnapshot(&err, snap)
-				return stats, err
+		if useLeafLog {
+			rootPolicies[i] = OrderedRootStorageValueLogLeaves
+		} else {
+			rootPolicies[i] = OrderedRootStoragePagerLeaves
+		}
+	}
+	stopScanning := false
+	scanRoot := func(root maintenanceRoot, storagePolicy OrderedRootStoragePolicy) error {
+		if root.rootID == 0 {
+			return nil
+		}
+		it := tree.New(snap.idx.pager, &snap.reader, root.rootID).
+			IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+		defer func() { _ = it.Close() }()
+		for ; it.Valid(); it.Next() {
+			if err := ctx.Err(); err != nil {
+				canceledErr = err
+				break
 			}
-			sourceBytes = int64(recordLen)
-			if selectedSourceBytes > 0 && selectedSourceBytes+sourceBytes > maxCopiedBytes {
+			_, oldPtr, flags := it.UnsafeEntry()
+			if flags&node.FlagPointer == 0 || !page.IsValueLogFileID(oldPtr.FileID) {
+				continue
+			}
+			if restrictSource {
+				if restrictSingleID {
+					if oldPtr.FileID != singleSourceID {
+						continue
+					}
+				} else {
+					if _, ok := sourceIDs[oldPtr.FileID]; !ok {
+						continue
+					}
+				}
+				if sourceChunkSet != nil {
+					ok, chunkErr := rewriteSourceChunkSelected(oldPtr, sourceChunkSet, sourceChunkBytes)
+					if chunkErr != nil {
+						return chunkErr
+					}
+					if !ok {
+						continue
+					}
+				}
+			}
+			unsafeKey := it.UnsafeKey()
+			sourceBytes := int64(0)
+			if maxCopiedBytes > 0 {
+				recordLen, err := db.valueLogRecordLengthForRewrite(oldPtr)
+				if err != nil {
+					return err
+				}
+				sourceBytes = int64(recordLen)
+				if selectedSourceBytes > 0 && selectedSourceBytes+sourceBytes > maxCopiedBytes {
+					stopScanning = true
+					break
+				}
+			}
+			keyStart := len(candidateKeyArena)
+			candidateKeyArena = append(candidateKeyArena, unsafeKey...)
+			key := candidateKeyArena[keyStart:len(candidateKeyArena):len(candidateKeyArena)]
+			candidates = append(candidates, rewriteCandidate{
+				key:         key,
+				oldPtr:      oldPtr,
+				sourceBytes: sourceBytes,
+			})
+			selectedSourceBytes += sourceBytes
+			if len(candidates) >= batchSize {
+				if err := flushBatch(root, storagePolicy); err != nil {
+					return err
+				}
+			}
+			if maxCopiedBytes > 0 && selectedSourceBytes >= maxCopiedBytes {
+				stopScanning = true
 				break
 			}
 		}
-		keyStart := len(candidateKeyArena)
-		candidateKeyArena = append(candidateKeyArena, unsafeKey...)
-		key := candidateKeyArena[keyStart:len(candidateKeyArena):len(candidateKeyArena)]
-		candidates = append(candidates, rewriteCandidate{
-			key:         key,
-			oldPtr:      oldPtr,
-			sourceBytes: sourceBytes,
-		})
-		selectedSourceBytes += sourceBytes
-		if len(candidates) >= batchSize {
-			if err := flushBatch(); err != nil {
-				_ = it.Close()
-				closeRewriteSnapshot(&err, snap)
-				return stats, err
-			}
+		if err := it.Error(); err != nil {
+			return err
 		}
-		if maxCopiedBytes > 0 && selectedSourceBytes >= maxCopiedBytes {
+		if canceledErr == nil {
+			if err := flushBatch(root, storagePolicy); err != nil {
+				return err
+			}
+		} else {
+			// Stop publishing further swaps after cancellation; cleanup below still
+			// reconciles already-committed rewrite batches and rewrite-created files.
+			swaps = swaps[:0]
+			candidates = candidates[:0]
+		}
+		return nil
+	}
+	for i, root := range roots {
+		if stopScanning || canceledErr != nil {
 			break
 		}
-	}
-	iterErr := it.Error()
-	_ = it.Close()
-	closeRewriteSnapshot(&err, snap)
-	if iterErr != nil {
-		return stats, iterErr
-	}
-	if canceledErr == nil {
-		if err := flushBatch(); err != nil {
+		if err := scanRoot(root, rootPolicies[i]); err != nil {
+			closeRewriteSnapshot(&err, snap)
 			return stats, err
 		}
-	} else {
-		// Stop publishing further swaps after cancellation; cleanup below still
-		// reconciles already-committed rewrite batches and rewrite-created files.
-		swaps = swaps[:0]
+	}
+	closeRewriteSnapshot(&err, snap)
+	if err != nil {
+		return stats, err
 	}
 	if err := writer.Sync(); err != nil {
 		return stats, err
@@ -2223,6 +2262,183 @@ func (db *DB) applyRewriteSwapBatch(swaps []rewriteSwap, sync bool) error {
 		}
 	}
 	return db.applyRewriteSwapBatchSerialized(swaps, sync)
+}
+
+func (db *DB) applyRewriteSwapBatchToMaintenanceRoot(root maintenanceRoot, storagePolicy OrderedRootStoragePolicy, swaps []rewriteSwap, sync bool) error {
+	switch root.kind {
+	case maintenanceRootUser:
+		return db.applyRewriteSwapBatch(swaps, sync)
+	case maintenanceRootSystem:
+		return db.applyRewriteSwapBatchToSystemRoot(swaps, sync)
+	case maintenanceRootCollection:
+		return db.applyRewriteSwapBatchToCollectionRoot(root.descriptorKey, storagePolicy, swaps, sync)
+	default:
+		return fmt.Errorf("vlog-rewrite: unknown maintenance root kind %d", root.kind)
+	}
+}
+
+func (db *DB) applyRewriteSwapBatchToSystemRoot(swaps []rewriteSwap, sync bool) error {
+	if len(swaps) == 0 {
+		return nil
+	}
+	db.writeMu.Lock()
+	defer db.writeMu.Unlock()
+
+	if db.readOnly {
+		return ErrReadOnly
+	}
+	idx := db.idx.Load()
+	if idx == nil {
+		return fmt.Errorf("missing index")
+	}
+	state := db.state.Load()
+	if state == nil {
+		return fmt.Errorf("missing backend state")
+	}
+
+	db.mu.RLock()
+	userRoot := db.meta.UserRootPageID
+	systemRoot := db.meta.SystemRootPageID
+	db.mu.RUnlock()
+	if systemRoot == 0 {
+		return nil
+	}
+
+	systemOpts := systemRootOrderedPublishOptions(db)
+	newSystemRoot, retired, metrics, touched, changed, err := db.applyRewriteSwapsToRootLocked(idx, state, systemRoot, systemOpts, swaps)
+	if err != nil || !changed {
+		return err
+	}
+	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, sync, metrics, touched, systemOpts.outerLeavesInValueLog, nil, nil, nil); err != nil {
+		return err
+	}
+	db.clearLeafGenerationReachabilityCaches()
+	return nil
+}
+
+func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, storagePolicy OrderedRootStoragePolicy, swaps []rewriteSwap, sync bool) error {
+	if len(swaps) == 0 {
+		return nil
+	}
+	if len(descriptorKey) == 0 {
+		return errors.New("vlog-rewrite: missing collection root descriptor key")
+	}
+
+	db.writeMu.Lock()
+	defer db.writeMu.Unlock()
+
+	if db.readOnly {
+		return ErrReadOnly
+	}
+	idx := db.idx.Load()
+	if idx == nil {
+		return fmt.Errorf("missing index")
+	}
+	state := db.state.Load()
+	if state == nil {
+		return fmt.Errorf("missing backend state")
+	}
+
+	db.mu.RLock()
+	userRoot := db.meta.UserRootPageID
+	systemRoot := db.meta.SystemRootPageID
+	db.mu.RUnlock()
+	if systemRoot == 0 {
+		return nil
+	}
+
+	reader := newValueReader(state.ValueLogSet)
+	collectionRoot, ok, err := lookupCollectionRootDescriptorID(idx.pager, reader, systemRoot, descriptorKey)
+	if err != nil || !ok || collectionRoot == 0 {
+		return err
+	}
+	rootOpts, err := db.orderedRootPublishOptionsForPolicy(storagePolicy)
+	if err != nil {
+		return err
+	}
+	newCollectionRoot, retired, metrics, touched, changed, err := db.applyRewriteSwapsToRootLocked(idx, state, collectionRoot, rootOpts, swaps)
+	if err != nil || !changed {
+		return err
+	}
+	if newCollectionRoot == collectionRoot {
+		if err := db.finalizeCommit(userRoot, systemRoot, retired, sync, metrics, touched, rootOpts.outerLeavesInValueLog, nil, nil, nil); err != nil {
+			return err
+		}
+		db.clearLeafGenerationReachabilityCaches()
+		return nil
+	}
+
+	encodedRoot := make([]byte, 8)
+	binary.BigEndian.PutUint64(encodedRoot, newCollectionRoot)
+	systemDelta := memtable.NewAppendOnlyWithEntryCapacity(1)
+	systemDelta.Set(descriptorKey, encodedRoot)
+	systemDelta.Freeze()
+	systemIter := systemDelta.NewIterator(nil, nil)
+	systemOpts := systemRootOrderedPublishOptions(db)
+	newSystemRoot, systemRetired, systemMetrics, err := db.publishOrderedRootDeltaIterator(systemRoot, systemIter, systemOpts)
+	if err != nil {
+		return err
+	}
+	retired = append(retired, systemRetired...)
+	mergeOrderedRootPublishMetrics(&metrics, systemMetrics)
+	forceValueLogRefresh := rootOpts.outerLeavesInValueLog || systemOpts.outerLeavesInValueLog
+	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, sync, metrics, touched, forceValueLogRefresh, nil, nil, nil); err != nil {
+		return err
+	}
+	db.clearLeafGenerationReachabilityCaches()
+	return nil
+}
+
+func (db *DB) applyRewriteSwapsToRootLocked(idx *indexGen, state *DBState, rootID uint64, opts orderedRootPublishOptions, swaps []rewriteSwap) (uint64, []uint64, adaptive.Metrics, []uint32, bool, error) {
+	var metrics adaptive.Metrics
+	if len(swaps) == 0 || rootID == 0 {
+		return rootID, nil, metrics, nil, false, nil
+	}
+	tr := tree.New(idx.pager, newValueReader(state.ValueLogSet), rootID)
+	b := batch.Acquire(db.valueLogManager, db.InlineThreshold())
+	defer batch.Release(b)
+	b.Reserve(len(swaps))
+	if _, err := collectRewriteSwapPointerMatches(tr, b, swaps, false); err != nil {
+		return rootID, nil, metrics, nil, false, err
+	}
+	if len(b.SortedEntries()) == 0 {
+		return rootID, nil, metrics, nil, false, nil
+	}
+	noteRewriteSwapTouchedSegments(b, swaps)
+	touched := append([]uint32(nil), b.TouchedValueLogSegments()...)
+	rootZipper, err := db.orderedRootZipperForOptions(idx, opts)
+	if err != nil {
+		return rootID, nil, metrics, nil, false, err
+	}
+	newRoot, retired, metrics, err := rootZipper.Apply(rootID, b)
+	if err != nil {
+		return rootID, nil, metrics, nil, false, err
+	}
+	return newRoot, retired, metrics, touched, true, nil
+}
+
+func lookupCollectionRootDescriptorID(p *pager.Pager, reader tree.SlabReader, systemRootID uint64, key []byte) (uint64, bool, error) {
+	if p == nil {
+		return 0, false, errors.New("vlog-rewrite: missing pager")
+	}
+	if systemRootID == 0 || len(key) == 0 {
+		return 0, false, nil
+	}
+	entry, err := tree.New(p, reader, systemRootID).GetEntry(key)
+	if err != nil {
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	val, _, err := vacuumCollectionRootDescriptorValue(reader, key, entry.Value, entry.ValuePtr, entry.Flags, nil)
+	if err != nil {
+		return 0, false, err
+	}
+	if len(val) != 8 {
+		return 0, false, fmt.Errorf("vlog-rewrite: collection root descriptor %q has malformed root id length %d", string(key), len(val))
+	}
+	return binary.BigEndian.Uint64(val), true, nil
 }
 
 func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (bool, error) {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2420,7 +2420,7 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 
 	if target.systemRoot != systemRoot || target.rootID == 0 || len(target.descriptorAliases) == 0 {
 		reader := newValueReader(state.ValueLogSet)
-		collectionRoot, descriptorAliases, ok, err := lookupCollectionRootDescriptorAliases(idx.pager, reader, systemRoot, target.descriptorKey)
+		collectionRoot, descriptorAliases, ok, err := lookupCollectionRootDescriptorAliases(idx.pager, reader, systemRoot, target.descriptorKey, target.descriptorAliases)
 		if err != nil {
 			return err
 		}
@@ -2525,11 +2525,11 @@ func (db *DB) canTrackRewriteValueLogRefDelta(baseSeq uint64, outerLeavesInValue
 	return db != nil && db.valueLogRefTracker != nil && db.valueLogRefTracker.canTrack(baseSeq) && !outerLeavesInValueLog
 }
 
-func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReader, systemRootID uint64, key []byte) (uint64, [][]byte, bool, error) {
+func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReader, systemRootID uint64, key []byte, aliasKeys [][]byte) (uint64, [][]byte, bool, error) {
 	if p == nil {
 		return 0, nil, false, errors.New("vlog-rewrite: missing pager")
 	}
-	if systemRootID == 0 || len(key) == 0 {
+	if systemRootID == 0 || (len(key) == 0 && len(aliasKeys) == 0) {
 		return 0, nil, false, nil
 	}
 	descriptors, err := vacuumCollectCollectionRootDescriptors(p, reader, systemRootID)
@@ -2538,10 +2538,16 @@ func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReade
 	}
 	var rootID uint64
 	for _, descriptor := range descriptors {
-		if bytes.Equal(descriptor.key, key) {
-			rootID = descriptor.rootID
-			break
+		if !collectionRootDescriptorKeyMatches(descriptor.key, key, aliasKeys) {
+			continue
 		}
+		if descriptor.rootID == 0 {
+			continue
+		}
+		if rootID != 0 && rootID != descriptor.rootID {
+			return 0, nil, false, fmt.Errorf("vlog-rewrite: collection descriptor aliases resolve to conflicting roots %d and %d", rootID, descriptor.rootID)
+		}
+		rootID = descriptor.rootID
 	}
 	if rootID == 0 {
 		return 0, nil, false, nil
@@ -2553,6 +2559,18 @@ func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReade
 		}
 	}
 	return rootID, aliases, true, nil
+}
+
+func collectionRootDescriptorKeyMatches(got, primary []byte, aliases [][]byte) bool {
+	if len(primary) > 0 && bytes.Equal(got, primary) {
+		return true
+	}
+	for _, alias := range aliases {
+		if bytes.Equal(got, alias) {
+			return true
+		}
+	}
+	return false
 }
 
 func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (bool, error) {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2299,19 +2299,27 @@ func (db *DB) applyRewriteSwapBatchToSystemRoot(swaps []rewriteSwap, sync bool) 
 	db.mu.RLock()
 	userRoot := db.meta.UserRootPageID
 	systemRoot := db.meta.SystemRootPageID
+	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 	if systemRoot == 0 {
 		return nil
 	}
 
 	systemOpts := systemRootOrderedPublishOptions(db)
-	newSystemRoot, retired, metrics, touched, changed, err := db.applyRewriteSwapsToRootLocked(idx, state, systemRoot, systemOpts, swaps)
+	trackValueLogRefDelta := db.canTrackRewriteValueLogRefDelta(baseSeq, systemOpts.outerLeavesInValueLog)
+	newSystemRoot, retired, metrics, touched, vlogRefDelta, changed, err := db.applyRewriteSwapsToRootLocked(idx, state, systemRoot, systemOpts, swaps, trackValueLogRefDelta)
 	if err != nil || !changed {
 		return err
 	}
-	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, sync, metrics, touched, systemOpts.outerLeavesInValueLog, nil, nil, nil); err != nil {
+	defer func() {
+		if vlogRefDelta != nil {
+			releaseValueLogRefDelta(vlogRefDelta)
+		}
+	}()
+	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, sync, metrics, touched, systemOpts.outerLeavesInValueLog, vlogRefDelta, nil, nil); err != nil {
 		return err
 	}
+	vlogRefDelta = nil
 	db.clearLeafGenerationReachabilityCaches()
 	return nil
 }
@@ -2342,6 +2350,7 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, storag
 	db.mu.RLock()
 	userRoot := db.meta.UserRootPageID
 	systemRoot := db.meta.SystemRootPageID
+	baseSeq := db.meta.CommitSeq
 	db.mu.RUnlock()
 	if systemRoot == 0 {
 		return nil
@@ -2356,14 +2365,21 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, storag
 	if err != nil {
 		return err
 	}
-	newCollectionRoot, retired, metrics, touched, changed, err := db.applyRewriteSwapsToRootLocked(idx, state, collectionRoot, rootOpts, swaps)
+	trackValueLogRefDelta := db.canTrackRewriteValueLogRefDelta(baseSeq, rootOpts.outerLeavesInValueLog)
+	newCollectionRoot, retired, metrics, touched, vlogRefDelta, changed, err := db.applyRewriteSwapsToRootLocked(idx, state, collectionRoot, rootOpts, swaps, trackValueLogRefDelta)
 	if err != nil || !changed {
 		return err
 	}
+	defer func() {
+		if vlogRefDelta != nil {
+			releaseValueLogRefDelta(vlogRefDelta)
+		}
+	}()
 	if newCollectionRoot == collectionRoot {
-		if err := db.finalizeCommit(userRoot, systemRoot, retired, sync, metrics, touched, rootOpts.outerLeavesInValueLog, nil, nil, nil); err != nil {
+		if err := db.finalizeCommit(userRoot, systemRoot, retired, sync, metrics, touched, rootOpts.outerLeavesInValueLog, vlogRefDelta, nil, nil); err != nil {
 			return err
 		}
+		vlogRefDelta = nil
 		db.clearLeafGenerationReachabilityCaches()
 		return nil
 	}
@@ -2384,39 +2400,48 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, storag
 	retired = append(retired, systemRetired...)
 	mergeOrderedRootPublishMetrics(&metrics, systemMetrics)
 	forceValueLogRefresh := rootOpts.outerLeavesInValueLog || systemOpts.outerLeavesInValueLog
-	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, sync, metrics, touched, forceValueLogRefresh, nil, nil, nil); err != nil {
+	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, sync, metrics, touched, forceValueLogRefresh, vlogRefDelta, nil, nil); err != nil {
 		return err
 	}
+	vlogRefDelta = nil
 	db.clearLeafGenerationReachabilityCaches()
 	return nil
 }
 
-func (db *DB) applyRewriteSwapsToRootLocked(idx *indexGen, state *DBState, rootID uint64, opts orderedRootPublishOptions, swaps []rewriteSwap) (uint64, []uint64, adaptive.Metrics, []uint32, bool, error) {
+func (db *DB) applyRewriteSwapsToRootLocked(idx *indexGen, state *DBState, rootID uint64, opts orderedRootPublishOptions, swaps []rewriteSwap, trackValueLogRefDelta bool) (uint64, []uint64, adaptive.Metrics, []uint32, *valueLogRefDelta, bool, error) {
 	var metrics adaptive.Metrics
 	if len(swaps) == 0 || rootID == 0 {
-		return rootID, nil, metrics, nil, false, nil
+		return rootID, nil, metrics, nil, nil, false, nil
 	}
 	tr := tree.New(idx.pager, newValueReader(state.ValueLogSet), rootID)
 	b := batch.Acquire(db.valueLogManager, db.InlineThreshold())
 	defer batch.Release(b)
 	b.Reserve(len(swaps))
-	if _, err := collectRewriteSwapPointerMatches(tr, b, swaps, false); err != nil {
-		return rootID, nil, metrics, nil, false, err
+	vlogRefDelta, err := collectRewriteSwapPointerMatches(tr, b, swaps, trackValueLogRefDelta)
+	if err != nil {
+		return rootID, nil, metrics, nil, nil, false, err
 	}
 	if len(b.SortedEntries()) == 0 {
-		return rootID, nil, metrics, nil, false, nil
+		releaseValueLogRefDelta(vlogRefDelta)
+		return rootID, nil, metrics, nil, nil, false, nil
 	}
 	noteRewriteSwapTouchedSegments(b, swaps)
 	touched := append([]uint32(nil), b.TouchedValueLogSegments()...)
 	rootZipper, err := db.orderedRootZipperForOptions(idx, opts)
 	if err != nil {
-		return rootID, nil, metrics, nil, false, err
+		releaseValueLogRefDelta(vlogRefDelta)
+		return rootID, nil, metrics, nil, nil, false, err
 	}
 	newRoot, retired, metrics, err := rootZipper.Apply(rootID, b)
 	if err != nil {
-		return rootID, nil, metrics, nil, false, err
+		releaseValueLogRefDelta(vlogRefDelta)
+		return rootID, nil, metrics, nil, nil, false, err
 	}
-	return newRoot, retired, metrics, touched, true, nil
+	return newRoot, retired, metrics, touched, vlogRefDelta, true, nil
+}
+
+func (db *DB) canTrackRewriteValueLogRefDelta(baseSeq uint64, outerLeavesInValueLog bool) bool {
+	return db != nil && db.valueLogRefTracker != nil && db.valueLogRefTracker.canTrack(baseSeq) && !outerLeavesInValueLog
 }
 
 func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReader, systemRootID uint64, key []byte) (uint64, [][]byte, bool, error) {
@@ -2479,7 +2504,7 @@ func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (b
 	defer batch.Release(b)
 	b.Reserve(len(swaps))
 
-	trackValueLogRefDelta := db.valueLogRefTracker != nil && db.valueLogRefTracker.canTrack(baseSeq) && !db.indexOuterLeavesInValueLog
+	trackValueLogRefDelta := db.canTrackRewriteValueLogRefDelta(baseSeq, db.indexOuterLeavesInValueLog)
 	rewriteDelta, err := collectRewriteSwapPointerMatches(tr, b, swaps, trackValueLogRefDelta)
 	if err != nil {
 		return false, err
@@ -2571,7 +2596,7 @@ func (db *DB) applyRewriteSwapBatchSerialized(swaps []rewriteSwap, sync bool) er
 	defer batch.Release(b)
 	b.Reserve(len(swaps))
 
-	trackValueLogRefDelta := db.valueLogRefTracker != nil && db.valueLogRefTracker.canTrack(baseSeq) && !db.indexOuterLeavesInValueLog
+	trackValueLogRefDelta := db.canTrackRewriteValueLogRefDelta(baseSeq, db.indexOuterLeavesInValueLog)
 	rewriteDelta, err := collectRewriteSwapPointerMatches(tr, b, swaps, trackValueLogRefDelta)
 	if err != nil {
 		return err

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -223,6 +223,14 @@ type rewriteCandidate struct {
 	sourceBytes int64
 }
 
+type collectionRewriteRootState struct {
+	descriptorKey     []byte
+	descriptorAliases [][]byte
+	rootID            uint64
+	systemRoot        uint64
+	storagePolicy     OrderedRootStoragePolicy
+}
+
 type rewriteSourceSelectionStats struct {
 	ageBlockedSegments        int
 	ageBlockedBytesTotal      int64
@@ -1750,7 +1758,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	}
 	selectedSourceBytes := int64(0)
 
-	flushBatch := func(root maintenanceRoot, storagePolicy OrderedRootStoragePolicy) error {
+	flushBatch := func(root maintenanceRoot, collectionState *collectionRewriteRootState) error {
 		if len(candidates) == 0 {
 			return nil
 		}
@@ -1832,7 +1840,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			lastRegisteredCreatedID = id
 			hasLastRegisteredID = true
 		}
-		if err := db.applyRewriteSwapBatchToMaintenanceRoot(root, storagePolicy, swaps, opts.SyncEachBatch); err != nil {
+		if err := db.applyRewriteSwapBatchToMaintenanceRoot(root, collectionState, swaps, opts.SyncEachBatch); err != nil {
 			return err
 		}
 		candidates = candidates[:0]
@@ -1866,20 +1874,13 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		closeRewriteSnapshot(&err, snap)
 		return stats, err
 	}
-	rootPolicies := make([]OrderedRootStoragePolicy, len(roots))
-	for i, root := range roots {
-		if root.kind != maintenanceRootCollection || root.rootID == 0 {
-			continue
-		}
-		storagePolicy, err := valueLogRewriteCollectionRootStoragePolicy(snap.idx.pager, root.rootID)
-		if err != nil {
-			closeRewriteSnapshot(&err, snap)
-			return stats, fmt.Errorf("vlog-rewrite: inspect collection root %q storage: %w", string(root.descriptorKey), err)
-		}
-		rootPolicies[i] = storagePolicy
+	collectionStates, err := valueLogRewriteCollectionRootStates(snap, roots)
+	if err != nil {
+		closeRewriteSnapshot(&err, snap)
+		return stats, err
 	}
 	stopScanning := false
-	scanRoot := func(root maintenanceRoot, storagePolicy OrderedRootStoragePolicy) error {
+	scanRoot := func(root maintenanceRoot, collectionState *collectionRewriteRootState) error {
 		if root.rootID == 0 {
 			return nil
 		}
@@ -1938,7 +1939,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			})
 			selectedSourceBytes += sourceBytes
 			if len(candidates) >= batchSize {
-				if err := flushBatch(root, storagePolicy); err != nil {
+				if err := flushBatch(root, collectionState); err != nil {
 					return err
 				}
 			}
@@ -1951,7 +1952,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			return err
 		}
 		if canceledErr == nil {
-			if err := flushBatch(root, storagePolicy); err != nil {
+			if err := flushBatch(root, collectionState); err != nil {
 				return err
 			}
 		} else {
@@ -1966,7 +1967,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		if stopScanning || canceledErr != nil {
 			break
 		}
-		if err := scanRoot(root, rootPolicies[i]); err != nil {
+		if err := scanRoot(root, collectionStates[i]); err != nil {
 			closeRewriteSnapshot(&err, snap)
 			return stats, err
 		}
@@ -2256,6 +2257,59 @@ func scanValueLogFileMaxRID(seg *valuelog.File) (uint64, error) {
 	return maxRID, nil
 }
 
+func valueLogRewriteCollectionRootStates(snap *Snapshot, roots []maintenanceRoot) ([]*collectionRewriteRootState, error) {
+	states := make([]*collectionRewriteRootState, len(roots))
+	if snap == nil || snap.state == nil || snap.idx == nil || snap.idx.pager == nil {
+		return states, nil
+	}
+	var (
+		descriptors       []vacuumCollectionRootDescriptor
+		descriptorsLoaded bool
+	)
+	for i, root := range roots {
+		if root.kind != maintenanceRootCollection || root.rootID == 0 {
+			continue
+		}
+		if !descriptorsLoaded {
+			var err error
+			descriptors, err = vacuumCollectCollectionRootDescriptors(snap.idx.pager, &snap.reader, snap.state.SystemRootPageID)
+			if err != nil {
+				return nil, fmt.Errorf("vlog-rewrite: collect collection root descriptors: %w", err)
+			}
+			descriptorsLoaded = true
+		}
+		storagePolicy, err := valueLogRewriteCollectionRootStoragePolicy(snap.idx.pager, root.rootID)
+		if err != nil {
+			return nil, fmt.Errorf("vlog-rewrite: inspect collection root %q storage: %w", string(root.descriptorKey), err)
+		}
+		aliases := valueLogRewriteCollectionRootDescriptorAliases(descriptors, root.rootID)
+		if len(aliases) == 0 && len(root.descriptorKey) > 0 {
+			aliases = append(aliases, append([]byte(nil), root.descriptorKey...))
+		}
+		states[i] = &collectionRewriteRootState{
+			descriptorKey:     append([]byte(nil), root.descriptorKey...),
+			descriptorAliases: aliases,
+			rootID:            root.rootID,
+			systemRoot:        snap.state.SystemRootPageID,
+			storagePolicy:     storagePolicy,
+		}
+	}
+	return states, nil
+}
+
+func valueLogRewriteCollectionRootDescriptorAliases(descriptors []vacuumCollectionRootDescriptor, rootID uint64) [][]byte {
+	if rootID == 0 {
+		return nil
+	}
+	var aliases [][]byte
+	for _, descriptor := range descriptors {
+		if descriptor.rootID == rootID {
+			aliases = append(aliases, append([]byte(nil), descriptor.key...))
+		}
+	}
+	return aliases
+}
+
 func (db *DB) applyRewriteSwapBatch(swaps []rewriteSwap, sync bool) error {
 	if len(swaps) == 0 {
 		return nil
@@ -2272,14 +2326,14 @@ func (db *DB) applyRewriteSwapBatch(swaps []rewriteSwap, sync bool) error {
 	return db.applyRewriteSwapBatchSerialized(swaps, sync)
 }
 
-func (db *DB) applyRewriteSwapBatchToMaintenanceRoot(root maintenanceRoot, storagePolicy OrderedRootStoragePolicy, swaps []rewriteSwap, sync bool) error {
+func (db *DB) applyRewriteSwapBatchToMaintenanceRoot(root maintenanceRoot, collectionState *collectionRewriteRootState, swaps []rewriteSwap, sync bool) error {
 	switch root.kind {
 	case maintenanceRootUser:
 		return db.applyRewriteSwapBatch(swaps, sync)
 	case maintenanceRootSystem:
 		return db.applyRewriteSwapBatchToSystemRoot(swaps, sync)
 	case maintenanceRootCollection:
-		return db.applyRewriteSwapBatchToCollectionRoot(root.descriptorKey, storagePolicy, swaps, sync)
+		return db.applyRewriteSwapBatchToCollectionRoot(collectionState, swaps, sync)
 	default:
 		return fmt.Errorf("vlog-rewrite: unknown maintenance root kind %d", root.kind)
 	}
@@ -2332,11 +2386,11 @@ func (db *DB) applyRewriteSwapBatchToSystemRoot(swaps []rewriteSwap, sync bool) 
 	return nil
 }
 
-func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, _ OrderedRootStoragePolicy, swaps []rewriteSwap, sync bool) error {
+func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRootState, swaps []rewriteSwap, sync bool) error {
 	if len(swaps) == 0 {
 		return nil
 	}
-	if len(descriptorKey) == 0 {
+	if target == nil || len(target.descriptorKey) == 0 {
 		return errors.New("vlog-rewrite: missing collection root descriptor key")
 	}
 
@@ -2364,16 +2418,23 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, _ Orde
 		return nil
 	}
 
-	reader := newValueReader(state.ValueLogSet)
-	collectionRoot, descriptorAliases, ok, err := lookupCollectionRootDescriptorAliases(idx.pager, reader, systemRoot, descriptorKey)
-	if err != nil || !ok || collectionRoot == 0 {
-		return err
+	if target.systemRoot != systemRoot || target.rootID == 0 || len(target.descriptorAliases) == 0 {
+		reader := newValueReader(state.ValueLogSet)
+		collectionRoot, descriptorAliases, ok, err := lookupCollectionRootDescriptorAliases(idx.pager, reader, systemRoot, target.descriptorKey)
+		if err != nil || !ok || collectionRoot == 0 {
+			return err
+		}
+		currentStoragePolicy, err := valueLogRewriteCollectionRootStoragePolicy(idx.pager, collectionRoot)
+		if err != nil {
+			return fmt.Errorf("vlog-rewrite: inspect current collection root %q storage: %w", string(target.descriptorKey), err)
+		}
+		target.rootID = collectionRoot
+		target.descriptorAliases = descriptorAliases
+		target.systemRoot = systemRoot
+		target.storagePolicy = currentStoragePolicy
 	}
-	currentStoragePolicy, err := valueLogRewriteCollectionRootStoragePolicy(idx.pager, collectionRoot)
-	if err != nil {
-		return fmt.Errorf("vlog-rewrite: inspect current collection root %q storage: %w", string(descriptorKey), err)
-	}
-	rootOpts, err := db.orderedRootPublishOptionsForPolicy(currentStoragePolicy)
+	collectionRoot := target.rootID
+	rootOpts, err := db.orderedRootPublishOptionsForPolicy(target.storagePolicy)
 	if err != nil {
 		return err
 	}
@@ -2398,8 +2459,8 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, _ Orde
 
 	encodedRoot := make([]byte, 8)
 	binary.BigEndian.PutUint64(encodedRoot, newCollectionRoot)
-	systemDelta := memtable.NewAppendOnlyWithEntryCapacity(len(descriptorAliases))
-	for _, aliasKey := range descriptorAliases {
+	systemDelta := memtable.NewAppendOnlyWithEntryCapacity(len(target.descriptorAliases))
+	for _, aliasKey := range target.descriptorAliases {
 		systemDelta.Set(aliasKey, encodedRoot)
 	}
 	systemDelta.Freeze()
@@ -2416,6 +2477,8 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, _ Orde
 		return err
 	}
 	vlogRefDelta = nil
+	target.rootID = newCollectionRoot
+	target.systemRoot = newSystemRoot
 	db.clearLeafGenerationReachabilityCaches()
 	return nil
 }

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2421,8 +2421,14 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 	if target.systemRoot != systemRoot || target.rootID == 0 || len(target.descriptorAliases) == 0 {
 		reader := newValueReader(state.ValueLogSet)
 		collectionRoot, descriptorAliases, ok, err := lookupCollectionRootDescriptorAliases(idx.pager, reader, systemRoot, target.descriptorKey)
-		if err != nil || !ok || collectionRoot == 0 {
+		if err != nil {
 			return err
+		}
+		if !ok {
+			return fmt.Errorf("vlog-rewrite: collection root descriptor %q not found", string(target.descriptorKey))
+		}
+		if collectionRoot == 0 {
+			return fmt.Errorf("vlog-rewrite: collection root descriptor %q has empty root", string(target.descriptorKey))
 		}
 		target.rootID = collectionRoot
 		target.descriptorAliases = descriptorAliases

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2348,7 +2348,7 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, storag
 	}
 
 	reader := newValueReader(state.ValueLogSet)
-	collectionRoot, ok, err := lookupCollectionRootDescriptorID(idx.pager, reader, systemRoot, descriptorKey)
+	collectionRoot, descriptorAliases, ok, err := lookupCollectionRootDescriptorAliases(idx.pager, reader, systemRoot, descriptorKey)
 	if err != nil || !ok || collectionRoot == 0 {
 		return err
 	}
@@ -2370,8 +2370,10 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(descriptorKey []byte, storag
 
 	encodedRoot := make([]byte, 8)
 	binary.BigEndian.PutUint64(encodedRoot, newCollectionRoot)
-	systemDelta := memtable.NewAppendOnlyWithEntryCapacity(1)
-	systemDelta.Set(descriptorKey, encodedRoot)
+	systemDelta := memtable.NewAppendOnlyWithEntryCapacity(len(descriptorAliases))
+	for _, aliasKey := range descriptorAliases {
+		systemDelta.Set(aliasKey, encodedRoot)
+	}
 	systemDelta.Freeze()
 	systemIter := systemDelta.NewIterator(nil, nil)
 	systemOpts := systemRootOrderedPublishOptions(db)
@@ -2417,28 +2419,34 @@ func (db *DB) applyRewriteSwapsToRootLocked(idx *indexGen, state *DBState, rootI
 	return newRoot, retired, metrics, touched, true, nil
 }
 
-func lookupCollectionRootDescriptorID(p *pager.Pager, reader tree.SlabReader, systemRootID uint64, key []byte) (uint64, bool, error) {
+func lookupCollectionRootDescriptorAliases(p *pager.Pager, reader tree.SlabReader, systemRootID uint64, key []byte) (uint64, [][]byte, bool, error) {
 	if p == nil {
-		return 0, false, errors.New("vlog-rewrite: missing pager")
+		return 0, nil, false, errors.New("vlog-rewrite: missing pager")
 	}
 	if systemRootID == 0 || len(key) == 0 {
-		return 0, false, nil
+		return 0, nil, false, nil
 	}
-	entry, err := tree.New(p, reader, systemRootID).GetEntry(key)
+	descriptors, err := vacuumCollectCollectionRootDescriptors(p, reader, systemRootID)
 	if err != nil {
-		if errors.Is(err, tree.ErrKeyNotFound) {
-			return 0, false, nil
+		return 0, nil, false, err
+	}
+	var rootID uint64
+	for _, descriptor := range descriptors {
+		if bytes.Equal(descriptor.key, key) {
+			rootID = descriptor.rootID
+			break
 		}
-		return 0, false, err
 	}
-	val, _, err := vacuumCollectionRootDescriptorValue(reader, key, entry.Value, entry.ValuePtr, entry.Flags, nil)
-	if err != nil {
-		return 0, false, err
+	if rootID == 0 {
+		return 0, nil, false, nil
 	}
-	if len(val) != 8 {
-		return 0, false, fmt.Errorf("vlog-rewrite: collection root descriptor %q has malformed root id length %d", string(key), len(val))
+	aliases := make([][]byte, 0, 1)
+	for _, descriptor := range descriptors {
+		if descriptor.rootID == rootID {
+			aliases = append(aliases, descriptor.key)
+		}
 	}
-	return binary.BigEndian.Uint64(val), true, nil
+	return rootID, aliases, true, nil
 }
 
 func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (bool, error) {

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -568,6 +568,78 @@ func TestValueLogRewriteOnline_RewritesCollectionRootPointers(t *testing.T) {
 	}
 }
 
+func TestValueLogRewriteOnline_RepointsAliasedCollectionRootDescriptors(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	ptr := appendPointersInNewSegment(t, dir, 0, 1, 515_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("collection-online-alias-pointer-live|"), 24)
+	})[0]
+	aliasDescriptorKey := "collections/root/users/alias"
+	_, rootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemPointerMemtable(t, "doc/p", ptr).NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStoragePagerLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			return nil, fmt.Errorf("rootIDs=%d want 1", len(rootIDs))
+		}
+		return mustFrozenRawMemtable(t,
+			maintenanceTestCollectionRootKey, encodeMaintenanceRootID(rootIDs[0]),
+			aliasDescriptorKey, encodeMaintenanceRootID(rootIDs[0]),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish aliased collection root: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs=%d want 1", len(rootIDs))
+	}
+	oldRoot := rootIDs[0]
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs: []uint32{ptr.FileID},
+		BatchSize:     1,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if stats.RecordsCopied != 1 {
+		t.Fatalf("expected one collection pointer record to be copied, stats=%+v", stats)
+	}
+	if stats.SourceSegmentsUnreferenced != 1 {
+		t.Fatalf("source segments unreferenced=%d want 1 (stats=%+v)", stats.SourceSegmentsUnreferenced, stats)
+	}
+
+	newRoot := readCollectionRootID(t, db, maintenanceTestCollectionRootKey)
+	aliasRoot := readCollectionRootID(t, db, aliasDescriptorKey)
+	if newRoot == oldRoot {
+		t.Fatalf("primary descriptor still points at old root %d", oldRoot)
+	}
+	if aliasRoot != newRoot {
+		t.Fatalf("alias descriptor root=%d want rewritten root %d", aliasRoot, newRoot)
+	}
+	want := bytes.Repeat([]byte("collection-online-alias-pointer-live|"), 24)
+	for _, descriptorKey := range []string{maintenanceTestCollectionRootKey, aliasDescriptorKey} {
+		got := readCollectionRootValue(t, db, descriptorKey, []byte("doc/p"))
+		if !bytes.Equal(got, want) {
+			t.Fatalf("collection value mismatch through descriptor %q after online rewrite", descriptorKey)
+		}
+	}
+	referenced, err := db.referencedValueLogSegments(context.Background())
+	if err != nil {
+		t.Fatalf("referencedValueLogSegments: %v", err)
+	}
+	if _, ok := referenced[ptr.FileID]; ok {
+		t.Fatalf("source segment %d remains referenced after aliased collection rewrite: %v", ptr.FileID, referenced)
+	}
+}
+
 func TestValueLogRewriteOnline_RewritesCollectionLeafRefRootPointers(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 	dir := db.dir

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -519,6 +519,121 @@ func TestValueLogRewriteOffline_RewritesCollectionRootPointers(t *testing.T) {
 	}
 }
 
+func TestValueLogRewriteOnline_RewritesCollectionRootPointers(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	ptr := appendPointersInNewSegment(t, dir, 0, 1, 510_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("collection-online-pointer-live|"), 32)
+	})[0]
+	publishCollectionPointerRoot(t, db, maintenanceTestCollectionRootKey, ptr)
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs: []uint32{ptr.FileID},
+		BatchSize:     1,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if stats.RecordsCopied != 1 {
+		t.Fatalf("expected one collection pointer record to be copied, stats=%+v", stats)
+	}
+	if stats.SourceSegmentsUnreferenced != 1 {
+		t.Fatalf("source segments unreferenced=%d want 1 (stats=%+v)", stats.SourceSegmentsUnreferenced, stats)
+	}
+
+	got := readCollectionRootValue(t, db, maintenanceTestCollectionRootKey, []byte("doc/p"))
+	want := bytes.Repeat([]byte("collection-online-pointer-live|"), 32)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("collection value mismatch after online rewrite")
+	}
+	newPtr, flags := readCollectionProjectedPointerByKey(t, db, maintenanceTestCollectionRootKey, []byte("doc/p"))
+	if flags&node.FlagPointer == 0 {
+		t.Fatalf("collection entry flags=%#x want pointer", flags)
+	}
+	if newPtr.FileID == ptr.FileID {
+		t.Fatalf("collection pointer still references source segment %d", ptr.FileID)
+	}
+	referenced, err := db.referencedValueLogSegments(context.Background())
+	if err != nil {
+		t.Fatalf("referencedValueLogSegments: %v", err)
+	}
+	if _, ok := referenced[ptr.FileID]; ok {
+		t.Fatalf("source segment %d remains referenced after collection rewrite: %v", ptr.FileID, referenced)
+	}
+}
+
+func TestValueLogRewriteOnline_RewritesCollectionLeafRefRootPointers(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+	dir := db.dir
+
+	ptr := appendPointersInNewSegment(t, dir, 0, 1, 520_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("collection-online-leafref-pointer-live|"), 24)
+	})[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh value log set: %v", err)
+	}
+	_, rootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemPointerMemtable(t, "doc/p", ptr).NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			return nil, fmt.Errorf("rootIDs=%d want 1", len(rootIDs))
+		}
+		return mustFrozenRawMemtable(t, maintenanceTestCollectionRootKey, encodeMaintenanceRootID(rootIDs[0])).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish collection leaf-ref root: %v", err)
+	}
+	oldRoot := rootIDs[0]
+	if _, ok := page.DecodeLeafRef(oldRoot); !ok {
+		t.Fatalf("collection root=%d want leaf ref", oldRoot)
+	}
+	if err := leafLog.Sync(); err != nil {
+		t.Fatalf("sync leaf log: %v", err)
+	}
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs: []uint32{ptr.FileID},
+		BatchSize:     1,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if stats.RecordsCopied != 1 {
+		t.Fatalf("expected one collection leaf-ref pointer record to be copied, stats=%+v", stats)
+	}
+	if stats.SourceSegmentsUnreferenced != 1 {
+		t.Fatalf("source segments unreferenced=%d want 1 (stats=%+v)", stats.SourceSegmentsUnreferenced, stats)
+	}
+
+	newRoot := readCollectionRootID(t, db, maintenanceTestCollectionRootKey)
+	if newRoot == oldRoot {
+		t.Fatalf("collection descriptor still points at old leaf-ref root %d", oldRoot)
+	}
+	if _, ok := page.DecodeLeafRef(newRoot); !ok {
+		t.Fatalf("rewritten collection root=%d want leaf ref", newRoot)
+	}
+	got := readCollectionRootValue(t, db, maintenanceTestCollectionRootKey, []byte("doc/p"))
+	want := bytes.Repeat([]byte("collection-online-leafref-pointer-live|"), 24)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("collection leaf-ref value mismatch after online rewrite")
+	}
+	newPtr, flags := readCollectionProjectedPointerByKey(t, db, maintenanceTestCollectionRootKey, []byte("doc/p"))
+	if flags&node.FlagPointer == 0 {
+		t.Fatalf("collection leaf-ref entry flags=%#x want pointer", flags)
+	}
+	if newPtr.FileID == ptr.FileID {
+		t.Fatalf("collection leaf-ref pointer still references source segment %d", ptr.FileID)
+	}
+}
+
 func TestValueLogRewriteOffline_RewritesCollectionLeafRefRoot(t *testing.T) {
 	dir := t.TempDir()
 	opts := Options{
@@ -4408,6 +4523,33 @@ func readCollectionRootValue(t *testing.T, db *DB, descriptorKey string, key []b
 		t.Fatalf("read collection key %q at root %d: %v", key, rootID, err)
 	}
 	return append([]byte(nil), val...)
+}
+
+func readCollectionProjectedPointerByKey(t *testing.T, db *DB, descriptorKey string, key []byte) (page.ValuePtr, byte) {
+	t.Helper()
+	rootID := readCollectionRootID(t, db, descriptorKey)
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer snap.Close()
+	it, err := snap.IteratorAtRootWithOptions(rootID, nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+	if err != nil {
+		t.Fatalf("IteratorAtRootWithOptions(%d): %v", rootID, err)
+	}
+	defer it.Close()
+	for ; it.Valid(); it.Next() {
+		if !bytes.Equal(it.UnsafeKey(), key) {
+			continue
+		}
+		_, ptr, flags := it.UnsafeEntry()
+		return ptr, flags
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("collection projection iterator error: %v", err)
+	}
+	t.Fatalf("missing collection key %q in projection iterator", key)
+	return page.ValuePtr{}, 0
 }
 
 func leafLogSegmentPath(t *testing.T, dir string, fileID uint32) string {

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -851,6 +851,82 @@ func TestValueLogRewriteOnline_ToleratesDivergedDescriptorAlias(t *testing.T) {
 	}
 }
 
+func TestValueLogRewriteOnline_RefreshesFullyRenamedCollectionAlias(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	oldPtr := appendPointersInNewSegment(t, dir, 0, 1, 542_000, 1, func(int) []byte {
+		return []byte("old collection fully renamed alias value")
+	})[0]
+	newValue := []byte("new collection fully renamed alias value")
+	newPtr := appendPointersInNewSegment(t, dir, 0, 2, 543_000, 1, func(int) []byte {
+		return newValue
+	})[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh value log set: %v", err)
+	}
+
+	aliasDescriptorKey := "collections/root/users/renamed-old-alias"
+	newDescriptorKey := "collections/root/users/renamed-new-alias"
+	_, rootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemPointerMemtable(t, "doc/p", oldPtr).NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStoragePagerLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			return nil, fmt.Errorf("rootIDs=%d want 1", len(rootIDs))
+		}
+		return mustFrozenRawMemtable(t,
+			maintenanceTestCollectionRootKey, encodeMaintenanceRootID(rootIDs[0]),
+			aliasDescriptorKey, encodeMaintenanceRootID(rootIDs[0]),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish aliased collection root: %v", err)
+	}
+	oldRoot := rootIDs[0]
+	otherRoot, err := db.PublishOrderedRootIterator(0, mustFrozenRawMemtable(t, "doc/other", []byte("other")).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish other root: %v", err)
+	}
+	if _, err := db.PublishSystemRootIterator(mustFrozenRawMemtable(t,
+		maintenanceTestCollectionRootKey, encodeMaintenanceRootID(otherRoot),
+		aliasDescriptorKey, encodeMaintenanceRootID(otherRoot),
+		newDescriptorKey, encodeMaintenanceRootID(oldRoot),
+	).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("rename collection descriptor: %v", err)
+	}
+
+	target := &collectionRewriteRootState{
+		descriptorKey: append([]byte(nil), maintenanceTestCollectionRootKey...),
+		descriptorAliases: [][]byte{
+			append([]byte(nil), maintenanceTestCollectionRootKey...),
+			[]byte(aliasDescriptorKey),
+		},
+		rootID:     oldRoot,
+		systemRoot: 0,
+	}
+	if err := db.applyRewriteSwapBatchToCollectionRoot(target, []rewriteSwap{{key: []byte("doc/p"), oldPtr: oldPtr, newPtr: newPtr}}, false); err != nil {
+		t.Fatalf("apply collection rewrite swap with fully renamed alias: %v", err)
+	}
+	if got := readCollectionRootValue(t, db, newDescriptorKey, []byte("doc/p")); !bytes.Equal(got, newValue) {
+		t.Fatalf("renamed descriptor value=%q want %q", got, newValue)
+	}
+	if len(target.descriptorAliases) != 1 || !bytes.Equal(target.descriptorAliases[0], []byte(newDescriptorKey)) {
+		t.Fatalf("refreshed descriptor aliases=%q want renamed alias only", target.descriptorAliases)
+	}
+	for _, descriptorKey := range []string{maintenanceTestCollectionRootKey, aliasDescriptorKey} {
+		if gotRoot := readCollectionRootID(t, db, descriptorKey); gotRoot != otherRoot {
+			t.Fatalf("descriptor %q root=%d want unrelated root %d", descriptorKey, gotRoot, otherRoot)
+		}
+	}
+}
+
 func TestValueLogRewriteOnline_RewritesCollectionLeafRefRootPointers(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 	dir := db.dir

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -710,6 +710,75 @@ func TestValueLogRewriteOnline_RepointsAliasedCollectionRootDescriptors(t *testi
 	}
 }
 
+func TestValueLogRewriteOnline_RefreshesCollectionRootThroughDescriptorAlias(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	oldPtr := appendPointersInNewSegment(t, dir, 0, 1, 530_000, 1, func(int) []byte {
+		return []byte("old collection alias value")
+	})[0]
+	newValue := []byte("new collection alias value")
+	newPtr := appendPointersInNewSegment(t, dir, 0, 2, 531_000, 1, func(int) []byte {
+		return newValue
+	})[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh value log set: %v", err)
+	}
+
+	aliasDescriptorKey := "collections/root/users/alias"
+	_, rootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemPointerMemtable(t, "doc/p", oldPtr).NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStoragePagerLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			return nil, fmt.Errorf("rootIDs=%d want 1", len(rootIDs))
+		}
+		return mustFrozenRawMemtable(t,
+			maintenanceTestCollectionRootKey, encodeMaintenanceRootID(rootIDs[0]),
+			aliasDescriptorKey, encodeMaintenanceRootID(rootIDs[0]),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish aliased collection root: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs=%d want 1", len(rootIDs))
+	}
+	oldRoot := rootIDs[0]
+	state := db.State()
+	if state == nil {
+		t.Fatal("expected db state")
+	}
+	target := &collectionRewriteRootState{
+		descriptorKey: append([]byte(nil), maintenanceTestCollectionRootKey...),
+		descriptorAliases: [][]byte{
+			append([]byte(nil), maintenanceTestCollectionRootKey...),
+			[]byte(aliasDescriptorKey),
+		},
+		rootID:     oldRoot,
+		systemRoot: state.SystemRootPageID,
+	}
+
+	if _, err := db.PublishSystemRootIterator(mustFrozenRawMemtable(t, aliasDescriptorKey, encodeMaintenanceRootID(oldRoot)).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("remove primary descriptor through system publish: %v", err)
+	}
+	if err := db.applyRewriteSwapBatchToCollectionRoot(target, []rewriteSwap{{key: []byte("doc/p"), oldPtr: oldPtr, newPtr: newPtr}}, false); err != nil {
+		t.Fatalf("apply collection rewrite swap through descriptor alias: %v", err)
+	}
+	if got := readCollectionRootValue(t, db, aliasDescriptorKey, []byte("doc/p")); !bytes.Equal(got, newValue) {
+		t.Fatalf("alias descriptor value=%q want %q", got, newValue)
+	}
+	if len(target.descriptorAliases) != 1 || !bytes.Equal(target.descriptorAliases[0], []byte(aliasDescriptorKey)) {
+		t.Fatalf("refreshed descriptor aliases=%q want alias only", target.descriptorAliases)
+	}
+}
+
 func TestValueLogRewriteOnline_RewritesCollectionLeafRefRootPointers(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 	dir := db.dir

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -812,8 +812,17 @@ func TestValueLogRewriteOnline_CollectionRootCommitUsesCurrentStoragePolicy(t *t
 	}
 	primeValueLogRefTracker(t, db)
 
+	state := db.State()
+	if state == nil {
+		t.Fatal("expected db state")
+	}
 	target := &collectionRewriteRootState{
 		descriptorKey: append([]byte(nil), maintenanceTestCollectionRootKey...),
+		descriptorAliases: [][]byte{
+			append([]byte(nil), maintenanceTestCollectionRootKey...),
+		},
+		rootID:        oldRoot,
+		systemRoot:    state.SystemRootPageID,
 		storagePolicy: OrderedRootStoragePagerLeaves, // stale scan-time policy; current root uses value-log leaves.
 	}
 	if err := db.applyRewriteSwapBatchToCollectionRoot(target, []rewriteSwap{{key: []byte("doc/p"), oldPtr: oldPtr, newPtr: newPtr}}, false); err != nil {

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -767,6 +767,67 @@ func TestValueLogRewriteOnline_RewritesCollectionLeafRefRootPointers(t *testing.
 	}
 }
 
+func TestValueLogRewriteOnline_CollectionRootCommitUsesCurrentStoragePolicy(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+	dir := db.dir
+
+	oldPtr := appendPointersInNewSegment(t, dir, 0, 1, 525_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("collection-current-policy-old|"), 24)
+	})[0]
+	newValue := bytes.Repeat([]byte("collection-current-policy-new|"), 24)
+	newPtr := appendPointersInNewSegment(t, dir, 0, 2, 526_000, 1, func(int) []byte {
+		return newValue
+	})[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh value log set: %v", err)
+	}
+	_, rootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemPointerMemtable(t, "doc/p", oldPtr).NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			return nil, fmt.Errorf("rootIDs=%d want 1", len(rootIDs))
+		}
+		return mustFrozenRawMemtable(t, maintenanceTestCollectionRootKey, encodeMaintenanceRootID(rootIDs[0])).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish collection leaf-ref root: %v", err)
+	}
+	oldRoot := rootIDs[0]
+	if _, ok := page.DecodeLeafRef(oldRoot); !ok {
+		t.Fatalf("collection root=%d want leaf ref", oldRoot)
+	}
+	if err := leafLog.Sync(); err != nil {
+		t.Fatalf("sync leaf log: %v", err)
+	}
+	primeValueLogRefTracker(t, db)
+
+	if err := db.applyRewriteSwapBatchToCollectionRoot(
+		[]byte(maintenanceTestCollectionRootKey),
+		OrderedRootStoragePagerLeaves, // stale scan-time policy; current root uses value-log leaves.
+		[]rewriteSwap{{key: []byte("doc/p"), oldPtr: oldPtr, newPtr: newPtr}},
+		false,
+	); err != nil {
+		t.Fatalf("apply collection rewrite swap with stale policy: %v", err)
+	}
+	if _, ok := db.valueLogRefTracker.referencedSet(db.currentCommitSeq()); ok {
+		t.Fatal("expected value-log-leaf collection rewrite to invalidate value-log ref tracker")
+	}
+
+	newRoot := readCollectionRootID(t, db, maintenanceTestCollectionRootKey)
+	if newRoot == oldRoot {
+		t.Fatalf("collection descriptor still points at old leaf-ref root %d", oldRoot)
+	}
+	if _, ok := page.DecodeLeafRef(newRoot); !ok {
+		t.Fatalf("rewritten collection root=%d want leaf ref", newRoot)
+	}
+	got := readCollectionRootValue(t, db, maintenanceTestCollectionRootKey, []byte("doc/p"))
+	if !bytes.Equal(got, newValue) {
+		t.Fatalf("collection value mismatch after stale-policy rewrite")
+	}
+}
+
 func TestValueLogRewriteOffline_RewritesCollectionLeafRefRoot(t *testing.T) {
 	dir := t.TempDir()
 	opts := Options{
@@ -4616,6 +4677,14 @@ func readCollectionRootID(t *testing.T, db *DB, descriptorKey string) uint64 {
 		t.Fatal("expected snapshot")
 	}
 	defer snap.Close()
+	return readCollectionRootIDFromSnapshot(t, snap, descriptorKey)
+}
+
+func readCollectionRootIDFromSnapshot(t *testing.T, snap *Snapshot, descriptorKey string) uint64 {
+	t.Helper()
+	if snap == nil || snap.state == nil {
+		t.Fatal("expected snapshot")
+	}
 	encoded, err := snap.GetAtRoot(snap.state.SystemRootPageID, []byte(descriptorKey))
 	if err != nil {
 		t.Fatalf("read collection descriptor %q: %v", descriptorKey, err)
@@ -4628,12 +4697,12 @@ func readCollectionRootID(t *testing.T, db *DB, descriptorKey string) uint64 {
 
 func readCollectionRootValue(t *testing.T, db *DB, descriptorKey string, key []byte) []byte {
 	t.Helper()
-	rootID := readCollectionRootID(t, db, descriptorKey)
 	snap := db.AcquireSnapshot()
 	if snap == nil {
 		t.Fatal("expected snapshot")
 	}
 	defer snap.Close()
+	rootID := readCollectionRootIDFromSnapshot(t, snap, descriptorKey)
 	val, err := snap.GetAtRoot(rootID, key)
 	if err != nil {
 		t.Fatalf("read collection key %q at root %d: %v", key, rootID, err)
@@ -4643,12 +4712,12 @@ func readCollectionRootValue(t *testing.T, db *DB, descriptorKey string, key []b
 
 func readCollectionProjectedPointerByKey(t *testing.T, db *DB, descriptorKey string, key []byte) (page.ValuePtr, byte) {
 	t.Helper()
-	rootID := readCollectionRootID(t, db, descriptorKey)
 	snap := db.AcquireSnapshot()
 	if snap == nil {
 		t.Fatal("expected snapshot")
 	}
 	defer snap.Close()
+	rootID := readCollectionRootIDFromSnapshot(t, snap, descriptorKey)
 	it, err := snap.IteratorAtRootWithOptions(rootID, nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
 	if err != nil {
 		t.Fatalf("IteratorAtRootWithOptions(%d): %v", rootID, err)

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -779,6 +779,78 @@ func TestValueLogRewriteOnline_RefreshesCollectionRootThroughDescriptorAlias(t *
 	}
 }
 
+func TestValueLogRewriteOnline_ToleratesDivergedDescriptorAlias(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	oldPtr := appendPointersInNewSegment(t, dir, 0, 1, 540_000, 1, func(int) []byte {
+		return []byte("old collection diverged alias value")
+	})[0]
+	newValue := []byte("new collection diverged alias value")
+	newPtr := appendPointersInNewSegment(t, dir, 0, 2, 541_000, 1, func(int) []byte {
+		return newValue
+	})[0]
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("refresh value log set: %v", err)
+	}
+
+	aliasDescriptorKey := "collections/root/users/diverged-alias"
+	_, rootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenSystemPointerMemtable(t, "doc/p", oldPtr).NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStoragePagerLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			return nil, fmt.Errorf("rootIDs=%d want 1", len(rootIDs))
+		}
+		return mustFrozenRawMemtable(t,
+			maintenanceTestCollectionRootKey, encodeMaintenanceRootID(rootIDs[0]),
+			aliasDescriptorKey, encodeMaintenanceRootID(rootIDs[0]),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish aliased collection root: %v", err)
+	}
+	oldRoot := rootIDs[0]
+	otherRoot, err := db.PublishOrderedRootIterator(0, mustFrozenRawMemtable(t, "doc/other", []byte("other")).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish other root: %v", err)
+	}
+	if _, err := db.PublishSystemRootIterator(mustFrozenRawMemtable(t,
+		maintenanceTestCollectionRootKey, encodeMaintenanceRootID(otherRoot),
+		aliasDescriptorKey, encodeMaintenanceRootID(oldRoot),
+	).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("diverge primary descriptor: %v", err)
+	}
+
+	target := &collectionRewriteRootState{
+		descriptorKey: append([]byte(nil), maintenanceTestCollectionRootKey...),
+		descriptorAliases: [][]byte{
+			append([]byte(nil), maintenanceTestCollectionRootKey...),
+			[]byte(aliasDescriptorKey),
+		},
+		rootID:     oldRoot,
+		systemRoot: 0,
+	}
+	if err := db.applyRewriteSwapBatchToCollectionRoot(target, []rewriteSwap{{key: []byte("doc/p"), oldPtr: oldPtr, newPtr: newPtr}}, false); err != nil {
+		t.Fatalf("apply collection rewrite swap with diverged alias: %v", err)
+	}
+	if got := readCollectionRootValue(t, db, aliasDescriptorKey, []byte("doc/p")); !bytes.Equal(got, newValue) {
+		t.Fatalf("alias descriptor value=%q want %q", got, newValue)
+	}
+	if len(target.descriptorAliases) != 1 || !bytes.Equal(target.descriptorAliases[0], []byte(aliasDescriptorKey)) {
+		t.Fatalf("refreshed descriptor aliases=%q want diverged alias only", target.descriptorAliases)
+	}
+	if gotRoot := readCollectionRootID(t, db, maintenanceTestCollectionRootKey); gotRoot != otherRoot {
+		t.Fatalf("primary descriptor root=%d want unrelated root %d", gotRoot, otherRoot)
+	}
+}
+
 func TestValueLogRewriteOnline_RewritesCollectionLeafRefRootPointers(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 	dir := db.dir
@@ -4841,17 +4913,16 @@ func readCollectionProjectedPointerByKey(t *testing.T, db *DB, descriptorKey str
 	}
 	defer snap.Close()
 	rootID := readCollectionRootIDFromSnapshot(t, snap, descriptorKey)
-	it, err := snap.IteratorAtRootWithOptions(rootID, nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+	it, err := snap.IteratorAtRootWithOptions(rootID, key, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
 	if err != nil {
 		t.Fatalf("IteratorAtRootWithOptions(%d): %v", rootID, err)
 	}
 	defer it.Close()
-	for ; it.Valid(); it.Next() {
-		if !bytes.Equal(it.UnsafeKey(), key) {
-			continue
+	if it.Valid() {
+		if bytes.Equal(it.UnsafeKey(), key) {
+			_, ptr, flags := it.UnsafeEntry()
+			return ptr, flags
 		}
-		_, ptr, flags := it.UnsafeEntry()
-		return ptr, flags
 	}
 	if err := it.Error(); err != nil {
 		t.Fatalf("collection projection iterator error: %v", err)

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -638,13 +638,20 @@ func TestValueLogRewriteOnline_RepointsAliasedCollectionRootDescriptors(t *testi
 	}
 	defer closeNoErr(t, db)
 
-	ptr := appendPointersInNewSegment(t, dir, 0, 1, 515_000, 1, func(int) []byte {
-		return bytes.Repeat([]byte("collection-online-alias-pointer-live|"), 24)
-	})[0]
+	ptrs := appendPointersInNewSegment(t, dir, 0, 1, 515_000, 2, func(i int) []byte {
+		return bytes.Repeat([]byte(fmt.Sprintf("collection-online-alias-pointer-live-%d|", i)), 24)
+	})
+	rootTable, err := memtable.NewWithCapacityMode(2, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("new root memtable: %v", err)
+	}
+	rootTable.SetEntry([]byte("doc/p"), nil, ptrs[0], node.FlagPointer)
+	rootTable.SetEntry([]byte("doc/q"), nil, ptrs[1], node.FlagPointer)
+	rootTable.Freeze()
 	aliasDescriptorKey := "collections/root/users/alias"
 	_, rootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
 		BaseRoot:      0,
-		Iter:          mustFrozenSystemPointerMemtable(t, "doc/p", ptr).NewIterator(nil, nil),
+		Iter:          rootTable.NewIterator(nil, nil),
 		StoragePolicy: OrderedRootStoragePagerLeaves,
 	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		if len(rootIDs) != 1 {
@@ -664,14 +671,14 @@ func TestValueLogRewriteOnline_RepointsAliasedCollectionRootDescriptors(t *testi
 	oldRoot := rootIDs[0]
 
 	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
-		SourceFileIDs: []uint32{ptr.FileID},
+		SourceFileIDs: []uint32{ptrs[0].FileID},
 		BatchSize:     1,
 	})
 	if err != nil {
 		t.Fatalf("ValueLogRewriteOnline: %v", err)
 	}
-	if stats.RecordsCopied != 1 {
-		t.Fatalf("expected one collection pointer record to be copied, stats=%+v", stats)
+	if stats.RecordsCopied != 2 {
+		t.Fatalf("expected two collection pointer records to be copied, stats=%+v", stats)
 	}
 	if stats.SourceSegmentsUnreferenced != 1 {
 		t.Fatalf("source segments unreferenced=%d want 1 (stats=%+v)", stats.SourceSegmentsUnreferenced, stats)
@@ -685,19 +692,21 @@ func TestValueLogRewriteOnline_RepointsAliasedCollectionRootDescriptors(t *testi
 	if aliasRoot != newRoot {
 		t.Fatalf("alias descriptor root=%d want rewritten root %d", aliasRoot, newRoot)
 	}
-	want := bytes.Repeat([]byte("collection-online-alias-pointer-live|"), 24)
 	for _, descriptorKey := range []string{maintenanceTestCollectionRootKey, aliasDescriptorKey} {
-		got := readCollectionRootValue(t, db, descriptorKey, []byte("doc/p"))
-		if !bytes.Equal(got, want) {
-			t.Fatalf("collection value mismatch through descriptor %q after online rewrite", descriptorKey)
+		for i, key := range []string{"doc/p", "doc/q"} {
+			got := readCollectionRootValue(t, db, descriptorKey, []byte(key))
+			want := bytes.Repeat([]byte(fmt.Sprintf("collection-online-alias-pointer-live-%d|", i)), 24)
+			if !bytes.Equal(got, want) {
+				t.Fatalf("collection value mismatch through descriptor %q key %q after online rewrite", descriptorKey, key)
+			}
 		}
 	}
 	referenced, err := db.referencedValueLogSegments(context.Background())
 	if err != nil {
 		t.Fatalf("referencedValueLogSegments: %v", err)
 	}
-	if _, ok := referenced[ptr.FileID]; ok {
-		t.Fatalf("source segment %d remains referenced after aliased collection rewrite: %v", ptr.FileID, referenced)
+	if _, ok := referenced[ptrs[0].FileID]; ok {
+		t.Fatalf("source segment %d remains referenced after aliased collection rewrite: %v", ptrs[0].FileID, referenced)
 	}
 }
 
@@ -803,12 +812,11 @@ func TestValueLogRewriteOnline_CollectionRootCommitUsesCurrentStoragePolicy(t *t
 	}
 	primeValueLogRefTracker(t, db)
 
-	if err := db.applyRewriteSwapBatchToCollectionRoot(
-		[]byte(maintenanceTestCollectionRootKey),
-		OrderedRootStoragePagerLeaves, // stale scan-time policy; current root uses value-log leaves.
-		[]rewriteSwap{{key: []byte("doc/p"), oldPtr: oldPtr, newPtr: newPtr}},
-		false,
-	); err != nil {
+	target := &collectionRewriteRootState{
+		descriptorKey: append([]byte(nil), maintenanceTestCollectionRootKey...),
+		storagePolicy: OrderedRootStoragePagerLeaves, // stale scan-time policy; current root uses value-log leaves.
+	}
+	if err := db.applyRewriteSwapBatchToCollectionRoot(target, []rewriteSwap{{key: []byte("doc/p"), oldPtr: oldPtr, newPtr: newPtr}}, false); err != nil {
 		t.Fatalf("apply collection rewrite swap with stale policy: %v", err)
 	}
 	if _, ok := db.valueLogRefTracker.referencedSet(db.currentCommitSeq()); ok {

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -532,6 +532,7 @@ func TestValueLogRewriteOnline_RewritesCollectionRootPointers(t *testing.T) {
 		return bytes.Repeat([]byte("collection-online-pointer-live|"), 32)
 	})[0]
 	publishCollectionPointerRoot(t, db, maintenanceTestCollectionRootKey, ptr)
+	primeValueLogRefTracker(t, db)
 
 	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
 		SourceFileIDs: []uint32{ptr.FileID},
@@ -559,12 +560,72 @@ func TestValueLogRewriteOnline_RewritesCollectionRootPointers(t *testing.T) {
 	if newPtr.FileID == ptr.FileID {
 		t.Fatalf("collection pointer still references source segment %d", ptr.FileID)
 	}
+	trackerRefs := requireValueLogRefTrackerValid(t, db)
+	if _, ok := trackerRefs[ptr.FileID]; ok {
+		t.Fatalf("value-log ref tracker still references source segment %d: %v", ptr.FileID, trackerRefs)
+	}
+	if _, ok := trackerRefs[newPtr.FileID]; !ok {
+		t.Fatalf("value-log ref tracker missing rewritten segment %d: %v", newPtr.FileID, trackerRefs)
+	}
 	referenced, err := db.referencedValueLogSegments(context.Background())
 	if err != nil {
 		t.Fatalf("referencedValueLogSegments: %v", err)
 	}
 	if _, ok := referenced[ptr.FileID]; ok {
 		t.Fatalf("source segment %d remains referenced after collection rewrite: %v", ptr.FileID, referenced)
+	}
+}
+
+func TestValueLogRewriteOnline_PreservesRefTrackerForSystemRootPointers(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer closeNoErr(t, db)
+
+	ptr := appendPointersInNewSegment(t, dir, 0, 1, 512_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("system-online-pointer-live|"), 32)
+	})[0]
+	if _, err := db.PublishSystemRootIterator(mustFrozenSystemPointerMemtable(t, "sys/p", ptr).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("publish system pointer root: %v", err)
+	}
+	primeValueLogRefTracker(t, db)
+
+	stats, err := db.ValueLogRewriteOnline(context.Background(), ValueLogRewriteOnlineOptions{
+		SourceFileIDs: []uint32{ptr.FileID},
+		BatchSize:     1,
+	})
+	if err != nil {
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if stats.RecordsCopied != 1 {
+		t.Fatalf("expected one system pointer record to be copied, stats=%+v", stats)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil || snap.State() == nil {
+		t.Fatal("expected snapshot")
+	}
+	entry, err := snap.GetEntryAtRoot(snap.State().SystemRootPageID, []byte("sys/p"))
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("read system pointer: %v", err)
+	}
+	_ = snap.Close()
+	if entry.Flags&node.FlagPointer == 0 {
+		t.Fatalf("system entry flags=%#x want pointer", entry.Flags)
+	}
+	if entry.ValuePtr.FileID == ptr.FileID {
+		t.Fatalf("system pointer still references source segment %d", ptr.FileID)
+	}
+	trackerRefs := requireValueLogRefTrackerValid(t, db)
+	if _, ok := trackerRefs[ptr.FileID]; ok {
+		t.Fatalf("value-log ref tracker still references source segment %d: %v", ptr.FileID, trackerRefs)
+	}
+	if _, ok := trackerRefs[entry.ValuePtr.FileID]; !ok {
+		t.Fatalf("value-log ref tracker missing rewritten system segment %d: %v", entry.ValuePtr.FileID, trackerRefs)
 	}
 }
 
@@ -4605,6 +4666,27 @@ func readCollectionProjectedPointerByKey(t *testing.T, db *DB, descriptorKey str
 	}
 	t.Fatalf("missing collection key %q in projection iterator", key)
 	return page.ValuePtr{}, 0
+}
+
+func primeValueLogRefTracker(t *testing.T, db *DB) {
+	t.Helper()
+	if _, err := db.referencedValueLogSegments(context.Background()); err != nil {
+		t.Fatalf("prime value-log ref tracker: %v", err)
+	}
+	requireValueLogRefTrackerValid(t, db)
+}
+
+func requireValueLogRefTrackerValid(t *testing.T, db *DB) map[uint32]struct{} {
+	t.Helper()
+	if db == nil || db.valueLogRefTracker == nil {
+		t.Fatal("missing value-log ref tracker")
+	}
+	seq := db.currentCommitSeq()
+	refs, ok := db.valueLogRefTracker.referencedSet(seq)
+	if !ok {
+		t.Fatalf("expected value-log ref tracker to remain valid at seq=%d", seq)
+	}
+	return refs
 }
 
 func leafLogSegmentPath(t *testing.T, dir string, fileID uint32) string {


### PR DESCRIPTION
## Summary
- extend `ValueLogRewriteOnline` to scan the full maintenance-root set instead of only the user root
- apply rewrite pointer swaps to system roots and collection roots, preserving pager vs value-log-leaf collection storage policy
- update collection root descriptors when collection root IDs change during online value rewrite
- add regressions for pager-backed and value-log LeafRef-backed collection roots

## Validation
- `go test ./TreeDB/db -run 'TestValueLogRewriteOnline_RewritesCollectionRootPointers|TestValueLogRewriteOnline_RewritesCollectionLeafRefRootPointers|TestLeafGenerationPack_RewritesCollectionLeafRefRoot|TestValueLogRewriteOffline_RewritesCollectionLeafRefRoot|TestValueLogRewriteOffline_RewritesCollectionLeafRefRootWithPagerDefault' -count=1`\n- `go test ./TreeDB/collections -count=1`\n- `go test ./TreeDB/db -count=1`\n