### PR TITLE
Add canonical collections benchmark harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ UNIFIED_BENCH_DIR := cmd/unified_bench
 BENCHPROF_DIR := cmd/benchprof
 COLLECTION_LOAD_FIXTURE_DIR := cmd/collection_load_fixture
 COLLECTION_BENCH_MATRIX_DIR := cmd/collection_bench_matrix
+COLLECTION_CANONICAL_BENCH_DIR := cmd/collection_canonical_bench
 BIN_DIR := bin
 
 BENCH_KEYCOUNTS ?= 1,10,100,1000,10000,100000,1000000
@@ -31,6 +32,8 @@ help:
 	@echo "  make benchprof      - build profile analyzer binary"
 	@echo "  make collection-load-fixture - build kept TreeDB collection load fixture"
 	@echo "  make collection-bench-matrix - build collection benchmark matrix runner"
+	@echo "  make collection-canonical-bench-bin - build canonical collection benchmark runner"
+	@echo "  make bench-collections-canonical - run canonical TreeDB collections vs SQLite benchmark"
 	@echo "  make clean          - remove ./$(BIN_DIR) and temp dirs"
 
 .PHONY: fmt
@@ -88,8 +91,8 @@ deps:
 docs-check:
 	bash ./scripts/docs_check.sh
 
-.PHONY: build build-hashdb build-treedb treemap treemap-bin unified-bench benchprof collection-load-fixture collection-bench-matrix
-build: build-hashdb build-treedb unified-bench benchprof collection-load-fixture collection-bench-matrix
+.PHONY: build build-hashdb build-treedb treemap treemap-bin unified-bench benchprof collection-load-fixture collection-bench-matrix collection-canonical-bench-bin collection-canonical-bench
+build: build-hashdb build-treedb unified-bench benchprof collection-load-fixture collection-bench-matrix collection-canonical-bench-bin
 
 build-hashdb:
 	mkdir -p $(BIN_DIR)
@@ -128,12 +131,22 @@ collection-bench-matrix:
 	mkdir -p $(BIN_DIR)
 	cd $(COLLECTION_BENCH_MATRIX_DIR) && go build -o ../../$(BIN_DIR)/collection-bench-matrix .
 
+collection-canonical-bench-bin:
+	mkdir -p $(BIN_DIR)
+	cd $(COLLECTION_CANONICAL_BENCH_DIR) && go build -o ../../$(BIN_DIR)/collection-canonical-bench .
+
+collection-canonical-bench: collection-canonical-bench-bin
+
 .PHONY: bench bench-readme
 bench: unified-bench
 	./$(BIN_DIR)/unified-bench
 
 bench-readme: unified-bench
 	./$(BIN_DIR)/unified-bench -suite readme -format markdown -seed 1 -keycounts "$(BENCH_KEYCOUNTS)" -valsize "$(BENCH_VALSIZE)" -batchsize "$(BENCH_BATCHSIZE)" -range-queries "$(BENCH_RANGE_QUERIES)" -range-span "$(BENCH_RANGE_SPAN)" -outdir "$(BENCH_OUTDIR)" -progress=false | go run ./scripts/update_readme_bench.go
