### PR TITLE
[codex] Add Mongo gateway cursor commands

### DIFF
--- a/TreeDB/mongo_gateway/PLAN.md
+++ b/TreeDB/mongo_gateway/PLAN.md
@@ -271,6 +271,8 @@ Priority workloads:
 - Current find-planner slice adds `_id` `$in`, indexed scalar equality/`$in`,
   top-level `$and`, bounded scan fallback for range predicates, single-field
   sort, skip, limit, and top-level projection.
+- Current cursor slice adds in-memory server cursor state for batched `find`,
+  `getMore`, and `killCursors`.
 
 Metrics to record for every run:
 

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -110,7 +110,7 @@ func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Do
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 	ns := db + "." + collection
-	cursorID, firstBatch, err := s.openCursor(ns, docs, int(batchSize), batchSizeSet, cursorOwner)
+	cursorID, firstBatch, err := s.openCursor(ns, docs, int(batchSize), batchSizeSet, defaultCursorBatchSize, cursorOwner)
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
@@ -482,7 +482,7 @@ func (s *Server) getMoreResponse(command wire.Document) (wire.Document, error) {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 	ns := db + "." + collection
-	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, int(batchSize), batchSizeSet)
+	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, int(batchSize), batchSizeSet, int(^uint(0)>>1))
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
@@ -546,8 +546,8 @@ func marshalCursorResponseWithID(ns string, cursorID int64, batchKey string, bat
 	})
 }
 
