### PR TITLE
Collections: detach async indexed flush publish

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -420,28 +420,47 @@ type indexedFlushUnit struct {
 	rootPolicies    map[string]backenddb.OrderedRootStoragePolicy
 	rootBaseIDs     map[string]uint64
 	uniqueValueRuns map[string][]memtable.Table
+	docCount        int
+	byteCount       int64
 	rootRunCount    int
 }
 
+type indexedFlushPublishWork struct {
+	pin            *backenddb.Snapshot
+	meta           CollectionMeta
+	catalog        *collectionCatalog
+	baseSystemRoot uint64
+	baseCommitSeq  uint64
+	units          []indexedFlushUnit
+	flushUnit      indexedFlushUnit
+	rootNames      []string
+	rootBaseIDs    map[string]uint64
+	docCount       int
+	byteCount      int64
+	rootRunCount   int
+	rootCount      int
+}
+
 type bufferedIndexedCheckpoint struct {
-	loaded                bool
-	meta                  CollectionMeta
-	catalog               *collectionCatalog
-	baseCommitSeq         uint64
-	baseSystemRoot        uint64
-	primaryRoot           uint64
-	count                 int
-	bufferedBytes         int64
-	mutableCount          int
-	mutableBytes          int64
-	writeGeneration       uint64
-	rootRuns              map[string][]memtable.Table
-	rootPolicies          map[string]backenddb.OrderedRootStoragePolicy
-	rootBaseIDs           map[string]uint64
-	indexedFlushUnits     []indexedFlushUnit
-	primaryRunIndexActive bool
-	uniqueValueRuns       map[string][]memtable.Table
-	rootRunCount          int
+	loaded                 bool
+	meta                   CollectionMeta
+	catalog                *collectionCatalog
+	baseCommitSeq          uint64
+	baseSystemRoot         uint64
+	primaryRoot            uint64
+	count                  int
+	bufferedBytes          int64
+	mutableCount           int
+	mutableBytes           int64
+	writeGeneration        uint64
+	rootRuns               map[string][]memtable.Table
+	rootPolicies           map[string]backenddb.OrderedRootStoragePolicy
+	rootBaseIDs            map[string]uint64
+	indexedPublishingUnits []indexedFlushUnit
+	indexedFlushUnits      []indexedFlushUnit
+	primaryRunIndexActive  bool
+	uniqueValueRuns        map[string][]memtable.Table
+	rootRunCount           int
 }
 
 type bufferedUniqueValueIndex struct {
@@ -465,31 +484,32 @@ type collectionWriteDomain struct {
 	// mutationMu serializes root descriptor publishes for handles opened
 	// through the same manager so optimistic retries do not starve under
 	// sustained collection write contention.
-	mutationMu        sync.Mutex
-	mu                sync.RWMutex
-	indexedAsyncMu    sync.Mutex
-	indexedAsyncCond  *sync.Cond
-	indexedAsyncRun   bool
-	indexedAsyncErr   error
-	updateCombineMu   sync.Mutex
-	updateCombiner    *collectionUpdateCombiner
-	updateDraining    *collectionUpdateCombiner
-	updateCombineDone bool
-	updateCombineTTL  time.Duration
-	closingWrites     atomic.Bool
-	loaded            bool
-	meta              CollectionMeta
-	catalog           *collectionCatalog
-	baseCommitSeq     uint64
-	baseSystemRoot    uint64
-	primaryRoot       uint64
-	storagePolicy     backenddb.OrderedRootStoragePolicy
-	table             memtable.Table
-	indexedFlushUnits []indexedFlushUnit
-	rootRuns          map[string][]memtable.Table
-	rootPolicies      map[string]backenddb.OrderedRootStoragePolicy
-	rootBaseIDs       map[string]uint64
-	primaryIDIndex    *bufferedUniqueValueIndex
+	mutationMu             sync.Mutex
+	mu                     sync.RWMutex
+	indexedAsyncMu         sync.Mutex
+	indexedAsyncCond       *sync.Cond
+	indexedAsyncRun        bool
+	indexedAsyncErr        error
+	updateCombineMu        sync.Mutex
+	updateCombiner         *collectionUpdateCombiner
+	updateDraining         *collectionUpdateCombiner
+	updateCombineDone      bool
+	updateCombineTTL       time.Duration
+	closingWrites          atomic.Bool
+	loaded                 bool
+	meta                   CollectionMeta
+	catalog                *collectionCatalog
+	baseCommitSeq          uint64
+	baseSystemRoot         uint64
+	primaryRoot            uint64
+	storagePolicy          backenddb.OrderedRootStoragePolicy
+	table                  memtable.Table
+	indexedPublishingUnits []indexedFlushUnit
+	indexedFlushUnits      []indexedFlushUnit
+	rootRuns               map[string][]memtable.Table
+	rootPolicies           map[string]backenddb.OrderedRootStoragePolicy
+	rootBaseIDs            map[string]uint64
+	primaryIDIndex         *bufferedUniqueValueIndex
 	// Built lazily by readers so write-only indexed buffering does not pay for
 	// an auxiliary lookup structure it never uses.
 	primaryRunIndex  *bufferedPrimaryRunIndex
@@ -700,7 +720,7 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.PendingDocuments = domain.count
 	stats.PendingBytes = domain.bufferedBytes
 	stats.PendingRootRuns = bufferedIndexedRootRunCount(domain)
-	stats.PendingIndexedFlushUnits = len(domain.indexedFlushUnits)
+	stats.PendingIndexedFlushUnits = len(domain.indexedPublishingUnits) + len(domain.indexedFlushUnits)
 	domain.mu.RUnlock()
 	if domain.indexedAsyncFlushRunning() {
 		stats.IndexedAsyncFlushRunning = 1
@@ -982,6 +1002,28 @@ func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain)
 	return collection.flushBufferedWritesLocked(domain)
 }
 
+func flushCollectionWriteDomainAsync(db *backenddb.DB, domain *collectionWriteDomain) error {
+	if db == nil || domain == nil {
+		return nil
+	}
+	collection := &Collection{db: db, writeDomain: domain}
+	for {
+		work, err := collection.prepareIndexedAsyncPublish()
+		if err != nil || work == nil {
+			return err
+		}
+		if err := collection.publishPreparedIndexedFlush(work); err != nil {
+			return err
+		}
+		domain.mu.RLock()
+		more := len(domain.indexedFlushUnits) > 0
+		domain.mu.RUnlock()
+		if !more {
+			return nil
+		}
+	}
+}
+
 func (c *Collection) scheduleIndexedAsyncFlush(domain *collectionWriteDomain) bool {
 	if c == nil || c.db == nil || domain == nil {
 		return false
@@ -992,7 +1034,7 @@ func (c *Collection) scheduleIndexedAsyncFlush(domain *collectionWriteDomain) bo
 	domain.indexedAsyncFlushScheduled.Add(1)
 	db := c.db
 	go func() {
-		err := flushCollectionWriteDomain(db, domain)
+		err := flushCollectionWriteDomainAsync(db, domain)
 		domain.finishIndexedAsyncFlush(err)
 	}()
 	return true
@@ -1894,13 +1936,15 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 				return 0, err
 			}
 		}
-		if !hasPendingIndexedRootRunsForRootLocked(domain, run.name) {
-			domain.rootBaseIDs[run.name] = catalog.rootID(run.name)
-		} else if baseRoot, ok := pendingIndexedRootBaseIDLocked(domain, run.name); ok && baseRoot != catalog.rootID(run.name) {
+		baseRoot := catalog.rootID(run.name)
+		if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, run.name); ok && pendingBaseRoot != baseRoot {
 			if autoFlushEnabled {
 				rollbackBufferedIndexedDomain(domain, checkpoint)
 			}
 			return 0, errConcurrentRootModification(catalog.meta.Name, run.name)
+		}
+		if _, ok := domain.rootBaseIDs[run.name]; !ok {
+			domain.rootBaseIDs[run.name] = baseRoot
 		}
 		domain.rootPolicies[run.name] = run.storagePolicy
 		domain.rootRuns[run.name] = append(domain.rootRuns[run.name], run.table)
@@ -1967,6 +2011,7 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.baseCommitSeq = baseCommitSeq
 	domain.baseSystemRoot = baseSystemRoot
 	domain.primaryRoot = catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
+	domain.indexedPublishingUnits = nil
 	domain.indexedFlushUnits = nil
 	domain.rootRuns = nil
 	domain.rootPolicies = nil
@@ -2042,6 +2087,15 @@ func bufferedIndexedRootRunCount(domain *collectionWriteDomain) int {
 		return 0
 	}
 	total := 0
+	for _, unit := range domain.indexedPublishingUnits {
+		if unit.rootRunCount > 0 || len(unit.rootRuns) == 0 {
+			total = saturatingAddNonNegativeInt(total, unit.rootRunCount)
+			continue
+		}
+		for _, runs := range unit.rootRuns {
+			total = saturatingAddNonNegativeInt(total, len(runs))
+		}
+	}
 	for _, unit := range domain.indexedFlushUnits {
 		if unit.rootRunCount > 0 || len(unit.rootRuns) == 0 {
 			total = saturatingAddNonNegativeInt(total, unit.rootRunCount)
@@ -2082,12 +2136,16 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 	if opts.BufferedIndexedAsyncFlush {
 		rotateIndexedMutableToFlushUnitLocked(domain)
 		if opts.BufferedIndexedAsyncFlushMaxQueuedUnits > 0 && len(domain.indexedFlushUnits) >= opts.BufferedIndexedAsyncFlushMaxQueuedUnits {
-			domain.indexedAsyncFlushBackpressure.Add(1)
-			flushStart := time.Now()
-			err := c.flushBufferedIndexedLocked(domain)
-			return time.Since(flushStart), err
+			if len(domain.indexedPublishingUnits) == 0 {
+				domain.indexedAsyncFlushBackpressure.Add(1)
+				flushStart := time.Now()
+				err := c.flushBufferedIndexedLocked(domain)
+				return time.Since(flushStart), err
+			}
+			c.scheduleIndexedAsyncFlush(domain)
+			return 0, nil
 		}
-		if !c.scheduleIndexedAsyncFlush(domain) {
+		if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
 			flushStart := time.Now()
 			err := c.flushBufferedIndexedLocked(domain)
 			return time.Since(flushStart), err
@@ -2107,10 +2165,13 @@ func pendingIndexedRootRunsLocked(domain *collectionWriteDomain, rootName string
 	if domain == nil || rootName == "" {
 		return nil
 	}
-	if len(domain.indexedFlushUnits) == 0 {
+	if len(domain.indexedPublishingUnits) == 0 && len(domain.indexedFlushUnits) == 0 {
 		return domain.rootRuns[rootName]
 	}
 	total := len(domain.rootRuns[rootName])
+	for _, unit := range domain.indexedPublishingUnits {
+		total = saturatingAddNonNegativeInt(total, len(unit.rootRuns[rootName]))
+	}
 	for _, unit := range domain.indexedFlushUnits {
 		total = saturatingAddNonNegativeInt(total, len(unit.rootRuns[rootName]))
 	}
@@ -2118,6 +2179,9 @@ func pendingIndexedRootRunsLocked(domain *collectionWriteDomain, rootName string
 		return nil
 	}
 	out := make([]memtable.Table, 0, total)
+	for _, unit := range domain.indexedPublishingUnits {
+		out = append(out, unit.rootRuns[rootName]...)
+	}
 	for _, unit := range domain.indexedFlushUnits {
 		out = append(out, unit.rootRuns[rootName]...)
 	}
@@ -2132,6 +2196,11 @@ func hasPendingIndexedRootRunsForRootLocked(domain *collectionWriteDomain, rootN
 	if len(domain.rootRuns[rootName]) > 0 {
 		return true
 	}
+	for _, unit := range domain.indexedPublishingUnits {
+		if len(unit.rootRuns[rootName]) > 0 {
+			return true
+		}
+	}
 	for _, unit := range domain.indexedFlushUnits {
 		if len(unit.rootRuns[rootName]) > 0 {
 			return true
@@ -2144,10 +2213,13 @@ func pendingIndexedRootRunMapLocked(domain *collectionWriteDomain) map[string][]
 	if domain == nil {
 		return nil
 	}
-	if len(domain.indexedFlushUnits) == 0 {
+	if len(domain.indexedPublishingUnits) == 0 && len(domain.indexedFlushUnits) == 0 {
 		return domain.rootRuns
 	}
-	out := make(map[string][]memtable.Table, len(domain.rootRuns)+len(domain.indexedFlushUnits))
+	out := make(map[string][]memtable.Table, len(domain.rootRuns)+len(domain.indexedPublishingUnits)+len(domain.indexedFlushUnits))
+	for _, unit := range domain.indexedPublishingUnits {
+		appendTableRunMap(out, unit.rootRuns)
+	}
 	for _, unit := range domain.indexedFlushUnits {
 		appendTableRunMap(out, unit.rootRuns)
 	}
@@ -2174,6 +2246,11 @@ func pendingIndexedRootBaseIDLocked(domain *collectionWriteDomain, rootName stri
 	if domain == nil || rootName == "" {
 		return 0, false
 	}
+	for _, unit := range domain.indexedPublishingUnits {
+		if baseRoot, ok := unit.rootBaseIDs[rootName]; ok {
+			return baseRoot, true
+		}
+	}
 	for _, unit := range domain.indexedFlushUnits {
 		if baseRoot, ok := unit.rootBaseIDs[rootName]; ok {
 			return baseRoot, true
@@ -2187,7 +2264,7 @@ func forEachPendingIndexedRootBaseIDLocked(domain *collectionWriteDomain, fn fun
 	if domain == nil || fn == nil {
 		return nil
 	}
-	if len(domain.indexedFlushUnits) == 0 {
+	if len(domain.indexedPublishingUnits) == 0 && len(domain.indexedFlushUnits) == 0 {
 		for rootName, baseRoot := range domain.rootBaseIDs {
 			if err := fn(rootName, baseRoot); err != nil {
 				return err
@@ -2196,6 +2273,20 @@ func forEachPendingIndexedRootBaseIDLocked(domain *collectionWriteDomain, fn fun
 		return nil
 	}
 	seen := make(map[string]uint64, len(domain.rootBaseIDs))
+	for _, unit := range domain.indexedPublishingUnits {
+		for rootName, baseRoot := range unit.rootBaseIDs {
+			if prior, ok := seen[rootName]; ok {
+				if prior != baseRoot {
+					return fmt.Errorf("collections: buffered indexed root %q has conflicting base roots %d and %d", rootName, prior, baseRoot)
+				}
+				continue
+			}
+			seen[rootName] = baseRoot
+			if err := fn(rootName, baseRoot); err != nil {
+				return err
+			}
+		}
+	}
 	for _, unit := range domain.indexedFlushUnits {
 		for rootName, baseRoot := range unit.rootBaseIDs {
 			if prior, ok := seen[rootName]; ok {
@@ -2236,29 +2327,50 @@ func saturatingAddNonNegativeInt64(total, n int64) int64 {
 	return total + n
 }
 
+func subtractNonNegativeInt(total, n int) int {
+	if n <= 0 {
+		return total
+	}
+	if n >= total {
+		return 0
+	}
+	return total - n
+}
+
+func subtractNonNegativeInt64(total, n int64) int64 {
+	if n <= 0 {
+		return total
+	}
+	if n >= total {
+		return 0
+	}
+	return total - n
+}
+
 func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedIndexedCheckpoint {
 	if domain == nil {
 		return bufferedIndexedCheckpoint{}
 	}
 	return bufferedIndexedCheckpoint{
-		loaded:                domain.loaded,
-		meta:                  domain.meta,
-		catalog:               domain.catalog,
-		baseCommitSeq:         domain.baseCommitSeq,
-		baseSystemRoot:        domain.baseSystemRoot,
-		primaryRoot:           domain.primaryRoot,
-		count:                 domain.count,
-		bufferedBytes:         domain.bufferedBytes,
-		mutableCount:          domain.mutableCount,
-		mutableBytes:          domain.mutableBytes,
-		writeGeneration:       domain.writeGeneration,
-		rootRuns:              cloneTableRunMap(domain.rootRuns),
-		rootPolicies:          cloneRootPolicyMap(domain.rootPolicies),
-		rootBaseIDs:           cloneUint64Map(domain.rootBaseIDs),
-		indexedFlushUnits:     cloneIndexedFlushUnits(domain.indexedFlushUnits),
-		primaryRunIndexActive: domain.primaryRunIndex != nil,
-		uniqueValueRuns:       cloneTableRunMap(domain.uniqueValueRuns),
-		rootRunCount:          domain.rootRunCount,
+		loaded:                 domain.loaded,
+		meta:                   domain.meta,
+		catalog:                domain.catalog,
+		baseCommitSeq:          domain.baseCommitSeq,
+		baseSystemRoot:         domain.baseSystemRoot,
+		primaryRoot:            domain.primaryRoot,
+		count:                  domain.count,
+		bufferedBytes:          domain.bufferedBytes,
+		mutableCount:           domain.mutableCount,
+		mutableBytes:           domain.mutableBytes,
+		writeGeneration:        domain.writeGeneration,
+		rootRuns:               cloneTableRunMap(domain.rootRuns),
+		rootPolicies:           cloneRootPolicyMap(domain.rootPolicies),
+		rootBaseIDs:            cloneUint64Map(domain.rootBaseIDs),
+		indexedPublishingUnits: cloneIndexedFlushUnits(domain.indexedPublishingUnits),
+		indexedFlushUnits:      cloneIndexedFlushUnits(domain.indexedFlushUnits),
+		primaryRunIndexActive:  domain.primaryRunIndex != nil,
+		uniqueValueRuns:        cloneTableRunMap(domain.uniqueValueRuns),
+		rootRunCount:           domain.rootRunCount,
 	}
 }
 
@@ -2280,12 +2392,13 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.mutableCount = checkpoint.mutableCount
 	domain.mutableBytes = checkpoint.mutableBytes
 	domain.writeGeneration = checkpoint.writeGeneration
+	domain.indexedPublishingUnits = checkpoint.indexedPublishingUnits
 	domain.indexedFlushUnits = checkpoint.indexedFlushUnits
 	domain.rootRuns = checkpoint.rootRuns
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
 	domain.rootRunCount = checkpoint.rootRunCount
-	pendingRuns := indexedFlushUnitPendingRootRunMap(checkpoint.indexedFlushUnits, checkpoint.rootRuns)
+	pendingRuns := indexedFlushUnitPendingRootRunMap(indexedFlushUnitsWithPublishing(checkpoint.indexedPublishingUnits, checkpoint.indexedFlushUnits), checkpoint.rootRuns)
 	domain.primaryIDIndex = rebuildBufferedPrimaryIDIndex(checkpoint.meta.Name, pendingRuns)
 	if checkpoint.primaryRunIndexActive {
 		index, err := rebuildBufferedPrimaryRunIndex(checkpoint.meta.Name, pendingRuns)
@@ -2299,7 +2412,7 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 		domain.primaryRunIndex = nil
 	}
 	domain.uniqueValueRuns = checkpoint.uniqueValueRuns
-	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(indexedFlushUnitPendingUniqueValueRunMap(checkpoint.indexedFlushUnits, checkpoint.uniqueValueRuns))
+	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(indexedFlushUnitPendingUniqueValueRunMap(indexedFlushUnitsWithPublishing(checkpoint.indexedPublishingUnits, checkpoint.indexedFlushUnits), checkpoint.uniqueValueRuns))
 }
 
 func cloneIndexedFlushUnits(in []indexedFlushUnit) []indexedFlushUnit {
@@ -2313,9 +2426,24 @@ func cloneIndexedFlushUnits(in []indexedFlushUnit) []indexedFlushUnit {
 			rootPolicies:    cloneRootPolicyMap(unit.rootPolicies),
 			rootBaseIDs:     cloneUint64Map(unit.rootBaseIDs),
 			uniqueValueRuns: cloneTableRunMap(unit.uniqueValueRuns),
+			docCount:        unit.docCount,
+			byteCount:       unit.byteCount,
 			rootRunCount:    unit.rootRunCount,
 		}
 	}
+	return out
+}
+
+func indexedFlushUnitsWithPublishing(publishing, queued []indexedFlushUnit) []indexedFlushUnit {
+	if len(publishing) == 0 {
+		return queued
+	}
+	if len(queued) == 0 {
+		return publishing
+	}
+	out := make([]indexedFlushUnit, 0, len(publishing)+len(queued))
+	out = append(out, publishing...)
+	out = append(out, queued...)
 	return out
 }
 
@@ -2349,6 +2477,33 @@ func indexedFlushUnitPendingUniqueValueRunMap(units []indexedFlushUnit, mutable 
 	return out
 }
 
+func pendingIndexedUniqueValueRunMapLocked(domain *collectionWriteDomain) map[string][]memtable.Table {
+	if domain == nil {
+		return nil
+	}
+	return indexedFlushUnitPendingUniqueValueRunMap(indexedFlushUnitsWithPublishing(domain.indexedPublishingUnits, domain.indexedFlushUnits), domain.uniqueValueRuns)
+}
+
+func rebuildBufferedPendingIndexesLocked(domain *collectionWriteDomain, collectionName string, preservePrimaryRunIndex bool) {
+	if domain == nil {
+		return
+	}
+	pendingRuns := pendingIndexedRootRunMapLocked(domain)
+	domain.primaryIDIndex = rebuildBufferedPrimaryIDIndex(collectionName, pendingRuns)
+	if preservePrimaryRunIndex {
+		index, err := rebuildBufferedPrimaryRunIndex(collectionName, pendingRuns)
+		if err != nil {
+			index = nil
+		} else if index == nil {
+			index = newBufferedPrimaryRunIndex(0)
+		}
+		domain.primaryRunIndex = index
+	} else {
+		domain.primaryRunIndex = nil
+	}
+	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(pendingIndexedUniqueValueRunMapLocked(domain))
+}
+
 func resetIndexedFlushUnitsAddedAfterCheckpoint(current []indexedFlushUnit, checkpoint bufferedIndexedCheckpoint) {
 	if len(current) == 0 {
 		return
@@ -2374,6 +2529,10 @@ func bufferedIndexedCheckpointTableSet(checkpoint bufferedIndexedCheckpoint) map
 	addTablesToSet(checkpoint.rootRuns)
 	addTablesToSet(checkpoint.uniqueValueRuns)
 	for _, unit := range checkpoint.indexedFlushUnits {
+		addTablesToSet(unit.rootRuns)
+		addTablesToSet(unit.uniqueValueRuns)
+	}
+	for _, unit := range checkpoint.indexedPublishingUnits {
 		addTablesToSet(unit.rootRuns)
 		addTablesToSet(unit.uniqueValueRuns)
 	}
@@ -3167,8 +3326,190 @@ func (it *bufferedRootRunsIterator) advanceItem(item bufferedRootRunHeapItem) {
 	}
 }
 
+func (c *Collection) prepareIndexedAsyncPublish() (*indexedFlushPublishWork, error) {
+	if c == nil || c.writeDomain == nil {
+		return nil, nil
+	}
+	domain := c.writeDomain
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	return c.prepareIndexedAsyncPublishLocked(domain)
+}
+
+func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDomain) (*indexedFlushPublishWork, error) {
+	if c == nil || c.db == nil || domain == nil || domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
+		return nil, nil
+	}
+	if len(domain.indexedFlushUnits) == 0 && len(domain.rootRuns) == 0 {
+		return nil, nil
+	}
+	if domain.catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
+	catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentCommitSeq, currentSystemRoot)
+	if err != nil {
+		return nil, err
+	}
+	meta := catalog.meta
+	c.meta = meta
+	pin := c.db.AcquireSnapshot()
+	if pin == nil {
+		return nil, backenddb.ErrClosed
+	}
+	work := &indexedFlushPublishWork{pin: pin, meta: meta, catalog: catalog}
+	defer func() {
+		if err != nil && work.pin != nil {
+			_ = work.pin.Close()
+		}
+	}()
+	pinnedCatalog, err := loadCollectionCatalog(pin, meta.Name)
+	if err != nil {
+		return nil, err
+	}
+	if pinnedCatalog == nil {
+		err = errCollectionNotFound
+		return nil, err
+	}
+	if !sameCollectionMeta(pinnedCatalog.meta, meta) {
+		err = fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
+		return nil, err
+	}
+	if err = forEachPendingIndexedRootBaseIDLocked(domain, func(rootName string, baseRoot uint64) error {
+		if got := pinnedCatalog.rootID(rootName); got != baseRoot {
+			return errConcurrentRootModification(meta.Name, rootName)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	rotateIndexedMutableToFlushUnitLocked(domain)
+	units := domain.indexedFlushUnits
+	flushUnit := mergedIndexedFlushUnits(units)
+	rootNames := orderedBufferedRootNames(meta, flushUnit.rootRuns)
+	if len(rootNames) == 0 {
+		_ = pin.Close()
+		work.pin = nil
+		domain.indexedFlushUnits = nil
+		domain.count = 0
+		domain.bufferedBytes = 0
+		domain.mutableCount = 0
+		domain.mutableBytes = 0
+		return nil, nil
+	}
+	rootBaseIDs := make(map[string]uint64, len(rootNames))
+	for _, rootName := range rootNames {
+		baseRoot, ok := flushUnit.rootBaseIDs[rootName]
+		if !ok {
+			err = fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
+			return nil, err
+		}
+		rootBaseIDs[rootName] = baseRoot
+	}
+	work.baseSystemRoot = snapshotSystemRoot(pin)
+	work.baseCommitSeq = snapshotCommitSeq(pin)
+	work.units = units
+	work.flushUnit = flushUnit
+	work.rootNames = rootNames
+	work.rootBaseIDs = rootBaseIDs
+	work.docCount = flushUnit.docCount
+	work.byteCount = flushUnit.byteCount
+	work.rootRunCount = indexedFlushUnitRootRunCount(flushUnit)
+	work.rootCount = len(rootNames)
+
+	domain.indexedPublishingUnits = append(domain.indexedPublishingUnits, units...)
+	domain.indexedFlushUnits = nil
+	domain.writeGeneration++
+	return work, nil
+}
+
+func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) error {
+	if c == nil || c.db == nil || work == nil {
+		return nil
+	}
+	defer func() {
+		if work.pin != nil {
+			_ = work.pin.Close()
+		}
+	}()
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(work.rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(work.rootNames))
+	for _, rootName := range work.rootNames {
+		iter := newBufferedRootRunsIteratorWithDeleted(work.flushUnit.rootRuns[rootName], nil, nil, true)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot:      work.rootBaseIDs[rootName],
+			Iter:          iter,
+			StoragePolicy: work.flushUnit.rootPolicies[rootName],
+		})
+	}
+	publishStart := time.Now()
+	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootDescriptorSystemDeltaIterator(work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, rootIDs)
+	})
+	for _, it := range iterators {
+		_ = it.Close()
+	}
+	if publishErr == nil && len(rootIDs) != len(work.rootNames) {
+		publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
+	}
+	completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, time.Since(publishStart))
+	if publishErr != nil {
+		return publishErr
+	}
+	return completeErr
+}
+
+func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork, newSystemRoot uint64, rootIDs []uint64, publishErr error, elapsed time.Duration) error {
+	if c == nil || c.writeDomain == nil || work == nil {
+		return publishErr
+	}
+	domain := c.writeDomain
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	preservePrimaryRunIndex := domain.primaryRunIndex != nil
+	if publishErr != nil {
+		if removed, ok := removeIndexedPublishingWorkUnitsLocked(domain, work.units); ok {
+			domain.indexedFlushUnits = append(removed, domain.indexedFlushUnits...)
+		}
+		rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
+		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, publishErr)
+		return publishErr
+	}
+	baseCatalog := domain.catalog
+	if baseCatalog == nil {
+		baseCatalog = work.catalog
+	}
+	nextCatalog := cloneCatalogWithRootUpdates(baseCatalog, work.meta, work.rootNames, rootIDs)
+	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
+	if !owned {
+		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
+		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, err)
+		return err
+	}
+	domain.loaded = true
+	domain.meta = work.meta
+	domain.catalog = nextCatalog
+	domain.baseCommitSeq = c.commitSeqForSystemRoot(newSystemRoot)
+	domain.baseSystemRoot = newSystemRoot
+	domain.primaryRoot = nextCatalog.rootID(collectionPrimaryRootName(work.meta.Name))
+	domain.count = subtractNonNegativeInt(domain.count, work.docCount)
+	domain.bufferedBytes = subtractNonNegativeInt64(domain.bufferedBytes, work.byteCount)
+	retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
+	rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
+	c.meta = work.meta
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	resetIndexedFlushUnits(oldPublishing)
+	domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, nil)
+	return nil
+}
+
 func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (err error) {
 	if domain == nil || domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
+		return nil
+	}
+	if len(domain.indexedPublishingUnits) > 0 {
 		return nil
 	}
 	if domain.catalog == nil {
@@ -3304,6 +3645,8 @@ func rotateIndexedMutableToFlushUnitLocked(domain *collectionWriteDomain) bool {
 		rootPolicies:    domain.rootPolicies,
 		rootBaseIDs:     domain.rootBaseIDs,
 		uniqueValueRuns: domain.uniqueValueRuns,
+		docCount:        domain.mutableCount,
+		byteCount:       domain.mutableBytes,
 		rootRunCount:    domain.rootRunCount,
 	}
 	domain.indexedFlushUnits = append(domain.indexedFlushUnits, unit)
@@ -3315,6 +3658,115 @@ func rotateIndexedMutableToFlushUnitLocked(domain *collectionWriteDomain) bool {
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
 	return true
+}
+
+func removeIndexedPublishingUnitsLocked(domain *collectionWriteDomain, n int) []indexedFlushUnit {
+	if domain == nil || n <= 0 || len(domain.indexedPublishingUnits) == 0 {
+		return nil
+	}
+	if n > len(domain.indexedPublishingUnits) {
+		n = len(domain.indexedPublishingUnits)
+	}
+	removed := domain.indexedPublishingUnits[:n]
+	remaining := domain.indexedPublishingUnits[n:]
+	if len(remaining) == 0 {
+		domain.indexedPublishingUnits = nil
+	} else {
+		domain.indexedPublishingUnits = remaining
+	}
+	return removed
+}
+
+func removeIndexedPublishingWorkUnitsLocked(domain *collectionWriteDomain, units []indexedFlushUnit) ([]indexedFlushUnit, bool) {
+	if len(units) == 0 {
+		return nil, true
+	}
+	if domain == nil || len(domain.indexedPublishingUnits) < len(units) {
+		return nil, false
+	}
+	for i := range units {
+		if !sameIndexedFlushUnitTables(domain.indexedPublishingUnits[i], units[i]) {
+			return nil, false
+		}
+	}
+	return removeIndexedPublishingUnitsLocked(domain, len(units)), true
+}
+
+func sameIndexedFlushUnitTables(a, b indexedFlushUnit) bool {
+	return sameTableRunMap(a.rootRuns, b.rootRuns) && sameTableRunMap(a.uniqueValueRuns, b.uniqueValueRuns)
+}
+
+func sameTableRunMap(a, b map[string][]memtable.Table) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for name, aRuns := range a {
+		bRuns, ok := b[name]
+		if !ok || len(aRuns) != len(bRuns) {
+			return false
+		}
+		for i := range aRuns {
+			if aRuns[i] != bRuns[i] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func retargetPendingIndexedRootBaseIDsLocked(domain *collectionWriteDomain, rootNames []string, oldBaseIDs map[string]uint64, newRootIDs []uint64) {
+	if domain == nil || len(rootNames) == 0 || len(newRootIDs) == 0 {
+		return
+	}
+	retarget := func(rootBaseIDs map[string]uint64) {
+		for i, rootName := range rootNames {
+			if i >= len(newRootIDs) {
+				return
+			}
+			oldBase, ok := oldBaseIDs[rootName]
+			if !ok {
+				continue
+			}
+			if current, ok := rootBaseIDs[rootName]; ok && current == oldBase {
+				rootBaseIDs[rootName] = newRootIDs[i]
+			}
+		}
+	}
+	for i := range domain.indexedFlushUnits {
+		retarget(domain.indexedFlushUnits[i].rootBaseIDs)
+	}
+	retarget(domain.rootBaseIDs)
+}
+
+func mergedIndexedFlushUnits(units []indexedFlushUnit) indexedFlushUnit {
+	if len(units) == 0 {
+		return indexedFlushUnit{}
+	}
+	if len(units) == 1 {
+		return units[0]
+	}
+	unit := indexedFlushUnit{
+		rootRuns:        make(map[string][]memtable.Table, len(units)),
+		rootPolicies:    make(map[string]backenddb.OrderedRootStoragePolicy, len(units)),
+		rootBaseIDs:     make(map[string]uint64, len(units)),
+		uniqueValueRuns: make(map[string][]memtable.Table, len(units)),
+	}
+	for _, pending := range units {
+		mergeIndexedFlushUnit(&unit, pending)
+	}
+	if len(unit.rootRuns) == 0 {
+		unit.rootRuns = nil
+	}
+	if len(unit.rootPolicies) == 0 {
+		unit.rootPolicies = nil
+	}
+	if len(unit.rootBaseIDs) == 0 {
+		unit.rootBaseIDs = nil
+	}
+	if len(unit.uniqueValueRuns) == 0 {
+		unit.uniqueValueRuns = nil
+	}
+	return unit
 }
 
 func mergedIndexedFlushUnitLocked(domain *collectionWriteDomain) indexedFlushUnit {
@@ -3369,6 +3821,8 @@ func mergeIndexedFlushUnit(dst *indexedFlushUnit, src indexedFlushUnit) {
 			dst.rootBaseIDs[rootName] = baseRoot
 		}
 	}
+	dst.docCount = saturatingAddNonNegativeInt(dst.docCount, src.docCount)
+	dst.byteCount = saturatingAddNonNegativeInt64(dst.byteCount, src.byteCount)
 	dst.rootRunCount = saturatingAddNonNegativeInt(dst.rootRunCount, indexedFlushUnitRootRunCount(src))
 }
 
@@ -6002,10 +6456,11 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		if table == nil || table.Len() == 0 {
 			continue
 		}
-		if !hasPendingIndexedRootRunsForRootLocked(domain, rootName) {
-			domain.rootBaseIDs[rootName] = baseRoot
-		} else if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, rootName); ok && pendingBaseRoot != baseRoot {
+		if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, rootName); ok && pendingBaseRoot != baseRoot {
 			return false, errConcurrentRootModification(plan.meta.Name, rootName)
+		}
+		if _, ok := domain.rootBaseIDs[rootName]; !ok {
+			domain.rootBaseIDs[rootName] = baseRoot
 		}
 		if rootName == collectionPrimaryRootName(plan.meta.Name) && domain.primaryRunIndex != nil {
 			if err := addBufferedPrimaryRunIndexEntries(domain.primaryRunIndex, table); err != nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1749,10 +1749,17 @@ func (c *Collection) flushBufferedWrites() error {
 	if domain == nil {
 		return nil
 	}
-	domain.waitIndexedAsyncFlush()
-	domain.mu.Lock()
-	defer domain.mu.Unlock()
-	return c.flushBufferedWritesLocked(domain)
+	for {
+		domain.waitIndexedAsyncFlush()
+		domain.mu.Lock()
+		if domain.indexedAsyncFlushRunning() {
+			domain.mu.Unlock()
+			continue
+		}
+		err := c.flushBufferedWritesLocked(domain)
+		domain.mu.Unlock()
+		return err
+	}
 }
 
 func (c *Collection) flushBufferedWritesLocked(domain *collectionWriteDomain) error {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -994,6 +994,7 @@ func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain)
 	if db == nil || domain == nil {
 		return nil
 	}
+	domain.waitIndexedAsyncFlush()
 	collection := &Collection{db: db, writeDomain: domain}
 	unlockMutation := lockCollectionDomainMutation(domain)
 	defer unlockMutation()
@@ -1747,6 +1748,7 @@ func (c *Collection) flushBufferedWrites() error {
 	if domain == nil {
 		return nil
 	}
+	domain.waitIndexedAsyncFlush()
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	return c.flushBufferedWritesLocked(domain)
@@ -2142,8 +2144,28 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 				err := c.flushBufferedIndexedLocked(domain)
 				return time.Since(flushStart), err
 			}
-			c.scheduleIndexedAsyncFlush(domain)
-			return 0, nil
+			domain.indexedAsyncFlushBackpressure.Add(1)
+			flushStart := time.Now()
+			if domain.indexedAsyncFlushRunning() {
+				domain.mu.Unlock()
+				domain.waitIndexedAsyncFlush()
+				domain.mu.Lock()
+				if err := domain.consumeIndexedAsyncFlushError(); err != nil {
+					return time.Since(flushStart), err
+				}
+				if domain.count == 0 || len(domain.indexedFlushUnits) == 0 || !hasBufferedIndexedRootRuns(domain) {
+					return time.Since(flushStart), nil
+				}
+				if len(domain.indexedPublishingUnits) == 0 {
+					err := c.flushBufferedIndexedLocked(domain)
+					return time.Since(flushStart), err
+				}
+			}
+			if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
+				err := c.flushBufferedIndexedLocked(domain)
+				return time.Since(flushStart), err
+			}
+			return time.Since(flushStart), nil
 		}
 		if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
 			flushStart := time.Now()
@@ -3446,7 +3468,7 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	}
 	publishStart := time.Now()
 	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, rootIDs)
 	})
 	for _, it := range iterators {
 		_ = it.Close()
@@ -3510,7 +3532,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		return nil
 	}
 	if len(domain.indexedPublishingUnits) > 0 {
-		return nil
+		return errors.New("collections: indexed async publish still in flight")
 	}
 	if domain.catalog == nil {
 		return errCollectionNotFound

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -994,10 +994,10 @@ func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain)
 	if db == nil || domain == nil {
 		return nil
 	}
-	domain.waitIndexedAsyncFlush()
 	collection := &Collection{db: db, writeDomain: domain}
 	unlockMutation := lockCollectionDomainMutation(domain)
 	defer unlockMutation()
+	domain.waitIndexedAsyncFlush()
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	return collection.flushBufferedWritesLocked(domain)
@@ -1527,10 +1527,11 @@ func (c *Collection) Flush() error {
 		return errCollectionDBNil
 	}
 	if c.writeDomain != nil {
+		unlockMutation := c.lockMutation()
+		defer unlockMutation()
 		c.writeDomain.waitIndexedAsyncFlush()
+		return c.flushBufferedWrites()
 	}
-	unlockMutation := c.lockMutation()
-	defer unlockMutation()
 	return c.flushBufferedWrites()
 }
 
@@ -3518,6 +3519,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	domain.primaryRoot = nextCatalog.rootID(collectionPrimaryRootName(work.meta.Name))
 	domain.count = subtractNonNegativeInt(domain.count, work.docCount)
 	domain.bufferedBytes = subtractNonNegativeInt64(domain.bufferedBytes, work.byteCount)
+	domain.clearIndexedAsyncFlushError()
 	retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
 	rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
 	c.meta = work.meta

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3374,6 +3374,51 @@ func TestCollectionIndexedWriteMemtablesCreateIndexWaitsForPublishingUnits(t *te
 	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"))
 }
 
+func TestCollectionIndexedWriteMemtablesAsyncSuccessClearsPriorError(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1024,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	col.writeDomain.finishIndexedAsyncFlush(errors.New("prior async failure"))
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	if err := col.publishPreparedIndexedFlush(work); err != nil {
+		t.Fatalf("publish prepared async flush: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush after successful async publish surfaced stale error: %v", err)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesAsyncPublishRetargetsMutableRuns(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2902,6 +2902,136 @@ func TestCollectionIndexedWriteMemtablesAsyncBackpressurePublishesSynchronously(
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesAsyncBackpressureWaitsForPublishingUnit(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        100,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 1,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("seed insert batch: %v", err)
+	}
+
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	var asyncFinished atomic.Bool
+	finishAsync := func(err error) {
+		if asyncFinished.CompareAndSwap(false, true) {
+			col.writeDomain.finishIndexedAsyncFlush(err)
+		}
+	}
+	if !col.writeDomain.beginIndexedAsyncFlush() {
+		t.Fatal("begin async flush returned false")
+	}
+	t.Cleanup(func() {
+		if !asyncFinished.Load() && work.pin != nil {
+			_ = work.pin.Close()
+			work.pin = nil
+		}
+		finishAsync(errors.New("test cleanup"))
+	})
+
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"email":"grace@example.com"}`)},
+	); err != nil {
+		t.Fatalf("second insert batch: %v", err)
+	}
+
+	backpressureDone := make(chan error, 1)
+	go func() {
+		col.writeDomain.mu.Lock()
+		_, err := col.flushBufferedIndexedAfterThresholdLocked(col.writeDomain, CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 1,
+		})
+		col.writeDomain.mu.Unlock()
+		backpressureDone <- err
+	}()
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if mgr.StatsSnapshot().IndexedAsyncFlushBackpressure > 0 {
+			break
+		}
+		select {
+		case err := <-backpressureDone:
+			t.Fatalf("backpressure flush returned before in-flight async publish drained: %v", err)
+		case <-time.After(time.Millisecond):
+		}
+	}
+	if got := mgr.StatsSnapshot().IndexedAsyncFlushBackpressure; got == 0 {
+		t.Fatal("async backpressure did not wait for in-flight publishing unit")
+	}
+
+	publishDone := make(chan error, 1)
+	go func() {
+		err := col.publishPreparedIndexedFlush(work)
+		finishAsync(err)
+		publishDone <- err
+	}()
+	select {
+	case err := <-publishDone:
+		if err != nil {
+			t.Fatalf("publish prepared async flush: %v", err)
+		}
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out publishing prepared async flush")
+	}
+	select {
+	case err := <-backpressureDone:
+		if err != nil {
+			t.Fatalf("backpressure flush: %v", err)
+		}
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out waiting for backpressure flush")
+	}
+
+	stats := mgr.StatsSnapshot()
+	if got := stats.PendingIndexedFlushUnits; got != 0 {
+		t.Fatalf("pending indexed flush units after backpressure drain=%d want 0", got)
+	}
+	if got := stats.PendingDocuments; got != 0 {
+		t.Fatalf("pending documents after backpressure drain=%d want 0", got)
+	}
+	for _, id := range []string{"u1", "u2"} {
+		got, err := col.Get([]byte(id))
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if len(got) == 0 {
+			t.Fatalf("get %s returned empty document", id)
+		}
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesAsyncScheduleRacePublishesSynchronously(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -3063,12 +3193,12 @@ func TestCollectionIndexedWriteMemtablesAsyncPublishingUnitsParticipateInReadsAn
 	}
 }
 
-func TestCollectionIndexedWriteMemtablesSyncFlushSkipsPublishingUnits(t *testing.T) {
+func TestCollectionIndexedWriteMemtablesFlushWaitsForPublishingUnits(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	defer func() { _ = d.Close() }()
+	t.Cleanup(func() { _ = d.Close() })
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{
 		Name: "users",
@@ -3099,17 +3229,53 @@ func TestCollectionIndexedWriteMemtablesSyncFlushSkipsPublishingUnits(t *testing
 	if work == nil {
 		t.Fatal("prepare async publish returned nil work")
 	}
-	col.writeDomain.mu.Lock()
-	err = col.flushBufferedIndexedLocked(col.writeDomain)
-	col.writeDomain.mu.Unlock()
-	if err != nil {
-		t.Fatalf("foreground flush while publish is in-flight: %v", err)
+	var asyncFinished atomic.Bool
+	finishAsync := func(err error) {
+		if asyncFinished.CompareAndSwap(false, true) {
+			col.writeDomain.finishIndexedAsyncFlush(err)
+		}
 	}
-	if got := mgr.StatsSnapshot().PendingIndexedFlushUnits; got != 1 {
-		t.Fatalf("pending publishing units after skipped foreground flush=%d want 1", got)
+	if !col.writeDomain.beginIndexedAsyncFlush() {
+		t.Fatal("begin async flush returned false")
 	}
-	if err := col.publishPreparedIndexedFlush(work); err != nil {
-		t.Fatalf("publish prepared async flush: %v", err)
+	t.Cleanup(func() {
+		if !asyncFinished.Load() && work.pin != nil {
+			_ = work.pin.Close()
+			work.pin = nil
+		}
+		finishAsync(errors.New("test cleanup"))
+	})
+
+	flushDone := make(chan error, 1)
+	go func() {
+		flushDone <- col.flushBufferedWrites()
+	}()
+	select {
+	case err := <-flushDone:
+		t.Fatalf("flush returned before in-flight async publish drained: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	publishDone := make(chan error, 1)
+	go func() {
+		err := col.publishPreparedIndexedFlush(work)
+		finishAsync(err)
+		publishDone <- err
+	}()
+	select {
+	case err := <-publishDone:
+		if err != nil {
+			t.Fatalf("publish prepared async flush: %v", err)
+		}
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out publishing prepared async flush")
+	}
+	select {
+	case err := <-flushDone:
+		if err != nil {
+			t.Fatalf("flush after in-flight async publish: %v", err)
+		}
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out waiting for flush after publish")
 	}
 	if got := mgr.StatsSnapshot().PendingDocuments; got != 0 {
 		t.Fatalf("pending docs after async publish=%d want 0", got)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3282,6 +3282,106 @@ func TestCollectionIndexedWriteMemtablesFlushWaitsForPublishingUnits(t *testing.
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesFlushRetriesAsyncScheduledDuringWaitGap(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1024,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	domain := col.writeDomain
+	domain.mu.Lock()
+	scanDone := make(chan error, 1)
+	go func() {
+		_, err := col.ScanDocumentsFunc(16, func(DocumentRecord) (bool, error) {
+			return true, nil
+		})
+		scanDone <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	if !domain.beginIndexedAsyncFlush() {
+		domain.mu.Unlock()
+		t.Fatal("begin async flush returned false")
+	}
+	work, err := col.prepareIndexedAsyncPublishLocked(domain)
+	if err != nil {
+		domain.mu.Unlock()
+		domain.finishIndexedAsyncFlush(err)
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		domain.mu.Unlock()
+		domain.finishIndexedAsyncFlush(nil)
+		t.Fatal("prepare async publish returned nil work")
+	}
+	domain.mu.Unlock()
+
+	var asyncFinished atomic.Bool
+	finishAsync := func(err error) {
+		if asyncFinished.CompareAndSwap(false, true) {
+			domain.finishIndexedAsyncFlush(err)
+		}
+	}
+	t.Cleanup(func() {
+		if !asyncFinished.Load() && work.pin != nil {
+			_ = work.pin.Close()
+			work.pin = nil
+		}
+		finishAsync(errors.New("test cleanup"))
+	})
+
+	select {
+	case err := <-scanDone:
+		t.Fatalf("scan returned before scheduled async publish drained: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	publishDone := make(chan error, 1)
+	go func() {
+		err := col.publishPreparedIndexedFlush(work)
+		finishAsync(err)
+		publishDone <- err
+	}()
+	select {
+	case err := <-publishDone:
+		if err != nil {
+			t.Fatalf("publish prepared async flush: %v", err)
+		}
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out publishing prepared async flush")
+	}
+	select {
+	case err := <-scanDone:
+		if err != nil {
+			t.Fatalf("scan after scheduled async publish: %v", err)
+		}
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out waiting for scan after publish")
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesCreateIndexWaitsForPublishingUnits(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3282,6 +3282,98 @@ func TestCollectionIndexedWriteMemtablesFlushWaitsForPublishingUnits(t *testing.
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesCreateIndexWaitsForPublishingUnits(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1024,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	var asyncFinished atomic.Bool
+	finishAsync := func(err error) {
+		if asyncFinished.CompareAndSwap(false, true) {
+			col.writeDomain.finishIndexedAsyncFlush(err)
+		}
+	}
+	if !col.writeDomain.beginIndexedAsyncFlush() {
+		t.Fatal("begin async flush returned false")
+	}
+	t.Cleanup(func() {
+		if !asyncFinished.Load() && work.pin != nil {
+			_ = work.pin.Close()
+			work.pin = nil
+		}
+		finishAsync(errors.New("test cleanup"))
+	})
+
+	createDone := make(chan error, 1)
+	go func() {
+		_, err := col.CreateIndex(IndexDefinition{Name: "city", Field: "city"})
+		createDone <- err
+	}()
+	select {
+	case err := <-createDone:
+		t.Fatalf("CreateIndex returned before in-flight async publish drained: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	publishDone := make(chan error, 1)
+	go func() {
+		err := col.publishPreparedIndexedFlush(work)
+		finishAsync(err)
+		publishDone <- err
+	}()
+	select {
+	case err := <-publishDone:
+		if err != nil {
+			t.Fatalf("publish prepared async flush: %v", err)
+		}
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out publishing prepared async flush")
+	}
+	select {
+	case err := <-createDone:
+		if err != nil {
+			t.Fatalf("CreateIndex after in-flight async publish: %v", err)
+		}
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out waiting for CreateIndex after publish")
+	}
+	ids, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city after CreateIndex: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"))
+}
+
 func TestCollectionIndexedWriteMemtablesAsyncPublishRetargetsMutableRuns(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2991,6 +2991,202 @@ func TestCollectionIndexedWriteMemtablesAsyncQueuedUnitsParticipateInUniqueCheck
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesAsyncPublishingUnitsParticipateInReadsAndUniqueChecks(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1024,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", Unique: true},
+			{Name: "city", Field: "city"},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com","city":"hnl"}`),
+			[]byte(`{"email":"grace@example.com","city":"hnl"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	if got := mgr.StatsSnapshot().PendingIndexedFlushUnits; got != 1 {
+		t.Fatalf("pending publishing units=%d want 1", got)
+	}
+	got, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get publishing doc: %v", err)
+	}
+	if want := []byte(`{"email":"grace@example.com","city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("publishing doc=%q want %q", got, want)
+	}
+	ids, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find publishing city: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"), []byte("u2"))
+	_, err = col.InsertBatch(
+		[][]byte{[]byte("u3")},
+		[][]byte{[]byte(`{"email":"grace@example.com","city":"sfo"}`)},
+	)
+	if err == nil || !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("duplicate publishing unique insert err=%v want ErrUniqueIndexConflict", err)
+	}
+	if err := col.publishPreparedIndexedFlush(work); err != nil {
+		t.Fatalf("publish prepared async flush: %v", err)
+	}
+	if got := mgr.StatsSnapshot().PendingDocuments; got != 0 {
+		t.Fatalf("pending docs after publish=%d want 0", got)
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesSyncFlushSkipsPublishingUnits(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1024,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	col.writeDomain.mu.Lock()
+	err = col.flushBufferedIndexedLocked(col.writeDomain)
+	col.writeDomain.mu.Unlock()
+	if err != nil {
+		t.Fatalf("foreground flush while publish is in-flight: %v", err)
+	}
+	if got := mgr.StatsSnapshot().PendingIndexedFlushUnits; got != 1 {
+		t.Fatalf("pending publishing units after skipped foreground flush=%d want 1", got)
+	}
+	if err := col.publishPreparedIndexedFlush(work); err != nil {
+		t.Fatalf("publish prepared async flush: %v", err)
+	}
+	if got := mgr.StatsSnapshot().PendingDocuments; got != 0 {
+		t.Fatalf("pending docs after async publish=%d want 0", got)
+	}
+}
+
+func TestCollectionIndexedWriteMemtablesAsyncPublishRetargetsMutableRuns(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1024,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city"}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl","score":1}`)},
+	); err != nil {
+		t.Fatalf("insert first batch: %v", err)
+	}
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"city":"hnl","score":2}`)},
+	); err != nil {
+		t.Fatalf("insert while publish is in flight: %v", err)
+	}
+	if err := col.publishPreparedIndexedFlush(work); err != nil {
+		t.Fatalf("publish prepared async flush: %v", err)
+	}
+	if got := mgr.StatsSnapshot().PendingDocuments; got != 1 {
+		t.Fatalf("pending docs after publish=%d want mutable doc", got)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush mutable runs after publish retarget: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err := reopenedCol.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city after retargeted flush: %v", err)
+	}
+	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"), []byte("u2"))
+}
+
 func TestCollectionIndexedWriteMemtablesAsyncUpdateAndDeleteDrainCorrectly(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})


### PR DESCRIPTION
## Summary

Follow-up to #1151 for #1132. This moves the opt-in async indexed flush path closer to a real write-back pipeline by detaching immutable flush units before publishing roots. The background publisher can publish detached units without holding `collectionWriteDomain.mu`, while reads and unique checks continue to see those in-flight units as pending writes.

Key points:
- add explicit in-flight `indexedPublishingUnits` next to queued immutable units and current mutable runs
- include publishing units in primary reads, secondary lookups, unique preflight checks, pending stats, checkpoints, and rollback rebuilds
- keep a pinned snapshot for detached publish so base roots remain safe during page reuse
- after publish, remove only the completed in-flight units, retarget newer queued/mutable root base IDs to the newly published roots, and rebuild pending conflict/read indexes
- foreground/synchronous flush never consumes async-owned publishing units
- async completion verifies it still owns the exact work units before reset/requeue
- async worker drains already-rotated immutable units while avoiding below-threshold tiny publish amplification

## Validation

```bash
go test ./TreeDB/collections -run 'TestCollectionIndexedWriteMemtables(AsyncPublishingUnitsParticipateInReadsAndUniqueChecks|SyncFlushSkipsPublishingUnits|AsyncPublishRetargetsMutableRuns|AsyncScheduleRacePublishesSynchronously|AsyncAutoFlushDrainsOnFlush|AsyncQueuedUnitsParticipateInUniqueChecks|AsyncBackpressurePublishesSynchronously)' -count 1
go test ./TreeDB/collections ./cmd/collection_load_fixture ./cmd/mongo_gateway_bench -count 1
git diff --check
```

All passed locally on the clean branch from `origin/main`.

## Focused Go Benchmark

Command:

```bash
TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 \
TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=true \
TREEDB_COLLECTION_BENCH_BATCH_SIZE=800 \
TREEDB_COLLECTION_BUFFERED_INDEXED_ASYNC_FLUSH=true \
go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkCollectionShapeInsertBatch/indexes_2$' \
  -benchtime=100000x \
  -count=3
```

Observed `BenchmarkCollectionShapeInsertBatch/indexes_2` on Apple M3 before the cadence fix was 812-997 ns/op. The fixture below is the better end-to-end signal after the cadence fix.

## Fixture Benchmark

Command:

```bash
RUN_BASE=/tmp/gomap_1132_detached_fixture_1777700821
go run ./cmd/collection_load_fixture -dir "$RUN_BASE/sync" -reset -docs 300000 -batch-size 800 -format template-v1 -indexes 2 -profile fast -index-outer-leaves-in-vlog=true -checkpoint=true -reopen-verify=false -progress=false -json > "$RUN_BASE/sync.json"
RUN_DIR=/tmp/gomap_1132_detached_fixture_async_cadence_1777700904
go run ./cmd/collection_load_fixture -dir "$RUN_DIR" -reset -docs 300000 -batch-size 800 -format template-v1 -indexes 2 -profile fast -index-outer-leaves-in-vlog=true -buffered-indexed-async-flush=true -checkpoint=true -reopen-verify=false -progress=false -json > "$RUN_DIR.json"
```

| mode | wall docs/sec | insert docs/sec | final flush sec | publish calls | roots published | final bytes | B/doc |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| sync threshold baseline | 508,497 | 825,897 | 0.0299 | 5 | 16 | 16,391,492 | 54.64 |
| async detached after cadence fix | 556,358 | 1,094,015 | 0.0287 | 5 | 16 | 16,358,745 | 54.53 |

Current head keeps the storage/publish cadence comparable to sync threshold while improving this fixture shape by about +9.4% wall docs/sec and +32.5% insert docs/sec.

## Notes

This intentionally does not solve durable acknowledged async writes yet. It keeps #1151's opt-in flush-boundary durability contract, but removes the next coordination problem: root publish no longer has to hold the write-domain state lock while the physical root delta group is built and published.
