### PR TITLE
Avoid per-batch unique secondary root map allocation

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3187,27 +3187,6 @@ func uniqueCollectionIndexNames(meta CollectionMeta) map[string]struct{} {
 	return uniqueIndexes
 }
 
-func uniqueCollectionSecondaryIndexForRootName(meta CollectionMeta, rootName string) (IndexDefinition, bool) {
-	if !strings.HasPrefix(rootName, meta.Name) {
-		return IndexDefinition{}, false
-	}
-	suffix := rootName[len(meta.Name):]
-	const indexRootPrefix = "/index/"
-	if !strings.HasPrefix(suffix, indexRootPrefix) {
-		return IndexDefinition{}, false
-	}
-	indexName := suffix[len(indexRootPrefix):]
-	if indexName == "" {
-		return IndexDefinition{}, false
-	}
-	for _, idx := range meta.Indexes {
-		if idx.Unique && idx.Name == indexName {
-			return idx, true
-		}
-	}
-	return IndexDefinition{}, false
-}
-
 func rejectBufferedUniqueIndexConflicts(indexName string, valueType IndexValueType, pendingIndex *bufferedUniqueValueIndex, batchIndex memtable.Table) error {
 	it := batchIndex.NewIterator(nil, nil)
 	defer func() { _ = it.Close() }()
@@ -6017,6 +5996,7 @@ type updateBatchPlan struct {
 	baseRootIDs                 map[string]uint64
 	policies                    []backenddb.OrderedRootStoragePolicy
 	deltaTables                 []memtable.Table
+	uniqueSecondaryIndexByRoot  []int
 	canBufferIndexedUpdateBatch bool
 	bufferedBase                bool
 	bufferedReadGeneration      uint64
@@ -6044,6 +6024,7 @@ type updateBatchPlanScratch struct {
 	baseRootIDs      map[string]uint64
 	policies         []backenddb.OrderedRootStoragePolicy
 	deltaTables      []memtable.Table
+	uniqueSecondary  []int
 }
 
 var updateBatchPlanScratchPool sync.Pool
@@ -6132,6 +6113,11 @@ func getUpdateBatchPlanScratch(itemCount, runtimeCount int) *updateBatchPlanScra
 	} else {
 		scratch.deltaTables = scratch.deltaTables[:0]
 	}
+	if cap(scratch.uniqueSecondary) < rootCap || cap(scratch.uniqueSecondary) > updateBatchPlanScratchMaxRootNameCap {
+		scratch.uniqueSecondary = make([]int, 0, rootCap)
+	} else {
+		scratch.uniqueSecondary = scratch.uniqueSecondary[:0]
+	}
 	return scratch
 }
 
@@ -6184,6 +6170,8 @@ func putUpdateBatchPlanScratch(scratch *updateBatchPlanScratch) {
 	scratch.policies = scratch.policies[:0]
 	clear(scratch.deltaTables)
 	scratch.deltaTables = scratch.deltaTables[:0]
+	clear(scratch.uniqueSecondary)
+	scratch.uniqueSecondary = scratch.uniqueSecondary[:0]
 	updateBatchPlanScratchPool.Put(scratch)
 }
 
@@ -6673,12 +6661,14 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	baseRootIDs := scratch.baseRootIDs
 	policies := scratch.policies
 	deltaTables := scratch.deltaTables
