### PR TITLE
[codex] Plan safe collection updates against buffered writes

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4052,6 +4052,17 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 						replan = true
 						return nil
 					}
+					if plan.bufferedBase && !c.bufferedUpdateBatchPlanStillCurrent(plan) {
+						if useBufferedRead {
+							if err := c.flushBufferedWrites(); err != nil {
+								return err
+							}
+							useBufferedRead = false
+							replan = true
+							return nil
+						}
+						return ErrConcurrentMutation
+					}
 					if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
 						return err
 					}
@@ -4078,6 +4089,11 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 				}
 				if err := c.flushBufferedWrites(); err != nil {
 					return err
+				}
+				if useBufferedRead {
+					useBufferedRead = false
+					replan = true
+					return nil
 				}
 				var publishErr error
 				results, publishErr = c.publishUpdateBatchPlanLocked(plan)
@@ -4142,6 +4158,23 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 		return publishErr
 	})
 	return results, err
+}
+
+func (c *Collection) bufferedUpdateBatchPlanStillCurrent(plan *updateBatchPlan) bool {
+	if plan == nil || !plan.bufferedBase {
+		return true
+	}
+	domain := c.writeDomain
+	if domain == nil {
+		return false
+	}
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	if domain.count == 0 {
+		return false
+	}
+	return updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) &&
+		plan.bufferedReadGeneration == domain.writeGeneration
 }
 
 func (c *Collection) withMutationLock(fn func() error) error {
@@ -4326,16 +4359,18 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	if len(changed) == 0 {
 		primaryRootName := collectionPrimaryRootName(meta.Name)
 		return &updateBatchPlan{
-			results:             results,
-			meta:                meta,
-			catalog:             catalog,
-			snap:                snap,
-			baseUserRoot:        baseUserRoot,
-			baseSystemRoot:      baseSystemRoot,
-			baseCommitSeq:       baseCommitSeq,
-			rootNames:           []string{primaryRootName},
-			baseRootIDs:         map[string]uint64{primaryRootName: primaryRoot},
-			bufferedReadBlocked: bufferedReadBlocked,
+			results:                results,
+			meta:                   meta,
+			catalog:                catalog,
+			snap:                   snap,
+			baseUserRoot:           baseUserRoot,
+			baseSystemRoot:         baseSystemRoot,
+			baseCommitSeq:          baseCommitSeq,
+			rootNames:              []string{primaryRootName},
+			baseRootIDs:            map[string]uint64{primaryRootName: primaryRoot},
+			bufferedBase:           bufferedRead.enabled,
+			bufferedReadGeneration: bufferedRead.writeGeneration,
+			bufferedReadBlocked:    bufferedReadBlocked,
 		}, nil
 	}
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3969,6 +3969,7 @@ type updateBatchPlan struct {
 	deltaTables                 []memtable.Table
 	canBufferIndexedUpdateBatch bool
 	bufferedBase                bool
+	bufferedReadBlocked         bool
 }
 
 type updateBatchBufferedRead struct {
@@ -4008,6 +4009,14 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 					return nil
 				}
 				if len(plan.deltaTables) == 0 {
+					if plan.bufferedReadBlocked && useBufferedRead {
+						plan.close()
+						if err := c.flushBufferedWrites(); err != nil {
+							return err
+						}
+						useBufferedRead = false
+						continue
+					}
 					if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
 						plan.close()
 						return err
@@ -4188,6 +4197,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 	var bufferedRead updateBatchBufferedRead
+	bufferedReadBlocked := false
 	if domain := c.writeDomain; useBufferedRead && domain != nil && mode != updateBatchModeAny {
 		domain.mu.RLock()
 		if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) {
@@ -4196,6 +4206,8 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 				primaryRuns: append([]memtable.Table(nil), domain.rootRuns[collectionPrimaryRootName(meta.Name)]...),
 			}
 			plannerOptions = collectionOptionsWithBufferedTemplateV1Resolver(plannerOptions, domain, meta.Name)
+		} else if domain.count > 0 && len(domain.rootRuns) > 0 {
+			bufferedReadBlocked = true
 		}
 		domain.mu.RUnlock()
 	}
