### PR TITLE
Bound indexed collection write buffers

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1434,12 +1434,7 @@ func addBufferedPrimaryIDs(index *bufferedUniqueValueIndex, batchPrimary memtabl
 	if index == nil || batchPrimary == nil {
 		return nil
 	}
-	arenaCap := int64(batchPrimary.Len() * 16)
-	maxInt := int(^uint(0) >> 1)
-	if arenaCap < 0 || arenaCap > int64(maxInt) {
-		arenaCap = 0
-	}
-	arena := make([]byte, 0, int(arenaCap))
+	arena := make([]byte, 0, bufferedPrimaryIDArenaCap(batchPrimary.Len()))
 	it := batchPrimary.NewIterator(nil, nil)
 	defer func() { _ = it.Close() }()
 	for it.Valid() {
@@ -1456,6 +1451,18 @@ func addBufferedPrimaryIDs(index *bufferedUniqueValueIndex, batchPrimary memtabl
 		index.arenas = append(index.arenas, arena)
 	}
 	return nil
+}
+
+func bufferedPrimaryIDArenaCap(entries int) int {
+	if entries <= 0 {
+		return 0
+	}
+	const bytesPerKeyEstimate = 16
+	maxInt := int(^uint(0) >> 1)
+	if entries > maxInt/bytesPerKeyEstimate {
+		return 0
+	}
+	return entries * bytesPerKeyEstimate
 }
 
 func rebuildBufferedPrimaryIDIndex(collectionName string, runs map[string][]memtable.Table) *bufferedUniqueValueIndex {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -240,6 +240,7 @@ type bufferedIndexedCheckpoint struct {
 type bufferedUniqueValueIndex struct {
 	values     map[uint64][]byte
 	collisions map[uint64][][]byte
+	arenas     [][]byte
 }
 
 type collectionWriteDomain struct {
@@ -259,6 +260,7 @@ type collectionWriteDomain struct {
 	rootRuns         map[string][]memtable.Table
 	rootPolicies     map[string]backenddb.OrderedRootStoragePolicy
 	rootBaseIDs      map[string]uint64
+	primaryIDIndex   *bufferedUniqueValueIndex
 	uniqueValueRuns  map[string][]memtable.Table
 	uniqueValueIndex map[string]*bufferedUniqueValueIndex
 	count            int
@@ -1109,6 +1111,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 			var err error
 			uniqueValueTable, uniquePrefixes, err = bufferedUniqueIndexValueRun(run.table)
 			if err != nil {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
 				return 0, err
 			}
 		}
@@ -1118,6 +1121,15 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 		domain.rootPolicies[run.name] = run.storagePolicy
 		domain.rootRuns[run.name] = append(domain.rootRuns[run.name], run.table)
 		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, run.table.Size())
+		if run.kind == collectionRootPrimary {
+			if domain.primaryIDIndex == nil {
+				domain.primaryIDIndex = newBufferedUniqueValueIndex(max(1, run.table.Len()))
+			}
+			if err := addBufferedPrimaryIDs(domain.primaryIDIndex, run.table); err != nil {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
+				return 0, err
+			}
+		}
 		if uniqueValueTable != nil {
 			domain.uniqueValueRuns[run.indexName] = append(domain.uniqueValueRuns[run.indexName], uniqueValueTable)
 			index := domain.uniqueValueIndex[run.indexName]
@@ -1157,6 +1169,7 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.rootRuns = nil
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
+	domain.primaryIDIndex = nil
 	domain.uniqueValueRuns = nil
 	domain.uniqueValueIndex = nil
 	domain.bufferedBytes = 0
@@ -1211,6 +1224,7 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.rootRuns = checkpoint.rootRuns
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
+	domain.primaryIDIndex = rebuildBufferedPrimaryIDIndex(domain.meta.Name, checkpoint.rootRuns)
 	domain.uniqueValueRuns = checkpoint.uniqueValueRuns
 	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(checkpoint.uniqueValueRuns)
 }
@@ -1359,7 +1373,7 @@ func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collecti
 			if run.name != primaryName {
 				continue
 			}
-			if err := rejectBufferedPrimaryConflicts(pendingPrimary, run.table); err != nil {
+			if err := rejectBufferedPrimaryConflicts(domain.primaryIDIndex, pendingPrimary, run.table); err != nil {
 				return err
 			}
 			break
@@ -1384,12 +1398,17 @@ func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collecti
 	return nil
 }
 
-func rejectBufferedPrimaryConflicts(pendingPrimary []memtable.Table, batchPrimary memtable.Table) error {
+func rejectBufferedPrimaryConflicts(pendingIndex *bufferedUniqueValueIndex, pendingPrimary []memtable.Table, batchPrimary memtable.Table) error {
 	it := batchPrimary.NewIterator(nil, nil)
 	defer func() { _ = it.Close() }()
 	for it.Valid() {
-		if _, _, flags, found := getBufferedRunEntry(pendingPrimary, it.UnsafeKey()); found && flags&node.FlagTombstone == 0 {
+		if pendingIndex != nil && pendingIndex.contains(it.UnsafeKey()) {
 			return ErrDocumentExists
+		}
+		if pendingIndex == nil {
+			if _, _, flags, found := getBufferedRunEntry(pendingPrimary, it.UnsafeKey()); found && flags&node.FlagTombstone == 0 {
+				return ErrDocumentExists
+			}
 		}
 		it.Next()
 	}
@@ -1397,6 +1416,54 @@ func rejectBufferedPrimaryConflicts(pendingPrimary []memtable.Table, batchPrimar
 		return err
 	}
 	return nil
+}
+
+func addBufferedPrimaryIDs(index *bufferedUniqueValueIndex, batchPrimary memtable.Table) error {
+	if index == nil || batchPrimary == nil {
+		return nil
+	}
+	arenaCap := int64(batchPrimary.Len() * 16)
+	maxInt := int(^uint(0) >> 1)
+	if arenaCap < 0 || arenaCap > int64(maxInt) {
+		arenaCap = 0
+	}
+	arena := make([]byte, 0, int(arenaCap))
+	it := batchPrimary.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		key := it.UnsafeKey()
+		start := len(arena)
+		arena = append(arena, key...)
+		index.add(arena[start:len(arena)])
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return err
+	}
+	if len(arena) > 0 {
+		index.arenas = append(index.arenas, arena)
+	}
+	return nil
+}
+
+func rebuildBufferedPrimaryIDIndex(collectionName string, runs map[string][]memtable.Table) *bufferedUniqueValueIndex {
+	if collectionName == "" || len(runs) == 0 {
+		return nil
+	}
+	tables := runs[collectionPrimaryRootName(collectionName)]
+	if len(tables) == 0 {
+		return nil
+	}
+	index := newBufferedUniqueValueIndex(0)
+	for _, table := range tables {
+		if err := addBufferedPrimaryIDs(index, table); err != nil {
+			return nil
+		}
+	}
+	if index.len() == 0 {
+		return nil
+	}
+	return index
 }
 
 func uniqueCollectionIndexNames(meta CollectionMeta) map[string]struct{} {
@@ -1846,6 +1913,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 	domain.rootRuns = nil
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
+	domain.primaryIDIndex = nil
 	oldUniqueValueRuns := domain.uniqueValueRuns
 	domain.uniqueValueRuns = nil
 	domain.uniqueValueIndex = nil
@@ -2739,6 +2807,7 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.rootRuns = nil
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
+	domain.primaryIDIndex = nil
 	domain.uniqueValueRuns = nil
 	domain.uniqueValueIndex = nil
 	if domain.table == nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -179,6 +179,14 @@ type CollectionOptions struct {
 	// primary and secondary reads on the same manager, but durability remains at
 	// the explicit flush boundary, matching the existing no-index buffered path.
 	BufferedIndexedWrites bool `json:"buffered_indexed_writes,omitempty"`
+	// BufferedIndexedWriteMaxDocuments flushes indexed write buffers once this
+	// many staged documents are pending. Zero leaves flushing to explicit
+	// Flush/Close calls.
+	BufferedIndexedWriteMaxDocuments int `json:"buffered_indexed_write_max_documents,omitempty"`
+	// BufferedIndexedWriteMaxBytes flushes indexed write buffers once the staged
+	// root-run payload estimate reaches this many bytes. Zero leaves flushing to
+	// explicit Flush/Close calls.
+	BufferedIndexedWriteMaxBytes int64 `json:"buffered_indexed_write_max_bytes,omitempty"`
 }
 
 type IndexDefinition struct {
@@ -219,6 +227,15 @@ type noIndexBatchEntry struct {
 	document []byte
 }
 
+type bufferedIndexedCheckpoint struct {
+	count           int
+	bufferedBytes   int64
+	rootRuns        map[string][]memtable.Table
+	rootPolicies    map[string]backenddb.OrderedRootStoragePolicy
+	rootBaseIDs     map[string]uint64
+	uniqueValueRuns map[string][]memtable.Table
+}
+
 type collectionWriteDomain struct {
 	// mutationMu serializes root descriptor publishes for handles opened
 	// through the same manager so optimistic retries do not starve under
@@ -238,6 +255,7 @@ type collectionWriteDomain struct {
 	rootBaseIDs     map[string]uint64
 	uniqueValueRuns map[string][]memtable.Table
 	count           int
+	bufferedBytes   int64
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -1024,31 +1042,31 @@ func (c *Collection) shouldBufferIndexedInserts(meta CollectionMeta) bool {
 	return c != nil && c.writeDomain != nil && meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
 }
 
-func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, baseCommitSeq, baseSystemRoot uint64, plan *insertBatchPlan) error {
+func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, baseCommitSeq, baseSystemRoot uint64, plan *insertBatchPlan) (time.Duration, error) {
 	domain := c.writeDomain
 	if domain == nil {
-		return errors.New("collections: missing write domain")
+		return 0, errors.New("collections: missing write domain")
 	}
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	if catalog == nil {
-		return errCollectionNotFound
+		return 0, errCollectionNotFound
 	}
 	if len(catalog.meta.Indexes) == 0 {
-		return errors.New("collections: indexed write buffer requires an indexed schema")
+		return 0, errors.New("collections: indexed write buffer requires an indexed schema")
 	}
 	if domain.count > 0 {
 		currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
 		currentCatalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentCommitSeq, currentSystemRoot)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		if !sameCollectionMeta(currentCatalog.meta, catalog.meta) {
-			return fmt.Errorf("collections: concurrent schema modification detected for %q", catalog.meta.Name)
+			return 0, fmt.Errorf("collections: concurrent schema modification detected for %q", catalog.meta.Name)
 		}
 		for rootName, baseRoot := range domain.rootBaseIDs {
 			if got := currentCatalog.rootID(rootName); got != baseRoot {
-				return fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
+				return 0, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
 			}
 		}
 		catalog = currentCatalog
@@ -1057,7 +1075,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	}
 
 	if err := c.rejectBufferedIndexedInsertConflictsLocked(domain, catalog.meta, plan); err != nil {
-		return err
+		return 0, err
 	}
 	if domain.rootPolicies == nil {
 		domain.rootPolicies = make(map[string]backenddb.OrderedRootStoragePolicy, len(plan.runs))
@@ -1071,14 +1089,16 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	if domain.uniqueValueRuns == nil {
 		domain.uniqueValueRuns = make(map[string][]memtable.Table)
 	}
+	checkpoint := checkpointBufferedIndexedDomain(domain)
 	uniqueIndexes := uniqueCollectionIndexNames(catalog.meta)
+	var stagedBytes int64
 	for _, run := range plan.runs {
 		var uniqueValueTable memtable.Table
 		if _, ok := uniqueIndexes[run.indexName]; ok && run.kind == collectionRootSecondary {
 			var err error
 			uniqueValueTable, err = bufferedUniqueIndexValueRun(run.table)
 			if err != nil {
-				return err
+				return 0, err
 			}
 		}
 		if len(domain.rootRuns[run.name]) == 0 {
@@ -1086,8 +1106,10 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 		}
 		domain.rootPolicies[run.name] = run.storagePolicy
 		domain.rootRuns[run.name] = append(domain.rootRuns[run.name], run.table)
+		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, run.table.Size())
 		if uniqueValueTable != nil {
 			domain.uniqueValueRuns[run.indexName] = append(domain.uniqueValueRuns[run.indexName], uniqueValueTable)
+			stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, uniqueValueTable.Size())
 		}
 	}
 	domain.loaded = true
@@ -1095,8 +1117,17 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.catalog = catalog
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
 	domain.count += len(plan.resultIDs)
+	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
 	c.meta = catalog.meta
-	return nil
+	if shouldFlushBufferedIndexedWrites(domain, catalog.meta.Options) {
+		flushStart := time.Now()
+		if err := c.flushBufferedIndexedLocked(domain); err != nil {
+			rollbackBufferedIndexedDomain(domain, checkpoint)
+			return 0, err
+		}
+		return time.Since(flushStart), nil
+	}
+	return 0, nil
 }
 
 func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWriteDomain, catalog *collectionCatalog, baseCommitSeq, baseSystemRoot uint64) {
@@ -1110,6 +1141,104 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.uniqueValueRuns = nil
+	domain.bufferedBytes = 0
+}
+
+func shouldFlushBufferedIndexedWrites(domain *collectionWriteDomain, opts CollectionOptions) bool {
+	if domain == nil || domain.count == 0 {
+		return false
+	}
+	if opts.BufferedIndexedWriteMaxDocuments > 0 && domain.count >= opts.BufferedIndexedWriteMaxDocuments {
+		return true
+	}
+	if opts.BufferedIndexedWriteMaxBytes > 0 && domain.bufferedBytes >= opts.BufferedIndexedWriteMaxBytes {
+		return true
+	}
+	return false
+}
+
+func saturatingAddNonNegativeInt64(total, n int64) int64 {
+	if n <= 0 {
+		return total
+	}
+	const maxInt64 = int64(^uint64(0) >> 1)
+	if total > maxInt64-n {
+		return maxInt64
+	}
+	return total + n
+}
+
+func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedIndexedCheckpoint {
+	if domain == nil {
+		return bufferedIndexedCheckpoint{}
+	}
+	return bufferedIndexedCheckpoint{
+		count:           domain.count,
+		bufferedBytes:   domain.bufferedBytes,
+		rootRuns:        cloneTableRunMap(domain.rootRuns),
+		rootPolicies:    cloneRootPolicyMap(domain.rootPolicies),
+		rootBaseIDs:     cloneUint64Map(domain.rootBaseIDs),
+		uniqueValueRuns: cloneTableRunMap(domain.uniqueValueRuns),
+	}
+}
+
+func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint bufferedIndexedCheckpoint) {
+	if domain == nil {
+		return
+	}
+	resetTableRunsAddedAfterCheckpoint(domain.rootRuns, checkpoint.rootRuns)
+	resetTableRunsAddedAfterCheckpoint(domain.uniqueValueRuns, checkpoint.uniqueValueRuns)
+	domain.count = checkpoint.count
+	domain.bufferedBytes = checkpoint.bufferedBytes
+	domain.rootRuns = checkpoint.rootRuns
+	domain.rootPolicies = checkpoint.rootPolicies
+	domain.rootBaseIDs = checkpoint.rootBaseIDs
+	domain.uniqueValueRuns = checkpoint.uniqueValueRuns
+}
+
+func resetTableRunsAddedAfterCheckpoint(current, checkpoint map[string][]memtable.Table) {
+	for name, runs := range current {
+		keep := 0
+		if checkpointRuns, ok := checkpoint[name]; ok {
+			keep = len(checkpointRuns)
+		}
+		for _, table := range runs[keep:] {
+			resetCollectionRunTable(table)
+		}
+	}
+}
+
+func cloneTableRunMap(in map[string][]memtable.Table) map[string][]memtable.Table {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string][]memtable.Table, len(in))
+	for name, runs := range in {
+		out[name] = runs
+	}
+	return out
+}
+
+func cloneRootPolicyMap(in map[string]backenddb.OrderedRootStoragePolicy) map[string]backenddb.OrderedRootStoragePolicy {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]backenddb.OrderedRootStoragePolicy, len(in))
+	for name, policy := range in {
+		out[name] = policy
+	}
+	return out
+}
+
+func cloneUint64Map(in map[string]uint64) map[string]uint64 {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]uint64, len(in))
+	for name, value := range in {
+		out[name] = value
+	}
+	return out
 }
 
 func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collectionWriteDomain, meta CollectionMeta, plan *insertBatchPlan) error {
@@ -1564,6 +1693,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 	rootNames := orderedBufferedRootNames(meta, domain.rootRuns)
 	if len(rootNames) == 0 {
 		domain.count = 0
+		domain.bufferedBytes = 0
 		return nil
 	}
 	baseSystemRoot := snapshotSystemRoot(pin)
@@ -1608,6 +1738,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 	oldUniqueValueRuns := domain.uniqueValueRuns
 	domain.uniqueValueRuns = nil
 	domain.count = 0
+	domain.bufferedBytes = 0
 	c.meta = meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	for _, runs := range oldRuns {
@@ -1800,12 +1931,13 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 	}
 
 	if c.shouldBufferIndexedInserts(c.meta) {
-		err := c.bufferIndexedInsertPlanLocked(catalog, baseCommitSeq, baseSystemRoot, plan)
+		bufferFlushElapsed, err := c.bufferIndexedInsertPlanLocked(catalog, baseCommitSeq, baseSystemRoot, plan)
 		_ = snap.Close()
 		if err != nil {
 			resetCollectionRunTables(plan.runs)
 			return nil, err
 		}
+		plan.stats.Publish += bufferFlushElapsed
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
 		return plan.resultIDs, nil
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1101,7 +1101,11 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	if domain.uniqueValueIndex == nil {
 		domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex)
 	}
-	checkpoint := checkpointBufferedIndexedDomain(domain)
+	autoFlushEnabled := bufferedIndexedAutoFlushEnabled(catalog.meta.Options)
+	var checkpoint bufferedIndexedCheckpoint
+	if autoFlushEnabled {
+		checkpoint = checkpointBufferedIndexedDomain(domain)
+	}
 	uniqueIndexes := uniqueCollectionIndexNames(catalog.meta)
 	var stagedBytes int64
 	for _, run := range plan.runs {
@@ -1111,7 +1115,9 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 			var err error
 			uniqueValueTable, uniquePrefixes, err = bufferedUniqueIndexValueRun(run.table)
 			if err != nil {
-				rollbackBufferedIndexedDomain(domain, checkpoint)
+				if autoFlushEnabled {
+					rollbackBufferedIndexedDomain(domain, checkpoint)
+				}
 				return 0, err
 			}
 		}
@@ -1126,7 +1132,9 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 				domain.primaryIDIndex = newBufferedUniqueValueIndex(max(1, run.table.Len()))
 			}
 			if err := addBufferedPrimaryIDs(domain.primaryIDIndex, run.table); err != nil {
-				rollbackBufferedIndexedDomain(domain, checkpoint)
+				if autoFlushEnabled {
+					rollbackBufferedIndexedDomain(domain, checkpoint)
+				}
 				return 0, err
 			}
 		}
