### PR TITLE
Map current leaf vlog ahead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BENCHPROF_DIR := cmd/benchprof
 COLLECTION_LOAD_FIXTURE_DIR := cmd/collection_load_fixture
 COLLECTION_BENCH_MATRIX_DIR := cmd/collection_bench_matrix
 COLLECTION_CANONICAL_BENCH_DIR := cmd/collection_canonical_bench
+TREEDB_OUT_OF_CORE_SMOKE_DIR := cmd/treedb_out_of_core_smoke
 BIN_DIR := bin
 
 BENCH_KEYCOUNTS ?= 1,10,100,1000,10000,100000,1000000
@@ -34,6 +35,7 @@ help:
 	@echo "  make collection-bench-matrix - build collection benchmark matrix runner"
 	@echo "  make collection-canonical-bench-bin - build canonical collection benchmark runner"
 	@echo "  make bench-collections-canonical - run canonical TreeDB collections vs SQLite benchmark"
+	@echo "  make bench-out-of-core-smoke - run CI-sized TreeDB out-of-core guardrail smoke"
 	@echo "  make clean          - remove ./$(BIN_DIR) and temp dirs"
 
 .PHONY: fmt
@@ -91,8 +93,8 @@ deps:
 docs-check:
 	bash ./scripts/docs_check.sh
 
-.PHONY: build build-hashdb build-treedb treemap treemap-bin unified-bench benchprof collection-load-fixture collection-bench-matrix collection-canonical-bench-bin collection-canonical-bench
-build: build-hashdb build-treedb unified-bench benchprof collection-load-fixture collection-bench-matrix collection-canonical-bench-bin
+.PHONY: build build-hashdb build-treedb treemap treemap-bin unified-bench benchprof collection-load-fixture collection-bench-matrix collection-canonical-bench-bin collection-canonical-bench treedb-out-of-core-smoke-bin treedb-out-of-core-smoke
+build: build-hashdb build-treedb unified-bench benchprof collection-load-fixture collection-bench-matrix collection-canonical-bench-bin treedb-out-of-core-smoke-bin
 
 build-hashdb:
 	mkdir -p $(BIN_DIR)
@@ -137,6 +139,12 @@ collection-canonical-bench-bin:
 
 collection-canonical-bench: collection-canonical-bench-bin
 
+treedb-out-of-core-smoke-bin:
+	mkdir -p $(BIN_DIR)
+	cd $(TREEDB_OUT_OF_CORE_SMOKE_DIR) && go build -o ../../$(BIN_DIR)/treedb-out-of-core-smoke .
+
+treedb-out-of-core-smoke: treedb-out-of-core-smoke-bin
+
 .PHONY: bench bench-readme
 bench: unified-bench
 	./$(BIN_DIR)/unified-bench
@@ -147,6 +155,10 @@ bench-readme: unified-bench
 .PHONY: bench-collections-canonical
 bench-collections-canonical:
 	./scripts/bench_collections_canonical.sh
+
+.PHONY: bench-out-of-core-smoke
+bench-out-of-core-smoke:
+	./scripts/bench_out_of_core_smoke.sh
 
 .PHONY: benchmark-all benchmark-quick
 benchmark-all: build-hashdb

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -25184,6 +25184,7 @@ func (db *DB) Stats() map[string]string {
 		stats["treedb.cache.vlog_mmap.remaps"] = fmt.Sprintf("%d", remaps)
 		stats["treedb.cache.vlog_mmap.dead_mappings"] = fmt.Sprintf("%d", deadMappings)
 		stats["treedb.cache.vlog_mmap.dead_mappings.cap_base"] = fmt.Sprintf("%d", valuelog.MaxDeadMappings)
+		stats["treedb.cache.vlog_mmap.current_writable_map_target_bytes"] = fmt.Sprintf("%d", valuelog.CurrentWritableMmapTargetBytes)
 		stats["treedb.cache.vlog_mmap.max_mapped_sealed_segments"] = fmt.Sprintf("%d", valuelog.MaxMappedSealedSegments)
 		stats["treedb.cache.vlog_mmap.max_mapped_sealed_bytes"] = fmt.Sprintf("%d", valuelog.MaxMappedSealedBytes)
 		zombieSegments, zombieBytes, zombiePinnedSegments, zombiePinnedBytes, zombieUnpinnedSegments, zombieUnpinnedBytes := db.valueLogReader.ZombieStats()

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -646,6 +646,7 @@ func (db *DB) Stats() map[string]string {
 		stats["treedb.vlog.mmap_remaps"] = fmt.Sprintf("%d", vlogRemaps)
 		stats["treedb.vlog.mmap_dead_mappings"] = fmt.Sprintf("%d", vlogDeadMappings)
 		stats["treedb.vlog.mmap_dead_mappings.cap_base"] = fmt.Sprintf("%d", valuelog.MaxDeadMappings)
+		stats["treedb.vlog.mmap_current_writable_map_target_bytes"] = fmt.Sprintf("%d", valuelog.CurrentWritableMmapTargetBytes)
 		stats["treedb.vlog.mmap_max_mapped_sealed_segments"] = fmt.Sprintf("%d", valuelog.MaxMappedSealedSegments)
 		stats["treedb.vlog.mmap_max_mapped_sealed_bytes"] = fmt.Sprintf("%d", valuelog.MaxMappedSealedBytes)
 		currentSegments, currentBytes, sealedSegments, sealedBytes, _, deadBytes := db.valueLogManager.MmapResidencyStats()

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -92,6 +92,15 @@ func withMaxDeadMappings(t *testing.T, max int) {
 	})
 }
 
