### PR TITLE
Cache collection index runtimes for update planning

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -460,8 +460,13 @@ type collectionMetaDisk struct {
 type collectionCatalog struct {
 	// collectionCatalog is immutable once cached or published. Root updates must
 	// create a replacement catalog via cloneCatalogWithRootUpdates.
-	meta  CollectionMeta
-	roots map[string]uint64
+	meta               CollectionMeta
+	roots              map[string]uint64
+	primaryRootName    string
+	templateRootName   string
+	indexStateRootName string
+	indexRuntimes      []indexRuntime
+	indexRuntimesErr   error
 }
 
 type createIndexBackfillPlan struct {
@@ -6623,9 +6628,20 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		}
 	}
 
-	primaryRoot := catalog.rootID(collectionPrimaryRootName(meta.Name))
+	primaryRootName := catalog.primaryRootName
+	if primaryRootName == "" {
+		primaryRootName = collectionPrimaryRootName(meta.Name)
+	}
+	templateRootName := catalog.templateRootName
+	if templateRootName == "" {
+		templateRootName = collectionTemplateRootName(meta.Name)
+	}
+	indexStateRootName := catalog.indexStateRootName
+	if indexStateRootName == "" {
+		indexStateRootName = collectionIndexStateRootName(meta.Name)
+	}
+	primaryRoot := catalog.rootID(primaryRootName)
 	if primaryRoot == 0 && !bufferedRead.enabled {
-		primaryRootName := collectionPrimaryRootName(meta.Name)
 		plan := newUpdateBatchPlan()
 		*plan = updateBatchPlan{
 			results:                results,
@@ -6643,10 +6659,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		}
 		return plan, nil
 	}
-	runtimes, err := (insertBatchPlanner{
-		collection: meta.Name,
-		indexes:    plannerIndexes(meta.Indexes),
-	}).indexRuntimes()
+	runtimes, err := catalog.cachedIndexRuntimes()
 	if err != nil {
 		_ = snap.Close()
 		return nil, err
@@ -6831,7 +6844,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		templatePlan := &insertBatchPlan{}
 		if err := (insertBatchPlanner{
 			collection:             meta.Name,
-			templateRoot:           collectionTemplateRootName(meta.Name),
+			templateRoot:           templateRootName,
 			options:                plannerOptions,
 			cloneTemplateRunValues: true,
 		}).emitTemplateRun(templatePlan, templateRecords); err != nil {
@@ -6847,7 +6860,6 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		stats.TemplateRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 	}
 
-	primaryRootName := collectionPrimaryRootName(meta.Name)
 	rootNames = append(rootNames, primaryRootName)
 	uniqueSecondary = append(uniqueSecondary, -1)
 	baseRootIDs[primaryRootName] = primaryRoot
@@ -6884,7 +6896,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		}
 		if stateTable != nil && stateTable.Len() > 0 {
 			stateTable.Freeze()
-			stateRootName := collectionIndexStateRootName(meta.Name)
+			stateRootName := indexStateRootName
 			rootNames = append(rootNames, stateRootName)
 			uniqueSecondary = append(uniqueSecondary, -1)
 			baseRootIDs[stateRootName] = catalog.rootID(stateRootName)
@@ -6899,7 +6911,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 				continue
 			}
 			for runtimeIdx, runtime := range runtimes {
-				rootName := collectionSecondaryRootName(meta.Name, runtime.def.name)
+				rootName := runtimeSecondaryRootName(meta.Name, runtime)
 				table := secondaryTables[rootName]
 				if table == nil {
 					table = newCollectionRunTable(0)
@@ -6928,7 +6940,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			}
 		}
 		for runtimeIdx, runtime := range runtimes {
-			rootName := collectionSecondaryRootName(meta.Name, runtime.def.name)
+			rootName := runtimeSecondaryRootName(meta.Name, runtime)
 			table := secondaryTables[rootName]
 			if table == nil || table.Len() == 0 {
 				continue
@@ -7572,7 +7584,38 @@ func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, r
 			roots[name] = rootIDs[i]
 		}
 	}
-	return &collectionCatalog{meta: copyCollectionMeta(meta), roots: roots}
+	return newCollectionCatalog(copyCollectionMeta(meta), roots)
+}
+
+func newCollectionCatalog(meta CollectionMeta, roots map[string]uint64) *collectionCatalog {
+	catalog := &collectionCatalog{
+		meta:               meta,
+		roots:              roots,
+		primaryRootName:    collectionPrimaryRootName(meta.Name),
+		templateRootName:   collectionTemplateRootName(meta.Name),
+		indexStateRootName: collectionIndexStateRootName(meta.Name),
+	}
+	if len(meta.Indexes) > 0 {
+		catalog.indexRuntimes, catalog.indexRuntimesErr = (insertBatchPlanner{
+			collection: meta.Name,
+			indexes:    plannerIndexes(meta.Indexes),
+		}).indexRuntimes()
+	}
+	return catalog
+}
+
+func (c *collectionCatalog) cachedIndexRuntimes() ([]indexRuntime, error) {
+	if c == nil {
+		return nil, nil
+	}
+	return c.indexRuntimes, c.indexRuntimesErr
+}
+
+func runtimeSecondaryRootName(collection string, runtime indexRuntime) string {
+	if runtime.secondaryRootName != "" {
+		return runtime.secondaryRootName
+	}
+	return collectionSecondaryRootName(collection, runtime.def.name)
 }
 
 func buildDeleteRootDeltaTable(deleteKeys [][]byte) memtable.Table {
@@ -8986,7 +9029,7 @@ func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCa
 		}
 		roots[rootName] = rootID
 	}
