### PR TITLE
[codex] Expand Mongo gateway find planner

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -137,6 +137,8 @@ type CollectionSecondaryRunStats struct {
 	Build         time.Duration
 }
 
+// DocumentRecord is one primary collection record returned by ScanDocuments.
+// ID and Document are cloned byte slices owned by the caller.
 type DocumentRecord struct {
 	ID       []byte
 	Document []byte
@@ -2135,11 +2137,17 @@ func (c *Collection) FindByIndex(indexName, value string) ([][]byte, error) {
 	return c.FindByIndexValue(indexName, value)
 }
 
+// FindByIndexValue returns document IDs whose named secondary index equals
+// value. Supported scalar value types are string, bool, int32, int64, float64,
+// json.Number, and nil. If indexName does not exist, it returns nil, nil.
 func (c *Collection) FindByIndexValue(indexName string, value any) ([][]byte, error) {
 	out, _, err := c.findByIndexValue(indexName, value, 0)
 	return out, err
 }
 
+// FindByIndexValueLimit is like FindByIndexValue but stops after maxResults
+// document IDs and reports whether additional matches were present. If
+// indexName does not exist, it returns nil, false, nil.
 func (c *Collection) FindByIndexValueLimit(indexName string, value any, maxResults int) ([][]byte, bool, error) {
 	if maxResults <= 0 {
 		return nil, false, errors.New("collections: max index results must be positive")

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -132,6 +132,11 @@ type CollectionSecondaryRunStats struct {
 	Build         time.Duration
 }
 
+type DocumentRecord struct {
+	ID       []byte
+	Document []byte
+}
+
 type RootStoragePolicy string
 
 const (
@@ -1791,6 +1796,10 @@ func (c *Collection) getBufferedDocument(documentID []byte) ([]byte, bool) {
 }
 
 func (c *Collection) FindByIndex(indexName, value string) ([][]byte, error) {
+	return c.FindByIndexValue(indexName, value)
+}
+
+func (c *Collection) FindByIndexValue(indexName string, value any) ([][]byte, error) {
 	if c == nil {
 		return nil, errCollectionNil
 	}
@@ -1852,6 +1861,66 @@ func (c *Collection) FindByIndex(indexName, value string) ([][]byte, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+func (c *Collection) ScanDocuments(maxDocuments int) ([]DocumentRecord, bool, error) {
+	if c == nil {
+		return nil, false, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, false, errors.New("collections: db is nil")
+	}
+	if maxDocuments <= 0 {
+		return nil, false, errors.New("collections: max documents must be positive")
+	}
+	if err := c.flushBufferedNoIndex(); err != nil {
+		return nil, false, err
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, false, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return nil, false, err
+	}
+	if catalog == nil {
+		return nil, false, errCollectionNotFound
+	}
+	rootID := catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
+	if rootID == 0 {
+		return nil, false, nil
+	}
+	it, err := snap.IteratorAtRoot(rootID, nil, nil)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = it.Close() }()
+	out := make([]DocumentRecord, 0)
+	truncated := false
+	for it.Valid() {
+		if it.IsDeleted() {
+			it.Next()
+			continue
+		}
+		if len(out) >= maxDocuments {
+			truncated = true
+			break
+		}
+		out = append(out, DocumentRecord{
+			ID:       bytes.Clone(it.UnsafeKey()),
+			Document: it.ValueCopy(nil),
+		})
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return nil, false, err
+	}
+	return out, truncated, nil
 }
 
 func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCatalog, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2136,67 +2136,84 @@ func (c *Collection) FindByIndex(indexName, value string) ([][]byte, error) {
 }
 
 func (c *Collection) FindByIndexValue(indexName string, value any) ([][]byte, error) {
+	out, _, err := c.findByIndexValue(indexName, value, 0)
+	return out, err
+}
+
+func (c *Collection) FindByIndexValueLimit(indexName string, value any, maxResults int) ([][]byte, bool, error) {
+	if maxResults <= 0 {
+		return nil, false, errors.New("collections: max index results must be positive")
+	}
+	return c.findByIndexValue(indexName, value, maxResults)
+}
+
+func (c *Collection) findByIndexValue(indexName string, value any, maxResults int) ([][]byte, bool, error) {
 	if c == nil {
-		return nil, errCollectionNil
+		return nil, false, errCollectionNil
 	}
 	if err := ValidateIndexName(indexName); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if err := c.flushBufferedNoIndex(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
-		return nil, backenddb.ErrClosed
+		return nil, false, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
 	catalog, err := c.catalogForSnapshot(snap)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if catalog == nil {
-		return nil, errCollectionNotFound
+		return nil, false, errCollectionNotFound
 	}
 	idx, ok := findIndex(catalog.meta.Indexes, indexName)
 	if !ok {
-		return nil, nil
+		return nil, false, nil
 	}
 	rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
 	if rootID == 0 {
-		return nil, nil
+		return nil, false, nil
 	}
 	var arena []byte
 	arena, encoded, err := appendIndexScalar(arena, value)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	arena, prefix, err := appendIndexValuePrefixSlice(arena, encoded)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	it, err := snap.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
 	if errors.Is(err, tree.ErrKeyNotFound) {
-		return nil, nil
+		return nil, false, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer func() { _ = it.Close() }()
 	out := make([][]byte, 0, 1)
+	truncated := false
 	for it.Valid() {
 		key := it.UnsafeKey()
 		if !bytes.HasPrefix(key, prefix) {
 			break
 		}
 		if !it.IsDeleted() {
+			if maxResults > 0 && len(out) >= maxResults {
+				truncated = true
+				break
+			}
 			out = append(out, bytes.Clone(key[len(prefix):]))
 		}
 		it.Next()
 	}
 	if err := it.Error(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return out, nil
+	return out, truncated, nil
 }
 
 // ScanDocuments flushes buffered no-index writes before acquiring a snapshot,

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2199,6 +2199,9 @@ func (c *Collection) FindByIndexValue(indexName string, value any) ([][]byte, er
 	return out, nil
 }
 
+// ScanDocuments flushes buffered no-index writes before acquiring a snapshot,
+// then scans the collection primary root up to maxDocuments. The returned
+// boolean is true when additional documents were present beyond the limit.
 func (c *Collection) ScanDocuments(maxDocuments int) ([]DocumentRecord, bool, error) {
 	if c == nil {
 		return nil, false, errCollectionNil

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1308,6 +1308,36 @@ func TestCollectionScanDocumentsAndFindByIndexValue(t *testing.T) {
 	}
 }
 
+func TestCollectionFindByIndexValueMatchesLargeJSONInteger(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "big", Field: "big"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"big":9007199254740993}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	ids, err := col.FindByIndexValue("big", int64(9007199254740993))
+	if err != nil {
+		t.Fatalf("find by index value: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("ids=%q want u1", ids)
+	}
+}
+
 func TestCollectionCreateIndexBackfill_EmptyCollectionUpdatesSchema(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1260,10 +1260,11 @@ func TestCollectionScanDocumentsAndFindByIndexValue(t *testing.T) {
 		t.Fatalf("open collection: %v", err)
 	}
 	if _, err := col.InsertBatch(
-		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte("u1"), []byte("u2"), []byte("u3")},
 		[][]byte{
 			[]byte(`{"city":"hnl","name":"ada"}`),
 			[]byte(`{"city":"sfo","name":"grace"}`),
+			[]byte(`{"city":"hnl","name":"katherine"}`),
 		},
 	); err != nil {
 		t.Fatalf("insert batch: %v", err)
@@ -1273,8 +1274,16 @@ func TestCollectionScanDocumentsAndFindByIndexValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("find by index value: %v", err)
 	}
-	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
-		t.Fatalf("ids=%q want u1", ids)
+	if len(ids) != 2 || !bytes.Equal(ids[0], []byte("u1")) || !bytes.Equal(ids[1], []byte("u3")) {
+		t.Fatalf("ids=%q want u1,u3", ids)
+	}
+
+	ids, truncated, err := col.FindByIndexValueLimit("city", "hnl", 1)
+	if err != nil {
+		t.Fatalf("find by index value limit: %v", err)
+	}
+	if !truncated || len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("limited ids=%q truncated=%v want u1/true", ids, truncated)
 	}
 
 	records, truncated, err := col.ScanDocuments(10)
@@ -1284,8 +1293,8 @@ func TestCollectionScanDocumentsAndFindByIndexValue(t *testing.T) {
 	if truncated {
 		t.Fatal("scan unexpectedly truncated")
 	}
-	if len(records) != 2 {
-		t.Fatalf("records len=%d want 2", len(records))
+	if len(records) != 3 {
+		t.Fatalf("records len=%d want 3", len(records))
 	}
 	if !bytes.Equal(records[0].ID, []byte("u1")) || !bytes.Contains(records[0].Document, []byte(`"ada"`)) {
 		t.Fatalf("first record=%+v", records[0])

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1204,6 +1204,64 @@ func TestCollectionDropIndexUpdatesSchema(t *testing.T) {
 	}
 }
 
+func TestCollectionScanDocumentsAndFindByIndexValue(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"city":"hnl","name":"ada"}`),
+			[]byte(`{"city":"sfo","name":"grace"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	ids, err := col.FindByIndexValue("city", "hnl")
+	if err != nil {
+		t.Fatalf("find by index value: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("ids=%q want u1", ids)
+	}
+
+	records, truncated, err := col.ScanDocuments(10)
+	if err != nil {
+		t.Fatalf("scan documents: %v", err)
+	}
+	if truncated {
+		t.Fatal("scan unexpectedly truncated")
+	}
+	if len(records) != 2 {
+		t.Fatalf("records len=%d want 2", len(records))
+	}
+	if !bytes.Equal(records[0].ID, []byte("u1")) || !bytes.Contains(records[0].Document, []byte(`"ada"`)) {
+		t.Fatalf("first record=%+v", records[0])
+	}
+	records, truncated, err = col.ScanDocuments(1)
+	if err != nil {
+		t.Fatalf("scan limited documents: %v", err)
+	}
+	if !truncated || len(records) != 1 {
+		t.Fatalf("limited scan truncated=%v len=%d want true/1", truncated, len(records))
+	}
+}
+
 func TestCollectionCreateIndexBackfill_EmptyCollectionUpdatesSchema(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -1421,6 +1421,15 @@ func appendIndexScalar(dst []byte, value any) ([]byte, []byte, error) {
 		} else {
 			dst = append(dst, "b:0"...)
 		}
+	case int:
+		dst = append(dst, "n:"...)
+		dst = strconv.AppendInt(dst, int64(v), 10)
+	case int32:
+		dst = append(dst, "n:"...)
+		dst = strconv.AppendInt(dst, int64(v), 10)
+	case int64:
+		dst = append(dst, "n:"...)
+		dst = strconv.AppendInt(dst, v, 10)
 	case float64:
 		dst = append(dst, "n:"...)
 		dst = strconv.AppendFloat(dst, v, 'g', -1, 64)

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"sort"
 	"strconv"
@@ -817,7 +818,15 @@ func orderedIndexStateForDocumentWithArena(document []byte, runtimes []indexRunt
 		return state, err
 	}
 	var decoded any
-	if err := json.Unmarshal(document, &decoded); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("collections: index extraction requires JSON document: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			err = errors.New("unexpected trailing JSON value")
+		}
 		return nil, fmt.Errorf("collections: index extraction requires JSON document: %w", err)
 	}
 	obj, ok := decoded.(map[string]any)
@@ -1045,21 +1054,39 @@ func appendJSONParserIndexScalar(dst []byte, raw []byte, valueType jsonparser.Va
 			return dst, nil, fmt.Errorf("collections: unsupported indexed JSON boolean %q", raw)
 		}
 	case jsonparser.Number:
-		num, err := jsonparser.ParseFloat(raw)
-		if err != nil || math.IsInf(num, 0) {
-			if err != nil {
-				return dst, nil, fmt.Errorf("collections: unsupported indexed JSON number %q: %w", raw, err)
-			}
-			return dst, nil, fmt.Errorf("collections: unsupported indexed JSON number %q", raw)
-		}
-		dst = append(dst, "n:"...)
-		dst = strconv.AppendFloat(dst, num, 'g', -1, 64)
+		return appendJSONNumberIndexScalar(dst, string(raw))
 	case jsonparser.Null:
 		dst = append(dst, "z:"...)
 	default:
 		return dst, nil, fmt.Errorf("collections: unsupported indexed JSON value type %s", valueType)
 	}
 	return dst, dst[start:len(dst):len(dst)], nil
+}
+
+func appendJSONNumberIndexScalar(dst []byte, raw string) ([]byte, []byte, error) {
+	start := len(dst)
+	if jsonNumberLooksInteger(raw) {
+		num, err := strconv.ParseInt(raw, 10, 64)
+		if err == nil {
+			dst = append(dst, "n:"...)
+			dst = strconv.AppendInt(dst, num, 10)
+			return dst, dst[start:len(dst):len(dst)], nil
+		}
+	}
+	num, err := strconv.ParseFloat(raw, 64)
+	if err != nil || math.IsInf(num, 0) {
+		if err != nil {
+			return dst, nil, fmt.Errorf("collections: unsupported indexed JSON number %q: %w", raw, err)
+		}
+		return dst, nil, fmt.Errorf("collections: unsupported indexed JSON number %q", raw)
+	}
+	dst = append(dst, "n:"...)
+	dst = strconv.AppendFloat(dst, num, 'g', -1, 64)
+	return dst, dst[start:len(dst):len(dst)], nil
+}
+
+func jsonNumberLooksInteger(raw string) bool {
+	return !strings.ContainsAny(raw, ".eE")
 }
 
 func (a *indexEncodeArena) appendSingleValueRef(value []byte) [][]byte {
@@ -1433,6 +1460,8 @@ func appendIndexScalar(dst []byte, value any) ([]byte, []byte, error) {
 	case float64:
 		dst = append(dst, "n:"...)
 		dst = strconv.AppendFloat(dst, v, 'g', -1, 64)
+	case json.Number:
+		return appendJSONNumberIndexScalar(dst, v.String())
 	case nil:
 		dst = append(dst, "z:"...)
 	default:

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -1448,9 +1448,6 @@ func appendIndexScalar(dst []byte, value any) ([]byte, []byte, error) {
 		} else {
 			dst = append(dst, "b:0"...)
 		}
-	case int:
-		dst = append(dst, "n:"...)
-		dst = strconv.AppendInt(dst, int64(v), 10)
 	case int32:
 		dst = append(dst, "n:"...)
 		dst = strconv.AppendInt(dst, int64(v), 10)

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -154,6 +154,13 @@ func TestAppendIndexScalarEncodesIntoArena(t *testing.T) {
 	}
 }
 
+func TestAppendIndexScalarRejectsPlatformInt(t *testing.T) {
+	_, _, err := appendIndexScalar(nil, int(42))
+	if err == nil || !strings.Contains(err.Error(), "unsupported indexed value type int") {
+		t.Fatalf("appendIndexScalar(int) err=%v want unsupported int", err)
+	}
+}
+
 func TestOrderedIndexStateForDocumentHandlesScalarAndArrayValues(t *testing.T) {
 	scalarRuntime := []indexRuntime{{
 		def:  indexDefinition{name: "email", field: "email"},

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -188,6 +188,32 @@ func TestOrderedIndexStateForDocumentHandlesScalarAndArrayValues(t *testing.T) {
 	}
 }
 
+func TestOrderedIndexStateForDocumentPreservesLargeIntegerNumbers(t *testing.T) {
+	rootRuntime := []indexRuntime{{
+		def:  indexDefinition{name: "big", field: "big"},
+		path: []string{"big"},
+	}}
+	rootState, err := orderedIndexStateForDocument([]byte(`{"big":9007199254740993}`), rootRuntime, collectionOptions{})
+	if err != nil {
+		t.Fatalf("root large int index state: %v", err)
+	}
+	if got, want := rootState.valuesAt(0), [][]byte{[]byte("n:9007199254740993")}; !byteMatrixEqual(got, want) {
+		t.Fatalf("root large int values=%q want %q", got, want)
+	}
+
+	nestedRuntime := []indexRuntime{{
+		def:  indexDefinition{name: "big", field: "nested.big"},
+		path: []string{"nested", "big"},
+	}}
+	nestedState, err := orderedIndexStateForDocument([]byte(`{"nested":{"big":9007199254740993}}`), nestedRuntime, collectionOptions{})
+	if err != nil {
+		t.Fatalf("nested large int index state: %v", err)
+	}
+	if got, want := nestedState.valuesAt(0), [][]byte{[]byte("n:9007199254740993")}; !byteMatrixEqual(got, want) {
+		t.Fatalf("nested large int values=%q want %q", got, want)
+	}
+}
+
 func TestOrderedIndexStateForDocumentJSONRootFastPathPreservesFieldSemantics(t *testing.T) {
 	planner := insertBatchPlanner{
 		indexes: []indexDefinition{

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -131,6 +131,8 @@ func TestAppendIndexScalarEncodesIntoArena(t *testing.T) {
 		{name: "bool true", value: true, want: "b:1"},
 		{name: "bool false", value: false, want: "b:0"},
 		{name: "number", value: float64(42.5), want: "n:42.5"},
+		{name: "int32", value: int32(42), want: "n:42"},
+		{name: "int64", value: int64(9007199254740993), want: "n:9007199254740993"},
 		{name: "null", value: nil, want: "z:"},
 	}
 	for _, tc := range tests {

--- a/TreeDB/mongo_gateway/PLAN.md
+++ b/TreeDB/mongo_gateway/PLAN.md
@@ -268,6 +268,9 @@ Priority workloads:
 - Current metadata slice adds `listCollections`, `createIndexes`,
   `listIndexes`, and `dropIndexes` for single-field ascending collection
   secondary indexes.
+- Current find-planner slice adds `_id` `$in`, indexed scalar equality/`$in`,
+  top-level `$and`, bounded scan fallback for range predicates, single-field
+  sort, skip, limit, and top-level projection.
 
 Metrics to record for every run:
 

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -90,6 +90,9 @@ func (s *Server) findResponse(command wire.Document) (wire.Document, error) {
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
+	if err := validateFindCommandOptions(command, filter); err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
 	col, err := s.Collections.OpenCollection(name)
 	if errors.Is(err, collections.ErrCollectionNotFound) {
 		return marshalCursorResponse(db, collection, bson.A{})

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -90,7 +90,8 @@ func (s *Server) findResponse(command wire.Document) (wire.Document, error) {
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
-	if err := validateFindCommandOptions(command, filter); err != nil {
+	plan, err := parseFindPlan(command, filter)
+	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
 	col, err := s.Collections.OpenCollection(name)
@@ -100,7 +101,7 @@ func (s *Server) findResponse(command wire.Document) (wire.Document, error) {
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	firstBatch, err := s.executeFind(col, command, filter)
+	firstBatch, err := s.executeFind(col, plan)
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -91,44 +91,18 @@ func (s *Server) findResponse(command wire.Document) (wire.Document, error) {
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
-	if filter == nil {
-		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway find currently requires an _id equality filter")
-	}
-	id, err := idEqualityFilterValue(filter, "find")
-	if err != nil {
-		return commandError(commandCodeBadValue, "BadValue", err.Error())
-	}
-	key, err := encodePrimaryKey(id)
-	if err != nil {
-		return commandError(commandCodeBadValue, "BadValue", err.Error())
-	}
-
-	firstBatch := bson.A{}
 	col, err := s.Collections.OpenCollection(name)
-	if err == nil {
-		stored, err := col.Get(key)
-		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
-		}
-		if len(stored) > 0 {
-			doc, err := storedDocumentToBSON(stored)
-			if err != nil {
-				return commandError(commandCodeBadValue, "BadValue", err.Error())
-			}
-			firstBatch = append(firstBatch, bson.Raw(doc))
-		}
-	} else if !errors.Is(err, collections.ErrCollectionNotFound) {
+	if errors.Is(err, collections.ErrCollectionNotFound) {
+		return marshalCursorResponse(db, collection, bson.A{})
+	}
+	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-
-	return marshalDocument(bson.D{
-		{Key: "cursor", Value: bson.D{
-			{Key: "id", Value: int64(0)},
-			{Key: "ns", Value: db + "." + collection},
-			{Key: "firstBatch", Value: firstBatch},
-		}},
-		{Key: "ok", Value: 1.0},
-	})
+	firstBatch, err := s.executeFind(col, command, filter)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	return marshalCursorResponse(db, collection, firstBatch)
 }
 
 func (s *Server) updateResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -76,6 +76,8 @@ func parseFindPlan(command wire.Document, filter wire.Document) (findPlan, error
 }
 
 func (s *Server) executeFind(col *collections.Collection, plan findPlan) (bson.A, error) {
+	// MaxFindScanDocuments is a candidate-work cap, not a page-size cap. It is
+	// intentionally enforced before later skip/limit pagination.
 	docs, err := s.findCandidateDocuments(col, plan.predicates)
 	if err != nil {
 		return nil, err
@@ -133,7 +135,10 @@ func (s *Server) executeFind(col *collections.Collection, plan findPlan) (bson.A
 	return firstBatch, nil
 }
 
-const findBatchOverheadBytes = 5 // BSON document length plus trailing NUL.
+const (
+	findBatchOverheadBytes        = 5 // BSON document length plus trailing NUL.
+	findBatchResponseReserveBytes = 4096
+)
 
 func findBatchDocumentBytes(doc wire.Document, index int) int {
 	return len(doc) + bsonArrayElementOverhead(index)
@@ -149,7 +154,7 @@ func validateFindCommandOptions(command wire.Document, filter wire.Document) err
 }
 
 func (s *Server) maxFindBatchBytes() int {
-	max := int(s.maxMessageLength()) - 4096
+	max := int(s.maxMessageLength()) - findBatchResponseReserveBytes
 	if max < 0 {
 		return 0
 	}
@@ -202,6 +207,8 @@ func (s *Server) findCandidateDocuments(col *collections.Collection, predicates 
 }
 
 func (s *Server) limitCandidateDocuments(docs []wire.Document) ([]wire.Document, error) {
+	// This bound limits planner work and memory before predicate filtering,
+	// sorting, projection, and skip/limit pagination are applied.
 	if len(docs) > s.maxFindScanDocuments() {
 		return nil, fmt.Errorf("Mongo gateway find candidate set exceeded %d documents", s.maxFindScanDocuments())
 	}
@@ -253,10 +260,11 @@ func documentsForPrimaryPredicate(col *collections.Collection, pred findPredicat
 		if err != nil {
 			return nil, err
 		}
-		if _, ok := seen[string(key)]; ok {
+		encodedKey := string(key)
+		if _, ok := seen[encodedKey]; ok {
 			continue
 		}
-		seen[string(key)] = struct{}{}
+		seen[encodedKey] = struct{}{}
 		stored, err := col.Get(key)
 		if err != nil {
 			return nil, err
@@ -764,6 +772,13 @@ func projectionValueIncluded(value bson.RawValue) (bool, error) {
 func lookupDocumentValue(doc wire.Document, field string) (bson.RawValue, bool) {
 	if field == "" {
 		return bson.RawValue{}, false
+	}
+	if !strings.Contains(field, ".") {
+		value := bson.Raw(doc).Lookup(field)
+		if value.IsZero() {
+			return bson.RawValue{}, false
+		}
+		return value, true
 	}
 	parts := strings.Split(field, ".")
 	current := bson.Raw(doc)

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -85,7 +85,11 @@ func (s *Server) executeFind(col *collections.Collection, command wire.Document,
 		docs = docs[:limit]
 	}
 
-	projection, err := commandOptionalDocument(command, "projection")
+	projectionDoc, err := commandOptionalDocument(command, "projection")
+	if err != nil {
+		return nil, err
+	}
+	projection, err := compileProjection(projectionDoc)
 	if err != nil {
 		return nil, err
 	}
@@ -93,12 +97,15 @@ func (s *Server) executeFind(col *collections.Collection, command wire.Document,
 	batchBytes := 0
 	maxBatchBytes := s.maxFindBatchBytes()
 	for _, doc := range docs {
-		projected, err := projectDocument(doc, projection)
+		projected, err := projectDocumentWithProjection(doc, projection)
 		if err != nil {
 			return nil, err
 		}
 		docBytes := len(projected) + 16
-		if len(firstBatch) > 0 && batchBytes+docBytes > maxBatchBytes {
+		if docBytes > maxBatchBytes {
+			return nil, fmt.Errorf("Mongo gateway find result document exceeds max message size")
+		}
+		if batchBytes+docBytes > maxBatchBytes {
 			break
 		}
 		firstBatch = append(firstBatch, bson.Raw(projected))
@@ -131,8 +138,8 @@ func validateFindCommandOptions(command wire.Document, filter wire.Document) err
 
 func (s *Server) maxFindBatchBytes() int {
 	max := int(s.maxMessageLength()) - 4096
-	if max < 1024 {
-		return 1024
+	if max < 0 {
+		return 0
 	}
 	return max
 }
@@ -140,10 +147,18 @@ func (s *Server) maxFindBatchBytes() int {
 func (s *Server) findCandidateDocuments(col *collections.Collection, predicates []findPredicate) ([]wire.Document, error) {
 	meta := col.Meta()
 	if pred, ok := primaryCandidatePredicate(predicates); ok {
-		return documentsForPrimaryPredicate(col, pred)
+		docs, err := documentsForPrimaryPredicate(col, pred)
+		if err != nil {
+			return nil, err
+		}
+		return s.limitCandidateDocuments(docs)
 	}
 	if pred, idx, ok := indexedCandidatePredicate(meta, predicates); ok {
-		return documentsForIndexedPredicate(col, pred, idx)
+		docs, err := documentsForIndexedPredicate(col, pred, idx)
+		if err != nil {
+			return nil, err
+		}
+		return s.limitCandidateDocuments(docs)
 	}
 	records, truncated, err := col.ScanDocuments(s.maxFindScanDocuments())
 	if err != nil {
@@ -161,6 +176,13 @@ func (s *Server) findCandidateDocuments(col *collections.Collection, predicates 
 		out = append(out, doc)
 	}
 	return out, nil
+}
+
+func (s *Server) limitCandidateDocuments(docs []wire.Document) ([]wire.Document, error) {
+	if len(docs) > s.maxFindScanDocuments() {
+		return nil, fmt.Errorf("Mongo gateway find candidate set exceeded %d documents", s.maxFindScanDocuments())
+	}
+	return docs, nil
 }
 
 func primaryCandidatePredicate(predicates []findPredicate) (findPredicate, bool) {
@@ -531,19 +553,49 @@ func compareDocumentField(left, right wire.Document, field string) int {
 	return compareRawValues(leftValue, rightValue)
 }
 
-func projectDocument(doc wire.Document, projection wire.Document) (wire.Document, error) {
+type compiledProjection struct {
+	present     bool
+	mode        projectionMode
+	fields      map[string]struct{}
+	includeID   bool
+	idSpecified bool
+}
+
+func compileProjection(projection wire.Document) (compiledProjection, error) {
 	if projection == nil {
-		return doc, nil
+		return compiledProjection{}, nil
 	}
 	mode, fields, includeID, idSpecified, err := parseProjection(projection)
 	if err != nil {
+		return compiledProjection{}, err
+	}
+	return compiledProjection{
+		present:     true,
+		mode:        mode,
+		fields:      fields,
+		includeID:   includeID,
+		idSpecified: idSpecified,
+	}, nil
+}
+
+func projectDocument(doc wire.Document, projection wire.Document) (wire.Document, error) {
+	compiled, err := compileProjection(projection)
+	if err != nil {
 		return nil, err
 	}
+	return projectDocumentWithProjection(doc, compiled)
+}
+
+func projectDocumentWithProjection(doc wire.Document, projection compiledProjection) (wire.Document, error) {
+	if !projection.present {
+		return doc, nil
+	}
+	mode := projection.mode
 	if mode == projectionNone {
-		if !idSpecified {
+		if !projection.idSpecified {
 			return doc, nil
 		}
-		if includeID {
+		if projection.includeID {
 			mode = projectionInclude
 		} else {
 			mode = projectionExclude
@@ -559,10 +611,10 @@ func projectDocument(doc wire.Document, projection wire.Document) (wire.Document
 		if err != nil {
 			return nil, err
 		}
-		if key == "_id" && !includeID {
+		if key == "_id" && !projection.includeID {
 			continue
 		}
-		_, selected := fields[key]
+		_, selected := projection.fields[key]
 		if mode == projectionInclude && (selected || key == "_id") {
 			out = append(out, bson.E{Key: key, Value: elem.Value()})
 		}

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -36,18 +36,52 @@ type findSort struct {
 	desc  bool
 }
 
-func (s *Server) executeFind(col *collections.Collection, command wire.Document, filter wire.Document) (bson.A, error) {
+type findPlan struct {
+	predicates []findPredicate
+	sort       findSort
+	skip       int32
+	limit      int32
+	projection compiledProjection
+}
+
+func parseFindPlan(command wire.Document, filter wire.Document) (findPlan, error) {
 	predicates, err := parseFindPredicates(filter)
 	if err != nil {
-		return nil, err
+		return findPlan{}, err
 	}
-	docs, err := s.findCandidateDocuments(col, predicates)
+	sortSpec, err := parseFindSort(command)
+	if err != nil {
+		return findPlan{}, err
+	}
+	skip, limit, err := parseFindPagination(command)
+	if err != nil {
+		return findPlan{}, err
+	}
+	projectionDoc, err := commandOptionalDocument(command, "projection")
+	if err != nil {
+		return findPlan{}, err
+	}
+	projection, err := compileProjection(projectionDoc)
+	if err != nil {
+		return findPlan{}, err
+	}
+	return findPlan{
+		predicates: predicates,
+		sort:       sortSpec,
+		skip:       skip,
+		limit:      limit,
+		projection: projection,
+	}, nil
+}
+
+func (s *Server) executeFind(col *collections.Collection, plan findPlan) (bson.A, error) {
+	docs, err := s.findCandidateDocuments(col, plan.predicates)
 	if err != nil {
 		return nil, err
 	}
 	filtered := docs[:0]
 	for _, doc := range docs {
-		match, err := documentMatchesPredicates(doc, predicates)
+		match, err := documentMatchesPredicates(doc, plan.predicates)
 		if err != nil {
 			return nil, err
 		}
@@ -57,57 +91,40 @@ func (s *Server) executeFind(col *collections.Collection, command wire.Document,
 	}
 	docs = filtered
 
-	sortSpec, err := parseFindSort(command)
-	if err != nil {
-		return nil, err
-	}
-	if sortSpec.field != "" {
+	if plan.sort.field != "" {
 		sort.SliceStable(docs, func(i, j int) bool {
-			cmp := compareDocumentField(docs[i], docs[j], sortSpec.field)
-			if sortSpec.desc {
+			cmp := compareDocumentField(docs[i], docs[j], plan.sort.field)
+			if plan.sort.desc {
 				return cmp > 0
 			}
 			return cmp < 0
 		})
 	}
 
-	skip, limit, err := parseFindPagination(command)
-	if err != nil {
-		return nil, err
-	}
-	if skip > 0 {
-		if int(skip) >= len(docs) {
+	if plan.skip > 0 {
+		if int(plan.skip) >= len(docs) {
 			docs = nil
 		} else {
-			docs = docs[skip:]
+			docs = docs[plan.skip:]
 		}
 	}
-	if limit > 0 && int(limit) < len(docs) {
-		docs = docs[:limit]
-	}
-
-	projectionDoc, err := commandOptionalDocument(command, "projection")
-	if err != nil {
-		return nil, err
-	}
-	projection, err := compileProjection(projectionDoc)
-	if err != nil {
-		return nil, err
+	if plan.limit > 0 && int(plan.limit) < len(docs) {
+		docs = docs[:plan.limit]
 	}
 	firstBatch := make(bson.A, 0, len(docs))
 	batchBytes := 0
 	maxBatchBytes := s.maxFindBatchBytes()
 	for _, doc := range docs {
-		projected, err := projectDocumentWithProjection(doc, projection)
+		projected, err := projectDocumentWithProjection(doc, plan.projection)
 		if err != nil {
 			return nil, err
 		}
 		docBytes := len(projected) + 16
 		if docBytes > maxBatchBytes {
-			return nil, fmt.Errorf("Mongo gateway find result document exceeds max message size")
+			return nil, fmt.Errorf("Mongo gateway find result document exceeds max message size: docBytes=%d maxBatchBytes=%d", docBytes, maxBatchBytes)
 		}
 		if batchBytes+docBytes > maxBatchBytes {
-			return nil, fmt.Errorf("Mongo gateway find results exceed max message size")
+			return nil, fmt.Errorf("Mongo gateway find results exceed max message size: batchBytes=%d docBytes=%d maxBatchBytes=%d", batchBytes, docBytes, maxBatchBytes)
 		}
 		firstBatch = append(firstBatch, bson.Raw(projected))
 		batchBytes += docBytes
@@ -116,25 +133,8 @@ func (s *Server) executeFind(col *collections.Collection, command wire.Document,
 }
 
 func validateFindCommandOptions(command wire.Document, filter wire.Document) error {
-	if _, err := parseFindPredicates(filter); err != nil {
-		return err
-	}
-	if _, err := parseFindSort(command); err != nil {
-		return err
-	}
-	if _, _, err := parseFindPagination(command); err != nil {
-		return err
-	}
-	projection, err := commandOptionalDocument(command, "projection")
-	if err != nil {
-		return err
-	}
-	if projection != nil {
-		if _, _, _, _, err := parseProjection(projection); err != nil {
-			return err
-		}
-	}
-	return nil
+	_, err := parseFindPlan(command, filter)
+	return err
 }
 
 func (s *Server) maxFindBatchBytes() int {
@@ -511,6 +511,9 @@ func parseFindSort(command wire.Document) (findSort, error) {
 	if err != nil {
 		return findSort{}, err
 	}
+	if field == "" || strings.HasPrefix(field, "$") {
+		return findSort{}, errors.New("Mongo gateway find sort field must be a supported document field")
+	}
 	value := elements[0].Value()
 	if isAscendingIndexKey(value) {
 		return findSort{field: field}, nil
@@ -884,9 +887,15 @@ func indexScalarForBSONValue(value bson.RawValue) (any, bool) {
 		return nil, true
 	case bson.TypeDouble:
 		out, ok := value.DoubleOK()
+		if ok && (math.IsNaN(out) || math.IsInf(out, 0)) {
+			return nil, false
+		}
 		return out, ok
-	case bson.TypeInt32, bson.TypeInt64:
-		out, ok := value.AsFloat64OK()
+	case bson.TypeInt32:
+		out, ok := value.Int32OK()
+		return out, ok
+	case bson.TypeInt64:
+		out, ok := value.Int64OK()
 		return out, ok
 	default:
 		return nil, false

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math/big"
 	"sort"
 	"strings"
 
@@ -61,10 +62,7 @@ func (s *Server) executeFind(col *collections.Collection, command wire.Document,
 	}
 	if sortSpec.field != "" {
 		sort.SliceStable(docs, func(i, j int) bool {
-			cmp, ok := compareDocumentField(docs[i], docs[j], sortSpec.field)
-			if !ok {
-				return false
-			}
+			cmp := compareDocumentField(docs[i], docs[j], sortSpec.field)
 			if sortSpec.desc {
 				return cmp > 0
 			}
@@ -72,7 +70,7 @@ func (s *Server) executeFind(col *collections.Collection, command wire.Document,
 		})
 	}
 
-	skip, err := optionalInt32Field(command, "skip")
+	skip, limit, err := parseFindPagination(command)
 	if err != nil {
 		return nil, err
 	}
@@ -83,10 +81,6 @@ func (s *Server) executeFind(col *collections.Collection, command wire.Document,
 			docs = docs[skip:]
 		}
 	}
-	limit, err := optionalInt32Field(command, "limit")
-	if err != nil {
-		return nil, err
-	}
 	if limit > 0 && int(limit) < len(docs) {
 		docs = docs[:limit]
 	}
@@ -96,14 +90,51 @@ func (s *Server) executeFind(col *collections.Collection, command wire.Document,
 		return nil, err
 	}
 	firstBatch := make(bson.A, 0, len(docs))
+	batchBytes := 0
+	maxBatchBytes := s.maxFindBatchBytes()
 	for _, doc := range docs {
 		projected, err := projectDocument(doc, projection)
 		if err != nil {
 			return nil, err
 		}
+		docBytes := len(projected) + 16
+		if len(firstBatch) > 0 && batchBytes+docBytes > maxBatchBytes {
+			break
+		}
 		firstBatch = append(firstBatch, bson.Raw(projected))
+		batchBytes += docBytes
 	}
 	return firstBatch, nil
+}
+
+func validateFindCommandOptions(command wire.Document, filter wire.Document) error {
+	if _, err := parseFindPredicates(filter); err != nil {
+		return err
+	}
+	if _, err := parseFindSort(command); err != nil {
+		return err
+	}
+	if _, _, err := parseFindPagination(command); err != nil {
+		return err
+	}
+	projection, err := commandOptionalDocument(command, "projection")
+	if err != nil {
+		return err
+	}
+	if projection != nil {
+		if _, _, _, _, err := parseProjection(projection); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) maxFindBatchBytes() int {
+	max := int(s.maxMessageLength()) - 4096
+	if max < 1024 {
+		return 1024
+	}
+	return max
 }
 
 func (s *Server) findCandidateDocuments(col *collections.Collection, predicates []findPredicate) ([]wire.Document, error) {
@@ -363,10 +394,7 @@ func valueMatchesPredicate(value bson.RawValue, pred findPredicate) (bool, error
 		}
 		return false, nil
 	case findPredicateGT, findPredicateGTE, findPredicateLT, findPredicateLTE:
-		cmp, ok := compareRawValues(value, pred.values[0])
-		if !ok {
-			return false, nil
-		}
+		cmp := compareRawValues(value, pred.values[0])
 		switch pred.op {
 		case findPredicateGT:
 			return cmp > 0, nil
@@ -417,17 +445,32 @@ func parseFindSort(command wire.Document) (findSort, error) {
 	return findSort{}, errors.New("Mongo gateway find sort direction must be 1 or -1")
 }
 
-func compareDocumentField(left, right wire.Document, field string) (int, bool) {
+func parseFindPagination(command wire.Document) (int32, int32, error) {
+	skip, err := optionalInt32Field(command, "skip")
+	if err != nil {
+		return 0, 0, err
+	}
+	if skip < 0 {
+		return 0, 0, errors.New("Mongo gateway find skip must be non-negative")
+	}
+	limit, err := optionalInt32Field(command, "limit")
+	if err != nil {
+		return 0, 0, err
+	}
+	if limit < 0 {
+		return 0, 0, errors.New("Mongo gateway find limit must be non-negative")
+	}
+	return skip, limit, nil
+}
+
+func compareDocumentField(left, right wire.Document, field string) int {
 	leftValue, leftOK := lookupDocumentValue(left, field)
 	rightValue, rightOK := lookupDocumentValue(right, field)
-	if !leftOK && !rightOK {
-		return 0, true
-	}
 	if !leftOK {
-		return 1, true
+		leftValue = bson.RawValue{Type: bson.TypeNull}
 	}
 	if !rightOK {
-		return -1, true
+		rightValue = bson.RawValue{Type: bson.TypeNull}
 	}
 	return compareRawValues(leftValue, rightValue)
 }
@@ -436,12 +479,19 @@ func projectDocument(doc wire.Document, projection wire.Document) (wire.Document
 	if projection == nil {
 		return doc, nil
 	}
-	mode, fields, includeID, err := parseProjection(projection)
+	mode, fields, includeID, idSpecified, err := parseProjection(projection)
 	if err != nil {
 		return nil, err
 	}
 	if mode == projectionNone {
-		return doc, nil
+		if !idSpecified {
+			return doc, nil
+		}
+		if includeID {
+			mode = projectionInclude
+		} else {
+			mode = projectionExclude
+		}
 	}
 	elements, err := bson.Raw(doc).Elements()
 	if err != nil {
@@ -479,41 +529,43 @@ const (
 	projectionExclude
 )
 
-func parseProjection(projection wire.Document) (projectionMode, map[string]struct{}, bool, error) {
+func parseProjection(projection wire.Document) (projectionMode, map[string]struct{}, bool, bool, error) {
 	elements, err := bson.Raw(projection).Elements()
 	if err != nil {
-		return projectionNone, nil, true, err
+		return projectionNone, nil, true, false, err
 	}
 	fields := make(map[string]struct{}, len(elements))
 	mode := projectionNone
 	includeID := true
+	idSpecified := false
 	for _, elem := range elements {
 		key, err := elem.KeyErr()
 		if err != nil {
-			return projectionNone, nil, true, err
+			return projectionNone, nil, true, false, err
 		}
 		include, err := projectionValueIncluded(elem.Value())
 		if err != nil {
-			return projectionNone, nil, true, err
+			return projectionNone, nil, true, false, err
 		}
 		if key == "_id" {
 			includeID = include
+			idSpecified = true
 			continue
 		}
 		if strings.Contains(key, ".") {
-			return projectionNone, nil, true, errors.New("Mongo gateway projection currently supports top-level fields only")
+			return projectionNone, nil, true, false, errors.New("Mongo gateway projection currently supports top-level fields only")
 		}
 		nextMode := projectionExclude
 		if include {
 			nextMode = projectionInclude
 		}
 		if mode != projectionNone && mode != nextMode {
-			return projectionNone, nil, true, errors.New("Mongo gateway projection cannot mix include and exclude fields")
+			return projectionNone, nil, true, false, errors.New("Mongo gateway projection cannot mix include and exclude fields")
 		}
 		mode = nextMode
 		fields[key] = struct{}{}
 	}
-	return mode, fields, includeID, nil
+	return mode, fields, includeID, idSpecified, nil
 }
 
 func projectionValueIncluded(value bson.RawValue) (bool, error) {
@@ -557,52 +609,118 @@ func lookupDocumentValue(doc wire.Document, field string) (bson.RawValue, bool) 
 
 func rawValuesEqual(left, right bson.RawValue) bool {
 	if left.IsNumber() && right.IsNumber() {
-		leftNumber, leftOK := left.AsFloat64OK()
-		rightNumber, rightOK := right.AsFloat64OK()
-		return leftOK && rightOK && leftNumber == rightNumber
+		return compareRawValues(left, right) == 0
 	}
 	return left.Equal(right)
 }
 
-func compareRawValues(left, right bson.RawValue) (int, bool) {
+func compareRawValues(left, right bson.RawValue) int {
 	if left.IsNumber() && right.IsNumber() {
-		leftNumber, leftOK := left.AsFloat64OK()
-		rightNumber, rightOK := right.AsFloat64OK()
-		if !leftOK || !rightOK {
-			return 0, false
-		}
-		switch {
-		case leftNumber < rightNumber:
-			return -1, true
-		case leftNumber > rightNumber:
-			return 1, true
-		default:
-			return 0, true
-		}
+		return compareRawNumbers(left, right)
 	}
 	if left.Type != right.Type {
-		return 0, false
+		return compareInt(bsonTypeSortRank(left.Type), bsonTypeSortRank(right.Type))
 	}
 	switch left.Type {
 	case bson.TypeString:
-		return strings.Compare(left.StringValue(), right.StringValue()), true
+		return strings.Compare(left.StringValue(), right.StringValue())
 	case bson.TypeBoolean:
 		leftBool := left.Boolean()
 		rightBool := right.Boolean()
 		switch {
 		case leftBool == rightBool:
-			return 0, true
+			return 0
 		case !leftBool && rightBool:
-			return -1, true
+			return -1
 		default:
-			return 1, true
+			return 1
 		}
 	case bson.TypeNull:
-		return 0, true
+		return 0
 	case bson.TypeObjectID:
-		return bytes.Compare(left.Value, right.Value), true
+		return bytes.Compare(left.Value, right.Value)
 	default:
-		return bytes.Compare(left.Value, right.Value), true
+		return bytes.Compare(left.Value, right.Value)
+	}
+}
+
+func compareRawNumbers(left, right bson.RawValue) int {
+	leftRat, leftOK := rawNumberRat(left)
+	rightRat, rightOK := rawNumberRat(right)
+	if !leftOK || !rightOK {
+		return compareInt(bsonTypeSortRank(left.Type), bsonTypeSortRank(right.Type))
+	}
+	return leftRat.Cmp(rightRat)
+}
+
+func rawNumberRat(value bson.RawValue) (*big.Rat, bool) {
+	switch value.Type {
+	case bson.TypeInt32:
+		v, ok := value.Int32OK()
+		if !ok {
+			return nil, false
+		}
+		return big.NewRat(int64(v), 1), true
+	case bson.TypeInt64:
+		v, ok := value.Int64OK()
+		if !ok {
+			return nil, false
+		}
+		return big.NewRat(v, 1), true
+	case bson.TypeDouble:
+		v, ok := value.DoubleOK()
+		if !ok {
+			return nil, false
+		}
+		rat := new(big.Rat)
+		if rat.SetFloat64(v) == nil {
+			return nil, false
+		}
+		return rat, true
+	default:
+		return nil, false
+	}
+}
+
+func compareInt(left, right int) int {
+	switch {
+	case left < right:
+		return -1
+	case left > right:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func bsonTypeSortRank(t bson.Type) int {
+	switch t {
+	case bson.TypeMinKey:
+		return 0
+	case bson.TypeNull:
+		return 1
+	case bson.TypeInt32, bson.TypeInt64, bson.TypeDouble:
+		return 2
+	case bson.TypeString:
+		return 3
+	case bson.TypeEmbeddedDocument:
+		return 4
+	case bson.TypeArray:
+		return 5
+	case bson.TypeBinary:
+		return 6
+	case bson.TypeObjectID:
+		return 7
+	case bson.TypeBoolean:
+		return 8
+	case bson.TypeDateTime:
+		return 9
+	case bson.TypeTimestamp:
+		return 10
+	case bson.TypeMaxKey:
+		return 100
+	default:
+		return 50 + int(t)
 	}
 }
 

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -159,18 +159,29 @@ func (s *Server) maxFindBatchBytes() int {
 func (s *Server) findCandidateDocuments(col *collections.Collection, predicates []findPredicate) ([]wire.Document, error) {
 	meta := col.Meta()
 	maxDocuments := s.maxFindScanDocuments()
+	var primaryDocs []wire.Document
+	primarySet := false
 	if pred, ok := primaryCandidatePredicate(predicates); ok {
 		docs, err := documentsForPrimaryPredicate(col, pred, maxDocuments)
 		if err != nil {
 			return nil, err
 		}
-		return s.limitCandidateDocuments(docs)
+		primaryDocs = docs
+		primarySet = true
 	}
 	if docs, ok, err := s.bestIndexedCandidateDocuments(col, meta, predicates, maxDocuments); ok || err != nil {
 		if err != nil {
+			if primarySet {
+				return s.limitCandidateDocuments(primaryDocs)
+			}
 			return nil, err
 		}
-		return s.limitCandidateDocuments(docs)
+		if !primarySet || len(docs) < len(primaryDocs) {
+			return s.limitCandidateDocuments(docs)
+		}
+	}
+	if primarySet {
+		return s.limitCandidateDocuments(primaryDocs)
 	}
 	records, truncated, err := col.ScanDocuments(maxDocuments)
 	if err != nil {
@@ -538,7 +549,7 @@ func valueMatchesPredicate(value bson.RawValue, pred findPredicate) (bool, error
 
 func rangeValuesComparable(left, right bson.RawValue) bool {
 	if left.IsNumber() && right.IsNumber() {
-		return true
+		return rawNumberComparable(left) && rawNumberComparable(right)
 	}
 	return left.Type == right.Type
 }
@@ -562,7 +573,7 @@ func parseFindSort(command wire.Document) (findSort, error) {
 	if err != nil {
 		return findSort{}, err
 	}
-	if field == "" || strings.HasPrefix(field, "$") {
+	if field == "" || strings.HasPrefix(field, "$") || strings.Contains(field, ".") {
 		return findSort{}, errors.New("Mongo gateway find sort field must be a supported document field")
 	}
 	value := elements[0].Value()
@@ -914,7 +925,10 @@ func compareRawNumbers(left, right bson.RawValue) int {
 	if leftRank != rightRank {
 		return compareInt(leftRank, rightRank)
 	}
-	return bytes.Compare(left.Value, right.Value)
+	if left.Type != right.Type {
+		return compareInt(bsonTypeSortRank(left.Type), bsonTypeSortRank(right.Type))
+	}
+	return 0
 }
 
 func numberSortRank(value bson.RawValue, finite bool) int {
@@ -969,9 +983,55 @@ func rawNumberRat(value bson.RawValue) (*big.Rat, bool) {
 			return nil, false
 		}
 		return rat, true
+	case bson.TypeDecimal128:
+		v, ok := value.Decimal128OK()
+		if !ok {
+			return nil, false
+		}
+		return decimal128Rat(v)
 	default:
 		return nil, false
 	}
+}
+
+func rawNumberComparable(value bson.RawValue) bool {
+	if _, ok := rawNumberRat(value); ok {
+		return true
+	}
+	return rawNumberIsNonFiniteDouble(value) && !rawValueIsNaN(value)
+}
+
+func rawNumberIsNonFiniteDouble(value bson.RawValue) bool {
+	if value.Type != bson.TypeDouble {
+		return false
+	}
+	v, ok := value.DoubleOK()
+	return ok && (math.IsInf(v, -1) || math.IsInf(v, 1) || math.IsNaN(v))
+}
+
+func decimal128Rat(value bson.Decimal128) (*big.Rat, bool) {
+	significand, exponent, err := value.BigInt()
+	if err != nil {
+		return nil, false
+	}
+	rat := new(big.Rat).SetInt(significand)
+	if exponent == 0 {
+		return rat, true
+	}
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(absInt(exponent))), nil)
+	if exponent > 0 {
+		rat.Mul(rat, new(big.Rat).SetInt(scale))
+	} else {
+		rat.Quo(rat, new(big.Rat).SetInt(scale))
+	}
+	return rat, true
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
 }
 
 func compareInt(left, right int) int {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/big"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -154,8 +155,7 @@ func (s *Server) findCandidateDocuments(col *collections.Collection, predicates 
 		}
 		return s.limitCandidateDocuments(docs)
 	}
-	if pred, idx, ok := indexedCandidatePredicate(meta, predicates); ok {
-		docs, err := documentsForIndexedPredicate(col, pred, idx)
+	if docs, ok, err := s.bestIndexedCandidateDocuments(col, meta, predicates); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -184,6 +184,34 @@ func (s *Server) limitCandidateDocuments(docs []wire.Document) ([]wire.Document,
 		return nil, fmt.Errorf("Mongo gateway find candidate set exceeded %d documents", s.maxFindScanDocuments())
 	}
 	return docs, nil
+}
+
+func (s *Server) bestIndexedCandidateDocuments(col *collections.Collection, meta collections.CollectionMeta, predicates []findPredicate) ([]wire.Document, bool, error) {
+	var best []wire.Document
+	bestSet := false
+	for _, pred := range predicates {
+		if pred.op != findPredicateEq && pred.op != findPredicateIn {
+			continue
+		}
+		if predicateContainsNull(pred) {
+			continue
+		}
+		for _, idx := range meta.Indexes {
+			if idx.Field != pred.field {
+				continue
+			}
+			docs, err := documentsForIndexedPredicate(col, pred, idx)
+			if err != nil {
+				return nil, false, err
+			}
+			if !bestSet || len(docs) < len(best) {
+				best = docs
+				bestSet = true
+			}
+			break
+		}
+	}
+	return best, bestSet, nil
 }
 
 func primaryCandidatePredicate(predicates []findPredicate) (findPredicate, bool) {
@@ -424,16 +452,29 @@ func rangeOperator(op string) findPredicateOp {
 
 func documentMatchesPredicates(doc wire.Document, predicates []findPredicate) (bool, error) {
 	for _, pred := range predicates {
-		value, ok := lookupDocumentValue(doc, pred.field)
+		values, ok, err := lookupDocumentPredicateValues(doc, pred.field)
+		if err != nil {
+			return false, err
+		}
 		if !ok {
 			if missingValueMatchesPredicate(pred) {
 				continue
 			}
 			return false, nil
 		}
-		match, err := valueMatchesPredicate(value, pred)
-		if err != nil || !match {
-			return match, err
+		matched := false
+		for _, value := range values {
+			match, err := valueMatchesPredicate(value, pred)
+			if err != nil {
+				return false, err
+			}
+			if match {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false, nil
 		}
 	}
 	return true, nil
@@ -720,6 +761,85 @@ func lookupDocumentValue(doc wire.Document, field string) (bson.RawValue, bool) 
 		current = next
 	}
 	return bson.RawValue{}, false
+}
+
+func lookupDocumentPredicateValues(doc wire.Document, field string) ([]bson.RawValue, bool, error) {
+	if field == "" {
+		return nil, false, nil
+	}
+	parts := strings.Split(field, ".")
+	return lookupRawValuesForParts(bson.Raw(doc), parts)
+}
+
+func lookupRawValuesForParts(current bson.Raw, parts []string) ([]bson.RawValue, bool, error) {
+	if len(parts) == 0 {
+		return nil, false, nil
+	}
+	value := current.Lookup(parts[0])
+	if value.IsZero() {
+		return nil, false, nil
+	}
+	if len(parts) == 1 {
+		return []bson.RawValue{value}, true, nil
+	}
+	return lookupRawValueDescendants(value, parts[1:])
+}
+
+func lookupRawValueDescendants(value bson.RawValue, parts []string) ([]bson.RawValue, bool, error) {
+	if doc, ok := value.DocumentOK(); ok {
+		return lookupRawValuesForParts(doc, parts)
+	}
+	array, ok := value.ArrayOK()
+	if !ok {
+		return nil, false, nil
+	}
+	values, err := array.Values()
+	if err != nil {
+		return nil, false, err
+	}
+	if index, ok := dottedArrayIndex(parts[0]); ok {
+		if index >= len(values) {
+			return nil, false, nil
+		}
+		if len(parts) == 1 {
+			return []bson.RawValue{values[index]}, true, nil
+		}
+		return lookupRawValueDescendants(values[index], parts[1:])
+	}
+	var out []bson.RawValue
+	for _, item := range values {
+		doc, ok := item.DocumentOK()
+		if !ok {
+			continue
+		}
+		itemValues, itemOK, err := lookupRawValuesForParts(doc, parts)
+		if err != nil {
+			return nil, false, err
+		}
+		if itemOK {
+			out = append(out, itemValues...)
+		}
+	}
+	if len(out) == 0 {
+		return nil, false, nil
+	}
+	return out, true, nil
+}
+
+func dottedArrayIndex(part string) (int, bool) {
+	if part == "" {
+		return 0, false
+	}
+	for _, r := range part {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
+	index, err := strconv.Atoi(part)
+	if err != nil {
+		return 0, false
+	}
+	return index, true
 }
 
 func rawValuesEqual(left, right bson.RawValue) bool {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -1,0 +1,628 @@
+package mongogateway
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type findPredicateOp uint8
+
+const (
+	findPredicateEq findPredicateOp = iota + 1
+	findPredicateIn
+	findPredicateGT
+	findPredicateGTE
+	findPredicateLT
+	findPredicateLTE
+)
+
+type findPredicate struct {
+	field  string
+	op     findPredicateOp
+	values []bson.RawValue
+}
+
+type findSort struct {
+	field string
+	desc  bool
+}
+
+func (s *Server) executeFind(col *collections.Collection, command wire.Document, filter wire.Document) (bson.A, error) {
+	predicates, err := parseFindPredicates(filter)
+	if err != nil {
+		return nil, err
+	}
+	docs, err := s.findCandidateDocuments(col, predicates)
+	if err != nil {
+		return nil, err
+	}
+	filtered := docs[:0]
+	for _, doc := range docs {
+		match, err := documentMatchesPredicates(doc, predicates)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			filtered = append(filtered, doc)
+		}
+	}
+	docs = filtered
+
+	sortSpec, err := parseFindSort(command)
+	if err != nil {
+		return nil, err
+	}
+	if sortSpec.field != "" {
+		sort.SliceStable(docs, func(i, j int) bool {
+			cmp, ok := compareDocumentField(docs[i], docs[j], sortSpec.field)
+			if !ok {
+				return false
+			}
+			if sortSpec.desc {
+				return cmp > 0
+			}
+			return cmp < 0
+		})
+	}
+
+	skip, err := optionalInt32Field(command, "skip")
+	if err != nil {
+		return nil, err
+	}
+	if skip > 0 {
+		if int(skip) >= len(docs) {
+			docs = nil
+		} else {
+			docs = docs[skip:]
+		}
+	}
+	limit, err := optionalInt32Field(command, "limit")
+	if err != nil {
+		return nil, err
+	}
+	if limit > 0 && int(limit) < len(docs) {
+		docs = docs[:limit]
+	}
+
+	projection, err := commandOptionalDocument(command, "projection")
+	if err != nil {
+		return nil, err
+	}
+	firstBatch := make(bson.A, 0, len(docs))
+	for _, doc := range docs {
+		projected, err := projectDocument(doc, projection)
+		if err != nil {
+			return nil, err
+		}
+		firstBatch = append(firstBatch, bson.Raw(projected))
+	}
+	return firstBatch, nil
+}
+
+func (s *Server) findCandidateDocuments(col *collections.Collection, predicates []findPredicate) ([]wire.Document, error) {
+	meta := col.Meta()
+	if pred, ok := primaryCandidatePredicate(predicates); ok {
+		return documentsForPrimaryPredicate(col, pred)
+	}
+	if pred, idx, ok := indexedCandidatePredicate(meta, predicates); ok {
+		return documentsForIndexedPredicate(col, pred, idx)
+	}
+	records, truncated, err := col.ScanDocuments(s.maxFindScanDocuments())
+	if err != nil {
+		return nil, err
+	}
+	if truncated {
+		return nil, fmt.Errorf("Mongo gateway find requires a bounded scan and exceeded %d documents", s.maxFindScanDocuments())
+	}
+	out := make([]wire.Document, 0, len(records))
+	for _, record := range records {
+		doc, err := storedDocumentToBSON(record.Document)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, doc)
+	}
+	return out, nil
+}
+
+func primaryCandidatePredicate(predicates []findPredicate) (findPredicate, bool) {
+	for _, pred := range predicates {
+		if pred.field == "_id" && (pred.op == findPredicateEq || pred.op == findPredicateIn) {
+			return pred, true
+		}
+	}
+	return findPredicate{}, false
+}
+
+func indexedCandidatePredicate(meta collections.CollectionMeta, predicates []findPredicate) (findPredicate, collections.IndexDefinition, bool) {
+	for _, pred := range predicates {
+		if pred.op != findPredicateEq && pred.op != findPredicateIn {
+			continue
+		}
+		for _, idx := range meta.Indexes {
+			if idx.Field == pred.field {
+				return pred, idx, true
+			}
+		}
+	}
+	return findPredicate{}, collections.IndexDefinition{}, false
+}
+
+func documentsForPrimaryPredicate(col *collections.Collection, pred findPredicate) ([]wire.Document, error) {
+	out := make([]wire.Document, 0, len(pred.values))
+	seen := make(map[string]struct{}, len(pred.values))
+	for _, value := range pred.values {
+		key, err := encodePrimaryKey(value)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[string(key)]; ok {
+			continue
+		}
+		seen[string(key)] = struct{}{}
+		stored, err := col.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		if len(stored) == 0 {
+			continue
+		}
+		doc, err := storedDocumentToBSON(stored)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, doc)
+	}
+	return out, nil
+}
+
+func documentsForIndexedPredicate(col *collections.Collection, pred findPredicate, idx collections.IndexDefinition) ([]wire.Document, error) {
+	out := make([]wire.Document, 0)
+	seen := make(map[string]struct{})
+	for _, value := range pred.values {
+		scalar, ok := indexScalarForBSONValue(value)
+		if !ok {
+			continue
+		}
+		ids, err := col.FindByIndexValue(idx.Name, scalar)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range ids {
+			if _, ok := seen[string(id)]; ok {
+				continue
+			}
+			seen[string(id)] = struct{}{}
+			stored, err := col.Get(id)
+			if err != nil {
+				return nil, err
+			}
+			if len(stored) == 0 {
+				continue
+			}
+			doc, err := storedDocumentToBSON(stored)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, doc)
+		}
+	}
+	return out, nil
+}
+
+func parseFindPredicates(filter wire.Document) ([]findPredicate, error) {
+	if filter == nil {
+		return nil, nil
+	}
+	return parseFindPredicateDocument(filter)
+}
+
+func parseFindPredicateDocument(doc wire.Document) ([]findPredicate, error) {
+	elements, err := bson.Raw(doc).Elements()
+	if err != nil {
+		return nil, err
+	}
+	var out []findPredicate
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, err
+		}
+		value := elem.Value()
+		if key == "$and" {
+			preds, err := parseAndPredicates(value)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, preds...)
+			continue
+		}
+		preds, err := parseFieldPredicate(key, value)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, preds...)
+	}
+	return out, nil
+}
+
+func parseAndPredicates(value bson.RawValue) ([]findPredicate, error) {
+	array, ok := value.ArrayOK()
+	if !ok {
+		return nil, errors.New("Mongo gateway $and must be an array")
+	}
+	values, err := array.Values()
+	if err != nil {
+		return nil, err
+	}
+	var out []findPredicate
+	for i, value := range values {
+		doc, ok := value.DocumentOK()
+		if !ok {
+			return nil, fmt.Errorf("Mongo gateway $and[%d] must be a document", i)
+		}
+		preds, err := parseFindPredicateDocument(wire.Document(doc))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, preds...)
+	}
+	return out, nil
+}
+
+func parseFieldPredicate(field string, value bson.RawValue) ([]findPredicate, error) {
+	if field == "" || strings.HasPrefix(field, "$") {
+		return nil, fmt.Errorf("Mongo gateway unsupported find predicate %q", field)
+	}
+	if doc, ok := value.DocumentOK(); ok && operatorDocument(doc) {
+		elements, err := doc.Elements()
+		if err != nil {
+			return nil, err
+		}
+		out := make([]findPredicate, 0, len(elements))
+		for _, elem := range elements {
+			op, err := elem.KeyErr()
+			if err != nil {
+				return nil, err
+			}
+			opValue := elem.Value()
+			switch op {
+			case "$in":
+				array, ok := opValue.ArrayOK()
+				if !ok {
+					return nil, fmt.Errorf("Mongo gateway find field %q $in must be an array", field)
+				}
+				values, err := array.Values()
+				if err != nil {
+					return nil, err
+				}
+				out = append(out, findPredicate{field: field, op: findPredicateIn, values: values})
+			case "$gt", "$gte", "$lt", "$lte":
+				out = append(out, findPredicate{field: field, op: rangeOperator(op), values: []bson.RawValue{opValue}})
+			default:
+				return nil, fmt.Errorf("Mongo gateway unsupported find operator %q", op)
+			}
+		}
+		return out, nil
+	}
+	return []findPredicate{{field: field, op: findPredicateEq, values: []bson.RawValue{value}}}, nil
+}
+
+func operatorDocument(doc bson.Raw) bool {
+	elements, err := doc.Elements()
+	if err != nil || len(elements) == 0 {
+		return false
+	}
+	key, err := elements[0].KeyErr()
+	return err == nil && strings.HasPrefix(key, "$")
+}
+
+func rangeOperator(op string) findPredicateOp {
+	switch op {
+	case "$gt":
+		return findPredicateGT
+	case "$gte":
+		return findPredicateGTE
+	case "$lt":
+		return findPredicateLT
+	default:
+		return findPredicateLTE
+	}
+}
+
+func documentMatchesPredicates(doc wire.Document, predicates []findPredicate) (bool, error) {
+	for _, pred := range predicates {
+		value, ok := lookupDocumentValue(doc, pred.field)
+		if !ok {
+			return false, nil
+		}
+		match, err := valueMatchesPredicate(value, pred)
+		if err != nil || !match {
+			return match, err
+		}
+	}
+	return true, nil
+}
+
+func valueMatchesPredicate(value bson.RawValue, pred findPredicate) (bool, error) {
+	switch pred.op {
+	case findPredicateEq:
+		return rawValuesEqual(value, pred.values[0]), nil
+	case findPredicateIn:
+		for _, candidate := range pred.values {
+			if rawValuesEqual(value, candidate) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case findPredicateGT, findPredicateGTE, findPredicateLT, findPredicateLTE:
+		cmp, ok := compareRawValues(value, pred.values[0])
+		if !ok {
+			return false, nil
+		}
+		switch pred.op {
+		case findPredicateGT:
+			return cmp > 0, nil
+		case findPredicateGTE:
+			return cmp >= 0, nil
+		case findPredicateLT:
+			return cmp < 0, nil
+		default:
+			return cmp <= 0, nil
+		}
+	default:
+		return false, errors.New("Mongo gateway internal unknown predicate")
+	}
+}
+
+func parseFindSort(command wire.Document) (findSort, error) {
+	sortDoc, err := commandOptionalDocument(command, "sort")
+	if err != nil || sortDoc == nil {
+		return findSort{}, err
+	}
+	elements, err := bson.Raw(sortDoc).Elements()
+	if err != nil {
+		return findSort{}, err
+	}
+	if len(elements) == 0 {
+		return findSort{}, nil
+	}
+	if len(elements) != 1 {
+		return findSort{}, errors.New("Mongo gateway find sort currently supports one field")
+	}
+	field, err := elements[0].KeyErr()
+	if err != nil {
+		return findSort{}, err
+	}
+	value := elements[0].Value()
+	if isAscendingIndexKey(value) {
+		return findSort{field: field}, nil
+	}
+	if v, ok := value.Int32OK(); ok && v == -1 {
+		return findSort{field: field, desc: true}, nil
+	}
+	if v, ok := value.Int64OK(); ok && v == -1 {
+		return findSort{field: field, desc: true}, nil
+	}
+	if v, ok := value.DoubleOK(); ok && v == -1 {
+		return findSort{field: field, desc: true}, nil
+	}
+	return findSort{}, errors.New("Mongo gateway find sort direction must be 1 or -1")
+}
+
+func compareDocumentField(left, right wire.Document, field string) (int, bool) {
+	leftValue, leftOK := lookupDocumentValue(left, field)
+	rightValue, rightOK := lookupDocumentValue(right, field)
+	if !leftOK && !rightOK {
+		return 0, true
+	}
+	if !leftOK {
+		return 1, true
+	}
+	if !rightOK {
+		return -1, true
+	}
+	return compareRawValues(leftValue, rightValue)
+}
+
+func projectDocument(doc wire.Document, projection wire.Document) (wire.Document, error) {
+	if projection == nil {
+		return doc, nil
+	}
+	mode, fields, includeID, err := parseProjection(projection)
+	if err != nil {
+		return nil, err
+	}
+	if mode == projectionNone {
+		return doc, nil
+	}
+	elements, err := bson.Raw(doc).Elements()
+	if err != nil {
+		return nil, err
+	}
+	out := make(bson.D, 0, len(elements))
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, err
+		}
+		if key == "_id" && !includeID {
+			continue
+		}
+		_, selected := fields[key]
+		if mode == projectionInclude && (selected || key == "_id") {
+			out = append(out, bson.E{Key: key, Value: elem.Value()})
+		}
+		if mode == projectionExclude && !selected {
+			out = append(out, bson.E{Key: key, Value: elem.Value()})
+		}
+	}
+	raw, err := bson.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	return wire.Document(raw), nil
+}
+
+type projectionMode uint8
+
+const (
+	projectionNone projectionMode = iota
+	projectionInclude
+	projectionExclude
+)
+
+func parseProjection(projection wire.Document) (projectionMode, map[string]struct{}, bool, error) {
+	elements, err := bson.Raw(projection).Elements()
+	if err != nil {
+		return projectionNone, nil, true, err
+	}
+	fields := make(map[string]struct{}, len(elements))
+	mode := projectionNone
+	includeID := true
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return projectionNone, nil, true, err
+		}
+		include, err := projectionValueIncluded(elem.Value())
+		if err != nil {
+			return projectionNone, nil, true, err
+		}
+		if key == "_id" {
+			includeID = include
+			continue
+		}
+		if strings.Contains(key, ".") {
+			return projectionNone, nil, true, errors.New("Mongo gateway projection currently supports top-level fields only")
+		}
+		nextMode := projectionExclude
+		if include {
+			nextMode = projectionInclude
+		}
+		if mode != projectionNone && mode != nextMode {
+			return projectionNone, nil, true, errors.New("Mongo gateway projection cannot mix include and exclude fields")
+		}
+		mode = nextMode
+		fields[key] = struct{}{}
+	}
+	return mode, fields, includeID, nil
+}
+
+func projectionValueIncluded(value bson.RawValue) (bool, error) {
+	if v, ok := value.BooleanOK(); ok {
+		return v, nil
+	}
+	if v, ok := value.Int32OK(); ok {
+		return v != 0, nil
+	}
+	if v, ok := value.Int64OK(); ok {
+		return v != 0, nil
+	}
+	if v, ok := value.DoubleOK(); ok {
+		return v != 0, nil
+	}
+	return false, errors.New("Mongo gateway projection values must be boolean or numeric")
+}
+
+func lookupDocumentValue(doc wire.Document, field string) (bson.RawValue, bool) {
+	if field == "" {
+		return bson.RawValue{}, false
+	}
+	parts := strings.Split(field, ".")
+	current := bson.Raw(doc)
+	for i, part := range parts {
+		value := current.Lookup(part)
+		if value.IsZero() {
+			return bson.RawValue{}, false
+		}
+		if i == len(parts)-1 {
+			return value, true
+		}
+		next, ok := value.DocumentOK()
+		if !ok {
+			return bson.RawValue{}, false
+		}
+		current = next
+	}
+	return bson.RawValue{}, false
+}
+
+func rawValuesEqual(left, right bson.RawValue) bool {
+	if left.IsNumber() && right.IsNumber() {
+		leftNumber, leftOK := left.AsFloat64OK()
+		rightNumber, rightOK := right.AsFloat64OK()
+		return leftOK && rightOK && leftNumber == rightNumber
+	}
+	return left.Equal(right)
+}
+
+func compareRawValues(left, right bson.RawValue) (int, bool) {
+	if left.IsNumber() && right.IsNumber() {
+		leftNumber, leftOK := left.AsFloat64OK()
+		rightNumber, rightOK := right.AsFloat64OK()
+		if !leftOK || !rightOK {
+			return 0, false
+		}
+		switch {
+		case leftNumber < rightNumber:
+			return -1, true
+		case leftNumber > rightNumber:
+			return 1, true
+		default:
+			return 0, true
+		}
+	}
+	if left.Type != right.Type {
+		return 0, false
+	}
+	switch left.Type {
+	case bson.TypeString:
+		return strings.Compare(left.StringValue(), right.StringValue()), true
+	case bson.TypeBoolean:
+		leftBool := left.Boolean()
+		rightBool := right.Boolean()
+		switch {
+		case leftBool == rightBool:
+			return 0, true
+		case !leftBool && rightBool:
+			return -1, true
+		default:
+			return 1, true
+		}
+	case bson.TypeNull:
+		return 0, true
+	case bson.TypeObjectID:
+		return bytes.Compare(left.Value, right.Value), true
+	default:
+		return bytes.Compare(left.Value, right.Value), true
+	}
+}
+
+func indexScalarForBSONValue(value bson.RawValue) (any, bool) {
+	switch value.Type {
+	case bson.TypeString:
+		out, ok := value.StringValueOK()
+		return out, ok
+	case bson.TypeBoolean:
+		out, ok := value.BooleanOK()
+		return out, ok
+	case bson.TypeNull:
+		return nil, true
+	case bson.TypeDouble:
+		out, ok := value.DoubleOK()
+		return out, ok
+	case bson.TypeInt32, bson.TypeInt64:
+		out, ok := value.AsFloat64OK()
+		return out, ok
+	default:
+		return nil, false
+	}
+}

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -220,7 +220,7 @@ func documentsForIndexedPredicate(col *collections.Collection, pred findPredicat
 	for _, value := range pred.values {
 		scalar, ok := indexScalarForBSONValue(value)
 		if !ok {
-			continue
+			return nil, fmt.Errorf("Mongo gateway find value cannot be represented in index %q", idx.Name)
 		}
 		ids, err := col.FindByIndexValue(idx.Name, scalar)
 		if err != nil {
@@ -293,6 +293,9 @@ func parseAndPredicates(value bson.RawValue) ([]findPredicate, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(values) == 0 {
+		return nil, errors.New("Mongo gateway $and must contain at least one expression")
+	}
 	var out []findPredicate
 	for i, value := range values {
 		doc, ok := value.DocumentOK()
@@ -312,7 +315,14 @@ func parseFieldPredicate(field string, value bson.RawValue) ([]findPredicate, er
 	if field == "" || strings.HasPrefix(field, "$") {
 		return nil, fmt.Errorf("Mongo gateway unsupported find predicate %q", field)
 	}
-	if doc, ok := value.DocumentOK(); ok && operatorDocument(doc) {
+	if doc, ok := value.DocumentOK(); ok {
+		isOperatorDoc, err := operatorDocument(doc)
+		if err != nil {
+			return nil, err
+		}
+		if !isOperatorDoc {
+			return []findPredicate{{field: field, op: findPredicateEq, values: []bson.RawValue{value}}}, nil
+		}
 		elements, err := doc.Elements()
 		if err != nil {
 			return nil, err
@@ -346,13 +356,31 @@ func parseFieldPredicate(field string, value bson.RawValue) ([]findPredicate, er
 	return []findPredicate{{field: field, op: findPredicateEq, values: []bson.RawValue{value}}}, nil
 }
 
-func operatorDocument(doc bson.Raw) bool {
+func operatorDocument(doc bson.Raw) (bool, error) {
 	elements, err := doc.Elements()
-	if err != nil || len(elements) == 0 {
-		return false
+	if err != nil {
+		return false, err
 	}
-	key, err := elements[0].KeyErr()
-	return err == nil && strings.HasPrefix(key, "$")
+	if len(elements) == 0 {
+		return false, nil
+	}
+	sawOperator := false
+	sawNonOperator := false
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return false, err
+		}
+		if strings.HasPrefix(key, "$") {
+			sawOperator = true
+		} else {
+			sawNonOperator = true
+		}
+		if sawOperator && sawNonOperator {
+			return false, errors.New("Mongo gateway find field predicate document cannot mix operator and non-operator keys")
+		}
+	}
+	return sawOperator, nil
 }
 
 func rangeOperator(op string) findPredicateOp {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -32,11 +32,6 @@ type findPredicate struct {
 	values []bson.RawValue
 }
 
-type fieldPredicateGroup struct {
-	field      string
-	predicates []findPredicate
-}
-
 type findSort struct {
 	field string
 	desc  bool
@@ -456,57 +451,33 @@ func rangeOperator(op string) findPredicateOp {
 }
 
 func documentMatchesPredicates(doc wire.Document, predicates []findPredicate) (bool, error) {
-	for _, group := range groupFindPredicatesByField(predicates) {
-		values, ok, err := lookupDocumentPredicateValues(doc, group.field)
+	for _, pred := range predicates {
+		values, ok, err := lookupDocumentPredicateValues(doc, pred.field)
 		if err != nil {
 			return false, err
 		}
 		if !ok {
-			for _, pred := range group.predicates {
-				if !missingValueMatchesPredicate(pred) {
-					return false, nil
-				}
+			if missingValueMatchesPredicate(pred) {
+				continue
 			}
-			continue
+			return false, nil
 		}
-		groupMatched := false
+		matched := false
 		for _, value := range values {
-			valueMatched := true
-			for _, pred := range group.predicates {
-				match, err := valueMatchesPredicate(value, pred)
-				if err != nil {
-					return false, err
-				}
-				if !match {
-					valueMatched = false
-					break
-				}
+			match, err := valueMatchesPredicate(value, pred)
+			if err != nil {
+				return false, err
 			}
-			if valueMatched {
-				groupMatched = true
+			if match {
+				matched = true
 				break
 			}
 		}
-		if !groupMatched {
+		if !matched {
 			return false, nil
 		}
 	}
 	return true, nil
-}
-
-func groupFindPredicatesByField(predicates []findPredicate) []fieldPredicateGroup {
-	groups := make([]fieldPredicateGroup, 0, len(predicates))
-	groupByField := make(map[string]int, len(predicates))
-	for _, pred := range predicates {
-		index, ok := groupByField[pred.field]
-		if !ok {
-			index = len(groups)
-			groupByField[pred.field] = index
-			groups = append(groups, fieldPredicateGroup{field: pred.field})
-		}
-		groups[index].predicates = append(groups[index].predicates, pred)
-	}
-	return groups
 }
 
 func missingValueMatchesPredicate(pred findPredicate) bool {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sort"
 	"strings"
@@ -106,7 +107,7 @@ func (s *Server) executeFind(col *collections.Collection, command wire.Document,
 			return nil, fmt.Errorf("Mongo gateway find result document exceeds max message size")
 		}
 		if batchBytes+docBytes > maxBatchBytes {
-			break
+			return nil, fmt.Errorf("Mongo gateway find results exceed max message size")
 		}
 		firstBatch = append(firstBatch, bson.Raw(projected))
 		batchBytes += docBytes
@@ -472,6 +473,9 @@ func valueMatchesPredicate(value bson.RawValue, pred findPredicate) (bool, error
 		}
 		return false, nil
 	case findPredicateGT, findPredicateGTE, findPredicateLT, findPredicateLTE:
+		if rawValueIsNaN(value) || rawValueIsNaN(pred.values[0]) {
+			return false, nil
+		}
 		cmp := compareRawValues(value, pred.values[0])
 		switch pred.op {
 		case findPredicateGT:
@@ -717,6 +721,9 @@ func lookupDocumentValue(doc wire.Document, field string) (bson.RawValue, bool) 
 
 func rawValuesEqual(left, right bson.RawValue) bool {
 	if left.IsNumber() && right.IsNumber() {
+		if rawValueIsNaN(left) || rawValueIsNaN(right) {
+			return false
+		}
 		return compareRawValues(left, right) == 0
 	}
 	return left.Equal(right)
@@ -755,10 +762,43 @@ func compareRawValues(left, right bson.RawValue) int {
 func compareRawNumbers(left, right bson.RawValue) int {
 	leftRat, leftOK := rawNumberRat(left)
 	rightRat, rightOK := rawNumberRat(right)
-	if !leftOK || !rightOK {
-		return compareInt(bsonTypeSortRank(left.Type), bsonTypeSortRank(right.Type))
+	if leftOK && rightOK {
+		return leftRat.Cmp(rightRat)
 	}
-	return leftRat.Cmp(rightRat)
+	leftRank := numberSortRank(left, leftOK)
+	rightRank := numberSortRank(right, rightOK)
+	if leftRank != rightRank {
+		return compareInt(leftRank, rightRank)
+	}
+	return bytes.Compare(left.Value, right.Value)
+}
+
+func numberSortRank(value bson.RawValue, finite bool) int {
+	if finite {
+		return 1
+	}
+	if value.Type == bson.TypeDouble {
+		v, ok := value.DoubleOK()
+		if ok {
+			switch {
+			case math.IsInf(v, -1):
+				return 0
+			case math.IsInf(v, 1):
+				return 2
+			case math.IsNaN(v):
+				return 3
+			}
+		}
+	}
+	return 4
+}
+
+func rawValueIsNaN(value bson.RawValue) bool {
+	if value.Type != bson.TypeDouble {
+		return false
+	}
+	v, ok := value.DoubleOK()
+	return ok && math.IsNaN(v)
 }
 
 func rawNumberRat(value bson.RawValue) (*big.Rat, bool) {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -32,6 +32,11 @@ type findPredicate struct {
 	values []bson.RawValue
 }
 
+type fieldPredicateGroup struct {
+	field      string
+	predicates []findPredicate
+}
+
 type findSort struct {
 	field string
 	desc  bool
@@ -120,17 +125,27 @@ func (s *Server) executeFind(col *collections.Collection, plan findPlan) (bson.A
 		if err != nil {
 			return nil, err
 		}
-		docBytes := len(projected) + 16
-		if docBytes > maxBatchBytes {
+		docBytes := findBatchDocumentBytes(projected, len(firstBatch))
+		if findBatchOverheadBytes+docBytes > maxBatchBytes {
 			return nil, fmt.Errorf("Mongo gateway find result document exceeds max message size: docBytes=%d maxBatchBytes=%d", docBytes, maxBatchBytes)
 		}
-		if batchBytes+docBytes > maxBatchBytes {
+		if findBatchOverheadBytes+batchBytes+docBytes > maxBatchBytes {
 			return nil, fmt.Errorf("Mongo gateway find results exceed max message size: batchBytes=%d docBytes=%d maxBatchBytes=%d", batchBytes, docBytes, maxBatchBytes)
 		}
 		firstBatch = append(firstBatch, bson.Raw(projected))
 		batchBytes += docBytes
 	}
 	return firstBatch, nil
+}
+
+const findBatchOverheadBytes = 5 // BSON document length plus trailing NUL.
+
+func findBatchDocumentBytes(doc wire.Document, index int) int {
+	return len(doc) + bsonArrayElementOverhead(index)
+}
+
+func bsonArrayElementOverhead(index int) int {
+	return 1 + len(strconv.Itoa(index)) + 1
 }
 
 func validateFindCommandOptions(command wire.Document, filter wire.Document) error {
@@ -148,25 +163,26 @@ func (s *Server) maxFindBatchBytes() int {
 
 func (s *Server) findCandidateDocuments(col *collections.Collection, predicates []findPredicate) ([]wire.Document, error) {
 	meta := col.Meta()
+	maxDocuments := s.maxFindScanDocuments()
 	if pred, ok := primaryCandidatePredicate(predicates); ok {
-		docs, err := documentsForPrimaryPredicate(col, pred)
+		docs, err := documentsForPrimaryPredicate(col, pred, maxDocuments)
 		if err != nil {
 			return nil, err
 		}
 		return s.limitCandidateDocuments(docs)
 	}
-	if docs, ok, err := s.bestIndexedCandidateDocuments(col, meta, predicates); ok || err != nil {
+	if docs, ok, err := s.bestIndexedCandidateDocuments(col, meta, predicates, maxDocuments); ok || err != nil {
 		if err != nil {
 			return nil, err
 		}
 		return s.limitCandidateDocuments(docs)
 	}
-	records, truncated, err := col.ScanDocuments(s.maxFindScanDocuments())
+	records, truncated, err := col.ScanDocuments(maxDocuments)
 	if err != nil {
 		return nil, err
 	}
 	if truncated {
-		return nil, fmt.Errorf("Mongo gateway find requires a bounded scan and exceeded %d documents", s.maxFindScanDocuments())
+		return nil, fmt.Errorf("Mongo gateway find requires a bounded scan and exceeded %d documents", maxDocuments)
 	}
 	out := make([]wire.Document, 0, len(records))
 	for _, record := range records {
@@ -186,7 +202,7 @@ func (s *Server) limitCandidateDocuments(docs []wire.Document) ([]wire.Document,
 	return docs, nil
 }
 
-func (s *Server) bestIndexedCandidateDocuments(col *collections.Collection, meta collections.CollectionMeta, predicates []findPredicate) ([]wire.Document, bool, error) {
+func (s *Server) bestIndexedCandidateDocuments(col *collections.Collection, meta collections.CollectionMeta, predicates []findPredicate, maxDocuments int) ([]wire.Document, bool, error) {
 	var best []wire.Document
 	bestSet := false
 	for _, pred := range predicates {
@@ -200,7 +216,7 @@ func (s *Server) bestIndexedCandidateDocuments(col *collections.Collection, meta
 			if idx.Field != pred.field {
 				continue
 			}
-			docs, err := documentsForIndexedPredicate(col, pred, idx)
+			docs, err := documentsForIndexedPredicate(col, pred, idx, maxDocuments)
 			if err != nil {
 				return nil, false, err
 			}
@@ -223,24 +239,7 @@ func primaryCandidatePredicate(predicates []findPredicate) (findPredicate, bool)
 	return findPredicate{}, false
 }
 
-func indexedCandidatePredicate(meta collections.CollectionMeta, predicates []findPredicate) (findPredicate, collections.IndexDefinition, bool) {
-	for _, pred := range predicates {
-		if pred.op != findPredicateEq && pred.op != findPredicateIn {
-			continue
-		}
-		if predicateContainsNull(pred) {
-			continue
-		}
-		for _, idx := range meta.Indexes {
-			if idx.Field == pred.field {
-				return pred, idx, true
-			}
-		}
-	}
-	return findPredicate{}, collections.IndexDefinition{}, false
-}
-
-func documentsForPrimaryPredicate(col *collections.Collection, pred findPredicate) ([]wire.Document, error) {
+func documentsForPrimaryPredicate(col *collections.Collection, pred findPredicate, maxDocuments int) ([]wire.Document, error) {
 	out := make([]wire.Document, 0, len(pred.values))
 	seen := make(map[string]struct{}, len(pred.values))
 	for _, value := range pred.values {
@@ -264,11 +263,14 @@ func documentsForPrimaryPredicate(col *collections.Collection, pred findPredicat
 			return nil, err
 		}
 		out = append(out, doc)
+		if len(out) > maxDocuments {
+			return out, nil
+		}
 	}
 	return out, nil
 }
 
-func documentsForIndexedPredicate(col *collections.Collection, pred findPredicate, idx collections.IndexDefinition) ([]wire.Document, error) {
+func documentsForIndexedPredicate(col *collections.Collection, pred findPredicate, idx collections.IndexDefinition, maxDocuments int) ([]wire.Document, error) {
 	out := make([]wire.Document, 0)
 	seen := make(map[string]struct{})
 	for _, value := range pred.values {
@@ -276,7 +278,7 @@ func documentsForIndexedPredicate(col *collections.Collection, pred findPredicat
 		if !ok {
 			return nil, fmt.Errorf("Mongo gateway find value cannot be represented in index %q", idx.Name)
 		}
-		ids, err := col.FindByIndexValue(idx.Name, scalar)
+		ids, _, err := col.FindByIndexValueLimit(idx.Name, scalar, maxDocuments+1)
 		if err != nil {
 			return nil, err
 		}
@@ -297,6 +299,9 @@ func documentsForIndexedPredicate(col *collections.Collection, pred findPredicat
 				return nil, err
 			}
 			out = append(out, doc)
+			if len(out) > maxDocuments {
+				return out, nil
+			}
 		}
 	}
 	return out, nil
@@ -451,33 +456,57 @@ func rangeOperator(op string) findPredicateOp {
 }
 
 func documentMatchesPredicates(doc wire.Document, predicates []findPredicate) (bool, error) {
-	for _, pred := range predicates {
-		values, ok, err := lookupDocumentPredicateValues(doc, pred.field)
+	for _, group := range groupFindPredicatesByField(predicates) {
+		values, ok, err := lookupDocumentPredicateValues(doc, group.field)
 		if err != nil {
 			return false, err
 		}
 		if !ok {
-			if missingValueMatchesPredicate(pred) {
-				continue
+			for _, pred := range group.predicates {
+				if !missingValueMatchesPredicate(pred) {
+					return false, nil
+				}
 			}
-			return false, nil
+			continue
 		}
-		matched := false
+		groupMatched := false
 		for _, value := range values {
-			match, err := valueMatchesPredicate(value, pred)
-			if err != nil {
-				return false, err
+			valueMatched := true
+			for _, pred := range group.predicates {
+				match, err := valueMatchesPredicate(value, pred)
+				if err != nil {
+					return false, err
+				}
+				if !match {
+					valueMatched = false
+					break
+				}
 			}
-			if match {
-				matched = true
+			if valueMatched {
+				groupMatched = true
 				break
 			}
 		}
-		if !matched {
+		if !groupMatched {
 			return false, nil
 		}
 	}
 	return true, nil
+}
+
+func groupFindPredicatesByField(predicates []findPredicate) []fieldPredicateGroup {
+	groups := make([]fieldPredicateGroup, 0, len(predicates))
+	groupByField := make(map[string]int, len(predicates))
+	for _, pred := range predicates {
+		index, ok := groupByField[pred.field]
+		if !ok {
+			index = len(groups)
+			groupByField[pred.field] = index
+			groups = append(groups, fieldPredicateGroup{field: pred.field})
+		}
+		groups[index].predicates = append(groups[index].predicates, pred)
+	}
+	return groups
 }
 
 func missingValueMatchesPredicate(pred findPredicate) bool {
@@ -517,6 +546,9 @@ func valueMatchesPredicate(value bson.RawValue, pred findPredicate) (bool, error
 		if rawValueIsNaN(value) || rawValueIsNaN(pred.values[0]) {
 			return false, nil
 		}
+		if !rangeValuesComparable(value, pred.values[0]) {
+			return false, nil
+		}
 		cmp := compareRawValues(value, pred.values[0])
 		switch pred.op {
 		case findPredicateGT:
@@ -531,6 +563,13 @@ func valueMatchesPredicate(value bson.RawValue, pred findPredicate) (bool, error
 	default:
 		return false, errors.New("Mongo gateway internal unknown predicate")
 	}
+}
+
+func rangeValuesComparable(left, right bson.RawValue) bool {
+	if left.IsNumber() && right.IsNumber() {
+		return true
+	}
+	return left.Type == right.Type
 }
 
 func parseFindSort(command wire.Document) (findSort, error) {
@@ -780,7 +819,18 @@ func lookupRawValuesForParts(current bson.Raw, parts []string) ([]bson.RawValue,
 		return nil, false, nil
 	}
 	if len(parts) == 1 {
-		return []bson.RawValue{value}, true, nil
+		array, ok := value.ArrayOK()
+		if !ok {
+			return []bson.RawValue{value}, true, nil
+		}
+		values, err := array.Values()
+		if err != nil {
+			return nil, false, err
+		}
+		out := make([]bson.RawValue, 0, len(values)+1)
+		out = append(out, value)
+		out = append(out, values...)
+		return out, true, nil
 	}
 	return lookupRawValueDescendants(value, parts[1:])
 }

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -177,6 +177,9 @@ func indexedCandidatePredicate(meta collections.CollectionMeta, predicates []fin
 		if pred.op != findPredicateEq && pred.op != findPredicateIn {
 			continue
 		}
+		if predicateContainsNull(pred) {
+			continue
+		}
 		for _, idx := range meta.Indexes {
 			if idx.Field == pred.field {
 				return pred, idx, true
@@ -400,6 +403,9 @@ func documentMatchesPredicates(doc wire.Document, predicates []findPredicate) (b
 	for _, pred := range predicates {
 		value, ok := lookupDocumentValue(doc, pred.field)
 		if !ok {
+			if missingValueMatchesPredicate(pred) {
+				continue
+			}
 			return false, nil
 		}
 		match, err := valueMatchesPredicate(value, pred)
@@ -408,6 +414,28 @@ func documentMatchesPredicates(doc wire.Document, predicates []findPredicate) (b
 		}
 	}
 	return true, nil
+}
+
+func missingValueMatchesPredicate(pred findPredicate) bool {
+	switch pred.op {
+	case findPredicateEq, findPredicateIn:
+		return predicateContainsNull(pred)
+	default:
+		return false
+	}
+}
+
+func predicateContainsNull(pred findPredicate) bool {
+	for _, value := range pred.values {
+		if rawValueIsNull(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func rawValueIsNull(value bson.RawValue) bool {
+	return value.Type == bson.TypeNull
 }
 
 func valueMatchesPredicate(value bson.RawValue, pred findPredicate) (bool, error) {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -15,13 +15,15 @@ import (
 )
 
 const (
-	defaultMaxBSONObjectSize = 16 * 1024 * 1024
-	defaultMaxWriteBatchSize = 100_000
+	defaultMaxBSONObjectSize    = 16 * 1024 * 1024
+	defaultMaxWriteBatchSize    = 100_000
+	defaultMaxFindScanDocuments = 10_000
 )
 
 type Server struct {
-	MaxMessageLength int32
-	Collections      *collections.CollectionManager
+	MaxMessageLength     int32
+	MaxFindScanDocuments int
+	Collections          *collections.CollectionManager
 
 	nextResponseID atomic.Int32
 }
@@ -196,6 +198,13 @@ func (s *Server) maxMessageLength() int32 {
 		return wire.DefaultMaxMessageLength
 	}
 	return s.MaxMessageLength
+}
+
+func (s *Server) maxFindScanDocuments() int {
+	if s.MaxFindScanDocuments <= 0 {
+		return defaultMaxFindScanDocuments
+	}
+	return s.MaxFindScanDocuments
 }
 
 func (s *Server) nextID() int32 {

--- a/TreeDB/mongo_gateway/server_driver_test.go
+++ b/TreeDB/mongo_gateway/server_driver_test.go
@@ -240,3 +240,113 @@ func TestServerOfficialGoDriverIndexMetadata(t *testing.T) {
 		t.Fatal("serve loop did not stop")
 	}
 }
+
+func TestServerOfficialGoDriverFindPlanner(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
+					serveErr <- nil
+					return
+				}
+				serveErr <- err
+				return
+			}
+			go func() {
+				_ = server.ServeConn(ctx, conn)
+			}()
+		}
+	}()
+
+	client, err := mongo.Connect(options.Client().
+		ApplyURI("mongodb://" + ln.Addr().String()).
+		SetDirect(true).
+		SetServerSelectionTimeout(time.Second))
+	if err != nil {
+		t.Fatalf("mongo connect: %v", err)
+	}
+	defer func() { _ = client.Disconnect(context.Background()) }()
+
+	opCtx, opCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer opCancel()
+	coll := client.Database("app").Collection("users")
+	if _, err := coll.Indexes().CreateOne(opCtx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "city", Value: int32(1)}},
+		Options: options.Index().SetName("city_1"),
+	}); err != nil {
+		t.Fatalf("driver create city index: %v", err)
+	}
+	docs := []any{
+		bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "ada"}, {Key: "city", Value: "hnl"}, {Key: "age", Value: int64(37)}},
+		bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "grace"}, {Key: "city", Value: "hnl"}, {Key: "age", Value: int64(42)}},
+		bson.D{{Key: "_id", Value: "u3"}, {Key: "name", Value: "katherine"}, {Key: "city", Value: "sfo"}, {Key: "age", Value: int64(36)}},
+	}
+	if _, err := coll.InsertMany(opCtx, docs); err != nil {
+		t.Fatalf("driver insert many: %v", err)
+	}
+
+	cursor, err := coll.Find(opCtx,
+		bson.D{{Key: "$and", Value: bson.A{
+			bson.D{{Key: "city", Value: "hnl"}},
+			bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: int64(40)}}}},
+		}}},
+		options.Find().
+			SetProjection(bson.D{{Key: "name", Value: int32(1)}, {Key: "_id", Value: int32(0)}}))
+	if err != nil {
+		t.Fatalf("driver indexed find: %v", err)
+	}
+	var results []bson.M
+	if err := cursor.All(opCtx, &results); err != nil {
+		t.Fatalf("driver indexed find all: %v", err)
+	}
+	if len(results) != 1 || results[0]["name"] != "grace" {
+		t.Fatalf("indexed find results=%v want grace", results)
+	}
+	if _, ok := results[0]["_id"]; ok {
+		t.Fatalf("indexed find projection included _id: %v", results[0])
+	}
+
+	cursor, err = coll.Find(opCtx,
+		bson.D{{Key: "_id", Value: bson.D{{Key: "$in", Value: bson.A{"u3", "u1"}}}}},
+		options.Find().SetSort(bson.D{{Key: "name", Value: int32(1)}}).SetSkip(1).SetLimit(1))
+	if err != nil {
+		t.Fatalf("driver _id in find: %v", err)
+	}
+	results = nil
+	if err := cursor.All(opCtx, &results); err != nil {
+		t.Fatalf("driver _id in find all: %v", err)
+	}
+	if len(results) != 1 || results[0]["name"] != "katherine" {
+		t.Fatalf("_id in find results=%v want katherine", results)
+	}
+
+	cancel()
+	_ = ln.Close()
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("serve loop: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("serve loop did not stop")
+	}
+}

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -353,6 +353,76 @@ func TestServerIndexMetadataCommands(t *testing.T) {
 	assertIndexName(t, indexBatch[0], "_id_")
 }
 
+func TestServerFindPlannerIndexedAndBoundedPredicates(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 232, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "city", Value: int32(1)}}},
+			{Key: "name", Value: "city_1"},
+		}}},
+		{Key: "$db", Value: "app"},
+	}))
+	id1 := bson.NewObjectID()
+	id2 := bson.NewObjectID()
+	id3 := bson.NewObjectID()
+	assertOK(t, serveCommand(t, server, 233, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: id1}, {Key: "name", Value: "ada"}, {Key: "city", Value: "hnl"}, {Key: "age", Value: int64(37)}},
+			bson.D{{Key: "_id", Value: id2}, {Key: "name", Value: "grace"}, {Key: "city", Value: "hnl"}, {Key: "age", Value: int64(42)}},
+			bson.D{{Key: "_id", Value: id3}, {Key: "name", Value: "katherine"}, {Key: "city", Value: "sfo"}, {Key: "age", Value: int64(36)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	indexedFind := serveCommand(t, server, 234, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "$and", Value: bson.A{
+			bson.D{{Key: "city", Value: "hnl"}},
+			bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: int64(40)}}}},
+		}}}},
+		{Key: "projection", Value: bson.D{{Key: "name", Value: int32(1)}, {Key: "_id", Value: int32(0)}}},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch := cursorFirstBatch(t, indexedFind)
+	if len(firstBatch) != 1 {
+		t.Fatalf("indexed firstBatch len=%d want 1", len(firstBatch))
+	}
+	if got, ok := firstBatch[0].Lookup("name").StringValueOK(); !ok || got != "grace" {
+		t.Fatalf("projected name=%q ok=%v want grace", got, ok)
+	}
+	if !firstBatch[0].Lookup("_id").IsZero() {
+		t.Fatalf("projected document unexpectedly includes _id: %v", firstBatch[0])
+	}
+	if !firstBatch[0].Lookup("age").IsZero() {
+		t.Fatalf("projected document unexpectedly includes age: %v", firstBatch[0])
+	}
+
+	inFind := serveCommand(t, server, 235, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: bson.D{{Key: "$in", Value: bson.A{id3, id1}}}}}},
+		{Key: "sort", Value: bson.D{{Key: "name", Value: int32(1)}}},
+		{Key: "skip", Value: int32(1)},
+		{Key: "limit", Value: int32(1)},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch = cursorFirstBatch(t, inFind)
+	if len(firstBatch) != 1 {
+		t.Fatalf("$in firstBatch len=%d want 1", len(firstBatch))
+	}
+	if got, ok := firstBatch[0].Lookup("name").StringValueOK(); !ok || got != "katherine" {
+		t.Fatalf("$in sorted/skipped name=%q ok=%v want katherine", got, ok)
+	}
+}
+
 func TestServerFindByIDMissingCollectionReturnsEmptyBatch(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -581,6 +581,27 @@ func TestServerFindPlannerIndexedAndBoundedPredicates(t *testing.T) {
 		{Key: "$db", Value: "app"},
 	})
 	assertCommandError(t, negativeSkipMissingCollection, "BadValue")
+
+	emptyAnd := serveCommand(t, server, 241, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "$and", Value: bson.A{}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, emptyAnd, "BadValue")
+
+	mixedOperator := serveCommand(t, server, 242, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "age", Value: bson.D{{Key: "x", Value: int32(1)}, {Key: "$gte", Value: int64(40)}}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, mixedOperator, "BadValue")
+
+	nonIndexableValue := serveCommand(t, server, 243, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "city", Value: bson.D{{Key: "nested", Value: "hnl"}}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, nonIndexableValue, "BadValue")
 }
 
 func TestApplySetUpdateAppendsNewFieldsInSetOrder(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -632,7 +632,15 @@ func TestServerFindPlannerIndexedAndBoundedPredicates(t *testing.T) {
 	})
 	assertCommandError(t, unsupportedSort, "BadValue")
 
-	nonIndexableValue := serveCommand(t, server, 244, bson.D{
+	dottedSort := serveCommand(t, server, 244, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{}},
+		{Key: "sort", Value: bson.D{{Key: "profile.name", Value: int32(1)}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, dottedSort, "BadValue")
+
+	nonIndexableValue := serveCommand(t, server, 245, bson.D{
 		{Key: "find", Value: "users"},
 		{Key: "filter", Value: bson.D{{Key: "city", Value: bson.D{{Key: "nested", Value: "hnl"}}}}},
 		{Key: "$db", Value: "app"},
@@ -807,6 +815,44 @@ func TestServerFindChoosesNarrowestIndexedPredicate(t *testing.T) {
 	assertBatchIDs(t, cursorFirstBatch(t, findResponse), []string{"u2"})
 }
 
+func TestServerFindChoosesIndexedPredicateBeforeOversizedPrimaryCandidates(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.MaxFindScanDocuments = 1
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 256, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "email", Value: "one@example.com"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "email", Value: "target@example.com"}},
+			bson.D{{Key: "_id", Value: "u3"}, {Key: "email", Value: "three@example.com"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	assertOK(t, serveCommand(t, server, 257, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+			{Key: "name", Value: "email_1"},
+		}}},
+		{Key: "$db", Value: "app"},
+	}))
+	findResponse := serveCommand(t, server, 258, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "$and", Value: bson.A{
+			bson.D{{Key: "_id", Value: bson.D{{Key: "$in", Value: bson.A{"u1", "u2", "u3"}}}}},
+			bson.D{{Key: "email", Value: "target@example.com"}},
+		}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, findResponse), []string{"u2"})
+}
+
 func TestServerFindDottedArrayPredicates(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -908,17 +954,23 @@ func TestServerFindRangePredicatesUseTypeBrackets(t *testing.T) {
 }
 
 func TestCompareRawNumbersHandlesNonFiniteDoubles(t *testing.T) {
+	decimal, err := bson.ParseDecimal128("1.50")
+	if err != nil {
+		t.Fatalf("parse decimal: %v", err)
+	}
 	raw := bson.Raw(mustDocument(t, bson.D{
 		{Key: "nan", Value: math.NaN()},
 		{Key: "pos_inf", Value: math.Inf(1)},
 		{Key: "neg_inf", Value: math.Inf(-1)},
 		{Key: "finite", Value: 1.5},
+		{Key: "decimal", Value: decimal},
 		{Key: "large_int", Value: int64(9007199254740993)},
 	}))
 	nanValue := raw.Lookup("nan")
 	posInf := raw.Lookup("pos_inf")
 	negInf := raw.Lookup("neg_inf")
 	finite := raw.Lookup("finite")
+	decimalValue := raw.Lookup("decimal")
 	largeInt := raw.Lookup("large_int")
 
 	if rawValuesEqual(nanValue, finite) {
@@ -932,6 +984,9 @@ func TestCompareRawNumbersHandlesNonFiniteDoubles(t *testing.T) {
 	}
 	if cmp := compareRawValues(negInf, finite); cmp >= 0 {
 		t.Fatalf("-Inf vs finite cmp=%d want <0", cmp)
+	}
+	if cmp := compareRawValues(decimalValue, finite); cmp != 0 {
+		t.Fatalf("Decimal128 vs double cmp=%d want 0", cmp)
 	}
 	scalar, ok := indexScalarForBSONValue(largeInt)
 	if !ok || scalar != int64(9007199254740993) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -853,7 +853,7 @@ func TestServerFindDottedArrayPredicates(t *testing.T) {
 	assertBatchIDs(t, cursorFirstBatch(t, itemFind), []string{"match"})
 }
 
-func TestServerFindArrayRangePredicatesUseSameElement(t *testing.T) {
+func TestServerFindArrayRangePredicatesCanUseDifferentElements(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -878,7 +878,7 @@ func TestServerFindArrayRangePredicatesUseSameElement(t *testing.T) {
 		}}}},
 		{Key: "$db", Value: "app"},
 	})
-	assertBatchIDs(t, cursorFirstBatch(t, rangeFind), []string{"yes"})
+	assertBatchIDs(t, cursorFirstBatch(t, rangeFind), []string{"no", "yes"})
 }
 
 func TestServerFindRangePredicatesUseTypeBrackets(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -672,6 +673,65 @@ func TestServerFindNullEqualityMatchesMissingWithIndex(t *testing.T) {
 		{Key: "$db", Value: "app"},
 	})
 	assertBatchIDs(t, cursorFirstBatch(t, inFind), []string{"hnl", "missing", "null"})
+}
+
+func TestServerFindRejectsOversizedResultDocument(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.MaxMessageLength = 4500
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 248, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "large"}, {Key: "payload", Value: strings.Repeat("x", 600)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	tooLarge := serveCommand(t, server, 249, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: "large"}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, tooLarge, "BadValue")
+}
+
+func TestServerFindCapsIndexedCandidates(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.MaxFindScanDocuments = 1
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 250, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "hnl"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	assertOK(t, serveCommand(t, server, 251, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "city", Value: int32(1)}}},
+			{Key: "name", Value: "city_1"},
+		}}},
+		{Key: "$db", Value: "app"},
+	}))
+	tooMany := serveCommand(t, server, 252, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "city", Value: "hnl"}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, tooMany, "BadValue")
 }
 
 func TestApplySetUpdateAppendsNewFieldsInSetOrder(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -769,6 +769,76 @@ func TestServerFindCapsIndexedCandidates(t *testing.T) {
 	assertCommandError(t, tooMany, "BadValue")
 }
 
+func TestServerFindChoosesNarrowestIndexedPredicate(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.MaxFindScanDocuments = 1
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 253, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}, {Key: "email", Value: "one@example.com"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "hnl"}, {Key: "email", Value: "target@example.com"}},
+			bson.D{{Key: "_id", Value: "u3"}, {Key: "city", Value: "hnl"}, {Key: "email", Value: "three@example.com"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	assertOK(t, serveCommand(t, server, 254, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{{Key: "key", Value: bson.D{{Key: "city", Value: int32(1)}}}, {Key: "name", Value: "city_1"}},
+			bson.D{{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}}, {Key: "name", Value: "email_1"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	findResponse := serveCommand(t, server, 255, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "$and", Value: bson.A{
+			bson.D{{Key: "city", Value: "hnl"}},
+			bson.D{{Key: "email", Value: "target@example.com"}},
+		}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, findResponse), []string{"u2"})
+}
+
+func TestServerFindDottedArrayPredicates(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 256, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "match"}, {Key: "tags", Value: bson.A{"a", "b"}}, {Key: "items", Value: bson.A{bson.D{{Key: "sku", Value: "sku-1"}}}}},
+			bson.D{{Key: "_id", Value: "miss"}, {Key: "tags", Value: bson.A{"b"}}, {Key: "items", Value: bson.A{bson.D{{Key: "sku", Value: "sku-2"}}}}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	tagFind := serveCommand(t, server, 257, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "tags.0", Value: "a"}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, tagFind), []string{"match"})
+
+	itemFind := serveCommand(t, server, 258, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "items.sku", Value: "sku-1"}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, itemFind), []string{"match"})
+}
+
 func TestCompareRawNumbersHandlesNonFiniteDoubles(t *testing.T) {
 	raw := bson.Raw(mustDocument(t, bson.D{
 		{Key: "nan", Value: math.NaN()},

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -831,12 +831,80 @@ func TestServerFindDottedArrayPredicates(t *testing.T) {
 	})
 	assertBatchIDs(t, cursorFirstBatch(t, tagFind), []string{"match"})
 
-	itemFind := serveCommand(t, server, 258, bson.D{
+	scalarTagFind := serveCommand(t, server, 258, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "tags", Value: "a"}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, scalarTagFind), []string{"match"})
+
+	inTagFind := serveCommand(t, server, 259, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "tags", Value: bson.D{{Key: "$in", Value: bson.A{"a"}}}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, inTagFind), []string{"match"})
+
+	itemFind := serveCommand(t, server, 260, bson.D{
 		{Key: "find", Value: "users"},
 		{Key: "filter", Value: bson.D{{Key: "items.sku", Value: "sku-1"}}},
 		{Key: "$db", Value: "app"},
 	})
 	assertBatchIDs(t, cursorFirstBatch(t, itemFind), []string{"match"})
+}
+
+func TestServerFindArrayRangePredicatesUseSameElement(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 261, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "no"}, {Key: "scores", Value: bson.A{int32(1), int32(10)}}},
+			bson.D{{Key: "_id", Value: "yes"}, {Key: "scores", Value: bson.A{int32(6), int32(7)}}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	rangeFind := serveCommand(t, server, 262, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "scores", Value: bson.D{
+			{Key: "$gt", Value: int32(5)},
+			{Key: "$lt", Value: int32(8)},
+		}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, rangeFind), []string{"yes"})
+}
+
+func TestServerFindRangePredicatesUseTypeBrackets(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 263, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "num"}, {Key: "age", Value: int32(10)}},
+			bson.D{{Key: "_id", Value: "string"}, {Key: "age", Value: "old"}},
+			bson.D{{Key: "_id", Value: "object"}, {Key: "age", Value: bson.D{{Key: "nested", Value: true}}}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	rangeFind := serveCommand(t, server, 264, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "age", Value: bson.D{{Key: "$gt", Value: int32(5)}}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, rangeFind), []string{"num"})
 }
 
 func TestCompareRawNumbersHandlesNonFiniteDoubles(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -624,7 +624,15 @@ func TestServerFindPlannerIndexedAndBoundedPredicates(t *testing.T) {
 	})
 	assertCommandError(t, mixedOperator, "BadValue")
 
-	nonIndexableValue := serveCommand(t, server, 243, bson.D{
+	unsupportedSort := serveCommand(t, server, 243, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{}},
+		{Key: "sort", Value: bson.D{{Key: "$natural", Value: int32(1)}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, unsupportedSort, "BadValue")
+
+	nonIndexableValue := serveCommand(t, server, 244, bson.D{
 		{Key: "find", Value: "users"},
 		{Key: "filter", Value: bson.D{{Key: "city", Value: bson.D{{Key: "nested", Value: "hnl"}}}}},
 		{Key: "$db", Value: "app"},
@@ -767,11 +775,13 @@ func TestCompareRawNumbersHandlesNonFiniteDoubles(t *testing.T) {
 		{Key: "pos_inf", Value: math.Inf(1)},
 		{Key: "neg_inf", Value: math.Inf(-1)},
 		{Key: "finite", Value: 1.5},
+		{Key: "large_int", Value: int64(9007199254740993)},
 	}))
 	nanValue := raw.Lookup("nan")
 	posInf := raw.Lookup("pos_inf")
 	negInf := raw.Lookup("neg_inf")
 	finite := raw.Lookup("finite")
+	largeInt := raw.Lookup("large_int")
 
 	if rawValuesEqual(nanValue, finite) {
 		t.Fatal("NaN compared equal to finite number")
@@ -784,6 +794,10 @@ func TestCompareRawNumbersHandlesNonFiniteDoubles(t *testing.T) {
 	}
 	if cmp := compareRawValues(negInf, finite); cmp >= 0 {
 		t.Fatalf("-Inf vs finite cmp=%d want <0", cmp)
+	}
+	scalar, ok := indexScalarForBSONValue(largeInt)
+	if !ok || scalar != int64(9007199254740993) {
+		t.Fatalf("large int scalar=%v ok=%v want int64", scalar, ok)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"net"
 	"strings"
 	"testing"
@@ -700,6 +701,32 @@ func TestServerFindRejectsOversizedResultDocument(t *testing.T) {
 	assertCommandError(t, tooLarge, "BadValue")
 }
 
+func TestServerFindRejectsFirstBatchOverflow(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.MaxMessageLength = 5200
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 250, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "a"}, {Key: "payload", Value: strings.Repeat("a", 700)}},
+			bson.D{{Key: "_id", Value: "b"}, {Key: "payload", Value: strings.Repeat("b", 700)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	overflow := serveCommand(t, server, 251, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, overflow, "BadValue")
+}
+
 func TestServerFindCapsIndexedCandidates(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -732,6 +759,32 @@ func TestServerFindCapsIndexedCandidates(t *testing.T) {
 		{Key: "$db", Value: "app"},
 	})
 	assertCommandError(t, tooMany, "BadValue")
+}
+
+func TestCompareRawNumbersHandlesNonFiniteDoubles(t *testing.T) {
+	raw := bson.Raw(mustDocument(t, bson.D{
+		{Key: "nan", Value: math.NaN()},
+		{Key: "pos_inf", Value: math.Inf(1)},
+		{Key: "neg_inf", Value: math.Inf(-1)},
+		{Key: "finite", Value: 1.5},
+	}))
+	nanValue := raw.Lookup("nan")
+	posInf := raw.Lookup("pos_inf")
+	negInf := raw.Lookup("neg_inf")
+	finite := raw.Lookup("finite")
+
+	if rawValuesEqual(nanValue, finite) {
+		t.Fatal("NaN compared equal to finite number")
+	}
+	if match, err := valueMatchesPredicate(nanValue, findPredicate{op: findPredicateGT, values: []bson.RawValue{finite}}); err != nil || match {
+		t.Fatalf("NaN range match/err=%v/%v want false/nil", match, err)
+	}
+	if cmp := compareRawValues(posInf, finite); cmp <= 0 {
+		t.Fatalf("+Inf vs finite cmp=%d want >0", cmp)
+	}
+	if cmp := compareRawValues(negInf, finite); cmp >= 0 {
+		t.Fatalf("-Inf vs finite cmp=%d want <0", cmp)
+	}
 }
 
 func TestApplySetUpdateAppendsNewFieldsInSetOrder(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -630,6 +630,50 @@ func TestServerFindPlannerIndexedAndBoundedPredicates(t *testing.T) {
 	assertCommandError(t, nonIndexableValue, "BadValue")
 }
 
+func TestServerFindNullEqualityMatchesMissingWithIndex(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 244, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "null"}, {Key: "city", Value: nil}},
+			bson.D{{Key: "_id", Value: "missing"}, {Key: "name", Value: "no city"}},
+			bson.D{{Key: "_id", Value: "hnl"}, {Key: "city", Value: "hnl"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	assertOK(t, serveCommand(t, server, 245, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "city", Value: int32(1)}}},
+			{Key: "name", Value: "city_1"},
+		}}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	nullFind := serveCommand(t, server, 246, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "city", Value: nil}}},
+		{Key: "sort", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, nullFind), []string{"missing", "null"})
+
+	inFind := serveCommand(t, server, 247, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "city", Value: bson.D{{Key: "$in", Value: bson.A{nil, "hnl"}}}}}},
+		{Key: "sort", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, inFind), []string{"hnl", "missing", "null"})
+}
+
 func TestApplySetUpdateAppendsNewFieldsInSetOrder(t *testing.T) {
 	doc, err := bson.Marshal(bson.D{
 		{Key: "_id", Value: "u1"},
@@ -902,6 +946,19 @@ func cursorFirstBatch(tb testing.TB, doc wire.Document) []bson.Raw {
 		out = append(out, doc)
 	}
 	return out
+}
+
+func assertBatchIDs(tb testing.TB, batch []bson.Raw, want []string) {
+	tb.Helper()
+	if len(batch) != len(want) {
+		tb.Fatalf("batch len=%d want %d", len(batch), len(want))
+	}
+	for i, doc := range batch {
+		got, ok := doc.Lookup("_id").StringValueOK()
+		if !ok || got != want[i] {
+			tb.Fatalf("batch[%d]._id=%q ok=%v want %q", i, got, ok, want[i])
+		}
+	}
 }
 
 func assertInt32(tb testing.TB, doc wire.Document, key string, want int32) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -515,6 +515,72 @@ func TestServerFindPlannerIndexedAndBoundedPredicates(t *testing.T) {
 	if got, ok := firstBatch[0].Lookup("name").StringValueOK(); !ok || got != "katherine" {
 		t.Fatalf("$in sorted/skipped name=%q ok=%v want katherine", got, ok)
 	}
+
+	withoutID := serveCommand(t, server, 236, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: id1}}},
+		{Key: "projection", Value: bson.D{{Key: "_id", Value: int32(0)}}},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch = cursorFirstBatch(t, withoutID)
+	if len(firstBatch) != 1 {
+		t.Fatalf("_id exclude firstBatch len=%d want 1", len(firstBatch))
+	}
+	if !firstBatch[0].Lookup("_id").IsZero() {
+		t.Fatalf("_id exclude projection returned _id: %v", firstBatch[0])
+	}
+	if got, ok := firstBatch[0].Lookup("name").StringValueOK(); !ok || got != "ada" {
+		t.Fatalf("_id exclude name=%q ok=%v want ada", got, ok)
+	}
+
+	onlyID := serveCommand(t, server, 237, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: id1}}},
+		{Key: "projection", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch = cursorFirstBatch(t, onlyID)
+	if len(firstBatch) != 1 {
+		t.Fatalf("_id include firstBatch len=%d want 1", len(firstBatch))
+	}
+	elements, err := firstBatch[0].Elements()
+	if err != nil {
+		t.Fatalf("_id include elements: %v", err)
+	}
+	if len(elements) != 1 || firstBatch[0].Lookup("_id").IsZero() {
+		t.Fatalf("_id include projection=%v want only _id", firstBatch[0])
+	}
+
+	id4 := bson.NewObjectID()
+	id5 := bson.NewObjectID()
+	assertOK(t, serveCommand(t, server, 238, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: id4}, {Key: "name", Value: "large-a"}, {Key: "big", Value: int64(9007199254740992)}},
+			bson.D{{Key: "_id", Value: id5}, {Key: "name", Value: "large-b"}, {Key: "big", Value: int64(9007199254740993)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	largeFind := serveCommand(t, server, 239, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "big", Value: int64(9007199254740993)}}},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch = cursorFirstBatch(t, largeFind)
+	if len(firstBatch) != 1 {
+		t.Fatalf("large int firstBatch len=%d want 1", len(firstBatch))
+	}
+	if got, ok := firstBatch[0].Lookup("name").StringValueOK(); !ok || got != "large-b" {
+		t.Fatalf("large int matched name=%q ok=%v want large-b", got, ok)
+	}
+
+	negativeSkipMissingCollection := serveCommand(t, server, 240, bson.D{
+		{Key: "find", Value: "missing"},
+		{Key: "filter", Value: bson.D{}},
+		{Key: "skip", Value: int32(-1)},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, negativeSkipMissingCollection, "BadValue")
 }
 
 func TestApplySetUpdateAppendsNewFieldsInSetOrder(t *testing.T) {
@@ -559,6 +625,18 @@ func TestApplySetUpdateAppendsNewFieldsInSetOrder(t *testing.T) {
 		if keys[i] != want[i] {
 			t.Fatalf("keys=%v want %v", keys, want)
 		}
+	}
+}
+
+func TestCompareDocumentFieldTreatsMissingAsNull(t *testing.T) {
+	missing := mustDocument(t, bson.D{{Key: "_id", Value: "missing"}})
+	nullValue := mustDocument(t, bson.D{{Key: "_id", Value: "null"}, {Key: "rank", Value: nil}})
+	numberValue := mustDocument(t, bson.D{{Key: "_id", Value: "number"}, {Key: "rank", Value: int64(1)}})
+	if cmp := compareDocumentField(missing, nullValue, "rank"); cmp != 0 {
+		t.Fatalf("missing vs null cmp=%d want 0", cmp)
+	}
+	if cmp := compareDocumentField(missing, numberValue, "rank"); cmp >= 0 {
+		t.Fatalf("missing vs number cmp=%d want <0", cmp)
 	}
 }
 


### PR DESCRIPTION
## Summary

Expands the Mongo gateway `find` path on top of the metadata PR:

- adds a narrow collection API for typed secondary-index lookup and bounded primary scans
- supports `_id` `$in`, indexed scalar equality/`$in`, top-level `$and`, and range predicates through bounded scan/post-filtering
- supports single-field sort, skip, limit, and top-level include/exclude projection
- keeps scan fallback bounded and returns a clear error if the configured cap is exceeded
- adds protocol and official Go driver coverage for indexed find, `$and`, range filtering, projection, sort, skip, and limit

## Validation

- `GOWORK=off go test ./TreeDB/collections ./TreeDB/mongo_gateway/... -count=1`
