### PR TITLE
[codex] Add Mongo gateway update and delete commands

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -1079,11 +1080,12 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 		deleted, err := c.deleteDocumentOnce(documentID)
 		if errors.Is(err, ErrConcurrentMutation) {
 			lastErr = err
+			waitBeforeCollectionMutationRetry(attempt)
 			continue
 		}
 		return deleted, err
 	}
-	return false, lastErr
+	return false, collectionMutationRetryExhausted(lastErr)
 }
 
 func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
@@ -1210,7 +1212,10 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 }
 
 func (c *Collection) Replace(documentID, document []byte) (bool, error) {
-	matched, _, err := c.Update(documentID, func([]byte) ([]byte, bool, error) {
+	matched, _, err := c.Update(documentID, func(current []byte) ([]byte, bool, error) {
+		if bytes.Equal(current, document) {
+			return current, false, nil
+		}
 		return document, true, nil
 	})
 	return matched, err
@@ -1240,11 +1245,31 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 		matched, modified, err := c.updateDocumentOnce(documentID, update)
 		if errors.Is(err, ErrConcurrentMutation) {
 			lastErr = err
+			waitBeforeCollectionMutationRetry(attempt)
 			continue
 		}
 		return matched, modified, err
 	}
-	return false, false, lastErr
+	return false, false, collectionMutationRetryExhausted(lastErr)
+}
+
+func waitBeforeCollectionMutationRetry(attempt int) {
+	if attempt < 4 {
+		runtime.Gosched()
+		return
+	}
+	shift := attempt - 4
+	if shift > 6 {
+		shift = 6
+	}
+	time.Sleep(time.Duration(1<<shift) * time.Microsecond)
+}
+
+func collectionMutationRetryExhausted(err error) error {
+	if err == nil {
+		err = ErrConcurrentMutation
+	}
+	return fmt.Errorf("%w: retry budget exceeded after %d attempts: %v", ErrConcurrentMutation, maxCollectionMutationRetries, err)
 }
 
 func (c *Collection) updateDocumentOnce(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1185,6 +1185,183 @@ func (c *Collection) Delete(documentID []byte) error {
 	return nil
 }
 
+func (c *Collection) Replace(documentID, document []byte) (bool, error) {
+	if c == nil {
+		return false, errCollectionNil
+	}
+	if c.db == nil {
+		return false, errors.New("collections: db is nil")
+	}
+	if len(documentID) == 0 {
+		return false, errors.New("collections: document id cannot be empty")
+	}
+	if err := c.flushBufferedNoIndex(); err != nil {
+		return false, err
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return false, backenddb.ErrClosed
+	}
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		_ = snap.Close()
+		return false, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return false, errCollectionNotFound
+	}
+	c.meta = catalog.meta
+	plannerOptions, err := collectionPlannerOptions(c.meta)
+	if err != nil {
+		_ = snap.Close()
+		return false, err
+	}
+	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
+	baseSystemRoot := snapshotSystemRoot(snap)
+
+	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
+	if primaryRoot == 0 {
+		_ = snap.Close()
+		return false, nil
+	}
+	entry, err := snap.GetEntryAtRoot(primaryRoot, documentID)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		_ = snap.Close()
+		return false, nil
+	}
+	if err != nil {
+		_ = snap.Close()
+		return false, err
+	}
+
+	runtimes, err := (insertBatchPlanner{
+		collection: c.meta.Name,
+		indexes:    plannerIndexes(c.meta.Indexes),
+	}).indexRuntimes()
+	if err != nil {
+		_ = snap.Close()
+		return false, err
+	}
+	var oldState documentIndexState
+	var newState documentIndexState
+	if len(runtimes) > 0 {
+		oldState, err = loadDeleteIndexState(snap, catalog, documentID, entry.Value, runtimes, plannerOptions)
+		if err != nil {
+			_ = snap.Close()
+			return false, err
+		}
+		newState, err = indexStateForDocument(document, runtimes, plannerOptions)
+		if err != nil {
+			_ = snap.Close()
+			return false, err
+		}
+		if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, newState, documentID); err != nil {
+			_ = snap.Close()
+			return false, err
+		}
+	}
+
+	rootNames := []string{collectionPrimaryRootName(c.meta.Name)}
+	baseRootIDs := map[string]uint64{
+		rootNames[0]: primaryRoot,
+	}
+	policies := []backenddb.OrderedRootStoragePolicy{plannerOptions.dataStoragePolicy}
+	deltaTables := make([]memtable.Table, 0, 2+len(runtimes))
+	primaryTable := newCollectionRunTable(1)
+	setCollectionRunValue(primaryTable, bytes.Clone(documentID), document)
+	primaryTable.Freeze()
+	deltaTables = append(deltaTables, primaryTable)
+
+	if len(runtimes) > 0 {
+		stateRootName := collectionIndexStateRootName(c.meta.Name)
+		stateRootID := catalog.rootID(stateRootName)
+		rootNames = append(rootNames, stateRootName)
+		baseRootIDs[stateRootName] = stateRootID
+		policies = append(policies, plannerOptions.indexStateStoragePolicy)
+		stateTable := newCollectionRunTable(1)
+		rawState, err := encodeDocumentIndexState(newState)
+		if err != nil {
+			_ = snap.Close()
+			resetCollectionTables(append(deltaTables, stateTable))
+			return false, err
+		}
+		if len(newState) == 0 {
+			stateTable.DeleteSteal(bytes.Clone(documentID))
+		} else {
+			stateTable.SetSteal(bytes.Clone(documentID), rawState)
+		}
+		stateTable.Freeze()
+		deltaTables = append(deltaTables, stateTable)
+
+		for _, runtime := range runtimes {
+			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
+			rootID := catalog.rootID(rootName)
+			table := newCollectionRunTable(0)
+			deleteKeys, err := secondaryDeleteKeysForDocument(runtime, oldState, documentID)
+			if err != nil {
+				_ = snap.Close()
+				resetCollectionTables(append(deltaTables, table))
+				return false, err
+			}
+			for _, key := range deleteKeys {
+				table.DeleteSteal(bytes.Clone(key))
+			}
+			for _, encoded := range newState[runtime.def.name] {
+				key, err := indexEntryKey(encoded, documentID)
+				if err != nil {
+					_ = snap.Close()
+					resetCollectionTables(append(deltaTables, table))
+					return false, err
+				}
+				table.SetSteal(key, nil)
+			}
+			if table.Len() == 0 {
+				resetCollectionRunTable(table)
+				continue
+			}
+			table.Freeze()
+			rootNames = append(rootNames, rootName)
+			baseRootIDs[rootName] = rootID
+			policies = append(policies, runtime.def.storagePolicy)
+			deltaTables = append(deltaTables, table)
+		}
+	}
+	_ = snap.Close()
+
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	defer func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+		resetCollectionTables(deltaTables)
+	}()
+	for i, rootName := range rootNames {
+		iter := deltaTables[i].NewIterator(nil, nil)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot:      baseRootIDs[rootName],
+			Iter:          iter,
+			StoragePolicy: policies[i],
+		})
+	}
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(rootIDs) != len(rootNames) {
+		return false, errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return true, nil
+}
+
 func (c *Collection) catalogForSnapshot(snap *backenddb.Snapshot) (*collectionCatalog, error) {
 	if snap == nil {
 		return nil, backenddb.ErrClosed
@@ -1572,6 +1749,55 @@ func secondaryDeleteKeysForDocument(runtime indexRuntime, state documentIndexSta
 		out = append(out, key)
 	}
 	return out, nil
+}
+
+func rejectReplaceUniqueConflicts(snap *backenddb.Snapshot, catalog *collectionCatalog, runtimes []indexRuntime, state documentIndexState, documentID []byte) error {
+	if snap == nil || catalog == nil {
+		return nil
+	}
+	for _, runtime := range runtimes {
+		if !runtime.def.unique {
+			continue
+		}
+		rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, runtime.def.name))
+		if rootID == 0 {
+			continue
+		}
+		for _, encoded := range state[runtime.def.name] {
+			_, prefix, err := appendIndexValuePrefixSlice(make([]byte, 0, 2+len(encoded)), encoded)
+			if err != nil {
+				return err
+			}
+			it, err := snap.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
+			if errors.Is(err, tree.ErrKeyNotFound) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			conflict := false
+			for it.Valid() {
+				key := it.UnsafeKey()
+				if !bytes.HasPrefix(key, prefix) {
+					break
+				}
+				if !it.IsDeleted() && !bytes.Equal(key[len(prefix):], documentID) {
+					conflict = true
+					break
+				}
+				it.Next()
+			}
+			iterErr := it.Error()
+			_ = it.Close()
+			if iterErr != nil {
+				return iterErr
+			}
+			if conflict {
+				return fmt.Errorf("%w %q", ErrUniqueIndexConflict, runtime.def.name)
+			}
+		}
+	}
+	return nil
 }
 
 func (c *Collection) Get(documentID []byte) ([]byte, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -21,13 +21,17 @@ import (
 	"github.com/snissn/gomap/TreeDB/tree"
 )
 
-const collectionMetaVersion = 1
+const (
+	collectionMetaVersion        = 1
+	maxCollectionMutationRetries = 64
+)
 
 var (
 	ErrCollectionNotFound  = errors.New("collections: collection not found")
 	ErrDocumentExists      = errors.New("collections: document already exists")
 	ErrDuplicateDocumentID = errors.New("collections: duplicate document id in batch")
 	ErrUniqueIndexConflict = errors.New("collections: unique index conflict")
+	ErrConcurrentMutation  = errors.New("collections: concurrent mutation")
 
 	errCollectionManagerNil = errors.New("collections: collection manager is nil")
 	errCollectionNil        = errors.New("collections: collection is nil")
@@ -1050,142 +1054,13 @@ func (c *Collection) insertBatchNoIndex(
 }
 
 func (c *Collection) Delete(documentID []byte) error {
-	if c == nil {
-		return errCollectionNil
-	}
-	if c.db == nil {
-		return errors.New("collections: db is nil")
-	}
-	if len(documentID) == 0 {
-		return errors.New("collections: document id cannot be empty")
-	}
-	if err := c.flushBufferedNoIndex(); err != nil {
-		return err
-	}
-
-	snap := c.db.AcquireSnapshot()
-	if snap == nil {
-		return backenddb.ErrClosed
-	}
-	catalog, err := c.catalogForSnapshot(snap)
-	if err != nil {
-		_ = snap.Close()
-		return err
-	}
-	if catalog == nil {
-		_ = snap.Close()
-		return errCollectionNotFound
-	}
-	c.meta = catalog.meta
-	plannerOptions, err := collectionPlannerOptions(c.meta)
-	if err != nil {
-		_ = snap.Close()
-		return err
-	}
-	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
-	baseSystemRoot := snapshotSystemRoot(snap)
-
-	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
-	if primaryRoot == 0 {
-		_ = snap.Close()
-		return nil
-	}
-	entry, err := snap.GetEntryAtRoot(primaryRoot, documentID)
-	if errors.Is(err, tree.ErrKeyNotFound) {
-		_ = snap.Close()
-		return nil
-	}
-	if err != nil {
-		_ = snap.Close()
-		return err
-	}
-
-	runtimes, err := (insertBatchPlanner{
-		collection: c.meta.Name,
-		indexes:    plannerIndexes(c.meta.Indexes),
-	}).indexRuntimes()
-	if err != nil {
-		_ = snap.Close()
-		return err
-	}
-	var state documentIndexState
-	if len(runtimes) > 0 {
-		state, err = loadDeleteIndexState(snap, catalog, documentID, entry.Value, runtimes, plannerOptions)
-		if err != nil {
-			_ = snap.Close()
-			return err
-		}
-	}
-
-	rootNames := []string{collectionPrimaryRootName(c.meta.Name)}
-	baseRootIDs := map[string]uint64{
-		rootNames[0]: primaryRoot,
-	}
-	policies := []backenddb.OrderedRootStoragePolicy{plannerOptions.dataStoragePolicy}
-	deltaTables := make([]memtable.Table, 0, 2+len(runtimes))
-	deltaTables = append(deltaTables, buildDeleteRootDeltaTable([][]byte{documentID}))
-
-	if len(runtimes) > 0 {
-		stateRootName := collectionIndexStateRootName(c.meta.Name)
-		stateRootID := catalog.rootID(stateRootName)
-		if stateRootID != 0 {
-			rootNames = append(rootNames, stateRootName)
-			baseRootIDs[stateRootName] = stateRootID
-			policies = append(policies, plannerOptions.indexStateStoragePolicy)
-			deltaTables = append(deltaTables, buildDeleteRootDeltaTable([][]byte{documentID}))
-		}
-		for _, runtime := range runtimes {
-			deleteKeys, err := secondaryDeleteKeysForDocument(runtime, state, documentID)
-			if err != nil {
-				_ = snap.Close()
-				return err
-			}
-			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
-			rootID := catalog.rootID(rootName)
-			if rootID == 0 || len(deleteKeys) == 0 {
-				continue
-			}
-			rootNames = append(rootNames, rootName)
-			baseRootIDs[rootName] = rootID
-			policies = append(policies, runtime.def.storagePolicy)
-			deltaTables = append(deltaTables, buildDeleteRootDeltaTable(deleteKeys))
-		}
-	}
-	_ = snap.Close()
-
-	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
-	defer func() {
-		for _, it := range iterators {
-			_ = it.Close()
-		}
-		resetCollectionTables(deltaTables)
-	}()
-	for i, rootName := range rootNames {
-		iter := deltaTables[i].NewIterator(nil, nil)
-		iterators = append(iterators, iter)
-		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      baseRootIDs[rootName],
-			Iter:          iter,
-			StoragePolicy: policies[i],
-		})
-	}
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
-	})
-	if err != nil {
-		return err
-	}
-	if len(rootIDs) != len(rootNames) {
-		return errors.New("collections: ordered root publish returned unexpected root count")
-	}
-	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
-	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
-	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
-	return nil
+	_, err := c.DeleteDocument(documentID)
+	return err
 }
 
