### PR TITLE
[codex] Cache collection catalogs for gateway hot paths

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -966,6 +966,17 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	if snap == nil {
 		return nil, collectionOptions{}, false, backenddb.ErrClosed
 	}
+	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
+	if catalog := cachedWriteDomainCatalogForStateLocked(domain, baseSystemRoot, baseCommitSeq); catalog != nil {
+		c.rememberCatalog(snap, catalog)
+		_ = snap.Close()
+		options, err := collectionPlannerOptions(catalog.meta)
+		if err != nil {
+			return nil, collectionOptions{}, false, err
+		}
+		return catalog, options, len(catalog.meta.Indexes) > 0, nil
+	}
 	name := c.meta.Name
 	if domain.meta.Name != "" {
 		name = domain.meta.Name
@@ -979,8 +990,6 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		_ = snap.Close()
 		return nil, collectionOptions{}, false, errCollectionNotFound
 	}
-	baseSystemRoot := snapshotSystemRoot(snap)
-	baseCommitSeq := snapshotCommitSeq(snap)
 	c.rememberCatalog(snap, catalog)
 	_ = snap.Close()
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -966,7 +966,11 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	if snap == nil {
 		return nil, collectionOptions{}, false, backenddb.ErrClosed
 	}
-	catalog, err := c.catalogForSnapshot(snap)
+	name := c.meta.Name
+	if domain.meta.Name != "" {
+		name = domain.meta.Name
+	}
+	catalog, err := loadCollectionCatalog(snap, name)
 	if err != nil {
 		_ = snap.Close()
 		return nil, collectionOptions{}, false, err
@@ -977,6 +981,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	}
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
+	c.rememberCatalog(snap, catalog)
 	_ = snap.Close()
 
 	options, err := collectionPlannerOptions(catalog.meta)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -519,6 +519,9 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 	if err := ValidateCollectionName(name); err != nil {
 		return nil, err
 	}
