### PR TITLE
Add multi-producer Mongo gateway benchmark mode

### DIFF
--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -76,11 +76,13 @@ goroutines. The effective producer count is capped at the number of insert
 batches so small runs do not open unused clients. Official-driver modes share one
 `mongo.Client`, so
 `-mongo-max-pool-size`, `-mongo-min-pool-size`, and `-mongo-max-connecting`
-control the driver pool used by those producers. `raw-wire-tcp` opens one
-fastclient connection per effective producer, and `raw-wire` uses one in-process
-wire owner per effective producer. JSON output includes `effective_producers`
-and `producer_results` for the load phase plus `mongo_pool_stats_after_load` and
-`mongo_pool_stats_final` when the official driver pool is involved.
+control the driver pool used by those producers. When `-mongo-max-pool-size` is
+left unset, validation treats the driver default max pool size as 100 for
+`-mongo-min-pool-size` checks. `raw-wire-tcp` opens one fastclient connection per
+effective producer, and `raw-wire` uses one in-process wire owner per effective
+producer. JSON output includes `effective_producers` and `producer_results` for
+the load phase plus `mongo_pool_stats_after_load` and `mongo_pool_stats_final`
+when the official driver pool is involved.
 
 The TreeDB benchmark target defaults are intended to match the optimized
 collection benchmark profile:

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -19,6 +19,10 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
   -treedb-dir /tmp/treedb-mongo-bench \
   -keep-treedb-dir \
   -documents 10000 \
+  -batch-size 1000 \
+  -insert-producers 4 \
+  -mongo-max-pool-size 32 \
+  -mongo-max-connecting 8 \
   -reads 10000 \
   -range-reads 1000 \
   -updates 1000 \
@@ -67,6 +71,15 @@ documents and raw BSON bytes before the measured workload. `driver-command` and
 `raw-wire` reuse the raw bytes during the load phase so their insert-call timing
 does not include fixture BSON marshaling.
 
+Use `-insert-producers N` to split the insert load phase across `N` producer
+goroutines. Official-driver modes share one `mongo.Client`, so
+`-mongo-max-pool-size`, `-mongo-min-pool-size`, and `-mongo-max-connecting`
+control the driver pool used by those producers. `raw-wire-tcp` opens one
+fastclient connection per producer, and `raw-wire` uses one in-process wire owner
+per producer. JSON output includes `producer_results` for the load phase plus
+`mongo_pool_stats_after_load` and `mongo_pool_stats_final` when the official
+driver pool is involved.
+
 The TreeDB benchmark target defaults are intended to match the optimized
 collection benchmark profile:
 
@@ -99,6 +112,10 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
   -target mongo \
   -mongo-uri mongodb://127.0.0.1:27017 \
   -documents 10000 \
+  -batch-size 1000 \
+  -insert-producers 4 \
+  -mongo-max-pool-size 32 \
+  -mongo-max-connecting 8 \
   -reads 10000 \
   -range-reads 1000 \
   -updates 1000 \
@@ -146,6 +163,9 @@ scripts/mongo_gateway_compare.sh \
   --concurrent-reads 10000 \
   --concurrent-writers 4 \
   --concurrent-writes 1000 \
+  --insert-producers 4 \
+  --mongo-max-pool-size 32 \
+  --mongo-max-connecting 8 \
   --mongo-mode docker
 ```
 
@@ -256,7 +276,9 @@ The initial workload phases are:
   documents})` for `driver-command`, `RunCommand` with a prebuilt raw BSON
   command for `driver-command-raw`, unacknowledged `InsertMany` plus a post-load
   visibility wait for `driver-unack`, and raw OP_MSG document sequences for
-  `raw-wire`/`raw-wire-tcp`.
+  `raw-wire`/`raw-wire-tcp`. When `-insert-producers` is greater than 1, this
+  phase reports aggregate wall-clock throughput and per-producer call latency in
+  `producer_results`.
 - `id_find_one`: point lookup by `_id`.
 - `email_find_one`: point lookup by the `email` field; emitted only when the
   email secondary index is part of the cell.
@@ -276,6 +298,12 @@ sampled values when investigating gateway/client overhead with prebuilt
 fixtures, and wall `ops_sec` when measuring the full benchmark loop. Insert
 latency percentiles are per batch call. Range-query samples include cursor
 materialization with `cursor.All`.
+
+`mongo_pool_stats_after_load` is reset immediately before the insert load phase,
+so its checkout counters describe the measured insert phase rather than setup or
+index creation. `mongo_pool_stats_final` is cumulative from the load phase
+through the later read/update/delete phases.
+
 Use `-timeout 0` to run without an overall benchmark deadline.
 
 The package test `TestTreeDBProfileSmokeFastAndWALOnFast` runs a small write-only

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -71,14 +71,16 @@ documents and raw BSON bytes before the measured workload. `driver-command` and
 `raw-wire` reuse the raw bytes during the load phase so their insert-call timing
 does not include fixture BSON marshaling.
 
-Use `-insert-producers N` to split the insert load phase across `N` producer
-goroutines. Official-driver modes share one `mongo.Client`, so
+Use `-insert-producers N` to split the insert load phase across producer
+goroutines. The effective producer count is capped at the number of insert
+batches so small runs do not open unused clients. Official-driver modes share one
+`mongo.Client`, so
 `-mongo-max-pool-size`, `-mongo-min-pool-size`, and `-mongo-max-connecting`
 control the driver pool used by those producers. `raw-wire-tcp` opens one
-fastclient connection per producer, and `raw-wire` uses one in-process wire owner
-per producer. JSON output includes `producer_results` for the load phase plus
-`mongo_pool_stats_after_load` and `mongo_pool_stats_final` when the official
-driver pool is involved.
+fastclient connection per effective producer, and `raw-wire` uses one in-process
+wire owner per effective producer. JSON output includes `effective_producers`
+and `producer_results` for the load phase plus `mongo_pool_stats_after_load` and
+`mongo_pool_stats_final` when the official driver pool is involved.
 
 The TreeDB benchmark target defaults are intended to match the optimized
 collection benchmark profile:
@@ -302,7 +304,10 @@ materialization with `cursor.All`.
 `mongo_pool_stats_after_load` is reset immediately before the insert load phase,
 so its checkout counters describe the measured insert phase rather than setup or
 index creation. `mongo_pool_stats_final` is cumulative from the load phase
