### PR TITLE
Improve TreeDB IO hygiene instrumentation

### DIFF
--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -90,3 +90,42 @@ func (l *cachingLeafPageLog) CurrentValueLogSegment() (string, uint32, bool) {
 	}
 	return path, fileID, true
 }
+
+func (l *cachingLeafPageLog) RawWriteStats() valuelog.RawWriteStats {
+	writer := l.currentWriter()
+	if writer == nil {
+		return valuelog.RawWriteStats{}
+	}
+	snapper, ok := writer.(interface {
+		RawWriteStats() valuelog.RawWriteStats
+	})
+	if !ok {
+		return valuelog.RawWriteStats{}
+	}
+	return snapper.RawWriteStats()
+}
+
+func (l *cachingLeafPageLog) RawWritevStats() valuelog.RawWritevStats {
+	writer := l.currentWriter()
+	if writer == nil {
+		return valuelog.RawWritevStats{}
+	}
+	snapper, ok := writer.(interface {
+		RawWritevStats() valuelog.RawWritevStats
+	})
+	if !ok {
+		return valuelog.RawWritevStats{}
+	}
+	return snapper.RawWritevStats()
+}
+
+func (l *cachingLeafPageLog) currentWriter() valueWriter {
+	if l == nil || l.lane == nil {
+		return nil
+	}
+	lane := l.lane
+	lane.vlogMu.Lock()
+	writer := lane.vlog
+	lane.vlogMu.Unlock()
+	return writer
+}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3491,6 +3491,74 @@ type collectionUpdateCombineResult struct {
 	err      error
 }
 
+var collectionUpdateCombineBatchPool = sync.Pool{
+	New: func() any {
+		batch := make([]collectionUpdateCombineRequest, 0, defaultCollectionUpdateCombineMaxBatch)
+		return &batch
+	},
+}
+
+var collectionUpdateBatchItemPool = sync.Pool{
+	New: func() any {
+		items := make([]UpdateBatchItem, defaultCollectionUpdateCombineMaxBatch)
+		return &items
+	},
+}
+
+func acquireCollectionUpdateCombineBatch(capHint int) []collectionUpdateCombineRequest {
+	if capHint <= 0 {
+		capHint = 1
+	}
+	if v := collectionUpdateCombineBatchPool.Get(); v != nil {
+		if ptr, ok := v.(*[]collectionUpdateCombineRequest); ok && ptr != nil {
+			batch := *ptr
+			*ptr = nil
+			if cap(batch) >= capHint {
+				return batch[:0]
+			}
+		}
+	}
+	return make([]collectionUpdateCombineRequest, 0, capHint)
+}
+
+func releaseCollectionUpdateCombineBatch(batch []collectionUpdateCombineRequest) {
+	if cap(batch) == 0 {
+		return
+	}
+	for i := range batch {
+		batch[i] = collectionUpdateCombineRequest{}
+	}
+	batch = batch[:0]
+	collectionUpdateCombineBatchPool.Put(&batch)
+}
+
+func acquireCollectionUpdateBatchItems(n int) []UpdateBatchItem {
+	if n <= 0 {
+		return nil
+	}
+	if v := collectionUpdateBatchItemPool.Get(); v != nil {
+		if ptr, ok := v.(*[]UpdateBatchItem); ok && ptr != nil {
+			items := *ptr
+			*ptr = nil
+			if cap(items) >= n {
+				return items[:n]
+			}
+		}
+	}
+	return make([]UpdateBatchItem, n)
+}
+
+func releaseCollectionUpdateBatchItems(items []UpdateBatchItem) {
+	if cap(items) == 0 {
+		return
+	}
+	for i := range items {
+		items[i] = UpdateBatchItem{}
+	}
+	items = items[:0]
+	collectionUpdateBatchItemPool.Put(&items)
+}
+
 func (c *Collection) updateCombiner() *collectionUpdateCombiner {
 	if c == nil || c.db == nil || c.db.IsClosing() || c.writeDomain == nil {
 		return nil
@@ -3747,7 +3815,8 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 	if batchCap < 1 {
 		batchCap = 1
 	}
-	batch := make([]collectionUpdateCombineRequest, 0, batchCap)
+	batch := acquireCollectionUpdateCombineBatch(batchCap)
+	defer releaseCollectionUpdateCombineBatch(batch)
 	batch = append(batch, first)
 	for len(batch) < batchCap {
 		select {
@@ -3779,7 +3848,8 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 		}
 		return
 	}
-	items := make([]UpdateBatchItem, len(batch))
+	items := acquireCollectionUpdateBatchItems(len(batch))
+	defer releaseCollectionUpdateBatchItems(items)
 	for i, req := range batch {
 		items[i] = UpdateBatchItem{
 			DocumentID: req.documentID,

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3493,15 +3493,13 @@ type collectionUpdateCombineResult struct {
 
 var collectionUpdateCombineBatchPool = sync.Pool{
 	New: func() any {
-		batch := make([]collectionUpdateCombineRequest, 0, defaultCollectionUpdateCombineMaxBatch)
-		return &batch
+		return make([]collectionUpdateCombineRequest, 0, defaultCollectionUpdateCombineMaxBatch)
 	},
 }
 
 var collectionUpdateBatchItemPool = sync.Pool{
 	New: func() any {
-		items := make([]UpdateBatchItem, defaultCollectionUpdateCombineMaxBatch)
-		return &items
+		return make([]UpdateBatchItem, 0, defaultCollectionUpdateCombineMaxBatch)
 	},
 }
 
@@ -3510,9 +3508,7 @@ func acquireCollectionUpdateCombineBatch(capHint int) []collectionUpdateCombineR
 		capHint = 1
 	}
 	if v := collectionUpdateCombineBatchPool.Get(); v != nil {
-		if ptr, ok := v.(*[]collectionUpdateCombineRequest); ok && ptr != nil {
-			batch := *ptr
-			*ptr = nil
+		if batch, ok := v.([]collectionUpdateCombineRequest); ok {
 			if cap(batch) >= capHint {
 				return batch[:0]
 			}
@@ -3529,7 +3525,7 @@ func releaseCollectionUpdateCombineBatch(batch []collectionUpdateCombineRequest)
 		batch[i] = collectionUpdateCombineRequest{}
 	}
 	batch = batch[:0]
-	collectionUpdateCombineBatchPool.Put(&batch)
+	collectionUpdateCombineBatchPool.Put(batch)
 }
 
 func acquireCollectionUpdateBatchItems(n int) []UpdateBatchItem {
@@ -3537,9 +3533,7 @@ func acquireCollectionUpdateBatchItems(n int) []UpdateBatchItem {
 		return nil
 	}
 	if v := collectionUpdateBatchItemPool.Get(); v != nil {
-		if ptr, ok := v.(*[]UpdateBatchItem); ok && ptr != nil {
-			items := *ptr
-			*ptr = nil
+		if items, ok := v.([]UpdateBatchItem); ok {
 			if cap(items) >= n {
 				return items[:n]
 			}
@@ -3556,7 +3550,7 @@ func releaseCollectionUpdateBatchItems(items []UpdateBatchItem) {
 		items[i] = UpdateBatchItem{}
 	}
 	items = items[:0]
-	collectionUpdateBatchItemPool.Put(&items)
+	collectionUpdateBatchItemPool.Put(items)
 }
 
 func (c *Collection) updateCombiner() *collectionUpdateCombiner {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3816,7 +3816,9 @@ func (combiner *collectionUpdateCombiner) runBatchStartingWith(first collectionU
 		batchCap = 1
 	}
 	batch := acquireCollectionUpdateCombineBatch(batchCap)
-	defer releaseCollectionUpdateCombineBatch(batch)
+	defer func() {
+		releaseCollectionUpdateCombineBatch(batch)
+	}()
 	batch = append(batch, first)
 	for len(batch) < batchCap {
 		select {

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -693,6 +693,39 @@ func (db *DB) Stats() map[string]string {
 			stats["treedb.vlog.template_def_cache.hit_ratio"] = fmt.Sprintf("%.6f", float64(hits)/float64(total))
 		}
 	}
+	if db.leafPageLog != nil {
+		if snapper, ok := db.leafPageLog.(interface {
+			RawWriteStats() valuelog.RawWriteStats
+		}); ok {
+			snap := snapper.RawWriteStats()
+			stats["treedb.leaf_vlog_write.syscalls"] = fmt.Sprintf("%d", snap.Syscalls)
+			stats["treedb.leaf_vlog_write.bytes"] = fmt.Sprintf("%d", snap.Bytes)
+			stats["treedb.leaf_vlog_write.calls"] = fmt.Sprintf("%d", snap.Calls)
+			if snap.Syscalls > 0 {
+				stats["treedb.leaf_vlog_write.bytes_per_syscall"] = fmt.Sprintf("%.1f", float64(snap.Bytes)/float64(snap.Syscalls))
+			}
+			if snap.Calls > 0 {
+				stats["treedb.leaf_vlog_write.syscalls_per_call"] = fmt.Sprintf("%.2f", float64(snap.Syscalls)/float64(snap.Calls))
+			}
+		}
+		if snapper, ok := db.leafPageLog.(interface {
+			RawWritevStats() valuelog.RawWritevStats
+		}); ok {
+			snap := snapper.RawWritevStats()
+			stats["treedb.leaf_vlog_writev.syscalls"] = fmt.Sprintf("%d", snap.Syscalls)
+			stats["treedb.leaf_vlog_writev.bytes"] = fmt.Sprintf("%d", snap.Bytes)
+			stats["treedb.leaf_vlog_writev.iovecs"] = fmt.Sprintf("%d", snap.Iovecs)
+			stats["treedb.leaf_vlog_writev.flushes"] = fmt.Sprintf("%d", snap.Flushes)
+			if snap.Syscalls > 0 {
+				stats["treedb.leaf_vlog_writev.bytes_per_syscall"] = fmt.Sprintf("%.1f", float64(snap.Bytes)/float64(snap.Syscalls))
+				stats["treedb.leaf_vlog_writev.iovecs_per_syscall"] = fmt.Sprintf("%.2f", float64(snap.Iovecs)/float64(snap.Syscalls))
+			}
+			if snap.Flushes > 0 {
+				stats["treedb.leaf_vlog_writev.bytes_per_flush"] = fmt.Sprintf("%.1f", float64(snap.Bytes)/float64(snap.Flushes))
+				stats["treedb.leaf_vlog_writev.syscalls_per_flush"] = fmt.Sprintf("%.2f", float64(snap.Syscalls)/float64(snap.Flushes))
+			}
+		}
+	}
 	watermarkLockDelaySharePct, watermarkLatencyP99Ms := db.publishWatermarkStats()
 	stats["treedb.publish.watermark.lock_delay_share_pct"] = fmt.Sprintf("%.3f", watermarkLockDelaySharePct)
 	stats["treedb.publish.watermark.latency_p99_ms"] = fmt.Sprintf("%.3f", watermarkLatencyP99Ms)

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -119,6 +120,32 @@ func (l *leafPageLogWithRecordLengthHints) CurrentValueLogSegment() (path string
 		return "", 0, false
 	}
 	return provider.CurrentValueLogSegment()
+}
+
+func (l *leafPageLogWithRecordLengthHints) RawWriteStats() valuelog.RawWriteStats {
+	if l == nil || l.inner == nil {
+		return valuelog.RawWriteStats{}
+	}
+	provider, ok := l.inner.(interface {
+		RawWriteStats() valuelog.RawWriteStats
+	})
+	if !ok {
+		return valuelog.RawWriteStats{}
+	}
+	return provider.RawWriteStats()
+}
+
+func (l *leafPageLogWithRecordLengthHints) RawWritevStats() valuelog.RawWritevStats {
+	if l == nil || l.inner == nil {
+		return valuelog.RawWritevStats{}
+	}
+	provider, ok := l.inner.(interface {
+		RawWritevStats() valuelog.RawWritevStats
+	})
+	if !ok {
+		return valuelog.RawWritevStats{}
+	}
+	return provider.RawWritevStats()
 }
 
 func (db *DB) currentLeafPageLogSegment() (path string, fileID uint32, ok bool) {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -513,7 +513,7 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		}
 	}
 	f.mmapReadFallbackReadAt.Add(1)
-	return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+	return readAtWithDictAllowed(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, f.allowsCompactLeafPayload())
 }
 
 func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
@@ -549,7 +549,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 			}
 		}
 		f.mmapReadFallbackReadAt.Add(1)
-		return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+		return readAtWithDictAllowed(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, f.allowsCompactLeafPayload())
 	}
 	// Avoid per-read Stat/lock churn once we have exhausted the dead-mapping
 	// budget: remapToFileSize won't be able to grow the mapping safely again.
@@ -571,7 +571,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		f.mmapReadMissDeadMappingCap.Add(1)
 	}
 	f.mmapReadFallbackReadAt.Add(1)
-	return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+	return readAtWithDictAllowed(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, f.allowsCompactLeafPayload())
 }
 
 // ReadUnsafeTo is like ReadUnsafe, but it may return a slice backed by dst
@@ -631,7 +631,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 				return val, usedDst, nil
 			}
 		}
