### PR TITLE
Skip buffered unique index misses

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6018,7 +6018,7 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 	if err != nil {
 		return nil, false, err
 	}
-	bufferedTable, err := bufferedIndexTableLocked(domain, catalog.meta.Name, indexName, prefix, maxResults)
+	bufferedTable, err := bufferedIndexTableLocked(domain, catalog.meta.Name, indexName, idx.Unique, prefix, maxResults)
 	if err != nil {
 		return nil, false, err
 	}
@@ -6052,7 +6052,7 @@ func (c *Collection) findByIndexValue(indexName string, value any, maxResults in
 // bufferedIndexTableLocked materializes buffered entries for one secondary
 // index prefix while domain.mu is held. The returned pooled table is owned by
 // the caller and must be released with resetCollectionRunTable.
-func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, indexName string, prefix []byte, maxResults int) (memtable.Table, error) {
+func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, indexName string, unique bool, prefix []byte, maxResults int) (memtable.Table, error) {
 	if domain == nil {
 		return nil, nil
 	}
@@ -6065,6 +6065,12 @@ func bufferedIndexTableLocked(domain *collectionWriteDomain, collectionName, ind
 	runs := domain.rootRuns[collectionSecondaryRootName(collectionName, indexName)]
 	if len(runs) == 0 {
 		return nil, nil
+	}
+	if unique {
+		pending := domain.uniqueValueIndex[indexName]
+		if pending != nil && !pending.contains(prefix) {
+			return nil, nil
+		}
 	}
 	table := newCollectionRunTable(0)
 	liveLimit := collectionLimitedResultSentinel(maxResults)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4951,7 +4951,16 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	uniqueSecondaryRoots := uniqueCollectionSecondaryRootNames(plan.meta)
 	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, stagedBytes)
 	if !shouldAutoFlushAfterAdding && len(uniqueSecondaryRoots) > 0 && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
-		shouldAutoFlushAfterAdding = true
+		for i, rootName := range plan.rootNames {
+			if _, ok := uniqueSecondaryRoots[rootName]; !ok {
+				continue
+			}
+			table := plan.deltaTables[i]
+			if table != nil && table.Len() > 0 {
+				shouldAutoFlushAfterAdding = true
+				break
+			}
+		}
 	}
 	var checkpoint bufferedIndexedCheckpoint
 	collectionMetaCheckpoint := c.meta

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1958,6 +1958,19 @@ func uniqueCollectionIndexNames(meta CollectionMeta) map[string]struct{} {
 	return uniqueIndexes
 }
 
+func uniqueCollectionSecondaryRootNames(meta CollectionMeta) map[string]string {
+	var uniqueRoots map[string]string
+	for _, idx := range meta.Indexes {
+		if idx.Unique {
+			if uniqueRoots == nil {
+				uniqueRoots = make(map[string]string, len(meta.Indexes))
+			}
+			uniqueRoots[collectionSecondaryRootName(meta.Name, idx.Name)] = idx.Name
+		}
+	}
+	return uniqueRoots
+}
+
 func rejectBufferedUniqueIndexConflicts(indexName string, pendingIndex *bufferedUniqueValueIndex, batchIndex memtable.Table) error {
 	it := batchIndex.NewIterator(nil, nil)
 	defer func() { _ = it.Close() }()
@@ -4935,7 +4948,11 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if domain.rootRuns == nil {
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
+	uniqueSecondaryRoots := uniqueCollectionSecondaryRootNames(plan.meta)
 	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, stagedBytes)
+	if !shouldAutoFlushAfterAdding && len(uniqueSecondaryRoots) > 0 && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
+		shouldAutoFlushAfterAdding = true
+	}
 	var checkpoint bufferedIndexedCheckpoint
 	collectionMetaCheckpoint := c.meta
 	if shouldAutoFlushAfterAdding {
@@ -4961,6 +4978,30 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 				}
 				return false, err
 			}
