### PR TITLE
Instrument collection update batch phases

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -173,11 +173,12 @@ func persistIndexStateForDocumentFormat(format DocumentFormat) bool {
 }
 
 type CollectionManager struct {
-	db              *backenddb.DB
-	closeUnregister func()
-	closing         atomic.Bool
-	domainMu        sync.RWMutex
-	domains         map[string]*collectionWriteDomain
+	db                       *backenddb.DB
+	closeUnregister          func()
+	closing                  atomic.Bool
+	updateBatchDetailedStats atomic.Bool
+	domainMu                 sync.RWMutex
+	domains                  map[string]*collectionWriteDomain
 }
 
 type Collection struct {
@@ -190,6 +191,8 @@ type Collection struct {
 	catalog           *collectionCatalog
 	insertStatsMu     sync.RWMutex
 	lastInsertStats   CollectionInsertStats
+	updateStatsMu     sync.RWMutex
+	lastUpdateStats   CollectionUpdateStats
 }
 
 // StoredDocumentJSONMaterializer reuses any resources needed to materialize
@@ -276,6 +279,33 @@ type CollectionSecondaryRunStats struct {
 	Build         time.Duration
 }
 
+// CollectionUpdateStats captures phase timings and counters from the most
+// recent successful UpdateBatch-style call on a Collection handle. Individual
+// Update calls that fall back to the legacy direct path are intentionally not
+// represented here yet; the write combiner and UpdateBatch path use this shape.
+type CollectionUpdateStats struct {
+	Items                  int
+	Matched                int
+	Modified               int
+	Indexes                int
+	Runs                   int
+	BufferedBatches        int
+	CurrentRead            time.Duration
+	Callback               time.Duration
+	PrepareDocuments       time.Duration
+	IndexStateExtraction   time.Duration
+	UniqueIndexPreflight   time.Duration
+	TemplateRunBuild       time.Duration
+	PrimaryRunBuild        time.Duration
+	IndexStateRunBuild     time.Duration
+	SecondaryRunBuild      time.Duration
+	BufferStage            time.Duration
+	Publish                time.Duration
+	SecondaryDeleteEntries int
+	SecondarySetEntries    int
+	SecondaryKeyBytes      int
+}
+
 // CollectionManagerStats captures aggregate write-domain counters for a
 // CollectionManager. The counters are process-local observability; they are
 // not persisted with collection metadata.
@@ -309,6 +339,26 @@ type CollectionManagerStats struct {
 	UpdateCombineBatchedRequests  uint64
 	UpdateCombineFallbackRequests uint64
 	UpdateCombineQueueDepthMax    uint64
+	UpdateBatchCalls              uint64
+	UpdateBatchItems              uint64
+	UpdateBatchMatched            uint64
+	UpdateBatchModified           uint64
+	UpdateBatchRuns               uint64
+	UpdateBatchBufferedBatches    uint64
+	UpdateBatchCurrentRead        time.Duration
+	UpdateBatchCallback           time.Duration
+	UpdateBatchPrepareDocuments   time.Duration
+	UpdateBatchIndexStateExtract  time.Duration
+	UpdateBatchUniquePreflight    time.Duration
+	UpdateBatchTemplateRunBuild   time.Duration
+	UpdateBatchPrimaryRunBuild    time.Duration
+	UpdateBatchIndexStateRunBuild time.Duration
+	UpdateBatchSecondaryRunBuild  time.Duration
+	UpdateBatchBufferStage        time.Duration
+	UpdateBatchPublish            time.Duration
+	UpdateBatchSecondaryDeletes   uint64
+	UpdateBatchSecondarySets      uint64
+	UpdateBatchSecondaryKeyBytes  uint64
 }
 
 // DocumentRecord is one primary collection record returned by ScanDocuments.
@@ -556,6 +606,27 @@ type collectionWriteDomain struct {
 	updateCombineBatchedRequests  atomic.Uint64
 	updateCombineFallbackRequests atomic.Uint64
 	updateCombineQueueDepthMax    atomic.Uint64
+	updateBatchCalls              atomic.Uint64
+	updateBatchItems              atomic.Uint64
+	updateBatchMatched            atomic.Uint64
+	updateBatchModified           atomic.Uint64
+	updateBatchRuns               atomic.Uint64
+	updateBatchBufferedBatches    atomic.Uint64
+	updateBatchCurrentReadNs      atomic.Uint64
+	updateBatchCallbackNs         atomic.Uint64
+	updateBatchPrepareNs          atomic.Uint64
+	updateBatchIndexStateNs       atomic.Uint64
+	updateBatchUniquePreflightNs  atomic.Uint64
+	updateBatchTemplateRunNs      atomic.Uint64
+	updateBatchPrimaryRunNs       atomic.Uint64
+	updateBatchIndexStateRunNs    atomic.Uint64
+	updateBatchSecondaryRunNs     atomic.Uint64
+	updateBatchBufferStageNs      atomic.Uint64
+	updateBatchPublishNs          atomic.Uint64
+	updateBatchSecondaryDeletes   atomic.Uint64
+	updateBatchSecondarySets      atomic.Uint64
+	updateBatchSecondaryKeyBytes  atomic.Uint64
+	updateBatchDetailedStats      atomic.Bool
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -564,6 +635,24 @@ func NewCollectionManager(database *backenddb.DB) *CollectionManager {
 		manager.closeUnregister = database.RegisterCloseHook(manager.closeForBackend)
 	}
 	return manager
+}
+
+// SetUpdateBatchDetailedStatsEnabled toggles high-resolution update-batch phase
+// timings for this manager's collection write domains. Lightweight counters
+// remain enabled either way; timings are opt-in so normal write paths do not pay
+// for repeated clock reads unless a benchmark or profiler explicitly asks.
+func (m *CollectionManager) SetUpdateBatchDetailedStatsEnabled(enabled bool) {
+	if m == nil {
+		return
+	}
+	m.updateBatchDetailedStats.Store(enabled)
+	m.domainMu.RLock()
+	for _, domain := range m.domains {
+		if domain != nil {
+			domain.updateBatchDetailedStats.Store(enabled)
+		}
+	}
+	m.domainMu.RUnlock()
 }
 
 func (m *CollectionManager) closeForBackend() error {
@@ -620,6 +709,47 @@ func cloneCollectionInsertStats(stats CollectionInsertStats) CollectionInsertSta
 	return stats
 }
 
+// LastUpdateStats returns phase timings and counters from the most recent
+// successful UpdateBatch-style call on this Collection handle.
+func (c *Collection) LastUpdateStats() CollectionUpdateStats {
+	if c == nil {
+		return CollectionUpdateStats{}
+	}
+	c.updateStatsMu.RLock()
+	defer c.updateStatsMu.RUnlock()
+	return c.lastUpdateStats
+}
+
+func (c *Collection) setLastUpdateStats(stats CollectionUpdateStats) {
+	if c == nil {
+		return
+	}
+	c.updateStatsMu.Lock()
+	c.lastUpdateStats = stats
+	c.updateStatsMu.Unlock()
+	if c.writeDomain != nil {
+		c.writeDomain.observeUpdateBatchStats(stats)
+	}
+}
+
+func (c *Collection) updateBatchDetailedStatsEnabled() bool {
+	return c != nil && c.writeDomain != nil && c.writeDomain.updateBatchDetailedStats.Load()
+}
+
+func updateBatchStatsNow(enabled bool) time.Time {
+	if !enabled {
+		return time.Time{}
+	}
+	return time.Now()
+}
+
+func updateBatchStatsSince(enabled bool, start time.Time) time.Duration {
+	if !enabled {
+		return 0
+	}
+	return time.Since(start)
+}
+
 // Stats returns aggregate process-local collection write-domain metrics with
 // stable TreeDB benchmark key names.
 func (m *CollectionManager) Stats() map[string]string {
@@ -660,6 +790,26 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_combine.batched_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineBatchedRequests)
 	out["treedb.collections.write_domain.update_combine.fallback_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineFallbackRequests)
 	out["treedb.collections.write_domain.update_combine.queue_depth_max"] = fmt.Sprintf("%d", stats.UpdateCombineQueueDepthMax)
+	out["treedb.collections.write_domain.update_batch.calls_total"] = fmt.Sprintf("%d", stats.UpdateBatchCalls)
+	out["treedb.collections.write_domain.update_batch.items_total"] = fmt.Sprintf("%d", stats.UpdateBatchItems)
+	out["treedb.collections.write_domain.update_batch.matched_total"] = fmt.Sprintf("%d", stats.UpdateBatchMatched)
+	out["treedb.collections.write_domain.update_batch.modified_total"] = fmt.Sprintf("%d", stats.UpdateBatchModified)
+	out["treedb.collections.write_domain.update_batch.root_runs_total"] = fmt.Sprintf("%d", stats.UpdateBatchRuns)
+	out["treedb.collections.write_domain.update_batch.buffered_batches_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferedBatches)
+	out["treedb.collections.write_domain.update_batch.current_read_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchCurrentRead.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.callback_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchCallback.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.prepare_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchPrepareDocuments.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.index_state_extract_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchIndexStateExtract.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.unique_preflight_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchUniquePreflight.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.template_run_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchTemplateRunBuild.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.primary_run_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchPrimaryRunBuild.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.index_state_run_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchIndexStateRunBuild.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.secondary_runs_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchSecondaryRunBuild.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferStage.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.publish_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchPublish.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.secondary_deletes_total"] = fmt.Sprintf("%d", stats.UpdateBatchSecondaryDeletes)
+	out["treedb.collections.write_domain.update_batch.secondary_sets_total"] = fmt.Sprintf("%d", stats.UpdateBatchSecondarySets)
+	out["treedb.collections.write_domain.update_batch.secondary_key_bytes_total"] = fmt.Sprintf("%d", stats.UpdateBatchSecondaryKeyBytes)
 	return out
 }
 
@@ -720,6 +870,26 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	if other.UpdateCombineQueueDepthMax > s.UpdateCombineQueueDepthMax {
 		s.UpdateCombineQueueDepthMax = other.UpdateCombineQueueDepthMax
 	}
+	s.UpdateBatchCalls += other.UpdateBatchCalls
+	s.UpdateBatchItems += other.UpdateBatchItems
+	s.UpdateBatchMatched += other.UpdateBatchMatched
+	s.UpdateBatchModified += other.UpdateBatchModified
+	s.UpdateBatchRuns += other.UpdateBatchRuns
+	s.UpdateBatchBufferedBatches += other.UpdateBatchBufferedBatches
+	s.UpdateBatchCurrentRead += other.UpdateBatchCurrentRead
+	s.UpdateBatchCallback += other.UpdateBatchCallback
+	s.UpdateBatchPrepareDocuments += other.UpdateBatchPrepareDocuments
+	s.UpdateBatchIndexStateExtract += other.UpdateBatchIndexStateExtract
+	s.UpdateBatchUniquePreflight += other.UpdateBatchUniquePreflight
+	s.UpdateBatchTemplateRunBuild += other.UpdateBatchTemplateRunBuild
+	s.UpdateBatchPrimaryRunBuild += other.UpdateBatchPrimaryRunBuild
+	s.UpdateBatchIndexStateRunBuild += other.UpdateBatchIndexStateRunBuild
+	s.UpdateBatchSecondaryRunBuild += other.UpdateBatchSecondaryRunBuild
+	s.UpdateBatchBufferStage += other.UpdateBatchBufferStage
+	s.UpdateBatchPublish += other.UpdateBatchPublish
+	s.UpdateBatchSecondaryDeletes += other.UpdateBatchSecondaryDeletes
+	s.UpdateBatchSecondarySets += other.UpdateBatchSecondarySets
+	s.UpdateBatchSecondaryKeyBytes += other.UpdateBatchSecondaryKeyBytes
 }
 
 func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
@@ -760,6 +930,26 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateCombineBatchedRequests = domain.updateCombineBatchedRequests.Load()
 	stats.UpdateCombineFallbackRequests = domain.updateCombineFallbackRequests.Load()
 	stats.UpdateCombineQueueDepthMax = domain.updateCombineQueueDepthMax.Load()
+	stats.UpdateBatchCalls = domain.updateBatchCalls.Load()
+	stats.UpdateBatchItems = domain.updateBatchItems.Load()
+	stats.UpdateBatchMatched = domain.updateBatchMatched.Load()
+	stats.UpdateBatchModified = domain.updateBatchModified.Load()
+	stats.UpdateBatchRuns = domain.updateBatchRuns.Load()
+	stats.UpdateBatchBufferedBatches = domain.updateBatchBufferedBatches.Load()
+	stats.UpdateBatchCurrentRead = durationFromAtomicNs(domain.updateBatchCurrentReadNs.Load())
+	stats.UpdateBatchCallback = durationFromAtomicNs(domain.updateBatchCallbackNs.Load())
+	stats.UpdateBatchPrepareDocuments = durationFromAtomicNs(domain.updateBatchPrepareNs.Load())
+	stats.UpdateBatchIndexStateExtract = durationFromAtomicNs(domain.updateBatchIndexStateNs.Load())
+	stats.UpdateBatchUniquePreflight = durationFromAtomicNs(domain.updateBatchUniquePreflightNs.Load())
+	stats.UpdateBatchTemplateRunBuild = durationFromAtomicNs(domain.updateBatchTemplateRunNs.Load())
+	stats.UpdateBatchPrimaryRunBuild = durationFromAtomicNs(domain.updateBatchPrimaryRunNs.Load())
+	stats.UpdateBatchIndexStateRunBuild = durationFromAtomicNs(domain.updateBatchIndexStateRunNs.Load())
+	stats.UpdateBatchSecondaryRunBuild = durationFromAtomicNs(domain.updateBatchSecondaryRunNs.Load())
+	stats.UpdateBatchBufferStage = durationFromAtomicNs(domain.updateBatchBufferStageNs.Load())
+	stats.UpdateBatchPublish = durationFromAtomicNs(domain.updateBatchPublishNs.Load())
+	stats.UpdateBatchSecondaryDeletes = domain.updateBatchSecondaryDeletes.Load()
+	stats.UpdateBatchSecondarySets = domain.updateBatchSecondarySets.Load()
+	stats.UpdateBatchSecondaryKeyBytes = domain.updateBatchSecondaryKeyBytes.Load()
 	return stats
 }
 
