### PR TITLE
Avoid staged primary index slices for stable run tables

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3102,19 +3102,25 @@ func addBufferedPrimaryRunIndexEntries(index *bufferedPrimaryRunIndex, batchPrim
 	if stable, ok := batchPrimary.(memtable.StableUnsafeIteratorTable); ok {
 		stableKeys = stable.StableUnsafeIteratorSlices()
 	}
+	it := batchPrimary.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	if stableKeys {
+		for it.Valid() {
+			key := it.UnsafeKey()
+			index.addRef(xxhash.Sum64(key), bufferedPrimaryRunRef{key: key, table: batchPrimary})
+			it.Next()
+		}
+		return it.Error()
+	}
 	arena := make([]byte, 0, bufferedPrimaryIDArenaCap(batchPrimary.Len()))
 	refs := make([]bufferedPrimaryRunRef, 0, batchPrimary.Len())
 	hashes := make([]uint64, 0, batchPrimary.Len())
-	it := batchPrimary.NewIterator(nil, nil)
-	defer func() { _ = it.Close() }()
 	for it.Valid() {
 		key := it.UnsafeKey()
 		refKey := key
-		if !stableKeys {
-			start := len(arena)
-			arena = append(arena, key...)
-			refKey = arena[start:len(arena)]
-		}
+		start := len(arena)
+		arena = append(arena, key...)
+		refKey = arena[start:len(arena)]
 		hashes = append(hashes, xxhash.Sum64(key))
 		refs = append(refs, bufferedPrimaryRunRef{key: refKey, table: batchPrimary})
 		it.Next()

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4028,6 +4028,9 @@ func TestBufferedPrimaryRunIndexFindsNewestTable(t *testing.T) {
 	if err := addBufferedPrimaryRunIndexEntries(index, newer); err != nil {
 		t.Fatalf("add newer table: %v", err)
 	}
+	if got := len(index.arenas); got != 0 {
+		t.Fatalf("stable primary run index retained arenas=%d want 0", got)
+	}
 	table, ok := index.lookup([]byte("u1"))
 	if !ok {
 		t.Fatal("lookup u1 missing")


### PR DESCRIPTION
## Summary

Stacked on #1162. Part of #1159.

The post-#1162 profile still showed collection-side allocation under `addBufferedPrimaryRunIndexEntries` while staging buffered indexed updates. Collection run tables are append-only tables that advertise stable unsafe iterator slices, so we do not need to build temporary `hashes` and `refs` slices before adding refs to the buffered primary run index.

This PR:

- Fast-paths `addBufferedPrimaryRunIndexEntries` for `StableUnsafeIteratorTable` sources.
- Adds refs directly from stable iterator keys.
- Keeps the existing arena/two-pass path for non-stable iterator sources where keys must be copied before adding refs.
- Extends the primary run index test to assert stable collection run tables do not retain copied key arenas.

## Benchmark evidence

Baseline from #1162 final patch:

```text
100000  10398 ns/op   96171 docs/sec  1376 B/op  7 allocs/op
100000   9832 ns/op  101712 docs/sec  1586 B/op  7 allocs/op
```

This branch, same command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=2
```

Results:

```text
100000  10149 ns/op   98535 docs/sec  1487 B/op  7 allocs/op
100000   9629 ns/op  103856 docs/sec  1360 B/op  7 allocs/op
```

The Go benchmark allocation count is unchanged at `7 allocs/op`, but this removes a known profile source inside buffer staging and keeps the non-stable safety path intact.

## Validation

```bash
go test ./TreeDB/collections \
  -run 'TestBufferedPrimaryRunIndexFindsNewestTable|TestCollectionCatalogCachesIndexRuntimesAndRootNames|TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation' \
  -count 1

go test ./TreeDB/collections ./cmd/mongo_gateway_bench -count 1
```

Both passed locally.