+		}
+		if indexName, ok := uniqueSecondaryRoots[rootName]; ok {
+			uniqueValueTable, uniquePrefixes, err := bufferedUniqueIndexValueRun(table)
+			if err != nil {
+				if shouldAutoFlushAfterAdding {
+					rollbackBufferedIndexedDomain(domain, checkpoint)
+					c.meta = collectionMetaCheckpoint
+				}
+				return false, err
+			}
+			if domain.uniqueValueRuns == nil {
+				domain.uniqueValueRuns = make(map[string][]memtable.Table)
+			}
+			if domain.uniqueValueIndex == nil {
+				domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex)
+			}
+			domain.uniqueValueRuns[indexName] = append(domain.uniqueValueRuns[indexName], uniqueValueTable)
+			index := domain.uniqueValueIndex[indexName]
+			if index == nil {
+				index = newBufferedUniqueValueIndex(max(1, len(uniquePrefixes)))
+				domain.uniqueValueIndex[indexName] = index
+			}
+			index.addAll(uniquePrefixes)
+			stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, uniqueValueTable.Size())
 		}
 		domain.rootPolicies[rootName] = plan.policies[i]
 		domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4972,6 +4972,74 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesReadsBufferedInsert
 	}
 }
 
+func TestCollectionUpdateBatchMaintainsBufferedUniqueValueIndex(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"a@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert flushed document: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush document: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"email":"b@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert buffered document: %v", err)
+	}
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONCity("sea")},
+	}); err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatal("update batch was not buffered")
+	}
+
+	encoded, err := encodeIndexScalar("a@example.com")
+	if err != nil {
+		t.Fatalf("encode email: %v", err)
+	}
+	_, prefix, err := appendIndexValuePrefixSlice(nil, encoded)
+	if err != nil {
+		t.Fatalf("email prefix: %v", err)
+	}
+	col.writeDomain.mu.RLock()
+	pending := col.writeDomain.uniqueValueIndex["email"]
+	contains := pending != nil && pending.contains(prefix)
+	col.writeDomain.mu.RUnlock()
+	if !contains {
+		t.Fatal("buffered update did not add unchanged unique email to pending unique-value index")
+	}
+	ids, err := col.FindByIndex("email", "a@example.com")
+	if err != nil {
+		t.Fatalf("find buffered updated email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("email ids=%q want [u1]", ids)
+	}
+}
+
 func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesDeclinesUniqueUpdates(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1999,7 +1999,7 @@ func TestBufferedIndexTableLockedLimitsLiveMaterialization(t *testing.T) {
 		},
 	}
 
-	buffered, err := bufferedIndexTableLocked(domain, "users", "city", prefix, 1)
+	buffered, err := bufferedIndexTableLocked(domain, "users", "city", false, prefix, 1)
 	if err != nil {
 		t.Fatalf("buffered index table: %v", err)
 	}