@@ -797,6 +987,48 @@ func (domain *collectionWriteDomain) observeMutationLock(wait, hold time.Duratio
 	domain.mutationLockCalls.Add(1)
 	domain.mutationLockWaitTotalNs.Add(durationToAtomicNs(wait))
 	domain.mutationLockHoldTotalNs.Add(durationToAtomicNs(hold))
+}
+
+func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpdateStats) {
+	if domain == nil {
+		return
+	}
+	domain.updateBatchCalls.Add(1)
+	if stats.Items > 0 {
+		domain.updateBatchItems.Add(uint64(stats.Items))
+	}
+	if stats.Matched > 0 {
+		domain.updateBatchMatched.Add(uint64(stats.Matched))
+	}
+	if stats.Modified > 0 {
+		domain.updateBatchModified.Add(uint64(stats.Modified))
+	}
+	if stats.Runs > 0 {
+		domain.updateBatchRuns.Add(uint64(stats.Runs))
+	}
+	if stats.BufferedBatches > 0 {
+		domain.updateBatchBufferedBatches.Add(uint64(stats.BufferedBatches))
+	}
+	domain.updateBatchCurrentReadNs.Add(durationToAtomicNs(stats.CurrentRead))
+	domain.updateBatchCallbackNs.Add(durationToAtomicNs(stats.Callback))
+	domain.updateBatchPrepareNs.Add(durationToAtomicNs(stats.PrepareDocuments))
+	domain.updateBatchIndexStateNs.Add(durationToAtomicNs(stats.IndexStateExtraction))
+	domain.updateBatchUniquePreflightNs.Add(durationToAtomicNs(stats.UniqueIndexPreflight))
+	domain.updateBatchTemplateRunNs.Add(durationToAtomicNs(stats.TemplateRunBuild))
+	domain.updateBatchPrimaryRunNs.Add(durationToAtomicNs(stats.PrimaryRunBuild))
+	domain.updateBatchIndexStateRunNs.Add(durationToAtomicNs(stats.IndexStateRunBuild))
+	domain.updateBatchSecondaryRunNs.Add(durationToAtomicNs(stats.SecondaryRunBuild))
+	domain.updateBatchBufferStageNs.Add(durationToAtomicNs(stats.BufferStage))
+	domain.updateBatchPublishNs.Add(durationToAtomicNs(stats.Publish))
+	if stats.SecondaryDeleteEntries > 0 {
+		domain.updateBatchSecondaryDeletes.Add(uint64(stats.SecondaryDeleteEntries))
+	}
+	if stats.SecondarySetEntries > 0 {
+		domain.updateBatchSecondarySets.Add(uint64(stats.SecondarySetEntries))
+	}
+	if stats.SecondaryKeyBytes > 0 {
+		domain.updateBatchSecondaryKeyBytes.Add(uint64(stats.SecondaryKeyBytes))
+	}
 }
 
 func (domain *collectionWriteDomain) observeIndexedStage(docs int, bytes int64, rootRuns int) {
@@ -956,6 +1188,7 @@ func (m *CollectionManager) writeDomainForCollection(name string) *collectionWri
 		return domain
 	}
 	domain := &collectionWriteDomain{}