-through the later read/update/delete phases.
+through the later read/update/delete phases. Pool checkout latency percentiles are
+computed from a bounded sample to keep high-concurrency benchmark overhead
+predictable; checkout counts and aggregate checkout duration still cover every
+recorded checkout event.
 
 Use `-timeout 0` to run without an overall benchmark deadline.
 

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -110,6 +110,7 @@ type phaseResult struct {
 	Name                    string           `json:"name"`
 	Operations              int              `json:"operations"`
 	DriverCalls             int              `json:"driver_calls"`
+	EffectiveProducers      int              `json:"effective_producers,omitempty"`
 	DurationMillis          float64          `json:"duration_ms"`
 	OpsPerSecond            float64          `json:"ops_per_sec"`
 	SampledOpsPerSecond     float64          `json:"sampled_ops_per_sec,omitempty"`
@@ -140,6 +141,8 @@ type mongoPoolSnapshot struct {
 	ConnectionCheckedOut      int64          `json:"connection_checked_out,omitempty"`
 	ConnectionCheckOutFailed  int64          `json:"connection_check_out_failed,omitempty"`
 	ConnectionPoolCleared     int64          `json:"connection_pool_cleared,omitempty"`
+	CheckoutSamples           int64          `json:"checkout_samples,omitempty"`
+	CheckoutSamplesDropped    int64          `json:"checkout_samples_dropped,omitempty"`
 	CheckoutAggregateMillis   float64        `json:"checkout_aggregate_duration_ms,omitempty"`
 	CheckoutMeanLatencyMicros float64        `json:"checkout_mean_latency_us,omitempty"`
 	CheckoutLatencyMicros     latencySummary `json:"checkout_latency_micros,omitempty"`
@@ -185,10 +188,15 @@ type mongoPoolStats struct {
 	connectionCheckedOut      atomic.Int64
 	connectionCheckOutFailed  atomic.Int64
 	connectionPoolCleared     atomic.Int64
+	checkoutDurationNanos     atomic.Int64
+	checkoutDurationCount     atomic.Int64
+	checkoutSamplesDropped    atomic.Int64
 
 	mu                sync.Mutex
 	checkoutDurations []time.Duration
 }
+
+const maxMongoPoolCheckoutDurationSamples = 8192
 
 func newMongoPoolStats() *mongoPoolStats {
 	return &mongoPoolStats{}
@@ -217,6 +225,9 @@ func (s *mongoPoolStats) Reset() {
 	s.connectionCheckedOut.Store(0)
 	s.connectionCheckOutFailed.Store(0)
 	s.connectionPoolCleared.Store(0)
+	s.checkoutDurationNanos.Store(0)
+	s.checkoutDurationCount.Store(0)
+	s.checkoutSamplesDropped.Store(0)
 	s.mu.Lock()
 	s.checkoutDurations = nil
 	s.mu.Unlock()
@@ -229,10 +240,8 @@ func (s *mongoPoolStats) Snapshot() *mongoPoolSnapshot {
 	s.mu.Lock()
 	durations := append([]time.Duration(nil), s.checkoutDurations...)
 	s.mu.Unlock()
-	var aggregate time.Duration
-	for _, duration := range durations {
-		aggregate += duration
-	}
+	aggregate := time.Duration(s.checkoutDurationNanos.Load())
+	durationCount := s.checkoutDurationCount.Load()
 	snapshot := &mongoPoolSnapshot{
 		ConnectionCreated:         s.connectionCreated.Load(),
 		ConnectionReady:           s.connectionReady.Load(),
@@ -242,11 +251,13 @@ func (s *mongoPoolStats) Snapshot() *mongoPoolSnapshot {
 		ConnectionCheckedOut:      s.connectionCheckedOut.Load(),
 		ConnectionCheckOutFailed:  s.connectionCheckOutFailed.Load(),
 		ConnectionPoolCleared:     s.connectionPoolCleared.Load(),
+		CheckoutSamples:           int64(len(durations)),
+		CheckoutSamplesDropped:    s.checkoutSamplesDropped.Load(),
 		CheckoutAggregateMillis:   float64(aggregate.Microseconds()) / 1000.0,
 		CheckoutLatencyMicros:     summarizeLatency(durations),
 	}
-	if len(durations) > 0 {
-		snapshot.CheckoutMeanLatencyMicros = float64(aggregate.Microseconds()) / float64(len(durations))
+	if durationCount > 0 {
+		snapshot.CheckoutMeanLatencyMicros = float64(aggregate.Microseconds()) / float64(durationCount)
 	}
 	return snapshot
 }
@@ -281,8 +292,14 @@ func (s *mongoPoolStats) recordCheckoutDuration(duration time.Duration) {
 	if duration <= 0 {
 		return
 	}
+	s.checkoutDurationNanos.Add(duration.Nanoseconds())
+	s.checkoutDurationCount.Add(1)
 	s.mu.Lock()
-	s.checkoutDurations = append(s.checkoutDurations, duration)
+	if len(s.checkoutDurations) < maxMongoPoolCheckoutDurationSamples {
+		s.checkoutDurations = append(s.checkoutDurations, duration)
+	} else {
+		s.checkoutSamplesDropped.Add(1)
+	}
 	s.mu.Unlock()
 }
 
@@ -1342,7 +1359,8 @@ func runTreeDBRawWireTCPLoadPhase(ctx context.Context, cfg config, target *bench
 	if target == nil || target.mongoAddr == "" {
 		return phaseResult{}, errors.New("raw-wire-tcp client mode requires a TreeDB gateway listener")
 	}
-	clients := make([]*fastclient.Client, cfg.InsertProducers)
+	producers := effectiveLoadProducers(cfg.Documents, cfg.BatchSize, cfg.InsertProducers)
+	clients := make([]*fastclient.Client, producers)
 	for i := range clients {
 		client, err := fastclient.Connect(ctx, target.mongoAddr)
 		if err != nil {
@@ -1800,18 +1818,23 @@ func makeLoadBatches(documents, batchSize int) []loadBatch {
 	return batches
 }
 
+func effectiveLoadProducers(documents, batchSize, requested int) int {
+	if requested <= 0 {
+		requested = 1
+	}
+	if documents <= 0 || batchSize <= 0 {
+		return requested
+	}
+	batches := (documents + batchSize - 1) / batchSize
+	if batches > 0 && requested > batches {
+		return batches
+	}
+	return requested
+}
+
 func measureLoadPhase(ctx context.Context, cfg config, runBatch func(producer, start, end int) error, after ...func() error) (phaseResult, error) {
 	batches := makeLoadBatches(cfg.Documents, cfg.BatchSize)
-	producers := cfg.InsertProducers
-	if producers <= 0 {
-		producers = 1
-	}
-	if len(batches) > 0 && producers > len(batches) {
-		producers = len(batches)
-	}
-	if producers <= 0 {
-		producers = 1
-	}
+	producers := effectiveLoadProducers(cfg.Documents, cfg.BatchSize, cfg.InsertProducers)
 
 	samples := make([]time.Duration, 0, len(batches))
 	producerSamples := make([][]time.Duration, producers)
@@ -1850,7 +1873,14 @@ func measureLoadPhase(ctx context.Context, cfg config, runBatch func(producer, s
 		}
 	}
 	duration := time.Since(started)
-	result := summarizePhase("load_insert_many", cfg.Documents, len(samples), duration, samples)
+	completedOperations := 0
+	for _, operations := range producerOperations {
+		completedOperations += operations
+	}
+	result := summarizePhase("load_insert_many", completedOperations, len(samples), duration, samples)
+	if producers != 1 || cfg.InsertProducers != producers {
+		result.EffectiveProducers = producers
+	}
 	if cfg.InsertProducers > 1 {
 		result.ProducerResults = make([]producerResult, 0, producers)
 		for producer := 0; producer < producers; producer++ {
@@ -1917,7 +1947,11 @@ func runLoadBatches(
 				started := time.Now()
 				err := runBatch(producer, batch.start, batch.end)
 				elapsed := time.Since(started)
-				recordBatch(producer, batch.end-batch.start, elapsed)
+				operations := batch.end - batch.start
+				if err != nil {
+					operations = 0
+				}
+				recordBatch(producer, operations, elapsed)
 				if err != nil {
 					recordErr(err)
 					return
@@ -2132,8 +2166,12 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)
 		}
 		for _, phase := range result.Phases {
-			fmt.Fprintf(out, "%-22s ops=%d calls=%d duration_ms=%.1f ops_sec=%.1f sampled_ops_sec=%.1f sampled_ns_op=%.1f driver_aggregate_ms=%.1f driver_mean_us=%.0f p50_us=%.0f p95_us=%.0f p99_us=%.0f\n",
-				phase.Name, phase.Operations, phase.DriverCalls, phase.DurationMillis, phase.OpsPerSecond,
+			fmt.Fprintf(out, "%-22s ops=%d calls=%d", phase.Name, phase.Operations, phase.DriverCalls)
+			if phase.EffectiveProducers > 0 {
+				fmt.Fprintf(out, " effective_producers=%d", phase.EffectiveProducers)
+			}
+			fmt.Fprintf(out, " duration_ms=%.1f ops_sec=%.1f sampled_ops_sec=%.1f sampled_ns_op=%.1f driver_aggregate_ms=%.1f driver_mean_us=%.0f p50_us=%.0f p95_us=%.0f p99_us=%.0f\n",
+				phase.DurationMillis, phase.OpsPerSecond,
 				phase.SampledOpsPerSecond, phase.SampledNsPerOp, phase.DriverAggregateMillis, phase.DriverMeanLatencyMicros,
 				phase.LatencyMicros.P50, phase.LatencyMicros.P95, phase.LatencyMicros.P99)
 			for _, producer := range phase.ProducerResults {
@@ -2220,7 +2258,7 @@ func writeMongoPoolStats(out io.Writer, label string, stats *mongoPoolSnapshot) 
 	if stats == nil {
 		return
 	}
-	fmt.Fprintf(out, "%s created=%d ready=%d closed=%d checkout_started=%d checked_out=%d checked_in=%d checkout_failed=%d pool_cleared=%d checkout_aggregate_ms=%.1f checkout_mean_us=%.0f checkout_p50_us=%.0f checkout_p95_us=%.0f checkout_p99_us=%.0f\n",
+	fmt.Fprintf(out, "%s created=%d ready=%d closed=%d checkout_started=%d checked_out=%d checked_in=%d checkout_failed=%d pool_cleared=%d checkout_samples=%d checkout_samples_dropped=%d checkout_aggregate_ms=%.1f checkout_mean_us=%.0f checkout_p50_us=%.0f checkout_p95_us=%.0f checkout_p99_us=%.0f\n",
 		label,
 		stats.ConnectionCreated,
 		stats.ConnectionReady,
@@ -2230,6 +2268,8 @@ func writeMongoPoolStats(out io.Writer, label string, stats *mongoPoolSnapshot) 
 		stats.ConnectionCheckedIn,
 		stats.ConnectionCheckOutFailed,
 		stats.ConnectionPoolCleared,
+		stats.CheckoutSamples,
+		stats.CheckoutSamplesDropped,
 		stats.CheckoutAggregateMillis,
 		stats.CheckoutMeanLatencyMicros,
 		stats.CheckoutLatencyMicros.P50,

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1193,7 +1193,7 @@ func runLoadPhase(ctx context.Context, cfg config, target *benchTarget, coll *mo
 }
 
 func runDriverLoadPhase(ctx context.Context, cfg config, coll *mongo.Collection, prebuilt []bson.D) (phaseResult, error) {
-	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
 		docs := make([]any, 0, end-start)
 		for i := start; i < end; i++ {
 			if prebuilt != nil {
@@ -1202,13 +1202,13 @@ func runDriverLoadPhase(ctx context.Context, cfg config, coll *mongo.Collection,
 				docs = append(docs, benchmarkDocument(i))
 			}
 		}
-		_, err := coll.InsertMany(ctx, docs)
+		_, err := coll.InsertMany(batchCtx, docs)
 		return err
 	})
 }
 
 func runDriverCommandLoadPhase(ctx context.Context, cfg config, db *mongo.Database, prebuilt []bson.D, prebuiltRaw []bson.Raw) (phaseResult, error) {
-	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
 		docs := make(bson.A, 0, end-start)
 		for i := start; i < end; i++ {
 			if prebuiltRaw != nil {
@@ -1219,7 +1219,7 @@ func runDriverCommandLoadPhase(ctx context.Context, cfg config, db *mongo.Databa
 				docs = append(docs, benchmarkDocument(i))
 			}
 		}
-		return db.RunCommand(ctx, bson.D{
+		return db.RunCommand(batchCtx, bson.D{
 			{Key: "insert", Value: cfg.Collection},
 			{Key: "documents", Value: docs},
 			{Key: "ordered", Value: true},
@@ -1228,12 +1228,12 @@ func runDriverCommandLoadPhase(ctx context.Context, cfg config, db *mongo.Databa
 }
 
 func runDriverCommandRawLoadPhase(ctx context.Context, cfg config, db *mongo.Database, prebuilt []bson.D, prebuiltRaw []bson.Raw) (phaseResult, error) {
-	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
 		command, err := rawInsertCommand(cfg.Collection, start, end, prebuilt, prebuiltRaw)
 		if err != nil {
 			return err
 		}
-		return db.RunCommand(ctx, command).Err()
+		return db.RunCommand(batchCtx, command).Err()
 	})
 }
 
@@ -1276,7 +1276,7 @@ func rawInsertCommand(collection string, start, end int, prebuilt []bson.D, preb
 func runDriverUnackLoadPhase(ctx context.Context, cfg config, db *mongo.Database, prebuilt []bson.D) (phaseResult, error) {
 	unackColl := db.Collection(cfg.Collection, options.Collection().SetWriteConcern(writeconcern.Unacknowledged()))
 	ackColl := db.Collection(cfg.Collection)
-	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
 		docs := make([]any, 0, end-start)
 		for i := start; i < end; i++ {
 			if prebuilt != nil {
@@ -1285,7 +1285,7 @@ func runDriverUnackLoadPhase(ctx context.Context, cfg config, db *mongo.Database
 				docs = append(docs, benchmarkDocument(i))
 			}
 		}
-		_, err := unackColl.InsertMany(ctx, docs)
+		_, err := unackColl.InsertMany(batchCtx, docs)
 		return err
 	}, func() error {
 		return waitForLoadVisible(ctx, cfg, ackColl)
@@ -1372,7 +1372,10 @@ func runTreeDBRawWireLoadPhase(ctx context.Context, cfg config, target *benchTar
 	}
 	commandDoc := wire.Document(commandRaw)
 	var requestID atomic.Int32
-	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
+		if err := batchCtx.Err(); err != nil {
+			return err
+		}
 		docs := make([]wire.Document, end-start)
 		for i := start; i < end; i++ {
 			if prebuiltRaw != nil {
@@ -1418,12 +1421,12 @@ func runTreeDBRawWireTCPLoadPhase(ctx context.Context, cfg config, target *bench
 			_ = client.Close()
 		}
 	}()
-	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+	return measureLoadPhase(ctx, cfg, func(batchCtx context.Context, producer, start, end int) error {
 		docs, err := rawBSONDocuments(start, end, prebuilt, prebuiltRaw)
 		if err != nil {
 			return err
 		}
-		_, err = clients[producer].InsertManyRawBSON(ctx, cfg.Database, cfg.Collection, docs)
+		_, err = clients[producer].InsertManyRawBSON(batchCtx, cfg.Database, cfg.Collection, docs)
 		return err
 	})
 }
@@ -1872,7 +1875,7 @@ func effectiveLoadProducers(documents, batchSize, requested int) int {
 	return requested
 }
 
-func measureLoadPhase(ctx context.Context, cfg config, runBatch func(producer, start, end int) error, after ...func() error) (phaseResult, error) {
+func measureLoadPhase(ctx context.Context, cfg config, runBatch func(context.Context, int, int, int) error, after ...func() error) (phaseResult, error) {
 	batches := makeLoadBatches(cfg.Documents, cfg.BatchSize)
 	producers := effectiveLoadProducers(cfg.Documents, cfg.BatchSize, cfg.InsertProducers)
 
@@ -1940,7 +1943,7 @@ func runLoadBatches(
 	ctx context.Context,
 	batches []loadBatch,
 	producers int,
-	runBatch func(producer, start, end int) error,
+	runBatch func(context.Context, int, int, int) error,
 	recordBatch func(producer, operations int, duration time.Duration),
 	recordProducerDuration func(producer int, duration time.Duration),
 ) error {
@@ -1985,7 +1988,7 @@ func runLoadBatches(
 				}
 				batch := batches[batchIndex]
 				started := time.Now()
-				err := runBatch(producer, batch.start, batch.end)
+				err := runBatch(runCtx, producer, batch.start, batch.end)
 				elapsed := time.Since(started)
 				operations := batch.end - batch.start
 				if err != nil {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -438,6 +438,9 @@ func parseConfig(args []string) (config, error) {
 	if cfg.MongoMaxPoolSize < 0 || cfg.MongoMinPoolSize < 0 || cfg.MongoMaxConnecting < 0 {
 		return config{}, errors.New("MongoDB pool option values cannot be negative")
 	}
+	if cfg.MongoMaxPoolSize > 0 && cfg.MongoMinPoolSize > cfg.MongoMaxPoolSize {
+		return config{}, errors.New("mongo-min-pool-size cannot exceed mongo-max-pool-size")
+	}
 	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 || cfg.ConcurrentReads < 0 || cfg.ConcurrentWrites < 0 {
 		return config{}, errors.New("operation counts cannot be negative")
 	}
@@ -1301,13 +1304,22 @@ func waitForLoadVisible(ctx context.Context, cfg config, coll *mongo.Collection)
 	defer cancel()
 	visible := make([]bool, len(ids))
 	remaining := len(ids)
+	cursor := 0
 	ticker := time.NewTicker(2 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		for i, id := range ids {
+		checks := remaining
+		if checks > maxUnackVisibilityChecksPerPoll {
+			checks = maxUnackVisibilityChecksPerPoll
+		}
+		for checked, scanned := 0, 0; checked < checks && scanned < len(ids); scanned++ {
+			i := cursor
+			cursor = (cursor + 1) % len(ids)
 			if visible[i] {
 				continue
 			}
+			checked++
+			id := ids[i]
 			var out bson.M
 			err := coll.FindOne(waitCtx, bson.D{{Key: "_id", Value: id}}).Decode(&out)
 			if err == nil {
@@ -1332,6 +1344,8 @@ func waitForLoadVisible(ctx context.Context, cfg config, coll *mongo.Collection)
 		}
 	}
 }
+
+const maxUnackVisibilityChecksPerPoll = 128
 
 func loadVisibilitySentinelIDs(documents, batchSize int) []string {
 	batches := makeLoadBatches(documents, batchSize)
@@ -2073,8 +2087,10 @@ func summarizePhase(name string, operations, driverCalls int, duration time.Dura
 	}
 	if driverCalls > 0 && driverDuration > 0 {
 		result.DriverMeanLatencyMicros = float64(driverDuration.Microseconds()) / float64(driverCalls)
-		result.SampledOpsPerSecond = float64(operations) / driverDuration.Seconds()
-		result.SampledNsPerOp = float64(driverDuration.Nanoseconds()) / float64(operations)
+		if operations > 0 {
+			result.SampledOpsPerSecond = float64(operations) / driverDuration.Seconds()
+			result.SampledNsPerOp = float64(driverDuration.Nanoseconds()) / float64(operations)
+		}
 	}
 	return result
 }

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -35,6 +35,8 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 )
 
+const defaultMongoDriverMaxPoolSize = 100
+
 type config struct {
 	Target                      string
 	MongoURI                    string
@@ -438,8 +440,12 @@ func parseConfig(args []string) (config, error) {
 	if cfg.MongoMaxPoolSize < 0 || cfg.MongoMinPoolSize < 0 || cfg.MongoMaxConnecting < 0 {
 		return config{}, errors.New("MongoDB pool option values cannot be negative")
 	}
-	if cfg.MongoMaxPoolSize > 0 && cfg.MongoMinPoolSize > cfg.MongoMaxPoolSize {
-		return config{}, errors.New("mongo-min-pool-size cannot exceed mongo-max-pool-size")
+	mongoMaxPoolSize := cfg.MongoMaxPoolSize
+	if mongoMaxPoolSize == 0 {
+		mongoMaxPoolSize = defaultMongoDriverMaxPoolSize
+	}
+	if cfg.MongoMinPoolSize > mongoMaxPoolSize {
+		return config{}, fmt.Errorf("mongo-min-pool-size cannot exceed mongo-max-pool-size (%d when unset)", defaultMongoDriverMaxPoolSize)
 	}
 	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 || cfg.ConcurrentReads < 0 || cfg.ConcurrentWrites < 0 {
 		return config{}, errors.New("operation counts cannot be negative")

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1293,29 +1293,55 @@ func waitForLoadVisible(ctx context.Context, cfg config, coll *mongo.Collection)
 	if cfg.Documents <= 0 {
 		return nil
 	}
+	ids := loadVisibilitySentinelIDs(cfg.Documents, cfg.BatchSize)
+	if len(ids) == 0 {
+		return nil
+	}
 	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	id := benchmarkID(cfg.Documents - 1)
+	visible := make([]bool, len(ids))
+	remaining := len(ids)
 	ticker := time.NewTicker(2 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		var out bson.M
-		err := coll.FindOne(waitCtx, bson.D{{Key: "_id", Value: id}}).Decode(&out)
-		if err == nil {
-			if out["_id"] != id {
-				return fmt.Errorf("post-unack visibility lookup returned _id=%v want %s", out["_id"], id)
+		for i, id := range ids {
+			if visible[i] {
+				continue
 			}
-			return nil
+			var out bson.M
+			err := coll.FindOne(waitCtx, bson.D{{Key: "_id", Value: id}}).Decode(&out)
+			if err == nil {
+				if out["_id"] != id {
+					return fmt.Errorf("post-unack visibility lookup returned _id=%v want %s", out["_id"], id)
+				}
+				visible[i] = true
+				remaining--
+				continue
+			}
+			if !errors.Is(err, mongo.ErrNoDocuments) {
+				return err
+			}
 		}
-		if !errors.Is(err, mongo.ErrNoDocuments) {
-			return err
+		if remaining == 0 {
+			return nil
 		}
 		select {
 		case <-waitCtx.Done():
-			return fmt.Errorf("wait for unacknowledged load visibility: %w", waitCtx.Err())
+			return fmt.Errorf("wait for unacknowledged load visibility: %d batch sentinel ids still missing: %w", remaining, waitCtx.Err())
 		case <-ticker.C:
 		}
 	}
+}
+
+func loadVisibilitySentinelIDs(documents, batchSize int) []string {
+	batches := makeLoadBatches(documents, batchSize)
+	ids := make([]string, 0, len(batches))
+	for _, batch := range batches {
+		if batch.end > batch.start {
+			ids = append(ids, benchmarkID(batch.end-1))
+		}
+	}
+	return ids
 }
 
 func runTreeDBRawWireLoadPhase(ctx context.Context, cfg config, target *benchTarget, prebuilt []bson.D, prebuiltRaw []bson.Raw) (phaseResult, error) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/fastclient"
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/event"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/writeconcern"
@@ -44,6 +45,10 @@ type config struct {
 	Collection                  string
 	Documents                   int
 	BatchSize                   int
+	InsertProducers             int
+	MongoMaxPoolSize            int
+	MongoMinPoolSize            int
+	MongoMaxConnecting          int
 	Reads                       int
 	RangeReads                  int
 	Updates                     int
@@ -72,6 +77,11 @@ type benchmarkResult struct {
 	Database                    string              `json:"database"`
 	Collection                  string              `json:"collection"`
 	Documents                   int                 `json:"documents"`
+	BatchSize                   int                 `json:"batch_size"`
+	InsertProducers             int                 `json:"insert_producers"`
+	MongoMaxPoolSize            int                 `json:"mongo_max_pool_size,omitempty"`
+	MongoMinPoolSize            int                 `json:"mongo_min_pool_size,omitempty"`
+	MongoMaxConnecting          int                 `json:"mongo_max_connecting,omitempty"`
 	SecondaryIndexes            int                 `json:"secondary_indexes"`
 	ClientMode                  string              `json:"client_mode"`
 	ConcurrentReaders           int                 `json:"concurrent_readers,omitempty"`
@@ -92,19 +102,47 @@ type benchmarkResult struct {
 	TreeDBMaintenance           []maintenanceResult `json:"treedb_maintenance,omitempty"`
 	MongoDBStatsAfterLoad       map[string]any      `json:"mongodb_stats_after_load,omitempty"`
 	MongoDBStatsFinal           map[string]any      `json:"mongodb_stats_final,omitempty"`
+	MongoPoolStatsAfterLoad     *mongoPoolSnapshot  `json:"mongo_pool_stats_after_load,omitempty"`
+	MongoPoolStatsFinal         *mongoPoolSnapshot  `json:"mongo_pool_stats_final,omitempty"`
 }
 
 type phaseResult struct {
-	Name                    string         `json:"name"`
+	Name                    string           `json:"name"`
+	Operations              int              `json:"operations"`
+	DriverCalls             int              `json:"driver_calls"`
+	DurationMillis          float64          `json:"duration_ms"`
+	OpsPerSecond            float64          `json:"ops_per_sec"`
+	SampledOpsPerSecond     float64          `json:"sampled_ops_per_sec,omitempty"`
+	SampledNsPerOp          float64          `json:"sampled_ns_per_op,omitempty"`
+	DriverAggregateMillis   float64          `json:"driver_aggregate_duration_ms,omitempty"`
+	DriverMeanLatencyMicros float64          `json:"driver_mean_latency_us,omitempty"`
+	LatencyMicros           latencySummary   `json:"latency_micros"`
+	ProducerResults         []producerResult `json:"producer_results,omitempty"`
+}
+
+type producerResult struct {
+	Producer                int            `json:"producer"`
 	Operations              int            `json:"operations"`
 	DriverCalls             int            `json:"driver_calls"`
 	DurationMillis          float64        `json:"duration_ms"`
 	OpsPerSecond            float64        `json:"ops_per_sec"`
-	SampledOpsPerSecond     float64        `json:"sampled_ops_per_sec,omitempty"`
-	SampledNsPerOp          float64        `json:"sampled_ns_per_op,omitempty"`
 	DriverAggregateMillis   float64        `json:"driver_aggregate_duration_ms,omitempty"`
 	DriverMeanLatencyMicros float64        `json:"driver_mean_latency_us,omitempty"`
 	LatencyMicros           latencySummary `json:"latency_micros"`
+}
+
+type mongoPoolSnapshot struct {
+	ConnectionCreated         int64          `json:"connection_created,omitempty"`
+	ConnectionReady           int64          `json:"connection_ready,omitempty"`
+	ConnectionClosed          int64          `json:"connection_closed,omitempty"`
+	ConnectionCheckedIn       int64          `json:"connection_checked_in,omitempty"`
+	ConnectionCheckOutStarted int64          `json:"connection_check_out_started,omitempty"`
+	ConnectionCheckedOut      int64          `json:"connection_checked_out,omitempty"`
+	ConnectionCheckOutFailed  int64          `json:"connection_check_out_failed,omitempty"`
+	ConnectionPoolCleared     int64          `json:"connection_pool_cleared,omitempty"`
+	CheckoutAggregateMillis   float64        `json:"checkout_aggregate_duration_ms,omitempty"`
+	CheckoutMeanLatencyMicros float64        `json:"checkout_mean_latency_us,omitempty"`
+	CheckoutLatencyMicros     latencySummary `json:"checkout_latency_micros,omitempty"`
 }
 
 type maintenanceResult struct {
@@ -134,7 +172,118 @@ type benchTarget struct {
 	mongoAddr       string
 	treedbDir       string
 	removeTreeDBDir bool
+	poolStats       *mongoPoolStats
 	cleanup         func(context.Context) error
+}
+
+type mongoPoolStats struct {
+	connectionCreated         atomic.Int64
+	connectionReady           atomic.Int64
+	connectionClosed          atomic.Int64
+	connectionCheckedIn       atomic.Int64
+	connectionCheckOutStarted atomic.Int64
+	connectionCheckedOut      atomic.Int64
+	connectionCheckOutFailed  atomic.Int64
+	connectionPoolCleared     atomic.Int64
+
+	mu                sync.Mutex
+	checkoutDurations []time.Duration
+}
+
+func newMongoPoolStats() *mongoPoolStats {
+	return &mongoPoolStats{}
+}
+
+func (s *mongoPoolStats) Monitor() *event.PoolMonitor {
+	if s == nil {
+		return nil
+	}
+	return &event.PoolMonitor{
+		Event: func(evt *event.PoolEvent) {
+			s.record(evt)
+		},
+	}
+}
+
+func (s *mongoPoolStats) Reset() {
+	if s == nil {
+		return
+	}
+	s.connectionCreated.Store(0)
+	s.connectionReady.Store(0)
+	s.connectionClosed.Store(0)
+	s.connectionCheckedIn.Store(0)
+	s.connectionCheckOutStarted.Store(0)
+	s.connectionCheckedOut.Store(0)
+	s.connectionCheckOutFailed.Store(0)
+	s.connectionPoolCleared.Store(0)
+	s.mu.Lock()
+	s.checkoutDurations = nil
+	s.mu.Unlock()
+}
+
+func (s *mongoPoolStats) Snapshot() *mongoPoolSnapshot {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	durations := append([]time.Duration(nil), s.checkoutDurations...)
+	s.mu.Unlock()
+	var aggregate time.Duration
+	for _, duration := range durations {
+		aggregate += duration
+	}
+	snapshot := &mongoPoolSnapshot{
+		ConnectionCreated:         s.connectionCreated.Load(),
+		ConnectionReady:           s.connectionReady.Load(),
+		ConnectionClosed:          s.connectionClosed.Load(),
+		ConnectionCheckedIn:       s.connectionCheckedIn.Load(),
+		ConnectionCheckOutStarted: s.connectionCheckOutStarted.Load(),
+		ConnectionCheckedOut:      s.connectionCheckedOut.Load(),
+		ConnectionCheckOutFailed:  s.connectionCheckOutFailed.Load(),
+		ConnectionPoolCleared:     s.connectionPoolCleared.Load(),
+		CheckoutAggregateMillis:   float64(aggregate.Microseconds()) / 1000.0,
+		CheckoutLatencyMicros:     summarizeLatency(durations),
+	}
+	if len(durations) > 0 {
+		snapshot.CheckoutMeanLatencyMicros = float64(aggregate.Microseconds()) / float64(len(durations))
+	}
+	return snapshot
+}
+
+func (s *mongoPoolStats) record(evt *event.PoolEvent) {
+	if s == nil || evt == nil {
+		return
+	}
+	switch evt.Type {
+	case event.ConnectionCreated:
+		s.connectionCreated.Add(1)
+	case event.ConnectionReady:
+		s.connectionReady.Add(1)
+	case event.ConnectionClosed:
+		s.connectionClosed.Add(1)
+	case event.ConnectionCheckedIn:
+		s.connectionCheckedIn.Add(1)
+	case event.ConnectionCheckOutStarted:
+		s.connectionCheckOutStarted.Add(1)
+	case event.ConnectionCheckedOut:
+		s.connectionCheckedOut.Add(1)
+		s.recordCheckoutDuration(evt.Duration)
+	case event.ConnectionCheckOutFailed:
+		s.connectionCheckOutFailed.Add(1)
+		s.recordCheckoutDuration(evt.Duration)
+	case event.ConnectionPoolCleared:
+		s.connectionPoolCleared.Add(1)
+	}
+}
+
+func (s *mongoPoolStats) recordCheckoutDuration(duration time.Duration) {
+	if duration <= 0 {
+		return
+	}
+	s.mu.Lock()
+	s.checkoutDurations = append(s.checkoutDurations, duration)
+	s.mu.Unlock()
 }
 
 const (
@@ -199,6 +348,7 @@ func parseConfig(args []string) (config, error) {
 		TreeDBIndexRootStorage:      collections.RootStorageCompressed,
 		TreeDBMaintenance:           treeDBMaintenanceFull,
 		ClientMode:                  clientModeDriver,
+		InsertProducers:             1,
 	}
 	fs := flag.NewFlagSet("mongo_gateway_bench", flag.ContinueOnError)
 	var flagOutput bytes.Buffer
@@ -219,6 +369,10 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.Collection, "collection", "docs", "collection name")
 	fs.IntVar(&cfg.Documents, "documents", 1000, "documents to insert")
 	fs.IntVar(&cfg.BatchSize, "batch-size", 500, "InsertMany batch size")
+	fs.IntVar(&cfg.InsertProducers, "insert-producers", cfg.InsertProducers, "producer goroutines for the insert load phase")
+	fs.IntVar(&cfg.MongoMaxPoolSize, "mongo-max-pool-size", 0, "MongoDB Go driver maxPoolSize; 0 leaves the driver default")
+	fs.IntVar(&cfg.MongoMinPoolSize, "mongo-min-pool-size", 0, "MongoDB Go driver minPoolSize; 0 leaves the driver default")
+	fs.IntVar(&cfg.MongoMaxConnecting, "mongo-max-connecting", 0, "MongoDB Go driver maxConnecting; 0 leaves the driver default")
 	fs.IntVar(&cfg.Reads, "reads", 1000, "point reads by _id and by email")
 	fs.IntVar(&cfg.RangeReads, "range-reads", 100, "range reads with limit")
 	fs.IntVar(&cfg.Updates, "updates", 100, "$set updates by _id")
@@ -260,6 +414,12 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.BatchSize <= 0 {
 		return config{}, errors.New("batch-size must be > 0")
+	}
+	if cfg.InsertProducers <= 0 {
+		return config{}, errors.New("insert-producers must be > 0")
+	}
+	if cfg.MongoMaxPoolSize < 0 || cfg.MongoMinPoolSize < 0 || cfg.MongoMaxConnecting < 0 {
+		return config{}, errors.New("MongoDB pool option values cannot be negative")
 	}
 	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 || cfg.ConcurrentReads < 0 || cfg.ConcurrentWrites < 0 {
 		return config{}, errors.New("operation counts cannot be negative")
@@ -460,10 +620,9 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 	serveErr := make(chan error, 1)
 	go serveLoop(serveCtx, ln, server, serveErr)
 
-	client, err := mongo.Connect(options.Client().
-		ApplyURI("mongodb://" + ln.Addr().String()).
-		SetDirect(true).
-		SetServerSelectionTimeout(5 * time.Second))
+	poolStats := newMongoPoolStats()
+	clientOpts := mongoClientOptions("mongodb://"+ln.Addr().String(), cfg, poolStats).SetDirect(true)
+	client, err := mongo.Connect(clientOpts)
 	if err != nil {
 		cancelServe()
 		_ = ln.Close()
@@ -507,6 +666,7 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 		mongoAddr:       ln.Addr().String(),
 		treedbDir:       dir,
 		removeTreeDBDir: removeDir,
+		poolStats:       poolStats,
 		cleanup:         cleanup,
 	}, nil
 }
@@ -650,9 +810,8 @@ func unsafeResetPathMode(mode os.FileMode) bool {
 }
 
 func openMongoTarget(ctx context.Context, cfg config) (*benchTarget, error) {
-	client, err := mongo.Connect(options.Client().
-		ApplyURI(cfg.MongoURI).
-		SetServerSelectionTimeout(5 * time.Second))
+	poolStats := newMongoPoolStats()
+	client, err := mongo.Connect(mongoClientOptions(cfg.MongoURI, cfg, poolStats))
 	if err != nil {
 		return nil, err
 	}
@@ -667,11 +826,31 @@ func openMongoTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 		}
 	}
 	return &benchTarget{
-		client: client,
+		client:    client,
+		poolStats: poolStats,
 		cleanup: func(cleanupCtx context.Context) error {
 			return client.Disconnect(cleanupCtx)
 		},
 	}, nil
+}
+
+func mongoClientOptions(uri string, cfg config, poolStats *mongoPoolStats) *options.ClientOptions {
+	opts := options.Client().
+		ApplyURI(uri).
+		SetServerSelectionTimeout(5 * time.Second)
+	if cfg.MongoMaxPoolSize > 0 {
+		opts.SetMaxPoolSize(uint64(cfg.MongoMaxPoolSize))
+	}
+	if cfg.MongoMinPoolSize > 0 {
+		opts.SetMinPoolSize(uint64(cfg.MongoMinPoolSize))
+	}
+	if cfg.MongoMaxConnecting > 0 {
+		opts.SetMaxConnecting(uint64(cfg.MongoMaxConnecting))
+	}
+	if poolStats != nil {
+		opts.SetPoolMonitor(poolStats.Monitor())
+	}
+	return opts
 }
 
 func redactMongoURI(rawURI string) string {
@@ -709,17 +888,22 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	db := target.client.Database(cfg.Database)
 	coll := db.Collection(cfg.Collection)
 	result := &benchmarkResult{
-		Target:            cfg.Target,
-		Database:          cfg.Database,
-		Collection:        cfg.Collection,
-		Documents:         cfg.Documents,
-		SecondaryIndexes:  cfg.SecondaryIndexes,
-		ClientMode:        cfg.ClientMode,
-		ConcurrentReaders: cfg.ConcurrentReaders,
-		ConcurrentReads:   cfg.ConcurrentReads,
-		ConcurrentWriters: cfg.ConcurrentWriters,
-		ConcurrentWrites:  cfg.ConcurrentWrites,
-		PrebuildDocuments: cfg.PrebuildDocuments,
+		Target:             cfg.Target,
+		Database:           cfg.Database,
+		Collection:         cfg.Collection,
+		Documents:          cfg.Documents,
+		BatchSize:          cfg.BatchSize,
+		InsertProducers:    cfg.InsertProducers,
+		MongoMaxPoolSize:   cfg.MongoMaxPoolSize,
+		MongoMinPoolSize:   cfg.MongoMinPoolSize,
+		MongoMaxConnecting: cfg.MongoMaxConnecting,
+		SecondaryIndexes:   cfg.SecondaryIndexes,
+		ClientMode:         cfg.ClientMode,
+		ConcurrentReaders:  cfg.ConcurrentReaders,
+		ConcurrentReads:    cfg.ConcurrentReads,
+		ConcurrentWriters:  cfg.ConcurrentWriters,
+		ConcurrentWrites:   cfg.ConcurrentWrites,
+		PrebuildDocuments:  cfg.PrebuildDocuments,
 	}
 	if cfg.Target == "treedb" {
 		if cfg.TreeDBDir != "" || cfg.KeepTreeDBDir {
@@ -753,11 +937,17 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 			prebuiltRaw[i] = bson.Raw(raw)
 		}
 	}
+	if target.poolStats != nil {
+		target.poolStats.Reset()
+	}
 	loadPhase, err := runLoadPhase(ctx, cfg, target, coll, prebuilt, prebuiltRaw)
 	if err != nil {
 		return nil, err
 	}
 	result.Phases = append(result.Phases, loadPhase)
+	if target.poolStats != nil {
+		result.MongoPoolStatsAfterLoad = target.poolStats.Snapshot()
+	}
 	if err := collectAfterLoadStats(ctx, cfg, target, result); err != nil {
 		return nil, err
 	}
@@ -933,6 +1123,9 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	if err := collectFinalStats(ctx, cfg, target, result); err != nil {
 		return nil, err
 	}
+	if target.poolStats != nil {
+		result.MongoPoolStatsFinal = target.poolStats.Snapshot()
+	}
 	return result, nil
 }
 
@@ -980,82 +1173,47 @@ func runLoadPhase(ctx context.Context, cfg config, target *benchTarget, coll *mo
 }
 
 func runDriverLoadPhase(ctx context.Context, cfg config, coll *mongo.Collection, prebuilt []bson.D) (phaseResult, error) {
-	return measurePhase("load_insert_many", cfg.Documents, func(sample func(time.Duration)) error {
-		for start := 0; start < cfg.Documents; start += cfg.BatchSize {
-			end := start + cfg.BatchSize
-			if end > cfg.Documents {
-				end = cfg.Documents
-			}
-			docs := make([]any, 0, end-start)
-			for i := start; i < end; i++ {
-				if prebuilt != nil {
-					docs = append(docs, prebuilt[i])
-				} else {
-					docs = append(docs, benchmarkDocument(i))
-				}
-			}
-			begin := time.Now()
-			_, err := coll.InsertMany(ctx, docs)
-			sample(time.Since(begin))
-			if err != nil {
-				return err
+	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+		docs := make([]any, 0, end-start)
+		for i := start; i < end; i++ {
+			if prebuilt != nil {
+				docs = append(docs, prebuilt[i])
+			} else {
+				docs = append(docs, benchmarkDocument(i))
 			}
 		}
-		return nil
+		_, err := coll.InsertMany(ctx, docs)
+		return err
 	})
 }
 
 func runDriverCommandLoadPhase(ctx context.Context, cfg config, db *mongo.Database, prebuilt []bson.D, prebuiltRaw []bson.Raw) (phaseResult, error) {
-	return measurePhase("load_insert_many", cfg.Documents, func(sample func(time.Duration)) error {
-		for start := 0; start < cfg.Documents; start += cfg.BatchSize {
-			end := start + cfg.BatchSize
-			if end > cfg.Documents {
-				end = cfg.Documents
-			}
-			docs := make(bson.A, 0, end-start)
-			for i := start; i < end; i++ {
-				if prebuiltRaw != nil {
-					docs = append(docs, prebuiltRaw[i])
-				} else if prebuilt != nil {
-					docs = append(docs, prebuilt[i])
-				} else {
-					docs = append(docs, benchmarkDocument(i))
-				}
-			}
-			begin := time.Now()
-			err := db.RunCommand(ctx, bson.D{
-				{Key: "insert", Value: cfg.Collection},
-				{Key: "documents", Value: docs},
-				{Key: "ordered", Value: true},
-			}).Err()
-			sample(time.Since(begin))
-			if err != nil {
-				return err
+	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+		docs := make(bson.A, 0, end-start)
+		for i := start; i < end; i++ {
+			if prebuiltRaw != nil {
+				docs = append(docs, prebuiltRaw[i])
+			} else if prebuilt != nil {
+				docs = append(docs, prebuilt[i])
+			} else {
+				docs = append(docs, benchmarkDocument(i))
 			}
 		}
-		return nil
+		return db.RunCommand(ctx, bson.D{
+			{Key: "insert", Value: cfg.Collection},
+			{Key: "documents", Value: docs},
+			{Key: "ordered", Value: true},
+		}).Err()
 	})
 }
 
 func runDriverCommandRawLoadPhase(ctx context.Context, cfg config, db *mongo.Database, prebuilt []bson.D, prebuiltRaw []bson.Raw) (phaseResult, error) {
-	return measurePhase("load_insert_many", cfg.Documents, func(sample func(time.Duration)) error {
-		for start := 0; start < cfg.Documents; start += cfg.BatchSize {
-			end := start + cfg.BatchSize
-			if end > cfg.Documents {
-				end = cfg.Documents
-			}
-			command, err := rawInsertCommand(cfg.Collection, start, end, prebuilt, prebuiltRaw)
-			if err != nil {
-				return err
-			}
-			begin := time.Now()
-			err = db.RunCommand(ctx, command).Err()
-			sample(time.Since(begin))
-			if err != nil {
-				return err
-			}
+	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+		command, err := rawInsertCommand(cfg.Collection, start, end, prebuilt, prebuiltRaw)
+		if err != nil {
+			return err
 		}
-		return nil
+		return db.RunCommand(ctx, command).Err()
 	})
 }
 
@@ -1098,27 +1256,18 @@ func rawInsertCommand(collection string, start, end int, prebuilt []bson.D, preb
 func runDriverUnackLoadPhase(ctx context.Context, cfg config, db *mongo.Database, prebuilt []bson.D) (phaseResult, error) {
 	unackColl := db.Collection(cfg.Collection, options.Collection().SetWriteConcern(writeconcern.Unacknowledged()))
 	ackColl := db.Collection(cfg.Collection)
-	return measurePhase("load_insert_many", cfg.Documents, func(sample func(time.Duration)) error {
-		for start := 0; start < cfg.Documents; start += cfg.BatchSize {
-			end := start + cfg.BatchSize
-			if end > cfg.Documents {
-				end = cfg.Documents
-			}
-			docs := make([]any, 0, end-start)
-			for i := start; i < end; i++ {
-				if prebuilt != nil {
-					docs = append(docs, prebuilt[i])
-				} else {
-					docs = append(docs, benchmarkDocument(i))
-				}
-			}
-			begin := time.Now()
-			_, err := unackColl.InsertMany(ctx, docs)
-			sample(time.Since(begin))
-			if err != nil {
-				return err
+	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+		docs := make([]any, 0, end-start)
+		for i := start; i < end; i++ {
+			if prebuilt != nil {
+				docs = append(docs, prebuilt[i])
+			} else {
+				docs = append(docs, benchmarkDocument(i))
 			}
 		}
+		_, err := unackColl.InsertMany(ctx, docs)
+		return err
+	}, func() error {
 		return waitForLoadVisible(ctx, cfg, ackColl)
 	})
 }
@@ -1165,46 +1314,27 @@ func runTreeDBRawWireLoadPhase(ctx context.Context, cfg config, target *benchTar
 		return phaseResult{}, err
 	}
 	commandDoc := wire.Document(commandRaw)
-	var requestID int32
-	return measurePhase("load_insert_many", cfg.Documents, func(sample func(time.Duration)) error {
-		for start := 0; start < cfg.Documents; start += cfg.BatchSize {
-			if err := ctx.Err(); err != nil {
-				return err
+	var requestID atomic.Int32
+	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+		docs := make([]wire.Document, end-start)
+		for i := start; i < end; i++ {
+			if prebuiltRaw != nil {
+				docs[i-start] = wire.Document(prebuiltRaw[i])
+				continue
 			}
-			end := start + cfg.BatchSize
-			if end > cfg.Documents {
-				end = cfg.Documents
+			var doc bson.D
+			if prebuilt != nil {
+				doc = prebuilt[i]
+			} else {
+				doc = benchmarkDocument(i)
 			}
-			docs := make([]wire.Document, end-start)
-			for i := start; i < end; i++ {
-				if prebuiltRaw != nil {
-					docs[i-start] = wire.Document(prebuiltRaw[i])
-					continue
-				}
-				var doc bson.D
-				if prebuilt != nil {
-					doc = prebuilt[i]
-				} else {
-					doc = benchmarkDocument(i)
-				}
-				raw, err := bson.Marshal(doc)
-				if err != nil {
-					return err
-				}
-				docs[i-start] = wire.Document(raw)
-			}
-			requestID++
-			begin := time.Now()
-			err := serveRawWireInsert(target.server, requestID, commandDoc, docs)
-			sample(time.Since(begin))
+			raw, err := bson.Marshal(doc)
 			if err != nil {
 				return err
 			}
-			if err := ctx.Err(); err != nil {
-				return err
-			}
+			docs[i-start] = wire.Document(raw)
 		}
-		return nil
+		return serveRawWireInsert(target.server, requestID.Add(1), int64(producer+1), commandDoc, docs)
 	})
 }
 
@@ -1212,32 +1342,31 @@ func runTreeDBRawWireTCPLoadPhase(ctx context.Context, cfg config, target *bench
 	if target == nil || target.mongoAddr == "" {
 		return phaseResult{}, errors.New("raw-wire-tcp client mode requires a TreeDB gateway listener")
 	}
-	client, err := fastclient.Connect(ctx, target.mongoAddr)
-	if err != nil {
-		return phaseResult{}, err
-	}
-	defer func() { _ = client.Close() }()
-	return measurePhase("load_insert_many", cfg.Documents, func(sample func(time.Duration)) error {
-		for start := 0; start < cfg.Documents; start += cfg.BatchSize {
-			if err := ctx.Err(); err != nil {
-				return err
+	clients := make([]*fastclient.Client, cfg.InsertProducers)
+	for i := range clients {
+		client, err := fastclient.Connect(ctx, target.mongoAddr)
+		if err != nil {
+			for _, existing := range clients {
+				if existing != nil {
+					_ = existing.Close()
+				}
 			}
-			end := start + cfg.BatchSize
-			if end > cfg.Documents {
-				end = cfg.Documents
-			}
-			docs, err := rawBSONDocuments(start, end, prebuilt, prebuiltRaw)
-			if err != nil {
-				return err
-			}
-			begin := time.Now()
-			_, err = client.InsertManyRawBSON(ctx, cfg.Database, cfg.Collection, docs)
-			sample(time.Since(begin))
-			if err != nil {
-				return err
-			}
+			return phaseResult{}, err
 		}
-		return nil
+		clients[i] = client
+	}
+	defer func() {
+		for _, client := range clients {
+			_ = client.Close()
+		}
+	}()
+	return measureLoadPhase(ctx, cfg, func(producer, start, end int) error {
+		docs, err := rawBSONDocuments(start, end, prebuilt, prebuiltRaw)
+		if err != nil {
+			return err
+		}
+		_, err = clients[producer].InsertManyRawBSON(ctx, cfg.Database, cfg.Collection, docs)
+		return err
 	})
 }
 
@@ -1275,7 +1404,7 @@ func rawBSONDocuments(start, end int, prebuilt []bson.D, prebuiltRaw []bson.Raw)
 	return docs, nil
 }
 
-func serveRawWireInsert(server *mongogateway.Server, requestID int32, commandDoc wire.Document, docs []wire.Document) error {
+func serveRawWireInsert(server *mongogateway.Server, requestID int32, cursorOwner int64, commandDoc wire.Document, docs []wire.Document) error {
 	msg, err := wire.AppendMsgMessageWithSequences(nil, requestID, 0, 0, commandDoc, []wire.DocumentSequence{{
 		Identifier: "documents",
 		Documents:  docs,
@@ -1284,7 +1413,7 @@ func serveRawWireInsert(server *mongogateway.Server, requestID int32, commandDoc
 		return err
 	}
 	rw := inMemoryReadWriter{r: bytes.NewReader(msg)}
-	if err := server.ServeOneWithOwner(&rw, 1); err != nil {
+	if err := server.ServeOneWithOwner(&rw, cursorOwner); err != nil {
 		return err
 	}
 	return assertRawWireInsertOK(rw.w.Bytes(), len(docs))
@@ -1651,6 +1780,158 @@ func int64Value(value any) (int64, bool) {
 	}
 }
 
+type loadBatch struct {
+	start int
+	end   int
+}
+
+func makeLoadBatches(documents, batchSize int) []loadBatch {
+	if documents <= 0 || batchSize <= 0 {
+		return nil
+	}
+	batches := make([]loadBatch, 0, (documents+batchSize-1)/batchSize)
+	for start := 0; start < documents; start += batchSize {
+		end := start + batchSize
+		if end > documents {
+			end = documents
+		}
+		batches = append(batches, loadBatch{start: start, end: end})
+	}
+	return batches
+}
+
+func measureLoadPhase(ctx context.Context, cfg config, runBatch func(producer, start, end int) error, after ...func() error) (phaseResult, error) {
+	batches := makeLoadBatches(cfg.Documents, cfg.BatchSize)
+	producers := cfg.InsertProducers
+	if producers <= 0 {
+		producers = 1
+	}
+	if len(batches) > 0 && producers > len(batches) {
+		producers = len(batches)
+	}
+	if producers <= 0 {
+		producers = 1
+	}
+
+	samples := make([]time.Duration, 0, len(batches))
+	producerSamples := make([][]time.Duration, producers)
+	producerOperations := make([]int, producers)
+	producerDurations := make([]time.Duration, producers)
+	var samplesMu sync.Mutex
+	recordBatch := func(producer, operations int, duration time.Duration) {
+		samplesMu.Lock()
+		samples = append(samples, duration)
+		if producer >= 0 && producer < producers {
+			producerOperations[producer] += operations
+			producerSamples[producer] = append(producerSamples[producer], duration)
+		}
+		samplesMu.Unlock()
+	}
+	recordProducerDuration := func(producer int, duration time.Duration) {
+		if producer < 0 || producer >= producers {
+			return
+		}
+		samplesMu.Lock()
+		producerDurations[producer] = duration
+		samplesMu.Unlock()
+	}
+
+	started := time.Now()
+	err := runLoadBatches(ctx, batches, producers, runBatch, recordBatch, recordProducerDuration)
+	if err == nil {
+		for _, hook := range after {
+			if hook == nil {
+				continue
+			}
+			if hookErr := hook(); hookErr != nil {
+				err = hookErr
+				break
+			}
+		}
+	}
+	duration := time.Since(started)
+	result := summarizePhase("load_insert_many", cfg.Documents, len(samples), duration, samples)
+	if cfg.InsertProducers > 1 {
+		result.ProducerResults = make([]producerResult, 0, producers)
+		for producer := 0; producer < producers; producer++ {
+			result.ProducerResults = append(result.ProducerResults, summarizeProducerResult(
+				producer,
+				producerOperations[producer],
+				len(producerSamples[producer]),
+				producerDurations[producer],
+				producerSamples[producer],
+			))
+		}
+	}
+	return result, err
+}
+
+func runLoadBatches(
+	ctx context.Context,
+	batches []loadBatch,
+	producers int,
+	runBatch func(producer, start, end int) error,
+	recordBatch func(producer, operations int, duration time.Duration),
+	recordProducerDuration func(producer int, duration time.Duration),
+) error {
+	if len(batches) == 0 {
+		return nil
+	}
+	if producers <= 0 {
+		producers = 1
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	var errOnce sync.Once
+	var firstErr error
+	recordErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errOnce.Do(func() {
+			firstErr = err
+			cancel()
+		})
+	}
+
+	for producer := 0; producer < producers; producer++ {
+		wg.Add(1)
+		go func(producer int) {
+			defer wg.Done()
+			producerStart := time.Now()
+			defer func() {
+				recordProducerDuration(producer, time.Since(producerStart))
+			}()
+			for {
+				if err := runCtx.Err(); err != nil {
+					return
+				}
+				batchIndex := int(next.Add(1) - 1)
+				if batchIndex >= len(batches) {
+					return
+				}
+				batch := batches[batchIndex]
+				started := time.Now()
+				err := runBatch(producer, batch.start, batch.end)
+				elapsed := time.Since(started)
+				recordBatch(producer, batch.end-batch.start, elapsed)
+				if err != nil {
+					recordErr(err)
+					return
+				}
+			}
+		}(producer)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return firstErr
+	}
+	return ctx.Err()
+}
+
 func measurePhase(name string, operations int, run func(sample func(time.Duration)) error) (phaseResult, error) {
 	samples := make([]time.Duration, 0)
 	var samplesMu sync.Mutex
@@ -1738,6 +2019,28 @@ func summarizePhase(name string, operations, driverCalls int, duration time.Dura
 	return result
 }
 
+func summarizeProducerResult(producer, operations, driverCalls int, duration time.Duration, samples []time.Duration) producerResult {
+	var driverDuration time.Duration
+	for _, sample := range samples {
+		driverDuration += sample
+	}
+	result := producerResult{
+		Producer:              producer,
+		Operations:            operations,
+		DriverCalls:           driverCalls,
+		DurationMillis:        float64(duration.Microseconds()) / 1000.0,
+		DriverAggregateMillis: float64(driverDuration.Microseconds()) / 1000.0,
+		LatencyMicros:         summarizeLatency(samples),
+	}
+	if duration > 0 {
+		result.OpsPerSecond = float64(operations) / duration.Seconds()
+	}
+	if driverCalls > 0 && driverDuration > 0 {
+		result.DriverMeanLatencyMicros = float64(driverDuration.Microseconds()) / float64(driverCalls)
+	}
+	return result
+}
+
 func summarizeLatency(samples []time.Duration) latencySummary {
 	if len(samples) == 0 {
 		return latencySummary{}
@@ -1813,8 +2116,9 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(result)
 	case "text":
-		fmt.Fprintf(out, "target=%s client_mode=%s database=%s collection=%s documents=%d secondary_indexes=%d concurrent_readers=%d concurrent_reads=%d concurrent_writers=%d concurrent_writes=%d\n",
-			result.Target, result.ClientMode, result.Database, result.Collection, result.Documents, result.SecondaryIndexes,
+		fmt.Fprintf(out, "target=%s client_mode=%s database=%s collection=%s documents=%d batch_size=%d insert_producers=%d mongo_max_pool_size=%d mongo_min_pool_size=%d mongo_max_connecting=%d secondary_indexes=%d concurrent_readers=%d concurrent_reads=%d concurrent_writers=%d concurrent_writes=%d\n",
+			result.Target, result.ClientMode, result.Database, result.Collection, result.Documents, result.BatchSize,
+			result.InsertProducers, result.MongoMaxPoolSize, result.MongoMinPoolSize, result.MongoMaxConnecting, result.SecondaryIndexes,
 			result.ConcurrentReaders, result.ConcurrentReads, result.ConcurrentWriters, result.ConcurrentWrites)
 		if result.TreeDBDir != "" {
 			fmt.Fprintf(out, "treedb_dir=%s\n", result.TreeDBDir)
@@ -1832,6 +2136,15 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 				phase.Name, phase.Operations, phase.DriverCalls, phase.DurationMillis, phase.OpsPerSecond,
 				phase.SampledOpsPerSecond, phase.SampledNsPerOp, phase.DriverAggregateMillis, phase.DriverMeanLatencyMicros,
 				phase.LatencyMicros.P50, phase.LatencyMicros.P95, phase.LatencyMicros.P99)
+			for _, producer := range phase.ProducerResults {
+				fmt.Fprintf(out, "  producer=%d ops=%d calls=%d duration_ms=%.1f ops_sec=%.1f driver_aggregate_ms=%.1f driver_mean_us=%.0f p50_us=%.0f p95_us=%.0f p99_us=%.0f\n",
+					producer.Producer, producer.Operations, producer.DriverCalls, producer.DurationMillis, producer.OpsPerSecond,
+					producer.DriverAggregateMillis, producer.DriverMeanLatencyMicros,
+					producer.LatencyMicros.P50, producer.LatencyMicros.P95, producer.LatencyMicros.P99)
+			}
+		}
+		if result.MongoPoolStatsAfterLoad != nil {
+			writeMongoPoolStats(out, "mongo_pool_after_load", result.MongoPoolStatsAfterLoad)
 		}
 		if result.TreeDBDiskAfterLoad != nil {
 			writeDiskSnapshot(out, "treedb_after_load", result.TreeDBDiskAfterLoad)
@@ -1850,6 +2163,9 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		}
 		if result.MongoDBStatsFinal != nil {
 			writeMongoStats(out, "mongodb_final", result.MongoDBStatsFinal)
+		}
+		if result.MongoPoolStatsFinal != nil {
+			writeMongoPoolStats(out, "mongo_pool_final", result.MongoPoolStatsFinal)
 		}
 		return nil
 	default:
@@ -1898,4 +2214,26 @@ func writeMongoStats(out io.Writer, label string, stats map[string]any) {
 		}
 	}
 	fmt.Fprintln(out)
+}
+
+func writeMongoPoolStats(out io.Writer, label string, stats *mongoPoolSnapshot) {
+	if stats == nil {
+		return
+	}
+	fmt.Fprintf(out, "%s created=%d ready=%d closed=%d checkout_started=%d checked_out=%d checked_in=%d checkout_failed=%d pool_cleared=%d checkout_aggregate_ms=%.1f checkout_mean_us=%.0f checkout_p50_us=%.0f checkout_p95_us=%.0f checkout_p99_us=%.0f\n",
+		label,
+		stats.ConnectionCreated,
+		stats.ConnectionReady,
+		stats.ConnectionClosed,
+		stats.ConnectionCheckOutStarted,
+		stats.ConnectionCheckedOut,
+		stats.ConnectionCheckedIn,
+		stats.ConnectionCheckOutFailed,
+		stats.ConnectionPoolCleared,
+		stats.CheckoutAggregateMillis,
+		stats.CheckoutMeanLatencyMicros,
+		stats.CheckoutLatencyMicros.P50,
+		stats.CheckoutLatencyMicros.P95,
+		stats.CheckoutLatencyMicros.P99,
+	)
 }

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -361,6 +361,12 @@ func TestParseConfigValidation(t *testing.T) {
 	if _, err := parseConfig([]string{"-mongo-max-pool-size", "4", "-mongo-min-pool-size", "8"}); err == nil {
 		t.Fatal("mongo-min-pool-size greater than mongo-max-pool-size accepted")
 	}
+	if _, err := parseConfig([]string{"-mongo-min-pool-size", "101"}); err == nil {
+		t.Fatal("mongo-min-pool-size greater than default mongo-max-pool-size accepted")
+	}
+	if _, err := parseConfig([]string{"-mongo-min-pool-size", "100"}); err != nil {
+		t.Fatalf("mongo-min-pool-size equal to default mongo-max-pool-size rejected: %v", err)
+	}
 }
 
 func TestRawInsertCommandBuildsBSONCommand(t *testing.T) {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -36,6 +36,19 @@ func TestSummarizeLatencyNearestRank(t *testing.T) {
 	}
 }
 
+func TestSummarizePhaseZeroOperationsWithSamples(t *testing.T) {
+	phase := summarizePhase("load_insert_many", 0, 1, time.Millisecond, []time.Duration{time.Millisecond})
+	if phase.DriverMeanLatencyMicros == 0 {
+		t.Fatal("driver mean latency should still be reported for sampled driver calls")
+	}
+	if phase.SampledOpsPerSecond != 0 {
+		t.Fatalf("sampled ops/sec=%v want 0 for zero completed operations", phase.SampledOpsPerSecond)
+	}
+	if phase.SampledNsPerOp != 0 {
+		t.Fatalf("sampled ns/op=%v want 0 for zero completed operations", phase.SampledNsPerOp)
+	}
+}
+
 func TestCollectDiskSnapshotBreakdown(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.db"), []byte("1234"), 0o600); err != nil {
@@ -344,6 +357,9 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if _, err := parseConfig([]string{"-mongo-max-pool-size", "-1"}); err == nil {
 		t.Fatal("negative mongo-max-pool-size accepted")
+	}
+	if _, err := parseConfig([]string{"-mongo-max-pool-size", "4", "-mongo-min-pool-size", "8"}); err == nil {
+		t.Fatal("mongo-min-pool-size greater than mongo-max-pool-size accepted")
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -14,6 +14,7 @@ import (
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/event"
 )
 
 func TestSummarizeLatencyNearestRank(t *testing.T) {
@@ -647,6 +648,15 @@ func TestMakeLoadBatchesSplitsDocumentRange(t *testing.T) {
 	}
 }
 
+func TestEffectiveLoadProducersCapsAtBatchCount(t *testing.T) {
+	if got := effectiveLoadProducers(10, 4, 8); got != 3 {
+		t.Fatalf("effectiveLoadProducers=%d want 3", got)
+	}
+	if got := effectiveLoadProducers(10, 4, 2); got != 2 {
+		t.Fatalf("effectiveLoadProducers=%d want 2", got)
+	}
+}
+
 func TestMeasureLoadPhaseReportsProducerResults(t *testing.T) {
 	cfg := config{Documents: 12, BatchSize: 2, InsertProducers: 3}
 	seen := make([]atomic.Int64, cfg.Documents)
@@ -665,6 +675,9 @@ func TestMeasureLoadPhaseReportsProducerResults(t *testing.T) {
 	if phase.Name != "load_insert_many" || phase.Operations != cfg.Documents || phase.DriverCalls != 6 {
 		t.Fatalf("unexpected phase summary: %+v", phase)
 	}
+	if phase.EffectiveProducers != cfg.InsertProducers {
+		t.Fatalf("EffectiveProducers=%d want %d", phase.EffectiveProducers, cfg.InsertProducers)
+	}
 	if len(phase.ProducerResults) != cfg.InsertProducers {
 		t.Fatalf("producer results=%d want %d: %+v", len(phase.ProducerResults), cfg.InsertProducers, phase.ProducerResults)
 	}
@@ -680,6 +693,47 @@ func TestMeasureLoadPhaseReportsProducerResults(t *testing.T) {
 		if got := seen[doc].Load(); got != 1 {
 			t.Fatalf("doc %d seen %d times, want once", doc, got)
 		}
+	}
+}
+
+func TestMeasureLoadPhaseErrorReportsCompletedOperations(t *testing.T) {
+	sentinel := errors.New("load failed")
+	cfg := config{Documents: 6, BatchSize: 2, InsertProducers: 1}
+	phase, err := measureLoadPhase(context.Background(), cfg, func(producer, start, end int) error {
+		if start >= 2 {
+			return sentinel
+		}
+		return nil
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err=%v want sentinel", err)
+	}
+	if phase.Operations != 2 {
+		t.Fatalf("Operations=%d want completed operations 2", phase.Operations)
+	}
+	if phase.DriverCalls != 2 {
+		t.Fatalf("DriverCalls=%d want 2", phase.DriverCalls)
+	}
+}
+
+func TestMongoPoolStatsCapsCheckoutSamples(t *testing.T) {
+	stats := newMongoPoolStats()
+	total := maxMongoPoolCheckoutDurationSamples + 3
+	for i := 0; i < total; i++ {
+		stats.record(&event.PoolEvent{Type: event.ConnectionCheckedOut, Duration: time.Microsecond})
+	}
+	snapshot := stats.Snapshot()
+	if snapshot.ConnectionCheckedOut != int64(total) {
+		t.Fatalf("ConnectionCheckedOut=%d want %d", snapshot.ConnectionCheckedOut, total)
+	}
+	if snapshot.CheckoutSamples != int64(maxMongoPoolCheckoutDurationSamples) {
+		t.Fatalf("CheckoutSamples=%d want %d", snapshot.CheckoutSamples, maxMongoPoolCheckoutDurationSamples)
+	}
+	if snapshot.CheckoutSamplesDropped != 3 {
+		t.Fatalf("CheckoutSamplesDropped=%d want 3", snapshot.CheckoutSamplesDropped)
+	}
+	if snapshot.CheckoutMeanLatencyMicros != 1 {
+		t.Fatalf("CheckoutMeanLatencyMicros=%f want 1", snapshot.CheckoutMeanLatencyMicros)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -657,6 +657,19 @@ func TestEffectiveLoadProducersCapsAtBatchCount(t *testing.T) {
 	}
 }
 
+func TestLoadVisibilitySentinelIDsUseBatchBoundaries(t *testing.T) {
+	got := loadVisibilitySentinelIDs(10, 4)
+	want := []string{benchmarkID(3), benchmarkID(7), benchmarkID(9)}
+	if len(got) != len(want) {
+		t.Fatalf("len(sentinels)=%d want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sentinel %d=%q want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestMeasureLoadPhaseReportsProducerResults(t *testing.T) {
 	cfg := config{Documents: 12, BatchSize: 2, InsertProducers: 3}
 	seen := make([]atomic.Int64, cfg.Documents)

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -689,7 +689,10 @@ func TestLoadVisibilitySentinelIDsUseBatchBoundaries(t *testing.T) {
 func TestMeasureLoadPhaseReportsProducerResults(t *testing.T) {
 	cfg := config{Documents: 12, BatchSize: 2, InsertProducers: 3}
 	seen := make([]atomic.Int64, cfg.Documents)
-	phase, err := measureLoadPhase(context.Background(), cfg, func(producer, start, end int) error {
+	phase, err := measureLoadPhase(context.Background(), cfg, func(ctx context.Context, producer, start, end int) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if producer < 0 || producer >= cfg.InsertProducers {
 			return os.ErrInvalid
 		}
@@ -728,7 +731,10 @@ func TestMeasureLoadPhaseReportsProducerResults(t *testing.T) {
 func TestMeasureLoadPhaseErrorReportsCompletedOperations(t *testing.T) {
 	sentinel := errors.New("load failed")
 	cfg := config{Documents: 6, BatchSize: 2, InsertProducers: 1}
-	phase, err := measureLoadPhase(context.Background(), cfg, func(producer, start, end int) error {
+	phase, err := measureLoadPhase(context.Background(), cfg, func(ctx context.Context, producer, start, end int) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if start >= 2 {
 			return sentinel
 		}
@@ -742,6 +748,57 @@ func TestMeasureLoadPhaseErrorReportsCompletedOperations(t *testing.T) {
 	}
 	if phase.DriverCalls != 2 {
 		t.Fatalf("DriverCalls=%d want 2", phase.DriverCalls)
+	}
+}
+
+func TestRunLoadBatchesCancelsInFlightBatchContext(t *testing.T) {
+	sentinel := errors.New("load failed")
+	releaseFailure := make(chan struct{})
+	started := make(chan int, 2)
+	done := make(chan error, 1)
+	go func() {
+		done <- runLoadBatches(
+			context.Background(),
+			[]loadBatch{{start: 0, end: 1}, {start: 1, end: 2}},
+			2,
+			func(ctx context.Context, producer, start, end int) error {
+				started <- start
+				if start == 0 {
+					<-releaseFailure
+					return sentinel
+				}
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(2 * time.Second):
+					return errors.New("in-flight batch context was not canceled")
+				}
+			},
+			func(producer, operations int, duration time.Duration) {},
+			func(producer int, duration time.Duration) {},
+		)
+	}()
+	seen := map[int]bool{}
+	for len(seen) < 2 {
+		select {
+		case start := <-started:
+			seen[start] = true
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for both batches to start; seen=%v", seen)
+		}
+	}
+	close(releaseFailure)
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for runLoadBatches to return after failure")
+	}
+	if err == nil {
+		t.Fatal("runLoadBatches returned nil before failure released")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err=%v want sentinel", err)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -257,6 +257,11 @@ func TestParseConfigValidation(t *testing.T) {
 	cfg, err := parseConfig([]string{
 		"-target", "mongo",
 		"-documents", "10",
+		"-batch-size", "5",
+		"-insert-producers", "4",
+		"-mongo-max-pool-size", "32",
+		"-mongo-min-pool-size", "8",
+		"-mongo-max-connecting", "16",
 		"-secondary-indexes", "1",
 		"-format", "json",
 		"-concurrent-readers", "4",
@@ -269,6 +274,8 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if cfg.Target != "mongo" || cfg.Documents != 10 || cfg.SecondaryIndexes != 1 || cfg.Format != "json" ||
 		cfg.ClientMode != clientModeDriver ||
+		cfg.BatchSize != 5 || cfg.InsertProducers != 4 ||
+		cfg.MongoMaxPoolSize != 32 || cfg.MongoMinPoolSize != 8 || cfg.MongoMaxConnecting != 16 ||
 		cfg.ConcurrentReaders != 4 || cfg.ConcurrentReads != 20 || cfg.ConcurrentWriters != 2 || cfg.ConcurrentWrites != 10 {
 		t.Fatalf("unexpected config: %+v", cfg)
 	}
@@ -331,6 +338,12 @@ func TestParseConfigValidation(t *testing.T) {
 	if _, err := parseConfig([]string{"-concurrent-reads", "1"}); err == nil {
 		t.Fatal("concurrent-reads without concurrent-readers accepted")
 	}
+	if _, err := parseConfig([]string{"-insert-producers", "0"}); err == nil {
+		t.Fatal("zero insert-producers accepted")
+	}
+	if _, err := parseConfig([]string{"-mongo-max-pool-size", "-1"}); err == nil {
+		t.Fatal("negative mongo-max-pool-size accepted")
+	}
 }
 
 func TestRawInsertCommandBuildsBSONCommand(t *testing.T) {
@@ -391,6 +404,9 @@ func TestParseConfigTreeDBCorrectnessDefaults(t *testing.T) {
 	}
 	if cfg.TreeDBMaintenance != treeDBMaintenanceFull {
 		t.Fatalf("TreeDBMaintenance=%q want %q", cfg.TreeDBMaintenance, treeDBMaintenanceFull)
+	}
+	if cfg.InsertProducers != 1 {
+		t.Fatalf("InsertProducers=%d want 1", cfg.InsertProducers)
 	}
 }
 
@@ -618,12 +634,63 @@ func TestRunConcurrentOperationsReturnsFirstError(t *testing.T) {
 	}
 }
 
+func TestMakeLoadBatchesSplitsDocumentRange(t *testing.T) {
+	batches := makeLoadBatches(10, 4)
+	want := []loadBatch{{start: 0, end: 4}, {start: 4, end: 8}, {start: 8, end: 10}}
+	if len(batches) != len(want) {
+		t.Fatalf("len(batches)=%d want %d: %+v", len(batches), len(want), batches)
+	}
+	for i := range want {
+		if batches[i] != want[i] {
+			t.Fatalf("batch %d=%+v want %+v", i, batches[i], want[i])
+		}
+	}
+}
+
+func TestMeasureLoadPhaseReportsProducerResults(t *testing.T) {
+	cfg := config{Documents: 12, BatchSize: 2, InsertProducers: 3}
+	seen := make([]atomic.Int64, cfg.Documents)
+	phase, err := measureLoadPhase(context.Background(), cfg, func(producer, start, end int) error {
+		if producer < 0 || producer >= cfg.InsertProducers {
+			return os.ErrInvalid
+		}
+		for i := start; i < end; i++ {
+			seen[i].Add(1)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("measureLoadPhase: %v", err)
+	}
+	if phase.Name != "load_insert_many" || phase.Operations != cfg.Documents || phase.DriverCalls != 6 {
+		t.Fatalf("unexpected phase summary: %+v", phase)
+	}
+	if len(phase.ProducerResults) != cfg.InsertProducers {
+		t.Fatalf("producer results=%d want %d: %+v", len(phase.ProducerResults), cfg.InsertProducers, phase.ProducerResults)
+	}
+	var producerOps, producerCalls int
+	for _, producer := range phase.ProducerResults {
+		producerOps += producer.Operations
+		producerCalls += producer.DriverCalls
+	}
+	if producerOps != cfg.Documents || producerCalls != phase.DriverCalls {
+		t.Fatalf("producer totals ops/calls=%d/%d want %d/%d", producerOps, producerCalls, cfg.Documents, phase.DriverCalls)
+	}
+	for doc := range seen {
+		if got := seen[doc].Load(); got != 1 {
+			t.Fatalf("doc %d seen %d times, want once", doc, got)
+		}
+	}
+}
+
 func TestWriteResultSupportsGenericWriter(t *testing.T) {
 	result := &benchmarkResult{
 		Target:           "treedb",
 		Database:         "bench",
 		Collection:       "docs",
 		Documents:        1,
+		BatchSize:        1,
+		InsertProducers:  2,
 		SecondaryIndexes: 1,
 		Phases: []phaseResult{{
 			Name:           "load_insert_many",
@@ -631,6 +698,13 @@ func TestWriteResultSupportsGenericWriter(t *testing.T) {
 			DriverCalls:    1,
 			DurationMillis: 1,
 			OpsPerSecond:   1000,
+			ProducerResults: []producerResult{{
+				Producer:       0,
+				Operations:     1,
+				DriverCalls:    1,
+				DurationMillis: 1,
+				OpsPerSecond:   1000,
+			}},
 		}},
 	}
 	var out bytes.Buffer
@@ -639,6 +713,9 @@ func TestWriteResultSupportsGenericWriter(t *testing.T) {
 	}
 	if !bytes.Contains(out.Bytes(), []byte("target=treedb")) {
 		t.Fatalf("text output missing target: %q", out.String())
+	}
+	if !bytes.Contains(out.Bytes(), []byte("insert_producers=2")) || !bytes.Contains(out.Bytes(), []byte("producer=0")) {
+		t.Fatalf("text output missing producer metadata: %q", out.String())
 	}
 }
 

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -451,6 +451,14 @@ for value_name in DELETES CONCURRENT_READERS CONCURRENT_WRITERS MONGO_MAX_POOL_S
     exit 2
   fi
 done
+effective_mongo_max_pool_size="$MONGO_MAX_POOL_SIZE"
+if [[ "$effective_mongo_max_pool_size" -eq 0 ]]; then
+  effective_mongo_max_pool_size=100
+fi
+if [[ "$MONGO_MIN_POOL_SIZE" -gt "$effective_mongo_max_pool_size" ]]; then
+  echo "invalid MONGO_MIN_POOL_SIZE=$MONGO_MIN_POOL_SIZE (must be <= effective maxPoolSize $effective_mongo_max_pool_size)" >&2
+  exit 2
+fi
 if [[ "$PREBUILD_DOCUMENTS" != "true" && "$PREBUILD_DOCUMENTS" != "false" ]]; then
   echo "invalid PREBUILD_DOCUMENTS=$PREBUILD_DOCUMENTS (want true or false)" >&2
   exit 2

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -10,6 +10,10 @@ OUT_DIR="${OUT_DIR:-$(mktemp -d "$TMP_BASE/gomap_mongo_gateway_compare_XXXXXX")}
 DOCS_LIST="${DOCS_LIST:-1000 10000}"
 INDEXES_LIST="${INDEXES_LIST:-0 2}"
 BATCH_SIZE="${BATCH_SIZE:-500}"
+INSERT_PRODUCERS="${INSERT_PRODUCERS:-1}"
+MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-0}"
+MONGO_MIN_POOL_SIZE="${MONGO_MIN_POOL_SIZE:-0}"
+MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-0}"
 PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-false}"
 READS="${READS:-}"
 READS_DIVISOR="${READS_DIVISOR:-1}"
@@ -56,6 +60,13 @@ Options:
   --range-reads COUNT   Range reads per target/cell. Default: documents / 10.
   --updates COUNT       Updates per target/cell. Default: documents / 10.
   --deletes COUNT       Deletes per target/cell. Default: 0.
+  --insert-producers N  Producer goroutines for the insert load phase. Default: 1.
+  --mongo-max-pool-size N
+                        MongoDB Go driver maxPoolSize. Default: 0, use driver default.
+  --mongo-min-pool-size N
+                        MongoDB Go driver minPoolSize. Default: 0, use driver default.
+  --mongo-max-connecting N
+                        MongoDB Go driver maxConnecting. Default: 0, use driver default.
   --prebuild-documents  Prebuild documents before timed load phases.
   --concurrent-readers N
                         Reader goroutines for the concurrent _id read phase.
@@ -84,7 +95,8 @@ Options:
   --help                Show this help.
 
 Environment overrides:
-  OUT_DIR, DOCS_LIST, INDEXES_LIST, BATCH_SIZE, PREBUILD_DOCUMENTS,
+  OUT_DIR, DOCS_LIST, INDEXES_LIST, BATCH_SIZE, INSERT_PRODUCERS,
+  MONGO_MAX_POOL_SIZE, MONGO_MIN_POOL_SIZE, MONGO_MAX_CONNECTING, PREBUILD_DOCUMENTS,
   READS, READS_DIVISOR,
   RANGE_READS, UPDATES, DELETES, RANGE_READS_DIVISOR, UPDATES_DIVISOR,
   CONCURRENT_READERS, CONCURRENT_READS, CONCURRENT_READS_DIVISOR,
@@ -125,6 +137,22 @@ while [[ $# -gt 0 ]]; do
       ;;
     --deletes)
       DELETES="$2"
+      shift 2
+      ;;
+    --insert-producers)
+      INSERT_PRODUCERS="$2"
+      shift 2
+      ;;
+    --mongo-max-pool-size)
+      MONGO_MAX_POOL_SIZE="$2"
+      shift 2
+      ;;
+    --mongo-min-pool-size)
+      MONGO_MIN_POOL_SIZE="$2"
+      shift 2
+      ;;
+    --mongo-max-connecting)
+      MONGO_MAX_CONNECTING="$2"
       shift 2
       ;;
     --prebuild-documents)
@@ -385,6 +413,10 @@ run_target() {
     -collection "$COLLECTION" \
     -documents "$docs" \
     -batch-size "$BATCH_SIZE" \
+    -insert-producers "$INSERT_PRODUCERS" \
+    -mongo-max-pool-size "$MONGO_MAX_POOL_SIZE" \
+    -mongo-min-pool-size "$MONGO_MIN_POOL_SIZE" \
+    -mongo-max-connecting "$MONGO_MAX_CONNECTING" \
     -reads "$reads" \
     -range-reads "$range_reads" \
     -updates "$updates" \
@@ -408,7 +440,11 @@ if [[ "$MONGO_MODE" == "docker" ]] && ! command -v docker >/dev/null 2>&1; then
   echo "MONGO_MODE=docker requires docker; use --mongo-mode external --mongo-uri URI to use an existing server" >&2
   exit 2
 fi
-for value_name in DELETES CONCURRENT_READERS CONCURRENT_WRITERS; do
+if ! is_positive_int "$INSERT_PRODUCERS"; then
+  echo "invalid INSERT_PRODUCERS=$INSERT_PRODUCERS (want positive integer)" >&2
+  exit 2
+fi
+for value_name in DELETES CONCURRENT_READERS CONCURRENT_WRITERS MONGO_MAX_POOL_SIZE MONGO_MIN_POOL_SIZE MONGO_MAX_CONNECTING; do
   value=${!value_name}
   if ! is_nonnegative_int "$value"; then
     echo "invalid $value_name=$value (want non-negative integer)" >&2
@@ -433,6 +469,8 @@ fi
   echo "docs list: $DOCS_LIST"
   echo "secondary-index list: $INDEXES_LIST"
   echo "batch size: $BATCH_SIZE"
+  echo "insert producers: $INSERT_PRODUCERS"
+  echo "mongo pool options: maxPoolSize=$MONGO_MAX_POOL_SIZE minPoolSize=$MONGO_MIN_POOL_SIZE maxConnecting=$MONGO_MAX_CONNECTING"
   echo "prebuild documents: $PREBUILD_DOCUMENTS"
   echo "reads: ${READS:-documents / $READS_DIVISOR}"
   echo "range reads: ${RANGE_READS:-documents / $RANGE_READS_DIVISOR}"
@@ -567,6 +605,8 @@ cat >"$README" <<EOF
 - docs list: \`$DOCS_LIST\`
 - secondary-index list: \`$INDEXES_LIST\`
 - batch size: \`$BATCH_SIZE\`
+- insert producers: \`$INSERT_PRODUCERS\`
+- MongoDB Go driver pool options: \`maxPoolSize=$MONGO_MAX_POOL_SIZE minPoolSize=$MONGO_MIN_POOL_SIZE maxConnecting=$MONGO_MAX_CONNECTING\`
 - prebuild documents: \`$PREBUILD_DOCUMENTS\`
 - reads: \`${READS:-documents / $READS_DIVISOR}\`
 - range reads: \`${RANGE_READS:-documents / $RANGE_READS_DIVISOR}\`


### PR DESCRIPTION
## Summary

Adds true multi-producer insert-load support to `cmd/mongo_gateway_bench` so we can tell when the Mongo-compatible benchmark is client-limited versus gateway/storage-limited.

Changes:
- adds `-insert-producers` for the insert load phase
- adds official MongoDB Go driver pool knobs: `-mongo-max-pool-size`, `-mongo-min-pool-size`, `-mongo-max-connecting`
- records per-producer insert metrics in `producer_results`
- records Mongo Go driver pool counters after load and at final report time
- forwards the same knobs through `scripts/mongo_gateway_compare.sh`
- documents the new workflow and output semantics

## Benchmark Results

Configuration for both runs unless noted:

```sh
-target treedb
-secondary-indexes 2
-treedb-document-format bson
-treedb-maintenance none
-batch-size 10000
-mongo-max-pool-size 64
-mongo-max-connecting 16
-prebuild-documents
-timeout 0
```

Raw result directories:

- mixed read/write matrix: `/tmp/gomap_mongo_multiproducer_1777611055`
- load-only 1M-doc matrix: `/tmp/gomap_mongo_multiproducer_loadonly_1777611381`

### 1M Document Load-Only Check

Command shape:

```sh
./bin/mongo_gateway_bench \
  -target treedb \
  -client-mode "$mode" \
  -documents 1000000 \
  -batch-size 10000 \
  -insert-producers "$producers" \
  -mongo-max-pool-size 64 \
  -mongo-max-connecting 16 \
  -reads 0 \
  -range-reads 0 \
  -updates 0 \
  -secondary-indexes 2 \
  -treedb-document-format bson \
  -treedb-maintenance none \
  -prebuild-documents \
  -timeout 0 \
  -format json
```

| mode | producers | load docs/sec | load p50 us | load p95 us | load p99 us | pool checkouts | pool created |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| driver | 1 | 228,250 | 30,451 | 129,463 | 140,674 | 100 | 0 |
| driver | 4 | 361,270 | 103,474 | 212,447 | 295,603 | 100 | 3 |
| driver | 8 | 362,742 | 209,766 | 316,688 | 354,067 | 100 | 7 |
| driver-command-raw | 1 | 453,299 | 10,953 | 85,170 | 110,089 | 100 | 0 |
| driver-command-raw | 4 | 582,597 | 78,416 | 127,987 | 136,418 | 100 | 3 |
| driver-command-raw | 8 | 525,531 | 147,699 | 229,806 | 252,187 | 100 | 7 |
| raw-wire-tcp | 1 | 480,109 | 10,838 | 70,855 | 109,933 | 0 | 0 |
| raw-wire-tcp | 4 | 580,631 | 74,876 | 135,873 | 144,317 | 0 | 0 |
| raw-wire-tcp | 8 | 549,687 | 116,511 | 219,123 | 232,426 | 0 | 0 |
| raw-wire | 1 | 459,063 | 10,939 | 71,509 | 109,031 | 0 | 0 |
| raw-wire | 4 | 514,426 | 77,390 | 180,084 | 192,670 | 0 | 0 |
| raw-wire | 8 | 543,266 | 128,766 | 232,082 | 248,401 | 0 | 0 |

Read: multi-producer improves throughput, but with this two-index same-collection workload the best point is 4-ish producers for the raw-command/raw-wire paths. The official `InsertMany` path still trails `driver-command-raw`, so pool tuning helps but does not erase driver CRUD-helper overhead.

### 100k Document Mixed Read/Write Check

Command shape adds:

```sh
-documents 100000
-reads 100000
-updates 10000
-concurrent-readers 16
-concurrent-reads 100000
-concurrent-writers 8
-concurrent-writes 10000
```

| mode | producers | load docs/sec | load p50 us | load p95 us | load p99 us | pool checkouts | pool created | concurrent read ops/sec | read p95 us | concurrent write ops/sec | write p95 us |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| driver | 1 | 250,457 | 36,175 | 84,994 | 84,994 | 10 | 0 | 49,478 | 595 | 13,227 | 717 |
| driver | 2 | 385,731 | 40,178 | 91,166 | 91,166 | 10 | 1 | 50,164 | 575 | 13,111 | 741 |
| driver | 4 | 449,458 | 77,357 | 128,154 | 128,154 | 10 | 3 | 47,856 | 610 | 13,020 | 765 |
| driver | 8 | 403,652 | 129,177 | 234,902 | 234,902 | 10 | 7 | 47,780 | 609 | 13,120 | 738 |
| driver | 16 | 325,418 | 168,861 | 307,275 | 307,275 | 10 | 8 | 47,910 | 609 | 13,149 | 746 |
| driver-command-raw | 1 | 557,946 | 12,014 | 64,819 | 64,819 | 10 | 0 | 49,230 | 587 | 13,163 | 728 |
| driver-command-raw | 2 | 656,686 | 19,049 | 75,045 | 75,045 | 10 | 1 | 47,721 | 616 | 13,371 | 727 |
| driver-command-raw | 4 | 682,344 | 39,331 | 89,690 | 89,690 | 10 | 3 | 50,216 | 576 | 13,256 | 732 |
| driver-command-raw | 8 | 696,522 | 59,664 | 130,956 | 130,956 | 10 | 7 | 47,590 | 619 | 10,165 | 1,289 |
| driver-command-raw | 16 | 631,968 | 60,390 | 153,968 | 153,968 | 10 | 9 | 50,344 | 574 | 13,261 | 736 |
| raw-wire-tcp | 1 | 584,711 | 11,496 | 62,784 | 62,784 | 0 | 0 | 50,176 | 575 | 12,473 | 811 |
| raw-wire-tcp | 2 | 613,551 | 20,551 | 84,596 | 84,596 | 0 | 0 | 49,649 | 579 | 13,194 | 741 |
| raw-wire-tcp | 4 | 701,576 | 36,398 | 90,038 | 90,038 | 0 | 0 | 50,357 | 574 | 13,263 | 727 |
| raw-wire-tcp | 8 | 641,328 | 59,205 | 143,624 | 143,624 | 0 | 0 | 49,571 | 591 | 13,277 | 734 |
| raw-wire-tcp | 16 | 541,254 | 52,772 | 184,744 | 184,744 | 0 | 0 | 50,094 | 577 | 13,095 | 754 |
| raw-wire | 1 | 584,935 | 11,152 | 62,201 | 62,201 | 0 | 0 | 48,331 | 600 | 13,218 | 741 |
| raw-wire | 2 | 584,363 | 24,089 | 74,859 | 74,859 | 0 | 0 | 49,400 | 587 | 13,315 | 732 |
| raw-wire | 4 | 727,494 | 35,574 | 86,274 | 86,274 | 0 | 0 | 48,607 | 595 | 13,400 | 727 |
| raw-wire | 8 | 647,537 | 56,577 | 141,890 | 141,890 | 0 | 0 | 49,777 | 584 | 13,380 | 713 |
| raw-wire | 16 | 529,277 | 45,006 | 182,567 | 182,567 | 0 | 0 | 48,250 | 599 | 13,321 | 720 |

Read/write phases were intentionally kept after load in this mixed run. Concurrent `_id` reads are roughly 48k-50k ops/sec with p95 around 575-619 us, and concurrent updates are roughly 13k ops/sec with p95 usually around 720-810 us in this setup.

## Validation

- `GOWORK=off go test ./cmd/mongo_gateway_bench ./cmd/mongo_gateway_compare_report -count 1`
- `bash -n scripts/mongo_gateway_compare.sh`
- `git diff --check`
- live smoke: `GOWORK=off go run ./cmd/mongo_gateway_bench -target treedb -documents 1000 -batch-size 100 -insert-producers 4 -mongo-max-pool-size 16 -mongo-max-connecting 8 -reads 100 -range-reads 10 -updates 10 -concurrent-readers 4 -concurrent-reads 100 -concurrent-writers 2 -concurrent-writes 20 -secondary-indexes 2 -treedb-document-format bson -treedb-maintenance none -prebuild-documents -timeout 0`
