### PR TITLE
collections: group low-cardinality secondary runs

### DIFF
--- a/TreeDB/collections/overhead_bench_test.go
+++ b/TreeDB/collections/overhead_bench_test.go
@@ -419,10 +419,12 @@ func overheadBenchPlanIndexedPrecomputedState(
 	if err := planner.emitPrimaryRun(plan, items, primaryOrder); err != nil {
 		return err
 	}
-	if err := planner.emitIndexStateRun(plan, items, runtimes); err != nil {
-		return err
+	if persistIndexStateForOptions(planner.options) {
+		if err := planner.emitIndexStateRun(plan, items, runtimes); err != nil {
+			return err
+		}
 	}
-	if err := planner.emitSecondaryRuns(plan, items, runtimes); err != nil {
+	if err := planner.emitSecondaryRuns(plan, items, runtimes, primaryOrder); err != nil {
 		return err
 	}
 	resetCollectionRunTables(plan.runs)

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -606,9 +606,17 @@ func (p insertBatchPlanner) emitIndexStateRun(plan *insertBatchPlan, items []ins
 func (p insertBatchPlanner) emitSecondaryRuns(plan *insertBatchPlan, items []insertBatchItem, runtimes []indexRuntime, documentIDOrder []int) error {
 	for runtimeIdx, runtime := range runtimes {
 		runStart := time.Now()
-		entryCount, keyBytes, alreadySorted, err := secondaryEntryOrderStats(items, runtimeIdx, documentIDOrder)
+		entryCount, keyBytes, alreadySorted, err := secondaryEntryOrderStats(items, runtimeIdx, nil)
 		if err != nil {
 			return err
+		}
+		emitOrder := []int(nil)
+		if !alreadySorted && documentIDOrder != nil {
+			entryCount, keyBytes, alreadySorted, err = secondaryEntryOrderStats(items, runtimeIdx, documentIDOrder)
+			if err != nil {
+				return err
+			}
+			emitOrder = documentIDOrder
 		}
 		runStats := CollectionSecondaryRunStats{
 			IndexName:     runtime.def.name,
@@ -628,7 +636,7 @@ func (p insertBatchPlanner) emitSecondaryRuns(plan *insertBatchPlan, items []ins
 			valuePos := 0
 			if err := applyCollectionRunEntries(table, entryCount, func(_ int) (key, value []byte, err error) {
 				for itemPos < len(items) {
-					idx := orderedItemIndex(documentIDOrder, itemPos)
+					idx := orderedItemIndex(emitOrder, itemPos)
 					values := items[idx].state.valuesAt(runtimeIdx)
 					if valuePos < len(values) {
 						encoded := values[valuePos]
@@ -659,7 +667,7 @@ func (p insertBatchPlanner) emitSecondaryRuns(plan *insertBatchPlan, items []ins
 			continue
 		}
 
-		if table, ok, err := p.emitGroupedSecondaryRunTable(items, runtimeIdx, documentIDOrder, entryCount, keyBytes); err != nil {
+		if table, ok, err := p.emitGroupedSecondaryRunTable(items, runtimeIdx, runtime.def.name, documentIDOrder, entryCount, keyBytes); err != nil {
 			return err
 		} else if ok {
 			plan.runs = append(plan.runs, collectionRootRun{
@@ -724,7 +732,7 @@ type secondaryValueGroup struct {
 	documentIDs [][]byte
 }
 
-func (p insertBatchPlanner) emitGroupedSecondaryRunTable(items []insertBatchItem, runtimeIdx int, documentIDOrder []int, entryCount, keyBytes int) (memtable.Table, bool, error) {
+func (p insertBatchPlanner) emitGroupedSecondaryRunTable(items []insertBatchItem, runtimeIdx int, indexName string, documentIDOrder []int, entryCount, keyBytes int) (memtable.Table, bool, error) {
 	if entryCount <= 0 {
 		return nil, false, nil
 	}
@@ -773,7 +781,16 @@ func (p insertBatchPlanner) emitGroupedSecondaryRunTable(items []insertBatchItem
 			groupPos++
 			documentPos = 0
 		}
-		return nil, nil, errors.New("collections: grouped secondary index entry count mismatch")
+		return nil, nil, fmt.Errorf(
+			"collections: grouped secondary index entry count mismatch collection=%q index=%q runtimeIdx=%d entryCount=%d groups=%d groupPos=%d documentPos=%d",
+			p.collection,
+			indexName,
+			runtimeIdx,
+			entryCount,
+			len(groups),
+			groupPos,
+			documentPos,
+		)
 	}); err != nil {
 		return nil, false, err
 	}

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -37,6 +37,10 @@ const (
 	// 128K slice headers is enough for the current native benchmark batches
 	// while keeping speculative header memory around 3 MiB on 64-bit platforms.
 	indexEncodeArenaMaxInitialValueRefs = 128 << 10
+	// Non-unique secondary indexes often have a small number of distinct values
+	// in a large batch. Up to this point, grouping by value avoids sorting every
+	// full secondary key; above it, the generic key sort avoids quadratic scans.
+	secondaryGroupedRunMaxDistinctValues = 128
 )
 
 type collectionRootKind uint8
@@ -257,7 +261,7 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 			plan.stats.IndexStateRunBuild = time.Since(phaseStart)
 		}
 		phaseStart = time.Now()
-		if err := p.emitSecondaryRuns(plan, items, runtimes); err != nil {
+		if err := p.emitSecondaryRuns(plan, items, runtimes, primaryOrder); err != nil {
 			return nil, err
 		}
 		plan.stats.SecondaryRunBuild = time.Since(phaseStart)
@@ -599,10 +603,10 @@ func (p insertBatchPlanner) emitIndexStateRun(plan *insertBatchPlan, items []ins
 	return nil
 }
 
-func (p insertBatchPlanner) emitSecondaryRuns(plan *insertBatchPlan, items []insertBatchItem, runtimes []indexRuntime) error {
+func (p insertBatchPlanner) emitSecondaryRuns(plan *insertBatchPlan, items []insertBatchItem, runtimes []indexRuntime, documentIDOrder []int) error {
 	for runtimeIdx, runtime := range runtimes {
 		runStart := time.Now()
-		entryCount, keyBytes, alreadySorted, err := secondaryEntryOrderStats(items, runtimeIdx)
+		entryCount, keyBytes, alreadySorted, err := secondaryEntryOrderStats(items, runtimeIdx, documentIDOrder)
 		if err != nil {
 			return err
 		}
@@ -624,11 +628,12 @@ func (p insertBatchPlanner) emitSecondaryRuns(plan *insertBatchPlan, items []ins
 			valuePos := 0
 			if err := applyCollectionRunEntries(table, entryCount, func(_ int) (key, value []byte, err error) {
 				for itemPos < len(items) {
-					values := items[itemPos].state.valuesAt(runtimeIdx)
+					idx := orderedItemIndex(documentIDOrder, itemPos)
+					values := items[idx].state.valuesAt(runtimeIdx)
 					if valuePos < len(values) {
 						encoded := values[valuePos]
 						valuePos++
-						keyArena, key, err = appendIndexEntryKey(keyArena, encoded, items[itemPos].id)
+						keyArena, key, err = appendIndexEntryKey(keyArena, encoded, items[idx].id)
 						return key, nil, err
 					}
 					itemPos++
@@ -654,12 +659,31 @@ func (p insertBatchPlanner) emitSecondaryRuns(plan *insertBatchPlan, items []ins
 			continue
 		}
 
+		if table, ok, err := p.emitGroupedSecondaryRunTable(items, runtimeIdx, documentIDOrder, entryCount, keyBytes); err != nil {
+			return err
+		} else if ok {
+			plan.runs = append(plan.runs, collectionRootRun{
+				name:          p.collection + "/index/" + runtime.def.name,
+				kind:          collectionRootSecondary,
+				indexName:     runtime.def.name,
+				table:         table,
+				storagePolicy: runtime.def.storagePolicy,
+			})
+			runStats.Build = time.Since(runStart)
+			plan.stats.SecondaryRuns = append(plan.stats.SecondaryRuns, runStats)
+			plan.stats.SecondaryEntries += entryCount
+			plan.stats.SecondaryKeyBytes += keyBytes
+			plan.stats.SecondaryUnsortedRuns++
+			continue
+		}
+
 		keys := make([][]byte, 0, entryCount)
 		keyArena := make([]byte, 0, keyBytes)
 		for i := range items {
-			for _, encoded := range items[i].state.valuesAt(runtimeIdx) {
+			idx := orderedItemIndex(documentIDOrder, i)
+			for _, encoded := range items[idx].state.valuesAt(runtimeIdx) {
 				var key []byte
-				keyArena, key, err = appendIndexEntryKey(keyArena, encoded, items[i].id)
+				keyArena, key, err = appendIndexEntryKey(keyArena, encoded, items[idx].id)
 				if err != nil {
 					return err
 				}
@@ -695,22 +719,85 @@ func (p insertBatchPlanner) emitSecondaryRuns(plan *insertBatchPlan, items []ins
 	return nil
 }
 
-func secondaryEntryOrderStats(items []insertBatchItem, runtimeIdx int) (entryCount int, keyBytes int, alreadySorted bool, err error) {
+type secondaryValueGroup struct {
+	encoded     []byte
+	documentIDs [][]byte
+}
+
+func (p insertBatchPlanner) emitGroupedSecondaryRunTable(items []insertBatchItem, runtimeIdx int, documentIDOrder []int, entryCount, keyBytes int) (memtable.Table, bool, error) {
+	if entryCount <= 0 {
+		return nil, false, nil
+	}
+	groups := make([]secondaryValueGroup, 0, min(entryCount, secondaryGroupedRunMaxDistinctValues))
+	for i := range items {
+		idx := orderedItemIndex(documentIDOrder, i)
+		item := &items[idx]
+		for _, encoded := range item.state.valuesAt(runtimeIdx) {
+			groupIdx := -1
+			for j := range groups {
+				if bytes.Equal(groups[j].encoded, encoded) {
+					groupIdx = j
+					break
+				}
+			}
+			if groupIdx < 0 {
+				if len(groups) >= secondaryGroupedRunMaxDistinctValues {
+					return nil, false, nil
+				}
+				groups = append(groups, secondaryValueGroup{encoded: encoded})
+				groupIdx = len(groups) - 1
+			}
+			groups[groupIdx].documentIDs = append(groups[groupIdx].documentIDs, item.id)
+		}
+	}
+	if len(groups) == 0 || len(groups) == entryCount {
+		return nil, false, nil
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		return compareIndexValuePrefixEncoded(groups[i].encoded, groups[j].encoded) < 0
+	})
+
+	table := newCollectionRunTable(entryCount)
+	keyArena := make([]byte, 0, keyBytes)
+	groupPos := 0
+	documentPos := 0
+	if err := applyCollectionRunEntries(table, entryCount, func(_ int) (key, value []byte, err error) {
+		for groupPos < len(groups) {
+			group := &groups[groupPos]
+			if documentPos < len(group.documentIDs) {
+				documentID := group.documentIDs[documentPos]
+				documentPos++
+				keyArena, key, err = appendIndexEntryKey(keyArena, group.encoded, documentID)
+				return key, nil, err
+			}
+			groupPos++
+			documentPos = 0
+		}
+		return nil, nil, errors.New("collections: grouped secondary index entry count mismatch")
+	}); err != nil {
+		return nil, false, err
+	}
+	table.Freeze()
+	return table, true, nil
+}
+
+func secondaryEntryOrderStats(items []insertBatchItem, runtimeIdx int, documentIDOrder []int) (entryCount int, keyBytes int, alreadySorted bool, err error) {
 	alreadySorted = true
 	var lastValue []byte
 	var lastDocumentID []byte
 	for i := range items {
-		for _, encoded := range items[i].state.valuesAt(runtimeIdx) {
+		idx := orderedItemIndex(documentIDOrder, i)
+		for _, encoded := range items[idx].state.valuesAt(runtimeIdx) {
 			if len(encoded) > 65535 {
 				return 0, 0, false, errors.New("collections: index key too large")
 			}
-			if entryCount > 0 && compareIndexEntryKeyParts(lastValue, lastDocumentID, encoded, items[i].id) > 0 {
+			if entryCount > 0 && compareIndexEntryKeyParts(lastValue, lastDocumentID, encoded, items[idx].id) > 0 {
 				alreadySorted = false
 			}
 			lastValue = encoded
-			lastDocumentID = items[i].id
+			lastDocumentID = items[idx].id
 			entryCount++
-			keyBytes += 2 + len(encoded) + len(items[i].id)
+			keyBytes += 2 + len(encoded) + len(items[idx].id)
 		}
 	}
 	return entryCount, keyBytes, alreadySorted, nil

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -109,6 +109,52 @@ func TestInsertBatchPlanner_TemplateV1SkipsIndexStateRun(t *testing.T) {
 	_ = mustFindRun(t, plan, collectionRootSecondary, "city")
 }
 
+func TestEmitGroupedSecondaryRunTableSortsValueGroupsByDocumentID(t *testing.T) {
+	items := []insertBatchItem{
+		{id: []byte("u3"), state: orderedDocumentIndexState{{[]byte("s:city-01")}}},
+		{id: []byte("u1"), state: orderedDocumentIndexState{{[]byte("s:city-01")}}},
+		{id: []byte("u4"), state: orderedDocumentIndexState{{[]byte("s:city-00")}}},
+		{id: []byte("u2"), state: orderedDocumentIndexState{{[]byte("s:city-00")}}},
+	}
+	order := sortedItemOrderByKey(items, func(item *insertBatchItem) []byte { return item.id })
+	entryCount, keyBytes, alreadySorted, err := secondaryEntryOrderStats(items, 0, order)
+	if err != nil {
+		t.Fatalf("secondary stats: %v", err)
+	}
+	if alreadySorted {
+		t.Fatal("test data should exercise grouped unsorted construction")
+	}
+	table, ok, err := (insertBatchPlanner{}).emitGroupedSecondaryRunTable(items, 0, order, entryCount, keyBytes)
+	if err != nil {
+		t.Fatalf("grouped secondary run: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected grouped secondary construction")
+	}
+	entries := collectRunEntries(t, collectionRootRun{name: "city", table: table})
+	assertSortedEntries(t, entries)
+
+	want := make([][]byte, 0, 4)
+	for _, pair := range []struct {
+		encoded    []byte
+		documentID []byte
+	}{
+		{[]byte("s:city-00"), []byte("u2")},
+		{[]byte("s:city-00"), []byte("u4")},
+		{[]byte("s:city-01"), []byte("u1")},
+		{[]byte("s:city-01"), []byte("u3")},
+	} {
+		key, err := indexEntryKey(pair.encoded, pair.documentID)
+		if err != nil {
+			t.Fatalf("expected key: %v", err)
+		}
+		want = append(want, key)
+	}
+	if got := entryKeys(entries); !byteMatrixEqual(got, want) {
+		t.Fatalf("grouped keys=%q want %q", got, want)
+	}
+}
+
 func TestInsertBatchPlanner_PreservesCallerVisibleResultOrdering(t *testing.T) {
 	planner := insertBatchPlanner{collection: "users"}
 	ids := [][]byte{[]byte("u3"), []byte("u1"), []byte("u2")}

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -124,7 +124,7 @@ func TestEmitGroupedSecondaryRunTableSortsValueGroupsByDocumentID(t *testing.T) 
 	if alreadySorted {
 		t.Fatal("test data should exercise grouped unsorted construction")
 	}
-	table, ok, err := (insertBatchPlanner{}).emitGroupedSecondaryRunTable(items, 0, order, entryCount, keyBytes)
+	table, ok, err := (insertBatchPlanner{collection: "users"}).emitGroupedSecondaryRunTable(items, 0, "city", order, entryCount, keyBytes)
 	if err != nil {
 		t.Fatalf("grouped secondary run: %v", err)
 	}
@@ -153,6 +153,33 @@ func TestEmitGroupedSecondaryRunTableSortsValueGroupsByDocumentID(t *testing.T) 
 	if got := entryKeys(entries); !byteMatrixEqual(got, want) {
 		t.Fatalf("grouped keys=%q want %q", got, want)
 	}
+}
+
+func TestEmitSecondaryRunsPreservesInputOrderSortedFastPath(t *testing.T) {
+	items := []insertBatchItem{
+		{id: []byte("u2"), state: orderedDocumentIndexState{{[]byte("s:city-00")}}},
+		{id: []byte("u1"), state: orderedDocumentIndexState{{[]byte("s:city-01")}}},
+	}
+	primaryOrder := sortedItemOrderByKey(items, func(item *insertBatchItem) []byte { return item.id })
+	if primaryOrder == nil {
+		t.Fatal("test data should have different primary-key order")
+	}
+	planner := insertBatchPlanner{collection: "users"}
+	plan := &insertBatchPlan{}
+	runtimes := []indexRuntime{{
+		def: indexDefinition{name: "city", field: "city"},
+	}}
+	if err := planner.emitSecondaryRuns(plan, items, runtimes, primaryOrder); err != nil {
+		t.Fatalf("emit secondary runs: %v", err)
+	}
+	if got, want := plan.stats.SecondarySortedRuns, 1; got != want {
+		t.Fatalf("sorted runs=%d want %d", got, want)
+	}
+	if got := plan.stats.SecondaryUnsortedRuns; got != 0 {
+		t.Fatalf("unsorted runs=%d want 0", got)
+	}
+	entries := collectRunEntries(t, mustFindRun(t, plan, collectionRootSecondary, "city"))
+	assertSortedEntries(t, entries)
 }
 
 func TestInsertBatchPlanner_PreservesCallerVisibleResultOrdering(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add a grouped construction path for unsorted secondary index runs when a batch has a low number of distinct encoded index values.
- Stream grouped entries in primary-key order, sort only the distinct encoded values, and fall back to the existing full-key sort above 128 distinct values.
- Route overhead benchmarks through the same template-v1 index-state elision behavior as the real planner.

Stacked on #1103.

## Validation

- `go test -count=1 ./TreeDB/collections`
- `go test -count=1 ./TreeDB/collections ./TreeDB/db`
- Focused indexed template-v1 insert benchmark after this change:
  - command: `TREEDB_COLLECTION_BENCH_ENGINE=production_fast TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 TREEDB_COLLECTION_BENCH_BATCH_SIZE=16000 TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=true TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=true go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionShapeInsertBatch$/indexes_2$' -benchtime=10s -count=3 -benchmem`
  - results: `772.4 ns/op`, `767.7 ns/op`, `757.2 ns/op`
  - secondary run build: `128.1`, `129.7`, `128.9 secondary_runs_ns/doc`

## Comparison to previous sprint

On #1103, the same local benchmark produced `892.6 ns/op`, `904.1 ns/op`, and one noisy `1192 ns/op` run; secondary construction was `189.2`, `197.1`, and `267.9 secondary_runs_ns/doc`. This PR keeps `roots/batch=3.001` from #1103 and reduces the non-unique secondary construction cost for the benchmark's low-cardinality city index.
