### PR TITLE
[codex] Coalesce Mongo gateway update commands

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -664,6 +664,30 @@ func (c *Collection) Meta() CollectionMeta {
 	return *c.meta.copy()
 }
 
+// SameCachedCatalog reports whether both handles were opened against the same
+// collection catalog state.
+func (c *Collection) SameCachedCatalog(other *Collection) bool {
+	if c == nil || other == nil {
+		return false
+	}
+	cName, cSystemRoot, cCommitSeq := c.cachedCatalogIdentity()
+	otherName, otherSystemRoot, otherCommitSeq := other.cachedCatalogIdentity()
+	return cName != "" &&
+		cName == otherName &&
+		cSystemRoot != 0 &&
+		cSystemRoot == otherSystemRoot &&
+		cCommitSeq == otherCommitSeq
+}
+
+func (c *Collection) cachedCatalogIdentity() (name string, systemRoot, commitSeq uint64) {
+	if c == nil {
+		return "", 0, 0
+	}
+	c.catalogMu.RLock()
+	defer c.catalogMu.RUnlock()
+	return c.meta.Name, c.catalogSystemRoot, c.catalogCommitSeq
+}
+
 func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 	if c == nil {
 		return nil, errCollectionNil

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -241,6 +241,7 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 type mongoUpdateItem struct {
 	index     int
 	key       []byte
+	keyString string
 	updateDoc wire.Document
 }
 
@@ -281,7 +282,7 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 	if err != nil {
 		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
 	}
-	return mongoUpdateItem{index: index, key: key, updateDoc: updateDoc}, nil
+	return mongoUpdateItem{index: index, key: key, keyString: string(key), updateDoc: updateDoc}, nil
 }
 
 func mongoUpdateParseCommandError(err error) (wire.Document, error) {
@@ -558,6 +559,7 @@ func (c *mongoUpdateCoalescer) closeRequests() bool {
 	}
 	c.stopped = true
 	close(c.stoppedCh)
+	close(c.requests)
 	c.mu.Unlock()
 	return true
 }
