### PR TITLE
[codex] Batch unique-safe collection updates

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3098,7 +3098,8 @@ func (c *Collection) UpdateBatchIfNoSecondaryUniqueIndexes(items []UpdateBatchIt
 // secondary unique index value changes in the planning snapshot. This lets the
 // write combiner batch updates that touch non-unique fields on schemas that
 // also have unique indexes, while preserving per-document fallback semantics
-// for unique value mutations.
+// for unique value mutations. When batched=false and err=nil, the returned
+// results are zero-valued with len(items).
 func (c *Collection) UpdateBatchIfNoSecondaryUniqueIndexChanges(items []UpdateBatchItem) ([]UpdateBatchResult, bool, error) {
 	return c.updateBatch(items, updateBatchModeNoSecondaryUniqueIndexChanges)
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4383,8 +4383,21 @@ func encodedIndexValueSetsEqual(left, right [][]byte) bool {
 	if len(left) != len(right) {
 		return false
 	}
-	for i := range left {
-		if !bytes.Equal(left[i], right[i]) {
+	if len(left) == 0 {
+		return true
+	}
+	used := make([]bool, len(right))
+	for _, leftValue := range left {
+		found := false
+		for i, rightValue := range right {
+			if used[i] || !bytes.Equal(leftValue, rightValue) {
+				continue
+			}
+			used[i] = true
+			found = true
+			break
+		}
+		if !found {
 			return false
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4386,18 +4386,19 @@ func encodedIndexValueSetsEqual(left, right [][]byte) bool {
 	if len(left) == 0 {
 		return true
 	}
-	used := make([]bool, len(right))
-	for _, leftValue := range left {
-		found := false
-		for i, rightValue := range right {
-			if used[i] || !bytes.Equal(leftValue, rightValue) {
-				continue
-			}
-			used[i] = true
-			found = true
-			break
-		}
-		if !found {
+	if len(left) == 1 {
+		return bytes.Equal(left[0], right[0])
+	}
+	leftSorted := append([][]byte(nil), left...)
+	rightSorted := append([][]byte(nil), right...)
+	sort.Slice(leftSorted, func(i, j int) bool {
+		return bytes.Compare(leftSorted[i], leftSorted[j]) < 0
+	})
+	sort.Slice(rightSorted, func(i, j int) bool {
+		return bytes.Compare(rightSorted[i], rightSorted[j]) < 0
+	})
+	for i := range leftSorted {
+		if !bytes.Equal(leftSorted[i], rightSorted[i]) {
 			return false
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4391,7 +4391,7 @@ func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []p
 		}
 		indexName := runtime.def.name
 		for _, update := range updates {
-			if !encodedIndexValueSetsEqual(update.oldState[indexName], update.newState[indexName]) {
+			if !normalizedEncodedIndexValuesEqual(update.oldState[indexName], update.newState[indexName]) {
 				return true
 			}
 		}
@@ -4399,26 +4399,12 @@ func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []p
 	return false
 }
 
-func encodedIndexValueSetsEqual(left, right [][]byte) bool {
+func normalizedEncodedIndexValuesEqual(left, right [][]byte) bool {
 	if len(left) != len(right) {
 		return false
 	}
-	if len(left) == 0 {
-		return true
-	}
-	if len(left) == 1 {
-		return bytes.Equal(left[0], right[0])
-	}
-	leftSorted := append([][]byte(nil), left...)
-	rightSorted := append([][]byte(nil), right...)
-	sort.Slice(leftSorted, func(i, j int) bool {
-		return bytes.Compare(leftSorted[i], leftSorted[j]) < 0
-	})
-	sort.Slice(rightSorted, func(i, j int) bool {
-		return bytes.Compare(rightSorted[i], rightSorted[j]) < 0
-	})
-	for i := range leftSorted {
-		if !bytes.Equal(leftSorted[i], rightSorted[i]) {
+	for i := range left {
+		if !bytes.Equal(left[i], right[i]) {
 			return false
 		}
 	}
@@ -4468,12 +4454,10 @@ func batchUniqueReplacementOwners(runtimes []indexRuntime, updates []preparedBat
 }
 
 func documentIndexStateContainsValue(values [][]byte, target []byte) bool {
-	for _, value := range values {
-		if bytes.Equal(value, target) {
-			return true
-		}
-	}
-	return false
+	i := sort.Search(len(values), func(i int) bool {
+		return bytes.Compare(values[i], target) >= 0
+	})
+	return i < len(values) && bytes.Equal(values[i], target)
 }
 
 func (s batchUniqueReplacementSet) allows(indexName string, encoded, documentID []byte) bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -48,12 +48,13 @@ var (
 	ErrUniqueIndexConflict = errors.New("collections: unique index conflict")
 	ErrConcurrentMutation  = errors.New("collections: concurrent mutation")
 
-	errCollectionManagerNil               = errors.New("collections: collection manager is nil")
-	errCollectionNil                      = errors.New("collections: collection is nil")
-	errCollectionDBNil                    = errors.New("collections: db is nil")
-	errCollectionNotFound                 = ErrCollectionNotFound
-	errUpdateBatchHasSecondaryUniqueIndex = errors.New("collections: update batch has secondary unique index")
-	errUpdateCombinerStopped              = errors.New("collections: update combiner stopped before DB update completed; callback may have been invoked")
+	errCollectionManagerNil                   = errors.New("collections: collection manager is nil")
+	errCollectionNil                          = errors.New("collections: collection is nil")
+	errCollectionDBNil                        = errors.New("collections: db is nil")
+	errCollectionNotFound                     = ErrCollectionNotFound
+	errUpdateBatchHasSecondaryUniqueIndex     = errors.New("collections: update batch has secondary unique index")
+	errUpdateBatchChangesSecondaryUniqueIndex = errors.New("collections: update batch changes secondary unique index")
+	errUpdateCombinerStopped                  = errors.New("collections: update combiner stopped before DB update completed; callback may have been invoked")
 )
 
 // UpdateBatchItem describes one document update in a batch. DocumentID must be
@@ -66,6 +67,14 @@ type UpdateBatchItem struct {
 	DocumentID []byte
 	Update     func(current []byte) (replacement []byte, changed bool, err error)
 }
+
+type updateBatchMode uint8
+
+const (
+	updateBatchModeAny updateBatchMode = iota
+	updateBatchModeNoSecondaryUniqueIndexes
+	updateBatchModeNoSecondaryUniqueIndexChanges
+)
 
 // UpdateBatchResult reports the outcome for one UpdateBatch item.
 type UpdateBatchResult struct {
@@ -3072,7 +3081,7 @@ func (c *Collection) updateDirect(documentID []byte, update func(current []byte)
 // rejected so callers that require same-document ordering can fall back to
 // sequential Update calls.
 func (c *Collection) UpdateBatch(items []UpdateBatchItem) ([]UpdateBatchResult, error) {
-	results, _, err := c.updateBatch(items, false)
+	results, _, err := c.updateBatch(items, updateBatchModeAny)
 	return results, err
 }
 
@@ -3082,10 +3091,19 @@ func (c *Collection) UpdateBatch(items []UpdateBatchItem) ([]UpdateBatchResult, 
 // present so callers can preserve ordered per-document update semantics. When
 // batched=false and err=nil, the returned results are zero-valued with len(items).
 func (c *Collection) UpdateBatchIfNoSecondaryUniqueIndexes(items []UpdateBatchItem) ([]UpdateBatchResult, bool, error) {
-	return c.updateBatch(items, true)
+	return c.updateBatch(items, updateBatchModeNoSecondaryUniqueIndexes)
 }
 
-func (c *Collection) updateBatch(items []UpdateBatchItem, requireNoSecondaryUniqueIndexes bool) ([]UpdateBatchResult, bool, error) {
+// UpdateBatchIfNoSecondaryUniqueIndexChanges applies UpdateBatch only when no
+// secondary unique index value changes in the planning snapshot. This lets the
+// write combiner batch updates that touch non-unique fields on schemas that
+// also have unique indexes, while preserving per-document fallback semantics
+// for unique value mutations.
+func (c *Collection) UpdateBatchIfNoSecondaryUniqueIndexChanges(items []UpdateBatchItem) ([]UpdateBatchResult, bool, error) {
+	return c.updateBatch(items, updateBatchModeNoSecondaryUniqueIndexChanges)
+}
+
+func (c *Collection) updateBatch(items []UpdateBatchItem, mode updateBatchMode) ([]UpdateBatchResult, bool, error) {
 	if c == nil {
 		return nil, false, errCollectionNil
 	}
@@ -3105,8 +3123,9 @@ func (c *Collection) updateBatch(items []UpdateBatchItem, requireNoSecondaryUniq
 
 	var lastErr error
 	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
-		results, err := c.updateBatchOnce(items, requireNoSecondaryUniqueIndexes)
-		if errors.Is(err, errUpdateBatchHasSecondaryUniqueIndex) {
+		results, err := c.updateBatchOnce(items, mode)
+		if errors.Is(err, errUpdateBatchHasSecondaryUniqueIndex) ||
+			errors.Is(err, errUpdateBatchChangesSecondaryUniqueIndex) {
 			return make([]UpdateBatchResult, len(items)), false, nil
 		}
 		if errors.Is(err, ErrConcurrentMutation) {
@@ -3474,7 +3493,7 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 			Update:     recoverCollectionUpdateCallback(req.update),
 		}
 	}
-	results, batched, err := batch[0].collection.UpdateBatchIfNoSecondaryUniqueIndexes(items)
+	results, batched, err := batch[0].collection.UpdateBatchIfNoSecondaryUniqueIndexChanges(items)
 	if !batched && err == nil {
 		for _, req := range batch {
 			completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
@@ -3921,14 +3940,14 @@ func (plan *updateBatchPlan) close() {
 	plan.deltaTables = nil
 }
 
-func (c *Collection) updateBatchOnce(items []UpdateBatchItem, requireNoSecondaryUniqueIndexes bool) ([]UpdateBatchResult, error) {
+func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMode) ([]UpdateBatchResult, error) {
 	if err := c.withMutationLock(func() error {
 		return c.flushBufferedWrites()
 	}); err != nil {
 		return nil, err
 	}
 
-	plan, err := c.buildUpdateBatchPlan(items, requireNoSecondaryUniqueIndexes)
+	plan, err := c.buildUpdateBatchPlan(items, mode)
 	if err != nil {
 		return nil, err
 	}
@@ -3970,7 +3989,7 @@ func (c *Collection) withMutationLock(fn func() error) error {
 	return fn()
 }
 
-func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, requireNoSecondaryUniqueIndexes bool) (*updateBatchPlan, error) {
+func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBatchMode) (*updateBatchPlan, error) {
 	results := make([]UpdateBatchResult, len(items))
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
@@ -3986,7 +4005,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, requireNoSeco
 		return nil, errCollectionNotFound
 	}
 	meta := catalog.meta
-	if requireNoSecondaryUniqueIndexes && collectionMetaHasSecondaryUniqueIndex(meta) {
+	if mode == updateBatchModeNoSecondaryUniqueIndexes && collectionMetaHasSecondaryUniqueIndex(meta) {
 		_ = snap.Close()
 		return nil, errUpdateBatchHasSecondaryUniqueIndex
 	}
@@ -4109,6 +4128,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, requireNoSeco
 			}
 			changed[i].indexStateChanged = !documentIndexStatesEqual(changed[i].oldState, changed[i].newState)
 		}
+	}
+	if mode == updateBatchModeNoSecondaryUniqueIndexChanges && updateBatchChangesSecondaryUniqueIndex(runtimes, changed) {
+		_ = snap.Close()
+		return nil, errUpdateBatchChangesSecondaryUniqueIndex
 	}
 	batchReplacements := batchUniqueReplacementOwners(runtimes, changed)
 	for i := range changed {
@@ -4336,6 +4359,36 @@ func rejectBatchUniqueConflicts(runtimes []indexRuntime, updates []preparedBatch
 		}
 	}
 	return nil
+}
+
+func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []preparedBatchUpdate) bool {
+	if len(runtimes) == 0 || len(updates) == 0 {
+		return false
+	}
+	for _, runtime := range runtimes {
+		if !runtime.def.unique {
+			continue
+		}
+		indexName := runtime.def.name
+		for _, update := range updates {
+			if !encodedIndexValueSetsEqual(update.oldState[indexName], update.newState[indexName]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func encodedIndexValueSetsEqual(left, right [][]byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if !bytes.Equal(left[i], right[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 type batchUniqueReplacementSet map[string]map[string]map[string]struct{}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4509,27 +4509,20 @@ func incrementJSONCount(current []byte) ([]byte, bool, error) {
 }
 
 func setJSONEmail(email string) func([]byte) ([]byte, bool, error) {
-	return func(current []byte) ([]byte, bool, error) {
-		var doc map[string]any
-		if err := json.Unmarshal(current, &doc); err != nil {
-			return nil, false, err
-		}
-		doc["email"] = email
-		next, err := json.Marshal(doc)
-		if err != nil {
-			return nil, false, err
-		}
-		return next, true, nil
-	}
+	return setJSONField("email", email)
 }
 
 func setJSONCity(city string) func([]byte) ([]byte, bool, error) {
+	return setJSONField("city", city)
+}
+
+func setJSONField(field string, value any) func([]byte) ([]byte, bool, error) {
 	return func(current []byte) ([]byte, bool, error) {
 		var doc map[string]any
 		if err := json.Unmarshal(current, &doc); err != nil {
 			return nil, false, err
 		}
-		doc["city"] = city
+		doc[field] = value
 		next, err := json.Marshal(doc)
 		if err != nil {
 			return nil, false, err

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3979,6 +3979,20 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesDeclinesUniqueUpdat
 	}
 }
 
+func TestEncodedIndexValueSetsEqualIgnoresOrder(t *testing.T) {
+	left := [][]byte{[]byte("s:b"), []byte("s:a")}
+	right := [][]byte{[]byte("s:a"), []byte("s:b")}
+	if !encodedIndexValueSetsEqual(left, right) {
+		t.Fatalf("encodedIndexValueSetsEqual(%q, %q)=false want true", left, right)
+	}
+	if encodedIndexValueSetsEqual(left, [][]byte{[]byte("s:a"), []byte("s:c")}) {
+		t.Fatal("encodedIndexValueSetsEqual matched different value sets")
+	}
+	if encodedIndexValueSetsEqual([][]byte{[]byte("s:a"), []byte("s:a")}, [][]byte{[]byte("s:a"), []byte("s:b")}) {
+		t.Fatal("encodedIndexValueSetsEqual ignored duplicate cardinality")
+	}
+}
+
 func TestCollectionUpdateBatchClonesAliasedReplacements(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3980,17 +3980,20 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesDeclinesUniqueUpdat
 	}
 }
 
-func TestEncodedIndexValueSetsEqualIgnoresOrder(t *testing.T) {
-	left := [][]byte{[]byte("s:b"), []byte("s:a")}
+func TestNormalizedEncodedIndexValuesEqualUsesCanonicalOrder(t *testing.T) {
+	left := [][]byte{[]byte("s:a"), []byte("s:b")}
 	right := [][]byte{[]byte("s:a"), []byte("s:b")}
-	if !encodedIndexValueSetsEqual(left, right) {
-		t.Fatalf("encodedIndexValueSetsEqual(%q, %q)=false want true", left, right)
+	if !normalizedEncodedIndexValuesEqual(left, right) {
+		t.Fatalf("normalizedEncodedIndexValuesEqual(%q, %q)=false want true", left, right)
 	}
-	if encodedIndexValueSetsEqual(left, [][]byte{[]byte("s:a"), []byte("s:c")}) {
-		t.Fatal("encodedIndexValueSetsEqual matched different value sets")
+	if normalizedEncodedIndexValuesEqual([][]byte{[]byte("s:b"), []byte("s:a")}, right) {
+		t.Fatal("normalizedEncodedIndexValuesEqual ignored canonical order")
 	}
-	if encodedIndexValueSetsEqual([][]byte{[]byte("s:a"), []byte("s:a")}, [][]byte{[]byte("s:a"), []byte("s:b")}) {
-		t.Fatal("encodedIndexValueSetsEqual ignored duplicate cardinality")
+	if normalizedEncodedIndexValuesEqual(left, [][]byte{[]byte("s:a"), []byte("s:c")}) {
+		t.Fatal("normalizedEncodedIndexValuesEqual matched different values")
+	}
+	if normalizedEncodedIndexValuesEqual([][]byte{[]byte("s:a"), []byte("s:a")}, right) {
+		t.Fatal("normalizedEncodedIndexValuesEqual ignored duplicate cardinality")
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2913,6 +2913,79 @@ func TestCollectionUpdateCombinerRunBatchPublishesDistinctIDsOnce(t *testing.T) 
 	}
 }
 
+func TestCollectionUpdateCombinerBatchesWhenSecondaryUniqueValuesAreUnchanged(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"a@example.com","city":"hnl"}`),
+			[]byte(`{"email":"b@example.com","city":"hnl"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	before := d.State()
+	combiner := &collectionUpdateCombiner{maxBatch: 8}
+	requests := []collectionUpdateCombineRequest{
+		{
+			collection: col,
+			documentID: []byte("u1"),
+			update:     setJSONCity("sea"),
+			done:       make(chan collectionUpdateCombineResult, 1),
+		},
+		{
+			collection: col,
+			documentID: []byte("u2"),
+			update:     setJSONCity("sfo"),
+			done:       make(chan collectionUpdateCombineResult, 1),
+		},
+	}
+	combiner.runBatch(requests)
+	for i, req := range requests {
+		result := <-req.done
+		if result.err != nil {
+			t.Fatalf("request %d err: %v", i, result.err)
+		}
+		if !result.matched || !result.modified {
+			t.Fatalf("request %d matched=%v modified=%v", i, result.matched, result.modified)
+		}
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("combined unique-schema batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("sea ids=%q want [u1]", seaIDs)
+	}
+}
+
 func TestCollectionUpdateCombinerRunBatchPreservesIndependentItemErrorOutcomes(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -3776,6 +3849,129 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexesDeclinesFreshUniqueCatal
 	}
 }
 
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesBatchesNonUniqueUpdates(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"a@example.com","city":"hnl"}`),
+			[]byte(`{"email":"b@example.com","city":"hnl"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	before := d.State()
+
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("sea")},
+		{DocumentID: []byte("u2"), Update: setJSONCity("sfo")},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatalf("batched=%v results=%+v want batched", batched, results)
+	}
+	if len(results) != 2 || !results[0].Matched || !results[0].Modified || !results[1].Matched || !results[1].Modified {
+		t.Fatalf("results=%+v want two modified rows", results)
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("sea ids=%q want [u1]", seaIDs)
+	}
+	emailIDs, err := col.FindByIndex("email", "a@example.com")
+	if err != nil {
+		t.Fatalf("find email: %v", err)
+	}
+	if len(emailIDs) != 1 || !bytes.Equal(emailIDs[0], []byte("u1")) {
+		t.Fatalf("email ids=%q want [u1]", emailIDs)
+	}
+}
+
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesDeclinesUniqueUpdates(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"email":"a@example.com"}`), []byte(`{"email":"b@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	before := d.State()
+
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONEmail("c@example.com")},
+		{DocumentID: []byte("u2"), Update: setJSONEmail("d@example.com")},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if batched {
+		t.Fatalf("batched=%v results=%+v want declined", batched, results)
+	}
+	if len(results) != 2 || results[0].Matched || results[0].Modified || results[1].Matched || results[1].Modified {
+		t.Fatalf("declined results=%+v want two zero-valued results", results)
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("declined unique update advanced commit seq by %d", after.CommitSeq-before.CommitSeq)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"email":"a@example.com"`)) {
+		t.Fatalf("u1 document=%s want unchanged email", got)
+	}
+}
+
 func TestCollectionUpdateBatchClonesAliasedReplacements(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -4298,6 +4494,21 @@ func setJSONEmail(email string) func([]byte) ([]byte, bool, error) {
 			return nil, false, err
 		}
 		doc["email"] = email
+		next, err := json.Marshal(doc)
+		if err != nil {
+			return nil, false, err
+		}
+		return next, true, nil
+	}
+}
+
+func setJSONCity(city string) func([]byte) ([]byte, bool, error) {
+	return func(current []byte) ([]byte, bool, error) {
+		var doc map[string]any
+		if err := json.Unmarshal(current, &doc); err != nil {
+			return nil, false, err
+		}
+		doc["city"] = city
 		next, err := json.Marshal(doc)
 		if err != nil {
 			return nil, false, err

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -365,6 +365,9 @@ func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem)
 }
 
 func runMongoUpdateBatchResults(col *collections.Collection, updates []mongoUpdateItem) ([]collections.UpdateBatchResult, bool, error) {
+	if !mongoUpdateItemsCanUseBatch(col, updates) {
+		return nil, false, nil
+	}
 	materializer, err := storedDocumentMaterializerForCollection(col)
 	if err != nil {
 		return nil, false, err
@@ -441,7 +444,7 @@ type mongoUpdateCoalescerResult struct {
 }
 
 func (s *Server) runMongoUpdateCoalesced(name string, col *collections.Collection, update mongoUpdateItem) (bool, bool, error) {
-	if mongoUpdateTouchesSecondaryUniqueIndex(col, update) {
+	if !mongoUpdateCanUseBatch(col, update) {
 		return runMongoUpdateOne(col, update)
 	}
 	coalescer := s.mongoUpdateCoalescer(name)
@@ -727,7 +730,7 @@ func (c *mongoUpdateCoalescer) runBatch(batch []mongoUpdateCoalescerRequest) {
 	if len(batch) == 1 ||
 		mongoUpdateCoalescerHasDuplicateKeys(batch) ||
 		!mongoUpdateCoalescerUsesSingleCollection(batch) ||
-		mongoUpdateBatchTouchesSecondaryUniqueIndex(batch) {
+		!mongoUpdateCoalescerBatchCanUseBatch(batch) {
 		runMongoUpdateCoalescerSequential(batch)
 		return
 	}
@@ -822,6 +825,19 @@ func mongoUpdateCoalescerUsesSingleCollection(batch []mongoUpdateCoalescerReques
 	return true
 }
 
+func mongoUpdateCoalescerBatchCanUseBatch(batch []mongoUpdateCoalescerRequest) bool {
+	if len(batch) == 0 || batch[0].col == nil {
+		return false
+	}
+	meta := batch[0].col.Meta()
+	for _, req := range batch {
+		if !mongoUpdateCanUseBatchMeta(meta, req.item) {
+			return false
+		}
+	}
+	return true
+}
+
 func runMongoUpdateCoalescerSequential(batch []mongoUpdateCoalescerRequest) {
 	for _, req := range batch {
 		matched, modified, err := runMongoUpdateOne(req.col, req.item)
@@ -829,34 +845,36 @@ func runMongoUpdateCoalescerSequential(batch []mongoUpdateCoalescerRequest) {
 	}
 }
 
-func mongoUpdateBatchTouchesSecondaryUniqueIndex(batch []mongoUpdateCoalescerRequest) bool {
-	if len(batch) == 0 || batch[0].col == nil {
-		return false
-	}
-	meta := batch[0].col.Meta()
-	for _, req := range batch {
-		if mongoUpdateTouchesSecondaryUniqueIndexMeta(meta, req.item) {
-			return true
-		}
-	}
-	return false
-}
-
-func mongoUpdateTouchesSecondaryUniqueIndex(col *collections.Collection, update mongoUpdateItem) bool {
+func mongoUpdateItemsCanUseBatch(col *collections.Collection, updates []mongoUpdateItem) bool {
 	if col == nil {
 		return false
 	}
-	return mongoUpdateTouchesSecondaryUniqueIndexMeta(col.Meta(), update)
+	meta := col.Meta()
+	for _, update := range updates {
+		if !mongoUpdateCanUseBatchMeta(meta, update) {
+			return false
+		}
+	}
+	return true
 }
 
-func mongoUpdateTouchesSecondaryUniqueIndexMeta(meta collections.CollectionMeta, update mongoUpdateItem) bool {
-	if !update.setFieldsOK {
-		for _, idx := range meta.Indexes {
-			if idx.Unique {
-				return true
-			}
-		}
+func mongoUpdateCanUseBatch(col *collections.Collection, update mongoUpdateItem) bool {
+	if col == nil {
 		return false
+	}
+	return mongoUpdateCanUseBatchMeta(col.Meta(), update)
+}
+
+func mongoUpdateCanUseBatchMeta(meta collections.CollectionMeta, update mongoUpdateItem) bool {
+	if !update.setFieldsOK {
+		return false
+	}
+	return !mongoUpdateSetFieldsTouchSecondaryUniqueIndexMeta(meta, update)
+}
+
+func mongoUpdateSetFieldsTouchSecondaryUniqueIndexMeta(meta collections.CollectionMeta, update mongoUpdateItem) bool {
+	if !update.setFieldsOK {
+		return true
 	}
 	for _, idx := range meta.Indexes {
 		if !idx.Unique {
@@ -882,7 +900,7 @@ func mongoSetUpdateFields(updateDoc wire.Document) (map[string]struct{}, bool) {
 	if !ok {
 		return nil, false
 	}
-	_, order, err := parseSetDocument(setDoc)
+	order, err := parseSetFieldNames(setDoc)
 	if err != nil {
 		return nil, false
 	}
@@ -2036,37 +2054,66 @@ func parseSetDocument(doc bson.Raw) (map[string]bson.RawValue, []string, error) 
 	if err != nil {
 		return nil, nil, err
 	}
+	order, err := parseSetFieldNamesFromElements(elements)
+	if err != nil {
+		return nil, nil, err
+	}
 	sets := make(map[string]bson.RawValue, len(elements))
-	order := make([]string, 0, len(elements))
-	seen := make(map[string]struct{}, len(elements))
 	for _, elem := range elements {
 		key, err := elem.KeyErr()
 		if err != nil {
 			return nil, nil, err
 		}
-		if key == "" {
-			return nil, nil, errors.New("Mongo gateway $set field name cannot be empty")
-		}
-		if key == "_id" {
-			return nil, nil, errors.New("Mongo gateway update cannot modify _id")
-		}
-		if strings.Contains(key, ".") {
-			return nil, nil, errors.New("Mongo gateway $set currently supports top-level fields only")
-		}
-		if strings.HasPrefix(key, "$") {
-			return nil, nil, errors.New("Mongo gateway $set field names cannot start with $")
-		}
 		value := elem.Value()
 		if err := validateSupportedValue(key, value); err != nil {
 			return nil, nil, err
+		}
+		sets[key] = value
+	}
+	return sets, order, nil
+}
+
+func parseSetFieldNames(doc bson.Raw) ([]string, error) {
+	elements, err := doc.Elements()
+	if err != nil {
+		return nil, err
+	}
+	return parseSetFieldNamesFromElements(elements)
+}
+
+func parseSetFieldNamesFromElements(elements []bson.RawElement) ([]string, error) {
+	order := make([]string, 0, len(elements))
+	seen := make(map[string]struct{}, len(elements))
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return nil, err
+		}
+		if err := validateSetFieldName(key); err != nil {
+			return nil, err
 		}
 		if _, ok := seen[key]; !ok {
 			order = append(order, key)
 			seen[key] = struct{}{}
 		}
-		sets[key] = value
 	}
-	return sets, order, nil
+	return order, nil
+}
+
+func validateSetFieldName(key string) error {
+	if key == "" {
+		return errors.New("Mongo gateway $set field name cannot be empty")
+	}
+	if key == "_id" {
+		return errors.New("Mongo gateway update cannot modify _id")
+	}
+	if strings.Contains(key, ".") {
+		return errors.New("Mongo gateway $set currently supports top-level fields only")
+	}
+	if strings.HasPrefix(key, "$") {
+		return errors.New("Mongo gateway $set field names cannot start with $")
+	}
+	return nil
 }
 
 func encodePrimaryKey(value bson.RawValue) ([]byte, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -830,8 +830,12 @@ func runMongoUpdateCoalescerSequential(batch []mongoUpdateCoalescerRequest) {
 }
 
 func mongoUpdateBatchTouchesSecondaryUniqueIndex(batch []mongoUpdateCoalescerRequest) bool {
+	if len(batch) == 0 || batch[0].col == nil {
+		return false
+	}
+	meta := batch[0].col.Meta()
 	for _, req := range batch {
-		if mongoUpdateTouchesSecondaryUniqueIndex(req.col, req.item) {
+		if mongoUpdateTouchesSecondaryUniqueIndexMeta(meta, req.item) {
 			return true
 		}
 	}
@@ -842,35 +846,27 @@ func mongoUpdateTouchesSecondaryUniqueIndex(col *collections.Collection, update 
 	if col == nil {
 		return false
 	}
-	uniqueFields := collectionSecondaryUniqueIndexFields(col)
-	if len(uniqueFields) == 0 {
+	return mongoUpdateTouchesSecondaryUniqueIndexMeta(col.Meta(), update)
+}
+
+func mongoUpdateTouchesSecondaryUniqueIndexMeta(meta collections.CollectionMeta, update mongoUpdateItem) bool {
+	if !update.setFieldsOK {
+		for _, idx := range meta.Indexes {
+			if idx.Unique {
+				return true
+			}
+		}
 		return false
 	}
-	if !update.setFieldsOK {
-		return true
-	}
-	for field := range update.setFields {
-		if _, unique := uniqueFields[field]; unique {
+	for _, idx := range meta.Indexes {
+		if !idx.Unique {
+			continue
+		}
+		if _, ok := update.setFields[idx.Field]; ok {
 			return true
 		}
 	}
 	return false
-}
-
-func collectionSecondaryUniqueIndexFields(col *collections.Collection) map[string]struct{} {
-	if col == nil {
-		return nil
-	}
-	out := make(map[string]struct{})
-	for _, idx := range col.Meta().Indexes {
-		if idx.Unique {
-			out[idx.Field] = struct{}{}
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
 }
 
 func mongoSetUpdateFields(updateDoc wire.Document) (map[string]struct{}, bool) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -240,9 +240,11 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 }
 
 type mongoUpdateItem struct {
-	index     int
-	key       []byte
-	updateDoc wire.Document
+	index       int
+	key         []byte
+	updateDoc   wire.Document
+	setFields   map[string]struct{}
+	setFieldsOK bool
 }
 
 type mongoUpdateParseError struct {
@@ -282,7 +284,8 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 	if err != nil {
 		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
 	}
-	return mongoUpdateItem{index: index, key: key, updateDoc: updateDoc}, nil
+	setFields, setFieldsOK := mongoSetUpdateFields(updateDoc)
+	return mongoUpdateItem{index: index, key: key, updateDoc: updateDoc, setFields: setFields, setFieldsOK: setFieldsOK}, nil
 }
 
 func mongoUpdateParseCommandError(err error) (wire.Document, error) {
@@ -379,7 +382,7 @@ func runMongoUpdateBatchResults(col *collections.Collection, updates []mongoUpda
 			},
 		}
 	}
-	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexes(items)
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges(items)
 	if !batched {
 		return nil, false, err
 	}
@@ -438,7 +441,7 @@ type mongoUpdateCoalescerResult struct {
 }
 
 func (s *Server) runMongoUpdateCoalesced(name string, col *collections.Collection, update mongoUpdateItem) (bool, bool, error) {
-	if collectionHasSecondaryUniqueIndexes(col) {
+	if mongoUpdateTouchesSecondaryUniqueIndex(col, update) {
 		return runMongoUpdateOne(col, update)
 	}
 	coalescer := s.mongoUpdateCoalescer(name)
@@ -724,7 +727,7 @@ func (c *mongoUpdateCoalescer) runBatch(batch []mongoUpdateCoalescerRequest) {
 	if len(batch) == 1 ||
 		mongoUpdateCoalescerHasDuplicateKeys(batch) ||
 		!mongoUpdateCoalescerUsesSingleCollection(batch) ||
-		collectionHasSecondaryUniqueIndexes(batch[0].col) {
+		mongoUpdateBatchTouchesSecondaryUniqueIndex(batch) {
 		runMongoUpdateCoalescerSequential(batch)
 		return
 	}
@@ -826,16 +829,72 @@ func runMongoUpdateCoalescerSequential(batch []mongoUpdateCoalescerRequest) {
 	}
 }
 
-func collectionHasSecondaryUniqueIndexes(col *collections.Collection) bool {
-	if col == nil {
-		return false
-	}
-	for _, idx := range col.Meta().Indexes {
-		if idx.Unique {
+func mongoUpdateBatchTouchesSecondaryUniqueIndex(batch []mongoUpdateCoalescerRequest) bool {
+	for _, req := range batch {
+		if mongoUpdateTouchesSecondaryUniqueIndex(req.col, req.item) {
 			return true
 		}
 	}
 	return false
+}
+
+func mongoUpdateTouchesSecondaryUniqueIndex(col *collections.Collection, update mongoUpdateItem) bool {
+	if col == nil {
+		return false
+	}
+	uniqueFields := collectionSecondaryUniqueIndexFields(col)
+	if len(uniqueFields) == 0 {
+		return false
+	}
+	if !update.setFieldsOK {
+		return true
+	}
+	for field := range update.setFields {
+		if _, unique := uniqueFields[field]; unique {
+			return true
+		}
+	}
+	return false
+}
+
+func collectionSecondaryUniqueIndexFields(col *collections.Collection) map[string]struct{} {
+	if col == nil {
+		return nil
+	}
+	out := make(map[string]struct{})
+	for _, idx := range col.Meta().Indexes {
+		if idx.Unique {
+			out[idx.Field] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func mongoSetUpdateFields(updateDoc wire.Document) (map[string]struct{}, bool) {
+	updateElements, err := bson.Raw(updateDoc).Elements()
+	if err != nil || len(updateElements) != 1 {
+		return nil, false
+	}
+	operator, err := updateElements[0].KeyErr()
+	if err != nil || operator != "$set" {
+		return nil, false
+	}
+	setDoc, ok := updateElements[0].Value().DocumentOK()
+	if !ok {
+		return nil, false
+	}
+	_, order, err := parseSetDocument(setDoc)
+	if err != nil {
+		return nil, false
+	}
+	out := make(map[string]struct{}, len(order))
+	for _, field := range order {
+		out[field] = struct{}{}
+	}
+	return out, true
 }
 
 func (s *Server) deleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -366,7 +366,7 @@ func runMongoUpdateBatch(col *collections.Collection, updates []mongoUpdateItem)
 
 func runMongoUpdateBatchResults(col *collections.Collection, updates []mongoUpdateItem) ([]collections.UpdateBatchResult, bool, error) {
 	if !mongoUpdateItemsCanUseBatch(col, updates) {
-		return nil, false, nil
+		return make([]collections.UpdateBatchResult, len(updates)), false, nil
 	}
 	materializer, err := storedDocumentMaterializerForCollection(col)
 	if err != nil {
@@ -387,7 +387,10 @@ func runMongoUpdateBatchResults(col *collections.Collection, updates []mongoUpda
 	}
 	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges(items)
 	if !batched {
-		return nil, false, err
+		if results == nil {
+			results = make([]collections.UpdateBatchResult, len(updates))
+		}
+		return results, false, err
 	}
 	if err != nil {
 		return nil, true, err

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -2054,19 +2054,24 @@ func parseSetDocument(doc bson.Raw) (map[string]bson.RawValue, []string, error) 
 	if err != nil {
 		return nil, nil, err
 	}
-	order, err := parseSetFieldNamesFromElements(elements)
-	if err != nil {
-		return nil, nil, err
-	}
+	order := make([]string, 0, len(elements))
+	seen := make(map[string]struct{}, len(elements))
 	sets := make(map[string]bson.RawValue, len(elements))
 	for _, elem := range elements {
 		key, err := elem.KeyErr()
 		if err != nil {
 			return nil, nil, err
 		}
+		if err := validateSetFieldName(key); err != nil {
+			return nil, nil, err
+		}
 		value := elem.Value()
 		if err := validateSupportedValue(key, value); err != nil {
 			return nil, nil, err
+		}
+		if _, ok := seen[key]; !ok {
+			order = append(order, key)
+			seen[key] = struct{}{}
 		}
 		sets[key] = value
 	}

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -709,6 +709,27 @@ func TestRunMongoUpdateBatchDeclinesFreshSecondaryUniqueIndex(t *testing.T) {
 	}
 }
 
+func TestRunMongoUpdateBatchResultsDeclineReturnsZeroResults(t *testing.T) {
+	results, batched, err := runMongoUpdateBatchResults(nil, []mongoUpdateItem{
+		{index: 0, key: []byte("u1")},
+		{index: 1, key: []byte("u2")},
+	})
+	if err != nil {
+		t.Fatalf("runMongoUpdateBatchResults: %v", err)
+	}
+	if batched {
+		t.Fatal("runMongoUpdateBatchResults batched with nil collection")
+	}
+	if len(results) != 2 {
+		t.Fatalf("results len=%d want 2", len(results))
+	}
+	for i, result := range results {
+		if result.Matched || result.Modified {
+			t.Fatalf("result[%d]=%+v want zero value", i, result)
+		}
+	}
+}
+
 func TestRunMongoUpdateBatchBatchesNonUniqueFieldWithSecondaryUniqueIndex(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -709,6 +709,71 @@ func TestRunMongoUpdateBatchDeclinesFreshSecondaryUniqueIndex(t *testing.T) {
 	}
 }
 
+func TestRunMongoUpdateBatchBatchesNonUniqueFieldWithSecondaryUniqueIndex(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mgr := collections.NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name: "app.users",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatBSON,
+		},
+		Indexes: []collections.IndexDefinition{
+			{Name: "email_1", Field: "email", Unique: true},
+			{Name: "city_1", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	id1, err := encodePrimaryKey(mustRawValue(t, "u1"))
+	if err != nil {
+		t.Fatalf("encode u1: %v", err)
+	}
+	id2, err := encodePrimaryKey(mustRawValue(t, "u2"))
+	if err != nil {
+		t.Fatalf("encode u2: %v", err)
+	}
+	doc1 := mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "email", Value: "a@example.com"}, {Key: "city", Value: "hnl"}})
+	doc2 := mustDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "email", Value: "b@example.com"}, {Key: "city", Value: "hnl"}})
+	if _, err := col.InsertBatchValidatedBSON([][]byte{id1, id2}, [][]byte{doc1, doc2}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	before := db.State()
+
+	matched, modified, batched, err := runMongoUpdateBatch(col, []mongoUpdateItem{
+		{index: 0, key: id1, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sea"}}}})},
+		{index: 1, key: id2, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sfo"}}}})},
+	})
+	if err != nil {
+		t.Fatalf("runMongoUpdateBatch: %v", err)
+	}
+	if !batched || matched != 2 || modified != 2 {
+		t.Fatalf("matched=%d modified=%d batched=%v want 2,2,true", matched, modified, batched)
+	}
+	after := db.State()
+	if after.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	}
+	ids, err := col.FindByIndex("city_1", "sea")
+	if err != nil {
+		t.Fatalf("find city sea: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], id1) {
+		t.Fatalf("sea ids=%q want [%q]", ids, id1)
+	}
+}
+
 func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterParseError(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -750,10 +750,21 @@ func TestRunMongoUpdateBatchBatchesNonUniqueFieldWithSecondaryUniqueIndex(t *tes
 		t.Fatalf("flush insert buffer: %v", err)
 	}
 	before := db.State()
+	buildUpdateItem := func(index int, id string, update bson.D) mongoUpdateItem {
+		t.Helper()
+		item, err := parseMongoUpdateItem(index, mustDocument(t, bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: id}}},
+			{Key: "u", Value: update},
+		}))
+		if err != nil {
+			t.Fatalf("parse update item: %v", err)
+		}
+		return item
+	}
 
 	matched, modified, batched, err := runMongoUpdateBatch(col, []mongoUpdateItem{
-		{index: 0, key: id1, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sea"}}}}), setFields: map[string]struct{}{"city": {}}, setFieldsOK: true},
-		{index: 1, key: id2, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sfo"}}}}), setFields: map[string]struct{}{"city": {}}, setFieldsOK: true},
+		buildUpdateItem(0, "u1", bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sea"}}}}),
+		buildUpdateItem(1, "u2", bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sfo"}}}}),
 	})
 	if err != nil {
 		t.Fatalf("runMongoUpdateBatch: %v", err)

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -752,8 +752,8 @@ func TestRunMongoUpdateBatchBatchesNonUniqueFieldWithSecondaryUniqueIndex(t *tes
 	before := db.State()
 
 	matched, modified, batched, err := runMongoUpdateBatch(col, []mongoUpdateItem{
-		{index: 0, key: id1, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sea"}}}})},
-		{index: 1, key: id2, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sfo"}}}})},
+		{index: 0, key: id1, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sea"}}}}), setFields: map[string]struct{}{"city": {}}, setFieldsOK: true},
+		{index: 1, key: id2, updateDoc: mustDocument(t, bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "sfo"}}}}), setFields: map[string]struct{}{"city": {}}, setFieldsOK: true},
 	})
 	if err != nil {
 		t.Fatalf("runMongoUpdateBatch: %v", err)
@@ -1175,6 +1175,53 @@ func TestServerUpdateCoalescedSkipsCoalescerForSecondaryUniqueIndex(t *testing.T
 	server.updateMu.Unlock()
 	if cached {
 		t.Fatal("secondary unique update created a coalescer")
+	}
+}
+
+func TestServerUpdateCoalescedSkipsCoalescerForUnrecognizedUpdateShape(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.UpdateCoalescingMaxDelay = 5 * time.Second
+	server.UpdateCoalescingMaxBatch = 2
+	assertOK(t, serveCommand(t, server, 2280, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(1)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	col, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	update, err := parseMongoUpdateItem(0, mustDocument(t, bson.D{
+		{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "u", Value: bson.D{{Key: "$inc", Value: bson.D{{Key: "score", Value: int32(1)}}}}},
+	}))
+	if err != nil {
+		t.Fatalf("parse update: %v", err)
+	}
+	if update.setFieldsOK {
+		t.Fatal("test update unexpectedly parsed as $set")
+	}
+	matched, modified, err := server.runMongoUpdateCoalesced("app.users", col, update)
+	if err == nil {
+		t.Fatal("runMongoUpdateCoalesced succeeded for unsupported $inc update")
+	}
+	if matched || modified {
+		t.Fatalf("matched=%v modified=%v want false,false", matched, modified)
+	}
+	server.updateMu.Lock()
+	_, cached := server.updateCoalescers["app.users"]
+	server.updateMu.Unlock()
+	if cached {
+		t.Fatal("unrecognized update shape created a coalescer")
 	}
 }
 


### PR DESCRIPTION
## Summary

Allows collection and Mongo gateway update batching on schemas that have secondary unique indexes when the planned updates leave all secondary unique index values unchanged.

This keeps unique-value mutations on the existing ordered/direct fallback path, but lets the common two-index shape (`email` unique + `city` nonunique) coalesce `$set` updates to `city`. The Mongo gateway unique-index gate is now field-aware and uses the parsed `$set` field list cached on `mongoUpdateItem`.

## Correctness notes

- `UpdateBatchIfNoSecondaryUniqueIndexes` keeps the old catalog-level behavior.
- New `UpdateBatchIfNoSecondaryUniqueIndexChanges` plans the batch, declines without publishing if any secondary unique value changes, and otherwise publishes one batch.
- Mongo gateway coalescing still runs ordered/direct for updates that touch a secondary unique indexed field or have an unrecognized update shape.

## Validation

- `go test ./TreeDB/collections -run 'TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChanges|TestCollectionUpdateBatchIfNoSecondaryUniqueIndexes|TestCollectionUpdateCombiner(BatchesWhenSecondaryUniqueValuesAreUnchanged|RunBatchPublishesDistinctIDsOnce)' -count 1`
- `go test ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench ./cmd/mongo_gateway_compare_report -count 1`

## Benchmarks

Direct collection concurrent update benchmark, 100k preload docs, BSON, 2 indexes, 8 writers, 80k updates:

| branch | ns/op | docs/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| PR 1120 head (`b08819cb10`) | 67,049 | 14,914 | 27,900 | 148 |
| this PR (`7a149c7c62`) | 29,430 | 33,979 | 26,237 | 100 |

Command:

```sh
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=10000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=80000x \
  -count=1
```

Mongo gateway driver-command-raw benchmark, 100k preload docs, BSON, 2 indexes, `-update-indexed-field`, 8 concurrent writers, 80k updates:

| branch | update ops/sec | p50 | p95 | p99 | final publish calls |
| --- | ---: | ---: | ---: | ---: | ---: |
| PR 1120 head (`b08819cb10`) | 1,987 | 3,899 us | 4,616 us | 8,244 us | 80,004 |
| this PR (`7a149c7c62`) | 5,286 | 1,381 us | 1,836 us | 3,715 us | 21,230 |

Head command:

```sh
go run ./cmd/mongo_gateway_bench \
  -target treedb \
  -database unique_safe_head2 \
  -collection docs \
  -documents 100000 \
  -batch-size 10000 \
  -insert-producers 8 \
  -prebuild-documents \
  -secondary-indexes 2 \
  -concurrent-writers 8 \
  -concurrent-writes 80000 \
  -concurrent-readers 0 \
  -concurrent-reads 0 \
  -reads 0 \
  -range-reads 0 \
  -updates 0 \
  -deletes 0 \
  -treedb-profile wal_on_fast \
  -treedb-document-format bson \
  -client-mode driver-command-raw \
  -treedb-data-root-storage compressed \
  -treedb-index-state-root-storage compressed \
  -treedb-index-root-storage compressed \
  -treedb-maintenance none \
  -update-indexed-field \
  -treedb-dir /private/tmp/gomap_unique_safe_gateway_head2_1777642757 \
  -keep-treedb-dir \
  -format json
```

Scaling matrix on this PR (`UPDATE_INDEXED_FIELD=true`, 100k docs, 2 BSON indexes, batch size 10k, 40k ops/cell):

| phase | wall ops/sec | p95 |
| --- | ---: | ---: |
| writers_1 | 1,927 | 590 us |
| writers_2 | 2,103 | 1,189 us |
| writers_4 | 3,357 | 1,329 us |
| writers_8 | 5,135 | 1,937 us |
| readers_1 | 16,893 | 63 us |
| readers_2 | 28,796 | 97 us |
| readers_4 | 41,417 | 155 us |
| readers_8 | 54,312 | 233 us |

Scaling output: `/private/tmp/gomap_unique_safe_scaling_head_1777642624/report.md`

## pprof note

Profiled gateway w8 update run: `/private/tmp/gomap_unique_safe_gateway_head_profiles_1777642514`.

`go tool pprof -top` on `concurrent_id_update_set_w8.cpu.pprof` still shows the remaining dominant work in grouped root publish/zipper and value-log leaf reads:

- `collections.(*Collection).UpdateBatchIfNoSecondaryUniqueIndexChanges`: 6.72s cumulative
- `collections.(*Collection).publishUpdateBatchPlanLocked`: 5.93s cumulative
- `zipper.(*Zipper).mergeInternal`: 10.70s cumulative
- `valuelog.(*File).readGroupedCompressedFromFileTo`: 5.12s cumulative

So this PR reduces publish count substantially; the next deeper target is still native staged update/delete memtables or a shorter root-publish critical path.
