### PR TITLE
[codex] Shrink collection insert mutation lock

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2434,7 +2434,15 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			mutationLocked = true
 		}
 		c.meta = meta
-		pin, currentCatalog, err := c.validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked, snap, catalog, meta, rootNames, baseRootIDs, plan)
+		validation := insertBatchValidationContext{
+			snap:        snap,
+			catalog:     catalog,
+			meta:        meta,
+			rootNames:   rootNames,
+			baseRootIDs: baseRootIDs,
+			plan:        plan,
+		}
+		pin, currentCatalog, err := c.validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked, validation)
 		if err != nil {
 			resetCollectionRunTables(plan.runs)
 			return nil, err
@@ -2456,7 +2464,15 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		mutationLocked = true
 	}
 	c.meta = meta
-	pin, currentCatalog, err := c.validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked, snap, catalog, meta, rootNames, baseRootIDs, plan)
+	validation := insertBatchValidationContext{
+		snap:        snap,
+		catalog:     catalog,
+		meta:        meta,
+		rootNames:   rootNames,
+		baseRootIDs: baseRootIDs,
+		plan:        plan,
+	}
+	pin, currentCatalog, err := c.validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked, validation)
 	if err != nil {
 		resetCollectionRunTables(plan.runs)
 		return nil, err
@@ -2528,23 +2544,32 @@ func insertBatchPlanRootNamesAndBaseIDs(plan *insertBatchPlan, catalog *collecti
 	return rootNames, baseRootIDs
 }
 
-func (c *Collection) validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked bool, snap *backenddb.Snapshot, catalog *collectionCatalog, meta CollectionMeta, rootNames []string, baseRootIDs map[string]uint64, plan *insertBatchPlan) (*backenddb.Snapshot, *collectionCatalog, error) {
+type insertBatchValidationContext struct {
+	snap        *backenddb.Snapshot
+	catalog     *collectionCatalog
+	meta        CollectionMeta
+	rootNames   []string
+	baseRootIDs map[string]uint64
+	plan        *insertBatchPlan
+}
+
+func (c *Collection) validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked bool, validation insertBatchValidationContext) (*backenddb.Snapshot, *collectionCatalog, error) {
 	if plannedWithMutationLocked {
-		if err := c.validateInsertBatchPlanWithSnapshotLocked(snap, catalog, meta, rootNames, baseRootIDs, plan); err != nil {
-			_ = snap.Close()
+		if err := c.validateInsertBatchPlanWithSnapshotLocked(validation); err != nil {
+			_ = validation.snap.Close()
 			return nil, nil, err
 		}
-		return snap, catalog, nil
+		return validation.snap, validation.catalog, nil
 	}
-	current, currentCatalog, err := c.validateInsertBatchPlanLocked(meta, rootNames, baseRootIDs, plan)
-	_ = snap.Close()
+	current, currentCatalog, err := c.validateInsertBatchPlanLocked(validation)
+	_ = validation.snap.Close()
 	if err != nil {
 		return nil, nil, err
 	}
 	return current, currentCatalog, nil
 }
 
-func (c *Collection) validateInsertBatchPlanLocked(meta CollectionMeta, rootNames []string, baseRootIDs map[string]uint64, plan *insertBatchPlan) (*backenddb.Snapshot, *collectionCatalog, error) {
+func (c *Collection) validateInsertBatchPlanLocked(validation insertBatchValidationContext) (*backenddb.Snapshot, *collectionCatalog, error) {
 	if c == nil || c.db == nil {
 		return nil, nil, backenddb.ErrClosed
 	}
@@ -2552,7 +2577,7 @@ func (c *Collection) validateInsertBatchPlanLocked(meta CollectionMeta, rootName
 	if current == nil {
 		return nil, nil, backenddb.ErrClosed
 	}
-	catalog, err := loadCollectionCatalog(current, meta.Name)
+	catalog, err := loadCollectionCatalog(current, validation.meta.Name)
 	if err != nil {
 		_ = current.Close()
 		return nil, nil, err
@@ -2561,33 +2586,35 @@ func (c *Collection) validateInsertBatchPlanLocked(meta CollectionMeta, rootName
 		_ = current.Close()
 		return nil, nil, errCollectionNotFound
 	}
-	if err := c.validateInsertBatchPlanWithSnapshotLocked(current, catalog, meta, rootNames, baseRootIDs, plan); err != nil {
+	validation.snap = current
+	validation.catalog = catalog
+	if err := c.validateInsertBatchPlanWithSnapshotLocked(validation); err != nil {
 		_ = current.Close()
 		return nil, nil, err
 	}
 	return current, catalog, nil
 }
 
-func (c *Collection) validateInsertBatchPlanWithSnapshotLocked(snap *backenddb.Snapshot, catalog *collectionCatalog, meta CollectionMeta, rootNames []string, baseRootIDs map[string]uint64, plan *insertBatchPlan) error {
-	if c == nil || c.db == nil || snap == nil {
+func (c *Collection) validateInsertBatchPlanWithSnapshotLocked(validation insertBatchValidationContext) error {
+	if c == nil || c.db == nil || validation.snap == nil {
 		return backenddb.ErrClosed
 	}
-	if catalog == nil {
+	if validation.catalog == nil {
 		return errCollectionNotFound
 	}
-	if !sameCollectionMeta(catalog.meta, meta) {
-		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
+	if !sameCollectionMeta(validation.catalog.meta, validation.meta) {
+		return fmt.Errorf("collections: concurrent schema modification detected for %q", validation.meta.Name)
 	}
-	for _, rootName := range rootNames {
-		want, ok := baseRootIDs[rootName]
+	for _, rootName := range validation.rootNames {
+		want, ok := validation.baseRootIDs[rootName]
 		if !ok {
-			return fmt.Errorf("collections: insert plan missing base root id for %q", rootName)
+			return fmt.Errorf("collections: insert plan missing base root id for collection %q root %q", validation.meta.Name, rootName)
 		}
-		if got := catalog.rootID(rootName); got != want {
-			return errConcurrentRootModification(meta.Name, rootName)
+		if got := validation.catalog.rootID(rootName); got != want {
+			return errConcurrentRootModification(validation.meta.Name, rootName)
 		}
 	}
-	return plan.checkPersistedConflicts(snap, catalog)
+	return validation.plan.checkPersistedConflicts(validation.snap, validation.catalog)
 }
 
 func collectionOptionsWithTrustedBSONDocuments(opts collectionOptions, trusted bool) (collectionOptions, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1071,12 +1071,12 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	if len(domain.rootBaseIDs) > 0 {
 		for rootName, baseRootID := range domain.rootBaseIDs {
 			if rootID := catalog.rootID(rootName); rootID != baseRootID {
-				return nil, fmt.Errorf("collections: %w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
+				return nil, errConcurrentRootModification(domain.meta.Name, rootName)
 			}
 		}
 	} else {
 		if rootID := catalog.rootID(primaryRootName); rootID != domain.primaryRoot {
-			return nil, fmt.Errorf("collections: %w: concurrent root modification detected for %q", ErrConcurrentMutation, primaryRootName)
+			return nil, errConcurrentRootModification(domain.meta.Name, primaryRootName)
 		}
 	}
 	options, err := collectionPlannerOptions(catalog.meta)
@@ -1178,7 +1178,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
 	}
 	if got := pinnedCatalog.rootID(rootName); got != baseRoot {
-		return fmt.Errorf("collections: %w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
+		return errConcurrentRootModification(meta.Name, rootName)
 	}
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
@@ -1254,7 +1254,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 		}
 		for rootName, baseRoot := range domain.rootBaseIDs {
 			if got := currentCatalog.rootID(rootName); got != baseRoot {
-				return 0, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
+				return 0, errConcurrentRootModification(catalog.meta.Name, rootName)
 			}
 		}
 		catalog = currentCatalog
@@ -2062,7 +2062,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 	}
 	for rootName, baseRoot := range domain.rootBaseIDs {
 		if got := pinnedCatalog.rootID(rootName); got != baseRoot {
-			return fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
+			return errConcurrentRootModification(meta.Name, rootName)
 		}
 	}
 
@@ -2542,7 +2542,7 @@ func (c *Collection) validateInsertBatchPlanLocked(meta CollectionMeta, rootName
 		}
 		if got := catalog.rootID(rootName); got != want {
 			_ = current.Close()
-			return nil, nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
+			return nil, nil, errConcurrentRootModification(meta.Name, rootName)
 		}
 	}
 	if err := plan.checkPersistedConflicts(current, catalog); err != nil {
@@ -2974,7 +2974,11 @@ func collectionMutationRetryExhausted(err error) error {
 	if err == nil {
 		err = ErrConcurrentMutation
 	}
-	return fmt.Errorf("%w: retry budget exceeded after %d attempts: %v", ErrConcurrentMutation, maxCollectionMutationRetries, err)
+	return fmt.Errorf("collections: retry budget exceeded after %d attempts: %w", maxCollectionMutationRetries, err)
+}
+
+func errConcurrentRootModification(collectionName, rootName string) error {
+	return fmt.Errorf("%w: concurrent root modification detected for collection=%q root=%q", ErrConcurrentMutation, collectionName, rootName)
 }
 
 func (c *Collection) updateDocumentOnce(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
@@ -3967,7 +3971,7 @@ func (c *Collection) validateRootDescriptorSystemDelta(expectedCommitSeq, expect
 		}
 		for _, rootName := range rootNames {
 			if got, want := catalog.rootID(rootName), baseRootIDs[rootName]; got != want {
-				return fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
+				return errConcurrentRootModification(c.meta.Name, rootName)
 			}
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2339,32 +2339,38 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	if snap == nil {
 		return nil, backenddb.ErrClosed
 	}
+	closePlanningSnapshot := func() {
+		if snap != nil {
+			_ = snap.Close()
+			snap = nil
+		}
+	}
 	catalog, err := c.catalogForSnapshot(snap)
 	if err != nil {
-		_ = snap.Close()
+		closePlanningSnapshot()
 		return nil, err
 	}
 	if catalog == nil {
-		_ = snap.Close()
+		closePlanningSnapshot()
 		return nil, errCollectionNotFound
 	}
 	meta := catalog.meta
 	c.meta = meta
 	plannerOptions, err := collectionPlannerOptions(meta)
 	if err != nil {
-		_ = snap.Close()
+		closePlanningSnapshot()
 		return nil, err
 	}
 	plannerOptions, err = collectionOptionsWithTrustedBSONDocuments(plannerOptions, trustedValidBSON)
 	if err != nil {
-		_ = snap.Close()
+		closePlanningSnapshot()
 		return nil, err
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 	indexedMemtablesEnabled := c.shouldBufferIndexedInserts(meta)
 	bufferIndexedInserts := c.shouldBufferIndexedInsertBatch(meta, len(documents))
 	if indexedMemtablesEnabled && !bufferIndexedInserts {
-		_ = snap.Close()
+		closePlanningSnapshot()
 		if err := c.flushBufferedWrites(); err != nil {
 			return nil, err
 		}
@@ -2374,23 +2380,23 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		}
 		catalog, err = c.catalogForSnapshot(snap)
 		if err != nil {
-			_ = snap.Close()
+			closePlanningSnapshot()
 			return nil, err
 		}
 		if catalog == nil {
-			_ = snap.Close()
+			closePlanningSnapshot()
 			return nil, errCollectionNotFound
 		}
 		meta = catalog.meta
 		c.meta = meta
 		plannerOptions, err = collectionPlannerOptions(meta)
 		if err != nil {
-			_ = snap.Close()
+			closePlanningSnapshot()
 			return nil, err
 		}
 		plannerOptions, err = collectionOptionsWithTrustedBSONDocuments(plannerOptions, trustedValidBSON)
 		if err != nil {
-			_ = snap.Close()
+			closePlanningSnapshot()
 			return nil, err
 		}
 		plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
@@ -2409,6 +2415,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 
 	unlockForPlanning := shouldUnlockInsertPlanning(plannerOptions, indexedMemtablesEnabled, bufferIndexedInserts)
 	if unlockForPlanning {
+		closePlanningSnapshot()
 		unlockIfLocked()
 	}
 
@@ -2426,7 +2433,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	}
 	plan, err := planner.planInsertBatch(ids, documents)
 	if err != nil {
-		_ = snap.Close()
+		closePlanningSnapshot()
 		return nil, err
 	}
 	if bufferIndexedInserts {
@@ -2435,7 +2442,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		plan.stats.BufferedIndexedBypassBatches = 1
 	}
 	if len(plan.runs) == 0 {
-		_ = snap.Close()
+		closePlanningSnapshot()
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
 		return plan.resultIDs, nil
 	}
@@ -2445,30 +2452,16 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	if bufferIndexedInserts {
 		resultIDs, err := cloneBatchDocumentIDs(plan.resultIDs)
 		if err != nil {
-			_ = snap.Close()
+			closePlanningSnapshot()
 			resetCollectionRunTables(plan.runs)
 			return nil, err
 		}
-		plannedWithMutationLocked := mutationLocked
-		if !mutationLocked {
-			unlockMutation = c.lockMutation()
-			mutationLocked = true
-		}
-		c.meta = meta
-		validation := insertBatchValidationContext{
-			snap:        snap,
-			catalog:     catalog,
-			meta:        meta,
-			rootNames:   rootNames,
-			baseRootIDs: baseRootIDs,
-			plan:        plan,
-		}
-		pin, currentCatalog, err := c.validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked, validation)
+		pin, currentCatalog, pinCommitSeq, pinSystemRoot, err := c.lockAndValidateInsertBatchPlan(&mutationLocked, &unlockMutation, snap, catalog, meta, rootNames, baseRootIDs, plan)
 		if err != nil {
 			resetCollectionRunTables(plan.runs)
 			return nil, err
 		}
-		bufferFlushElapsed, err := c.bufferIndexedInsertPlanLocked(currentCatalog, snapshotCommitSeq(pin), snapshotSystemRoot(pin), plan)
+		bufferFlushElapsed, err := c.bufferIndexedInsertPlanLocked(currentCatalog, pinCommitSeq, pinSystemRoot, plan)
 		_ = pin.Close()
 		if err != nil {
 			resetCollectionRunTables(plan.runs)
@@ -2479,27 +2472,13 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		return resultIDs, nil
 	}
 
-	plannedWithMutationLocked := mutationLocked
-	if !mutationLocked {
-		unlockMutation = c.lockMutation()
-		mutationLocked = true
-	}
-	c.meta = meta
-	validation := insertBatchValidationContext{
-		snap:        snap,
-		catalog:     catalog,
-		meta:        meta,
-		rootNames:   rootNames,
-		baseRootIDs: baseRootIDs,
-		plan:        plan,
-	}
-	pin, currentCatalog, err := c.validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked, validation)
+	pin, currentCatalog, pinCommitSeq, pinSystemRoot, err := c.lockAndValidateInsertBatchPlan(&mutationLocked, &unlockMutation, snap, catalog, meta, rootNames, baseRootIDs, plan)
 	if err != nil {
 		resetCollectionRunTables(plan.runs)
 		return nil, err
 	}
-	baseCommitSeq = snapshotCommitSeq(pin)
-	baseSystemRoot = snapshotSystemRoot(pin)
+	baseCommitSeq = pinCommitSeq
+	baseSystemRoot = pinSystemRoot
 	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
 	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = pin.Close() }()
@@ -2574,6 +2553,37 @@ type insertBatchValidationContext struct {
 	plan        *insertBatchPlan
 }
 
+func (c *Collection) lockAndValidateInsertBatchPlan(
+	mutationLocked *bool,
+	unlockMutation *func(),
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	meta CollectionMeta,
+	rootNames []string,
+	baseRootIDs map[string]uint64,
+	plan *insertBatchPlan,
+) (*backenddb.Snapshot, *collectionCatalog, uint64, uint64, error) {
+	plannedWithMutationLocked := *mutationLocked
+	if !*mutationLocked {
+		*unlockMutation = c.lockMutation()
+		*mutationLocked = true
+	}
+	c.meta = meta
+	validation := insertBatchValidationContext{
+		snap:        snap,
+		catalog:     catalog,
+		meta:        meta,
+		rootNames:   rootNames,
+		baseRootIDs: baseRootIDs,
+		plan:        plan,
+	}
+	pin, currentCatalog, err := c.validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked, validation)
+	if err != nil {
+		return nil, nil, 0, 0, err
+	}
+	return pin, currentCatalog, snapshotCommitSeq(pin), snapshotSystemRoot(pin), nil
+}
+
 func (c *Collection) validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked bool, validation insertBatchValidationContext) (*backenddb.Snapshot, *collectionCatalog, error) {
 	if plannedWithMutationLocked {
 		if err := c.validateInsertBatchPlanWithSnapshotLocked(validation); err != nil {
@@ -2583,7 +2593,9 @@ func (c *Collection) validateInsertBatchPlanAfterPlanningLocked(plannedWithMutat
 		return validation.snap, validation.catalog, nil
 	}
 	current, currentCatalog, err := c.validateInsertBatchPlanLocked(validation)
-	_ = validation.snap.Close()
+	if validation.snap != nil {
+		_ = validation.snap.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1039,12 +1039,12 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	if len(domain.rootBaseIDs) > 0 {
 		for rootName, baseRootID := range domain.rootBaseIDs {
 			if rootID := catalog.rootID(rootName); rootID != baseRootID {
-				return nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, domain.meta.Name)
+				return nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
 			}
 		}
 	} else {
 		if rootID := catalog.rootID(primaryRootName); rootID != domain.primaryRoot {
-			return nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, domain.meta.Name)
+			return nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, primaryRootName)
 		}
 	}
 	options, err := collectionPlannerOptions(catalog.meta)
@@ -2503,7 +2503,12 @@ func (c *Collection) validateInsertBatchPlanLocked(meta CollectionMeta, rootName
 		return nil, nil, fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
 	}
 	for _, rootName := range rootNames {
-		if got, want := catalog.rootID(rootName), baseRootIDs[rootName]; got != want {
+		want, ok := baseRootIDs[rootName]
+		if !ok {
+			_ = current.Close()
+			return nil, nil, fmt.Errorf("collections: insert plan missing base root id for %q", rootName)
+		}
+		if got := catalog.rootID(rootName); got != want {
 			_ = current.Close()
 			return nil, nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2425,18 +2425,8 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			mutationLocked = true
 		}
 		c.meta = meta
-		pin := snap
-		currentCatalog := catalog
-		if plannedWithMutationLocked {
-			err = c.validateInsertBatchPlanWithSnapshotLocked(snap, catalog, meta, rootNames, baseRootIDs, plan)
-		} else {
-			pin, currentCatalog, err = c.validateInsertBatchPlanLocked(meta, rootNames, baseRootIDs, plan)
-			_ = snap.Close()
-		}
+		pin, currentCatalog, err := c.validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked, snap, catalog, meta, rootNames, baseRootIDs, plan)
 		if err != nil {
-			if plannedWithMutationLocked {
-				_ = snap.Close()
-			}
 			resetCollectionRunTables(plan.runs)
 			return nil, err
 		}
@@ -2457,18 +2447,8 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		mutationLocked = true
 	}
 	c.meta = meta
-	pin := snap
-	currentCatalog := catalog
-	if plannedWithMutationLocked {
-		err = c.validateInsertBatchPlanWithSnapshotLocked(snap, catalog, meta, rootNames, baseRootIDs, plan)
-	} else {
-		pin, currentCatalog, err = c.validateInsertBatchPlanLocked(meta, rootNames, baseRootIDs, plan)
-		_ = snap.Close()
-	}
+	pin, currentCatalog, err := c.validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked, snap, catalog, meta, rootNames, baseRootIDs, plan)
 	if err != nil {
-		if plannedWithMutationLocked {
-			_ = snap.Close()
-		}
 		resetCollectionRunTables(plan.runs)
 		return nil, err
 	}
@@ -2537,6 +2517,22 @@ func insertBatchPlanRootNamesAndBaseIDs(plan *insertBatchPlan, catalog *collecti
 		}
 	}
 	return rootNames, baseRootIDs
+}
+
+func (c *Collection) validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked bool, snap *backenddb.Snapshot, catalog *collectionCatalog, meta CollectionMeta, rootNames []string, baseRootIDs map[string]uint64, plan *insertBatchPlan) (*backenddb.Snapshot, *collectionCatalog, error) {
+	if plannedWithMutationLocked {
+		if err := c.validateInsertBatchPlanWithSnapshotLocked(snap, catalog, meta, rootNames, baseRootIDs, plan); err != nil {
+			_ = snap.Close()
+			return nil, nil, err
+		}
+		return snap, catalog, nil
+	}
+	current, currentCatalog, err := c.validateInsertBatchPlanLocked(meta, rootNames, baseRootIDs, plan)
+	_ = snap.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+	return current, currentCatalog, nil
 }
 
 func (c *Collection) validateInsertBatchPlanLocked(meta CollectionMeta, rootNames []string, baseRootIDs map[string]uint64, plan *insertBatchPlan) (*backenddb.Snapshot, *collectionCatalog, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1030,12 +1030,12 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	if len(domain.rootBaseIDs) > 0 {
 		for rootName, baseRootID := range domain.rootBaseIDs {
 			if rootID := catalog.rootID(rootName); rootID != baseRootID {
-				return nil, fmt.Errorf("collections: concurrent root modification detected for %q", domain.meta.Name)
+				return nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, domain.meta.Name)
 			}
 		}
 	} else {
 		if rootID := catalog.rootID(primaryRootName); rootID != domain.primaryRoot {
-			return nil, fmt.Errorf("collections: concurrent root modification detected for %q", domain.meta.Name)
+			return nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, domain.meta.Name)
 		}
 	}
 	options, err := collectionPlannerOptions(catalog.meta)
@@ -1137,7 +1137,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
 	}
 	if got := pinnedCatalog.rootID(rootName); got != baseRoot {
-		return fmt.Errorf("collections: concurrent root modification detected for %q", meta.Name)
+		return fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, meta.Name)
 	}
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
@@ -2021,7 +2021,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 	}
 	for rootName, baseRoot := range domain.rootBaseIDs {
 		if got := pinnedCatalog.rootID(rootName); got != baseRoot {
-			return fmt.Errorf("collections: concurrent root modification detected for %q", rootName)
+			return fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
 		}
 	}
 
@@ -2216,8 +2216,31 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 	if c.db == nil {
 		return nil, errors.New("collections: db is nil")
 	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
+		resultIDs, err := c.insertBatchOnce(ids, documents, trustedValidBSON)
+		if errors.Is(err, ErrConcurrentMutation) {
+			lastErr = err
+			waitBeforeCollectionMutationRetry(attempt)
+			continue
+		}
+		return resultIDs, err
+	}
+	return nil, collectionMutationRetryExhausted(lastErr)
+}
+
+func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON bool) ([][]byte, error) {
 	unlockMutation := c.lockMutation()
-	defer unlockMutation()
+	mutationLocked := true
+	unlockIfLocked := func() {
+		if mutationLocked {
+			unlockMutation()
+			mutationLocked = false
+		}
+	}
+	defer unlockIfLocked()
+
 	if len(documents) == 0 {
 		c.setLastInsertStats(CollectionInsertStats{
 			Documents: 0,
@@ -2242,8 +2265,9 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 		_ = snap.Close()
 		return nil, errCollectionNotFound
 	}
-	c.meta = catalog.meta
-	plannerOptions, err := collectionPlannerOptions(c.meta)
+	meta := catalog.meta
+	c.meta = meta
+	plannerOptions, err := collectionPlannerOptions(meta)
 	if err != nil {
 		_ = snap.Close()
 		return nil, err
@@ -2254,8 +2278,8 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 		return nil, err
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
-	indexedMemtablesEnabled := c.shouldBufferIndexedInserts(c.meta)
-	bufferIndexedInserts := c.shouldBufferIndexedInsertBatch(c.meta, len(documents))
+	indexedMemtablesEnabled := c.shouldBufferIndexedInserts(meta)
+	bufferIndexedInserts := c.shouldBufferIndexedInsertBatch(meta, len(documents))
 	if indexedMemtablesEnabled && !bufferIndexedInserts {
 		_ = snap.Close()
 		if err := c.flushBufferedWrites(); err != nil {
@@ -2274,8 +2298,9 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 			_ = snap.Close()
 			return nil, errCollectionNotFound
 		}
-		c.meta = catalog.meta
-		plannerOptions, err = collectionPlannerOptions(c.meta)
+		meta = catalog.meta
+		c.meta = meta
+		plannerOptions, err = collectionPlannerOptions(meta)
 		if err != nil {
 			_ = snap.Close()
 			return nil, err
@@ -2286,36 +2311,37 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 			return nil, err
 		}
 		plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
-		indexedMemtablesEnabled = c.shouldBufferIndexedInserts(c.meta)
-		bufferIndexedInserts = c.shouldBufferIndexedInsertBatch(c.meta, len(documents))
+		indexedMemtablesEnabled = c.shouldBufferIndexedInserts(meta)
+		bufferIndexedInserts = c.shouldBufferIndexedInsertBatch(meta, len(documents))
 	}
 	if bufferIndexedInserts {
-		plannerOptions = collectionOptionsWithBufferedTemplateV1Resolver(plannerOptions, c.writeDomain, c.meta.Name)
+		plannerOptions = collectionOptionsWithBufferedTemplateV1Resolver(plannerOptions, c.writeDomain, meta.Name)
 	}
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 
-	if len(c.meta.Indexes) == 0 && plannerOptions.documentFormat == DocumentFormatJSON {
+	if len(meta.Indexes) == 0 && plannerOptions.documentFormat == DocumentFormatJSON {
 		return c.insertBatchNoIndex(catalog, snap, baseCommitSeq, baseSystemRoot, plannerOptions, ids, documents)
 	}
 
+	unlockForPlanning := plannerOptions.documentFormat != DocumentFormatTemplateV1
+	if unlockForPlanning {
+		unlockIfLocked()
+	}
+
 	planner := insertBatchPlanner{
-		collection:     c.meta.Name,
-		primaryRoot:    collectionPrimaryRootName(c.meta.Name),
-		templateRoot:   collectionTemplateRootName(c.meta.Name),
-		indexStateRoot: collectionIndexStateRootName(c.meta.Name),
-		indexes:        plannerIndexes(c.meta.Indexes),
+		collection:     meta.Name,
+		primaryRoot:    collectionPrimaryRootName(meta.Name),
+		templateRoot:   collectionTemplateRootName(meta.Name),
+		indexStateRoot: collectionIndexStateRootName(meta.Name),
+		indexes:        plannerIndexes(meta.Indexes),
 		options:        plannerOptions,
 	}
 	if bufferIndexedInserts {
 		planner.buildPrimaryVal = clonePrimaryDocument
 		planner.cloneTemplateRunValues = true
 	}
-	plan, err := planner.planInsertBatchWithPreflight(ids, documents, insertBatchPreflight{
-		snapshot:           snap,
-		primaryRootID:      catalog.rootID(collectionPrimaryRootName(c.meta.Name)),
-		uniqueIndexRootIDs: uniqueIndexRootIDs(catalog),
-	})
+	plan, err := planner.planInsertBatch(ids, documents)
 	if err != nil {
 		_ = snap.Close()
 		return nil, err
@@ -2331,6 +2357,8 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 		return plan.resultIDs, nil
 	}
 
+	rootNames, baseRootIDs := insertBatchPlanRootNamesAndBaseIDs(plan, catalog)
+
 	if bufferIndexedInserts {
 		resultIDs, err := cloneBatchDocumentIDs(plan.resultIDs)
 		if err != nil {
@@ -2338,8 +2366,19 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 			resetCollectionRunTables(plan.runs)
 			return nil, err
 		}
-		bufferFlushElapsed, err := c.bufferIndexedInsertPlanLocked(catalog, baseCommitSeq, baseSystemRoot, plan)
+		if !mutationLocked {
+			unlockMutation = c.lockMutation()
+			mutationLocked = true
+		}
+		c.meta = meta
+		pin, currentCatalog, err := c.validateInsertBatchPlanLocked(meta, rootNames, baseRootIDs, plan)
 		_ = snap.Close()
+		if err != nil {
+			resetCollectionRunTables(plan.runs)
+			return nil, err
+		}
+		bufferFlushElapsed, err := c.bufferIndexedInsertPlanLocked(currentCatalog, snapshotCommitSeq(pin), snapshotSystemRoot(pin), plan)
+		_ = pin.Close()
 		if err != nil {
 			resetCollectionRunTables(plan.runs)
 			return nil, err
@@ -2349,13 +2388,22 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 		return resultIDs, nil
 	}
 
-	baseRootIDs := make(map[string]uint64, len(plan.runs))
-	for _, run := range plan.runs {
-		baseRootIDs[run.name] = catalog.rootID(run.name)
+	if !mutationLocked {
+		unlockMutation = c.lockMutation()
+		mutationLocked = true
 	}
+	c.meta = meta
+	pin, currentCatalog, err := c.validateInsertBatchPlanLocked(meta, rootNames, baseRootIDs, plan)
+	_ = snap.Close()
+	if err != nil {
+		resetCollectionRunTables(plan.runs)
+		return nil, err
+	}
+	baseCommitSeq = snapshotCommitSeq(pin)
+	baseSystemRoot = snapshotSystemRoot(pin)
 	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
 	// base roots before stale-root validation rejects concurrent modifications.
-	defer func() { _ = snap.Close() }()
+	defer func() { _ = pin.Close() }()
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.runs))
 	iterators := make([]iterator.UnsafeIterator, 0, len(plan.runs))
@@ -2375,10 +2423,6 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 		})
 	}
 
-	rootNames := make([]string, len(plan.runs))
-	for i, run := range plan.runs {
-		rootNames[i] = run.name
-	}
 	publishStart := time.Now()
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
@@ -2390,11 +2434,60 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 	if len(rootIDs) != len(plan.runs) {
 		return nil, errors.New("collections: ordered root publish returned unexpected root count")
 	}
-	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
+	nextCatalog := cloneCatalogWithRootUpdates(currentCatalog, meta, rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	c.setLastInsertStats(plan.stats.CollectionInsertStats)
 	return plan.resultIDs, nil
+}
+
+func insertBatchPlanRootNamesAndBaseIDs(plan *insertBatchPlan, catalog *collectionCatalog) ([]string, map[string]uint64) {
+	if plan == nil {
+		return nil, nil
+	}
+	rootNames := make([]string, len(plan.runs))
+	baseRootIDs := make(map[string]uint64, len(plan.runs))
+	for i, run := range plan.runs {
+		rootNames[i] = run.name
+		if catalog != nil {
+			baseRootIDs[run.name] = catalog.rootID(run.name)
+		}
+	}
+	return rootNames, baseRootIDs
+}
+
+func (c *Collection) validateInsertBatchPlanLocked(meta CollectionMeta, rootNames []string, baseRootIDs map[string]uint64, plan *insertBatchPlan) (*backenddb.Snapshot, *collectionCatalog, error) {
+	if c == nil || c.db == nil {
+		return nil, nil, backenddb.ErrClosed
+	}
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return nil, nil, backenddb.ErrClosed
+	}
+	catalog, err := loadCollectionCatalog(current, meta.Name)
+	if err != nil {
+		_ = current.Close()
+		return nil, nil, err
+	}
+	if catalog == nil {
+		_ = current.Close()
+		return nil, nil, errCollectionNotFound
+	}
+	if !sameCollectionMeta(catalog.meta, meta) {
+		_ = current.Close()
+		return nil, nil, fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
+	}
+	for _, rootName := range rootNames {
+		if got, want := catalog.rootID(rootName), baseRootIDs[rootName]; got != want {
+			_ = current.Close()
+			return nil, nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
+		}
+	}
+	if err := plan.checkPersistedConflicts(current, catalog); err != nil {
+		_ = current.Close()
+		return nil, nil, err
+	}
+	return current, catalog, nil
 }
 
 func collectionOptionsWithTrustedBSONDocuments(opts collectionOptions, trusted bool) (collectionOptions, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2545,12 +2545,13 @@ func insertBatchPlanRootNamesAndBaseIDs(plan *insertBatchPlan, catalog *collecti
 }
 
 type insertBatchValidationContext struct {
-	snap        *backenddb.Snapshot
-	catalog     *collectionCatalog
-	meta        CollectionMeta
-	rootNames   []string
-	baseRootIDs map[string]uint64
-	plan        *insertBatchPlan
+	snap           *backenddb.Snapshot
+	catalog        *collectionCatalog
+	meta           CollectionMeta
+	rootNames      []string
+	baseRootIDs    map[string]uint64
+	plan           *insertBatchPlan
+	allowRootDrift bool
 }
 
 func (c *Collection) lockAndValidateInsertBatchPlan(
@@ -2570,18 +2571,31 @@ func (c *Collection) lockAndValidateInsertBatchPlan(
 	}
 	c.meta = meta
 	validation := insertBatchValidationContext{
-		snap:        snap,
-		catalog:     catalog,
-		meta:        meta,
-		rootNames:   rootNames,
-		baseRootIDs: baseRootIDs,
-		plan:        plan,
+		snap:           snap,
+		catalog:        catalog,
+		meta:           meta,
+		rootNames:      rootNames,
+		baseRootIDs:    baseRootIDs,
+		plan:           plan,
+		allowRootDrift: !plannedWithMutationLocked,
 	}
 	pin, currentCatalog, err := c.validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked, validation)
 	if err != nil {
 		return nil, nil, 0, 0, err
 	}
+	if !plannedWithMutationLocked {
+		updateInsertBatchBaseRootIDs(rootNames, baseRootIDs, currentCatalog)
+	}
 	return pin, currentCatalog, snapshotCommitSeq(pin), snapshotSystemRoot(pin), nil
+}
+
+func updateInsertBatchBaseRootIDs(rootNames []string, baseRootIDs map[string]uint64, catalog *collectionCatalog) {
+	if catalog == nil || baseRootIDs == nil {
+		return
+	}
+	for _, rootName := range rootNames {
+		baseRootIDs[rootName] = catalog.rootID(rootName)
+	}
 }
 
 func (c *Collection) validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked bool, validation insertBatchValidationContext) (*backenddb.Snapshot, *collectionCatalog, error) {
@@ -2643,7 +2657,7 @@ func (c *Collection) validateInsertBatchPlanWithSnapshotLocked(validation insert
 		if !ok {
 			return fmt.Errorf("collections: insert plan missing base root id collection=%q root=%q", validation.meta.Name, rootName)
 		}
-		if got := validation.catalog.rootID(rootName); got != want {
+		if got := validation.catalog.rootID(rootName); got != want && !validation.allowRootDrift {
 			return errConcurrentRootModification(validation.meta.Name, rootName)
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2629,7 +2629,7 @@ func (c *Collection) validateInsertBatchPlanWithSnapshotLocked(validation insert
 	for _, rootName := range validation.rootNames {
 		want, ok := validation.baseRootIDs[rootName]
 		if !ok {
-			return fmt.Errorf("collections: insert plan missing base root id for collection %q root %q", validation.meta.Name, rootName)
+			return fmt.Errorf("collections: insert plan missing base root id collection=%q root=%q", validation.meta.Name, rootName)
 		}
 		if got := validation.catalog.rootID(rootName); got != want {
 			return errConcurrentRootModification(validation.meta.Name, rootName)
@@ -3069,6 +3069,9 @@ func validateBSONReplacementPreservesID(current, replacement []byte, opts collec
 }
 
 func waitBeforeCollectionMutationRetry(attempt int) {
+	if attempt+1 >= maxCollectionMutationRetries {
+		return
+	}
 	if attempt < 4 {
 		runtime.Gosched()
 		return

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2418,14 +2418,24 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			resetCollectionRunTables(plan.runs)
 			return nil, err
 		}
+		plannedWithMutationLocked := mutationLocked
 		if !mutationLocked {
 			unlockMutation = c.lockMutation()
 			mutationLocked = true
 		}
 		c.meta = meta
-		pin, currentCatalog, err := c.validateInsertBatchPlanLocked(meta, rootNames, baseRootIDs, plan)
-		_ = snap.Close()
+		pin := snap
+		currentCatalog := catalog
+		if plannedWithMutationLocked {
+			err = c.validateInsertBatchPlanWithSnapshotLocked(snap, catalog, meta, rootNames, baseRootIDs, plan)
+		} else {
+			pin, currentCatalog, err = c.validateInsertBatchPlanLocked(meta, rootNames, baseRootIDs, plan)
+			_ = snap.Close()
+		}
 		if err != nil {
+			if plannedWithMutationLocked {
+				_ = snap.Close()
+			}
 			resetCollectionRunTables(plan.runs)
 			return nil, err
 		}
@@ -2440,14 +2450,24 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		return resultIDs, nil
 	}
 
+	plannedWithMutationLocked := mutationLocked
 	if !mutationLocked {
 		unlockMutation = c.lockMutation()
 		mutationLocked = true
 	}
 	c.meta = meta
-	pin, currentCatalog, err := c.validateInsertBatchPlanLocked(meta, rootNames, baseRootIDs, plan)
-	_ = snap.Close()
+	pin := snap
+	currentCatalog := catalog
+	if plannedWithMutationLocked {
+		err = c.validateInsertBatchPlanWithSnapshotLocked(snap, catalog, meta, rootNames, baseRootIDs, plan)
+	} else {
+		pin, currentCatalog, err = c.validateInsertBatchPlanLocked(meta, rootNames, baseRootIDs, plan)
+		_ = snap.Close()
+	}
 	if err != nil {
+		if plannedWithMutationLocked {
+			_ = snap.Close()
+		}
 		resetCollectionRunTables(plan.runs)
 		return nil, err
 	}
@@ -2535,26 +2555,33 @@ func (c *Collection) validateInsertBatchPlanLocked(meta CollectionMeta, rootName
 		_ = current.Close()
 		return nil, nil, errCollectionNotFound
 	}
-	if !sameCollectionMeta(catalog.meta, meta) {
-		_ = current.Close()
-		return nil, nil, fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
-	}
-	for _, rootName := range rootNames {
-		want, ok := baseRootIDs[rootName]
-		if !ok {
-			_ = current.Close()
-			return nil, nil, fmt.Errorf("collections: insert plan missing base root id for %q", rootName)
-		}
-		if got := catalog.rootID(rootName); got != want {
-			_ = current.Close()
-			return nil, nil, errConcurrentRootModification(meta.Name, rootName)
-		}
-	}
-	if err := plan.checkPersistedConflicts(current, catalog); err != nil {
+	if err := c.validateInsertBatchPlanWithSnapshotLocked(current, catalog, meta, rootNames, baseRootIDs, plan); err != nil {
 		_ = current.Close()
 		return nil, nil, err
 	}
 	return current, catalog, nil
+}
+
+func (c *Collection) validateInsertBatchPlanWithSnapshotLocked(snap *backenddb.Snapshot, catalog *collectionCatalog, meta CollectionMeta, rootNames []string, baseRootIDs map[string]uint64, plan *insertBatchPlan) error {
+	if c == nil || c.db == nil || snap == nil {
+		return backenddb.ErrClosed
+	}
+	if catalog == nil {
+		return errCollectionNotFound
+	}
+	if !sameCollectionMeta(catalog.meta, meta) {
+		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
+	}
+	for _, rootName := range rootNames {
+		want, ok := baseRootIDs[rootName]
+		if !ok {
+			return fmt.Errorf("collections: insert plan missing base root id for %q", rootName)
+		}
+		if got := catalog.rootID(rootName); got != want {
+			return errConcurrentRootModification(meta.Name, rootName)
+		}
+	}
+	return plan.checkPersistedConflicts(snap, catalog)
 }
 
 func collectionOptionsWithTrustedBSONDocuments(opts collectionOptions, trusted bool) (collectionOptions, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2220,9 +2220,15 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 		return nil, errors.New("collections: db is nil")
 	}
 
+	return retryInsertBatchMutation(func() ([][]byte, error) {
+		return c.insertBatchOnce(ids, documents, trustedValidBSON)
+	})
+}
+
+func retryInsertBatchMutation(run func() ([][]byte, error)) ([][]byte, error) {
 	var lastErr error
 	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
-		resultIDs, err := c.insertBatchOnce(ids, documents, trustedValidBSON)
+		resultIDs, err := run()
 		if errors.Is(err, ErrConcurrentMutation) {
 			lastErr = err
 			waitBeforeCollectionMutationRetry(attempt)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1071,12 +1071,12 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	if len(domain.rootBaseIDs) > 0 {
 		for rootName, baseRootID := range domain.rootBaseIDs {
 			if rootID := catalog.rootID(rootName); rootID != baseRootID {
-				return nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
+				return nil, fmt.Errorf("collections: %w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
 			}
 		}
 	} else {
 		if rootID := catalog.rootID(primaryRootName); rootID != domain.primaryRoot {
-			return nil, fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, primaryRootName)
+			return nil, fmt.Errorf("collections: %w: concurrent root modification detected for %q", ErrConcurrentMutation, primaryRootName)
 		}
 	}
 	options, err := collectionPlannerOptions(catalog.meta)
@@ -1178,7 +1178,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
 	}
 	if got := pinnedCatalog.rootID(rootName); got != baseRoot {
-		return fmt.Errorf("%w: concurrent root modification detected for %q", ErrConcurrentMutation, meta.Name)
+		return fmt.Errorf("collections: %w: concurrent root modification detected for %q", ErrConcurrentMutation, rootName)
 	}
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2601,7 +2601,9 @@ func updateInsertBatchBaseRootIDs(rootNames []string, baseRootIDs map[string]uin
 func (c *Collection) validateInsertBatchPlanAfterPlanningLocked(plannedWithMutationLocked bool, validation insertBatchValidationContext) (*backenddb.Snapshot, *collectionCatalog, error) {
 	if plannedWithMutationLocked {
 		if err := c.validateInsertBatchPlanWithSnapshotLocked(validation); err != nil {
-			_ = validation.snap.Close()
+			if validation.snap != nil {
+				_ = validation.snap.Close()
+			}
 			return nil, nil, err
 		}
 		return validation.snap, validation.catalog, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2327,7 +2327,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		return c.insertBatchNoIndex(catalog, snap, baseCommitSeq, baseSystemRoot, plannerOptions, ids, documents)
 	}
 
-	unlockForPlanning := plannerOptions.documentFormat != DocumentFormatTemplateV1
+	unlockForPlanning := shouldUnlockInsertPlanning(plannerOptions, indexedMemtablesEnabled, bufferIndexedInserts)
 	if unlockForPlanning {
 		unlockIfLocked()
 	}
@@ -2442,6 +2442,16 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	c.setLastInsertStats(plan.stats.CollectionInsertStats)
 	return plan.resultIDs, nil
+}
+
+func shouldUnlockInsertPlanning(opts collectionOptions, indexedMemtablesEnabled, bufferIndexedInserts bool) bool {
+	if opts.documentFormat == DocumentFormatTemplateV1 {
+		return false
+	}
+	if indexedMemtablesEnabled && !bufferIndexedInserts {
+		return false
+	}
+	return true
 }
 
 func insertBatchPlanRootNamesAndBaseIDs(plan *insertBatchPlan, catalog *collectionCatalog) ([]string, map[string]uint64) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2514,6 +2514,84 @@ func TestCollectionValidateInsertBatchPlanLockedClassifiesRaces(t *testing.T) {
 	}
 }
 
+func TestCollectionLockAndValidateInsertBatchPlanAllowsDisjointRootDrift(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DisableIndexedWriteMemtables: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"city":"a"}`)}); err != nil {
+		t.Fatalf("insert initial: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog: %v", err)
+	}
+	meta := catalog.meta
+	plannerOptions, err := collectionPlannerOptions(meta)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("planner options: %v", err)
+	}
+	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
+	plan, err := (insertBatchPlanner{
+		collection:     meta.Name,
+		primaryRoot:    collectionPrimaryRootName(meta.Name),
+		templateRoot:   collectionTemplateRootName(meta.Name),
+		indexStateRoot: collectionIndexStateRootName(meta.Name),
+		indexes:        plannerIndexes(meta.Indexes),
+		options:        plannerOptions,
+	}).planInsertBatch([][]byte{[]byte("u2")}, [][]byte{[]byte(`{"city":"b"}`)})
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("plan insert: %v", err)
+	}
+	defer resetCollectionRunTables(plan.runs)
+	rootNames, baseRootIDs := insertBatchPlanRootNamesAndBaseIDs(plan, catalog)
+	oldPrimaryRoot := baseRootIDs[collectionPrimaryRootName("users")]
+
+	if _, err := col.InsertBatch([][]byte{[]byte("u3")}, [][]byte{[]byte(`{"city":"c"}`)}); err != nil {
+		t.Fatalf("insert disjoint concurrent row: %v", err)
+	}
+
+	mutationLocked := false
+	unlockMutation := func() {}
+	pin, currentCatalog, _, _, err := col.lockAndValidateInsertBatchPlan(&mutationLocked, &unlockMutation, nil, catalog, meta, rootNames, baseRootIDs, plan)
+	if err != nil {
+		t.Fatalf("validate disjoint root drift: %v", err)
+	}
+	defer unlockMutation()
+	defer func() { _ = pin.Close() }()
+	currentPrimaryRoot := currentCatalog.rootID(collectionPrimaryRootName("users"))
+	if currentPrimaryRoot == oldPrimaryRoot {
+		t.Fatal("test did not create primary root drift")
+	}
+	if got := baseRootIDs[collectionPrimaryRootName("users")]; got != currentPrimaryRoot {
+		t.Fatalf("rebased primary root=%d want %d", got, currentPrimaryRoot)
+	}
+}
+
 func TestOpenCollectionWriteDomainCatalogCacheUsesCommitSeq(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1510,6 +1510,18 @@ func TestCollectionInsertPlanningKeepsLockForIndexedMemtableBypass(t *testing.T)
 			wantUnlock:              false,
 		},
 		{
+			name:           "bson-no-indexed-memtables",
+			documentFormat: DocumentFormatBSON,
+			wantUnlock:     true,
+		},
+		{
+			name:                    "bson-direct-indexed-memtable-bypass",
+			documentFormat:          DocumentFormatBSON,
+			indexedMemtablesEnabled: true,
+			bufferIndexedInserts:    false,
+			wantUnlock:              false,
+		},
+		{
 			name:           "template-v1",
 			documentFormat: DocumentFormatTemplateV1,
 			wantUnlock:     false,

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2456,6 +2456,7 @@ func TestCollectionValidateInsertBatchPlanLockedClassifiesRaces(t *testing.T) {
 	}
 	rootName := collectionPrimaryRootName("users")
 	plan := &insertBatchPlan{
+		resultIDs:   [][]byte{[]byte("u2")},
 		primaryKeys: [][]byte{[]byte("u2")},
 		runs:        []collectionRootRun{{name: rootName}},
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2480,7 +2480,13 @@ func TestCollectionValidateInsertBatchPlanLockedClassifiesRaces(t *testing.T) {
 	}
 	rootNames, baseRootIDs := insertBatchPlanRootNamesAndBaseIDs(plan, catalog)
 	staleRootIDs := map[string]uint64{rootName: baseRootIDs[rootName] + 1}
-	if current, _, err := col.validateInsertBatchPlanLocked(catalog.meta, rootNames, staleRootIDs, plan); current != nil || !errors.Is(err, ErrConcurrentMutation) {
+	validation := insertBatchValidationContext{
+		meta:        catalog.meta,
+		rootNames:   rootNames,
+		baseRootIDs: staleRootIDs,
+		plan:        plan,
+	}
+	if current, _, err := col.validateInsertBatchPlanLocked(validation); current != nil || !errors.Is(err, ErrConcurrentMutation) {
 		if current != nil {
 			_ = current.Close()
 		}
@@ -2488,7 +2494,8 @@ func TestCollectionValidateInsertBatchPlanLockedClassifiesRaces(t *testing.T) {
 	} else if !strings.Contains(err.Error(), `collection="users"`) || !strings.Contains(err.Error(), `root="users/primary"`) {
 		t.Fatalf("root mismatch err=%v missing collection/root context", err)
 	}
-	if current, _, err := col.validateInsertBatchPlanLocked(catalog.meta, rootNames, map[string]uint64{}, plan); current != nil || err == nil || errors.Is(err, ErrConcurrentMutation) || !strings.Contains(err.Error(), "missing base root id") {
+	validation.baseRootIDs = map[string]uint64{}
+	if current, _, err := col.validateInsertBatchPlanLocked(validation); current != nil || err == nil || errors.Is(err, ErrConcurrentMutation) || !strings.Contains(err.Error(), `collection "users" root "users/primary"`) {
 		if current != nil {
 			_ = current.Close()
 		}
@@ -2497,7 +2504,9 @@ func TestCollectionValidateInsertBatchPlanLockedClassifiesRaces(t *testing.T) {
 
 	schemaMeta := catalog.meta
 	schemaMeta.Options.AllowArrayValuesInIndex = !schemaMeta.Options.AllowArrayValuesInIndex
-	if current, _, err := col.validateInsertBatchPlanLocked(schemaMeta, rootNames, baseRootIDs, plan); current != nil || err == nil || errors.Is(err, ErrConcurrentMutation) {
+	validation.meta = schemaMeta
+	validation.baseRootIDs = baseRootIDs
+	if current, _, err := col.validateInsertBatchPlanLocked(validation); current != nil || err == nil || errors.Is(err, ErrConcurrentMutation) {
 		if current != nil {
 			_ = current.Close()
 		}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1470,6 +1470,53 @@ func TestCollectionIndexedWriteMemtablesBypassDefaultLargeBatches(t *testing.T) 
 	}
 }
 
+func TestCollectionInsertPlanningKeepsLockForIndexedMemtableBypass(t *testing.T) {
+	tests := []struct {
+		name                    string
+		documentFormat          DocumentFormat
+		indexedMemtablesEnabled bool
+		bufferIndexedInserts    bool
+		wantUnlock              bool
+	}{
+		{
+			name:           "json-no-indexed-memtables",
+			documentFormat: DocumentFormatJSON,
+			wantUnlock:     true,
+		},
+		{
+			name:                    "json-buffered-indexed-memtables",
+			documentFormat:          DocumentFormatJSON,
+			indexedMemtablesEnabled: true,
+			bufferIndexedInserts:    true,
+			wantUnlock:              true,
+		},
+		{
+			name:                    "json-direct-indexed-memtable-bypass",
+			documentFormat:          DocumentFormatJSON,
+			indexedMemtablesEnabled: true,
+			bufferIndexedInserts:    false,
+			wantUnlock:              false,
+		},
+		{
+			name:           "template-v1",
+			documentFormat: DocumentFormatTemplateV1,
+			wantUnlock:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldUnlockInsertPlanning(
+				collectionOptions{documentFormat: tt.documentFormat},
+				tt.indexedMemtablesEnabled,
+				tt.bufferIndexedInserts,
+			)
+			if got != tt.wantUnlock {
+				t.Fatalf("shouldUnlockInsertPlanning()=%v want %v", got, tt.wantUnlock)
+			}
+		})
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesReadAfterDomainTableAllocated(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1517,6 +1517,59 @@ func TestCollectionInsertPlanningKeepsLockForIndexedMemtableBypass(t *testing.T)
 	}
 }
 
+func TestCollectionInsertRetryRetriesWrappedConcurrentMutation(t *testing.T) {
+	attempts := 0
+	result, err := retryInsertBatchMutation(func() ([][]byte, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, fmt.Errorf("wrapped attempt %d: %w", attempts, ErrConcurrentMutation)
+		}
+		return [][]byte{[]byte("u1")}, nil
+	})
+	if err != nil {
+		t.Fatalf("retryInsertBatchMutation err=%v want nil", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts=%d want 3", attempts)
+	}
+	if len(result) != 1 || !bytes.Equal(result[0], []byte("u1")) {
+		t.Fatalf("result=%q want [u1]", result)
+	}
+}
+
+func TestCollectionInsertRetryReturnsNonRetryableImmediately(t *testing.T) {
+	attempts := 0
+	wantErr := errors.New("boom")
+	_, err := retryInsertBatchMutation(func() ([][]byte, error) {
+		attempts++
+		return nil, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("retryInsertBatchMutation err=%v want %v", err, wantErr)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts=%d want 1", attempts)
+	}
+}
+
+func TestCollectionInsertRetryExhaustionWrapsLastConcurrentMutation(t *testing.T) {
+	attempts := 0
+	lastErr := fmt.Errorf("last stale root: %w", ErrConcurrentMutation)
+	_, err := retryInsertBatchMutation(func() ([][]byte, error) {
+		attempts++
+		return nil, lastErr
+	})
+	if !errors.Is(err, ErrConcurrentMutation) {
+		t.Fatalf("retryInsertBatchMutation err=%v want ErrConcurrentMutation", err)
+	}
+	if !strings.Contains(err.Error(), lastErr.Error()) {
+		t.Fatalf("retryInsertBatchMutation err=%q want last error %q", err, lastErr)
+	}
+	if attempts != maxCollectionMutationRetries {
+		t.Fatalf("attempts=%d want %d", attempts, maxCollectionMutationRetries)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesReadAfterDomainTableAllocated(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2426,6 +2426,58 @@ func TestCollectionCachedCatalogUsesCommitSeq(t *testing.T) {
 	}
 }
 
+func TestCollectionValidateInsertBatchPlanLockedClassifiesRaces(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"ada"}`)}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	rootName := collectionPrimaryRootName("users")
+	plan := &insertBatchPlan{
+		primaryKeys: [][]byte{[]byte("u2")},
+		runs:        []collectionRootRun{{name: rootName}},
+	}
+	rootNames, baseRootIDs := insertBatchPlanRootNamesAndBaseIDs(plan, catalog)
+	staleRootIDs := map[string]uint64{rootName: baseRootIDs[rootName] + 1}
+	if current, _, err := col.validateInsertBatchPlanLocked(catalog.meta, rootNames, staleRootIDs, plan); current != nil || !errors.Is(err, ErrConcurrentMutation) {
+		if current != nil {
+			_ = current.Close()
+		}
+		t.Fatalf("root mismatch current=%v err=%v want ErrConcurrentMutation", current, err)
+	}
+
+	schemaMeta := catalog.meta
+	schemaMeta.Options.AllowArrayValuesInIndex = !schemaMeta.Options.AllowArrayValuesInIndex
+	if current, _, err := col.validateInsertBatchPlanLocked(schemaMeta, rootNames, baseRootIDs, plan); current != nil || err == nil || errors.Is(err, ErrConcurrentMutation) {
+		if current != nil {
+			_ = current.Close()
+		}
+		t.Fatalf("schema mismatch current=%v err=%v want non-retryable schema error", current, err)
+	}
+}
+
 func TestOpenCollectionUsesWriteDomainCatalogCache(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2592,6 +2592,14 @@ func TestCollectionLockAndValidateInsertBatchPlanAllowsDisjointRootDrift(t *test
 	}
 }
 
+func TestCollectionValidateInsertBatchPlanAfterPlanningLockedNilSnapshot(t *testing.T) {
+	col := &Collection{}
+	pin, catalog, err := col.validateInsertBatchPlanAfterPlanningLocked(true, insertBatchValidationContext{})
+	if pin != nil || catalog != nil || !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("pin=%v catalog=%v err=%v want ErrClosed without panic", pin, catalog, err)
+	}
+}
+
 func TestOpenCollectionWriteDomainCatalogCacheUsesCommitSeq(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1577,6 +1577,9 @@ func TestCollectionInsertRetryExhaustionWrapsLastConcurrentMutation(t *testing.T
 	if !strings.Contains(err.Error(), lastErr.Error()) {
 		t.Fatalf("retryInsertBatchMutation err=%q want last error %q", err, lastErr)
 	}
+	if got := strings.Count(err.Error(), ErrConcurrentMutation.Error()); got != 1 {
+		t.Fatalf("retryInsertBatchMutation err=%q contains ErrConcurrentMutation text %d times, want 1", err, got)
+	}
 	if attempts != maxCollectionMutationRetries {
 		t.Fatalf("attempts=%d want %d", attempts, maxCollectionMutationRetries)
 	}
@@ -2470,6 +2473,8 @@ func TestCollectionValidateInsertBatchPlanLockedClassifiesRaces(t *testing.T) {
 			_ = current.Close()
 		}
 		t.Fatalf("root mismatch current=%v err=%v want ErrConcurrentMutation", current, err)
+	} else if !strings.Contains(err.Error(), `collection="users"`) || !strings.Contains(err.Error(), `root="users/primary"`) {
+		t.Fatalf("root mismatch err=%v missing collection/root context", err)
 	}
 	if current, _, err := col.validateInsertBatchPlanLocked(catalog.meta, rootNames, map[string]uint64{}, plan); current != nil || err == nil || errors.Is(err, ErrConcurrentMutation) || !strings.Contains(err.Error(), "missing base root id") {
 		if current != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2467,6 +2467,12 @@ func TestCollectionValidateInsertBatchPlanLockedClassifiesRaces(t *testing.T) {
 		}
 		t.Fatalf("root mismatch current=%v err=%v want ErrConcurrentMutation", current, err)
 	}
+	if current, _, err := col.validateInsertBatchPlanLocked(catalog.meta, rootNames, map[string]uint64{}, plan); current != nil || err == nil || errors.Is(err, ErrConcurrentMutation) || !strings.Contains(err.Error(), "missing base root id") {
+		if current != nil {
+			_ = current.Close()
+		}
+		t.Fatalf("missing base root current=%v err=%v want non-retryable missing base root error", current, err)
+	}
 
 	schemaMeta := catalog.meta
 	schemaMeta.Options.AllowArrayValuesInIndex = !schemaMeta.Options.AllowArrayValuesInIndex

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2495,7 +2495,7 @@ func TestCollectionValidateInsertBatchPlanLockedClassifiesRaces(t *testing.T) {
 		t.Fatalf("root mismatch err=%v missing collection/root context", err)
 	}
 	validation.baseRootIDs = map[string]uint64{}
-	if current, _, err := col.validateInsertBatchPlanLocked(validation); current != nil || err == nil || errors.Is(err, ErrConcurrentMutation) || !strings.Contains(err.Error(), `collection "users" root "users/primary"`) {
+	if current, _, err := col.validateInsertBatchPlanLocked(validation); current != nil || err == nil || errors.Is(err, ErrConcurrentMutation) || !strings.Contains(err.Error(), `collection="users"`) || !strings.Contains(err.Error(), `root="users/primary"`) {
 		if current != nil {
 			_ = current.Close()
 		}

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -81,14 +81,14 @@ type insertBatchPlanner struct {
 }
 
 type insertBatchPlan struct {
-	resultIDs          [][]byte
-	primaryKeys        [][]byte
-	runs               []collectionRootRun
-	uniqueProbeRuns    []collectionUniqueProbeRun
-	allUniqueProbeRuns []collectionUniqueProbeRun
-	uniqueProbeRunsSet bool
-	templateRecords    []templateV1Record
-	stats              insertBatchPlanStats
+	resultIDs               [][]byte
+	primaryKeys             [][]byte
+	runs                    []collectionRootRun
+	uniqueProbeRuns         []collectionUniqueProbeRun
+	allUniqueProbeRuns      []collectionUniqueProbeRun
+	allUniqueProbeRunsBuilt bool
+	templateRecords         []templateV1Record
+	stats                   insertBatchPlanStats
 }
 
 type insertBatchPlanStats struct {
@@ -242,13 +242,13 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	stats.UniqueIndexPreflight = time.Since(phaseStart)
 
 	plan := &insertBatchPlan{
-		resultIDs:          resultIDs,
-		primaryKeys:        primaryKeys,
-		uniqueProbeRuns:    uniqueProbeRuns,
-		allUniqueProbeRuns: allUniqueProbeRuns,
-		uniqueProbeRunsSet: true,
-		templateRecords:    templateRecords,
-		stats:              insertBatchPlanStats{CollectionInsertStats: stats},
+		resultIDs:               resultIDs,
+		primaryKeys:             primaryKeys,
+		uniqueProbeRuns:         uniqueProbeRuns,
+		allUniqueProbeRuns:      allUniqueProbeRuns,
+		allUniqueProbeRunsBuilt: true,
+		templateRecords:         templateRecords,
+		stats:                   insertBatchPlanStats{CollectionInsertStats: stats},
 	}
 	if len(templateRecords) > 0 {
 		phaseStart = time.Now()
@@ -347,7 +347,7 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 		return fmt.Errorf("collections: insert conflict check missing primary keys: got %d, want %d", len(plan.primaryKeys), len(plan.resultIDs))
 	}
 	uniqueRootIDs := uniqueIndexRootIDs(catalog)
-	if len(plan.resultIDs) > 0 && len(uniqueRootIDs) > 0 && !plan.uniqueProbeRunsSet {
+	if len(plan.resultIDs) > 0 && len(uniqueRootIDs) > 0 && !plan.allUniqueProbeRunsBuilt {
 		return errors.New("collections: insert conflict check missing unique probe runs")
 	}
 	preflight := insertBatchPreflight{

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -358,18 +358,9 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 		return fmt.Errorf("collections: insert conflict check missing primary keys: got %d, want %d", len(plan.primaryKeys), len(plan.resultIDs))
 	}
 	uniqueRootIDs := uniqueIndexRootIDs(catalog)
-	if len(plan.resultIDs) > 0 && len(uniqueRootIDs) > 0 && !plan.allUniqueProbeRunsBuilt {
-		if !plan.uniqueProbeCandidatesBuilt {
-			return errors.New("collections: insert conflict check missing unique probe candidates")
-		}
-		runs, err := buildUniqueProbeRunsFromSorted(plan.uniqueProbeCandidates, func(indexName string) bool {
-			return uniqueRootIDs[indexName] != 0
-		})
-		if err != nil {
-			return err
-		}
-		plan.allUniqueProbeRuns = runs
-		plan.allUniqueProbeRunsBuilt = true
+	uniqueProbeRuns, err := plan.uniqueProbeRunsForPersistedConflicts(uniqueRootIDs)
+	if err != nil {
+		return err
 	}
 	preflight := insertBatchPreflight{
 		snapshot:           snap,
@@ -379,7 +370,22 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 	if err := preflight.checkDocumentConflictKeys(plan.primaryKeys); err != nil {
 		return err
 	}
-	return preflight.checkUniqueConflicts(plan.allUniqueProbeRuns)
+	return preflight.checkUniqueConflicts(uniqueProbeRuns)
+}
+
+func (plan *insertBatchPlan) uniqueProbeRunsForPersistedConflicts(uniqueRootIDs map[string]uint64) ([]collectionUniqueProbeRun, error) {
+	if plan == nil || len(plan.resultIDs) == 0 || len(uniqueRootIDs) == 0 {
+		return nil, nil
+	}
+	if plan.allUniqueProbeRunsBuilt {
+		return plan.allUniqueProbeRuns, nil
+	}
+	if !plan.uniqueProbeCandidatesBuilt {
+		return nil, errors.New("collections: insert conflict check missing unique probe candidates")
+	}
+	return buildUniqueProbeRunsFromSorted(plan.uniqueProbeCandidates, func(indexName string) bool {
+		return uniqueRootIDs[indexName] != 0
+	})
 }
 
 func (p insertBatchPreflight) checkUniqueConflicts(runs []collectionUniqueProbeRun) error {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -84,6 +84,7 @@ type insertBatchPlan struct {
 	resultIDs               [][]byte
 	primaryKeys             [][]byte
 	runs                    []collectionRootRun
+	uniqueProbeCandidates   []uniqueProbeCandidate
 	uniqueProbeRuns         []collectionUniqueProbeRun
 	allUniqueProbeRuns      []collectionUniqueProbeRun
 	allUniqueProbeRunsBuilt bool
@@ -231,22 +232,29 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	if err := rejectDuplicateUniqueProbeCandidates(uniqueProbes); err != nil {
 		return nil, err
 	}
-	allUniqueProbeRuns, err := buildUniqueProbeRunsFromSorted(uniqueProbes, nil)
-	if err != nil {
-		return nil, err
-	}
-	uniqueProbeRuns := uniqueProbeRunsForPreflight(allUniqueProbeRuns, preflight)
-	if err := preflight.checkUniqueConflicts(uniqueProbeRuns); err != nil {
-		return nil, err
+	var uniqueProbeRuns []collectionUniqueProbeRun
+	var allUniqueProbeRuns []collectionUniqueProbeRun
+	allUniqueProbeRunsBuilt := false
+	if preflight.snapshot != nil && len(preflight.uniqueIndexRootIDs) > 0 {
+		allUniqueProbeRuns, err = buildUniqueProbeRunsFromSorted(uniqueProbes, nil)
+		if err != nil {
+			return nil, err
+		}
+		allUniqueProbeRunsBuilt = true
+		uniqueProbeRuns = uniqueProbeRunsForPreflight(allUniqueProbeRuns, preflight)
+		if err := preflight.checkUniqueConflicts(uniqueProbeRuns); err != nil {
+			return nil, err
+		}
 	}
 	stats.UniqueIndexPreflight = time.Since(phaseStart)
 
 	plan := &insertBatchPlan{
 		resultIDs:               resultIDs,
 		primaryKeys:             primaryKeys,
+		uniqueProbeCandidates:   uniqueProbes,
 		uniqueProbeRuns:         uniqueProbeRuns,
 		allUniqueProbeRuns:      allUniqueProbeRuns,
-		allUniqueProbeRunsBuilt: true,
+		allUniqueProbeRunsBuilt: allUniqueProbeRunsBuilt,
 		templateRecords:         templateRecords,
 		stats:                   insertBatchPlanStats{CollectionInsertStats: stats},
 	}
@@ -348,7 +356,14 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 	}
 	uniqueRootIDs := uniqueIndexRootIDs(catalog)
 	if len(plan.resultIDs) > 0 && len(uniqueRootIDs) > 0 && !plan.allUniqueProbeRunsBuilt {
-		return errors.New("collections: insert conflict check missing unique probe runs")
+		runs, err := buildUniqueProbeRunsFromSorted(plan.uniqueProbeCandidates, func(indexName string) bool {
+			return uniqueRootIDs[indexName] != 0
+		})
+		if err != nil {
+			return err
+		}
+		plan.allUniqueProbeRuns = runs
+		plan.allUniqueProbeRunsBuilt = true
 	}
 	preflight := insertBatchPreflight{
 		snapshot:           snap,

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -81,15 +81,16 @@ type insertBatchPlanner struct {
 }
 
 type insertBatchPlan struct {
-	resultIDs               [][]byte
-	primaryKeys             [][]byte
-	runs                    []collectionRootRun
-	uniqueProbeCandidates   []uniqueProbeCandidate
-	uniqueProbeRuns         []collectionUniqueProbeRun
-	allUniqueProbeRuns      []collectionUniqueProbeRun
-	allUniqueProbeRunsBuilt bool
-	templateRecords         []templateV1Record
-	stats                   insertBatchPlanStats
+	resultIDs                  [][]byte
+	primaryKeys                [][]byte
+	runs                       []collectionRootRun
+	uniqueProbeCandidates      []uniqueProbeCandidate
+	uniqueProbeCandidatesBuilt bool
+	uniqueProbeRuns            []collectionUniqueProbeRun
+	allUniqueProbeRuns         []collectionUniqueProbeRun
+	allUniqueProbeRunsBuilt    bool
+	templateRecords            []templateV1Record
+	stats                      insertBatchPlanStats
 }
 
 type insertBatchPlanStats struct {
@@ -249,14 +250,15 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	stats.UniqueIndexPreflight = time.Since(phaseStart)
 
 	plan := &insertBatchPlan{
-		resultIDs:               resultIDs,
-		primaryKeys:             primaryKeys,
-		uniqueProbeCandidates:   uniqueProbes,
-		uniqueProbeRuns:         uniqueProbeRuns,
-		allUniqueProbeRuns:      allUniqueProbeRuns,
-		allUniqueProbeRunsBuilt: allUniqueProbeRunsBuilt,
-		templateRecords:         templateRecords,
-		stats:                   insertBatchPlanStats{CollectionInsertStats: stats},
+		resultIDs:                  resultIDs,
+		primaryKeys:                primaryKeys,
+		uniqueProbeCandidates:      uniqueProbes,
+		uniqueProbeCandidatesBuilt: true,
+		uniqueProbeRuns:            uniqueProbeRuns,
+		allUniqueProbeRuns:         allUniqueProbeRuns,
+		allUniqueProbeRunsBuilt:    allUniqueProbeRunsBuilt,
+		templateRecords:            templateRecords,
+		stats:                      insertBatchPlanStats{CollectionInsertStats: stats},
 	}
 	if len(templateRecords) > 0 {
 		phaseStart = time.Now()
@@ -356,6 +358,9 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 	}
 	uniqueRootIDs := uniqueIndexRootIDs(catalog)
 	if len(plan.resultIDs) > 0 && len(uniqueRootIDs) > 0 && !plan.allUniqueProbeRunsBuilt {
+		if !plan.uniqueProbeCandidatesBuilt {
+			return errors.New("collections: insert conflict check missing unique probe runs")
+		}
 		runs, err := buildUniqueProbeRunsFromSorted(plan.uniqueProbeCandidates, func(indexName string) bool {
 			return uniqueRootIDs[indexName] != 0
 		})

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -86,6 +86,7 @@ type insertBatchPlan struct {
 	runs               []collectionRootRun
 	uniqueProbeRuns    []collectionUniqueProbeRun
 	allUniqueProbeRuns []collectionUniqueProbeRun
+	uniqueProbeRunsSet bool
 	templateRecords    []templateV1Record
 	stats              insertBatchPlanStats
 }
@@ -245,6 +246,7 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 		primaryKeys:        primaryKeys,
 		uniqueProbeRuns:    uniqueProbeRuns,
 		allUniqueProbeRuns: allUniqueProbeRuns,
+		uniqueProbeRunsSet: true,
 		templateRecords:    templateRecords,
 		stats:              insertBatchPlanStats{CollectionInsertStats: stats},
 	}
@@ -341,10 +343,17 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 	if catalog == nil {
 		return errors.New("collections: insert conflict check missing catalog")
 	}
+	if len(plan.primaryKeys) != len(plan.resultIDs) {
+		return fmt.Errorf("collections: insert conflict check missing primary keys: got %d, want %d", len(plan.primaryKeys), len(plan.resultIDs))
+	}
+	uniqueRootIDs := uniqueIndexRootIDs(catalog)
+	if len(plan.resultIDs) > 0 && len(uniqueRootIDs) > 0 && !plan.uniqueProbeRunsSet {
+		return errors.New("collections: insert conflict check missing unique probe runs")
+	}
 	preflight := insertBatchPreflight{
 		snapshot:           snap,
 		primaryRootID:      catalog.rootID(collectionPrimaryRootName(catalog.meta.Name)),
-		uniqueIndexRootIDs: uniqueIndexRootIDs(catalog),
+		uniqueIndexRootIDs: uniqueRootIDs,
 	}
 	if err := preflight.checkDocumentConflictKeys(plan.primaryKeys); err != nil {
 		return err

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -81,13 +81,13 @@ type insertBatchPlanner struct {
 }
 
 type insertBatchPlan struct {
-	resultIDs       [][]byte
-	primaryKeys     [][]byte
-	runs            []collectionRootRun
-	uniqueProbeRuns []collectionUniqueProbeRun
-	allUniqueProbes []collectionUniqueProbeRun
-	templateRecords []templateV1Record
-	stats           insertBatchPlanStats
+	resultIDs          [][]byte
+	primaryKeys        [][]byte
+	runs               []collectionRootRun
+	uniqueProbeRuns    []collectionUniqueProbeRun
+	allUniqueProbeRuns []collectionUniqueProbeRun
+	templateRecords    []templateV1Record
+	stats              insertBatchPlanStats
 }
 
 type insertBatchPlanStats struct {
@@ -230,26 +230,23 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	if err := rejectDuplicateUniqueProbeCandidates(uniqueProbes); err != nil {
 		return nil, err
 	}
-	allUniqueProbes, err := buildUniqueProbeRunsFromSorted(uniqueProbes, nil)
+	allUniqueProbeRuns, err := buildUniqueProbeRunsFromSorted(uniqueProbes, nil)
 	if err != nil {
 		return nil, err
 	}
-	uniqueProbeRuns, err := buildUniqueProbeRunsForPreflightFromSorted(uniqueProbes, preflight)
-	if err != nil {
-		return nil, err
-	}
+	uniqueProbeRuns := uniqueProbeRunsForPreflight(allUniqueProbeRuns, preflight)
 	if err := preflight.checkUniqueConflicts(uniqueProbeRuns); err != nil {
 		return nil, err
 	}
 	stats.UniqueIndexPreflight = time.Since(phaseStart)
 
 	plan := &insertBatchPlan{
-		resultIDs:       resultIDs,
-		primaryKeys:     primaryKeys,
-		uniqueProbeRuns: uniqueProbeRuns,
-		allUniqueProbes: allUniqueProbes,
-		templateRecords: templateRecords,
-		stats:           insertBatchPlanStats{CollectionInsertStats: stats},
+		resultIDs:          resultIDs,
+		primaryKeys:        primaryKeys,
+		uniqueProbeRuns:    uniqueProbeRuns,
+		allUniqueProbeRuns: allUniqueProbeRuns,
+		templateRecords:    templateRecords,
+		stats:              insertBatchPlanStats{CollectionInsertStats: stats},
 	}
 	if len(templateRecords) > 0 {
 		phaseStart = time.Now()
@@ -352,7 +349,7 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 	if err := preflight.checkDocumentConflictKeys(plan.primaryKeys); err != nil {
 		return err
 	}
-	return preflight.checkUniqueConflicts(plan.allUniqueProbes)
+	return preflight.checkUniqueConflicts(plan.allUniqueProbeRuns)
 }
 
 func (p insertBatchPreflight) checkUniqueConflicts(runs []collectionUniqueProbeRun) error {
@@ -360,8 +357,8 @@ func (p insertBatchPreflight) checkUniqueConflicts(runs []collectionUniqueProbeR
 		return nil
 	}
 	for _, run := range runs {
-		rootID := p.uniqueIndexRootIDs[run.indexName]
-		if rootID == 0 {
+		rootID, ok := p.uniqueIndexRootIDs[run.indexName]
+		if !ok || rootID == 0 {
 			continue
 		}
 		exists, err := p.snapshot.HasPrefixesAtRoot(rootID, run.prefixes)
@@ -493,13 +490,19 @@ func estimateUniqueProbePrefixBytes(candidates []uniqueProbeCandidate) int {
 	return total
 }
 
-func buildUniqueProbeRunsForPreflightFromSorted(candidates []uniqueProbeCandidate, preflight insertBatchPreflight) ([]collectionUniqueProbeRun, error) {
-	if preflight.snapshot == nil || len(preflight.uniqueIndexRootIDs) == 0 {
-		return nil, nil
+func uniqueProbeRunsForPreflight(runs []collectionUniqueProbeRun, preflight insertBatchPreflight) []collectionUniqueProbeRun {
+	if preflight.snapshot == nil || len(preflight.uniqueIndexRootIDs) == 0 || len(runs) == 0 {
+		return nil
 	}
-	return buildUniqueProbeRunsFromSorted(candidates, func(indexName string) bool {
-		return preflight.uniqueIndexRootIDs[indexName] != 0
-	})
+	out := make([]collectionUniqueProbeRun, 0, len(runs))
+	for _, run := range runs {
+		rootID, ok := preflight.uniqueIndexRootIDs[run.indexName]
+		if !ok || rootID == 0 {
+			continue
+		}
+		out = append(out, run)
+	}
+	return out
 }
 
 func buildUniqueProbeRunsFromSorted(candidates []uniqueProbeCandidate, includeIndex func(indexName string) bool) ([]collectionUniqueProbeRun, error) {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -82,8 +82,10 @@ type insertBatchPlanner struct {
 
 type insertBatchPlan struct {
 	resultIDs       [][]byte
+	primaryKeys     [][]byte
 	runs            []collectionRootRun
 	uniqueProbeRuns []collectionUniqueProbeRun
+	allUniqueProbes []collectionUniqueProbeRun
 	templateRecords []templateV1Record
 	stats           insertBatchPlanStats
 }
@@ -207,7 +209,8 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	if err := rejectDuplicateDocumentIDs(items, primaryOrder); err != nil {
 		return nil, err
 	}
-	if err := preflight.checkDocumentConflicts(items, primaryOrder, resultIDs); err != nil {
+	primaryKeys := sortedDocumentIDKeys(items, primaryOrder, resultIDs)
+	if err := preflight.checkDocumentConflictKeys(primaryKeys); err != nil {
 		return nil, err
 	}
 	stats.DuplicateDocumentPreflight = time.Since(phaseStart)
@@ -227,6 +230,10 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	if err := rejectDuplicateUniqueProbeCandidates(uniqueProbes); err != nil {
 		return nil, err
 	}
+	allUniqueProbes, err := buildUniqueProbeRunsFromSorted(uniqueProbes, nil)
+	if err != nil {
+		return nil, err
+	}
 	uniqueProbeRuns, err := buildUniqueProbeRunsForPreflightFromSorted(uniqueProbes, preflight)
 	if err != nil {
 		return nil, err
@@ -238,7 +245,9 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 
 	plan := &insertBatchPlan{
 		resultIDs:       resultIDs,
+		primaryKeys:     primaryKeys,
 		uniqueProbeRuns: uniqueProbeRuns,
+		allUniqueProbes: allUniqueProbes,
 		templateRecords: templateRecords,
 		stats:           insertBatchPlanStats{CollectionInsertStats: stats},
 	}
@@ -295,17 +304,12 @@ func cloneBatchDocumentIDs(ids [][]byte) ([][]byte, error) {
 }
 
 func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem, order []int, presortedIDs [][]byte) error {
+	return p.checkDocumentConflictKeys(sortedDocumentIDKeys(items, order, presortedIDs))
+}
+
+func (p insertBatchPreflight) checkDocumentConflictKeys(keys [][]byte) error {
 	if p.snapshot == nil || p.primaryRootID == 0 {
 		return nil
-	}
-	// sortedItemOrderByKey returns nil only when items are already sorted by ID,
-	// so the caller-owned presortedIDs slice is safe to reuse only in that case.
-	keys := presortedIDs
-	if order != nil || len(keys) != len(items) {
-		keys = make([][]byte, len(items))
-		for i := range items {
-			keys[i] = items[orderedItemIndex(order, i)].id
-		}
 	}
 	exists, err := p.snapshot.HasAnySortedAtRoot(p.primaryRootID, keys)
 	if err != nil {
@@ -315,6 +319,34 @@ func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem, or
 		return ErrDocumentExists
 	}
 	return nil
+}
+
+func sortedDocumentIDKeys(items []insertBatchItem, order []int, presortedIDs [][]byte) [][]byte {
+	// sortedItemOrderByKey returns nil only when items are already sorted by ID,
+	// so the caller-owned presortedIDs slice is safe to reuse only in that case.
+	if order == nil && len(presortedIDs) == len(items) {
+		return presortedIDs
+	}
+	keys := make([][]byte, len(items))
+	for i := range items {
+		keys[i] = items[orderedItemIndex(order, i)].id
+	}
+	return keys
+}
+
+func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, catalog *collectionCatalog) error {
+	if plan == nil || snap == nil || catalog == nil {
+		return nil
+	}
+	preflight := insertBatchPreflight{
+		snapshot:           snap,
+		primaryRootID:      catalog.rootID(collectionPrimaryRootName(catalog.meta.Name)),
+		uniqueIndexRootIDs: uniqueIndexRootIDs(catalog),
+	}
+	if err := preflight.checkDocumentConflictKeys(plan.primaryKeys); err != nil {
+		return err
+	}
+	return preflight.checkUniqueConflicts(plan.allUniqueProbes)
 }
 
 func (p insertBatchPreflight) checkUniqueConflicts(runs []collectionUniqueProbeRun) error {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -235,13 +235,14 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	}
 	var uniqueProbeRuns []collectionUniqueProbeRun
 	var allUniqueProbeRuns []collectionUniqueProbeRun
-	allUniqueProbeRunsBuilt := false
-	if preflight.snapshot != nil && len(preflight.uniqueIndexRootIDs) > 0 {
+	allUniqueProbeRunsBuilt := true
+	if len(uniqueProbes) > 0 {
 		allUniqueProbeRuns, err = buildUniqueProbeRunsFromSorted(uniqueProbes, nil)
 		if err != nil {
 			return nil, err
 		}
-		allUniqueProbeRunsBuilt = true
+	}
+	if preflight.snapshot != nil && len(preflight.uniqueIndexRootIDs) > 0 {
 		uniqueProbeRuns = uniqueProbeRunsForPreflight(allUniqueProbeRuns, preflight)
 		if err := preflight.checkUniqueConflicts(uniqueProbeRuns); err != nil {
 			return nil, err
@@ -359,7 +360,7 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 	uniqueRootIDs := uniqueIndexRootIDs(catalog)
 	if len(plan.resultIDs) > 0 && len(uniqueRootIDs) > 0 && !plan.allUniqueProbeRunsBuilt {
 		if !plan.uniqueProbeCandidatesBuilt {
-			return errors.New("collections: insert conflict check missing unique probe runs")
+			return errors.New("collections: insert conflict check missing unique probe candidates")
 		}
 		runs, err := buildUniqueProbeRunsFromSorted(plan.uniqueProbeCandidates, func(indexName string) bool {
 			return uniqueRootIDs[indexName] != 0

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -335,8 +335,14 @@ func sortedDocumentIDKeys(items []insertBatchItem, order []int, presortedIDs [][
 }
 
 func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, catalog *collectionCatalog) error {
-	if plan == nil || snap == nil || catalog == nil {
-		return nil
+	if plan == nil {
+		return errors.New("collections: insert conflict check missing plan")
+	}
+	if snap == nil {
+		return errors.New("collections: insert conflict check missing snapshot")
+	}
+	if catalog == nil {
+		return errors.New("collections: insert conflict check missing catalog")
 	}
 	preflight := insertBatchPreflight{
 		snapshot:           snap,

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -536,6 +536,47 @@ func TestInsertBatchPlanCheckPersistedConflictsRejectsMissingInputs(t *testing.T
 	}
 }
 
+func TestInsertBatchPlanCheckPersistedConflictsRejectsIncompleteDerivedInputs(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	catalog := &collectionCatalog{
+		meta:  CollectionMeta{Name: "users"},
+		roots: map[string]uint64{},
+	}
+	err = (&insertBatchPlan{resultIDs: [][]byte{[]byte("u1")}}).checkPersistedConflicts(snap, catalog)
+	if err == nil || !strings.Contains(err.Error(), "missing primary keys") {
+		t.Fatalf("checkPersistedConflicts err=%v want missing primary keys", err)
+	}
+
+	catalog.meta.Indexes = []IndexDefinition{{Name: "email", Field: "email", Unique: true}}
+	catalog.roots[collectionSecondaryRootName("users", "email")] = 2
+	err = (&insertBatchPlan{
+		resultIDs:   [][]byte{[]byte("u1")},
+		primaryKeys: [][]byte{[]byte("u1")},
+	}).checkPersistedConflicts(snap, catalog)
+	if err == nil || !strings.Contains(err.Error(), "missing unique probe runs") {
+		t.Fatalf("checkPersistedConflicts err=%v want missing unique probe runs", err)
+	}
+
+	err = (&insertBatchPlan{
+		resultIDs:          [][]byte{[]byte("u1")},
+		primaryKeys:        [][]byte{[]byte("u1")},
+		uniqueProbeRunsSet: true,
+	}).checkPersistedConflicts(snap, catalog)
+	if err != nil {
+		t.Fatalf("checkPersistedConflicts with built empty probes: %v", err)
+	}
+}
+
 func TestInsertBatchPlanner_FailFastDuplicatesBeforePayloadConstruction(t *testing.T) {
 	builds := 0
 	planner := insertBatchPlanner{

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -456,6 +456,9 @@ func TestInsertBatchPlanner_BuildsUniqueProbePrefixesOnlyForPersistedRoots(t *te
 	if got, want := len(plan.uniqueProbeRuns), 1; got != want {
 		t.Fatalf("unique probe runs=%d want %d", got, want)
 	}
+	if got, want := len(plan.allUniqueProbeRuns), 2; got != want {
+		t.Fatalf("all unique probe runs=%d want %d", got, want)
+	}
 	if got, want := plan.uniqueProbeRuns[0].indexName, "email"; got != want {
 		t.Fatalf("unique probe index=%q want %q", got, want)
 	}
@@ -466,6 +469,29 @@ func TestInsertBatchPlanner_BuildsUniqueProbePrefixesOnlyForPersistedRoots(t *te
 		if bytes.Contains(prefix, []byte("u1")) || bytes.Contains(prefix, []byte("u2")) {
 			t.Fatalf("unique probe prefix contains a document id: %q", prefix)
 		}
+	}
+	if got, want := probe.hasPrefixesCalls, 1; got != want {
+		t.Fatalf("HasPrefixesAtRoot calls=%d want %d", got, want)
+	}
+	if got, want := probe.lastHasPrefixesRootID, uint64(77); got != want {
+		t.Fatalf("HasPrefixesAtRoot root=%d want %d", got, want)
+	}
+}
+
+func TestInsertBatchPreflightCheckUniqueConflictsSkipsMissingRoots(t *testing.T) {
+	probe := &recordingRootSnapshotProbe{}
+	preflight := insertBatchPreflight{
+		snapshot: probe,
+		uniqueIndexRootIDs: map[string]uint64{
+			"email": 77,
+		},
+	}
+	err := preflight.checkUniqueConflicts([]collectionUniqueProbeRun{
+		{indexName: "username", prefixes: [][]byte{[]byte("ada")}},
+		{indexName: "email", prefixes: [][]byte{[]byte("ada@example.com")}},
+	})
+	if err != nil {
+		t.Fatalf("check unique conflicts: %v", err)
 	}
 	if got, want := probe.hasPrefixesCalls, 1; got != want {
 		t.Fatalf("HasPrefixesAtRoot calls=%d want %d", got, want)

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -476,6 +476,25 @@ func TestInsertBatchPlanner_BuildsUniqueProbePrefixesOnlyForPersistedRoots(t *te
 	if got, want := probe.lastHasPrefixesRootID, uint64(77); got != want {
 		t.Fatalf("HasPrefixesAtRoot root=%d want %d", got, want)
 	}
+
+	noRootProbe := &recordingRootSnapshotProbe{}
+	planWithoutPersistedRoots, err := planner.planInsertBatchWithPreflight(
+		[][]byte{[]byte("u3")},
+		[][]byte{[]byte(`{"email":"katherine@example.com","username":"katherine"}`)},
+		insertBatchPreflight{snapshot: noRootProbe},
+	)
+	if err != nil {
+		t.Fatalf("plan insert batch without persisted roots: %v", err)
+	}
+	if !planWithoutPersistedRoots.allUniqueProbeRunsBuilt {
+		t.Fatal("all unique probe runs were not built")
+	}
+	if got, want := len(planWithoutPersistedRoots.allUniqueProbeRuns), 2; got != want {
+		t.Fatalf("all unique probe runs without persisted roots=%d want %d", got, want)
+	}
+	if noRootProbe.hasPrefixesCalls != 0 {
+		t.Fatalf("HasPrefixesAtRoot calls without persisted roots=%d want 0", noRootProbe.hasPrefixesCalls)
+	}
 }
 
 func TestInsertBatchPreflightCheckUniqueConflictsSkipsMissingRoots(t *testing.T) {
@@ -563,8 +582,8 @@ func TestInsertBatchPlanCheckPersistedConflictsRejectsIncompleteDerivedInputs(t 
 		resultIDs:   [][]byte{[]byte("u1")},
 		primaryKeys: [][]byte{[]byte("u1")},
 	}).checkPersistedConflicts(snap, catalog)
-	if err == nil || !strings.Contains(err.Error(), "missing unique probe runs") {
-		t.Fatalf("checkPersistedConflicts err=%v want missing unique probe runs", err)
+	if err == nil || !strings.Contains(err.Error(), "missing unique probe candidates") {
+		t.Fatalf("checkPersistedConflicts err=%v want missing unique probe candidates", err)
 	}
 
 	err = (&insertBatchPlan{

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -568,9 +568,9 @@ func TestInsertBatchPlanCheckPersistedConflictsRejectsIncompleteDerivedInputs(t 
 	}
 
 	err = (&insertBatchPlan{
-		resultIDs:          [][]byte{[]byte("u1")},
-		primaryKeys:        [][]byte{[]byte("u1")},
-		uniqueProbeRunsSet: true,
+		resultIDs:               [][]byte{[]byte("u1")},
+		primaryKeys:             [][]byte{[]byte("u1")},
+		allUniqueProbeRunsBuilt: true,
 	}).checkPersistedConflicts(snap, catalog)
 	if err != nil {
 		t.Fatalf("checkPersistedConflicts with built empty probes: %v", err)

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -475,6 +475,41 @@ func TestInsertBatchPlanner_BuildsUniqueProbePrefixesOnlyForPersistedRoots(t *te
 	}
 }
 
+func TestInsertBatchPlanCheckPersistedConflictsRejectsMissingInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		plan    *insertBatchPlan
+		catalog *collectionCatalog
+		want    string
+	}{
+		{name: "plan", want: "missing plan"},
+		{name: "snapshot", plan: &insertBatchPlan{}, catalog: &collectionCatalog{meta: CollectionMeta{Name: "users"}}, want: "missing snapshot"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.plan.checkPersistedConflicts(nil, tt.catalog)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("checkPersistedConflicts err=%v want %q", err, tt.want)
+			}
+		})
+	}
+
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	err = (&insertBatchPlan{}).checkPersistedConflicts(snap, nil)
+	if err == nil || !strings.Contains(err.Error(), "missing catalog") {
+		t.Fatalf("checkPersistedConflicts err=%v want missing catalog", err)
+	}
+}
+
 func TestInsertBatchPlanner_FailFastDuplicatesBeforePayloadConstruction(t *testing.T) {
 	builds := 0
 	planner := insertBatchPlanner{


### PR DESCRIPTION
## Summary

Shrinks the collection `InsertBatch` mutation lock for BSON/JSON indexed batch inserts. The insert path now builds root-local runs outside the collection mutation lock, then reacquires the lock to validate persisted conflicts against a fresh snapshot and publish. Template-v1 keeps the conservative locked planning path because its resolver can read existing template roots during preparation.

The PR also classifies root revalidation changes as `ErrConcurrentMutation` where they are safe to retry, so optimistic insert retries can replan against the latest roots instead of surfacing transient stale-root errors.

## Validation

- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1`

## Benchmark

Focused 100k-doc / 2-index / BSON / driver-command-raw run with 8 insert producers and 8 concurrent update writers, 80k update commands, no maintenance:

- PR3 stack: load `446,941 docs/sec`, concurrent update `22,706 docs/sec`
- This PR: load `554,110 docs/sec`, concurrent update `22,549 docs/sec`

Profile directory: `/tmp/gomap_pr4_insertlock_profile_kotLso`.