+	domain.updateBatchDetailedStats.Store(m.updateBatchDetailedStats.Load())
 	m.domains[name] = domain
 	return domain
 }
@@ -4779,6 +5012,7 @@ func (c *Collection) updateBatch(items []UpdateBatchItem, mode updateBatchMode) 
 		return nil, false, err
 	}
 	if len(items) == 0 {
+		c.setLastUpdateStats(CollectionUpdateStats{})
 		return nil, true, nil
 	}
 	if err := validateUpdateBatchItems(items); err != nil {
@@ -5764,6 +5998,7 @@ type preparedBatchUpdate struct {
 
 type updateBatchPlan struct {
 	results                     []UpdateBatchResult
+	stats                       CollectionUpdateStats
 	meta                        CollectionMeta
 	catalog                     *collectionCatalog
 	snap                        *backenddb.Snapshot
@@ -6056,6 +6291,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 				results, publishErr = c.publishUpdateBatchPlanLocked(plan)
 				return publishErr
 			})
+			stats := plan.stats
 			plan.close()
 			if err != nil {
 				return nil, err
@@ -6063,6 +6299,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 			if replan {
 				continue
 			}
+			c.setLastUpdateStats(stats)
 			return results, nil
 		}
 	}
@@ -6094,6 +6331,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 		}); err != nil {
 			return nil, err
 		}
