### PR TITLE
[codex] Stage safe collection update batches

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4371,11 +4371,21 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if modifiedCount == 0 {
 		return false, nil
 	}
+	hasDeltaTable := false
+	for _, table := range plan.deltaTables {
+		if table != nil && table.Len() > 0 {
+			hasDeltaTable = true
+			break
+		}
+	}
+	if !hasDeltaTable {
+		return false, errors.New("collections: UpdateBatch modified rows without delta tables")
+	}
 	domain := c.writeDomain
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	if domain.count != 0 {
-		return false, nil
+		return false, ErrConcurrentMutation
 	}
 	if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
 		return false, err

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2182,7 +2182,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
 	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
 	for _, rootName := range rootNames {
-		iter := newBufferedRootRunsIterator(domain.rootRuns[rootName], nil, nil)
+		iter := newBufferedRootRunsIteratorWithDeleted(domain.rootRuns[rootName], nil, nil, true)
 		iterators = append(iterators, iter)
 		baseRoot := domain.rootBaseIDs[rootName]
 		baseRootIDs[rootName] = baseRoot
@@ -3932,6 +3932,7 @@ type updateBatchPlan struct {
 	baseRootIDs    map[string]uint64
 	policies       []backenddb.OrderedRootStoragePolicy
 	deltaTables    []memtable.Table
+	bufferSafe     bool
 }
 
 func (plan *updateBatchPlan) close() {
@@ -3979,10 +3980,18 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 
 	var results []UpdateBatchResult
 	err = c.withMutationLock(func() error {
+		buffered, bufferErr := c.bufferUpdateBatchPlanLocked(plan)
+		if bufferErr != nil {
+			return bufferErr
+		}
+		if buffered {
+			results = plan.results
+			return nil
+		}
+		var publishErr error
 		if err := c.flushBufferedWrites(); err != nil {
 			return err
 		}
-		var publishErr error
 		results, publishErr = c.publishUpdateBatchPlanLocked(plan)
 		return publishErr
 	})
@@ -4015,6 +4024,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, errUpdateBatchHasSecondaryUniqueIndex
 	}
+	bufferSafe := len(meta.Indexes) > 0 &&
+		(!collectionMetaHasSecondaryUniqueIndex(meta) ||
+			mode == updateBatchModeNoSecondaryUniqueIndexes ||
+			mode == updateBatchModeNoSecondaryUniqueIndexChanges)
 	plannerOptions, err := collectionPlannerOptions(meta)
 	if err != nil {
 		_ = snap.Close()
@@ -4288,6 +4301,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		baseCommitSeq:  baseCommitSeq,
 		rootNames:      rootNames,
 		baseRootIDs:    baseRootIDs,
+		bufferSafe:     bufferSafe,
 		policies:       policies,
 		deltaTables:    deltaTables,
 	}, nil
@@ -4341,6 +4355,89 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	return plan.results, nil
+}
+
+func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, error) {
+	if c == nil || plan == nil || len(plan.deltaTables) == 0 {
+		return false, nil
+	}
+	if c.writeDomain == nil || !plan.bufferSafe || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
+		return false, nil
+	}
+	if len(plan.rootNames) != len(plan.deltaTables) || len(plan.rootNames) != len(plan.policies) {
+		return false, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
+	}
+	modifiedCount := updateBatchModifiedCount(plan.results)
+	if modifiedCount == 0 {
+		return false, nil
+	}
+	domain := c.writeDomain
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	if domain.count != 0 {
+		return false, nil
+	}
+	if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
+		return false, err
+	}
+	if plan.catalog != nil {
+		c.initializeWriteDomainFromCatalogLocked(domain, plan.catalog, plan.baseCommitSeq, plan.baseSystemRoot)
+	}
+	if domain.rootPolicies == nil {
+		domain.rootPolicies = make(map[string]backenddb.OrderedRootStoragePolicy, len(plan.rootNames))
+	}
+	if domain.rootBaseIDs == nil {
+		domain.rootBaseIDs = make(map[string]uint64, len(plan.rootNames))
+	}
+	if domain.rootRuns == nil {
+		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
+	}
+	var stagedBytes int64
+	for i, rootName := range plan.rootNames {
+		baseRoot, ok := plan.baseRootIDs[rootName]
+		if !ok {
+			return false, fmt.Errorf("collections: UpdateBatch collection %q plan missing base root for %q", plan.meta.Name, rootName)
+		}
+		table := plan.deltaTables[i]
+		if table == nil || table.Len() == 0 {
+			continue
+		}
+		if len(domain.rootRuns[rootName]) == 0 {
+			domain.rootBaseIDs[rootName] = baseRoot
+		}
+		domain.rootPolicies[rootName] = plan.policies[i]
+		domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)
+		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, table.Size())
+		plan.deltaTables[i] = nil
+	}
+	plan.deltaTables = nil
+	domain.loaded = true
+	domain.meta = plan.meta
+	domain.catalog = plan.catalog
+	domain.baseCommitSeq = plan.baseCommitSeq
+	domain.baseSystemRoot = plan.baseSystemRoot
+	if plan.catalog != nil {
+		domain.primaryRoot = plan.catalog.rootID(collectionPrimaryRootName(plan.meta.Name))
+	}
+	domain.count += modifiedCount
+	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
+	c.meta = plan.meta
+	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
+		if err := c.flushBufferedIndexedLocked(domain); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func updateBatchModifiedCount(results []UpdateBatchResult) int {
+	count := 0
+	for _, result := range results {
+		if result.Modified {
+			count++
+		}
+	}
+	return count
 }
 
 func rejectBatchUniqueConflicts(runtimes []indexRuntime, updates []preparedBatchUpdate) error {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -356,6 +356,12 @@ type noIndexBatchEntry struct {
 }
 
 type bufferedIndexedCheckpoint struct {
+	loaded          bool
+	meta            CollectionMeta
+	catalog         *collectionCatalog
+	baseCommitSeq   uint64
+	baseSystemRoot  uint64
+	primaryRoot     uint64
 	count           int
 	bufferedBytes   int64
 	rootRuns        map[string][]memtable.Table
@@ -1473,7 +1479,7 @@ func shouldFlushBufferedIndexedWrites(domain *collectionWriteDomain, opts Collec
 	return false
 }
 
-func shouldFlushBufferedIndexedWritesAfter(domain *collectionWriteDomain, opts CollectionOptions, addedCount int, addedBytes int64) bool {
+func shouldFlushBufferedIndexedWritesAfterAdding(domain *collectionWriteDomain, opts CollectionOptions, addedCount int, addedBytes int64) bool {
 	if domain == nil || addedCount <= 0 {
 		return false
 	}
@@ -1508,6 +1514,12 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		return bufferedIndexedCheckpoint{}
 	}
 	return bufferedIndexedCheckpoint{
+		loaded:          domain.loaded,
+		meta:            domain.meta,
+		catalog:         domain.catalog,
+		baseCommitSeq:   domain.baseCommitSeq,
+		baseSystemRoot:  domain.baseSystemRoot,
+		primaryRoot:     domain.primaryRoot,
 		count:           domain.count,
 		bufferedBytes:   domain.bufferedBytes,
 		rootRuns:        cloneTableRunMap(domain.rootRuns),
@@ -1523,12 +1535,18 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	}
 	resetTableRunsAddedAfterCheckpoint(domain.rootRuns, checkpoint.rootRuns)
 	resetTableRunsAddedAfterCheckpoint(domain.uniqueValueRuns, checkpoint.uniqueValueRuns)
+	domain.loaded = checkpoint.loaded
+	domain.meta = checkpoint.meta
+	domain.catalog = checkpoint.catalog
+	domain.baseCommitSeq = checkpoint.baseCommitSeq
+	domain.baseSystemRoot = checkpoint.baseSystemRoot
+	domain.primaryRoot = checkpoint.primaryRoot
 	domain.count = checkpoint.count
 	domain.bufferedBytes = checkpoint.bufferedBytes
 	domain.rootRuns = checkpoint.rootRuns
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
-	domain.primaryIDIndex = rebuildBufferedPrimaryIDIndex(domain.meta.Name, checkpoint.rootRuns)
+	domain.primaryIDIndex = rebuildBufferedPrimaryIDIndex(checkpoint.meta.Name, checkpoint.rootRuns)
 	domain.uniqueValueRuns = checkpoint.uniqueValueRuns
 	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(checkpoint.uniqueValueRuns)
 }
@@ -4454,8 +4472,9 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if domain.rootRuns == nil {
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
-	autoFlushEnabled := shouldFlushBufferedIndexedWritesAfter(domain, plan.meta.Options, modifiedCount, stagedBytes)
+	autoFlushEnabled := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, stagedBytes)
 	var checkpoint bufferedIndexedCheckpoint
+	collectionMetaCheckpoint := c.meta
 	if autoFlushEnabled {
 		checkpoint = checkpointBufferedIndexedDomain(domain)
 	}
@@ -4488,6 +4507,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		if err := c.flushBufferedIndexedLocked(domain); err != nil {
 			if autoFlushEnabled {
 				rollbackBufferedIndexedDomain(domain, checkpoint)
+				c.meta = collectionMetaCheckpoint
 			}
 			return false, err
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1473,6 +1473,21 @@ func shouldFlushBufferedIndexedWrites(domain *collectionWriteDomain, opts Collec
 	return false
 }
 
+func shouldFlushBufferedIndexedWritesAfter(domain *collectionWriteDomain, opts CollectionOptions, addedCount int, addedBytes int64) bool {
+	if domain == nil || addedCount <= 0 {
+		return false
+	}
+	nextCount := domain.count + addedCount
+	if opts.BufferedIndexedWriteMaxDocuments > 0 && nextCount >= opts.BufferedIndexedWriteMaxDocuments {
+		return true
+	}
+	nextBytes := saturatingAddNonNegativeInt64(domain.bufferedBytes, addedBytes)
+	if opts.BufferedIndexedWriteMaxBytes > 0 && nextBytes >= opts.BufferedIndexedWriteMaxBytes {
+		return true
+	}
+	return false
+}
+
 func bufferedIndexedAutoFlushEnabled(opts CollectionOptions) bool {
 	return opts.BufferedIndexedWriteMaxDocuments > 0 || opts.BufferedIndexedWriteMaxBytes > 0
 }
@@ -4393,6 +4408,21 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
 		return false, err
 	}
+	var stagedBytes int64
+	for i, rootName := range plan.rootNames {
+		baseRoot, ok := plan.baseRootIDs[rootName]
+		if !ok {
+			return false, fmt.Errorf("collections: UpdateBatch collection %q plan missing base root for %q", plan.meta.Name, rootName)
+		}
+		table := plan.deltaTables[i]
+		if table == nil || table.Len() == 0 {
+			continue
+		}
+		if len(domain.rootRuns[rootName]) > 0 && domain.rootBaseIDs[rootName] != baseRoot {
+			return false, errConcurrentRootModification(plan.meta.Name, rootName)
+		}
+		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, table.Size())
+	}
 	if plan.catalog != nil {
 		c.initializeWriteDomainFromCatalogLocked(domain, plan.catalog, plan.baseCommitSeq, plan.baseSystemRoot)
 	}
@@ -4405,17 +4435,13 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if domain.rootRuns == nil {
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
-	autoFlushEnabled := bufferedIndexedAutoFlushEnabled(plan.meta.Options)
+	autoFlushEnabled := shouldFlushBufferedIndexedWritesAfter(domain, plan.meta.Options, modifiedCount, stagedBytes)
 	var checkpoint bufferedIndexedCheckpoint
 	if autoFlushEnabled {
 		checkpoint = checkpointBufferedIndexedDomain(domain)
 	}
-	var stagedBytes int64
 	for i, rootName := range plan.rootNames {
-		baseRoot, ok := plan.baseRootIDs[rootName]
-		if !ok {
-			return false, fmt.Errorf("collections: UpdateBatch collection %q plan missing base root for %q", plan.meta.Name, rootName)
-		}
+		baseRoot := plan.baseRootIDs[rootName]
 		table := plan.deltaTables[i]
 		if table == nil || table.Len() == 0 {
 			continue
@@ -4425,7 +4451,6 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		}
 		domain.rootPolicies[rootName] = plan.policies[i]
 		domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)
-		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, table.Size())
 		plan.deltaTables[i] = nil
 	}
 	plan.deltaTables = nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3922,18 +3922,18 @@ type preparedBatchUpdate struct {
 }
 
 type updateBatchPlan struct {
-	results        []UpdateBatchResult
-	meta           CollectionMeta
-	catalog        *collectionCatalog
-	snap           *backenddb.Snapshot
-	baseUserRoot   uint64
-	baseSystemRoot uint64
-	baseCommitSeq  uint64
-	rootNames      []string
-	baseRootIDs    map[string]uint64
-	policies       []backenddb.OrderedRootStoragePolicy
-	deltaTables    []memtable.Table
-	bufferSafe     bool
+	results                     []UpdateBatchResult
+	meta                        CollectionMeta
+	catalog                     *collectionCatalog
+	snap                        *backenddb.Snapshot
+	baseUserRoot                uint64
+	baseSystemRoot              uint64
+	baseCommitSeq               uint64
+	rootNames                   []string
+	baseRootIDs                 map[string]uint64
+	policies                    []backenddb.OrderedRootStoragePolicy
+	deltaTables                 []memtable.Table
+	canBufferIndexedUpdateBatch bool
 }
 
 func (plan *updateBatchPlan) close() {
@@ -4025,7 +4025,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, errUpdateBatchHasSecondaryUniqueIndex
 	}
