### PR TITLE
[codex] Shrink collection update batch mutation lock

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3549,16 +3549,19 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 	if err != nil {
 		return nil, err
 	}
-	if plan == nil || len(plan.deltaTables) == 0 {
-		if plan != nil {
-			defer plan.close()
-			return plan.results, nil
-		}
+	if plan == nil {
 		return nil, nil
+	}
+	defer plan.close()
+	if len(plan.deltaTables) == 0 {
+		return plan.results, nil
 	}
 
 	unlockMutation = c.lockMutation()
 	defer unlockMutation()
+	if err := c.flushBufferedWrites(); err != nil {
+		return nil, err
+	}
 	return c.publishUpdateBatchPlanLocked(plan)
 }
 
@@ -3824,7 +3827,6 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	if plan == nil {
 		return nil, nil
 	}
-	defer plan.close()
 	if len(plan.deltaTables) == 0 {
 		return plan.results, nil
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3731,23 +3731,23 @@ func (plan *updateBatchPlan) close() {
 }
 
 func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondaryUniqueIndexes bool) ([]UpdateBatchResult, error) {
-	unlockMutation := c.lockMutation()
-	if err := c.flushBufferedWrites(); err != nil {
-		unlockMutation()
+	hasUnique := false
+	if err := c.withMutationLock(func() error {
+		if err := c.flushBufferedWrites(); err != nil {
+			return err
+		}
+		if !requireNoSecondaryUniqueIndexes {
+			return nil
+		}
+		var err error
+		hasUnique, err = c.hasSecondaryUniqueIndexLocked()
+		return err
+	}); err != nil {
 		return nil, err
 	}
-	if requireNoSecondaryUniqueIndexes {
-		hasUnique, err := c.hasSecondaryUniqueIndexLocked()
-		if err != nil {
-			unlockMutation()
-			return nil, err
-		}
-		if hasUnique {
-			unlockMutation()
-			return nil, errUpdateBatchHasSecondaryUniqueIndex
-		}
+	if hasUnique {
+		return nil, errUpdateBatchHasSecondaryUniqueIndex
 	}
-	unlockMutation()
 
 	plan, err := c.buildUpdateBatchPlan(items, requireNoSecondaryUniqueIndexes)
 	if err != nil {
@@ -3758,23 +3758,37 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 	}
 	defer plan.close()
 	if len(plan.deltaTables) == 0 {
-		unlockMutation = c.lockMutation()
-		defer unlockMutation()
-		if err := c.flushBufferedWrites(); err != nil {
-			return nil, err
-		}
-		if err := c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq); err != nil {
+		if err := c.withMutationLock(func() error {
+			if err := c.flushBufferedWrites(); err != nil {
+				return err
+			}
+			if err := c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq); err != nil {
+				return err
+			}
+			c.meta = plan.meta
+			return nil
+		}); err != nil {
 			return nil, err
 		}
 		return plan.results, nil
 	}
 
-	unlockMutation = c.lockMutation()
+	var results []UpdateBatchResult
+	err = c.withMutationLock(func() error {
+		if err := c.flushBufferedWrites(); err != nil {
+			return err
+		}
+		var publishErr error
+		results, publishErr = c.publishUpdateBatchPlanLocked(plan)
+		return publishErr
+	})
+	return results, err
+}
+
+func (c *Collection) withMutationLock(fn func() error) error {
+	unlockMutation := c.lockMutation()
 	defer unlockMutation()
-	if err := c.flushBufferedWrites(); err != nil {
-		return nil, err
-	}
-	return c.publishUpdateBatchPlanLocked(plan)
+	return fn()
 }
 
 func (c *Collection) hasSecondaryUniqueIndexLocked() (bool, error) {
@@ -4122,7 +4136,7 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 		return nil, err
 	}
 	if len(rootIDs) != len(plan.rootNames) {
-		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+		return nil, fmt.Errorf("collections: UpdateBatch collection %q ordered root publish returned unexpected root count expected=%d actual=%d", plan.meta.Name, len(plan.rootNames), len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(plan.catalog, plan.meta, plan.rootNames, rootIDs)
 	c.meta = plan.meta
@@ -4650,7 +4664,7 @@ func (c *Collection) validateRootDescriptorSystemDeltaForMeta(meta CollectionMet
 		for _, rootName := range rootNames {
 			want, ok := baseRootIDs[rootName]
 			if !ok {
-				return fmt.Errorf("collections: missing base root for %q", rootName)
+				return fmt.Errorf("collections: missing base root for collection %q root %q", meta.Name, rootName)
 			}
 			if got := catalog.rootID(rootName); got != want {
 				return errConcurrentRootModification(meta.Name, rootName)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4796,7 +4796,7 @@ func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedCommitSeq, e
 
 func (c *Collection) buildRootDescriptorSystemDeltaIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 	if len(rootIDs) != len(rootNames) {
-		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+		return nil, fmt.Errorf("collections: ordered root publish returned unexpected root count for %q: expected %d, got %d", meta.Name, len(rootNames), len(rootIDs))
 	}
 	if err := c.validateRootDescriptorSystemDeltaForMeta(meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs); err != nil {
 		return nil, err

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -850,7 +850,7 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 		return nil, err
 	}
 	if len(rootIDs) != len(plan.rootNames) {
-		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+		return nil, unexpectedOrderedRootCountError(newMeta.Name, len(plan.rootNames), len(rootIDs))
 	}
 	c.meta = newMeta
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, plan.rootNames, rootIDs)
@@ -1287,7 +1287,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 		return err
 	}
 	if len(rootIDs) != 1 {
-		return errors.New("collections: ordered root publish returned unexpected root count")
+		return unexpectedOrderedRootCountError(meta.Name, 1, len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(domain.catalog, meta, []string{rootName}, rootIDs)
 	domain.loaded = true
@@ -2187,7 +2187,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 		return err
 	}
 	if len(rootIDs) != len(rootNames) {
-		return errors.New("collections: ordered root publish returned unexpected root count")
+		return unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(domain.catalog, meta, rootNames, rootIDs)
 	oldRuns := domain.rootRuns
@@ -2310,7 +2310,7 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 		return nil, err
 	}
 	if len(rootIDs) != 1 {
-		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+		return nil, unexpectedOrderedRootCountError(c.meta.Name, 1, len(rootIDs))
 	}
 	c.rememberCatalogAtSystemRoot(newSystemRoot, cloneCatalogWithRootUpdates(catalog, c.meta, []string{rootName}, rootIDs))
 	return resultID, nil
@@ -2566,7 +2566,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		return nil, err
 	}
 	if len(rootIDs) != len(plan.runs) {
-		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+		return nil, unexpectedOrderedRootCountError(meta.Name, len(plan.runs), len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(currentCatalog, meta, rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
@@ -2823,7 +2823,7 @@ func (c *Collection) insertBatchNoIndex(
 		return nil, err
 	}
 	if len(rootIDs) != 1 {
-		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+		return nil, unexpectedOrderedRootCountError(c.meta.Name, 1, len(rootIDs))
 	}
 	stats.Runs = 1
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, []string{rootName}, rootIDs)
@@ -2992,7 +2992,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 		return false, err
 	}
 	if len(rootIDs) != len(rootNames) {
-		return false, errors.New("collections: ordered root publish returned unexpected root count")
+		return false, unexpectedOrderedRootCountError(c.meta.Name, len(rootNames), len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
@@ -3897,7 +3897,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		return false, false, err
 	}
 	if len(rootIDs) != len(rootNames) {
-		return false, false, errors.New("collections: ordered root publish returned unexpected root count")
+		return false, false, unexpectedOrderedRootCountError(c.meta.Name, len(rootNames), len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
@@ -4324,7 +4324,7 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 		return nil, err
 	}
 	if len(rootIDs) != len(plan.rootNames) {
-		return nil, fmt.Errorf("collections: UpdateBatch collection %q ordered root publish returned unexpected root count expected=%d actual=%d", plan.meta.Name, len(plan.rootNames), len(rootIDs))
+		return nil, unexpectedOrderedRootCountError(plan.meta.Name, len(plan.rootNames), len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(plan.catalog, plan.meta, plan.rootNames, rootIDs)
 	c.meta = plan.meta
@@ -4780,7 +4780,7 @@ func documentIndexStatesEqual(left, right documentIndexState) bool {
 
 func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 	if len(rootIDs) != len(rootNames) {
-		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+		return nil, unexpectedOrderedRootCountError(c.meta.Name, len(rootNames), len(rootIDs))
 	}
 	current := c.db.AcquireSnapshot()
 	if current == nil {
@@ -4806,6 +4806,13 @@ func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseR
 	return buildSystemTargetIterator(current, updates)
 }
 
+func unexpectedOrderedRootCountError(collectionName string, expected, actual int) error {
+	if collectionName != "" {
+		return fmt.Errorf("collections: ordered root publish returned unexpected root count collection=%q expected=%d actual=%d", collectionName, expected, actual)
+	}
+	return fmt.Errorf("collections: ordered root publish returned unexpected root count expected=%d actual=%d", expected, actual)
+}
+
 func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 	if c == nil || c.db == nil {
 		return nil, backenddb.ErrClosed
@@ -4815,7 +4822,7 @@ func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedCommitSeq, e
 
 func (c *Collection) buildRootDescriptorSystemDeltaIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 	if len(rootIDs) != len(rootNames) {
-		return nil, fmt.Errorf("collections: ordered root publish returned unexpected root count for %q: expected %d, got %d", meta.Name, len(rootNames), len(rootIDs))
+		return nil, unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
 	}
 	if err := c.validateRootDescriptorSystemDeltaForMeta(meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs); err != nil {
 		return nil, err
@@ -4900,7 +4907,7 @@ func (c *Collection) buildSchemaAndRootDescriptorSystemIterator(
 	rootIDs []uint64,
 ) (iterator.UnsafeIterator, error) {
 	if len(rootIDs) != len(rootNames) {
-		return nil, errors.New("collections: ordered root publish returned unexpected root count")
+		return nil, unexpectedOrderedRootCountError(newMeta.Name, len(rootNames), len(rootIDs))
 	}
 	current := c.db.AcquireSnapshot()
 	if current == nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4005,6 +4005,9 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	if len(plan.deltaTables) == 0 {
 		return plan.results, nil
 	}
+	if len(plan.rootNames) != len(plan.deltaTables) || len(plan.rootNames) != len(plan.policies) {
+		return nil, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
+	}
 
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
 	iterators := make([]iterator.UnsafeIterator, 0, len(plan.rootNames))
@@ -4016,7 +4019,7 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	for i, rootName := range plan.rootNames {
 		baseRoot, ok := plan.baseRootIDs[rootName]
 		if !ok {
-			return nil, fmt.Errorf("collections: update batch plan missing base root for %q", rootName)
+			return nil, fmt.Errorf("collections: UpdateBatch collection %q plan missing base root for %q", plan.meta.Name, rootName)
 		}
 		iter := plan.deltaTables[i].NewIterator(nil, nil)
 		iterators = append(iterators, iter)
@@ -4544,8 +4547,7 @@ func (c *Collection) validateRootDescriptorSystemDeltaForMeta(meta CollectionMet
 	if c == nil || c.db == nil {
 		return backenddb.ErrClosed
 	}
-	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(nil)
-	currentCommitSeq, currentSystemRoot = dbCommitSeqAndSystemRoot(c.db)
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
 	if currentSystemRoot != expectedSystemRoot || currentCommitSeq != expectedCommitSeq {
 		current := c.db.AcquireSnapshot()
 		if current == nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3927,6 +3927,10 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 	}
 	defer plan.close()
 	if len(plan.deltaTables) == 0 {
+		if plan.snap != nil {
+			_ = plan.snap.Close()
+			plan.snap = nil
+		}
 		if err := c.withMutationLock(func() error {
 			if err := c.flushBufferedWrites(); err != nil {
 				return err
@@ -4778,6 +4782,9 @@ func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseR
 }
 
 func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	if c == nil || c.db == nil {
+		return nil, backenddb.ErrClosed
+	}
 	return c.buildRootDescriptorSystemDeltaIteratorForMeta(c.meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs, rootIDs)
 }
 
@@ -4796,6 +4803,9 @@ func (c *Collection) buildRootDescriptorSystemDeltaIteratorForMeta(meta Collecti
 }
 
 func (c *Collection) validateRootDescriptorSystemDelta(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64) error {
+	if c == nil || c.db == nil {
+		return backenddb.ErrClosed
+	}
 	return c.validateRootDescriptorSystemDeltaForMeta(c.meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs)
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3698,6 +3698,17 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 		unlockMutation()
 		return nil, err
 	}
+	if requireNoSecondaryUniqueIndexes {
+		hasUnique, err := c.hasSecondaryUniqueIndexLocked()
+		if err != nil {
+			unlockMutation()
+			return nil, err
+		}
+		if hasUnique {
+			unlockMutation()
+			return nil, errUpdateBatchHasSecondaryUniqueIndex
+		}
+	}
 	unlockMutation()
 
 	plan, err := c.buildUpdateBatchPlan(items, requireNoSecondaryUniqueIndexes)
@@ -3709,6 +3720,14 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 	}
 	defer plan.close()
 	if len(plan.deltaTables) == 0 {
+		unlockMutation = c.lockMutation()
+		defer unlockMutation()
+		if err := c.flushBufferedWrites(); err != nil {
+			return nil, err
+		}
+		if err := c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq); err != nil {
+			return nil, err
+		}
 		return plan.results, nil
 	}
 
@@ -3718,6 +3737,22 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 		return nil, err
 	}
 	return c.publishUpdateBatchPlanLocked(plan)
+}
+
+func (c *Collection) hasSecondaryUniqueIndexLocked() (bool, error) {
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return false, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return false, err
+	}
+	if catalog == nil {
+		return false, errCollectionNotFound
+	}
+	return collectionMetaHasSecondaryUniqueIndex(catalog.meta), nil
 }
 
 func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, requireNoSecondaryUniqueIndexes bool) (*updateBatchPlan, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3671,8 +3671,15 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem) (*updateBatch
 
 	primaryRoot := catalog.rootID(collectionPrimaryRootName(meta.Name))
 	if primaryRoot == 0 {
-		_ = snap.Close()
-		return &updateBatchPlan{results: results, meta: meta, catalog: catalog}, nil
+		return &updateBatchPlan{
+			results:        results,
+			meta:           meta,
+			catalog:        catalog,
+			snap:           snap,
+			baseUserRoot:   baseUserRoot,
+			baseSystemRoot: baseSystemRoot,
+			baseCommitSeq:  baseCommitSeq,
+		}, nil
 	}
 	runtimes, err := (insertBatchPlanner{
 		collection: meta.Name,
@@ -3722,8 +3729,15 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem) (*updateBatch
 		changedDocuments = append(changedDocuments, bytes.Clone(document))
 	}
 	if len(changed) == 0 {
-		_ = snap.Close()
-		return &updateBatchPlan{results: results, meta: meta, catalog: catalog}, nil
+		return &updateBatchPlan{
+			results:        results,
+			meta:           meta,
+			catalog:        catalog,
+			snap:           snap,
+			baseUserRoot:   baseUserRoot,
+			baseSystemRoot: baseSystemRoot,
+			baseCommitSeq:  baseCommitSeq,
+		}, nil
 	}
 
 	preparedDocuments, templateRecords, templateResolver, err := prepareInsertDocuments(changedDocuments, plannerOptions)
@@ -3911,7 +3925,6 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 		return plan.results, nil
 	}
 
-	c.meta = plan.meta
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
 	iterators := make([]iterator.UnsafeIterator, 0, len(plan.rootNames))
 	defer func() {
@@ -3941,6 +3954,7 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 		return nil, errors.New("collections: ordered root publish returned unexpected root count")
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(plan.catalog, plan.meta, plan.rootNames, rootIDs)
+	c.meta = plan.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	return plan.results, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4698,6 +4698,11 @@ func (c *Collection) validateRootDescriptorSystemDeltaForMeta(meta CollectionMet
 	if c == nil || c.db == nil {
 		return backenddb.ErrClosed
 	}
+	for _, rootName := range rootNames {
+		if _, ok := baseRootIDs[rootName]; !ok {
+			return fmt.Errorf("collections: missing base root for collection %q root %q", meta.Name, rootName)
+		}
+	}
 	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
 	if currentSystemRoot != expectedSystemRoot || currentCommitSeq != expectedCommitSeq {
 		current := c.db.AcquireSnapshot()
@@ -4716,10 +4721,7 @@ func (c *Collection) validateRootDescriptorSystemDeltaForMeta(meta CollectionMet
 			return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
 		}
 		for _, rootName := range rootNames {
-			want, ok := baseRootIDs[rootName]
-			if !ok {
-				return fmt.Errorf("collections: missing base root for collection %q root %q", meta.Name, rootName)
-			}
+			want := baseRootIDs[rootName]
 			if got := catalog.rootID(rootName); got != want {
 				return errConcurrentRootModification(meta.Name, rootName)
 			}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3997,10 +3997,14 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 		}
 	}()
 	for i, rootName := range plan.rootNames {
+		baseRoot, ok := plan.baseRootIDs[rootName]
+		if !ok {
+			return nil, fmt.Errorf("collections: update batch plan missing base root for %q", rootName)
+		}
 		iter := plan.deltaTables[i].NewIterator(nil, nil)
 		iterators = append(iterators, iter)
 		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      plan.baseRootIDs[rootName],
+			BaseRoot:      baseRoot,
 			Iter:          iter,
 			StoragePolicy: plan.policies[i],
 		})
@@ -4009,7 +4013,7 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 		return c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq)
 	}
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIteratorForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, rootIDs)
 	})
 	if err != nil {
 		return nil, err
@@ -4481,10 +4485,14 @@ func (c *Collection) buildRootDescriptorSystemIterator(rootNames []string, baseR
 }
 
 func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	return c.buildRootDescriptorSystemDeltaIteratorForMeta(c.meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs, rootIDs)
+}
+
+func (c *Collection) buildRootDescriptorSystemDeltaIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 	if len(rootIDs) != len(rootNames) {
 		return nil, errors.New("collections: ordered root publish returned unexpected root count")
 	}
-	if err := c.validateRootDescriptorSystemDelta(expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs); err != nil {
+	if err := c.validateRootDescriptorSystemDeltaForMeta(meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs); err != nil {
 		return nil, err
 	}
 	updates := make(map[string][]byte, len(rootNames))
@@ -4495,29 +4503,38 @@ func (c *Collection) buildRootDescriptorSystemDeltaIterator(expectedCommitSeq, e
 }
 
 func (c *Collection) validateRootDescriptorSystemDelta(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64) error {
-	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(nil)
-	if c != nil {
-		currentCommitSeq, currentSystemRoot = dbCommitSeqAndSystemRoot(c.db)
+	return c.validateRootDescriptorSystemDeltaForMeta(c.meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs)
+}
+
+func (c *Collection) validateRootDescriptorSystemDeltaForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64) error {
+	if c == nil || c.db == nil {
+		return backenddb.ErrClosed
 	}
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(nil)
+	currentCommitSeq, currentSystemRoot = dbCommitSeqAndSystemRoot(c.db)
 	if currentSystemRoot != expectedSystemRoot || currentCommitSeq != expectedCommitSeq {
 		current := c.db.AcquireSnapshot()
 		if current == nil {
 			return backenddb.ErrClosed
 		}
 		defer func() { _ = current.Close() }()
-		catalog, err := loadCollectionCatalog(current, c.meta.Name)
+		catalog, err := loadCollectionCatalog(current, meta.Name)
 		if err != nil {
 			return err
 		}
 		if catalog == nil {
 			return errCollectionNotFound
 		}
-		if !sameCollectionMeta(catalog.meta, c.meta) {
-			return fmt.Errorf("collections: concurrent schema modification detected for %q", c.meta.Name)
+		if !sameCollectionMeta(catalog.meta, meta) {
+			return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
 		}
 		for _, rootName := range rootNames {
-			if got, want := catalog.rootID(rootName), baseRootIDs[rootName]; got != want {
-				return errConcurrentRootModification(c.meta.Name, rootName)
+			want, ok := baseRootIDs[rootName]
+			if !ok {
+				return fmt.Errorf("collections: missing base root for %q", rootName)
+			}
+			if got := catalog.rootID(rootName); got != want {
+				return errConcurrentRootModification(meta.Name, rootName)
 			}
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3037,9 +3037,9 @@ func (c *Collection) UpdateBatch(items []UpdateBatchItem) ([]UpdateBatchResult, 
 }
 
 // UpdateBatchIfNoSecondaryUniqueIndexes applies UpdateBatch only when the
-// collection has no secondary unique indexes in the mutation-locked catalog.
-// It reports batched=false without applying updates if a unique secondary index
-// is present so callers can preserve ordered per-document update semantics. When
+// collection has no secondary unique indexes in the planning snapshot. It
+// reports batched=false without applying updates if a unique secondary index is
+// present so callers can preserve ordered per-document update semantics. When
 // batched=false and err=nil, the returned results are zero-valued with len(items).
 func (c *Collection) UpdateBatchIfNoSecondaryUniqueIndexes(items []UpdateBatchItem) ([]UpdateBatchResult, bool, error) {
 	return c.updateBatch(items, true)
@@ -3804,22 +3804,10 @@ func (plan *updateBatchPlan) close() {
 }
 
 func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondaryUniqueIndexes bool) ([]UpdateBatchResult, error) {
-	hasUnique := false
 	if err := c.withMutationLock(func() error {
-		if err := c.flushBufferedWrites(); err != nil {
-			return err
-		}
-		if !requireNoSecondaryUniqueIndexes {
-			return nil
-		}
-		var err error
-		hasUnique, err = c.hasSecondaryUniqueIndexLocked()
-		return err
+		return c.flushBufferedWrites()
 	}); err != nil {
 		return nil, err
-	}
-	if hasUnique {
-		return nil, errUpdateBatchHasSecondaryUniqueIndex
 	}
 
 	plan, err := c.buildUpdateBatchPlan(items, requireNoSecondaryUniqueIndexes)
@@ -3835,6 +3823,8 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 			if err := c.flushBufferedWrites(); err != nil {
 				return err
 			}
+			// validateMutationRootDescriptors does not consult c.meta; refresh
+			// the handle metadata only after the planned root snapshot is still current.
 			if err := c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq); err != nil {
 				return err
 			}
@@ -3862,22 +3852,6 @@ func (c *Collection) withMutationLock(fn func() error) error {
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
 	return fn()
-}
-
-func (c *Collection) hasSecondaryUniqueIndexLocked() (bool, error) {
-	snap := c.db.AcquireSnapshot()
-	if snap == nil {
-		return false, backenddb.ErrClosed
-	}
-	defer func() { _ = snap.Close() }()
-	catalog, err := c.catalogForSnapshot(snap)
-	if err != nil {
-		return false, err
-	}
-	if catalog == nil {
-		return false, errCollectionNotFound
-	}
-	return collectionMetaHasSecondaryUniqueIndex(catalog.meta), nil
 }
 
 func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, requireNoSecondaryUniqueIndexes bool) (*updateBatchPlan, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2919,11 +2919,6 @@ func (c *Collection) UpdateBatch(items []UpdateBatchItem) ([]UpdateBatchResult, 
 	if err := validateUpdateBatchItems(items); err != nil {
 		return nil, err
 	}
-	unlockMutation := c.lockMutation()
-	defer unlockMutation()
-	if err := c.flushBufferedWrites(); err != nil {
-		return nil, err
-	}
 
 	var lastErr error
 	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
@@ -3516,7 +3511,58 @@ type preparedBatchUpdate struct {
 	indexStateChanged bool
 }
 
+type updateBatchPlan struct {
+	results        []UpdateBatchResult
+	meta           CollectionMeta
+	catalog        *collectionCatalog
+	snap           *backenddb.Snapshot
+	baseUserRoot   uint64
+	baseSystemRoot uint64
+	baseCommitSeq  uint64
+	rootNames      []string
+	baseRootIDs    map[string]uint64
+	policies       []backenddb.OrderedRootStoragePolicy
+	deltaTables    []memtable.Table
+}
+
+func (plan *updateBatchPlan) close() {
+	if plan == nil {
+		return
+	}
+	if plan.snap != nil {
+		_ = plan.snap.Close()
+		plan.snap = nil
+	}
+	resetCollectionTables(plan.deltaTables)
+	plan.deltaTables = nil
+}
+
 func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResult, error) {
+	unlockMutation := c.lockMutation()
+	if err := c.flushBufferedWrites(); err != nil {
+		unlockMutation()
+		return nil, err
+	}
+	unlockMutation()
+
+	plan, err := c.buildUpdateBatchPlan(items)
+	if err != nil {
+		return nil, err
+	}
+	if plan == nil || len(plan.deltaTables) == 0 {
+		if plan != nil {
+			defer plan.close()
+			return plan.results, nil
+		}
+		return nil, nil
+	}
+
+	unlockMutation = c.lockMutation()
+	defer unlockMutation()
+	return c.publishUpdateBatchPlanLocked(plan)
+}
+
+func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem) (*updateBatchPlan, error) {
 	results := make([]UpdateBatchResult, len(items))
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
@@ -3531,8 +3577,8 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 		_ = snap.Close()
 		return nil, errCollectionNotFound
 	}
-	c.meta = catalog.meta
-	plannerOptions, err := collectionPlannerOptions(c.meta)
+	meta := catalog.meta
+	plannerOptions, err := collectionPlannerOptions(meta)
 	if err != nil {
 		_ = snap.Close()
 		return nil, err
@@ -3542,14 +3588,14 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 
-	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
+	primaryRoot := catalog.rootID(collectionPrimaryRootName(meta.Name))
 	if primaryRoot == 0 {
 		_ = snap.Close()
-		return results, nil
+		return &updateBatchPlan{results: results, meta: meta, catalog: catalog}, nil
 	}
 	runtimes, err := (insertBatchPlanner{
-		collection: c.meta.Name,
-		indexes:    plannerIndexes(c.meta.Indexes),
+		collection: meta.Name,
+		indexes:    plannerIndexes(meta.Indexes),
 	}).indexRuntimes()
 	if err != nil {
 		_ = snap.Close()
@@ -3596,7 +3642,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 	}
 	if len(changed) == 0 {
 		_ = snap.Close()
-		return results, nil
+		return &updateBatchPlan{results: results, meta: meta, catalog: catalog}, nil
 	}
 
 	preparedDocuments, templateRecords, templateResolver, err := prepareInsertDocuments(changedDocuments, plannerOptions)
@@ -3642,11 +3688,12 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 	deltaTables := make([]memtable.Table, 0, 2+len(runtimes))
 	var stateTable memtable.Table
 	secondaryTables := make(map[string]memtable.Table, len(runtimes))
-	var iterators []iterator.UnsafeIterator
+	success := false
 	defer func() {
-		for _, it := range iterators {
-			_ = it.Close()
+		if success {
+			return
 		}
+		_ = snap.Close()
 		resetCollectionTables(deltaTables)
 		resetCollectionRunTable(stateTable)
 		for _, table := range secondaryTables {
@@ -3657,12 +3704,11 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 	if len(templateRecords) > 0 {
 		templatePlan := &insertBatchPlan{}
 		if err := (insertBatchPlanner{
-			collection:             c.meta.Name,
-			templateRoot:           collectionTemplateRootName(c.meta.Name),
+			collection:             meta.Name,
+			templateRoot:           collectionTemplateRootName(meta.Name),
 			options:                plannerOptions,
 			cloneTemplateRunValues: true,
 		}).emitTemplateRun(templatePlan, templateRecords); err != nil {
-			_ = snap.Close()
 			return nil, err
 		}
 		for _, run := range templatePlan.runs {
@@ -3673,7 +3719,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 		}
 	}
 
-	primaryRootName := collectionPrimaryRootName(c.meta.Name)
+	primaryRootName := collectionPrimaryRootName(meta.Name)
 	rootNames = append(rootNames, primaryRootName)
 	baseRootIDs[primaryRootName] = primaryRoot
 	policies = append(policies, plannerOptions.dataStoragePolicy)
@@ -3706,7 +3752,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 				}
 			}
 			for _, runtime := range runtimes {
-				rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
+				rootName := collectionSecondaryRootName(meta.Name, runtime.def.name)
 				table := secondaryTables[rootName]
 				if table == nil {
 					table = newCollectionRunTable(0)
@@ -3732,7 +3778,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 		}
 		if stateTable != nil && stateTable.Len() > 0 {
 			stateTable.Freeze()
-			stateRootName := collectionIndexStateRootName(c.meta.Name)
+			stateRootName := collectionIndexStateRootName(meta.Name)
 			rootNames = append(rootNames, stateRootName)
 			baseRootIDs[stateRootName] = catalog.rootID(stateRootName)
 			policies = append(policies, plannerOptions.indexStateStoragePolicy)
@@ -3740,7 +3786,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 			stateTable = nil
 		}
 		for _, runtime := range runtimes {
-			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
+			rootName := collectionSecondaryRootName(meta.Name, runtime.def.name)
 			table := secondaryTables[rootName]
 			if table == nil || table.Len() == 0 {
 				continue
@@ -3754,34 +3800,68 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem) ([]UpdateBatchResu
 		}
 	}
 
-	defer func() { _ = snap.Close() }()
-	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
-	iterators = make([]iterator.UnsafeIterator, 0, len(rootNames))
-	for i, rootName := range rootNames {
-		iter := deltaTables[i].NewIterator(nil, nil)
+	resetCollectionRunTable(stateTable)
+	for _, table := range secondaryTables {
+		resetCollectionRunTable(table)
+	}
+	success = true
+	return &updateBatchPlan{
+		results:        results,
+		meta:           meta,
+		catalog:        catalog,
+		snap:           snap,
+		baseUserRoot:   baseUserRoot,
+		baseSystemRoot: baseSystemRoot,
+		baseCommitSeq:  baseCommitSeq,
+		rootNames:      rootNames,
+		baseRootIDs:    baseRootIDs,
+		policies:       policies,
+		deltaTables:    deltaTables,
+	}, nil
+}
+
+func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]UpdateBatchResult, error) {
+	if plan == nil {
+		return nil, nil
+	}
+	defer plan.close()
+	if len(plan.deltaTables) == 0 {
+		return plan.results, nil
+	}
+
+	c.meta = plan.meta
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(plan.rootNames))
+	defer func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+	}()
+	for i, rootName := range plan.rootNames {
+		iter := plan.deltaTables[i].NewIterator(nil, nil)
 		iterators = append(iterators, iter)
 		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      baseRootIDs[rootName],
+			BaseRoot:      plan.baseRootIDs[rootName],
 			Iter:          iter,
-			StoragePolicy: policies[i],
+			StoragePolicy: plan.policies[i],
 		})
 	}
 	preflight := func() error {
-		return c.validateMutationRootDescriptors(baseUserRoot, baseSystemRoot, baseCommitSeq)
+		return c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq)
 	}
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIterator(plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, rootIDs)
 	})
 	if err != nil {
 		return nil, err
 	}
-	if len(rootIDs) != len(rootNames) {
+	if len(rootIDs) != len(plan.rootNames) {
 		return nil, errors.New("collections: ordered root publish returned unexpected root count")
 	}
-	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
+	nextCatalog := cloneCatalogWithRootUpdates(plan.catalog, plan.meta, plan.rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
-	return results, nil
+	return plan.results, nil
 }
 
 func rejectBatchUniqueConflicts(runtimes []indexRuntime, updates []preparedBatchUpdate) error {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3932,10 +3932,6 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 	}
 	defer plan.close()
 	if len(plan.deltaTables) == 0 {
-		if plan.snap != nil {
-			_ = plan.snap.Close()
-			plan.snap = nil
-		}
 		if err := c.withMutationLock(func() error {
 			if err := c.flushBufferedWrites(); err != nil {
 				return err

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3906,9 +3906,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondary
 			if err := c.flushBufferedWrites(); err != nil {
 				return err
 			}
-			// validateMutationRootDescriptors does not consult c.meta; refresh
-			// the handle metadata only after the planned root snapshot is still current.
-			if err := c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq); err != nil {
+			if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
 				return err
 			}
 			c.meta = plan.meta
@@ -3969,6 +3967,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, requireNoSeco
 
 	primaryRoot := catalog.rootID(collectionPrimaryRootName(meta.Name))
 	if primaryRoot == 0 {
+		primaryRootName := collectionPrimaryRootName(meta.Name)
 		return &updateBatchPlan{
 			results:        results,
 			meta:           meta,
@@ -3977,6 +3976,8 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, requireNoSeco
 			baseUserRoot:   baseUserRoot,
 			baseSystemRoot: baseSystemRoot,
 			baseCommitSeq:  baseCommitSeq,
+			rootNames:      []string{primaryRootName},
+			baseRootIDs:    map[string]uint64{primaryRootName: primaryRoot},
 		}, nil
 	}
 	runtimes, err := (insertBatchPlanner{
@@ -4031,6 +4032,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, requireNoSeco
 		changedDocuments = append(changedDocuments, bytes.Clone(document))
 	}
 	if len(changed) == 0 {
+		primaryRootName := collectionPrimaryRootName(meta.Name)
 		return &updateBatchPlan{
 			results:        results,
 			meta:           meta,
@@ -4039,6 +4041,8 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, requireNoSeco
 			baseUserRoot:   baseUserRoot,
 			baseSystemRoot: baseSystemRoot,
 			baseCommitSeq:  baseCommitSeq,
+			rootNames:      []string{primaryRootName},
+			baseRootIDs:    map[string]uint64{primaryRootName: primaryRoot},
 		}, nil
 	}
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3883,9 +3883,11 @@ func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testin
 	}()
 	defer func() {
 		close(stopRight)
+		timer := time.NewTimer(collectionTestTimeout(t, 5*time.Second))
+		defer timer.Stop()
 		select {
 		case <-rightFinished:
-		case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		case <-timer.C:
 			t.Error("timed out waiting for concurrent update goroutine cleanup")
 		}
 	}()

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -784,6 +784,8 @@ func collectionMaintenanceTestContext(t *testing.T) (context.Context, context.Ca
 	return context.WithTimeout(context.Background(), timeout)
 }
 
+const collectionTestDeadlineBuffer = 500 * time.Millisecond
+
 func collectionTestTimeout(t *testing.T, fallback time.Duration) time.Duration {
 	t.Helper()
 	if deadline, ok := t.Deadline(); ok {
@@ -791,10 +793,10 @@ func collectionTestTimeout(t *testing.T, fallback time.Duration) time.Duration {
 		if remaining <= 0 {
 			return time.Nanosecond
 		}
-		if remaining <= 500*time.Millisecond {
+		if remaining <= collectionTestDeadlineBuffer {
 			return remaining
 		}
-		remaining -= 500 * time.Millisecond
+		remaining -= collectionTestDeadlineBuffer
 		if remaining > 0 && remaining < fallback {
 			return remaining
 		}
@@ -4016,23 +4018,11 @@ func TestCollectionUpdateBatchFlushesBufferedIndexedWritesBeforePublish(t *testi
 		DocumentID: []byte("u1"),
 		Update: func([]byte) ([]byte, bool, error) {
 			if staged.CompareAndSwap(false, true) {
-				insertDone := make(chan error, 1)
-				go func() {
-					_, err := right.InsertBatch(
-						[][]byte{[]byte("u2")},
-						[][]byte{[]byte(`{"city":"sfo","score":2}`)},
-					)
-					insertDone <- err
-				}()
-				timer := time.NewTimer(collectionTestTimeout(t, 5*time.Second))
-				defer timer.Stop()
-				select {
-				case err := <-insertDone:
-					if err != nil {
-						return nil, false, err
-					}
-				case <-timer.C:
-					return nil, false, errors.New("timed out waiting for right.InsertBatch to complete")
+				if _, err := right.InsertBatch(
+					[][]byte{[]byte("u2")},
+					[][]byte{[]byte(`{"city":"sfo","score":2}`)},
+				); err != nil {
+					return nil, false, err
 				}
 			}
 			return []byte(`{"city":"sea","score":1}`), true, nil

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3359,9 +3359,15 @@ func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testin
 	}
 
 	ready := make(chan struct{})
+	stopRight := make(chan struct{})
+	var readyOnce sync.Once
 	rightDone := make(chan error, 1)
 	go func() {
-		<-ready
+		select {
+		case <-ready:
+		case <-stopRight:
+			return
+		}
 		_, err := right.UpdateBatch([]UpdateBatchItem{{
 			DocumentID: []byte("u2"),
 			Update: func([]byte) ([]byte, bool, error) {
@@ -3370,6 +3376,7 @@ func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testin
 		}})
 		rightDone <- err
 	}()
+	defer close(stopRight)
 
 	concurrentUpdateWait := 10 * time.Second
 	if deadline, ok := t.Deadline(); ok {
@@ -3382,7 +3389,7 @@ func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testin
 		DocumentID: []byte("u1"),
 		Update: func([]byte) ([]byte, bool, error) {
 			if callbackCalls.Add(1) == 1 {
-				close(ready)
+				readyOnce.Do(func() { close(ready) })
 				timer := time.NewTimer(concurrentUpdateWait)
 				defer timer.Stop()
 				select {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3126,6 +3127,89 @@ func TestCollectionUpdateBatchClonesAliasedReplacements(t *testing.T) {
 		{id: []byte("u2"), score: `"score":2`},
 	} {
 		got, err := col.Get(tc.id)
+		if err != nil {
+			t.Fatalf("get %s: %v", tc.id, err)
+		}
+		if !bytes.Contains(got, []byte(tc.score)) {
+			t.Fatalf("%s document=%s want %s", tc.id, got, tc.score)
+		}
+	}
+}
+
+func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	left, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open left collection: %v", err)
+	}
+	right, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open right collection: %v", err)
+	}
+	if _, err := left.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"score":0}`), []byte(`{"score":0}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	ready := make(chan struct{})
+	rightDone := make(chan error, 1)
+	go func() {
+		<-ready
+		_, err := right.UpdateBatch([]UpdateBatchItem{{
+			DocumentID: []byte("u2"),
+			Update: func([]byte) ([]byte, bool, error) {
+				return []byte(`{"score":2}`), true, nil
+			},
+		}})
+		rightDone <- err
+	}()
+
+	var callbackCalls atomic.Int32
+	results, err := left.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func([]byte) ([]byte, bool, error) {
+			if callbackCalls.Add(1) == 1 {
+				close(ready)
+				select {
+				case err := <-rightDone:
+					if err != nil {
+						return nil, false, err
+					}
+				case <-time.After(2 * time.Second):
+					return nil, false, errors.New("timed out waiting for concurrent update")
+				}
+			}
+			return []byte(`{"score":1}`), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("left UpdateBatch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("results=%+v want matched modified", results)
+	}
+	if got := callbackCalls.Load(); got < 2 {
+		t.Fatalf("callbackCalls=%d want retry after concurrent collection mutation", got)
+	}
+	for _, tc := range []struct {
+		id    []byte
+		score string
+	}{
+		{id: []byte("u1"), score: `"score":1`},
+		{id: []byte("u2"), score: `"score":2`},
+	} {
+		got, err := left.Get(tc.id)
 		if err != nil {
 			t.Fatalf("get %s: %v", tc.id, err)
 		}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -784,6 +784,17 @@ func collectionMaintenanceTestContext(t *testing.T) (context.Context, context.Ca
 	return context.WithTimeout(context.Background(), timeout)
 }
 
+func collectionTestTimeout(t *testing.T, fallback time.Duration) time.Duration {
+	t.Helper()
+	if deadline, ok := t.Deadline(); ok {
+		remaining := time.Until(deadline) - 500*time.Millisecond
+		if remaining > 0 && remaining < fallback {
+			return remaining
+		}
+	}
+	return fallback
+}
+
 func collectionMaintenanceCloseOnce(cleanup func() error) func() error {
 	var once sync.Once
 	var closeErr error
@@ -3712,17 +3723,12 @@ func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testin
 		close(stopRight)
 		select {
 		case <-rightFinished:
-		case <-time.After(time.Second):
+		case <-time.After(collectionTestTimeout(t, 5*time.Second)):
 			t.Error("timed out waiting for concurrent update goroutine cleanup")
 		}
 	}()
 
-	concurrentUpdateWait := 10 * time.Second
-	if deadline, ok := t.Deadline(); ok {
-		if remaining := time.Until(deadline) - 500*time.Millisecond; remaining > 0 && remaining < concurrentUpdateWait {
-			concurrentUpdateWait = remaining
-		}
-	}
+	concurrentUpdateWait := collectionTestTimeout(t, 10*time.Second)
 	var callbackCalls atomic.Int32
 	results, err := left.UpdateBatch([]UpdateBatchItem{{
 		DocumentID: []byte("u1"),
@@ -3858,11 +3864,23 @@ func TestCollectionUpdateBatchFlushesBufferedIndexedWritesBeforePublish(t *testi
 		DocumentID: []byte("u1"),
 		Update: func([]byte) ([]byte, bool, error) {
 			if staged.CompareAndSwap(false, true) {
-				if _, err := right.InsertBatch(
-					[][]byte{[]byte("u2")},
-					[][]byte{[]byte(`{"city":"sfo","score":2}`)},
-				); err != nil {
-					return nil, false, err
+				insertDone := make(chan error, 1)
+				go func() {
+					_, err := right.InsertBatch(
+						[][]byte{[]byte("u2")},
+						[][]byte{[]byte(`{"city":"sfo","score":2}`)},
+					)
+					insertDone <- err
+				}()
+				timer := time.NewTimer(collectionTestTimeout(t, 5*time.Second))
+				defer timer.Stop()
+				select {
+				case err := <-insertDone:
+					if err != nil {
+						return nil, false, err
+					}
+				case <-timer.C:
+					return nil, false, errors.New("timed out waiting for right.InsertBatch to complete")
 				}
 			}
 			return []byte(`{"city":"sea","score":1}`), true, nil
@@ -3887,6 +3905,60 @@ func TestCollectionUpdateBatchFlushesBufferedIndexedWritesBeforePublish(t *testi
 		t.Fatalf("find sfo: %v", err)
 	}
 	collectionMaintenanceRequireUnorderedIDs(t, sfoIDs, []byte("u2"))
+}
+
+func TestCollectionUpdateBatchNoOpAllowsOtherCollectionRootDrift(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create users collection: %v", err)
+	}
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "teams"}); err != nil {
+		t.Fatalf("create teams collection: %v", err)
+	}
+	users, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open users collection: %v", err)
+	}
+	teams, err := mgr.OpenCollection("teams")
+	if err != nil {
+		t.Fatalf("open teams collection: %v", err)
+	}
+	if _, err := users.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl","score":0}`)},
+	); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	var callbackCalls atomic.Int32
+	results, err := users.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			call := callbackCalls.Add(1)
+			if _, err := teams.InsertBatch(
+				[][]byte{[]byte(fmt.Sprintf("team-%d", call))},
+				[][]byte{[]byte(fmt.Sprintf(`{"name":"team-%d"}`, call))},
+			); err != nil {
+				return nil, false, err
+			}
+			return current, false, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || results[0].Modified {
+		t.Fatalf("results=%+v want matched and not modified", results)
+	}
+	if got := callbackCalls.Load(); got != 1 {
+		t.Fatalf("callback calls=%d want 1", got)
+	}
 }
 
 func TestCollectionUpdateBatchBSONRejectsIDMutation(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3175,18 +3175,26 @@ func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testin
 		rightDone <- err
 	}()
 
+	concurrentUpdateWait := 10 * time.Second
+	if deadline, ok := t.Deadline(); ok {
+		if remaining := time.Until(deadline) - 500*time.Millisecond; remaining > 0 && remaining < concurrentUpdateWait {
+			concurrentUpdateWait = remaining
+		}
+	}
 	var callbackCalls atomic.Int32
 	results, err := left.UpdateBatch([]UpdateBatchItem{{
 		DocumentID: []byte("u1"),
 		Update: func([]byte) ([]byte, bool, error) {
 			if callbackCalls.Add(1) == 1 {
 				close(ready)
+				timer := time.NewTimer(concurrentUpdateWait)
+				defer timer.Stop()
 				select {
 				case err := <-rightDone:
 					if err != nil {
 						return nil, false, err
 					}
-				case <-time.After(2 * time.Second):
+				case <-timer.C:
 					return nil, false, errors.New("timed out waiting for concurrent update")
 				}
 			}
@@ -3217,6 +3225,74 @@ func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testin
 			t.Fatalf("%s document=%s want %s", tc.id, got, tc.score)
 		}
 	}
+}
+
+func TestCollectionUpdateBatchFlushesBufferedIndexedWritesBeforePublish(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	left, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open left collection: %v", err)
+	}
+	right, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open right collection: %v", err)
+	}
+	if _, err := left.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl","score":0}`)},
+	); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if err := mgr.FlushAll(); err != nil {
+		t.Fatalf("flush initial indexed write: %v", err)
+	}
+
+	var staged atomic.Bool
+	results, err := left.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func([]byte) ([]byte, bool, error) {
+			if staged.CompareAndSwap(false, true) {
+				if _, err := right.InsertBatch(
+					[][]byte{[]byte("u2")},
+					[][]byte{[]byte(`{"city":"sfo","score":2}`)},
+				); err != nil {
+					return nil, false, err
+				}
+			}
+			return []byte(`{"city":"sea","score":1}`), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("results=%+v want matched modified", results)
+	}
+	if err := mgr.FlushAll(); err != nil {
+		t.Fatalf("FlushAll after update with staged indexed write: %v", err)
+	}
+	seaIDs, err := left.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, seaIDs, []byte("u1"))
+	sfoIDs, err := left.FindByIndex("city", "sfo")
+	if err != nil {
+		t.Fatalf("find sfo: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, sfoIDs, []byte("u2"))
 }
 
 func TestCollectionUpdateBatchBSONRejectsIDMutation(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3549,7 +3549,7 @@ func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testin
 		select {
 		case <-rightFinished:
 		case <-time.After(time.Second):
-			t.Log("timed out waiting for concurrent update goroutine cleanup")
+			t.Error("timed out waiting for concurrent update goroutine cleanup")
 		}
 	}()
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3528,7 +3528,9 @@ func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testin
 	stopRight := make(chan struct{})
 	var readyOnce sync.Once
 	rightDone := make(chan error, 1)
+	rightFinished := make(chan struct{})
 	go func() {
+		defer close(rightFinished)
 		select {
 		case <-ready:
 		case <-stopRight:
@@ -3542,7 +3544,14 @@ func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testin
 		}})
 		rightDone <- err
 	}()
-	defer close(stopRight)
+	defer func() {
+		close(stopRight)
+		select {
+		case <-rightFinished:
+		case <-time.After(time.Second):
+			t.Log("timed out waiting for concurrent update goroutine cleanup")
+		}
+	}()
 
 	concurrentUpdateWait := 10 * time.Second
 	if deadline, ok := t.Deadline(); ok {
@@ -3581,17 +3590,21 @@ func TestCollectionUpdateBatchReplansAfterConcurrentCollectionMutation(t *testin
 	}
 	for _, tc := range []struct {
 		id    []byte
-		score string
+		score float64
 	}{
-		{id: []byte("u1"), score: `"score":1`},
-		{id: []byte("u2"), score: `"score":2`},
+		{id: []byte("u1"), score: 1},
+		{id: []byte("u2"), score: 2},
 	} {
 		got, err := left.Get(tc.id)
 		if err != nil {
 			t.Fatalf("get %s: %v", tc.id, err)
 		}
-		if !bytes.Contains(got, []byte(tc.score)) {
-			t.Fatalf("%s document=%s want %s", tc.id, got, tc.score)
+		var doc map[string]any
+		if err := json.Unmarshal(got, &doc); err != nil {
+			t.Fatalf("parse %s document=%s: %v", tc.id, got, err)
+		}
+		if gotScore, ok := doc["score"].(float64); !ok || gotScore != tc.score {
+			t.Fatalf("%s score=%v want %v document=%s", tc.id, doc["score"], tc.score, got)
 		}
 	}
 }

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -787,7 +787,14 @@ func collectionMaintenanceTestContext(t *testing.T) (context.Context, context.Ca
 func collectionTestTimeout(t *testing.T, fallback time.Duration) time.Duration {
 	t.Helper()
 	if deadline, ok := t.Deadline(); ok {
-		remaining := time.Until(deadline) - 500*time.Millisecond
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return time.Nanosecond
+		}
+		if remaining <= 500*time.Millisecond {
+			return remaining
+		}
+		remaining -= 500 * time.Millisecond
 		if remaining > 0 && remaining < fallback {
 			return remaining
 		}
@@ -4005,6 +4012,16 @@ func TestCollectionUpdateBatchNoOpAllowsOtherCollectionRootDrift(t *testing.T) {
 	}
 	if got := callbackCalls.Load(); got != 1 {
 		t.Fatalf("callback calls=%d want 1", got)
+	}
+}
+
+func TestCollectionRootDescriptorDeltaWrappersRejectNilReceiver(t *testing.T) {
+	var col *Collection
+	if _, err := col.buildRootDescriptorSystemDeltaIterator(0, 0, nil, nil, nil); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("buildRootDescriptorSystemDeltaIterator err=%v want ErrClosed", err)
+	}
+	if err := col.validateRootDescriptorSystemDelta(0, 0, nil, nil); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("validateRootDescriptorSystemDelta err=%v want ErrClosed", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- move UpdateBatch planning, document materialization, index-state extraction, unique preflight, and delta-table construction outside the collection mutation lock
- keep buffered flush and final grouped publish serialized under the mutation lock
- retain optimistic correctness by pinning the planning snapshot through publish and retrying on concurrent collection root changes
- add a regression test that forces a concurrent collection mutation between plan and publish and verifies UpdateBatch replans successfully

## Validation
- go test ./TreeDB/collections -count 1
- go test ./TreeDB/collections ./cmd/mongo_gateway_bench -count 1
- MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=20000 MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=5000 MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' -benchtime=2000x -count 1
  - observed 27,940 docs/sec, 35,791 ns/doc, 8 writers on local Apple M3

## Stack
- Based on PR #1117
- PR #1117 is based on PR #1116

This is a step toward the larger collection-indexed write path: it does not remove the backend ordered-root publish serialization, but it stops expensive UpdateBatch planning from occupying the per-collection mutation lane.