### PR TITLE
Optimize buffered primary collection reads

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -378,6 +378,17 @@ type bufferedUniqueValueIndex struct {
 	arenas     [][]byte
 }
 
+type bufferedPrimaryRunIndex struct {
+	values     map[uint64]bufferedPrimaryRunRef
+	collisions map[uint64][]bufferedPrimaryRunRef
+	arenas     [][]byte
+}
+
+type bufferedPrimaryRunRef struct {
+	key   []byte
+	table memtable.Table
+}
+
 type collectionWriteDomain struct {
 	// mutationMu serializes root descriptor publishes for handles opened
 	// through the same manager so optimistic retries do not starve under
@@ -402,11 +413,14 @@ type collectionWriteDomain struct {
 	rootPolicies      map[string]backenddb.OrderedRootStoragePolicy
 	rootBaseIDs       map[string]uint64
 	primaryIDIndex    *bufferedUniqueValueIndex
-	uniqueValueRuns   map[string][]memtable.Table
-	uniqueValueIndex  map[string]*bufferedUniqueValueIndex
-	count             int
-	bufferedBytes     int64
-	writeGeneration   uint64
+	// Built lazily by readers so write-only indexed buffering does not pay for
+	// an auxiliary lookup structure it never uses.
+	primaryRunIndex  *bufferedPrimaryRunIndex
+	uniqueValueRuns  map[string][]memtable.Table
+	uniqueValueIndex map[string]*bufferedUniqueValueIndex
+	count            int
+	bufferedBytes    int64
+	writeGeneration  uint64
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -1423,6 +1437,15 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 				}
 				return 0, err
 			}
+			if domain.primaryRunIndex != nil {
+				if err := addBufferedPrimaryRunIndexEntries(domain.primaryRunIndex, run.table); err != nil {
+					domain.primaryRunIndex = nil
+					if autoFlushEnabled {
+						rollbackBufferedIndexedDomain(domain, checkpoint)
+					}
+					return 0, err
+				}
+			}
 		}
 		if uniqueValueTable != nil {
 			domain.uniqueValueRuns[run.indexName] = append(domain.uniqueValueRuns[run.indexName], uniqueValueTable)
@@ -1465,6 +1488,7 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.primaryIDIndex = nil
+	domain.primaryRunIndex = nil
 	domain.uniqueValueRuns = nil
 	domain.uniqueValueIndex = nil
 	domain.bufferedBytes = 0
@@ -1563,6 +1587,7 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
 	domain.primaryIDIndex = rebuildBufferedPrimaryIDIndex(checkpoint.meta.Name, checkpoint.rootRuns)
+	domain.primaryRunIndex = rebuildBufferedPrimaryRunIndex(checkpoint.meta.Name, checkpoint.rootRuns)
 	domain.uniqueValueRuns = checkpoint.uniqueValueRuns
 	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(checkpoint.uniqueValueRuns)
 }
@@ -1779,6 +1804,93 @@ func addBufferedPrimaryIDs(index *bufferedUniqueValueIndex, batchPrimary memtabl
 	return nil
 }
 
