### PR TITLE
[codex] Add Mongo gateway scaling benchmark runner

### DIFF
--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -403,8 +403,9 @@ storage, `driver-command-raw`, prebuilt BSON documents, and no final maintenance
 so the measured phases focus on concurrency. Add
 `--include-mongo --mongo-uri mongodb://127.0.0.1:27017` to run matching cells
 against an existing MongoDB server. The bundle contains `report.md`,
-`summary.tsv`, `matrix.tsv`, raw JSON, and kept TreeDB data directories for
-profile follow-up.
+`summary.tsv`, `matrix.tsv`, raw JSON, and a README that records the kept
+TreeDB data path for profile follow-up. Depending on where `--out` is placed,
+that kept TreeDB data directory may be outside the bundle directory.
 
 ## Gateway Profiling Benchmarks
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -370,6 +370,34 @@ For insert-scaling investigations, run the same command repeatedly with
 investigations, keep the load shape fixed and vary `-concurrent-writers` /
 `-concurrent-writes`.
 
+## Reader/Writer Scaling Wrapper
+
+Use `scripts/mongo_gateway_scaling_bench.sh` for a repeatable reader/writer
+scaling sweep. It runs `mongo_gateway_bench` for each reader and writer count,
+writes raw JSON for every cell, then feeds the matrix into
+`mongo_gateway_compare_report` so the output shape matches the normal
+TreeDB-vs-MongoDB comparison bundle.
+
+```sh
+scripts/mongo_gateway_scaling_bench.sh \
+  --out /tmp/gomap_mongo_gateway_scaling \
+  --docs 100000 \
+  --indexes 2 \
+  --batch-size 10000 \
+  --insert-producers 8 \
+  --writers "1 2 4 8 16" \
+  --readers "1 2 4 8 16" \
+  --concurrent-writes 80000 \
+  --concurrent-reads 80000
+```
+
+The default sweep is TreeDB-only, using `wal_on_fast`, native BSON collection
+storage, `driver-command-raw`, prebuilt BSON documents, and no final maintenance
+so the measured phases focus on concurrency. Add `--include-mongo --mongo-uri
+mongodb://127.0.0.1:27017` to run matching cells against an existing MongoDB
+server. The bundle contains `report.md`, `summary.tsv`, `matrix.tsv`, raw JSON,
+and kept TreeDB data directories for profile follow-up.
+
 ## Gateway Profiling Benchmarks
 
 The package also includes benchmark-only entry points for isolating Mongo

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -393,10 +393,11 @@ scripts/mongo_gateway_scaling_bench.sh \
 
 The default sweep is TreeDB-only, using `wal_on_fast`, native BSON collection
 storage, `driver-command-raw`, prebuilt BSON documents, and no final maintenance
-so the measured phases focus on concurrency. Add `--include-mongo --mongo-uri
-mongodb://127.0.0.1:27017` to run matching cells against an existing MongoDB
-server. The bundle contains `report.md`, `summary.tsv`, `matrix.tsv`, raw JSON,
-and kept TreeDB data directories for profile follow-up.
+so the measured phases focus on concurrency. Add
+`--include-mongo --mongo-uri mongodb://127.0.0.1:27017` to run matching cells
+against an existing MongoDB server. The bundle contains `report.md`,
+`summary.tsv`, `matrix.tsv`, raw JSON, and kept TreeDB data directories for
+profile follow-up.
 
 ## Gateway Profiling Benchmarks
 

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -275,29 +275,32 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongos map[string]*
 		return record, nil
 	}
 	treeScenario := scalingScenarioSuffix(treeConfig)
-	if len(mongos) == 1 {
-		for mongoConfig, record := range mongos {
-			mongoScenario := scalingScenarioSuffix(mongoConfig)
-			if treeScenario == mongoScenario {
-				return record, nil
-			}
-		}
-		return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
-	}
 	var matched *runRecord
+	var candidates []string
 	for mongoConfig, record := range mongos {
 		if scalingScenarioSuffix(mongoConfig) != treeScenario {
 			continue
 		}
-		if matched != nil {
-			return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
-		}
 		matched = record
+		candidates = append(candidates, mongoConfig)
+	}
+	sort.Strings(candidates)
+	if len(candidates) > 1 {
+		return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario, candidates, sortedRunRecordKeys(mongos))
 	}
 	if matched != nil {
 		return matched, nil
 	}
