### PR TITLE
[codex] Fix TreeDB benchmark regressions

### DIFF
--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -3709,6 +3709,7 @@ func TestSchedulePendingVlogGenerationCheckpointKick_PrioritizesDueDeferredWake(
 	}}, true, stageObservedAt); err != nil {
 		t.Fatalf("seed staged rewrite ledger: %v", err)
 	}
+	forceRewriteStageConfirmDue(t, db)
 
 	db.vlogGenerationCheckpointKickPending.Store(true)
 	db.vlogGenerationDeferredMaintenanceRunning.Store(true)
@@ -7018,6 +7019,7 @@ func TestVlogGenerationMaintenance_CheckpointPendingYieldsToDueStageConfirm(t *t
 	}}, true, stageObservedAt); err != nil {
 		t.Fatalf("seed staged rewrite ledger: %v", err)
 	}
+	forceRewriteStageConfirmDue(t, db)
 
 	db.vlogGenerationCheckpointKickPending.Store(true)
 	t.Cleanup(func() { db.vlogGenerationCheckpointKickPending.Store(false) })

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2322,63 +2322,91 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 // then scans the collection primary root up to maxDocuments. The returned
 // boolean is true when additional documents were present beyond the limit.
 func (c *Collection) ScanDocuments(maxDocuments int) ([]DocumentRecord, bool, error) {
+	out := make([]DocumentRecord, 0)
+	truncated, err := c.ScanDocumentsFunc(maxDocuments, func(record DocumentRecord) (bool, error) {
+		out = append(out, record)
+		return true, nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return out, truncated, nil
+}
+
+// ScanDocumentsFunc flushes buffered no-index writes before acquiring a
+// snapshot, then calls fn for primary collection records until maxDocuments is
+// reached, the collection is exhausted, or fn returns false. The returned
+// boolean is true only when additional documents were present beyond the
+// maxDocuments limit.
+func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord) (bool, error)) (bool, error) {
 	if c == nil {
-		return nil, false, errCollectionNil
+		return false, errCollectionNil
 	}
 	if c.db == nil {
-		return nil, false, errors.New("collections: db is nil")
+		return false, errors.New("collections: db is nil")
 	}
 	if maxDocuments <= 0 {
-		return nil, false, errors.New("collections: max documents must be positive")
+		return false, errors.New("collections: max documents must be positive")
+	}
+	if fn == nil {
+		return false, errors.New("collections: scan callback is nil")
 	}
 	if err := c.flushBufferedNoIndex(); err != nil {
-		return nil, false, err
+		return false, err
 	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
-		return nil, false, backenddb.ErrClosed
+		return false, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
 	catalog, err := c.catalogForSnapshot(snap)
 	if err != nil {
-		return nil, false, err
+		return false, err
 	}
 	if catalog == nil {
-		return nil, false, errCollectionNotFound
+		return false, errCollectionNotFound
 	}
 	rootID := catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
 	if rootID == 0 {
-		return nil, false, nil
+		return false, nil
 	}
 	it, err := snap.IteratorAtRoot(rootID, nil, nil)
 	if errors.Is(err, tree.ErrKeyNotFound) {
-		return nil, false, nil
+		return false, nil
 	}
 	if err != nil {
-		return nil, false, err
+		return false, err
 	}
 	defer func() { _ = it.Close() }()
-	out := make([]DocumentRecord, 0)
 	truncated := false
+	scanned := 0
 	for it.Valid() {
 		if it.IsDeleted() {
 			it.Next()
 			continue
 		}
-		if len(out) >= maxDocuments {
+		if scanned >= maxDocuments {
 			truncated = true
 			break
 		}
-		out = append(out, DocumentRecord{
+		record := DocumentRecord{
 			ID:       bytes.Clone(it.UnsafeKey()),
 			Document: it.ValueCopy(nil),
-		})
+		}
+		scanned++
+		next, err := fn(record)
+		if err != nil {
+			return false, err
+		}
+		if !next {
+			return false, nil
+		}
 		it.Next()
 	}
 	if err := it.Error(); err != nil {
-		return nil, false, err
+		return false, err
 	}
-	return out, truncated, nil
+	return truncated, nil
 }
 
 func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCatalog, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -97,6 +97,7 @@ type Collection struct {
 	writeDomain       *collectionWriteDomain
 	meta              CollectionMeta
 	catalogMu         sync.RWMutex
+	catalogCommitSeq  uint64
 	catalogSystemRoot uint64
 	catalog           *collectionCatalog
 	insertStatsMu     sync.RWMutex
@@ -210,6 +211,7 @@ type collectionWriteDomain struct {
 	loaded         bool
 	meta           CollectionMeta
 	catalog        *collectionCatalog
+	baseCommitSeq  uint64
 	baseSystemRoot uint64
 	primaryRoot    uint64
 	storagePolicy  backenddb.OrderedRootStoragePolicy
@@ -747,12 +749,9 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	if domain == nil {
 		return nil, collectionOptions{}, false, errors.New("collections: missing write domain")
 	}
-	currentSystemRoot := uint64(0)
-	if state := c.db.State(); state != nil {
-		currentSystemRoot = state.SystemRootPageID
-	}
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
 	if domain.loaded && domain.count > 0 {
-		catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentSystemRoot)
+		catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentCommitSeq, currentSystemRoot)
 		if err != nil {
 			return nil, collectionOptions{}, false, err
 		}
@@ -762,7 +761,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		}
 		return catalog, options, len(catalog.meta.Indexes) > 0, nil
 	}
-	if domain.loaded && domain.count == 0 && domain.baseSystemRoot == currentSystemRoot {
+	if domain.loaded && domain.count == 0 && domain.baseSystemRoot == currentSystemRoot && domain.baseCommitSeq == currentCommitSeq {
 		options, err := collectionPlannerOptions(domain.meta)
 		if err != nil {
 			return nil, collectionOptions{}, false, err
@@ -784,6 +783,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		return nil, collectionOptions{}, false, errCollectionNotFound
 	}
 	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
 	_ = snap.Close()
 
 	options, err := collectionPlannerOptions(catalog.meta)
@@ -794,13 +794,14 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	domain.loaded = true
 	domain.meta = catalog.meta
 	domain.catalog = catalog
+	domain.baseCommitSeq = baseCommitSeq
 	domain.baseSystemRoot = baseSystemRoot
 	domain.primaryRoot = catalog.rootID(rootName)
 	domain.storagePolicy = options.dataStoragePolicy
 	return catalog, options, len(catalog.meta.Indexes) > 0, nil
 }
 
-func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWriteDomain, currentSystemRoot uint64) (*collectionCatalog, error) {
+func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWriteDomain, currentCommitSeq, currentSystemRoot uint64) (*collectionCatalog, error) {
 	if c == nil || c.db == nil {
 		return nil, errors.New("collections: db is nil")
 	}
@@ -810,7 +811,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	if domain.catalog == nil {
 		return nil, errCollectionNotFound
 	}
-	if domain.baseSystemRoot == currentSystemRoot {
+	if domain.baseSystemRoot == currentSystemRoot && domain.baseCommitSeq == currentCommitSeq {
 		return domain.catalog, nil
 	}
 
@@ -820,6 +821,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	}
 	catalog, err := loadCollectionCatalog(snap, domain.meta.Name)
 	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
 	_ = snap.Close()
 	if err != nil {
 		return nil, err
@@ -841,6 +843,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	}
 	domain.meta = catalog.meta
 	domain.catalog = catalog
+	domain.baseCommitSeq = baseCommitSeq
 	domain.baseSystemRoot = baseSystemRoot
 	domain.primaryRoot = catalog.rootID(rootName)
 	domain.storagePolicy = options.dataStoragePolicy
@@ -880,11 +883,8 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	if domain.catalog == nil {
 		return errCollectionNotFound
 	}
-	currentSystemRoot := uint64(0)
-	if state := c.db.State(); state != nil {
-		currentSystemRoot = state.SystemRootPageID
-	}
-	catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentSystemRoot)
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
+	catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentCommitSeq, currentSystemRoot)
 	if err != nil {
 		return err
 	}
@@ -914,6 +914,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 		return fmt.Errorf("collections: concurrent root modification detected for %q", meta.Name)
 	}
 	baseSystemRoot := snapshotSystemRoot(pin)
+	baseCommitSeq := snapshotCommitSeq(pin)
 	baseRootIDs := map[string]uint64{rootName: baseRoot}
 	table := domain.table
 	iter := table.NewIterator(nil, nil)
