### PR TITLE
[codex] Add Mongo gateway benchmark harness

### DIFF
--- a/TreeDB/mongo_gateway/PLAN.md
+++ b/TreeDB/mongo_gateway/PLAN.md
@@ -273,6 +273,9 @@ Priority workloads:
   sort, skip, limit, and top-level projection.
 - Current cursor slice adds in-memory server cursor state for batched `find`,
   `getMore`, and `killCursors`.
+- Current benchmark slice adds `cmd/mongo_gateway_bench`, a reproducible
+  MongoDB-driver workload that can target either the TreeDB gateway or a MongoDB
+  server and report ops/sec, latency percentiles, and storage stats.
 
 Metrics to record for every run:
 
@@ -329,7 +332,7 @@ Metrics to record for every run:
 - [x] Implement `insert` and `_id` lookup against TreeDB collections.
 - [ ] Implement single-field index creation and indexed `find`.
 - [ ] Add protocol-level compatibility tests using a real MongoDB driver.
-- [ ] Add a reproducible MongoDB-vs-TreeDB benchmark harness.
+- [x] Add a reproducible MongoDB-vs-TreeDB benchmark harness.
 - [ ] Publish first benchmark report with disk usage and ops/sec.
 - [ ] Revisit scope after the first benchmark report and decide whether to
       expand compatibility or keep the gateway benchmark-only.

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -95,6 +95,7 @@ The initial workload phases are:
 Latency samples are per MongoDB driver call. Insert ops/sec is normalized by
 document count, while insert latency percentiles are per `InsertMany` call.
 Range-query samples include cursor materialization with `cursor.All`.
+Use `-timeout 0` to run without an overall benchmark deadline.
 
 ## Interpreting Results
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -1,0 +1,111 @@
+# Mongo Gateway Benchmark Harness
+
+`mongo_gateway_bench` runs the same MongoDB-driver workload against either the
+TreeDB Mongo gateway or a MongoDB server. It is intended to make the first
+Mongo-compatible product benchmarks reproducible, especially ops/sec and disk
+usage comparisons.
+
+## Build
+
+```sh
+GOWORK=off go build ./cmd/mongo_gateway_bench
+```
+
+## TreeDB Target
+
+```sh
+GOWORK=off go run ./cmd/mongo_gateway_bench \
+  -target treedb \
+  -treedb-dir /tmp/treedb-mongo-bench \
+  -keep-treedb-dir \
+  -documents 10000 \
+  -reads 10000 \
+  -range-reads 1000 \
+  -updates 1000 \
+  -secondary-indexes 2 \
+  -format json
+```
+
+For `-target treedb`, the command starts an in-process TreeDB Mongo gateway on a
+loopback listener, connects with the official MongoDB Go driver, and reports
+filesystem bytes for the TreeDB directory after load and after a final
+checkpoint.
+
+## MongoDB Target
+
+```sh
+GOWORK=off go run ./cmd/mongo_gateway_bench \
+  -target mongo \
+  -mongo-uri mongodb://127.0.0.1:27017 \
+  -documents 10000 \
+  -reads 10000 \
+  -range-reads 1000 \
+  -updates 1000 \
+  -secondary-indexes 2 \
+  -format json
+```
+
+For `-target mongo`, the command connects to the supplied URI, drops the
+benchmark database by default, and reports `dbStats` fields after load and at
+the end of the run.
+
+## Suggested Matrix
+
+Run both targets with the same values and keep the raw JSON outputs:
+
+```sh
+for docs in 1000 10000 100000; do
+  for indexes in 0 1 2; do
+    GOWORK=off go run ./cmd/mongo_gateway_bench \
+      -target treedb \
+      -treedb-dir "/tmp/treedb-mongo-${docs}-${indexes}" \
+      -keep-treedb-dir \
+      -documents "$docs" \
+      -reads "$docs" \
+      -range-reads "$((docs / 10))" \
+      -updates "$((docs / 10))" \
+      -secondary-indexes "$indexes" \
+      -format json > "treedb-${docs}-${indexes}.json"
+
+    GOWORK=off go run ./cmd/mongo_gateway_bench \
+      -target mongo \
+      -documents "$docs" \
+      -reads "$docs" \
+      -range-reads "$((docs / 10))" \
+      -updates "$((docs / 10))" \
+      -secondary-indexes "$indexes" \
+      -format json > "mongo-${docs}-${indexes}.json"
+  done
+done
+```
+
+The initial workload phases are:
+
+- `load_insert_many`: batched document inserts.
+- `id_find_one`: point lookup by `_id`.
+- `email_find_one`: point lookup by the `email` field.
+- `age_range_limit_10`: bounded range query with `limit: 10`.
+- `id_update_set`: `$set` update by `_id`.
+- `id_delete_one`: optional deletes; disabled unless `-deletes` is non-zero.
+
+Latency samples are per MongoDB driver call. Insert ops/sec is normalized by
+document count, while insert latency percentiles are per `InsertMany` call.
+
+## Interpreting Results
+
+`-secondary-indexes 2` creates `email_1` and `city_1`; the age range phase is
+currently a bounded scan in the gateway and is included to make that cost
+visible.
+
+For TreeDB, compare `treedb_disk_after_checkpoint.total_bytes` and the child
+path breakdown, especially `index.db`, `leaf_vlog`, and `value_vlog`.
+
+For MongoDB, compare `mongodb_stats_final.storageSize`,
+`mongodb_stats_final.indexSize`, and `mongodb_stats_final.totalSize`. If the
+MongoDB server is local, also capture a filesystem `du` of the database path for
+the final report.
+
+The benchmark intentionally keeps BSON format questions visible. If TreeDB load
+or read phases spend a meaningful amount of time re-encoding documents in future
+profiles, that is evidence for adding a native BSON collection document format
+beside JSON and template-v1.

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -31,7 +31,8 @@ loopback listener, connects with the official MongoDB Go driver, and reports
 the sum of regular file sizes for the TreeDB directory after load and after a
 final checkpoint. If `-treedb-dir` is provided and already exists, the harness
 removes and recreates it before loading deterministic fixtures so repeated runs
-are reproducible.
+are reproducible. Obvious unsafe reset targets such as root, the current
+checkout, the temp directory itself, or a home directory are rejected.
 
 ## MongoDB Target
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -32,7 +32,8 @@ the sum of regular file sizes for the TreeDB directory after load and after a
 final checkpoint. If `-treedb-dir` is provided and already exists, the harness
 removes and recreates it before loading deterministic fixtures so repeated runs
 are reproducible. Obvious unsafe reset targets such as root, the current
-checkout, the temp directory itself, or a home directory are rejected.
+checkout, the temp directory itself, a home directory, or an immediate child of
+a home directory are rejected.
 
 ## MongoDB Target
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -28,8 +28,10 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
 
 For `-target treedb`, the command starts an in-process TreeDB Mongo gateway on a
 loopback listener, connects with the official MongoDB Go driver, and reports
-filesystem bytes for the TreeDB directory after load and after a final
-checkpoint.
+the sum of regular file sizes for the TreeDB directory after load and after a
+final checkpoint. If `-treedb-dir` is provided and already exists, the harness
+removes and recreates it before loading deterministic fixtures so repeated runs
+are reproducible.
 
 ## MongoDB Target
 
@@ -84,12 +86,14 @@ The initial workload phases are:
 - `load_insert_many`: batched document inserts.
 - `id_find_one`: point lookup by `_id`.
 - `email_find_one`: point lookup by the `email` field.
-- `age_range_limit_10`: bounded range query with `limit: 10`.
+- `age_range_limit_10`: bounded range query with `limit: 10`; operations count
+  range queries, not returned documents.
 - `id_update_set`: `$set` update by `_id`.
 - `id_delete_one`: optional deletes; disabled unless `-deletes` is non-zero.
 
 Latency samples are per MongoDB driver call. Insert ops/sec is normalized by
 document count, while insert latency percentiles are per `InsertMany` call.
