### PR TITLE
[codex] Add Mongo gateway collection index metadata commands

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -584,14 +584,17 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 	_ = snap.Close()
 
 	nextIndexes := make([]IndexDefinition, 0, len(baseMeta.Indexes))
+	clearedRootNames := make([]string, 0, len(baseMeta.Indexes)+1)
 	dropped := 0
 	for _, idx := range baseMeta.Indexes {
 		if all {
 			dropped++
+			clearedRootNames = append(clearedRootNames, collectionSecondaryRootName(baseMeta.Name, idx.Name))
 			continue
 		}
 		if _, ok := names[idx.Name]; ok {
 			dropped++
+			clearedRootNames = append(clearedRootNames, collectionSecondaryRootName(baseMeta.Name, idx.Name))
 			continue
 		}
 		nextIndexes = append(nextIndexes, idx)
@@ -613,18 +616,22 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 	if err != nil {
 		return nil, err
 	}
+	if len(newMeta.Indexes) == 0 {
+		clearedRootNames = append(clearedRootNames, collectionIndexStateRootName(baseMeta.Name))
+	}
 	encodedMeta, err := encodeCollectionMeta(newMeta)
 	if err != nil {
 		return nil, err
 	}
 	newSystemRoot, _, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
-		return c.buildSchemaOnlySystemDeltaIterator(baseMeta, encodedMeta)
+		return c.buildSchemaOnlySystemDeltaIterator(baseMeta, encodedMeta, clearedRootNames)
 	})
 	if err != nil {
 		return nil, err
 	}
 	c.meta = newMeta
-	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, nil, nil)
+	clearedRootIDs := make([]uint64, len(clearedRootNames))
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, clearedRootNames, clearedRootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	return newMeta.copy(), nil
@@ -1938,7 +1945,7 @@ func (c *Collection) buildSchemaAndRootDescriptorSystemIterator(
 	return buildSystemTargetIterator(current, updates)
 }
 
-func (c *Collection) buildSchemaOnlySystemDeltaIterator(baseMeta CollectionMeta, encodedMeta []byte) (iterator.UnsafeIterator, error) {
+func (c *Collection) buildSchemaOnlySystemDeltaIterator(baseMeta CollectionMeta, encodedMeta []byte, clearedRootNames []string) (iterator.UnsafeIterator, error) {
 	current := c.db.AcquireSnapshot()
 	if current == nil {
 		return nil, backenddb.ErrClosed
@@ -1954,9 +1961,13 @@ func (c *Collection) buildSchemaOnlySystemDeltaIterator(baseMeta CollectionMeta,
 	if !sameCollectionMeta(catalog.meta, baseMeta) {
 		return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", baseMeta.Name)
 	}
-	return buildSystemDeltaIterator(map[string][]byte{
+	updates := map[string][]byte{
 		systemCollectionMetaKey(baseMeta.Name): encodedMeta,
-	})
+	}
+	for _, rootName := range clearedRootNames {
+		updates[systemCollectionRootKey(rootName)] = encodeRootID(0)
+	}
+	return buildSystemDeltaIterator(updates)
 }
 
 func loadDeleteIndexState(snap *backenddb.Snapshot, catalog *collectionCatalog, documentID, document []byte, runtimes []indexRuntime, opts collectionOptions) (documentIndexState, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -27,6 +27,7 @@ var (
 	ErrCollectionNotFound  = errors.New("collections: collection not found")
 	ErrDocumentExists      = errors.New("collections: document already exists")
 	ErrDuplicateDocumentID = errors.New("collections: duplicate document id in batch")
+	ErrIndexNotFound       = errors.New("collections: index not found")
 	ErrUniqueIndexConflict = errors.New("collections: unique index conflict")
 
 	errCollectionManagerNil = errors.New("collections: collection manager is nil")
@@ -384,6 +385,55 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 	return collection, nil
 }
 
+func (m *CollectionManager) ListCollections() ([]CollectionMeta, error) {
+	if m == nil {
+		return nil, errCollectionManagerNil
+	}
+	if m.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
+	snap := m.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	if snap.State() == nil || snap.State().SystemRootPageID == 0 {
+		return nil, nil
+	}
+	prefix := []byte(systemCollectionMetaPrefix)
+	it, err := snap.IteratorAtRoot(snap.State().SystemRootPageID, prefix, prefixEnd(prefix))
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = it.Close() }()
+
+	var out []CollectionMeta
+	for it.Valid() {
+		key := it.UnsafeKey()
+		if !bytes.HasPrefix(key, prefix) {
+			break
+		}
+		if !it.IsDeleted() {
+			meta, err := decodeCollectionMeta(it.ValueCopy(nil))
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, meta)
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
 func (c *Collection) Name() string {
 	if c == nil {
 		return ""
@@ -484,6 +534,92 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 	}
 	c.meta = newMeta
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, plan.rootNames, rootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return newMeta.copy(), nil
+}
+
+func (c *Collection) DropIndex(name string) (*CollectionMeta, error) {
+	if err := ValidateIndexName(name); err != nil {
+		return nil, err
+	}
+	return c.dropIndexes(map[string]struct{}{name: {}}, false)
+}
+
+func (c *Collection) DropAllIndexes() (*CollectionMeta, error) {
+	return c.dropIndexes(nil, true)
+}
+
+func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*CollectionMeta, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
+	if err := c.flushBufferedNoIndex(); err != nil {
+		return nil, err
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return nil, errCollectionNotFound
+	}
+	baseMeta := catalog.meta
+	baseSystemRoot := snapshotSystemRoot(snap)
+	_ = snap.Close()
+
+	nextIndexes := make([]IndexDefinition, 0, len(baseMeta.Indexes))
+	dropped := 0
+	for _, idx := range baseMeta.Indexes {
+		if all {
+			dropped++
+			continue
+		}
+		if _, ok := names[idx.Name]; ok {
+			dropped++
+			continue
+		}
+		nextIndexes = append(nextIndexes, idx)
+	}
+	if !all && dropped != len(names) {
+		return nil, ErrIndexNotFound
+	}
+	if dropped == 0 {
+		c.meta = baseMeta
+		c.rememberCatalogAtSystemRoot(baseSystemRoot, catalog)
+		return baseMeta.copy(), nil
+	}
+
+	newMeta, err := normalizeCollectionMeta(CollectionMeta{
+		Name:    baseMeta.Name,
+		Options: baseMeta.Options,
+		Indexes: nextIndexes,
+	})
+	if err != nil {
+		return nil, err
+	}
+	encodedMeta, err := encodeCollectionMeta(newMeta)
+	if err != nil {
+		return nil, err
+	}
+	newSystemRoot, _, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+		return c.buildSchemaOnlySystemDeltaIterator(baseMeta, encodedMeta)
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.meta = newMeta
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, nil, nil)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	return newMeta.copy(), nil
@@ -1716,6 +1852,27 @@ func (c *Collection) buildSchemaAndRootDescriptorSystemIterator(
 		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
 	}
 	return buildSystemTargetIterator(current, updates)
+}
+
+func (c *Collection) buildSchemaOnlySystemDeltaIterator(baseMeta CollectionMeta, encodedMeta []byte) (iterator.UnsafeIterator, error) {
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	catalog, err := loadCollectionCatalog(current, baseMeta.Name)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	if !sameCollectionMeta(catalog.meta, baseMeta) {
+		return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", baseMeta.Name)
+	}
+	return buildSystemDeltaIterator(map[string][]byte{
+		systemCollectionMetaKey(baseMeta.Name): encodedMeta,
+	})
 }
 
 func loadDeleteIndexState(snap *backenddb.Snapshot, catalog *collectionCatalog, documentID, document []byte, runtimes []indexRuntime, opts collectionOptions) (documentIndexState, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -551,6 +551,20 @@ func (c *Collection) DropIndex(name string) (*CollectionMeta, error) {
 	return c.dropIndexes(map[string]struct{}{name: {}}, false)
 }
 
+func (c *Collection) DropIndexes(names []string) (*CollectionMeta, error) {
+	if len(names) == 0 {
+		return nil, ErrIndexNotFound
+	}
+	nameSet := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if err := ValidateIndexName(name); err != nil {
+			return nil, err
+		}
+		nameSet[name] = struct{}{}
+	}
+	return c.dropIndexes(nameSet, false)
+}
+
 func (c *Collection) DropAllIndexes() (*CollectionMeta, error) {
 	return c.dropIndexes(nil, true)
 }
@@ -580,6 +594,7 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 		return nil, errCollectionNotFound
 	}
 	baseMeta := catalog.meta
+	c.meta = baseMeta
 	baseSystemRoot := snapshotSystemRoot(snap)
 	_ = snap.Close()
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -27,6 +27,7 @@ var (
 	ErrCollectionNotFound  = errors.New("collections: collection not found")
 	ErrDocumentExists      = errors.New("collections: document already exists")
 	ErrDuplicateDocumentID = errors.New("collections: duplicate document id in batch")
+	ErrIndexNotFound       = errors.New("collections: index not found")
 	ErrUniqueIndexConflict = errors.New("collections: unique index conflict")
 
 	errCollectionManagerNil = errors.New("collections: collection manager is nil")
@@ -384,6 +385,55 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 	return collection, nil
 }
 
+func (m *CollectionManager) ListCollections() ([]CollectionMeta, error) {
+	if m == nil {
+		return nil, errCollectionManagerNil
+	}
+	if m.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
+	snap := m.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	if snap.State() == nil || snap.State().SystemRootPageID == 0 {
+		return nil, nil
+	}
+	prefix := []byte(systemCollectionMetaPrefix)
+	it, err := snap.IteratorAtRoot(snap.State().SystemRootPageID, prefix, prefixEnd(prefix))
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = it.Close() }()
+
+	var out []CollectionMeta
+	for it.Valid() {
+		key := it.UnsafeKey()
+		if !bytes.HasPrefix(key, prefix) {
+			break
+		}
+		if !it.IsDeleted() {
+			meta, err := decodeCollectionMeta(it.ValueCopy(nil))
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, meta)
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
 func (c *Collection) Name() string {
 	if c == nil {
 		return ""
@@ -484,6 +534,92 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 	}
 	c.meta = newMeta
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, plan.rootNames, rootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return newMeta.copy(), nil
+}
+
+func (c *Collection) DropIndex(name string) (*CollectionMeta, error) {
+	if err := ValidateIndexName(name); err != nil {
+		return nil, err
+	}
+	return c.dropIndexes(map[string]struct{}{name: {}}, false)
+}
+
+func (c *Collection) DropAllIndexes() (*CollectionMeta, error) {
+	return c.dropIndexes(nil, true)
+}
+
+func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*CollectionMeta, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
+	if err := c.flushBufferedNoIndex(); err != nil {
+		return nil, err
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return nil, errCollectionNotFound
+	}
+	baseMeta := catalog.meta
+	baseSystemRoot := snapshotSystemRoot(snap)
+	_ = snap.Close()
+
+	nextIndexes := make([]IndexDefinition, 0, len(baseMeta.Indexes))
+	dropped := 0
+	for _, idx := range baseMeta.Indexes {
+		if all {
+			dropped++
+			continue
+		}
+		if _, ok := names[idx.Name]; ok {
+			dropped++
+			continue
+		}
+		nextIndexes = append(nextIndexes, idx)
+	}
+	if !all && dropped != len(names) {
+		return nil, ErrIndexNotFound
+	}
+	if dropped == 0 {
+		c.meta = baseMeta
+		c.rememberCatalogAtSystemRoot(baseSystemRoot, catalog)
+		return baseMeta.copy(), nil
+	}
+
+	newMeta, err := normalizeCollectionMeta(CollectionMeta{
+		Name:    baseMeta.Name,
+		Options: baseMeta.Options,
+		Indexes: nextIndexes,
+	})
+	if err != nil {
+		return nil, err
+	}
+	encodedMeta, err := encodeCollectionMeta(newMeta)
+	if err != nil {
+		return nil, err
+	}
+	newSystemRoot, _, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+		return c.buildSchemaOnlySystemDeltaIterator(baseMeta, encodedMeta)
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.meta = newMeta
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, nil, nil)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	return newMeta.copy(), nil
@@ -1539,6 +1675,27 @@ func (c *Collection) buildSchemaAndRootDescriptorSystemIterator(
 		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
 	}
 	return buildSystemTargetIterator(current, updates)
+}
+
+func (c *Collection) buildSchemaOnlySystemDeltaIterator(baseMeta CollectionMeta, encodedMeta []byte) (iterator.UnsafeIterator, error) {
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	catalog, err := loadCollectionCatalog(current, baseMeta.Name)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	if !sameCollectionMeta(catalog.meta, baseMeta) {
+		return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", baseMeta.Name)
+	}
+	return buildSystemDeltaIterator(map[string][]byte{
+		systemCollectionMetaKey(baseMeta.Name): encodedMeta,
+	})
 }
 
 func loadDeleteIndexState(snap *backenddb.Snapshot, catalog *collectionCatalog, documentID, document []byte, runtimes []indexRuntime, opts collectionOptions) (documentIndexState, error) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1201,6 +1201,25 @@ func TestCollectionDropIndexUpdatesSchema(t *testing.T) {
 	} else if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
 		t.Fatalf("find retained email ids=%q want u1", ids)
 	}
