### PR TITLE
[codex] Add reusable Mongo gateway pprof harness

### DIFF
--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -325,6 +325,8 @@ CPU profile per measured phase, plus heap, allocs, block, mutex, and goroutine
 profiles captured after each phase. It also writes `profile_manifest.json` and
 `benchmark_result.json` into the same directory so the profile files can be tied
 back to the exact benchmark config and phase throughput.
+The profile directory must be empty at startup; use a fresh `mktemp -d`
+directory for each run so stale artifacts cannot be mixed into a new capture.
 
 CPU profiles are phase-scoped. Heap, allocs, block, mutex, and goroutine
 profiles are runtime snapshots captured at phase end; block, mutex, and allocs

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -315,6 +315,57 @@ The package test `TestTreeDBProfileSmokeFastAndWALOnFast` runs a small write-onl
 TreeDB gateway smoke against both `fast` and `wal_on_fast` to catch large
 profile regressions without making the smoke a replacement for the full matrix.
 
+## Phase Pprof Artifacts
+
+Use `-profile-dir` when a full benchmark run exposes a scaling wall and the
+next step is to inspect the TreeDB or gateway hot path. The command writes one
+CPU profile per measured phase, plus heap, allocs, block, mutex, and goroutine
+profiles captured after each phase. It also writes `profile_manifest.json` and
+`benchmark_result.json` into the same directory so the profile files can be tied
+back to the exact benchmark config and phase throughput.
+
+```sh
+OUT=$(mktemp -d /tmp/gomap_mongo_gateway_pprof_XXXXXX)
+GOWORK=off go run ./cmd/mongo_gateway_bench \
+  -target treedb \
+  -client-mode driver-command-raw \
+  -treedb-document-format bson \
+  -documents 1000000 \
+  -batch-size 5000 \
+  -insert-producers 8 \
+  -reads 0 \
+  -range-reads 0 \
+  -updates 0 \
+  -concurrent-writers 8 \
+  -concurrent-writes 80000 \
+  -secondary-indexes 2 \
+  -prebuild-documents \
+  -treedb-maintenance none \
+  -profile-dir "$OUT" \
+  -format json
+```
+
+Useful first-pass commands:
+
+```sh
+GOWORK=off go build -o ./bin/mongo_gateway_bench ./cmd/mongo_gateway_bench
+go tool pprof -top -cum ./bin/mongo_gateway_bench "$OUT/load_insert_many.cpu.pprof"
+go tool pprof -top -cum ./bin/mongo_gateway_bench "$OUT/concurrent_id_update_set_w8.cpu.pprof"
+go tool pprof -top -cum ./bin/mongo_gateway_bench "$OUT/concurrent_id_update_set_w8.mutex.pprof"
+```
+
+By default, profiling mode enables block profiling at rate `1` and mutex
+profiling at fraction `5`. Use `-profile-block-rate 0` or
+`-profile-mutex-fraction 0` to disable either profile. Runtime traces are larger
+and are off by default; add `-profile-trace` when scheduler-level detail is
+needed.
+
+For insert-scaling investigations, run the same command repeatedly with
+`-insert-producers 1`, `2`, `4`, `8`, and `16` while keeping `-documents`,
+`-batch-size`, `-client-mode`, and document format constant. For write-contention
+investigations, keep the load shape fixed and vary `-concurrent-writers` /
+`-concurrent-writes`.
+
 ## Gateway Profiling Benchmarks
 
 The package also includes benchmark-only entry points for isolating Mongo
@@ -325,7 +376,7 @@ OUT=$(mktemp -d /tmp/gomap_mongo_gateway_profile_XXXXXX)
 MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=10000 \
 GOWORK=off go test ./cmd/mongo_gateway_bench \
   -run '^$' \
-  -bench '^(BenchmarkTreeDBGatewayLoadBSONIndexes2|BenchmarkTreeDBGatewayLoadGeneratedIDBSONIndexes2|BenchmarkTreeDBGatewayLoadObjectIDBSONIndexes2|BenchmarkTreeDBGatewayLoadUnackBSONIndexes2|BenchmarkTreeDBGatewayRunCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRunRawCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireTCPLoadBSONIndexes2|BenchmarkDirectCollectionLoadBSONIndexes2|BenchmarkClientBSONBatchEncode)$' \
+  -bench '^(BenchmarkTreeDBGatewayLoadBSONIndexes2|BenchmarkTreeDBGatewayLoadGeneratedIDBSONIndexes2|BenchmarkTreeDBGatewayLoadObjectIDBSONIndexes2|BenchmarkTreeDBGatewayLoadUnackBSONIndexes2|BenchmarkTreeDBGatewayRunCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRunRawCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireTCPLoadBSONIndexes2|BenchmarkDirectCollectionLoadBSONIndexes2|BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2|BenchmarkClientBSONBatchEncode)$' \
   -benchtime 2000000x \
   -count 1 \
   -timeout 0 \
@@ -365,8 +416,17 @@ The benchmark shapes are intentionally different:
   and connection-serving cost from the official driver's CRUD-helper cost.
 - `BenchmarkDirectCollectionLoadBSONIndexes2` inserts the same BSON document
   shape through the collection API without the Mongo gateway.
+- `BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2` preloads a BSON
+  collection, then runs concurrent `_id` updates through `Collection.Update`
+  without the Mongo gateway. This is useful when comparing gateway update
+  profiles with the storage/update path directly.
 - `BenchmarkClientBSONBatchEncode` measures client-side BSON document encoding
   alone.
+
+The benchmark-only helpers accept these optional environment variables:
+`MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE`,
+`MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS`, and
+`MONGO_GATEWAY_PROFILE_BENCH_WRITERS`.
 
 Use the official-driver row for user-visible Mongo compatibility throughput, the
 driver-command rows to quantify the driver's CRUD-helper overhead, the raw-wire

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -317,6 +317,57 @@ The package test `TestTreeDBProfileSmokeFastAndWALOnFast` runs a small write-onl
 TreeDB gateway smoke against both `fast` and `wal_on_fast` to catch large
 profile regressions without making the smoke a replacement for the full matrix.
 
+## Phase Pprof Artifacts
+
+Use `-profile-dir` when a full benchmark run exposes a scaling wall and the
+next step is to inspect the TreeDB or gateway hot path. The command writes one
+CPU profile per measured phase, plus heap, allocs, block, mutex, and goroutine
+profiles captured after each phase. It also writes `profile_manifest.json` and
+`benchmark_result.json` into the same directory so the profile files can be tied
+back to the exact benchmark config and phase throughput.
+
+```sh
+OUT=$(mktemp -d /tmp/gomap_mongo_gateway_pprof_XXXXXX)
+GOWORK=off go run ./cmd/mongo_gateway_bench \
+  -target treedb \
+  -client-mode driver-command-raw \
+  -treedb-document-format bson \
+  -documents 1000000 \
+  -batch-size 5000 \
+  -insert-producers 8 \
+  -reads 0 \
+  -range-reads 0 \
+  -updates 0 \
+  -concurrent-writers 8 \
+  -concurrent-writes 80000 \
+  -secondary-indexes 2 \
+  -prebuild-documents \
+  -treedb-maintenance none \
+  -profile-dir "$OUT" \
+  -format json
+```
+
+Useful first-pass commands:
+
+```sh
+GOWORK=off go build -o ./bin/mongo_gateway_bench ./cmd/mongo_gateway_bench
+go tool pprof -top -cum ./bin/mongo_gateway_bench "$OUT/load_insert_many.cpu.pprof"
+go tool pprof -top -cum ./bin/mongo_gateway_bench "$OUT/concurrent_id_update_set_w8.cpu.pprof"
+go tool pprof -top -cum ./bin/mongo_gateway_bench "$OUT/concurrent_id_update_set_w8.mutex.pprof"
+```
+
+By default, profiling mode enables block profiling at rate `1` and mutex
+profiling at fraction `5`. Use `-profile-block-rate 0` or
+`-profile-mutex-fraction 0` to disable either profile. Runtime traces are larger
+and are off by default; add `-profile-trace` when scheduler-level detail is
+needed.
+
+For insert-scaling investigations, run the same command repeatedly with
+`-insert-producers 1`, `2`, `4`, `8`, and `16` while keeping `-documents`,
+`-batch-size`, `-client-mode`, and document format constant. For write-contention
+investigations, keep the load shape fixed and vary `-concurrent-writers` /
+`-concurrent-writes`.
+
 ## Gateway Profiling Benchmarks
 
 The package also includes benchmark-only entry points for isolating Mongo
@@ -327,7 +378,7 @@ OUT=$(mktemp -d /tmp/gomap_mongo_gateway_profile_XXXXXX)
 MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=10000 \
 GOWORK=off go test ./cmd/mongo_gateway_bench \
   -run '^$' \
-  -bench '^(BenchmarkTreeDBGatewayLoadBSONIndexes2|BenchmarkTreeDBGatewayLoadGeneratedIDBSONIndexes2|BenchmarkTreeDBGatewayLoadObjectIDBSONIndexes2|BenchmarkTreeDBGatewayLoadUnackBSONIndexes2|BenchmarkTreeDBGatewayRunCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRunRawCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireTCPLoadBSONIndexes2|BenchmarkDirectCollectionLoadBSONIndexes2|BenchmarkClientBSONBatchEncode)$' \
+  -bench '^(BenchmarkTreeDBGatewayLoadBSONIndexes2|BenchmarkTreeDBGatewayLoadGeneratedIDBSONIndexes2|BenchmarkTreeDBGatewayLoadObjectIDBSONIndexes2|BenchmarkTreeDBGatewayLoadUnackBSONIndexes2|BenchmarkTreeDBGatewayRunCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRunRawCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireTCPLoadBSONIndexes2|BenchmarkDirectCollectionLoadBSONIndexes2|BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2|BenchmarkClientBSONBatchEncode)$' \
   -benchtime 2000000x \
   -count 1 \
   -timeout 0 \
@@ -367,8 +418,17 @@ The benchmark shapes are intentionally different:
   and connection-serving cost from the official driver's CRUD-helper cost.
 - `BenchmarkDirectCollectionLoadBSONIndexes2` inserts the same BSON document
   shape through the collection API without the Mongo gateway.
+- `BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2` preloads a BSON
+  collection, then runs concurrent `_id` updates through `Collection.Update`
+  without the Mongo gateway. This is useful when comparing gateway update
+  profiles with the storage/update path directly.
 - `BenchmarkClientBSONBatchEncode` measures client-side BSON document encoding
   alone.
+
+The benchmark-only helpers accept these optional environment variables:
+`MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE`,
+`MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS`, and
+`MONGO_GATEWAY_PROFILE_BENCH_WRITERS`.
 
 Use the official-driver row for user-visible Mongo compatibility throughput, the
 driver-command rows to quantify the driver's CRUD-helper overhead, the raw-wire

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -326,6 +326,11 @@ profiles captured after each phase. It also writes `profile_manifest.json` and
 `benchmark_result.json` into the same directory so the profile files can be tied
 back to the exact benchmark config and phase throughput.
 