-	return &collectionCatalog{meta: meta, roots: roots}, nil
+	return newCollectionCatalog(meta, roots), nil
 }
 
 func (c *collectionCatalog) rootID(rootName string) uint64 {
@@ -9004,10 +9047,7 @@ func (c *collectionCatalog) copy() *collectionCatalog {
 	for name, rootID := range c.roots {
 		roots[name] = rootID
 	}
-	return &collectionCatalog{
-		meta:  copyCollectionMeta(c.meta),
-		roots: roots,
-	}
+	return newCollectionCatalog(copyCollectionMeta(c.meta), roots)
 }
 
 func getSystemValue(snap *backenddb.Snapshot, key string) ([]byte, bool, error) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -680,6 +680,41 @@ func TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation(t *testing
 	}
 }
 
+func TestCollectionCatalogCachesIndexRuntimesAndRootNames(t *testing.T) {
+	meta := CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "profile.email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}
+	catalog := newCollectionCatalog(meta, map[string]uint64{
+		collectionPrimaryRootName(meta.Name): 11,
+	})
+	runtimes, err := catalog.cachedIndexRuntimes()
+	if err != nil {
+		t.Fatalf("cached index runtimes: %v", err)
+	}
+	if got, want := len(runtimes), 2; got != want {
+		t.Fatalf("cached runtime count=%d want %d", got, want)
+	}
+	if got, want := catalog.primaryRootName, "users/primary"; got != want {
+		t.Fatalf("primary root name=%q want %q", got, want)
+	}
+	if got, want := runtimes[0].secondaryRootName, "users/index/email"; got != want {
+		t.Fatalf("secondary root name=%q want %q", got, want)
+	}
+	if got, want := strings.Join(runtimes[0].path, "."), "profile.email"; got != want {
+		t.Fatalf("runtime path=%q want %q", got, want)
+	}
+	if allocs := testing.AllocsPerRun(1000, func() {
+		runtimes, _ := catalog.cachedIndexRuntimes()
+		_ = runtimeSecondaryRootName(meta.Name, runtimes[0])
+	}); allocs != 0 {
+		t.Fatalf("cached runtime/root lookup allocs=%v want zero", allocs)
+	}
+}
+
 func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -120,8 +120,9 @@ type insertBatchItem struct {
 }
 
 type indexRuntime struct {
-	def  indexDefinition
-	path []string
+	def               indexDefinition
+	path              []string
+	secondaryRootName string
 }
 
 type uniqueProbeCandidate struct {
@@ -449,9 +450,14 @@ func (p insertBatchPlanner) indexRuntimes() ([]indexRuntime, error) {
 			return nil, fmt.Errorf("collections: duplicate index %q", idx.name)
 		}
 		seen[idx.name] = struct{}{}
+		secondaryRootName := ""
+		if p.collection != "" {
+			secondaryRootName = collectionSecondaryRootName(p.collection, idx.name)
+		}
 		runtimes[i] = indexRuntime{
-			def:  idx,
-			path: splitIndexPath(idx.field),
+			def:               idx,
+			path:              splitIndexPath(idx.field),
+			secondaryRootName: secondaryRootName,
 		}
 	}
 	return runtimes, nil


### PR DESCRIPTION
## Summary

Stacked on #1161. Part of #1159.

The post-#1161 allocation profile showed repeated per-update-batch schema derivation in the direct concurrent BSON indexed update path:

- `plannerIndexes` / `indexRuntimes` / `splitIndexPath` were rebuilt every update batch.
- `collectionSecondaryRootName` allocated per update-batch planning pass.
- `collectionPrimaryRootName` also appeared in allocation-object profiles.

This PR caches immutable catalog-derived planning metadata and uses it in `buildUpdateBatchPlan`:

- `collectionCatalog` now stores primary/template/index-state root names.
- `collectionCatalog` stores cached `indexRuntime` values, including precomputed secondary root names.
- `buildUpdateBatchPlan` reuses cached runtimes/root names instead of rebuilding them per batch.
- Adds a zero-allocation catalog runtime/root-name test.

## Benchmark evidence

Baseline from #1161 final patch:

```text
100000  10264 ns/op  97424 docs/sec   1745 B/op  9 allocs/op
100000  10320 ns/op  96896 docs/sec   1473 B/op  9 allocs/op
```

This branch, same command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=2
```

Results:

```text
100000  10398 ns/op   96171 docs/sec  1376 B/op  7 allocs/op
100000   9832 ns/op  101712 docs/sec  1586 B/op  7 allocs/op
```

The main effect is allocation pressure: the direct update path drops from `9 allocs/op` to `7 allocs/op` by avoiding repeated derived schema/root metadata construction in the update planner.

## Profiling context

Profile captured before this PR on #1161 head:

```bash
PROFILE_DIR=/tmp/gomap_1159_post1161_profile_W7kbzA
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

Selected allocation-object hotspots from that profile:

```text
collectionSecondaryRootName                         830141 objects
splitIndexPath                                      688138 objects
insertBatchPlanner.indexRuntimes                    399830 objects
plannerIndexes                                      308988 objects
collectionPrimaryRootName                           371379 objects
```

## Validation

```bash
go test ./TreeDB/collections \
  -run 'TestCollectionCatalogCachesIndexRuntimesAndRootNames|TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation|TestCollectionUpdateBatchStatsExposeIndexRunShape|TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChanges' \
  -count 1

go test ./TreeDB/collections ./cmd/mongo_gateway_bench -count 1
```

Both passed locally.
