### PR TITLE
Break down collection update buffer staging metrics

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2485,6 +2485,14 @@ func bufferedIndexedAutoFlushEnabled(opts CollectionOptions) bool {
 	return opts.BufferedIndexedWriteMaxDocuments > 0 || opts.BufferedIndexedWriteMaxBytes > 0 || opts.BufferedIndexedWriteMaxRootRuns > 0
 }
 
+func collectionObservedElapsedSince(start time.Time) time.Duration {
+	elapsed := time.Since(start)
+	if elapsed <= 0 {
+		return time.Nanosecond
+	}
+	return elapsed
+}
+
 // flushBufferedIndexedAfterThresholdLocked returns the local schedule/publish
 // duration plus any interval where domain.mu was deliberately released while
 // waiting for an already-running async flush. The released interval is not lock
@@ -2501,7 +2509,7 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 				domain.indexedAsyncFlushBackpressure.Add(1)
 				flushStart := time.Now()
 				err := c.flushBufferedIndexedLocked(domain)
-				return time.Since(flushStart), 0, err
+				return collectionObservedElapsedSince(flushStart), 0, err
 			}
 			domain.indexedAsyncFlushBackpressure.Add(1)
 			flushStart := time.Now()
@@ -2521,26 +2529,26 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 				if len(domain.indexedPublishingUnits) == 0 {
 					flushStart = time.Now()
 					err := c.flushBufferedIndexedLocked(domain)
-					return time.Since(flushStart), lockReleased, err
+					return collectionObservedElapsedSince(flushStart), lockReleased, err
 				}
 			}
 			flushStart = time.Now()
 			if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
 				err := c.flushBufferedIndexedLocked(domain)
-				return time.Since(flushStart), lockReleased, err
+				return collectionObservedElapsedSince(flushStart), lockReleased, err
 			}
-			return time.Since(flushStart), lockReleased, nil
+			return collectionObservedElapsedSince(flushStart), lockReleased, nil
 		}
 		flushStart := time.Now()
 		if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
 			err := c.flushBufferedIndexedLocked(domain)
-			return time.Since(flushStart), 0, err
+			return collectionObservedElapsedSince(flushStart), 0, err
 		}
-		return time.Since(flushStart), 0, nil
+		return collectionObservedElapsedSince(flushStart), 0, nil
 	}
 	flushStart := time.Now()
 	err := c.flushBufferedIndexedLocked(domain)
-	return time.Since(flushStart), 0, err
+	return collectionObservedElapsedSince(flushStart), 0, err
 }
 
 func hasBufferedIndexedRootRuns(domain *collectionWriteDomain) bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1084,16 +1084,18 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 	domain.updateBatchIndexStateRunNs.Add(durationToAtomicNs(stats.IndexStateRunBuild))
 	domain.updateBatchSecondaryRunNs.Add(durationToAtomicNs(stats.SecondaryRunBuild))
 	domain.updateBatchBufferStageNs.Add(durationToAtomicNs(stats.BufferStage))
-	domain.updateBatchBufferPrecheckNs.Add(durationToAtomicNs(stats.BufferStagePrecheck))
-	domain.updateBatchBufferLockWaitNs.Add(durationToAtomicNs(stats.BufferStageLockWait))
-	domain.updateBatchBufferLockHoldNs.Add(durationToAtomicNs(stats.BufferStageLockHold))
-	domain.updateBatchBufferValidationNs.Add(durationToAtomicNs(stats.BufferStageValidation))
-	domain.updateBatchBufferRootScanNs.Add(durationToAtomicNs(stats.BufferStageRootScan))
-	domain.updateBatchBufferDomainInitNs.Add(durationToAtomicNs(stats.BufferStageDomainInit))
-	domain.updateBatchBufferPrimaryIdxNs.Add(durationToAtomicNs(stats.BufferStagePrimaryIdx))
-	domain.updateBatchBufferUniqueIdxNs.Add(durationToAtomicNs(stats.BufferStageUniqueIdx))
-	domain.updateBatchBufferRootAppendNs.Add(durationToAtomicNs(stats.BufferStageRootAppend))
-	domain.updateBatchBufferFlushNs.Add(durationToAtomicNs(stats.BufferStageFlush))
+	if updateStatsHasBufferStageBreakdown(stats) {
+		domain.updateBatchBufferPrecheckNs.Add(durationToAtomicNs(stats.BufferStagePrecheck))
+		domain.updateBatchBufferLockWaitNs.Add(durationToAtomicNs(stats.BufferStageLockWait))
+		domain.updateBatchBufferLockHoldNs.Add(durationToAtomicNs(stats.BufferStageLockHold))
+		domain.updateBatchBufferValidationNs.Add(durationToAtomicNs(stats.BufferStageValidation))
+		domain.updateBatchBufferRootScanNs.Add(durationToAtomicNs(stats.BufferStageRootScan))
+		domain.updateBatchBufferDomainInitNs.Add(durationToAtomicNs(stats.BufferStageDomainInit))
+		domain.updateBatchBufferPrimaryIdxNs.Add(durationToAtomicNs(stats.BufferStagePrimaryIdx))
+		domain.updateBatchBufferUniqueIdxNs.Add(durationToAtomicNs(stats.BufferStageUniqueIdx))
+		domain.updateBatchBufferRootAppendNs.Add(durationToAtomicNs(stats.BufferStageRootAppend))
+		domain.updateBatchBufferFlushNs.Add(durationToAtomicNs(stats.BufferStageFlush))
+	}
 	domain.updateBatchPublishNs.Add(durationToAtomicNs(stats.Publish))
 	if stats.SecondaryDeleteEntries > 0 {
 		domain.updateBatchSecondaryDeletes.Add(uint64(stats.SecondaryDeleteEntries))
@@ -1104,6 +1106,19 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 	if stats.SecondaryKeyBytes > 0 {
 		domain.updateBatchSecondaryKeyBytes.Add(uint64(stats.SecondaryKeyBytes))
 	}
+}
+
+func updateStatsHasBufferStageBreakdown(stats CollectionUpdateStats) bool {
+	return stats.BufferStagePrecheck != 0 ||
+		stats.BufferStageLockWait != 0 ||
+		stats.BufferStageLockHold != 0 ||
+		stats.BufferStageValidation != 0 ||
+		stats.BufferStageRootScan != 0 ||
+		stats.BufferStageDomainInit != 0 ||
+		stats.BufferStagePrimaryIdx != 0 ||
+		stats.BufferStageUniqueIdx != 0 ||
+		stats.BufferStageRootAppend != 0 ||
+		stats.BufferStageFlush != 0
 }
 
 func (domain *collectionWriteDomain) observeIndexedStage(docs int, bytes int64, rootRuns int) {
@@ -2323,7 +2338,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.observeIndexedStage(len(plan.resultIDs), stagedBytes, stagedRootRuns)
 	c.meta = catalog.meta
 	if shouldFlushBufferedIndexedWrites(domain, catalog.meta.Options) {
-		flushElapsed, err := c.flushBufferedIndexedAfterThresholdLocked(domain, catalog.meta.Options)
+		flushElapsed, _, err := c.flushBufferedIndexedAfterThresholdLocked(domain, catalog.meta.Options)
 		if err != nil {
 			rollbackBufferedIndexedDomain(domain, checkpoint)
 			return 0, err
@@ -2457,9 +2472,9 @@ func bufferedIndexedAutoFlushEnabled(opts CollectionOptions) bool {
 	return opts.BufferedIndexedWriteMaxDocuments > 0 || opts.BufferedIndexedWriteMaxBytes > 0 || opts.BufferedIndexedWriteMaxRootRuns > 0
 }
 
-func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collectionWriteDomain, opts CollectionOptions) (time.Duration, error) {
+func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collectionWriteDomain, opts CollectionOptions) (time.Duration, time.Duration, error) {
 	if domain == nil {
-		return 0, nil
+		return 0, 0, nil
 	}
 	domain.indexedAutoFlushes.Add(1)
 	if opts.BufferedIndexedAsyncFlush {
@@ -2469,41 +2484,44 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 				domain.indexedAsyncFlushBackpressure.Add(1)
 				flushStart := time.Now()
 				err := c.flushBufferedIndexedLocked(domain)
-				return time.Since(flushStart), err
+				return time.Since(flushStart), 0, err
 			}
 			domain.indexedAsyncFlushBackpressure.Add(1)
 			flushStart := time.Now()
+			var lockReleased time.Duration
 			if domain.indexedAsyncFlushRunning() {
+				unlockStart := time.Now()
 				domain.mu.Unlock()
 				domain.waitIndexedAsyncFlush()
 				domain.mu.Lock()
+				lockReleased += time.Since(unlockStart)
 				if err := domain.consumeIndexedAsyncFlushError(); err != nil {
-					return time.Since(flushStart), err
+					return time.Since(flushStart), lockReleased, err
 				}
 				if domain.count == 0 || len(domain.indexedFlushUnits) == 0 || !hasBufferedIndexedRootRuns(domain) {
-					return time.Since(flushStart), nil
+					return time.Since(flushStart), lockReleased, nil
 				}
 				if len(domain.indexedPublishingUnits) == 0 {
 					err := c.flushBufferedIndexedLocked(domain)
-					return time.Since(flushStart), err
+					return time.Since(flushStart), lockReleased, err
 				}
 			}
 			if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
 				err := c.flushBufferedIndexedLocked(domain)
-				return time.Since(flushStart), err
+				return time.Since(flushStart), lockReleased, err
 			}
-			return time.Since(flushStart), nil
+			return time.Since(flushStart), lockReleased, nil
 		}
 		if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
 			flushStart := time.Now()
 			err := c.flushBufferedIndexedLocked(domain)
-			return time.Since(flushStart), err
+			return time.Since(flushStart), 0, err
 		}
-		return 0, nil
+		return 0, 0, nil
 	}
 	flushStart := time.Now()
 	err := c.flushBufferedIndexedLocked(domain)