+func newBufferedPrimaryRunIndex(capacity int) *bufferedPrimaryRunIndex {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return &bufferedPrimaryRunIndex{values: make(map[uint64]bufferedPrimaryRunRef, capacity)}
+}
+
+func (index *bufferedPrimaryRunIndex) addRef(hash uint64, ref bufferedPrimaryRunRef) {
+	if index == nil || ref.table == nil {
+		return
+	}
+	if existing, ok := index.values[hash]; !ok {
+		index.values[hash] = ref
+		return
+	} else if bytes.Equal(existing.key, ref.key) {
+		index.values[hash] = ref
+		return
+	}
+	collisions := index.collisions
+	if collisions == nil {
+		collisions = make(map[uint64][]bufferedPrimaryRunRef)
+		index.collisions = collisions
+	}
+	bucket := collisions[hash]
+	for i := len(bucket) - 1; i >= 0; i-- {
+		if bytes.Equal(bucket[i].key, ref.key) {
+			bucket[i] = ref
+			collisions[hash] = bucket
+			return
+		}
+	}
+	collisions[hash] = append(bucket, ref)
+}
+
+func (index *bufferedPrimaryRunIndex) lookup(key []byte) (memtable.Table, bool) {
+	if index == nil {
+		return nil, false
+	}
+	hash := xxhash.Sum64(key)
+	if ref, ok := index.values[hash]; ok && bytes.Equal(ref.key, key) {
+		return ref.table, true
+	}
+	for _, ref := range index.collisions[hash] {
+		if bytes.Equal(ref.key, key) {
+			return ref.table, true
+		}
+	}
+	return nil, false
+}
+
+func addBufferedPrimaryRunIndexEntries(index *bufferedPrimaryRunIndex, batchPrimary memtable.Table) error {
+	if index == nil || batchPrimary == nil {
+		return nil
+	}
+	stableKeys := false
+	if stable, ok := batchPrimary.(memtable.StableUnsafeIteratorTable); ok {
+		stableKeys = stable.StableUnsafeIteratorSlices()
+	}
+	arena := make([]byte, 0, bufferedPrimaryIDArenaCap(batchPrimary.Len()))
+	refs := make([]bufferedPrimaryRunRef, 0, batchPrimary.Len())
+	hashes := make([]uint64, 0, batchPrimary.Len())
+	it := batchPrimary.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		key := it.UnsafeKey()
+		refKey := key
+		if !stableKeys {
+			start := len(arena)
+			arena = append(arena, key...)
+			refKey = arena[start:len(arena)]
+		}
+		hashes = append(hashes, xxhash.Sum64(key))
+		refs = append(refs, bufferedPrimaryRunRef{key: refKey, table: batchPrimary})
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return err
+	}
+	for i, ref := range refs {
+		index.addRef(hashes[i], ref)
+	}
+	if len(arena) > 0 {
+		index.arenas = append(index.arenas, arena)
+	}
+	return nil
+}
+
 func bufferedPrimaryIDArenaCap(entries int) int {
 	if entries <= 0 {
 		return 0
@@ -1788,6 +1900,26 @@ func bufferedPrimaryIDArenaCap(entries int) int {
 		return 0
 	}
 	return entries * bytesPerKeyEstimate
+}
+
+func rebuildBufferedPrimaryRunIndex(collectionName string, runs map[string][]memtable.Table) *bufferedPrimaryRunIndex {
+	if collectionName == "" || len(runs) == 0 {
+		return nil
+	}
+	tables := runs[collectionPrimaryRootName(collectionName)]
+	if len(tables) == 0 {
+		return nil
+	}
+	index := newBufferedPrimaryRunIndex(0)
+	for _, table := range tables {
+		if err := addBufferedPrimaryRunIndexEntries(index, table); err != nil {
+			return nil
+		}
+	}
+	if len(index.values) == 0 {
+		return nil
+	}
+	return index
 }
 
 func rebuildBufferedPrimaryIDIndex(collectionName string, runs map[string][]memtable.Table) *bufferedUniqueValueIndex {
@@ -2303,6 +2435,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.primaryIDIndex = nil
+	domain.primaryRunIndex = nil
 	oldUniqueValueRuns := domain.uniqueValueRuns
 	domain.uniqueValueRuns = nil
 	domain.uniqueValueIndex = nil
@@ -4813,6 +4946,16 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		} else if domain.rootBaseIDs[rootName] != baseRoot {
 			return false, errConcurrentRootModification(plan.meta.Name, rootName)
 		}
+		if rootName == collectionPrimaryRootName(plan.meta.Name) && domain.primaryRunIndex != nil {
+			if err := addBufferedPrimaryRunIndexEntries(domain.primaryRunIndex, table); err != nil {
+				domain.primaryRunIndex = nil
+				if shouldAutoFlushAfterAdding {
+					rollbackBufferedIndexedDomain(domain, checkpoint)
+					c.meta = collectionMetaCheckpoint
+				}
+				return false, err
+			}
+		}
 		domain.rootPolicies[rootName] = plan.policies[i]
 		domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)
 		plan.deltaTables[i] = nil