+	if m.db.IsClosing() {
+		return nil, backenddb.ErrClosed
+	}
 	if collection, ok := m.openCollectionFromWriteDomainCache(name); ok {
 		return collection, nil
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -47,6 +47,7 @@ var (
 
 	errCollectionManagerNil = errors.New("collections: collection manager is nil")
 	errCollectionNil        = errors.New("collections: collection is nil")
+	errCollectionDBNil      = errors.New("collections: db is nil")
 	errCollectionNotFound   = ErrCollectionNotFound
 )
 
@@ -111,7 +112,7 @@ func persistIndexStateForDocumentFormat(format DocumentFormat) bool {
 type CollectionManager struct {
 	db              *backenddb.DB
 	closeUnregister func()
-	domainMu        sync.Mutex
+	domainMu        sync.RWMutex
 	domains         map[string]*collectionWriteDomain
 }
 
@@ -283,6 +284,8 @@ type collectionMetaDisk struct {
 }
 
 type collectionCatalog struct {
+	// collectionCatalog is immutable once cached or published. Root updates must
+	// create a replacement catalog via cloneCatalogWithRootUpdates.
 	meta  CollectionMeta
 	roots map[string]uint64
 }
@@ -394,8 +397,8 @@ func (m *CollectionManager) existingWriteDomainForCollection(name string) *colle
 	if m == nil {
 		return nil
 	}
-	m.domainMu.Lock()
-	defer m.domainMu.Unlock()
+	m.domainMu.RLock()
+	defer m.domainMu.RUnlock()
 	if m.domains == nil {
 		return nil
 	}
@@ -409,14 +412,14 @@ func (m *CollectionManager) FlushAll() error {
 	if m == nil || m.db == nil {
 		return nil
 	}
-	m.domainMu.Lock()
+	m.domainMu.RLock()
 	domains := make([]*collectionWriteDomain, 0, len(m.domains))
 	for _, domain := range m.domains {
 		if domain != nil {
 			domains = append(domains, domain)
 		}
 	}
-	m.domainMu.Unlock()
+	m.domainMu.RUnlock()
 
 	var errs []error
 	for _, domain := range domains {
@@ -452,7 +455,7 @@ func (m *CollectionManager) CreateCollection(meta *CollectionMeta) (*CollectionM
 		return nil, errCollectionManagerNil
 	}
 	if m.db == nil {
-		return nil, errors.New("collections: db is nil")
+		return nil, errCollectionDBNil
 	}
 	if meta == nil {
 		return nil, errors.New("collections: nil collection metadata")
@@ -514,7 +517,7 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 		return nil, errCollectionManagerNil
 	}
 	if m.db == nil {
-		return nil, errors.New("collections: db is nil")
+		return nil, errCollectionDBNil
 	}
 	if err := ValidateCollectionName(name); err != nil {
 		return nil, err
@@ -562,7 +565,7 @@ func (m *CollectionManager) openCollectionFromWriteDomainCache(name string) (*Co
 	if domain == nil {
 		return nil, false
 	}
-	catalog := cachedWriteDomainCatalogForSystemRoot(domain, state.SystemRootPageID)
+	catalog := cachedWriteDomainCatalogForState(domain, state.SystemRootPageID, state.CommitSeq)
 	if catalog == nil {
 		return nil, false
 	}
@@ -572,9 +575,6 @@ func (m *CollectionManager) openCollectionFromWriteDomainCache(name string) (*Co
 		meta:        catalog.meta,
 	}
 	collection.rememberCatalogAtSystemRoot(state.SystemRootPageID, catalog)
-	if m.db.IsClosing() {
-		return nil, false
-	}
 	return collection, true
 }
 
@@ -583,7 +583,7 @@ func (m *CollectionManager) ListCollections() ([]CollectionMeta, error) {
 		return nil, errCollectionManagerNil
 	}
 	if m.db == nil {
-		return nil, errors.New("collections: db is nil")
+		return nil, errCollectionDBNil
 	}
 	snap := m.db.AcquireSnapshot()
 	if snap == nil {
@@ -646,7 +646,7 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 		return nil, errCollectionNil
 	}
 	if c.db == nil {
-		return nil, errors.New("collections: db is nil")
+		return nil, errCollectionDBNil
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
@@ -767,7 +767,7 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 		return nil, errCollectionNil
 	}
 	if c.db == nil {
-		return nil, errors.New("collections: db is nil")
+		return nil, errCollectionDBNil
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
@@ -852,7 +852,7 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 		return nil, errCollectionNil
 	}
 	if c.db == nil {
-		return nil, errors.New("collections: db is nil")
+		return nil, errCollectionDBNil
 	}
 	if len(c.meta.Indexes) == 0 {
 		return c.insertOneNoIndexBuffered(id, document)
@@ -875,7 +875,7 @@ func (c *Collection) Flush() error {
 		return errCollectionNil
 	}
 	if c.db == nil {
-		return errors.New("collections: db is nil")
+		return errCollectionDBNil
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
@@ -990,7 +990,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 
 func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWriteDomain, currentCommitSeq, currentSystemRoot uint64) (*collectionCatalog, error) {
 	if c == nil || c.db == nil {
-		return nil, errors.New("collections: db is nil")
+		return nil, errCollectionDBNil
 	}
 	if domain == nil {
 		return nil, errors.New("collections: missing write domain")
@@ -2208,7 +2208,7 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 		return nil, errCollectionNil
 	}
 	if c.db == nil {
-		return nil, errors.New("collections: db is nil")
+		return nil, errCollectionDBNil
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
@@ -2514,7 +2514,7 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 		return false, errCollectionNil
 	}
 	if c.db == nil {
-		return false, errors.New("collections: db is nil")
+		return false, errCollectionDBNil
 	}
 	if len(documentID) == 0 {
 		return false, errors.New("collections: document id cannot be empty")
@@ -2683,7 +2683,7 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 		return false, false, errCollectionNil
 	}
 	if c.db == nil {
-		return false, false, errors.New("collections: db is nil")
+		return false, false, errCollectionDBNil
 	}
 	if len(documentID) == 0 {
 		return false, false, errors.New("collections: document id cannot be empty")
@@ -2965,7 +2965,7 @@ func (c *Collection) catalogForSnapshot(snap *backenddb.Snapshot) (*collectionCa
 	}
 	c.catalogMu.RUnlock()
 
-	if cached := cachedWriteDomainCatalogForSystemRoot(c.writeDomain, systemRoot); cached != nil {
+	if cached := cachedWriteDomainCatalogForState(c.writeDomain, systemRoot, commitSeq); cached != nil {
 		c.rememberCatalog(snap, cached)
 		return cached, nil
 	}
@@ -2978,13 +2978,13 @@ func (c *Collection) catalogForSnapshot(snap *backenddb.Snapshot) (*collectionCa
 	return catalog, nil
 }
 
-func cachedWriteDomainCatalogForSystemRoot(domain *collectionWriteDomain, systemRoot uint64) *collectionCatalog {
+func cachedWriteDomainCatalogForState(domain *collectionWriteDomain, systemRoot, commitSeq uint64) *collectionCatalog {
 	if domain == nil || systemRoot == 0 {
 		return nil
 	}
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()
-	if !domain.loaded || domain.catalog == nil || domain.baseSystemRoot != systemRoot {
+	if !domain.loaded || domain.catalog == nil || domain.baseSystemRoot != systemRoot || domain.baseCommitSeq != commitSeq {
 		return nil
 	}
 	return domain.catalog
@@ -3564,7 +3564,7 @@ func (c *Collection) NewStoredDocumentJSONMaterializer() (*StoredDocumentJSONMat
 		return nil, errCollectionNil
 	}
 	if c.db == nil {
-		return nil, errors.New("collections: db is nil")
+		return nil, errCollectionDBNil
 	}
 	documentFormat, err := normalizeDocumentFormat(c.meta.Options.DocumentFormat)
 	if err != nil {
@@ -3631,7 +3631,7 @@ func (c *Collection) GetInto(documentID []byte, dst []byte) ([]byte, bool, error
 		return dst[:0], false, errCollectionNil
 	}
 	if c.db == nil {
-		return dst[:0], false, errors.New("collections: db is nil")
+		return dst[:0], false, errCollectionDBNil
 	}
 	if len(documentID) == 0 {
 		return dst[:0], false, errors.New("collections: document id cannot be empty")
@@ -3929,7 +3929,7 @@ func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord)
 		return false, errCollectionNil
 	}
 	if c.db == nil {
-		return false, errors.New("collections: db is nil")
+		return false, errCollectionDBNil
 	}
 	if maxDocuments <= 0 {
 		return false, errors.New("collections: max documents must be positive")

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -523,6 +523,9 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 		return nil, backenddb.ErrClosed
 	}
 	if collection, ok := m.openCollectionFromWriteDomainCache(name); ok {
+		if m.db.IsClosing() {
+			return nil, backenddb.ErrClosed
+		}
 		return collection, nil
 	}
 	snap := m.db.AcquireSnapshot()
@@ -569,6 +572,9 @@ func (m *CollectionManager) openCollectionFromWriteDomainCache(name string) (*Co
 		meta:        catalog.meta,
 	}
 	collection.rememberCatalogAtSystemRoot(state.SystemRootPageID, catalog)
+	if m.db.IsClosing() {
+		return nil, false
+	}
 	return collection, true
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -390,6 +390,18 @@ func (m *CollectionManager) writeDomainForCollection(name string) *collectionWri
 	return domain
 }
 
+func (m *CollectionManager) existingWriteDomainForCollection(name string) *collectionWriteDomain {
+	if m == nil {
+		return nil
+	}
+	m.domainMu.Lock()
+	defer m.domainMu.Unlock()
+	if m.domains == nil {
+		return nil
+	}
+	return m.domains[name]
+}
+
 // FlushAll publishes buffered writes for every collection opened through this
 // manager. The backend DB also calls this as a close hook while write APIs are
 // still available.
@@ -507,6 +519,9 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 	if err := ValidateCollectionName(name); err != nil {
 		return nil, err
 	}
+	if collection, ok := m.openCollectionFromWriteDomainCache(name); ok {
+		return collection, nil
+	}
 	snap := m.db.AcquireSnapshot()
 	if snap == nil {
 		return nil, backenddb.ErrClosed
@@ -525,7 +540,33 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 		meta:        catalog.meta,
 	}
 	collection.rememberCatalog(snap, catalog)
+	collection.noteWriteDomainCatalog(snapshotSystemRoot(snap), catalog)
 	return collection, nil
+}
+
+func (m *CollectionManager) openCollectionFromWriteDomainCache(name string) (*Collection, bool) {
+	if m == nil || m.db == nil {
+		return nil, false
+	}
+	state := m.db.State()
+	if state == nil || state.SystemRootPageID == 0 {
+		return nil, false
+	}
+	domain := m.existingWriteDomainForCollection(name)
+	if domain == nil {
+		return nil, false
+	}
+	catalog := cachedWriteDomainCatalogForSystemRoot(domain, state.SystemRootPageID)
+	if catalog == nil {
+		return nil, false
+	}
+	collection := &Collection{
+		db:          m.db,
+		writeDomain: domain,
+		meta:        catalog.meta,
+	}
+	collection.rememberCatalogAtSystemRoot(state.SystemRootPageID, catalog)
+	return collection, true
 }
 
 func (m *CollectionManager) ListCollections() ([]CollectionMeta, error) {
@@ -2915,12 +2956,29 @@ func (c *Collection) catalogForSnapshot(snap *backenddb.Snapshot) (*collectionCa
 	}
 	c.catalogMu.RUnlock()
 
+	if cached := cachedWriteDomainCatalogForSystemRoot(c.writeDomain, systemRoot); cached != nil {
+		c.rememberCatalog(snap, cached)
+		return cached, nil
+	}
+
 	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
 	if err != nil {
 		return nil, err
 	}
 	c.rememberCatalog(snap, catalog)
 	return catalog, nil
+}
+
+func cachedWriteDomainCatalogForSystemRoot(domain *collectionWriteDomain, systemRoot uint64) *collectionCatalog {
+	if domain == nil || systemRoot == 0 {
+		return nil
+	}
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	if !domain.loaded || domain.catalog == nil || domain.baseSystemRoot != systemRoot {
+		return nil
+	}
+	return domain.catalog
 }
 
 func snapshotSystemRoot(snap *backenddb.Snapshot) uint64 {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2993,7 +2993,7 @@ func cachedWriteDomainCatalogForState(domain *collectionWriteDomain, systemRoot,
 	if !domain.loaded || domain.catalog == nil || domain.baseSystemRoot != systemRoot || domain.baseCommitSeq != commitSeq {
 		return nil
 	}
-	return domain.catalog.copy()
+	return domain.catalog
 }
 
 func snapshotSystemRoot(snap *backenddb.Snapshot) uint64 {
@@ -3117,7 +3117,11 @@ func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, r
 			roots[name] = rootIDs[i]
 		}
 	}
-	return (&collectionCatalog{meta: meta, roots: roots}).copy()
+	metaCopy := meta
+	if copied := meta.copy(); copied != nil {
+		metaCopy = *copied
+	}
+	return &collectionCatalog{meta: metaCopy, roots: roots}
 }
 
 func buildDeleteRootDeltaTable(deleteKeys [][]byte) memtable.Table {
@@ -4022,7 +4026,7 @@ func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCa
 		}
 		roots[rootName] = rootID
 	}
-	return (&collectionCatalog{meta: meta, roots: roots}).copy(), nil
+	return &collectionCatalog{meta: meta, roots: roots}, nil
 }
 
 func (c *collectionCatalog) rootID(rootName string) uint64 {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -546,7 +546,7 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 	collection := &Collection{
 		db:          m.db,
 		writeDomain: m.writeDomainForCollection(catalog.meta.Name),
-		meta:        *catalog.meta.copy(),
+		meta:        copyCollectionMeta(catalog.meta),
 	}
 	collection.rememberCatalog(snap, catalog)
 	collection.noteWriteDomainCatalog(snapshotSystemRoot(snap), catalog)
@@ -578,7 +578,7 @@ func (m *CollectionManager) openCollectionFromWriteDomainCache(name string) (*Co
 	collection := &Collection{
 		db:          m.db,
 		writeDomain: domain,
-		meta:        *catalog.meta.copy(),
+		meta:        copyCollectionMeta(catalog.meta),
 	}
 	collection.rememberCatalogAtSystemRoot(state.SystemRootPageID, catalog)
 	return collection, true
@@ -2963,6 +2963,14 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 }
 
 func (c *Collection) catalogForSnapshot(snap *backenddb.Snapshot) (*collectionCatalog, error) {
+	return c.catalogForSnapshotWithWriteDomainLockState(snap, false)
+}
+
+func (c *Collection) catalogForSnapshotWithWriteDomainLocked(snap *backenddb.Snapshot) (*collectionCatalog, error) {
+	return c.catalogForSnapshotWithWriteDomainLockState(snap, true)
+}
+
+func (c *Collection) catalogForSnapshotWithWriteDomainLockState(snap *backenddb.Snapshot, writeDomainLocked bool) (*collectionCatalog, error) {
 	if snap == nil {
 		return nil, backenddb.ErrClosed
 	}
@@ -2976,7 +2984,13 @@ func (c *Collection) catalogForSnapshot(snap *backenddb.Snapshot) (*collectionCa
 	}
 	c.catalogMu.RUnlock()
 
-	if cached := cachedWriteDomainCatalogForState(c.writeDomain, systemRoot, commitSeq); cached != nil {
+	var cached *collectionCatalog
+	if writeDomainLocked {
+		cached = cachedWriteDomainCatalogForStateLocked(c.writeDomain, systemRoot, commitSeq)
+	} else {
+		cached = cachedWriteDomainCatalogForState(c.writeDomain, systemRoot, commitSeq)
+	}
+	if cached != nil {
 		c.rememberCatalog(snap, cached)
 		return cached, nil
 	}
@@ -2995,11 +3009,18 @@ func cachedWriteDomainCatalogForState(domain *collectionWriteDomain, systemRoot,
 	}
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()
+	return cachedWriteDomainCatalogForStateLocked(domain, systemRoot, commitSeq)
+}
+
+func cachedWriteDomainCatalogForStateLocked(domain *collectionWriteDomain, systemRoot, commitSeq uint64) *collectionCatalog {
+	if domain == nil || systemRoot == 0 {
+		return nil
+	}
 	if !domain.loaded || domain.catalog == nil || domain.baseSystemRoot != systemRoot || domain.baseCommitSeq != commitSeq {
 		return nil
 	}
-	// The write domain owns this catalog. Callers may read it directly, but must
-	// copy before retaining it in another cache.
+	// Collection catalogs are immutable after publication, so callers may retain
+	// and share this pointer across handle-local caches.
 	return domain.catalog
 }
 
@@ -3063,7 +3084,7 @@ func (c *Collection) rememberCatalog(snap *backenddb.Snapshot, catalog *collecti
 	c.catalogMu.Lock()
 	c.catalogCommitSeq = commitSeq
 	c.catalogSystemRoot = systemRoot
-	c.catalog = catalog.copy()
+	c.catalog = catalog
 	c.catalogMu.Unlock()
 }
 
@@ -3075,7 +3096,7 @@ func (c *Collection) rememberCatalogAtSystemRoot(systemRoot uint64, catalog *col
 	c.catalogMu.Lock()
 	c.catalogCommitSeq = commitSeq
 	c.catalogSystemRoot = systemRoot
-	c.catalog = catalog.copy()
+	c.catalog = catalog
 	c.catalogMu.Unlock()
 }
 
@@ -3095,8 +3116,8 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 		return
 	}
 	domain.loaded = true
-	domain.meta = *catalog.meta.copy()
-	domain.catalog = catalog.copy()
+	domain.meta = copyCollectionMeta(catalog.meta)
+	domain.catalog = catalog
 	domain.baseCommitSeq = c.commitSeqForSystemRoot(systemRoot)
 	domain.baseSystemRoot = systemRoot
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
@@ -3124,11 +3145,7 @@ func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, r
 			roots[name] = rootIDs[i]
 		}
 	}
-	metaCopy := meta
-	if copied := meta.copy(); copied != nil {
-		metaCopy = *copied
-	}
-	return &collectionCatalog{meta: metaCopy, roots: roots}
+	return &collectionCatalog{meta: copyCollectionMeta(meta), roots: roots}
 }
 
 func buildDeleteRootDeltaTable(deleteKeys [][]byte) memtable.Table {
@@ -3763,7 +3780,7 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 		return nil, false, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
-	catalog, err := c.catalogForSnapshot(snap)
+	catalog, err := c.catalogForSnapshotWithWriteDomainLocked(snap)
 	if err != nil {
 		return nil, false, err
 	}
@@ -4052,7 +4069,7 @@ func (c *collectionCatalog) copy() *collectionCatalog {
 		roots[name] = rootID
 	}
 	return &collectionCatalog{
-		meta:  *c.meta.copy(),
+		meta:  copyCollectionMeta(c.meta),
 		roots: roots,
 	}
 }
@@ -4332,6 +4349,13 @@ func (m CollectionMeta) copy() *CollectionMeta {
 		Options: m.Options,
 		Indexes: append([]IndexDefinition(nil), m.Indexes...),
 	}
+}
+
+func copyCollectionMeta(meta CollectionMeta) CollectionMeta {
+	if copied := meta.copy(); copied != nil {
+		return *copied
+	}
+	return meta
 }
 
 func sameCollectionMeta(a, b CollectionMeta) bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2993,6 +2993,8 @@ func cachedWriteDomainCatalogForState(domain *collectionWriteDomain, systemRoot,
 	if !domain.loaded || domain.catalog == nil || domain.baseSystemRoot != systemRoot || domain.baseCommitSeq != commitSeq {
 		return nil
 	}
+	// The write domain owns this catalog. Callers may read it directly, but must
+	// copy before retaining it in another cache.
 	return domain.catalog
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -519,11 +519,11 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 	if m.db == nil {
 		return nil, errCollectionDBNil
 	}
-	if err := ValidateCollectionName(name); err != nil {
-		return nil, err
-	}
 	if m.db.IsClosing() {
 		return nil, backenddb.ErrClosed
+	}
+	if err := ValidateCollectionName(name); err != nil {
+		return nil, err
 	}
 	if collection, ok := m.openCollectionFromWriteDomainCache(name); ok {
 		if m.db.IsClosing() {
@@ -546,7 +546,7 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 	collection := &Collection{
 		db:          m.db,
 		writeDomain: m.writeDomainForCollection(catalog.meta.Name),
-		meta:        catalog.meta,
+		meta:        *catalog.meta.copy(),
 	}
 	collection.rememberCatalog(snap, catalog)
 	collection.noteWriteDomainCatalog(snapshotSystemRoot(snap), catalog)
@@ -569,10 +569,16 @@ func (m *CollectionManager) openCollectionFromWriteDomainCache(name string) (*Co
 	if catalog == nil {
 		return nil, false
 	}
+	currentState := m.db.State()
+	if currentState == nil ||
+		currentState.SystemRootPageID != state.SystemRootPageID ||
+		currentState.CommitSeq != state.CommitSeq {
+		return nil, false
+	}
 	collection := &Collection{
 		db:          m.db,
 		writeDomain: domain,
-		meta:        catalog.meta,
+		meta:        *catalog.meta.copy(),
 	}
 	collection.rememberCatalogAtSystemRoot(state.SystemRootPageID, catalog)
 	return collection, true
@@ -2987,7 +2993,7 @@ func cachedWriteDomainCatalogForState(domain *collectionWriteDomain, systemRoot,
 	if !domain.loaded || domain.catalog == nil || domain.baseSystemRoot != systemRoot || domain.baseCommitSeq != commitSeq {
 		return nil
 	}
-	return domain.catalog
+	return domain.catalog.copy()
 }
 
 func snapshotSystemRoot(snap *backenddb.Snapshot) uint64 {
@@ -3050,7 +3056,7 @@ func (c *Collection) rememberCatalog(snap *backenddb.Snapshot, catalog *collecti
 	c.catalogMu.Lock()
 	c.catalogCommitSeq = commitSeq
 	c.catalogSystemRoot = systemRoot
-	c.catalog = catalog
+	c.catalog = catalog.copy()
 	c.catalogMu.Unlock()
 }
 
@@ -3062,7 +3068,7 @@ func (c *Collection) rememberCatalogAtSystemRoot(systemRoot uint64, catalog *col
 	c.catalogMu.Lock()
 	c.catalogCommitSeq = commitSeq
 	c.catalogSystemRoot = systemRoot
-	c.catalog = catalog
+	c.catalog = catalog.copy()
 	c.catalogMu.Unlock()
 }
 
@@ -3082,8 +3088,8 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 		return
 	}
 	domain.loaded = true
-	domain.meta = catalog.meta
-	domain.catalog = catalog
+	domain.meta = *catalog.meta.copy()
+	domain.catalog = catalog.copy()
 	domain.baseCommitSeq = c.commitSeqForSystemRoot(systemRoot)
 	domain.baseSystemRoot = systemRoot
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
@@ -3111,10 +3117,7 @@ func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, r
 			roots[name] = rootIDs[i]
 		}
 	}
-	return &collectionCatalog{
-		meta:  meta,
-		roots: roots,
-	}
+	return (&collectionCatalog{meta: meta, roots: roots}).copy()
 }
 
 func buildDeleteRootDeltaTable(deleteKeys [][]byte) memtable.Table {
@@ -4019,7 +4022,7 @@ func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCa
 		}
 		roots[rootName] = rootID
 	}
-	return &collectionCatalog{meta: meta, roots: roots}, nil
+	return (&collectionCatalog{meta: meta, roots: roots}).copy(), nil
 }
 
 func (c *collectionCatalog) rootID(rootName string) uint64 {
@@ -4027,6 +4030,20 @@ func (c *collectionCatalog) rootID(rootName string) uint64 {
 		return 0
 	}
 	return c.roots[rootName]
+}
+
+func (c *collectionCatalog) copy() *collectionCatalog {
+	if c == nil {
+		return nil
+	}
+	roots := make(map[string]uint64, len(c.roots))
+	for name, rootID := range c.roots {
+		roots[name] = rootID
+	}
+	return &collectionCatalog{
+		meta:  *c.meta.copy(),
+		roots: roots,
+	}
 }
 
 func getSystemValue(snap *backenddb.Snapshot, key string) ([]byte, bool, error) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -42,7 +42,7 @@ func TestCollectionGetNilDBReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "db is nil") {
+	if !errors.Is(err, errCollectionDBNil) {
 		t.Fatalf("Get nil db error=%v", err)
 	}
 }
@@ -50,8 +50,8 @@ func TestCollectionGetNilDBReturnsError(t *testing.T) {
 func TestCollectionManagerOpenCollectionNilDBReturnsConfigurationError(t *testing.T) {
 	mgr := NewCollectionManager(nil)
 	_, err := mgr.OpenCollection("users")
-	if err == nil || !strings.Contains(err.Error(), "db is nil") {
-		t.Fatalf("OpenCollection nil db err=%v want db is nil", err)
+	if !errors.Is(err, errCollectionDBNil) {
+		t.Fatalf("OpenCollection nil db err=%v want errCollectionDBNil", err)
 	}
 }
 
@@ -2325,7 +2325,7 @@ func TestCollectionCachedCatalogUsesCommitSeq(t *testing.T) {
 	}
 }
 
-func TestOpenCollectionUsesWriteDomainCatalogCache(t *testing.T) {
+func TestOpenCollectionWriteDomainCatalogCacheUsesCommitSeq(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -2346,9 +2346,12 @@ func TestOpenCollectionUsesWriteDomainCatalogCache(t *testing.T) {
 
 	state := d.State()
 	domain := mgr.existingWriteDomainForCollection("users")
-	cached := cachedWriteDomainCatalogForSystemRoot(domain, state.SystemRootPageID)
+	cached := cachedWriteDomainCatalogForState(domain, state.SystemRootPageID, state.CommitSeq)
 	if cached == nil {
 		t.Fatal("expected populated write-domain catalog cache")
+	}
+	if stale := cachedWriteDomainCatalogForState(domain, state.SystemRootPageID, state.CommitSeq+1); stale != nil {
+		t.Fatal("write-domain catalog cache ignored commit sequence")
 	}
 	if err := d.Set([]byte("raw/unrelated"), []byte("value")); err != nil {
 		t.Fatalf("raw set: %v", err)
@@ -2374,8 +2377,11 @@ func TestOpenCollectionUsesWriteDomainCatalogCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("catalogForSnapshot: %v", err)
 	}
-	if reopenedCatalog != cached {
-		t.Fatalf("OpenCollection did not reuse write-domain catalog cache")
+	if reopenedCatalog == cached {
+		t.Fatal("OpenCollection reused stale write-domain catalog cache after commit sequence changed")
+	}
+	if fresh := cachedWriteDomainCatalogForState(domain, rawState.SystemRootPageID, rawState.CommitSeq); fresh != reopenedCatalog {
+		t.Fatal("OpenCollection did not refresh write-domain catalog cache for new commit sequence")
 	}
 	if got, err := reopened.Get([]byte("u1")); err != nil || !bytes.Equal(got, []byte(`{"name":"ada"}`)) {
 		t.Fatalf("reopened get got=%q err=%v", got, err)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -47,7 +47,7 @@ func TestCollectionGetNilDBReturnsError(t *testing.T) {
 	}
 }
 
-func TestCollectionManagerOpenCollectionNilDBReturnsConfigurationError(t *testing.T) {
+func TestCollectionManagerOpenCollectionNilDBReturnsErrCollectionDBNil(t *testing.T) {
 	mgr := NewCollectionManager(nil)
 	_, err := mgr.OpenCollection("users")
 	if !errors.Is(err, errCollectionDBNil) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2295,6 +2295,63 @@ func TestCollectionCachedCatalogUsesCommitSeq(t *testing.T) {
 	}
 }
 
+func TestOpenCollectionUsesWriteDomainCatalogCache(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"ada"}`)}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	state := d.State()
+	domain := mgr.existingWriteDomainForCollection("users")
+	cached := cachedWriteDomainCatalogForSystemRoot(domain, state.SystemRootPageID)
+	if cached == nil {
+		t.Fatal("expected populated write-domain catalog cache")
+	}
+	if err := d.Set([]byte("raw/unrelated"), []byte("value")); err != nil {
+		t.Fatalf("raw set: %v", err)
+	}
+	rawState := d.State()
+	if rawState.SystemRootPageID != state.SystemRootPageID {
+		t.Fatalf("raw write changed system root from %d to %d", state.SystemRootPageID, rawState.SystemRootPageID)
+	}
+	if rawState.CommitSeq == state.CommitSeq {
+		t.Fatalf("raw write did not advance commit seq: before=%d after=%d", state.CommitSeq, rawState.CommitSeq)
+	}
+
+	reopened, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("reopen collection: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	reopenedCatalog, err := reopened.catalogForSnapshot(snap)
+	if err != nil {
+		t.Fatalf("catalogForSnapshot: %v", err)
+	}
+	if reopenedCatalog != cached {
+		t.Fatalf("OpenCollection did not reuse write-domain catalog cache")
+	}
+	if got, err := reopened.Get([]byte("u1")); err != nil || !bytes.Equal(got, []byte(`{"name":"ada"}`)) {
+		t.Fatalf("reopened get got=%q err=%v", got, err)
+	}
+}
+
 func TestCollectionSingleInsertMatchesSingleItemBatch(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -47,6 +47,14 @@ func TestCollectionGetNilDBReturnsError(t *testing.T) {
 	}
 }
 
+func TestCollectionManagerOpenCollectionNilDBReturnsConfigurationError(t *testing.T) {
+	mgr := NewCollectionManager(nil)
+	_, err := mgr.OpenCollection("users")
+	if err == nil || !strings.Contains(err.Error(), "db is nil") {
+		t.Fatalf("OpenCollection nil db err=%v want db is nil", err)
+	}
+}
+
 func TestCollectionManagerOpenCollectionCacheRejectsClosedDB(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2395,6 +2395,46 @@ func TestOpenCollectionWriteDomainCatalogCacheUsesCommitSeq(t *testing.T) {
 	}
 }
 
+func TestNoIndexInsertAfterRawCommitDoesNotReenterWriteDomainLock(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		_ = d.Close()
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("open collection: %v", err)
+	}
+	if err := d.Set([]byte("raw/unrelated"), []byte("value")); err != nil {
+		_ = d.Close()
+		t.Fatalf("raw set: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := col.Insert([]byte("u1"), []byte(`{"name":"ada"}`))
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			_ = d.Close()
+			t.Fatalf("insert: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("insert blocked while refreshing write-domain catalog after raw commit")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+}
+
 func TestCollectionSingleInsertMatchesSingleItemBatch(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -75,6 +75,9 @@ func TestCollectionManagerOpenCollectionCacheRejectsClosedDB(t *testing.T) {
 	if _, err := mgr.OpenCollection("users"); !errors.Is(err, backenddb.ErrClosed) {
 		t.Fatalf("OpenCollection after close err=%v want ErrClosed", err)
 	}
+	if _, err := mgr.OpenCollection(""); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("OpenCollection invalid name after close err=%v want ErrClosed", err)
+	}
 }
 
 func TestCollectionInsertBatchBridge_RoundTripWithSecondaryIndexes(t *testing.T) {
@@ -2350,6 +2353,11 @@ func TestOpenCollectionWriteDomainCatalogCacheUsesCommitSeq(t *testing.T) {
 	if cached == nil {
 		t.Fatal("expected populated write-domain catalog cache")
 	}
+	cachedRoot := cached.rootID(collectionPrimaryRootName("users"))
+	cached.roots[collectionPrimaryRootName("users")] = ^uint64(0)
+	if cachedAgain := cachedWriteDomainCatalogForState(domain, state.SystemRootPageID, state.CommitSeq); cachedAgain == nil || cachedAgain.rootID(collectionPrimaryRootName("users")) != cachedRoot {
+		t.Fatalf("write-domain catalog cache exposed mutable roots: got=%v want root %d", cachedAgain, cachedRoot)
+	}
 	if stale := cachedWriteDomainCatalogForState(domain, state.SystemRootPageID, state.CommitSeq+1); stale != nil {
 		t.Fatal("write-domain catalog cache ignored commit sequence")
 	}
@@ -2377,10 +2385,10 @@ func TestOpenCollectionWriteDomainCatalogCacheUsesCommitSeq(t *testing.T) {
 	if err != nil {
 		t.Fatalf("catalogForSnapshot: %v", err)
 	}
-	if reopenedCatalog == cached {
-		t.Fatal("OpenCollection reused stale write-domain catalog cache after commit sequence changed")
+	if got := reopenedCatalog.rootID(collectionPrimaryRootName("users")); got == ^uint64(0) {
+		t.Fatalf("OpenCollection reused mutated write-domain catalog roots: %d", got)
 	}
-	if fresh := cachedWriteDomainCatalogForState(domain, rawState.SystemRootPageID, rawState.CommitSeq); fresh != reopenedCatalog {
+	if fresh := cachedWriteDomainCatalogForState(domain, rawState.SystemRootPageID, rawState.CommitSeq); fresh == nil || fresh.rootID(collectionPrimaryRootName("users")) != reopenedCatalog.rootID(collectionPrimaryRootName("users")) {
 		t.Fatal("OpenCollection did not refresh write-domain catalog cache for new commit sequence")
 	}
 	if got, err := reopened.Get([]byte("u1")); err != nil || !bytes.Equal(got, []byte(`{"name":"ada"}`)) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2434,6 +2434,12 @@ func TestNoIndexInsertAfterRawCommitDoesNotReenterWriteDomainLock(t *testing.T) 
 			t.Fatalf("insert: %v", err)
 		}
 	case <-timer.C:
+		_ = d.Close()
+		select {
+		case err := <-done:
+			t.Fatalf("insert unblocked after timeout with err=%v", err)
+		case <-time.After(time.Second):
+		}
 		t.Fatal("insert blocked while refreshing write-domain catalog after raw commit")
 	}
 }

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -47,6 +47,28 @@ func TestCollectionGetNilDBReturnsError(t *testing.T) {
 	}
 }
 
+func TestCollectionManagerOpenCollectionCacheRejectsClosedDB(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if _, err := mgr.OpenCollection("users"); err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	if _, err := mgr.OpenCollection("users"); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("OpenCollection after close err=%v want ErrClosed", err)
+	}
+}
+
 func TestCollectionInsertBatchBridge_RoundTripWithSecondaryIndexes(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2400,21 +2400,28 @@ func TestNoIndexInsertAfterRawCommitDoesNotReenterWriteDomainLock(t *testing.T) 
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
+	defer func() { _ = d.Close() }()
 
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
-		_ = d.Close()
 		t.Fatalf("create collection: %v", err)
 	}
 	col, err := mgr.OpenCollection("users")
 	if err != nil {
-		_ = d.Close()
 		t.Fatalf("open collection: %v", err)
 	}
 	if err := d.Set([]byte("raw/unrelated"), []byte("value")); err != nil {
-		_ = d.Close()
 		t.Fatalf("raw set: %v", err)
 	}
+
+	timeout := 5 * time.Second
+	if deadline, ok := t.Deadline(); ok {
+		if remaining := time.Until(deadline) / 2; remaining > 0 && remaining < timeout {
+			timeout = remaining
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 
 	done := make(chan error, 1)
 	go func() {
@@ -2424,14 +2431,10 @@ func TestNoIndexInsertAfterRawCommitDoesNotReenterWriteDomainLock(t *testing.T) 
 	select {
 	case err := <-done:
 		if err != nil {
-			_ = d.Close()
 			t.Fatalf("insert: %v", err)
 		}
-	case <-time.After(time.Second):
+	case <-timer.C:
 		t.Fatal("insert blocked while refreshing write-domain catalog after raw commit")
-	}
-	if err := d.Close(); err != nil {
-		t.Fatalf("close db: %v", err)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2354,9 +2354,8 @@ func TestOpenCollectionWriteDomainCatalogCacheUsesCommitSeq(t *testing.T) {
 		t.Fatal("expected populated write-domain catalog cache")
 	}
 	cachedRoot := cached.rootID(collectionPrimaryRootName("users"))
-	cached.roots[collectionPrimaryRootName("users")] = ^uint64(0)
-	if cachedAgain := cachedWriteDomainCatalogForState(domain, state.SystemRootPageID, state.CommitSeq); cachedAgain == nil || cachedAgain.rootID(collectionPrimaryRootName("users")) != cachedRoot {
-		t.Fatalf("write-domain catalog cache exposed mutable roots: got=%v want root %d", cachedAgain, cachedRoot)
+	if cachedRoot == 0 {
+		t.Fatal("write-domain catalog cache did not include primary root")
 	}
 	if stale := cachedWriteDomainCatalogForState(domain, state.SystemRootPageID, state.CommitSeq+1); stale != nil {
 		t.Fatal("write-domain catalog cache ignored commit sequence")
@@ -2385,8 +2384,8 @@ func TestOpenCollectionWriteDomainCatalogCacheUsesCommitSeq(t *testing.T) {
 	if err != nil {
 		t.Fatalf("catalogForSnapshot: %v", err)
 	}
-	if got := reopenedCatalog.rootID(collectionPrimaryRootName("users")); got == ^uint64(0) {
-		t.Fatalf("OpenCollection reused mutated write-domain catalog roots: %d", got)
+	if got := reopenedCatalog.rootID(collectionPrimaryRootName("users")); got != cachedRoot {
+		t.Fatalf("OpenCollection refreshed root=%d want %d", got, cachedRoot)
 	}
 	if fresh := cachedWriteDomainCatalogForState(domain, rawState.SystemRootPageID, rawState.CommitSeq); fresh == nil || fresh.rootID(collectionPrimaryRootName("users")) != reopenedCatalog.rootID(collectionPrimaryRootName("users")) {
 		t.Fatal("OpenCollection did not refresh write-domain catalog cache for new commit sequence")

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2251,6 +2251,10 @@ func (db *DB) State() *DBState {
 	return db.state.Load()
 }
 
+func (db *DB) IsClosing() bool {
+	return db == nil || db.closing.Load()
+}
+
 func (db *DB) publishSnapshotView(idx *indexGen, state *DBState, vm *valuelog.Manager) {
 	if db == nil {
 		return

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2251,6 +2251,7 @@ func (db *DB) State() *DBState {
 	return db.state.Load()
 }
 
+// IsClosing reports whether the database is closing. It returns true if db is nil.
 func (db *DB) IsClosing() bool {
 	return db == nil || db.closing.Load()
 }


### PR DESCRIPTION
## Summary

- Cache collection catalogs in the shared collection write domain and let fresh `OpenCollection` handles reuse that cache when both the system root and commit sequence match.
- Teach `catalogForSnapshot` to fall back to the write-domain catalog before loading collection metadata from the system tree.
- Keep the gateway pattern of opening short-lived collection handles, rather than sharing one mutable `Collection` handle across connections.
- Add coverage for refreshing the write-domain catalog after a raw user-root commit advances commit seq without changing the system root.

## Why this shape

The profiling showed update traffic spending visible CPU in `loadCollectionCatalog` and `OpenCollection`. A server-global handle cache would risk sharing mutable `Collection` handle fields across concurrent gateway commands. This patch instead keeps handles cheap by caching the immutable catalog/root descriptor state in the existing write domain.

The cache key intentionally includes both `SystemRootPageID` and `CommitSeq`. A raw user-root commit does not change collection metadata, but it does advance the DB snapshot sequence; the code refreshes the write-domain catalog for that new sequence rather than reusing an entry across commit-seq drift.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run 'Test(OpenCollectionUsesWriteDomainCatalogCache|CollectionCachedCatalogUsesCommitSeq|CollectionReadSeesWriterCommitWithCachedCatalog)' -count=1`
- `GOWORK=off go test ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1`

## Benchmark evidence

Focused TreeDB BSON gateway run: 100k docs, 2 indexes, 8 insert producers, 8 concurrent update writers, 80k updates, no maintenance.

- Before this PR, based on PR #1111: `concurrent_id_update_set_w8` = `8,067 docs/sec`
- After this PR: `concurrent_id_update_set_w8` = `9,769 docs/sec`

Pprof evidence from the same run:

- Before: `loadCollectionCatalog` = `4.19s / 22.33%` cumulative in concurrent update CPU profile; `OpenCollection` = `2.13s / 11.35%`.
- After: neither `loadCollectionCatalog` nor `OpenCollection` appeared in the filtered concurrent update CPU top output.

Artifacts:

- Before: `/tmp/gomap_pr1_base_profile_T6ixkP`
- After: `/tmp/gomap_pr1_base_profile_beibdY`

## Stack

Stacked on PR #1111 (`codex/mongo-gateway-pprof-harness`).