-	return time.Since(flushStart), err
+	return time.Since(flushStart), 0, err
 }
 
 func hasBufferedIndexedRootRuns(domain *collectionWriteDomain) bool {
@@ -7181,8 +7199,17 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.mu.Lock()
 	plan.stats.BufferStageLockWait += updateBatchStatsSince(detailedStats, lockStart)
 	lockHoldStart := updateBatchStatsNow(detailedStats)
+	var lockReleasedDuringHold time.Duration
 	defer func() {
-		plan.stats.BufferStageLockHold += updateBatchStatsSince(detailedStats, lockHoldStart)
+		lockHold := updateBatchStatsSince(detailedStats, lockHoldStart)
+		if lockReleasedDuringHold > 0 {
+			if lockHold > lockReleasedDuringHold {
+				lockHold -= lockReleasedDuringHold
+			} else {
+				lockHold = 0
+			}
+		}
+		plan.stats.BufferStageLockHold += lockHold
 		domain.mu.Unlock()
 	}()
 	phaseStart := updateBatchStatsNow(detailedStats)
@@ -7336,13 +7363,16 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	c.meta = plan.meta
 	phaseStart = updateBatchStatsNow(detailedStats)
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
-		if _, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options); err != nil {
+		if _, lockReleased, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options); err != nil {
+			lockReleasedDuringHold += lockReleased
 			plan.stats.BufferStageFlush += updateBatchStatsSince(detailedStats, phaseStart)
 			if shouldAutoFlushAfterAdding {
 				rollbackBufferedIndexedDomain(domain, checkpoint)
 				c.meta = collectionMetaCheckpoint
 			}
 			return false, err
+		} else {
+			lockReleasedDuringHold += lockReleased
 		}
 	}
 	plan.stats.BufferStageFlush += updateBatchStatsSince(detailedStats, phaseStart)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -300,6 +300,16 @@ type CollectionUpdateStats struct {
 	IndexStateRunBuild     time.Duration
 	SecondaryRunBuild      time.Duration
 	BufferStage            time.Duration
+	BufferStagePrecheck    time.Duration
+	BufferStageLockWait    time.Duration
+	BufferStageLockHold    time.Duration
+	BufferStageValidation  time.Duration
+	BufferStageRootScan    time.Duration
+	BufferStageDomainInit  time.Duration
+	BufferStagePrimaryIdx  time.Duration
+	BufferStageUniqueIdx   time.Duration
+	BufferStageRootAppend  time.Duration
+	BufferStageFlush       time.Duration
 	Publish                time.Duration
 	SecondaryDeleteEntries int
 	SecondarySetEntries    int
@@ -355,6 +365,16 @@ type CollectionManagerStats struct {
 	UpdateBatchIndexStateRunBuild time.Duration
 	UpdateBatchSecondaryRunBuild  time.Duration
 	UpdateBatchBufferStage        time.Duration
+	UpdateBatchBufferPrecheck     time.Duration
+	UpdateBatchBufferLockWait     time.Duration
+	UpdateBatchBufferLockHold     time.Duration
+	UpdateBatchBufferValidation   time.Duration
+	UpdateBatchBufferRootScan     time.Duration
+	UpdateBatchBufferDomainInit   time.Duration
+	UpdateBatchBufferPrimaryIdx   time.Duration
+	UpdateBatchBufferUniqueIdx    time.Duration
+	UpdateBatchBufferRootAppend   time.Duration
+	UpdateBatchBufferFlush        time.Duration
 	UpdateBatchPublish            time.Duration
 	UpdateBatchSecondaryDeletes   uint64
 	UpdateBatchSecondarySets      uint64
@@ -627,6 +647,16 @@ type collectionWriteDomain struct {
 	updateBatchIndexStateRunNs    atomic.Uint64
 	updateBatchSecondaryRunNs     atomic.Uint64
 	updateBatchBufferStageNs      atomic.Uint64
+	updateBatchBufferPrecheckNs   atomic.Uint64
+	updateBatchBufferLockWaitNs   atomic.Uint64
+	updateBatchBufferLockHoldNs   atomic.Uint64
+	updateBatchBufferValidationNs atomic.Uint64
+	updateBatchBufferRootScanNs   atomic.Uint64
+	updateBatchBufferDomainInitNs atomic.Uint64
+	updateBatchBufferPrimaryIdxNs atomic.Uint64
+	updateBatchBufferUniqueIdxNs  atomic.Uint64
+	updateBatchBufferRootAppendNs atomic.Uint64
+	updateBatchBufferFlushNs      atomic.Uint64
 	updateBatchPublishNs          atomic.Uint64
 	updateBatchSecondaryDeletes   atomic.Uint64
 	updateBatchSecondarySets      atomic.Uint64
@@ -811,6 +841,16 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_batch.index_state_run_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchIndexStateRunBuild.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.secondary_runs_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchSecondaryRunBuild.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferStage.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_precheck_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferPrecheck.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_lock_wait_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferLockWait.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_lock_hold_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferLockHold.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_validation_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferValidation.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_root_scan_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferRootScan.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_domain_init_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferDomainInit.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_primary_index_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferPrimaryIdx.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_unique_index_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferUniqueIdx.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_root_append_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferRootAppend.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_flush_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferFlush.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.publish_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchPublish.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.secondary_deletes_total"] = fmt.Sprintf("%d", stats.UpdateBatchSecondaryDeletes)
 	out["treedb.collections.write_domain.update_batch.secondary_sets_total"] = fmt.Sprintf("%d", stats.UpdateBatchSecondarySets)
@@ -891,6 +931,16 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.UpdateBatchIndexStateRunBuild += other.UpdateBatchIndexStateRunBuild
 	s.UpdateBatchSecondaryRunBuild += other.UpdateBatchSecondaryRunBuild
 	s.UpdateBatchBufferStage += other.UpdateBatchBufferStage
+	s.UpdateBatchBufferPrecheck += other.UpdateBatchBufferPrecheck
+	s.UpdateBatchBufferLockWait += other.UpdateBatchBufferLockWait
+	s.UpdateBatchBufferLockHold += other.UpdateBatchBufferLockHold
+	s.UpdateBatchBufferValidation += other.UpdateBatchBufferValidation
+	s.UpdateBatchBufferRootScan += other.UpdateBatchBufferRootScan
+	s.UpdateBatchBufferDomainInit += other.UpdateBatchBufferDomainInit
+	s.UpdateBatchBufferPrimaryIdx += other.UpdateBatchBufferPrimaryIdx
+	s.UpdateBatchBufferUniqueIdx += other.UpdateBatchBufferUniqueIdx
+	s.UpdateBatchBufferRootAppend += other.UpdateBatchBufferRootAppend
+	s.UpdateBatchBufferFlush += other.UpdateBatchBufferFlush
 	s.UpdateBatchPublish += other.UpdateBatchPublish
 	s.UpdateBatchSecondaryDeletes += other.UpdateBatchSecondaryDeletes
 	s.UpdateBatchSecondarySets += other.UpdateBatchSecondarySets
@@ -951,6 +1001,16 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateBatchIndexStateRunBuild = durationFromAtomicNs(domain.updateBatchIndexStateRunNs.Load())
 	stats.UpdateBatchSecondaryRunBuild = durationFromAtomicNs(domain.updateBatchSecondaryRunNs.Load())
 	stats.UpdateBatchBufferStage = durationFromAtomicNs(domain.updateBatchBufferStageNs.Load())
+	stats.UpdateBatchBufferPrecheck = durationFromAtomicNs(domain.updateBatchBufferPrecheckNs.Load())
+	stats.UpdateBatchBufferLockWait = durationFromAtomicNs(domain.updateBatchBufferLockWaitNs.Load())
+	stats.UpdateBatchBufferLockHold = durationFromAtomicNs(domain.updateBatchBufferLockHoldNs.Load())
+	stats.UpdateBatchBufferValidation = durationFromAtomicNs(domain.updateBatchBufferValidationNs.Load())
+	stats.UpdateBatchBufferRootScan = durationFromAtomicNs(domain.updateBatchBufferRootScanNs.Load())
+	stats.UpdateBatchBufferDomainInit = durationFromAtomicNs(domain.updateBatchBufferDomainInitNs.Load())
+	stats.UpdateBatchBufferPrimaryIdx = durationFromAtomicNs(domain.updateBatchBufferPrimaryIdxNs.Load())
+	stats.UpdateBatchBufferUniqueIdx = durationFromAtomicNs(domain.updateBatchBufferUniqueIdxNs.Load())
+	stats.UpdateBatchBufferRootAppend = durationFromAtomicNs(domain.updateBatchBufferRootAppendNs.Load())
+	stats.UpdateBatchBufferFlush = durationFromAtomicNs(domain.updateBatchBufferFlushNs.Load())
 	stats.UpdateBatchPublish = durationFromAtomicNs(domain.updateBatchPublishNs.Load())
 	stats.UpdateBatchSecondaryDeletes = domain.updateBatchSecondaryDeletes.Load()
 	stats.UpdateBatchSecondarySets = domain.updateBatchSecondarySets.Load()
@@ -1024,6 +1084,16 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 	domain.updateBatchIndexStateRunNs.Add(durationToAtomicNs(stats.IndexStateRunBuild))
 	domain.updateBatchSecondaryRunNs.Add(durationToAtomicNs(stats.SecondaryRunBuild))
 	domain.updateBatchBufferStageNs.Add(durationToAtomicNs(stats.BufferStage))
+	domain.updateBatchBufferPrecheckNs.Add(durationToAtomicNs(stats.BufferStagePrecheck))
+	domain.updateBatchBufferLockWaitNs.Add(durationToAtomicNs(stats.BufferStageLockWait))
+	domain.updateBatchBufferLockHoldNs.Add(durationToAtomicNs(stats.BufferStageLockHold))
+	domain.updateBatchBufferValidationNs.Add(durationToAtomicNs(stats.BufferStageValidation))
+	domain.updateBatchBufferRootScanNs.Add(durationToAtomicNs(stats.BufferStageRootScan))
+	domain.updateBatchBufferDomainInitNs.Add(durationToAtomicNs(stats.BufferStageDomainInit))
+	domain.updateBatchBufferPrimaryIdxNs.Add(durationToAtomicNs(stats.BufferStagePrimaryIdx))
+	domain.updateBatchBufferUniqueIdxNs.Add(durationToAtomicNs(stats.BufferStageUniqueIdx))
+	domain.updateBatchBufferRootAppendNs.Add(durationToAtomicNs(stats.BufferStageRootAppend))
+	domain.updateBatchBufferFlushNs.Add(durationToAtomicNs(stats.BufferStageFlush))
 	domain.updateBatchPublishNs.Add(durationToAtomicNs(stats.Publish))
 	if stats.SecondaryDeleteEntries > 0 {
 		domain.updateBatchSecondaryDeletes.Add(uint64(stats.SecondaryDeleteEntries))
@@ -7073,20 +7143,25 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	}
 	detailedStats := c.updateBatchDetailedStatsEnabled()
 	bufferStart := updateBatchStatsNow(detailedStats)
+	precheckStart := updateBatchStatsNow(detailedStats)
 	defer func() {
 		plan.stats.BufferStage += updateBatchStatsSince(detailedStats, bufferStart)
 	}()
 	if c.writeDomain == nil || !plan.canBufferIndexedUpdateBatch || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
+		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 		return false, nil
 	}
 	if len(plan.rootNames) != len(plan.deltaTables) || len(plan.rootNames) != len(plan.policies) {
+		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 		return false, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
 	}
 	if len(plan.uniqueSecondaryIndexByRoot) != len(plan.rootNames) {
+		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 		return false, fmt.Errorf("collections: UpdateBatch collection %q invalid unique index plan length roots=%d unique=%d", plan.meta.Name, len(plan.rootNames), len(plan.uniqueSecondaryIndexByRoot))
 	}
 	modifiedCount := updateBatchModifiedCount(plan.results)
 	if modifiedCount == 0 {
+		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 		return false, nil
 	}
 	hasDeltaTable := false
@@ -7097,29 +7172,44 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		}
 	}
 	if !hasDeltaTable {
+		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 		return false, fmt.Errorf("collections: UpdateBatch collection %q modified rows without delta tables modified=%d roots=%d deltas=%d policies=%d", plan.meta.Name, modifiedCount, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
 	}
+	plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 	domain := c.writeDomain
+	lockStart := updateBatchStatsNow(detailedStats)
 	domain.mu.Lock()
-	defer domain.mu.Unlock()
+	plan.stats.BufferStageLockWait += updateBatchStatsSince(detailedStats, lockStart)
+	lockHoldStart := updateBatchStatsNow(detailedStats)
+	defer func() {
+		plan.stats.BufferStageLockHold += updateBatchStatsSince(detailedStats, lockHoldStart)
+		domain.mu.Unlock()
+	}()
+	phaseStart := updateBatchStatsNow(detailedStats)
 	if domain.count != 0 {
 		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) {
 			// The caller retries from the normal pre-plan flush path so a plan built
 			// before a concurrent buffered write is not published against stale roots.
+			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
 		}
 		if plan.bufferedReadGeneration != domain.writeGeneration {
+			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, ErrConcurrentMutation
 		}
 	}
 	if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
+		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 		return false, err
 	}
+	plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 	var stagedBytes int64
 	stagedRootRuns := 0
+	phaseStart = updateBatchStatsNow(detailedStats)
 	for i, rootName := range plan.rootNames {
 		baseRoot, ok := plan.baseRootIDs[rootName]
 		if !ok {
+			plan.stats.BufferStageRootScan += updateBatchStatsSince(detailedStats, phaseStart)
 			return false, fmt.Errorf("collections: UpdateBatch collection %q plan missing base root for %q", plan.meta.Name, rootName)
 		}
 		table := plan.deltaTables[i]
@@ -7128,12 +7218,15 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		}
 		if hasPendingIndexedRootRunsForRootLocked(domain, rootName) {
 			if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, rootName); ok && pendingBaseRoot != baseRoot {
+				plan.stats.BufferStageRootScan += updateBatchStatsSince(detailedStats, phaseStart)
 				return false, errConcurrentRootModification(plan.meta.Name, rootName)
 			}
 		}
 		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, table.Size())
 		stagedRootRuns++
 	}
+	plan.stats.BufferStageRootScan += updateBatchStatsSince(detailedStats, phaseStart)
+	phaseStart = updateBatchStatsNow(detailedStats)
 	if domain.count == 0 && plan.catalog != nil {
 		c.initializeWriteDomainFromCatalogLocked(domain, plan.catalog, plan.baseCommitSeq, plan.baseSystemRoot)
 	}
@@ -7165,6 +7258,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if shouldAutoFlushAfterAdding {
 		checkpoint = checkpointBufferedIndexedDomain(domain)
 	}
