### PR TITLE
[codex] Measure collection root publish contention

### DIFF
--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -700,6 +700,10 @@ func (db *DB) Stats() map[string]string {
 	// for suite compatibility and fail-closed checks that require key presence.
 	stats["treedb.publish.watermark.lag_drift_bytes_per_sec"] = "0.000"
 	orderedDeltaStats := db.orderedRootDeltaGroupPublishStats()
+	// Ordered-root delta group stats cover calls that entered the DB write
+	// lock, including failed calls. roots_total counts successfully published
+	// non-system roots, avg_roots_per_call divides by calls_total, and the
+	// latency fields include both write-lock wait time and lock hold time.
 	stats["treedb.publish.ordered_root_delta_group.calls_total"] = fmt.Sprintf("%d", orderedDeltaStats.calls)
 	stats["treedb.publish.ordered_root_delta_group.errors_total"] = fmt.Sprintf("%d", orderedDeltaStats.errors)
 	stats["treedb.publish.ordered_root_delta_group.roots_total"] = fmt.Sprintf("%d", orderedDeltaStats.roots)

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
@@ -698,6 +699,16 @@ func (db *DB) Stats() map[string]string {
 	// Backend DB path currently doesn't track queue drift; emit a stable default
 	// for suite compatibility and fail-closed checks that require key presence.
 	stats["treedb.publish.watermark.lag_drift_bytes_per_sec"] = "0.000"
+	orderedDeltaStats := db.orderedRootDeltaGroupPublishStats()
+	stats["treedb.publish.ordered_root_delta_group.calls_total"] = fmt.Sprintf("%d", orderedDeltaStats.calls)
+	stats["treedb.publish.ordered_root_delta_group.errors_total"] = fmt.Sprintf("%d", orderedDeltaStats.errors)
+	stats["treedb.publish.ordered_root_delta_group.roots_total"] = fmt.Sprintf("%d", orderedDeltaStats.roots)
+	stats["treedb.publish.ordered_root_delta_group.avg_roots_per_call"] = fmt.Sprintf("%.3f", orderedDeltaStats.avgRootsPerCall)
+	stats["treedb.publish.ordered_root_delta_group.write_lock_wait_ns_total"] = fmt.Sprintf("%d", orderedDeltaStats.waitTotalNs)
+	stats["treedb.publish.ordered_root_delta_group.write_lock_hold_ns_total"] = fmt.Sprintf("%d", orderedDeltaStats.holdTotalNs)
+	stats["treedb.publish.ordered_root_delta_group.write_lock_wait_share_pct"] = fmt.Sprintf("%.3f", orderedDeltaStats.writeLockWaitShare)
+	stats["treedb.publish.ordered_root_delta_group.latency_p99_ms"] = fmt.Sprintf("%.3f", float64(orderedDeltaStats.latencyP99)/float64(time.Millisecond))
+	stats["treedb.publish.ordered_root_delta_group.latency_max_ms"] = fmt.Sprintf("%.3f", float64(orderedDeltaStats.latencyMax)/float64(time.Millisecond))
 	warmPublishStats := db.systemRootPublishStatsSnapshot()
 	stats["treedb.publish.system_root.warm_attempts"] = fmt.Sprintf("%d", warmPublishStats.warmAttempts)
 	stats["treedb.publish.system_root.warm_native_apply_attempts"] = fmt.Sprintf("%d", warmPublishStats.warmNativeApplyAttempts)

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -170,6 +170,15 @@ type DB struct {
 	publishWatermarkLatencyMaxNs   atomic.Uint64
 	publishWatermarkLatencyBuckets [publishWatermarkLatencyBucketCount]atomic.Uint64
 
+	// Ordered-root delta groups are the collection multi-root publish hot path.
+	orderedRootDeltaGroupCalls          atomic.Uint64
+	orderedRootDeltaGroupErrors         atomic.Uint64
+	orderedRootDeltaGroupRoots          atomic.Uint64
+	orderedRootDeltaGroupWaitTotalNs    atomic.Uint64
+	orderedRootDeltaGroupHoldTotalNs    atomic.Uint64
+	orderedRootDeltaGroupLatencyMaxNs   atomic.Uint64
+	orderedRootDeltaGroupLatencyBuckets [publishWatermarkLatencyBucketCount]atomic.Uint64
+
 	// R4 warm-publish counters. Warm native apply is used for bounded deltas;
 	// larger or ineligible deltas record an explicit rebuild fallback selection.
 	systemRootWarmPublishAttempts         atomic.Uint64

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -810,14 +810,21 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	holdStart := time.Now()
 	wait := holdStart.Sub(lockStart)
 	rootsObserved := 0
-	defer func() {
+	finished := false
+	finishPublish := func() {
+		if finished {
+			return
+		}
+		finished = true
 		hold := time.Since(holdStart)
 		db.writeMu.Unlock()
 		db.observeOrderedRootDeltaGroupPublish(wait, hold, rootsObserved, err)
-	}()
+	}
 
 	if db.readOnly {
-		return 0, nil, ErrReadOnly
+		err = ErrReadOnly
+		finishPublish()
+		return 0, nil, err
 	}
 
 	db.mu.RLock()
@@ -830,6 +837,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	rootIDs = make([]uint64, len(ordered))
 	orderedConsumed := make([]bool, len(ordered))
 	defer closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
+	defer finishPublish()
 	var retired []uint64
 	var merged adaptive.Metrics
 	for idx := range ordered {
@@ -875,17 +883,15 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 		}
 		vlogRefDelta = nil
 	}
-	defer func() {
-		if vlogRefDelta != nil {
-			releaseValueLogRefDelta(vlogRefDelta)
-		}
-	}()
-
 	db.mu.RLock()
 	curUserRoot := db.meta.UserRootPageID
 	curSystemRoot := db.meta.SystemRootPageID
 	db.mu.RUnlock()
 	if curUserRoot != userRoot || curSystemRoot != baseSystemRoot {
+		if vlogRefDelta != nil {
+			releaseValueLogRefDelta(vlogRefDelta)
+			vlogRefDelta = nil
+		}
 		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
 	}
 
@@ -893,6 +899,10 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 		vlogRefDelta = db.newNoopValueLogRefDeltaIfTrackable(baseSeq)
 	}
 	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil); err != nil {
+		if vlogRefDelta != nil {
+			releaseValueLogRefDelta(vlogRefDelta)
+			vlogRefDelta = nil
+		}
 		return 0, nil, err
 	}
 	vlogRefDelta = nil
@@ -930,14 +940,21 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 	holdStart := time.Now()
 	wait := holdStart.Sub(lockStart)
 	rootsObserved := 0
-	defer func() {
+	finished := false
+	finishPublish := func() {
+		if finished {
+			return
+		}
+		finished = true
 		hold := time.Since(holdStart)
 		db.writeMu.Unlock()
 		db.observeOrderedRootDeltaGroupPublish(wait, hold, rootsObserved, err)
-	}()
+	}
 
 	if db.readOnly {
-		return 0, nil, ErrReadOnly
+		err = ErrReadOnly
+		finishPublish()
+		return 0, nil, err
 	}
 
 	db.mu.RLock()
@@ -945,7 +962,8 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 	baseSystemRoot := db.meta.SystemRootPageID
 	db.mu.RUnlock()
 	if preflight != nil {
-		if err := preflight(); err != nil {
+		if err = preflight(); err != nil {
+			finishPublish()
 			return 0, nil, err
 		}
 	}
@@ -954,6 +972,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 	rootIDs = make([]uint64, len(ordered))
 	orderedConsumed := make([]bool, len(ordered))
 	defer closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
+	defer finishPublish()
 	var retired []uint64
 	var merged adaptive.Metrics
 	for idx := range ordered {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -828,7 +828,6 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 
 	systemOpts := systemRootOrderedPublishOptions(db)
 	rootIDs = make([]uint64, len(ordered))
-	rootsObserved = len(ordered)
 	orderedConsumed := make([]bool, len(ordered))
 	defer closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
 	var retired []uint64
@@ -844,6 +843,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 			return 0, nil, err
 		}
 		rootIDs[idx] = rootID
+		rootsObserved++
 		retired = append(retired, rootRetired...)
 		mergeOrderedRootPublishMetrics(&merged, metrics)
 	}
@@ -949,7 +949,6 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 			return 0, nil, err
 		}
 	}
-	rootsObserved = len(ordered)
 
 	systemOpts := systemRootOrderedPublishOptions(db)
 	rootIDs = make([]uint64, len(ordered))
@@ -968,6 +967,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 			return 0, nil, err
 		}
 		rootIDs[idx] = rootID
+		rootsObserved++
 		retired = append(retired, rootRetired...)
 		mergeOrderedRootPublishMetrics(&merged, metrics)
 	}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -794,7 +794,7 @@ func (db *DB) PublishOrderedRootGroupWithSystemBuilder(ordered []OrderedRootPubl
 // PublishOrderedRootDeltaGroupWithSystemBuilder applies root-local mutation
 // streams to non-system roots, then builds and commits a system-root iterator
 // that can persist the produced root IDs in the same backend commit.
-func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRootDeltaPublishInput, buildSystemIter OrderedRootGroupSystemBuilder) (uint64, []uint64, error) {
+func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRootDeltaPublishInput, buildSystemIter OrderedRootGroupSystemBuilder) (newSystemRoot uint64, rootIDs []uint64, err error) {
 	if buildSystemIter == nil {
 		return 0, nil, errors.New("nil ordered root group system builder")
 	}
@@ -805,8 +805,16 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 		return 0, nil, ErrClosed
 	}
 