-	bufferSafe := len(meta.Indexes) > 0 &&
+	canBufferIndexedUpdateBatch := len(meta.Indexes) > 0 &&
 		(!collectionMetaHasSecondaryUniqueIndex(meta) ||
 			mode == updateBatchModeNoSecondaryUniqueIndexes ||
 			mode == updateBatchModeNoSecondaryUniqueIndexChanges)
@@ -4293,18 +4293,18 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	}
 	success = true
 	return &updateBatchPlan{
-		results:        results,
-		meta:           meta,
-		catalog:        catalog,
-		snap:           snap,
-		baseUserRoot:   baseUserRoot,
-		baseSystemRoot: baseSystemRoot,
-		baseCommitSeq:  baseCommitSeq,
-		rootNames:      rootNames,
-		baseRootIDs:    baseRootIDs,
-		bufferSafe:     bufferSafe,
-		policies:       policies,
-		deltaTables:    deltaTables,
+		results:                     results,
+		meta:                        meta,
+		catalog:                     catalog,
+		snap:                        snap,
+		baseUserRoot:                baseUserRoot,
+		baseSystemRoot:              baseSystemRoot,
+		baseCommitSeq:               baseCommitSeq,
+		rootNames:                   rootNames,
+		baseRootIDs:                 baseRootIDs,
+		canBufferIndexedUpdateBatch: canBufferIndexedUpdateBatch,
+		policies:                    policies,
+		deltaTables:                 deltaTables,
 	}, nil
 }
 