@@ -923,7 +924,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 		Iter:          iter,
 		StoragePolicy: domain.storagePolicy,
 	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
 	})
 	_ = iter.Close()
 	if err != nil {
@@ -936,6 +937,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	domain.loaded = true
 	domain.meta = meta
 	domain.catalog = nextCatalog
+	domain.baseCommitSeq = c.commitSeqForSystemRoot(newSystemRoot)
 	domain.baseSystemRoot = newSystemRoot
 	domain.primaryRoot = rootIDs[0]
 	domain.table = newCollectionRunTable(0)
@@ -979,6 +981,7 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
 
 	rootName := collectionPrimaryRootName(c.meta.Name)
 	baseRoot := catalog.rootID(rootName)
@@ -1005,7 +1008,7 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 		Iter:          iter,
 		StoragePolicy: plannerOptions.dataStoragePolicy,
 	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, []string{rootName}, map[string]uint64{rootName: baseRoot}, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, []string{rootName}, map[string]uint64{rootName: baseRoot}, rootIDs)
 	})
 	if err != nil {
 		return nil, err
@@ -1067,9 +1070,10 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
 
 	if len(c.meta.Indexes) == 0 && plannerOptions.documentFormat == DocumentFormatJSON {
-		return c.insertBatchNoIndex(catalog, snap, baseSystemRoot, plannerOptions, ids, documents)
+		return c.insertBatchNoIndex(catalog, snap, baseCommitSeq, baseSystemRoot, plannerOptions, ids, documents)
 	}
 
 	planner := insertBatchPlanner{
@@ -1125,7 +1129,7 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	}
 	publishStart := time.Now()
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
 	plan.stats.Publish = time.Since(publishStart)
 	if err != nil {
@@ -1144,6 +1148,7 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 func (c *Collection) insertBatchNoIndex(
 	catalog *collectionCatalog,
 	snap *backenddb.Snapshot,
+	baseCommitSeq uint64,
 	baseSystemRoot uint64,
 	plannerOptions collectionOptions,
 	ids, documents [][]byte,
@@ -1221,7 +1226,7 @@ func (c *Collection) insertBatchNoIndex(
 		Iter:          iter,
 		StoragePolicy: plannerOptions.dataStoragePolicy,
 	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
 	})
 	stats.Publish = time.Since(publishStart)
 	if err != nil {
@@ -1294,6 +1299,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
 
 	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
 	if primaryRoot == 0 {
@@ -1381,7 +1387,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 		})
 	}
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
 	if err != nil {
 		return false, err
@@ -1478,6 +1484,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
 
 	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
 	if primaryRoot == 0 {
@@ -1620,7 +1627,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		})
 	}
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
 	if err != nil {
 		return false, false, err
@@ -1639,9 +1646,10 @@ func (c *Collection) catalogForSnapshot(snap *backenddb.Snapshot) (*collectionCa
 		return nil, backenddb.ErrClosed
 	}
 	systemRoot := snapshotSystemRoot(snap)
+	commitSeq := snapshotCommitSeq(snap)
 
 	c.catalogMu.RLock()
-	if cached := c.catalog; cached != nil && c.catalogSystemRoot == systemRoot {
+	if cached := c.catalog; cached != nil && c.catalogSystemRoot == systemRoot && c.catalogCommitSeq == commitSeq {
 		c.catalogMu.RUnlock()
 		return cached, nil
 	}
@@ -1665,12 +1673,45 @@ func snapshotSystemRoot(snap *backenddb.Snapshot) uint64 {
 	return 0
 }
 
+func snapshotCommitSeq(snap *backenddb.Snapshot) uint64 {
+	if snap == nil {
+		return 0
+	}
+	if state := snap.State(); state != nil {
+		return state.CommitSeq
+	}
+	return 0
+}
+
+func dbCommitSeqAndSystemRoot(db *backenddb.DB) (uint64, uint64) {
+	if db == nil {
+		return 0, 0
+	}
+	if state := db.State(); state != nil {
+		return state.CommitSeq, state.SystemRootPageID
+	}
+	return 0, 0
+}
+
+func (c *Collection) commitSeqForSystemRoot(systemRoot uint64) uint64 {
+	if c == nil {
+		return 0
+	}
+	commitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
+	if currentSystemRoot != systemRoot {
+		return 0
+	}
+	return commitSeq
+}
+
 func (c *Collection) rememberCatalog(snap *backenddb.Snapshot, catalog *collectionCatalog) {
 	if c == nil || snap == nil || catalog == nil {
 		return
 	}
+	commitSeq := snapshotCommitSeq(snap)
 	systemRoot := snapshotSystemRoot(snap)
 	c.catalogMu.Lock()
+	c.catalogCommitSeq = commitSeq
 	c.catalogSystemRoot = systemRoot
 	c.catalog = catalog
 	c.catalogMu.Unlock()
@@ -1680,7 +1721,9 @@ func (c *Collection) rememberCatalogAtSystemRoot(systemRoot uint64, catalog *col
 	if c == nil || catalog == nil {
 		return
 	}
+	commitSeq := c.commitSeqForSystemRoot(systemRoot)
 	c.catalogMu.Lock()
+	c.catalogCommitSeq = commitSeq
 	c.catalogSystemRoot = systemRoot
 	c.catalog = catalog
 	c.catalogMu.Unlock()
@@ -1704,6 +1747,7 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.loaded = true
 	domain.meta = catalog.meta
 	domain.catalog = catalog
+	domain.baseCommitSeq = c.commitSeqForSystemRoot(systemRoot)
 	domain.baseSystemRoot = systemRoot
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
 	domain.storagePolicy = options.dataStoragePolicy
@@ -1920,17 +1964,15 @@ func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseR
 	return buildSystemTargetIterator(current, updates)
 }
 
-func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 	if len(rootIDs) != len(rootNames) {
 		return nil, errors.New("collections: ordered root publish returned unexpected root count")
 	}
-	currentSystemRoot := uint64(0)
-	if c != nil && c.db != nil {
-		if state := c.db.State(); state != nil {
-			currentSystemRoot = state.SystemRootPageID
-		}
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(nil)
+	if c != nil {
+		currentCommitSeq, currentSystemRoot = dbCommitSeqAndSystemRoot(c.db)
 	}
-	if currentSystemRoot != expectedSystemRoot {
+	if currentSystemRoot != expectedSystemRoot || currentCommitSeq != expectedCommitSeq {
 		current := c.db.AcquireSnapshot()
 		if current == nil {
 			return nil, backenddb.ErrClosed

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -215,6 +215,10 @@ type noIndexBatchEntry struct {
 }
 
 type collectionWriteDomain struct {
+	// mutationMu serializes root descriptor publishes for handles opened
+	// through the same manager so optimistic retries do not starve under
+	// sustained collection write contention.
+	mutationMu     sync.Mutex
 	mu             sync.RWMutex
 	loaded         bool
 	meta           CollectionMeta
@@ -309,9 +313,19 @@ func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain)
 		return nil
 	}
 	collection := &Collection{db: db, writeDomain: domain}
+	domain.mutationMu.Lock()
+	defer domain.mutationMu.Unlock()
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	return collection.flushBufferedNoIndexLocked(domain)
+}
+
+func (c *Collection) lockMutation() func() {
+	if c == nil || c.writeDomain == nil {
+		return func() {}
+	}
+	c.writeDomain.mutationMu.Lock()
+	return c.writeDomain.mutationMu.Unlock
 }
 
 func (m *CollectionManager) CreateCollection(meta *CollectionMeta) (*CollectionMeta, error) {
@@ -477,6 +491,8 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 	if c.db == nil {
 		return nil, errors.New("collections: db is nil")
 	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation()
 	if err := c.flushBufferedNoIndex(); err != nil {
 		return nil, err
 	}
@@ -596,6 +612,8 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 	if c.db == nil {
 		return nil, errors.New("collections: db is nil")
 	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation()
 	if err := c.flushBufferedNoIndex(); err != nil {
 		return nil, err
 	}
@@ -702,6 +720,8 @@ func (c *Collection) Flush() error {
 	if c.db == nil {
 		return errors.New("collections: db is nil")
 	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation()
 	return c.flushBufferedNoIndex()
 }
 
@@ -1052,6 +1072,8 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	if c.db == nil {
 		return nil, errors.New("collections: db is nil")
 	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation()
 	if len(documents) == 0 {
 		c.setLastInsertStats(CollectionInsertStats{
 			Documents: 0,
@@ -1278,6 +1300,8 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 	if len(documentID) == 0 {
 		return false, errors.New("collections: document id cannot be empty")
 	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation()
 	if err := c.flushBufferedNoIndex(); err != nil {
 		return false, err
 	}
@@ -1448,6 +1472,8 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 	if update == nil {
 		return false, false, errors.New("collections: update function is nil")
 	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation()
 	if err := c.flushBufferedNoIndex(); err != nil {
 		return false, false, err
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1343,7 +1343,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 			deltaTables = append(deltaTables, buildDeleteRootDeltaTable(deleteKeys))
 		}
 	}
-	_ = snap.Close()
+	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
 	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
@@ -1580,7 +1580,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 			deltaTables = append(deltaTables, table)
 		}
 	}
-	_ = snap.Close()
+	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
 	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -526,6 +526,8 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 		_ = snap.Close()
 		return nil, err
 	}
+	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
+	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
@@ -907,6 +909,8 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	if pin == nil {
 		return backenddb.ErrClosed
 	}
+	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
+	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = pin.Close() }()
 	pinnedCatalog, err := loadCollectionCatalog(pin, meta.Name)
 	if err != nil {
@@ -1002,6 +1006,8 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 			return nil, err
 		}
 	}
+	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
+	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
 
 	resultID := bytes.Clone(id)
@@ -1111,6 +1117,8 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	for _, run := range plan.runs {
 		baseRootIDs[run.name] = catalog.rootID(run.name)
 	}
+	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
+	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.runs))
@@ -1212,6 +1220,8 @@ func (c *Collection) insertBatchNoIndex(
 		}
 	}
 	stats.DuplicateDocumentPreflight = time.Since(phaseStart)
+	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
+	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
 
 	phaseStart = time.Now()
@@ -1377,6 +1387,8 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 			deltaTables = append(deltaTables, buildDeleteRootDeltaTable(deleteKeys))
 		}
 	}
+	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
+	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
@@ -1620,6 +1632,8 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 			deltaTables = append(deltaTables, table)
 		}
 	}
+	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
+	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -513,10 +513,11 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 		return nil, err
 	}
 	plan, err := buildCreateIndexBackfillPlan(snap, catalog, newRuntime, existingRuntimes, baseOptions)
-	_ = snap.Close()
 	if err != nil {
+		_ = snap.Close()
 		return nil, err
 	}
+	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
 	iterators := make([]iterator.UnsafeIterator, 0, len(plan.rootNames))
@@ -895,7 +896,25 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	c.meta = meta
 	rootName := collectionPrimaryRootName(meta.Name)
 	baseRoot := domain.primaryRoot
-	baseSystemRoot := domain.baseSystemRoot
+	pin := c.db.AcquireSnapshot()
+	if pin == nil {
+		return backenddb.ErrClosed
+	}
+	defer func() { _ = pin.Close() }()
+	pinnedCatalog, err := loadCollectionCatalog(pin, meta.Name)
+	if err != nil {
+		return err
+	}
+	if pinnedCatalog == nil {
+		return errCollectionNotFound
+	}
+	if !sameCollectionMeta(pinnedCatalog.meta, meta) {
+		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
+	}
+	if got := pinnedCatalog.rootID(rootName); got != baseRoot {
+		return fmt.Errorf("collections: concurrent root modification detected for %q", meta.Name)
+	}
+	baseSystemRoot := snapshotSystemRoot(pin)
 	baseRootIDs := map[string]uint64{rootName: baseRoot}
 	table := domain.table
 	iter := table.NewIterator(nil, nil)
@@ -973,7 +992,7 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 			return nil, err
 		}
 	}
-	_ = snap.Close()
+	defer func() { _ = snap.Close() }()
 
 	resultID := bytes.Clone(id)
 	iter := &systemTargetIterator{entries: []systemTargetEntry{{
@@ -1081,7 +1100,7 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	for _, run := range plan.runs {
 		baseRootIDs[run.name] = catalog.rootID(run.name)
 	}
-	_ = snap.Close()
+	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.runs))
 	iterators := make([]iterator.UnsafeIterator, 0, len(plan.runs))
@@ -1181,7 +1200,7 @@ func (c *Collection) insertBatchNoIndex(
 		}
 	}
 	stats.DuplicateDocumentPreflight = time.Since(phaseStart)
-	_ = snap.Close()
+	defer func() { _ = snap.Close() }()
 
 	phaseStart = time.Now()
 	table := newCollectionRunTable(len(entries))

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1517,6 +1517,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	}
 	var oldState documentIndexState
 	var newState documentIndexState
+	indexStateChanged := false
 	if len(runtimes) > 0 {
 		oldState, err = loadDeleteIndexState(snap, catalog, documentID, entry.Value, runtimes, plannerOptions)
 		if err != nil {
@@ -1528,9 +1529,12 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 			_ = snap.Close()
 			return false, false, err
 		}
-		if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, newState, documentID); err != nil {
-			_ = snap.Close()
-			return false, false, err
+		indexStateChanged = !documentIndexStatesEqual(oldState, newState)
+		if indexStateChanged {
+			if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, newState, documentID); err != nil {
+				_ = snap.Close()
+				return false, false, err
+			}
 		}
 	}
 
@@ -1545,7 +1549,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	primaryTable.Freeze()
 	deltaTables = append(deltaTables, primaryTable)
 
-	if len(runtimes) > 0 {
+	if indexStateChanged {
 		stateRootName := collectionIndexStateRootName(c.meta.Name)
 		stateRootID := catalog.rootID(stateRootName)
 		rootNames = append(rootNames, stateRootName)
@@ -1909,6 +1913,24 @@ func cloneDocumentIndexState(state documentIndexState) documentIndexState {
 		out[name] = normalizeEncodedIndexValues(values)
 	}
 	return out
+}
+
+func documentIndexStatesEqual(left, right documentIndexState) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for name, leftValues := range left {
+		rightValues, ok := right[name]
+		if !ok || len(leftValues) != len(rightValues) {
+			return false
+		}
+		for i := range leftValues {
+			if !bytes.Equal(leftValues[i], rightValues[i]) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -97,8 +97,8 @@ type Collection struct {
 	writeDomain       *collectionWriteDomain
 	meta              CollectionMeta
 	catalogMu         sync.RWMutex
-	catalogSystemRoot uint64
 	catalogCommitSeq  uint64
+	catalogSystemRoot uint64
 	catalog           *collectionCatalog
 	insertStatsMu     sync.RWMutex
 	lastInsertStats   CollectionInsertStats
@@ -211,6 +211,7 @@ type collectionWriteDomain struct {
 	loaded         bool
 	meta           CollectionMeta
 	catalog        *collectionCatalog
+	baseCommitSeq  uint64
 	baseSystemRoot uint64
 	primaryRoot    uint64
 	storagePolicy  backenddb.OrderedRootStoragePolicy
@@ -748,12 +749,9 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	if domain == nil {
 		return nil, collectionOptions{}, false, errors.New("collections: missing write domain")
 	}
-	currentSystemRoot := uint64(0)
-	if state := c.db.State(); state != nil {
-		currentSystemRoot = state.SystemRootPageID
-	}
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
 	if domain.loaded && domain.count > 0 {
-		catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentSystemRoot)
+		catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentCommitSeq, currentSystemRoot)
 		if err != nil {
 			return nil, collectionOptions{}, false, err
 		}
@@ -763,7 +761,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		}
 		return catalog, options, len(catalog.meta.Indexes) > 0, nil
 	}
-	if domain.loaded && domain.count == 0 && domain.baseSystemRoot == currentSystemRoot {
+	if domain.loaded && domain.count == 0 && domain.baseSystemRoot == currentSystemRoot && domain.baseCommitSeq == currentCommitSeq {
 		options, err := collectionPlannerOptions(domain.meta)
 		if err != nil {
 			return nil, collectionOptions{}, false, err
@@ -785,6 +783,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		return nil, collectionOptions{}, false, errCollectionNotFound
 	}
 	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
 	_ = snap.Close()
 
 	options, err := collectionPlannerOptions(catalog.meta)
@@ -795,13 +794,14 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	domain.loaded = true
 	domain.meta = catalog.meta
 	domain.catalog = catalog
+	domain.baseCommitSeq = baseCommitSeq
 	domain.baseSystemRoot = baseSystemRoot
 	domain.primaryRoot = catalog.rootID(rootName)
 	domain.storagePolicy = options.dataStoragePolicy
 	return catalog, options, len(catalog.meta.Indexes) > 0, nil
 }
 
-func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWriteDomain, currentSystemRoot uint64) (*collectionCatalog, error) {
+func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWriteDomain, currentCommitSeq, currentSystemRoot uint64) (*collectionCatalog, error) {
 	if c == nil || c.db == nil {
 		return nil, errors.New("collections: db is nil")
 	}
@@ -811,7 +811,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	if domain.catalog == nil {
 		return nil, errCollectionNotFound
 	}
-	if domain.baseSystemRoot == currentSystemRoot {
+	if domain.baseSystemRoot == currentSystemRoot && domain.baseCommitSeq == currentCommitSeq {
 		return domain.catalog, nil
 	}
 
@@ -821,6 +821,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	}
 	catalog, err := loadCollectionCatalog(snap, domain.meta.Name)
 	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
 	_ = snap.Close()
 	if err != nil {
 		return nil, err
@@ -842,6 +843,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	}
 	domain.meta = catalog.meta
 	domain.catalog = catalog
+	domain.baseCommitSeq = baseCommitSeq
 	domain.baseSystemRoot = baseSystemRoot
 	domain.primaryRoot = catalog.rootID(rootName)
 	domain.storagePolicy = options.dataStoragePolicy
@@ -881,11 +883,8 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	if domain.catalog == nil {
 		return errCollectionNotFound
 	}
-	currentSystemRoot := uint64(0)
-	if state := c.db.State(); state != nil {
-		currentSystemRoot = state.SystemRootPageID
-	}
-	catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentSystemRoot)
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
+	catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentCommitSeq, currentSystemRoot)
 	if err != nil {
 		return err
 	}
@@ -915,6 +914,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 		return fmt.Errorf("collections: concurrent root modification detected for %q", meta.Name)
 	}
 	baseSystemRoot := snapshotSystemRoot(pin)
+	baseCommitSeq := snapshotCommitSeq(pin)
 	baseRootIDs := map[string]uint64{rootName: baseRoot}
 	table := domain.table
 	iter := table.NewIterator(nil, nil)
