### PR TITLE
Reclaim retired mmap regions after reader epochs

### DIFF
--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -96,6 +96,7 @@ type File struct {
 	remapMu        sync.Mutex
 	remapRequested atomic.Bool
 
+	mmapActiveReaders      atomic.Int64
 	deadMappings           [][]byte
 	deadMappedBytes        atomic.Uint64
 	remapCount             atomic.Uint64
@@ -484,7 +485,10 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 	if err := f.ensureCurrentWritableReadable(); err != nil {
 		return nil, err
 	}
-	if val, err, ok := f.readViaMmap(ptr, verifyCRC); ok {
+	f.beginMmapRead()
+	val, err, ok := f.readViaMmap(ptr, verifyCRC)
+	f.endMmapRead()
+	if ok {
 		f.mmapReadHits.Add(1)
 		if err != nil {
 			return nil, err
@@ -523,12 +527,21 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 	if err := f.ensureCurrentWritableReadable(); err != nil {
 		return nil, err
 	}
-	if val, err, ok := f.readViaMmapView(ptr, verifyCRC); ok {
-		f.mmapReadHits.Add(1)
-		if err != nil {
-			return nil, err
+	readViaMmapViewOwned := func() ([]byte, error, bool) {
+		f.beginMmapRead()
+		defer f.endMmapRead()
+		val, err, ok := f.readViaMmapView(ptr, verifyCRC)
+		if !ok || err != nil {
+			return nil, err, ok
 		}
 		val, _, _, err = f.maybeDecodeLeafLogPayloadTo(val, nil)
+		if err != nil {
+			return nil, err, true
+		}
+		return cloneValueLogBytes(val), nil, true
+	}
+	if val, err, ok := readViaMmapViewOwned(); ok {
+		f.mmapReadHits.Add(1)
 		if err != nil {
 			return nil, err
 		}
@@ -536,12 +549,8 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 	}
 	if !f.usesPersistentMmap() {
 		if f.tryEnableSealedLazyMmap() {
-			if val, err, ok := f.readViaMmapView(ptr, verifyCRC); ok {
+			if val, err, ok := readViaMmapViewOwned(); ok {
 				f.mmapReadHits.Add(1)
-				if err != nil {
-					return nil, err
-				}
-				val, _, _, err = f.maybeDecodeLeafLogPayloadTo(val, nil)
 				if err != nil {
 					return nil, err
 				}
@@ -556,12 +565,8 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 	data, _ := f.mmapData.Load().([]byte)
 	if !deadMappingsCapExhausted(f.deadMappingsCount.Load(), len(data)) {
 		f.remapToFileSize()
-		if val, err, ok := f.readViaMmapView(ptr, verifyCRC); ok {
+		if val, err, ok := readViaMmapViewOwned(); ok {
 			f.mmapReadHits.Add(1)
-			if err != nil {
-				return nil, err
-			}
-			val, _, _, err = f.maybeDecodeLeafLogPayloadTo(val, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -584,33 +589,38 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 	if err := f.ensureCurrentWritableReadable(); err != nil {
 		return nil, false, err
 	}
-	if val, usedDst, err, ok := f.readViaMmapViewTo(ptr, verifyCRC, dst); ok {
-		f.mmapReadHits.Add(1)
-		if err != nil {
-			return nil, false, err
+	readViaMmapViewToOwned := func() ([]byte, bool, error, bool) {
+		f.beginMmapRead()
+		defer f.endMmapRead()
+		val, usedDst, err, ok := f.readViaMmapViewTo(ptr, verifyCRC, dst)
+		if !ok || err != nil {
+			return nil, false, err, ok
 		}
 		val, compactUsedDst, compactDecoded, err := f.maybeDecodeLeafLogPayloadTo(val, dst)
 		if err != nil {
-			return nil, false, err
+			return nil, false, err, true
 		}
 		if compactDecoded {
-			return val, compactUsedDst, nil
+			usedDst = compactUsedDst
+		}
+		if !usedDst {
+			val = cloneValueLogBytes(val)
+		}
+		return val, usedDst, nil, true
+	}
+	if val, usedDst, err, ok := readViaMmapViewToOwned(); ok {
+		f.mmapReadHits.Add(1)
+		if err != nil {
+			return nil, false, err
 		}
 		return val, usedDst, nil
 	}
 	if !f.usesPersistentMmap() {
 		if f.tryEnableSealedLazyMmap() {
-			if val, usedDst, err, ok := f.readViaMmapViewTo(ptr, verifyCRC, dst); ok {
+			if val, usedDst, err, ok := readViaMmapViewToOwned(); ok {
 				f.mmapReadHits.Add(1)
 				if err != nil {
 					return nil, false, err
-				}
-				val, compactUsedDst, compactDecoded, err := f.maybeDecodeLeafLogPayloadTo(val, dst)
-				if err != nil {
-					return nil, false, err
-				}
-				if compactDecoded {
-					return val, compactUsedDst, nil
 				}
 				return val, usedDst, nil
 			}
@@ -638,17 +648,10 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 	data, _ := f.mmapData.Load().([]byte)
 	if !deadMappingsCapExhausted(f.deadMappingsCount.Load(), len(data)) {
 		f.remapToFileSize()
-		if val, usedDst, err, ok := f.readViaMmapViewTo(ptr, verifyCRC, dst); ok {
+		if val, usedDst, err, ok := readViaMmapViewToOwned(); ok {
 			f.mmapReadHits.Add(1)
 			if err != nil {
 				return nil, false, err
-			}
-			val, compactUsedDst, compactDecoded, err := f.maybeDecodeLeafLogPayloadTo(val, dst)
-			if err != nil {
-				return nil, false, err
-			}
-			if compactDecoded {
-				return val, compactUsedDst, nil
 			}
 			return val, usedDst, nil
 		}
@@ -845,7 +848,10 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 	if err := f.ensureCurrentWritableReadable(); err != nil {
 		return nil, err
 	}
-	if val, err, ok := f.readViaMmapAppend(ptr, verifyCRC, dst); ok {
+	f.beginMmapRead()
+	val, err, ok := f.readViaMmapAppend(ptr, verifyCRC, dst)
+	f.endMmapRead()
+	if ok {
 		f.mmapReadHits.Add(1)
 		return val, err
 	}

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -456,8 +456,8 @@ func TestManagerPromoteCurrentWritable_RetiresLeafCurrentMmapBeforeSealedFallbac
 	if data, _ := f1.mmapData.Load().([]byte); len(data) != 0 {
 		t.Fatalf("expected prior current leaf mmap to be retired after promotion, len=%d", len(data))
 	}
-	if dead := f1.deadMappingsCount.Load(); dead == 0 {
-		t.Fatalf("expected retired current leaf mapping to move into deadMappings")
+	if dead := f1.deadMappingsCount.Load(); dead != 0 {
+		t.Fatalf("expected retired current leaf mapping to be reclaimed after readers drain, got=%d", dead)
 	}
 
 	got, err = mgr.ReadUnsafe(ptr1)
@@ -712,8 +712,8 @@ func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlready
 	if data, _ := f2.mmapData.Load().([]byte); len(data) != 0 {
 		t.Fatalf("expected demoted second segment to retire active mmap once sealed budget is full, len=%d", len(data))
 	}
-	if dead := f2.deadMappingsCount.Load(); dead == 0 {
-		t.Fatalf("expected demoted second segment to move prior current mmap into deadMappings")
+	if dead := f2.deadMappingsCount.Load(); dead != 0 {
+		t.Fatalf("expected demoted second segment mmap to be reclaimed after readers drain, got=%d", dead)
 	}
 	currentSegs, _, sealedSegs, _, deadMappings, _ := mgr.MmapResidencyStats()
 	if currentSegs != 0 {
@@ -722,8 +722,8 @@ func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenSealedBudgetAlready
 	if sealedSegs != 1 {
 		t.Fatalf("expected sealed mmap count to stay capped at one, sealedSegs=%d", sealedSegs)
 	}
-	if deadMappings == 0 {
-		t.Fatalf("expected deadMappings to record the retired second segment")
+	if deadMappings != 0 {
+		t.Fatalf("expected no retained dead mappings after reader epochs drain, got=%d", deadMappings)
 	}
 }
 
@@ -793,8 +793,8 @@ func TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenFileGrewPastSealedB
 	if data, _ := f1.mmapData.Load().([]byte); len(data) != 0 {
 		t.Fatalf("expected demoted id1 mapping to retire once sealed file size exceeds byte cap, len=%d", len(data))
 	}
-	if dead := f1.deadMappingsCount.Load(); dead == 0 {
-		t.Fatalf("expected demoted id1 mapping to be retained in deadMappings after retirement")
+	if dead := f1.deadMappingsCount.Load(); dead != 0 {
+		t.Fatalf("expected demoted id1 mapping to be reclaimed after readers drain, got=%d", dead)
 	}
 }
 

--- a/TreeDB/internal/valuelog/mmap_safety_test.go
+++ b/TreeDB/internal/valuelog/mmap_safety_test.go
@@ -23,11 +23,9 @@ func ptrInMapping(view, mapping []byte) bool {
 	return vp >= mp && vp < end
 }
 
-// TestMmapSafety_ZeroCopy_Remap verifies that holding a zero-copy view of an
-// older mmap remains safe even after the File remaps due to growth.
-//
-// Without retaining dead mappings, this test would crash with SIGSEGV.
-func TestMmapSafety_ZeroCopy_Remap(t *testing.T) {
+// TestMmapSafety_ReadUnsafeOwnedAcrossRemap verifies that ReadUnsafe callers do
+// not receive a slice tied to an mmap that can later be retired.
+func TestMmapSafety_ReadUnsafeOwnedAcrossRemap(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap not supported on windows")
 	}
@@ -68,8 +66,8 @@ func TestMmapSafety_ZeroCopy_Remap(t *testing.T) {
 		t.Fatalf("view1 mismatch")
 	}
 	oldMap, _ := f.mmapData.Load().([]byte)
-	if !ptrInMapping(view1, oldMap) {
-		t.Fatalf("expected view1 to reference mmap (zero-copy)")
+	if ptrInMapping(view1, oldMap) {
+		t.Fatalf("expected ReadUnsafe to return owned bytes, not mmap backing")
 	}
 
 	// Grow the file enough to force a remap on the next read.
@@ -95,13 +93,90 @@ func TestMmapSafety_ZeroCopy_Remap(t *testing.T) {
 	if string(view2) != "v2" {
 		t.Fatalf("view2 mismatch")
 	}
-	if len(f.deadMappings) == 0 {
-		t.Fatalf("expected at least one dead mapping after remap")
+	if len(f.deadMappings) != 0 {
+		t.Fatalf("expected retired mapping to be reclaimed after ReadUnsafe returns, got=%d", len(f.deadMappings))
 	}
 
 	// Access view1 again (should not crash).
 	if !bytes.Equal(view1, val1) {
 		t.Fatalf("view1 corrupted after remap")
+	}
+}
+
+func TestMmapSafety_RetiredMappingsReclaimedAfterReaderEpoch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	old := enableCurrentWritableMmap
+	enableCurrentWritableMmap = true
+	defer func() { enableCurrentWritableMmap = old }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-l0-000001.log")
+	fileID := uint32(123)
+
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	val1 := bytes.Repeat([]byte("v1"), 1024)
+	ptr1, err := w.Append(0, nil, 1, val1)
+	if err != nil {
+		t.Fatalf("Append 1: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush 1: %v", err)
+	}
+
+	f, err := openFile(path, fileID, nil, nil, templ.DecodeOptions{}, nil)
+	if err != nil {
+		t.Fatalf("openFile: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.ReadUnsafe(ptr1, false); err != nil {
+		t.Fatalf("ReadUnsafe 1: %v", err)
+	}
+	oldMap, _ := f.mmapData.Load().([]byte)
+	if len(oldMap) == 0 {
+		t.Fatalf("expected initial mmap")
+	}
+
+	f.beginMmapRead()
+	blob := bytes.Repeat([]byte("X"), 1024*1024)
+	for i := 0; i < 10; i++ {
+		if _, err := w.Append(0, nil, uint64(2+i), blob); err != nil {
+			t.Fatalf("Append grow %d: %v", i, err)
+		}
+	}
+	val2 := []byte("v2")
+	ptr2, err := w.Append(0, nil, 999, val2)
+	if err != nil {
+		t.Fatalf("Append 2: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush 2: %v", err)
+	}
+	if got := oldMap[0]; got == 0xff {
+		t.Fatalf("impossible old-map sentinel: %x", got)
+	}
+
+	if _, err := f.ReadUnsafe(ptr2, false); err != nil {
+		f.endMmapRead()
+		t.Fatalf("ReadUnsafe 2: %v", err)
+	}
+	if dead := f.deadMappingsCount.Load(); dead == 0 {
+		f.endMmapRead()
+		t.Fatalf("expected retired mapping to remain while reader epoch is active")
+	}
+	f.endMmapRead()
+	if dead := f.deadMappingsCount.Load(); dead != 0 {
+		t.Fatalf("expected retired mapping to be reclaimed after reader epoch drains, got=%d", dead)
+	}
+	if bytes := f.deadMappedBytes.Load(); bytes != 0 {
+		t.Fatalf("expected retired mapping bytes to be reclaimed, got=%d", bytes)
 	}
 }
 

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -37,8 +37,9 @@ const readViaMmapViewPrefixCacheEnabled = false
 // vm.max_map_count. Unless explicitly configured, the effective cap can grow
 // with mapped size up to maxAdaptiveDeadMappings. Set <= 0 to disable the cap.
 //
-// Each remap retains the previous mapping until the file is closed to avoid
-// use-after-unmap with concurrent readers.
+// Each remap retires the previous mapping and keeps it alive until active mmap
+// readers drain, avoiding use-after-unmap without retaining stale mappings for
+// the lifetime of the file.
 var MaxDeadMappings = defaultMaxDeadMappings
 
 const (
@@ -180,6 +181,51 @@ func effectiveMaxDeadMappings(mappedLen int) int {
 func deadMappingsCapExhausted(deadMappingsCount uint64, mappedLen int) bool {
 	maxMappings := effectiveMaxDeadMappings(mappedLen)
 	return maxMappings > 0 && deadMappingsCount >= uint64(maxMappings)
+}
+
+func (f *File) beginMmapRead() {
+	if f != nil {
+		f.mmapActiveReaders.Add(1)
+	}
+}
+
+func (f *File) endMmapRead() {
+	if f == nil {
+		return
+	}
+	if active := f.mmapActiveReaders.Add(-1); active == 0 {
+		f.reclaimDeadMappings()
+	}
+}
+
+func (f *File) reclaimDeadMappings() {
+	if f == nil || f.mmapActiveReaders.Load() != 0 {
+		return
+	}
+	f.remapMu.Lock()
+	defer f.remapMu.Unlock()
+	f.reclaimDeadMappingsLocked()
+}
+
+func (f *File) reclaimDeadMappingsLocked() {
+	if f == nil || f.mmapActiveReaders.Load() != 0 || len(f.deadMappings) == 0 {
+		return
+	}
+	for _, b := range f.deadMappings {
+		_ = munmap(b)
+	}
+	f.deadMappings = nil
+	f.deadMappingsCount.Store(0)
+	f.deadMappedBytes.Store(0)
+}
+
+func cloneValueLogBytes(src []byte) []byte {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
 }
 
 func (f *File) usesPersistentMmap() bool {
@@ -355,6 +401,7 @@ func (f *File) retirePersistentMmapToDeadLocked() bool {
 	f.deadMappingsCount.Add(1)
 	f.deadMappedBytes.Add(uint64(len(data)))
 	f.mmapData.Store([]byte(nil))
+	f.reclaimDeadMappingsLocked()
 	return true
 }
 
@@ -443,6 +490,7 @@ func (f *File) remapToFileSizeWithPolicy(requirePersistent bool) {
 	// If we have already hit the dead-mapping cap, we cannot remap again without
 	// risking use-after-unmap for callers holding unsafe mmap views. Avoid the
 	// per-call Stat allocation when reads keep missing the current mapping.
+	f.reclaimDeadMappingsLocked()
 	data, _ := f.mmapData.Load().([]byte)
 	if data != nil && deadMappingsCapExhausted(f.deadMappingsCount.Load(), len(data)) {
 		return
@@ -488,6 +536,7 @@ func (f *File) remapToFileSizeWithPolicy(requirePersistent bool) {
 	}
 	f.mmapData.Store(b)
 	f.remapCount.Add(1)
+	f.reclaimDeadMappingsLocked()
 }
 
 func (f *File) readViaMmap(ptr page.ValuePtr, verifyCRC bool) ([]byte, error, bool) {
@@ -872,6 +921,11 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 			}
 			return decoded, false, nil, true
 		}
+		if cap(dst) >= len(payload) {
+			out := dst[:len(payload)]
+			copy(out, payload)
+			return out, true, nil, true
+		}
 		return payload, false, nil, true
 	}
 
@@ -963,7 +1017,16 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		if srcStart < 0 || srcEnd < srcStart || srcEnd > len(payload) {
 			return nil, false, ErrCorrupt, true
 		}
-		val, _, err := decodeTemplatePayload(payload[srcStart:srcEnd])
+		src := payload[srcStart:srcEnd]
+		if f.templateLookup == nil || !templ.IsEncodedPayload(src) {
+			if cap(dst) >= len(src) {
+				out := dst[:len(src)]
+				copy(out, src)
+				return out, true, nil, true
+			}
+			return src, false, nil, true
+		}
+		val, _, err := decodeTemplatePayload(src)
 		if err != nil {
 			return nil, false, err, true
 		}


### PR DESCRIPTION
## Summary

- add per-file mmap reader epochs around mmap-backed reads
- reclaim retired mmap mappings once active readers drain instead of retaining them until file close
- make ReadUnsafe return owned bytes so callers cannot hold a slice into a reclaimed mmap region
- keep ReadUnsafeTo efficient by copying direct mmap payloads into caller-provided dst when available
- update mmap safety tests to cover active reader epochs and reclamation

## Validation

- go test ./TreeDB/internal/valuelog -count 1
- go test ./TreeDB/db ./TreeDB/internal/valuelog ./TreeDB/caching ./TreeDB/tree ./TreeDB/zipper -count 1

## Stack

Stacked on #1144 / codex/current-leaf-page-cache-1136.
