### PR TITLE
Collections: buffer singleton safe updates

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -334,7 +334,7 @@ type CollectionOptions struct {
 	// comparisons; indexed collections use memtables by default.
 	DisableIndexedWriteMemtables bool `json:"disable_indexed_write_memtables,omitempty"`
 	// BufferedIndexedWrites is normalized metadata describing whether indexed
-	// insert and safe update root deltas are staged in the collection write
+	// inserts and safe update root deltas are staged in the collection write
 	// domain before Flush/Close or auto-flush. Staged writes are visible to
 	// primary and secondary reads on the same manager, but durability remains at
 	// the flush boundary, matching the existing no-index buffered path.
@@ -4081,7 +4081,8 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 			completeUpdateCombineBatchWithError(batch, collectionUpdatePanicError("combiner", recovered))
 		}
 	}()
-	if (combiner.domain != nil && combiner.domain.closingWrites.Load()) ||
+	if combiner.domain == nil ||
+		combiner.domain.closingWrites.Load() ||
 		collectionUpdateCombineHasDuplicateIDs(batch) ||
 		!collectionUpdateCombineSameCollection(batch) {
 		if combiner.domain != nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -334,10 +334,10 @@ type CollectionOptions struct {
 	// comparisons; indexed collections use memtables by default.
 	DisableIndexedWriteMemtables bool `json:"disable_indexed_write_memtables,omitempty"`
 	// BufferedIndexedWrites is normalized metadata describing whether indexed
-	// InsertBatch root deltas are staged in the collection write domain before
-	// Flush/Close or auto-flush. Staged writes are visible to primary and
-	// secondary reads on the same manager, but durability remains at the flush
-	// boundary, matching the existing no-index buffered path.
+	// insert and safe update root deltas are staged in the collection write
+	// domain before Flush/Close or auto-flush. Staged writes are visible to
+	// primary and secondary reads on the same manager, but durability remains at
+	// the flush boundary, matching the existing no-index buffered path.
 	BufferedIndexedWrites bool `json:"buffered_indexed_writes,omitempty"`
 	// BufferedIndexedWriteMaxDocuments flushes indexed write buffers once this
 	// many staged documents are pending. Zero uses the native default for indexed
@@ -3608,7 +3608,10 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 }
 
 // Update applies update to the latest document value and retries if another
-// collection write changes the root before this update publishes.
+// collection write changes the root before this update publishes. For indexed
+// collections with BufferedIndexedWrites enabled, updates that do not change
+// secondary unique index values may be staged in the write domain and become
+// durable at Flush/Close or auto-flush.
 //
 // Callback panics are recovered and returned as errors in both direct and
 // combined execution. When the collection write domain combines concurrent
@@ -4078,7 +4081,9 @@ func (combiner *collectionUpdateCombiner) runBatch(batch []collectionUpdateCombi
 			completeUpdateCombineBatchWithError(batch, collectionUpdatePanicError("combiner", recovered))
 		}
 	}()
-	if len(batch) == 1 || collectionUpdateCombineHasDuplicateIDs(batch) || !collectionUpdateCombineSameCollection(batch) {
+	if (combiner.domain != nil && combiner.domain.closingWrites.Load()) ||
+		collectionUpdateCombineHasDuplicateIDs(batch) ||
+		!collectionUpdateCombineSameCollection(batch) {
 		if combiner.domain != nil {
 			combiner.domain.observeUpdateCombineBatch(len(batch), true)
 		}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3820,6 +3820,81 @@ func TestCollectionUpdateCombinerBatchesWhenSecondaryUniqueValuesAreUnchanged(t 
 	}
 }
 
+func TestCollectionUpdateCombinerBuffersSingletonWhenSecondaryUniqueValuesAreUnchanged(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"a@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+
+	before := d.State()
+	statsBefore := mgr.StatsSnapshot()
+	combiner := &collectionUpdateCombiner{maxBatch: 8, domain: col.writeDomain}
+	req := collectionUpdateCombineRequest{
+		collection: col,
+		documentID: []byte("u1"),
+		update:     setJSONCity("sea"),
+		done:       make(chan collectionUpdateCombineResult, 1),
+	}
+	combiner.runBatch([]collectionUpdateCombineRequest{req})
+	result := <-req.done
+	if result.err != nil {
+		t.Fatalf("request err: %v", result.err)
+	}
+	if !result.matched || !result.modified {
+		t.Fatalf("request matched=%v modified=%v", result.matched, result.modified)
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("singleton safe update advanced commit seq by %d before flush, want buffered", after.CommitSeq-before.CommitSeq)
+	}
+	stats := mgr.StatsSnapshot()
+	if got, want := stats.IndexedStageDocs-statsBefore.IndexedStageDocs, uint64(1); got != want {
+		t.Fatalf("indexed staged docs=%d want %d", got, want)
+	}
+	if got := stats.UpdateCombineFallbackRequests - statsBefore.UpdateCombineFallbackRequests; got != 0 {
+		t.Fatalf("fallback requests=%d want 0", got)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("sea ids=%q want [u1]", seaIDs)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush singleton buffered update: %v", err)
+	}
+	flushed := d.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flushed singleton update advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
+	}
+}
+
 func TestCollectionUpdateCombinerRunBatchPreservesIndependentItemErrorOutcomes(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3705,7 +3705,7 @@ func TestCollectionUpdateCombinerRunBatchPublishesDistinctIDsOnce(t *testing.T) 
 	}
 
 	before := d.State()