-		return ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
+		return readAtWithDictToAllowed(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst, f.allowsCompactLeafPayload())
 	}
 	// Avoid per-read Stat/lock churn once we have exhausted the dead-mapping
 	// budget: remapToFileSize won't be able to grow the mapping safely again.
@@ -671,7 +671,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 			return val, usedDst, nil
 		}
 	}
-	return ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
+	return readAtWithDictToAllowed(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst, f.allowsCompactLeafPayload())
 }
 
 // readGroupedCompressedFromFileTo handles grouped+compressed reads on the
@@ -806,18 +806,18 @@ func (f *File) readGroupedCompressedFromFileTo(ptr page.ValuePtr, dst []byte) ([
 	}
 	val := raw[valStart:valEnd]
 	if f.templateLookup != nil && templ.IsEncodedPayload(val) {
-		encoded := append([]byte(nil), val...)
 		cachedRaw := f.groupedFrameCacheStore(start, false, k, offsets, raw, pooledRaw)
+		decoded, usedDst, err := decodeTemplatePayloadTo(val, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
+		if err != nil {
+			if pooledRaw && !cachedRaw {
+				f.releaseDecodeScratch(raw)
+			}
+			return nil, false, err, true
+		}
 		if pooledRaw && !cachedRaw {
 			f.releaseDecodeScratch(raw)
 		}
-		decoded, err := templ.DecodePayloadAppend(nil, encoded, func(id uint64) (templ.TemplateDef, error) {
-			return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
-		}, f.templateDecodeOpts)
-		if err != nil {
-			return nil, false, err, true
-		}
-		return decoded, false, nil, true
+		return decoded, usedDst, nil, true
 	}
 
 	if dst != nil && cap(dst) >= len(val) {
@@ -982,7 +982,7 @@ func (f *File) appendDecodedRecordTo(ptr page.ValuePtr, verifyCRC bool, dst []by
 	if oldLen <= cap(dst) {
 		tail = dst[oldLen:cap(dst)]
 	}
-	val, usedDst, err := ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, tail[:0])
+	val, usedDst, err := readAtWithDictToAllowed(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, tail[:0], f.allowsCompactLeafPayload())
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/internal/valuelog/reader.go
+++ b/TreeDB/internal/valuelog/reader.go
@@ -184,6 +184,7 @@ type Reader struct {
 	templateLookup     TemplateLookup
 	templateDecodeOpts templ.DecodeOptions
 	templateDefCache   *templateDefCache
+	compactLeafAllowed bool
 	pending            []frameEntry
 	pendingIndex       int
 	headerScratch      [HeaderSize]byte
@@ -215,12 +216,13 @@ func NewReaderWithBufferSize(path string, fileID uint32, bufferSize int) (*Reade
 		return nil, err
 	}
 	return &Reader{
-		f:            f,
-		closeFn:      f.Close,
-		r:            bufio.NewReaderSize(f, bufferSize),
-		fileID:       fileID,
-		verifies:     true,
-		decodeValues: true,
+		f:                  f,
+		closeFn:            f.Close,
+		r:                  bufio.NewReaderSize(f, bufferSize),
+		fileID:             fileID,
+		verifies:           true,
+		decodeValues:       true,
+		compactLeafAllowed: allowsCompactLeafLogPayload(fileID, path),
 	}, nil
 }
 
@@ -236,11 +238,12 @@ func NewReaderFromFileWithBufferSize(f *os.File, fileID uint32, bufferSize int) 
 	}
 	sr := io.NewSectionReader(f, 0, 1<<63-1)
 	return &Reader{
-		f:            f,
-		r:            bufio.NewReaderSize(sr, bufferSize),
-		fileID:       fileID,
-		verifies:     true,
-		decodeValues: true,
+		f:                  f,
+		r:                  bufio.NewReaderSize(sr, bufferSize),
+		fileID:             fileID,
+		verifies:           true,
+		decodeValues:       true,
+		compactLeafAllowed: allowsCompactLeafLogPayload(fileID, f.Name()),
 	}
 }
 
@@ -267,6 +270,13 @@ func (r *Reader) SetTemplateLookup(lookup TemplateLookup, opts templ.DecodeOptio
 	r.templateLookup = lookup
 	r.templateDecodeOpts = opts
 	r.templateDefCache = newTemplateDefCache(opts.DefCacheSize)
+}
+
+func (r *Reader) maybeDecodeLeafLogPayloadTo(payload, dst []byte) ([]byte, bool, bool, error) {
+	if r == nil {
+		return payload, false, false, nil
+	}
+	return maybeDecodeLeafLogPayloadToAllowed(r.compactLeafAllowed, payload, dst)
 }
 
 func (r *Reader) ReadNext() (uint64, []byte, page.ValuePtr, error) {
@@ -321,7 +331,7 @@ func (r *Reader) ReadNext() (uint64, []byte, page.ValuePtr, error) {
 		if r.fileID == 0 {
 			return rid, payload, ptr, nil
 		}
-		payload, _, _, err := maybeDecodeLeafLogPayloadTo(r.fileID, r.f.Name(), payload, nil)
+		payload, _, _, err := r.maybeDecodeLeafLogPayloadTo(payload, nil)
 		if err != nil {
 			return 0, nil, page.ValuePtr{}, err
 		}
@@ -387,7 +397,7 @@ func (r *Reader) ReadNext() (uint64, []byte, page.ValuePtr, error) {
 				}
 				val = decoded
 			}
-			val, _, _, err = maybeDecodeLeafLogPayloadTo(r.fileID, r.f.Name(), val, nil)
+			val, _, _, err = r.maybeDecodeLeafLogPayloadTo(val, nil)
 			if err != nil {
 				return 0, nil, page.ValuePtr{}, err
 			}
@@ -725,6 +735,14 @@ func ReadAtTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 }
 
 func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions) ([]byte, error) {
+	compactLeafAllowed := false
+	if f != nil {
+		compactLeafAllowed = allowsCompactLeafLogPayload(ptr.FileID, f.Name())
+	}
+	return readAtWithDictAllowed(f, ptr, verifyCRC, dictLookup, templateLookup, templateCache, templateOpts, compactLeafAllowed)
+}
+
+func readAtWithDictAllowed(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions, compactLeafAllowed bool) ([]byte, error) {
 	if f == nil {
 		return nil, errors.New("valuelog: nil file")
 	}
@@ -843,13 +861,13 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 				if err != nil {
 					return nil, err
 				}
-				decoded, _, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
+				decoded, _, _, err = maybeDecodeLeafLogPayloadToAllowed(compactLeafAllowed, decoded, nil)
 				if err != nil {
 					return nil, err
 				}
 				return decoded, nil
 			}
