### PR TITLE
treedb: cache compact leaf payload eligibility

### DIFF
--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -114,8 +114,8 @@ func allowsCompactLeafLogPayload(fileID uint32, path string) bool {
 	return filepath.Base(filepath.Dir(path)) == compactLeafPagePayloadDirName
 }
 
-func maybeDecodeLeafLogPayloadTo(fileID uint32, path string, payload, dst []byte) ([]byte, bool, bool, error) {
-	if !allowsCompactLeafLogPayload(fileID, path) {
+func maybeDecodeLeafLogPayloadToAllowed(allowed bool, payload, dst []byte) ([]byte, bool, bool, error) {
+	if !allowed {
 		return payload, false, false, nil
 	}
 	out, usedDst, decoded, err := decodeCompactLeafLogPayloadTo(payload, dst)
@@ -128,8 +128,12 @@ func maybeDecodeLeafLogPayloadTo(fileID uint32, path string, payload, dst []byte
 	return payload, false, false, nil
 }
 
-func appendMaybeDecodeLeafLogPayload(fileID uint32, path string, dst, payload []byte) ([]byte, error) {
-	if !allowsCompactLeafLogPayload(fileID, path) {
+func maybeDecodeLeafLogPayloadTo(fileID uint32, path string, payload, dst []byte) ([]byte, bool, bool, error) {
+	return maybeDecodeLeafLogPayloadToAllowed(allowsCompactLeafLogPayload(fileID, path), payload, dst)
+}
+
+func appendMaybeDecodeLeafLogPayloadAllowed(allowed bool, dst, payload []byte) ([]byte, error) {
+	if !allowed {
 		if len(payload) == 0 {
 			return dst, nil
 		}
@@ -139,4 +143,8 @@ func appendMaybeDecodeLeafLogPayload(fileID uint32, path string, dst, payload []
 		return append(dst, payload...), nil
 	}
 	return appendCompactLeafLogPayload(dst, payload)
+}
+
+func appendMaybeDecodeLeafLogPayload(fileID uint32, path string, dst, payload []byte) ([]byte, error) {
+	return appendMaybeDecodeLeafLogPayloadAllowed(allowsCompactLeafLogPayload(fileID, path), dst, payload)
 }

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -67,6 +67,15 @@ func TestOpenFileCachesCompactLeafPayloadEligibility(t *testing.T) {
 	}
 }
 
+func TestFileLiteralDerivesCompactLeafPayloadEligibility(t *testing.T) {
+	path := compactLeafPayloadTestPath(t, t.TempDir(), 1)
+	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
+	f := &File{ID: fileID, Path: path}
+	if !f.allowsCompactLeafPayload() {
+		t.Fatal("File literal should derive compact leaf payload eligibility from ID and Path")
+	}
+}
+
 func newLeafPayloadTestManager(t *testing.T, dir, path string, fileID uint32) *Manager {
 	t.Helper()
 	mgr, err := NewManager(dir)

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -39,6 +39,34 @@ func compactLeafPayloadTestPath(t *testing.T, root string, seq uint32) string {
 	return filepath.Join(leafDir, fmt.Sprintf("value-l%d-%06d.log", ReservedLeafLogLaneID, seq))
 }
 
+func TestOpenFileCachesCompactLeafPayloadEligibility(t *testing.T) {
+	path := compactLeafPayloadTestPath(t, t.TempDir(), 1)
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
+	f, err := openFile(path, fileID, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile: %v", err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+	if !f.allowsCompactLeafPayload() {
+		t.Fatal("leaf log file should allow compact leaf payloads")
+	}
+
+	// The path-derived classification is immutable for an opened file. Mutating
+	// the exported Path field here catches accidental reintroduction of filepath
+	// parsing on the read hot path.
+	f.Path = filepath.Join(t.TempDir(), "value_vlog", filepath.Base(path))
+	if !f.allowsCompactLeafPayload() {
+		t.Fatal("compact leaf payload eligibility should be cached at open")
+	}
+}
+
 func newLeafPayloadTestManager(t *testing.T, dir, path string, fileID uint32) *Manager {
 	t.Helper()
 	mgr, err := NewManager(dir)

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -59,6 +59,9 @@ type File struct {
 	templateLookup     TemplateLookup
 	templateDecodeOpts templ.DecodeOptions
 	templateDefCache   *templateDefCache
+	// compactLeafPayloadAllowed is derived once from immutable file identity and
+	// path. Hot reads should not re-run filepath parsing for every leaf payload.
+	compactLeafPayloadAllowed bool
 
 	cacheMu    sync.Mutex
 	cacheStart atomic.Int64
@@ -117,7 +120,15 @@ func (f *File) allowsCompactLeafPayload() bool {
 	if f == nil {
 		return false
 	}
-	return allowsCompactLeafLogPayload(f.ID, f.Path)
+	return f.compactLeafPayloadAllowed
+}
+
+func (f *File) maybeDecodeLeafLogPayloadTo(payload, dst []byte) ([]byte, bool, bool, error) {
+	return maybeDecodeLeafLogPayloadToAllowed(f.allowsCompactLeafPayload(), payload, dst)
+}
+
+func (f *File) appendMaybeDecodeLeafLogPayload(dst, payload []byte) ([]byte, error) {
+	return appendMaybeDecodeLeafLogPayloadAllowed(f.allowsCompactLeafPayload(), dst, payload)
 }
 
 func openFile(path string, id uint32, dictLookup DictLookup, templateLookup TemplateLookup, templateOpts templ.DecodeOptions, templateCache *templateDefCache) (*File, error) {
@@ -126,15 +137,16 @@ func openFile(path string, id uint32, dictLookup DictLookup, templateLookup Temp
 		return nil, err
 	}
 	vf := &File{
-		ID:                       id,
-		Path:                     path,
-		File:                     f,
-		dictLookup:               dictLookup,
-		templateLookup:           templateLookup,
-		templateDecodeOpts:       templateOpts,
-		templateDefCache:         templateCache,
-		groupedFrameCacheEntries: defaultGroupedFrameCacheEntries,
-		groupedFrameCacheMaxRaw:  defaultGroupedFrameCacheMaxRawBytes,
+		ID:                        id,
+		Path:                      path,
+		File:                      f,
+		dictLookup:                dictLookup,
+		templateLookup:            templateLookup,
+		templateDecodeOpts:        templateOpts,
+		templateDefCache:          templateCache,
+		compactLeafPayloadAllowed: allowsCompactLeafLogPayload(id, path),
+		groupedFrameCacheEntries:  defaultGroupedFrameCacheEntries,
+		groupedFrameCacheMaxRaw:   defaultGroupedFrameCacheMaxRawBytes,
 	}
 	vf.mmapData.Store([]byte(nil))
 	if info, err := f.Stat(); err == nil {
@@ -470,7 +482,7 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+		val, _, _, err = f.maybeDecodeLeafLogPayloadTo(val, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -486,7 +498,7 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+			val, _, _, err = f.maybeDecodeLeafLogPayloadTo(val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -509,7 +521,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+		val, _, _, err = f.maybeDecodeLeafLogPayloadTo(val, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -522,7 +534,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 				if err != nil {
 					return nil, err
 				}
-				val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+				val, _, _, err = f.maybeDecodeLeafLogPayloadTo(val, nil)
 				if err != nil {
 					return nil, err
 				}
@@ -542,7 +554,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			val, _, _, err = maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, nil)
+			val, _, _, err = f.maybeDecodeLeafLogPayloadTo(val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -570,7 +582,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 		if err != nil {
 			return nil, false, err
 		}
-		val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+		val, compactUsedDst, compactDecoded, err := f.maybeDecodeLeafLogPayloadTo(val, dst)
 		if err != nil {
 			return nil, false, err
 		}
@@ -586,7 +598,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 				if err != nil {
 					return nil, false, err
 				}
-				val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+				val, compactUsedDst, compactDecoded, err := f.maybeDecodeLeafLogPayloadTo(val, dst)
 				if err != nil {
 					return nil, false, err
 				}
@@ -602,7 +614,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 				if err != nil {
 					return nil, false, err
 				}
-				val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+				val, compactUsedDst, compactDecoded, err := f.maybeDecodeLeafLogPayloadTo(val, dst)
 				if err != nil {
 					return nil, false, err
 				}
@@ -624,7 +636,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 			if err != nil {
 				return nil, false, err
 			}
-			val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+			val, compactUsedDst, compactDecoded, err := f.maybeDecodeLeafLogPayloadTo(val, dst)
 			if err != nil {
 				return nil, false, err
 			}
@@ -642,7 +654,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 			if err != nil {
 				return nil, false, err
 			}
-			val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(f.ID, f.Path, val, dst)
+			val, compactUsedDst, compactDecoded, err := f.maybeDecodeLeafLogPayloadTo(val, dst)
 			if err != nil {
 				return nil, false, err
 			}
@@ -996,14 +1008,14 @@ func (f *File) appendPayloadFromFile(dst []byte, off int64, payloadLen int) ([]b
 		return nil, err
 	}
 	if f.templateLookup == nil || !templ.IsEncodedPayload(payload) {
-		return appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], payload)
+		return f.appendMaybeDecodeLeafLogPayload(dst[:oldLen], payload)
 	}
 	encoded := append([]byte(nil), payload...)
 	decoded, err := appendDecodedTemplatePayload(dst[:oldLen], encoded, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
 	if err != nil {
 		return nil, err
 	}
-	return appendMaybeDecodeLeafLogPayload(f.ID, f.Path, decoded[:oldLen], decoded[oldLen:])
+	return f.appendMaybeDecodeLeafLogPayload(decoded[:oldLen], decoded[oldLen:])
 }
 
 // Set is an immutable snapshot of value-log files for snapshot isolation.

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -59,9 +59,12 @@ type File struct {
 	templateLookup     TemplateLookup
 	templateDecodeOpts templ.DecodeOptions
 	templateDefCache   *templateDefCache
-	// compactLeafPayloadAllowed is derived once from immutable file identity and
+	// compactLeafPayloadAllowed is derived at open time from the file ID and
 	// path. Hot reads should not re-run filepath parsing for every leaf payload.
-	compactLeafPayloadAllowed bool
+	// Tests may still construct File literals directly; those fall back to
+	// deriving eligibility from ID/Path in allowsCompactLeafPayload.
+	compactLeafPayloadAllowed    bool
+	compactLeafPayloadAllowedSet bool
 
 	cacheMu    sync.Mutex
 	cacheStart atomic.Int64
@@ -120,6 +123,9 @@ func (f *File) allowsCompactLeafPayload() bool {
 	if f == nil {
 		return false
 	}
+	if !f.compactLeafPayloadAllowedSet {
+		return allowsCompactLeafLogPayload(f.ID, f.Path)
+	}
 	return f.compactLeafPayloadAllowed
 }
 
@@ -137,16 +143,17 @@ func openFile(path string, id uint32, dictLookup DictLookup, templateLookup Temp
 		return nil, err
 	}
 	vf := &File{
-		ID:                        id,
-		Path:                      path,
-		File:                      f,
-		dictLookup:                dictLookup,
-		templateLookup:            templateLookup,
-		templateDecodeOpts:        templateOpts,
-		templateDefCache:          templateCache,
-		compactLeafPayloadAllowed: allowsCompactLeafLogPayload(id, path),
-		groupedFrameCacheEntries:  defaultGroupedFrameCacheEntries,
-		groupedFrameCacheMaxRaw:   defaultGroupedFrameCacheMaxRawBytes,
+		ID:                           id,
+		Path:                         path,
+		File:                         f,
+		dictLookup:                   dictLookup,
+		templateLookup:               templateLookup,
+		templateDecodeOpts:           templateOpts,
+		templateDefCache:             templateCache,
+		compactLeafPayloadAllowed:    allowsCompactLeafLogPayload(id, path),
+		compactLeafPayloadAllowedSet: true,
+		groupedFrameCacheEntries:     defaultGroupedFrameCacheEntries,
+		groupedFrameCacheMaxRaw:      defaultGroupedFrameCacheMaxRawBytes,
 	}
 	vf.mmapData.Store([]byte(nil))
 	if info, err := f.Stat(); err == nil {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -1018,7 +1018,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		if err != nil {
 			return nil, err, true
 		}
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
+		dst, err = f.appendMaybeDecodeLeafLogPayload(dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1074,7 +1074,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 				if err != nil {
 					return nil, err, true
 				}
-				dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
+				dst, err = f.appendMaybeDecodeLeafLogPayload(dst[:oldLen], dst[oldLen:])
 				if err != nil {
 					return nil, err, true
 				}
@@ -1124,7 +1124,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		if err != nil {
 			return nil, err, true
 		}
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
+		dst, err = f.appendMaybeDecodeLeafLogPayload(dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1151,7 +1151,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		if err != nil {
 			return nil, err, true
 		}
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
+		dst, err = f.appendMaybeDecodeLeafLogPayload(dst[:oldLen], dst[oldLen:])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1214,7 +1214,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		f.setCacheRawLocked(nil, false)
 		f.cacheStart.Store(start)
 		f.cacheMu.Unlock()
-		dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:oldLen+int(rawLen)])
+		dst, err = f.appendMaybeDecodeLeafLogPayload(dst[:oldLen], dst[oldLen:oldLen+int(rawLen)])
 		if err != nil {
 			return nil, err, true
 		}
@@ -1279,7 +1279,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	if len(dst) < oldLen {
 		return nil, ErrCorrupt, true
 	}
-	dst, err = appendMaybeDecodeLeafLogPayload(f.ID, f.Path, dst[:oldLen], dst[oldLen:])
+	dst, err = f.appendMaybeDecodeLeafLogPayload(dst[:oldLen], dst[oldLen:])
 	if err != nil {
 		return nil, err, true
 	}


### PR DESCRIPTION
## Summary

- Cache compact leaf-log payload eligibility on `valuelog.File` at open time.
- Route hot `File` read/mmap paths through the cached eligibility bit instead of recomputing path classification with `filepath.Base(filepath.Dir(path))` for every payload read.
- Keep standalone helper behavior unchanged for raw `*os.File` reader paths.

## Validation

- `go test -count=1 ./TreeDB/internal/valuelog`
- `go test -count=1 ./TreeDB/internal/valuelog ./TreeDB/collections ./TreeDB/db`
- Focused collection read benchmark after change:
  - command used `BENCH_REGEX='^BenchmarkCollectionShapeReadPrimaryInto$/indexes_2$' BENCHTIME=10s COUNT=1 scripts/bench_collections_report.sh`
  - output dir: `/tmp/gomap_collections_read_cache_after_20260429_193220`
  - result: `BenchmarkCollectionShapeReadPrimaryInto/indexes_2-8 12857222 950.0 ns/op 391 B/op 1 allocs/op`
- Baseline from the prior profiling run:
  - output dir: `/tmp/gomap_collections_bottlenecks_20260429_190650/read_primary_into_serial_template_v1_index_vlog_10s`
  - result: `BenchmarkCollectionShapeReadPrimaryInto/indexes_2-8 10913212 1107 ns/op 392 B/op 1 allocs/op`

## Profiling note

The earlier read profile showed filepath path classification in the collection read hot path. The follow-up profile no longer shows `filepath` / `internal/filepathlite` in the top CPU output; the remaining dominant work is leaf-log value read/decode, especially LZ4/grouped-frame decode.