+		c.setLastUpdateStats(plan.stats)
 		return plan.results, nil
 	}
 
@@ -6114,6 +6352,9 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 		results, publishErr = c.publishUpdateBatchPlanLocked(plan)
 		return publishErr
 	})
+	if err == nil {
+		c.setLastUpdateStats(plan.stats)
+	}
 	return results, err
 }
 
@@ -6349,6 +6590,11 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		return nil, errCollectionNotFound
 	}
 	meta := catalog.meta
+	stats := CollectionUpdateStats{
+		Items:   len(items),
+		Indexes: len(meta.Indexes),
+	}
+	detailedStats := c.updateBatchDetailedStatsEnabled()
 	if mode == updateBatchModeNoSecondaryUniqueIndexes && collectionMetaHasSecondaryUniqueIndex(meta) {
 		_ = snap.Close()
 		return nil, errUpdateBatchHasSecondaryUniqueIndex
@@ -6387,6 +6633,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		plan := newUpdateBatchPlan()
 		*plan = updateBatchPlan{
 			results:                results,
+			stats:                  stats,
 			meta:                   meta,
 			catalog:                catalog,
 			snap:                   snap,
@@ -6430,7 +6677,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	}()
 	var currentScratch []byte
 	for i, item := range items {
+		phaseStart := updateBatchStatsNow(detailedStats)
 		current, err := readUpdateBatchCurrentDocument(snap, primaryRoot, i, item.DocumentID, bufferedRead, currentScratch[:0])
+		stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()
 			return nil, updateBatchItemError(i, err)
@@ -6449,13 +6698,17 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			documentID: item.DocumentID,
 		}
 		if len(runtimes) > 0 {
+			phaseStart = updateBatchStatsNow(detailedStats)
 			prepared.oldState, err = orderedIndexStateForDocumentWithArena(current.value, runtimes, plannerOptions, stateArena)
+			stats.IndexStateExtraction += updateBatchStatsSince(detailedStats, phaseStart)
 			if err != nil {
 				_ = snap.Close()
 				return nil, updateBatchItemError(i, err)
 			}
 		}
+		phaseStart = updateBatchStatsNow(detailedStats)
 		document, changedOne, err := callCollectionUpdateCallback(item.Update, current.value)
+		stats.Callback += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()
 			return nil, updateBatchItemError(i, err)
@@ -6487,6 +6740,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		plan := newUpdateBatchPlan()
 		*plan = updateBatchPlan{
 			results:                results,
+			stats:                  updateCollectionUpdateStatsCounts(stats, results, 0),
 			meta:                   meta,
 			catalog:                catalog,
 			snap:                   snap,
@@ -6504,7 +6758,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		return plan, nil
 	}
 
+	phaseStart := updateBatchStatsNow(detailedStats)
 	preparedDocuments, templateRecords, templateResolver, err := prepareInsertDocuments(changedDocuments, plannerOptions)
+	stats.PrepareDocuments += updateBatchStatsSince(detailedStats, phaseStart)
 	if err != nil {
 		for i, document := range changedDocuments {
 			if _, _, _, itemErr := prepareInsertDocuments([][]byte{document}, plannerOptions); itemErr != nil {
@@ -6525,7 +6781,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	for i := range changed {
 		changed[i].document = preparedDocuments[i]
 		if len(runtimes) > 0 {
+			phaseStart = updateBatchStatsNow(detailedStats)
 			changed[i].newState, err = orderedIndexStateForDocumentWithArena(changed[i].document, runtimes, plannerOptions, stateArena)
+			stats.IndexStateExtraction += updateBatchStatsSince(detailedStats, phaseStart)
 			if err != nil {
 				_ = snap.Close()
 				return nil, updateBatchItemError(changed[i].itemIndex, err)
@@ -6537,6 +6795,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, errUpdateBatchChangesSecondaryUniqueIndex
 	}
+	phaseStart = updateBatchStatsNow(detailedStats)
 	batchReplacements := batchUniqueReplacementOwners(runtimes, changed)
 	for i := range changed {
 		if changed[i].indexStateChanged {
@@ -6550,6 +6809,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, err
 	}
+	stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 
 	var stateTable memtable.Table
 	secondaryTables := make(map[string]memtable.Table, len(runtimes))
@@ -6567,6 +6827,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	}()
 
 	if len(templateRecords) > 0 {
+		phaseStart = updateBatchStatsNow(detailedStats)
 		templatePlan := &insertBatchPlan{}
 		if err := (insertBatchPlanner{
 			collection:             meta.Name,
@@ -6582,12 +6843,14 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			policies = append(policies, run.storagePolicy)
 			deltaTables = append(deltaTables, run.table)
 		}
+		stats.TemplateRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 	}
 
 	primaryRootName := collectionPrimaryRootName(meta.Name)
 	rootNames = append(rootNames, primaryRootName)
 	baseRootIDs[primaryRootName] = primaryRoot
 	policies = append(policies, plannerOptions.dataStoragePolicy)
+	phaseStart = updateBatchStatsNow(detailedStats)
 	primaryTable := newCollectionRunTable(len(changed))
 	for _, item := range changed {
 		setCollectionRunCopiedValue(primaryTable, item.documentID, item.document)
@@ -6595,26 +6858,42 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	}
 	primaryTable.Freeze()
 	deltaTables = append(deltaTables, primaryTable)
+	stats.PrimaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 
 	if len(runtimes) > 0 {
 		if persistIndexStateForOptions(plannerOptions) {
 			stateTable = newCollectionRunTable(len(changed))
 		}
+		phaseStart = updateBatchStatsNow(detailedStats)
+		for _, item := range changed {
+			if !item.indexStateChanged || stateTable == nil {
+				continue
+			}
+			if orderedDocumentIndexStateEmpty(item.newState) {
+				stateTable.DeleteSteal(bytes.Clone(item.documentID))
+			} else {
+				rawState, err := encodeRuntimeOrderedDocumentIndexState(item.newState, runtimes)
+				if err != nil {
+					_ = snap.Close()
+					return nil, err
+				}
+				stateTable.SetSteal(bytes.Clone(item.documentID), rawState)
+			}
+		}
+		if stateTable != nil && stateTable.Len() > 0 {
+			stateTable.Freeze()
+			stateRootName := collectionIndexStateRootName(meta.Name)
+			rootNames = append(rootNames, stateRootName)
+			baseRootIDs[stateRootName] = catalog.rootID(stateRootName)
+			policies = append(policies, plannerOptions.indexStateStoragePolicy)
+			deltaTables = append(deltaTables, stateTable)
+			stateTable = nil
+		}
+		stats.IndexStateRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
+		phaseStart = updateBatchStatsNow(detailedStats)
 		for _, item := range changed {
 			if !item.indexStateChanged {
 				continue
-			}
-			if stateTable != nil {
-				if orderedDocumentIndexStateEmpty(item.newState) {
-					stateTable.DeleteSteal(bytes.Clone(item.documentID))
-				} else {
-					rawState, err := encodeRuntimeOrderedDocumentIndexState(item.newState, runtimes)
-					if err != nil {
-						_ = snap.Close()
-						return nil, err
-					}
-					stateTable.SetSteal(bytes.Clone(item.documentID), rawState)
-				}
 			}
 			for runtimeIdx, runtime := range runtimes {
 				rootName := collectionSecondaryRootName(meta.Name, runtime.def.name)
@@ -6630,6 +6909,8 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 				}
 				for _, key := range deleteKeys {
 					table.DeleteSteal(bytes.Clone(key))
+					stats.SecondaryDeleteEntries++
+					stats.SecondaryKeyBytes += len(key)
 				}
 				for _, encoded := range item.newState.valuesAt(runtimeIdx) {
 					key, err := indexEntryKey(encoded, item.documentID)
@@ -6638,17 +6919,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 						return nil, err
 					}
 					table.SetSteal(key, nil)
+					stats.SecondarySetEntries++
+					stats.SecondaryKeyBytes += len(key)
 				}
 			}
-		}
-		if stateTable != nil && stateTable.Len() > 0 {
-			stateTable.Freeze()
-			stateRootName := collectionIndexStateRootName(meta.Name)
-			rootNames = append(rootNames, stateRootName)
-			baseRootIDs[stateRootName] = catalog.rootID(stateRootName)
-			policies = append(policies, plannerOptions.indexStateStoragePolicy)
-			deltaTables = append(deltaTables, stateTable)
-			stateTable = nil
 		}
 		for _, runtime := range runtimes {
 			rootName := collectionSecondaryRootName(meta.Name, runtime.def.name)
@@ -6663,6 +6937,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			deltaTables = append(deltaTables, table)
 			delete(secondaryTables, rootName)
 		}
+		stats.SecondaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 	}
 
 	// Tables moved into deltaTables are nil/deleted above; only unused scratch
@@ -6673,8 +6948,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	}
 	success = true
 	plan := newUpdateBatchPlan()
+	stats = updateCollectionUpdateStatsCounts(stats, results, len(deltaTables))
 	*plan = updateBatchPlan{
 		results:                     results,
+		stats:                       stats,
 		meta:                        meta,
 		catalog:                     catalog,
 		snap:                        snap,
@@ -6729,9 +7006,12 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	preflight := func() error {
 		return c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq)
 	}
+	detailedStats := c.updateBatchDetailedStatsEnabled()
+	publishStart := updateBatchStatsNow(detailedStats)
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIteratorForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, rootIDs)
 	})
+	plan.stats.Publish += updateBatchStatsSince(detailedStats, publishStart)
 	if err != nil {
 		return nil, err
 	}
@@ -6749,6 +7029,11 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if c == nil || plan == nil || len(plan.deltaTables) == 0 {
 		return false, nil
 	}
+	detailedStats := c.updateBatchDetailedStatsEnabled()
+	bufferStart := updateBatchStatsNow(detailedStats)
+	defer func() {
+		plan.stats.BufferStage += updateBatchStatsSince(detailedStats, bufferStart)
+	}()
 	if c.writeDomain == nil || !plan.canBufferIndexedUpdateBatch || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
 		return false, nil
 	}