+	lockStart := time.Now()
 	db.writeMu.Lock()
-	defer db.writeMu.Unlock()
+	holdStart := time.Now()
+	wait := holdStart.Sub(lockStart)
+	rootsObserved := 0
+	defer func() {
+		hold := time.Since(holdStart)
+		db.writeMu.Unlock()
+		db.observeOrderedRootDeltaGroupPublish(wait, hold, rootsObserved, err)
+	}()
 
 	if db.readOnly {
 		return 0, nil, ErrReadOnly
@@ -819,7 +827,8 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	db.mu.RUnlock()
 
 	systemOpts := systemRootOrderedPublishOptions(db)
-	rootIDs := make([]uint64, len(ordered))
+	rootIDs = make([]uint64, len(ordered))
+	rootsObserved = len(ordered)
 	orderedConsumed := make([]bool, len(ordered))
 	defer closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
 	var retired []uint64
@@ -850,7 +859,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	if err != nil {
 		return 0, nil, err
 	}
-	newSystemRoot := rootID
+	newSystemRoot = rootID
 	retired = append(retired, rootRetired...)
 	mergeOrderedRootPublishMetrics(&merged, metrics)
 	vlogRefDelta := refDelta

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -958,10 +958,13 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 		db.writeMu.Unlock()
 		db.observeOrderedRootDeltaGroupPublish(wait, hold, rootsObserved, err)
 	}
+	rootIDs = make([]uint64, len(ordered))
+	orderedConsumed := make([]bool, len(ordered))
+	defer closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
+	defer finishPublish()
 
 	if db.readOnly {
 		err = ErrReadOnly
-		finishPublish()
 		return 0, nil, err
 	}
 
@@ -971,16 +974,11 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 	db.mu.RUnlock()
 	if preflight != nil {
 		if err = preflight(); err != nil {
-			finishPublish()
 			return 0, nil, err
 		}
 	}
 
 	systemOpts := systemRootOrderedPublishOptions(db)
-	rootIDs = make([]uint64, len(ordered))
-	orderedConsumed := make([]bool, len(ordered))
-	defer closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
-	defer finishPublish()
 	var retired []uint64
 	var merged adaptive.Metrics
 	for idx := range ordered {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -920,10 +920,11 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 	db.writeMu.Lock()
 	wait := time.Since(lockStart)
 	holdStart := time.Now()
+	rootsObserved := 0
 	defer func() {
 		hold := time.Since(holdStart)
 		db.writeMu.Unlock()
-		db.observeOrderedRootDeltaGroupPublish(wait, hold, len(ordered), err)
+		db.observeOrderedRootDeltaGroupPublish(wait, hold, rootsObserved, err)
 	}()
 
 	if db.readOnly {
@@ -939,6 +940,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 			return 0, nil, err
 		}
 	}
+	rootsObserved = len(ordered)
 
 	systemOpts := systemRootOrderedPublishOptions(db)
 	rootIDs = make([]uint64, len(ordered))

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -3,6 +3,7 @@ package db
 import (
 	"bytes"
 	"errors"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
@@ -904,7 +905,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ord
 	return db.publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, preflight, buildSystemDeltaIter)
 }
 
-func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []OrderedRootDeltaPublishInput, preflight OrderedRootGroupPreflight, buildSystemDeltaIter OrderedRootGroupSystemBuilder) (uint64, []uint64, error) {
+func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []OrderedRootDeltaPublishInput, preflight OrderedRootGroupPreflight, buildSystemDeltaIter OrderedRootGroupSystemBuilder) (newSystemRoot uint64, rootIDs []uint64, err error) {
 	if buildSystemDeltaIter == nil {
 		return 0, nil, errors.New("nil ordered root group system delta builder")
 	}
@@ -915,8 +916,15 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 		return 0, nil, ErrClosed
 	}
 
+	lockStart := time.Now()
 	db.writeMu.Lock()
-	defer db.writeMu.Unlock()
+	wait := time.Since(lockStart)
+	holdStart := time.Now()
+	defer func() {
+		hold := time.Since(holdStart)
+		db.writeMu.Unlock()
+		db.observeOrderedRootDeltaGroupPublish(wait, hold, len(ordered), err)
+	}()
 
 	if db.readOnly {
 		return 0, nil, ErrReadOnly
@@ -933,7 +941,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 	}
 
 	systemOpts := systemRootOrderedPublishOptions(db)
-	rootIDs := make([]uint64, len(ordered))
+	rootIDs = make([]uint64, len(ordered))
 	orderedConsumed := make([]bool, len(ordered))
 	defer closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
 	var retired []uint64
@@ -964,7 +972,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 	if err != nil {
 		return 0, nil, err
 	}
-	newSystemRoot := rootID
+	newSystemRoot = rootID
 	retired = append(retired, rootRetired...)
 	mergeOrderedRootPublishMetrics(&merged, metrics)
 

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -820,10 +820,17 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 		db.writeMu.Unlock()
 		db.observeOrderedRootDeltaGroupPublish(wait, hold, rootsObserved, err)
 	}
+	cleanupIterators := func() {}
+	// finishPublish intentionally runs before iterator cleanup: caller-provided
+	// iterator Close paths can do arbitrary cleanup and should not extend the
+	// write-lock hold time reported for the publish itself.
+	defer func() {
+		finishPublish()
+		cleanupIterators()
+	}()
 
 	if db.readOnly {
 		err = ErrReadOnly
-		finishPublish()
 		return 0, nil, err
 	}
 
@@ -836,11 +843,9 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	systemOpts := systemRootOrderedPublishOptions(db)
 	rootIDs = make([]uint64, len(ordered))
 	orderedConsumed := make([]bool, len(ordered))
-	// finishPublish intentionally runs before iterator cleanup: caller-provided
-	// iterator Close paths can do arbitrary cleanup and should not extend the
-	// write-lock hold time reported for the publish itself.
-	defer closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
-	defer finishPublish()
+	cleanupIterators = func() {
+		closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
+	}
 	var retired []uint64
 	var merged adaptive.Metrics
 	for idx := range ordered {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -918,8 +918,8 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 
 	lockStart := time.Now()
 	db.writeMu.Lock()
-	wait := time.Since(lockStart)
 	holdStart := time.Now()
+	wait := holdStart.Sub(lockStart)
 	rootsObserved := 0
 	defer func() {
 		hold := time.Since(holdStart)

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -836,6 +836,9 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	systemOpts := systemRootOrderedPublishOptions(db)
 	rootIDs = make([]uint64, len(ordered))
 	orderedConsumed := make([]bool, len(ordered))
+	// finishPublish intentionally runs before iterator cleanup: caller-provided
+	// iterator Close paths can do arbitrary cleanup and should not extend the
+	// write-lock hold time reported for the publish itself.
 	defer closeUnconsumedOrderedRootDeltaPublishIterators(ordered, orderedConsumed)
 	defer finishPublish()
 	var retired []uint64

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -790,6 +790,42 @@ func TestPublishOrderedRootDeltaGroupPreflightFailureDoesNotCountRoots(t *testin
 	}
 }
 
+func TestPublishOrderedRootDeltaGroupSystemBuilderFailureDoesNotCountRoots(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t, "root/a", "va").NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+	delta := mustFrozenSystemMemtable(t, "root/b", "vb")
+	wantErr := errors.New("system builder failed")
+	_, _, err = db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot: baseRoot,
+		Iter:     delta.NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return nil, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err=%v want %v", err, wantErr)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.publish.ordered_root_delta_group.calls_total"]; got != "1" {
+		t.Fatalf("calls stat=%q want 1", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.errors_total"]; got != "1" {
+		t.Fatalf("errors stat=%q want 1", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.roots_total"]; got != "0" {
+		t.Fatalf("roots stat=%q want 0", got)
+	}
+}
+
 func TestPublishOrderedRootDeltaGroupWithSystemBuilder_AppliesDeletes(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -712,6 +712,46 @@ func TestPublishOrderedRootDeltaGroupWithSystemBuilder_PreservesOmittedBaseEntri
 	}
 }
 