-	combiner := &collectionUpdateCombiner{maxBatch: 8}
+	combiner := &collectionUpdateCombiner{maxBatch: 8, domain: col.writeDomain}
 	requests := []collectionUpdateCombineRequest{
 		{
 			collection: col,
@@ -3775,7 +3775,7 @@ func TestCollectionUpdateCombinerBatchesWhenSecondaryUniqueValuesAreUnchanged(t 
 	}
 
 	before := d.State()
-	combiner := &collectionUpdateCombiner{maxBatch: 8}
+	combiner := &collectionUpdateCombiner{maxBatch: 8, domain: col.writeDomain}
 	requests := []collectionUpdateCombineRequest{
 		{
 			collection: col,
@@ -3830,6 +3830,11 @@ func TestCollectionUpdateCombinerBuffersSingletonWhenSecondaryUniqueValuesAreUnc
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{
 		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 1 << 20,
+			BufferedIndexedWriteMaxRootRuns:  1 << 20,
+		},
 		Indexes: []IndexDefinition{
 			{Name: "email", Field: "email", Unique: true},
 			{Name: "city", Field: "city"},


### PR DESCRIPTION
## Summary

Part of #1132. This follows the merged write-domain instrumentation in #1146. The new counters showed that the Mongo update workload was still publishing nearly one ordered-root group per update because singleton combiner batches were forced down the direct publish path.

- route singleton update-combiner batches through `UpdateBatchIfNoSecondaryUniqueIndexChanges` first
- preserve direct fallback for duplicate IDs, mixed collections, and manager-close draining
- document that safe indexed updates may be staged when `BufferedIndexedWrites` is enabled
- add a regression test proving a singleton safe update is buffered, visible through the secondary index, and durable after `Flush`

## Validation

- `go test ./TreeDB/collections -run 'TestCollectionUpdateCombiner(BuffersSingletonWhenSecondaryUniqueValuesAreUnchanged|RunBatchPublishesDistinctIDsOnce|BatchesWhenSecondaryUniqueValuesAreUnchanged|DuplicateIDsPreserveOrder|MixedCollectionsFallbackDirect)' -count=1`\n- `go test ./TreeDB/collections -run 'TestCollectionManagerCloseForBackendDrainsCombinerBeforeFlush|TestCollectionUpdateCombinerBuffersSingletonWhenSecondaryUniqueValuesAreUnchanged' -count=1`\n- `go test ./TreeDB/collections -count=1`\n- `go test ./cmd/mongo_gateway_bench -count=1`\n- `go vet ./TreeDB/collections ./cmd/mongo_gateway_bench`\n- `MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=20000 MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' -benchtime=20000x -count=1`\n\n## Benchmark Evidence\n\nSame local Mongo gateway smoke before this PR, using #1146/main instrumentation:\n\n```bash\ngo run ./cmd/mongo_gateway_bench \\\n  -target treedb \\\n  -documents 20000 \\\n  -batch-size 2000 \\\n  -secondary-indexes 2 \\\n  -reads 0 -range-reads 0 -updates 0 -deletes 0 \\\n  -concurrent-writers 8 \\\n  -concurrent-writes 20000 \\\n  -treedb-document-format bson \\\n  -treedb-maintenance none \\\n  -prebuild-documents \\\n  -format json\n```\n\nBefore:\n\n| Metric | Value |\n| --- | ---: |\n| concurrent update throughput | 19,385 ops/sec |\n| ordered-root delta group calls | 19,998 |\n| ordered-root roots total | 19,998 |\n| update-combiner fallback requests | 19,993 |\n\nAfter:\n\n| Metric | Value |\n| --- | ---: |\n| concurrent update throughput | 34,480 ops/sec |\n| ordered-root delta group calls | 50 |\n| ordered-root roots total | 50 |\n| update-combiner fallback requests | 0 |\n\nDirect collection benchmark after this PR:\n\n```text\nBenchmarkDirectCollectionConcurrentUpdateBSONIndexes2-8  20000  18474 ns/op  54129 docs/sec  18474 ns/doc  8.000 writers  32605 B/op  92 allocs/op\n```\n