@@ -608,14 +610,9 @@ func (c *mongoUpdateCoalescer) markStopped() {
 }
 
 func (c *mongoUpdateCoalescer) drainRequestsDirect() {
-	for {
-		select {
-		case req := <-c.requests:
-			matched, modified, err := runMongoUpdateOne(req.col, req.item)
-			req.done <- mongoUpdateCoalescerResult{matched: matched, modified: modified, err: err}
-		default:
-			return
-		}
+	for req := range c.requests {
+		matched, modified, err := runMongoUpdateOne(req.col, req.item)
+		req.done <- mongoUpdateCoalescerResult{matched: matched, modified: modified, err: err}
 	}
 }
 
@@ -647,7 +644,10 @@ func (c *mongoUpdateCoalescer) run() {
 	}
 	for {
 		select {
-		case first := <-c.requests:
+		case first, ok := <-c.requests:
+			if !ok {
+				return
+			}
 			c.runBatchStartingWith(first)
 			resetIdle()
 		case <-idle:
@@ -669,7 +669,10 @@ func (c *mongoUpdateCoalescer) runBatchStartingWith(first mongoUpdateCoalescerRe
 	collect:
 		for len(batch) < c.maxBatch {
 			select {
-			case req := <-c.requests:
+			case req, ok := <-c.requests:
+				if !ok {
+					break collect
+				}
 				batch = append(batch, req)
 			case <-timer.C:
 				break collect
@@ -686,7 +689,10 @@ func (c *mongoUpdateCoalescer) runBatchStartingWith(first mongoUpdateCoalescerRe
 	}
 	for len(batch) < c.maxBatch {
 		select {
-		case req := <-c.requests:
+		case req, ok := <-c.requests:
+			if !ok {
+				goto drained
+			}
 			batch = append(batch, req)
 		case <-c.stoppedCh:
 			goto drained
@@ -727,7 +733,10 @@ func (c *mongoUpdateCoalescer) runBatch(batch []mongoUpdateCoalescerRequest) {
 func mongoUpdateCoalescerHasDuplicateKeys(batch []mongoUpdateCoalescerRequest) bool {
 	seen := make(map[string]struct{}, len(batch))
 	for _, req := range batch {
-		key := string(req.item.key)
+		key := req.item.keyString
+		if key == "" {
+			key = string(req.item.key)
+		}
 		if _, ok := seen[key]; ok {
 			return true
 		}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -438,6 +438,9 @@ type mongoUpdateCoalescerResult struct {
 }
 
 func (s *Server) runMongoUpdateCoalesced(name string, col *collections.Collection, update mongoUpdateItem) (bool, bool, error) {
+	if collectionHasSecondaryUniqueIndexes(col) {
+		return runMongoUpdateOne(col, update)
+	}
 	coalescer := s.mongoUpdateCoalescer(name)
 	if coalescer == nil {
 		return runMongoUpdateOne(col, update)
@@ -762,11 +765,11 @@ func collectionUpdateBatchErrorIndex(err error) (int, bool) {
 	if err == nil {
 		return 0, false
 	}
-	var index int
-	if _, scanErr := fmt.Sscanf(err.Error(), "collections: update batch index %d:", &index); scanErr != nil {
-		return 0, false
+	var itemErr *collections.UpdateBatchItemError
+	if errors.As(err, &itemErr) {
+		return itemErr.Index, true
 	}
-	return index, true
+	return 0, false
 }
 
 func mongoUpdateCoalescerHasDuplicateKeys(batch []mongoUpdateCoalescerRequest) bool {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -397,19 +397,17 @@ func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer 
 }
 
 type mongoUpdateCoalescer struct {
-	maxDelay       time.Duration
-	maxBatch       int
-	idleTTL        time.Duration
-	requests       chan mongoUpdateCoalescerRequest
-	stoppedCh      chan struct{}
-	done           chan struct{}
-	server         *Server
-	name           string
-	mu             sync.RWMutex
-	stopped        bool
-	enqueueMu      sync.Mutex
-	activeEnqueues int
-	enqueueCond    *sync.Cond
+	maxDelay  time.Duration
+	maxBatch  int
+	idleTTL   time.Duration
+	requests  chan mongoUpdateCoalescerRequest
+	stoppedCh chan struct{}
+	done      chan struct{}
+	server    *Server
+	name      string
+	mu        sync.RWMutex
+	stopped   bool
+	enqueueMu sync.Mutex
 }
 
 type mongoUpdateCoalescerRequest struct {
@@ -493,7 +491,6 @@ func (s *Server) mongoUpdateCoalescer(name string) *mongoUpdateCoalescer {
 		server:    s,
 		name:      name,
 	}
-	coalescer.enqueueCond = sync.NewCond(&coalescer.enqueueMu)
 	s.updateCoalescers[name] = coalescer
 	go coalescer.run()
 	return coalescer
@@ -511,35 +508,20 @@ func (c *mongoUpdateCoalescer) enqueue(req mongoUpdateCoalescerRequest) bool {
 		return false
 	}
 	c.enqueueMu.Lock()
+	defer c.enqueueMu.Unlock()
 	c.mu.RLock()
 	stopped := c.stopped
 	requests := c.requests
-	stoppedCh := c.stoppedCh
 	c.mu.RUnlock()
 	if stopped {
-		c.enqueueMu.Unlock()
 		return false
 	}
-	c.activeEnqueues++
-	c.enqueueMu.Unlock()
-	defer c.finishEnqueue()
 	select {
 	case requests <- req:
 		return true
-	case <-stoppedCh:
-		return false
 	default:
 		return false
 	}
-}
-
-func (c *mongoUpdateCoalescer) finishEnqueue() {
-	c.enqueueMu.Lock()
-	c.activeEnqueues--
-	if c.enqueueCond != nil {
-		c.enqueueCond.Broadcast()
-	}
-	c.enqueueMu.Unlock()
 }
 
 func (c *mongoUpdateCoalescer) stop() {
@@ -555,9 +537,6 @@ func (c *mongoUpdateCoalescer) stop() {
 func (c *mongoUpdateCoalescer) closeRequests() bool {
 	c.enqueueMu.Lock()
 	defer c.enqueueMu.Unlock()
-	if c.enqueueCond == nil {
-		c.enqueueCond = sync.NewCond(&c.enqueueMu)
-	}
 	c.mu.Lock()
 	if c.stopped {
 		c.mu.Unlock()
@@ -569,10 +548,6 @@ func (c *mongoUpdateCoalescer) closeRequests() bool {
 	c.stopped = true
 	close(c.stoppedCh)
 	c.mu.Unlock()
-
-	for c.activeEnqueues > 0 {
-		c.enqueueCond.Wait()
-	}
 	return true
 }
 

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -724,6 +724,11 @@ func (c *mongoUpdateCoalescer) runBatch(batch []mongoUpdateCoalescerRequest) {
 		return
 	}
 	if err != nil {
+		if index, ok := collectionUpdateBatchErrorIndex(err); ok && index >= 0 && index < len(batch) {
+			completeMongoUpdateCoalescerBatchExcept(batch, index)
+			batch[index].done <- mongoUpdateCoalescerResult{err: err}
+			return
+		}
 		completeMongoUpdateCoalescerBatch(batch, mongoUpdateCoalescerResult{err: err})
 		return
 	}
@@ -741,6 +746,27 @@ func completeMongoUpdateCoalescerBatch(batch []mongoUpdateCoalescerRequest, resu
 	for _, req := range batch {
 		req.done <- result
 	}
+}
+
+func completeMongoUpdateCoalescerBatchExcept(batch []mongoUpdateCoalescerRequest, skip int) {
+	for i, req := range batch {
+		if i == skip {
+			continue
+		}
+		matched, modified, err := runMongoUpdateOne(req.col, req.item)
+		req.done <- mongoUpdateCoalescerResult{matched: matched, modified: modified, err: err}
+	}
+}
+
+func collectionUpdateBatchErrorIndex(err error) (int, bool) {
+	if err == nil {
+		return 0, false
+	}
+	var index int
+	if _, scanErr := fmt.Sscanf(err.Error(), "collections: update batch index %d:", &index); scanErr != nil {
+		return 0, false
+	}
+	return index, true
 }
 
 func mongoUpdateCoalescerHasDuplicateKeys(batch []mongoUpdateCoalescerRequest) bool {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -387,6 +388,8 @@ type mongoUpdateCoalescer struct {
 	maxDelay time.Duration
 	maxBatch int
 	requests chan mongoUpdateCoalescerRequest
+	mu       sync.RWMutex
+	stopped  bool
 }
 
 type mongoUpdateCoalescerRequest struct {
@@ -407,7 +410,9 @@ func (s *Server) runMongoUpdateCoalesced(name string, col *collections.Collectio
 		return runMongoUpdateOne(col, update)
 	}
 	done := make(chan mongoUpdateCoalescerResult, 1)
-	coalescer.requests <- mongoUpdateCoalescerRequest{col: col, item: update, done: done}
+	if !coalescer.enqueue(mongoUpdateCoalescerRequest{col: col, item: update, done: done}) {
+		return runMongoUpdateOne(col, update)
+	}
 	result := <-done
 	return result.matched, result.modified, result.err
 }
@@ -423,6 +428,9 @@ func (s *Server) mongoUpdateCoalescer(name string) *mongoUpdateCoalescer {
 	maxDelay := s.UpdateCoalescingMaxDelay
 	s.updateMu.Lock()
 	defer s.updateMu.Unlock()
+	if s.closed {
+		return nil
+	}
 	if s.updateCoalescers == nil {
 		s.updateCoalescers = make(map[string]*mongoUpdateCoalescer)
 	}
@@ -439,6 +447,36 @@ func (s *Server) mongoUpdateCoalescer(name string) *mongoUpdateCoalescer {
 	return coalescer
 }
 
+func (c *mongoUpdateCoalescer) enqueue(req mongoUpdateCoalescerRequest) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.stopped {
+		return false
+	}
+	select {
+	case c.requests <- req:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *mongoUpdateCoalescer) stop() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stopped {
+		return
+	}
+	c.stopped = true
+	close(c.requests)
+}
+
 func (c *mongoUpdateCoalescer) run() {
 	for first := range c.requests {
 		batch := []mongoUpdateCoalescerRequest{first}
@@ -447,7 +485,10 @@ func (c *mongoUpdateCoalescer) run() {
 		collect:
 			for len(batch) < c.maxBatch {
 				select {
-				case req := <-c.requests:
+				case req, ok := <-c.requests:
+					if !ok {
+						break collect
+					}
 					batch = append(batch, req)
 				case <-timer.C:
 					break collect
@@ -462,7 +503,10 @@ func (c *mongoUpdateCoalescer) run() {
 		}
 		for len(batch) < c.maxBatch {
 			select {
-			case req := <-c.requests:
+			case req, ok := <-c.requests:
+				if !ok {
+					goto drained
+				}
 				batch = append(batch, req)
 			default:
 				goto drained

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -574,16 +574,12 @@ func (c *mongoUpdateCoalescer) retireIdle() bool {
 	}
 	stopped := false
 	if c.server != nil {
-		shouldStop := false
 		c.server.updateMu.Lock()
 		if c.server.updateCoalescers != nil && c.server.updateCoalescers[c.name] == c {
+			stopped = c.closeRequests()
 			delete(c.server.updateCoalescers, c.name)
-			shouldStop = true
 		}
 		c.server.updateMu.Unlock()
-		if shouldStop {
-			stopped = c.closeRequests()
-		}
 	} else {
 		stopped = c.closeRequests()
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -478,12 +478,8 @@ func (c *mongoUpdateCoalescer) enqueue(req mongoUpdateCoalescerRequest) bool {
 	if c.stopped {
 		return false
 	}
-	select {
-	case c.requests <- req:
-		return true
-	default:
-		return false
-	}
+	c.requests <- req
+	return true
 }
 
 func (c *mongoUpdateCoalescer) stop() {
@@ -522,13 +518,27 @@ func (c *mongoUpdateCoalescer) retireIdle() bool {
 		stopped = c.closeRequests()
 	}
 	if !stopped {
+		if c.isStopped() {
+			c.drainRequestsDirect()
+			return true
+		}
 		return false
 	}
+	c.drainRequestsDirect()
+	return true
+}
+
+func (c *mongoUpdateCoalescer) isStopped() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.stopped
+}
+
+func (c *mongoUpdateCoalescer) drainRequestsDirect() {
 	for req := range c.requests {
 		matched, modified, err := runMongoUpdateOne(req.col, req.item)
 		req.done <- mongoUpdateCoalescerResult{matched: matched, modified: modified, err: err}
 	}
-	return true
 }
 
 func (c *mongoUpdateCoalescer) run() {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -402,6 +402,7 @@ type mongoUpdateCoalescer struct {
 	idleTTL        time.Duration
 	requests       chan mongoUpdateCoalescerRequest
 	stoppedCh      chan struct{}
+	done           chan struct{}
 	server         *Server
 	name           string
 	mu             sync.RWMutex
@@ -432,8 +433,30 @@ func (s *Server) runMongoUpdateCoalesced(name string, col *collections.Collectio
 	if !coalescer.enqueue(mongoUpdateCoalescerRequest{col: col, item: update, done: done}) {
 		return runMongoUpdateOne(col, update)
 	}
-	result := <-done
+	result := coalescer.waitForUpdateResult(done)
 	return result.matched, result.modified, result.err
+}
+
+func (c *mongoUpdateCoalescer) waitForUpdateResult(done chan mongoUpdateCoalescerResult) mongoUpdateCoalescerResult {
+	select {
+	case result := <-done:
+		return result
+	default:
+	}
+	if c == nil || c.done == nil {
+		return <-done
+	}
+	select {
+	case result := <-done:
+		return result
+	case <-c.done:
+		select {
+		case result := <-done:
+			return result
+		default:
+			return mongoUpdateCoalescerResult{err: errors.New("mongo gateway update coalescer stopped before completing request")}
+		}
+	}
 }
 
 func (s *Server) mongoUpdateCoalescer(name string) *mongoUpdateCoalescer {
@@ -466,6 +489,7 @@ func (s *Server) mongoUpdateCoalescer(name string) *mongoUpdateCoalescer {
 		idleTTL:   idleTTL,
 		requests:  make(chan mongoUpdateCoalescerRequest, maxBatch*4),
 		stoppedCh: make(chan struct{}),
+		done:      make(chan struct{}),
 		server:    s,
 		name:      name,
 	}
@@ -523,6 +547,9 @@ func (c *mongoUpdateCoalescer) stop() {
 		return
 	}
 	_ = c.closeRequests()
+	if c.done != nil {
+		<-c.done
+	}
 }
 
 func (c *mongoUpdateCoalescer) closeRequests() bool {
@@ -585,6 +612,15 @@ func (c *mongoUpdateCoalescer) isStopped() bool {
 	return c.stopped
 }
 
+func (c *mongoUpdateCoalescer) markStopped() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.stopped = true
+	c.mu.Unlock()
+}
+
 func (c *mongoUpdateCoalescer) drainRequestsDirect() {
 	for {
 		select {
@@ -598,6 +634,12 @@ func (c *mongoUpdateCoalescer) drainRequestsDirect() {
 }
 
 func (c *mongoUpdateCoalescer) run() {
+	defer func() {
+		c.markStopped()
+		if c.done != nil {
+			close(c.done)
+		}
+	}()
 	var idle <-chan time.Time
 	var timer *time.Timer
 	if c.idleTTL > 0 {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -525,20 +525,31 @@ func (c *mongoUpdateCoalescer) enqueue(req mongoUpdateCoalescerRequest) bool {
 	if c == nil {
 		return false
 	}
-	c.mu.RLock()
-	if c.stopped {
+	for {
+		c.enqueueMu.Lock()
+		c.mu.RLock()
+		if c.stopped || c.requests == nil {
+			c.mu.RUnlock()
+			c.enqueueMu.Unlock()
+			return false
+		}
+		requests := c.requests
+		stoppedCh := c.stoppedCh
+		select {
+		case requests <- req:
+			c.mu.RUnlock()
+			c.enqueueMu.Unlock()
+			return true
+		default:
+		}
 		c.mu.RUnlock()
-		return false
-	}
-	requests := c.requests
-	stoppedCh := c.stoppedCh
-	select {
-	case requests <- req:
-		c.mu.RUnlock()
-		return true
-	case <-stoppedCh:
-		c.mu.RUnlock()
-		return false
+		c.enqueueMu.Unlock()
+
+		select {
+		case <-stoppedCh:
+			return false
+		case <-time.After(time.Millisecond):
+		}
 	}
 }
 
@@ -729,7 +740,7 @@ func (c *mongoUpdateCoalescer) runBatch(batch []mongoUpdateCoalescerRequest) {
 	if err != nil {
 		if index, ok := collectionUpdateBatchErrorIndex(err); ok && index >= 0 && index < len(batch) {
 			completeMongoUpdateCoalescerBatchExcept(batch, index)
-			batch[index].done <- mongoUpdateCoalescerResult{err: err}
+			batch[index].done <- mongoUpdateCoalescerResult{err: collectionUpdateBatchErrorForRequest(err, batch[index].item.index)}
 			return
 		}
 		completeMongoUpdateCoalescerBatch(batch, mongoUpdateCoalescerResult{err: err})
@@ -770,6 +781,14 @@ func collectionUpdateBatchErrorIndex(err error) (int, bool) {
 		return itemErr.Index, true
 	}
 	return 0, false
+}
+
+func collectionUpdateBatchErrorForRequest(err error, updateIndex int) error {
+	var itemErr *collections.UpdateBatchItemError
+	if errors.As(err, &itemErr) {
+		return mongoUpdateErrorWithIndex(updateIndex, itemErr.Err)
+	}
+	return err
 }
 
 func mongoUpdateCoalescerHasDuplicateKeys(batch []mongoUpdateCoalescerRequest) bool {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -435,7 +435,7 @@ func (s *Server) mongoUpdateCoalescer(name string) *mongoUpdateCoalescer {
 	}
 	s.updateMu.Lock()
 	defer s.updateMu.Unlock()
-	if s.closed {
+	if s.closed.Load() {
 		return nil
 	}
 	if s.updateCoalescers == nil {
@@ -961,6 +961,9 @@ func marshalCursorResponseWithID(ns string, cursorID int64, batchKey string, bat
 }
 
 func (s *Server) openCursor(ns string, docs []wire.Document, projection compiledProjection, batchSize int, explicitBatchSize bool, defaultBatchSize int, owner int64) (int64, bson.A, error) {
+	if s.isClosed() {
+		return 0, nil, errServerClosed
+	}
 	batchSize, err := normalizeBatchSize(batchSize, explicitBatchSize, defaultBatchSize)
 	if err != nil {
 		return 0, nil, err
@@ -984,6 +987,9 @@ func (s *Server) openCursor(ns string, docs []wire.Document, projection compiled
 	now := time.Now()
 	s.cursorMu.Lock()
 	defer s.cursorMu.Unlock()
+	if s.isClosed() {
+		return 0, nil, errServerClosed
+	}
 	s.reapExpiredCursorsLocked(now)
 	if s.cursors == nil {
 		s.cursors = make(map[int64]*serverCursor)

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -444,7 +444,7 @@ func (s *Server) runMongoUpdateCoalesced(name string, col *collections.Collectio
 	}
 	done := make(chan mongoUpdateCoalescerResult, 1)
 	if !coalescer.enqueue(mongoUpdateCoalescerRequest{col: col, item: update, done: done}) {
-		return false, false, errors.New("mongo gateway update coalescer stopped before enqueue")
+		return runMongoUpdateOne(col, update)
 	}
 	result := coalescer.waitForUpdateResult(done)
 	return result.matched, result.modified, result.err

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -209,7 +209,16 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 		parsed = append(parsed, item)
 	}
 	var matched, modified int32
-	if len(parsed) > 1 && !hasDuplicateKey {
+	if len(parsed) == 1 {
+		var matchedOne, modifiedOne bool
+		matchedOne, modifiedOne, err = s.runMongoUpdateCoalesced(name, col, parsed[0])
+		if matchedOne {
+			matched = 1
+		}
+		if modifiedOne {
+			modified = 1
+		}
+	} else if len(parsed) > 1 && !hasDuplicateKey {
 		matched, modified, err = runMongoUpdateBatch(col, parsed)
 	} else {
 		matched, modified, err = runMongoUpdatesSequential(col, parsed)
@@ -310,9 +319,27 @@ func runMongoUpdateOne(col *collections.Collection, update mongoUpdateItem) (boo
 }
 
 func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem) (int32, int32, error) {
-	materializer, err := storedDocumentMaterializerForCollection(col)
+	results, err := runMongoUpdateBatchResults(col, updates)
 	if err != nil {
 		return 0, 0, err
+	}
+	var matched int32
+	var modified int32
+	for _, result := range results {
+		if result.Matched {
+			matched++
+		}
+		if result.Modified {
+			modified++
+		}
+	}
+	return matched, modified, nil
+}
+
+func runMongoUpdateBatchResults(col *collections.Collection, updates []mongoUpdateItem) ([]collections.UpdateBatchResult, error) {
+	materializer, err := storedDocumentMaterializerForCollection(col)
+	if err != nil {
+		return nil, err
 	}
 	if materializer != nil {
 		defer func() { _ = materializer.Close() }()
@@ -329,19 +356,9 @@ func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem)
 	}
 	results, err := col.UpdateBatch(items)
 	if err != nil {
-		return 0, 0, err
+		return nil, err
 	}
-	var matched int32
-	var modified int32
-	for _, result := range results {
-		if result.Matched {
-			matched++
-		}
-		if result.Modified {
-			modified++
-		}
-	}
-	return matched, modified, nil
+	return results, nil
 }
 
 func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, update mongoUpdateItem, stored []byte) ([]byte, bool, error) {
@@ -364,6 +381,133 @@ func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer 
 		return nil, false, nil
 	}
 	return encoded, true, nil
+}
+
+type mongoUpdateCoalescer struct {
+	maxDelay time.Duration
+	maxBatch int
+	requests chan mongoUpdateCoalescerRequest
+}
+
+type mongoUpdateCoalescerRequest struct {
+	col  *collections.Collection
+	item mongoUpdateItem
+	done chan mongoUpdateCoalescerResult
+}
+
+type mongoUpdateCoalescerResult struct {
+	matched  bool
+	modified bool
+	err      error
+}
+
+func (s *Server) runMongoUpdateCoalesced(name string, col *collections.Collection, update mongoUpdateItem) (bool, bool, error) {
+	coalescer := s.mongoUpdateCoalescer(name)
+	if coalescer == nil {
+		return runMongoUpdateOne(col, update)
+	}
+	done := make(chan mongoUpdateCoalescerResult, 1)
+	coalescer.requests <- mongoUpdateCoalescerRequest{col: col, item: update, done: done}
+	result := <-done
+	return result.matched, result.modified, result.err
+}
+
+func (s *Server) mongoUpdateCoalescer(name string) *mongoUpdateCoalescer {
+	if s == nil || s.UpdateCoalescingMaxBatch <= 1 || s.UpdateCoalescingMaxDelay < 0 {
+		return nil
+	}
+	maxBatch := s.UpdateCoalescingMaxBatch
+	if maxBatch <= 1 {
+		return nil
+	}
+	maxDelay := s.UpdateCoalescingMaxDelay
+	s.updateMu.Lock()
+	defer s.updateMu.Unlock()
+	if s.updateCoalescers == nil {
+		s.updateCoalescers = make(map[string]*mongoUpdateCoalescer)
+	}
+	if coalescer := s.updateCoalescers[name]; coalescer != nil {
+		return coalescer
+	}
+	coalescer := &mongoUpdateCoalescer{
+		maxDelay: maxDelay,
+		maxBatch: maxBatch,
+		requests: make(chan mongoUpdateCoalescerRequest, maxBatch*4),
+	}
+	s.updateCoalescers[name] = coalescer
+	go coalescer.run()
+	return coalescer
+}
+
+func (c *mongoUpdateCoalescer) run() {
+	for first := range c.requests {
+		batch := []mongoUpdateCoalescerRequest{first}
+		if c.maxDelay > 0 {
+			timer := time.NewTimer(c.maxDelay)
+		collect:
+			for len(batch) < c.maxBatch {
+				select {
+				case req := <-c.requests:
+					batch = append(batch, req)
+				case <-timer.C:
+					break collect
+				}
+			}
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		}
+		for len(batch) < c.maxBatch {
+			select {
+			case req := <-c.requests:
+				batch = append(batch, req)
+			default:
+				goto drained
+			}
+		}
+	drained:
+		c.runBatch(batch)
+	}
+}
+
+func (c *mongoUpdateCoalescer) runBatch(batch []mongoUpdateCoalescerRequest) {
+	if len(batch) == 1 || mongoUpdateCoalescerHasDuplicateKeys(batch) {
+		for _, req := range batch {
+			matched, modified, err := runMongoUpdateOne(req.col, req.item)
+			req.done <- mongoUpdateCoalescerResult{matched: matched, modified: modified, err: err}
+		}
+		return
+	}
+	updates := make([]mongoUpdateItem, len(batch))
+	for i, req := range batch {
+		updates[i] = req.item
+	}
+	results, err := runMongoUpdateBatchResults(batch[0].col, updates)
+	if err != nil {
+		for _, req := range batch {
+			req.done <- mongoUpdateCoalescerResult{err: err}
+		}
+		return
+	}
+	for i, req := range batch {
+		result := results[i]
+		req.done <- mongoUpdateCoalescerResult{matched: result.Matched, modified: result.Modified}
+	}
+}
+
+func mongoUpdateCoalescerHasDuplicateKeys(batch []mongoUpdateCoalescerRequest) bool {
+	seen := make(map[string]struct{}, len(batch))
+	for _, req := range batch {
+		key := string(req.item.key)
+		if _, ok := seen[key]; ok {
+			return true
+		}
+		seen[key] = struct{}{}
+	}
+	return false
 }
 
 func (s *Server) deleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -387,7 +387,10 @@ func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer 
 type mongoUpdateCoalescer struct {
 	maxDelay time.Duration
 	maxBatch int
+	idleTTL  time.Duration
 	requests chan mongoUpdateCoalescerRequest
+	server   *Server
+	name     string
 	mu       sync.RWMutex
 	stopped  bool
 }
@@ -426,6 +429,10 @@ func (s *Server) mongoUpdateCoalescer(name string) *mongoUpdateCoalescer {
 		return nil
 	}
 	maxDelay := s.UpdateCoalescingMaxDelay
+	idleTTL := s.UpdateCoalescingIdleTTL
+	if idleTTL == 0 {
+		idleTTL = defaultUpdateCoalescingIdleTTL
+	}
 	s.updateMu.Lock()
 	defer s.updateMu.Unlock()
 	if s.closed {
@@ -440,7 +447,10 @@ func (s *Server) mongoUpdateCoalescer(name string) *mongoUpdateCoalescer {
 	coalescer := &mongoUpdateCoalescer{
 		maxDelay: maxDelay,
 		maxBatch: maxBatch,
+		idleTTL:  idleTTL,
 		requests: make(chan mongoUpdateCoalescerRequest, maxBatch*4),
+		server:   s,
+		name:     name,
 	}
 	s.updateCoalescers[name] = coalescer
 	go coalescer.run()
@@ -468,53 +478,115 @@ func (c *mongoUpdateCoalescer) stop() {
 	if c == nil {
 		return
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.stopped {
+	if !c.markStopped() {
 		return
 	}
-	c.stopped = true
 	close(c.requests)
 }
 
+func (c *mongoUpdateCoalescer) markStopped() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stopped {
+		return false
+	}
+	c.stopped = true
+	return true
+}
+
+func (c *mongoUpdateCoalescer) retireIdle() bool {
+	if c == nil {
+		return false
+	}
+	if c.server != nil {
+		c.server.updateMu.Lock()
+		if c.server.updateCoalescers != nil && c.server.updateCoalescers[c.name] == c {
+			delete(c.server.updateCoalescers, c.name)
+		}
+		c.server.updateMu.Unlock()
+	}
+	if !c.markStopped() {
+		return false
+	}
+	close(c.requests)
+	for req := range c.requests {
+		matched, modified, err := runMongoUpdateOne(req.col, req.item)
+		req.done <- mongoUpdateCoalescerResult{matched: matched, modified: modified, err: err}
+	}
+	return true
+}
+
 func (c *mongoUpdateCoalescer) run() {
-	for first := range c.requests {
-		batch := []mongoUpdateCoalescerRequest{first}
-		if c.maxDelay > 0 {
-			timer := time.NewTimer(c.maxDelay)
-		collect:
-			for len(batch) < c.maxBatch {
-				select {
-				case req, ok := <-c.requests:
-					if !ok {
-						break collect
-					}
-					batch = append(batch, req)
-				case <-timer.C:
-					break collect
-				}
-			}
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
+	var idle <-chan time.Time
+	var timer *time.Timer
+	if c.idleTTL > 0 {
+		timer = time.NewTimer(c.idleTTL)
+		idle = timer.C
+		defer timer.Stop()
+	}
+	resetIdle := func() {
+		if timer == nil {
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
 			}
 		}
+		timer.Reset(c.idleTTL)
+	}
+	for {
+		select {
+		case first, ok := <-c.requests:
+			if !ok {
+				return
+			}
+			c.runBatchStartingWith(first)
+			resetIdle()
+		case <-idle:
+			c.retireIdle()
+			return
+		}
+	}
+}
+
+func (c *mongoUpdateCoalescer) runBatchStartingWith(first mongoUpdateCoalescerRequest) {
+	batch := []mongoUpdateCoalescerRequest{first}
+	if c.maxDelay > 0 {
+		timer := time.NewTimer(c.maxDelay)
+	collect:
 		for len(batch) < c.maxBatch {
 			select {
 			case req, ok := <-c.requests:
 				if !ok {
-					goto drained
+					break collect
 				}
 				batch = append(batch, req)
-			default:
-				goto drained
+			case <-timer.C:
+				break collect
 			}
 		}
-	drained:
-		c.runBatch(batch)
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
 	}
+	for len(batch) < c.maxBatch {
+		select {
+		case req, ok := <-c.requests:
+			if !ok {
+				goto drained
+			}
+			batch = append(batch, req)
+		default:
+			goto drained
+		}
+	}
+drained:
+	c.runBatch(batch)
 }
 
 func (c *mongoUpdateCoalescer) runBatch(batch []mongoUpdateCoalescerRequest) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -397,14 +397,18 @@ func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer 
 }
 
 type mongoUpdateCoalescer struct {
-	maxDelay time.Duration
-	maxBatch int
-	idleTTL  time.Duration
-	requests chan mongoUpdateCoalescerRequest
-	server   *Server
-	name     string
-	mu       sync.RWMutex
-	stopped  bool
+	maxDelay       time.Duration
+	maxBatch       int
+	idleTTL        time.Duration
+	requests       chan mongoUpdateCoalescerRequest
+	stoppedCh      chan struct{}
+	server         *Server
+	name           string
+	mu             sync.RWMutex
+	stopped        bool
+	enqueueMu      sync.Mutex
+	activeEnqueues int
+	enqueueCond    *sync.Cond
 }
 
 type mongoUpdateCoalescerRequest struct {
@@ -436,7 +440,7 @@ func (s *Server) mongoUpdateCoalescer(name string) *mongoUpdateCoalescer {
 	if s == nil || s.UpdateCoalescingMaxBatch <= 1 || s.UpdateCoalescingMaxDelay < 0 {
 		return nil
 	}
-	maxBatch := s.UpdateCoalescingMaxBatch
+	maxBatch := clampUpdateCoalescingMaxBatch(s.UpdateCoalescingMaxBatch)
 	if maxBatch <= 1 {
 		return nil
 	}
@@ -457,33 +461,61 @@ func (s *Server) mongoUpdateCoalescer(name string) *mongoUpdateCoalescer {
 		return coalescer
 	}
 	coalescer := &mongoUpdateCoalescer{
-		maxDelay: maxDelay,
-		maxBatch: maxBatch,
-		idleTTL:  idleTTL,
-		requests: make(chan mongoUpdateCoalescerRequest, maxBatch*4),
-		server:   s,
-		name:     name,
+		maxDelay:  maxDelay,
+		maxBatch:  maxBatch,
+		idleTTL:   idleTTL,
+		requests:  make(chan mongoUpdateCoalescerRequest, maxBatch*4),
+		stoppedCh: make(chan struct{}),
+		server:    s,
+		name:      name,
 	}
+	coalescer.enqueueCond = sync.NewCond(&coalescer.enqueueMu)
 	s.updateCoalescers[name] = coalescer
 	go coalescer.run()
 	return coalescer
+}
+
+func clampUpdateCoalescingMaxBatch(maxBatch int) int {
+	if maxBatch > maxUpdateCoalescingBatch {
+		return maxUpdateCoalescingBatch
+	}
+	return maxBatch
 }
 
 func (c *mongoUpdateCoalescer) enqueue(req mongoUpdateCoalescerRequest) bool {
 	if c == nil {
 		return false
 	}
+	c.enqueueMu.Lock()
 	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.stopped {
+	stopped := c.stopped
+	requests := c.requests
+	stoppedCh := c.stoppedCh
+	c.mu.RUnlock()
+	if stopped {
+		c.enqueueMu.Unlock()
 		return false
 	}
+	c.activeEnqueues++
+	c.enqueueMu.Unlock()
+	defer c.finishEnqueue()
 	select {
-	case c.requests <- req:
+	case requests <- req:
 		return true
+	case <-stoppedCh:
+		return false
 	default:
 		return false
 	}
+}
+
+func (c *mongoUpdateCoalescer) finishEnqueue() {
+	c.enqueueMu.Lock()
+	c.activeEnqueues--
+	if c.enqueueCond != nil {
+		c.enqueueCond.Broadcast()
+	}
+	c.enqueueMu.Unlock()
 }
 
 func (c *mongoUpdateCoalescer) stop() {
@@ -494,13 +526,26 @@ func (c *mongoUpdateCoalescer) stop() {
 }
 
 func (c *mongoUpdateCoalescer) closeRequests() bool {
+	c.enqueueMu.Lock()
+	defer c.enqueueMu.Unlock()
+	if c.enqueueCond == nil {
+		c.enqueueCond = sync.NewCond(&c.enqueueMu)
+	}
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.stopped {
+		c.mu.Unlock()
 		return false
 	}
+	if c.stoppedCh == nil {
+		c.stoppedCh = make(chan struct{})
+	}
 	c.stopped = true
-	close(c.requests)
+	close(c.stoppedCh)
+	c.mu.Unlock()
+
+	for c.activeEnqueues > 0 {
+		c.enqueueCond.Wait()
+	}
 	return true
 }
 
@@ -541,9 +586,14 @@ func (c *mongoUpdateCoalescer) isStopped() bool {
 }
 
 func (c *mongoUpdateCoalescer) drainRequestsDirect() {
-	for req := range c.requests {
-		matched, modified, err := runMongoUpdateOne(req.col, req.item)
-		req.done <- mongoUpdateCoalescerResult{matched: matched, modified: modified, err: err}
+	for {
+		select {
+		case req := <-c.requests:
+			matched, modified, err := runMongoUpdateOne(req.col, req.item)
+			req.done <- mongoUpdateCoalescerResult{matched: matched, modified: modified, err: err}
+		default:
+			return
+		}
 	}
 }
 
@@ -569,10 +619,7 @@ func (c *mongoUpdateCoalescer) run() {
 	}
 	for {
 		select {
-		case first, ok := <-c.requests:
-			if !ok {
-				return
-			}
+		case first := <-c.requests:
 			c.runBatchStartingWith(first)
 			resetIdle()
 		case <-idle:
@@ -580,6 +627,9 @@ func (c *mongoUpdateCoalescer) run() {
 				return
 			}
 			resetIdle()
+		case <-c.stoppedCh:
+			c.drainRequestsDirect()
+			return
 		}
 	}
 }
@@ -591,12 +641,11 @@ func (c *mongoUpdateCoalescer) runBatchStartingWith(first mongoUpdateCoalescerRe
 	collect:
 		for len(batch) < c.maxBatch {
 			select {
-			case req, ok := <-c.requests:
-				if !ok {
-					break collect
-				}
+			case req := <-c.requests:
 				batch = append(batch, req)
 			case <-timer.C:
+				break collect
+			case <-c.stoppedCh:
 				break collect
 			}
 		}
@@ -609,11 +658,10 @@ func (c *mongoUpdateCoalescer) runBatchStartingWith(first mongoUpdateCoalescerRe
 	}
 	for len(batch) < c.maxBatch {
 		select {
-		case req, ok := <-c.requests:
-			if !ok {
-				goto drained
-			}
+		case req := <-c.requests:
 			batch = append(batch, req)
+		case <-c.stoppedCh:
+			goto drained
 		default:
 			goto drained
 		}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -656,12 +656,12 @@ func mongoUpdateCoalescerUsesSingleCollection(batch []mongoUpdateCoalescerReques
 	if len(batch) == 0 {
 		return true
 	}
-	name := batch[0].col.Name()
-	if name == "" {
+	col := batch[0].col
+	if col == nil {
 		return false
 	}
 	for _, req := range batch[1:] {
-		if req.col == nil || req.col.Name() != name {
+		if !col.SameCachedCatalog(req.col) {
 			return false
 		}
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -242,7 +242,6 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 type mongoUpdateItem struct {
 	index     int
 	key       []byte
-	keyString string
 	updateDoc wire.Document
 }
 
@@ -283,7 +282,7 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 	if err != nil {
 		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
 	}
-	return mongoUpdateItem{index: index, key: key, keyString: string(key), updateDoc: updateDoc}, nil
+	return mongoUpdateItem{index: index, key: key, updateDoc: updateDoc}, nil
 }
 
 func mongoUpdateParseCommandError(err error) (wire.Document, error) {
@@ -445,7 +444,7 @@ func (s *Server) runMongoUpdateCoalesced(name string, col *collections.Collectio
 	}
 	done := make(chan mongoUpdateCoalescerResult, 1)
 	if !coalescer.enqueue(mongoUpdateCoalescerRequest{col: col, item: update, done: done}) {
-		return runMongoUpdateOne(col, update)
+		return false, false, errors.New("mongo gateway update coalescer stopped before enqueue")
 	}
 	result := coalescer.waitForUpdateResult(done)
 	return result.matched, result.modified, result.err
@@ -523,19 +522,19 @@ func (c *mongoUpdateCoalescer) enqueue(req mongoUpdateCoalescerRequest) bool {
 	if c == nil {
 		return false
 	}
-	c.enqueueMu.Lock()
-	defer c.enqueueMu.Unlock()
 	c.mu.RLock()
-	stopped := c.stopped
-	requests := c.requests
-	c.mu.RUnlock()
-	if stopped {
+	if c.stopped {
+		c.mu.RUnlock()
 		return false
 	}
+	requests := c.requests
+	stoppedCh := c.stoppedCh
 	select {
 	case requests <- req:
+		c.mu.RUnlock()
 		return true
-	default:
+	case <-stoppedCh:
+		c.mu.RUnlock()
 		return false
 	}
 }
@@ -720,8 +719,16 @@ func (c *mongoUpdateCoalescer) runBatch(batch []mongoUpdateCoalescerRequest) {
 		updates[i] = req.item
 	}
 	results, batched, err := runMongoUpdateBatchResults(batch[0].col, updates)
-	if err != nil || !batched || len(results) != len(batch) {
+	if !batched {
 		runMongoUpdateCoalescerSequential(batch)
+		return
+	}
+	if err != nil {
+		completeMongoUpdateCoalescerBatch(batch, mongoUpdateCoalescerResult{err: err})
+		return
+	}
+	if len(results) != len(batch) {
+		completeMongoUpdateCoalescerBatch(batch, mongoUpdateCoalescerResult{err: fmt.Errorf("mongo gateway update coalescer batch results=%d want %d", len(results), len(batch))})
 		return
 	}
 	for i, req := range batch {
@@ -730,13 +737,16 @@ func (c *mongoUpdateCoalescer) runBatch(batch []mongoUpdateCoalescerRequest) {
 	}
 }
 
+func completeMongoUpdateCoalescerBatch(batch []mongoUpdateCoalescerRequest, result mongoUpdateCoalescerResult) {
+	for _, req := range batch {
+		req.done <- result
+	}
+}
+
 func mongoUpdateCoalescerHasDuplicateKeys(batch []mongoUpdateCoalescerRequest) bool {
 	seen := make(map[string]struct{}, len(batch))
 	for _, req := range batch {
-		key := req.item.keyString
-		if key == "" {
-			key = string(req.item.key)
-		}
+		key := string(req.item.key)
 		if _, ok := seen[key]; ok {
 			return true
 		}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -478,8 +478,12 @@ func (c *mongoUpdateCoalescer) enqueue(req mongoUpdateCoalescerRequest) bool {
 	if c.stopped {
 		return false
 	}
-	c.requests <- req
-	return true
+	select {
+	case c.requests <- req:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *mongoUpdateCoalescer) stop() {
@@ -506,14 +510,16 @@ func (c *mongoUpdateCoalescer) retireIdle() bool {
 	}
 	stopped := false
 	if c.server != nil {
+		shouldStop := false
 		c.server.updateMu.Lock()
 		if c.server.updateCoalescers != nil && c.server.updateCoalescers[c.name] == c {
-			stopped = c.closeRequests()
-			if stopped {
-				delete(c.server.updateCoalescers, c.name)
-			}
+			delete(c.server.updateCoalescers, c.name)
+			shouldStop = true
 		}
 		c.server.updateMu.Unlock()
+		if shouldStop {
+			stopped = c.closeRequests()
+		}
 	} else {
 		stopped = c.closeRequests()
 	}
@@ -570,8 +576,10 @@ func (c *mongoUpdateCoalescer) run() {
 			c.runBatchStartingWith(first)
 			resetIdle()
 		case <-idle:
-			c.retireIdle()
-			return
+			if c.retireIdle() {
+				return
+			}
+			resetIdle()
 		}
 	}
 }

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -488,7 +488,8 @@ func (c *mongoUpdateCoalescer) runBatch(batch []mongoUpdateCoalescerRequest) {
 	results, err := runMongoUpdateBatchResults(batch[0].col, updates)
 	if err != nil {
 		for _, req := range batch {
-			req.done <- mongoUpdateCoalescerResult{err: err}
+			matched, modified, err := runMongoUpdateOne(req.col, req.item)
+			req.done <- mongoUpdateCoalescerResult{matched: matched, modified: modified, err: err}
 		}
 		return
 	}

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	lastCursorReap   time.Time
 	updateMu         sync.Mutex
 	updateCoalescers map[string]*mongoUpdateCoalescer
+	closed           bool
 }
 
 type serverCursor struct {
@@ -71,6 +72,31 @@ func NewServer() *Server {
 	}
 	s.nextResponseID.Store(0)
 	return s
+}
+
+func (s *Server) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.closeUpdateCoalescers()
+	s.cursorMu.Lock()
+	s.cursors = nil
+	s.cursorMu.Unlock()
+	return nil
+}
+
+func (s *Server) closeUpdateCoalescers() {
+	if s == nil {
+		return
+	}
+	s.updateMu.Lock()
+	coalescers := s.updateCoalescers
+	s.updateCoalescers = nil
+	s.closed = true
+	s.updateMu.Unlock()
+	for _, coalescer := range coalescers {
+		coalescer.stop()
+	}
 }
 
 func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -26,6 +26,7 @@ const (
 	defaultCursorReapInterval      = time.Second
 	defaultUpdateCoalescingDelay   = 0
 	defaultUpdateCoalescingBatch   = 256
+	maxUpdateCoalescingBatch       = 4096
 	defaultUpdateCoalescingIdleTTL = 30 * time.Second
 )
 
@@ -42,6 +43,7 @@ type Server struct {
 	// work; negative disables coalescing.
 	UpdateCoalescingMaxDelay time.Duration
 	// UpdateCoalescingMaxBatch caps one coalesced same-collection update publish.
+	// Values above maxUpdateCoalescingBatch are clamped.
 	UpdateCoalescingMaxBatch int
 	// UpdateCoalescingIdleTTL removes an idle per-collection coalescer after this
 	// duration. Zero uses the default; negative disables idle removal.

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -24,14 +24,22 @@ const (
 	defaultCursorBatchSize        = 101
 	defaultCursorIdleTimeout      = 10 * time.Minute
 	defaultCursorReapInterval     = time.Second
+	defaultUpdateCoalescingDelay  = 0
+	defaultUpdateCoalescingBatch  = 256
 )
 
 type Server struct {
-	MaxMessageLength          int32
-	MaxFindScanDocuments      int
-	MaxCursorRetainedBytes    int
-	MaxOpenCursors            int
-	CursorIdleTimeout         time.Duration
+	MaxMessageLength       int32
+	MaxFindScanDocuments   int
+	MaxCursorRetainedBytes int
+	MaxOpenCursors         int
+	CursorIdleTimeout      time.Duration
+	// UpdateCoalescingMaxDelay waits for additional same-collection update
+	// commands before publishing a batch. Zero batches only already-queued work;
+	// negative disables coalescing.
+	UpdateCoalescingMaxDelay time.Duration
+	// UpdateCoalescingMaxBatch caps one coalesced same-collection update publish.
+	UpdateCoalescingMaxBatch  int
 	Collections               *collections.CollectionManager
 	DefaultCollectionOptions  collections.CollectionOptions
 	DefaultIndexStoragePolicy collections.RootStoragePolicy
@@ -42,6 +50,8 @@ type Server struct {
 	cursorMu         sync.Mutex
 	cursors          map[int64]*serverCursor
 	lastCursorReap   time.Time
+	updateMu         sync.Mutex
+	updateCoalescers map[string]*mongoUpdateCoalescer
 }
 
 type serverCursor struct {
@@ -54,7 +64,11 @@ type serverCursor struct {
 }
 
 func NewServer() *Server {
-	s := &Server{MaxMessageLength: wire.DefaultMaxMessageLength}
+	s := &Server{
+		MaxMessageLength:         wire.DefaultMaxMessageLength,
+		UpdateCoalescingMaxDelay: defaultUpdateCoalescingDelay,
+		UpdateCoalescingMaxBatch: defaultUpdateCoalescingBatch,
+	}
 	s.nextResponseID.Store(0)
 	return s
 }

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -16,16 +16,17 @@ import (
 )
 
 const (
-	defaultMaxBSONObjectSize      = 16 * 1024 * 1024
-	defaultMaxWriteBatchSize      = 100_000
-	defaultMaxFindScanDocuments   = 10_000
-	defaultMaxCursorRetainedBytes = 64 * 1024 * 1024
-	defaultMaxOpenCursors         = 1_024
-	defaultCursorBatchSize        = 101
-	defaultCursorIdleTimeout      = 10 * time.Minute
-	defaultCursorReapInterval     = time.Second
-	defaultUpdateCoalescingDelay  = 0
-	defaultUpdateCoalescingBatch  = 256
+	defaultMaxBSONObjectSize       = 16 * 1024 * 1024
+	defaultMaxWriteBatchSize       = 100_000
+	defaultMaxFindScanDocuments    = 10_000
+	defaultMaxCursorRetainedBytes  = 64 * 1024 * 1024
+	defaultMaxOpenCursors          = 1_024
+	defaultCursorBatchSize         = 101
+	defaultCursorIdleTimeout       = 10 * time.Minute
+	defaultCursorReapInterval      = time.Second
+	defaultUpdateCoalescingDelay   = 0
+	defaultUpdateCoalescingBatch   = 256
+	defaultUpdateCoalescingIdleTTL = 30 * time.Second
 )
 
 type Server struct {
@@ -39,7 +40,10 @@ type Server struct {
 	// negative disables coalescing.
 	UpdateCoalescingMaxDelay time.Duration
 	// UpdateCoalescingMaxBatch caps one coalesced same-collection update publish.
-	UpdateCoalescingMaxBatch  int
+	UpdateCoalescingMaxBatch int
+	// UpdateCoalescingIdleTTL removes an idle per-collection coalescer after this
+	// duration. Zero uses the default; negative disables idle removal.
+	UpdateCoalescingIdleTTL   time.Duration
 	Collections               *collections.CollectionManager
 	DefaultCollectionOptions  collections.CollectionOptions
 	DefaultIndexStoragePolicy collections.RootStoragePolicy
@@ -69,6 +73,7 @@ func NewServer() *Server {
 		MaxMessageLength:         wire.DefaultMaxMessageLength,
 		UpdateCoalescingMaxDelay: defaultUpdateCoalescingDelay,
 		UpdateCoalescingMaxBatch: defaultUpdateCoalescingBatch,
+		UpdateCoalescingIdleTTL:  defaultUpdateCoalescingIdleTTL,
 	}
 	s.nextResponseID.Store(0)
 	return s

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -102,7 +102,6 @@ func (s *Server) closeUpdateCoalescers() {
 	if s == nil {
 		return
 	}
-	s.closed.Store(true)
 	s.updateMu.Lock()
 	coalescers := s.updateCoalescers
 	s.updateCoalescers = nil

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -29,6 +29,8 @@ const (
 	defaultUpdateCoalescingIdleTTL = 30 * time.Second
 )
 
+var errServerClosed = errors.New("mongo gateway server is closed")
+
 type Server struct {
 	MaxMessageLength       int32
 	MaxFindScanDocuments   int
@@ -36,8 +38,8 @@ type Server struct {
 	MaxOpenCursors         int
 	CursorIdleTimeout      time.Duration
 	// UpdateCoalescingMaxDelay waits for additional same-collection update
-	// commands before publishing a batch. Zero batches only already-queued work;
-	// negative disables coalescing.
+	// commands before publishing a batch. Zero means only coalesce already-queued
+	// work; negative disables coalescing.
 	UpdateCoalescingMaxDelay time.Duration
 	// UpdateCoalescingMaxBatch caps one coalesced same-collection update publish.
 	UpdateCoalescingMaxBatch int
@@ -56,7 +58,7 @@ type Server struct {
 	lastCursorReap   time.Time
 	updateMu         sync.Mutex
 	updateCoalescers map[string]*mongoUpdateCoalescer
-	closed           bool
+	closed           atomic.Bool
 }
 
 type serverCursor struct {
@@ -94,18 +96,28 @@ func (s *Server) closeUpdateCoalescers() {
 	if s == nil {
 		return
 	}
+	s.closed.Store(true)
 	s.updateMu.Lock()
 	coalescers := s.updateCoalescers
 	s.updateCoalescers = nil
-	s.closed = true
 	s.updateMu.Unlock()
 	for _, coalescer := range coalescers {
 		coalescer.stop()
 	}
 }
 
+func (s *Server) isClosed() bool {
+	if s == nil {
+		return true
+	}
+	return s.closed.Load()
+}
+
 func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	defer conn.Close()
+	if s.isClosed() {
+		return errServerClosed
+	}
 	owner := s.nextConnectionID.Add(1)
 	defer s.killCursorsForOwner(owner)
 
@@ -149,6 +161,9 @@ func (s *Server) ServeOne(rw io.ReadWriter) error {
 }
 
 func (s *Server) ServeOneWithOwner(rw io.ReadWriter, cursorOwner int64) error {
+	if s.isClosed() {
+		return errServerClosed
+	}
 	h, body, err := wire.ReadMessage(rw, s.maxMessageLength())
 	if err != nil {
 		return err
@@ -164,6 +179,9 @@ func (s *Server) ServeOneWithOwner(rw io.ReadWriter, cursorOwner int64) error {
 }
 
 func (s *Server) handleMessage(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
+	if s.isClosed() {
+		return nil, errServerClosed
+	}
 	s.reapExpiredCursors()
 	switch h.OpCode {
 	case wire.OpQuery:

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1152,6 +1152,69 @@ func TestMongoUpdateCoalescerRejectsEnqueueAfterStop(t *testing.T) {
 	}
 }
 
+func TestServerUpdateCoalescedFallsBackWhenCoalescerStopsBeforeEnqueue(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	server.UpdateCoalescingMaxDelay = 5 * time.Second
+	server.UpdateCoalescingMaxBatch = 2
+	assertOK(t, serveCommand(t, server, 2280, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(0)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	coalescer := server.mongoUpdateCoalescer("app.users")
+	if coalescer == nil {
+		t.Fatal("expected coalescer")
+	}
+	coalescer.stop()
+
+	col, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	update, err := parseMongoUpdateItem(0, mustDocument(t, bson.D{
+		{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(7)}}}}},
+	}))
+	if err != nil {
+		t.Fatalf("parse update: %v", err)
+	}
+
+	matched, modified, err := server.runMongoUpdateCoalesced("app.users", col, update)
+	if err != nil {
+		t.Fatalf("runMongoUpdateCoalesced: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true,true", matched, modified)
+	}
+
+	findResponse := serveCommand(t, server, 2281, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch := cursorFirstBatch(t, findResponse)
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	gotScore, ok := firstBatch[0].Lookup("score").Int32OK()
+	if !ok || gotScore != 7 {
+		t.Fatalf("u1 score=%d ok=%v want 7", gotScore, ok)
+	}
+}
+
 func TestMongoUpdateCoalescerWaitReturnsWhenWorkerStops(t *testing.T) {
 	coalescer := &mongoUpdateCoalescer{done: make(chan struct{})}
 	done := make(chan mongoUpdateCoalescerResult, 1)

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -744,6 +744,12 @@ func TestServerCloseStopsUpdateCoalescers(t *testing.T) {
 	if got := server.mongoUpdateCoalescer("app.users"); got != nil {
 		t.Fatal("closed server created a new coalescer")
 	}
+	if err := server.ServeOne(&readWriter{r: bytes.NewReader(nil)}); !errors.Is(err, errServerClosed) {
+		t.Fatalf("ServeOne after Close err=%v want %v", err, errServerClosed)
+	}
+	if _, _, err := server.openCursor("app.users", []wire.Document{mustDocument(t, bson.D{{Key: "_id", Value: "u1"}})}, compiledProjection{}, 1, true, defaultCursorBatchSize, 1); !errors.Is(err, errServerClosed) {
+		t.Fatalf("openCursor after Close err=%v want %v", err, errServerClosed)
+	}
 }
 
 func TestServerUpdateCoalescerEvictsWhenIdle(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1205,6 +1205,65 @@ func TestServerUpdateCoalescerEvictsWhenIdle(t *testing.T) {
 	}
 }
 
+func TestMongoUpdateCoalescerRetireIdleStopsBeforeUncache(t *testing.T) {
+	server := NewServer()
+	coalescer := server.mongoUpdateCoalescer("app.users")
+	if coalescer == nil {
+		t.Fatal("expected coalescer")
+	}
+	coalescer.enqueueMu.Lock()
+	retired := make(chan bool, 1)
+	go func() {
+		retired <- coalescer.retireIdle()
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		if !server.updateMu.TryLock() {
+			break
+		}
+		server.updateMu.Unlock()
+		if time.Now().After(deadline) {
+			coalescer.enqueueMu.Unlock()
+			t.Fatal("retireIdle did not hold server update lock while stopping")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	replacement := make(chan *mongoUpdateCoalescer, 1)
+	go func() {
+		replacement <- server.mongoUpdateCoalescer("app.users")
+	}()
+	select {
+	case got := <-replacement:
+		coalescer.enqueueMu.Unlock()
+		if got != coalescer {
+			t.Fatal("created replacement coalescer before old coalescer stopped")
+		}
+		t.Fatal("returned old coalescer while idle retirement was stopping it")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	coalescer.enqueueMu.Unlock()
+	select {
+	case ok := <-retired:
+		if !ok {
+			t.Fatal("retireIdle reported false")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("retireIdle did not finish")
+	}
+	select {
+	case got := <-replacement:
+		if got == nil || got == coalescer {
+			t.Fatalf("replacement=%p old=%p want new coalescer", got, coalescer)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("replacement coalescer was not created after idle retirement")
+	}
+	_ = server.Close()
+}
+
 func TestServerUpdateWithUniqueIndexKeepsAcquireBeforeReleaseOrdered(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -808,7 +808,7 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 	server.DefaultCollectionOptions = collections.CollectionOptions{
 		DocumentFormat: collections.DocumentFormatBSON,
 	}
-	server.UpdateCoalescingMaxDelay = 20 * time.Millisecond
+	server.UpdateCoalescingMaxDelay = 200 * time.Millisecond
 	server.UpdateCoalescingMaxBatch = 2
 	assertOK(t, serveCommand(t, server, 2260, bson.D{
 		{Key: "insert", Value: "users"},
@@ -869,7 +869,7 @@ func TestServerUpdateCoalescedBatchIsolatesItemErrors(t *testing.T) {
 	server.DefaultCollectionOptions = collections.CollectionOptions{
 		DocumentFormat: collections.DocumentFormatBSON,
 	}
-	server.UpdateCoalescingMaxDelay = 20 * time.Millisecond
+	server.UpdateCoalescingMaxDelay = 200 * time.Millisecond
 	server.UpdateCoalescingMaxBatch = 2
 	assertOK(t, serveCommand(t, server, 2262, bson.D{
 		{Key: "insert", Value: "users"},

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -808,7 +808,7 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 	server.DefaultCollectionOptions = collections.CollectionOptions{
 		DocumentFormat: collections.DocumentFormatBSON,
 	}
-	server.UpdateCoalescingMaxDelay = 200 * time.Millisecond
+	server.UpdateCoalescingMaxDelay = 5 * time.Second
 	server.UpdateCoalescingMaxBatch = 2
 	assertOK(t, serveCommand(t, server, 2260, bson.D{
 		{Key: "insert", Value: "users"},
@@ -869,7 +869,7 @@ func TestServerUpdateCoalescedBatchIsolatesItemErrors(t *testing.T) {
 	server.DefaultCollectionOptions = collections.CollectionOptions{
 		DocumentFormat: collections.DocumentFormatBSON,
 	}
-	server.UpdateCoalescingMaxDelay = 200 * time.Millisecond
+	server.UpdateCoalescingMaxDelay = 5 * time.Second
 	server.UpdateCoalescingMaxBatch = 2
 	assertOK(t, serveCommand(t, server, 2262, bson.D{
 		{Key: "insert", Value: "users"},

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -584,6 +585,63 @@ func TestServerUpdateBatchesDistinctIDs(t *testing.T) {
 		if !ok || gotScore != tc.score {
 			t.Fatalf("%s score=%d ok=%v want %d", tc.id, gotScore, ok, tc.score)
 		}
+	}
+}
+
+func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	server.UpdateCoalescingMaxDelay = 20 * time.Millisecond
+	server.UpdateCoalescingMaxBatch = 8
+	assertOK(t, serveCommand(t, server, 2260, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(0)}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "score", Value: int32(0)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	before := db.State()
+	start := make(chan struct{})
+	responses := make(chan wire.Document, 2)
+	var wg sync.WaitGroup
+	for i, id := range []string{"u1", "u2"} {
+		i, id := i, id
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			responses <- serveCommand(t, server, int32(2261+i), bson.D{
+				{Key: "update", Value: "users"},
+				{Key: "updates", Value: bson.A{bson.D{
+					{Key: "q", Value: bson.D{{Key: "_id", Value: id}}},
+					{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(10 + i)}}}}},
+				}}},
+				{Key: "$db", Value: "app"},
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(responses)
+	for response := range responses {
+		assertOK(t, response)
+		assertInt32(t, response, "n", 1)
+		assertInt32(t, response, "nModified", 1)
+	}
+	after := db.State()
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("coalesced updates advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1062,6 +1062,68 @@ func TestMongoUpdateCoalescerUniqueIndexFallsBackToOrderedSingles(t *testing.T) 
 	}
 }
 
+func TestServerUpdateCoalescedSkipsCoalescerForSecondaryUniqueIndex(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.UpdateCoalescingMaxDelay = 5 * time.Second
+	server.UpdateCoalescingMaxBatch = 2
+	assertOK(t, serveCommand(t, server, 2270, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}}, {Key: "name", Value: "email_1"}, {Key: "unique", Value: true}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	assertOK(t, serveCommand(t, server, 2271, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "email", Value: "a@example.com"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	col, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	update, err := parseMongoUpdateItem(0, mustDocument(t, bson.D{
+		{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "email", Value: "b@example.com"}}}}},
+	}))
+	if err != nil {
+		t.Fatalf("parse update: %v", err)
+	}
+	matched, modified, err := server.runMongoUpdateCoalesced("app.users", col, update)
+	if err != nil {
+		t.Fatalf("runMongoUpdateCoalesced: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("matched=%v modified=%v want true,true", matched, modified)
+	}
+	server.updateMu.Lock()
+	_, cached := server.updateCoalescers["app.users"]
+	server.updateMu.Unlock()
+	if cached {
+		t.Fatal("secondary unique update created a coalescer")
+	}
+}
+
+func TestCollectionUpdateBatchErrorIndexUsesTypedError(t *testing.T) {
+	err := fmt.Errorf("wrap: %w", &collections.UpdateBatchItemError{
+		Index: 3,
+		Err:   errors.New("bad replacement"),
+	})
+	index, ok := collectionUpdateBatchErrorIndex(err)
+	if !ok || index != 3 {
+		t.Fatalf("index=%d ok=%v want 3,true", index, ok)
+	}
+}
+
 func TestMongoUpdateCoalescerUsesSingleCollection(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1082,6 +1082,34 @@ func TestServerCloseStopsUpdateCoalescers(t *testing.T) {
 	}
 }
 
+func TestMongoUpdateCoalescerRejectsEnqueueAfterStop(t *testing.T) {
+	server := NewServer()
+	coalescer := server.mongoUpdateCoalescer("app.users")
+	if coalescer == nil {
+		t.Fatal("expected coalescer")
+	}
+	coalescer.stop()
+	if coalescer.enqueue(mongoUpdateCoalescerRequest{done: make(chan mongoUpdateCoalescerResult, 1)}) {
+		t.Fatal("stopped coalescer accepted enqueue")
+	}
+}
+
+func TestMongoUpdateCoalescerClampsConfiguredMaxBatch(t *testing.T) {
+	server := NewServer()
+	server.UpdateCoalescingMaxBatch = maxUpdateCoalescingBatch + 1
+	coalescer := server.mongoUpdateCoalescer("app.users")
+	if coalescer == nil {
+		t.Fatal("expected coalescer")
+	}
+	defer func() { _ = server.Close() }()
+	if coalescer.maxBatch != maxUpdateCoalescingBatch {
+		t.Fatalf("maxBatch=%d want %d", coalescer.maxBatch, maxUpdateCoalescingBatch)
+	}
+	if got, want := cap(coalescer.requests), maxUpdateCoalescingBatch*4; got != want {
+		t.Fatalf("request queue cap=%d want %d", got, want)
+	}
+}
+
 func TestServerUpdateCoalescerEvictsWhenIdle(t *testing.T) {
 	server := NewServer()
 	server.UpdateCoalescingIdleTTL = time.Millisecond

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -601,7 +601,7 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 		DocumentFormat: collections.DocumentFormatBSON,
 	}
 	server.UpdateCoalescingMaxDelay = 20 * time.Millisecond
-	server.UpdateCoalescingMaxBatch = 8
+	server.UpdateCoalescingMaxBatch = 2
 	assertOK(t, serveCommand(t, server, 2260, bson.D{
 		{Key: "insert", Value: "users"},
 		{Key: "documents", Value: bson.A{
@@ -658,7 +658,7 @@ func TestServerUpdateCoalescedBatchIsolatesItemErrors(t *testing.T) {
 		DocumentFormat: collections.DocumentFormatBSON,
 	}
 	server.UpdateCoalescingMaxDelay = 20 * time.Millisecond
-	server.UpdateCoalescingMaxBatch = 8
+	server.UpdateCoalescingMaxBatch = 2
 	assertOK(t, serveCommand(t, server, 2262, bson.D{
 		{Key: "insert", Value: "users"},
 		{Key: "documents", Value: bson.A{
@@ -723,6 +723,26 @@ func TestServerUpdateCoalescedBatchIsolatesItemErrors(t *testing.T) {
 	gotScore, ok := firstBatch[0].Lookup("score").Int32OK()
 	if !ok || gotScore != 12 {
 		t.Fatalf("u2 score=%d ok=%v want 12", gotScore, ok)
+	}
+}
+
+func TestServerCloseStopsUpdateCoalescers(t *testing.T) {
+	server := NewServer()
+	coalescer := server.mongoUpdateCoalescer("app.users")
+	if coalescer == nil {
+		t.Fatal("expected coalescer")
+	}
+	if err := server.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	coalescer.mu.RLock()
+	stopped := coalescer.stopped
+	coalescer.mu.RUnlock()
+	if !stopped {
+		t.Fatal("coalescer was not stopped")
+	}
+	if got := server.mongoUpdateCoalescer("app.users"); got != nil {
+		t.Fatal("closed server created a new coalescer")
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1040,6 +1040,20 @@ func TestMongoUpdateCoalescerUsesSingleCollection(t *testing.T) {
 	if mongoUpdateCoalescerUsesSingleCollection([]mongoUpdateCoalescerRequest{{col: usersA}, {col: posts}}) {
 		t.Fatal("mixed collections reported as single collection")
 	}
+	schemaCol, err := manager.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open users for schema change: %v", err)
+	}
+	if _, err := schemaCol.CreateIndex(collections.IndexDefinition{Name: "email", Field: "email"}); err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+	usersAfterSchemaChange, err := manager.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open users after schema change: %v", err)
+	}
+	if mongoUpdateCoalescerUsesSingleCollection([]mongoUpdateCoalescerRequest{{col: usersA}, {col: usersAfterSchemaChange}}) {
+		t.Fatal("different collection catalog states reported as single collection")
+	}
 }
 
 func TestServerCloseStopsUpdateCoalescers(t *testing.T) {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -746,6 +746,29 @@ func TestServerCloseStopsUpdateCoalescers(t *testing.T) {
 	}
 }
 
+func TestServerUpdateCoalescerEvictsWhenIdle(t *testing.T) {
+	server := NewServer()
+	server.UpdateCoalescingIdleTTL = time.Millisecond
+	coalescer := server.mongoUpdateCoalescer("app.users")
+	if coalescer == nil {
+		t.Fatal("expected coalescer")
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		server.updateMu.Lock()
+		_, stillCached := server.updateCoalescers["app.users"]
+		server.updateMu.Unlock()
+		coalescer.mu.RLock()
+		stopped := coalescer.stopped
+		coalescer.mu.RUnlock()
+		if !stillCached && stopped {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("coalescer was not evicted after idle timeout")
+}
+
 func TestServerUpdateRejectsIDMutation(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -645,6 +645,87 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 	}
 }
 
+func TestServerUpdateCoalescedBatchIsolatesItemErrors(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	server.UpdateCoalescingMaxDelay = 20 * time.Millisecond
+	server.UpdateCoalescingMaxBatch = 8
+	assertOK(t, serveCommand(t, server, 2262, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(0)}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "score", Value: int32(0)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	type updateResponse struct {
+		name string
+		doc  wire.Document
+	}
+	start := make(chan struct{})
+	responses := make(chan updateResponse, 2)
+	var wg sync.WaitGroup
+	for i, tc := range []struct {
+		name string
+		id   string
+		set  bson.D
+	}{
+		{name: "invalid", id: "u1", set: bson.D{{Key: "_id", Value: "moved"}}},
+		{name: "valid", id: "u2", set: bson.D{{Key: "score", Value: int32(12)}}},
+	} {
+		i, tc := i, tc
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			responses <- updateResponse{name: tc.name, doc: serveCommand(t, server, int32(2263+i), bson.D{
+				{Key: "update", Value: "users"},
+				{Key: "updates", Value: bson.A{bson.D{
+					{Key: "q", Value: bson.D{{Key: "_id", Value: tc.id}}},
+					{Key: "u", Value: bson.D{{Key: "$set", Value: tc.set}}},
+				}}},
+				{Key: "$db", Value: "app"},
+			})}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(responses)
+
+	got := make(map[string]wire.Document, 2)
+	for response := range responses {
+		got[response.name] = response.doc
+	}
+	assertCommandError(t, got["invalid"], "BadValue")
+	assertOK(t, got["valid"])
+	assertInt32(t, got["valid"], "n", 1)
+	assertInt32(t, got["valid"], "nModified", 1)
+
+	findResponse := serveCommand(t, server, 2265, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: "u2"}}},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch := cursorFirstBatch(t, findResponse)
+	if len(firstBatch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(firstBatch))
+	}
+	gotScore, ok := firstBatch[0].Lookup("score").Int32OK()
+	if !ok || gotScore != 12 {
+		t.Fatalf("u2 score=%d ok=%v want 12", gotScore, ok)
+	}
+}
+
 func TestServerUpdateRejectsIDMutation(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1071,6 +1071,11 @@ func TestServerCloseStopsUpdateCoalescers(t *testing.T) {
 	if !stopped {
 		t.Fatal("coalescer was not stopped")
 	}
+	select {
+	case <-coalescer.done:
+	default:
+		t.Fatal("Close returned before coalescer worker exited")
+	}
 	if got := server.mongoUpdateCoalescer("app.users"); got != nil {
 		t.Fatal("closed server created a new coalescer")
 	}
@@ -1091,6 +1096,16 @@ func TestMongoUpdateCoalescerRejectsEnqueueAfterStop(t *testing.T) {
 	coalescer.stop()
 	if coalescer.enqueue(mongoUpdateCoalescerRequest{done: make(chan mongoUpdateCoalescerResult, 1)}) {
 		t.Fatal("stopped coalescer accepted enqueue")
+	}
+}
+
+func TestMongoUpdateCoalescerWaitReturnsWhenWorkerStops(t *testing.T) {
+	coalescer := &mongoUpdateCoalescer{done: make(chan struct{})}
+	done := make(chan mongoUpdateCoalescerResult, 1)
+	close(coalescer.done)
+	result := coalescer.waitForUpdateResult(done)
+	if result.err == nil || !strings.Contains(result.err.Error(), "stopped before completing request") {
+		t.Fatalf("result err=%v want stopped error", result.err)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1124,6 +1124,19 @@ func TestCollectionUpdateBatchErrorIndexUsesTypedError(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBatchErrorForRequestUsesCommandIndex(t *testing.T) {
+	err := collectionUpdateBatchErrorForRequest(&collections.UpdateBatchItemError{
+		Index: 2,
+		Err:   errors.New("bad replacement"),
+	}, 0)
+	if err == nil || strings.Contains(err.Error(), "update batch index") {
+		t.Fatalf("request err=%v should not expose coalesced batch index", err)
+	}
+	if !strings.Contains(err.Error(), "updates[0]") || !strings.Contains(err.Error(), "bad replacement") {
+		t.Fatalf("request err=%v want command update index", err)
+	}
+}
+
 func TestMongoUpdateCoalescerUsesSingleCollection(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -1211,6 +1224,40 @@ func TestMongoUpdateCoalescerRejectsEnqueueAfterStop(t *testing.T) {
 	coalescer.stop()
 	if coalescer.enqueue(mongoUpdateCoalescerRequest{done: make(chan mongoUpdateCoalescerResult, 1)}) {
 		t.Fatal("stopped coalescer accepted enqueue")
+	}
+}
+
+func TestMongoUpdateCoalescerCloseDoesNotBlockBehindFullQueue(t *testing.T) {
+	coalescer := &mongoUpdateCoalescer{
+		requests:  make(chan mongoUpdateCoalescerRequest, 1),
+		stoppedCh: make(chan struct{}),
+	}
+	coalescer.requests <- mongoUpdateCoalescerRequest{done: make(chan mongoUpdateCoalescerResult, 1)}
+	enqueueDone := make(chan bool, 1)
+	go func() {
+		enqueueDone <- coalescer.enqueue(mongoUpdateCoalescerRequest{done: make(chan mongoUpdateCoalescerResult, 1)})
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	closed := make(chan bool, 1)
+	go func() {
+		closed <- coalescer.closeRequests()
+	}()
+	select {
+	case ok := <-closed:
+		if !ok {
+			t.Fatal("closeRequests reported false")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("closeRequests blocked behind a full enqueue")
+	}
+	select {
+	case ok := <-enqueueDone:
+		if ok {
+			t.Fatal("enqueue succeeded after close")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("enqueue did not observe close")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds opportunistic same-collection coalescing for single-update Mongo gateway commands. Single-update commands enqueue through a per-collection coalescer, which drains already-waiting requests and applies distinct document IDs via the batched collection update path from the previous PR. Duplicate document IDs fall back to sequential updates to preserve ordering.

The default delay is zero, so the gateway batches only work already queued behind the current command. A positive `UpdateCoalescingMaxDelay` is available for tests/experiments, and a negative value disables coalescing.

## Validation

- `GOWORK=off go test ./TreeDB/mongo_gateway -run 'TestServerUpdate(CoalescesConcurrentDistinctIDs|BatchesDistinctIDs|RejectsIDMutation)' -count=1`
- `GOWORK=off go test ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1`

## Benchmark

Focused 100k-doc / 2-index / BSON / driver-command-raw run with 8 insert producers and 8 concurrent update writers, 80k update commands, no maintenance:

- Pre-coalescing cached-catalog stack: `9,769 docs/sec`, mean driver latency `818 us`
- Coalescing with a 100us wait was a regression: `6,332 docs/sec`, mean driver latency `1,262 us`
- Zero-delay opportunistic coalescing: `22,706 docs/sec`, mean driver latency `351 us`

Profile directory for the winning run: `/tmp/gomap_pr3_coalesce0_profile_wXXJ3K`.