### PR TITLE
[codex] Add batched collection updates

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -45,10 +45,11 @@ var (
 	ErrUniqueIndexConflict = errors.New("collections: unique index conflict")
 	ErrConcurrentMutation  = errors.New("collections: concurrent mutation")
 
-	errCollectionManagerNil = errors.New("collections: collection manager is nil")
-	errCollectionNil        = errors.New("collections: collection is nil")
-	errCollectionDBNil      = errors.New("collections: db is nil")
-	errCollectionNotFound   = ErrCollectionNotFound
+	errCollectionManagerNil               = errors.New("collections: collection manager is nil")
+	errCollectionNil                      = errors.New("collections: collection is nil")
+	errCollectionDBNil                    = errors.New("collections: db is nil")
+	errCollectionNotFound                 = ErrCollectionNotFound
+	errUpdateBatchHasSecondaryUniqueIndex = errors.New("collections: update batch has secondary unique index")
 )
 
 // UpdateBatchItem describes one document update in a batch. DocumentID must be
@@ -2743,36 +2744,52 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 // rejected so callers that require same-document ordering can fall back to
 // sequential Update calls.
 func (c *Collection) UpdateBatch(items []UpdateBatchItem) ([]UpdateBatchResult, error) {
+	results, _, err := c.updateBatch(items, false)
+	return results, err
+}
+
+// UpdateBatchIfNoSecondaryUniqueIndexes applies UpdateBatch only when the
+// collection has no secondary unique indexes in the mutation-locked catalog.
+// It reports batched=false without applying updates if a unique secondary index
+// is present so callers can preserve ordered per-document update semantics.
+func (c *Collection) UpdateBatchIfNoSecondaryUniqueIndexes(items []UpdateBatchItem) ([]UpdateBatchResult, bool, error) {
+	return c.updateBatch(items, true)
+}
+
+func (c *Collection) updateBatch(items []UpdateBatchItem, requireNoSecondaryUniqueIndexes bool) ([]UpdateBatchResult, bool, error) {
 	if c == nil {
-		return nil, errCollectionNil
+		return nil, false, errCollectionNil
 	}
 	if c.db == nil {
-		return nil, errCollectionDBNil
+		return nil, false, errCollectionDBNil
 	}
 	if len(items) == 0 {
-		return nil, nil
+		return nil, true, nil
 	}
 	if err := validateUpdateBatchItems(items); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	items = cloneUpdateBatchItems(items)
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
 	if err := c.flushBufferedWrites(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var lastErr error
 	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
-		results, err := c.updateBatchOnce(items)
+		results, err := c.updateBatchOnce(items, requireNoSecondaryUniqueIndexes)
+		if errors.Is(err, errUpdateBatchHasSecondaryUniqueIndex) {
+			return nil, false, nil
+		}
 		if errors.Is(err, ErrConcurrentMutation) {
 			lastErr = err
 			waitBeforeCollectionMutationRetry(attempt)
 			continue
 		}
-		return results, err
+		return results, true, err
 	}
-	return nil, collectionMutationRetryExhausted(lastErr)
+	return nil, false, collectionMutationRetryExhausted(lastErr)
 }
 
 func validateUpdateBatchItems(items []UpdateBatchItem) error {
@@ -3075,7 +3092,7 @@ type preparedBatchUpdate struct {
 	indexStateChanged bool
 }
 
-func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResult, error) {
+func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondaryUniqueIndexes bool) ([]UpdateBatchResult, error) {
 	results := make([]UpdateBatchResult, len(items))
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
@@ -3091,6 +3108,10 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 		return nil, errCollectionNotFound
 	}
 	c.meta = catalog.meta
