### PR TITLE
Make indexed collection memtables native

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -26,6 +26,14 @@ import (
 const (
 	collectionMetaVersion        = 1
 	maxCollectionMutationRetries = 64
+
+	// DefaultIndexedWriteMemtableMaxDocuments bounds the native indexed
+	// collection write-domain before it auto-flushes to persistent roots.
+	DefaultIndexedWriteMemtableMaxDocuments = 64000
+	// DefaultIndexedWriteMemtableDirectBatchDocuments keeps large, already
+	// well-amortized InsertBatch calls on the immediate publish path. Smaller
+	// batches use the indexed write-domain memtable path by default.
+	DefaultIndexedWriteMemtableDirectBatchDocuments = DefaultIndexedWriteMemtableMaxDocuments / 4
 )
 
 var (
@@ -116,11 +124,13 @@ type Collection struct {
 // CollectionInsertStats captures phase timings and counters from the most
 // recent successful InsertBatch call on a Collection handle.
 type CollectionInsertStats struct {
-	Documents            int
-	Indexes              int
-	Runs                 int
-	PrepareDocuments     time.Duration
-	IndexStateExtraction time.Duration
+	Documents                    int
+	Indexes                      int
+	Runs                         int
+	BufferedIndexedBatches       int
+	BufferedIndexedBypassBatches int
+	PrepareDocuments             time.Duration
+	IndexStateExtraction         time.Duration
 	// DuplicateDocumentPreflight includes duplicate-ID detection and
 	// existing-document conflict checks.
 	DuplicateDocumentPreflight time.Duration
@@ -175,14 +185,20 @@ type CollectionOptions struct {
 	DocumentFormat          DocumentFormat    `json:"document_format,omitempty"`
 	DataRootStoragePolicy   RootStoragePolicy `json:"data_root_storage_policy,omitempty"`
 	IndexStateStoragePolicy RootStoragePolicy `json:"index_state_storage_policy,omitempty"`
-	// BufferedIndexedWrites stages indexed InsertBatch root deltas in the
-	// collection write domain until Flush/Close. Staged writes are visible to
-	// primary and secondary reads on the same manager, but durability remains at
-	// the explicit flush boundary, matching the existing no-index buffered path.
+	// DisableIndexedWriteMemtables opts an indexed collection out of the native
+	// write-domain memtable path. It is intended for debugging and baseline
+	// comparisons; indexed collections use memtables by default.
+	DisableIndexedWriteMemtables bool `json:"disable_indexed_write_memtables,omitempty"`
+	// BufferedIndexedWrites is normalized metadata describing whether indexed
+	// InsertBatch root deltas are staged in the collection write domain before
+	// Flush/Close or auto-flush. Staged writes are visible to primary and
+	// secondary reads on the same manager, but durability remains at the flush
+	// boundary, matching the existing no-index buffered path.
 	BufferedIndexedWrites bool `json:"buffered_indexed_writes,omitempty"`
 	// BufferedIndexedWriteMaxDocuments flushes indexed write buffers once this
-	// many staged documents are pending. Zero leaves flushing to explicit
-	// Flush/Close calls.
+	// many staged documents are pending. Zero uses the native default for indexed
+	// memtables unless DisableIndexedWriteMemtables is set or the schema has no
+	// indexes.
 	BufferedIndexedWriteMaxDocuments int `json:"buffered_indexed_write_max_documents,omitempty"`
 	// BufferedIndexedWriteMaxBytes flushes indexed write buffers once the staged
 	// root-run payload estimate reaches this many bytes. Zero leaves flushing to
@@ -1049,6 +1065,17 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 
 func (c *Collection) shouldBufferIndexedInserts(meta CollectionMeta) bool {
 	return c != nil && c.writeDomain != nil && meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
+}
+
+func (c *Collection) shouldBufferIndexedInsertBatch(meta CollectionMeta, documentCount int) bool {
+	if !c.shouldBufferIndexedInserts(meta) {
+		return false
+	}
+	if documentCount >= DefaultIndexedWriteMemtableDirectBatchDocuments &&
+		meta.Options.BufferedIndexedWriteMaxDocuments == DefaultIndexedWriteMemtableMaxDocuments {
+		return false
+	}
+	return true
 }
 
 func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, baseCommitSeq, baseSystemRoot uint64, plan *insertBatchPlan) (time.Duration, error) {
@@ -2099,6 +2126,39 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 		return nil, err
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
+	indexedMemtablesEnabled := c.shouldBufferIndexedInserts(c.meta)
+	bufferIndexedInserts := c.shouldBufferIndexedInsertBatch(c.meta, len(documents))
+	if indexedMemtablesEnabled && !bufferIndexedInserts {
+		_ = snap.Close()
+		if err := c.flushBufferedWrites(); err != nil {
+			return nil, err
+		}
+		snap = c.db.AcquireSnapshot()
+		if snap == nil {
+			return nil, backenddb.ErrClosed
+		}
+		catalog, err = c.catalogForSnapshot(snap)
+		if err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		if catalog == nil {
+			_ = snap.Close()
+			return nil, errCollectionNotFound
+		}
+		c.meta = catalog.meta
+		plannerOptions, err = collectionPlannerOptions(c.meta)
+		if err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
+		indexedMemtablesEnabled = c.shouldBufferIndexedInserts(c.meta)
+		bufferIndexedInserts = c.shouldBufferIndexedInsertBatch(c.meta, len(documents))
+	}
+	if bufferIndexedInserts {
+		plannerOptions = collectionOptionsWithBufferedTemplateV1Resolver(plannerOptions, c.writeDomain, c.meta.Name)
+	}
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 
@@ -2114,6 +2174,10 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 		indexes:        plannerIndexes(c.meta.Indexes),
 		options:        plannerOptions,
 	}
+	if bufferIndexedInserts {
+		planner.buildPrimaryVal = clonePrimaryDocument
+		planner.cloneTemplateRunValues = true
+	}
 	plan, err := planner.planInsertBatchWithPreflight(ids, documents, insertBatchPreflight{
 		snapshot:           snap,
 		primaryRootID:      catalog.rootID(collectionPrimaryRootName(c.meta.Name)),
@@ -2123,13 +2187,24 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 		_ = snap.Close()
 		return nil, err
 	}
+	if bufferIndexedInserts {
+		plan.stats.BufferedIndexedBatches = 1
+	} else if indexedMemtablesEnabled {
+		plan.stats.BufferedIndexedBypassBatches = 1
+	}
 	if len(plan.runs) == 0 {
 		_ = snap.Close()
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
 		return plan.resultIDs, nil
 	}
 
-	if c.shouldBufferIndexedInserts(c.meta) {
+	if bufferIndexedInserts {
+		resultIDs, err := cloneBatchDocumentIDs(plan.resultIDs)
+		if err != nil {
+			_ = snap.Close()
+			resetCollectionRunTables(plan.runs)
+			return nil, err
+		}
 		bufferFlushElapsed, err := c.bufferIndexedInsertPlanLocked(catalog, baseCommitSeq, baseSystemRoot, plan)
 		_ = snap.Close()
 		if err != nil {
@@ -2138,7 +2213,7 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 		}
 		plan.stats.Publish += bufferFlushElapsed
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
-		return plan.resultIDs, nil
+		return resultIDs, nil
 	}
 
 	baseRootIDs := make(map[string]uint64, len(plan.runs))
@@ -3401,6 +3476,17 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err := c.flushBufferedNoIndex(); err != nil {
 		return nil, false, err
 	}
+	domain := c.writeDomain
+	domainLocked := false
+	if domain != nil {
+		domain.mu.RLock()
+		domainLocked = true
+		defer func() {
+			if domainLocked {
+				domain.mu.RUnlock()
+			}
+		}()
+	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
 		return nil, false, backenddb.ErrClosed
@@ -3426,12 +3512,14 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err != nil {
 		return nil, false, err
 	}
-	out, truncated, err := c.bufferedIndexIDs(indexName, prefix, maxResults)
+	collectLimit := collectionIndexReadCollectLimit(maxResults)
+	bufferedIDs, bufferedTruncated, err := c.bufferedIndexIDsLocked(domain, catalog.meta.Name, indexName, prefix, collectLimit)
 	if err != nil {
 		return nil, false, err
 	}
-	if maxResults > 0 && truncated {
-		return out, true, nil
+	if domainLocked {
+		domain.mu.RUnlock()
+		domainLocked = false
 	}
 	// Buffered indexed writes currently stage inserts only. Primary conflict
 	// checks reject IDs that already exist in pending or persisted roots, so
@@ -3440,48 +3528,43 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	// tombstones before returning persisted rows.
 	rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
 	if rootID == 0 {
+		out, truncated := mergeCollectionIndexIDResults(bufferedIDs, nil, maxResults, bufferedTruncated, false)
 		return out, truncated, nil
 	}
 	it, err := snap.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
 	if errors.Is(err, tree.ErrKeyNotFound) {
+		out, truncated := mergeCollectionIndexIDResults(bufferedIDs, nil, maxResults, bufferedTruncated, false)
 		return out, truncated, nil
 	}
 	if err != nil {
 		return nil, false, err
 	}
 	defer func() { _ = it.Close() }()
-	for it.Valid() {
-		key := it.UnsafeKey()
-		if !bytes.HasPrefix(key, prefix) {
-			break
-		}
-		if !it.IsDeleted() {
-			id := key[len(prefix):]
-			if maxResults > 0 && len(out) >= maxResults {
-				truncated = true
-				break
-			}
-			out = append(out, bytes.Clone(id))
-		}
-		it.Next()
-	}
-	if err := it.Error(); err != nil {
+	persistedIDs, persistedTruncated, err := collectCollectionIndexIDsFromIterator(it, prefix, collectLimit)
+	if err != nil {
 		return nil, false, err
 	}
+	out, truncated := mergeCollectionIndexIDResults(bufferedIDs, persistedIDs, maxResults, bufferedTruncated, persistedTruncated)
 	return out, truncated, nil
 }
 
-func (c *Collection) bufferedIndexIDs(indexName string, prefix []byte, maxResults int) ([][]byte, bool, error) {
-	if c == nil || c.writeDomain == nil {
+func collectionIndexReadCollectLimit(maxResults int) int {
+	if maxResults <= 0 {
+		return 0
+	}
+	if maxResults == int(^uint(0)>>1) {
+		return 0
+	}
+	return maxResults + 1
+}
+
+func (c *Collection) bufferedIndexIDsLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte, limit int) ([][]byte, bool, error) {
+	if c == nil || domain == nil {
 		return nil, false, nil
 	}
-	domain := c.writeDomain
-	domain.mu.RLock()
-	defer domain.mu.RUnlock()
 	if domain.count == 0 || len(domain.rootRuns) == 0 {
 		return nil, false, nil
 	}
-	collectionName := c.meta.Name
 	if domain.meta.Name != "" {
 		collectionName = domain.meta.Name
 	}
@@ -3491,6 +3574,13 @@ func (c *Collection) bufferedIndexIDs(indexName string, prefix []byte, maxResult
 	}
 	it := newBufferedRootRunsIterator(runs, prefix, prefixEnd(prefix))
 	defer func() { _ = it.Close() }()
+	return collectCollectionIndexIDsFromIterator(it, prefix, limit)
+}
+
+func collectCollectionIndexIDsFromIterator(it iterator.UnsafeIterator, prefix []byte, limit int) ([][]byte, bool, error) {
+	if it == nil {
+		return nil, false, nil
+	}
 	out := make([][]byte, 0, 1)
 	truncated := false
 	for it.Valid() {
@@ -3499,7 +3589,7 @@ func (c *Collection) bufferedIndexIDs(indexName string, prefix []byte, maxResult
 			break
 		}
 		if !it.IsDeleted() {
-			if maxResults > 0 && len(out) >= maxResults {
+			if limit > 0 && len(out) >= limit {
 				truncated = true
 				break
 			}
@@ -3511,6 +3601,51 @@ func (c *Collection) bufferedIndexIDs(indexName string, prefix []byte, maxResult
 		return nil, false, err
 	}
 	return out, truncated, nil
+}
+
+func mergeCollectionIndexIDResults(bufferedIDs, persistedIDs [][]byte, maxResults int, bufferedTruncated, persistedTruncated bool) ([][]byte, bool) {
+	total := len(bufferedIDs) + len(persistedIDs)
+	limit := collectionIndexReadCollectLimit(maxResults)
+	if limit > 0 && total > limit {
+		total = limit
+	}
+	out := make([][]byte, 0, total)
+	truncated := bufferedTruncated || persistedTruncated
+	i, j := 0, 0
+	appendID := func(id []byte) {
+		if len(out) > 0 && bytes.Equal(out[len(out)-1], id) {
+			return
+		}
+		out = append(out, id)
+	}
+	for (i < len(bufferedIDs) || j < len(persistedIDs)) && (limit == 0 || len(out) < limit) {
+		switch {
+		case i >= len(bufferedIDs):
+			appendID(persistedIDs[j])
+			j++
+		case j >= len(persistedIDs):
+			appendID(bufferedIDs[i])
+			i++
+		default:
+			cmp := bytes.Compare(bufferedIDs[i], persistedIDs[j])
+			if cmp < 0 {
+				appendID(bufferedIDs[i])
+				i++
+			} else if cmp > 0 {
+				appendID(persistedIDs[j])
+				j++
+			} else {
+				appendID(bufferedIDs[i])
+				i++
+				j++
+			}
+		}
+	}
+	if maxResults > 0 && len(out) > maxResults {
+		out = out[:maxResults]
+		truncated = true
+	}
+	return out, truncated
 }
 
 // ScanDocuments flushes buffered writes before acquiring a snapshot, then scans
@@ -3857,6 +3992,12 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 	if _, err := backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy); err != nil {
 		return CollectionMeta{}, err
 	}
+	if meta.Options.BufferedIndexedWriteMaxDocuments < 0 {
+		return CollectionMeta{}, errors.New("collections: buffered indexed write max documents cannot be negative")
+	}
+	if meta.Options.BufferedIndexedWriteMaxBytes < 0 {
+		return CollectionMeta{}, errors.New("collections: buffered indexed write max bytes cannot be negative")
+	}
 	documentFormat, err := normalizeDocumentFormat(meta.Options.DocumentFormat)
 	if err != nil {
 		return CollectionMeta{}, err
@@ -3887,6 +4028,16 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		seen[indexes[i].Name] = struct{}{}
 	}
 	meta.Indexes = indexes
+	if len(meta.Indexes) == 0 || meta.Options.DisableIndexedWriteMemtables {
+		meta.Options.BufferedIndexedWrites = false
+		meta.Options.BufferedIndexedWriteMaxDocuments = 0
+		meta.Options.BufferedIndexedWriteMaxBytes = 0
+	} else {
+		meta.Options.BufferedIndexedWrites = true
+		if meta.Options.BufferedIndexedWriteMaxDocuments == 0 && meta.Options.BufferedIndexedWriteMaxBytes == 0 {
+			meta.Options.BufferedIndexedWriteMaxDocuments = DefaultIndexedWriteMemtableMaxDocuments
+		}
+	}
 	return meta, nil
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -26,6 +26,14 @@ import (
 const (
 	collectionMetaVersion        = 1
 	maxCollectionMutationRetries = 64
+
+	// DefaultIndexedWriteMemtableMaxDocuments bounds the native indexed
+	// collection write-domain before it auto-flushes to persistent roots.
+	DefaultIndexedWriteMemtableMaxDocuments = 64000
+	// DefaultIndexedWriteMemtableDirectBatchDocuments keeps large, already
+	// well-amortized InsertBatch calls on the immediate publish path. Smaller
+	// batches use the indexed write-domain memtable path by default.
+	DefaultIndexedWriteMemtableDirectBatchDocuments = DefaultIndexedWriteMemtableMaxDocuments / 4
 )
 
 var (
@@ -116,11 +124,13 @@ type Collection struct {
 // CollectionInsertStats captures phase timings and counters from the most
 // recent successful InsertBatch call on a Collection handle.
 type CollectionInsertStats struct {
-	Documents            int
-	Indexes              int
-	Runs                 int
-	PrepareDocuments     time.Duration
-	IndexStateExtraction time.Duration
+	Documents                    int
+	Indexes                      int
+	Runs                         int
+	BufferedIndexedBatches       int
+	BufferedIndexedBypassBatches int
+	PrepareDocuments             time.Duration
+	IndexStateExtraction         time.Duration
 	// DuplicateDocumentPreflight includes duplicate-ID detection and
 	// existing-document conflict checks.
 	DuplicateDocumentPreflight time.Duration
@@ -175,14 +185,20 @@ type CollectionOptions struct {
 	DocumentFormat          DocumentFormat    `json:"document_format,omitempty"`
 	DataRootStoragePolicy   RootStoragePolicy `json:"data_root_storage_policy,omitempty"`
 	IndexStateStoragePolicy RootStoragePolicy `json:"index_state_storage_policy,omitempty"`
-	// BufferedIndexedWrites stages indexed InsertBatch root deltas in the
-	// collection write domain until Flush/Close. Staged writes are visible to
-	// primary and secondary reads on the same manager, but durability remains at
-	// the explicit flush boundary, matching the existing no-index buffered path.
+	// DisableIndexedWriteMemtables opts an indexed collection out of the native
+	// write-domain memtable path. It is intended for debugging and baseline
+	// comparisons; indexed collections use memtables by default.
+	DisableIndexedWriteMemtables bool `json:"disable_indexed_write_memtables,omitempty"`
+	// BufferedIndexedWrites is normalized metadata describing whether indexed
+	// InsertBatch root deltas are staged in the collection write domain before
+	// Flush/Close or auto-flush. Staged writes are visible to primary and
+	// secondary reads on the same manager, but durability remains at the flush
+	// boundary, matching the existing no-index buffered path.
 	BufferedIndexedWrites bool `json:"buffered_indexed_writes,omitempty"`
 	// BufferedIndexedWriteMaxDocuments flushes indexed write buffers once this
-	// many staged documents are pending. Zero leaves flushing to explicit
-	// Flush/Close calls.
+	// many staged documents are pending. Zero uses the native default for indexed
+	// memtables unless DisableIndexedWriteMemtables is set or the schema has no
+	// indexes.
 	BufferedIndexedWriteMaxDocuments int `json:"buffered_indexed_write_max_documents,omitempty"`
 	// BufferedIndexedWriteMaxBytes flushes indexed write buffers once the staged
 	// root-run payload estimate reaches this many bytes. Zero leaves flushing to
@@ -1049,6 +1065,17 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 
 func (c *Collection) shouldBufferIndexedInserts(meta CollectionMeta) bool {
 	return c != nil && c.writeDomain != nil && meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
+}
+
+func (c *Collection) shouldBufferIndexedInsertBatch(meta CollectionMeta, documentCount int) bool {
+	if !c.shouldBufferIndexedInserts(meta) {
+		return false
+	}
+	if documentCount >= DefaultIndexedWriteMemtableDirectBatchDocuments &&
+		meta.Options.BufferedIndexedWriteMaxDocuments == DefaultIndexedWriteMemtableMaxDocuments {
+		return false
+	}
+	return true
 }
 
 func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, baseCommitSeq, baseSystemRoot uint64, plan *insertBatchPlan) (time.Duration, error) {
@@ -2099,6 +2126,39 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 		return nil, err
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
+	indexedMemtablesEnabled := c.shouldBufferIndexedInserts(c.meta)
+	bufferIndexedInserts := c.shouldBufferIndexedInsertBatch(c.meta, len(documents))
+	if indexedMemtablesEnabled && !bufferIndexedInserts {
+		_ = snap.Close()
+		if err := c.flushBufferedWrites(); err != nil {
+			return nil, err
+		}
+		snap = c.db.AcquireSnapshot()
+		if snap == nil {
+			return nil, backenddb.ErrClosed
+		}
+		catalog, err = c.catalogForSnapshot(snap)
+		if err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		if catalog == nil {
+			_ = snap.Close()
+			return nil, errCollectionNotFound
+		}
+		c.meta = catalog.meta
+		plannerOptions, err = collectionPlannerOptions(c.meta)
+		if err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
+		indexedMemtablesEnabled = c.shouldBufferIndexedInserts(c.meta)
+		bufferIndexedInserts = c.shouldBufferIndexedInsertBatch(c.meta, len(documents))
+	}
+	if bufferIndexedInserts {
+		plannerOptions = collectionOptionsWithBufferedTemplateV1Resolver(plannerOptions, c.writeDomain, c.meta.Name)
+	}
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 
@@ -2114,6 +2174,10 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 		indexes:        plannerIndexes(c.meta.Indexes),
 		options:        plannerOptions,
 	}
+	if bufferIndexedInserts {
+		planner.buildPrimaryVal = clonePrimaryDocument
+		planner.cloneTemplateRunValues = true
+	}
 	plan, err := planner.planInsertBatchWithPreflight(ids, documents, insertBatchPreflight{
 		snapshot:           snap,
 		primaryRootID:      catalog.rootID(collectionPrimaryRootName(c.meta.Name)),
@@ -2123,13 +2187,24 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 		_ = snap.Close()
 		return nil, err
 	}
+	if bufferIndexedInserts {
+		plan.stats.BufferedIndexedBatches = 1
+	} else if indexedMemtablesEnabled {
+		plan.stats.BufferedIndexedBypassBatches = 1
+	}
 	if len(plan.runs) == 0 {
 		_ = snap.Close()
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
 		return plan.resultIDs, nil
 	}
 
-	if c.shouldBufferIndexedInserts(c.meta) {
+	if bufferIndexedInserts {
+		resultIDs, err := cloneBatchDocumentIDs(plan.resultIDs)
+		if err != nil {
+			_ = snap.Close()
+			resetCollectionRunTables(plan.runs)
+			return nil, err
+		}
 		bufferFlushElapsed, err := c.bufferIndexedInsertPlanLocked(catalog, baseCommitSeq, baseSystemRoot, plan)
 		_ = snap.Close()
 		if err != nil {
@@ -2138,7 +2213,7 @@ func (c *Collection) InsertBatch(ids, documents [][]byte) ([][]byte, error) {
 		}
 		plan.stats.Publish += bufferFlushElapsed
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
-		return plan.resultIDs, nil
+		return resultIDs, nil
 	}
 
 	baseRootIDs := make(map[string]uint64, len(plan.runs))
@@ -3401,6 +3476,17 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err := c.flushBufferedNoIndex(); err != nil {
 		return nil, false, err
 	}
+	domain := c.writeDomain
+	domainLocked := false
+	if domain != nil {
+		domain.mu.RLock()
+		domainLocked = true
+		defer func() {
+			if domainLocked {
+				domain.mu.RUnlock()
+			}
+		}()
+	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
 		return nil, false, backenddb.ErrClosed
@@ -3426,12 +3512,14 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err != nil {
 		return nil, false, err
 	}
-	out, truncated, err := c.bufferedIndexIDs(indexName, prefix, maxResults)
+	collectLimit := collectionIndexReadCollectLimit(maxResults)
+	bufferedIDs, bufferedTruncated, err := c.bufferedIndexIDsLocked(domain, catalog.meta.Name, indexName, prefix, collectLimit)
 	if err != nil {
 		return nil, false, err
 	}
-	if maxResults > 0 && truncated {
-		return out, true, nil
+	if domainLocked {
+		domain.mu.RUnlock()
+		domainLocked = false
 	}
 	// Buffered indexed writes currently stage inserts only. Primary conflict
 	// checks reject IDs that already exist in pending or persisted roots, so
@@ -3440,48 +3528,40 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	// tombstones before returning persisted rows.
 	rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
 	if rootID == 0 {
+		out, truncated := mergeCollectionIndexIDResults(bufferedIDs, nil, maxResults, bufferedTruncated, false)
 		return out, truncated, nil
 	}
 	it, err := snap.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
 	if errors.Is(err, tree.ErrKeyNotFound) {
+		out, truncated := mergeCollectionIndexIDResults(bufferedIDs, nil, maxResults, bufferedTruncated, false)
 		return out, truncated, nil
 	}
 	if err != nil {
 		return nil, false, err
 	}
 	defer func() { _ = it.Close() }()
-	for it.Valid() {
-		key := it.UnsafeKey()
-		if !bytes.HasPrefix(key, prefix) {
-			break
-		}
-		if !it.IsDeleted() {
-			id := key[len(prefix):]
-			if maxResults > 0 && len(out) >= maxResults {
-				truncated = true
-				break
-			}
-			out = append(out, bytes.Clone(id))
-		}
-		it.Next()
-	}
-	if err := it.Error(); err != nil {
+	persistedIDs, persistedTruncated, err := collectCollectionIndexIDsFromIterator(it, prefix, collectLimit)
+	if err != nil {
 		return nil, false, err
 	}
+	out, truncated := mergeCollectionIndexIDResults(bufferedIDs, persistedIDs, maxResults, bufferedTruncated, persistedTruncated)
 	return out, truncated, nil
 }
 
-func (c *Collection) bufferedIndexIDs(indexName string, prefix []byte, maxResults int) ([][]byte, bool, error) {
-	if c == nil || c.writeDomain == nil {
+func collectionIndexReadCollectLimit(maxResults int) int {
+	if maxResults <= 0 {
+		return 0
+	}
+	return maxResults + 1
+}
+
+func (c *Collection) bufferedIndexIDsLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte, limit int) ([][]byte, bool, error) {
+	if c == nil || domain == nil {
 		return nil, false, nil
 	}
-	domain := c.writeDomain
-	domain.mu.RLock()
-	defer domain.mu.RUnlock()
 	if domain.count == 0 || len(domain.rootRuns) == 0 {
 		return nil, false, nil
 	}
-	collectionName := c.meta.Name
 	if domain.meta.Name != "" {
 		collectionName = domain.meta.Name
 	}
@@ -3491,6 +3571,13 @@ func (c *Collection) bufferedIndexIDs(indexName string, prefix []byte, maxResult
 	}
 	it := newBufferedRootRunsIterator(runs, prefix, prefixEnd(prefix))
 	defer func() { _ = it.Close() }()
+	return collectCollectionIndexIDsFromIterator(it, prefix, limit)
+}
+
+func collectCollectionIndexIDsFromIterator(it iterator.UnsafeIterator, prefix []byte, limit int) ([][]byte, bool, error) {
+	if it == nil {
+		return nil, false, nil
+	}
 	out := make([][]byte, 0, 1)
 	truncated := false
 	for it.Valid() {
@@ -3499,7 +3586,7 @@ func (c *Collection) bufferedIndexIDs(indexName string, prefix []byte, maxResult
 			break
 		}
 		if !it.IsDeleted() {
-			if maxResults > 0 && len(out) >= maxResults {
+			if limit > 0 && len(out) >= limit {
 				truncated = true
 				break
 			}
@@ -3511,6 +3598,54 @@ func (c *Collection) bufferedIndexIDs(indexName string, prefix []byte, maxResult
 		return nil, false, err
 	}
 	return out, truncated, nil
+}
+
+func mergeCollectionIndexIDResults(bufferedIDs, persistedIDs [][]byte, maxResults int, bufferedTruncated, persistedTruncated bool) ([][]byte, bool) {
+	total := len(bufferedIDs) + len(persistedIDs)
+	if maxResults > 0 && total > maxResults+1 {
+		total = maxResults + 1
+	}
+	out := make([][]byte, 0, total)
+	truncated := bufferedTruncated || persistedTruncated
+	i, j := 0, 0
+	appendID := func(id []byte) {
+		if len(out) > 0 && bytes.Equal(out[len(out)-1], id) {
+			return
+		}
+		out = append(out, id)
+	}
+	limit := 0
+	if maxResults > 0 {
+		limit = maxResults + 1
+	}
+	for (i < len(bufferedIDs) || j < len(persistedIDs)) && (limit == 0 || len(out) < limit) {
+		switch {
+		case i >= len(bufferedIDs):
+			appendID(persistedIDs[j])
+			j++
+		case j >= len(persistedIDs):
+			appendID(bufferedIDs[i])
+			i++
+		default:
+			cmp := bytes.Compare(bufferedIDs[i], persistedIDs[j])
+			if cmp < 0 {
+				appendID(bufferedIDs[i])
+				i++
+			} else if cmp > 0 {
+				appendID(persistedIDs[j])
+				j++
+			} else {
+				appendID(bufferedIDs[i])
+				i++
+				j++
+			}
+		}
+	}
+	if maxResults > 0 && len(out) > maxResults {
+		out = out[:maxResults]
+		truncated = true
+	}
+	return out, truncated
 }
 
 // ScanDocuments flushes buffered writes before acquiring a snapshot, then scans
@@ -3857,6 +3992,12 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 	if _, err := backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy); err != nil {
 		return CollectionMeta{}, err
 	}
+	if meta.Options.BufferedIndexedWriteMaxDocuments < 0 {
+		return CollectionMeta{}, errors.New("collections: buffered indexed write max documents cannot be negative")
+	}
+	if meta.Options.BufferedIndexedWriteMaxBytes < 0 {
+		return CollectionMeta{}, errors.New("collections: buffered indexed write max bytes cannot be negative")
+	}
 	documentFormat, err := normalizeDocumentFormat(meta.Options.DocumentFormat)
 	if err != nil {
 		return CollectionMeta{}, err
@@ -3887,6 +4028,16 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		seen[indexes[i].Name] = struct{}{}
 	}
 	meta.Indexes = indexes
+	if len(meta.Indexes) == 0 || meta.Options.DisableIndexedWriteMemtables {
+		meta.Options.BufferedIndexedWrites = false
+		meta.Options.BufferedIndexedWriteMaxDocuments = 0
+		meta.Options.BufferedIndexedWriteMaxBytes = 0
+	} else {
+		meta.Options.BufferedIndexedWrites = true
+		if meta.Options.BufferedIndexedWriteMaxDocuments == 0 && meta.Options.BufferedIndexedWriteMaxBytes == 0 {
+			meta.Options.BufferedIndexedWriteMaxDocuments = DefaultIndexedWriteMemtableMaxDocuments
+		}
+	}
 	return meta, nil
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -108,6 +108,9 @@ func TestCollectionInsertBatchBridge_RoundTripWithSecondaryIndexes(t *testing.T)
 		t.Fatalf("find city: %v", err)
 	}
 	collectionMaintenanceRequireUnorderedIDs(t, cityIDs, []byte("u1"), []byte("u2"))
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush indexed memtables: %v", err)
+	}
 
 	snap := d.AcquireSnapshot()
 	if snap == nil {
@@ -330,6 +333,9 @@ func TestCollectionLeafGenerationPackGC_RoundTripWithTemplateV1SecondaryIndexes(
 		}
 	}
 	requireCollectionMaintenanceTemplateReads(t, col)
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush indexed memtables: %v", err)
+	}
 	if err := d.Checkpoint(); err != nil {
 		t.Fatalf("checkpoint: %v", err)
 	}
@@ -1282,6 +1288,166 @@ func TestCollectionIndexedWriteMemtablesReadUniqueAndFlush(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesDefaultForIndexedSchemas(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	meta, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if !meta.Options.BufferedIndexedWrites {
+		t.Fatal("indexed collection did not enable native write memtables by default")
+	}
+	if got := meta.Options.BufferedIndexedWriteMaxDocuments; got != DefaultIndexedWriteMemtableMaxDocuments {
+		t.Fatalf("default max docs=%d want %d", got, DefaultIndexedWriteMemtableMaxDocuments)
+	}
+	if got := meta.Options.BufferedIndexedWriteMaxBytes; got != 0 {
+		t.Fatalf("default max bytes=%d want 0", got)
+	}
+
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get buffered doc: %v", err)
+	}
+	if want := []byte(`{"city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("buffered doc=%q want %q", got, want)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got != 0 {
+		t.Fatalf("primary root persisted before flush: %d", got)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush default indexed memtable: %v", err)
+	}
+	snap = d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected post-flush snapshot")
+	}
+	catalog, err = loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load post-flush catalog: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
+		t.Fatal("primary root was not persisted after flush")
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesDefaultSkipsNoIndexSchemas(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	meta, err := NewCollectionManager(d).CreateCollection(&CollectionMeta{Name: "users"})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if meta.Options.BufferedIndexedWrites {
+		t.Fatal("no-index collection enabled indexed write memtables")
+	}
+	if meta.Options.BufferedIndexedWriteMaxDocuments != 0 || meta.Options.BufferedIndexedWriteMaxBytes != 0 {
+		t.Fatalf("no-index buffered limits docs=%d bytes=%d want zero",
+			meta.Options.BufferedIndexedWriteMaxDocuments, meta.Options.BufferedIndexedWriteMaxBytes)
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesCanBeDisabled(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	meta, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DisableIndexedWriteMemtables: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if meta.Options.BufferedIndexedWrites {
+		t.Fatal("disabled indexed write memtables reported enabled")
+	}
+	if meta.Options.BufferedIndexedWriteMaxDocuments != 0 || meta.Options.BufferedIndexedWriteMaxBytes != 0 {
+		t.Fatalf("disabled buffered limits docs=%d bytes=%d want zero",
+			meta.Options.BufferedIndexedWriteMaxDocuments, meta.Options.BufferedIndexedWriteMaxBytes)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
+		t.Fatal("disabled indexed write memtables did not publish primary root immediately")
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesBypassDefaultLargeBatches(t *testing.T) {
+	col := &Collection{writeDomain: &collectionWriteDomain{}}
+	meta := CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: DefaultIndexedWriteMemtableMaxDocuments,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}
+	if !col.shouldBufferIndexedInsertBatch(meta, DefaultIndexedWriteMemtableDirectBatchDocuments-1) {
+		t.Fatal("default indexed memtable path bypassed a below-threshold batch")
+	}
+	if col.shouldBufferIndexedInsertBatch(meta, DefaultIndexedWriteMemtableDirectBatchDocuments) {
+		t.Fatal("default indexed memtable path buffered a large direct-publish batch")
+	}
+	meta.Options.BufferedIndexedWriteMaxDocuments = 2
+	if !col.shouldBufferIndexedInsertBatch(meta, 2) {
+		t.Fatal("explicit small flush threshold should not trigger the default large-batch bypass")
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesReadAfterDomainTableAllocated(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -1387,6 +1553,86 @@ func TestCollectionIndexedWriteMemtablesFindLimitExactBufferedCount(t *testing.T
 	}
 	if len(ids) != 1 {
 		t.Fatalf("over buffered limit returned %d ids want 1", len(ids))
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesFindLimitMergesBufferedAndPersistedOrder(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u0")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert persisted row: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush persisted row: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert buffered row: %v", err)
+	}
+	ids, truncated, err := col.FindByIndexValueLimit("city", "hnl", 1)
+	if err != nil {
+		t.Fatalf("find limited merged index rows: %v", err)
+	}
+	if !truncated || len(ids) != 1 || !bytes.Equal(ids[0], []byte("u0")) {
+		t.Fatalf("limited ids=%q truncated=%v want [u0]/true", ids, truncated)
+	}
+	ids, err = col.FindByIndexValue("city", "hnl")
+	if err != nil {
+		t.Fatalf("find merged index rows: %v", err)
+	}
+	if len(ids) != 2 || !bytes.Equal(ids[0], []byte("u0")) || !bytes.Equal(ids[1], []byte("u1")) {
+		t.Fatalf("merged ids=%q want [u0 u1]", ids)
+	}
+}
+
+func TestCollectionFindByIndexValueLimitMaxIntDoesNotOverflow(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert row: %v", err)
+	}
+	ids, truncated, err := col.FindByIndexValueLimit("city", "hnl", int(^uint(0)>>1))
+	if err != nil {
+		t.Fatalf("find max-int limit: %v", err)
+	}
+	if truncated || len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("max-int limited ids=%q truncated=%v want [u1]/false", ids, truncated)
 	}
 }
 
@@ -3127,6 +3373,9 @@ func TestCollectionUpdateSkipsIndexRootsWhenIndexedValuesUnchanged(t *testing.T)
 		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl","seen":false}`)},
 	); err != nil {
 		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush indexed memtables: %v", err)
 	}
 
 	loadCatalog := func() *collectionCatalog {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -108,6 +108,9 @@ func TestCollectionInsertBatchBridge_RoundTripWithSecondaryIndexes(t *testing.T)
 		t.Fatalf("find city: %v", err)
 	}
 	collectionMaintenanceRequireUnorderedIDs(t, cityIDs, []byte("u1"), []byte("u2"))
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush indexed memtables: %v", err)
+	}
 
 	snap := d.AcquireSnapshot()
 	if snap == nil {
@@ -330,6 +333,9 @@ func TestCollectionLeafGenerationPackGC_RoundTripWithTemplateV1SecondaryIndexes(
 		}
 	}
 	requireCollectionMaintenanceTemplateReads(t, col)
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush indexed memtables: %v", err)
+	}
 	if err := d.Checkpoint(); err != nil {
 		t.Fatalf("checkpoint: %v", err)
 	}
@@ -1282,6 +1288,166 @@ func TestCollectionIndexedWriteMemtablesReadUniqueAndFlush(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesDefaultForIndexedSchemas(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	meta, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if !meta.Options.BufferedIndexedWrites {
+		t.Fatal("indexed collection did not enable native write memtables by default")
+	}
+	if got := meta.Options.BufferedIndexedWriteMaxDocuments; got != DefaultIndexedWriteMemtableMaxDocuments {
+		t.Fatalf("default max docs=%d want %d", got, DefaultIndexedWriteMemtableMaxDocuments)
+	}
+	if got := meta.Options.BufferedIndexedWriteMaxBytes; got != 0 {
+		t.Fatalf("default max bytes=%d want 0", got)
+	}
+
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get buffered doc: %v", err)
+	}
+	if want := []byte(`{"city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("buffered doc=%q want %q", got, want)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got != 0 {
+		t.Fatalf("primary root persisted before flush: %d", got)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush default indexed memtable: %v", err)
+	}
+	snap = d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected post-flush snapshot")
+	}
+	catalog, err = loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load post-flush catalog: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
+		t.Fatal("primary root was not persisted after flush")
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesDefaultSkipsNoIndexSchemas(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	meta, err := NewCollectionManager(d).CreateCollection(&CollectionMeta{Name: "users"})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if meta.Options.BufferedIndexedWrites {
+		t.Fatal("no-index collection enabled indexed write memtables")
+	}
+	if meta.Options.BufferedIndexedWriteMaxDocuments != 0 || meta.Options.BufferedIndexedWriteMaxBytes != 0 {
+		t.Fatalf("no-index buffered limits docs=%d bytes=%d want zero",
+			meta.Options.BufferedIndexedWriteMaxDocuments, meta.Options.BufferedIndexedWriteMaxBytes)
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesCanBeDisabled(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	meta, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DisableIndexedWriteMemtables: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if meta.Options.BufferedIndexedWrites {
+		t.Fatal("disabled indexed write memtables reported enabled")
+	}
+	if meta.Options.BufferedIndexedWriteMaxDocuments != 0 || meta.Options.BufferedIndexedWriteMaxBytes != 0 {
+		t.Fatalf("disabled buffered limits docs=%d bytes=%d want zero",
+			meta.Options.BufferedIndexedWriteMaxDocuments, meta.Options.BufferedIndexedWriteMaxBytes)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
+		t.Fatal("disabled indexed write memtables did not publish primary root immediately")
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesBypassDefaultLargeBatches(t *testing.T) {
+	col := &Collection{writeDomain: &collectionWriteDomain{}}
+	meta := CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: DefaultIndexedWriteMemtableMaxDocuments,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}
+	if !col.shouldBufferIndexedInsertBatch(meta, DefaultIndexedWriteMemtableDirectBatchDocuments-1) {
+		t.Fatal("default indexed memtable path bypassed a below-threshold batch")
+	}
+	if col.shouldBufferIndexedInsertBatch(meta, DefaultIndexedWriteMemtableDirectBatchDocuments) {
+		t.Fatal("default indexed memtable path buffered a large direct-publish batch")
+	}
+	meta.Options.BufferedIndexedWriteMaxDocuments = 2
+	if !col.shouldBufferIndexedInsertBatch(meta, 2) {
+		t.Fatal("explicit small flush threshold should not trigger the default large-batch bypass")
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesReadAfterDomainTableAllocated(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -1387,6 +1553,54 @@ func TestCollectionIndexedWriteMemtablesFindLimitExactBufferedCount(t *testing.T
 	}
 	if len(ids) != 1 {
 		t.Fatalf("over buffered limit returned %d ids want 1", len(ids))
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesFindLimitMergesBufferedAndPersistedOrder(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u0")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert persisted row: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush persisted row: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert buffered row: %v", err)
+	}
+	ids, truncated, err := col.FindByIndexValueLimit("city", "hnl", 1)
+	if err != nil {
+		t.Fatalf("find limited merged index rows: %v", err)
+	}
+	if !truncated || len(ids) != 1 || !bytes.Equal(ids[0], []byte("u0")) {
+		t.Fatalf("limited ids=%q truncated=%v want [u0]/true", ids, truncated)
+	}
+	ids, err = col.FindByIndexValue("city", "hnl")
+	if err != nil {
+		t.Fatalf("find merged index rows: %v", err)
+	}
+	if len(ids) != 2 || !bytes.Equal(ids[0], []byte("u0")) || !bytes.Equal(ids[1], []byte("u1")) {
+		t.Fatalf("merged ids=%q want [u0 u1]", ids)
 	}
 }
 
@@ -3127,6 +3341,9 @@ func TestCollectionUpdateSkipsIndexRootsWhenIndexedValuesUnchanged(t *testing.T)
 		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl","seen":false}`)},
 	); err != nil {
 		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush indexed memtables: %v", err)
 	}
 
 	loadCatalog := func() *collectionCatalog {

--- a/TreeDB/collections/bench_test.go
+++ b/TreeDB/collections/bench_test.go
@@ -566,7 +566,7 @@ func openBenchmarkCollection(b *testing.B, name string, indexes ...collections.I
 	manager := collections.NewCollectionManager(backend)
 	dataOuter, indexOuter := benchmarkCollectionStoragePolicy(b)
 	documentFormat := benchmarkCollectionDocumentFormat(b)
-	bufferedIndexedWrites := benchmarkBoolEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITES", false) && len(indexes) > 0
+	bufferedIndexedWrites := benchmarkBoolEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITES", true) && len(indexes) > 0
 	bufferedIndexedWriteMaxDocuments := benchmarkIntEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", 0)
 	bufferedIndexedWriteMaxBytes := benchmarkInt64Env(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_BYTES", 0)
 	for i := range indexes {
@@ -578,6 +578,7 @@ func openBenchmarkCollection(b *testing.B, name string, indexes ...collections.I
 			DocumentFormat:                   documentFormat,
 			DataRootStoragePolicy:            benchmarkRootStoragePolicy(dataOuter),
 			IndexStateStoragePolicy:          benchmarkRootStoragePolicy(dataOuter),
+			DisableIndexedWriteMemtables:     !bufferedIndexedWrites && len(indexes) > 0,
 			BufferedIndexedWrites:            bufferedIndexedWrites,
 			BufferedIndexedWriteMaxDocuments: bufferedIndexedWriteMaxDocuments,
 			BufferedIndexedWriteMaxBytes:     bufferedIndexedWriteMaxBytes,

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -69,13 +69,14 @@ type indexDefinition struct {
 }
 
 type insertBatchPlanner struct {
-	collection      string
-	primaryRoot     string
-	templateRoot    string
-	indexStateRoot  string
-	indexes         []indexDefinition
-	options         collectionOptions
-	buildPrimaryVal func(documentID, document []byte) ([]byte, error)
+	collection             string
+	primaryRoot            string
+	templateRoot           string
+	indexStateRoot         string
+	indexes                []indexDefinition
+	options                collectionOptions
+	buildPrimaryVal        func(documentID, document []byte) ([]byte, error)
+	cloneTemplateRunValues bool
 }
 
 type insertBatchPlan struct {
@@ -341,6 +342,10 @@ func borrowPrimaryDocument(_, document []byte) ([]byte, error) {
 	return document, nil
 }
 
+func clonePrimaryDocument(_, document []byte) ([]byte, error) {
+	return bytes.Clone(document), nil
+}
+
 func rejectDuplicateDocumentIDs(items []insertBatchItem, order []int) error {
 	for i := 1; i < len(items); i++ {
 		if bytes.Equal(items[orderedItemIndex(order, i-1)].id, items[orderedItemIndex(order, i)].id) {
@@ -530,7 +535,11 @@ func (p insertBatchPlanner) emitTemplateRun(plan *insertBatchPlan, records []tem
 	}
 	table := newCollectionRunTable(len(records))
 	if err := applyCollectionRunEntries(table, len(records), func(i int) (key, value []byte, err error) {
-		return records[i].id[:], records[i].raw, nil
+		raw := records[i].raw
+		if p.cloneTemplateRunValues {
+			raw = bytes.Clone(raw)
+		}
+		return records[i].id[:], raw, nil
 	}); err != nil {
 		return err
 	}

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -20,6 +20,8 @@ func addCollectionInsertStats(dst *collections.CollectionInsertStats, src collec
 	dst.Documents += src.Documents
 	dst.Indexes += src.Indexes
 	dst.Runs += src.Runs
+	dst.BufferedIndexedBatches += src.BufferedIndexedBatches
+	dst.BufferedIndexedBypassBatches += src.BufferedIndexedBypassBatches
 	dst.PrepareDocuments += src.PrepareDocuments
 	dst.IndexStateExtraction += src.IndexStateExtraction
 	dst.DuplicateDocumentPreflight += src.DuplicateDocumentPreflight
@@ -64,6 +66,12 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 		b.ReportMetric(float64(stats.Runs)/float64(batches), "roots/batch")
 		b.ReportMetric(float64(stats.SecondarySortedRuns)/float64(batches), "secondary_sorted_runs/batch")
 		b.ReportMetric(float64(stats.SecondaryUnsortedRuns)/float64(batches), "secondary_unsorted_runs/batch")
+		if stats.BufferedIndexedBatches > 0 {
+			b.ReportMetric(float64(stats.BufferedIndexedBatches), "buffered_indexed_batches")
+		}
+		if stats.BufferedIndexedBypassBatches > 0 {
+			b.ReportMetric(float64(stats.BufferedIndexedBypassBatches), "buffered_indexed_bypass_batches")
+		}
 	}
 }
 
@@ -191,10 +199,10 @@ func benchmarkCollectionShapeInsertBatch(b *testing.B, indexCount int, checkpoin
 		if meta.Options.BufferedIndexedWriteMaxBytes > 0 {
 			b.ReportMetric(float64(meta.Options.BufferedIndexedWriteMaxBytes), "buffered_max_bytes")
 		}
-		if insertElapsed > 0 {
+		if insertStats.BufferedIndexedBatches > 0 && insertStats.BufferedIndexedBypassBatches == 0 && insertElapsed > 0 {
 			b.ReportMetric(float64(insertElapsed.Nanoseconds())/float64(b.N), "buffered_insert_ns/doc")
 		}
-		if bufferedFlushElapsed > 0 {
+		if insertStats.BufferedIndexedBatches > 0 && insertStats.BufferedIndexedBypassBatches == 0 && bufferedFlushElapsed > 0 {
 			b.ReportMetric(float64(bufferedFlushElapsed.Nanoseconds())/float64(b.N), "buffered_flush_ns/doc")
 		}
 	}

--- a/TreeDB/collections/template_v1.go
+++ b/TreeDB/collections/template_v1.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/tree"
 )
 
@@ -64,6 +66,12 @@ type templateV1SnapshotResolver struct {
 	snap   *backenddb.Snapshot
 	rootID uint64
 	cache  map[string]*templateV1Template
+}
+
+type templateV1BufferedRunsResolver struct {
+	runs     []memtable.Table
+	fallback templateV1Resolver
+	cache    map[string]*templateV1Template
 }
 
 type templateV1ObjectRef struct {
@@ -118,6 +126,25 @@ func collectionOptionsWithTemplateV1Resolver(opts collectionOptions, snap *backe
 		snap:   snap,
 		rootID: catalog.rootID(collectionTemplateRootName(catalog.meta.Name)),
 		cache:  make(map[string]*templateV1Template),
+	}
+	return opts
+}
+
+func collectionOptionsWithBufferedTemplateV1Resolver(opts collectionOptions, domain *collectionWriteDomain, collectionName string) collectionOptions {
+	if normalizedDocumentFormat(opts.documentFormat) != DocumentFormatTemplateV1 || domain == nil || collectionName == "" {
+		return opts
+	}
+	rootName := collectionTemplateRootName(collectionName)
+	domain.mu.RLock()
+	runs := append([]memtable.Table(nil), domain.rootRuns[rootName]...)
+	domain.mu.RUnlock()
+	if len(runs) == 0 {
+		return opts
+	}
+	opts.templateResolver = &templateV1BufferedRunsResolver{
+		runs:     runs,
+		fallback: opts.templateResolver,
+		cache:    make(map[string]*templateV1Template),
 	}
 	return opts
 }
@@ -340,6 +367,42 @@ func (r *templateV1SnapshotResolver) lookupTemplateV1(id [32]byte) (*templateV1T
 	}
 	r.cache[key] = record.tpl
 	return record.tpl, nil
+}
+
+func (r *templateV1BufferedRunsResolver) lookupTemplateV1(id [32]byte) (*templateV1Template, error) {
+	if r == nil {
+		return nil, errTemplateV1MissingResolver
+	}
+	key := string(id[:])
+	if tpl := r.cache[key]; tpl != nil {
+		return tpl, nil
+	}
+	for i := len(r.runs) - 1; i >= 0; i-- {
+		run := r.runs[i]
+		if run == nil {
+			continue
+		}
+		value, _, flags, found := run.GetEntry(id[:])
+		if !found || flags&node.FlagTombstone != 0 {
+			continue
+		}
+		record, err := parseTemplateV1Record(value)
+		if err != nil {
+			return nil, err
+		}
+		if record.id != id {
+			return nil, errors.New("collections: template-v1 template id mismatch")
+		}
+		if r.cache == nil {
+			r.cache = make(map[string]*templateV1Template)
+		}
+		r.cache[key] = record.tpl
+		return record.tpl, nil
+	}
+	if r.fallback != nil {
+		return r.fallback.lookupTemplateV1(id)
+	}
+	return nil, errTemplateV1TemplateNotFound
 }
 
 func sortTemplateV1Records(records []templateV1Record) {

--- a/TreeDB/collections/template_v1_test.go
+++ b/TreeDB/collections/template_v1_test.go
@@ -108,6 +108,9 @@ func TestTemplateV1CollectionInsertBatchIndexesAndTemplateRoot(t *testing.T) {
 	if len(cityIDs) != 2 || !bytes.Equal(cityIDs[0], []byte("u1")) || !bytes.Equal(cityIDs[1], []byte("u2")) {
 		t.Fatalf("city ids=%q want [u1 u2]", cityIDs)
 	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush indexed memtables: %v", err)
+	}
 
 	snap := d.AcquireSnapshot()
 	if snap == nil {
@@ -279,6 +282,9 @@ func TestTemplateV1EncoderReusesPersistedTemplateRoot(t *testing.T) {
 	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{doc1}); err != nil {
 		t.Fatalf("insert doc1: %v", err)
 	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush first indexed memtable: %v", err)
+	}
 	snap := d.AcquireSnapshot()
 	if snap == nil {
 		t.Fatal("expected snapshot")
@@ -318,6 +324,79 @@ func TestTemplateV1EncoderReusesPersistedTemplateRoot(t *testing.T) {
 	}
 	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
 		t.Fatalf("email ids=%q want u2", ids)
+	}
+}
+
+func TestTemplateV1IndexedWriteMemtablesResolveBufferedTemplateAcrossBatches(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatTemplateV1,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	var encoder TemplateV1Encoder
+	doc1, err := encoder.EncodeDocument([]string{"email", "city"}, []any{"ada@example.com", "hnl"})
+	if err != nil {
+		t.Fatalf("encode doc1: %v", err)
+	}
+	doc2, err := encoder.EncodeDocument([]string{"email", "city"}, []any{"grace@example.com", "sea"})
+	if err != nil {
+		t.Fatalf("encode doc2: %v", err)
+	}
+	if !bytes.HasPrefix(doc2, []byte(templateV1StoredMagic)) {
+		t.Fatalf("second encoded doc should reuse emitted template and be stored bytes")
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{doc1}); err != nil {
+		t.Fatalf("insert first buffered batch: %v", err)
+	}
+	for i := range doc1 {
+		doc1[i] = 0
+	}
+	col.writeDomain.mu.RLock()
+	bufferedTemplateRuns := len(col.writeDomain.rootRuns[collectionTemplateRootName("users")])
+	col.writeDomain.mu.RUnlock()
+	if bufferedTemplateRuns != 1 {
+		t.Fatalf("buffered template runs=%d want 1", bufferedTemplateRuns)
+	}
+	storedDoc2, _, err := parseTemplateV1InsertDocument(doc2)
+	if err != nil {
+		t.Fatalf("parse doc2: %v", err)
+	}
+	rootDoc2, err := parseTemplateV1StoredDocument(storedDoc2)
+	if err != nil {
+		t.Fatalf("parse doc2 root: %v", err)
+	}
+	opts := collectionOptionsWithBufferedTemplateV1Resolver(collectionOptions{
+		documentFormat:   DocumentFormatTemplateV1,
+		templateResolver: nil,
+	}, col.writeDomain, "users")
+	if _, err := opts.templateResolver.lookupTemplateV1(rootDoc2.templateID); err != nil {
+		t.Fatalf("lookup buffered template directly: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u2")}, [][]byte{doc2}); err != nil {
+		t.Fatalf("insert second buffered batch: %v", err)
+	}
+	ids, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find buffered city: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
+		t.Fatalf("city ids=%q want [u2]", ids)
 	}
 }
 

--- a/cmd/collection_load_fixture/README.md
+++ b/cmd/collection_load_fixture/README.md
@@ -16,6 +16,9 @@ Default load shape:
 - two secondary indexes: unique `email_idx` and non-unique `city_idx`
 - collection data/index-state outer leaves in the value log
 - secondary-index outer leaves in the value log
+- native indexed write memtables enabled with a default 64000-document
+  auto-flush limit; batches at 16000 documents or larger use direct publish by
+  default because they already amortize publish overhead well
 - `fast` TreeDB profile
 - final checkpoint and reopen verification
 - automatic offline index vacuum when `-vlog-rewrite` or `-leafgen-pack-gc`
@@ -45,15 +48,20 @@ Useful variants:
 # Disable secondary-index value-log outer leaves.
 ./bin/collection-load-fixture -index-outer-leaves-in-vlog=false -dir /tmp/treedb_two_index_template_v1_fast_index -reset
 
-# Stage indexed InsertBatch writes in collection-local memtables and publish
-# them at Flush/Close. The summary reports insert and flush timing separately.
-./bin/collection-load-fixture -buffered-indexed-writes -dir /tmp/treedb_two_index_buffered -reset
-
-# Stage indexed writes but force bounded publishes every 64000 staged docs.
+# Native indexed write memtables are enabled by default. This explicitly keeps
+# them enabled and force-bounds publishes every 64000 staged docs; very large
+# batches at the default 16000-document direct-publish threshold still bypass
+# staging.
 ./bin/collection-load-fixture \
-  -buffered-indexed-writes \
+  -buffered-indexed-writes=true \
   -buffered-indexed-write-max-docs 64000 \
   -dir /tmp/treedb_two_index_buffered_bounded \
+  -reset
+
+# Disable indexed write memtables for immediate-publish baseline comparisons.
+./bin/collection-load-fixture \
+  -buffered-indexed-writes=false \
+  -dir /tmp/treedb_two_index_immediate_publish \
   -reset
 
 # Generate machine-readable output and optional profiles.

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -296,23 +296,25 @@ func main() {
 
 func parseConfig(args []string, output io.Writer) (config, error) {
 	cfg := config{
-		Docs:                       defaultDocs,
-		BatchSize:                  defaultBatchSize,
-		Collection:                 defaultCollectionName,
-		DocumentFormat:             collections.DocumentFormatTemplateV1,
-		IndexCount:                 2,
-		Profile:                    treedb.ProfileFast,
-		DataOuterLeavesInValueLog:  true,
-		IndexOuterLeavesInValueLog: true,
-		KeepRecent:                 1,
-		PreferAppendAlloc:          false,
-		Checkpoint:                 true,
-		ReopenVerify:               true,
-		VerifySamples:              8,
-		ValueLogGC:                 true,
-		LeafGenerationPackMaxGen:   1,
-		IndexVacuum:                indexVacuumModeAuto,
-		Progress:                   true,
+		Docs:                        defaultDocs,
+		BatchSize:                   defaultBatchSize,
+		Collection:                  defaultCollectionName,
+		DocumentFormat:              collections.DocumentFormatTemplateV1,
+		IndexCount:                  2,
+		BufferedIndexedWrites:       true,
+		BufferedIndexedWriteMaxDocs: collections.DefaultIndexedWriteMemtableMaxDocuments,
+		Profile:                     treedb.ProfileFast,
+		DataOuterLeavesInValueLog:   true,
+		IndexOuterLeavesInValueLog:  true,
+		KeepRecent:                  1,
+		PreferAppendAlloc:           false,
+		Checkpoint:                  true,
+		ReopenVerify:                true,
+		VerifySamples:               8,
+		ValueLogGC:                  true,
+		LeafGenerationPackMaxGen:    1,
+		IndexVacuum:                 indexVacuumModeAuto,
+		Progress:                    true,
 	}
 	var documentFormat string
 	var profile string
@@ -328,8 +330,8 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	fs.StringVar(&cfg.Collection, "collection", cfg.Collection, "collection name")
 	fs.StringVar(&documentFormat, "format", string(cfg.DocumentFormat), "document format: json or template-v1")
 	fs.IntVar(&cfg.IndexCount, "indexes", cfg.IndexCount, "secondary index count for the benchmark shape: 0, 1, 2, or 3")
-	fs.BoolVar(&cfg.BufferedIndexedWrites, "buffered-indexed-writes", false, "stage indexed InsertBatch writes in collection-local memtables until flush")
-	fs.IntVar(&cfg.BufferedIndexedWriteMaxDocs, "buffered-indexed-write-max-docs", 0, "flush indexed write buffers after this many staged documents; 0 means Flush/Close only")
+	fs.BoolVar(&cfg.BufferedIndexedWrites, "buffered-indexed-writes", cfg.BufferedIndexedWrites, "use native collection-local memtables for indexed InsertBatch writes; set false for immediate-publish baseline comparisons")
+	fs.IntVar(&cfg.BufferedIndexedWriteMaxDocs, "buffered-indexed-write-max-docs", cfg.BufferedIndexedWriteMaxDocs, "flush indexed write buffers after this many staged documents; 0 uses the collection default")
 	fs.Int64Var(&cfg.BufferedIndexedWriteMaxBytes, "buffered-indexed-write-max-bytes", 0, "flush indexed write buffers after this many staged root-run bytes; 0 means Flush/Close only")
 	fs.StringVar(&profile, "profile", string(cfg.Profile), "TreeDB profile: fast, wal_on_fast, durable, or bench")
 	fs.BoolVar(&cfg.DataOuterLeavesInValueLog, "data-outer-leaves-in-vlog", cfg.DataOuterLeavesInValueLog, "store collection primary/index-state outer leaves through the value log")
@@ -751,6 +753,7 @@ func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Co
 			DocumentFormat:                   cfg.DocumentFormat,
 			DataRootStoragePolicy:            rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
 			IndexStateStoragePolicy:          rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+			DisableIndexedWriteMemtables:     !cfg.BufferedIndexedWrites && cfg.IndexCount > 0,
 			BufferedIndexedWrites:            bufferedIndexedWrites,
 			BufferedIndexedWriteMaxDocuments: bufferedIndexedWriteMaxDocs,
 			BufferedIndexedWriteMaxBytes:     bufferedIndexedWriteMaxBytes,

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -25,6 +25,12 @@ func TestParseConfigDefaultsToInspectableTwoIndexTemplateFixture(t *testing.T) {
 	if cfg.IndexCount != 2 {
 		t.Fatalf("index count=%d want 2", cfg.IndexCount)
 	}
+	if !cfg.BufferedIndexedWrites {
+		t.Fatal("expected indexed write memtables enabled by default")
+	}
+	if cfg.BufferedIndexedWriteMaxDocs != collections.DefaultIndexedWriteMemtableMaxDocuments {
+		t.Fatalf("buffered indexed max docs=%d want %d", cfg.BufferedIndexedWriteMaxDocs, collections.DefaultIndexedWriteMemtableMaxDocuments)
+	}
 	if !cfg.DataOuterLeavesInValueLog {
 		t.Fatal("expected data outer leaves in value log by default")
 	}
@@ -190,6 +196,26 @@ func TestRunFixtureReportsBufferedIndexedWritesOnlyWhenIndexesUseThem(t *testing
 	}
 	if indexedSummary.BufferedIndexedWriteMaxDocs != 16 || indexedSummary.BufferedIndexedWriteMaxBytes != 1024 {
 		t.Fatalf("indexed buffered limits docs=%d bytes=%d want 16/1024", indexedSummary.BufferedIndexedWriteMaxDocs, indexedSummary.BufferedIndexedWriteMaxBytes)
+	}
+
+	disabledDir := filepath.Join(t.TempDir(), "disabled")
+	disabledCfg, err := parseConfig([]string{
+		"-dir", disabledDir,
+		"-docs", "8",
+		"-batch-size", "4",
+		"-indexes", "1",
+		"-buffered-indexed-writes=false",
+		"-progress=false",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse disabled config: %v", err)
+	}
+	disabledSummary, err := runFixture(disabledCfg)
+	if err != nil {
+		t.Fatalf("run disabled fixture: %v", err)
+	}
+	if disabledSummary.BufferedIndexedWrites {
+		t.Fatal("disabled summary reported buffered indexed writes enabled")
 	}
 }
 


### PR DESCRIPTION
## Summary

- makes indexed collection write-domain memtables the default for indexed schemas, with `DisableIndexedWriteMemtables` retained for immediate-publish baselines/debugging
- adds a default 64k-doc auto-flush bound plus a 16k-doc adaptive direct-publish threshold so small/medium batches get memtable coalescing while already-large batches stay on the faster immediate publish path
- keeps buffered correctness by owning primary/template bytes, cloning returned IDs, resolving template-v1 records from buffered template roots, and merging buffered+persistent secondary-index reads in sorted order
- updates collection benchmarks/fixture defaults and reports buffered vs bypass batch counters

## TDD / correctness coverage

- default indexed memtable normalization and disable path
- default large-batch bypass rule
- buffered returned-ID ownership
- template-v1 buffered template resolution across batches, including caller mutation of the original template envelope
- limited secondary-index reads merging buffered and persisted rows in key order

## Local validation

- `go test ./TreeDB/collections ./cmd/collection_load_fixture -count 1`
- `go test ./... -count 1`

## Local benchmark snapshot

Commands use `BenchmarkCollectionShapeInsertBatch/indexes_2`, `template-v1`, `-benchtime=100000x`, Apple M3. These are local/noisy but directionally useful.

| Batch | Mode | ns/doc | docs/sec | Disk B/doc | Notes |
| ---: | --- | ---: | ---: | ---: | --- |
| 800 | immediate publish baseline | 1926 | 519,211 | 151.8 | `TREEDB_COLLECTION_BUFFERED_INDEXED_WRITES=false` |
| 800 | native indexed memtables | 1215 | 823,045 | 108.6 | 125 buffered batches |
| 16000 | immediate publish baseline | 856.7 | 1,167,270 | 108.7 | `TREEDB_COLLECTION_BUFFERED_INDEXED_WRITES=false` |
| 16000 | native adaptive default | 756.9 | 1,321,178 | 108.7 | 6 bypass batches, 1 buffered tail batch |

## Stack

This is stacked on #1106 (`codex/indexed-collection-buffer-limits`), which is stacked on #1105.
