### PR TITLE
collections: elide template-v1 index-state roots

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -85,6 +85,14 @@ func collectionPlannerOptions(meta CollectionMeta) (collectionOptions, error) {
 	}, nil
 }
 
+func persistIndexStateForOptions(opts collectionOptions) bool {
+	return persistIndexStateForDocumentFormat(opts.documentFormat)
+}
+
+func persistIndexStateForDocumentFormat(format DocumentFormat) bool {
+	return normalizedDocumentFormat(format) != DocumentFormatTemplateV1
+}
+
 type CollectionManager struct {
 	db              *backenddb.DB
 	closeUnregister func()
@@ -639,7 +647,7 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 	if err != nil {
 		return nil, err
 	}
-	if len(newMeta.Indexes) == 0 {
+	if len(newMeta.Indexes) == 0 && persistIndexStateForDocumentFormat(baseMeta.Options.DocumentFormat) {
 		clearedRootNames = append(clearedRootNames, collectionIndexStateRootName(baseMeta.Name))
 	}
 	encodedMeta, err := encodeCollectionMeta(newMeta)
@@ -1318,13 +1326,15 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	deltaTables = append(deltaTables, buildDeleteRootDeltaTable([][]byte{documentID}))
 
 	if len(runtimes) > 0 {
-		stateRootName := collectionIndexStateRootName(c.meta.Name)
-		stateRootID := catalog.rootID(stateRootName)
-		if stateRootID != 0 {
-			rootNames = append(rootNames, stateRootName)
-			baseRootIDs[stateRootName] = stateRootID
-			policies = append(policies, plannerOptions.indexStateStoragePolicy)
-			deltaTables = append(deltaTables, buildDeleteRootDeltaTable([][]byte{documentID}))
+		if persistIndexStateForOptions(plannerOptions) {
+			stateRootName := collectionIndexStateRootName(c.meta.Name)
+			stateRootID := catalog.rootID(stateRootName)
+			if stateRootID != 0 {
+				rootNames = append(rootNames, stateRootName)
+				baseRootIDs[stateRootName] = stateRootID
+				policies = append(policies, plannerOptions.indexStateStoragePolicy)
+				deltaTables = append(deltaTables, buildDeleteRootDeltaTable([][]byte{documentID}))
+			}
 		}
 		for _, runtime := range runtimes {
 			deleteKeys, err := secondaryDeleteKeysForDocument(runtime, state, documentID)
@@ -1527,25 +1537,27 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	deltaTables = append(deltaTables, primaryTable)
 
 	if len(runtimes) > 0 {
-		stateRootName := collectionIndexStateRootName(c.meta.Name)
-		stateRootID := catalog.rootID(stateRootName)
-		rootNames = append(rootNames, stateRootName)
-		baseRootIDs[stateRootName] = stateRootID
-		policies = append(policies, plannerOptions.indexStateStoragePolicy)
-		stateTable := newCollectionRunTable(1)
-		rawState, err := encodeDocumentIndexState(newState)
-		if err != nil {
-			_ = snap.Close()
-			resetCollectionTables(append(deltaTables, stateTable))
-			return false, false, err
+		if persistIndexStateForOptions(plannerOptions) {
+			stateRootName := collectionIndexStateRootName(c.meta.Name)
+			stateRootID := catalog.rootID(stateRootName)
+			rootNames = append(rootNames, stateRootName)
+			baseRootIDs[stateRootName] = stateRootID
+			policies = append(policies, plannerOptions.indexStateStoragePolicy)
+			stateTable := newCollectionRunTable(1)
+			rawState, err := encodeDocumentIndexState(newState)
+			if err != nil {
+				_ = snap.Close()
+				resetCollectionTables(append(deltaTables, stateTable))
+				return false, false, err
+			}
+			if len(newState) == 0 {
+				stateTable.DeleteSteal(bytes.Clone(documentID))
+			} else {
+				stateTable.SetSteal(bytes.Clone(documentID), rawState)
+			}
+			stateTable.Freeze()
+			deltaTables = append(deltaTables, stateTable)
 		}
-		if len(newState) == 0 {
-			stateTable.DeleteSteal(bytes.Clone(documentID))
-		} else {
-			stateTable.SetSteal(bytes.Clone(documentID), rawState)
-		}
-		stateTable.Freeze()
-		deltaTables = append(deltaTables, stateTable)
 
 		for _, runtime := range runtimes {
 			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
@@ -1789,7 +1801,11 @@ func buildCreateIndexBackfillPlan(
 	}
 	defer func() { _ = it.Close() }()
 
-	indexStateTable := newCollectionRunTable(0)
+	persistIndexState := persistIndexStateForOptions(opts)
+	var indexStateTable memtable.Table
+	if persistIndexState {
+		indexStateTable = newCollectionRunTable(0)
+	}
 	secondaryTable := newCollectionRunTable(0)
 	uniqueProbes := make([]uniqueProbeCandidate, 0)
 	stateRootName := collectionIndexStateRootName(catalog.meta.Name)
@@ -1812,23 +1828,25 @@ func buildCreateIndexBackfillPlan(
 		if err != nil {
 			return nil, err
 		}
-		existingState, err := loadBackfillIndexState(snap, stateRootID, documentID, document, existingRuntimes, opts)
-		if err != nil {
-			return nil, err
-		}
-		merged := cloneDocumentIndexState(existingState)
 		values := newState[newRuntime.def.name]
-		if len(values) > 0 {
-			merged[newRuntime.def.name] = values
-		} else {
-			delete(merged, newRuntime.def.name)
+		if persistIndexState {
+			existingState, err := loadBackfillIndexState(snap, stateRootID, documentID, document, existingRuntimes, opts)
+			if err != nil {
+				return nil, err
+			}
+			merged := cloneDocumentIndexState(existingState)
+			if len(values) > 0 {
+				merged[newRuntime.def.name] = values
+			} else {
+				delete(merged, newRuntime.def.name)
+			}
+			rawState, err := encodeNormalizedDocumentIndexState(merged)
+			if err != nil {
+				return nil, err
+			}
+			indexStateTable.SetSteal(bytes.Clone(documentID), rawState)
+			documentCount++
 		}
-		rawState, err := encodeNormalizedDocumentIndexState(merged)
-		if err != nil {
-			return nil, err
-		}
-		indexStateTable.SetSteal(bytes.Clone(documentID), rawState)
-		documentCount++
 
 		for _, encoded := range values {
 			key, err := indexEntryKey(encoded, documentID)
@@ -1872,7 +1890,7 @@ func buildCreateIndexBackfillPlan(
 }
 
 func loadBackfillIndexState(snap *backenddb.Snapshot, stateRootID uint64, documentID, document []byte, existingRuntimes []indexRuntime, opts collectionOptions) (documentIndexState, error) {
-	if stateRootID != 0 {
+	if persistIndexStateForOptions(opts) && stateRootID != 0 {
 		entry, err := snap.GetEntryAtRoot(stateRootID, documentID)
 		if err == nil {
 			return decodeDocumentIndexState(entry.Value)
@@ -2067,7 +2085,7 @@ func loadDeleteIndexState(snap *backenddb.Snapshot, catalog *collectionCatalog, 
 		return nil, nil
 	}
 	stateRoot := catalog.rootID(collectionIndexStateRootName(catalog.meta.Name))
-	if stateRoot != 0 {
+	if persistIndexStateForOptions(opts) && stateRoot != 0 {
 		entry, err := snap.GetEntryAtRoot(stateRoot, documentID)
 		if err == nil {
 			return decodeDocumentIndexState(entry.Value)
@@ -2767,7 +2785,7 @@ func collectionRootNames(meta CollectionMeta) []string {
 	if normalizedDocumentFormat(meta.Options.DocumentFormat) == DocumentFormatTemplateV1 {
 		out = append(out, collectionTemplateRootName(meta.Name))
 	}
-	if len(meta.Indexes) > 0 {
+	if len(meta.Indexes) > 0 && persistIndexStateForDocumentFormat(meta.Options.DocumentFormat) {
 		out = append(out, collectionIndexStateRootName(meta.Name))
 	}
 	for _, idx := range meta.Indexes {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -161,7 +161,8 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	if p.templateRoot == "" {
 		p.templateRoot = p.collection + "/templates"
 	}
-	if len(p.indexes) > 0 && p.indexStateRoot == "" {
+	persistIndexState := persistIndexStateForOptions(p.options)
+	if len(p.indexes) > 0 && persistIndexState && p.indexStateRoot == "" {
 		p.indexStateRoot = p.collection + "/index-state"
 	}
 	if p.buildPrimaryVal == nil {
@@ -248,11 +249,13 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	}
 	plan.stats.PrimaryRunBuild = time.Since(phaseStart)
 	if len(runtimes) > 0 {
-		phaseStart = time.Now()
-		if err := p.emitIndexStateRun(plan, items, runtimes); err != nil {
-			return nil, err
+		if persistIndexState {
+			phaseStart = time.Now()
+			if err := p.emitIndexStateRun(plan, items, runtimes); err != nil {
+				return nil, err
+			}
+			plan.stats.IndexStateRunBuild = time.Since(phaseStart)
 		}
-		plan.stats.IndexStateRunBuild = time.Since(phaseStart)
 		phaseStart = time.Now()
 		if err := p.emitSecondaryRuns(plan, items, runtimes); err != nil {
 			return nil, err

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -73,6 +73,42 @@ func TestInsertBatchPlanner_EmitsRootLocalRunsForPrimaryIndexStateAndSecondaryRo
 	}
 }
 
+func TestInsertBatchPlanner_TemplateV1SkipsIndexStateRun(t *testing.T) {
+	planner := insertBatchPlanner{
+		collection: "users",
+		indexes: []indexDefinition{
+			{name: "email", field: "email", unique: true},
+			{name: "city", field: "city"},
+		},
+		options: collectionOptions{documentFormat: DocumentFormatTemplateV1},
+	}
+
+	plan, err := planner.planInsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			mustTemplateV1Document(t, []string{"email", "city"}, []any{"ada@example.com", "hnl"}),
+			mustTemplateV1Document(t, []string{"email", "city"}, []any{"grace@example.com", "hnl"}),
+		},
+	)
+	if err != nil {
+		t.Fatalf("plan template-v1 insert batch: %v", err)
+	}
+	if got, want := len(plan.runs), 4; got != want {
+		t.Fatalf("runs len=%d want %d", got, want)
+	}
+	if idx := findRunIndex(plan, collectionRootIndexState, ""); idx >= 0 {
+		t.Fatalf("template-v1 plan unexpectedly emitted index-state run at %d", idx)
+	}
+	if got := plan.stats.IndexStateRunBuild; got != 0 {
+		t.Fatalf("template-v1 index-state run build=%s want 0", got)
+	}
+
+	_ = mustFindRun(t, plan, collectionRootPrimary, "")
+	_ = mustFindRun(t, plan, collectionRootTemplate, "")
+	_ = mustFindRun(t, plan, collectionRootSecondary, "email")
+	_ = mustFindRun(t, plan, collectionRootSecondary, "city")
+}
+
 func TestInsertBatchPlanner_PreservesCallerVisibleResultOrdering(t *testing.T) {
 	planner := insertBatchPlanner{collection: "users"}
 	ids := [][]byte{[]byte("u3"), []byte("u1"), []byte("u2")}
@@ -674,12 +710,22 @@ func mustFindRun(t *testing.T, plan *insertBatchPlan, kind collectionRootKind, i
 
 func mustFindRunIndex(t *testing.T, plan *insertBatchPlan, kind collectionRootKind, indexName string) int {
 	t.Helper()
+	if idx := findRunIndex(plan, kind, indexName); idx >= 0 {
+		return idx
+	}
+	t.Fatalf("missing run kind=%d index=%q", kind, indexName)
+	return -1
+}
+
+func findRunIndex(plan *insertBatchPlan, kind collectionRootKind, indexName string) int {
+	if plan == nil {
+		return -1
+	}
 	for i, run := range plan.runs {
 		if run.kind == kind && run.indexName == indexName {
 			return i
 		}
 	}
-	t.Fatalf("missing run kind=%d index=%q", kind, indexName)
 	return -1
 }
 

--- a/TreeDB/collections/template_v1_test.go
+++ b/TreeDB/collections/template_v1_test.go
@@ -16,6 +16,24 @@ func mustTemplateV1Document(t *testing.T, fields []string, values []any) []byte 
 	return doc
 }
 
+func requireNoCollectionRootDescriptor(t *testing.T, snap *backenddb.Snapshot, rootName string) {
+	t.Helper()
+	raw, ok, err := getSystemValue(snap, systemCollectionRootKey(rootName))
+	if err != nil {
+		t.Fatalf("read root descriptor %q: %v", rootName, err)
+	}
+	if !ok {
+		return
+	}
+	rootID, err := decodeRootID(raw)
+	if err != nil {
+		t.Fatalf("decode root descriptor %q: %v", rootName, err)
+	}
+	if rootID != 0 {
+		t.Fatalf("root descriptor %q persisted root %d", rootName, rootID)
+	}
+}
+
 func TestEncodeTemplateV1DocumentRejectsInvalidFieldSlices(t *testing.T) {
 	if _, err := EncodeTemplateV1Document([]string{"email", "email"}, []any{"ada@example.com", "grace@example.com"}); err == nil {
 		t.Fatal("expected duplicate field error")
@@ -105,10 +123,7 @@ func TestTemplateV1CollectionInsertBatchIndexesAndTemplateRoot(t *testing.T) {
 		_ = snap.Close()
 		t.Fatal("template root was not persisted")
 	}
-	if stateRoot := catalog.rootID(collectionIndexStateRootName("users")); stateRoot != 0 {
-		_ = snap.Close()
-		t.Fatalf("template-v1 collection persisted index-state root %d", stateRoot)
-	}
+	requireNoCollectionRootDescriptor(t, snap, collectionIndexStateRootName("users"))
 	root, err := parseTemplateV1StoredDocument(got)
 	if err != nil {
 		_ = snap.Close()
@@ -553,14 +568,8 @@ func TestTemplateV1CreateIndexBackfillsFromTemplateRoot(t *testing.T) {
 	if snap == nil {
 		t.Fatal("expected snapshot")
 	}
-	catalog, err := loadCollectionCatalog(snap, "users")
+	requireNoCollectionRootDescriptor(t, snap, collectionIndexStateRootName("users"))
 	_ = snap.Close()
-	if err != nil {
-		t.Fatalf("load catalog: %v", err)
-	}
-	if stateRoot := catalog.rootID(collectionIndexStateRootName("users")); stateRoot != 0 {
-		t.Fatalf("template-v1 create-index backfill persisted index-state root %d", stateRoot)
-	}
 }
 
 func TestTemplateV1MultiKeyIndex(t *testing.T) {

--- a/TreeDB/collections/template_v1_test.go
+++ b/TreeDB/collections/template_v1_test.go
@@ -105,6 +105,10 @@ func TestTemplateV1CollectionInsertBatchIndexesAndTemplateRoot(t *testing.T) {
 		_ = snap.Close()
 		t.Fatal("template root was not persisted")
 	}
+	if stateRoot := catalog.rootID(collectionIndexStateRootName("users")); stateRoot != 0 {
+		_ = snap.Close()
+		t.Fatalf("template-v1 collection persisted index-state root %d", stateRoot)
+	}
 	root, err := parseTemplateV1StoredDocument(got)
 	if err != nil {
 		_ = snap.Close()
@@ -543,6 +547,19 @@ func TestTemplateV1CreateIndexBackfillsFromTemplateRoot(t *testing.T) {
 	}
 	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
 		t.Fatalf("city ids=%q want u2", ids)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if stateRoot := catalog.rootID(collectionIndexStateRootName("users")); stateRoot != 0 {
+		t.Fatalf("template-v1 create-index backfill persisted index-state root %d", stateRoot)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stop persisting the separate collection `index-state` root for `template-v1` collections.
- Keep JSON collections on the existing persisted index-state path.
- Use the existing recompute-from-primary fallback for template-v1 delete/update/create-index maintenance, so secondary indexes still delete and backfill correctly without an index-state root.
- Leave index extraction in the insert planner because uniqueness checks and secondary run construction still need those values.

Stacked on #1102.

## Validation

- `go test -count=1 ./TreeDB/collections`
- `go test -count=1 ./TreeDB/collections ./TreeDB/db`
- Focused indexed template-v1 insert benchmark:
  - command: `TREEDB_COLLECTION_BENCH_ENGINE=production_fast TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 TREEDB_COLLECTION_BENCH_BATCH_SIZE=16000 TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=true TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=true go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionShapeInsertBatch$/indexes_2$' -benchtime=10s -count=3 -benchmem`
  - results: `892.6 ns/op`, `904.1 ns/op`, `1192 ns/op` across three local runs
  - structural metrics: `roots/batch` is now `3.001`; `index_state_run_ns/doc` is no longer emitted for template-v1
- Focused planner benchmark:
  - command: `TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 TREEDB_COLLECTION_BENCH_BATCH_SIZE=16000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionOverheadPlanIndexedTemplateV1$' -benchtime=10s -count=3 -benchmem`
  - results: `523.9 ns/op`, `611.5 ns/op`, `631.4 ns/op`

## Notes

Prior profiling put the two-index template-v1 insert shape around `~992 ns/doc`, with `index_state_run_ns/doc` around `~120 ns/doc` and four published collection roots per batch. This change removes that run and one published root for template-v1 while preserving the JSON path.