+
+.PHONY: bench-collections-canonical
+bench-collections-canonical:
+	./scripts/bench_collections_canonical.sh
 
 .PHONY: benchmark-all benchmark-quick
 benchmark-all: build-hashdb

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -267,6 +267,9 @@ func run(argv []string) error {
 	if cfg.OutDir == "" {
 		cfg.OutDir = filepath.Join(os.TempDir(), "collection_canonical_bench_"+time.Now().Format("20060102_150405"))
 	}
+	if err := normalizeRunPaths(&cfg); err != nil {
+		return err
+	}
 	if cfg.Benchtime == "" {
 		cfg.Benchtime = fmt.Sprintf("%dx", cfg.Docs)
 	}
@@ -347,6 +350,15 @@ func run(argv []string) error {
 	if hasErrorCheck(canon.Checks) && !cfg.AllowIncomplete {
 		return errors.New("guardrail validation failed; rerun with -allow-incomplete to keep partial results")
 	}
+	return nil
+}
+
+func normalizeRunPaths(cfg *config) error {
+	outDir, err := filepath.Abs(cfg.OutDir)
+	if err != nil {
+		return fmt.Errorf("resolve -out-dir: %w", err)
+	}
+	cfg.OutDir = outDir
 	return nil
 }
 

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -415,8 +415,8 @@ func parseConfig(args []string) (config, error) {
 	if cfg.BatchSize <= 0 {
 		return config{}, errors.New("-batch-size must be > 0")
 	}
-	if cfg.Indexes < 0 {
-		return config{}, errors.New("-indexes must be >= 0")
+	if cfg.Indexes < 0 || cfg.Indexes > 3 {
+		return config{}, errors.New("-indexes must be 0, 1, 2, or 3")
 	}
 	if cfg.Count <= 0 {
 		return config{}, errors.New("-count must be > 0")

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -279,7 +279,10 @@ func run(argv []string) error {
 	}
 
 	branch := resolveBranch(cfg.RepoRoot)
-	commit, _ := gitOutput(cfg.RepoRoot, "rev-parse", "--short=12", "HEAD")
+	commit, err := gitOutput(cfg.RepoRoot, "rev-parse", "--short=12", "HEAD")
+	if err != nil {
+		return fmt.Errorf("resolve git commit: %w", err)
+	}
 	commandLine := argv
 	if rawCommand := strings.TrimSpace(os.Getenv(envCanonicalCommandLine)); rawCommand != "" {
 		commandLine = []string{rawCommand}
@@ -970,8 +973,12 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 	treeDBConfig := compactedTreeDBConfigName(canon)
 	sqliteJSONConfig := sqliteJSONConfigName(canon)
 	sqliteNativeConfig := sqliteNativeConfigName(canon)
+	sqliteRows := hasSQLiteRows(canon.Results)
+	sqliteSkipped := canon.Config.SkipSQLite || !sqliteRows
 	if canon.Config.SkipSQLite {
 		add("warning", "sqlite.skipped", "SQLite rows were intentionally skipped; fair compacted SQLite comparisons are omitted")
+	} else if !sqliteRows {
+		add("warning", "sqlite.auto_skipped", "SQLite rows are absent; treating them as auto-skipped because SQLite benchmarks may be unavailable")
 	} else {
 		if findResult(canon.Results, sqliteJSONConfig, phaseSQLiteVacuum) == nil {
 			add("error", "missing_sqlite_json_vacuum", "SQLite JSON VACUUM result is required for fair compacted-state comparison")
@@ -992,7 +999,7 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 			add("error", "compacted_compared_to_sqlite_post_insert", fmt.Sprintf("%s compares TreeDB compacted phase %s against SQLite phase %s", cmp.ComparisonName, cmp.TreeDBPhase, cmp.SQLitePhase))
 		}
 	}
-	if !canon.Config.SkipSQLite {
+	if !sqliteSkipped {
 		for _, treedbPhase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
 			if findResult(canon.Results, treeDBConfig, treedbPhase) == nil {
 				continue
@@ -1005,6 +1012,15 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 		}
 	}
 	return checks
+}
+
+func hasSQLiteRows(rows []resultRow) bool {
+	for _, r := range rows {
+		if strings.HasPrefix(r.ConfigName, "sqlite_") || strings.HasPrefix(r.Engine, "sqlite") {
+			return true
+		}
+	}
+	return false
 }
 
 func finalizeRunMetadata(canon *canonicalRun) {
@@ -1336,7 +1352,8 @@ func writeCSV(path string, rows []resultRow) error {
 			return err
 		}
 	}
-	return nil
+	w.Flush()
+	return w.Error()
 }
 
 func writeJSON(path string, v any) error {
@@ -1657,11 +1674,32 @@ func markdownEscape(v string) string {
 	return v
 }
 
+func markdownInlineCode(v string) string {
+	v = markdownEscape(v)
+	maxRun := 0
+	run := 0
+	for _, r := range v {
+		if r == '`' {
+			run++
+			if run > maxRun {
+				maxRun = run
+			}
+			continue
+		}
+		run = 0
+	}
+	fence := strings.Repeat("`", maxRun+1)
+	if strings.HasPrefix(v, "`") || strings.HasSuffix(v, "`") {
+		return fence + " " + v + " " + fence
+	}
+	return fence + v + fence
+}
+
 func writeKVTable(sb *strings.Builder, rows [][2]string) {
 	sb.WriteString("| Key | Value |\n")
 	sb.WriteString("| --- | --- |\n")
 	for _, row := range rows {
-		sb.WriteString(fmt.Sprintf("| `%s` | `%s` |\n", row[0], markdownEscape(row[1])))
+		sb.WriteString(fmt.Sprintf("| %s | %s |\n", markdownInlineCode(row[0]), markdownInlineCode(row[1])))
 	}
 }
 

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -1,0 +1,1597 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const schemaVersion = "collections-canonical-benchmark/v1"
+const envCanonicalCommandLine = "COLLECTION_CANONICAL_BENCH_COMMAND"
+
+const (
+	phasePostInsert               = "post_insert"
+	phaseOnlineOnePassMaintenance = "online_one_pass_maintenance"
+	phaseOfflineRewrite           = "offline_rewrite"
+	phaseFullLeafgenPackGC        = "full_leafgen_pack_gc"
+	phaseSQLiteVacuum             = "sqlite_vacuum"
+)
+
+type config struct {
+	RepoRoot                  string
+	OutDir                    string
+	Docs                      int
+	BatchSize                 int
+	Indexes                   int
+	Benchtime                 string
+	Count                     int
+	TreeEngine                string
+	Profile                   string
+	Formats                   string
+	StorageCells              string
+	LeafSegmentTargetBytes    int64
+	LeafgenPackFrameK         int
+	FullLeafgenForce          bool
+	FullLeafgenMaxGenerations int
+	FullLeafgenIndexVacuum    string
+	SkipTimedMatrix           bool
+	SkipOfflineRewrite        bool
+	SkipFullLeafgen           bool
+	SkipSQLite                bool
+	AllowIncomplete           bool
+}
+
+type canonicalRun struct {
+	SchemaVersion string            `json:"schema_version"`
+	GeneratedAt   string            `json:"generated_at"`
+	RunDir        string            `json:"run_dir"`
+	Worktree      string            `json:"worktree"`
+	Branch        string            `json:"branch"`
+	Commit        string            `json:"commit"`
+	CommandLine   []string          `json:"command_line"`
+	Config        canonicalConfig   `json:"config"`
+	Artifacts     map[string]string `json:"artifacts"`
+	Commands      []commandRecord   `json:"commands"`
+	Results       []resultRow       `json:"results"`
+	Comparisons   []comparisonRow   `json:"comparisons"`
+	Checks        []guardrailCheck  `json:"guardrail_checks"`
+}
+
+type canonicalConfig struct {
+	Docs                      int      `json:"docs"`
+	BatchSize                 int      `json:"batch_size"`
+	Indexes                   int      `json:"indexes"`
+	Benchtime                 string   `json:"benchtime"`
+	Count                     int      `json:"count"`
+	TreeEngine                string   `json:"tree_engine"`
+	Profile                   string   `json:"profile"`
+	Formats                   []string `json:"formats"`
+	StorageCells              string   `json:"storage_cells"`
+	LeafSegmentTargetBytes    int64    `json:"leaf_segment_target_bytes"`
+	LeafgenPackFrameK         int      `json:"leafgen_pack_frame_k"`
+	FullLeafgenForce          bool     `json:"full_leafgen_force"`
+	FullLeafgenMaxGenerations int      `json:"full_leafgen_max_generations"`
+	FullLeafgenIndexVacuum    string   `json:"full_leafgen_index_vacuum"`
+}
+
+type commandRecord struct {
+	Name     string            `json:"name"`
+	Command  []string          `json:"command"`
+	Env      map[string]string `json:"env,omitempty"`
+	WorkDir  string            `json:"work_dir"`
+	LogPath  string            `json:"log_path,omitempty"`
+	ExitCode int               `json:"exit_code"`
+	Duration string            `json:"duration"`
+}
+
+type resultRow struct {
+	GeneratedAt      string             `json:"generated_at,omitempty"`
+	RunDir           string             `json:"run_dir,omitempty"`
+	Worktree         string             `json:"worktree,omitempty"`
+	Branch           string             `json:"branch,omitempty"`
+	Commit           string             `json:"commit,omitempty"`
+	CommandLine      []string           `json:"command_line,omitempty"`
+	ConfigName       string             `json:"config_name"`
+	Engine           string             `json:"engine"`
+	Format           string             `json:"format"`
+	Shape            string             `json:"shape"`
+	IndexCount       int                `json:"index_count"`
+	DocumentCount    int                `json:"document_count"`
+	BenchmarkName    string             `json:"benchmark_name"`
+	Phase            string             `json:"phase"`
+	MaintenanceMode  string             `json:"maintenance_mode"`
+	TotalBytes       *int64             `json:"total_bytes,omitempty"`
+	BytesPerDoc      *float64           `json:"bytes_per_doc,omitempty"`
+	DocsPerSec       *float64           `json:"docs_per_sec,omitempty"`
+	NsPerDoc         *float64           `json:"ns_per_doc,omitempty"`
+	BatchSize        int                `json:"batch_size,omitempty"`
+	BenchmarkTimed   bool               `json:"benchmark_timed"`
+	MeasurementKind  string             `json:"measurement_kind"`
+	MeasurementNote  string             `json:"measurement_note,omitempty"`
+	CompactionFlags  map[string]string  `json:"compaction_flags,omitempty"`
+	SourceArtifact   string             `json:"source_artifact,omitempty"`
+	MaintenanceStats map[string]float64 `json:"maintenance_stats,omitempty"`
+	Extra            map[string]string  `json:"extra,omitempty"`
+}
+
+type comparisonRow struct {
+	GeneratedAt       string   `json:"generated_at,omitempty"`
+	RunDir            string   `json:"run_dir,omitempty"`
+	Worktree          string   `json:"worktree,omitempty"`
+	Branch            string   `json:"branch,omitempty"`
+	Commit            string   `json:"commit,omitempty"`
+	CommandLine       []string `json:"command_line,omitempty"`
+	ComparisonName    string   `json:"comparison_name"`
+	TreeDBConfigName  string   `json:"treedb_config_name"`
+	TreeDBPhase       string   `json:"treedb_phase"`
+	SQLiteConfigName  string   `json:"sqlite_config_name"`
+	SQLitePhase       string   `json:"sqlite_phase"`
+	TreeDBBytesPerDoc float64  `json:"treedb_bytes_per_doc"`
+	SQLiteBytesPerDoc float64  `json:"sqlite_bytes_per_doc"`
+	SmallerRatio      float64  `json:"smaller_ratio"`
+	ComparisonBasis   string   `json:"comparison_basis"`
+}
+
+type guardrailCheck struct {
+	Severity string `json:"severity"`
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+}
+
+type collectionReport struct {
+	GeneratedAt         string          `json:"generated_at"`
+	Status              string          `json:"status"`
+	ExecutionPath       string          `json:"execution_path"`
+	BenchmarkEngine     string          `json:"benchmark_engine"`
+	DocumentFormat      string          `json:"document_format"`
+	StoragePolicy       string          `json:"storage_policy"`
+	Worktree            string          `json:"worktree"`
+	Branch              string          `json:"branch"`
+	Commit              string          `json:"commit"`
+	BenchPattern        string          `json:"bench_pattern"`
+	Count               int             `json:"count"`
+	CollectionBatchSize int             `json:"collection_batch_size"`
+	Sections            []reportSection `json:"sections"`
+}
+
+type reportSection struct {
+	Title      string            `json:"title"`
+	Benchmarks []reportBenchmark `json:"benchmarks"`
+}
+
+type reportBenchmark struct {
+	Name        string             `json:"name"`
+	Section     string             `json:"section"`
+	Description string             `json:"description"`
+	MeanNSPerOp float64            `json:"mean_ns_per_op"`
+	OpsPerSec   float64            `json:"ops_per_sec"`
+	MeanMetrics map[string]float64 `json:"mean_metrics"`
+}
+
+type fixtureSummary struct {
+	GeneratedAt                string                 `json:"generated_at"`
+	Dir                        string                 `json:"dir"`
+	Collection                 string                 `json:"collection"`
+	DocumentFormat             string                 `json:"document_format"`
+	Profile                    string                 `json:"profile"`
+	Docs                       int                    `json:"docs"`
+	BatchSize                  int                    `json:"batch_size"`
+	IndexCount                 int                    `json:"index_count"`
+	DataOuterLeavesInValueLog  bool                   `json:"data_outer_leaves_in_value_log"`
+	IndexOuterLeavesInValueLog bool                   `json:"index_outer_leaves_in_value_log"`
+	WallTiming                 timingSummary          `json:"wall_timing"`
+	InsertTiming               timingSummary          `json:"insert_timing"`
+	DiskUsageBeforeMaintenance *diskUsageSummary      `json:"disk_usage_before_maintenance"`
+	DiskUsageFinal             *diskUsageSummary      `json:"disk_usage_final"`
+	LeafGeneration             *leafGenerationSummary `json:"leaf_generation"`
+	IndexVacuum                *fixtureIndexVacuum    `json:"index_vacuum"`
+}
+
+type timingSummary struct {
+	Seconds   float64 `json:"seconds"`
+	SecPerOp  float64 `json:"sec_per_op"`
+	OpsPerSec float64 `json:"ops_per_sec"`
+}
+
+type diskUsageSummary struct {
+	TotalBytes  int64   `json:"total_bytes"`
+	BytesPerDoc float64 `json:"bytes_per_doc"`
+}
+
+type leafGenerationSummary struct {
+	Enabled                bool   `json:"enabled"`
+	Force                  bool   `json:"force"`
+	MaxGenerations         int    `json:"max_generations,omitempty"`
+	PlanAdmission          string `json:"plan_admission,omitempty"`
+	DiskBytesBefore        int64  `json:"disk_bytes_before,omitempty"`
+	DiskBytesAfterPack     int64  `json:"disk_bytes_after_pack,omitempty"`
+	DiskBytesAfterGC       int64  `json:"disk_bytes_after_gc,omitempty"`
+	CandidateGenerations   int    `json:"candidate_generations,omitempty"`
+	CandidateBytesTotal    int64  `json:"candidate_bytes_total,omitempty"`
+	CandidateBytesLive     int64  `json:"candidate_bytes_live,omitempty"`
+	CandidateBytesDead     int64  `json:"candidate_bytes_dead,omitempty"`
+	CandidateBytesToCopy   int64  `json:"candidate_bytes_to_copy,omitempty"`
+	ExpectedReclaimBytes   int64  `json:"expected_reclaim_bytes,omitempty"`
+	PackGenerationsMatched int    `json:"pack_generations_matched,omitempty"`
+	PackLeafPagesCopied    int    `json:"pack_leaf_pages_copied,omitempty"`
+	PackLeafFramesWritten  int    `json:"pack_leaf_frames_written,omitempty"`
+	PackMaxLeafFrameK      int    `json:"pack_max_leaf_frame_k,omitempty"`
+	PackBytesCopied        int64  `json:"pack_bytes_copied,omitempty"`
+	GCGenerationsDeleted   int    `json:"gc_generations_deleted,omitempty"`
+	GCFilesDeleted         int    `json:"gc_files_deleted,omitempty"`
+	GCBytesDeleted         int64  `json:"gc_bytes_deleted,omitempty"`
+}
+
+type fixtureIndexVacuum struct {
+	Mode               string        `json:"mode"`
+	Enabled            bool          `json:"enabled"`
+	Timing             timingSummary `json:"timing"`
+	DiskBytesBefore    int64         `json:"disk_bytes_before,omitempty"`
+	DiskBytesAfter     int64         `json:"disk_bytes_after,omitempty"`
+	IndexDBBytesBefore int64         `json:"index_db_bytes_before,omitempty"`
+	IndexDBBytesAfter  int64         `json:"index_db_bytes_after,omitempty"`
+}
+
+func main() {
+	if err := run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "collection-canonical-bench: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(argv []string) error {
+	cfg, err := parseConfig(argv[1:])
+	if err != nil {
+		return err
+	}
+	if cfg.RepoRoot == "" {
+		cfg.RepoRoot, err = gitOutput("", "rev-parse", "--show-toplevel")
+		if err != nil {
+			return err
+		}
+	}
+	if cfg.OutDir == "" {
+		cfg.OutDir = filepath.Join(os.TempDir(), "collection_canonical_bench_"+time.Now().Format("20060102_150405"))
+	}
+	if cfg.Benchtime == "" {
+		cfg.Benchtime = fmt.Sprintf("%dx", cfg.Docs)
+	}
+	formats := splitCSV(cfg.Formats)
+	if len(formats) == 0 {
+		return errors.New("-formats must contain at least one value")
+	}
+	if err := os.MkdirAll(filepath.Join(cfg.OutDir, "logs"), 0755); err != nil {
+		return err
+	}
+
+	branch, _ := gitOutput(cfg.RepoRoot, "branch", "--show-current")
+	commit, _ := gitOutput(cfg.RepoRoot, "rev-parse", "--short=12", "HEAD")
+	commandLine := argv
+	if rawCommand := strings.TrimSpace(os.Getenv(envCanonicalCommandLine)); rawCommand != "" {
+		commandLine = []string{rawCommand}
+	}
+	canon := &canonicalRun{
+		SchemaVersion: schemaVersion,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		RunDir:        cfg.OutDir,
+		Worktree:      cfg.RepoRoot,
+		Branch:        branch,
+		Commit:        commit,
+		CommandLine:   commandLine,
+		Config: canonicalConfig{
+			Docs:                      cfg.Docs,
+			BatchSize:                 cfg.BatchSize,
+			Indexes:                   cfg.Indexes,
+			Benchtime:                 cfg.Benchtime,
+			Count:                     cfg.Count,
+			TreeEngine:                cfg.TreeEngine,
+			Profile:                   cfg.Profile,
+			Formats:                   formats,
+			StorageCells:              cfg.StorageCells,
+			LeafSegmentTargetBytes:    cfg.LeafSegmentTargetBytes,
+			LeafgenPackFrameK:         cfg.LeafgenPackFrameK,
+			FullLeafgenForce:          cfg.FullLeafgenForce,
+			FullLeafgenMaxGenerations: cfg.FullLeafgenMaxGenerations,
+			FullLeafgenIndexVacuum:    cfg.FullLeafgenIndexVacuum,
+		},
+		Artifacts: map[string]string{},
+	}
+
+	fmt.Printf("canonical collections benchmark run dir: %s\n", cfg.OutDir)
+	if err := runBuildHelpers(cfg, canon); err != nil {
+		return err
+	}
+	if !cfg.SkipTimedMatrix {
+		if err := runTimedMatrix(cfg, canon); err != nil {
+			return err
+		}
+	}
+	if !cfg.SkipOfflineRewrite {
+		if err := runOfflineRewriteMatrix(cfg, canon); err != nil {
+			return err
+		}
+	}
+	if !cfg.SkipFullLeafgen {
+		if err := runFullLeafgenFixture(cfg, canon); err != nil {
+			return err
+		}
+	}
+
+	canon.Comparisons = buildCompactedComparisons(canon)
+	finalizeRunMetadata(canon)
+	canon.Checks = validateCanonicalRun(canon)
+	if err := writeOutputs(canon); err != nil {
+		return err
+	}
+	fmt.Printf("wrote %s\n", filepath.Join(cfg.OutDir, "benchmark_summary.md"))
+	fmt.Printf("wrote %s\n", filepath.Join(cfg.OutDir, "benchmark_results.json"))
+	fmt.Printf("wrote %s\n", filepath.Join(cfg.OutDir, "benchmark_matrix.csv"))
+	if hasErrorCheck(canon.Checks) && !cfg.AllowIncomplete {
+		return errors.New("guardrail validation failed; rerun with -allow-incomplete to keep partial results")
+	}
+	return nil
+}
+
+func parseConfig(args []string) (config, error) {
+	cfg := config{
+		Docs:                      100000,
+		BatchSize:                 16000,
+		Indexes:                   2,
+		Count:                     1,
+		TreeEngine:                "production_fast",
+		Profile:                   "fast",
+		Formats:                   "json,template-v1",
+		StorageCells:              "index-vlog",
+		LeafSegmentTargetBytes:    1048576,
+		LeafgenPackFrameK:         16,
+		FullLeafgenForce:          true,
+		FullLeafgenMaxGenerations: 0,
+		FullLeafgenIndexVacuum:    "offline",
+	}
+	fs := flag.NewFlagSet("collection_canonical_bench", flag.ContinueOnError)
+	fs.StringVar(&cfg.RepoRoot, "repo-root", "", "Repository root; defaults to git rev-parse --show-toplevel")
+	fs.StringVar(&cfg.OutDir, "out-dir", "", "Output directory; defaults to /tmp/collection_canonical_bench_<timestamp>")
+	fs.IntVar(&cfg.Docs, "docs", cfg.Docs, "Document count for canonical runs")
+	fs.IntVar(&cfg.BatchSize, "batch-size", cfg.BatchSize, "Batch size for collection inserts")
+	fs.IntVar(&cfg.Indexes, "indexes", cfg.Indexes, "Secondary index count for primary comparison")
+	fs.StringVar(&cfg.Benchtime, "benchtime", "", "go test -benchtime for timed matrix; defaults to <docs>x")
+	fs.IntVar(&cfg.Count, "count", cfg.Count, "go test -count for timed matrix")
+	fs.StringVar(&cfg.TreeEngine, "tree-engine", cfg.TreeEngine, "TreeDB collection benchmark engine")
+	fs.StringVar(&cfg.Profile, "profile", cfg.Profile, "Fixture/raw TreeDB profile")
+	fs.StringVar(&cfg.Formats, "formats", cfg.Formats, "Comma-separated TreeDB document formats for timed matrix")
+	fs.StringVar(&cfg.StorageCells, "storage-cells", cfg.StorageCells, "collection_bench_matrix storage cells")
+	fs.Int64Var(&cfg.LeafSegmentTargetBytes, "leaf-segment-target-bytes", cfg.LeafSegmentTargetBytes, "Leaf vlog segment target bytes used by canonical compacted runs")
+	fs.IntVar(&cfg.LeafgenPackFrameK, "leafgen-pack-frame-k", cfg.LeafgenPackFrameK, "Leaf pages per grouped frame for full leafgen pack")
+	fs.BoolVar(&cfg.FullLeafgenForce, "leafgen-pack-force", cfg.FullLeafgenForce, "Force full leafgen pack candidate selection")
+	fs.IntVar(&cfg.FullLeafgenMaxGenerations, "leafgen-pack-max-generations", cfg.FullLeafgenMaxGenerations, "Max generations to pack in full leafgen phase; 0 means no limit")
+	fs.StringVar(&cfg.FullLeafgenIndexVacuum, "index-vacuum", cfg.FullLeafgenIndexVacuum, "Index vacuum mode for full leafgen fixture: offline, online, auto, or none")
+	fs.BoolVar(&cfg.SkipTimedMatrix, "skip-timed-matrix", false, "Skip timed TreeDB/SQLite benchmark matrix")
+	fs.BoolVar(&cfg.SkipOfflineRewrite, "skip-offline-rewrite", false, "Skip PR 1096-style offline rewrite matrix")
+	fs.BoolVar(&cfg.SkipFullLeafgen, "skip-full-leafgen", false, "Skip full leafgen pack/GC fixture")
+	fs.BoolVar(&cfg.SkipSQLite, "skip-sqlite", false, "Skip SQLite cells in timed matrix")
+	fs.BoolVar(&cfg.AllowIncomplete, "allow-incomplete", false, "Write report even when guardrail checks fail")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	if cfg.Docs <= 0 {
+		return config{}, errors.New("-docs must be > 0")
+	}
+	if cfg.BatchSize <= 0 {
+		return config{}, errors.New("-batch-size must be > 0")
+	}
+	if cfg.Indexes < 0 {
+		return config{}, errors.New("-indexes must be >= 0")
+	}
+	if cfg.Count <= 0 {
+		return config{}, errors.New("-count must be > 0")
+	}
+	if cfg.LeafSegmentTargetBytes < 0 {
+		return config{}, errors.New("-leaf-segment-target-bytes must be >= 0")
+	}
+	if cfg.LeafgenPackFrameK < 0 {
+		return config{}, errors.New("-leafgen-pack-frame-k must be >= 0")
+	}
+	if cfg.FullLeafgenMaxGenerations < 0 {
+		return config{}, errors.New("-leafgen-pack-max-generations must be >= 0")
+	}
+	return cfg, nil
+}
+
+func runBuildHelpers(cfg config, canon *canonicalRun) error {
+	return runLoggedCommand(cfg, canon, "build_helpers", nil, "make", "collection-load-fixture", "treemap-bin")
+}
+
+func runTimedMatrix(cfg config, canon *canonicalRun) error {
+	matrixDir := filepath.Join(cfg.OutDir, "timed_matrix")
+	treePattern := fmt.Sprintf("^BenchmarkCollectionShapeInsertBatch$/^indexes_%d$", cfg.Indexes)
+	sqlitePattern := fmt.Sprintf("^(BenchmarkSQLiteShapeInsertBatchJSON|BenchmarkSQLiteShapeInsertBatchNativeColumns)$/^indexes_%d$", cfg.Indexes)
+	args := []string{
+		"run", "./cmd/collection_bench_matrix",
+		"-out-dir", matrixDir,
+		"-formats", cfg.Formats,
+		"-storage-cells", cfg.StorageCells,
+		"-tree-bench-pattern", treePattern,
+		"-sqlite-bench-pattern", sqlitePattern,
+		"-batch-size", strconv.Itoa(cfg.BatchSize),
+		"-benchtime", cfg.Benchtime,
+		"-count", strconv.Itoa(cfg.Count),
+		"-leaf-segment-target-bytes", strconv.FormatInt(cfg.LeafSegmentTargetBytes, 10),
+		"-leafgen-pack-frame-k", strconv.Itoa(cfg.LeafgenPackFrameK),
+	}
+	if cfg.SkipSQLite {
+		args = append(args, "-skip-sqlite")
+	}
+	if err := runLoggedCommand(cfg, canon, "timed_matrix", nil, "go", args...); err != nil {
+		return err
+	}
+	canon.Artifacts["timed_matrix_dir"] = matrixDir
+	return parseTimedMatrixReports(canon, matrixDir, cfg)
+}
+
+func runOfflineRewriteMatrix(cfg config, canon *canonicalRun) error {
+	rewriteDir := filepath.Join(cfg.OutDir, "offline_rewrite")
+	env := map[string]string{
+		"RUN_DIR": rewriteDir,
+		"DOCS":    strconv.Itoa(cfg.Docs),
+		"BATCH":   strconv.Itoa(cfg.BatchSize),
+		"PROFILE": cfg.Profile,
+	}
+	if err := runLoggedCommand(cfg, canon, "offline_rewrite_matrix", env, "bash", "./scripts/treedb_collection_compression_matrix.sh"); err != nil {
+		return err
+	}
+	canon.Artifacts["offline_rewrite_dir"] = rewriteDir
+	canon.Artifacts["offline_rewrite_tsv"] = filepath.Join(rewriteDir, "compression_matrix.tsv")
+	return parseOfflineRewriteTSV(canon, filepath.Join(rewriteDir, "compression_matrix.tsv"), cfg)
+}
+
+func runFullLeafgenFixture(cfg config, canon *canonicalRun) error {
+	fullDir := filepath.Join(cfg.OutDir, "full_leafgen_pack_gc", canonicalConfigName("treedb", "template-v1", "collection", cfg.Indexes))
+	summaryPath := filepath.Join(cfg.OutDir, "full_leafgen_pack_gc", "fixture_summary.json")
+	stderrPath := filepath.Join(cfg.OutDir, "logs", "full_leafgen_pack_gc.stderr.log")
+	if err := os.MkdirAll(filepath.Dir(summaryPath), 0755); err != nil {
+		return err
+	}
+	args := []string{
+		"-json",
+		"-dir", fullDir,
+		"-reset",
+		"-docs", strconv.Itoa(cfg.Docs),
+		"-batch-size", strconv.Itoa(cfg.BatchSize),
+		"-format", "template-v1",
+		"-indexes", strconv.Itoa(cfg.Indexes),
+		"-profile", cfg.Profile,
+		"-progress=false",
+		"-leaf-segment-target-bytes", strconv.FormatInt(cfg.LeafSegmentTargetBytes, 10),
+		"-leafgen-pack-gc",
+		"-leafgen-pack-force=" + strconv.FormatBool(cfg.FullLeafgenForce),
+		"-leafgen-pack-max-generations", strconv.Itoa(cfg.FullLeafgenMaxGenerations),
+		"-leafgen-pack-frame-k", strconv.Itoa(cfg.LeafgenPackFrameK),
+		"-index-vacuum", cfg.FullLeafgenIndexVacuum,
+	}
+	start := time.Now()
+	cmd := exec.Command(filepath.Join(cfg.RepoRoot, "bin", "collection-load-fixture"), args...)
+	cmd.Dir = cfg.RepoRoot
+	stdout, err := os.Create(summaryPath)
+	if err != nil {
+		return err
+	}
+	defer stdout.Close()
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		return err
+	}
+	defer stderr.Close()
+	cmd.Stdout = stdout
+	cmd.Stderr = io.MultiWriter(os.Stderr, stderr)
+	err = cmd.Run()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+	canon.Commands = append(canon.Commands, commandRecord{
+		Name:     "full_leafgen_pack_gc",
+		Command:  append([]string{filepath.Join(cfg.RepoRoot, "bin", "collection-load-fixture")}, args...),
+		WorkDir:  cfg.RepoRoot,
+		LogPath:  stderrPath,
+		ExitCode: exitCode,
+		Duration: time.Since(start).String(),
+	})
+	if err != nil {
+		return fmt.Errorf("full leafgen fixture: %w", err)
+	}
+	canon.Artifacts["full_leafgen_dir"] = filepath.Dir(summaryPath)
+	canon.Artifacts["full_leafgen_fixture_dir"] = fullDir
+	canon.Artifacts["full_leafgen_summary_json"] = summaryPath
+	return parseFullLeafgenSummary(canon, summaryPath, cfg)
+}
+
+func runLoggedCommand(cfg config, canon *canonicalRun, name string, env map[string]string, bin string, args ...string) error {
+	logPath := filepath.Join(cfg.OutDir, "logs", name+".log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
+		return err
+	}
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = cfg.RepoRoot
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	cmd.Stdout = io.MultiWriter(os.Stdout, logFile)
+	cmd.Stderr = io.MultiWriter(os.Stderr, logFile)
+	start := time.Now()
+	err = cmd.Run()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+	canon.Commands = append(canon.Commands, commandRecord{
+		Name:     name,
+		Command:  append([]string{bin}, args...),
+		Env:      env,
+		WorkDir:  cfg.RepoRoot,
+		LogPath:  logPath,
+		ExitCode: exitCode,
+		Duration: time.Since(start).String(),
+	})
+	if err != nil {
+		return fmt.Errorf("%s: %w (log: %s)", name, err, logPath)
+	}
+	return nil
+}
+
+func parseTimedMatrixReports(canon *canonicalRun, matrixDir string, cfg config) error {
+	return filepath.WalkDir(matrixDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Base(path) != "collections_report.json" {
+			return nil
+		}
+		var report collectionReport
+		if err := readJSONFile(path, &report); err != nil {
+			return err
+		}
+		for _, section := range report.Sections {
+			for _, bench := range section.Benchmarks {
+				if strings.Contains(bench.Name, "BenchmarkCollectionShapeInsertBatch") {
+					addTreeDBTimedRows(canon, report, bench, path, cfg)
+				}
+				if strings.Contains(bench.Name, "BenchmarkSQLiteShapeInsertBatch") {
+					addSQLiteTimedRows(canon, report, bench, path, cfg)
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func addTreeDBTimedRows(canon *canonicalRun, report collectionReport, bench reportBenchmark, path string, cfg config) {
+	metrics := bench.MeanMetrics
+	docs := int(metricDefault(metrics, "stored_docs", float64(cfg.Docs)))
+	indexes := int(metricDefault(metrics, "indexes/doc", float64(cfg.Indexes)))
+	format := canonicalFormat(report.DocumentFormat)
+	configName := canonicalConfigName("treedb", format, "collection", indexes)
+	total := int64(metricDefault(metrics, "disk_total_bytes", 0))
+	bpd := bytesPerDoc(total, docs)
+	ns := bench.MeanNSPerOp
+	canon.Results = append(canon.Results, resultRow{
+		ConfigName:       configName,
+		Engine:           report.BenchmarkEngine,
+		Format:           format,
+		Shape:            "collection",
+		IndexCount:       indexes,
+		DocumentCount:    docs,
+		BenchmarkName:    bench.Name,
+		Phase:            phasePostInsert,
+		MaintenanceMode:  "none",
+		TotalBytes:       int64Ptr(total),
+		BytesPerDoc:      floatPtr(bpd),
+		DocsPerSec:       floatPtr(bench.OpsPerSec),
+		NsPerDoc:         floatPtr(ns),
+		BatchSize:        cfg.BatchSize,
+		BenchmarkTimed:   true,
+		MeasurementKind:  "go_benchmark",
+		MeasurementNote:  "post-insert benchmark size; not compacted",
+		SourceArtifact:   path,
+		MaintenanceStats: copyMetrics(metrics, "prepare_ns/doc", "publish_ns/doc", "secondary_runs_ns/doc", "disk_total_bytes"),
+	})
+
+	onlineTotal, onlineMetric := firstMetric(metrics,
+		"leafgen_pack_gc_vacuum_disk_total_bytes_after",
+		"leafgen_pack_gc_disk_total_bytes_after",
+		"vlog_rewrite_gc_vacuum_disk_total_bytes_after",
+		"vlog_rewrite_gc_disk_total_bytes_after",
+	)
+	if onlineMetric == "" {
+		return
+	}
+	onlineStats := copyMetrics(metrics,
+		"vlog_rewrite_ns/op",
+		"vlog_rewrite_records_copied",
+		"vlog_rewrite_segments_before",
+		"vlog_rewrite_segments_after",
+		"leafgen_plan_candidate_generations",
+		"leafgen_pack_generations_matched",
+		"leafgen_pack_leaf_frames_written",
+		"leafgen_pack_max_leaf_frame_k",
+		"leafgen_gc_bytes_deleted",
+		"leafgen_pack_gc_vacuum_ns/op",
+	)
+	canon.Results = append(canon.Results, resultRow{
+		ConfigName:      configName,
+		Engine:          report.BenchmarkEngine,
+		Format:          format,
+		Shape:           "collection",
+		IndexCount:      indexes,
+		DocumentCount:   docs,
+		BenchmarkName:   bench.Name,
+		Phase:           phaseOnlineOnePassMaintenance,
+		MaintenanceMode: "online_one_pass_vlog_rewrite_then_one_leafgen_pack",
+		TotalBytes:      int64Ptr(int64(onlineTotal)),
+		BytesPerDoc:     floatPtr(onlineTotal / float64(docs)),
+		BatchSize:       cfg.BatchSize,
+		BenchmarkTimed:  false,
+		MeasurementKind: "benchmark_post_processing",
+		MeasurementNote: "partial online maintenance from the timed benchmark harness; not full compaction",
+		CompactionFlags: map[string]string{
+			"report-vlog-rewrite":                "true",
+			"report-leafgen-pack-gc":             "true",
+			"leafgen-pack-force":                 "false",
+			"leafgen-pack-max-generations":       "1",
+			"leafgen-pack-frame-k":               strconv.Itoa(cfg.LeafgenPackFrameK),
+			"leaf-segment-target-bytes":          strconv.FormatInt(cfg.LeafSegmentTargetBytes, 10),
+			"post-maintenance-index-vacuum":      "online",
+			"selected-online-total-bytes-metric": onlineMetric,
+		},
+		SourceArtifact:   path,
+		MaintenanceStats: onlineStats,
+	})
+}
+
+func addSQLiteTimedRows(canon *canonicalRun, report collectionReport, bench reportBenchmark, path string, cfg config) {
+	metrics := bench.MeanMetrics
+	docs := int(metricDefault(metrics, "stored_docs", float64(cfg.Docs)))
+	indexes := int(metricDefault(metrics, "indexes/doc", float64(cfg.Indexes)))
+	format := "json"
+	if strings.Contains(strings.ToLower(bench.Name), "nativecolumns") {
+		format = "native-columns"
+	}
+	configName := canonicalConfigName("sqlite", format, "collection", indexes)
+	total := int64(metricDefault(metrics, "disk_total_bytes", 0))
+	canon.Results = append(canon.Results, resultRow{
+		ConfigName:      configName,
+		Engine:          report.BenchmarkEngine,
+		Format:          format,
+		Shape:           "collection",
+		IndexCount:      indexes,
+		DocumentCount:   docs,
+		BenchmarkName:   bench.Name,
+		Phase:           phasePostInsert,
+		MaintenanceMode: "none",
+		TotalBytes:      int64Ptr(total),
+		BytesPerDoc:     floatPtr(bytesPerDoc(total, docs)),
+		DocsPerSec:      floatPtr(bench.OpsPerSec),
+		NsPerDoc:        floatPtr(bench.MeanNSPerOp),
+		BatchSize:       cfg.BatchSize,
+		BenchmarkTimed:  true,
+		MeasurementKind: "go_benchmark",
+		MeasurementNote: "SQLite post-insert size before VACUUM; not compacted",
+		SourceArtifact:  path,
+	})
+	vacuumTotal, ok := metrics["sqlite_vacuum_disk_total_bytes_after"]
+	if !ok {
+		return
+	}
+	vacuumNS := metricDefault(metrics, "sqlite_vacuum_ns/op", 0)
+	row := resultRow{
+		ConfigName:      configName,
+		Engine:          report.BenchmarkEngine,
+		Format:          format,
+		Shape:           "collection",
+		IndexCount:      indexes,
+		DocumentCount:   docs,
+		BenchmarkName:   bench.Name,
+		Phase:           phaseSQLiteVacuum,
+		MaintenanceMode: "sqlite_vacuum",
+		TotalBytes:      int64Ptr(int64(vacuumTotal)),
+		BytesPerDoc:     floatPtr(vacuumTotal / float64(docs)),
+		BatchSize:       cfg.BatchSize,
+		BenchmarkTimed:  false,
+		MeasurementKind: "benchmark_post_processing",
+		MeasurementNote: "SQLite compacted baseline; use this for compacted-state comparisons",
+		CompactionFlags: map[string]string{"sqlite": "VACUUM"},
+		SourceArtifact:  path,
+		MaintenanceStats: copyMetrics(metrics,
+			"sqlite_vacuum_ns/op",
+			"sqlite_vacuum_disk_total_bytes_before",
+			"sqlite_vacuum_disk_total_bytes_after",
+			"sqlite_vacuum_disk_total_bytes_delta",
+		),
+	}
+	if vacuumNS > 0 {
+		row.MaintenanceStats["sqlite_vacuum_ops/sec"] = 1e9 / vacuumNS
+	}
+	canon.Results = append(canon.Results, row)
+}
+
+func parseOfflineRewriteTSV(canon *canonicalRun, path string, cfg config) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	var header []string
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if header == nil {
+			header = fields
+			continue
+		}
+		row := map[string]string{}
+		for i, key := range header {
+			if i < len(fields) {
+				row[key] = fields[i]
+			}
+		}
+		mode := row["mode"]
+		indexLabel := row["indexes"]
+		shape := "collection"
+		indexes := cfg.Indexes
+		if mode == "raw_treedb" {
+			shape = "raw"
+			indexes = 0
+		} else if indexLabel != "-" {
+			parsed, err := strconv.Atoi(indexLabel)
+			if err == nil {
+				indexes = parsed
+			}
+		}
+		total := parseInt64(row["total_bytes"])
+		docs := cfg.Docs
+		phase := phasePostInsert
+		maintenance := "none"
+		note := "offline rewrite matrix before-rewrite size; not compacted"
+		flags := map[string]string(nil)
+		if row["phase"] == "after_rewrite" {
+			phase = phaseOfflineRewrite
+			maintenance = "treemap_vlog_rewrite_rw"
+			note = "PR 1096-style offline rewrite using treemap vlog-rewrite -rw"
+			flags = map[string]string{
+				"treemap":                   "vlog-rewrite -rw",
+				"template-mode":             "off",
+				"leaf-segment-target-bytes": "persisted/default",
+				"index-vacuum":              "offline index swap from rewrite",
+			}
+		}
+		extra := map[string]string{
+			"total_gzip_bytes":              row["total_gzip_bytes"],
+			"total_bytes_per_gzip_byte":     row["total_bytes_per_gzip_byte"],
+			"leaf_vlog_bytes":               row["leaf_vlog_bytes"],
+			"leaf_vlog_bytes_per_gzip_byte": row["leaf_vlog_bytes_per_gzip_byte"],
+			"index_db_bytes":                row["index_db_bytes"],
+			"value_vlog_bytes":              row["value_vlog_bytes"],
+		}
+		canon.Results = append(canon.Results, resultRow{
+			ConfigName:      canonicalConfigName("treedb", "template-v1", shape, indexes),
+			Engine:          "treedb_" + cfg.Profile,
+			Format:          "template-v1",
+			Shape:           shape,
+			IndexCount:      indexes,
+			DocumentCount:   docs,
+			BenchmarkName:   "treedb_collection_compression_matrix",
+			Phase:           phase,
+			MaintenanceMode: maintenance,
+			TotalBytes:      int64Ptr(total),
+			BytesPerDoc:     floatPtr(bytesPerDoc(total, docs)),
+			BatchSize:       cfg.BatchSize,
+			BenchmarkTimed:  false,
+			MeasurementKind: "offline_script",
+			MeasurementNote: note,
+			CompactionFlags: flags,
+			SourceArtifact:  path,
+			Extra:           extra,
+		})
+	}
+	return sc.Err()
+}
+
+func parseFullLeafgenSummary(canon *canonicalRun, path string, cfg config) error {
+	var summary fixtureSummary
+	if err := readJSONFile(path, &summary); err != nil {
+		return err
+	}
+	docs := summary.Docs
+	if docs == 0 {
+		docs = cfg.Docs
+	}
+	indexes := summary.IndexCount
+	if indexes == 0 {
+		indexes = cfg.Indexes
+	}
+	format := canonicalFormat(summary.DocumentFormat)
+	configName := canonicalConfigName("treedb", format, "collection", indexes)
+	if summary.DiskUsageBeforeMaintenance != nil {
+		total := summary.DiskUsageBeforeMaintenance.TotalBytes
+		row := resultRow{
+			ConfigName:      configName,
+			Engine:          "treedb_" + summary.Profile,
+			Format:          format,
+			Shape:           "collection",
+			IndexCount:      indexes,
+			DocumentCount:   docs,
+			BenchmarkName:   "collection-load-fixture",
+			Phase:           phasePostInsert,
+			MaintenanceMode: "none",
+			TotalBytes:      int64Ptr(total),
+			BytesPerDoc:     floatPtr(bytesPerDoc(total, docs)),
+			DocsPerSec:      floatPtr(summary.InsertTiming.OpsPerSec),
+			BatchSize:       summary.BatchSize,
+			BenchmarkTimed:  false,
+			MeasurementKind: "fixture_wall_timed",
+			MeasurementNote: "full leafgen fixture pre-maintenance size; use benchmark-timed rows for primary throughput",
+			SourceArtifact:  path,
+		}
+		if summary.InsertTiming.SecPerOp > 0 {
+			row.NsPerDoc = floatPtr(summary.InsertTiming.SecPerOp * 1e9)
+		}
+		canon.Results = append(canon.Results, row)
+	}
+	if summary.DiskUsageFinal == nil {
+		return nil
+	}
+	total := summary.DiskUsageFinal.TotalBytes
+	stats := map[string]float64{}
+	if summary.LeafGeneration != nil {
+		stats["leafgen_candidate_generations"] = float64(summary.LeafGeneration.CandidateGenerations)
+		stats["leafgen_candidate_bytes_total"] = float64(summary.LeafGeneration.CandidateBytesTotal)
+		stats["leafgen_candidate_bytes_live"] = float64(summary.LeafGeneration.CandidateBytesLive)
+		stats["leafgen_candidate_bytes_dead"] = float64(summary.LeafGeneration.CandidateBytesDead)
+		stats["leafgen_expected_reclaim_bytes"] = float64(summary.LeafGeneration.ExpectedReclaimBytes)
+		stats["leafgen_pack_generations_matched"] = float64(summary.LeafGeneration.PackGenerationsMatched)
+		stats["leafgen_pack_leaf_pages_copied"] = float64(summary.LeafGeneration.PackLeafPagesCopied)
+		stats["leafgen_pack_leaf_frames_written"] = float64(summary.LeafGeneration.PackLeafFramesWritten)
+		stats["leafgen_pack_max_leaf_frame_k"] = float64(summary.LeafGeneration.PackMaxLeafFrameK)
+		stats["leafgen_gc_generations_deleted"] = float64(summary.LeafGeneration.GCGenerationsDeleted)
+		stats["leafgen_gc_files_deleted"] = float64(summary.LeafGeneration.GCFilesDeleted)
+		stats["leafgen_gc_bytes_deleted"] = float64(summary.LeafGeneration.GCBytesDeleted)
+	}
+	if summary.IndexVacuum != nil {
+		stats["index_vacuum_seconds"] = summary.IndexVacuum.Timing.Seconds
+		stats["index_vacuum_disk_bytes_before"] = float64(summary.IndexVacuum.DiskBytesBefore)
+		stats["index_vacuum_disk_bytes_after"] = float64(summary.IndexVacuum.DiskBytesAfter)
+		stats["index_vacuum_index_db_bytes_before"] = float64(summary.IndexVacuum.IndexDBBytesBefore)
+		stats["index_vacuum_index_db_bytes_after"] = float64(summary.IndexVacuum.IndexDBBytesAfter)
+	}
+	canon.Results = append(canon.Results, resultRow{
+		ConfigName:      configName,
+		Engine:          "treedb_" + summary.Profile,
+		Format:          format,
+		Shape:           "collection",
+		IndexCount:      indexes,
+		DocumentCount:   docs,
+		BenchmarkName:   "collection-load-fixture",
+		Phase:           phaseFullLeafgenPackGC,
+		MaintenanceMode: "full_leafgen_pack_gc",
+		TotalBytes:      int64Ptr(total),
+		BytesPerDoc:     floatPtr(bytesPerDoc(total, docs)),
+		BatchSize:       summary.BatchSize,
+		BenchmarkTimed:  false,
+		MeasurementKind: "fixture_post_processing",
+		MeasurementNote: "full leafgen pack/GC with explicit flags followed by configured index vacuum",
+		CompactionFlags: map[string]string{
+			"leaf-segment-target-bytes":    strconv.FormatInt(cfg.LeafSegmentTargetBytes, 10),
+			"leafgen-pack-gc":              "true",
+			"leafgen-pack-force":           strconv.FormatBool(cfg.FullLeafgenForce),
+			"leafgen-pack-max-generations": strconv.Itoa(cfg.FullLeafgenMaxGenerations),
+			"leafgen-pack-frame-k":         strconv.Itoa(cfg.LeafgenPackFrameK),
+			"index-vacuum":                 cfg.FullLeafgenIndexVacuum,
+		},
+		SourceArtifact:   path,
+		MaintenanceStats: stats,
+	})
+	return nil
+}
+
+func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
+	var checks []guardrailCheck
+	add := func(sev, code, msg string) {
+		checks = append(checks, guardrailCheck{Severity: sev, Code: code, Message: msg})
+	}
+	add("warning", "phase.online_one_pass.partial", "online_one_pass_maintenance is partial online maintenance; do not describe it as full compaction")
+	for _, r := range canon.Results {
+		if r.GeneratedAt == "" || r.RunDir == "" || r.Branch == "" || r.Commit == "" || len(r.CommandLine) == 0 {
+			add("error", "missing_row_run_metadata", fmt.Sprintf("%s/%s is missing row-level run metadata", r.ConfigName, r.Phase))
+		}
+		if r.TotalBytes != nil && r.DocumentCount <= 0 {
+			add("error", "missing_document_count", fmt.Sprintf("%s/%s has bytes but no document count", r.ConfigName, r.Phase))
+		}
+		if r.Shape != "collection" && r.Shape != "raw" {
+			add("error", "missing_shape_label", fmt.Sprintf("%s/%s has non-canonical shape label %q", r.ConfigName, r.Phase, r.Shape))
+		}
+		if (r.Phase == phaseOfflineRewrite || r.Phase == phaseFullLeafgenPackGC || r.Phase == phaseSQLiteVacuum) && len(r.CompactionFlags) == 0 {
+			add("error", "missing_compaction_flags", fmt.Sprintf("%s/%s is missing compaction flags", r.ConfigName, r.Phase))
+		}
+	}
+	if findResult(canon.Results, "sqlite_json_2_indexes", phaseSQLiteVacuum) == nil {
+		add("error", "missing_sqlite_json_vacuum", "SQLite JSON VACUUM result is required for fair compacted-state comparison")
+	}
+	if findResult(canon.Results, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum) == nil {
+		add("error", "missing_sqlite_native_vacuum", "SQLite native-columns VACUUM result is required for fair compacted-state comparison")
+	}
+	if findResult(canon.Results, "treedb_template_v1_collection_2_indexes", phaseOfflineRewrite) != nil &&
+		findResult(canon.Results, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum) == nil {
+		add("error", "unfair_compacted_comparison", "TreeDB offline/full compaction must be compared against SQLite after VACUUM, not SQLite post-insert")
+	}
+	if findResult(canon.Results, "treedb_template_v1_raw", phaseOfflineRewrite) != nil {
+		add("info", "raw_shape_labeled", "raw TreeDB rows are labeled shape=raw and should not be mixed with collection rows without that label")
+	}
+	for _, cmp := range comparisonsForReport(canon) {
+		if isTreeDBCompactedPhase(cmp.TreeDBPhase) && cmp.SQLitePhase != phaseSQLiteVacuum {
+			add("error", "compacted_compared_to_sqlite_post_insert", fmt.Sprintf("%s compares TreeDB compacted phase %s against SQLite phase %s", cmp.ComparisonName, cmp.TreeDBPhase, cmp.SQLitePhase))
+		}
+	}
+	for _, treedbPhase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
+		if findResult(canon.Results, "treedb_template_v1_collection_2_indexes", treedbPhase) == nil {
+			continue
+		}
+		for _, sqliteName := range []string{"sqlite_native_columns_2_indexes", "sqlite_json_2_indexes"} {
+			if findComparison(canon.Comparisons, "treedb_template_v1_collection_2_indexes", treedbPhase, sqliteName, phaseSQLiteVacuum) == nil {
+				add("error", "missing_compacted_ratio", fmt.Sprintf("missing derived compacted comparison for %s/%s vs %s/%s", "treedb_template_v1_collection_2_indexes", treedbPhase, sqliteName, phaseSQLiteVacuum))
+			}
+		}
+	}
+	return checks
+}
+
+func finalizeRunMetadata(canon *canonicalRun) {
+	if canon == nil {
+		return
+	}
+	for i := range canon.Results {
+		canon.Results[i].GeneratedAt = canon.GeneratedAt
+		canon.Results[i].RunDir = canon.RunDir
+		canon.Results[i].Worktree = canon.Worktree
+		canon.Results[i].Branch = canon.Branch
+		canon.Results[i].Commit = canon.Commit
+		canon.Results[i].CommandLine = append([]string(nil), canon.CommandLine...)
+	}
+	for i := range canon.Comparisons {
+		canon.Comparisons[i].GeneratedAt = canon.GeneratedAt
+		canon.Comparisons[i].RunDir = canon.RunDir
+		canon.Comparisons[i].Worktree = canon.Worktree
+		canon.Comparisons[i].Branch = canon.Branch
+		canon.Comparisons[i].Commit = canon.Commit
+		canon.Comparisons[i].CommandLine = append([]string(nil), canon.CommandLine...)
+	}
+}
+
+func buildCompactedComparisons(canon *canonicalRun) []comparisonRow {
+	if canon == nil {
+		return nil
+	}
+	var comparisons []comparisonRow
+	treeDBConfig := "treedb_template_v1_collection_2_indexes"
+	sqliteConfigs := []string{"sqlite_native_columns_2_indexes", "sqlite_json_2_indexes"}
+	for _, treedbPhase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
+		treeRow := findResult(canon.Results, treeDBConfig, treedbPhase)
+		if treeRow == nil || treeRow.BytesPerDoc == nil || *treeRow.BytesPerDoc <= 0 {
+			continue
+		}
+		for _, sqliteConfig := range sqliteConfigs {
+			sqliteRow := findResult(canon.Results, sqliteConfig, phaseSQLiteVacuum)
+			if sqliteRow == nil || sqliteRow.BytesPerDoc == nil || *sqliteRow.BytesPerDoc <= 0 {
+				continue
+			}
+			comparisonName := fmt.Sprintf("%s_%s_vs_%s_%s", treeDBConfig, treedbPhase, sqliteConfig, phaseSQLiteVacuum)
+			comparisons = append(comparisons, comparisonRow{
+				ComparisonName:    comparisonName,
+				TreeDBConfigName:  treeDBConfig,
+				TreeDBPhase:       treedbPhase,
+				SQLiteConfigName:  sqliteConfig,
+				SQLitePhase:       phaseSQLiteVacuum,
+				TreeDBBytesPerDoc: *treeRow.BytesPerDoc,
+				SQLiteBytesPerDoc: *sqliteRow.BytesPerDoc,
+				SmallerRatio:      *sqliteRow.BytesPerDoc / *treeRow.BytesPerDoc,
+				ComparisonBasis:   "TreeDB compacted phase versus SQLite after VACUUM",
+			})
+		}
+	}
+	return comparisons
+}
+
+func comparisonsForReport(canon *canonicalRun) []comparisonRow {
+	if canon == nil {
+		return nil
+	}
+	if len(canon.Comparisons) > 0 {
+		return canon.Comparisons
+	}
+	return buildCompactedComparisons(canon)
+}
+
+func findComparison(comparisons []comparisonRow, treeConfig, treePhase, sqliteConfig, sqlitePhase string) *comparisonRow {
+	for i := range comparisons {
+		cmp := &comparisons[i]
+		if cmp.TreeDBConfigName == treeConfig && cmp.TreeDBPhase == treePhase &&
+			cmp.SQLiteConfigName == sqliteConfig && cmp.SQLitePhase == sqlitePhase {
+			return cmp
+		}
+	}
+	return nil
+}
+
+func isTreeDBCompactedPhase(phase string) bool {
+	return phase == phaseOfflineRewrite || phase == phaseFullLeafgenPackGC
+}
+
+func writeOutputs(canon *canonicalRun) error {
+	sortResults(canon.Results)
+	resultsPath := filepath.Join(canon.RunDir, "benchmark_results.json")
+	canon.Artifacts["benchmark_results_json"] = resultsPath
+	canon.Artifacts["benchmark_summary_md"] = filepath.Join(canon.RunDir, "benchmark_summary.md")
+	canon.Artifacts["benchmark_matrix_csv"] = filepath.Join(canon.RunDir, "benchmark_matrix.csv")
+	if err := writeJSON(resultsPath, canon); err != nil {
+		return err
+	}
+	if err := os.WriteFile(canon.Artifacts["benchmark_summary_md"], []byte(renderMarkdownReport(canon)), 0644); err != nil {
+		return err
+	}
+	return writeCSV(canon.Artifacts["benchmark_matrix_csv"], canon.Results)
+}
+
+func renderMarkdownReport(canon *canonicalRun) string {
+	var sb strings.Builder
+	sb.WriteString("# TreeDB Collections Canonical Benchmark\n\n")
+	sb.WriteString("## Executive Summary\n\n")
+	sb.WriteString(renderExecutiveSummary(canon))
+	sb.WriteString("\n\n")
+
+	sb.WriteString("## Benchmark Configuration\n\n")
+	writeKVTable(&sb, [][2]string{
+		{"generated_at", canon.GeneratedAt},
+		{"run_dir", canon.RunDir},
+		{"worktree", canon.Worktree},
+		{"branch", canon.Branch},
+		{"commit", canon.Commit},
+		{"command_line", displayCommandLine(canon.CommandLine)},
+		{"docs", strconv.Itoa(canon.Config.Docs)},
+		{"batch_size", strconv.Itoa(canon.Config.BatchSize)},
+		{"indexes", strconv.Itoa(canon.Config.Indexes)},
+		{"tree_engine", canon.Config.TreeEngine},
+		{"profile", canon.Config.Profile},
+		{"formats", strings.Join(canon.Config.Formats, ",")},
+		{"leaf_segment_target_bytes", strconv.FormatInt(canon.Config.LeafSegmentTargetBytes, 10)},
+		{"leafgen_pack_force", strconv.FormatBool(canon.Config.FullLeafgenForce)},
+		{"leafgen_pack_max_generations", strconv.Itoa(canon.Config.FullLeafgenMaxGenerations)},
+		{"leafgen_pack_frame_k", strconv.Itoa(canon.Config.LeafgenPackFrameK)},
+		{"index_vacuum", canon.Config.FullLeafgenIndexVacuum},
+	})
+	sb.WriteString("\n")
+
+	sb.WriteString("## Throughput Results\n\n")
+	sb.WriteString("These rows are benchmark-timed post-insert measurements. Maintenance rows are excluded from throughput ranking.\n\n")
+	sb.WriteString("| Config | Format | Indexes | Docs/sec | ns/doc | Batch size | Source |\n")
+	sb.WriteString("| --- | --- | ---: | ---: | ---: | ---: | --- |\n")
+	for _, r := range throughputRows(canon.Results) {
+		sb.WriteString(fmt.Sprintf("| `%s` | %s | %d | %s | %s | %d | %s |\n",
+			r.ConfigName, r.Format, r.IndexCount, formatFloatPtr(r.DocsPerSec, 0), formatFloatPtr(r.NsPerDoc, 1), r.BatchSize, r.MeasurementKind))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("## Post-Insert Storage Comparison\n\n")
+	sb.WriteString("These rows use the timed benchmark matrix post-insert basis. They are fair to compare with each other, but they are not compacted-state numbers.\n\n")
+	sb.WriteString("| Config | Format | Indexes | Total bytes | B/doc | Docs/sec |\n")
+	sb.WriteString("| --- | --- | ---: | ---: | ---: | ---: |\n")
+	for _, r := range postInsertComparisonRows(canon.Results) {
+		sb.WriteString(fmt.Sprintf("| `%s` | %s | %d | %s | %s | %s |\n",
+			r.ConfigName, r.Format, r.IndexCount, formatIntPtr(r.TotalBytes), formatFloatPtr(r.BytesPerDoc, 1), formatFloatPtr(r.DocsPerSec, 0)))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("## Storage Results by Phase\n\n")
+	sb.WriteString("| Config | Shape | Phase | Total bytes | B/doc | Measurement | Note |\n")
+	sb.WriteString("| --- | --- | --- | ---: | ---: | --- | --- |\n")
+	for _, r := range storageRows(canon.Results) {
+		sb.WriteString(fmt.Sprintf("| `%s` | %s | `%s` | %s | %s | %s | %s |\n",
+			r.ConfigName, r.Shape, r.Phase, formatIntPtr(r.TotalBytes), formatFloatPtr(r.BytesPerDoc, 1), r.MeasurementKind, markdownEscape(r.MeasurementNote)))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("## Fair Compacted-State Comparison\n\n")
+	sb.WriteString("TreeDB fully compacted rows are compared with SQLite after `VACUUM`. Do not compare TreeDB `offline_rewrite` or `full_leafgen_pack_gc` only against SQLite `post_insert` rows.\n\n")
+	writeFairComparison(&sb, canon)
+	sb.WriteString("\n")
+
+	sb.WriteString("## Maintenance/Compaction Details\n\n")
+	sb.WriteString("| Phase | Canonical meaning | Required comparison basis |\n")
+	sb.WriteString("| --- | --- | --- |\n")
+	sb.WriteString("| `post_insert` | Size after insert benchmark/fixture and correctness flush/checkpoint. | Compare with other post-insert rows only. |\n")
+	sb.WriteString("| `online_one_pass_maintenance` | Partial online maintenance from benchmark harness; currently one online rewrite/GC path and one leafgen-pack pass. | Do not present as full compaction. |\n")
+	sb.WriteString("| `offline_rewrite` | PR 1096-style `treemap vlog-rewrite <dir> -rw`. | Compare with SQLite `sqlite_vacuum`. |\n")
+	sb.WriteString("| `full_leafgen_pack_gc` | Forced/full leaf generation pack/GC with explicit knobs and configured index vacuum. | Compare with SQLite `sqlite_vacuum`. |\n")
+	sb.WriteString("| `sqlite_vacuum` | SQLite compacted baseline after `VACUUM`. | Required baseline for compacted-state comparison. |\n\n")
+	sb.WriteString("Full leafgen knobs recorded for this run:\n\n")
+	writeKVTable(&sb, [][2]string{
+		{"leaf-segment-target-bytes", strconv.FormatInt(canon.Config.LeafSegmentTargetBytes, 10)},
+		{"leafgen-pack-gc", "true"},
+		{"leafgen-pack-force", strconv.FormatBool(canon.Config.FullLeafgenForce)},
+		{"leafgen-pack-max-generations", strconv.Itoa(canon.Config.FullLeafgenMaxGenerations)},
+		{"leafgen-pack-frame-k", strconv.Itoa(canon.Config.LeafgenPackFrameK)},
+		{"index-vacuum", canon.Config.FullLeafgenIndexVacuum},
+	})
+	sb.WriteString("\n")
+
+	sb.WriteString("## Guardrail Checks\n\n")
+	sb.WriteString("| Severity | Code | Message |\n")
+	sb.WriteString("| --- | --- | --- |\n")
+	for _, check := range canon.Checks {
+		sb.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n", check.Severity, check.Code, markdownEscape(check.Message)))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("## Raw Results Appendix\n\n")
+	sb.WriteString(fmt.Sprintf("Machine-readable JSON: `%s`\n\n", filepath.Base(canon.Artifacts["benchmark_results_json"])))
+	sb.WriteString(fmt.Sprintf("CSV matrix: `%s`\n\n", filepath.Base(canon.Artifacts["benchmark_matrix_csv"])))
+	sb.WriteString("| Config | Phase | Engine | Format | Indexes | Docs | Bytes | B/doc | Docs/sec | ns/doc |\n")
+	sb.WriteString("| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+	for _, r := range canon.Results {
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %s | %s | %d | %d | %s | %s | %s | %s |\n",
+			r.ConfigName, r.Phase, r.Engine, r.Format, r.IndexCount, r.DocumentCount, formatIntPtr(r.TotalBytes), formatFloatPtr(r.BytesPerDoc, 1), formatFloatPtr(r.DocsPerSec, 0), formatFloatPtr(r.NsPerDoc, 1)))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("## Reproduction Commands\n\n")
+	sb.WriteString("Canonical entry point:\n\n")
+	sb.WriteString("```bash\n")
+	sb.WriteString("./scripts/bench_collections_canonical.sh\n")
+	sb.WriteString("# or\n")
+	sb.WriteString("make bench-collections-canonical\n")
+	sb.WriteString("```\n\n")
+	sb.WriteString("Exact command records from this run:\n\n")
+	for _, cmd := range canon.Commands {
+		sb.WriteString(fmt.Sprintf("### %s\n\n", cmd.Name))
+		if len(cmd.Env) > 0 {
+			keys := make([]string, 0, len(cmd.Env))
+			for k := range cmd.Env {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				sb.WriteString(fmt.Sprintf("%s=%s ", k, shellQuote(cmd.Env[k])))
+			}
+		}
+		sb.WriteString(shellQuoteCommand(cmd.Command))
+		sb.WriteString("\n\n")
+	}
+	return sb.String()
+}
+
+func renderExecutiveSummary(canon *canonicalRun) string {
+	fastest := fastestThroughput(canon.Results)
+	offline := findResult(canon.Results, "treedb_template_v1_collection_2_indexes", phaseOfflineRewrite)
+	full := findResult(canon.Results, "treedb_template_v1_collection_2_indexes", phaseFullLeafgenPackGC)
+	sqliteJSON := findResult(canon.Results, "sqlite_json_2_indexes", phaseSQLiteVacuum)
+	sqliteNative := findResult(canon.Results, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum)
+	if offline != nil && full != nil && sqliteJSON != nil && sqliteNative != nil &&
+		offline.BytesPerDoc != nil && full.BytesPerDoc != nil && sqliteJSON.BytesPerDoc != nil && sqliteNative.BytesPerDoc != nil {
+		engine := "TreeDB"
+		if fastest != nil {
+			engine = fastest.ConfigName
+		}
+		offlineNative := *sqliteNative.BytesPerDoc / *offline.BytesPerDoc
+		fullNative := *sqliteNative.BytesPerDoc / *full.BytesPerDoc
+		offlineJSON := *sqliteJSON.BytesPerDoc / *offline.BytesPerDoc
+		fullJSON := *sqliteJSON.BytesPerDoc / *full.BytesPerDoc
+		return fmt.Sprintf("`%s` is the fastest indexed ingest row in this run. TreeDB fully compacted two-index template-v1 collection storage is %.1f B/doc via PR 1096-style offline rewrite and %.1f B/doc via full leafgen pack/GC. Compared with SQLite after `VACUUM`, offline rewrite is about %.1fx smaller than SQLite native columns and %.1fx smaller than SQLite JSON; full leafgen pack/GC is about %.1fx and %.1fx smaller, respectively.",
+			engine, *offline.BytesPerDoc, *full.BytesPerDoc, offlineNative, offlineJSON, fullNative, fullJSON)
+	}
+	return "This report separates post-insert, partial online maintenance, offline rewrite, full leafgen pack/GC, and SQLite VACUUM states. Some compacted-state rows are missing, so the fair compacted-state headline could not be generated."
+}
+
+func writeFairComparison(sb *strings.Builder, canon *canonicalRun) {
+	sqliteJSON := findResult(canon.Results, "sqlite_json_2_indexes", phaseSQLiteVacuum)
+	sqliteNative := findResult(canon.Results, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum)
+	comparisons := comparisonsForReport(canon)
+	sb.WriteString("SQLite compacted baselines:\n\n")
+	sb.WriteString("| Config | Phase | B/doc | Total bytes |\n")
+	sb.WriteString("| --- | --- | ---: | ---: |\n")
+	for _, r := range []*resultRow{sqliteJSON, sqliteNative} {
+		if r == nil {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %s | %s |\n", r.ConfigName, r.Phase, formatFloatPtr(r.BytesPerDoc, 1), formatIntPtr(r.TotalBytes)))
+	}
+	sb.WriteString("\nTreeDB compacted rows versus SQLite after `VACUUM`:\n\n")
+	sb.WriteString("| TreeDB config | Phase | B/doc | vs SQLite native-columns VACUUM | vs SQLite JSON VACUUM |\n")
+	sb.WriteString("| --- | --- | ---: | ---: | ---: |\n")
+	for _, phase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
+		nativeCmp := findComparison(comparisons, "treedb_template_v1_collection_2_indexes", phase, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum)
+		jsonCmp := findComparison(comparisons, "treedb_template_v1_collection_2_indexes", phase, "sqlite_json_2_indexes", phaseSQLiteVacuum)
+		if nativeCmp == nil && jsonCmp == nil {
+			continue
+		}
+		bpd := 0.0
+		if nativeCmp != nil {
+			bpd = nativeCmp.TreeDBBytesPerDoc
+		} else {
+			bpd = jsonCmp.TreeDBBytesPerDoc
+		}
+		nativeRatio := "-"
+		jsonRatio := "-"
+		if nativeCmp != nil {
+			nativeRatio = fmt.Sprintf("%.1fx smaller", nativeCmp.SmallerRatio)
+		}
+		if jsonCmp != nil {
+			jsonRatio = fmt.Sprintf("%.1fx smaller", jsonCmp.SmallerRatio)
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %.1f | %s | %s |\n", "treedb_template_v1_collection_2_indexes", phase, bpd, nativeRatio, jsonRatio))
+	}
+	sb.WriteString("\nDerived comparison rows are also emitted in `benchmark_results.json` under `comparisons`.\n")
+}
+
+func writeCSV(path string, rows []resultRow) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	defer w.Flush()
+	header := []string{"generated_at", "run_dir", "branch", "commit", "config_name", "phase", "engine", "format", "shape", "index_count", "document_count", "benchmark_name", "maintenance_mode", "total_bytes", "bytes_per_doc", "docs_per_sec", "ns_per_doc", "batch_size", "benchmark_timed", "measurement_kind", "source_artifact"}
+	if err := w.Write(header); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		record := []string{
+			r.GeneratedAt,
+			r.RunDir,
+			r.Branch,
+			r.Commit,
+			r.ConfigName,
+			r.Phase,
+			r.Engine,
+			r.Format,
+			r.Shape,
+			strconv.Itoa(r.IndexCount),
+			strconv.Itoa(r.DocumentCount),
+			r.BenchmarkName,
+			r.MaintenanceMode,
+			intPtrString(r.TotalBytes),
+			floatPtrString(r.BytesPerDoc),
+			floatPtrString(r.DocsPerSec),
+			floatPtrString(r.NsPerDoc),
+			strconv.Itoa(r.BatchSize),
+			strconv.FormatBool(r.BenchmarkTimed),
+			r.MeasurementKind,
+			r.SourceArtifact,
+		}
+		if err := w.Write(record); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeJSON(path string, v any) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return err
+	}
+	return os.WriteFile(path, buf.Bytes(), 0644)
+}
+
+func readJSONFile(path string, v any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return nil
+}
+
+func gitOutput(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func splitCSV(v string) []string {
+	var out []string
+	for _, part := range strings.Split(v, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func canonicalFormat(format string) string {
+	return strings.ReplaceAll(strings.TrimSpace(format), "_", "-")
+}
+
+func canonicalConfigName(engine, format, shape string, indexes int) string {
+	format = strings.ReplaceAll(canonicalFormat(format), "-", "_")
+	if engine == "sqlite" {
+		return fmt.Sprintf("sqlite_%s_%d_indexes", format, indexes)
+	}
+	if shape == "raw" {
+		return fmt.Sprintf("%s_%s_raw", engine, format)
+	}
+	return fmt.Sprintf("%s_%s_%s_%d_indexes", engine, format, shape, indexes)
+}
+
+func metricDefault(metrics map[string]float64, key string, def float64) float64 {
+	if metrics == nil {
+		return def
+	}
+	if v, ok := metrics[key]; ok {
+		return v
+	}
+	return def
+}
+
+func firstMetric(metrics map[string]float64, keys ...string) (float64, string) {
+	for _, key := range keys {
+		if v, ok := metrics[key]; ok {
+			return v, key
+		}
+	}
+	return 0, ""
+}
+
+func copyMetrics(metrics map[string]float64, keys ...string) map[string]float64 {
+	out := map[string]float64{}
+	for _, key := range keys {
+		if v, ok := metrics[key]; ok {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+func bytesPerDoc(total int64, docs int) float64 {
+	if docs <= 0 {
+		return 0
+	}
+	return float64(total) / float64(docs)
+}
+
+func parseInt64(v string) int64 {
+	n, _ := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+	return n
+}
+
+func int64Ptr(v int64) *int64     { return &v }
+func floatPtr(v float64) *float64 { return &v }
+
+func findResult(rows []resultRow, configName, phase string) *resultRow {
+	for i := range rows {
+		if rows[i].ConfigName == configName && rows[i].Phase == phase {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+func throughputRows(rows []resultRow) []resultRow {
+	var out []resultRow
+	for _, r := range rows {
+		if r.Phase == phasePostInsert && r.BenchmarkTimed && r.DocsPerSec != nil {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return *out[i].DocsPerSec > *out[j].DocsPerSec
+	})
+	return out
+}
+
+func storageRows(rows []resultRow) []resultRow {
+	var out []resultRow
+	for _, r := range rows {
+		if r.TotalBytes != nil {
+			out = append(out, r)
+		}
+	}
+	sortResults(out)
+	return out
+}
+
+func postInsertComparisonRows(rows []resultRow) []resultRow {
+	var out []resultRow
+	for _, r := range rows {
+		if r.Phase == phasePostInsert && r.BenchmarkTimed && r.TotalBytes != nil {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].BytesPerDoc != nil && out[j].BytesPerDoc != nil && *out[i].BytesPerDoc != *out[j].BytesPerDoc {
+			return *out[i].BytesPerDoc < *out[j].BytesPerDoc
+		}
+		return out[i].ConfigName < out[j].ConfigName
+	})
+	return out
+}
+
+func fastestThroughput(rows []resultRow) *resultRow {
+	var best *resultRow
+	for i := range rows {
+		r := &rows[i]
+		if r.Phase != phasePostInsert || !r.BenchmarkTimed || r.DocsPerSec == nil {
+			continue
+		}
+		if best == nil || *r.DocsPerSec > *best.DocsPerSec {
+			best = r
+		}
+	}
+	return best
+}
+
+func sortResults(rows []resultRow) {
+	phaseRank := map[string]int{
+		phasePostInsert:               0,
+		phaseOnlineOnePassMaintenance: 1,
+		phaseOfflineRewrite:           2,
+		phaseFullLeafgenPackGC:        3,
+		phaseSQLiteVacuum:             4,
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		ri, rj := rows[i], rows[j]
+		if ri.ConfigName != rj.ConfigName {
+			return ri.ConfigName < rj.ConfigName
+		}
+		if phaseRank[ri.Phase] != phaseRank[rj.Phase] {
+			return phaseRank[ri.Phase] < phaseRank[rj.Phase]
+		}
+		return ri.MeasurementKind < rj.MeasurementKind
+	})
+}
+
+func hasErrorCheck(checks []guardrailCheck) bool {
+	for _, c := range checks {
+		if c.Severity == "error" {
+			return true
+		}
+	}
+	return false
+}
+
+func formatIntPtr(v *int64) string {
+	if v == nil {
+		return "-"
+	}
+	return formatInt(*v)
+}
+
+func formatInt(v int64) string {
+	sign := ""
+	if v < 0 {
+		sign = "-"
+		v = -v
+	}
+	s := strconv.FormatInt(v, 10)
+	var parts []string
+	for len(s) > 3 {
+		parts = append(parts, s[len(s)-3:])
+		s = s[:len(s)-3]
+	}
+	parts = append(parts, s)
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+	return sign + strings.Join(parts, ",")
+}
+
+func formatFloatPtr(v *float64, prec int) string {
+	if v == nil {
+		return "-"
+	}
+	return formatFloat(*v, prec)
+}
+
+func formatFloat(v float64, prec int) string {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return "-"
+	}
+	return strconv.FormatFloat(v, 'f', prec, 64)
+}
+
+func intPtrString(v *int64) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.FormatInt(*v, 10)
+}
+
+func floatPtrString(v *float64) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.FormatFloat(*v, 'f', -1, 64)
+}
+
+func markdownEscape(v string) string {
+	v = strings.ReplaceAll(v, "|", "\\|")
+	v = strings.ReplaceAll(v, "\n", " ")
+	return v
+}
+
+func writeKVTable(sb *strings.Builder, rows [][2]string) {
+	sb.WriteString("| Key | Value |\n")
+	sb.WriteString("| --- | --- |\n")
+	for _, row := range rows {
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` |\n", row[0], markdownEscape(row[1])))
+	}
+}
+
+func shellQuoteCommand(args []string) string {
+	parts := make([]string, 0, len(args))
+	for _, arg := range args {
+		parts = append(parts, shellQuote(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func displayCommandLine(args []string) string {
+	if len(args) == 1 {
+		return args[0]
+	}
+	return shellQuoteCommand(args)
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if strings.IndexFunc(s, func(r rune) bool {
+		return !(r == '/' || r == '.' || r == '-' || r == '_' || r == '=' || r == ':' || r == ',' || r == '+' ||
+			(r >= '0' && r <= '9') || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z'))
+	}) == -1 {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -418,6 +418,12 @@ func parseConfig(args []string) (config, error) {
 	if cfg.Indexes < 0 || cfg.Indexes > 3 {
 		return config{}, errors.New("-indexes must be 0, 1, 2, or 3")
 	}
+	cfg.FullLeafgenIndexVacuum = strings.ToLower(strings.TrimSpace(cfg.FullLeafgenIndexVacuum))
+	switch cfg.FullLeafgenIndexVacuum {
+	case "offline", "online", "auto", "none":
+	default:
+		return config{}, errors.New("-index-vacuum must be one of offline, online, auto, or none")
+	}
 	if cfg.Count <= 0 {
 		return config{}, errors.New("-count must be > 0")
 	}
@@ -863,9 +869,6 @@ func parseFullLeafgenSummary(canon *canonicalRun, path string, cfg config) error
 		docs = cfg.Docs
 	}
 	indexes := summary.IndexCount
-	if indexes == 0 {
-		indexes = cfg.Indexes
-	}
 	format := canonicalFormat(summary.DocumentFormat)
 	configName := canonicalConfigName("treedb", format, "collection", indexes)
 	if summary.DiskUsageBeforeMaintenance != nil {

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -465,10 +465,11 @@ func runTimedMatrix(cfg config, canon *canonicalRun) error {
 func runOfflineRewriteMatrix(cfg config, canon *canonicalRun) error {
 	rewriteDir := filepath.Join(cfg.OutDir, "offline_rewrite")
 	env := map[string]string{
-		"RUN_DIR": rewriteDir,
-		"DOCS":    strconv.Itoa(cfg.Docs),
-		"BATCH":   strconv.Itoa(cfg.BatchSize),
-		"PROFILE": cfg.Profile,
+		"RUN_DIR":            rewriteDir,
+		"DOCS":               strconv.Itoa(cfg.Docs),
+		"BATCH":              strconv.Itoa(cfg.BatchSize),
+		"PROFILE":            cfg.Profile,
+		"COLLECTION_INDEXES": strings.Join(offlineRewriteIndexArgs(cfg.Indexes), " "),
 	}
 	if err := runLoggedCommand(cfg, canon, "offline_rewrite_matrix", env, "bash", "./scripts/treedb_collection_compression_matrix.sh"); err != nil {
 		return err
@@ -1425,6 +1426,24 @@ func canonicalIndexCount(canon *canonicalRun) int {
 		return canon.Config.Indexes
 	}
 	return 0
+}
+
+func offlineRewriteIndexArgs(configured int) []string {
+	seen := make(map[int]bool, 4)
+	var indexes []int
+	for _, idx := range []int{0, 1, 2, configured} {
+		if idx < 0 || seen[idx] {
+			continue
+		}
+		seen[idx] = true
+		indexes = append(indexes, idx)
+	}
+	sort.Ints(indexes)
+	out := make([]string, 0, len(indexes))
+	for _, idx := range indexes {
+		out = append(out, strconv.Itoa(idx))
+	}
+	return out
 }
 
 func indexCountLabel(indexes int) string {

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -85,6 +85,7 @@ type canonicalConfig struct {
 	FullLeafgenForce          bool     `json:"full_leafgen_force"`
 	FullLeafgenMaxGenerations int      `json:"full_leafgen_max_generations"`
 	FullLeafgenIndexVacuum    string   `json:"full_leafgen_index_vacuum"`
+	SkipSQLite                bool     `json:"skip_sqlite"`
 }
 
 type commandRecord struct {
@@ -306,6 +307,7 @@ func run(argv []string) error {
 			FullLeafgenForce:          cfg.FullLeafgenForce,
 			FullLeafgenMaxGenerations: cfg.FullLeafgenMaxGenerations,
 			FullLeafgenIndexVacuum:    cfg.FullLeafgenIndexVacuum,
+			SkipSQLite:                cfg.SkipSQLite,
 		},
 		Artifacts: map[string]string{},
 	}
@@ -948,15 +950,19 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 	treeDBConfig := compactedTreeDBConfigName(canon)
 	sqliteJSONConfig := sqliteJSONConfigName(canon)
 	sqliteNativeConfig := sqliteNativeConfigName(canon)
-	if findResult(canon.Results, sqliteJSONConfig, phaseSQLiteVacuum) == nil {
-		add("error", "missing_sqlite_json_vacuum", "SQLite JSON VACUUM result is required for fair compacted-state comparison")
-	}
-	if findResult(canon.Results, sqliteNativeConfig, phaseSQLiteVacuum) == nil {
-		add("error", "missing_sqlite_native_vacuum", "SQLite native-columns VACUUM result is required for fair compacted-state comparison")
-	}
-	if findResult(canon.Results, treeDBConfig, phaseOfflineRewrite) != nil &&
-		findResult(canon.Results, sqliteNativeConfig, phaseSQLiteVacuum) == nil {
-		add("error", "unfair_compacted_comparison", "TreeDB offline/full compaction must be compared against SQLite after VACUUM, not SQLite post-insert")
+	if canon.Config.SkipSQLite {
+		add("warning", "sqlite.skipped", "SQLite rows were intentionally skipped; fair compacted SQLite comparisons are omitted")
+	} else {
+		if findResult(canon.Results, sqliteJSONConfig, phaseSQLiteVacuum) == nil {
+			add("error", "missing_sqlite_json_vacuum", "SQLite JSON VACUUM result is required for fair compacted-state comparison")
+		}
+		if findResult(canon.Results, sqliteNativeConfig, phaseSQLiteVacuum) == nil {
+			add("error", "missing_sqlite_native_vacuum", "SQLite native-columns VACUUM result is required for fair compacted-state comparison")
+		}
+		if findResult(canon.Results, treeDBConfig, phaseOfflineRewrite) != nil &&
+			findResult(canon.Results, sqliteNativeConfig, phaseSQLiteVacuum) == nil {
+			add("error", "unfair_compacted_comparison", "TreeDB offline/full compaction must be compared against SQLite after VACUUM, not SQLite post-insert")
+		}
 	}
 	if findResult(canon.Results, "treedb_template_v1_raw", phaseOfflineRewrite) != nil {
 		add("info", "raw_shape_labeled", "raw TreeDB rows are labeled shape=raw and should not be mixed with collection rows without that label")
@@ -966,13 +972,15 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 			add("error", "compacted_compared_to_sqlite_post_insert", fmt.Sprintf("%s compares TreeDB compacted phase %s against SQLite phase %s", cmp.ComparisonName, cmp.TreeDBPhase, cmp.SQLitePhase))
 		}
 	}
-	for _, treedbPhase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
-		if findResult(canon.Results, treeDBConfig, treedbPhase) == nil {
-			continue
-		}
-		for _, sqliteName := range []string{sqliteNativeConfig, sqliteJSONConfig} {
-			if findComparison(canon.Comparisons, treeDBConfig, treedbPhase, sqliteName, phaseSQLiteVacuum) == nil {
-				add("error", "missing_compacted_ratio", fmt.Sprintf("missing derived compacted comparison for %s/%s vs %s/%s", treeDBConfig, treedbPhase, sqliteName, phaseSQLiteVacuum))
+	if !canon.Config.SkipSQLite {
+		for _, treedbPhase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
+			if findResult(canon.Results, treeDBConfig, treedbPhase) == nil {
+				continue
+			}
+			for _, sqliteName := range []string{sqliteNativeConfig, sqliteJSONConfig} {
+				if findComparison(canon.Comparisons, treeDBConfig, treedbPhase, sqliteName, phaseSQLiteVacuum) == nil {
+					add("error", "missing_compacted_ratio", fmt.Sprintf("missing derived compacted comparison for %s/%s vs %s/%s", treeDBConfig, treedbPhase, sqliteName, phaseSQLiteVacuum))
+				}
 			}
 		}
 	}
@@ -1218,8 +1226,8 @@ func renderExecutiveSummary(canon *canonicalRun) string {
 		fullNative := *sqliteNative.BytesPerDoc / *full.BytesPerDoc
 		offlineJSON := *sqliteJSON.BytesPerDoc / *offline.BytesPerDoc
 		fullJSON := *sqliteJSON.BytesPerDoc / *full.BytesPerDoc
-		return fmt.Sprintf("`%s` is the fastest indexed ingest row in this run. TreeDB fully compacted two-index template-v1 collection storage is %.1f B/doc via PR 1096-style offline rewrite and %.1f B/doc via full leafgen pack/GC. Compared with SQLite after `VACUUM`, offline rewrite is about %.1fx smaller than SQLite native columns and %.1fx smaller than SQLite JSON; full leafgen pack/GC is about %.1fx and %.1fx smaller, respectively.",
-			engine, *offline.BytesPerDoc, *full.BytesPerDoc, offlineNative, offlineJSON, fullNative, fullJSON)
+		return fmt.Sprintf("`%s` is the fastest indexed ingest row in this run. TreeDB fully compacted %s template-v1 collection storage is %.1f B/doc via PR 1096-style offline rewrite and %.1f B/doc via full leafgen pack/GC. Compared with SQLite after `VACUUM`, offline rewrite is about %.1fx smaller than SQLite native columns and %.1fx smaller than SQLite JSON; full leafgen pack/GC is about %.1fx and %.1fx smaller, respectively.",
+			engine, indexCountLabel(canonicalIndexCount(canon)), *offline.BytesPerDoc, *full.BytesPerDoc, offlineNative, offlineJSON, fullNative, fullJSON)
 	}
 	return "This report separates post-insert, partial online maintenance, offline rewrite, full leafgen pack/GC, and SQLite VACUUM states. Some compacted-state rows are missing, so the fair compacted-state headline could not be generated."
 }
@@ -1398,6 +1406,17 @@ func canonicalIndexCount(canon *canonicalRun) int {
 		return canon.Config.Indexes
 	}
 	return 0
+}
+
+func indexCountLabel(indexes int) string {
+	switch indexes {
+	case 1:
+		return "one-index"
+	case 2:
+		return "two-index"
+	default:
+		return fmt.Sprintf("%d-index", indexes)
+	}
 }
 
 func hasPositiveBytesPerDoc(row *resultRow) bool {

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -274,7 +274,7 @@ func run(argv []string) error {
 	if len(formats) == 0 {
 		return errors.New("-formats must contain at least one value")
 	}
-	if err := os.MkdirAll(filepath.Join(cfg.OutDir, "logs"), 0755); err != nil {
+	if err := prepareRunDir(cfg); err != nil {
 		return err
 	}
 
@@ -347,6 +347,24 @@ func run(argv []string) error {
 	return nil
 }
 
+func prepareRunDir(cfg config) error {
+	paths := []string{
+		"logs",
+		"timed_matrix",
+		"offline_rewrite",
+		"full_leafgen_pack_gc",
+		"benchmark_results.json",
+		"benchmark_summary.md",
+		"benchmark_matrix.csv",
+	}
+	for _, rel := range paths {
+		if err := os.RemoveAll(filepath.Join(cfg.OutDir, rel)); err != nil {
+			return err
+		}
+	}
+	return os.MkdirAll(filepath.Join(cfg.OutDir, "logs"), 0755)
+}
+
 func parseConfig(args []string) (config, error) {
 	cfg := config{
 		Docs:                      100000,
@@ -365,7 +383,7 @@ func parseConfig(args []string) (config, error) {
 	}
 	fs := flag.NewFlagSet("collection_canonical_bench", flag.ContinueOnError)
 	fs.StringVar(&cfg.RepoRoot, "repo-root", "", "Repository root; defaults to git rev-parse --show-toplevel")
-	fs.StringVar(&cfg.OutDir, "out-dir", "", "Output directory; defaults to /tmp/collection_canonical_bench_<timestamp>")
+	fs.StringVar(&cfg.OutDir, "out-dir", "", "Output directory; defaults under os.TempDir() as collection_canonical_bench_<timestamp>")
 	fs.IntVar(&cfg.Docs, "docs", cfg.Docs, "Document count for canonical runs")
 	fs.IntVar(&cfg.BatchSize, "batch-size", cfg.BatchSize, "Batch size for collection inserts")
 	fs.IntVar(&cfg.Indexes, "indexes", cfg.Indexes, "Secondary index count for primary comparison")
@@ -424,6 +442,7 @@ func runTimedMatrix(cfg config, canon *canonicalRun) error {
 		"run", "./cmd/collection_bench_matrix",
 		"-out-dir", matrixDir,
 		"-formats", cfg.Formats,
+		"-engine", cfg.TreeEngine,
 		"-storage-cells", cfg.StorageCells,
 		"-tree-bench-pattern", treePattern,
 		"-sqlite-bench-pattern", sqlitePattern,

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -277,7 +277,7 @@ func run(argv []string) error {
 		return err
 	}
 
-	branch, _ := gitOutput(cfg.RepoRoot, "branch", "--show-current")
+	branch := resolveBranch(cfg.RepoRoot)
 	commit, _ := gitOutput(cfg.RepoRoot, "rev-parse", "--short=12", "HEAD")
 	commandLine := argv
 	if rawCommand := strings.TrimSpace(os.Getenv(envCanonicalCommandLine)); rawCommand != "" {
@@ -932,7 +932,7 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 	}
 	add("warning", "phase.online_one_pass.partial", "online_one_pass_maintenance is partial online maintenance; do not describe it as full compaction")
 	for _, r := range canon.Results {
-		if r.GeneratedAt == "" || r.RunDir == "" || r.Branch == "" || r.Commit == "" || len(r.CommandLine) == 0 {
+		if r.GeneratedAt == "" || r.RunDir == "" || r.Worktree == "" || r.Commit == "" || len(r.CommandLine) == 0 {
 			add("error", "missing_row_run_metadata", fmt.Sprintf("%s/%s is missing row-level run metadata", r.ConfigName, r.Phase))
 		}
 		if r.TotalBytes != nil && r.DocumentCount <= 0 {
@@ -945,14 +945,17 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 			add("error", "missing_compaction_flags", fmt.Sprintf("%s/%s is missing compaction flags", r.ConfigName, r.Phase))
 		}
 	}
-	if findResult(canon.Results, "sqlite_json_2_indexes", phaseSQLiteVacuum) == nil {
+	treeDBConfig := compactedTreeDBConfigName(canon)
+	sqliteJSONConfig := sqliteJSONConfigName(canon)
+	sqliteNativeConfig := sqliteNativeConfigName(canon)
+	if findResult(canon.Results, sqliteJSONConfig, phaseSQLiteVacuum) == nil {
 		add("error", "missing_sqlite_json_vacuum", "SQLite JSON VACUUM result is required for fair compacted-state comparison")
 	}
-	if findResult(canon.Results, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum) == nil {
+	if findResult(canon.Results, sqliteNativeConfig, phaseSQLiteVacuum) == nil {
 		add("error", "missing_sqlite_native_vacuum", "SQLite native-columns VACUUM result is required for fair compacted-state comparison")
 	}
-	if findResult(canon.Results, "treedb_template_v1_collection_2_indexes", phaseOfflineRewrite) != nil &&
-		findResult(canon.Results, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum) == nil {
+	if findResult(canon.Results, treeDBConfig, phaseOfflineRewrite) != nil &&
+		findResult(canon.Results, sqliteNativeConfig, phaseSQLiteVacuum) == nil {
 		add("error", "unfair_compacted_comparison", "TreeDB offline/full compaction must be compared against SQLite after VACUUM, not SQLite post-insert")
 	}
 	if findResult(canon.Results, "treedb_template_v1_raw", phaseOfflineRewrite) != nil {
@@ -964,12 +967,12 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 		}
 	}
 	for _, treedbPhase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
-		if findResult(canon.Results, "treedb_template_v1_collection_2_indexes", treedbPhase) == nil {
+		if findResult(canon.Results, treeDBConfig, treedbPhase) == nil {
 			continue
 		}
-		for _, sqliteName := range []string{"sqlite_native_columns_2_indexes", "sqlite_json_2_indexes"} {
-			if findComparison(canon.Comparisons, "treedb_template_v1_collection_2_indexes", treedbPhase, sqliteName, phaseSQLiteVacuum) == nil {
-				add("error", "missing_compacted_ratio", fmt.Sprintf("missing derived compacted comparison for %s/%s vs %s/%s", "treedb_template_v1_collection_2_indexes", treedbPhase, sqliteName, phaseSQLiteVacuum))
+		for _, sqliteName := range []string{sqliteNativeConfig, sqliteJSONConfig} {
+			if findComparison(canon.Comparisons, treeDBConfig, treedbPhase, sqliteName, phaseSQLiteVacuum) == nil {
+				add("error", "missing_compacted_ratio", fmt.Sprintf("missing derived compacted comparison for %s/%s vs %s/%s", treeDBConfig, treedbPhase, sqliteName, phaseSQLiteVacuum))
 			}
 		}
 	}
@@ -1003,16 +1006,16 @@ func buildCompactedComparisons(canon *canonicalRun) []comparisonRow {
 		return nil
 	}
 	var comparisons []comparisonRow
-	treeDBConfig := "treedb_template_v1_collection_2_indexes"
-	sqliteConfigs := []string{"sqlite_native_columns_2_indexes", "sqlite_json_2_indexes"}
+	treeDBConfig := compactedTreeDBConfigName(canon)
+	sqliteConfigs := []string{sqliteNativeConfigName(canon), sqliteJSONConfigName(canon)}
 	for _, treedbPhase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
 		treeRow := findResult(canon.Results, treeDBConfig, treedbPhase)
-		if treeRow == nil || treeRow.BytesPerDoc == nil || *treeRow.BytesPerDoc <= 0 {
+		if !hasPositiveBytesPerDoc(treeRow) {
 			continue
 		}
 		for _, sqliteConfig := range sqliteConfigs {
 			sqliteRow := findResult(canon.Results, sqliteConfig, phaseSQLiteVacuum)
-			if sqliteRow == nil || sqliteRow.BytesPerDoc == nil || *sqliteRow.BytesPerDoc <= 0 {
+			if !hasPositiveBytesPerDoc(sqliteRow) {
 				continue
 			}
 			comparisonName := fmt.Sprintf("%s_%s_vs_%s_%s", treeDBConfig, treedbPhase, sqliteConfig, phaseSQLiteVacuum)
@@ -1201,12 +1204,12 @@ func renderMarkdownReport(canon *canonicalRun) string {
 
 func renderExecutiveSummary(canon *canonicalRun) string {
 	fastest := fastestThroughput(canon.Results)
-	offline := findResult(canon.Results, "treedb_template_v1_collection_2_indexes", phaseOfflineRewrite)
-	full := findResult(canon.Results, "treedb_template_v1_collection_2_indexes", phaseFullLeafgenPackGC)
-	sqliteJSON := findResult(canon.Results, "sqlite_json_2_indexes", phaseSQLiteVacuum)
-	sqliteNative := findResult(canon.Results, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum)
-	if offline != nil && full != nil && sqliteJSON != nil && sqliteNative != nil &&
-		offline.BytesPerDoc != nil && full.BytesPerDoc != nil && sqliteJSON.BytesPerDoc != nil && sqliteNative.BytesPerDoc != nil {
+	offline := findResult(canon.Results, compactedTreeDBConfigName(canon), phaseOfflineRewrite)
+	full := findResult(canon.Results, compactedTreeDBConfigName(canon), phaseFullLeafgenPackGC)
+	sqliteJSON := findResult(canon.Results, sqliteJSONConfigName(canon), phaseSQLiteVacuum)
+	sqliteNative := findResult(canon.Results, sqliteNativeConfigName(canon), phaseSQLiteVacuum)
+	if hasPositiveBytesPerDoc(offline) && hasPositiveBytesPerDoc(full) &&
+		hasPositiveBytesPerDoc(sqliteJSON) && hasPositiveBytesPerDoc(sqliteNative) {
 		engine := "TreeDB"
 		if fastest != nil {
 			engine = fastest.ConfigName
@@ -1222,8 +1225,11 @@ func renderExecutiveSummary(canon *canonicalRun) string {
 }
 
 func writeFairComparison(sb *strings.Builder, canon *canonicalRun) {
-	sqliteJSON := findResult(canon.Results, "sqlite_json_2_indexes", phaseSQLiteVacuum)
-	sqliteNative := findResult(canon.Results, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum)
+	treeDBConfig := compactedTreeDBConfigName(canon)
+	sqliteJSONConfig := sqliteJSONConfigName(canon)
+	sqliteNativeConfig := sqliteNativeConfigName(canon)
+	sqliteJSON := findResult(canon.Results, sqliteJSONConfig, phaseSQLiteVacuum)
+	sqliteNative := findResult(canon.Results, sqliteNativeConfig, phaseSQLiteVacuum)
 	comparisons := comparisonsForReport(canon)
 	sb.WriteString("SQLite compacted baselines:\n\n")
 	sb.WriteString("| Config | Phase | B/doc | Total bytes |\n")
@@ -1238,8 +1244,8 @@ func writeFairComparison(sb *strings.Builder, canon *canonicalRun) {
 	sb.WriteString("| TreeDB config | Phase | B/doc | vs SQLite native-columns VACUUM | vs SQLite JSON VACUUM |\n")
 	sb.WriteString("| --- | --- | ---: | ---: | ---: |\n")
 	for _, phase := range []string{phaseOfflineRewrite, phaseFullLeafgenPackGC} {
-		nativeCmp := findComparison(comparisons, "treedb_template_v1_collection_2_indexes", phase, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum)
-		jsonCmp := findComparison(comparisons, "treedb_template_v1_collection_2_indexes", phase, "sqlite_json_2_indexes", phaseSQLiteVacuum)
+		nativeCmp := findComparison(comparisons, treeDBConfig, phase, sqliteNativeConfig, phaseSQLiteVacuum)
+		jsonCmp := findComparison(comparisons, treeDBConfig, phase, sqliteJSONConfig, phaseSQLiteVacuum)
 		if nativeCmp == nil && jsonCmp == nil {
 			continue
 		}
@@ -1257,7 +1263,7 @@ func writeFairComparison(sb *strings.Builder, canon *canonicalRun) {
 		if jsonCmp != nil {
 			jsonRatio = fmt.Sprintf("%.1fx smaller", jsonCmp.SmallerRatio)
 		}
-		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %.1f | %s | %s |\n", "treedb_template_v1_collection_2_indexes", phase, bpd, nativeRatio, jsonRatio))
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %.1f | %s | %s |\n", treeDBConfig, phase, bpd, nativeRatio, jsonRatio))
 	}
 	sb.WriteString("\nDerived comparison rows are also emitted in `benchmark_results.json` under `comparisons`.\n")
 }
@@ -1338,6 +1344,17 @@ func gitOutput(dir string, args ...string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+func resolveBranch(repoRoot string) string {
+	if branch, _ := gitOutput(repoRoot, "branch", "--show-current"); branch != "" {
+		return branch
+	}
+	if branch, _ := gitOutput(repoRoot, "rev-parse", "--abbrev-ref", "HEAD"); branch != "" && branch != "HEAD" {
+		return branch
+	}
+	branch, _ := gitOutput(repoRoot, "describe", "--all", "--always", "HEAD")
+	return branch
+}
+
 func splitCSV(v string) []string {
 	var out []string
 	for _, part := range strings.Split(v, ",") {
@@ -1362,6 +1379,29 @@ func canonicalConfigName(engine, format, shape string, indexes int) string {
 		return fmt.Sprintf("%s_%s_raw", engine, format)
 	}
 	return fmt.Sprintf("%s_%s_%s_%d_indexes", engine, format, shape, indexes)
+}
+
+func compactedTreeDBConfigName(canon *canonicalRun) string {
+	return canonicalConfigName("treedb", "template-v1", "collection", canonicalIndexCount(canon))
+}
+
+func sqliteJSONConfigName(canon *canonicalRun) string {
+	return canonicalConfigName("sqlite", "json", "collection", canonicalIndexCount(canon))
+}
+
+func sqliteNativeConfigName(canon *canonicalRun) string {
+	return canonicalConfigName("sqlite", "native-columns", "collection", canonicalIndexCount(canon))
+}
+
+func canonicalIndexCount(canon *canonicalRun) int {
+	if canon != nil && canon.Config.Indexes >= 0 {
+		return canon.Config.Indexes
+	}
+	return 0
+}
+
+func hasPositiveBytesPerDoc(row *resultRow) bool {
+	return row != nil && row.BytesPerDoc != nil && *row.BytesPerDoc > 0
 }
 
 func metricDefault(metrics map[string]float64, key string, def float64) float64 {

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -21,6 +21,7 @@ import (
 
 const schemaVersion = "collections-canonical-benchmark/v1"
 const envCanonicalCommandLine = "COLLECTION_CANONICAL_BENCH_COMMAND"
+const runDirSentinel = ".collection_canonical_bench_run"
 
 const (
 	phasePostInsert               = "post_insert"
@@ -363,6 +364,9 @@ func normalizeRunPaths(cfg *config) error {
 }
 
 func prepareRunDir(cfg config) error {
+	if err := validateSafeRunDir(cfg.OutDir); err != nil {
+		return err
+	}
 	paths := []string{
 		"logs",
 		"timed_matrix",
@@ -377,7 +381,43 @@ func prepareRunDir(cfg config) error {
 			return err
 		}
 	}
-	return os.MkdirAll(filepath.Join(cfg.OutDir, "logs"), 0755)
+	if err := os.MkdirAll(filepath.Join(cfg.OutDir, "logs"), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(cfg.OutDir, runDirSentinel), []byte(schemaVersion+"\n"), 0644)
+}
+
+func validateSafeRunDir(outDir string) error {
+	if outDir == "" {
+		return errors.New("-out-dir must not be empty")
+	}
+	clean := filepath.Clean(outDir)
+	if filepath.Dir(clean) == clean {
+		return fmt.Errorf("refusing to use filesystem root as -out-dir: %s", outDir)
+	}
+	info, err := os.Stat(clean)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stat -out-dir: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("-out-dir is not a directory: %s", outDir)
+	}
+	if _, err := os.Stat(filepath.Join(clean, runDirSentinel)); err == nil {
+		return nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("stat run-dir sentinel: %w", err)
+	}
+	entries, err := os.ReadDir(clean)
+	if err != nil {
+		return fmt.Errorf("read -out-dir: %w", err)
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	return fmt.Errorf("-out-dir already exists and is not an empty canonical benchmark run dir: %s; choose a new directory or use a directory containing %s", outDir, runDirSentinel)
 }
 
 func parseConfig(args []string) (config, error) {

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -140,6 +140,50 @@ func TestExecutiveSummarySkipsZeroBytesPerDocRatios(t *testing.T) {
 	}
 }
 
+func TestExecutiveSummaryUsesConfiguredIndexCountLabel(t *testing.T) {
+	canon := knownExampleRun()
+	canon.Config.Indexes = 1
+	canon.Results = append(canon.Results,
+		testStorageRow("sqlite_json_1_indexes", "sqlite_wal_normal", "json", "collection", phaseSQLiteVacuum, 1, 18000000, 180.0),
+		testStorageRow("sqlite_native_columns_1_indexes", "sqlite_wal_normal", "native-columns", "collection", phaseSQLiteVacuum, 1, 12000000, 120.0),
+		testStorageRow("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseFullLeafgenPackGC, 1, 2800000, 28.0),
+	)
+	finalizeRunMetadata(canon)
+
+	summary := renderExecutiveSummary(canon)
+	if !strings.Contains(summary, "fully compacted one-index template-v1 collection storage") {
+		t.Fatalf("summary did not use configured index count: %s", summary)
+	}
+	if strings.Contains(summary, "two-index") {
+		t.Fatalf("summary should not hardcode two-index for one-index run: %s", summary)
+	}
+}
+
+func TestGuardrailRespectsSkipSQLite(t *testing.T) {
+	canon := knownExampleRun()
+	canon.Config.SkipSQLite = true
+	var filtered []resultRow
+	for _, row := range canon.Results {
+		if strings.HasPrefix(row.ConfigName, "sqlite_") {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	canon.Results = filtered
+	canon.Comparisons = buildCompactedComparisons(canon)
+	finalizeRunMetadata(canon)
+
+	checks := validateCanonicalRun(canon)
+	for _, check := range checks {
+		if check.Code == "missing_sqlite_json_vacuum" ||
+			check.Code == "missing_sqlite_native_vacuum" ||
+			check.Code == "missing_compacted_ratio" {
+			t.Fatalf("skip-sqlite should not fail SQLite comparison guardrails, got %#v", checks)
+		}
+	}
+	assertCheckCode(t, checks, "sqlite.skipped")
+}
+
 func TestGuardrailRejectsBadCompactedComparisonBasis(t *testing.T) {
 	canon := knownExampleRun()
 	canon.Comparisons = append(canon.Comparisons, comparisonRow{

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -95,6 +95,48 @@ func TestParseConfigRejectsUnsupportedIndexCount(t *testing.T) {
 	}
 }
 
+func TestParseConfigValidatesIndexVacuum(t *testing.T) {
+	cfg, err := parseConfig([]string{"-index-vacuum", "ONLINE"})
+	if err != nil {
+		t.Fatalf("parseConfig rejected valid normalized index vacuum: %v", err)
+	}
+	if cfg.FullLeafgenIndexVacuum != "online" {
+		t.Fatalf("index vacuum was not normalized: %q", cfg.FullLeafgenIndexVacuum)
+	}
+	_, err = parseConfig([]string{"-index-vacuum", "bogus"})
+	if err == nil || !strings.Contains(err.Error(), "-index-vacuum must be one of offline, online, auto, or none") {
+		t.Fatalf("parseConfig accepted unsupported index vacuum, err=%v", err)
+	}
+}
+
+func TestParseFullLeafgenSummaryPreservesZeroIndexCount(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "summary.json")
+	summary := fixtureSummary{
+		DocumentFormat: "template-v1",
+		Profile:        "fast",
+		Docs:           100,
+		BatchSize:      16,
+		IndexCount:     0,
+		DiskUsageFinal: &diskUsageSummary{TotalBytes: 1234},
+	}
+	if err := writeJSON(path, summary); err != nil {
+		t.Fatal(err)
+	}
+	canon := knownExampleRun()
+	canon.Config.Indexes = 2
+	canon.Results = nil
+	if err := parseFullLeafgenSummary(canon, path, config{Docs: 100, Indexes: 2, FullLeafgenIndexVacuum: "offline"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(canon.Results) != 1 {
+		t.Fatalf("expected one full leafgen row, got %d", len(canon.Results))
+	}
+	row := canon.Results[0]
+	if row.IndexCount != 0 || row.ConfigName != "treedb_template_v1_collection_0_indexes" {
+		t.Fatalf("zero-index full leafgen row was mislabeled: index=%d config=%s", row.IndexCount, row.ConfigName)
+	}
+}
+
 func TestGuardrailRequiresSQLiteVacuumForCompactedComparison(t *testing.T) {
 	canon := knownExampleRun()
 	var filtered []resultRow

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -38,6 +40,34 @@ func TestCanonicalReportKnownCompressionShape(t *testing.T) {
 	fairSection := markdownSection(md, "## Fair Compacted-State Comparison", "## Maintenance/Compaction Details")
 	if strings.Contains(fairSection, "treedb_template_v1_raw") {
 		t.Fatalf("fair compacted comparison must not include raw TreeDB rows\n%s", fairSection)
+	}
+}
+
+func TestPrepareRunDirRemovesPriorCanonicalArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	staleReport := filepath.Join(dir, "timed_matrix", "stale", "collections_report.json")
+	if err := os.MkdirAll(filepath.Dir(staleReport), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(staleReport, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	keepPath := filepath.Join(dir, "keep.txt")
+	if err := os.WriteFile(keepPath, []byte("keep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := prepareRunDir(config{OutDir: dir}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "timed_matrix")); !os.IsNotExist(err) {
+		t.Fatalf("expected stale timed_matrix to be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "logs")); err != nil {
+		t.Fatalf("expected fresh logs directory: %v", err)
+	}
+	if _, err := os.Stat(keepPath); err != nil {
+		t.Fatalf("non-canonical files should be preserved: %v", err)
 	}
 }
 

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -90,6 +90,56 @@ func TestCanonicalDerivedCompactedComparisons(t *testing.T) {
 	}
 }
 
+func TestCanonicalDerivedCompactedComparisonsUseConfiguredIndexCount(t *testing.T) {
+	canon := knownExampleRun()
+	canon.Config.Indexes = 1
+	canon.Results = append(canon.Results,
+		testStorageRow("sqlite_json_1_indexes", "sqlite_wal_normal", "json", "collection", phaseSQLiteVacuum, 1, 18000000, 180.0),
+		testStorageRow("sqlite_native_columns_1_indexes", "sqlite_wal_normal", "native-columns", "collection", phaseSQLiteVacuum, 1, 12000000, 120.0),
+		testStorageRow("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseFullLeafgenPackGC, 1, 2800000, 28.0),
+	)
+	finalizeRunMetadata(canon)
+
+	comparisons := buildCompactedComparisons(canon)
+	if got := findComparison(comparisons, "treedb_template_v1_collection_1_indexes", phaseOfflineRewrite, "sqlite_native_columns_1_indexes", phaseSQLiteVacuum); got == nil {
+		t.Fatalf("missing configured one-index comparison, got %#v", comparisons)
+	}
+	if got := findComparison(comparisons, "treedb_template_v1_collection_2_indexes", phaseOfflineRewrite, "sqlite_native_columns_2_indexes", phaseSQLiteVacuum); got != nil {
+		t.Fatalf("unexpected hardcoded two-index comparison: %#v", got)
+	}
+}
+
+func TestGuardrailAllowsDetachedHeadBranchMetadata(t *testing.T) {
+	canon := knownExampleRun()
+	canon.Branch = ""
+	finalizeRunMetadata(canon)
+
+	checks := validateCanonicalRun(canon)
+	for _, check := range checks {
+		if check.Code == "missing_row_run_metadata" {
+			t.Fatalf("detached-head branch metadata should be allowed, got %#v", checks)
+		}
+	}
+}
+
+func TestExecutiveSummarySkipsZeroBytesPerDocRatios(t *testing.T) {
+	canon := knownExampleRun()
+	for i := range canon.Results {
+		if canon.Results[i].ConfigName == "treedb_template_v1_collection_2_indexes" && canon.Results[i].Phase == phaseOfflineRewrite {
+			canon.Results[i].BytesPerDoc = floatPtr(0)
+			break
+		}
+	}
+
+	summary := renderExecutiveSummary(canon)
+	if strings.Contains(summary, "+Inf") || strings.Contains(summary, "NaN") {
+		t.Fatalf("summary should not emit invalid ratios: %s", summary)
+	}
+	if !strings.Contains(summary, "fair compacted-state headline could not be generated") {
+		t.Fatalf("summary should fall back when ratio inputs are unusable: %s", summary)
+	}
+}
+
 func TestGuardrailRejectsBadCompactedComparisonBasis(t *testing.T) {
 	canon := knownExampleRun()
 	canon.Comparisons = append(canon.Comparisons, comparisonRow{
@@ -153,6 +203,25 @@ func markdownSection(md, start, end string) string {
 		return rest
 	}
 	return rest[:endIdx]
+}
+
+func testStorageRow(config, engine, format, shape, phase string, indexes int, bytes int64, bpd float64) resultRow {
+	return resultRow{
+		ConfigName:      config,
+		Engine:          engine,
+		Format:          format,
+		Shape:           shape,
+		IndexCount:      indexes,
+		DocumentCount:   100000,
+		BenchmarkName:   "test-fixture",
+		Phase:           phase,
+		MaintenanceMode: phase,
+		TotalBytes:      int64Ptr(bytes),
+		BytesPerDoc:     floatPtr(bpd),
+		BatchSize:       16000,
+		MeasurementKind: "test_fixture",
+		CompactionFlags: map[string]string{"test": "true"},
+	}
 }
 
 func knownExampleRun() *canonicalRun {

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -88,6 +88,13 @@ func TestOfflineRewriteIndexArgsIncludesConfiguredShape(t *testing.T) {
 	}
 }
 
+func TestParseConfigRejectsUnsupportedIndexCount(t *testing.T) {
+	_, err := parseConfig([]string{"-indexes", "4"})
+	if err == nil || !strings.Contains(err.Error(), "-indexes must be 0, 1, 2, or 3") {
+		t.Fatalf("parseConfig accepted unsupported index count, err=%v", err)
+	}
+}
+
 func TestGuardrailRequiresSQLiteVacuumForCompactedComparison(t *testing.T) {
 	canon := knownExampleRun()
 	var filtered []resultRow

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -231,6 +231,30 @@ func TestGuardrailRespectsSkipSQLite(t *testing.T) {
 	assertCheckCode(t, checks, "sqlite.skipped")
 }
 
+func TestGuardrailTreatsAbsentSQLiteRowsAsAutoSkipped(t *testing.T) {
+	canon := knownExampleRun()
+	var filtered []resultRow
+	for _, row := range canon.Results {
+		if strings.HasPrefix(row.ConfigName, "sqlite_") {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	canon.Results = filtered
+	canon.Comparisons = buildCompactedComparisons(canon)
+	finalizeRunMetadata(canon)
+
+	checks := validateCanonicalRun(canon)
+	for _, check := range checks {
+		if check.Code == "missing_sqlite_json_vacuum" ||
+			check.Code == "missing_sqlite_native_vacuum" ||
+			check.Code == "missing_compacted_ratio" {
+			t.Fatalf("auto-skipped SQLite should not fail SQLite comparison guardrails, got %#v", checks)
+		}
+	}
+	assertCheckCode(t, checks, "sqlite.auto_skipped")
+}
+
 func TestGuardrailRejectsBadCompactedComparisonBasis(t *testing.T) {
 	canon := knownExampleRun()
 	canon.Comparisons = append(canon.Comparisons, comparisonRow{
@@ -271,6 +295,17 @@ func TestGuardrailRequiresExplicitShapeLabel(t *testing.T) {
 	canon.Results[0].Shape = ""
 	checks := validateCanonicalRun(canon)
 	assertCheckCode(t, checks, "missing_shape_label")
+}
+
+func TestMarkdownInlineCodeHandlesBackticks(t *testing.T) {
+	got := markdownInlineCode("run `quoted` value")
+	if got != "``run `quoted` value``" {
+		t.Fatalf("markdownInlineCode with embedded backticks = %q", got)
+	}
+	got = markdownInlineCode("`edge`")
+	if got != "`` `edge` ``" {
+		t.Fatalf("markdownInlineCode with edge backticks = %q", got)
+	}
 }
 
 func assertCheckCode(t *testing.T, checks []guardrailCheck, code string) {

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -45,6 +45,9 @@ func TestCanonicalReportKnownCompressionShape(t *testing.T) {
 
 func TestPrepareRunDirRemovesPriorCanonicalArtifacts(t *testing.T) {
 	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, runDirSentinel), []byte(schemaVersion+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	staleReport := filepath.Join(dir, "timed_matrix", "stale", "collections_report.json")
 	if err := os.MkdirAll(filepath.Dir(staleReport), 0755); err != nil {
 		t.Fatal(err)
@@ -69,6 +72,9 @@ func TestPrepareRunDirRemovesPriorCanonicalArtifacts(t *testing.T) {
 	if _, err := os.Stat(keepPath); err != nil {
 		t.Fatalf("non-canonical files should be preserved: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(dir, runDirSentinel)); err != nil {
+		t.Fatalf("run-dir sentinel should be present: %v", err)
+	}
 }
 
 func TestNormalizeRunPathsMakesOutDirAbsolute(t *testing.T) {
@@ -81,6 +87,43 @@ func TestNormalizeRunPathsMakesOutDirAbsolute(t *testing.T) {
 	}
 	if !strings.HasSuffix(cfg.OutDir, filepath.Join("relative", "bench-run")) {
 		t.Fatalf("out dir lost the requested suffix: %q", cfg.OutDir)
+	}
+}
+
+func TestValidateSafeRunDirRefusesUnsafeExistingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "unrelated.txt"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := validateSafeRunDir(dir)
+	if err == nil || !strings.Contains(err.Error(), "not an empty canonical benchmark run dir") {
+		t.Fatalf("expected unsafe existing directory to be rejected, err=%v", err)
+	}
+}
+
+func TestValidateSafeRunDirAllowsEmptyOrSentinelDirectory(t *testing.T) {
+	emptyDir := t.TempDir()
+	if err := validateSafeRunDir(emptyDir); err != nil {
+		t.Fatalf("empty directory should be allowed: %v", err)
+	}
+
+	sentinelDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sentinelDir, runDirSentinel), []byte(schemaVersion+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sentinelDir, "unrelated.txt"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSafeRunDir(sentinelDir); err != nil {
+		t.Fatalf("sentinel directory should be allowed: %v", err)
+	}
+}
+
+func TestValidateSafeRunDirRefusesFilesystemRoot(t *testing.T) {
+	root := filepath.Clean(string(os.PathSeparator))
+	err := validateSafeRunDir(root)
+	if err == nil || !strings.Contains(err.Error(), "filesystem root") {
+		t.Fatalf("expected filesystem root to be rejected, err=%v", err)
 	}
 }
 

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCanonicalReportKnownCompressionShape(t *testing.T) {
+	canon := knownExampleRun()
+	canon.Checks = validateCanonicalRun(canon)
+	md := renderMarkdownReport(canon)
+
+	required := []string{
+		"| `command_line` | `./scripts/bench_collections_canonical.sh -docs 100000` |",
+		"44.3 B/doc via PR 1096-style offline rewrite and 31.7 B/doc via full leafgen pack/GC",
+		"offline rewrite is about 3.5x smaller than SQLite native columns and 5.2x smaller than SQLite JSON",
+		"full leafgen pack/GC is about 4.9x and 7.3x smaller, respectively",
+		"`online_one_pass_maintenance`",
+		"Do not compare TreeDB `offline_rewrite` or `full_leafgen_pack_gc` only against SQLite `post_insert` rows.",
+		"`treedb_template_v1_collection_2_indexes` | `offline_rewrite` | 44.3",
+		"`treedb_template_v1_collection_2_indexes` | `full_leafgen_pack_gc` | 31.7",
+		"make bench-collections-canonical",
+	}
+	for _, want := range required {
+		if !strings.Contains(md, want) {
+			t.Fatalf("report missing %q\n%s", want, md)
+		}
+	}
+	for _, check := range canon.Checks {
+		if check.Severity == "error" {
+			t.Fatalf("unexpected guardrail error: %+v", check)
+		}
+	}
+	if strings.Contains(md, "online_one_pass_maintenance` | Full") ||
+		strings.Contains(md, "online_one_pass_maintenance` | full") {
+		t.Fatalf("online one-pass maintenance appears to be labeled as full compaction\n%s", md)
+	}
+	fairSection := markdownSection(md, "## Fair Compacted-State Comparison", "## Maintenance/Compaction Details")
+	if strings.Contains(fairSection, "treedb_template_v1_raw") {
+		t.Fatalf("fair compacted comparison must not include raw TreeDB rows\n%s", fairSection)
+	}
+}
+
+func TestGuardrailRequiresSQLiteVacuumForCompactedComparison(t *testing.T) {
+	canon := knownExampleRun()
+	var filtered []resultRow
+	for _, row := range canon.Results {
+		if row.ConfigName == "sqlite_native_columns_2_indexes" && row.Phase == phaseSQLiteVacuum {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	canon.Results = filtered
+	checks := validateCanonicalRun(canon)
+	if !hasErrorCheck(checks) {
+		t.Fatalf("expected guardrail error, got %#v", checks)
+	}
+	var saw bool
+	for _, check := range checks {
+		if check.Code == "missing_sqlite_native_vacuum" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatalf("expected missing_sqlite_native_vacuum check, got %#v", checks)
+	}
+}
+
+func TestCanonicalDerivedCompactedComparisons(t *testing.T) {
+	canon := knownExampleRun()
+	comparisons := buildCompactedComparisons(canon)
+	cases := []struct {
+		phase        string
+		sqliteConfig string
+		wantRatio    float64
+	}{
+		{phaseOfflineRewrite, "sqlite_native_columns_2_indexes", 156.7 / 44.3},
+		{phaseFullLeafgenPackGC, "sqlite_native_columns_2_indexes", 156.7 / 31.7},
+		{phaseOfflineRewrite, "sqlite_json_2_indexes", 231.7 / 44.3},
+		{phaseFullLeafgenPackGC, "sqlite_json_2_indexes", 231.7 / 31.7},
+	}
+	for _, tc := range cases {
+		got := findComparison(comparisons, "treedb_template_v1_collection_2_indexes", tc.phase, tc.sqliteConfig, phaseSQLiteVacuum)
+		if got == nil {
+			t.Fatalf("missing comparison for %s vs %s", tc.phase, tc.sqliteConfig)
+		}
+		if diff := got.SmallerRatio - tc.wantRatio; diff < -0.0001 || diff > 0.0001 {
+			t.Fatalf("ratio for %s vs %s = %f, want %f", tc.phase, tc.sqliteConfig, got.SmallerRatio, tc.wantRatio)
+		}
+	}
+}
+
+func TestGuardrailRejectsBadCompactedComparisonBasis(t *testing.T) {
+	canon := knownExampleRun()
+	canon.Comparisons = append(canon.Comparisons, comparisonRow{
+		ComparisonName:    "bad",
+		TreeDBConfigName:  "treedb_template_v1_collection_2_indexes",
+		TreeDBPhase:       phaseFullLeafgenPackGC,
+		SQLiteConfigName:  "sqlite_native_columns_2_indexes",
+		SQLitePhase:       phasePostInsert,
+		TreeDBBytesPerDoc: 31.7,
+		SQLiteBytesPerDoc: 176.1,
+		SmallerRatio:      176.1 / 31.7,
+	})
+	checks := validateCanonicalRun(canon)
+	assertCheckCode(t, checks, "compacted_compared_to_sqlite_post_insert")
+}
+
+func TestGuardrailRequiresDocumentCountForBytesPerDoc(t *testing.T) {
+	canon := knownExampleRun()
+	canon.Results[0].DocumentCount = 0
+	checks := validateCanonicalRun(canon)
+	assertCheckCode(t, checks, "missing_document_count")
+}
+
+func TestGuardrailRequiresCompactionFlags(t *testing.T) {
+	canon := knownExampleRun()
+	for i := range canon.Results {
+		if canon.Results[i].Phase == phaseFullLeafgenPackGC {
+			canon.Results[i].CompactionFlags = nil
+			break
+		}
+	}
+	checks := validateCanonicalRun(canon)
+	assertCheckCode(t, checks, "missing_compaction_flags")
+}
+
+func TestGuardrailRequiresExplicitShapeLabel(t *testing.T) {
+	canon := knownExampleRun()
+	canon.Results[0].Shape = ""
+	checks := validateCanonicalRun(canon)
+	assertCheckCode(t, checks, "missing_shape_label")
+}
+
+func assertCheckCode(t *testing.T, checks []guardrailCheck, code string) {
+	t.Helper()
+	for _, check := range checks {
+		if check.Code == code {
+			return
+		}
+	}
+	t.Fatalf("expected guardrail check %q, got %#v", code, checks)
+}
+
+func markdownSection(md, start, end string) string {
+	startIdx := strings.Index(md, start)
+	if startIdx < 0 {
+		return ""
+	}
+	rest := md[startIdx:]
+	endIdx := strings.Index(rest, end)
+	if endIdx < 0 {
+		return rest
+	}
+	return rest[:endIdx]
+}
+
+func knownExampleRun() *canonicalRun {
+	docs := 100000
+	batch := 16000
+	row := func(config, engine, format, shape, phase string, indexes int, bytes int64, bpd float64) resultRow {
+		return resultRow{
+			ConfigName:      config,
+			Engine:          engine,
+			Format:          format,
+			Shape:           shape,
+			IndexCount:      indexes,
+			DocumentCount:   docs,
+			BenchmarkName:   "known-example",
+			Phase:           phase,
+			MaintenanceMode: phase,
+			TotalBytes:      int64Ptr(bytes),
+			BytesPerDoc:     floatPtr(bpd),
+			BatchSize:       batch,
+			MeasurementKind: "test_fixture",
+			CompactionFlags: map[string]string{"test": "true"},
+		}
+	}
+	canon := &canonicalRun{
+		SchemaVersion: schemaVersion,
+		GeneratedAt:   "2026-04-29T00:00:00Z",
+		RunDir:        "/tmp/example",
+		Worktree:      "/repo",
+		Branch:        "test",
+		Commit:        "abcdef",
+		CommandLine:   []string{"./scripts/bench_collections_canonical.sh -docs 100000"},
+		Config: canonicalConfig{
+			Docs:                      docs,
+			BatchSize:                 batch,
+			Indexes:                   2,
+			TreeEngine:                "production_fast",
+			Profile:                   "fast",
+			Formats:                   []string{"json", "template-v1"},
+			LeafSegmentTargetBytes:    1048576,
+			LeafgenPackFrameK:         16,
+			FullLeafgenForce:          true,
+			FullLeafgenMaxGenerations: 0,
+			FullLeafgenIndexVacuum:    "offline",
+		},
+		Artifacts: map[string]string{
+			"benchmark_results_json": "benchmark_results.json",
+			"benchmark_matrix_csv":   "benchmark_matrix.csv",
+		},
+		Results: []resultRow{
+			{
+				ConfigName:      "treedb_template_v1_collection_2_indexes",
+				Engine:          "production_fast",
+				Format:          "template-v1",
+				Shape:           "collection",
+				IndexCount:      2,
+				DocumentCount:   docs,
+				BenchmarkName:   "BenchmarkCollectionShapeInsertBatch/indexes_2",
+				Phase:           phasePostInsert,
+				MaintenanceMode: "none",
+				TotalBytes:      int64Ptr(10555966),
+				BytesPerDoc:     floatPtr(105.6),
+				DocsPerSec:      floatPtr(584112),
+				NsPerDoc:        floatPtr(1712),
+				BatchSize:       batch,
+				BenchmarkTimed:  true,
+				MeasurementKind: "go_benchmark",
+			},
+			{
+				ConfigName:      "treedb_template_v1_collection_2_indexes",
+				Engine:          "production_fast",
+				Format:          "template-v1",
+				Shape:           "collection",
+				IndexCount:      2,
+				DocumentCount:   docs,
+				BenchmarkName:   "BenchmarkCollectionShapeInsertBatch/indexes_2",
+				Phase:           phaseOnlineOnePassMaintenance,
+				MaintenanceMode: "online_one_pass_vlog_rewrite_then_one_leafgen_pack",
+				TotalBytes:      int64Ptr(9923257),
+				BytesPerDoc:     floatPtr(99.2),
+				BatchSize:       batch,
+				MeasurementKind: "benchmark_post_processing",
+				CompactionFlags: map[string]string{"leafgen-pack-max-generations": "1"},
+			},
+			row("treedb_template_v1_raw", "treedb_fast", "template-v1", "raw", phaseOfflineRewrite, 0, 1983120, 19.8),
+			row("treedb_template_v1_collection_0_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineRewrite, 0, 1948075, 19.5),
+			row("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineRewrite, 1, 3751406, 37.5),
+			row("treedb_template_v1_collection_2_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineRewrite, 2, 4434451, 44.3),
+			row("treedb_template_v1_collection_2_indexes", "treedb_fast", "template-v1", "collection", phaseFullLeafgenPackGC, 2, 3174681, 31.7),
+			row("sqlite_json_2_indexes", "sqlite_wal_normal", "json", "collection", phaseSQLiteVacuum, 2, 23166976, 231.7),
+			row("sqlite_native_columns_2_indexes", "sqlite_wal_normal", "native-columns", "collection", phaseSQLiteVacuum, 2, 15671296, 156.7),
+		},
+	}
+	canon.Comparisons = buildCompactedComparisons(canon)
+	finalizeRunMetadata(canon)
+	return canon
+}

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -71,6 +71,23 @@ func TestPrepareRunDirRemovesPriorCanonicalArtifacts(t *testing.T) {
 	}
 }
 
+func TestOfflineRewriteIndexArgsIncludesConfiguredShape(t *testing.T) {
+	tests := []struct {
+		configured int
+		want       string
+	}{
+		{configured: 0, want: "0,1,2"},
+		{configured: 2, want: "0,1,2"},
+		{configured: 3, want: "0,1,2,3"},
+	}
+	for _, tt := range tests {
+		got := strings.Join(offlineRewriteIndexArgs(tt.configured), ",")
+		if got != tt.want {
+			t.Fatalf("offlineRewriteIndexArgs(%d) = %q, want %q", tt.configured, got, tt.want)
+		}
+	}
+}
+
 func TestGuardrailRequiresSQLiteVacuumForCompactedComparison(t *testing.T) {
 	canon := knownExampleRun()
 	var filtered []resultRow

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -71,6 +71,19 @@ func TestPrepareRunDirRemovesPriorCanonicalArtifacts(t *testing.T) {
 	}
 }
 
+func TestNormalizeRunPathsMakesOutDirAbsolute(t *testing.T) {
+	cfg := config{OutDir: filepath.Join("relative", "bench-run")}
+	if err := normalizeRunPaths(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(cfg.OutDir) {
+		t.Fatalf("out dir was not normalized to an absolute path: %q", cfg.OutDir)
+	}
+	if !strings.HasSuffix(cfg.OutDir, filepath.Join("relative", "bench-run")) {
+		t.Fatalf("out dir lost the requested suffix: %q", cfg.OutDir)
+	}
+}
+
 func TestOfflineRewriteIndexArgsIncludesConfiguredShape(t *testing.T) {
 	tests := []struct {
 		configured int

--- a/docs/benchmarks/collections_canonical_benchmark.md
+++ b/docs/benchmarks/collections_canonical_benchmark.md
@@ -40,6 +40,11 @@ Use `-out-dir <dir>` to keep a specific run directory:
 ./scripts/bench_collections_canonical.sh -out-dir /tmp/collections_canonical_run
 ```
 
+For cleanup safety, a user-supplied `-out-dir` must either not exist, be empty,
+or contain the harness sentinel file `.collection_canonical_bench_run` from a
+previous canonical run. The runner refuses filesystem roots and non-empty
+directories without that sentinel.
+
 ## Canonical Phases
 
 `post_insert`

--- a/docs/benchmarks/collections_canonical_benchmark.md
+++ b/docs/benchmarks/collections_canonical_benchmark.md
@@ -1,0 +1,193 @@
+# TreeDB Collections Canonical Benchmark
+
+This workflow is the canonical way to compare TreeDB collection storage against
+SQLite. It exists to prevent the earlier reporting mistake where TreeDB's
+partial online maintenance size was presented as if it were a fully compacted
+state.
+
+## Run
+
+The canonical end-to-end run target is:
+
+```bash
+make bench-collections-canonical
+```
+
+Equivalent direct command:
+
+```bash
+./scripts/bench_collections_canonical.sh
+```
+
+`make collection-canonical-bench-bin` builds only the runner binary. The older
+`make collection-canonical-bench` target is kept as a build alias for
+compatibility; it is not the canonical benchmark run target.
+
+The runner creates a timestamped directory under `/tmp` by default and writes:
+
+- `benchmark_results.json`: canonical machine-readable results and guardrails.
+- `benchmark_summary.md`: human-readable report.
+- `benchmark_matrix.csv`: flat table for spreadsheet/diff tooling.
+- `timed_matrix/`: existing timed TreeDB/SQLite benchmark matrix artifacts.
+- `offline_rewrite/`: PR 1096-style offline rewrite artifacts.
+- `full_leafgen_pack_gc/`: full leaf-generation pack/GC fixture artifacts.
+
+Use `-out-dir <dir>` to keep a specific run directory:
+
+```bash
+./scripts/bench_collections_canonical.sh -out-dir /tmp/collections_canonical_run
+```
+
+## Canonical Phases
+
+`post_insert`
+
+Size after insert and the flush/checkpoint needed for correctness. This is not a
+compacted state. It can be compared with other post-insert rows.
+
+`online_one_pass_maintenance`
+
+The current benchmark harness's online maintenance path. It is useful for
+tracking what a bounded online maintenance pass accomplishes, but it is partial
+maintenance and must not be described as full compaction.
+
+`offline_rewrite`
+
+The PR 1096-style offline path:
+
+```bash
+treemap vlog-rewrite <dir> -rw
+```
+
+This is a full/offline rewrite comparison point. Compare it with SQLite after
+`VACUUM`, not SQLite post-insert.
+
+`full_leafgen_pack_gc`
+
+The explicit full leaf-generation pack/GC path. The canonical runner records
+the exact knobs:
+
+- `leaf-segment-target-bytes`
+- `leafgen-pack-gc`
+- `leafgen-pack-force`
+- `leafgen-pack-max-generations`
+- `leafgen-pack-frame-k`
+- `index-vacuum`
+
+This is also a full compacted TreeDB comparison point. Compare it with SQLite
+after `VACUUM`.
+
+`sqlite_vacuum`
+
+SQLite compacted baseline after `VACUUM`. This is the required SQLite baseline
+when comparing against TreeDB `offline_rewrite` or `full_leafgen_pack_gc`.
+
+## Fair Comparisons
+
+Fair post-insert comparison:
+
+- TreeDB `post_insert`
+- SQLite `post_insert`
+
+Fair compacted-state comparison:
+
+- TreeDB `offline_rewrite`
+- TreeDB `full_leafgen_pack_gc`
+- SQLite `sqlite_vacuum`
+
+Do not compare TreeDB fully compacted rows only against SQLite post-insert rows.
+The generated report includes guardrail checks for missing SQLite VACUUM rows
+and labels `online_one_pass_maintenance` as partial maintenance.
+
+## Default Shape
+
+The default run uses:
+
+- 100,000 documents
+- batch size 16,000
+- two secondary indexes for the primary TreeDB/SQLite comparison
+- TreeDB `production_fast`
+- TreeDB document formats `json` and `template-v1`
+- SQLite JSON and SQLite native-column baselines
+- full leafgen pack/GC with:
+  - `leaf-segment-target-bytes=1048576`
+  - `leafgen-pack-force=true`
+  - `leafgen-pack-max-generations=0`
+  - `leafgen-pack-frame-k=16`
+  - `index-vacuum=offline`
+
+## Adding Configurations
+
+For TreeDB document formats, pass `-formats`:
+
+```bash
+./scripts/bench_collections_canonical.sh -formats json,template-v1
+```
+
+For a different primary index-count shape:
+
+```bash
+./scripts/bench_collections_canonical.sh -indexes 3
+```
+
+For compaction sweeps, vary the leafgen flags:
+
+```bash
+./scripts/bench_collections_canonical.sh \
+  -leaf-segment-target-bytes 1048576 \
+  -leafgen-pack-frame-k 16 \
+  -leafgen-pack-max-generations 0 \
+  -index-vacuum offline
+```
+
+If adding a new SQLite or TreeDB shape to the underlying benchmark matrix, keep
+the canonical names stable and explicit:
+
+- `treedb_template_v1_collection_2_indexes`
+- `treedb_template_v1_raw`
+- `sqlite_json_2_indexes`
+- `sqlite_native_columns_2_indexes`
+
+## Comparing Runs
+
+Prefer comparing `benchmark_results.json` or `benchmark_matrix.csv` rather than
+scraping Markdown. The stable fields are:
+
+- `config_name`
+- `phase`
+- `format`
+- `shape`
+- `index_count`
+- `document_count`
+- `total_bytes`
+- `bytes_per_doc`
+- `docs_per_sec`
+- `ns_per_doc`
+- `measurement_kind`
+- `compaction_flags`
+
+`benchmark_results.json` also contains a `comparisons` array with derived
+compacted-state ratios. Those ratios are computed from the run's TreeDB
+compacted rows and SQLite `sqlite_vacuum` rows; they are not hardcoded.
+
+`bytes_per_doc` is always `total_bytes / document_count`. If document count is
+missing, the guardrail checks report an error because B/doc would be ambiguous.
+
+## Known Example Shape
+
+The canonical report can represent the PR 1096-style finding without hardcoding
+it as production output:
+
+- offline rewrite:
+  - raw TreeDB template-v1: about 19.8 B/doc
+  - collection, 0 indexes: about 19.5 B/doc
+  - collection, 1 index: about 37.5 B/doc
+  - collection, 2 indexes: about 44.3 B/doc
+- full leafgen pack/GC:
+  - collection template-v1, 2 indexes: about 31.7 B/doc
+- SQLite after `VACUUM`:
+  - JSON: about 231.7 B/doc
+  - native columns: about 156.7 B/doc
+
+The exact numbers in a report should always come from that run's generated JSON,
+not from this document.

--- a/docs/benchmarks/collections_canonical_benchmark.md
+++ b/docs/benchmarks/collections_canonical_benchmark.md
@@ -23,7 +23,9 @@ Equivalent direct command:
 `make collection-canonical-bench` target is kept as a build alias for
 compatibility; it is not the canonical benchmark run target.
 
-The runner creates a timestamped directory under `/tmp` by default and writes:
+The runner creates a timestamped directory under the system temporary directory
+returned by `os.TempDir()` by default (often `/tmp` on Linux, but it may be
+another location such as `$TMPDIR` on macOS) and writes:
 
 - `benchmark_results.json`: canonical machine-readable results and guardrails.
 - `benchmark_summary.md`: human-readable report.

--- a/scripts/bench_collections_canonical.sh
+++ b/scripts/bench_collections_canonical.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+cmd_display="./scripts/bench_collections_canonical.sh"
+for arg in "$@"; do
+	printf -v quoted '%q' "$arg"
+	cmd_display+=" $quoted"
+done
+export COLLECTION_CANONICAL_BENCH_COMMAND="$cmd_display"
+
+if [[ "${USE_BUILT_BIN:-0}" == "1" ]]; then
+	make collection-canonical-bench-bin >/dev/null
+	exec "$repo_root/bin/collection-canonical-bench" "$@"
+fi
+
+exec go run ./cmd/collection_canonical_bench "$@"

--- a/scripts/treedb_collection_compression_matrix.sh
+++ b/scripts/treedb_collection_compression_matrix.sh
@@ -7,6 +7,7 @@ DOCS="${DOCS:-100000}"
 BATCH="${BATCH:-16000}"
 RUN_DIR="${RUN_DIR:-/tmp/treedb_collection_compression_$(date +%Y%m%d_%H%M%S)}"
 PROFILE="${PROFILE:-fast}"
+COLLECTION_INDEXES="${COLLECTION_INDEXES:-0 1 2}"
 
 mkdir -p "$RUN_DIR"/{dbs,logs}
 
@@ -292,9 +293,19 @@ run_collection_case() {
 printf 'mode\tindexes\tphase\ttotal_bytes\ttotal_gzip_bytes\ttotal_bytes_per_gzip_byte\tleaf_vlog_bytes\tleaf_vlog_bytes_per_gzip_byte\tindex_db_bytes\tvalue_vlog_bytes\n' >"$tsv"
 
 run_raw_case
-run_collection_case 0
-run_collection_case 1
-run_collection_case 2
+read -r -a collection_index_values <<<"$COLLECTION_INDEXES"
+if [[ "${#collection_index_values[@]}" -eq 0 ]]; then
+	echo "COLLECTION_INDEXES must include at least one index count" >&2
+	exit 1
+fi
+
+for indexes in "${collection_index_values[@]}"; do
+	if [[ ! "$indexes" =~ ^[0-9]+$ ]]; then
+		echo "invalid COLLECTION_INDEXES entry: $indexes" >&2
+		exit 1
+	fi
+	run_collection_case "$indexes"
+done
 
 {
 	printf '# TreeDB Collection Compression Matrix\n\n'
@@ -303,7 +314,7 @@ run_collection_case 2
 	printf -- '- Batch size: `%s`\n' "$BATCH"
 	printf -- '- Document shape: template-v1 fixture fields `name`, `email`, `city`, `pad`\n'
 	printf -- '- Raw TreeDB case: generated template-v1 payloads stored directly by key\n'
-	printf -- '- Collection cases: generated template-v1 payloads inserted through collection mode with 0, 1, and 2 indexes\n'
+	printf -- '- Collection cases: generated template-v1 payloads inserted through collection mode with indexes `%s`\n' "$COLLECTION_INDEXES"
 	printf -- '- Offline rewrite: `treemap vlog-rewrite <dir> -rw`\n'
 	printf -- '- Gzip ratio is `bytes/gzip_bytes`; lower is closer to gzip-compressed density already being present on disk.\n\n'
 	printf '| Mode | Indexes | Before bytes | Before gzip | Before bytes/gzip | After rewrite bytes | After rewrite gzip | After bytes/gzip | Disk delta | Gzip delta | After leaf_vlog bytes | After leaf bytes/gzip | After index.db bytes | After value_vlog bytes |\n'
@@ -312,7 +323,7 @@ run_collection_case 2
 		if [[ "$mode" == "raw_treedb" ]]; then
 			index_values=("-")
 		else
-			index_values=(0 1 2)
+			index_values=("${collection_index_values[@]}")
 		fi
 		for indexes in "${index_values[@]}"; do
 			before_line="$(awk -F '\t' -v mode="$mode" -v idx="$indexes" '$1 == mode && $2 == idx && $3 == "before_rewrite" { print; exit }' "$tsv")"


### PR DESCRIPTION
## Summary

- add `cmd/collection_canonical_bench` as the canonical TreeDB collections vs SQLite benchmark workflow
- add `scripts/bench_collections_canonical.sh` and canonical `make bench-collections-canonical`; keep `make collection-canonical-bench` as a build alias
- emit `benchmark_results.json`, `benchmark_summary.md`, and `benchmark_matrix.csv` with guardrails, derived compacted ratios, and reproduction commands
- address AI review feedback for detached-HEAD metadata, configured index-count comparisons, zero-ratio summary safety, `-skip-sqlite`, configurable summary labels, stale artifact cleanup, `-tree-engine` pass-through, temp-dir wording, parameterized offline-rewrite index cases, Markdown escaping, commit resolution, CSV flush errors, and auto-skipped SQLite guardrails, and absolute `-out-dir` normalization, and output cleanup safety guard

## Validation

- `go test ./cmd/collection_canonical_bench -count 1`
- `go test ./cmd/collection_canonical_bench ./cmd/collection_load_fixture ./cmd/collection_bench_matrix ./cmd/collection_bench_matrix_summary ./cmd/collection_bench_report -count 1`
- `bash -n scripts/bench_collections_canonical.sh scripts/treedb_collection_compression_matrix.sh`
- `git diff --check`
- `make collection-canonical-bench-bin collection-canonical-bench`
- `make docs-check`
- `./scripts/bench_collections_canonical.sh -docs 1000 -benchtime 1000x -skip-sqlite -out-dir /tmp/collection_canonical_skip_sqlite_smoke`
- `./scripts/bench_collections_canonical.sh -docs 1000 -benchtime 1000x -skip-sqlite -indexes 3 -out-dir /tmp/collection_canonical_indexes3_smoke`
- `./scripts/bench_collections_canonical.sh -docs 1000 -benchtime 1000x -skip-sqlite -out-dir /tmp/collection_canonical_safety_smoke_<timestamp>`
- `./scripts/bench_collections_canonical.sh`

A broad `go test ./... -count 1` run had one transient unrelated failure in `TreeDB/caching`: `TestVlogGenerationRewriteQueue_FreshBypassThenExpiredRetryPrefersImprovedStalePayoff`, with output `unexpected rewrite source ids=[11]`. Rerunning that exact test and then `go test ./TreeDB/caching -count 1` both passed.

## Generated benchmark_summary.md

<details open>
<summary>Latest full canonical run (from 3f990f4c3041; later commits aa0779c5bb, 420ce2e678, dc4a60795e, and 7bfb14f933 are validation/reporting-only)</summary>

# TreeDB Collections Canonical Benchmark

## Executive Summary

`treedb_json_collection_2_indexes` is the fastest indexed ingest row in this run. TreeDB fully compacted two-index template-v1 collection storage is 44.2 B/doc via PR 1096-style offline rewrite and 31.7 B/doc via full leafgen pack/GC. Compared with SQLite after `VACUUM`, offline rewrite is about 3.5x smaller than SQLite native columns and 5.2x smaller than SQLite JSON; full leafgen pack/GC is about 4.9x and 7.3x smaller, respectively.

## Benchmark Configuration

| Key | Value |
| --- | --- |
| `generated_at` | `2026-04-30T01:11:05Z` |
| `run_dir` | `/var/folders/v0/pbplq_x54gg1bjh38mw1m0600000gn/T/collection_canonical_bench_20260429_151105` |
| `worktree` | `/Users/michaelseiler/dev/snissn/gomap` |
| `branch` | `test/collections-canonical-benchmark` |
| `commit` | `3f990f4c3041` |
| `command_line` | `./scripts/bench_collections_canonical.sh` |
| `docs` | `100000` |
| `batch_size` | `16000` |
| `indexes` | `2` |
| `tree_engine` | `production_fast` |
| `profile` | `fast` |
| `formats` | `json,template-v1` |
| `leaf_segment_target_bytes` | `1048576` |
| `leafgen_pack_force` | `true` |
| `leafgen_pack_max_generations` | `0` |
| `leafgen_pack_frame_k` | `16` |
| `index_vacuum` | `offline` |

## Throughput Results

These rows are benchmark-timed post-insert measurements. Maintenance rows are excluded from throughput ranking.

| Config | Format | Indexes | Docs/sec | ns/doc | Batch size | Source |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| `treedb_json_collection_2_indexes` | json | 2 | 559597 | 1787.0 | 16000 | go_benchmark |
| `treedb_template_v1_collection_2_indexes` | template-v1 | 2 | 558971 | 1789.0 | 16000 | go_benchmark |
| `sqlite_native_columns_2_indexes` | native-columns | 2 | 497512 | 2010.0 | 16000 | go_benchmark |
| `sqlite_json_2_indexes` | json | 2 | 395257 | 2530.0 | 16000 | go_benchmark |

## Post-Insert Storage Comparison

These rows use the timed benchmark matrix post-insert basis. They are fair to compare with each other, but they are not compacted-state numbers.

| Config | Format | Indexes | Total bytes | B/doc | Docs/sec |
| --- | --- | ---: | ---: | ---: | ---: |
| `treedb_template_v1_collection_2_indexes` | template-v1 | 2 | 10,555,966 | 105.6 | 558971 |
| `treedb_json_collection_2_indexes` | json | 2 | 10,651,807 | 106.5 | 559597 |
| `sqlite_native_columns_2_indexes` | native-columns | 2 | 17,612,800 | 176.1 | 497512 |
| `sqlite_json_2_indexes` | json | 2 | 26,263,552 | 262.6 | 395257 |

## Storage Results by Phase

| Config | Shape | Phase | Total bytes | B/doc | Measurement | Note |
| --- | --- | --- | ---: | ---: | --- | --- |
| `sqlite_json_2_indexes` | collection | `post_insert` | 26,263,552 | 262.6 | go_benchmark | SQLite post-insert size before VACUUM; not compacted |
| `sqlite_json_2_indexes` | collection | `sqlite_vacuum` | 23,166,976 | 231.7 | benchmark_post_processing | SQLite compacted baseline; use this for compacted-state comparisons |
| `sqlite_native_columns_2_indexes` | collection | `post_insert` | 17,612,800 | 176.1 | go_benchmark | SQLite post-insert size before VACUUM; not compacted |
| `sqlite_native_columns_2_indexes` | collection | `sqlite_vacuum` | 15,671,296 | 156.7 | benchmark_post_processing | SQLite compacted baseline; use this for compacted-state comparisons |
| `treedb_json_collection_2_indexes` | collection | `post_insert` | 10,651,807 | 106.5 | go_benchmark | post-insert benchmark size; not compacted |
| `treedb_json_collection_2_indexes` | collection | `online_one_pass_maintenance` | 9,977,567 | 99.8 | benchmark_post_processing | partial online maintenance from the timed benchmark harness; not full compaction |
| `treedb_template_v1_collection_0_indexes` | collection | `post_insert` | 6,868,208 | 68.7 | offline_script | offline rewrite matrix before-rewrite size; not compacted |
| `treedb_template_v1_collection_0_indexes` | collection | `offline_rewrite` | 1,969,499 | 19.7 | offline_script | PR 1096-style offline rewrite using treemap vlog-rewrite -rw |
| `treedb_template_v1_collection_1_indexes` | collection | `post_insert` | 9,026,091 | 90.3 | offline_script | offline rewrite matrix before-rewrite size; not compacted |
| `treedb_template_v1_collection_1_indexes` | collection | `offline_rewrite` | 3,751,406 | 37.5 | offline_script | PR 1096-style offline rewrite using treemap vlog-rewrite -rw |
| `treedb_template_v1_collection_2_indexes` | collection | `post_insert` | 10,752,992 | 107.5 | fixture_wall_timed | full leafgen fixture pre-maintenance size; use benchmark-timed rows for primary throughput |
| `treedb_template_v1_collection_2_indexes` | collection | `post_insert` | 10,555,966 | 105.6 | go_benchmark | post-insert benchmark size; not compacted |
| `treedb_template_v1_collection_2_indexes` | collection | `post_insert` | 10,667,386 | 106.7 | offline_script | offline rewrite matrix before-rewrite size; not compacted |
| `treedb_template_v1_collection_2_indexes` | collection | `online_one_pass_maintenance` | 9,923,257 | 99.2 | benchmark_post_processing | partial online maintenance from the timed benchmark harness; not full compaction |
| `treedb_template_v1_collection_2_indexes` | collection | `offline_rewrite` | 4,419,008 | 44.2 | offline_script | PR 1096-style offline rewrite using treemap vlog-rewrite -rw |
| `treedb_template_v1_collection_2_indexes` | collection | `full_leafgen_pack_gc` | 3,174,681 | 31.7 | fixture_post_processing | full leafgen pack/GC with explicit flags followed by configured index vacuum |
| `treedb_template_v1_raw` | raw | `post_insert` | 6,866,329 | 68.7 | offline_script | offline rewrite matrix before-rewrite size; not compacted |
| `treedb_template_v1_raw` | raw | `offline_rewrite` | 2,002,967 | 20.0 | offline_script | PR 1096-style offline rewrite using treemap vlog-rewrite -rw |

## Fair Compacted-State Comparison

TreeDB fully compacted rows are compared with SQLite after `VACUUM`. Do not compare TreeDB `offline_rewrite` or `full_leafgen_pack_gc` only against SQLite `post_insert` rows.

SQLite compacted baselines:

| Config | Phase | B/doc | Total bytes |
| --- | --- | ---: | ---: |
| `sqlite_json_2_indexes` | `sqlite_vacuum` | 231.7 | 23,166,976 |
| `sqlite_native_columns_2_indexes` | `sqlite_vacuum` | 156.7 | 15,671,296 |

TreeDB compacted rows versus SQLite after `VACUUM`:

| TreeDB config | Phase | B/doc | vs SQLite native-columns VACUUM | vs SQLite JSON VACUUM |
| --- | --- | ---: | ---: | ---: |
| `treedb_template_v1_collection_2_indexes` | `offline_rewrite` | 44.2 | 3.5x smaller | 5.2x smaller |
| `treedb_template_v1_collection_2_indexes` | `full_leafgen_pack_gc` | 31.7 | 4.9x smaller | 7.3x smaller |

Derived comparison rows are also emitted in `benchmark_results.json` under `comparisons`.

## Maintenance/Compaction Details

| Phase | Canonical meaning | Required comparison basis |
| --- | --- | --- |
| `post_insert` | Size after insert benchmark/fixture and correctness flush/checkpoint. | Compare with other post-insert rows only. |
| `online_one_pass_maintenance` | Partial online maintenance from benchmark harness; currently one online rewrite/GC path and one leafgen-pack pass. | Do not present as full compaction. |
| `offline_rewrite` | PR 1096-style `treemap vlog-rewrite <dir> -rw`. | Compare with SQLite `sqlite_vacuum`. |
| `full_leafgen_pack_gc` | Forced/full leaf generation pack/GC with explicit knobs and configured index vacuum. | Compare with SQLite `sqlite_vacuum`. |
| `sqlite_vacuum` | SQLite compacted baseline after `VACUUM`. | Required baseline for compacted-state comparison. |

Full leafgen knobs recorded for this run:

| Key | Value |
| --- | --- |
| `leaf-segment-target-bytes` | `1048576` |
| `leafgen-pack-gc` | `true` |
| `leafgen-pack-force` | `true` |
| `leafgen-pack-max-generations` | `0` |
| `leafgen-pack-frame-k` | `16` |
| `index-vacuum` | `offline` |

## Guardrail Checks

| Severity | Code | Message |
| --- | --- | --- |
| warning | `phase.online_one_pass.partial` | online_one_pass_maintenance is partial online maintenance; do not describe it as full compaction |
| info | `raw_shape_labeled` | raw TreeDB rows are labeled shape=raw and should not be mixed with collection rows without that label |

## Raw Results Appendix

Machine-readable JSON: `benchmark_results.json`

CSV matrix: `benchmark_matrix.csv`

| Config | Phase | Engine | Format | Indexes | Docs | Bytes | B/doc | Docs/sec | ns/doc |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `sqlite_json_2_indexes` | `post_insert` | sqlite_wal_normal | json | 2 | 100000 | 26,263,552 | 262.6 | 395257 | 2530.0 |
| `sqlite_json_2_indexes` | `sqlite_vacuum` | sqlite_wal_normal | json | 2 | 100000 | 23,166,976 | 231.7 | - | - |
| `sqlite_native_columns_2_indexes` | `post_insert` | sqlite_wal_normal | native-columns | 2 | 100000 | 17,612,800 | 176.1 | 497512 | 2010.0 |
| `sqlite_native_columns_2_indexes` | `sqlite_vacuum` | sqlite_wal_normal | native-columns | 2 | 100000 | 15,671,296 | 156.7 | - | - |
| `treedb_json_collection_2_indexes` | `post_insert` | production_fast | json | 2 | 100000 | 10,651,807 | 106.5 | 559597 | 1787.0 |
| `treedb_json_collection_2_indexes` | `online_one_pass_maintenance` | production_fast | json | 2 | 100000 | 9,977,567 | 99.8 | - | - |
| `treedb_template_v1_collection_0_indexes` | `post_insert` | treedb_fast | template-v1 | 0 | 100000 | 6,868,208 | 68.7 | - | - |
| `treedb_template_v1_collection_0_indexes` | `offline_rewrite` | treedb_fast | template-v1 | 0 | 100000 | 1,969,499 | 19.7 | - | - |
| `treedb_template_v1_collection_1_indexes` | `post_insert` | treedb_fast | template-v1 | 1 | 100000 | 9,026,091 | 90.3 | - | - |
| `treedb_template_v1_collection_1_indexes` | `offline_rewrite` | treedb_fast | template-v1 | 1 | 100000 | 3,751,406 | 37.5 | - | - |
| `treedb_template_v1_collection_2_indexes` | `post_insert` | treedb_fast | template-v1 | 2 | 100000 | 10,752,992 | 107.5 | 646857 | 1545.9 |
| `treedb_template_v1_collection_2_indexes` | `post_insert` | production_fast | template-v1 | 2 | 100000 | 10,555,966 | 105.6 | 558971 | 1789.0 |
| `treedb_template_v1_collection_2_indexes` | `post_insert` | treedb_fast | template-v1 | 2 | 100000 | 10,667,386 | 106.7 | - | - |
| `treedb_template_v1_collection_2_indexes` | `online_one_pass_maintenance` | production_fast | template-v1 | 2 | 100000 | 9,923,257 | 99.2 | - | - |
| `treedb_template_v1_collection_2_indexes` | `offline_rewrite` | treedb_fast | template-v1 | 2 | 100000 | 4,419,008 | 44.2 | - | - |
| `treedb_template_v1_collection_2_indexes` | `full_leafgen_pack_gc` | treedb_fast | template-v1 | 2 | 100000 | 3,174,681 | 31.7 | - | - |
| `treedb_template_v1_raw` | `post_insert` | treedb_fast | template-v1 | 0 | 100000 | 6,866,329 | 68.7 | - | - |
| `treedb_template_v1_raw` | `offline_rewrite` | treedb_fast | template-v1 | 0 | 100000 | 2,002,967 | 20.0 | - | - |

## Reproduction Commands

Canonical entry point:

```bash
./scripts/bench_collections_canonical.sh
# or
make bench-collections-canonical
```

Exact command records from this run:

### build_helpers

make collection-load-fixture treemap-bin

### timed_matrix

go run ./cmd/collection_bench_matrix -out-dir /var/folders/v0/pbplq_x54gg1bjh38mw1m0600000gn/T/collection_canonical_bench_20260429_151105/timed_matrix -formats json,template-v1 -engine production_fast -storage-cells index-vlog -tree-bench-pattern '^BenchmarkCollectionShapeInsertBatch$/^indexes_2$' -sqlite-bench-pattern '^(BenchmarkSQLiteShapeInsertBatchJSON|BenchmarkSQLiteShapeInsertBatchNativeColumns)$/^indexes_2$' -batch-size 16000 -benchtime 100000x -count 1 -leaf-segment-target-bytes 1048576 -leafgen-pack-frame-k 16

### offline_rewrite_matrix

BATCH=16000 COLLECTION_INDEXES='0 1 2' DOCS=100000 PROFILE=fast RUN_DIR=/var/folders/v0/pbplq_x54gg1bjh38mw1m0600000gn/T/collection_canonical_bench_20260429_151105/offline_rewrite bash ./scripts/treedb_collection_compression_matrix.sh

### full_leafgen_pack_gc

/Users/michaelseiler/dev/snissn/gomap/bin/collection-load-fixture -json -dir /var/folders/v0/pbplq_x54gg1bjh38mw1m0600000gn/T/collection_canonical_bench_20260429_151105/full_leafgen_pack_gc/treedb_template_v1_collection_2_indexes -reset -docs 100000 -batch-size 16000 -format template-v1 -indexes 2 -profile fast -progress=false -leaf-segment-target-bytes 1048576 -leafgen-pack-gc -leafgen-pack-force=true -leafgen-pack-max-generations 0 -leafgen-pack-frame-k 16 -index-vacuum offline


</details>




