### PR TITLE
Collections: add write-domain contention stats

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -270,6 +270,36 @@ type CollectionSecondaryRunStats struct {
 	Build         time.Duration
 }
 
+// CollectionManagerStats captures aggregate write-domain counters for a
+// CollectionManager. The counters are process-local observability; they are
+// not persisted with collection metadata.
+type CollectionManagerStats struct {
+	Domains                       int
+	PendingDocuments              int
+	PendingBytes                  int64
+	PendingRootRuns               int
+	MutationLockCalls             uint64
+	MutationLockWait              time.Duration
+	MutationLockHold              time.Duration
+	IndexedStageBatches           uint64
+	IndexedStageDocs              uint64
+	IndexedStageBytes             uint64
+	IndexedStageRootRuns          uint64
+	IndexedAutoFlushes            uint64
+	IndexedFlushCalls             uint64
+	IndexedFlushErrors            uint64
+	IndexedFlushDocs              uint64
+	IndexedFlushBytes             uint64
+	IndexedFlushRootRuns          uint64
+	IndexedFlushRoots             uint64
+	IndexedFlushDuration          time.Duration
+	UpdateCombineRequests         uint64
+	UpdateCombineBatches          uint64
+	UpdateCombineBatchedRequests  uint64
+	UpdateCombineFallbackRequests uint64
+	UpdateCombineQueueDepthMax    uint64
+}
+
 // DocumentRecord is one primary collection record returned by ScanDocuments.
 // ID and Document are cloned byte slices owned by the caller.
 type DocumentRecord struct {
@@ -434,6 +464,27 @@ type collectionWriteDomain struct {
 	bufferedBytes    int64
 	rootRunCount     int
 	writeGeneration  uint64
+
+	mutationLockCalls             atomic.Uint64
+	mutationLockWaitTotalNs       atomic.Uint64
+	mutationLockHoldTotalNs       atomic.Uint64
+	indexedStageBatches           atomic.Uint64
+	indexedStageDocs              atomic.Uint64
+	indexedStageBytes             atomic.Uint64
+	indexedStageRootRuns          atomic.Uint64
+	indexedAutoFlushes            atomic.Uint64
+	indexedFlushCalls             atomic.Uint64
+	indexedFlushErrors            atomic.Uint64
+	indexedFlushDocs              atomic.Uint64
+	indexedFlushBytes             atomic.Uint64
+	indexedFlushRootRuns          atomic.Uint64
+	indexedFlushRoots             atomic.Uint64
+	indexedFlushDurationTotalNs   atomic.Uint64
+	updateCombineRequests         atomic.Uint64
+	updateCombineBatches          atomic.Uint64
+	updateCombineBatchedRequests  atomic.Uint64
+	updateCombineFallbackRequests atomic.Uint64
+	updateCombineQueueDepthMax    atomic.Uint64
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -496,6 +547,228 @@ func cloneCollectionInsertStats(stats CollectionInsertStats) CollectionInsertSta
 		stats.SecondaryRuns = append([]CollectionSecondaryRunStats(nil), stats.SecondaryRuns...)
 	}
 	return stats
+}
+
+// Stats returns aggregate process-local collection write-domain metrics with
+// stable TreeDB benchmark key names.
+func (m *CollectionManager) Stats() map[string]string {
+	stats := m.StatsSnapshot()
+	if stats == (CollectionManagerStats{}) {
+		return nil
+	}
+	out := make(map[string]string, 32)
+	out["treedb.collections.write_domain.domains"] = fmt.Sprintf("%d", stats.Domains)
+	out["treedb.collections.write_domain.pending_docs"] = fmt.Sprintf("%d", stats.PendingDocuments)
+	out["treedb.collections.write_domain.pending_bytes"] = fmt.Sprintf("%d", stats.PendingBytes)
+	out["treedb.collections.write_domain.pending_root_runs"] = fmt.Sprintf("%d", stats.PendingRootRuns)
+	out["treedb.collections.write_domain.mutation_lock.calls_total"] = fmt.Sprintf("%d", stats.MutationLockCalls)
+	out["treedb.collections.write_domain.mutation_lock.wait_ns_total"] = fmt.Sprintf("%d", stats.MutationLockWait.Nanoseconds())
+	out["treedb.collections.write_domain.mutation_lock.hold_ns_total"] = fmt.Sprintf("%d", stats.MutationLockHold.Nanoseconds())
+	if denom := stats.MutationLockWait + stats.MutationLockHold; denom > 0 {
+		out["treedb.collections.write_domain.mutation_lock.wait_share_pct"] = fmt.Sprintf("%.3f", 100*float64(stats.MutationLockWait)/float64(denom))
+	}
+	out["treedb.collections.write_domain.indexed_stage.batches_total"] = fmt.Sprintf("%d", stats.IndexedStageBatches)
+	out["treedb.collections.write_domain.indexed_stage.docs_total"] = fmt.Sprintf("%d", stats.IndexedStageDocs)
+	out["treedb.collections.write_domain.indexed_stage.bytes_total"] = fmt.Sprintf("%d", stats.IndexedStageBytes)
+	out["treedb.collections.write_domain.indexed_stage.root_runs_total"] = fmt.Sprintf("%d", stats.IndexedStageRootRuns)
+	out["treedb.collections.write_domain.indexed_stage.auto_flushes_total"] = fmt.Sprintf("%d", stats.IndexedAutoFlushes)
+	out["treedb.collections.write_domain.indexed_flush.calls_total"] = fmt.Sprintf("%d", stats.IndexedFlushCalls)
+	out["treedb.collections.write_domain.indexed_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedFlushErrors)
+	out["treedb.collections.write_domain.indexed_flush.docs_total"] = fmt.Sprintf("%d", stats.IndexedFlushDocs)
+	out["treedb.collections.write_domain.indexed_flush.bytes_total"] = fmt.Sprintf("%d", stats.IndexedFlushBytes)
+	out["treedb.collections.write_domain.indexed_flush.root_runs_total"] = fmt.Sprintf("%d", stats.IndexedFlushRootRuns)
+	out["treedb.collections.write_domain.indexed_flush.roots_total"] = fmt.Sprintf("%d", stats.IndexedFlushRoots)
+	out["treedb.collections.write_domain.indexed_flush.duration_ns_total"] = fmt.Sprintf("%d", stats.IndexedFlushDuration.Nanoseconds())
+	out["treedb.collections.write_domain.update_combine.requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineRequests)
+	out["treedb.collections.write_domain.update_combine.batches_total"] = fmt.Sprintf("%d", stats.UpdateCombineBatches)
+	out["treedb.collections.write_domain.update_combine.batched_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineBatchedRequests)
+	out["treedb.collections.write_domain.update_combine.fallback_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineFallbackRequests)
+	out["treedb.collections.write_domain.update_combine.queue_depth_max"] = fmt.Sprintf("%d", stats.UpdateCombineQueueDepthMax)
+	return out
+}
+
+// StatsSnapshot returns aggregate process-local collection write-domain
+// counters in typed form for tests and in-process diagnostics.
+func (m *CollectionManager) StatsSnapshot() CollectionManagerStats {
+	if m == nil {
+		return CollectionManagerStats{}
+	}
+	m.domainMu.RLock()
+	domains := make([]*collectionWriteDomain, 0, len(m.domains))
+	for _, domain := range m.domains {
+		if domain != nil {
+			domains = append(domains, domain)
+		}
+	}
+	m.domainMu.RUnlock()
+
+	var stats CollectionManagerStats
+	stats.Domains = len(domains)
+	for _, domain := range domains {
+		stats.add(domain.statsSnapshot())
+	}
+	return stats
+}
+
+func (s *CollectionManagerStats) add(other CollectionManagerStats) {
+	if s == nil {
+		return
+	}
+	s.PendingDocuments = saturatingAddNonNegativeInt(s.PendingDocuments, other.PendingDocuments)
+	s.PendingBytes = saturatingAddNonNegativeInt64(s.PendingBytes, other.PendingBytes)
+	s.PendingRootRuns = saturatingAddNonNegativeInt(s.PendingRootRuns, other.PendingRootRuns)
+	s.MutationLockCalls += other.MutationLockCalls
+	s.MutationLockWait += other.MutationLockWait
+	s.MutationLockHold += other.MutationLockHold
+	s.IndexedStageBatches += other.IndexedStageBatches
+	s.IndexedStageDocs += other.IndexedStageDocs
+	s.IndexedStageBytes += other.IndexedStageBytes
+	s.IndexedStageRootRuns += other.IndexedStageRootRuns
+	s.IndexedAutoFlushes += other.IndexedAutoFlushes
+	s.IndexedFlushCalls += other.IndexedFlushCalls
+	s.IndexedFlushErrors += other.IndexedFlushErrors
+	s.IndexedFlushDocs += other.IndexedFlushDocs
+	s.IndexedFlushBytes += other.IndexedFlushBytes
+	s.IndexedFlushRootRuns += other.IndexedFlushRootRuns
+	s.IndexedFlushRoots += other.IndexedFlushRoots
+	s.IndexedFlushDuration += other.IndexedFlushDuration
+	s.UpdateCombineRequests += other.UpdateCombineRequests
+	s.UpdateCombineBatches += other.UpdateCombineBatches
+	s.UpdateCombineBatchedRequests += other.UpdateCombineBatchedRequests
+	s.UpdateCombineFallbackRequests += other.UpdateCombineFallbackRequests
+	if other.UpdateCombineQueueDepthMax > s.UpdateCombineQueueDepthMax {
+		s.UpdateCombineQueueDepthMax = other.UpdateCombineQueueDepthMax
+	}
+}
+
+func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
+	if domain == nil {
+		return CollectionManagerStats{}
+	}
+	var stats CollectionManagerStats
+	domain.mu.RLock()
+	stats.PendingDocuments = domain.count
+	stats.PendingBytes = domain.bufferedBytes
+	stats.PendingRootRuns = bufferedIndexedRootRunCount(domain)
+	domain.mu.RUnlock()
+
+	stats.MutationLockCalls = domain.mutationLockCalls.Load()
+	stats.MutationLockWait = durationFromAtomicNs(domain.mutationLockWaitTotalNs.Load())
+	stats.MutationLockHold = durationFromAtomicNs(domain.mutationLockHoldTotalNs.Load())
+	stats.IndexedStageBatches = domain.indexedStageBatches.Load()
+	stats.IndexedStageDocs = domain.indexedStageDocs.Load()
+	stats.IndexedStageBytes = domain.indexedStageBytes.Load()
+	stats.IndexedStageRootRuns = domain.indexedStageRootRuns.Load()
+	stats.IndexedAutoFlushes = domain.indexedAutoFlushes.Load()
+	stats.IndexedFlushCalls = domain.indexedFlushCalls.Load()
+	stats.IndexedFlushErrors = domain.indexedFlushErrors.Load()
+	stats.IndexedFlushDocs = domain.indexedFlushDocs.Load()
+	stats.IndexedFlushBytes = domain.indexedFlushBytes.Load()
+	stats.IndexedFlushRootRuns = domain.indexedFlushRootRuns.Load()
+	stats.IndexedFlushRoots = domain.indexedFlushRoots.Load()
+	stats.IndexedFlushDuration = durationFromAtomicNs(domain.indexedFlushDurationTotalNs.Load())
+	stats.UpdateCombineRequests = domain.updateCombineRequests.Load()
+	stats.UpdateCombineBatches = domain.updateCombineBatches.Load()
+	stats.UpdateCombineBatchedRequests = domain.updateCombineBatchedRequests.Load()
+	stats.UpdateCombineFallbackRequests = domain.updateCombineFallbackRequests.Load()
+	stats.UpdateCombineQueueDepthMax = domain.updateCombineQueueDepthMax.Load()
+	return stats
+}
+
+func durationFromAtomicNs(ns uint64) time.Duration {
+	const maxDurationNs = uint64(1<<63 - 1)
+	if ns > maxDurationNs {
+		return time.Duration(maxDurationNs)
+	}
+	return time.Duration(ns)
+}
+
+func durationToAtomicNs(d time.Duration) uint64 {
+	if d <= 0 {
+		return 0
+	}
+	return uint64(d.Nanoseconds())
+}
+
+func atomicMaxUint64(value *atomic.Uint64, candidate uint64) {
+	if value == nil {
+		return
+	}
+	for {
+		current := value.Load()
+		if candidate <= current || value.CompareAndSwap(current, candidate) {
+			return
+		}
+	}
+}
+
+func (domain *collectionWriteDomain) observeMutationLock(wait, hold time.Duration) {
+	if domain == nil {
+		return
+	}
+	domain.mutationLockCalls.Add(1)
+	domain.mutationLockWaitTotalNs.Add(durationToAtomicNs(wait))
+	domain.mutationLockHoldTotalNs.Add(durationToAtomicNs(hold))
+}
+
+func (domain *collectionWriteDomain) observeIndexedStage(docs int, bytes int64, rootRuns int) {
+	if domain == nil {
+		return
+	}
+	domain.indexedStageBatches.Add(1)
+	if docs > 0 {
+		domain.indexedStageDocs.Add(uint64(docs))
+	}
+	if bytes > 0 {
+		domain.indexedStageBytes.Add(uint64(bytes))
+	}
+	if rootRuns > 0 {
+		domain.indexedStageRootRuns.Add(uint64(rootRuns))
+	}
+}
+
+func (domain *collectionWriteDomain) observeIndexedFlush(docs int, bytes int64, rootRuns, roots int, duration time.Duration, err error) {
+	if domain == nil {
+		return
+	}
+	domain.indexedFlushCalls.Add(1)
+	if err != nil {
+		domain.indexedFlushErrors.Add(1)
+	}
+	if docs > 0 {
+		domain.indexedFlushDocs.Add(uint64(docs))
+	}
+	if bytes > 0 {
+		domain.indexedFlushBytes.Add(uint64(bytes))
+	}
+	if rootRuns > 0 {
+		domain.indexedFlushRootRuns.Add(uint64(rootRuns))
+	}
+	if roots > 0 {
+		domain.indexedFlushRoots.Add(uint64(roots))
+	}
+	domain.indexedFlushDurationTotalNs.Add(durationToAtomicNs(duration))
+}
+
+func (domain *collectionWriteDomain) observeUpdateCombineRequest(queueDepth int) {
+	if domain == nil {
+		return
+	}
+	domain.updateCombineRequests.Add(1)
+	if queueDepth > 0 {
+		atomicMaxUint64(&domain.updateCombineQueueDepthMax, uint64(queueDepth))
+	}
+}
+
+func (domain *collectionWriteDomain) observeUpdateCombineBatch(requests int, fallback bool) {
+	if domain == nil || requests <= 0 {
+		return
+	}
+	domain.updateCombineBatches.Add(1)
+	domain.updateCombineBatchedRequests.Add(uint64(requests))
+	if fallback {
+		domain.updateCombineFallbackRequests.Add(uint64(requests))
+	}
 }
 
 func (m *CollectionManager) writeDomainForCollection(name string) *collectionWriteDomain {
@@ -566,8 +839,8 @@ func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain)
 		return nil
 	}
 	collection := &Collection{db: db, writeDomain: domain}
-	domain.mutationMu.Lock()
-	defer domain.mutationMu.Unlock()
+	unlockMutation := lockCollectionDomainMutation(domain)
+	defer unlockMutation()
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	return collection.flushBufferedWritesLocked(domain)
@@ -577,8 +850,22 @@ func (c *Collection) lockMutation() func() {
 	if c == nil || c.writeDomain == nil {
 		return func() {}
 	}
-	c.writeDomain.mutationMu.Lock()
-	return c.writeDomain.mutationMu.Unlock
+	return lockCollectionDomainMutation(c.writeDomain)
+}
+
+func lockCollectionDomainMutation(domain *collectionWriteDomain) func() {
+	if domain == nil {
+		return func() {}
+	}
+	lockStart := time.Now()
+	domain.mutationMu.Lock()
+	holdStart := time.Now()
+	wait := holdStart.Sub(lockStart)
+	return func() {
+		hold := time.Since(holdStart)
+		domain.mutationMu.Unlock()
+		domain.observeMutationLock(wait, hold)
+	}
 }
 
 func (m *CollectionManager) CreateCollection(meta *CollectionMeta) (*CollectionMeta, error) {
@@ -1421,6 +1708,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	}
 	uniqueIndexes := uniqueCollectionIndexNames(catalog.meta)
 	var stagedBytes int64
+	stagedRootRuns := 0
 	for _, run := range plan.runs {
 		var uniqueValueTable memtable.Table
 		var uniquePrefixes [][]byte
@@ -1440,6 +1728,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 		domain.rootPolicies[run.name] = run.storagePolicy
 		domain.rootRuns[run.name] = append(domain.rootRuns[run.name], run.table)
 		domain.rootRunCount = saturatingAddNonNegativeInt(domain.rootRunCount, 1)
+		stagedRootRuns++
 		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, run.table.Size())
 		if run.kind == collectionRootPrimary {
 			if domain.primaryIDIndex == nil {
@@ -1479,8 +1768,10 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.count += len(plan.resultIDs)
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
 	domain.writeGeneration++
+	domain.observeIndexedStage(len(plan.resultIDs), stagedBytes, stagedRootRuns)
 	c.meta = catalog.meta
 	if shouldFlushBufferedIndexedWrites(domain, catalog.meta.Options) {
+		domain.indexedAutoFlushes.Add(1)
 		flushStart := time.Now()
 		if err := c.flushBufferedIndexedLocked(domain); err != nil {
 			rollbackBufferedIndexedDomain(domain, checkpoint)
@@ -2414,7 +2705,7 @@ func (it *bufferedRootRunsIterator) advanceItem(item bufferedRootRunHeapItem) {
 	}
 }
 
-func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) error {
+func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (err error) {
 	if domain == nil || domain.count == 0 || len(domain.rootRuns) == 0 {
 		return nil
 	}
@@ -2457,6 +2748,14 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) e
 		domain.bufferedBytes = 0
 		return nil
 	}
+	flushDocs := domain.count
+	flushBytes := domain.bufferedBytes
+	flushRootRuns := bufferedIndexedRootRunCount(domain)
+	flushRoots := len(rootNames)
+	flushStart := time.Now()
+	defer func() {
+		domain.observeIndexedFlush(flushDocs, flushBytes, flushRootRuns, flushRoots, time.Since(flushStart), err)
+	}()
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
 	baseRootIDs := make(map[string]uint64, len(rootNames))
@@ -3626,6 +3925,9 @@ func (combiner *collectionUpdateCombiner) enqueue(req collectionUpdateCombineReq
 	}
 	select {
 	case combiner.requests <- req:
+		if combiner.domain != nil {
+			combiner.domain.observeUpdateCombineRequest(len(combiner.requests))
+		}
 		return true
 	default:
 		return false
@@ -3770,10 +4072,16 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 	defer combiner.running.Store(false)
 	defer func() {
 		if recovered := recover(); recovered != nil {
+			if combiner.domain != nil {
+				combiner.domain.observeUpdateCombineBatch(len(batch), false)
+			}
 			completeUpdateCombineBatchWithError(batch, collectionUpdatePanicError("combiner", recovered))
 		}
 	}()
 	if len(batch) == 1 || collectionUpdateCombineHasDuplicateIDs(batch) || !collectionUpdateCombineSameCollection(batch) {
+		if combiner.domain != nil {
+			combiner.domain.observeUpdateCombineBatch(len(batch), true)
+		}
 		for _, req := range batch {
 			completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
 		}
@@ -3788,6 +4096,9 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 	}
 	results, batched, err := batch[0].collection.UpdateBatchIfNoSecondaryUniqueIndexChanges(items)
 	if !batched && err == nil {
+		if combiner.domain != nil {
+			combiner.domain.observeUpdateCombineBatch(len(batch), true)
+		}
 		for _, req := range batch {
 			completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
 		}
@@ -3795,14 +4106,26 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 	}
 	if err != nil {
 		if completeUpdateCombineBatchWithItemFallback(batch, err) {
+			if combiner.domain != nil {
+				combiner.domain.observeUpdateCombineBatch(len(batch), true)
+			}
 			return
+		}
+		if combiner.domain != nil {
+			combiner.domain.observeUpdateCombineBatch(len(batch), false)
 		}
 		completeUpdateCombineBatchWithError(batch, err)
 		return
 	}
 	if len(results) != len(batch) {
+		if combiner.domain != nil {
+			combiner.domain.observeUpdateCombineBatch(len(batch), false)
+		}
 		completeUpdateCombineBatchWithError(batch, fmt.Errorf("collections: update combiner result count %d for batch size %d", len(results), len(batch)))
 		return
+	}
+	if combiner.domain != nil {
+		combiner.domain.observeUpdateCombineBatch(len(batch), false)
 	}
 	for i, req := range batch {
 		result := results[i]
@@ -5147,8 +5470,10 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.count += modifiedCount
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
 	domain.writeGeneration++
+	domain.observeIndexedStage(modifiedCount, stagedBytes, stagedRootRuns)
 	c.meta = plan.meta
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
+		domain.indexedAutoFlushes.Add(1)
 		if err := c.flushBufferedIndexedLocked(domain); err != nil {
 			if shouldAutoFlushAfterAdding {
 				rollbackBufferedIndexedDomain(domain, checkpoint)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -530,6 +530,88 @@ func TestCollectionInsertBatchStatsExposeIndexRunShape(t *testing.T) {
 	}
 }
 
+func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com"}`),
+			[]byte(`{"email":"grace@example.com"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	stats := mgr.StatsSnapshot()
+	if got, want := stats.Domains, 1; got != want {
+		t.Fatalf("stats domains=%d want %d", got, want)
+	}
+	if got, want := stats.PendingDocuments, 2; got != want {
+		t.Fatalf("stats pending documents=%d want %d", got, want)
+	}
+	if stats.PendingBytes == 0 {
+		t.Fatal("stats pending bytes=0 want positive")
+	}
+	if stats.PendingRootRuns == 0 {
+		t.Fatal("stats pending root runs=0 want positive")
+	}
+	if got, want := stats.IndexedStageBatches, uint64(1); got != want {
+		t.Fatalf("stats indexed stage batches=%d want %d", got, want)
+	}
+	if got, want := stats.IndexedStageDocs, uint64(2); got != want {
+		t.Fatalf("stats indexed stage docs=%d want %d", got, want)
+	}
+	if stats.IndexedStageBytes == 0 || stats.IndexedStageRootRuns == 0 {
+		t.Fatalf("stats indexed stage bytes/root-runs=%d/%d want positive", stats.IndexedStageBytes, stats.IndexedStageRootRuns)
+	}
+	if stats.MutationLockCalls == 0 {
+		t.Fatal("stats mutation lock calls=0 want positive")
+	}
+	exported := mgr.Stats()
+	for _, key := range []string{
+		"treedb.collections.write_domain.pending_docs",
+		"treedb.collections.write_domain.indexed_stage.batches_total",
+		"treedb.collections.write_domain.mutation_lock.calls_total",
+	} {
+		if exported[key] == "" {
+			t.Fatalf("exported stats missing %s from %#v", key, exported)
+		}
+	}
+
+	if err := mgr.FlushAll(); err != nil {
+		t.Fatalf("flush all: %v", err)
+	}
+	stats = mgr.StatsSnapshot()
+	if got := stats.PendingDocuments; got != 0 {
+		t.Fatalf("stats pending documents after flush=%d want 0", got)
+	}
+	if got, want := stats.IndexedFlushCalls, uint64(1); got != want {
+		t.Fatalf("stats indexed flush calls=%d want %d", got, want)
+	}
+	if got, want := stats.IndexedFlushDocs, uint64(2); got != want {
+		t.Fatalf("stats indexed flush docs=%d want %d", got, want)
+	}
+	if stats.IndexedFlushBytes == 0 || stats.IndexedFlushRootRuns == 0 || stats.IndexedFlushRoots == 0 {
+		t.Fatalf("stats indexed flush bytes/root-runs/roots=%d/%d/%d want positive", stats.IndexedFlushBytes, stats.IndexedFlushRootRuns, stats.IndexedFlushRoots)
+	}
+}
+
 func writeStandaloneValueLogSegment(t *testing.T, valueDir string, lane, seq uint32, value []byte) string {
 	t.Helper()
 	if err := os.MkdirAll(valueDir, 0o755); err != nil {

--- a/cmd/internal/treedbstats/selected.go
+++ b/cmd/internal/treedbstats/selected.go
@@ -43,6 +43,8 @@ func isSelectedKey(key string) bool {
 		return true
 	case strings.HasPrefix(key, "treedb.publish.ordered_root_delta_group."):
 		return true
+	case strings.HasPrefix(key, "treedb.collections.write_domain."):
+		return true
 	case strings.HasPrefix(key, "treedb.publish.watermark."):
 		return true
 	default:

--- a/cmd/internal/treedbstats/selected_test.go
+++ b/cmd/internal/treedbstats/selected_test.go
@@ -5,11 +5,12 @@ import "testing"
 func TestSelectedKeepsSharedTreeDBStats(t *testing.T) {
 	stats := map[string]string{
 		"treedb.commit_seq": "7",
-		"treedb.process.read_path.outer_leaf.cache.hits":         "11",
-		"treedb.vlog.mmap_read.fallback_readat":                  "13",
-		"treedb.publish.ordered_root_delta_group.calls_total":    "19",
-		"treedb.publish.watermark.latency_p99_ms":                "23",
-		"treedb.unrelated_stat_that_should_not_leave_the_helper": "17",
+		"treedb.process.read_path.outer_leaf.cache.hits":            "11",
+		"treedb.vlog.mmap_read.fallback_readat":                     "13",
+		"treedb.publish.ordered_root_delta_group.calls_total":       "19",
+		"treedb.publish.watermark.latency_p99_ms":                   "23",
+		"treedb.collections.write_domain.indexed_flush.calls_total": "29",
+		"treedb.unrelated_stat_that_should_not_leave_the_helper":    "17",
 	}
 	got := Selected(stats)
 	for _, key := range []string{
@@ -18,6 +19,7 @@ func TestSelectedKeepsSharedTreeDBStats(t *testing.T) {
 		"treedb.vlog.mmap_read.fallback_readat",
 		"treedb.publish.ordered_root_delta_group.calls_total",
 		"treedb.publish.watermark.latency_p99_ms",
+		"treedb.collections.write_domain.indexed_flush.calls_total",
 	} {
 		if got[key] == "" {
 			t.Fatalf("Selected missing %s from %#v", key, got)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1685,7 +1685,7 @@ func collectAfterLoadStats(ctx context.Context, cfg config, target *benchTarget,
 		}
 		result.TreeDBDiskAfterLoad = &snapshot
 		if target.db != nil {
-			result.TreeDBStatsAfterLoad = selectedTreeDBStats(target.db.Stats())
+			result.TreeDBStatsAfterLoad = collectLiveTreeDBStats(target)
 		}
 		return nil
 	}
@@ -1706,7 +1706,7 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 				}
 			}
 			if target.db != nil {
-				result.TreeDBStatsFinal = selectedTreeDBStats(target.db.Stats())
+				result.TreeDBStatsFinal = collectLiveTreeDBStats(target)
 			}
 			return nil
 		}
@@ -1726,7 +1726,7 @@ func collectFinalStats(ctx context.Context, cfg config, target *benchTarget, res
 		}
 		result.TreeDBDiskAfterCheckpoint = &snapshot
 		if target.db != nil {
-			stats := selectedTreeDBStats(target.db.Stats())
+			stats := collectLiveTreeDBStats(target)
 			result.TreeDBStatsAfterCheckpoint = stats
 			result.TreeDBStatsFinal = stats
 		}
@@ -1822,7 +1822,7 @@ func collectTreeDBStatsFromDir(cfg config, target *benchTarget) (map[string]stri
 		return nil, nil
 	}
 	if target.db != nil {
-		return selectedTreeDBStats(target.db.Stats()), nil
+		return collectLiveTreeDBStats(target), nil
 	}
 	if target.treedbDir == "" {
 		return nil, nil
@@ -1835,6 +1835,24 @@ func collectTreeDBStatsFromDir(cfg config, target *benchTarget) (map[string]stri
 	}
 	defer func() { _ = cleanup() }()
 	return selectedTreeDBStats(db.Stats()), nil
+}
+
+func collectLiveTreeDBStats(target *benchTarget) map[string]string {
+	if target == nil {
+		return nil
+	}
+	stats := make(map[string]string)
+	if target.db != nil {
+		for key, value := range target.db.Stats() {
+			stats[key] = value
+		}
+	}
+	if target.collections != nil {
+		for key, value := range target.collections.Stats() {
+			stats[key] = value
+		}
+	}
+	return selectedTreeDBStats(stats)
 }
 
 func mergeTreeDBPersistentStats(base, refreshed map[string]string) map[string]string {
@@ -1875,7 +1893,7 @@ func appendTreeDBMaintenanceStep(ctx context.Context, target *benchTarget, resul
 		if err := target.db.Checkpoint(); err != nil {
 			return fmt.Errorf("checkpoint after %s: %w", name, err)
 		}
-		result.TreeDBStatsFinal = selectedTreeDBStats(target.db.Stats())
+		result.TreeDBStatsFinal = collectLiveTreeDBStats(target)
 	}
 	snapshot, err := collectDiskSnapshot(target.treedbDir)
 	if err != nil {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -127,6 +127,7 @@ func TestSelectedTreeDBStatsKeepsExpectedKeys(t *testing.T) {
 		{name: "exact commit seq", key: "treedb.commit_seq", want: true},
 		{name: "ordered root prefix", key: "treedb.publish.ordered_root_delta_group.calls_total", want: true},
 		{name: "watermark prefix", key: "treedb.publish.watermark.latency_p99_ms", want: true},
+		{name: "collection write-domain prefix", key: "treedb.collections.write_domain.indexed_flush.calls_total", want: true},
 		{name: "non match", key: "treedb.vlog.reads_total", want: false},
 	}
 	for _, tt := range tests {
@@ -148,16 +149,18 @@ func TestSelectedTreeDBStats(t *testing.T) {
 	}
 	got := selectedTreeDBStats(map[string]string{
 		"treedb.commit_seq": "11",
-		"treedb.publish.ordered_root_delta_group.calls_total":    "3",
-		"treedb.publish.ordered_root_delta_group.latency_p99_ms": "1.5",
-		"treedb.publish.watermark.latency_p99_ms":                "2.5",
-		"treedb.vlog.reads_total":                                "7",
+		"treedb.publish.ordered_root_delta_group.calls_total":       "3",
+		"treedb.publish.ordered_root_delta_group.latency_p99_ms":    "1.5",
+		"treedb.publish.watermark.latency_p99_ms":                   "2.5",
+		"treedb.collections.write_domain.indexed_flush.calls_total": "4",
+		"treedb.vlog.reads_total":                                   "7",
 	})
 	want := map[string]string{
 		"treedb.commit_seq": "11",
-		"treedb.publish.ordered_root_delta_group.calls_total":    "3",
-		"treedb.publish.ordered_root_delta_group.latency_p99_ms": "1.5",
-		"treedb.publish.watermark.latency_p99_ms":                "2.5",
+		"treedb.publish.ordered_root_delta_group.calls_total":       "3",
+		"treedb.publish.ordered_root_delta_group.latency_p99_ms":    "1.5",
+		"treedb.publish.watermark.latency_p99_ms":                   "2.5",
+		"treedb.collections.write_domain.indexed_flush.calls_total": "4",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("selected stats=%v want %v", got, want)


### PR DESCRIPTION
## Summary

Part of #1132. This is the first instrumentation slice before changing collection write-back semantics.

- add aggregate `CollectionManager` write-domain stats for mutation-lock wait/hold, pending indexed buffers, indexed staging, indexed flushes, and update-combiner batching/fallbacks
- surface `treedb.collections.write_domain.*` through the shared TreeDB stats allowlist
- include collection write-domain stats in `mongo_gateway_bench` TreeDB stats artifacts next to existing ordered-root publish counters

## Validation

- `go test ./TreeDB/collections -run 'TestCollectionManagerStatsExposeIndexedWriteDomainMetrics|TestCollectionInsertBatchStatsExposeIndexRunShape' -count=1`\n- `go test ./cmd/internal/treedbstats ./cmd/mongo_gateway_bench -run 'TestSelected|TestSelectedTreeDBStats' -count=1`\n- `go test ./TreeDB/collections -count=1`\n- `go test ./cmd/internal/treedbstats ./cmd/mongo_gateway_bench -count=1`\n- `go test ./cmd/collection_bench_matrix ./cmd/collection_load_fixture -count=1`\n- `go vet ./TreeDB/collections ./cmd/internal/treedbstats ./cmd/mongo_gateway_bench`\n- smoke artifact: `go run ./cmd/mongo_gateway_bench -target treedb -documents 1000 -batch-size 100 -secondary-indexes 2 -reads 0 -range-reads 0 -updates 0 -deletes 0 -treedb-maintenance none -format json > /tmp/mongo_gateway_bench_1132_stats.json`\n- focused benchmark: `TREEDB_COLLECTION_BENCH_BATCH_SIZE=128 TREEDB_COLLECTION_MIXED_SEED_DOCS=1024 TREEDB_COLLECTION_MIXED_WRITE_BATCH_SIZE=64 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionMixedReadWriteScaling(Primary|SecondaryUnique)$' -benchtime=20000x -count=1`\n\n## Smoke Stats Example\n\nThe smoke JSON now includes collection-domain stats such as:\n\n```text\ntreedb.collections.write_domain.indexed_stage.batches_total=10\ntreedb.collections.write_domain.indexed_stage.docs_total=1000\ntreedb.collections.write_domain.indexed_stage.root_runs_total=31\ntreedb.collections.write_domain.indexed_flush.calls_total=1\ntreedb.collections.write_domain.indexed_flush.docs_total=1000\ntreedb.collections.write_domain.indexed_flush.root_runs_total=31\ntreedb.collections.write_domain.indexed_flush.roots_total=4\ntreedb.collections.write_domain.mutation_lock.calls_total=14\n```\n\nExisting ordered-root counters remain in the same artifact, e.g. `treedb.publish.ordered_root_delta_group.calls_total=3` and `treedb.publish.ordered_root_delta_group.roots_total=4`.\n\n## Benchmark Smoke\n\nFocused mixed read/write smoke on this branch:\n\n| Shape | readers/writers | reader ops/sec | writer docs/sec |\n| --- | ---: | ---: | ---: |\n| primary | 1/1 | 138,645 | 415,412 |\n| primary | 4/1 | 425,171 | 421,489 |\n| primary | 8/2 | 529,859 | 336,472 |\n| secondary unique | 1/1 | 177,283 | 464,329 |\n| secondary unique | 4/1 | 220,887 | 443,521 |\n| secondary unique | 8/2 | 273,848 | 413,702 |\n