@@ -1186,6 +1194,10 @@ func shouldFlushBufferedIndexedWrites(domain *collectionWriteDomain, opts Collec
 		return true
 	}
 	return false
+}
+
+func bufferedIndexedAutoFlushEnabled(opts CollectionOptions) bool {
+	return opts.BufferedIndexedWriteMaxDocuments > 0 || opts.BufferedIndexedWriteMaxBytes > 0
 }
 
 func saturatingAddNonNegativeInt64(total, n int64) int64 {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/cespare/xxhash/v2"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
@@ -236,26 +237,32 @@ type bufferedIndexedCheckpoint struct {
 	uniqueValueRuns map[string][]memtable.Table
 }
 
+type bufferedUniqueValueIndex struct {
+	values     map[uint64][]byte
+	collisions map[uint64][][]byte
+}
+
 type collectionWriteDomain struct {
 	// mutationMu serializes root descriptor publishes for handles opened
 	// through the same manager so optimistic retries do not starve under
 	// sustained collection write contention.
-	mutationMu      sync.Mutex
-	mu              sync.RWMutex
-	loaded          bool
-	meta            CollectionMeta
-	catalog         *collectionCatalog
-	baseCommitSeq   uint64
-	baseSystemRoot  uint64
-	primaryRoot     uint64
-	storagePolicy   backenddb.OrderedRootStoragePolicy
-	table           memtable.Table
-	rootRuns        map[string][]memtable.Table
-	rootPolicies    map[string]backenddb.OrderedRootStoragePolicy
-	rootBaseIDs     map[string]uint64
-	uniqueValueRuns map[string][]memtable.Table
-	count           int
-	bufferedBytes   int64
+	mutationMu       sync.Mutex
+	mu               sync.RWMutex
+	loaded           bool
+	meta             CollectionMeta
+	catalog          *collectionCatalog
+	baseCommitSeq    uint64
+	baseSystemRoot   uint64
+	primaryRoot      uint64
+	storagePolicy    backenddb.OrderedRootStoragePolicy
+	table            memtable.Table
+	rootRuns         map[string][]memtable.Table
+	rootPolicies     map[string]backenddb.OrderedRootStoragePolicy
+	rootBaseIDs      map[string]uint64
+	uniqueValueRuns  map[string][]memtable.Table
+	uniqueValueIndex map[string]*bufferedUniqueValueIndex
+	count            int
+	bufferedBytes    int64
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -1089,14 +1096,18 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	if domain.uniqueValueRuns == nil {
 		domain.uniqueValueRuns = make(map[string][]memtable.Table)
 	}
+	if domain.uniqueValueIndex == nil {
+		domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex)
+	}
 	checkpoint := checkpointBufferedIndexedDomain(domain)
 	uniqueIndexes := uniqueCollectionIndexNames(catalog.meta)
 	var stagedBytes int64
 	for _, run := range plan.runs {
 		var uniqueValueTable memtable.Table
+		var uniquePrefixes [][]byte
 		if _, ok := uniqueIndexes[run.indexName]; ok && run.kind == collectionRootSecondary {
 			var err error
-			uniqueValueTable, err = bufferedUniqueIndexValueRun(run.table)
+			uniqueValueTable, uniquePrefixes, err = bufferedUniqueIndexValueRun(run.table)
 			if err != nil {
 				return 0, err
 			}
@@ -1109,6 +1120,12 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, run.table.Size())
 		if uniqueValueTable != nil {
 			domain.uniqueValueRuns[run.indexName] = append(domain.uniqueValueRuns[run.indexName], uniqueValueTable)
+			index := domain.uniqueValueIndex[run.indexName]
+			if index == nil {
+				index = newBufferedUniqueValueIndex(max(1, len(uniquePrefixes)))
+				domain.uniqueValueIndex[run.indexName] = index
+			}
+			index.addAll(uniquePrefixes)
 			stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, uniqueValueTable.Size())
 		}
 	}
