### PR TITLE
[codex] Make buffered index overlays tombstone-aware

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5379,6 +5379,9 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	return collectMergedCollectionIndexIDs(bufferedIt, persistedIt, prefix, maxResults)
 }
 
+// bufferedIndexTableLocked materializes the buffered overlay for one secondary
+// index prefix while domain.mu is held. The returned pooled table is owned by
+// the caller and must be released with resetCollectionRunTable.
 func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte, maxResults int) (memtable.Table, error) {
 	if domain == nil {
 		return nil, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5338,10 +5338,20 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err != nil {
 		return nil, false, err
 	}
-	bufferedRuns := bufferedIndexRunsLocked(domain, catalog.meta.Name, indexName)
+	bufferedTable, err := bufferedIndexTableLocked(domain, catalog.meta.Name, indexName, prefix)
+	if err != nil {
+		return nil, false, err
+	}
+	if domainLocked {
+		domain.mu.RUnlock()
+		domainLocked = false
+	}
+	if bufferedTable != nil {
+		defer resetCollectionRunTable(bufferedTable)
+	}
 	var bufferedIt iterator.UnsafeIterator
-	if len(bufferedRuns) > 0 {
-		bufferedIt = newBufferedRootRunsIteratorWithDeleted(bufferedRuns, prefix, prefixEnd(prefix), true)
+	if bufferedTable != nil {
+		bufferedIt = bufferedTable.NewIterator(prefix, prefixEnd(prefix))
 		defer func() { _ = bufferedIt.Close() }()
 	}
 	rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
@@ -5359,17 +5369,45 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	return collectMergedCollectionIndexIDs(bufferedIt, persistedIt, prefix, maxResults)
 }
 
-func bufferedIndexRunsLocked(domain *collectionWriteDomain, collectionName, indexName string) []memtable.Table {
+func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte) (memtable.Table, error) {
 	if domain == nil {
-		return nil
+		return nil, nil
 	}
 	if domain.count == 0 || len(domain.rootRuns) == 0 {
-		return nil
+		return nil, nil
 	}
 	if domain.meta.Name != "" {
 		collectionName = domain.meta.Name
 	}
-	return append([]memtable.Table(nil), domain.rootRuns[collectionSecondaryRootName(collectionName, indexName)]...)
+	runs := domain.rootRuns[collectionSecondaryRootName(collectionName, indexName)]
+	if len(runs) == 0 {
+		return nil, nil
+	}
+	table := newCollectionRunTable(0)
+	it := newBufferedRootRunsIteratorWithDeleted(runs, prefix, prefixEnd(prefix), true)
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		key := it.UnsafeKey()
+		if !bytes.HasPrefix(key, prefix) {
+			break
+		}
+		if it.IsDeleted() {
+			table.DeleteSteal(bytes.Clone(key))
+		} else {
+			setCollectionRunValue(table, bytes.Clone(key), nil)
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		resetCollectionRunTable(table)
+		return nil, err
+	}
+	if table.Len() == 0 {
+		resetCollectionRunTable(table)
+		return nil, nil
+	}
+	table.Freeze()
+	return table, nil
 }
 
 func collectMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIterator, prefix []byte, maxResults int) ([][]byte, bool, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5400,7 +5400,9 @@ func collectMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIter
 		}
 		switch {
 		case !bufferedOK:
-			appendID(persistedID)
+			if !persistedIt.IsDeleted() {
+				appendID(persistedID)
+			}
 			persistedIt.Next()
 		case !persistedOK:
 			if !bufferedIt.IsDeleted() {
@@ -5415,7 +5417,9 @@ func collectMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIter
 				}
 				bufferedIt.Next()
 			} else if cmp > 0 {
-				appendID(persistedID)
+				if !persistedIt.IsDeleted() {
+					appendID(persistedID)
+				}
 				persistedIt.Next()
 			} else {
 				if !bufferedIt.IsDeleted() {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5380,6 +5380,10 @@ func collectMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIter
 	capHint := 1
 	if limit > 0 {
 		capHint = limit
+		const maxInitialCap = 1024
+		if capHint > maxInitialCap {
+			capHint = maxInitialCap
+		}
 	}
 	out := make([][]byte, 0, capHint)
 	appendID := func(id []byte) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1939,7 +1939,7 @@ func newBufferedRootRunsIterator(runs []memtable.Table, start, end []byte) itera
 }
 
 func newBufferedRootRunsIteratorWithDeleted(runs []memtable.Table, start, end []byte, includeDeleted bool) iterator.UnsafeIterator {
-	if len(runs) == 1 && includeDeleted {
+	if len(runs) == 1 && includeDeleted && runs[0] != nil {
 		return runs[0].NewIterator(start, end)
 	}
 	it := &bufferedRootRunsIterator{
@@ -5369,7 +5369,7 @@ func bufferedIndexRunsLocked(domain *collectionWriteDomain, collectionName, inde
 	if domain.meta.Name != "" {
 		collectionName = domain.meta.Name
 	}
-	return domain.rootRuns[collectionSecondaryRootName(collectionName, indexName)]
+	return append([]memtable.Table(nil), domain.rootRuns[collectionSecondaryRootName(collectionName, indexName)]...)
 }
 
 func collectMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIterator, prefix []byte, maxResults int) ([][]byte, bool, error) {
@@ -5377,7 +5377,7 @@ func collectMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIter
 	if maxResults > 0 && maxResults < int(^uint(0)>>1) {
 		limit = maxResults + 1
 	}
-	capHint := 1
+	capHint := 16
 	if limit > 0 {
 		capHint = limit
 		const maxInitialCap = 1024

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -28,6 +28,7 @@ import (
 const (
 	collectionMetaVersion        = 1
 	maxCollectionMutationRetries = 64
+	maxCollectionInt             = int(^uint(0) >> 1)
 
 	// DefaultIndexedWriteMemtableMaxDocuments bounds the native indexed
 	// collection write-domain before it auto-flushes to persistent roots.
@@ -1735,8 +1736,7 @@ func bufferedPrimaryIDArenaCap(entries int) int {
 		return 0
 	}
 	const bytesPerKeyEstimate = 16
-	maxInt := int(^uint(0) >> 1)
-	if entries > maxInt/bytesPerKeyEstimate {
+	if entries > maxCollectionInt/bytesPerKeyEstimate {
 		return 0
 	}
 	return entries * bytesPerKeyEstimate
@@ -1793,9 +1793,8 @@ func rejectBufferedUniqueIndexConflicts(indexName string, pendingIndex *buffered
 
 func bufferedUniqueIndexValueRun(batchIndex memtable.Table) (memtable.Table, [][]byte, error) {
 	table := newCollectionRunTable(max(0, batchIndex.Len()))
-	maxInt := int(^uint(0) >> 1)
 	arenaCap := batchIndex.Size()
-	if arenaCap < 0 || arenaCap > int64(maxInt) {
+	if arenaCap < 0 || arenaCap > int64(maxCollectionInt) {
 		arenaCap = 0
 	}
 	arena := make([]byte, 0, int(arenaCap))
@@ -5379,7 +5378,7 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	return collectMergedCollectionIndexIDs(bufferedIt, persistedIt, prefix, maxResults)
 }
 
-// bufferedIndexTableLocked materializes the buffered overlay for one secondary
+// bufferedIndexTableLocked materializes buffered entries for one secondary
 // index prefix while domain.mu is held. The returned pooled table is owned by
 // the caller and must be released with resetCollectionRunTable.
 func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte, maxResults int) (memtable.Table, error) {
@@ -5397,10 +5396,7 @@ func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, ind
 		return nil, nil
 	}
 	table := newCollectionRunTable(0)
-	liveLimit := 0
-	if maxResults > 0 && maxResults < int(^uint(0)>>1) {
-		liveLimit = maxResults + 1
-	}
+	liveLimit := collectionLimitedResultSentinel(maxResults)
 	liveCount := 0
 	it := newBufferedRootRunsIteratorWithDeleted(runs, prefix, prefixEnd(prefix), true)
 	defer func() { _ = it.Close() }()
@@ -5433,10 +5429,7 @@ func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, ind
 }
 
 func collectMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIterator, prefix []byte, maxResults int) ([][]byte, bool, error) {
-	limit := 0
-	if maxResults > 0 && maxResults < int(^uint(0)>>1) {
-		limit = maxResults + 1
-	}
+	limit := collectionLimitedResultSentinel(maxResults)
 	capHint := 16
 	if limit > 0 {
 		capHint = limit
@@ -5502,6 +5495,13 @@ func collectMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIter
 		truncated = true
 	}
 	return out, truncated, nil
+}
+
+func collectionLimitedResultSentinel(maxResults int) int {
+	if maxResults <= 0 || maxResults >= maxCollectionInt {
+		return 0
+	}
+	return maxResults + 1
 }
 
 func collectionIndexIteratorID(it iterator.UnsafeIterator, prefix []byte) ([]byte, bool) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5348,7 +5348,7 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err != nil {
 		return nil, false, err
 	}
-	bufferedTable, err := bufferedIndexTableLocked(domain, catalog.meta.Name, indexName, prefix)
+	bufferedTable, err := bufferedIndexTableLocked(domain, catalog.meta.Name, indexName, prefix, maxResults)
 	if err != nil {
 		return nil, false, err
 	}
@@ -5379,7 +5379,7 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	return collectMergedCollectionIndexIDs(bufferedIt, persistedIt, prefix, maxResults)
 }
 
-func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte) (memtable.Table, error) {
+func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte, maxResults int) (memtable.Table, error) {
 	if domain == nil {
 		return nil, nil
 	}
@@ -5394,6 +5394,11 @@ func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, ind
 		return nil, nil
 	}
 	table := newCollectionRunTable(0)
+	liveLimit := 0
+	if maxResults > 0 && maxResults < int(^uint(0)>>1) {
+		liveLimit = maxResults + 1
+	}
+	liveCount := 0
 	it := newBufferedRootRunsIteratorWithDeleted(runs, prefix, prefixEnd(prefix), true)
 	defer func() { _ = it.Close() }()
 	for it.Valid() {
@@ -5405,6 +5410,10 @@ func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, ind
 			table.DeleteSteal(bytes.Clone(key))
 		} else {
 			setCollectionRunValue(table, bytes.Clone(key), nil)
+			liveCount++
+			if liveLimit > 0 && liveCount >= liveLimit {
+				break
+			}
 		}
 		it.Next()
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1939,7 +1939,7 @@ func newBufferedRootRunsIterator(runs []memtable.Table, start, end []byte) itera
 }
 
 func newBufferedRootRunsIteratorWithDeleted(runs []memtable.Table, start, end []byte, includeDeleted bool) iterator.UnsafeIterator {
-	if len(runs) == 1 {
+	if len(runs) == 1 && includeDeleted {
 		return runs[0].NewIterator(start, end)
 	}
 	it := &bufferedRootRunsIterator{
@@ -5337,196 +5337,120 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err != nil {
 		return nil, false, err
 	}
-	buffered, err := c.bufferedIndexOverlayLocked(domain, catalog.meta.Name, indexName, prefix)
-	if err != nil {
-		return nil, false, err
-	}
-	if domainLocked {
-		domain.mu.RUnlock()
-		domainLocked = false
+	bufferedRuns := bufferedIndexRunsLocked(domain, catalog.meta.Name, indexName)
+	var bufferedIt iterator.UnsafeIterator
+	if len(bufferedRuns) > 0 {
+		bufferedIt = newBufferedRootRunsIteratorWithDeleted(bufferedRuns, prefix, prefixEnd(prefix), true)
+		defer func() { _ = bufferedIt.Close() }()
 	}
 	rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
-	if rootID == 0 {
-		out, truncated := mergeCollectionIndexIDResults(buffered.liveIDs, nil, buffered.deletedIDs, maxResults, buffered.truncated, false)
-		return out, truncated, nil
+	var persistedIt iterator.UnsafeIterator
+	if rootID != 0 {
+		it, err := snap.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
+		if err != nil && !errors.Is(err, tree.ErrKeyNotFound) {
+			return nil, false, err
+		}
+		if err == nil {
+			persistedIt = it
+			defer func() { _ = persistedIt.Close() }()
+		}
 	}
-	collectLimit := collectionIndexReadCollectLimit(maxResults)
-	if collectLimit > 0 && len(buffered.deletedIDs) > 0 {
-		collectLimit = saturatingIndexCollectLimit(maxResults, len(buffered.deletedIDs))
-	}
-	it, err := snap.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
-	if errors.Is(err, tree.ErrKeyNotFound) {
-		out, truncated := mergeCollectionIndexIDResults(buffered.liveIDs, nil, buffered.deletedIDs, maxResults, buffered.truncated, false)
-		return out, truncated, nil
-	}
-	if err != nil {
-		return nil, false, err
-	}
-	defer func() { _ = it.Close() }()
-	persistedIDs, persistedTruncated, err := collectCollectionIndexIDsFromIterator(it, prefix, collectLimit)
-	if err != nil {
-		return nil, false, err
-	}
-	out, truncated := mergeCollectionIndexIDResults(buffered.liveIDs, persistedIDs, buffered.deletedIDs, maxResults, buffered.truncated, persistedTruncated)
-	return out, truncated, nil
+	return collectMergedCollectionIndexIDs(bufferedIt, persistedIt, prefix, maxResults)
 }
 
-func collectionIndexReadCollectLimit(maxResults int) int {
-	if maxResults <= 0 {
-		return 0
-	}
-	if maxResults == int(^uint(0)>>1) {
-		return 0
-	}
-	return maxResults + 1
-}
-
-func saturatingIndexCollectLimit(maxResults, deletedIDs int) int {
-	if maxResults <= 0 || maxResults == int(^uint(0)>>1) {
-		return 0
-	}
-	maxInt := int(^uint(0) >> 1)
-	if deletedIDs >= maxInt-maxResults {
-		return 0
-	}
-	limit := maxResults + deletedIDs
-	if limit == maxInt {
-		return 0
-	}
-	return limit + 1
-}
-
-type collectionIndexIDOverlay struct {
-	liveIDs    [][]byte
-	deletedIDs [][]byte
-	truncated  bool
-}
-
-func (c *Collection) bufferedIndexOverlayLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte) (collectionIndexIDOverlay, error) {
-	if c == nil || domain == nil {
-		return collectionIndexIDOverlay{}, nil
+func bufferedIndexRunsLocked(domain *collectionWriteDomain, collectionName, indexName string) []memtable.Table {
+	if domain == nil {
+		return nil
 	}
 	if domain.count == 0 || len(domain.rootRuns) == 0 {
-		return collectionIndexIDOverlay{}, nil
+		return nil
 	}
 	if domain.meta.Name != "" {
 		collectionName = domain.meta.Name
 	}
-	runs := domain.rootRuns[collectionSecondaryRootName(collectionName, indexName)]
-	if len(runs) == 0 {
-		return collectionIndexIDOverlay{}, nil
-	}
-	it := newBufferedRootRunsIteratorWithDeleted(runs, prefix, prefixEnd(prefix), true)
-	defer func() { _ = it.Close() }()
-	liveIDs, deletedIDs, err := collectCollectionIndexIDOverlayFromIterator(it, prefix)
-	return collectionIndexIDOverlay{liveIDs: liveIDs, deletedIDs: deletedIDs}, err
+	return domain.rootRuns[collectionSecondaryRootName(collectionName, indexName)]
 }
 
-func collectCollectionIndexIDsFromIterator(it iterator.UnsafeIterator, prefix []byte, limit int) ([][]byte, bool, error) {
-	if it == nil {
-		return nil, false, nil
+func collectMergedCollectionIndexIDs(bufferedIt, persistedIt iterator.UnsafeIterator, prefix []byte, maxResults int) ([][]byte, bool, error) {
+	limit := 0
+	if maxResults > 0 && maxResults < int(^uint(0)>>1) {
+		limit = maxResults + 1
 	}
-	out := make([][]byte, 0, 1)
-	truncated := false
-	for it.Valid() {
-		key := it.UnsafeKey()
-		if !bytes.HasPrefix(key, prefix) {
-			break
-		}
-		if !it.IsDeleted() {
-			if limit > 0 && len(out) >= limit {
-				truncated = true
-				break
-			}
-			out = append(out, bytes.Clone(key[len(prefix):]))
-		}
-		it.Next()
+	capHint := 1
+	if limit > 0 {
+		capHint = limit
 	}
-	if err := it.Error(); err != nil {
-		return nil, false, err
-	}
-	return out, truncated, nil
-}
-
-func collectCollectionIndexIDOverlayFromIterator(it iterator.UnsafeIterator, prefix []byte) ([][]byte, [][]byte, error) {
-	if it == nil {
-		return nil, nil, nil
-	}
-	liveIDs := make([][]byte, 0, 1)
-	var deletedIDs [][]byte
-	for it.Valid() {
-		key := it.UnsafeKey()
-		if !bytes.HasPrefix(key, prefix) {
-			break
-		}
-		id := bytes.Clone(key[len(prefix):])
-		if it.IsDeleted() {
-			deletedIDs = append(deletedIDs, id)
-		} else {
-			liveIDs = append(liveIDs, id)
-		}
-		it.Next()
-	}
-	if err := it.Error(); err != nil {
-		return nil, nil, err
-	}
-	return liveIDs, deletedIDs, nil
-}
-
-func mergeCollectionIndexIDResults(bufferedIDs, persistedIDs, deletedIDs [][]byte, maxResults int, bufferedTruncated, persistedTruncated bool) ([][]byte, bool) {
-	total := len(bufferedIDs) + len(persistedIDs)
-	limit := collectionIndexReadCollectLimit(maxResults)
-	if limit > 0 && total > limit {
-		total = limit
-	}
-	out := make([][]byte, 0, total)
-	truncated := bufferedTruncated || persistedTruncated
-	i, j := 0, 0
+	out := make([][]byte, 0, capHint)
 	appendID := func(id []byte) {
 		if len(out) > 0 && bytes.Equal(out[len(out)-1], id) {
 			return
 		}
-		out = append(out, id)
+		out = append(out, bytes.Clone(id))
 	}
-	for (i < len(bufferedIDs) || j < len(persistedIDs)) && (limit == 0 || len(out) < limit) {
+	for limit == 0 || len(out) < limit {
+		bufferedID, bufferedOK := collectionIndexIteratorID(bufferedIt, prefix)
+		persistedID, persistedOK := collectionIndexIteratorID(persistedIt, prefix)
+		if !bufferedOK && !persistedOK {
+			break
+		}
 		switch {
-		case i >= len(bufferedIDs):
-			if !collectionIndexIDDeleted(deletedIDs, persistedIDs[j]) {
-				appendID(persistedIDs[j])
+		case !bufferedOK:
+			appendID(persistedID)
+			persistedIt.Next()
+		case !persistedOK:
+			if !bufferedIt.IsDeleted() {
+				appendID(bufferedID)
 			}
-			j++
-		case j >= len(persistedIDs):
-			appendID(bufferedIDs[i])
-			i++
+			bufferedIt.Next()
 		default:
-			cmp := bytes.Compare(bufferedIDs[i], persistedIDs[j])
+			cmp := bytes.Compare(bufferedID, persistedID)
 			if cmp < 0 {
-				appendID(bufferedIDs[i])
-				i++
-			} else if cmp > 0 {
-				if !collectionIndexIDDeleted(deletedIDs, persistedIDs[j]) {
-					appendID(persistedIDs[j])
+				if !bufferedIt.IsDeleted() {
+					appendID(bufferedID)
 				}
-				j++
+				bufferedIt.Next()
+			} else if cmp > 0 {
+				appendID(persistedID)
+				persistedIt.Next()
 			} else {
-				appendID(bufferedIDs[i])
-				i++
-				j++
+				if !bufferedIt.IsDeleted() {
+					appendID(bufferedID)
+				}
+				bufferedIt.Next()
+				persistedIt.Next()
 			}
 		}
 	}
+	if err := collectionIndexIteratorError(bufferedIt); err != nil {
+		return nil, false, err
+	}
+	if err := collectionIndexIteratorError(persistedIt); err != nil {
+		return nil, false, err
+	}
+	truncated := false
 	if maxResults > 0 && len(out) > maxResults {
 		out = out[:maxResults]
 		truncated = true
 	}
-	return out, truncated
+	return out, truncated, nil
 }
 
-func collectionIndexIDDeleted(deletedIDs [][]byte, id []byte) bool {
-	i := sort.Search(len(deletedIDs), func(i int) bool {
-		return bytes.Compare(deletedIDs[i], id) >= 0
-	})
-	return i < len(deletedIDs) && bytes.Equal(deletedIDs[i], id)
+func collectionIndexIteratorID(it iterator.UnsafeIterator, prefix []byte) ([]byte, bool) {
+	if it == nil || !it.Valid() {
+		return nil, false
+	}
+	key := it.UnsafeKey()
+	if !bytes.HasPrefix(key, prefix) {
+		return nil, false
+	}
+	return key[len(prefix):], true
+}
+
+func collectionIndexIteratorError(it iterator.UnsafeIterator) error {
+	if it == nil {
+		return nil
+	}
+	return it.Error()
 }
 
 // ScanDocuments flushes buffered writes before acquiring a snapshot, then scans

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1922,25 +1922,31 @@ func (h *bufferedRootRunHeap) down(i0, n int) bool {
 }
 
 type bufferedRootRunsIterator struct {
-	iters    []iterator.UnsafeIterator
-	heap     bufferedRootRunHeap
-	cur      bufferedRootRunHeapItem
-	hasCur   bool
-	valid    bool
-	start    []byte
-	end      []byte
-	closed   bool
-	firstErr error
+	iters          []iterator.UnsafeIterator
+	heap           bufferedRootRunHeap
+	cur            bufferedRootRunHeapItem
+	hasCur         bool
+	valid          bool
+	includeDeleted bool
+	start          []byte
+	end            []byte
+	closed         bool
+	firstErr       error
 }
 
 func newBufferedRootRunsIterator(runs []memtable.Table, start, end []byte) iterator.UnsafeIterator {
+	return newBufferedRootRunsIteratorWithDeleted(runs, start, end, false)
+}
+
+func newBufferedRootRunsIteratorWithDeleted(runs []memtable.Table, start, end []byte, includeDeleted bool) iterator.UnsafeIterator {
 	if len(runs) == 1 {
 		return runs[0].NewIterator(start, end)
 	}
 	it := &bufferedRootRunsIterator{
-		iters: make([]iterator.UnsafeIterator, 0, len(runs)),
-		start: start,
-		end:   end,
+		iters:          make([]iterator.UnsafeIterator, 0, len(runs)),
+		includeDeleted: includeDeleted,
+		start:          start,
+		end:            end,
 	}
 	for i, run := range runs {
 		if run == nil {
@@ -2105,7 +2111,7 @@ func (it *bufferedRootRunsIterator) advance() {
 			shadowed := it.heap.pop()
 			it.advanceItem(shadowed)
 		}
-		if it.iters[top.idx].IsDeleted() {
+		if !it.includeDeleted && it.iters[top.idx].IsDeleted() {
 			it.advanceItem(top)
 			continue
 		}
@@ -5331,8 +5337,7 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err != nil {
 		return nil, false, err
 	}
-	collectLimit := collectionIndexReadCollectLimit(maxResults)
-	bufferedIDs, bufferedTruncated, err := c.bufferedIndexIDsLocked(domain, catalog.meta.Name, indexName, prefix, collectLimit)
+	buffered, err := c.bufferedIndexOverlayLocked(domain, catalog.meta.Name, indexName, prefix)
 	if err != nil {
 		return nil, false, err
 	}
@@ -5340,19 +5345,18 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 		domain.mu.RUnlock()
 		domainLocked = false
 	}
-	// Buffered indexed writes currently stage inserts only. Primary conflict
-	// checks reject IDs that already exist in pending or persisted roots, so
-	// buffered secondary IDs cannot duplicate persisted secondary IDs. If update
-	// or delete staging is added here, this merge must account for pending
-	// tombstones before returning persisted rows.
 	rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
 	if rootID == 0 {
-		out, truncated := mergeCollectionIndexIDResults(bufferedIDs, nil, maxResults, bufferedTruncated, false)
+		out, truncated := mergeCollectionIndexIDResults(buffered.liveIDs, nil, buffered.deletedIDs, maxResults, buffered.truncated, false)
 		return out, truncated, nil
+	}
+	collectLimit := collectionIndexReadCollectLimit(maxResults)
+	if collectLimit > 0 && len(buffered.deletedIDs) > 0 {
+		collectLimit = saturatingIndexCollectLimit(maxResults, len(buffered.deletedIDs))
 	}
 	it, err := snap.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
 	if errors.Is(err, tree.ErrKeyNotFound) {
-		out, truncated := mergeCollectionIndexIDResults(bufferedIDs, nil, maxResults, bufferedTruncated, false)
+		out, truncated := mergeCollectionIndexIDResults(buffered.liveIDs, nil, buffered.deletedIDs, maxResults, buffered.truncated, false)
 		return out, truncated, nil
 	}
 	if err != nil {
@@ -5363,7 +5367,7 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err != nil {
 		return nil, false, err
 	}
-	out, truncated := mergeCollectionIndexIDResults(bufferedIDs, persistedIDs, maxResults, bufferedTruncated, persistedTruncated)
+	out, truncated := mergeCollectionIndexIDResults(buffered.liveIDs, persistedIDs, buffered.deletedIDs, maxResults, buffered.truncated, persistedTruncated)
 	return out, truncated, nil
 }
 
@@ -5377,23 +5381,45 @@ func collectionIndexReadCollectLimit(maxResults int) int {
 	return maxResults + 1
 }
 
-func (c *Collection) bufferedIndexIDsLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte, limit int) ([][]byte, bool, error) {
+func saturatingIndexCollectLimit(maxResults, deletedIDs int) int {
+	if maxResults <= 0 || maxResults == int(^uint(0)>>1) {
+		return 0
+	}
+	maxInt := int(^uint(0) >> 1)
+	if deletedIDs >= maxInt-maxResults {
+		return 0
+	}
+	limit := maxResults + deletedIDs
+	if limit == maxInt {
+		return 0
+	}
+	return limit + 1
+}
+
+type collectionIndexIDOverlay struct {
+	liveIDs    [][]byte
+	deletedIDs [][]byte
+	truncated  bool
+}
+
+func (c *Collection) bufferedIndexOverlayLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte) (collectionIndexIDOverlay, error) {
 	if c == nil || domain == nil {
-		return nil, false, nil
+		return collectionIndexIDOverlay{}, nil
 	}
 	if domain.count == 0 || len(domain.rootRuns) == 0 {
-		return nil, false, nil
+		return collectionIndexIDOverlay{}, nil
 	}
 	if domain.meta.Name != "" {
 		collectionName = domain.meta.Name
 	}
 	runs := domain.rootRuns[collectionSecondaryRootName(collectionName, indexName)]
 	if len(runs) == 0 {
-		return nil, false, nil
+		return collectionIndexIDOverlay{}, nil
 	}
-	it := newBufferedRootRunsIterator(runs, prefix, prefixEnd(prefix))
+	it := newBufferedRootRunsIteratorWithDeleted(runs, prefix, prefixEnd(prefix), true)
 	defer func() { _ = it.Close() }()
-	return collectCollectionIndexIDsFromIterator(it, prefix, limit)
+	liveIDs, deletedIDs, err := collectCollectionIndexIDOverlayFromIterator(it, prefix)
+	return collectionIndexIDOverlay{liveIDs: liveIDs, deletedIDs: deletedIDs}, err
 }
 
 func collectCollectionIndexIDsFromIterator(it iterator.UnsafeIterator, prefix []byte, limit int) ([][]byte, bool, error) {
@@ -5422,7 +5448,32 @@ func collectCollectionIndexIDsFromIterator(it iterator.UnsafeIterator, prefix []
 	return out, truncated, nil
 }
 
-func mergeCollectionIndexIDResults(bufferedIDs, persistedIDs [][]byte, maxResults int, bufferedTruncated, persistedTruncated bool) ([][]byte, bool) {
+func collectCollectionIndexIDOverlayFromIterator(it iterator.UnsafeIterator, prefix []byte) ([][]byte, [][]byte, error) {
+	if it == nil {
+		return nil, nil, nil
+	}
+	liveIDs := make([][]byte, 0, 1)
+	var deletedIDs [][]byte
+	for it.Valid() {
+		key := it.UnsafeKey()
+		if !bytes.HasPrefix(key, prefix) {
+			break
+		}
+		id := bytes.Clone(key[len(prefix):])
+		if it.IsDeleted() {
+			deletedIDs = append(deletedIDs, id)
+		} else {
+			liveIDs = append(liveIDs, id)
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return nil, nil, err
+	}
+	return liveIDs, deletedIDs, nil
+}
+
+func mergeCollectionIndexIDResults(bufferedIDs, persistedIDs, deletedIDs [][]byte, maxResults int, bufferedTruncated, persistedTruncated bool) ([][]byte, bool) {
 	total := len(bufferedIDs) + len(persistedIDs)
 	limit := collectionIndexReadCollectLimit(maxResults)
 	if limit > 0 && total > limit {
@@ -5440,7 +5491,9 @@ func mergeCollectionIndexIDResults(bufferedIDs, persistedIDs [][]byte, maxResult
 	for (i < len(bufferedIDs) || j < len(persistedIDs)) && (limit == 0 || len(out) < limit) {
 		switch {
 		case i >= len(bufferedIDs):
-			appendID(persistedIDs[j])
+			if !collectionIndexIDDeleted(deletedIDs, persistedIDs[j]) {
+				appendID(persistedIDs[j])
+			}
 			j++
 		case j >= len(persistedIDs):
 			appendID(bufferedIDs[i])
@@ -5451,7 +5504,9 @@ func mergeCollectionIndexIDResults(bufferedIDs, persistedIDs [][]byte, maxResult
 				appendID(bufferedIDs[i])
 				i++
 			} else if cmp > 0 {
-				appendID(persistedIDs[j])
+				if !collectionIndexIDDeleted(deletedIDs, persistedIDs[j]) {
+					appendID(persistedIDs[j])
+				}
 				j++
 			} else {
 				appendID(bufferedIDs[i])
@@ -5465,6 +5520,13 @@ func mergeCollectionIndexIDResults(bufferedIDs, persistedIDs [][]byte, maxResult
 		truncated = true
 	}
 	return out, truncated
+}
+
+func collectionIndexIDDeleted(deletedIDs [][]byte, id []byte) bool {
+	i := sort.Search(len(deletedIDs), func(i int) bool {
+		return bytes.Compare(deletedIDs[i], id) >= 0
+	})
+	return i < len(deletedIDs) && bytes.Equal(deletedIDs[i], id)
 }
 
 // ScanDocuments flushes buffered writes before acquiring a snapshot, then scans

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1940,6 +1940,34 @@ func TestBufferedRootRunsIteratorSingleRunHidesTombstones(t *testing.T) {
 	}
 }
 
+func TestCollectMergedCollectionIndexIDsSkipsPersistedTombstones(t *testing.T) {
+	encoded, err := encodeIndexScalar("hnl")
+	if err != nil {
+		t.Fatalf("encode city: %v", err)
+	}
+	_, prefix, err := appendIndexValuePrefixSlice(nil, encoded)
+	if err != nil {
+		t.Fatalf("index prefix: %v", err)
+	}
+	key, err := indexEntryKey(encoded, []byte("u1"))
+	if err != nil {
+		t.Fatalf("index key: %v", err)
+	}
+	table := newCollectionRunTable(1)
+	table.DeleteSteal(key)
+	table.Freeze()
+	it := table.NewIterator(prefix, prefixEnd(prefix))
+	defer func() { _ = it.Close() }()
+
+	ids, truncated, err := collectMergedCollectionIndexIDs(nil, it, prefix, 1)
+	if err != nil {
+		t.Fatalf("collect merged ids: %v", err)
+	}
+	if truncated || len(ids) != 0 {
+		t.Fatalf("ids=%q truncated=%v want empty/false", ids, truncated)
+	}
+}
+
 func TestCollectionFindByIndexValueLimitMaxIntDoesNotOverflow(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1858,6 +1858,88 @@ func TestCollectionIndexedWriteMemtablesFindSkipsBufferedSecondaryTombstone(t *t
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesFindLimitFiltersOnlyBufferedTombstone(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert persisted row: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush persisted row: %v", err)
+	}
+
+	encoded, err := encodeIndexScalar("hnl")
+	if err != nil {
+		t.Fatalf("encode city: %v", err)
+	}
+	key, err := indexEntryKey(encoded, []byte("u1"))
+	if err != nil {
+		t.Fatalf("index key: %v", err)
+	}
+	table := newCollectionRunTable(1)
+	table.DeleteSteal(key)
+	table.Freeze()
+	domain := col.writeDomain
+	domain.mu.Lock()
+	domain.count = 1
+	domain.meta = col.Meta()
+	domain.rootRuns = map[string][]memtable.Table{
+		collectionSecondaryRootName("users", "city"): {table},
+	}
+	domain.mu.Unlock()
+
+	ids, truncated, err := col.FindByIndexValueLimit("city", "hnl", 1)
+	if err != nil {
+		t.Fatalf("find limited city: %v", err)
+	}
+	if truncated || len(ids) != 0 {
+		t.Fatalf("limited ids=%q truncated=%v want empty/false", ids, truncated)
+	}
+}
+
+func TestBufferedRootRunsIteratorSingleRunHidesTombstones(t *testing.T) {
+	table := newCollectionRunTable(2)
+	table.DeleteSteal([]byte("a"))
+	setCollectionRunValue(table, []byte("b"), []byte("value"))
+	table.Freeze()
+
+	it := newBufferedRootRunsIterator([]memtable.Table{table}, nil, nil)
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		t.Fatal("iterator invalid, want live key b")
+	}
+	if got := it.UnsafeKey(); !bytes.Equal(got, []byte("b")) {
+		t.Fatalf("first key=%q want b", got)
+	}
+	it.Next()
+	if it.Valid() {
+		t.Fatalf("iterator has extra key %q", it.UnsafeKey())
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+}
+
 func TestCollectionFindByIndexValueLimitMaxIntDoesNotOverflow(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1917,6 +1917,49 @@ func TestCollectionIndexedWriteMemtablesFindLimitFiltersOnlyBufferedTombstone(t 
 	}
 }
 
+func TestBufferedIndexTableLockedLimitsLiveMaterialization(t *testing.T) {
+	encoded, err := encodeIndexScalar("hnl")
+	if err != nil {
+		t.Fatalf("encode city: %v", err)
+	}
+	_, prefix, err := appendIndexValuePrefixSlice(nil, encoded)
+	if err != nil {
+		t.Fatalf("index prefix: %v", err)
+	}
+	table := newCollectionRunTable(4)
+	for _, id := range [][]byte{[]byte("u0"), []byte("u1"), []byte("u2"), []byte("u3")} {
+		key, err := indexEntryKey(encoded, id)
+		if err != nil {
+			t.Fatalf("index key %q: %v", id, err)
+		}
+		if bytes.Equal(id, []byte("u0")) {
+			table.DeleteSteal(key)
+		} else {
+			setCollectionRunValue(table, key, nil)
+		}
+	}
+	table.Freeze()
+	domain := &collectionWriteDomain{
+		count: 4,
+		meta:  CollectionMeta{Name: "users"},
+		rootRuns: map[string][]memtable.Table{
+			collectionSecondaryRootName("users", "city"): {table},
+		},
+	}
+
+	buffered, err := bufferedIndexTableLocked(domain, "users", "city", prefix, 1)
+	if err != nil {
+		t.Fatalf("buffered index table: %v", err)
+	}
+	defer resetCollectionRunTable(buffered)
+	if buffered == nil {
+		t.Fatal("buffered index table nil")
+	}
+	if got := buffered.Len(); got != 3 {
+		t.Fatalf("buffered table len=%d want tombstone plus two live rows", got)
+	}
+}
+
 func TestBufferedRootRunsIteratorSingleRunHidesTombstones(t *testing.T) {
 	table := newCollectionRunTable(2)
 	table.DeleteSteal([]byte("a"))

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1824,7 +1824,7 @@ func TestCollectionIndexedWriteMemtablesFindSkipsBufferedSecondaryTombstone(t *t
 	}
 	table := newCollectionRunTable(2)
 	table.DeleteSteal(oldKey)
-	table.SetSteal(newKey, nil)
+	setCollectionRunValue(table, newKey, nil)
 	table.Freeze()
 	domain := col.writeDomain
 	domain.mu.Lock()

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1940,6 +1940,32 @@ func TestBufferedRootRunsIteratorSingleRunHidesTombstones(t *testing.T) {
 	}
 }
 
+func TestBufferedRootRunsIteratorSingleRunIncludesTombstones(t *testing.T) {
+	table := newCollectionRunTable(2)
+	table.DeleteSteal([]byte("a"))
+	setCollectionRunValue(table, []byte("b"), []byte("value"))
+	table.Freeze()
+
+	it := newBufferedRootRunsIteratorWithDeleted([]memtable.Table{table}, nil, nil, true)
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		t.Fatal("iterator invalid, want tombstone key a")
+	}
+	if got := it.UnsafeKey(); !bytes.Equal(got, []byte("a")) || !it.IsDeleted() {
+		t.Fatalf("first key=%q deleted=%v want tombstone a", got, it.IsDeleted())
+	}
+	it.Next()
+	if !it.Valid() {
+		t.Fatal("iterator missing live key b")
+	}
+	if got := it.UnsafeKey(); !bytes.Equal(got, []byte("b")) || it.IsDeleted() {
+		t.Fatalf("second key=%q deleted=%v want live b", got, it.IsDeleted())
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+}
+
 func TestCollectMergedCollectionIndexIDsSkipsPersistedTombstones(t *testing.T) {
 	encoded, err := encodeIndexScalar("hnl")
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1966,6 +1966,48 @@ func TestBufferedRootRunsIteratorSingleRunIncludesTombstones(t *testing.T) {
 	}
 }
 
+func TestBufferedRootRunsIteratorMultiRunIncludesNewestTombstone(t *testing.T) {
+	older := newCollectionRunTable(2)
+	setCollectionRunValue(older, []byte("a"), []byte("older"))
+	setCollectionRunValue(older, []byte("b"), []byte("older"))
+	older.Freeze()
+
+	newer := newCollectionRunTable(2)
+	newer.DeleteSteal([]byte("a"))
+	setCollectionRunValue(newer, []byte("c"), []byte("newer"))
+	newer.Freeze()
+
+	it := newBufferedRootRunsIteratorWithDeleted([]memtable.Table{older, newer}, nil, nil, true)
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		t.Fatal("iterator invalid, want tombstone key a")
+	}
+	if got := it.UnsafeKey(); !bytes.Equal(got, []byte("a")) || !it.IsDeleted() {
+		t.Fatalf("first key=%q deleted=%v want newest tombstone a", got, it.IsDeleted())
+	}
+	it.Next()
+	if !it.Valid() {
+		t.Fatal("iterator missing live key b")
+	}
+	if got := it.UnsafeKey(); !bytes.Equal(got, []byte("b")) || it.IsDeleted() {
+		t.Fatalf("second key=%q deleted=%v want live b", got, it.IsDeleted())
+	}
+	it.Next()
+	if !it.Valid() {
+		t.Fatal("iterator missing live key c")
+	}
+	if got := it.UnsafeKey(); !bytes.Equal(got, []byte("c")) || it.IsDeleted() {
+		t.Fatalf("third key=%q deleted=%v want live c", got, it.IsDeleted())
+	}
+	it.Next()
+	if it.Valid() {
+		t.Fatalf("iterator has extra key %q", it.UnsafeKey())
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+}
+
 func TestCollectMergedCollectionIndexIDsSkipsPersistedTombstones(t *testing.T) {
 	encoded, err := encodeIndexScalar("hnl")
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -17,6 +17,7 @@ import (
 
 	treedb "github.com/snissn/gomap/TreeDB"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -1772,6 +1773,88 @@ func TestCollectionIndexedWriteMemtablesFindLimitMergesBufferedAndPersistedOrder
 	}
 	if len(ids) != 2 || !bytes.Equal(ids[0], []byte("u0")) || !bytes.Equal(ids[1], []byte("u1")) {
 		t.Fatalf("merged ids=%q want [u0 u1]", ids)
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesFindSkipsBufferedSecondaryTombstone(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"city":"hnl"}`), []byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert persisted rows: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush persisted rows: %v", err)
+	}
+
+	oldEncoded, err := encodeIndexScalar("hnl")
+	if err != nil {
+		t.Fatalf("encode old city: %v", err)
+	}
+	oldKey, err := indexEntryKey(oldEncoded, []byte("u1"))
+	if err != nil {
+		t.Fatalf("old index key: %v", err)
+	}
+	newEncoded, err := encodeIndexScalar("sea")
+	if err != nil {
+		t.Fatalf("encode new city: %v", err)
+	}
+	newKey, err := indexEntryKey(newEncoded, []byte("u1"))
+	if err != nil {
+		t.Fatalf("new index key: %v", err)
+	}
+	table := newCollectionRunTable(2)
+	table.DeleteSteal(oldKey)
+	table.SetSteal(newKey, nil)
+	table.Freeze()
+	domain := col.writeDomain
+	domain.mu.Lock()
+	domain.count = 1
+	domain.meta = col.Meta()
+	domain.rootRuns = map[string][]memtable.Table{
+		collectionSecondaryRootName("users", "city"): {table},
+	}
+	domain.mu.Unlock()
+
+	ids, err := col.FindByIndexValue("city", "hnl")
+	if err != nil {
+		t.Fatalf("find old city: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
+		t.Fatalf("old city ids=%q want [u2]", ids)
+	}
+	ids, truncated, err := col.FindByIndexValueLimit("city", "hnl", 1)
+	if err != nil {
+		t.Fatalf("find old city limited: %v", err)
+	}
+	if truncated || len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
+		t.Fatalf("limited old city ids=%q truncated=%v want [u2]/false", ids, truncated)
+	}
+	ids, err = col.FindByIndexValue("city", "sea")
+	if err != nil {
+		t.Fatalf("find new city: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("new city ids=%q want [u1]", ids)
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes collection buffered secondary-index reads account for pending tombstones before merging with persisted index rows. This is groundwork for native staged update/delete memtables: once secondary index updates are staged in the collection write domain, queries for the old secondary value must not return persisted rows hidden by a buffered tombstone.

## Details

- Adds a buffered root-run iterator mode that can surface tombstones instead of always hiding them.
- Streams buffered secondary-index rows as live entries and tombstones, preserving production collection-run encoding for synthetic rows.
- For limited reads, streams buffered and persisted rows together until it has the requested result count plus a truncation sentinel, so tombstoned persisted rows cannot cause short or misleading results.
- Filters duplicate/tombstoned secondary IDs during the merge without materializing all buffered live rows for limited reads.

## Validation

```sh
go test ./TreeDB/collections -run 'TestCollectionIndexedWriteMemtablesFindSkipsBufferedSecondaryTombstone|TestCollectionFindByIndexValueLimitMaxIntDoesNotOverflow|TestBufferedIndexTableLockedLimitsLiveMaterialization' -count 1
go test ./TreeDB/collections -count 1
```