@@ -924,7 +924,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 		Iter:          iter,
 		StoragePolicy: domain.storagePolicy,
 	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
 	})
 	_ = iter.Close()
 	if err != nil {
@@ -937,6 +937,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	domain.loaded = true
 	domain.meta = meta
 	domain.catalog = nextCatalog
+	domain.baseCommitSeq = c.commitSeqForSystemRoot(newSystemRoot)
 	domain.baseSystemRoot = newSystemRoot
 	domain.primaryRoot = rootIDs[0]
 	domain.table = newCollectionRunTable(0)
@@ -980,6 +981,7 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
 
 	rootName := collectionPrimaryRootName(c.meta.Name)
 	baseRoot := catalog.rootID(rootName)
@@ -1006,7 +1008,7 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 		Iter:          iter,
 		StoragePolicy: plannerOptions.dataStoragePolicy,
 	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, []string{rootName}, map[string]uint64{rootName: baseRoot}, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, []string{rootName}, map[string]uint64{rootName: baseRoot}, rootIDs)
 	})
 	if err != nil {
 		return nil, err
@@ -1068,9 +1070,10 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
 
 	if len(c.meta.Indexes) == 0 && plannerOptions.documentFormat == DocumentFormatJSON {
-		return c.insertBatchNoIndex(catalog, snap, baseSystemRoot, plannerOptions, ids, documents)
+		return c.insertBatchNoIndex(catalog, snap, baseCommitSeq, baseSystemRoot, plannerOptions, ids, documents)
 	}
 
 	planner := insertBatchPlanner{
@@ -1126,7 +1129,7 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	}
 	publishStart := time.Now()
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
 	plan.stats.Publish = time.Since(publishStart)
 	if err != nil {
@@ -1145,6 +1148,7 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 func (c *Collection) insertBatchNoIndex(
 	catalog *collectionCatalog,
 	snap *backenddb.Snapshot,
+	baseCommitSeq uint64,
 	baseSystemRoot uint64,
 	plannerOptions collectionOptions,
 	ids, documents [][]byte,
@@ -1222,7 +1226,7 @@ func (c *Collection) insertBatchNoIndex(
 		Iter:          iter,
 		StoragePolicy: plannerOptions.dataStoragePolicy,
 	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
 	})
 	stats.Publish = time.Since(publishStart)
 	if err != nil {
@@ -1295,6 +1299,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
 
 	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
 	if primaryRoot == 0 {
@@ -1382,7 +1387,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 		})
 	}
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
 	if err != nil {
 		return false, err
@@ -1626,7 +1631,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		return c.validateMutationRootDescriptors(baseUserRoot, baseSystemRoot, baseCommitSeq)
 	}
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
 	if err != nil {
 		return false, false, err
@@ -1692,15 +1697,36 @@ func snapshotCommitSeq(snap *backenddb.Snapshot) uint64 {
 	return 0
 }
 
+func dbCommitSeqAndSystemRoot(db *backenddb.DB) (uint64, uint64) {
+	if db == nil {
+		return 0, 0
+	}
+	if state := db.State(); state != nil {
+		return state.CommitSeq, state.SystemRootPageID
+	}
+	return 0, 0
+}
+
+func (c *Collection) commitSeqForSystemRoot(systemRoot uint64) uint64 {
+	if c == nil {
+		return 0
+	}
+	commitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
+	if currentSystemRoot != systemRoot {
+		return 0
+	}
+	return commitSeq
+}
+
 func (c *Collection) rememberCatalog(snap *backenddb.Snapshot, catalog *collectionCatalog) {
 	if c == nil || snap == nil || catalog == nil {
 		return
 	}
-	systemRoot := snapshotSystemRoot(snap)
 	commitSeq := snapshotCommitSeq(snap)
+	systemRoot := snapshotSystemRoot(snap)
 	c.catalogMu.Lock()
-	c.catalogSystemRoot = systemRoot
 	c.catalogCommitSeq = commitSeq
+	c.catalogSystemRoot = systemRoot
 	c.catalog = catalog
 	c.catalogMu.Unlock()
 }
@@ -1709,22 +1735,12 @@ func (c *Collection) rememberCatalogAtSystemRoot(systemRoot uint64, catalog *col
 	if c == nil || catalog == nil {
 		return
 	}
+	commitSeq := c.commitSeqForSystemRoot(systemRoot)
 	c.catalogMu.Lock()
+	c.catalogCommitSeq = commitSeq
 	c.catalogSystemRoot = systemRoot
-	c.catalogCommitSeq = c.commitSeqForSystemRoot(systemRoot)
 	c.catalog = catalog
 	c.catalogMu.Unlock()
-}
-
-func (c *Collection) commitSeqForSystemRoot(systemRoot uint64) uint64 {
-	if c == nil || c.db == nil {
-		return 0
-	}
-	state := c.db.State()
-	if state == nil || state.SystemRootPageID != systemRoot {
-		return 0
-	}
-	return state.CommitSeq
 }
 
 func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collectionCatalog) {
@@ -1745,6 +1761,7 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.loaded = true
 	domain.meta = catalog.meta
 	domain.catalog = catalog
+	domain.baseCommitSeq = c.commitSeqForSystemRoot(systemRoot)
 	domain.baseSystemRoot = systemRoot
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
 	domain.storagePolicy = options.dataStoragePolicy
@@ -1961,11 +1978,11 @@ func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseR
 	return buildSystemTargetIterator(current, updates)
 }
 
-func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 	if len(rootIDs) != len(rootNames) {
 		return nil, errors.New("collections: ordered root publish returned unexpected root count")
 	}
-	if err := c.validateRootDescriptorSystemDelta(expectedSystemRoot, rootNames, baseRootIDs); err != nil {
+	if err := c.validateRootDescriptorSystemDelta(expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs); err != nil {
 		return nil, err
 	}
 	updates := make(map[string][]byte, len(rootNames))
@@ -1975,14 +1992,12 @@ func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedSystemRoot u
 	return buildSystemDeltaIterator(updates)
 }
 
-func (c *Collection) validateRootDescriptorSystemDelta(expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64) error {
-	currentSystemRoot := uint64(0)
-	if c != nil && c.db != nil {
-		if state := c.db.State(); state != nil {
-			currentSystemRoot = state.SystemRootPageID
-		}
+func (c *Collection) validateRootDescriptorSystemDelta(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64) error {
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(nil)
+	if c != nil {
+		currentCommitSeq, currentSystemRoot = dbCommitSeqAndSystemRoot(c.db)
 	}
-	if currentSystemRoot != expectedSystemRoot {
+	if currentSystemRoot != expectedSystemRoot || currentCommitSeq != expectedCommitSeq {
 		current := c.db.AcquireSnapshot()
 		if current == nil {
 			return backenddb.ErrClosed

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -512,10 +512,11 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 		return nil, err
 	}
 	plan, err := buildCreateIndexBackfillPlan(snap, catalog, newRuntime, existingRuntimes, baseOptions)
-	_ = snap.Close()
 	if err != nil {
+		_ = snap.Close()
 		return nil, err
 	}
+	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
 	iterators := make([]iterator.UnsafeIterator, 0, len(plan.rootNames))
@@ -894,7 +895,25 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	c.meta = meta
 	rootName := collectionPrimaryRootName(meta.Name)
 	baseRoot := domain.primaryRoot
-	baseSystemRoot := domain.baseSystemRoot
+	pin := c.db.AcquireSnapshot()
+	if pin == nil {
+		return backenddb.ErrClosed
+	}
+	defer func() { _ = pin.Close() }()
+	pinnedCatalog, err := loadCollectionCatalog(pin, meta.Name)
+	if err != nil {
+		return err
+	}
+	if pinnedCatalog == nil {
+		return errCollectionNotFound
+	}
+	if !sameCollectionMeta(pinnedCatalog.meta, meta) {
+		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
+	}
+	if got := pinnedCatalog.rootID(rootName); got != baseRoot {
+		return fmt.Errorf("collections: concurrent root modification detected for %q", meta.Name)
+	}
+	baseSystemRoot := snapshotSystemRoot(pin)
 	baseRootIDs := map[string]uint64{rootName: baseRoot}
 	table := domain.table
 	iter := table.NewIterator(nil, nil)
@@ -972,7 +991,7 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 			return nil, err
 		}
 	}
-	_ = snap.Close()
+	defer func() { _ = snap.Close() }()
 
 	resultID := bytes.Clone(id)
 	iter := &systemTargetIterator{entries: []systemTargetEntry{{
@@ -1080,7 +1099,7 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	for _, run := range plan.runs {
 		baseRootIDs[run.name] = catalog.rootID(run.name)
 	}
-	_ = snap.Close()
+	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.runs))
 	iterators := make([]iterator.UnsafeIterator, 0, len(plan.runs))
@@ -1180,7 +1199,7 @@ func (c *Collection) insertBatchNoIndex(
 		}
 	}
 	stats.DuplicateDocumentPreflight = time.Since(phaseStart)
-	_ = snap.Close()
+	defer func() { _ = snap.Close() }()
 
 	phaseStart = time.Now()
 	table := newCollectionRunTable(len(entries))

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1342,7 +1342,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 			deltaTables = append(deltaTables, buildDeleteRootDeltaTable(deleteKeys))
 		}
 	}
-	_ = snap.Close()
+	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
 	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
@@ -1577,7 +1577,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 			deltaTables = append(deltaTables, table)
 		}
 	}
