### PR TITLE
Improve collection leaf generation compression

### DIFF
--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/internal/compression"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -161,6 +162,18 @@ func (db *DB) leafGenerationPackLocked(ctx context.Context, opts LeafGenerationP
 	writer.ConfigureLeafLog(layout.leafVLogDir, rewriteLeafLogLaneID, leafStartSeq)
 	writer.blockCompression = db.valueLogCompression != ValueLogCompressionOff
 	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
+	writer.leafBlockCodec = leafPageBlockCodecFromOptions(db.valueLogCompression, db.valueLogAutoPolicy, db.valueLogBlockCodec, db.indexOuterLeavesInValueLog)
+	if writer.blockCompression {
+		if state := db.State(); state != nil {
+			leafDictID, leafDictBytes, leafDictUseRawPages, err := prepareRewriteLeafDict(db, state, db.valueLogDictCurrentForClass, db.valueLogDictLeafPayloadMode, db.valueLogDictLookup, db.valueLogDictPut, db.valueLogDictSetCurrentForClass, db.valueLogDictSetLeafPayloadMode, compression.TrainConfig{})
+			if err != nil {
+				return stats, err
+			}
+			if leafDictID != 0 && len(leafDictBytes) > 0 {
+				writer.SetLeafDictMode(leafDictID, leafDictBytes, leafDictUseRawPages)
+			}
+		}
+	}
 	defer func() { _ = writer.Close() }()
 
 	sourceValueIDs := make(map[uint32]struct{}, len(rawSourceIDs))

