### PR TITLE
[codex] Combine collection update writes

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3026,9 +3026,6 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 	if combiner := c.updateCombiner(); combiner != nil {
 		return combiner.update(c, documentID, update)
 	}
-	if err := c.ensureWriteDomainOpen(); err != nil {
-		return false, false, err
-	}
 	return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
 }
 
@@ -3333,21 +3330,8 @@ func (combiner *collectionUpdateCombiner) stop() {
 	if combiner == nil {
 		return
 	}
-	closed := combiner.closeRequests()
-	if !closed {
-		return
-	}
-	if combiner.running.Load() {
-		return
-	}
-	if combiner.done != nil {
-		timer := time.NewTimer(collectionUpdateCombinerStopTimeout)
-		defer timer.Stop()
-		select {
-		case <-combiner.done:
-		case <-timer.C:
-		}
-	}
+	_ = combiner.closeRequests()
+	combiner.waitDoneWithTimeout(collectionUpdateCombinerStopTimeout)
 }
 
 func (combiner *collectionUpdateCombiner) waitDone() {
@@ -3355,6 +3339,28 @@ func (combiner *collectionUpdateCombiner) waitDone() {
 		return
 	}
 	<-combiner.done
+}
+
+func (combiner *collectionUpdateCombiner) waitDoneWithTimeout(timeout time.Duration) bool {
+	if combiner == nil || combiner.done == nil {
+		return true
+	}
+	if timeout <= 0 {
+		select {
+		case <-combiner.done:
+			return true
+		default:
+			return false
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-combiner.done:
+		return true
+	case <-timer.C:
+		return false
+	}
 }
 
 func (combiner *collectionUpdateCombiner) closeRequests() bool {
@@ -3478,7 +3484,7 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 			completeUpdateCombineBatchWithError(batch, collectionUpdatePanicError("combiner", recovered))
 		}
 	}()
-	if len(batch) == 1 || collectionUpdateCombineHasDuplicateIDs(batch) {
+	if len(batch) == 1 || collectionUpdateCombineHasDuplicateIDs(batch) || !collectionUpdateCombineSameCollection(batch) {
 		for _, req := range batch {
 			completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
 		}
@@ -3513,6 +3519,26 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 		result := results[i]
 		completeUpdateCombineRequest(req, collectionUpdateCombineResult{matched: result.Matched, modified: result.Modified})
 	}
+}
+
+func collectionUpdateCombineSameCollection(batch []collectionUpdateCombineRequest) bool {
+	if len(batch) == 0 {
+		return true
+	}
+	first := batch[0].collection
+	var firstDomain *collectionWriteDomain
+	if first != nil {
+		firstDomain = first.writeDomain
+	}
+	for _, req := range batch[1:] {
+		if req.collection == first {
+			continue
+		}
+		if req.collection == nil || firstDomain == nil || req.collection.writeDomain != firstDomain {
+			return false
+		}
+	}
+	return true
 }
 
 func runUpdateCombineDirect(req collectionUpdateCombineRequest) collectionUpdateCombineResult {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3442,7 +3442,7 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 	}
 	batch := make([]collectionUpdateCombineRequest, 0, batchCap)
 	batch = append(batch, first)