-	_ = snap.Close()
+	defer func() { _ = snap.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
 	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2228,63 +2228,91 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 // then scans the collection primary root up to maxDocuments. The returned
 // boolean is true when additional documents were present beyond the limit.
 func (c *Collection) ScanDocuments(maxDocuments int) ([]DocumentRecord, bool, error) {
+	out := make([]DocumentRecord, 0)
+	truncated, err := c.ScanDocumentsFunc(maxDocuments, func(record DocumentRecord) (bool, error) {
+		out = append(out, record)
+		return true, nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return out, truncated, nil
+}
+
+// ScanDocumentsFunc flushes buffered no-index writes before acquiring a
+// snapshot, then calls fn for primary collection records until maxDocuments is
+// reached, the collection is exhausted, or fn returns false. The returned
+// boolean is true only when additional documents were present beyond the
+// maxDocuments limit.
+func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord) (bool, error)) (bool, error) {
 	if c == nil {
-		return nil, false, errCollectionNil
+		return false, errCollectionNil
 	}
 	if c.db == nil {
-		return nil, false, errors.New("collections: db is nil")
+		return false, errors.New("collections: db is nil")
 	}
 	if maxDocuments <= 0 {
-		return nil, false, errors.New("collections: max documents must be positive")
+		return false, errors.New("collections: max documents must be positive")
+	}
+	if fn == nil {
+		return false, errors.New("collections: scan callback is nil")
 	}
 	if err := c.flushBufferedNoIndex(); err != nil {
-		return nil, false, err
+		return false, err
 	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
-		return nil, false, backenddb.ErrClosed
+		return false, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
 	catalog, err := c.catalogForSnapshot(snap)
 	if err != nil {
-		return nil, false, err
+		return false, err
 	}
 	if catalog == nil {
-		return nil, false, errCollectionNotFound
+		return false, errCollectionNotFound
 	}
 	rootID := catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
 	if rootID == 0 {
-		return nil, false, nil
+		return false, nil
 	}
 	it, err := snap.IteratorAtRoot(rootID, nil, nil)
 	if errors.Is(err, tree.ErrKeyNotFound) {
-		return nil, false, nil
+		return false, nil
 	}
 	if err != nil {
-		return nil, false, err
+		return false, err
 	}
 	defer func() { _ = it.Close() }()
-	out := make([]DocumentRecord, 0)
 	truncated := false
+	scanned := 0
 	for it.Valid() {
 		if it.IsDeleted() {
 			it.Next()
 			continue
 		}
-		if len(out) >= maxDocuments {
+		if scanned >= maxDocuments {
 			truncated = true
 			break
 		}
-		out = append(out, DocumentRecord{
+		record := DocumentRecord{
 			ID:       bytes.Clone(it.UnsafeKey()),
 			Document: it.ValueCopy(nil),
-		})
+		}
+		scanned++
+		next, err := fn(record)
+		if err != nil {
+			return false, err
+		}
+		if !next {
+			return false, nil
+		}
 		it.Next()
 	}
 	if err := it.Error(); err != nil {
-		return nil, false, err
+		return false, err
 	}
-	return out, truncated, nil
+	return truncated, nil
 }
 
 func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCatalog, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1514,6 +1514,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	}
 	var oldState documentIndexState
 	var newState documentIndexState
+	indexStateChanged := false
 	if len(runtimes) > 0 {
 		oldState, err = loadDeleteIndexState(snap, catalog, documentID, entry.Value, runtimes, plannerOptions)
 		if err != nil {
@@ -1525,9 +1526,12 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 			_ = snap.Close()
 			return false, false, err
 		}
-		if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, newState, documentID); err != nil {
-			_ = snap.Close()
-			return false, false, err
+		indexStateChanged = !documentIndexStatesEqual(oldState, newState)
+		if indexStateChanged {
+			if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, newState, documentID); err != nil {
+				_ = snap.Close()
+				return false, false, err
+			}
 		}
 	}
 
@@ -1542,7 +1546,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	primaryTable.Freeze()
 	deltaTables = append(deltaTables, primaryTable)
 
-	if len(runtimes) > 0 {
+	if indexStateChanged {
 		stateRootName := collectionIndexStateRootName(c.meta.Name)
 		stateRootID := catalog.rootID(stateRootName)
 		rootNames = append(rootNames, stateRootName)
@@ -1868,6 +1872,24 @@ func cloneDocumentIndexState(state documentIndexState) documentIndexState {
 		out[name] = normalizeEncodedIndexValues(values)
 	}
 	return out
+}
+
+func documentIndexStatesEqual(left, right documentIndexState) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for name, leftValues := range left {
+		rightValues, ok := right[name]
+		if !ok || len(leftValues) != len(rightValues) {
+			return false
+		}
+		for i := range leftValues {
+			if !bytes.Equal(leftValues[i], rightValues[i]) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1146,6 +1146,7 @@ func TestRootDescriptorDeltaRejectsConcurrentSchemaChange(t *testing.T) {
 		t.Fatal("expected snapshot")
 	}
 	catalog, err := loadCollectionCatalog(snap, "users")
+	baseCommitSeq := snapshotCommitSeq(snap)
 	baseSystemRoot := snapshotSystemRoot(snap)
 	_ = snap.Close()
 	if err != nil {
@@ -1168,6 +1169,7 @@ func TestRootDescriptorDeltaRejectsConcurrentSchemaChange(t *testing.T) {
 	}
 
 	iter, err := col.buildRootDescriptorSystemDeltaIterator(
+		baseCommitSeq,
 		baseSystemRoot,
 		[]string{rootName},
 		map[string]uint64{rootName: baseRoot},
@@ -1344,6 +1346,55 @@ func TestCollectionCachedCatalogRefreshesAfterCrossHandleWrite(t *testing.T) {
 	}
 	if want := []byte(`{"name":"ada"}`); !bytes.Equal(got, want) {
 		t.Fatalf("reader saw stale catalog value=%q want %q", got, want)
+	}
+}
+
+func TestCollectionCachedCatalogUsesCommitSeq(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"ada"}`)}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	rootName := collectionPrimaryRootName("users")
+	staleCatalog := cloneCatalogWithRootUpdates(catalog, catalog.meta, []string{rootName}, []uint64{^uint64(0)})
+
+	col.catalogMu.Lock()
+	col.catalog = staleCatalog
+	col.catalogSystemRoot = snapshotSystemRoot(snap)
+	col.catalogCommitSeq = snapshotCommitSeq(snap) + 1
+	col.catalogMu.Unlock()
+
+	refreshed, err := col.catalogForSnapshot(snap)
+	if err != nil {
+		t.Fatalf("catalogForSnapshot: %v", err)
+	}
+	if got := refreshed.rootID(rootName); got == ^uint64(0) {
+		t.Fatalf("catalog cache ignored commit sequence and returned stale root %d", got)
+	}
+	if got, want := refreshed.rootID(rootName), catalog.rootID(rootName); got != want {
+		t.Fatalf("refreshed root=%d want %d", got, want)
 	}
 }
 
@@ -2162,7 +2213,7 @@ func TestCollectionUpdateConcurrentCounterNoLostUpdates(t *testing.T) {
 			}
 			<-start
 			for j := 0; j < increments; j++ {
-				if _, _, err := workerCol.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+				matched, modified, err := workerCol.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
 					var doc struct {
 						Count int `json:"count"`
 					}
@@ -2175,8 +2226,13 @@ func TestCollectionUpdateConcurrentCounterNoLostUpdates(t *testing.T) {
 						return nil, false, err
 					}
 					return next, true, nil
-				}); err != nil {
+				})
+				if err != nil {
 					errs <- err
+					return
+				}
+				if !matched || !modified {
+					errs <- fmt.Errorf("update matched=%v modified=%v", matched, modified)
 					return
 				}
 			}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2207,6 +2207,131 @@ func TestCollectionUpdateConcurrentCounterNoLostUpdates(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateSkipsIndexRootsWhenIndexedValuesUnchanged(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl","seen":false}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	loadCatalog := func() *collectionCatalog {
+		t.Helper()
+		snap := d.AcquireSnapshot()
+		if snap == nil {
+			t.Fatal("expected snapshot")
+		}
+		defer func() { _ = snap.Close() }()
+		catalog, err := loadCollectionCatalog(snap, "users")
+		if err != nil {
+			t.Fatalf("load catalog: %v", err)
+		}
+		if catalog == nil {
+			t.Fatal("missing catalog")
+		}
+		return catalog
+	}
+	roots := func(catalog *collectionCatalog) map[string]uint64 {
+		t.Helper()
+		names := []string{
+			collectionPrimaryRootName("users"),
+			collectionIndexStateRootName("users"),
+			collectionSecondaryRootName("users", "email"),
+			collectionSecondaryRootName("users", "city"),
+		}
+		out := make(map[string]uint64, len(names))
+		for _, name := range names {
+			rootID := catalog.rootID(name)
+			if rootID == 0 {
+				t.Fatalf("root %q was not persisted", name)
+			}
+			out[name] = rootID
+		}
+		return out
+	}
+
+	before := roots(loadCatalog())
+	matched, modified, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"email":"ada@example.com","city":"hnl","seen":true}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("update non-indexed field: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("update matched=%v modified=%v want true/true", matched, modified)
+	}
+	after := roots(loadCatalog())
+	for _, rootName := range []string{
+		collectionIndexStateRootName("users"),
+		collectionSecondaryRootName("users", "email"),
+		collectionSecondaryRootName("users", "city"),
+	} {
+		if after[rootName] != before[rootName] {
+			t.Fatalf("root %q changed from %d to %d for non-indexed update", rootName, before[rootName], after[rootName])
+		}
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated document: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"seen":true`)) {
+		t.Fatalf("updated document=%q want seen=true", got)
+	}
+
+	matched, modified, err = col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"email":"ada2@example.com","city":"hnl","seen":true}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("update indexed field: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("indexed update matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterIndexed := roots(loadCatalog())
+	for _, rootName := range []string{
+		collectionIndexStateRootName("users"),
+		collectionSecondaryRootName("users", "email"),
+	} {
+		if afterIndexed[rootName] == after[rootName] {
+			t.Fatalf("root %q did not change for indexed update", rootName)
+		}
+	}
+	ids, err := col.FindByIndexValue("email", "ada2@example.com")
+	if err != nil {
+		t.Fatalf("find new email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("new email ids=%q want u1", ids)
+	}
+	ids, err = col.FindByIndexValue("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find old email: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("old email ids=%q want none", ids)
+	}
+}
+
 func TestCollectionInsertBatchBridge_RejectsPersistedUniqueConflictAtomically(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2450,6 +2450,117 @@ func TestCollectionUpdateConcurrentCounterNoLostUpdates(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateConcurrentIndexedNoRetryExhaustion(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	const documents = 32
+	ids := make([][]byte, documents)
+	docs := make([][]byte, documents)
+	for i := 0; i < documents; i++ {
+		ids[i] = []byte(fmt.Sprintf("u%02d", i))
+		docs[i] = []byte(fmt.Sprintf(`{"email":"user%02d@example.test","city":"hnl","count":0}`, i))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	const (
+		workers = 8
+		updates = 100
+	)
+	workerCols := make([]*Collection, workers)
+	for i := range workerCols {
+		workerCol, err := mgr.OpenCollection("users")
+		if err != nil {
+			t.Fatalf("open worker collection: %v", err)
+		}
+		workerCols[i] = workerCol
+	}
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(worker int, workerCol *Collection) {
+			defer wg.Done()
+			<-start
+			for update := 0; update < updates; update++ {
+				id := ids[(worker*updates+update*37)%documents]
+				matched, modified, err := workerCol.Update(id, func(current []byte) ([]byte, bool, error) {
+					var doc struct {
+						Email string `json:"email"`
+						City  string `json:"city"`
+						Count int    `json:"count"`
+					}
+					if err := json.Unmarshal(current, &doc); err != nil {
+						return nil, false, err
+					}
+					doc.Count++
+					next, err := json.Marshal(doc)
+					if err != nil {
+						return nil, false, err
+					}
+					return next, true, nil
+				})
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !matched || !modified {
+					errs <- fmt.Errorf("update matched=%v modified=%v", matched, modified)
+					return
+				}
+			}
+			errs <- nil
+		}(worker, workerCols[worker])
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("update: %v", err)
+		}
+	}
+
+	total := 0
+	for _, id := range ids {
+		got, err := col.Get(id)
+		if err != nil {
+			t.Fatalf("get %q: %v", id, err)
+		}
+		var doc struct {
+			Count int `json:"count"`
+		}
+		if err := json.Unmarshal(got, &doc); err != nil {
+			t.Fatalf("unmarshal %q: %v", id, err)
+		}
+		total += doc.Count
+	}
+	if want := workers * updates; total != want {
+		t.Fatalf("total count=%d want %d", total, want)
+	}
+}
+
 func TestCollectionUpdateAllowsUnrelatedUserRootCommit(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1330,6 +1330,7 @@ func TestRootDescriptorDeltaRejectsConcurrentSchemaChange(t *testing.T) {
 		t.Fatal("expected snapshot")
 	}
 	catalog, err := loadCollectionCatalog(snap, "users")
+	baseCommitSeq := snapshotCommitSeq(snap)
 	baseSystemRoot := snapshotSystemRoot(snap)
 	_ = snap.Close()
 	if err != nil {
@@ -1352,6 +1353,7 @@ func TestRootDescriptorDeltaRejectsConcurrentSchemaChange(t *testing.T) {
 	}
 
 	iter, err := col.buildRootDescriptorSystemDeltaIterator(
+		baseCommitSeq,
 		baseSystemRoot,
 		[]string{rootName},
 		map[string]uint64{rootName: baseRoot},
@@ -1528,6 +1530,55 @@ func TestCollectionCachedCatalogRefreshesAfterCrossHandleWrite(t *testing.T) {
 	}
 	if want := []byte(`{"name":"ada"}`); !bytes.Equal(got, want) {
 		t.Fatalf("reader saw stale catalog value=%q want %q", got, want)
+	}
+}
+
+func TestCollectionCachedCatalogUsesCommitSeq(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"ada"}`)}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	rootName := collectionPrimaryRootName("users")
+	staleCatalog := cloneCatalogWithRootUpdates(catalog, catalog.meta, []string{rootName}, []uint64{^uint64(0)})
+
+	col.catalogMu.Lock()
+	col.catalog = staleCatalog
+	col.catalogSystemRoot = snapshotSystemRoot(snap)
+	col.catalogCommitSeq = snapshotCommitSeq(snap) + 1
+	col.catalogMu.Unlock()
+
+	refreshed, err := col.catalogForSnapshot(snap)
+	if err != nil {
+		t.Fatalf("catalogForSnapshot: %v", err)
+	}
+	if got := refreshed.rootID(rootName); got == ^uint64(0) {
+		t.Fatalf("catalog cache ignored commit sequence and returned stale root %d", got)
+	}
+	if got, want := refreshed.rootID(rootName), catalog.rootID(rootName); got != want {
+		t.Fatalf("refreshed root=%d want %d", got, want)
 	}
 }
 
@@ -2349,7 +2400,7 @@ func TestCollectionUpdateConcurrentCounterNoLostUpdates(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for j := 0; j < increments; j++ {
-				if _, _, err := workerCol.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+				matched, modified, err := workerCol.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
 					var doc struct {
 						Count int `json:"count"`
 					}
@@ -2362,8 +2413,13 @@ func TestCollectionUpdateConcurrentCounterNoLostUpdates(t *testing.T) {
 						return nil, false, err
 					}
 					return next, true, nil
-				}); err != nil {
+				})
+				if err != nil {
 					errs <- err
+					return
+				}
+				if !matched || !modified {
+					errs <- fmt.Errorf("update matched=%v modified=%v", matched, modified)
 					return
 				}
 			}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2006,6 +2006,17 @@ func TestCollectionScanDocumentsAndFindByIndexValue(t *testing.T) {
 	if !truncated || len(records) != 1 {
 		t.Fatalf("limited scan truncated=%v len=%d want true/1", truncated, len(records))
 	}
+	var callbackIDs [][]byte
+	truncated, err = col.ScanDocumentsFunc(1, func(record DocumentRecord) (bool, error) {
+		callbackIDs = append(callbackIDs, record.ID)
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("scan documents func: %v", err)
+	}
+	if truncated || len(callbackIDs) != 1 || !bytes.Equal(callbackIDs[0], []byte("u1")) {
+		t.Fatalf("callback scan truncated=%v ids=%q want false/[u1]", truncated, callbackIDs)
+	}
 }
 
 func TestCollectionFindByIndexValueMatchesLargeJSONInteger(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1822,6 +1822,17 @@ func TestCollectionScanDocumentsAndFindByIndexValue(t *testing.T) {
 	if !truncated || len(records) != 1 {
 		t.Fatalf("limited scan truncated=%v len=%d want true/1", truncated, len(records))
 	}
+	var callbackIDs [][]byte
+	truncated, err = col.ScanDocumentsFunc(1, func(record DocumentRecord) (bool, error) {
+		callbackIDs = append(callbackIDs, record.ID)
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("scan documents func: %v", err)
+	}
+	if truncated || len(callbackIDs) != 1 || !bytes.Equal(callbackIDs[0], []byte("u1")) {
+		t.Fatalf("callback scan truncated=%v ids=%q want false/[u1]", truncated, callbackIDs)
+	}
 }
 
 func TestCollectionFindByIndexValueMatchesLargeJSONInteger(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2467,6 +2467,131 @@ func TestCollectionUpdateAllowsUnrelatedUserRootCommit(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateSkipsIndexRootsWhenIndexedValuesUnchanged(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl","seen":false}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	loadCatalog := func() *collectionCatalog {
+		t.Helper()
+		snap := d.AcquireSnapshot()
+		if snap == nil {
+			t.Fatal("expected snapshot")
+		}
+		defer func() { _ = snap.Close() }()
+		catalog, err := loadCollectionCatalog(snap, "users")
+		if err != nil {
+			t.Fatalf("load catalog: %v", err)
+		}
+		if catalog == nil {
+			t.Fatal("missing catalog")
+		}
+		return catalog
+	}
+	roots := func(catalog *collectionCatalog) map[string]uint64 {
+		t.Helper()
+		names := []string{
+			collectionPrimaryRootName("users"),
+			collectionIndexStateRootName("users"),
+			collectionSecondaryRootName("users", "email"),
+			collectionSecondaryRootName("users", "city"),
+		}
+		out := make(map[string]uint64, len(names))
+		for _, name := range names {
+			rootID := catalog.rootID(name)
+			if rootID == 0 {
+				t.Fatalf("root %q was not persisted", name)
+			}
+			out[name] = rootID
+		}
+		return out
+	}
+
+	before := roots(loadCatalog())
+	matched, modified, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"email":"ada@example.com","city":"hnl","seen":true}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("update non-indexed field: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("update matched=%v modified=%v want true/true", matched, modified)
+	}
+	after := roots(loadCatalog())
+	for _, rootName := range []string{
+		collectionIndexStateRootName("users"),
+		collectionSecondaryRootName("users", "email"),
+		collectionSecondaryRootName("users", "city"),
+	} {
+		if after[rootName] != before[rootName] {
+			t.Fatalf("root %q changed from %d to %d for non-indexed update", rootName, before[rootName], after[rootName])
+		}
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated document: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"seen":true`)) {
+		t.Fatalf("updated document=%q want seen=true", got)
+	}
+
+	matched, modified, err = col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"email":"ada2@example.com","city":"hnl","seen":true}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("update indexed field: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("indexed update matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterIndexed := roots(loadCatalog())
+	for _, rootName := range []string{
+		collectionIndexStateRootName("users"),
+		collectionSecondaryRootName("users", "email"),
+	} {
+		if afterIndexed[rootName] == after[rootName] {
+			t.Fatalf("root %q did not change for indexed update", rootName)
+		}
+	}
+	ids, err := col.FindByIndexValue("email", "ada2@example.com")
+	if err != nil {
+		t.Fatalf("find new email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("new email ids=%q want u1", ids)
+	}
+	ids, err = col.FindByIndexValue("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find old email: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("old email ids=%q want none", ids)
+	}
+}
+
 func TestCollectionInsertBatchBridge_RejectsPersistedUniqueConflictAtomically(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -266,6 +266,18 @@ func (s *Server) findUnsortedScanDocuments(col *collections.Collection, plan fin
 
 func storedDocumentMatchesPredicates(stored []byte, predicates []findPredicate) (bool, bool, error) {
 	for _, pred := range predicates {
+		if isRangePredicate(pred.op) {
+			match, ok, err := storedDocumentMatchesInt64RangePredicate(stored, pred)
+			if err != nil {
+				return false, false, err
+			}
+			if ok {
+				if !match {
+					return false, true, nil
+				}
+				continue
+			}
+		}
 		value, found, ok, err := storedDocumentPredicateValue(stored, pred.field)
 		if err != nil {
 			return false, false, err
@@ -288,6 +300,118 @@ func storedDocumentMatchesPredicates(stored []byte, predicates []findPredicate) 
 		}
 	}
 	return true, true, nil
+}
+
+func isRangePredicate(op findPredicateOp) bool {
+	switch op {
+	case findPredicateGT, findPredicateGTE, findPredicateLT, findPredicateLTE:
+		return true
+	default:
+		return false
+	}
+}
+
+func storedDocumentMatchesInt64RangePredicate(stored []byte, pred findPredicate) (bool, bool, error) {
+	if field := pred.field; field == "" || strings.Contains(field, ".") {
+		return false, false, nil
+	}
+	if len(pred.values) != 1 {
+		return false, false, nil
+	}
+	threshold, ok := rawValueInt64(pred.values[0])
+	if !ok {
+		return false, false, nil
+	}
+	raw, valueType, _, err := jsonparser.Get(stored, pred.field)
+	if err == jsonparser.KeyPathNotFoundError {
+		return false, true, nil
+	}
+	if err != nil {
+		return false, false, err
+	}
+	value, ok, err := storedJSONInt64(raw, valueType)
+	if err != nil || !ok {
+		return false, ok, err
+	}
+	switch pred.op {
+	case findPredicateGT:
+		return value > threshold, true, nil
+	case findPredicateGTE:
+		return value >= threshold, true, nil
+	case findPredicateLT:
+		return value < threshold, true, nil
+	case findPredicateLTE:
+		return value <= threshold, true, nil
+	default:
+		return false, false, nil
+	}
+}
+
+func rawValueInt64(value bson.RawValue) (int64, bool) {
+	if v, ok := value.Int64OK(); ok {
+		return v, true
+	}
+	if v, ok := value.Int32OK(); ok {
+		return int64(v), true
+	}
+	return 0, false
+}
+
+func storedJSONInt64(raw []byte, valueType jsonparser.ValueType) (int64, bool, error) {
+	switch valueType {
+	case jsonparser.Number:
+		value, err := jsonparser.ParseInt(raw)
+		if err != nil {
+			return 0, false, nil
+		}
+		return value, true, nil
+	case jsonparser.Object:
+		return storedExtendedJSONInt64(raw)
+	default:
+		return 0, false, nil
+	}
+}
+
+func storedExtendedJSONInt64(raw []byte) (int64, bool, error) {
+	var (
+		key       string
+		value     []byte
+		valueType jsonparser.ValueType
+		count     int
+	)
+	err := jsonparser.ObjectEach(raw, func(k, v []byte, t jsonparser.ValueType, _ int) error {
+		count++
+		key = string(k)
+		value = append(value[:0], v...)
+		valueType = t
+		return nil
+	})
+	if err != nil {
+		return 0, false, err
+	}
+	if count != 1 || valueType != jsonparser.String {
+		return 0, false, nil
+	}
+	text, err := jsonparser.ParseString(value)
+	if err != nil {
+		return 0, false, err
+	}
+	switch key {
+	case "$numberInt":
+		parsed, err := strconv.ParseInt(text, 10, 32)
+		if err != nil {
+			return 0, false, err
+		}
+		return parsed, true, nil
+	case "$numberLong":
+		parsed, err := strconv.ParseInt(text, 10, 64)
+		if err != nil {
+			return 0, false, err
+		}
+		return parsed, true, nil
+	default:
+		return 0, false, nil
+	}
 }
 
 func storedDocumentPredicateValue(stored []byte, field string) (bson.RawValue, bool, bool, error) {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/buger/jsonparser"
 	"github.com/snissn/gomap/TreeDB/collections"
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -225,13 +226,22 @@ func (s *Server) findUnsortedScanDocuments(col *collections.Collection, plan fin
 	docs := make([]wire.Document, 0)
 	matched := 0
 	truncated, err := col.ScanDocumentsFunc(maxDocuments, func(record collections.DocumentRecord) (bool, error) {
+		match, ok, err := storedDocumentMatchesPredicates(record.Document, plan.predicates)
+		if err != nil {
+			return false, err
+		}
+		if ok && !match {
+			return true, nil
+		}
 		doc, err := storedDocumentToBSON(record.Document)
 		if err != nil {
 			return false, err
 		}
-		match, err := documentMatchesPredicates(doc, plan.predicates)
-		if err != nil {
-			return false, err
+		if !ok {
+			match, err = documentMatchesPredicates(doc, plan.predicates)
+			if err != nil {
+				return false, err
+			}
 		}
 		if !match {
 			return true, nil
@@ -252,6 +262,164 @@ func (s *Server) findUnsortedScanDocuments(col *collections.Collection, plan fin
 		return nil, true, fmt.Errorf("Mongo gateway find requires a bounded scan and exceeded %d documents", maxDocuments)
 	}
 	return docs, true, nil
+}
+
+func storedDocumentMatchesPredicates(stored []byte, predicates []findPredicate) (bool, bool, error) {
+	for _, pred := range predicates {
+		value, found, ok, err := storedDocumentPredicateValue(stored, pred.field)
+		if err != nil {
+			return false, false, err
+		}
+		if !ok {
+			return false, false, nil
+		}
+		if !found {
+			if missingValueMatchesPredicate(pred) {
+				continue
+			}
+			return false, true, nil
+		}
+		match, err := valueMatchesPredicate(value, pred)
+		if err != nil {
+			return false, false, err
+		}
+		if !match {
+			return false, true, nil
+		}
+	}
+	return true, true, nil
+}
+
+func storedDocumentPredicateValue(stored []byte, field string) (bson.RawValue, bool, bool, error) {
+	if field == "" || strings.Contains(field, ".") {
+		return bson.RawValue{}, false, false, nil
+	}
+	raw, valueType, _, err := jsonparser.Get(stored, field)
+	if err == jsonparser.KeyPathNotFoundError {
+		return bson.RawValue{}, false, true, nil
+	}
+	if err != nil {
+		return bson.RawValue{}, false, false, err
+	}
+	value, ok, err := bsonRawValueFromStoredJSON(raw, valueType)
+	return value, true, ok, err
+}
+
+func bsonRawValueFromStoredJSON(raw []byte, valueType jsonparser.ValueType) (bson.RawValue, bool, error) {
+	switch valueType {
+	case jsonparser.String:
+		value, err := jsonparser.ParseString(raw)
+		if err != nil {
+			return bson.RawValue{}, false, err
+		}
+		rawValue, err := bsonRawValueFromGoValue(value)
+		return rawValue, true, err
+	case jsonparser.Number:
+		rawValue, err := bsonRawValueFromJSONNumber(raw)
+		return rawValue, true, err
+	case jsonparser.Boolean:
+		switch string(raw) {
+		case "true":
+			rawValue, err := bsonRawValueFromGoValue(true)
+			return rawValue, true, err
+		case "false":
+			rawValue, err := bsonRawValueFromGoValue(false)
+			return rawValue, true, err
+		default:
+			return bson.RawValue{}, false, jsonparser.MalformedValueError
+		}
+	case jsonparser.Null:
+		return bson.RawValue{Type: bson.TypeNull}, true, nil
+	case jsonparser.Object:
+		return bsonRawValueFromStoredExtendedJSON(raw)
+	default:
+		return bson.RawValue{}, false, nil
+	}
+}
+
+func bsonRawValueFromJSONNumber(raw []byte) (bson.RawValue, error) {
+	if !bytes.ContainsAny(raw, ".eE") {
+		if value, err := jsonparser.ParseInt(raw); err == nil {
+			return bsonRawValueFromGoValue(value)
+		}
+	}
+	value, err := jsonparser.ParseFloat(raw)
+	if err != nil {
+		return bson.RawValue{}, err
+	}
+	return bsonRawValueFromGoValue(value)
+}
+
+func bsonRawValueFromStoredExtendedJSON(raw []byte) (bson.RawValue, bool, error) {
+	var (
+		key       string
+		value     []byte
+		valueType jsonparser.ValueType
+		count     int
+	)
+	err := jsonparser.ObjectEach(raw, func(k, v []byte, t jsonparser.ValueType, _ int) error {
+		count++
+		key = string(k)
+		value = append(value[:0], v...)
+		valueType = t
+		return nil
+	})
+	if err != nil {
+		return bson.RawValue{}, false, err
+	}
+	if count != 1 || valueType != jsonparser.String {
+		return bson.RawValue{}, false, nil
+	}
+	text, err := jsonparser.ParseString(value)
+	if err != nil {
+		return bson.RawValue{}, false, err
+	}
+	switch key {
+	case "$numberInt":
+		parsed, err := strconv.ParseInt(text, 10, 32)
+		if err != nil {
+			return bson.RawValue{}, false, err
+		}
+		rawValue, err := bsonRawValueFromGoValue(int32(parsed))
+		return rawValue, true, err
+	case "$numberLong":
+		parsed, err := strconv.ParseInt(text, 10, 64)
+		if err != nil {
+			return bson.RawValue{}, false, err
+		}
+		rawValue, err := bsonRawValueFromGoValue(parsed)
+		return rawValue, true, err
+	case "$numberDouble":
+		parsed, err := parseExtendedJSONDouble(text)
+		if err != nil {
+			return bson.RawValue{}, false, err
+		}
+		rawValue, err := bsonRawValueFromGoValue(parsed)
+		return rawValue, true, err
+	default:
+		return bson.RawValue{}, false, nil
+	}
+}
+
+func parseExtendedJSONDouble(text string) (float64, error) {
+	switch text {
+	case "NaN":
+		return math.NaN(), nil
+	case "Infinity":
+		return math.Inf(1), nil
+	case "-Infinity":
+		return math.Inf(-1), nil
+	default:
+		return strconv.ParseFloat(text, 64)
+	}
+}
+
+func bsonRawValueFromGoValue(value any) (bson.RawValue, error) {
+	valueType, raw, err := bson.MarshalValue(value)
+	if err != nil {
+		return bson.RawValue{}, err
+	}
+	return bson.RawValue{Type: valueType, Value: raw}, nil
 }
 
 func findPlanHasDirectCandidate(meta collections.CollectionMeta, predicates []findPredicate) bool {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -233,11 +233,12 @@ func (s *Server) findUnsortedScanDocuments(col *collections.Collection, plan fin
 		if ok && !match {
 			return true, nil
 		}
-		doc, err := storedDocumentToBSON(record.Document)
-		if err != nil {
-			return false, err
-		}
+		var doc wire.Document
 		if !ok {
+			doc, err = storedDocumentToBSON(record.Document)
+			if err != nil {
+				return false, err
+			}
 			match, err = documentMatchesPredicates(doc, plan.predicates)
 			if err != nil {
 				return false, err
@@ -246,9 +247,17 @@ func (s *Server) findUnsortedScanDocuments(col *collections.Collection, plan fin
 		if !match {
 			return true, nil
 		}
-		if matched >= int(plan.skip) {
-			docs = append(docs, doc)
+		if matched < int(plan.skip) {
+			matched++
+			return true, nil
 		}
+		if ok {
+			doc, err = storedDocumentToBSON(record.Document)
+			if err != nil {
+				return false, err
+			}
+		}
+		docs = append(docs, doc)
 		matched++
 		if plan.limit > 0 && len(docs) >= int(plan.limit) {
 			return false, nil

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -82,7 +82,15 @@ func parseFindPlan(command wire.Document, filter wire.Document) (findPlan, error
 
 func (s *Server) executeFind(col *collections.Collection, plan findPlan) (findResultSet, error) {
 	// MaxFindScanDocuments is a candidate-work cap, not a page-size cap. It is
-	// intentionally enforced before later skip/limit pagination.
+	// enforced while scanning candidates. Unsorted collection scans can stop
+	// early once skip/limit is satisfied because later records cannot affect the
+	// result set.
+	if docs, ok, err := s.findUnsortedScanDocuments(col, plan); ok || err != nil {
+		if err != nil {
+			return findResultSet{}, err
+		}
+		return findResultSet{docs: docs, projection: plan.projection}, nil
+	}
 	docs, err := s.findCandidateDocuments(col, plan.predicates)
 	if err != nil {
 		return findResultSet{}, err
@@ -207,6 +215,63 @@ func (s *Server) findCandidateDocuments(col *collections.Collection, predicates 
 		out = append(out, doc)
 	}
 	return out, nil
+}
+
+func (s *Server) findUnsortedScanDocuments(col *collections.Collection, plan findPlan) ([]wire.Document, bool, error) {
+	if plan.sort.field != "" || findPlanHasDirectCandidate(col.Meta(), plan.predicates) {
+		return nil, false, nil
+	}
+	maxDocuments := s.maxFindScanDocuments()
+	docs := make([]wire.Document, 0)
+	matched := 0
+	truncated, err := col.ScanDocumentsFunc(maxDocuments, func(record collections.DocumentRecord) (bool, error) {
+		doc, err := storedDocumentToBSON(record.Document)
+		if err != nil {
+			return false, err
+		}
+		match, err := documentMatchesPredicates(doc, plan.predicates)
+		if err != nil {
+			return false, err
+		}
+		if !match {
+			return true, nil
+		}
+		if matched >= int(plan.skip) {
+			docs = append(docs, doc)
+		}
+		matched++
+		if plan.limit > 0 && len(docs) >= int(plan.limit) {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, true, err
+	}
+	if truncated {
+		return nil, true, fmt.Errorf("Mongo gateway find requires a bounded scan and exceeded %d documents", maxDocuments)
+	}
+	return docs, true, nil
+}
+
+func findPlanHasDirectCandidate(meta collections.CollectionMeta, predicates []findPredicate) bool {
+	if _, ok := primaryCandidatePredicate(predicates); ok {
+		return true
+	}
+	for _, pred := range predicates {
+		if pred.op != findPredicateEq && pred.op != findPredicateIn {
+			continue
+		}
+		if predicateContainsNull(pred) {
+			continue
+		}
+		for _, idx := range meta.Indexes {
+			if idx.Field == pred.field {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (s *Server) limitCandidateDocuments(docs []wire.Document) ([]wire.Document, error) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1344,6 +1344,33 @@ func TestServerFindCapsIndexedCandidates(t *testing.T) {
 	assertCommandError(t, tooMany, "BadValue")
 }
 
+func TestServerFindUnindexedLimitStopsBeforeScanCap(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.MaxFindScanDocuments = 1
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 257, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "hnl"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	findResponse := serveCommand(t, server, 258, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "city", Value: "hnl"}}},
+		{Key: "limit", Value: int32(1)},
+		{Key: "$db", Value: "app"},
+	})
+	assertBatchIDs(t, cursorFirstBatch(t, findResponse), []string{"u1"})
+}
+
 func TestServerFindChoosesNarrowestIndexedPredicate(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1371,6 +1371,48 @@ func TestServerFindUnindexedLimitStopsBeforeScanCap(t *testing.T) {
 	assertBatchIDs(t, cursorFirstBatch(t, findResponse), []string{"u1"})
 }
 
+func TestStoredDocumentMatchesPredicatesExtendedJSONScalars(t *testing.T) {
+	_, stored, err := prepareInsertDocument(mustDocument(t, bson.D{
+		{Key: "_id", Value: "u1"},
+		{Key: "city", Value: "hnl"},
+		{Key: "age", Value: int64(42)},
+		{Key: "active", Value: true},
+	}))
+	if err != nil {
+		t.Fatalf("prepare insert document: %v", err)
+	}
+	predicates := []findPredicate{
+		{field: "city", op: findPredicateEq, values: []bson.RawValue{mustRawValue(t, "hnl")}},
+		{field: "age", op: findPredicateGTE, values: []bson.RawValue{mustRawValue(t, int64(40))}},
+		{field: "active", op: findPredicateEq, values: []bson.RawValue{mustRawValue(t, true)}},
+	}
+	match, ok, err := storedDocumentMatchesPredicates(stored, predicates)
+	if err != nil {
+		t.Fatalf("match stored predicates: %v", err)
+	}
+	if !ok || !match {
+		t.Fatalf("match=%v ok=%v want true/true", match, ok)
+	}
+	match, ok, err = storedDocumentMatchesPredicates(stored, []findPredicate{
+		{field: "age", op: findPredicateLT, values: []bson.RawValue{mustRawValue(t, int64(40))}},
+	})
+	if err != nil {
+		t.Fatalf("match stored miss predicate: %v", err)
+	}
+	if !ok || match {
+		t.Fatalf("miss match=%v ok=%v want false/true", match, ok)
+	}
+	_, ok, err = storedDocumentMatchesPredicates(stored, []findPredicate{
+		{field: "profile.rank", op: findPredicateEq, values: []bson.RawValue{mustRawValue(t, int32(1))}},
+	})
+	if err != nil {
+		t.Fatalf("match unsupported dotted predicate: %v", err)
+	}
+	if ok {
+		t.Fatal("dotted predicate should fall back to BSON evaluation")
+	}
+}
+
 func TestServerFindChoosesNarrowestIndexedPredicate(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -1785,6 +1827,15 @@ func mustDocument(tb testing.TB, doc bson.D) wire.Document {
 		tb.Fatalf("marshal BSON document: %v", err)
 	}
 	return wire.Document(raw)
+}
+
+func mustRawValue(tb testing.TB, value any) bson.RawValue {
+	tb.Helper()
+	valueType, raw, err := bson.MarshalValue(value)
+	if err != nil {
+		tb.Fatalf("marshal BSON value: %v", err)
+	}
+	return bson.RawValue{Type: valueType, Value: raw}
 }
 
 func serveCommand(tb testing.TB, server *Server, requestID int32, doc bson.D) wire.Document {

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -144,7 +144,8 @@ The initial workload phases are:
 
 - `load_insert_many`: batched document inserts.
 - `id_find_one`: point lookup by `_id`.
-- `email_find_one`: point lookup by the `email` field.
+- `email_find_one`: point lookup by the `email` field; emitted only when the
+  email secondary index is part of the cell.
 - `age_range_limit_10`: bounded range query with `limit: 10`; operations count
   range queries, not returned documents.
 - `id_update_set`: `$set` update by `_id`.

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -22,6 +22,10 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
   -reads 10000 \
   -range-reads 1000 \
   -updates 1000 \
+  -concurrent-readers 8 \
+  -concurrent-reads 10000 \
+  -concurrent-writers 4 \
+  -concurrent-writes 1000 \
   -secondary-indexes 2 \
   -format json
 ```
@@ -45,6 +49,10 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
   -reads 10000 \
   -range-reads 1000 \
   -updates 1000 \
+  -concurrent-readers 8 \
+  -concurrent-reads 10000 \
+  -concurrent-writers 4 \
+  -concurrent-writes 1000 \
   -secondary-indexes 2 \
   -format json
 ```
@@ -66,6 +74,10 @@ scripts/mongo_gateway_compare.sh \
   --out /tmp/gomap_mongo_gateway_compare \
   --docs "1000 10000" \
   --indexes "0 2" \
+  --concurrent-readers 8 \
+  --concurrent-reads 10000 \
+  --concurrent-writers 4 \
+  --concurrent-writes 1000 \
   --mongo-mode docker
 ```
 
@@ -107,8 +119,28 @@ Useful overrides:
 - `INDEXES_LIST="0 1 2"`
 - `READS=50000`, `RANGE_READS=5000`, `UPDATES=5000`
 - `DELETES=1000`
+- `CONCURRENT_READERS=16`, `CONCURRENT_READS=50000`
+- `CONCURRENT_WRITERS=8`, `CONCURRENT_WRITES=10000`
 - `BATCH_SIZE=1000`
 - `MONGO_IMAGE=mongo:8`
+
+For a larger MongoDB comparison that keeps the 1M-doc cell bounded enough for a
+local run, use explicit operation counts:
+
+```sh
+BATCH_SIZE=5000 scripts/mongo_gateway_compare.sh \
+  --out /tmp/gomap_mongo_gateway_compare_large \
+  --docs "100000 1000000" \
+  --indexes "2" \
+  --reads 50000 \
+  --range-reads 5000 \
+  --updates 5000 \
+  --concurrent-readers 16 \
+  --concurrent-reads 50000 \
+  --concurrent-writers 8 \
+  --concurrent-writes 10000 \
+  --timeout 120m
+```
 
 ## Manual Matrix
 
@@ -125,6 +157,10 @@ for docs in 1000 10000 100000; do
       -reads "$docs" \
       -range-reads "$((docs / 10))" \
       -updates "$((docs / 10))" \
+      -concurrent-readers 8 \
+      -concurrent-reads "$((docs / 10))" \
+      -concurrent-writers 4 \
+      -concurrent-writes "$((docs / 20))" \
       -secondary-indexes "$indexes" \
       -format json > "treedb-${docs}-${indexes}.json"
 
@@ -134,6 +170,10 @@ for docs in 1000 10000 100000; do
       -reads "$docs" \
       -range-reads "$((docs / 10))" \
       -updates "$((docs / 10))" \
+      -concurrent-readers 8 \
+      -concurrent-reads "$((docs / 10))" \
+      -concurrent-writers 4 \
+      -concurrent-writes "$((docs / 20))" \
       -secondary-indexes "$indexes" \
       -format json > "mongo-${docs}-${indexes}.json"
   done
@@ -149,6 +189,10 @@ The initial workload phases are:
 - `age_range_limit_10`: bounded range query with `limit: 10`; operations count
   range queries, not returned documents.
 - `id_update_set`: `$set` update by `_id`.
+- `concurrent_id_find_one_rN`: total `_id` point reads split across `N`
+  goroutines.
+- `concurrent_id_update_set_wN`: total `$set` updates split across `N`
+  goroutines.
 - `id_delete_one`: optional deletes; disabled unless `-deletes` is non-zero.
 
 Latency samples are per MongoDB driver call. Insert ops/sec is normalized by

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -518,26 +518,28 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	}
 	result.Phases = append(result.Phases, idPhase)
 
-	emailPhase, err := measurePhase("email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
-		for i := 0; i < cfg.Reads; i++ {
-			email := benchmarkEmail((i * 17) % cfg.Documents)
-			var out bson.M
-			begin := time.Now()
-			err := coll.FindOne(ctx, bson.D{{Key: "email", Value: email}}).Decode(&out)
-			sample(time.Since(begin))
-			if err != nil {
-				return err
+	if runEmailFindPhase(cfg) {
+		emailPhase, err := measurePhase("email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+			for i := 0; i < cfg.Reads; i++ {
+				email := benchmarkEmail((i * 17) % cfg.Documents)
+				var out bson.M
+				begin := time.Now()
+				err := coll.FindOne(ctx, bson.D{{Key: "email", Value: email}}).Decode(&out)
+				sample(time.Since(begin))
+				if err != nil {
+					return err
+				}
+				if out["email"] != email {
+					return fmt.Errorf("email lookup returned email=%v want %s", out["email"], email)
+				}
 			}
-			if out["email"] != email {
-				return fmt.Errorf("email lookup returned email=%v want %s", out["email"], email)
-			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
+		result.Phases = append(result.Phases, emailPhase)
 	}
-	result.Phases = append(result.Phases, emailPhase)
 
 	rangePhase, err := measurePhase("age_range_limit_10", cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
@@ -619,6 +621,10 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 		return nil, err
 	}
 	return result, nil
+}
+
+func runEmailFindPhase(cfg config) bool {
+	return cfg.Reads > 0 && cfg.SecondaryIndexes >= 1
 }
 
 func createIndexes(ctx context.Context, coll *mongo.Collection, secondaryIndexes int) error {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -16,6 +16,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -27,22 +29,26 @@ import (
 )
 
 type config struct {
-	Target           string
-	MongoURI         string
-	TreeDBDir        string
-	KeepTreeDBDir    bool
-	DropBeforeRun    bool
-	Database         string
-	Collection       string
-	Documents        int
-	BatchSize        int
-	Reads            int
-	RangeReads       int
-	Updates          int
-	Deletes          int
-	SecondaryIndexes int
-	Timeout          time.Duration
-	Format           string
+	Target            string
+	MongoURI          string
+	TreeDBDir         string
+	KeepTreeDBDir     bool
+	DropBeforeRun     bool
+	Database          string
+	Collection        string
+	Documents         int
+	BatchSize         int
+	Reads             int
+	RangeReads        int
+	Updates           int
+	Deletes           int
+	ConcurrentReaders int
+	ConcurrentReads   int
+	ConcurrentWriters int
+	ConcurrentWrites  int
+	SecondaryIndexes  int
+	Timeout           time.Duration
+	Format            string
 }
 
 type benchmarkResult struct {
@@ -53,6 +59,10 @@ type benchmarkResult struct {
 	Collection                string         `json:"collection"`
 	Documents                 int            `json:"documents"`
 	SecondaryIndexes          int            `json:"secondary_indexes"`
+	ConcurrentReaders         int            `json:"concurrent_readers,omitempty"`
+	ConcurrentReads           int            `json:"concurrent_reads,omitempty"`
+	ConcurrentWriters         int            `json:"concurrent_writers,omitempty"`
+	ConcurrentWrites          int            `json:"concurrent_writes,omitempty"`
 	Phases                    []phaseResult  `json:"phases"`
 	TreeDBDiskAfterLoad       *diskSnapshot  `json:"treedb_disk_after_load,omitempty"`
 	TreeDBDiskAfterCheckpoint *diskSnapshot  `json:"treedb_disk_after_checkpoint,omitempty"`
@@ -146,6 +156,10 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.RangeReads, "range-reads", 100, "range reads with limit")
 	fs.IntVar(&cfg.Updates, "updates", 100, "$set updates by _id")
 	fs.IntVar(&cfg.Deletes, "deletes", 0, "deleteOne operations by _id")
+	fs.IntVar(&cfg.ConcurrentReaders, "concurrent-readers", 0, "reader goroutines for the concurrent _id read phase; 0 disables the phase")
+	fs.IntVar(&cfg.ConcurrentReads, "concurrent-reads", 0, "total _id read operations for the concurrent read phase")
+	fs.IntVar(&cfg.ConcurrentWriters, "concurrent-writers", 0, "writer goroutines for the concurrent _id update phase; 0 disables the phase")
+	fs.IntVar(&cfg.ConcurrentWrites, "concurrent-writes", 0, "total update operations for the concurrent write phase")
 	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=both single-field indexes: email and city")
 	fs.DurationVar(&cfg.Timeout, "timeout", 10*time.Minute, "overall benchmark timeout")
 	fs.StringVar(&cfg.Format, "format", "text", "output format: text or json")
@@ -164,8 +178,17 @@ func parseConfig(args []string) (config, error) {
 	if cfg.BatchSize <= 0 {
 		return config{}, errors.New("batch-size must be > 0")
 	}
-	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 {
+	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 || cfg.ConcurrentReads < 0 || cfg.ConcurrentWrites < 0 {
 		return config{}, errors.New("operation counts cannot be negative")
+	}
+	if cfg.ConcurrentReaders < 0 || cfg.ConcurrentWriters < 0 {
+		return config{}, errors.New("concurrency values cannot be negative")
+	}
+	if (cfg.ConcurrentReaders == 0) != (cfg.ConcurrentReads == 0) {
+		return config{}, errors.New("concurrent-readers and concurrent-reads must both be > 0 or both be 0")
+	}
+	if (cfg.ConcurrentWriters == 0) != (cfg.ConcurrentWrites == 0) {
+		return config{}, errors.New("concurrent-writers and concurrent-writes must both be > 0 or both be 0")
 	}
 	if cfg.Timeout < 0 {
 		return config{}, errors.New("timeout cannot be negative")
@@ -453,11 +476,15 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	db := target.client.Database(cfg.Database)
 	coll := db.Collection(cfg.Collection)
 	result := &benchmarkResult{
-		Target:           cfg.Target,
-		Database:         cfg.Database,
-		Collection:       cfg.Collection,
-		Documents:        cfg.Documents,
-		SecondaryIndexes: cfg.SecondaryIndexes,
+		Target:            cfg.Target,
+		Database:          cfg.Database,
+		Collection:        cfg.Collection,
+		Documents:         cfg.Documents,
+		SecondaryIndexes:  cfg.SecondaryIndexes,
+		ConcurrentReaders: cfg.ConcurrentReaders,
+		ConcurrentReads:   cfg.ConcurrentReads,
+		ConcurrentWriters: cfg.ConcurrentWriters,
+		ConcurrentWrites:  cfg.ConcurrentWrites,
 	}
 	if cfg.Target == "treedb" {
 		if cfg.TreeDBDir != "" || cfg.KeepTreeDBDir {
@@ -594,6 +621,54 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 		return nil, err
 	}
 	result.Phases = append(result.Phases, updatePhase)
+
+	if cfg.ConcurrentReaders > 0 && cfg.ConcurrentReads > 0 {
+		concurrentReadPhase, err := measurePhase(fmt.Sprintf("concurrent_id_find_one_r%d", cfg.ConcurrentReaders), cfg.ConcurrentReads, func(sample func(time.Duration)) error {
+			return runConcurrentOperations(ctx, cfg.ConcurrentReaders, cfg.ConcurrentReads, func(op int) error {
+				id := benchmarkID((op * 17) % cfg.Documents)
+				var out bson.M
+				begin := time.Now()
+				err := coll.FindOne(ctx, bson.D{{Key: "_id", Value: id}}).Decode(&out)
+				sample(time.Since(begin))
+				if err != nil {
+					return err
+				}
+				if out["_id"] != id {
+					return fmt.Errorf("concurrent id lookup returned _id=%v want %s", out["_id"], id)
+				}
+				return nil
+			})
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, concurrentReadPhase)
+	}
+
+	if cfg.ConcurrentWriters > 0 && cfg.ConcurrentWrites > 0 {
+		concurrentWritePhase, err := measurePhase(fmt.Sprintf("concurrent_id_update_set_w%d", cfg.ConcurrentWriters), cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
+			return runConcurrentOperations(ctx, cfg.ConcurrentWriters, cfg.ConcurrentWrites, func(op int) error {
+				id := benchmarkID((op * 37) % cfg.Documents)
+				begin := time.Now()
+				res, err := coll.UpdateOne(ctx,
+					bson.D{{Key: "_id", Value: id}},
+					bson.D{{Key: "$set", Value: bson.D{{Key: "concurrent_updated", Value: true}, {Key: "concurrent_update_seq", Value: int64(op)}}}},
+				)
+				sample(time.Since(begin))
+				if err != nil {
+					return err
+				}
+				if res.MatchedCount != 1 {
+					return fmt.Errorf("concurrent update matched=%d want 1", res.MatchedCount)
+				}
+				return nil
+			})
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.Phases = append(result.Phases, concurrentWritePhase)
+	}
 
 	if cfg.Deletes > 0 {
 		deletePhase, err := measurePhase("id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
@@ -753,12 +828,65 @@ func int64Value(value any) (int64, bool) {
 
 func measurePhase(name string, operations int, run func(sample func(time.Duration)) error) (phaseResult, error) {
 	samples := make([]time.Duration, 0)
+	var samplesMu sync.Mutex
 	start := time.Now()
 	err := run(func(sample time.Duration) {
+		samplesMu.Lock()
 		samples = append(samples, sample)
+		samplesMu.Unlock()
 	})
 	duration := time.Since(start)
 	return summarizePhase(name, operations, len(samples), duration, samples), err
+}
+
+func runConcurrentOperations(ctx context.Context, workers, operations int, run func(op int) error) error {
+	if workers <= 0 || operations <= 0 {
+		return nil
+	}
+	if workers > operations {
+		workers = operations
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	var errOnce sync.Once
+	var firstErr error
+	recordErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errOnce.Do(func() {
+			firstErr = err
+			cancel()
+		})
+	}
+
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				if err := runCtx.Err(); err != nil {
+					return
+				}
+				op := int(next.Add(1) - 1)
+				if op >= operations {
+					return
+				}
+				if err := run(op); err != nil {
+					recordErr(err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return firstErr
+	}
+	return ctx.Err()
 }
 
 func summarizePhase(name string, operations, driverCalls int, duration time.Duration, samples []time.Duration) phaseResult {
@@ -840,8 +968,9 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(result)
 	case "text":
-		fmt.Fprintf(out, "target=%s database=%s collection=%s documents=%d secondary_indexes=%d\n",
-			result.Target, result.Database, result.Collection, result.Documents, result.SecondaryIndexes)
+		fmt.Fprintf(out, "target=%s database=%s collection=%s documents=%d secondary_indexes=%d concurrent_readers=%d concurrent_reads=%d concurrent_writers=%d concurrent_writes=%d\n",
+			result.Target, result.Database, result.Collection, result.Documents, result.SecondaryIndexes,
+			result.ConcurrentReaders, result.ConcurrentReads, result.ConcurrentWriters, result.ConcurrentWrites)
 		if result.TreeDBDir != "" {
 			fmt.Fprintf(out, "treedb_dir=%s\n", result.TreeDBDir)
 		}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -167,11 +170,21 @@ func TestParseConfigValidation(t *testing.T) {
 	if _, err := parseConfig([]string{"-target", "bad"}); err == nil {
 		t.Fatal("bad target accepted")
 	}
-	cfg, err := parseConfig([]string{"-target", "mongo", "-documents", "10", "-secondary-indexes", "1", "-format", "json"})
+	cfg, err := parseConfig([]string{
+		"-target", "mongo",
+		"-documents", "10",
+		"-secondary-indexes", "1",
+		"-format", "json",
+		"-concurrent-readers", "4",
+		"-concurrent-reads", "20",
+		"-concurrent-writers", "2",
+		"-concurrent-writes", "10",
+	})
 	if err != nil {
 		t.Fatalf("parse valid config: %v", err)
 	}
-	if cfg.Target != "mongo" || cfg.Documents != 10 || cfg.SecondaryIndexes != 1 || cfg.Format != "json" {
+	if cfg.Target != "mongo" || cfg.Documents != 10 || cfg.SecondaryIndexes != 1 || cfg.Format != "json" ||
+		cfg.ConcurrentReaders != 4 || cfg.ConcurrentReads != 20 || cfg.ConcurrentWriters != 2 || cfg.ConcurrentWrites != 10 {
 		t.Fatalf("unexpected config: %+v", cfg)
 	}
 	if _, err := parseConfig([]string{"-timeout", "0"}); err != nil {
@@ -179,6 +192,15 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if _, err := parseConfig([]string{"-timeout", "-1s"}); err == nil {
 		t.Fatal("negative timeout accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-readers", "-1"}); err == nil {
+		t.Fatal("negative concurrent-readers accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-readers", "1"}); err == nil {
+		t.Fatal("concurrent-readers without concurrent-reads accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-reads", "1"}); err == nil {
+		t.Fatal("concurrent-reads without concurrent-readers accepted")
 	}
 }
 
@@ -191,6 +213,43 @@ func TestRunEmailFindPhaseRequiresEmailIndex(t *testing.T) {
 	}
 	if runEmailFindPhase(config{Reads: 0, SecondaryIndexes: 1}) {
 		t.Fatal("email phase should be skipped when reads are disabled")
+	}
+}
+
+func TestRunConcurrentOperationsRunsAllOpsOnce(t *testing.T) {
+	var count atomic.Int64
+	seen := make([]atomic.Int64, 25)
+	err := runConcurrentOperations(context.Background(), 4, len(seen), func(op int) error {
+		if op < 0 || op >= len(seen) {
+			return os.ErrInvalid
+		}
+		seen[op].Add(1)
+		count.Add(1)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run concurrent operations: %v", err)
+	}
+	if got := count.Load(); got != int64(len(seen)) {
+		t.Fatalf("operation count=%d want %d", got, len(seen))
+	}
+	for op := range seen {
+		if got := seen[op].Load(); got != 1 {
+			t.Fatalf("op %d ran %d times, want once", op, got)
+		}
+	}
+}
+
+func TestRunConcurrentOperationsReturnsFirstError(t *testing.T) {
+	sentinel := errors.New("boom")
+	err := runConcurrentOperations(context.Background(), 4, 100, func(op int) error {
+		if op == 3 {
+			return sentinel
+		}
+		return nil
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err=%v want sentinel", err)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -182,6 +182,18 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 }
 
+func TestRunEmailFindPhaseRequiresEmailIndex(t *testing.T) {
+	if runEmailFindPhase(config{Reads: 10, SecondaryIndexes: 0}) {
+		t.Fatal("email phase should be skipped without an email index")
+	}
+	if !runEmailFindPhase(config{Reads: 10, SecondaryIndexes: 1}) {
+		t.Fatal("email phase should run when the email index exists")
+	}
+	if runEmailFindPhase(config{Reads: 0, SecondaryIndexes: 1}) {
+		t.Fatal("email phase should be skipped when reads are disabled")
+	}
+}
+
 func TestWriteResultSupportsGenericWriter(t *testing.T) {
 	result := &benchmarkResult{
 		Target:           "treedb",

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -11,11 +11,18 @@ DOCS_LIST="${DOCS_LIST:-1000 10000}"
 INDEXES_LIST="${INDEXES_LIST:-0 2}"
 BATCH_SIZE="${BATCH_SIZE:-500}"
 READS="${READS:-}"
+READS_DIVISOR="${READS_DIVISOR:-1}"
 RANGE_READS="${RANGE_READS:-}"
 UPDATES="${UPDATES:-}"
 DELETES="${DELETES:-0}"
 RANGE_READS_DIVISOR="${RANGE_READS_DIVISOR:-10}"
 UPDATES_DIVISOR="${UPDATES_DIVISOR:-10}"
+CONCURRENT_READERS="${CONCURRENT_READERS:-0}"
+CONCURRENT_READS="${CONCURRENT_READS:-}"
+CONCURRENT_READS_DIVISOR="${CONCURRENT_READS_DIVISOR:-10}"
+CONCURRENT_WRITERS="${CONCURRENT_WRITERS:-0}"
+CONCURRENT_WRITES="${CONCURRENT_WRITES:-}"
+CONCURRENT_WRITES_DIVISOR="${CONCURRENT_WRITES_DIVISOR:-10}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
 MONGO_IMAGE="${MONGO_IMAGE:-mongo:7}"
@@ -35,6 +42,18 @@ Options:
   --out DIR             Output directory. Default: mktemp under $TMPDIR or /tmp.
   --docs LIST           Space-separated document counts. Default: "1000 10000".
   --indexes LIST        Space-separated secondary-index counts. Default: "0 2".
+  --reads COUNT         Point reads per target/cell. Default: documents.
+  --range-reads COUNT   Range reads per target/cell. Default: documents / 10.
+  --updates COUNT       Updates per target/cell. Default: documents / 10.
+  --deletes COUNT       Deletes per target/cell. Default: 0.
+  --concurrent-readers N
+                        Reader goroutines for the concurrent _id read phase.
+  --concurrent-reads COUNT
+                        Concurrent point reads per target/cell.
+  --concurrent-writers N
+                        Writer goroutines for the concurrent update phase.
+  --concurrent-writes COUNT
+                        Concurrent updates per target/cell.
   --mongo-mode MODE     docker or external. Default: docker.
   --mongo-uri URI       MongoDB URI for --mongo-mode external.
   --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo:7.
@@ -43,9 +62,12 @@ Options:
   --help                Show this help.
 
 Environment overrides:
-  OUT_DIR, DOCS_LIST, INDEXES_LIST, BATCH_SIZE, READS, RANGE_READS, UPDATES,
-  DELETES, RANGE_READS_DIVISOR, UPDATES_DIVISOR, MONGO_MODE, MONGO_URI,
-  MONGO_IMAGE, DATABASE_PREFIX, COLLECTION, TIMEOUT, TITLE.
+  OUT_DIR, DOCS_LIST, INDEXES_LIST, BATCH_SIZE, READS, READS_DIVISOR,
+  RANGE_READS, UPDATES, DELETES, RANGE_READS_DIVISOR, UPDATES_DIVISOR,
+  CONCURRENT_READERS, CONCURRENT_READS, CONCURRENT_READS_DIVISOR,
+  CONCURRENT_WRITERS, CONCURRENT_WRITES, CONCURRENT_WRITES_DIVISOR,
+  MONGO_MODE, MONGO_URI, MONGO_IMAGE, DATABASE_PREFIX, COLLECTION, TIMEOUT,
+  TITLE.
 EOF
 }
 
@@ -61,6 +83,38 @@ while [[ $# -gt 0 ]]; do
       ;;
     --indexes)
       INDEXES_LIST="$2"
+      shift 2
+      ;;
+    --reads)
+      READS="$2"
+      shift 2
+      ;;
+    --range-reads)
+      RANGE_READS="$2"
+      shift 2
+      ;;
+    --updates)
+      UPDATES="$2"
+      shift 2
+      ;;
+    --deletes)
+      DELETES="$2"
+      shift 2
+      ;;
+    --concurrent-readers)
+      CONCURRENT_READERS="$2"
+      shift 2
+      ;;
+    --concurrent-reads)
+      CONCURRENT_READS="$2"
+      shift 2
+      ;;
+    --concurrent-writers)
+      CONCURRENT_WRITERS="$2"
+      shift 2
+      ;;
+    --concurrent-writes)
+      CONCURRENT_WRITES="$2"
       shift 2
       ;;
     --mongo-mode)
@@ -127,11 +181,19 @@ is_positive_int() {
   [[ "$1" =~ ^[0-9]+$ ]] && [[ "$1" -gt 0 ]]
 }
 
+is_nonnegative_int() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
 derived_count() {
   local docs=$1
   local explicit=$2
   local divisor=$3
   if [[ -n "$explicit" ]]; then
+    if ! is_nonnegative_int "$explicit"; then
+      echo "invalid explicit operation count: $explicit" >&2
+      exit 2
+    fi
     echo "$explicit"
     return
   fi
@@ -250,7 +312,11 @@ run_target() {
   local range_reads=$7
   local updates=$8
   local deletes=$9
-  shift 9
+  local concurrent_readers=${10}
+  local concurrent_reads=${11}
+  local concurrent_writers=${12}
+  local concurrent_writes=${13}
+  shift 13
 
   "$BENCH_BIN" \
     -target "$target" \
@@ -262,6 +328,10 @@ run_target() {
     -range-reads "$range_reads" \
     -updates "$updates" \
     -deletes "$deletes" \
+    -concurrent-readers "$concurrent_readers" \
+    -concurrent-reads "$concurrent_reads" \
+    -concurrent-writers "$concurrent_writers" \
+    -concurrent-writes "$concurrent_writes" \
     -secondary-indexes "$indexes" \
     -timeout "$TIMEOUT" \
     -format json \
@@ -276,12 +346,35 @@ if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
   echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI to use an existing server" >&2
   exit 2
 fi
+for value_name in DELETES CONCURRENT_READERS CONCURRENT_WRITERS; do
+  value=${!value_name}
+  if ! is_nonnegative_int "$value"; then
+    echo "invalid $value_name=$value (want non-negative integer)" >&2
+    exit 2
+  fi
+done
+if [[ "$CONCURRENT_READERS" -eq 0 && -n "$CONCURRENT_READS" && "$CONCURRENT_READS" != "0" ]]; then
+  echo "CONCURRENT_READERS must be > 0 when CONCURRENT_READS is set" >&2
+  exit 2
+fi
+if [[ "$CONCURRENT_WRITERS" -eq 0 && -n "$CONCURRENT_WRITES" && "$CONCURRENT_WRITES" != "0" ]]; then
+  echo "CONCURRENT_WRITERS must be > 0 when CONCURRENT_WRITES is set" >&2
+  exit 2
+fi
 
 {
   echo "running Mongo gateway comparison into: $OUT_DIR"
   echo "docs list: $DOCS_LIST"
   echo "secondary-index list: $INDEXES_LIST"
   echo "batch size: $BATCH_SIZE"
+  echo "reads: ${READS:-documents / $READS_DIVISOR}"
+  echo "range reads: ${RANGE_READS:-documents / $RANGE_READS_DIVISOR}"
+  echo "updates: ${UPDATES:-documents / $UPDATES_DIVISOR}"
+  echo "deletes: $DELETES"
+  echo "concurrent readers: $CONCURRENT_READERS"
+  echo "concurrent reads: ${CONCURRENT_READS:-documents / $CONCURRENT_READS_DIVISOR when readers > 0}"
+  echo "concurrent writers: $CONCURRENT_WRITERS"
+  echo "concurrent writes: ${CONCURRENT_WRITES:-documents / $CONCURRENT_WRITES_DIVISOR when writers > 0}"
   echo "mongo mode: $MONGO_MODE"
   if [[ "$MONGO_MODE" == "docker" ]]; then
     echo "mongo image: $MONGO_IMAGE"
@@ -301,9 +394,25 @@ for docs in $DOCS_LIST; do
     echo "invalid document count: $docs" >&2
     exit 2
   fi
-  reads="${READS:-$docs}"
+  reads=$(derived_count "$docs" "$READS" "$READS_DIVISOR")
   range_reads=$(derived_count "$docs" "$RANGE_READS" "$RANGE_READS_DIVISOR")
   updates=$(derived_count "$docs" "$UPDATES" "$UPDATES_DIVISOR")
+  concurrent_reads=0
+  if [[ "$CONCURRENT_READERS" -gt 0 ]]; then
+    concurrent_reads=$(derived_count "$docs" "$CONCURRENT_READS" "$CONCURRENT_READS_DIVISOR")
+    if [[ "$concurrent_reads" -eq 0 ]]; then
+      echo "concurrent reads must be > 0 when CONCURRENT_READERS is > 0" >&2
+      exit 2
+    fi
+  fi
+  concurrent_writes=0
+  if [[ "$CONCURRENT_WRITERS" -gt 0 ]]; then
+    concurrent_writes=$(derived_count "$docs" "$CONCURRENT_WRITES" "$CONCURRENT_WRITES_DIVISOR")
+    if [[ "$concurrent_writes" -eq 0 ]]; then
+      echo "concurrent writes must be > 0 when CONCURRENT_WRITERS is > 0" >&2
+      exit 2
+    fi
+  fi
   for indexes in $INDEXES_LIST; do
     if [[ ! "$indexes" =~ ^[0-9]+$ ]]; then
       echo "invalid index count: $indexes" >&2
@@ -321,6 +430,7 @@ for docs in $DOCS_LIST; do
     echo
     echo "==> $cell TreeDB"
     run_target treedb "$docs" "$indexes" "$tree_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
+      "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
       -treedb-dir "$tree_data" \
       -keep-treedb-dir
     tree_physical=$(du_bytes "$tree_data")
@@ -339,6 +449,7 @@ for docs in $DOCS_LIST; do
       fi
     fi
     run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
+      "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
       -mongo-uri "$mongo_uri"
     if [[ "$MONGO_MODE" == "docker" ]]; then
       stop_mongo_container "$mongo_container"
@@ -369,10 +480,14 @@ cat >"$README" <<EOF
 - docs list: \`$DOCS_LIST\`
 - secondary-index list: \`$INDEXES_LIST\`
 - batch size: \`$BATCH_SIZE\`
-- reads: \`per-cell ${READS:-documents}\`
+- reads: \`${READS:-documents / $READS_DIVISOR}\`
 - range reads: \`${RANGE_READS:-documents / $RANGE_READS_DIVISOR}\`
 - updates: \`${UPDATES:-documents / $UPDATES_DIVISOR}\`
 - deletes: \`$DELETES\`
+- concurrent readers: \`$CONCURRENT_READERS\`
+- concurrent reads: \`${CONCURRENT_READS:-documents / $CONCURRENT_READS_DIVISOR when readers > 0}\`
+- concurrent writers: \`$CONCURRENT_WRITERS\`
+- concurrent writes: \`${CONCURRENT_WRITES:-documents / $CONCURRENT_WRITES_DIVISOR when writers > 0}\`
 - MongoDB mode: \`$MONGO_MODE\`
 - MongoDB image: \`$MONGO_IMAGE\`
 - benchmark timeout: \`$TIMEOUT\`


### PR DESCRIPTION
## Summary

This PR tracks iterative TreeDB benchmark bug/performance work found while running the collection benchmark suite against MongoDB and SQLite from `origin/main`.

Initial root cause: the Mongo gateway benchmark's 10k / 0-secondary-index TreeDB cell was effectively stuck because the workload still ran `email_find_one` without an email index. The gateway materialized an unindexed scan and decoded every document from canonical Extended JSON before applying the `FindOne` limit, which turned 10k point reads into roughly 100M document decodes.

Initial changes:

- add `Collection.ScanDocumentsFunc` for streaming primary-root scans
- make unsorted unindexed gateway finds stop once `skip`/`limit` is satisfied
- skip `email_find_one` in `cmd/mongo_gateway_bench` cells where the email index does not exist
- add focused tests and update benchmark docs

## Benchmark Evidence So Far

MongoDB comparison, after the first fix:

- bundle: `/tmp/gomap_mongo_gateway_compare_main_fixed_OGFPep/report.md`
- exact branch/commit at run time: `main` / `97dc6abe44bb` plus local fix commit
- before: `docs_10000_idx_0 TreeDB` remained CPU-active for >9 minutes and was interrupted; stack showed `FindOne` waiting while the gateway was repeatedly in `findCandidateDocuments -> storedDocumentToBSON -> bson.UnmarshalExtJSON`
- after: full default `scripts/mongo_gateway_compare.sh` completed in about 20 seconds
- TreeDB vs MongoDB 10k/0-index after fix:
  - `id_find_one`: 12683 ops/sec vs MongoDB 8144 ops/sec, 1.56x TreeDB/MongoDB
  - `age_range_limit_10`: 2213 ops/sec vs MongoDB 4366 ops/sec, 0.51x TreeDB/MongoDB
  - `id_update_set`: 8262 ops/sec vs MongoDB 7369 ops/sec, 1.12x TreeDB/MongoDB
  - disk: TreeDB checkpoint 4.00 MiB / physical 4.03 MiB vs MongoDB physical 300.11 MiB

SQLite canonical comparison, after the first fix:

- bundle: `/tmp/collection_canonical_main_fixed_8TMjDO/benchmark_summary.md`
- exact command: `./scripts/bench_collections_canonical.sh -out-dir /tmp/collection_canonical_main_fixed_8TMjDO`
- `sqlite_native_columns_2_indexes`: 356379 docs/sec, 176.1 B/doc post-insert, 156.7 B/doc after VACUUM
- `sqlite_json_2_indexes`: 322477 docs/sec, 262.6 B/doc post-insert, 231.7 B/doc after VACUUM
- `treedb_template_v1_collection_2_indexes`: 346500 docs/sec, 105.6 B/doc post-insert, 44.3 B/doc offline rewrite, 31.7 B/doc full leafgen pack/GC
- compacted TreeDB template-v1 was 3.5x smaller than SQLite native columns after VACUUM via offline rewrite, and 4.9x smaller via full leafgen pack/GC

I will keep adding PR comments as new benchmark iterations find and validate additional fixes.

## Validation

- `GOWORK=off go test ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench ./cmd/mongo_gateway_compare_report`
- `GOWORK=off go test ./TreeDB/collections -run '^TestCollectionScanDocumentsAndFindByIndexValue$' -count=1`
- `git diff --check`
- focused formerly-stuck TreeDB 10k/0-index benchmark completed in about 2 seconds

Known unrelated current-main issue observed during validation:

- `GOWORK=off go test ./TreeDB/collections` fails in `TestCollectionUpdateConcurrentCounterNoLostUpdates` with `invalid page type` even when run by itself.