+	if requireNoSecondaryUniqueIndexes && collectionMetaHasSecondaryUniqueIndex(c.meta) {
+		_ = snap.Close()
+		return nil, errUpdateBatchHasSecondaryUniqueIndex
+	}
 	plannerOptions, err := collectionPlannerOptions(c.meta)
 	if err != nil {
 		_ = snap.Close()
@@ -4841,6 +4862,15 @@ func sameCollectionMeta(a, b CollectionMeta) bool {
 		return false
 	}
 	return reflect.DeepEqual(na, nb)
+}
+
+func collectionMetaHasSecondaryUniqueIndex(meta CollectionMeta) bool {
+	for _, idx := range meta.Indexes {
+		if idx.Unique {
+			return true
+		}
+	}
+	return false
 }
 
 func addIndexToCollectionMeta(meta CollectionMeta, def IndexDefinition) (CollectionMeta, IndexDefinition, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -50,6 +50,21 @@ var (
 	errCollectionNotFound   = ErrCollectionNotFound
 )
 
+// UpdateBatchItem describes one document update in a batch. DocumentID must be
+// non-empty and unique within the batch. Update receives the current stored
+// document bytes and returns the replacement document bytes in the same format
+// expected by Update.
+type UpdateBatchItem struct {
+	DocumentID []byte
+	Update     func(current []byte) (replacement []byte, changed bool, err error)
+}
+
+// UpdateBatchResult reports the outcome for one UpdateBatch item.
+type UpdateBatchResult struct {
+	Matched  bool
+	Modified bool
+}
+
 func IsDuplicateKeyError(err error) bool {
 	return errors.Is(err, ErrDocumentExists) ||
 		errors.Is(err, ErrDuplicateDocumentID) ||
@@ -2701,6 +2716,60 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 	return false, false, collectionMutationRetryExhausted(lastErr)
 }
 
+// UpdateBatch applies a unique set of document updates under one collection
+// mutation. Missing documents report Matched=false. Duplicate document IDs are
+// rejected so callers that require same-document ordering can fall back to
+// sequential Update calls.
+func (c *Collection) UpdateBatch(items []UpdateBatchItem) ([]UpdateBatchResult, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, errors.New("collections: db is nil")
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	if err := validateUpdateBatchItems(items); err != nil {
+		return nil, err
+	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation()
+	if err := c.flushBufferedWrites(); err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
+		results, err := c.updateBatchOnce(items)
+		if errors.Is(err, ErrConcurrentMutation) {
+			lastErr = err
+			waitBeforeCollectionMutationRetry(attempt)
+			continue
+		}
+		return results, err
+	}
+	return nil, collectionMutationRetryExhausted(lastErr)
+}
+
+func validateUpdateBatchItems(items []UpdateBatchItem) error {
+	seen := make(map[string]struct{}, len(items))
+	for i, item := range items {
+		if len(item.DocumentID) == 0 {
+			return errors.New("collections: document id cannot be empty")
+		}
+		if item.Update == nil {
+			return errors.New("collections: update function is nil")
+		}
+		key := string(item.DocumentID)
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("%w at index %d", ErrDuplicateDocumentID, i)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
 func waitBeforeCollectionMutationRetry(attempt int) {
 	if attempt < 4 {
 		runtime.Gosched()
@@ -2940,6 +3009,291 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	return true, true, nil
+}
+
+type preparedBatchUpdate struct {
+	itemIndex         int
+	documentID        []byte
+	document          []byte
+	oldState          documentIndexState
+	newState          documentIndexState
+	indexStateChanged bool
+}
+
+func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResult, error) {
+	results := make([]UpdateBatchResult, len(items))
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return nil, errCollectionNotFound
+	}
+	c.meta = catalog.meta
+	plannerOptions, err := collectionPlannerOptions(c.meta)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
+	baseUserRoot := snapshotUserRoot(snap)
+	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
+
+	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
+	if primaryRoot == 0 {
+		_ = snap.Close()
+		return results, nil
+	}
+	runtimes, err := (insertBatchPlanner{
+		collection: c.meta.Name,
+		indexes:    plannerIndexes(c.meta.Indexes),
+	}).indexRuntimes()
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+
+	changed := make([]preparedBatchUpdate, 0, len(items))
+	changedDocuments := make([][]byte, 0, len(items))
+	for i, item := range items {
+		entry, err := snap.GetEntryAtRoot(primaryRoot, item.DocumentID)
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			continue
+		}
+		if err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		results[i].Matched = true
+		document, changedOne, err := item.Update(bytes.Clone(entry.Value))
+		if err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		if !changedOne {
+			continue
+		}
+		prepared := preparedBatchUpdate{
+			itemIndex:  i,
+			documentID: bytes.Clone(item.DocumentID),
+		}
+		if len(runtimes) > 0 {
+			prepared.oldState, err = loadDeleteIndexState(snap, catalog, item.DocumentID, entry.Value, runtimes, plannerOptions)
+			if err != nil {
+				_ = snap.Close()
+				return nil, err
+			}
+		}
+		changed = append(changed, prepared)
+		changedDocuments = append(changedDocuments, document)
+	}
+	if len(changed) == 0 {
+		_ = snap.Close()
+		return results, nil
+	}
+
+	preparedDocuments, templateRecords, templateResolver, err := prepareInsertDocuments(changedDocuments, plannerOptions)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	if len(preparedDocuments) != len(changed) {
+		_ = snap.Close()
+		return nil, errors.New("collections: update batch prepared unexpected document count")
+	}
+	if templateResolver != nil {
+		plannerOptions.templateResolver = templateResolver
+	}
+	for i := range changed {
+		changed[i].document = preparedDocuments[i]
+		if len(runtimes) > 0 {
+			changed[i].newState, err = indexStateForDocument(changed[i].document, runtimes, plannerOptions)
+			if err != nil {
+				_ = snap.Close()
+				return nil, err
+			}
+			changed[i].indexStateChanged = !documentIndexStatesEqual(changed[i].oldState, changed[i].newState)
+			if changed[i].indexStateChanged {
+				if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, changed[i].newState, changed[i].documentID); err != nil {
+					_ = snap.Close()
+					return nil, err
+				}
+			}
+		}
+	}
+	if err := rejectBatchUniqueConflicts(runtimes, changed); err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+
+	rootNames := make([]string, 0, 2+len(runtimes))
+	baseRootIDs := make(map[string]uint64, 2+len(runtimes))
+	policies := make([]backenddb.OrderedRootStoragePolicy, 0, 2+len(runtimes))
+	deltaTables := make([]memtable.Table, 0, 2+len(runtimes))
+
+	if len(templateRecords) > 0 {
+		templatePlan := &insertBatchPlan{}
+		if err := (insertBatchPlanner{
+			collection:             c.meta.Name,
+			templateRoot:           collectionTemplateRootName(c.meta.Name),
+			options:                plannerOptions,
+			cloneTemplateRunValues: true,
+		}).emitTemplateRun(templatePlan, templateRecords); err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		for _, run := range templatePlan.runs {
+			rootNames = append(rootNames, run.name)
+			baseRootIDs[run.name] = catalog.rootID(run.name)
+			policies = append(policies, run.storagePolicy)
+			deltaTables = append(deltaTables, run.table)
+		}
+	}
+
+	primaryRootName := collectionPrimaryRootName(c.meta.Name)
+	rootNames = append(rootNames, primaryRootName)
+	baseRootIDs[primaryRootName] = primaryRoot
+	policies = append(policies, plannerOptions.dataStoragePolicy)
+	primaryTable := newCollectionRunTable(len(changed))
+	for _, item := range changed {
+		setCollectionRunValue(primaryTable, bytes.Clone(item.documentID), item.document)
+		results[item.itemIndex].Modified = true
+	}
+	primaryTable.Freeze()
+	deltaTables = append(deltaTables, primaryTable)
+
+	if len(runtimes) > 0 {
+		var stateTable memtable.Table
+		if persistIndexStateForOptions(plannerOptions) {
+			stateTable = newCollectionRunTable(len(changed))
+		}
+		secondaryTables := make(map[string]memtable.Table, len(runtimes))
+		for _, item := range changed {
+			if !item.indexStateChanged {
+				continue
+			}
+			if stateTable != nil {
+				rawState, err := encodeDocumentIndexState(item.newState)
+				if err != nil {
+					_ = snap.Close()
+					resetCollectionTables(append(deltaTables, stateTable))
+					return nil, err
+				}
+				if len(item.newState) == 0 {
+					stateTable.DeleteSteal(bytes.Clone(item.documentID))
+				} else {
+					stateTable.SetSteal(bytes.Clone(item.documentID), rawState)
+				}
+			}
+			for _, runtime := range runtimes {
+				rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
+				table := secondaryTables[rootName]
+				if table == nil {
+					table = newCollectionRunTable(0)
+					secondaryTables[rootName] = table
+				}
+				deleteKeys, err := secondaryDeleteKeysForDocument(runtime, item.oldState, item.documentID)
+				if err != nil {
+					_ = snap.Close()
+					resetCollectionTables(append(deltaTables, table))
+					return nil, err
+				}
+				for _, key := range deleteKeys {
+					table.DeleteSteal(bytes.Clone(key))
+				}
+				for _, encoded := range item.newState[runtime.def.name] {
+					key, err := indexEntryKey(encoded, item.documentID)
+					if err != nil {
+						_ = snap.Close()
+						resetCollectionTables(append(deltaTables, table))
+						return nil, err
+					}
+					table.SetSteal(key, nil)
+				}
+			}
+		}
+		if stateTable != nil && stateTable.Len() > 0 {
+			stateTable.Freeze()
+			stateRootName := collectionIndexStateRootName(c.meta.Name)
+			rootNames = append(rootNames, stateRootName)
+			baseRootIDs[stateRootName] = catalog.rootID(stateRootName)
+			policies = append(policies, plannerOptions.indexStateStoragePolicy)
+			deltaTables = append(deltaTables, stateTable)
+		}
+		for _, runtime := range runtimes {
+			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
+			table := secondaryTables[rootName]
+			if table == nil || table.Len() == 0 {
+				continue
+			}
+			table.Freeze()
+			rootNames = append(rootNames, rootName)
+			baseRootIDs[rootName] = catalog.rootID(rootName)
+			policies = append(policies, runtime.def.storagePolicy)
+			deltaTables = append(deltaTables, table)
+		}
+	}
+
+	defer func() { _ = snap.Close() }()
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	defer func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+		resetCollectionTables(deltaTables)
+	}()
+	for i, rootName := range rootNames {
+		iter := deltaTables[i].NewIterator(nil, nil)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot:      baseRootIDs[rootName],
+			Iter:          iter,
+			StoragePolicy: policies[i],
+		})
+	}
+	preflight := func() error {
+		return c.validateMutationRootDescriptors(baseUserRoot, baseSystemRoot, baseCommitSeq)
+	}
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(rootIDs) != len(rootNames) {
+		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+	}
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return results, nil
+}
+
+func rejectBatchUniqueConflicts(runtimes []indexRuntime, updates []preparedBatchUpdate) error {
+	for _, runtime := range runtimes {
+		if !runtime.def.unique {
+			continue
+		}
+		seen := make(map[string][]byte)
+		for _, update := range updates {
+			for _, encoded := range update.newState[runtime.def.name] {
+				key := string(encoded)
+				if previous, ok := seen[key]; ok && !bytes.Equal(previous, update.documentID) {
+					return fmt.Errorf("%w %q", ErrUniqueIndexConflict, runtime.def.name)
+				}
+				seen[key] = update.documentID
+			}
+		}
+	}
+	return nil
 }
 
 func (c *Collection) catalogForSnapshot(snap *backenddb.Snapshot) (*collectionCatalog, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3165,6 +3165,10 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 		if !changedOne {
 			continue
 		}
+		if len(document) == 0 {
+			_ = snap.Close()
+			return nil, fmt.Errorf("collections: update batch index %d: changed replacement document cannot be empty", i)
+		}
 		if err := validateBSONReplacementPreservesID(entry.Value, document, plannerOptions); err != nil {
 			_ = snap.Close()
 			return nil, fmt.Errorf("collections: update batch index %d: %w", i, err)
@@ -3188,10 +3192,16 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 		return results, nil
 	}
 
+	for i, document := range changedDocuments {
+		if _, _, _, err := prepareInsertDocuments([][]byte{document}, plannerOptions); err != nil {
+			_ = snap.Close()
+			return nil, fmt.Errorf("collections: update batch index %d: %w", changed[i].itemIndex, err)
+		}
+	}
 	preparedDocuments, templateRecords, templateResolver, err := prepareInsertDocuments(changedDocuments, plannerOptions)
 	if err != nil {
 		_ = snap.Close()
-		return nil, err
+		return nil, fmt.Errorf("collections: update batch replacement prepare: %w", err)
 	}
 	if len(preparedDocuments) != len(changed) {
 		_ = snap.Close()

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3136,7 +3136,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 		}
 		prepared := preparedBatchUpdate{
 			itemIndex:  i,
-			documentID: bytes.Clone(item.DocumentID),
+			documentID: item.DocumentID,
 		}
 		if len(runtimes) > 0 {
 			prepared.oldState, err = loadDeleteIndexState(snap, catalog, item.DocumentID, entry.Value, runtimes, plannerOptions)
@@ -3339,18 +3339,23 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 }
 
 func rejectBatchUniqueConflicts(runtimes []indexRuntime, updates []preparedBatchUpdate) error {
+	type seenUniqueValue struct {
+		documentID []byte
+		itemIndex  int
+	}
+
 	for _, runtime := range runtimes {
 		if !runtime.def.unique {
 			continue
 		}
-		seen := make(map[string][]byte)
+		seen := make(map[string]seenUniqueValue)
 		for _, update := range updates {
 			for _, encoded := range update.newState[runtime.def.name] {
 				key := string(encoded)
-				if previous, ok := seen[key]; ok && !bytes.Equal(previous, update.documentID) {
-					return fmt.Errorf("%w %q", ErrUniqueIndexConflict, runtime.def.name)
+				if previous, ok := seen[key]; ok && !bytes.Equal(previous.documentID, update.documentID) {
+					return fmt.Errorf("%w %q: batch indexes %d and %d document ids %q and %q", ErrUniqueIndexConflict, runtime.def.name, previous.itemIndex, update.itemIndex, previous.documentID, update.documentID)
 				}
-				seen[key] = update.documentID
+				seen[key] = seenUniqueValue{documentID: update.documentID, itemIndex: update.itemIndex}
 			}
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2781,7 +2781,8 @@ func (c *Collection) UpdateBatch(items []UpdateBatchItem) ([]UpdateBatchResult, 
 // UpdateBatchIfNoSecondaryUniqueIndexes applies UpdateBatch only when the
 // collection has no secondary unique indexes in the mutation-locked catalog.
 // It reports batched=false without applying updates if a unique secondary index
-// is present so callers can preserve ordered per-document update semantics.
+// is present so callers can preserve ordered per-document update semantics. When
+// batched=false and err=nil, the returned results are zero-valued with len(items).
 func (c *Collection) UpdateBatchIfNoSecondaryUniqueIndexes(items []UpdateBatchItem) ([]UpdateBatchResult, bool, error) {
 	return c.updateBatch(items, true)
 }
@@ -2810,7 +2811,7 @@ func (c *Collection) updateBatch(items []UpdateBatchItem, requireNoSecondaryUniq
 	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
 		results, err := c.updateBatchOnce(items, requireNoSecondaryUniqueIndexes)
 		if errors.Is(err, errUpdateBatchHasSecondaryUniqueIndex) {
-			return nil, false, nil
+			return make([]UpdateBatchResult, len(items)), false, nil
 		}
 		if errors.Is(err, ErrConcurrentMutation) {
 			lastErr = err
@@ -3220,14 +3221,14 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 		return results, nil
 	}
 
-	for i, document := range changedDocuments {
-		if _, _, _, err := prepareInsertDocuments([][]byte{document}, plannerOptions); err != nil {
-			_ = snap.Close()
-			return nil, updateBatchItemError(changed[i].itemIndex, err)
-		}
-	}
 	preparedDocuments, templateRecords, templateResolver, err := prepareInsertDocuments(changedDocuments, plannerOptions)
 	if err != nil {
+		for i, document := range changedDocuments {
+			if _, _, _, itemErr := prepareInsertDocuments([][]byte{document}, plannerOptions); itemErr != nil {
+				_ = snap.Close()
+				return nil, updateBatchItemError(changed[i].itemIndex, itemErr)
+			}
+		}
 		_ = snap.Close()
 		return nil, fmt.Errorf("collections: update batch replacement prepare: %w", err)
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2765,16 +2765,39 @@ func validateUpdateBatchItems(items []UpdateBatchItem) error {
 	seen := make(map[string]struct{}, len(items))
 	for i, item := range items {
 		if len(item.DocumentID) == 0 {
-			return errors.New("collections: document id cannot be empty")
+			return fmt.Errorf("collections: document id cannot be empty at index %d", i)
 		}
 		if item.Update == nil {
-			return errors.New("collections: update function is nil")
+			return fmt.Errorf("collections: update function is nil at index %d", i)
 		}
 		key := string(item.DocumentID)
 		if _, ok := seen[key]; ok {
 			return fmt.Errorf("%w at index %d", ErrDuplicateDocumentID, i)
 		}
 		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+func validateBSONReplacementPreservesID(current, replacement []byte, opts collectionOptions) error {
+	if normalizedDocumentFormat(opts.documentFormat) != DocumentFormatBSON {
+		return nil
+	}
+	currentRaw := bson.Raw(current)
+	if err := currentRaw.Validate(); err != nil {
+		return fmt.Errorf("collections: current BSON document: %w", err)
+	}
+	replacementRaw := bson.Raw(replacement)
+	if err := replacementRaw.Validate(); err != nil {
+		return fmt.Errorf("collections: replacement BSON document: %w", err)
+	}
+	currentID := currentRaw.Lookup("_id")
+	replacementID := replacementRaw.Lookup("_id")
+	if currentID.IsZero() && replacementID.IsZero() {
+		return nil
+	}
+	if currentID.IsZero() || replacementID.IsZero() || !currentID.Equal(replacementID) {
+		return errors.New("collections: update replacement cannot modify _id")
 	}
 	return nil
 }
@@ -3086,6 +3109,10 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 			_ = snap.Close()
 			return nil, err
 		}
+		if err := validateBSONReplacementPreservesID(entry.Value, document, plannerOptions); err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
 		if !changedOne {
 			continue
 		}
@@ -3101,7 +3128,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 			}
 		}
 		changed = append(changed, prepared)
-		changedDocuments = append(changedDocuments, document)
+		changedDocuments = append(changedDocuments, bytes.Clone(document))
 	}
 	if len(changed) == 0 {
 		_ = snap.Close()

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2742,7 +2742,7 @@ func (c *Collection) UpdateBatch(items []UpdateBatchItem) ([]UpdateBatchResult, 
 		return nil, errCollectionNil
 	}
 	if c.db == nil {
-		return nil, errors.New("collections: db is nil")
+		return nil, errCollectionDBNil
 	}
 	if len(items) == 0 {
 		return nil, nil
@@ -2750,6 +2750,7 @@ func (c *Collection) UpdateBatch(items []UpdateBatchItem) ([]UpdateBatchResult, 
 	if err := validateUpdateBatchItems(items); err != nil {
 		return nil, err
 	}
+	items = cloneUpdateBatchItems(items)
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
 	if err := c.flushBufferedWrites(); err != nil {
@@ -2785,6 +2786,15 @@ func validateUpdateBatchItems(items []UpdateBatchItem) error {
 		seen[key] = struct{}{}
 	}
 	return nil
+}
+
+func cloneUpdateBatchItems(items []UpdateBatchItem) []UpdateBatchItem {
+	out := make([]UpdateBatchItem, len(items))
+	for i, item := range items {
+		out[i] = item
+		out[i].DocumentID = bytes.Clone(item.DocumentID)
+	}
+	return out
 }
 
 func validateBSONReplacementPreservesID(current, replacement []byte, opts collectionOptions) error {
@@ -3109,20 +3119,20 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 		}
 		if err != nil {
 			_ = snap.Close()
-			return nil, err
+			return nil, fmt.Errorf("collections: update batch index %d: %w", i, err)
 		}
 		results[i].Matched = true
 		document, changedOne, err := item.Update(bytes.Clone(entry.Value))
 		if err != nil {
 			_ = snap.Close()
-			return nil, err
+			return nil, fmt.Errorf("collections: update batch index %d: %w", i, err)
 		}
 		if !changedOne {
 			continue
 		}
 		if err := validateBSONReplacementPreservesID(entry.Value, document, plannerOptions); err != nil {
 			_ = snap.Close()
-			return nil, err
+			return nil, fmt.Errorf("collections: update batch index %d: %w", i, err)
 		}
 		prepared := preparedBatchUpdate{
 			itemIndex:  i,
@@ -3132,7 +3142,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 			prepared.oldState, err = loadDeleteIndexState(snap, catalog, item.DocumentID, entry.Value, runtimes, plannerOptions)
 			if err != nil {
 				_ = snap.Close()
-				return nil, err
+				return nil, fmt.Errorf("collections: update batch index %d: %w", i, err)
 			}
 		}
 		changed = append(changed, prepared)
@@ -3161,7 +3171,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 			changed[i].newState, err = indexStateForDocument(changed[i].document, runtimes, plannerOptions)
 			if err != nil {
 				_ = snap.Close()
-				return nil, err
+				return nil, fmt.Errorf("collections: update batch index %d: %w", changed[i].itemIndex, err)
 			}
 			changed[i].indexStateChanged = !documentIndexStatesEqual(changed[i].oldState, changed[i].newState)
 		}
@@ -3171,7 +3181,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 		if changed[i].indexStateChanged {
 			if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, changed[i].newState, changed[i].documentID, batchReplacements); err != nil {
 				_ = snap.Close()
-				return nil, err
+				return nil, fmt.Errorf("collections: update batch index %d: %w", changed[i].itemIndex, err)
 			}
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2879,7 +2879,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		}
 		indexStateChanged = !documentIndexStatesEqual(oldState, newState)
 		if indexStateChanged {
-			if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, newState, documentID); err != nil {
+			if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, newState, documentID, nil); err != nil {
 				_ = snap.Close()
 				return false, false, err
 			}
@@ -3123,11 +3123,14 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 				return nil, err
 			}
 			changed[i].indexStateChanged = !documentIndexStatesEqual(changed[i].oldState, changed[i].newState)
-			if changed[i].indexStateChanged {
-				if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, changed[i].newState, changed[i].documentID); err != nil {
-					_ = snap.Close()
-					return nil, err
-				}
+		}
+	}
+	batchReplacements := batchUniqueReplacementOwners(runtimes, changed)
+	for i := range changed {
+		if changed[i].indexStateChanged {
+			if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, changed[i].newState, changed[i].documentID, batchReplacements); err != nil {
+				_ = snap.Close()
+				return nil, err
 			}
 		}
 	}
@@ -3140,6 +3143,19 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 	baseRootIDs := make(map[string]uint64, 2+len(runtimes))
 	policies := make([]backenddb.OrderedRootStoragePolicy, 0, 2+len(runtimes))
 	deltaTables := make([]memtable.Table, 0, 2+len(runtimes))
+	var stateTable memtable.Table
+	secondaryTables := make(map[string]memtable.Table, len(runtimes))
+	var iterators []iterator.UnsafeIterator
+	defer func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+		resetCollectionTables(deltaTables)
+		resetCollectionRunTable(stateTable)
+		for _, table := range secondaryTables {
+			resetCollectionRunTable(table)
+		}
+	}()
 
 	if len(templateRecords) > 0 {
 		templatePlan := &insertBatchPlan{}
@@ -3173,11 +3189,9 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 	deltaTables = append(deltaTables, primaryTable)
 
 	if len(runtimes) > 0 {
-		var stateTable memtable.Table
 		if persistIndexStateForOptions(plannerOptions) {
 			stateTable = newCollectionRunTable(len(changed))
 		}
-		secondaryTables := make(map[string]memtable.Table, len(runtimes))
 		for _, item := range changed {
 			if !item.indexStateChanged {
 				continue
@@ -3186,7 +3200,6 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 				rawState, err := encodeDocumentIndexState(item.newState)
 				if err != nil {
 					_ = snap.Close()
-					resetCollectionTables(append(deltaTables, stateTable))
 					return nil, err
 				}
 				if len(item.newState) == 0 {
@@ -3205,7 +3218,6 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 				deleteKeys, err := secondaryDeleteKeysForDocument(runtime, item.oldState, item.documentID)
 				if err != nil {
 					_ = snap.Close()
-					resetCollectionTables(append(deltaTables, table))
 					return nil, err
 				}
 				for _, key := range deleteKeys {
@@ -3215,7 +3227,6 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 					key, err := indexEntryKey(encoded, item.documentID)
 					if err != nil {
 						_ = snap.Close()
-						resetCollectionTables(append(deltaTables, table))
 						return nil, err
 					}
 					table.SetSteal(key, nil)
@@ -3229,6 +3240,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 			baseRootIDs[stateRootName] = catalog.rootID(stateRootName)
 			policies = append(policies, plannerOptions.indexStateStoragePolicy)
 			deltaTables = append(deltaTables, stateTable)
+			stateTable = nil
 		}
 		for _, runtime := range runtimes {
 			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
@@ -3241,18 +3253,13 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 			baseRootIDs[rootName] = catalog.rootID(rootName)
 			policies = append(policies, runtime.def.storagePolicy)
 			deltaTables = append(deltaTables, table)
+			delete(secondaryTables, rootName)
 		}
 	}
 
 	defer func() { _ = snap.Close() }()
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
-	defer func() {
-		for _, it := range iterators {
-			_ = it.Close()
-		}
-		resetCollectionTables(deltaTables)
-	}()
+	iterators = make([]iterator.UnsafeIterator, 0, len(rootNames))
 	for i, rootName := range rootNames {
 		iter := deltaTables[i].NewIterator(nil, nil)
 		iterators = append(iterators, iter)
@@ -3297,6 +3304,73 @@ func rejectBatchUniqueConflicts(runtimes []indexRuntime, updates []preparedBatch
 		}
 	}
 	return nil
+}
+
+type batchUniqueReplacementSet map[string]map[string]map[string]struct{}
+
+func batchUniqueReplacementOwners(runtimes []indexRuntime, updates []preparedBatchUpdate) batchUniqueReplacementSet {
+	if len(runtimes) == 0 || len(updates) == 0 {
+		return nil
+	}
+	out := make(batchUniqueReplacementSet)
+	for _, runtime := range runtimes {
+		if !runtime.def.unique {
+			continue
+		}
+		indexName := runtime.def.name
+		for _, update := range updates {
+			oldValues := update.oldState[indexName]
+			if len(oldValues) == 0 {
+				continue
+			}
+			newValues := update.newState[indexName]
+			for _, oldValue := range oldValues {
+				if documentIndexStateContainsValue(newValues, oldValue) {
+					continue
+				}
+				byValue := out[indexName]
+				if byValue == nil {
+					byValue = make(map[string]map[string]struct{})
+					out[indexName] = byValue
+				}
+				owners := byValue[string(oldValue)]
+				if owners == nil {
+					owners = make(map[string]struct{})
+					byValue[string(oldValue)] = owners
+				}
+				owners[string(update.documentID)] = struct{}{}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func documentIndexStateContainsValue(values [][]byte, target []byte) bool {
+	for _, value := range values {
+		if bytes.Equal(value, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s batchUniqueReplacementSet) allows(indexName string, encoded, documentID []byte) bool {
+	if len(s) == 0 {
+		return false
+	}
+	byValue := s[indexName]
+	if len(byValue) == 0 {
+		return false
+	}
+	owners := byValue[string(encoded)]
+	if len(owners) == 0 {
+		return false
+	}
+	_, ok := owners[string(documentID)]
+	return ok
 }
 
 func (c *Collection) catalogForSnapshot(snap *backenddb.Snapshot) (*collectionCatalog, error) {
@@ -3834,7 +3908,7 @@ func secondaryDeleteKeysForDocument(runtime indexRuntime, state documentIndexSta
 	return out, nil
 }
 
-func rejectReplaceUniqueConflicts(snap *backenddb.Snapshot, catalog *collectionCatalog, runtimes []indexRuntime, state documentIndexState, documentID []byte) error {
+func rejectReplaceUniqueConflicts(snap *backenddb.Snapshot, catalog *collectionCatalog, runtimes []indexRuntime, state documentIndexState, documentID []byte, batchReplacements batchUniqueReplacementSet) error {
 	if snap == nil || catalog == nil {
 		return nil
 	}
@@ -3864,7 +3938,8 @@ func rejectReplaceUniqueConflicts(snap *backenddb.Snapshot, catalog *collectionC
 				if !bytes.HasPrefix(key, prefix) {
 					break
 				}
-				if !it.IsDeleted() && !bytes.Equal(key[len(prefix):], documentID) {
+				ownerID := key[len(prefix):]
+				if !it.IsDeleted() && !bytes.Equal(ownerID, documentID) && !batchReplacements.allows(runtime.def.name, encoded, ownerID) {
 					conflict = true
 					break
 				}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -69,6 +69,27 @@ type UpdateBatchResult struct {
 	Modified bool
 }
 
+// UpdateBatchItemError wraps an error produced while preparing or applying one
+// item in an UpdateBatch call.
+type UpdateBatchItemError struct {
+	Index int
+	Err   error
+}
+
+func (e *UpdateBatchItemError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("collections: update batch index %d: %v", e.Index, e.Err)
+}
+
+func (e *UpdateBatchItemError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
 func IsDuplicateKeyError(err error) bool {
 	return errors.Is(err, ErrDocumentExists) ||
 		errors.Is(err, ErrDuplicateDocumentID) ||
@@ -2819,6 +2840,13 @@ func validateUpdateBatchItems(items []UpdateBatchItem) error {
 	return nil
 }
 
+func updateBatchItemError(index int, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &UpdateBatchItemError{Index: index, Err: err}
+}
+
 func cloneUpdateBatchItems(items []UpdateBatchItem) []UpdateBatchItem {
 	out := make([]UpdateBatchItem, len(items))
 	for i, item := range items {
@@ -3154,24 +3182,24 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 		}
 		if err != nil {
 			_ = snap.Close()
-			return nil, fmt.Errorf("collections: update batch index %d: %w", i, err)
+			return nil, updateBatchItemError(i, err)
 		}
 		results[i].Matched = true
 		document, changedOne, err := item.Update(bytes.Clone(entry.Value))
 		if err != nil {
 			_ = snap.Close()
-			return nil, fmt.Errorf("collections: update batch index %d: %w", i, err)
+			return nil, updateBatchItemError(i, err)
 		}
 		if !changedOne {
 			continue
 		}
 		if len(document) == 0 {
 			_ = snap.Close()
-			return nil, fmt.Errorf("collections: update batch index %d: changed replacement document cannot be empty", i)
+			return nil, updateBatchItemError(i, errors.New("changed replacement document cannot be empty"))
 		}
 		if err := validateBSONReplacementPreservesID(entry.Value, document, plannerOptions); err != nil {
 			_ = snap.Close()
-			return nil, fmt.Errorf("collections: update batch index %d: %w", i, err)
+			return nil, updateBatchItemError(i, err)
 		}
 		prepared := preparedBatchUpdate{
 			itemIndex:  i,
@@ -3181,7 +3209,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 			prepared.oldState, err = loadDeleteIndexState(snap, catalog, item.DocumentID, entry.Value, runtimes, plannerOptions)
 			if err != nil {
 				_ = snap.Close()
-				return nil, fmt.Errorf("collections: update batch index %d: %w", i, err)
+				return nil, updateBatchItemError(i, err)
 			}
 		}
 		changed = append(changed, prepared)
@@ -3195,7 +3223,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 	for i, document := range changedDocuments {
 		if _, _, _, err := prepareInsertDocuments([][]byte{document}, plannerOptions); err != nil {
 			_ = snap.Close()
-			return nil, fmt.Errorf("collections: update batch index %d: %w", changed[i].itemIndex, err)
+			return nil, updateBatchItemError(changed[i].itemIndex, err)
 		}
 	}
 	preparedDocuments, templateRecords, templateResolver, err := prepareInsertDocuments(changedDocuments, plannerOptions)
@@ -3216,7 +3244,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 			changed[i].newState, err = indexStateForDocument(changed[i].document, runtimes, plannerOptions)
 			if err != nil {
 				_ = snap.Close()
-				return nil, fmt.Errorf("collections: update batch index %d: %w", changed[i].itemIndex, err)
+				return nil, updateBatchItemError(changed[i].itemIndex, err)
 			}
 			changed[i].indexStateChanged = !documentIndexStatesEqual(changed[i].oldState, changed[i].newState)
 		}
@@ -3226,7 +3254,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 		if changed[i].indexStateChanged {
 			if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, changed[i].newState, changed[i].documentID, batchReplacements); err != nil {
 				_ = snap.Close()
-				return nil, fmt.Errorf("collections: update batch index %d: %w", changed[i].itemIndex, err)
+				return nil, updateBatchItemError(changed[i].itemIndex, err)
 			}
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -54,7 +54,9 @@ var (
 // UpdateBatchItem describes one document update in a batch. DocumentID must be
 // non-empty and unique within the batch. Update receives the current stored
 // document bytes and returns the replacement document bytes in the same format
-// expected by Update.
+// expected by Update. If Update returns changed=true, replacement must be a
+// complete valid stored document for the collection format; returning
+// replacement=nil, changed=false is the supported no-op form.
 type UpdateBatchItem struct {
 	DocumentID []byte
 	Update     func(current []byte) (replacement []byte, changed bool, err error)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3109,12 +3109,12 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 			_ = snap.Close()
 			return nil, err
 		}
+		if !changedOne {
+			continue
+		}
 		if err := validateBSONReplacementPreservesID(entry.Value, document, plannerOptions); err != nil {
 			_ = snap.Close()
 			return nil, err
-		}
-		if !changedOne {
-			continue
 		}
 		prepared := preparedBatchUpdate{
 			itemIndex:  i,

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2479,6 +2479,50 @@ func TestCollectionUpdateBatchRejectsUniqueConflictsWithinBatch(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBatchAllowsUniqueHandoff(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.CreateIndex(IndexDefinition{Name: "email", Field: "email", Unique: true}); err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"email":"a@example.com"}`), []byte(`{"email":"b@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	results, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONEmail("c@example.com")},
+		{DocumentID: []byte("u2"), Update: setJSONEmail("a@example.com")},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 2 || !results[0].Modified || !results[1].Modified {
+		t.Fatalf("results=%+v want both modified", results)
+	}
+	got, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"email":"a@example.com"`)) {
+		t.Fatalf("u2 document=%s want handed-off email", got)
+	}
+}
+
 func incrementJSONCount(current []byte) ([]byte, bool, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(current, &doc); err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2488,6 +2488,39 @@ func TestCollectionUpdateBatchValidationErrorsIncludeIndex(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBatchRejectsEmptyChangedReplacementWithIndex(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"count":0}`), []byte(`{"count":0}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	_, err = col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: incrementJSONCount},
+		{DocumentID: []byte("u2"), Update: func([]byte) ([]byte, bool, error) {
+			return nil, true, nil
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "update batch index 1") || !strings.Contains(err.Error(), "cannot be empty") {
+		t.Fatalf("UpdateBatch err=%v want index 1 empty replacement", err)
+	}
+}
+
 func TestCollectionUpdateBatchRejectsUniqueConflictsWithinBatch(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2352,6 +2352,153 @@ func TestOpenCollectionUsesWriteDomainCatalogCache(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBatchUpdatesMultipleDocuments(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"name":"ada","count":0}`), []byte(`{"name":"grace","count":0}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	before := d.State()
+	results, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: incrementJSONCount},
+		{DocumentID: []byte("u2"), Update: incrementJSONCount},
+		{DocumentID: []byte("missing"), Update: incrementJSONCount},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results=%d want 3", len(results))
+	}
+	if !results[0].Matched || !results[0].Modified || !results[1].Matched || !results[1].Modified {
+		t.Fatalf("unexpected matched/modified results: %+v", results)
+	}
+	if results[2].Matched || results[2].Modified {
+		t.Fatalf("missing document result matched/modified: %+v", results[2])
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("CommitSeq after batch=%d want %d", after.CommitSeq, before.CommitSeq+1)
+	}
+	for _, id := range []string{"u1", "u2"} {
+		got, err := col.Get([]byte(id))
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if !bytes.Contains(got, []byte(`"count":1`)) {
+			t.Fatalf("%s document=%s want count 1", id, got)
+		}
+	}
+}
+
+func TestCollectionUpdateBatchRejectsDuplicateIDs(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	_, err = (&Collection{db: d}).UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: incrementJSONCount},
+		{DocumentID: []byte("u1"), Update: incrementJSONCount},
+	})
+	if !errors.Is(err, ErrDuplicateDocumentID) {
+		t.Fatalf("UpdateBatch err=%v want ErrDuplicateDocumentID", err)
+	}
+}
+
+func TestCollectionUpdateBatchRejectsUniqueConflictsWithinBatch(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.CreateIndex(IndexDefinition{Name: "email", Field: "email", Unique: true}); err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"email":"a@example.com"}`), []byte(`{"email":"b@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	_, err = col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONEmail("same@example.com")},
+		{DocumentID: []byte("u2"), Update: setJSONEmail("same@example.com")},
+	})
+	if !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("UpdateBatch err=%v want ErrUniqueIndexConflict", err)
+	}
+}
+
+func incrementJSONCount(current []byte) ([]byte, bool, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(current, &doc); err != nil {
+		return nil, false, err
+	}
+	count, _ := int64ValueForTest(doc["count"])
+	doc["count"] = count + 1
+	next, err := json.Marshal(doc)
+	if err != nil {
+		return nil, false, err
+	}
+	return next, true, nil
+}
+
+func setJSONEmail(email string) func([]byte) ([]byte, bool, error) {
+	return func(current []byte) ([]byte, bool, error) {
+		var doc map[string]any
+		if err := json.Unmarshal(current, &doc); err != nil {
+			return nil, false, err
+		}
+		doc["email"] = email
+		next, err := json.Marshal(doc)
+		if err != nil {
+			return nil, false, err
+		}
+		return next, true, nil
+	}
+}
+
+func int64ValueForTest(value any) (int64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return int64(v), true
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	default:
+		return 0, false
+	}
+}
+
 func TestCollectionSingleInsertMatchesSingleItemBatch(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2523,6 +2523,92 @@ func TestCollectionUpdateBatchAllowsUniqueHandoff(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBatchTemplateV1MaterializesUpdatedDocuments(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatTemplateV1,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			mustTemplateV1Document(t, []string{"name", "city", "score"}, []any{"ada", "hnl", int64(0)}),
+			mustTemplateV1Document(t, []string{"name", "city", "score"}, []any{"grace", "hnl", int64(0)}),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	setScore := func(score int64, city string) func([]byte) ([]byte, bool, error) {
+		return func([]byte) ([]byte, bool, error) {
+			next, err := EncodeTemplateV1DocumentJSON([]byte(fmt.Sprintf(`{"name":"updated","city":%q,"score":%d}`, city, score)))
+			if err != nil {
+				return nil, false, err
+			}
+			return next, true, nil
+		}
+	}
+	results, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setScore(11, "sea")},
+		{DocumentID: []byte("u2"), Update: setScore(12, "sfo")},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 2 || !results[0].Modified || !results[1].Modified {
+		t.Fatalf("results=%+v want both modified", results)
+	}
+	for _, tc := range []struct {
+		id    []byte
+		score int64
+		city  string
+	}{
+		{id: []byte("u1"), score: 11, city: "sea"},
+		{id: []byte("u2"), score: 12, city: "sfo"},
+	} {
+		stored, err := col.Get(tc.id)
+		if err != nil {
+			t.Fatalf("get %s: %v", tc.id, err)
+		}
+		jsonDoc, err := col.StoredDocumentJSON(stored)
+		if err != nil {
+			t.Fatalf("materialize %s: %v", tc.id, err)
+		}
+		var doc map[string]any
+		if err := json.Unmarshal(jsonDoc, &doc); err != nil {
+			t.Fatalf("unmarshal %s: %v", tc.id, err)
+		}
+		if got, _ := int64ValueForTest(doc["score"]); got != tc.score {
+			t.Fatalf("%s score=%d want %d", tc.id, got, tc.score)
+		}
+		if got, _ := doc["city"].(string); got != tc.city {
+			t.Fatalf("%s city=%q want %q", tc.id, got, tc.city)
+		}
+	}
+	ids, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find city index: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("city index ids=%q want [u1]", ids)
+	}
+}
+
 func incrementJSONCount(current []byte) ([]byte, bool, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(current, &doc); err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2639,6 +2639,51 @@ func TestCollectionUpdateBatchBSONRejectsIDMutation(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBatchBSONAllowsNoopNilReplacement(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Options: CollectionOptions{DocumentFormat: DocumentFormatBSON},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	doc := mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(0)}})
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{doc}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	results, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: func([]byte) ([]byte, bool, error) {
+			return nil, false, nil
+		}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatch noop: %v", err)
+	}
+	if got, want := len(results), 1; got != want {
+		t.Fatalf("results len=%d want %d", got, want)
+	}
+	if !results[0].Matched || results[0].Modified {
+		t.Fatalf("result=%+v want matched noop", results[0])
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got, doc) {
+		t.Fatalf("document changed got=%v want=%v", bson.Raw(got), bson.Raw(doc))
+	}
+}
+
 func TestCollectionUpdateBatchTemplateV1MaterializesUpdatedDocuments(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2645,6 +2645,9 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexesDeclinesFreshUniqueCatal
 	if batched {
 		t.Fatalf("batched=%v results=%+v want declined", batched, results)
 	}
+	if len(results) != 2 || results[0].Matched || results[0].Modified || results[1].Matched || results[1].Modified {
+		t.Fatalf("declined results=%+v want two zero-valued results", results)
+	}
 	got, err := stale.Get([]byte("u1"))
 	if err != nil {
 		t.Fatalf("get u1: %v", err)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -16,6 +16,7 @@ import (
 	treedb "github.com/snissn/gomap/TreeDB"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func TestCollectionErrorsAreClassifiable(t *testing.T) {
@@ -2453,6 +2454,23 @@ func TestCollectionUpdateBatchRejectsDuplicateIDs(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBatchValidationErrorsIncludeIndex(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	_, err = (&Collection{db: d}).UpdateBatch([]UpdateBatchItem{{Update: incrementJSONCount}})
+	if err == nil || !strings.Contains(err.Error(), "index 0") {
+		t.Fatalf("empty id err=%v want index 0", err)
+	}
+	_, err = (&Collection{db: d}).UpdateBatch([]UpdateBatchItem{{DocumentID: []byte("u1")}})
+	if err == nil || !strings.Contains(err.Error(), "index 0") {
+		t.Fatalf("nil update err=%v want index 0", err)
+	}
+}
+
 func TestCollectionUpdateBatchRejectsUniqueConflictsWithinBatch(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -2528,6 +2546,90 @@ func TestCollectionUpdateBatchAllowsUniqueHandoff(t *testing.T) {
 	}
 	if !bytes.Contains(got, []byte(`"email":"a@example.com"`)) {
 		t.Fatalf("u2 document=%s want handed-off email", got)
+	}
+}
+
+func TestCollectionUpdateBatchClonesAliasedReplacements(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"score":0}`), []byte(`{"score":0}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	scratch := make([]byte, 0, 32)
+	setScore := func(score int) func([]byte) ([]byte, bool, error) {
+		return func([]byte) ([]byte, bool, error) {
+			scratch = append(scratch[:0], fmt.Sprintf(`{"score":%d}`, score)...)
+			return scratch, true, nil
+		}
+	}
+	if _, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setScore(1)},
+		{DocumentID: []byte("u2"), Update: setScore(2)},
+	}); err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	for _, tc := range []struct {
+		id    []byte
+		score string
+	}{
+		{id: []byte("u1"), score: `"score":1`},
+		{id: []byte("u2"), score: `"score":2`},
+	} {
+		got, err := col.Get(tc.id)
+		if err != nil {
+			t.Fatalf("get %s: %v", tc.id, err)
+		}
+		if !bytes.Contains(got, []byte(tc.score)) {
+			t.Fatalf("%s document=%s want %s", tc.id, got, tc.score)
+		}
+	}
+}
+
+func TestCollectionUpdateBatchBSONRejectsIDMutation(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Options: CollectionOptions{DocumentFormat: DocumentFormatBSON},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	doc := mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(0)}})
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{doc}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	replacement := mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "score", Value: int32(1)}})
+	_, err = col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: func([]byte) ([]byte, bool, error) {
+			return replacement, true, nil
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot modify _id") {
+		t.Fatalf("UpdateBatch err=%v want _id mutation error", err)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2520,6 +2520,9 @@ func TestCollectionUpdateBatchRejectsUniqueConflictsWithinBatch(t *testing.T) {
 	if !errors.Is(err, ErrUniqueIndexConflict) {
 		t.Fatalf("UpdateBatch err=%v want ErrUniqueIndexConflict", err)
 	}
+	if !strings.Contains(err.Error(), "batch indexes 0 and 1") {
+		t.Fatalf("UpdateBatch err=%v missing conflicting batch indexes", err)
+	}
 }
 
 func TestCollectionUpdateBatchAllowsUniqueHandoff(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2569,6 +2569,54 @@ func TestCollectionUpdateBatchAllowsUniqueHandoff(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexesDeclinesFreshUniqueCatalog(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	stale, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open stale collection: %v", err)
+	}
+	if _, err := stale.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"email":"a@example.com"}`), []byte(`{"email":"b@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	fresh, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open fresh collection: %v", err)
+	}
+	if _, err := fresh.CreateIndex(IndexDefinition{Name: "email", Field: "email", Unique: true}); err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+
+	results, batched, err := stale.UpdateBatchIfNoSecondaryUniqueIndexes([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONEmail("c@example.com")},
+		{DocumentID: []byte("u2"), Update: setJSONEmail("a@example.com")},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexes: %v", err)
+	}
+	if batched {
+		t.Fatalf("batched=%v results=%+v want declined", batched, results)
+	}
+	got, err := stale.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"email":"a@example.com"`)) {
+		t.Fatalf("u1 document=%s want unchanged email", got)
+	}
+}
+
 func TestCollectionUpdateBatchClonesAliasedReplacements(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2519,6 +2519,10 @@ func TestCollectionUpdateBatchRejectsEmptyChangedReplacementWithIndex(t *testing
 	if err == nil || !strings.Contains(err.Error(), "update batch index 1") || !strings.Contains(err.Error(), "cannot be empty") {
 		t.Fatalf("UpdateBatch err=%v want index 1 empty replacement", err)
 	}
+	var itemErr *UpdateBatchItemError
+	if !errors.As(err, &itemErr) || itemErr.Index != 1 {
+		t.Fatalf("UpdateBatch err=%v want typed item index 1", err)
+	}
 }
 
 func TestCollectionUpdateBatchRejectsUniqueConflictsWithinBatch(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2483,6 +2483,10 @@ func TestCollectionUpdateBatchValidationErrorsIncludeIndex(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "index 0") {
 		t.Fatalf("nil update err=%v want index 0", err)
 	}
+	_, err = (&Collection{}).UpdateBatch([]UpdateBatchItem{{DocumentID: []byte("u1"), Update: incrementJSONCount}})
+	if !errors.Is(err, errCollectionDBNil) {
+		t.Fatalf("nil db err=%v want errCollectionDBNil", err)
+	}
 }
 
 func TestCollectionUpdateBatchRejectsUniqueConflictsWithinBatch(t *testing.T) {
@@ -2614,6 +2618,53 @@ func TestCollectionUpdateBatchClonesAliasedReplacements(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBatchClonesDocumentIDs(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"score":0}`), []byte(`{"score":0}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	id := []byte("u1")
+	if _, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: id,
+		Update: func([]byte) ([]byte, bool, error) {
+			id[1] = '2'
+			return []byte(`{"score":1}`), true, nil
+		},
+	}}); err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	gotU1, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if !bytes.Contains(gotU1, []byte(`"score":1`)) {
+		t.Fatalf("u1 document=%s want score 1", gotU1)
+	}
+	gotU2, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
+	if !bytes.Contains(gotU2, []byte(`"score":0`)) {
+		t.Fatalf("u2 document=%s want score 0", gotU2)
+	}
+}
+
 func TestCollectionUpdateBatchBSONRejectsIDMutation(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -2642,8 +2693,8 @@ func TestCollectionUpdateBatchBSONRejectsIDMutation(t *testing.T) {
 			return replacement, true, nil
 		}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "cannot modify _id") {
-		t.Fatalf("UpdateBatch err=%v want _id mutation error", err)
+	if err == nil || !strings.Contains(err.Error(), "index 0") || !strings.Contains(err.Error(), "cannot modify _id") {
+		t.Fatalf("UpdateBatch err=%v want indexed _id mutation error", err)
 	}
 }
 

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -199,6 +199,11 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 	for i, update := range updates {
 		item, err := parseMongoUpdateItem(i, update)
 		if err != nil {
+			if len(parsed) > 0 {
+				if _, _, runErr := runMongoUpdatesSequential(col, parsed); runErr != nil {
+					return mongoUpdateWriteCommandError(runErr)
+				}
+			}
 			return mongoUpdateParseCommandError(err)
 		}
 		keyString := string(item.key)
@@ -215,11 +220,7 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 		matched, modified, err = runMongoUpdatesSequential(col, parsed)
 	}
 	if err != nil {
-		code, codeName := commandCodeBadValue, "BadValue"
-		if collections.IsDuplicateKeyError(err) {
-			code, codeName = commandCodeDuplicateKey, "DuplicateKey"
-		}
-		return commandError(code, codeName, err.Error())
+		return mongoUpdateWriteCommandError(err)
 	}
 	return marshalUpdateResponse(matched, modified)
 }
@@ -276,6 +277,14 @@ func mongoUpdateParseCommandError(err error) (wire.Document, error) {
 		return commandError(parseErr.code, parseErr.codeName, parseErr.message)
 	}
 	return commandError(commandCodeBadValue, "BadValue", err.Error())
+}
+
+func mongoUpdateWriteCommandError(err error) (wire.Document, error) {
+	code, codeName := commandCodeBadValue, "BadValue"
+	if collections.IsDuplicateKeyError(err) {
+		code, codeName = commandCodeDuplicateKey, "DuplicateKey"
+	}
+	return commandError(code, codeName, err.Error())
 }
 
 func runMongoUpdatesSequential(col *collections.Collection, updates []mongoUpdateItem) (int32, int32, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -214,7 +214,7 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 		parsed = append(parsed, item)
 	}
 	var matched, modified int32
-	if len(parsed) > 1 && !hasDuplicateKey && !collectionHasSecondaryUniqueIndexes(col) {
+	if len(parsed) > 1 && !hasDuplicateKey {
 		var batched bool
 		matched, modified, batched, err = runMongoUpdateBatch(col, parsed)
 		if err != nil || !batched {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -260,12 +260,12 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 	if multi, err := optionalBoolField(update, "multi"); err != nil {
 		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
 	} else if multi {
-		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: "Mongo gateway update currently supports updateOne only"}
+		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: fmt.Sprintf("updates[%d]: Mongo gateway update currently supports updateOne only", index)}
 	}
 	if upsert, err := optionalBoolField(update, "upsert"); err != nil {
 		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
 	} else if upsert {
-		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: "Mongo gateway update currently does not support upsert"}
+		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: fmt.Sprintf("updates[%d]: Mongo gateway update currently does not support upsert", index)}
 	}
 	updateDoc, err := requiredDocumentField(update, "u")
 	if err != nil {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -186,8 +186,6 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 
-	var matched int32
-	var modified int32
 	col, err := s.Collections.OpenCollection(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
@@ -195,70 +193,98 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 		}
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
+	parsed := make([]mongoUpdateItem, 0, len(updates))
+	seenKeys := make(map[string]struct{}, len(updates))
+	hasDuplicateKey := false
 	for i, update := range updates {
-		filter, err := requiredDocumentField(update, "q")
+		item, err := parseMongoUpdateItem(i, update)
 		if err != nil {
-			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("updates[%d]: %v", i, err))
+			return mongoUpdateParseCommandError(err)
 		}
-		id, err := idEqualityFilterValue(filter, "update")
-		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: %v", i, err))
+		keyString := string(item.key)
+		if _, ok := seenKeys[keyString]; ok {
+			hasDuplicateKey = true
 		}
-		key, err := encodePrimaryKey(id)
-		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: %v", i, err))
+		seenKeys[keyString] = struct{}{}
+		parsed = append(parsed, item)
+	}
+	var matched, modified int32
+	if len(parsed) > 1 && !hasDuplicateKey {
+		matched, modified, err = runMongoUpdateBatch(col, parsed)
+	} else {
+		matched, modified, err = runMongoUpdatesSequential(col, parsed)
+	}
+	if err != nil {
+		code, codeName := commandCodeBadValue, "BadValue"
+		if collections.IsDuplicateKeyError(err) {
+			code, codeName = commandCodeDuplicateKey, "DuplicateKey"
 		}
-		if multi, err := optionalBoolField(update, "multi"); err != nil {
-			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("updates[%d]: %v", i, err))
-		} else if multi {
-			return commandError(commandCodeBadValue, "BadValue", "Mongo gateway update currently supports updateOne only")
-		}
-		if upsert, err := optionalBoolField(update, "upsert"); err != nil {
-			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("updates[%d]: %v", i, err))
-		} else if upsert {
-			return commandError(commandCodeBadValue, "BadValue", "Mongo gateway update currently does not support upsert")
-		}
-		updateDoc, err := requiredDocumentField(update, "u")
-		if err != nil {
-			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("updates[%d]: %v", i, err))
-		}
+		return commandError(code, codeName, err.Error())
+	}
+	return marshalUpdateResponse(matched, modified)
+}
 
-		materializer, err := storedDocumentMaterializerForCollection(col)
+type mongoUpdateItem struct {
+	index     int
+	key       []byte
+	updateDoc wire.Document
+}
+
+type mongoUpdateParseError struct {
+	code     int32
+	codeName string
+	message  string
+}
+
+func (e mongoUpdateParseError) Error() string {
+	return e.message
+}
+
+func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, error) {
+	filter, err := requiredDocumentField(update, "q")
+	if err != nil {
+		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
+	}
+	id, err := idEqualityFilterValue(filter, "update")
+	if err != nil {
+		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: fmt.Sprintf("updates[%d]: %v", index, err)}
+	}
+	key, err := encodePrimaryKey(id)
+	if err != nil {
+		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: fmt.Sprintf("updates[%d]: %v", index, err)}
+	}
+	if multi, err := optionalBoolField(update, "multi"); err != nil {
+		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
+	} else if multi {
+		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: "Mongo gateway update currently supports updateOne only"}
+	}
+	if upsert, err := optionalBoolField(update, "upsert"); err != nil {
+		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
+	} else if upsert {
+		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeBadValue, codeName: "BadValue", message: "Mongo gateway update currently does not support upsert"}
+	}
+	updateDoc, err := requiredDocumentField(update, "u")
+	if err != nil {
+		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
+	}
+	return mongoUpdateItem{index: index, key: key, updateDoc: updateDoc}, nil
+}
+
+func mongoUpdateParseCommandError(err error) (wire.Document, error) {
+	var parseErr mongoUpdateParseError
+	if errors.As(err, &parseErr) {
+		return commandError(parseErr.code, parseErr.codeName, parseErr.message)
+	}
+	return commandError(commandCodeBadValue, "BadValue", err.Error())
+}
+
+func runMongoUpdatesSequential(col *collections.Collection, updates []mongoUpdateItem) (int32, int32, error) {
+	var matched int32
+	var modified int32
+	for _, update := range updates {
+		matchedOne, modifiedOne, err := runMongoUpdateOne(col, update)
 		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: %v", i, err))
-		}
-		matchedOne, modifiedOne, err := func() (bool, bool, error) {
-			if materializer != nil {
-				defer func() { _ = materializer.Close() }()
-			}
-			return col.Update(key, func(stored []byte) ([]byte, bool, error) {
-				raw, err := storedDocumentToBSON(col, materializer, stored)
-				if err != nil {
-					return nil, false, err
-				}
-				updated, changed, err := applySetUpdate(raw, updateDoc)
-				if err != nil {
-					return nil, false, fmt.Errorf("updates[%d]: %w", i, err)
-				}
-				updatedKey, encoded, err := prepareInsertDocument(updated, col.Meta().Options.DocumentFormat)
-				if err != nil {
-					return nil, false, fmt.Errorf("updates[%d]: %w", i, err)
-				}
-				if !bytes.Equal(updatedKey, key) {
-					return nil, false, errors.New("Mongo gateway update cannot modify _id")
-				}
-				if !changed {
-					return nil, false, nil
-				}
-				return encoded, true, nil
-			})
-		}()
-		if err != nil {
-			code, codeName := commandCodeBadValue, "BadValue"
-			if collections.IsDuplicateKeyError(err) {
-				code, codeName = commandCodeDuplicateKey, "DuplicateKey"
-			}
-			return commandError(code, codeName, err.Error())
+			return 0, 0, err
 		}
 		if matchedOne {
 			matched++
@@ -267,7 +293,77 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 			modified++
 		}
 	}
-	return marshalUpdateResponse(matched, modified)
+	return matched, modified, nil
+}
+
+func runMongoUpdateOne(col *collections.Collection, update mongoUpdateItem) (bool, bool, error) {
+	materializer, err := storedDocumentMaterializerForCollection(col)
+	if err != nil {
+		return false, false, fmt.Errorf("updates[%d]: %w", update.index, err)
+	}
+	if materializer != nil {
+		defer func() { _ = materializer.Close() }()
+	}
+	return col.Update(update.key, func(stored []byte) ([]byte, bool, error) {
+		return applyMongoUpdateToStoredDocument(col, materializer, update, stored)
+	})
+}
+
+func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem) (int32, int32, error) {
+	materializer, err := storedDocumentMaterializerForCollection(col)
+	if err != nil {
+		return 0, 0, err
+	}
+	if materializer != nil {
+		defer func() { _ = materializer.Close() }()
+	}
+	items := make([]collections.UpdateBatchItem, len(updates))
+	for i, update := range updates {
+		update := update
+		items[i] = collections.UpdateBatchItem{
+			DocumentID: bytes.Clone(update.key),
+			Update: func(stored []byte) ([]byte, bool, error) {
+				return applyMongoUpdateToStoredDocument(col, materializer, update, stored)
+			},
+		}
+	}
+	results, err := col.UpdateBatch(items)
+	if err != nil {
+		return 0, 0, err
+	}
+	var matched int32
+	var modified int32
+	for _, result := range results {
+		if result.Matched {
+			matched++
+		}
+		if result.Modified {
+			modified++
+		}
+	}
+	return matched, modified, nil
+}
+
+func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, update mongoUpdateItem, stored []byte) ([]byte, bool, error) {
+	raw, err := storedDocumentToBSON(col, materializer, stored)
+	if err != nil {
+		return nil, false, err
+	}
+	updated, changed, err := applySetUpdate(raw, update.updateDoc)
+	if err != nil {
+		return nil, false, fmt.Errorf("updates[%d]: %w", update.index, err)
+	}
+	updatedKey, encoded, err := prepareInsertDocument(updated, col.Meta().Options.DocumentFormat)
+	if err != nil {
+		return nil, false, fmt.Errorf("updates[%d]: %w", update.index, err)
+	}
+	if !bytes.Equal(updatedKey, update.key) {
+		return nil, false, errors.New("Mongo gateway update cannot modify _id")
+	}
+	if !changed {
+		return nil, false, nil
+	}
+	return encoded, true, nil
 }
 
 func (s *Server) deleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -333,7 +333,7 @@ func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem)
 	for i, update := range updates {
 		update := update
 		items[i] = collections.UpdateBatchItem{
-			DocumentID: bytes.Clone(update.key),
+			DocumentID: update.key,
 			Update: func(stored []byte) ([]byte, bool, error) {
 				return applyMongoUpdateToStoredDocument(col, materializer, update, stored)
 			},

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -214,7 +214,7 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 		parsed = append(parsed, item)
 	}
 	var matched, modified int32
-	if len(parsed) > 1 && !hasDuplicateKey {
+	if len(parsed) > 1 && !hasDuplicateKey && !collectionHasSecondaryUniqueIndexes(col) {
 		matched, modified, err = runMongoUpdateBatch(col, parsed)
 		if err != nil {
 			matched, modified, err = runMongoUpdatesSequential(col, parsed)
@@ -370,12 +370,24 @@ func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer 
 		return nil, false, fmt.Errorf("updates[%d]: %w", update.index, err)
 	}
 	if !bytes.Equal(updatedKey, update.key) {
-		return nil, false, errors.New("Mongo gateway update cannot modify _id")
+		return nil, false, fmt.Errorf("updates[%d]: Mongo gateway update cannot modify _id", update.index)
 	}
 	if !changed {
 		return nil, false, nil
 	}
 	return encoded, true, nil
+}
+
+func collectionHasSecondaryUniqueIndexes(col *collections.Collection) bool {
+	if col == nil {
+		return false
+	}
+	for _, idx := range col.Meta().Indexes {
+		if idx.Unique {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) deleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -216,6 +216,9 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 	var matched, modified int32
 	if len(parsed) > 1 && !hasDuplicateKey {
 		matched, modified, err = runMongoUpdateBatch(col, parsed)
+		if err != nil {
+			matched, modified, err = runMongoUpdatesSequential(col, parsed)
+		}
 	} else {
 		matched, modified, err = runMongoUpdatesSequential(col, parsed)
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -296,7 +296,7 @@ func runMongoUpdatesSequential(col *collections.Collection, updates []mongoUpdat
 	for _, update := range updates {
 		matchedOne, modifiedOne, err := runMongoUpdateOne(col, update)
 		if err != nil {
-			return 0, 0, err
+			return 0, 0, mongoUpdateErrorWithIndex(update.index, err)
 		}
 		if matchedOne {
 			matched++
@@ -306,6 +306,17 @@ func runMongoUpdatesSequential(col *collections.Collection, updates []mongoUpdat
 		}
 	}
 	return matched, modified, nil
+}
+
+func mongoUpdateErrorWithIndex(index int, err error) error {
+	if err == nil {
+		return nil
+	}
+	prefix := fmt.Sprintf("updates[%d]:", index)
+	if strings.HasPrefix(err.Error(), prefix) {
+		return err
+	}
+	return fmt.Errorf("updates[%d]: %w", index, err)
 }
 
 func runMongoUpdateOne(col *collections.Collection, update mongoUpdateItem) (bool, bool, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -359,7 +359,7 @@ func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem)
 func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, update mongoUpdateItem, stored []byte) ([]byte, bool, error) {
 	raw, err := storedDocumentToBSON(col, materializer, stored)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("updates[%d]: %w", update.index, err)
 	}
 	updated, changed, err := applySetUpdate(raw, update.updateDoc)
 	if err != nil {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -215,8 +215,9 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 	}
 	var matched, modified int32
 	if len(parsed) > 1 && !hasDuplicateKey && !collectionHasSecondaryUniqueIndexes(col) {
-		matched, modified, err = runMongoUpdateBatch(col, parsed)
-		if err != nil {
+		var batched bool
+		matched, modified, batched, err = runMongoUpdateBatch(col, parsed)
+		if err != nil || !batched {
 			matched, modified, err = runMongoUpdatesSequential(col, parsed)
 		}
 	} else {
@@ -332,10 +333,10 @@ func runMongoUpdateOne(col *collections.Collection, update mongoUpdateItem) (boo
 	})
 }
 
-func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem) (int32, int32, error) {
+func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem) (int32, int32, bool, error) {
 	materializer, err := storedDocumentMaterializerForCollection(col)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, false, err
 	}
 	if materializer != nil {
 		defer func() { _ = materializer.Close() }()
@@ -350,9 +351,12 @@ func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem)
 			},
 		}
 	}
-	results, err := col.UpdateBatch(items)
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexes(items)
+	if !batched {
+		return 0, 0, false, err
+	}
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, true, err
 	}
 	var matched int32
 	var modified int32
@@ -364,7 +368,7 @@ func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem)
 			modified++
 		}
 	}