+	uniqueSecondary := scratch.uniqueSecondary
 	defer func() {
 		scratch.changed = changed
 		scratch.changedDocuments = changedDocuments
 		scratch.rootNames = rootNames
 		scratch.policies = policies
 		scratch.deltaTables = deltaTables
+		scratch.uniqueSecondary = uniqueSecondary
 		if !scratchOwnedByPlan {
 			putUpdateBatchPlanScratch(scratch)
 		}
@@ -6745,22 +6735,24 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		primaryRootName := collectionPrimaryRootName(meta.Name)
 		baseRootIDs[primaryRootName] = primaryRoot
 		rootNames = append(rootNames, primaryRootName)
+		uniqueSecondary = append(uniqueSecondary, -1)
 		plan := newUpdateBatchPlan()
 		*plan = updateBatchPlan{
-			results:                results,
-			stats:                  updateCollectionUpdateStatsCounts(stats, results, 0),
-			meta:                   meta,
-			catalog:                catalog,
-			snap:                   snap,
-			baseUserRoot:           baseUserRoot,
-			baseSystemRoot:         baseSystemRoot,
-			baseCommitSeq:          baseCommitSeq,
-			rootNames:              rootNames,
-			baseRootIDs:            baseRootIDs,
-			bufferedBase:           bufferedRead.enabled,
-			bufferedReadGeneration: bufferedRead.writeGeneration,
-			bufferedReadBlocked:    bufferedReadBlocked,
-			scratch:                scratch,
+			results:                    results,
+			stats:                      updateCollectionUpdateStatsCounts(stats, results, 0),
+			meta:                       meta,
+			catalog:                    catalog,
+			snap:                       snap,
+			baseUserRoot:               baseUserRoot,
+			baseSystemRoot:             baseSystemRoot,
+			baseCommitSeq:              baseCommitSeq,
+			rootNames:                  rootNames,
+			baseRootIDs:                baseRootIDs,
+			uniqueSecondaryIndexByRoot: uniqueSecondary,
+			bufferedBase:               bufferedRead.enabled,
+			bufferedReadGeneration:     bufferedRead.writeGeneration,
+			bufferedReadBlocked:        bufferedReadBlocked,
+			scratch:                    scratch,
 		}
 		scratchOwnedByPlan = true
 		return plan, nil
@@ -6847,6 +6839,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		}
 		for _, run := range templatePlan.runs {
 			rootNames = append(rootNames, run.name)
+			uniqueSecondary = append(uniqueSecondary, -1)
 			baseRootIDs[run.name] = catalog.rootID(run.name)
 			policies = append(policies, run.storagePolicy)
 			deltaTables = append(deltaTables, run.table)
@@ -6856,6 +6849,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 
 	primaryRootName := collectionPrimaryRootName(meta.Name)
 	rootNames = append(rootNames, primaryRootName)
+	uniqueSecondary = append(uniqueSecondary, -1)
 	baseRootIDs[primaryRootName] = primaryRoot
 	policies = append(policies, plannerOptions.dataStoragePolicy)
 	phaseStart = updateBatchStatsNow(detailedStats)
@@ -6892,6 +6886,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			stateTable.Freeze()
 			stateRootName := collectionIndexStateRootName(meta.Name)
 			rootNames = append(rootNames, stateRootName)
+			uniqueSecondary = append(uniqueSecondary, -1)
 			baseRootIDs[stateRootName] = catalog.rootID(stateRootName)
 			policies = append(policies, plannerOptions.indexStateStoragePolicy)
 			deltaTables = append(deltaTables, stateTable)
@@ -6932,7 +6927,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 				}
 			}
 		}