+Range-query samples include cursor materialization with `cursor.All`.
 
 ## Interpreting Results
 
@@ -98,7 +102,11 @@ currently a bounded scan in the gateway and is included to make that cost
 visible.
 
 For TreeDB, compare `treedb_disk_after_checkpoint.total_bytes` and the child
-path breakdown, especially `index.db`, `leaf_vlog`, and `value_vlog`.
+path breakdown, especially `index.db`, `leaf_vlog`, and `value_vlog`. These are
+logical bytes: the sum of regular file sizes, not allocated physical disk usage
+including block allocation, sparse-file effects, filesystem compression, or
+metadata. Capture `du` separately when physical on-disk usage is the comparison
+target.
 
 For MongoDB, compare `mongodb_stats_final.storageSize`,
 `mongodb_stats_final.indexSize`, and `mongodb_stats_final.totalSize`. If the

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -99,7 +99,10 @@ func run(parent context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(parent, cfg.Timeout)
+	ctx, cancel := context.WithCancel(parent)
+	if cfg.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(parent, cfg.Timeout)
+	}
 	defer cancel()
 
 	target, err := openTarget(ctx, cfg)
@@ -152,6 +155,9 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 {
 		return config{}, errors.New("operation counts cannot be negative")
+	}
+	if cfg.Timeout < 0 {
+		return config{}, errors.New("timeout cannot be negative")
 	}
 	if cfg.SecondaryIndexes < 0 || cfg.SecondaryIndexes > 2 {
 		return config{}, errors.New("secondary-indexes must be 0, 1, or 2")

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -144,7 +144,7 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.RangeReads, "range-reads", 100, "range reads with limit")
 	fs.IntVar(&cfg.Updates, "updates", 100, "$set updates by _id")
 	fs.IntVar(&cfg.Deletes, "deletes", 0, "deleteOne operations by _id")