-	for len(batch) < combiner.maxBatch {
+	for len(batch) < batchCap {
 		select {
 		case req, ok := <-combiner.requests:
 			if !ok {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -370,6 +370,7 @@ type collectionWriteDomain struct {
 	mu                sync.RWMutex
 	updateCombineMu   sync.Mutex
 	updateCombiner    *collectionUpdateCombiner
+	updateDraining    *collectionUpdateCombiner
 	updateCombineDone bool
 	updateCombineTTL  time.Duration
 	closingWrites     atomic.Bool
@@ -3202,6 +3203,11 @@ func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 			domain.updateCombineMu.Unlock()
 			return nil
 		}
+		if draining := domain.updateDraining; draining != nil {
+			domain.updateCombineMu.Unlock()
+			draining.waitDone()
+			continue
+		}
 		if domain.updateCombiner != nil {
 			combiner := domain.updateCombiner
 			if !combiner.isStopped() {
@@ -3235,11 +3241,16 @@ func (domain *collectionWriteDomain) stopUpdateCombiner() {
 	domain.closingWrites.Store(true)
 	domain.updateCombineMu.Lock()
 	combiner := domain.updateCombiner
+	draining := domain.updateDraining
 	domain.updateCombiner = nil
+	domain.updateDraining = nil
 	domain.updateCombineDone = true
 	domain.updateCombineMu.Unlock()
 	if combiner != nil {
 		combiner.stop()
+	}
+	if draining != nil && draining != combiner {
+		draining.waitDone()
 	}
 }
 
@@ -3262,6 +3273,9 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 	if !combiner.enqueue(req) {
 		// Combining is a best-effort throughput optimization. Saturated or stopped
 		// combiners fall back to the direct path so updates still make progress.
+		if combiner.isStopped() {
+			combiner.waitDone()
+		}
 		if err := c.ensureWriteDomainOpen(); err != nil {
 			return false, false, err
 		}
@@ -3334,6 +3348,13 @@ func (combiner *collectionUpdateCombiner) stop() {
 	}
 }
 
+func (combiner *collectionUpdateCombiner) waitDone() {
+	if combiner == nil || combiner.done == nil {
+		return
+	}
+	<-combiner.done
+}
+
 func (combiner *collectionUpdateCombiner) closeRequests() bool {
 	combiner.mu.Lock()
 	defer combiner.mu.Unlock()
@@ -3404,6 +3425,10 @@ func (combiner *collectionUpdateCombiner) retireIdle() bool {
 		combiner.domain.updateCombineMu.Lock()
 		if combiner.domain.updateCombiner == combiner {
 			stopped = combiner.closeRequests()
+			if stopped {
+				combiner.domain.updateCombiner = nil
+				combiner.domain.updateDraining = combiner
+			}
 		}
 		combiner.domain.updateCombineMu.Unlock()
 	} else {
@@ -3417,8 +3442,8 @@ func (combiner *collectionUpdateCombiner) retireIdle() bool {
 	}
 	if combiner.domain != nil {
 		combiner.domain.updateCombineMu.Lock()
-		if combiner.domain.updateCombiner == combiner {
-			combiner.domain.updateCombiner = nil
+		if combiner.domain.updateDraining == combiner {
+			combiner.domain.updateDraining = nil
 		}
 		combiner.domain.updateCombineMu.Unlock()
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -349,6 +349,7 @@ type collectionWriteDomain struct {
 	updateCombineMu   sync.Mutex
 	updateCombiner    *collectionUpdateCombiner
 	updateCombineDone bool
+	updateCombineTTL  time.Duration
 	loaded            bool
 	meta              CollectionMeta
 	catalog           *collectionCatalog
@@ -2871,7 +2872,7 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 	if combiner := c.updateCombiner(); combiner != nil {
 		return combiner.update(c, documentID, update)
 	}
-	return c.updateDirect(documentID, update)
+	return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
 }
 
 func validateCollectionUpdateInput(c *Collection, documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) error {
@@ -3013,7 +3014,7 @@ func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 		}
 		combiner := &collectionUpdateCombiner{
 			maxBatch: defaultCollectionUpdateCombineMaxBatch,
-			idleTTL:  collectionUpdateCombineIdleTTL,
+			idleTTL:  domain.updateCombineIdleTTL(),
 			requests: make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4),
 			done:     make(chan struct{}),
 			domain:   domain,
@@ -3051,7 +3052,7 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 		done:       done,
 	}
 	if !combiner.enqueue(req) {
-		return c.updateDirect(documentID, update)
+		return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
 	}
 	result := <-done
 	return result.matched, result.modified, result.err
@@ -3207,7 +3208,7 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 	for i, req := range batch {
 		items[i] = UpdateBatchItem{
 			DocumentID: req.documentID,
-			Update:     recoverUpdateCombineCallback(req.update),
+			Update:     recoverCollectionUpdateCallback(req.update),
 		}
 	}
 	results, err := batch[0].collection.UpdateBatch(items)
@@ -3228,21 +3229,28 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 }
 
 func runUpdateCombineDirect(req collectionUpdateCombineRequest) collectionUpdateCombineResult {
-	matched, modified, err := req.collection.updateDirect(req.documentID, recoverUpdateCombineCallback(req.update))
+	matched, modified, err := req.collection.updateDirect(req.documentID, recoverCollectionUpdateCallback(req.update))
 	return collectionUpdateCombineResult{matched: matched, modified: modified, err: err}
 }
 
-func recoverUpdateCombineCallback(update func(current []byte) (replacement []byte, changed bool, err error)) func(current []byte) (replacement []byte, changed bool, err error) {
+func recoverCollectionUpdateCallback(update func(current []byte) (replacement []byte, changed bool, err error)) func(current []byte) (replacement []byte, changed bool, err error) {
 	return func(current []byte) (replacement []byte, changed bool, err error) {
 		defer func() {
 			if recovered := recover(); recovered != nil {
 				replacement = nil
 				changed = false
-				err = fmt.Errorf("collections: update combiner callback panic (%T): %v\n%s", recovered, recovered, debug.Stack())
+				err = fmt.Errorf("collections: update callback panic (%T): %v\n%s", recovered, recovered, debug.Stack())
 			}
 		}()
 		return update(current)
 	}
+}
+
+func (domain *collectionWriteDomain) updateCombineIdleTTL() time.Duration {
+	if domain != nil && domain.updateCombineTTL > 0 {
+		return domain.updateCombineTTL
+	}
+	return collectionUpdateCombineIdleTTL
 }
 
 func completeUpdateCombineBatchWithError(batch []collectionUpdateCombineRequest, err error) {
@@ -3252,13 +3260,10 @@ func completeUpdateCombineBatchWithError(batch []collectionUpdateCombineRequest,
 }
 
 func completeUpdateCombineRequest(req collectionUpdateCombineRequest, result collectionUpdateCombineResult) {
-	if req.done == nil || cap(req.done) == 0 {
+	if req.done == nil {
 		return
 	}
-	select {
-	case req.done <- result:
-	default:
-	}
+	req.done <- result
 }
 
 func collectionUpdateCombineHasDuplicateIDs(batch []collectionUpdateCombineRequest) bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -127,6 +128,7 @@ func persistIndexStateForDocumentFormat(format DocumentFormat) bool {
 type CollectionManager struct {
 	db              *backenddb.DB
 	closeUnregister func()
+	closing         atomic.Bool
 	domainMu        sync.Mutex
 	domains         map[string]*collectionWriteDomain
 }
@@ -334,26 +336,27 @@ type collectionWriteDomain struct {
 	// mutationMu serializes root descriptor publishes for handles opened
 	// through the same manager so optimistic retries do not starve under
 	// sustained collection write contention.
-	mutationMu       sync.Mutex
-	mu               sync.RWMutex
-	updateCombineMu  sync.Mutex
-	updateCombiner   *collectionUpdateCombiner
-	loaded           bool
-	meta             CollectionMeta
-	catalog          *collectionCatalog
-	baseCommitSeq    uint64
-	baseSystemRoot   uint64
-	primaryRoot      uint64
-	storagePolicy    backenddb.OrderedRootStoragePolicy
-	table            memtable.Table
-	rootRuns         map[string][]memtable.Table
-	rootPolicies     map[string]backenddb.OrderedRootStoragePolicy
-	rootBaseIDs      map[string]uint64
-	primaryIDIndex   *bufferedUniqueValueIndex
-	uniqueValueRuns  map[string][]memtable.Table
-	uniqueValueIndex map[string]*bufferedUniqueValueIndex
-	count            int
-	bufferedBytes    int64
+	mutationMu        sync.Mutex
+	mu                sync.RWMutex
+	updateCombineMu   sync.Mutex
+	updateCombiner    *collectionUpdateCombiner
+	updateCombineDone bool
+	loaded            bool
+	meta              CollectionMeta
+	catalog           *collectionCatalog
+	baseCommitSeq     uint64
+	baseSystemRoot    uint64
+	primaryRoot       uint64
+	storagePolicy     backenddb.OrderedRootStoragePolicy
+	table             memtable.Table
+	rootRuns          map[string][]memtable.Table
+	rootPolicies      map[string]backenddb.OrderedRootStoragePolicy
+	rootBaseIDs       map[string]uint64
+	primaryIDIndex    *bufferedUniqueValueIndex
+	uniqueValueRuns   map[string][]memtable.Table
+	uniqueValueIndex  map[string]*bufferedUniqueValueIndex
+	count             int
+	bufferedBytes     int64
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -365,9 +368,14 @@ func NewCollectionManager(database *backenddb.DB) *CollectionManager {
 }
 
 func (m *CollectionManager) closeForBackend() error {
+	m.closing.Store(true)
 	err := m.FlushAll()
 	m.stopUpdateCombiners()
 	return err
+}
+
+func (m *CollectionManager) isClosing() bool {
+	return m == nil || m.closing.Load() || m.db == nil || m.db.IsClosing()
 }
 
 func (m *CollectionManager) stopUpdateCombiners() {
@@ -418,8 +426,14 @@ func (m *CollectionManager) writeDomainForCollection(name string) *collectionWri
 	if m == nil {
 		return nil
 	}
+	if m.closing.Load() {
+		return nil
+	}
 	m.domainMu.Lock()
 	defer m.domainMu.Unlock()
+	if m.closing.Load() {
+		return nil
+	}
 	if m.domains == nil {
 		m.domains = make(map[string]*collectionWriteDomain)
 	}
@@ -433,6 +447,9 @@ func (m *CollectionManager) writeDomainForCollection(name string) *collectionWri
 
 func (m *CollectionManager) existingWriteDomainForCollection(name string) *collectionWriteDomain {
 	if m == nil {
+		return nil
+	}
+	if m.closing.Load() {
 		return nil
 	}
 	m.domainMu.Lock()
@@ -494,6 +511,9 @@ func (m *CollectionManager) CreateCollection(meta *CollectionMeta) (*CollectionM
 	}
 	if m.db == nil {
 		return nil, errors.New("collections: db is nil")
+	}
+	if m.isClosing() {
+		return nil, backenddb.ErrClosed
 	}
 	if meta == nil {
 		return nil, errors.New("collections: nil collection metadata")
@@ -560,7 +580,7 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 	if err := ValidateCollectionName(name); err != nil {
 		return nil, err
 	}
-	if m.db.IsClosing() {
+	if m.isClosing() {
 		return nil, backenddb.ErrClosed
 	}
 	if collection, ok := m.openCollectionFromWriteDomainCache(name); ok {
@@ -583,13 +603,16 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 		writeDomain: m.writeDomainForCollection(catalog.meta.Name),
 		meta:        catalog.meta,
 	}
+	if collection.writeDomain == nil {
+		return nil, backenddb.ErrClosed
+	}
 	collection.rememberCatalog(snap, catalog)
 	collection.noteWriteDomainCatalog(snapshotSystemRoot(snap), catalog)
 	return collection, nil
 }
 
 func (m *CollectionManager) openCollectionFromWriteDomainCache(name string) (*Collection, bool) {
-	if m == nil || m.db == nil {
+	if m == nil || m.db == nil || m.isClosing() {
 		return nil, false
 	}
 	state := m.db.State()
@@ -2953,6 +2976,9 @@ func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 	domain := c.writeDomain
 	domain.updateCombineMu.Lock()
 	defer domain.updateCombineMu.Unlock()
+	if domain.updateCombineDone {
+		return nil
+	}
 	if domain.updateCombiner != nil {
 		return domain.updateCombiner
 	}
@@ -2972,6 +2998,7 @@ func (domain *collectionWriteDomain) stopUpdateCombiner() {
 	domain.updateCombineMu.Lock()
 	combiner := domain.updateCombiner
 	domain.updateCombiner = nil
+	domain.updateCombineDone = true
 	domain.updateCombineMu.Unlock()
 	if combiner != nil {
 		combiner.stop()
@@ -3046,10 +3073,14 @@ func (combiner *collectionUpdateCombiner) run() {
 }
 
 func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombineRequest) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			completeUpdateCombineBatchWithError(batch, fmt.Errorf("collections: update combiner panic: %v", recovered))
+		}
+	}()
 	if len(batch) == 1 || collectionUpdateCombineHasDuplicateIDs(batch) {
 		for _, req := range batch {
-			matched, modified, err := req.collection.updateDirect(req.documentID, req.update)
-			req.done <- collectionUpdateCombineResult{matched: matched, modified: modified, err: err}
+			completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
 		}
 		return
 	}
@@ -3057,31 +3088,68 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 	for i, req := range batch {
 		items[i] = UpdateBatchItem{
 			DocumentID: req.documentID,
-			Update:     req.update,
+			Update:     recoverUpdateCombineCallback(req.update),
 		}
 	}
 	results, err := batch[0].collection.UpdateBatch(items)
 	if err != nil {
 		for _, req := range batch {
-			matched, modified, err := req.collection.updateDirect(req.documentID, req.update)
-			req.done <- collectionUpdateCombineResult{matched: matched, modified: modified, err: err}
+			completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
 		}
 		return
 	}
 	for i, req := range batch {
 		result := results[i]
-		req.done <- collectionUpdateCombineResult{matched: result.Matched, modified: result.Modified}
+		completeUpdateCombineRequest(req, collectionUpdateCombineResult{matched: result.Matched, modified: result.Modified})
+	}
+}
+
+func runUpdateCombineDirect(req collectionUpdateCombineRequest) collectionUpdateCombineResult {
+	matched, modified, err := req.collection.updateDirect(req.documentID, recoverUpdateCombineCallback(req.update))
+	return collectionUpdateCombineResult{matched: matched, modified: modified, err: err}
+}
+
+func recoverUpdateCombineCallback(update func(current []byte) (replacement []byte, changed bool, err error)) func(current []byte) (replacement []byte, changed bool, err error) {
+	return func(current []byte) (replacement []byte, changed bool, err error) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				replacement = nil
+				changed = false
+				err = fmt.Errorf("collections: update combiner callback panic: %v", recovered)
+			}
+		}()
+		return update(current)
+	}
+}
+
+func completeUpdateCombineBatchWithError(batch []collectionUpdateCombineRequest, err error) {
+	for _, req := range batch {
+		completeUpdateCombineRequest(req, collectionUpdateCombineResult{err: err})
+	}
+}
+
+func completeUpdateCombineRequest(req collectionUpdateCombineRequest, result collectionUpdateCombineResult) {
+	select {
+	case req.done <- result:
+	default:
 	}
 }
 
 func collectionUpdateCombineHasDuplicateIDs(batch []collectionUpdateCombineRequest) bool {
-	seen := make(map[string]struct{}, len(batch))
-	for _, req := range batch {
-		key := string(req.documentID)
-		if _, ok := seen[key]; ok {
+	if len(batch) < 2 {
+		return false
+	}
+	order := make([]int, len(batch))
+	for i := range order {
+		order[i] = i
+	}
+	sort.Slice(order, func(i, j int) bool {
+		return bytes.Compare(batch[order[i]].documentID, batch[order[j]].documentID) < 0
+	})
+	for i := 1; i < len(order); i++ {
+		if bytes.Equal(batch[order[i-1]].documentID, batch[order[i]].documentID) {
 			return true
 		}
-		seen[key] = struct{}{}
 	}
 	return false
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3309,7 +3309,10 @@ func (combiner *collectionUpdateCombiner) enqueue(req collectionUpdateCombineReq
 	if combiner == nil {
 		return false
 	}
-	if req.done == nil || cap(req.done) == 0 {
+	if validateCollectionUpdateCombineRequest(req) != nil {
+		return false
+	}
+	if req.done == nil || cap(req.done) == 0 || len(req.done) > 0 {
 		return false
 	}
 	combiner.mu.RLock()
@@ -3524,8 +3527,27 @@ func collectionUpdateCombineSameCollection(batch []collectionUpdateCombineReques
 }
 
 func runUpdateCombineDirect(req collectionUpdateCombineRequest) collectionUpdateCombineResult {
+	if err := validateCollectionUpdateCombineRequest(req); err != nil {
+		return collectionUpdateCombineResult{err: err}
+	}
 	matched, modified, err := req.collection.updateDirect(req.documentID, recoverCollectionUpdateCallback(req.update))
 	return collectionUpdateCombineResult{matched: matched, modified: modified, err: err}
+}
+
+func validateCollectionUpdateCombineRequest(req collectionUpdateCombineRequest) error {
+	if req.collection == nil {
+		return errCollectionNil
+	}
+	if req.collection.db == nil {
+		return errCollectionDBNil
+	}
+	if len(req.documentID) == 0 {
+		return errors.New("collections: document id cannot be empty")
+	}
+	if req.update == nil {
+		return errors.New("collections: update function is nil")
+	}
+	return nil
 }
 
 func collectionUpdatePanicError(where string, recovered any) error {
@@ -3584,10 +3606,7 @@ func completeUpdateCombineRequest(req collectionUpdateCombineRequest, result col
 	if req.done == nil {
 		return
 	}
-	select {
-	case req.done <- result:
-	default:
-	}
+	req.done <- result
 }
 
 func collectionUpdateCombineHasDuplicateIDs(batch []collectionUpdateCombineRequest) bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3381,8 +3381,17 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 			Update:     recoverCollectionUpdateCallback(req.update),
 		}
 	}
-	results, err := batch[0].collection.UpdateBatch(items)
+	results, batched, err := batch[0].collection.UpdateBatchIfNoSecondaryUniqueIndexes(items)
+	if !batched && err == nil {
+		for _, req := range batch {
+			completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+		}
+		return
+	}
 	if err != nil {
+		if completeUpdateCombineBatchWithItemFallback(batch, err) {
+			return
+		}
 		completeUpdateCombineBatchWithError(batch, err)
 		return
 	}
@@ -3429,6 +3438,28 @@ func completeUpdateCombineBatchWithError(batch []collectionUpdateCombineRequest,
 	for _, req := range batch {
 		completeUpdateCombineRequest(req, collectionUpdateCombineResult{err: err})
 	}
+}
+
+func completeUpdateCombineBatchWithItemFallback(batch []collectionUpdateCombineRequest, err error) bool {
+	var itemErr *UpdateBatchItemError
+	if !errors.As(err, &itemErr) {
+		return false
+	}
+	if itemErr.Index < 0 || itemErr.Index >= len(batch) {
+		return false
+	}
+	for i, req := range batch {
+		if i == itemErr.Index {
+			reqErr := itemErr.Err
+			if reqErr == nil {
+				reqErr = err
+			}
+			completeUpdateCombineRequest(req, collectionUpdateCombineResult{err: reqErr})
+			continue
+		}
+		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+	}
+	return true
 }
 
 func completeUpdateCombineRequest(req collectionUpdateCombineRequest, result collectionUpdateCombineResult) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -392,14 +392,14 @@ func (m *CollectionManager) stopUpdateCombiners() {
 	if m == nil {
 		return
 	}
-	m.domainMu.Lock()
+	m.domainMu.RLock()
 	domains := make([]*collectionWriteDomain, 0, len(m.domains))
 	for _, domain := range m.domains {
 		if domain != nil {
 			domains = append(domains, domain)
 		}
 	}
-	m.domainMu.Unlock()
+	m.domainMu.RUnlock()
 	for _, domain := range domains {
 		domain.stopUpdateCombiner()
 	}
@@ -3229,7 +3229,9 @@ func (combiner *collectionUpdateCombiner) closeRequests() bool {
 		return false
 	}
 	combiner.stopped = true
-	close(combiner.requests)
+	if combiner.requests != nil {
+		close(combiner.requests)
+	}
 	return true
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -38,7 +38,6 @@ const (
 	DefaultIndexedWriteMemtableDirectBatchDocuments = DefaultIndexedWriteMemtableMaxDocuments / 4
 	defaultCollectionUpdateCombineMaxBatch          = 256
 	collectionUpdateCombineIdleTTL                  = 30 * time.Second
-	collectionUpdateCombinerStopTimeout             = 5 * time.Second
 )
 
 var (
@@ -3331,7 +3330,7 @@ func (combiner *collectionUpdateCombiner) stop() {
 		return
 	}
 	_ = combiner.closeRequests()
-	combiner.waitDoneWithTimeout(collectionUpdateCombinerStopTimeout)
+	combiner.waitDone()
 }
 
 func (combiner *collectionUpdateCombiner) waitDone() {
@@ -3339,28 +3338,6 @@ func (combiner *collectionUpdateCombiner) waitDone() {
 		return
 	}
 	<-combiner.done
-}
-
-func (combiner *collectionUpdateCombiner) waitDoneWithTimeout(timeout time.Duration) bool {
-	if combiner == nil || combiner.done == nil {
-		return true
-	}
-	if timeout <= 0 {
-		select {
-		case <-combiner.done:
-			return true
-		default:
-			return false
-		}
-	}
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case <-combiner.done:
-		return true
-	case <-timer.C:
-		return false
-	}
 }
 
 func (combiner *collectionUpdateCombiner) closeRequests() bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -71,6 +71,7 @@ type UpdateBatchItem struct {
 type UpdateBatchResult struct {
 	Matched  bool
 	Modified bool
+	Err      error
 }
 
 func IsDuplicateKeyError(err error) bool {
@@ -3032,15 +3033,14 @@ func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 		}
 		if domain.updateCombiner != nil {
 			combiner := domain.updateCombiner
-			done := combiner.done
 			if !combiner.isStopped() {
 				domain.updateCombineMu.Unlock()
 				return combiner
 			}
-			domain.updateCombineMu.Unlock()
-			if done != nil {
-				<-done
+			if domain.updateCombiner == combiner {
+				domain.updateCombiner = nil
 			}
+			domain.updateCombineMu.Unlock()
 			continue
 		}
 		combiner := &collectionUpdateCombiner{
@@ -3255,8 +3255,15 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 	}
 	for i, req := range batch {
 		result := results[i]
-		completeUpdateCombineRequest(req, collectionUpdateCombineResult{matched: result.Matched, modified: result.Modified})
+		completeUpdateCombineRequest(req, updateCombineResultFromBatchResult(result))
 	}
+}
+
+func updateCombineResultFromBatchResult(result UpdateBatchResult) collectionUpdateCombineResult {
+	if result.Err != nil {
+		return collectionUpdateCombineResult{err: result.Err}
+	}
+	return collectionUpdateCombineResult{matched: result.Matched, modified: result.Modified}
 }
 
 func runUpdateCombineDirect(req collectionUpdateCombineRequest) collectionUpdateCombineResult {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -38,6 +38,7 @@ const (
 	DefaultIndexedWriteMemtableDirectBatchDocuments = DefaultIndexedWriteMemtableMaxDocuments / 4
 	defaultCollectionUpdateCombineMaxBatch          = 256
 	collectionUpdateCombineIdleTTL                  = 30 * time.Second
+	collectionUpdateCombinerStopTimeout             = 5 * time.Second
 )
 
 var (
@@ -2977,10 +2978,11 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 // Update applies update to the latest document value and retries if another
 // collection write changes the root before this update publishes.
 //
-// When the collection write domain combines concurrent updates, update may run
-// on an internal combiner goroutine. The callback must not rely on caller
-// goroutine behavior such as recover, runtime.Goexit, or testing.T.Fatal.
-// Callback panics are recovered and returned as errors.
+// Callback panics are recovered and returned as errors in both direct and
+// combined execution. When the collection write domain combines concurrent
+// updates, update may run on an internal combiner goroutine. The callback must
+// not rely on caller goroutine behavior such as recover, runtime.Goexit, or
+// testing.T.Fatal.
 func (c *Collection) Update(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
 	if err := validateCollectionUpdateInput(c, documentID, update); err != nil {
 		return false, false, err
@@ -3249,7 +3251,12 @@ func (combiner *collectionUpdateCombiner) stop() {
 	}
 	_ = combiner.closeRequests()
 	if combiner.done != nil {
-		<-combiner.done
+		timer := time.NewTimer(collectionUpdateCombinerStopTimeout)
+		defer timer.Stop()
+		select {
+		case <-combiner.done:
+		case <-timer.C:
+		}
 	}
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3085,7 +3085,16 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 	if !combiner.enqueue(req) {
 		return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
 	}
-	result := <-done
+	var result collectionUpdateCombineResult
+	select {
+	case result = <-done:
+	case <-combiner.done:
+		select {
+		case result = <-done:
+		default:
+			return false, false, errors.New("collections: update combiner stopped before completing request")
+		}
+	}
 	return result.matched, result.modified, result.err
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3436,7 +3436,8 @@ func (combiner *collectionUpdateCombiner) retireIdle() bool {
 }
 
 func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionUpdateCombineRequest) {
-	batch := []collectionUpdateCombineRequest{first}
+	batch := make([]collectionUpdateCombineRequest, 0, combiner.maxBatch)
+	batch = append(batch, first)
 	for len(batch) < combiner.maxBatch {
 		select {
 		case req, ok := <-combiner.requests:

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3073,7 +3073,7 @@ func (domain *collectionWriteDomain) stopUpdateCombiner() {
 
 func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
 	if combiner == nil || combiner.maxBatch <= 1 {
-		return c.updateDirect(documentID, update)
+		return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
 	}
 	done := make(chan collectionUpdateCombineResult, 1)
 	req := collectionUpdateCombineRequest{

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3383,9 +3383,7 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 	}
 	results, err := batch[0].collection.UpdateBatch(items)
 	if err != nil {
-		for _, req := range batch {
-			completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
-		}
+		completeUpdateCombineBatchWithError(batch, err)
 		return
 	}
 	if len(results) != len(batch) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -54,7 +54,7 @@ var (
 	errCollectionNil         = errors.New("collections: collection is nil")
 	errCollectionDBNil       = errors.New("collections: db is nil")
 	errCollectionNotFound    = ErrCollectionNotFound
-	errUpdateCombinerStopped = errors.New("collections: update combiner stopped before completing request")
+	errUpdateCombinerStopped = errors.New("collections: update combiner stopped before completing request; request was not completed and caller may retry")
 )
 
 // UpdateBatchItem describes one document update in a batch. DocumentID must be
@@ -72,7 +72,6 @@ type UpdateBatchItem struct {
 type UpdateBatchResult struct {
 	Matched  bool
 	Modified bool
-	Err      error
 }
 
 func IsDuplicateKeyError(err error) bool {
@@ -3191,18 +3190,9 @@ func (combiner *collectionUpdateCombiner) isStopped() bool {
 	return combiner.stopped
 }
 
-func (combiner *collectionUpdateCombiner) markStopped() {
-	if combiner == nil {
-		return
-	}
-	combiner.mu.Lock()
-	combiner.stopped = true
-	combiner.mu.Unlock()
-}
-
 func (combiner *collectionUpdateCombiner) run() {
 	defer func() {
-		combiner.markStopped()
+		_ = combiner.closeRequests()
 		if combiner.done != nil {
 			close(combiner.done)
 		}
@@ -3322,15 +3312,8 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 	}
 	for i, req := range batch {
 		result := results[i]
-		completeUpdateCombineRequest(req, updateCombineResultFromBatchResult(result))
+		completeUpdateCombineRequest(req, collectionUpdateCombineResult{matched: result.Matched, modified: result.Modified})
 	}
-}
-
-func updateCombineResultFromBatchResult(result UpdateBatchResult) collectionUpdateCombineResult {
-	if result.Err != nil {
-		return collectionUpdateCombineResult{err: result.Err}
-	}
-	return collectionUpdateCombineResult{matched: result.Matched, modified: result.Modified}
 }
 
 func runUpdateCombineDirect(req collectionUpdateCombineRequest) collectionUpdateCombineResult {
@@ -3368,7 +3351,10 @@ func completeUpdateCombineRequest(req collectionUpdateCombineRequest, result col
 	if req.done == nil {
 		return
 	}
-	req.done <- result
+	select {
+	case req.done <- result:
+	default:
+	}
 }
 
 func collectionUpdateCombineHasDuplicateIDs(batch []collectionUpdateCombineRequest) bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2989,10 +2989,10 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 // Update applies update to the latest document value and retries if another
 // collection write changes the root before this update publishes.
 //
-// When the collection write domain combines concurrent updates, update may run
-// on an internal combiner goroutine. The callback must not rely on caller
-// goroutine behavior such as recover, runtime.Goexit, or testing.T.Fatal.
-// Callback panics are recovered and returned as errors.
+// Callback panics are recovered and returned as errors. When the collection
+// write domain combines concurrent updates, update may run on an internal
+// combiner goroutine; the callback must not rely on caller goroutine behavior
+// such as recover, runtime.Goexit, or testing.T.Fatal.
 func (c *Collection) Update(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
 	if err := validateCollectionUpdateInput(c, documentID, update); err != nil {
 		return false, false, err
@@ -3124,6 +3124,7 @@ type collectionUpdateCombiner struct {
 	requests chan collectionUpdateCombineRequest
 	done     chan struct{}
 	domain   *collectionWriteDomain
+	running  atomic.Bool
 	mu       sync.RWMutex
 	stopped  bool
 }
@@ -3259,7 +3260,13 @@ func (combiner *collectionUpdateCombiner) stop() {
 	if combiner == nil {
 		return
 	}
-	_ = combiner.closeRequests()
+	closed := combiner.closeRequests()
+	if !closed {
+		return
+	}
+	if combiner.running.Load() {
+		return
+	}
 	if combiner.done != nil {
 		<-combiner.done
 	}
@@ -3375,6 +3382,8 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 }
 
 func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombineRequest) {
+	combiner.running.Store(true)
+	defer combiner.running.Store(false)
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			completeUpdateCombineBatchWithError(batch, collectionUpdatePanicError("combiner", recovered))

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3436,7 +3436,12 @@ func (combiner *collectionUpdateCombiner) retireIdle() bool {
 }
 
 func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionUpdateCombineRequest) {
-	batch := []collectionUpdateCombineRequest{first}
+	batchCap := combiner.maxBatch
+	if batchCap < 1 {
+		batchCap = 1
+	}
+	batch := make([]collectionUpdateCombineRequest, 0, batchCap)
+	batch = append(batch, first)
 	for len(batch) < combiner.maxBatch {
 		select {
 		case req, ok := <-combiner.requests:

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -2989,24 +2990,37 @@ func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 		return nil
 	}
 	domain := c.writeDomain
-	domain.updateCombineMu.Lock()
-	defer domain.updateCombineMu.Unlock()
-	if domain.updateCombineDone {
-		return nil
+	for {
+		domain.updateCombineMu.Lock()
+		if domain.updateCombineDone {
+			domain.updateCombineMu.Unlock()
+			return nil
+		}
+		if domain.updateCombiner != nil {
+			combiner := domain.updateCombiner
+			done := combiner.done
+			if !combiner.isStopped() {
+				domain.updateCombineMu.Unlock()
+				return combiner
+			}
+			domain.updateCombineMu.Unlock()
+			if done != nil {
+				<-done
+			}
+			continue
+		}
+		combiner := &collectionUpdateCombiner{
+			maxBatch: defaultCollectionUpdateCombineMaxBatch,
+			idleTTL:  collectionUpdateCombineIdleTTL,
+			requests: make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4),
+			done:     make(chan struct{}),
+			domain:   domain,
+		}
+		domain.updateCombiner = combiner
+		domain.updateCombineMu.Unlock()
+		go combiner.run()
+		return combiner
 	}
-	if domain.updateCombiner != nil {
-		return domain.updateCombiner
-	}
-	combiner := &collectionUpdateCombiner{
-		maxBatch: defaultCollectionUpdateCombineMaxBatch,
-		idleTTL:  collectionUpdateCombineIdleTTL,
-		requests: make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4),
-		done:     make(chan struct{}),
-		domain:   domain,
-	}
-	domain.updateCombiner = combiner
-	go combiner.run()
-	return combiner
 }
 
 func (domain *collectionWriteDomain) stopUpdateCombiner() {
@@ -3045,6 +3059,9 @@ func (combiner *collectionUpdateCombiner) enqueue(req collectionUpdateCombineReq
 	if combiner == nil {
 		return false
 	}
+	if req.done == nil || cap(req.done) == 0 {
+		return false
+	}
 	combiner.mu.RLock()
 	defer combiner.mu.RUnlock()
 	if combiner.stopped {
@@ -3077,6 +3094,12 @@ func (combiner *collectionUpdateCombiner) closeRequests() bool {
 	combiner.stopped = true
 	close(combiner.requests)
 	return true
+}
+
+func (combiner *collectionUpdateCombiner) isStopped() bool {
+	combiner.mu.RLock()
+	defer combiner.mu.RUnlock()
+	return combiner.stopped
 }
 
 func (combiner *collectionUpdateCombiner) run() {
@@ -3127,9 +3150,6 @@ func (combiner *collectionUpdateCombiner) retireIdle() bool {
 		combiner.domain.updateCombineMu.Lock()
 		if combiner.domain.updateCombiner == combiner {
 			stopped = combiner.closeRequests()
-			if stopped {
-				combiner.domain.updateCombiner = nil
-			}
 		}
 		combiner.domain.updateCombineMu.Unlock()
 	} else {
@@ -3140,6 +3160,13 @@ func (combiner *collectionUpdateCombiner) retireIdle() bool {
 	}
 	for req := range combiner.requests {
 		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+	}
+	if combiner.domain != nil {
+		combiner.domain.updateCombineMu.Lock()
+		if combiner.domain.updateCombiner == combiner {
+			combiner.domain.updateCombiner = nil
+		}
+		combiner.domain.updateCombineMu.Unlock()
 	}
 	return true
 }
@@ -3165,7 +3192,7 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombineRequest) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			completeUpdateCombineBatchWithError(batch, fmt.Errorf("collections: update combiner panic: %v", recovered))
+			completeUpdateCombineBatchWithError(batch, fmt.Errorf("collections: update combiner panic (%T): %v\n%s", recovered, recovered, debug.Stack()))
 		}
 	}()
 	if len(batch) == 1 || collectionUpdateCombineHasDuplicateIDs(batch) {
@@ -3209,7 +3236,7 @@ func recoverUpdateCombineCallback(update func(current []byte) (replacement []byt
 			if recovered := recover(); recovered != nil {
 				replacement = nil
 				changed = false
-				err = fmt.Errorf("collections: update combiner callback panic: %v", recovered)
+				err = fmt.Errorf("collections: update combiner callback panic (%T): %v\n%s", recovered, recovered, debug.Stack())
 			}
 		}()
 		return update(current)
@@ -3223,6 +3250,9 @@ func completeUpdateCombineBatchWithError(batch []collectionUpdateCombineRequest,
 }
 
 func completeUpdateCombineRequest(req collectionUpdateCombineRequest, result collectionUpdateCombineResult) {
+	if req.done == nil || cap(req.done) == 0 {
+		return
+	}
 	select {
 	case req.done <- result:
 	default:
@@ -3233,17 +3263,13 @@ func collectionUpdateCombineHasDuplicateIDs(batch []collectionUpdateCombineReque
 	if len(batch) < 2 {
 		return false
 	}
-	order := make([]int, len(batch))
-	for i := range order {
-		order[i] = i
-	}
-	sort.Slice(order, func(i, j int) bool {
-		return bytes.Compare(batch[order[i]].documentID, batch[order[j]].documentID) < 0
-	})
-	for i := 1; i < len(order); i++ {
-		if bytes.Equal(batch[order[i-1]].documentID, batch[order[i]].documentID) {
+	seen := make(map[string]struct{}, len(batch))
+	for _, req := range batch {
+		key := string(req.documentID)
+		if _, ok := seen[key]; ok {
 			return true
 		}
+		seen[key] = struct{}{}
 	}
 	return false
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -39,6 +39,8 @@ const (
 	defaultCollectionUpdateCombineMaxBatch          = 256
 )
 
+var collectionUpdateCombineIdleTTL = 30 * time.Second
+
 var (
 	ErrCollectionNotFound  = errors.New("collections: collection not found")
 	ErrDocumentExists      = errors.New("collections: document already exists")
@@ -369,9 +371,8 @@ func NewCollectionManager(database *backenddb.DB) *CollectionManager {
 
 func (m *CollectionManager) closeForBackend() error {
 	m.closing.Store(true)
-	err := m.FlushAll()
 	m.stopUpdateCombiners()
-	return err
+	return m.FlushAll()
 }
 
 func (m *CollectionManager) isClosing() bool {
@@ -2957,7 +2958,10 @@ func validateUpdateBatchItems(items []UpdateBatchItem) error {
 
 type collectionUpdateCombiner struct {
 	maxBatch int
+	idleTTL  time.Duration
 	requests chan collectionUpdateCombineRequest
+	done     chan struct{}
+	domain   *collectionWriteDomain
 	mu       sync.RWMutex
 	stopped  bool
 }
@@ -2990,7 +2994,10 @@ func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 	}
 	combiner := &collectionUpdateCombiner{
 		maxBatch: defaultCollectionUpdateCombineMaxBatch,
+		idleTTL:  collectionUpdateCombineIdleTTL,
 		requests: make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4),
+		done:     make(chan struct{}),
+		domain:   domain,
 	}
 	domain.updateCombiner = combiner
 	go combiner.run()
@@ -3050,32 +3057,100 @@ func (combiner *collectionUpdateCombiner) stop() {
 	if combiner == nil {
 		return
 	}
+	if combiner.markStopped() {
+		close(combiner.requests)
+	}
+	if combiner.done != nil {
+		<-combiner.done
+	}
+}
+
+func (combiner *collectionUpdateCombiner) markStopped() bool {
 	combiner.mu.Lock()
 	defer combiner.mu.Unlock()
 	if combiner.stopped {
-		return
+		return false
 	}
 	combiner.stopped = true
-	close(combiner.requests)
+	return true
 }
 
 func (combiner *collectionUpdateCombiner) run() {
-	for first := range combiner.requests {
-		batch := []collectionUpdateCombineRequest{first}
-		for len(batch) < combiner.maxBatch {
-			select {
-			case req, ok := <-combiner.requests:
-				if !ok {
-					goto drained
-				}
-				batch = append(batch, req)
-			default:
-				goto drained
-			}
-		}
-	drained:
-		combiner.runBatch(batch)
+	if combiner.done != nil {
+		defer close(combiner.done)
 	}
+	if combiner.idleTTL <= 0 {
+		for first := range combiner.requests {
+			combiner.runBatchStartingWith(first)
+		}
+		return
+	}
+	idle := time.NewTimer(combiner.idleTTL)
+	defer idle.Stop()
+	for {
+		select {
+		case first, ok := <-combiner.requests:
+			if !ok {
+				return
+			}
+			stopAndDrainTimer(idle)
+			combiner.runBatchStartingWith(first)
+			idle.Reset(combiner.idleTTL)
+		case <-idle.C:
+			if combiner.retireIdle() {
+				return
+			}
+			idle.Reset(combiner.idleTTL)
+		}
+	}
+}
+
+func stopAndDrainTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+func (combiner *collectionUpdateCombiner) retireIdle() bool {
+	if combiner == nil {
+		return false
+	}
+	if combiner.domain != nil {
+		combiner.domain.updateCombineMu.Lock()
+		if combiner.domain.updateCombiner == combiner {
+			combiner.domain.updateCombiner = nil
+		}
+		combiner.domain.updateCombineMu.Unlock()
+	}
+	if !combiner.markStopped() {
+		return false
+	}
+	close(combiner.requests)
+	for req := range combiner.requests {
+		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+	}
+	return true
+}
+
+func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionUpdateCombineRequest) {
+	batch := []collectionUpdateCombineRequest{first}
+	for len(batch) < combiner.maxBatch {
+		select {
+		case req, ok := <-combiner.requests:
+			if !ok {
+				combiner.runBatch(batch)
+				return
+			}
+			batch = append(batch, req)
+		default:
+			combiner.runBatch(batch)
+			return
+		}
+	}
+	combiner.runBatch(batch)
 }
 
 func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombineRequest) {
@@ -3102,6 +3177,10 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 		for _, req := range batch {
 			completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
 		}
+		return
+	}
+	if len(results) != len(batch) {
+		completeUpdateCombineBatchWithError(batch, fmt.Errorf("collections: update combiner result count %d for batch size %d", len(results), len(batch)))
 		return
 	}
 	for i, req := range batch {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -35,6 +35,7 @@ const (
 	// well-amortized InsertBatch calls on the immediate publish path. Smaller
 	// batches use the indexed write-domain memtable path by default.
 	DefaultIndexedWriteMemtableDirectBatchDocuments = DefaultIndexedWriteMemtableMaxDocuments / 4
+	defaultCollectionUpdateCombineMaxBatch          = 256
 )
 
 var (
@@ -335,6 +336,8 @@ type collectionWriteDomain struct {
 	// sustained collection write contention.
 	mutationMu       sync.Mutex
 	mu               sync.RWMutex
+	updateCombineMu  sync.Mutex
+	updateCombiner   *collectionUpdateCombiner
 	loaded           bool
 	meta             CollectionMeta
 	catalog          *collectionCatalog
@@ -2778,18 +2781,32 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 // Update applies update to the latest document value and retries if another
 // collection write changes the root before this update publishes.
 func (c *Collection) Update(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
+	if err := validateCollectionUpdateInput(c, documentID, update); err != nil {
+		return false, false, err
+	}
+	if combiner := c.updateCombiner(); combiner != nil {
+		return combiner.update(c, documentID, update)
+	}
+	return c.updateDirect(documentID, update)
+}
+
+func validateCollectionUpdateInput(c *Collection, documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) error {
 	if c == nil {
-		return false, false, errCollectionNil
+		return errCollectionNil
 	}
 	if c.db == nil {
-		return false, false, errors.New("collections: db is nil")
+		return errors.New("collections: db is nil")
 	}
 	if len(documentID) == 0 {
-		return false, false, errors.New("collections: document id cannot be empty")
+		return errors.New("collections: document id cannot be empty")
 	}
 	if update == nil {
-		return false, false, errors.New("collections: update function is nil")
+		return errors.New("collections: update function is nil")
 	}
+	return nil
+}
+
+func (c *Collection) updateDirect(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
 	if err := c.flushBufferedWrites(); err != nil {
@@ -2861,6 +2878,119 @@ func validateUpdateBatchItems(items []UpdateBatchItem) error {
 		seen[key] = struct{}{}
 	}
 	return nil
+}
+
+type collectionUpdateCombiner struct {
+	maxBatch int
+	requests chan collectionUpdateCombineRequest
+}
+
+type collectionUpdateCombineRequest struct {
+	collection *Collection
+	documentID []byte
+	update     func(current []byte) (replacement []byte, changed bool, err error)
+	done       chan collectionUpdateCombineResult
+}
+
+type collectionUpdateCombineResult struct {
+	matched  bool
+	modified bool
+	err      error
+}
+
+func (c *Collection) updateCombiner() *collectionUpdateCombiner {
+	if c == nil || c.writeDomain == nil {
+		return nil
+	}
+	domain := c.writeDomain
+	domain.updateCombineMu.Lock()
+	defer domain.updateCombineMu.Unlock()
+	if domain.updateCombiner != nil {
+		return domain.updateCombiner
+	}
+	combiner := &collectionUpdateCombiner{
+		maxBatch: defaultCollectionUpdateCombineMaxBatch,
+		requests: make(chan collectionUpdateCombineRequest, defaultCollectionUpdateCombineMaxBatch*4),
+	}
+	domain.updateCombiner = combiner
+	go combiner.run()
+	return combiner
+}
+
+func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
+	if combiner == nil || combiner.maxBatch <= 1 {
+		return c.updateDirect(documentID, update)
+	}
+	done := make(chan collectionUpdateCombineResult, 1)
+	req := collectionUpdateCombineRequest{
+		collection: c,
+		documentID: bytes.Clone(documentID),
+		update:     update,
+		done:       done,
+	}
+	select {
+	case combiner.requests <- req:
+	default:
+		return c.updateDirect(documentID, update)
+	}
+	result := <-done
+	return result.matched, result.modified, result.err
+}
+
+func (combiner *collectionUpdateCombiner) run() {
+	for first := range combiner.requests {
+		batch := []collectionUpdateCombineRequest{first}
+		for len(batch) < combiner.maxBatch {
+			select {
+			case req := <-combiner.requests:
+				batch = append(batch, req)
+			default:
+				goto drained
+			}
+		}
+	drained:
+		combiner.runBatch(batch)
+	}
+}
+
+func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombineRequest) {
+	if len(batch) == 1 || collectionUpdateCombineHasDuplicateIDs(batch) {
+		for _, req := range batch {
+			matched, modified, err := req.collection.updateDirect(req.documentID, req.update)
+			req.done <- collectionUpdateCombineResult{matched: matched, modified: modified, err: err}
+		}
+		return
+	}
+	items := make([]UpdateBatchItem, len(batch))
+	for i, req := range batch {
+		items[i] = UpdateBatchItem{
+			DocumentID: req.documentID,
+			Update:     req.update,
+		}
+	}
+	results, err := batch[0].collection.UpdateBatch(items)
+	if err != nil {
+		for _, req := range batch {
+			req.done <- collectionUpdateCombineResult{err: err}
+		}
+		return
+	}
+	for i, req := range batch {
+		result := results[i]
+		req.done <- collectionUpdateCombineResult{matched: result.Matched, modified: result.Modified}
+	}
+}
+
+func collectionUpdateCombineHasDuplicateIDs(batch []collectionUpdateCombineRequest) bool {
+	seen := make(map[string]struct{}, len(batch))
+	for _, req := range batch {
+		key := string(req.documentID)
+		if _, ok := seen[key]; ok {
+			return true
+		}
+		seen[key] = struct{}{}
+	}
+	return false
 }
 
 func waitBeforeCollectionMutationRetry(attempt int) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -54,7 +54,7 @@ var (
 	errCollectionDBNil                    = errors.New("collections: db is nil")
 	errCollectionNotFound                 = ErrCollectionNotFound
 	errUpdateBatchHasSecondaryUniqueIndex = errors.New("collections: update batch has secondary unique index")
-	errUpdateCombinerStopped              = errors.New("collections: update combiner stopped before completing request; request was not completed and caller may retry")
+	errUpdateCombinerStopped              = errors.New("collections: update combiner stopped before DB update completed; callback may have been invoked")
 )
 
 // UpdateBatchItem describes one document update in a batch. DocumentID must be
@@ -372,6 +372,7 @@ type collectionWriteDomain struct {
 	updateCombiner    *collectionUpdateCombiner
 	updateCombineDone bool
 	updateCombineTTL  time.Duration
+	closingWrites     atomic.Bool
 	loaded            bool
 	meta              CollectionMeta
 	catalog           *collectionCatalog
@@ -2345,6 +2346,9 @@ func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool)
 	if c.db == nil {
 		return nil, errCollectionDBNil
 	}
+	if err := c.ensureWriteDomainOpen(); err != nil {
+		return nil, err
+	}
 
 	return retryInsertBatchMutation(func() ([][]byte, error) {
 		return c.insertBatchOnce(ids, documents, trustedValidBSON)
@@ -2827,6 +2831,9 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 	if c.db == nil {
 		return false, errCollectionDBNil
 	}
+	if err := c.ensureWriteDomainOpen(); err != nil {
+		return false, err
+	}
 	if len(documentID) == 0 {
 		return false, errors.New("collections: document id cannot be empty")
 	}
@@ -3012,6 +3019,9 @@ func validateCollectionUpdateInput(c *Collection, documentID []byte, update func
 	if c.db == nil {
 		return errCollectionDBNil
 	}
+	if err := c.ensureWriteDomainOpen(); err != nil {
+		return err
+	}
 	if len(documentID) == 0 {
 		return errors.New("collections: document id cannot be empty")
 	}
@@ -3066,6 +3076,9 @@ func (c *Collection) updateBatch(items []UpdateBatchItem, requireNoSecondaryUniq
 	if c.db == nil {
 		return nil, false, errCollectionDBNil
 	}
+	if err := c.ensureWriteDomainOpen(); err != nil {
+		return nil, false, err
+	}
 	if len(items) == 0 {
 		return nil, true, nil
 	}
@@ -3093,6 +3106,19 @@ func (c *Collection) updateBatch(items []UpdateBatchItem, requireNoSecondaryUniq
 		return results, true, err
 	}
 	return nil, false, collectionMutationRetryExhausted(lastErr)
+}
+
+func (c *Collection) ensureWriteDomainOpen() error {
+	if c == nil || c.db == nil {
+		return nil
+	}
+	if c.db.IsClosing() {
+		return backenddb.ErrClosed
+	}
+	if c.writeDomain != nil && c.writeDomain.closingWrites.Load() {
+		return backenddb.ErrClosed
+	}
+	return nil
 }
 
 func validateUpdateBatchItems(items []UpdateBatchItem) error {
@@ -3150,6 +3176,9 @@ func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 		return nil
 	}
 	domain := c.writeDomain
+	if domain.closingWrites.Load() {
+		return nil
+	}
 	for {
 		domain.updateCombineMu.Lock()
 		if domain.updateCombineDone {
@@ -3186,6 +3215,7 @@ func (domain *collectionWriteDomain) stopUpdateCombiner() {
 	if domain == nil {
 		return
 	}
+	domain.closingWrites.Store(true)
 	domain.updateCombineMu.Lock()
 	combiner := domain.updateCombiner
 	domain.updateCombiner = nil
@@ -3210,6 +3240,8 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 		done:         done,
 	}
 	if !combiner.enqueue(req) {
+		// Combining is a best-effort throughput optimization. Saturated or stopped
+		// combiners fall back to the direct path so updates still make progress.
 		return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
 	}
 	result := combiner.waitForUpdateResult(done)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3023,6 +3023,9 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 	if combiner := c.updateCombiner(); combiner != nil {
 		return combiner.update(c, documentID, update)
 	}
+	if err := c.ensureWriteDomainOpen(); err != nil {
+		return false, false, err
+	}
 	return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
 }
 
@@ -3242,6 +3245,9 @@ func (domain *collectionWriteDomain) stopUpdateCombiner() {
 
 func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
 	if combiner == nil || combiner.maxBatch <= 1 {
+		if err := c.ensureWriteDomainOpen(); err != nil {
+			return false, false, err
+		}
 		return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
 	}
 	done := make(chan collectionUpdateCombineResult, 1)
@@ -3256,6 +3262,9 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 	if !combiner.enqueue(req) {
 		// Combining is a best-effort throughput optimization. Saturated or stopped
 		// combiners fall back to the direct path so updates still make progress.
+		if err := c.ensureWriteDomainOpen(); err != nil {
+			return false, false, err
+		}
 		return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
 	}
 	result := combiner.waitForUpdateResult(done)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -37,9 +37,8 @@ const (
 	// batches use the indexed write-domain memtable path by default.
 	DefaultIndexedWriteMemtableDirectBatchDocuments = DefaultIndexedWriteMemtableMaxDocuments / 4
 	defaultCollectionUpdateCombineMaxBatch          = 256
+	collectionUpdateCombineIdleTTL                  = 30 * time.Second
 )
-
-var collectionUpdateCombineIdleTTL = 30 * time.Second
 
 var (
 	ErrCollectionNotFound  = errors.New("collections: collection not found")
@@ -405,7 +404,7 @@ func (m *CollectionManager) closeForBackend() error {
 }
 
 func (m *CollectionManager) isClosing() bool {
-	return m == nil || m.closing.Load() || m.db == nil || m.db.IsClosing()
+	return m.closing.Load() || m.db == nil || m.db.IsClosing()
 }
 
 func (m *CollectionManager) stopUpdateCombiners() {
@@ -645,7 +644,7 @@ func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
 }
 
 func (m *CollectionManager) openCollectionFromWriteDomainCache(name string) (*Collection, bool) {
-	if m.isClosing() {
+	if m == nil || m.isClosing() {
 		return nil, false
 	}
 	state := m.db.State()
@@ -3118,11 +3117,11 @@ type collectionUpdateCombiner struct {
 }
 
 type collectionUpdateCombineRequest struct {
-	collection  *Collection
-	documentID  []byte
-	documentKey string
-	update      func(current []byte) (replacement []byte, changed bool, err error)
-	done        chan collectionUpdateCombineResult
+	collection   *Collection
+	documentID   []byte
+	documentHash uint64
+	update       func(current []byte) (replacement []byte, changed bool, err error)
+	done         chan collectionUpdateCombineResult
 }
 
 type collectionUpdateCombineResult struct {
@@ -3187,12 +3186,13 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 		return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
 	}
 	done := make(chan collectionUpdateCombineResult, 1)
+	clonedDocumentID := bytes.Clone(documentID)
 	req := collectionUpdateCombineRequest{
-		collection:  c,
-		documentID:  bytes.Clone(documentID),
-		documentKey: string(documentID),
-		update:      update,
-		done:        done,
+		collection:   c,
+		documentID:   clonedDocumentID,
+		documentHash: xxhash.Sum64(clonedDocumentID),
+		update:       update,
+		done:         done,
 	}
 	if !combiner.enqueue(req) {
 		return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
@@ -3445,16 +3445,19 @@ func collectionUpdateCombineHasDuplicateIDs(batch []collectionUpdateCombineReque
 	if len(batch) < 2 {
 		return false
 	}
-	seen := make(map[string]struct{}, len(batch))
+	seen := make(map[uint64][][]byte, len(batch))
 	for _, req := range batch {
-		key := req.documentKey
-		if key == "" {
-			key = string(req.documentID)
+		hash := req.documentHash
+		if hash == 0 && len(req.documentID) > 0 {
+			hash = xxhash.Sum64(req.documentID)
 		}
-		if _, ok := seen[key]; ok {
-			return true
+		candidates := seen[hash]
+		for _, candidate := range candidates {
+			if bytes.Equal(candidate, req.documentID) {
+				return true
+			}
 		}
-		seen[key] = struct{}{}
+		seen[hash] = append(candidates, req.documentID)
 	}
 	return false
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -50,10 +50,11 @@ var (
 	ErrUniqueIndexConflict = errors.New("collections: unique index conflict")
 	ErrConcurrentMutation  = errors.New("collections: concurrent mutation")
 
-	errCollectionManagerNil = errors.New("collections: collection manager is nil")
-	errCollectionNil        = errors.New("collections: collection is nil")
-	errCollectionDBNil      = errors.New("collections: db is nil")
-	errCollectionNotFound   = ErrCollectionNotFound
+	errCollectionManagerNil  = errors.New("collections: collection manager is nil")
+	errCollectionNil         = errors.New("collections: collection is nil")
+	errCollectionDBNil       = errors.New("collections: db is nil")
+	errCollectionNotFound    = ErrCollectionNotFound
+	errUpdateCombinerStopped = errors.New("collections: update combiner stopped before completing request")
 )
 
 // UpdateBatchItem describes one document update in a batch. DocumentID must be
@@ -3085,8 +3086,30 @@ func (combiner *collectionUpdateCombiner) update(c *Collection, documentID []byt
 	if !combiner.enqueue(req) {
 		return c.updateDirect(documentID, recoverCollectionUpdateCallback(update))
 	}
-	result := <-done
+	result := combiner.waitForUpdateResult(done)
 	return result.matched, result.modified, result.err
+}
+
+func (combiner *collectionUpdateCombiner) waitForUpdateResult(done chan collectionUpdateCombineResult) collectionUpdateCombineResult {
+	select {
+	case result := <-done:
+		return result
+	default:
+	}
+	if combiner == nil || combiner.done == nil {
+		return <-done
+	}
+	select {
+	case result := <-done:
+		return result
+	case <-combiner.done:
+		select {
+		case result := <-done:
+			return result
+		default:
+			return collectionUpdateCombineResult{err: errUpdateCombinerStopped}
+		}
+	}
 }
 
 func (combiner *collectionUpdateCombiner) enqueue(req collectionUpdateCombineRequest) bool {
@@ -3136,10 +3159,22 @@ func (combiner *collectionUpdateCombiner) isStopped() bool {
 	return combiner.stopped
 }
 
-func (combiner *collectionUpdateCombiner) run() {
-	if combiner.done != nil {
-		defer close(combiner.done)
+func (combiner *collectionUpdateCombiner) markStopped() {
+	if combiner == nil {
+		return
 	}
+	combiner.mu.Lock()
+	combiner.stopped = true
+	combiner.mu.Unlock()
+}
+
+func (combiner *collectionUpdateCombiner) run() {
+	defer func() {
+		combiner.markStopped()
+		if combiner.done != nil {
+			close(combiner.done)
+		}
+	}()
 	if combiner.idleTTL <= 0 {
 		for first := range combiner.requests {
 			combiner.runBatchStartingWith(first)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -2936,6 +2937,44 @@ func TestCollectionUpdateCombinerMaxBatchOneRecoversCallbackPanic(t *testing.T) 
 	}
 	if matched || modified {
 		t.Fatalf("matched=%v modified=%v want false,false", matched, modified)
+	}
+}
+
+func TestCollectionUpdateCombinerUpdateReturnsWhenWorkerExits(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"score":0}`)}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	combiner := col.updateCombiner()
+	if combiner == nil {
+		t.Fatal("expected update combiner")
+	}
+	matched, modified, err := combiner.update(col, []byte("u1"), func([]byte) ([]byte, bool, error) {
+		runtime.Goexit()
+		return nil, false, nil
+	})
+	if !errors.Is(err, errUpdateCombinerStopped) {
+		t.Fatalf("update err=%v want errUpdateCombinerStopped", err)
+	}
+	if matched || modified {
+		t.Fatalf("matched=%v modified=%v want false,false", matched, modified)
+	}
+	if !combiner.isStopped() {
+		t.Fatal("worker exit did not mark combiner stopped")
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3165,17 +3165,19 @@ func TestCollectionUpdateCombinerUpdateReturnsWhenWorkerExits(t *testing.T) {
 	}
 }
 
-func TestCompleteUpdateCombineRequestDoesNotBlockWhenDoneIsFull(t *testing.T) {
+func TestCollectionUpdateCombinerRejectsFullDoneChannel(t *testing.T) {
+	combiner := &collectionUpdateCombiner{
+		requests: make(chan collectionUpdateCombineRequest, 1),
+	}
 	done := make(chan collectionUpdateCombineResult, 1)
-	original := collectionUpdateCombineResult{matched: true}
-	done <- original
-	completeUpdateCombineRequest(
-		collectionUpdateCombineRequest{done: done},
-		collectionUpdateCombineResult{modified: true},
-	)
-	got := <-done
-	if got != original {
-		t.Fatalf("done result=%+v want original %+v", got, original)
+	done <- collectionUpdateCombineResult{matched: true}
+	if combiner.enqueue(collectionUpdateCombineRequest{
+		collection: &Collection{db: &backenddb.DB{}},
+		documentID: []byte("u1"),
+		update:     func([]byte) ([]byte, bool, error) { return nil, false, nil },
+		done:       done,
+	}) {
+		t.Fatal("enqueue accepted a request with a full done channel")
 	}
 }
 
@@ -3542,7 +3544,7 @@ func TestCollectionUpdateCombinerStopWaitsForActiveWorker(t *testing.T) {
 	select {
 	case <-stopReturned:
 		t.Fatal("stop returned before active combiner worker drained")
-	case <-time.After(25 * time.Millisecond):
+	default:
 	}
 
 	close(release)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3168,7 +3168,7 @@ func TestCollectionUpdateCombinerEvictsWhenIdle(t *testing.T) {
 		t.Fatalf("open collection: %v", err)
 	}
 	col.writeDomain.updateCombineMu.Lock()
-	col.writeDomain.updateCombineTTL = time.Millisecond
+	col.writeDomain.updateCombineTTL = 25 * time.Millisecond
 	col.writeDomain.updateCombineMu.Unlock()
 	combiner := col.updateCombiner()
 	if combiner == nil {
@@ -3258,7 +3258,7 @@ func TestCollectionUpdateCombinerReplacesStoppedCachedCombinerWithoutWaiting(t *
 			t.Fatal("updateCombiner reused stopped combiner")
 		}
 		got.stop()
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("updateCombiner waited for stopped combiner done channel")
 	}
 }

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3168,7 +3168,7 @@ func TestCollectionUpdateCombinerEvictsWhenIdle(t *testing.T) {
 		t.Fatalf("open collection: %v", err)
 	}
 	col.writeDomain.updateCombineMu.Lock()
-	col.writeDomain.updateCombineTTL = time.Millisecond
+	col.writeDomain.updateCombineTTL = 25 * time.Millisecond
 	col.writeDomain.updateCombineMu.Unlock()
 	combiner := col.updateCombiner()
 	if combiner == nil {
@@ -3258,8 +3258,83 @@ func TestCollectionUpdateCombinerReplacesStoppedCachedCombinerWithoutWaiting(t *
 			t.Fatal("updateCombiner reused stopped combiner")
 		}
 		got.stop()
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("updateCombiner waited for stopped combiner done channel")
+	}
+}
+
+func TestCollectionUpdateCombinerStopDoesNotWaitForActiveWorker(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"score":0}`)}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	combiner := &collectionUpdateCombiner{
+		maxBatch: 8,
+		requests: make(chan collectionUpdateCombineRequest, 4),
+		done:     make(chan struct{}),
+	}
+	go combiner.run()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	resultCh := make(chan collectionUpdateCombineResult, 1)
+	if !combiner.enqueue(collectionUpdateCombineRequest{
+		collection: col,
+		documentID: []byte("u1"),
+		update: func([]byte) ([]byte, bool, error) {
+			close(started)
+			<-release
+			return []byte(`{"score":5}`), true, nil
+		},
+		done: resultCh,
+	}) {
+		t.Fatal("enqueue update")
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("combiner worker did not start update")
+	}
+
+	stopReturned := make(chan struct{})
+	go func() {
+		combiner.stop()
+		close(stopReturned)
+	}()
+	select {
+	case <-stopReturned:
+	case <-time.After(time.Second):
+		t.Fatal("stop waited for active combiner worker")
+	}
+
+	close(release)
+	var result collectionUpdateCombineResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("active update did not complete after release")
+	}
+	if result.err != nil || !result.matched || !result.modified {
+		t.Fatalf("combined result=%+v want matched modified nil err", result)
+	}
+	select {
+	case <-combiner.done:
+	case <-time.After(time.Second):
+		t.Fatal("combiner worker did not exit after active update completed")
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -19,6 +19,8 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
+var collectionUpdateCombineIdleTTLTestMu sync.Mutex
+
 func TestCollectionErrorsAreClassifiable(t *testing.T) {
 	if !errors.Is(ErrCollectionNotFound, ErrCollectionNotFound) {
 		t.Fatal("ErrCollectionNotFound should be errors.Is-compatible")
@@ -2894,6 +2896,8 @@ func TestCollectionUpdateCombinerDuplicateIDsPreserveOrder(t *testing.T) {
 }
 
 func TestCollectionUpdateCombinerEvictsWhenIdle(t *testing.T) {
+	collectionUpdateCombineIdleTTLTestMu.Lock()
+	defer collectionUpdateCombineIdleTTLTestMu.Unlock()
 	oldTTL := collectionUpdateCombineIdleTTL
 	collectionUpdateCombineIdleTTL = time.Millisecond
 	defer func() { collectionUpdateCombineIdleTTL = oldTTL }()

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2806,7 +2806,7 @@ func TestCollectionUpdateCombinerRunBatchPublishesDistinctIDsOnce(t *testing.T) 
 	}
 }
 
-func TestCollectionUpdateCombinerRunBatchIsolatesItemErrors(t *testing.T) {
+func TestCollectionUpdateCombinerRunBatchDoesNotReplayCallbacksAfterBatchError(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -2830,12 +2830,15 @@ func TestCollectionUpdateCombinerRunBatchIsolatesItemErrors(t *testing.T) {
 
 	itemErr := errors.New("bad update")
 	combiner := &collectionUpdateCombiner{maxBatch: 8}
+	firstCalls := 0
+	secondCalls := 0
 	requests := []collectionUpdateCombineRequest{
 		{
 			collection: col,
 			documentID: []byte("u1"),
 			update: func([]byte) ([]byte, bool, error) {
-				return nil, false, itemErr
+				firstCalls++
+				return []byte(`{"score":1}`), true, nil
 			},
 			done: make(chan collectionUpdateCombineResult, 1),
 		},
@@ -2843,7 +2846,8 @@ func TestCollectionUpdateCombinerRunBatchIsolatesItemErrors(t *testing.T) {
 			collection: col,
 			documentID: []byte("u2"),
 			update: func([]byte) ([]byte, bool, error) {
-				return []byte(`{"score":2}`), true, nil
+				secondCalls++
+				return nil, false, itemErr
 			},
 			done: make(chan collectionUpdateCombineResult, 1),
 		},
@@ -2851,21 +2855,21 @@ func TestCollectionUpdateCombinerRunBatchIsolatesItemErrors(t *testing.T) {
 	combiner.runBatch(requests)
 	first := <-requests[0].done
 	if !errors.Is(first.err, itemErr) {
-		t.Fatalf("first err=%v want itemErr", first.err)
+		t.Fatalf("first err=%v want shared itemErr", first.err)
 	}
 	second := <-requests[1].done
-	if second.err != nil {
-		t.Fatalf("second err: %v", second.err)
+	if !errors.Is(second.err, itemErr) {
+		t.Fatalf("second err=%v want itemErr", second.err)
 	}
-	if !second.matched || !second.modified {
-		t.Fatalf("second matched=%v modified=%v", second.matched, second.modified)
+	if firstCalls != 1 || secondCalls != 1 {
+		t.Fatalf("callback calls first=%d second=%d want 1,1", firstCalls, secondCalls)
 	}
-	got, err := col.Get([]byte("u2"))
+	got, err := col.Get([]byte("u1"))
 	if err != nil {
-		t.Fatalf("get u2: %v", err)
+		t.Fatalf("get u1: %v", err)
 	}
-	if !bytes.Contains(got, []byte(`"score":2`)) {
-		t.Fatalf("u2 document=%s want score 2", got)
+	if !bytes.Contains(got, []byte(`"score":0`)) {
+		t.Fatalf("u1 document=%s want unchanged score", got)
 	}
 }
 
@@ -2892,6 +2896,7 @@ func TestCollectionUpdateCombinerRunBatchRecoversCallbackPanic(t *testing.T) {
 	}
 
 	combiner := &collectionUpdateCombiner{maxBatch: 8}
+	secondCalls := 0
 	requests := []collectionUpdateCombineRequest{
 		{
 			collection: col,
@@ -2905,6 +2910,7 @@ func TestCollectionUpdateCombinerRunBatchRecoversCallbackPanic(t *testing.T) {
 			collection: col,
 			documentID: []byte("u2"),
 			update: func([]byte) ([]byte, bool, error) {
+				secondCalls++
 				return []byte(`{"score":2}`), true, nil
 			},
 			done: make(chan collectionUpdateCombineResult, 1),
@@ -2917,11 +2923,12 @@ func TestCollectionUpdateCombinerRunBatchRecoversCallbackPanic(t *testing.T) {
 	}
 	assertNoStackTraceInError(t, first.err)
 	second := <-requests[1].done
-	if second.err != nil {
-		t.Fatalf("second err: %v", second.err)
+	if second.err == nil || !strings.Contains(second.err.Error(), "bad callback") {
+		t.Fatalf("second err=%v want shared recovered panic", second.err)
 	}
-	if !second.matched || !second.modified {
-		t.Fatalf("second matched=%v modified=%v", second.matched, second.modified)
+	assertNoStackTraceInError(t, second.err)
+	if secondCalls != 0 {
+		t.Fatalf("second callback calls=%d want 0", secondCalls)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2457,6 +2457,64 @@ func TestCollectionUpdateBatchRejectsUniqueConflictsWithinBatch(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateCombinerRunBatchPublishesDistinctIDsOnce(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"score":0}`), []byte(`{"score":0}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	before := d.State()
+	combiner := &collectionUpdateCombiner{maxBatch: 8}
+	requests := []collectionUpdateCombineRequest{
+		{
+			collection: col,
+			documentID: []byte("u1"),
+			update: func([]byte) ([]byte, bool, error) {
+				return []byte(`{"score":1}`), true, nil
+			},
+			done: make(chan collectionUpdateCombineResult, 1),
+		},
+		{
+			collection: col,
+			documentID: []byte("u2"),
+			update: func([]byte) ([]byte, bool, error) {
+				return []byte(`{"score":2}`), true, nil
+			},
+			done: make(chan collectionUpdateCombineResult, 1),
+		},
+	}
+	combiner.runBatch(requests)
+	for i, req := range requests {
+		result := <-req.done
+		if result.err != nil {
+			t.Fatalf("request %d err: %v", i, result.err)
+		}
+		if !result.matched || !result.modified {
+			t.Fatalf("request %d matched=%v modified=%v", i, result.matched, result.modified)
+		}
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("combined batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	}
+}
+
 func incrementJSONCount(current []byte) ([]byte, bool, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(current, &doc); err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2811,17 +2811,6 @@ func TestCollectionUpdateCombinerRunBatchIsolatesItemErrors(t *testing.T) {
 	}
 }
 
-func TestUpdateCombineResultFromBatchResultPropagatesPerItemError(t *testing.T) {
-	itemErr := errors.New("item failed")
-	result := updateCombineResultFromBatchResult(UpdateBatchResult{Matched: true, Modified: true, Err: itemErr})
-	if !errors.Is(result.err, itemErr) {
-		t.Fatalf("result err=%v want %v", result.err, itemErr)
-	}
-	if result.matched || result.modified {
-		t.Fatalf("matched=%v modified=%v want false,false when err is set", result.matched, result.modified)
-	}
-}
-
 func TestCollectionUpdateCombinerRunBatchRecoversCallbackPanic(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -2975,6 +2964,28 @@ func TestCollectionUpdateCombinerUpdateReturnsWhenWorkerExits(t *testing.T) {
 	}
 	if !combiner.isStopped() {
 		t.Fatal("worker exit did not mark combiner stopped")
+	}
+	select {
+	case _, ok := <-combiner.requests:
+		if ok {
+			t.Fatal("worker exit left request channel open")
+		}
+	default:
+		t.Fatal("worker exit did not close request channel")
+	}
+}
+
+func TestCompleteUpdateCombineRequestDoesNotBlockWhenDoneIsFull(t *testing.T) {
+	done := make(chan collectionUpdateCombineResult, 1)
+	original := collectionUpdateCombineResult{matched: true}
+	done <- original
+	completeUpdateCombineRequest(
+		collectionUpdateCombineRequest{done: done},
+		collectionUpdateCombineResult{modified: true},
+	)
+	got := <-done
+	if got != original {
+		t.Fatalf("done result=%+v want original %+v", got, original)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2755,6 +2755,93 @@ func TestCollectionUpdateCombinerRunBatchRecoversCallbackPanic(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateCombinerDuplicateIDsPreserveOrder(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"score":0}`)}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	setScore := func(score int32) func([]byte) ([]byte, bool, error) {
+		return func([]byte) ([]byte, bool, error) {
+			return []byte(fmt.Sprintf(`{"score":%d}`, score)), true, nil
+		}
+	}
+	combiner := &collectionUpdateCombiner{maxBatch: 8}
+	requests := []collectionUpdateCombineRequest{
+		{collection: col, documentID: []byte("u1"), update: setScore(1), done: make(chan collectionUpdateCombineResult, 1)},
+		{collection: col, documentID: []byte("u1"), update: setScore(2), done: make(chan collectionUpdateCombineResult, 1)},
+	}
+	combiner.runBatch(requests)
+	for i, req := range requests {
+		result := <-req.done
+		if result.err != nil {
+			t.Fatalf("request %d err: %v", i, result.err)
+		}
+		if !result.matched || !result.modified {
+			t.Fatalf("request %d matched=%v modified=%v", i, result.matched, result.modified)
+		}
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"score":2`)) {
+		t.Fatalf("u1 document=%s want final score 2", got)
+	}
+}
+
+func TestCollectionUpdateCombinerEvictsWhenIdle(t *testing.T) {
+	oldTTL := collectionUpdateCombineIdleTTL
+	collectionUpdateCombineIdleTTL = time.Millisecond
+	defer func() { collectionUpdateCombineIdleTTL = oldTTL }()
+
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	combiner := col.updateCombiner()
+	if combiner == nil {
+		t.Fatal("expected update combiner")
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		col.writeDomain.updateCombineMu.Lock()
+		stillCached := col.writeDomain.updateCombiner == combiner
+		col.writeDomain.updateCombineMu.Unlock()
+		combiner.mu.RLock()
+		stopped := combiner.stopped
+		combiner.mu.RUnlock()
+		if !stillCached && stopped {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("combiner was not evicted after idle timeout")
+}
+
 func TestCollectionManagerCloseStopsUpdateCombiners(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -2823,6 +2910,55 @@ func TestCollectionManagerCloseForBackendPreventsCombinerRecreationBeforeDBClosi
 	}
 	if _, err := mgr.OpenCollection("users"); !errors.Is(err, backenddb.ErrClosed) {
 		t.Fatalf("OpenCollection during manager close err=%v want ErrClosed", err)
+	}
+}
+
+func TestCollectionManagerCloseForBackendDrainsCombinerBeforeFlush(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"score":0}`)}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	combiner := col.updateCombiner()
+	if combiner == nil {
+		t.Fatal("expected update combiner")
+	}
+	done := make(chan collectionUpdateCombineResult, 1)
+	if !combiner.enqueue(collectionUpdateCombineRequest{
+		collection: col,
+		documentID: []byte("u1"),
+		update: func([]byte) ([]byte, bool, error) {
+			return []byte(`{"score":9}`), true, nil
+		},
+		done: done,
+	}) {
+		t.Fatal("enqueue update")
+	}
+	if err := mgr.closeForBackend(); err != nil {
+		t.Fatalf("closeForBackend: %v", err)
+	}
+	result := <-done
+	if result.err != nil || !result.matched || !result.modified {
+		t.Fatalf("combined result=%+v want matched modified nil err", result)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"score":9`)) {
+		t.Fatalf("u1 document=%s want score 9", got)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3238,6 +3238,71 @@ func TestCollectionUpdateCombinerDuplicateIDsPreserveOrder(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateCombinerMixedCollectionsFallbackDirect(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "left"}); err != nil {
+		t.Fatalf("create left: %v", err)
+	}
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "right"}); err != nil {
+		t.Fatalf("create right: %v", err)
+	}
+	left, err := mgr.OpenCollection("left")
+	if err != nil {
+		t.Fatalf("open left: %v", err)
+	}
+	right, err := mgr.OpenCollection("right")
+	if err != nil {
+		t.Fatalf("open right: %v", err)
+	}
+	if _, err := left.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"score":0}`)}); err != nil {
+		t.Fatalf("insert left: %v", err)
+	}
+	if _, err := right.InsertBatch([][]byte{[]byte("u2")}, [][]byte{[]byte(`{"score":0}`)}); err != nil {
+		t.Fatalf("insert right: %v", err)
+	}
+
+	setScore := func(score int32) func([]byte) ([]byte, bool, error) {
+		return func([]byte) ([]byte, bool, error) {
+			return []byte(fmt.Sprintf(`{"score":%d}`, score)), true, nil
+		}
+	}
+	combiner := &collectionUpdateCombiner{maxBatch: 8}
+	requests := []collectionUpdateCombineRequest{
+		{collection: left, documentID: []byte("u1"), update: setScore(1), done: make(chan collectionUpdateCombineResult, 1)},
+		{collection: right, documentID: []byte("u2"), update: setScore(2), done: make(chan collectionUpdateCombineResult, 1)},
+	}
+	combiner.runBatch(requests)
+	for i, req := range requests {
+		result := <-req.done
+		if result.err != nil {
+			t.Fatalf("request %d err: %v", i, result.err)
+		}
+		if !result.matched || !result.modified {
+			t.Fatalf("request %d matched=%v modified=%v want true,true", i, result.matched, result.modified)
+		}
+	}
+	got, err := left.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get left u1: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"score":1`)) {
+		t.Fatalf("left document=%s want score 1", got)
+	}
+	got, err = right.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get right u2: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"score":2`)) {
+		t.Fatalf("right document=%s want score 2", got)
+	}
+}
+
 func TestCollectionUpdateCombinerEvictsWhenIdle(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -3396,7 +3461,7 @@ func TestCollectionUpdateCombinerWaitsForIdleDrain(t *testing.T) {
 	}
 }
 
-func TestCollectionUpdateCombinerStopDoesNotWaitForActiveWorker(t *testing.T) {
+func TestCollectionUpdateCombinerStopWaitsForActiveWorker(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -3450,11 +3515,16 @@ func TestCollectionUpdateCombinerStopDoesNotWaitForActiveWorker(t *testing.T) {
 	}()
 	select {
 	case <-stopReturned:
-	case <-time.After(time.Second):
-		t.Fatal("stop waited for active combiner worker")
+		t.Fatal("stop returned before active combiner worker drained")
+	case <-time.After(25 * time.Millisecond):
 	}
 
 	close(release)
+	select {
+	case <-stopReturned:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not return after active combiner worker drained")
+	}
 	var result collectionUpdateCombineResult
 	select {
 	case result = <-resultCh:

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2810,6 +2810,17 @@ func TestCollectionUpdateCombinerRunBatchIsolatesItemErrors(t *testing.T) {
 	}
 }
 
+func TestUpdateCombineResultFromBatchResultPropagatesPerItemError(t *testing.T) {
+	itemErr := errors.New("item failed")
+	result := updateCombineResultFromBatchResult(UpdateBatchResult{Matched: true, Modified: true, Err: itemErr})
+	if !errors.Is(result.err, itemErr) {
+		t.Fatalf("result err=%v want %v", result.err, itemErr)
+	}
+	if result.matched || result.modified {
+		t.Fatalf("matched=%v modified=%v want false,false when err is set", result.matched, result.modified)
+	}
+}
+
 func TestCollectionUpdateCombinerRunBatchRecoversCallbackPanic(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -3043,6 +3054,47 @@ func TestCollectionManagerCloseStopsUpdateCombiners(t *testing.T) {
 	}
 	if got := col.updateCombiner(); got != nil {
 		t.Fatal("closed manager created a new combiner")
+	}
+}
+
+func TestCollectionUpdateCombinerReplacesStoppedCachedCombinerWithoutWaiting(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	stopped := &collectionUpdateCombiner{done: make(chan struct{})}
+	stopped.mu.Lock()
+	stopped.stopped = true
+	stopped.mu.Unlock()
+	col.writeDomain.updateCombineMu.Lock()
+	col.writeDomain.updateCombiner = stopped
+	col.writeDomain.updateCombineMu.Unlock()
+
+	gotCh := make(chan *collectionUpdateCombiner, 1)
+	go func() {
+		gotCh <- col.updateCombiner()
+	}()
+	select {
+	case got := <-gotCh:
+		if got == nil {
+			t.Fatal("updateCombiner returned nil")
+		}
+		if got == stopped {
+			t.Fatal("updateCombiner reused stopped combiner")
+		}
+		got.stop()
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("updateCombiner waited for stopped combiner done channel")
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -19,8 +19,6 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-var collectionUpdateCombineIdleTTLTestMu sync.Mutex
-
 func TestCollectionErrorsAreClassifiable(t *testing.T) {
 	if !errors.Is(ErrCollectionNotFound, ErrCollectionNotFound) {
 		t.Fatal("ErrCollectionNotFound should be errors.Is-compatible")
@@ -2848,6 +2846,38 @@ func TestCollectionUpdateCombinerRunBatchRecoversCallbackPanic(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateDirectRecoversCallbackPanic(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"score":0}`)}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	directCol := *col
+	directCol.writeDomain = nil
+	matched, modified, err := directCol.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		panic("bad callback")
+	})
+	if err == nil || !strings.Contains(err.Error(), "bad callback") {
+		t.Fatalf("Update err=%v want recovered panic", err)
+	}
+	if matched || modified {
+		t.Fatalf("matched=%v modified=%v want false,false", matched, modified)
+	}
+}
+
 func TestCollectionUpdateCombinerDuplicateIDsPreserveOrder(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -2897,12 +2927,6 @@ func TestCollectionUpdateCombinerDuplicateIDsPreserveOrder(t *testing.T) {
 }
 
 func TestCollectionUpdateCombinerEvictsWhenIdle(t *testing.T) {
-	collectionUpdateCombineIdleTTLTestMu.Lock()
-	defer collectionUpdateCombineIdleTTLTestMu.Unlock()
-	oldTTL := collectionUpdateCombineIdleTTL
-	collectionUpdateCombineIdleTTL = time.Millisecond
-	defer func() { collectionUpdateCombineIdleTTL = oldTTL }()
-
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -2917,24 +2941,27 @@ func TestCollectionUpdateCombinerEvictsWhenIdle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open collection: %v", err)
 	}
+	col.writeDomain.updateCombineMu.Lock()
+	col.writeDomain.updateCombineTTL = time.Millisecond
+	col.writeDomain.updateCombineMu.Unlock()
 	combiner := col.updateCombiner()
 	if combiner == nil {
 		t.Fatal("expected update combiner")
 	}
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		col.writeDomain.updateCombineMu.Lock()
-		stillCached := col.writeDomain.updateCombiner == combiner
-		col.writeDomain.updateCombineMu.Unlock()
-		combiner.mu.RLock()
-		stopped := combiner.stopped
-		combiner.mu.RUnlock()
-		if !stillCached && stopped {
-			return
-		}
-		time.Sleep(time.Millisecond)
+	select {
+	case <-combiner.done:
+	case <-time.After(time.Second):
+		t.Fatal("combiner was not evicted after idle timeout")
 	}
-	t.Fatal("combiner was not evicted after idle timeout")
+	col.writeDomain.updateCombineMu.Lock()
+	stillCached := col.writeDomain.updateCombiner == combiner
+	col.writeDomain.updateCombineMu.Unlock()
+	combiner.mu.RLock()
+	stopped := combiner.stopped
+	combiner.mu.RUnlock()
+	if stillCached || !stopped {
+		t.Fatalf("stillCached=%v stopped=%v want false,true", stillCached, stopped)
+	}
 }
 
 func TestCollectionManagerCloseStopsUpdateCombiners(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3372,6 +3372,17 @@ func TestCollectionManagerCloseForBackendPreventsCombinerRecreationBeforeDBClosi
 	if got := col.updateCombiner(); got != nil {
 		t.Fatal("close hook window recreated update combiner")
 	}
+	if _, _, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"score":1}`), true, nil
+	}); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("Update after manager close err=%v want ErrClosed", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"score":1}`)}); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("InsertBatch after manager close err=%v want ErrClosed", err)
+	}
+	if _, err := col.DeleteDocument([]byte("u1")); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("DeleteDocument after manager close err=%v want ErrClosed", err)
+	}
 	if _, err := mgr.OpenCollection("users"); !errors.Is(err, backenddb.ErrClosed) {
 		t.Fatalf("OpenCollection during manager close err=%v want ErrClosed", err)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2890,6 +2890,36 @@ func TestCollectionUpdateDirectRecoversCallbackPanic(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateCombinerDisabledRecoversCallbackPanic(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"score":0}`)}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	matched, modified, err := (&collectionUpdateCombiner{maxBatch: 1}).update(col, []byte("u1"), func([]byte) ([]byte, bool, error) {
+		panic("bad callback")
+	})
+	if err == nil || !strings.Contains(err.Error(), "bad callback") {
+		t.Fatalf("update err=%v want recovered panic", err)
+	}
+	if matched || modified {
+		t.Fatalf("matched=%v modified=%v want false,false", matched, modified)
+	}
+}
+
 func TestCollectionUpdateCombinerDuplicateIDsPreserveOrder(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3043,6 +3043,16 @@ func TestCompleteUpdateCombineRequestDoesNotBlockWhenDoneIsFull(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateCombinerCloseRequestsAllowsNilRequests(t *testing.T) {
+	combiner := &collectionUpdateCombiner{}
+	if !combiner.closeRequests() {
+		t.Fatal("closeRequests returned false for fresh combiner")
+	}
+	if !combiner.isStopped() {
+		t.Fatal("closeRequests did not mark combiner stopped")
+	}
+}
+
 func TestCollectionUpdateCombinerDuplicateIDsPreserveOrder(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3508,11 +3508,31 @@ func TestCollectionUpdateCombinerStopWaitsForActiveWorker(t *testing.T) {
 		t.Fatal("combiner worker did not start update")
 	}
 
+	stopStarted := make(chan struct{})
 	stopReturned := make(chan struct{})
 	go func() {
+		close(stopStarted)
 		combiner.stop()
 		close(stopReturned)
 	}()
+	select {
+	case <-stopStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stop goroutine did not start")
+	}
+	for {
+		combiner.mu.RLock()
+		stopped := combiner.stopped
+		combiner.mu.RUnlock()
+		if stopped {
+			break
+		}
+		select {
+		case <-stopReturned:
+			t.Fatal("stop returned before marking combiner stopped")
+		case <-time.After(time.Millisecond):
+		}
+	}
 	select {
 	case <-stopReturned:
 		t.Fatal("stop returned before active combiner worker drained")

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3056,8 +3056,7 @@ func TestCollectionUpdateDirectRecoversCallbackPanic(t *testing.T) {
 		t.Fatalf("insert batch: %v", err)
 	}
 
-	directCol := *col
-	directCol.writeDomain = nil
+	directCol := &Collection{db: d, meta: col.Meta()}
 	matched, modified, err := directCol.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
 		panic("bad callback")
 	})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2806,7 +2806,7 @@ func TestCollectionUpdateCombinerRunBatchPublishesDistinctIDsOnce(t *testing.T) 
 	}
 }
 
-func TestCollectionUpdateCombinerRunBatchDoesNotReplayCallbacksAfterBatchError(t *testing.T) {
+func TestCollectionUpdateCombinerRunBatchPreservesIndependentItemErrorOutcomes(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -2854,22 +2854,32 @@ func TestCollectionUpdateCombinerRunBatchDoesNotReplayCallbacksAfterBatchError(t
 	}
 	combiner.runBatch(requests)
 	first := <-requests[0].done
-	if !errors.Is(first.err, itemErr) {
-		t.Fatalf("first err=%v want shared itemErr", first.err)
+	if first.err != nil {
+		t.Fatalf("first err=%v want nil", first.err)
+	}
+	if !first.matched || !first.modified {
+		t.Fatalf("first matched=%v modified=%v want true,true", first.matched, first.modified)
 	}
 	second := <-requests[1].done
 	if !errors.Is(second.err, itemErr) {
 		t.Fatalf("second err=%v want itemErr", second.err)
 	}
-	if firstCalls != 1 || secondCalls != 1 {
-		t.Fatalf("callback calls first=%d second=%d want 1,1", firstCalls, secondCalls)
+	if firstCalls == 0 || secondCalls != 1 {
+		t.Fatalf("callback calls first=%d second=%d want first called and second called once", firstCalls, secondCalls)
 	}
 	got, err := col.Get([]byte("u1"))
 	if err != nil {
 		t.Fatalf("get u1: %v", err)
 	}
+	if !bytes.Contains(got, []byte(`"score":1`)) {
+		t.Fatalf("u1 document=%s want updated score", got)
+	}
+	got, err = col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
 	if !bytes.Contains(got, []byte(`"score":0`)) {
-		t.Fatalf("u1 document=%s want unchanged score", got)
+		t.Fatalf("u2 document=%s want unchanged score", got)
 	}
 }
 
@@ -2923,12 +2933,21 @@ func TestCollectionUpdateCombinerRunBatchRecoversCallbackPanic(t *testing.T) {
 	}
 	assertNoStackTraceInError(t, first.err)
 	second := <-requests[1].done
-	if second.err == nil || !strings.Contains(second.err.Error(), "bad callback") {
-		t.Fatalf("second err=%v want shared recovered panic", second.err)
+	if second.err != nil {
+		t.Fatalf("second err=%v want nil", second.err)
 	}
-	assertNoStackTraceInError(t, second.err)
-	if secondCalls != 0 {
-		t.Fatalf("second callback calls=%d want 0", secondCalls)
+	if !second.matched || !second.modified {
+		t.Fatalf("second matched=%v modified=%v want true,true", second.matched, second.modified)
+	}
+	if secondCalls != 1 {
+		t.Fatalf("second callback calls=%d want 1", secondCalls)
+	}
+	got, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"score":2`)) {
+		t.Fatalf("u2 document=%s want updated score", got)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2700,6 +2700,61 @@ func TestCollectionUpdateCombinerRunBatchIsolatesItemErrors(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateCombinerRunBatchRecoversCallbackPanic(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"score":0}`), []byte(`{"score":0}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	combiner := &collectionUpdateCombiner{maxBatch: 8}
+	requests := []collectionUpdateCombineRequest{
+		{
+			collection: col,
+			documentID: []byte("u1"),
+			update: func([]byte) ([]byte, bool, error) {
+				panic("bad callback")
+			},
+			done: make(chan collectionUpdateCombineResult, 1),
+		},
+		{
+			collection: col,
+			documentID: []byte("u2"),
+			update: func([]byte) ([]byte, bool, error) {
+				return []byte(`{"score":2}`), true, nil
+			},
+			done: make(chan collectionUpdateCombineResult, 1),
+		},
+	}
+	combiner.runBatch(requests)
+	first := <-requests[0].done
+	if first.err == nil || !strings.Contains(first.err.Error(), "bad callback") {
+		t.Fatalf("first err=%v want recovered panic", first.err)
+	}
+	second := <-requests[1].done
+	if second.err != nil {
+		t.Fatalf("second err: %v", second.err)
+	}
+	if !second.matched || !second.modified {
+		t.Fatalf("second matched=%v modified=%v", second.matched, second.modified)
+	}
+}
+
 func TestCollectionManagerCloseStopsUpdateCombiners(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -2729,6 +2784,45 @@ func TestCollectionManagerCloseStopsUpdateCombiners(t *testing.T) {
 	}
 	if got := col.updateCombiner(); got != nil {
 		t.Fatal("closed manager created a new combiner")
+	}
+}
+
+func TestCollectionManagerCloseForBackendPreventsCombinerRecreationBeforeDBClosing(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	combiner := col.updateCombiner()
+	if combiner == nil {
+		t.Fatal("expected update combiner")
+	}
+	if err := mgr.closeForBackend(); err != nil {
+		t.Fatalf("closeForBackend: %v", err)
+	}
+	if d.IsClosing() {
+		t.Fatal("backend DB is closing; test must cover pre-closing close-hook window")
+	}
+	combiner.mu.RLock()
+	stopped := combiner.stopped
+	combiner.mu.RUnlock()
+	if !stopped {
+		t.Fatal("combiner was not stopped")
+	}
+	if got := col.updateCombiner(); got != nil {
+		t.Fatal("close hook window recreated update combiner")
+	}
+	if _, err := mgr.OpenCollection("users"); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("OpenCollection during manager close err=%v want ErrClosed", err)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2890,6 +2890,37 @@ func TestCollectionUpdateDirectRecoversCallbackPanic(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateCombinerMaxBatchOneRecoversCallbackPanic(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"score":0}`)}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	combiner := &collectionUpdateCombiner{maxBatch: 1}
+	matched, modified, err := combiner.update(col, []byte("u1"), func([]byte) ([]byte, bool, error) {
+		panic("bad callback")
+	})
+	if err == nil || !strings.Contains(err.Error(), "bad callback") {
+		t.Fatalf("Update err=%v want recovered panic", err)
+	}
+	if matched || modified {
+		t.Fatalf("matched=%v modified=%v want false,false", matched, modified)
+	}
+}
+
 func TestCollectionUpdateCombinerDuplicateIDsPreserveOrder(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3509,10 +3509,17 @@ func TestCollectionUpdateCombinerStopWaitsForActiveWorker(t *testing.T) {
 	}
 
 	stopReturned := make(chan struct{})
+	stopStarted := make(chan struct{})
 	go func() {
+		close(stopStarted)
 		combiner.stop()
 		close(stopReturned)
 	}()
+	select {
+	case <-stopStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stop goroutine did not start")
+	}
 	select {
 	case <-stopReturned:
 		t.Fatal("stop returned before active combiner worker drained")

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2921,6 +2921,27 @@ func TestCollectionUpdateCombinerMaxBatchOneRecoversCallbackPanic(t *testing.T) 
 	}
 }
 
+func TestCollectionUpdateCombinerUpdateReturnsWhenCombinerStops(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	combiner := &collectionUpdateCombiner{
+		maxBatch: 8,
+		requests: make(chan collectionUpdateCombineRequest, 1),
+		done:     done,
+	}
+
+	matched, modified, err := combiner.update(&Collection{}, []byte("u1"), func([]byte) ([]byte, bool, error) {
+		t.Fatal("update callback should not run after combiner stop")
+		return nil, false, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "stopped before completing request") {
+		t.Fatalf("err=%v want stopped error", err)
+	}
+	if matched || modified {
+		t.Fatalf("matched=%v modified=%v want false,false", matched, modified)
+	}
+}
+
 func TestCollectionUpdateCombinerDuplicateIDsPreserveOrder(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3435,14 +3435,21 @@ func TestCollectionUpdateCombinerWaitsForIdleDrain(t *testing.T) {
 	col.writeDomain.updateDraining = draining
 	col.writeDomain.updateCombineMu.Unlock()
 
+	started := make(chan struct{})
 	gotCh := make(chan *collectionUpdateCombiner, 1)
 	go func() {
+		close(started)
 		gotCh <- col.updateCombiner()
 	}()
 	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("updateCombiner goroutine did not start")
+	}
+	select {
 	case got := <-gotCh:
 		t.Fatalf("updateCombiner returned %v before idle drain completed", got)
-	case <-time.After(25 * time.Millisecond):
+	default:
 	}
 
 	col.writeDomain.updateCombineMu.Lock()

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3341,6 +3341,53 @@ func TestCollectionUpdateCombinerReplacesStoppedCachedCombinerWithoutWaiting(t *
 	}
 }
 
+func TestCollectionUpdateCombinerWaitsForIdleDrain(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	draining := &collectionUpdateCombiner{done: make(chan struct{})}
+	col.writeDomain.updateCombineMu.Lock()
+	col.writeDomain.updateDraining = draining
+	col.writeDomain.updateCombineMu.Unlock()
+
+	gotCh := make(chan *collectionUpdateCombiner, 1)
+	go func() {
+		gotCh <- col.updateCombiner()
+	}()
+	select {
+	case got := <-gotCh:
+		t.Fatalf("updateCombiner returned %v before idle drain completed", got)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	col.writeDomain.updateCombineMu.Lock()
+	col.writeDomain.updateDraining = nil
+	col.writeDomain.updateCombineMu.Unlock()
+	close(draining.done)
+
+	select {
+	case got := <-gotCh:
+		if got == nil || got == draining {
+			t.Fatalf("updateCombiner returned %v after idle drain", got)
+		}
+		got.stop()
+	case <-time.After(time.Second):
+		t.Fatal("updateCombiner did not resume after idle drain completed")
+	}
+}
+
 func TestCollectionUpdateCombinerStopDoesNotWaitForActiveWorker(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds a per-collection write-domain combiner for `Collection.Update`. Concurrent single-document updates now enqueue through the shared collection write domain; the combiner drains already-waiting distinct document IDs and applies them through `UpdateBatch`, reducing root publishes. If a drained batch contains duplicate document IDs, it falls back to sequential direct updates to preserve same-document ordering.

This is the collection-layer version of the Mongo gateway coalescing work: it helps direct collection callers and any future gateway path that does not already batch at the command layer.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionUpdate(CombinerRunBatchPublishesDistinctIDsOnce|BatchUpdatesMultipleDocuments|ConcurrentIndexedNoRetryExhaustion)' -count=1`
- `GOWORK=off go test ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1`

## Benchmarks

Direct collection concurrent update benchmark, 100k preload docs, 2 BSON indexes, 8 writers, 80k updates:

- PR4 base: `83,280 ns/op`, `12,008 docs/sec`, `25,537 B/op`, `147 allocs/op`
- This PR: `36,689 ns/op`, `27,256 docs/sec`, `21,904 B/op`, `104 allocs/op`

Gateway smoke on the same 100k-doc / 2-index / BSON / driver-command-raw benchmark remains in the PR4 range because gateway command coalescing already batches there:

- load `537,141 docs/sec`
- concurrent update `22,367 docs/sec`
- profile directory `/tmp/gomap_pr5_gateway_profile_JUScJP`

Review clarification: Update combining is best-effort under saturation. If the shared combiner queue is full or has stopped, callers fall back to the direct update path so writes keep making progress rather than blocking indefinitely. Backend shutdown now marks the collection write domain closed so existing handles return `backenddb.ErrClosed` instead of bypassing the combiner and writing during close.