+	if err := reopened.Delete([]byte("u1")); err != nil {
+		t.Fatalf("delete while city index dropped: %v", err)
+	}
+	if _, err := reopened.Insert([]byte("u2"), []byte(`{"email":"grace@example.com","city":"sfo"}`)); err != nil {
+		t.Fatalf("insert while city index dropped: %v", err)
+	}
+	if _, err := reopened.CreateIndex(IndexDefinition{Name: "city", Field: "city"}); err != nil {
+		t.Fatalf("recreate city index: %v", err)
+	}
+	if ids, err := reopened.FindByIndex("city", "hnl"); err != nil {
+		t.Fatalf("find recreated city hnl: %v", err)
+	} else if len(ids) != 0 {
+		t.Fatalf("recreated city hnl ids=%q want none", ids)
+	}
+	if ids, err := reopened.FindByIndex("city", "sfo"); err != nil {
+		t.Fatalf("find recreated city sfo: %v", err)
+	} else if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
+		t.Fatalf("recreated city sfo ids=%q want u2", ids)
+	}
 	if _, err := reopened.DropIndex("missing"); !errors.Is(err, ErrIndexNotFound) {
 		t.Fatalf("drop missing err=%v want ErrIndexNotFound", err)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1223,6 +1223,22 @@ func TestCollectionDropIndexUpdatesSchema(t *testing.T) {
 	if _, err := reopened.DropIndex("missing"); !errors.Is(err, ErrIndexNotFound) {
 		t.Fatalf("drop missing err=%v want ErrIndexNotFound", err)
 	}
+	if _, err := reopened.DropIndexes([]string{"city", "missing"}); !errors.Is(err, ErrIndexNotFound) {
+		t.Fatalf("bulk drop with missing err=%v want ErrIndexNotFound", err)
+	}
+	if _, ok := findIndex(reopened.Meta().Indexes, "city"); !ok {
+		t.Fatalf("bulk drop with missing removed city index: %+v", reopened.Meta().Indexes)
+	}
+	if _, ok := findIndex(reopened.Meta().Indexes, "email"); !ok {
+		t.Fatalf("bulk drop with missing removed email index: %+v", reopened.Meta().Indexes)
+	}
+	meta, err = reopened.DropIndexes([]string{"city", "email"})
+	if err != nil {
+		t.Fatalf("bulk drop indexes: %v", err)
+	}
+	if len(meta.Indexes) != 0 {
+		t.Fatalf("bulk drop meta indexes=%+v want none", meta.Indexes)
+	}
 }
 
 func TestCollectionCreateIndexBackfill_EmptyCollectionUpdatesSchema(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -125,6 +125,39 @@ func TestCollectionInsertBatchBridge_RoundTripWithSecondaryIndexes(t *testing.T)
 	}
 }
 
