### PR TITLE
Add Mongo gateway concurrent reader sweep

### DIFF
--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -246,7 +246,7 @@ BATCH_SIZE=5000 scripts/mongo_gateway_compare.sh \
   --range-reads 5000 \
   --range-index \
   --updates 5000 \
-  --concurrent-readers 16 \
+  --concurrent-reader-sweep "1,2,4,8,16" \
   --concurrent-reads 50000 \
   --concurrent-writers 8 \
   --concurrent-writes 10000 \
@@ -309,7 +309,13 @@ The initial workload phases are:
   indexed variant is emitted when `-range-index` creates `age_1`.
 - `id_update_set`: `$set` update by `_id`.
 - `concurrent_id_find_one_rN`: total `_id` point reads split across `N`
-  goroutines.
+  goroutines. Use `-concurrent-reader-sweep 1,2,4,8,16` with
+  `-concurrent-reads` to emit multiple `concurrent_id_find_one_rN` phases from
+  one loaded database. The comparison report groups these rows into a
+  "Concurrent Read Sweep" table so the reader-count scaling is visible as one
+  throughput sweep rather than unrelated phases. The legacy
+  `-concurrent-readers N` flag still emits one `concurrent_id_find_one_rN`
+  phase and cannot be combined with `-concurrent-reader-sweep`.
 - `concurrent_id_update_set_wN`: total `$set` updates split across `N`
   goroutines.
 - `id_delete_one`: optional deletes; disabled unless `-deletes` is non-zero.

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -58,6 +58,7 @@ type config struct {
 	Updates                                       int
 	Deletes                                       int
 	ConcurrentReaders                             int
+	ConcurrentReaderSweep                         []int
 	ConcurrentReads                               int
 	ConcurrentWriters                             int
 	ConcurrentWrites                              int
@@ -87,23 +88,24 @@ type config struct {
 }
 
 type benchmarkResult struct {
-	Target             string `json:"target"`
-	MongoURI           string `json:"mongo_uri,omitempty"`
-	TreeDBDir          string `json:"treedb_dir,omitempty"`
-	Database           string `json:"database"`
-	Collection         string `json:"collection"`
-	Documents          int    `json:"documents"`
-	BatchSize          int    `json:"batch_size"`
-	InsertProducers    int    `json:"insert_producers"`
-	MongoMaxPoolSize   int    `json:"mongo_max_pool_size,omitempty"`
-	MongoMinPoolSize   int    `json:"mongo_min_pool_size,omitempty"`
-	MongoMaxConnecting int    `json:"mongo_max_connecting,omitempty"`
-	SecondaryIndexes   int    `json:"secondary_indexes"`
-	ClientMode         string `json:"client_mode"`
-	ConcurrentReaders  int    `json:"concurrent_readers,omitempty"`
-	ConcurrentReads    int    `json:"concurrent_reads,omitempty"`
-	ConcurrentWriters  int    `json:"concurrent_writers,omitempty"`
-	ConcurrentWrites   int    `json:"concurrent_writes,omitempty"`
+	Target                string `json:"target"`
+	MongoURI              string `json:"mongo_uri,omitempty"`
+	TreeDBDir             string `json:"treedb_dir,omitempty"`
+	Database              string `json:"database"`
+	Collection            string `json:"collection"`
+	Documents             int    `json:"documents"`
+	BatchSize             int    `json:"batch_size"`
+	InsertProducers       int    `json:"insert_producers"`
+	MongoMaxPoolSize      int    `json:"mongo_max_pool_size,omitempty"`
+	MongoMinPoolSize      int    `json:"mongo_min_pool_size,omitempty"`
+	MongoMaxConnecting    int    `json:"mongo_max_connecting,omitempty"`
+	SecondaryIndexes      int    `json:"secondary_indexes"`
+	ClientMode            string `json:"client_mode"`
+	ConcurrentReaders     int    `json:"concurrent_readers,omitempty"`
+	ConcurrentReaderSweep []int  `json:"concurrent_reader_sweep,omitempty"`
+	ConcurrentReads       int    `json:"concurrent_reads,omitempty"`
+	ConcurrentWriters     int    `json:"concurrent_writers,omitempty"`
+	ConcurrentWrites      int    `json:"concurrent_writes,omitempty"`
 
 	// Always emit this knob in JSON so benchmark artifacts distinguish default
 	// false runs from older runs that predate indexed-field update coverage.
@@ -455,7 +457,9 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.RangeReads, "range-reads", 100, "range reads with limit")
 	fs.IntVar(&cfg.Updates, "updates", 100, "$set updates by _id")
 	fs.IntVar(&cfg.Deletes, "deletes", 0, "deleteOne operations by _id")
+	var concurrentReaderSweep string
 	fs.IntVar(&cfg.ConcurrentReaders, "concurrent-readers", 0, "reader goroutines for the concurrent _id read phase; 0 disables the phase")
+	fs.StringVar(&concurrentReaderSweep, "concurrent-reader-sweep", "", "comma- or space-separated reader counts for a concurrent _id read throughput sweep; requires -concurrent-reads and cannot be combined with -concurrent-readers")
 	fs.IntVar(&cfg.ConcurrentReads, "concurrent-reads", 0, "total _id read operations for the concurrent read phase")
 	fs.IntVar(&cfg.ConcurrentWriters, "concurrent-writers", 0, "writer goroutines for the concurrent _id update phase; 0 disables the phase")
 	fs.IntVar(&cfg.ConcurrentWrites, "concurrent-writes", 0, "total update operations for the concurrent write phase")
@@ -521,10 +525,22 @@ func parseConfig(args []string) (config, error) {
 	if cfg.Reads < 0 || cfg.RangeReads < 0 || cfg.Updates < 0 || cfg.Deletes < 0 || cfg.ConcurrentReads < 0 || cfg.ConcurrentWrites < 0 {
 		return config{}, errors.New("operation counts cannot be negative")
 	}
+	concurrentReaderSweepValues, err := parsePositiveIntList(concurrentReaderSweep, "concurrent-reader-sweep")
+	if err != nil {
+		return config{}, err
+	}
+	cfg.ConcurrentReaderSweep = concurrentReaderSweepValues
 	if cfg.ConcurrentReaders < 0 || cfg.ConcurrentWriters < 0 {
 		return config{}, errors.New("concurrency values cannot be negative")
 	}
-	if (cfg.ConcurrentReaders == 0) != (cfg.ConcurrentReads == 0) {
+	if len(cfg.ConcurrentReaderSweep) > 0 {
+		if cfg.ConcurrentReaders != 0 {
+			return config{}, errors.New("concurrent-reader-sweep cannot be combined with concurrent-readers")
+		}
+		if cfg.ConcurrentReads == 0 {
+			return config{}, errors.New("concurrent-reader-sweep requires concurrent-reads > 0")
+		}
+	} else if (cfg.ConcurrentReaders == 0) != (cfg.ConcurrentReads == 0) {
 		return config{}, errors.New("concurrent-readers and concurrent-reads must both be > 0 or both be 0")
 	}
 	if (cfg.ConcurrentWriters == 0) != (cfg.ConcurrentWrites == 0) {
@@ -673,6 +689,46 @@ func parseClientMode(raw string) (string, error) {
 	default:
 		return "", fmt.Errorf("unknown client-mode %q", raw)
 	}
+}
+
+func parsePositiveIntList(raw, name string) ([]int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	})
+	out := make([]int, 0, len(parts))
+	seen := make(map[int]struct{}, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		value, err := strconv.Atoi(part)
+		if err != nil || value <= 0 {
+			return nil, fmt.Errorf("%s must contain positive integers: %q", name, raw)
+		}
+		if _, ok := seen[value]; ok {
+			return nil, fmt.Errorf("%s contains duplicate value %d", name, value)
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("%s must contain at least one positive integer", name)
+	}
+	return out, nil
+}
+
+func concurrentReaderCounts(cfg config) []int {
+	if len(cfg.ConcurrentReaderSweep) > 0 {
+		return cfg.ConcurrentReaderSweep
+	}
+	if cfg.ConcurrentReaders > 0 && cfg.ConcurrentReads > 0 {
+		return []int{cfg.ConcurrentReaders}
+	}
+	return nil
 }
 
 func isRawWireClientMode(mode string) bool {
@@ -1017,24 +1073,25 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	db := target.client.Database(cfg.Database)
 	coll := db.Collection(cfg.Collection)
 	result := &benchmarkResult{
-		Target:             cfg.Target,
-		Database:           cfg.Database,
-		Collection:         cfg.Collection,
-		Documents:          cfg.Documents,
-		BatchSize:          cfg.BatchSize,
-		InsertProducers:    cfg.InsertProducers,
-		MongoMaxPoolSize:   cfg.MongoMaxPoolSize,
-		MongoMinPoolSize:   cfg.MongoMinPoolSize,
-		MongoMaxConnecting: cfg.MongoMaxConnecting,
-		SecondaryIndexes:   cfg.SecondaryIndexes,
-		ClientMode:         cfg.ClientMode,
-		ConcurrentReaders:  cfg.ConcurrentReaders,
-		ConcurrentReads:    cfg.ConcurrentReads,
-		ConcurrentWriters:  cfg.ConcurrentWriters,
-		ConcurrentWrites:   cfg.ConcurrentWrites,
-		UpdateIndexedField: cfg.UpdateIndexedField,
-		RangeIndex:         cfg.RangeIndex,
-		PrebuildDocuments:  cfg.PrebuildDocuments,
+		Target:                cfg.Target,
+		Database:              cfg.Database,
+		Collection:            cfg.Collection,
+		Documents:             cfg.Documents,
+		BatchSize:             cfg.BatchSize,
+		InsertProducers:       cfg.InsertProducers,
+		MongoMaxPoolSize:      cfg.MongoMaxPoolSize,
+		MongoMinPoolSize:      cfg.MongoMinPoolSize,
+		MongoMaxConnecting:    cfg.MongoMaxConnecting,
+		SecondaryIndexes:      cfg.SecondaryIndexes,
+		ClientMode:            cfg.ClientMode,
+		ConcurrentReaders:     cfg.ConcurrentReaders,
+		ConcurrentReaderSweep: append([]int(nil), cfg.ConcurrentReaderSweep...),
+		ConcurrentReads:       cfg.ConcurrentReads,
+		ConcurrentWriters:     cfg.ConcurrentWriters,
+		ConcurrentWrites:      cfg.ConcurrentWrites,
+		UpdateIndexedField:    cfg.UpdateIndexedField,
+		RangeIndex:            cfg.RangeIndex,
+		PrebuildDocuments:     cfg.PrebuildDocuments,
 	}
 	if cfg.Target == "treedb" {
 		if cfg.TreeDBDir != "" || cfg.KeepTreeDBDir {
@@ -1212,10 +1269,10 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	}
 	result.Phases = append(result.Phases, updatePhase)
 
-	if cfg.ConcurrentReaders > 0 && cfg.ConcurrentReads > 0 {
-		phaseName := fmt.Sprintf("concurrent_id_find_one_r%d", cfg.ConcurrentReaders)
+	for _, concurrentReaders := range concurrentReaderCounts(cfg) {
+		phaseName := fmt.Sprintf("concurrent_id_find_one_r%d", concurrentReaders)
 		concurrentReadPhase, err := measureProfiledPhase(profiler, phaseName, cfg.ConcurrentReads, func(sample func(time.Duration)) error {
-			return runConcurrentOperations(ctx, cfg.ConcurrentReaders, cfg.ConcurrentReads, func(op int) error {
+			return runConcurrentOperations(ctx, concurrentReaders, cfg.ConcurrentReads, func(op int) error {
 				id := benchmarkID(benchmarkDocumentOrdinal(op, 17, cfg.Documents))
 				var out bson.M
 				begin := time.Now()
@@ -2636,10 +2693,10 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(result)
 	case "text":
-		fmt.Fprintf(out, "target=%s client_mode=%s database=%s collection=%s documents=%d batch_size=%d insert_producers=%d mongo_max_pool_size=%d mongo_min_pool_size=%d mongo_max_connecting=%d secondary_indexes=%d concurrent_readers=%d concurrent_reads=%d concurrent_writers=%d concurrent_writes=%d\n",
+		fmt.Fprintf(out, "target=%s client_mode=%s database=%s collection=%s documents=%d batch_size=%d insert_producers=%d mongo_max_pool_size=%d mongo_min_pool_size=%d mongo_max_connecting=%d secondary_indexes=%d concurrent_readers=%d concurrent_reader_sweep=%v concurrent_reads=%d concurrent_writers=%d concurrent_writes=%d\n",
 			result.Target, result.ClientMode, result.Database, result.Collection, result.Documents, result.BatchSize,
 			result.InsertProducers, result.MongoMaxPoolSize, result.MongoMinPoolSize, result.MongoMaxConnecting, result.SecondaryIndexes,
-			result.ConcurrentReaders, result.ConcurrentReads, result.ConcurrentWriters, result.ConcurrentWrites)
+			result.ConcurrentReaders, result.ConcurrentReaderSweep, result.ConcurrentReads, result.ConcurrentWriters, result.ConcurrentWrites)
 		fmt.Fprintf(out, "update_indexed_field=%t\n", result.UpdateIndexedField)
 		fmt.Fprintf(out, "range_index=%t\n", result.RangeIndex)
 		if result.TreeDBDir != "" {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -350,6 +350,16 @@ func TestParseConfigValidation(t *testing.T) {
 		!cfg.UpdateIndexedField || !cfg.RangeIndex {
 		t.Fatalf("unexpected config: %+v", cfg)
 	}
+	sweepCfg, err := parseConfig([]string{
+		"-concurrent-reader-sweep", "1,2 4",
+		"-concurrent-reads", "30",
+	})
+	if err != nil {
+		t.Fatalf("parse concurrent reader sweep config: %v", err)
+	}
+	if !reflect.DeepEqual(sweepCfg.ConcurrentReaderSweep, []int{1, 2, 4}) || sweepCfg.ConcurrentReads != 30 {
+		t.Fatalf("unexpected concurrent reader sweep config: %+v", sweepCfg)
+	}
 	rawWireCfg, err := parseConfig([]string{"-target", "treedb", "-client-mode", "raw-wire"})
 	if err != nil {
 		t.Fatalf("parse raw-wire config: %v", err)
@@ -415,6 +425,18 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if _, err := parseConfig([]string{"-concurrent-reads", "1"}); err == nil {
 		t.Fatal("concurrent-reads without concurrent-readers accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-reader-sweep", "1,2"}); err == nil {
+		t.Fatal("concurrent-reader-sweep without concurrent-reads accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-reader-sweep", "1,2", "-concurrent-reads", "10", "-concurrent-readers", "2"}); err == nil {
+		t.Fatal("concurrent-reader-sweep combined with concurrent-readers accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-reader-sweep", "1,0", "-concurrent-reads", "10"}); err == nil {
+		t.Fatal("invalid concurrent-reader-sweep accepted")
+	}
+	if _, err := parseConfig([]string{"-concurrent-reader-sweep", "1,1", "-concurrent-reads", "10"}); err == nil {
+		t.Fatal("duplicate concurrent-reader-sweep value accepted")
 	}
 	if _, err := parseConfig([]string{"-insert-producers", "0"}); err == nil {
 		t.Fatal("zero insert-producers accepted")

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -43,6 +43,7 @@ type benchmarkResult struct {
 	SecondaryIndexes           int            `json:"secondary_indexes"`
 	RangeIndex                 bool           `json:"range_index"`
 	ClientMode                 string         `json:"client_mode,omitempty"`
+	ConcurrentReaderSweep      []int          `json:"concurrent_reader_sweep,omitempty"`
 	TreeDBDocumentFormat       string         `json:"treedb_document_format,omitempty"`
 	Phases                     []phaseResult  `json:"phases"`
 	ProfileDir                 string         `json:"profile_dir,omitempty"`
@@ -542,6 +543,7 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	b.WriteString("\n")
 	renderDiskTable(&b, cells)
 	b.WriteString("\n")
+	renderConcurrentReadSweepTable(&b, cells)
 	renderOpsTable(&b, cells)
 	b.WriteString("\n")
 	b.WriteString("## Raw Inputs\n\n")
@@ -578,6 +580,7 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	b.WriteString("- MongoDB `dbStats.totalSize` is reported separately because it can diverge sharply from the isolated data-directory `du` measurement on small WiredTiger workloads.\n")
 	b.WriteString("- MongoDB physical bytes are the preferred local disk comparison when the matrix runner has an isolated data directory, such as Docker mode.\n")
 	b.WriteString("- Wall ops/sec values include the full benchmark phase loop. Sampled ops/sec values isolate the timed driver/gateway call inside each phase and are useful when prebuilt fixtures are enabled.\n")
+	b.WriteString("- `concurrent_id_find_one_rN` phases are an `_id` read throughput sweep over `N` concurrent readers, and are grouped in the Concurrent Read Sweep section when present.\n")
 	b.WriteString("- Range-query benchmark rows use explicit phase names: `age_range_indexed_limit_10` means `-range-index` created `age_1`; `age_range_scan_limit_10` means bounded scan fallback.\n")
 	return b.String()
 }
@@ -745,6 +748,71 @@ func renderDiskTable(b *strings.Builder, cells []cellComparison) {
 			formatRatio(safeRatio(float64(treePhysical), float64(mongoPhysical))),
 		)
 	}
+}
+
+func renderConcurrentReadSweepTable(b *strings.Builder, cells []cellComparison) {
+	rows := concurrentReadSweepComparisons(cells)
+	if len(rows) == 0 {
+		return
+	}
+	b.WriteString("## Concurrent Read Sweep\n\n")
+	b.WriteString("These rows group `concurrent_id_find_one_rN` phases as one `_id` read throughput sweep. Serial `id_find_one` remains a separate single-in-flight latency phase.\n\n")
+	b.WriteString("| docs | indexes | TreeDB config | readers | TreeDB wall ops/sec | TreeDB sampled ops/sec | MongoDB wall ops/sec | MongoDB sampled ops/sec | TreeDB / MongoDB wall | TreeDB p95 us | MongoDB p95 us |\n")
+	b.WriteString("| ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+	for _, cmp := range rows {
+		readers, _ := concurrentReadReaders(cmp.Name)
+		fmt.Fprintf(b, "| %d | %d | `%s` | %d | %s | %s | %s | %s | %s | %s | %s |\n",
+			cmp.Cell.Documents,
+			cmp.Cell.SecondaryIndexes,
+			cmp.Cell.TreeDBConfig,
+			readers,
+			formatPhaseOps(cmp.HasTreeDB, cmp.TreeDBPhase.OpsPerSecond),
+			formatPhaseOps(cmp.HasTreeDB && cmp.TreeDBPhase.SampledOpsPerSecond > 0, cmp.TreeDBPhase.SampledOpsPerSecond),
+			formatPhaseOps(cmp.HasMongo, cmp.MongoPhase.OpsPerSecond),
+			formatPhaseOps(cmp.HasMongo && cmp.MongoPhase.SampledOpsPerSecond > 0, cmp.MongoPhase.SampledOpsPerSecond),
+			formatRatio(cmp.Ratio),
+			formatPhaseLatency(cmp.HasTreeDB, cmp.TreeDBPhase.LatencyMicros.P95),
+			formatPhaseLatency(cmp.HasMongo, cmp.MongoPhase.LatencyMicros.P95),
+		)
+	}
+	b.WriteString("\n")
+}
+
+func concurrentReadSweepComparisons(cells []cellComparison) []phaseComparison {
+	var out []phaseComparison
+	for _, cmp := range allPhaseComparisons(cells) {
+		if _, ok := concurrentReadReaders(cmp.Name); ok {
+			out = append(out, cmp)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		left, right := out[i], out[j]
+		if left.Cell.Documents != right.Cell.Documents {
+			return left.Cell.Documents < right.Cell.Documents
+		}
+		if left.Cell.SecondaryIndexes != right.Cell.SecondaryIndexes {
+			return left.Cell.SecondaryIndexes < right.Cell.SecondaryIndexes
+		}
+		if left.Cell.TreeDBConfig != right.Cell.TreeDBConfig {
+			return left.Cell.TreeDBConfig < right.Cell.TreeDBConfig
+		}
+		leftReaders, _ := concurrentReadReaders(left.Name)
+		rightReaders, _ := concurrentReadReaders(right.Name)
+		return leftReaders < rightReaders
+	})
+	return out
+}
+
+func concurrentReadReaders(name string) (int, bool) {
+	const prefix = "concurrent_id_find_one_r"
+	if !strings.HasPrefix(name, prefix) {
+		return 0, false
+	}
+	readers, err := strconv.Atoi(strings.TrimPrefix(name, prefix))
+	if err != nil || readers <= 0 {
+		return 0, false
+	}
+	return readers, true
 }
 
 func renderOpsTable(b *strings.Builder, cells []cellComparison) {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -865,7 +865,18 @@ func renderOpsTable(b *strings.Builder, cells []cellComparison) {
 	b.WriteString("## Ops/Sec Summary\n\n")
 	b.WriteString("| docs | indexes | range index | range mode | TreeDB config | phase | TreeDB wall ops/sec | TreeDB sampled ops/sec | MongoDB wall ops/sec | MongoDB sampled ops/sec | TreeDB / MongoDB wall | TreeDB / MongoDB sampled | TreeDB p95 us | MongoDB p95 us |\n")
 	b.WriteString("| ---: | ---: | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+	sweepCells := make(map[cellKey]bool, len(cells))
+	for _, cell := range cells {
+		if cellHasConcurrentReadSweep(cell) {
+			sweepCells[cell.Key] = true
+		}
+	}
 	for _, cmp := range allPhaseComparisons(cells) {
+		if sweepCells[cmp.Cell] {
+			if _, ok := concurrentReadReaders(cmp.Name); ok {
+				continue
+			}
+		}
 		sampledRatio := safeRatio(cmp.TreeDBPhase.SampledOpsPerSecond, cmp.MongoPhase.SampledOpsPerSecond)
 		fmt.Fprintf(b, "| %d | %d | %t | %s | `%s` | `%s` | %s | %s | %s | %s | %s | %s | %s | %s |\n",
 			cmp.Cell.Documents,

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -780,9 +780,32 @@ func renderConcurrentReadSweepTable(b *strings.Builder, cells []cellComparison) 
 
 func concurrentReadSweepComparisons(cells []cellComparison) []phaseComparison {
 	var out []phaseComparison
-	for _, cmp := range allPhaseComparisons(cells) {
-		if _, ok := concurrentReadReaders(cmp.Name); ok {
-			out = append(out, cmp)
+	for _, cell := range cells {
+		if !cellHasConcurrentReadSweep(cell) {
+			continue
+		}
+		var mongoPhases []phaseResult
+		mongoPhaseMap := map[string]phaseResult{}
+		if cell.Mongo != nil {
+			mongoPhases = cell.Mongo.Result.Phases
+			mongoPhaseMap = cell.Mongo.PhaseMap
+		}
+		for _, name := range phaseNames(cell.TreeDB.Result.Phases, mongoPhases) {
+			if _, ok := concurrentReadReaders(name); !ok {
+				continue
+			}
+			treePhase, hasTree := cell.TreeDB.PhaseMap[name]
+			mongoPhase, hasMongo := mongoPhaseMap[name]
+			out = append(out, phaseComparison{
+				Cell:        cell.Key,
+				Name:        name,
+				RangeIndex:  cell.TreeDB.Result.RangeIndex,
+				TreeDBPhase: treePhase,
+				MongoPhase:  mongoPhase,
+				HasTreeDB:   hasTree,
+				HasMongo:    hasMongo,
+				Ratio:       safeRatio(treePhase.OpsPerSecond, mongoPhase.OpsPerSecond),
+			})
 		}
 	}
 	sort.SliceStable(out, func(i, j int) bool {
@@ -801,6 +824,29 @@ func concurrentReadSweepComparisons(cells []cellComparison) []phaseComparison {
 		return leftReaders < rightReaders
 	})
 	return out
+}
+
+func cellHasConcurrentReadSweep(cell cellComparison) bool {
+	if len(cell.TreeDB.Result.ConcurrentReaderSweep) > 0 {
+		return true
+	}
+	if cell.Mongo != nil && len(cell.Mongo.Result.ConcurrentReaderSweep) > 0 {
+		return true
+	}
+	readers := make(map[int]struct{})
+	for _, phase := range cell.TreeDB.Result.Phases {
+		if readerCount, ok := concurrentReadReaders(phase.Name); ok {
+			readers[readerCount] = struct{}{}
+		}
+	}
+	if cell.Mongo != nil {
+		for _, phase := range cell.Mongo.Result.Phases {
+			if readerCount, ok := concurrentReadReaders(phase.Name); ok {
+				readers[readerCount] = struct{}{}
+			}
+		}
+	}
+	return len(readers) > 1
 }
 
 func concurrentReadReaders(name string) (int, bool) {

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -197,6 +197,60 @@ func TestRangeModeLabelsIndexedAndScanPhases(t *testing.T) {
 	}
 }
 
+func TestReportGroupsConcurrentReadSweepRows(t *testing.T) {
+	treedbPhases := []phaseResult{
+		{Name: "concurrent_id_find_one_r4", OpsPerSecond: 4000, SampledOpsPerSecond: 4200, LatencyMicros: latencySummary{P95: 10}},
+		{Name: "concurrent_id_find_one_r1", OpsPerSecond: 1000, SampledOpsPerSecond: 1200, LatencyMicros: latencySummary{P95: 15}},
+	}
+	mongoPhases := []phaseResult{
+		{Name: "concurrent_id_find_one_r4", OpsPerSecond: 2000, SampledOpsPerSecond: 2200, LatencyMicros: latencySummary{P95: 20}},
+		{Name: "concurrent_id_find_one_r1", OpsPerSecond: 500, SampledOpsPerSecond: 600, LatencyMicros: latencySummary{P95: 30}},
+	}
+	cells := []cellComparison{{
+		Key: cellKey{Documents: 100, SecondaryIndexes: 0, TreeDBConfig: "treedb_bson"},
+		TreeDB: &runRecord{
+			Row:      matrixRow{Target: "treedb", Config: "treedb_bson", Documents: 100, RawJSON: "treedb.json"},
+			Result:   benchmarkResult{Target: "treedb", Documents: 100, Phases: treedbPhases},
+			PhaseMap: phaseMap(treedbPhases),
+		},
+		Mongo: &runRecord{
+			Row:      matrixRow{Target: "mongo", Config: "mongo", Documents: 100, RawJSON: "mongo.json"},
+			Result:   benchmarkResult{Target: "mongo", Documents: 100, Phases: mongoPhases},
+			PhaseMap: phaseMap(mongoPhases),
+		},
+	}}
+
+	report := renderReport(config{Title: "test", MatrixPath: "matrix.tsv"}, cells, time.Unix(0, 0).UTC())
+	for _, want := range []string{
+		"## Concurrent Read Sweep",
+		"Serial `id_find_one` remains a separate single-in-flight latency phase.",
+		"| 100 | 0 | `treedb_bson` | 1 | 1000 | 1200 | 500 | 600 | 2.00x | 15.0 | 30.0 |",
+		"| 100 | 0 | `treedb_bson` | 4 | 4000 | 4200 | 2000 | 2200 | 2.00x | 10.0 | 20.0 |",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q\n%s", want, report)
+		}
+	}
+	if strings.Index(report, "| 100 | 0 | `treedb_bson` | 1 |") > strings.Index(report, "| 100 | 0 | `treedb_bson` | 4 |") {
+		t.Fatalf("reader sweep rows should be ordered by reader count:\n%s", report)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		readers int
+		ok      bool
+	}{
+		{name: "concurrent_id_find_one_r8", readers: 8, ok: true},
+		{name: "concurrent_id_find_one_r0", ok: false},
+		{name: "id_find_one", ok: false},
+	} {
+		readers, ok := concurrentReadReaders(tc.name)
+		if readers != tc.readers || ok != tc.ok {
+			t.Fatalf("concurrentReadReaders(%q)=%d,%t want %d,%t", tc.name, readers, ok, tc.readers, tc.ok)
+		}
+	}
+}
+
 func TestReportRejectsIncompleteCell(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "treedb.json"), `{

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -251,6 +251,31 @@ func TestReportGroupsConcurrentReadSweepRows(t *testing.T) {
 	}
 }
 
+func TestReportDoesNotGroupLegacySingleConcurrentReadPhase(t *testing.T) {
+	phase := phaseResult{Name: "concurrent_id_find_one_r8", OpsPerSecond: 8000}
+	cells := []cellComparison{{
+		Key: cellKey{Documents: 100, SecondaryIndexes: 0, TreeDBConfig: "treedb_legacy"},
+		TreeDB: &runRecord{
+			Row:      matrixRow{Target: "treedb", Config: "treedb_legacy", Documents: 100, RawJSON: "treedb.json"},
+			Result:   benchmarkResult{Target: "treedb", Documents: 100, Phases: []phaseResult{phase}},
+			PhaseMap: phaseMap([]phaseResult{phase}),
+		},
+		Mongo: &runRecord{
+			Row:      matrixRow{Target: "mongo", Config: "mongo", Documents: 100, RawJSON: "mongo.json"},
+			Result:   benchmarkResult{Target: "mongo", Documents: 100, Phases: []phaseResult{phase}},
+			PhaseMap: phaseMap([]phaseResult{phase}),
+		},
+	}}
+
+	report := renderReport(config{Title: "test", MatrixPath: "matrix.tsv"}, cells, time.Unix(0, 0).UTC())
+	if strings.Contains(report, "## Concurrent Read Sweep") {
+		t.Fatalf("legacy single concurrent-read phase should not render sweep section:\n%s", report)
+	}
+	if !strings.Contains(report, "`concurrent_id_find_one_r8`") {
+		t.Fatalf("legacy single concurrent-read phase should remain in ops summary:\n%s", report)
+	}
+}
+
 func TestReportRejectsIncompleteCell(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "treedb.json"), `{

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -234,6 +234,10 @@ func TestReportGroupsConcurrentReadSweepRows(t *testing.T) {
 	if strings.Index(report, "| 100 | 0 | `treedb_bson` | 1 |") > strings.Index(report, "| 100 | 0 | `treedb_bson` | 4 |") {
 		t.Fatalf("reader sweep rows should be ordered by reader count:\n%s", report)
 	}
+	opsSection := strings.Split(strings.Split(report, "## Ops/Sec Summary")[1], "## Raw Inputs")[0]
+	if strings.Contains(opsSection, "`concurrent_id_find_one_r1`") || strings.Contains(opsSection, "`concurrent_id_find_one_r4`") {
+		t.Fatalf("sweep phases should be grouped in the sweep section, not repeated in ops summary:\n%s", opsSection)
+	}
 
 	for _, tc := range []struct {
 		name    string

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -294,6 +294,13 @@ is_nonnegative_int() {
   [[ "$1" =~ ^[0-9]+$ ]]
 }
 
+trim_spaces() {
+  local value=$1
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
 derived_count() {
   local docs=$1
   local explicit=$2
@@ -502,20 +509,44 @@ if [[ "$PROFILE_TREEDB" != "true" && "$PROFILE_TREEDB" != "false" ]]; then
   echo "invalid PROFILE_TREEDB=$PROFILE_TREEDB (want true or false)" >&2
   exit 2
 fi
+raw_concurrent_reader_sweep=$CONCURRENT_READER_SWEEP
+CONCURRENT_READER_SWEEP=$(trim_spaces "$CONCURRENT_READER_SWEEP")
+if [[ -n "$raw_concurrent_reader_sweep" && -z "$CONCURRENT_READER_SWEEP" ]]; then
+  echo "CONCURRENT_READER_SWEEP must contain at least one positive integer" >&2
+  exit 2
+fi
 if [[ -n "$CONCURRENT_READER_SWEEP" && "$CONCURRENT_READERS" -gt 0 ]]; then
   echo "CONCURRENT_READER_SWEEP cannot be combined with CONCURRENT_READERS" >&2
   exit 2
 fi
 if [[ -n "$CONCURRENT_READER_SWEEP" ]]; then
+  declare -A seen_reader_counts=()
+  validated_reader_counts=0
   for reader_count in ${CONCURRENT_READER_SWEEP//,/ }; do
     if ! is_positive_int "$reader_count"; then
       echo "invalid CONCURRENT_READER_SWEEP value: $reader_count" >&2
       exit 2
     fi
+    if [[ -n "${seen_reader_counts[$reader_count]:-}" ]]; then
+      echo "duplicate CONCURRENT_READER_SWEEP value: $reader_count" >&2
+      exit 2
+    fi
+    seen_reader_counts[$reader_count]=1
+    validated_reader_counts=$((validated_reader_counts + 1))
   done
-  if [[ -z "$CONCURRENT_READS" || "$CONCURRENT_READS" == "0" ]]; then
-    echo "CONCURRENT_READER_SWEEP requires CONCURRENT_READS > 0" >&2
+  if [[ "$validated_reader_counts" -eq 0 ]]; then
+    echo "CONCURRENT_READER_SWEEP must contain at least one positive integer" >&2
     exit 2
+  fi
+  if [[ -n "$CONCURRENT_READS" && "$CONCURRENT_READS" == "0" ]]; then
+    echo "CONCURRENT_READER_SWEEP requires CONCURRENT_READS > 0 when CONCURRENT_READS is set" >&2
+    exit 2
+  fi
+  if [[ -n "$CONCURRENT_READS" ]]; then
+    if ! is_nonnegative_int "$CONCURRENT_READS"; then
+      echo "invalid CONCURRENT_READS=$CONCURRENT_READS (want non-negative integer)" >&2
+      exit 2
+    fi
   fi
 elif [[ "$CONCURRENT_READERS" -eq 0 && -n "$CONCURRENT_READS" && "$CONCURRENT_READS" != "0" ]]; then
   echo "CONCURRENT_READERS or CONCURRENT_READER_SWEEP must be set when CONCURRENT_READS is set" >&2

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -522,17 +522,27 @@ if [[ -n "$CONCURRENT_READER_SWEEP" && "$CONCURRENT_READERS" -gt 0 ]]; then
 fi
 if [[ -n "$CONCURRENT_READER_SWEEP" ]]; then
   seen_reader_counts=""
+  normalized_reader_sweep=""
   validated_reader_counts=0
   for reader_count in ${CONCURRENT_READER_SWEEP//,/ }; do
     if ! is_positive_int "$reader_count"; then
       echo "invalid CONCURRENT_READER_SWEEP value: $reader_count" >&2
       exit 2
     fi
-    if [[ " $seen_reader_counts " == *" $reader_count "* ]]; then
+    normalized_reader_count=$reader_count
+    while [[ "$normalized_reader_count" == 0* && ${#normalized_reader_count} -gt 1 ]]; do
+      normalized_reader_count=${normalized_reader_count#0}
+    done
+    if [[ " $seen_reader_counts " == *" $normalized_reader_count "* ]]; then
       echo "duplicate CONCURRENT_READER_SWEEP value: $reader_count" >&2
       exit 2
     fi
-    seen_reader_counts="$seen_reader_counts $reader_count"
+    seen_reader_counts="$seen_reader_counts $normalized_reader_count"
+    if [[ -z "$normalized_reader_sweep" ]]; then
+      normalized_reader_sweep=$normalized_reader_count
+    else
+      normalized_reader_sweep="$normalized_reader_sweep,$normalized_reader_count"
+    fi
     validated_reader_counts=$((validated_reader_counts + 1))
   done
   if [[ "$validated_reader_counts" -eq 0 ]]; then
@@ -549,6 +559,7 @@ if [[ -n "$CONCURRENT_READER_SWEEP" ]]; then
       exit 2
     fi
   fi
+  CONCURRENT_READER_SWEEP=$normalized_reader_sweep
 elif [[ "$CONCURRENT_READERS" -eq 0 && -n "$CONCURRENT_READS" && "$CONCURRENT_READS" != "0" ]]; then
   echo "CONCURRENT_READERS or CONCURRENT_READER_SWEEP must be set when CONCURRENT_READS is set" >&2
   exit 2

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -25,6 +25,7 @@ DELETES="${DELETES:-0}"
 RANGE_READS_DIVISOR="${RANGE_READS_DIVISOR:-10}"
 UPDATES_DIVISOR="${UPDATES_DIVISOR:-10}"
 CONCURRENT_READERS="${CONCURRENT_READERS:-0}"
+CONCURRENT_READER_SWEEP="${CONCURRENT_READER_SWEEP:-}"
 CONCURRENT_READS="${CONCURRENT_READS:-}"
 CONCURRENT_READS_DIVISOR="${CONCURRENT_READS_DIVISOR:-10}"
 CONCURRENT_WRITERS="${CONCURRENT_WRITERS:-0}"
@@ -74,6 +75,11 @@ Options:
   --profile-treedb      Capture per-phase TreeDB pprof artifacts in profiles/.
   --concurrent-readers N
                         Reader goroutines for the concurrent _id read phase.
+  --concurrent-reader-sweep LIST
+                        Space- or comma-separated reader counts for concurrent
+                        _id read throughput sweep phases. Requires
+                        --concurrent-reads and cannot be combined with
+                        --concurrent-readers.
   --concurrent-reads COUNT
                         Concurrent point reads per target/cell.
   --concurrent-writers N
@@ -105,6 +111,7 @@ Environment overrides:
   READS, READS_DIVISOR,
   RANGE_READS, UPDATES, DELETES, RANGE_READS_DIVISOR, UPDATES_DIVISOR,
   CONCURRENT_READERS, CONCURRENT_READS, CONCURRENT_READS_DIVISOR,
+  CONCURRENT_READER_SWEEP,
   CONCURRENT_WRITERS, CONCURRENT_WRITES, CONCURRENT_WRITES_DIVISOR,
   MONGO_MODE, MONGO_URI, MONGO_IMAGE, DATABASE_PREFIX, COLLECTION, TIMEOUT,
   TREEDB_PROFILE, TREEDB_DOCUMENT_FORMAT, TREEDB_DOCUMENT_FORMATS,
@@ -174,6 +181,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --concurrent-readers)
       CONCURRENT_READERS="$2"
+      shift 2
+      ;;
+    --concurrent-reader-sweep)
+      CONCURRENT_READER_SWEEP="$2"
       shift 2
       ;;
     --concurrent-reads)
@@ -440,6 +451,7 @@ run_target() {
     -updates "$updates" \
     -deletes "$deletes" \
     -concurrent-readers "$concurrent_readers" \
+    -concurrent-reader-sweep "$CONCURRENT_READER_SWEEP" \
     -concurrent-reads "$concurrent_reads" \
     -concurrent-writers "$concurrent_writers" \
     -concurrent-writes "$concurrent_writes" \
@@ -490,8 +502,23 @@ if [[ "$PROFILE_TREEDB" != "true" && "$PROFILE_TREEDB" != "false" ]]; then
   echo "invalid PROFILE_TREEDB=$PROFILE_TREEDB (want true or false)" >&2
   exit 2
 fi
-if [[ "$CONCURRENT_READERS" -eq 0 && -n "$CONCURRENT_READS" && "$CONCURRENT_READS" != "0" ]]; then
-  echo "CONCURRENT_READERS must be > 0 when CONCURRENT_READS is set" >&2
+if [[ -n "$CONCURRENT_READER_SWEEP" && "$CONCURRENT_READERS" -gt 0 ]]; then
+  echo "CONCURRENT_READER_SWEEP cannot be combined with CONCURRENT_READERS" >&2
+  exit 2
+fi
+if [[ -n "$CONCURRENT_READER_SWEEP" ]]; then
+  for reader_count in ${CONCURRENT_READER_SWEEP//,/ }; do
+    if ! is_positive_int "$reader_count"; then
+      echo "invalid CONCURRENT_READER_SWEEP value: $reader_count" >&2
+      exit 2
+    fi
+  done
+  if [[ -z "$CONCURRENT_READS" || "$CONCURRENT_READS" == "0" ]]; then
+    echo "CONCURRENT_READER_SWEEP requires CONCURRENT_READS > 0" >&2
+    exit 2
+  fi
+elif [[ "$CONCURRENT_READERS" -eq 0 && -n "$CONCURRENT_READS" && "$CONCURRENT_READS" != "0" ]]; then
+  echo "CONCURRENT_READERS or CONCURRENT_READER_SWEEP must be set when CONCURRENT_READS is set" >&2
   exit 2
 fi
 if [[ "$CONCURRENT_WRITERS" -eq 0 && -n "$CONCURRENT_WRITES" && "$CONCURRENT_WRITES" != "0" ]]; then
@@ -514,7 +541,8 @@ fi
   echo "updates: ${UPDATES:-documents / $UPDATES_DIVISOR}"
   echo "deletes: $DELETES"
   echo "concurrent readers: $CONCURRENT_READERS"
-  echo "concurrent reads: ${CONCURRENT_READS:-documents / $CONCURRENT_READS_DIVISOR when readers > 0}"
+  echo "concurrent reader sweep: ${CONCURRENT_READER_SWEEP:-none}"
+  echo "concurrent reads: ${CONCURRENT_READS:-documents / $CONCURRENT_READS_DIVISOR when readers or reader sweep is set}"
   echo "concurrent writers: $CONCURRENT_WRITERS"
   echo "concurrent writes: ${CONCURRENT_WRITES:-documents / $CONCURRENT_WRITES_DIVISOR when writers > 0}"
   echo "mongo mode: $MONGO_MODE"
@@ -545,10 +573,10 @@ for docs in $DOCS_LIST; do
   range_reads=$(derived_count "$docs" "$RANGE_READS" "$RANGE_READS_DIVISOR")
   updates=$(derived_count "$docs" "$UPDATES" "$UPDATES_DIVISOR")
   concurrent_reads=0
-  if [[ "$CONCURRENT_READERS" -gt 0 ]]; then
+  if [[ "$CONCURRENT_READERS" -gt 0 || -n "$CONCURRENT_READER_SWEEP" ]]; then
     concurrent_reads=$(derived_count "$docs" "$CONCURRENT_READS" "$CONCURRENT_READS_DIVISOR")
     if [[ "$concurrent_reads" -eq 0 ]]; then
-      echo "concurrent reads must be > 0 when CONCURRENT_READERS is > 0" >&2
+      echo "concurrent reads must be > 0 when concurrent readers or reader sweep is set" >&2
       exit 2
     fi
   fi
@@ -668,7 +696,8 @@ cat >"$README" <<EOF
 - updates: \`${UPDATES:-documents / $UPDATES_DIVISOR}\`
 - deletes: \`$DELETES\`
 - concurrent readers: \`$CONCURRENT_READERS\`
-- concurrent reads: \`${CONCURRENT_READS:-documents / $CONCURRENT_READS_DIVISOR when readers > 0}\`
+- concurrent reader sweep: \`${CONCURRENT_READER_SWEEP:-none}\`
+- concurrent reads: \`${CONCURRENT_READS:-documents / $CONCURRENT_READS_DIVISOR when readers or reader sweep is set}\`
 - concurrent writers: \`$CONCURRENT_WRITERS\`
 - concurrent writes: \`${CONCURRENT_WRITES:-documents / $CONCURRENT_WRITES_DIVISOR when writers > 0}\`
 - MongoDB mode: \`$MONGO_MODE\`

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -77,9 +77,10 @@ Options:
                         Reader goroutines for the concurrent _id read phase.
   --concurrent-reader-sweep LIST
                         Space- or comma-separated reader counts for concurrent
-                        _id read throughput sweep phases. Requires
-                        --concurrent-reads and cannot be combined with
-                        --concurrent-readers.
+                        _id read throughput sweep phases. Uses
+                        --concurrent-reads when set, otherwise derives from
+                        documents / CONCURRENT_READS_DIVISOR. Cannot be
+                        combined with --concurrent-readers.
   --concurrent-reads COUNT
                         Concurrent point reads per target/cell.
   --concurrent-writers N

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -520,18 +520,18 @@ if [[ -n "$CONCURRENT_READER_SWEEP" && "$CONCURRENT_READERS" -gt 0 ]]; then
   exit 2
 fi
 if [[ -n "$CONCURRENT_READER_SWEEP" ]]; then
-  declare -A seen_reader_counts=()
+  seen_reader_counts=""
   validated_reader_counts=0
   for reader_count in ${CONCURRENT_READER_SWEEP//,/ }; do
     if ! is_positive_int "$reader_count"; then
       echo "invalid CONCURRENT_READER_SWEEP value: $reader_count" >&2
       exit 2
     fi
-    if [[ -n "${seen_reader_counts[$reader_count]:-}" ]]; then
+    if [[ " $seen_reader_counts " == *" $reader_count "* ]]; then
       echo "duplicate CONCURRENT_READER_SWEEP value: $reader_count" >&2
       exit 2
     fi
-    seen_reader_counts[$reader_count]=1
+    seen_reader_counts="$seen_reader_counts $reader_count"
     validated_reader_counts=$((validated_reader_counts + 1))
   done
   if [[ "$validated_reader_counts" -eq 0 ]]; then

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -295,6 +295,15 @@ is_nonnegative_int() {
   [[ "$1" =~ ^[0-9]+$ ]]
 }
 
+is_positive_decimal_string() {
+  [[ "$1" =~ ^[0-9]+$ ]] || return 1
+  local value=$1
+  while [[ "$value" == 0* && ${#value} -gt 1 ]]; do
+    value=${value#0}
+  done
+  [[ "$value" != "0" ]]
+}
+
 trim_spaces() {
   local value=$1
   value="${value#"${value%%[![:space:]]*}"}"
@@ -525,7 +534,7 @@ if [[ -n "$CONCURRENT_READER_SWEEP" ]]; then
   normalized_reader_sweep=""
   validated_reader_counts=0
   for reader_count in ${CONCURRENT_READER_SWEEP//,/ }; do
-    if ! is_positive_int "$reader_count"; then
+    if ! is_positive_decimal_string "$reader_count"; then
       echo "invalid CONCURRENT_READER_SWEEP value: $reader_count" >&2
       exit 2
     fi


### PR DESCRIPTION
## Summary
- add `-concurrent-reader-sweep` to emit multiple `concurrent_id_find_one_rN` phases from one loaded benchmark database
- plumb the sweep through `scripts/mongo_gateway_compare.sh` and document it in the Mongo gateway benchmark README
- add a dedicated `Concurrent Read Sweep` section to the comparison report so reader-count scaling is shown as one sweep instead of unrelated rows

## Validation
- `bash -n scripts/mongo_gateway_compare.sh`
- `go test ./cmd/mongo_gateway_bench ./cmd/mongo_gateway_compare_report -count 1`
- `GOWORK=off go run ./cmd/mongo_gateway_bench -target treedb -treedb-dir /tmp/treedb-reader-sweep-smoke -documents 20 -batch-size 10 -reads 0 -range-reads 0 -updates 0 -secondary-indexes 0 -concurrent-reader-sweep 1,2 -concurrent-reads 4 -format json`