@@ -4204,15 +4216,16 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	if primaryRoot == 0 && !bufferedRead.enabled {
 		primaryRootName := collectionPrimaryRootName(meta.Name)
 		return &updateBatchPlan{
-			results:        results,
-			meta:           meta,
-			catalog:        catalog,
-			snap:           snap,
-			baseUserRoot:   baseUserRoot,
-			baseSystemRoot: baseSystemRoot,
-			baseCommitSeq:  baseCommitSeq,
-			rootNames:      []string{primaryRootName},
-			baseRootIDs:    map[string]uint64{primaryRootName: primaryRoot},
+			results:             results,
+			meta:                meta,
+			catalog:             catalog,
+			snap:                snap,
+			baseUserRoot:        baseUserRoot,
+			baseSystemRoot:      baseSystemRoot,
+			baseCommitSeq:       baseCommitSeq,
+			rootNames:           []string{primaryRootName},
+			baseRootIDs:         map[string]uint64{primaryRootName: primaryRoot},
+			bufferedReadBlocked: bufferedReadBlocked,
 		}, nil
 	}
 	runtimes, err := (insertBatchPlanner{
@@ -4273,15 +4286,16 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	if len(changed) == 0 {
 		primaryRootName := collectionPrimaryRootName(meta.Name)
 		return &updateBatchPlan{
-			results:        results,
-			meta:           meta,
-			catalog:        catalog,
-			snap:           snap,
-			baseUserRoot:   baseUserRoot,
-			baseSystemRoot: baseSystemRoot,
-			baseCommitSeq:  baseCommitSeq,
-			rootNames:      []string{primaryRootName},
-			baseRootIDs:    map[string]uint64{primaryRootName: primaryRoot},
+			results:             results,
+			meta:                meta,
+			catalog:             catalog,
+			snap:                snap,
+			baseUserRoot:        baseUserRoot,
+			baseSystemRoot:      baseSystemRoot,
+			baseCommitSeq:       baseCommitSeq,
+			rootNames:           []string{primaryRootName},
+			baseRootIDs:         map[string]uint64{primaryRootName: primaryRoot},
+			bufferedReadBlocked: bufferedReadBlocked,
 		}, nil
 	}
 
@@ -4469,6 +4483,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		baseRootIDs:                 baseRootIDs,
 		canBufferIndexedUpdateBatch: canBufferIndexedUpdateBatch,
 		bufferedBase:                bufferedRead.enabled,
+		bufferedReadBlocked:         bufferedReadBlocked,
 		policies:                    policies,
 		deltaTables:                 deltaTables,
 	}, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3933,6 +3933,12 @@ type updateBatchPlan struct {
 	policies       []backenddb.OrderedRootStoragePolicy
 	deltaTables    []memtable.Table
 	bufferSafe     bool
+	bufferedBase   bool
+}
+
+type updateBatchBufferedRead struct {
+	enabled     bool
+	primaryRuns []memtable.Table
 }
 
 func (plan *updateBatchPlan) close() {
@@ -3948,6 +3954,43 @@ func (plan *updateBatchPlan) close() {
 }
 
 func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMode) ([]UpdateBatchResult, error) {
+	if c.shouldPlanUpdateBatchWithBufferedWrites(mode) {
+		var results []UpdateBatchResult
+		err := c.withMutationLock(func() error {
+			plan, err := c.buildUpdateBatchPlan(items, mode)
+			if err != nil {
+				return err
+			}
+			if plan == nil {
+				return nil
+			}
+			defer plan.close()
+			if len(plan.deltaTables) == 0 {
+				if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
+					return err
+				}
+				c.meta = plan.meta
+				results = plan.results
+				return nil
+			}
+			buffered, bufferErr := c.bufferUpdateBatchPlanLocked(plan)
+			if bufferErr != nil {
+				return bufferErr
+			}
+			if buffered {
+				results = plan.results
+				return nil
+			}
+			if err := c.flushBufferedWrites(); err != nil {
+				return err
+			}
+			var publishErr error
+			results, publishErr = c.publishUpdateBatchPlanLocked(plan)
+			return publishErr
+		})
+		return results, err
+	}
+
 	if err := c.withMutationLock(func() error {
 		return c.flushBufferedWrites()
 	}); err != nil {
@@ -4004,6 +4047,57 @@ func (c *Collection) withMutationLock(fn func() error) error {
 	return fn()
 }
 
+func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMode) bool {
+	if c == nil || c.writeDomain == nil || mode == updateBatchModeAny {
+		return false
+	}
+	domain := c.writeDomain
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	return domain.count > 0 && len(domain.rootRuns) > 0
+}
+
+func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta CollectionMeta, baseCommitSeq, baseSystemRoot uint64) bool {
+	if domain == nil || domain.count == 0 || len(domain.rootRuns) == 0 {
+		return false
+	}
+	if !domain.loaded || domain.catalog == nil {
+		return false
+	}
+	if domain.baseCommitSeq != baseCommitSeq || domain.baseSystemRoot != baseSystemRoot {
+		return false
+	}
+	if !sameCollectionMeta(domain.meta, meta) {
+		return false
+	}
+	if len(domain.rootRuns[collectionPrimaryRootName(meta.Name)]) == 0 {
+		return false
+	}
+	return meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
+}
+
+func readUpdateBatchCurrentDocument(snap *backenddb.Snapshot, primaryRoot uint64, documentID []byte, buffered updateBatchBufferedRead) ([]byte, bool, bool, error) {
+	if buffered.enabled {
+		if value, _, flags, found := getBufferedRunEntry(buffered.primaryRuns, documentID); found {
+			if flags&node.FlagTombstone != 0 {
+				return nil, true, false, nil
+			}
+			return value, true, true, nil
+		}
+	}
+	if primaryRoot == 0 {
+		return nil, false, false, nil
+	}
+	entry, err := snap.GetEntryAtRoot(primaryRoot, documentID)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return nil, false, false, nil
+	}
+	if err != nil {
+		return nil, false, false, err
+	}
+	return entry.Value, false, true, nil
+}
+
 func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBatchMode) (*updateBatchPlan, error) {
 	results := make([]UpdateBatchResult, len(items))
 	snap := c.db.AcquireSnapshot()
@@ -4037,9 +4131,27 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	baseUserRoot := snapshotUserRoot(snap)
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
+	var bufferedRead updateBatchBufferedRead
+	var unlockBufferedRead func()
+	if domain := c.writeDomain; domain != nil && mode != updateBatchModeAny {
+		domain.mu.RLock()
+		if updateBatchCanReadBufferedDomainLocked(domain, meta, baseCommitSeq, baseSystemRoot) {
+			bufferedRead = updateBatchBufferedRead{
+				enabled:     true,
+				primaryRuns: domain.rootRuns[collectionPrimaryRootName(meta.Name)],
+			}
+			plannerOptions = collectionOptionsWithBufferedTemplateV1Resolver(plannerOptions, domain, meta.Name)
+			unlockBufferedRead = domain.mu.RUnlock
+		} else {
+			domain.mu.RUnlock()
+		}
+	}
+	if unlockBufferedRead != nil {
+		defer unlockBufferedRead()
+	}
 
 	primaryRoot := catalog.rootID(collectionPrimaryRootName(meta.Name))
-	if primaryRoot == 0 {
+	if primaryRoot == 0 && !bufferedRead.enabled {
 		primaryRootName := collectionPrimaryRootName(meta.Name)
 		return &updateBatchPlan{
 			results:        results,
@@ -4065,16 +4177,16 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	changed := make([]preparedBatchUpdate, 0, len(items))
 	changedDocuments := make([][]byte, 0, len(items))
 	for i, item := range items {
-		entry, err := snap.GetEntryAtRoot(primaryRoot, item.DocumentID)
-		if errors.Is(err, tree.ErrKeyNotFound) {
-			continue
-		}
+		currentDocument, bufferedDocument, found, err := readUpdateBatchCurrentDocument(snap, primaryRoot, item.DocumentID, bufferedRead)
 		if err != nil {
 			_ = snap.Close()
 			return nil, updateBatchItemError(i, err)
 		}
+		if !found {
+			continue
+		}
 		results[i].Matched = true
-		document, changedOne, err := item.Update(bytes.Clone(entry.Value))
+		document, changedOne, err := item.Update(bytes.Clone(currentDocument))
 		if err != nil {
 			_ = snap.Close()
 			return nil, updateBatchItemError(i, err)
@@ -4086,7 +4198,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			_ = snap.Close()
 			return nil, updateBatchItemError(i, errors.New("changed replacement document cannot be empty"))
 		}
-		if err := validateBSONReplacementPreservesID(entry.Value, document, plannerOptions); err != nil {
+		if err := validateBSONReplacementPreservesID(currentDocument, document, plannerOptions); err != nil {
 			_ = snap.Close()
 			return nil, updateBatchItemError(i, err)
 		}
@@ -4095,7 +4207,11 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			documentID: item.DocumentID,
 		}
 		if len(runtimes) > 0 {
-			prepared.oldState, err = loadDeleteIndexState(snap, catalog, item.DocumentID, entry.Value, runtimes, plannerOptions)
+			if bufferedDocument {
+				prepared.oldState, err = indexStateForDocument(currentDocument, runtimes, plannerOptions)
+			} else {
+				prepared.oldState, err = loadDeleteIndexState(snap, catalog, item.DocumentID, currentDocument, runtimes, plannerOptions)
+			}
 			if err != nil {
 				_ = snap.Close()
 				return nil, updateBatchItemError(i, err)
@@ -4302,6 +4418,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		rootNames:      rootNames,
 		baseRootIDs:    baseRootIDs,
 		bufferSafe:     bufferSafe,
+		bufferedBase:   bufferedRead.enabled,
 		policies:       policies,
 		deltaTables:    deltaTables,
 	}, nil
@@ -4375,12 +4492,14 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	if domain.count != 0 {
-		return false, nil
+		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseCommitSeq, plan.baseSystemRoot) {
+			return false, nil
+		}
 	}
 	if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
 		return false, err
 	}
-	if plan.catalog != nil {
+	if domain.count == 0 && plan.catalog != nil {
 		c.initializeWriteDomainFromCatalogLocked(domain, plan.catalog, plan.baseCommitSeq, plan.baseSystemRoot)
 	}
 	if domain.rootPolicies == nil {
@@ -4404,6 +4523,8 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		}
 		if len(domain.rootRuns[rootName]) == 0 {
 			domain.rootBaseIDs[rootName] = baseRoot
+		} else if domain.rootBaseIDs[rootName] != baseRoot {
+			return false, errConcurrentRootModification(plan.meta.Name, rootName)
 		}
 		domain.rootPolicies[rootName] = plan.policies[i]
 		domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4071,7 +4071,7 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 	if !domain.loaded || domain.catalog == nil {
 		return false
 	}
-	if domain.baseCommitSeq != baseCommitSeq || domain.baseSystemRoot != baseSystemRoot {
+	if domain.baseSystemRoot != baseSystemRoot {
 		return false
 	}
 	if !sameCollectionMeta(domain.meta, meta) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3979,36 +3979,51 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 	if c.shouldPlanUpdateBatchWithBufferedWrites(mode) {
 		var results []UpdateBatchResult
 		err := c.withMutationLock(func() error {
-			plan, err := c.buildUpdateBatchPlan(items, mode, true)
-			if err != nil {
-				return err
-			}
-			if plan == nil {
-				return nil
-			}
-			defer plan.close()
-			if len(plan.deltaTables) == 0 {
-				if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
+			useBufferedRead := true
+			for {
+				plan, err := c.buildUpdateBatchPlan(items, mode, useBufferedRead)
+				if err != nil {
 					return err
 				}
-				c.meta = plan.meta
-				results = plan.results
-				return nil
+				if plan == nil {
+					return nil
+				}
+				if len(plan.deltaTables) == 0 {
+					if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
+						plan.close()
+						return err
+					}
+					c.meta = plan.meta
+					results = plan.results
+					plan.close()
+					return nil
+				}
+				buffered, bufferErr := c.bufferUpdateBatchPlanLocked(plan)
+				if bufferErr != nil {
+					plan.close()
+					if errors.Is(bufferErr, ErrConcurrentMutation) && useBufferedRead {
+						if err := c.flushBufferedWrites(); err != nil {
+							return err
+						}
+						useBufferedRead = false
+						continue
+					}
+					return bufferErr
+				}
+				if buffered {
+					results = plan.results
+					plan.close()
+					return nil
+				}
+				if err := c.flushBufferedWrites(); err != nil {
+					plan.close()
+					return err
+				}
+				var publishErr error
+				results, publishErr = c.publishUpdateBatchPlanLocked(plan)
+				plan.close()
+				return publishErr
 			}
-			buffered, bufferErr := c.bufferUpdateBatchPlanLocked(plan)
-			if bufferErr != nil {
-				return bufferErr
-			}
-			if buffered {
-				results = plan.results
-				return nil
-			}
-			if err := c.flushBufferedWrites(); err != nil {
-				return err
-			}
-			var publishErr error
-			results, publishErr = c.publishUpdateBatchPlanLocked(plan)
-			return publishErr
 		})
 		return results, err
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4047,7 +4047,7 @@ type updateBatchPlan struct {
 
 type updateBatchBufferedRead struct {
 	enabled         bool
-	primaryEntries  map[string]updateBatchBufferedEntry
+	primaryEntries  []updateBatchBufferedEntry
 	writeGeneration uint64
 }
 
@@ -4258,13 +4258,16 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 	return meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
 }
 
-func readUpdateBatchCurrentDocument(snap *backenddb.Snapshot, primaryRoot uint64, documentID []byte, buffered updateBatchBufferedRead) (updateBatchCurrentDocument, error) {
+func readUpdateBatchCurrentDocument(snap *backenddb.Snapshot, primaryRoot uint64, itemIndex int, documentID []byte, buffered updateBatchBufferedRead) (updateBatchCurrentDocument, error) {
 	if buffered.enabled {
-		if entry := buffered.primaryEntries[string(documentID)]; entry.found {
-			if entry.flags&node.FlagTombstone != 0 {
-				return updateBatchCurrentDocument{buffered: true}, nil
+		if itemIndex >= 0 && itemIndex < len(buffered.primaryEntries) {
+			entry := buffered.primaryEntries[itemIndex]
+			if entry.found {
+				if entry.flags&node.FlagTombstone != 0 {
+					return updateBatchCurrentDocument{buffered: true}, nil
+				}
+				return updateBatchCurrentDocument{value: entry.value, buffered: true, found: true}, nil
 			}
-			return updateBatchCurrentDocument{value: entry.value, buffered: true, found: true}, nil
 		}
 	}
 	if primaryRoot == 0 {
@@ -4278,6 +4281,57 @@ func readUpdateBatchCurrentDocument(snap *backenddb.Snapshot, primaryRoot uint64
 		return updateBatchCurrentDocument{}, err
 	}
 	return updateBatchCurrentDocument{value: entry.Value, found: true}, nil
+}
+
+const updateBatchBufferedPrimaryDirectProbeLimit = 1024
+
+func snapshotUpdateBatchBufferedPrimaryEntries(runs []memtable.Table, items []UpdateBatchItem) ([]updateBatchBufferedEntry, error) {
+	entries := make([]updateBatchBufferedEntry, len(items))
+	if len(runs) == 0 || len(items) == 0 {
+		return entries, nil
+	}
+	if len(runs) <= 1 || len(runs)*len(items) <= updateBatchBufferedPrimaryDirectProbeLimit {
+		for i, item := range items {
+			if value, _, flags, found := getBufferedRunEntry(runs, item.DocumentID); found {
+				entries[i] = updateBatchBufferedEntry{
+					value: bytes.Clone(value),
+					flags: flags,
+					found: true,
+				}
+			}
+		}
+		return entries, nil
+	}
+	targets := make(map[string]int, len(items))
+	for i, item := range items {
+		targets[string(item.DocumentID)] = i
+	}
+	for i := len(runs) - 1; i >= 0 && len(targets) > 0; i-- {
+		run := runs[i]
+		if run == nil {
+			continue
+		}
+		it := run.NewIterator(nil, nil)
+		for it.Valid() && len(targets) > 0 {
+			key := string(it.UnsafeKey())
+			if itemIndex, ok := targets[key]; ok && !entries[itemIndex].found {
+				value, _, flags := it.UnsafeEntry()
+				entries[itemIndex] = updateBatchBufferedEntry{
+					value: bytes.Clone(value),
+					flags: flags,
+					found: true,
+				}
+				delete(targets, key)
+			}
+			it.Next()
+		}
+		if err := it.Error(); err != nil {
+			_ = it.Close()
+			return nil, err
+		}
+		_ = it.Close()
+	}
+	return entries, nil
 }
 
 func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBatchMode, useBufferedRead bool) (*updateBatchPlan, error) {
@@ -4315,23 +4369,15 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	baseCommitSeq := snapshotCommitSeq(snap)
 	var bufferedRead updateBatchBufferedRead
 	var bufferedTemplateRuns []memtable.Table
-	defer resetCollectionTables(bufferedTemplateRuns)
+	defer func() { resetCollectionTables(bufferedTemplateRuns) }()
 	bufferedReadBlocked := false
 	if domain := c.writeDomain; useBufferedRead && domain != nil && mode != updateBatchModeAny {
 		domain.mu.RLock()
 		if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) {
 			primaryRuns := domain.rootRuns[collectionPrimaryRootName(meta.Name)]
-			primaryEntries := make(map[string]updateBatchBufferedEntry, len(items))
-			for _, item := range items {
-				if value, _, flags, found := getBufferedRunEntry(primaryRuns, item.DocumentID); found {
-					primaryEntries[string(item.DocumentID)] = updateBatchBufferedEntry{
-						value: bytes.Clone(value),
-						flags: flags,
-						found: true,
-					}
-				}
-			}
-			if normalizedDocumentFormat(plannerOptions.documentFormat) == DocumentFormatTemplateV1 {
+			var primaryEntries []updateBatchBufferedEntry
+			primaryEntries, err = snapshotUpdateBatchBufferedPrimaryEntries(primaryRuns, items)
+			if err == nil && normalizedDocumentFormat(plannerOptions.documentFormat) == DocumentFormatTemplateV1 {
 				bufferedTemplateRuns, err = cloneCollectionRunTables(domain.rootRuns[collectionTemplateRootName(meta.Name)])
 			}
 			bufferedRead = updateBatchBufferedRead{
@@ -4381,7 +4427,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	changed := make([]preparedBatchUpdate, 0, len(items))
 	changedDocuments := make([][]byte, 0, len(items))
 	for i, item := range items {
-		current, err := readUpdateBatchCurrentDocument(snap, primaryRoot, item.DocumentID, bufferedRead)
+		current, err := readUpdateBatchCurrentDocument(snap, primaryRoot, i, item.DocumentID, bufferedRead)
 		if err != nil {
 			_ = snap.Close()
 			return nil, updateBatchItemError(i, err)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1893,6 +1893,46 @@ func getBufferedRunEntry(runs []memtable.Table, key []byte) ([]byte, page.ValueP
 	return nil, page.ValuePtr{}, 0, false
 }
 
+func cloneCollectionRunTables(runs []memtable.Table) ([]memtable.Table, error) {
+	if len(runs) == 0 {
+		return nil, nil
+	}
+	out := make([]memtable.Table, 0, len(runs))
+	for _, run := range runs {
+		if run == nil {
+			out = append(out, nil)
+			continue
+		}
+		cloned, err := cloneCollectionRunTable(run)
+		if err != nil {
+			resetCollectionTables(out)
+			return nil, err
+		}
+		out = append(out, cloned)
+	}
+	return out, nil
+}
+
+func cloneCollectionRunTable(run memtable.Table) (memtable.Table, error) {
+	if run == nil {
+		return nil, nil
+	}
+	table := newCollectionRunTable(max(0, run.Len()))
+	it := run.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		value, ptr, flags := it.UnsafeEntry()
+		table.SetEntrySteal(bytes.Clone(it.UnsafeKey()), bytes.Clone(value), ptr, flags)
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		resetCollectionRunTable(table)
+		return nil, err
+	}
+	table.Freeze()
+	return table, nil
+}
+
 type bufferedRootRunHeapItem struct {
 	idx      int
 	priority int
@@ -4007,8 +4047,14 @@ type updateBatchPlan struct {
 
 type updateBatchBufferedRead struct {
 	enabled         bool
-	primaryRuns     []memtable.Table
+	primaryEntries  map[string]updateBatchBufferedEntry
 	writeGeneration uint64
+}
+
+type updateBatchBufferedEntry struct {
+	value []byte
+	flags byte
+	found bool
 }
 
 type updateBatchCurrentDocument struct {
@@ -4214,11 +4260,11 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 
 func readUpdateBatchCurrentDocument(snap *backenddb.Snapshot, primaryRoot uint64, documentID []byte, buffered updateBatchBufferedRead) (updateBatchCurrentDocument, error) {
 	if buffered.enabled {
-		if value, _, flags, found := getBufferedRunEntry(buffered.primaryRuns, documentID); found {
-			if flags&node.FlagTombstone != 0 {
+		if entry := buffered.primaryEntries[string(documentID)]; entry.found {
+			if entry.flags&node.FlagTombstone != 0 {
 				return updateBatchCurrentDocument{buffered: true}, nil
 			}
-			return updateBatchCurrentDocument{value: value, buffered: true, found: true}, nil
+			return updateBatchCurrentDocument{value: entry.value, buffered: true, found: true}, nil
 		}
 	}
 	if primaryRoot == 0 {
@@ -4268,20 +4314,42 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 	var bufferedRead updateBatchBufferedRead
+	var bufferedTemplateRuns []memtable.Table
+	defer resetCollectionTables(bufferedTemplateRuns)
 	bufferedReadBlocked := false
 	if domain := c.writeDomain; useBufferedRead && domain != nil && mode != updateBatchModeAny {
 		domain.mu.RLock()
 		if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) {
+			primaryRuns := domain.rootRuns[collectionPrimaryRootName(meta.Name)]
+			primaryEntries := make(map[string]updateBatchBufferedEntry, len(items))
+			for _, item := range items {
+				if value, _, flags, found := getBufferedRunEntry(primaryRuns, item.DocumentID); found {
+					primaryEntries[string(item.DocumentID)] = updateBatchBufferedEntry{
+						value: bytes.Clone(value),
+						flags: flags,
+						found: true,
+					}
+				}
+			}
+			if normalizedDocumentFormat(plannerOptions.documentFormat) == DocumentFormatTemplateV1 {
+				bufferedTemplateRuns, err = cloneCollectionRunTables(domain.rootRuns[collectionTemplateRootName(meta.Name)])
+			}
 			bufferedRead = updateBatchBufferedRead{
 				enabled:         true,
-				primaryRuns:     append([]memtable.Table(nil), domain.rootRuns[collectionPrimaryRootName(meta.Name)]...),
+				primaryEntries:  primaryEntries,
 				writeGeneration: domain.writeGeneration,
 			}
-			plannerOptions = collectionOptionsWithBufferedTemplateV1Resolver(plannerOptions, domain, meta.Name)
 		} else if domain.count > 0 && len(domain.rootRuns) > 0 {
 			bufferedReadBlocked = true
 		}
 		domain.mu.RUnlock()
+		if err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		if len(bufferedTemplateRuns) > 0 {
+			plannerOptions = collectionOptionsWithBufferedTemplateV1RunsResolver(plannerOptions, bufferedTemplateRuns)
+		}
 	}
 
 	primaryRoot := catalog.rootID(collectionPrimaryRootName(meta.Name))

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4064,7 +4064,7 @@ func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMod
 	return domain.count > 0 && len(domain.rootRuns) > 0
 }
 
-func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta CollectionMeta, baseCommitSeq, baseSystemRoot uint64) bool {
+func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64) bool {
 	if domain == nil || domain.count == 0 || len(domain.rootRuns) == 0 {
 		return false
 	}
@@ -4141,7 +4141,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	var bufferedRead updateBatchBufferedRead
 	if domain := c.writeDomain; useBufferedRead && domain != nil && mode != updateBatchModeAny {
 		domain.mu.RLock()
-		if updateBatchCanReadBufferedDomainLocked(domain, meta, baseCommitSeq, baseSystemRoot) {
+		if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) {
 			bufferedRead = updateBatchBufferedRead{
 				enabled:     true,
 				primaryRuns: append([]memtable.Table(nil), domain.rootRuns[collectionPrimaryRootName(meta.Name)]...),
@@ -4503,7 +4503,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	if domain.count != 0 {
-		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseCommitSeq, plan.baseSystemRoot) {
+		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) {
 			// The caller retries from the normal pre-plan flush path so a plan built
 			// before a concurrent buffered write is not published against stale roots.
 			return false, ErrConcurrentMutation

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4015,63 +4015,67 @@ func (plan *updateBatchPlan) close() {
 
 func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMode) ([]UpdateBatchResult, error) {
 	if c.shouldPlanUpdateBatchWithBufferedWrites(mode) {
-		var results []UpdateBatchResult
-		err := c.withMutationLock(func() error {
-			useBufferedRead := true
-			for {
-				plan, err := c.buildUpdateBatchPlan(items, mode, useBufferedRead)
-				if err != nil {
-					return err
-				}
-				if plan == nil {
-					return nil
-				}
+		useBufferedRead := true
+		for {
+			plan, err := c.buildUpdateBatchPlan(items, mode, useBufferedRead)
+			if err != nil {
+				return nil, err
+			}
+			if plan == nil {
+				return nil, nil
+			}
+			var results []UpdateBatchResult
+			replan := false
+			err = c.withMutationLock(func() error {
 				if len(plan.deltaTables) == 0 {
 					if plan.bufferedReadBlocked && useBufferedRead {
-						plan.close()
 						if err := c.flushBufferedWrites(); err != nil {
 							return err
 						}
 						useBufferedRead = false
-						continue
+						replan = true
+						return nil
 					}
 					if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
-						plan.close()
 						return err
 					}
 					c.meta = plan.meta
 					results = plan.results
-					plan.close()
 					return nil
 				}
 				buffered, bufferErr := c.bufferUpdateBatchPlanLocked(plan)
 				if bufferErr != nil {
-					plan.close()
 					if errors.Is(bufferErr, ErrConcurrentMutation) && useBufferedRead {
 						if err := c.flushBufferedWrites(); err != nil {
 							return err
 						}
 						useBufferedRead = false
-						continue
+						replan = true
+						return nil
 					}
 					return bufferErr
 				}
 				if buffered {
+					c.meta = plan.meta
 					results = plan.results
-					plan.close()
 					return nil
 				}
 				if err := c.flushBufferedWrites(); err != nil {
-					plan.close()
 					return err
 				}
 				var publishErr error
 				results, publishErr = c.publishUpdateBatchPlanLocked(plan)
-				plan.close()
 				return publishErr
+			})
+			plan.close()
+			if err != nil {
+				return nil, err
 			}
-		})
-		return results, err
+			if replan {
+				continue
+			}
+			return results, nil
+		}
 	}
 
 	if err := c.withMutationLock(func() error {
@@ -5692,7 +5696,7 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	return collectMergedCollectionIndexIDs(bufferedIt, persistedIt, prefix, maxResults)
 }
 
-// bufferedIndexTableLocked materializes the buffered overlay for one secondary
+// bufferedIndexTableLocked materializes buffered entries for one secondary
 // index prefix while domain.mu is held. The returned pooled table is owned by
 // the caller and must be released with resetCollectionRunTable.
 func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte, maxResults int) (memtable.Table, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -365,6 +365,7 @@ type bufferedIndexedCheckpoint struct {
 	primaryRoot     uint64
 	count           int
 	bufferedBytes   int64
+	writeGeneration uint64
 	rootRuns        map[string][]memtable.Table
 	rootPolicies    map[string]backenddb.OrderedRootStoragePolicy
 	rootBaseIDs     map[string]uint64
@@ -405,6 +406,7 @@ type collectionWriteDomain struct {
 	uniqueValueIndex  map[string]*bufferedUniqueValueIndex
 	count             int
 	bufferedBytes     int64
+	writeGeneration   uint64
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -1439,6 +1441,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
 	domain.count += len(plan.resultIDs)
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
+	domain.writeGeneration++
 	c.meta = catalog.meta
 	if shouldFlushBufferedIndexedWrites(domain, catalog.meta.Options) {
 		flushStart := time.Now()
@@ -1533,6 +1536,7 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		primaryRoot:     domain.primaryRoot,
 		count:           domain.count,
 		bufferedBytes:   domain.bufferedBytes,
+		writeGeneration: domain.writeGeneration,
 		rootRuns:        cloneTableRunMap(domain.rootRuns),
 		rootPolicies:    cloneRootPolicyMap(domain.rootPolicies),
 		rootBaseIDs:     cloneUint64Map(domain.rootBaseIDs),
@@ -1554,6 +1558,7 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.primaryRoot = checkpoint.primaryRoot
 	domain.count = checkpoint.count
 	domain.bufferedBytes = checkpoint.bufferedBytes
+	domain.writeGeneration = checkpoint.writeGeneration
 	domain.rootRuns = checkpoint.rootRuns
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
@@ -3996,12 +4001,14 @@ type updateBatchPlan struct {
 	deltaTables                 []memtable.Table
 	canBufferIndexedUpdateBatch bool
 	bufferedBase                bool
+	bufferedReadGeneration      uint64
 	bufferedReadBlocked         bool
 }
 
 type updateBatchBufferedRead struct {
-	enabled     bool
-	primaryRuns []memtable.Table
+	enabled         bool
+	primaryRuns     []memtable.Table
+	writeGeneration uint64
 }
 
 type updateBatchCurrentDocument struct {
@@ -4233,8 +4240,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		domain.mu.RLock()
 		if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) {
 			bufferedRead = updateBatchBufferedRead{
-				enabled:     true,
-				primaryRuns: append([]memtable.Table(nil), domain.rootRuns[collectionPrimaryRootName(meta.Name)]...),
+				enabled:         true,
+				primaryRuns:     append([]memtable.Table(nil), domain.rootRuns[collectionPrimaryRootName(meta.Name)]...),
+				writeGeneration: domain.writeGeneration,
 			}
 			plannerOptions = collectionOptionsWithBufferedTemplateV1Resolver(plannerOptions, domain, meta.Name)
 		} else if domain.count > 0 && len(domain.rootRuns) > 0 {
@@ -4247,16 +4255,17 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	if primaryRoot == 0 && !bufferedRead.enabled {
 		primaryRootName := collectionPrimaryRootName(meta.Name)
 		return &updateBatchPlan{
-			results:             results,
-			meta:                meta,
-			catalog:             catalog,
-			snap:                snap,
-			baseUserRoot:        baseUserRoot,
-			baseSystemRoot:      baseSystemRoot,
-			baseCommitSeq:       baseCommitSeq,
-			rootNames:           []string{primaryRootName},
-			baseRootIDs:         map[string]uint64{primaryRootName: primaryRoot},
-			bufferedReadBlocked: bufferedReadBlocked,
+			results:                results,
+			meta:                   meta,
+			catalog:                catalog,
+			snap:                   snap,
+			baseUserRoot:           baseUserRoot,
+			baseSystemRoot:         baseSystemRoot,
+			baseCommitSeq:          baseCommitSeq,
+			rootNames:              []string{primaryRootName},
+			baseRootIDs:            map[string]uint64{primaryRootName: primaryRoot},
+			bufferedReadGeneration: bufferedRead.writeGeneration,
+			bufferedReadBlocked:    bufferedReadBlocked,
 		}, nil
 	}
 	runtimes, err := (insertBatchPlanner{
@@ -4514,6 +4523,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		baseRootIDs:                 baseRootIDs,
 		canBufferIndexedUpdateBatch: canBufferIndexedUpdateBatch,
 		bufferedBase:                bufferedRead.enabled,
+		bufferedReadGeneration:      bufferedRead.writeGeneration,
 		bufferedReadBlocked:         bufferedReadBlocked,
 		policies:                    policies,
 		deltaTables:                 deltaTables,
@@ -4603,6 +4613,9 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			// before a concurrent buffered write is not published against stale roots.
 			return false, ErrConcurrentMutation
 		}
+		if plan.bufferedReadGeneration != domain.writeGeneration {
+			return false, ErrConcurrentMutation
+		}
 	}
 	if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
 		return false, err
@@ -4666,6 +4679,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	}
 	domain.count += modifiedCount
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
+	domain.writeGeneration++
 	c.meta = plan.meta
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		if err := c.flushBufferedIndexedLocked(domain); err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2376,14 +2376,15 @@ func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {
 		roots: map[string]uint64{collectionPrimaryRootName("users"): 42},
 	}
 	domain := &collectionWriteDomain{
-		loaded:         true,
-		meta:           catalog.meta,
-		catalog:        catalog,
-		baseCommitSeq:  7,
-		baseSystemRoot: 11,
-		primaryRoot:    42,
-		count:          3,
-		bufferedBytes:  99,
+		loaded:          true,
+		meta:            catalog.meta,
+		catalog:         catalog,
+		baseCommitSeq:   7,
+		baseSystemRoot:  11,
+		primaryRoot:     42,
+		count:           3,
+		bufferedBytes:   99,
+		writeGeneration: 12,
 		rootRuns: map[string][]memtable.Table{
 			collectionPrimaryRootName("users"): nil,
 		},
@@ -2407,6 +2408,7 @@ func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {
 	domain.primaryRoot = 300
 	domain.count = 400
 	domain.bufferedBytes = 500
+	domain.writeGeneration = 600
 	domain.rootRuns = map[string][]memtable.Table{collectionPrimaryRootName("other"): nil}
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
@@ -2419,8 +2421,8 @@ func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {
 	if domain.baseCommitSeq != 7 || domain.baseSystemRoot != 11 || domain.primaryRoot != 42 {
 		t.Fatalf("roots after rollback commit=%d system=%d primary=%d", domain.baseCommitSeq, domain.baseSystemRoot, domain.primaryRoot)
 	}
-	if domain.count != 3 || domain.bufferedBytes != 99 {
-		t.Fatalf("counters after rollback count=%d bytes=%d", domain.count, domain.bufferedBytes)
+	if domain.count != 3 || domain.bufferedBytes != 99 || domain.writeGeneration != 12 {
+		t.Fatalf("counters after rollback count=%d bytes=%d generation=%d", domain.count, domain.bufferedBytes, domain.writeGeneration)
 	}
 	if _, ok := domain.rootRuns[collectionPrimaryRootName("users")]; !ok {
 		t.Fatalf("rootRuns=%v missing users primary root", domain.rootRuns)
@@ -4453,6 +4455,75 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesAppendsToBufferedUp
 	flushed := d.State()
 	if flushed.CommitSeq != before.CommitSeq+1 {
 		t.Fatalf("flush advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
+	}
+}
+
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStaleBufferedPlan(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"a@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("sea")},
+	}); err != nil {
+		t.Fatalf("first UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("first batch was declined")
+	}
+
+	plan, err := col.buildUpdateBatchPlan([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("sfo")},
+	}, updateBatchModeNoSecondaryUniqueIndexChanges, true)
+	if err != nil {
+		t.Fatalf("build stale plan: %v", err)
+	}
+	defer plan.close()
+	if !plan.bufferedBase || plan.bufferedReadGeneration == 0 {
+		t.Fatalf("plan bufferedBase=%v generation=%d want buffered read", plan.bufferedBase, plan.bufferedReadGeneration)
+	}
+
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("oak")},
+	}); err != nil {
+		t.Fatalf("second UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("second batch was declined")
+	}
+
+	err = col.withMutationLock(func() error {
+		buffered, err := col.bufferUpdateBatchPlanLocked(plan)
+		if buffered {
+			t.Fatalf("stale plan buffered successfully")
+		}
+		return err
+	})
+	if !errors.Is(err, ErrConcurrentMutation) {
+		t.Fatalf("buffer stale plan err=%v want ErrConcurrentMutation", err)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4293,6 +4293,9 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesReadsBufferedAfterR
 	if rawState.SystemRootPageID != before.SystemRootPageID {
 		t.Fatalf("raw write changed system root from %d to %d", before.SystemRootPageID, rawState.SystemRootPageID)
 	}
+	if rawState.CommitSeq == before.CommitSeq {
+		t.Fatalf("raw write did not advance commit seq: before=%d after=%d", before.CommitSeq, rawState.CommitSeq)
+	}
 	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
 		{DocumentID: []byte("u1"), Update: setJSONCity("sfo")},
 	}); err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4376,6 +4376,66 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesReadsBufferedAfterR
 	}
 }
 
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesFlushesUnreadableBufferedInsert(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create users collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open users collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"a@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert buffered document: %v", err)
+	}
+	beforeSchemaChange := d.State()
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "audit"}); err != nil {
+		t.Fatalf("create audit collection: %v", err)
+	}
+	afterSchemaChange := d.State()
+	if afterSchemaChange.SystemRootPageID == beforeSchemaChange.SystemRootPageID {
+		t.Fatalf("schema change did not advance system root: before=%d after=%d", beforeSchemaChange.SystemRootPageID, afterSchemaChange.SystemRootPageID)
+	}
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("sea")},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatalf("batched=%v results=%+v want batched", batched, results)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("results=%+v want one modified row from flushed buffered insert", results)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq == afterSchemaChange.CommitSeq {
+		t.Fatalf("unreadable buffered insert was not flushed before update: commit seq stayed %d", afterUpdate.CommitSeq)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("sea ids=%q want [u1]", seaIDs)
+	}
+}
+
 func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesReadsBufferedInsert(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4194,6 +4194,74 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesAppendsToBufferedUp
 	}
 }
 
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesReadsBufferedAfterRawCommit(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"a@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	before := d.State()
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("sea")},
+	}); err != nil {
+		t.Fatalf("first UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("first batch was declined")
+	}
+	if err := d.Set([]byte("raw/unrelated"), []byte("value")); err != nil {
+		t.Fatalf("raw set: %v", err)
+	}
+	rawState := d.State()
+	if rawState.SystemRootPageID != before.SystemRootPageID {
+		t.Fatalf("raw write changed system root from %d to %d", before.SystemRootPageID, rawState.SystemRootPageID)
+	}
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("sfo")},
+	}); err != nil {
+		t.Fatalf("second UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("second batch was declined")
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city: %v", err)
+	}
+	if len(seaIDs) != 0 {
+		t.Fatalf("sea ids=%q want none after raw commit plus second buffered update", seaIDs)
+	}
+	sfoIDs, err := col.FindByIndex("city", "sfo")
+	if err != nil {
+		t.Fatalf("find sfo city: %v", err)
+	}
+	if len(sfoIDs) != 1 || !bytes.Equal(sfoIDs[0], []byte("u1")) {
+		t.Fatalf("sfo ids=%q want [u1]", sfoIDs)
+	}
+}
+
 func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesReadsBufferedInsert(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -19,6 +19,7 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/node"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
@@ -2304,6 +2305,24 @@ func TestBufferedPrimaryIDArenaCapAvoidsOverflow(t *testing.T) {
 	}
 	if got := bufferedPrimaryIDArenaCap(maxCollectionInt/16 + 1); got != 0 {
 		t.Fatalf("overflow arena cap=%d want 0", got)
+	}
+}
+
+func TestCloneCollectionRunTablesSurvivesSourceReset(t *testing.T) {
+	table := newCollectionRunTable(1)
+	setCollectionRunValue(table, []byte("k"), []byte("value"))
+	table.Freeze()
+
+	cloned, err := cloneCollectionRunTables([]memtable.Table{table})
+	if err != nil {
+		t.Fatalf("clone tables: %v", err)
+	}
+	defer resetCollectionTables(cloned)
+	resetCollectionRunTable(table)
+
+	value, _, flags, found := cloned[0].GetEntry([]byte("k"))
+	if !found || flags&node.FlagTombstone != 0 || !bytes.Equal(value, []byte("value")) {
+		t.Fatalf("cloned entry found=%v flags=%d value=%q want live value", found, flags, value)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4458,12 +4458,13 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesAppendsToBufferedUp
 	}
 }
 
-func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStaleBufferedPlan(t *testing.T) {
+func newBufferedUsersUpdateCollection(t *testing.T) (*backenddb.DB, *Collection) {
+	t.Helper()
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	defer func() { _ = d.Close() }()
+	t.Cleanup(func() { _ = d.Close() })
 
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{
@@ -4488,6 +4489,11 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStaleBuffere
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush insert buffer: %v", err)
 	}
+	return d, col
+}
+
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStaleBufferedPlan(t *testing.T) {
+	_, col := newBufferedUsersUpdateCollection(t)
 	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
 		{DocumentID: []byte("u1"), Update: setJSONCity("sea")},
 	}); err != nil {
@@ -4505,6 +4511,9 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStaleBuffere
 	defer plan.close()
 	if !plan.bufferedBase || plan.bufferedReadGeneration == 0 {
 		t.Fatalf("plan bufferedBase=%v generation=%d want buffered read", plan.bufferedBase, plan.bufferedReadGeneration)
+	}
+	if !col.bufferedUpdateBatchPlanStillCurrent(plan) {
+		t.Fatalf("fresh buffered plan was unexpectedly stale")
 	}
 
 	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
@@ -4524,6 +4533,50 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStaleBuffere
 	})
 	if !errors.Is(err, ErrConcurrentMutation) {
 		t.Fatalf("buffer stale plan err=%v want ErrConcurrentMutation", err)
+	}
+}
+
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStaleZeroDeltaPlan(t *testing.T) {
+	_, col := newBufferedUsersUpdateCollection(t)
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("sea")},
+	}); err != nil {
+		t.Fatalf("first UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("first batch was declined")
+	}
+
+	plan, err := col.buildUpdateBatchPlan([]UpdateBatchItem{
+		{
+			DocumentID: []byte("u1"),
+			Update: func(current []byte) ([]byte, bool, error) {
+				if !bytes.Contains(current, []byte(`"city":"sea"`)) {
+					return nil, false, fmt.Errorf("current document %s did not include buffered city", current)
+				}
+				return current, false, nil
+			},
+		},
+	}, updateBatchModeNoSecondaryUniqueIndexChanges, true)
+	if err != nil {
+		t.Fatalf("build stale zero-delta plan: %v", err)
+	}
+	defer plan.close()
+	if len(plan.deltaTables) != 0 || !plan.bufferedBase || plan.bufferedReadGeneration == 0 {
+		t.Fatalf("plan deltas=%d bufferedBase=%v generation=%d want zero-delta buffered read", len(plan.deltaTables), plan.bufferedBase, plan.bufferedReadGeneration)
+	}
+	if !col.bufferedUpdateBatchPlanStillCurrent(plan) {
+		t.Fatalf("fresh zero-delta plan was unexpectedly stale")
+	}
+
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("oak")},
+	}); err != nil {
+		t.Fatalf("second UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("second batch was declined")
+	}
+	if col.bufferedUpdateBatchPlanStillCurrent(plan) {
+		t.Fatalf("stale zero-delta plan still appeared current")
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4035,6 +4035,150 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesBatchesNonUniqueUpd
 	}
 }
 
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesAppendsToBufferedUpdates(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"a@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	before := d.State()
+
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("sea")},
+	}); err != nil {
+		t.Fatalf("first UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("first batch was declined")
+	}
+	afterFirst := d.State()
+	if afterFirst.CommitSeq != before.CommitSeq {
+		t.Fatalf("first buffered batch advanced commit seq by %d, want 0", afterFirst.CommitSeq-before.CommitSeq)
+	}
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("sfo")},
+	}); err != nil {
+		t.Fatalf("second UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("second batch was declined")
+	}
+	afterSecond := d.State()
+	if afterSecond.CommitSeq != before.CommitSeq {
+		t.Fatalf("second buffered batch advanced commit seq by %d, want 0", afterSecond.CommitSeq-before.CommitSeq)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city: %v", err)
+	}
+	if len(seaIDs) != 0 {
+		t.Fatalf("sea ids=%q want none after second buffered update", seaIDs)
+	}
+	sfoIDs, err := col.FindByIndex("city", "sfo")
+	if err != nil {
+		t.Fatalf("find sfo city: %v", err)
+	}
+	if len(sfoIDs) != 1 || !bytes.Equal(sfoIDs[0], []byte("u1")) {
+		t.Fatalf("sfo ids=%q want [u1]", sfoIDs)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered update batches: %v", err)
+	}
+	flushed := d.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flush advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
+	}
+}
+
+func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesReadsBufferedInsert(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	before := d.State()
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"a@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert buffered document: %v", err)
+	}
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("sea")},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatalf("batched=%v results=%+v want batched", batched, results)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("results=%+v want one modified row", results)
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("buffered insert+update advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
+	}
+	hnlIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find hnl city: %v", err)
+	}
+	if len(hnlIDs) != 0 {
+		t.Fatalf("hnl ids=%q want none after buffered insert+update", hnlIDs)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("sea ids=%q want [u1]", seaIDs)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered insert+update: %v", err)
+	}
+	flushed := d.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flush advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
+	}
+}
+
 func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesDeclinesUniqueUpdates(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4344,6 +4344,13 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesReadsBufferedAfterR
 	} else if !batched {
 		t.Fatalf("second batch was declined")
 	}
+	afterSecondState := d.State()
+	if afterSecondState.CommitSeq != rawState.CommitSeq {
+		t.Fatalf("second buffered update advanced commit seq: raw=%d after=%d", rawState.CommitSeq, afterSecondState.CommitSeq)
+	}
+	if afterSecondState.SystemRootPageID != rawState.SystemRootPageID {
+		t.Fatalf("second buffered update changed system root from %d to %d", rawState.SystemRootPageID, afterSecondState.SystemRootPageID)
+	}
 	seaIDs, err := col.FindByIndex("city", "sea")
 	if err != nil {
 		t.Fatalf("find sea city: %v", err)
@@ -4357,6 +4364,13 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesReadsBufferedAfterR
 	}
 	if len(sfoIDs) != 1 || !bytes.Equal(sfoIDs[0], []byte("u1")) {
 		t.Fatalf("sfo ids=%q want [u1]", sfoIDs)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered updates: %v", err)
+	}
+	flushedState := d.State()
+	if flushedState.CommitSeq != afterSecondState.CommitSeq+1 {
+		t.Fatalf("flush commit seq=%d want %d", flushedState.CommitSeq, afterSecondState.CommitSeq+1)
 	}
 }
 

--- a/TreeDB/collections/template_v1.go
+++ b/TreeDB/collections/template_v1.go
@@ -151,6 +151,13 @@ func collectionOptionsWithBufferedTemplateV1Resolver(opts collectionOptions, dom
 	if len(runs) == 0 {
 		return opts
 	}
+	return collectionOptionsWithBufferedTemplateV1RunsResolver(opts, runs)
+}
+
+func collectionOptionsWithBufferedTemplateV1RunsResolver(opts collectionOptions, runs []memtable.Table) collectionOptions {
+	if normalizedDocumentFormat(opts.documentFormat) != DocumentFormatTemplateV1 || len(runs) == 0 {
+		return opts
+	}
 	opts.templateResolver = &templateV1BufferedRunsResolver{
 		runs:     runs,
 		fallback: opts.templateResolver,


### PR DESCRIPTION
## Summary
- let safe indexed update batches plan against pending buffered indexed writes instead of forcing a pre-plan flush
- allow safe update batch delta tables to append to an existing indexed write domain when they were planned from the same buffered base
- cover consecutive safe update batches and update-after-buffered-insert visibility before/after flush

## Benchmark
Focused local benchmark on Apple M3:

```text
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=10000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
go test ./cmd/mongo_gateway_bench -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=80000x -count=1
```

Latest post-review result on this branch:

```text
80000  30476 ns/op  32812 docs/sec  30476 ns/doc  8.000 writers  29415 B/op  102 allocs/op
```

Earlier local run on this branch before review cleanup measured `33985 docs/sec` / `29424 ns/doc`. For context, PR1123 was about `30376 docs/sec` / `32921 ns/doc`, and the earlier PR1121 post-review baseline was about `32851 docs/sec` / `30441 ns/doc`. I would read this PR as correctness/enabling work with small, noisy throughput movement rather than a decisive benchmark win.

## Validation
- `go test ./TreeDB/collections -run 'TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChanges(BatchesNonUniqueUpdates|AppendsToBufferedUpdates|ReadsBufferedInsert|DeclinesUniqueUpdates)|TestCollectionUpdateCombinerBatchesWhenSecondaryUniqueValuesAreUnchanged|TestCollectionIndexedWriteMemtablesFind(SkipsBufferedSecondaryTombstone|LimitFiltersOnlyBufferedTombstone)|TestBufferedRootRunsIteratorSingleRunHidesTombstones' -count 1`
- `go test ./TreeDB/collections -count 1`
- `go test ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench ./cmd/mongo_gateway_compare_report -count 1`