@@ -6915,6 +7200,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			return false, err
 		}
 	}
+	plan.stats.BufferedBatches = 1
 	return true, nil
 }
 
@@ -6926,6 +7212,23 @@ func updateBatchModifiedCount(results []UpdateBatchResult) int {
 		}
 	}
 	return count
+}
+
+func updateBatchMatchedCount(results []UpdateBatchResult) int {
+	count := 0
+	for _, result := range results {
+		if result.Matched {
+			count++
+		}
+	}
+	return count
+}
+
+func updateCollectionUpdateStatsCounts(stats CollectionUpdateStats, results []UpdateBatchResult, runs int) CollectionUpdateStats {
+	stats.Matched = updateBatchMatchedCount(results)
+	stats.Modified = updateBatchModifiedCount(results)
+	stats.Runs = runs
+	return stats
 }
 
 func rejectBatchUniqueConflicts(runtimes []indexRuntime, updates []preparedBatchUpdate) error {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -530,6 +530,118 @@ func TestCollectionInsertBatchStatsExposeIndexRunShape(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com","city":"hnl"}`),
+			[]byte(`{"email":"grace@example.com","city":"sfo"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+
+	results, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"lhr"}`), true, nil
+		}},
+		{DocumentID: []byte("u2"), Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"grace@example.com","city":"ord"}`), true, nil
+		}},
+	})
+	if err != nil {
+		t.Fatalf("update batch: %v", err)
+	}
+	for i, result := range results {
+		if !result.Matched || !result.Modified {
+			t.Fatalf("result %d=%+v want matched+modified", i, result)
+		}
+	}
+
+	stats := col.LastUpdateStats()
+	if got, want := stats.Items, 2; got != want {
+		t.Fatalf("stats items=%d want %d", got, want)
+	}
+	if got, want := stats.Matched, 2; got != want {
+		t.Fatalf("stats matched=%d want %d", got, want)
+	}
+	if got, want := stats.Modified, 2; got != want {
+		t.Fatalf("stats modified=%d want %d", got, want)
+	}
+	if got, want := stats.Indexes, 2; got != want {
+		t.Fatalf("stats indexes=%d want %d", got, want)
+	}
+	if got := stats.Runs; got < 2 {
+		t.Fatalf("stats runs=%d want at least primary+secondary", got)
+	}
+	if got := stats.SecondaryDeleteEntries; got < 2 {
+		t.Fatalf("stats secondary deletes=%d want at least 2", got)
+	}
+	if got := stats.SecondarySetEntries; got < 2 {
+		t.Fatalf("stats secondary sets=%d want at least 2", got)
+	}
+	if stats.SecondaryKeyBytes == 0 {
+		t.Fatal("stats secondary key bytes=0 want positive")
+	}
+	if stats.CurrentRead != 0 || stats.Callback != 0 || stats.BufferStage != 0 {
+		t.Fatalf("default update timings=%+v want zero unless detailed stats enabled", stats)
+	}
+
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
+	if _, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"sea"}`), true, nil
+		}},
+		{DocumentID: []byte("u2"), Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"grace@example.com","city":"bos"}`), true, nil
+		}},
+	}); err != nil {
+		t.Fatalf("timed update batch: %v", err)
+	}
+	timedStats := col.LastUpdateStats()
+	if timedStats.CurrentRead <= 0 {
+		t.Fatalf("timed current read=%s want positive with detailed stats enabled", timedStats.CurrentRead)
+	}
+
+	managerStats := mgr.StatsSnapshot()
+	if got := managerStats.UpdateBatchCalls; got == 0 {
+		t.Fatal("manager update batch calls=0 want positive")
+	}
+	if got := managerStats.UpdateBatchItems; got < 2 {
+		t.Fatalf("manager update batch items=%d want at least 2", got)
+	}
+	if got := managerStats.UpdateBatchModified; got < 2 {
+		t.Fatalf("manager update batch modified=%d want at least 2", got)
+	}
+	if got := managerStats.UpdateBatchSecondarySets; got < 2 {
+		t.Fatalf("manager update batch secondary sets=%d want at least 2", got)
+	}
+	exported := mgr.Stats()
+	if _, ok := exported["treedb.collections.write_domain.update_batch.secondary_sets_total"]; !ok {
+		t.Fatalf("manager stats missing update batch secondary set counter: keys=%v", exported)
+	}
+}
+
 func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -610,6 +610,7 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	mgr.SetUpdateBatchDetailedStatsEnabled(true)
 	if _, err := col.UpdateBatch([]UpdateBatchItem{
 		{DocumentID: []byte("u1"), Update: func(current []byte) ([]byte, bool, error) {
+			time.Sleep(time.Millisecond)
 			return []byte(`{"email":"ada@example.com","city":"sea"}`), true, nil
 		}},
 		{DocumentID: []byte("u2"), Update: func(current []byte) ([]byte, bool, error) {
@@ -619,8 +620,8 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 		t.Fatalf("timed update batch: %v", err)
 	}
 	timedStats := col.LastUpdateStats()
-	if timedStats.CurrentRead <= 0 {
-		t.Fatalf("timed current read=%s want positive with detailed stats enabled", timedStats.CurrentRead)
+	if timedStats.Callback <= 0 {
+		t.Fatalf("timed callback=%s want positive with detailed stats enabled", timedStats.Callback)
 	}
 
 	managerStats := mgr.StatsSnapshot()

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -491,7 +491,13 @@ The benchmark shapes are intentionally different:
 - `BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2` preloads a BSON
   collection, then runs concurrent `_id` updates through `Collection.Update`
   without the Mongo gateway. This is useful when comparing gateway update
-  profiles with the storage/update path directly.
+  profiles with the storage/update path directly. The benchmark enables
+  collection-manager detailed update timing for its measured phase and reports
+  update attribution metrics such as `update_current_read_ns/doc`,
+  `update_callback_ns/doc`, `update_index_state_extract_ns/doc`,
+  `update_primary_run_ns/doc`, `update_secondary_runs_ns/doc`,
+  `update_buffer_stage_ns/doc`, `update_publish_ns/doc`, and
+  `update_items/batch` from the collection manager's measured-phase counters.
 - `BenchmarkClientBSONBatchEncode` measures client-side BSON document encoding
   alone.
 

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -494,6 +494,8 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	}
 
 	b.ReportAllocs()
+	manager.SetUpdateBatchDetailedStatsEnabled(true)
+	statsBefore := manager.StatsSnapshot()
 	b.ResetTimer()
 	started := time.Now()
 	err = runProfileBenchDirectCollectionConcurrentUpdates(context.Background(), writers, b.N, documentCount, idStride, ids, updateDocs, collection)
@@ -503,7 +505,81 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 		b.Fatalf("run concurrent updates: %v", err)
 	}
 	b.ReportMetric(float64(writers), "writers")
+	reportCollectionManagerUpdateStats(b, deltaCollectionManagerUpdateStats(manager.StatsSnapshot(), statsBefore), b.N)
 	reportDocsPerSecond(b, b.N, timedElapsed)
+}
+
+func deltaCollectionManagerUpdateStats(after, before collections.CollectionManagerStats) collections.CollectionManagerStats {
+	return collections.CollectionManagerStats{
+		UpdateBatchCalls:              after.UpdateBatchCalls - before.UpdateBatchCalls,
+		UpdateBatchItems:              after.UpdateBatchItems - before.UpdateBatchItems,
+		UpdateBatchMatched:            after.UpdateBatchMatched - before.UpdateBatchMatched,
+		UpdateBatchModified:           after.UpdateBatchModified - before.UpdateBatchModified,
+		UpdateBatchRuns:               after.UpdateBatchRuns - before.UpdateBatchRuns,
+		UpdateBatchBufferedBatches:    after.UpdateBatchBufferedBatches - before.UpdateBatchBufferedBatches,
+		UpdateBatchCurrentRead:        after.UpdateBatchCurrentRead - before.UpdateBatchCurrentRead,
+		UpdateBatchCallback:           after.UpdateBatchCallback - before.UpdateBatchCallback,
+		UpdateBatchPrepareDocuments:   after.UpdateBatchPrepareDocuments - before.UpdateBatchPrepareDocuments,
+		UpdateBatchIndexStateExtract:  after.UpdateBatchIndexStateExtract - before.UpdateBatchIndexStateExtract,
+		UpdateBatchUniquePreflight:    after.UpdateBatchUniquePreflight - before.UpdateBatchUniquePreflight,
+		UpdateBatchTemplateRunBuild:   after.UpdateBatchTemplateRunBuild - before.UpdateBatchTemplateRunBuild,
+		UpdateBatchPrimaryRunBuild:    after.UpdateBatchPrimaryRunBuild - before.UpdateBatchPrimaryRunBuild,
+		UpdateBatchIndexStateRunBuild: after.UpdateBatchIndexStateRunBuild - before.UpdateBatchIndexStateRunBuild,
+		UpdateBatchSecondaryRunBuild:  after.UpdateBatchSecondaryRunBuild - before.UpdateBatchSecondaryRunBuild,
+		UpdateBatchBufferStage:        after.UpdateBatchBufferStage - before.UpdateBatchBufferStage,
+		UpdateBatchPublish:            after.UpdateBatchPublish - before.UpdateBatchPublish,
+		UpdateBatchSecondaryDeletes:   after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
+		UpdateBatchSecondarySets:      after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
+		UpdateBatchSecondaryKeyBytes:  after.UpdateBatchSecondaryKeyBytes - before.UpdateBatchSecondaryKeyBytes,
+	}
+}
+
+func reportCollectionManagerUpdateStats(b *testing.B, stats collections.CollectionManagerStats, docs int) {
+	b.Helper()
+	if docs <= 0 {
+		return
+	}
+	if stats.UpdateBatchCalls > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchCalls), "update_batches")
+		b.ReportMetric(float64(stats.UpdateBatchItems)/float64(stats.UpdateBatchCalls), "update_items/batch")
+	}
+	if stats.UpdateBatchRuns > 0 && stats.UpdateBatchCalls > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchRuns)/float64(stats.UpdateBatchCalls), "update_roots/batch")
+	}
+	if stats.UpdateBatchMatched > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchMatched)/float64(docs), "update_matched/doc")
+	}
+	if stats.UpdateBatchModified > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchModified)/float64(docs), "update_modified/doc")
+	}
+	if stats.UpdateBatchBufferedBatches > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchBufferedBatches), "update_buffered_batches")
+	}
+	if stats.UpdateBatchSecondaryDeletes > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchSecondaryDeletes)/float64(docs), "update_secondary_deletes/doc")
+	}
+	if stats.UpdateBatchSecondarySets > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchSecondarySets)/float64(docs), "update_secondary_sets/doc")
+	}
+	if stats.UpdateBatchSecondaryKeyBytes > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchSecondaryKeyBytes)/float64(docs), "update_secondary_key_bytes/doc")
+	}
+	reportDuration := func(name string, d time.Duration) {
+		if d > 0 {
+			b.ReportMetric(float64(d.Nanoseconds())/float64(docs), name)
+		}
+	}
+	reportDuration("update_current_read_ns/doc", stats.UpdateBatchCurrentRead)
+	reportDuration("update_callback_ns/doc", stats.UpdateBatchCallback)
+	reportDuration("update_prepare_ns/doc", stats.UpdateBatchPrepareDocuments)
+	reportDuration("update_index_state_extract_ns/doc", stats.UpdateBatchIndexStateExtract)
+	reportDuration("update_unique_preflight_ns/doc", stats.UpdateBatchUniquePreflight)
+	reportDuration("update_template_run_ns/doc", stats.UpdateBatchTemplateRunBuild)
+	reportDuration("update_primary_run_ns/doc", stats.UpdateBatchPrimaryRunBuild)
+	reportDuration("update_index_state_run_ns/doc", stats.UpdateBatchIndexStateRunBuild)
+	reportDuration("update_secondary_runs_ns/doc", stats.UpdateBatchSecondaryRunBuild)
+	reportDuration("update_buffer_stage_ns/doc", stats.UpdateBatchBufferStage)
+	reportDuration("update_publish_ns/doc", stats.UpdateBatchPublish)
 }
 
 func runProfileBenchDirectCollectionConcurrentUpdates(


### PR DESCRIPTION
## Summary

Part of #1159.

This PR adds collection update-batch attribution so the next optimization PRs can separate root publish/staging cost from read, callback, index-state, primary run, secondary run, and unique-preflight cost.

- Adds `CollectionUpdateStats` and `Collection.LastUpdateStats()` for the most recent successful `UpdateBatch`/combined update path.
- Adds aggregate manager counters under `treedb.collections.write_domain.update_batch.*`.
- Keeps lightweight counters always available, but makes high-resolution phase timers opt-in with `CollectionManager.SetUpdateBatchDetailedStatsEnabled(true)` so normal collection writes do not pay repeated clock-read overhead.
- Updates `BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2` to enable detailed timing only for the measured phase and report `update_*_ns/doc`, roots/batch, items/batch, matched/modified ratios, and secondary key counters.

## Benchmark / profile evidence

Main baseline from detached `origin/main` worktree `/tmp/gomap_1159_main`:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=2
```