-		for _, runtime := range runtimes {
+		for runtimeIdx, runtime := range runtimes {
 			rootName := collectionSecondaryRootName(meta.Name, runtime.def.name)
 			table := secondaryTables[rootName]
 			if table == nil || table.Len() == 0 {
@@ -6940,6 +6935,11 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			}
 			table.Freeze()
 			rootNames = append(rootNames, rootName)
+			if runtime.def.unique {
+				uniqueSecondary = append(uniqueSecondary, runtimeIdx)
+			} else {
+				uniqueSecondary = append(uniqueSecondary, -1)
+			}
 			baseRootIDs[rootName] = catalog.rootID(rootName)
 			policies = append(policies, runtime.def.storagePolicy)
 			deltaTables = append(deltaTables, table)
@@ -6968,6 +6968,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		baseCommitSeq:               baseCommitSeq,
 		rootNames:                   rootNames,
 		baseRootIDs:                 baseRootIDs,
+		uniqueSecondaryIndexByRoot:  uniqueSecondary,
 		canBufferIndexedUpdateBatch: canBufferIndexedUpdateBatch,
 		bufferedBase:                bufferedRead.enabled,
 		bufferedReadGeneration:      bufferedRead.writeGeneration,
@@ -7033,6 +7034,21 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	return plan.results, nil
 }
 
+func updateBatchPlanUniqueSecondaryIndex(plan *updateBatchPlan, rootOffset int) (IndexDefinition, bool) {
+	if plan == nil || rootOffset < 0 || rootOffset >= len(plan.uniqueSecondaryIndexByRoot) {
+		return IndexDefinition{}, false
+	}
+	indexOffset := plan.uniqueSecondaryIndexByRoot[rootOffset]
+	if indexOffset < 0 || indexOffset >= len(plan.meta.Indexes) {
+		return IndexDefinition{}, false
+	}
+	indexDef := plan.meta.Indexes[indexOffset]
+	if !indexDef.Unique {
+		return IndexDefinition{}, false
+	}
+	return indexDef, true
+}
+
 func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, error) {
 	if c == nil || plan == nil || len(plan.deltaTables) == 0 {
 		return false, nil
@@ -7047,6 +7063,9 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	}
 	if len(plan.rootNames) != len(plan.deltaTables) || len(plan.rootNames) != len(plan.policies) {
 		return false, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
+	}
+	if len(plan.uniqueSecondaryIndexByRoot) != len(plan.rootNames) {
+		return false, fmt.Errorf("collections: UpdateBatch collection %q invalid unique index plan length roots=%d unique=%d", plan.meta.Name, len(plan.rootNames), len(plan.uniqueSecondaryIndexByRoot))
 	}
 	modifiedCount := updateBatchModifiedCount(plan.results)
 	if modifiedCount == 0 {
@@ -7112,8 +7131,8 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	hasUniqueSecondaryRoots := collectionMetaHasSecondaryUniqueIndex(plan.meta)
 	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, stagedBytes, stagedRootRuns)
 	if !shouldAutoFlushAfterAdding && hasUniqueSecondaryRoots && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
-		for i, rootName := range plan.rootNames {
-			if _, ok := uniqueCollectionSecondaryIndexForRootName(plan.meta, rootName); !ok {
+		for i := range plan.rootNames {
+			if _, ok := updateBatchPlanUniqueSecondaryIndex(plan, i); !ok {
 				continue
 			}
 			table := plan.deltaTables[i]
@@ -7150,7 +7169,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 				return false, err
 			}
 		}
-		if indexDef, ok := uniqueCollectionSecondaryIndexForRootName(plan.meta, rootName); ok {
+		if indexDef, ok := updateBatchPlanUniqueSecondaryIndex(plan, i); ok {
 			uniqueValueTable, uniquePrefixes, err := bufferedUniqueIndexValueRun(table, indexDef.ValueType)
 			if err != nil {
 				if shouldAutoFlushAfterAdding {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3187,17 +3187,25 @@ func uniqueCollectionIndexNames(meta CollectionMeta) map[string]struct{} {
 	return uniqueIndexes
 }
 
-func uniqueCollectionSecondaryRootNames(meta CollectionMeta) map[string]string {
-	var uniqueRoots map[string]string
+func uniqueCollectionSecondaryIndexForRootName(meta CollectionMeta, rootName string) (IndexDefinition, bool) {
+	if !strings.HasPrefix(rootName, meta.Name) {
+		return IndexDefinition{}, false
+	}
+	suffix := rootName[len(meta.Name):]
+	const indexRootPrefix = "/index/"
+	if !strings.HasPrefix(suffix, indexRootPrefix) {
+		return IndexDefinition{}, false
+	}
+	indexName := suffix[len(indexRootPrefix):]
+	if indexName == "" {
+		return IndexDefinition{}, false
+	}
 	for _, idx := range meta.Indexes {
-		if idx.Unique {
-			if uniqueRoots == nil {
-				uniqueRoots = make(map[string]string, len(meta.Indexes))
-			}
-			uniqueRoots[collectionSecondaryRootName(meta.Name, idx.Name)] = idx.Name
+		if idx.Unique && idx.Name == indexName {
+			return idx, true
 		}
 	}
-	return uniqueRoots
+	return IndexDefinition{}, false
 }
 
 func rejectBufferedUniqueIndexConflicts(indexName string, valueType IndexValueType, pendingIndex *bufferedUniqueValueIndex, batchIndex memtable.Table) error {
@@ -7101,11 +7109,11 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if domain.rootRuns == nil {
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
-	uniqueSecondaryRoots := uniqueCollectionSecondaryRootNames(plan.meta)
+	hasUniqueSecondaryRoots := collectionMetaHasSecondaryUniqueIndex(plan.meta)
 	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, stagedBytes, stagedRootRuns)
-	if !shouldAutoFlushAfterAdding && len(uniqueSecondaryRoots) > 0 && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
+	if !shouldAutoFlushAfterAdding && hasUniqueSecondaryRoots && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
 		for i, rootName := range plan.rootNames {
-			if _, ok := uniqueSecondaryRoots[rootName]; !ok {
+			if _, ok := uniqueCollectionSecondaryIndexForRootName(plan.meta, rootName); !ok {
 				continue
 			}
 			table := plan.deltaTables[i]
@@ -7142,11 +7150,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 				return false, err
 			}
 		}
-		if indexName, ok := uniqueSecondaryRoots[rootName]; ok {
-			indexDef, ok := findIndex(plan.meta.Indexes, indexName)
-			if !ok {
-				return false, fmt.Errorf("collections: unique index %q missing from schema", indexName)
-			}
+		if indexDef, ok := uniqueCollectionSecondaryIndexForRootName(plan.meta, rootName); ok {
 			uniqueValueTable, uniquePrefixes, err := bufferedUniqueIndexValueRun(table, indexDef.ValueType)
 			if err != nil {
 				if shouldAutoFlushAfterAdding {
@@ -7161,11 +7165,11 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			if domain.uniqueValueIndex == nil {
 				domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex)
 			}
-			domain.uniqueValueRuns[indexName] = append(domain.uniqueValueRuns[indexName], uniqueValueTable)
-			index := domain.uniqueValueIndex[indexName]
+			domain.uniqueValueRuns[indexDef.Name] = append(domain.uniqueValueRuns[indexDef.Name], uniqueValueTable)
+			index := domain.uniqueValueIndex[indexDef.Name]
 			if index == nil {
 				index = newBufferedUniqueValueIndex(max(1, len(uniquePrefixes)))
-				domain.uniqueValueIndex[indexName] = index
+				domain.uniqueValueIndex[indexDef.Name] = index
 			}
 			index.addAll(uniquePrefixes)
 			stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, uniqueValueTable.Size())

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -643,31 +643,40 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	}
 }
 
-func TestUniqueCollectionSecondaryIndexForRootNameAvoidsMapAllocation(t *testing.T) {
+func TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation(t *testing.T) {
 	meta := CollectionMeta{
 		Name: "users",
 		Indexes: []IndexDefinition{
 			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
 			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "sku", Field: "sku", ValueType: IndexValueString, Unique: true},
 		},
 	}
-	idx, ok := uniqueCollectionSecondaryIndexForRootName(meta, "users/index/email")
+	plan := &updateBatchPlan{
+		meta:                       meta,
+		rootNames:                  []string{"users/primary", "users/index/email", "users/index/city", "users/index/sku"},
+		uniqueSecondaryIndexByRoot: []int{-1, 0, -1, 2},
+	}
+	idx, ok := updateBatchPlanUniqueSecondaryIndex(plan, 1)
 	if !ok {
-		t.Fatal("unique root lookup did not find email index")
+		t.Fatal("unique root metadata did not find email index")
 	}
 	if got, want := idx.Name, "email"; got != want {
-		t.Fatalf("unique root lookup index=%q want %q", got, want)
+		t.Fatalf("unique root metadata index=%q want %q", got, want)
 	}
-	if _, ok := uniqueCollectionSecondaryIndexForRootName(meta, "users/index/city"); ok {
+	if _, ok := updateBatchPlanUniqueSecondaryIndex(plan, 2); ok {
 		t.Fatal("non-unique city index reported as unique")
 	}
-	if _, ok := uniqueCollectionSecondaryIndexForRootName(meta, "users/primary"); ok {
+	if _, ok := updateBatchPlanUniqueSecondaryIndex(plan, 0); ok {
 		t.Fatal("primary root reported as unique secondary index")
 	}
+	if idx, ok := updateBatchPlanUniqueSecondaryIndex(plan, 3); !ok || idx.Name != "sku" {
+		t.Fatalf("unique root metadata sku=(%q,%v) want sku,true", idx.Name, ok)
+	}
 	if allocs := testing.AllocsPerRun(1000, func() {
-		_, _ = uniqueCollectionSecondaryIndexForRootName(meta, "users/index/email")
+		_, _ = updateBatchPlanUniqueSecondaryIndex(plan, 1)
 	}); allocs != 0 {
-		t.Fatalf("unique root lookup allocs=%v want zero", allocs)
+		t.Fatalf("unique root metadata allocs=%v want zero", allocs)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -642,6 +642,34 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	}
 }
 
+func TestUniqueCollectionSecondaryIndexForRootNameAvoidsMapAllocation(t *testing.T) {
+	meta := CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}
+	idx, ok := uniqueCollectionSecondaryIndexForRootName(meta, "users/index/email")
+	if !ok {
+		t.Fatal("unique root lookup did not find email index")
+	}
+	if got, want := idx.Name, "email"; got != want {
+		t.Fatalf("unique root lookup index=%q want %q", got, want)
+	}
+	if _, ok := uniqueCollectionSecondaryIndexForRootName(meta, "users/index/city"); ok {
+		t.Fatal("non-unique city index reported as unique")
+	}
+	if _, ok := uniqueCollectionSecondaryIndexForRootName(meta, "users/primary"); ok {
+		t.Fatal("primary root reported as unique secondary index")
+	}
+	if allocs := testing.AllocsPerRun(1000, func() {
+		_, _ = uniqueCollectionSecondaryIndexForRootName(meta, "users/index/email")
+	}); allocs != 0 {
+		t.Fatalf("unique root lookup allocs=%v want zero", allocs)
+	}
+}
+
 func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {


### PR DESCRIPTION
## Summary

Part of #1159. Follows the #1160 instrumentation PR, which exposed `uniqueCollectionSecondaryRootNames` at roughly 125 MB allocated in the direct concurrent BSON two-index update allocation profile.

This PR removes that per-buffered-update map allocation without replacing it with repeated root-name parsing or linear metadata scans:

- Records `uniqueSecondaryIndexByRoot` in `buildUpdateBatchPlan`, aligned with `rootNames` and backed by the existing pooled update-plan scratch object.
- Uses O(1) per-root lookup in `bufferUpdateBatchPlanLocked` for unique secondary auto-flush checks and buffered unique-value run maintenance.
- Keeps existing unique-index behavior: auto-flush still triggers for unique secondary roots, and buffered unique-value indexes are still updated with the matching index definition.
- Adds a focused zero-allocation helper test for primary, non-unique secondary, and unique secondary root offsets.

## Benchmark evidence

Baseline from #1160 branch with detailed update timing enabled in the measured phase:

```text
100000  11389 ns/op  87804 docs/sec  1546 B/op  10 allocs/op
100000  10123 ns/op  98789 docs/sec  1455 B/op  10 allocs/op
```

This branch, final patch, same command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=2
```

Results:

```text
100000  10264 ns/op  97424 docs/sec  1745 B/op  9 allocs/op
100000  10320 ns/op  96896 docs/sec  1473 B/op  9 allocs/op
```

The direct per-operation allocation count drops from `10 allocs/op` to `9 allocs/op`, while the revised lookup path avoids both the old map allocation and the wider-schema O(changed roots × indexes) scan concern from review.

## Validation

```bash
go test ./TreeDB/collections \
  -run 'TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation|TestCollectionUpdateBatchStatsExposeIndexRunShape|TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChanges' \
  -count 1

go test ./TreeDB/collections ./cmd/mongo_gateway_bench -count 1
```

Both passed locally.