@@ -4362,7 +4362,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if c == nil || plan == nil || len(plan.deltaTables) == 0 {
 		return false, nil
 	}
-	if c.writeDomain == nil || !plan.bufferSafe || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
+	if c.writeDomain == nil || !plan.canBufferIndexedUpdateBatch || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
 		return false, nil
 	}
 	if len(plan.rootNames) != len(plan.deltaTables) || len(plan.rootNames) != len(plan.policies) {
@@ -4380,12 +4380,14 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		}
 	}
 	if !hasDeltaTable {
-		return false, errors.New("collections: UpdateBatch modified rows without delta tables")
+		return false, fmt.Errorf("collections: UpdateBatch collection %q modified rows without delta tables modified=%d roots=%d deltas=%d policies=%d", plan.meta.Name, modifiedCount, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
 	}
 	domain := c.writeDomain
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	if domain.count != 0 {
+		// The caller retries from the normal pre-plan flush path so a plan built
+		// before a concurrent buffered write is not published against stale roots.
 		return false, ErrConcurrentMutation
 	}
 	if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
@@ -4402,6 +4404,11 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	}
 	if domain.rootRuns == nil {
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
+	}
+	autoFlushEnabled := bufferedIndexedAutoFlushEnabled(plan.meta.Options)
+	var checkpoint bufferedIndexedCheckpoint
+	if autoFlushEnabled {
+		checkpoint = checkpointBufferedIndexedDomain(domain)
 	}
 	var stagedBytes int64
 	for i, rootName := range plan.rootNames {
@@ -4435,6 +4442,9 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	c.meta = plan.meta
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		if err := c.flushBufferedIndexedLocked(domain); err != nil {
+			if autoFlushEnabled {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
+			}
 			return false, err
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1484,7 +1484,7 @@ func shouldFlushBufferedIndexedWritesAfterAdding(domain *collectionWriteDomain, 
 	if domain == nil || addedCount <= 0 {
 		return false
 	}
-	nextCount := domain.count + addedCount
+	nextCount := saturatingAddNonNegativeInt(domain.count, addedCount)
 	if opts.BufferedIndexedWriteMaxDocuments > 0 && nextCount >= opts.BufferedIndexedWriteMaxDocuments {
 		return true
 	}
@@ -1493,6 +1493,16 @@ func shouldFlushBufferedIndexedWritesAfterAdding(domain *collectionWriteDomain, 
 		return true
 	}
 	return false
+}
+
+func saturatingAddNonNegativeInt(total, n int) int {
+	if n <= 0 {
+		return total
+	}
+	if total > maxCollectionInt-n {
+		return maxCollectionInt
+	}
+	return total + n
 }
 
 func bufferedIndexedAutoFlushEnabled(opts CollectionOptions) bool {
@@ -4471,10 +4481,10 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if domain.rootRuns == nil {
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
-	autoFlushEnabled := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, stagedBytes)
+	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, stagedBytes)
 	var checkpoint bufferedIndexedCheckpoint
 	collectionMetaCheckpoint := c.meta
-	if autoFlushEnabled {
+	if shouldAutoFlushAfterAdding {
 		checkpoint = checkpointBufferedIndexedDomain(domain)
 	}
 	for i, rootName := range plan.rootNames {
@@ -4504,7 +4514,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	c.meta = plan.meta
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		if err := c.flushBufferedIndexedLocked(domain); err != nil {
-			if autoFlushEnabled {
+			if shouldAutoFlushAfterAdding {
 				rollbackBufferedIndexedDomain(domain, checkpoint)
 				c.meta = collectionMetaCheckpoint
 			}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2302,9 +2302,71 @@ func TestBufferedPrimaryIDArenaCapAvoidsOverflow(t *testing.T) {
 	if got := bufferedPrimaryIDArenaCap(2); got != 32 {
 		t.Fatalf("small arena cap=%d want 32", got)
 	}
-	maxInt := int(^uint(0) >> 1)
-	if got := bufferedPrimaryIDArenaCap(maxInt/16 + 1); got != 0 {
+	if got := bufferedPrimaryIDArenaCap(maxCollectionInt/16 + 1); got != 0 {
 		t.Fatalf("overflow arena cap=%d want 0", got)
+	}
+}
+
+func TestShouldFlushBufferedIndexedWritesAfterAddingBoundaries(t *testing.T) {
+	opts := CollectionOptions{
+		BufferedIndexedWriteMaxDocuments: 10,
+		BufferedIndexedWriteMaxBytes:     100,
+	}
+	cases := []struct {
+		name       string
+		domain     *collectionWriteDomain
+		addedCount int
+		addedBytes int64
+		want       bool
+	}{
+		{
+			name:       "nil domain",
+			addedCount: 1,
+			addedBytes: 1,
+		},
+		{
+			name:       "zero added count ignores bytes",
+			domain:     &collectionWriteDomain{bufferedBytes: 99},
+			addedBytes: 1,
+		},
+		{
+			name:       "just below document limit",
+			domain:     &collectionWriteDomain{count: 8},
+			addedCount: 1,
+		},
+		{
+			name:       "exactly at document limit",
+			domain:     &collectionWriteDomain{count: 9},
+			addedCount: 1,
+			want:       true,
+		},
+		{
+			name:       "above document limit",
+			domain:     &collectionWriteDomain{count: 9},
+			addedCount: 2,
+			want:       true,
+		},
+		{
+			name:       "count overflow clamps to flush",
+			domain:     &collectionWriteDomain{count: maxCollectionInt},
+			addedCount: 1,
+			want:       true,
+		},
+		{
+			name:       "byte overflow clamps to flush",
+			domain:     &collectionWriteDomain{count: 1, bufferedBytes: int64(^uint64(0) >> 1)},
+			addedCount: 1,
+			addedBytes: 1,
+			want:       true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldFlushBufferedIndexedWritesAfterAdding(tc.domain, opts, tc.addedCount, tc.addedBytes)
+			if got != tc.want {
+				t.Fatalf("shouldFlushBufferedIndexedWritesAfterAdding()=%v want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2265,6 +2265,66 @@ func TestBufferedPrimaryIDArenaCapAvoidsOverflow(t *testing.T) {
 	}
 }
 
+func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {
+	catalog := &collectionCatalog{
+		meta:  CollectionMeta{Name: "users"},
+		roots: map[string]uint64{collectionPrimaryRootName("users"): 42},
+	}
+	domain := &collectionWriteDomain{
+		loaded:         true,
+		meta:           catalog.meta,
+		catalog:        catalog,
+		baseCommitSeq:  7,
+		baseSystemRoot: 11,
+		primaryRoot:    42,
+		count:          3,
+		bufferedBytes:  99,
+		rootRuns: map[string][]memtable.Table{
+			collectionPrimaryRootName("users"): nil,
+		},
+		rootPolicies: map[string]backenddb.OrderedRootStoragePolicy{
+			collectionPrimaryRootName("users"): backenddb.OrderedRootStorageDefault,
+		},
+		rootBaseIDs: map[string]uint64{
+			collectionPrimaryRootName("users"): 42,
+		},
+		uniqueValueRuns: map[string][]memtable.Table{
+			collectionSecondaryRootName("users", "email"): nil,
+		},
+	}
+	checkpoint := checkpointBufferedIndexedDomain(domain)
+
+	domain.loaded = false
+	domain.meta = CollectionMeta{Name: "other"}
+	domain.catalog = &collectionCatalog{meta: CollectionMeta{Name: "other"}}
+	domain.baseCommitSeq = 100
+	domain.baseSystemRoot = 200
+	domain.primaryRoot = 300
+	domain.count = 400
+	domain.bufferedBytes = 500
+	domain.rootRuns = map[string][]memtable.Table{collectionPrimaryRootName("other"): nil}
+	domain.rootPolicies = nil
+	domain.rootBaseIDs = nil
+	domain.uniqueValueRuns = nil
+
+	rollbackBufferedIndexedDomain(domain, checkpoint)
+	if !domain.loaded || domain.meta.Name != "users" || domain.catalog != catalog {
+		t.Fatalf("metadata after rollback loaded=%v meta=%+v catalog=%p want users/%p", domain.loaded, domain.meta, domain.catalog, catalog)
+	}
+	if domain.baseCommitSeq != 7 || domain.baseSystemRoot != 11 || domain.primaryRoot != 42 {
+		t.Fatalf("roots after rollback commit=%d system=%d primary=%d", domain.baseCommitSeq, domain.baseSystemRoot, domain.primaryRoot)
+	}
+	if domain.count != 3 || domain.bufferedBytes != 99 {
+		t.Fatalf("counters after rollback count=%d bytes=%d", domain.count, domain.bufferedBytes)
+	}
+	if _, ok := domain.rootRuns[collectionPrimaryRootName("users")]; !ok {
+		t.Fatalf("rootRuns=%v missing users primary root", domain.rootRuns)
+	}
+	if _, ok := domain.uniqueValueRuns[collectionSecondaryRootName("users", "email")]; !ok {
+		t.Fatalf("uniqueValueRuns=%v missing users email root", domain.uniqueValueRuns)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesCloseFlushes(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3057,8 +3057,8 @@ func TestCollectionUpdateCombinerBatchesWhenSecondaryUniqueValuesAreUnchanged(t 
 		}
 	}
 	after := d.State()
-	if after.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("combined unique-schema batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("combined unique-schema batch advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
 	}
 	seaIDs, err := col.FindByIndex("city", "sea")
 	if err != nil {
@@ -3066,6 +3066,13 @@ func TestCollectionUpdateCombinerBatchesWhenSecondaryUniqueValuesAreUnchanged(t 
 	}
 	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
 		t.Fatalf("sea ids=%q want [u1]", seaIDs)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush combined unique-schema batch: %v", err)
+	}
+	flushed := d.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flushed combined unique-schema batch advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
 	}
 }
 
@@ -3988,8 +3995,8 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesBatchesNonUniqueUpd
 		t.Fatalf("results=%+v want two modified rows", results)
 	}
 	after := d.State()
-	if after.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("buffered batch advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
 	}
 	seaIDs, err := col.FindByIndex("city", "sea")
 	if err != nil {
@@ -3998,12 +4005,33 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesBatchesNonUniqueUpd
 	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
 		t.Fatalf("sea ids=%q want [u1]", seaIDs)
 	}
+	hnlIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find hnl city: %v", err)
+	}
+	if len(hnlIDs) != 0 {
+		t.Fatalf("hnl ids=%q want none after buffered city update", hnlIDs)
+	}
 	emailIDs, err := col.FindByIndex("email", "a@example.com")
 	if err != nil {
 		t.Fatalf("find email: %v", err)
 	}
 	if len(emailIDs) != 1 || !bytes.Equal(emailIDs[0], []byte("u1")) {
 		t.Fatalf("email ids=%q want [u1]", emailIDs)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered update batch: %v", err)
+	}
+	flushed := d.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flush advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
+	}
+	seaIDs, err = col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city after flush: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("flushed sea ids=%q want [u1]", seaIDs)
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -773,8 +773,8 @@ func TestRunMongoUpdateBatchBatchesNonUniqueFieldWithSecondaryUniqueIndex(t *tes
 		t.Fatalf("matched=%d modified=%d batched=%v want 2,2,true", matched, modified, batched)
 	}
 	after := db.State()
-	if after.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("buffered batch advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
 	}
 	ids, err := col.FindByIndex("city_1", "sea")
 	if err != nil {
@@ -782,6 +782,27 @@ func TestRunMongoUpdateBatchBatchesNonUniqueFieldWithSecondaryUniqueIndex(t *tes
 	}
 	if len(ids) != 1 || !bytes.Equal(ids[0], id1) {
 		t.Fatalf("sea ids=%q want [%q]", ids, id1)
+	}
+	ids, err = col.FindByIndex("city_1", "hnl")
+	if err != nil {
+		t.Fatalf("find city hnl: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("hnl ids=%q want none after buffered updates", ids)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered mongo update batch: %v", err)
+	}
+	flushed := db.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flushed batch advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
+	}
+	ids, err = col.FindByIndex("city_1", "sfo")
+	if err != nil {
+		t.Fatalf("find city sfo after flush: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], id2) {
+		t.Fatalf("flushed sfo ids=%q want [%q]", ids, id2)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stage safe indexed `UpdateBatch` plans into the collection write domain instead of immediately publishing them
- preserve buffered secondary-index tombstones when flushing staged update tables
- update collection and Mongo gateway tests to assert buffered index visibility before flush and persisted visibility after flush

## Notes
This is a conservative step toward native indexed update memtables. `UpdateBatch` still flushes any previously buffered writes before planning, so this does not yet accumulate multiple update batches against the same overlay. The next slice should remove that pre-plan flush by teaching update planning to read from the buffered domain overlay.

## Validation
- `go test ./TreeDB/collections -run 'TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChanges(BatchesNonUniqueUpdates|DeclinesUniqueUpdates)|TestCollectionUpdateCombinerBatchesWhenSecondaryUniqueValuesAreUnchanged|TestCollectionIndexedWriteMemtablesFindSkipsBufferedSecondaryTombstone' -count 1`
- `go test ./TreeDB/collections -count 1`
- `go test ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench ./cmd/mongo_gateway_compare_report -count 1`