+func TestCollectionManagerListCollections(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create users: %v", err)
+	}
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "orders",
+		Indexes: []IndexDefinition{{Name: "user_id", Field: "user_id"}},
+	}); err != nil {
+		t.Fatalf("create orders: %v", err)
+	}
+
+	metas, err := mgr.ListCollections()
+	if err != nil {
+		t.Fatalf("list collections: %v", err)
+	}
+	if len(metas) != 2 {
+		t.Fatalf("collection count=%d want 2: %+v", len(metas), metas)
+	}
+	if metas[0].Name != "orders" || metas[1].Name != "users" {
+		t.Fatalf("collection order=%q,%q want orders,users", metas[0].Name, metas[1].Name)
+	}
+	if len(metas[0].Indexes) != 1 || metas[0].Indexes[0].Name != "user_id" {
+		t.Fatalf("orders indexes=%+v want user_id", metas[0].Indexes)
+	}
+}
+
 func TestCollectionInsertBatchStatsExposeIndexRunShape(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -1110,6 +1143,64 @@ func TestCollectionCreateIndexBackfill_BuildsSecondaryAndIndexState(t *testing.T
 		!bytes.Equal(cityIDs[1], []byte("u2")) ||
 		!bytes.Equal(cityIDs[2], []byte("u3")) {
 		t.Fatalf("city ids after insert=%q want [u1 u2 u3]", cityIDs)
+	}
+}
+
+func TestCollectionDropIndexUpdatesSchema(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	meta, err := col.DropIndex("city")
+	if err != nil {
+		t.Fatalf("drop index: %v", err)
+	}
+	if _, ok := findIndex(meta.Indexes, "city"); ok {
+		t.Fatalf("dropped meta still has city index: %+v", meta.Indexes)
+	}
+	if _, ok := findIndex(meta.Indexes, "email"); !ok {
+		t.Fatalf("dropped meta lost email index: %+v", meta.Indexes)
+	}
+
+	reopened, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("reopen collection: %v", err)
+	}
+	if _, ok := findIndex(reopened.Meta().Indexes, "city"); ok {
+		t.Fatalf("reopened meta still has city index: %+v", reopened.Meta().Indexes)
+	}
+	if ids, err := reopened.FindByIndex("city", "hnl"); err != nil {
+		t.Fatalf("find dropped city: %v", err)
+	} else if len(ids) != 0 {
+		t.Fatalf("find dropped city ids=%q want none", ids)
+	}
+	if ids, err := reopened.FindByIndex("email", "ada@example.com"); err != nil {
+		t.Fatalf("find retained email: %v", err)
+	} else if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("find retained email ids=%q want u1", ids)
+	}
+	if _, err := reopened.DropIndex("missing"); !errors.Is(err, ErrIndexNotFound) {
+		t.Fatalf("drop missing err=%v want ErrIndexNotFound", err)
 	}
 }
 

--- a/TreeDB/mongo_gateway/PLAN.md
+++ b/TreeDB/mongo_gateway/PLAN.md
@@ -1,7 +1,7 @@
 # MongoDB-Compatible Gateway Plan
 
-Status: planning, work log, early wire-protocol prototype, and first
-collection-backed command path.
+Status: planning, work log, early wire-protocol prototype, first
+collection-backed command path, CRUD MVP, and collection/index metadata MVP.
 
 This folder tracks the product expansion effort to expose TreeDB collections
 through a MongoDB-compatible gateway. The near-term goal is not to claim full
@@ -258,6 +258,16 @@ Priority workloads:
 - Indexed range scan with limit.
 - Mixed insert/read workload with checkpointing enabled.
 - Disk usage after load, after checkpoint, and after maintenance.
+
+## Work Log
+
+- PR 1088 added OP_MSG document sequences plus collection-backed `insert` and
+  exact `_id` equality `find`, with a real Go driver insert/find smoke test.
+- PR 1089 adds exact `_id` equality `update`/`delete` command support for the
+  gateway CRUD MVP.
+- Current metadata slice adds `listCollections`, `createIndexes`,
+  `listIndexes`, and `dropIndexes` for single-field ascending collection
+  secondary indexes.
 
 Metrics to record for every run:
 

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	commandCodeBadValue      int32 = 2
-	commandCodeFailedToParse int32 = 9
-	commandCodeDuplicateKey  int32 = 11000
+	commandCodeBadValue          int32 = 2
+	commandCodeFailedToParse     int32 = 9
+	commandCodeNamespaceNotFound int32 = 26
+	commandCodeIndexNotFound     int32 = 27
+	commandCodeDuplicateKey      int32 = 11000
 )
 
 const primaryKeyPrefixBSONValue byte = 1
@@ -292,6 +294,184 @@ func (s *Server) deleteResponse(command wire.Document, sequences []wire.Document
 	return marshalDeleteResponse(deleted)
 }
 