+func withCurrentWritableMmapTargetBytes(t *testing.T, target int64) {
+	t.Helper()
+	prev := CurrentWritableMmapTargetBytes
+	CurrentWritableMmapTargetBytes = target
+	t.Cleanup(func() {
+		CurrentWritableMmapTargetBytes = prev
+	})
+}
+
 func TestManagerMmapReadStatsAggregatesCounters(t *testing.T) {
 	mgr := &Manager{
 		files: map[uint32]*File{
@@ -477,6 +486,7 @@ func TestManagerPromoteCurrentWritable_KeepsLeafCurrentMmapWhenSealedBudgetAllow
 	enableCurrentLeafWritableMmap = true
 	withMappedLeafSealedBudget(t, 1)
 	withMappedLeafSealedBytesBudget(t, 1<<20)
+	withCurrentWritableMmapTargetBytes(t, 64<<10)
 	t.Cleanup(func() {
 		waitForRemapIdle(t, files...)
 		enableCurrentWritableMmap = prevCurrent
@@ -569,6 +579,7 @@ func TestManagerPromoteCurrentWritable_ExcludesNextCurrentFromSealedBudget(t *te
 	enableCurrentLeafWritableMmap = true
 	withMappedLeafSealedBudget(t, 1)
 	withMappedLeafSealedBytesBudget(t, 1<<20)
+	withCurrentWritableMmapTargetBytes(t, 64<<10)
 	t.Cleanup(func() {
 		waitForRemapIdle(t, files...)
 		enableCurrentWritableMmap = prevCurrent
@@ -637,6 +648,7 @@ func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlready
 	enableCurrentLeafWritableMmap = true
 	withMappedLeafSealedBudget(t, 1)
 	withMappedLeafSealedBytesBudget(t, 1<<20)
+	withCurrentWritableMmapTargetBytes(t, 64<<10)
 	t.Cleanup(func() {
 		waitForRemapIdle(t, files...)
 		enableCurrentWritableMmap = prevCurrent
@@ -798,6 +810,7 @@ func TestManagerPromoteCurrentWritable_DeadMappingCapKeepsDemotedLeafMapped(t *t
 	withMappedLeafSealedBudget(t, 1)
 	withMappedLeafSealedBytesBudget(t, 1<<20)
 	withMaxDeadMappings(t, 1)
+	withCurrentWritableMmapTargetBytes(t, 64<<10)
 	t.Cleanup(func() {
 		waitForRemapIdle(t, files...)
 		enableCurrentWritableMmap = prevCurrent

--- a/TreeDB/internal/valuelog/mmap_safety_test.go
+++ b/TreeDB/internal/valuelog/mmap_safety_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/snissn/gomap/TreeDB/page"
 	templ "github.com/snissn/gomap/TreeDB/template"
 )
 
@@ -265,5 +266,64 @@ func TestCurrentWritableMmapTargetMapsAheadWithinLeafSegment(t *testing.T) {
 	}
 	if fallbacks := f.mmapReadFallbackReadAt.Load(); fallbacks != 0 {
 		t.Fatalf("mapped-ahead current leaf should avoid ReadAt fallback, got=%d", fallbacks)
+	}
+}
+
+func TestCurrentWritableMmapTargetDoesNotReadPastFileSize(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withCurrentWritableMmapTargetBytes(t, 64<<10)
+	defer func() {
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	}()
+
+	dir := t.TempDir()
+	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
+	path := filepath.Join(dir, "value-l255-000001.log")
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	ptr, err := w.Append(0, nil, 1, bytes.Repeat([]byte("a"), 1024))
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	f, err := openFile(path, fileID, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile: %v", err)
+	}
+	f.currentWritable.Store(true)
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.ReadUnsafe(ptr, false); err != nil {
+		t.Fatalf("ReadUnsafe valid ptr: %v", err)
+	}
+	data, _ := f.mmapData.Load().([]byte)
+	if gotLen := len(data); gotLen < 64<<10 {
+		t.Fatalf("mapped length=%d, want at least target", gotLen)
+	}
+
+	pastEOF := page.ValuePtr{
+		FileID: fileID,
+		Offset: uint64(len(data) / 2),
+		Length: 1024,
+	}
+	if _, err := f.ReadUnsafe(pastEOF, false); err == nil {
+		t.Fatalf("ReadUnsafe past EOF unexpectedly succeeded")
+	}
+	if fallbacks := f.mmapReadFallbackReadAt.Load(); fallbacks == 0 {
+		t.Fatalf("past-EOF mapped-ahead read should fall back instead of reading mmap bytes")
 	}
 }

--- a/TreeDB/internal/valuelog/mmap_safety_test.go
+++ b/TreeDB/internal/valuelog/mmap_safety_test.go
@@ -269,6 +269,28 @@ func TestCurrentWritableMmapTargetMapsAheadWithinLeafSegment(t *testing.T) {
 	}
 }
 
+func TestCurrentWritableMmapTargetSizeMapsAheadAtBoundary(t *testing.T) {
+	withCurrentWritableMmapTargetBytes(t, 64)
+
+	tests := []struct {
+		name        string
+		currentSize int64
+		want        int64
+	}{
+		{name: "small rounds to target", currentSize: 1, want: 64},
+		{name: "partial chunk rounds up", currentSize: 65, want: 128},
+		{name: "exact chunk maps one more chunk ahead", currentSize: 64, want: 128},
+		{name: "exact later chunk maps one more chunk ahead", currentSize: 128, want: 192},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := currentWritableMmapTargetSize(tt.currentSize); got != tt.want {
+				t.Fatalf("currentWritableMmapTargetSize(%d)=%d, want %d", tt.currentSize, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCurrentWritableMmapTargetDoesNotReadPastFileSize(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")

--- a/TreeDB/internal/valuelog/mmap_safety_test.go
+++ b/TreeDB/internal/valuelog/mmap_safety_test.go
@@ -320,6 +320,10 @@ func TestCurrentWritableMmapTargetDoesNotReadPastFileSize(t *testing.T) {
 		Offset: uint64(len(data) / 2),
 		Length: 1024,
 	}
+	// Simulate a stale/inflated file-size hint. Current-writable mappings may
+	// be larger than the actual file; even with a bad hint, reads must re-stat
+	// before slicing mapped-ahead bytes.
+	f.fileSize.Store(int64(len(data) + 1))
 	if _, err := f.ReadUnsafe(pastEOF, false); err == nil {
 		t.Fatalf("ReadUnsafe past EOF unexpectedly succeeded")
 	}

--- a/TreeDB/internal/valuelog/mmap_safety_test.go
+++ b/TreeDB/internal/valuelog/mmap_safety_test.go
@@ -189,3 +189,81 @@ func TestMmapSafety_Concurrent_Remap(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestCurrentWritableMmapTargetMapsAheadWithinLeafSegment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = true
+	withMaxDeadMappings(t, 1)
+	withCurrentWritableMmapTargetBytes(t, 64<<10)
+	defer func() {
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	}()
+
+	dir := t.TempDir()
+	fileID := mustEncodeFileID(t, ReservedLeafLogLaneID, 1)
+	path := filepath.Join(dir, "value-l255-000001.log")
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	first := bytes.Repeat([]byte("a"), 1024)
+	ptr, err := w.Append(0, nil, 1, first)
+	if err != nil {
+		t.Fatalf("Append first: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush first: %v", err)
+	}
+
+	f, err := openFile(path, fileID, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile: %v", err)
+	}
+	f.currentWritable.Store(true)
+	defer func() { _ = f.Close() }()
+
+	got, err := f.ReadUnsafe(ptr, false)
+	if err != nil {
+		t.Fatalf("ReadUnsafe first: %v", err)
+	}
+	if !bytes.Equal(got, first) {
+		t.Fatalf("first read mismatch")
+	}
+	data, _ := f.mmapData.Load().([]byte)
+	if gotLen := len(data); gotLen < 64<<10 {
+		t.Fatalf("mapped length=%d, want at least target", gotLen)
+	}
+
+	for i := 0; i < 20; i++ {
+		value := bytes.Repeat([]byte{byte('b' + i%20)}, 1024)
+		ptr, err := w.Append(0, nil, uint64(2+i), value)
+		if err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+		if err := w.Flush(); err != nil {
+			t.Fatalf("Flush %d: %v", i, err)
+		}
+		got, err := f.ReadUnsafe(ptr, false)
+		if err != nil {
+			t.Fatalf("ReadUnsafe %d: %v", i, err)
+		}
+		if !bytes.Equal(got, value) {
+			t.Fatalf("read %d mismatch", i)
+		}
+	}
+
+	if dead := f.deadMappingsCount.Load(); dead != 0 {
+		t.Fatalf("mapped-ahead current leaf should not churn dead mappings within target, got=%d", dead)
+	}
+	if fallbacks := f.mmapReadFallbackReadAt.Load(); fallbacks != 0 {
+		t.Fatalf("mapped-ahead current leaf should avoid ReadAt fallback, got=%d", fallbacks)
+	}
+}

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -49,6 +49,7 @@ const (
 	enableAdaptiveCapEnvKey         = "TREEDB_VLOG_ADAPTIVE_DEAD_MAPPINGS"
 	enableCurrentWritableEnvKey     = "TREEDB_VLOG_ENABLE_CURRENT_WRITABLE_MMAP"
 	enableCurrentLeafWritableEnvKey = "TREEDB_VLOG_ENABLE_CURRENT_LEAF_WRITABLE_MMAP"
+	currentWritableMapTargetEnvKey  = "TREEDB_VLOG_CURRENT_WRITABLE_MMAP_TARGET_BYTES"
 	maxMappedSealedEnvKey           = "TREEDB_VLOG_MAX_MAPPED_SEALED_SEGMENTS"
 	maxMappedSealedBytesEnvKey      = "TREEDB_VLOG_MAX_MAPPED_SEALED_BYTES"
 	maxMappedLeafSealedEnvKey       = "TREEDB_VLOG_MAX_MAPPED_LEAF_SEALED_SEGMENTS"
@@ -58,17 +59,19 @@ const (
 	defaultMaxMappedSealedBytes     = 64 << 20
 	defaultMaxMappedLeafSealed      = defaultMaxMappedSealed * 4
 	defaultMaxMappedLeafSealedBytes = defaultMaxMappedSealedBytes * 4
+	defaultCurrentWritableMapTarget = 32 << 20
 )
 
 var (
-	maxDeadMappingsExplicit       bool
-	adaptiveDeadMappings                = defaultAdaptiveCapEnabled
-	enableCurrentWritableMmap           = false
-	enableCurrentLeafWritableMmap       = true
-	MaxMappedSealedSegments             = defaultMaxMappedSealed
-	MaxMappedSealedBytes          int64 = defaultMaxMappedSealedBytes
-	MaxMappedLeafSealedSegments         = defaultMaxMappedLeafSealed
-	MaxMappedLeafSealedBytes      int64 = defaultMaxMappedLeafSealedBytes
+	maxDeadMappingsExplicit        bool
+	adaptiveDeadMappings                 = defaultAdaptiveCapEnabled
+	enableCurrentWritableMmap            = false
+	enableCurrentLeafWritableMmap        = true
+	CurrentWritableMmapTargetBytes       = int64(defaultCurrentWritableMapTarget)
+	MaxMappedSealedSegments              = defaultMaxMappedSealed
+	MaxMappedSealedBytes           int64 = defaultMaxMappedSealedBytes
+	MaxMappedLeafSealedSegments          = defaultMaxMappedLeafSealed
+	MaxMappedLeafSealedBytes       int64 = defaultMaxMappedLeafSealedBytes
 )
 
 func init() {
@@ -100,6 +103,11 @@ func init() {
 			enableCurrentLeafWritableMmap = false
 		case "1", "true", "on", "yes":
 			enableCurrentLeafWritableMmap = true
+		}
+	}
+	if raw := strings.TrimSpace(os.Getenv(currentWritableMapTargetEnvKey)); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v >= 0 {
+			CurrentWritableMmapTargetBytes = v
 		}
 	}
 	if raw := strings.TrimSpace(os.Getenv(maxMappedSealedEnvKey)); raw != "" {
@@ -300,6 +308,22 @@ func (f *File) sealedLazyMmapTargetSize() int64 {
 	return targetSize
 }
 
+func currentWritableMmapTargetSize(currentSize int64) int64 {
+	if currentSize <= 0 || CurrentWritableMmapTargetBytes <= 0 {
+		return currentSize
+	}
+	target := CurrentWritableMmapTargetBytes
+	const maxInt64 = int64(^uint64(0) >> 1)
+	if currentSize >= maxInt64-target {
+		return currentSize
+	}
+	rem := currentSize % target
+	if rem == 0 {
+		return currentSize
+	}
+	return currentSize + target - rem
+}
+
 func (f *File) retirePersistentMmapToDead() {
 	if f == nil {
 		return
@@ -420,7 +444,11 @@ func (f *File) remapToFileSizeWithPolicy(requirePersistent bool) {
 		return
 	}
 
-	if data != nil && int64(len(data)) >= currentSize {
+	mapSize := currentSize
+	if f.currentWritablePersistentMmapEnabled() {
+		mapSize = currentWritableMmapTargetSize(currentSize)
+	}
+	if data != nil && int64(len(data)) >= mapSize {
 		return
 	}
 	if data != nil {
@@ -429,7 +457,7 @@ func (f *File) remapToFileSizeWithPolicy(requirePersistent bool) {
 		f.deadMappedBytes.Add(uint64(len(data)))
 	}
 
-	b, err := mmapReadOnly(f.File, int(currentSize))
+	b, err := mmapReadOnly(f.File, int(mapSize))
 	if err != nil {
 		return
 	}

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -380,15 +380,6 @@ func (f *File) tryRefreshMmapRange(start, end int64) ([]byte, bool) {
 	if f == nil || start < 0 || end < start {
 		return nil, false
 	}
-	if cur, _ := f.mmapData.Load().([]byte); cur != nil {
-		curLen := int64(len(cur))
-		if known := f.fileSize.Load(); known > 0 && known <= curLen {
-			// Out-of-range on an existing mapping implies our cached file-size hint
-			// may be stale. Nudge it above the current mapping length so
-			// remapToFileSize does a real stat/refresh instead of returning early.
-			f.fileSize.Store(curLen + 1)
-		}
-	}
 	// Perform a synchronous refresh on out-of-range misses so stale mappings
 	// do not repeatedly fall back to ReadAt. This is especially important for
 	// safe read paths, which do not re-enter tryEnableSealedLazyMmap.
@@ -407,7 +398,7 @@ func (f *File) ensureMmapRangeReadable(data []byte, start, end int64) ([]byte, b
 	if data == nil || end > int64(len(data)) {
 		return f.tryRefreshMmapRange(start, end)
 	}
-	if known := f.fileSize.Load(); known >= end {
+	if known := f.fileSize.Load(); known >= end && known <= int64(len(data)) {
 		return data, true
 	}
 	info, err := f.File.Stat()

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -309,19 +309,23 @@ func (f *File) sealedLazyMmapTargetSize() int64 {
 }
 
 func currentWritableMmapTargetSize(currentSize int64) int64 {
-	if currentSize <= 0 || CurrentWritableMmapTargetBytes <= 0 {
+	target := CurrentWritableMmapTargetBytes
+	if currentSize <= 0 || target <= 0 {
 		return currentSize
 	}
-	target := CurrentWritableMmapTargetBytes
 	const maxInt64 = int64(^uint64(0) >> 1)
 	if currentSize >= maxInt64-target {
 		return currentSize
 	}
 	rem := currentSize % target
+	add := target - rem
 	if rem == 0 {
+		add = target
+	}
+	if add <= 0 || currentSize > maxInt64-add {
 		return currentSize
 	}
-	return currentSize + target - rem
+	return currentSize + add
 }
 
 func (f *File) retirePersistentMmapToDead() {

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -400,6 +400,30 @@ func (f *File) tryRefreshMmapRange(start, end int64) ([]byte, bool) {
 	return data, true
 }
 
+func (f *File) ensureMmapRangeReadable(data []byte, start, end int64) ([]byte, bool) {
+	if f == nil || start < 0 || end < start {
+		return nil, false
+	}
+	if data == nil || end > int64(len(data)) {
+		return f.tryRefreshMmapRange(start, end)
+	}
+	if known := f.fileSize.Load(); known >= end {
+		return data, true
+	}
+	info, err := f.File.Stat()
+	if err != nil {
+		return nil, false
+	}
+	currentSize := info.Size()
+	if currentSize > 0 {
+		f.fileSize.Store(currentSize)
+	}
+	if currentSize < end {
+		return nil, false
+	}
+	return data, true
+}
+
 func (f *File) remapToFileSizePersistentOnly() {
 	f.remapToFileSizeWithPolicy(true)
 }
@@ -448,6 +472,12 @@ func (f *File) remapToFileSizeWithPolicy(requirePersistent bool) {
 	if f.currentWritablePersistentMmapEnabled() {
 		mapSize = currentWritableMmapTargetSize(currentSize)
 	}
+	if mapSize <= 0 || mapSize > int64(int(mapSize)) {
+		return
+	}
+	if runtime.GOARCH == "386" && mapSize > int64(^uint32(0)) {
+		return
+	}
 	if data != nil && int64(len(data)) >= mapSize {
 		return
 	}
@@ -490,13 +520,11 @@ func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error
 		return nil, ErrCorrupt, true
 	}
 	start := int64(ptr.Offset - 4)
-	if start < 0 || start+HeaderSize > int64(len(data)) {
+	if refreshed, ok := f.ensureMmapRangeReadable(data, start, start+HeaderSize); ok {
+		data = refreshed
+	} else {
 		f.mmapReadMissOutOfRange.Add(1)
-		if refreshed, ok := f.tryRefreshMmapRange(start, start+HeaderSize); ok {
-			data = refreshed
-		} else {
-			return nil, nil, false
-		}
+		return nil, nil, false
 	}
 
 	header := data[start : start+HeaderSize]
@@ -516,14 +544,12 @@ func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error
 	}
 
 	end := start + HeaderSize + int64(valueLen)
-	if end > int64(len(data)) {
+	if refreshed, ok := f.ensureMmapRangeReadable(data, start, end); ok {
+		data = refreshed
+		header = data[start : start+HeaderSize]
+	} else {
 		f.mmapReadMissOutOfRange.Add(1)
-		if refreshed, ok := f.tryRefreshMmapRange(start, end); ok {
-			data = refreshed
-			header = data[start : start+HeaderSize]
-		} else {
-			return nil, nil, false
-		}
+		return nil, nil, false
 	}
 
 	payload := data[start+HeaderSize : end]
@@ -800,13 +826,11 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		return nil, false, ErrCorrupt, true
 	}
 	start := int64(ptr.Offset - 4)
-	if start < 0 || start+HeaderSize > int64(len(data)) {
+	if refreshed, ok := f.ensureMmapRangeReadable(data, start, start+HeaderSize); ok {
+		data = refreshed
+	} else {
 		f.mmapReadMissOutOfRange.Add(1)
-		if refreshed, ok := f.tryRefreshMmapRange(start, start+HeaderSize); ok {
-			data = refreshed
-		} else {
-			return nil, false, nil, false
-		}
+		return nil, false, nil, false
 	}
 
 	header := data[start : start+HeaderSize]
@@ -826,14 +850,12 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 
 	end := start + HeaderSize + int64(valueLen)
-	if end > int64(len(data)) {
+	if refreshed, ok := f.ensureMmapRangeReadable(data, start, end); ok {
+		data = refreshed
+		header = data[start : start+HeaderSize]
+	} else {
 		f.mmapReadMissOutOfRange.Add(1)
-		if refreshed, ok := f.tryRefreshMmapRange(start, end); ok {
-			data = refreshed
-			header = data[start : start+HeaderSize]
-		} else {
-			return nil, false, nil, false
-		}
+		return nil, false, nil, false
 	}
 
 	payload := data[start+HeaderSize : end]
@@ -996,13 +1018,11 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		return nil, ErrCorrupt, true
 	}
 	start := int64(ptr.Offset - 4)
-	if start < 0 || start+HeaderSize > int64(len(data)) {
+	if refreshed, ok := f.ensureMmapRangeReadable(data, start, start+HeaderSize); ok {
+		data = refreshed
+	} else {
 		f.mmapReadMissOutOfRange.Add(1)
-		if refreshed, ok := f.tryRefreshMmapRange(start, start+HeaderSize); ok {
-			data = refreshed
-		} else {
-			return nil, nil, false
-		}
+		return nil, nil, false
 	}
 
 	header := data[start : start+HeaderSize]
@@ -1022,14 +1042,12 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 
 	end := start + HeaderSize + int64(valueLen)
-	if end > int64(len(data)) {
+	if refreshed, ok := f.ensureMmapRangeReadable(data, start, end); ok {
+		data = refreshed
+		header = data[start : start+HeaderSize]
+	} else {
 		f.mmapReadMissOutOfRange.Add(1)
-		if refreshed, ok := f.tryRefreshMmapRange(start, end); ok {
-			data = refreshed
-			header = data[start : start+HeaderSize]
-		} else {
-			return nil, nil, false
-		}
+		return nil, nil, false
 	}
 
 	payload := data[start+HeaderSize : end]

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -263,6 +263,7 @@ type loadSummary struct {
 	LeafGeneration                *leafGenerationSummary `json:"leaf_generation,omitempty"`
 	IndexVacuum                   indexVacuumSummary     `json:"index_vacuum,omitempty"`
 	IndexStorageFinal             indexStorageSummary    `json:"index_storage_final"`
+	TreeDBStatsFinal              map[string]string      `json:"treedb_stats_final,omitempty"`
 	Verify                        verifySummary          `json:"verify"`
 	CPUProfile                    string                 `json:"cpu_profile,omitempty"`
 	MemProfile                    string                 `json:"mem_profile,omitempty"`
@@ -587,6 +588,7 @@ func runFixture(cfg config) (loadSummary, error) {
 	if err != nil {
 		return loadSummary{}, err
 	}
+	finalStats := selectedTreeDBStats(backend.Stats())
 	wallElapsed := time.Since(wallStart)
 
 	if !closed {
@@ -661,6 +663,7 @@ func runFixture(cfg config) (loadSummary, error) {
 		LeafGeneration:                leafGeneration,
 		IndexVacuum:                   indexVacuum,
 		IndexStorageFinal:             finalIndexStorage,
+		TreeDBStatsFinal:              finalStats,
 		Verify:                        verify,
 		CPUProfile:                    cfg.CPUProfile,
 		MemProfile:                    cfg.MemProfile,
@@ -668,6 +671,47 @@ func runFixture(cfg config) (loadSummary, error) {
 		GOOS:                          runtime.GOOS,
 		GOARCH:                        runtime.GOARCH,
 	}, nil
+}
+
+func selectedTreeDBStats(stats map[string]string) map[string]string {
+	if len(stats) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	for key, value := range stats {
+		if isSelectedTreeDBStatKey(key) {
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func isSelectedTreeDBStatKey(key string) bool {
+	switch {
+	case key == "treedb.commit_seq":
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_mmap."):
+		return true
+	case strings.HasPrefix(key, "treedb.vlog.mmap"):
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_zombie."):
+		return true
+	case strings.HasPrefix(key, "treedb.process.memory.vlog_zombie"):
+		return true
+	case strings.HasPrefix(key, "treedb.vlog.outer_leaf_block_cache."):
+		return true
+	case strings.HasPrefix(key, "treedb.process.read_path.outer_leaf."):
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_generation."):
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_retained_prune."):
+		return true
+	default:
+		return false
+	}
 }
 
 func prepareFixtureDir(cfg config) (string, bool, error) {

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -22,6 +22,7 @@ import (
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/cmd/internal/treedbstats"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
@@ -588,7 +589,7 @@ func runFixture(cfg config) (loadSummary, error) {
 	if err != nil {
 		return loadSummary{}, err
 	}
-	finalStats := selectedTreeDBStats(backend.Stats())
+	finalStats := treedbstats.Selected(backend.Stats())
 	wallElapsed := time.Since(wallStart)
 
 	if !closed {
@@ -671,47 +672,6 @@ func runFixture(cfg config) (loadSummary, error) {
 		GOOS:                          runtime.GOOS,
 		GOARCH:                        runtime.GOARCH,
 	}, nil
-}
-
-func selectedTreeDBStats(stats map[string]string) map[string]string {
-	if len(stats) == 0 {
-		return nil
-	}
-	out := make(map[string]string)
-	for key, value := range stats {
-		if isSelectedTreeDBStatKey(key) {
-			out[key] = value
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func isSelectedTreeDBStatKey(key string) bool {
-	switch {
-	case key == "treedb.commit_seq":
-		return true
-	case strings.HasPrefix(key, "treedb.cache.vlog_mmap."):
-		return true
-	case strings.HasPrefix(key, "treedb.vlog.mmap"):
-		return true
-	case strings.HasPrefix(key, "treedb.cache.vlog_zombie."):
-		return true
-	case strings.HasPrefix(key, "treedb.process.memory.vlog_zombie"):
-		return true
-	case strings.HasPrefix(key, "treedb.vlog.outer_leaf_block_cache."):
-		return true
-	case strings.HasPrefix(key, "treedb.process.read_path.outer_leaf."):
-		return true
-	case strings.HasPrefix(key, "treedb.cache.vlog_generation."):
-		return true
-	case strings.HasPrefix(key, "treedb.cache.vlog_retained_prune."):
-		return true
-	default:
-		return false
-	}
 }
 
 func prepareFixtureDir(cfg config) (string, bool, error) {

--- a/cmd/internal/treedbstats/selected.go
+++ b/cmd/internal/treedbstats/selected.go
@@ -41,6 +41,10 @@ func IsSelectedKey(key string) bool {
 		return true
 	case strings.HasPrefix(key, "treedb.cache.vlog_retained_prune."):
 		return true
+	case strings.HasPrefix(key, "treedb.publish.ordered_root_delta_group."):
+		return true
+	case strings.HasPrefix(key, "treedb.publish.watermark."):
+		return true
 	default:
 		return false
 	}

--- a/cmd/internal/treedbstats/selected.go
+++ b/cmd/internal/treedbstats/selected.go
@@ -1,0 +1,47 @@
+package treedbstats
+
+import "strings"
+
+// Selected returns the TreeDB stats that benchmark/reporting tools preserve in
+// JSON artifacts. Keeping the allowlist in one place avoids drift between
+// fixture producers and report consumers.
+func Selected(stats map[string]string) map[string]string {
+	if len(stats) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	for key, value := range stats {
+		if IsSelectedKey(key) {
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func IsSelectedKey(key string) bool {
+	switch {
+	case key == "treedb.commit_seq":
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_mmap."):
+		return true
+	case strings.HasPrefix(key, "treedb.vlog.mmap"):
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_zombie."):
+		return true
+	case strings.HasPrefix(key, "treedb.process.memory.vlog_zombie"):
+		return true
+	case strings.HasPrefix(key, "treedb.vlog.outer_leaf_block_cache."):
+		return true
+	case strings.HasPrefix(key, "treedb.process.read_path.outer_leaf."):
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_generation."):
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_retained_prune."):
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/internal/treedbstats/selected.go
+++ b/cmd/internal/treedbstats/selected.go
@@ -11,7 +11,7 @@ func Selected(stats map[string]string) map[string]string {
 	}
 	out := make(map[string]string)
 	for key, value := range stats {
-		if IsSelectedKey(key) {
+		if isSelectedKey(key) {
 			out[key] = value
 		}
 	}
@@ -21,7 +21,7 @@ func Selected(stats map[string]string) map[string]string {
 	return out
 }
 
-func IsSelectedKey(key string) bool {
+func isSelectedKey(key string) bool {
 	switch {
 	case key == "treedb.commit_seq":
 		return true

--- a/cmd/internal/treedbstats/selected_test.go
+++ b/cmd/internal/treedbstats/selected_test.go
@@ -1,0 +1,25 @@
+package treedbstats
+
+import "testing"
+
+func TestSelectedKeepsSharedTreeDBStats(t *testing.T) {
+	stats := map[string]string{
+		"treedb.commit_seq": "7",
+		"treedb.process.read_path.outer_leaf.cache.hits":         "11",
+		"treedb.vlog.mmap_read.fallback_readat":                  "13",
+		"treedb.unrelated_stat_that_should_not_leave_the_helper": "17",
+	}
+	got := Selected(stats)
+	for _, key := range []string{
+		"treedb.commit_seq",
+		"treedb.process.read_path.outer_leaf.cache.hits",
+		"treedb.vlog.mmap_read.fallback_readat",
+	} {
+		if got[key] == "" {
+			t.Fatalf("Selected missing %s from %#v", key, got)
+		}
+	}
+	if _, ok := got["treedb.unrelated_stat_that_should_not_leave_the_helper"]; ok {
+		t.Fatalf("Selected kept unrelated stat: %#v", got)
+	}
+}

--- a/cmd/internal/treedbstats/selected_test.go
+++ b/cmd/internal/treedbstats/selected_test.go
@@ -7,6 +7,8 @@ func TestSelectedKeepsSharedTreeDBStats(t *testing.T) {
 		"treedb.commit_seq": "7",
 		"treedb.process.read_path.outer_leaf.cache.hits":         "11",
 		"treedb.vlog.mmap_read.fallback_readat":                  "13",
+		"treedb.publish.ordered_root_delta_group.calls_total":    "19",
+		"treedb.publish.watermark.latency_p99_ms":                "23",
 		"treedb.unrelated_stat_that_should_not_leave_the_helper": "17",
 	}
 	got := Selected(stats)
@@ -14,6 +16,8 @@ func TestSelectedKeepsSharedTreeDBStats(t *testing.T) {
 		"treedb.commit_seq",
 		"treedb.process.read_path.outer_leaf.cache.hits",
 		"treedb.vlog.mmap_read.fallback_readat",
+		"treedb.publish.ordered_root_delta_group.calls_total",
+		"treedb.publish.watermark.latency_p99_ms",
 	} {
 		if got[key] == "" {
 			t.Fatalf("Selected missing %s from %#v", key, got)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -2612,6 +2612,14 @@ func newSelectedTreeDBExactStatKeySet(keys []string) map[string]struct{} {
 var selectedTreeDBStatPrefixes = [...]string{
 	"treedb.publish.ordered_root_delta_group.",
 	"treedb.publish.watermark.",
+	"treedb.cache.vlog_mmap.",
+	"treedb.vlog.mmap",
+	"treedb.cache.vlog_zombie.",
+	"treedb.process.memory.vlog_zombie",
+	"treedb.vlog.outer_leaf_block_cache.",
+	"treedb.process.read_path.outer_leaf.",
+	"treedb.cache.vlog_generation.",
+	"treedb.cache.vlog_retained_prune.",
 }
 
 func isSelectedTreeDBStatKey(key string) bool {

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -28,6 +28,7 @@ import (
 	mongogateway "github.com/snissn/gomap/TreeDB/mongo_gateway"
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/fastclient"
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
+	"github.com/snissn/gomap/cmd/internal/treedbstats"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/event"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -2599,47 +2600,8 @@ var selectedTreeDBExactStatKeys = [...]string{
 	"treedb.commit_seq",
 }
 
-var selectedTreeDBExactStatKeySet = newSelectedTreeDBExactStatKeySet(selectedTreeDBExactStatKeys[:])
-
-func newSelectedTreeDBExactStatKeySet(keys []string) map[string]struct{} {
-	keySet := make(map[string]struct{}, len(keys))
-	for _, key := range keys {
-		keySet[key] = struct{}{}
-	}
-	return keySet
-}
-
-var selectedTreeDBStatPrefixes = [...]string{
-	"treedb.publish.ordered_root_delta_group.",
-	"treedb.publish.watermark.",
-}
-
-func isSelectedTreeDBStatKey(key string) bool {
-	if _, ok := selectedTreeDBExactStatKeySet[key]; ok {
-		return true
-	}
-	for _, prefix := range selectedTreeDBStatPrefixes {
-		if strings.HasPrefix(key, prefix) {
-			return true
-		}
-	}
-	return false
-}
-
 func selectedTreeDBStats(stats map[string]string) map[string]string {
-	if len(stats) == 0 {
-		return nil
-	}
-	out := make(map[string]string)
-	for key, value := range stats {
-		if isSelectedTreeDBStatKey(key) {
-			out[key] = value
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
+	return treedbstats.Selected(stats)
 }
 
 func writeTreeDBStats(out io.Writer, label string, stats map[string]string) {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -118,7 +118,7 @@ func TestCollectDiskSnapshotEmptyLeavesPathsNil(t *testing.T) {
 	}
 }
 
-func TestIsSelectedTreeDBStatKey(t *testing.T) {
+func TestSelectedTreeDBStatsKeepsExpectedKeys(t *testing.T) {
 	tests := []struct {
 		name string
 		key  string
@@ -131,8 +131,9 @@ func TestIsSelectedTreeDBStatKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isSelectedTreeDBStatKey(tt.key); got != tt.want {
-				t.Fatalf("isSelectedTreeDBStatKey(%q)=%v want %v", tt.key, got, tt.want)
+			got := selectedTreeDBStats(map[string]string{tt.key: "1"})
+			if kept := got != nil && got[tt.key] == "1"; kept != tt.want {
+				t.Fatalf("selectedTreeDBStats kept %q=%v want %v (stats=%v)", tt.key, kept, tt.want, got)
 			}
 		})
 	}

--- a/cmd/treedb_out_of_core_smoke/main.go
+++ b/cmd/treedb_out_of_core_smoke/main.go
@@ -1,0 +1,1512 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+const schemaVersion = "treedb-out-of-core-smoke/v1"
+const envCommandLine = "TREEDB_OUT_OF_CORE_SMOKE_COMMAND"
+const runDirSentinel = ".treedb_out_of_core_smoke_run"
+
+type config struct {
+	RepoRoot               string
+	OutDir                 string
+	RawKeys                int
+	CollectionDocs         int
+	BatchSize              int
+	ValueSize              int
+	ReadWorkers            int
+	FormatsCSV             string
+	IndexesCSV             string
+	Profile                string
+	LeafSegmentTargetBytes int64
+	CacheBudgetBytes       int64
+	RetiredMmapBudgetBytes int64
+	MaxDeadMappings        int
+	IncludeMongo           bool
+	SkipRaw                bool
+	SkipCollections        bool
+	FailOnWarnings         bool
+	AllowExistingRunDir    bool
+	internalRawWorker      bool
+	rawDir                 string
+	rawJSONPath            string
+	formats                []string
+	indexes                []int
+}
+
+type smokeRun struct {
+	SchemaVersion string             `json:"schema_version"`
+	GeneratedAt   string             `json:"generated_at"`
+	RunDir        string             `json:"run_dir"`
+	Worktree      string             `json:"worktree"`
+	Branch        string             `json:"branch"`
+	Commit        string             `json:"commit"`
+	CommandLine   []string           `json:"command_line"`
+	Config        smokeConfig        `json:"config"`
+	Artifacts     map[string]string  `json:"artifacts"`
+	Commands      []commandRecord    `json:"commands"`
+	Results       []resultRow        `json:"results"`
+	Deferred      []deferredWorkload `json:"deferred_workloads,omitempty"`
+	Checks        []guardrailCheck   `json:"guardrail_checks"`
+}
+
+type smokeConfig struct {
+	RawKeys                int      `json:"raw_keys"`
+	CollectionDocs         int      `json:"collection_docs"`
+	BatchSize              int      `json:"batch_size"`
+	ValueSize              int      `json:"value_size"`
+	ReadWorkers            int      `json:"read_workers"`
+	Formats                []string `json:"formats"`
+	Indexes                []int    `json:"indexes"`
+	Profile                string   `json:"profile"`
+	LeafSegmentTargetBytes int64    `json:"leaf_segment_target_bytes"`
+	Budgets                budgets  `json:"budgets"`
+	IncludeMongo           bool     `json:"include_mongo"`
+}
+
+type budgets struct {
+	CacheBudgetBytes       int64 `json:"cache_budget_bytes"`
+	RetiredMmapBudgetBytes int64 `json:"retired_mmap_budget_bytes"`
+	MaxDeadMappings        int   `json:"max_dead_mappings"`
+}
+
+type commandRecord struct {
+	Name     string            `json:"name"`
+	Command  []string          `json:"command"`
+	Env      map[string]string `json:"env,omitempty"`
+	WorkDir  string            `json:"work_dir"`
+	LogPath  string            `json:"log_path,omitempty"`
+	ExitCode int               `json:"exit_code"`
+	Duration string            `json:"duration"`
+}
+
+type resultRow struct {
+	GeneratedAt      string            `json:"generated_at,omitempty"`
+	RunDir           string            `json:"run_dir,omitempty"`
+	CommandLine      []string          `json:"command_line,omitempty"`
+	ConfigName       string            `json:"config_name"`
+	WorkloadName     string            `json:"workload_name"`
+	Engine           string            `json:"engine"`
+	Shape            string            `json:"shape"`
+	Format           string            `json:"format,omitempty"`
+	IndexCount       int               `json:"index_count,omitempty"`
+	DocumentCount    int               `json:"document_count,omitempty"`
+	KeyCount         int               `json:"key_count,omitempty"`
+	ItemCount        int               `json:"item_count"`
+	BatchSize        int               `json:"batch_size,omitempty"`
+	Phase            string            `json:"phase"`
+	MeasurementKind  string            `json:"measurement_kind"`
+	BenchmarkTimed   bool              `json:"benchmark_timed"`
+	OpsPerSec        *float64          `json:"ops_per_sec,omitempty"`
+	DocsPerSec       *float64          `json:"docs_per_sec,omitempty"`
+	NsPerItem        *float64          `json:"ns_per_item,omitempty"`
+	TotalBytes       *uint64           `json:"total_bytes,omitempty"`
+	BytesPerItem     *float64          `json:"bytes_per_item,omitempty"`
+	ComponentBytes   map[string]uint64 `json:"component_bytes,omitempty"`
+	Budgets          budgets           `json:"budgets"`
+	PressureClaimed  bool              `json:"pressure_claimed"`
+	Mmap             *mmapStats        `json:"mmap,omitempty"`
+	Cache            *cacheStats       `json:"cache,omitempty"`
+	StatsAvailable   []string          `json:"stats_available,omitempty"`
+	SourceArtifact   string            `json:"source_artifact,omitempty"`
+	MeasurementNotes string            `json:"measurement_notes,omitempty"`
+}
+
+type mmapStats struct {
+	Remaps             uint64   `json:"remaps,omitempty"`
+	DeadMappings       uint64   `json:"dead_mappings,omitempty"`
+	DeadMappingCap     uint64   `json:"dead_mapping_cap,omitempty"`
+	ActiveSegments     uint64   `json:"active_segments,omitempty"`
+	ActiveBytes        uint64   `json:"active_bytes,omitempty"`
+	CurrentSegments    uint64   `json:"current_segments,omitempty"`
+	CurrentBytes       uint64   `json:"current_bytes,omitempty"`
+	SealedSegments     uint64   `json:"sealed_segments,omitempty"`
+	SealedBytes        uint64   `json:"sealed_bytes,omitempty"`
+	DeadBytes          uint64   `json:"dead_bytes,omitempty"`
+	Hits               uint64   `json:"hits,omitempty"`
+	MissOutOfRange     uint64   `json:"miss_out_of_range,omitempty"`
+	MissNoMapping      uint64   `json:"miss_no_mapping,omitempty"`
+	MissDeadMappingCap uint64   `json:"miss_dead_mapping_cap,omitempty"`
+	FallbackReadAt     uint64   `json:"fallback_readat,omitempty"`
+	HitRatio           *float64 `json:"hit_ratio,omitempty"`
+}
+
+type cacheStats struct {
+	OuterLeafBlockHits     *uint64  `json:"outer_leaf_block_hits,omitempty"`
+	OuterLeafBlockMisses   *uint64  `json:"outer_leaf_block_misses,omitempty"`
+	OuterLeafBlockHitRatio *float64 `json:"outer_leaf_block_hit_ratio,omitempty"`
+	OuterLeafBlockEntries  *uint64  `json:"outer_leaf_block_entries,omitempty"`
+	OuterLeafBlockCapacity *uint64  `json:"outer_leaf_block_capacity,omitempty"`
+}
+
+type guardrailCheck struct {
+	Severity string `json:"severity"`
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+	Subject  string `json:"subject,omitempty"`
+}
+
+type deferredWorkload struct {
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
+	Issue  string `json:"issue,omitempty"`
+}
+
+type rawWorkerSummary struct {
+	GeneratedAt       string            `json:"generated_at"`
+	Dir               string            `json:"dir"`
+	Keys              int               `json:"keys"`
+	BatchSize         int               `json:"batch_size"`
+	ValueSize         int               `json:"value_size"`
+	Profile           string            `json:"profile"`
+	LeafSegmentTarget int64             `json:"leaf_segment_target_bytes"`
+	Timings           map[string]timing `json:"timings"`
+	DiskUsageFinal    diskUsage         `json:"disk_usage_final"`
+	TreeDBStatsFinal  map[string]string `json:"treedb_stats_final,omitempty"`
+}
+
+type fixtureSummary struct {
+	GeneratedAt                string            `json:"generated_at"`
+	Dir                        string            `json:"dir"`
+	Collection                 string            `json:"collection"`
+	DocumentFormat             string            `json:"document_format"`
+	Profile                    string            `json:"profile"`
+	Docs                       int               `json:"docs"`
+	BatchSize                  int               `json:"batch_size"`
+	IndexCount                 int               `json:"index_count"`
+	LeafSegmentTargetBytes     int64             `json:"leaf_segment_target_bytes,omitempty"`
+	InsertTiming               timing            `json:"insert_timing"`
+	DiskUsageFinal             diskUsage         `json:"disk_usage_final"`
+	TreeDBStatsFinal           map[string]string `json:"treedb_stats_final,omitempty"`
+	DataOuterLeavesInValueLog  bool              `json:"data_outer_leaves_in_value_log"`
+	IndexOuterLeavesInValueLog bool              `json:"index_outer_leaves_in_value_log"`
+}
+
+type timing struct {
+	Seconds   float64 `json:"seconds"`
+	SecPerOp  float64 `json:"sec_per_op,omitempty"`
+	OpsPerSec float64 `json:"ops_per_sec,omitempty"`
+}
+
+type diskUsage struct {
+	TotalBytes  uint64        `json:"total_bytes"`
+	BytesPerDoc float64       `json:"bytes_per_doc,omitempty"`
+	FileCount   int           `json:"file_count"`
+	TopFiles    []fileSummary `json:"top_files,omitempty"`
+}
+
+type fileSummary struct {
+	Path  string `json:"path"`
+	Bytes uint64 `json:"bytes"`
+}
+
+func main() {
+	cfg, err := parseConfig(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "treedb-out-of-core-smoke: %v\n", err)
+		os.Exit(2)
+	}
+	if cfg.internalRawWorker {
+		if err := runRawWorker(cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "raw worker: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if err := run(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "treedb-out-of-core-smoke: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func parseConfig(args []string) (config, error) {
+	cfg := config{
+		RawKeys:                5000,
+		CollectionDocs:         1500,
+		BatchSize:              500,
+		ValueSize:              256,
+		ReadWorkers:            2,
+		FormatsCSV:             "template-v1,bson,json",
+		IndexesCSV:             "0,1,2",
+		Profile:                "fast",
+		LeafSegmentTargetBytes: 32 << 10,
+		CacheBudgetBytes:       32 << 10,
+		RetiredMmapBudgetBytes: 32 << 10,
+		MaxDeadMappings:        2,
+	}
+	fs := flag.NewFlagSet("treedb-out-of-core-smoke", flag.ContinueOnError)
+	fs.StringVar(&cfg.OutDir, "out-dir", "", "output run directory; empty creates a timestamped /tmp directory")
+	fs.IntVar(&cfg.RawKeys, "raw-keys", cfg.RawKeys, "raw TreeDB key count")
+	fs.IntVar(&cfg.CollectionDocs, "collection-docs", cfg.CollectionDocs, "collection document count per shape")
+	fs.IntVar(&cfg.BatchSize, "batch-size", cfg.BatchSize, "batch/write size")
+	fs.IntVar(&cfg.ValueSize, "value-size", cfg.ValueSize, "raw TreeDB value size in bytes")
+	fs.IntVar(&cfg.ReadWorkers, "read-workers", cfg.ReadWorkers, "raw TreeDB parallel read workers")
+	fs.StringVar(&cfg.FormatsCSV, "formats", cfg.FormatsCSV, "collection formats CSV: template-v1,bson,json")
+	fs.StringVar(&cfg.IndexesCSV, "indexes", cfg.IndexesCSV, "collection index counts CSV")
+	fs.StringVar(&cfg.Profile, "profile", cfg.Profile, "TreeDB profile")
+	fs.Int64Var(&cfg.LeafSegmentTargetBytes, "leaf-segment-target-bytes", cfg.LeafSegmentTargetBytes, "small leaf_vlog segment target used to force churn")
+	fs.Int64Var(&cfg.CacheBudgetBytes, "cache-budget-bytes", cfg.CacheBudgetBytes, "reported current-leaf/page cache budget for pressure validation")
+	fs.Int64Var(&cfg.RetiredMmapBudgetBytes, "retired-mmap-budget-bytes", cfg.RetiredMmapBudgetBytes, "reported retired mmap budget for pressure validation")
+	fs.IntVar(&cfg.MaxDeadMappings, "max-dead-mappings", cfg.MaxDeadMappings, "TREEDB_VLOG_MAX_DEAD_MAPPINGS for child workloads")
+	fs.BoolVar(&cfg.IncludeMongo, "include-mongo", false, "include a tiny Mongo gateway smoke workload; normally deferred to #1141")
+	fs.BoolVar(&cfg.SkipRaw, "skip-raw", false, "skip raw TreeDB focused helper")
+	fs.BoolVar(&cfg.SkipCollections, "skip-collections", false, "skip collection fixture matrix")
+	fs.BoolVar(&cfg.FailOnWarnings, "fail-on-warnings", false, "return non-zero when guardrail warnings are present")
+	fs.BoolVar(&cfg.AllowExistingRunDir, "allow-existing-run-dir", false, "allow writing into an existing smoke run directory")
+	fs.BoolVar(&cfg.internalRawWorker, "internal-raw-worker", false, "internal raw TreeDB worker mode")
+	fs.StringVar(&cfg.rawDir, "raw-dir", "", "internal raw worker DB directory")
+	fs.StringVar(&cfg.rawJSONPath, "raw-json", "", "internal raw worker JSON output path")
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		return cfg, err
+	}
+	if fs.NArg() != 0 {
+		return cfg, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if cfg.RawKeys <= 0 {
+		return cfg, errors.New("-raw-keys must be > 0")
+	}
+	if cfg.CollectionDocs <= 0 {
+		return cfg, errors.New("-collection-docs must be > 0")
+	}
+	if cfg.BatchSize <= 0 {
+		return cfg, errors.New("-batch-size must be > 0")
+	}
+	if cfg.ValueSize <= 0 {
+		return cfg, errors.New("-value-size must be > 0")
+	}
+	if cfg.ReadWorkers <= 0 {
+		return cfg, errors.New("-read-workers must be > 0")
+	}
+	if cfg.LeafSegmentTargetBytes <= 0 {
+		return cfg, errors.New("-leaf-segment-target-bytes must be > 0")
+	}
+	if cfg.CacheBudgetBytes <= 0 {
+		return cfg, errors.New("-cache-budget-bytes must be > 0")
+	}
+	if cfg.RetiredMmapBudgetBytes <= 0 {
+		return cfg, errors.New("-retired-mmap-budget-bytes must be > 0")
+	}
+	if cfg.MaxDeadMappings <= 0 {
+		return cfg, errors.New("-max-dead-mappings must be > 0")
+	}
+	var err error
+	cfg.formats, err = parseFormats(cfg.FormatsCSV)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.indexes, err = parseIndexes(cfg.IndexesCSV)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.RepoRoot, err = os.Getwd()
+	if err != nil {
+		return cfg, err
+	}
+	if cfg.OutDir == "" && !cfg.internalRawWorker {
+		cfg.OutDir = filepath.Join(os.TempDir(), fmt.Sprintf("gomap_out_of_core_smoke_%s", time.Now().UTC().Format("20060102T150405Z")))
+	}
+	if cfg.OutDir != "" {
+		cfg.OutDir, err = filepath.Abs(cfg.OutDir)
+		if err != nil {
+			return cfg, err
+		}
+	}
+	return cfg, nil
+}
+
+func parseFormats(raw string) ([]string, error) {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, part := range parts {
+		v := strings.ToLower(strings.TrimSpace(part))
+		if v == "" {
+			continue
+		}
+		switch v {
+		case "json", "template-v1", "bson":
+		default:
+			return nil, fmt.Errorf("unsupported format %q", v)
+		}
+		if _, ok := seen[v]; !ok {
+			out = append(out, v)
+			seen[v] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil, errors.New("at least one format is required")
+	}
+	return out, nil
+}
+
+func parseIndexes(raw string) ([]int, error) {
+	parts := strings.Split(raw, ",")
+	out := make([]int, 0, len(parts))
+	seen := map[int]struct{}{}
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		v, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("parse index count %q: %w", part, err)
+		}
+		if v < 0 || v > 3 {
+			return nil, fmt.Errorf("index count %d is unsupported; use 0, 1, 2, or 3", v)
+		}
+		if _, ok := seen[v]; !ok {
+			out = append(out, v)
+			seen[v] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil, errors.New("at least one index count is required")
+	}
+	sort.Ints(out)
+	return out, nil
+}
+
+func run(cfg config) error {
+	if err := prepareRunDir(cfg.OutDir, cfg.AllowExistingRunDir); err != nil {
+		return err
+	}
+	logDir := filepath.Join(cfg.OutDir, "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return err
+	}
+	branch := gitOutput(cfg.RepoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	commit := gitOutput(cfg.RepoRoot, "rev-parse", "HEAD")
+	run := &smokeRun{
+		SchemaVersion: schemaVersion,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		RunDir:        cfg.OutDir,
+		Worktree:      cfg.RepoRoot,
+		Branch:        branch,
+		Commit:        commit,
+		CommandLine:   commandLine(),
+		Config: smokeConfig{
+			RawKeys:                cfg.RawKeys,
+			CollectionDocs:         cfg.CollectionDocs,
+			BatchSize:              cfg.BatchSize,
+			ValueSize:              cfg.ValueSize,
+			ReadWorkers:            cfg.ReadWorkers,
+			Formats:                append([]string(nil), cfg.formats...),
+			Indexes:                append([]int(nil), cfg.indexes...),
+			Profile:                cfg.Profile,
+			LeafSegmentTargetBytes: cfg.LeafSegmentTargetBytes,
+			Budgets:                cfg.budgets(),
+			IncludeMongo:           cfg.IncludeMongo,
+		},
+		Artifacts: map[string]string{},
+	}
+	if !cfg.SkipRaw {
+		if err := runRawShape(cfg, run, logDir); err != nil {
+			return err
+		}
+	}
+	if !cfg.SkipCollections {
+		for _, format := range cfg.formats {
+			for _, indexes := range cfg.indexes {
+				if err := runCollectionShape(cfg, run, logDir, format, indexes); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if !cfg.IncludeMongo {
+		run.Deferred = append(run.Deferred, deferredWorkload{
+			Name:   "mongo_gateway_smoke",
+			Issue:  "#1141",
+			Reason: "Mongo gateway out-of-core/concurrency coverage is intentionally split from the CI-sized raw/collection smoke harness so client/protocol/gateway costs are not conflated with core TreeDB storage guardrails.",
+		})
+	}
+	run.Checks = validateSmokeRun(run)
+	resultsPath := filepath.Join(cfg.OutDir, "out_of_core_smoke_results.json")
+	ndjsonPath := filepath.Join(cfg.OutDir, "out_of_core_smoke_results.ndjson")
+	mdPath := filepath.Join(cfg.OutDir, "out_of_core_smoke_summary.md")
+	run.Artifacts["json"] = resultsPath
+	run.Artifacts["ndjson"] = ndjsonPath
+	run.Artifacts["markdown"] = mdPath
+	if err := writeJSON(resultsPath, run); err != nil {
+		return err
+	}
+	if err := writeNDJSON(ndjsonPath, run.Results); err != nil {
+		return err
+	}
+	if err := os.WriteFile(mdPath, []byte(renderMarkdown(run)), 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("out-of-core smoke run: %s\n", cfg.OutDir)
+	fmt.Printf("summary: %s\n", mdPath)
+	fmt.Printf("json: %s\n", resultsPath)
+	fmt.Printf("ndjson: %s\n", ndjsonPath)
+	if cfg.FailOnWarnings && hasWarnings(run.Checks) {
+		return errors.New("guardrail warnings present")
+	}
+	if hasErrors(run.Checks) {
+		return errors.New("guardrail errors present")
+	}
+	return nil
+}
+
+func prepareRunDir(dir string, allowExisting bool) error {
+	if dir == "" {
+		return errors.New("missing run dir")
+	}
+	if filepath.Clean(dir) == filepath.Clean(string(os.PathSeparator)) {
+		return errors.New("refusing to use filesystem root as run dir")
+	}
+	entries, err := os.ReadDir(dir)
+	if err == nil && len(entries) > 0 && !allowExisting {
+		if _, statErr := os.Stat(filepath.Join(dir, runDirSentinel)); statErr != nil {
+			return fmt.Errorf("%s is not an empty out-of-core smoke run dir; use -allow-existing-run-dir to append", dir)
+		}
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, runDirSentinel), []byte(schemaVersion+"\n"), 0o644)
+}
+
+func (cfg config) budgets() budgets {
+	return budgets{
+		CacheBudgetBytes:       cfg.CacheBudgetBytes,
+		RetiredMmapBudgetBytes: cfg.RetiredMmapBudgetBytes,
+		MaxDeadMappings:        cfg.MaxDeadMappings,
+	}
+}
+
+func runRawShape(cfg config, run *smokeRun, logDir string) error {
+	dir := filepath.Join(cfg.OutDir, "raw_treedb")
+	jsonPath := filepath.Join(cfg.OutDir, "raw_treedb_summary.json")
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	args := []string{
+		"-internal-raw-worker",
+		"-raw-dir", dir,
+		"-raw-json", jsonPath,
+		"-raw-keys", strconv.Itoa(cfg.RawKeys),
+		"-batch-size", strconv.Itoa(cfg.BatchSize),
+		"-value-size", strconv.Itoa(cfg.ValueSize),
+		"-read-workers", strconv.Itoa(cfg.ReadWorkers),
+		"-profile", cfg.Profile,
+		"-leaf-segment-target-bytes", strconv.FormatInt(cfg.LeafSegmentTargetBytes, 10),
+	}
+	rec, stdout, err := runLoggedCommand("raw_treedb", exe, args, cfg.RepoRoot, cfg.childEnv(), filepath.Join(logDir, "raw_treedb.log"))
+	run.Commands = append(run.Commands, rec)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(stdout) != "" {
+		jsonPath = strings.TrimSpace(stdout)
+	}
+	var summary rawWorkerSummary
+	if err := readJSON(jsonPath, &summary); err != nil {
+		return err
+	}
+	components, _ := collectComponentBytes(summary.Dir)
+	total := summary.DiskUsageFinal.TotalBytes
+	bytesPerItem := bytesPer(total, summary.Keys)
+	write := summary.Timings["batch_write"]
+	read := summary.Timings["random_read_parallel"]
+	overwrite := summary.Timings["overwrite"]
+	run.Results = append(run.Results,
+		resultRow{
+			ConfigName:      "treedb_raw",
+			WorkloadName:    "raw_batch_write",
+			Engine:          "treedb",
+			Shape:           "raw",
+			KeyCount:        summary.Keys,
+			ItemCount:       summary.Keys,
+			BatchSize:       summary.BatchSize,
+			Phase:           "post_insert",
+			MeasurementKind: "benchmark_timed",
+			BenchmarkTimed:  true,
+			OpsPerSec:       ptrFloat(write.OpsPerSec),
+			NsPerItem:       nsPerItem(write),
+			TotalBytes:      &total,
+			BytesPerItem:    bytesPerItem,
+			ComponentBytes:  components,
+			Budgets:         cfg.budgets(),
+			PressureClaimed: true,
+			Mmap:            extractMmapStats(summary.TreeDBStatsFinal),
+			Cache:           extractCacheStats(summary.TreeDBStatsFinal),
+			StatsAvailable:  sortedKeys(summary.TreeDBStatsFinal),
+			SourceArtifact:  jsonPath,
+		},
+		resultRow{
+			ConfigName:      "treedb_raw",
+			WorkloadName:    "raw_random_read_parallel",
+			Engine:          "treedb",
+			Shape:           "raw",
+			KeyCount:        summary.Keys,
+			ItemCount:       summary.Keys,
+			BatchSize:       summary.BatchSize,
+			Phase:           "post_insert_read",
+			MeasurementKind: "benchmark_timed",
+			BenchmarkTimed:  true,
+			OpsPerSec:       ptrFloat(read.OpsPerSec),
+			NsPerItem:       nsPerItem(read),
+			TotalBytes:      &total,
+			BytesPerItem:    bytesPerItem,
+			ComponentBytes:  components,
+			Budgets:         cfg.budgets(),
+			PressureClaimed: true,
+			Mmap:            extractMmapStats(summary.TreeDBStatsFinal),
+			Cache:           extractCacheStats(summary.TreeDBStatsFinal),
+			StatsAvailable:  sortedKeys(summary.TreeDBStatsFinal),
+			SourceArtifact:  jsonPath,
+		},
+		resultRow{
+			ConfigName:      "treedb_raw",
+			WorkloadName:    "raw_overwrite",
+			Engine:          "treedb",
+			Shape:           "raw",
+			KeyCount:        summary.Keys,
+			ItemCount:       summary.Keys,
+			BatchSize:       summary.BatchSize,
+			Phase:           "post_overwrite",
+			MeasurementKind: "benchmark_timed",
+			BenchmarkTimed:  true,
+			OpsPerSec:       ptrFloat(overwrite.OpsPerSec),
+			NsPerItem:       nsPerItem(overwrite),
+			TotalBytes:      &total,
+			BytesPerItem:    bytesPerItem,
+			ComponentBytes:  components,
+			Budgets:         cfg.budgets(),
+			PressureClaimed: true,
+			Mmap:            extractMmapStats(summary.TreeDBStatsFinal),
+			Cache:           extractCacheStats(summary.TreeDBStatsFinal),
+			StatsAvailable:  sortedKeys(summary.TreeDBStatsFinal),
+			SourceArtifact:  jsonPath,
+		},
+	)
+	return nil
+}
+
+func runCollectionShape(cfg config, run *smokeRun, logDir, format string, indexes int) error {
+	name := fmt.Sprintf("collection_%s_%d_indexes", sanitizeName(format), indexes)
+	dir := filepath.Join(cfg.OutDir, name)
+	args := []string{
+		"run", "./cmd/collection_load_fixture",
+		"-dir", dir,
+		"-reset",
+		"-docs", strconv.Itoa(cfg.CollectionDocs),
+		"-batch-size", strconv.Itoa(cfg.BatchSize),
+		"-format", format,
+		"-indexes", strconv.Itoa(indexes),
+		"-profile", cfg.Profile,
+		"-data-outer-leaves-in-vlog",
+		"-index-outer-leaves-in-vlog",
+		"-leaf-segment-target-bytes", strconv.FormatInt(cfg.LeafSegmentTargetBytes, 10),
+		"-checkpoint",
+		"-reopen-verify",
+		"-verify-samples", strconv.Itoa(min(50, cfg.CollectionDocs)),
+		"-progress=false",
+		"-json",
+	}
+	rec, stdout, err := runLoggedCommand(name, "go", args, cfg.RepoRoot, cfg.childEnv(), filepath.Join(logDir, name+".log"))
+	run.Commands = append(run.Commands, rec)
+	if err != nil {
+		return err
+	}
+	artifact := filepath.Join(cfg.OutDir, name+"_summary.json")
+	if err := os.WriteFile(artifact, []byte(stdout), 0o644); err != nil {
+		return err
+	}
+	var summary fixtureSummary
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		return fmt.Errorf("parse %s JSON: %w", name, err)
+	}
+	components, _ := collectComponentBytes(summary.Dir)
+	total := summary.DiskUsageFinal.TotalBytes
+	bytesPerItem := bytesPer(total, summary.Docs)
+	row := resultRow{
+		ConfigName:       fmt.Sprintf("treedb_%s_collection_%d_indexes", sanitizeName(summary.DocumentFormat), summary.IndexCount),
+		WorkloadName:     "collection_insert",
+		Engine:           "treedb",
+		Shape:            "collection",
+		Format:           summary.DocumentFormat,
+		IndexCount:       summary.IndexCount,
+		DocumentCount:    summary.Docs,
+		ItemCount:        summary.Docs,
+		BatchSize:        summary.BatchSize,
+		Phase:            "post_insert",
+		MeasurementKind:  "benchmark_timed",
+		BenchmarkTimed:   true,
+		DocsPerSec:       ptrFloat(summary.InsertTiming.OpsPerSec),
+		OpsPerSec:        ptrFloat(summary.InsertTiming.OpsPerSec),
+		NsPerItem:        nsPerItem(summary.InsertTiming),
+		TotalBytes:       &total,
+		BytesPerItem:     bytesPerItem,
+		ComponentBytes:   components,
+		Budgets:          cfg.budgets(),
+		PressureClaimed:  true,
+		Mmap:             extractMmapStats(summary.TreeDBStatsFinal),
+		Cache:            extractCacheStats(summary.TreeDBStatsFinal),
+		StatsAvailable:   sortedKeys(summary.TreeDBStatsFinal),
+		SourceArtifact:   artifact,
+		MeasurementNotes: "collection-load-fixture insert plus checkpoint and reopen/index smoke verification",
+	}
+	run.Results = append(run.Results, row)
+	return nil
+}
+
+func (cfg config) childEnv() map[string]string {
+	return map[string]string{
+		"TREEDB_VLOG_MAX_DEAD_MAPPINGS":     strconv.Itoa(cfg.MaxDeadMappings),
+		"TREEDB_OUTER_LEAF_READ_SAMPLE_MOD": "1",
+	}
+}
+
+func runLoggedCommand(name, bin string, args []string, workDir string, env map[string]string, logPath string) (commandRecord, string, error) {
+	start := time.Now()
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = workDir
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		exitCode = 1
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+	}
+	log := bytes.Buffer{}
+	log.WriteString("$ ")
+	log.WriteString(bin)
+	for _, arg := range args {
+		log.WriteByte(' ')
+		log.WriteString(shellQuote(arg))
+	}
+	log.WriteString("\n\n# stdout\n")
+	log.Write(stdout.Bytes())
+	log.WriteString("\n# stderr\n")
+	log.Write(stderr.Bytes())
+	if writeErr := os.WriteFile(logPath, log.Bytes(), 0o644); writeErr != nil && err == nil {
+		err = writeErr
+	}
+	rec := commandRecord{
+		Name:     name,
+		Command:  append([]string{bin}, args...),
+		Env:      env,
+		WorkDir:  workDir,
+		LogPath:  logPath,
+		ExitCode: exitCode,
+		Duration: time.Since(start).String(),
+	}
+	if err != nil {
+		return rec, stdout.String(), fmt.Errorf("%s failed (exit=%d, log=%s): %w", name, exitCode, logPath, err)
+	}
+	return rec, stdout.String(), nil
+}
+
+func runRawWorker(cfg config) error {
+	if cfg.rawDir == "" {
+		return errors.New("-raw-dir is required")
+	}
+	if cfg.rawJSONPath == "" {
+		return errors.New("-raw-json is required")
+	}
+	if err := os.RemoveAll(cfg.rawDir); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(cfg.rawDir, 0o755); err != nil {
+		return err
+	}
+	profile, err := parseProfile(cfg.Profile)
+	if err != nil {
+		return err
+	}
+	opts := treedb.OptionsFor(profile, cfg.rawDir)
+	opts.IndexOuterLeavesInValueLog = true
+	opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationHotWarmCold
+	opts.ValueLog.Generational.LeafSegmentTargetBytes = cfg.LeafSegmentTargetBytes
+	db, err := treedb.Open(opts)
+	if err != nil {
+		return err
+	}
+	timings := make(map[string]timing)
+	start := time.Now()
+	if err := rawBatchSet(db, 0, cfg.RawKeys, cfg.BatchSize, cfg.ValueSize, 0); err != nil {
+		_ = db.Close()
+		return err
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		return err
+	}
+	timings["batch_write"] = elapsedTiming(time.Since(start), cfg.RawKeys)
+
+	start = time.Now()
+	if err := rawParallelRead(db, cfg.RawKeys, cfg.ValueSize, 0, cfg.ReadWorkers); err != nil {
+		_ = db.Close()
+		return err
+	}
+	timings["random_read_parallel"] = elapsedTiming(time.Since(start), cfg.RawKeys)
+
+	start = time.Now()
+	if err := rawBatchSet(db, 0, cfg.RawKeys, cfg.BatchSize, cfg.ValueSize, 1); err != nil {
+		_ = db.Close()
+		return err
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		return err
+	}
+	timings["overwrite"] = elapsedTiming(time.Since(start), cfg.RawKeys)
+
+	start = time.Now()
+	if err := rawParallelRead(db, cfg.RawKeys, cfg.ValueSize, 1, cfg.ReadWorkers); err != nil {
+		_ = db.Close()
+		return err
+	}
+	timings["post_overwrite_random_read_parallel"] = elapsedTiming(time.Since(start), cfg.RawKeys)
+
+	stats := selectedTreeDBStats(db.Stats())
+	if err := db.Close(); err != nil {
+		return err
+	}
+	usage, err := directoryUsage(cfg.rawDir, cfg.RawKeys)
+	if err != nil {
+		return err
+	}
+	summary := rawWorkerSummary{
+		GeneratedAt:       time.Now().UTC().Format(time.RFC3339),
+		Dir:               cfg.rawDir,
+		Keys:              cfg.RawKeys,
+		BatchSize:         cfg.BatchSize,
+		ValueSize:         cfg.ValueSize,
+		Profile:           cfg.Profile,
+		LeafSegmentTarget: cfg.LeafSegmentTargetBytes,
+		Timings:           timings,
+		DiskUsageFinal:    usage,
+		TreeDBStatsFinal:  stats,
+	}
+	if err := writeJSON(cfg.rawJSONPath, summary); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, cfg.rawJSONPath)
+	return nil
+}
+
+func parseProfile(raw string) (treedb.Profile, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "fast", "production_fast":
+		return treedb.ProfileFast, nil
+	case "wal_on_fast", "production_wal_on_fast":
+		return treedb.ProfileWALOnFast, nil
+	case "durable":
+		return treedb.ProfileDurable, nil
+	case "bench":
+		return treedb.ProfileBench, nil
+	default:
+		return "", fmt.Errorf("unsupported profile %q", raw)
+	}
+}
+
+func rawBatchSet(db *treedb.DB, start, count, batchSize, valueSize, generation int) error {
+	for pos := start; pos < start+count; {
+		n := min(batchSize, start+count-pos)
+		batch := db.NewBatchWithSize(n)
+		if batch == nil {
+			return errors.New("NewBatchWithSize returned nil")
+		}
+		for i := 0; i < n; i++ {
+			keyID := pos + i
+			if err := batch.Set(rawKey(keyID), rawValue(keyID, generation, valueSize)); err != nil {
+				_ = batch.Close()
+				return err
+			}
+		}
+		if err := batch.Write(); err != nil {
+			_ = batch.Close()
+			return err
+		}
+		if err := batch.Close(); err != nil {
+			return err
+		}
+		pos += n
+	}
+	return nil
+}
+
+func rawParallelRead(db *treedb.DB, keys, valueSize, generation, workers int) error {
+	if workers <= 0 {
+		workers = 1
+	}
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var dst []byte
+			for i := worker; i < keys; i += workers {
+				got, err := db.GetAppend(rawKey(i), dst[:0])
+				if err != nil {
+					errCh <- err
+					return
+				}
+				want := rawValue(i, generation, valueSize)
+				if !bytes.Equal(got, want) {
+					errCh <- fmt.Errorf("key %d mismatch: got %d bytes", i, len(got))
+					return
+				}
+				dst = got[:0]
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rawKey(i int) []byte {
+	return []byte(fmt.Sprintf("raw:%012d", i))
+}
+
+func rawValue(i, generation, size int) []byte {
+	out := make([]byte, size)
+	prefix := fmt.Sprintf("value:%012d:generation:%02d:", i, generation)
+	copy(out, prefix)
+	for j := len(prefix); j < len(out); j++ {
+		out[j] = byte('a' + (i+j+generation)%26)
+	}
+	return out
+}
+
+func elapsedTiming(d time.Duration, n int) timing {
+	out := timing{Seconds: d.Seconds()}
+	if n > 0 && d > 0 {
+		out.SecPerOp = d.Seconds() / float64(n)
+		out.OpsPerSec = float64(n) / d.Seconds()
+	}
+	return out
+}
+
+func directoryUsage(root string, docs int) (diskUsage, error) {
+	var out diskUsage
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		size := uint64(info.Size())
+		out.TotalBytes += size
+		out.FileCount++
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		out.TopFiles = append(out.TopFiles, fileSummary{Path: filepath.ToSlash(rel), Bytes: size})
+		return nil
+	})
+	if err != nil {
+		return out, err
+	}
+	sort.Slice(out.TopFiles, func(i, j int) bool {
+		if out.TopFiles[i].Bytes == out.TopFiles[j].Bytes {
+			return out.TopFiles[i].Path < out.TopFiles[j].Path
+		}
+		return out.TopFiles[i].Bytes > out.TopFiles[j].Bytes
+	})
+	if len(out.TopFiles) > 20 {
+		out.TopFiles = out.TopFiles[:20]
+	}
+	if docs > 0 {
+		out.BytesPerDoc = float64(out.TotalBytes) / float64(docs)
+	}
+	return out, nil
+}
+
+func collectComponentBytes(root string) (map[string]uint64, error) {
+	out := map[string]uint64{}
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(filepath.Clean(rel))
+		size := uint64(info.Size())
+		out["total"] += size
+		parts := strings.Split(rel, "/")
+		if len(parts) == 0 {
+			return nil
+		}
+		out[parts[0]] += size
+		if strings.HasSuffix(rel, "index.db") {
+			out["index.db"] += size
+			if len(parts) >= 2 {
+				out[parts[0]+"/index.db"] += size
+			}
+		}
+		if len(parts) >= 2 {
+			switch parts[1] {
+			case "leaf_vlog", "value_vlog", "wal":
+				out[parts[0]+"/"+parts[1]] += size
+			}
+		}
+		return nil
+	})
+	return out, err
+}
+
+func selectedTreeDBStats(stats map[string]string) map[string]string {
+	if len(stats) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	for key, value := range stats {
+		if isSelectedTreeDBStatKey(key) {
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func isSelectedTreeDBStatKey(key string) bool {
+	switch {
+	case key == "treedb.commit_seq":
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_mmap."):
+		return true
+	case strings.HasPrefix(key, "treedb.vlog.mmap"):
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_zombie."):
+		return true
+	case strings.HasPrefix(key, "treedb.process.memory.vlog_zombie"):
+		return true
+	case strings.HasPrefix(key, "treedb.vlog.outer_leaf_block_cache."):
+		return true
+	case strings.HasPrefix(key, "treedb.process.read_path.outer_leaf."):
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_generation."):
+		return true
+	case strings.HasPrefix(key, "treedb.cache.vlog_retained_prune."):
+		return true
+	default:
+		return false
+	}
+}
+
+func extractMmapStats(stats map[string]string) *mmapStats {
+	if len(stats) == 0 {
+		return nil
+	}
+	var out mmapStats
+	var saw bool
+	set := func(dst *uint64, keys ...string) {
+		if v, ok := statUint(stats, keys...); ok {
+			*dst = v
+			saw = true
+		}
+	}
+	set(&out.Remaps, "treedb.cache.vlog_mmap.remaps", "treedb.vlog.mmap_remaps")
+	set(&out.DeadMappings, "treedb.cache.vlog_mmap.dead_mappings", "treedb.vlog.mmap_dead_mappings")
+	set(&out.DeadMappingCap, "treedb.cache.vlog_mmap.dead_mappings.cap_base", "treedb.vlog.mmap_dead_mappings.cap_base")
+	set(&out.ActiveSegments, "treedb.cache.vlog_mmap.active_segments", "treedb.vlog.mmap_active_segments")
+	set(&out.ActiveBytes, "treedb.cache.vlog_mmap.active_bytes", "treedb.vlog.mmap_active_bytes")
+	set(&out.CurrentSegments, "treedb.cache.vlog_mmap.current_segments", "treedb.vlog.mmap_current_segments")
+	set(&out.CurrentBytes, "treedb.cache.vlog_mmap.current_bytes", "treedb.vlog.mmap_current_bytes")
+	set(&out.SealedSegments, "treedb.cache.vlog_mmap.sealed_segments", "treedb.vlog.mmap_sealed_segments")
+	set(&out.SealedBytes, "treedb.cache.vlog_mmap.sealed_bytes", "treedb.vlog.mmap_sealed_bytes")
+	set(&out.DeadBytes, "treedb.cache.vlog_mmap.dead_bytes", "treedb.vlog.mmap_dead_bytes")
+	set(&out.Hits, "treedb.cache.vlog_mmap.read.hits", "treedb.vlog.mmap_read.hits")
+	set(&out.MissOutOfRange, "treedb.cache.vlog_mmap.read.miss_out_of_range", "treedb.vlog.mmap_read.miss_out_of_range")
+	set(&out.MissNoMapping, "treedb.cache.vlog_mmap.read.miss_no_mapping", "treedb.vlog.mmap_read.miss_no_mapping")
+	set(&out.MissDeadMappingCap, "treedb.cache.vlog_mmap.read.miss_dead_mapping_cap", "treedb.vlog.mmap_read.miss_dead_mapping_cap")
+	set(&out.FallbackReadAt, "treedb.cache.vlog_mmap.read.fallback_readat", "treedb.vlog.mmap_read.fallback_readat")
+	if v, ok := statFloat(stats, "treedb.cache.vlog_mmap.read.hit_ratio", "treedb.vlog.mmap_read.hit_ratio"); ok {
+		out.HitRatio = &v
+		saw = true
+	}
+	if !saw {
+		return nil
+	}
+	return &out
+}
+
+func extractCacheStats(stats map[string]string) *cacheStats {
+	if len(stats) == 0 {
+		return nil
+	}
+	var out cacheStats
+	var saw bool
+	if v, ok := statUint(stats, "treedb.vlog.outer_leaf_block_cache.hits"); ok {
+		out.OuterLeafBlockHits = &v
+		saw = true
+	}
+	if v, ok := statUint(stats, "treedb.vlog.outer_leaf_block_cache.misses"); ok {
+		out.OuterLeafBlockMisses = &v
+		saw = true
+	}
+	if v, ok := statFloat(stats, "treedb.vlog.outer_leaf_block_cache.hit_ratio"); ok {
+		out.OuterLeafBlockHitRatio = &v
+		saw = true
+	}
+	if v, ok := statUint(stats, "treedb.vlog.outer_leaf_block_cache.entries"); ok {
+		out.OuterLeafBlockEntries = &v
+		saw = true
+	}
+	if v, ok := statUint(stats, "treedb.vlog.outer_leaf_block_cache.capacity"); ok {
+		out.OuterLeafBlockCapacity = &v
+		saw = true
+	}
+	if !saw {
+		return nil
+	}
+	return &out
+}
+
+func validateSmokeRun(run *smokeRun) []guardrailCheck {
+	var checks []guardrailCheck
+	if run == nil {
+		return []guardrailCheck{{Severity: "error", Code: "nil_run", Message: "smoke run is nil"}}
+	}
+	if len(run.Results) == 0 {
+		checks = append(checks, guardrailCheck{Severity: "error", Code: "missing_results", Message: "no benchmark results were recorded"})
+	}
+	for _, row := range run.Results {
+		subject := row.ConfigName + "/" + row.WorkloadName
+		if strings.TrimSpace(row.Shape) == "" {
+			checks = append(checks, guardrailCheck{Severity: "error", Code: "missing_shape_label", Subject: subject, Message: "result row is missing raw/collection/Mongo shape label"})
+		}
+		if row.Shape != "raw" && row.Shape != "collection" && row.Shape != "mongo" {
+			checks = append(checks, guardrailCheck{Severity: "error", Code: "invalid_shape_label", Subject: subject, Message: fmt.Sprintf("result row has unsupported shape label %q", row.Shape)})
+		}
+		if row.ItemCount <= 0 {
+			checks = append(checks, guardrailCheck{Severity: "error", Code: "missing_item_count", Subject: subject, Message: "result row is missing document/key count, making bytes-per-item ambiguous"})
+		}
+		if row.BytesPerItem != nil && row.ItemCount <= 0 {
+			checks = append(checks, guardrailCheck{Severity: "error", Code: "bytes_per_item_without_count", Subject: subject, Message: "bytes-per-item was reported without a positive document/key count"})
+		}
+		if row.PressureClaimed {
+			if row.TotalBytes == nil {
+				checks = append(checks, guardrailCheck{Severity: "error", Code: "pressure_without_total_bytes", Subject: subject, Message: "pressure/out-of-core guardrail row is missing total bytes"})
+			} else {
+				budget := maxInt64(row.Budgets.CacheBudgetBytes, row.Budgets.RetiredMmapBudgetBytes)
+				if budget <= 0 {
+					checks = append(checks, guardrailCheck{Severity: "error", Code: "missing_budget", Subject: subject, Message: "pressure/out-of-core guardrail row is missing configured budget bytes"})
+				} else if *row.TotalBytes <= uint64(budget*2) {
+					checks = append(checks, guardrailCheck{Severity: "warning", Code: "dataset_not_larger_than_budget", Subject: subject, Message: fmt.Sprintf("dataset bytes %d do not exceed the largest configured budget %d by more than 2x", *row.TotalBytes, budget)})
+				}
+			}
+		}
+		if row.Engine == "treedb" && row.Mmap == nil {
+			checks = append(checks, guardrailCheck{Severity: "warning", Code: "missing_mmap_counters", Subject: subject, Message: "TreeDB row has no mmap counters; #1135/#1136 validation needs these counters"})
+		}
+		if row.Mmap != nil && row.Budgets.RetiredMmapBudgetBytes > 0 && row.Mmap.DeadBytes > uint64(row.Budgets.RetiredMmapBudgetBytes) {
+			checks = append(checks, guardrailCheck{Severity: "warning", Code: "retired_mmap_budget_exceeded", Subject: subject, Message: fmt.Sprintf("dead mmap bytes %d exceed configured smoke budget %d", row.Mmap.DeadBytes, row.Budgets.RetiredMmapBudgetBytes)})
+		}
+		if row.Budgets.MaxDeadMappings <= 0 {
+			checks = append(checks, guardrailCheck{Severity: "error", Code: "missing_dead_mapping_budget", Subject: subject, Message: "row is missing max dead mapping budget"})
+		}
+	}
+	if mixesRawAndCollectionWithoutLabels(run.Results) {
+		checks = append(checks, guardrailCheck{Severity: "error", Code: "mixed_shapes_without_labels", Message: "raw TreeDB and collection rows are mixed without explicit shape labels"})
+	}
+	if len(checks) == 0 {
+		checks = append(checks, guardrailCheck{Severity: "pass", Code: "ok", Message: "all out-of-core smoke guardrails passed"})
+	}
+	return checks
+}
+
+func mixesRawAndCollectionWithoutLabels(rows []resultRow) bool {
+	var raw, collection bool
+	for _, row := range rows {
+		raw = raw || row.Shape == "raw"
+		collection = collection || row.Shape == "collection"
+		if row.Shape == "" && (raw || collection) {
+			return true
+		}
+	}
+	return false
+}
+
+func renderMarkdown(run *smokeRun) string {
+	var sb strings.Builder
+	sb.WriteString("# TreeDB Out-of-Core Smoke Report\n\n")
+	sb.WriteString("## Executive Summary\n\n")
+	errorsCount, warningsCount := countChecks(run.Checks)
+	sb.WriteString(fmt.Sprintf("- Results: %d rows across raw TreeDB and collection smoke shapes.\n", len(run.Results)))
+	sb.WriteString(fmt.Sprintf("- Guardrails: %d errors, %d warnings.\n", errorsCount, warningsCount))
+	sb.WriteString("- This is a CI-sized budget-pressure smoke, not a true large-than-RAM benchmark. It intentionally uses tiny configured budgets to exercise bounded behavior before #1135/#1136 changes.\n\n")
+
+	sb.WriteString("## Benchmark Configuration\n\n")
+	sb.WriteString("| Field | Value |\n| --- | --- |\n")
+	sb.WriteString(fmt.Sprintf("| `schema_version` | `%s` |\n", run.SchemaVersion))
+	sb.WriteString(fmt.Sprintf("| `generated_at` | `%s` |\n", run.GeneratedAt))
+	sb.WriteString(fmt.Sprintf("| `run_dir` | `%s` |\n", run.RunDir))
+	sb.WriteString(fmt.Sprintf("| `branch` | `%s` |\n", run.Branch))
+	sb.WriteString(fmt.Sprintf("| `commit` | `%s` |\n", run.Commit))
+	sb.WriteString(fmt.Sprintf("| `command_line` | `%s` |\n", strings.Join(run.CommandLine, " ")))
+	sb.WriteString(fmt.Sprintf("| `raw_keys` | `%d` |\n", run.Config.RawKeys))
+	sb.WriteString(fmt.Sprintf("| `collection_docs` | `%d` |\n", run.Config.CollectionDocs))
+	sb.WriteString(fmt.Sprintf("| `batch_size` | `%d` |\n", run.Config.BatchSize))
+	sb.WriteString(fmt.Sprintf("| `formats` | `%s` |\n", strings.Join(run.Config.Formats, ",")))
+	sb.WriteString(fmt.Sprintf("| `indexes` | `%s` |\n", joinInts(run.Config.Indexes)))
+	sb.WriteString(fmt.Sprintf("| `leaf_segment_target_bytes` | `%d` |\n", run.Config.LeafSegmentTargetBytes))
+	sb.WriteString(fmt.Sprintf("| `cache_budget_bytes` | `%d` |\n", run.Config.Budgets.CacheBudgetBytes))
+	sb.WriteString(fmt.Sprintf("| `retired_mmap_budget_bytes` | `%d` |\n", run.Config.Budgets.RetiredMmapBudgetBytes))
+	sb.WriteString(fmt.Sprintf("| `max_dead_mappings` | `%d` |\n", run.Config.Budgets.MaxDeadMappings))
+	sb.WriteString("\n")
+
+	sb.WriteString("## Throughput And Storage Results\n\n")
+	sb.WriteString("| Config | Shape | Format | Indexes | Items | Phase | ops/sec | ns/item | Total bytes | B/item | mmap hits | ReadAt fallback | dead mmap bytes |\n")
+	sb.WriteString("| --- | --- | --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+	for _, row := range run.Results {
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` | %d | %d | `%s` | %s | %s | %s | %s | %s | %s | %s |\n",
+			row.ConfigName,
+			row.Shape,
+			emptyDash(row.Format),
+			row.IndexCount,
+			row.ItemCount,
+			row.Phase,
+			formatFloatPtr(firstFloat(row.OpsPerSec, row.DocsPerSec)),
+			formatFloatPtr(row.NsPerItem),
+			formatUintPtr(row.TotalBytes),
+			formatFloatPtr(row.BytesPerItem),
+			formatMmapUint(row.Mmap, func(m *mmapStats) uint64 { return m.Hits }),
+			formatMmapUint(row.Mmap, func(m *mmapStats) uint64 { return m.FallbackReadAt }),
+			formatMmapUint(row.Mmap, func(m *mmapStats) uint64 { return m.DeadBytes }),
+		))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("## Component Bytes\n\n")
+	sb.WriteString("| Config | Shape | Component | Bytes |\n| --- | --- | --- | ---: |\n")
+	seenComponents := make(map[string]struct{})
+	for _, row := range run.Results {
+		seenKey := row.ConfigName + "\x00" + row.Shape + "\x00" + row.SourceArtifact
+		if _, ok := seenComponents[seenKey]; ok {
+			continue
+		}
+		seenComponents[seenKey] = struct{}{}
+		keys := sortedComponentKeys(row.ComponentBytes)
+		for _, key := range keys {
+			sb.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` | %d |\n", row.ConfigName, row.Shape, key, row.ComponentBytes[key]))
+		}
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("## Guardrails\n\n")
+	sb.WriteString("| Severity | Code | Subject | Message |\n| --- | --- | --- | --- |\n")
+	for _, check := range run.Checks {
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` | %s |\n", check.Severity, check.Code, check.Subject, escapePipes(check.Message)))
+	}
+	sb.WriteString("\n")
+
+	if len(run.Deferred) > 0 {
+		sb.WriteString("## Deferred Workloads\n\n")
+		for _, deferred := range run.Deferred {
+			sb.WriteString(fmt.Sprintf("- `%s`: %s", deferred.Name, deferred.Reason))
+			if deferred.Issue != "" {
+				sb.WriteString(fmt.Sprintf(" (%s)", deferred.Issue))
+			}
+			sb.WriteString("\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("## Reproduction Commands\n\n")
+	sb.WriteString("Canonical entry point:\n\n")
+	sb.WriteString("```bash\nmake bench-out-of-core-smoke\n```\n\n")
+	sb.WriteString("Exact command captured for this run:\n\n")
+	sb.WriteString("```bash\n")
+	sb.WriteString(strings.Join(run.CommandLine, " "))
+	sb.WriteString("\n```\n\n")
+
+	sb.WriteString("## Command Log\n\n")
+	sb.WriteString("| Name | Exit | Duration | Log |\n| --- | ---: | ---: | --- |\n")
+	for _, cmd := range run.Commands {
+		sb.WriteString(fmt.Sprintf("| `%s` | %d | `%s` | `%s` |\n", cmd.Name, cmd.ExitCode, cmd.Duration, cmd.LogPath))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func writeJSON(path string, v any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}
+
+func readJSON(path string, v any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}
+
+func writeNDJSON(path string, rows []resultRow) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, row := range rows {
+		if err := enc.Encode(row); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(path, buf.Bytes(), 0o644)
+}
+
+func statUint(stats map[string]string, keys ...string) (uint64, bool) {
+	for _, key := range keys {
+		raw, ok := stats[key]
+		if !ok {
+			continue
+		}
+		v, err := strconv.ParseUint(strings.TrimSpace(raw), 10, 64)
+		if err == nil {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func statFloat(stats map[string]string, keys ...string) (float64, bool) {
+	for _, key := range keys {
+		raw, ok := stats[key]
+		if !ok {
+			continue
+		}
+		v, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+		if err == nil {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func commandLine() []string {
+	if raw := strings.TrimSpace(os.Getenv(envCommandLine)); raw != "" {
+		return strings.Fields(raw)
+	}
+	return append([]string(nil), os.Args...)
+}
+
+func gitOutput(workDir string, args ...string) string {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = workDir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for key := range m {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedComponentKeys(m map[string]uint64) []string {
+	out := make([]string, 0, len(m))
+	for key := range m {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func bytesPer(total uint64, count int) *float64 {
+	if count <= 0 {
+		return nil
+	}
+	v := float64(total) / float64(count)
+	return &v
+}
+
+func nsPerItem(t timing) *float64 {
+	if t.SecPerOp > 0 {
+		v := t.SecPerOp * 1e9
+		return &v
+	}
+	if t.OpsPerSec > 0 {
+		v := 1e9 / t.OpsPerSec
+		return &v
+	}
+	return nil
+}
+
+func ptrFloat(v float64) *float64 {
+	if v <= 0 || math.IsNaN(v) || math.IsInf(v, 0) {
+		return nil
+	}
+	return &v
+}
+
+func firstFloat(vals ...*float64) *float64 {
+	for _, v := range vals {
+		if v != nil {
+			return v
+		}
+	}
+	return nil
+}
+
+func formatFloatPtr(v *float64) string {
+	if v == nil {
+		return "-"
+	}
+	if *v >= 1000 {
+		return fmt.Sprintf("%.0f", *v)
+	}
+	return fmt.Sprintf("%.2f", *v)
+}
+
+func formatUintPtr(v *uint64) string {
+	if v == nil {
+		return "-"
+	}
+	return strconv.FormatUint(*v, 10)
+}
+
+func formatMmapUint(m *mmapStats, fn func(*mmapStats) uint64) string {
+	if m == nil {
+		return "-"
+	}
+	return strconv.FormatUint(fn(m), 10)
+}
+
+func emptyDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}
+
+func joinInts(vals []int) string {
+	parts := make([]string, 0, len(vals))
+	for _, v := range vals {
+		parts = append(parts, strconv.Itoa(v))
+	}
+	return strings.Join(parts, ",")
+}
+
+func escapePipes(s string) string {
+	return strings.ReplaceAll(s, "|", "\\|")
+}
+
+func sanitizeName(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.ReplaceAll(s, "-", "_")
+	s = strings.ReplaceAll(s, "/", "_")
+	return s
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if strings.IndexFunc(s, func(r rune) bool {
+		return !(r == '-' || r == '_' || r == '.' || r == '/' || r == '=' || r == ':' || r == ',' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'))
+	}) < 0 {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func countChecks(checks []guardrailCheck) (errorsCount, warningsCount int) {
+	for _, check := range checks {
+		switch check.Severity {
+		case "error":
+			errorsCount++
+		case "warning":
+			warningsCount++
+		}
+	}
+	return errorsCount, warningsCount
+}
+
+func hasErrors(checks []guardrailCheck) bool {
+	errorsCount, _ := countChecks(checks)
+	return errorsCount > 0
+}
+
+func hasWarnings(checks []guardrailCheck) bool {
+	_, warningsCount := countChecks(checks)
+	return warningsCount > 0
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cmd/treedb_out_of_core_smoke/main.go
+++ b/cmd/treedb_out_of_core_smoke/main.go
@@ -200,6 +200,36 @@ type fixtureSummary struct {
 	IndexOuterLeavesInValueLog bool              `json:"index_outer_leaves_in_value_log"`
 }
 
+type mongoGatewaySummary struct {
+	Target                     string                 `json:"target"`
+	TreeDBDir                  string                 `json:"treedb_dir,omitempty"`
+	Documents                  int                    `json:"documents"`
+	BatchSize                  int                    `json:"batch_size"`
+	SecondaryIndexes           int                    `json:"secondary_indexes"`
+	ClientMode                 string                 `json:"client_mode"`
+	TreeDBProfile              string                 `json:"treedb_profile,omitempty"`
+	TreeDBDocumentFormat       string                 `json:"treedb_document_format,omitempty"`
+	TreeDBMaintenanceMode      string                 `json:"treedb_maintenance_mode,omitempty"`
+	Phases                     []mongoGatewayPhase    `json:"phases"`
+	TreeDBDiskAfterLoad        *mongoGatewayDiskUsage `json:"treedb_disk_after_load,omitempty"`
+	TreeDBDiskAfterCheckpoint  *mongoGatewayDiskUsage `json:"treedb_disk_after_checkpoint,omitempty"`
+	TreeDBDiskAfterMaintenance *mongoGatewayDiskUsage `json:"treedb_disk_after_maintenance,omitempty"`
+	TreeDBStatsFinal           map[string]string      `json:"treedb_stats_final,omitempty"`
+}
+
+type mongoGatewayPhase struct {
+	Name           string  `json:"name"`
+	Operations     int     `json:"operations"`
+	OpsPerSecond   float64 `json:"ops_per_sec"`
+	SampledNsPerOp float64 `json:"sampled_ns_per_op,omitempty"`
+	DurationMillis float64 `json:"duration_ms,omitempty"`
+}
+
+type mongoGatewayDiskUsage struct {
+	TotalBytes int64            `json:"total_bytes"`
+	Paths      map[string]int64 `json:"paths,omitempty"`
+}
+
 type timing struct {
 	Seconds   float64 `json:"seconds"`
 	SecPerOp  float64 `json:"sec_per_op,omitempty"`
@@ -435,7 +465,11 @@ func run(cfg config) error {
 			}
 		}
 	}
-	if !cfg.IncludeMongo {
+	if cfg.IncludeMongo {
+		if err := runMongoGatewayShape(cfg, run, logDir); err != nil {
+			return err
+		}
+	} else {
 		run.Deferred = append(run.Deferred, deferredWorkload{
 			Name:   "mongo_gateway_smoke",
 			Issue:  "#1141",
@@ -704,6 +738,170 @@ func runCollectionShape(cfg config, run *smokeRun, logDir, format string, indexe
 	}
 	run.Results = append(run.Results, row)
 	return nil
+}
+
+func runMongoGatewayShape(cfg config, run *smokeRun, logDir string) error {
+	format := preferredMongoFormat(cfg.formats)
+	indexes := preferredMongoIndexCount(cfg.indexes)
+	name := fmt.Sprintf("mongo_gateway_%s_%d_indexes", sanitizeName(format), indexes)
+	baseDir := cfg.OutDir
+	if resolved, err := filepath.EvalSymlinks(cfg.OutDir); err == nil {
+		baseDir = resolved
+	}
+	dir := filepath.Join(baseDir, name)
+	docs := cfg.CollectionDocs
+	reads := min(100, docs)
+	rangeReads := min(20, docs)
+	updates := min(50, docs)
+	args := []string{
+		"run", "./cmd/mongo_gateway_bench",
+		"-target", "treedb",
+		"-treedb-dir", dir,
+		"-keep-treedb-dir",
+		"-documents", strconv.Itoa(docs),
+		"-batch-size", strconv.Itoa(cfg.BatchSize),
+		"-reads", strconv.Itoa(reads),
+		"-range-reads", strconv.Itoa(rangeReads),
+		"-updates", strconv.Itoa(updates),
+		"-secondary-indexes", strconv.Itoa(indexes),
+		"-treedb-profile", cfg.Profile,
+		"-treedb-document-format", format,
+		"-treedb-maintenance", "checkpoint",
+		"-format", "json",
+	}
+	rec, stdout, err := runLoggedCommand(name, "go", args, cfg.RepoRoot, cfg.childEnv(), filepath.Join(logDir, name+".log"))
+	run.Commands = append(run.Commands, rec)
+	if err != nil {
+		return err
+	}
+	artifact := filepath.Join(cfg.OutDir, name+"_summary.json")
+	if err := os.WriteFile(artifact, []byte(stdout), 0o644); err != nil {
+		return err
+	}
+	var summary mongoGatewaySummary
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		return fmt.Errorf("parse %s JSON: %w", name, err)
+	}
+	row := mongoGatewayResultRow(cfg, summary, artifact)
+	run.Results = append(run.Results, row)
+	return nil
+}
+
+func mongoGatewayResultRow(cfg config, summary mongoGatewaySummary, artifact string) resultRow {
+	load := mongoGatewayPhaseByName(summary.Phases, "load_insert_many")
+	disk := firstMongoDisk(summary.TreeDBDiskAfterCheckpoint, summary.TreeDBDiskAfterLoad, summary.TreeDBDiskAfterMaintenance)
+	var totalPtr *uint64
+	var components map[string]uint64
+	if disk != nil && disk.TotalBytes >= 0 {
+		total := uint64(disk.TotalBytes)
+		totalPtr = &total
+		components = mongoDiskComponentBytes(disk)
+	} else if summary.TreeDBDir != "" {
+		components, _ = collectComponentBytes(summary.TreeDBDir)
+		if components != nil {
+			var total uint64
+			for _, bytes := range components {
+				total += bytes
+			}
+			totalPtr = &total
+		}
+	}
+	format := summary.TreeDBDocumentFormat
+	if format == "" {
+		format = preferredMongoFormat(cfg.formats)
+	}
+	indexes := summary.SecondaryIndexes
+	if indexes == 0 {
+		indexes = preferredMongoIndexCount(cfg.indexes)
+	}
+	return resultRow{
+		ConfigName:       fmt.Sprintf("treedb_mongo_gateway_%s_%d_indexes", sanitizeName(format), indexes),
+		WorkloadName:     "mongo_gateway_insert",
+		Engine:           "treedb",
+		Shape:            "mongo",
+		Format:           format,
+		IndexCount:       indexes,
+		DocumentCount:    summary.Documents,
+		ItemCount:        summary.Documents,
+		BatchSize:        summary.BatchSize,
+		Phase:            "post_insert",
+		MeasurementKind:  "benchmark_timed",
+		BenchmarkTimed:   true,
+		DocsPerSec:       ptrFloat(load.OpsPerSecond),
+		OpsPerSec:        ptrFloat(load.OpsPerSecond),
+		NsPerItem:        ptrFloat(load.SampledNsPerOp),
+		TotalBytes:       totalPtr,
+		BytesPerItem:     bytesPerFromPtr(totalPtr, summary.Documents),
+		ComponentBytes:   components,
+		Budgets:          cfg.budgets(),
+		PressureClaimed:  true,
+		Mmap:             extractMmapStats(summary.TreeDBStatsFinal),
+		Cache:            extractCacheStats(summary.TreeDBStatsFinal),
+		StatsAvailable:   sortedKeys(summary.TreeDBStatsFinal),
+		SourceArtifact:   artifact,
+		MeasurementNotes: "mongo_gateway_bench in-process TreeDB gateway smoke; maintenance=checkpoint, not full compaction",
+	}
+}
+
+func mongoGatewayPhaseByName(phases []mongoGatewayPhase, name string) mongoGatewayPhase {
+	for _, phase := range phases {
+		if phase.Name == name {
+			return phase
+		}
+	}
+	return mongoGatewayPhase{Name: name}
+}
+
+func firstMongoDisk(disks ...*mongoGatewayDiskUsage) *mongoGatewayDiskUsage {
+	for _, disk := range disks {
+		if disk != nil {
+			return disk
+		}
+	}
+	return nil
+}
+
+func mongoDiskComponentBytes(disk *mongoGatewayDiskUsage) map[string]uint64 {
+	if disk == nil || len(disk.Paths) == 0 {
+		return nil
+	}
+	out := make(map[string]uint64)
+	for path, bytes := range disk.Paths {
+		if bytes >= 0 {
+			out[path] = uint64(bytes)
+		}
+	}
+	return out
+}
+
+func preferredMongoFormat(formats []string) string {
+	for _, format := range formats {
+		if format == "bson" {
+			return format
+		}
+	}
+	for _, format := range formats {
+		if format == "template-v1" {
+			return format
+		}
+	}
+	if len(formats) > 0 {
+		return formats[0]
+	}
+	return "bson"
+}
+
+func preferredMongoIndexCount(indexes []int) int {
+	out := 0
+	for _, indexCount := range indexes {
+		if indexCount > out {
+			out = indexCount
+		}
+	}
+	if out > 2 {
+		return 2
+	}
+	return out
 }
 
 func (cfg config) childEnv() map[string]string {
@@ -1376,6 +1574,13 @@ func bytesPer(total uint64, count int) *float64 {
 	}
 	v := float64(total) / float64(count)
 	return &v
+}
+
+func bytesPerFromPtr(total *uint64, count int) *float64 {
+	if total == nil {
+		return nil
+	}
+	return bytesPer(*total, count)
 }
 
 func nsPerItem(t timing) *float64 {

--- a/cmd/treedb_out_of_core_smoke/main.go
+++ b/cmd/treedb_out_of_core_smoke/main.go
@@ -1317,10 +1317,10 @@ func validateSmokeRun(run *smokeRun) []guardrailCheck {
 	}
 	for _, row := range run.Results {
 		subject := row.ConfigName + "/" + row.WorkloadName
-		if strings.TrimSpace(row.Shape) == "" {
+		shape := strings.TrimSpace(row.Shape)
+		if shape == "" {
 			checks = append(checks, guardrailCheck{Severity: "error", Code: "missing_shape_label", Subject: subject, Message: "result row is missing raw/collection/Mongo shape label"})
-		}
-		if row.Shape != "raw" && row.Shape != "collection" && row.Shape != "mongo" {
+		} else if shape != "raw" && shape != "collection" && shape != "mongo" {
 			checks = append(checks, guardrailCheck{Severity: "error", Code: "invalid_shape_label", Subject: subject, Message: fmt.Sprintf("result row has unsupported shape label %q", row.Shape)})
 		}
 		if row.ItemCount <= 0 {
@@ -1336,7 +1336,7 @@ func validateSmokeRun(run *smokeRun) []guardrailCheck {
 				budget := maxInt64(row.Budgets.CacheBudgetBytes, row.Budgets.RetiredMmapBudgetBytes)
 				if budget <= 0 {
 					checks = append(checks, guardrailCheck{Severity: "error", Code: "missing_budget", Subject: subject, Message: "pressure/out-of-core guardrail row is missing configured budget bytes"})
-				} else if *row.TotalBytes <= uint64(budget*2) {
+				} else if datasetDoesNotExceedDoubleBudget(*row.TotalBytes, budget) {
 					checks = append(checks, guardrailCheck{Severity: "warning", Code: "dataset_not_larger_than_budget", Subject: subject, Message: fmt.Sprintf("dataset bytes %d do not exceed the largest configured budget %d by more than 2x", *row.TotalBytes, budget)})
 				}
 			}
@@ -1358,6 +1358,15 @@ func validateSmokeRun(run *smokeRun) []guardrailCheck {
 		checks = append(checks, guardrailCheck{Severity: "pass", Code: "ok", Message: "all out-of-core smoke guardrails passed"})
 	}
 	return checks
+}
+
+func datasetDoesNotExceedDoubleBudget(total uint64, budget int64) bool {
+	if budget <= 0 {
+		return false
+	}
+	// budget is positive int64, so doubling after conversion cannot overflow
+	// uint64: 2*math.MaxInt64 == math.MaxUint64-1.
+	return total <= uint64(budget)*2
 }
 
 func mixesRawAndCollectionWithoutLabels(rows []resultRow) bool {

--- a/cmd/treedb_out_of_core_smoke/main.go
+++ b/cmd/treedb_out_of_core_smoke/main.go
@@ -171,16 +171,17 @@ type deferredWorkload struct {
 }
 
 type rawWorkerSummary struct {
-	GeneratedAt       string            `json:"generated_at"`
-	Dir               string            `json:"dir"`
-	Keys              int               `json:"keys"`
-	BatchSize         int               `json:"batch_size"`
-	ValueSize         int               `json:"value_size"`
-	Profile           string            `json:"profile"`
-	LeafSegmentTarget int64             `json:"leaf_segment_target_bytes"`
-	Timings           map[string]timing `json:"timings"`
-	DiskUsageFinal    diskUsage         `json:"disk_usage_final"`
-	TreeDBStatsFinal  map[string]string `json:"treedb_stats_final,omitempty"`
+	GeneratedAt       string               `json:"generated_at"`
+	Dir               string               `json:"dir"`
+	Keys              int                  `json:"keys"`
+	BatchSize         int                  `json:"batch_size"`
+	ValueSize         int                  `json:"value_size"`
+	Profile           string               `json:"profile"`
+	LeafSegmentTarget int64                `json:"leaf_segment_target_bytes"`
+	Timings           map[string]timing    `json:"timings"`
+	DiskUsageFinal    diskUsage            `json:"disk_usage_final"`
+	DiskUsageByPhase  map[string]diskUsage `json:"disk_usage_by_phase,omitempty"`
+	TreeDBStatsFinal  map[string]string    `json:"treedb_stats_final,omitempty"`
 }
 
 type fixtureSummary struct {
@@ -568,9 +569,14 @@ func runRawShape(cfg config, run *smokeRun, logDir string) error {
 	if err := readJSON(jsonPath, &summary); err != nil {
 		return err
 	}
-	components, _ := collectComponentBytes(summary.Dir)
-	total := summary.DiskUsageFinal.TotalBytes
-	bytesPerItem := bytesPer(total, summary.Keys)
+	postInsertUsage := rawDiskUsageForPhase(summary, "post_insert")
+	postOverwriteUsage := rawDiskUsageForPhase(summary, "post_overwrite")
+	postInsertTotal := postInsertUsage.TotalBytes
+	postOverwriteTotal := postOverwriteUsage.TotalBytes
+	postInsertBytesPerItem := bytesPer(postInsertTotal, summary.Keys)
+	postOverwriteBytesPerItem := bytesPer(postOverwriteTotal, summary.Keys)
+	postInsertComponents := componentBytesFromDiskUsage(postInsertUsage)
+	postOverwriteComponents := componentBytesFromDiskUsage(postOverwriteUsage)
 	write := summary.Timings["batch_write"]
 	read := summary.Timings["random_read_parallel"]
 	overwrite := summary.Timings["overwrite"]
@@ -589,9 +595,9 @@ func runRawShape(cfg config, run *smokeRun, logDir string) error {
 			BenchmarkTimed:  true,
 			OpsPerSec:       ptrFloat(write.OpsPerSec),
 			NsPerItem:       nsPerItem(write),
-			TotalBytes:      &total,
-			BytesPerItem:    bytesPerItem,
-			ComponentBytes:  components,
+			TotalBytes:      &postInsertTotal,
+			BytesPerItem:    postInsertBytesPerItem,
+			ComponentBytes:  postInsertComponents,
 			Budgets:         cfg.budgets(),
 			PressureClaimed: true,
 			Mmap:            extractMmapStats(summary.TreeDBStatsFinal),
@@ -612,9 +618,9 @@ func runRawShape(cfg config, run *smokeRun, logDir string) error {
 			BenchmarkTimed:  true,
 			OpsPerSec:       ptrFloat(read.OpsPerSec),
 			NsPerItem:       nsPerItem(read),
-			TotalBytes:      &total,
-			BytesPerItem:    bytesPerItem,
-			ComponentBytes:  components,
+			TotalBytes:      &postInsertTotal,
+			BytesPerItem:    postInsertBytesPerItem,
+			ComponentBytes:  postInsertComponents,
 			Budgets:         cfg.budgets(),
 			PressureClaimed: true,
 			Mmap:            extractMmapStats(summary.TreeDBStatsFinal),
@@ -635,9 +641,9 @@ func runRawShape(cfg config, run *smokeRun, logDir string) error {
 			BenchmarkTimed:  true,
 			OpsPerSec:       ptrFloat(overwrite.OpsPerSec),
 			NsPerItem:       nsPerItem(overwrite),
-			TotalBytes:      &total,
-			BytesPerItem:    bytesPerItem,
-			ComponentBytes:  components,
+			TotalBytes:      &postOverwriteTotal,
+			BytesPerItem:    postOverwriteBytesPerItem,
+			ComponentBytes:  postOverwriteComponents,
 			Budgets:         cfg.budgets(),
 			PressureClaimed: true,
 			Mmap:            extractMmapStats(summary.TreeDBStatsFinal),
@@ -658,9 +664,9 @@ func runRawShape(cfg config, run *smokeRun, logDir string) error {
 			BenchmarkTimed:  true,
 			OpsPerSec:       ptrFloat(postOverwriteRead.OpsPerSec),
 			NsPerItem:       nsPerItem(postOverwriteRead),
-			TotalBytes:      &total,
-			BytesPerItem:    bytesPerItem,
-			ComponentBytes:  components,
+			TotalBytes:      &postOverwriteTotal,
+			BytesPerItem:    postOverwriteBytesPerItem,
+			ComponentBytes:  postOverwriteComponents,
 			Budgets:         cfg.budgets(),
 			PressureClaimed: true,
 			Mmap:            extractMmapStats(summary.TreeDBStatsFinal),
@@ -670,6 +676,26 @@ func runRawShape(cfg config, run *smokeRun, logDir string) error {
 		},
 	)
 	return nil
+}
+
+func rawDiskUsageForPhase(summary rawWorkerSummary, phase string) diskUsage {
+	if summary.DiskUsageByPhase != nil {
+		if usage, ok := summary.DiskUsageByPhase[phase]; ok {
+			return usage
+		}
+	}
+	return summary.DiskUsageFinal
+}
+
+func componentBytesFromDiskUsage(usage diskUsage) map[string]uint64 {
+	if len(usage.TopFiles) == 0 {
+		return nil
+	}
+	out := make(map[string]uint64, len(usage.TopFiles))
+	for _, file := range usage.TopFiles {
+		out[file.Path] = file.Bytes
+	}
+	return out
 }
 
 func runCollectionShape(cfg config, run *smokeRun, logDir, format string, indexes int) error {
@@ -1001,6 +1027,11 @@ func runRawWorker(cfg config) error {
 		return err
 	}
 	timings["batch_write"] = elapsedTiming(time.Since(start), cfg.RawKeys)
+	usageAfterInsert, err := directoryUsage(cfg.rawDir, cfg.RawKeys)
+	if err != nil {
+		_ = db.Close()
+		return err
+	}
 
 	start = time.Now()
 	if err := rawParallelRead(db, cfg.RawKeys, cfg.ValueSize, 0, cfg.ReadWorkers); err != nil {
@@ -1019,6 +1050,11 @@ func runRawWorker(cfg config) error {
 		return err
 	}
 	timings["overwrite"] = elapsedTiming(time.Since(start), cfg.RawKeys)
+	usageAfterOverwrite, err := directoryUsage(cfg.rawDir, cfg.RawKeys)
+	if err != nil {
+		_ = db.Close()
+		return err
+	}
 
 	start = time.Now()
 	if err := rawParallelRead(db, cfg.RawKeys, cfg.ValueSize, 1, cfg.ReadWorkers); err != nil {
@@ -1031,7 +1067,7 @@ func runRawWorker(cfg config) error {
 	if err := db.Close(); err != nil {
 		return err
 	}
-	usage, err := directoryUsage(cfg.rawDir, cfg.RawKeys)
+	usageFinal, err := directoryUsage(cfg.rawDir, cfg.RawKeys)
 	if err != nil {
 		return err
 	}
@@ -1044,8 +1080,12 @@ func runRawWorker(cfg config) error {
 		Profile:           cfg.Profile,
 		LeafSegmentTarget: cfg.LeafSegmentTargetBytes,
 		Timings:           timings,
-		DiskUsageFinal:    usage,
-		TreeDBStatsFinal:  stats,
+		DiskUsageFinal:    usageFinal,
+		DiskUsageByPhase: map[string]diskUsage{
+			"post_insert":    usageAfterInsert,
+			"post_overwrite": usageAfterOverwrite,
+		},
+		TreeDBStatsFinal: stats,
 	}
 	if err := writeJSON(cfg.rawJSONPath, summary); err != nil {
 		return err
@@ -1432,17 +1472,17 @@ func renderMarkdown(run *smokeRun) string {
 	sb.WriteString("\n")
 
 	sb.WriteString("## Component Bytes\n\n")
-	sb.WriteString("| Config | Shape | Component | Bytes |\n| --- | --- | --- | ---: |\n")
+	sb.WriteString("| Config | Shape | Phase | Component | Bytes |\n| --- | --- | --- | --- | ---: |\n")
 	seenComponents := make(map[string]struct{})
 	for _, row := range run.Results {
-		seenKey := row.ConfigName + "\x00" + row.Shape + "\x00" + row.SourceArtifact
+		seenKey := row.ConfigName + "\x00" + row.Shape + "\x00" + row.Phase + "\x00" + row.SourceArtifact
 		if _, ok := seenComponents[seenKey]; ok {
 			continue
 		}
 		seenComponents[seenKey] = struct{}{}
 		keys := sortedComponentKeys(row.ComponentBytes)
 		for _, key := range keys {
-			sb.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` | %d |\n", row.ConfigName, row.Shape, key, row.ComponentBytes[key]))
+			sb.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` | `%s` | %d |\n", row.ConfigName, row.Shape, row.Phase, key, row.ComponentBytes[key]))
 		}
 	}
 	sb.WriteString("\n")

--- a/cmd/treedb_out_of_core_smoke/main.go
+++ b/cmd/treedb_out_of_core_smoke/main.go
@@ -837,9 +837,6 @@ func mongoGatewayResultRow(cfg config, summary mongoGatewaySummary, artifact str
 		format = preferredMongoFormat(cfg.formats)
 	}
 	indexes := summary.SecondaryIndexes
-	if indexes == 0 {
-		indexes = preferredMongoIndexCount(cfg.indexes)
-	}
 	return resultRow{
 		ConfigName:       fmt.Sprintf("treedb_mongo_gateway_%s_%d_indexes", sanitizeName(format), indexes),
 		WorkloadName:     "mongo_gateway_insert",

--- a/cmd/treedb_out_of_core_smoke/main.go
+++ b/cmd/treedb_out_of_core_smoke/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"io/fs"
 	"math"
 	"os"
@@ -19,6 +18,7 @@ import (
 	"time"
 
 	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/cmd/internal/treedbstats"
 )
 
 const schemaVersion = "treedb-out-of-core-smoke/v1"
@@ -221,6 +221,9 @@ type fileSummary struct {
 func main() {
 	cfg, err := parseConfig(os.Args[1:])
 	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
 		fmt.Fprintf(os.Stderr, "treedb-out-of-core-smoke: %v\n", err)
 		os.Exit(2)
 	}
@@ -274,7 +277,6 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.internalRawWorker, "internal-raw-worker", false, "internal raw TreeDB worker mode")
 	fs.StringVar(&cfg.rawDir, "raw-dir", "", "internal raw worker DB directory")
 	fs.StringVar(&cfg.rawJSONPath, "raw-json", "", "internal raw worker JSON output path")
-	fs.SetOutput(io.Discard)
 	if err := fs.Parse(args); err != nil {
 		return cfg, err
 	}
@@ -477,9 +479,12 @@ func prepareRunDir(dir string, allowExisting bool) error {
 		return errors.New("refusing to use filesystem root as run dir")
 	}
 	entries, err := os.ReadDir(dir)
-	if err == nil && len(entries) > 0 && !allowExisting {
+	if err == nil && len(entries) > 0 {
 		if _, statErr := os.Stat(filepath.Join(dir, runDirSentinel)); statErr != nil {
-			return fmt.Errorf("%s is not an empty out-of-core smoke run dir; use -allow-existing-run-dir to append", dir)
+			return fmt.Errorf("%s is non-empty and is not an out-of-core smoke run dir", dir)
+		}
+		if !allowExisting {
+			return fmt.Errorf("%s is an existing out-of-core smoke run dir; use -allow-existing-run-dir to append", dir)
 		}
 	}
 	if err != nil && !os.IsNotExist(err) {
@@ -535,6 +540,7 @@ func runRawShape(cfg config, run *smokeRun, logDir string) error {
 	write := summary.Timings["batch_write"]
 	read := summary.Timings["random_read_parallel"]
 	overwrite := summary.Timings["overwrite"]
+	postOverwriteRead := summary.Timings["post_overwrite_random_read_parallel"]
 	run.Results = append(run.Results,
 		resultRow{
 			ConfigName:      "treedb_raw",
@@ -595,6 +601,29 @@ func runRawShape(cfg config, run *smokeRun, logDir string) error {
 			BenchmarkTimed:  true,
 			OpsPerSec:       ptrFloat(overwrite.OpsPerSec),
 			NsPerItem:       nsPerItem(overwrite),
+			TotalBytes:      &total,
+			BytesPerItem:    bytesPerItem,
+			ComponentBytes:  components,
+			Budgets:         cfg.budgets(),
+			PressureClaimed: true,
+			Mmap:            extractMmapStats(summary.TreeDBStatsFinal),
+			Cache:           extractCacheStats(summary.TreeDBStatsFinal),
+			StatsAvailable:  sortedKeys(summary.TreeDBStatsFinal),
+			SourceArtifact:  jsonPath,
+		},
+		resultRow{
+			ConfigName:      "treedb_raw",
+			WorkloadName:    "raw_post_overwrite_random_read_parallel",
+			Engine:          "treedb",
+			Shape:           "raw",
+			KeyCount:        summary.Keys,
+			ItemCount:       summary.Keys,
+			BatchSize:       summary.BatchSize,
+			Phase:           "post_overwrite_read",
+			MeasurementKind: "benchmark_timed",
+			BenchmarkTimed:  true,
+			OpsPerSec:       ptrFloat(postOverwriteRead.OpsPerSec),
+			NsPerItem:       nsPerItem(postOverwriteRead),
 			TotalBytes:      &total,
 			BytesPerItem:    bytesPerItem,
 			ComponentBytes:  components,
@@ -715,8 +744,13 @@ func runLoggedCommand(name, bin string, args []string, workDir string, env map[s
 	log.Write(stdout.Bytes())
 	log.WriteString("\n# stderr\n")
 	log.Write(stderr.Bytes())
-	if writeErr := os.WriteFile(logPath, log.Bytes(), 0o644); writeErr != nil && err == nil {
-		err = writeErr
+	if writeErr := os.WriteFile(logPath, log.Bytes(), 0o644); writeErr != nil {
+		writeErr = fmt.Errorf("write command log %s: %w", logPath, writeErr)
+		if err != nil {
+			err = errors.Join(err, writeErr)
+		} else {
+			err = writeErr
+		}
 	}
 	rec := commandRecord{
 		Name:     name,
@@ -795,7 +829,7 @@ func runRawWorker(cfg config) error {
 	}
 	timings["post_overwrite_random_read_parallel"] = elapsedTiming(time.Since(start), cfg.RawKeys)
 
-	stats := selectedTreeDBStats(db.Stats())
+	stats := treedbstats.Selected(db.Stats())
 	if err := db.Close(); err != nil {
 		return err
 	}
@@ -1006,47 +1040,6 @@ func collectComponentBytes(root string) (map[string]uint64, error) {
 	return out, err
 }
 
-func selectedTreeDBStats(stats map[string]string) map[string]string {
-	if len(stats) == 0 {
-		return nil
-	}
-	out := make(map[string]string)
-	for key, value := range stats {
-		if isSelectedTreeDBStatKey(key) {
-			out[key] = value
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func isSelectedTreeDBStatKey(key string) bool {
-	switch {
-	case key == "treedb.commit_seq":
-		return true
-	case strings.HasPrefix(key, "treedb.cache.vlog_mmap."):
-		return true
-	case strings.HasPrefix(key, "treedb.vlog.mmap"):
-		return true
-	case strings.HasPrefix(key, "treedb.cache.vlog_zombie."):
-		return true
-	case strings.HasPrefix(key, "treedb.process.memory.vlog_zombie"):
-		return true
-	case strings.HasPrefix(key, "treedb.vlog.outer_leaf_block_cache."):
-		return true
-	case strings.HasPrefix(key, "treedb.process.read_path.outer_leaf."):
-		return true
-	case strings.HasPrefix(key, "treedb.cache.vlog_generation."):
-		return true
-	case strings.HasPrefix(key, "treedb.cache.vlog_retained_prune."):
-		return true
-	default:
-		return false
-	}
-}
-
 func extractMmapStats(stats map[string]string) *mmapStats {
 	if len(stats) == 0 {
 		return nil
@@ -1188,7 +1181,7 @@ func renderMarkdown(run *smokeRun) string {
 	errorsCount, warningsCount := countChecks(run.Checks)
 	sb.WriteString(fmt.Sprintf("- Results: %d rows across raw TreeDB and collection smoke shapes.\n", len(run.Results)))
 	sb.WriteString(fmt.Sprintf("- Guardrails: %d errors, %d warnings.\n", errorsCount, warningsCount))
-	sb.WriteString("- This is a CI-sized budget-pressure smoke, not a true large-than-RAM benchmark. It intentionally uses tiny configured budgets to exercise bounded behavior before #1135/#1136 changes.\n\n")
+	sb.WriteString("- This is a CI-sized budget-pressure smoke, not a true larger-than-RAM benchmark. It intentionally uses tiny configured budgets to exercise bounded behavior before #1135/#1136 changes.\n\n")
 
 	sb.WriteString("## Benchmark Configuration\n\n")
 	sb.WriteString("| Field | Value |\n| --- | --- |\n")
@@ -1344,7 +1337,7 @@ func statFloat(stats map[string]string, keys ...string) (float64, bool) {
 
 func commandLine() []string {
 	if raw := strings.TrimSpace(os.Getenv(envCommandLine)); raw != "" {
-		return strings.Fields(raw)
+		return []string{raw}
 	}
 	return append([]string(nil), os.Args...)
 }

--- a/cmd/treedb_out_of_core_smoke/main_test.go
+++ b/cmd/treedb_out_of_core_smoke/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -87,6 +89,36 @@ func TestRenderMarkdownAndJSONPreserveShapeLabels(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"shape":"raw"`) || !strings.Contains(string(data), `"shape":"collection"`) {
 		t.Fatalf("json did not preserve shape labels: %s", data)
+	}
+}
+
+func TestPrepareRunDirRequiresSentinelAndExplicitReuse(t *testing.T) {
+	nonSmoke := t.TempDir()
+	if err := os.WriteFile(filepath.Join(nonSmoke, "unrelated.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareRunDir(nonSmoke, true); err == nil {
+		t.Fatalf("expected non-smoke non-empty dir to be rejected")
+	}
+
+	smokeDir := t.TempDir()
+	if err := prepareRunDir(smokeDir, false); err != nil {
+		t.Fatalf("prepare empty smoke dir: %v", err)
+	}
+	if err := prepareRunDir(smokeDir, false); err == nil {
+		t.Fatalf("expected existing smoke dir to require -allow-existing-run-dir")
+	}
+	if err := prepareRunDir(smokeDir, true); err != nil {
+		t.Fatalf("allow existing smoke dir: %v", err)
+	}
+}
+
+func TestCommandLinePreservesWrapperDisplayString(t *testing.T) {
+	raw := `./scripts/bench_out_of_core_smoke.sh -out-dir /tmp/has\ space`
+	t.Setenv(envCommandLine, raw)
+	got := commandLine()
+	if len(got) != 1 || got[0] != raw {
+		t.Fatalf("commandLine=%q, want single preserved display string %q", got, raw)
 	}
 }
 

--- a/cmd/treedb_out_of_core_smoke/main_test.go
+++ b/cmd/treedb_out_of_core_smoke/main_test.go
@@ -92,6 +92,56 @@ func TestRenderMarkdownAndJSONPreserveShapeLabels(t *testing.T) {
 	}
 }
 
+func TestMongoGatewayResultRowLabelsOptInWorkload(t *testing.T) {
+	cfg := testConfig()
+	summary := mongoGatewaySummary{
+		Target:               "treedb",
+		TreeDBDir:            "/tmp/treedb-mongo",
+		Documents:            100,
+		BatchSize:            25,
+		SecondaryIndexes:     2,
+		TreeDBDocumentFormat: "bson",
+		Phases: []mongoGatewayPhase{{
+			Name:           "load_insert_many",
+			Operations:     100,
+			OpsPerSecond:   5000,
+			SampledNsPerOp: 200000,
+		}},
+		TreeDBDiskAfterCheckpoint: &mongoGatewayDiskUsage{
+			TotalBytes: 6400,
+			Paths: map[string]int64{
+				"format.json": 64,
+				"index.db":    1024,
+			},
+		},
+		TreeDBStatsFinal: map[string]string{
+			"treedb.vlog.mmap_read.hits":            "3",
+			"treedb.vlog.mmap_read.fallback_readat": "1",
+		},
+	}
+	row := mongoGatewayResultRow(cfg, summary, "/tmp/mongo.json")
+	if row.Shape != "mongo" || row.Engine != "treedb" {
+		t.Fatalf("row shape/engine = %s/%s, want mongo/treedb", row.Shape, row.Engine)
+	}
+	if row.ConfigName != "treedb_mongo_gateway_bson_2_indexes" {
+		t.Fatalf("config name = %s", row.ConfigName)
+	}
+	if row.TotalBytes == nil || *row.TotalBytes != 6400 {
+		t.Fatalf("total bytes = %v", row.TotalBytes)
+	}
+	if row.BytesPerItem == nil || *row.BytesPerItem != 64 {
+		t.Fatalf("bytes per item = %v", row.BytesPerItem)
+	}
+	if row.Mmap == nil || row.Mmap.Hits != 3 || row.Mmap.FallbackReadAt != 1 {
+		t.Fatalf("mmap stats = %#v", row.Mmap)
+	}
+	run := smokeRunWithRows([]resultRow{row})
+	checks := validateSmokeRun(&run)
+	if hasErrors(checks) {
+		t.Fatalf("mongo row should pass guardrail errors, got %#v", checks)
+	}
+}
+
 func TestPrepareRunDirRequiresSentinelAndExplicitReuse(t *testing.T) {
 	nonSmoke := t.TempDir()
 	if err := os.WriteFile(filepath.Join(nonSmoke, "unrelated.txt"), []byte("x"), 0o644); err != nil {
@@ -119,6 +169,20 @@ func TestCommandLinePreservesWrapperDisplayString(t *testing.T) {
 	got := commandLine()
 	if len(got) != 1 || got[0] != raw {
 		t.Fatalf("commandLine=%q, want single preserved display string %q", got, raw)
+	}
+}
+
+func testConfig() config {
+	return config{
+		FormatsCSV:             "template-v1,bson,json",
+		IndexesCSV:             "0,1,2",
+		formats:                []string{"template-v1", "bson", "json"},
+		indexes:                []int{0, 1, 2},
+		BatchSize:              10,
+		CollectionDocs:         100,
+		CacheBudgetBytes:       32 << 10,
+		RetiredMmapBudgetBytes: 32 << 10,
+		MaxDeadMappings:        2,
 	}
 }
 

--- a/cmd/treedb_out_of_core_smoke/main_test.go
+++ b/cmd/treedb_out_of_core_smoke/main_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestValidateSmokeRunRequiresShapeLabel(t *testing.T) {
+	run := smokeRunWithRows([]resultRow{{
+		ConfigName:      "treedb_raw",
+		WorkloadName:    "raw_batch_write",
+		Engine:          "treedb",
+		ItemCount:       10,
+		TotalBytes:      ptrUint(1024),
+		BytesPerItem:    ptrFloatForTest(102.4),
+		Budgets:         testBudgets(),
+		PressureClaimed: true,
+		Mmap:            &mmapStats{},
+	}})
+	checks := validateSmokeRun(&run)
+	if !hasCheck(checks, "error", "missing_shape_label") {
+		t.Fatalf("expected missing_shape_label error, got %#v", checks)
+	}
+}
+
+func TestValidateSmokeRunRequiresItemCountForBytesPerItem(t *testing.T) {
+	run := smokeRunWithRows([]resultRow{{
+		ConfigName:      "treedb_raw",
+		WorkloadName:    "raw_batch_write",
+		Engine:          "treedb",
+		Shape:           "raw",
+		TotalBytes:      ptrUint(1024),
+		BytesPerItem:    ptrFloatForTest(102.4),
+		Budgets:         testBudgets(),
+		PressureClaimed: true,
+		Mmap:            &mmapStats{},
+	}})
+	checks := validateSmokeRun(&run)
+	if !hasCheck(checks, "error", "missing_item_count") {
+		t.Fatalf("expected missing_item_count error, got %#v", checks)
+	}
+	if !hasCheck(checks, "error", "bytes_per_item_without_count") {
+		t.Fatalf("expected bytes_per_item_without_count error, got %#v", checks)
+	}
+}
+
+func TestValidateSmokeRunWarnsWhenDatasetDoesNotExceedBudget(t *testing.T) {
+	run := smokeRunWithRows([]resultRow{validRow("treedb_raw", "raw", 100, 1024)})
+	checks := validateSmokeRun(&run)
+	if !hasCheck(checks, "warning", "dataset_not_larger_than_budget") {
+		t.Fatalf("expected dataset_not_larger_than_budget warning, got %#v", checks)
+	}
+}
+
+func TestValidateSmokeRunWarnsOnRetiredMmapBudgetOverflow(t *testing.T) {
+	row := validRow("treedb_raw", "raw", 100, 1<<20)
+	row.Mmap.DeadBytes = 128 << 10
+	run := smokeRunWithRows([]resultRow{row})
+	checks := validateSmokeRun(&run)
+	if !hasCheck(checks, "warning", "retired_mmap_budget_exceeded") {
+		t.Fatalf("expected retired_mmap_budget_exceeded warning, got %#v", checks)
+	}
+}
+
+func TestRenderMarkdownAndJSONPreserveShapeLabels(t *testing.T) {
+	run := smokeRunWithRows([]resultRow{
+		validRow("treedb_raw", "raw", 100, 1<<20),
+		validRow("treedb_template_v1_collection_2_indexes", "collection", 100, 2<<20),
+	})
+	run.Checks = validateSmokeRun(&run)
+	md := renderMarkdown(&run)
+	for _, want := range []string{
+		"`treedb_raw` | `raw`",
+		"`treedb_template_v1_collection_2_indexes` | `collection`",
+		"make bench-out-of-core-smoke",
+		"`cache_budget_bytes`",
+		"`retired_mmap_budget_bytes`",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("markdown missing %q\n%s", want, md)
+		}
+	}
+	data, err := json.Marshal(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"shape":"raw"`) || !strings.Contains(string(data), `"shape":"collection"`) {
+		t.Fatalf("json did not preserve shape labels: %s", data)
+	}
+}
+
+func smokeRunWithRows(rows []resultRow) smokeRun {
+	return smokeRun{
+		SchemaVersion: schemaVersion,
+		GeneratedAt:   "2026-05-01T00:00:00Z",
+		RunDir:        "/tmp/smoke",
+		Worktree:      "/repo",
+		Branch:        "test",
+		Commit:        "deadbeef",
+		CommandLine:   []string{"./scripts/bench_out_of_core_smoke.sh"},
+		Config: smokeConfig{
+			RawKeys:        100,
+			CollectionDocs: 100,
+			BatchSize:      10,
+			Formats:        []string{"template-v1"},
+			Indexes:        []int{0, 1, 2},
+			Budgets:        testBudgets(),
+		},
+		Results: rows,
+	}
+}
+
+func validRow(configName, shape string, items int, total uint64) resultRow {
+	return resultRow{
+		ConfigName:      configName,
+		WorkloadName:    "workload",
+		Engine:          "treedb",
+		Shape:           shape,
+		ItemCount:       items,
+		TotalBytes:      &total,
+		BytesPerItem:    bytesPer(total, items),
+		Budgets:         testBudgets(),
+		PressureClaimed: true,
+		Mmap:            &mmapStats{Hits: 1, DeadMappingCap: 2},
+	}
+}
+
+func testBudgets() budgets {
+	return budgets{
+		CacheBudgetBytes:       32 << 10,
+		RetiredMmapBudgetBytes: 32 << 10,
+		MaxDeadMappings:        2,
+	}
+}
+
+func hasCheck(checks []guardrailCheck, severity, code string) bool {
+	for _, check := range checks {
+		if check.Severity == severity && check.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func ptrUint(v uint64) *uint64 {
+	return &v
+}
+
+func ptrFloatForTest(v float64) *float64 {
+	return &v
+}

--- a/cmd/treedb_out_of_core_smoke/main_test.go
+++ b/cmd/treedb_out_of_core_smoke/main_test.go
@@ -156,6 +156,30 @@ func TestMongoGatewayResultRowLabelsOptInWorkload(t *testing.T) {
 	}
 }
 
+func TestMongoGatewayResultRowPreservesZeroIndexShape(t *testing.T) {
+	cfg := testConfig()
+	summary := mongoGatewaySummary{
+		Target:               "treedb",
+		Documents:            100,
+		BatchSize:            25,
+		SecondaryIndexes:     0,
+		TreeDBDocumentFormat: "bson",
+		Phases: []mongoGatewayPhase{{
+			Name:         "load_insert_many",
+			Operations:   100,
+			OpsPerSecond: 5000,
+		}},
+		TreeDBDiskAfterCheckpoint: &mongoGatewayDiskUsage{TotalBytes: 6400},
+		TreeDBStatsFinal: map[string]string{
+			"treedb.vlog.mmap_read.hits": "3",
+		},
+	}
+	row := mongoGatewayResultRow(cfg, summary, "/tmp/mongo.json")
+	if row.IndexCount != 0 || row.ConfigName != "treedb_mongo_gateway_bson_0_indexes" {
+		t.Fatalf("row index shape = %d/%s, want 0-index config", row.IndexCount, row.ConfigName)
+	}
+}
+
 func TestRawDiskUsageForPhasePrefersPhaseSnapshot(t *testing.T) {
 	summary := rawWorkerSummary{
 		DiskUsageFinal: diskUsage{TotalBytes: 300},

--- a/cmd/treedb_out_of_core_smoke/main_test.go
+++ b/cmd/treedb_out_of_core_smoke/main_test.go
@@ -156,6 +156,27 @@ func TestMongoGatewayResultRowLabelsOptInWorkload(t *testing.T) {
 	}
 }
 
+func TestRawDiskUsageForPhasePrefersPhaseSnapshot(t *testing.T) {
+	summary := rawWorkerSummary{
+		DiskUsageFinal: diskUsage{TotalBytes: 300},
+		DiskUsageByPhase: map[string]diskUsage{
+			"post_insert":    {TotalBytes: 100, TopFiles: []fileSummary{{Path: "index.db", Bytes: 80}}},
+			"post_overwrite": {TotalBytes: 200},
+		},
+	}
+	insert := rawDiskUsageForPhase(summary, "post_insert")
+	if insert.TotalBytes != 100 {
+		t.Fatalf("post_insert bytes=%d want 100", insert.TotalBytes)
+	}
+	components := componentBytesFromDiskUsage(insert)
+	if components["index.db"] != 80 {
+		t.Fatalf("components=%v want index.db=80", components)
+	}
+	if got := rawDiskUsageForPhase(summary, "unknown").TotalBytes; got != 300 {
+		t.Fatalf("fallback bytes=%d want final 300", got)
+	}
+}
+
 func TestPrepareRunDirRequiresSentinelAndExplicitReuse(t *testing.T) {
 	nonSmoke := t.TempDir()
 	if err := os.WriteFile(filepath.Join(nonSmoke, "unrelated.txt"), []byte("x"), 0o644); err != nil {

--- a/cmd/treedb_out_of_core_smoke/main_test.go
+++ b/cmd/treedb_out_of_core_smoke/main_test.go
@@ -24,6 +24,9 @@ func TestValidateSmokeRunRequiresShapeLabel(t *testing.T) {
 	if !hasCheck(checks, "error", "missing_shape_label") {
 		t.Fatalf("expected missing_shape_label error, got %#v", checks)
 	}
+	if hasCheck(checks, "error", "invalid_shape_label") {
+		t.Fatalf("empty shape should not also report invalid_shape_label: %#v", checks)
+	}
 }
 
 func TestValidateSmokeRunRequiresItemCountForBytesPerItem(t *testing.T) {
@@ -52,6 +55,17 @@ func TestValidateSmokeRunWarnsWhenDatasetDoesNotExceedBudget(t *testing.T) {
 	checks := validateSmokeRun(&run)
 	if !hasCheck(checks, "warning", "dataset_not_larger_than_budget") {
 		t.Fatalf("expected dataset_not_larger_than_budget warning, got %#v", checks)
+	}
+}
+
+func TestValidateSmokeRunLargeBudgetComparisonDoesNotOverflow(t *testing.T) {
+	row := validRow("treedb_raw", "raw", 100, 1)
+	row.Budgets.CacheBudgetBytes = 1 << 62
+	row.Budgets.RetiredMmapBudgetBytes = 1
+	run := smokeRunWithRows([]resultRow{row})
+	checks := validateSmokeRun(&run)
+	if !hasCheck(checks, "warning", "dataset_not_larger_than_budget") {
+		t.Fatalf("expected dataset_not_larger_than_budget warning for huge budget, got %#v", checks)
 	}
 }
 

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -205,6 +205,25 @@ Notes / gotchas:
 - Dict training is CPU-heavy and is disabled by default.
 - Trained dictionaries are persisted in `dictdb/` and used to decode values after reopen.
 
+### Leaf value-log mmap growth
+
+TreeDB maps current writable `leaf_vlog` files ahead to a bounded segment-scale
+target so recently appended outer leaf pages stay on the mmap read path without
+remapping on every append.
+
+- `TREEDB_VLOG_CURRENT_WRITABLE_MMAP_TARGET_BYTES` sets the map-ahead target
+  for current writable value-log files. The default is 32 MiB, matching the
+  default leaf segment scale. Set to `0` to map only the current file size.
+- `TREEDB_VLOG_MAX_DEAD_MAPPINGS` still caps retained stale mappings for safety;
+  frequent current-writable remaps can hit this cap and force `ReadAt` fallback.
+
+Useful stats:
+- `treedb.vlog.mmap_current_writable_map_target_bytes`
+- `treedb.vlog.mmap_remaps`
+- `treedb.vlog.mmap_dead_mappings`
+- `treedb.vlog.mmap_read.fallback_readat`
+- `treedb.vlog.mmap_read.miss_dead_mapping_cap`
+
 ### Leaf key compression (`Options.LeafPrefixCompression`)
 
 TreeDB can compress keys stored in **leaf pages** using a front-coding scheme

--- a/docs/benchmarks/out_of_core_smoke.md
+++ b/docs/benchmarks/out_of_core_smoke.md
@@ -1,0 +1,88 @@
+# TreeDB Out-of-Core Smoke Harness
+
+This harness is the small implementation slice for issue #1138. It is a
+CI-sized budget-pressure smoke, not a true larger-than-RAM benchmark. The goal is
+to give mmap/cache work a repeatable guardrail before deeper changes in #1135
+and #1136.
+
+## Run
+
+```bash
+make bench-out-of-core-smoke
+```
+
+Equivalent direct command:
+
+```bash
+./scripts/bench_out_of_core_smoke.sh
+```
+
+Useful overrides:
+
+```bash
+./scripts/bench_out_of_core_smoke.sh \
+  -raw-keys 10000 \
+  -collection-docs 3000 \
+  -batch-size 500 \
+  -formats template-v1,bson,json \
+  -indexes 0,1,2 \
+  -cache-budget-bytes 32768 \
+  -retired-mmap-budget-bytes 32768 \
+  -max-dead-mappings 2
+```
+
+The script creates a timestamped run directory under `/tmp` unless `-out-dir` is
+provided.
+
+## Outputs
+
+Each run writes:
+
+- `out_of_core_smoke_summary.md`
+- `out_of_core_smoke_results.json`
+- `out_of_core_smoke_results.ndjson`
+- per-workload command logs under `logs/`
+- kept raw TreeDB and collection fixture directories
+
+Every row labels the workload shape as `raw`, `collection`, or `mongo` so raw
+TreeDB rows cannot be confused with collection rows.
+
+## What The Smoke Covers
+
+The default run includes:
+
+- raw TreeDB batch write, parallel read, overwrite, and post-overwrite read
+- collection inserts with 0, 1, and 2 indexes
+- collection document formats `template-v1`, `bson`, and `json`
+- small `leaf_vlog` segment targets to force churn
+- tiny reported cache/retired-mmap budgets
+- a low `TREEDB_VLOG_MAX_DEAD_MAPPINGS` child-process setting
+- selected mmap/cache stats from TreeDB
+
+Mongo gateway coverage is intentionally deferred to #1141 by default because it
+mixes client, protocol, gateway, BSON conversion, and storage costs. Use
+`-include-mongo` only after that path has a focused implementation.
+
+## Guardrails
+
+The report warns or fails for:
+
+- missing raw/collection/Mongo shape labels
+- missing document/key count when bytes-per-item is reported
+- pressure/out-of-core rows without total bytes or budgets
+- datasets that do not exceed the configured budget by more than 2x
+- TreeDB rows without mmap counters
+- dead mmap bytes exceeding the configured retired-mmap smoke budget
+
+The smoke harness intentionally uses configured budgets rather than relying on
+physical RAM exhaustion. True large local and larger-than-memory validation is
+split into #1139, #1140, and #1141.
+
+## Relationship To Follow-Up Work
+
+- #1135 should use this harness to prove mmap lifetime changes remain bounded
+  and avoid the current-leaf `ReadAt` cliff.
+- #1136 should use this harness to prove any current-leaf cache is bounded and
+  eviction-safe.
+- #1132 should use the later Mongo/large-dataset tracks after the storage
+  read-path baseline is cleaner.

--- a/docs/benchmarks/out_of_core_smoke.md
+++ b/docs/benchmarks/out_of_core_smoke.md
@@ -60,8 +60,10 @@ The default run includes:
 - selected mmap/cache stats from TreeDB
 
 Mongo gateway coverage is intentionally deferred to #1141 by default because it
-mixes client, protocol, gateway, BSON conversion, and storage costs. Use
-`-include-mongo` only after that path has a focused implementation.
+mixes client, protocol, gateway, BSON conversion, and storage costs. Passing
+`-include-mongo` adds one tiny in-process TreeDB Mongo-gateway smoke row labeled
+with `shape=mongo`; keep it opt-in unless the run is explicitly checking gateway
+behavior.
 
 ## Guardrails
 

--- a/docs/benchmarks/out_of_core_smoke.md
+++ b/docs/benchmarks/out_of_core_smoke.md
@@ -31,8 +31,8 @@ Useful overrides:
   -max-dead-mappings 2
 ```
 
-The script creates a timestamped run directory under `/tmp` unless `-out-dir` is
-provided.
+The script creates a timestamped run directory under the host `os.TempDir()`
+location unless `-out-dir` is provided.
 
 ## Outputs
 

--- a/scripts/bench_out_of_core_smoke.sh
+++ b/scripts/bench_out_of_core_smoke.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+cmd_display="./scripts/bench_out_of_core_smoke.sh"
+for arg in "$@"; do
+	printf -v quoted '%q' "$arg"
+	cmd_display+=" $quoted"
+done
+export TREEDB_OUT_OF_CORE_SMOKE_COMMAND="$cmd_display"
+
+if [[ "${USE_BUILT_BIN:-0}" == "1" ]]; then
+	make treedb-out-of-core-smoke-bin >/dev/null
+	exec "$repo_root/bin/treedb-out-of-core-smoke" "$@"
+fi
+
+exec go run ./cmd/treedb_out_of_core_smoke "$@"


### PR DESCRIPTION
## Summary

- maps current writable `leaf_vlog` files ahead to a bounded segment-scale target instead of remapping exactly to the current file size
- adds `TREEDB_VLOG_CURRENT_WRITABLE_MMAP_TARGET_BYTES` plus raw/cached stats so benchmark harnesses can see the active target
- extends mmap safety tests to prove appends within the target do not churn dead mappings or fall back to `ReadAt`
- includes the new mmap stats in `mongo_gateway_bench` selected TreeDB stats and documents the tuning knob

This is the first pragmatic #1135 implementation slice. It avoids the measured current-leaf `ReadAt` cliff without changing `ReadUnsafe` ownership semantics. A fuller leased/epoch mmap view API can remain a follow-up if profiling still shows unsafe-view reclamation as material.

## Local validation

- `go test ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/caching ./cmd/mongo_gateway_bench ./cmd/treedb_out_of_core_smoke ./cmd/collection_load_fixture`
- `go test -race ./TreeDB/internal/valuelog -run 'Test(MmapSafety_Concurrent_Remap|CurrentWritableMmapTargetMapsAheadWithinLeafSegment)' -count 1`
- `make docs-check`
- `go test ./...`
- `git diff --check`

## Benchmark / smoke evidence

Out-of-core smoke with the new 32 MiB default map-ahead target:

```bash
OUT=/tmp/gomap_1135_smoke_default32_$(date +%s)
./scripts/bench_out_of_core_smoke.sh -out-dir "$OUT" -raw-keys 1000 -collection-docs 500 -batch-size 100
```

Run directory: `/tmp/gomap_1135_smoke_default32_1777675107`

- 12 rows across raw TreeDB and collections
- template-v1/BSON/JSON collection formats
- 0/1/2 collection indexes
- guardrails: 0 errors, 0 warnings
- reported collection rows had `ReadAt fallback = 0`

Mongo update-heavy repro, default 32 MiB map-ahead vs disabled target:

| run | load ops/s | update ops/s | concurrent update ops/s | remaps | dead mappings | dead bytes | hits | fallback | dead-cap | target bytes |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| default32 | 346189 | 3793 | 6592 | 1 | 0 | 0 | 186026 | 0 | 0 | 33554432 |
| target0 | 334350 | 2578 | 3536 | 67 | 66 | 37331311 | 5758 | 196317 | 193374 | 0 |

Commands:

```bash
OUT=/tmp/gomap_1135_mongo_default32_$(date +%s)
go run ./cmd/mongo_gateway_bench \
  -target treedb -documents 5000 -batch-size 500 -insert-producers 4 \
  -reads 1000 -range-reads 100 -updates 1000 \
  -concurrent-readers 4 -concurrent-reads 2000 \
  -concurrent-writers 8 -concurrent-writes 2000 \
  -secondary-indexes 2 -update-indexed-field \
  -treedb-document-format bson -treedb-maintenance checkpoint \
  -profile-dir "$OUT/profiles" -profile-heap-gc -format json > "$OUT/result.json"

OUT=/tmp/gomap_1135_mongo_target0_stats_$(date +%s)
TREEDB_VLOG_CURRENT_WRITABLE_MMAP_TARGET_BYTES=0 \
go run ./cmd/mongo_gateway_bench \
  -target treedb -documents 5000 -batch-size 500 -insert-producers 4 \
  -reads 1000 -range-reads 100 -updates 1000 \
  -concurrent-readers 4 -concurrent-reads 2000 \
  -concurrent-writers 8 -concurrent-writes 2000 \
  -secondary-indexes 2 -update-indexed-field \
  -treedb-document-format bson -treedb-maintenance checkpoint \
  -profile-dir "$OUT/profiles" -profile-heap-gc -format json > "$OUT/result.json"
```