-			val, _, _, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, nil)
+			val, _, _, err := maybeDecodeLeafLogPayloadToAllowed(compactLeafAllowed, val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -871,7 +889,7 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 	if err != nil {
 		return nil, err
 	}
-	val, _, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, nil)
+	val, _, _, err = maybeDecodeLeafLogPayloadToAllowed(compactLeafAllowed, val, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -883,6 +901,14 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 // The returned slice may alias dst when usedDst is true. The returned bytes are
 // immutable from the caller perspective.
 func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions, dst []byte) ([]byte, bool, error) {
+	compactLeafAllowed := false
+	if f != nil {
+		compactLeafAllowed = allowsCompactLeafLogPayload(ptr.FileID, f.Name())
+	}
+	return readAtWithDictToAllowed(f, ptr, verifyCRC, dictLookup, templateLookup, templateCache, templateOpts, dst, compactLeafAllowed)
+}
+
+func readAtWithDictToAllowed(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions, dst []byte, compactLeafAllowed bool) ([]byte, bool, error) {
 	if f == nil {
 		return nil, false, errors.New("valuelog: nil file")
 	}
@@ -1010,13 +1036,13 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 				if err != nil {
 					return nil, false, err
 				}
-				decoded, _, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
+				decoded, _, _, err = maybeDecodeLeafLogPayloadToAllowed(compactLeafAllowed, decoded, nil)
 				if err != nil {
 					return nil, false, err
 				}
 				return decoded, false, nil
 			}
-			val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, dst)
+			val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadToAllowed(compactLeafAllowed, val, dst)
 			if err != nil {
 				return nil, false, err
 			}
@@ -1054,13 +1080,13 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 			if err != nil {
 				return nil, false, err
 			}
-			decoded, _, _, err = maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), decoded, nil)
+			decoded, _, _, err = maybeDecodeLeafLogPayloadToAllowed(compactLeafAllowed, decoded, nil)
 			if err != nil {
 				return nil, false, err
 			}
 			return decoded, false, nil
 		}
-		payload, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), payload, dst)
+		payload, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadToAllowed(compactLeafAllowed, payload, dst)
 		if err != nil {
 			return nil, false, err
 		}
@@ -1088,7 +1114,7 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 		putDecodeScratch(payloadScratch)
 		return nil, false, err
 	}
-	val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, dst)
+	val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadToAllowed(compactLeafAllowed, val, dst)
 	if err != nil {
 		putDecodeScratch(payloadScratch)
 		return nil, false, err
@@ -1243,14 +1269,14 @@ func decodeRecordTo(header *[HeaderSize]byte, payload []byte, ptr page.ValuePtr,
 		if page.ValuePtrIsGrouped(ptr) {
 			return nil, false, ErrCorrupt
 		}
-		if templateLookup != nil && templ.IsEncodedPayload(payload) {
-			decoded, err := templ.DecodePayloadAppend(nil, payload, func(id uint64) (templ.TemplateDef, error) {
-				return resolveTemplateDef(id, templateLookup, templateCache)
-			}, templateOpts)
+		if templateLookup != nil {
+			decoded, usedDst, err := decodeTemplatePayloadTo(payload, templateLookup, templateCache, templateOpts, dst)
 			if err != nil {
 				return nil, false, err
 			}
-			return decoded, false, nil
+			if usedDst || templ.IsEncodedPayload(payload) {
+				return decoded, usedDst, nil
+			}
 		}
 		return payload, false, nil
 	}
@@ -1292,13 +1318,11 @@ func decodeRecordTo(header *[HeaderSize]byte, payload []byte, ptr page.ValuePtr,
 				}
 				val := raw
 				if templateLookup != nil && templ.IsEncodedPayload(val) {
-					decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
-						return resolveTemplateDef(id, templateLookup, templateCache)
-					}, templateOpts)
+					decoded, usedTemplateDst, err := decodeTemplatePayloadTo(val, templateLookup, templateCache, templateOpts, dst)
 					if err != nil {
 						return nil, false, err
 					}
-					return decoded, false, nil
+					return decoded, usedTemplateDst, nil
 				}
 				return val, true, nil
 			}
