### PR TITLE
Optimize buffered update planning lookups

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1590,7 +1590,13 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
 	domain.primaryIDIndex = rebuildBufferedPrimaryIDIndex(checkpoint.meta.Name, checkpoint.rootRuns)
 	if checkpoint.primaryRunIndexActive {
-		domain.primaryRunIndex = rebuildBufferedPrimaryRunIndex(checkpoint.meta.Name, checkpoint.rootRuns)
+		index, err := rebuildBufferedPrimaryRunIndex(checkpoint.meta.Name, checkpoint.rootRuns)
+		if err != nil {
+			index = nil
+		} else if index == nil {
+			index = newBufferedPrimaryRunIndex(0)
+		}
+		domain.primaryRunIndex = index
 	} else {
 		domain.primaryRunIndex = nil
 	}
@@ -1908,24 +1914,24 @@ func bufferedPrimaryIDArenaCap(entries int) int {
 	return entries * bytesPerKeyEstimate
 }
 
-func rebuildBufferedPrimaryRunIndex(collectionName string, runs map[string][]memtable.Table) *bufferedPrimaryRunIndex {
+func rebuildBufferedPrimaryRunIndex(collectionName string, runs map[string][]memtable.Table) (*bufferedPrimaryRunIndex, error) {
 	if collectionName == "" || len(runs) == 0 {
-		return nil
+		return nil, nil
 	}
 	tables := runs[collectionPrimaryRootName(collectionName)]
 	if len(tables) == 0 {
-		return nil
+		return nil, nil
 	}
 	index := newBufferedPrimaryRunIndex(0)
 	for _, table := range tables {
 		if err := addBufferedPrimaryRunIndexEntries(index, table); err != nil {
-			return nil
+			return nil, err
 		}
 	}
 	if len(index.values) == 0 {
-		return nil
+		return nil, nil
 	}
-	return index
+	return index, nil
 }
 
 func rebuildBufferedPrimaryIDIndex(collectionName string, runs map[string][]memtable.Table) *bufferedUniqueValueIndex {
@@ -4404,7 +4410,8 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 	if !sameCollectionMeta(domain.meta, meta) {
 		return false
 	}
-	if len(domain.rootRuns[collectionPrimaryRootName(meta.Name)]) == 0 {
+	collectionName := bufferedDomainCollectionName(domain, meta.Name)
+	if collectionName == "" || len(domain.rootRuns[collectionPrimaryRootName(collectionName)]) == 0 {
 		return false
 	}
 	return meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
@@ -4522,10 +4529,16 @@ func snapshotUpdateBatchBufferedRead(domain *collectionWriteDomain, meta Collect
 
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
-	if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) && domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, meta.Name) {
-		if index := rebuildBufferedPrimaryRunIndex(meta.Name, domain.rootRuns); index != nil {
-			domain.primaryRunIndex = index
+	bufferedCollectionName := bufferedDomainCollectionName(domain, meta.Name)
+	if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) && domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, bufferedCollectionName) {
+		index, err := rebuildBufferedPrimaryRunIndex(bufferedCollectionName, domain.rootRuns)
+		if err != nil {
+			return updateBatchBufferedRead{}, nil, false, err
 		}
+		if index == nil {
+			index = newBufferedPrimaryRunIndex(0)
+		}
+		domain.primaryRunIndex = index
 	}
 	read, templateRuns, blocked, _, err = snapshotUpdateBatchBufferedReadLocked(domain, meta, baseSystemRoot, items, documentFormat, false)
 	return read, templateRuns, blocked, err
@@ -4533,10 +4546,11 @@ func snapshotUpdateBatchBufferedRead(domain *collectionWriteDomain, meta Collect
 
 func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64, items []UpdateBatchItem, documentFormat DocumentFormat, allowPrimaryRunIndexBuild bool) (updateBatchBufferedRead, []memtable.Table, bool, bool, error) {
 	if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) {
-		if allowPrimaryRunIndexBuild && domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, meta.Name) {
+		bufferedCollectionName := bufferedDomainCollectionName(domain, meta.Name)
+		if allowPrimaryRunIndexBuild && domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, bufferedCollectionName) {
 			return updateBatchBufferedRead{}, nil, false, true, nil
 		}
-		primaryRuns := domain.rootRuns[collectionPrimaryRootName(meta.Name)]
+		primaryRuns := domain.rootRuns[collectionPrimaryRootName(bufferedCollectionName)]
 		var primaryEntries []updateBatchBufferedEntry
 		var err error
 		if domain.primaryRunIndex != nil {
@@ -4549,7 +4563,7 @@ func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta C
 		}
 		var templateRuns []memtable.Table
 		if normalizedDocumentFormat(documentFormat) == DocumentFormatTemplateV1 {
-			templateRuns, err = cloneCollectionRunTables(domain.rootRuns[collectionTemplateRootName(meta.Name)])
+			templateRuns, err = cloneCollectionRunTables(domain.rootRuns[collectionTemplateRootName(bufferedCollectionName)])
 			if err != nil {
 				return updateBatchBufferedRead{}, nil, false, false, err
 			}
@@ -6025,7 +6039,11 @@ func (c *Collection) getBufferedDocumentIntoWithPrimaryRunIndex(documentID []byt
 	}
 	if domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, c.meta.Name) {
 		collectionName := bufferedDomainCollectionName(domain, c.meta.Name)
-		if index := rebuildBufferedPrimaryRunIndex(collectionName, domain.rootRuns); index != nil {
+		index, err := rebuildBufferedPrimaryRunIndex(collectionName, domain.rootRuns)
+		if err == nil {
+			if index == nil {
+				index = newBufferedPrimaryRunIndex(0)
+			}
 			domain.primaryRunIndex = index
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4486,6 +4486,86 @@ func snapshotUpdateBatchBufferedPrimaryEntries(runs []memtable.Table, items []Up
 	return entries, nil
 }
 
+func snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(index *bufferedPrimaryRunIndex, items []UpdateBatchItem) ([]updateBatchBufferedEntry, error) {
+	entries := make([]updateBatchBufferedEntry, len(items))
+	if index == nil || len(items) == 0 {
+		return entries, nil
+	}
+	for i, item := range items {
+		table, ok := index.lookup(item.DocumentID)
+		if !ok || table == nil {
+			continue
+		}
+		value, _, flags, found := table.GetEntry(item.DocumentID)
+		if !found {
+			continue
+		}
+		entries[i] = updateBatchBufferedEntry{
+			value: bytes.Clone(value),
+			flags: flags,
+			found: true,
+		}
+	}
+	return entries, nil
+}
+
+func snapshotUpdateBatchBufferedRead(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64, items []UpdateBatchItem, documentFormat DocumentFormat) (updateBatchBufferedRead, []memtable.Table, bool, error) {
+	if domain == nil {
+		return updateBatchBufferedRead{}, nil, false, nil
+	}
+	domain.mu.RLock()
+	read, templateRuns, blocked, needPrimaryRunIndex, err := snapshotUpdateBatchBufferedReadLocked(domain, meta, baseSystemRoot, items, documentFormat, true)
+	domain.mu.RUnlock()
+	if err != nil || !needPrimaryRunIndex {
+		return read, templateRuns, blocked, err
+	}
+
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) && domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, meta.Name) {
+		if index := rebuildBufferedPrimaryRunIndex(meta.Name, domain.rootRuns); index != nil {
+			domain.primaryRunIndex = index
+		}
+	}
+	read, templateRuns, blocked, _, err = snapshotUpdateBatchBufferedReadLocked(domain, meta, baseSystemRoot, items, documentFormat, false)
+	return read, templateRuns, blocked, err
+}
+
+func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64, items []UpdateBatchItem, documentFormat DocumentFormat, allowPrimaryRunIndexBuild bool) (updateBatchBufferedRead, []memtable.Table, bool, bool, error) {
+	if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) {
+		if allowPrimaryRunIndexBuild && domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, meta.Name) {
+			return updateBatchBufferedRead{}, nil, false, true, nil
+		}
+		primaryRuns := domain.rootRuns[collectionPrimaryRootName(meta.Name)]
+		var primaryEntries []updateBatchBufferedEntry
+		var err error
+		if domain.primaryRunIndex != nil {
+			primaryEntries, err = snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(domain.primaryRunIndex, items)
+		} else {
+			primaryEntries, err = snapshotUpdateBatchBufferedPrimaryEntries(primaryRuns, items)
+		}
+		if err != nil {
+			return updateBatchBufferedRead{}, nil, false, false, err
+		}
+		var templateRuns []memtable.Table
+		if normalizedDocumentFormat(documentFormat) == DocumentFormatTemplateV1 {
+			templateRuns, err = cloneCollectionRunTables(domain.rootRuns[collectionTemplateRootName(meta.Name)])
+			if err != nil {
+				return updateBatchBufferedRead{}, nil, false, false, err
+			}
+		}
+		return updateBatchBufferedRead{
+			enabled:         true,
+			primaryEntries:  primaryEntries,
+			writeGeneration: domain.writeGeneration,
+		}, templateRuns, false, false, nil
+	}
+	if domain.count > 0 && len(domain.rootRuns) > 0 {
+		return updateBatchBufferedRead{}, nil, true, false, nil
+	}
+	return updateBatchBufferedRead{}, nil, false, false, nil
+}
+
 func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBatchMode, useBufferedRead bool) (*updateBatchPlan, error) {
 	results := make([]UpdateBatchResult, len(items))
 	snap := c.db.AcquireSnapshot()
@@ -4524,23 +4604,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	defer func() { resetCollectionTables(bufferedTemplateRuns) }()
 	bufferedReadBlocked := false
 	if domain := c.writeDomain; useBufferedRead && domain != nil && mode != updateBatchModeAny {
-		domain.mu.RLock()
-		if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) {
-			primaryRuns := domain.rootRuns[collectionPrimaryRootName(meta.Name)]
-			var primaryEntries []updateBatchBufferedEntry
-			primaryEntries, err = snapshotUpdateBatchBufferedPrimaryEntries(primaryRuns, items)
-			if err == nil && normalizedDocumentFormat(plannerOptions.documentFormat) == DocumentFormatTemplateV1 {
-				bufferedTemplateRuns, err = cloneCollectionRunTables(domain.rootRuns[collectionTemplateRootName(meta.Name)])
-			}
-			bufferedRead = updateBatchBufferedRead{
-				enabled:         true,
-				primaryEntries:  primaryEntries,
-				writeGeneration: domain.writeGeneration,
-			}
-		} else if domain.count > 0 && len(domain.rootRuns) > 0 {
-			bufferedReadBlocked = true
-		}
-		domain.mu.RUnlock()
+		bufferedRead, bufferedTemplateRuns, bufferedReadBlocked, err = snapshotUpdateBatchBufferedRead(domain, meta, baseSystemRoot, items, plannerOptions.documentFormat)
 		if err != nil {
 			_ = snap.Close()
 			return nil, err

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -5014,10 +5014,7 @@ func TestCollectionUpdateBatchBuildsPrimaryRunIndexForBufferedPlanning(t *testin
 	if !batched || len(first) != 1 || !first[0].Matched || !first[0].Modified {
 		t.Fatalf("first results=%+v batched=%v want one modified row", first, batched)
 	}
-	col.writeDomain.mu.RLock()
-	beforeIndex := col.writeDomain.primaryRunIndex
-	col.writeDomain.mu.RUnlock()
-	if beforeIndex != nil {
+	if collectionHasBufferedPrimaryRunIndexForTest(t, col) {
 		t.Fatal("primary run index was built before buffered read planning")
 	}
 
@@ -5050,12 +5047,53 @@ func TestCollectionUpdateBatchBuildsPrimaryRunIndexForBufferedPlanning(t *testin
 	if !sawBufferedUpdate {
 		t.Fatal("second update did not read the buffered first update")
 	}
-	col.writeDomain.mu.RLock()
-	afterIndex := col.writeDomain.primaryRunIndex
-	col.writeDomain.mu.RUnlock()
-	if afterIndex == nil {
+	if !collectionHasBufferedPrimaryRunIndexForTest(t, col) {
 		t.Fatal("primary run index was not built for buffered update planning")
 	}
+}
+
+func TestSnapshotUpdateBatchBufferedReadCachesEmptyPrimaryRunIndex(t *testing.T) {
+	meta := CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}
+	domain := &collectionWriteDomain{
+		loaded:         true,
+		meta:           meta,
+		catalog:        &collectionCatalog{meta: meta},
+		baseSystemRoot: 7,
+		count:          1,
+		rootRuns: map[string][]memtable.Table{
+			collectionPrimaryRootName("users"): {newCollectionRunTable(0)},
+		},
+	}
+
+	read, _, blocked, err := snapshotUpdateBatchBufferedRead(domain, meta, 7, []UpdateBatchItem{{DocumentID: []byte("missing")}}, DocumentFormatJSON)
+	if err != nil {
+		t.Fatalf("snapshotUpdateBatchBufferedRead: %v", err)
+	}
+	if blocked {
+		t.Fatal("buffered read reported blocked")
+	}
+	if !read.enabled {
+		t.Fatal("buffered read was not enabled")
+	}
+	domain.mu.RLock()
+	built := domain.primaryRunIndex != nil
+	domain.mu.RUnlock()
+	if !built {
+		t.Fatal("empty primary run index was not cached")
+	}
+}
+
+func collectionHasBufferedPrimaryRunIndexForTest(t *testing.T, col *Collection) bool {
+	t.Helper()
+	col.writeDomain.mu.RLock()
+	defer col.writeDomain.mu.RUnlock()
+	return col.writeDomain.primaryRunIndex != nil
 }
 
 func TestCollectionUpdateBatchMaintainsBufferedUniqueValueIndex(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4972,6 +4972,92 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesReadsBufferedInsert
 	}
 }
 
+func TestCollectionUpdateBatchBuildsPrimaryRunIndexForBufferedPlanning(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl","score":0}`)},
+	); err != nil {
+		t.Fatalf("insert document: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush document: %v", err)
+	}
+
+	first, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONField("score", 1)},
+	})
+	if err != nil {
+		t.Fatalf("first UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched || len(first) != 1 || !first[0].Matched || !first[0].Modified {
+		t.Fatalf("first results=%+v batched=%v want one modified row", first, batched)
+	}
+	col.writeDomain.mu.RLock()
+	beforeIndex := col.writeDomain.primaryRunIndex
+	col.writeDomain.mu.RUnlock()
+	if beforeIndex != nil {
+		t.Fatal("primary run index was built before buffered read planning")
+	}
+
+	sawBufferedUpdate := false
+	second, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			var doc map[string]any
+			if err := json.Unmarshal(current, &doc); err != nil {
+				return nil, false, err
+			}
+			if score, ok := int64ValueForTest(doc["score"]); !ok || score != 1 {
+				return nil, false, fmt.Errorf("score=%v want buffered score 1 in %s", doc["score"], current)
+			}
+			sawBufferedUpdate = true
+			doc["score"] = 2
+			next, err := json.Marshal(doc)
+			if err != nil {
+				return nil, false, err
+			}
+			return next, true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("second UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched || len(second) != 1 || !second[0].Matched || !second[0].Modified {
+		t.Fatalf("second results=%+v batched=%v want one modified row", second, batched)
+	}
+	if !sawBufferedUpdate {
+		t.Fatal("second update did not read the buffered first update")
+	}
+	col.writeDomain.mu.RLock()
+	afterIndex := col.writeDomain.primaryRunIndex
+	col.writeDomain.mu.RUnlock()
+	if afterIndex == nil {
+		t.Fatal("primary run index was not built for buffered update planning")
+	}
+}
+
 func TestCollectionUpdateBatchMaintainsBufferedUniqueValueIndex(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {


### PR DESCRIPTION
## Summary
- reuse the buffered primary-run index when update planning reads staged indexed collection writes
- lazily build the same index used by primary reads before falling back to direct run probing/scanning
- add a regression test proving buffered update planning sees the staged document and builds the index

## Why
The post-1127 profile still showed concurrent indexed updates spending time in update planning and buffered flush/publish paths. A quick coalescing experiment made throughput worse because larger small batches accumulated many buffered root runs; the safer target is making those buffered reads cheaper instead of changing batch cadence.

## Benchmark / profile evidence
Baseline profile on `origin/main` before this PR:

```sh
PROFILE_DIR=$(mktemp -d /tmp/direct_collection_update_profile_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=20000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
go test ./cmd/mongo_gateway_bench -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=20000x -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" -memprofile "$PROFILE_DIR/mem.pprof"
```

Baseline row: `35,374 ns/op`, `28,269 docs/sec`, `37,862 B/op`, `106 allocs/op`.

This PR, same command with `-count=3`:

| run | ns/op | docs/sec | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 38,151 | 26,212 | 33,955 | 106 |
| 2 | 28,029 | 35,678 | 34,050 | 102 |
| 3 | 32,386 | 30,878 | 34,196 | 108 |

Secondary mixed reader/writer smoke remains in the same healthy range:

```sh
go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkCollectionMixedReadWriteScalingSecondaryUnique$/readers_8/writers_2$' \
  -benchtime=20000x -count=3
```

| run | ns/op | reader_ops/sec | writer_docs/sec | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 7,647 | 130,778 | 474,738 | 15,217 | 32 |
| 2 | 8,163 | 122,510 | 427,591 | 14,958 | 31 |
| 3 | 6,515 | 153,491 | 539,729 | 14,997 | 31 |

The CPU profile for this PR was captured at `/tmp/direct_collection_update_index_profile_e32Mbf`; remaining top cumulative costs are still root publish / zipper / leaf value-log read-write work, not the old buffered primary-run scan.

## Validation
```sh
go test ./TreeDB/collections -run 'TestCollectionUpdateBatch(BuildsPrimaryRunIndexForBufferedPlanning|IfNoSecondaryUniqueIndexChangesReadsBufferedInsert|MaintainsBufferedUniqueValueIndex)' -count 1
go test ./TreeDB/collections ./cmd/mongo_gateway_bench ./cmd/collection_bench_matrix -count 1
go vet ./TreeDB/collections ./cmd/mongo_gateway_bench ./cmd/collection_bench_matrix
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionMixedReadWriteScalingSecondaryUnique$/readers_8/writers_2$' -benchtime=20000x -count=3
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=20000 MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' -benchtime=20000x -count=3
```