-func (s *Server) openCursor(ns string, docs []wire.Document, batchSize int, explicitBatchSize bool, owner int64) (int64, bson.A, error) {
-	batchSize, err := normalizeBatchSize(batchSize, explicitBatchSize)
+func (s *Server) openCursor(ns string, docs []wire.Document, batchSize int, explicitBatchSize bool, defaultBatchSize int, owner int64) (int64, bson.A, error) {
+	batchSize, err := normalizeBatchSize(batchSize, explicitBatchSize, defaultBatchSize)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -571,11 +571,11 @@ func (s *Server) openCursor(ns string, docs []wire.Document, batchSize int, expl
 	return cursorID, firstBatch, nil
 }
 
-func (s *Server) getMore(cursorID int64, ns string, batchSize int, explicitBatchSize bool) (int64, bson.A, bool, error) {
+func (s *Server) getMore(cursorID int64, ns string, batchSize int, explicitBatchSize bool, defaultBatchSize int) (int64, bson.A, bool, error) {
 	if cursorID == 0 {
 		return 0, nil, false, nil
 	}
-	batchSize, err := normalizeBatchSize(batchSize, explicitBatchSize)
+	batchSize, err := normalizeBatchSize(batchSize, explicitBatchSize, defaultBatchSize)
 	if err != nil {
 		return 0, nil, false, err
 	}
@@ -625,9 +625,9 @@ func (s *Server) killCursors(ns string, cursorIDs []int64) ([]int64, []int64) {
 	return killed, notFound
 }
 
-func normalizeBatchSize(batchSize int, explicit bool) (int, error) {
+func normalizeBatchSize(batchSize int, explicit bool, defaultBatchSize int) (int, error) {
 	if !explicit {
-		return defaultCursorBatchSize, nil
+		return defaultBatchSize, nil
 	}
 	if batchSize < 0 {
 		return 0, errors.New("Mongo gateway cursor batchSize must be non-negative")

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -16,6 +16,7 @@ const (
 	commandCodeFailedToParse     int32 = 9
 	commandCodeNamespaceNotFound int32 = 26
 	commandCodeIndexNotFound     int32 = 27
+	commandCodeCursorNotFound    int32 = 43
 	commandCodeDuplicateKey      int32 = 11000
 )
 
@@ -70,7 +71,7 @@ func (s *Server) insertResponse(command wire.Document, sequences []wire.Document
 	})
 }
 
-func (s *Server) findResponse(command wire.Document) (wire.Document, error) {
+func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Document, error) {
 	if s.Collections == nil {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
 	}
@@ -104,12 +105,15 @@ func (s *Server) findResponse(command wire.Document) (wire.Document, error) {
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	batchSize, err := optionalInt32Field(command, "batchSize")
+	batchSize, batchSizeSet, err := optionalInt32FieldWithPresence(command, "batchSize")
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 	ns := db + "." + collection
-	cursorID, firstBatch := s.openCursor(ns, docs, int(batchSize))
+	cursorID, firstBatch, err := s.openCursor(ns, docs, int(batchSize), batchSizeSet, cursorOwner)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
 	return marshalCursorResponseWithID(ns, cursorID, "firstBatch", firstBatch)
 }
 
@@ -473,14 +477,17 @@ func (s *Server) getMoreResponse(command wire.Document) (wire.Document, error) {
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
-	batchSize, err := optionalInt32Field(command, "batchSize")
+	batchSize, batchSizeSet, err := optionalInt32FieldWithPresence(command, "batchSize")
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 	ns := db + "." + collection
-	nextID, nextBatch, ok := s.getMore(cursorID, ns, int(batchSize))
+	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, int(batchSize), batchSizeSet)
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
 	if !ok {
-		return commandError(43, "CursorNotFound", fmt.Sprintf("cursor not found: %d", cursorID))
+		return commandError(commandCodeCursorNotFound, "CursorNotFound", fmt.Sprintf("cursor not found: %d", cursorID))
 	}
 	return marshalCursorResponseWithID(ns, nextID, "nextBatch", nextBatch)
 }
@@ -539,44 +546,66 @@ func marshalCursorResponseWithID(ns string, cursorID int64, batchKey string, bat
 	})
 }
 
-func (s *Server) openCursor(ns string, docs []wire.Document, batchSize int) (int64, bson.A) {
-	batchSize = normalizeBatchSize(batchSize)
-	if len(docs) <= batchSize {
-		return 0, documentsBatch(docs)
+func (s *Server) openCursor(ns string, docs []wire.Document, batchSize int, explicitBatchSize bool, owner int64) (int64, bson.A, error) {
+	batchSize, err := normalizeBatchSize(batchSize, explicitBatchSize)
+	if err != nil {
+		return 0, nil, err
 	}
-	firstBatch := documentsBatch(docs[:batchSize])
-	remaining := append([]wire.Document(nil), docs[batchSize:]...)
+	firstBatch, consumed := documentsBatchWithLimit(docs, batchSize, s.maxFindBatchBytes())
+	if consumed >= len(docs) {
+		return 0, firstBatch, nil
+	}
 	cursorID := s.nextCursorID.Add(1)
 	if cursorID == 0 {
 		cursorID = s.nextCursorID.Add(1)
 	}
 	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
 	if s.cursors == nil {
 		s.cursors = make(map[int64]*serverCursor)
 	}
-	s.cursors[cursorID] = &serverCursor{ns: ns, docs: remaining}
-	s.cursorMu.Unlock()
-	return cursorID, firstBatch
+	if len(s.cursors) >= s.maxOpenCursors() {
+		return 0, nil, errors.New("Mongo gateway cursor limit exceeded")
+	}
+	s.cursors[cursorID] = &serverCursor{ns: ns, owner: owner, docs: docs, pos: consumed}
+	return cursorID, firstBatch, nil
 }
 
-func (s *Server) getMore(cursorID int64, ns string, batchSize int) (int64, bson.A, bool) {
+func (s *Server) getMore(cursorID int64, ns string, batchSize int, explicitBatchSize bool) (int64, bson.A, bool, error) {
 	if cursorID == 0 {
-		return 0, nil, false
+		return 0, nil, false, nil
 	}
-	batchSize = normalizeBatchSize(batchSize)
+	batchSize, err := normalizeBatchSize(batchSize, explicitBatchSize)
+	if err != nil {
+		return 0, nil, false, err
+	}
 	s.cursorMu.Lock()
 	defer s.cursorMu.Unlock()
 	cursor := s.cursors[cursorID]
 	if cursor == nil || cursor.ns != ns {
-		return 0, nil, false
+		return 0, nil, false, nil
 	}
-	if len(cursor.docs) <= batchSize {
+	remaining := cursor.docs[cursor.pos:]
+	batch, consumed := documentsBatchWithLimit(remaining, batchSize, s.maxFindBatchBytes())
+	cursor.pos += consumed
+	if cursor.pos >= len(cursor.docs) {
 		delete(s.cursors, cursorID)
-		return 0, documentsBatch(cursor.docs), true
+		return 0, batch, true, nil
 	}
-	batch := documentsBatch(cursor.docs[:batchSize])
-	cursor.docs = append([]wire.Document(nil), cursor.docs[batchSize:]...)
-	return cursorID, batch, true
+	return cursorID, batch, true, nil
+}
+
+func (s *Server) killCursorsForOwner(owner int64) {
+	if owner == 0 {
+		return
+	}
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	for cursorID, cursor := range s.cursors {
+		if cursor.owner == owner {
+			delete(s.cursors, cursorID)
+		}
+	}
 }
 
 func (s *Server) killCursors(ns string, cursorIDs []int64) ([]int64, []int64) {
@@ -596,19 +625,42 @@ func (s *Server) killCursors(ns string, cursorIDs []int64) ([]int64, []int64) {
 	return killed, notFound
 }
 
-func normalizeBatchSize(batchSize int) int {
-	if batchSize <= 0 {
-		return defaultCursorBatchSize
+func normalizeBatchSize(batchSize int, explicit bool) (int, error) {
+	if !explicit {
+		return defaultCursorBatchSize, nil
 	}
-	return batchSize
+	if batchSize < 0 {
+		return 0, errors.New("Mongo gateway cursor batchSize must be non-negative")
+	}
+	return batchSize, nil
 }
 
 func documentsBatch(docs []wire.Document) bson.A {
-	out := make(bson.A, 0, len(docs))
-	for _, doc := range docs {
-		out = append(out, bson.Raw(doc))
-	}
+	out, _ := documentsBatchWithLimit(docs, len(docs), int(^uint(0)>>1))
 	return out
+}
+
+func documentsBatchWithLimit(docs []wire.Document, maxDocs int, maxBytes int) (bson.A, int) {
+	if maxDocs < 0 || maxDocs > len(docs) {
+		maxDocs = len(docs)
+	}
+	if maxBytes <= 0 {
+		maxBytes = int(^uint(0) >> 1)
+	}
+	out := make(bson.A, 0, len(docs))
+	batchBytes := 0
+	consumed := 0
+	for consumed < maxDocs {
+		doc := docs[consumed]
+		docBytes := len(doc) + 16
+		if consumed > 0 && batchBytes+docBytes > maxBytes {
+			break
+		}
+		out = append(out, bson.Raw(doc))
+		batchBytes += docBytes
+		consumed++
+	}
+	return out, consumed
 }
 
 func (s *Server) openOrCreateCollection(name string) (*collections.Collection, error) {
@@ -674,20 +726,25 @@ func optionalBoolField(doc wire.Document, key string) (bool, error) {
 }
 
 func optionalInt32Field(doc wire.Document, key string) (int32, error) {
+	out, _, err := optionalInt32FieldWithPresence(doc, key)
+	return out, err
+}
+
+func optionalInt32FieldWithPresence(doc wire.Document, key string) (int32, bool, error) {
 	value := bson.Raw(doc).Lookup(key)
 	if value.IsZero() {
-		return 0, nil
+		return 0, false, nil
 	}
 	if out, ok := value.Int32OK(); ok {
-		return out, nil
+		return out, true, nil
 	}
 	if out, ok := value.Int64OK(); ok {
 		if out < 0 || out > int64(^uint32(0)>>1) {
-			return 0, fmt.Errorf("Mongo command field %q is out of int32 range", key)
+			return 0, true, fmt.Errorf("Mongo command field %q is out of int32 range", key)
 		}
-		return int32(out), nil
+		return int32(out), true, nil
 	}
-	return 0, fmt.Errorf("Mongo command field %q must be an integer", key)
+	return 0, true, fmt.Errorf("Mongo command field %q must be an integer", key)
 }
 
 func requiredInt64Field(doc wire.Document, key string) (int64, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -484,6 +484,9 @@ func (s *Server) getMoreResponse(command wire.Document) (wire.Document, error) {
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
+	if batchSizeSet && batchSize == 0 {
+		batchSizeSet = false
+	}
 	ns := db + "." + collection
 	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, int(batchSize), batchSizeSet, maxInt)
 	if err != nil {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
@@ -112,7 +113,22 @@ func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Do
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
+	singleBatch, err := optionalBoolField(command, "singleBatch")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
 	ns := db + "." + collection
+	if singleBatch {
+		normalizedBatchSize, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		firstBatch, _, err := documentsBatchWithLimit(results.docs, results.projection, normalizedBatchSize, s.maxFindBatchBytes())
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", err.Error())
+		}
+		return marshalCursorResponseWithID(ns, 0, "firstBatch", firstBatch)
+	}
 	cursorID, firstBatch, err := s.openCursor(ns, results.docs, results.projection, int(batchSize), batchSizeSet, defaultCursorBatchSize, cursorOwner)
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
@@ -488,7 +504,7 @@ func (s *Server) getMoreResponse(command wire.Document, cursorOwner int64) (wire
 		batchSizeSet = false
 	}
 	ns := db + "." + collection
-	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, cursorOwner, int(batchSize), batchSizeSet, maxInt)
+	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, cursorOwner, int(batchSize), batchSizeSet, defaultCursorBatchSize)
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
@@ -568,15 +584,21 @@ func (s *Server) openCursor(ns string, docs []wire.Document, projection compiled
 	if cursorID == 0 {
 		cursorID = s.nextCursorID.Add(1)
 	}
+	now := time.Now()
+	storedBatchSize := batchSize
+	if storedBatchSize == 0 {
+		storedBatchSize = defaultBatchSize
+	}
 	s.cursorMu.Lock()
 	defer s.cursorMu.Unlock()
+	s.reapExpiredCursorsLocked(now)
 	if s.cursors == nil {
 		s.cursors = make(map[int64]*serverCursor)
 	}
 	if len(s.cursors) >= s.maxOpenCursors() {
 		return 0, nil, errors.New("Mongo gateway cursor limit exceeded")
 	}
-	s.cursors[cursorID] = &serverCursor{ns: ns, owner: owner, docs: docs, projection: projection, pos: consumed}
+	s.cursors[cursorID] = &serverCursor{ns: ns, owner: owner, docs: docs, projection: projection, batchSize: storedBatchSize, pos: consumed, lastUsed: now}
 	return cursorID, firstBatch, nil
 }
 
@@ -584,12 +606,16 @@ func (s *Server) getMore(cursorID int64, ns string, owner int64, batchSize int, 
 	if cursorID == 0 {
 		return 0, nil, false, nil
 	}
-	batchSize, err := normalizeBatchSize(batchSize, explicitBatchSize, defaultBatchSize)
-	if err != nil {
-		return 0, nil, false, err
+	if explicitBatchSize {
+		var err error
+		batchSize, err = normalizeBatchSize(batchSize, true, defaultBatchSize)
+		if err != nil {
+			return 0, nil, false, err
+		}
 	}
 	for {
 		s.cursorMu.Lock()
+		s.reapExpiredCursorsLocked(time.Now())
 		cursor := s.cursors[cursorID]
 		if cursor == nil || cursor.ns != ns || cursor.owner != owner {
 			s.cursorMu.Unlock()
@@ -598,9 +624,16 @@ func (s *Server) getMore(cursorID int64, ns string, owner int64, batchSize int, 
 		startPos := cursor.pos
 		remaining := cursor.docs[startPos:]
 		projection := cursor.projection
+		effectiveBatchSize := batchSize
+		if !explicitBatchSize {
+			effectiveBatchSize = cursor.batchSize
+			if effectiveBatchSize <= 0 {
+				effectiveBatchSize = defaultBatchSize
+			}
+		}
 		s.cursorMu.Unlock()
 
-		batch, consumed, err := documentsBatchWithLimit(remaining, projection, batchSize, s.maxFindBatchBytes())
+		batch, consumed, err := documentsBatchWithLimit(remaining, projection, effectiveBatchSize, s.maxFindBatchBytes())
 		if err != nil {
 			return 0, nil, false, err
 		}
@@ -616,6 +649,7 @@ func (s *Server) getMore(cursorID int64, ns string, owner int64, batchSize int, 
 			continue
 		}
 		current.pos += consumed
+		current.lastUsed = time.Now()
 		if current.pos >= len(current.docs) {
 			delete(s.cursors, cursorID)
 			s.cursorMu.Unlock()
@@ -642,6 +676,7 @@ func (s *Server) killCursorsForOwner(owner int64) {
 func (s *Server) killCursors(ns string, owner int64, cursorIDs []int64) ([]int64, []int64) {
 	s.cursorMu.Lock()
 	defer s.cursorMu.Unlock()
+	s.reapExpiredCursorsLocked(time.Now())
 	killed := make([]int64, 0, len(cursorIDs))
 	notFound := make([]int64, 0)
 	for _, cursorID := range cursorIDs {
@@ -654,6 +689,29 @@ func (s *Server) killCursors(ns string, owner int64, cursorIDs []int64) ([]int64
 		killed = append(killed, cursorID)
 	}
 	return killed, notFound
+}
+
+func (s *Server) reapExpiredCursors() {
+	timeout := s.cursorIdleTimeout()
+	if timeout <= 0 {
+		return
+	}
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	s.reapExpiredCursorsLocked(time.Now())
+}
+
+func (s *Server) reapExpiredCursorsLocked(now time.Time) {
+	timeout := s.cursorIdleTimeout()
+	if timeout <= 0 {
+		return
+	}
+	cutoff := now.Add(-timeout)
+	for cursorID, cursor := range s.cursors {
+		if !cursor.lastUsed.IsZero() && !cursor.lastUsed.After(cutoff) {
+			delete(s.cursors, cursorID)
+		}
+	}
 }
 
 func normalizeBatchSize(batchSize int, explicit bool, defaultBatchSize int) (int, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -467,7 +467,7 @@ func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, erro
 	})
 }
 
-func (s *Server) getMoreResponse(command wire.Document) (wire.Document, error) {
+func (s *Server) getMoreResponse(command wire.Document, cursorOwner int64) (wire.Document, error) {
 	cursorID, err := requiredInt64Field(command, "getMore")
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
@@ -488,7 +488,7 @@ func (s *Server) getMoreResponse(command wire.Document) (wire.Document, error) {
 		batchSizeSet = false
 	}
 	ns := db + "." + collection
-	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, int(batchSize), batchSizeSet, maxInt)
+	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, cursorOwner, int(batchSize), batchSizeSet, maxInt)
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
@@ -498,7 +498,7 @@ func (s *Server) getMoreResponse(command wire.Document) (wire.Document, error) {
 	return marshalCursorResponseWithID(ns, nextID, "nextBatch", nextBatch)
 }
 
-func (s *Server) killCursorsResponse(command wire.Document) (wire.Document, error) {
+func (s *Server) killCursorsResponse(command wire.Document, cursorOwner int64) (wire.Document, error) {
 	collection, err := commandString(command, "killCursors")
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
@@ -512,7 +512,7 @@ func (s *Server) killCursorsResponse(command wire.Document) (wire.Document, erro
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 	ns := db + "." + collection
-	killed, notFound := s.killCursors(ns, cursorIDs)
+	killed, notFound := s.killCursors(ns, cursorOwner, cursorIDs)
 	return marshalDocument(bson.D{
 		{Key: "ok", Value: 1.0},
 		{Key: "cursorsKilled", Value: int64Array(killed)},
@@ -580,7 +580,7 @@ func (s *Server) openCursor(ns string, docs []wire.Document, projection compiled
 	return cursorID, firstBatch, nil
 }
 
-func (s *Server) getMore(cursorID int64, ns string, batchSize int, explicitBatchSize bool, defaultBatchSize int) (int64, bson.A, bool, error) {
+func (s *Server) getMore(cursorID int64, ns string, owner int64, batchSize int, explicitBatchSize bool, defaultBatchSize int) (int64, bson.A, bool, error) {
 	if cursorID == 0 {
 		return 0, nil, false, nil
 	}
@@ -588,23 +588,42 @@ func (s *Server) getMore(cursorID int64, ns string, batchSize int, explicitBatch
 	if err != nil {
 		return 0, nil, false, err
 	}
-	s.cursorMu.Lock()
-	defer s.cursorMu.Unlock()
-	cursor := s.cursors[cursorID]
-	if cursor == nil || cursor.ns != ns {
-		return 0, nil, false, nil
+	for {
+		s.cursorMu.Lock()
+		cursor := s.cursors[cursorID]
+		if cursor == nil || cursor.ns != ns || cursor.owner != owner {
+			s.cursorMu.Unlock()
+			return 0, nil, false, nil
+		}
+		startPos := cursor.pos
+		remaining := cursor.docs[startPos:]
+		projection := cursor.projection
+		s.cursorMu.Unlock()
+
+		batch, consumed, err := documentsBatchWithLimit(remaining, projection, batchSize, s.maxFindBatchBytes())
+		if err != nil {
+			return 0, nil, false, err
+		}
+
+		s.cursorMu.Lock()
+		current := s.cursors[cursorID]
+		if current == nil || current != cursor || current.ns != ns || current.owner != owner {
+			s.cursorMu.Unlock()
+			return 0, nil, false, nil
+		}
+		if current.pos != startPos {
+			s.cursorMu.Unlock()
+			continue
+		}
+		current.pos += consumed
+		if current.pos >= len(current.docs) {
+			delete(s.cursors, cursorID)
+			s.cursorMu.Unlock()
+			return 0, batch, true, nil
+		}
+		s.cursorMu.Unlock()
+		return cursorID, batch, true, nil
 	}
-	remaining := cursor.docs[cursor.pos:]
-	batch, consumed, err := documentsBatchWithLimit(remaining, cursor.projection, batchSize, s.maxFindBatchBytes())
-	if err != nil {
-		return 0, nil, false, err
-	}
-	cursor.pos += consumed
-	if cursor.pos >= len(cursor.docs) {
-		delete(s.cursors, cursorID)
-		return 0, batch, true, nil
-	}
-	return cursorID, batch, true, nil
 }
 
 func (s *Server) killCursorsForOwner(owner int64) {
@@ -620,14 +639,14 @@ func (s *Server) killCursorsForOwner(owner int64) {
 	}
 }
 
-func (s *Server) killCursors(ns string, cursorIDs []int64) ([]int64, []int64) {
+func (s *Server) killCursors(ns string, owner int64, cursorIDs []int64) ([]int64, []int64) {
 	s.cursorMu.Lock()
 	defer s.cursorMu.Unlock()
 	killed := make([]int64, 0, len(cursorIDs))
 	notFound := make([]int64, 0)
 	for _, cursorID := range cursorIDs {
 		cursor := s.cursors[cursorID]
-		if cursor == nil || cursor.ns != ns {
+		if cursor == nil || cursor.ns != ns || cursor.owner != owner {
 			notFound = append(notFound, cursorID)
 			continue
 		}
@@ -669,7 +688,7 @@ func documentsBatchWithLimit(docs []wire.Document, projection compiledProjection
 		}
 		docBytes := findBatchDocumentBytes(doc, len(out))
 		if findBatchOverheadBytes+docBytes > maxBytes {
-			return nil, 0, fmt.Errorf("Mongo gateway cursor document exceeds max message size: docBytes=%d maxBatchBytes=%d", docBytes, maxBytes)
+			return nil, 0, fmt.Errorf("Mongo gateway cursor document exceeds max message size: docBytes=%d maxBytes=%d", docBytes, maxBytes)
 		}
 		if len(out) > 0 && findBatchOverheadBytes+batchBytes+docBytes > maxBytes {
 			break

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -500,11 +500,9 @@ func (s *Server) getMoreResponse(command wire.Document, cursorOwner int64) (wire
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
-	if batchSizeSet && batchSize == 0 {
-		batchSizeSet = false
-	}
+	batchSizeValue, batchSizeSet := normalizeGetMoreBatchSize(batchSize, batchSizeSet)
 	ns := db + "." + collection
-	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, cursorOwner, int(batchSize), batchSizeSet, maxInt)
+	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, cursorOwner, batchSizeValue, batchSizeSet, maxInt)
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
@@ -580,6 +578,11 @@ func (s *Server) openCursor(ns string, docs []wire.Document, projection compiled
 	if consumed >= len(docs) {
 		return 0, firstBatch, nil
 	}
+	retainedDocs := append([]wire.Document(nil), docs[consumed:]...)
+	retainedBytes := documentsBytes(retainedDocs)
+	if maxBytes := s.maxCursorRetainedBytes(); retainedBytes > maxBytes {
+		return 0, nil, fmt.Errorf("Mongo gateway cursor retained bytes exceeds limit: retainedBytes=%d maxBytes=%d", retainedBytes, maxBytes)
+	}
 	cursorID := s.nextCursorID.Add(1)
 	if cursorID == 0 {
 		cursorID = s.nextCursorID.Add(1)
@@ -594,7 +597,7 @@ func (s *Server) openCursor(ns string, docs []wire.Document, projection compiled
 	if len(s.cursors) >= s.maxOpenCursors() {
 		return 0, nil, errors.New("Mongo gateway cursor limit exceeded")
 	}
-	s.cursors[cursorID] = &serverCursor{ns: ns, owner: owner, docs: docs, projection: projection, pos: consumed, lastUsed: now}
+	s.cursors[cursorID] = &serverCursor{ns: ns, owner: owner, docs: retainedDocs, projection: projection, pos: 0, lastUsed: now}
 	return cursorID, firstBatch, nil
 }
 
@@ -628,6 +631,12 @@ func (s *Server) getMore(cursorID int64, ns string, owner int64, batchSize int, 
 
 		batch, consumed, err := documentsBatchWithLimit(remaining, projection, effectiveBatchSize, s.maxFindBatchBytes())
 		if err != nil {
+			s.cursorMu.Lock()
+			current := s.cursors[cursorID]
+			if current == cursor && current.ns == ns && current.owner == owner && current.pos == startPos {
+				delete(s.cursors, cursorID)
+			}
+			s.cursorMu.Unlock()
 			return 0, nil, false, err
 		}
 
@@ -689,9 +698,14 @@ func (s *Server) reapExpiredCursors() {
 	if timeout <= 0 {
 		return
 	}
+	now := time.Now()
 	s.cursorMu.Lock()
 	defer s.cursorMu.Unlock()
-	s.reapExpiredCursorsLocked(time.Now())
+	if !s.lastCursorReap.IsZero() && now.Sub(s.lastCursorReap) < defaultCursorReapInterval {
+		return
+	}
+	s.lastCursorReap = now
+	s.reapExpiredCursorsLocked(now)
 }
 
 func (s *Server) reapExpiredCursorsLocked(now time.Time) {
@@ -717,9 +731,29 @@ func normalizeBatchSize(batchSize int, explicit bool, defaultBatchSize int) (int
 	return batchSize, nil
 }
 
+func normalizeGetMoreBatchSize(batchSize int32, explicit bool) (int, bool) {
+	// MongoDB treats getMore batchSize: 0 like an omitted count limit; find
+	// batchSize: 0 is intentionally different and opens an empty first batch.
+	if explicit && batchSize == 0 {
+		return 0, false
+	}
+	return int(batchSize), explicit
+}
+
 func documentsBatch(docs []wire.Document) bson.A {
 	out, _, _ := documentsBatchWithLimit(docs, compiledProjection{}, len(docs), maxInt)
 	return out
+}
+
+func documentsBytes(docs []wire.Document) int {
+	total := 0
+	for _, doc := range docs {
+		if len(doc) > maxInt-total {
+			return maxInt
+		}
+		total += len(doc)
+	}
+	return total
 }
 
 func documentsBatchWithLimit(docs []wire.Document, projection compiledProjection, maxDocs int, maxBytes int) (bson.A, int, error) {
@@ -840,7 +874,7 @@ func requiredInt64Field(doc wire.Document, key string) (int64, error) {
 	if value.IsZero() {
 		return 0, fmt.Errorf("Mongo command missing %q", key)
 	}
-	if out, ok := value.AsInt64OK(); ok {
+	if out, ok := strictBSONInt64(value); ok {
 		return out, nil
 	}
 	return 0, fmt.Errorf("Mongo command field %q must be an integer", key)
@@ -861,13 +895,23 @@ func requiredInt64ArrayField(doc wire.Document, key string) ([]int64, error) {
 	}
 	out := make([]int64, 0, len(values))
 	for i, value := range values {
-		item, ok := value.AsInt64OK()
+		item, ok := strictBSONInt64(value)
 		if !ok {
 			return nil, fmt.Errorf("Mongo command field %q[%d] must be an integer", key, i)
 		}
 		out = append(out, item)
 	}
 	return out, nil
+}
+
+func strictBSONInt64(value bson.RawValue) (int64, bool) {
+	if out, ok := value.Int64OK(); ok {
+		return out, true
+	}
+	if out, ok := value.Int32OK(); ok {
+		return int64(out), true
+	}
+	return 0, false
 }
 
 func int64Array(values []int64) bson.A {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -504,7 +504,7 @@ func (s *Server) getMoreResponse(command wire.Document, cursorOwner int64) (wire
 		batchSizeSet = false
 	}
 	ns := db + "." + collection
-	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, cursorOwner, int(batchSize), batchSizeSet, defaultCursorBatchSize)
+	nextID, nextBatch, ok, err := s.getMore(cursorID, ns, cursorOwner, int(batchSize), batchSizeSet, maxInt)
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
@@ -585,10 +585,6 @@ func (s *Server) openCursor(ns string, docs []wire.Document, projection compiled
 		cursorID = s.nextCursorID.Add(1)
 	}
 	now := time.Now()
-	storedBatchSize := batchSize
-	if storedBatchSize == 0 {
-		storedBatchSize = defaultBatchSize
-	}
 	s.cursorMu.Lock()
 	defer s.cursorMu.Unlock()
 	s.reapExpiredCursorsLocked(now)
@@ -598,7 +594,7 @@ func (s *Server) openCursor(ns string, docs []wire.Document, projection compiled
 	if len(s.cursors) >= s.maxOpenCursors() {
 		return 0, nil, errors.New("Mongo gateway cursor limit exceeded")
 	}
-	s.cursors[cursorID] = &serverCursor{ns: ns, owner: owner, docs: docs, projection: projection, batchSize: storedBatchSize, pos: consumed, lastUsed: now}
+	s.cursors[cursorID] = &serverCursor{ns: ns, owner: owner, docs: docs, projection: projection, pos: consumed, lastUsed: now}
 	return cursorID, firstBatch, nil
 }
 
@@ -626,10 +622,7 @@ func (s *Server) getMore(cursorID int64, ns string, owner int64, batchSize int, 
 		projection := cursor.projection
 		effectiveBatchSize := batchSize
 		if !explicitBatchSize {
-			effectiveBatchSize = cursor.batchSize
-			if effectiveBatchSize <= 0 {
-				effectiveBatchSize = defaultBatchSize
-			}
+			effectiveBatchSize = defaultBatchSize
 		}
 		s.cursorMu.Unlock()
 

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -98,11 +98,17 @@ func (s *Server) findResponse(command wire.Document) (wire.Document, error) {
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	firstBatch, err := s.executeFind(col, command, filter)
+	docs, err := s.executeFind(col, command, filter)
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	return marshalCursorResponse(db, collection, firstBatch)
+	batchSize, err := optionalInt32Field(command, "batchSize")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	ns := db + "." + collection
+	cursorID, firstBatch := s.openCursor(ns, docs, int(batchSize))
+	return marshalCursorResponseWithID(ns, cursorID, "firstBatch", firstBatch)
 }
 
 func (s *Server) updateResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
@@ -446,6 +452,55 @@ func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, erro
 	})
 }
 
+func (s *Server) getMoreResponse(command wire.Document) (wire.Document, error) {
+	cursorID, err := requiredInt64Field(command, "getMore")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	collection, err := commandString(command, "collection")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	batchSize, err := optionalInt32Field(command, "batchSize")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	ns := db + "." + collection
+	nextID, nextBatch, ok := s.getMore(cursorID, ns, int(batchSize))
+	if !ok {
+		return commandError(43, "CursorNotFound", fmt.Sprintf("cursor not found: %d", cursorID))
+	}
+	return marshalCursorResponseWithID(ns, nextID, "nextBatch", nextBatch)
+}
+
+func (s *Server) killCursorsResponse(command wire.Document) (wire.Document, error) {
+	collection, err := commandString(command, "killCursors")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	cursorIDs, err := requiredInt64ArrayField(command, "cursors")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	ns := db + "." + collection
+	killed, notFound := s.killCursors(ns, cursorIDs)
+	return marshalDocument(bson.D{
+		{Key: "ok", Value: 1.0},
+		{Key: "cursorsKilled", Value: int64Array(killed)},
+		{Key: "cursorsNotFound", Value: int64Array(notFound)},
+		{Key: "cursorsAlive", Value: bson.A{}},
+		{Key: "cursorsUnknown", Value: bson.A{}},
+	})
+}
+
 func marshalUpdateResponse(matched, modified int32) (wire.Document, error) {
 	return marshalDocument(bson.D{
 		{Key: "ok", Value: 1.0},
@@ -462,14 +517,90 @@ func marshalDeleteResponse(deleted int32) (wire.Document, error) {
 }
 
 func marshalCursorResponse(db, collection string, firstBatch bson.A) (wire.Document, error) {
+	return marshalCursorResponseWithID(db+"."+collection, 0, "firstBatch", firstBatch)
+}
+
+func marshalCursorResponseWithID(ns string, cursorID int64, batchKey string, batch bson.A) (wire.Document, error) {
 	return marshalDocument(bson.D{
 		{Key: "cursor", Value: bson.D{
-			{Key: "id", Value: int64(0)},
-			{Key: "ns", Value: db + "." + collection},
-			{Key: "firstBatch", Value: firstBatch},
+			{Key: "id", Value: cursorID},
+			{Key: "ns", Value: ns},
+			{Key: batchKey, Value: batch},
 		}},
 		{Key: "ok", Value: 1.0},
 	})
+}
+
+func (s *Server) openCursor(ns string, docs []wire.Document, batchSize int) (int64, bson.A) {
+	batchSize = normalizeBatchSize(batchSize)
+	if len(docs) <= batchSize {
+		return 0, documentsBatch(docs)
+	}
+	firstBatch := documentsBatch(docs[:batchSize])
+	remaining := append([]wire.Document(nil), docs[batchSize:]...)
+	cursorID := s.nextCursorID.Add(1)
+	if cursorID == 0 {
+		cursorID = s.nextCursorID.Add(1)
+	}
+	s.cursorMu.Lock()
+	if s.cursors == nil {
+		s.cursors = make(map[int64]*serverCursor)
+	}
+	s.cursors[cursorID] = &serverCursor{ns: ns, docs: remaining}
+	s.cursorMu.Unlock()
+	return cursorID, firstBatch
+}
+
+func (s *Server) getMore(cursorID int64, ns string, batchSize int) (int64, bson.A, bool) {
+	if cursorID == 0 {
+		return 0, nil, false
+	}
+	batchSize = normalizeBatchSize(batchSize)
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	cursor := s.cursors[cursorID]
+	if cursor == nil || cursor.ns != ns {
+		return 0, nil, false
+	}
+	if len(cursor.docs) <= batchSize {
+		delete(s.cursors, cursorID)
+		return 0, documentsBatch(cursor.docs), true
+	}
+	batch := documentsBatch(cursor.docs[:batchSize])
+	cursor.docs = append([]wire.Document(nil), cursor.docs[batchSize:]...)
+	return cursorID, batch, true
+}
+
+func (s *Server) killCursors(ns string, cursorIDs []int64) ([]int64, []int64) {
+	s.cursorMu.Lock()
+	defer s.cursorMu.Unlock()
+	killed := make([]int64, 0, len(cursorIDs))
+	notFound := make([]int64, 0)
+	for _, cursorID := range cursorIDs {
+		cursor := s.cursors[cursorID]
+		if cursor == nil || cursor.ns != ns {
+			notFound = append(notFound, cursorID)
+			continue
+		}
+		delete(s.cursors, cursorID)
+		killed = append(killed, cursorID)
+	}
+	return killed, notFound
+}
+
+func normalizeBatchSize(batchSize int) int {
+	if batchSize <= 0 {
+		return defaultCursorBatchSize
+	}
+	return batchSize
+}
+
+func documentsBatch(docs []wire.Document) bson.A {
+	out := make(bson.A, 0, len(docs))
+	for _, doc := range docs {
+		out = append(out, bson.Raw(doc))
+	}
+	return out
 }
 
 func (s *Server) openOrCreateCollection(name string) (*collections.Collection, error) {
@@ -549,6 +680,49 @@ func optionalInt32Field(doc wire.Document, key string) (int32, error) {
 		return int32(out), nil
 	}
 	return 0, fmt.Errorf("Mongo command field %q must be an integer", key)
+}
+
+func requiredInt64Field(doc wire.Document, key string) (int64, error) {
+	value := bson.Raw(doc).Lookup(key)
+	if value.IsZero() {
+		return 0, fmt.Errorf("Mongo command missing %q", key)
+	}
+	if out, ok := value.AsInt64OK(); ok {
+		return out, nil
+	}
+	return 0, fmt.Errorf("Mongo command field %q must be an integer", key)
+}
+
+func requiredInt64ArrayField(doc wire.Document, key string) ([]int64, error) {
+	value := bson.Raw(doc).Lookup(key)
+	if value.IsZero() {
+		return nil, fmt.Errorf("Mongo command missing %q", key)
+	}
+	array, ok := value.ArrayOK()
+	if !ok {
+		return nil, fmt.Errorf("Mongo command field %q must be an array", key)
+	}
+	values, err := array.Values()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]int64, 0, len(values))
+	for i, value := range values {
+		item, ok := value.AsInt64OK()
+		if !ok {
+			return nil, fmt.Errorf("Mongo command field %q[%d] must be an integer", key, i)
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func int64Array(values []int64) bson.A {
+	out := make(bson.A, 0, len(values))
+	for _, value := range values {
+		out = append(out, value)
+	}
+	return out
 }
 
 func collectionNameFilter(filter wire.Document) (string, error) {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -90,19 +90,12 @@ func (s *Server) executeFind(col *collections.Collection, command wire.Document,
 		return nil, err
 	}
 	out := make([]wire.Document, 0, len(docs))
-	batchBytes := 0
-	maxBatchBytes := s.maxFindBatchBytes()
 	for _, doc := range docs {
 		projected, err := projectDocument(doc, projection)
 		if err != nil {
 			return nil, err
 		}
-		docBytes := len(projected) + 16
-		if len(out) > 0 && batchBytes+docBytes > maxBatchBytes {
-			break
-		}
 		out = append(out, projected)
-		batchBytes += docBytes
 	}
 	return out, nil
 }
@@ -115,6 +108,13 @@ func validateFindCommandOptions(command wire.Document, filter wire.Document) err
 		return err
 	}
 	if _, _, err := parseFindPagination(command); err != nil {
+		return err
+	}
+	batchSize, batchSizeSet, err := optionalInt32FieldWithPresence(command, "batchSize")
+	if err != nil {
+		return err
+	}
+	if _, err := normalizeBatchSize(int(batchSize), batchSizeSet); err != nil {
 		return err
 	}
 	projection, err := commandOptionalDocument(command, "projection")

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -145,6 +145,9 @@ func validateFindCommandOptions(command wire.Document, filter wire.Document) err
 	if _, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize); err != nil {
 		return err
 	}
+	if _, err := optionalBoolField(command, "singleBatch"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -114,7 +114,7 @@ func validateFindCommandOptions(command wire.Document, filter wire.Document) err
 	if err != nil {
 		return err
 	}
-	if _, err := normalizeBatchSize(int(batchSize), batchSizeSet); err != nil {
+	if _, err := normalizeBatchSize(int(batchSize), batchSizeSet, defaultCursorBatchSize); err != nil {
 		return err
 	}
 	projection, err := commandOptionalDocument(command, "projection")

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -34,7 +34,7 @@ type findSort struct {
 	desc  bool
 }
 
-func (s *Server) executeFind(col *collections.Collection, command wire.Document, filter wire.Document) (bson.A, error) {
+func (s *Server) executeFind(col *collections.Collection, command wire.Document, filter wire.Document) ([]wire.Document, error) {
 	predicates, err := parseFindPredicates(filter)
 	if err != nil {
 		return nil, err
@@ -95,15 +95,15 @@ func (s *Server) executeFind(col *collections.Collection, command wire.Document,
 	if err != nil {
 		return nil, err
 	}
-	firstBatch := make(bson.A, 0, len(docs))
+	out := make([]wire.Document, 0, len(docs))
 	for _, doc := range docs {
 		projected, err := projectDocument(doc, projection)
 		if err != nil {
 			return nil, err
 		}
-		firstBatch = append(firstBatch, bson.Raw(projected))
+		out = append(out, projected)
 	}
-	return firstBatch, nil
+	return out, nil
 }
 
 func (s *Server) findCandidateDocuments(col *collections.Collection, predicates []findPredicate) ([]wire.Document, error) {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -85,7 +85,7 @@ func (s *Server) executeFind(col *collections.Collection, plan findPlan) (findRe
 	if err != nil {
 		return findResultSet{}, err
 	}
-	filtered := docs[:0]
+	filtered := make([]wire.Document, 0, len(docs))
 	for _, doc := range docs {
 		match, err := documentMatchesPredicates(doc, plan.predicates)
 		if err != nil {
@@ -116,6 +116,9 @@ func (s *Server) executeFind(col *collections.Collection, plan findPlan) (findRe
 	}
 	if plan.limit > 0 && int(plan.limit) < len(docs) {
 		docs = docs[:plan.limit]
+	}
+	if len(docs) > 0 {
+		docs = append([]wire.Document(nil), docs...)
 	}
 	return findResultSet{docs: docs, projection: plan.projection}, nil
 }

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -16,26 +16,30 @@ import (
 )
 
 const (
-	defaultMaxBSONObjectSize    = 16 * 1024 * 1024
-	defaultMaxWriteBatchSize    = 100_000
-	defaultMaxFindScanDocuments = 10_000
-	defaultMaxOpenCursors       = 1_024
-	defaultCursorBatchSize      = 101
-	defaultCursorIdleTimeout    = 10 * time.Minute
+	defaultMaxBSONObjectSize      = 16 * 1024 * 1024
+	defaultMaxWriteBatchSize      = 100_000
+	defaultMaxFindScanDocuments   = 10_000
+	defaultMaxCursorRetainedBytes = 64 * 1024 * 1024
+	defaultMaxOpenCursors         = 1_024
+	defaultCursorBatchSize        = 101
+	defaultCursorIdleTimeout      = 10 * time.Minute
+	defaultCursorReapInterval     = time.Second
 )
 
 type Server struct {
-	MaxMessageLength     int32
-	MaxFindScanDocuments int
-	MaxOpenCursors       int
-	CursorIdleTimeout    time.Duration
-	Collections          *collections.CollectionManager
+	MaxMessageLength       int32
+	MaxFindScanDocuments   int
+	MaxCursorRetainedBytes int
+	MaxOpenCursors         int
+	CursorIdleTimeout      time.Duration
+	Collections            *collections.CollectionManager
 
 	nextResponseID   atomic.Int32
 	nextConnectionID atomic.Int64
 	nextCursorID     atomic.Int64
 	cursorMu         sync.Mutex
 	cursors          map[int64]*serverCursor
+	lastCursorReap   time.Time
 }
 
 type serverCursor struct {
@@ -248,6 +252,13 @@ func (s *Server) maxOpenCursors() int {
 		return defaultMaxOpenCursors
 	}
 	return s.MaxOpenCursors
+}
+
+func (s *Server) maxCursorRetainedBytes() int {
+	if s.MaxCursorRetainedBytes <= 0 {
+		return defaultMaxCursorRetainedBytes
+	}
+	return s.MaxCursorRetainedBytes
 }
 
 func (s *Server) cursorIdleTimeout() time.Duration {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -21,12 +21,14 @@ const (
 	defaultMaxFindScanDocuments = 10_000
 	defaultMaxOpenCursors       = 1_024
 	defaultCursorBatchSize      = 101
+	defaultCursorIdleTimeout    = 10 * time.Minute
 )
 
 type Server struct {
 	MaxMessageLength     int32
 	MaxFindScanDocuments int
 	MaxOpenCursors       int
+	CursorIdleTimeout    time.Duration
 	Collections          *collections.CollectionManager
 
 	nextResponseID   atomic.Int32
@@ -41,7 +43,9 @@ type serverCursor struct {
 	owner      int64
 	docs       []wire.Document
 	projection compiledProjection
+	batchSize  int
 	pos        int
+	lastUsed   time.Time
 }
 
 func NewServer() *Server {
@@ -84,11 +88,14 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	}
 }
 
-// ServeOne serves a single MongoDB wire message using cursor owner 0.
+// ServeOne serves a single MongoDB wire message with a one-shot cursor owner.
 // Callers serving a real long-lived connection should use ServeOneWithOwner or
-// ServeConn so opened cursors participate in owner-based cleanup.
+// ServeConn so cursors survive across getMore/killCursors commands on the same
+// connection owner.
 func (s *Server) ServeOne(rw io.ReadWriter) error {
-	return s.ServeOneWithOwner(rw, 0)
+	owner := s.nextConnectionID.Add(1)
+	defer s.killCursorsForOwner(owner)
+	return s.ServeOneWithOwner(rw, owner)
 }
 
 func (s *Server) ServeOneWithOwner(rw io.ReadWriter, cursorOwner int64) error {
@@ -104,6 +111,7 @@ func (s *Server) ServeOneWithOwner(rw io.ReadWriter, cursorOwner int64) error {
 }
 
 func (s *Server) handleMessage(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
+	s.reapExpiredCursors()
 	switch h.OpCode {
 	case wire.OpQuery:
 		return s.handleQuery(h, body, cursorOwner)
@@ -241,6 +249,16 @@ func (s *Server) maxOpenCursors() int {
 		return defaultMaxOpenCursors
 	}
 	return s.MaxOpenCursors
+}
+
+func (s *Server) cursorIdleTimeout() time.Duration {
+	if s.CursorIdleTimeout < 0 {
+		return 0
+	}
+	if s.CursorIdleTimeout == 0 {
+		return defaultCursorIdleTimeout
+	}
+	return s.CursorIdleTimeout
 }
 
 func (s *Server) nextID() int32 {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -43,7 +43,6 @@ type serverCursor struct {
 	owner      int64
 	docs       []wire.Document
 	projection compiledProjection
-	batchSize  int
 	pos        int
 	lastUsed   time.Time
 }

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -72,7 +72,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		default:
 		}
 
-		if err := s.serveOne(conn, owner); err != nil {
+		if err := s.ServeOneWithOwner(conn, owner); err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
@@ -84,11 +84,14 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	}
 }
 
+// ServeOne serves a single MongoDB wire message using cursor owner 0.
+// Callers serving a real long-lived connection should use ServeOneWithOwner or
+// ServeConn so opened cursors participate in owner-based cleanup.
 func (s *Server) ServeOne(rw io.ReadWriter) error {
-	return s.serveOne(rw, 0)
+	return s.ServeOneWithOwner(rw, 0)
 }
 
-func (s *Server) serveOne(rw io.ReadWriter, cursorOwner int64) error {
+func (s *Server) ServeOneWithOwner(rw io.ReadWriter, cursorOwner int64) error {
 	h, body, err := wire.ReadMessage(rw, s.maxMessageLength())
 	if err != nil {
 		return err
@@ -158,9 +161,9 @@ func (s *Server) commandResponse(name string, command wire.Document, sequences [
 	case "find":
 		return s.findResponse(command, cursorOwner)
 	case "getMore":
-		return s.getMoreResponse(command)
+		return s.getMoreResponse(command, cursorOwner)
 	case "killCursors":
-		return s.killCursorsResponse(command)
+		return s.killCursorsResponse(command, cursorOwner)
 	case "update":
 		return s.updateResponse(command, sequences)
 	case "delete":

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -18,6 +19,7 @@ const (
 	defaultMaxBSONObjectSize    = 16 * 1024 * 1024
 	defaultMaxWriteBatchSize    = 100_000
 	defaultMaxFindScanDocuments = 10_000
+	defaultCursorBatchSize      = 101
 )
 
 type Server struct {
@@ -26,6 +28,14 @@ type Server struct {
 	Collections          *collections.CollectionManager
 
 	nextResponseID atomic.Int32
+	nextCursorID   atomic.Int64
+	cursorMu       sync.Mutex
+	cursors        map[int64]*serverCursor
+}
+
+type serverCursor struct {
+	ns   string
+	docs []wire.Document
 }
 
 func NewServer() *Server {
@@ -135,6 +145,10 @@ func (s *Server) commandResponse(name string, command wire.Document, sequences [
 		return s.insertResponse(command, sequences)
 	case "find":
 		return s.findResponse(command)
+	case "getMore":
+		return s.getMoreResponse(command)
+	case "killCursors":
+		return s.killCursorsResponse(command)
 	case "update":
 		return s.updateResponse(command, sequences)
 	case "delete":

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -19,23 +19,28 @@ const (
 	defaultMaxBSONObjectSize    = 16 * 1024 * 1024
 	defaultMaxWriteBatchSize    = 100_000
 	defaultMaxFindScanDocuments = 10_000
+	defaultMaxOpenCursors       = 1_024
 	defaultCursorBatchSize      = 101
 )
 
 type Server struct {
 	MaxMessageLength     int32
 	MaxFindScanDocuments int
+	MaxOpenCursors       int
 	Collections          *collections.CollectionManager
 
-	nextResponseID atomic.Int32
-	nextCursorID   atomic.Int64
-	cursorMu       sync.Mutex
-	cursors        map[int64]*serverCursor
+	nextResponseID   atomic.Int32
+	nextConnectionID atomic.Int64
+	nextCursorID     atomic.Int64
+	cursorMu         sync.Mutex
+	cursors          map[int64]*serverCursor
 }
 
 type serverCursor struct {
-	ns   string
-	docs []wire.Document
+	ns    string
+	owner int64
+	docs  []wire.Document
+	pos   int
 }
 
 func NewServer() *Server {
@@ -46,6 +51,8 @@ func NewServer() *Server {
 
 func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	defer conn.Close()
+	owner := s.nextConnectionID.Add(1)
+	defer s.killCursorsForOwner(owner)
 
 	done := make(chan struct{})
 	defer close(done)
@@ -64,7 +71,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		default:
 		}
 
-		if err := s.ServeOne(conn); err != nil {
+		if err := s.serveOne(conn, owner); err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
@@ -77,23 +84,27 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 }
 
 func (s *Server) ServeOne(rw io.ReadWriter) error {
+	return s.serveOne(rw, 0)
+}
+
+func (s *Server) serveOne(rw io.ReadWriter, cursorOwner int64) error {
 	h, body, err := wire.ReadMessage(rw, s.maxMessageLength())
 	if err != nil {
 		return err
 	}
-	response, err := s.handleMessage(h, body)
+	response, err := s.handleMessage(h, body, cursorOwner)
 	if err != nil {
 		return err
 	}
 	return writeFull(rw, response)
 }
 
-func (s *Server) handleMessage(h wire.Header, body []byte) ([]byte, error) {
+func (s *Server) handleMessage(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
 	switch h.OpCode {
 	case wire.OpQuery:
-		return s.handleQuery(h, body)
+		return s.handleQuery(h, body, cursorOwner)
 	case wire.OpMsg:
-		return s.handleMsg(h, body)
+		return s.handleMsg(h, body, cursorOwner)
 	case wire.OpCompressed:
 		return nil, fmt.Errorf("%w: OP_COMPRESSED", wire.ErrUnsupported)
 	default:
@@ -101,7 +112,7 @@ func (s *Server) handleMessage(h wire.Header, body []byte) ([]byte, error) {
 	}
 }
 
-func (s *Server) handleQuery(h wire.Header, body []byte) ([]byte, error) {
+func (s *Server) handleQuery(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
 	q, err := wire.ParseQuery(body)
 	if err != nil {
 		return nil, err
@@ -111,14 +122,14 @@ func (s *Server) handleQuery(h wire.Header, body []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	response, err := s.commandResponse(name, q.Query, nil)
+	response, err := s.commandResponse(name, q.Query, nil, cursorOwner)
 	if err != nil {
 		return nil, err
 	}
 	return wire.AppendReplyMessage(nil, s.nextID(), h.RequestID, 0, 0, 0, response)
 }
 
-func (s *Server) handleMsg(h wire.Header, body []byte) ([]byte, error) {
+func (s *Server) handleMsg(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
 	msg, err := wire.ParseMsg(body)
 	if err != nil {
 		return nil, err
@@ -128,14 +139,14 @@ func (s *Server) handleMsg(h wire.Header, body []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	response, err := s.commandResponse(name, msg.Body, msg.Sequences)
+	response, err := s.commandResponse(name, msg.Body, msg.Sequences, cursorOwner)
 	if err != nil {
 		return nil, err
 	}
 	return wire.AppendMsgMessage(nil, s.nextID(), h.RequestID, 0, response)
 }
 
-func (s *Server) commandResponse(name string, command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+func (s *Server) commandResponse(name string, command wire.Document, sequences []wire.DocumentSequence, cursorOwner int64) (wire.Document, error) {
 	switch name {
 	case "hello", "isMaster", "ismaster":
 		return marshalDocument(helloResponse(s.maxMessageLength()))
@@ -144,7 +155,7 @@ func (s *Server) commandResponse(name string, command wire.Document, sequences [
 	case "insert":
 		return s.insertResponse(command, sequences)
 	case "find":
-		return s.findResponse(command)
+		return s.findResponse(command, cursorOwner)
 	case "getMore":
 		return s.getMoreResponse(command)
 	case "killCursors":
@@ -219,6 +230,13 @@ func (s *Server) maxFindScanDocuments() int {
 		return defaultMaxFindScanDocuments
 	}
 	return s.MaxFindScanDocuments
+}
+
+func (s *Server) maxOpenCursors() int {
+	if s.MaxOpenCursors <= 0 {
+		return defaultMaxOpenCursors
+	}
+	return s.MaxOpenCursors
 }
 
 func (s *Server) nextID() int32 {

--- a/TreeDB/mongo_gateway/server_driver_test.go
+++ b/TreeDB/mongo_gateway/server_driver_test.go
@@ -339,6 +339,20 @@ func TestServerOfficialGoDriverFindPlanner(t *testing.T) {
 		t.Fatalf("_id in find results=%v want katherine", results)
 	}
 
+	cursor, err = coll.Find(opCtx,
+		bson.D{},
+		options.Find().SetSort(bson.D{{Key: "name", Value: int32(1)}}).SetBatchSize(1))
+	if err != nil {
+		t.Fatalf("driver batched find: %v", err)
+	}
+	results = nil
+	if err := cursor.All(opCtx, &results); err != nil {
+		t.Fatalf("driver batched find all: %v", err)
+	}
+	if len(results) != 3 || results[0]["name"] != "ada" || results[2]["name"] != "katherine" {
+		t.Fatalf("batched find results=%v want ada..katherine", results)
+	}
+
 	cancel()
 	_ = ln.Close()
 	select {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -673,6 +674,153 @@ func TestServerFindGetMoreAndKillCursors(t *testing.T) {
 		{Key: "$db", Value: "app"},
 	})
 	assertCommandError(t, missingResponse, "CursorNotFound")
+}
+
+func TestServerFindBatchSizeZeroKeepsCursorEmpty(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 241, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "ada"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "grace"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	findResponse := serveCommand(t, server, 242, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{}},
+		{Key: "sort", Value: bson.D{{Key: "name", Value: int32(1)}}},
+		{Key: "batchSize", Value: int32(0)},
+		{Key: "$db", Value: "app"},
+	})
+	if firstBatch := cursorFirstBatch(t, findResponse); len(firstBatch) != 0 {
+		t.Fatalf("firstBatch len=%d want 0", len(firstBatch))
+	}
+	cursorID := cursorIDFromResponse(t, findResponse)
+	if cursorID == 0 {
+		t.Fatal("cursor id=0 want open cursor")
+	}
+
+	emptyGetMore := serveCommand(t, server, 243, bson.D{
+		{Key: "getMore", Value: cursorID},
+		{Key: "collection", Value: "users"},
+		{Key: "batchSize", Value: int32(0)},
+		{Key: "$db", Value: "app"},
+	})
+	if nextBatch := cursorNextBatch(t, emptyGetMore); len(nextBatch) != 0 {
+		t.Fatalf("empty getMore nextBatch len=%d want 0", len(nextBatch))
+	}
+	if nextID := cursorIDFromResponse(t, emptyGetMore); nextID != cursorID {
+		t.Fatalf("cursor id after empty getMore=%d want %d", nextID, cursorID)
+	}
+
+	getMoreResponse := serveCommand(t, server, 244, bson.D{
+		{Key: "getMore", Value: cursorID},
+		{Key: "collection", Value: "users"},
+		{Key: "batchSize", Value: int32(1)},
+		{Key: "$db", Value: "app"},
+	})
+	nextBatch := cursorNextBatch(t, getMoreResponse)
+	if len(nextBatch) != 1 {
+		t.Fatalf("nextBatch len=%d want 1", len(nextBatch))
+	}
+	name, ok := nextBatch[0].Lookup("name").StringValueOK()
+	if !ok || name != "ada" {
+		t.Fatalf("nextBatch[0].name=%q ok=%v want ada", name, ok)
+	}
+}
+
+func TestServerCursorOwnerCleanup(t *testing.T) {
+	server := NewServer()
+	docs := []wire.Document{
+		mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}),
+		mustDocument(t, bson.D{{Key: "_id", Value: "u2"}}),
+	}
+	cursorID, firstBatch, err := server.openCursor("app.users", docs, 0, true, 99)
+	if err != nil {
+		t.Fatalf("openCursor: %v", err)
+	}
+	if cursorID == 0 {
+		t.Fatal("cursor id=0 want open cursor")
+	}
+	if len(firstBatch) != 0 {
+		t.Fatalf("firstBatch len=%d want 0", len(firstBatch))
+	}
+
+	server.killCursorsForOwner(99)
+	if _, _, ok, err := server.getMore(cursorID, "app.users", 1, true); err != nil || ok {
+		t.Fatalf("getMore after owner cleanup ok/err=%v/%v want false/nil", ok, err)
+	}
+}
+
+func TestServerCursorLimit(t *testing.T) {
+	server := NewServer()
+	server.MaxOpenCursors = 1
+	docs := []wire.Document{
+		mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}),
+	}
+
+	cursorID, _, err := server.openCursor("app.users", docs, 0, true, 1)
+	if err != nil {
+		t.Fatalf("openCursor first: %v", err)
+	}
+	if cursorID == 0 {
+		t.Fatal("cursor id=0 want open cursor")
+	}
+	if _, _, err := server.openCursor("app.users", docs, 0, true, 2); err == nil {
+		t.Fatal("second openCursor err=nil want cursor limit error")
+	}
+}
+
+func TestServerCursorBatchesRespectMessageSize(t *testing.T) {
+	server := NewServer()
+	server.MaxMessageLength = 5 * 1024
+	docs := []wire.Document{
+		mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "payload", Value: strings.Repeat("a", 900)}}),
+		mustDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "payload", Value: strings.Repeat("b", 900)}}),
+		mustDocument(t, bson.D{{Key: "_id", Value: "u3"}, {Key: "payload", Value: strings.Repeat("c", 900)}}),
+	}
+
+	cursorID, firstBatch, err := server.openCursor("app.users", docs, 10, true, 0)
+	if err != nil {
+		t.Fatalf("openCursor: %v", err)
+	}
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	if cursorID == 0 {
+		t.Fatal("cursor id=0 want open cursor")
+	}
+
+	nextID, nextBatch, ok, err := server.getMore(cursorID, "app.users", 10, true)
+	if err != nil || !ok {
+		t.Fatalf("getMore ok/err=%v/%v want true/nil", ok, err)
+	}
+	if len(nextBatch) != 1 {
+		t.Fatalf("nextBatch len=%d want 1", len(nextBatch))
+	}
+	if nextID != cursorID {
+		t.Fatalf("cursor id after getMore=%d want %d", nextID, cursorID)
+	}
+
+	finalID, finalBatch, ok, err := server.getMore(cursorID, "app.users", 10, true)
+	if err != nil || !ok {
+		t.Fatalf("final getMore ok/err=%v/%v want true/nil", ok, err)
+	}
+	if len(finalBatch) != 1 {
+		t.Fatalf("finalBatch len=%d want 1", len(finalBatch))
+	}
+	if finalID != 0 {
+		t.Fatalf("final cursor id=%d want 0", finalID)
+	}
 }
 
 func TestApplySetUpdateAppendsNewFieldsInSetOrder(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -854,7 +854,7 @@ func TestServeOneCleansUpOneShotCursors(t *testing.T) {
 	}
 }
 
-func TestServerGetMoreWithoutBatchSizeReusesCursorBatchSize(t *testing.T) {
+func TestServerGetMoreWithoutBatchSizeUsesMessageLimit(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -894,11 +894,11 @@ func TestServerGetMoreWithoutBatchSizeReusesCursorBatchSize(t *testing.T) {
 		{Key: "$db", Value: "app"},
 	})
 	nextBatch := cursorNextBatch(t, getMoreResponse)
-	if len(nextBatch) != 1 {
-		t.Fatalf("nextBatch len=%d want 1", len(nextBatch))
+	if len(nextBatch) != 3 {
+		t.Fatalf("nextBatch len=%d want 3", len(nextBatch))
 	}
-	if nextID := cursorIDFromResponse(t, getMoreResponse); nextID != cursorID {
-		t.Fatalf("cursor id after getMore=%d want %d", nextID, cursorID)
+	if nextID := cursorIDFromResponse(t, getMoreResponse); nextID != 0 {
+		t.Fatalf("cursor id after getMore=%d want 0", nextID)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -771,7 +771,90 @@ func TestServerFindBatchSizeZeroKeepsCursorEmpty(t *testing.T) {
 	}
 }
 
-func TestServerGetMoreWithoutBatchSizeUsesMessageLimit(t *testing.T) {
+func TestServerFindSingleBatchClosesCursor(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 244, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "ada"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "grace"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	findResponse := serveCommand(t, server, 245, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{}},
+		{Key: "sort", Value: bson.D{{Key: "name", Value: int32(1)}}},
+		{Key: "batchSize", Value: int32(1)},
+		{Key: "singleBatch", Value: true},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch := cursorFirstBatch(t, findResponse)
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	if cursorID := cursorIDFromResponse(t, findResponse); cursorID != 0 {
+		t.Fatalf("singleBatch cursor id=%d want 0", cursorID)
+	}
+	server.cursorMu.Lock()
+	defer server.cursorMu.Unlock()
+	if len(server.cursors) != 0 {
+		t.Fatalf("open cursors=%d want 0", len(server.cursors))
+	}
+}
+
+func TestServeOneCleansUpOneShotCursors(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 246, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}},
+			bson.D{{Key: "_id", Value: "u2"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	commandDoc := mustDocument(t, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{}},
+		{Key: "batchSize", Value: int32(0)},
+		{Key: "$db", Value: "app"},
+	})
+	req, err := wire.AppendMsgMessage(nil, 247, 0, 0, commandDoc)
+	if err != nil {
+		t.Fatalf("AppendMsgMessage: %v", err)
+	}
+	rw := &readWriter{r: bytes.NewReader(req)}
+	if err := server.ServeOne(rw); err != nil {
+		t.Fatalf("ServeOne: %v", err)
+	}
+	findResponse := readMsgResponse(t, rw.w.Bytes(), 247)
+	if cursorID := cursorIDFromResponse(t, findResponse); cursorID == 0 {
+		t.Fatal("one-shot find cursor id=0 want returned cursor id")
+	}
+	server.cursorMu.Lock()
+	defer server.cursorMu.Unlock()
+	if len(server.cursors) != 0 {
+		t.Fatalf("open cursors=%d want 0", len(server.cursors))
+	}
+}
+
+func TestServerGetMoreWithoutBatchSizeReusesCursorBatchSize(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -811,11 +894,11 @@ func TestServerGetMoreWithoutBatchSizeUsesMessageLimit(t *testing.T) {
 		{Key: "$db", Value: "app"},
 	})
 	nextBatch := cursorNextBatch(t, getMoreResponse)
-	if len(nextBatch) != 3 {
-		t.Fatalf("nextBatch len=%d want 3", len(nextBatch))
+	if len(nextBatch) != 1 {
+		t.Fatalf("nextBatch len=%d want 1", len(nextBatch))
 	}
-	if nextID := cursorIDFromResponse(t, getMoreResponse); nextID != 0 {
-		t.Fatalf("cursor id after getMore=%d want 0", nextID)
+	if nextID := cursorIDFromResponse(t, getMoreResponse); nextID != cursorID {
+		t.Fatalf("cursor id after getMore=%d want %d", nextID, cursorID)
 	}
 }
 
@@ -927,6 +1010,30 @@ func TestServerCursorLimit(t *testing.T) {
 	}
 	if _, _, err := server.openCursor("app.users", docs, compiledProjection{}, 0, true, defaultCursorBatchSize, 2); err == nil {
 		t.Fatal("second openCursor err=nil want cursor limit error")
+	}
+}
+
+func TestServerCursorIdleExpiry(t *testing.T) {
+	server := NewServer()
+	server.CursorIdleTimeout = time.Minute
+	docs := []wire.Document{
+		mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}),
+		mustDocument(t, bson.D{{Key: "_id", Value: "u2"}}),
+	}
+	cursorID, _, err := server.openCursor("app.users", docs, compiledProjection{}, 1, true, defaultCursorBatchSize, 1)
+	if err != nil {
+		t.Fatalf("openCursor: %v", err)
+	}
+	if cursorID == 0 {
+		t.Fatal("cursor id=0 want open cursor")
+	}
+
+	server.cursorMu.Lock()
+	server.cursors[cursorID].lastUsed = time.Now().Add(-2 * time.Minute)
+	server.cursorMu.Unlock()
+
+	if _, _, ok, err := server.getMore(cursorID, "app.users", 1, 1, true, defaultCursorBatchSize); err != nil || ok {
+		t.Fatalf("expired getMore ok/err=%v/%v want false/nil", ok, err)
 	}
 }
 
@@ -1546,8 +1653,8 @@ func serveCommand(tb testing.TB, server *Server, requestID int32, doc bson.D) wi
 		tb.Fatalf("AppendMsgMessage: %v", err)
 	}
 	rw := &readWriter{r: bytes.NewReader(req)}
-	if err := server.ServeOne(rw); err != nil {
-		tb.Fatalf("ServeOne: %v", err)
+	if err := server.ServeOneWithOwner(rw, 1); err != nil {
+		tb.Fatalf("ServeOneWithOwner: %v", err)
 	}
 	return readMsgResponse(tb, rw.w.Bytes(), requestID)
 }

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -874,8 +874,32 @@ func TestServerCursorOwnerCleanup(t *testing.T) {
 	}
 
 	server.killCursorsForOwner(99)
-	if _, _, ok, err := server.getMore(cursorID, "app.users", 1, true, defaultCursorBatchSize); err != nil || ok {
+	if _, _, ok, err := server.getMore(cursorID, "app.users", 99, 1, true, defaultCursorBatchSize); err != nil || ok {
 		t.Fatalf("getMore after owner cleanup ok/err=%v/%v want false/nil", ok, err)
+	}
+}
+
+func TestServerCursorOwnerIsolation(t *testing.T) {
+	server := NewServer()
+	docs := []wire.Document{
+		mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}),
+		mustDocument(t, bson.D{{Key: "_id", Value: "u2"}}),
+	}
+	cursorID, firstBatch, err := server.openCursor("app.users", docs, compiledProjection{}, 1, true, defaultCursorBatchSize, 1)
+	if err != nil {
+		t.Fatalf("openCursor: %v", err)
+	}
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	if _, _, ok, err := server.getMore(cursorID, "app.users", 2, 1, true, defaultCursorBatchSize); err != nil || ok {
+		t.Fatalf("wrong-owner getMore ok/err=%v/%v want false/nil", ok, err)
+	}
+	if killed, notFound := server.killCursors("app.users", 2, []int64{cursorID}); len(killed) != 0 || len(notFound) != 1 {
+		t.Fatalf("wrong-owner kill killed=%v notFound=%v want none/one", killed, notFound)
+	}
+	if nextID, batch, ok, err := server.getMore(cursorID, "app.users", 1, 1, true, defaultCursorBatchSize); err != nil || !ok || nextID != 0 || len(batch) != 1 {
+		t.Fatalf("owner getMore id=%d len=%d ok/err=%v/%v want 0/1 true/nil", nextID, len(batch), ok, err)
 	}
 }
 
@@ -918,7 +942,7 @@ func TestServerCursorBatchesRespectMessageSize(t *testing.T) {
 		t.Fatal("cursor id=0 want open cursor")
 	}
 
-	nextID, nextBatch, ok, err := server.getMore(cursorID, "app.users", 10, true, defaultCursorBatchSize)
+	nextID, nextBatch, ok, err := server.getMore(cursorID, "app.users", 0, 10, true, defaultCursorBatchSize)
 	if err != nil || !ok {
 		t.Fatalf("getMore ok/err=%v/%v want true/nil", ok, err)
 	}
@@ -929,7 +953,7 @@ func TestServerCursorBatchesRespectMessageSize(t *testing.T) {
 		t.Fatalf("cursor id after getMore=%d want %d", nextID, cursorID)
 	}
 
-	finalID, finalBatch, ok, err := server.getMore(cursorID, "app.users", 10, true, defaultCursorBatchSize)
+	finalID, finalBatch, ok, err := server.getMore(cursorID, "app.users", 0, 10, true, defaultCursorBatchSize)
 	if err != nil || !ok {
 		t.Fatalf("final getMore ok/err=%v/%v want true/nil", ok, err)
 	}

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -437,6 +437,77 @@ func TestServerFindPlannerIndexedAndBoundedPredicates(t *testing.T) {
 	}
 }
 
+func TestServerFindGetMoreAndKillCursors(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 236, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "ada"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "grace"}},
+			bson.D{{Key: "_id", Value: "u3"}, {Key: "name", Value: "katherine"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	findResponse := serveCommand(t, server, 237, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{}},
+		{Key: "sort", Value: bson.D{{Key: "name", Value: int32(1)}}},
+		{Key: "batchSize", Value: int32(1)},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch := cursorFirstBatch(t, findResponse)
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	cursorID := cursorIDFromResponse(t, findResponse)
+	if cursorID == 0 {
+		t.Fatal("cursor id=0 want open cursor")
+	}
+
+	getMoreResponse := serveCommand(t, server, 238, bson.D{
+		{Key: "getMore", Value: cursorID},
+		{Key: "collection", Value: "users"},
+		{Key: "batchSize", Value: int32(1)},
+		{Key: "$db", Value: "app"},
+	})
+	nextBatch := cursorNextBatch(t, getMoreResponse)
+	if len(nextBatch) != 1 {
+		t.Fatalf("nextBatch len=%d want 1", len(nextBatch))
+	}
+	if nextID := cursorIDFromResponse(t, getMoreResponse); nextID != cursorID {
+		t.Fatalf("cursor id after first getMore=%d want %d", nextID, cursorID)
+	}
+
+	killResponse := serveCommand(t, server, 239, bson.D{
+		{Key: "killCursors", Value: "users"},
+		{Key: "cursors", Value: bson.A{cursorID}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, killResponse)
+	killed, ok := bson.Raw(killResponse).Lookup("cursorsKilled").ArrayOK()
+	if !ok {
+		t.Fatal("cursorsKilled missing")
+	}
+	if values, err := killed.Values(); err != nil || len(values) != 1 {
+		t.Fatalf("cursorsKilled values len/err=%d/%v want 1/nil", len(values), err)
+	}
+
+	missingResponse := serveCommand(t, server, 240, bson.D{
+		{Key: "getMore", Value: cursorID},
+		{Key: "collection", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, missingResponse, "CursorNotFound")
+}
+
 func TestServerFindByIDMissingCollectionReturnsEmptyBatch(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -652,6 +723,44 @@ func cursorFirstBatch(tb testing.TB, doc wire.Document) []bson.Raw {
 		out = append(out, doc)
 	}
 	return out
+}
+
+func cursorNextBatch(tb testing.TB, doc wire.Document) []bson.Raw {
+	tb.Helper()
+	cursor, ok := bson.Raw(doc).Lookup("cursor").DocumentOK()
+	if !ok {
+		tb.Fatalf("cursor missing or not document in %v", bson.Raw(doc))
+	}
+	batch, ok := cursor.Lookup("nextBatch").ArrayOK()
+	if !ok {
+		tb.Fatalf("cursor.nextBatch missing or not array in %v", cursor)
+	}
+	values, err := batch.Values()
+	if err != nil {
+		tb.Fatalf("nextBatch values: %v", err)
+	}
+	out := make([]bson.Raw, 0, len(values))
+	for i, value := range values {
+		doc, ok := value.DocumentOK()
+		if !ok {
+			tb.Fatalf("nextBatch[%d] is not a document", i)
+		}
+		out = append(out, doc)
+	}
+	return out
+}
+
+func cursorIDFromResponse(tb testing.TB, doc wire.Document) int64 {
+	tb.Helper()
+	cursor, ok := bson.Raw(doc).Lookup("cursor").DocumentOK()
+	if !ok {
+		tb.Fatalf("cursor missing or not document in %v", bson.Raw(doc))
+	}
+	id, ok := cursor.Lookup("id").Int64OK()
+	if !ok {
+		tb.Fatalf("cursor.id missing or not int64 in %v", cursor)
+	}
+	return id
 }
 
 func assertInt32(tb testing.TB, doc wire.Document, key string, want int32) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -744,28 +744,18 @@ func TestServerFindBatchSizeZeroKeepsCursorEmpty(t *testing.T) {
 		t.Fatal("cursor id=0 want open cursor")
 	}
 
-	emptyGetMore := serveCommand(t, server, 243, bson.D{
+	zeroGetMore := serveCommand(t, server, 243, bson.D{
 		{Key: "getMore", Value: cursorID},
 		{Key: "collection", Value: "users"},
 		{Key: "batchSize", Value: int32(0)},
 		{Key: "$db", Value: "app"},
 	})
-	if nextBatch := cursorNextBatch(t, emptyGetMore); len(nextBatch) != 0 {
-		t.Fatalf("empty getMore nextBatch len=%d want 0", len(nextBatch))
+	nextBatch := cursorNextBatch(t, zeroGetMore)
+	if len(nextBatch) != 2 {
+		t.Fatalf("zero getMore nextBatch len=%d want 2", len(nextBatch))
 	}
-	if nextID := cursorIDFromResponse(t, emptyGetMore); nextID != cursorID {
-		t.Fatalf("cursor id after empty getMore=%d want %d", nextID, cursorID)
-	}
-
-	getMoreResponse := serveCommand(t, server, 244, bson.D{
-		{Key: "getMore", Value: cursorID},
-		{Key: "collection", Value: "users"},
-		{Key: "batchSize", Value: int32(1)},
-		{Key: "$db", Value: "app"},
-	})
-	nextBatch := cursorNextBatch(t, getMoreResponse)
-	if len(nextBatch) != 1 {
-		t.Fatalf("nextBatch len=%d want 1", len(nextBatch))
+	if nextID := cursorIDFromResponse(t, zeroGetMore); nextID != 0 {
+		t.Fatalf("cursor id after zero getMore=%d want 0", nextID)
 	}
 	name, ok := nextBatch[0].Lookup("name").StringValueOK()
 	if !ok || name != "ada" {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -947,6 +947,32 @@ func TestServerCursorRejectsNegativeBatchSize(t *testing.T) {
 	assertCommandError(t, negativeGetMore, "BadValue")
 }
 
+func TestRequiredInt64FieldsRejectNonIntegerNumerics(t *testing.T) {
+	doc := mustDocument(t, bson.D{
+		{Key: "getMore", Value: 1.5},
+		{Key: "cursors", Value: bson.A{int32(1), int64(2), 3.5}},
+	})
+	if _, err := requiredInt64Field(doc, "getMore"); err == nil {
+		t.Fatal("requiredInt64Field accepted double cursor id")
+	}
+	values, err := requiredInt64ArrayField(doc, "cursors")
+	if err == nil {
+		t.Fatalf("requiredInt64ArrayField values=%v err=nil want double rejection", values)
+	}
+
+	okDoc := mustDocument(t, bson.D{
+		{Key: "getMore", Value: int32(7)},
+		{Key: "cursors", Value: bson.A{int32(8), int64(9)}},
+	})
+	if value, err := requiredInt64Field(okDoc, "getMore"); err != nil || value != 7 {
+		t.Fatalf("requiredInt64Field int32 value/err=%d/%v want 7/nil", value, err)
+	}
+	values, err = requiredInt64ArrayField(okDoc, "cursors")
+	if err != nil || len(values) != 2 || values[0] != 8 || values[1] != 9 {
+		t.Fatalf("requiredInt64ArrayField values/err=%v/%v want [8 9]/nil", values, err)
+	}
+}
+
 func TestServerCursorOwnerCleanup(t *testing.T) {
 	server := NewServer()
 	docs := []wire.Document{
@@ -1013,6 +1039,23 @@ func TestServerCursorLimit(t *testing.T) {
 	}
 }
 
+func TestServerCursorRetainedBytesLimit(t *testing.T) {
+	server := NewServer()
+	server.MaxCursorRetainedBytes = 1
+	docs := []wire.Document{
+		mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}),
+		mustDocument(t, bson.D{{Key: "_id", Value: "u2"}}),
+	}
+
+	cursorID, firstBatch, err := server.openCursor("app.users", docs, compiledProjection{}, 1, true, defaultCursorBatchSize, 1)
+	if err == nil {
+		t.Fatalf("openCursor id=%d firstBatch=%d err=nil want retained bytes error", cursorID, len(firstBatch))
+	}
+	if cursorID != 0 || firstBatch != nil {
+		t.Fatalf("openCursor id/firstBatch=%d/%v want zero/nil on retained bytes error", cursorID, firstBatch)
+	}
+}
+
 func TestServerCursorIdleExpiry(t *testing.T) {
 	server := NewServer()
 	server.CursorIdleTimeout = time.Minute
@@ -1034,6 +1077,34 @@ func TestServerCursorIdleExpiry(t *testing.T) {
 
 	if _, _, ok, err := server.getMore(cursorID, "app.users", 1, 1, true, defaultCursorBatchSize); err != nil || ok {
 		t.Fatalf("expired getMore ok/err=%v/%v want false/nil", ok, err)
+	}
+}
+
+func TestServerBackgroundCursorReapIsThrottled(t *testing.T) {
+	server := NewServer()
+	server.CursorIdleTimeout = time.Nanosecond
+	server.cursorMu.Lock()
+	server.cursors = map[int64]*serverCursor{
+		1: {ns: "app.users", owner: 1, lastUsed: time.Now().Add(-time.Minute)},
+	}
+	server.lastCursorReap = time.Now()
+	server.cursorMu.Unlock()
+
+	server.reapExpiredCursors()
+	server.cursorMu.Lock()
+	_, stillPresent := server.cursors[1]
+	server.lastCursorReap = time.Now().Add(-2 * defaultCursorReapInterval)
+	server.cursorMu.Unlock()
+	if !stillPresent {
+		t.Fatal("cursor reaped despite throttle interval")
+	}
+
+	server.reapExpiredCursors()
+	server.cursorMu.Lock()
+	_, stillPresent = server.cursors[1]
+	server.cursorMu.Unlock()
+	if stillPresent {
+		t.Fatal("cursor not reaped after throttle interval")
 	}
 }
 
@@ -1193,6 +1264,50 @@ func TestServerFindFirstBatchOverflowOpensCursor(t *testing.T) {
 	if nextID := cursorIDFromResponse(t, getMoreResponse); nextID != 0 {
 		t.Fatalf("cursor id after getMore=%d want 0", nextID)
 	}
+}
+
+func TestServerGetMoreDropsCursorOnOversizedNextDocument(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.MaxMessageLength = 4500
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 253, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "a"}, {Key: "payload", Value: "small"}},
+			bson.D{{Key: "_id", Value: "b"}, {Key: "payload", Value: strings.Repeat("x", 600)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	findResponse := serveCommand(t, server, 254, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{}},
+		{Key: "sort", Value: bson.D{{Key: "_id", Value: int32(1)}}},
+		{Key: "batchSize", Value: int32(1)},
+		{Key: "$db", Value: "app"},
+	})
+	cursorID := cursorIDFromResponse(t, findResponse)
+	if cursorID == 0 {
+		t.Fatal("cursor id=0 want open cursor")
+	}
+
+	tooLarge := serveCommand(t, server, 255, bson.D{
+		{Key: "getMore", Value: cursorID},
+		{Key: "collection", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, tooLarge, "BadValue")
+	missing := serveCommand(t, server, 256, bson.D{
+		{Key: "getMore", Value: cursorID},
+		{Key: "collection", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, missing, "CursorNotFound")
 }
 
 func TestServerFindCapsIndexedCandidates(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -738,13 +738,61 @@ func TestServerFindBatchSizeZeroKeepsCursorEmpty(t *testing.T) {
 	}
 }
 
+func TestServerGetMoreWithoutBatchSizeUsesMessageLimit(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	documents := make(bson.A, 0, 4)
+	for _, name := range []string{"ada", "grace", "katherine", "mary"} {
+		documents = append(documents, bson.D{{Key: "_id", Value: name}, {Key: "name", Value: name}})
+	}
+	assertOK(t, serveCommand(t, server, 245, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: documents},
+		{Key: "$db", Value: "app"},
+	}))
+
+	findResponse := serveCommand(t, server, 246, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{}},
+		{Key: "sort", Value: bson.D{{Key: "name", Value: int32(1)}}},
+		{Key: "batchSize", Value: int32(1)},
+		{Key: "$db", Value: "app"},
+	})
+	if firstBatch := cursorFirstBatch(t, findResponse); len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	cursorID := cursorIDFromResponse(t, findResponse)
+	if cursorID == 0 {
+		t.Fatal("cursor id=0 want open cursor")
+	}
+
+	getMoreResponse := serveCommand(t, server, 247, bson.D{
+		{Key: "getMore", Value: cursorID},
+		{Key: "collection", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	nextBatch := cursorNextBatch(t, getMoreResponse)
+	if len(nextBatch) != 3 {
+		t.Fatalf("nextBatch len=%d want 3", len(nextBatch))
+	}
+	if nextID := cursorIDFromResponse(t, getMoreResponse); nextID != 0 {
+		t.Fatalf("cursor id after getMore=%d want 0", nextID)
+	}
+}
+
 func TestServerCursorOwnerCleanup(t *testing.T) {
 	server := NewServer()
 	docs := []wire.Document{
 		mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}),
 		mustDocument(t, bson.D{{Key: "_id", Value: "u2"}}),
 	}
-	cursorID, firstBatch, err := server.openCursor("app.users", docs, 0, true, 99)
+	cursorID, firstBatch, err := server.openCursor("app.users", docs, 0, true, defaultCursorBatchSize, 99)
 	if err != nil {
 		t.Fatalf("openCursor: %v", err)
 	}
@@ -756,7 +804,7 @@ func TestServerCursorOwnerCleanup(t *testing.T) {
 	}
 
 	server.killCursorsForOwner(99)
-	if _, _, ok, err := server.getMore(cursorID, "app.users", 1, true); err != nil || ok {
+	if _, _, ok, err := server.getMore(cursorID, "app.users", 1, true, defaultCursorBatchSize); err != nil || ok {
 		t.Fatalf("getMore after owner cleanup ok/err=%v/%v want false/nil", ok, err)
 	}
 }
@@ -768,14 +816,14 @@ func TestServerCursorLimit(t *testing.T) {
 		mustDocument(t, bson.D{{Key: "_id", Value: "u1"}}),
 	}
 
-	cursorID, _, err := server.openCursor("app.users", docs, 0, true, 1)
+	cursorID, _, err := server.openCursor("app.users", docs, 0, true, defaultCursorBatchSize, 1)
 	if err != nil {
 		t.Fatalf("openCursor first: %v", err)
 	}
 	if cursorID == 0 {
 		t.Fatal("cursor id=0 want open cursor")
 	}
-	if _, _, err := server.openCursor("app.users", docs, 0, true, 2); err == nil {
+	if _, _, err := server.openCursor("app.users", docs, 0, true, defaultCursorBatchSize, 2); err == nil {
 		t.Fatal("second openCursor err=nil want cursor limit error")
 	}
 }
@@ -789,7 +837,7 @@ func TestServerCursorBatchesRespectMessageSize(t *testing.T) {
 		mustDocument(t, bson.D{{Key: "_id", Value: "u3"}, {Key: "payload", Value: strings.Repeat("c", 900)}}),
 	}
 
-	cursorID, firstBatch, err := server.openCursor("app.users", docs, 10, true, 0)
+	cursorID, firstBatch, err := server.openCursor("app.users", docs, 10, true, defaultCursorBatchSize, 0)
 	if err != nil {
 		t.Fatalf("openCursor: %v", err)
 	}
@@ -800,7 +848,7 @@ func TestServerCursorBatchesRespectMessageSize(t *testing.T) {
 		t.Fatal("cursor id=0 want open cursor")
 	}
 
-	nextID, nextBatch, ok, err := server.getMore(cursorID, "app.users", 10, true)
+	nextID, nextBatch, ok, err := server.getMore(cursorID, "app.users", 10, true, defaultCursorBatchSize)
 	if err != nil || !ok {
 		t.Fatalf("getMore ok/err=%v/%v want true/nil", ok, err)
 	}
@@ -811,7 +859,7 @@ func TestServerCursorBatchesRespectMessageSize(t *testing.T) {
 		t.Fatalf("cursor id after getMore=%d want %d", nextID, cursorID)
 	}
 
-	finalID, finalBatch, ok, err := server.getMore(cursorID, "app.users", 10, true)
+	finalID, finalBatch, ok, err := server.getMore(cursorID, "app.users", 10, true, defaultCursorBatchSize)
 	if err != nil || !ok {
 		t.Fatalf("final getMore ok/err=%v/%v want true/nil", ok, err)
 	}


### PR DESCRIPTION
## Summary
- add in-memory Mongo gateway cursor state for batched find results
- implement OP_MSG getMore and killCursors command responses
- extend driver coverage for batchSize-driven getMore behavior

## Validation
- GOWORK=off go test ./TreeDB/collections ./TreeDB/mongo_gateway/... -count=1