+func (s *Server) listCollectionsResponse(command wire.Document) (wire.Document, error) {
+	if s.Collections == nil {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	nameOnly, err := optionalBoolField(command, "nameOnly")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	filter, err := commandOptionalDocument(command, "filter")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	nameFilter, err := collectionNameFilter(filter)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+
+	metas, err := s.Collections.ListCollections()
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	prefix := db + "."
+	firstBatch := bson.A{}
+	for _, meta := range metas {
+		collectionName, ok := strings.CutPrefix(meta.Name, prefix)
+		if !ok {
+			continue
+		}
+		if nameFilter != "" && collectionName != nameFilter {
+			continue
+		}
+		firstBatch = append(firstBatch, mongoCollectionDocument(collectionName, nameOnly))
+	}
+	return marshalCursorResponse(db, "$cmd.listCollections", firstBatch)
+}
+
+func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, error) {
+	if s.Collections == nil {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+	}
+	collection, err := commandString(command, "createIndexes")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	indexDocs, err := commandDocumentArray(command, "indexes")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	defs := make([]collections.IndexDefinition, 0, len(indexDocs))
+	for i, indexDoc := range indexDocs {
+		def, err := parseCreateIndexDefinition(indexDoc)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("indexes[%d]: %v", i, err))
+		}
+		defs = append(defs, def)
+	}
+
+	createdAutomatically := false
+	col, err := s.Collections.OpenCollection(name)
+	if err != nil {
+		if !errors.Is(err, collections.ErrCollectionNotFound) {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		if _, err := s.Collections.CreateCollection(&collections.CollectionMeta{Name: name}); err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		createdAutomatically = true
+		col, err = s.Collections.OpenCollection(name)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+	}
+	numBefore := int32(1 + len(col.Meta().Indexes))
+	meta := col.Meta()
+	for _, def := range defs {
+		next, err := col.CreateIndex(def)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		meta = *next
+	}
+	return marshalDocument(bson.D{
+		{Key: "ok", Value: 1.0},
+		{Key: "createdCollectionAutomatically", Value: createdAutomatically},
+		{Key: "numIndexesBefore", Value: numBefore},
+		{Key: "numIndexesAfter", Value: int32(1 + len(meta.Indexes))},
+	})
+}
+
+func (s *Server) listIndexesResponse(command wire.Document) (wire.Document, error) {
+	if s.Collections == nil {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+	}
+	collection, err := commandString(command, "listIndexes")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	col, err := s.Collections.OpenCollection(name)
+	if err != nil {
+		if errors.Is(err, collections.ErrCollectionNotFound) {
+			return commandError(commandCodeNamespaceNotFound, "NamespaceNotFound", "collection not found: "+db+"."+collection)
+		}
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	return marshalCursorResponse(db, collection, mongoIndexDocuments(col.Meta()))
+}
+
+func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, error) {
+	if s.Collections == nil {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+	}
+	collection, err := commandString(command, "dropIndexes")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	col, err := s.Collections.OpenCollection(name)
+	if err != nil {
+		if errors.Is(err, collections.ErrCollectionNotFound) {
+			return commandError(commandCodeNamespaceNotFound, "NamespaceNotFound", "collection not found: "+db+"."+collection)
+		}
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	before := int32(1 + len(col.Meta().Indexes))
+	names, all, err := dropIndexNames(command)
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	if all {
+		if _, err := col.DropAllIndexes(); err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+	} else {
+		for _, indexName := range names {
+			if indexName == "_id_" {
+				return commandError(commandCodeBadValue, "BadValue", "cannot drop _id index")
+			}
+			if _, err := col.DropIndex(indexName); err != nil {
+				if errors.Is(err, collections.ErrIndexNotFound) {
+					return commandError(commandCodeIndexNotFound, "IndexNotFound", "index not found: "+indexName)
+				}
+				return commandError(commandCodeBadValue, "BadValue", err.Error())
+			}
+		}
+	}
+	return marshalDocument(bson.D{
+		{Key: "ok", Value: 1.0},
+		{Key: "nIndexesWas", Value: before},
+	})
+}
+
 func marshalUpdateResponse(matched, modified int32) (wire.Document, error) {
 	return marshalDocument(bson.D{
 		{Key: "ok", Value: 1.0},
@@ -304,6 +484,17 @@ func marshalDeleteResponse(deleted int32) (wire.Document, error) {
 	return marshalDocument(bson.D{
 		{Key: "ok", Value: 1.0},
 		{Key: "n", Value: deleted},
+	})
+}
+
+func marshalCursorResponse(db, collection string, firstBatch bson.A) (wire.Document, error) {
+	return marshalDocument(bson.D{
+		{Key: "cursor", Value: bson.D{
+			{Key: "id", Value: int64(0)},
+			{Key: "ns", Value: db + "." + collection},
+			{Key: "firstBatch", Value: firstBatch},
+		}},
+		{Key: "ok", Value: 1.0},
 	})
 }
 
@@ -384,6 +575,34 @@ func optionalInt32Field(doc wire.Document, key string) (int32, error) {
 		return int32(out), nil
 	}
 	return 0, fmt.Errorf("Mongo command field %q must be an integer", key)
+}
+
+func collectionNameFilter(filter wire.Document) (string, error) {
+	if filter == nil {
+		return "", nil
+	}
+	elements, err := bson.Raw(filter).Elements()
+	if err != nil {
+		return "", err
+	}
+	if len(elements) == 0 {
+		return "", nil
+	}
+	if len(elements) != 1 {
+		return "", errors.New("Mongo gateway listCollections filter currently supports name equality only")
+	}
+	key, err := elements[0].KeyErr()
+	if err != nil {
+		return "", err
+	}
+	if key != "name" {
+		return "", errors.New("Mongo gateway listCollections filter currently supports name equality only")
+	}
+	name, ok := elements[0].Value().StringValueOK()
+	if !ok {
+		return "", errors.New("Mongo gateway listCollections name filter must be a string")
+	}
+	return name, nil
 }
 
 func commandDocumentArray(doc wire.Document, key string) ([]wire.Document, error) {
@@ -568,6 +787,143 @@ func applySetUpdate(doc wire.Document, update wire.Document) (wire.Document, boo
 		return nil, false, err
 	}
 	return wire.Document(raw), changed, nil
+}
+
+func parseCreateIndexDefinition(doc wire.Document) (collections.IndexDefinition, error) {
+	keyDoc, err := requiredDocumentField(doc, "key")
+	if err != nil {
+		return collections.IndexDefinition{}, err
+	}
+	elements, err := bson.Raw(keyDoc).Elements()
+	if err != nil {
+		return collections.IndexDefinition{}, err
+	}
+	if len(elements) != 1 {
+		return collections.IndexDefinition{}, errors.New("Mongo gateway createIndexes currently supports single-field indexes only")
+	}
+	field, err := elements[0].KeyErr()
+	if err != nil {
+		return collections.IndexDefinition{}, err
+	}
+	if field == "_id" {
+		return collections.IndexDefinition{}, errors.New("Mongo gateway cannot create the built-in _id index")
+	}
+	if !isAscendingIndexKey(elements[0].Value()) {
+		return collections.IndexDefinition{}, errors.New("Mongo gateway createIndexes currently supports ascending indexes only")
+	}
+	name, err := optionalStringField(doc, "name")
+	if err != nil {
+		return collections.IndexDefinition{}, err
+	}
+	if name == "" {
+		name = field + "_1"
+	}
+	unique, err := optionalBoolField(doc, "unique")
+	if err != nil {
+		return collections.IndexDefinition{}, err
+	}
+	return collections.IndexDefinition{
+		Name:   name,
+		Field:  field,
+		Unique: unique,
+	}, nil
+}
+
+func optionalStringField(doc wire.Document, key string) (string, error) {
+	value := bson.Raw(doc).Lookup(key)
+	if value.IsZero() {
+		return "", nil
+	}
+	out, ok := value.StringValueOK()
+	if !ok {
+		return "", fmt.Errorf("Mongo command field %q must be a string", key)
+	}
+	return out, nil
+}
+
+func isAscendingIndexKey(value bson.RawValue) bool {
+	if v, ok := value.Int32OK(); ok {
+		return v == 1
+	}
+	if v, ok := value.Int64OK(); ok {
+		return v == 1
+	}
+	if v, ok := value.DoubleOK(); ok {
+		return v == 1
+	}
+	return false
+}
+
+func mongoCollectionDocument(name string, nameOnly bool) bson.D {
+	doc := bson.D{
+		{Key: "name", Value: name},
+		{Key: "type", Value: "collection"},
+	}
+	if nameOnly {
+		return doc
+	}
+	return append(doc,
+		bson.E{Key: "options", Value: bson.D{}},
+		bson.E{Key: "info", Value: bson.D{{Key: "readOnly", Value: false}}},
+		bson.E{Key: "idIndex", Value: bson.D{
+			{Key: "v", Value: int32(2)},
+			{Key: "key", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+			{Key: "name", Value: "_id_"},
+		}},
+	)
+}
+
+func mongoIndexDocuments(meta collections.CollectionMeta) bson.A {
+	out := bson.A{bson.D{
+		{Key: "v", Value: int32(2)},
+		{Key: "key", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+		{Key: "name", Value: "_id_"},
+	}}
+	for _, idx := range meta.Indexes {
+		doc := bson.D{
+			{Key: "v", Value: int32(2)},
+			{Key: "key", Value: bson.D{{Key: idx.Field, Value: int32(1)}}},
+			{Key: "name", Value: idx.Name},
+		}
+		if idx.Unique {
+			doc = append(doc, bson.E{Key: "unique", Value: true})
+		}
+		out = append(out, doc)
+	}
+	return out
+}
+
+func dropIndexNames(command wire.Document) ([]string, bool, error) {
+	value := bson.Raw(command).Lookup("index")
+	if value.IsZero() {
+		return nil, false, errors.New("Mongo command missing \"index\"")
+	}
+	if name, ok := value.StringValueOK(); ok {
+		if name == "*" {
+			return nil, true, nil
+		}
+		return []string{name}, false, nil
+	}
+	array, ok := value.ArrayOK()
+	if !ok {
+		return nil, false, errors.New("Mongo command field \"index\" must be a string or array")
+	}
+	values, err := array.Values()
+	if err != nil {
+		return nil, false, err
+	}
+	names := make([]string, 0, len(values))
+	for i, value := range values {
+		name, ok := value.StringValueOK()
+		if !ok {
+			return nil, false, fmt.Errorf("Mongo command field \"index\"[%d] must be a string", i)
+		}
+		if name == "*" {
+			return nil, true, nil
+		}
+		names = append(names, name)
+	}
+	return names, false, nil
 }
 
 func parseSetDocument(doc bson.Raw) (map[string]bson.RawValue, []string, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	commandCodeBadValue      int32 = 2
-	commandCodeFailedToParse int32 = 9
-	commandCodeDuplicateKey  int32 = 11000
+	commandCodeBadValue          int32 = 2
+	commandCodeFailedToParse     int32 = 9
+	commandCodeNamespaceNotFound int32 = 26
+	commandCodeIndexNotFound     int32 = 27
+	commandCodeDuplicateKey      int32 = 11000
 )
 
 const primaryKeyPrefixBSONValue byte = 1
@@ -291,6 +293,184 @@ func (s *Server) deleteResponse(command wire.Document, sequences []wire.Document
 	return marshalDeleteResponse(deleted)
 }
 
+func (s *Server) listCollectionsResponse(command wire.Document) (wire.Document, error) {
+	if s.Collections == nil {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	nameOnly, err := optionalBoolField(command, "nameOnly")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	filter, err := commandOptionalDocument(command, "filter")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	nameFilter, err := collectionNameFilter(filter)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+
+	metas, err := s.Collections.ListCollections()
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	prefix := db + "."
+	firstBatch := bson.A{}
+	for _, meta := range metas {
+		collectionName, ok := strings.CutPrefix(meta.Name, prefix)
+		if !ok {
+			continue
+		}
+		if nameFilter != "" && collectionName != nameFilter {
+			continue
+		}
+		firstBatch = append(firstBatch, mongoCollectionDocument(collectionName, nameOnly))
+	}
+	return marshalCursorResponse(db, "$cmd.listCollections", firstBatch)
+}
+
+func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, error) {
+	if s.Collections == nil {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+	}
+	collection, err := commandString(command, "createIndexes")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	indexDocs, err := commandDocumentArray(command, "indexes")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	defs := make([]collections.IndexDefinition, 0, len(indexDocs))
+	for i, indexDoc := range indexDocs {
+		def, err := parseCreateIndexDefinition(indexDoc)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("indexes[%d]: %v", i, err))
+		}
+		defs = append(defs, def)
+	}
+
+	createdAutomatically := false
+	col, err := s.Collections.OpenCollection(name)
+	if err != nil {
+		if !errors.Is(err, collections.ErrCollectionNotFound) {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		if _, err := s.Collections.CreateCollection(&collections.CollectionMeta{Name: name}); err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		createdAutomatically = true
+		col, err = s.Collections.OpenCollection(name)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+	}
+	numBefore := int32(1 + len(col.Meta().Indexes))
+	meta := col.Meta()
+	for _, def := range defs {
+		next, err := col.CreateIndex(def)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		meta = *next
+	}
+	return marshalDocument(bson.D{
+		{Key: "ok", Value: 1.0},
+		{Key: "createdCollectionAutomatically", Value: createdAutomatically},
+		{Key: "numIndexesBefore", Value: numBefore},
+		{Key: "numIndexesAfter", Value: int32(1 + len(meta.Indexes))},
+	})
+}
+
+func (s *Server) listIndexesResponse(command wire.Document) (wire.Document, error) {
+	if s.Collections == nil {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+	}
+	collection, err := commandString(command, "listIndexes")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	col, err := s.Collections.OpenCollection(name)
+	if err != nil {
+		if errors.Is(err, collections.ErrCollectionNotFound) {
+			return commandError(commandCodeNamespaceNotFound, "NamespaceNotFound", "collection not found: "+db+"."+collection)
+		}
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	return marshalCursorResponse(db, collection, mongoIndexDocuments(col.Meta()))
+}
+
+func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, error) {
+	if s.Collections == nil {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+	}
+	collection, err := commandString(command, "dropIndexes")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	col, err := s.Collections.OpenCollection(name)
+	if err != nil {
+		if errors.Is(err, collections.ErrCollectionNotFound) {
+			return commandError(commandCodeNamespaceNotFound, "NamespaceNotFound", "collection not found: "+db+"."+collection)
+		}
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	before := int32(1 + len(col.Meta().Indexes))
+	names, all, err := dropIndexNames(command)
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	if all {
+		if _, err := col.DropAllIndexes(); err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+	} else {
+		for _, indexName := range names {
+			if indexName == "_id_" {
+				return commandError(commandCodeBadValue, "BadValue", "cannot drop _id index")
+			}
+			if _, err := col.DropIndex(indexName); err != nil {
+				if errors.Is(err, collections.ErrIndexNotFound) {
+					return commandError(commandCodeIndexNotFound, "IndexNotFound", "index not found: "+indexName)
+				}
+				return commandError(commandCodeBadValue, "BadValue", err.Error())
+			}
+		}
+	}
+	return marshalDocument(bson.D{
+		{Key: "ok", Value: 1.0},
+		{Key: "nIndexesWas", Value: before},
+	})
+}
+
 func marshalUpdateResponse(matched, modified int32) (wire.Document, error) {
 	return marshalDocument(bson.D{
 		{Key: "ok", Value: 1.0},
@@ -303,6 +483,17 @@ func marshalDeleteResponse(deleted int32) (wire.Document, error) {
 	return marshalDocument(bson.D{
 		{Key: "ok", Value: 1.0},
 		{Key: "n", Value: deleted},
+	})
+}
+
+func marshalCursorResponse(db, collection string, firstBatch bson.A) (wire.Document, error) {
+	return marshalDocument(bson.D{
+		{Key: "cursor", Value: bson.D{
+			{Key: "id", Value: int64(0)},
+			{Key: "ns", Value: db + "." + collection},
+			{Key: "firstBatch", Value: firstBatch},
+		}},
+		{Key: "ok", Value: 1.0},
 	})
 }
 
@@ -383,6 +574,34 @@ func optionalInt32Field(doc wire.Document, key string) (int32, error) {
 		return int32(out), nil
 	}
 	return 0, fmt.Errorf("Mongo command field %q must be an integer", key)
+}
+
+func collectionNameFilter(filter wire.Document) (string, error) {
+	if filter == nil {
+		return "", nil
+	}
+	elements, err := bson.Raw(filter).Elements()
+	if err != nil {
+		return "", err
+	}
+	if len(elements) == 0 {
+		return "", nil
+	}
+	if len(elements) != 1 {
+		return "", errors.New("Mongo gateway listCollections filter currently supports name equality only")
+	}
+	key, err := elements[0].KeyErr()
+	if err != nil {
+		return "", err
+	}
+	if key != "name" {
+		return "", errors.New("Mongo gateway listCollections filter currently supports name equality only")
+	}
+	name, ok := elements[0].Value().StringValueOK()
+	if !ok {
+		return "", errors.New("Mongo gateway listCollections name filter must be a string")
+	}
+	return name, nil
 }
 
 func commandDocumentArray(doc wire.Document, key string) ([]wire.Document, error) {
@@ -567,6 +786,143 @@ func applySetUpdate(doc wire.Document, update wire.Document) (wire.Document, boo
 		return nil, false, err
 	}
 	return wire.Document(raw), changed, nil
+}
+
+func parseCreateIndexDefinition(doc wire.Document) (collections.IndexDefinition, error) {
+	keyDoc, err := requiredDocumentField(doc, "key")
+	if err != nil {
+		return collections.IndexDefinition{}, err
+	}
+	elements, err := bson.Raw(keyDoc).Elements()
+	if err != nil {
+		return collections.IndexDefinition{}, err
+	}
+	if len(elements) != 1 {
+		return collections.IndexDefinition{}, errors.New("Mongo gateway createIndexes currently supports single-field indexes only")
+	}
+	field, err := elements[0].KeyErr()
+	if err != nil {
+		return collections.IndexDefinition{}, err
+	}
+	if field == "_id" {
+		return collections.IndexDefinition{}, errors.New("Mongo gateway cannot create the built-in _id index")
+	}
+	if !isAscendingIndexKey(elements[0].Value()) {
+		return collections.IndexDefinition{}, errors.New("Mongo gateway createIndexes currently supports ascending indexes only")
+	}
+	name, err := optionalStringField(doc, "name")
+	if err != nil {
+		return collections.IndexDefinition{}, err
+	}
+	if name == "" {
+		name = field + "_1"
+	}
+	unique, err := optionalBoolField(doc, "unique")
+	if err != nil {
+		return collections.IndexDefinition{}, err
+	}
+	return collections.IndexDefinition{
+		Name:   name,
+		Field:  field,
+		Unique: unique,
+	}, nil
+}
+
+func optionalStringField(doc wire.Document, key string) (string, error) {
+	value := bson.Raw(doc).Lookup(key)
+	if value.IsZero() {
+		return "", nil
+	}
+	out, ok := value.StringValueOK()
+	if !ok {
+		return "", fmt.Errorf("Mongo command field %q must be a string", key)
+	}
+	return out, nil
+}
+
+func isAscendingIndexKey(value bson.RawValue) bool {
+	if v, ok := value.Int32OK(); ok {
+		return v == 1
+	}
+	if v, ok := value.Int64OK(); ok {
+		return v == 1
+	}
+	if v, ok := value.DoubleOK(); ok {
+		return v == 1
+	}
+	return false
+}
+
+func mongoCollectionDocument(name string, nameOnly bool) bson.D {
+	doc := bson.D{
+		{Key: "name", Value: name},
+		{Key: "type", Value: "collection"},
+	}
+	if nameOnly {
+		return doc
+	}
+	return append(doc,
+		bson.E{Key: "options", Value: bson.D{}},
+		bson.E{Key: "info", Value: bson.D{{Key: "readOnly", Value: false}}},
+		bson.E{Key: "idIndex", Value: bson.D{
+			{Key: "v", Value: int32(2)},
+			{Key: "key", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+			{Key: "name", Value: "_id_"},
+		}},
+	)
+}
+
+func mongoIndexDocuments(meta collections.CollectionMeta) bson.A {
+	out := bson.A{bson.D{
+		{Key: "v", Value: int32(2)},
+		{Key: "key", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+		{Key: "name", Value: "_id_"},
+	}}
+	for _, idx := range meta.Indexes {
+		doc := bson.D{
+			{Key: "v", Value: int32(2)},
+			{Key: "key", Value: bson.D{{Key: idx.Field, Value: int32(1)}}},
+			{Key: "name", Value: idx.Name},
+		}
+		if idx.Unique {
+			doc = append(doc, bson.E{Key: "unique", Value: true})
+		}
+		out = append(out, doc)
+	}
+	return out
+}
+
+func dropIndexNames(command wire.Document) ([]string, bool, error) {
+	value := bson.Raw(command).Lookup("index")
+	if value.IsZero() {
+		return nil, false, errors.New("Mongo command missing \"index\"")
+	}
+	if name, ok := value.StringValueOK(); ok {
+		if name == "*" {
+			return nil, true, nil
+		}
+		return []string{name}, false, nil
+	}
+	array, ok := value.ArrayOK()
+	if !ok {
+		return nil, false, errors.New("Mongo command field \"index\" must be a string or array")
+	}
+	values, err := array.Values()
+	if err != nil {
+		return nil, false, err
+	}
+	names := make([]string, 0, len(values))
+	for i, value := range values {
+		name, ok := value.StringValueOK()
+		if !ok {
+			return nil, false, fmt.Errorf("Mongo command field \"index\"[%d] must be a string", i)
+		}
+		if name == "*" {
+			return nil, true, nil
+		}
+		names = append(names, name)
+	}
+	return names, false, nil
 }
 
 func parseSetDocument(doc bson.Raw) (map[string]bson.RawValue, []string, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -294,6 +294,9 @@ func (s *Server) listCollectionsResponse(command wire.Document) (wire.Document, 
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
+	if err := validateMongoDatabaseName(db); err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
 	nameOnly, err := optionalBoolField(command, "nameOnly")
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
@@ -346,6 +349,9 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
+	if len(indexDocs) == 0 {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway createIndexes requires at least one index")
+	}
 	defs := make([]collections.IndexDefinition, 0, len(indexDocs))
 	for i, indexDoc := range indexDocs {
 		def, err := parseCreateIndexDefinition(indexDoc)
@@ -373,9 +379,16 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 	numBefore := int32(1 + len(col.Meta().Indexes))
 	meta := col.Meta()
 	for _, def := range defs {
+		if existing, ok := findIndexDefinition(meta.Indexes, def.Name); ok && sameIndexDefinition(existing, def) {
+			continue
+		}
 		next, err := col.CreateIndex(def)
 		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
+			code, codeName := commandCodeBadValue, "BadValue"
+			if collections.IsDuplicateKeyError(err) {
+				code, codeName = commandCodeDuplicateKey, "DuplicateKey"
+			}
+			return commandError(code, codeName, err.Error())
 		}
 		meta = *next
 	}
@@ -661,20 +674,27 @@ func idEqualityFilterValue(filter wire.Document, commandName string) (bson.RawVa
 }
 
 func gatewayCollectionName(db, collection string) (string, error) {
-	if db == "" {
-		return "", errors.New("Mongo database name cannot be empty")
-	}
 	if collection == "" {
 		return "", errors.New("Mongo collection name cannot be empty")
 	}
-	if strings.ContainsAny(db, "\x00/:") {
-		return "", errors.New("Mongo database name contains reserved punctuation")
+	if err := validateMongoDatabaseName(db); err != nil {
+		return "", err
 	}
 	name := db + "." + collection
 	if err := collections.ValidateCollectionName(name); err != nil {
 		return "", err
 	}
 	return name, nil
+}
+
+func validateMongoDatabaseName(db string) error {
+	if db == "" {
+		return errors.New("Mongo database name cannot be empty")
+	}
+	if strings.ContainsAny(db, "\x00/:") {
+		return errors.New("Mongo database name contains reserved punctuation")
+	}
+	return nil
 }
 
 // prepareInsertDocument uses canonical Extended JSON as the temporary collection
@@ -803,11 +823,14 @@ func parseCreateIndexDefinition(doc wire.Document) (collections.IndexDefinition,
 	if !isAscendingIndexKey(elements[0].Value()) {
 		return collections.IndexDefinition{}, errors.New("Mongo gateway createIndexes currently supports ascending indexes only")
 	}
-	name, err := optionalStringField(doc, "name")
+	name, namePresent, err := optionalStringFieldWithPresence(doc, "name")
 	if err != nil {
 		return collections.IndexDefinition{}, err
 	}
-	if name == "" {
+	if namePresent && name == "" {
+		return collections.IndexDefinition{}, errors.New("Mongo gateway createIndexes index name cannot be empty")
+	}
+	if !namePresent {
 		name = field + "_1"
 	}
 	unique, err := optionalBoolField(doc, "unique")
@@ -822,15 +845,20 @@ func parseCreateIndexDefinition(doc wire.Document) (collections.IndexDefinition,
 }
 
 func optionalStringField(doc wire.Document, key string) (string, error) {
+	out, _, err := optionalStringFieldWithPresence(doc, key)
+	return out, err
+}
+
+func optionalStringFieldWithPresence(doc wire.Document, key string) (string, bool, error) {
 	value := bson.Raw(doc).Lookup(key)
 	if value.IsZero() {
-		return "", nil
+		return "", false, nil
 	}
 	out, ok := value.StringValueOK()
 	if !ok {
-		return "", fmt.Errorf("Mongo command field %q must be a string", key)
+		return "", true, fmt.Errorf("Mongo command field %q must be a string", key)
 	}
-	return out, nil
+	return out, true, nil
 }
 
 func isAscendingIndexKey(value bson.RawValue) bool {
@@ -885,6 +913,23 @@ func mongoIndexDocuments(meta collections.CollectionMeta) bson.A {
 	return out
 }
 
+func findIndexDefinition(indexes []collections.IndexDefinition, name string) (collections.IndexDefinition, bool) {
+	for _, index := range indexes {
+		if index.Name == name {
+			return index, true
+		}
+	}
+	return collections.IndexDefinition{}, false
+}
+
+func sameIndexDefinition(left, right collections.IndexDefinition) bool {
+	return left.Name == right.Name &&
+		left.Field == right.Field &&
+		left.Unique == right.Unique &&
+		left.MultiKey == right.MultiKey &&
+		left.StoragePolicy == right.StoragePolicy
+}
+
 func dropIndexNames(command wire.Document) ([]string, bool, error) {
 	value := bson.Raw(command).Lookup("index")
 	if value.IsZero() {
@@ -903,6 +948,9 @@ func dropIndexNames(command wire.Document) ([]string, bool, error) {
 	values, err := array.Values()
 	if err != nil {
 		return nil, false, err
+	}
+	if len(values) == 0 {
+		return nil, false, errors.New("Mongo command field \"index\" must not be empty")
 	}
 	names := make([]string, 0, len(values))
 	for i, value := range values {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -463,12 +463,12 @@ func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, erro
 			if indexName == "_id_" {
 				return commandError(commandCodeBadValue, "BadValue", "cannot drop _id index")
 			}
-			if _, err := col.DropIndex(indexName); err != nil {
-				if errors.Is(err, collections.ErrIndexNotFound) {
-					return commandError(commandCodeIndexNotFound, "IndexNotFound", "index not found: "+indexName)
-				}
-				return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		if _, err := col.DropIndexes(names); err != nil {
+			if errors.Is(err, collections.ErrIndexNotFound) {
+				return commandError(commandCodeIndexNotFound, "IndexNotFound", "index not found")
 			}
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
 		}
 	}
 	return marshalDocument(bson.D{

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -137,6 +137,14 @@ func (s *Server) commandResponse(name string, command wire.Document, sequences [
 		return s.updateResponse(command, sequences)
 	case "delete":
 		return s.deleteResponse(command, sequences)
+	case "listCollections":
+		return s.listCollectionsResponse(command)
+	case "createIndexes":
+		return s.createIndexesResponse(command)
+	case "listIndexes":
+		return s.listIndexesResponse(command)
+	case "dropIndexes":
+		return s.dropIndexesResponse(command)
 	default:
 		return commandError(59, "CommandNotFound", "unsupported MongoDB gateway command: "+name)
 	}

--- a/TreeDB/mongo_gateway/server_driver_test.go
+++ b/TreeDB/mongo_gateway/server_driver_test.go
@@ -136,3 +136,107 @@ func TestServerOfficialGoDriverBasicCRUD(t *testing.T) {
 		t.Fatal("serve loop did not stop")
 	}
 }
+
+func TestServerOfficialGoDriverIndexMetadata(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
+					serveErr <- nil
+					return
+				}
+				serveErr <- err
+				return
+			}
+			go func() {
+				_ = server.ServeConn(ctx, conn)
+			}()
+		}
+	}()
+
+	client, err := mongo.Connect(options.Client().
+		ApplyURI("mongodb://" + ln.Addr().String()).
+		SetDirect(true).
+		SetServerSelectionTimeout(time.Second))
+	if err != nil {
+		t.Fatalf("mongo connect: %v", err)
+	}
+	defer func() { _ = client.Disconnect(context.Background()) }()
+
+	opCtx, opCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer opCancel()
+	coll := client.Database("app").Collection("users")
+	indexName, err := coll.Indexes().CreateOne(opCtx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "email", Value: int32(1)}},
+		Options: options.Index().SetName("email_1").SetUnique(true),
+	})
+	if err != nil {
+		t.Fatalf("driver create index: %v", err)
+	}
+	if indexName != "email_1" {
+		t.Fatalf("created index name=%q want email_1", indexName)
+	}
+
+	names, err := client.Database("app").ListCollectionNames(opCtx, bson.D{})
+	if err != nil {
+		t.Fatalf("driver list collection names: %v", err)
+	}
+	if len(names) != 1 || names[0] != "users" {
+		t.Fatalf("collection names=%q want [users]", names)
+	}
+
+	specs, err := coll.Indexes().ListSpecifications(opCtx)
+	if err != nil {
+		t.Fatalf("driver list index specs: %v", err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("index spec len=%d want 2: %+v", len(specs), specs)
+	}
+	if specs[0].Name != "_id_" || specs[1].Name != "email_1" {
+		t.Fatalf("index spec names=%q,%q want _id_,email_1", specs[0].Name, specs[1].Name)
+	}
+	if specs[1].Unique == nil || !*specs[1].Unique {
+		t.Fatalf("email_1 unique=%v want true", specs[1].Unique)
+	}
+
+	if err := coll.Indexes().DropOne(opCtx, "email_1"); err != nil {
+		t.Fatalf("driver drop index: %v", err)
+	}
+	specs, err = coll.Indexes().ListSpecifications(opCtx)
+	if err != nil {
+		t.Fatalf("driver list after drop: %v", err)
+	}
+	if len(specs) != 1 || specs[0].Name != "_id_" {
+		t.Fatalf("index specs after drop=%+v want only _id_", specs)
+	}
+
+	cancel()
+	_ = ln.Close()
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("serve loop: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("serve loop did not stop")
+	}
+}

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -323,6 +323,19 @@ func TestServerIndexMetadataCommands(t *testing.T) {
 	assertInt32(t, createResponse, "numIndexesBefore", 1)
 	assertInt32(t, createResponse, "numIndexesAfter", 2)
 
+	idempotentResponse := serveCommand(t, server, 2271, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+			{Key: "name", Value: "email_1"},
+			{Key: "unique", Value: true},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, idempotentResponse)
+	assertInt32(t, idempotentResponse, "numIndexesBefore", 2)
+	assertInt32(t, idempotentResponse, "numIndexesAfter", 2)
+
 	collectionsResponse := serveCommand(t, server, 228, bson.D{
 		{Key: "listCollections", Value: int32(1)},
 		{Key: "nameOnly", Value: true},
@@ -365,6 +378,73 @@ func TestServerIndexMetadataCommands(t *testing.T) {
 		t.Fatalf("index batch after drop len=%d want %d", got, want)
 	}
 	assertIndexName(t, indexBatch[0], "_id_")
+}
+
+func TestServerIndexMetadataRejectsInvalidCommands(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	emptyCreate := serveCommand(t, server, 232, bson.D{
+		{Key: "createIndexes", Value: "empty"},
+		{Key: "indexes", Value: bson.A{}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, emptyCreate, "BadValue")
+
+	emptyName := serveCommand(t, server, 233, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+			{Key: "name", Value: ""},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, emptyName, "BadValue")
+
+	invalidListCollectionsDB := serveCommand(t, server, 234, bson.D{
+		{Key: "listCollections", Value: int32(1)},
+		{Key: "$db", Value: "bad/name"},
+	})
+	assertCommandError(t, invalidListCollectionsDB, "BadValue")
+
+	assertOK(t, serveCommand(t, server, 235, bson.D{
+		{Key: "insert", Value: "dupes"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "email", Value: "same@example.com"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "email", Value: "same@example.com"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	uniqueConflict := serveCommand(t, server, 236, bson.D{
+		{Key: "createIndexes", Value: "dupes"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+			{Key: "name", Value: "email_1"},
+			{Key: "unique", Value: true},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, uniqueConflict, "DuplicateKey")
+
+	assertOK(t, serveCommand(t, server, 237, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "city", Value: int32(1)}}},
+			{Key: "name", Value: "city_1"},
+		}}},
+		{Key: "$db", Value: "app"},
+	}))
+	emptyDrop := serveCommand(t, server, 238, bson.D{
+		{Key: "dropIndexes", Value: "users"},
+		{Key: "index", Value: bson.A{}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, emptyDrop, "FailedToParse")
 }
 
 func TestApplySetUpdateAppendsNewFieldsInSetOrder(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -301,6 +301,72 @@ func TestServerUpdateRejectsIDMutation(t *testing.T) {
 	assertCommandError(t, updateResponse, "BadValue")
 }
 
+func TestServerIndexMetadataCommands(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	createResponse := serveCommand(t, server, 227, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+			{Key: "name", Value: "email_1"},
+			{Key: "unique", Value: true},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, createResponse)
+	assertInt32(t, createResponse, "numIndexesBefore", 1)
+	assertInt32(t, createResponse, "numIndexesAfter", 2)
+
+	collectionsResponse := serveCommand(t, server, 228, bson.D{
+		{Key: "listCollections", Value: int32(1)},
+		{Key: "nameOnly", Value: true},
+		{Key: "$db", Value: "app"},
+	})
+	collectionBatch := cursorFirstBatch(t, collectionsResponse)
+	if len(collectionBatch) != 1 {
+		t.Fatalf("collection batch len=%d want 1", len(collectionBatch))
+	}
+	if got, ok := collectionBatch[0].Lookup("name").StringValueOK(); !ok || got != "users" {
+		t.Fatalf("collection name=%q ok=%v want users", got, ok)
+	}
+
+	indexesResponse := serveCommand(t, server, 229, bson.D{
+		{Key: "listIndexes", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	indexBatch := cursorFirstBatch(t, indexesResponse)
+	if got, want := len(indexBatch), 2; got != want {
+		t.Fatalf("index batch len=%d want %d", got, want)
+	}
+	assertIndexName(t, indexBatch[0], "_id_")
+	assertIndexName(t, indexBatch[1], "email_1")
+	assertBool(t, wire.Document(indexBatch[1]), "unique", true)
+
+	dropResponse := serveCommand(t, server, 230, bson.D{
+		{Key: "dropIndexes", Value: "users"},
+		{Key: "index", Value: "email_1"},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, dropResponse)
+	assertInt32(t, dropResponse, "nIndexesWas", 2)
+
+	afterDrop := serveCommand(t, server, 231, bson.D{
+		{Key: "listIndexes", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	indexBatch = cursorFirstBatch(t, afterDrop)
+	if got, want := len(indexBatch), 1; got != want {
+		t.Fatalf("index batch after drop len=%d want %d", got, want)
+	}
+	assertIndexName(t, indexBatch[0], "_id_")
+}
+
 func TestServerFindByIDMissingCollectionReturnsEmptyBatch(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -538,5 +604,13 @@ func assertCommandError(tb testing.TB, doc wire.Document, codeName string) {
 	got, gotOK := raw.Lookup("codeName").StringValueOK()
 	if !gotOK || got != codeName {
 		tb.Fatalf("codeName=%q typeOK=%v want %q", got, gotOK, codeName)
+	}
+}
+
+func assertIndexName(tb testing.TB, doc bson.Raw, want string) {
+	tb.Helper()
+	got, ok := doc.Lookup("name").StringValueOK()
+	if !ok || got != want {
+		tb.Fatalf("index name=%q typeOK=%v want %q", got, ok, want)
 	}
 }

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -287,6 +287,72 @@ func TestServerUpdateRejectsIDMutation(t *testing.T) {
 	assertCommandError(t, updateResponse, "BadValue")
 }
 
+func TestServerIndexMetadataCommands(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	createResponse := serveCommand(t, server, 227, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+			{Key: "name", Value: "email_1"},
+			{Key: "unique", Value: true},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, createResponse)
+	assertInt32(t, createResponse, "numIndexesBefore", 1)
+	assertInt32(t, createResponse, "numIndexesAfter", 2)
+
+	collectionsResponse := serveCommand(t, server, 228, bson.D{
+		{Key: "listCollections", Value: int32(1)},
+		{Key: "nameOnly", Value: true},
+		{Key: "$db", Value: "app"},
+	})
+	collectionBatch := cursorFirstBatch(t, collectionsResponse)
+	if len(collectionBatch) != 1 {
+		t.Fatalf("collection batch len=%d want 1", len(collectionBatch))
+	}
+	if got, ok := collectionBatch[0].Lookup("name").StringValueOK(); !ok || got != "users" {
+		t.Fatalf("collection name=%q ok=%v want users", got, ok)
+	}
+
+	indexesResponse := serveCommand(t, server, 229, bson.D{
+		{Key: "listIndexes", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	indexBatch := cursorFirstBatch(t, indexesResponse)
+	if got, want := len(indexBatch), 2; got != want {
+		t.Fatalf("index batch len=%d want %d", got, want)
+	}
+	assertIndexName(t, indexBatch[0], "_id_")
+	assertIndexName(t, indexBatch[1], "email_1")
+	assertBool(t, wire.Document(indexBatch[1]), "unique", true)
+
+	dropResponse := serveCommand(t, server, 230, bson.D{
+		{Key: "dropIndexes", Value: "users"},
+		{Key: "index", Value: "email_1"},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, dropResponse)
+	assertInt32(t, dropResponse, "nIndexesWas", 2)
+
+	afterDrop := serveCommand(t, server, 231, bson.D{
+		{Key: "listIndexes", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	indexBatch = cursorFirstBatch(t, afterDrop)
+	if got, want := len(indexBatch), 1; got != want {
+		t.Fatalf("index batch after drop len=%d want %d", got, want)
+	}
+	assertIndexName(t, indexBatch[0], "_id_")
+}
+
 func TestServerFindByIDMissingCollectionReturnsEmptyBatch(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -524,5 +590,13 @@ func assertCommandError(tb testing.TB, doc wire.Document, codeName string) {
 	got, gotOK := raw.Lookup("codeName").StringValueOK()
 	if !gotOK || got != codeName {
 		tb.Fatalf("codeName=%q typeOK=%v want %q", got, gotOK, codeName)
+	}
+}
+
+func assertIndexName(tb testing.TB, doc bson.Raw, want string) {
+	tb.Helper()
+	got, ok := doc.Lookup("name").StringValueOK()
+	if !ok || got != want {
+		tb.Fatalf("index name=%q typeOK=%v want %q", got, ok, want)
 	}
 }

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -439,12 +439,38 @@ func TestServerIndexMetadataRejectsInvalidCommands(t *testing.T) {
 		}}},
 		{Key: "$db", Value: "app"},
 	}))
-	emptyDrop := serveCommand(t, server, 238, bson.D{
+	assertOK(t, serveCommand(t, server, 238, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+			{Key: "name", Value: "email_1"},
+		}}},
+		{Key: "$db", Value: "app"},
+	}))
+	emptyDrop := serveCommand(t, server, 239, bson.D{
 		{Key: "dropIndexes", Value: "users"},
 		{Key: "index", Value: bson.A{}},
 		{Key: "$db", Value: "app"},
 	})
 	assertCommandError(t, emptyDrop, "FailedToParse")
+
+	partialDrop := serveCommand(t, server, 240, bson.D{
+		{Key: "dropIndexes", Value: "users"},
+		{Key: "index", Value: bson.A{"city_1", "missing_1"}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, partialDrop, "IndexNotFound")
+	afterPartialDrop := serveCommand(t, server, 241, bson.D{
+		{Key: "listIndexes", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	indexBatch := cursorFirstBatch(t, afterPartialDrop)
+	if got, want := len(indexBatch), 3; got != want {
+		t.Fatalf("index batch after failed drop len=%d want %d", got, want)
+	}
+	assertIndexName(t, indexBatch[0], "_id_")
+	assertIndexName(t, indexBatch[1], "city_1")
+	assertIndexName(t, indexBatch[2], "email_1")
 }
 
 func TestApplySetUpdateAppendsNewFieldsInSetOrder(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the Mongo gateway collection/index metadata slice on top of the CRUD PR:

- exposes collection metadata listing through `listCollections`
- maps single-field ascending Mongo `createIndexes` declarations into TreeDB collection secondary indexes
- returns `_id_` plus TreeDB secondary indexes from `listIndexes`
- supports `dropIndexes` by removing secondary indexes from collection schema metadata
- adds collection API support for listing collections and dropping index metadata
- extends Go driver smoke coverage for create/list/drop index and list collection names

## Validation

- `GOWORK=off go test ./TreeDB/collections ./TreeDB/mongo_gateway/... -count=1`