+CPU profiles are phase-scoped. Heap, allocs, block, mutex, and goroutine
+profiles are runtime snapshots captured at phase end; block, mutex, and allocs
+profiles are cumulative within the benchmark process rather than reset between
+phases.
+
 ```sh
 OUT=$(mktemp -d /tmp/gomap_mongo_gateway_pprof_XXXXXX)
 GOWORK=off go run ./cmd/mongo_gateway_bench \

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -360,7 +360,9 @@ By default, profiling mode enables block profiling at rate `1` and mutex
 profiling at fraction `5`. Use `-profile-block-rate 0` or
 `-profile-mutex-fraction 0` to disable either profile. Runtime traces are larger
 and are off by default; add `-profile-trace` when scheduler-level detail is
-needed.
+needed. Heap profiles are captured without forcing a garbage collection by
+default so measured phases keep their normal heap state; add `-profile-heap-gc`
+when you specifically want post-GC heap snapshots.
 
 For insert-scaling investigations, run the same command repeatedly with
 `-insert-producers 1`, `2`, `4`, `8`, and `16` while keeping `-documents`,

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -369,7 +369,9 @@ func run(parent context.Context, args []string) error {
 	result, err := runBenchmark(ctx, cfg, target, profiler)
 	if err != nil {
 		if profiler != nil {
-			_ = profiler.WriteManifest(nil, err)
+			if manifestErr := profiler.WriteManifest(nil, err); manifestErr != nil {
+				return errors.Join(err, manifestErr)
+			}
 		}
 		return err
 	}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -510,6 +510,9 @@ func parseConfig(args []string) (config, error) {
 	if cfg.ProfileTrace && strings.TrimSpace(cfg.ProfileDir) == "" {
 		return config{}, errors.New("profile-trace requires -profile-dir")
 	}
+	if cfg.ProfileHeapGC && strings.TrimSpace(cfg.ProfileDir) == "" {
+		return config{}, errors.New("profile-heap-gc requires -profile-dir")
+	}
 	if cfg.SecondaryIndexes < 0 || cfg.SecondaryIndexes > 2 {
 		return config{}, errors.New("secondary-indexes must be 0, 1, or 2")
 	}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -443,7 +443,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&treeDBIndexRootStorage, "treedb-index-root-storage", treeDBIndexRootStorage, "TreeDB secondary index root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&cfg.TreeDBMaintenance, "treedb-maintenance", cfg.TreeDBMaintenance, "TreeDB final disk maintenance for -target treedb: full, checkpoint, or none")
 	fs.BoolVar(&cfg.PrebuildDocuments, "prebuild-documents", false, "prebuild benchmark documents before the timed load phase")
-	fs.StringVar(&cfg.ProfileDir, "profile-dir", "", "write per-phase pprof artifacts and a profile_manifest.json into this directory")
+	fs.StringVar(&cfg.ProfileDir, "profile-dir", "", "write per-phase pprof artifacts and a profile_manifest.json into an empty directory")
 	fs.IntVar(&cfg.ProfileBlockRate, "profile-block-rate", cfg.ProfileBlockRate, "runtime block profile rate when -profile-dir is set; 0 disables block profiling")
 	fs.IntVar(&cfg.ProfileMutexFraction, "profile-mutex-fraction", cfg.ProfileMutexFraction, "runtime mutex profile sampling fraction when -profile-dir is set; 0 disables mutex profiling")
 	fs.BoolVar(&cfg.ProfileTrace, "profile-trace", false, "also write per-phase runtime trace.out files when -profile-dir is set")

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -68,6 +68,10 @@ type config struct {
 	TreeDBIndexRootStorage      collections.RootStoragePolicy
 	TreeDBMaintenance           string
 	PrebuildDocuments           bool
+	ProfileDir                  string
+	ProfileBlockRate            int
+	ProfileMutexFraction        int
+	ProfileTrace                bool
 	Timeout                     time.Duration
 	Format                      string
 }
@@ -106,6 +110,9 @@ type benchmarkResult struct {
 	MongoDBStatsFinal           map[string]any      `json:"mongodb_stats_final,omitempty"`
 	MongoPoolStatsAfterLoad     *mongoPoolSnapshot  `json:"mongo_pool_stats_after_load,omitempty"`
 	MongoPoolStatsFinal         *mongoPoolSnapshot  `json:"mongo_pool_stats_final,omitempty"`
+	ProfileDir                  string              `json:"profile_dir,omitempty"`
+	ProfileManifest             string              `json:"profile_manifest,omitempty"`
+	ProfileResult               string              `json:"profile_result,omitempty"`
 }
 
 type phaseResult struct {
@@ -351,9 +358,31 @@ func run(parent context.Context, args []string) error {
 		_ = closeBenchTarget(cleanupCtx, target)
 	}()
 
-	result, err := runBenchmark(ctx, cfg, target)
+	profiler, err := newProfileRecorder(cfg)
 	if err != nil {
 		return err
+	}
+	if profiler != nil {
+		defer profiler.Close()
+	}
+
+	result, err := runBenchmark(ctx, cfg, target, profiler)
+	if err != nil {
+		if profiler != nil {
+			_ = profiler.WriteManifest(nil, err)
+		}
+		return err
+	}
+	if profiler != nil {
+		result.ProfileDir = profiler.Dir()
+		result.ProfileManifest = profiler.ManifestPath()
+		result.ProfileResult = profiler.ResultPath()
+		if err := profiler.WriteResult(result); err != nil {
+			return err
+		}
+		if err := profiler.WriteManifest(result, nil); err != nil {
+			return err
+		}
 	}
 	return writeResult(os.Stdout, cfg.Format, result)
 }
@@ -368,6 +397,8 @@ func parseConfig(args []string) (config, error) {
 		TreeDBMaintenance:           treeDBMaintenanceFull,
 		ClientMode:                  clientModeDriver,
 		InsertProducers:             1,
+		ProfileBlockRate:            1,
+		ProfileMutexFraction:        5,
 	}
 	fs := flag.NewFlagSet("mongo_gateway_bench", flag.ContinueOnError)
 	var flagOutput bytes.Buffer
@@ -409,6 +440,10 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&treeDBIndexRootStorage, "treedb-index-root-storage", treeDBIndexRootStorage, "TreeDB secondary index root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&cfg.TreeDBMaintenance, "treedb-maintenance", cfg.TreeDBMaintenance, "TreeDB final disk maintenance for -target treedb: full, checkpoint, or none")
 	fs.BoolVar(&cfg.PrebuildDocuments, "prebuild-documents", false, "prebuild benchmark documents before the timed load phase")
+	fs.StringVar(&cfg.ProfileDir, "profile-dir", "", "write per-phase pprof artifacts and a profile_manifest.json into this directory")
+	fs.IntVar(&cfg.ProfileBlockRate, "profile-block-rate", cfg.ProfileBlockRate, "runtime block profile rate when -profile-dir is set; 0 disables block profiling")
+	fs.IntVar(&cfg.ProfileMutexFraction, "profile-mutex-fraction", cfg.ProfileMutexFraction, "runtime mutex profile sampling fraction when -profile-dir is set; 0 disables mutex profiling")
+	fs.BoolVar(&cfg.ProfileTrace, "profile-trace", false, "also write per-phase runtime trace.out files when -profile-dir is set")
 	fs.DurationVar(&cfg.Timeout, "timeout", 10*time.Minute, "overall benchmark timeout")
 	fs.StringVar(&cfg.Format, "format", "text", "output format: text or json")
 	if err := fs.Parse(args); err != nil {
@@ -461,6 +496,15 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.Timeout < 0 {
 		return config{}, errors.New("timeout cannot be negative")
+	}
+	if cfg.ProfileBlockRate < 0 {
+		return config{}, errors.New("profile-block-rate cannot be negative")
+	}
+	if cfg.ProfileMutexFraction < 0 {
+		return config{}, errors.New("profile-mutex-fraction cannot be negative")
+	}
+	if cfg.ProfileTrace && strings.TrimSpace(cfg.ProfileDir) == "" {
+		return config{}, errors.New("profile-trace requires -profile-dir")
 	}
 	if cfg.SecondaryIndexes < 0 || cfg.SecondaryIndexes > 2 {
 		return config{}, errors.New("secondary-indexes must be 0, 1, or 2")
@@ -910,7 +954,7 @@ func serveLoop(ctx context.Context, ln net.Listener, server *mongogateway.Server
 	}
 }
 
-func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchmarkResult, error) {
+func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (*benchmarkResult, error) {
 	db := target.client.Database(cfg.Database)
 	coll := db.Collection(cfg.Collection)
 	result := &benchmarkResult{
@@ -966,7 +1010,9 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	if target.poolStats != nil {
 		target.poolStats.Reset()
 	}
-	loadPhase, err := runLoadPhase(ctx, cfg, target, coll, prebuilt, prebuiltRaw)
+	loadPhase, err := runProfiledPhase(profiler, "load_insert_many", func() (phaseResult, error) {
+		return runLoadPhase(ctx, cfg, target, coll, prebuilt, prebuiltRaw)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -978,7 +1024,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 		return nil, err
 	}
 
-	idPhase, err := measurePhase("id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+	idPhase, err := measureProfiledPhase(profiler, "id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Reads; i++ {
 			id := benchmarkID(i % cfg.Documents)
 			var out bson.M
@@ -1000,7 +1046,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	result.Phases = append(result.Phases, idPhase)
 
 	if runEmailFindPhase(cfg) {
-		emailPhase, err := measurePhase("email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+		emailPhase, err := measureProfiledPhase(profiler, "email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 			for i := 0; i < cfg.Reads; i++ {
 				email := benchmarkEmail((i * 17) % cfg.Documents)
 				var out bson.M
@@ -1022,7 +1068,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 		result.Phases = append(result.Phases, emailPhase)
 	}
 
-	rangePhase, err := measurePhase("age_range_limit_10", cfg.RangeReads, func(sample func(time.Duration)) error {
+	rangePhase, err := measureProfiledPhase(profiler, "age_range_limit_10", cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
 			minAge := int64(20 + (i % 40))
 			begin := time.Now()
@@ -1053,7 +1099,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	}
 	result.Phases = append(result.Phases, rangePhase)
 
-	updatePhase, err := measurePhase("id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
+	updatePhase, err := measureProfiledPhase(profiler, "id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Updates; i++ {
 			id := benchmarkID((i * 31) % cfg.Documents)
 			begin := time.Now()
@@ -1077,7 +1123,8 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	result.Phases = append(result.Phases, updatePhase)
 
 	if cfg.ConcurrentReaders > 0 && cfg.ConcurrentReads > 0 {
-		concurrentReadPhase, err := measurePhase(fmt.Sprintf("concurrent_id_find_one_r%d", cfg.ConcurrentReaders), cfg.ConcurrentReads, func(sample func(time.Duration)) error {
+		phaseName := fmt.Sprintf("concurrent_id_find_one_r%d", cfg.ConcurrentReaders)
+		concurrentReadPhase, err := measureProfiledPhase(profiler, phaseName, cfg.ConcurrentReads, func(sample func(time.Duration)) error {
 			return runConcurrentOperations(ctx, cfg.ConcurrentReaders, cfg.ConcurrentReads, func(op int) error {
 				id := benchmarkID((op * 17) % cfg.Documents)
 				var out bson.M
@@ -1100,7 +1147,8 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	}
 
 	if cfg.ConcurrentWriters > 0 && cfg.ConcurrentWrites > 0 {
-		concurrentWritePhase, err := measurePhase(fmt.Sprintf("concurrent_id_update_set_w%d", cfg.ConcurrentWriters), cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
+		phaseName := fmt.Sprintf("concurrent_id_update_set_w%d", cfg.ConcurrentWriters)
+		concurrentWritePhase, err := measureProfiledPhase(profiler, phaseName, cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
 			return runConcurrentOperations(ctx, cfg.ConcurrentWriters, cfg.ConcurrentWrites, func(op int) error {
 				id := benchmarkID((op * 37) % cfg.Documents)
 				begin := time.Now()
@@ -1125,7 +1173,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	}
 
 	if cfg.Deletes > 0 {
-		deletePhase, err := measurePhase("id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
+		deletePhase, err := measureProfiledPhase(profiler, "id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
 			for i := 0; i < cfg.Deletes; i++ {
 				id := benchmarkID(cfg.Documents - 1 - i)
 				begin := time.Now()
@@ -1153,6 +1201,19 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 		result.MongoPoolStatsFinal = target.poolStats.Snapshot()
 	}
 	return result, nil
+}
+
+func measureProfiledPhase(profiler *profileRecorder, name string, operations int, run func(func(time.Duration)) error) (phaseResult, error) {
+	return runProfiledPhase(profiler, name, func() (phaseResult, error) {
+		return measurePhase(name, operations, run)
+	})
+}
+
+func runProfiledPhase(profiler *profileRecorder, name string, run func() (phaseResult, error)) (phaseResult, error) {
+	if profiler == nil {
+		return run()
+	}
+	return profiler.RunPhase(name, run)
 }
 
 func runEmailFindPhase(cfg config) bool {
@@ -2215,6 +2276,10 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)
+		}
+		if result.ProfileDir != "" {
+			fmt.Fprintf(out, "profile_dir=%s profile_manifest=%s profile_result=%s\n",
+				result.ProfileDir, result.ProfileManifest, result.ProfileResult)
 		}
 		for _, phase := range result.Phases {
 			fmt.Fprintf(out, "%-22s ops=%d calls=%d", phase.Name, phase.Operations, phase.DriverCalls)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -72,6 +72,7 @@ type config struct {
 	ProfileBlockRate            int
 	ProfileMutexFraction        int
 	ProfileTrace                bool
+	ProfileHeapGC               bool
 	Timeout                     time.Duration
 	Format                      string
 }
@@ -377,8 +378,8 @@ func run(parent context.Context, args []string) error {
 	}
 	if profiler != nil {
 		result.ProfileDir = profiler.Dir()
-		result.ProfileManifest = profiler.ManifestPath()
-		result.ProfileResult = profiler.ResultPath()
+		result.ProfileManifest = profileManifestFile
+		result.ProfileResult = profileResultFile
 		if err := profiler.WriteResult(result); err != nil {
 			return err
 		}
@@ -446,6 +447,7 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.ProfileBlockRate, "profile-block-rate", cfg.ProfileBlockRate, "runtime block profile rate when -profile-dir is set; 0 disables block profiling")
 	fs.IntVar(&cfg.ProfileMutexFraction, "profile-mutex-fraction", cfg.ProfileMutexFraction, "runtime mutex profile sampling fraction when -profile-dir is set; 0 disables mutex profiling")
 	fs.BoolVar(&cfg.ProfileTrace, "profile-trace", false, "also write per-phase runtime trace.out files when -profile-dir is set")
+	fs.BoolVar(&cfg.ProfileHeapGC, "profile-heap-gc", false, "force runtime.GC before each heap profile snapshot when -profile-dir is set")
 	fs.DurationVar(&cfg.Timeout, "timeout", 10*time.Minute, "overall benchmark timeout")
 	fs.StringVar(&cfg.Format, "format", "text", "output format: text or json")
 	if err := fs.Parse(args); err != nil {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -66,6 +66,10 @@ type config struct {
 	TreeDBIndexRootStorage      collections.RootStoragePolicy
 	TreeDBMaintenance           string
 	PrebuildDocuments           bool
+	ProfileDir                  string
+	ProfileBlockRate            int
+	ProfileMutexFraction        int
+	ProfileTrace                bool
 	Timeout                     time.Duration
 	Format                      string
 }
@@ -104,6 +108,9 @@ type benchmarkResult struct {
 	MongoDBStatsFinal           map[string]any      `json:"mongodb_stats_final,omitempty"`
 	MongoPoolStatsAfterLoad     *mongoPoolSnapshot  `json:"mongo_pool_stats_after_load,omitempty"`
 	MongoPoolStatsFinal         *mongoPoolSnapshot  `json:"mongo_pool_stats_final,omitempty"`
+	ProfileDir                  string              `json:"profile_dir,omitempty"`
+	ProfileManifest             string              `json:"profile_manifest,omitempty"`
+	ProfileResult               string              `json:"profile_result,omitempty"`
 }
 
 type phaseResult struct {
@@ -349,9 +356,31 @@ func run(parent context.Context, args []string) error {
 		_ = closeBenchTarget(cleanupCtx, target)
 	}()
 
-	result, err := runBenchmark(ctx, cfg, target)
+	profiler, err := newProfileRecorder(cfg)
 	if err != nil {
 		return err
+	}
+	if profiler != nil {
+		defer profiler.Close()
+	}
+
+	result, err := runBenchmark(ctx, cfg, target, profiler)
+	if err != nil {
+		if profiler != nil {
+			_ = profiler.WriteManifest(nil, err)
+		}
+		return err
+	}
+	if profiler != nil {
+		result.ProfileDir = profiler.Dir()
+		result.ProfileManifest = profiler.ManifestPath()
+		result.ProfileResult = profiler.ResultPath()
+		if err := profiler.WriteResult(result); err != nil {
+			return err
+		}
+		if err := profiler.WriteManifest(result, nil); err != nil {
+			return err
+		}
 	}
 	return writeResult(os.Stdout, cfg.Format, result)
 }
@@ -366,6 +395,8 @@ func parseConfig(args []string) (config, error) {
 		TreeDBMaintenance:           treeDBMaintenanceFull,
 		ClientMode:                  clientModeDriver,
 		InsertProducers:             1,
+		ProfileBlockRate:            1,
+		ProfileMutexFraction:        5,
 	}
 	fs := flag.NewFlagSet("mongo_gateway_bench", flag.ContinueOnError)
 	var flagOutput bytes.Buffer
@@ -407,6 +438,10 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&treeDBIndexRootStorage, "treedb-index-root-storage", treeDBIndexRootStorage, "TreeDB secondary index root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&cfg.TreeDBMaintenance, "treedb-maintenance", cfg.TreeDBMaintenance, "TreeDB final disk maintenance for -target treedb: full, checkpoint, or none")
 	fs.BoolVar(&cfg.PrebuildDocuments, "prebuild-documents", false, "prebuild benchmark documents before the timed load phase")
+	fs.StringVar(&cfg.ProfileDir, "profile-dir", "", "write per-phase pprof artifacts and a profile_manifest.json into this directory")
+	fs.IntVar(&cfg.ProfileBlockRate, "profile-block-rate", cfg.ProfileBlockRate, "runtime block profile rate when -profile-dir is set; 0 disables block profiling")
+	fs.IntVar(&cfg.ProfileMutexFraction, "profile-mutex-fraction", cfg.ProfileMutexFraction, "runtime mutex profile sampling fraction when -profile-dir is set; 0 disables mutex profiling")
+	fs.BoolVar(&cfg.ProfileTrace, "profile-trace", false, "also write per-phase runtime trace.out files when -profile-dir is set")
 	fs.DurationVar(&cfg.Timeout, "timeout", 10*time.Minute, "overall benchmark timeout")
 	fs.StringVar(&cfg.Format, "format", "text", "output format: text or json")
 	if err := fs.Parse(args); err != nil {
@@ -455,6 +490,15 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.Timeout < 0 {
 		return config{}, errors.New("timeout cannot be negative")
+	}
+	if cfg.ProfileBlockRate < 0 {
+		return config{}, errors.New("profile-block-rate cannot be negative")
+	}
+	if cfg.ProfileMutexFraction < 0 {
+		return config{}, errors.New("profile-mutex-fraction cannot be negative")
+	}
+	if cfg.ProfileTrace && strings.TrimSpace(cfg.ProfileDir) == "" {
+		return config{}, errors.New("profile-trace requires -profile-dir")
 	}
 	if cfg.SecondaryIndexes < 0 || cfg.SecondaryIndexes > 2 {
 		return config{}, errors.New("secondary-indexes must be 0, 1, or 2")
@@ -904,7 +948,7 @@ func serveLoop(ctx context.Context, ln net.Listener, server *mongogateway.Server
 	}
 }
 
-func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchmarkResult, error) {
+func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler *profileRecorder) (*benchmarkResult, error) {
 	db := target.client.Database(cfg.Database)
 	coll := db.Collection(cfg.Collection)
 	result := &benchmarkResult{
@@ -960,7 +1004,9 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	if target.poolStats != nil {
 		target.poolStats.Reset()
 	}
-	loadPhase, err := runLoadPhase(ctx, cfg, target, coll, prebuilt, prebuiltRaw)
+	loadPhase, err := runProfiledPhase(profiler, "load_insert_many", func() (phaseResult, error) {
+		return runLoadPhase(ctx, cfg, target, coll, prebuilt, prebuiltRaw)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -972,7 +1018,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 		return nil, err
 	}
 
-	idPhase, err := measurePhase("id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+	idPhase, err := measureProfiledPhase(profiler, "id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Reads; i++ {
 			id := benchmarkID(i % cfg.Documents)
 			var out bson.M
@@ -994,7 +1040,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	result.Phases = append(result.Phases, idPhase)
 
 	if runEmailFindPhase(cfg) {
-		emailPhase, err := measurePhase("email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+		emailPhase, err := measureProfiledPhase(profiler, "email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 			for i := 0; i < cfg.Reads; i++ {
 				email := benchmarkEmail((i * 17) % cfg.Documents)
 				var out bson.M
@@ -1016,7 +1062,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 		result.Phases = append(result.Phases, emailPhase)
 	}
 
-	rangePhase, err := measurePhase("age_range_limit_10", cfg.RangeReads, func(sample func(time.Duration)) error {
+	rangePhase, err := measureProfiledPhase(profiler, "age_range_limit_10", cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
 			minAge := int64(20 + (i % 40))
 			begin := time.Now()
@@ -1047,7 +1093,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	}
 	result.Phases = append(result.Phases, rangePhase)
 
-	updatePhase, err := measurePhase("id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
+	updatePhase, err := measureProfiledPhase(profiler, "id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Updates; i++ {
 			id := benchmarkID((i * 31) % cfg.Documents)
 			begin := time.Now()
@@ -1071,7 +1117,8 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	result.Phases = append(result.Phases, updatePhase)
 
 	if cfg.ConcurrentReaders > 0 && cfg.ConcurrentReads > 0 {
-		concurrentReadPhase, err := measurePhase(fmt.Sprintf("concurrent_id_find_one_r%d", cfg.ConcurrentReaders), cfg.ConcurrentReads, func(sample func(time.Duration)) error {
+		phaseName := fmt.Sprintf("concurrent_id_find_one_r%d", cfg.ConcurrentReaders)
+		concurrentReadPhase, err := measureProfiledPhase(profiler, phaseName, cfg.ConcurrentReads, func(sample func(time.Duration)) error {
 			return runConcurrentOperations(ctx, cfg.ConcurrentReaders, cfg.ConcurrentReads, func(op int) error {
 				id := benchmarkID((op * 17) % cfg.Documents)
 				var out bson.M
@@ -1094,7 +1141,8 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	}
 
 	if cfg.ConcurrentWriters > 0 && cfg.ConcurrentWrites > 0 {
-		concurrentWritePhase, err := measurePhase(fmt.Sprintf("concurrent_id_update_set_w%d", cfg.ConcurrentWriters), cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
+		phaseName := fmt.Sprintf("concurrent_id_update_set_w%d", cfg.ConcurrentWriters)
+		concurrentWritePhase, err := measureProfiledPhase(profiler, phaseName, cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
 			return runConcurrentOperations(ctx, cfg.ConcurrentWriters, cfg.ConcurrentWrites, func(op int) error {
 				id := benchmarkID((op * 37) % cfg.Documents)
 				begin := time.Now()
@@ -1119,7 +1167,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 	}
 
 	if cfg.Deletes > 0 {
-		deletePhase, err := measurePhase("id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
+		deletePhase, err := measureProfiledPhase(profiler, "id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
 			for i := 0; i < cfg.Deletes; i++ {
 				id := benchmarkID(cfg.Documents - 1 - i)
 				begin := time.Now()
@@ -1147,6 +1195,19 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget) (*benchm
 		result.MongoPoolStatsFinal = target.poolStats.Snapshot()
 	}
 	return result, nil
+}
+
+func measureProfiledPhase(profiler *profileRecorder, name string, operations int, run func(func(time.Duration)) error) (phaseResult, error) {
+	return runProfiledPhase(profiler, name, func() (phaseResult, error) {
+		return measurePhase(name, operations, run)
+	})
+}
+
+func runProfiledPhase(profiler *profileRecorder, name string, run func() (phaseResult, error)) (phaseResult, error) {
+	if profiler == nil {
+		return run()
+	}
+	return profiler.RunPhase(name, run)
 }
 
 func runEmailFindPhase(cfg config) bool {
@@ -2209,6 +2270,10 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)
+		}
+		if result.ProfileDir != "" {
+			fmt.Fprintf(out, "profile_dir=%s profile_manifest=%s profile_result=%s\n",
+				result.ProfileDir, result.ProfileManifest, result.ProfileResult)
 		}
 		for _, phase := range result.Phases {
 			fmt.Fprintf(out, "%-22s ops=%d calls=%d", phase.Name, phase.Operations, phase.DriverCalls)

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -645,6 +645,25 @@ func TestNewProfileRecorderTightensProfileDirPermissions(t *testing.T) {
 	}
 }
 
+func TestNewProfileRecorderRejectsNonEmptyProfileDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "stale.cpu.pprof"), []byte("old"), 0o600); err != nil {
+		t.Fatalf("write stale artifact: %v", err)
+	}
+	cfg, err := parseConfig([]string{"-profile-dir", dir})
+	if err != nil {
+		t.Fatalf("parse profile config: %v", err)
+	}
+	recorder, err := newProfileRecorder(cfg)
+	if err == nil {
+		recorder.Close()
+		t.Fatal("newProfileRecorder accepted non-empty profile dir")
+	}
+	if !strings.Contains(err.Error(), "must be empty") {
+		t.Fatalf("newProfileRecorder err=%v want empty-dir error", err)
+	}
+}
+
 func TestCreateProfileFileRejectsSymlink(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target.pprof")
@@ -659,6 +678,49 @@ func TestCreateProfileFileRejectsSymlink(t *testing.T) {
 	if err == nil {
 		_ = file.Close()
 		t.Fatal("createProfileFile accepted symlink")
+	}
+}
+
+func TestProfileRecorderManifestRecordsProfileStopError(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := parseConfig([]string{"-profile-dir", dir})
+	if err != nil {
+		t.Fatalf("parse profile config: %v", err)
+	}
+	recorder, err := newProfileRecorder(cfg)
+	if err != nil {
+		t.Fatalf("newProfileRecorder: %v", err)
+	}
+	defer recorder.Close()
+
+	if _, err := recorder.RunPhase("unit phase", func() (phaseResult, error) {
+		if err := os.Mkdir(filepath.Join(dir, "unit_phase.heap.pprof"), 0o700); err != nil {
+			return phaseResult{}, err
+		}
+		return summarizePhase("unit phase", 1, 1, time.Millisecond, []time.Duration{time.Millisecond}), nil
+	}); err == nil {
+		t.Fatal("RunPhase succeeded despite profile artifact write failure")
+	}
+	if err := recorder.WriteManifest(nil, nil); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, profileManifestFile))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var manifest profileManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if len(manifest.Artifacts) != 1 {
+		t.Fatalf("manifest artifacts=%d want 1", len(manifest.Artifacts))
+	}
+	if manifest.Artifacts[0].Error == "" {
+		t.Fatal("manifest artifact error is empty")
+	}
+	if !strings.Contains(manifest.Artifacts[0].Error, "unit_phase.heap.pprof") {
+		t.Fatalf("manifest artifact error=%q want heap path context", manifest.Artifacts[0].Error)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -473,6 +473,9 @@ func TestParseConfigProfileOptions(t *testing.T) {
 	if _, err := parseConfig([]string{"-profile-trace"}); err == nil {
 		t.Fatal("profile-trace without profile-dir accepted")
 	}
+	if _, err := parseConfig([]string{"-profile-heap-gc"}); err == nil {
+		t.Fatal("profile-heap-gc without profile-dir accepted")
+	}
 	if _, err := parseConfig([]string{"-profile-block-rate", "-1"}); err == nil {
 		t.Fatal("negative profile-block-rate accepted")
 	}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -501,6 +501,12 @@ func TestProfileRecorderWritesPhaseArtifactsAndManifest(t *testing.T) {
 	defer recorder.Close()
 
 	phase, err := recorder.RunPhase("unit phase", func() (phaseResult, error) {
+		var sink uint64
+		deadline := time.Now().Add(25 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			sink++
+		}
+		runtime.KeepAlive(sink)
 		return summarizePhase("unit phase", 1, 1, time.Millisecond, []time.Duration{time.Millisecond}), nil
 	})
 	if err != nil {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -449,6 +450,7 @@ func TestParseConfigProfileOptions(t *testing.T) {
 		"-profile-block-rate", "7",
 		"-profile-mutex-fraction", "11",
 		"-profile-trace",
+		"-profile-heap-gc",
 	})
 	if err != nil {
 		t.Fatalf("parse profile options: %v", err)
@@ -464,6 +466,9 @@ func TestParseConfigProfileOptions(t *testing.T) {
 	}
 	if !cfg.ProfileTrace {
 		t.Fatal("ProfileTrace=false want true")
+	}
+	if !cfg.ProfileHeapGC {
+		t.Fatal("ProfileHeapGC=false want true")
 	}
 	if _, err := parseConfig([]string{"-profile-trace"}); err == nil {
 		t.Fatal("profile-trace without profile-dir accepted")
@@ -506,7 +511,7 @@ func TestProfileRecorderWritesPhaseArtifactsAndManifest(t *testing.T) {
 		BatchSize:     1,
 		Phases:        []phaseResult{phase},
 		ProfileDir:    recorder.Dir(),
-		ProfileResult: recorder.ResultPath(),
+		ProfileResult: profileResultFile,
 	}
 	if err := recorder.WriteResult(result); err != nil {
 		t.Fatalf("WriteResult: %v", err)
@@ -532,6 +537,9 @@ func TestProfileRecorderWritesPhaseArtifactsAndManifest(t *testing.T) {
 		}
 		if info.Size() == 0 {
 			t.Fatalf("%s is empty", name)
+		}
+		if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+			t.Fatalf("%s permissions=%#o want 0600", name, info.Mode().Perm())
 		}
 	}
 }

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -550,6 +551,114 @@ func TestProfileRecorderWritesPhaseArtifactsAndManifest(t *testing.T) {
 		if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 			t.Fatalf("%s permissions=%#o want 0600", name, info.Mode().Perm())
 		}
+	}
+}
+
+func TestProfileRecorderWritesTraceArtifactAndManifest(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := parseConfig([]string{
+		"-profile-dir", dir,
+		"-profile-trace",
+	})
+	if err != nil {
+		t.Fatalf("parse profile config: %v", err)
+	}
+	recorder, err := newProfileRecorder(cfg)
+	if err != nil {
+		t.Fatalf("newProfileRecorder: %v", err)
+	}
+	defer recorder.Close()
+
+	if _, err := recorder.RunPhase("trace phase", func() (phaseResult, error) {
+		time.Sleep(time.Millisecond)
+		return summarizePhase("trace phase", 1, 1, time.Millisecond, []time.Duration{time.Millisecond}), nil
+	}); err != nil {
+		t.Fatalf("RunPhase: %v", err)
+	}
+	if err := recorder.WriteManifest(nil, nil); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	traceName := "trace_phase.trace.out"
+	info, err := os.Stat(filepath.Join(dir, traceName))
+	if err != nil {
+		t.Fatalf("stat trace artifact: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("trace artifact is empty")
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, profileManifestFile))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var manifest profileManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if len(manifest.Artifacts) != 1 {
+		t.Fatalf("manifest artifacts=%d want 1", len(manifest.Artifacts))
+	}
+	if manifest.Artifacts[0].Trace != traceName {
+		t.Fatalf("manifest trace=%q want %q", manifest.Artifacts[0].Trace, traceName)
+	}
+}
+
+func TestSanitizeProfileNameAvoidsHiddenArtifacts(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{name: ".", want: "phase"},
+		{name: ".hidden", want: "hidden"},
+		{name: "..phase", want: "phase"},
+		{name: "load.insert", want: "load.insert"},
+	} {
+		if got := sanitizeProfileName(tc.name); got != tc.want {
+			t.Fatalf("sanitizeProfileName(%q)=%q want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestNewProfileRecorderTightensProfileDirPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("profile directory chmod is not enforced on windows")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod setup dir: %v", err)
+	}
+	cfg, err := parseConfig([]string{"-profile-dir", dir})
+	if err != nil {
+		t.Fatalf("parse profile config: %v", err)
+	}
+	recorder, err := newProfileRecorder(cfg)
+	if err != nil {
+		t.Fatalf("newProfileRecorder: %v", err)
+	}
+	defer recorder.Close()
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat profile dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("profile dir permissions=%#o want 0700", got)
+	}
+}
+
+func TestCreateProfileFileRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.pprof")
+	if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(dir, "link.pprof")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	file, err := createProfileFile(link)
+	if err == nil {
+		_ = file.Close()
+		t.Fatal("createProfileFile accepted symlink")
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -681,6 +681,18 @@ func TestCreateProfileFileRejectsSymlink(t *testing.T) {
 	}
 }
 
+func TestCreateProfileFileRejectsExistingRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "existing.pprof")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+	file, err := createProfileFile(path)
+	if err == nil {
+		_ = file.Close()
+		t.Fatal("createProfileFile accepted existing regular file")
+	}
+}
+
 func TestProfileRecorderManifestRecordsProfileStopError(t *testing.T) {
 	dir := t.TempDir()
 	cfg, err := parseConfig([]string{"-profile-dir", dir})

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -443,6 +443,99 @@ func TestParseConfigAcceptsTreeDBBSONDocumentFormat(t *testing.T) {
 	}
 }
 
+func TestParseConfigProfileOptions(t *testing.T) {
+	cfg, err := parseConfig([]string{
+		"-profile-dir", "/tmp/mongo-gateway-bench-profiles",
+		"-profile-block-rate", "7",
+		"-profile-mutex-fraction", "11",
+		"-profile-trace",
+	})
+	if err != nil {
+		t.Fatalf("parse profile options: %v", err)
+	}
+	if cfg.ProfileDir != "/tmp/mongo-gateway-bench-profiles" {
+		t.Fatalf("ProfileDir=%q", cfg.ProfileDir)
+	}
+	if cfg.ProfileBlockRate != 7 {
+		t.Fatalf("ProfileBlockRate=%d want 7", cfg.ProfileBlockRate)
+	}
+	if cfg.ProfileMutexFraction != 11 {
+		t.Fatalf("ProfileMutexFraction=%d want 11", cfg.ProfileMutexFraction)
+	}
+	if !cfg.ProfileTrace {
+		t.Fatal("ProfileTrace=false want true")
+	}
+	if _, err := parseConfig([]string{"-profile-trace"}); err == nil {
+		t.Fatal("profile-trace without profile-dir accepted")
+	}
+	if _, err := parseConfig([]string{"-profile-block-rate", "-1"}); err == nil {
+		t.Fatal("negative profile-block-rate accepted")
+	}
+	if _, err := parseConfig([]string{"-profile-mutex-fraction", "-1"}); err == nil {
+		t.Fatal("negative profile-mutex-fraction accepted")
+	}
+}
+
+func TestProfileRecorderWritesPhaseArtifactsAndManifest(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := parseConfig([]string{
+		"-profile-dir", dir,
+		"-profile-block-rate", "1",
+		"-profile-mutex-fraction", "1",
+	})
+	if err != nil {
+		t.Fatalf("parse profile config: %v", err)
+	}
+	recorder, err := newProfileRecorder(cfg)
+	if err != nil {
+		t.Fatalf("newProfileRecorder: %v", err)
+	}
+	defer recorder.Close()
+
+	phase, err := recorder.RunPhase("unit phase", func() (phaseResult, error) {
+		return summarizePhase("unit phase", 1, 1, time.Millisecond, []time.Duration{time.Millisecond}), nil
+	})
+	if err != nil {
+		t.Fatalf("RunPhase: %v", err)
+	}
+	result := &benchmarkResult{
+		Target:        "treedb",
+		Database:      "db",
+		Collection:    "docs",
+		Documents:     1,
+		BatchSize:     1,
+		Phases:        []phaseResult{phase},
+		ProfileDir:    recorder.Dir(),
+		ProfileResult: recorder.ResultPath(),
+	}
+	if err := recorder.WriteResult(result); err != nil {
+		t.Fatalf("WriteResult: %v", err)
+	}
+	if err := recorder.WriteManifest(result, nil); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	for _, name := range []string{
+		"unit_phase.cpu.pprof",
+		"unit_phase.heap.pprof",
+		"unit_phase.allocs.pprof",
+		"unit_phase.block.pprof",
+		"unit_phase.mutex.pprof",
+		"unit_phase.goroutine.pprof",
+		profileManifestFile,
+		profileResultFile,
+	} {
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if info.Size() == 0 {
+			t.Fatalf("%s is empty", name)
+		}
+	}
+}
+
 func TestTreeDBProfileSmokeFastAndWALOnFast(t *testing.T) {
 	if testing.Short() {
 		t.Skip("profile smoke benchmark skipped in short mode")
@@ -539,7 +632,7 @@ func runTreeDBProfileSmoke(t *testing.T, profile treedb.Profile) float64 {
 			t.Errorf("cleanup %s: %v", profile, err)
 		}
 	}()
-	result, err := runBenchmark(context.Background(), cfg, target)
+	result, err := runBenchmark(context.Background(), cfg, target, nil)
 	if err != nil {
 		t.Fatalf("run benchmark for %s: %v", profile, err)
 	}
@@ -586,7 +679,7 @@ func runTreeDBClientModeSmoke(t *testing.T, clientMode string) float64 {
 			t.Errorf("cleanup client mode %s: %v", clientMode, err)
 		}
 	}()
-	result, err := runBenchmark(context.Background(), cfg, target)
+	result, err := runBenchmark(context.Background(), cfg, target, nil)
 	if err != nil {
 		t.Fatalf("run benchmark for client mode %s: %v", clientMode, err)
 	}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -536,6 +536,52 @@ func TestProfileRecorderWritesPhaseArtifactsAndManifest(t *testing.T) {
 	}
 }
 
+func TestProfileRecorderSkipsDisabledBlockAndMutexProfiles(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := parseConfig([]string{
+		"-profile-dir", dir,
+		"-profile-block-rate", "0",
+		"-profile-mutex-fraction", "0",
+	})
+	if err != nil {
+		t.Fatalf("parse profile config: %v", err)
+	}
+	recorder, err := newProfileRecorder(cfg)
+	if err != nil {
+		t.Fatalf("newProfileRecorder: %v", err)
+	}
+	defer recorder.Close()
+
+	if _, err := recorder.RunPhase("unit phase", func() (phaseResult, error) {
+		return summarizePhase("unit phase", 1, 1, time.Millisecond, []time.Duration{time.Millisecond}), nil
+	}); err != nil {
+		t.Fatalf("RunPhase: %v", err)
+	}
+	if err := recorder.WriteManifest(nil, nil); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	for _, name := range []string{
+		"unit_phase.cpu.pprof",
+		"unit_phase.heap.pprof",
+		"unit_phase.allocs.pprof",
+		"unit_phase.goroutine.pprof",
+		profileManifestFile,
+	} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+	}
+	for _, name := range []string{
+		"unit_phase.block.pprof",
+		"unit_phase.mutex.pprof",
+	} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Fatalf("stat %s err=%v want not-exist", name, err)
+		}
+	}
+}
+
 func TestTreeDBProfileSmokeFastAndWALOnFast(t *testing.T) {
 	if testing.Short() {
 		t.Skip("profile smoke benchmark skipped in short mode")

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -437,6 +437,99 @@ func TestParseConfigAcceptsTreeDBBSONDocumentFormat(t *testing.T) {
 	}
 }
 
+func TestParseConfigProfileOptions(t *testing.T) {
+	cfg, err := parseConfig([]string{
+		"-profile-dir", "/tmp/mongo-gateway-bench-profiles",
+		"-profile-block-rate", "7",
+		"-profile-mutex-fraction", "11",
+		"-profile-trace",
+	})
+	if err != nil {
+		t.Fatalf("parse profile options: %v", err)
+	}
+	if cfg.ProfileDir != "/tmp/mongo-gateway-bench-profiles" {
+		t.Fatalf("ProfileDir=%q", cfg.ProfileDir)
+	}
+	if cfg.ProfileBlockRate != 7 {
+		t.Fatalf("ProfileBlockRate=%d want 7", cfg.ProfileBlockRate)
+	}
+	if cfg.ProfileMutexFraction != 11 {
+		t.Fatalf("ProfileMutexFraction=%d want 11", cfg.ProfileMutexFraction)
+	}
+	if !cfg.ProfileTrace {
+		t.Fatal("ProfileTrace=false want true")
+	}
+	if _, err := parseConfig([]string{"-profile-trace"}); err == nil {
+		t.Fatal("profile-trace without profile-dir accepted")
+	}
+	if _, err := parseConfig([]string{"-profile-block-rate", "-1"}); err == nil {
+		t.Fatal("negative profile-block-rate accepted")
+	}
+	if _, err := parseConfig([]string{"-profile-mutex-fraction", "-1"}); err == nil {
+		t.Fatal("negative profile-mutex-fraction accepted")
+	}
+}
+
+func TestProfileRecorderWritesPhaseArtifactsAndManifest(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := parseConfig([]string{
+		"-profile-dir", dir,
+		"-profile-block-rate", "1",
+		"-profile-mutex-fraction", "1",
+	})
+	if err != nil {
+		t.Fatalf("parse profile config: %v", err)
+	}
+	recorder, err := newProfileRecorder(cfg)
+	if err != nil {
+		t.Fatalf("newProfileRecorder: %v", err)
+	}
+	defer recorder.Close()
+
+	phase, err := recorder.RunPhase("unit phase", func() (phaseResult, error) {
+		return summarizePhase("unit phase", 1, 1, time.Millisecond, []time.Duration{time.Millisecond}), nil
+	})
+	if err != nil {
+		t.Fatalf("RunPhase: %v", err)
+	}
+	result := &benchmarkResult{
+		Target:        "treedb",
+		Database:      "db",
+		Collection:    "docs",
+		Documents:     1,
+		BatchSize:     1,
+		Phases:        []phaseResult{phase},
+		ProfileDir:    recorder.Dir(),
+		ProfileResult: recorder.ResultPath(),
+	}
+	if err := recorder.WriteResult(result); err != nil {
+		t.Fatalf("WriteResult: %v", err)
+	}
+	if err := recorder.WriteManifest(result, nil); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	for _, name := range []string{
+		"unit_phase.cpu.pprof",
+		"unit_phase.heap.pprof",
+		"unit_phase.allocs.pprof",
+		"unit_phase.block.pprof",
+		"unit_phase.mutex.pprof",
+		"unit_phase.goroutine.pprof",
+		profileManifestFile,
+		profileResultFile,
+	} {
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if info.Size() == 0 {
+			t.Fatalf("%s is empty", name)
+		}
+	}
+}
+
 func TestTreeDBProfileSmokeFastAndWALOnFast(t *testing.T) {
 	if testing.Short() {
 		t.Skip("profile smoke benchmark skipped in short mode")
@@ -533,7 +626,7 @@ func runTreeDBProfileSmoke(t *testing.T, profile treedb.Profile) float64 {
 			t.Errorf("cleanup %s: %v", profile, err)
 		}
 	}()
-	result, err := runBenchmark(context.Background(), cfg, target)
+	result, err := runBenchmark(context.Background(), cfg, target, nil)
 	if err != nil {
 		t.Fatalf("run benchmark for %s: %v", profile, err)
 	}
@@ -580,7 +673,7 @@ func runTreeDBClientModeSmoke(t *testing.T, clientMode string) float64 {
 			t.Errorf("cleanup client mode %s: %v", clientMode, err)
 		}
 	}()
-	result, err := runBenchmark(context.Background(), cfg, target)
+	result, err := runBenchmark(context.Background(), cfg, target, nil)
 	if err != nil {
 		t.Fatalf("run benchmark for client mode %s: %v", clientMode, err)
 	}

--- a/cmd/mongo_gateway_bench/profile.go
+++ b/cmd/mongo_gateway_bench/profile.go
@@ -83,7 +83,7 @@ func newProfileRecorder(cfg config) (*profileRecorder, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(abs, 0o700); err != nil {
+	if err := ensureProfileDir(abs); err != nil {
 		return nil, err
 	}
 	recorder := &profileRecorder{
@@ -236,17 +236,13 @@ func (r *profileRecorder) startPhase(name string) (*activeProfilePhase, error) {
 		tracePath := filepath.Join(r.dir, prefix+".trace.out")
 		traceFile, err := createProfileFile(tracePath)
 		if err != nil {
-			stopErr := phase.stop(err)
+			stopErr := phase.cleanupSetup()
 			return nil, errors.Join(err, stopErr)
 		}
 		phase.traceFile = traceFile
 		phase.artifact.Trace = filepath.Base(tracePath)
 		if err := trace.Start(traceFile); err != nil {
-			_ = traceFile.Close()
-			_ = os.Remove(tracePath)
-			phase.traceFile = nil
-			phase.artifact.Trace = ""
-			stopErr := phase.stop(err)
+			stopErr := phase.cleanupSetup()
 			return nil, errors.Join(err, stopErr)
 		}
 		phase.traceOn = true
@@ -295,6 +291,40 @@ func (p *activeProfilePhase) stop(runErr error) error {
 	p.recorder.mu.Lock()
 	p.recorder.artifacts = append(p.recorder.artifacts, p.artifact)
 	p.recorder.mu.Unlock()
+	return errors.Join(errs...)
+}
+
+func (p *activeProfilePhase) cleanupSetup() error {
+	if p == nil {
+		return nil
+	}
+	if p.traceOn {
+		trace.Stop()
+		p.traceOn = false
+	}
+	if p.cpuActive {
+		pprof.StopCPUProfile()
+		p.cpuActive = false
+	}
+	var errs []error
+	if p.traceFile != nil {
+		errs = append(errs, p.traceFile.Close())
+		p.traceFile = nil
+	}
+	if p.cpuFile != nil {
+		errs = append(errs, p.cpuFile.Close())
+		p.cpuFile = nil
+	}
+	for _, name := range []string{p.artifact.Trace, p.artifact.CPUProfile} {
+		if name == "" || p.recorder == nil {
+			continue
+		}
+		if err := os.Remove(filepath.Join(p.recorder.dir, name)); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+	}
+	p.artifact.Trace = ""
+	p.artifact.CPUProfile = ""
 	return errors.Join(errs...)
 }
 
@@ -357,7 +387,29 @@ func writeProfileJSONFile(path string, value any) (err error) {
 }
 
 func createProfileFile(path string) (*os.File, error) {
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("profile artifact path %q is a symlink", path)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("profile artifact path %q is not a regular file", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
 	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+}
+
+func ensureProfileDir(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return err
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(path, 0o700); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func sanitizeProfileName(name string) string {
@@ -376,7 +428,7 @@ func sanitizeProfileName(name string) string {
 			lastUnderscore = true
 		}
 	}
-	out := strings.Trim(builder.String(), "_")
+	out := strings.TrimLeft(strings.Trim(builder.String(), "_"), ".")
 	if out == "" {
 		return "phase"
 	}

--- a/cmd/mongo_gateway_bench/profile.go
+++ b/cmd/mongo_gateway_bench/profile.go
@@ -20,19 +20,21 @@ const (
 )
 
 type profileRecorder struct {
-	dir                  string
-	blockRate            int
-	mutexFraction        int
-	traceEnabled         bool
-	heapGC               bool
-	createdAt            time.Time
-	resultPath           string
-	manifestPath         string
-	mu                   sync.Mutex
-	phaseMu              sync.Mutex
-	seenNames            map[string]int
-	artifacts            []profilePhaseArtifact
-	profilingRatesActive bool
+	dir                   string
+	blockRate             int
+	mutexFraction         int
+	traceEnabled          bool
+	heapGC                bool
+	createdAt             time.Time
+	resultPath            string
+	manifestPath          string
+	mu                    sync.Mutex
+	phaseMu               sync.Mutex
+	seenNames             map[string]int
+	artifacts             []profilePhaseArtifact
+	blockProfileActive    bool
+	mutexProfileActive    bool
+	previousMutexFraction int
 }
 
 type profileManifest struct {
@@ -98,11 +100,11 @@ func newProfileRecorder(cfg config) (*profileRecorder, error) {
 	}
 	if recorder.blockRate > 0 {
 		runtime.SetBlockProfileRate(recorder.blockRate)
-		recorder.profilingRatesActive = true
+		recorder.blockProfileActive = true
 	}
 	if recorder.mutexFraction > 0 {
-		runtime.SetMutexProfileFraction(recorder.mutexFraction)
-		recorder.profilingRatesActive = true
+		recorder.previousMutexFraction = runtime.SetMutexProfileFraction(recorder.mutexFraction)
+		recorder.mutexProfileActive = true
 	}
 	return recorder, nil
 }
@@ -129,12 +131,17 @@ func (r *profileRecorder) ResultPath() string {
 }
 
 func (r *profileRecorder) Close() {
-	if r == nil || !r.profilingRatesActive {
+	if r == nil {
 		return
 	}
-	runtime.SetBlockProfileRate(0)
-	runtime.SetMutexProfileFraction(0)
-	r.profilingRatesActive = false
+	// Block and mutex profiling knobs are process-global. The runtime exposes
+	// the previous mutex fraction but not the previous block profile rate, so
+	// Close restores only the setting it can restore without guessing.
+	if r.mutexProfileActive {
+		runtime.SetMutexProfileFraction(r.previousMutexFraction)
+		r.mutexProfileActive = false
+	}
+	r.blockProfileActive = false
 }
 
 func (r *profileRecorder) RunPhase(name string, run func() (phaseResult, error)) (result phaseResult, err error) {
@@ -317,7 +324,7 @@ func (p *activeProfilePhase) writeRuntimeProfiles() []error {
 	return errs
 }
 
-func writeRuntimeProfile(name, path string) error {
+func writeRuntimeProfile(name, path string) (err error) {
 	profile := pprof.Lookup(name)
 	if profile == nil {
 		return fmt.Errorf("runtime profile %q is unavailable", name)
@@ -326,16 +333,20 @@ func writeRuntimeProfile(name, path string) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err = errors.Join(err, file.Close())
+	}()
 	return profile.WriteTo(file, 0)
 }
 
-func writeProfileJSONFile(path string, value any) error {
+func writeProfileJSONFile(path string, value any) (err error) {
 	file, err := createProfileFile(path)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err = errors.Join(err, file.Close())
+	}()
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(value)

--- a/cmd/mongo_gateway_bench/profile.go
+++ b/cmd/mongo_gateway_bench/profile.go
@@ -155,17 +155,23 @@ func (r *profileRecorder) RunPhase(name string, run func() (phaseResult, error))
 	if startErr != nil {
 		return phaseResult{}, startErr
 	}
+	var ended time.Time
 	defer func() {
+		if ended.IsZero() {
+			ended = time.Now()
+		}
 		if recovered := recover(); recovered != nil {
-			stopErr := phase.stop(fmt.Errorf("panic: %v", recovered))
+			stopErr := phase.stop(fmt.Errorf("panic: %v", recovered), ended)
 			if stopErr != nil {
 				err = errors.Join(err, stopErr)
 			}
 			panic(recovered)
 		}
-		err = errors.Join(err, phase.stop(err))
+		err = errors.Join(err, phase.stop(err, ended))
 	}()
-	return run()
+	result, err = run()
+	ended = time.Now()
+	return result, err
 }
 
 func (r *profileRecorder) WriteResult(result *benchmarkResult) error {
@@ -262,9 +268,12 @@ func (r *profileRecorder) nextPrefix(name string) string {
 	return fmt.Sprintf("%s_%d", base, count+1)
 }
 
-func (p *activeProfilePhase) stop(runErr error) error {
+func (p *activeProfilePhase) stop(runErr error, ended time.Time) error {
 	if p == nil {
 		return nil
+	}
+	if ended.IsZero() {
+		ended = time.Now()
 	}
 	if p.traceOn {
 		trace.Stop()
@@ -283,7 +292,7 @@ func (p *activeProfilePhase) stop(runErr error) error {
 		errs = append(errs, p.cpuFile.Close())
 		p.cpuFile = nil
 	}
-	p.artifact.DurationMillis = float64(time.Since(p.started).Nanoseconds()) / 1e6
+	p.artifact.DurationMillis = float64(ended.Sub(p.started).Nanoseconds()) / 1e6
 	errs = append(errs, p.writeRuntimeProfiles()...)
 	stopErr := errors.Join(errs...)
 	if runErr != nil {
@@ -400,7 +409,7 @@ func createProfileFile(path string) (*os.File, error) {
 	} else if !os.IsNotExist(err) {
 		return nil, err
 	}
-	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	return os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 }
 
 func ensureProfileDir(path string) error {

--- a/cmd/mongo_gateway_bench/profile.go
+++ b/cmd/mongo_gateway_bench/profile.go
@@ -136,12 +136,16 @@ func (r *profileRecorder) Close() {
 	}
 	// Block and mutex profiling knobs are process-global. The runtime exposes
 	// the previous mutex fraction but not the previous block profile rate, so
-	// Close restores only the setting it can restore without guessing.
+	// Close restores mutex sampling and disables block profiling if this
+	// recorder enabled it.
 	if r.mutexProfileActive {
 		runtime.SetMutexProfileFraction(r.previousMutexFraction)
 		r.mutexProfileActive = false
 	}
-	r.blockProfileActive = false
+	if r.blockProfileActive {
+		runtime.SetBlockProfileRate(0)
+		r.blockProfileActive = false
+	}
 }
 
 func (r *profileRecorder) RunPhase(name string, run func() (phaseResult, error)) (result phaseResult, err error) {

--- a/cmd/mongo_gateway_bench/profile.go
+++ b/cmd/mongo_gateway_bench/profile.go
@@ -137,16 +137,24 @@ func (r *profileRecorder) Close() {
 	r.profilingRatesActive = false
 }
 
-func (r *profileRecorder) RunPhase(name string, run func() (phaseResult, error)) (phaseResult, error) {
+func (r *profileRecorder) RunPhase(name string, run func() (phaseResult, error)) (result phaseResult, err error) {
 	r.phaseMu.Lock()
 	defer r.phaseMu.Unlock()
 	phase, startErr := r.startPhase(name)
 	if startErr != nil {
 		return phaseResult{}, startErr
 	}
-	result, runErr := run()
-	stopErr := phase.stop(runErr)
-	return result, errors.Join(runErr, stopErr)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			stopErr := phase.stop(fmt.Errorf("panic: %v", recovered))
+			if stopErr != nil {
+				err = errors.Join(err, stopErr)
+			}
+			panic(recovered)
+		}
+		err = errors.Join(err, phase.stop(err))
+	}()
+	return run()
 }
 
 func (r *profileRecorder) WriteResult(result *benchmarkResult) error {
@@ -208,6 +216,7 @@ func (r *profileRecorder) startPhase(name string) (*activeProfilePhase, error) {
 	phase.artifact.CPUProfile = filepath.Base(cpuPath)
 	if err := pprof.StartCPUProfile(cpuFile); err != nil {
 		_ = cpuFile.Close()
+		_ = os.Remove(cpuPath)
 		return nil, err
 	}
 	phase.cpuActive = true
@@ -222,6 +231,10 @@ func (r *profileRecorder) startPhase(name string) (*activeProfilePhase, error) {
 		phase.traceFile = traceFile
 		phase.artifact.Trace = filepath.Base(tracePath)
 		if err := trace.Start(traceFile); err != nil {
+			_ = traceFile.Close()
+			_ = os.Remove(tracePath)
+			phase.traceFile = nil
+			phase.artifact.Trace = ""
 			stopErr := phase.stop(err)
 			return nil, errors.Join(err, stopErr)
 		}

--- a/cmd/mongo_gateway_bench/profile.go
+++ b/cmd/mongo_gateway_bench/profile.go
@@ -1,0 +1,340 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	profileManifestFile = "profile_manifest.json"
+	profileResultFile   = "benchmark_result.json"
+)
+
+type profileRecorder struct {
+	dir                  string
+	blockRate            int
+	mutexFraction        int
+	traceEnabled         bool
+	createdAt            time.Time
+	resultPath           string
+	manifestPath         string
+	mu                   sync.Mutex
+	seenNames            map[string]int
+	artifacts            []profilePhaseArtifact
+	profilingRatesActive bool
+}
+
+type profileManifest struct {
+	Version              int                    `json:"version"`
+	CreatedAt            string                 `json:"created_at"`
+	ProfileDir           string                 `json:"profile_dir"`
+	BlockRate            int                    `json:"block_rate,omitempty"`
+	MutexFraction        int                    `json:"mutex_fraction,omitempty"`
+	TraceEnabled         bool                   `json:"trace_enabled,omitempty"`
+	ResultFile           string                 `json:"result_file,omitempty"`
+	RunError             string                 `json:"run_error,omitempty"`
+	Artifacts            []profilePhaseArtifact `json:"artifacts"`
+	RecommendedPprofArgs []string               `json:"recommended_pprof_args,omitempty"`
+}
+
+type profilePhaseArtifact struct {
+	Phase          string  `json:"phase"`
+	Prefix         string  `json:"prefix"`
+	StartedAt      string  `json:"started_at"`
+	DurationMillis float64 `json:"duration_ms"`
+	CPUProfile     string  `json:"cpu_profile,omitempty"`
+	HeapProfile    string  `json:"heap_profile,omitempty"`
+	AllocsProfile  string  `json:"allocs_profile,omitempty"`
+	BlockProfile   string  `json:"block_profile,omitempty"`
+	MutexProfile   string  `json:"mutex_profile,omitempty"`
+	GoroutineDump  string  `json:"goroutine_dump,omitempty"`
+	Trace          string  `json:"trace,omitempty"`
+	Error          string  `json:"error,omitempty"`
+}
+
+type activeProfilePhase struct {
+	recorder  *profileRecorder
+	artifact  profilePhaseArtifact
+	started   time.Time
+	cpuFile   *os.File
+	traceFile *os.File
+	cpuActive bool
+	traceOn   bool
+}
+
+func newProfileRecorder(cfg config) (*profileRecorder, error) {
+	if strings.TrimSpace(cfg.ProfileDir) == "" {
+		return nil, nil
+	}
+	abs, err := filepath.Abs(cfg.ProfileDir)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(abs, 0o700); err != nil {
+		return nil, err
+	}
+	recorder := &profileRecorder{
+		dir:           abs,
+		blockRate:     cfg.ProfileBlockRate,
+		mutexFraction: cfg.ProfileMutexFraction,
+		traceEnabled:  cfg.ProfileTrace,
+		createdAt:     time.Now(),
+		resultPath:    filepath.Join(abs, profileResultFile),
+		manifestPath:  filepath.Join(abs, profileManifestFile),
+		seenNames:     make(map[string]int),
+		artifacts:     make([]profilePhaseArtifact, 0, 8),
+	}
+	if recorder.blockRate > 0 {
+		runtime.SetBlockProfileRate(recorder.blockRate)
+		recorder.profilingRatesActive = true
+	}
+	if recorder.mutexFraction > 0 {
+		runtime.SetMutexProfileFraction(recorder.mutexFraction)
+		recorder.profilingRatesActive = true
+	}
+	return recorder, nil
+}
+
+func (r *profileRecorder) Dir() string {
+	if r == nil {
+		return ""
+	}
+	return r.dir
+}
+
+func (r *profileRecorder) ManifestPath() string {
+	if r == nil {
+		return ""
+	}
+	return r.manifestPath
+}
+
+func (r *profileRecorder) ResultPath() string {
+	if r == nil {
+		return ""
+	}
+	return r.resultPath
+}
+
+func (r *profileRecorder) Close() {
+	if r == nil || !r.profilingRatesActive {
+		return
+	}
+	runtime.SetBlockProfileRate(0)
+	runtime.SetMutexProfileFraction(0)
+	r.profilingRatesActive = false
+}
+
+func (r *profileRecorder) RunPhase(name string, run func() (phaseResult, error)) (phaseResult, error) {
+	phase, startErr := r.startPhase(name)
+	if startErr != nil {
+		return phaseResult{}, startErr
+	}
+	result, runErr := run()
+	stopErr := phase.stop(runErr)
+	return result, errors.Join(runErr, stopErr)
+}
+
+func (r *profileRecorder) WriteResult(result *benchmarkResult) error {
+	if r == nil || result == nil {
+		return nil
+	}
+	return writeProfileJSONFile(r.resultPath, result)
+}
+
+func (r *profileRecorder) WriteManifest(result *benchmarkResult, runErr error) error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	artifacts := append([]profilePhaseArtifact(nil), r.artifacts...)
+	r.mu.Unlock()
+	manifest := profileManifest{
+		Version:       1,
+		CreatedAt:     r.createdAt.Format(time.RFC3339Nano),
+		ProfileDir:    r.dir,
+		BlockRate:     r.blockRate,
+		MutexFraction: r.mutexFraction,
+		TraceEnabled:  r.traceEnabled,
+		Artifacts:     artifacts,
+		RecommendedPprofArgs: []string{
+			"go tool pprof -top -cum <binary> <profile.cpu.pprof>",
+			"go tool pprof -http=:0 <binary> <profile.cpu.pprof>",
+		},
+	}
+	if result != nil {
+		manifest.ResultFile = profileResultFile
+	}
+	if runErr != nil {
+		manifest.RunError = runErr.Error()
+	}
+	return writeProfileJSONFile(r.manifestPath, manifest)
+}
+
+func (r *profileRecorder) startPhase(name string) (*activeProfilePhase, error) {
+	prefix := r.nextPrefix(name)
+	started := time.Now()
+	artifact := profilePhaseArtifact{
+		Phase:     name,
+		Prefix:    prefix,
+		StartedAt: started.Format(time.RFC3339Nano),
+	}
+	phase := &activeProfilePhase{
+		recorder: r,
+		artifact: artifact,
+		started:  started,
+	}
+
+	cpuPath := filepath.Join(r.dir, prefix+".cpu.pprof")
+	cpuFile, err := os.Create(cpuPath)
+	if err != nil {
+		return nil, err
+	}
+	phase.cpuFile = cpuFile
+	phase.artifact.CPUProfile = filepath.Base(cpuPath)
+	if err := pprof.StartCPUProfile(cpuFile); err != nil {
+		_ = cpuFile.Close()
+		return nil, err
+	}
+	phase.cpuActive = true
+
+	if r.traceEnabled {
+		tracePath := filepath.Join(r.dir, prefix+".trace.out")
+		traceFile, err := os.Create(tracePath)
+		if err != nil {
+			phase.stop(err)
+			return nil, err
+		}
+		phase.traceFile = traceFile
+		phase.artifact.Trace = filepath.Base(tracePath)
+		if err := trace.Start(traceFile); err != nil {
+			phase.stop(err)
+			return nil, err
+		}
+		phase.traceOn = true
+	}
+	return phase, nil
+}
+
+func (r *profileRecorder) nextPrefix(name string) string {
+	base := sanitizeProfileName(name)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := r.seenNames[base]
+	r.seenNames[base] = count + 1
+	if count == 0 {
+		return base
+	}
+	return fmt.Sprintf("%s_%d", base, count+1)
+}
+
+func (p *activeProfilePhase) stop(runErr error) error {
+	if p == nil {
+		return nil
+	}
+	if p.traceOn {
+		trace.Stop()
+		p.traceOn = false
+	}
+	if p.cpuActive {
+		pprof.StopCPUProfile()
+		p.cpuActive = false
+	}
+	var errs []error
+	if p.traceFile != nil {
+		errs = append(errs, p.traceFile.Close())
+		p.traceFile = nil
+	}
+	if p.cpuFile != nil {
+		errs = append(errs, p.cpuFile.Close())
+		p.cpuFile = nil
+	}
+	p.artifact.DurationMillis = float64(time.Since(p.started).Nanoseconds()) / 1e6
+	if runErr != nil {
+		p.artifact.Error = runErr.Error()
+	}
+	errs = append(errs, p.writeRuntimeProfiles()...)
+	p.recorder.mu.Lock()
+	p.recorder.artifacts = append(p.recorder.artifacts, p.artifact)
+	p.recorder.mu.Unlock()
+	return errors.Join(errs...)
+}
+
+func (p *activeProfilePhase) writeRuntimeProfiles() []error {
+	profiles := []struct {
+		name string
+		set  func(string)
+	}{
+		{name: "heap", set: func(path string) { p.artifact.HeapProfile = path }},
+		{name: "allocs", set: func(path string) { p.artifact.AllocsProfile = path }},
+		{name: "block", set: func(path string) { p.artifact.BlockProfile = path }},
+		{name: "mutex", set: func(path string) { p.artifact.MutexProfile = path }},
+		{name: "goroutine", set: func(path string) { p.artifact.GoroutineDump = path }},
+	}
+	var errs []error
+	for _, profile := range profiles {
+		outPath := filepath.Join(p.recorder.dir, p.artifact.Prefix+"."+profile.name+".pprof")
+		if err := writeRuntimeProfile(profile.name, outPath); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		profile.set(filepath.Base(outPath))
+	}
+	return errs
+}
+
+func writeRuntimeProfile(name, path string) error {
+	profile := pprof.Lookup(name)
+	if profile == nil {
+		return fmt.Errorf("runtime profile %q is unavailable", name)
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return profile.WriteTo(file, 0)
+}
+
+func writeProfileJSONFile(path string, value any) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func sanitizeProfileName(name string) string {
+	var builder strings.Builder
+	builder.Grow(len(name))
+	lastUnderscore := false
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '.'
+		if ok {
+			builder.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			builder.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	out := strings.Trim(builder.String(), "_")
+	if out == "" {
+		return "phase"
+	}
+	return out
+}

--- a/cmd/mongo_gateway_bench/profile.go
+++ b/cmd/mongo_gateway_bench/profile.go
@@ -273,15 +273,22 @@ func (p *activeProfilePhase) writeRuntimeProfiles() []error {
 	profiles := []struct {
 		name string
 		set  func(string)
+		want bool
 	}{
-		{name: "heap", set: func(path string) { p.artifact.HeapProfile = path }},
-		{name: "allocs", set: func(path string) { p.artifact.AllocsProfile = path }},
-		{name: "block", set: func(path string) { p.artifact.BlockProfile = path }},
-		{name: "mutex", set: func(path string) { p.artifact.MutexProfile = path }},
-		{name: "goroutine", set: func(path string) { p.artifact.GoroutineDump = path }},
+		{name: "heap", set: func(path string) { p.artifact.HeapProfile = path }, want: true},
+		{name: "allocs", set: func(path string) { p.artifact.AllocsProfile = path }, want: true},
+		{name: "block", set: func(path string) { p.artifact.BlockProfile = path }, want: p.recorder.blockRate > 0},
+		{name: "mutex", set: func(path string) { p.artifact.MutexProfile = path }, want: p.recorder.mutexFraction > 0},
+		{name: "goroutine", set: func(path string) { p.artifact.GoroutineDump = path }, want: true},
 	}
 	var errs []error
 	for _, profile := range profiles {
+		if !profile.want {
+			continue
+		}
+		if profile.name == "heap" {
+			runtime.GC()
+		}
 		outPath := filepath.Join(p.recorder.dir, p.artifact.Prefix+"."+profile.name+".pprof")
 		if err := writeRuntimeProfile(profile.name, outPath); err != nil {
 			errs = append(errs, err)

--- a/cmd/mongo_gateway_bench/profile.go
+++ b/cmd/mongo_gateway_bench/profile.go
@@ -29,6 +29,7 @@ type profileRecorder struct {
 	resultPath           string
 	manifestPath         string
 	mu                   sync.Mutex
+	phaseMu              sync.Mutex
 	seenNames            map[string]int
 	artifacts            []profilePhaseArtifact
 	profilingRatesActive bool
@@ -137,6 +138,8 @@ func (r *profileRecorder) Close() {
 }
 
 func (r *profileRecorder) RunPhase(name string, run func() (phaseResult, error)) (phaseResult, error) {
+	r.phaseMu.Lock()
+	defer r.phaseMu.Unlock()
 	phase, startErr := r.startPhase(name)
 	if startErr != nil {
 		return phaseResult{}, startErr

--- a/cmd/mongo_gateway_bench/profile.go
+++ b/cmd/mongo_gateway_bench/profile.go
@@ -48,18 +48,18 @@ type profileManifest struct {
 }
 
 type profilePhaseArtifact struct {
-	Phase          string  `json:"phase"`
-	Prefix         string  `json:"prefix"`
-	StartedAt      string  `json:"started_at"`
-	DurationMillis float64 `json:"duration_ms"`
-	CPUProfile     string  `json:"cpu_profile,omitempty"`
-	HeapProfile    string  `json:"heap_profile,omitempty"`
-	AllocsProfile  string  `json:"allocs_profile,omitempty"`
-	BlockProfile   string  `json:"block_profile,omitempty"`
-	MutexProfile   string  `json:"mutex_profile,omitempty"`
-	GoroutineDump  string  `json:"goroutine_dump,omitempty"`
-	Trace          string  `json:"trace,omitempty"`
-	Error          string  `json:"error,omitempty"`
+	Phase            string  `json:"phase"`
+	Prefix           string  `json:"prefix"`
+	StartedAt        string  `json:"started_at"`
+	DurationMillis   float64 `json:"duration_ms"`
+	CPUProfile       string  `json:"cpu_profile,omitempty"`
+	HeapProfile      string  `json:"heap_profile,omitempty"`
+	AllocsProfile    string  `json:"allocs_profile,omitempty"`
+	BlockProfile     string  `json:"block_profile,omitempty"`
+	MutexProfile     string  `json:"mutex_profile,omitempty"`
+	GoroutineProfile string  `json:"goroutine_profile,omitempty"`
+	Trace            string  `json:"trace,omitempty"`
+	Error            string  `json:"error,omitempty"`
 }
 
 type activeProfilePhase struct {
@@ -213,14 +213,14 @@ func (r *profileRecorder) startPhase(name string) (*activeProfilePhase, error) {
 		tracePath := filepath.Join(r.dir, prefix+".trace.out")
 		traceFile, err := createProfileFile(tracePath)
 		if err != nil {
-			phase.stop(err)
-			return nil, err
+			stopErr := phase.stop(err)
+			return nil, errors.Join(err, stopErr)
 		}
 		phase.traceFile = traceFile
 		phase.artifact.Trace = filepath.Base(tracePath)
 		if err := trace.Start(traceFile); err != nil {
-			phase.stop(err)
-			return nil, err
+			stopErr := phase.stop(err)
+			return nil, errors.Join(err, stopErr)
 		}
 		phase.traceOn = true
 	}
@@ -281,7 +281,7 @@ func (p *activeProfilePhase) writeRuntimeProfiles() []error {
 		{name: "allocs", set: func(path string) { p.artifact.AllocsProfile = path }, want: true},
 		{name: "block", set: func(path string) { p.artifact.BlockProfile = path }, want: p.recorder.blockRate > 0},
 		{name: "mutex", set: func(path string) { p.artifact.MutexProfile = path }, want: p.recorder.mutexFraction > 0},
-		{name: "goroutine", set: func(path string) { p.artifact.GoroutineDump = path }, want: true},
+		{name: "goroutine", set: func(path string) { p.artifact.GoroutineProfile = path }, want: true},
 	}
 	var errs []error
 	for _, profile := range profiles {

--- a/cmd/mongo_gateway_bench/profile.go
+++ b/cmd/mongo_gateway_bench/profile.go
@@ -284,14 +284,17 @@ func (p *activeProfilePhase) stop(runErr error) error {
 		p.cpuFile = nil
 	}
 	p.artifact.DurationMillis = float64(time.Since(p.started).Nanoseconds()) / 1e6
+	errs = append(errs, p.writeRuntimeProfiles()...)
+	stopErr := errors.Join(errs...)
 	if runErr != nil {
 		p.artifact.Error = runErr.Error()
+	} else if stopErr != nil {
+		p.artifact.Error = stopErr.Error()
 	}
-	errs = append(errs, p.writeRuntimeProfiles()...)
 	p.recorder.mu.Lock()
 	p.recorder.artifacts = append(p.recorder.artifacts, p.artifact)
 	p.recorder.mu.Unlock()
-	return errors.Join(errs...)
+	return stopErr
 }
 
 func (p *activeProfilePhase) cleanupSetup() error {
@@ -408,6 +411,13 @@ func ensureProfileDir(path string) error {
 		if err := os.Chmod(path, 0o700); err != nil {
 			return err
 		}
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+	if len(entries) != 0 {
+		return fmt.Errorf("profile directory %q must be empty", path)
 	}
 	return nil
 }

--- a/cmd/mongo_gateway_bench/profile.go
+++ b/cmd/mongo_gateway_bench/profile.go
@@ -24,6 +24,7 @@ type profileRecorder struct {
 	blockRate            int
 	mutexFraction        int
 	traceEnabled         bool
+	heapGC               bool
 	createdAt            time.Time
 	resultPath           string
 	manifestPath         string
@@ -87,6 +88,7 @@ func newProfileRecorder(cfg config) (*profileRecorder, error) {
 		blockRate:     cfg.ProfileBlockRate,
 		mutexFraction: cfg.ProfileMutexFraction,
 		traceEnabled:  cfg.ProfileTrace,
+		heapGC:        cfg.ProfileHeapGC,
 		createdAt:     time.Now(),
 		resultPath:    filepath.Join(abs, profileResultFile),
 		manifestPath:  filepath.Join(abs, profileManifestFile),
@@ -195,7 +197,7 @@ func (r *profileRecorder) startPhase(name string) (*activeProfilePhase, error) {
 	}
 
 	cpuPath := filepath.Join(r.dir, prefix+".cpu.pprof")
-	cpuFile, err := os.Create(cpuPath)
+	cpuFile, err := createProfileFile(cpuPath)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +211,7 @@ func (r *profileRecorder) startPhase(name string) (*activeProfilePhase, error) {
 
 	if r.traceEnabled {
 		tracePath := filepath.Join(r.dir, prefix+".trace.out")
-		traceFile, err := os.Create(tracePath)
+		traceFile, err := createProfileFile(tracePath)
 		if err != nil {
 			phase.stop(err)
 			return nil, err
@@ -286,7 +288,7 @@ func (p *activeProfilePhase) writeRuntimeProfiles() []error {
 		if !profile.want {
 			continue
 		}
-		if profile.name == "heap" {
+		if profile.name == "heap" && p.recorder.heapGC {
 			runtime.GC()
 		}
 		outPath := filepath.Join(p.recorder.dir, p.artifact.Prefix+"."+profile.name+".pprof")
@@ -304,7 +306,7 @@ func writeRuntimeProfile(name, path string) error {
 	if profile == nil {
 		return fmt.Errorf("runtime profile %q is unavailable", name)
 	}
-	file, err := os.Create(path)
+	file, err := createProfileFile(path)
 	if err != nil {
 		return err
 	}
@@ -313,7 +315,7 @@ func writeRuntimeProfile(name, path string) error {
 }
 
 func writeProfileJSONFile(path string, value any) error {
-	file, err := os.Create(path)
+	file, err := createProfileFile(path)
 	if err != nil {
 		return err
 	}
@@ -321,6 +323,10 @@ func writeProfileJSONFile(path string, value any) error {
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(value)
+}
+
+func createProfileFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 }
 
 func sanitizeProfileName(name string) string {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -418,18 +418,15 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 		updateRaw := updateDocs[op%len(updateDocs)]
 		matched, _, err := collection.Update(id, func(stored []byte) ([]byte, bool, error) {
 			raw := bson.Raw(stored)
-			if err := raw.Validate(); err != nil {
-				return nil, false, err
-			}
 			originalID := raw.Lookup("_id")
-			updated, changed, err := profileBenchApplySetUpdate(raw, updateRaw)
+			updated, shouldWrite, err := profileBenchApplySetUpdate(raw, updateRaw)
 			if err != nil {
 				return nil, false, err
 			}
 			if !updated.Lookup("_id").Equal(originalID) {
 				return nil, false, errUpdatedPrimaryKey
 			}
-			return []byte(updated), changed, nil
+			return []byte(updated), shouldWrite, nil
 		})
 		if err != nil {
 			return err

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -31,10 +31,56 @@ const (
 	// Keep update payloads bounded so the benchmark stresses collection update
 	// concurrency instead of BSON allocation variety.
 	profileBenchUpdateDocPoolSize = 4096
-	// Scramble sequential operation numbers across the preloaded ID set while
-	// still using a deterministic, cache-friendly access pattern.
-	profileBenchUpdateIDScrambleMultiplier = 37
+	// Preferred deterministic stride for scrambling sequential operation
+	// numbers across the preloaded ID set.
+	profileBenchPreferredUpdateIDStride = 37
 )
+
+func profileBenchUpdateIDStride(documentCount int) int {
+	if documentCount <= 1 {
+		return 1
+	}
+	stride := profileBenchPreferredUpdateIDStride
+	if stride >= documentCount {
+		stride %= documentCount
+	}
+	if stride <= 0 {
+		stride = 1
+	}
+	for profileBenchGCD(stride, documentCount) != 1 {
+		stride++
+		if stride >= documentCount {
+			stride = 1
+		}
+	}
+	return stride
+}
+
+func profileBenchGCD(a, b int) int {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func TestProfileBenchUpdateIDStrideCoversDocumentSet(t *testing.T) {
+	for _, documentCount := range []int{1, 2, 37, 74, 1000} {
+		stride := profileBenchUpdateIDStride(documentCount)
+		seen := make(map[int]struct{}, documentCount)
+		for op := 0; op < documentCount; op++ {
+			seen[(op*stride)%documentCount] = struct{}{}
+		}
+		if len(seen) != documentCount {
+			t.Fatalf("documentCount=%d stride=%d covered=%d", documentCount, stride, len(seen))
+		}
+	}
+}
 
 func BenchmarkTreeDBGatewayLoadBSONIndexes2(b *testing.B) {
 	benchmarkTreeDBGatewayLoad(b, collections.DocumentFormatBSON, 2, false)
@@ -416,13 +462,14 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	for i := range ids {
 		ids[i] = []byte(benchmarkID(i))
 	}
+	idStride := profileBenchUpdateIDStride(documentCount)
 
 	writers := profileBenchConcurrentWriters(b)
 	b.ReportAllocs()
 	b.ResetTimer()
 	started := time.Now()
 	err = runConcurrentOperations(context.Background(), writers, b.N, func(op int) error {
-		id := ids[(op*profileBenchUpdateIDScrambleMultiplier)%documentCount]
+		id := ids[(op*idStride)%documentCount]
 		updateRaw := updateDocs[op%len(updateDocs)]
 		matched, _, err := collection.Update(id, func(stored []byte) ([]byte, bool, error) {
 			raw := bson.Raw(stored)

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -403,13 +403,17 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 		}
 		updateDocs[i] = bson.Raw(updateRaw)
 	}
+	ids := make([][]byte, documentCount)
+	for i := range ids {
+		ids[i] = []byte(benchmarkID(i))
+	}
 
 	writers := profileBenchConcurrentWriters(b)
 	b.ReportAllocs()
 	b.ResetTimer()
 	started := time.Now()
 	err = runConcurrentOperations(context.Background(), writers, b.N, func(op int) error {
-		id := []byte(benchmarkID((op * 37) % documentCount))
+		id := ids[(op*37)%documentCount]
 		updateRaw := updateDocs[op%len(updateDocs)]
 		matched, _, err := collection.Update(id, func(stored []byte) ([]byte, bool, error) {
 			raw := bson.Raw(stored)

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -392,6 +392,17 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	if err := backend.Checkpoint(); err != nil {
 		b.Fatalf("checkpoint preload: %v", err)
 	}
+	updateDocs := make([]bson.Raw, 4096)
+	for i := range updateDocs {
+		updateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{
+			{Key: "concurrent_updated", Value: true},
+			{Key: "concurrent_update_seq", Value: int64(i)},
+		}}})
+		if err != nil {
+			b.Fatalf("marshal update document: %v", err)
+		}
+		updateDocs[i] = bson.Raw(updateRaw)
+	}
 
 	writers := profileBenchConcurrentWriters(b)
 	b.ReportAllocs()
@@ -399,20 +410,14 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	started := time.Now()
 	err = runConcurrentOperations(context.Background(), writers, b.N, func(op int) error {
 		id := []byte(benchmarkID((op * 37) % documentCount))
-		updateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{
-			{Key: "concurrent_updated", Value: true},
-			{Key: "concurrent_update_seq", Value: int64(op)},
-		}}})
-		if err != nil {
-			return err
-		}
+		updateRaw := updateDocs[op&(len(updateDocs)-1)]
 		matched, _, err := collection.Update(id, func(stored []byte) ([]byte, bool, error) {
 			raw := bson.Raw(stored)
 			if err := raw.Validate(); err != nil {
 				return nil, false, err
 			}
 			originalID := raw.Lookup("_id")
-			updated, changed, err := profileBenchApplySetUpdate(raw, bson.Raw(updateRaw))
+			updated, changed, err := profileBenchApplySetUpdate(raw, updateRaw)
 			if err != nil {
 				return nil, false, err
 			}

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -470,6 +471,18 @@ func profileBenchApplySetUpdate(doc bson.Raw, update bson.Raw) (bson.Raw, bool, 
 		if err != nil {
 			return nil, false, err
 		}
+		if key == "" {
+			return nil, false, errors.New("profile benchmark $set field name cannot be empty")
+		}
+		if key == "_id" {
+			return nil, false, errors.New("profile benchmark update cannot modify _id")
+		}
+		if strings.Contains(key, ".") {
+			return nil, false, errors.New("profile benchmark $set currently supports top-level fields only")
+		}
+		if strings.HasPrefix(key, "$") {
+			return nil, false, errors.New("profile benchmark $set field names cannot start with $")
+		}
 		if _, exists := sets[key]; !exists {
 			setOrder = append(setOrder, key)
 		}
@@ -510,6 +523,33 @@ func profileBenchApplySetUpdate(doc bson.Raw, update bson.Raw) (bson.Raw, bool, 
 		return nil, false, err
 	}
 	return bson.Raw(raw), changed, nil
+}
+
+func TestProfileBenchApplySetUpdateRejectsGatewayInvalidSetFields(t *testing.T) {
+	docRaw, err := bson.Marshal(bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "ada"}})
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "empty", key: ""},
+		{name: "id", key: "_id"},
+		{name: "dotted", key: "profile.name"},
+		{name: "dollar", key: "$name"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{{Key: tt.key, Value: "grace"}}}})
+			if err != nil {
+				t.Fatalf("marshal update: %v", err)
+			}
+			if _, _, err := profileBenchApplySetUpdate(bson.Raw(docRaw), bson.Raw(updateRaw)); err == nil {
+				t.Fatalf("profileBenchApplySetUpdate accepted key %q", tt.key)
+			}
+		})
+	}
 }
 
 type profileBenchReadWriter struct {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -504,7 +504,8 @@ func profileBenchApplySetUpdate(doc bson.Raw, update bson.Raw) (bson.Raw, bool, 
 	}
 	out := make(bson.D, 0, len(elements)+len(sets))
 	used := make(map[string]struct{}, len(sets))
-	changed := true
+	// Force the benchmark down the write/index update path for any non-empty $set.
+	forceWrite := true
 	for _, elem := range elements {
 		key, err := elem.KeyErr()
 		if err != nil {
@@ -527,7 +528,7 @@ func profileBenchApplySetUpdate(doc bson.Raw, update bson.Raw) (bson.Raw, bool, 
 	if err != nil {
 		return nil, false, err
 	}
-	return bson.Raw(raw), changed, nil
+	return bson.Raw(raw), forceWrite, nil
 }
 
 func TestProfileBenchApplySetUpdateHappyPath(t *testing.T) {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -27,6 +27,15 @@ var (
 	errProfileBenchUpdateMiss = errors.New("profile benchmark update missed document")
 )
 
+const (
+	// Keep update payloads bounded so the benchmark stresses collection update
+	// concurrency instead of BSON allocation variety.
+	profileBenchUpdateDocPoolSize = 4096
+	// Scramble sequential operation numbers across the preloaded ID set while
+	// still using a deterministic, cache-friendly access pattern.
+	profileBenchUpdateIDScrambleMultiplier = 37
+)
+
 func BenchmarkTreeDBGatewayLoadBSONIndexes2(b *testing.B) {
 	benchmarkTreeDBGatewayLoad(b, collections.DocumentFormatBSON, 2, false)
 }
@@ -392,8 +401,7 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	if err := backend.Checkpoint(); err != nil {
 		b.Fatalf("checkpoint preload: %v", err)
 	}
-	const updateDocPoolSize = 4096
-	updateDocs := make([]bson.Raw, updateDocPoolSize)
+	updateDocs := make([]bson.Raw, profileBenchUpdateDocPoolSize)
 	for i := range updateDocs {
 		updateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{
 			{Key: "concurrent_updated", Value: true},
@@ -414,7 +422,7 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	b.ResetTimer()
 	started := time.Now()
 	err = runConcurrentOperations(context.Background(), writers, b.N, func(op int) error {
-		id := ids[(op*37)%documentCount]
+		id := ids[(op*profileBenchUpdateIDScrambleMultiplier)%documentCount]
 		updateRaw := updateDocs[op%len(updateDocs)]
 		matched, _, err := collection.Update(id, func(stored []byte) ([]byte, bool, error) {
 			raw := bson.Raw(stored)

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -392,7 +392,8 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	if err := backend.Checkpoint(); err != nil {
 		b.Fatalf("checkpoint preload: %v", err)
 	}
-	updateDocs := make([]bson.Raw, 4096)
+	const updateDocPoolSize = 4096
+	updateDocs := make([]bson.Raw, updateDocPoolSize)
 	for i := range updateDocs {
 		updateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{
 			{Key: "concurrent_updated", Value: true},

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -410,7 +410,7 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	started := time.Now()
 	err = runConcurrentOperations(context.Background(), writers, b.N, func(op int) error {
 		id := []byte(benchmarkID((op * 37) % documentCount))
-		updateRaw := updateDocs[op&(len(updateDocs)-1)]
+		updateRaw := updateDocs[op%len(updateDocs)]
 		matched, _, err := collection.Update(id, func(stored []byte) ([]byte, bool, error) {
 			raw := bson.Raw(stored)
 			if err := raw.Validate(); err != nil {
@@ -500,7 +500,7 @@ func profileBenchApplySetUpdate(doc bson.Raw, update bson.Raw) (bson.Raw, bool, 
 	}
 	out := make(bson.D, 0, len(elements)+len(sets))
 	used := make(map[string]struct{}, len(sets))
-	changed := false
+	changed := true
 	for _, elem := range elements {
 		key, err := elem.KeyErr()
 		if err != nil {
@@ -508,9 +508,6 @@ func profileBenchApplySetUpdate(doc bson.Raw, update bson.Raw) (bson.Raw, bool, 
 		}
 		value := elem.Value()
 		if replacement, ok := sets[key]; ok {
-			if !replacement.Equal(value) {
-				changed = true
-			}
 			value = replacement
 			used[key] = struct{}{}
 		}
@@ -521,13 +518,57 @@ func profileBenchApplySetUpdate(doc bson.Raw, update bson.Raw) (bson.Raw, bool, 
 			continue
 		}
 		out = append(out, bson.E{Key: key, Value: sets[key]})
-		changed = true
 	}
 	raw, err := bson.Marshal(out)
 	if err != nil {
 		return nil, false, err
 	}
 	return bson.Raw(raw), changed, nil
+}
+
+func TestProfileBenchApplySetUpdateHappyPath(t *testing.T) {
+	docRaw, err := bson.Marshal(bson.D{
+		{Key: "_id", Value: "u1"},
+		{Key: "name", Value: "ada"},
+		{Key: "count", Value: int32(1)},
+	})
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	updateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{
+		{Key: "name", Value: "grace"},
+		{Key: "city", Value: "hnl"},
+		{Key: "count", Value: int32(1)},
+	}}})
+	if err != nil {
+		t.Fatalf("marshal update: %v", err)
+	}
+	updated, changed, err := profileBenchApplySetUpdate(bson.Raw(docRaw), bson.Raw(updateRaw))
+	if err != nil {
+		t.Fatalf("apply update: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed=false want true for non-empty $set")
+	}
+	if got, ok := updated.Lookup("_id").StringValueOK(); !ok || got != "u1" {
+		t.Fatalf("_id=%q ok=%v want u1", got, ok)
+	}
+	if got, ok := updated.Lookup("name").StringValueOK(); !ok || got != "grace" {
+		t.Fatalf("name=%q ok=%v want grace", got, ok)
+	}
+	if got, ok := updated.Lookup("city").StringValueOK(); !ok || got != "hnl" {
+		t.Fatalf("city=%q ok=%v want hnl", got, ok)
+	}
+	if got, ok := updated.Lookup("count").Int32OK(); !ok || got != 1 {
+		t.Fatalf("count=%d ok=%v want 1", got, ok)
+	}
+	_, changed, err = profileBenchApplySetUpdate(updated, bson.Raw(updateRaw))
+	if err != nil {
+		t.Fatalf("reapply update: %v", err)
+	}
+	if !changed {
+		t.Fatal("reapply changed=false want true so benchmark exercises write path")
+	}
 }
 
 func TestProfileBenchApplySetUpdateRejectsGatewayInvalidSetFields(t *testing.T) {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -18,6 +19,11 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/writeconcern"
+)
+
+var (
+	errUpdatedPrimaryKey      = errors.New("profile benchmark update changed _id")
+	errProfileBenchUpdateMiss = errors.New("profile benchmark update missed document")
 )
 
 func BenchmarkTreeDBGatewayLoadBSONIndexes2(b *testing.B) {
@@ -311,6 +317,201 @@ func BenchmarkDirectCollectionLoadBSONIndexes2(b *testing.B) {
 	reportDocsPerSecond(b, b.N, timedElapsed)
 }
 
+func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
+	dir := filepath.Join(b.TempDir(), "treedb")
+	opts := treedb.OptionsFor(treedb.ProfileWALOnFast, dir)
+	opts.IndexOuterLeavesInValueLog = true
+	opts.IndexInternalBaseDelta = false
+	backend, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		b.Fatalf("open backend: %v", err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			b.Fatalf("close backend: %v", err)
+		}
+	}()
+	manager := collections.NewCollectionManager(backend)
+	if _, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: "bench.docs",
+		Options: collections.CollectionOptions{
+			DocumentFormat:          collections.DocumentFormatBSON,
+			DataRootStoragePolicy:   collections.RootStorageCompressed,
+			IndexStateStoragePolicy: collections.RootStorageCompressed,
+		},
+	}); err != nil {
+		b.Fatalf("create collection: %v", err)
+	}
+	collection, err := manager.OpenCollection("bench.docs")
+	if err != nil {
+		b.Fatalf("open collection: %v", err)
+	}
+	if _, err := collection.CreateIndex(collections.IndexDefinition{
+		Name:          "email_1",
+		Field:         "email",
+		Unique:        true,
+		StoragePolicy: collections.RootStorageCompressed,
+	}); err != nil {
+		b.Fatalf("create email index: %v", err)
+	}
+	if _, err := collection.CreateIndex(collections.IndexDefinition{
+		Name:          "city_1",
+		Field:         "city",
+		StoragePolicy: collections.RootStorageCompressed,
+	}); err != nil {
+		b.Fatalf("create city index: %v", err)
+	}
+
+	documentCount := profileBenchUpdateDocumentCount(b)
+	batchSize := profileBenchBatchSize(b)
+	for inserted := 0; inserted < documentCount; {
+		count := batchSize
+		if remaining := documentCount - inserted; remaining < count {
+			count = remaining
+		}
+		ids := make([][]byte, count)
+		docs := make([][]byte, count)
+		for i := 0; i < count; i++ {
+			docNum := inserted + i
+			ids[i] = []byte(benchmarkID(docNum))
+			raw, err := bson.Marshal(benchmarkDocument(docNum))
+			if err != nil {
+				b.Fatalf("marshal BSON document: %v", err)
+			}
+			docs[i] = raw
+		}
+		if _, err := collection.InsertBatchValidatedBSON(ids, docs); err != nil {
+			b.Fatalf("insert preload batch: %v", err)
+		}
+		inserted += count
+	}
+	if err := manager.FlushAll(); err != nil {
+		b.Fatalf("flush preload: %v", err)
+	}
+	if err := backend.Checkpoint(); err != nil {
+		b.Fatalf("checkpoint preload: %v", err)
+	}
+
+	writers := profileBenchConcurrentWriters(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	started := time.Now()
+	err = runConcurrentOperations(context.Background(), writers, b.N, func(op int) error {
+		id := []byte(benchmarkID((op * 37) % documentCount))
+		updateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{
+			{Key: "concurrent_updated", Value: true},
+			{Key: "concurrent_update_seq", Value: int64(op)},
+		}}})
+		if err != nil {
+			return err
+		}
+		matched, _, err := collection.Update(id, func(stored []byte) ([]byte, bool, error) {
+			raw := bson.Raw(stored)
+			if err := raw.Validate(); err != nil {
+				return nil, false, err
+			}
+			originalID := raw.Lookup("_id")
+			updated, changed, err := profileBenchApplySetUpdate(raw, bson.Raw(updateRaw))
+			if err != nil {
+				return nil, false, err
+			}
+			if !updated.Lookup("_id").Equal(originalID) {
+				return nil, false, errUpdatedPrimaryKey
+			}
+			return []byte(updated), changed, nil
+		})
+		if err != nil {
+			return err
+		}
+		if !matched {
+			return errProfileBenchUpdateMiss
+		}
+		return nil
+	})
+	timedElapsed := time.Since(started)
+	b.StopTimer()
+	if err != nil {
+		b.Fatalf("run concurrent updates: %v", err)
+	}
+	b.ReportMetric(float64(writers), "writers")
+	reportDocsPerSecond(b, b.N, timedElapsed)
+}
+
+func profileBenchApplySetUpdate(doc bson.Raw, update bson.Raw) (bson.Raw, bool, error) {
+	updateElements, err := update.Elements()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(updateElements) != 1 {
+		return nil, false, errors.New("profile benchmark update supports exactly one $set operator")
+	}
+	operator, err := updateElements[0].KeyErr()
+	if err != nil {
+		return nil, false, err
+	}
+	if operator != "$set" {
+		return nil, false, errors.New("profile benchmark update supports $set only")
+	}
+	setDoc, ok := updateElements[0].Value().DocumentOK()
+	if !ok {
+		return nil, false, errors.New("profile benchmark $set value must be a document")
+	}
+	setElements, err := setDoc.Elements()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(setElements) == 0 {
+		return doc, false, nil
+	}
+	sets := make(map[string]bson.RawValue, len(setElements))
+	setOrder := make([]string, 0, len(setElements))
+	for _, elem := range setElements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, false, err
+		}
+		if _, exists := sets[key]; !exists {
+			setOrder = append(setOrder, key)
+		}
+		sets[key] = elem.Value()
+	}
+
+	elements, err := doc.Elements()
+	if err != nil {
+		return nil, false, err
+	}
+	out := make(bson.D, 0, len(elements)+len(sets))
+	used := make(map[string]struct{}, len(sets))
+	changed := false
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, false, err
+		}
+		value := elem.Value()
+		if replacement, ok := sets[key]; ok {
+			if !replacement.Equal(value) {
+				changed = true
+			}
+			value = replacement
+			used[key] = struct{}{}
+		}
+		out = append(out, bson.E{Key: key, Value: value})
+	}
+	for _, key := range setOrder {
+		if _, ok := used[key]; ok {
+			continue
+		}
+		out = append(out, bson.E{Key: key, Value: sets[key]})
+		changed = true
+	}
+	raw, err := bson.Marshal(out)
+	if err != nil {
+		return nil, false, err
+	}
+	return bson.Raw(raw), changed, nil
+}
+
 type profileBenchReadWriter struct {
 	r *bytes.Reader
 	w bytes.Buffer
@@ -572,15 +773,26 @@ func benchmarkTreeDBGatewayRunRawCommandLoad(b *testing.B, format collections.Do
 }
 
 func profileBenchBatchSize(tb testing.TB) int {
+	return profileBenchPositiveEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE", 10000)
+}
+
+func profileBenchUpdateDocumentCount(tb testing.TB) int {
+	return profileBenchPositiveEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS", 100000)
+}
+
+func profileBenchConcurrentWriters(tb testing.TB) int {
+	return profileBenchPositiveEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_WRITERS", 8)
+}
+
+func profileBenchPositiveEnvInt(tb testing.TB, name string, defaultValue int) int {
 	tb.Helper()
-	const defaultBatchSize = 10000
-	raw := os.Getenv("MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE")
+	raw := os.Getenv(name)
 	if raw == "" {
-		return defaultBatchSize
+		return defaultValue
 	}
 	value, err := strconv.Atoi(raw)
 	if err != nil || value <= 0 {
-		tb.Fatalf("invalid MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=%q", raw)
+		tb.Fatalf("invalid %s=%q", name, raw)
 	}
 	return value
 }


### PR DESCRIPTION
## Summary

- Add `-profile-dir` support to `cmd/mongo_gateway_bench` so a normal benchmark run writes per-phase pprof artifacts and a manifest.
- Capture CPU during each measured phase, plus heap, allocs, block, mutex, and goroutine profiles after each phase; `-profile-trace` optionally adds runtime traces.
- Write `profile_manifest.json` and `benchmark_result.json` beside the profile files so future bottleneck investigations keep results and artifacts tied together.
- Add a direct collection concurrent-update profiling benchmark to compare gateway update profiles against the underlying BSON collection update path.
- Document reusable insert-scaling and write-contention profiling workflows.

## Validation

- `GOWORK=off go test ./cmd/mongo_gateway_bench -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1`
- `GOWORK=off go build ./cmd/mongo_gateway_bench`
- `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100 MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=50 MONGO_GATEWAY_PROFILE_BENCH_WRITERS=2 GOWORK=off go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' -benchtime 10x -count 1`
- CLI profile smoke produced the expected phase files, `profile_manifest.json`, and `benchmark_result.json` under `/tmp/gomap_mongo_gateway_pprof_smoke_x2rp5E`.

## Stack

This is intentionally stacked on `codex/mongo-gateway-multi-producer-bench` / PR #1110 so the profiling mode can use the multi-producer and concurrent operation benchmark surfaces added there.