+	plan.stats.BufferStageDomainInit += updateBatchStatsSince(detailedStats, phaseStart)
 	for i, rootName := range plan.rootNames {
 		baseRoot := plan.baseRootIDs[rootName]
 		table := plan.deltaTables[i]
@@ -7178,7 +7272,9 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			domain.rootBaseIDs[rootName] = baseRoot
 		}
 		if rootName == collectionPrimaryRootName(plan.meta.Name) && domain.primaryRunIndex != nil {
+			phaseStart = updateBatchStatsNow(detailedStats)
 			if err := addBufferedPrimaryRunIndexEntries(domain.primaryRunIndex, table); err != nil {
+				plan.stats.BufferStagePrimaryIdx += updateBatchStatsSince(detailedStats, phaseStart)
 				domain.primaryRunIndex = nil
 				if shouldAutoFlushAfterAdding {
 					rollbackBufferedIndexedDomain(domain, checkpoint)
@@ -7186,10 +7282,13 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 				}
 				return false, err
 			}
+			plan.stats.BufferStagePrimaryIdx += updateBatchStatsSince(detailedStats, phaseStart)
 		}
 		if indexDef, ok := updateBatchPlanUniqueSecondaryIndex(plan, i); ok {
+			phaseStart = updateBatchStatsNow(detailedStats)
 			uniqueValueTable, uniquePrefixes, err := bufferedUniqueIndexValueRun(table, indexDef.ValueType)
 			if err != nil {
+				plan.stats.BufferStageUniqueIdx += updateBatchStatsSince(detailedStats, phaseStart)
 				if shouldAutoFlushAfterAdding {
 					rollbackBufferedIndexedDomain(domain, checkpoint)
 					c.meta = collectionMetaCheckpoint
@@ -7210,11 +7309,14 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			}
 			index.addAll(uniquePrefixes)
 			stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, uniqueValueTable.Size())
+			plan.stats.BufferStageUniqueIdx += updateBatchStatsSince(detailedStats, phaseStart)
 		}
+		phaseStart = updateBatchStatsNow(detailedStats)
 		domain.rootPolicies[rootName] = plan.policies[i]
 		domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)
 		domain.rootRunCount = saturatingAddNonNegativeInt(domain.rootRunCount, 1)
 		plan.deltaTables[i] = nil
+		plan.stats.BufferStageRootAppend += updateBatchStatsSince(detailedStats, phaseStart)
 	}
 	plan.deltaTables = nil
 	domain.loaded = true
@@ -7232,8 +7334,10 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.writeGeneration++
 	domain.observeIndexedStage(modifiedCount, stagedBytes, stagedRootRuns)
 	c.meta = plan.meta
+	phaseStart = updateBatchStatsNow(detailedStats)
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		if _, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options); err != nil {
+			plan.stats.BufferStageFlush += updateBatchStatsSince(detailedStats, phaseStart)
 			if shouldAutoFlushAfterAdding {
 				rollbackBufferedIndexedDomain(domain, checkpoint)
 				c.meta = collectionMetaCheckpoint
@@ -7241,6 +7345,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			return false, err
 		}
 	}