-	return matched, modified, nil
+	return matched, modified, true, nil
 }
 
 func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, update mongoUpdateItem, stored []byte) ([]byte, bool, error) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -564,14 +564,14 @@ func TestServerUpdateBatchesDistinctIDs(t *testing.T) {
 	assertInt32(t, updateResponse, "n", 2)
 	assertInt32(t, updateResponse, "nModified", 2)
 
-	for _, tc := range []struct {
+	for i, tc := range []struct {
 		id    string
 		score int32
 	}{
 		{id: "u1", score: 1},
 		{id: "u2", score: 2},
 	} {
-		findResponse := serveCommand(t, server, 2259, bson.D{
+		findResponse := serveCommand(t, server, int32(2259+i), bson.D{
 			{Key: "find", Value: "users"},
 			{Key: "filter", Value: bson.D{{Key: "_id", Value: tc.id}}},
 			{Key: "$db", Value: "app"},
@@ -626,7 +626,7 @@ func TestServerUpdateBatchTemplateV1UpdatesDistinctIDs(t *testing.T) {
 	assertInt32(t, updateResponse, "n", 2)
 	assertInt32(t, updateResponse, "nModified", 2)
 
-	for _, tc := range []struct {
+	for i, tc := range []struct {
 		id    string
 		score int32
 		city  string
@@ -634,7 +634,7 @@ func TestServerUpdateBatchTemplateV1UpdatesDistinctIDs(t *testing.T) {
 		{id: "u1", score: 11, city: "hnl"},
 		{id: "u2", score: 12, city: "sea"},
 	} {
-		findResponse := serveCommand(t, server, 22593, bson.D{
+		findResponse := serveCommand(t, server, int32(22593+i), bson.D{
 			{Key: "find", Value: "users"},
 			{Key: "filter", Value: bson.D{{Key: "_id", Value: tc.id}}},
 			{Key: "$db", Value: "app"},
@@ -701,6 +701,65 @@ func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterParseError(t *testin
 	gotScore, ok := firstBatch[0].Lookup("score").Int32OK()
 	if !ok || gotScore != 1 {
 		t.Fatalf("u1 score=%d ok=%v want 1", gotScore, ok)
+	}
+}
+
+func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterWriteError(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	assertOK(t, serveCommand(t, server, 22597, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}}, {Key: "name", Value: "email_1"}, {Key: "unique", Value: true}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	assertOK(t, serveCommand(t, server, 22598, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "email", Value: "a@example.com"}, {Key: "city", Value: "hnl"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "email", Value: "b@example.com"}, {Key: "city", Value: "hnl"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	updateResponse := serveCommand(t, server, 22599, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sea"}}}}},
+			},
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "email", Value: "a@example.com"}}}}},
+			},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, updateResponse, "DuplicateKey")
+
+	findResponse := serveCommand(t, server, 22600, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch := cursorFirstBatch(t, findResponse)
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	gotCity, ok := firstBatch[0].Lookup("city").StringValueOK()
+	if !ok || gotCity != "sea" {
+		t.Fatalf("u1 city=%q ok=%v want sea", gotCity, ok)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -587,6 +587,123 @@ func TestServerUpdateBatchesDistinctIDs(t *testing.T) {
 	}
 }
 
+func TestServerUpdateBatchTemplateV1UpdatesDistinctIDs(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatTemplateV1,
+	}
+	assertOK(t, serveCommand(t, server, 22591, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "ada"}, {Key: "score", Value: int32(0)}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "grace"}, {Key: "score", Value: int32(0)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	updateResponse := serveCommand(t, server, 22592, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(11)}, {Key: "city", Value: "hnl"}}}}},
+			},
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(12)}, {Key: "city", Value: "sea"}}}}},
+			},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, updateResponse)
+	assertInt32(t, updateResponse, "n", 2)
+	assertInt32(t, updateResponse, "nModified", 2)
+
+	for _, tc := range []struct {
+		id    string
+		score int32
+		city  string
+	}{
+		{id: "u1", score: 11, city: "hnl"},
+		{id: "u2", score: 12, city: "sea"},
+	} {
+		findResponse := serveCommand(t, server, 22593, bson.D{
+			{Key: "find", Value: "users"},
+			{Key: "filter", Value: bson.D{{Key: "_id", Value: tc.id}}},
+			{Key: "$db", Value: "app"},
+		})
+		firstBatch := cursorFirstBatch(t, findResponse)
+		if len(firstBatch) != 1 {
+			t.Fatalf("%s firstBatch len=%d want 1", tc.id, len(firstBatch))
+		}
+		gotScore, ok := firstBatch[0].Lookup("score").Int32OK()
+		if !ok || gotScore != tc.score {
+			t.Fatalf("%s score=%d ok=%v want %d", tc.id, gotScore, ok, tc.score)
+		}
+		gotCity, ok := firstBatch[0].Lookup("city").StringValueOK()
+		if !ok || gotCity != tc.city {
+			t.Fatalf("%s city=%q ok=%v want %q", tc.id, gotCity, ok, tc.city)
+		}
+	}
+}
+
+func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterParseError(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	assertOK(t, serveCommand(t, server, 22594, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(0)}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "score", Value: int32(0)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	updateResponse := serveCommand(t, server, 22595, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(1)}}}}},
+			},
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}},
+				{Key: "multi", Value: true},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(2)}}}}},
+			},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, updateResponse, "BadValue")
+
+	findResponse := serveCommand(t, server, 22596, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch := cursorFirstBatch(t, findResponse)
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	gotScore, ok := firstBatch[0].Lookup("score").Int32OK()
+	if !ok || gotScore != 1 {
+		t.Fatalf("u1 score=%d ok=%v want 1", gotScore, ok)
+	}
+}
+
 func TestServerUpdateRejectsIDMutation(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -654,6 +654,59 @@ func TestServerUpdateBatchTemplateV1UpdatesDistinctIDs(t *testing.T) {
 	}
 }
 
