### PR TITLE
Bound indexed write buffer root runs

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -33,6 +33,10 @@ const (
 	// DefaultIndexedWriteMemtableMaxDocuments bounds the native indexed
 	// collection write-domain before it auto-flushes to persistent roots.
 	DefaultIndexedWriteMemtableMaxDocuments = 64000
+	// DefaultIndexedWriteMemtableMaxRootRuns bounds accumulated root-local
+	// mutation runs so many small indexed update batches do not create an
+	// expensive pending-run chain before the document threshold is reached.
+	DefaultIndexedWriteMemtableMaxRootRuns = 256
 	// DefaultIndexedWriteMemtableDirectBatchDocuments keeps large, already
 	// well-amortized InsertBatch calls on the immediate publish path. Smaller
 	// batches use the indexed write-domain memtable path by default.
@@ -314,6 +318,10 @@ type CollectionOptions struct {
 	// root-run payload estimate reaches this many bytes. Zero leaves flushing to
 	// explicit Flush/Close calls.
 	BufferedIndexedWriteMaxBytes int64 `json:"buffered_indexed_write_max_bytes,omitempty"`
+	// BufferedIndexedWriteMaxRootRuns flushes indexed write buffers once this
+	// many root-local mutation runs are pending. Zero disables the run-count
+	// trigger unless defaulted during metadata normalization.
+	BufferedIndexedWriteMaxRootRuns int `json:"buffered_indexed_write_max_root_runs,omitempty"`
 }
 
 type IndexDefinition struct {
@@ -371,6 +379,7 @@ type bufferedIndexedCheckpoint struct {
 	rootBaseIDs           map[string]uint64
 	primaryRunIndexActive bool
 	uniqueValueRuns       map[string][]memtable.Table
+	rootRunCount          int
 }
 
 type bufferedUniqueValueIndex struct {
@@ -421,6 +430,7 @@ type collectionWriteDomain struct {
 	uniqueValueIndex map[string]*bufferedUniqueValueIndex
 	count            int
 	bufferedBytes    int64
+	rootRunCount     int
 	writeGeneration  uint64
 }
 
@@ -1427,6 +1437,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 		}
 		domain.rootPolicies[run.name] = run.storagePolicy
 		domain.rootRuns[run.name] = append(domain.rootRuns[run.name], run.table)
+		domain.rootRunCount = saturatingAddNonNegativeInt(domain.rootRunCount, 1)
 		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, run.table.Size())
 		if run.kind == collectionRootPrimary {
 			if domain.primaryIDIndex == nil {
@@ -1488,6 +1499,7 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.rootRuns = nil
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
+	domain.rootRunCount = 0
 	domain.primaryIDIndex = nil
 	domain.primaryRunIndex = nil
 	domain.uniqueValueRuns = nil
@@ -1505,10 +1517,13 @@ func shouldFlushBufferedIndexedWrites(domain *collectionWriteDomain, opts Collec
 	if opts.BufferedIndexedWriteMaxBytes > 0 && domain.bufferedBytes >= opts.BufferedIndexedWriteMaxBytes {
 		return true
 	}
+	if opts.BufferedIndexedWriteMaxRootRuns > 0 && bufferedIndexedRootRunCount(domain) >= opts.BufferedIndexedWriteMaxRootRuns {
+		return true
+	}
 	return false
 }
 
-func shouldFlushBufferedIndexedWritesAfterAdding(domain *collectionWriteDomain, opts CollectionOptions, addedCount int, addedBytes int64) bool {
+func shouldFlushBufferedIndexedWritesAfterAdding(domain *collectionWriteDomain, opts CollectionOptions, addedCount int, addedBytes int64, addedRootRuns int) bool {
 	if domain == nil || addedCount <= 0 {
 		return false
 	}
@@ -1520,7 +1535,25 @@ func shouldFlushBufferedIndexedWritesAfterAdding(domain *collectionWriteDomain, 
 	if opts.BufferedIndexedWriteMaxBytes > 0 && nextBytes >= opts.BufferedIndexedWriteMaxBytes {
 		return true
 	}
+	nextRootRuns := saturatingAddNonNegativeInt(bufferedIndexedRootRunCount(domain), addedRootRuns)
+	if opts.BufferedIndexedWriteMaxRootRuns > 0 && nextRootRuns >= opts.BufferedIndexedWriteMaxRootRuns {
+		return true
+	}
 	return false
+}
+
+func bufferedIndexedRootRunCount(domain *collectionWriteDomain) int {
+	if domain == nil {
+		return 0
+	}
+	if domain.rootRunCount > 0 || len(domain.rootRuns) == 0 {
+		return domain.rootRunCount
+	}
+	total := 0
+	for _, runs := range domain.rootRuns {
+		total = saturatingAddNonNegativeInt(total, len(runs))
+	}
+	return total
 }
 
 func saturatingAddNonNegativeInt(total, n int) int {
@@ -1534,7 +1567,7 @@ func saturatingAddNonNegativeInt(total, n int) int {
 }
 
 func bufferedIndexedAutoFlushEnabled(opts CollectionOptions) bool {
-	return opts.BufferedIndexedWriteMaxDocuments > 0 || opts.BufferedIndexedWriteMaxBytes > 0
+	return opts.BufferedIndexedWriteMaxDocuments > 0 || opts.BufferedIndexedWriteMaxBytes > 0 || opts.BufferedIndexedWriteMaxRootRuns > 0
 }
 
 func saturatingAddNonNegativeInt64(total, n int64) int64 {
@@ -1567,6 +1600,7 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		rootBaseIDs:           cloneUint64Map(domain.rootBaseIDs),
 		primaryRunIndexActive: domain.primaryRunIndex != nil,
 		uniqueValueRuns:       cloneTableRunMap(domain.uniqueValueRuns),
+		rootRunCount:          domain.rootRunCount,
 	}
 }
 
@@ -1588,6 +1622,7 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.rootRuns = checkpoint.rootRuns
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
+	domain.rootRunCount = checkpoint.rootRunCount
 	domain.primaryIDIndex = rebuildBufferedPrimaryIDIndex(checkpoint.meta.Name, checkpoint.rootRuns)
 	if checkpoint.primaryRunIndexActive {
 		domain.primaryRunIndex = rebuildBufferedPrimaryRunIndex(checkpoint.meta.Name, checkpoint.rootRuns)
@@ -2453,6 +2488,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 	domain.rootRuns = nil
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
+	domain.rootRunCount = 0
 	domain.primaryIDIndex = nil
 	domain.primaryRunIndex = nil
 	oldUniqueValueRuns := domain.uniqueValueRuns
@@ -4986,6 +5022,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		return false, err
 	}
 	var stagedBytes int64
+	stagedRootRuns := 0
 	for i, rootName := range plan.rootNames {
 		baseRoot, ok := plan.baseRootIDs[rootName]
 		if !ok {
@@ -4999,6 +5036,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			return false, errConcurrentRootModification(plan.meta.Name, rootName)
 		}
 		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, table.Size())
+		stagedRootRuns++
 	}
 	if domain.count == 0 && plan.catalog != nil {
 		c.initializeWriteDomainFromCatalogLocked(domain, plan.catalog, plan.baseCommitSeq, plan.baseSystemRoot)
@@ -5013,7 +5051,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
 	uniqueSecondaryRoots := uniqueCollectionSecondaryRootNames(plan.meta)
-	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, stagedBytes)
+	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, stagedBytes, stagedRootRuns)
 	if !shouldAutoFlushAfterAdding && len(uniqueSecondaryRoots) > 0 && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
 		for i, rootName := range plan.rootNames {
 			if _, ok := uniqueSecondaryRoots[rootName]; !ok {
@@ -5078,6 +5116,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		}
 		domain.rootPolicies[rootName] = plan.policies[i]
 		domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)
+		domain.rootRunCount = saturatingAddNonNegativeInt(domain.rootRunCount, 1)
 		plan.deltaTables[i] = nil
 	}
 	plan.deltaTables = nil
@@ -5397,6 +5436,7 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 	domain.rootRuns = nil
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
+	domain.rootRunCount = 0
 	domain.primaryIDIndex = nil
 	domain.primaryRunIndex = nil
 	domain.uniqueValueRuns = nil
@@ -6698,6 +6738,9 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 	if meta.Options.BufferedIndexedWriteMaxBytes < 0 {
 		return CollectionMeta{}, errors.New("collections: buffered indexed write max bytes cannot be negative")
 	}
+	if meta.Options.BufferedIndexedWriteMaxRootRuns < 0 {
+		return CollectionMeta{}, errors.New("collections: buffered indexed write max root runs cannot be negative")
+	}
 	documentFormat, err := normalizeDocumentFormat(meta.Options.DocumentFormat)
 	if err != nil {
 		return CollectionMeta{}, err
@@ -6732,10 +6775,12 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		meta.Options.BufferedIndexedWrites = false
 		meta.Options.BufferedIndexedWriteMaxDocuments = 0
 		meta.Options.BufferedIndexedWriteMaxBytes = 0
+		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
 	} else {
 		meta.Options.BufferedIndexedWrites = true
-		if meta.Options.BufferedIndexedWriteMaxDocuments == 0 && meta.Options.BufferedIndexedWriteMaxBytes == 0 {
+		if meta.Options.BufferedIndexedWriteMaxDocuments == 0 && meta.Options.BufferedIndexedWriteMaxBytes == 0 && meta.Options.BufferedIndexedWriteMaxRootRuns == 0 {
 			meta.Options.BufferedIndexedWriteMaxDocuments = DefaultIndexedWriteMemtableMaxDocuments
+			meta.Options.BufferedIndexedWriteMaxRootRuns = DefaultIndexedWriteMemtableMaxRootRuns
 		}
 	}
 	return meta, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -320,7 +320,9 @@ type CollectionOptions struct {
 	BufferedIndexedWriteMaxBytes int64 `json:"buffered_indexed_write_max_bytes,omitempty"`
 	// BufferedIndexedWriteMaxRootRuns flushes indexed write buffers once this
 	// many root-local mutation runs are pending. Zero disables the run-count
-	// trigger unless defaulted during metadata normalization.
+	// trigger when another flush limit is explicitly configured; when all
+	// indexed buffer limits are zero, metadata normalization installs native
+	// defaults.
 	BufferedIndexedWriteMaxRootRuns int `json:"buffered_indexed_write_max_root_runs,omitempty"`
 }
 
@@ -6796,10 +6798,11 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
 	} else {
 		meta.Options.BufferedIndexedWrites = true
-		if meta.Options.BufferedIndexedWriteMaxDocuments == 0 {
+		useNativeDocumentDefault := meta.Options.BufferedIndexedWriteMaxDocuments == 0
+		if useNativeDocumentDefault {
 			meta.Options.BufferedIndexedWriteMaxDocuments = DefaultIndexedWriteMemtableMaxDocuments
 		}
-		if meta.Options.BufferedIndexedWriteMaxBytes == 0 && meta.Options.BufferedIndexedWriteMaxRootRuns == 0 {
+		if useNativeDocumentDefault && meta.Options.BufferedIndexedWriteMaxBytes == 0 && meta.Options.BufferedIndexedWriteMaxRootRuns == 0 {
 			meta.Options.BufferedIndexedWriteMaxRootRuns = DefaultIndexedWriteMemtableMaxRootRuns
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6796,8 +6796,10 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
 	} else {
 		meta.Options.BufferedIndexedWrites = true
-		if meta.Options.BufferedIndexedWriteMaxDocuments == 0 && meta.Options.BufferedIndexedWriteMaxBytes == 0 && meta.Options.BufferedIndexedWriteMaxRootRuns == 0 {
+		if meta.Options.BufferedIndexedWriteMaxDocuments == 0 {
 			meta.Options.BufferedIndexedWriteMaxDocuments = DefaultIndexedWriteMemtableMaxDocuments
+		}
+		if meta.Options.BufferedIndexedWriteMaxBytes == 0 && meta.Options.BufferedIndexedWriteMaxRootRuns == 0 {
 			meta.Options.BufferedIndexedWriteMaxRootRuns = DefaultIndexedWriteMemtableMaxRootRuns
 		}
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1496,6 +1496,32 @@ func TestCollectionIndexedWriteMemtablesPreserveDocumentDefaultWithRootRunLimit(
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesCanDisableRootRunLimitWithDocumentLimit(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	meta, err := NewCollectionManager(d).CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWriteMaxDocuments: DefaultIndexedWriteMemtableMaxDocuments,
+			BufferedIndexedWriteMaxRootRuns:  0,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email"}},
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if got := meta.Options.BufferedIndexedWriteMaxDocuments; got != DefaultIndexedWriteMemtableMaxDocuments {
+		t.Fatalf("max documents=%d want default %d", got, DefaultIndexedWriteMemtableMaxDocuments)
+	}
+	if got := meta.Options.BufferedIndexedWriteMaxRootRuns; got != 0 {
+		t.Fatalf("max root runs=%d want disabled", got)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesDefaultSkipsNoIndexSchemas(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1420,6 +1420,9 @@ func TestCollectionIndexedWriteMemtablesDefaultForIndexedSchemas(t *testing.T) {
 	if got := meta.Options.BufferedIndexedWriteMaxBytes; got != 0 {
 		t.Fatalf("default max bytes=%d want 0", got)
 	}
+	if got := meta.Options.BufferedIndexedWriteMaxRootRuns; got != DefaultIndexedWriteMemtableMaxRootRuns {
+		t.Fatalf("default max root runs=%d want %d", got, DefaultIndexedWriteMemtableMaxRootRuns)
+	}
 
 	col, err := mgr.OpenCollection("users")
 	if err != nil {
@@ -1481,9 +1484,9 @@ func TestCollectionIndexedWriteMemtablesDefaultSkipsNoIndexSchemas(t *testing.T)
 	if meta.Options.BufferedIndexedWrites {
 		t.Fatal("no-index collection enabled indexed write memtables")
 	}
-	if meta.Options.BufferedIndexedWriteMaxDocuments != 0 || meta.Options.BufferedIndexedWriteMaxBytes != 0 {
-		t.Fatalf("no-index buffered limits docs=%d bytes=%d want zero",
-			meta.Options.BufferedIndexedWriteMaxDocuments, meta.Options.BufferedIndexedWriteMaxBytes)
+	if meta.Options.BufferedIndexedWriteMaxDocuments != 0 || meta.Options.BufferedIndexedWriteMaxBytes != 0 || meta.Options.BufferedIndexedWriteMaxRootRuns != 0 {
+		t.Fatalf("no-index buffered limits docs=%d bytes=%d rootRuns=%d want zero",
+			meta.Options.BufferedIndexedWriteMaxDocuments, meta.Options.BufferedIndexedWriteMaxBytes, meta.Options.BufferedIndexedWriteMaxRootRuns)
 	}
 }
 
@@ -1507,9 +1510,9 @@ func TestCollectionIndexedWriteMemtablesCanBeDisabled(t *testing.T) {
 	if meta.Options.BufferedIndexedWrites {
 		t.Fatal("disabled indexed write memtables reported enabled")
 	}
-	if meta.Options.BufferedIndexedWriteMaxDocuments != 0 || meta.Options.BufferedIndexedWriteMaxBytes != 0 {
-		t.Fatalf("disabled buffered limits docs=%d bytes=%d want zero",
-			meta.Options.BufferedIndexedWriteMaxDocuments, meta.Options.BufferedIndexedWriteMaxBytes)
+	if meta.Options.BufferedIndexedWriteMaxDocuments != 0 || meta.Options.BufferedIndexedWriteMaxBytes != 0 || meta.Options.BufferedIndexedWriteMaxRootRuns != 0 {
+		t.Fatalf("disabled buffered limits docs=%d bytes=%d rootRuns=%d want zero",
+			meta.Options.BufferedIndexedWriteMaxDocuments, meta.Options.BufferedIndexedWriteMaxBytes, meta.Options.BufferedIndexedWriteMaxRootRuns)
 	}
 	col, err := mgr.OpenCollection("users")
 	if err != nil {
@@ -2410,6 +2413,67 @@ func TestCollectionIndexedWriteMemtablesAutoFlushMaxBytes(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesAutoFlushMaxRootRuns(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:           true,
+			BufferedIndexedWriteMaxRootRuns: 2,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot after root-run threshold flush")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog after root-run threshold flush: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
+		t.Fatal("primary root was not persisted after root-run threshold flush")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err := reopenedCol.FindByIndex("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find email after root-run threshold flush: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("email ids=%q want [u1]", ids)
+	}
+}
+
 func TestBufferedPrimaryIDArenaCapAvoidsOverflow(t *testing.T) {
 	if got := bufferedPrimaryIDArenaCap(2); got != 32 {
 		t.Fatalf("small arena cap=%d want 32", got)
@@ -2468,13 +2532,15 @@ func TestShouldFlushBufferedIndexedWritesAfterAddingBoundaries(t *testing.T) {
 	opts := CollectionOptions{
 		BufferedIndexedWriteMaxDocuments: 10,
 		BufferedIndexedWriteMaxBytes:     100,
+		BufferedIndexedWriteMaxRootRuns:  5,
 	}
 	cases := []struct {
-		name       string
-		domain     *collectionWriteDomain
-		addedCount int
-		addedBytes int64
-		want       bool
+		name          string
+		domain        *collectionWriteDomain
+		addedCount    int
+		addedBytes    int64
+		addedRootRuns int
+		want          bool
 	}{
 		{
 			name:       "nil domain",
@@ -2516,10 +2582,30 @@ func TestShouldFlushBufferedIndexedWritesAfterAddingBoundaries(t *testing.T) {
 			addedBytes: 1,
 			want:       true,
 		},
+		{
+			name:          "just below root run limit",
+			domain:        &collectionWriteDomain{count: 1, rootRuns: map[string][]memtable.Table{"a": make([]memtable.Table, 3)}},
+			addedCount:    1,
+			addedRootRuns: 1,
+		},
+		{
+			name:          "exactly at root run limit",
+			domain:        &collectionWriteDomain{count: 1, rootRuns: map[string][]memtable.Table{"a": make([]memtable.Table, 4)}},
+			addedCount:    1,
+			addedRootRuns: 1,
+			want:          true,
+		},
+		{
+			name:          "root run overflow clamps to flush",
+			domain:        &collectionWriteDomain{count: 1},
+			addedCount:    1,
+			addedRootRuns: maxCollectionInt,
+			want:          true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := shouldFlushBufferedIndexedWritesAfterAdding(tc.domain, opts, tc.addedCount, tc.addedBytes)
+			got := shouldFlushBufferedIndexedWritesAfterAdding(tc.domain, opts, tc.addedCount, tc.addedBytes, tc.addedRootRuns)
 			if got != tc.want {
 				t.Fatalf("shouldFlushBufferedIndexedWritesAfterAdding()=%v want %v", got, tc.want)
 			}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1471,6 +1471,31 @@ func TestCollectionIndexedWriteMemtablesDefaultForIndexedSchemas(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesPreserveDocumentDefaultWithRootRunLimit(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	meta, err := NewCollectionManager(d).CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWriteMaxRootRuns: 8,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email"}},
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if got := meta.Options.BufferedIndexedWriteMaxDocuments; got != DefaultIndexedWriteMemtableMaxDocuments {
+		t.Fatalf("max documents=%d want default %d", got, DefaultIndexedWriteMemtableMaxDocuments)
+	}
+	if got := meta.Options.BufferedIndexedWriteMaxRootRuns; got != 8 {
+		t.Fatalf("max root runs=%d want 8", got)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesDefaultSkipsNoIndexSchemas(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -204,6 +204,9 @@ func benchmarkCollectionShapeInsertBatch(b *testing.B, indexCount int, checkpoin
 		if meta.Options.BufferedIndexedWriteMaxBytes > 0 {
 			b.ReportMetric(float64(meta.Options.BufferedIndexedWriteMaxBytes), "buffered_max_bytes")
 		}
+		if meta.Options.BufferedIndexedWriteMaxRootRuns > 0 {
+			b.ReportMetric(float64(meta.Options.BufferedIndexedWriteMaxRootRuns), "buffered_max_root_runs")
+		}
 		if insertStats.BufferedIndexedBatches > 0 && insertStats.BufferedIndexedBypassBatches == 0 && insertElapsed > 0 {
 			b.ReportMetric(float64(insertElapsed.Nanoseconds())/float64(b.N), "buffered_insert_ns/doc")
 		}

--- a/cmd/collection_load_fixture/README.md
+++ b/cmd/collection_load_fixture/README.md
@@ -58,6 +58,7 @@ Useful variants:
 ./bin/collection-load-fixture \
   -buffered-indexed-writes=true \
   -buffered-indexed-write-max-docs 64000 \
+  -buffered-indexed-write-max-root-runs 256 \
   -dir /tmp/treedb_two_index_buffered_bounded \
   -reset
 

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -49,6 +49,7 @@ type config struct {
 	BufferedIndexedWrites        bool
 	BufferedIndexedWriteMaxDocs  int
 	BufferedIndexedWriteMaxBytes int64
+	BufferedIndexedWriteMaxRuns  int
 	Profile                      treedb.Profile
 	DataOuterLeavesInValueLog    bool
 	IndexOuterLeavesInValueLog   bool
@@ -237,6 +238,7 @@ type loadSummary struct {
 	BufferedIndexedWrites         bool                   `json:"buffered_indexed_writes,omitempty"`
 	BufferedIndexedWriteMaxDocs   int                    `json:"buffered_indexed_write_max_docs,omitempty"`
 	BufferedIndexedWriteMaxBytes  int64                  `json:"buffered_indexed_write_max_bytes,omitempty"`
+	BufferedIndexedWriteMaxRuns   int                    `json:"buffered_indexed_write_max_root_runs,omitempty"`
 	DataOuterLeavesInValueLog     bool                   `json:"data_outer_leaves_in_value_log"`
 	IndexOuterLeavesInValueLog    bool                   `json:"index_outer_leaves_in_value_log"`
 	ChunkSize                     int64                  `json:"chunk_size,omitempty"`
@@ -304,6 +306,7 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 		IndexCount:                  2,
 		BufferedIndexedWrites:       true,
 		BufferedIndexedWriteMaxDocs: collections.DefaultIndexedWriteMemtableMaxDocuments,
+		BufferedIndexedWriteMaxRuns: collections.DefaultIndexedWriteMemtableMaxRootRuns,
 		Profile:                     treedb.ProfileFast,
 		DataOuterLeavesInValueLog:   true,
 		IndexOuterLeavesInValueLog:  true,
@@ -334,6 +337,7 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	fs.BoolVar(&cfg.BufferedIndexedWrites, "buffered-indexed-writes", cfg.BufferedIndexedWrites, "use native collection-local memtables for indexed InsertBatch writes; set false for immediate-publish baseline comparisons")
 	fs.IntVar(&cfg.BufferedIndexedWriteMaxDocs, "buffered-indexed-write-max-docs", cfg.BufferedIndexedWriteMaxDocs, "flush indexed write buffers after this many staged documents; 0 uses the collection default")
 	fs.Int64Var(&cfg.BufferedIndexedWriteMaxBytes, "buffered-indexed-write-max-bytes", 0, "flush indexed write buffers after this many staged root-run bytes; 0 means Flush/Close only")
+	fs.IntVar(&cfg.BufferedIndexedWriteMaxRuns, "buffered-indexed-write-max-root-runs", cfg.BufferedIndexedWriteMaxRuns, "flush indexed write buffers after this many staged root-local mutation runs; 0 uses the collection default")
 	fs.StringVar(&profile, "profile", string(cfg.Profile), "TreeDB profile: fast, wal_on_fast, durable, or bench")
 	fs.BoolVar(&cfg.DataOuterLeavesInValueLog, "data-outer-leaves-in-vlog", cfg.DataOuterLeavesInValueLog, "store collection primary/index-state outer leaves through the value log")
 	fs.BoolVar(&cfg.IndexOuterLeavesInValueLog, "index-outer-leaves-in-vlog", cfg.IndexOuterLeavesInValueLog, "store secondary-index outer leaves through the value log")
@@ -391,6 +395,9 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	}
 	if cfg.BufferedIndexedWriteMaxBytes < 0 {
 		return cfg, fmt.Errorf("-buffered-indexed-write-max-bytes must be >= 0")
+	}
+	if cfg.BufferedIndexedWriteMaxRuns < 0 {
+		return cfg, fmt.Errorf("-buffered-indexed-write-max-root-runs must be >= 0")
 	}
 	if strings.TrimSpace(cfg.Collection) == "" {
 		return cfg, fmt.Errorf("-collection cannot be empty")
@@ -629,6 +636,7 @@ func runFixture(cfg config) (loadSummary, error) {
 		BufferedIndexedWrites:         collectionMeta.Options.BufferedIndexedWrites,
 		BufferedIndexedWriteMaxDocs:   collectionMeta.Options.BufferedIndexedWriteMaxDocuments,
 		BufferedIndexedWriteMaxBytes:  collectionMeta.Options.BufferedIndexedWriteMaxBytes,
+		BufferedIndexedWriteMaxRuns:   collectionMeta.Options.BufferedIndexedWriteMaxRootRuns,
 		DataOuterLeavesInValueLog:     cfg.DataOuterLeavesInValueLog,
 		IndexOuterLeavesInValueLog:    cfg.IndexOuterLeavesInValueLog,
 		ChunkSize:                     cfg.ChunkSize,
@@ -746,9 +754,11 @@ func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Co
 	bufferedIndexedWrites := cfg.BufferedIndexedWrites && cfg.IndexCount > 0
 	bufferedIndexedWriteMaxDocs := 0
 	var bufferedIndexedWriteMaxBytes int64
+	bufferedIndexedWriteMaxRuns := 0
 	if bufferedIndexedWrites {
 		bufferedIndexedWriteMaxDocs = cfg.BufferedIndexedWriteMaxDocs
 		bufferedIndexedWriteMaxBytes = cfg.BufferedIndexedWriteMaxBytes
+		bufferedIndexedWriteMaxRuns = cfg.BufferedIndexedWriteMaxRuns
 	}
 	_, err := manager.CreateCollection(&collections.CollectionMeta{
 		Name: cfg.Collection,
@@ -760,6 +770,7 @@ func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Co
 			BufferedIndexedWrites:            bufferedIndexedWrites,
 			BufferedIndexedWriteMaxDocuments: bufferedIndexedWriteMaxDocs,
 			BufferedIndexedWriteMaxBytes:     bufferedIndexedWriteMaxBytes,
+			BufferedIndexedWriteMaxRootRuns:  bufferedIndexedWriteMaxRuns,
 		},
 		Indexes: indexes,
 	})
@@ -1591,9 +1602,9 @@ func printHumanSummary(w io.Writer, summary loadSummary) {
 		summary.DocumentFormat, summary.IndexCount, summary.DataOuterLeavesInValueLog, summary.IndexOuterLeavesInValueLog, summary.Profile)
 	if summary.BufferedIndexedWrites {
 		fmt.Fprintln(w, "indexed write buffering: enabled")
-		if summary.BufferedIndexedWriteMaxDocs > 0 || summary.BufferedIndexedWriteMaxBytes > 0 {
-			fmt.Fprintf(w, "indexed write buffer limits: max_docs=%d max_bytes=%s\n",
-				summary.BufferedIndexedWriteMaxDocs, humanBytes(uint64(summary.BufferedIndexedWriteMaxBytes)))
+		if summary.BufferedIndexedWriteMaxDocs > 0 || summary.BufferedIndexedWriteMaxBytes > 0 || summary.BufferedIndexedWriteMaxRuns > 0 {
+			fmt.Fprintf(w, "indexed write buffer limits: max_docs=%d max_bytes=%s max_root_runs=%d\n",
+				summary.BufferedIndexedWriteMaxDocs, humanBytes(uint64(summary.BufferedIndexedWriteMaxBytes)), summary.BufferedIndexedWriteMaxRuns)
 		}
 	}
 	fmt.Fprintf(w, "index policy: keep_recent=%d prefer_append_alloc=%t background_prune=%t\n",

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -337,7 +337,7 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	fs.BoolVar(&cfg.BufferedIndexedWrites, "buffered-indexed-writes", cfg.BufferedIndexedWrites, "use native collection-local memtables for indexed InsertBatch writes; set false for immediate-publish baseline comparisons")
 	fs.IntVar(&cfg.BufferedIndexedWriteMaxDocs, "buffered-indexed-write-max-docs", cfg.BufferedIndexedWriteMaxDocs, "flush indexed write buffers after this many staged documents; 0 uses the collection default")
 	fs.Int64Var(&cfg.BufferedIndexedWriteMaxBytes, "buffered-indexed-write-max-bytes", 0, "flush indexed write buffers after this many staged root-run bytes; 0 means Flush/Close only")
-	fs.IntVar(&cfg.BufferedIndexedWriteMaxRuns, "buffered-indexed-write-max-root-runs", cfg.BufferedIndexedWriteMaxRuns, "flush indexed write buffers after this many staged root-local mutation runs; 0 uses the collection default")
+	fs.IntVar(&cfg.BufferedIndexedWriteMaxRuns, "buffered-indexed-write-max-root-runs", cfg.BufferedIndexedWriteMaxRuns, "flush indexed write buffers after this many staged root-local mutation runs; 0 disables this trigger")
 	fs.StringVar(&profile, "profile", string(cfg.Profile), "TreeDB profile: fast, wal_on_fast, durable, or bench")
 	fs.BoolVar(&cfg.DataOuterLeavesInValueLog, "data-outer-leaves-in-vlog", cfg.DataOuterLeavesInValueLog, "store collection primary/index-state outer leaves through the value log")
 	fs.BoolVar(&cfg.IndexOuterLeavesInValueLog, "index-outer-leaves-in-vlog", cfg.IndexOuterLeavesInValueLog, "store secondary-index outer leaves through the value log")

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -31,6 +31,9 @@ func TestParseConfigDefaultsToInspectableTwoIndexTemplateFixture(t *testing.T) {
 	if cfg.BufferedIndexedWriteMaxDocs != collections.DefaultIndexedWriteMemtableMaxDocuments {
 		t.Fatalf("buffered indexed max docs=%d want %d", cfg.BufferedIndexedWriteMaxDocs, collections.DefaultIndexedWriteMemtableMaxDocuments)
 	}
+	if cfg.BufferedIndexedWriteMaxRuns != collections.DefaultIndexedWriteMemtableMaxRootRuns {
+		t.Fatalf("buffered indexed max root runs=%d want %d", cfg.BufferedIndexedWriteMaxRuns, collections.DefaultIndexedWriteMemtableMaxRootRuns)
+	}
 	if !cfg.DataOuterLeavesInValueLog {
 		t.Fatal("expected data outer leaves in value log by default")
 	}
@@ -166,6 +169,7 @@ func TestRunFixtureReportsBufferedIndexedWritesOnlyWhenIndexesUseThem(t *testing
 		"-buffered-indexed-writes",
 		"-buffered-indexed-write-max-docs", "16",
 		"-buffered-indexed-write-max-bytes", "1024",
+		"-buffered-indexed-write-max-root-runs", "8",
 		"-reopen-verify=false",
 		"-progress=false",
 	}, io.Discard)
@@ -179,8 +183,9 @@ func TestRunFixtureReportsBufferedIndexedWritesOnlyWhenIndexesUseThem(t *testing
 	if noIndexSummary.BufferedIndexedWrites {
 		t.Fatal("no-index summary reported buffered indexed writes enabled")
 	}
-	if noIndexSummary.BufferedIndexedWriteMaxDocs != 0 || noIndexSummary.BufferedIndexedWriteMaxBytes != 0 {
-		t.Fatalf("no-index buffered limits docs=%d bytes=%d want both zero", noIndexSummary.BufferedIndexedWriteMaxDocs, noIndexSummary.BufferedIndexedWriteMaxBytes)
+	if noIndexSummary.BufferedIndexedWriteMaxDocs != 0 || noIndexSummary.BufferedIndexedWriteMaxBytes != 0 || noIndexSummary.BufferedIndexedWriteMaxRuns != 0 {
+		t.Fatalf("no-index buffered limits docs=%d bytes=%d rootRuns=%d want zero",
+			noIndexSummary.BufferedIndexedWriteMaxDocs, noIndexSummary.BufferedIndexedWriteMaxBytes, noIndexSummary.BufferedIndexedWriteMaxRuns)
 	}
 
 	indexedDir := filepath.Join(t.TempDir(), "indexed")
@@ -192,6 +197,7 @@ func TestRunFixtureReportsBufferedIndexedWritesOnlyWhenIndexesUseThem(t *testing
 		"-buffered-indexed-writes",
 		"-buffered-indexed-write-max-docs", "16",
 		"-buffered-indexed-write-max-bytes", "1024",
+		"-buffered-indexed-write-max-root-runs", "8",
 		"-progress=false",
 	}, io.Discard)
 	if err != nil {
@@ -204,8 +210,9 @@ func TestRunFixtureReportsBufferedIndexedWritesOnlyWhenIndexesUseThem(t *testing
 	if !indexedSummary.BufferedIndexedWrites {
 		t.Fatal("indexed summary reported buffered indexed writes disabled")
 	}
-	if indexedSummary.BufferedIndexedWriteMaxDocs != 16 || indexedSummary.BufferedIndexedWriteMaxBytes != 1024 {
-		t.Fatalf("indexed buffered limits docs=%d bytes=%d want 16/1024", indexedSummary.BufferedIndexedWriteMaxDocs, indexedSummary.BufferedIndexedWriteMaxBytes)
+	if indexedSummary.BufferedIndexedWriteMaxDocs != 16 || indexedSummary.BufferedIndexedWriteMaxBytes != 1024 || indexedSummary.BufferedIndexedWriteMaxRuns != 8 {
+		t.Fatalf("indexed buffered limits docs=%d bytes=%d rootRuns=%d want 16/1024/8",
+			indexedSummary.BufferedIndexedWriteMaxDocs, indexedSummary.BufferedIndexedWriteMaxBytes, indexedSummary.BufferedIndexedWriteMaxRuns)
 	}
 
 	disabledDir := filepath.Join(t.TempDir(), "disabled")


### PR DESCRIPTION
## Summary
- add a `BufferedIndexedWriteMaxRootRuns` limit for indexed collection write-domain buffers
- keep the trigger cheap with an O(1) pending root-run counter covered by rollback/checkpoint state
- expose the limit in collection shape benchmarks and `collection-load-fixture` summaries/docs

## Why
Many small indexed update batches can accumulate root-local mutation runs before the document or byte threshold fires. That makes later buffered reads/planning and flush work pay for an unnecessarily long pending-run chain. This PR adds a bounded maintenance cadence without affecting non-collection TreeDB paths.

## Validation
- `go test ./TreeDB/collections -run 'Test(CollectionIndexedWriteMemtablesDefaultForIndexedSchemas|CollectionIndexedWriteMemtablesDefaultSkipsNoIndexSchemas|CollectionIndexedWriteMemtablesCanBeDisabled|CollectionIndexedWriteMemtablesAutoFlushMaxRootRuns|ShouldFlushBufferedIndexedWritesAfterAddingBoundaries)' -count 1`\n- `go test ./cmd/collection_load_fixture -count 1`\n- `go test ./TreeDB/collections ./cmd/collection_load_fixture ./cmd/collection_bench_matrix -count 1`\n- `go vet ./TreeDB/collections ./cmd/collection_load_fixture ./cmd/collection_bench_matrix`\n- `TREEDB_COLLECTION_BENCH_BATCH_SIZE=128 TREEDB_COLLECTION_MIXED_SEED_DOCS=1024 TREEDB_COLLECTION_MIXED_WRITE_BATCH_SIZE=64 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionMixedReadWriteScalingSecondaryUnique$/readers_8/writers_2$' -benchtime=20000x -count=1`\n  - `4165 ns/op`, `240114 reader_ops/sec`, `367424 writer_docs/sec`, `96.25 writer_flush_ns/doc`, `4902 B/op`, `21 allocs/op`\n- `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=20000 MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' -benchtime=20000x -count=1`\n  - `29144 ns/op`, `34312 docs/sec`, `37638 B/op`, `105 allocs/op`