### PR TITLE
Collections: add opt-in async indexed flush

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -48,7 +48,6 @@ const (
 	DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits = 4
 	defaultCollectionUpdateCombineMaxBatch              = 256
 	collectionUpdateCombineIdleTTL                      = 30 * time.Second
-	collectionIndexedAsyncFlushIdleDebounce             = 2 * time.Millisecond
 )
 
 var (
@@ -993,35 +992,10 @@ func (c *Collection) scheduleIndexedAsyncFlush(domain *collectionWriteDomain) bo
 	domain.indexedAsyncFlushScheduled.Add(1)
 	db := c.db
 	go func() {
-		waitForIndexedAsyncFlushIdle(domain)
 		err := flushCollectionWriteDomain(db, domain)
 		domain.finishIndexedAsyncFlush(err)
 	}()
 	return true
-}
-
-func waitForIndexedAsyncFlushIdle(domain *collectionWriteDomain) {
-	if domain == nil {
-		return
-	}
-	for {
-		domain.mu.RLock()
-		if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
-			domain.mu.RUnlock()
-			return
-		}
-		generation := domain.writeGeneration
-		domain.mu.RUnlock()
-
-		time.Sleep(collectionIndexedAsyncFlushIdleDebounce)
-
-		domain.mu.RLock()
-		idle := domain.writeGeneration == generation
-		domain.mu.RUnlock()
-		if idle {
-			return
-		}
-	}
 }
 
 func (c *Collection) lockMutation() func() {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -41,8 +41,14 @@ const (
 	// well-amortized InsertBatch calls on the immediate publish path. Smaller
 	// batches use the indexed write-domain memtable path by default.
 	DefaultIndexedWriteMemtableDirectBatchDocuments = DefaultIndexedWriteMemtableMaxDocuments / 4
-	defaultCollectionUpdateCombineMaxBatch          = 256
-	collectionUpdateCombineIdleTTL                  = 30 * time.Second
+	// DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits bounds opt-in
+	// background indexed flush work. When the queue reaches this many immutable
+	// flush units, the triggering writer publishes synchronously to cap memory
+	// and visibility lag.
+	DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits = 4
+	defaultCollectionUpdateCombineMaxBatch              = 256
+	collectionUpdateCombineIdleTTL                      = 30 * time.Second
+	collectionIndexedAsyncFlushIdleDebounce             = 2 * time.Millisecond
 )
 
 var (
@@ -278,6 +284,8 @@ type CollectionManagerStats struct {
 	PendingDocuments              int
 	PendingBytes                  int64
 	PendingRootRuns               int
+	PendingIndexedFlushUnits      int
+	IndexedAsyncFlushRunning      int
 	MutationLockCalls             uint64
 	MutationLockWait              time.Duration
 	MutationLockHold              time.Duration
@@ -286,6 +294,9 @@ type CollectionManagerStats struct {
 	IndexedStageBytes             uint64
 	IndexedStageRootRuns          uint64
 	IndexedAutoFlushes            uint64
+	IndexedAsyncFlushScheduled    uint64
+	IndexedAsyncFlushBackpressure uint64
+	IndexedAsyncFlushErrors       uint64
 	IndexedFlushCalls             uint64
 	IndexedFlushErrors            uint64
 	IndexedFlushDocs              uint64
@@ -354,6 +365,15 @@ type CollectionOptions struct {
 	// indexed buffer limits are zero, metadata normalization installs native
 	// defaults.
 	BufferedIndexedWriteMaxRootRuns int `json:"buffered_indexed_write_max_root_runs,omitempty"`
+	// BufferedIndexedAsyncFlush lets threshold-triggered indexed memtable flushes
+	// publish from a background goroutine. This is an opt-in performance mode:
+	// Flush, FlushAll, and backend Close still drain pending indexed writes before
+	// returning, but auto-flush thresholds no longer imply immediate durability.
+	BufferedIndexedAsyncFlush bool `json:"buffered_indexed_async_flush,omitempty"`
+	// BufferedIndexedAsyncFlushMaxQueuedUnits bounds immutable indexed flush
+	// units queued for the background publisher. Zero uses the native default
+	// when async flush is enabled on an indexed schema.
+	BufferedIndexedAsyncFlushMaxQueuedUnits int `json:"buffered_indexed_async_flush_max_queued_units,omitempty"`
 }
 
 type IndexDefinition struct {
@@ -413,6 +433,8 @@ type bufferedIndexedCheckpoint struct {
 	primaryRoot           uint64
 	count                 int
 	bufferedBytes         int64
+	mutableCount          int
+	mutableBytes          int64
 	writeGeneration       uint64
 	rootRuns              map[string][]memtable.Table
 	rootPolicies          map[string]backenddb.OrderedRootStoragePolicy
@@ -446,6 +468,10 @@ type collectionWriteDomain struct {
 	// sustained collection write contention.
 	mutationMu        sync.Mutex
 	mu                sync.RWMutex
+	indexedAsyncMu    sync.Mutex
+	indexedAsyncCond  *sync.Cond
+	indexedAsyncRun   bool
+	indexedAsyncErr   error
 	updateCombineMu   sync.Mutex
 	updateCombiner    *collectionUpdateCombiner
 	updateDraining    *collectionUpdateCombiner
@@ -472,6 +498,8 @@ type collectionWriteDomain struct {
 	uniqueValueIndex map[string]*bufferedUniqueValueIndex
 	count            int
 	bufferedBytes    int64
+	mutableCount     int
+	mutableBytes     int64
 	rootRunCount     int
 	writeGeneration  uint64
 
@@ -483,6 +511,9 @@ type collectionWriteDomain struct {
 	indexedStageBytes             atomic.Uint64
 	indexedStageRootRuns          atomic.Uint64
 	indexedAutoFlushes            atomic.Uint64
+	indexedAsyncFlushScheduled    atomic.Uint64
+	indexedAsyncFlushBackpressure atomic.Uint64
+	indexedAsyncFlushErrors       atomic.Uint64
 	indexedFlushCalls             atomic.Uint64
 	indexedFlushErrors            atomic.Uint64
 	indexedFlushDocs              atomic.Uint64
@@ -571,6 +602,8 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.pending_docs"] = fmt.Sprintf("%d", stats.PendingDocuments)
 	out["treedb.collections.write_domain.pending_bytes"] = fmt.Sprintf("%d", stats.PendingBytes)
 	out["treedb.collections.write_domain.pending_root_runs"] = fmt.Sprintf("%d", stats.PendingRootRuns)
+	out["treedb.collections.write_domain.pending_indexed_flush_units"] = fmt.Sprintf("%d", stats.PendingIndexedFlushUnits)
+	out["treedb.collections.write_domain.indexed_async_flush.running_domains"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushRunning)
 	out["treedb.collections.write_domain.mutation_lock.calls_total"] = fmt.Sprintf("%d", stats.MutationLockCalls)
 	out["treedb.collections.write_domain.mutation_lock.wait_ns_total"] = fmt.Sprintf("%d", stats.MutationLockWait.Nanoseconds())
 	out["treedb.collections.write_domain.mutation_lock.hold_ns_total"] = fmt.Sprintf("%d", stats.MutationLockHold.Nanoseconds())
@@ -582,6 +615,9 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_stage.bytes_total"] = fmt.Sprintf("%d", stats.IndexedStageBytes)
 	out["treedb.collections.write_domain.indexed_stage.root_runs_total"] = fmt.Sprintf("%d", stats.IndexedStageRootRuns)
 	out["treedb.collections.write_domain.indexed_stage.auto_flushes_total"] = fmt.Sprintf("%d", stats.IndexedAutoFlushes)
+	out["treedb.collections.write_domain.indexed_async_flush.scheduled_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushScheduled)
+	out["treedb.collections.write_domain.indexed_async_flush.backpressure_sync_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushBackpressure)
+	out["treedb.collections.write_domain.indexed_async_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushErrors)
 	out["treedb.collections.write_domain.indexed_flush.calls_total"] = fmt.Sprintf("%d", stats.IndexedFlushCalls)
 	out["treedb.collections.write_domain.indexed_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedFlushErrors)
 	out["treedb.collections.write_domain.indexed_flush.docs_total"] = fmt.Sprintf("%d", stats.IndexedFlushDocs)
@@ -627,6 +663,8 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.PendingDocuments = saturatingAddNonNegativeInt(s.PendingDocuments, other.PendingDocuments)
 	s.PendingBytes = saturatingAddNonNegativeInt64(s.PendingBytes, other.PendingBytes)
 	s.PendingRootRuns = saturatingAddNonNegativeInt(s.PendingRootRuns, other.PendingRootRuns)
+	s.PendingIndexedFlushUnits = saturatingAddNonNegativeInt(s.PendingIndexedFlushUnits, other.PendingIndexedFlushUnits)
+	s.IndexedAsyncFlushRunning = saturatingAddNonNegativeInt(s.IndexedAsyncFlushRunning, other.IndexedAsyncFlushRunning)
 	s.MutationLockCalls += other.MutationLockCalls
 	s.MutationLockWait += other.MutationLockWait
 	s.MutationLockHold += other.MutationLockHold
@@ -635,6 +673,9 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.IndexedStageBytes += other.IndexedStageBytes
 	s.IndexedStageRootRuns += other.IndexedStageRootRuns
 	s.IndexedAutoFlushes += other.IndexedAutoFlushes
+	s.IndexedAsyncFlushScheduled += other.IndexedAsyncFlushScheduled
+	s.IndexedAsyncFlushBackpressure += other.IndexedAsyncFlushBackpressure
+	s.IndexedAsyncFlushErrors += other.IndexedAsyncFlushErrors
 	s.IndexedFlushCalls += other.IndexedFlushCalls
 	s.IndexedFlushErrors += other.IndexedFlushErrors
 	s.IndexedFlushDocs += other.IndexedFlushDocs
@@ -660,7 +701,11 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.PendingDocuments = domain.count
 	stats.PendingBytes = domain.bufferedBytes
 	stats.PendingRootRuns = bufferedIndexedRootRunCount(domain)
+	stats.PendingIndexedFlushUnits = len(domain.indexedFlushUnits)
 	domain.mu.RUnlock()
+	if domain.indexedAsyncFlushRunning() {
+		stats.IndexedAsyncFlushRunning = 1
+	}
 
 	stats.MutationLockCalls = domain.mutationLockCalls.Load()
 	stats.MutationLockWait = durationFromAtomicNs(domain.mutationLockWaitTotalNs.Load())
@@ -670,6 +715,9 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.IndexedStageBytes = domain.indexedStageBytes.Load()
 	stats.IndexedStageRootRuns = domain.indexedStageRootRuns.Load()
 	stats.IndexedAutoFlushes = domain.indexedAutoFlushes.Load()
+	stats.IndexedAsyncFlushScheduled = domain.indexedAsyncFlushScheduled.Load()
+	stats.IndexedAsyncFlushBackpressure = domain.indexedAsyncFlushBackpressure.Load()
+	stats.IndexedAsyncFlushErrors = domain.indexedAsyncFlushErrors.Load()
 	stats.IndexedFlushCalls = domain.indexedFlushCalls.Load()
 	stats.IndexedFlushErrors = domain.indexedFlushErrors.Load()
 	stats.IndexedFlushDocs = domain.indexedFlushDocs.Load()
@@ -735,6 +783,84 @@ func (domain *collectionWriteDomain) observeIndexedStage(docs int, bytes int64, 
 	if rootRuns > 0 {
 		domain.indexedStageRootRuns.Add(uint64(rootRuns))
 	}
+}
+
+func (domain *collectionWriteDomain) beginIndexedAsyncFlush() bool {
+	if domain == nil {
+		return false
+	}
+	domain.indexedAsyncMu.Lock()
+	defer domain.indexedAsyncMu.Unlock()
+	if domain.indexedAsyncCond == nil {
+		domain.indexedAsyncCond = sync.NewCond(&domain.indexedAsyncMu)
+	}
+	if domain.indexedAsyncRun {
+		return false
+	}
+	domain.indexedAsyncRun = true
+	return true
+}
+
+func (domain *collectionWriteDomain) finishIndexedAsyncFlush(err error) {
+	if domain == nil {
+		return
+	}
+	if err != nil {
+		domain.indexedAsyncFlushErrors.Add(1)
+	}
+	domain.indexedAsyncMu.Lock()
+	if err != nil {
+		domain.indexedAsyncErr = err
+	}
+	domain.indexedAsyncRun = false
+	if domain.indexedAsyncCond != nil {
+		domain.indexedAsyncCond.Broadcast()
+	}
+	domain.indexedAsyncMu.Unlock()
+}
+
+func (domain *collectionWriteDomain) waitIndexedAsyncFlush() {
+	if domain == nil {
+		return
+	}
+	domain.indexedAsyncMu.Lock()
+	if domain.indexedAsyncCond == nil {
+		domain.indexedAsyncCond = sync.NewCond(&domain.indexedAsyncMu)
+	}
+	for domain.indexedAsyncRun {
+		domain.indexedAsyncCond.Wait()
+	}
+	domain.indexedAsyncMu.Unlock()
+}
+
+func (domain *collectionWriteDomain) indexedAsyncFlushRunning() bool {
+	if domain == nil {
+		return false
+	}
+	domain.indexedAsyncMu.Lock()
+	running := domain.indexedAsyncRun
+	domain.indexedAsyncMu.Unlock()
+	return running
+}
+
+func (domain *collectionWriteDomain) clearIndexedAsyncFlushError() {
+	if domain == nil {
+		return
+	}
+	domain.indexedAsyncMu.Lock()
+	domain.indexedAsyncErr = nil
+	domain.indexedAsyncMu.Unlock()
+}
+
+func (domain *collectionWriteDomain) consumeIndexedAsyncFlushError() error {
+	if domain == nil {
+		return nil
+	}
+	domain.indexedAsyncMu.Lock()
+	err := domain.indexedAsyncErr
+	domain.indexedAsyncErr = nil
+	domain.indexedAsyncMu.Unlock()
+	return err
 }
 
 func (domain *collectionWriteDomain) observeIndexedFlush(docs int, bytes int64, rootRuns, roots int, duration time.Duration, err error) {
@@ -837,6 +963,7 @@ func (m *CollectionManager) FlushAll() error {
 
 	var errs []error
 	for _, domain := range domains {
+		domain.waitIndexedAsyncFlush()
 		if err := flushCollectionWriteDomain(m.db, domain); err != nil {
 			errs = append(errs, err)
 		}
@@ -854,6 +981,47 @@ func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain)
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	return collection.flushBufferedWritesLocked(domain)
+}
+
+func (c *Collection) scheduleIndexedAsyncFlush(domain *collectionWriteDomain) bool {
+	if c == nil || c.db == nil || domain == nil {
+		return false
+	}
+	if !domain.beginIndexedAsyncFlush() {
+		return false
+	}
+	domain.indexedAsyncFlushScheduled.Add(1)
+	db := c.db
+	go func() {
+		waitForIndexedAsyncFlushIdle(domain)
+		err := flushCollectionWriteDomain(db, domain)
+		domain.finishIndexedAsyncFlush(err)
+	}()
+	return true
+}
+
+func waitForIndexedAsyncFlushIdle(domain *collectionWriteDomain) {
+	if domain == nil {
+		return
+	}
+	for {
+		domain.mu.RLock()
+		if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
+			domain.mu.RUnlock()
+			return
+		}
+		generation := domain.writeGeneration
+		domain.mu.RUnlock()
+
+		time.Sleep(collectionIndexedAsyncFlushIdleDebounce)
+
+		domain.mu.RLock()
+		idle := domain.writeGeneration == generation
+		domain.mu.RUnlock()
+		if idle {
+			return
+		}
+	}
 }
 
 func (c *Collection) lockMutation() func() {
@@ -1341,6 +1509,9 @@ func (c *Collection) Flush() error {
 	if c.db == nil {
 		return errCollectionDBNil
 	}
+	if c.writeDomain != nil {
+		c.writeDomain.waitIndexedAsyncFlush()
+	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation()
 	return c.flushBufferedWrites()
@@ -1566,13 +1737,22 @@ func (c *Collection) flushBufferedWrites() error {
 }
 
 func (c *Collection) flushBufferedWritesLocked(domain *collectionWriteDomain) error {
-	if domain == nil || domain.count == 0 {
+	if domain == nil {
 		return nil
 	}
-	if hasBufferedIndexedRootRuns(domain) {
-		return c.flushBufferedIndexedLocked(domain)
+	if domain.count == 0 {
+		return domain.consumeIndexedAsyncFlushError()
 	}
-	return c.flushBufferedNoIndexLocked(domain)
+	var err error
+	if hasBufferedIndexedRootRuns(domain) {
+		err = c.flushBufferedIndexedLocked(domain)
+	} else {
+		err = c.flushBufferedNoIndexLocked(domain)
+	}
+	if err == nil {
+		domain.clearIndexedAsyncFlushError()
+	}
+	return err
 }
 
 func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) error {
@@ -1643,6 +1823,8 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	domain.primaryRoot = rootIDs[0]
 	domain.table = newCollectionRunTable(0)
 	domain.count = 0
+	domain.mutableCount = 0
+	domain.mutableBytes = 0
 	c.meta = meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetCollectionRunTable(table)
@@ -1788,17 +1970,18 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
 	domain.count += len(plan.resultIDs)
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
+	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, len(plan.resultIDs))
+	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
 	domain.writeGeneration++
 	domain.observeIndexedStage(len(plan.resultIDs), stagedBytes, stagedRootRuns)
 	c.meta = catalog.meta
 	if shouldFlushBufferedIndexedWrites(domain, catalog.meta.Options) {
-		domain.indexedAutoFlushes.Add(1)
-		flushStart := time.Now()
-		if err := c.flushBufferedIndexedLocked(domain); err != nil {
+		flushElapsed, err := c.flushBufferedIndexedAfterThresholdLocked(domain, catalog.meta.Options)
+		if err != nil {
 			rollbackBufferedIndexedDomain(domain, checkpoint)
 			return 0, err
 		}
-		return time.Since(flushStart), nil
+		return flushElapsed, nil
 	}
 	return 0, nil
 }
@@ -1815,24 +1998,39 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.rootRunCount = 0
+	domain.mutableCount = 0
+	domain.mutableBytes = 0
 	domain.primaryIDIndex = nil
 	domain.primaryRunIndex = nil
 	domain.uniqueValueRuns = nil
 	domain.uniqueValueIndex = nil
 	domain.bufferedBytes = 0
+	domain.mutableCount = 0
+	domain.mutableBytes = 0
 }
 
 func shouldFlushBufferedIndexedWrites(domain *collectionWriteDomain, opts CollectionOptions) bool {
 	if domain == nil || domain.count == 0 {
 		return false
 	}
-	if opts.BufferedIndexedWriteMaxDocuments > 0 && domain.count >= opts.BufferedIndexedWriteMaxDocuments {
+	count := domain.count
+	bytes := domain.bufferedBytes
+	rootRuns := bufferedIndexedRootRunCount(domain)
+	if opts.BufferedIndexedAsyncFlush {
+		if len(domain.rootRuns) == 0 {
+			return false
+		}
+		count = domain.mutableCount
+		bytes = domain.mutableBytes
+		rootRuns = domain.rootRunCount
+	}
+	if opts.BufferedIndexedWriteMaxDocuments > 0 && count >= opts.BufferedIndexedWriteMaxDocuments {
 		return true
 	}
-	if opts.BufferedIndexedWriteMaxBytes > 0 && domain.bufferedBytes >= opts.BufferedIndexedWriteMaxBytes {
+	if opts.BufferedIndexedWriteMaxBytes > 0 && bytes >= opts.BufferedIndexedWriteMaxBytes {
 		return true
 	}
-	if opts.BufferedIndexedWriteMaxRootRuns > 0 && bufferedIndexedRootRunCount(domain) >= opts.BufferedIndexedWriteMaxRootRuns {
+	if opts.BufferedIndexedWriteMaxRootRuns > 0 && rootRuns >= opts.BufferedIndexedWriteMaxRootRuns {
 		return true
 	}
 	return false
@@ -1842,15 +2040,23 @@ func shouldFlushBufferedIndexedWritesAfterAdding(domain *collectionWriteDomain, 
 	if domain == nil || addedCount <= 0 {
 		return false
 	}
-	nextCount := saturatingAddNonNegativeInt(domain.count, addedCount)
+	baseCount := domain.count
+	baseBytes := domain.bufferedBytes
+	baseRootRuns := bufferedIndexedRootRunCount(domain)
+	if opts.BufferedIndexedAsyncFlush {
+		baseCount = domain.mutableCount
+		baseBytes = domain.mutableBytes
+		baseRootRuns = domain.rootRunCount
+	}
+	nextCount := saturatingAddNonNegativeInt(baseCount, addedCount)
 	if opts.BufferedIndexedWriteMaxDocuments > 0 && nextCount >= opts.BufferedIndexedWriteMaxDocuments {
 		return true
 	}
-	nextBytes := saturatingAddNonNegativeInt64(domain.bufferedBytes, addedBytes)
+	nextBytes := saturatingAddNonNegativeInt64(baseBytes, addedBytes)
 	if opts.BufferedIndexedWriteMaxBytes > 0 && nextBytes >= opts.BufferedIndexedWriteMaxBytes {
 		return true
 	}
-	nextRootRuns := saturatingAddNonNegativeInt(bufferedIndexedRootRunCount(domain), addedRootRuns)
+	nextRootRuns := saturatingAddNonNegativeInt(baseRootRuns, addedRootRuns)
 	if opts.BufferedIndexedWriteMaxRootRuns > 0 && nextRootRuns >= opts.BufferedIndexedWriteMaxRootRuns {
 		return true
 	}
@@ -1892,6 +2098,27 @@ func saturatingAddNonNegativeInt(total, n int) int {
 
 func bufferedIndexedAutoFlushEnabled(opts CollectionOptions) bool {
 	return opts.BufferedIndexedWriteMaxDocuments > 0 || opts.BufferedIndexedWriteMaxBytes > 0 || opts.BufferedIndexedWriteMaxRootRuns > 0
+}
+
+func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collectionWriteDomain, opts CollectionOptions) (time.Duration, error) {
+	if domain == nil {
+		return 0, nil
+	}
+	domain.indexedAutoFlushes.Add(1)
+	if opts.BufferedIndexedAsyncFlush {
+		rotateIndexedMutableToFlushUnitLocked(domain)
+		if opts.BufferedIndexedAsyncFlushMaxQueuedUnits > 0 && len(domain.indexedFlushUnits) >= opts.BufferedIndexedAsyncFlushMaxQueuedUnits {
+			domain.indexedAsyncFlushBackpressure.Add(1)
+			flushStart := time.Now()
+			err := c.flushBufferedIndexedLocked(domain)
+			return time.Since(flushStart), err
+		}
+		c.scheduleIndexedAsyncFlush(domain)
+		return 0, nil
+	}
+	flushStart := time.Now()
+	err := c.flushBufferedIndexedLocked(domain)
+	return time.Since(flushStart), err
 }
 
 func hasBufferedIndexedRootRuns(domain *collectionWriteDomain) bool {
@@ -2044,6 +2271,8 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		primaryRoot:           domain.primaryRoot,
 		count:                 domain.count,
 		bufferedBytes:         domain.bufferedBytes,
+		mutableCount:          domain.mutableCount,
+		mutableBytes:          domain.mutableBytes,
 		writeGeneration:       domain.writeGeneration,
 		rootRuns:              cloneTableRunMap(domain.rootRuns),
 		rootPolicies:          cloneRootPolicyMap(domain.rootPolicies),
@@ -2070,6 +2299,8 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.primaryRoot = checkpoint.primaryRoot
 	domain.count = checkpoint.count
 	domain.bufferedBytes = checkpoint.bufferedBytes
+	domain.mutableCount = checkpoint.mutableCount
+	domain.mutableBytes = checkpoint.mutableBytes
 	domain.writeGeneration = checkpoint.writeGeneration
 	domain.indexedFlushUnits = checkpoint.indexedFlushUnits
 	domain.rootRuns = checkpoint.rootRuns
@@ -3005,6 +3236,8 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		domain.indexedFlushUnits = nil
 		domain.count = 0
 		domain.bufferedBytes = 0
+		domain.mutableCount = 0
+		domain.mutableBytes = 0
 		return nil
 	}
 	flushDocs := domain.count
@@ -3070,6 +3303,8 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	domain.uniqueValueIndex = nil
 	domain.count = 0
 	domain.bufferedBytes = 0
+	domain.mutableCount = 0
+	domain.mutableBytes = 0
 	c.meta = meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetIndexedFlushUnits(oldUnits)
@@ -3099,6 +3334,8 @@ func rotateIndexedMutableToFlushUnitLocked(domain *collectionWriteDomain) bool {
 	domain.rootBaseIDs = nil
 	domain.uniqueValueRuns = nil
 	domain.rootRunCount = 0
+	domain.mutableCount = 0
+	domain.mutableBytes = 0
 	return true
 }
 
@@ -5842,12 +6079,13 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	}
 	domain.count += modifiedCount
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
+	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
+	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
 	domain.writeGeneration++
 	domain.observeIndexedStage(modifiedCount, stagedBytes, stagedRootRuns)
 	c.meta = plan.meta
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
-		domain.indexedAutoFlushes.Add(1)
-		if err := c.flushBufferedIndexedLocked(domain); err != nil {
+		if _, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options); err != nil {
 			if shouldAutoFlushAfterAdding {
 				rollbackBufferedIndexedDomain(domain, checkpoint)
 				c.meta = collectionMetaCheckpoint
@@ -7460,6 +7698,9 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 	if meta.Options.BufferedIndexedWriteMaxRootRuns < 0 {
 		return CollectionMeta{}, errors.New("collections: buffered indexed write max root runs cannot be negative")
 	}
+	if meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits < 0 {
+		return CollectionMeta{}, errors.New("collections: buffered indexed async flush max queued units cannot be negative")
+	}
 	documentFormat, err := normalizeDocumentFormat(meta.Options.DocumentFormat)
 	if err != nil {
 		return CollectionMeta{}, err
@@ -7495,6 +7736,8 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		meta.Options.BufferedIndexedWriteMaxDocuments = 0
 		meta.Options.BufferedIndexedWriteMaxBytes = 0
 		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
+		meta.Options.BufferedIndexedAsyncFlush = false
+		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
 	} else if len(meta.Indexes) == 0 {
 		meta.Options.BufferedIndexedWrites = false
 	} else {
@@ -7505,6 +7748,9 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		}
 		if useNativeDocumentDefault && meta.Options.BufferedIndexedWriteMaxBytes == 0 && meta.Options.BufferedIndexedWriteMaxRootRuns == 0 {
 			meta.Options.BufferedIndexedWriteMaxRootRuns = DefaultIndexedWriteMemtableMaxRootRuns
+		}
+		if meta.Options.BufferedIndexedAsyncFlush && meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits == 0 {
+			meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits
 		}
 	}
 	return meta, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2087,7 +2087,11 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 			err := c.flushBufferedIndexedLocked(domain)
 			return time.Since(flushStart), err
 		}
-		c.scheduleIndexedAsyncFlush(domain)
+		if !c.scheduleIndexedAsyncFlush(domain) {
+			flushStart := time.Now()
+			err := c.flushBufferedIndexedLocked(domain)
+			return time.Since(flushStart), err
+		}
 		return 0, nil
 	}
 	flushStart := time.Now()

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -586,7 +586,9 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	exported := mgr.Stats()
 	for _, key := range []string{
 		"treedb.collections.write_domain.pending_docs",
+		"treedb.collections.write_domain.pending_indexed_flush_units",
 		"treedb.collections.write_domain.indexed_stage.batches_total",
+		"treedb.collections.write_domain.indexed_async_flush.scheduled_total",
 		"treedb.collections.write_domain.mutation_lock.calls_total",
 	} {
 		if exported[key] == "" {
@@ -1778,6 +1780,31 @@ func TestCollectionIndexedWriteMemtablesPreserveDocumentDefaultWithRootRunLimit(
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesAsyncFlushDefaultsQueueLimit(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	meta, err := NewCollectionManager(d).CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedAsyncFlush: true,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email"}},
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if !meta.Options.BufferedIndexedAsyncFlush {
+		t.Fatal("async indexed flush was not preserved for indexed collection")
+	}
+	if got := meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits; got != DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits {
+		t.Fatalf("async max queued units=%d want %d", got, DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesCanDisableRootRunLimitWithDocumentLimit(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -2727,6 +2754,285 @@ func TestCollectionIndexedWriteMemtablesAutoFlushMaxDocuments(t *testing.T) {
 	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"), []byte("u2"))
 }
 
+func TestCollectionIndexedWriteMemtablesAsyncAutoFlushDrainsOnFlush(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        2,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("first insert batch: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog after first batch: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got != 0 {
+		t.Fatalf("primary root persisted before threshold flush: %d", got)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"email":"grace@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("second insert batch: %v", err)
+	}
+	stats := mgr.StatsSnapshot()
+	if got, want := stats.IndexedAutoFlushes, uint64(1); got != want {
+		t.Fatalf("indexed auto flushes=%d want %d", got, want)
+	}
+	if got, want := stats.IndexedAsyncFlushScheduled, uint64(1); got != want {
+		t.Fatalf("async flush scheduled=%d want %d", got, want)
+	}
+	if got, err := col.Get([]byte("u2")); err != nil {
+		t.Fatalf("get queued async doc: %v", err)
+	} else if want := []byte(`{"email":"grace@example.com","city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("queued async doc=%q want %q", got, want)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush async indexed writes: %v", err)
+	}
+	stats = mgr.StatsSnapshot()
+	if got := stats.PendingDocuments; got != 0 {
+		t.Fatalf("pending docs after async flush drain=%d want 0", got)
+	}
+	if got := stats.PendingIndexedFlushUnits; got != 0 {
+		t.Fatalf("pending async flush units after drain=%d want 0", got)
+	}
+	if stats.IndexedFlushCalls == 0 {
+		t.Fatal("indexed flush calls=0 want background or drain flush")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err := reopenedCol.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city after async flush: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"), []byte("u2"))
+}
+
+func TestCollectionIndexedWriteMemtablesAsyncBackpressurePublishesSynchronously(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 1,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	stats := mgr.StatsSnapshot()
+	if got, want := stats.IndexedAsyncFlushBackpressure, uint64(1); got != want {
+		t.Fatalf("async backpressure sync=%d want %d", got, want)
+	}
+	if got := stats.IndexedAsyncFlushScheduled; got != 0 {
+		t.Fatalf("async scheduled=%d want 0 when backpressure syncs", got)
+	}
+	if got := stats.PendingDocuments; got != 0 {
+		t.Fatalf("pending docs after backpressure sync=%d want 0", got)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot after backpressure sync")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog after backpressure sync: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
+		t.Fatal("primary root was not persisted after backpressure sync")
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesAsyncQueuedUnitsParticipateInUniqueChecks(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        2,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com"}`),
+			[]byte(`{"email":"grace@example.com"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if got := mgr.StatsSnapshot().IndexedAsyncFlushScheduled; got != 1 {
+		t.Fatalf("async flush scheduled=%d want 1", got)
+	}
+	_, err = col.InsertBatch(
+		[][]byte{[]byte("u3")},
+		[][]byte{[]byte(`{"email":"grace@example.com"}`)},
+	)
+	if err == nil || !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("duplicate queued unique insert err=%v want ErrUniqueIndexConflict", err)
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesAsyncUpdateAndDeleteDrainCorrectly(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"city":"hnl","score":0}`),
+			[]byte(`{"city":"hnl","score":0}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed: %v", err)
+	}
+	results, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func([]byte) ([]byte, bool, error) {
+			return []byte(`{"city":"sfo","score":1}`), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("update batch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("update results=%+v want matched modified", results)
+	}
+	if got := mgr.StatsSnapshot().IndexedAsyncFlushScheduled; got == 0 {
+		t.Fatal("async flush scheduled=0 want update to schedule a flush")
+	}
+	ids, err := col.FindByIndex("city", "sfo")
+	if err != nil {
+		t.Fatalf("find updated city before drain: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"))
+	deleted, err := col.DeleteDocument([]byte("u1"))
+	if err != nil {
+		t.Fatalf("delete after queued update: %v", err)
+	}
+	if !deleted {
+		t.Fatal("delete after queued update reported not found")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	if got, err := reopenedCol.Get([]byte("u1")); err != nil {
+		t.Fatalf("get deleted doc after reopen: %v", err)
+	} else if got != nil {
+		t.Fatalf("deleted doc after reopen=%s want nil", got)
+	}
+	ids, err = reopenedCol.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find hnl after reopen: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u2"))
+}
+
 func TestCollectionIndexedWriteMemtablesAutoFlushMaxBytes(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})
@@ -2977,10 +3283,35 @@ func TestShouldFlushBufferedIndexedWritesAfterAddingBoundaries(t *testing.T) {
 			addedRootRuns: maxCollectionInt,
 			want:          true,
 		},
+		{
+			name:          "async uses mutable document count after rotated units",
+			domain:        &collectionWriteDomain{count: 100, mutableCount: 8, indexedFlushUnits: []indexedFlushUnit{{rootRuns: map[string][]memtable.Table{"a": nil}}}},
+			addedCount:    1,
+			addedRootRuns: 1,
+			want:          false,
+		},
+		{
+			name:          "async mutable document count reaches threshold",
+			domain:        &collectionWriteDomain{count: 100, mutableCount: 9, indexedFlushUnits: []indexedFlushUnit{{rootRuns: map[string][]memtable.Table{"a": nil}}}},
+			addedCount:    1,
+			addedRootRuns: 1,
+			want:          true,
+		},
+		{
+			name:          "async uses mutable root run count after rotated units",
+			domain:        &collectionWriteDomain{count: 100, mutableCount: 1, rootRunCount: 3, indexedFlushUnits: []indexedFlushUnit{{rootRuns: map[string][]memtable.Table{"a": make([]memtable.Table, 10)}}}},
+			addedCount:    1,
+			addedRootRuns: 1,
+			want:          false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := shouldFlushBufferedIndexedWritesAfterAdding(tc.domain, opts, tc.addedCount, tc.addedBytes, tc.addedRootRuns)
+			caseOpts := opts
+			if strings.HasPrefix(tc.name, "async ") {
+				caseOpts.BufferedIndexedAsyncFlush = true
+			}
+			got := shouldFlushBufferedIndexedWritesAfterAdding(tc.domain, caseOpts, tc.addedCount, tc.addedBytes, tc.addedRootRuns)
 			if got != tc.want {
 				t.Fatalf("shouldFlushBufferedIndexedWritesAfterAdding()=%v want %v", got, tc.want)
 			}
@@ -3002,6 +3333,8 @@ func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {
 		primaryRoot:     42,
 		count:           3,
 		bufferedBytes:   99,
+		mutableCount:    2,
+		mutableBytes:    88,
 		writeGeneration: 12,
 		rootRuns: map[string][]memtable.Table{
 			collectionPrimaryRootName("users"): nil,
@@ -3026,6 +3359,8 @@ func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {
 	domain.primaryRoot = 300
 	domain.count = 400
 	domain.bufferedBytes = 500
+	domain.mutableCount = 501
+	domain.mutableBytes = 502
 	domain.writeGeneration = 600
 	domain.rootRuns = map[string][]memtable.Table{collectionPrimaryRootName("other"): nil}
 	domain.rootPolicies = nil
@@ -3040,8 +3375,8 @@ func TestRollbackBufferedIndexedDomainRestoresMetadata(t *testing.T) {
 	if domain.baseCommitSeq != 7 || domain.baseSystemRoot != 11 || domain.primaryRoot != 42 {
 		t.Fatalf("roots after rollback commit=%d system=%d primary=%d", domain.baseCommitSeq, domain.baseSystemRoot, domain.primaryRoot)
 	}
-	if domain.count != 3 || domain.bufferedBytes != 99 || domain.writeGeneration != 12 {
-		t.Fatalf("counters after rollback count=%d bytes=%d generation=%d", domain.count, domain.bufferedBytes, domain.writeGeneration)
+	if domain.count != 3 || domain.bufferedBytes != 99 || domain.mutableCount != 2 || domain.mutableBytes != 88 || domain.writeGeneration != 12 {
+		t.Fatalf("counters after rollback count=%d bytes=%d mutable=%d/%d generation=%d", domain.count, domain.bufferedBytes, domain.mutableCount, domain.mutableBytes, domain.writeGeneration)
 	}
 	if _, ok := domain.rootRuns[collectionPrimaryRootName("users")]; !ok {
 		t.Fatalf("rootRuns=%v missing users primary root", domain.rootRuns)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2902,6 +2902,51 @@ func TestCollectionIndexedWriteMemtablesAsyncBackpressurePublishesSynchronously(
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesAsyncScheduleRacePublishesSynchronously(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if !col.writeDomain.beginIndexedAsyncFlush() {
+		t.Fatal("begin async flush returned false")
+	}
+	defer col.writeDomain.finishIndexedAsyncFlush(nil)
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	stats := mgr.StatsSnapshot()
+	if got := stats.IndexedAsyncFlushScheduled; got != 0 {
+		t.Fatalf("async scheduled=%d want 0 when scheduling race falls back", got)
+	}
+	if got := stats.IndexedFlushCalls; got != 1 {
+		t.Fatalf("indexed flush calls=%d want sync fallback flush", got)
+	}
+	if got := stats.PendingDocuments; got != 0 {
+		t.Fatalf("pending docs after sync fallback=%d want 0", got)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesAsyncQueuedUnitsParticipateInUniqueChecks(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/bench_test.go
+++ b/TreeDB/collections/bench_test.go
@@ -578,6 +578,8 @@ func openBenchmarkCollectionWithManager(b *testing.B, name string, indexes ...co
 	bufferedIndexedWriteMaxDocuments := benchmarkIntEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", 0)
 	bufferedIndexedWriteMaxBytes := benchmarkInt64Env(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_BYTES", 0)
 	bufferedIndexedWriteMaxRootRuns := benchmarkIntEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", 0)
+	bufferedIndexedAsyncFlush := benchmarkBoolEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_ASYNC_FLUSH", false) && len(indexes) > 0
+	bufferedIndexedAsyncFlushMaxQueuedUnits := benchmarkIntEnv(b, "TREEDB_COLLECTION_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS", 0)
 	indexes = append([]collections.IndexDefinition(nil), indexes...)
 	for i := range indexes {
 		indexes[i].StoragePolicy = benchmarkRootStoragePolicy(indexOuter)
@@ -585,14 +587,16 @@ func openBenchmarkCollectionWithManager(b *testing.B, name string, indexes ...co
 	if _, err := manager.CreateCollection(&collections.CollectionMeta{
 		Name: name,
 		Options: collections.CollectionOptions{
-			DocumentFormat:                   documentFormat,
-			DataRootStoragePolicy:            benchmarkRootStoragePolicy(dataOuter),
-			IndexStateStoragePolicy:          benchmarkRootStoragePolicy(dataOuter),
-			DisableIndexedWriteMemtables:     !bufferedIndexedWrites && len(indexes) > 0,
-			BufferedIndexedWrites:            bufferedIndexedWrites,
-			BufferedIndexedWriteMaxDocuments: bufferedIndexedWriteMaxDocuments,
-			BufferedIndexedWriteMaxBytes:     bufferedIndexedWriteMaxBytes,
-			BufferedIndexedWriteMaxRootRuns:  bufferedIndexedWriteMaxRootRuns,
+			DocumentFormat:                          documentFormat,
+			DataRootStoragePolicy:                   benchmarkRootStoragePolicy(dataOuter),
+			IndexStateStoragePolicy:                 benchmarkRootStoragePolicy(dataOuter),
+			DisableIndexedWriteMemtables:            !bufferedIndexedWrites && len(indexes) > 0,
+			BufferedIndexedWrites:                   bufferedIndexedWrites,
+			BufferedIndexedWriteMaxDocuments:        bufferedIndexedWriteMaxDocuments,
+			BufferedIndexedWriteMaxBytes:            bufferedIndexedWriteMaxBytes,
+			BufferedIndexedWriteMaxRootRuns:         bufferedIndexedWriteMaxRootRuns,
+			BufferedIndexedAsyncFlush:               bufferedIndexedAsyncFlush,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: bufferedIndexedAsyncFlushMaxQueuedUnits,
 		},
 		Indexes: indexes,
 	}); err != nil {

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -207,6 +207,12 @@ func benchmarkCollectionShapeInsertBatch(b *testing.B, indexCount int, checkpoin
 		if meta.Options.BufferedIndexedWriteMaxRootRuns > 0 {
 			b.ReportMetric(float64(meta.Options.BufferedIndexedWriteMaxRootRuns), "buffered_max_root_runs")
 		}
+		if meta.Options.BufferedIndexedAsyncFlush {
+			b.ReportMetric(1, "buffered_async_flush")
+			if meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits > 0 {
+				b.ReportMetric(float64(meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits), "buffered_async_max_units")
+			}
+		}
 		if insertStats.BufferedIndexedBatches > 0 && insertStats.BufferedIndexedBypassBatches == 0 && insertElapsed > 0 {
 			b.ReportMetric(float64(insertElapsed.Nanoseconds())/float64(b.N), "buffered_insert_ns/doc")
 		}

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -40,45 +40,47 @@ const (
 )
 
 type config struct {
-	Dir                          string
-	Reset                        bool
-	Docs                         int
-	BatchSize                    int
-	Collection                   string
-	DocumentFormat               collections.DocumentFormat
-	IndexCount                   int
-	BufferedIndexedWrites        bool
-	BufferedIndexedWriteMaxDocs  int
-	BufferedIndexedWriteMaxBytes int64
-	BufferedIndexedWriteMaxRuns  int
-	Profile                      treedb.Profile
-	DataOuterLeavesInValueLog    bool
-	IndexOuterLeavesInValueLog   bool
-	ChunkSize                    int64
-	KeepRecent                   uint64
-	PreferAppendAlloc            bool
-	PagerSyncConcurrency         int
-	DisableBackgroundPrune       bool
-	PruneInterval                time.Duration
-	PruneMaxPages                int
-	PruneMaxDuration             time.Duration
-	LeafSegmentTargetBytes       int64
-	Checkpoint                   bool
-	CheckpointEachBatch          bool
-	ReopenVerify                 bool
-	VerifySamples                int
-	ValueLogRewrite              bool
-	ValueLogGC                   bool
-	LeafGenerationPackGC         bool
-	LeafGenerationPackForce      bool
-	LeafGenerationPackMaxGen     int
-	LeafGenerationPackFrameK     int
-	IndexVacuum                  string
-	Progress                     bool
-	JSONOutput                   bool
-	CPUProfile                   string
-	MemProfile                   string
-	createdTempDir               bool
+	Dir                                     string
+	Reset                                   bool
+	Docs                                    int
+	BatchSize                               int
+	Collection                              string
+	DocumentFormat                          collections.DocumentFormat
+	IndexCount                              int
+	BufferedIndexedWrites                   bool
+	BufferedIndexedWriteMaxDocs             int
+	BufferedIndexedWriteMaxBytes            int64
+	BufferedIndexedWriteMaxRuns             int
+	BufferedIndexedAsyncFlush               bool
+	BufferedIndexedAsyncFlushMaxQueuedUnits int
+	Profile                                 treedb.Profile
+	DataOuterLeavesInValueLog               bool
+	IndexOuterLeavesInValueLog              bool
+	ChunkSize                               int64
+	KeepRecent                              uint64
+	PreferAppendAlloc                       bool
+	PagerSyncConcurrency                    int
+	DisableBackgroundPrune                  bool
+	PruneInterval                           time.Duration
+	PruneMaxPages                           int
+	PruneMaxDuration                        time.Duration
+	LeafSegmentTargetBytes                  int64
+	Checkpoint                              bool
+	CheckpointEachBatch                     bool
+	ReopenVerify                            bool
+	VerifySamples                           int
+	ValueLogRewrite                         bool
+	ValueLogGC                              bool
+	LeafGenerationPackGC                    bool
+	LeafGenerationPackForce                 bool
+	LeafGenerationPackMaxGen                int
+	LeafGenerationPackFrameK                int
+	IndexVacuum                             string
+	Progress                                bool
+	JSONOutput                              bool
+	CPUProfile                              string
+	MemProfile                              string
+	createdTempDir                          bool
 }
 
 type timingSummary struct {
@@ -226,51 +228,53 @@ type verifySummary struct {
 }
 
 type loadSummary struct {
-	GeneratedAt                   string                 `json:"generated_at"`
-	Dir                           string                 `json:"dir"`
-	CreatedTempDir                bool                   `json:"created_temp_dir,omitempty"`
-	Collection                    string                 `json:"collection"`
-	DocumentFormat                string                 `json:"document_format"`
-	Profile                       string                 `json:"profile"`
-	Docs                          int                    `json:"docs"`
-	BatchSize                     int                    `json:"batch_size"`
-	Batches                       int                    `json:"batches"`
-	IndexCount                    int                    `json:"index_count"`
-	BufferedIndexedWrites         bool                   `json:"buffered_indexed_writes,omitempty"`
-	BufferedIndexedWriteMaxDocs   int                    `json:"buffered_indexed_write_max_docs,omitempty"`
-	BufferedIndexedWriteMaxBytes  int64                  `json:"buffered_indexed_write_max_bytes,omitempty"`
-	BufferedIndexedWriteMaxRuns   int                    `json:"buffered_indexed_write_max_root_runs,omitempty"`
-	DataOuterLeavesInValueLog     bool                   `json:"data_outer_leaves_in_value_log"`
-	IndexOuterLeavesInValueLog    bool                   `json:"index_outer_leaves_in_value_log"`
-	ChunkSize                     int64                  `json:"chunk_size,omitempty"`
-	KeepRecent                    uint64                 `json:"keep_recent"`
-	PreferAppendAlloc             bool                   `json:"prefer_append_alloc"`
-	PagerSyncConcurrency          int                    `json:"pager_sync_concurrency,omitempty"`
-	DisableBackgroundPrune        bool                   `json:"disable_background_prune,omitempty"`
-	PruneInterval                 string                 `json:"prune_interval,omitempty"`
-	PruneMaxPages                 int                    `json:"prune_max_pages,omitempty"`
-	PruneMaxDuration              string                 `json:"prune_max_duration,omitempty"`
-	LeafSegmentTargetBytes        int64                  `json:"leaf_segment_target_bytes,omitempty"`
-	WallTiming                    timingSummary          `json:"wall_timing"`
-	GenerationTiming              timingSummary          `json:"generation_timing"`
-	InsertTiming                  timingSummary          `json:"insert_timing"`
-	FlushTiming                   timingSummary          `json:"flush_timing,omitempty"`
-	CheckpointTiming              timingSummary          `json:"checkpoint_timing,omitempty"`
-	InsertPhases                  insertPhaseSummary     `json:"insert_phases"`
-	IndexStorageBeforeMaintenance indexStorageSummary    `json:"index_storage_before_maintenance"`
-	DiskUsageBeforeMaintenance    diskUsageSummary       `json:"disk_usage_before_maintenance"`
-	DiskUsageFinal                diskUsageSummary       `json:"disk_usage_final"`
-	Rewrite                       rewriteSummary         `json:"rewrite,omitempty"`
-	LeafGeneration                *leafGenerationSummary `json:"leaf_generation,omitempty"`
-	IndexVacuum                   indexVacuumSummary     `json:"index_vacuum,omitempty"`
-	IndexStorageFinal             indexStorageSummary    `json:"index_storage_final"`
-	TreeDBStatsFinal              map[string]string      `json:"treedb_stats_final,omitempty"`
-	Verify                        verifySummary          `json:"verify"`
-	CPUProfile                    string                 `json:"cpu_profile,omitempty"`
-	MemProfile                    string                 `json:"mem_profile,omitempty"`
-	GoVersion                     string                 `json:"go_version"`
-	GOOS                          string                 `json:"goos"`
-	GOARCH                        string                 `json:"goarch"`
+	GeneratedAt                             string                 `json:"generated_at"`
+	Dir                                     string                 `json:"dir"`
+	CreatedTempDir                          bool                   `json:"created_temp_dir,omitempty"`
+	Collection                              string                 `json:"collection"`
+	DocumentFormat                          string                 `json:"document_format"`
+	Profile                                 string                 `json:"profile"`
+	Docs                                    int                    `json:"docs"`
+	BatchSize                               int                    `json:"batch_size"`
+	Batches                                 int                    `json:"batches"`
+	IndexCount                              int                    `json:"index_count"`
+	BufferedIndexedWrites                   bool                   `json:"buffered_indexed_writes,omitempty"`
+	BufferedIndexedWriteMaxDocs             int                    `json:"buffered_indexed_write_max_docs,omitempty"`
+	BufferedIndexedWriteMaxBytes            int64                  `json:"buffered_indexed_write_max_bytes,omitempty"`
+	BufferedIndexedWriteMaxRuns             int                    `json:"buffered_indexed_write_max_root_runs,omitempty"`
+	BufferedIndexedAsyncFlush               bool                   `json:"buffered_indexed_async_flush,omitempty"`
+	BufferedIndexedAsyncFlushMaxQueuedUnits int                    `json:"buffered_indexed_async_flush_max_queued_units,omitempty"`
+	DataOuterLeavesInValueLog               bool                   `json:"data_outer_leaves_in_value_log"`
+	IndexOuterLeavesInValueLog              bool                   `json:"index_outer_leaves_in_value_log"`
+	ChunkSize                               int64                  `json:"chunk_size,omitempty"`
+	KeepRecent                              uint64                 `json:"keep_recent"`
+	PreferAppendAlloc                       bool                   `json:"prefer_append_alloc"`
+	PagerSyncConcurrency                    int                    `json:"pager_sync_concurrency,omitempty"`
+	DisableBackgroundPrune                  bool                   `json:"disable_background_prune,omitempty"`
+	PruneInterval                           string                 `json:"prune_interval,omitempty"`
+	PruneMaxPages                           int                    `json:"prune_max_pages,omitempty"`
+	PruneMaxDuration                        string                 `json:"prune_max_duration,omitempty"`
+	LeafSegmentTargetBytes                  int64                  `json:"leaf_segment_target_bytes,omitempty"`
+	WallTiming                              timingSummary          `json:"wall_timing"`
+	GenerationTiming                        timingSummary          `json:"generation_timing"`
+	InsertTiming                            timingSummary          `json:"insert_timing"`
+	FlushTiming                             timingSummary          `json:"flush_timing,omitempty"`
+	CheckpointTiming                        timingSummary          `json:"checkpoint_timing,omitempty"`
+	InsertPhases                            insertPhaseSummary     `json:"insert_phases"`
+	IndexStorageBeforeMaintenance           indexStorageSummary    `json:"index_storage_before_maintenance"`
+	DiskUsageBeforeMaintenance              diskUsageSummary       `json:"disk_usage_before_maintenance"`
+	DiskUsageFinal                          diskUsageSummary       `json:"disk_usage_final"`
+	Rewrite                                 rewriteSummary         `json:"rewrite,omitempty"`
+	LeafGeneration                          *leafGenerationSummary `json:"leaf_generation,omitempty"`
+	IndexVacuum                             indexVacuumSummary     `json:"index_vacuum,omitempty"`
+	IndexStorageFinal                       indexStorageSummary    `json:"index_storage_final"`
+	TreeDBStatsFinal                        map[string]string      `json:"treedb_stats_final,omitempty"`
+	Verify                                  verifySummary          `json:"verify"`
+	CPUProfile                              string                 `json:"cpu_profile,omitempty"`
+	MemProfile                              string                 `json:"mem_profile,omitempty"`
+	GoVersion                               string                 `json:"go_version"`
+	GOOS                                    string                 `json:"goos"`
+	GOARCH                                  string                 `json:"goarch"`
 }
 
 func main() {
@@ -340,6 +344,8 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	fs.IntVar(&cfg.BufferedIndexedWriteMaxDocs, "buffered-indexed-write-max-docs", cfg.BufferedIndexedWriteMaxDocs, "flush indexed write buffers after this many staged documents; 0 uses the collection default")
 	fs.Int64Var(&cfg.BufferedIndexedWriteMaxBytes, "buffered-indexed-write-max-bytes", 0, "flush indexed write buffers after this many staged root-run bytes; 0 means Flush/Close only")
 	fs.IntVar(&cfg.BufferedIndexedWriteMaxRuns, "buffered-indexed-write-max-root-runs", cfg.BufferedIndexedWriteMaxRuns, "flush indexed write buffers after this many staged root-local mutation runs; 0 disables this trigger")
+	fs.BoolVar(&cfg.BufferedIndexedAsyncFlush, "buffered-indexed-async-flush", false, "publish threshold-triggered indexed write flushes in the background; Flush/Close still drain before returning")
+	fs.IntVar(&cfg.BufferedIndexedAsyncFlushMaxQueuedUnits, "buffered-indexed-async-flush-max-queued-units", 0, "max immutable indexed flush units queued for background publish; 0 uses the collection default when async flush is enabled")
 	fs.StringVar(&profile, "profile", string(cfg.Profile), "TreeDB profile: fast, wal_on_fast, durable, or bench")
 	fs.BoolVar(&cfg.DataOuterLeavesInValueLog, "data-outer-leaves-in-vlog", cfg.DataOuterLeavesInValueLog, "store collection primary/index-state outer leaves through the value log")
 	fs.BoolVar(&cfg.IndexOuterLeavesInValueLog, "index-outer-leaves-in-vlog", cfg.IndexOuterLeavesInValueLog, "store secondary-index outer leaves through the value log")
@@ -400,6 +406,9 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	}
 	if cfg.BufferedIndexedWriteMaxRuns < 0 {
 		return cfg, fmt.Errorf("-buffered-indexed-write-max-root-runs must be >= 0")
+	}
+	if cfg.BufferedIndexedAsyncFlushMaxQueuedUnits < 0 {
+		return cfg, fmt.Errorf("-buffered-indexed-async-flush-max-queued-units must be >= 0")
 	}
 	if strings.TrimSpace(cfg.Collection) == "" {
 		return cfg, fmt.Errorf("-collection cannot be empty")
@@ -496,7 +505,7 @@ func runFixture(cfg config) (loadSummary, error) {
 		}
 	}()
 
-	collection, err := createFixtureCollection(backend, cfg)
+	manager, collection, err := createFixtureCollection(backend, cfg)
 	if err != nil {
 		return loadSummary{}, err
 	}
@@ -589,7 +598,14 @@ func runFixture(cfg config) (loadSummary, error) {
 	if err != nil {
 		return loadSummary{}, err
 	}
-	finalStats := treedbstats.Selected(backend.Stats())
+	rawFinalStats := backend.Stats()
+	if rawFinalStats == nil {
+		rawFinalStats = make(map[string]string)
+	}
+	for key, value := range manager.Stats() {
+		rawFinalStats[key] = value
+	}
+	finalStats := treedbstats.Selected(rawFinalStats)
 	wallElapsed := time.Since(wallStart)
 
 	if !closed {
@@ -626,51 +642,53 @@ func runFixture(cfg config) (loadSummary, error) {
 	}
 
 	return loadSummary{
-		GeneratedAt:                   time.Now().UTC().Format(time.RFC3339),
-		Dir:                           cfg.Dir,
-		CreatedTempDir:                cfg.createdTempDir,
-		Collection:                    cfg.Collection,
-		DocumentFormat:                string(cfg.DocumentFormat),
-		Profile:                       string(cfg.Profile),
-		Docs:                          cfg.Docs,
-		BatchSize:                     cfg.BatchSize,
-		Batches:                       batches,
-		IndexCount:                    cfg.IndexCount,
-		BufferedIndexedWrites:         collectionMeta.Options.BufferedIndexedWrites,
-		BufferedIndexedWriteMaxDocs:   collectionMeta.Options.BufferedIndexedWriteMaxDocuments,
-		BufferedIndexedWriteMaxBytes:  collectionMeta.Options.BufferedIndexedWriteMaxBytes,
-		BufferedIndexedWriteMaxRuns:   collectionMeta.Options.BufferedIndexedWriteMaxRootRuns,
-		DataOuterLeavesInValueLog:     cfg.DataOuterLeavesInValueLog,
-		IndexOuterLeavesInValueLog:    cfg.IndexOuterLeavesInValueLog,
-		ChunkSize:                     cfg.ChunkSize,
-		KeepRecent:                    cfg.KeepRecent,
-		PreferAppendAlloc:             cfg.PreferAppendAlloc,
-		PagerSyncConcurrency:          cfg.PagerSyncConcurrency,
-		DisableBackgroundPrune:        cfg.DisableBackgroundPrune,
-		PruneInterval:                 durationString(cfg.PruneInterval),
-		PruneMaxPages:                 cfg.PruneMaxPages,
-		PruneMaxDuration:              durationString(cfg.PruneMaxDuration),
-		LeafSegmentTargetBytes:        cfg.LeafSegmentTargetBytes,
-		WallTiming:                    timing(wallElapsed, cfg.Docs),
-		GenerationTiming:              timing(generationElapsed, cfg.Docs),
-		InsertTiming:                  timing(insertElapsed, cfg.Docs),
-		FlushTiming:                   timing(flushElapsed, cfg.Docs),
-		CheckpointTiming:              timing(checkpointElapsed, cfg.Docs),
-		InsertPhases:                  summarizeInsertPhases(insertStats, secondaryRuns, cfg.Docs, batches),
-		IndexStorageBeforeMaintenance: beforeIndexStorage,
-		DiskUsageBeforeMaintenance:    beforeMaintenance,
-		DiskUsageFinal:                finalUsage,
-		Rewrite:                       rewrite,
-		LeafGeneration:                leafGeneration,
-		IndexVacuum:                   indexVacuum,
-		IndexStorageFinal:             finalIndexStorage,
-		TreeDBStatsFinal:              finalStats,
-		Verify:                        verify,
-		CPUProfile:                    cfg.CPUProfile,
-		MemProfile:                    cfg.MemProfile,
-		GoVersion:                     runtime.Version(),
-		GOOS:                          runtime.GOOS,
-		GOARCH:                        runtime.GOARCH,
+		GeneratedAt:                             time.Now().UTC().Format(time.RFC3339),
+		Dir:                                     cfg.Dir,
+		CreatedTempDir:                          cfg.createdTempDir,
+		Collection:                              cfg.Collection,
+		DocumentFormat:                          string(cfg.DocumentFormat),
+		Profile:                                 string(cfg.Profile),
+		Docs:                                    cfg.Docs,
+		BatchSize:                               cfg.BatchSize,
+		Batches:                                 batches,
+		IndexCount:                              cfg.IndexCount,
+		BufferedIndexedWrites:                   collectionMeta.Options.BufferedIndexedWrites,
+		BufferedIndexedWriteMaxDocs:             collectionMeta.Options.BufferedIndexedWriteMaxDocuments,
+		BufferedIndexedWriteMaxBytes:            collectionMeta.Options.BufferedIndexedWriteMaxBytes,
+		BufferedIndexedWriteMaxRuns:             collectionMeta.Options.BufferedIndexedWriteMaxRootRuns,
+		BufferedIndexedAsyncFlush:               collectionMeta.Options.BufferedIndexedAsyncFlush && collectionMeta.Options.BufferedIndexedWrites,
+		BufferedIndexedAsyncFlushMaxQueuedUnits: collectionMeta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits,
+		DataOuterLeavesInValueLog:               cfg.DataOuterLeavesInValueLog,
+		IndexOuterLeavesInValueLog:              cfg.IndexOuterLeavesInValueLog,
+		ChunkSize:                               cfg.ChunkSize,
+		KeepRecent:                              cfg.KeepRecent,
+		PreferAppendAlloc:                       cfg.PreferAppendAlloc,
+		PagerSyncConcurrency:                    cfg.PagerSyncConcurrency,
+		DisableBackgroundPrune:                  cfg.DisableBackgroundPrune,
+		PruneInterval:                           durationString(cfg.PruneInterval),
+		PruneMaxPages:                           cfg.PruneMaxPages,
+		PruneMaxDuration:                        durationString(cfg.PruneMaxDuration),
+		LeafSegmentTargetBytes:                  cfg.LeafSegmentTargetBytes,
+		WallTiming:                              timing(wallElapsed, cfg.Docs),
+		GenerationTiming:                        timing(generationElapsed, cfg.Docs),
+		InsertTiming:                            timing(insertElapsed, cfg.Docs),
+		FlushTiming:                             timing(flushElapsed, cfg.Docs),
+		CheckpointTiming:                        timing(checkpointElapsed, cfg.Docs),
+		InsertPhases:                            summarizeInsertPhases(insertStats, secondaryRuns, cfg.Docs, batches),
+		IndexStorageBeforeMaintenance:           beforeIndexStorage,
+		DiskUsageBeforeMaintenance:              beforeMaintenance,
+		DiskUsageFinal:                          finalUsage,
+		Rewrite:                                 rewrite,
+		LeafGeneration:                          leafGeneration,
+		IndexVacuum:                             indexVacuum,
+		IndexStorageFinal:                       finalIndexStorage,
+		TreeDBStatsFinal:                        finalStats,
+		Verify:                                  verify,
+		CPUProfile:                              cfg.CPUProfile,
+		MemProfile:                              cfg.MemProfile,
+		GoVersion:                               runtime.Version(),
+		GOOS:                                    runtime.GOOS,
+		GOARCH:                                  runtime.GOARCH,
 	}, nil
 }
 
@@ -749,7 +767,7 @@ func openBackendReadOnly(cfg config, readOnly bool) (*backenddb.DB, func() error
 	return backend, cleanup, nil
 }
 
-func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Collection, error) {
+func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.CollectionManager, *collections.Collection, error) {
 	manager := collections.NewCollectionManager(backend)
 	indexes := collectionShapeIndexes(cfg.IndexCount)
 	for i := range indexes {
@@ -759,33 +777,39 @@ func createFixtureCollection(backend *backenddb.DB, cfg config) (*collections.Co
 	bufferedIndexedWriteMaxDocs := 0
 	var bufferedIndexedWriteMaxBytes int64
 	bufferedIndexedWriteMaxRuns := 0
+	bufferedIndexedAsyncFlush := false
+	bufferedIndexedAsyncFlushMaxQueuedUnits := 0
 	if bufferedIndexedWrites {
 		bufferedIndexedWriteMaxDocs = cfg.BufferedIndexedWriteMaxDocs
 		bufferedIndexedWriteMaxBytes = cfg.BufferedIndexedWriteMaxBytes
 		bufferedIndexedWriteMaxRuns = cfg.BufferedIndexedWriteMaxRuns
+		bufferedIndexedAsyncFlush = cfg.BufferedIndexedAsyncFlush
+		bufferedIndexedAsyncFlushMaxQueuedUnits = cfg.BufferedIndexedAsyncFlushMaxQueuedUnits
 	}
 	_, err := manager.CreateCollection(&collections.CollectionMeta{
 		Name: cfg.Collection,
 		Options: collections.CollectionOptions{
-			DocumentFormat:                   cfg.DocumentFormat,
-			DataRootStoragePolicy:            rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
-			IndexStateStoragePolicy:          rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
-			DisableIndexedWriteMemtables:     !cfg.BufferedIndexedWrites && cfg.IndexCount > 0,
-			BufferedIndexedWrites:            bufferedIndexedWrites,
-			BufferedIndexedWriteMaxDocuments: bufferedIndexedWriteMaxDocs,
-			BufferedIndexedWriteMaxBytes:     bufferedIndexedWriteMaxBytes,
-			BufferedIndexedWriteMaxRootRuns:  bufferedIndexedWriteMaxRuns,
+			DocumentFormat:                          cfg.DocumentFormat,
+			DataRootStoragePolicy:                   rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+			IndexStateStoragePolicy:                 rootStoragePolicy(cfg.DataOuterLeavesInValueLog),
+			DisableIndexedWriteMemtables:            !cfg.BufferedIndexedWrites && cfg.IndexCount > 0,
+			BufferedIndexedWrites:                   bufferedIndexedWrites,
+			BufferedIndexedWriteMaxDocuments:        bufferedIndexedWriteMaxDocs,
+			BufferedIndexedWriteMaxBytes:            bufferedIndexedWriteMaxBytes,
+			BufferedIndexedWriteMaxRootRuns:         bufferedIndexedWriteMaxRuns,
+			BufferedIndexedAsyncFlush:               bufferedIndexedAsyncFlush,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: bufferedIndexedAsyncFlushMaxQueuedUnits,
 		},
 		Indexes: indexes,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("create collection: %w", err)
+		return nil, nil, fmt.Errorf("create collection: %w", err)
 	}
 	collection, err := manager.OpenCollection(cfg.Collection)
 	if err != nil {
-		return nil, fmt.Errorf("open collection: %w", err)
+		return nil, nil, fmt.Errorf("open collection: %w", err)
 	}
-	return collection, nil
+	return manager, collection, nil
 }
 
 func rootStoragePolicy(outerLeavesInValueLog bool) collections.RootStoragePolicy {
@@ -1609,6 +1633,9 @@ func printHumanSummary(w io.Writer, summary loadSummary) {
 		if summary.BufferedIndexedWriteMaxDocs > 0 || summary.BufferedIndexedWriteMaxBytes > 0 || summary.BufferedIndexedWriteMaxRuns > 0 {
 			fmt.Fprintf(w, "indexed write buffer limits: max_docs=%d max_bytes=%s max_root_runs=%d\n",
 				summary.BufferedIndexedWriteMaxDocs, humanBytes(uint64(summary.BufferedIndexedWriteMaxBytes)), summary.BufferedIndexedWriteMaxRuns)
+		}
+		if summary.BufferedIndexedAsyncFlush {
+			fmt.Fprintf(w, "indexed async flush: enabled max_queued_units=%d\n", summary.BufferedIndexedAsyncFlushMaxQueuedUnits)
 		}
 	}
 	fmt.Fprintf(w, "index policy: keep_recent=%d prefer_append_alloc=%t background_prune=%t\n",

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -170,6 +170,8 @@ func TestRunFixtureReportsBufferedIndexedWritesOnlyWhenIndexesUseThem(t *testing
 		"-buffered-indexed-write-max-docs", "16",
 		"-buffered-indexed-write-max-bytes", "1024",
 		"-buffered-indexed-write-max-root-runs", "8",
+		"-buffered-indexed-async-flush",
+		"-buffered-indexed-async-flush-max-queued-units", "3",
 		"-reopen-verify=false",
 		"-progress=false",
 	}, io.Discard)
@@ -187,6 +189,10 @@ func TestRunFixtureReportsBufferedIndexedWritesOnlyWhenIndexesUseThem(t *testing
 		t.Fatalf("no-index buffered limits docs=%d bytes=%d rootRuns=%d want zero",
 			noIndexSummary.BufferedIndexedWriteMaxDocs, noIndexSummary.BufferedIndexedWriteMaxBytes, noIndexSummary.BufferedIndexedWriteMaxRuns)
 	}
+	if noIndexSummary.BufferedIndexedAsyncFlush || noIndexSummary.BufferedIndexedAsyncFlushMaxQueuedUnits != 0 {
+		t.Fatalf("no-index async flush=%t max=%d want false/0",
+			noIndexSummary.BufferedIndexedAsyncFlush, noIndexSummary.BufferedIndexedAsyncFlushMaxQueuedUnits)
+	}
 
 	indexedDir := filepath.Join(t.TempDir(), "indexed")
 	indexedCfg, err := parseConfig([]string{
@@ -198,6 +204,8 @@ func TestRunFixtureReportsBufferedIndexedWritesOnlyWhenIndexesUseThem(t *testing
 		"-buffered-indexed-write-max-docs", "16",
 		"-buffered-indexed-write-max-bytes", "1024",
 		"-buffered-indexed-write-max-root-runs", "8",
+		"-buffered-indexed-async-flush",
+		"-buffered-indexed-async-flush-max-queued-units", "3",
 		"-progress=false",
 	}, io.Discard)
 	if err != nil {
@@ -213,6 +221,13 @@ func TestRunFixtureReportsBufferedIndexedWritesOnlyWhenIndexesUseThem(t *testing
 	if indexedSummary.BufferedIndexedWriteMaxDocs != 16 || indexedSummary.BufferedIndexedWriteMaxBytes != 1024 || indexedSummary.BufferedIndexedWriteMaxRuns != 8 {
 		t.Fatalf("indexed buffered limits docs=%d bytes=%d rootRuns=%d want 16/1024/8",
 			indexedSummary.BufferedIndexedWriteMaxDocs, indexedSummary.BufferedIndexedWriteMaxBytes, indexedSummary.BufferedIndexedWriteMaxRuns)
+	}
+	if !indexedSummary.BufferedIndexedAsyncFlush || indexedSummary.BufferedIndexedAsyncFlushMaxQueuedUnits != 3 {
+		t.Fatalf("indexed async flush=%t max=%d want true/3",
+			indexedSummary.BufferedIndexedAsyncFlush, indexedSummary.BufferedIndexedAsyncFlushMaxQueuedUnits)
+	}
+	if indexedSummary.TreeDBStatsFinal["treedb.collections.write_domain.indexed_stage.batches_total"] == "" {
+		t.Fatalf("indexed summary missing collection write-domain stats: %#v", indexedSummary.TreeDBStatsFinal)
 	}
 
 	disabledDir := filepath.Join(t.TempDir(), "disabled")

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -40,47 +40,49 @@ import (
 const defaultMongoDriverMaxPoolSize = 100
 
 type config struct {
-	Target                                 string
-	MongoURI                               string
-	TreeDBDir                              string
-	KeepTreeDBDir                          bool
-	DropBeforeRun                          bool
-	Database                               string
-	Collection                             string
-	Documents                              int
-	BatchSize                              int
-	InsertProducers                        int
-	MongoMaxPoolSize                       int
-	MongoMinPoolSize                       int
-	MongoMaxConnecting                     int
-	Reads                                  int
-	RangeReads                             int
-	Updates                                int
-	Deletes                                int
-	ConcurrentReaders                      int
-	ConcurrentReads                        int
-	ConcurrentWriters                      int
-	ConcurrentWrites                       int
-	UpdateIndexedField                     bool
-	SecondaryIndexes                       int
-	ClientMode                             string
-	TreeDBProfile                          treedb.Profile
-	TreeDBDocumentFormat                   collections.DocumentFormat
-	TreeDBDataRootStorage                  collections.RootStoragePolicy
-	TreeDBIndexStateRootStorage            collections.RootStoragePolicy
-	TreeDBIndexRootStorage                 collections.RootStoragePolicy
-	TreeDBBufferedIndexedWriteMaxDocuments int
-	TreeDBBufferedIndexedWriteMaxBytes     int64
-	TreeDBBufferedIndexedWriteMaxRootRuns  int
-	TreeDBMaintenance                      string
-	PrebuildDocuments                      bool
-	ProfileDir                             string
-	ProfileBlockRate                       int
-	ProfileMutexFraction                   int
-	ProfileTrace                           bool
-	ProfileHeapGC                          bool
-	Timeout                                time.Duration
-	Format                                 string
+	Target                                        string
+	MongoURI                                      string
+	TreeDBDir                                     string
+	KeepTreeDBDir                                 bool
+	DropBeforeRun                                 bool
+	Database                                      string
+	Collection                                    string
+	Documents                                     int
+	BatchSize                                     int
+	InsertProducers                               int
+	MongoMaxPoolSize                              int
+	MongoMinPoolSize                              int
+	MongoMaxConnecting                            int
+	Reads                                         int
+	RangeReads                                    int
+	Updates                                       int
+	Deletes                                       int
+	ConcurrentReaders                             int
+	ConcurrentReads                               int
+	ConcurrentWriters                             int
+	ConcurrentWrites                              int
+	UpdateIndexedField                            bool
+	SecondaryIndexes                              int
+	ClientMode                                    string
+	TreeDBProfile                                 treedb.Profile
+	TreeDBDocumentFormat                          collections.DocumentFormat
+	TreeDBDataRootStorage                         collections.RootStoragePolicy
+	TreeDBIndexStateRootStorage                   collections.RootStoragePolicy
+	TreeDBIndexRootStorage                        collections.RootStoragePolicy
+	TreeDBBufferedIndexedWriteMaxDocuments        int
+	TreeDBBufferedIndexedWriteMaxBytes            int64
+	TreeDBBufferedIndexedWriteMaxRootRuns         int
+	TreeDBBufferedIndexedAsyncFlush               bool
+	TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits int
+	TreeDBMaintenance                             string
+	PrebuildDocuments                             bool
+	ProfileDir                                    string
+	ProfileBlockRate                              int
+	ProfileMutexFraction                          int
+	ProfileTrace                                  bool
+	ProfileHeapGC                                 bool
+	Timeout                                       time.Duration
+	Format                                        string
 }
 
 type benchmarkResult struct {
@@ -106,31 +108,33 @@ type benchmarkResult struct {
 	// false runs from older runs that predate indexed-field update coverage.
 	UpdateIndexedField bool `json:"update_indexed_field"`
 
-	TreeDBProfile                          string              `json:"treedb_profile,omitempty"`
-	TreeDBDocumentFormat                   string              `json:"treedb_document_format,omitempty"`
-	TreeDBDataRootStorage                  string              `json:"treedb_data_root_storage,omitempty"`
-	TreeDBIndexStateRootStorage            string              `json:"treedb_index_state_root_storage,omitempty"`
-	TreeDBIndexRootStorage                 string              `json:"treedb_index_root_storage,omitempty"`
-	TreeDBBufferedIndexedWriteMaxDocuments int                 `json:"treedb_buffered_indexed_write_max_documents"`
-	TreeDBBufferedIndexedWriteMaxBytes     int64               `json:"treedb_buffered_indexed_write_max_bytes"`
-	TreeDBBufferedIndexedWriteMaxRootRuns  int                 `json:"treedb_buffered_indexed_write_max_root_runs"`
-	TreeDBMaintenanceMode                  string              `json:"treedb_maintenance_mode,omitempty"`
-	PrebuildDocuments                      bool                `json:"prebuild_documents,omitempty"`
-	Phases                                 []phaseResult       `json:"phases"`
-	TreeDBDiskAfterLoad                    *diskSnapshot       `json:"treedb_disk_after_load,omitempty"`
-	TreeDBDiskAfterCheckpoint              *diskSnapshot       `json:"treedb_disk_after_checkpoint,omitempty"`
-	TreeDBDiskAfterMaintenance             *diskSnapshot       `json:"treedb_disk_after_maintenance,omitempty"`
-	TreeDBStatsAfterLoad                   map[string]string   `json:"treedb_stats_after_load,omitempty"`
-	TreeDBStatsAfterCheckpoint             map[string]string   `json:"treedb_stats_after_checkpoint,omitempty"`
-	TreeDBStatsFinal                       map[string]string   `json:"treedb_stats_final,omitempty"`
-	TreeDBMaintenance                      []maintenanceResult `json:"treedb_maintenance,omitempty"`
-	MongoDBStatsAfterLoad                  map[string]any      `json:"mongodb_stats_after_load,omitempty"`
-	MongoDBStatsFinal                      map[string]any      `json:"mongodb_stats_final,omitempty"`
-	MongoPoolStatsAfterLoad                *mongoPoolSnapshot  `json:"mongo_pool_stats_after_load,omitempty"`
-	MongoPoolStatsFinal                    *mongoPoolSnapshot  `json:"mongo_pool_stats_final,omitempty"`
-	ProfileDir                             string              `json:"profile_dir,omitempty"`
-	ProfileManifest                        string              `json:"profile_manifest,omitempty"`
-	ProfileResult                          string              `json:"profile_result,omitempty"`
+	TreeDBProfile                                 string              `json:"treedb_profile,omitempty"`
+	TreeDBDocumentFormat                          string              `json:"treedb_document_format,omitempty"`
+	TreeDBDataRootStorage                         string              `json:"treedb_data_root_storage,omitempty"`
+	TreeDBIndexStateRootStorage                   string              `json:"treedb_index_state_root_storage,omitempty"`
+	TreeDBIndexRootStorage                        string              `json:"treedb_index_root_storage,omitempty"`
+	TreeDBBufferedIndexedWriteMaxDocuments        int                 `json:"treedb_buffered_indexed_write_max_documents"`
+	TreeDBBufferedIndexedWriteMaxBytes            int64               `json:"treedb_buffered_indexed_write_max_bytes"`
+	TreeDBBufferedIndexedWriteMaxRootRuns         int                 `json:"treedb_buffered_indexed_write_max_root_runs"`
+	TreeDBBufferedIndexedAsyncFlush               bool                `json:"treedb_buffered_indexed_async_flush,omitempty"`
+	TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits int                 `json:"treedb_buffered_indexed_async_flush_max_queued_units,omitempty"`
+	TreeDBMaintenanceMode                         string              `json:"treedb_maintenance_mode,omitempty"`
+	PrebuildDocuments                             bool                `json:"prebuild_documents,omitempty"`
+	Phases                                        []phaseResult       `json:"phases"`
+	TreeDBDiskAfterLoad                           *diskSnapshot       `json:"treedb_disk_after_load,omitempty"`
+	TreeDBDiskAfterCheckpoint                     *diskSnapshot       `json:"treedb_disk_after_checkpoint,omitempty"`
+	TreeDBDiskAfterMaintenance                    *diskSnapshot       `json:"treedb_disk_after_maintenance,omitempty"`
+	TreeDBStatsAfterLoad                          map[string]string   `json:"treedb_stats_after_load,omitempty"`
+	TreeDBStatsAfterCheckpoint                    map[string]string   `json:"treedb_stats_after_checkpoint,omitempty"`
+	TreeDBStatsFinal                              map[string]string   `json:"treedb_stats_final,omitempty"`
+	TreeDBMaintenance                             []maintenanceResult `json:"treedb_maintenance,omitempty"`
+	MongoDBStatsAfterLoad                         map[string]any      `json:"mongodb_stats_after_load,omitempty"`
+	MongoDBStatsFinal                             map[string]any      `json:"mongodb_stats_final,omitempty"`
+	MongoPoolStatsAfterLoad                       *mongoPoolSnapshot  `json:"mongo_pool_stats_after_load,omitempty"`
+	MongoPoolStatsFinal                           *mongoPoolSnapshot  `json:"mongo_pool_stats_final,omitempty"`
+	ProfileDir                                    string              `json:"profile_dir,omitempty"`
+	ProfileManifest                               string              `json:"profile_manifest,omitempty"`
+	ProfileResult                                 string              `json:"profile_result,omitempty"`
 }
 
 type phaseResult struct {
@@ -464,6 +468,8 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.TreeDBBufferedIndexedWriteMaxDocuments, "treedb-buffered-indexed-write-max-documents", cfg.TreeDBBufferedIndexedWriteMaxDocuments, "TreeDB indexed collection write-domain document auto-flush threshold; 0 uses the collection default")
 	fs.Int64Var(&cfg.TreeDBBufferedIndexedWriteMaxBytes, "treedb-buffered-indexed-write-max-bytes", cfg.TreeDBBufferedIndexedWriteMaxBytes, "TreeDB indexed collection write-domain byte auto-flush threshold; 0 disables this trigger")
 	fs.IntVar(&cfg.TreeDBBufferedIndexedWriteMaxRootRuns, "treedb-buffered-indexed-write-max-root-runs", cfg.TreeDBBufferedIndexedWriteMaxRootRuns, "TreeDB indexed collection write-domain root-run auto-flush threshold; 0 disables this trigger unless all thresholds normalize to collection defaults")
+	fs.BoolVar(&cfg.TreeDBBufferedIndexedAsyncFlush, "treedb-buffered-indexed-async-flush", false, "TreeDB indexed collection threshold flushes publish in the background; explicit Flush/Close still drain before returning")
+	fs.IntVar(&cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, "treedb-buffered-indexed-async-flush-max-queued-units", 0, "TreeDB indexed collection background flush unit queue limit; 0 uses the collection default when async flush is enabled")
 	fs.StringVar(&cfg.TreeDBMaintenance, "treedb-maintenance", cfg.TreeDBMaintenance, "TreeDB final disk maintenance for -target treedb: full, checkpoint, or none")
 	fs.BoolVar(&cfg.PrebuildDocuments, "prebuild-documents", false, "prebuild benchmark documents before the timed load phase")
 	fs.StringVar(&cfg.ProfileDir, "profile-dir", "", "write per-phase pprof artifacts and a profile_manifest.json into an empty directory")
@@ -550,6 +556,9 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.TreeDBBufferedIndexedWriteMaxRootRuns < 0 {
 		return config{}, errors.New("treedb-buffered-indexed-write-max-root-runs must be >= 0")
+	}
+	if cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits < 0 {
+		return config{}, errors.New("treedb-buffered-indexed-async-flush-max-queued-units must be >= 0")
 	}
 	if cfg.Format != "text" && cfg.Format != "json" {
 		return config{}, fmt.Errorf("unknown format %q", cfg.Format)
@@ -713,12 +722,14 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 	server.Collections = manager
 	server.MaxFindScanDocuments = cfg.Documents
 	server.DefaultCollectionOptions = collections.CollectionOptions{
-		DocumentFormat:                   cfg.TreeDBDocumentFormat,
-		DataRootStoragePolicy:            cfg.TreeDBDataRootStorage,
-		IndexStateStoragePolicy:          cfg.TreeDBIndexStateRootStorage,
-		BufferedIndexedWriteMaxDocuments: cfg.TreeDBBufferedIndexedWriteMaxDocuments,
-		BufferedIndexedWriteMaxBytes:     cfg.TreeDBBufferedIndexedWriteMaxBytes,
-		BufferedIndexedWriteMaxRootRuns:  cfg.TreeDBBufferedIndexedWriteMaxRootRuns,
+		DocumentFormat:                          cfg.TreeDBDocumentFormat,
+		DataRootStoragePolicy:                   cfg.TreeDBDataRootStorage,
+		IndexStateStoragePolicy:                 cfg.TreeDBIndexStateRootStorage,
+		BufferedIndexedWriteMaxDocuments:        cfg.TreeDBBufferedIndexedWriteMaxDocuments,
+		BufferedIndexedWriteMaxBytes:            cfg.TreeDBBufferedIndexedWriteMaxBytes,
+		BufferedIndexedWriteMaxRootRuns:         cfg.TreeDBBufferedIndexedWriteMaxRootRuns,
+		BufferedIndexedAsyncFlush:               cfg.TreeDBBufferedIndexedAsyncFlush,
+		BufferedIndexedAsyncFlushMaxQueuedUnits: cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
 	}
 	server.DefaultIndexStoragePolicy = cfg.TreeDBIndexRootStorage
 
@@ -1033,6 +1044,8 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.TreeDBBufferedIndexedWriteMaxDocuments = cfg.TreeDBBufferedIndexedWriteMaxDocuments
 		result.TreeDBBufferedIndexedWriteMaxBytes = cfg.TreeDBBufferedIndexedWriteMaxBytes
 		result.TreeDBBufferedIndexedWriteMaxRootRuns = cfg.TreeDBBufferedIndexedWriteMaxRootRuns
+		result.TreeDBBufferedIndexedAsyncFlush = cfg.TreeDBBufferedIndexedAsyncFlush
+		result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits = cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits
 		result.TreeDBMaintenanceMode = cfg.TreeDBMaintenance
 	} else {
 		result.MongoURI = redactMongoURI(cfg.MongoURI)
@@ -1335,6 +1348,8 @@ func recordEffectiveTreeDBCollectionOptions(result *benchmarkResult, cfg config,
 	result.TreeDBBufferedIndexedWriteMaxDocuments = meta.Options.BufferedIndexedWriteMaxDocuments
 	result.TreeDBBufferedIndexedWriteMaxBytes = meta.Options.BufferedIndexedWriteMaxBytes
 	result.TreeDBBufferedIndexedWriteMaxRootRuns = meta.Options.BufferedIndexedWriteMaxRootRuns
+	result.TreeDBBufferedIndexedAsyncFlush = meta.Options.BufferedIndexedAsyncFlush
+	result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits = meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits
 	return nil
 }
 
@@ -2579,11 +2594,12 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 			fmt.Fprintf(out, "treedb_dir=%s\n", result.TreeDBDir)
 		}
 		if result.TreeDBProfile != "" {
-			fmt.Fprintf(out, "treedb_profile=%s document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s buffered_indexed_max_docs=%d buffered_indexed_max_bytes=%d buffered_indexed_max_root_runs=%d maintenance=%s\n",
+			fmt.Fprintf(out, "treedb_profile=%s document_format=%s data_root_storage=%s index_state_root_storage=%s index_root_storage=%s buffered_indexed_max_docs=%d buffered_indexed_max_bytes=%d buffered_indexed_max_root_runs=%d buffered_indexed_async_flush=%t buffered_indexed_async_max_queued_units=%d maintenance=%s\n",
 				result.TreeDBProfile, result.TreeDBDocumentFormat, result.TreeDBDataRootStorage,
 				result.TreeDBIndexStateRootStorage, result.TreeDBIndexRootStorage,
 				result.TreeDBBufferedIndexedWriteMaxDocuments, result.TreeDBBufferedIndexedWriteMaxBytes,
-				result.TreeDBBufferedIndexedWriteMaxRootRuns, result.TreeDBMaintenanceMode)
+				result.TreeDBBufferedIndexedWriteMaxRootRuns, result.TreeDBBufferedIndexedAsyncFlush,
+				result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits, result.TreeDBMaintenanceMode)
 		}
 		if result.MongoURI != "" {
 			fmt.Fprintf(out, "mongo_uri=%s\n", result.MongoURI)

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -512,6 +512,12 @@ func TestParseConfigTreeDBCorrectnessDefaults(t *testing.T) {
 	if cfg.TreeDBBufferedIndexedWriteMaxRootRuns != collections.DefaultIndexedWriteMemtableMaxRootRuns {
 		t.Fatalf("TreeDBBufferedIndexedWriteMaxRootRuns=%d want %d", cfg.TreeDBBufferedIndexedWriteMaxRootRuns, collections.DefaultIndexedWriteMemtableMaxRootRuns)
 	}
+	if cfg.TreeDBBufferedIndexedAsyncFlush {
+		t.Fatal("TreeDBBufferedIndexedAsyncFlush=true want false by default")
+	}
+	if cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 0 {
+		t.Fatalf("TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits=%d want 0", cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits)
+	}
 	if cfg.InsertProducers != 1 {
 		t.Fatalf("InsertProducers=%d want 1", cfg.InsertProducers)
 	}
@@ -522,6 +528,8 @@ func TestParseConfigTreeDBBufferedIndexedWriteThresholds(t *testing.T) {
 		"-treedb-buffered-indexed-write-max-documents", "1234",
 		"-treedb-buffered-indexed-write-max-bytes", "5678",
 		"-treedb-buffered-indexed-write-max-root-runs", "90",
+		"-treedb-buffered-indexed-async-flush",
+		"-treedb-buffered-indexed-async-flush-max-queued-units", "3",
 	})
 	if err != nil {
 		t.Fatalf("parse buffered indexed thresholds: %v", err)
@@ -534,6 +542,12 @@ func TestParseConfigTreeDBBufferedIndexedWriteThresholds(t *testing.T) {
 	}
 	if cfg.TreeDBBufferedIndexedWriteMaxRootRuns != 90 {
 		t.Fatalf("TreeDBBufferedIndexedWriteMaxRootRuns=%d want 90", cfg.TreeDBBufferedIndexedWriteMaxRootRuns)
+	}
+	if !cfg.TreeDBBufferedIndexedAsyncFlush {
+		t.Fatal("TreeDBBufferedIndexedAsyncFlush=false want true")
+	}
+	if cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 {
+		t.Fatalf("TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits=%d want 3", cfg.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits)
 	}
 }
 
@@ -1500,7 +1514,9 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		TreeDBBufferedIndexedWriteMaxDocuments: 1234,
 		TreeDBBufferedIndexedWriteMaxBytes:     5678,
 		TreeDBBufferedIndexedWriteMaxRootRuns:  90,
-		TreeDBMaintenanceMode:                  "none",
+		TreeDBBufferedIndexedAsyncFlush:        true,
+		TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits: 3,
+		TreeDBMaintenanceMode:                         "none",
 	}
 	var out bytes.Buffer
 	if err := writeResult(&out, "text", result); err != nil {
@@ -1511,6 +1527,8 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		"buffered_indexed_max_docs=1234",
 		"buffered_indexed_max_bytes=5678",
 		"buffered_indexed_max_root_runs=90",
+		"buffered_indexed_async_flush=true",
+		"buffered_indexed_async_max_queued_units=3",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("text output missing %s: %q", want, text)
@@ -1527,11 +1545,15 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	}
 	if decoded.TreeDBBufferedIndexedWriteMaxDocuments != 1234 ||
 		decoded.TreeDBBufferedIndexedWriteMaxBytes != 5678 ||
-		decoded.TreeDBBufferedIndexedWriteMaxRootRuns != 90 {
-		t.Fatalf("json thresholds docs=%d bytes=%d rootRuns=%d want 1234/5678/90",
+		decoded.TreeDBBufferedIndexedWriteMaxRootRuns != 90 ||
+		!decoded.TreeDBBufferedIndexedAsyncFlush ||
+		decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 {
+		t.Fatalf("json thresholds docs=%d bytes=%d rootRuns=%d async=%t asyncMax=%d want 1234/5678/90/true/3",
 			decoded.TreeDBBufferedIndexedWriteMaxDocuments,
 			decoded.TreeDBBufferedIndexedWriteMaxBytes,
-			decoded.TreeDBBufferedIndexedWriteMaxRootRuns)
+			decoded.TreeDBBufferedIndexedWriteMaxRootRuns,
+			decoded.TreeDBBufferedIndexedAsyncFlush,
+			decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits)
 	}
 }
 
@@ -1545,9 +1567,11 @@ func TestRecordEffectiveTreeDBCollectionOptionsUsesNormalizedMetadata(t *testing
 	if _, err := manager.CreateCollection(&collections.CollectionMeta{
 		Name: "bench.docs",
 		Options: collections.CollectionOptions{
-			BufferedIndexedWriteMaxDocuments: 0,
-			BufferedIndexedWriteMaxBytes:     777,
-			BufferedIndexedWriteMaxRootRuns:  0,
+			BufferedIndexedWriteMaxDocuments:        0,
+			BufferedIndexedWriteMaxBytes:            777,
+			BufferedIndexedWriteMaxRootRuns:         0,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 3,
 		},
 		Indexes: []collections.IndexDefinition{{Name: "email_1", Field: "email", Unique: true}},
 	}); err != nil {
@@ -1569,11 +1593,15 @@ func TestRecordEffectiveTreeDBCollectionOptionsUsesNormalizedMetadata(t *testing
 	}
 	if result.TreeDBBufferedIndexedWriteMaxDocuments != collections.DefaultIndexedWriteMemtableMaxDocuments ||
 		result.TreeDBBufferedIndexedWriteMaxBytes != 777 ||
-		result.TreeDBBufferedIndexedWriteMaxRootRuns != 0 {
-		t.Fatalf("effective thresholds docs=%d bytes=%d rootRuns=%d want %d/777/0",
+		result.TreeDBBufferedIndexedWriteMaxRootRuns != 0 ||
+		!result.TreeDBBufferedIndexedAsyncFlush ||
+		result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 {
+		t.Fatalf("effective thresholds docs=%d bytes=%d rootRuns=%d async=%t asyncMax=%d want %d/777/0/true/3",
 			result.TreeDBBufferedIndexedWriteMaxDocuments,
 			result.TreeDBBufferedIndexedWriteMaxBytes,
 			result.TreeDBBufferedIndexedWriteMaxRootRuns,
+			result.TreeDBBufferedIndexedAsyncFlush,
+			result.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
 			collections.DefaultIndexedWriteMemtableMaxDocuments)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up for #1132. This PR adds an opt-in async indexed flush mode on top of the merged indexed flush-unit work. It keeps the default synchronous threshold behavior unchanged. When `BufferedIndexedAsyncFlush` is enabled, thresholded mutable indexed runs rotate into immutable flush units and an idle-debounced background publisher drains them. `Flush`, `FlushAll`, and backend `Close` remain drain barriers. A bounded queue limit falls back to synchronous publish to cap memory and visibility lag.

Key correctness points:
- async mode is explicit metadata/CLI configuration, not the default
- reads and unique checks continue to see base roots + queued immutable units + current mutable runs
- mutable docs/bytes are tracked separately from total pending docs/bytes so async thresholds rotate at real per-unit thresholds instead of every batch after the first threshold
- collection stats now expose pending flush units, async schedules, backpressure syncs, async errors, and running async flush domains
- collection-load-fixture and mongo_gateway_bench expose the async knobs for reproducible benchmark runs

## Benchmarks

Go benchmark command:

```bash
TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 \
TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=true \
TREEDB_COLLECTION_BENCH_BATCH_SIZE=800 \
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionShapeInsertBatch/indexes_2$' -benchtime=100000x -count=3

TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 \
TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=true \
TREEDB_COLLECTION_BENCH_BATCH_SIZE=800 \
TREEDB_COLLECTION_BUFFERED_INDEXED_ASYNC_FLUSH=true \
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionShapeInsertBatch/indexes_2$' -benchtime=100000x -count=3
```

100k docs, batch 800, template-v1, 2 indexes:

| Mode | ns/op range | buffered insert ns/doc | buffered flush ns/doc | disk bytes/doc | Notes |
| --- | ---: | ---: | ---: | ---: | --- |
| default sync threshold | 1208-1377 | 963-1127 | 245-253 | 81.96 | current default behavior |
| async flush opt-in | 1239-1324 | 589-676 | 647-678 | 80.66 | publish shifted out of insert path |

Fixture command:

```bash
go run ./cmd/collection_load_fixture \
  -dir "$RUN_DIR" -reset -docs 1000000 -batch-size 800 \
  -format template-v1 -indexes 2 -profile fast \
  -index-outer-leaves-in-vlog=true \
  -checkpoint=true -reopen-verify=false -progress=false -json

go run ./cmd/collection_load_fixture \
  -dir "$RUN_DIR" -reset -docs 1000000 -batch-size 800 \
  -format template-v1 -indexes 2 -profile fast \
  -index-outer-leaves-in-vlog=true \
  -buffered-indexed-async-flush=true \
  -checkpoint=true -reopen-verify=false -progress=false -json
```

1M docs, batch 800, template-v1, 2 indexes:

| Mode | Wall docs/sec | Insert docs/sec | Final flush | Total bytes | B/doc | index.db | Publish calls | Roots published |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| default sync threshold | 510,227 | 778,584 | 26.8 ms | 48,717,880 | 48.72 | 8,388,608 | 16 | 49 |
| async flush opt-in | 481,127 | 822,154 | 205.7 ms | 43,599,260 | 43.60 | 4,194,304 | 4 | 13 |

Interpretation: this PR validates the flush-unit queue/coalescing mechanism. It improves the timed insert phase and cuts root publish amplification/disk churn in this fixture, but because the final explicit drain does more deferred work, total wall time is not yet a win for this single-producer shape. That is expected for this opt-in first async slice; the next #1132 slices should focus on durable/background publish scheduling and multi-producer behavior.

## Tests

```bash
go test ./TreeDB/collections ./cmd/collection_load_fixture ./cmd/mongo_gateway_bench -count 1
go test ./... -count 1
```