+func TestRunMongoUpdateBatchDeclinesFreshSecondaryUniqueIndex(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mgr := collections.NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name: "app.users",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	stale, err := mgr.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open stale collection: %v", err)
+	}
+	id1, err := encodePrimaryKey(mustRawValue(t, "u1"))
+	if err != nil {
+		t.Fatalf("encode u1: %v", err)
+	}
+	id2, err := encodePrimaryKey(mustRawValue(t, "u2"))
+	if err != nil {
+		t.Fatalf("encode u2: %v", err)
+	}
+	doc1 := mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "email", Value: "a@example.com"}})
+	doc2 := mustDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "email", Value: "b@example.com"}})
+	if _, err := stale.InsertBatchValidatedBSON([][]byte{id1, id2}, [][]byte{doc1, doc2}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	fresh, err := mgr.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open fresh collection: %v", err)
+	}
+	if _, err := fresh.CreateIndex(collections.IndexDefinition{Name: "email_1", Field: "email", Unique: true}); err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+
+	matched, modified, batched, err := runMongoUpdateBatch(stale, []mongoUpdateItem{
+		{index: 0, key: id1, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "email", Value: "c@example.com"}}}})},
+		{index: 1, key: id2, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "email", Value: "a@example.com"}}}})},
+	})
+	if err != nil {
+		t.Fatalf("runMongoUpdateBatch: %v", err)
+	}
+	if batched || matched != 0 || modified != 0 {
+		t.Fatalf("matched=%d modified=%d batched=%v want declined", matched, modified, batched)
+	}
+}
+
 func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterParseError(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -861,6 +861,17 @@ func TestServerUpdateWithUniqueIndexKeepsAcquireBeforeReleaseOrdered(t *testing.
 	}
 }
 