@@ -1317,13 +1341,11 @@ func decodeRecordTo(header *[HeaderSize]byte, payload []byte, ptr page.ValuePtr,
 			copy(val, raw[start:end])
 			putDecodeScratch(raw)
 			if templateLookup != nil && templ.IsEncodedPayload(val) {
-				decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
-					return resolveTemplateDef(id, templateLookup, templateCache)
-				}, templateOpts)
+				decoded, usedTemplateDst, err := decodeTemplatePayloadTo(val, templateLookup, templateCache, templateOpts, dst)
 				if err != nil {
 					return nil, false, err
 				}
-				return decoded, false, nil
+				return decoded, usedTemplateDst, nil
 			}
 			return val, true, nil
 		}
@@ -1344,13 +1366,11 @@ func decodeRecordTo(header *[HeaderSize]byte, payload []byte, ptr page.ValuePtr,
 		copy(val, raw[start:end])
 		putDecodeScratch(raw)
 		if templateLookup != nil && templ.IsEncodedPayload(val) {
-			decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
-				return resolveTemplateDef(id, templateLookup, templateCache)
-			}, templateOpts)
+			decoded, usedTemplateDst, err := decodeTemplatePayloadTo(val, templateLookup, templateCache, templateOpts, dst)
 			if err != nil {
 				return nil, false, err
 			}
-			return decoded, false, nil
+			return decoded, usedTemplateDst, nil
 		}
 		return val, false, nil
 	}
@@ -1365,13 +1385,12 @@ func decodeRecordTo(header *[HeaderSize]byte, payload []byte, ptr page.ValuePtr,
 	val := raw[start:end]
 	usedDst := false
 	if templateLookup != nil && templ.IsEncodedPayload(val) {
-		decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
-			return resolveTemplateDef(id, templateLookup, templateCache)
-		}, templateOpts)
+		decoded, usedTemplateDst, err := decodeTemplatePayloadTo(val, templateLookup, templateCache, templateOpts, dst)
 		if err != nil {
 			return nil, false, err
 		}
 		val = decoded