-func (c *Collection) Replace(documentID, document []byte) (bool, error) {
+// DeleteDocument removes a document and reports whether this call deleted an
+// existing primary document.
+func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 	if c == nil {
 		return false, errCollectionNil
 	}
@@ -1199,6 +1074,19 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 		return false, err
 	}
 
+	var lastErr error
+	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
+		deleted, err := c.deleteDocumentOnce(documentID)
+		if errors.Is(err, ErrConcurrentMutation) {
+			lastErr = err
+			continue
+		}
+		return deleted, err
+	}
+	return false, lastErr
+}
+
+func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
 		return false, backenddb.ErrClosed
@@ -1244,22 +1132,193 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 		_ = snap.Close()
 		return false, err
 	}
+	var state documentIndexState
+	if len(runtimes) > 0 {
+		state, err = loadDeleteIndexState(snap, catalog, documentID, entry.Value, runtimes, plannerOptions)
+		if err != nil {
+			_ = snap.Close()
+			return false, err
+		}
+	}
+
+	rootNames := []string{collectionPrimaryRootName(c.meta.Name)}
+	baseRootIDs := map[string]uint64{
+		rootNames[0]: primaryRoot,
+	}
+	policies := []backenddb.OrderedRootStoragePolicy{plannerOptions.dataStoragePolicy}
+	deltaTables := make([]memtable.Table, 0, 2+len(runtimes))
+	deltaTables = append(deltaTables, buildDeleteRootDeltaTable([][]byte{documentID}))
+
+	if len(runtimes) > 0 {
+		stateRootName := collectionIndexStateRootName(c.meta.Name)
+		stateRootID := catalog.rootID(stateRootName)
+		if stateRootID != 0 {
+			rootNames = append(rootNames, stateRootName)
+			baseRootIDs[stateRootName] = stateRootID
+			policies = append(policies, plannerOptions.indexStateStoragePolicy)
+			deltaTables = append(deltaTables, buildDeleteRootDeltaTable([][]byte{documentID}))
+		}
+		for _, runtime := range runtimes {
+			deleteKeys, err := secondaryDeleteKeysForDocument(runtime, state, documentID)
+			if err != nil {
+				_ = snap.Close()
+				return false, err
+			}
+			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
+			rootID := catalog.rootID(rootName)
+			if rootID == 0 || len(deleteKeys) == 0 {
+				continue
+			}
+			rootNames = append(rootNames, rootName)
+			baseRootIDs[rootName] = rootID
+			policies = append(policies, runtime.def.storagePolicy)
+			deltaTables = append(deltaTables, buildDeleteRootDeltaTable(deleteKeys))
+		}
+	}
+	_ = snap.Close()
+
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	defer func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+		resetCollectionTables(deltaTables)
+	}()
+	for i, rootName := range rootNames {
+		iter := deltaTables[i].NewIterator(nil, nil)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot:      baseRootIDs[rootName],
+			Iter:          iter,
+			StoragePolicy: policies[i],
+		})
+	}
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(rootIDs) != len(rootNames) {
+		return false, errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return true, nil
+}
+
+func (c *Collection) Replace(documentID, document []byte) (bool, error) {
+	matched, _, err := c.Update(documentID, func([]byte) ([]byte, bool, error) {
+		return document, true, nil
+	})
+	return matched, err
+}
+
+// Update applies update to the latest document value and retries if another
+// collection write changes the root before this update publishes.
+func (c *Collection) Update(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
+	if c == nil {
+		return false, false, errCollectionNil
+	}
+	if c.db == nil {
+		return false, false, errors.New("collections: db is nil")
+	}
+	if len(documentID) == 0 {
+		return false, false, errors.New("collections: document id cannot be empty")
+	}
+	if update == nil {
+		return false, false, errors.New("collections: update function is nil")
+	}
+	if err := c.flushBufferedNoIndex(); err != nil {
+		return false, false, err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
+		matched, modified, err := c.updateDocumentOnce(documentID, update)
+		if errors.Is(err, ErrConcurrentMutation) {
+			lastErr = err
+			continue
+		}
+		return matched, modified, err
+	}
+	return false, false, lastErr
+}
+
+func (c *Collection) updateDocumentOnce(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return false, false, backenddb.ErrClosed
+	}
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		_ = snap.Close()
+		return false, false, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return false, false, errCollectionNotFound
+	}
+	c.meta = catalog.meta
+	plannerOptions, err := collectionPlannerOptions(c.meta)
+	if err != nil {
+		_ = snap.Close()
+		return false, false, err
+	}
+	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
+	baseSystemRoot := snapshotSystemRoot(snap)
+
+	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
+	if primaryRoot == 0 {
+		_ = snap.Close()
+		return false, false, nil
+	}
+	entry, err := snap.GetEntryAtRoot(primaryRoot, documentID)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		_ = snap.Close()
+		return false, false, nil
+	}
+	if err != nil {
+		_ = snap.Close()
+		return false, false, err
+	}
+
+	document, changed, err := update(bytes.Clone(entry.Value))
+	if err != nil {
+		_ = snap.Close()
+		return false, false, err
+	}
+	if !changed {
+		_ = snap.Close()
+		return true, false, nil
+	}
+
+	runtimes, err := (insertBatchPlanner{
+		collection: c.meta.Name,
+		indexes:    plannerIndexes(c.meta.Indexes),
+	}).indexRuntimes()
+	if err != nil {
+		_ = snap.Close()
+		return false, false, err
+	}
 	var oldState documentIndexState
 	var newState documentIndexState
 	if len(runtimes) > 0 {
 		oldState, err = loadDeleteIndexState(snap, catalog, documentID, entry.Value, runtimes, plannerOptions)
 		if err != nil {
 			_ = snap.Close()
-			return false, err
+			return false, false, err
 		}
 		newState, err = indexStateForDocument(document, runtimes, plannerOptions)
 		if err != nil {
 			_ = snap.Close()
-			return false, err
+			return false, false, err
 		}
 		if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, newState, documentID); err != nil {
 			_ = snap.Close()
-			return false, err
+			return false, false, err
 		}
 	}
 