@@ -1141,6 +1158,7 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.uniqueValueRuns = nil
+	domain.uniqueValueIndex = nil
 	domain.bufferedBytes = 0
 }
 
@@ -1194,6 +1212,7 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
 	domain.uniqueValueRuns = checkpoint.uniqueValueRuns
+	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(checkpoint.uniqueValueRuns)
 }
 
 func resetTableRunsAddedAfterCheckpoint(current, checkpoint map[string][]memtable.Table) {
@@ -1241,6 +1260,95 @@ func cloneUint64Map(in map[string]uint64) map[string]uint64 {
 	return out
 }
 
+func newBufferedUniqueValueIndex(capacity int) *bufferedUniqueValueIndex {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return &bufferedUniqueValueIndex{values: make(map[uint64][]byte, capacity)}
+}
+
+func (idx *bufferedUniqueValueIndex) len() int {
+	if idx == nil {
+		return 0
+	}
+	total := len(idx.values)
+	for _, collisions := range idx.collisions {
+		total += len(collisions)
+	}
+	return total
+}
+
+func (idx *bufferedUniqueValueIndex) addAll(prefixes [][]byte) {
+	if idx == nil {
+		return
+	}
+	if idx.values == nil {
+		idx.values = make(map[uint64][]byte, len(prefixes))
+	}
+	for _, prefix := range prefixes {
+		idx.add(prefix)
+	}
+}
+
+func (idx *bufferedUniqueValueIndex) add(prefix []byte) {
+	if idx == nil {
+		return
+	}
+	hash := xxhash.Sum64(prefix)
+	if existing, ok := idx.values[hash]; ok {
+		if bytes.Equal(existing, prefix) {
+			return
+		}
+		if idx.collisions == nil {
+			idx.collisions = make(map[uint64][][]byte)
+		}
+		idx.collisions[hash] = append(idx.collisions[hash], prefix)
+		return
+	}
+	idx.values[hash] = prefix
+}
+
+func (idx *bufferedUniqueValueIndex) contains(prefix []byte) bool {
+	if idx == nil || len(idx.values) == 0 {
+		return false
+	}
+	hash := xxhash.Sum64(prefix)
+	if bytes.Equal(idx.values[hash], prefix) {
+		return true
+	}
+	for _, candidate := range idx.collisions[hash] {
+		if bytes.Equal(candidate, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func rebuildBufferedUniqueValueIndexes(runs map[string][]memtable.Table) map[string]*bufferedUniqueValueIndex {
+	if len(runs) == 0 {
+		return nil
+	}
+	out := make(map[string]*bufferedUniqueValueIndex, len(runs))
+	for indexName, tables := range runs {
+		index := newBufferedUniqueValueIndex(0)
+		for _, table := range tables {
+			it := table.NewIterator(nil, nil)
+			for it.Valid() {
+				index.add(bytes.Clone(it.UnsafeKey()))
+				it.Next()
+			}
+			_ = it.Close()
+		}
+		if index.len() > 0 {
+			out[indexName] = index
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collectionWriteDomain, meta CollectionMeta, plan *insertBatchPlan) error {
 	if domain == nil || domain.count == 0 || len(domain.rootRuns) == 0 {
 		return nil
@@ -1265,8 +1373,8 @@ func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collecti
 		if _, ok := uniqueIndexes[run.indexName]; !ok {
 			continue
 		}
-		pending := domain.uniqueValueRuns[run.indexName]
-		if len(pending) == 0 {
+		pending := domain.uniqueValueIndex[run.indexName]
+		if pending == nil || pending.len() == 0 {
 			continue
 		}
 		if err := rejectBufferedUniqueIndexConflicts(run.indexName, pending, run.table); err != nil {
@@ -1301,7 +1409,7 @@ func uniqueCollectionIndexNames(meta CollectionMeta) map[string]struct{} {
 	return uniqueIndexes
 }
 
-func rejectBufferedUniqueIndexConflicts(indexName string, pendingIndex []memtable.Table, batchIndex memtable.Table) error {
+func rejectBufferedUniqueIndexConflicts(indexName string, pendingIndex *bufferedUniqueValueIndex, batchIndex memtable.Table) error {
 	it := batchIndex.NewIterator(nil, nil)
 	defer func() { _ = it.Close() }()
 	for it.Valid() {
@@ -1309,7 +1417,7 @@ func rejectBufferedUniqueIndexConflicts(indexName string, pendingIndex []memtabl
 		if err != nil {
 			return err
 		}
-		if _, _, flags, found := getBufferedRunEntry(pendingIndex, prefix); found && flags&node.FlagTombstone == 0 {
+		if pendingIndex.contains(prefix) {
 			return fmt.Errorf("%w %q", ErrUniqueIndexConflict, indexName)
 		}
 		it.Next()
@@ -1320,7 +1428,7 @@ func rejectBufferedUniqueIndexConflicts(indexName string, pendingIndex []memtabl
 	return nil
 }
 
-func bufferedUniqueIndexValueRun(batchIndex memtable.Table) (memtable.Table, error) {
+func bufferedUniqueIndexValueRun(batchIndex memtable.Table) (memtable.Table, [][]byte, error) {
 	table := newCollectionRunTable(max(0, batchIndex.Len()))
 	maxInt := int(^uint(0) >> 1)
 	arenaCap := batchIndex.Size()
@@ -1328,25 +1436,28 @@ func bufferedUniqueIndexValueRun(batchIndex memtable.Table) (memtable.Table, err
 		arenaCap = 0
 	}
 	arena := make([]byte, 0, int(arenaCap))
+	prefixes := make([][]byte, 0, max(0, batchIndex.Len()))
 	it := batchIndex.NewIterator(nil, nil)
 	defer func() { _ = it.Close() }()
 	for it.Valid() {
 		prefix, err := indexEntryValuePrefix(it.UnsafeKey())
 		if err != nil {
 			resetCollectionRunTable(table)
-			return nil, err
+			return nil, nil, err
 		}
 		start := len(arena)
 		arena = append(arena, prefix...)
-		setCollectionRunValue(table, arena[start:len(arena)], nil)
+		owned := arena[start:len(arena)]
+		setCollectionRunValue(table, owned, nil)
+		prefixes = append(prefixes, owned)
 		it.Next()
 	}
 	if err := it.Error(); err != nil {
 		resetCollectionRunTable(table)
-		return nil, err
+		return nil, nil, err
 	}
 	table.Freeze()
-	return table, nil
+	return table, prefixes, nil
 }
 
 func indexEntryValuePrefix(key []byte) ([]byte, error) {
@@ -1737,6 +1848,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 	domain.rootBaseIDs = nil
 	oldUniqueValueRuns := domain.uniqueValueRuns
 	domain.uniqueValueRuns = nil
+	domain.uniqueValueIndex = nil
 	domain.count = 0
 	domain.bufferedBytes = 0
 	c.meta = meta
@@ -2628,6 +2740,7 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.uniqueValueRuns = nil
+	domain.uniqueValueIndex = nil
 	if domain.table == nil {
 		domain.table = newCollectionRunTable(0)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1464,6 +1464,67 @@ func TestCollectionIndexedWriteMemtablesAutoFlushMaxDocuments(t *testing.T) {
 	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"), []byte("u2"))
 }
 
+func TestCollectionIndexedWriteMemtablesAutoFlushMaxBytes(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:        true,
+			BufferedIndexedWriteMaxBytes: 1,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot after byte threshold flush")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog after byte threshold flush: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
+		t.Fatal("primary root was not persisted after byte threshold flush")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err := reopenedCol.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find email after byte threshold flush: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("email ids=%q want [u1]", ids)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesCloseFlushes(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1469,6 +1469,16 @@ func TestCollectionIndexedWriteMemtablesAutoFlushMaxBytes(t *testing.T) {
 	}
 }
 
+func TestBufferedPrimaryIDArenaCapAvoidsOverflow(t *testing.T) {
+	if got := bufferedPrimaryIDArenaCap(2); got != 32 {
+		t.Fatalf("small arena cap=%d want 32", got)
+	}
+	maxInt := int(^uint(0) >> 1)
+	if got := bufferedPrimaryIDArenaCap(maxInt/16 + 1); got != 0 {
+		t.Fatalf("overflow arena cap=%d want 0", got)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesCloseFlushes(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1328,6 +1328,86 @@ func TestCollectionIndexedWriteMemtablesRejectPersistedUniqueConflict(t *testing
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesAutoFlushMaxDocuments(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 2,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("first insert batch: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog after first batch: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got != 0 {
+		t.Fatalf("primary root persisted before threshold flush: %d", got)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"email":"grace@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("second insert batch: %v", err)
+	}
+	snap = d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot after threshold flush")
+	}
+	catalog, err = loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog after threshold flush: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
+		t.Fatal("primary root was not persisted after threshold flush")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err := reopenedCol.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city after threshold flush: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"), []byte("u2"))
+}
+
 func TestCollectionIndexedWriteMemtablesCloseFlushes(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1408,6 +1408,67 @@ func TestCollectionIndexedWriteMemtablesAutoFlushMaxDocuments(t *testing.T) {
 	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"), []byte("u2"))
 }
 
+func TestCollectionIndexedWriteMemtablesAutoFlushMaxBytes(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:        true,
+			BufferedIndexedWriteMaxBytes: 1,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot after byte threshold flush")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog after byte threshold flush: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
+		t.Fatal("primary root was not persisted after byte threshold flush")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err := reopenedCol.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find email after byte threshold flush: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("email ids=%q want [u1]", ids)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesCloseFlushes(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1525,6 +1525,16 @@ func TestCollectionIndexedWriteMemtablesAutoFlushMaxBytes(t *testing.T) {
 	}
 }
 
+func TestBufferedPrimaryIDArenaCapAvoidsOverflow(t *testing.T) {
+	if got := bufferedPrimaryIDArenaCap(2); got != 32 {
+		t.Fatalf("small arena cap=%d want 32", got)
+	}
+	maxInt := int(^uint(0) >> 1)
+	if got := bufferedPrimaryIDArenaCap(maxInt/16 + 1); got != 0 {
+		t.Fatalf("overflow arena cap=%d want 0", got)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesCloseFlushes(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1384,6 +1384,86 @@ func TestCollectionIndexedWriteMemtablesRejectPersistedUniqueConflict(t *testing
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesAutoFlushMaxDocuments(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 2,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("first insert batch: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog after first batch: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got != 0 {
+		t.Fatalf("primary root persisted before threshold flush: %d", got)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"email":"grace@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("second insert batch: %v", err)
+	}
+	snap = d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot after threshold flush")
+	}
+	catalog, err = loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog after threshold flush: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
+		t.Fatal("primary root was not persisted after threshold flush")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err := reopenedCol.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city after threshold flush: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"), []byte("u2"))
+}
+
 func TestCollectionIndexedWriteMemtablesCloseFlushes(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/bench_test.go
+++ b/TreeDB/collections/bench_test.go
@@ -567,16 +567,20 @@ func openBenchmarkCollection(b *testing.B, name string, indexes ...collections.I
 	dataOuter, indexOuter := benchmarkCollectionStoragePolicy(b)
 	documentFormat := benchmarkCollectionDocumentFormat(b)
 	bufferedIndexedWrites := benchmarkBoolEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITES", false) && len(indexes) > 0
+	bufferedIndexedWriteMaxDocuments := benchmarkIntEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", 0)
+	bufferedIndexedWriteMaxBytes := benchmarkInt64Env(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_BYTES", 0)
 	for i := range indexes {
 		indexes[i].StoragePolicy = benchmarkRootStoragePolicy(indexOuter)
 	}
 	if _, err := manager.CreateCollection(&collections.CollectionMeta{
 		Name: name,
 		Options: collections.CollectionOptions{
-			DocumentFormat:          documentFormat,
-			DataRootStoragePolicy:   benchmarkRootStoragePolicy(dataOuter),
-			IndexStateStoragePolicy: benchmarkRootStoragePolicy(dataOuter),
-			BufferedIndexedWrites:   bufferedIndexedWrites,
+			DocumentFormat:                   documentFormat,
+			DataRootStoragePolicy:            benchmarkRootStoragePolicy(dataOuter),
+			IndexStateStoragePolicy:          benchmarkRootStoragePolicy(dataOuter),
+			BufferedIndexedWrites:            bufferedIndexedWrites,
+			BufferedIndexedWriteMaxDocuments: bufferedIndexedWriteMaxDocuments,
+			BufferedIndexedWriteMaxBytes:     bufferedIndexedWriteMaxBytes,
 		},
 		Indexes: indexes,
 	}); err != nil {

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -183,7 +183,14 @@ func benchmarkCollectionShapeInsertBatch(b *testing.B, indexCount int, checkpoin
 	b.ReportMetric(float64(targetBatchSize), metricName)
 	b.ReportMetric(float64(indexCount), "indexes/doc")
 	if bufferedIndexedWrites {
+		meta := collection.Meta()
 		b.ReportMetric(1, "buffered_indexed_writes")
+		if meta.Options.BufferedIndexedWriteMaxDocuments > 0 {
+			b.ReportMetric(float64(meta.Options.BufferedIndexedWriteMaxDocuments), "buffered_max_docs")
+		}
+		if meta.Options.BufferedIndexedWriteMaxBytes > 0 {
+			b.ReportMetric(float64(meta.Options.BufferedIndexedWriteMaxBytes), "buffered_max_bytes")
+		}
 		if insertElapsed > 0 {
 			b.ReportMetric(float64(insertElapsed.Nanoseconds())/float64(b.N), "buffered_insert_ns/doc")
 		}

--- a/cmd/collection_load_fixture/README.md
+++ b/cmd/collection_load_fixture/README.md
@@ -49,6 +49,13 @@ Useful variants:
 # them at Flush/Close. The summary reports insert and flush timing separately.
 ./bin/collection-load-fixture -buffered-indexed-writes -dir /tmp/treedb_two_index_buffered -reset
 
+# Stage indexed writes but force bounded publishes every 64000 staged docs.
+./bin/collection-load-fixture \
+  -buffered-indexed-writes \
+  -buffered-indexed-write-max-docs 64000 \
+  -dir /tmp/treedb_two_index_buffered_bounded \
+  -reset
+
 # Generate machine-readable output and optional profiles.
 ./bin/collection-load-fixture \
   -json \

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -38,42 +38,44 @@ const (
 )
 
 type config struct {
-	Dir                        string
-	Reset                      bool
-	Docs                       int
-	BatchSize                  int
-	Collection                 string
-	DocumentFormat             collections.DocumentFormat
-	IndexCount                 int
-	BufferedIndexedWrites      bool
-	Profile                    treedb.Profile
-	DataOuterLeavesInValueLog  bool
-	IndexOuterLeavesInValueLog bool
-	ChunkSize                  int64
-	KeepRecent                 uint64
-	PreferAppendAlloc          bool
-	PagerSyncConcurrency       int
-	DisableBackgroundPrune     bool
-	PruneInterval              time.Duration
-	PruneMaxPages              int
-	PruneMaxDuration           time.Duration
-	LeafSegmentTargetBytes     int64
-	Checkpoint                 bool
-	CheckpointEachBatch        bool
-	ReopenVerify               bool
-	VerifySamples              int
-	ValueLogRewrite            bool
-	ValueLogGC                 bool
-	LeafGenerationPackGC       bool
-	LeafGenerationPackForce    bool
-	LeafGenerationPackMaxGen   int
-	LeafGenerationPackFrameK   int
-	IndexVacuum                string
-	Progress                   bool
-	JSONOutput                 bool
-	CPUProfile                 string
-	MemProfile                 string
-	createdTempDir             bool
+	Dir                          string
+	Reset                        bool
+	Docs                         int
+	BatchSize                    int
+	Collection                   string
+	DocumentFormat               collections.DocumentFormat
+	IndexCount                   int
+	BufferedIndexedWrites        bool
+	BufferedIndexedWriteMaxDocs  int
+	BufferedIndexedWriteMaxBytes int64
+	Profile                      treedb.Profile
+	DataOuterLeavesInValueLog    bool
+	IndexOuterLeavesInValueLog   bool
+	ChunkSize                    int64
+	KeepRecent                   uint64
+	PreferAppendAlloc            bool
+	PagerSyncConcurrency         int
+	DisableBackgroundPrune       bool
+	PruneInterval                time.Duration
+	PruneMaxPages                int
+	PruneMaxDuration             time.Duration
+	LeafSegmentTargetBytes       int64
+	Checkpoint                   bool
+	CheckpointEachBatch          bool
+	ReopenVerify                 bool
+	VerifySamples                int
+	ValueLogRewrite              bool
+	ValueLogGC                   bool
+	LeafGenerationPackGC         bool
+	LeafGenerationPackForce      bool
+	LeafGenerationPackMaxGen     int
+	LeafGenerationPackFrameK     int
+	IndexVacuum                  string
+	Progress                     bool
+	JSONOutput                   bool
+	CPUProfile                   string
+	MemProfile                   string
+	createdTempDir               bool
 }
 
 type timingSummary struct {
@@ -232,6 +234,8 @@ type loadSummary struct {
 	Batches                       int                    `json:"batches"`
 	IndexCount                    int                    `json:"index_count"`
 	BufferedIndexedWrites         bool                   `json:"buffered_indexed_writes,omitempty"`
+	BufferedIndexedWriteMaxDocs   int                    `json:"buffered_indexed_write_max_docs,omitempty"`
+	BufferedIndexedWriteMaxBytes  int64                  `json:"buffered_indexed_write_max_bytes,omitempty"`
 	DataOuterLeavesInValueLog     bool                   `json:"data_outer_leaves_in_value_log"`
 	IndexOuterLeavesInValueLog    bool                   `json:"index_outer_leaves_in_value_log"`
 	ChunkSize                     int64                  `json:"chunk_size,omitempty"`
@@ -325,6 +329,8 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	fs.StringVar(&documentFormat, "format", string(cfg.DocumentFormat), "document format: json or template-v1")
 	fs.IntVar(&cfg.IndexCount, "indexes", cfg.IndexCount, "secondary index count for the benchmark shape: 0, 1, 2, or 3")
 	fs.BoolVar(&cfg.BufferedIndexedWrites, "buffered-indexed-writes", false, "stage indexed InsertBatch writes in collection-local memtables until flush")
+	fs.IntVar(&cfg.BufferedIndexedWriteMaxDocs, "buffered-indexed-write-max-docs", 0, "flush indexed write buffers after this many staged documents; 0 means Flush/Close only")
+	fs.Int64Var(&cfg.BufferedIndexedWriteMaxBytes, "buffered-indexed-write-max-bytes", 0, "flush indexed write buffers after this many staged root-run bytes; 0 means Flush/Close only")
 	fs.StringVar(&profile, "profile", string(cfg.Profile), "TreeDB profile: fast, wal_on_fast, durable, or bench")
 	fs.BoolVar(&cfg.DataOuterLeavesInValueLog, "data-outer-leaves-in-vlog", cfg.DataOuterLeavesInValueLog, "store collection primary/index-state outer leaves through the value log")
 	fs.BoolVar(&cfg.IndexOuterLeavesInValueLog, "index-outer-leaves-in-vlog", cfg.IndexOuterLeavesInValueLog, "store secondary-index outer leaves through the value log")
@@ -376,6 +382,12 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	}
 	if cfg.IndexCount < 0 || cfg.IndexCount > 3 {
 		return cfg, fmt.Errorf("-indexes must be 0, 1, 2, or 3")
+	}
+	if cfg.BufferedIndexedWriteMaxDocs < 0 {
+		return cfg, fmt.Errorf("-buffered-indexed-write-max-docs must be >= 0")
+	}
+	if cfg.BufferedIndexedWriteMaxBytes < 0 {
+		return cfg, fmt.Errorf("-buffered-indexed-write-max-bytes must be >= 0")
 	}
 	if strings.TrimSpace(cfg.Collection) == "" {
 		return cfg, fmt.Errorf("-collection cannot be empty")
@@ -608,6 +620,8 @@ func runFixture(cfg config) (loadSummary, error) {
 		Batches:                       batches,
 		IndexCount:                    cfg.IndexCount,
 		BufferedIndexedWrites:         cfg.BufferedIndexedWrites,
+		BufferedIndexedWriteMaxDocs:   cfg.BufferedIndexedWriteMaxDocs,
+		BufferedIndexedWriteMaxBytes:  cfg.BufferedIndexedWriteMaxBytes,
 		DataOuterLeavesInValueLog:     cfg.DataOuterLeavesInValueLog,
 		IndexOuterLeavesInValueLog:    cfg.IndexOuterLeavesInValueLog,
 		ChunkSize:                     cfg.ChunkSize,
@@ -725,10 +739,12 @@ func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Co
 	_, err := manager.CreateCollection(&collections.CollectionMeta{
 		Name: cfg.Collection,
 		Options: collections.CollectionOptions{
-			DocumentFormat:          cfg.DocumentFormat,
-			DataRootStoragePolicy:   rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
-			IndexStateStoragePolicy: rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
-			BufferedIndexedWrites:   cfg.BufferedIndexedWrites && cfg.IndexCount > 0,
+			DocumentFormat:                   cfg.DocumentFormat,
+			DataRootStoragePolicy:            rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+			IndexStateStoragePolicy:          rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+			BufferedIndexedWrites:            cfg.BufferedIndexedWrites && cfg.IndexCount > 0,
+			BufferedIndexedWriteMaxDocuments: cfg.BufferedIndexedWriteMaxDocs,
+			BufferedIndexedWriteMaxBytes:     cfg.BufferedIndexedWriteMaxBytes,
 		},
 		Indexes: indexes,
 	})
@@ -1545,6 +1561,10 @@ func printHumanSummary(w io.Writer, summary loadSummary) {
 		summary.DocumentFormat, summary.IndexCount, summary.DataOuterLeavesInValueLog, summary.IndexOuterLeavesInValueLog, summary.Profile)
 	if summary.BufferedIndexedWrites {
 		fmt.Fprintln(w, "indexed write buffering: enabled")
+		if summary.BufferedIndexedWriteMaxDocs > 0 || summary.BufferedIndexedWriteMaxBytes > 0 {
+			fmt.Fprintf(w, "indexed write buffer limits: max_docs=%d max_bytes=%s\n",
+				summary.BufferedIndexedWriteMaxDocs, humanBytes(uint64(summary.BufferedIndexedWriteMaxBytes)))
+		}
 	}
 	fmt.Fprintf(w, "index policy: keep_recent=%d prefer_append_alloc=%t background_prune=%t\n",
 		summary.KeepRecent, summary.PreferAppendAlloc, !summary.DisableBackgroundPrune)

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -486,6 +486,8 @@ func runFixture(cfg config) (loadSummary, error) {
 	if err != nil {
 		return loadSummary{}, err
 	}
+	collectionMeta := collection.Meta()
+	bufferedIndexedWrites := collectionMeta.Options.BufferedIndexedWrites
 
 	var insertStats collections.CollectionInsertStats
 	secondaryRuns := make(map[string]*secondaryRunSummary)
@@ -521,7 +523,7 @@ func runFixture(cfg config) (loadSummary, error) {
 		inserted += batchSize
 
 		if cfg.CheckpointEachBatch {
-			if cfg.BufferedIndexedWrites && cfg.IndexCount > 0 {
+			if bufferedIndexedWrites {
 				flushStart := time.Now()
 				if err := collection.Flush(); err != nil {
 					return loadSummary{}, fmt.Errorf("flush after batch %d: %w", batches, err)
@@ -619,9 +621,9 @@ func runFixture(cfg config) (loadSummary, error) {
 		BatchSize:                     cfg.BatchSize,
 		Batches:                       batches,
 		IndexCount:                    cfg.IndexCount,
-		BufferedIndexedWrites:         cfg.BufferedIndexedWrites,
-		BufferedIndexedWriteMaxDocs:   cfg.BufferedIndexedWriteMaxDocs,
-		BufferedIndexedWriteMaxBytes:  cfg.BufferedIndexedWriteMaxBytes,
+		BufferedIndexedWrites:         collectionMeta.Options.BufferedIndexedWrites,
+		BufferedIndexedWriteMaxDocs:   collectionMeta.Options.BufferedIndexedWriteMaxDocuments,
+		BufferedIndexedWriteMaxBytes:  collectionMeta.Options.BufferedIndexedWriteMaxBytes,
 		DataOuterLeavesInValueLog:     cfg.DataOuterLeavesInValueLog,
 		IndexOuterLeavesInValueLog:    cfg.IndexOuterLeavesInValueLog,
 		ChunkSize:                     cfg.ChunkSize,
@@ -736,15 +738,22 @@ func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Co
 	for i := range indexes {
 		indexes[i].StoragePolicy = rootStoragePolicy(cfg.IndexOuterLeavesInValueLog)
 	}
+	bufferedIndexedWrites := cfg.BufferedIndexedWrites && cfg.IndexCount > 0
+	bufferedIndexedWriteMaxDocs := 0
+	var bufferedIndexedWriteMaxBytes int64
+	if bufferedIndexedWrites {
+		bufferedIndexedWriteMaxDocs = cfg.BufferedIndexedWriteMaxDocs
+		bufferedIndexedWriteMaxBytes = cfg.BufferedIndexedWriteMaxBytes
+	}
 	_, err := manager.CreateCollection(&collections.CollectionMeta{
 		Name: cfg.Collection,
 		Options: collections.CollectionOptions{
 			DocumentFormat:                   cfg.DocumentFormat,
 			DataRootStoragePolicy:            rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
 			IndexStateStoragePolicy:          rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
-			BufferedIndexedWrites:            cfg.BufferedIndexedWrites && cfg.IndexCount > 0,
-			BufferedIndexedWriteMaxDocuments: cfg.BufferedIndexedWriteMaxDocs,
-			BufferedIndexedWriteMaxBytes:     cfg.BufferedIndexedWriteMaxBytes,
+			BufferedIndexedWrites:            bufferedIndexedWrites,
+			BufferedIndexedWriteMaxDocuments: bufferedIndexedWriteMaxDocs,
+			BufferedIndexedWriteMaxBytes:     bufferedIndexedWriteMaxBytes,
 		},
 		Indexes: indexes,
 	})

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -140,6 +140,34 @@ func TestRunFixtureKeepsTemplateV1ThreeIndexDatabase(t *testing.T) {
 	}
 }
 
+func TestRunFixtureReportsBufferedIndexedWritesOnlyWhenIndexesUseThem(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "fixture")
+	cfg, err := parseConfig([]string{
+		"-dir", dir,
+		"-docs", "8",
+		"-batch-size", "4",
+		"-indexes", "0",
+		"-buffered-indexed-writes",
+		"-buffered-indexed-write-max-docs", "16",
+		"-buffered-indexed-write-max-bytes", "1024",
+		"-reopen-verify=false",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	summary, err := runFixture(cfg)
+	if err != nil {
+		t.Fatalf("run fixture: %v", err)
+	}
+	if summary.BufferedIndexedWrites {
+		t.Fatal("expected indexed buffering to be reported disabled for zero-index fixture")
+	}
+	if summary.BufferedIndexedWriteMaxDocs != 0 || summary.BufferedIndexedWriteMaxBytes != 0 {
+		t.Fatalf("buffered limits docs=%d bytes=%d want both zero", summary.BufferedIndexedWriteMaxDocs, summary.BufferedIndexedWriteMaxBytes)
+	}
+}
+
 func TestLeafGenerationSummaryOmittedWhenDisabled(t *testing.T) {
 	leafGeneration, err := maybePackLeafGenerations(config{}, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary

- adds max-doc and max-byte flush thresholds for opt-in indexed collection write buffers
- tracks approximate staged root-run bytes and rolls back newly staged runs if an automatic threshold flush fails
- skips rollback checkpoint cloning when auto-flush thresholds are disabled, keeping the unbounded opt-in hot path lean
- adds collision-checked pending primary-ID and unique-value indexes so buffered conflict checks do not scan every staged run
- exposes threshold knobs in collection benchmarks and `collection-load-fixture`
- reports effective fixture buffering options from the created collection metadata, so `-indexes=0` cannot claim indexed buffering that did not run

## Validation

- `go test ./TreeDB/collections -run 'TestCollectionIndexedWriteMemtables' -count 1`
- `go test ./TreeDB/collections -run 'TestBufferedPrimaryIDArenaCapAvoidsOverflow|TestCollectionIndexedWriteMemtables' -count 1`
- `go test ./TreeDB/collections ./cmd/collection_load_fixture -count 1`
- `go test ./cmd/collection_load_fixture -run 'TestRunFixtureReportsBufferedIndexedWritesOnlyWhenIndexesUseThem|TestRunFixtureKeepsTemplateV1' -count 1`
- `go test ./TreeDB/caching -run '^TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity$' -count 1`
- `go test ./TreeDB/caching -count 1`
- `go test ./... -count 1`
  - broad run had one unrelated transient in `TreeDB/caching`: `TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity`, with output `checkpoint kick rewrite runs="0" want 1`; rerunning that exact test and then `go test ./TreeDB/caching -count 1` both passed.
- `TREEDB_COLLECTION_BENCH_BATCH_SIZE=800 TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionShapeInsertBatch$/^indexes_2$' -benchtime=100000x -count=1 -timeout 30m`
  - baseline: `1809 ns/op`, `151.7 disk_bytes/doc`, `1417 publish_ns/doc`, `0 allocs/op`
- `TREEDB_COLLECTION_BENCH_BATCH_SIZE=800 TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 TREEDB_COLLECTION_BUFFERED_INDEXED_WRITES=true TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS=64000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionShapeInsertBatch$/^indexes_2$' -benchtime=100000x -count=1 -timeout 30m`
  - bounded buffered best focused run: `1261 ns/op`, `108.6 disk_bytes/doc`, `406.5 publish_ns/doc`, `0 allocs/op`
  - later local rerun after review cleanup was noisier but still preserved storage/alloc behavior: `1796 ns/op`, `108.6 disk_bytes/doc`, `560.3 publish_ns/doc`, `0 allocs/op`
- `RUN_DIR=/tmp/treedb_buffered_limit_64k_smoke_1777539468 && go run ./cmd/collection_load_fixture -dir "$RUN_DIR" -reset -docs 100000 -batch-size 800 -format template-v1 -indexes 2 -buffered-indexed-writes -buffered-indexed-write-max-docs 64000 -progress=false -json`
  - insert phase: `812,063 docs/sec`; final size `83.60 B/doc`; reopen verification passed
- `RUN_DIR=/tmp/treedb_baseline_800_smoke_1777539037 && go run ./cmd/collection_load_fixture -dir "$RUN_DIR" -reset -docs 100000 -batch-size 800 -format template-v1 -indexes 2 -progress=false -json`
  - insert phase: `417,409 docs/sec`; final size `165.51 B/doc`; reopen verification passed

## Notes

The focused benchmark favors a 64k staged-doc threshold for the 800-doc batch shape once pending primary/unique conflict checks use hash indexes. Fixture output should still be read with the insert/flush split in mind: bounded buffering intentionally moves part of the publish cost to the flush boundary.