+		usedDst = usedTemplateDst
 	} else if dst != nil && cap(dst) >= outLen {
 		// Uncompressed path: copy into dst to allow callers to avoid retaining a
 		// large frame payload allocation.

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -864,8 +864,10 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 	fFlags := frameHeader[1]
 
-	decodeTemplatePayload := func(val []byte) ([]byte, bool, error) {
-		return decodeTemplatePayloadTo(val, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
+	decodeTemplatePayload := func(val []byte) ([]byte, bool, bool, error) {
+		templateEncoded := f.templateLookup != nil && templ.IsEncodedPayload(val)
+		decoded, usedDst, err := decodeTemplatePayloadTo(val, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
+		return decoded, usedDst, templateEncoded, err
 	}
 
 	subIndex := int(page.ValuePtrSubIndex(ptr))
@@ -884,12 +886,12 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 			if err != nil {
 				return nil, false, err, true
 			}
-			val, decoded, err := decodeTemplatePayload(val)
+			val, templateUsedDst, templateDecoded, err := decodeTemplatePayload(val)
 			if err != nil {
 				return nil, false, err, true
 			}
-			if decoded {
-				return val, false, nil, true
+			if templateDecoded {
+				return val, templateUsedDst, nil, true
 			}
 			return val, usedDst, nil, true
 		}
@@ -927,11 +929,11 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		if srcStart < 0 || srcEnd < srcStart || srcEnd > len(payload) {
 			return nil, false, ErrCorrupt, true
 		}
-		val, _, err := decodeTemplatePayload(payload[srcStart:srcEnd])
+		val, templateUsedDst, _, err := decodeTemplatePayload(payload[srcStart:srcEnd])
 		if err != nil {
 			return nil, false, err, true
 		}
-		return val, false, nil, true
+		return val, templateUsedDst, nil, true
 	}
 
 	if len(payload) < prefixLen {
@@ -954,14 +956,12 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	// dst is used iff it was provided with enough capacity to hold rawLen.
 	usedDst := dst != nil && cap(dst) >= int(rawLen)
 
-	val, decoded, err := decodeTemplatePayload(raw[valStart:valEnd])
+	val, templateUsedDst, templateDecoded, err := decodeTemplatePayload(raw[valStart:valEnd])
 	if err != nil {
 		return nil, false, err, true
 	}
-	// Template decoding allocates new bytes; the returned slice is no longer
-	// backed by dst even if we decoded into it.
-	if decoded {
-		usedDst = false
+	if templateDecoded {
+		usedDst = templateUsedDst
 	}
 	return val, usedDst, nil, true
 }

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -25,6 +25,24 @@ func appendDecodedTemplatePayload(dst, payload []byte, lookup TemplateLookup, ca
 	}, opts)
 }
 
+func decodeTemplatePayloadTo(payload []byte, lookup TemplateLookup, cache *templateDefCache, opts templ.DecodeOptions, dst []byte) ([]byte, bool, error) {
+	if lookup == nil || !templ.IsEncodedPayload(payload) {
+		return payload, false, nil
+	}
+	// Avoid decoding into dst when the encoded payload itself aliases dst.
+	// Template decode is append-style and may overwrite dst as it reads.
+	if dst != nil && sliceAliasesBytes(dst, payload) {
+		dst = nil
+	}
+	decoded, err := templ.DecodePayloadAppend(dst[:0], payload, func(id uint64) (templ.TemplateDef, error) {
+		return resolveTemplateDef(id, lookup, cache)
+	}, opts)
+	if err != nil {
+		return nil, false, err
+	}
+	return decoded, dst != nil && sliceAliasesBytes(dst, decoded), nil
+}
+
 // readViaMmapViewPrefixCacheEnabled controls whether unsafe mmap-view reads
 // consult/publish the shared per-file grouped prefix cache.
 //
@@ -818,14 +836,14 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 
 	// Non-grouped record: the payload is the value.
 	if flags&recordFlagGrouped == 0 {
-		if f.templateLookup != nil && templ.IsEncodedPayload(payload) {
-			decoded, err := templ.DecodePayloadAppend(nil, payload, func(id uint64) (templ.TemplateDef, error) {
-				return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
-			}, f.templateDecodeOpts)
+		if f.templateLookup != nil {
+			decoded, usedDst, err := decodeTemplatePayloadTo(payload, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
 			if err != nil {
 				return nil, false, err, true
 			}
-			return decoded, false, nil, true
+			if usedDst || templ.IsEncodedPayload(payload) {
+				return decoded, usedDst, nil, true
+			}
 		}
 		return payload, false, nil, true
 	}
@@ -847,16 +865,7 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	fFlags := frameHeader[1]
 
 	decodeTemplatePayload := func(val []byte) ([]byte, bool, error) {
-		if f.templateLookup == nil || !templ.IsEncodedPayload(val) {
-			return val, false, nil
-		}
-		decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
-			return resolveTemplateDef(id, f.templateLookup, f.templateDefCache)
-		}, f.templateDecodeOpts)
-		if err != nil {
-			return nil, false, err
-		}
-		return decoded, true, nil
+		return decodeTemplatePayloadTo(val, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
 	}
 
 	subIndex := int(page.ValuePtrSubIndex(ptr))

--- a/TreeDB/internal/valuelog/reader_to_test.go
+++ b/TreeDB/internal/valuelog/reader_to_test.go
@@ -77,3 +77,78 @@ func TestReadAtWithDictTo_UsesDstForCompressedGroupedSubrecord(t *testing.T) {
 		}
 	}
 }
+
+func TestReadAtWithDictTo_DecodesTemplatePayloadIntoDst(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+
+	def := templ.TemplateDef{
+		Kind:    templ.TemplateAnchors,
+		Anchors: [][]byte{bytes.Repeat([]byte("A"), 16), bytes.Repeat([]byte("B"), 16)},
+	}
+	defBytes, err := templ.EncodeTemplateDef(def, templ.Config{})
+	if err != nil {
+		t.Fatalf("EncodeTemplateDef: %v", err)
+	}
+	payload, err := templ.EncodePayload(1, [][]byte{[]byte("alpha"), []byte("beta"), []byte("gamma")})
+	if err != nil {
+		t.Fatalf("EncodePayload: %v", err)
+	}
+	want, err := templ.DecodePayloadAppend(nil, payload, func(id uint64) (templ.TemplateDef, error) {
+		if id != 1 {
+			return templ.TemplateDef{}, ErrMissingTemplate
+		}
+		return def, nil
+	}, templ.DecodeOptions{})
+	if err != nil {
+		t.Fatalf("DecodePayloadAppend: %v", err)
+	}
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	ptr, err := writer.Append(0, nil, 1, payload)
+	if err != nil {
+		_ = writer.Close()
+		t.Fatalf("append: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	lookup := func(id uint64) ([]byte, error) {
+		if id != 1 {
+			return nil, ErrMissingTemplate
+		}
+		return defBytes, nil
+	}
+	dst := make([]byte, 0, len(want))
+	dstBacking := dst[:1]
+	got, usedDst, err := ReadAtWithDictTo(f, ptr, true, nil, lookup, nil, templ.DecodeOptions{}, dst)
+	if err != nil {
+		t.Fatalf("ReadAtWithDictTo: %v", err)
+	}
+	if !usedDst {
+		t.Fatalf("expected usedDst=true")
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got len=%d want=%d", len(got), len(want))
+	}
+	if &got[0] != &dstBacking[0] {
+		t.Fatalf("expected returned slice to be backed by dst")
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("value mismatch: got %q want %q", got, want)
+	}
+}

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -501,6 +501,15 @@ sizes, not allocated physical disk usage including block allocation, sparse-file
 effects, filesystem compression, or metadata. Capture `du` separately when
 physical on-disk usage is the comparison target.
 
+TreeDB JSON output also includes per-phase `treedb_stats_delta` and
+`treedb_stats_after` fields for selected storage counters. Use these when
+checking I/O hygiene regressions: `treedb.*vlog_mmap*.fallback_readat` should
+stay low in mmap-eligible workloads, `*.hits`/`*.hit_ratio` show mmap use,
+`*.miss_*` identifies why a phase left the mmap path, and
+`treedb.cache.vlog_write*` / `treedb.cache.vlog_writev*` show write syscall
+batching. The text format prints the same per-phase counter deltas as
+`treedb_phase_stats`.
+
 For MongoDB, compare `mongodb_stats_final.storageSize`,
 `mongodb_stats_final.indexSize`, and `mongodb_stats_final.totalSize`. If the
 MongoDB server is local, also capture a filesystem `du` of the database path for

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -127,20 +127,20 @@ type benchmarkResult struct {
 }
 
 type phaseResult struct {
-	Name                    string             `json:"name"`
-	Operations              int                `json:"operations"`
-	DriverCalls             int                `json:"driver_calls"`
-	EffectiveProducers      int                `json:"effective_producers,omitempty"`
-	DurationMillis          float64            `json:"duration_ms"`
-	OpsPerSecond            float64            `json:"ops_per_sec"`
-	SampledOpsPerSecond     float64            `json:"sampled_ops_per_sec,omitempty"`
-	SampledNsPerOp          float64            `json:"sampled_ns_per_op,omitempty"`
-	DriverAggregateMillis   float64            `json:"driver_aggregate_duration_ms,omitempty"`
-	DriverMeanLatencyMicros float64            `json:"driver_mean_latency_us,omitempty"`
-	LatencyMicros           latencySummary     `json:"latency_micros"`
-	ProducerResults         []producerResult   `json:"producer_results,omitempty"`
-	TreeDBStatsDelta        map[string]float64 `json:"treedb_stats_delta,omitempty"`
-	TreeDBStatsAfter        map[string]string  `json:"treedb_stats_after,omitempty"`
+	Name                    string            `json:"name"`
+	Operations              int               `json:"operations"`
+	DriverCalls             int               `json:"driver_calls"`
+	EffectiveProducers      int               `json:"effective_producers,omitempty"`
+	DurationMillis          float64           `json:"duration_ms"`
+	OpsPerSecond            float64           `json:"ops_per_sec"`
+	SampledOpsPerSecond     float64           `json:"sampled_ops_per_sec,omitempty"`
+	SampledNsPerOp          float64           `json:"sampled_ns_per_op,omitempty"`
+	DriverAggregateMillis   float64           `json:"driver_aggregate_duration_ms,omitempty"`
+	DriverMeanLatencyMicros float64           `json:"driver_mean_latency_us,omitempty"`
+	LatencyMicros           latencySummary    `json:"latency_micros"`
+	ProducerResults         []producerResult  `json:"producer_results,omitempty"`
+	TreeDBStatsDelta        map[string]int64  `json:"treedb_stats_delta,omitempty"`
+	TreeDBStatsAfter        map[string]string `json:"treedb_stats_after,omitempty"`
 }
 
 type producerResult struct {
@@ -2689,26 +2689,26 @@ func selectedTreeDBStats(stats map[string]string) map[string]string {
 	return out
 }
 
-func treeDBStatDeltas(before, after map[string]string) map[string]float64 {
+func treeDBStatDeltas(before, after map[string]string) map[string]int64 {
 	if len(after) == 0 {
 		return nil
 	}
-	out := make(map[string]float64)
+	out := make(map[string]int64)
 	for key, afterValue := range after {
 		if !isTreeDBDeltaStatKey(key) {
 			continue
 		}
-		afterFloat, ok := parseTreeDBFloatStat(afterValue)
+		afterInt, ok := parseTreeDBIntStat(afterValue)
 		if !ok {
 			continue
 		}
-		beforeFloat := 0.0
+		beforeInt := int64(0)
 		if beforeValue, exists := before[key]; exists {
-			if parsed, ok := parseTreeDBFloatStat(beforeValue); ok {
-				beforeFloat = parsed
+			if parsed, ok := parseTreeDBIntStat(beforeValue); ok {
+				beforeInt = parsed
 			}
 		}
-		delta := afterFloat - beforeFloat
+		delta := afterInt - beforeInt
 		if delta != 0 {
 			out[key] = delta
 		}
@@ -2719,11 +2719,11 @@ func treeDBStatDeltas(before, after map[string]string) map[string]float64 {
 	return out
 }
 
-func parseTreeDBFloatStat(value string) (float64, bool) {
+func parseTreeDBIntStat(value string) (int64, bool) {
 	if value == "" {
 		return 0, false
 	}
-	parsed, err := strconv.ParseFloat(value, 64)
+	parsed, err := strconv.ParseInt(value, 10, 64)
 	return parsed, err == nil
 }
 
@@ -2772,7 +2772,7 @@ func writeTreeDBStats(out io.Writer, label string, stats map[string]string) {
 	}
 }
 
-func writeTreeDBStatDeltas(out io.Writer, label string, stats map[string]float64) {
+func writeTreeDBStatDeltas(out io.Writer, label string, stats map[string]int64) {
 	if len(stats) == 0 {
 		return
 	}
@@ -2783,7 +2783,7 @@ func writeTreeDBStatDeltas(out io.Writer, label string, stats map[string]float64
 	sort.Strings(keys)
 	fmt.Fprintf(out, "%s", label)
 	for _, key := range keys {
-		fmt.Fprintf(out, " %s.delta=%.0f", key, stats[key])
+		fmt.Fprintf(out, " %s.delta=%d", key, stats[key])
 	}
 	fmt.Fprintln(out)
 }

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -127,18 +127,20 @@ type benchmarkResult struct {
 }
 
 type phaseResult struct {
-	Name                    string           `json:"name"`
-	Operations              int              `json:"operations"`
-	DriverCalls             int              `json:"driver_calls"`
-	EffectiveProducers      int              `json:"effective_producers,omitempty"`
-	DurationMillis          float64          `json:"duration_ms"`
-	OpsPerSecond            float64          `json:"ops_per_sec"`
-	SampledOpsPerSecond     float64          `json:"sampled_ops_per_sec,omitempty"`
-	SampledNsPerOp          float64          `json:"sampled_ns_per_op,omitempty"`
-	DriverAggregateMillis   float64          `json:"driver_aggregate_duration_ms,omitempty"`
-	DriverMeanLatencyMicros float64          `json:"driver_mean_latency_us,omitempty"`
-	LatencyMicros           latencySummary   `json:"latency_micros"`
-	ProducerResults         []producerResult `json:"producer_results,omitempty"`
+	Name                    string             `json:"name"`
+	Operations              int                `json:"operations"`
+	DriverCalls             int                `json:"driver_calls"`
+	EffectiveProducers      int                `json:"effective_producers,omitempty"`
+	DurationMillis          float64            `json:"duration_ms"`
+	OpsPerSecond            float64            `json:"ops_per_sec"`
+	SampledOpsPerSecond     float64            `json:"sampled_ops_per_sec,omitempty"`
+	SampledNsPerOp          float64            `json:"sampled_ns_per_op,omitempty"`
+	DriverAggregateMillis   float64            `json:"driver_aggregate_duration_ms,omitempty"`
+	DriverMeanLatencyMicros float64            `json:"driver_mean_latency_us,omitempty"`
+	LatencyMicros           latencySummary     `json:"latency_micros"`
+	ProducerResults         []producerResult   `json:"producer_results,omitempty"`
+	TreeDBStatsDelta        map[string]float64 `json:"treedb_stats_delta,omitempty"`
+	TreeDBStatsAfter        map[string]string  `json:"treedb_stats_after,omitempty"`
 }
 
 type producerResult struct {
@@ -1041,7 +1043,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	if target.poolStats != nil {
 		target.poolStats.Reset()
 	}
-	loadPhase, err := runProfiledPhase(profiler, "load_insert_many", func() (phaseResult, error) {
+	loadPhase, err := runProfiledTreeDBPhase(profiler, target, "load_insert_many", func() (phaseResult, error) {
 		return runLoadPhase(ctx, cfg, target, coll, prebuilt, prebuiltRaw)
 	})
 	if err != nil {
@@ -1055,7 +1057,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		return nil, err
 	}
 
-	idPhase, err := measureProfiledPhase(profiler, "id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+	idPhase, err := measureProfiledTreeDBPhase(profiler, target, "id_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Reads; i++ {
 			id := benchmarkID(i % cfg.Documents)
 			var out bson.M
@@ -1077,7 +1079,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	result.Phases = append(result.Phases, idPhase)
 
 	if runEmailFindPhase(cfg) {
-		emailPhase, err := measureProfiledPhase(profiler, "email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
+		emailPhase, err := measureProfiledTreeDBPhase(profiler, target, "email_find_one", cfg.Reads, func(sample func(time.Duration)) error {
 			for i := 0; i < cfg.Reads; i++ {
 				email := benchmarkEmail((i * 17) % cfg.Documents)
 				var out bson.M
@@ -1099,7 +1101,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.Phases = append(result.Phases, emailPhase)
 	}
 
-	rangePhase, err := measureProfiledPhase(profiler, "age_range_limit_10", cfg.RangeReads, func(sample func(time.Duration)) error {
+	rangePhase, err := measureProfiledTreeDBPhase(profiler, target, "age_range_limit_10", cfg.RangeReads, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.RangeReads; i++ {
 			minAge := int64(20 + (i % 40))
 			begin := time.Now()
@@ -1134,7 +1136,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	if cfg.Updates > 0 {
 		updateCityValues = updatedCityValuesForUpdate()
 	}
-	updatePhase, err := measureProfiledPhase(profiler, "id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
+	updatePhase, err := measureProfiledTreeDBPhase(profiler, target, "id_update_set", cfg.Updates, func(sample func(time.Duration)) error {
 		for i := 0; i < cfg.Updates; i++ {
 			documentOrdinal := benchmarkDocumentOrdinal(i, 31, cfg.Documents)
 			id := benchmarkID(documentOrdinal)
@@ -1167,7 +1169,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 
 	if cfg.ConcurrentReaders > 0 && cfg.ConcurrentReads > 0 {
 		phaseName := fmt.Sprintf("concurrent_id_find_one_r%d", cfg.ConcurrentReaders)
-		concurrentReadPhase, err := measureProfiledPhase(profiler, phaseName, cfg.ConcurrentReads, func(sample func(time.Duration)) error {
+		concurrentReadPhase, err := measureProfiledTreeDBPhase(profiler, target, phaseName, cfg.ConcurrentReads, func(sample func(time.Duration)) error {
 			return runConcurrentOperations(ctx, cfg.ConcurrentReaders, cfg.ConcurrentReads, func(op int) error {
 				id := benchmarkID(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
 				var out bson.M
@@ -1192,7 +1194,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	if cfg.ConcurrentWriters > 0 && cfg.ConcurrentWrites > 0 {
 		phaseName := fmt.Sprintf("concurrent_id_update_set_w%d", cfg.ConcurrentWriters)
 		concurrentUpdateCityValues := updatedCityValuesForUpdate()
-		concurrentWritePhase, err := measureProfiledPhase(profiler, phaseName, cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
+		concurrentWritePhase, err := measureProfiledTreeDBPhase(profiler, target, phaseName, cfg.ConcurrentWrites, func(sample func(time.Duration)) error {
 			return runConcurrentOperations(ctx, cfg.ConcurrentWriters, cfg.ConcurrentWrites, func(op int) error {
 				documentOrdinal := benchmarkDocumentOrdinal(op, 37, cfg.Documents)
 				id := benchmarkID(documentOrdinal)
@@ -1226,7 +1228,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	}
 
 	if cfg.Deletes > 0 {
-		deletePhase, err := measureProfiledPhase(profiler, "id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
+		deletePhase, err := measureProfiledTreeDBPhase(profiler, target, "id_delete_one", cfg.Deletes, func(sample func(time.Duration)) error {
 			for i := 0; i < cfg.Deletes; i++ {
 				id := benchmarkID(cfg.Documents - 1 - i)
 				begin := time.Now()
@@ -1262,11 +1264,45 @@ func measureProfiledPhase(profiler *profileRecorder, name string, operations int
 	})
 }
 
+func measureProfiledTreeDBPhase(profiler *profileRecorder, target *benchTarget, name string, operations int, run func(func(time.Duration)) error) (phaseResult, error) {
+	return runProfiledTreeDBPhase(profiler, target, name, func() (phaseResult, error) {
+		return measurePhase(name, operations, run)
+	})
+}
+
 func runProfiledPhase(profiler *profileRecorder, name string, run func() (phaseResult, error)) (phaseResult, error) {
 	if profiler == nil {
 		return run()
 	}
 	return profiler.RunPhase(name, run)
+}
+
+func runProfiledTreeDBPhase(profiler *profileRecorder, target *benchTarget, name string, run func() (phaseResult, error)) (phaseResult, error) {
+	before := treeDBPhaseStatsSnapshot(target)
+	phase, err := runProfiledPhase(profiler, name, run)
+	attachTreeDBPhaseStats(target, &phase, before)
+	return phase, err
+}
+
+func treeDBPhaseStatsSnapshot(target *benchTarget) map[string]string {
+	if target == nil || target.db == nil {
+		return nil
+	}
+	return selectedTreeDBStats(target.db.Stats())
+}
+
+func attachTreeDBPhaseStats(target *benchTarget, phase *phaseResult, before map[string]string) {
+	if phase == nil {
+		return
+	}
+	after := treeDBPhaseStatsSnapshot(target)
+	if len(after) == 0 {
+		return
+	}
+	phase.TreeDBStatsAfter = after
+	if delta := treeDBStatDeltas(before, after); len(delta) > 0 {
+		phase.TreeDBStatsDelta = delta
+	}
 }
 
 func runEmailFindPhase(cfg config) bool {
@@ -2542,6 +2578,7 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 					producer.DriverAggregateMillis, producer.DriverMeanLatencyMicros,
 					producer.LatencyMicros.P50, producer.LatencyMicros.P95, producer.LatencyMicros.P99)
 			}
+			writeTreeDBStatDeltas(out, "  treedb_phase_stats", phase.TreeDBStatsDelta)
 		}
 		if result.MongoPoolStatsAfterLoad != nil {
 			writeMongoPoolStats(out, "mongo_pool_after_load", result.MongoPoolStatsAfterLoad)
@@ -2612,6 +2649,16 @@ func newSelectedTreeDBExactStatKeySet(keys []string) map[string]struct{} {
 var selectedTreeDBStatPrefixes = [...]string{
 	"treedb.publish.ordered_root_delta_group.",
 	"treedb.publish.watermark.",
+	"treedb.cache.vlog_writev.",
+	"treedb.cache.vlog_write.",
+	"treedb.cache.vlog_io.",
+	"treedb.cache.vlog_mmap.",
+	"treedb.cache.vlog_decode_buffer_grow.",
+	"treedb.leaf_vlog_write.",
+	"treedb.leaf_vlog_writev.",
+	"treedb.vlog.mmap_",
+	"treedb.process.memory.vlog_mmap_",
+	"treedb.process.memory.peak_vlog_mmap_",
 }
 
 func isSelectedTreeDBStatKey(key string) bool {
@@ -2642,6 +2689,65 @@ func selectedTreeDBStats(stats map[string]string) map[string]string {
 	return out
 }
 
+func treeDBStatDeltas(before, after map[string]string) map[string]float64 {
+	if len(after) == 0 {
+		return nil
+	}
+	out := make(map[string]float64)
+	for key, afterValue := range after {
+		if !isTreeDBDeltaStatKey(key) {
+			continue
+		}
+		afterFloat, ok := parseTreeDBFloatStat(afterValue)
+		if !ok {
+			continue
+		}
+		beforeFloat := 0.0
+		if beforeValue, exists := before[key]; exists {
+			if parsed, ok := parseTreeDBFloatStat(beforeValue); ok {
+				beforeFloat = parsed
+			}
+		}
+		delta := afterFloat - beforeFloat
+		if delta != 0 {
+			out[key] = delta
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func parseTreeDBFloatStat(value string) (float64, bool) {
+	if value == "" {
+		return 0, false
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	return parsed, err == nil
+}
+
+func isTreeDBDeltaStatKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	if strings.Contains(key, "_per_") || strings.HasSuffix(key, ".hit_ratio") || strings.HasSuffix(key, ".enabled") {
+		return false
+	}
+	if strings.HasSuffix(key, "_pct") || strings.HasSuffix(key, "_ms") ||
+		strings.Contains(key, ".avg_") {
+		return false
+	}
+	if strings.Contains(key, ".active_") || strings.Contains(key, "_active_") ||
+		strings.Contains(key, ".current_") || strings.Contains(key, "_current_") ||
+		strings.Contains(key, ".sealed_") || strings.Contains(key, "_sealed_") ||
+		strings.Contains(key, ".dead_bytes") || strings.Contains(key, "_dead_bytes") ||
+		strings.Contains(key, ".max_mapped_") || strings.Contains(key, ".cap_base") {
+		return false
+	}
+	return true
+}
+
 func writeTreeDBStats(out io.Writer, label string, stats map[string]string) {
 	if len(stats) == 0 {
 		return
@@ -2664,6 +2770,22 @@ func writeTreeDBStats(out io.Writer, label string, stats map[string]string) {
 	if wroteAny {
 		fmt.Fprintln(out)
 	}
+}
+
+func writeTreeDBStatDeltas(out io.Writer, label string, stats map[string]float64) {
+	if len(stats) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(stats))
+	for key := range stats {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	fmt.Fprintf(out, "%s", label)
+	for _, key := range keys {
+		fmt.Fprintf(out, " %s.delta=%.0f", key, stats[key])
+	}
+	fmt.Fprintln(out)
 }
 
 func writeMaintenanceResult(out io.Writer, step maintenanceResult) {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1132,6 +1132,87 @@ func TestMeasureLoadPhaseReportsProducerResults(t *testing.T) {
 	}
 }
 
+func TestSelectedTreeDBStatsIncludesIOHygieneCounters(t *testing.T) {
+	stats := map[string]string{
+		"treedb.commit_seq":                                    "7",
+		"treedb.cache.vlog_mmap.read.hits":                     "11",
+		"treedb.cache.vlog_mmap.read.fallback_readat":          "3",
+		"treedb.cache.vlog_mmap.read.hit_ratio":                "0.785714",
+		"treedb.cache.vlog_writev.syscalls":                    "5",
+		"treedb.cache.vlog_writev.bytes_per_syscall":           "4096.0",
+		"treedb.cache.vlog_io.bytes_per_syscall":               "2048.0",
+		"treedb.cache.vlog_decode_buffer_grow.foo.calls_total": "13",
+		"treedb.leaf_vlog_write.syscalls":                      "29",
+		"treedb.leaf_vlog_writev.bytes_per_syscall":            "8192.0",
+		"treedb.vlog.mmap_read.miss_no_mapping":                "17",
+		"treedb.process.memory.peak_vlog_mmap_active_bytes":    "19",
+		"treedb.publish.ordered_root_delta_group.calls":        "23",
+		"treedb.unrelated":                                     "ignored",
+	}
+	got := selectedTreeDBStats(stats)
+	for _, key := range []string{
+		"treedb.commit_seq",
+		"treedb.cache.vlog_mmap.read.hits",
+		"treedb.cache.vlog_mmap.read.fallback_readat",
+		"treedb.cache.vlog_mmap.read.hit_ratio",
+		"treedb.cache.vlog_writev.syscalls",
+		"treedb.cache.vlog_writev.bytes_per_syscall",
+		"treedb.cache.vlog_io.bytes_per_syscall",
+		"treedb.cache.vlog_decode_buffer_grow.foo.calls_total",
+		"treedb.leaf_vlog_write.syscalls",
+		"treedb.leaf_vlog_writev.bytes_per_syscall",
+		"treedb.vlog.mmap_read.miss_no_mapping",
+		"treedb.process.memory.peak_vlog_mmap_active_bytes",
+		"treedb.publish.ordered_root_delta_group.calls",
+	} {
+		if got[key] != stats[key] {
+			t.Fatalf("selectedTreeDBStats[%q]=%q want %q; got=%v", key, got[key], stats[key], got)
+		}
+	}
+	if _, ok := got["treedb.unrelated"]; ok {
+		t.Fatalf("selectedTreeDBStats included unrelated key: %v", got)
+	}
+}
+
+func TestTreeDBStatDeltasReportCounterDeltasOnly(t *testing.T) {
+	before := map[string]string{
+		"treedb.cache.vlog_mmap.read.hits":                       "10",
+		"treedb.cache.vlog_mmap.read.fallback_readat":            "2",
+		"treedb.cache.vlog_mmap.read.hit_ratio":                  "0.833333",
+		"treedb.cache.vlog_writev.bytes_per_syscall":             "4096.0",
+		"treedb.publish.watermark.lock_delay_share_pct":          "1.0",
+		"treedb.publish.ordered_root_delta_group.latency_max_ms": "5.0",
+		"treedb.process.memory.vlog_mmap_active_bytes":           "8192",
+	}
+	after := map[string]string{
+		"treedb.cache.vlog_mmap.read.hits":                       "18",
+		"treedb.cache.vlog_mmap.read.fallback_readat":            "5",
+		"treedb.cache.vlog_mmap.read.hit_ratio":                  "0.782609",
+		"treedb.cache.vlog_writev.bytes_per_syscall":             "6144.0",
+		"treedb.publish.watermark.lock_delay_share_pct":          "2.0",
+		"treedb.publish.ordered_root_delta_group.latency_max_ms": "7.0",
+		"treedb.process.memory.vlog_mmap_active_bytes":           "16384",
+	}
+	got := treeDBStatDeltas(before, after)
+	if got["treedb.cache.vlog_mmap.read.hits"] != 8 {
+		t.Fatalf("hits delta=%v want 8; got=%v", got["treedb.cache.vlog_mmap.read.hits"], got)
+	}
+	if got["treedb.cache.vlog_mmap.read.fallback_readat"] != 3 {
+		t.Fatalf("fallback delta=%v want 3; got=%v", got["treedb.cache.vlog_mmap.read.fallback_readat"], got)
+	}
+	for _, key := range []string{
+		"treedb.cache.vlog_mmap.read.hit_ratio",
+		"treedb.cache.vlog_writev.bytes_per_syscall",
+		"treedb.publish.watermark.lock_delay_share_pct",
+		"treedb.publish.ordered_root_delta_group.latency_max_ms",
+		"treedb.process.memory.vlog_mmap_active_bytes",
+	} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("treeDBStatDeltas included non-counter key %q: %v", key, got)
+		}
+	}
+}
+
 func TestMeasureLoadPhaseErrorReportsCompletedOperations(t *testing.T) {
 	sentinel := errors.New("load failed")
 	cfg := config{Documents: 6, BatchSize: 2, InsertProducers: 1}


### PR DESCRIPTION
## Summary

This PR turns the current TreeDB allocation/I/O hygiene investigation into repeatable instrumentation and a few low-risk hot-path cleanups before the larger indexed-write architecture work.

Changes:

- Add per-phase TreeDB storage counter deltas to `mongo_gateway_bench` JSON/text output, including mmap hit/fallback reasons, publish-root counters, write/writev syscall counters, and mmap residency gauges.
- Expose backend leaf-log `RawWriteStats`/`RawWritevStats` through DB stats so collection/Mongo runs can see leaf-vlog syscall shape, not just value-vlog stats.
- Decode template-v1 payloads into caller-owned buffers on more `ReadUnsafeTo`/fallback paths, with alias protection when encoded input overlaps `dst`.
- Cache compact leaf-log payload eligibility on streaming readers and File fallback reads instead of recomputing path/dir classification on hot fallback reads.
- Pool collection update-combiner scratch batches/items to reduce per-update batch slice churn.
- Document the new Mongo gateway TreeDB phase stats and add unit coverage for stat selection/delta guardrails and template decode-to-dst behavior.

## Validation

Tests run locally:

```sh
go test ./TreeDB/internal/valuelog ./TreeDB/collections ./cmd/mongo_gateway_bench -count 1
go test ./TreeDB/db ./TreeDB/caching ./TreeDB/internal/valuelog ./TreeDB/collections ./cmd/mongo_gateway_bench -count 1
go test ./... -count 1
```

Benchmarks/profiles refreshed from this branch:

```sh
go test ./TreeDB/internal/valuelog -run '^$' -bench 'BenchmarkValueLogTemplateReadAppend' -benchtime=200ms -count=3 -benchmem
go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' -benchtime=10000x -count=3 -benchmem
```

Template-v1 read result: `cache_64` now reports `0 B/op` and `0 allocs/op` in all three runs (`1692`, `1698`, `1731 ns/op`). `cache_off` remains `48 B/op`, `1 allocs/op`.

Direct BSON indexed update result: `27.5-28.1 us/op`, `35.6k-36.3k docs/sec`, `25.9 KB/op`, `105 allocs/op`.

Focused collection profile run:

```sh
OUT=/tmp/gomap_io_hygiene_collections_final_aRjX47
TREEDB_COLLECTION_BENCH_BATCH_SIZE=16000 \
TREEDB_COLLECTION_MIXED_SEED_DOCS=4096 \
TREEDB_COLLECTION_MIXED_WRITE_BATCH_SIZE=128 \
go test ./TreeDB/collections -run '^$' \
  -bench '^(BenchmarkCollectionShapeInsertBatch|BenchmarkCollectionMixedReadWritePrimary)$' \
  -benchtime=20000x -count=1 -benchmem \
  -cpuprofile "$OUT/collections_cpu.pprof" \
  -memprofile "$OUT/collections_allocs.pprof" \
  -blockprofile "$OUT/collections_block.pprof" \
  -mutexprofile "$OUT/collections_mutex.pprof"
```

Selected results: `BenchmarkCollectionShapeInsertBatch/indexes_2` = `1103 ns/op`, `1385 B/op`, `0 allocs/op`; `BenchmarkCollectionMixedReadWritePrimary` = `1587 ns/op`, `445,418 writer_docs/sec`, `6481 B/op`, `10 allocs/op`.

Raw TreeDB unified bench profile run:

```sh
OUT=/tmp/gomap_io_hygiene_unified_final_ZcXvu2
./bin/unified-bench -dbs treedb -profile fast -keys 100000 \
  -test batch_write,random_read_parallel -read-workers 4 \
  -profile-dir "$OUT" -path-label native-fastpath \
  -format markdown -progress=false
./bin/benchprof -profiles-dir "$OUT"
```

Selected results: `batch_write` = `18,162,417 ops/sec`; `random_read_parallel` = `11,596,500 ops/sec`; raw TreeDB selected mmap fallback counters were zero at end of run. Profile artifacts are in `/tmp/gomap_io_hygiene_unified_final_ZcXvu2`.

Mongo gateway phase-profile run:

```sh
OUT=/tmp/gomap_io_hygiene_mongo_final_HbJaED
go run ./cmd/mongo_gateway_bench \
  -target treedb -documents 5000 -batch-size 500 -insert-producers 4 \
  -reads 1000 -range-reads 100 -updates 1000 \
  -concurrent-readers 4 -concurrent-reads 2000 \
  -concurrent-writers 8 -concurrent-writes 2000 \
  -secondary-indexes 2 -update-indexed-field \
  -treedb-document-format bson -treedb-maintenance checkpoint \
  -profile-dir "$OUT/profiles" -profile-heap-gc -format json > "$OUT/result.json"
```

Selected phase deltas from the new stats:

| phase | ops/sec | mmap hits delta | ReadAt fallback delta | dead-cap miss delta |
| --- | ---: | ---: | ---: | ---: |
| load_insert_many | 228,308 | 40 | 0 | 0 |
| id_find_one | 15,546 | 1,000 | 0 | 0 |
| email_find_one | 17,784 | 2,022 | 0 | 0 |
| age_range_limit_10 | 5,545 | 273 | 0 | 0 |
| id_update_set | 2,447 | 2,398 | 67,083 | 66,184 |
| concurrent_id_find_one_r4 | 42,893 | 0 | 2,000 | 2,000 |
| concurrent_id_update_set_w8 | 3,550 | 0 | 127,237 | 125,193 |

For `concurrent_id_update_set_w8`, phase stats also show `treedb.publish.ordered_root_delta_group.calls_total.delta=1881`, `roots_total.delta=5643`, `treedb.leaf_vlog_write.bytes.delta=8099802`, `calls.delta=9789`, `syscalls.delta=9789`. Profile artifacts are in `/tmp/gomap_io_hygiene_mongo_final_HbJaED/profiles`.

Config sanity checks:

- `TREEDB_VLOG_MAX_DEAD_MAPPINGS=4096` removes ReadAt fallback in the update phases and improves update throughput, but retained stale mmap address space reached `~2.81 GB` after `id_update_set` and `~7.78 GB` after concurrent update in this small 5k-doc run. This is not safe as a default fix.
- `TREEDB_VLOG_ENABLE_CURRENT_LEAF_WRITABLE_MMAP=false` avoids dead mappings but keeps the workload on ReadAt and is slower than the high-cap mmap run.

## Interpretation / follow-up for #1132

The cleaned baseline suggests two tracks:

1. Hygiene fixed or made visible here: per-phase mmap/readat/write syscall stats, caller-buffer template decode, cached compact-leaf classification, and update-combiner scratch pooling.
2. Remaining bottleneck is architectural/current-leaf safety: update-heavy collection/Mongo workloads churn current writable leaf-log mappings until the dead-mapping cap is reached, then fall back to ReadAt. Simply raising the cap is fast but retains too much stale mmap address space. The right follow-up is an epoch/RCU-safe current-leaf remap strategy, a current-leaf record/frame cache, or a larger write-back design that avoids synchronously rereading freshly written leaf pages during multi-root publish.