+func TestMongoUpdateErrorWithIndexAddsMissingContext(t *testing.T) {
+	err := mongoUpdateErrorWithIndex(3, errors.New("write failed"))
+	if err == nil || !strings.Contains(err.Error(), "updates[3]: write failed") {
+		t.Fatalf("err=%v want indexed context", err)
+	}
+	alreadyIndexed := errors.New("updates[3]: bad bson")
+	if got := mongoUpdateErrorWithIndex(3, alreadyIndexed); got != alreadyIndexed {
+		t.Fatalf("already indexed err changed: %v", got)
+	}
+}
+
 func TestServerUpdateRejectsIDMutation(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -688,6 +688,10 @@ func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterParseError(t *testin
 		{Key: "$db", Value: "app"},
 	})
 	assertCommandError(t, updateResponse, "BadValue")
+	errmsg, ok := bson.Raw(updateResponse).Lookup("errmsg").StringValueOK()
+	if !ok || !strings.Contains(errmsg, "updates[1]") {
+		t.Fatalf("errmsg=%q ok=%v want updates[1]", errmsg, ok)
+	}
 
 	findResponse := serveCommand(t, server, 22596, bson.D{
 		{Key: "find", Value: "users"},
@@ -701,6 +705,33 @@ func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterParseError(t *testin
 	gotScore, ok := firstBatch[0].Lookup("score").Int32OK()
 	if !ok || gotScore != 1 {
 		t.Fatalf("u1 score=%d ok=%v want 1", gotScore, ok)
+	}
+}
+
+func TestParseMongoUpdateItemUnsupportedFlagsIncludeIndex(t *testing.T) {
+	tests := []struct {
+		name string
+		flag bson.E
+		want string
+	}{
+		{name: "multi", flag: bson.E{Key: "multi", Value: true}, want: "updateOne only"},
+		{name: "upsert", flag: bson.E{Key: "upsert", Value: true}, want: "does not support upsert"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := mustDocument(t, bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+				tt.flag,
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(1)}}}}},
+			})
+			_, err := parseMongoUpdateItem(3, doc)
+			if err == nil {
+				t.Fatal("parseMongoUpdateItem accepted unsupported flag")
+			}
+			if !strings.Contains(err.Error(), "updates[3]") || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("err=%v want index and %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -794,6 +794,73 @@ func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterWriteError(t *testin
 	}
 }
 
