### PR TITLE
Add opt-in indexed collection write-domain buffering

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -174,6 +174,11 @@ type CollectionOptions struct {
 	DocumentFormat          DocumentFormat    `json:"document_format,omitempty"`
 	DataRootStoragePolicy   RootStoragePolicy `json:"data_root_storage_policy,omitempty"`
 	IndexStateStoragePolicy RootStoragePolicy `json:"index_state_storage_policy,omitempty"`
+	// BufferedIndexedWrites stages indexed InsertBatch root deltas in the
+	// collection write domain until Flush/Close. Staged writes are visible to
+	// primary and secondary reads on the same manager, but durability remains at
+	// the explicit flush boundary, matching the existing no-index buffered path.
+	BufferedIndexedWrites bool `json:"buffered_indexed_writes,omitempty"`
 }
 
 type IndexDefinition struct {
@@ -218,17 +223,21 @@ type collectionWriteDomain struct {
 	// mutationMu serializes root descriptor publishes for handles opened
 	// through the same manager so optimistic retries do not starve under
 	// sustained collection write contention.
-	mutationMu     sync.Mutex
-	mu             sync.RWMutex
-	loaded         bool
-	meta           CollectionMeta
-	catalog        *collectionCatalog
-	baseCommitSeq  uint64
-	baseSystemRoot uint64
-	primaryRoot    uint64
-	storagePolicy  backenddb.OrderedRootStoragePolicy
-	table          memtable.Table
-	count          int
+	mutationMu      sync.Mutex
+	mu              sync.RWMutex
+	loaded          bool
+	meta            CollectionMeta
+	catalog         *collectionCatalog
+	baseCommitSeq   uint64
+	baseSystemRoot  uint64
+	primaryRoot     uint64
+	storagePolicy   backenddb.OrderedRootStoragePolicy
+	table           memtable.Table
+	rootRuns        map[string][]memtable.Table
+	rootPolicies    map[string]backenddb.OrderedRootStoragePolicy
+	rootBaseIDs     map[string]uint64
+	uniqueValueRuns map[string][]memtable.Table
+	count           int
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -317,7 +326,7 @@ func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain)
 	defer domain.mutationMu.Unlock()
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
-	return collection.flushBufferedNoIndexLocked(domain)
+	return collection.flushBufferedWritesLocked(domain)
 }
 
 func (c *Collection) lockMutation() func() {
@@ -493,7 +502,7 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
-	if err := c.flushBufferedNoIndex(); err != nil {
+	if err := c.flushBufferedWrites(); err != nil {
 		return nil, err
 	}
 
@@ -614,7 +623,7 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
-	if err := c.flushBufferedNoIndex(); err != nil {
+	if err := c.flushBufferedWrites(); err != nil {
 		return nil, err
 	}
 
@@ -722,7 +731,7 @@ func (c *Collection) Flush() error {
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
-	return c.flushBufferedNoIndex()
+	return c.flushBufferedWrites()
 }
 
 func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, error) {
@@ -863,9 +872,17 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 		return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", domain.meta.Name)
 	}
 
-	rootName := collectionPrimaryRootName(domain.meta.Name)
-	if rootID := catalog.rootID(rootName); rootID != domain.primaryRoot {
-		return nil, fmt.Errorf("collections: concurrent root modification detected for %q", domain.meta.Name)
+	primaryRootName := collectionPrimaryRootName(domain.meta.Name)
+	if len(domain.rootBaseIDs) > 0 {
+		for rootName, baseRootID := range domain.rootBaseIDs {
+			if rootID := catalog.rootID(rootName); rootID != baseRootID {
+				return nil, fmt.Errorf("collections: concurrent root modification detected for %q", domain.meta.Name)
+			}
+		}
+	} else {
+		if rootID := catalog.rootID(primaryRootName); rootID != domain.primaryRoot {
+			return nil, fmt.Errorf("collections: concurrent root modification detected for %q", domain.meta.Name)
+		}
 	}
 	options, err := collectionPlannerOptions(catalog.meta)
 	if err != nil {
@@ -875,7 +892,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	domain.catalog = catalog
 	domain.baseCommitSeq = baseCommitSeq
 	domain.baseSystemRoot = baseSystemRoot
-	domain.primaryRoot = catalog.rootID(rootName)
+	domain.primaryRoot = catalog.rootID(primaryRootName)
 	domain.storagePolicy = options.dataStoragePolicy
 	c.meta = catalog.meta
 	c.rememberCatalogAtSystemRoot(baseSystemRoot, catalog)
@@ -903,6 +920,29 @@ func (c *Collection) flushBufferedNoIndex() error {
 	}
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
+	if len(domain.rootRuns) > 0 {
+		return nil
+	}
+	return c.flushBufferedNoIndexLocked(domain)
+}
+
+func (c *Collection) flushBufferedWrites() error {
+	domain := c.writeDomain
+	if domain == nil {
+		return nil
+	}
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	return c.flushBufferedWritesLocked(domain)
+}
+
+func (c *Collection) flushBufferedWritesLocked(domain *collectionWriteDomain) error {
+	if domain == nil || domain.count == 0 {
+		return nil
+	}
+	if len(domain.rootRuns) > 0 {
+		return c.flushBufferedIndexedLocked(domain)
+	}
 	return c.flushBufferedNoIndexLocked(domain)
 }
 
@@ -978,6 +1018,623 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetCollectionRunTable(table)
 	return nil
+}
+
+func (c *Collection) shouldBufferIndexedInserts(meta CollectionMeta) bool {
+	return c != nil && c.writeDomain != nil && meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
+}
+
+func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, baseCommitSeq, baseSystemRoot uint64, plan *insertBatchPlan) error {
+	domain := c.writeDomain
+	if domain == nil {
+		return errors.New("collections: missing write domain")
+	}
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	if catalog == nil {
+		return errCollectionNotFound
+	}
+	if len(catalog.meta.Indexes) == 0 {
+		return errors.New("collections: indexed write buffer requires an indexed schema")
+	}
+	if domain.count > 0 {
+		currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
+		currentCatalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentCommitSeq, currentSystemRoot)
+		if err != nil {
+			return err
+		}
+		if !sameCollectionMeta(currentCatalog.meta, catalog.meta) {
+			return fmt.Errorf("collections: concurrent schema modification detected for %q", catalog.meta.Name)
+		}
+		for rootName, baseRoot := range domain.rootBaseIDs {
+			if got := catalog.rootID(rootName); got != baseRoot {
+				return fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
+			}
+		}
+	} else {
+		c.initializeWriteDomainFromCatalogLocked(domain, catalog, baseCommitSeq, baseSystemRoot)
+	}
+
+	if err := c.rejectBufferedIndexedInsertConflictsLocked(domain, catalog.meta, plan); err != nil {
+		return err
+	}
+	if domain.rootPolicies == nil {
+		domain.rootPolicies = make(map[string]backenddb.OrderedRootStoragePolicy, len(plan.runs))
+	}
+	if domain.rootBaseIDs == nil {
+		domain.rootBaseIDs = make(map[string]uint64, len(plan.runs))
+	}
+	if domain.rootRuns == nil {
+		domain.rootRuns = make(map[string][]memtable.Table, len(plan.runs))
+	}
+	if domain.uniqueValueRuns == nil {
+		domain.uniqueValueRuns = make(map[string][]memtable.Table)
+	}
+	uniqueIndexes := uniqueCollectionIndexNames(catalog.meta)
+	for _, run := range plan.runs {
+		var uniqueValueTable memtable.Table
+		if _, ok := uniqueIndexes[run.indexName]; ok && run.kind == collectionRootSecondary {
+			var err error
+			uniqueValueTable, err = bufferedUniqueIndexValueRun(run.table)
+			if err != nil {
+				return err
+			}
+		}
+		if len(domain.rootRuns[run.name]) == 0 {
+			domain.rootBaseIDs[run.name] = catalog.rootID(run.name)
+		}
+		domain.rootPolicies[run.name] = run.storagePolicy
+		domain.rootRuns[run.name] = append(domain.rootRuns[run.name], run.table)
+		if uniqueValueTable != nil {
+			domain.uniqueValueRuns[run.indexName] = append(domain.uniqueValueRuns[run.indexName], uniqueValueTable)
+		}
+	}
+	domain.loaded = true
+	domain.meta = catalog.meta
+	domain.catalog = catalog
+	domain.baseCommitSeq = baseCommitSeq
+	domain.baseSystemRoot = baseSystemRoot
+	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
+	domain.count += len(plan.resultIDs)
+	c.meta = catalog.meta
+	return nil
+}
+
+func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWriteDomain, catalog *collectionCatalog, baseCommitSeq, baseSystemRoot uint64) {
+	domain.loaded = true
+	domain.meta = catalog.meta
+	domain.catalog = catalog
+	domain.baseCommitSeq = baseCommitSeq
+	domain.baseSystemRoot = baseSystemRoot
+	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
+	domain.rootRuns = nil
+	domain.rootPolicies = nil
+	domain.rootBaseIDs = nil
+	domain.uniqueValueRuns = nil
+}
+
+func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collectionWriteDomain, meta CollectionMeta, plan *insertBatchPlan) error {
+	if domain == nil || domain.count == 0 || len(domain.rootRuns) == 0 {
+		return nil
+	}
+	primaryName := collectionPrimaryRootName(meta.Name)
+	if pendingPrimary := domain.rootRuns[primaryName]; len(pendingPrimary) > 0 {
+		for _, run := range plan.runs {
+			if run.name != primaryName {
+				continue
+			}
+			if err := rejectBufferedPrimaryConflicts(pendingPrimary, run.table); err != nil {
+				return err
+			}
+			break
+		}
+	}
+	uniqueIndexes := uniqueCollectionIndexNames(meta)
+	for _, run := range plan.runs {
+		if run.kind != collectionRootSecondary {
+			continue
+		}
+		if _, ok := uniqueIndexes[run.indexName]; !ok {
+			continue
+		}
+		pending := domain.uniqueValueRuns[run.indexName]
+		if len(pending) == 0 {
+			continue
+		}
+		if err := rejectBufferedUniqueIndexConflicts(run.indexName, pending, run.table); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectBufferedPrimaryConflicts(pendingPrimary []memtable.Table, batchPrimary memtable.Table) error {
+	it := batchPrimary.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		if _, _, flags, found := getBufferedRunEntry(pendingPrimary, it.UnsafeKey()); found && flags&node.FlagTombstone == 0 {
+			return ErrDocumentExists
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func uniqueCollectionIndexNames(meta CollectionMeta) map[string]struct{} {
+	uniqueIndexes := make(map[string]struct{}, len(meta.Indexes))
+	for _, idx := range meta.Indexes {
+		if idx.Unique {
+			uniqueIndexes[idx.Name] = struct{}{}
+		}
+	}
+	return uniqueIndexes
+}
+
+func rejectBufferedUniqueIndexConflicts(indexName string, pendingIndex []memtable.Table, batchIndex memtable.Table) error {
+	it := batchIndex.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		prefix, err := indexEntryValuePrefix(it.UnsafeKey())
+		if err != nil {
+			return err
+		}
+		if _, _, flags, found := getBufferedRunEntry(pendingIndex, prefix); found && flags&node.FlagTombstone == 0 {
+			return fmt.Errorf("%w %q", ErrUniqueIndexConflict, indexName)
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func bufferedUniqueIndexValueRun(batchIndex memtable.Table) (memtable.Table, error) {
+	table := newCollectionRunTable(max(0, batchIndex.Len()))
+	it := batchIndex.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		prefix, err := indexEntryValuePrefix(it.UnsafeKey())
+		if err != nil {
+			resetCollectionRunTable(table)
+			return nil, err
+		}
+		setCollectionRunValue(table, prefix, nil)
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		resetCollectionRunTable(table)
+		return nil, err
+	}
+	table.Freeze()
+	return table, nil
+}
+
+func indexEntryValuePrefix(key []byte) ([]byte, error) {
+	if len(key) < 2 {
+		return nil, errors.New("collections: malformed index entry key")
+	}
+	n := int(binary.BigEndian.Uint16(key[:2]))
+	if len(key) < 2+n {
+		return nil, errors.New("collections: malformed index entry key")
+	}
+	return key[:2+n], nil
+}
+
+func getBufferedRunEntry(runs []memtable.Table, key []byte) ([]byte, page.ValuePtr, byte, bool) {
+	for i := len(runs) - 1; i >= 0; i-- {
+		if runs[i] == nil {
+			continue
+		}
+		if value, ptr, flags, found := runs[i].GetEntry(key); found {
+			return value, ptr, flags, true
+		}
+	}
+	return nil, page.ValuePtr{}, 0, false
+}
+
+type bufferedRootRunHeapItem struct {
+	idx      int
+	priority int
+	key      []byte
+}
+
+type bufferedRootRunHeap []bufferedRootRunHeapItem
+
+func (h bufferedRootRunHeap) Len() int { return len(h) }
+
+func (h bufferedRootRunHeap) Less(i, j int) bool {
+	if cmp := bytes.Compare(h[i].key, h[j].key); cmp != 0 {
+		return cmp < 0
+	}
+	return h[i].priority < h[j].priority
+}
+
+func (h bufferedRootRunHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+func (h *bufferedRootRunHeap) push(item bufferedRootRunHeapItem) {
+	*h = append(*h, item)
+	h.up(len(*h) - 1)
+}
+
+func (h *bufferedRootRunHeap) pop() bufferedRootRunHeapItem {
+	old := *h
+	n := len(old)
+	if n == 0 {
+		return bufferedRootRunHeapItem{}
+	}
+	old.Swap(0, n-1)
+	h.down(0, n-1)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
+}
+
+func (h bufferedRootRunHeap) peek() *bufferedRootRunHeapItem {
+	if len(h) == 0 {
+		return nil
+	}
+	return &h[0]
+}
+
+func (h *bufferedRootRunHeap) up(j int) {
+	for {
+		i := (j - 1) / 2
+		if i == j || !h.Less(j, i) {
+			break
+		}
+		h.Swap(i, j)
+		j = i
+	}
+}
+
+func (h *bufferedRootRunHeap) down(i0, n int) bool {
+	i := i0
+	for {
+		j1 := 2*i + 1
+		if j1 >= n || j1 < 0 {
+			break
+		}
+		j := j1
+		if j2 := j1 + 1; j2 < n && h.Less(j2, j1) {
+			j = j2
+		}
+		if !h.Less(j, i) {
+			break
+		}
+		h.Swap(i, j)
+		i = j
+	}
+	return i > i0
+}
+
+type bufferedRootRunsIterator struct {
+	iters    []iterator.UnsafeIterator
+	heap     bufferedRootRunHeap
+	cur      bufferedRootRunHeapItem
+	hasCur   bool
+	valid    bool
+	start    []byte
+	end      []byte
+	closed   bool
+	firstErr error
+}
+
+func newBufferedRootRunsIterator(runs []memtable.Table, start, end []byte) iterator.UnsafeIterator {
+	if len(runs) == 1 {
+		return runs[0].NewIterator(start, end)
+	}
+	it := &bufferedRootRunsIterator{
+		iters: make([]iterator.UnsafeIterator, 0, len(runs)),
+		start: start,
+		end:   end,
+	}
+	for i, run := range runs {
+		if run == nil {
+			continue
+		}
+		runIter := run.NewIterator(start, end)
+		idx := len(it.iters)
+		it.iters = append(it.iters, runIter)
+		if runIter.Valid() {
+			it.heap.push(bufferedRootRunHeapItem{
+				idx:      idx,
+				priority: len(runs) - 1 - i,
+				key:      runIter.UnsafeKey(),
+			})
+		}
+	}
+	it.advance()
+	return it
+}
+
+func (it *bufferedRootRunsIterator) Valid() bool {
+	return it != nil && it.valid
+}
+
+func (it *bufferedRootRunsIterator) Next() {
+	if it == nil || !it.valid {
+		return
+	}
+	if it.hasCur {
+		it.advanceItem(it.cur)
+		it.hasCur = false
+	}
+	it.advance()
+}
+
+func (it *bufferedRootRunsIterator) Seek(key []byte) {
+	if it == nil || it.closed {
+		return
+	}
+	if it.start != nil && bytes.Compare(key, it.start) < 0 {
+		key = it.start
+	}
+	it.heap = it.heap[:0]
+	it.valid = false
+	it.hasCur = false
+	for idx, source := range it.iters {
+		source.Seek(key)
+		if source.Valid() {
+			it.heap.push(bufferedRootRunHeapItem{
+				idx:      idx,
+				priority: len(it.iters) - 1 - idx,
+				key:      source.UnsafeKey(),
+			})
+		}
+	}
+	it.advance()
+}
+
+func (it *bufferedRootRunsIterator) UnsafeKey() []byte {
+	if !it.Valid() {
+		return nil
+	}
+	return it.iters[it.cur.idx].UnsafeKey()
+}
+
+func (it *bufferedRootRunsIterator) UnsafeValue() []byte {
+	if !it.Valid() {
+		return nil
+	}
+	return it.iters[it.cur.idx].UnsafeValue()
+}
+
+func (it *bufferedRootRunsIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	if !it.Valid() {
+		return nil, page.ValuePtr{}, node.FlagInline
+	}
+	return it.iters[it.cur.idx].UnsafeEntry()
+}
+
+func (it *bufferedRootRunsIterator) Key() []byte {
+	return it.UnsafeKey()
+}
+
+func (it *bufferedRootRunsIterator) Value() []byte {
+	return it.UnsafeValue()
+}
+
+func (it *bufferedRootRunsIterator) KeyCopy(dst []byte) []byte {
+	if !it.Valid() {
+		return dst
+	}
+	return append(dst[:0], it.UnsafeKey()...)
+}
+
+func (it *bufferedRootRunsIterator) ValueCopy(dst []byte) []byte {
+	if !it.Valid() {
+		return dst
+	}
+	return append(dst[:0], it.UnsafeValue()...)
+}
+
+func (it *bufferedRootRunsIterator) IsDeleted() bool {
+	return it.Valid() && it.iters[it.cur.idx].IsDeleted()
+}
+
+func (it *bufferedRootRunsIterator) Error() error {
+	if it == nil {
+		return nil
+	}
+	if it.firstErr != nil {
+		return it.firstErr
+	}
+	for _, source := range it.iters {
+		if err := source.Error(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (it *bufferedRootRunsIterator) Close() error {
+	if it == nil || it.closed {
+		return nil
+	}
+	it.closed = true
+	var firstErr error
+	for _, source := range it.iters {
+		if err := source.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	it.valid = false
+	it.hasCur = false
+	it.heap = nil
+	if firstErr != nil {
+		it.firstErr = firstErr
+	}
+	return firstErr
+}
+
+func (it *bufferedRootRunsIterator) Domain() (start, end []byte) {
+	if it == nil {
+		return nil, nil
+	}
+	return it.start, it.end
+}
+
+func (it *bufferedRootRunsIterator) advance() {
+	it.valid = false
+	it.hasCur = false
+	for it.heap.Len() > 0 {
+		top := it.heap.pop()
+		key := top.key
+		if it.end != nil && bytes.Compare(key, it.end) >= 0 {
+			return
+		}
+		for it.heap.Len() > 0 {
+			next := it.heap.peek()
+			if next == nil || !bytes.Equal(next.key, key) {
+				break
+			}
+			shadowed := it.heap.pop()
+			it.advanceItem(shadowed)
+		}
+		if it.iters[top.idx].IsDeleted() {
+			it.advanceItem(top)
+			continue
+		}
+		it.cur = top
+		it.hasCur = true
+		it.valid = true
+		return
+	}
+}
+
+func (it *bufferedRootRunsIterator) advanceItem(item bufferedRootRunHeapItem) {
+	source := it.iters[item.idx]
+	source.Next()
+	if source.Valid() {
+		item.key = source.UnsafeKey()
+		it.heap.push(item)
+	} else if err := source.Error(); err != nil && it.firstErr == nil {
+		it.firstErr = err
+	}
+}
+
+func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) error {
+	if domain == nil || domain.count == 0 || len(domain.rootRuns) == 0 {
+		return nil
+	}
+	if domain.catalog == nil {
+		return errCollectionNotFound
+	}
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
+	catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentCommitSeq, currentSystemRoot)
+	if err != nil {
+		return err
+	}
+	meta := catalog.meta
+	c.meta = meta
+	pin := c.db.AcquireSnapshot()
+	if pin == nil {
+		return backenddb.ErrClosed
+	}
+	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
+	// base roots before stale-root validation rejects concurrent modifications.
+	defer func() { _ = pin.Close() }()
+	pinnedCatalog, err := loadCollectionCatalog(pin, meta.Name)
+	if err != nil {
+		return err
+	}
+	if pinnedCatalog == nil {
+		return errCollectionNotFound
+	}
+	if !sameCollectionMeta(pinnedCatalog.meta, meta) {
+		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
+	}
+	for rootName, baseRoot := range domain.rootBaseIDs {
+		if got := pinnedCatalog.rootID(rootName); got != baseRoot {
+			return fmt.Errorf("collections: concurrent root modification detected for %q", meta.Name)
+		}
+	}
+
+	rootNames := orderedBufferedRootNames(meta, domain.rootRuns)
+	if len(rootNames) == 0 {
+		domain.count = 0
+		return nil
+	}
+	baseSystemRoot := snapshotSystemRoot(pin)
+	baseCommitSeq := snapshotCommitSeq(pin)
+	baseRootIDs := make(map[string]uint64, len(rootNames))
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	for _, rootName := range rootNames {
+		iter := newBufferedRootRunsIterator(domain.rootRuns[rootName], nil, nil)
+		iterators = append(iterators, iter)
+		baseRoot := domain.rootBaseIDs[rootName]
+		baseRootIDs[rootName] = baseRoot
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot:      baseRoot,
+			Iter:          iter,
+			StoragePolicy: domain.rootPolicies[rootName],
+		})
+	}
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+	})
+	for _, it := range iterators {
+		_ = it.Close()
+	}
+	if err != nil {
+		return err
+	}
+	if len(rootIDs) != len(rootNames) {
+		return errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	nextCatalog := cloneCatalogWithRootUpdates(domain.catalog, meta, rootNames, rootIDs)
+	oldRuns := domain.rootRuns
+	domain.loaded = true
+	domain.meta = meta
+	domain.catalog = nextCatalog
+	domain.baseCommitSeq = c.commitSeqForSystemRoot(newSystemRoot)
+	domain.baseSystemRoot = newSystemRoot
+	domain.primaryRoot = nextCatalog.rootID(collectionPrimaryRootName(meta.Name))
+	domain.rootRuns = nil
+	domain.rootPolicies = nil
+	domain.rootBaseIDs = nil
+	oldUniqueValueRuns := domain.uniqueValueRuns
+	domain.uniqueValueRuns = nil
+	domain.count = 0
+	c.meta = meta
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	for _, runs := range oldRuns {
+		resetCollectionTables(runs)
+	}
+	for _, runs := range oldUniqueValueRuns {
+		resetCollectionTables(runs)
+	}
+	return nil
+}
+
+func orderedBufferedRootNames(meta CollectionMeta, runs map[string][]memtable.Table) []string {
+	if len(runs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(runs))
+	seen := make(map[string]struct{}, len(runs))
+	for _, rootName := range collectionRootNames(meta) {
+		if len(runs[rootName]) > 0 {
+			out = append(out, rootName)
+			seen[rootName] = struct{}{}
+		}
+	}
+	extra := make([]string, 0)
+	for rootName, rootRuns := range runs {
+		if _, ok := seen[rootName]; !ok {
+			if len(rootRuns) > 0 {
+				extra = append(extra, rootName)
+			}
+		}
+	}
+	sort.Strings(extra)
+	out = append(out, extra...)
+	return out
 }
 
 func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
@@ -1131,6 +1788,17 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	}
 	if len(plan.runs) == 0 {
 		_ = snap.Close()
+		c.setLastInsertStats(plan.stats.CollectionInsertStats)
+		return plan.resultIDs, nil
+	}
+
+	if c.shouldBufferIndexedInserts(c.meta) {
+		err := c.bufferIndexedInsertPlanLocked(catalog, baseCommitSeq, baseSystemRoot, plan)
+		_ = snap.Close()
+		if err != nil {
+			resetCollectionRunTables(plan.runs)
+			return nil, err
+		}
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
 		return plan.resultIDs, nil
 	}
@@ -1302,7 +1970,7 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
-	if err := c.flushBufferedNoIndex(); err != nil {
+	if err := c.flushBufferedWrites(); err != nil {
 		return false, err
 	}
 
@@ -1474,7 +2142,7 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
-	if err := c.flushBufferedNoIndex(); err != nil {
+	if err := c.flushBufferedWrites(); err != nil {
 		return false, false, err
 	}
 
@@ -1817,6 +2485,10 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.baseSystemRoot = systemRoot
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
 	domain.storagePolicy = options.dataStoragePolicy
+	domain.rootRuns = nil
+	domain.rootPolicies = nil
+	domain.rootBaseIDs = nil
+	domain.uniqueValueRuns = nil
 	if domain.table == nil {
 		domain.table = newCollectionRunTable(0)
 	}
@@ -2328,10 +3000,26 @@ func (c *Collection) getBufferedDocumentInto(documentID []byte, dst []byte) ([]b
 	domain := c.writeDomain
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()
-	if domain.count == 0 || domain.table == nil {
+	if domain.count == 0 {
 		return nil, false, false
 	}
-	value, _, flags, found := domain.table.GetEntry(documentID)
+	table := domain.table
+	if table == nil && len(domain.rootRuns) > 0 {
+		name := collectionPrimaryRootName(c.meta.Name)
+		if domain.meta.Name != "" {
+			name = collectionPrimaryRootName(domain.meta.Name)
+		}
+		if value, _, flags, found := getBufferedRunEntry(domain.rootRuns[name], documentID); found {
+			if flags&node.FlagTombstone != 0 {
+				return dst[:0], true, false
+			}
+			return append(dst[:0], value...), true, true
+		}
+	}
+	if table == nil {
+		return nil, false, false
+	}
+	value, _, flags, found := table.GetEntry(documentID)
 	if !found {
 		return nil, false, false
 	}
@@ -2389,10 +3077,6 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if !ok {
 		return nil, false, nil
 	}
-	rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
-	if rootID == 0 {
-		return nil, false, nil
-	}
 	var arena []byte
 	arena, encoded, err := appendIndexScalar(arena, value)
 	if err != nil {
@@ -2402,13 +3086,78 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err != nil {
 		return nil, false, err
 	}
+	out, truncated, err := c.bufferedIndexIDs(indexName, prefix, maxResults)
+	if err != nil {
+		return nil, false, err
+	}
+	if maxResults > 0 && len(out) >= maxResults {
+		return out, true, nil
+	}
+	rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
+	if rootID == 0 {
+		return out, truncated, nil
+	}
 	it, err := snap.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
 	if errors.Is(err, tree.ErrKeyNotFound) {
-		return nil, false, nil
+		return out, truncated, nil
 	}
 	if err != nil {
 		return nil, false, err
 	}
+	defer func() { _ = it.Close() }()
+	seen := map[string]struct{}(nil)
+	if len(out) > 0 {
+		seen = make(map[string]struct{}, len(out))
+		for _, id := range out {
+			seen[string(id)] = struct{}{}
+		}
+	}
+	for it.Valid() {
+		key := it.UnsafeKey()
+		if !bytes.HasPrefix(key, prefix) {
+			break
+		}
+		if !it.IsDeleted() {
+			id := key[len(prefix):]
+			if seen != nil {
+				if _, ok := seen[string(id)]; ok {
+					it.Next()
+					continue
+				}
+			}
+			if maxResults > 0 && len(out) >= maxResults {
+				truncated = true
+				break
+			}
+			out = append(out, bytes.Clone(id))
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return nil, false, err
+	}
+	return out, truncated, nil
+}
+
+func (c *Collection) bufferedIndexIDs(indexName string, prefix []byte, maxResults int) ([][]byte, bool, error) {
+	if c == nil || c.writeDomain == nil {
+		return nil, false, nil
+	}
+	domain := c.writeDomain
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	if domain.count == 0 || len(domain.rootRuns) == 0 {
+		return nil, false, nil
+	}
+	collectionName := c.meta.Name
+	if domain.meta.Name != "" {
+		collectionName = domain.meta.Name
+	}
+	runs := domain.rootRuns[collectionSecondaryRootName(collectionName, indexName)]
+	if len(runs) == 0 {
+		return nil, false, nil
+	}
+	it := newBufferedRootRunsIterator(runs, prefix, prefixEnd(prefix))
 	defer func() { _ = it.Close() }()
 	out := make([][]byte, 0, 1)
 	truncated := false
@@ -2465,7 +3214,7 @@ func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord)
 	if fn == nil {
 		return false, errors.New("collections: scan callback is nil")
 	}
-	if err := c.flushBufferedNoIndex(); err != nil {
+	if err := c.flushBufferedWrites(); err != nil {
 		return false, err
 	}
 	snap := c.db.AcquireSnapshot()

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3097,7 +3097,7 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err != nil {
 		return nil, false, err
 	}
-	if maxResults > 0 && len(out) >= maxResults {
+	if maxResults > 0 && truncated {
 		return out, true, nil
 	}
 	// Buffered indexed writes currently stage inserts only. Primary conflict

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1557,7 +1557,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 	}
 	for rootName, baseRoot := range domain.rootBaseIDs {
 		if got := pinnedCatalog.rootID(rootName); got != baseRoot {
-			return fmt.Errorf("collections: concurrent root modification detected for %q", meta.Name)
+			return fmt.Errorf("collections: concurrent root modification detected for %q", rootName)
 		}
 	}
 
@@ -3011,7 +3011,7 @@ func (c *Collection) getBufferedDocumentInto(documentID []byte, dst []byte) ([]b
 		return nil, false, false
 	}
 	table := domain.table
-	if table == nil && len(domain.rootRuns) > 0 {
+	if len(domain.rootRuns) > 0 {
 		name := collectionPrimaryRootName(c.meta.Name)
 		if domain.meta.Name != "" {
 			name = collectionPrimaryRootName(domain.meta.Name)
@@ -3180,9 +3180,9 @@ func (c *Collection) bufferedIndexIDs(indexName string, prefix []byte, maxResult
 	return out, truncated, nil
 }
 
-// ScanDocuments flushes buffered no-index writes before acquiring a snapshot,
-// then scans the collection primary root up to maxDocuments. The returned
-// boolean is true when additional documents were present beyond the limit.
+// ScanDocuments flushes buffered writes before acquiring a snapshot, then scans
+// the collection primary root up to maxDocuments. The returned boolean is true
+// when additional documents were present beyond the limit.
 func (c *Collection) ScanDocuments(maxDocuments int) ([]DocumentRecord, bool, error) {
 	out := make([]DocumentRecord, 0)
 	truncated, err := c.ScanDocumentsFunc(maxDocuments, func(record DocumentRecord) (bool, error) {
@@ -3195,11 +3195,10 @@ func (c *Collection) ScanDocuments(maxDocuments int) ([]DocumentRecord, bool, er
 	return out, truncated, nil
 }
 
-// ScanDocumentsFunc flushes buffered no-index writes before acquiring a
-// snapshot, then calls fn for primary collection records until maxDocuments is
-// reached, the collection is exhausted, or fn returns false. The returned
-// boolean is true only when additional documents were present beyond the
-// maxDocuments limit.
+// ScanDocumentsFunc flushes buffered writes before acquiring a snapshot, then
+// calls fn for primary collection records until maxDocuments is reached, the
+// collection is exhausted, or fn returns false. The returned boolean is true
+// only when additional documents were present beyond the maxDocuments limit.
 func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord) (bool, error)) (bool, error) {
 	if c == nil {
 		return false, errCollectionNil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1047,10 +1047,11 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 			return fmt.Errorf("collections: concurrent schema modification detected for %q", catalog.meta.Name)
 		}
 		for rootName, baseRoot := range domain.rootBaseIDs {
-			if got := catalog.rootID(rootName); got != baseRoot {
+			if got := currentCatalog.rootID(rootName); got != baseRoot {
 				return fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
 			}
 		}
+		catalog = currentCatalog
 	} else {
 		c.initializeWriteDomainFromCatalogLocked(domain, catalog, baseCommitSeq, baseSystemRoot)
 	}
@@ -1092,8 +1093,6 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.loaded = true
 	domain.meta = catalog.meta
 	domain.catalog = catalog
-	domain.baseCommitSeq = baseCommitSeq
-	domain.baseSystemRoot = baseSystemRoot
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
 	domain.count += len(plan.resultIDs)
 	c.meta = catalog.meta
@@ -1194,6 +1193,12 @@ func rejectBufferedUniqueIndexConflicts(indexName string, pendingIndex []memtabl
 
 func bufferedUniqueIndexValueRun(batchIndex memtable.Table) (memtable.Table, error) {
 	table := newCollectionRunTable(max(0, batchIndex.Len()))
+	maxInt := int(^uint(0) >> 1)
+	arenaCap := batchIndex.Size()
+	if arenaCap < 0 || arenaCap > int64(maxInt) {
+		arenaCap = 0
+	}
+	arena := make([]byte, 0, int(arenaCap))
 	it := batchIndex.NewIterator(nil, nil)
 	defer func() { _ = it.Close() }()
 	for it.Valid() {
@@ -1202,7 +1207,9 @@ func bufferedUniqueIndexValueRun(batchIndex memtable.Table) (memtable.Table, err
 			resetCollectionRunTable(table)
 			return nil, err
 		}
-		setCollectionRunValue(table, prefix, nil)
+		start := len(arena)
+		arena = append(arena, prefix...)
+		setCollectionRunValue(table, arena[start:len(arena)], nil)
 		it.Next()
 	}
 	if err := it.Error(); err != nil {
@@ -3093,6 +3100,11 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if maxResults > 0 && len(out) >= maxResults {
 		return out, true, nil
 	}
+	// Buffered indexed writes currently stage inserts only. Primary conflict
+	// checks reject IDs that already exist in pending or persisted roots, so
+	// buffered secondary IDs cannot duplicate persisted secondary IDs. If update
+	// or delete staging is added here, this merge must account for pending
+	// tombstones before returning persisted rows.
 	rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
 	if rootID == 0 {
 		return out, truncated, nil
@@ -3105,13 +3117,6 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 		return nil, false, err
 	}
 	defer func() { _ = it.Close() }()
-	seen := map[string]struct{}(nil)
-	if len(out) > 0 {
-		seen = make(map[string]struct{}, len(out))
-		for _, id := range out {
-			seen[string(id)] = struct{}{}
-		}
-	}
 	for it.Valid() {
 		key := it.UnsafeKey()
 		if !bytes.HasPrefix(key, prefix) {
@@ -3119,12 +3124,6 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 		}
 		if !it.IsDeleted() {
 			id := key[len(prefix):]
-			if seen != nil {
-				if _, ok := seen[string(id)]; ok {
-					it.Next()
-					continue
-				}
-			}
 			if maxResults > 0 && len(out) >= maxResults {
 				truncated = true
 				break

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1282,6 +1282,62 @@ func TestCollectionIndexedWriteMemtablesReadUniqueAndFlush(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesFindLimitExactBufferedCount(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	ids, truncated, err := col.FindByIndexValueLimit("city", "hnl", 1)
+	if err != nil {
+		t.Fatalf("find exact buffered limit: %v", err)
+	}
+	if truncated {
+		t.Fatalf("exact buffered limit truncated=true ids=%q", ids)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("exact buffered limit ids=%q want [u1]", ids)
+	}
+
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert u2: %v", err)
+	}
+	ids, truncated, err = col.FindByIndexValueLimit("city", "hnl", 1)
+	if err != nil {
+		t.Fatalf("find over buffered limit: %v", err)
+	}
+	if !truncated {
+		t.Fatalf("over buffered limit truncated=false ids=%q", ids)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("over buffered limit returned %d ids want 1", len(ids))
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesRejectPersistedUniqueConflict(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1238,6 +1238,12 @@ func TestCollectionIndexedWriteMemtablesReadUniqueAndFlush(t *testing.T) {
 		t.Fatalf("buffered duplicate unique err=%v want unique index conflict", err)
 	}
 	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u4")},
+		[][]byte{[]byte(`{"email":"grace@example.com","city":"sea"}`)},
+	); err == nil || !strings.Contains(err.Error(), "unique index") {
+		t.Fatalf("buffered duplicate unique after iterator advance err=%v want unique index conflict", err)
+	}
+	if _, err := col.InsertBatch(
 		[][]byte{[]byte("u1")},
 		[][]byte{[]byte(`{"email":"new@example.com","city":"sea"}`)},
 	); err == nil || !strings.Contains(err.Error(), "document already exists") {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1165,6 +1165,208 @@ func TestCollectionSingleInsertBufferedNoIndexFlushPersistsAfterReopen(t *testin
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesReadUniqueAndFlush(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2"), []byte("u1")},
+		[][]byte{
+			[]byte(`{"email":"grace@example.com","city":"hnl"}`),
+			[]byte(`{"email":"ada@example.com","city":"hnl"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get buffered u1: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("buffered u1=%q want %q", got, want)
+	}
+	emailIDs, err := col.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find buffered email: %v", err)
+	}
+	if len(emailIDs) != 1 || !bytes.Equal(emailIDs[0], []byte("u1")) {
+		t.Fatalf("buffered email ids=%q want [u1]", emailIDs)
+	}
+	cityIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find buffered city: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, cityIDs, []byte("u1"), []byte("u2"))
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got != 0 {
+		t.Fatalf("primary root persisted before flush: %d", got)
+	}
+
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u3")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"sea"}`)},
+	); err == nil || !strings.Contains(err.Error(), "unique index") {
+		t.Fatalf("buffered duplicate unique err=%v want unique index conflict", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"new@example.com","city":"sea"}`)},
+	); err == nil || !strings.Contains(err.Error(), "document already exists") {
+		t.Fatalf("buffered duplicate id err=%v want document exists", err)
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush indexed buffer: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	got, err = reopenedCol.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get reopened u2: %v", err)
+	}
+	if want := []byte(`{"email":"grace@example.com","city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("reopened u2=%q want %q", got, want)
+	}
+	emailIDs, err = reopenedCol.FindByIndex("email", "grace@example.com")
+	if err != nil {
+		t.Fatalf("find reopened email: %v", err)
+	}
+	if len(emailIDs) != 1 || !bytes.Equal(emailIDs[0], []byte("u2")) {
+		t.Fatalf("reopened email ids=%q want [u2]", emailIDs)
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesRejectPersistedUniqueConflict(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"email":"ada@example.com"}`)}); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed: %v", err)
+	}
+	_, err = col.InsertBatch(
+		[][]byte{[]byte("u2"), []byte("u3")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com"}`),
+			[]byte(`{"email":"grace@example.com"}`),
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "unique index") {
+		t.Fatalf("persisted duplicate unique err=%v want unique index conflict", err)
+	}
+	got, err := col.Get([]byte("u3"))
+	if err != nil {
+		t.Fatalf("get failed insert: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("failed insert left buffered doc=%q", got)
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesCloseFlushes(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"email":"ada@example.com"}`)}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err := reopenedCol.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find reopened email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("reopened email ids=%q want [u1]", ids)
+	}
+}
+
 func TestCollectionSingleInsertBufferedNoIndexCloseFlushes(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1282,6 +1282,58 @@ func TestCollectionIndexedWriteMemtablesReadUniqueAndFlush(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesReadAfterDomainTableAllocated(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed: %v", err)
+	}
+	if deleted, err := col.DeleteDocument([]byte("u1")); err != nil {
+		t.Fatalf("delete seed: %v", err)
+	} else if !deleted {
+		t.Fatal("delete seed deleted=false want true")
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("buffer insert after delete: %v", err)
+	}
+	got, found, err := col.GetInto([]byte("u2"), nil)
+	if err != nil {
+		t.Fatalf("get buffered u2: %v", err)
+	}
+	if !found {
+		t.Fatal("get buffered u2 found=false want true")
+	}
+	if want := []byte(`{"city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("get buffered u2=%q want %q", got, want)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesFindLimitExactBufferedCount(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/bench_test.go
+++ b/TreeDB/collections/bench_test.go
@@ -566,6 +566,7 @@ func openBenchmarkCollection(b *testing.B, name string, indexes ...collections.I
 	manager := collections.NewCollectionManager(backend)
 	dataOuter, indexOuter := benchmarkCollectionStoragePolicy(b)
 	documentFormat := benchmarkCollectionDocumentFormat(b)
+	bufferedIndexedWrites := benchmarkBoolEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITES", false) && len(indexes) > 0
 	for i := range indexes {
 		indexes[i].StoragePolicy = benchmarkRootStoragePolicy(indexOuter)
 	}
@@ -575,6 +576,7 @@ func openBenchmarkCollection(b *testing.B, name string, indexes ...collections.I
 			DocumentFormat:          documentFormat,
 			DataRootStoragePolicy:   benchmarkRootStoragePolicy(dataOuter),
 			IndexStateStoragePolicy: benchmarkRootStoragePolicy(dataOuter),
+			BufferedIndexedWrites:   bufferedIndexedWrites,
 		},
 		Indexes: indexes,
 	}); err != nil {

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -125,9 +125,11 @@ func benchmarkCollectionShapeInsertBatch(b *testing.B, indexCount int, checkpoin
 	targetBatchSize := benchmarkBatchSize(b)
 	startKeyFallback, startPrefixFallback := benchmarkNativeProbeFallbackCounters(b, backend)
 	var insertElapsed time.Duration
+	var bufferedFlushElapsed time.Duration
 	var syncElapsed time.Duration
 	var insertStats collections.CollectionInsertStats
 	batches := 0
+	bufferedIndexedWrites := collection.Meta().Options.BufferedIndexedWrites
 
 	metricName := "target_docs/batch"
 	if checkpoint {
@@ -154,6 +156,13 @@ func benchmarkCollectionShapeInsertBatch(b *testing.B, indexCount int, checkpoin
 		batches++
 		if checkpoint {
 			b.StartTimer()
+			if bufferedIndexedWrites {
+				flushStart := time.Now()
+				if err := collection.Flush(); err != nil {
+					b.Fatalf("flush buffered indexed writes: %v", err)
+				}
+				bufferedFlushElapsed += time.Since(flushStart)
+			}
 			syncStart := time.Now()
 			benchmarkSyncBoundary(b, backend)
 			syncElapsed += time.Since(syncStart)
@@ -161,9 +170,27 @@ func benchmarkCollectionShapeInsertBatch(b *testing.B, indexCount int, checkpoin
 		}
 		inserted += batchSize
 	}
+	if bufferedIndexedWrites && !checkpoint {
+		b.StartTimer()
+		flushStart := time.Now()
+		if err := collection.Flush(); err != nil {
+			b.Fatalf("flush buffered indexed writes: %v", err)
+		}
+		bufferedFlushElapsed += time.Since(flushStart)
+		b.StopTimer()
+	}
 	b.StopTimer()
 	b.ReportMetric(float64(targetBatchSize), metricName)
 	b.ReportMetric(float64(indexCount), "indexes/doc")
+	if bufferedIndexedWrites {
+		b.ReportMetric(1, "buffered_indexed_writes")
+		if insertElapsed > 0 {
+			b.ReportMetric(float64(insertElapsed.Nanoseconds())/float64(b.N), "buffered_insert_ns/doc")
+		}
+		if bufferedFlushElapsed > 0 {
+			b.ReportMetric(float64(bufferedFlushElapsed.Nanoseconds())/float64(b.N), "buffered_flush_ns/doc")
+		}
+	}
 	if checkpoint {
 		benchmarkReportCheckpointSplit(b, b.N, insertElapsed, syncElapsed)
 	}

--- a/cmd/collection_load_fixture/README.md
+++ b/cmd/collection_load_fixture/README.md
@@ -45,6 +45,10 @@ Useful variants:
 # Disable secondary-index value-log outer leaves.
 ./bin/collection-load-fixture -index-outer-leaves-in-vlog=false -dir /tmp/treedb_two_index_template_v1_fast_index -reset
 
+# Stage indexed InsertBatch writes in collection-local memtables and publish
+# them at Flush/Close. The summary reports insert and flush timing separately.
+./bin/collection-load-fixture -buffered-indexed-writes -dir /tmp/treedb_two_index_buffered -reset
+
 # Generate machine-readable output and optional profiles.
 ./bin/collection-load-fixture \
   -json \

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -607,7 +607,7 @@ func runFixture(cfg config) (loadSummary, error) {
 		BatchSize:                     cfg.BatchSize,
 		Batches:                       batches,
 		IndexCount:                    cfg.IndexCount,
-		BufferedIndexedWrites:         cfg.BufferedIndexedWrites,
+		BufferedIndexedWrites:         cfg.BufferedIndexedWrites && cfg.IndexCount > 0,
 		DataOuterLeavesInValueLog:     cfg.DataOuterLeavesInValueLog,
 		IndexOuterLeavesInValueLog:    cfg.IndexOuterLeavesInValueLog,
 		ChunkSize:                     cfg.ChunkSize,

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -45,6 +45,7 @@ type config struct {
 	Collection                 string
 	DocumentFormat             collections.DocumentFormat
 	IndexCount                 int
+	BufferedIndexedWrites      bool
 	Profile                    treedb.Profile
 	DataOuterLeavesInValueLog  bool
 	IndexOuterLeavesInValueLog bool
@@ -230,6 +231,7 @@ type loadSummary struct {
 	BatchSize                     int                    `json:"batch_size"`
 	Batches                       int                    `json:"batches"`
 	IndexCount                    int                    `json:"index_count"`
+	BufferedIndexedWrites         bool                   `json:"buffered_indexed_writes,omitempty"`
 	DataOuterLeavesInValueLog     bool                   `json:"data_outer_leaves_in_value_log"`
 	IndexOuterLeavesInValueLog    bool                   `json:"index_outer_leaves_in_value_log"`
 	ChunkSize                     int64                  `json:"chunk_size,omitempty"`
@@ -244,6 +246,7 @@ type loadSummary struct {
 	WallTiming                    timingSummary          `json:"wall_timing"`
 	GenerationTiming              timingSummary          `json:"generation_timing"`
 	InsertTiming                  timingSummary          `json:"insert_timing"`
+	FlushTiming                   timingSummary          `json:"flush_timing,omitempty"`
 	CheckpointTiming              timingSummary          `json:"checkpoint_timing,omitempty"`
 	InsertPhases                  insertPhaseSummary     `json:"insert_phases"`
 	IndexStorageBeforeMaintenance indexStorageSummary    `json:"index_storage_before_maintenance"`
@@ -321,6 +324,7 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	fs.StringVar(&cfg.Collection, "collection", cfg.Collection, "collection name")
 	fs.StringVar(&documentFormat, "format", string(cfg.DocumentFormat), "document format: json or template-v1")
 	fs.IntVar(&cfg.IndexCount, "indexes", cfg.IndexCount, "secondary index count for the benchmark shape: 0, 1, 2, or 3")
+	fs.BoolVar(&cfg.BufferedIndexedWrites, "buffered-indexed-writes", false, "stage indexed InsertBatch writes in collection-local memtables until flush")
 	fs.StringVar(&profile, "profile", string(cfg.Profile), "TreeDB profile: fast, wal_on_fast, durable, or bench")
 	fs.BoolVar(&cfg.DataOuterLeavesInValueLog, "data-outer-leaves-in-vlog", cfg.DataOuterLeavesInValueLog, "store collection primary/index-state outer leaves through the value log")
 	fs.BoolVar(&cfg.IndexOuterLeavesInValueLog, "index-outer-leaves-in-vlog", cfg.IndexOuterLeavesInValueLog, "store secondary-index outer leaves through the value log")
@@ -475,6 +479,7 @@ func runFixture(cfg config) (loadSummary, error) {
 	secondaryRuns := make(map[string]*secondaryRunSummary)
 	var generationElapsed time.Duration
 	var insertElapsed time.Duration
+	var flushElapsed time.Duration
 	var checkpointElapsed time.Duration
 	wallStart := time.Now()
 	batches := 0
@@ -504,6 +509,13 @@ func runFixture(cfg config) (loadSummary, error) {
 		inserted += batchSize
 
 		if cfg.CheckpointEachBatch {
+			if cfg.BufferedIndexedWrites && cfg.IndexCount > 0 {
+				flushStart := time.Now()
+				if err := collection.Flush(); err != nil {
+					return loadSummary{}, fmt.Errorf("flush after batch %d: %w", batches, err)
+				}
+				flushElapsed += time.Since(flushStart)
+			}
 			checkpointStart := time.Now()
 			if err := backend.Checkpoint(); err != nil {
 				return loadSummary{}, fmt.Errorf("checkpoint after batch %d: %w", batches, err)
@@ -516,9 +528,11 @@ func runFixture(cfg config) (loadSummary, error) {
 		}
 	}
 
+	flushStart := time.Now()
 	if err := collection.Flush(); err != nil {
 		return loadSummary{}, fmt.Errorf("flush collection: %w", err)
 	}
+	flushElapsed += time.Since(flushStart)
 	if cfg.Checkpoint {
 		checkpointStart := time.Now()
 		if err := backend.Checkpoint(); err != nil {
@@ -593,6 +607,7 @@ func runFixture(cfg config) (loadSummary, error) {
 		BatchSize:                     cfg.BatchSize,
 		Batches:                       batches,
 		IndexCount:                    cfg.IndexCount,
+		BufferedIndexedWrites:         cfg.BufferedIndexedWrites,
 		DataOuterLeavesInValueLog:     cfg.DataOuterLeavesInValueLog,
 		IndexOuterLeavesInValueLog:    cfg.IndexOuterLeavesInValueLog,
 		ChunkSize:                     cfg.ChunkSize,
@@ -607,6 +622,7 @@ func runFixture(cfg config) (loadSummary, error) {
 		WallTiming:                    timing(wallElapsed, cfg.Docs),
 		GenerationTiming:              timing(generationElapsed, cfg.Docs),
 		InsertTiming:                  timing(insertElapsed, cfg.Docs),
+		FlushTiming:                   timing(flushElapsed, cfg.Docs),
 		CheckpointTiming:              timing(checkpointElapsed, cfg.Docs),
 		InsertPhases:                  summarizeInsertPhases(insertStats, secondaryRuns, cfg.Docs, batches),
 		IndexStorageBeforeMaintenance: beforeIndexStorage,
@@ -712,6 +728,7 @@ func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Co
 			DocumentFormat:          cfg.DocumentFormat,
 			DataRootStoragePolicy:   rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
 			IndexStateStoragePolicy: rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+			BufferedIndexedWrites:   cfg.BufferedIndexedWrites && cfg.IndexCount > 0,
 		},
 		Indexes: indexes,
 	})
@@ -1526,6 +1543,9 @@ func printHumanSummary(w io.Writer, summary loadSummary) {
 	fmt.Fprintf(w, "collection: %s\n", summary.Collection)
 	fmt.Fprintf(w, "shape: format=%s indexes=%d data_outer_leaves_in_vlog=%t index_outer_leaves_in_vlog=%t profile=%s\n",
 		summary.DocumentFormat, summary.IndexCount, summary.DataOuterLeavesInValueLog, summary.IndexOuterLeavesInValueLog, summary.Profile)
+	if summary.BufferedIndexedWrites {
+		fmt.Fprintln(w, "indexed write buffering: enabled")
+	}
 	fmt.Fprintf(w, "index policy: keep_recent=%d prefer_append_alloc=%t background_prune=%t\n",
 		summary.KeepRecent, summary.PreferAppendAlloc, !summary.DisableBackgroundPrune)
 	if summary.LeafSegmentTargetBytes > 0 {
@@ -1535,6 +1555,9 @@ func printHumanSummary(w io.Writer, summary loadSummary) {
 	printTiming(w, "wall", summary.WallTiming)
 	printTiming(w, "document generation", summary.GenerationTiming)
 	printTiming(w, "insert", summary.InsertTiming)
+	if summary.FlushTiming.Seconds > 0 {
+		printTiming(w, "flush", summary.FlushTiming)
+	}
 	if summary.CheckpointTiming.Seconds > 0 {
 		printTiming(w, "checkpoint", summary.CheckpointTiming)
 	}

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -140,6 +140,48 @@ func TestRunFixtureKeepsTemplateV1ThreeIndexDatabase(t *testing.T) {
 	}
 }
 
+func TestRunFixtureReportsEffectiveBufferedIndexedWrites(t *testing.T) {
+	noIndexDir := filepath.Join(t.TempDir(), "no-index")
+	noIndexCfg, err := parseConfig([]string{
+		"-dir", noIndexDir,
+		"-docs", "8",
+		"-batch-size", "4",
+		"-indexes", "0",
+		"-buffered-indexed-writes",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse no-index config: %v", err)
+	}
+	noIndexSummary, err := runFixture(noIndexCfg)
+	if err != nil {
+		t.Fatalf("run no-index fixture: %v", err)
+	}
+	if noIndexSummary.BufferedIndexedWrites {
+		t.Fatal("no-index summary reported buffered indexed writes enabled")
+	}
+
+	indexedDir := filepath.Join(t.TempDir(), "indexed")
+	indexedCfg, err := parseConfig([]string{
+		"-dir", indexedDir,
+		"-docs", "8",
+		"-batch-size", "4",
+		"-indexes", "1",
+		"-buffered-indexed-writes",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse indexed config: %v", err)
+	}
+	indexedSummary, err := runFixture(indexedCfg)
+	if err != nil {
+		t.Fatalf("run indexed fixture: %v", err)
+	}
+	if !indexedSummary.BufferedIndexedWrites {
+		t.Fatal("indexed summary reported buffered indexed writes disabled")
+	}
+}
+
 func TestLeafGenerationSummaryOmittedWhenDisabled(t *testing.T) {
 	leafGeneration, err := maybePackLeafGenerations(config{}, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- adds an opt-in `CollectionOptions.BufferedIndexedWrites` mode that stages indexed `InsertBatch` root runs in the collection write domain until `Flush`/Close
- keeps staged primary and secondary index reads visible on the same manager, including buffered unique-conflict checks and exact `FindByIndexValueLimit` truncation semantics
- flushes all staged collection roots with one grouped root publish and validates all buffered root descriptors before publish
- exposes `-buffered-indexed-writes` in `collection-load-fixture` and `TREEDB_COLLECTION_BUFFERED_INDEXED_WRITES=true` in collection benchmarks, with separate insert/flush metrics

## Correctness notes
- default behavior is unchanged; the new path is opt-in because full insert+flush CPU is not yet a default win
- durability remains at explicit `Flush`/Close, matching existing no-index buffered insert semantics
- schema/index changes, delete, update, scan, manager close, and fixture checkpoint-each-batch flush buffered indexed writes first

## Local validation
- `go test ./TreeDB/collections -run 'TestCollectionIndexedWriteMemtablesFindLimitExactBufferedCount|TestCollectionIndexedWriteMemtablesReadUniqueAndFlush' -count 1`
- `go test ./TreeDB/collections ./cmd/collection_load_fixture -count 1`
- `go test ./... -count 1`
- `RUN_DIR=/tmp/treedb_indexed_buffered_1777537059 && go run ./cmd/collection_load_fixture -dir "$RUN_DIR" -reset -docs 100000 -batch-size 16000 -format template-v1 -indexes 2 -buffered-indexed-writes -progress=false -json`
- `RUN_DIR=/tmp/treedb_indexed_baseline_1777537065 && go run ./cmd/collection_load_fixture -dir "$RUN_DIR" -reset -docs 100000 -batch-size 16000 -format template-v1 -indexes 2 -progress=false -json`

## Focused benchmark snapshot
Command baseline:
`TREEDB_COLLECTION_BENCH_BATCH_SIZE=16000 TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 go test ./TreeDB/collections -run "^$" -bench "^BenchmarkCollectionShapeInsertBatch$/^indexes_2$" -benchtime=100000x -count=1 -timeout 30m`

Baseline result: `782.0 ns/doc`, `publish_ns/doc=444.9`, `disk_bytes/doc=108.7`, `0 allocs/op`.

Command buffered:
`TREEDB_COLLECTION_BENCH_BATCH_SIZE=16000 TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 TREEDB_COLLECTION_BUFFERED_INDEXED_WRITES=true go test ./TreeDB/collections -run "^$" -bench "^BenchmarkCollectionShapeInsertBatch$/^indexes_2$" -benchtime=100000x -count=1 -timeout 30m`

Buffered result: `1023 ns/doc` full insert+flush, `buffered_insert_ns/doc=595.7`, `buffered_flush_ns/doc=427.5`, `disk_bytes/doc=108.6`, `0 allocs/op`.

Fixture comparison at 100k docs / batch 16k / template-v1 / 2 indexes:
- baseline insert phase: `0.098715042s` (`1,013,016 docs/sec`), total before maintenance `88.26 B/doc`
- buffered insert phase: `0.060384752s` (`1,656,047 docs/sec`), flush phase `0.051010083s`, total before maintenance `82.30 B/doc`

Interpretation: this PR lands the correctness and harness foundation for indexed write-domain memtables. It improves staged writer return latency and reduces one-pass root/disk churn in the fixture, but full synchronous insert+flush is still slower locally, so it remains opt-in while follow-up PRs tackle background flush/coalescing and lower-cost flush construction.