--- a/TreeDB/db/leaf_generation_pack_test.go
+++ b/TreeDB/db/leaf_generation_pack_test.go
@@ -6,11 +6,13 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/snissn/compress/zstd"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
@@ -495,6 +497,131 @@ func TestLeafGenerationPack_MovesSparseSealedGeneration(t *testing.T) {
 	if err := waitForPathRemoval(path1, 5*time.Second); err != nil {
 		t.Fatalf("waitForPathRemoval(%s): %v", path1, err)
 	}
+}
+
+func TestLeafGenerationPack_UsesOuterLeafDict(t *testing.T) {
+	dir := t.TempDir()
+	const dictID = uint64(9001)
+	leafA, _, err := valuelog.MaybeCompactLeafLogPayload(buildRewriteLeafPageFixture(t, "pack-a"))
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload(a): %v", err)
+	}
+	leafB, _, err := valuelog.MaybeCompactLeafLogPayload(buildRewriteLeafPageFixture(t, "pack-b"))
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload(b): %v", err)
+	}
+	leafC, _, err := valuelog.MaybeCompactLeafLogPayload(buildRewriteLeafPageFixture(t, "pack-c"))
+	if err != nil {
+		t.Fatalf("MaybeCompactLeafLogPayload(c): %v", err)
+	}
+	dictBytes, err := zstd.BuildDict(zstd.BuildDictOptions{
+		ID:       uint32(dictID),
+		Contents: [][]byte{leafA, leafB, leafC},
+		History:  append([]byte(nil), leafA...),
+		Offsets:  [3]int{1, 4, 8},
+		Level:    zstd.SpeedFastest,
+	})
+	if err != nil {
+		t.Fatalf("BuildDict: %v", err)
+	}
+	if len(dictBytes) == 0 {
+		t.Fatal("expected non-empty outer leaf dict")
+	}
+
+	opts := Options{
+		Dir:                        dir,
+		Durability:                 DurabilityWALOffRelaxed,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		LeafPrefixCompression:      true,
+		IndexColumnarLeaves:        true,
+		IndexPackedValuePtr:        true,
+		ValueLog: ValueLogOptions{
+			Compression: ValueLogCompressionBlock,
+			BlockCodec:  ValueLogBlockLZ4,
+			DictLookup: func(id uint64) ([]byte, error) {
+				if id != dictID {
+					return nil, valuelog.ErrMissingDict
+				}
+				return append([]byte(nil), dictBytes...), nil
+			},
+			DictCurrentForClass: func(_ context.Context, class string) (uint64, error) {
+				if class == "outer_leaf" {
+					return dictID, nil
+				}
+				return 0, nil
+			},
+			DictLeafPayloadMode: func(_ context.Context, id uint64) (bool, bool, error) {
+				if id != dictID {
+					return false, false, nil
+				}
+				return false, true, nil
+			},
+		},
+	}
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 64<<20)
+	leafLog.ConfigureLeafLog(LeafLogDirPath(dir), rewriteLeafLogLaneID, 0)
+	db.SetLeafPageLog(leafLog)
+	defer func() {
+		closeNoErr(t, leafLog)
+		closeNoErr(t, db)
+	}()
+
+	writeLeafGenerationKeys(t, db, "dict-pack", 2048, 'a')
+	_, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, db, "dict-pack", 0, 1024, 'b')
+	writeLeafGenerationKeys(t, db, "dict-pack-live", 32, 'z')
+
+	manifest := loadLeafGenerationManifestOrFatal(t, dir)
+	gen1 := findLeafGenerationByFileID(t, manifest, rawFileID1)
+	stats, err := db.LeafGenerationPack(context.Background(), LeafGenerationPackOptions{
+		GenerationIDs: []uint64{gen1.GenerationID},
+		Force:         true,
+		Sync:          true,
+	})
+	if err != nil {
+		t.Fatalf("LeafGenerationPack: %v", err)
+	}
+	if len(stats.CreatedFileIDs) == 0 {
+		t.Fatalf("CreatedFileIDs empty, stats=%+v", stats)
+	}
+
+	header := readFirstLeafGenerationFrameHeader(t, dir, stats.CreatedFileIDs[0])
+	if header.DictID != dictID {
+		t.Fatalf("packed leaf frame dictID=%d want %d", header.DictID, dictID)
+	}
+}
+
+func readFirstLeafGenerationFrameHeader(t *testing.T, dir string, rawFileID uint32) valuelog.FrameHeader {
+	t.Helper()
+	path := leafLogSegmentPath(t, dir, rawFileID)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	var header [valuelog.HeaderSize]byte
+	if _, err := io.ReadFull(f, header[:]); err != nil {
+		t.Fatalf("read record header: %v", err)
+	}
+	bodyLen := binary.LittleEndian.Uint32(header[16:20])
+	body := make([]byte, int(bodyLen))
+	if _, err := io.ReadFull(f, body); err != nil {
+		t.Fatalf("read frame body: %v", err)
+	}
+	frameHeader, _, _, _, err := valuelog.DecodeFrame(body)
+	if err != nil {
+		t.Fatalf("DecodeFrame: %v", err)
+	}
+	return frameHeader
 }
 
 func TestLeafGenerationPack_RewritesCollectionLeafRefRoot(t *testing.T) {

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -220,7 +220,7 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 			PinnedCount:  db.leafGenerationPins.count(gen.GenerationID),
 		}
 		for _, rawFileID := range gen.FileIDs {
-			entry.BytesTotal += leafGenerationRawFileSize(db.dir, set, rawFileID)
+			entry.BytesTotal += leafGenerationRawFilePhysicalSize(db.dir, set, rawFileID)
 		}
 		if live := liveScan.Generations[gen.GenerationID]; live.LiveBytes > 0 || live.LivePages > 0 {
 			entry.BytesLive = live.LiveBytes

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -606,6 +606,43 @@ func TestLeafGenerationRecordLengthForPlan_UsesSealedIndex(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationPlan_UsesPhysicalFileSizeWhenCachedSizeIsStale(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "k", 2048, 'a')
+	path1, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	infoBefore, err := os.Stat(path1)
+	if err != nil {
+		t.Fatalf("stat leaf file before extension: %v", err)
+	}
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, db, "k", 0, 64, 'b')
+
+	const extraDeadBytes = int64(1 << 20)
+	physicalSize := infoBefore.Size() + extraDeadBytes
+	if err := os.Truncate(path1, physicalSize); err != nil {
+		t.Fatalf("extend sealed leaf file: %v", err)
+	}
+
+	plan, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{Force: true})
+	if err != nil {
+		t.Fatalf("LeafGenerationPlan: %v", err)
+	}
+	gen := findLeafGenerationPlanEntry(t, plan, findLeafGenerationByFileID(t, loadLeafGenerationManifestOrFatal(t, db.dir), rawFileID1).GenerationID)
+	if gen.BytesTotal < physicalSize {
+		t.Fatalf("generation bytes_total=%d, want at least physical size %d", gen.BytesTotal, physicalSize)
+	}
+	if gen.BytesDead < extraDeadBytes {
+		t.Fatalf("generation bytes_dead=%d, want at least injected dead bytes %d", gen.BytesDead, extraDeadBytes)
+	}
+	if !gen.Eligible {
+		t.Fatalf("generation eligible=%t skip=%q, want eligible after physical dead bytes", gen.Eligible, gen.SkipReason)
+	}
+}
+
 func TestLeafGenerationPlan_CachesLiveStatsPerPublishedState(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 	counter := withLeafGenerationLiveScanCounter(t)

--- a/TreeDB/db/leaf_generation_stats.go
+++ b/TreeDB/db/leaf_generation_stats.go
@@ -68,7 +68,7 @@ func (db *DB) collectLeafGenerationMetrics(set *valuelog.Set, excludePinIDs []ui
 		genFiles := len(gen.FileIDs)
 		genBytes := int64(0)
 		for _, rawFileID := range gen.FileIDs {
-			genBytes += leafGenerationRawFileSize(db.dir, set, rawFileID)
+			genBytes += leafGenerationRawFileSizeBestEffort(db.dir, set, rawFileID)
 		}
 		m.generationsTotal++
 		m.filesTotal += genFiles
@@ -116,24 +116,48 @@ func (db *DB) collectLeafGenerationMetrics(set *valuelog.Set, excludePinIDs []ui
 	return m
 }
 
-func leafGenerationRawFileSize(rootDir string, set *valuelog.Set, rawFileID uint32) int64 {
+func leafGenerationRawFileSizeBestEffort(rootDir string, set *valuelog.Set, rawFileID uint32) int64 {
 	if rawFileID == 0 {
 		return 0
 	}
-	if set != nil {
-		if f := set.Files[page.ValueLogFileID(rawFileID)]; f != nil {
-			if size := fileSize(f); size > 0 {
-				return size
-			}
-		}
+	// Stats are often read as lightweight telemetry. Preserve the cached-first
+	// path here; maintenance planning uses leafGenerationRawFilePhysicalSize.
+	cached, path := leafGenerationRawFileCachedSizeAndPath(set, rawFileID)
+	if cached > 0 {
+		return cached
 	}
-	path := leafGenerationFallbackPath(rootDir, rawFileID)
-	if path == "" {
+	return leafGenerationRawFileSizeFromPath(rootDir, rawFileID, path, 0)
+}
+
+func leafGenerationRawFilePhysicalSize(rootDir string, set *valuelog.Set, rawFileID uint32) int64 {
+	if rawFileID == 0 {
 		return 0
+	}
+	cached, path := leafGenerationRawFileCachedSizeAndPath(set, rawFileID)
+	return leafGenerationRawFileSizeFromPath(rootDir, rawFileID, path, cached)
+}
+
+func leafGenerationRawFileCachedSizeAndPath(set *valuelog.Set, rawFileID uint32) (int64, string) {
+	if set == nil || rawFileID == 0 {
+		return 0, ""
+	}
+	f := set.Files[page.ValueLogFileID(rawFileID)]
+	if f == nil {
+		return 0, ""
+	}
+	return fileSize(f), f.Path
+}
+
+func leafGenerationRawFileSizeFromPath(rootDir string, rawFileID uint32, path string, fallback int64) int64 {
+	if path == "" {
+		path = leafGenerationFallbackPath(rootDir, rawFileID)
+	}
+	if path == "" {
+		return fallback
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return 0
+		return fallback
 	}
 	return info.Size()
 }

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -704,12 +704,17 @@ func prepareRewriteLeafDict(d *DB, state *DBState, currentForClass func(context.
 	if d == nil || state == nil {
 		return 0, nil, false, nil
 	}
-	if currentForClass != nil {
+	canLookupDict := dictLookup != nil
+	canPublishDict := dictPut != nil
+	if !canLookupDict && !canPublishDict {
+		return 0, nil, false, nil
+	}
+	if currentForClass != nil && canLookupDict {
 		dictID, err := currentForClass(context.Background(), "outer_leaf")
 		if err != nil {
 			return 0, nil, false, err
 		}
-		if dictID != 0 && dictLookup != nil {
+		if dictID != 0 {
 			dictBytes, err := dictLookup(dictID)
 			if err == nil && len(dictBytes) > 0 {
 				useRawPages, err := resolveRewriteLeafDictUseRawPages(dictLeafPayloadMode, dictID, false)
@@ -720,31 +725,33 @@ func prepareRewriteLeafDict(d *DB, state *DBState, currentForClass func(context.
 			}
 		}
 	}
-	if preferredLeafDict, err := scanValueLogSetPreferredLeafDictID(state.ValueLogSet); err != nil {
-		return 0, nil, false, err
-	} else if preferredLeafDict != 0 && dictLookup != nil {
-		dictBytes, err := dictLookup(preferredLeafDict)
-		if err == nil && len(dictBytes) > 0 {
-			useRawPages, err := resolveRewriteLeafDictUseRawPages(dictLeafPayloadMode, preferredLeafDict, true)
-			if err != nil {
-				return 0, nil, false, err
+	if canLookupDict {
+		if preferredLeafDict, err := scanValueLogSetPreferredLeafDictID(state.ValueLogSet); err != nil {
+			return 0, nil, false, err
+		} else if preferredLeafDict != 0 {
+			dictBytes, err := dictLookup(preferredLeafDict)
+			if err == nil && len(dictBytes) > 0 {
+				useRawPages, err := resolveRewriteLeafDictUseRawPages(dictLeafPayloadMode, preferredLeafDict, true)
+				if err != nil {
+					return 0, nil, false, err
+				}
+				return preferredLeafDict, dictBytes, useRawPages, nil
 			}
-			return preferredLeafDict, dictBytes, useRawPages, nil
+		}
+		if preferredDictGlobal, err := scanValueLogSetPreferredDictID(state.ValueLogSet); err != nil {
+			return 0, nil, false, err
+		} else if preferredDictGlobal != 0 {
+			dictBytes, err := dictLookup(preferredDictGlobal)
+			if err == nil && len(dictBytes) > 0 {
+				useRawPages, err := resolveRewriteLeafDictUseRawPages(dictLeafPayloadMode, preferredDictGlobal, true)
+				if err != nil {
+					return 0, nil, false, err
+				}
+				return preferredDictGlobal, dictBytes, useRawPages, nil
+			}
 		}
 	}
-	if preferredDictGlobal, err := scanValueLogSetPreferredDictID(state.ValueLogSet); err != nil {
-		return 0, nil, false, err
-	} else if preferredDictGlobal != 0 && dictLookup != nil {
-		dictBytes, err := dictLookup(preferredDictGlobal)
-		if err == nil && len(dictBytes) > 0 {
-			useRawPages, err := resolveRewriteLeafDictUseRawPages(dictLeafPayloadMode, preferredDictGlobal, true)
-			if err != nil {
-				return 0, nil, false, err
-			}
-			return preferredDictGlobal, dictBytes, useRawPages, nil
-		}
-	}
-	if dictPut == nil {
+	if !canPublishDict {
 		return 0, nil, false, nil
 	}
 	dictBytes, err := trainRewriteLeafDictFromLiveLeafRefs(d, state, cfg)

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -5650,6 +5650,33 @@ func TestPrepareRewriteLeafDict_LiveLeafRefBootstrapBestEffort(t *testing.T) {
 	}
 }
 
+func TestPrepareRewriteLeafDict_NoUsableCallbacksSkipsWork(t *testing.T) {
+	calledCurrent := false
+	dictID, dictBytes, useRawPages, err := prepareRewriteLeafDict(
+		&DB{},
+		&DBState{ValueLogSet: &valuelog.Set{}},
+		func(context.Context, string) (uint64, error) {
+			calledCurrent = true
+			return 0, errors.New("current callback should be skipped without lookup or put")
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		compression.TrainConfig{},
+	)
+	if err != nil {
+		t.Fatalf("prepareRewriteLeafDict: %v", err)
+	}
+	if calledCurrent {
+		t.Fatal("current callback was called even though no lookup or publish callback was available")
+	}
+	if dictID != 0 || len(dictBytes) != 0 || useRawPages {
+		t.Fatalf("unexpected dict result: id=%d bytes=%d useRawPages=%t", dictID, len(dictBytes), useRawPages)
+	}
+}
+
 func TestPrepareRewriteLeafDict_CurrentClassCompactModePreserved(t *testing.T) {
 	state := &DBState{ValueLogSet: &valuelog.Set{}}
 	dictBytes := []byte("compact-leaf-dict")

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -541,14 +541,16 @@ func Open(opts Options) (*DB, error) {
 		opts.ValueLog.DictLeafPayloadMode = func(ctx context.Context, dictID uint64) (bool, bool, error) {
 			return dictStore.GetLeafPayloadMode(ctx, dictID)
 		}
-		opts.ValueLog.DictPut = func(ctx context.Context, dictBytes []byte) (uint64, error) {
-			return dictStore.PutDictBytes(ctx, dictBytes)
-		}
-		opts.ValueLog.DictSetCurrentForClass = func(ctx context.Context, class string, dictID uint64) error {
-			return dictStore.SetCurrentForClass(ctx, class, dictID)
-		}
-		opts.ValueLog.DictSetLeafPayloadMode = func(ctx context.Context, dictID uint64, useRawPages bool) error {
-			return dictStore.SetLeafPayloadMode(ctx, dictID, useRawPages)
+		if !opts.ReadOnly {
+			opts.ValueLog.DictPut = func(ctx context.Context, dictBytes []byte) (uint64, error) {
+				return dictStore.PutDictBytes(ctx, dictBytes)
+			}
+			opts.ValueLog.DictSetCurrentForClass = func(ctx context.Context, class string, dictID uint64) error {
+				return dictStore.SetCurrentForClass(ctx, class, dictID)
+			}
+			opts.ValueLog.DictSetLeafPayloadMode = func(ctx context.Context, dictID uint64, useRawPages bool) error {
+				return dictStore.SetLeafPayloadMode(ctx, dictID, useRawPages)
+			}
 		}
 	}
 

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -535,6 +535,21 @@ func Open(opts Options) (*DB, error) {
 		opts.ValueLog.DictLookup = func(dictID uint64) ([]byte, error) {
 			return dictStore.GetDictBytes(context.Background(), dictID)
 		}
+		opts.ValueLog.DictCurrentForClass = func(ctx context.Context, class string) (uint64, error) {
+			return dictStore.GetCurrentForClass(ctx, class)
+		}
+		opts.ValueLog.DictLeafPayloadMode = func(ctx context.Context, dictID uint64) (bool, bool, error) {
+			return dictStore.GetLeafPayloadMode(ctx, dictID)
+		}
+		opts.ValueLog.DictPut = func(ctx context.Context, dictBytes []byte) (uint64, error) {
+			return dictStore.PutDictBytes(ctx, dictBytes)
+		}
+		opts.ValueLog.DictSetCurrentForClass = func(ctx context.Context, class string, dictID uint64) error {
+			return dictStore.SetCurrentForClass(ctx, class, dictID)
+		}
+		opts.ValueLog.DictSetLeafPayloadMode = func(ctx context.Context, dictID uint64, useRawPages bool) error {
+			return dictStore.SetLeafPayloadMode(ctx, dictID, useRawPages)
+		}
 	}
 
 	if !opts.DisableSideStores && opts.ValueLog.TemplateMode != template.TemplateOff {

--- a/scripts/treedb_collection_compression_matrix.sh
+++ b/scripts/treedb_collection_compression_matrix.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DOCS="${DOCS:-100000}"
+BATCH="${BATCH:-16000}"
+RUN_DIR="${RUN_DIR:-/tmp/treedb_collection_compression_$(date +%Y%m%d_%H%M%S)}"
+PROFILE="${PROFILE:-fast}"
+
+mkdir -p "$RUN_DIR"/{dbs,logs}
+
+collection_fixture="$repo_root/bin/collection-load-fixture"
+treemap="$repo_root/bin/treemap"
+raw_loader="$RUN_DIR/raw_template_v1_loader.go"
+tsv="$RUN_DIR/compression_matrix.tsv"
+md="$RUN_DIR/compression_matrix.md"
+
+cat >"$raw_loader" <<'GO'
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+const (
+	fixtureCities = 64
+	fixturePad    = "01234567890123456789"
+)
+
+func main() {
+	dir := flag.String("dir", "", "TreeDB directory")
+	docs := flag.Int("docs", 100000, "documents to write")
+	batchSize := flag.Int("batch-size", 16000, "documents per batch")
+	reset := flag.Bool("reset", false, "remove directory before loading")
+	profile := flag.String("profile", "fast", "TreeDB profile: fast, wal_on_fast, durable, or bench")
+	flag.Parse()
+
+	if *dir == "" {
+		fatalf("-dir is required")
+	}
+	if *docs <= 0 {
+		fatalf("-docs must be > 0")
+	}
+	if *batchSize <= 0 {
+		fatalf("-batch-size must be > 0")
+	}
+	if *reset {
+		if err := os.RemoveAll(*dir); err != nil {
+			fatalf("reset %s: %v", *dir, err)
+		}
+	}
+
+	opts := treedb.OptionsFor(parseProfile(*profile), *dir)
+	opts.IndexOuterLeavesInValueLog = true
+	opts.IndexInternalBaseDelta = false
+	opts.KeepRecent = 1
+	opts.PreferAppendAlloc = false
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		fatalf("open TreeDB: %v", err)
+	}
+	var closeErr error
+	defer func() {
+		if err := db.Close(); err != nil && closeErr == nil {
+			closeErr = err
+		}
+		if closeErr != nil {
+			fatalf("%v", closeErr)
+		}
+	}()
+
+	var encoder collections.TemplateV1Encoder
+	for start := 0; start < *docs; start += *batchSize {
+		end := start + *batchSize
+		if end > *docs {
+			end = *docs
+		}
+		b := db.NewBatchWithSize(end - start)
+		if b == nil {
+			closeErr = fmt.Errorf("new batch returned nil")
+			return
+		}
+		for n := start; n < end; n++ {
+			doc, err := encoder.EncodeDocument(
+				[]string{"name", "email", "city", "pad"},
+				[]any{
+					fmt.Sprintf("user-%09d", n),
+					fmt.Sprintf("user-%09d@example.com", n),
+					fmt.Sprintf("city-%02d", n%fixtureCities),
+					fixturePad,
+				},
+			)
+			if err != nil {
+				_ = b.Close()
+				closeErr = fmt.Errorf("encode document %d: %w", n, err)
+				return
+			}
+			if err := b.Set([]byte(fmt.Sprintf("u-%09d", n)), doc); err != nil {
+				_ = b.Close()
+				closeErr = fmt.Errorf("set document %d: %w", n, err)
+				return
+			}
+		}
+		if err := b.Write(); err != nil {
+			_ = b.Close()
+			closeErr = fmt.Errorf("write batch starting at %d: %w", start, err)
+			return
+		}
+		if err := b.Close(); err != nil {
+			closeErr = fmt.Errorf("close batch starting at %d: %w", start, err)
+			return
+		}
+	}
+	if err := db.Checkpoint(); err != nil {
+		closeErr = fmt.Errorf("checkpoint: %w", err)
+	}
+}
+
+func parseProfile(raw string) treedb.Profile {
+	switch raw {
+	case "", "fast":
+		return treedb.ProfileFast
+	case "wal_on_fast":
+		return treedb.ProfileWALOnFast
+	case "durable":
+		return treedb.ProfileDurable
+	case "bench":
+		return treedb.ProfileBench
+	default:
+		fatalf("unsupported -profile %q", raw)
+		return ""
+	}
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "raw-template-v1-loader: "+format+"\n", args...)
+	os.Exit(1)
+}
+GO
+
+echo "Building benchmark helpers..."
+make -C "$repo_root" collection-load-fixture treemap-bin >/dev/null
+
+if [[ ! -x "$collection_fixture" ]]; then
+	echo "missing $collection_fixture" >&2
+	exit 1
+fi
+if [[ ! -x "$treemap" ]]; then
+	echo "missing $treemap" >&2
+	exit 1
+fi
+
+portable_stat_size() {
+	local path="$1"
+	if stat -f%z "$path" >/dev/null 2>&1; then
+		stat -f%z "$path"
+	else
+		stat -c%s "$path"
+	fi
+}
+
+dir_bytes() {
+	local dir="$1"
+	local total=0
+	local file
+	while IFS= read -r file; do
+		total=$((total + $(portable_stat_size "$file")))
+	done < <(find "$dir" -type f | LC_ALL=C sort)
+	printf '%s\n' "$total"
+}
+
+gzip_dir_bytes() {
+	local dir="$1"
+	find "$dir" -type f | LC_ALL=C sort | while IFS= read -r file; do
+		cat "$file"
+	done | gzip -c | wc -c | tr -d '[:space:]'
+}
+
+path_bytes() {
+	local path="$1"
+	if [[ ! -e "$path" ]]; then
+		printf '0\n'
+	elif [[ -d "$path" ]]; then
+		dir_bytes "$path"
+	else
+		portable_stat_size "$path"
+	fi
+}
+
+path_gzip_bytes() {
+	local path="$1"
+	if [[ ! -e "$path" ]]; then
+		printf '0\n'
+	elif [[ -d "$path" ]]; then
+		gzip_dir_bytes "$path"
+	else
+		gzip -c "$path" | wc -c | tr -d '[:space:]'
+	fi
+}
+
+ratio() {
+	awk -v bytes="$1" -v gzip_bytes="$2" 'BEGIN {
+		if (gzip_bytes > 0) {
+			printf "%.2f", bytes / gzip_bytes
+		} else {
+			printf "0.00"
+		}
+	}'
+}
+
+pct_delta() {
+	awk -v before="$1" -v after="$2" 'BEGIN {
+		if (before > 0) {
+			printf "%.1f%%", ((after - before) / before) * 100
+		} else {
+			printf "0.0%%"
+		}
+	}'
+}
+
+measure_tsv_row() {
+	local mode="$1"
+	local indexes="$2"
+	local db_dir="$3"
+	local phase="$4"
+	local total
+	local total_gzip
+	local leaf
+	local leaf_gzip
+	local index_db
+	local value_vlog
+	total="$(dir_bytes "$db_dir")"
+	total_gzip="$(gzip_dir_bytes "$db_dir")"
+	leaf="$(path_bytes "$db_dir/maindb/leaf_vlog")"
+	leaf_gzip="$(path_gzip_bytes "$db_dir/maindb/leaf_vlog")"
+	index_db="$(path_bytes "$db_dir/maindb/index.db")"
+	value_vlog="$(path_bytes "$db_dir/maindb/value_vlog")"
+	printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$mode" "$indexes" "$phase" "$total" "$total_gzip" "$(ratio "$total" "$total_gzip")" \
+		"$leaf" "$(ratio "$leaf" "$leaf_gzip")" "$index_db" "$value_vlog"
+}
+
+run_rewrite() {
+	local case_name="$1"
+	local db_dir="$2"
+	"$treemap" vlog-rewrite "$db_dir" -rw >"$RUN_DIR/logs/${case_name}.rewrite.log" 2>&1
+}
+
+run_raw_case() {
+	local case_name="raw_treedb"
+	local db_dir="$RUN_DIR/dbs/$case_name"
+	echo "Loading $case_name..."
+	(
+		cd "$repo_root"
+		go run "$raw_loader" -dir "$db_dir" -reset -docs "$DOCS" -batch-size "$BATCH" -profile "$PROFILE"
+	) >"$RUN_DIR/logs/${case_name}.load.log" 2>&1
+	measure_tsv_row "raw_treedb" "-" "$db_dir" "before_rewrite" >>"$tsv"
+	echo "Rewriting $case_name..."
+	run_rewrite "$case_name" "$db_dir"
+	measure_tsv_row "raw_treedb" "-" "$db_dir" "after_rewrite" >>"$tsv"
+}
+
+run_collection_case() {
+	local indexes="$1"
+	local case_name="collection_indexes_${indexes}"
+	local db_dir="$RUN_DIR/dbs/$case_name"
+	echo "Loading $case_name..."
+	"$collection_fixture" \
+		-json \
+		-dir "$db_dir" \
+		-reset \
+		-docs "$DOCS" \
+		-batch-size "$BATCH" \
+		-format template-v1 \
+		-indexes "$indexes" \
+		-profile "$PROFILE" \
+		-progress=false \
+		>"$RUN_DIR/logs/${case_name}.load.json" 2>"$RUN_DIR/logs/${case_name}.load.stderr"
+	measure_tsv_row "collection" "$indexes" "$db_dir" "before_rewrite" >>"$tsv"
+	echo "Rewriting $case_name..."
+	run_rewrite "$case_name" "$db_dir"
+	measure_tsv_row "collection" "$indexes" "$db_dir" "after_rewrite" >>"$tsv"
+}
+
+printf 'mode\tindexes\tphase\ttotal_bytes\ttotal_gzip_bytes\ttotal_bytes_per_gzip_byte\tleaf_vlog_bytes\tleaf_vlog_bytes_per_gzip_byte\tindex_db_bytes\tvalue_vlog_bytes\n' >"$tsv"
+
+run_raw_case
+run_collection_case 0
+run_collection_case 1
+run_collection_case 2
+
+{
+	printf '# TreeDB Collection Compression Matrix\n\n'
+	printf -- '- Run dir: `%s`\n' "$RUN_DIR"
+	printf -- '- Docs: `%s`\n' "$DOCS"
+	printf -- '- Batch size: `%s`\n' "$BATCH"
+	printf -- '- Document shape: template-v1 fixture fields `name`, `email`, `city`, `pad`\n'
+	printf -- '- Raw TreeDB case: generated template-v1 payloads stored directly by key\n'
+	printf -- '- Collection cases: generated template-v1 payloads inserted through collection mode with 0, 1, and 2 indexes\n'
+	printf -- '- Offline rewrite: `treemap vlog-rewrite <dir> -rw`\n'
+	printf -- '- Gzip ratio is `bytes/gzip_bytes`; lower is closer to gzip-compressed density already being present on disk.\n\n'
+	printf '| Mode | Indexes | Before bytes | Before gzip | Before bytes/gzip | After rewrite bytes | After rewrite gzip | After bytes/gzip | Disk delta | Gzip delta | After leaf_vlog bytes | After leaf bytes/gzip | After index.db bytes | After value_vlog bytes |\n'
+	printf '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n'
+	for mode in raw_treedb collection; do
+		if [[ "$mode" == "raw_treedb" ]]; then
+			index_values=("-")
+		else
+			index_values=(0 1 2)
+		fi
+		for indexes in "${index_values[@]}"; do
+			before_line="$(awk -F '\t' -v mode="$mode" -v idx="$indexes" '$1 == mode && $2 == idx && $3 == "before_rewrite" { print; exit }' "$tsv")"
+			after_line="$(awk -F '\t' -v mode="$mode" -v idx="$indexes" '$1 == mode && $2 == idx && $3 == "after_rewrite" { print; exit }' "$tsv")"
+			IFS=$'\t' read -r _ _ _ before_total before_gzip before_ratio _ _ _ _ <<<"$before_line"
+			IFS=$'\t' read -r _ _ _ after_total after_gzip after_ratio after_leaf after_leaf_ratio after_index_db after_value_vlog <<<"$after_line"
+			printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+				"$mode" "$indexes" "$before_total" "$before_gzip" "$before_ratio" \
+				"$after_total" "$after_gzip" "$after_ratio" \
+				"$(pct_delta "$before_total" "$after_total")" "$(pct_delta "$before_gzip" "$after_gzip")" \
+				"$after_leaf" "$after_leaf_ratio" "$after_index_db" "$after_value_vlog"
+		done
+	done
+	printf '\nRaw TSV: `%s`\n' "$tsv"
+} >"$md"
+
+cat "$md"


### PR DESCRIPTION
## Summary
- make leaf-generation pack configure leaf-log compression like value-log rewrite, including leaf-specific block codec selection and outer-leaf dictionary reuse/training
- wire public TreeDB side-store dictionary publish/current-class callbacks into the backend so public maintenance paths can train/reuse leaf dictionaries
- keep leaf-generation planning honest when cached segment sizes are stale by using physical file sizes for maintenance planning while retaining cached-first stats telemetry
- add `scripts/treedb_collection_compression_matrix.sh` to compare raw TreeDB template-v1 payload storage with collection mode across 0, 1, and 2 indexes before/after offline rewrite

## Compression review
Fixture: 100,000 template-v1 collection docs, 2 indexes, batch size 16,000, profile fast, index/data outer leaves in value log.

| Case | Total bytes | Total gzip bytes | Total bytes/gzip | leaf_vlog bytes | leaf_vlog gzip bytes | leaf_vlog bytes/gzip |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Collection generated | 10,667,424 | 1,005,401 | 10.61x | 6,308,482 | 933,028 | 6.76x |
| Collection + old leafgen-pack+GC | 10,451,398 | 862,418 | 12.12x | 6,092,456 | 747,745 | 8.15x |
| Collection + offline vlog-rewrite | 4,419,216 | 1,453,075 | 3.04x | 3,533,368 | 1,399,928 | 2.52x |
| Collection + patched leafgen-pack+GC | 7,959,765 | 1,549,978 | 5.14x | 3,600,821 | 1,436,450 | 2.51x |

Sanity baseline with raw TreeDB, 100,000 keys, 1,024-byte `highly_compressible_notail` values, profile fast:

| Case | Total bytes | Total gzip bytes | Total bytes/gzip | value_vlog bytes | value_vlog gzip bytes | value_vlog bytes/gzip | leaf_vlog bytes | leaf_vlog bytes/gzip |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Raw TreeDB before offline rewrite | 6,152,043 | 306,710 | 20.06x | 4,806,347 | 217,533 | 22.09x | 1,017,278 | 12.67x |
| Raw TreeDB after offline rewrite | 5,913,101 | 347,837 | 17.00x | 4,806,347 | 217,533 | 22.09x | 286,444 | 2.46x |

Interpretation: collection leaf logs had the same kind of residual compression gap as raw TreeDB leaf logs before rewrite. Offline rewrite already had the good outer-leaf path; leaf-generation pack did not. After this patch, leaf-generation pack produces a collection leaf_vlog with essentially the same residual gzip profile as offline rewrite (2.51x vs 2.52x) and almost the same leaf_vlog size (3.60 MB vs 3.53 MB on this fixture).

## Raw-vs-collection template-v1 matrix
Command:

```sh
DOCS=100000 BATCH=16000 scripts/treedb_collection_compression_matrix.sh
```

Run dir: `/tmp/treedb_collection_compression_20260429_071708`. Raw TreeDB stores the generated template-v1 payloads directly by key. Collection rows insert the same generated payloads through collection mode. Offline rewrite is `treemap vlog-rewrite <dir> -rw`. Gzip ratio is `bytes/gzip_bytes`; lower means the on-disk bytes are already closer to gzip-compressed density.

| Mode | Indexes | Before bytes | Before gzip | Before bytes/gzip | After rewrite bytes | After rewrite gzip | After bytes/gzip | Disk delta | Gzip delta | After leaf_vlog bytes | After leaf bytes/gzip | After index.db bytes | After value_vlog bytes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| raw_treedb | - | 6,833,561 | 312,846 | 21.84 | 1,983,120 | 607,960 | 3.26 | -71.0% | +94.3% | 1,359,414 | 2.35 | 262,144 | 0 |
| collection | 0 | 6,868,248 | 315,509 | 21.77 | 1,969,502 | 556,752 | 3.54 | -71.3% | +76.5% | 1,313,028 | 2.49 | 262,144 | 0 |
| collection | 1 | 9,058,899 | 607,826 | 14.90 | 3,766,809 | 1,140,704 | 3.30 | -58.4% | +87.7% | 2,848,191 | 2.61 | 524,288 | 0 |
| collection | 2 | 10,700,194 | 1,005,364 | 10.64 | 4,434,455 | 1,421,622 | 3.12 | -58.6% | +41.4% | 3,515,837 | 2.57 | 524,288 | 0 |

Inspection call: after offline rewrite, collection mode is not showing a large residual gzip-ratio gap versus raw TreeDB on the same generated template-v1 payloads. The post-rewrite total ratios are clustered at 3.12x-3.54x, and post-rewrite leaf ratios are clustered at 2.35x-2.61x. The remaining disk growth is mostly expected secondary-index leaf content plus one extra 256 KiB index chunk once indexes are present, rather than an obvious missed compression path comparable to the old leafgen-pack issue. The next worthwhile storage work is likely structural/index-entry footprint work, not another broad compression fix.

## Validation
- `bash -n scripts/treedb_collection_compression_matrix.sh`
- `DOCS=1000 BATCH=250 RUN_DIR=/tmp/treedb_collection_compression_smoke_$(date +%s) scripts/treedb_collection_compression_matrix.sh`
- `DOCS=100000 BATCH=16000 scripts/treedb_collection_compression_matrix.sh`
- `go test ./TreeDB/db -run 'LeafGeneration' -count 1`
- `go test ./TreeDB -run 'LeafGeneration|ValueLogRewriteOnline|ValueLogRewriteOffline' -count 1`
- `go test ./TreeDB/collections -count 1`
- `go test ./TreeDB/caching -run 'LeafGeneration|VlogGeneration.*Leaf|LeafRef' -count 1`
- `go test ./cmd/collection_load_fixture ./TreeDB/cmd/treemap -count 1`
- `go test ./TreeDB ./TreeDB/db -count 1`
- `go test ./cmd/unified_bench -count 1`
- `git diff --check`