@@ -2009,6 +2009,66 @@ func TestBufferedIndexTableLockedLimitsLiveMaterialization(t *testing.T) {
 	}
 	if got := buffered.Len(); got != 3 {
 		t.Fatalf("buffered table len=%d want tombstone plus two live rows", got)
+	}
+}
+
+func TestBufferedIndexTableLockedUsesUniqueValueIndexForMisses(t *testing.T) {
+	hnlEncoded, err := encodeIndexScalar("hnl@example.com")
+	if err != nil {
+		t.Fatalf("encode hnl email: %v", err)
+	}
+	_, hnlPrefix, err := appendIndexValuePrefixSlice(nil, hnlEncoded)
+	if err != nil {
+		t.Fatalf("hnl prefix: %v", err)
+	}
+	seaEncoded, err := encodeIndexScalar("sea@example.com")
+	if err != nil {
+		t.Fatalf("encode sea email: %v", err)
+	}
+	_, seaPrefix, err := appendIndexValuePrefixSlice(nil, seaEncoded)
+	if err != nil {
+		t.Fatalf("sea prefix: %v", err)
+	}
+	key, err := indexEntryKey(seaEncoded, []byte("u2"))
+	if err != nil {
+		t.Fatalf("sea index key: %v", err)
+	}
+	table := newCollectionRunTable(1)
+	setCollectionRunValue(table, key, nil)
+	table.Freeze()
+	defer resetCollectionRunTable(table)
+
+	pending := newBufferedUniqueValueIndex(1)
+	pending.add(seaPrefix)
+	domain := &collectionWriteDomain{
+		count: 1,
+		meta:  CollectionMeta{Name: "users"},
+		rootRuns: map[string][]memtable.Table{
+			collectionSecondaryRootName("users", "email"): {table},
+		},
+		uniqueValueIndex: map[string]*bufferedUniqueValueIndex{
+			"email": pending,
+		},
+	}
+
+	missing, err := bufferedIndexTableLocked(domain, "users", "email", true, hnlPrefix, 0)
+	if err != nil {
+		t.Fatalf("buffered unique miss: %v", err)
+	}
+	if missing != nil {
+		defer resetCollectionRunTable(missing)
+		t.Fatalf("buffered unique miss table len=%d want nil", missing.Len())
+	}
+	buffered, err := bufferedIndexTableLocked(domain, "users", "email", true, seaPrefix, 0)
+	if err != nil {
+		t.Fatalf("buffered unique hit: %v", err)
+	}
+	if buffered == nil {
+		t.Fatal("buffered unique hit table nil")
+	}
+	defer resetCollectionRunTable(buffered)
+	if got := buffered.Len(); got != 1 {
+		t.Fatalf("buffered unique hit len=%d want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- use the existing buffered unique-value index to prove negative buffered lookups for unique secondary indexes
- avoid materializing/scanning buffered secondary runs when a unique indexed value is not present in the pending write domain
- keep the non-unique path unchanged

## Benchmark evidence
Compared against PR1126 on the same local stack. Command:

```bash
TREEDB_COLLECTION_BENCH_BATCH_SIZE=128 \
TREEDB_COLLECTION_MIXED_SEED_DOCS=4096 \
TREEDB_COLLECTION_MIXED_WRITE_BATCH_SIZE=128 \
go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkCollectionMixedReadWriteScalingSecondaryUnique$/readers_8/writers_2$' \
  -benchtime=20000x -count=3
```

PR1126 reference row from the previous PR body/full scaling smoke:

| ns/op | reader_ops/sec | writer_docs/sec | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: |
| 32,707 | 30,575 | 347,270 | 72,546 | 260 |

This PR:

| run | ns/op | reader_ops/sec | writer_docs/sec | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 9,075 | 110,190 | 418,509 | 15,357 | 33 |
| 2 | 6,634 | 150,744 | 517,635 | 14,800 | 31 |
| 3 | 6,195 | 161,427 | 569,626 | 14,929 | 31 |

Full scaling smoke on this PR:

```bash
TREEDB_COLLECTION_BENCH_BATCH_SIZE=128 \
TREEDB_COLLECTION_MIXED_SEED_DOCS=4096 \
TREEDB_COLLECTION_MIXED_WRITE_BATCH_SIZE=128 \
go test ./TreeDB/collections -run '^$' \
  -bench '^(BenchmarkCollectionMixedReadWriteScalingPrimary|BenchmarkCollectionMixedReadWriteScalingSecondaryUnique)$' \
  -benchtime=20000x -count=1
```

Key rows:

| benchmark | ns/op | reader_ops/sec | writer_docs/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| primary readers_8/writers_2 | 1,356 | 737,348 | 644,137 | 6,572 | 11 |
| secondary unique readers_1/writers_1 | 2,475 | 403,979 | 921,665 | 5,318 | 24 |
| secondary unique readers_4/writers_1 | 2,010 | 497,450 | 867,101 | 4,361 | 21 |
| secondary unique readers_8/writers_2 | 6,468 | 154,612 | 555,200 | 15,130 | 32 |

## Validation
- `go test ./TreeDB/collections -run 'TestBufferedIndexTableLockedUsesUniqueValueIndexForMisses|TestBufferedIndexTableLockedLimitsLiveMaterialization|TestCollectionIndexedWriteMemtablesReadUniqueAndFlush' -count 1`
- `go test ./TreeDB/collections ./cmd/collection_bench_matrix -count 1`
- `go vet ./TreeDB/collections`