-	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=email+city")
+	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=both single-field indexes: email and city")
 	fs.DurationVar(&cfg.Timeout, "timeout", 10*time.Minute, "overall benchmark timeout")
 	fs.StringVar(&cfg.Format, "format", "text", "output format: text or json")
 	if err := fs.Parse(args); err != nil {
@@ -308,8 +308,11 @@ func validateResettableTreeDBDir(dir string) (string, error) {
 	if home, err := os.UserHomeDir(); err == nil && (abs == home || filepath.Dir(abs) == home) {
 		return "", fmt.Errorf("unsafe treedb-dir %q", dir)
 	}
-	if cwd, err := os.Getwd(); err == nil && abs == cwd {
-		return "", fmt.Errorf("unsafe treedb-dir %q", dir)
+	if cwd, err := os.Getwd(); err == nil {
+		cwdAbs, err := filepath.Abs(cwd)
+		if err == nil && (abs == cwdAbs || isPathDescendant(cwdAbs, abs)) {
+			return "", fmt.Errorf("unsafe treedb-dir %q", dir)
+		}
 	}
 	if tmp := os.TempDir(); tmp != "" {
 		if tmpAbs, err := filepath.Abs(tmp); err == nil && abs == tmpAbs {
@@ -320,6 +323,14 @@ func validateResettableTreeDBDir(dir string) (string, error) {
 		return "", err
 	}
 	return abs, nil
+}
+
+func isPathDescendant(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil || rel == "." || rel == ".." {
+		return false
+	}
+	return !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
 func rejectSymlinkedPath(path string) error {
@@ -557,25 +568,27 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	}
 	result.Phases = append(result.Phases, updatePhase)
 
-	deletePhase, err := measurePhase("id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
-		for i := 0; i < cfg.Deletes; i++ {
-			id := benchmarkID(cfg.Documents - 1 - i)
-			begin := time.Now()
-			res, err := coll.DeleteOne(ctx, bson.D{{Key: "_id", Value: id}})
-			sample(time.Since(begin))
-			if err != nil {
-				return err
+	if cfg.Deletes > 0 {
+		deletePhase, err := measurePhase("id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
+			for i := 0; i < cfg.Deletes; i++ {
+				id := benchmarkID(cfg.Documents - 1 - i)
+				begin := time.Now()
+				res, err := coll.DeleteOne(ctx, bson.D{{Key: "_id", Value: id}})
+				sample(time.Since(begin))
+				if err != nil {
+					return err
+				}
+				if res.DeletedCount != 1 {
+					return fmt.Errorf("delete deleted=%d want 1", res.DeletedCount)
+				}
 			}
-			if res.DeletedCount != 1 {
-				return fmt.Errorf("delete deleted=%d want 1", res.DeletedCount)
-			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
+		result.Phases = append(result.Phases, deletePhase)
 	}
-	result.Phases = append(result.Phases, deletePhase)
 
 	if err := collectFinalStats(ctx, cfg, target, result); err != nil {
 		return nil, err

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"math"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -106,7 +107,9 @@ func run(parent context.Context, args []string) error {
 		return err
 	}
 	defer func() {
-		_ = target.cleanup(context.Background())
+		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancelCleanup()
+		_ = target.cleanup(cleanupCtx)
 	}()
 
 	result, err := runBenchmark(ctx, cfg, target)
@@ -184,10 +187,7 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 		dir = tmp
 		removeDir = !cfg.KeepTreeDBDir
 	} else {
-		if err := os.RemoveAll(dir); err != nil {
-			return nil, err
-		}
-		if err := os.MkdirAll(dir, 0o700); err != nil {
+		if err := resetTreeDBDir(dir); err != nil {
 			return nil, err
 		}
 	}
@@ -249,8 +249,8 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 		select {
 		case err := <-serveErr:
 			errs = append(errs, err)
-		case <-time.After(time.Second):
-			errs = append(errs, errors.New("timed out waiting for gateway serve loop"))
+		case <-cleanupCtx.Done():
+			errs = append(errs, cleanupCtx.Err())
 		}
 		errs = append(errs, manager.FlushAll())
 		errs = append(errs, db.Close())
@@ -260,6 +260,44 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 		return errors.Join(errs...)
 	}
 	return &benchTarget{client: client, db: db, collections: manager, treedbDir: dir, cleanup: cleanup}, nil
+}
+
+func resetTreeDBDir(dir string) error {
+	abs, err := validateResettableTreeDBDir(dir)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(abs); err != nil {
+		return err
+	}
+	return os.MkdirAll(abs, 0o700)
+}
+
+func validateResettableTreeDBDir(dir string) (string, error) {
+	clean := filepath.Clean(strings.TrimSpace(dir))
+	if clean == "" || clean == "." || clean == ".." {
+		return "", fmt.Errorf("unsafe treedb-dir %q", dir)
+	}
+	abs, err := filepath.Abs(clean)
+	if err != nil {
+		return "", err
+	}
+	root := string(os.PathSeparator)
+	if abs == root || filepath.Dir(abs) == root {
+		return "", fmt.Errorf("unsafe treedb-dir %q", dir)
+	}
+	if home, err := os.UserHomeDir(); err == nil && (abs == home || filepath.Dir(abs) == home) {
+		return "", fmt.Errorf("unsafe treedb-dir %q", dir)
+	}
+	if cwd, err := os.Getwd(); err == nil && abs == cwd {
+		return "", fmt.Errorf("unsafe treedb-dir %q", dir)
+	}
+	if tmp := os.TempDir(); tmp != "" {
+		if tmpAbs, err := filepath.Abs(tmp); err == nil && abs == tmpAbs {
+			return "", fmt.Errorf("unsafe treedb-dir %q", dir)
+		}
+	}
+	return abs, nil
 }
 
 func openMongoTarget(ctx context.Context, cfg config) (*benchTarget, error) {
@@ -285,6 +323,20 @@ func openMongoTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 			return client.Disconnect(cleanupCtx)
 		},
 	}, nil
+}
+
+func redactMongoURI(rawURI string) string {
+	parsed, err := url.Parse(rawURI)
+	if err != nil || parsed.User == nil {
+		return rawURI
+	}
+	username := parsed.User.Username()
+	if username == "" {
+		parsed.User = nil
+	} else {
+		parsed.User = url.User(username)
+	}
+	return parsed.String()
 }
 
 func serveLoop(ctx context.Context, ln net.Listener, server *mongogateway.Server, serveErr chan<- error) {
@@ -317,7 +369,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	if cfg.Target == "treedb" {
 		result.TreeDBDir = target.treedbDir
 	} else {
-		result.MongoURI = cfg.MongoURI
+		result.MongoURI = redactMongoURI(cfg.MongoURI)
 	}
 
 	if err := createIndexes(ctx, coll, cfg.SecondaryIndexes); err != nil {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -130,6 +130,7 @@ func run(parent context.Context, args []string) error {
 func parseConfig(args []string) (config, error) {
 	cfg := config{}
 	fs := flag.NewFlagSet("mongo_gateway_bench", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
 	fs.StringVar(&cfg.Target, "target", "treedb", "benchmark target: treedb or mongo")
 	fs.StringVar(&cfg.MongoURI, "mongo-uri", "mongodb://127.0.0.1:27017", "MongoDB URI for -target mongo")
 	fs.StringVar(&cfg.TreeDBDir, "treedb-dir", "", "TreeDB directory for -target treedb; empty uses a temp dir")
@@ -315,7 +316,42 @@ func validateResettableTreeDBDir(dir string) (string, error) {
 			return "", fmt.Errorf("unsafe treedb-dir %q", dir)
 		}
 	}
+	if err := rejectSymlinkedPath(abs); err != nil {
+		return "", err
+	}
 	return abs, nil
+}
+
+func rejectSymlinkedPath(path string) error {
+	clean := filepath.Clean(path)
+	volume := filepath.VolumeName(clean)
+	rest := strings.TrimPrefix(clean, volume)
+	current := volume
+	if strings.HasPrefix(rest, string(os.PathSeparator)) {
+		current += string(os.PathSeparator)
+		rest = strings.TrimPrefix(rest, string(os.PathSeparator))
+	}
+	for _, part := range strings.Split(rest, string(os.PathSeparator)) {
+		if part == "" {
+			continue
+		}
+		if current == "" || strings.HasSuffix(current, string(os.PathSeparator)) {
+			current += part
+		} else {
+			current = filepath.Join(current, part)
+		}
+		info, err := os.Lstat(current)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("unsafe treedb-dir %q resolves through symlink %q", path, current)
+		}
+	}
+	return nil
 }
 
 func openMongoTarget(ctx context.Context, cfg config) (*benchTarget, error) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -99,9 +99,14 @@ func run(parent context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	ctx, cancel := context.WithCancel(parent)
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
 	if cfg.Timeout > 0 {
 		ctx, cancel = context.WithTimeout(parent, cfg.Timeout)
+	} else {
+		ctx, cancel = context.WithCancel(parent)
 	}
 	defer cancel()
 
@@ -288,8 +293,15 @@ func validateResettableTreeDBDir(dir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	parent := filepath.Dir(abs)
+	if parent == abs {
+		return "", fmt.Errorf("unsafe treedb-dir %q", dir)
+	}
 	root := string(os.PathSeparator)
-	if abs == root || filepath.Dir(abs) == root {
+	if volume := filepath.VolumeName(abs); volume != "" {
+		root = filepath.Clean(volume + string(os.PathSeparator))
+	}
+	if abs == root || parent == root {
 		return "", fmt.Errorf("unsafe treedb-dir %q", dir)
 	}
 	if home, err := os.UserHomeDir(); err == nil && (abs == home || filepath.Dir(abs) == home) {
@@ -708,7 +720,7 @@ func percentile(sorted []time.Duration, q float64) time.Duration {
 }
 
 func collectDiskSnapshot(dir string) (diskSnapshot, error) {
-	out := diskSnapshot{Paths: make(map[string]int64)}
+	out := diskSnapshot{}
 	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -727,6 +739,9 @@ func collectDiskSnapshot(dir string) (diskSnapshot, error) {
 			return err
 		}
 		topLevel, _, _ := strings.Cut(rel, string(os.PathSeparator))
+		if out.Paths == nil {
+			out.Paths = make(map[string]int64)
+		}
 		out.Paths[topLevel] += size
 		return nil
 	})
@@ -744,6 +759,9 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 			result.Target, result.Database, result.Collection, result.Documents, result.SecondaryIndexes)
 		if result.TreeDBDir != "" {
 			fmt.Fprintf(out, "treedb_dir=%s\n", result.TreeDBDir)
+		}
+		if result.MongoURI != "" {
+			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)
 		}
 		for _, phase := range result.Phases {
 			fmt.Fprintf(out, "%-22s ops=%d calls=%d duration_ms=%.1f ops_sec=%.1f p50_us=%.0f p95_us=%.0f p99_us=%.0f\n",

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -130,7 +131,8 @@ func run(parent context.Context, args []string) error {
 func parseConfig(args []string) (config, error) {
 	cfg := config{}
 	fs := flag.NewFlagSet("mongo_gateway_bench", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
+	var flagOutput bytes.Buffer
+	fs.SetOutput(&flagOutput)
 	fs.StringVar(&cfg.Target, "target", "treedb", "benchmark target: treedb or mongo")
 	fs.StringVar(&cfg.MongoURI, "mongo-uri", "mongodb://127.0.0.1:27017", "MongoDB URI for -target mongo")
 	fs.StringVar(&cfg.TreeDBDir, "treedb-dir", "", "TreeDB directory for -target treedb; empty uses a temp dir")
@@ -148,6 +150,9 @@ func parseConfig(args []string) (config, error) {
 	fs.DurationVar(&cfg.Timeout, "timeout", 10*time.Minute, "overall benchmark timeout")
 	fs.StringVar(&cfg.Format, "format", "text", "output format: text or json")
 	if err := fs.Parse(args); err != nil {
+		if output := strings.TrimSpace(flagOutput.String()); output != "" {
+			return config{}, fmt.Errorf("%w\n%s", err, output)
+		}
 		return config{}, err
 	}
 	if cfg.Target != "treedb" && cfg.Target != "mongo" {
@@ -309,9 +314,10 @@ func validateResettableTreeDBDir(dir string) (string, error) {
 		return "", fmt.Errorf("unsafe treedb-dir %q", dir)
 	}
 	if cwd, err := os.Getwd(); err == nil {
-		cwdAbs, err := filepath.Abs(cwd)
-		if err == nil && (abs == cwdAbs || isPathDescendant(cwdAbs, abs)) {
-			return "", fmt.Errorf("unsafe treedb-dir %q", dir)
+		for _, root := range checkoutPathCandidates(cwd) {
+			if abs == root || isPathDescendant(root, abs) {
+				return "", fmt.Errorf("unsafe treedb-dir %q", dir)
+			}
 		}
 	}
 	if tmp := os.TempDir(); tmp != "" {
@@ -325,7 +331,24 @@ func validateResettableTreeDBDir(dir string) (string, error) {
 	return abs, nil
 }
 
+func checkoutPathCandidates(cwd string) []string {
+	cwdAbs, err := filepath.Abs(cwd)
+	if err != nil {
+		return nil
+	}
+	candidates := []string{filepath.Clean(cwdAbs)}
+	if realCWD, err := filepath.EvalSymlinks(cwdAbs); err == nil {
+		realCWD = filepath.Clean(realCWD)
+		if realCWD != candidates[0] {
+			candidates = append(candidates, realCWD)
+		}
+	}
+	return candidates
+}
+
 func isPathDescendant(parent, child string) bool {
+	parent = filepath.Clean(parent)
+	child = filepath.Clean(child)
 	rel, err := filepath.Rel(parent, child)
 	if err != nil || rel == "." || rel == ".." {
 		return false
@@ -420,9 +443,9 @@ func serveLoop(ctx context.Context, ln net.Listener, server *mongogateway.Server
 			serveErr <- err
 			return
 		}
-		go func() {
+		go func(conn net.Conn) {
 			_ = server.ServeConn(ctx, conn)
-		}()
+		}(conn)
 	}
 }
 
@@ -437,7 +460,9 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 		SecondaryIndexes: cfg.SecondaryIndexes,
 	}
 	if cfg.Target == "treedb" {
-		result.TreeDBDir = target.treedbDir
+		if cfg.TreeDBDir != "" || cfg.KeepTreeDBDir {
+			result.TreeDBDir = target.treedbDir
+		}
 	} else {
 		result.MongoURI = redactMongoURI(cfg.MongoURI)
 	}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	"math"
 	"net"
@@ -182,6 +183,13 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 		}
 		dir = tmp
 		removeDir = !cfg.KeepTreeDBDir
+	} else {
+		if err := os.RemoveAll(dir); err != nil {
+			return nil, err
+		}
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, err
+		}
 	}
 
 	db, err := backenddb.Open(backenddb.Options{Dir: dir})
@@ -384,21 +392,23 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	}
 	result.Phases = append(result.Phases, emailPhase)
 
-	rangePhase, err := measurePhase("age_range_limit_10", cfg.RangeReads*10, func(sample func(time.Duration)) error {
+	rangePhase, err := measurePhase("age_range_limit_10", cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
 			minAge := int64(20 + (i % 40))
 			begin := time.Now()
 			cursor, err := coll.Find(ctx,
 				bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: minAge}}}},
 				options.Find().SetLimit(10))
-			sample(time.Since(begin))
 			if err != nil {
+				sample(time.Since(begin))
 				return err
 			}
 			var docs []bson.M
 			if err := cursor.All(ctx, &docs); err != nil {
+				sample(time.Since(begin))
 				return err
 			}
+			sample(time.Since(begin))
 			for _, doc := range docs {
 				age, ok := int64Value(doc["age"])
 				if !ok || age < minAge {
@@ -640,44 +650,32 @@ func percentile(sorted []time.Duration, q float64) time.Duration {
 }
 
 func collectDiskSnapshot(dir string) (diskSnapshot, error) {
-	total, err := pathSize(dir)
-	if err != nil {
-		return diskSnapshot{}, err
-	}
-	out := diskSnapshot{TotalBytes: total, Paths: make(map[string]int64)}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return diskSnapshot{}, err
-	}
-	for _, entry := range entries {
-		size, err := pathSize(filepath.Join(dir, entry.Name()))
-		if err != nil {
-			return diskSnapshot{}, err
-		}
-		out.Paths[entry.Name()] = size
-	}
-	return out, nil
-}
-
-func pathSize(path string) (int64, error) {
-	var total int64
-	err := filepath.WalkDir(path, func(_ string, entry fs.DirEntry, err error) error {
+	out := diskSnapshot{Paths: make(map[string]int64)}
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if entry.Type().IsRegular() {
-			info, err := entry.Info()
-			if err != nil {
-				return err
-			}
-			total += info.Size()
+		if !entry.Type().IsRegular() {
+			return nil
 		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		size := info.Size()
+		out.TotalBytes += size
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		topLevel, _, _ := strings.Cut(rel, string(os.PathSeparator))
+		out.Paths[topLevel] += size
 		return nil
 	})
-	return total, err
+	return out, err
 }
 
-func writeResult(out *os.File, format string, result *benchmarkResult) error {
+func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 	switch format {
 	case "json":
 		encoder := json.NewEncoder(out)
@@ -712,7 +710,7 @@ func writeResult(out *os.File, format string, result *benchmarkResult) error {
 	}
 }
 
-func writeDiskSnapshot(out *os.File, label string, snapshot *diskSnapshot) {
+func writeDiskSnapshot(out io.Writer, label string, snapshot *diskSnapshot) {
 	fmt.Fprintf(out, "%s total_bytes=%d", label, snapshot.TotalBytes)
 	names := make([]string, 0, len(snapshot.Paths))
 	for name := range snapshot.Paths {
@@ -725,7 +723,7 @@ func writeDiskSnapshot(out *os.File, label string, snapshot *diskSnapshot) {
 	fmt.Fprintln(out)
 }
 
-func writeMongoStats(out *os.File, label string, stats map[string]any) {
+func writeMongoStats(out io.Writer, label string, stats map[string]any) {
 	keys := []string{"dataSize", "storageSize", "indexSize", "totalSize", "objects"}
 	fmt.Fprint(out, label)
 	for _, key := range keys {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1,0 +1,737 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"math"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	mongogateway "github.com/snissn/gomap/TreeDB/mongo_gateway"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+type config struct {
+	Target           string
+	MongoURI         string
+	TreeDBDir        string
+	KeepTreeDBDir    bool
+	DropBeforeRun    bool
+	Database         string
+	Collection       string
+	Documents        int
+	BatchSize        int
+	Reads            int
+	RangeReads       int
+	Updates          int
+	Deletes          int
+	SecondaryIndexes int
+	Timeout          time.Duration
+	Format           string
+}
+
+type benchmarkResult struct {
+	Target                    string         `json:"target"`
+	MongoURI                  string         `json:"mongo_uri,omitempty"`
+	TreeDBDir                 string         `json:"treedb_dir,omitempty"`
+	Database                  string         `json:"database"`
+	Collection                string         `json:"collection"`
+	Documents                 int            `json:"documents"`
+	SecondaryIndexes          int            `json:"secondary_indexes"`
+	Phases                    []phaseResult  `json:"phases"`
+	TreeDBDiskAfterLoad       *diskSnapshot  `json:"treedb_disk_after_load,omitempty"`
+	TreeDBDiskAfterCheckpoint *diskSnapshot  `json:"treedb_disk_after_checkpoint,omitempty"`
+	MongoDBStatsAfterLoad     map[string]any `json:"mongodb_stats_after_load,omitempty"`
+	MongoDBStatsFinal         map[string]any `json:"mongodb_stats_final,omitempty"`
+}
+
+type phaseResult struct {
+	Name           string         `json:"name"`
+	Operations     int            `json:"operations"`
+	DriverCalls    int            `json:"driver_calls"`
+	DurationMillis float64        `json:"duration_ms"`
+	OpsPerSecond   float64        `json:"ops_per_sec"`
+	LatencyMicros  latencySummary `json:"latency_micros"`
+}
+
+type latencySummary struct {
+	P50 float64 `json:"p50"`
+	P95 float64 `json:"p95"`
+	P99 float64 `json:"p99"`
+}
+
+type diskSnapshot struct {
+	TotalBytes int64            `json:"total_bytes"`
+	Paths      map[string]int64 `json:"paths,omitempty"`
+}
+
+type benchTarget struct {
+	client      *mongo.Client
+	db          *backenddb.DB
+	collections *collections.CollectionManager
+	treedbDir   string
+	cleanup     func(context.Context) error
+}
+
+func main() {
+	if err := run(context.Background(), os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "mongo_gateway_bench: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(parent context.Context, args []string) error {
+	cfg, err := parseConfig(args)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(parent, cfg.Timeout)
+	defer cancel()
+
+	target, err := openTarget(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = target.cleanup(context.Background())
+	}()
+
+	result, err := runBenchmark(ctx, cfg, target)
+	if err != nil {
+		return err
+	}
+	return writeResult(os.Stdout, cfg.Format, result)
+}
+
+func parseConfig(args []string) (config, error) {
+	cfg := config{}
+	fs := flag.NewFlagSet("mongo_gateway_bench", flag.ContinueOnError)
+	fs.StringVar(&cfg.Target, "target", "treedb", "benchmark target: treedb or mongo")
+	fs.StringVar(&cfg.MongoURI, "mongo-uri", "mongodb://127.0.0.1:27017", "MongoDB URI for -target mongo")
+	fs.StringVar(&cfg.TreeDBDir, "treedb-dir", "", "TreeDB directory for -target treedb; empty uses a temp dir")
+	fs.BoolVar(&cfg.KeepTreeDBDir, "keep-treedb-dir", false, "keep an auto-created TreeDB temp dir after the run")
+	fs.BoolVar(&cfg.DropBeforeRun, "drop-before-run", true, "drop the MongoDB database before running -target mongo")
+	fs.StringVar(&cfg.Database, "database", "mongo_gateway_bench", "database name")
+	fs.StringVar(&cfg.Collection, "collection", "docs", "collection name")
+	fs.IntVar(&cfg.Documents, "documents", 1000, "documents to insert")
+	fs.IntVar(&cfg.BatchSize, "batch-size", 500, "InsertMany batch size")
+	fs.IntVar(&cfg.Reads, "reads", 1000, "point reads by _id and by email")
+	fs.IntVar(&cfg.RangeReads, "range-reads", 100, "range reads with limit")
+	fs.IntVar(&cfg.Updates, "updates", 100, "$set updates by _id")
+	fs.IntVar(&cfg.Deletes, "deletes", 0, "deleteOne operations by _id")
+	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=email+city")
+	fs.DurationVar(&cfg.Timeout, "timeout", 10*time.Minute, "overall benchmark timeout")
+	fs.StringVar(&cfg.Format, "format", "text", "output format: text or json")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	if cfg.Target != "treedb" && cfg.Target != "mongo" {
+		return config{}, fmt.Errorf("unknown target %q", cfg.Target)
+	}
+	if cfg.Documents <= 0 {
+		return config{}, errors.New("documents must be > 0")
+	}
+	if cfg.BatchSize <= 0 {
+		return config{}, errors.New("batch-size must be > 0")
+	}
+	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 {
+		return config{}, errors.New("operation counts cannot be negative")
+	}
+	if cfg.SecondaryIndexes < 0 || cfg.SecondaryIndexes > 2 {
+		return config{}, errors.New("secondary-indexes must be 0, 1, or 2")
+	}
+	if cfg.Format != "text" && cfg.Format != "json" {
+		return config{}, fmt.Errorf("unknown format %q", cfg.Format)
+	}
+	if cfg.Deletes > cfg.Documents {
+		return config{}, errors.New("deletes cannot exceed documents")
+	}
+	return cfg, nil
+}
+
+func openTarget(ctx context.Context, cfg config) (*benchTarget, error) {
+	switch cfg.Target {
+	case "treedb":
+		return openTreeDBTarget(ctx, cfg)
+	case "mongo":
+		return openMongoTarget(ctx, cfg)
+	default:
+		return nil, fmt.Errorf("unknown target %q", cfg.Target)
+	}
+}
+
+func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
+	dir := cfg.TreeDBDir
+	removeDir := false
+	if dir == "" {
+		tmp, err := os.MkdirTemp("", "mongo-gateway-bench-*")
+		if err != nil {
+			return nil, err
+		}
+		dir = tmp
+		removeDir = !cfg.KeepTreeDBDir
+	}
+
+	db, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+	manager := collections.NewCollectionManager(db)
+	server := mongogateway.NewServer()
+	server.Collections = manager
+	server.MaxFindScanDocuments = cfg.Documents
+
+	serveCtx, cancelServe := context.WithCancel(ctx)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		cancelServe()
+		_ = db.Close()
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+	serveErr := make(chan error, 1)
+	go serveLoop(serveCtx, ln, server, serveErr)
+
+	client, err := mongo.Connect(options.Client().
+		ApplyURI("mongodb://" + ln.Addr().String()).
+		SetDirect(true).
+		SetServerSelectionTimeout(5 * time.Second))
+	if err != nil {
+		cancelServe()
+		_ = ln.Close()
+		_ = db.Close()
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+	if err := client.Ping(ctx, nil); err != nil {
+		_ = client.Disconnect(context.Background())
+		cancelServe()
+		_ = ln.Close()
+		_ = db.Close()
+		if removeDir {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+
+	cleanup := func(cleanupCtx context.Context) error {
+		var errs []error
+		errs = append(errs, client.Disconnect(cleanupCtx))
+		cancelServe()
+		errs = append(errs, ln.Close())
+		select {
+		case err := <-serveErr:
+			errs = append(errs, err)
+		case <-time.After(time.Second):
+			errs = append(errs, errors.New("timed out waiting for gateway serve loop"))
+		}
+		errs = append(errs, manager.FlushAll())
+		errs = append(errs, db.Close())
+		if removeDir {
+			errs = append(errs, os.RemoveAll(dir))
+		}
+		return errors.Join(errs...)
+	}
+	return &benchTarget{client: client, db: db, collections: manager, treedbDir: dir, cleanup: cleanup}, nil
+}
+
+func openMongoTarget(ctx context.Context, cfg config) (*benchTarget, error) {
+	client, err := mongo.Connect(options.Client().
+		ApplyURI(cfg.MongoURI).
+		SetServerSelectionTimeout(5 * time.Second))
+	if err != nil {
+		return nil, err
+	}
+	if err := client.Ping(ctx, nil); err != nil {
+		_ = client.Disconnect(context.Background())
+		return nil, err
+	}
+	if cfg.DropBeforeRun {
+		if err := client.Database(cfg.Database).Drop(ctx); err != nil {
+			_ = client.Disconnect(context.Background())
+			return nil, err
+		}
+	}
+	return &benchTarget{
+		client: client,
+		cleanup: func(cleanupCtx context.Context) error {
+			return client.Disconnect(cleanupCtx)
+		},
+	}, nil
+}
+
+func serveLoop(ctx context.Context, ln net.Listener, server *mongogateway.Server, serveErr chan<- error) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
+				serveErr <- nil
+				return
+			}
+			serveErr <- err
+			return
+		}
+		go func() {
+			_ = server.ServeConn(ctx, conn)
+		}()
+	}
+}
+
+func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchmarkResult, error) {
+	db := target.client.Database(cfg.Database)
+	coll := db.Collection(cfg.Collection)
+	result := &benchmarkResult{
+		Target:           cfg.Target,
+		Database:         cfg.Database,
+		Collection:       cfg.Collection,
+		Documents:        cfg.Documents,
+		SecondaryIndexes: cfg.SecondaryIndexes,
+	}
+	if cfg.Target == "treedb" {
+		result.TreeDBDir = target.treedbDir
+	} else {
+		result.MongoURI = cfg.MongoURI
+	}
+
+	if err := createIndexes(ctx, coll, cfg.SecondaryIndexes); err != nil {
+		return nil, err
+	}
+	loadPhase, err := measurePhase("load_insert_many", cfg.Documents, func(sample func(time.Duration)) error {
+		for start := 0; start < cfg.Documents; start += cfg.BatchSize {
+			end := start + cfg.BatchSize
+			if end > cfg.Documents {
+				end = cfg.Documents
+			}
+			docs := make([]any, 0, end-start)
+			for i := start; i < end; i++ {
+				docs = append(docs, benchmarkDocument(i))
+			}
+			begin := time.Now()
+			_, err := coll.InsertMany(ctx, docs)
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, loadPhase)
+	if err := collectAfterLoadStats(ctx, cfg, target, result); err != nil {
+		return nil, err
+	}
+
+	idPhase, err := measurePhase("id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Reads; i++ {
+			id := benchmarkID(i % cfg.Documents)
+			var out bson.M
+			begin := time.Now()
+			err := coll.FindOne(ctx, bson.D{{Key: "_id", Value: id}}).Decode(&out)
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+			if out["_id"] != id {
+				return fmt.Errorf("id lookup returned _id=%v want %s", out["_id"], id)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, idPhase)
+
+	emailPhase, err := measurePhase("email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Reads; i++ {
+			email := benchmarkEmail((i * 17) % cfg.Documents)
+			var out bson.M
+			begin := time.Now()
+			err := coll.FindOne(ctx, bson.D{{Key: "email", Value: email}}).Decode(&out)
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+			if out["email"] != email {
+				return fmt.Errorf("email lookup returned email=%v want %s", out["email"], email)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, emailPhase)
+
+	rangePhase, err := measurePhase("age_range_limit_10", cfg.RangeReads*10, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.RangeReads; i++ {
+			minAge := int64(20 + (i % 40))
+			begin := time.Now()
+			cursor, err := coll.Find(ctx,
+				bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: minAge}}}},
+				options.Find().SetLimit(10))
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+			var docs []bson.M
+			if err := cursor.All(ctx, &docs); err != nil {
+				return err
+			}
+			for _, doc := range docs {
+				age, ok := int64Value(doc["age"])
+				if !ok || age < minAge {
+					return fmt.Errorf("range returned age=%v below %d", doc["age"], minAge)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, rangePhase)
+
+	updatePhase, err := measurePhase("id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Updates; i++ {
+			id := benchmarkID((i * 31) % cfg.Documents)
+			begin := time.Now()
+			res, err := coll.UpdateOne(ctx,
+				bson.D{{Key: "_id", Value: id}},
+				bson.D{{Key: "$set", Value: bson.D{{Key: "updated", Value: true}, {Key: "update_seq", Value: int64(i)}}}},
+			)
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+			if res.MatchedCount != 1 {
+				return fmt.Errorf("update matched=%d want 1", res.MatchedCount)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, updatePhase)
+
+	deletePhase, err := measurePhase("id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
+		for i := 0; i < cfg.Deletes; i++ {
+			id := benchmarkID(cfg.Documents - 1 - i)
+			begin := time.Now()
+			res, err := coll.DeleteOne(ctx, bson.D{{Key: "_id", Value: id}})
+			sample(time.Since(begin))
+			if err != nil {
+				return err
+			}
+			if res.DeletedCount != 1 {
+				return fmt.Errorf("delete deleted=%d want 1", res.DeletedCount)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Phases = append(result.Phases, deletePhase)
+
+	if err := collectFinalStats(ctx, cfg, target, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func createIndexes(ctx context.Context, coll *mongo.Collection, secondaryIndexes int) error {
+	if secondaryIndexes >= 1 {
+		if _, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
+			Keys:    bson.D{{Key: "email", Value: int32(1)}},
+			Options: options.Index().SetName("email_1").SetUnique(true),
+		}); err != nil {
+			return err
+		}
+	}
+	if secondaryIndexes >= 2 {
+		if _, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
+			Keys:    bson.D{{Key: "city", Value: int32(1)}},
+			Options: options.Index().SetName("city_1"),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func collectAfterLoadStats(ctx context.Context, cfg config, target *benchTarget, result *benchmarkResult) error {
+	if cfg.Target == "treedb" {
+		if target.collections != nil {
+			if err := target.collections.FlushAll(); err != nil {
+				return err
+			}
+		}
+		snapshot, err := collectDiskSnapshot(target.treedbDir)
+		if err != nil {
+			return err
+		}
+		result.TreeDBDiskAfterLoad = &snapshot
+		return nil
+	}
+	stats, err := mongoDBStats(ctx, target.client.Database(cfg.Database))
+	if err != nil {
+		return err
+	}
+	result.MongoDBStatsAfterLoad = stats
+	return nil
+}
+
+func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, result *benchmarkResult) error {
+	if cfg.Target == "treedb" {
+		if target.collections != nil {
+			if err := target.collections.FlushAll(); err != nil {
+				return err
+			}
+		}
+		if target.db != nil {
+			if err := target.db.Checkpoint(); err != nil {
+				return err
+			}
+		}
+		snapshot, err := collectDiskSnapshot(target.treedbDir)
+		if err != nil {
+			return err
+		}
+		result.TreeDBDiskAfterCheckpoint = &snapshot
+		return nil
+	}
+	stats, err := mongoDBStats(ctx, target.client.Database(cfg.Database))
+	if err != nil {
+		return err
+	}
+	result.MongoDBStatsFinal = stats
+	return nil
+}
+
+func mongoDBStats(ctx context.Context, db *mongo.Database) (map[string]any, error) {
+	var out bson.M
+	if err := db.RunCommand(ctx, bson.D{{Key: "dbStats", Value: 1}, {Key: "scale", Value: 1}}).Decode(&out); err != nil {
+		return nil, err
+	}
+	stats := make(map[string]any, len(out))
+	for key, value := range out {
+		stats[key] = value
+	}
+	return stats, nil
+}
+
+func benchmarkDocument(i int) bson.D {
+	city := benchmarkCity(i)
+	return bson.D{
+		{Key: "_id", Value: benchmarkID(i)},
+		{Key: "email", Value: benchmarkEmail(i)},
+		{Key: "city", Value: city},
+		{Key: "age", Value: int64(18 + (i % 67))},
+		{Key: "active", Value: i%2 == 0},
+		{Key: "score", Value: float64(i%1000) / 10.0},
+		{Key: "tags", Value: bson.A{city, fmt.Sprintf("bucket-%02d", i%32)}},
+		{Key: "profile", Value: bson.D{
+			{Key: "rank", Value: int32(i % 1000)},
+			{Key: "bio", Value: strings.Repeat("x", 96)},
+		}},
+	}
+}
+
+func benchmarkID(i int) string {
+	return fmt.Sprintf("doc-%012d", i)
+}
+
+func benchmarkEmail(i int) string {
+	return fmt.Sprintf("user%012d@example.test", i)
+}
+
+func benchmarkCity(i int) string {
+	cities := [...]string{"hnl", "sfo", "nyc", "lon", "sin", "ber", "tyo", "syd"}
+	return cities[i%len(cities)]
+}
+
+func int64Value(value any) (int64, bool) {
+	switch v := value.(type) {
+	case int32:
+		return int64(v), true
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func measurePhase(name string, operations int, run func(sample func(time.Duration)) error) (phaseResult, error) {
+	samples := make([]time.Duration, 0)
+	start := time.Now()
+	err := run(func(sample time.Duration) {
+		samples = append(samples, sample)
+	})
+	duration := time.Since(start)
+	return summarizePhase(name, operations, len(samples), duration, samples), err
+}
+
+func summarizePhase(name string, operations, driverCalls int, duration time.Duration, samples []time.Duration) phaseResult {
+	result := phaseResult{
+		Name:           name,
+		Operations:     operations,
+		DriverCalls:    driverCalls,
+		DurationMillis: float64(duration.Microseconds()) / 1000.0,
+		LatencyMicros:  summarizeLatency(samples),
+	}
+	if duration > 0 {
+		result.OpsPerSecond = float64(operations) / duration.Seconds()
+	}
+	return result
+}
+
+func summarizeLatency(samples []time.Duration) latencySummary {
+	if len(samples) == 0 {
+		return latencySummary{}
+	}
+	sorted := append([]time.Duration(nil), samples...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i] < sorted[j]
+	})
+	return latencySummary{
+		P50: float64(percentile(sorted, 0.50).Microseconds()),
+		P95: float64(percentile(sorted, 0.95).Microseconds()),
+		P99: float64(percentile(sorted, 0.99).Microseconds()),
+	}
+}
+
+func percentile(sorted []time.Duration, q float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	index := int(math.Ceil(q*float64(len(sorted)))) - 1
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(sorted) {
+		index = len(sorted) - 1
+	}
+	return sorted[index]
+}
+
+func collectDiskSnapshot(dir string) (diskSnapshot, error) {
+	total, err := pathSize(dir)
+	if err != nil {
+		return diskSnapshot{}, err
+	}
+	out := diskSnapshot{TotalBytes: total, Paths: make(map[string]int64)}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return diskSnapshot{}, err
+	}
+	for _, entry := range entries {
+		size, err := pathSize(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return diskSnapshot{}, err
+		}
+		out.Paths[entry.Name()] = size
+	}
+	return out, nil
+}
+
+func pathSize(path string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(path, func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type().IsRegular() {
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			total += info.Size()
+		}
+		return nil
+	})
+	return total, err
+}
+
+func writeResult(out *os.File, format string, result *benchmarkResult) error {
+	switch format {
+	case "json":
+		encoder := json.NewEncoder(out)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(result)
+	case "text":
+		fmt.Fprintf(out, "target=%s database=%s collection=%s documents=%d secondary_indexes=%d\n",
+			result.Target, result.Database, result.Collection, result.Documents, result.SecondaryIndexes)
+		if result.TreeDBDir != "" {
+			fmt.Fprintf(out, "treedb_dir=%s\n", result.TreeDBDir)
+		}
+		for _, phase := range result.Phases {
+			fmt.Fprintf(out, "%-22s ops=%d calls=%d duration_ms=%.1f ops_sec=%.1f p50_us=%.0f p95_us=%.0f p99_us=%.0f\n",
+				phase.Name, phase.Operations, phase.DriverCalls, phase.DurationMillis, phase.OpsPerSecond,
+				phase.LatencyMicros.P50, phase.LatencyMicros.P95, phase.LatencyMicros.P99)
+		}
+		if result.TreeDBDiskAfterLoad != nil {
+			writeDiskSnapshot(out, "treedb_after_load", result.TreeDBDiskAfterLoad)
+		}
+		if result.TreeDBDiskAfterCheckpoint != nil {
+			writeDiskSnapshot(out, "treedb_after_checkpoint", result.TreeDBDiskAfterCheckpoint)
+		}
+		if result.MongoDBStatsAfterLoad != nil {
+			writeMongoStats(out, "mongodb_after_load", result.MongoDBStatsAfterLoad)
+		}
+		if result.MongoDBStatsFinal != nil {
+			writeMongoStats(out, "mongodb_final", result.MongoDBStatsFinal)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown format %q", format)
+	}
+}
+
+func writeDiskSnapshot(out *os.File, label string, snapshot *diskSnapshot) {
+	fmt.Fprintf(out, "%s total_bytes=%d", label, snapshot.TotalBytes)
+	names := make([]string, 0, len(snapshot.Paths))
+	for name := range snapshot.Paths {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fmt.Fprintf(out, " %s=%d", name, snapshot.Paths[name])
+	}
+	fmt.Fprintln(out)
+}
+
+func writeMongoStats(out *os.File, label string, stats map[string]any) {
+	keys := []string{"dataSize", "storageSize", "indexSize", "totalSize", "objects"}
+	fmt.Fprint(out, label)
+	for _, key := range keys {
+		if value, ok := stats[key]; ok {
+			fmt.Fprintf(out, " %s=%v", key, value)
+		}
+	}
+	fmt.Fprintln(out)
+}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -347,11 +347,16 @@ func rejectSymlinkedPath(path string) error {
 			}
 			return err
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("unsafe treedb-dir %q resolves through symlink %q", path, current)
+		if unsafeResetPathMode(info.Mode()) {
+			return fmt.Errorf("unsafe treedb-dir %q resolves through link/reparse point %q", path, current)
 		}
 	}
 	return nil
+}
+
+func unsafeResetPathMode(mode os.FileMode) bool {
+	// Go 1.23 no longer reports all Windows junction/reparse points as symlinks.
+	return mode&(os.ModeSymlink|os.ModeIrregular) != 0
 }
 
 func openMongoTarget(ctx context.Context, cfg config) (*benchTarget, error) {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -75,9 +76,40 @@ func TestValidateResettableTreeDBDirRejectsDangerousPaths(t *testing.T) {
 			t.Fatal("validateResettableTreeDBDir accepted checkout child")
 		}
 	}
-	safe := filepath.Join(t.TempDir(), "treedb")
+	safeRoot := t.TempDir()
+	if realSafeRoot, err := filepath.EvalSymlinks(safeRoot); err == nil {
+		safeRoot = realSafeRoot
+	}
+	safe := filepath.Join(safeRoot, "treedb")
 	if got, err := validateResettableTreeDBDir(safe); err != nil || got == "" {
 		t.Fatalf("validate safe dir got/err=%q/%v", got, err)
+	}
+}
+
+func TestCheckoutPathCandidatesIncludeResolvedCWD(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.Mkdir(realDir, 0o700); err != nil {
+		t.Fatalf("mkdir real: %v", err)
+	}
+	linkDir := filepath.Join(root, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	wantReal := realDir
+	if evaluated, err := filepath.EvalSymlinks(realDir); err == nil {
+		wantReal = evaluated
+	}
+	candidates := checkoutPathCandidates(linkDir)
+	foundReal := false
+	for _, candidate := range candidates {
+		if candidate == wantReal {
+			foundReal = true
+		}
+	}
+	if !foundReal {
+		t.Fatalf("checkoutPathCandidates(%q)=%v missing real dir %q", linkDir, candidates, wantReal)
 	}
 }
 
@@ -129,6 +161,9 @@ func TestRedactMongoURI(t *testing.T) {
 }
 
 func TestParseConfigValidation(t *testing.T) {
+	if _, err := parseConfig([]string{"-bad"}); err == nil || !strings.Contains(err.Error(), "Usage of mongo_gateway_bench") {
+		t.Fatalf("bad flag err=%v want usage", err)
+	}
 	if _, err := parseConfig([]string{"-target", "bad"}); err == nil {
 		t.Fatal("bad target accepted")
 	}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -54,6 +54,16 @@ func TestCollectDiskSnapshotBreakdown(t *testing.T) {
 	}
 }
 
+func TestCollectDiskSnapshotEmptyLeavesPathsNil(t *testing.T) {
+	snapshot, err := collectDiskSnapshot(t.TempDir())
+	if err != nil {
+		t.Fatalf("collect empty disk snapshot: %v", err)
+	}
+	if snapshot.TotalBytes != 0 || snapshot.Paths != nil {
+		t.Fatalf("empty snapshot=%+v want zero total and nil paths", snapshot)
+	}
+}
+
 func TestValidateResettableTreeDBDirRejectsDangerousPaths(t *testing.T) {
 	for _, dir := range []string{"", ".", "..", string(os.PathSeparator), os.TempDir()} {
 		if _, err := validateResettableTreeDBDir(dir); err == nil {
@@ -114,5 +124,23 @@ func TestWriteResultSupportsGenericWriter(t *testing.T) {
 	}
 	if !bytes.Contains(out.Bytes(), []byte("target=treedb")) {
 		t.Fatalf("text output missing target: %q", out.String())
+	}
+}
+
+func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {
+	result := &benchmarkResult{
+		Target:           "mongo",
+		MongoURI:         "mongodb://user@127.0.0.1:27017",
+		Database:         "bench",
+		Collection:       "docs",
+		Documents:        1,
+		SecondaryIndexes: 1,
+	}
+	var out bytes.Buffer
+	if err := writeResult(&out, "text", result); err != nil {
+		t.Fatalf("writeResult: %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("mongo_uri=mongodb://user@127.0.0.1:27017")) {
+		t.Fatalf("text output missing mongo_uri: %q", out.String())
 	}
 }

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -54,6 +54,26 @@ func TestCollectDiskSnapshotBreakdown(t *testing.T) {
 	}
 }
 
+func TestValidateResettableTreeDBDirRejectsDangerousPaths(t *testing.T) {
+	for _, dir := range []string{"", ".", "..", string(os.PathSeparator), os.TempDir()} {
+		if _, err := validateResettableTreeDBDir(dir); err == nil {
+			t.Fatalf("validateResettableTreeDBDir(%q) err=nil want error", dir)
+		}
+	}
+	safe := filepath.Join(t.TempDir(), "treedb")
+	if got, err := validateResettableTreeDBDir(safe); err != nil || got == "" {
+		t.Fatalf("validate safe dir got/err=%q/%v", got, err)
+	}
+}
+
+func TestRedactMongoURI(t *testing.T) {
+	got := redactMongoURI("mongodb://user:secret@127.0.0.1:27017/db?authSource=admin")
+	want := "mongodb://user@127.0.0.1:27017/db?authSource=admin"
+	if got != want {
+		t.Fatalf("redacted URI=%q want %q", got, want)
+	}
+}
+
 func TestParseConfigValidation(t *testing.T) {
 	if _, err := parseConfig([]string{"-target", "bad"}); err == nil {
 		t.Fatal("bad target accepted")

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -70,9 +70,27 @@ func TestValidateResettableTreeDBDirRejectsDangerousPaths(t *testing.T) {
 			t.Fatalf("validateResettableTreeDBDir(%q) err=nil want error", dir)
 		}
 	}
+	if cwd, err := os.Getwd(); err == nil {
+		if _, err := validateResettableTreeDBDir(filepath.Join(cwd, "unsafe-treedb")); err == nil {
+			t.Fatal("validateResettableTreeDBDir accepted checkout child")
+		}
+	}
 	safe := filepath.Join(t.TempDir(), "treedb")
 	if got, err := validateResettableTreeDBDir(safe); err != nil || got == "" {
 		t.Fatalf("validate safe dir got/err=%q/%v", got, err)
+	}
+}
+
+func TestIsPathDescendant(t *testing.T) {
+	parent := filepath.Join("tmp", "repo")
+	if !isPathDescendant(parent, filepath.Join(parent, "bench")) {
+		t.Fatal("child path not recognized as descendant")
+	}
+	if isPathDescendant(parent, parent) {
+		t.Fatal("parent path recognized as descendant")
+	}
+	if isPathDescendant(parent, filepath.Join("tmp", "repo-sibling")) {
+		t.Fatal("sibling path recognized as descendant")
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -91,6 +91,17 @@ func TestValidateResettableTreeDBDirRejectsSymlinkComponents(t *testing.T) {
 	}
 }
 
+func TestUnsafeResetPathModeRejectsLinksAndReparsePoints(t *testing.T) {
+	for _, mode := range []os.FileMode{os.ModeSymlink, os.ModeIrregular, os.ModeDir | os.ModeIrregular} {
+		if !unsafeResetPathMode(mode) {
+			t.Fatalf("unsafeResetPathMode(%v)=false want true", mode)
+		}
+	}
+	if unsafeResetPathMode(os.ModeDir) {
+		t.Fatal("plain directory marked unsafe")
+	}
+}
+
 func TestRedactMongoURI(t *testing.T) {
 	got := redactMongoURI("mongodb://user:secret@127.0.0.1:27017/db?authSource=admin")
 	want := "mongodb://user@127.0.0.1:27017/db?authSource=admin"

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSummarizeLatencyNearestRank(t *testing.T) {
+	summary := summarizeLatency([]time.Duration{
+		10 * time.Microsecond,
+		50 * time.Microsecond,
+		20 * time.Microsecond,
+		40 * time.Microsecond,
+		30 * time.Microsecond,
+	})
+	if summary.P50 != 30 {
+		t.Fatalf("p50=%v want 30", summary.P50)
+	}
+	if summary.P95 != 50 {
+		t.Fatalf("p95=%v want 50", summary.P95)
+	}
+	if summary.P99 != 50 {
+		t.Fatalf("p99=%v want 50", summary.P99)
+	}
+}
+
+func TestCollectDiskSnapshotBreakdown(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.db"), []byte("1234"), 0o600); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "leaf_vlog"), 0o700); err != nil {
+		t.Fatalf("mkdir leaf_vlog: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "leaf_vlog", "value.log"), []byte("123456"), 0o600); err != nil {
+		t.Fatalf("write value log: %v", err)
+	}
+
+	snapshot, err := collectDiskSnapshot(dir)
+	if err != nil {
+		t.Fatalf("collect disk snapshot: %v", err)
+	}
+	if snapshot.TotalBytes != 10 {
+		t.Fatalf("total=%d want 10", snapshot.TotalBytes)
+	}
+	if snapshot.Paths["index.db"] != 4 {
+		t.Fatalf("index.db=%d want 4", snapshot.Paths["index.db"])
+	}
+	if snapshot.Paths["leaf_vlog"] != 6 {
+		t.Fatalf("leaf_vlog=%d want 6", snapshot.Paths["leaf_vlog"])
+	}
+}
+
+func TestParseConfigValidation(t *testing.T) {
+	if _, err := parseConfig([]string{"-target", "bad"}); err == nil {
+		t.Fatal("bad target accepted")
+	}
+	cfg, err := parseConfig([]string{"-target", "mongo", "-documents", "10", "-secondary-indexes", "1", "-format", "json"})
+	if err != nil {
+		t.Fatalf("parse valid config: %v", err)
+	}
+	if cfg.Target != "mongo" || cfg.Documents != 10 || cfg.SecondaryIndexes != 1 || cfg.Format != "json" {
+		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -63,5 +64,29 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if cfg.Target != "mongo" || cfg.Documents != 10 || cfg.SecondaryIndexes != 1 || cfg.Format != "json" {
 		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}
+
+func TestWriteResultSupportsGenericWriter(t *testing.T) {
+	result := &benchmarkResult{
+		Target:           "treedb",
+		Database:         "bench",
+		Collection:       "docs",
+		Documents:        1,
+		SecondaryIndexes: 1,
+		Phases: []phaseResult{{
+			Name:           "load_insert_many",
+			Operations:     1,
+			DriverCalls:    1,
+			DurationMillis: 1,
+			OpsPerSecond:   1000,
+		}},
+	}
+	var out bytes.Buffer
+	if err := writeResult(&out, "text", result); err != nil {
+		t.Fatalf("writeResult: %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("target=treedb")) {
+		t.Fatalf("text output missing target: %q", out.String())
 	}
 }

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -76,6 +76,21 @@ func TestValidateResettableTreeDBDirRejectsDangerousPaths(t *testing.T) {
 	}
 }
 
+func TestValidateResettableTreeDBDirRejectsSymlinkComponents(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := validateResettableTreeDBDir(filepath.Join(link, "treedb")); err == nil {
+		t.Fatal("symlinked treedb-dir accepted")
+	}
+}
+
 func TestRedactMongoURI(t *testing.T) {
 	got := redactMongoURI("mongodb://user:secret@127.0.0.1:27017/db?authSource=admin")
 	want := "mongodb://user@127.0.0.1:27017/db?authSource=admin"

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -85,6 +85,12 @@ func TestParseConfigValidation(t *testing.T) {
 	if cfg.Target != "mongo" || cfg.Documents != 10 || cfg.SecondaryIndexes != 1 || cfg.Format != "json" {
 		t.Fatalf("unexpected config: %+v", cfg)
 	}
+	if _, err := parseConfig([]string{"-timeout", "0"}); err != nil {
+		t.Fatalf("timeout 0 should disable deadline: %v", err)
+	}
+	if _, err := parseConfig([]string{"-timeout", "-1s"}); err == nil {
+		t.Fatal("negative timeout accepted")
+	}
 }
 
 func TestWriteResultSupportsGenericWriter(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `cmd/mongo_gateway_bench`, a MongoDB-driver benchmark CLI that targets either the TreeDB gateway or a MongoDB server
- report per-phase ops/sec, latency percentiles, TreeDB filesystem bytes, and MongoDB `dbStats` storage fields
- document the suggested TreeDB-vs-MongoDB matrix and how to interpret disk usage results

## Validation
- GOWORK=off go test ./cmd/mongo_gateway_bench ./TreeDB/collections ./TreeDB/mongo_gateway/... -count=1
- GOWORK=off go run ./cmd/mongo_gateway_bench -target treedb -documents 10 -reads 5 -range-reads 2 -updates 2 -secondary-indexes 2 -format json -timeout 30s