@@ -1285,7 +1344,7 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 		if err != nil {
 			_ = snap.Close()
 			resetCollectionTables(append(deltaTables, stateTable))
-			return false, err
+			return false, false, err
 		}
 		if len(newState) == 0 {
 			stateTable.DeleteSteal(bytes.Clone(documentID))
@@ -1303,7 +1362,7 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 			if err != nil {
 				_ = snap.Close()
 				resetCollectionTables(append(deltaTables, table))
-				return false, err
+				return false, false, err
 			}
 			for _, key := range deleteKeys {
 				table.DeleteSteal(bytes.Clone(key))
@@ -1313,7 +1372,7 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 				if err != nil {
 					_ = snap.Close()
 					resetCollectionTables(append(deltaTables, table))
-					return false, err
+					return false, false, err
 				}
 				table.SetSteal(key, nil)
 			}
@@ -1351,15 +1410,15 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	if len(rootIDs) != len(rootNames) {
-		return false, errors.New("collections: ordered root publish returned unexpected root count")
+		return false, false, errors.New("collections: ordered root publish returned unexpected root count")
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
-	return true, nil
+	return true, true, nil
 }
 
 func (c *Collection) catalogForSnapshot(snap *backenddb.Snapshot) (*collectionCatalog, error) {
@@ -1658,7 +1717,7 @@ func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedSystemRoot u
 		}
 		for _, rootName := range rootNames {
 			if got, want := catalog.rootID(rootName), baseRootIDs[rootName]; got != want {
-				return nil, fmt.Errorf("collections: concurrent root modification detected for %q", rootName)
+				return nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
 			}
 		}
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2,10 +2,12 @@ package collections
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -1351,6 +1353,91 @@ func TestCollectionReplaceRejectsUniqueConflictAtomically(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateConcurrentCounterNoLostUpdates(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"count":0}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	const (
+		workers    = 8
+		increments = 5
+	)
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			workerCol, err := mgr.OpenCollection("users")
+			if err != nil {
+				errs <- err
+				return
+			}
+			<-start
+			for j := 0; j < increments; j++ {
+				if _, _, err := workerCol.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+					var doc struct {
+						Count int `json:"count"`
+					}
+					if err := json.Unmarshal(current, &doc); err != nil {
+						return nil, false, err
+					}
+					doc.Count++
+					next, err := json.Marshal(doc)
+					if err != nil {
+						return nil, false, err
+					}
+					return next, true, nil
+				}); err != nil {
+					errs <- err
+					return
+				}
+			}
+			errs <- nil
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("update: %v", err)
+		}
+	}
+
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get counter: %v", err)
+	}
+	var doc struct {
+		Count int `json:"count"`
+	}
+	if err := json.Unmarshal(got, &doc); err != nil {
+		t.Fatalf("unmarshal counter: %v", err)
+	}
+	if want := workers * increments; doc.Count != want {
+		t.Fatalf("count=%d want %d", doc.Count, want)
+	}
+}
+
 func TestCollectionInsertBatchBridge_RejectsPersistedUniqueConflictAtomically(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -1498,8 +1585,26 @@ func TestCollectionDeleteBridge_RemovesPrimaryAndSecondaryEntries(t *testing.T) 
 		t.Fatalf("insert batch: %v", err)
 	}
 