+func TestServerUpdateWithUniqueIndexKeepsAcquireBeforeReleaseOrdered(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	assertOK(t, serveCommand(t, server, 22601, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}}, {Key: "name", Value: "email_1"}, {Key: "unique", Value: true}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	assertOK(t, serveCommand(t, server, 22602, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "email", Value: "a@example.com"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "email", Value: "b@example.com"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	updateResponse := serveCommand(t, server, 22603, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "email", Value: "a@example.com"}}}}},
+			},
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "email", Value: "c@example.com"}}}}},
+			},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, updateResponse, "DuplicateKey")
+
+	for i, tc := range []struct {
+		id    string
+		email string
+	}{
+		{id: "u1", email: "a@example.com"},
+		{id: "u2", email: "b@example.com"},
+	} {
+		findResponse := serveCommand(t, server, int32(22604+i), bson.D{
+			{Key: "find", Value: "users"},
+			{Key: "filter", Value: bson.D{{Key: "_id", Value: tc.id}}},
+			{Key: "$db", Value: "app"},
+		})
+		firstBatch := cursorFirstBatch(t, findResponse)
+		if len(firstBatch) != 1 {
+			t.Fatalf("%s firstBatch len=%d want 1", tc.id, len(firstBatch))
+		}
+		gotEmail, ok := firstBatch[0].Lookup("email").StringValueOK()
+		if !ok || gotEmail != tc.email {
+			t.Fatalf("%s email=%q ok=%v want %q", tc.id, gotEmail, ok, tc.email)
+		}
+	}
+}
+
 func TestServerUpdateRejectsIDMutation(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -825,6 +892,10 @@ func TestServerUpdateRejectsIDMutation(t *testing.T) {
 		{Key: "$db", Value: "app"},
 	})
 	assertCommandError(t, updateResponse, "BadValue")