+	plan.stats.BufferStageFlush += updateBatchStatsSince(detailedStats, phaseStart)
 	plan.stats.BufferedBatches = 1
 	return true, nil
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -306,9 +306,10 @@ type CollectionUpdateStats struct {
 	// overlaps the validation/root/index/root-append subphases; it is not
 	// additive with those child counters.
 	BufferStagePrecheck time.Duration
-	// BufferStageLockWait measures only domain mutex acquisition time. It does
-	// not include async flush completion waits performed after releasing the
-	// mutex for backpressure.
+	// BufferStageLockWait measures domain mutex acquisition time, including
+	// relock contention after an async flush wait. It does not include async
+	// flush completion waits performed after releasing the mutex for
+	// backpressure.
 	BufferStageLockWait      time.Duration
 	BufferStageLockHold      time.Duration
 	BufferStageValidation    time.Duration
@@ -1110,7 +1111,7 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 	domain.updateBatchIndexStateRunNs.Add(durationToAtomicNs(stats.IndexStateRunBuild))
 	domain.updateBatchSecondaryRunNs.Add(durationToAtomicNs(stats.SecondaryRunBuild))
 	domain.updateBatchBufferStageNs.Add(durationToAtomicNs(stats.BufferStage))
-	if stats.BufferStage != 0 {
+	if collectionUpdateStatsHasBufferStageBreakdown(stats) {
 		domain.updateBatchBufferPrecheckNs.Add(durationToAtomicNs(stats.BufferStagePrecheck))
 		domain.updateBatchBufferLockWaitNs.Add(durationToAtomicNs(stats.BufferStageLockWait))
 		domain.updateBatchBufferLockHoldNs.Add(durationToAtomicNs(stats.BufferStageLockHold))
@@ -1132,6 +1133,19 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 	if stats.SecondaryKeyBytes > 0 {
 		domain.updateBatchSecondaryKeyBytes.Add(uint64(stats.SecondaryKeyBytes))
 	}
+}
+
+func collectionUpdateStatsHasBufferStageBreakdown(stats CollectionUpdateStats) bool {
+	return stats.BufferStagePrecheck != 0 ||
+		stats.BufferStageLockWait != 0 ||
+		stats.BufferStageLockHold != 0 ||
+		stats.BufferStageValidation != 0 ||
+		stats.BufferStageRootScan != 0 ||
+		stats.BufferStageDomainPrepare != 0 ||
+		stats.BufferStagePrimaryIdx != 0 ||
+		stats.BufferStageUniqueIdx != 0 ||
+		stats.BufferStageRootAppend != 0 ||
+		stats.BufferStageFlush != 0
 }
 
 func (domain *collectionWriteDomain) observeIndexedStage(docs int, bytes int64, rootRuns int) {
@@ -2351,7 +2365,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.observeIndexedStage(len(plan.resultIDs), stagedBytes, stagedRootRuns)
 	c.meta = catalog.meta
 	if shouldFlushBufferedIndexedWrites(domain, catalog.meta.Options) {
-		flushElapsed, _, err := c.flushBufferedIndexedAfterThresholdLocked(domain, catalog.meta.Options)
+		flushElapsed, _, _, err := c.flushBufferedIndexedAfterThresholdLocked(domain, catalog.meta.Options)
 		if err != nil {
 			rollbackBufferedIndexedDomain(domain, checkpoint)
 			return 0, err
@@ -2493,13 +2507,13 @@ func collectionObservedElapsedSince(start time.Time) time.Duration {
 	return elapsed
 }
 
-// flushBufferedIndexedAfterThresholdLocked returns the local schedule/publish
-// duration plus any interval where domain.mu was deliberately released while
-// waiting for an already-running async flush. The released interval is not lock
-// acquisition wait and is not counted as local flush work.
-func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collectionWriteDomain, opts CollectionOptions) (time.Duration, time.Duration, error) {
+// flushBufferedIndexedAfterThresholdLocked returns local schedule/publish
+// duration, the full interval where domain.mu was deliberately released while
+// waiting for an already-running async flush, and any mutex reacquire wait after
+// that async wait. The released interval is not counted as local flush work.
+func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collectionWriteDomain, opts CollectionOptions) (time.Duration, time.Duration, time.Duration, error) {
 	if domain == nil {
-		return 0, 0, nil
+		return 0, 0, 0, nil
 	}
 	domain.indexedAutoFlushes.Add(1)
 	if opts.BufferedIndexedAsyncFlush {
@@ -2509,46 +2523,49 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 				domain.indexedAsyncFlushBackpressure.Add(1)
 				flushStart := time.Now()
 				err := c.flushBufferedIndexedLocked(domain)
-				return collectionObservedElapsedSince(flushStart), 0, err
+				return collectionObservedElapsedSince(flushStart), 0, 0, err
 			}
 			domain.indexedAsyncFlushBackpressure.Add(1)
 			flushStart := time.Now()
 			var lockReleased time.Duration
+			var relockWait time.Duration
 			if domain.indexedAsyncFlushRunning() {
 				unlockStart := time.Now()
 				domain.mu.Unlock()
 				domain.waitIndexedAsyncFlush()
+				relockStart := time.Now()
 				domain.mu.Lock()
+				relockWait += time.Since(relockStart)
 				lockReleased += time.Since(unlockStart)
 				if err := domain.consumeIndexedAsyncFlushError(); err != nil {
-					return 0, lockReleased, err
+					return 0, lockReleased, relockWait, err
 				}
 				if domain.count == 0 || len(domain.indexedFlushUnits) == 0 || !hasBufferedIndexedRootRuns(domain) {
-					return 0, lockReleased, nil
+					return 0, lockReleased, relockWait, nil
 				}
 				if len(domain.indexedPublishingUnits) == 0 {
 					flushStart = time.Now()
 					err := c.flushBufferedIndexedLocked(domain)
-					return collectionObservedElapsedSince(flushStart), lockReleased, err
+					return collectionObservedElapsedSince(flushStart), lockReleased, relockWait, err
 				}
 			}
 			flushStart = time.Now()
 			if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
 				err := c.flushBufferedIndexedLocked(domain)
-				return collectionObservedElapsedSince(flushStart), lockReleased, err
+				return collectionObservedElapsedSince(flushStart), lockReleased, relockWait, err
 			}
-			return collectionObservedElapsedSince(flushStart), lockReleased, nil
+			return collectionObservedElapsedSince(flushStart), lockReleased, relockWait, nil
 		}
 		flushStart := time.Now()
 		if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
 			err := c.flushBufferedIndexedLocked(domain)
-			return collectionObservedElapsedSince(flushStart), 0, err
+			return collectionObservedElapsedSince(flushStart), 0, 0, err
 		}
-		return collectionObservedElapsedSince(flushStart), 0, nil
+		return collectionObservedElapsedSince(flushStart), 0, 0, nil
 	}
 	flushStart := time.Now()
 	err := c.flushBufferedIndexedLocked(domain)
-	return collectionObservedElapsedSince(flushStart), 0, err
+	return collectionObservedElapsedSince(flushStart), 0, 0, err
 }
 
 func hasBufferedIndexedRootRuns(domain *collectionWriteDomain) bool {
@@ -7389,10 +7406,11 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.observeIndexedStage(modifiedCount, stagedBytes, stagedRootRuns)
 	c.meta = plan.meta
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
-		flushDuration, lockReleased, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
+		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {
 			lockReleasedDuringHold += lockReleased
 		}
+		plan.stats.BufferStageLockWait += updateBatchStatsDuration(detailedStats, relockWait)
 		plan.stats.BufferStageFlush += updateBatchStatsDuration(detailedStats, flushDuration)
 		if err != nil {
 			if shouldAutoFlushAfterAdding {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -284,22 +284,27 @@ type CollectionSecondaryRunStats struct {
 // Update calls that fall back to the legacy direct path are intentionally not
 // represented here yet; the write combiner and UpdateBatch path use this shape.
 type CollectionUpdateStats struct {
-	Items                    int
-	Matched                  int
-	Modified                 int
-	Indexes                  int
-	Runs                     int
-	BufferedBatches          int
-	CurrentRead              time.Duration
-	Callback                 time.Duration
-	PrepareDocuments         time.Duration
-	IndexStateExtraction     time.Duration
-	UniqueIndexPreflight     time.Duration
-	TemplateRunBuild         time.Duration
-	PrimaryRunBuild          time.Duration
-	IndexStateRunBuild       time.Duration
-	SecondaryRunBuild        time.Duration
-	BufferStage              time.Duration
+	Items                int
+	Matched              int
+	Modified             int
+	Indexes              int
+	Runs                 int
+	BufferedBatches      int
+	CurrentRead          time.Duration
+	Callback             time.Duration
+	PrepareDocuments     time.Duration
+	IndexStateExtraction time.Duration
+	UniqueIndexPreflight time.Duration
+	TemplateRunBuild     time.Duration
+	PrimaryRunBuild      time.Duration
+	IndexStateRunBuild   time.Duration
+	SecondaryRunBuild    time.Duration
+	BufferStage          time.Duration
+	// Buffer-stage subphase timings are populated only when
+	// CollectionManager.SetUpdateBatchDetailedStatsEnabled(true) is enabled.
+	// BufferStageLockHold is an enclosing domain mutex hold-time metric and
+	// overlaps the validation/root/index/root-append subphases; it is not
+	// additive with those child counters.
 	BufferStagePrecheck      time.Duration
 	BufferStageLockWait      time.Duration
 	BufferStageLockHold      time.Duration
@@ -309,62 +314,69 @@ type CollectionUpdateStats struct {
 	BufferStagePrimaryIdx    time.Duration
 	BufferStageUniqueIdx     time.Duration
 	BufferStageRootAppend    time.Duration
-	BufferStageFlush         time.Duration
-	Publish                  time.Duration
-	SecondaryDeleteEntries   int
-	SecondarySetEntries      int
-	SecondaryKeyBytes        int
+	// BufferStageFlush measures only threshold-flush work that was actually
+	// scheduled/executed while staging an indexed buffered update batch.
+	BufferStageFlush       time.Duration
+	Publish                time.Duration
+	SecondaryDeleteEntries int
+	SecondarySetEntries    int
+	SecondaryKeyBytes      int
 }
 
 // CollectionManagerStats captures aggregate write-domain counters for a
 // CollectionManager. The counters are process-local observability; they are
 // not persisted with collection metadata.
 type CollectionManagerStats struct {
-	Domains                        int
-	PendingDocuments               int
-	PendingBytes                   int64
-	PendingRootRuns                int
-	PendingIndexedFlushUnits       int
-	IndexedAsyncFlushRunning       int
-	MutationLockCalls              uint64
-	MutationLockWait               time.Duration
-	MutationLockHold               time.Duration
-	IndexedStageBatches            uint64
-	IndexedStageDocs               uint64
-	IndexedStageBytes              uint64
-	IndexedStageRootRuns           uint64
-	IndexedAutoFlushes             uint64
-	IndexedAsyncFlushScheduled     uint64
-	IndexedAsyncFlushBackpressure  uint64
-	IndexedAsyncFlushErrors        uint64
-	IndexedFlushCalls              uint64
-	IndexedFlushErrors             uint64
-	IndexedFlushDocs               uint64
-	IndexedFlushBytes              uint64
-	IndexedFlushRootRuns           uint64
-	IndexedFlushRoots              uint64
-	IndexedFlushDuration           time.Duration
-	UpdateCombineRequests          uint64
-	UpdateCombineBatches           uint64
-	UpdateCombineBatchedRequests   uint64
-	UpdateCombineFallbackRequests  uint64
-	UpdateCombineQueueDepthMax     uint64
-	UpdateBatchCalls               uint64
-	UpdateBatchItems               uint64
-	UpdateBatchMatched             uint64
-	UpdateBatchModified            uint64
-	UpdateBatchRuns                uint64
-	UpdateBatchBufferedBatches     uint64
-	UpdateBatchCurrentRead         time.Duration
-	UpdateBatchCallback            time.Duration
-	UpdateBatchPrepareDocuments    time.Duration
-	UpdateBatchIndexStateExtract   time.Duration
-	UpdateBatchUniquePreflight     time.Duration
-	UpdateBatchTemplateRunBuild    time.Duration
-	UpdateBatchPrimaryRunBuild     time.Duration
-	UpdateBatchIndexStateRunBuild  time.Duration
-	UpdateBatchSecondaryRunBuild   time.Duration
-	UpdateBatchBufferStage         time.Duration
+	Domains                       int
+	PendingDocuments              int
+	PendingBytes                  int64
+	PendingRootRuns               int
+	PendingIndexedFlushUnits      int
+	IndexedAsyncFlushRunning      int
+	MutationLockCalls             uint64
+	MutationLockWait              time.Duration
+	MutationLockHold              time.Duration
+	IndexedStageBatches           uint64
+	IndexedStageDocs              uint64
+	IndexedStageBytes             uint64
+	IndexedStageRootRuns          uint64
+	IndexedAutoFlushes            uint64
+	IndexedAsyncFlushScheduled    uint64
+	IndexedAsyncFlushBackpressure uint64
+	IndexedAsyncFlushErrors       uint64
+	IndexedFlushCalls             uint64
+	IndexedFlushErrors            uint64
+	IndexedFlushDocs              uint64
+	IndexedFlushBytes             uint64
+	IndexedFlushRootRuns          uint64
+	IndexedFlushRoots             uint64
+	IndexedFlushDuration          time.Duration
+	UpdateCombineRequests         uint64
+	UpdateCombineBatches          uint64
+	UpdateCombineBatchedRequests  uint64
+	UpdateCombineFallbackRequests uint64
+	UpdateCombineQueueDepthMax    uint64
+	UpdateBatchCalls              uint64
+	UpdateBatchItems              uint64
+	UpdateBatchMatched            uint64
+	UpdateBatchModified           uint64
+	UpdateBatchRuns               uint64
+	UpdateBatchBufferedBatches    uint64
+	UpdateBatchCurrentRead        time.Duration
+	UpdateBatchCallback           time.Duration
+	UpdateBatchPrepareDocuments   time.Duration
+	UpdateBatchIndexStateExtract  time.Duration
+	UpdateBatchUniquePreflight    time.Duration
+	UpdateBatchTemplateRunBuild   time.Duration
+	UpdateBatchPrimaryRunBuild    time.Duration
+	UpdateBatchIndexStateRunBuild time.Duration
+	UpdateBatchSecondaryRunBuild  time.Duration
+	UpdateBatchBufferStage        time.Duration
+	// Detailed buffer-stage aggregate timings are populated only when
+	// CollectionManager.SetUpdateBatchDetailedStatsEnabled(true) is enabled.
+	// UpdateBatchBufferLockHold is an enclosing domain mutex hold-time metric
+	// and overlaps the validation/root/index/root-append subphases; it is not
+	// additive with those child counters.
 	UpdateBatchBufferPrecheck      time.Duration
 	UpdateBatchBufferLockWait      time.Duration
 	UpdateBatchBufferLockHold      time.Duration
@@ -374,11 +386,13 @@ type CollectionManagerStats struct {
 	UpdateBatchBufferPrimaryIdx    time.Duration
 	UpdateBatchBufferUniqueIdx     time.Duration
 	UpdateBatchBufferRootAppend    time.Duration
-	UpdateBatchBufferFlush         time.Duration
-	UpdateBatchPublish             time.Duration
-	UpdateBatchSecondaryDeletes    uint64
-	UpdateBatchSecondarySets       uint64
-	UpdateBatchSecondaryKeyBytes   uint64
+	// UpdateBatchBufferFlush measures only threshold-flush work that was
+	// actually scheduled/executed while staging indexed buffered update batches.
+	UpdateBatchBufferFlush       time.Duration
+	UpdateBatchPublish           time.Duration
+	UpdateBatchSecondaryDeletes  uint64
+	UpdateBatchSecondarySets     uint64
+	UpdateBatchSecondaryKeyBytes uint64
 }
 
 // DocumentRecord is one primary collection record returned by ScanDocuments.
@@ -785,6 +799,13 @@ func updateBatchStatsSince(enabled bool, start time.Time) time.Duration {
 	return time.Since(start)
 }
 
+func updateBatchStatsDuration(enabled bool, duration time.Duration) time.Duration {
+	if !enabled {
+		return 0
+	}
+	return duration
+}
+
 // Stats returns aggregate process-local collection write-domain metrics with
 // stable TreeDB benchmark key names.
 func (m *CollectionManager) Stats() map[string]string {
@@ -1084,7 +1105,7 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 	domain.updateBatchIndexStateRunNs.Add(durationToAtomicNs(stats.IndexStateRunBuild))
 	domain.updateBatchSecondaryRunNs.Add(durationToAtomicNs(stats.SecondaryRunBuild))
 	domain.updateBatchBufferStageNs.Add(durationToAtomicNs(stats.BufferStage))
-	if updateStatsHasBufferStageBreakdown(stats) {
+	if stats.BufferStage != 0 {
 		domain.updateBatchBufferPrecheckNs.Add(durationToAtomicNs(stats.BufferStagePrecheck))
 		domain.updateBatchBufferLockWaitNs.Add(durationToAtomicNs(stats.BufferStageLockWait))
 		domain.updateBatchBufferLockHoldNs.Add(durationToAtomicNs(stats.BufferStageLockHold))
@@ -1106,19 +1127,6 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 	if stats.SecondaryKeyBytes > 0 {
 		domain.updateBatchSecondaryKeyBytes.Add(uint64(stats.SecondaryKeyBytes))
 	}
-}
-
-func updateStatsHasBufferStageBreakdown(stats CollectionUpdateStats) bool {
-	return stats.BufferStagePrecheck != 0 ||
-		stats.BufferStageLockWait != 0 ||
-		stats.BufferStageLockHold != 0 ||
-		stats.BufferStageValidation != 0 ||
-		stats.BufferStageRootScan != 0 ||
-		stats.BufferStageDomainPrepare != 0 ||
-		stats.BufferStagePrimaryIdx != 0 ||
-		stats.BufferStageUniqueIdx != 0 ||
-		stats.BufferStageRootAppend != 0 ||
-		stats.BufferStageFlush != 0
 }
 
 func (domain *collectionWriteDomain) observeIndexedStage(docs int, bytes int64, rootRuns int) {
@@ -7361,21 +7369,21 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.writeGeneration++
 	domain.observeIndexedStage(modifiedCount, stagedBytes, stagedRootRuns)
 	c.meta = plan.meta
-	phaseStart = updateBatchStatsNow(detailedStats)
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
-		if _, lockReleased, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options); err != nil {
+		flushDuration, lockReleased, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
+		if lockReleased > 0 {
 			lockReleasedDuringHold += lockReleased
-			plan.stats.BufferStageFlush += updateBatchStatsSince(detailedStats, phaseStart)
+			plan.stats.BufferStageLockWait += updateBatchStatsDuration(detailedStats, lockReleased)
+		}
+		plan.stats.BufferStageFlush += updateBatchStatsDuration(detailedStats, flushDuration)
+		if err != nil {
 			if shouldAutoFlushAfterAdding {
 				rollbackBufferedIndexedDomain(domain, checkpoint)
 				c.meta = collectionMetaCheckpoint
 			}
 			return false, err
-		} else {
-			lockReleasedDuringHold += lockReleased
 		}
 	}
-	plan.stats.BufferStageFlush += updateBatchStatsSince(detailedStats, phaseStart)
 	plan.stats.BufferedBatches = 1
 	return true, nil
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -284,101 +284,101 @@ type CollectionSecondaryRunStats struct {
 // Update calls that fall back to the legacy direct path are intentionally not
 // represented here yet; the write combiner and UpdateBatch path use this shape.
 type CollectionUpdateStats struct {
-	Items                  int
-	Matched                int
-	Modified               int
-	Indexes                int
-	Runs                   int
-	BufferedBatches        int
-	CurrentRead            time.Duration
-	Callback               time.Duration
-	PrepareDocuments       time.Duration
-	IndexStateExtraction   time.Duration
-	UniqueIndexPreflight   time.Duration
-	TemplateRunBuild       time.Duration
-	PrimaryRunBuild        time.Duration
-	IndexStateRunBuild     time.Duration
-	SecondaryRunBuild      time.Duration
-	BufferStage            time.Duration
-	BufferStagePrecheck    time.Duration
-	BufferStageLockWait    time.Duration
-	BufferStageLockHold    time.Duration
-	BufferStageValidation  time.Duration
-	BufferStageRootScan    time.Duration
-	BufferStageDomainInit  time.Duration
-	BufferStagePrimaryIdx  time.Duration
-	BufferStageUniqueIdx   time.Duration
-	BufferStageRootAppend  time.Duration
-	BufferStageFlush       time.Duration
-	Publish                time.Duration
-	SecondaryDeleteEntries int
-	SecondarySetEntries    int
-	SecondaryKeyBytes      int
+	Items                    int
+	Matched                  int
+	Modified                 int
+	Indexes                  int
+	Runs                     int
+	BufferedBatches          int
+	CurrentRead              time.Duration
+	Callback                 time.Duration
+	PrepareDocuments         time.Duration
+	IndexStateExtraction     time.Duration
+	UniqueIndexPreflight     time.Duration
+	TemplateRunBuild         time.Duration
+	PrimaryRunBuild          time.Duration
+	IndexStateRunBuild       time.Duration
+	SecondaryRunBuild        time.Duration
+	BufferStage              time.Duration
+	BufferStagePrecheck      time.Duration
+	BufferStageLockWait      time.Duration
+	BufferStageLockHold      time.Duration
+	BufferStageValidation    time.Duration
+	BufferStageRootScan      time.Duration
+	BufferStageDomainPrepare time.Duration
+	BufferStagePrimaryIdx    time.Duration
+	BufferStageUniqueIdx     time.Duration
+	BufferStageRootAppend    time.Duration
+	BufferStageFlush         time.Duration
+	Publish                  time.Duration
+	SecondaryDeleteEntries   int
+	SecondarySetEntries      int
+	SecondaryKeyBytes        int
 }
 
 // CollectionManagerStats captures aggregate write-domain counters for a
 // CollectionManager. The counters are process-local observability; they are
 // not persisted with collection metadata.
 type CollectionManagerStats struct {
-	Domains                       int
-	PendingDocuments              int
-	PendingBytes                  int64
-	PendingRootRuns               int
-	PendingIndexedFlushUnits      int
-	IndexedAsyncFlushRunning      int
-	MutationLockCalls             uint64
-	MutationLockWait              time.Duration
-	MutationLockHold              time.Duration
-	IndexedStageBatches           uint64
-	IndexedStageDocs              uint64
-	IndexedStageBytes             uint64
-	IndexedStageRootRuns          uint64
-	IndexedAutoFlushes            uint64
-	IndexedAsyncFlushScheduled    uint64
-	IndexedAsyncFlushBackpressure uint64
-	IndexedAsyncFlushErrors       uint64
-	IndexedFlushCalls             uint64
-	IndexedFlushErrors            uint64
-	IndexedFlushDocs              uint64
-	IndexedFlushBytes             uint64
-	IndexedFlushRootRuns          uint64
-	IndexedFlushRoots             uint64
-	IndexedFlushDuration          time.Duration
-	UpdateCombineRequests         uint64
-	UpdateCombineBatches          uint64
-	UpdateCombineBatchedRequests  uint64
-	UpdateCombineFallbackRequests uint64
-	UpdateCombineQueueDepthMax    uint64
-	UpdateBatchCalls              uint64
-	UpdateBatchItems              uint64
-	UpdateBatchMatched            uint64
-	UpdateBatchModified           uint64
-	UpdateBatchRuns               uint64
-	UpdateBatchBufferedBatches    uint64
-	UpdateBatchCurrentRead        time.Duration
-	UpdateBatchCallback           time.Duration
-	UpdateBatchPrepareDocuments   time.Duration
-	UpdateBatchIndexStateExtract  time.Duration
-	UpdateBatchUniquePreflight    time.Duration
-	UpdateBatchTemplateRunBuild   time.Duration
-	UpdateBatchPrimaryRunBuild    time.Duration
-	UpdateBatchIndexStateRunBuild time.Duration
-	UpdateBatchSecondaryRunBuild  time.Duration
-	UpdateBatchBufferStage        time.Duration
-	UpdateBatchBufferPrecheck     time.Duration
-	UpdateBatchBufferLockWait     time.Duration
-	UpdateBatchBufferLockHold     time.Duration
-	UpdateBatchBufferValidation   time.Duration
-	UpdateBatchBufferRootScan     time.Duration
-	UpdateBatchBufferDomainInit   time.Duration
-	UpdateBatchBufferPrimaryIdx   time.Duration
-	UpdateBatchBufferUniqueIdx    time.Duration
-	UpdateBatchBufferRootAppend   time.Duration
-	UpdateBatchBufferFlush        time.Duration
-	UpdateBatchPublish            time.Duration
-	UpdateBatchSecondaryDeletes   uint64
-	UpdateBatchSecondarySets      uint64
-	UpdateBatchSecondaryKeyBytes  uint64
+	Domains                        int
+	PendingDocuments               int
+	PendingBytes                   int64
+	PendingRootRuns                int
+	PendingIndexedFlushUnits       int
+	IndexedAsyncFlushRunning       int
+	MutationLockCalls              uint64
+	MutationLockWait               time.Duration
+	MutationLockHold               time.Duration
+	IndexedStageBatches            uint64
+	IndexedStageDocs               uint64
+	IndexedStageBytes              uint64
+	IndexedStageRootRuns           uint64
+	IndexedAutoFlushes             uint64
+	IndexedAsyncFlushScheduled     uint64
+	IndexedAsyncFlushBackpressure  uint64
+	IndexedAsyncFlushErrors        uint64
+	IndexedFlushCalls              uint64
+	IndexedFlushErrors             uint64
+	IndexedFlushDocs               uint64
+	IndexedFlushBytes              uint64
+	IndexedFlushRootRuns           uint64
+	IndexedFlushRoots              uint64
+	IndexedFlushDuration           time.Duration
+	UpdateCombineRequests          uint64
+	UpdateCombineBatches           uint64
+	UpdateCombineBatchedRequests   uint64
+	UpdateCombineFallbackRequests  uint64
+	UpdateCombineQueueDepthMax     uint64
+	UpdateBatchCalls               uint64
+	UpdateBatchItems               uint64
+	UpdateBatchMatched             uint64
+	UpdateBatchModified            uint64
+	UpdateBatchRuns                uint64
+	UpdateBatchBufferedBatches     uint64
+	UpdateBatchCurrentRead         time.Duration
+	UpdateBatchCallback            time.Duration
+	UpdateBatchPrepareDocuments    time.Duration
+	UpdateBatchIndexStateExtract   time.Duration
+	UpdateBatchUniquePreflight     time.Duration
+	UpdateBatchTemplateRunBuild    time.Duration
+	UpdateBatchPrimaryRunBuild     time.Duration
+	UpdateBatchIndexStateRunBuild  time.Duration
+	UpdateBatchSecondaryRunBuild   time.Duration
+	UpdateBatchBufferStage         time.Duration
+	UpdateBatchBufferPrecheck      time.Duration
+	UpdateBatchBufferLockWait      time.Duration
+	UpdateBatchBufferLockHold      time.Duration
+	UpdateBatchBufferValidation    time.Duration
+	UpdateBatchBufferRootScan      time.Duration
+	UpdateBatchBufferDomainPrepare time.Duration
+	UpdateBatchBufferPrimaryIdx    time.Duration
+	UpdateBatchBufferUniqueIdx     time.Duration
+	UpdateBatchBufferRootAppend    time.Duration
+	UpdateBatchBufferFlush         time.Duration
+	UpdateBatchPublish             time.Duration
+	UpdateBatchSecondaryDeletes    uint64
+	UpdateBatchSecondarySets       uint64
+	UpdateBatchSecondaryKeyBytes   uint64
 }
 
 // DocumentRecord is one primary collection record returned by ScanDocuments.
@@ -608,60 +608,60 @@ type collectionWriteDomain struct {
 	rootRunCount     int
 	writeGeneration  uint64
 
-	mutationLockCalls             atomic.Uint64
-	mutationLockWaitTotalNs       atomic.Uint64
-	mutationLockHoldTotalNs       atomic.Uint64
-	indexedStageBatches           atomic.Uint64
-	indexedStageDocs              atomic.Uint64
-	indexedStageBytes             atomic.Uint64
-	indexedStageRootRuns          atomic.Uint64
-	indexedAutoFlushes            atomic.Uint64
-	indexedAsyncFlushScheduled    atomic.Uint64
-	indexedAsyncFlushBackpressure atomic.Uint64
-	indexedAsyncFlushErrors       atomic.Uint64
-	indexedFlushCalls             atomic.Uint64
-	indexedFlushErrors            atomic.Uint64
-	indexedFlushDocs              atomic.Uint64
-	indexedFlushBytes             atomic.Uint64
-	indexedFlushRootRuns          atomic.Uint64
-	indexedFlushRoots             atomic.Uint64
-	indexedFlushDurationTotalNs   atomic.Uint64
-	updateCombineRequests         atomic.Uint64
-	updateCombineBatches          atomic.Uint64
-	updateCombineBatchedRequests  atomic.Uint64
-	updateCombineFallbackRequests atomic.Uint64
-	updateCombineQueueDepthMax    atomic.Uint64
-	updateBatchCalls              atomic.Uint64
-	updateBatchItems              atomic.Uint64
-	updateBatchMatched            atomic.Uint64
-	updateBatchModified           atomic.Uint64
-	updateBatchRuns               atomic.Uint64
-	updateBatchBufferedBatches    atomic.Uint64
-	updateBatchCurrentReadNs      atomic.Uint64
-	updateBatchCallbackNs         atomic.Uint64
-	updateBatchPrepareNs          atomic.Uint64
-	updateBatchIndexStateNs       atomic.Uint64
-	updateBatchUniquePreflightNs  atomic.Uint64
-	updateBatchTemplateRunNs      atomic.Uint64
-	updateBatchPrimaryRunNs       atomic.Uint64
-	updateBatchIndexStateRunNs    atomic.Uint64
-	updateBatchSecondaryRunNs     atomic.Uint64
-	updateBatchBufferStageNs      atomic.Uint64
-	updateBatchBufferPrecheckNs   atomic.Uint64
-	updateBatchBufferLockWaitNs   atomic.Uint64
-	updateBatchBufferLockHoldNs   atomic.Uint64
-	updateBatchBufferValidationNs atomic.Uint64
-	updateBatchBufferRootScanNs   atomic.Uint64
-	updateBatchBufferDomainInitNs atomic.Uint64
-	updateBatchBufferPrimaryIdxNs atomic.Uint64
-	updateBatchBufferUniqueIdxNs  atomic.Uint64
-	updateBatchBufferRootAppendNs atomic.Uint64
-	updateBatchBufferFlushNs      atomic.Uint64
-	updateBatchPublishNs          atomic.Uint64
-	updateBatchSecondaryDeletes   atomic.Uint64
-	updateBatchSecondarySets      atomic.Uint64
-	updateBatchSecondaryKeyBytes  atomic.Uint64
-	updateBatchDetailedStats      atomic.Bool
+	mutationLockCalls                atomic.Uint64
+	mutationLockWaitTotalNs          atomic.Uint64
+	mutationLockHoldTotalNs          atomic.Uint64
+	indexedStageBatches              atomic.Uint64
+	indexedStageDocs                 atomic.Uint64
+	indexedStageBytes                atomic.Uint64
+	indexedStageRootRuns             atomic.Uint64
+	indexedAutoFlushes               atomic.Uint64
+	indexedAsyncFlushScheduled       atomic.Uint64
+	indexedAsyncFlushBackpressure    atomic.Uint64
+	indexedAsyncFlushErrors          atomic.Uint64
+	indexedFlushCalls                atomic.Uint64
+	indexedFlushErrors               atomic.Uint64
+	indexedFlushDocs                 atomic.Uint64
+	indexedFlushBytes                atomic.Uint64
+	indexedFlushRootRuns             atomic.Uint64
+	indexedFlushRoots                atomic.Uint64
+	indexedFlushDurationTotalNs      atomic.Uint64
+	updateCombineRequests            atomic.Uint64
+	updateCombineBatches             atomic.Uint64
+	updateCombineBatchedRequests     atomic.Uint64
+	updateCombineFallbackRequests    atomic.Uint64
+	updateCombineQueueDepthMax       atomic.Uint64
+	updateBatchCalls                 atomic.Uint64
+	updateBatchItems                 atomic.Uint64
+	updateBatchMatched               atomic.Uint64
+	updateBatchModified              atomic.Uint64
+	updateBatchRuns                  atomic.Uint64
+	updateBatchBufferedBatches       atomic.Uint64
+	updateBatchCurrentReadNs         atomic.Uint64
+	updateBatchCallbackNs            atomic.Uint64
+	updateBatchPrepareNs             atomic.Uint64
+	updateBatchIndexStateNs          atomic.Uint64
+	updateBatchUniquePreflightNs     atomic.Uint64
+	updateBatchTemplateRunNs         atomic.Uint64
+	updateBatchPrimaryRunNs          atomic.Uint64
+	updateBatchIndexStateRunNs       atomic.Uint64
+	updateBatchSecondaryRunNs        atomic.Uint64
+	updateBatchBufferStageNs         atomic.Uint64
+	updateBatchBufferPrecheckNs      atomic.Uint64
+	updateBatchBufferLockWaitNs      atomic.Uint64
+	updateBatchBufferLockHoldNs      atomic.Uint64
+	updateBatchBufferValidationNs    atomic.Uint64
+	updateBatchBufferRootScanNs      atomic.Uint64
+	updateBatchBufferDomainPrepareNs atomic.Uint64
+	updateBatchBufferPrimaryIdxNs    atomic.Uint64
+	updateBatchBufferUniqueIdxNs     atomic.Uint64
+	updateBatchBufferRootAppendNs    atomic.Uint64
+	updateBatchBufferFlushNs         atomic.Uint64
+	updateBatchPublishNs             atomic.Uint64
+	updateBatchSecondaryDeletes      atomic.Uint64
+	updateBatchSecondarySets         atomic.Uint64
+	updateBatchSecondaryKeyBytes     atomic.Uint64
+	updateBatchDetailedStats         atomic.Bool
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -846,7 +846,7 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_batch.buffer_stage_lock_hold_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferLockHold.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_validation_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferValidation.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_root_scan_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferRootScan.Nanoseconds())
-	out["treedb.collections.write_domain.update_batch.buffer_stage_domain_init_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferDomainInit.Nanoseconds())
+	out["treedb.collections.write_domain.update_batch.buffer_stage_domain_prepare_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferDomainPrepare.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_primary_index_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferPrimaryIdx.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_unique_index_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferUniqueIdx.Nanoseconds())
 	out["treedb.collections.write_domain.update_batch.buffer_stage_root_append_ns_total"] = fmt.Sprintf("%d", stats.UpdateBatchBufferRootAppend.Nanoseconds())
@@ -936,7 +936,7 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.UpdateBatchBufferLockHold += other.UpdateBatchBufferLockHold
 	s.UpdateBatchBufferValidation += other.UpdateBatchBufferValidation
 	s.UpdateBatchBufferRootScan += other.UpdateBatchBufferRootScan
-	s.UpdateBatchBufferDomainInit += other.UpdateBatchBufferDomainInit
+	s.UpdateBatchBufferDomainPrepare += other.UpdateBatchBufferDomainPrepare
 	s.UpdateBatchBufferPrimaryIdx += other.UpdateBatchBufferPrimaryIdx
 	s.UpdateBatchBufferUniqueIdx += other.UpdateBatchBufferUniqueIdx
 	s.UpdateBatchBufferRootAppend += other.UpdateBatchBufferRootAppend
@@ -1006,7 +1006,7 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateBatchBufferLockHold = durationFromAtomicNs(domain.updateBatchBufferLockHoldNs.Load())
 	stats.UpdateBatchBufferValidation = durationFromAtomicNs(domain.updateBatchBufferValidationNs.Load())
 	stats.UpdateBatchBufferRootScan = durationFromAtomicNs(domain.updateBatchBufferRootScanNs.Load())
-	stats.UpdateBatchBufferDomainInit = durationFromAtomicNs(domain.updateBatchBufferDomainInitNs.Load())
+	stats.UpdateBatchBufferDomainPrepare = durationFromAtomicNs(domain.updateBatchBufferDomainPrepareNs.Load())
 	stats.UpdateBatchBufferPrimaryIdx = durationFromAtomicNs(domain.updateBatchBufferPrimaryIdxNs.Load())
 	stats.UpdateBatchBufferUniqueIdx = durationFromAtomicNs(domain.updateBatchBufferUniqueIdxNs.Load())
 	stats.UpdateBatchBufferRootAppend = durationFromAtomicNs(domain.updateBatchBufferRootAppendNs.Load())
@@ -1090,7 +1090,7 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 		domain.updateBatchBufferLockHoldNs.Add(durationToAtomicNs(stats.BufferStageLockHold))
 		domain.updateBatchBufferValidationNs.Add(durationToAtomicNs(stats.BufferStageValidation))
 		domain.updateBatchBufferRootScanNs.Add(durationToAtomicNs(stats.BufferStageRootScan))
-		domain.updateBatchBufferDomainInitNs.Add(durationToAtomicNs(stats.BufferStageDomainInit))
+		domain.updateBatchBufferDomainPrepareNs.Add(durationToAtomicNs(stats.BufferStageDomainPrepare))
 		domain.updateBatchBufferPrimaryIdxNs.Add(durationToAtomicNs(stats.BufferStagePrimaryIdx))
 		domain.updateBatchBufferUniqueIdxNs.Add(durationToAtomicNs(stats.BufferStageUniqueIdx))
 		domain.updateBatchBufferRootAppendNs.Add(durationToAtomicNs(stats.BufferStageRootAppend))
@@ -1114,7 +1114,7 @@ func updateStatsHasBufferStageBreakdown(stats CollectionUpdateStats) bool {
 		stats.BufferStageLockHold != 0 ||
 		stats.BufferStageValidation != 0 ||
 		stats.BufferStageRootScan != 0 ||
-		stats.BufferStageDomainInit != 0 ||
+		stats.BufferStageDomainPrepare != 0 ||
 		stats.BufferStagePrimaryIdx != 0 ||
 		stats.BufferStageUniqueIdx != 0 ||
 		stats.BufferStageRootAppend != 0 ||
@@ -7285,7 +7285,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if shouldAutoFlushAfterAdding {
 		checkpoint = checkpointBufferedIndexedDomain(domain)
 	}
-	plan.stats.BufferStageDomainInit += updateBatchStatsSince(detailedStats, phaseStart)
+	plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
 	for i, rootName := range plan.rootNames {
 		baseRoot := plan.baseRootIDs[rootName]
 		table := plan.deltaTables[i]

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -305,7 +305,10 @@ type CollectionUpdateStats struct {
 	// BufferStageLockHold is an enclosing domain mutex hold-time metric and
 	// overlaps the validation/root/index/root-append subphases; it is not
 	// additive with those child counters.
-	BufferStagePrecheck      time.Duration
+	BufferStagePrecheck time.Duration
+	// BufferStageLockWait measures only domain mutex acquisition time. It does
+	// not include async flush completion waits performed after releasing the
+	// mutex for backpressure.
 	BufferStageLockWait      time.Duration
 	BufferStageLockHold      time.Duration
 	BufferStageValidation    time.Duration
@@ -314,8 +317,10 @@ type CollectionUpdateStats struct {
 	BufferStagePrimaryIdx    time.Duration
 	BufferStageUniqueIdx     time.Duration
 	BufferStageRootAppend    time.Duration
-	// BufferStageFlush measures only threshold-flush work that was actually
-	// scheduled/executed while staging an indexed buffered update batch.
+	// BufferStageFlush measures local threshold-flush schedule/publish work
+	// performed while staging an indexed buffered update batch. It excludes
+	// waits for an already-running async flush that leave no local schedule or
+	// publish work for the current batch.
 	BufferStageFlush       time.Duration
 	Publish                time.Duration
 	SecondaryDeleteEntries int
@@ -2480,6 +2485,10 @@ func bufferedIndexedAutoFlushEnabled(opts CollectionOptions) bool {
 	return opts.BufferedIndexedWriteMaxDocuments > 0 || opts.BufferedIndexedWriteMaxBytes > 0 || opts.BufferedIndexedWriteMaxRootRuns > 0
 }
 
+// flushBufferedIndexedAfterThresholdLocked returns the local schedule/publish
+// duration plus any interval where domain.mu was deliberately released while
+// waiting for an already-running async flush. The released interval is not lock
+// acquisition wait and is not counted as local flush work.
 func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collectionWriteDomain, opts CollectionOptions) (time.Duration, time.Duration, error) {
 	if domain == nil {
 		return 0, 0, nil
@@ -2504,28 +2513,30 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 				domain.mu.Lock()
 				lockReleased += time.Since(unlockStart)
 				if err := domain.consumeIndexedAsyncFlushError(); err != nil {
-					return time.Since(flushStart), lockReleased, err
+					return 0, lockReleased, err
 				}
 				if domain.count == 0 || len(domain.indexedFlushUnits) == 0 || !hasBufferedIndexedRootRuns(domain) {
-					return time.Since(flushStart), lockReleased, nil
+					return 0, lockReleased, nil
 				}
 				if len(domain.indexedPublishingUnits) == 0 {
+					flushStart = time.Now()
 					err := c.flushBufferedIndexedLocked(domain)
 					return time.Since(flushStart), lockReleased, err
 				}
 			}
+			flushStart = time.Now()
 			if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
 				err := c.flushBufferedIndexedLocked(domain)
 				return time.Since(flushStart), lockReleased, err
 			}
 			return time.Since(flushStart), lockReleased, nil
 		}
+		flushStart := time.Now()
 		if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
-			flushStart := time.Now()
 			err := c.flushBufferedIndexedLocked(domain)
 			return time.Since(flushStart), 0, err
 		}
-		return 0, 0, nil
+		return time.Since(flushStart), 0, nil
 	}
 	flushStart := time.Now()
 	err := c.flushBufferedIndexedLocked(domain)
@@ -7373,7 +7384,6 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		flushDuration, lockReleased, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {
 			lockReleasedDuringHold += lockReleased
-			plan.stats.BufferStageLockWait += updateBatchStatsDuration(detailedStats, lockReleased)
 		}
 		plan.stats.BufferStageFlush += updateBatchStatsDuration(detailedStats, flushDuration)
 		if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -603,7 +603,10 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	if stats.SecondaryKeyBytes == 0 {
 		t.Fatal("stats secondary key bytes=0 want positive")
 	}
-	if stats.CurrentRead != 0 || stats.Callback != 0 || stats.BufferStage != 0 {
+	if stats.CurrentRead != 0 || stats.Callback != 0 || stats.BufferStage != 0 ||
+		stats.BufferStageLockWait != 0 || stats.BufferStageLockHold != 0 ||
+		stats.BufferStagePrimaryIdx != 0 || stats.BufferStageUniqueIdx != 0 ||
+		stats.BufferStageRootAppend != 0 || stats.BufferStageFlush != 0 {
 		t.Fatalf("default update timings=%+v want zero unless detailed stats enabled", stats)
 	}
 
@@ -623,6 +626,9 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	if timedStats.Callback <= 0 {
 		t.Fatalf("timed callback=%s want positive with detailed stats enabled", timedStats.Callback)
 	}
+	if timedStats.BufferStage <= 0 {
+		t.Fatalf("timed buffer stage=%s want positive with detailed stats enabled", timedStats.BufferStage)
+	}
 
 	managerStats := mgr.StatsSnapshot()
 	if got := managerStats.UpdateBatchCalls; got == 0 {
@@ -640,6 +646,9 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	exported := mgr.Stats()
 	if _, ok := exported["treedb.collections.write_domain.update_batch.secondary_sets_total"]; !ok {
 		t.Fatalf("manager stats missing update batch secondary set counter: keys=%v", exported)
+	}
+	if _, ok := exported["treedb.collections.write_domain.update_batch.buffer_stage_lock_hold_ns_total"]; !ok {
+		t.Fatalf("manager stats missing buffer stage lock hold counter: keys=%v", exported)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -747,7 +747,6 @@ func TestCollectionUpdateBufferBreakdownStatsSnapshotAndAdd(t *testing.T) {
 	}
 
 	var updateStats CollectionUpdateStats
-	updateStats.BufferStage = time.Nanosecond
 	for i, tc := range cases {
 		tc.set(&updateStats, time.Duration(i+1)*time.Nanosecond)
 	}
@@ -3280,7 +3279,7 @@ func TestCollectionIndexedWriteMemtablesAsyncBackpressureWaitsForPublishingUnit(
 	backpressureDone := make(chan error, 1)
 	go func() {
 		col.writeDomain.mu.Lock()
-		_, _, err := col.flushBufferedIndexedAfterThresholdLocked(col.writeDomain, CollectionOptions{
+		_, _, _, err := col.flushBufferedIndexedAfterThresholdLocked(col.writeDomain, CollectionOptions{
 			BufferedIndexedWrites:                   true,
 			BufferedIndexedWriteMaxDocuments:        1,
 			BufferedIndexedAsyncFlush:               true,

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -671,19 +671,20 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 func TestCollectionUpdateBufferBreakdownStatsSnapshotAndAdd(t *testing.T) {
 	cases := []struct {
 		name string
+		key  string
 		set  func(*CollectionUpdateStats, time.Duration)
 		get  func(CollectionManagerStats) time.Duration
 	}{
-		{"precheck", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStagePrecheck = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferPrecheck }},
-		{"lock_wait", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageLockWait = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferLockWait }},
-		{"lock_hold", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageLockHold = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferLockHold }},
-		{"validation", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageValidation = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferValidation }},
-		{"root_scan", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageRootScan = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferRootScan }},
-		{"domain_prepare", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageDomainPrepare = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferDomainPrepare }},
-		{"primary_index", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStagePrimaryIdx = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferPrimaryIdx }},
-		{"unique_index", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageUniqueIdx = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferUniqueIdx }},
-		{"root_append", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageRootAppend = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferRootAppend }},
-		{"flush", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageFlush = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferFlush }},
+		{"precheck", "treedb.collections.write_domain.update_batch.buffer_stage_precheck_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStagePrecheck = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferPrecheck }},
+		{"lock_wait", "treedb.collections.write_domain.update_batch.buffer_stage_lock_wait_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageLockWait = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferLockWait }},
+		{"lock_hold", "treedb.collections.write_domain.update_batch.buffer_stage_lock_hold_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageLockHold = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferLockHold }},
+		{"validation", "treedb.collections.write_domain.update_batch.buffer_stage_validation_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageValidation = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferValidation }},
+		{"root_scan", "treedb.collections.write_domain.update_batch.buffer_stage_root_scan_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageRootScan = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferRootScan }},
+		{"domain_prepare", "treedb.collections.write_domain.update_batch.buffer_stage_domain_prepare_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageDomainPrepare = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferDomainPrepare }},
+		{"primary_index", "treedb.collections.write_domain.update_batch.buffer_stage_primary_index_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStagePrimaryIdx = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferPrimaryIdx }},
+		{"unique_index", "treedb.collections.write_domain.update_batch.buffer_stage_unique_index_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageUniqueIdx = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferUniqueIdx }},
+		{"root_append", "treedb.collections.write_domain.update_batch.buffer_stage_root_append_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageRootAppend = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferRootAppend }},
+		{"flush", "treedb.collections.write_domain.update_batch.buffer_stage_flush_ns_total", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageFlush = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferFlush }},
 	}
 
 	var updateStats CollectionUpdateStats
@@ -696,6 +697,7 @@ func TestCollectionUpdateBufferBreakdownStatsSnapshotAndAdd(t *testing.T) {
 	snapshot := domain.statsSnapshot()
 	var merged CollectionManagerStats
 	merged.add(snapshot)
+	exported := (&CollectionManager{domains: map[string]*collectionWriteDomain{"test": domain}}).Stats()
 	for i, tc := range cases {
 		want := time.Duration(i+1) * time.Nanosecond
 		if got := tc.get(snapshot); got != want {
@@ -703,6 +705,9 @@ func TestCollectionUpdateBufferBreakdownStatsSnapshotAndAdd(t *testing.T) {
 		}
 		if got := tc.get(merged); got != want {
 			t.Fatalf("merged %s=%s want %s", tc.name, got, want)
+		}
+		if got, want := exported[tc.key], fmt.Sprintf("%d", want.Nanoseconds()); got != want {
+			t.Fatalf("exported %s=%q want %q", tc.key, got, want)
 		}
 	}
 }

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -604,7 +604,10 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 		t.Fatal("stats secondary key bytes=0 want positive")
 	}
 	if stats.CurrentRead != 0 || stats.Callback != 0 || stats.BufferStage != 0 ||
+		stats.BufferStagePrecheck != 0 ||
 		stats.BufferStageLockWait != 0 || stats.BufferStageLockHold != 0 ||
+		stats.BufferStageValidation != 0 || stats.BufferStageRootScan != 0 ||
+		stats.BufferStageDomainInit != 0 ||
 		stats.BufferStagePrimaryIdx != 0 || stats.BufferStageUniqueIdx != 0 ||
 		stats.BufferStageRootAppend != 0 || stats.BufferStageFlush != 0 {
 		t.Fatalf("default update timings=%+v want zero unless detailed stats enabled", stats)
@@ -644,8 +647,21 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	if _, ok := exported["treedb.collections.write_domain.update_batch.secondary_sets_total"]; !ok {
 		t.Fatalf("manager stats missing update batch secondary set counter: keys=%v", exported)
 	}
-	if _, ok := exported["treedb.collections.write_domain.update_batch.buffer_stage_lock_hold_ns_total"]; !ok {
-		t.Fatalf("manager stats missing buffer stage lock hold counter: keys=%v", exported)
+	for _, key := range []string{
+		"treedb.collections.write_domain.update_batch.buffer_stage_precheck_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_lock_wait_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_lock_hold_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_validation_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_root_scan_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_domain_init_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_primary_index_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_unique_index_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_root_append_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_flush_ns_total",
+	} {
+		if _, ok := exported[key]; !ok {
+			t.Fatalf("manager stats missing %s: keys=%v", key, exported)
+		}
 	}
 }
 
@@ -3158,7 +3174,7 @@ func TestCollectionIndexedWriteMemtablesAsyncBackpressureWaitsForPublishingUnit(
 	backpressureDone := make(chan error, 1)
 	go func() {
 		col.writeDomain.mu.Lock()
-		_, err := col.flushBufferedIndexedAfterThresholdLocked(col.writeDomain, CollectionOptions{
+		_, _, err := col.flushBufferedIndexedAfterThresholdLocked(col.writeDomain, CollectionOptions{
 			BufferedIndexedWrites:                   true,
 			BufferedIndexedWriteMaxDocuments:        1,
 			BufferedIndexedAsyncFlush:               true,

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -668,6 +668,65 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBufferFlushTimingCountsAsyncSchedule(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl","flag":false}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"hnl","flag":true}`), true, nil
+		}},
+	}); err != nil {
+		t.Fatalf("update batch: %v", err)
+	} else if !batched {
+		t.Fatal("update batch batched=false want true")
+	}
+	stats := col.LastUpdateStats()
+	if got := stats.BufferStageFlush; got <= 0 {
+		t.Fatalf("async schedule flush timing=%s want positive", got)
+	}
+	if got := mgr.StatsSnapshot().IndexedAsyncFlushScheduled; got == 0 {
+		t.Fatal("async flush scheduled=0 want positive")
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("drain async update: %v", err)
+	}
+}
+
 func TestCollectionUpdateBufferBreakdownStatsSnapshotAndAdd(t *testing.T) {
 	cases := []struct {
 		name string

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -607,7 +607,7 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 		stats.BufferStagePrecheck != 0 ||
 		stats.BufferStageLockWait != 0 || stats.BufferStageLockHold != 0 ||
 		stats.BufferStageValidation != 0 || stats.BufferStageRootScan != 0 ||
-		stats.BufferStageDomainInit != 0 ||
+		stats.BufferStageDomainPrepare != 0 ||
 		stats.BufferStagePrimaryIdx != 0 || stats.BufferStageUniqueIdx != 0 ||
 		stats.BufferStageRootAppend != 0 || stats.BufferStageFlush != 0 {
 		t.Fatalf("default update timings=%+v want zero unless detailed stats enabled", stats)
@@ -653,7 +653,7 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 		"treedb.collections.write_domain.update_batch.buffer_stage_lock_hold_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_validation_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_root_scan_ns_total",
-		"treedb.collections.write_domain.update_batch.buffer_stage_domain_init_ns_total",
+		"treedb.collections.write_domain.update_batch.buffer_stage_domain_prepare_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_primary_index_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_unique_index_ns_total",
 		"treedb.collections.write_domain.update_batch.buffer_stage_root_append_ns_total",

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -629,6 +629,9 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	if timedStats.Callback <= 0 {
 		t.Fatalf("timed callback=%s want positive with detailed stats enabled", timedStats.Callback)
 	}
+	if timedStats.BufferStageFlush != 0 {
+		t.Fatalf("timed flush stage=%s want zero without threshold flush", timedStats.BufferStageFlush)
+	}
 
 	managerStats := mgr.StatsSnapshot()
 	if got := managerStats.UpdateBatchCalls; got == 0 {
@@ -684,6 +687,7 @@ func TestCollectionUpdateBufferBreakdownStatsSnapshotAndAdd(t *testing.T) {
 	}
 
 	var updateStats CollectionUpdateStats
+	updateStats.BufferStage = time.Nanosecond
 	for i, tc := range cases {
 		tc.set(&updateStats, time.Duration(i+1)*time.Nanosecond)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -626,9 +626,6 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	if timedStats.Callback <= 0 {
 		t.Fatalf("timed callback=%s want positive with detailed stats enabled", timedStats.Callback)
 	}
-	if timedStats.BufferStage <= 0 {
-		t.Fatalf("timed buffer stage=%s want positive with detailed stats enabled", timedStats.BufferStage)
-	}
 
 	managerStats := mgr.StatsSnapshot()
 	if got := managerStats.UpdateBatchCalls; got == 0 {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -665,6 +665,44 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateBufferBreakdownStatsSnapshotAndAdd(t *testing.T) {
+	cases := []struct {
+		name string
+		set  func(*CollectionUpdateStats, time.Duration)
+		get  func(CollectionManagerStats) time.Duration
+	}{
+		{"precheck", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStagePrecheck = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferPrecheck }},
+		{"lock_wait", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageLockWait = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferLockWait }},
+		{"lock_hold", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageLockHold = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferLockHold }},
+		{"validation", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageValidation = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferValidation }},
+		{"root_scan", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageRootScan = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferRootScan }},
+		{"domain_prepare", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageDomainPrepare = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferDomainPrepare }},
+		{"primary_index", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStagePrimaryIdx = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferPrimaryIdx }},
+		{"unique_index", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageUniqueIdx = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferUniqueIdx }},
+		{"root_append", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageRootAppend = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferRootAppend }},
+		{"flush", func(s *CollectionUpdateStats, d time.Duration) { s.BufferStageFlush = d }, func(s CollectionManagerStats) time.Duration { return s.UpdateBatchBufferFlush }},
+	}
+
+	var updateStats CollectionUpdateStats
+	for i, tc := range cases {
+		tc.set(&updateStats, time.Duration(i+1)*time.Nanosecond)
+	}
+	domain := &collectionWriteDomain{}
+	domain.observeUpdateBatchStats(updateStats)
+	snapshot := domain.statsSnapshot()
+	var merged CollectionManagerStats
+	merged.add(snapshot)
+	for i, tc := range cases {
+		want := time.Duration(i+1) * time.Nanosecond
+		if got := tc.get(snapshot); got != want {
+			t.Fatalf("snapshot %s=%s want %s", tc.name, got, want)
+		}
+		if got := tc.get(merged); got != want {
+			t.Fatalf("merged %s=%s want %s", tc.name, got, want)
+		}
+	}
+}
+
 func TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation(t *testing.T) {
 	meta := CollectionMeta{
 		Name: "users",

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -502,8 +502,12 @@ The benchmark shapes are intentionally different:
   update attribution metrics such as `update_current_read_ns/doc`,
   `update_callback_ns/doc`, `update_index_state_extract_ns/doc`,
   `update_primary_run_ns/doc`, `update_secondary_runs_ns/doc`,
-  `update_buffer_stage_ns/doc`, `update_publish_ns/doc`, and
-  `update_items/batch` from the collection manager's measured-phase counters.
+  `update_buffer_stage_ns/doc`, buffer-stage submetrics such as
+  `update_buffer_lock_wait_ns/doc`, `update_buffer_lock_hold_ns/doc`,
+  `update_buffer_primary_index_ns/doc`, `update_buffer_unique_index_ns/doc`,
+  `update_buffer_root_append_ns/doc`, `update_buffer_flush_ns/doc`,
+  `update_publish_ns/doc`, and `update_items/batch` from the collection
+  manager's measured-phase counters.
 - `BenchmarkClientBSONBatchEncode` measures client-side BSON document encoding
   alone.
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -503,7 +503,9 @@ The benchmark shapes are intentionally different:
   `update_callback_ns/doc`, `update_index_state_extract_ns/doc`,
   `update_primary_run_ns/doc`, `update_secondary_runs_ns/doc`,
   `update_buffer_stage_ns/doc`, buffer-stage submetrics such as
-  `update_buffer_lock_wait_ns/doc`, `update_buffer_lock_hold_ns/doc`,
+  `update_buffer_precheck_ns/doc`, `update_buffer_lock_wait_ns/doc`,
+  `update_buffer_lock_hold_ns/doc`, `update_buffer_validation_ns/doc`,
+  `update_buffer_root_scan_ns/doc`, `update_buffer_domain_init_ns/doc`,
   `update_buffer_primary_index_ns/doc`, `update_buffer_unique_index_ns/doc`,
   `update_buffer_root_append_ns/doc`, `update_buffer_flush_ns/doc`,
   `update_publish_ns/doc`, and `update_items/batch` from the collection

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -505,11 +505,14 @@ The benchmark shapes are intentionally different:
   `update_buffer_stage_ns/doc`, buffer-stage submetrics such as
   `update_buffer_precheck_ns/doc`, `update_buffer_lock_wait_ns/doc`,
   `update_buffer_lock_hold_ns/doc`, `update_buffer_validation_ns/doc`,
-  `update_buffer_root_scan_ns/doc`, `update_buffer_domain_init_ns/doc`,
+  `update_buffer_root_scan_ns/doc`, `update_buffer_domain_prepare_ns/doc`,
   `update_buffer_primary_index_ns/doc`, `update_buffer_unique_index_ns/doc`,
   `update_buffer_root_append_ns/doc`, `update_buffer_flush_ns/doc`,
   `update_publish_ns/doc`, and `update_items/batch` from the collection
-  manager's measured-phase counters.
+  manager's measured-phase counters. `update_buffer_lock_hold_ns/doc` is the
+  enclosing domain mutex hold time for buffered staging, not an additive sibling
+  of the other buffer-stage submetrics; `update_buffer_flush_ns/doc` reports
+  threshold-flush scheduling/publish time separately.
 - `BenchmarkClientBSONBatchEncode` measures client-side BSON document encoding
   alone.
 

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -511,36 +511,36 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 
 func deltaCollectionManagerUpdateStats(after, before collections.CollectionManagerStats) collections.CollectionManagerStats {
 	return collections.CollectionManagerStats{
-		UpdateBatchCalls:              after.UpdateBatchCalls - before.UpdateBatchCalls,
-		UpdateBatchItems:              after.UpdateBatchItems - before.UpdateBatchItems,
-		UpdateBatchMatched:            after.UpdateBatchMatched - before.UpdateBatchMatched,
-		UpdateBatchModified:           after.UpdateBatchModified - before.UpdateBatchModified,
-		UpdateBatchRuns:               after.UpdateBatchRuns - before.UpdateBatchRuns,
-		UpdateBatchBufferedBatches:    after.UpdateBatchBufferedBatches - before.UpdateBatchBufferedBatches,
-		UpdateBatchCurrentRead:        after.UpdateBatchCurrentRead - before.UpdateBatchCurrentRead,
-		UpdateBatchCallback:           after.UpdateBatchCallback - before.UpdateBatchCallback,
-		UpdateBatchPrepareDocuments:   after.UpdateBatchPrepareDocuments - before.UpdateBatchPrepareDocuments,
-		UpdateBatchIndexStateExtract:  after.UpdateBatchIndexStateExtract - before.UpdateBatchIndexStateExtract,
-		UpdateBatchUniquePreflight:    after.UpdateBatchUniquePreflight - before.UpdateBatchUniquePreflight,
-		UpdateBatchTemplateRunBuild:   after.UpdateBatchTemplateRunBuild - before.UpdateBatchTemplateRunBuild,
-		UpdateBatchPrimaryRunBuild:    after.UpdateBatchPrimaryRunBuild - before.UpdateBatchPrimaryRunBuild,
-		UpdateBatchIndexStateRunBuild: after.UpdateBatchIndexStateRunBuild - before.UpdateBatchIndexStateRunBuild,
-		UpdateBatchSecondaryRunBuild:  after.UpdateBatchSecondaryRunBuild - before.UpdateBatchSecondaryRunBuild,
-		UpdateBatchBufferStage:        after.UpdateBatchBufferStage - before.UpdateBatchBufferStage,
-		UpdateBatchBufferPrecheck:     after.UpdateBatchBufferPrecheck - before.UpdateBatchBufferPrecheck,
-		UpdateBatchBufferLockWait:     after.UpdateBatchBufferLockWait - before.UpdateBatchBufferLockWait,
-		UpdateBatchBufferLockHold:     after.UpdateBatchBufferLockHold - before.UpdateBatchBufferLockHold,
-		UpdateBatchBufferValidation:   after.UpdateBatchBufferValidation - before.UpdateBatchBufferValidation,
-		UpdateBatchBufferRootScan:     after.UpdateBatchBufferRootScan - before.UpdateBatchBufferRootScan,
-		UpdateBatchBufferDomainInit:   after.UpdateBatchBufferDomainInit - before.UpdateBatchBufferDomainInit,
-		UpdateBatchBufferPrimaryIdx:   after.UpdateBatchBufferPrimaryIdx - before.UpdateBatchBufferPrimaryIdx,
-		UpdateBatchBufferUniqueIdx:    after.UpdateBatchBufferUniqueIdx - before.UpdateBatchBufferUniqueIdx,
-		UpdateBatchBufferRootAppend:   after.UpdateBatchBufferRootAppend - before.UpdateBatchBufferRootAppend,
-		UpdateBatchBufferFlush:        after.UpdateBatchBufferFlush - before.UpdateBatchBufferFlush,
-		UpdateBatchPublish:            after.UpdateBatchPublish - before.UpdateBatchPublish,
-		UpdateBatchSecondaryDeletes:   after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
-		UpdateBatchSecondarySets:      after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
-		UpdateBatchSecondaryKeyBytes:  after.UpdateBatchSecondaryKeyBytes - before.UpdateBatchSecondaryKeyBytes,
+		UpdateBatchCalls:               after.UpdateBatchCalls - before.UpdateBatchCalls,
+		UpdateBatchItems:               after.UpdateBatchItems - before.UpdateBatchItems,
+		UpdateBatchMatched:             after.UpdateBatchMatched - before.UpdateBatchMatched,
+		UpdateBatchModified:            after.UpdateBatchModified - before.UpdateBatchModified,
+		UpdateBatchRuns:                after.UpdateBatchRuns - before.UpdateBatchRuns,
+		UpdateBatchBufferedBatches:     after.UpdateBatchBufferedBatches - before.UpdateBatchBufferedBatches,
+		UpdateBatchCurrentRead:         after.UpdateBatchCurrentRead - before.UpdateBatchCurrentRead,
+		UpdateBatchCallback:            after.UpdateBatchCallback - before.UpdateBatchCallback,
+		UpdateBatchPrepareDocuments:    after.UpdateBatchPrepareDocuments - before.UpdateBatchPrepareDocuments,
+		UpdateBatchIndexStateExtract:   after.UpdateBatchIndexStateExtract - before.UpdateBatchIndexStateExtract,
+		UpdateBatchUniquePreflight:     after.UpdateBatchUniquePreflight - before.UpdateBatchUniquePreflight,
+		UpdateBatchTemplateRunBuild:    after.UpdateBatchTemplateRunBuild - before.UpdateBatchTemplateRunBuild,
+		UpdateBatchPrimaryRunBuild:     after.UpdateBatchPrimaryRunBuild - before.UpdateBatchPrimaryRunBuild,
+		UpdateBatchIndexStateRunBuild:  after.UpdateBatchIndexStateRunBuild - before.UpdateBatchIndexStateRunBuild,
+		UpdateBatchSecondaryRunBuild:   after.UpdateBatchSecondaryRunBuild - before.UpdateBatchSecondaryRunBuild,
+		UpdateBatchBufferStage:         after.UpdateBatchBufferStage - before.UpdateBatchBufferStage,
+		UpdateBatchBufferPrecheck:      after.UpdateBatchBufferPrecheck - before.UpdateBatchBufferPrecheck,
+		UpdateBatchBufferLockWait:      after.UpdateBatchBufferLockWait - before.UpdateBatchBufferLockWait,
+		UpdateBatchBufferLockHold:      after.UpdateBatchBufferLockHold - before.UpdateBatchBufferLockHold,
+		UpdateBatchBufferValidation:    after.UpdateBatchBufferValidation - before.UpdateBatchBufferValidation,
+		UpdateBatchBufferRootScan:      after.UpdateBatchBufferRootScan - before.UpdateBatchBufferRootScan,
+		UpdateBatchBufferDomainPrepare: after.UpdateBatchBufferDomainPrepare - before.UpdateBatchBufferDomainPrepare,
+		UpdateBatchBufferPrimaryIdx:    after.UpdateBatchBufferPrimaryIdx - before.UpdateBatchBufferPrimaryIdx,
+		UpdateBatchBufferUniqueIdx:     after.UpdateBatchBufferUniqueIdx - before.UpdateBatchBufferUniqueIdx,
+		UpdateBatchBufferRootAppend:    after.UpdateBatchBufferRootAppend - before.UpdateBatchBufferRootAppend,
+		UpdateBatchBufferFlush:         after.UpdateBatchBufferFlush - before.UpdateBatchBufferFlush,
+		UpdateBatchPublish:             after.UpdateBatchPublish - before.UpdateBatchPublish,
+		UpdateBatchSecondaryDeletes:    after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
+		UpdateBatchSecondarySets:       after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
+		UpdateBatchSecondaryKeyBytes:   after.UpdateBatchSecondaryKeyBytes - before.UpdateBatchSecondaryKeyBytes,
 	}
 }
 
@@ -594,7 +594,7 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	reportDuration("update_buffer_lock_hold_ns/doc", stats.UpdateBatchBufferLockHold)
 	reportDuration("update_buffer_validation_ns/doc", stats.UpdateBatchBufferValidation)
 	reportDuration("update_buffer_root_scan_ns/doc", stats.UpdateBatchBufferRootScan)
-	reportDuration("update_buffer_domain_init_ns/doc", stats.UpdateBatchBufferDomainInit)
+	reportDuration("update_buffer_domain_prepare_ns/doc", stats.UpdateBatchBufferDomainPrepare)
 	reportDuration("update_buffer_primary_index_ns/doc", stats.UpdateBatchBufferPrimaryIdx)
 	reportDuration("update_buffer_unique_index_ns/doc", stats.UpdateBatchBufferUniqueIdx)
 	reportDuration("update_buffer_root_append_ns/doc", stats.UpdateBatchBufferRootAppend)

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -527,6 +527,16 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateBatchIndexStateRunBuild: after.UpdateBatchIndexStateRunBuild - before.UpdateBatchIndexStateRunBuild,
 		UpdateBatchSecondaryRunBuild:  after.UpdateBatchSecondaryRunBuild - before.UpdateBatchSecondaryRunBuild,
 		UpdateBatchBufferStage:        after.UpdateBatchBufferStage - before.UpdateBatchBufferStage,
+		UpdateBatchBufferPrecheck:     after.UpdateBatchBufferPrecheck - before.UpdateBatchBufferPrecheck,
+		UpdateBatchBufferLockWait:     after.UpdateBatchBufferLockWait - before.UpdateBatchBufferLockWait,
+		UpdateBatchBufferLockHold:     after.UpdateBatchBufferLockHold - before.UpdateBatchBufferLockHold,
+		UpdateBatchBufferValidation:   after.UpdateBatchBufferValidation - before.UpdateBatchBufferValidation,
+		UpdateBatchBufferRootScan:     after.UpdateBatchBufferRootScan - before.UpdateBatchBufferRootScan,
+		UpdateBatchBufferDomainInit:   after.UpdateBatchBufferDomainInit - before.UpdateBatchBufferDomainInit,
+		UpdateBatchBufferPrimaryIdx:   after.UpdateBatchBufferPrimaryIdx - before.UpdateBatchBufferPrimaryIdx,
+		UpdateBatchBufferUniqueIdx:    after.UpdateBatchBufferUniqueIdx - before.UpdateBatchBufferUniqueIdx,
+		UpdateBatchBufferRootAppend:   after.UpdateBatchBufferRootAppend - before.UpdateBatchBufferRootAppend,
+		UpdateBatchBufferFlush:        after.UpdateBatchBufferFlush - before.UpdateBatchBufferFlush,
 		UpdateBatchPublish:            after.UpdateBatchPublish - before.UpdateBatchPublish,
 		UpdateBatchSecondaryDeletes:   after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
 		UpdateBatchSecondarySets:      after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
@@ -579,6 +589,16 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	reportDuration("update_index_state_run_ns/doc", stats.UpdateBatchIndexStateRunBuild)
 	reportDuration("update_secondary_runs_ns/doc", stats.UpdateBatchSecondaryRunBuild)
 	reportDuration("update_buffer_stage_ns/doc", stats.UpdateBatchBufferStage)
+	reportDuration("update_buffer_precheck_ns/doc", stats.UpdateBatchBufferPrecheck)
+	reportDuration("update_buffer_lock_wait_ns/doc", stats.UpdateBatchBufferLockWait)
+	reportDuration("update_buffer_lock_hold_ns/doc", stats.UpdateBatchBufferLockHold)
+	reportDuration("update_buffer_validation_ns/doc", stats.UpdateBatchBufferValidation)
+	reportDuration("update_buffer_root_scan_ns/doc", stats.UpdateBatchBufferRootScan)
+	reportDuration("update_buffer_domain_init_ns/doc", stats.UpdateBatchBufferDomainInit)
+	reportDuration("update_buffer_primary_index_ns/doc", stats.UpdateBatchBufferPrimaryIdx)
+	reportDuration("update_buffer_unique_index_ns/doc", stats.UpdateBatchBufferUniqueIdx)
+	reportDuration("update_buffer_root_append_ns/doc", stats.UpdateBatchBufferRootAppend)
+	reportDuration("update_buffer_flush_ns/doc", stats.UpdateBatchBufferFlush)
 	reportDuration("update_publish_ns/doc", stats.UpdateBatchPublish)
 }
 


### PR DESCRIPTION
## Summary

Part of #1159.

The post-#1163 direct update profile still reported a large `update_buffer_stage_ns/doc` aggregate. This PR keeps that total but splits it into lower-level detailed counters so the #1132/root-publish work can target measured subphases instead of one opaque bucket.

New detailed update timing fields cover:

- buffer precheck
- write-domain lock wait and lock hold
- root/catalog validation
- staged root scan and byte sizing
- domain/map initialization and auto-flush decision
- primary buffered-run index update
- unique-value buffered index update
- root-run append
- flush scheduling/synchronous threshold flush

The added timers are still gated by `CollectionManager.SetUpdateBatchDetailedStatsEnabled(true)`, so the normal write path keeps the existing lightweight counter posture unless detailed benchmark attribution is explicitly enabled.

## Benchmark evidence

Command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=2
```

Results on this branch:

```text
100000  12409 ns/op  80589 docs/sec  1296 B/op  7 allocs/op
  update_buffer_stage_ns/doc=8543
  update_buffer_lock_hold_ns/doc=8495
  update_buffer_flush_ns/doc=8230
  update_buffer_primary_index_ns/doc=122.7
  update_buffer_validation_ns/doc=32.27
  update_buffer_root_scan_ns/doc=10.70
  update_buffer_root_append_ns/doc=8.700
  update_buffer_lock_wait_ns/doc=4.735

100000  13278 ns/op  75311 docs/sec  1328 B/op  8 allocs/op
  update_buffer_stage_ns/doc=8918
  update_buffer_lock_hold_ns/doc=8850
  update_buffer_flush_ns/doc=8528
  update_buffer_primary_index_ns/doc=128.6
  update_buffer_validation_ns/doc=36.95
  update_buffer_root_scan_ns/doc=15.42
  update_buffer_root_append_ns/doc=15.21
  update_buffer_lock_wait_ns/doc=6.809
```

Interpretation: for this direct concurrent two-index update shape, the buffer-stage aggregate is dominated by lock-held synchronous threshold flush work, not by domain lock wait, root append, validation, or primary/unique index bookkeeping. That makes the next #1159/#1132 target much clearer: reduce synchronous flush/publish work while holding the write-domain lock.

## Validation

```bash
go test ./TreeDB/collections \
  -run 'TestCollectionUpdateBatchStatsExposeIndexRunShape|TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation|TestCollectionCatalogCachesIndexRuntimesAndRootNames' \
  -count 1

go test ./TreeDB/collections ./cmd/mongo_gateway_bench -count 1
```

Both passed locally.