+func TestPublishOrderedRootDeltaGroupWithSystemBuilder_ReportsPublishStats(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t, "root/a", "va").NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+	delta := mustFrozenSystemMemtable(t, "root/b", "vb")
+	if _, _, err := db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot: baseRoot,
+		Iter:     delta.NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	}); err != nil {
+		t.Fatalf("publish delta group: %v", err)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.publish.ordered_root_delta_group.calls_total"]; got != "1" {
+		t.Fatalf("calls stat=%q want 1", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.roots_total"]; got != "1" {
+		t.Fatalf("roots stat=%q want 1", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.avg_roots_per_call"]; got != "1.000" {
+		t.Fatalf("avg roots stat=%q want 1.000", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.errors_total"]; got != "0" {
+		t.Fatalf("errors stat=%q want 0", got)
+	}
+	if _, ok := stats["treedb.publish.ordered_root_delta_group.write_lock_wait_share_pct"]; !ok {
+		t.Fatalf("missing ordered root delta write lock wait share stat")
+	}
+}
+
 func TestPublishOrderedRootDeltaGroupWithSystemBuilder_AppliesDeletes(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -752,6 +752,44 @@ func TestPublishOrderedRootDeltaGroupWithSystemBuilder_ReportsPublishStats(t *te
 	}
 }
 
+func TestPublishOrderedRootDeltaGroupPreflightFailureDoesNotCountRoots(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t, "root/a", "va").NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+	delta := mustFrozenSystemMemtable(t, "root/b", "vb")
+	wantErr := errors.New("preflight failed")
+	_, _, err = db.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot: baseRoot,
+		Iter:     delta.NewIterator(nil, nil),
+	}}, func() error {
+		return wantErr
+	}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err=%v want %v", err, wantErr)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.publish.ordered_root_delta_group.calls_total"]; got != "1" {
+		t.Fatalf("calls stat=%q want 1", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.errors_total"]; got != "1" {
+		t.Fatalf("errors stat=%q want 1", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.roots_total"]; got != "0" {
+		t.Fatalf("roots stat=%q want 0", got)
+	}
+}
+
 func TestPublishOrderedRootDeltaGroupWithSystemBuilder_AppliesDeletes(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -725,7 +725,7 @@ func TestPublishOrderedRootDeltaGroupWithSystemBuilder_ReportsPublishStats(t *te
 		t.Fatalf("publish base root: %v", err)
 	}
 	delta := mustFrozenSystemMemtable(t, "root/b", "vb")
-	if _, _, err := db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]OrderedRootDeltaPublishInput{{
+	if _, _, err := db.PublishOrderedRootDeltaGroupWithSystemBuilder([]OrderedRootDeltaPublishInput{{
 		BaseRoot: baseRoot,
 		Iter:     delta.NewIterator(nil, nil),
 	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {

--- a/TreeDB/db/publish_watermark_metrics.go
+++ b/TreeDB/db/publish_watermark_metrics.go
@@ -193,8 +193,8 @@ func (db *DB) orderedRootDeltaGroupPublishStats() orderedRootDeltaGroupPublishSt
 	if calls > 0 {
 		stats.avgRootsPerCall = float64(roots) / float64(calls)
 	}
-	if denom := waitNs + holdNs; denom > 0 {
-		stats.writeLockWaitShare = 100 * float64(waitNs) / float64(denom)
+	if denom := float64(waitNs) + float64(holdNs); denom > 0 {
+		stats.writeLockWaitShare = 100 * float64(waitNs) / denom
 	}
 	if calls == 0 {
 		return stats

--- a/TreeDB/db/publish_watermark_metrics.go
+++ b/TreeDB/db/publish_watermark_metrics.go
@@ -122,3 +122,90 @@ func (db *DB) publishWatermarkStats() (lockDelaySharePct float64, latencyP99Ms f
 	latencyP99Ms = float64(p99) / float64(time.Millisecond)
 	return lockDelaySharePct, latencyP99Ms
 }
+
+type orderedRootDeltaGroupPublishStats struct {
+	calls              uint64
+	errors             uint64
+	roots              uint64
+	waitTotalNs        uint64
+	holdTotalNs        uint64
+	latencyP99         time.Duration
+	latencyMax         time.Duration
+	writeLockWaitShare float64
+	avgRootsPerCall    float64
+}
+
+func (db *DB) observeOrderedRootDeltaGroupPublish(wait, hold time.Duration, roots int, err error) {
+	if db == nil {
+		return
+	}
+	if wait < 0 {
+		wait = 0
+	}
+	if hold < 0 {
+		hold = 0
+	}
+	latency := wait + hold
+	if latency < 0 {
+		latency = 0
+	}
+	if roots < 0 {
+		roots = 0
+	}
+
+	waitNs := uint64(wait.Nanoseconds())
+	holdNs := uint64(hold.Nanoseconds())
+	latNs := uint64(latency.Nanoseconds())
+
+	db.orderedRootDeltaGroupCalls.Add(1)
+	if err != nil {
+		db.orderedRootDeltaGroupErrors.Add(1)
+	}
+	db.orderedRootDeltaGroupRoots.Add(uint64(roots))
+	db.orderedRootDeltaGroupWaitTotalNs.Add(waitNs)
+	db.orderedRootDeltaGroupHoldTotalNs.Add(holdNs)
+	for {
+		cur := db.orderedRootDeltaGroupLatencyMaxNs.Load()
+		if latNs <= cur || db.orderedRootDeltaGroupLatencyMaxNs.CompareAndSwap(cur, latNs) {
+			break
+		}
+	}
+	bucket := publishWatermarkLatencyBucketIndex(latency)
+	db.orderedRootDeltaGroupLatencyBuckets[bucket].Add(1)
+}
+
+func (db *DB) orderedRootDeltaGroupPublishStats() orderedRootDeltaGroupPublishStats {
+	if db == nil {
+		return orderedRootDeltaGroupPublishStats{}
+	}
+	calls := db.orderedRootDeltaGroupCalls.Load()
+	waitNs := db.orderedRootDeltaGroupWaitTotalNs.Load()
+	holdNs := db.orderedRootDeltaGroupHoldTotalNs.Load()
+	roots := db.orderedRootDeltaGroupRoots.Load()
+	stats := orderedRootDeltaGroupPublishStats{
+		calls:       calls,
+		errors:      db.orderedRootDeltaGroupErrors.Load(),
+		roots:       roots,
+		waitTotalNs: waitNs,
+		holdTotalNs: holdNs,
+		latencyMax:  time.Duration(db.orderedRootDeltaGroupLatencyMaxNs.Load()),
+	}
+	if calls > 0 {
+		stats.avgRootsPerCall = float64(roots) / float64(calls)
+	}
+	if denom := waitNs + holdNs; denom > 0 {
+		stats.writeLockWaitShare = 100 * float64(waitNs) / float64(denom)
+	}
+	if calls == 0 {
+		return stats
+	}
+	var buckets [publishWatermarkLatencyBucketCount]uint64
+	for i := range buckets {
+		buckets[i] = db.orderedRootDeltaGroupLatencyBuckets[i].Load()
+	}
+	stats.latencyP99 = estimatePublishWatermarkPercentile(buckets, calls, 0.99)
+	if stats.latencyP99 <= 0 && stats.latencyMax > 0 {
+		stats.latencyP99 = stats.latencyMax
+	}
+	return stats
+}

--- a/TreeDB/db/publish_watermark_metrics.go
+++ b/TreeDB/db/publish_watermark_metrics.go
@@ -2,6 +2,8 @@ package db
 
 import "time"
 
+const maxDurationNanos = uint64(1<<63 - 1)
+
 var publishWatermarkLatencyBucketUpperBounds = [...]time.Duration{
 	50 * time.Microsecond,
 	100 * time.Microsecond,
@@ -63,6 +65,13 @@ func estimatePublishWatermarkPercentile(buckets [publishWatermarkLatencyBucketCo
 	return publishWatermarkLatencyBucketUpperBounds[len(publishWatermarkLatencyBucketUpperBounds)-1] + time.Nanosecond
 }
 
+func durationFromUint64Nanos(ns uint64) time.Duration {
+	if ns > maxDurationNanos {
+		return time.Duration(maxDurationNanos)
+	}
+	return time.Duration(ns)
+}
+
 func (db *DB) observePublishWatermark(wait, hold, latency time.Duration) {
 	if db == nil {
 		return
@@ -116,7 +125,7 @@ func (db *DB) publishWatermarkStats() (lockDelaySharePct float64, latencyP99Ms f
 	p99 := estimatePublishWatermarkPercentile(buckets, samples, 0.99)
 	if p99 <= 0 {
 		if maxNs := db.publishWatermarkLatencyMaxNs.Load(); maxNs > 0 {
-			p99 = time.Duration(maxNs)
+			p99 = durationFromUint64Nanos(maxNs)
 		}
 	}
 	latencyP99Ms = float64(p99) / float64(time.Millisecond)
@@ -188,7 +197,7 @@ func (db *DB) orderedRootDeltaGroupPublishStats() orderedRootDeltaGroupPublishSt
 		roots:       roots,
 		waitTotalNs: waitNs,
 		holdTotalNs: holdNs,
-		latencyMax:  time.Duration(db.orderedRootDeltaGroupLatencyMaxNs.Load()),
+		latencyMax:  durationFromUint64Nanos(db.orderedRootDeltaGroupLatencyMaxNs.Load()),
 	}
 	if calls > 0 {
 		stats.avgRootsPerCall = float64(roots) / float64(calls)
@@ -206,6 +215,9 @@ func (db *DB) orderedRootDeltaGroupPublishStats() orderedRootDeltaGroupPublishSt
 		bucketSamples += buckets[i]
 	}
 	if bucketSamples == 0 {
+		if stats.latencyMax > 0 {
+			stats.latencyP99 = stats.latencyMax
+		}
 		return stats
 	}
 	stats.latencyP99 = estimatePublishWatermarkPercentile(buckets, bucketSamples, 0.99)

--- a/TreeDB/db/publish_watermark_metrics.go
+++ b/TreeDB/db/publish_watermark_metrics.go
@@ -2,7 +2,7 @@ package db
 
 import "time"
 
-const maxDurationNanos = uint64(1<<63 - 1)
+const maxDurationNs = uint64(1<<63 - 1)
 
 var publishWatermarkLatencyBucketUpperBounds = [...]time.Duration{
 	50 * time.Microsecond,
@@ -65,9 +65,9 @@ func estimatePublishWatermarkPercentile(buckets [publishWatermarkLatencyBucketCo
 	return publishWatermarkLatencyBucketUpperBounds[len(publishWatermarkLatencyBucketUpperBounds)-1] + time.Nanosecond
 }
 
-func durationFromUint64Nanos(ns uint64) time.Duration {
-	if ns > maxDurationNanos {
-		return time.Duration(maxDurationNanos)
+func durationFromUint64Ns(ns uint64) time.Duration {
+	if ns > maxDurationNs {
+		return time.Duration(maxDurationNs)
 	}
 	return time.Duration(ns)
 }
@@ -125,7 +125,7 @@ func (db *DB) publishWatermarkStats() (lockDelaySharePct float64, latencyP99Ms f
 	p99 := estimatePublishWatermarkPercentile(buckets, samples, 0.99)
 	if p99 <= 0 {
 		if maxNs := db.publishWatermarkLatencyMaxNs.Load(); maxNs > 0 {
-			p99 = durationFromUint64Nanos(maxNs)
+			p99 = durationFromUint64Ns(maxNs)
 		}
 	}
 	latencyP99Ms = float64(p99) / float64(time.Millisecond)
@@ -161,10 +161,10 @@ func (db *DB) observeOrderedRootDeltaGroupPublish(wait, hold time.Duration, root
 	waitNs := uint64(wait.Nanoseconds())
 	holdNs := uint64(hold.Nanoseconds())
 	latNs := waitNs + holdNs
-	if waitNs > maxDurationNanos-holdNs {
-		latNs = maxDurationNanos
+	if waitNs > maxDurationNs-holdNs {
+		latNs = maxDurationNs
 	}
-	latency := durationFromUint64Nanos(latNs)
+	latency := durationFromUint64Ns(latNs)
 
 	db.orderedRootDeltaGroupCalls.Add(1)
 	if err != nil {
@@ -197,7 +197,7 @@ func (db *DB) orderedRootDeltaGroupPublishStats() orderedRootDeltaGroupPublishSt
 		roots:       roots,
 		waitTotalNs: waitNs,
 		holdTotalNs: holdNs,
-		latencyMax:  durationFromUint64Nanos(db.orderedRootDeltaGroupLatencyMaxNs.Load()),
+		latencyMax:  durationFromUint64Ns(db.orderedRootDeltaGroupLatencyMaxNs.Load()),
 	}
 	if calls > 0 {
 		stats.avgRootsPerCall = float64(roots) / float64(calls)

--- a/TreeDB/db/publish_watermark_metrics.go
+++ b/TreeDB/db/publish_watermark_metrics.go
@@ -200,10 +200,15 @@ func (db *DB) orderedRootDeltaGroupPublishStats() orderedRootDeltaGroupPublishSt
 		return stats
 	}
 	var buckets [publishWatermarkLatencyBucketCount]uint64
+	var bucketSamples uint64
 	for i := range buckets {
 		buckets[i] = db.orderedRootDeltaGroupLatencyBuckets[i].Load()
+		bucketSamples += buckets[i]
 	}
-	stats.latencyP99 = estimatePublishWatermarkPercentile(buckets, calls, 0.99)
+	if bucketSamples == 0 {
+		return stats
+	}
+	stats.latencyP99 = estimatePublishWatermarkPercentile(buckets, bucketSamples, 0.99)
 	if stats.latencyP99 <= 0 && stats.latencyMax > 0 {
 		stats.latencyP99 = stats.latencyMax
 	}

--- a/TreeDB/db/publish_watermark_metrics.go
+++ b/TreeDB/db/publish_watermark_metrics.go
@@ -2,7 +2,7 @@ package db
 
 import "time"
 
-const maxDurationNs = uint64(1<<63 - 1)
+const maxTimeDurationNs = uint64(1<<63 - 1)
 
 var publishWatermarkLatencyBucketUpperBounds = [...]time.Duration{
 	50 * time.Microsecond,
@@ -66,8 +66,8 @@ func estimatePublishWatermarkPercentile(buckets [publishWatermarkLatencyBucketCo
 }
 
 func durationFromUint64Ns(ns uint64) time.Duration {
-	if ns > maxDurationNs {
-		return time.Duration(maxDurationNs)
+	if ns > maxTimeDurationNs {
+		return time.Duration(maxTimeDurationNs)
 	}
 	return time.Duration(ns)
 }
@@ -161,8 +161,8 @@ func (db *DB) observeOrderedRootDeltaGroupPublish(wait, hold time.Duration, root
 	waitNs := uint64(wait.Nanoseconds())
 	holdNs := uint64(hold.Nanoseconds())
 	latNs := waitNs + holdNs
-	if waitNs > maxDurationNs-holdNs {
-		latNs = maxDurationNs
+	if waitNs > maxTimeDurationNs-holdNs {
+		latNs = maxTimeDurationNs
 	}
 	latency := durationFromUint64Ns(latNs)
 

--- a/TreeDB/db/publish_watermark_metrics.go
+++ b/TreeDB/db/publish_watermark_metrics.go
@@ -169,8 +169,9 @@ func (db *DB) observeOrderedRootDeltaGroupPublish(wait, hold time.Duration, root
 	db.orderedRootDeltaGroupCalls.Add(1)
 	if err != nil {
 		db.orderedRootDeltaGroupErrors.Add(1)
+	} else {
+		db.orderedRootDeltaGroupRoots.Add(uint64(roots))
 	}
-	db.orderedRootDeltaGroupRoots.Add(uint64(roots))
 	db.orderedRootDeltaGroupWaitTotalNs.Add(waitNs)
 	db.orderedRootDeltaGroupHoldTotalNs.Add(holdNs)
 	for {

--- a/TreeDB/db/publish_watermark_metrics.go
+++ b/TreeDB/db/publish_watermark_metrics.go
@@ -154,17 +154,17 @@ func (db *DB) observeOrderedRootDeltaGroupPublish(wait, hold time.Duration, root
 	if hold < 0 {
 		hold = 0
 	}
-	latency := wait + hold
-	if latency < 0 {
-		latency = 0
-	}
 	if roots < 0 {
 		roots = 0
 	}
 
 	waitNs := uint64(wait.Nanoseconds())
 	holdNs := uint64(hold.Nanoseconds())
-	latNs := uint64(latency.Nanoseconds())
+	latNs := waitNs + holdNs
+	if waitNs > maxDurationNanos-holdNs {
+		latNs = maxDurationNanos
+	}
+	latency := durationFromUint64Nanos(latNs)
 
 	db.orderedRootDeltaGroupCalls.Add(1)
 	if err != nil {

--- a/TreeDB/db/publish_watermark_metrics_test.go
+++ b/TreeDB/db/publish_watermark_metrics_test.go
@@ -24,3 +24,35 @@ func TestEstimatePublishWatermarkPercentile_NonOverflow(t *testing.T) {
 		t.Fatalf("expected first bucket bound, got %v", got)
 	}
 }
+
+func TestObserveOrderedRootDeltaGroupPublishStats(t *testing.T) {
+	db := &DB{}
+	db.observeOrderedRootDeltaGroupPublish(2*time.Millisecond, 3*time.Millisecond, 4, nil)
+	db.observeOrderedRootDeltaGroupPublish(time.Millisecond, time.Millisecond, 2, errTestFinalizeCommitFailpoint)
+
+	stats := db.orderedRootDeltaGroupPublishStats()
+	if stats.calls != 2 {
+		t.Fatalf("calls=%d want 2", stats.calls)
+	}
+	if stats.errors != 1 {
+		t.Fatalf("errors=%d want 1", stats.errors)
+	}
+	if stats.roots != 6 {
+		t.Fatalf("roots=%d want 6", stats.roots)
+	}
+	if stats.waitTotalNs != uint64((3 * time.Millisecond).Nanoseconds()) {
+		t.Fatalf("waitTotalNs=%d", stats.waitTotalNs)
+	}
+	if stats.holdTotalNs != uint64((4 * time.Millisecond).Nanoseconds()) {
+		t.Fatalf("holdTotalNs=%d", stats.holdTotalNs)
+	}
+	if stats.avgRootsPerCall != 3 {
+		t.Fatalf("avgRootsPerCall=%f want 3", stats.avgRootsPerCall)
+	}
+	if stats.writeLockWaitShare <= 0 || stats.writeLockWaitShare >= 100 {
+		t.Fatalf("writeLockWaitShare=%f want between 0 and 100", stats.writeLockWaitShare)
+	}
+	if stats.latencyP99 <= 0 {
+		t.Fatalf("latencyP99=%v want >0", stats.latencyP99)
+	}
+}

--- a/TreeDB/db/publish_watermark_metrics_test.go
+++ b/TreeDB/db/publish_watermark_metrics_test.go
@@ -68,3 +68,11 @@ func TestOrderedRootDeltaGroupPublishStatsUsesBucketSnapshotForPercentile(t *tes
 		t.Fatalf("latencyP99=%v want first bucket bound", stats.latencyP99)
 	}
 }
+
+func TestDurationFromUint64NsClampsOverflow(t *testing.T) {
+	for _, ns := range []uint64{maxTimeDurationNs + 1, ^uint64(0)} {
+		if got := durationFromUint64Ns(ns); got != time.Duration(maxTimeDurationNs) {
+			t.Fatalf("durationFromUint64Ns(%d)=%v want %v", ns, got, time.Duration(maxTimeDurationNs))
+		}
+	}
+}

--- a/TreeDB/db/publish_watermark_metrics_test.go
+++ b/TreeDB/db/publish_watermark_metrics_test.go
@@ -37,8 +37,8 @@ func TestObserveOrderedRootDeltaGroupPublishStats(t *testing.T) {
 	if stats.errors != 1 {
 		t.Fatalf("errors=%d want 1", stats.errors)
 	}
-	if stats.roots != 6 {
-		t.Fatalf("roots=%d want 6", stats.roots)
+	if stats.roots != 4 {
+		t.Fatalf("roots=%d want 4", stats.roots)
 	}
 	if stats.waitTotalNs != uint64((3 * time.Millisecond).Nanoseconds()) {
 		t.Fatalf("waitTotalNs=%d", stats.waitTotalNs)
@@ -46,8 +46,8 @@ func TestObserveOrderedRootDeltaGroupPublishStats(t *testing.T) {
 	if stats.holdTotalNs != uint64((4 * time.Millisecond).Nanoseconds()) {
 		t.Fatalf("holdTotalNs=%d", stats.holdTotalNs)
 	}
-	if stats.avgRootsPerCall != 3 {
-		t.Fatalf("avgRootsPerCall=%f want 3", stats.avgRootsPerCall)
+	if stats.avgRootsPerCall != 2 {
+		t.Fatalf("avgRootsPerCall=%f want 2", stats.avgRootsPerCall)
 	}
 	if stats.writeLockWaitShare <= 0 || stats.writeLockWaitShare >= 100 {
 		t.Fatalf("writeLockWaitShare=%f want between 0 and 100", stats.writeLockWaitShare)

--- a/TreeDB/db/publish_watermark_metrics_test.go
+++ b/TreeDB/db/publish_watermark_metrics_test.go
@@ -56,3 +56,15 @@ func TestObserveOrderedRootDeltaGroupPublishStats(t *testing.T) {
 		t.Fatalf("latencyP99=%v want >0", stats.latencyP99)
 	}
 }
+
+func TestOrderedRootDeltaGroupPublishStatsUsesBucketSnapshotForPercentile(t *testing.T) {
+	db := &DB{}
+	db.orderedRootDeltaGroupCalls.Store(100)
+	db.orderedRootDeltaGroupLatencyMaxNs.Store(uint64(time.Millisecond))
+	db.orderedRootDeltaGroupLatencyBuckets[0].Store(1)
+
+	stats := db.orderedRootDeltaGroupPublishStats()
+	if stats.latencyP99 != 50*time.Microsecond {
+		t.Fatalf("latencyP99=%v want first bucket bound", stats.latencyP99)
+	}
+}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1695,9 +1695,6 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 			}
 			return nil
 		}
-		if target.db != nil {
-			result.TreeDBStatsFinal = selectedTreeDBStats(target.db.Stats())
-		}
 		return nil
 	}
 	stats, err := mongoDBStats(ctx, target.client.Database(cfg.Database))
@@ -2384,7 +2381,7 @@ func writeDiskSnapshot(out io.Writer, label string, snapshot *diskSnapshot) {
 	fmt.Fprintln(out)
 }
 
-var selectedTreeDBStatKeys = []string{
+var selectedTreeDBStatKeys = [...]string{
 	"treedb.commit_seq",
 	"treedb.publish.ordered_root_delta_group.calls_total",
 	"treedb.publish.ordered_root_delta_group.errors_total",

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2434,16 +2434,18 @@ var selectedTreeDBExactStatKeys = [...]string{
 	"treedb.commit_seq",
 }
 
+var selectedTreeDBExactStatKeySet = map[string]struct{}{
+	"treedb.commit_seq": {},
+}
+
 var selectedTreeDBStatPrefixes = [...]string{
 	"treedb.publish.ordered_root_delta_group.",
 	"treedb.publish.watermark.",
 }
 
 func isSelectedTreeDBStatKey(key string) bool {
-	for _, exact := range selectedTreeDBExactStatKeys {
-		if key == exact {
-			return true
-		}
+	if _, ok := selectedTreeDBExactStatKeySet[key]; ok {
+		return true
 	}
 	for _, prefix := range selectedTreeDBStatPrefixes {
 		if strings.HasPrefix(key, prefix) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1784,13 +1784,7 @@ func collectTreeDBStatsFromDir(cfg config, target *benchTarget) (map[string]stri
 		return nil, nil
 	}
 	opts := treedb.OptionsFor(cfg.TreeDBProfile, target.treedbDir)
-	opts.IndexOuterLeavesInValueLog = true
-	opts.IndexInternalBaseDelta = false
-	open := treedb.OpenBackend
-	if opts.IndexOuterLeavesInValueLog {
-		open = treedb.OpenBackendWithCachedLeafLog
-	}
-	db, cleanup, err := open(opts)
+	db, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -1800,14 +1794,11 @@ func collectTreeDBStatsFromDir(cfg config, target *benchTarget) (map[string]stri
 
 func mergeTreeDBPersistentStats(base, refreshed map[string]string) map[string]string {
 	if len(base) == 0 {
-		return refreshed
+		return cloneStringMap(refreshed)
 	}
+	merged := cloneStringMap(base)
 	if len(refreshed) == 0 {
-		return base
-	}
-	merged := make(map[string]string, len(base)+len(selectedTreeDBExactStatKeys))
-	for key, value := range base {
-		merged[key] = value
+		return merged
 	}
 	for _, key := range selectedTreeDBExactStatKeys {
 		if value, ok := refreshed[key]; ok {
@@ -1815,6 +1806,17 @@ func mergeTreeDBPersistentStats(base, refreshed map[string]string) map[string]st
 		}
 	}
 	return merged
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }
 
 func appendTreeDBMaintenanceStep(ctx context.Context, target *benchTarget, result *benchmarkResult, name string, run func() (map[string]int64, string, error)) error {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1680,17 +1680,14 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 			return err
 		}
 		result.TreeDBDiskAfterCheckpoint = &snapshot
+		if target.db != nil {
+			result.TreeDBStatsFinal = target.db.Stats()
+		}
 		if cfg.TreeDBMaintenance == treeDBMaintenanceFull {
 			if err := runTreeDBMaintenanceStack(ctx, target, result); err != nil {
 				return err
 			}
-			if target.db != nil {
-				result.TreeDBStatsFinal = target.db.Stats()
-			}
 			return nil
-		}
-		if target.db != nil {
-			result.TreeDBStatsFinal = target.db.Stats()
 		}
 		return nil
 	}
@@ -2393,13 +2390,19 @@ func writeTreeDBStats(out io.Writer, label string, stats map[string]string) {
 		"treedb.publish.watermark.lock_delay_share_pct",
 		"treedb.publish.watermark.latency_p99_ms",
 	}
-	fmt.Fprintf(out, "%s", label)
+	wroteAny := false
 	for _, key := range keys {
 		if value, ok := stats[key]; ok {
+			if !wroteAny {
+				fmt.Fprintf(out, "%s", label)
+				wroteAny = true
+			}
 			fmt.Fprintf(out, " %s=%s", key, value)
 		}
 	}
-	fmt.Fprintln(out)
+	if wroteAny {
+		fmt.Fprintln(out)
+	}
 }
 
 func writeMaintenanceResult(out io.Writer, step maintenanceResult) {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1641,7 +1641,7 @@ func collectAfterLoadStats(ctx context.Context, cfg config, target *benchTarget,
 		}
 		result.TreeDBDiskAfterLoad = &snapshot
 		if target.db != nil {
-			result.TreeDBStatsAfterLoad = target.db.Stats()
+			result.TreeDBStatsAfterLoad = selectedTreeDBStats(target.db.Stats())
 		}
 		return nil
 	}
@@ -1662,7 +1662,7 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 				}
 			}
 			if target.db != nil {
-				result.TreeDBStatsFinal = target.db.Stats()
+				result.TreeDBStatsFinal = selectedTreeDBStats(target.db.Stats())
 			}
 			return nil
 		}
@@ -1682,19 +1682,21 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 		}
 		result.TreeDBDiskAfterCheckpoint = &snapshot
 		if target.db != nil {
-			result.TreeDBStatsAfterCheckpoint = target.db.Stats()
+			stats := selectedTreeDBStats(target.db.Stats())
+			result.TreeDBStatsAfterCheckpoint = stats
+			result.TreeDBStatsFinal = stats
 		}
 		if cfg.TreeDBMaintenance == treeDBMaintenanceFull {
 			if err := runTreeDBMaintenanceStack(ctx, target, result); err != nil {
 				return err
 			}
 			if target.db != nil {
-				result.TreeDBStatsFinal = target.db.Stats()
+				result.TreeDBStatsFinal = selectedTreeDBStats(target.db.Stats())
 			}
 			return nil
 		}
 		if target.db != nil {
-			result.TreeDBStatsFinal = target.db.Stats()
+			result.TreeDBStatsFinal = selectedTreeDBStats(target.db.Stats())
 		}
 		return nil
 	}
@@ -2382,26 +2384,43 @@ func writeDiskSnapshot(out io.Writer, label string, snapshot *diskSnapshot) {
 	fmt.Fprintln(out)
 }
 
+var selectedTreeDBStatKeys = []string{
+	"treedb.commit_seq",
+	"treedb.publish.ordered_root_delta_group.calls_total",
+	"treedb.publish.ordered_root_delta_group.errors_total",
+	"treedb.publish.ordered_root_delta_group.roots_total",
+	"treedb.publish.ordered_root_delta_group.avg_roots_per_call",
+	"treedb.publish.ordered_root_delta_group.write_lock_wait_ns_total",
+	"treedb.publish.ordered_root_delta_group.write_lock_hold_ns_total",
+	"treedb.publish.ordered_root_delta_group.write_lock_wait_share_pct",
+	"treedb.publish.ordered_root_delta_group.latency_p99_ms",
+	"treedb.publish.ordered_root_delta_group.latency_max_ms",
+	"treedb.publish.watermark.lock_delay_share_pct",
+	"treedb.publish.watermark.latency_p99_ms",
+}
+
+func selectedTreeDBStats(stats map[string]string) map[string]string {
+	if len(stats) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(selectedTreeDBStatKeys))
+	for _, key := range selectedTreeDBStatKeys {
+		if value, ok := stats[key]; ok {
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func writeTreeDBStats(out io.Writer, label string, stats map[string]string) {
 	if len(stats) == 0 {
 		return
 	}
-	keys := []string{
-		"treedb.commit_seq",
-		"treedb.publish.ordered_root_delta_group.calls_total",
-		"treedb.publish.ordered_root_delta_group.errors_total",
-		"treedb.publish.ordered_root_delta_group.roots_total",
-		"treedb.publish.ordered_root_delta_group.avg_roots_per_call",
-		"treedb.publish.ordered_root_delta_group.write_lock_wait_ns_total",
-		"treedb.publish.ordered_root_delta_group.write_lock_hold_ns_total",
-		"treedb.publish.ordered_root_delta_group.write_lock_wait_share_pct",
-		"treedb.publish.ordered_root_delta_group.latency_p99_ms",
-		"treedb.publish.ordered_root_delta_group.latency_max_ms",
-		"treedb.publish.watermark.lock_delay_share_pct",
-		"treedb.publish.watermark.latency_p99_ms",
-	}
 	wroteAny := false
-	for _, key := range keys {
+	for _, key := range selectedTreeDBStatKeys {
 		if value, ok := stats[key]; ok {
 			if !wroteAny {
 				fmt.Fprintf(out, "%s", label)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1655,6 +1655,11 @@ func collectAfterLoadStats(ctx context.Context, cfg config, target *benchTarget,
 func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, result *benchmarkResult) error {
 	if cfg.Target == "treedb" {
 		if cfg.TreeDBMaintenance == treeDBMaintenanceNone {
+			if target.collections != nil {
+				if err := target.collections.FlushAll(); err != nil {
+					return err
+				}
+			}
 			if target.db != nil {
 				result.TreeDBStatsFinal = target.db.Stats()
 			}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1784,6 +1784,7 @@ func collectTreeDBStatsFromDir(cfg config, target *benchTarget) (map[string]stri
 		return nil, nil
 	}
 	opts := treedb.OptionsFor(cfg.TreeDBProfile, target.treedbDir)
+	opts.ReadOnly = true
 	db, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
 	if err != nil {
 		return nil, err
@@ -2434,8 +2435,14 @@ var selectedTreeDBExactStatKeys = [...]string{
 	"treedb.commit_seq",
 }
 
-var selectedTreeDBExactStatKeySet = map[string]struct{}{
-	"treedb.commit_seq": {},
+var selectedTreeDBExactStatKeySet = newSelectedTreeDBExactStatKeySet(selectedTreeDBExactStatKeys[:])
+
+func newSelectedTreeDBExactStatKeySet(keys []string) map[string]struct{} {
+	keySet := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		keySet[key] = struct{}{}
+	}
+	return keySet
 }
 
 var selectedTreeDBStatPrefixes = [...]string{

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -106,6 +106,8 @@ type benchmarkResult struct {
 	TreeDBDiskAfterLoad         *diskSnapshot       `json:"treedb_disk_after_load,omitempty"`
 	TreeDBDiskAfterCheckpoint   *diskSnapshot       `json:"treedb_disk_after_checkpoint,omitempty"`
 	TreeDBDiskAfterMaintenance  *diskSnapshot       `json:"treedb_disk_after_maintenance,omitempty"`
+	TreeDBStatsAfterLoad        map[string]string   `json:"treedb_stats_after_load,omitempty"`
+	TreeDBStatsFinal            map[string]string   `json:"treedb_stats_final,omitempty"`
 	TreeDBMaintenance           []maintenanceResult `json:"treedb_maintenance,omitempty"`
 	MongoDBStatsAfterLoad       map[string]any      `json:"mongodb_stats_after_load,omitempty"`
 	MongoDBStatsFinal           map[string]any      `json:"mongodb_stats_final,omitempty"`
@@ -1634,6 +1636,9 @@ func collectAfterLoadStats(ctx context.Context, cfg config, target *benchTarget,
 			return err
 		}
 		result.TreeDBDiskAfterLoad = &snapshot
+		if target.db != nil {
+			result.TreeDBStatsAfterLoad = target.db.Stats()
+		}
 		return nil
 	}
 	stats, err := mongoDBStats(ctx, target.client.Database(cfg.Database))
@@ -1647,6 +1652,9 @@ func collectAfterLoadStats(ctx context.Context, cfg config, target *benchTarget,
 func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, result *benchmarkResult) error {
 	if cfg.Target == "treedb" {
 		if cfg.TreeDBMaintenance == treeDBMaintenanceNone {
+			if target.db != nil {
+				result.TreeDBStatsFinal = target.db.Stats()
+			}
 			return nil
 		}
 		if target.collections != nil {
@@ -1665,7 +1673,16 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 		}
 		result.TreeDBDiskAfterCheckpoint = &snapshot
 		if cfg.TreeDBMaintenance == treeDBMaintenanceFull {
-			return runTreeDBMaintenanceStack(ctx, target, result)
+			if err := runTreeDBMaintenanceStack(ctx, target, result); err != nil {
+				return err
+			}
+			if target.db != nil {
+				result.TreeDBStatsFinal = target.db.Stats()
+			}
+			return nil
+		}
+		if target.db != nil {
+			result.TreeDBStatsFinal = target.db.Stats()
 		}
 		return nil
 	}
@@ -2307,6 +2324,9 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		if result.TreeDBDiskAfterLoad != nil {
 			writeDiskSnapshot(out, "treedb_after_load", result.TreeDBDiskAfterLoad)
 		}
+		if result.TreeDBStatsAfterLoad != nil {
+			writeTreeDBStats(out, "treedb_stats_after_load", result.TreeDBStatsAfterLoad)
+		}
 		if result.TreeDBDiskAfterCheckpoint != nil {
 			writeDiskSnapshot(out, "treedb_after_checkpoint", result.TreeDBDiskAfterCheckpoint)
 		}
@@ -2315,6 +2335,9 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		}
 		if result.TreeDBDiskAfterMaintenance != nil {
 			writeDiskSnapshot(out, "treedb_after_maintenance", result.TreeDBDiskAfterMaintenance)
+		}
+		if result.TreeDBStatsFinal != nil {
+			writeTreeDBStats(out, "treedb_stats_final", result.TreeDBStatsFinal)
 		}
 		if result.MongoDBStatsAfterLoad != nil {
 			writeMongoStats(out, "mongodb_after_load", result.MongoDBStatsAfterLoad)
@@ -2340,6 +2363,29 @@ func writeDiskSnapshot(out io.Writer, label string, snapshot *diskSnapshot) {
 	sort.Strings(names)
 	for _, name := range names {
 		fmt.Fprintf(out, " %s=%d", name, snapshot.Paths[name])
+	}
+	fmt.Fprintln(out)
+}
+
+func writeTreeDBStats(out io.Writer, label string, stats map[string]string) {
+	if len(stats) == 0 {
+		return
+	}
+	keys := []string{
+		"treedb.commit_seq",
+		"treedb.publish.ordered_root_delta_group.calls_total",
+		"treedb.publish.ordered_root_delta_group.roots_total",
+		"treedb.publish.ordered_root_delta_group.avg_roots_per_call",
+		"treedb.publish.ordered_root_delta_group.write_lock_wait_share_pct",
+		"treedb.publish.ordered_root_delta_group.latency_p99_ms",
+		"treedb.publish.watermark.lock_delay_share_pct",
+		"treedb.publish.watermark.latency_p99_ms",
+	}
+	fmt.Fprintf(out, "%s", label)
+	for _, key := range keys {
+		if value, ok := stats[key]; ok {
+			fmt.Fprintf(out, " %s=%s", key, value)
+		}
 	}
 	fmt.Fprintln(out)
 }

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2391,8 +2391,6 @@ var selectedTreeDBStatPrefixes = [...]string{
 	"treedb.publish.watermark.",
 }
 
-var warnMissingTreeDBStatKeysOnce sync.Once
-
 func isSelectedTreeDBStatKey(key string) bool {
 	for _, exact := range selectedTreeDBExactStatKeys {
 		if key == exact {
@@ -2412,21 +2410,10 @@ func selectedTreeDBStats(stats map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string)
-	missing := make([]string, 0)
 	for key, value := range stats {
 		if isSelectedTreeDBStatKey(key) {
 			out[key] = value
 		}
-	}
-	for _, key := range selectedTreeDBExactStatKeys {
-		if _, ok := stats[key]; !ok {
-			missing = append(missing, key)
-		}
-	}
-	if len(missing) > 0 {
-		warnMissingTreeDBStatKeysOnce.Do(func() {
-			fmt.Fprintf(os.Stderr, "warning: benchmark expected TreeDB stats missing from DB.Stats(): %s\n", strings.Join(missing, ", "))
-		})
 	}
 	if len(out) == 0 {
 		return nil

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1690,9 +1690,11 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 			if err := runTreeDBMaintenanceStack(ctx, target, result); err != nil {
 				return err
 			}
-			if target.db != nil {
-				result.TreeDBStatsFinal = selectedTreeDBStats(target.db.Stats())
+			stats, err := collectTreeDBStatsFromDir(cfg, target)
+			if err != nil {
+				return err
 			}
+			result.TreeDBStatsFinal = stats
 			return nil
 		}
 		return nil
@@ -1769,6 +1771,31 @@ func runTreeDBMaintenanceStack(ctx context.Context, target *benchTarget, result 
 		return err
 	}
 	return nil
+}
+
+func collectTreeDBStatsFromDir(cfg config, target *benchTarget) (map[string]string, error) {
+	if target == nil {
+		return nil, nil
+	}
+	if target.db != nil {
+		return selectedTreeDBStats(target.db.Stats()), nil
+	}
+	if target.treedbDir == "" {
+		return nil, nil
+	}
+	opts := treedb.OptionsFor(cfg.TreeDBProfile, target.treedbDir)
+	opts.IndexOuterLeavesInValueLog = true
+	opts.IndexInternalBaseDelta = false
+	open := treedb.OpenBackend
+	if opts.IndexOuterLeavesInValueLog {
+		open = treedb.OpenBackendWithCachedLeafLog
+	}
+	db, cleanup, err := open(opts)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cleanup() }()
+	return selectedTreeDBStats(db.Stats()), nil
 }
 
 func appendTreeDBMaintenanceStep(ctx context.Context, target *benchTarget, result *benchmarkResult, name string, run func() (map[string]int64, string, error)) error {
@@ -2427,9 +2454,7 @@ func writeTreeDBStats(out io.Writer, label string, stats map[string]string) {
 	}
 	keys := make([]string, 0, len(stats))
 	for key := range stats {
-		if isSelectedTreeDBStatKey(key) {
-			keys = append(keys, key)
-		}
+		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	wroteAny := false

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1694,7 +1694,7 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 			if err != nil {
 				return err
 			}
-			result.TreeDBStatsFinal = stats
+			result.TreeDBStatsFinal = mergeTreeDBPersistentStats(result.TreeDBStatsFinal, stats)
 			return nil
 		}
 		return nil
@@ -1796,6 +1796,25 @@ func collectTreeDBStatsFromDir(cfg config, target *benchTarget) (map[string]stri
 	}
 	defer func() { _ = cleanup() }()
 	return selectedTreeDBStats(db.Stats()), nil
+}
+
+func mergeTreeDBPersistentStats(base, refreshed map[string]string) map[string]string {
+	if len(base) == 0 {
+		return refreshed
+	}
+	if len(refreshed) == 0 {
+		return base
+	}
+	merged := make(map[string]string, len(base)+len(selectedTreeDBExactStatKeys))
+	for key, value := range base {
+		merged[key] = value
+	}
+	for _, key := range selectedTreeDBExactStatKeys {
+		if value, ok := refreshed[key]; ok {
+			merged[key] = value
+		}
+	}
+	return merged
 }
 
 func appendTreeDBMaintenanceStep(ctx context.Context, target *benchTarget, result *benchmarkResult, name string, run func() (map[string]int64, string, error)) error {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -107,6 +107,7 @@ type benchmarkResult struct {
 	TreeDBDiskAfterCheckpoint   *diskSnapshot       `json:"treedb_disk_after_checkpoint,omitempty"`
 	TreeDBDiskAfterMaintenance  *diskSnapshot       `json:"treedb_disk_after_maintenance,omitempty"`
 	TreeDBStatsAfterLoad        map[string]string   `json:"treedb_stats_after_load,omitempty"`
+	TreeDBStatsAfterCheckpoint  map[string]string   `json:"treedb_stats_after_checkpoint,omitempty"`
 	TreeDBStatsFinal            map[string]string   `json:"treedb_stats_final,omitempty"`
 	TreeDBMaintenance           []maintenanceResult `json:"treedb_maintenance,omitempty"`
 	MongoDBStatsAfterLoad       map[string]any      `json:"mongodb_stats_after_load,omitempty"`
@@ -1681,13 +1682,19 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 		}
 		result.TreeDBDiskAfterCheckpoint = &snapshot
 		if target.db != nil {
-			result.TreeDBStatsFinal = target.db.Stats()
+			result.TreeDBStatsAfterCheckpoint = target.db.Stats()
 		}
 		if cfg.TreeDBMaintenance == treeDBMaintenanceFull {
 			if err := runTreeDBMaintenanceStack(ctx, target, result); err != nil {
 				return err
 			}
+			if target.db != nil {
+				result.TreeDBStatsFinal = target.db.Stats()
+			}
 			return nil
+		}
+		if target.db != nil {
+			result.TreeDBStatsFinal = target.db.Stats()
 		}
 		return nil
 	}
@@ -2334,6 +2341,9 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		}
 		if result.TreeDBDiskAfterCheckpoint != nil {
 			writeDiskSnapshot(out, "treedb_after_checkpoint", result.TreeDBDiskAfterCheckpoint)
+		}
+		if result.TreeDBStatsAfterCheckpoint != nil {
+			writeTreeDBStats(out, "treedb_stats_after_checkpoint", result.TreeDBStatsAfterCheckpoint)
 		}
 		for _, step := range result.TreeDBMaintenance {
 			writeMaintenanceResult(out, step)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2396,15 +2396,25 @@ var selectedTreeDBStatKeys = [...]string{
 	"treedb.publish.watermark.latency_p99_ms",
 }
 
+var warnMissingTreeDBStatKeysOnce sync.Once
+
 func selectedTreeDBStats(stats map[string]string) map[string]string {
 	if len(stats) == 0 {
 		return nil
 	}
 	out := make(map[string]string, len(selectedTreeDBStatKeys))
+	missing := make([]string, 0)
 	for _, key := range selectedTreeDBStatKeys {
 		if value, ok := stats[key]; ok {
 			out[key] = value
+			continue
 		}
+		missing = append(missing, key)
+	}
+	if len(missing) > 0 {
+		warnMissingTreeDBStatKeysOnce.Do(func() {
+			fmt.Fprintf(os.Stderr, "warning: benchmark expected TreeDB stats missing from DB.Stats(): %s\n", strings.Join(missing, ", "))
+		})
 	}
 	if len(out) == 0 {
 		return nil

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1782,6 +1782,7 @@ func appendTreeDBMaintenanceStep(ctx context.Context, target *benchTarget, resul
 		if err := target.db.Checkpoint(); err != nil {
 			return fmt.Errorf("checkpoint after %s: %w", name, err)
 		}
+		result.TreeDBStatsFinal = selectedTreeDBStats(target.db.Stats())
 	}
 	snapshot, err := collectDiskSnapshot(target.treedbDir)
 	if err != nil {
@@ -2381,35 +2382,46 @@ func writeDiskSnapshot(out io.Writer, label string, snapshot *diskSnapshot) {
 	fmt.Fprintln(out)
 }
 
-var selectedTreeDBStatKeys = [...]string{
+var selectedTreeDBExactStatKeys = [...]string{
 	"treedb.commit_seq",
-	"treedb.publish.ordered_root_delta_group.calls_total",
-	"treedb.publish.ordered_root_delta_group.errors_total",
-	"treedb.publish.ordered_root_delta_group.roots_total",
-	"treedb.publish.ordered_root_delta_group.avg_roots_per_call",
-	"treedb.publish.ordered_root_delta_group.write_lock_wait_ns_total",
-	"treedb.publish.ordered_root_delta_group.write_lock_hold_ns_total",
-	"treedb.publish.ordered_root_delta_group.write_lock_wait_share_pct",
-	"treedb.publish.ordered_root_delta_group.latency_p99_ms",
-	"treedb.publish.ordered_root_delta_group.latency_max_ms",
-	"treedb.publish.watermark.lock_delay_share_pct",
-	"treedb.publish.watermark.latency_p99_ms",
+}
+
+var selectedTreeDBStatPrefixes = [...]string{
+	"treedb.publish.ordered_root_delta_group.",
+	"treedb.publish.watermark.",
 }
 
 var warnMissingTreeDBStatKeysOnce sync.Once
+
+func isSelectedTreeDBStatKey(key string) bool {
+	for _, exact := range selectedTreeDBExactStatKeys {
+		if key == exact {
+			return true
+		}
+	}
+	for _, prefix := range selectedTreeDBStatPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
 
 func selectedTreeDBStats(stats map[string]string) map[string]string {
 	if len(stats) == 0 {
 		return nil
 	}
-	out := make(map[string]string, len(selectedTreeDBStatKeys))
+	out := make(map[string]string)
 	missing := make([]string, 0)
-	for _, key := range selectedTreeDBStatKeys {
-		if value, ok := stats[key]; ok {
+	for key, value := range stats {
+		if isSelectedTreeDBStatKey(key) {
 			out[key] = value
-			continue
 		}
-		missing = append(missing, key)
+	}
+	for _, key := range selectedTreeDBExactStatKeys {
+		if _, ok := stats[key]; !ok {
+			missing = append(missing, key)
+		}
 	}
 	if len(missing) > 0 {
 		warnMissingTreeDBStatKeysOnce.Do(func() {
@@ -2426,8 +2438,15 @@ func writeTreeDBStats(out io.Writer, label string, stats map[string]string) {
 	if len(stats) == 0 {
 		return
 	}
+	keys := make([]string, 0, len(stats))
+	for key := range stats {
+		if isSelectedTreeDBStatKey(key) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
 	wroteAny := false
-	for _, key := range selectedTreeDBStatKeys {
+	for _, key := range keys {
 		if value, ok := stats[key]; ok {
 			if !wroteAny {
 				fmt.Fprintf(out, "%s", label)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2374,10 +2374,14 @@ func writeTreeDBStats(out io.Writer, label string, stats map[string]string) {
 	keys := []string{
 		"treedb.commit_seq",
 		"treedb.publish.ordered_root_delta_group.calls_total",
+		"treedb.publish.ordered_root_delta_group.errors_total",
 		"treedb.publish.ordered_root_delta_group.roots_total",
 		"treedb.publish.ordered_root_delta_group.avg_roots_per_call",
+		"treedb.publish.ordered_root_delta_group.write_lock_wait_ns_total",
+		"treedb.publish.ordered_root_delta_group.write_lock_hold_ns_total",
 		"treedb.publish.ordered_root_delta_group.write_lock_wait_share_pct",
 		"treedb.publish.ordered_root_delta_group.latency_p99_ms",
+		"treedb.publish.ordered_root_delta_group.latency_max_ms",
 		"treedb.publish.watermark.lock_delay_share_pct",
 		"treedb.publish.watermark.latency_p99_ms",
 	}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1225,6 +1225,29 @@ func TestMergeTreeDBPersistentStatsPreservesProcessCounters(t *testing.T) {
 	if got["treedb.publish.watermark.latency_p99_ms"] != "1.250" {
 		t.Fatalf("latency_p99_ms=%q want in-memory counter preserved", got["treedb.publish.watermark.latency_p99_ms"])
 	}
+	got["treedb.commit_seq"] = "mutated"
+	if base["treedb.commit_seq"] != "10" {
+		t.Fatalf("base map was aliased: %v", base)
+	}
+	if refreshed["treedb.commit_seq"] != "12" {
+		t.Fatalf("refreshed map was aliased: %v", refreshed)
+	}
+}
+
+func TestMergeTreeDBPersistentStatsClonesFastPaths(t *testing.T) {
+	base := map[string]string{"treedb.publish.ordered_root_delta_group.calls_total": "7"}
+	got := mergeTreeDBPersistentStats(base, nil)
+	got["treedb.publish.ordered_root_delta_group.calls_total"] = "mutated"
+	if base["treedb.publish.ordered_root_delta_group.calls_total"] != "7" {
+		t.Fatalf("base-only merge aliased input: %v", base)
+	}
+
+	refreshed := map[string]string{"treedb.commit_seq": "12"}
+	got = mergeTreeDBPersistentStats(nil, refreshed)
+	got["treedb.commit_seq"] = "mutated"
+	if refreshed["treedb.commit_seq"] != "12" {
+		t.Fatalf("refreshed-only merge aliased input: %v", refreshed)
+	}
 }
 
 func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -113,6 +114,51 @@ func TestCollectDiskSnapshotEmptyLeavesPathsNil(t *testing.T) {
 	}
 	if snapshot.TotalBytes != 0 || snapshot.Paths != nil {
 		t.Fatalf("empty snapshot=%+v want zero total and nil paths", snapshot)
+	}
+}
+
+func TestIsSelectedTreeDBStatKey(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{name: "exact commit seq", key: "treedb.commit_seq", want: true},
+		{name: "ordered root prefix", key: "treedb.publish.ordered_root_delta_group.calls_total", want: true},
+		{name: "watermark prefix", key: "treedb.publish.watermark.latency_p99_ms", want: true},
+		{name: "non match", key: "treedb.vlog.reads_total", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSelectedTreeDBStatKey(tt.key); got != tt.want {
+				t.Fatalf("isSelectedTreeDBStatKey(%q)=%v want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectedTreeDBStats(t *testing.T) {
+	if got := selectedTreeDBStats(nil); got != nil {
+		t.Fatalf("nil stats selected=%v want nil", got)
+	}
+	if got := selectedTreeDBStats(map[string]string{"treedb.vlog.reads_total": "7"}); got != nil {
+		t.Fatalf("unselected stats=%v want nil", got)
+	}
+	got := selectedTreeDBStats(map[string]string{
+		"treedb.commit_seq": "11",
+		"treedb.publish.ordered_root_delta_group.calls_total":    "3",
+		"treedb.publish.ordered_root_delta_group.latency_p99_ms": "1.5",
+		"treedb.publish.watermark.latency_p99_ms":                "2.5",
+		"treedb.vlog.reads_total":                                "7",
+	})
+	want := map[string]string{
+		"treedb.commit_seq": "11",
+		"treedb.publish.ordered_root_delta_group.calls_total":    "3",
+		"treedb.publish.ordered_root_delta_group.latency_p99_ms": "1.5",
+		"treedb.publish.watermark.latency_p99_ms":                "2.5",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected stats=%v want %v", got, want)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1204,6 +1204,29 @@ func TestWriteResultSupportsGenericWriter(t *testing.T) {
 	}
 }
 
+func TestMergeTreeDBPersistentStatsPreservesProcessCounters(t *testing.T) {
+	base := map[string]string{
+		"treedb.commit_seq": "10",
+		"treedb.publish.ordered_root_delta_group.calls_total": "7",
+		"treedb.publish.watermark.latency_p99_ms":             "1.250",
+	}
+	refreshed := map[string]string{
+		"treedb.commit_seq": "12",
+		"treedb.publish.ordered_root_delta_group.calls_total": "0",
+		"treedb.publish.watermark.latency_p99_ms":             "0.000",
+	}
+	got := mergeTreeDBPersistentStats(base, refreshed)
+	if got["treedb.commit_seq"] != "12" {
+		t.Fatalf("commit_seq=%q want refreshed value", got["treedb.commit_seq"])
+	}
+	if got["treedb.publish.ordered_root_delta_group.calls_total"] != "7" {
+		t.Fatalf("calls_total=%q want in-memory counter preserved", got["treedb.publish.ordered_root_delta_group.calls_total"])
+	}
+	if got["treedb.publish.watermark.latency_p99_ms"] != "1.250" {
+		t.Fatalf("latency_p99_ms=%q want in-memory counter preserved", got["treedb.publish.watermark.latency_p99_ms"])
+	}
+}
+
 func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {
 	result := &benchmarkResult{
 		Target:           "mongo",


### PR DESCRIPTION
## Summary
- add backend stats for ordered-root delta-group publish calls, root fanout, errors, write-lock wait/hold time, and latency
- include selected TreeDB publish stats in mongo_gateway_bench JSON/text output
- add focused coverage for the new publish metrics

## Validation
- go test ./TreeDB/db ./cmd/mongo_gateway_bench -count 1

## Stack
- Based on PR #1116 (`codex/collection-update-write-combiner`)

This is the observability base for the next optimization PRs: it makes collection multi-root publish amplification visible in benchmark artifacts instead of relying only on pprof interpretation.