Results:

- `10092 ns/op`, `99091 docs/sec`, `1703 B/op`, `10 allocs/op`
- `10309 ns/op`, `96998 docs/sec`, `1520 B/op`, `10 allocs/op`

This branch, same command, with the benchmark enabling detailed update timing only for the measured phase:

- `11389 ns/op`, `87804 docs/sec`, `1546 B/op`, `10 allocs/op`
- `10123 ns/op`, `98789 docs/sec`, `1455 B/op`, `10 allocs/op`

Fresh 10s profile command:

```bash
PROFILE_DIR=/tmp/gomap_1159_current_profile_V5isqK
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

Result:

- `15504 ns/op`, `64499 docs/sec`, `1543 B/op`, `10 allocs/op`
- update attribution from measured manager counters:
  - `update_buffer_stage_ns/doc`: `10590`
  - `update_current_read_ns/doc`: `2645`
  - `update_index_state_extract_ns/doc`: `316.1`
  - `update_callback_ns/doc`: `270.1`
  - `update_prepare_ns/doc`: `176.1`
  - `update_primary_run_ns/doc`: `162.6`
  - `update_secondary_runs_ns/doc`: `21.68`
  - `update_unique_preflight_ns/doc`: `25.13`
  - `update_items/batch`: `3.929`
  - `update_roots/batch`: `1.000`

CPU pprof headline from `/tmp/gomap_1159_current_profile_V5isqK/cpu.pprof`:

- `syscall.syscall`: `29.12%` flat
- `syscall.syscall6`: `17.41%` flat
- `runtime.pthread_cond_signal`: `16.01%` flat
- `runtime.pthread_cond_wait`: `13.63%` flat
- `valuelog.(*File).readViaMmapViewTo`: `7.18%` cumulative
- `Collection.bufferUpdateBatchPlanLocked`: `16.12%` cumulative
- `Collection.buildUpdateBatchPlan`: `10.97%` cumulative
- `Collection.flushBufferedIndexedAfterThresholdLocked`: `17.59%` cumulative
- `db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder`: `18.43%` cumulative
- `Snapshot.GetAppendAtRoot`: `10.72%` cumulative

Allocation pprof headline from `/tmp/gomap_1159_current_profile_V5isqK/mem.pprof`:

- `Batch.Set`: `781 MB` flat / `1428 MB` cumulative
- `Batch.ensureArenaChunk`: `647 MB` flat
- `memtable.getAppendOnlyValueArenaChunk`: `531 MB` flat
- zstd dictionary/compression setup remains visible in preload/flush paths
- `bufferUpdateBatchPlanLocked`: `1418 MB` cumulative
- `buildUpdateBatchPlan`: `1357 MB` cumulative

Interpretation for the next PRs: in this non-indexed-field update shape, secondary run construction and index-state run build are tiny. The expensive measured phases are buffered staging/flush-publish behavior plus current-document reads, which lines up with #1132 and the read/mmap tickets rather than a secondary-run-first fix for this benchmark shape.

## Validation

```bash
go test ./TreeDB/collections -run 'TestCollectionUpdateBatchStatsExposeIndexRunShape|TestCollectionInsertBatchStatsExposeIndexRunShape|TestCollectionManagerStatsExposeIndexedWriteDomainMetrics|TestCollectionUpdateBatch' -count 1
go test ./cmd/mongo_gateway_bench -run 'TestProfileBenchApplySetUpdate|TestProfileBenchUpdateIDStride' -count 1
go test ./TreeDB/collections ./cmd/mongo_gateway_bench -count 1
go test ./TreeDB/caching -count 1
```

All passed.

A broad `go test ./... -count 1` run had one unrelated caching failure:

```text
--- FAIL: TestVlogGenerationRewriteQueue_FreshBypassThenExpiredRetryPrefersImprovedStalePayoff (0.17s)
    vlog_generation_scheduler_test.go:4926: unexpected rewrite source ids=[11]
FAIL	github.com/snissn/gomap/TreeDB/caching	104.385s
```

The exact test failed once on immediate rerun, then passed on the next rerun, and `go test ./TreeDB/caching -count 1` passed.