-	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
+	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q tree_scenario=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario, sortedRunRecordKeys(mongos))
+}
+
+func sortedRunRecordKeys(records map[string]*runRecord) []string {
+	keys := make([]string, 0, len(records))
+	for key := range records {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func scalingScenarioSuffix(config string) string {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -308,15 +308,19 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongoIndex mongoSce
 	if treeScenario.hasMarker && !treeScenario.valid {
 		return nil, fmt.Errorf("invalid scaling scenario suffix for documents=%d secondary_indexes=%d config=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, sortedRunRecordKeys(mongoIndex.exact))
 	}
+	treeScenarioLabel := treeScenario.suffix
+	if !treeScenario.hasMarker {
+		treeScenarioLabel = "no scaling marker present"
+	}
 	matches := mongoIndex.bySuffix[treeScenario.suffix]
 	candidates := mongoIndex.suffixConfig[treeScenario.suffix]
 	if len(candidates) > 1 {
-		return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario.suffix, candidates, sortedRunRecordKeys(mongoIndex.exact))
+		return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenarioLabel, candidates, sortedRunRecordKeys(mongoIndex.exact))
 	}
 	if len(matches) == 1 {
 		return matches[0], nil
 	}
-	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q tree_scenario=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario.suffix, sortedRunRecordKeys(mongoIndex.exact))
+	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q tree_scenario=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenarioLabel, sortedRunRecordKeys(mongoIndex.exact))
 }
 
 func sortedRunRecordKeys(records map[string]*runRecord) []string {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -700,7 +700,7 @@ func allPhaseComparisons(cells []cellComparison) []phaseComparison {
 	var out []phaseComparison
 	for _, cell := range cells {
 		var mongoPhases []phaseResult
-		var mongoPhaseMap map[string]phaseResult
+		mongoPhaseMap := map[string]phaseResult{}
 		if cell.Mongo != nil {
 			mongoPhases = cell.Mongo.Result.Phases
 			mongoPhaseMap = cell.Mongo.PhaseMap

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -473,17 +473,18 @@ func phaseMap(phases []phaseResult) map[string]phaseResult {
 
 func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) string {
 	var b strings.Builder
+	hasMongo := hasMongoCells(cells)
 	fmt.Fprintf(&b, "# %s\n\n", cfg.Title)
 	fmt.Fprintf(&b, "- generated_at: `%s`\n", generatedAt.Format(time.RFC3339))
 	fmt.Fprintf(&b, "- matrix: `%s`\n", cfg.MatrixPath)
 	fmt.Fprintf(&b, "- comparison cells: `%d`\n", len(cells))
-	if hasMongoCells(cells) {
+	if hasMongo {
 		fmt.Fprintf(&b, "- targets: `treedb`, `mongo`\n\n")
 	} else {
 		fmt.Fprintf(&b, "- targets: `treedb`\n\n")
 	}
 	b.WriteString("## Highlights\n\n")
-	for _, line := range highlightLines(cells) {
+	for _, line := range highlightLines(cells, hasMongo) {
 		fmt.Fprintf(&b, "- %s\n", line)
 	}
 	b.WriteString("\n")
@@ -533,7 +534,7 @@ func hasMongoCells(cells []cellComparison) bool {
 	return false
 }
 
-func highlightLines(cells []cellComparison) []string {
+func highlightLines(cells []cellComparison, hasMongo bool) []string {
 	var lines []string
 	phaseComparisons := allPhaseComparisons(cells)
 	var bestTreeDB *phaseComparison
@@ -561,7 +562,7 @@ func highlightLines(cells []cellComparison) []string {
 			formatRatio(bestTreeDB.Ratio),
 		))
 	} else {
-		if hasMongoCells(cells) {
+		if hasMongo {
 			lines = append(lines, "No phase in this matrix had TreeDB ahead on ops/sec.")
 		} else {
 			lines = append(lines, "No MongoDB baseline rows were present; ops/sec tables are TreeDB-only.")
@@ -577,7 +578,7 @@ func highlightLines(cells []cellComparison) []string {
 			formatNumber(bestMongo.MongoPhase.OpsPerSecond),
 			formatRatio(bestMongo.Ratio),
 		))
-	} else if hasMongoCells(cells) {
+	} else if hasMongo {
 		lines = append(lines, "No phase in this matrix had MongoDB ahead on ops/sec.")
 	}
 	if cell := largestDiskCell(cells); cell != nil {
@@ -601,8 +602,8 @@ func highlightLines(cells []cellComparison) []string {
 				formatOptionalBytesPerDoc(treePhysical, cell.Key.Documents),
 			))
 		} else {
-			mongoData, _ := mongoDataBytes(cell.Mongo.Result)
-			mongoTotal, _ := mongoDBStatsTotalBytes(cell.Mongo.Result)
+			mongoData, mongoDataOK := mongoDataBytes(cell.Mongo.Result)
+			mongoTotal, mongoTotalOK := mongoDBStatsTotalBytes(cell.Mongo.Result)
 			mongoPhysical := cell.Mongo.Row.PhysicalBytes
 			lines = append(lines, fmt.Sprintf("Largest cell disk: at %d docs / %d indexes / `%s`, %s, TreeDB physical du was %s, MongoDB dbStats dataSize was %s, MongoDB dbStats totalSize was %s, and MongoDB physical du was %s (%s/doc).",
 				cell.Key.Documents,
@@ -610,8 +611,8 @@ func highlightLines(cells []cellComparison) []string {
 				cell.Key.TreeDBConfig,
 				treeSnapshotClause,
 				formatOptionalBytes(treePhysical),
-				formatBytes(mongoData),
-				formatBytes(mongoTotal),
+				formatMeasuredBytes(mongoDataOK, mongoData),
+				formatMeasuredBytes(mongoTotalOK, mongoTotal),
 				formatOptionalBytes(mongoPhysical),
 				formatOptionalBytesPerDoc(mongoPhysical, cell.Key.Documents),
 			))
@@ -644,10 +645,9 @@ func cellDiskScore(cell cellComparison) int64 {
 		}
 	}
 	if cell.Mongo != nil {
-		mongoTotal, _ := mongoDBStatsTotalBytes(cell.Mongo.Result)
 		if cell.Mongo.Row.PhysicalBytes > 0 {
 			score += cell.Mongo.Row.PhysicalBytes
-		} else {
+		} else if mongoTotal, ok := mongoDBStatsTotalBytes(cell.Mongo.Result); ok {
 			score += mongoTotal
 		}
 	}
@@ -663,9 +663,10 @@ func renderDiskTable(b *strings.Builder, cells []cellComparison) {
 		treePhysical := cell.TreeDB.Row.PhysicalBytes
 		hasMongo := cell.Mongo != nil
 		var mongoData, mongoTotal, mongoPhysical int64
+		var mongoDataOK, mongoTotalOK bool
 		if hasMongo {
-			mongoData, _ = mongoDataBytes(cell.Mongo.Result)
-			mongoTotal, _ = mongoDBStatsTotalBytes(cell.Mongo.Result)
+			mongoData, mongoDataOK = mongoDataBytes(cell.Mongo.Result)
+			mongoTotal, mongoTotalOK = mongoDBStatsTotalBytes(cell.Mongo.Result)
 			mongoPhysical = cell.Mongo.Row.PhysicalBytes
 		}
 		fmt.Fprintf(b, "| %d | %d | `%s` | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",
@@ -677,11 +678,11 @@ func renderDiskTable(b *strings.Builder, cells []cellComparison) {
 			formatMeasuredBytesPerDoc(treeOK, treeBytes, cell.Key.Documents),
 			formatOptionalBytes(treePhysical),
 			formatOptionalBytesPerDoc(treePhysical, cell.Key.Documents),
-			formatMeasuredBytes(hasMongo, mongoData),
-			formatMeasuredBytes(hasMongo, mongoTotal),
+			formatMeasuredBytes(mongoDataOK, mongoData),
+			formatMeasuredBytes(mongoTotalOK, mongoTotal),
 			formatOptionalBytes(mongoPhysical),
 			formatOptionalBytesPerDoc(mongoPhysical, cell.Key.Documents),
-			formatMeasuredRatio(treeOK && hasMongo, treeBytes, mongoTotal),
+			formatMeasuredRatio(treeOK && mongoTotalOK, treeBytes, mongoTotal),
 			formatRatio(safeRatio(float64(treePhysical), float64(mongoPhysical))),
 		)
 	}
@@ -800,9 +801,10 @@ func writeSummaryTSV(path string, cells []cellComparison) error {
 		treePhysical := cell.TreeDB.Row.PhysicalBytes
 		hasMongo := cell.Mongo != nil
 		var mongoData, mongoTotal, mongoPhysical int64
+		var mongoDataOK, mongoTotalOK bool
 		if hasMongo {
-			mongoData, _ = mongoDataBytes(cell.Mongo.Result)
-			mongoTotal, _ = mongoDBStatsTotalBytes(cell.Mongo.Result)
+			mongoData, mongoDataOK = mongoDataBytes(cell.Mongo.Result)
+			mongoTotal, mongoTotalOK = mongoDBStatsTotalBytes(cell.Mongo.Result)
 			mongoPhysical = cell.Mongo.Row.PhysicalBytes
 		}
 		sampledRatio := safeRatio(cmp.TreeDBPhase.SampledOpsPerSecond, cmp.MongoPhase.SampledOpsPerSecond)
@@ -828,10 +830,10 @@ func writeSummaryTSV(path string, cells []cellComparison) error {
 			treeSnapshot,
 			formatRawInt(treeOK, treeBytes),
 			strconv.FormatInt(treePhysical, 10),
-			formatRawInt(hasMongo, mongoData),
-			formatRawInt(hasMongo, mongoTotal),
+			formatRawInt(mongoDataOK, mongoData),
+			formatRawInt(mongoTotalOK, mongoTotal),
 			formatRawInt(hasMongo, mongoPhysical),
-			formatRawMeasuredRatio(treeOK && hasMongo, treeBytes, mongoTotal),
+			formatRawMeasuredRatio(treeOK && mongoTotalOK, treeBytes, mongoTotal),
 			formatRawRatio(safeRatio(float64(treePhysical), float64(mongoPhysical))),
 		}
 		if err := writer.Write(row); err != nil {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -236,8 +236,9 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 			return nil, fmt.Errorf("incomplete comparison cell documents=%d secondary_indexes=%d", key.Documents, key.SecondaryIndexes)
 		}
 		sort.Strings(cell.treeConfigKeys)
+		mongoIndex := buildMongoScenarioIndex(cell.mongos)
 		for _, config := range cell.treeConfigKeys {
-			mongo, err := matchingMongoRecord(key, config, cell.mongos, allowIncomplete)
+			mongo, err := matchingMongoRecord(key, config, mongoIndex, allowIncomplete)
 			if err != nil {
 				return nil, err
 			}
@@ -264,41 +265,55 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 	return cells, nil
 }
 
-func matchingMongoRecord(key baseCellKey, treeConfig string, mongos map[string]*runRecord, allowIncomplete bool) (*runRecord, error) {
-	if len(mongos) == 0 {
+type mongoScenarioIndex struct {
+	exact        map[string]*runRecord
+	bySuffix     map[string][]*runRecord
+	suffixConfig map[string][]string
+}
+
+func buildMongoScenarioIndex(mongos map[string]*runRecord) mongoScenarioIndex {
+	index := mongoScenarioIndex{
+		exact:        mongos,
+		bySuffix:     make(map[string][]*runRecord, len(mongos)),
+		suffixConfig: make(map[string][]string, len(mongos)),
+	}
+	for config, record := range mongos {
+		scenario := parseScalingScenario(config)
+		if scenario.hasMarker && !scenario.valid {
+			continue
+		}
+		index.bySuffix[scenario.suffix] = append(index.bySuffix[scenario.suffix], record)
+		index.suffixConfig[scenario.suffix] = append(index.suffixConfig[scenario.suffix], config)
+	}
+	for suffix := range index.suffixConfig {
+		sort.Strings(index.suffixConfig[suffix])
+	}
+	return index
+}
+
+func matchingMongoRecord(key baseCellKey, treeConfig string, mongoIndex mongoScenarioIndex, allowIncomplete bool) (*runRecord, error) {
+	if len(mongoIndex.exact) == 0 {
 		if allowIncomplete {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
 	}
-	if record := mongos[treeConfig]; record != nil {
+	if record := mongoIndex.exact[treeConfig]; record != nil {
 		return record, nil
 	}
 	treeScenario := parseScalingScenario(treeConfig)
 	if treeScenario.hasMarker && !treeScenario.valid {
-		return nil, fmt.Errorf("invalid scaling scenario suffix for documents=%d secondary_indexes=%d config=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, sortedRunRecordKeys(mongos))
+		return nil, fmt.Errorf("invalid scaling scenario suffix for documents=%d secondary_indexes=%d config=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, sortedRunRecordKeys(mongoIndex.exact))
 	}
-	var matched *runRecord
-	var candidates []string
-	for mongoConfig, record := range mongos {
-		mongoScenario := parseScalingScenario(mongoConfig)
-		if mongoScenario.hasMarker && !mongoScenario.valid {
-			continue
-		}
-		if mongoScenario.suffix != treeScenario.suffix {
-			continue
-		}
-		matched = record
-		candidates = append(candidates, mongoConfig)
-	}
-	sort.Strings(candidates)
+	matches := mongoIndex.bySuffix[treeScenario.suffix]
+	candidates := mongoIndex.suffixConfig[treeScenario.suffix]
 	if len(candidates) > 1 {
-		return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario.suffix, candidates, sortedRunRecordKeys(mongos))
+		return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario.suffix, candidates, sortedRunRecordKeys(mongoIndex.exact))
 	}
-	if matched != nil {
-		return matched, nil
+	if len(matches) == 1 {
+		return matches[0], nil
 	}
-	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q tree_scenario=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario.suffix, sortedRunRecordKeys(mongos))
+	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q tree_scenario=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario.suffix, sortedRunRecordKeys(mongoIndex.exact))
 }
 
 func sortedRunRecordKeys(records map[string]*runRecord) []string {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -302,7 +302,22 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongos map[string]*
 
 func scalingScenarioSuffix(config string) string {
 	for _, marker := range []string{"_writers_", "_readers_"} {
-		if idx := strings.LastIndex(config, marker); idx >= 0 {
+		idx := strings.LastIndex(config, marker)
+		if idx < 0 {
+			continue
+		}
+		count := config[idx+len(marker):]
+		if count == "" {
+			continue
+		}
+		valid := true
+		for i := 0; i < len(count); i++ {
+			if count[i] < '0' || count[i] > '9' {
+				valid = false
+				break
+			}
+		}
+		if valid {
 			return config[idx+1:]
 		}
 	}
@@ -559,7 +574,7 @@ func highlightLines(cells []cellComparison) []string {
 			formatNumber(bestMongo.MongoPhase.OpsPerSecond),
 			formatRatio(bestMongo.Ratio),
 		))
-	} else {
+	} else if hasMongoCells(cells) {
 		lines = append(lines, "No phase in this matrix had MongoDB ahead on ops/sec.")
 	}
 	if cell := largestDiskCell(cells); cell != nil {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -282,9 +282,6 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongos map[string]*
 				return record, nil
 			}
 		}
-		if allowIncomplete {
-			return nil, nil
-		}
 		return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
 	}
 	var matched *runRecord
@@ -299,9 +296,6 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongos map[string]*
 	}
 	if matched != nil {
 		return matched, nil
-	}
-	if allowIncomplete {
-		return nil, nil
 	}
 	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
 }

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -174,7 +174,8 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 	}
 	matrixDir := filepath.Dir(matrixPath)
 	type groupedCell struct {
-		mongo          *runRecord
+		mongos         map[string]*runRecord
+		mongoKeys      []string
 		trees          map[string]*runRecord
 		treeConfigKeys []string
 	}
@@ -208,7 +209,10 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 		key := baseCellKey{Documents: row.Documents, SecondaryIndexes: row.SecondaryIndexes}
 		cell := byCell[key]
 		if cell == nil {
-			cell = &groupedCell{trees: make(map[string]*runRecord)}
+			cell = &groupedCell{
+				mongos: make(map[string]*runRecord),
+				trees:  make(map[string]*runRecord),
+			}
 			byCell[key] = cell
 		}
 		switch row.Target {
@@ -219,21 +223,27 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 			cell.trees[record.Row.Config] = record
 			cell.treeConfigKeys = append(cell.treeConfigKeys, record.Row.Config)
 		case "mongo":
-			if cell.mongo != nil {
-				return nil, fmt.Errorf("duplicate mongo row for documents=%d secondary_indexes=%d", key.Documents, key.SecondaryIndexes)
+			if cell.mongos[record.Row.Config] != nil {
+				return nil, fmt.Errorf("duplicate mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, record.Row.Config)
 			}
-			cell.mongo = record
+			cell.mongos[record.Row.Config] = record
+			cell.mongoKeys = append(cell.mongoKeys, record.Row.Config)
 		default:
 			return nil, fmt.Errorf("unknown target %q in matrix", row.Target)
 		}
 	}
 	cells := make([]cellComparison, 0, len(byCell))
 	for key, cell := range byCell {
-		if len(cell.trees) == 0 || (cell.mongo == nil && !allowIncomplete) {
+		if len(cell.trees) == 0 || (len(cell.mongos) == 0 && !allowIncomplete) {
 			return nil, fmt.Errorf("incomplete comparison cell documents=%d secondary_indexes=%d", key.Documents, key.SecondaryIndexes)
 		}
 		sort.Strings(cell.treeConfigKeys)
+		sort.Strings(cell.mongoKeys)
 		for _, config := range cell.treeConfigKeys {
+			mongo, err := matchingMongoRecord(key, config, cell.mongos, allowIncomplete)
+			if err != nil {
+				return nil, err
+			}
 			cells = append(cells, cellComparison{
 				Key: cellKey{
 					Documents:        key.Documents,
@@ -241,7 +251,7 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 					TreeDBConfig:     config,
 				},
 				TreeDB: cell.trees[config],
-				Mongo:  cell.mongo,
+				Mongo:  mongo,
 			})
 		}
 	}
@@ -255,6 +265,52 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 		return cells[i].Key.TreeDBConfig < cells[j].Key.TreeDBConfig
 	})
 	return cells, nil
+}
+
+func matchingMongoRecord(key baseCellKey, treeConfig string, mongos map[string]*runRecord, allowIncomplete bool) (*runRecord, error) {
+	if len(mongos) == 0 {
+		if allowIncomplete {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
+	}
+	if len(mongos) == 1 {
+		for _, record := range mongos {
+			return record, nil
+		}
+	}
+	if record := mongos[treeConfig]; record != nil {
+		return record, nil
+	}
+	treeScenario := scalingScenarioSuffix(treeConfig)
+	if treeScenario != "" {
+		var matched *runRecord
+		for mongoConfig, record := range mongos {
+			if scalingScenarioSuffix(mongoConfig) != treeScenario {
+				continue
+			}
+			if matched != nil {
+				return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
+			}
+			matched = record
+		}
+		if matched != nil {
+			return matched, nil
+		}
+	}
+	if allowIncomplete {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
+}
+
+func scalingScenarioSuffix(config string) string {
+	for _, marker := range []string{"_writers_", "_readers_"} {
+		if idx := strings.LastIndex(config, marker); idx >= 0 {
+			return config[idx+1:]
+		}
+	}
+	return ""
 }
 
 func runConfig(row matrixRow, result benchmarkResult) string {
@@ -424,15 +480,22 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	b.WriteString("## Raw Inputs\n\n")
 	b.WriteString("| docs | indexes | config | target | raw json |\n")
 	b.WriteString("| ---: | ---: | --- | --- | --- |\n")
-	seenMongoRaw := make(map[baseCellKey]struct{})
+	type mongoRawKey struct {
+		baseCellKey
+		Config string
+	}
+	seenMongoRaw := make(map[mongoRawKey]struct{})
 	for _, cell := range cells {
 		fmt.Fprintf(&b, "| %d | %d | `%s` | treedb | `%s` |\n", cell.Key.Documents, cell.Key.SecondaryIndexes, cell.Key.TreeDBConfig, cell.TreeDB.DisplayRawPath)
-		mongoKey := baseCellKey{Documents: cell.Key.Documents, SecondaryIndexes: cell.Key.SecondaryIndexes}
 		if cell.Mongo != nil {
+			mongoKey := mongoRawKey{
+				baseCellKey: baseCellKey{Documents: cell.Key.Documents, SecondaryIndexes: cell.Key.SecondaryIndexes},
+				Config:      cell.Mongo.Row.Config,
+			}
 			if _, ok := seenMongoRaw[mongoKey]; ok {
 				continue
 			}
-			fmt.Fprintf(&b, "| %d | %d | `mongo` | mongo | `%s` |\n", cell.Key.Documents, cell.Key.SecondaryIndexes, cell.Mongo.DisplayRawPath)
+			fmt.Fprintf(&b, "| %d | %d | `%s` | mongo | `%s` |\n", cell.Key.Documents, cell.Key.SecondaryIndexes, cell.Mongo.Row.Config, cell.Mongo.DisplayRawPath)
 			seenMongoRaw[mongoKey] = struct{}{}
 		}
 	}

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -274,15 +274,22 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongos map[string]*
 		}
 		return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
 	}
-	if len(mongos) == 1 {
-		for _, record := range mongos {
-			return record, nil
-		}
-	}
 	if record := mongos[treeConfig]; record != nil {
 		return record, nil
 	}
 	treeScenario := scalingScenarioSuffix(treeConfig)
+	if len(mongos) == 1 {
+		for mongoConfig, record := range mongos {
+			mongoScenario := scalingScenarioSuffix(mongoConfig)
+			if treeScenario == "" || mongoScenario == "" || treeScenario == mongoScenario {
+				return record, nil
+			}
+		}
+		if allowIncomplete {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
+	}
 	if treeScenario != "" {
 		var matched *runRecord
 		for mongoConfig, record := range mongos {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -281,7 +281,7 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongos map[string]*
 	if len(mongos) == 1 {
 		for mongoConfig, record := range mongos {
 			mongoScenario := scalingScenarioSuffix(mongoConfig)
-			if treeScenario == "" || mongoScenario == "" || treeScenario == mongoScenario {
+			if treeScenario == mongoScenario {
 				return record, nil
 			}
 		}

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -175,7 +175,6 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 	matrixDir := filepath.Dir(matrixPath)
 	type groupedCell struct {
 		mongos         map[string]*runRecord
-		mongoKeys      []string
 		trees          map[string]*runRecord
 		treeConfigKeys []string
 	}
@@ -227,7 +226,6 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 				return nil, fmt.Errorf("duplicate mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, record.Row.Config)
 			}
 			cell.mongos[record.Row.Config] = record
-			cell.mongoKeys = append(cell.mongoKeys, record.Row.Config)
 		default:
 			return nil, fmt.Errorf("unknown target %q in matrix", row.Target)
 		}
@@ -238,7 +236,6 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 			return nil, fmt.Errorf("incomplete comparison cell documents=%d secondary_indexes=%d", key.Documents, key.SecondaryIndexes)
 		}
 		sort.Strings(cell.treeConfigKeys)
-		sort.Strings(cell.mongoKeys)
 		for _, config := range cell.treeConfigKeys {
 			mongo, err := matchingMongoRecord(key, config, cell.mongos, allowIncomplete)
 			if err != nil {
@@ -290,20 +287,18 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongos map[string]*
 		}
 		return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
 	}
-	if treeScenario != "" {
-		var matched *runRecord
-		for mongoConfig, record := range mongos {
-			if scalingScenarioSuffix(mongoConfig) != treeScenario {
-				continue
-			}
-			if matched != nil {
-				return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
-			}
-			matched = record
+	var matched *runRecord
+	for mongoConfig, record := range mongos {
+		if scalingScenarioSuffix(mongoConfig) != treeScenario {
+			continue
 		}
 		if matched != nil {
-			return matched, nil
+			return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q", key.Documents, key.SecondaryIndexes, treeConfig)
 		}
+		matched = record
+	}
+	if matched != nil {
+		return matched, nil
 	}
 	if allowIncomplete {
 		return nil, nil

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -17,10 +17,11 @@ import (
 )
 
 type config struct {
-	MatrixPath  string
-	ReportPath  string
-	SummaryPath string
-	Title       string
+	MatrixPath      string
+	ReportPath      string
+	SummaryPath     string
+	Title           string
+	AllowIncomplete bool
 }
 
 type matrixRow struct {
@@ -121,7 +122,7 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	cells, err := loadComparisons(cfg.MatrixPath)
+	cells, err := loadComparisons(cfg.MatrixPath, cfg.AllowIncomplete)
 	if err != nil {
 		return err
 	}
@@ -153,6 +154,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.ReportPath, "report", "", "Markdown report output path")
 	fs.StringVar(&cfg.SummaryPath, "summary", "", "optional TSV summary output path")
 	fs.StringVar(&cfg.Title, "title", "Mongo Gateway Benchmark Comparison", "report title")
+	fs.BoolVar(&cfg.AllowIncomplete, "allow-incomplete", false, "allow TreeDB-only or MongoDB-missing matrix cells")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
 	}
@@ -165,7 +167,7 @@ func parseConfig(args []string) (config, error) {
 	return cfg, nil
 }
 
-func loadComparisons(matrixPath string) ([]cellComparison, error) {
+func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison, error) {
 	rows, err := readMatrix(matrixPath)
 	if err != nil {
 		return nil, err
@@ -227,7 +229,7 @@ func loadComparisons(matrixPath string) ([]cellComparison, error) {
 	}
 	cells := make([]cellComparison, 0, len(byCell))
 	for key, cell := range byCell {
-		if len(cell.trees) == 0 || cell.mongo == nil {
+		if len(cell.trees) == 0 || (cell.mongo == nil && !allowIncomplete) {
 			return nil, fmt.Errorf("incomplete comparison cell documents=%d secondary_indexes=%d", key.Documents, key.SecondaryIndexes)
 		}
 		sort.Strings(cell.treeConfigKeys)
@@ -405,7 +407,11 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	fmt.Fprintf(&b, "- generated_at: `%s`\n", generatedAt.Format(time.RFC3339))
 	fmt.Fprintf(&b, "- matrix: `%s`\n", cfg.MatrixPath)
 	fmt.Fprintf(&b, "- comparison cells: `%d`\n", len(cells))
-	fmt.Fprintf(&b, "- targets: `treedb`, `mongo`\n\n")
+	if hasMongoCells(cells) {
+		fmt.Fprintf(&b, "- targets: `treedb`, `mongo`\n\n")
+	} else {
+		fmt.Fprintf(&b, "- targets: `treedb`\n\n")
+	}
 	b.WriteString("## Highlights\n\n")
 	for _, line := range highlightLines(cells) {
 		fmt.Fprintf(&b, "- %s\n", line)
@@ -422,7 +428,10 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	for _, cell := range cells {
 		fmt.Fprintf(&b, "| %d | %d | `%s` | treedb | `%s` |\n", cell.Key.Documents, cell.Key.SecondaryIndexes, cell.Key.TreeDBConfig, cell.TreeDB.DisplayRawPath)
 		mongoKey := baseCellKey{Documents: cell.Key.Documents, SecondaryIndexes: cell.Key.SecondaryIndexes}
-		if _, ok := seenMongoRaw[mongoKey]; !ok {
+		if cell.Mongo != nil {
+			if _, ok := seenMongoRaw[mongoKey]; ok {
+				continue
+			}
 			fmt.Fprintf(&b, "| %d | %d | `mongo` | mongo | `%s` |\n", cell.Key.Documents, cell.Key.SecondaryIndexes, cell.Mongo.DisplayRawPath)
 			seenMongoRaw[mongoKey] = struct{}{}
 		}
@@ -436,6 +445,15 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	b.WriteString("- MongoDB physical bytes are the preferred local disk comparison when the matrix runner has an isolated data directory, such as Docker mode.\n")
 	b.WriteString("- Wall ops/sec values include the full benchmark phase loop. Sampled ops/sec values isolate the timed driver/gateway call inside each phase and are useful when prebuilt fixtures are enabled.\n")
 	return b.String()
+}
+
+func hasMongoCells(cells []cellComparison) bool {
+	for _, cell := range cells {
+		if cell.Mongo != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func highlightLines(cells []cellComparison) []string {
@@ -466,7 +484,11 @@ func highlightLines(cells []cellComparison) []string {
 			formatRatio(bestTreeDB.Ratio),
 		))
 	} else {
-		lines = append(lines, "No phase in this matrix had TreeDB ahead on ops/sec.")
+		if hasMongoCells(cells) {
+			lines = append(lines, "No phase in this matrix had TreeDB ahead on ops/sec.")
+		} else {
+			lines = append(lines, "No MongoDB baseline rows were present; ops/sec tables are TreeDB-only.")
+		}
 	}
 	if bestMongo != nil {
 		lines = append(lines, fmt.Sprintf("Largest MongoDB ops/sec lead: `%s` at %d docs / %d indexes / `%s`, %s ops/sec vs %s ops/sec (%s TreeDB / MongoDB).",
@@ -484,9 +506,6 @@ func highlightLines(cells []cellComparison) []string {
 	if cell := largestDiskCell(cells); cell != nil {
 		treeBytes, treeSnapshot, treeOK := treeDBBytesSnapshot(cell.TreeDB.Result)
 		treePhysical := cell.TreeDB.Row.PhysicalBytes
-		mongoData, _ := mongoDataBytes(cell.Mongo.Result)
-		mongoTotal, _ := mongoDBStatsTotalBytes(cell.Mongo.Result)
-		mongoPhysical := cell.Mongo.Row.PhysicalBytes
 		treeSnapshotClause := "TreeDB disk snapshot was n/a"
 		if treeOK {
 			treeSnapshotClause = fmt.Sprintf("TreeDB %s snapshot used %s (%s/doc)",
@@ -495,17 +514,31 @@ func highlightLines(cells []cellComparison) []string {
 				formatBytesPerDoc(treeBytes, cell.Key.Documents),
 			)
 		}
-		lines = append(lines, fmt.Sprintf("Largest cell disk: at %d docs / %d indexes / `%s`, %s, TreeDB physical du was %s, MongoDB dbStats dataSize was %s, MongoDB dbStats totalSize was %s, and MongoDB physical du was %s (%s/doc).",
-			cell.Key.Documents,
-			cell.Key.SecondaryIndexes,
-			cell.Key.TreeDBConfig,
-			treeSnapshotClause,
-			formatOptionalBytes(treePhysical),
-			formatBytes(mongoData),
-			formatBytes(mongoTotal),
-			formatOptionalBytes(mongoPhysical),
-			formatOptionalBytesPerDoc(mongoPhysical, cell.Key.Documents),
-		))
+		if cell.Mongo == nil {
+			lines = append(lines, fmt.Sprintf("Largest TreeDB disk cell: at %d docs / %d indexes / `%s`, %s, and TreeDB physical du was %s (%s/doc).",
+				cell.Key.Documents,
+				cell.Key.SecondaryIndexes,
+				cell.Key.TreeDBConfig,
+				treeSnapshotClause,
+				formatOptionalBytes(treePhysical),
+				formatOptionalBytesPerDoc(treePhysical, cell.Key.Documents),
+			))
+		} else {
+			mongoData, _ := mongoDataBytes(cell.Mongo.Result)
+			mongoTotal, _ := mongoDBStatsTotalBytes(cell.Mongo.Result)
+			mongoPhysical := cell.Mongo.Row.PhysicalBytes
+			lines = append(lines, fmt.Sprintf("Largest cell disk: at %d docs / %d indexes / `%s`, %s, TreeDB physical du was %s, MongoDB dbStats dataSize was %s, MongoDB dbStats totalSize was %s, and MongoDB physical du was %s (%s/doc).",
+				cell.Key.Documents,
+				cell.Key.SecondaryIndexes,
+				cell.Key.TreeDBConfig,
+				treeSnapshotClause,
+				formatOptionalBytes(treePhysical),
+				formatBytes(mongoData),
+				formatBytes(mongoTotal),
+				formatOptionalBytes(mongoPhysical),
+				formatOptionalBytesPerDoc(mongoPhysical, cell.Key.Documents),
+			))
+		}
 	}
 	return lines
 }
@@ -551,9 +584,13 @@ func renderDiskTable(b *strings.Builder, cells []cellComparison) {
 	for _, cell := range cells {
 		treeBytes, treeSnapshot, treeOK := treeDBBytesSnapshot(cell.TreeDB.Result)
 		treePhysical := cell.TreeDB.Row.PhysicalBytes
-		mongoData, _ := mongoDataBytes(cell.Mongo.Result)
-		mongoTotal, _ := mongoDBStatsTotalBytes(cell.Mongo.Result)
-		mongoPhysical := cell.Mongo.Row.PhysicalBytes
+		hasMongo := cell.Mongo != nil
+		var mongoData, mongoTotal, mongoPhysical int64
+		if hasMongo {
+			mongoData, _ = mongoDataBytes(cell.Mongo.Result)
+			mongoTotal, _ = mongoDBStatsTotalBytes(cell.Mongo.Result)
+			mongoPhysical = cell.Mongo.Row.PhysicalBytes
+		}
 		fmt.Fprintf(b, "| %d | %d | `%s` | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",
 			cell.Key.Documents,
 			cell.Key.SecondaryIndexes,
@@ -563,11 +600,11 @@ func renderDiskTable(b *strings.Builder, cells []cellComparison) {
 			formatMeasuredBytesPerDoc(treeOK, treeBytes, cell.Key.Documents),
 			formatOptionalBytes(treePhysical),
 			formatOptionalBytesPerDoc(treePhysical, cell.Key.Documents),
-			formatBytes(mongoData),
-			formatBytes(mongoTotal),
+			formatMeasuredBytes(hasMongo, mongoData),
+			formatMeasuredBytes(hasMongo, mongoTotal),
 			formatOptionalBytes(mongoPhysical),
 			formatOptionalBytesPerDoc(mongoPhysical, cell.Key.Documents),
-			formatMeasuredRatio(treeOK, treeBytes, mongoTotal),
+			formatMeasuredRatio(treeOK && hasMongo, treeBytes, mongoTotal),
 			formatRatio(safeRatio(float64(treePhysical), float64(mongoPhysical))),
 		)
 	}
@@ -599,10 +636,16 @@ func renderOpsTable(b *strings.Builder, cells []cellComparison) {
 func allPhaseComparisons(cells []cellComparison) []phaseComparison {
 	var out []phaseComparison
 	for _, cell := range cells {
-		names := phaseNames(cell.TreeDB.Result.Phases, cell.Mongo.Result.Phases)
+		var mongoPhases []phaseResult
+		var mongoPhaseMap map[string]phaseResult
+		if cell.Mongo != nil {
+			mongoPhases = cell.Mongo.Result.Phases
+			mongoPhaseMap = cell.Mongo.PhaseMap
+		}
+		names := phaseNames(cell.TreeDB.Result.Phases, mongoPhases)
 		for _, name := range names {
 			treePhase, hasTree := cell.TreeDB.PhaseMap[name]
-			mongoPhase, hasMongo := cell.Mongo.PhaseMap[name]
+			mongoPhase, hasMongo := mongoPhaseMap[name]
 			out = append(out, phaseComparison{
 				Cell:        cell.Key,
 				Name:        name,
@@ -678,8 +721,13 @@ func writeSummaryTSV(path string, cells []cellComparison) error {
 		cell := findCell(cells, cmp.Cell)
 		treeBytes, treeSnapshot, treeOK := treeDBBytesSnapshot(cell.TreeDB.Result)
 		treePhysical := cell.TreeDB.Row.PhysicalBytes
-		mongoData, _ := mongoDataBytes(cell.Mongo.Result)
-		mongoTotal, _ := mongoDBStatsTotalBytes(cell.Mongo.Result)
+		hasMongo := cell.Mongo != nil
+		var mongoData, mongoTotal, mongoPhysical int64
+		if hasMongo {
+			mongoData, _ = mongoDataBytes(cell.Mongo.Result)
+			mongoTotal, _ = mongoDBStatsTotalBytes(cell.Mongo.Result)
+			mongoPhysical = cell.Mongo.Row.PhysicalBytes
+		}
 		sampledRatio := safeRatio(cmp.TreeDBPhase.SampledOpsPerSecond, cmp.MongoPhase.SampledOpsPerSecond)
 		row := []string{
 			strconv.Itoa(cmp.Cell.Documents),
@@ -703,11 +751,11 @@ func writeSummaryTSV(path string, cells []cellComparison) error {
 			treeSnapshot,
 			formatRawInt(treeOK, treeBytes),
 			strconv.FormatInt(treePhysical, 10),
-			strconv.FormatInt(mongoData, 10),
-			strconv.FormatInt(mongoTotal, 10),
-			strconv.FormatInt(cell.Mongo.Row.PhysicalBytes, 10),
-			formatRawMeasuredRatio(treeOK, treeBytes, mongoTotal),
-			formatRawRatio(safeRatio(float64(treePhysical), float64(cell.Mongo.Row.PhysicalBytes))),
+			formatRawInt(hasMongo, mongoData),
+			formatRawInt(hasMongo, mongoTotal),
+			formatRawInt(hasMongo, mongoPhysical),
+			formatRawMeasuredRatio(treeOK && hasMongo, treeBytes, mongoTotal),
+			formatRawRatio(safeRatio(float64(treePhysical), float64(mongoPhysical))),
 		}
 		if err := writer.Write(row); err != nil {
 			return err

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -154,7 +154,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.ReportPath, "report", "", "Markdown report output path")
 	fs.StringVar(&cfg.SummaryPath, "summary", "", "optional TSV summary output path")
 	fs.StringVar(&cfg.Title, "title", "Mongo Gateway Benchmark Comparison", "report title")
-	fs.BoolVar(&cfg.AllowIncomplete, "allow-incomplete", false, "allow TreeDB-only or MongoDB-missing matrix cells")
+	fs.BoolVar(&cfg.AllowIncomplete, "allow-incomplete", false, "allow cells with no MongoDB baseline rows; still requires scenario-matching MongoDB baselines when MongoDB rows are present")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
 	}
@@ -236,7 +236,10 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 			return nil, fmt.Errorf("incomplete comparison cell documents=%d secondary_indexes=%d", key.Documents, key.SecondaryIndexes)
 		}
 		sort.Strings(cell.treeConfigKeys)
-		mongoIndex := buildMongoScenarioIndex(cell.mongos)
+		mongoIndex, err := buildMongoScenarioIndex(cell.mongos)
+		if err != nil {
+			return nil, err
+		}
 		for _, config := range cell.treeConfigKeys {
 			mongo, err := matchingMongoRecord(key, config, mongoIndex, allowIncomplete)
 			if err != nil {
@@ -271,7 +274,7 @@ type mongoScenarioIndex struct {
 	suffixConfig map[string][]string
 }
 
-func buildMongoScenarioIndex(mongos map[string]*runRecord) mongoScenarioIndex {
+func buildMongoScenarioIndex(mongos map[string]*runRecord) (mongoScenarioIndex, error) {
 	index := mongoScenarioIndex{
 		exact:        mongos,
 		bySuffix:     make(map[string][]*runRecord, len(mongos)),
@@ -280,7 +283,7 @@ func buildMongoScenarioIndex(mongos map[string]*runRecord) mongoScenarioIndex {
 	for config, record := range mongos {
 		scenario := parseScalingScenario(config)
 		if scenario.hasMarker && !scenario.valid {
-			continue
+			return mongoScenarioIndex{}, fmt.Errorf("invalid scaling scenario suffix for mongo config=%q", config)
 		}
 		index.bySuffix[scenario.suffix] = append(index.bySuffix[scenario.suffix], record)
 		index.suffixConfig[scenario.suffix] = append(index.suffixConfig[scenario.suffix], config)
@@ -288,7 +291,7 @@ func buildMongoScenarioIndex(mongos map[string]*runRecord) mongoScenarioIndex {
 	for suffix := range index.suffixConfig {
 		sort.Strings(index.suffixConfig[suffix])
 	}
-	return index
+	return index, nil
 }
 
 func matchingMongoRecord(key baseCellKey, treeConfig string, mongoIndex mongoScenarioIndex, allowIncomplete bool) (*runRecord, error) {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -524,7 +524,7 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 		fmt.Fprintf(&b, "- targets: `treedb`\n\n")
 	}
 	b.WriteString("## Highlights\n\n")
-	for _, line := range highlightLines(cells, hasMongo) {
+	for _, line := range highlightLines(cells) {
 		fmt.Fprintf(&b, "- %s\n", line)
 	}
 	b.WriteString("\n")
@@ -574,8 +574,9 @@ func hasMongoCells(cells []cellComparison) bool {
 	return false
 }
 
-func highlightLines(cells []cellComparison, hasMongo bool) []string {
+func highlightLines(cells []cellComparison) []string {
 	var lines []string
+	hasMongo := hasMongoCells(cells)
 	phaseComparisons := allPhaseComparisons(cells)
 	var bestTreeDB *phaseComparison
 	var bestMongo *phaseComparison

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -325,26 +325,31 @@ type scalingScenario struct {
 }
 
 func parseScalingScenario(config string) scalingScenario {
+	selectedIdx := -1
+	selectedMarker := ""
 	for _, marker := range []string{"_writers_", "_readers_"} {
 		idx := strings.LastIndex(config, marker)
-		if idx < 0 {
-			continue
+		if idx > selectedIdx {
+			selectedIdx = idx
+			selectedMarker = marker
 		}
-		scenario := scalingScenario{hasMarker: true}
-		count := config[idx+len(marker):]
-		if count == "" {
-			return scenario
-		}
-		for i := 0; i < len(count); i++ {
-			if count[i] < '0' || count[i] > '9' {
-				return scenario
-			}
-		}
-		scenario.valid = true
-		scenario.suffix = config[idx+1:]
+	}
+	if selectedIdx < 0 {
+		return scalingScenario{valid: true}
+	}
+	scenario := scalingScenario{hasMarker: true}
+	count := config[selectedIdx+len(selectedMarker):]
+	if count == "" {
 		return scenario
 	}
-	return scalingScenario{valid: true}
+	for i := 0; i < len(count); i++ {
+		if count[i] < '0' || count[i] > '9' {
+			return scenario
+		}
+	}
+	scenario.valid = true
+	scenario.suffix = config[selectedIdx+1:]
+	return scenario
 }
 
 func runConfig(row matrixRow, result benchmarkResult) string {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -274,11 +274,18 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongos map[string]*
 	if record := mongos[treeConfig]; record != nil {
 		return record, nil
 	}
-	treeScenario := scalingScenarioSuffix(treeConfig)
+	treeScenario := parseScalingScenario(treeConfig)
+	if treeScenario.hasMarker && !treeScenario.valid {
+		return nil, fmt.Errorf("invalid scaling scenario suffix for documents=%d secondary_indexes=%d config=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, sortedRunRecordKeys(mongos))
+	}
 	var matched *runRecord
 	var candidates []string
 	for mongoConfig, record := range mongos {
-		if scalingScenarioSuffix(mongoConfig) != treeScenario {
+		mongoScenario := parseScalingScenario(mongoConfig)
+		if mongoScenario.hasMarker && !mongoScenario.valid {
+			continue
+		}
+		if mongoScenario.suffix != treeScenario.suffix {
 			continue
 		}
 		matched = record
@@ -286,12 +293,12 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongos map[string]*
 	}
 	sort.Strings(candidates)
 	if len(candidates) > 1 {
-		return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario, candidates, sortedRunRecordKeys(mongos))
+		return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario.suffix, candidates, sortedRunRecordKeys(mongos))
 	}
 	if matched != nil {
 		return matched, nil
 	}
-	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q tree_scenario=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario, sortedRunRecordKeys(mongos))
+	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q tree_scenario=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenario.suffix, sortedRunRecordKeys(mongos))
 }
 
 func sortedRunRecordKeys(records map[string]*runRecord) []string {
@@ -304,27 +311,40 @@ func sortedRunRecordKeys(records map[string]*runRecord) []string {
 }
 
 func scalingScenarioSuffix(config string) string {
+	scenario := parseScalingScenario(config)
+	if !scenario.valid {
+		return ""
+	}
+	return scenario.suffix
+}
+
+type scalingScenario struct {
+	suffix    string
+	valid     bool
+	hasMarker bool
+}
+
+func parseScalingScenario(config string) scalingScenario {
 	for _, marker := range []string{"_writers_", "_readers_"} {
 		idx := strings.LastIndex(config, marker)
 		if idx < 0 {
 			continue
 		}
+		scenario := scalingScenario{hasMarker: true}
 		count := config[idx+len(marker):]
 		if count == "" {
-			continue
+			return scenario
 		}
-		valid := true
 		for i := 0; i < len(count); i++ {
 			if count[i] < '0' || count[i] > '9' {
-				valid = false
-				break
+				return scenario
 			}
 		}
-		if valid {
-			return config[idx+1:]
-		}
+		scenario.valid = true
+		scenario.suffix = config[idx+1:]
+		return scenario
 	}
-	return ""
+	return scalingScenario{valid: true}
 }
 
 func runConfig(row matrixRow, result benchmarkResult) string {

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -413,6 +413,8 @@ func TestScalingScenarioSuffixRequiresTerminalCount(t *testing.T) {
 	}{
 		{config: "treedb_writers_4", want: "writers_4", valid: true, marker: true},
 		{config: "treedb_readers_16", want: "readers_16", valid: true, marker: true},
+		{config: "treedb_writers_4_readers_16", want: "readers_16", valid: true, marker: true},
+		{config: "treedb_readers_16_writers_4", want: "writers_4", valid: true, marker: true},
 		{config: "treedb_writers_4_extra", want: "", valid: false, marker: true},
 		{config: "treedb_writers_", want: "", valid: false, marker: true},
 		{config: "treedb_without_marker", want: "", valid: true, marker: false},

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -131,6 +131,63 @@ func TestReportAllowsIncompleteTreeDBOnlyCell(t *testing.T) {
 	}
 }
 
+func TestReportAllowsMixedIncompleteCells(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb_complete.json"), `{
+  "target": "treedb",
+  "documents": 10,
+  "secondary_indexes": 0,
+  "phases": [{"name": "load_insert_many", "operations": 10, "ops_per_sec": 1000, "sampled_ops_per_sec": 1100, "sampled_ns_per_op": 900, "latency_micros": {"p95": 2}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 100}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_complete.json"), `{
+  "target": "mongo",
+  "documents": 10,
+  "secondary_indexes": 0,
+  "phases": [{"name": "load_insert_many", "operations": 10, "ops_per_sec": 500, "sampled_ops_per_sec": 550, "sampled_ns_per_op": 1800, "latency_micros": {"p95": 4}}],
+  "mongodb_stats_final": {"dataSize": 200, "totalSize": 300}
+}`)
+	writeFile(t, filepath.Join(dir, "treedb_only.json"), `{
+  "target": "treedb",
+  "documents": 20,
+  "secondary_indexes": 1,
+  "phases": [{"name": "concurrent_id_find_one_r2", "operations": 20, "ops_per_sec": 2000, "sampled_ops_per_sec": 2200, "sampled_ns_per_op": 450, "latency_micros": {"p95": 3}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 400}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	reportPath := filepath.Join(dir, "report.md")
+	summaryPath := filepath.Join(dir, "summary.tsv")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_complete\t10\t0\ttreedb_complete.json\t100\n"+
+		"mongo\tmongo\t10\t0\tmongo_complete.json\t300\n"+
+		"treedb\ttreedb_only\t20\t1\ttreedb_only.json\t400\n")
+
+	if err := run([]string{
+		"-matrix", matrixPath,
+		"-report", reportPath,
+		"-summary", summaryPath,
+		"-allow-incomplete",
+	}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	report := readFile(t, reportPath)
+	for _, want := range []string{
+		"| 10 | 0 | `treedb_complete` | `load_insert_many` | 1000 | 1100 | 500 | 550 | 2.00x | 2.00x | 2.00 | 4.00 |",
+		"| 20 | 1 | `treedb_only` | `concurrent_id_find_one_r2` | 2000 | 2200 | n/a | n/a | n/a | n/a | 3.00 | n/a |",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q\n%s", want, report)
+		}
+	}
+	summary := readFile(t, summaryPath)
+	if !strings.Contains(summary, "load_insert_many\t1000.000000\t1100.000000\t900.000000\t500.000000\t550.000000\t1800.000000\t2.000000\t2.000000") {
+		t.Fatalf("summary missing complete comparison:\n%s", summary)
+	}
+	if !strings.Contains(summary, "concurrent_id_find_one_r2\t2000.000000\t2200.000000\t450.000000\t\t\t\t\t") {
+		t.Fatalf("summary missing incomplete comparison:\n%s", summary)
+	}
+}
+
 func TestReportSupportsMultipleTreeDBConfigsPerMongoCell(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "treedb_json.json"), `{

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -404,6 +404,26 @@ func TestReportAllowIncompleteStillRejectsMismatchedMongoScenario(t *testing.T) 
 	}
 }
 
+func TestMatchingMongoRecordNoScalingMarkerErrorSaysSo(t *testing.T) {
+	index := mongoScenarioIndex{
+		exact: map[string]*runRecord{
+			"mongo_writers_1": {Row: matrixRow{Config: "mongo_writers_1"}},
+		},
+		bySuffix: map[string][]*runRecord{
+			"writers_1": {{Row: matrixRow{Config: "mongo_writers_1"}}},
+		},
+		suffixConfig: map[string][]string{
+			"writers_1": {"mongo_writers_1"},
+		},
+	}
+	_, err := matchingMongoRecord(baseCellKey{Documents: 100, SecondaryIndexes: 2}, "treedb_without_marker", index, false)
+	if err == nil ||
+		!strings.Contains(err.Error(), `config="treedb_without_marker"`) ||
+		!strings.Contains(err.Error(), `tree_scenario="no scaling marker present"`) {
+		t.Fatalf("err=%v want explicit no scaling marker context", err)
+	}
+}
+
 func TestScalingScenarioSuffixRequiresTerminalCount(t *testing.T) {
 	for _, tc := range []struct {
 		config string

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -92,6 +92,45 @@ func TestReportRejectsIncompleteCell(t *testing.T) {
 	}
 }
 
+func TestReportAllowsIncompleteTreeDBOnlyCell(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb.json"), `{
+  "target": "treedb",
+  "documents": 10,
+  "secondary_indexes": 0,
+  "phases": [{"name": "concurrent_id_update_set_w4", "operations": 40, "ops_per_sec": 4000, "sampled_ops_per_sec": 5000, "sampled_ns_per_op": 200, "latency_micros": {"p50": 1, "p95": 2, "p99": 3}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 100}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	reportPath := filepath.Join(dir, "report.md")
+	summaryPath := filepath.Join(dir, "summary.tsv")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_writers_4\t10\t0\ttreedb.json\t100\n")
+
+	if err := run([]string{
+		"-matrix", matrixPath,
+		"-report", reportPath,
+		"-summary", summaryPath,
+		"-allow-incomplete",
+	}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	report := readFile(t, reportPath)
+	for _, want := range []string{
+		"- targets: `treedb`",
+		"No MongoDB baseline rows were present",
+		"| 10 | 0 | `treedb_bson_writers_4` | `concurrent_id_update_set_w4` | 4000 | 5000 | n/a | n/a | n/a | n/a | 2.00 | n/a |",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q\n%s", want, report)
+		}
+	}
+	summary := readFile(t, summaryPath)
+	if !strings.Contains(summary, "concurrent_id_update_set_w4\t4000.000000\t5000.000000\t200.000000\t\t\t\t\t") {
+		t.Fatalf("summary missing TreeDB-only row:\n%s", summary)
+	}
+}
+
 func TestReportSupportsMultipleTreeDBConfigsPerMongoCell(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "treedb_json.json"), `{

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -293,6 +293,44 @@ func TestReportSupportsScalingMongoConfigsPerScenario(t *testing.T) {
 	}
 }
 
+func TestReportRejectsLoneMismatchedMongoScenario(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb_w1.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "treedb_w2.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w2", "operations": 100, "ops_per_sec": 1500, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2200}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_w1.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 500, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver-command-raw_writers_1\t100\t2\ttreedb_w1.json\t2000\n"+
+		"treedb\ttreedb_bson_driver-command-raw_writers_2\t100\t2\ttreedb_w2.json\t2200\n"+
+		"mongo\tmongo_writers_1\t100\t2\tmongo_w1.json\t4000\n")
+
+	err := run([]string{
+		"-matrix", matrixPath,
+		"-report", filepath.Join(dir, "report.md"),
+	})
+	if err == nil || !strings.Contains(err.Error(), `config="treedb_bson_driver-command-raw_writers_2"`) {
+		t.Fatalf("err=%v want missing writers_2 mongo scenario", err)
+	}
+}
+
 func TestLargestDiskCellUsesDiskMetrics(t *testing.T) {
 	cells := []cellComparison{
 		{

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -125,6 +125,9 @@ func TestReportAllowsIncompleteTreeDBOnlyCell(t *testing.T) {
 			t.Fatalf("report missing %q\n%s", want, report)
 		}
 	}
+	if strings.Contains(report, "No phase in this matrix had MongoDB ahead on ops/sec.") {
+		t.Fatalf("TreeDB-only report should not mention MongoDB lead fallback:\n%s", report)
+	}
 	summary := readFile(t, summaryPath)
 	if !strings.Contains(summary, "concurrent_id_update_set_w4\t4000.000000\t5000.000000\t200.000000\t\t\t\t\t") {
 		t.Fatalf("summary missing TreeDB-only row:\n%s", summary)
@@ -359,6 +362,23 @@ func TestReportAllowIncompleteStillRejectsMismatchedMongoScenario(t *testing.T) 
 	})
 	if err == nil || !strings.Contains(err.Error(), `config="treedb_bson_driver-command-raw_writers_1"`) {
 		t.Fatalf("err=%v want mismatched mongo scenario despite allow-incomplete", err)
+	}
+}
+
+func TestScalingScenarioSuffixRequiresTerminalCount(t *testing.T) {
+	for _, tc := range []struct {
+		config string
+		want   string
+	}{
+		{config: "treedb_writers_4", want: "writers_4"},
+		{config: "treedb_readers_16", want: "readers_16"},
+		{config: "treedb_writers_4_extra", want: ""},
+		{config: "treedb_writers_", want: ""},
+		{config: "treedb_without_marker", want: ""},
+	} {
+		if got := scalingScenarioSuffix(tc.config); got != tc.want {
+			t.Fatalf("scalingScenarioSuffix(%q)=%q want %q", tc.config, got, tc.want)
+		}
 	}
 }
 

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -459,6 +459,38 @@ func TestReportRejectsInvalidScalingScenarioWithUnsuffixedMongo(t *testing.T) {
 	}
 }
 
+func TestReportRejectsInvalidScalingScenarioMongoConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "insert", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "insert", "operations": 100, "ops_per_sec": 500, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver-command-raw_writers_1\t100\t2\ttreedb.json\t2000\n"+
+		"mongo\tmongo_writers_bad\t100\t2\tmongo.json\t4000\n")
+
+	err := run([]string{
+		"-matrix", matrixPath,
+		"-report", filepath.Join(dir, "report.md"),
+	})
+	if err == nil ||
+		!strings.Contains(err.Error(), "invalid scaling scenario suffix") ||
+		!strings.Contains(err.Error(), `mongo config="mongo_writers_bad"`) {
+		t.Fatalf("err=%v want invalid mongo scaling scenario suffix", err)
+	}
+}
+
 func TestReportRejectsLoneMongoScenarioForUnsuffixedTreeConfig(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "treedb.json"), `{

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -331,6 +331,37 @@ func TestReportRejectsLoneMismatchedMongoScenario(t *testing.T) {
 	}
 }
 
+func TestReportAllowIncompleteStillRejectsMismatchedMongoScenario(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb_w1.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "insert", "operations": 100, "ops_per_sec": 500, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver-command-raw_writers_1\t100\t2\ttreedb_w1.json\t2000\n"+
+		"mongo\tmongo\t100\t2\tmongo.json\t4000\n")
+
+	err := run([]string{
+		"-matrix", matrixPath,
+		"-report", filepath.Join(dir, "report.md"),
+		"-allow-incomplete",
+	})
+	if err == nil || !strings.Contains(err.Error(), `config="treedb_bson_driver-command-raw_writers_1"`) {
+		t.Fatalf("err=%v want mismatched mongo scenario despite allow-incomplete", err)
+	}
+}
+
 func TestReportRejectsLoneMongoScenarioForUnsuffixedTreeConfig(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "treedb.json"), `{

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -361,6 +361,83 @@ func TestReportRejectsLoneMongoScenarioForUnsuffixedTreeConfig(t *testing.T) {
 	}
 }
 
+func TestReportMatchesUnsuffixedTreeConfigWithMixedMongoRows(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "insert", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "insert", "operations": 100, "ops_per_sec": 500, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_w1.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 600, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4100}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	reportPath := filepath.Join(dir, "report.md")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver-command-raw\t100\t2\ttreedb.json\t2000\n"+
+		"mongo\tmongo\t100\t2\tmongo.json\t4000\n"+
+		"mongo\tmongo_writers_1\t100\t2\tmongo_w1.json\t4100\n")
+
+	if err := run([]string{"-matrix", matrixPath, "-report", reportPath}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	report := readFile(t, reportPath)
+	if !strings.Contains(report, "| 100 | 2 | `treedb_bson_driver-command-raw` | `insert` | 1000 | n/a | 500 | n/a | 2.00x | n/a |") {
+		t.Fatalf("report missing unsuffixed comparison\n%s", report)
+	}
+}
+
+func TestReportRejectsAmbiguousScalingMongoConfigsPerScenario(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb_w1.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_w1_a.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 500, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_w1_b.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 550, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3100, "totalSize": 4100}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver-command-raw_writers_1\t100\t2\ttreedb_w1.json\t2000\n"+
+		"mongo\tmongo_a_writers_1\t100\t2\tmongo_w1_a.json\t4000\n"+
+		"mongo\tmongo_b_writers_1\t100\t2\tmongo_w1_b.json\t4100\n")
+
+	err := run([]string{
+		"-matrix", matrixPath,
+		"-report", filepath.Join(dir, "report.md"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous mongo rows") {
+		t.Fatalf("err=%v want ambiguous mongo rows", err)
+	}
+}
+
 func TestLargestDiskCellUsesDiskMetrics(t *testing.T) {
 	cells := []cellComparison{
 		{

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -331,6 +331,36 @@ func TestReportRejectsLoneMismatchedMongoScenario(t *testing.T) {
 	}
 }
 
+func TestReportRejectsLoneMongoScenarioForUnsuffixedTreeConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "insert", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_w1.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 500, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver-command-raw\t100\t2\ttreedb.json\t2000\n"+
+		"mongo\tmongo_writers_1\t100\t2\tmongo_w1.json\t4000\n")
+
+	err := run([]string{
+		"-matrix", matrixPath,
+		"-report", filepath.Join(dir, "report.md"),
+	})
+	if err == nil || !strings.Contains(err.Error(), `config="treedb_bson_driver-command-raw"`) {
+		t.Fatalf("err=%v want missing unsuffixed mongo baseline", err)
+	}
+}
+
 func TestLargestDiskCellUsesDiskMetrics(t *testing.T) {
 	cells := []cellComparison{
 		{

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -639,7 +639,7 @@ func TestMissingTreeDBDiskSnapshotRendersNA(t *testing.T) {
 		},
 	}}
 
-	lines := strings.Join(highlightLines(cells, true), "\n")
+	lines := strings.Join(highlightLines(cells), "\n")
 	if !strings.Contains(lines, "TreeDB disk snapshot was n/a") || strings.Contains(lines, "used 0 B") {
 		t.Fatalf("highlight rendered missing TreeDB disk snapshot incorrectly:\n%s", lines)
 	}

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -92,6 +92,37 @@ func TestReportRejectsIncompleteCell(t *testing.T) {
 	}
 }
 
+func TestReportRejectsDuplicateTreeDBRows(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb_a.json"), `{
+  "target": "treedb",
+  "documents": 10,
+  "secondary_indexes": 0,
+  "phases": [],
+  "treedb_disk_after_checkpoint": {"total_bytes": 100}
+}`)
+	writeFile(t, filepath.Join(dir, "treedb_b.json"), `{
+  "target": "treedb",
+  "documents": 10,
+  "secondary_indexes": 0,
+  "phases": [],
+  "treedb_disk_after_checkpoint": {"total_bytes": 120}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_writers_1\t10\t0\ttreedb_a.json\t100\n"+
+		"treedb\ttreedb_bson_writers_1\t10\t0\ttreedb_b.json\t120\n")
+
+	err := run([]string{
+		"-matrix", matrixPath,
+		"-report", filepath.Join(dir, "report.md"),
+		"-allow-incomplete",
+	})
+	if err == nil || !strings.Contains(err.Error(), `duplicate treedb row`) {
+		t.Fatalf("expected duplicate treedb row error, got %v", err)
+	}
+}
+
 func TestReportAllowsIncompleteTreeDBOnlyCell(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "treedb.json"), `{
@@ -329,8 +360,11 @@ func TestReportRejectsLoneMismatchedMongoScenario(t *testing.T) {
 		"-matrix", matrixPath,
 		"-report", filepath.Join(dir, "report.md"),
 	})
-	if err == nil || !strings.Contains(err.Error(), `config="treedb_bson_driver-command-raw_writers_2"`) {
-		t.Fatalf("err=%v want missing writers_2 mongo scenario", err)
+	if err == nil ||
+		!strings.Contains(err.Error(), `config="treedb_bson_driver-command-raw_writers_2"`) ||
+		!strings.Contains(err.Error(), `tree_scenario="writers_2"`) ||
+		!strings.Contains(err.Error(), `available_mongo_configs=[mongo_writers_1]`) {
+		t.Fatalf("err=%v want missing writers_2 mongo scenario with context", err)
 	}
 }
 
@@ -360,8 +394,11 @@ func TestReportAllowIncompleteStillRejectsMismatchedMongoScenario(t *testing.T) 
 		"-report", filepath.Join(dir, "report.md"),
 		"-allow-incomplete",
 	})
-	if err == nil || !strings.Contains(err.Error(), `config="treedb_bson_driver-command-raw_writers_1"`) {
-		t.Fatalf("err=%v want mismatched mongo scenario despite allow-incomplete", err)
+	if err == nil ||
+		!strings.Contains(err.Error(), `config="treedb_bson_driver-command-raw_writers_1"`) ||
+		!strings.Contains(err.Error(), `tree_scenario="writers_1"`) ||
+		!strings.Contains(err.Error(), `available_mongo_configs=[mongo]`) {
+		t.Fatalf("err=%v want mismatched mongo scenario despite allow-incomplete with context", err)
 	}
 }
 

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -599,7 +599,7 @@ func TestMissingTreeDBDiskSnapshotRendersNA(t *testing.T) {
 		},
 	}}
 
-	lines := strings.Join(highlightLines(cells), "\n")
+	lines := strings.Join(highlightLines(cells, true), "\n")
 	if !strings.Contains(lines, "TreeDB disk snapshot was n/a") || strings.Contains(lines, "used 0 B") {
 		t.Fatalf("highlight rendered missing TreeDB disk snapshot incorrectly:\n%s", lines)
 	}

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -182,6 +182,60 @@ func TestReportSupportsMultipleTreeDBConfigsPerMongoCell(t *testing.T) {
 	}
 }
 
+func TestReportSupportsScalingMongoConfigsPerScenario(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb_w1.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 1000, "latency_micros": {"p95": 10}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "treedb_w2.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w2", "operations": 100, "ops_per_sec": 1500, "latency_micros": {"p95": 20}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2200}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_w1.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 500, "latency_micros": {"p95": 30}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_w2.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "concurrent_id_update_set_w2", "operations": 100, "ops_per_sec": 750, "latency_micros": {"p95": 40}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4100}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	reportPath := filepath.Join(dir, "report.md")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver-command-raw_writers_1\t100\t2\ttreedb_w1.json\t2000\n"+
+		"mongo\tmongo_writers_1\t100\t2\tmongo_w1.json\t4000\n"+
+		"treedb\ttreedb_bson_driver-command-raw_writers_2\t100\t2\ttreedb_w2.json\t2200\n"+
+		"mongo\tmongo_writers_2\t100\t2\tmongo_w2.json\t4100\n")
+
+	if err := run([]string{"-matrix", matrixPath, "-report", reportPath}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	report := readFile(t, reportPath)
+	for _, want := range []string{
+		"| 100 | 2 | `treedb_bson_driver-command-raw_writers_1` | `concurrent_id_update_set_w1` | 1000 | n/a | 500 | n/a | 2.00x | n/a | 10.0 | 30.0 |",
+		"| 100 | 2 | `treedb_bson_driver-command-raw_writers_2` | `concurrent_id_update_set_w2` | 1500 | n/a | 750 | n/a | 2.00x | n/a | 20.0 | 40.0 |",
+		"| 100 | 2 | `mongo_writers_1` | mongo | `mongo_w1.json` |",
+		"| 100 | 2 | `mongo_writers_2` | mongo | `mongo_w2.json` |",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q\n%s", want, report)
+		}
+	}
+}
+
 func TestLargestDiskCellUsesDiskMetrics(t *testing.T) {
 	cells := []cellComparison{
 		{

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -150,7 +150,9 @@ func TestReportAllowsIncompleteTreeDBOnlyCell(t *testing.T) {
 	for _, want := range []string{
 		"- targets: `treedb`",
 		"No MongoDB baseline rows were present",
-		"| 10 | 0 | `treedb_bson_writers_4` | `concurrent_id_update_set_w4` | 4000 | 5000 | n/a | n/a | n/a | n/a | 2.00 | n/a |",
+		"`treedb_bson_writers_4`",
+		"`concurrent_id_update_set_w4`",
+		"| 4000 | 5000 |",
 	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("report missing %q\n%s", want, report)
@@ -406,16 +408,52 @@ func TestScalingScenarioSuffixRequiresTerminalCount(t *testing.T) {
 	for _, tc := range []struct {
 		config string
 		want   string
+		valid  bool
+		marker bool
 	}{
-		{config: "treedb_writers_4", want: "writers_4"},
-		{config: "treedb_readers_16", want: "readers_16"},
-		{config: "treedb_writers_4_extra", want: ""},
-		{config: "treedb_writers_", want: ""},
-		{config: "treedb_without_marker", want: ""},
+		{config: "treedb_writers_4", want: "writers_4", valid: true, marker: true},
+		{config: "treedb_readers_16", want: "readers_16", valid: true, marker: true},
+		{config: "treedb_writers_4_extra", want: "", valid: false, marker: true},
+		{config: "treedb_writers_", want: "", valid: false, marker: true},
+		{config: "treedb_without_marker", want: "", valid: true, marker: false},
 	} {
 		if got := scalingScenarioSuffix(tc.config); got != tc.want {
 			t.Fatalf("scalingScenarioSuffix(%q)=%q want %q", tc.config, got, tc.want)
 		}
+		got := parseScalingScenario(tc.config)
+		if got.valid != tc.valid || got.hasMarker != tc.marker {
+			t.Fatalf("parseScalingScenario(%q)=%+v want valid=%v marker=%v", tc.config, got, tc.valid, tc.marker)
+		}
+	}
+}
+
+func TestReportRejectsInvalidScalingScenarioWithUnsuffixedMongo(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "insert", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "insert", "operations": 100, "ops_per_sec": 500, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver-command-raw_writers_1_extra\t100\t2\ttreedb.json\t2000\n"+
+		"mongo\tmongo\t100\t2\tmongo.json\t4000\n")
+
+	err := run([]string{
+		"-matrix", matrixPath,
+		"-report", filepath.Join(dir, "report.md"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid scaling scenario suffix") {
+		t.Fatalf("err=%v want invalid scaling scenario suffix", err)
 	}
 }
 

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -368,24 +368,22 @@ for readers in $READERS_LIST; do
   run_cell "readers_${readers}" "$readers" "$CONCURRENT_READS" 0 0
 done
 
-report_extra=""
+report_extra=()
 if [[ "$INCLUDE_MONGO" != "1" ]]; then
-  report_extra="-allow-incomplete"
+  report_extra=(-allow-incomplete)
 fi
 
-if [[ -n "$report_extra" ]]; then
-  "$REPORT_BIN" \
-    -matrix "$MATRIX" \
-    -report "$REPORT" \
-    -summary "$SUMMARY" \
-    -title "$TITLE" \
-    "$report_extra"
-else
-  "$REPORT_BIN" \
-    -matrix "$MATRIX" \
-    -report "$REPORT" \
-    -summary "$SUMMARY" \
-    -title "$TITLE"
+"$REPORT_BIN" \
+  -matrix "$MATRIX" \
+  -report "$REPORT" \
+  -summary "$SUMMARY" \
+  -title "$TITLE" \
+  "${report_extra[@]}"
+
+report_extra_text=""
+if (( ${#report_extra[@]} > 0 )); then
+  report_extra_text=" \\
+  ${report_extra[*]}"
 fi
 
 cat >"$README" <<EOF
@@ -420,8 +418,7 @@ GOWORK=off go run ./cmd/mongo_gateway_compare_report \\
   -matrix "$MATRIX" \\
   -report "$REPORT" \\
   -summary "$SUMMARY" \\
-  -title "$TITLE" \\
-  $report_extra
+  -title "$TITLE"$report_extra_text
 \`\`\`
 EOF
 

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -104,6 +104,10 @@ normalize_bool_01() {
   esac
 }
 
+safe_label() {
+  printf '%s' "$1" | tr -c '[:alnum:]_.-' '_'
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --out)
@@ -260,10 +264,11 @@ if [[ -n "$(find "$OUT_DIR" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
   echo "output directory must be empty: $OUT_DIR" >&2
   exit 2
 fi
-RUN_ID=$(printf '%s' "$(basename "$OUT_DIR")" | tr -c '[:alnum:]_.-' '_')
+RUN_ID=$(safe_label "$(basename "$OUT_DIR")")
 if [[ -z "$DATABASE_PREFIX" ]]; then
   DATABASE_PREFIX="mongo_gateway_scaling_${RUN_ID}"
 fi
+DATABASE_PREFIX=$(safe_label "$DATABASE_PREFIX")
 RAW_DIR="$OUT_DIR/raw"
 BIN_DIR="$OUT_DIR/bin"
 MATRIX="$OUT_DIR/matrix.tsv"
@@ -293,10 +298,6 @@ REPORT_BIN="$BIN_DIR/mongo_gateway_compare_report"
 GO_WORK_MODE="${GOWORK:-off}"
 GOWORK="$GO_WORK_MODE" go build -o "$BENCH_BIN" ./cmd/mongo_gateway_bench
 GOWORK="$GO_WORK_MODE" go build -o "$REPORT_BIN" ./cmd/mongo_gateway_compare_report
-
-safe_label() {
-  printf '%s' "$1" | tr -c '[:alnum:]_.-' '_'
-}
 
 du_bytes() {
   local dir=$1

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 cd "$ROOT"
 
 TMP_BASE="${TMPDIR:-/tmp}"
@@ -32,7 +32,7 @@ MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-16}"
 PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-true}"
 INCLUDE_MONGO="${INCLUDE_MONGO:-0}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
-DATABASE_PREFIX="${DATABASE_PREFIX:-mongo_gateway_scaling}"
+DATABASE_PREFIX="${DATABASE_PREFIX:-}"
 COLLECTION="${COLLECTION:-docs}"
 TIMEOUT="${TIMEOUT:-60m}"
 TITLE="${TITLE:-Mongo Gateway Reader/Writer Scaling}"
@@ -57,6 +57,7 @@ Options:
   --concurrent-reads N   Total reads per reader-scaling cell. Default: 80000.
   --include-mongo        Also run each cell against an external MongoDB URI.
   --mongo-uri URI        MongoDB URI for --include-mongo. Default: mongodb://127.0.0.1:27017.
+  --database-prefix NAME MongoDB database prefix. Default: mongo_gateway_scaling_<run_id>.
   --treedb-format NAME   TreeDB document format. Default: bson.
   --client-mode NAME     TreeDB client mode. Default: driver-command-raw.
   --profile NAME         TreeDB profile. Default: wal_on_fast.
@@ -67,9 +68,9 @@ Options:
 
 Environment overrides use the uppercase variable names shown in the script:
 OUT_DIR, DOCS, INDEXES, BATCH_SIZE, INSERT_PRODUCERS, WRITERS_LIST,
-READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1, true/false, or yes/no), MONGO_URI,
+READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1, true/false, or yes/no), MONGO_URI, DATABASE_PREFIX,
 TREEDB_DOCUMENT_FORMAT, TREEDB_CLIENT_MODE, TREEDB_PROFILE,
-TREEDB_MAINTENANCE, TIMEOUT, TITLE, and related storage/pool settings.
+TREEDB_MAINTENANCE, GOWORK, TIMEOUT, TITLE, and related storage/pool settings.
 EOF
 }
 
@@ -157,6 +158,11 @@ while [[ $# -gt 0 ]]; do
     --mongo-uri)
       require_option_value "$1" "${2-}"
       MONGO_URI="$2"
+      shift 2
+      ;;
+    --database-prefix)
+      require_option_value "$1" "${2-}"
+      DATABASE_PREFIX="$2"
       shift 2
       ;;
     --treedb-format)
@@ -254,6 +260,10 @@ if [[ -d "$OUT_DIR" ]] && [[ -n "$(find "$OUT_DIR" -mindepth 1 -maxdepth 1 -prin
 fi
 mkdir -p "$OUT_DIR"
 OUT_DIR=$(cd "$OUT_DIR" && pwd -P)
+RUN_ID=$(printf '%s' "$(basename "$OUT_DIR")" | tr -c '[:alnum:]_.-' '_')
+if [[ -z "$DATABASE_PREFIX" ]]; then
+  DATABASE_PREFIX="mongo_gateway_scaling_${RUN_ID}"
+fi
 RAW_DIR="$OUT_DIR/raw"
 BIN_DIR="$OUT_DIR/bin"
 MATRIX="$OUT_DIR/matrix.tsv"
@@ -280,8 +290,9 @@ mkdir -p "$RAW_DIR" "$TREE_DIR" "$BIN_DIR"
 
 BENCH_BIN="$BIN_DIR/mongo_gateway_bench"
 REPORT_BIN="$BIN_DIR/mongo_gateway_compare_report"
-GOWORK=off go build -o "$BENCH_BIN" ./cmd/mongo_gateway_bench
-GOWORK=off go build -o "$REPORT_BIN" ./cmd/mongo_gateway_compare_report
+GO_WORK_MODE="${GOWORK:-off}"
+GOWORK="$GO_WORK_MODE" go build -o "$BENCH_BIN" ./cmd/mongo_gateway_bench
+GOWORK="$GO_WORK_MODE" go build -o "$REPORT_BIN" ./cmd/mongo_gateway_compare_report
 
 safe_label() {
   printf '%s' "$1" | tr -c '[:alnum:]_.-' '_'
@@ -429,12 +440,14 @@ cat >"$README" <<EOF
 - TreeDB maintenance: \`$TREEDB_MAINTENANCE\`
 - include MongoDB: \`$INCLUDE_MONGO\`
 - MongoDB URI: \`$MONGO_URI\`
+- MongoDB database prefix: \`$DATABASE_PREFIX\`
+- GOWORK: \`$GO_WORK_MODE\`
 - timeout: \`$TIMEOUT\`
 
 Regenerate the report:
 
 \`\`\`sh
-GOWORK=off go run ./cmd/mongo_gateway_compare_report \\
+GOWORK=$GO_WORK_MODE go run ./cmd/mongo_gateway_compare_report \\
   -matrix "$MATRIX" \\
   -report "$REPORT" \\
   -summary "$SUMMARY" \\

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -67,7 +67,7 @@ Options:
 
 Environment overrides use the uppercase variable names shown in the script:
 OUT_DIR, DOCS, INDEXES, BATCH_SIZE, INSERT_PRODUCERS, WRITERS_LIST,
-READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1 or true/false), MONGO_URI,
+READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1, true/false, or yes/no), MONGO_URI,
 TREEDB_DOCUMENT_FORMAT, TREEDB_CLIENT_MODE, TREEDB_PROFILE,
 TREEDB_MAINTENANCE, TIMEOUT, TITLE, and related storage/pool settings.
 EOF
@@ -94,7 +94,7 @@ normalize_bool_01() {
       printf '0'
       ;;
     *)
-      echo "$name must be 0/1 or true/false; got: $value" >&2
+      echo "$name must be 0/1, true/false, or yes/no; got: $value" >&2
       usage >&2
       exit 2
       ;;
@@ -249,12 +249,26 @@ INCLUDE_MONGO=$(normalize_bool_01 INCLUDE_MONGO "$INCLUDE_MONGO")
 mkdir -p "$OUT_DIR"
 OUT_DIR=$(cd "$OUT_DIR" && pwd -P)
 RAW_DIR="$OUT_DIR/raw"
-TREE_DIR="$OUT_DIR/treedb_data"
 BIN_DIR="$OUT_DIR/bin"
 MATRIX="$OUT_DIR/matrix.tsv"
 REPORT="$OUT_DIR/report.md"
 SUMMARY="$OUT_DIR/summary.tsv"
 README="$OUT_DIR/README.md"
+
+path_is_within() {
+  local child=${1%/}
+  local parent=${2%/}
+  case "$child/" in
+    "$parent"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if path_is_within "$OUT_DIR" "$ROOT"; then
+  TREE_DIR=$(mktemp -d "$TMP_BASE/gomap_mongo_gateway_scaling_treedb_XXXXXX")
+else
+  TREE_DIR="$OUT_DIR/treedb_data"
+fi
 
 mkdir -p "$RAW_DIR" "$TREE_DIR" "$BIN_DIR"
 

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -85,16 +85,18 @@ require_option_value() {
 
 normalize_bool_01() {
   local name=$1
-  local value=$2
+  local raw=$2
+  local value
+  value=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')
   case "$value" in
-    1|true|TRUE|yes|YES)
+    1|true|yes)
       printf '1'
       ;;
-    0|false|FALSE|no|NO)
+    0|false|no)
       printf '0'
       ;;
     *)
-      echo "$name must be 0/1, true/false, or yes/no; got: $value" >&2
+      echo "$name must be 0/1, true/false, or yes/no; got: $raw" >&2
       usage >&2
       exit 2
       ;;
@@ -262,10 +264,10 @@ README="$OUT_DIR/README.md"
 path_is_within() {
   local child=${1%/}
   local parent=${2%/}
-  case "$child/" in
-    "$parent"/*) return 0 ;;
-    *) return 1 ;;
-  esac
+  if [[ "$child/" == "$parent/"* ]]; then
+    return 0
+  fi
+  return 1
 }
 
 if path_is_within "$OUT_DIR" "$ROOT"; then

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -163,17 +163,18 @@ is_positive_int() {
   [[ "$1" =~ ^[0-9]+$ ]] && [[ "$1" -gt 0 ]]
 }
 
-for value_name in DOCS BATCH_SIZE INSERT_PRODUCERS CONCURRENT_WRITES CONCURRENT_READS MONGO_MAX_POOL_SIZE MONGO_MIN_POOL_SIZE MONGO_MAX_CONNECTING; do
+for value_name in DOCS BATCH_SIZE INSERT_PRODUCERS CONCURRENT_WRITES CONCURRENT_READS; do
   value=${!value_name}
-  if ! is_positive_int "$value" && [[ "$value_name" != MONGO_MIN_POOL_SIZE && "$value_name" != MONGO_MAX_POOL_SIZE && "$value_name" != MONGO_MAX_CONNECTING ]]; then
+  if ! is_positive_int "$value"; then
     echo "invalid $value_name=$value (want positive integer)" >&2
     exit 2
   fi
-  if [[ "$value_name" == MONGO_MIN_POOL_SIZE || "$value_name" == MONGO_MAX_POOL_SIZE || "$value_name" == MONGO_MAX_CONNECTING ]]; then
-    if ! is_nonnegative_int "$value"; then
-      echo "invalid $value_name=$value (want non-negative integer)" >&2
-      exit 2
-    fi
+done
+for value_name in MONGO_MAX_POOL_SIZE MONGO_MIN_POOL_SIZE MONGO_MAX_CONNECTING; do
+  value=${!value_name}
+  if ! is_nonnegative_int "$value"; then
+    echo "invalid $value_name=$value (want non-negative integer)" >&2
+    exit 2
   fi
 done
 for value_name in INDEXES READS RANGE_READS UPDATES DELETES; do

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -284,9 +284,8 @@ run_bench() {
   local concurrent_writes=$7
   shift 7
 
-  local prebuild_args=()
   if [[ "$PREBUILD_DOCUMENTS" == "true" ]]; then
-    prebuild_args=(-prebuild-documents)
+    set -- -prebuild-documents "$@"
   fi
 
   "$BENCH_BIN" \
@@ -310,7 +309,6 @@ run_bench() {
     -secondary-indexes "$INDEXES" \
     -timeout "$TIMEOUT" \
     -format json \
-    "${prebuild_args[@]}" \
     "$@" >"$raw_json"
 }
 
@@ -370,17 +368,25 @@ for readers in $READERS_LIST; do
   run_cell "readers_${readers}" "$readers" "$CONCURRENT_READS" 0 0
 done
 
-report_args=()
+report_extra=""
 if [[ "$INCLUDE_MONGO" != "1" ]]; then
-  report_args=(-allow-incomplete)
+  report_extra="-allow-incomplete"
 fi
 
-"$REPORT_BIN" \
-  -matrix "$MATRIX" \
-  -report "$REPORT" \
-  -summary "$SUMMARY" \
-  -title "$TITLE" \
-  "${report_args[@]}"
+if [[ -n "$report_extra" ]]; then
+  "$REPORT_BIN" \
+    -matrix "$MATRIX" \
+    -report "$REPORT" \
+    -summary "$SUMMARY" \
+    -title "$TITLE" \
+    "$report_extra"
+else
+  "$REPORT_BIN" \
+    -matrix "$MATRIX" \
+    -report "$REPORT" \
+    -summary "$SUMMARY" \
+    -title "$TITLE"
+fi
 
 cat >"$README" <<EOF
 # Mongo Gateway Scaling Bundle
@@ -415,7 +421,7 @@ GOWORK=off go run ./cmd/mongo_gateway_compare_report \\
   -report "$REPORT" \\
   -summary "$SUMMARY" \\
   -title "$TITLE" \\
-  ${report_args[*]}
+  $report_extra
 \`\`\`
 EOF
 

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -105,7 +105,16 @@ normalize_bool_01() {
 }
 
 safe_label() {
-  printf '%s' "$1" | tr -c '[:alnum:]_.-' '_'
+  printf '%s' "$1" | tr -c '[:alnum:]_-' '_'
+}
+
+mongo_database_prefix_label() {
+  local value
+  value=$(safe_label "$1")
+  if [[ -z "$value" ]]; then
+    value="mongo_gateway_scaling"
+  fi
+  printf '%.48s' "$value"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -268,7 +277,7 @@ RUN_ID=$(safe_label "$(basename "$OUT_DIR")")
 if [[ -z "$DATABASE_PREFIX" ]]; then
   DATABASE_PREFIX="mongo_gateway_scaling_${RUN_ID}"
 fi
-DATABASE_PREFIX=$(safe_label "$DATABASE_PREFIX")
+DATABASE_PREFIX=$(mongo_database_prefix_label "$DATABASE_PREFIX")
 RAW_DIR="$OUT_DIR/raw"
 BIN_DIR="$OUT_DIR/bin"
 MATRIX="$OUT_DIR/matrix.tsv"

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -275,6 +275,7 @@ MATRIX="$OUT_DIR/matrix.tsv"
 REPORT="$OUT_DIR/report.md"
 SUMMARY="$OUT_DIR/summary.tsv"
 README="$OUT_DIR/README.md"
+TREE_METADATA="$OUT_DIR/treedb-location.txt"
 
 path_is_within() {
   local child=${1%/}
@@ -285,11 +286,29 @@ path_is_within() {
   return 1
 }
 
+TREE_DIR_IS_TEMP=false
 if path_is_within "$OUT_DIR" "$ROOT"; then
   TREE_DIR=$(mktemp -d "$TMP_BASE/gomap_mongo_gateway_scaling_treedb_XXXXXX")
+  TREE_DIR_IS_TEMP=true
 else
   TREE_DIR="$OUT_DIR/treedb_data"
 fi
+
+cat >"$TREE_METADATA" <<EOF
+TreeDB directory: $TREE_DIR
+This file is written early so the TreeDB path can be recovered if the script exits before bundle documentation is generated.
+EOF
+
+report_treedb_location_on_exit() {
+  local status=$1
+  if [[ "$status" -ne 0 && "$TREE_DIR_IS_TEMP" == "true" ]]; then
+    echo "mongo_gateway_scaling_bench.sh exited before completion." >&2
+    echo "TreeDB data directory: $TREE_DIR" >&2
+    echo "Recorded in: $TREE_METADATA" >&2
+  fi
+}
+
+trap 'report_treedb_location_on_exit "$?"' EXIT
 
 mkdir -p "$RAW_DIR" "$TREE_DIR" "$BIN_DIR"
 
@@ -427,6 +446,7 @@ cat >"$README" <<EOF
 - matrix TSV: \`$MATRIX\`
 - raw JSON directory: \`$RAW_DIR\`
 - TreeDB data directory: \`$TREE_DIR\`
+- TreeDB location metadata: \`$TREE_METADATA\`
 - docs: \`$DOCS\`
 - secondary indexes: \`$INDEXES\`
 - batch size: \`$BATCH_SIZE\`

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+TMP_BASE="${TMPDIR:-/tmp}"
+TMP_BASE="${TMP_BASE%/}"
+OUT_DIR="${OUT_DIR:-$(mktemp -d "$TMP_BASE/gomap_mongo_gateway_scaling_XXXXXX")}"
+DOCS="${DOCS:-100000}"
+INDEXES="${INDEXES:-2}"
+BATCH_SIZE="${BATCH_SIZE:-10000}"
+INSERT_PRODUCERS="${INSERT_PRODUCERS:-8}"
+WRITERS_LIST="${WRITERS_LIST:-1 2 4 8 16}"
+READERS_LIST="${READERS_LIST:-1 2 4 8 16}"
+CONCURRENT_WRITES="${CONCURRENT_WRITES:-80000}"
+CONCURRENT_READS="${CONCURRENT_READS:-80000}"
+READS="${READS:-0}"
+RANGE_READS="${RANGE_READS:-0}"
+UPDATES="${UPDATES:-0}"
+DELETES="${DELETES:-0}"
+TREEDB_PROFILE="${TREEDB_PROFILE:-wal_on_fast}"
+TREEDB_DOCUMENT_FORMAT="${TREEDB_DOCUMENT_FORMAT:-bson}"
+TREEDB_CLIENT_MODE="${TREEDB_CLIENT_MODE:-driver-command-raw}"
+TREEDB_MAINTENANCE="${TREEDB_MAINTENANCE:-none}"
+TREEDB_DATA_ROOT_STORAGE="${TREEDB_DATA_ROOT_STORAGE:-compressed}"
+TREEDB_INDEX_STATE_ROOT_STORAGE="${TREEDB_INDEX_STATE_ROOT_STORAGE:-compressed}"
+TREEDB_INDEX_ROOT_STORAGE="${TREEDB_INDEX_ROOT_STORAGE:-compressed}"
+MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-64}"
+MONGO_MIN_POOL_SIZE="${MONGO_MIN_POOL_SIZE:-0}"
+MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-16}"
+PREBUILD_DOCUMENTS="${PREBUILD_DOCUMENTS:-true}"
+INCLUDE_MONGO="${INCLUDE_MONGO:-0}"
+MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
+DATABASE_PREFIX="${DATABASE_PREFIX:-mongo_gateway_scaling}"
+COLLECTION="${COLLECTION:-docs}"
+TIMEOUT="${TIMEOUT:-60m}"
+TITLE="${TITLE:-Mongo Gateway Reader/Writer Scaling}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/mongo_gateway_scaling_bench.sh [options]
+
+Runs a TreeDB Mongo gateway scaling matrix over concurrent reader and writer
+counts, writes raw mongo_gateway_bench JSON for every cell, and generates the
+standard mongo_gateway_compare_report Markdown/TSV output.
+
+Options:
+  --out DIR              Output directory. Default: mktemp under $TMPDIR or /tmp.
+  --docs N               Document count. Default: 100000.
+  --indexes N            Secondary index count. Default: 2.
+  --batch-size N         Insert batch size. Default: 10000.
+  --insert-producers N   Insert load producers. Default: 8.
+  --writers LIST         Space-separated concurrent writer counts. Default: "1 2 4 8 16".
+  --readers LIST         Space-separated concurrent reader counts. Default: "1 2 4 8 16".
+  --concurrent-writes N  Total updates per writer-scaling cell. Default: 80000.
+  --concurrent-reads N   Total reads per reader-scaling cell. Default: 80000.
+  --include-mongo        Also run each cell against an external MongoDB URI.
+  --mongo-uri URI        MongoDB URI for --include-mongo. Default: mongodb://127.0.0.1:27017.
+  --treedb-format NAME   TreeDB document format. Default: bson.
+  --client-mode NAME     TreeDB client mode. Default: driver-command-raw.
+  --profile NAME         TreeDB profile. Default: wal_on_fast.
+  --maintenance MODE     TreeDB maintenance mode. Default: none.
+  --timeout DURATION     Per-cell timeout. Default: 60m.
+  --title TITLE          Report title.
+  --help                 Show this help.
+
+Environment overrides use the uppercase variable names shown in the script:
+OUT_DIR, DOCS, INDEXES, BATCH_SIZE, INSERT_PRODUCERS, WRITERS_LIST,
+READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO, MONGO_URI,
+TREEDB_DOCUMENT_FORMAT, TREEDB_CLIENT_MODE, TREEDB_PROFILE,
+TREEDB_MAINTENANCE, TIMEOUT, TITLE, and related storage/pool settings.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --docs)
+      DOCS="$2"
+      shift 2
+      ;;
+    --indexes)
+      INDEXES="$2"
+      shift 2
+      ;;
+    --batch-size)
+      BATCH_SIZE="$2"
+      shift 2
+      ;;
+    --insert-producers)
+      INSERT_PRODUCERS="$2"
+      shift 2
+      ;;
+    --writers)
+      WRITERS_LIST="$2"
+      shift 2
+      ;;
+    --readers)
+      READERS_LIST="$2"
+      shift 2
+      ;;
+    --concurrent-writes)
+      CONCURRENT_WRITES="$2"
+      shift 2
+      ;;
+    --concurrent-reads)
+      CONCURRENT_READS="$2"
+      shift 2
+      ;;
+    --include-mongo)
+      INCLUDE_MONGO=1
+      shift
+      ;;
+    --mongo-uri)
+      MONGO_URI="$2"
+      shift 2
+      ;;
+    --treedb-format)
+      TREEDB_DOCUMENT_FORMAT="$2"
+      shift 2
+      ;;
+    --client-mode)
+      TREEDB_CLIENT_MODE="$2"
+      shift 2
+      ;;
+    --profile)
+      TREEDB_PROFILE="$2"
+      shift 2
+      ;;
+    --maintenance)
+      TREEDB_MAINTENANCE="$2"
+      shift 2
+      ;;
+    --timeout)
+      TIMEOUT="$2"
+      shift 2
+      ;;
+    --title)
+      TITLE="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+is_nonnegative_int() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+is_positive_int() {
+  [[ "$1" =~ ^[0-9]+$ ]] && [[ "$1" -gt 0 ]]
+}
+
+for value_name in DOCS BATCH_SIZE INSERT_PRODUCERS CONCURRENT_WRITES CONCURRENT_READS MONGO_MAX_POOL_SIZE MONGO_MIN_POOL_SIZE MONGO_MAX_CONNECTING; do
+  value=${!value_name}
+  if ! is_positive_int "$value" && [[ "$value_name" != MONGO_MIN_POOL_SIZE && "$value_name" != MONGO_MAX_POOL_SIZE && "$value_name" != MONGO_MAX_CONNECTING ]]; then
+    echo "invalid $value_name=$value (want positive integer)" >&2
+    exit 2
+  fi
+  if [[ "$value_name" == MONGO_MIN_POOL_SIZE || "$value_name" == MONGO_MAX_POOL_SIZE || "$value_name" == MONGO_MAX_CONNECTING ]]; then
+    if ! is_nonnegative_int "$value"; then
+      echo "invalid $value_name=$value (want non-negative integer)" >&2
+      exit 2
+    fi
+  fi
+done
+for value_name in INDEXES READS RANGE_READS UPDATES DELETES; do
+  value=${!value_name}
+  if ! is_nonnegative_int "$value"; then
+    echo "invalid $value_name=$value (want non-negative integer)" >&2
+    exit 2
+  fi
+done
+for writers in $WRITERS_LIST; do
+  if ! is_positive_int "$writers"; then
+    echo "invalid writer count: $writers" >&2
+    exit 2
+  fi
+done
+for readers in $READERS_LIST; do
+  if ! is_positive_int "$readers"; then
+    echo "invalid reader count: $readers" >&2
+    exit 2
+  fi
+done
+if [[ "$PREBUILD_DOCUMENTS" != "true" && "$PREBUILD_DOCUMENTS" != "false" ]]; then
+  echo "invalid PREBUILD_DOCUMENTS=$PREBUILD_DOCUMENTS (want true or false)" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+OUT_DIR=$(cd "$OUT_DIR" && pwd -P)
+RAW_DIR="$OUT_DIR/raw"
+TREE_DIR="$OUT_DIR/treedb_data"
+BIN_DIR="$OUT_DIR/bin"
+MATRIX="$OUT_DIR/matrix.tsv"
+REPORT="$OUT_DIR/report.md"
+SUMMARY="$OUT_DIR/summary.tsv"
+README="$OUT_DIR/README.md"
+
+mkdir -p "$RAW_DIR" "$TREE_DIR" "$BIN_DIR"
+
+BENCH_BIN="$BIN_DIR/mongo_gateway_bench"
+REPORT_BIN="$BIN_DIR/mongo_gateway_compare_report"
+GOWORK=off go build -o "$BENCH_BIN" ./cmd/mongo_gateway_bench
+GOWORK=off go build -o "$REPORT_BIN" ./cmd/mongo_gateway_compare_report
+
+safe_label() {
+  printf '%s' "$1" | tr -c '[:alnum:]_.-' '_'
+}
+
+du_bytes() {
+  local dir=$1
+  local kib
+  kib=$(du -sk "$dir" | awk '{print $1}')
+  echo $((kib * 1024))
+}
+
+run_bench() {
+  local target=$1
+  local raw_json=$2
+  local database=$3
+  local concurrent_readers=$4
+  local concurrent_reads=$5
+  local concurrent_writers=$6
+  local concurrent_writes=$7
+  shift 7
+
+  local prebuild_args=()
+  if [[ "$PREBUILD_DOCUMENTS" == "true" ]]; then
+    prebuild_args=(-prebuild-documents)
+  fi
+
+  "$BENCH_BIN" \
+    -target "$target" \
+    -database "$database" \
+    -collection "$COLLECTION" \
+    -documents "$DOCS" \
+    -batch-size "$BATCH_SIZE" \
+    -insert-producers "$INSERT_PRODUCERS" \
+    -mongo-max-pool-size "$MONGO_MAX_POOL_SIZE" \
+    -mongo-min-pool-size "$MONGO_MIN_POOL_SIZE" \
+    -mongo-max-connecting "$MONGO_MAX_CONNECTING" \
+    -reads "$READS" \
+    -range-reads "$RANGE_READS" \
+    -updates "$UPDATES" \
+    -deletes "$DELETES" \
+    -concurrent-readers "$concurrent_readers" \
+    -concurrent-reads "$concurrent_reads" \
+    -concurrent-writers "$concurrent_writers" \
+    -concurrent-writes "$concurrent_writes" \
+    -secondary-indexes "$INDEXES" \
+    -timeout "$TIMEOUT" \
+    -format json \
+    "${prebuild_args[@]}" \
+    "$@" >"$raw_json"
+}
+
+printf "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n" >"$MATRIX"
+
+echo "running Mongo gateway scaling matrix into: $OUT_DIR"
+echo "docs=$DOCS indexes=$INDEXES batch_size=$BATCH_SIZE insert_producers=$INSERT_PRODUCERS"
+echo "writers=$WRITERS_LIST readers=$READERS_LIST include_mongo=$INCLUDE_MONGO"
+
+run_cell() {
+  local scenario=$1
+  local readers=$2
+  local reads=$3
+  local writers=$4
+  local writes=$5
+  local config_suffix
+  config_suffix=$(safe_label "$scenario")
+
+  local tree_config="treedb_${TREEDB_DOCUMENT_FORMAT}_${TREEDB_CLIENT_MODE}_${config_suffix}"
+  tree_config=$(safe_label "$tree_config")
+  local tree_raw_rel="raw/${tree_config}.json"
+  local tree_raw="$OUT_DIR/$tree_raw_rel"
+  local tree_data="$TREE_DIR/$tree_config"
+  local database="${DATABASE_PREFIX}_${config_suffix}"
+
+  echo "==> TreeDB $scenario readers=$readers writers=$writers"
+  run_bench treedb "$tree_raw" "$database" "$readers" "$reads" "$writers" "$writes" \
+    -treedb-dir "$tree_data" \
+    -keep-treedb-dir \
+    -treedb-profile "$TREEDB_PROFILE" \
+    -treedb-document-format "$TREEDB_DOCUMENT_FORMAT" \
+    -client-mode "$TREEDB_CLIENT_MODE" \
+    -treedb-data-root-storage "$TREEDB_DATA_ROOT_STORAGE" \
+    -treedb-index-state-root-storage "$TREEDB_INDEX_STATE_ROOT_STORAGE" \
+    -treedb-index-root-storage "$TREEDB_INDEX_ROOT_STORAGE" \
+    -treedb-maintenance "$TREEDB_MAINTENANCE"
+  local tree_physical
+  tree_physical=$(du_bytes "$tree_data")
+  printf "treedb\t%s\t%s\t%s\t%s\t%s\n" "$tree_config" "$DOCS" "$INDEXES" "$tree_raw_rel" "$tree_physical" >>"$MATRIX"
+
+  if [[ "$INCLUDE_MONGO" == "1" ]]; then
+    local mongo_config="mongo_${config_suffix}"
+    local mongo_raw_rel="raw/${mongo_config}.json"
+    local mongo_raw="$OUT_DIR/$mongo_raw_rel"
+    echo "==> MongoDB $scenario readers=$readers writers=$writers"
+    run_bench mongo "$mongo_raw" "$database" "$readers" "$reads" "$writers" "$writes" \
+      -mongo-uri "$MONGO_URI"
+    printf "mongo\t%s\t%s\t%s\t%s\t0\n" "$mongo_config" "$DOCS" "$INDEXES" "$mongo_raw_rel" >>"$MATRIX"
+  fi
+}
+
+for writers in $WRITERS_LIST; do
+  run_cell "writers_${writers}" 0 0 "$writers" "$CONCURRENT_WRITES"
+done
+
+for readers in $READERS_LIST; do
+  run_cell "readers_${readers}" "$readers" "$CONCURRENT_READS" 0 0
+done
+
+report_args=()
+if [[ "$INCLUDE_MONGO" != "1" ]]; then
+  report_args=(-allow-incomplete)
+fi
+
+"$REPORT_BIN" \
+  -matrix "$MATRIX" \
+  -report "$REPORT" \
+  -summary "$SUMMARY" \
+  -title "$TITLE" \
+  "${report_args[@]}"
+
+cat >"$README" <<EOF
+# Mongo Gateway Scaling Bundle
+
+- output directory: \`$OUT_DIR\`
+- report: \`$REPORT\`
+- summary TSV: \`$SUMMARY\`
+- matrix TSV: \`$MATRIX\`
+- raw JSON directory: \`$RAW_DIR\`
+- TreeDB data directory: \`$TREE_DIR\`
+- docs: \`$DOCS\`
+- secondary indexes: \`$INDEXES\`
+- batch size: \`$BATCH_SIZE\`
+- insert producers: \`$INSERT_PRODUCERS\`
+- writer sweep: \`$WRITERS_LIST\`
+- reader sweep: \`$READERS_LIST\`
+- concurrent writes per writer cell: \`$CONCURRENT_WRITES\`
+- concurrent reads per reader cell: \`$CONCURRENT_READS\`
+- TreeDB profile: \`$TREEDB_PROFILE\`
+- TreeDB document format: \`$TREEDB_DOCUMENT_FORMAT\`
+- TreeDB client mode: \`$TREEDB_CLIENT_MODE\`
+- TreeDB maintenance: \`$TREEDB_MAINTENANCE\`
+- include MongoDB: \`$INCLUDE_MONGO\`
+- MongoDB URI: \`$MONGO_URI\`
+- timeout: \`$TIMEOUT\`
+
+Regenerate the report:
+
+\`\`\`sh
+GOWORK=off go run ./cmd/mongo_gateway_compare_report \\
+  -matrix "$MATRIX" \\
+  -report "$REPORT" \\
+  -summary "$SUMMARY" \\
+  -title "$TITLE" \\
+  ${report_args[*]}
+\`\`\`
+EOF
+
+echo "scaling report: $REPORT"
+echo "summary TSV: $SUMMARY"
+echo "bundle README: $README"

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -51,8 +51,8 @@ Options:
   --indexes N            Secondary index count. Default: 2.
   --batch-size N         Insert batch size. Default: 10000.
   --insert-producers N   Insert load producers. Default: 8.
-  --writers LIST         Space-separated concurrent writer counts. Default: "1 2 4 8 16".
-  --readers LIST         Space-separated concurrent reader counts. Default: "1 2 4 8 16".
+  --writers LIST         Quoted space-separated concurrent writer counts (for example: "1 2 4"). Default: "1 2 4 8 16".
+  --readers LIST         Quoted space-separated concurrent reader counts (for example: "1 2 4"). Default: "1 2 4 8 16".
   --concurrent-writes N  Total updates per writer-scaling cell. Default: 80000.
   --concurrent-reads N   Total reads per reader-scaling cell. Default: 80000.
   --include-mongo        Also run each cell against an external MongoDB URI.

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -67,7 +67,7 @@ Options:
 
 Environment overrides use the uppercase variable names shown in the script:
 OUT_DIR, DOCS, INDEXES, BATCH_SIZE, INSERT_PRODUCERS, WRITERS_LIST,
-READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO, MONGO_URI,
+READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1 or true/false), MONGO_URI,
 TREEDB_DOCUMENT_FORMAT, TREEDB_CLIENT_MODE, TREEDB_PROFILE,
 TREEDB_MAINTENANCE, TIMEOUT, TITLE, and related storage/pool settings.
 EOF
@@ -81,6 +81,24 @@ require_option_value() {
     usage >&2
     exit 2
   fi
+}
+
+normalize_bool_01() {
+  local name=$1
+  local value=$2
+  case "$value" in
+    1|true|TRUE|yes|YES)
+      printf '1'
+      ;;
+    0|false|FALSE|no|NO)
+      printf '0'
+      ;;
+    *)
+      echo "$name must be 0/1 or true/false; got: $value" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
 }
 
 while [[ $# -gt 0 ]]; do
@@ -226,6 +244,7 @@ if [[ "$PREBUILD_DOCUMENTS" != "true" && "$PREBUILD_DOCUMENTS" != "false" ]]; th
   echo "invalid PREBUILD_DOCUMENTS=$PREBUILD_DOCUMENTS (want true or false)" >&2
   exit 2
 fi
+INCLUDE_MONGO=$(normalize_bool_01 INCLUDE_MONGO "$INCLUDE_MONGO")
 
 mkdir -p "$OUT_DIR"
 OUT_DIR=$(cd "$OUT_DIR" && pwd -P)

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -73,41 +73,60 @@ TREEDB_MAINTENANCE, TIMEOUT, TITLE, and related storage/pool settings.
 EOF
 }
 
+require_option_value() {
+  local opt=$1
+  local value=${2-}
+  if [[ -z "$value" || "$value" == --* ]]; then
+    echo "missing value for $opt" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --out)
+      require_option_value "$1" "${2-}"
       OUT_DIR="$2"
       shift 2
       ;;
     --docs)
+      require_option_value "$1" "${2-}"
       DOCS="$2"
       shift 2
       ;;
     --indexes)
+      require_option_value "$1" "${2-}"
       INDEXES="$2"
       shift 2
       ;;
     --batch-size)
+      require_option_value "$1" "${2-}"
       BATCH_SIZE="$2"
       shift 2
       ;;
     --insert-producers)
+      require_option_value "$1" "${2-}"
       INSERT_PRODUCERS="$2"
       shift 2
       ;;
     --writers)
+      require_option_value "$1" "${2-}"
       WRITERS_LIST="$2"
       shift 2
       ;;
     --readers)
+      require_option_value "$1" "${2-}"
       READERS_LIST="$2"
       shift 2
       ;;
     --concurrent-writes)
+      require_option_value "$1" "${2-}"
       CONCURRENT_WRITES="$2"
       shift 2
       ;;
     --concurrent-reads)
+      require_option_value "$1" "${2-}"
       CONCURRENT_READS="$2"
       shift 2
       ;;
@@ -116,30 +135,37 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --mongo-uri)
+      require_option_value "$1" "${2-}"
       MONGO_URI="$2"
       shift 2
       ;;
     --treedb-format)
+      require_option_value "$1" "${2-}"
       TREEDB_DOCUMENT_FORMAT="$2"
       shift 2
       ;;
     --client-mode)
+      require_option_value "$1" "${2-}"
       TREEDB_CLIENT_MODE="$2"
       shift 2
       ;;
     --profile)
+      require_option_value "$1" "${2-}"
       TREEDB_PROFILE="$2"
       shift 2
       ;;
     --maintenance)
+      require_option_value "$1" "${2-}"
       TREEDB_MAINTENANCE="$2"
       shift 2
       ;;
     --timeout)
+      require_option_value "$1" "${2-}"
       TIMEOUT="$2"
       shift 2
       ;;
     --title)
+      require_option_value "$1" "${2-}"
       TITLE="$2"
       shift 2
       ;;

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -46,7 +46,7 @@ counts, writes raw mongo_gateway_bench JSON for every cell, and generates the
 standard mongo_gateway_compare_report Markdown/TSV output.
 
 Options:
-  --out DIR              Output directory. Default: mktemp under $TMPDIR or /tmp.
+  --out DIR              Output directory; if it exists, it must be empty. Default: mktemp under $TMPDIR or /tmp.
   --docs N               Document count. Default: 100000.
   --indexes N            Secondary index count. Default: 2.
   --batch-size N         Insert batch size. Default: 10000.
@@ -246,6 +246,10 @@ if [[ "$PREBUILD_DOCUMENTS" != "true" && "$PREBUILD_DOCUMENTS" != "false" ]]; th
 fi
 INCLUDE_MONGO=$(normalize_bool_01 INCLUDE_MONGO "$INCLUDE_MONGO")
 
+if [[ -d "$OUT_DIR" ]] && [[ -n "$(find "$OUT_DIR" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+  echo "output directory must be empty: $OUT_DIR" >&2
+  exit 2
+fi
 mkdir -p "$OUT_DIR"
 OUT_DIR=$(cd "$OUT_DIR" && pwd -P)
 RAW_DIR="$OUT_DIR/raw"

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -254,12 +254,12 @@ if [[ "$PREBUILD_DOCUMENTS" != "true" && "$PREBUILD_DOCUMENTS" != "false" ]]; th
 fi
 INCLUDE_MONGO=$(normalize_bool_01 INCLUDE_MONGO "$INCLUDE_MONGO")
 
-if [[ -d "$OUT_DIR" ]] && [[ -n "$(find "$OUT_DIR" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+mkdir -p "$OUT_DIR"
+OUT_DIR=$(cd "$OUT_DIR" && pwd -P)
+if [[ -n "$(find "$OUT_DIR" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
   echo "output directory must be empty: $OUT_DIR" >&2
   exit 2
 fi
-mkdir -p "$OUT_DIR"
-OUT_DIR=$(cd "$OUT_DIR" && pwd -P)
 RUN_ID=$(printf '%s' "$(basename "$OUT_DIR")" | tr -c '[:alnum:]_.-' '_')
 if [[ -z "$DATABASE_PREFIX" ]]; then
   DATABASE_PREFIX="mongo_gateway_scaling_${RUN_ID}"


### PR DESCRIPTION
## Summary
- add scripts/mongo_gateway_scaling_bench.sh for repeatable concurrent-reader and concurrent-writer sweeps
- reuse mongo_gateway_bench raw JSON plus mongo_gateway_compare_report output shape
- allow mongo_gateway_compare_report to render TreeDB-only matrices with -allow-incomplete, while preserving strict complete-cell behavior by default
- document the scaling workflow in cmd/mongo_gateway_bench/README.md

## Validation
- bash -n scripts/mongo_gateway_scaling_bench.sh
- go test ./cmd/mongo_gateway_compare_report -count 1
- go test ./cmd/mongo_gateway_compare_report ./cmd/mongo_gateway_bench -count 1
- OUT_DIR=$(mktemp -d /tmp/gomap_scaling_smoke_XXXXXX) DOCS=1000 INDEXES=1 BATCH_SIZE=250 INSERT_PRODUCERS=2 WRITERS_LIST="1" READERS_LIST="1" CONCURRENT_WRITES=20 CONCURRENT_READS=20 TIMEOUT=2m scripts/mongo_gateway_scaling_bench.sh
  - smoke report: /private/tmp/gomap_scaling_smoke_KgyTFI/report.md

## Stack
- Based on PR #1118
- PR #1118 -> PR #1117 -> PR #1116

This gives us a canonical way to produce the reader/writer scaling evidence requested for the next optimization passes.