+	errmsg, ok := bson.Raw(updateResponse).Lookup("errmsg").StringValueOK()
+	if !ok || !strings.Contains(errmsg, "updates[0]") {
+		t.Fatalf("errmsg=%q ok=%v want updates[0]", errmsg, ok)
+	}
 }
 
 func TestServerIndexMetadataCommands(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -525,6 +525,68 @@ func TestServerUpdateTemplateV1RefreshesMaterializerBetweenStatements(t *testing
 	}
 }
 
+func TestServerUpdateBatchesDistinctIDs(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	assertOK(t, serveCommand(t, server, 2257, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "ada"}, {Key: "score", Value: int32(0)}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "grace"}, {Key: "score", Value: int32(0)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	updateResponse := serveCommand(t, server, 2258, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(1)}}}}},
+			},
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(2)}}}}},
+			},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, updateResponse)
+	assertInt32(t, updateResponse, "n", 2)
+	assertInt32(t, updateResponse, "nModified", 2)
+
+	for _, tc := range []struct {
+		id    string
+		score int32
+	}{
+		{id: "u1", score: 1},
+		{id: "u2", score: 2},
+	} {
+		findResponse := serveCommand(t, server, 2259, bson.D{
+			{Key: "find", Value: "users"},
+			{Key: "filter", Value: bson.D{{Key: "_id", Value: tc.id}}},
+			{Key: "$db", Value: "app"},
+		})
+		firstBatch := cursorFirstBatch(t, findResponse)
+		if len(firstBatch) != 1 {
+			t.Fatalf("%s firstBatch len=%d want 1", tc.id, len(firstBatch))
+		}
+		gotScore, ok := firstBatch[0].Lookup("score").Int32OK()
+		if !ok || gotScore != tc.score {
+			t.Fatalf("%s score=%d ok=%v want %d", tc.id, gotScore, ok, tc.score)
+		}
+	}
+}
+
 func TestServerUpdateRejectsIDMutation(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `Collection.UpdateBatch` for unique-ID batches that publish many document updates as one collection mutation.
- Build primary, template, index-state, and secondary-index root deltas for the batch and publish them together.
- Reject duplicate document IDs so callers that need same-document ordering can keep the existing sequential path.
- Teach the Mongo gateway to use the batched path when one update command contains multiple distinct `_id` updates; duplicate `_id` commands fall back to the existing sequential behavior.
- Add collection-level and gateway-level coverage for batched updates, duplicate IDs, missing docs, and unique-index conflicts inside a batch.

## Validation

- `GOWORK=off go test ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1`

## Notes

This PR is the explicit batch primitive. It is not expected to improve the existing concurrent `UpdateOne` benchmark by itself because that benchmark sends one update per command. The next stacked PR will use this API to coalesce concurrent single-update gateway traffic.

## Stack

Stacked on PR #1112 (`codex/mongo-gateway-collection-cache`).
