### PR TITLE
Collections: raise indexed write root-run cap

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -36,7 +36,7 @@ const (
 	// DefaultIndexedWriteMemtableMaxRootRuns bounds accumulated root-local
 	// mutation runs so many small indexed update batches do not create an
 	// expensive pending-run chain before the document threshold is reached.
-	DefaultIndexedWriteMemtableMaxRootRuns = 256
+	DefaultIndexedWriteMemtableMaxRootRuns = 4096
 	// DefaultIndexedWriteMemtableDirectBatchDocuments keeps large, already
 	// well-amortized InsertBatch calls on the immediate publish path. Smaller
 	// batches use the indexed write-domain memtable path by default.

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7122,11 +7122,13 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		seen[indexes[i].Name] = struct{}{}
 	}
 	meta.Indexes = indexes
-	if len(meta.Indexes) == 0 || meta.Options.DisableIndexedWriteMemtables {
+	if meta.Options.DisableIndexedWriteMemtables {
 		meta.Options.BufferedIndexedWrites = false
 		meta.Options.BufferedIndexedWriteMaxDocuments = 0
 		meta.Options.BufferedIndexedWriteMaxBytes = 0
 		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
+	} else if len(meta.Indexes) == 0 {
+		meta.Options.BufferedIndexedWrites = false
 	} else {
 		meta.Options.BufferedIndexedWrites = true
 		useNativeDocumentDefault := meta.Options.BufferedIndexedWriteMaxDocuments == 0

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1623,6 +1623,48 @@ func TestCollectionIndexedWriteMemtablesDefaultSkipsNoIndexSchemas(t *testing.T)
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesPreserveNoIndexThresholdsForFutureIndexes(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	meta, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWriteMaxDocuments: 1234,
+			BufferedIndexedWriteMaxBytes:     5678,
+			BufferedIndexedWriteMaxRootRuns:  90,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if meta.Options.BufferedIndexedWrites {
+		t.Fatal("no-index collection enabled indexed write memtables")
+	}
+	if meta.Options.BufferedIndexedWriteMaxDocuments != 1234 || meta.Options.BufferedIndexedWriteMaxBytes != 5678 || meta.Options.BufferedIndexedWriteMaxRootRuns != 90 {
+		t.Fatalf("no-index buffered limits docs=%d bytes=%d rootRuns=%d want 1234/5678/90",
+			meta.Options.BufferedIndexedWriteMaxDocuments, meta.Options.BufferedIndexedWriteMaxBytes, meta.Options.BufferedIndexedWriteMaxRootRuns)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	meta, err = col.CreateIndex(IndexDefinition{Name: "email", Field: "email"})
+	if err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+	if !meta.Options.BufferedIndexedWrites {
+		t.Fatal("indexed collection did not enable indexed write memtables")
+	}
+	if meta.Options.BufferedIndexedWriteMaxDocuments != 1234 || meta.Options.BufferedIndexedWriteMaxBytes != 5678 || meta.Options.BufferedIndexedWriteMaxRootRuns != 90 {
+		t.Fatalf("indexed buffered limits docs=%d bytes=%d rootRuns=%d want 1234/5678/90",
+			meta.Options.BufferedIndexedWriteMaxDocuments, meta.Options.BufferedIndexedWriteMaxBytes, meta.Options.BufferedIndexedWriteMaxRootRuns)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesCanBeDisabled(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/bench_test.go
+++ b/TreeDB/collections/bench_test.go
@@ -577,6 +577,7 @@ func openBenchmarkCollectionWithManager(b *testing.B, name string, indexes ...co
 	bufferedIndexedWrites := benchmarkBoolEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITES", true) && len(indexes) > 0
 	bufferedIndexedWriteMaxDocuments := benchmarkIntEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", 0)
 	bufferedIndexedWriteMaxBytes := benchmarkInt64Env(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_BYTES", 0)
+	bufferedIndexedWriteMaxRootRuns := benchmarkIntEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", 0)
 	indexes = append([]collections.IndexDefinition(nil), indexes...)
 	for i := range indexes {
 		indexes[i].StoragePolicy = benchmarkRootStoragePolicy(indexOuter)
@@ -591,6 +592,7 @@ func openBenchmarkCollectionWithManager(b *testing.B, name string, indexes ...co
 			BufferedIndexedWrites:            bufferedIndexedWrites,
 			BufferedIndexedWriteMaxDocuments: bufferedIndexedWriteMaxDocuments,
 			BufferedIndexedWriteMaxBytes:     bufferedIndexedWriteMaxBytes,
+			BufferedIndexedWriteMaxRootRuns:  bufferedIndexedWriteMaxRootRuns,
 		},
 		Indexes: indexes,
 	}); err != nil {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1054,14 +1054,18 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 		if !errors.Is(err, collections.ErrCollectionNotFound) {
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
 		}
-		if _, err := s.Collections.CreateCollection(s.defaultCollectionMeta(name)); err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
-		}
-		createdAutomatically = true
-		col, err = s.Collections.OpenCollection(name)
+		meta := s.defaultCollectionMeta(name)
+		meta.Indexes = append([]collections.IndexDefinition(nil), defs...)
+		created, err := s.Collections.CreateCollection(meta)
 		if err != nil {
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
 		}
+		return marshalDocument(bson.D{
+			{Key: "ok", Value: 1.0},
+			{Key: "createdCollectionAutomatically", Value: true},
+			{Key: "numIndexesBefore", Value: int32(1)},
+			{Key: "numIndexesAfter", Value: int32(1 + len(created.Indexes))},
+		})
 	}
 	numBefore := int32(1 + len(col.Meta().Indexes))
 	meta := col.Meta()

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1060,9 +1060,10 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 		if err != nil {
 			// If another request created the collection after our miss, fall
 			// through to the idempotent add-index path below.
+			createErr := err
 			col, err = s.Collections.OpenCollection(name)
 			if err != nil {
-				return commandError(commandCodeBadValue, "BadValue", err.Error())
+				return commandError(commandCodeBadValue, "BadValue", createErr.Error())
 			}
 		} else {
 			return marshalDocument(bson.D{

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -1055,17 +1055,23 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
 		}
 		meta := s.defaultCollectionMeta(name)
-		meta.Indexes = append([]collections.IndexDefinition(nil), defs...)
+		meta.Indexes = dedupeIdenticalIndexDefinitions(defs)
 		created, err := s.Collections.CreateCollection(meta)
 		if err != nil {
-			return commandError(commandCodeBadValue, "BadValue", err.Error())
+			// If another request created the collection after our miss, fall
+			// through to the idempotent add-index path below.
+			col, err = s.Collections.OpenCollection(name)
+			if err != nil {
+				return commandError(commandCodeBadValue, "BadValue", err.Error())
+			}
+		} else {
+			return marshalDocument(bson.D{
+				{Key: "ok", Value: 1.0},
+				{Key: "createdCollectionAutomatically", Value: true},
+				{Key: "numIndexesBefore", Value: int32(1)},
+				{Key: "numIndexesAfter", Value: int32(1 + len(created.Indexes))},
+			})
 		}
-		return marshalDocument(bson.D{
-			{Key: "ok", Value: 1.0},
-			{Key: "createdCollectionAutomatically", Value: true},
-			{Key: "numIndexesBefore", Value: int32(1)},
-			{Key: "numIndexesAfter", Value: int32(1 + len(created.Indexes))},
-		})
 	}
 	numBefore := int32(1 + len(col.Meta().Indexes))
 	meta := col.Meta()
@@ -2010,6 +2016,17 @@ func findIndexDefinition(indexes []collections.IndexDefinition, name string) (co
 		}
 	}
 	return collections.IndexDefinition{}, false
+}
+
+func dedupeIdenticalIndexDefinitions(defs []collections.IndexDefinition) []collections.IndexDefinition {
+	out := make([]collections.IndexDefinition, 0, len(defs))
+	for _, def := range defs {
+		if existing, ok := findIndexDefinition(out, def.Name); ok && sameIndexDefinition(existing, def) {
+			continue
+		}
+		out = append(out, def)
+	}
+	return out
 }
 
 func sameIndexDefinition(left, right collections.IndexDefinition) bool {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1795,6 +1795,48 @@ func TestServerIndexMetadataCommands(t *testing.T) {
 	assertIndexName(t, indexBatch[0], "_id_")
 }
 
+func TestServerCreateIndexesAutoCreateDedupesIdenticalDefinitions(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	createResponse := serveCommand(t, server, 2272, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{
+				{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+				{Key: "name", Value: "email_1"},
+				{Key: "unique", Value: true},
+			},
+			bson.D{
+				{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+				{Key: "name", Value: "email_1"},
+				{Key: "unique", Value: true},
+			},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, createResponse)
+	assertBool(t, createResponse, "createdCollectionAutomatically", true)
+	assertInt32(t, createResponse, "numIndexesBefore", 1)
+	assertInt32(t, createResponse, "numIndexesAfter", 2)
+
+	indexesResponse := serveCommand(t, server, 2273, bson.D{
+		{Key: "listIndexes", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	indexBatch := cursorFirstBatch(t, indexesResponse)
+	if got, want := len(indexBatch), 2; got != want {
+		t.Fatalf("index batch len=%d want %d", got, want)
+	}
+	assertIndexName(t, indexBatch[0], "_id_")
+	assertIndexName(t, indexBatch[1], "email_1")
+}
+
 func TestServerIndexMetadataRejectsInvalidCommands(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1863,6 +1863,30 @@ func TestServerIndexMetadataRejectsInvalidCommands(t *testing.T) {
 	})
 	assertCommandError(t, emptyName, "BadValue")
 
+	conflictingDuplicate := serveCommand(t, server, 2331, bson.D{
+		{Key: "createIndexes", Value: "conflicting_dup"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{
+				{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+				{Key: "name", Value: "email_1"},
+				{Key: "unique", Value: true},
+			},
+			bson.D{
+				{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+				{Key: "name", Value: "email_1"},
+			},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, conflictingDuplicate, "BadValue")
+	errmsg, ok := bson.Raw(conflictingDuplicate).Lookup("errmsg").StringValueOK()
+	if !ok || !strings.Contains(errmsg, `duplicate index "email_1"`) {
+		t.Fatalf("errmsg=%q ok=%v want duplicate index", errmsg, ok)
+	}
+	if _, err := server.Collections.OpenCollection("app.conflicting_dup"); !errors.Is(err, collections.ErrCollectionNotFound) {
+		t.Fatalf("conflicting duplicate collection err=%v, want collection not found", err)
+	}
+
 	invalidListCollectionsDB := serveCommand(t, server, 234, bson.D{
 		{Key: "listCollections", Value: int32(1)},
 		{Key: "$db", Value: "bad/name"},

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -3173,9 +3173,11 @@ func TestServerAppliesDefaultCollectionAndIndexOptions(t *testing.T) {
 	server := NewServer()
 	server.Collections = collections.NewCollectionManager(db)
 	server.DefaultCollectionOptions = collections.CollectionOptions{
-		DocumentFormat:          collections.DocumentFormatTemplateV1,
-		DataRootStoragePolicy:   collections.RootStorageCompressed,
-		IndexStateStoragePolicy: collections.RootStorageCompressed,
+		DocumentFormat:                   collections.DocumentFormatTemplateV1,
+		DataRootStoragePolicy:            collections.RootStorageCompressed,
+		IndexStateStoragePolicy:          collections.RootStorageCompressed,
+		BufferedIndexedWriteMaxDocuments: 1234,
+		BufferedIndexedWriteMaxRootRuns:  90,
 	}
 	server.DefaultIndexStoragePolicy = collections.RootStorageCompressed
 
@@ -3221,6 +3223,12 @@ func TestServerAppliesDefaultCollectionAndIndexOptions(t *testing.T) {
 	indexedMeta := indexed.Meta()
 	if indexedMeta.Options.DocumentFormat != collections.DocumentFormatTemplateV1 {
 		t.Fatalf("auto-created document format=%q want %q", indexedMeta.Options.DocumentFormat, collections.DocumentFormatTemplateV1)
+	}
+	if indexedMeta.Options.BufferedIndexedWriteMaxDocuments != 1234 {
+		t.Fatalf("auto-created buffered indexed max documents=%d want 1234", indexedMeta.Options.BufferedIndexedWriteMaxDocuments)
+	}
+	if indexedMeta.Options.BufferedIndexedWriteMaxRootRuns != 90 {
+		t.Fatalf("auto-created buffered indexed max root runs=%d want 90", indexedMeta.Options.BufferedIndexedWriteMaxRootRuns)
 	}
 	def, ok := findIndexDefinition(indexedMeta.Indexes, "email_1")
 	if !ok {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -3243,6 +3243,7 @@ func TestServerAppliesDefaultCollectionAndIndexOptions(t *testing.T) {
 		DataRootStoragePolicy:            collections.RootStorageCompressed,
 		IndexStateStoragePolicy:          collections.RootStorageCompressed,
 		BufferedIndexedWriteMaxDocuments: 1234,
+		BufferedIndexedWriteMaxBytes:     5678,
 		BufferedIndexedWriteMaxRootRuns:  90,
 	}
 	server.DefaultIndexStoragePolicy = collections.RootStorageCompressed
@@ -3260,6 +3261,10 @@ func TestServerAppliesDefaultCollectionAndIndexOptions(t *testing.T) {
 	}
 	if meta.Options.IndexStateStoragePolicy != collections.RootStorageCompressed {
 		t.Fatalf("index state storage=%q want %q", meta.Options.IndexStateStoragePolicy, collections.RootStorageCompressed)
+	}
+	if meta.Options.BufferedIndexedWriteMaxDocuments != 1234 || meta.Options.BufferedIndexedWriteMaxBytes != 5678 || meta.Options.BufferedIndexedWriteMaxRootRuns != 90 {
+		t.Fatalf("no-index defaults docs=%d bytes=%d rootRuns=%d want 1234/5678/90",
+			meta.Options.BufferedIndexedWriteMaxDocuments, meta.Options.BufferedIndexedWriteMaxBytes, meta.Options.BufferedIndexedWriteMaxRootRuns)
 	}
 
 	commandDoc := mustDocument(t, bson.D{
@@ -3293,6 +3298,9 @@ func TestServerAppliesDefaultCollectionAndIndexOptions(t *testing.T) {
 	if indexedMeta.Options.BufferedIndexedWriteMaxDocuments != 1234 {
 		t.Fatalf("auto-created buffered indexed max documents=%d want 1234", indexedMeta.Options.BufferedIndexedWriteMaxDocuments)
 	}
+	if indexedMeta.Options.BufferedIndexedWriteMaxBytes != 5678 {
+		t.Fatalf("auto-created buffered indexed max bytes=%d want 5678", indexedMeta.Options.BufferedIndexedWriteMaxBytes)
+	}
 	if indexedMeta.Options.BufferedIndexedWriteMaxRootRuns != 90 {
 		t.Fatalf("auto-created buffered indexed max root runs=%d want 90", indexedMeta.Options.BufferedIndexedWriteMaxRootRuns)
 	}
@@ -3302,6 +3310,28 @@ func TestServerAppliesDefaultCollectionAndIndexOptions(t *testing.T) {
 	}
 	if def.StoragePolicy != collections.RootStorageCompressed {
 		t.Fatalf("index storage=%q want %q", def.StoragePolicy, collections.RootStorageCompressed)
+	}
+
+	existingCreateResponse := serveCommand(t, server, 215, bson.D{
+		{Key: "createIndexes", Value: "inserted"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "city", Value: int32(1)}}},
+			{Key: "name", Value: "city_1"},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, existingCreateResponse)
+	inserted, err := server.Collections.OpenCollection("app.inserted")
+	if err != nil {
+		t.Fatalf("open inserted collection after createIndexes: %v", err)
+	}
+	insertedMeta := inserted.Meta()
+	if !insertedMeta.Options.BufferedIndexedWrites {
+		t.Fatal("existing collection did not enable indexed writes after createIndexes")
+	}
+	if insertedMeta.Options.BufferedIndexedWriteMaxDocuments != 1234 || insertedMeta.Options.BufferedIndexedWriteMaxBytes != 5678 || insertedMeta.Options.BufferedIndexedWriteMaxRootRuns != 90 {
+		t.Fatalf("existing collection buffered indexed limits docs=%d bytes=%d rootRuns=%d want 1234/5678/90",
+			insertedMeta.Options.BufferedIndexedWriteMaxDocuments, insertedMeta.Options.BufferedIndexedWriteMaxBytes, insertedMeta.Options.BufferedIndexedWriteMaxRootRuns)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -113,8 +113,11 @@ canonical Extended JSON bridge used by the JSON/template-v1 gateway paths.
 Use `-treedb-buffered-indexed-write-max-documents`,
 `-treedb-buffered-indexed-write-max-bytes`, and
 `-treedb-buffered-indexed-write-max-root-runs` to reproduce indexed write-domain
-auto-flush threshold experiments. Setting a threshold to `0` disables that
-specific trigger.
+auto-flush threshold experiments. The benchmark report records the effective
+normalized collection thresholds after index creation. For document thresholds,
+`0` means use the collection default. For byte and root-run thresholds, `0`
+disables that trigger unless all indexed-write thresholds are otherwise left at
+their native defaults.
 
 ## MongoDB Target
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -92,6 +92,8 @@ collection benchmark profile:
 - `-treedb-data-root-storage compressed`
 - `-treedb-index-state-root-storage compressed`
 - `-treedb-index-root-storage compressed`
+- `-treedb-buffered-indexed-write-max-documents 64000`
+- `-treedb-buffered-indexed-write-max-root-runs 4096`
 - `-treedb-maintenance full`
 - `-client-mode driver`
 
@@ -108,6 +110,11 @@ metric, or `none` to skip final TreeDB disk reporting.
 `-treedb-document-format` accepts `json`, `template-v1`, and `bson`. BSON mode
 stores Mongo wire documents as native BSON collection records, avoiding the
 canonical Extended JSON bridge used by the JSON/template-v1 gateway paths.
+Use `-treedb-buffered-indexed-write-max-documents`,
+`-treedb-buffered-indexed-write-max-bytes`, and
+`-treedb-buffered-indexed-write-max-root-runs` to reproduce indexed write-domain
+auto-flush threshold experiments. Setting a threshold to `0` disables that
+specific trigger.
 
 ## MongoDB Target
 

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -40,44 +40,47 @@ import (
 const defaultMongoDriverMaxPoolSize = 100
 
 type config struct {
-	Target                      string
-	MongoURI                    string
-	TreeDBDir                   string
-	KeepTreeDBDir               bool
-	DropBeforeRun               bool
-	Database                    string
-	Collection                  string
-	Documents                   int
-	BatchSize                   int
-	InsertProducers             int
-	MongoMaxPoolSize            int
-	MongoMinPoolSize            int
-	MongoMaxConnecting          int
-	Reads                       int
-	RangeReads                  int
-	Updates                     int
-	Deletes                     int
-	ConcurrentReaders           int
-	ConcurrentReads             int
-	ConcurrentWriters           int
-	ConcurrentWrites            int
-	UpdateIndexedField          bool
-	SecondaryIndexes            int
-	ClientMode                  string
-	TreeDBProfile               treedb.Profile
-	TreeDBDocumentFormat        collections.DocumentFormat
-	TreeDBDataRootStorage       collections.RootStoragePolicy
-	TreeDBIndexStateRootStorage collections.RootStoragePolicy
-	TreeDBIndexRootStorage      collections.RootStoragePolicy
-	TreeDBMaintenance           string
-	PrebuildDocuments           bool
-	ProfileDir                  string
-	ProfileBlockRate            int
-	ProfileMutexFraction        int
-	ProfileTrace                bool
-	ProfileHeapGC               bool
-	Timeout                     time.Duration
-	Format                      string
+	Target                                 string
+	MongoURI                               string
+	TreeDBDir                              string
+	KeepTreeDBDir                          bool
+	DropBeforeRun                          bool
+	Database                               string
+	Collection                             string
+	Documents                              int
+	BatchSize                              int
+	InsertProducers                        int
+	MongoMaxPoolSize                       int
+	MongoMinPoolSize                       int
+	MongoMaxConnecting                     int
+	Reads                                  int
+	RangeReads                             int
+	Updates                                int
+	Deletes                                int
+	ConcurrentReaders                      int
+	ConcurrentReads                        int
+	ConcurrentWriters                      int
+	ConcurrentWrites                       int
+	UpdateIndexedField                     bool
+	SecondaryIndexes                       int
+	ClientMode                             string
+	TreeDBProfile                          treedb.Profile
+	TreeDBDocumentFormat                   collections.DocumentFormat
+	TreeDBDataRootStorage                  collections.RootStoragePolicy
+	TreeDBIndexStateRootStorage            collections.RootStoragePolicy
+	TreeDBIndexRootStorage                 collections.RootStoragePolicy
+	TreeDBBufferedIndexedWriteMaxDocuments int
+	TreeDBBufferedIndexedWriteMaxBytes     int64
+	TreeDBBufferedIndexedWriteMaxRootRuns  int
+	TreeDBMaintenance                      string
+	PrebuildDocuments                      bool
+	ProfileDir                             string
+	ProfileBlockRate                       int
+	ProfileMutexFraction                   int
+	ProfileTrace                           bool
+	ProfileHeapGC                          bool
+	Timeout                                time.Duration
+	Format                                 string
 }
 
 type benchmarkResult struct {
@@ -103,28 +106,31 @@ type benchmarkResult struct {
 	// false runs from older runs that predate indexed-field update coverage.
 	UpdateIndexedField bool `json:"update_indexed_field"`
 
-	TreeDBProfile               string              `json:"treedb_profile,omitempty"`
-	TreeDBDocumentFormat        string              `json:"treedb_document_format,omitempty"`
-	TreeDBDataRootStorage       string              `json:"treedb_data_root_storage,omitempty"`
-	TreeDBIndexStateRootStorage string              `json:"treedb_index_state_root_storage,omitempty"`
-	TreeDBIndexRootStorage      string              `json:"treedb_index_root_storage,omitempty"`
-	TreeDBMaintenanceMode       string              `json:"treedb_maintenance_mode,omitempty"`
-	PrebuildDocuments           bool                `json:"prebuild_documents,omitempty"`
-	Phases                      []phaseResult       `json:"phases"`
-	TreeDBDiskAfterLoad         *diskSnapshot       `json:"treedb_disk_after_load,omitempty"`
-	TreeDBDiskAfterCheckpoint   *diskSnapshot       `json:"treedb_disk_after_checkpoint,omitempty"`
-	TreeDBDiskAfterMaintenance  *diskSnapshot       `json:"treedb_disk_after_maintenance,omitempty"`
-	TreeDBStatsAfterLoad        map[string]string   `json:"treedb_stats_after_load,omitempty"`
-	TreeDBStatsAfterCheckpoint  map[string]string   `json:"treedb_stats_after_checkpoint,omitempty"`
-	TreeDBStatsFinal            map[string]string   `json:"treedb_stats_final,omitempty"`
-	TreeDBMaintenance           []maintenanceResult `json:"treedb_maintenance,omitempty"`
-	MongoDBStatsAfterLoad       map[string]any      `json:"mongodb_stats_after_load,omitempty"`
-	MongoDBStatsFinal           map[string]any      `json:"mongodb_stats_final,omitempty"`
-	MongoPoolStatsAfterLoad     *mongoPoolSnapshot  `json:"mongo_pool_stats_after_load,omitempty"`
-	MongoPoolStatsFinal         *mongoPoolSnapshot  `json:"mongo_pool_stats_final,omitempty"`
-	ProfileDir                  string              `json:"profile_dir,omitempty"`
-	ProfileManifest             string              `json:"profile_manifest,omitempty"`
-	ProfileResult               string              `json:"profile_result,omitempty"`
+	TreeDBProfile                          string              `json:"treedb_profile,omitempty"`
+	TreeDBDocumentFormat                   string              `json:"treedb_document_format,omitempty"`
+	TreeDBDataRootStorage                  string              `json:"treedb_data_root_storage,omitempty"`
+	TreeDBIndexStateRootStorage            string              `json:"treedb_index_state_root_storage,omitempty"`
+	TreeDBIndexRootStorage                 string              `json:"treedb_index_root_storage,omitempty"`
+	TreeDBBufferedIndexedWriteMaxDocuments int                 `json:"treedb_buffered_indexed_write_max_documents"`
+	TreeDBBufferedIndexedWriteMaxBytes     int64               `json:"treedb_buffered_indexed_write_max_bytes"`
+	TreeDBBufferedIndexedWriteMaxRootRuns  int                 `json:"treedb_buffered_indexed_write_max_root_runs"`
+	TreeDBMaintenanceMode                  string              `json:"treedb_maintenance_mode,omitempty"`
+	PrebuildDocuments                      bool                `json:"prebuild_documents,omitempty"`
+	Phases                                 []phaseResult       `json:"phases"`
+	TreeDBDiskAfterLoad                    *diskSnapshot       `json:"treedb_disk_after_load,omitempty"`
+	TreeDBDiskAfterCheckpoint              *diskSnapshot       `json:"treedb_disk_after_checkpoint,omitempty"`
+	TreeDBDiskAfterMaintenance             *diskSnapshot       `json:"treedb_disk_after_maintenance,omitempty"`
+	TreeDBStatsAfterLoad                   map[string]string   `json:"treedb_stats_after_load,omitempty"`
+	TreeDBStatsAfterCheckpoint             map[string]string   `json:"treedb_stats_after_checkpoint,omitempty"`
+	TreeDBStatsFinal                       map[string]string   `json:"treedb_stats_final,omitempty"`
+	TreeDBMaintenance                      []maintenanceResult `json:"treedb_maintenance,omitempty"`
+	MongoDBStatsAfterLoad                  map[string]any      `json:"mongodb_stats_after_load,omitempty"`
+	MongoDBStatsFinal                      map[string]any      `json:"mongodb_stats_final,omitempty"`
+	MongoPoolStatsAfterLoad                *mongoPoolSnapshot  `json:"mongo_pool_stats_after_load,omitempty"`
+	MongoPoolStatsFinal                    *mongoPoolSnapshot  `json:"mongo_pool_stats_final,omitempty"`
+	ProfileDir                             string              `json:"profile_dir,omitempty"`
+	ProfileManifest                        string              `json:"profile_manifest,omitempty"`
+	ProfileResult                          string              `json:"profile_result,omitempty"`
 }
 
 type phaseResult struct {
@@ -403,16 +409,18 @@ func run(parent context.Context, args []string) error {
 
 func parseConfig(args []string) (config, error) {
 	cfg := config{
-		TreeDBProfile:               treedb.ProfileWALOnFast,
-		TreeDBDocumentFormat:        collections.DocumentFormatTemplateV1,
-		TreeDBDataRootStorage:       collections.RootStorageCompressed,
-		TreeDBIndexStateRootStorage: collections.RootStorageCompressed,
-		TreeDBIndexRootStorage:      collections.RootStorageCompressed,
-		TreeDBMaintenance:           treeDBMaintenanceFull,
-		ClientMode:                  clientModeDriver,
-		InsertProducers:             1,
-		ProfileBlockRate:            1,
-		ProfileMutexFraction:        5,
+		TreeDBProfile:                          treedb.ProfileWALOnFast,
+		TreeDBDocumentFormat:                   collections.DocumentFormatTemplateV1,
+		TreeDBDataRootStorage:                  collections.RootStorageCompressed,
+		TreeDBIndexStateRootStorage:            collections.RootStorageCompressed,
+		TreeDBIndexRootStorage:                 collections.RootStorageCompressed,
+		TreeDBBufferedIndexedWriteMaxDocuments: collections.DefaultIndexedWriteMemtableMaxDocuments,
+		TreeDBBufferedIndexedWriteMaxRootRuns:  collections.DefaultIndexedWriteMemtableMaxRootRuns,
+		TreeDBMaintenance:                      treeDBMaintenanceFull,
+		ClientMode:                             clientModeDriver,
+		InsertProducers:                        1,
+		ProfileBlockRate:                       1,
+		ProfileMutexFraction:                   5,
 	}
 	fs := flag.NewFlagSet("mongo_gateway_bench", flag.ContinueOnError)
 	var flagOutput bytes.Buffer
@@ -453,6 +461,9 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&treeDBDataRootStorage, "treedb-data-root-storage", treeDBDataRootStorage, "TreeDB collection data root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&treeDBIndexStateRootStorage, "treedb-index-state-root-storage", treeDBIndexStateRootStorage, "TreeDB collection index-state root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&treeDBIndexRootStorage, "treedb-index-root-storage", treeDBIndexRootStorage, "TreeDB secondary index root storage for -target treedb: default, fast, or compressed")
+	fs.IntVar(&cfg.TreeDBBufferedIndexedWriteMaxDocuments, "treedb-buffered-indexed-write-max-documents", cfg.TreeDBBufferedIndexedWriteMaxDocuments, "TreeDB indexed collection write-domain document auto-flush threshold; 0 disables this trigger")
+	fs.Int64Var(&cfg.TreeDBBufferedIndexedWriteMaxBytes, "treedb-buffered-indexed-write-max-bytes", cfg.TreeDBBufferedIndexedWriteMaxBytes, "TreeDB indexed collection write-domain byte auto-flush threshold; 0 disables this trigger")
+	fs.IntVar(&cfg.TreeDBBufferedIndexedWriteMaxRootRuns, "treedb-buffered-indexed-write-max-root-runs", cfg.TreeDBBufferedIndexedWriteMaxRootRuns, "TreeDB indexed collection write-domain root-run auto-flush threshold; 0 disables this trigger")
 	fs.StringVar(&cfg.TreeDBMaintenance, "treedb-maintenance", cfg.TreeDBMaintenance, "TreeDB final disk maintenance for -target treedb: full, checkpoint, or none")
 	fs.BoolVar(&cfg.PrebuildDocuments, "prebuild-documents", false, "prebuild benchmark documents before the timed load phase")
 	fs.StringVar(&cfg.ProfileDir, "profile-dir", "", "write per-phase pprof artifacts and a profile_manifest.json into an empty directory")
@@ -530,6 +541,15 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.UpdateIndexedField && cfg.SecondaryIndexes < 2 {
 		return config{}, errors.New("update-indexed-field requires secondary-indexes=2 so the city index exists")
+	}
+	if cfg.TreeDBBufferedIndexedWriteMaxDocuments < 0 {
+		return config{}, errors.New("treedb-buffered-indexed-write-max-documents must be >= 0")
+	}
+	if cfg.TreeDBBufferedIndexedWriteMaxBytes < 0 {
+		return config{}, errors.New("treedb-buffered-indexed-write-max-bytes must be >= 0")
+	}
+	if cfg.TreeDBBufferedIndexedWriteMaxRootRuns < 0 {
+		return config{}, errors.New("treedb-buffered-indexed-write-max-root-runs must be >= 0")
 	}
 	if cfg.Format != "text" && cfg.Format != "json" {
 		return config{}, fmt.Errorf("unknown format %q", cfg.Format)
@@ -693,9 +713,12 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 	server.Collections = manager
 	server.MaxFindScanDocuments = cfg.Documents
 	server.DefaultCollectionOptions = collections.CollectionOptions{
-		DocumentFormat:          cfg.TreeDBDocumentFormat,
-		DataRootStoragePolicy:   cfg.TreeDBDataRootStorage,
-		IndexStateStoragePolicy: cfg.TreeDBIndexStateRootStorage,
+		DocumentFormat:                   cfg.TreeDBDocumentFormat,
+		DataRootStoragePolicy:            cfg.TreeDBDataRootStorage,
+		IndexStateStoragePolicy:          cfg.TreeDBIndexStateRootStorage,
+		BufferedIndexedWriteMaxDocuments: cfg.TreeDBBufferedIndexedWriteMaxDocuments,
+		BufferedIndexedWriteMaxBytes:     cfg.TreeDBBufferedIndexedWriteMaxBytes,
+		BufferedIndexedWriteMaxRootRuns:  cfg.TreeDBBufferedIndexedWriteMaxRootRuns,
 	}
 	server.DefaultIndexStoragePolicy = cfg.TreeDBIndexRootStorage
 
@@ -1007,6 +1030,9 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.TreeDBDataRootStorage = string(cfg.TreeDBDataRootStorage)
 		result.TreeDBIndexStateRootStorage = string(cfg.TreeDBIndexStateRootStorage)
 		result.TreeDBIndexRootStorage = string(cfg.TreeDBIndexRootStorage)
+		result.TreeDBBufferedIndexedWriteMaxDocuments = cfg.TreeDBBufferedIndexedWriteMaxDocuments
+		result.TreeDBBufferedIndexedWriteMaxBytes = cfg.TreeDBBufferedIndexedWriteMaxBytes
+		result.TreeDBBufferedIndexedWriteMaxRootRuns = cfg.TreeDBBufferedIndexedWriteMaxRootRuns
 		result.TreeDBMaintenanceMode = cfg.TreeDBMaintenance
 	} else {
 		result.MongoURI = redactMongoURI(cfg.MongoURI)
@@ -2535,9 +2561,11 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 			fmt.Fprintf(out, "treedb_dir=%s\n", result.TreeDBDir)
 		}
 		if result.TreeDBProfile != "" {
-			fmt.Fprintf(out, "treedb_profile=%s document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s maintenance=%s\n",
+			fmt.Fprintf(out, "treedb_profile=%s document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s buffered_indexed_max_docs=%d buffered_indexed_max_bytes=%d buffered_indexed_max_root_runs=%d maintenance=%s\n",
 				result.TreeDBProfile, result.TreeDBDocumentFormat, result.TreeDBDataRootStorage,
-				result.TreeDBIndexStateRootStorage, result.TreeDBIndexRootStorage, result.TreeDBMaintenanceMode)
+				result.TreeDBIndexStateRootStorage, result.TreeDBIndexRootStorage,
+				result.TreeDBBufferedIndexedWriteMaxDocuments, result.TreeDBBufferedIndexedWriteMaxBytes,
+				result.TreeDBBufferedIndexedWriteMaxRootRuns, result.TreeDBMaintenanceMode)
 		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -461,9 +461,9 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&treeDBDataRootStorage, "treedb-data-root-storage", treeDBDataRootStorage, "TreeDB collection data root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&treeDBIndexStateRootStorage, "treedb-index-state-root-storage", treeDBIndexStateRootStorage, "TreeDB collection index-state root storage for -target treedb: default, fast, or compressed")
 	fs.StringVar(&treeDBIndexRootStorage, "treedb-index-root-storage", treeDBIndexRootStorage, "TreeDB secondary index root storage for -target treedb: default, fast, or compressed")
-	fs.IntVar(&cfg.TreeDBBufferedIndexedWriteMaxDocuments, "treedb-buffered-indexed-write-max-documents", cfg.TreeDBBufferedIndexedWriteMaxDocuments, "TreeDB indexed collection write-domain document auto-flush threshold; 0 disables this trigger")
+	fs.IntVar(&cfg.TreeDBBufferedIndexedWriteMaxDocuments, "treedb-buffered-indexed-write-max-documents", cfg.TreeDBBufferedIndexedWriteMaxDocuments, "TreeDB indexed collection write-domain document auto-flush threshold; 0 uses the collection default")
 	fs.Int64Var(&cfg.TreeDBBufferedIndexedWriteMaxBytes, "treedb-buffered-indexed-write-max-bytes", cfg.TreeDBBufferedIndexedWriteMaxBytes, "TreeDB indexed collection write-domain byte auto-flush threshold; 0 disables this trigger")
-	fs.IntVar(&cfg.TreeDBBufferedIndexedWriteMaxRootRuns, "treedb-buffered-indexed-write-max-root-runs", cfg.TreeDBBufferedIndexedWriteMaxRootRuns, "TreeDB indexed collection write-domain root-run auto-flush threshold; 0 disables this trigger")
+	fs.IntVar(&cfg.TreeDBBufferedIndexedWriteMaxRootRuns, "treedb-buffered-indexed-write-max-root-runs", cfg.TreeDBBufferedIndexedWriteMaxRootRuns, "TreeDB indexed collection write-domain root-run auto-flush threshold; 0 disables this trigger unless all thresholds normalize to collection defaults")
 	fs.StringVar(&cfg.TreeDBMaintenance, "treedb-maintenance", cfg.TreeDBMaintenance, "TreeDB final disk maintenance for -target treedb: full, checkpoint, or none")
 	fs.BoolVar(&cfg.PrebuildDocuments, "prebuild-documents", false, "prebuild benchmark documents before the timed load phase")
 	fs.StringVar(&cfg.ProfileDir, "profile-dir", "", "write per-phase pprof artifacts and a profile_manifest.json into an empty directory")
@@ -1040,6 +1040,9 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	if err := createIndexes(ctx, coll, cfg.SecondaryIndexes); err != nil {
 		return nil, err
 	}
+	if err := recordEffectiveTreeDBCollectionOptions(result, cfg, target); err != nil {
+		return nil, err
+	}
 	var updatedCityValues []string
 	updatedCityValuesForUpdate := func() []string {
 		if !cfg.UpdateIndexedField {
@@ -1317,6 +1320,21 @@ func createIndexes(ctx context.Context, coll *mongo.Collection, secondaryIndexes
 			return err
 		}
 	}
+	return nil
+}
+
+func recordEffectiveTreeDBCollectionOptions(result *benchmarkResult, cfg config, target *benchTarget) error {
+	if result == nil || cfg.Target != "treedb" || target == nil || target.collections == nil || cfg.SecondaryIndexes == 0 {
+		return nil
+	}
+	col, err := target.collections.OpenCollection(cfg.Database + "." + cfg.Collection)
+	if err != nil {
+		return err
+	}
+	meta := col.Meta()
+	result.TreeDBBufferedIndexedWriteMaxDocuments = meta.Options.BufferedIndexedWriteMaxDocuments
+	result.TreeDBBufferedIndexedWriteMaxBytes = meta.Options.BufferedIndexedWriteMaxBytes
+	result.TreeDBBufferedIndexedWriteMaxRootRuns = meta.Options.BufferedIndexedWriteMaxRootRuns
 	return nil
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -17,6 +17,7 @@ import (
 
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/event"
 )
@@ -1514,6 +1515,66 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("text output missing %s: %q", want, text)
 		}
+	}
+
+	out.Reset()
+	if err := writeResult(&out, "json", result); err != nil {
+		t.Fatalf("writeResult json: %v", err)
+	}
+	var decoded benchmarkResult
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal json result: %v", err)
+	}
+	if decoded.TreeDBBufferedIndexedWriteMaxDocuments != 1234 ||
+		decoded.TreeDBBufferedIndexedWriteMaxBytes != 5678 ||
+		decoded.TreeDBBufferedIndexedWriteMaxRootRuns != 90 {
+		t.Fatalf("json thresholds docs=%d bytes=%d rootRuns=%d want 1234/5678/90",
+			decoded.TreeDBBufferedIndexedWriteMaxDocuments,
+			decoded.TreeDBBufferedIndexedWriteMaxBytes,
+			decoded.TreeDBBufferedIndexedWriteMaxRootRuns)
+	}
+}
+
+func TestRecordEffectiveTreeDBCollectionOptionsUsesNormalizedMetadata(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: "bench.docs",
+		Options: collections.CollectionOptions{
+			BufferedIndexedWriteMaxDocuments: 0,
+			BufferedIndexedWriteMaxBytes:     777,
+			BufferedIndexedWriteMaxRootRuns:  0,
+		},
+		Indexes: []collections.IndexDefinition{{Name: "email_1", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	result := &benchmarkResult{
+		TreeDBBufferedIndexedWriteMaxDocuments: 0,
+		TreeDBBufferedIndexedWriteMaxBytes:     0,
+		TreeDBBufferedIndexedWriteMaxRootRuns:  0,
+	}
+	cfg := config{
+		Target:           "treedb",
+		Database:         "bench",
+		Collection:       "docs",
+		SecondaryIndexes: 1,
+	}
+	if err := recordEffectiveTreeDBCollectionOptions(result, cfg, &benchTarget{collections: manager}); err != nil {
+		t.Fatalf("record effective options: %v", err)
+	}
+	if result.TreeDBBufferedIndexedWriteMaxDocuments != collections.DefaultIndexedWriteMemtableMaxDocuments ||
+		result.TreeDBBufferedIndexedWriteMaxBytes != 777 ||
+		result.TreeDBBufferedIndexedWriteMaxRootRuns != 0 {
+		t.Fatalf("effective thresholds docs=%d bytes=%d rootRuns=%d want %d/777/0",
+			result.TreeDBBufferedIndexedWriteMaxDocuments,
+			result.TreeDBBufferedIndexedWriteMaxBytes,
+			result.TreeDBBufferedIndexedWriteMaxRootRuns,
+			collections.DefaultIndexedWriteMemtableMaxDocuments)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -432,6 +432,15 @@ func TestParseConfigValidation(t *testing.T) {
 	if _, err := parseConfig([]string{"-secondary-indexes", "1", "-update-indexed-field"}); err == nil {
 		t.Fatal("update-indexed-field accepted without city index")
 	}
+	if _, err := parseConfig([]string{"-treedb-buffered-indexed-write-max-documents", "-1"}); err == nil {
+		t.Fatal("negative treedb buffered indexed max documents accepted")
+	}
+	if _, err := parseConfig([]string{"-treedb-buffered-indexed-write-max-bytes", "-1"}); err == nil {
+		t.Fatal("negative treedb buffered indexed max bytes accepted")
+	}
+	if _, err := parseConfig([]string{"-treedb-buffered-indexed-write-max-root-runs", "-1"}); err == nil {
+		t.Fatal("negative treedb buffered indexed max root runs accepted")
+	}
 }
 
 func TestRawInsertCommandBuildsBSONCommand(t *testing.T) {
@@ -493,8 +502,37 @@ func TestParseConfigTreeDBCorrectnessDefaults(t *testing.T) {
 	if cfg.TreeDBMaintenance != treeDBMaintenanceFull {
 		t.Fatalf("TreeDBMaintenance=%q want %q", cfg.TreeDBMaintenance, treeDBMaintenanceFull)
 	}
+	if cfg.TreeDBBufferedIndexedWriteMaxDocuments != collections.DefaultIndexedWriteMemtableMaxDocuments {
+		t.Fatalf("TreeDBBufferedIndexedWriteMaxDocuments=%d want %d", cfg.TreeDBBufferedIndexedWriteMaxDocuments, collections.DefaultIndexedWriteMemtableMaxDocuments)
+	}
+	if cfg.TreeDBBufferedIndexedWriteMaxBytes != 0 {
+		t.Fatalf("TreeDBBufferedIndexedWriteMaxBytes=%d want 0", cfg.TreeDBBufferedIndexedWriteMaxBytes)
+	}
+	if cfg.TreeDBBufferedIndexedWriteMaxRootRuns != collections.DefaultIndexedWriteMemtableMaxRootRuns {
+		t.Fatalf("TreeDBBufferedIndexedWriteMaxRootRuns=%d want %d", cfg.TreeDBBufferedIndexedWriteMaxRootRuns, collections.DefaultIndexedWriteMemtableMaxRootRuns)
+	}
 	if cfg.InsertProducers != 1 {
 		t.Fatalf("InsertProducers=%d want 1", cfg.InsertProducers)
+	}
+}
+
+func TestParseConfigTreeDBBufferedIndexedWriteThresholds(t *testing.T) {
+	cfg, err := parseConfig([]string{
+		"-treedb-buffered-indexed-write-max-documents", "1234",
+		"-treedb-buffered-indexed-write-max-bytes", "5678",
+		"-treedb-buffered-indexed-write-max-root-runs", "90",
+	})
+	if err != nil {
+		t.Fatalf("parse buffered indexed thresholds: %v", err)
+	}
+	if cfg.TreeDBBufferedIndexedWriteMaxDocuments != 1234 {
+		t.Fatalf("TreeDBBufferedIndexedWriteMaxDocuments=%d want 1234", cfg.TreeDBBufferedIndexedWriteMaxDocuments)
+	}
+	if cfg.TreeDBBufferedIndexedWriteMaxBytes != 5678 {
+		t.Fatalf("TreeDBBufferedIndexedWriteMaxBytes=%d want 5678", cfg.TreeDBBufferedIndexedWriteMaxBytes)
+	}
+	if cfg.TreeDBBufferedIndexedWriteMaxRootRuns != 90 {
+		t.Fatalf("TreeDBBufferedIndexedWriteMaxRootRuns=%d want 90", cfg.TreeDBBufferedIndexedWriteMaxRootRuns)
 	}
 }
 
@@ -1444,6 +1482,38 @@ func TestWriteResultIncludesRedactedMongoURI(t *testing.T) {
 	}
 	if !bytes.Contains(out.Bytes(), []byte("mongo_uri=mongodb://user@127.0.0.1:27017")) {
 		t.Fatalf("text output missing mongo_uri: %q", out.String())
+	}
+}
+
+func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
+	result := &benchmarkResult{
+		Target:                                 "treedb",
+		Database:                               "bench",
+		Collection:                             "docs",
+		Documents:                              1,
+		TreeDBProfile:                          "wal_on_fast",
+		TreeDBDocumentFormat:                   "bson",
+		TreeDBDataRootStorage:                  "compressed",
+		TreeDBIndexStateRootStorage:            "compressed",
+		TreeDBIndexRootStorage:                 "compressed",
+		TreeDBBufferedIndexedWriteMaxDocuments: 1234,
+		TreeDBBufferedIndexedWriteMaxBytes:     5678,
+		TreeDBBufferedIndexedWriteMaxRootRuns:  90,
+		TreeDBMaintenanceMode:                  "none",
+	}
+	var out bytes.Buffer
+	if err := writeResult(&out, "text", result); err != nil {
+		t.Fatalf("writeResult: %v", err)
+	}
+	text := out.String()
+	for _, want := range []string{
+		"buffered_indexed_max_docs=1234",
+		"buffered_indexed_max_bytes=5678",
+		"buffered_indexed_max_root_runs=90",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("text output missing %s: %q", want, text)
+		}
 	}
 }
 


### PR DESCRIPTION
Refs #1132.

## Summary

This is a small #1132 follow-on aimed at the remaining synchronous root-publish cost while we work toward the larger async indexed write-back design.

Changes:
- Raises `DefaultIndexedWriteMemtableMaxRootRuns` from `256` to `4096`.
- Adds `mongo_gateway_bench` flags and JSON/text output fields for indexed write-domain auto-flush thresholds:
  - `-treedb-buffered-indexed-write-max-documents`
  - `-treedb-buffered-indexed-write-max-bytes`
  - `-treedb-buffered-indexed-write-max-root-runs`
- Adds `TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS` support to collection benchmarks.
- Fixes Mongo gateway `createIndexes` on a missing collection to create the collection with the requested indexes up front, preserving `DefaultCollectionOptions` indexed-write thresholds. Previously the collection was first normalized as no-index, which cleared indexed-write threshold options before indexes were added.

## Why

After #1148, a focused direct profile still showed `flushBufferedIndexedLocked` / ordered root publish as roughly one third of CPU samples in the concurrent indexed update path. A root-run cap sweep showed the default `256` cap was forcing too many physical root publications for small update batches.

The gateway option preservation fix was necessary because the first sweep showed threshold flags were not actually affecting implicitly created collections that later received indexes via `createIndexes`.

## Benchmark evidence

Command shape for the fixed sweep:

```bash
go run ./cmd/mongo_gateway_bench \
  -target treedb \
  -documents 30000 \
  -batch-size 2000 \
  -secondary-indexes 2 \
  -reads 0 \
  -range-reads 0 \
  -updates 0 \
  -deletes 0 \
  -concurrent-writers 8 \
  -concurrent-writes 30000 \
  -treedb-document-format bson \
  -treedb-maintenance none \
  -prebuild-documents \
  -treedb-buffered-indexed-write-max-root-runs <cap> \
  -format json
```

Sweep output from `/tmp/gomap_1132_root_run_sweep_fixed_1777689264/summary.tsv`:

| cap | reported cap | concurrent update ops/sec | indexed flush calls | indexed root runs | ordered root publish calls | indexed flush duration ns |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 256 | 256 | 34,273 | 69 | 17,311 | 70 | 375,758,874 |
| 512 | 512 | 35,862 | 35 | 17,167 | 36 | 352,687,795 |
| 1024 | 1024 | 38,964 | 19 | 17,485 | 20 | 286,566,166 |
| 2048 | 2048 | 42,828 | 10 | 17,476 | 11 | 246,106,167 |
| 4096 | 4096 | 46,165 | 6 | 17,097 | 7 | 174,563,917 |
| 0 | 0 | 58,206 | 2 | 16,844 | 3 | 94,035,708 |

Post-change default sanity comparison from `/tmp/gomap_1132_root_run_default_1777689351/summary.tsv`:

| run | cap | concurrent update ops/sec | indexed flush calls | ordered root publish calls | indexed flush duration ns |
| --- | ---: | ---: | ---: | ---: | ---: |
| default | 4096 | 44,234 | 6 | 7 | 168,546,624 |
| explicit old cap | 256 | 34,034 | 73 | 74 | 368,459,880 |

Collection mixed reader/writer smoke:

```bash
TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS=<cap> \
TREEDB_COLLECTION_BENCH_BATCH_SIZE=128 \
TREEDB_COLLECTION_MIXED_SEED_DOCS=1024 \
TREEDB_COLLECTION_MIXED_WRITE_BATCH_SIZE=64 \
go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkCollectionMixedReadWriteScaling(Primary|SecondaryUnique)$' \
  -benchtime=20000x \
  -count=1
```

Key result: cap `4096` improved reader and writer throughput across all six primary/secondary-unique mixed shapes in this smoke run. Example: primary 8 readers / 2 writers moved from `519,995 reader_ops/sec`, `330,223 writer_docs/sec` at cap `256` to `759,353 reader_ops/sec`, `524,268 writer_docs/sec` at cap `4096`.

## Validation

```bash
go test ./TreeDB/collections -run 'TestNormalizeCollectionMeta|TestCollectionIndexedWriteMemtablesAutoFlushMaxRootRuns|TestShouldFlushBufferedIndexedWritesAfterAddingBoundaries|TestCollectionUpdateCombinerBuffersSingletonWhenSecondaryUniqueValuesAreUnchanged' -count=1
go test ./TreeDB/mongo_gateway -run '^TestServerAppliesDefaultCollectionAndIndexOptions$' -count=1
go test ./cmd/mongo_gateway_bench -run 'TestParseConfig|TestWriteResultIncludesTreeDBBufferedIndexedThresholds' -count=1
go test ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1
go test ./cmd/collection_load_fixture ./cmd/collection_bench_matrix -count=1
go vet ./TreeDB/collections ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench
```
