### PR TITLE
Avoid collecting indexed root runs for primary-index reads

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6683,12 +6683,12 @@ func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta C
 		if allowPrimaryRunIndexBuild && domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, bufferedCollectionName) {
 			return updateBatchBufferedRead{}, nil, false, true, nil
 		}
-		primaryRuns := pendingIndexedRootRunsLocked(domain, collectionPrimaryRootName(bufferedCollectionName))
 		var primaryEntries []updateBatchBufferedEntry
 		var err error
 		if domain.primaryRunIndex != nil {
 			primaryEntries, err = snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(domain.primaryRunIndex, items)
 		} else {
+			primaryRuns := pendingIndexedRootRunsLocked(domain, collectionPrimaryRootName(bufferedCollectionName))
 			primaryEntries, err = snapshotUpdateBatchBufferedPrimaryEntries(primaryRuns, items)
 		}
 		if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -6975,6 +6975,115 @@ func TestSnapshotUpdateBatchBufferedReadCachesEmptyPrimaryRunIndex(t *testing.T)
 	}
 }
 
+func TestSnapshotUpdateBatchBufferedReadPrimaryRunIndexAvoidsCollectingPendingRuns(t *testing.T) {
+	meta := CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city", ValueType: IndexValueString}},
+	}
+	primaryName := collectionPrimaryRootName("users")
+	primaryTable := newCollectionRunTable(1)
+	setCollectionRunValue(primaryTable, []byte("u1"), []byte(`{"city":"paris"}`))
+	primaryTable.Freeze()
+	defer resetCollectionRunTable(primaryTable)
+
+	primaryIndex := newBufferedPrimaryRunIndex(1)
+	if err := addBufferedPrimaryRunIndexEntries(primaryIndex, primaryTable); err != nil {
+		t.Fatalf("add primary run index entries: %v", err)
+	}
+	domain := &collectionWriteDomain{
+		loaded:         true,
+		meta:           meta,
+		catalog:        &collectionCatalog{meta: meta},
+		baseSystemRoot: 7,
+		count:          1,
+		rootRuns: map[string][]memtable.Table{
+			primaryName: {primaryTable},
+		},
+		primaryRunIndex: primaryIndex,
+	}
+	for i := 0; i < 256; i++ {
+		domain.indexedFlushUnits = append(domain.indexedFlushUnits, indexedFlushUnit{
+			rootRuns: map[string][]memtable.Table{
+				primaryName: make([]memtable.Table, 8),
+			},
+			rootRunCount: 8,
+		})
+	}
+	items := []UpdateBatchItem{{DocumentID: []byte("u1")}}
+	assertRead := func() {
+		t.Helper()
+		read, _, blocked, needPrimaryRunIndex, err := snapshotUpdateBatchBufferedReadLocked(domain, meta, 7, items, DocumentFormatJSON, false)
+		if err != nil {
+			t.Fatalf("snapshotUpdateBatchBufferedReadLocked: %v", err)
+		}
+		if blocked || needPrimaryRunIndex || !read.enabled {
+			t.Fatalf("read enabled=%v blocked=%v needPrimaryRunIndex=%v", read.enabled, blocked, needPrimaryRunIndex)
+		}
+		if len(read.primaryEntries) != 1 || !read.primaryEntries[0].found || !bytes.Equal(read.primaryEntries[0].value, []byte(`{"city":"paris"}`)) {
+			t.Fatalf("primary entries=%+v want buffered u1 document", read.primaryEntries)
+		}
+	}
+	assertRead()
+
+	if allocs := testing.AllocsPerRun(100, assertRead); allocs > 2 {
+		t.Fatalf("buffered read allocations/run=%0.1f want <= 2; primary-run index path should not collect pending root runs", allocs)
+	}
+}
+
+func BenchmarkSnapshotUpdateBatchBufferedReadPrimaryRunIndexPendingUnits(b *testing.B) {
+	meta := CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city", ValueType: IndexValueString}},
+	}
+	primaryName := collectionPrimaryRootName("users")
+	primaryTable := newCollectionRunTable(1)
+	setCollectionRunValue(primaryTable, []byte("u1"), []byte(`{"city":"paris"}`))
+	primaryTable.Freeze()
+	defer resetCollectionRunTable(primaryTable)
+
+	primaryIndex := newBufferedPrimaryRunIndex(1)
+	if err := addBufferedPrimaryRunIndexEntries(primaryIndex, primaryTable); err != nil {
+		b.Fatalf("add primary run index entries: %v", err)
+	}
+	domain := &collectionWriteDomain{
+		loaded:         true,
+		meta:           meta,
+		catalog:        &collectionCatalog{meta: meta},
+		baseSystemRoot: 7,
+		count:          1,
+		rootRuns: map[string][]memtable.Table{
+			primaryName: {primaryTable},
+		},
+		primaryRunIndex: primaryIndex,
+	}
+	for i := 0; i < 256; i++ {
+		domain.indexedFlushUnits = append(domain.indexedFlushUnits, indexedFlushUnit{
+			rootRuns: map[string][]memtable.Table{
+				primaryName: make([]memtable.Table, 8),
+			},
+			rootRunCount: 8,
+		})
+	}
+	items := []UpdateBatchItem{{DocumentID: []byte("u1")}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		read, _, blocked, needPrimaryRunIndex, err := snapshotUpdateBatchBufferedReadLocked(domain, meta, 7, items, DocumentFormatJSON, false)
+		if err != nil {
+			b.Fatalf("snapshotUpdateBatchBufferedReadLocked: %v", err)
+		}
+		if blocked || needPrimaryRunIndex || !read.enabled || len(read.primaryEntries) != 1 || !read.primaryEntries[0].found {
+			b.Fatalf("unexpected read enabled=%v entries=%d blocked=%v needPrimaryRunIndex=%v", read.enabled, len(read.primaryEntries), blocked, needPrimaryRunIndex)
+		}
+	}
+}
+
 func collectionHasBufferedPrimaryRunIndexForTest(t *testing.T, col *Collection) bool {
 	t.Helper()
 	col.writeDomain.mu.RLock()


### PR DESCRIPTION
## Summary
- skip `pendingIndexedRootRunsLocked` when buffered update planning can use the lazy primary-run index directly
- add a regression test covering many pending indexed flush units with an existing primary-run index
- add a focused microbenchmark for the direct indexed buffered-read path

## Why
A fresh #1159 profile on current `main` showed `collections.pendingIndexedRootRunsLocked` allocating ~568 MB in the two-index BSON update benchmark. The slice was built even though `domain.primaryRunIndex` was present and the fallback run scan was not used.

## Benchmarks / profiles
Baseline current main command:
```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1159_publish_profile_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

Baseline current main:
- `934137` iterations, `11346 ns/op`, `88138 docs/sec`, `1266 B/op`, `7 allocs/op`
- `pendingIndexedRootRunsLocked`: `568.27 MB` flat allocation, `7.52%` of alloc_space

After this PR, same command:
- `949586` iterations, `11938 ns/op`, `83766 docs/sec`, `1257 B/op`, `7 allocs/op`
- `pendingIndexedRootRunsLocked`: no longer appears in alloc_space profile (`go tool pprof -alloc_space -list pendingIndexedRootRunsLocked` reports no match)

Focused microbenchmark:
```bash
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkSnapshotUpdateBatchBufferedReadPrimaryRunIndexPendingUnits$' -benchmem -count=5
```

Results:
- `456.0 ns/op`, `48 B/op`, `2 allocs/op`
- `407.8 ns/op`, `48 B/op`, `2 allocs/op`
- `417.8 ns/op`, `48 B/op`, `2 allocs/op`
- `407.3 ns/op`, `48 B/op`, `2 allocs/op`
- `412.4 ns/op`, `48 B/op`, `2 allocs/op`

## Tests
- `go test ./TreeDB/collections -run 'TestSnapshotUpdateBatchBufferedReadPrimaryRunIndexAvoidsCollectingPendingRuns|TestSnapshotUpdateBatchBufferedReadCachesEmptyPrimaryRunIndex' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/mongo_gateway_bench -count=1`
- `git diff --check`

Part of #1159.