-	if err := col.Delete([]byte("u1")); err != nil {
+	deleted, err := col.DeleteDocument([]byte("missing"))
+	if err != nil {
+		t.Fatalf("delete missing: %v", err)
+	}
+	if deleted {
+		t.Fatal("delete missing reported deleted")
+	}
+	deleted, err = col.DeleteDocument([]byte("u1"))
+	if err != nil {
 		t.Fatalf("delete u1: %v", err)
+	}
+	if !deleted {
+		t.Fatal("delete u1 reported not deleted")
+	}
+	deleted, err = col.DeleteDocument([]byte("u1"))
+	if err != nil {
+		t.Fatalf("delete u1 again: %v", err)
+	}
+	if deleted {
+		t.Fatal("delete u1 again reported deleted")
 	}
 	got, err := col.Get([]byte("u1"))
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1351,6 +1351,25 @@ func TestCollectionReplaceRejectsUniqueConflictAtomically(t *testing.T) {
 	if len(ids) != 0 {
 		t.Fatalf("old email ids=%q want none", ids)
 	}
+
+	beforeState := d.State()
+	if beforeState == nil {
+		t.Fatal("missing db state before identical replace")
+	}
+	replaced, err = col.Replace([]byte("u1"), []byte(`{"email":"ada2@example.com","city":"hnl"}`))
+	if err != nil {
+		t.Fatalf("replace identical: %v", err)
+	}
+	if !replaced {
+		t.Fatal("replace identical reported false")
+	}
+	afterState := d.State()
+	if afterState == nil {
+		t.Fatal("missing db state after identical replace")
+	}
+	if afterState.SystemRootPageID != beforeState.SystemRootPageID {
+		t.Fatalf("identical replace changed system root from %d to %d", beforeState.SystemRootPageID, afterState.SystemRootPageID)
+	}
 }
 
 func TestCollectionUpdateConcurrentCounterNoLostUpdates(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1285,6 +1285,72 @@ func TestCollectionCreateIndexBackfill_RejectsUniqueConflictAtomically(t *testin
 	}
 }
 
+func TestCollectionReplaceRejectsUniqueConflictAtomically(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com","city":"hnl"}`),
+			[]byte(`{"email":"grace@example.com","city":"sfo"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	replaced, err := col.Replace([]byte("u1"), []byte(`{"email":"grace@example.com","city":"hnl"}`))
+	if !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("replace err=%v want ErrUniqueIndexConflict", err)
+	}
+	if replaced {
+		t.Fatal("replace reported success on unique conflict")
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1 after failed replace: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("u1 after failed replace=%q want %q", got, want)
+	}
+
+	replaced, err = col.Replace([]byte("u1"), []byte(`{"email":"ada2@example.com","city":"hnl"}`))
+	if err != nil {
+		t.Fatalf("replace valid: %v", err)
+	}
+	if !replaced {
+		t.Fatal("replace valid reported false")
+	}
+	ids, err := col.FindByIndex("email", "ada2@example.com")
+	if err != nil {
+		t.Fatalf("find replacement email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("replacement email ids=%q want u1", ids)
+	}
+	ids, err = col.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find old email: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("old email ids=%q want none", ids)
+	}
+}
+
 func TestCollectionInsertBatchBridge_RejectsPersistedUniqueConflictAtomically(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -188,33 +188,27 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("updates[%d]: %v", i, err))
 		}
 
-		stored, err := col.Get(key)
-		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
-		}
-		if len(stored) == 0 {
-			continue
-		}
-		raw, err := storedDocumentToBSON(stored)
-		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
-		}
-		updated, changed, err := applySetUpdate(raw, updateDoc)
-		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: %v", i, err))
-		}
-		updatedKey, encoded, err := prepareInsertDocument(updated)
-		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: %v", i, err))
-		}
-		if !bytes.Equal(updatedKey, key) {
-			return commandError(commandCodeBadValue, "BadValue", "Mongo gateway update cannot modify _id")
-		}
-		matched++
-		if !changed {
-			continue
-		}
-		replaced, err := col.Replace(key, encoded)
+		matchedOne, modifiedOne, err := col.Update(key, func(stored []byte) ([]byte, bool, error) {
+			raw, err := storedDocumentToBSON(stored)
+			if err != nil {
+				return nil, false, err
+			}
+			updated, changed, err := applySetUpdate(raw, updateDoc)
+			if err != nil {
+				return nil, false, fmt.Errorf("updates[%d]: %w", i, err)
+			}
+			updatedKey, encoded, err := prepareInsertDocument(updated)
+			if err != nil {
+				return nil, false, fmt.Errorf("updates[%d]: %w", i, err)
+			}
+			if !bytes.Equal(updatedKey, key) {
+				return nil, false, errors.New("Mongo gateway update cannot modify _id")
+			}
+			if !changed {
+				return nil, false, nil
+			}
+			return encoded, true, nil
+		})
 		if err != nil {
 			code, codeName := commandCodeBadValue, "BadValue"
 			if collections.IsDuplicateKeyError(err) {
@@ -222,7 +216,10 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 			}
 			return commandError(code, codeName, err.Error())
 		}
-		if replaced {
+		if matchedOne {
+			matched++
+		}
+		if modifiedOne {
 			modified++
 		}
 	}
@@ -277,17 +274,13 @@ func (s *Server) deleteResponse(command wire.Document, sequences []wire.Document
 		if err != nil {
 			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("deletes[%d]: %v", i, err))
 		}
-		stored, err := col.Get(key)
+		deletedOne, err := col.DeleteDocument(key)
 		if err != nil {
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
 		}
-		if len(stored) == 0 {
-			continue
+		if deletedOne {
+			deleted++
 		}
-		if err := col.Delete(key); err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
-		}
-		deleted++
 	}
 	return marshalDeleteResponse(deleted)
 }

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -210,18 +210,19 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 		if !bytes.Equal(updatedKey, key) {
 			return commandError(commandCodeBadValue, "BadValue", "Mongo gateway update cannot modify _id")
 		}
-		if err := col.Delete(key); err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		matched++
+		if !changed {
+			continue
 		}
-		if _, err := col.Insert(key, encoded); err != nil {
+		replaced, err := col.Replace(key, encoded)
+		if err != nil {
 			code, codeName := commandCodeBadValue, "BadValue"
 			if collections.IsDuplicateKeyError(err) {
 				code, codeName = commandCodeDuplicateKey, "DuplicateKey"
 			}
 			return commandError(code, codeName, err.Error())
 		}
-		matched++
-		if changed {
+		if replaced {
 			modified++
 		}
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -598,7 +597,6 @@ func parseSetDocument(doc bson.Raw) (map[string]bson.RawValue, []string, error) 
 		}
 		sets[key] = value
 	}
-	sort.Strings(order)
 	return sets, order, nil
 }
 

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1,8 +1,10 @@
 package mongogateway
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -90,7 +92,7 @@ func (s *Server) findResponse(command wire.Document) (wire.Document, error) {
 	if filter == nil {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway find currently requires an _id equality filter")
 	}
-	id, err := idEqualityFilterValue(filter)
+	id, err := idEqualityFilterValue(filter, "find")
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
@@ -124,6 +126,183 @@ func (s *Server) findResponse(command wire.Document) (wire.Document, error) {
 			{Key: "firstBatch", Value: firstBatch},
 		}},
 		{Key: "ok", Value: 1.0},
+	})
+}
+
+func (s *Server) updateResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+	if s.Collections == nil {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+	}
+	collection, err := commandString(command, "update")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	updates, err := commandDocuments(command, sequences, "updates")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+
+	var matched int32
+	var modified int32
+	col, err := s.Collections.OpenCollection(name)
+	if err != nil {
+		if errors.Is(err, collections.ErrCollectionNotFound) {
+			return marshalUpdateResponse(0, 0)
+		}
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+
+	for i, update := range updates {
+		filter, err := requiredDocumentField(update, "q")
+		if err != nil {
+			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("updates[%d]: %v", i, err))
+		}
+		id, err := idEqualityFilterValue(filter, "update")
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: %v", i, err))
+		}
+		key, err := encodePrimaryKey(id)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: %v", i, err))
+		}
+		if multi, err := optionalBoolField(update, "multi"); err != nil {
+			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("updates[%d]: %v", i, err))
+		} else if multi {
+			return commandError(commandCodeBadValue, "BadValue", "Mongo gateway update currently supports updateOne only")
+		}
+		if upsert, err := optionalBoolField(update, "upsert"); err != nil {
+			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("updates[%d]: %v", i, err))
+		} else if upsert {
+			return commandError(commandCodeBadValue, "BadValue", "Mongo gateway update currently does not support upsert")
+		}
+		updateDoc, err := requiredDocumentField(update, "u")
+		if err != nil {
+			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("updates[%d]: %v", i, err))
+		}
+
+		stored, err := col.Get(key)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		if len(stored) == 0 {
+			continue
+		}
+		raw, err := storedDocumentToBSON(stored)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		updated, changed, err := applySetUpdate(raw, updateDoc)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: %v", i, err))
+		}
+		updatedKey, encoded, err := prepareInsertDocument(updated)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: %v", i, err))
+		}
+		if !bytes.Equal(updatedKey, key) {
+			return commandError(commandCodeBadValue, "BadValue", "Mongo gateway update cannot modify _id")
+		}
+		if err := col.Delete(key); err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		if _, err := col.Insert(key, encoded); err != nil {
+			code, codeName := commandCodeBadValue, "BadValue"
+			if collections.IsDuplicateKeyError(err) {
+				code, codeName = commandCodeDuplicateKey, "DuplicateKey"
+			}
+			return commandError(code, codeName, err.Error())
+		}
+		matched++
+		if changed {
+			modified++
+		}
+	}
+	return marshalUpdateResponse(matched, modified)
+}
+
+func (s *Server) deleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+	if s.Collections == nil {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+	}
+	collection, err := commandString(command, "delete")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	deletes, err := commandDocuments(command, sequences, "deletes")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+
+	col, err := s.Collections.OpenCollection(name)
+	if err != nil {
+		if errors.Is(err, collections.ErrCollectionNotFound) {
+			return marshalDeleteResponse(0)
+		}
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+
+	var deleted int32
+	for i, deleteItem := range deletes {
+		filter, err := requiredDocumentField(deleteItem, "q")
+		if err != nil {
+			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("deletes[%d]: %v", i, err))
+		}
+		id, err := idEqualityFilterValue(filter, "delete")
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("deletes[%d]: %v", i, err))
+		}
+		if limit, err := optionalInt32Field(deleteItem, "limit"); err != nil {
+			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("deletes[%d]: %v", i, err))
+		} else if limit != 0 && limit != 1 {
+			return commandError(commandCodeBadValue, "BadValue", "Mongo gateway delete limit must be 0 or 1")
+		}
+		key, err := encodePrimaryKey(id)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("deletes[%d]: %v", i, err))
+		}
+		stored, err := col.Get(key)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		if len(stored) == 0 {
+			continue
+		}
+		if err := col.Delete(key); err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		deleted++
+	}
+	return marshalDeleteResponse(deleted)
+}
+
+func marshalUpdateResponse(matched, modified int32) (wire.Document, error) {
+	return marshalDocument(bson.D{
+		{Key: "ok", Value: 1.0},
+		{Key: "n", Value: matched},
+		{Key: "nModified", Value: modified},
+	})
+}
+
+func marshalDeleteResponse(deleted int32) (wire.Document, error) {
+	return marshalDocument(bson.D{
+		{Key: "ok", Value: 1.0},
+		{Key: "n", Value: deleted},
 	})
 }
 
@@ -163,6 +342,47 @@ func commandOptionalDocument(doc wire.Document, key string) (wire.Document, erro
 		return nil, fmt.Errorf("Mongo command field %q must be a document", key)
 	}
 	return wire.Document(out), nil
+}
+
+func requiredDocumentField(doc wire.Document, key string) (wire.Document, error) {
+	value := bson.Raw(doc).Lookup(key)
+	if value.IsZero() {
+		return nil, fmt.Errorf("Mongo command missing %q", key)
+	}
+	out, ok := value.DocumentOK()
+	if !ok {
+		return nil, fmt.Errorf("Mongo command field %q must be a document", key)
+	}
+	return wire.Document(out), nil
+}
+
+func optionalBoolField(doc wire.Document, key string) (bool, error) {
+	value := bson.Raw(doc).Lookup(key)
+	if value.IsZero() {
+		return false, nil
+	}
+	out, ok := value.BooleanOK()
+	if !ok {
+		return false, fmt.Errorf("Mongo command field %q must be a boolean", key)
+	}
+	return out, nil
+}
+
+func optionalInt32Field(doc wire.Document, key string) (int32, error) {
+	value := bson.Raw(doc).Lookup(key)
+	if value.IsZero() {
+		return 0, nil
+	}
+	if out, ok := value.Int32OK(); ok {
+		return out, nil
+	}
+	if out, ok := value.Int64OK(); ok {
+		if out < 0 || out > int64(^uint32(0)>>1) {
+			return 0, fmt.Errorf("Mongo command field %q is out of int32 range", key)
+		}
+		return int32(out), nil
+	}
+	return 0, fmt.Errorf("Mongo command field %q must be an integer", key)
 }
 
 func commandDocumentArray(doc wire.Document, key string) ([]wire.Document, error) {
@@ -210,20 +430,20 @@ func commandDocuments(doc wire.Document, sequences []wire.DocumentSequence, key 
 	return commandDocumentArray(doc, key)
 }
 
-func idEqualityFilterValue(filter wire.Document) (bson.RawValue, error) {
+func idEqualityFilterValue(filter wire.Document, commandName string) (bson.RawValue, error) {
 	elements, err := bson.Raw(filter).Elements()
 	if err != nil {
 		return bson.RawValue{}, err
 	}
 	if len(elements) != 1 {
-		return bson.RawValue{}, errors.New("Mongo gateway find currently supports exactly one _id equality predicate")
+		return bson.RawValue{}, fmt.Errorf("Mongo gateway %s currently supports exactly one _id equality predicate", commandName)
 	}
 	key, err := elements[0].KeyErr()
 	if err != nil {
 		return bson.RawValue{}, err
 	}
 	if key != "_id" {
-		return bson.RawValue{}, errors.New("Mongo gateway find currently requires an _id equality filter")
+		return bson.RawValue{}, fmt.Errorf("Mongo gateway %s currently requires an _id equality filter", commandName)
 	}
 	return elements[0].Value(), nil
 }
@@ -284,6 +504,108 @@ func storedDocumentToBSON(stored []byte) (wire.Document, error) {
 		return nil, err
 	}
 	return wire.Document(raw), nil
+}
+
+func applySetUpdate(doc wire.Document, update wire.Document) (wire.Document, bool, error) {
+	updateElements, err := bson.Raw(update).Elements()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(updateElements) != 1 {
+		return nil, false, errors.New("Mongo gateway update currently supports exactly one $set operator")
+	}
+	operator, err := updateElements[0].KeyErr()
+	if err != nil {
+		return nil, false, err
+	}
+	if operator != "$set" {
+		return nil, false, errors.New("Mongo gateway update currently supports $set only")
+	}
+	setDoc, ok := updateElements[0].Value().DocumentOK()
+	if !ok {
+		return nil, false, errors.New("Mongo gateway $set value must be a document")
+	}
+	sets, setOrder, err := parseSetDocument(setDoc)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(sets) == 0 {
+		return doc, false, nil
+	}
+
+	elements, err := bson.Raw(doc).Elements()
+	if err != nil {
+		return nil, false, err
+	}
+	out := make(bson.D, 0, len(elements)+len(sets))
+	used := make(map[string]struct{}, len(sets))
+	changed := false
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, false, err
+		}
+		value := elem.Value()
+		if replacement, ok := sets[key]; ok {
+			if !replacement.Equal(value) {
+				changed = true
+			}
+			value = replacement
+			used[key] = struct{}{}
+		}
+		out = append(out, bson.E{Key: key, Value: value})
+	}
+	for _, key := range setOrder {
+		if _, ok := used[key]; ok {
+			continue
+		}
+		out = append(out, bson.E{Key: key, Value: sets[key]})
+		changed = true
+	}
+	raw, err := bson.Marshal(out)
+	if err != nil {
+		return nil, false, err
+	}
+	return wire.Document(raw), changed, nil
+}
+
+func parseSetDocument(doc bson.Raw) (map[string]bson.RawValue, []string, error) {
+	elements, err := doc.Elements()
+	if err != nil {
+		return nil, nil, err
+	}
+	sets := make(map[string]bson.RawValue, len(elements))
+	order := make([]string, 0, len(elements))
+	seen := make(map[string]struct{}, len(elements))
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, nil, err
+		}
+		if key == "" {
+			return nil, nil, errors.New("Mongo gateway $set field name cannot be empty")
+		}
+		if key == "_id" {
+			return nil, nil, errors.New("Mongo gateway update cannot modify _id")
+		}
+		if strings.Contains(key, ".") {
+			return nil, nil, errors.New("Mongo gateway $set currently supports top-level fields only")
+		}
+		if strings.HasPrefix(key, "$") {
+			return nil, nil, errors.New("Mongo gateway $set field names cannot start with $")
+		}
+		value := elem.Value()
+		if err := validateSupportedValue(key, value); err != nil {
+			return nil, nil, err
+		}
+		if _, ok := seen[key]; !ok {
+			order = append(order, key)
+			seen[key] = struct{}{}
+		}
+		sets[key] = value
+	}
+	sort.Strings(order)
+	return sets, order, nil
 }
 
 func encodePrimaryKey(value bson.RawValue) ([]byte, error) {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -133,6 +133,10 @@ func (s *Server) commandResponse(name string, command wire.Document, sequences [
 		return s.insertResponse(command, sequences)
 	case "find":
 		return s.findResponse(command)
+	case "update":
+		return s.updateResponse(command, sequences)
+	case "delete":
+		return s.deleteResponse(command, sequences)
 	default:
 		return commandError(59, "CommandNotFound", "unsupported MongoDB gateway command: "+name)
 	}

--- a/TreeDB/mongo_gateway/server_driver_test.go
+++ b/TreeDB/mongo_gateway/server_driver_test.go
@@ -14,7 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
-func TestServerOfficialGoDriverInsertAndFindOne(t *testing.T) {
+func TestServerOfficialGoDriverBasicCRUD(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -87,6 +87,42 @@ func TestServerOfficialGoDriverInsertAndFindOne(t *testing.T) {
 	}
 	if got["age"] != int64(37) {
 		t.Fatalf("decoded age=%v want 37", got["age"])
+	}
+
+	updateResult, err := coll.UpdateOne(opCtx,
+		bson.D{{Key: "_id", Value: id}},
+		bson.D{{Key: "$set", Value: bson.D{
+			{Key: "age", Value: int64(38)},
+			{Key: "city", Value: "London"},
+		}}},
+	)
+	if err != nil {
+		t.Fatalf("driver update one: %v", err)
+	}
+	if updateResult.MatchedCount != 1 || updateResult.ModifiedCount != 1 {
+		t.Fatalf("update result matched=%d modified=%d want 1/1", updateResult.MatchedCount, updateResult.ModifiedCount)
+	}
+
+	got = nil
+	if err := coll.FindOne(opCtx, bson.D{{Key: "_id", Value: id}}).Decode(&got); err != nil {
+		t.Fatalf("driver find one after update: %v", err)
+	}
+	if got["age"] != int64(38) {
+		t.Fatalf("decoded updated age=%v want 38", got["age"])
+	}
+	if got["city"] != "London" {
+		t.Fatalf("decoded city=%v want London", got["city"])
+	}
+
+	deleteResult, err := coll.DeleteOne(opCtx, bson.D{{Key: "_id", Value: id}})
+	if err != nil {
+		t.Fatalf("driver delete one: %v", err)
+	}
+	if deleteResult.DeletedCount != 1 {
+		t.Fatalf("delete result deleted=%d want 1", deleteResult.DeletedCount)
+	}
+	if err := coll.FindOne(opCtx, bson.D{{Key: "_id", Value: id}}).Decode(&got); !errors.Is(err, mongo.ErrNoDocuments) {
+		t.Fatalf("driver find one after delete err=%v want ErrNoDocuments", err)
 	}
 
 	cancel()

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -215,7 +215,21 @@ func TestServerUpdateAndDeleteByID(t *testing.T) {
 	assertInt32(t, updateResponse, "n", 1)
 	assertInt32(t, updateResponse, "nModified", 1)
 
-	findResponse := serveCommand(t, server, 222, bson.D{
+	noopResponse := serveCommand(t, server, 222, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: id}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{
+				{Key: "age", Value: int64(38)},
+			}}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, noopResponse)
+	assertInt32(t, noopResponse, "n", 1)
+	assertInt32(t, noopResponse, "nModified", 0)
+
+	findResponse := serveCommand(t, server, 223, bson.D{
 		{Key: "find", Value: "users"},
 		{Key: "filter", Value: bson.D{{Key: "_id", Value: id}}},
 		{Key: "$db", Value: "app"},
@@ -233,7 +247,7 @@ func TestServerUpdateAndDeleteByID(t *testing.T) {
 		t.Fatalf("firstBatch city=%q ok=%v want London", gotCity, ok)
 	}
 
-	deleteResponse := serveCommand(t, server, 223, bson.D{
+	deleteResponse := serveCommand(t, server, 224, bson.D{
 		{Key: "delete", Value: "users"},
 		{Key: "deletes", Value: bson.A{bson.D{
 			{Key: "q", Value: bson.D{{Key: "_id", Value: id}}},
@@ -244,7 +258,7 @@ func TestServerUpdateAndDeleteByID(t *testing.T) {
 	assertOK(t, deleteResponse)
 	assertInt32(t, deleteResponse, "n", 1)
 
-	afterDelete := serveCommand(t, server, 224, bson.D{
+	afterDelete := serveCommand(t, server, 225, bson.D{
 		{Key: "find", Value: "users"},
 		{Key: "filter", Value: bson.D{{Key: "_id", Value: id}}},
 		{Key: "$db", Value: "app"},

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -177,6 +177,116 @@ func TestServerInsertAndFindByID(t *testing.T) {
 	assertBool(t, firstBatch[0], "active", true)
 }
 
+func TestServerUpdateAndDeleteByID(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	id := bson.NewObjectID()
+	insertResponse := serveCommand(t, server, 220, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{
+			{Key: "_id", Value: id},
+			{Key: "name", Value: "ada"},
+			{Key: "age", Value: int64(37)},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, insertResponse)
+
+	updateResponse := serveCommand(t, server, 221, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: id}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{
+				{Key: "age", Value: int64(38)},
+				{Key: "city", Value: "London"},
+			}}}},
+			{Key: "multi", Value: false},
+			{Key: "upsert", Value: false},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, updateResponse)
+	assertInt32(t, updateResponse, "n", 1)
+	assertInt32(t, updateResponse, "nModified", 1)
+
+	findResponse := serveCommand(t, server, 222, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: id}}},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch := cursorFirstBatch(t, findResponse)
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	gotAge, ok := firstBatch[0].Lookup("age").Int64OK()
+	if !ok || gotAge != 38 {
+		t.Fatalf("firstBatch age=%d ok=%v want 38", gotAge, ok)
+	}
+	gotCity, ok := firstBatch[0].Lookup("city").StringValueOK()
+	if !ok || gotCity != "London" {
+		t.Fatalf("firstBatch city=%q ok=%v want London", gotCity, ok)
+	}
+
+	deleteResponse := serveCommand(t, server, 223, bson.D{
+		{Key: "delete", Value: "users"},
+		{Key: "deletes", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: id}}},
+			{Key: "limit", Value: int32(1)},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, deleteResponse)
+	assertInt32(t, deleteResponse, "n", 1)
+
+	afterDelete := serveCommand(t, server, 224, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: id}}},
+		{Key: "$db", Value: "app"},
+	})
+	if firstBatch := cursorFirstBatch(t, afterDelete); len(firstBatch) != 0 {
+		t.Fatalf("firstBatch len=%d want 0", len(firstBatch))
+	}
+}
+
+func TestServerUpdateRejectsIDMutation(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	id := bson.NewObjectID()
+	insertResponse := serveCommand(t, server, 225, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{
+			{Key: "_id", Value: id},
+			{Key: "name", Value: "ada"},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, insertResponse)
+
+	updateResponse := serveCommand(t, server, 226, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: id}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{
+				{Key: "_id", Value: bson.NewObjectID()},
+			}}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, updateResponse, "BadValue")
+}
+
 func TestServerFindByIDMissingCollectionReturnsEmptyBatch(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -317,6 +427,20 @@ func mustDocument(tb testing.TB, doc bson.D) wire.Document {
 		tb.Fatalf("marshal BSON document: %v", err)
 	}
 	return wire.Document(raw)
+}
+
+func serveCommand(tb testing.TB, server *Server, requestID int32, doc bson.D) wire.Document {
+	tb.Helper()
+	commandDoc := mustDocument(tb, doc)
+	req, err := wire.AppendMsgMessage(nil, requestID, 0, 0, commandDoc)
+	if err != nil {
+		tb.Fatalf("AppendMsgMessage: %v", err)
+	}
+	rw := &readWriter{r: bytes.NewReader(req)}
+	if err := server.ServeOne(rw); err != nil {
+		tb.Fatalf("ServeOne: %v", err)
+	}
+	return readMsgResponse(tb, rw.w.Bytes(), requestID)
 }
 
 func assertOK(tb testing.TB, doc wire.Document) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -301,6 +301,51 @@ func TestServerUpdateRejectsIDMutation(t *testing.T) {
 	assertCommandError(t, updateResponse, "BadValue")
 }
 
+func TestApplySetUpdateAppendsNewFieldsInSetOrder(t *testing.T) {
+	doc, err := bson.Marshal(bson.D{
+		{Key: "_id", Value: "u1"},
+		{Key: "name", Value: "ada"},
+	})
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	update, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{
+		{Key: "zeta", Value: int32(1)},
+		{Key: "alpha", Value: int32(2)},
+	}}})
+	if err != nil {
+		t.Fatalf("marshal update: %v", err)
+	}
+	updated, changed, err := applySetUpdate(wire.Document(doc), wire.Document(update))
+	if err != nil {
+		t.Fatalf("apply set: %v", err)
+	}
+	if !changed {
+		t.Fatal("apply set changed=false want true")
+	}
+	elements, err := bson.Raw(updated).Elements()
+	if err != nil {
+		t.Fatalf("updated elements: %v", err)
+	}
+	keys := make([]string, 0, len(elements))
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			t.Fatalf("element key: %v", err)
+		}
+		keys = append(keys, key)
+	}
+	want := []string{"_id", "name", "zeta", "alpha"}
+	if len(keys) != len(want) {
+		t.Fatalf("keys=%v want %v", keys, want)
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("keys=%v want %v", keys, want)
+		}
+	}
+}
+
 func TestServerFindByIDMissingCollectionReturnsEmptyBatch(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds the next Mongo gateway CRUD slice:

- supports Mongo `update` commands for exact `_id` equality filters with a single `$set` update document
- supports Mongo `delete` commands for exact `_id` equality filters
- rejects unsupported MVP behavior clearly, including upsert, multi-update, dotted `$set` paths, and `_id` mutation
- extends the official Go driver smoke test from insert/find to a full insert/find/update/delete loop

## Validation

- `GOWORK=off go test ./TreeDB/mongo_gateway/... -count=1`