@@ -5135,6 +5278,7 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.primaryIDIndex = nil
+	domain.primaryRunIndex = nil
 	domain.uniqueValueRuns = nil
 	domain.uniqueValueIndex = nil
 	if domain.table == nil {
@@ -5739,17 +5883,54 @@ func (c *Collection) getBufferedDocumentInto(documentID []byte, dst []byte) ([]b
 	}
 	domain := c.writeDomain
 	domain.mu.RLock()
-	defer domain.mu.RUnlock()
+	if domain.count == 0 {
+		domain.mu.RUnlock()
+		return nil, false, false
+	}
+	if len(domain.rootRuns) > 0 && domain.primaryRunIndex == nil {
+		domain.mu.RUnlock()
+		return c.getBufferedDocumentIntoWithPrimaryRunIndex(documentID, dst)
+	}
+	value, buffered, found := c.getBufferedDocumentIntoLocked(domain, documentID, dst)
+	domain.mu.RUnlock()
+	return value, buffered, found
+}
+
+func (c *Collection) getBufferedDocumentIntoWithPrimaryRunIndex(documentID []byte, dst []byte) ([]byte, bool, bool) {
+	domain := c.writeDomain
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
 	if domain.count == 0 {
 		return nil, false, false
 	}
+	if len(domain.rootRuns) > 0 && domain.primaryRunIndex == nil {
+		collectionName := domain.meta.Name
+		if collectionName == "" {
+			collectionName = c.meta.Name
+		}
+		if index := rebuildBufferedPrimaryRunIndex(collectionName, domain.rootRuns); index != nil {
+			domain.primaryRunIndex = index
+		}
+	}
+	return c.getBufferedDocumentIntoLocked(domain, documentID, dst)
+}
+
+func (c *Collection) getBufferedDocumentIntoLocked(domain *collectionWriteDomain, documentID []byte, dst []byte) ([]byte, bool, bool) {
 	table := domain.table
 	if len(domain.rootRuns) > 0 {
 		name := collectionPrimaryRootName(c.meta.Name)
 		if domain.meta.Name != "" {
 			name = collectionPrimaryRootName(domain.meta.Name)
 		}
-		if value, _, flags, found := getBufferedRunEntry(domain.rootRuns[name], documentID); found {
+		var value []byte
+		var flags byte
+		found := false
+		if table, ok := domain.primaryRunIndex.lookup(documentID); ok {
+			value, _, flags, found = table.GetEntry(documentID)
+		} else if domain.primaryRunIndex == nil {
+			value, _, flags, found = getBufferedRunEntry(domain.rootRuns[name], documentID)
+		}
+		if found {
 			if flags&node.FlagTombstone != 0 {
 				return dst[:0], true, false
 			}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -357,19 +357,20 @@ type noIndexBatchEntry struct {
 }
 
 type bufferedIndexedCheckpoint struct {
-	loaded          bool
-	meta            CollectionMeta
-	catalog         *collectionCatalog
-	baseCommitSeq   uint64
-	baseSystemRoot  uint64
-	primaryRoot     uint64
-	count           int
-	bufferedBytes   int64
-	writeGeneration uint64
-	rootRuns        map[string][]memtable.Table
-	rootPolicies    map[string]backenddb.OrderedRootStoragePolicy
-	rootBaseIDs     map[string]uint64
-	uniqueValueRuns map[string][]memtable.Table
+	loaded                bool
+	meta                  CollectionMeta
+	catalog               *collectionCatalog
+	baseCommitSeq         uint64
+	baseSystemRoot        uint64
+	primaryRoot           uint64
+	count                 int
+	bufferedBytes         int64
+	writeGeneration       uint64
+	rootRuns              map[string][]memtable.Table
+	rootPolicies          map[string]backenddb.OrderedRootStoragePolicy
+	rootBaseIDs           map[string]uint64
+	primaryRunIndexActive bool
+	uniqueValueRuns       map[string][]memtable.Table
 }
 
 type bufferedUniqueValueIndex struct {
@@ -1552,19 +1553,20 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		return bufferedIndexedCheckpoint{}
 	}
 	return bufferedIndexedCheckpoint{
-		loaded:          domain.loaded,
-		meta:            domain.meta,
-		catalog:         domain.catalog,
-		baseCommitSeq:   domain.baseCommitSeq,
-		baseSystemRoot:  domain.baseSystemRoot,
-		primaryRoot:     domain.primaryRoot,
-		count:           domain.count,
-		bufferedBytes:   domain.bufferedBytes,
-		writeGeneration: domain.writeGeneration,
-		rootRuns:        cloneTableRunMap(domain.rootRuns),
-		rootPolicies:    cloneRootPolicyMap(domain.rootPolicies),
-		rootBaseIDs:     cloneUint64Map(domain.rootBaseIDs),
-		uniqueValueRuns: cloneTableRunMap(domain.uniqueValueRuns),
+		loaded:                domain.loaded,
+		meta:                  domain.meta,
+		catalog:               domain.catalog,
+		baseCommitSeq:         domain.baseCommitSeq,
+		baseSystemRoot:        domain.baseSystemRoot,
+		primaryRoot:           domain.primaryRoot,
+		count:                 domain.count,
+		bufferedBytes:         domain.bufferedBytes,
+		writeGeneration:       domain.writeGeneration,
+		rootRuns:              cloneTableRunMap(domain.rootRuns),
+		rootPolicies:          cloneRootPolicyMap(domain.rootPolicies),
+		rootBaseIDs:           cloneUint64Map(domain.rootBaseIDs),
+		primaryRunIndexActive: domain.primaryRunIndex != nil,
+		uniqueValueRuns:       cloneTableRunMap(domain.uniqueValueRuns),
 	}
 }
 
@@ -1587,7 +1589,11 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
 	domain.primaryIDIndex = rebuildBufferedPrimaryIDIndex(checkpoint.meta.Name, checkpoint.rootRuns)
-	domain.primaryRunIndex = rebuildBufferedPrimaryRunIndex(checkpoint.meta.Name, checkpoint.rootRuns)
+	if checkpoint.primaryRunIndexActive {
+		domain.primaryRunIndex = rebuildBufferedPrimaryRunIndex(checkpoint.meta.Name, checkpoint.rootRuns)
+	} else {
+		domain.primaryRunIndex = nil
+	}
 	domain.uniqueValueRuns = checkpoint.uniqueValueRuns
 	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(checkpoint.uniqueValueRuns)
 }
@@ -5887,7 +5893,7 @@ func (c *Collection) getBufferedDocumentInto(documentID []byte, dst []byte) ([]b
 		domain.mu.RUnlock()
 		return nil, false, false
 	}
-	if len(domain.rootRuns) > 0 && domain.primaryRunIndex == nil {
+	if domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, c.meta.Name) {
 		domain.mu.RUnlock()
 		return c.getBufferedDocumentIntoWithPrimaryRunIndex(documentID, dst)
 	}
@@ -5903,16 +5909,31 @@ func (c *Collection) getBufferedDocumentIntoWithPrimaryRunIndex(documentID []byt
 	if domain.count == 0 {
 		return nil, false, false
 	}
-	if len(domain.rootRuns) > 0 && domain.primaryRunIndex == nil {
-		collectionName := domain.meta.Name
-		if collectionName == "" {
-			collectionName = c.meta.Name
-		}
+	if domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, c.meta.Name) {
+		collectionName := bufferedDomainCollectionName(domain, c.meta.Name)
 		if index := rebuildBufferedPrimaryRunIndex(collectionName, domain.rootRuns); index != nil {
 			domain.primaryRunIndex = index
 		}
 	}
 	return c.getBufferedDocumentIntoLocked(domain, documentID, dst)
+}
+
+func bufferedDomainCollectionName(domain *collectionWriteDomain, fallback string) string {
+	if domain != nil && domain.meta.Name != "" {
+		return domain.meta.Name
+	}
+	return fallback
+}
+
+func hasBufferedPrimaryRootRuns(domain *collectionWriteDomain, fallbackCollectionName string) bool {
+	if domain == nil || len(domain.rootRuns) == 0 {
+		return false
+	}
+	collectionName := bufferedDomainCollectionName(domain, fallbackCollectionName)
+	if collectionName == "" {
+		return false
+	}
+	return len(domain.rootRuns[collectionPrimaryRootName(collectionName)]) > 0
 }
 
 func (c *Collection) getBufferedDocumentIntoLocked(domain *collectionWriteDomain, documentID []byte, dst []byte) ([]byte, bool, bool) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1346,6 +1346,57 @@ func TestCollectionIndexedWriteMemtablesReadUniqueAndFlush(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesReadFlushedDocumentWithBufferedRuns(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert flushed document: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush document: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"city":"sea"}`)},
+	); err != nil {
+		t.Fatalf("insert buffered document: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get flushed document with buffered runs: %v", err)
+	}
+	if want := []byte(`{"city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("flushed document=%q want %q", got, want)
+	}
+	got, err = col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get buffered document: %v", err)
+	}
+	if want := []byte(`{"city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("buffered document=%q want %q", got, want)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesDefaultForIndexedSchemas(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -2323,6 +2374,33 @@ func TestCloneCollectionRunTablesSurvivesSourceReset(t *testing.T) {
 	value, _, flags, found := cloned[0].GetEntry([]byte("k"))
 	if !found || flags&node.FlagTombstone != 0 || !bytes.Equal(value, []byte("value")) {
 		t.Fatalf("cloned entry found=%v flags=%d value=%q want live value", found, flags, value)
+	}
+}
+
+func TestBufferedPrimaryRunIndexFindsNewestTable(t *testing.T) {
+	older := newCollectionRunTable(1)
+	setCollectionRunValue(older, []byte("u1"), []byte("older"))
+	older.Freeze()
+	newer := newCollectionRunTable(1)
+	setCollectionRunValue(newer, []byte("u1"), []byte("newer"))
+	newer.Freeze()
+	defer resetCollectionRunTable(older)
+	defer resetCollectionRunTable(newer)
+
+	index := newBufferedPrimaryRunIndex(0)
+	if err := addBufferedPrimaryRunIndexEntries(index, older); err != nil {
+		t.Fatalf("add older table: %v", err)
+	}
+	if err := addBufferedPrimaryRunIndexEntries(index, newer); err != nil {
+		t.Fatalf("add newer table: %v", err)
+	}
+	table, ok := index.lookup([]byte("u1"))
+	if !ok {
+		t.Fatal("lookup u1 missing")
+	}
+	value, _, flags, found := table.GetEntry([]byte("u1"))
+	if !found || flags&node.FlagTombstone != 0 || !bytes.Equal(value, []byte("newer")) {
+		t.Fatalf("lookup found=%v flags=%d value=%q want newer live value", found, flags, value)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2509,6 +2509,7 @@ func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {
 	domain.rootRuns = map[string][]memtable.Table{collectionPrimaryRootName("other"): nil}
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
+	domain.primaryRunIndex = newBufferedPrimaryRunIndex(1)
 	domain.uniqueValueRuns = nil
 
 	rollbackBufferedIndexedDomain(domain, checkpoint)
@@ -2524,8 +2525,30 @@ func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {
 	if _, ok := domain.rootRuns[collectionPrimaryRootName("users")]; !ok {
 		t.Fatalf("rootRuns=%v missing users primary root", domain.rootRuns)
 	}
+	if domain.primaryRunIndex != nil {
+		t.Fatal("rollback rebuilt lazy primary run index that was absent at checkpoint")
+	}
 	if _, ok := domain.uniqueValueRuns[collectionSecondaryRootName("users", "email")]; !ok {
 		t.Fatalf("uniqueValueRuns=%v missing users email root", domain.uniqueValueRuns)
+	}
+}
+
+func TestHasBufferedPrimaryRootRunsIgnoresSecondaryOnlyRuns(t *testing.T) {
+	domain := &collectionWriteDomain{
+		meta: CollectionMeta{Name: "users"},
+		rootRuns: map[string][]memtable.Table{
+			collectionSecondaryRootName("users", "email"): {newCollectionRunTable(0)},
+		},
+	}
+	if hasBufferedPrimaryRootRuns(domain, "users") {
+		t.Fatal("secondary-only buffered runs reported primary runs")
+	}
+	domain.rootRuns[collectionPrimaryRootName("users")] = []memtable.Table{newCollectionRunTable(0)}
+	if !hasBufferedPrimaryRootRuns(domain, "users") {
+		t.Fatal("primary buffered run not detected")
+	}
+	for _, tables := range domain.rootRuns {
+		resetCollectionTables(tables)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a lazy primary-run index for buffered indexed collection root runs
- use it to prove both positive and negative buffered primary lookups without reverse-scanning every buffered run
- keep the index lazy so write-only indexed buffering does not pay the extra map/allocation cost

## Benchmark evidence
Compared locally against PR1125 (`codex/collection-rw-scaling-bench`, commit `7d8d88bc78`) using:

```bash
TREEDB_COLLECTION_BENCH_BATCH_SIZE=128 \
TREEDB_COLLECTION_MIXED_SEED_DOCS=4096 \
TREEDB_COLLECTION_MIXED_WRITE_BATCH_SIZE=128 \
go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkCollectionMixedReadWriteScalingPrimary$/readers_8/writers_2$' \
  -benchtime=20000x -count=3
```

PR1125 baseline:

| run | ns/op | reader_ops/sec | writer_docs/sec | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 10,398 | 96,170 | 318,599 | 18,378 | 25 |
| 2 | 10,116 | 98,856 | 320,520 | 18,247 | 25 |
| 3 | 10,118 | 98,834 | 319,809 | 18,241 | 25 |

This PR:

| run | ns/op | reader_ops/sec | writer_docs/sec | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 1,598 | 625,649 | 553,813 | 6,602 | 11 |
| 2 | 1,523 | 656,737 | 621,927 | 6,701 | 12 |
| 3 | 1,464 | 683,218 | 569,647 | 6,489 | 11 |

Write-only sanity comparison used:

```bash
TREEDB_COLLECTION_BENCH_BATCH_SIZE=128 \
go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkCollectionShapeInsertBatch$/indexes_2$' \
  -benchtime=100000x -count=3
```

The lazy index keeps write-only allocation at the PR1125 baseline: both branches report 3 allocs/op and roughly 2.3 KiB/op, with ns/op staying in the same noisy local band.

Full scaling smoke on this PR:

```bash
TREEDB_COLLECTION_BENCH_BATCH_SIZE=128 \
TREEDB_COLLECTION_MIXED_SEED_DOCS=4096 \
TREEDB_COLLECTION_MIXED_WRITE_BATCH_SIZE=128 \
go test ./TreeDB/collections -run '^$' \
  -bench '^(BenchmarkCollectionMixedReadWriteScalingPrimary|BenchmarkCollectionMixedReadWriteScalingSecondaryUnique)$' \
  -benchtime=20000x -count=1
```

Key rows:

| benchmark | ns/op | reader_ops/sec | writer_docs/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| primary readers_1/writers_1 | 4,034 | 247,900 | 714,732 | 11,253 | 22 |
| primary readers_4/writers_1 | 1,352 | 739,707 | 772,483 | 6,887 | 12 |
| primary readers_8/writers_2 | 1,368 | 730,894 | 721,582 | 6,772 | 12 |
| secondary unique readers_8/writers_2 | 32,707 | 30,575 | 347,270 | 72,546 | 260 |

A 5s CPU profile for the primary readers_8/writers_2 case was captured at `/tmp/collection_primary_run_index_profile_Z0hiI5`. The old buffered reverse-run scan no longer appears as a top primary-read cost; the remaining primary-read work is dominated by real tree/value-log reads and synchronization.

## Validation
- `go test ./TreeDB/collections ./cmd/collection_bench_matrix -count 1`
- `go vet ./TreeDB/collections ./cmd/collection_bench_matrix`
- `go test ./TreeDB/... ./cmd/... -count 1`
