### PR TITLE
Avoid closure allocation for collection mutation locks

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1357,7 +1357,7 @@ func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain)
 	}
 	collection := &Collection{db: db, writeDomain: domain}
 	unlockMutation := lockCollectionDomainMutation(domain)
-	defer unlockMutation()
+	defer unlockMutation.Unlock()
 	domain.waitIndexedAsyncFlush()
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
@@ -1402,26 +1402,37 @@ func (c *Collection) scheduleIndexedAsyncFlush(domain *collectionWriteDomain) bo
 	return true
 }
 
-func (c *Collection) lockMutation() func() {
+func (c *Collection) lockMutation() collectionMutationUnlock {
 	if c == nil || c.writeDomain == nil {
-		return func() {}
+		return collectionMutationUnlock{}
 	}
 	return lockCollectionDomainMutation(c.writeDomain)
 }
 
-func lockCollectionDomainMutation(domain *collectionWriteDomain) func() {
+type collectionMutationUnlock struct {
+	domain    *collectionWriteDomain
+	holdStart time.Time
+	wait      time.Duration
+}
+
+func lockCollectionDomainMutation(domain *collectionWriteDomain) collectionMutationUnlock {
 	if domain == nil {
-		return func() {}
+		return collectionMutationUnlock{}
 	}
 	lockStart := time.Now()
 	domain.mutationMu.Lock()
 	holdStart := time.Now()
 	wait := holdStart.Sub(lockStart)
-	return func() {
-		hold := time.Since(holdStart)
-		domain.mutationMu.Unlock()
-		domain.observeMutationLock(wait, hold)
+	return collectionMutationUnlock{domain: domain, holdStart: holdStart, wait: wait}
+}
+
+func (unlock collectionMutationUnlock) Unlock() {
+	if unlock.domain == nil {
+		return
 	}
+	hold := time.Since(unlock.holdStart)
+	unlock.domain.mutationMu.Unlock()
+	unlock.domain.observeMutationLock(unlock.wait, hold)
 }
 
 func (m *CollectionManager) CreateCollection(meta *CollectionMeta) (*CollectionMeta, error) {
@@ -1659,7 +1670,7 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 		return nil, errCollectionDBNil
 	}
 	unlockMutation := c.lockMutation()
-	defer unlockMutation()
+	defer unlockMutation.Unlock()
 	if err := c.flushBufferedWrites(); err != nil {
 		return nil, err
 	}
@@ -1780,7 +1791,7 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 		return nil, errCollectionDBNil
 	}
 	unlockMutation := c.lockMutation()
-	defer unlockMutation()
+	defer unlockMutation.Unlock()
 	if err := c.flushBufferedWrites(); err != nil {
 		return nil, err
 	}
@@ -1889,7 +1900,7 @@ func (c *Collection) Flush() error {
 	}
 	if c.writeDomain != nil {
 		unlockMutation := c.lockMutation()
-		defer unlockMutation()
+		defer unlockMutation.Unlock()
 		c.writeDomain.waitIndexedAsyncFlush()
 		return c.flushBufferedWrites()
 	}
@@ -4407,7 +4418,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	mutationLocked := true
 	unlockIfLocked := func() {
 		if mutationLocked {
-			unlockMutation()
+			unlockMutation.Unlock()
 			mutationLocked = false
 		}
 	}
@@ -4645,7 +4656,7 @@ type insertBatchValidationContext struct {
 
 func (c *Collection) lockAndValidateInsertBatchPlan(
 	mutationLocked *bool,
-	unlockMutation *func(),
+	unlockMutation *collectionMutationUnlock,
 	snap *backenddb.Snapshot,
 	catalog *collectionCatalog,
 	meta CollectionMeta,
@@ -4887,7 +4898,7 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 		return false, errors.New("collections: document id cannot be empty")
 	}
 	unlockMutation := c.lockMutation()
-	defer unlockMutation()
+	defer unlockMutation.Unlock()
 	if err := c.flushBufferedWrites(); err != nil {
 		return false, err
 	}
@@ -5085,7 +5096,7 @@ func validateCollectionUpdateInput(c *Collection, documentID []byte, update func
 
 func (c *Collection) updateDirect(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
 	unlockMutation := c.lockMutation()
-	defer unlockMutation()
+	defer unlockMutation.Unlock()
 	if err := c.flushBufferedWrites(); err != nil {
 		return false, false, err
 	}
@@ -6516,7 +6527,7 @@ func (c *Collection) bufferedUpdateBatchPlanStillCurrent(plan *updateBatchPlan) 
 
 func (c *Collection) withMutationLock(fn func() error) error {
 	unlockMutation := c.lockMutation()
-	defer unlockMutation()
+	defer unlockMutation.Unlock()
 	return fn()
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6683,12 +6683,12 @@ func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta C
 		if allowPrimaryRunIndexBuild && domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, bufferedCollectionName) {
 			return updateBatchBufferedRead{}, nil, false, true, nil
 		}
-		primaryRuns := pendingIndexedRootRunsLocked(domain, collectionPrimaryRootName(bufferedCollectionName))
 		var primaryEntries []updateBatchBufferedEntry
 		var err error
 		if domain.primaryRunIndex != nil {
 			primaryEntries, err = snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(domain.primaryRunIndex, items)
 		} else {
+			primaryRuns := pendingIndexedRootRunsLocked(domain, collectionPrimaryRootName(bufferedCollectionName))
 			primaryEntries, err = snapshotUpdateBatchBufferedPrimaryEntries(primaryRuns, items)
 		}
 		if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -6975,6 +6975,115 @@ func TestSnapshotUpdateBatchBufferedReadCachesEmptyPrimaryRunIndex(t *testing.T)
 	}
 }
 
+func TestSnapshotUpdateBatchBufferedReadPrimaryRunIndexAvoidsCollectingPendingRuns(t *testing.T) {
+	meta := CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city", ValueType: IndexValueString}},
+	}
+	primaryName := collectionPrimaryRootName("users")
+	primaryTable := newCollectionRunTable(1)
+	setCollectionRunValue(primaryTable, []byte("u1"), []byte(`{"city":"paris"}`))
+	primaryTable.Freeze()
+	defer resetCollectionRunTable(primaryTable)
+
+	primaryIndex := newBufferedPrimaryRunIndex(1)
+	if err := addBufferedPrimaryRunIndexEntries(primaryIndex, primaryTable); err != nil {
+		t.Fatalf("add primary run index entries: %v", err)
+	}
+	domain := &collectionWriteDomain{
+		loaded:         true,
+		meta:           meta,
+		catalog:        &collectionCatalog{meta: meta},
+		baseSystemRoot: 7,
+		count:          1,
+		rootRuns: map[string][]memtable.Table{
+			primaryName: {primaryTable},
+		},
+		primaryRunIndex: primaryIndex,
+	}
+	for i := 0; i < 256; i++ {
+		domain.indexedFlushUnits = append(domain.indexedFlushUnits, indexedFlushUnit{
+			rootRuns: map[string][]memtable.Table{
+				primaryName: make([]memtable.Table, 8),
+			},
+			rootRunCount: 8,
+		})
+	}
+	items := []UpdateBatchItem{{DocumentID: []byte("u1")}}
+	assertRead := func() {
+		t.Helper()
+		read, _, blocked, needPrimaryRunIndex, err := snapshotUpdateBatchBufferedReadLocked(domain, meta, 7, items, DocumentFormatJSON, false)
+		if err != nil {
+			t.Fatalf("snapshotUpdateBatchBufferedReadLocked: %v", err)
+		}
+		if blocked || needPrimaryRunIndex || !read.enabled {
+			t.Fatalf("read enabled=%v blocked=%v needPrimaryRunIndex=%v", read.enabled, blocked, needPrimaryRunIndex)
+		}
+		if len(read.primaryEntries) != 1 || !read.primaryEntries[0].found || !bytes.Equal(read.primaryEntries[0].value, []byte(`{"city":"paris"}`)) {
+			t.Fatalf("primary entries=%+v want buffered u1 document", read.primaryEntries)
+		}
+	}
+	assertRead()
+
+	if allocs := testing.AllocsPerRun(100, assertRead); allocs > 2 {
+		t.Fatalf("buffered read allocations/run=%0.1f want <= 2; primary-run index path should not collect pending root runs", allocs)
+	}
+}
+
+func BenchmarkSnapshotUpdateBatchBufferedReadPrimaryRunIndexPendingUnits(b *testing.B) {
+	meta := CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city", ValueType: IndexValueString}},
+	}
+	primaryName := collectionPrimaryRootName("users")
+	primaryTable := newCollectionRunTable(1)
+	setCollectionRunValue(primaryTable, []byte("u1"), []byte(`{"city":"paris"}`))
+	primaryTable.Freeze()
+	defer resetCollectionRunTable(primaryTable)
+
+	primaryIndex := newBufferedPrimaryRunIndex(1)
+	if err := addBufferedPrimaryRunIndexEntries(primaryIndex, primaryTable); err != nil {
+		b.Fatalf("add primary run index entries: %v", err)
+	}
+	domain := &collectionWriteDomain{
+		loaded:         true,
+		meta:           meta,
+		catalog:        &collectionCatalog{meta: meta},
+		baseSystemRoot: 7,
+		count:          1,
+		rootRuns: map[string][]memtable.Table{
+			primaryName: {primaryTable},
+		},
+		primaryRunIndex: primaryIndex,
+	}
+	for i := 0; i < 256; i++ {
+		domain.indexedFlushUnits = append(domain.indexedFlushUnits, indexedFlushUnit{
+			rootRuns: map[string][]memtable.Table{
+				primaryName: make([]memtable.Table, 8),
+			},
+			rootRunCount: 8,
+		})
+	}
+	items := []UpdateBatchItem{{DocumentID: []byte("u1")}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		read, _, blocked, needPrimaryRunIndex, err := snapshotUpdateBatchBufferedReadLocked(domain, meta, 7, items, DocumentFormatJSON, false)
+		if err != nil {
+			b.Fatalf("snapshotUpdateBatchBufferedReadLocked: %v", err)
+		}
+		if blocked || needPrimaryRunIndex || !read.enabled || len(read.primaryEntries) != 1 || !read.primaryEntries[0].found {
+			b.Fatalf("unexpected read enabled=%v entries=%d blocked=%v needPrimaryRunIndex=%v", read.enabled, len(read.primaryEntries), blocked, needPrimaryRunIndex)
+		}
+	}
+}
+
 func collectionHasBufferedPrimaryRunIndexForTest(t *testing.T, col *Collection) bool {
 	t.Helper()
 	col.writeDomain.mu.RLock()

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -5012,12 +5012,12 @@ func TestCollectionLockAndValidateInsertBatchPlanAllowsDisjointRootDrift(t *test
 	}
 
 	mutationLocked := false
-	unlockMutation := func() {}
+	var unlockMutation collectionMutationUnlock
 	pin, currentCatalog, _, _, err := col.lockAndValidateInsertBatchPlan(&mutationLocked, &unlockMutation, nil, catalog, meta, rootNames, baseRootIDs, plan)
 	if err != nil {
 		t.Fatalf("validate disjoint root drift: %v", err)
 	}
-	defer unlockMutation()
+	defer unlockMutation.Unlock()
 	defer func() { _ = pin.Close() }()
 	currentPrimaryRoot := currentCatalog.rootID(collectionPrimaryRootName("users"))
 	if currentPrimaryRoot == oldPrimaryRoot {
@@ -7081,6 +7081,20 @@ func BenchmarkSnapshotUpdateBatchBufferedReadPrimaryRunIndexPendingUnits(b *test
 		if blocked || needPrimaryRunIndex || !read.enabled || len(read.primaryEntries) != 1 || !read.primaryEntries[0].found {
 			b.Fatalf("unexpected read enabled=%v entries=%d blocked=%v needPrimaryRunIndex=%v", read.enabled, len(read.primaryEntries), blocked, needPrimaryRunIndex)
 		}
+	}
+}
+
+func TestLockCollectionDomainMutationDoesNotAllocate(t *testing.T) {
+	domain := &collectionWriteDomain{}
+	allocs := testing.AllocsPerRun(1000, func() {
+		unlock := lockCollectionDomainMutation(domain)
+		unlock.Unlock()
+	})
+	if allocs != 0 {
+		t.Fatalf("lockCollectionDomainMutation allocations/run=%0.1f want 0", allocs)
+	}
+	if got := domain.mutationLockCalls.Load(); got == 0 {
+		t.Fatal("mutation lock stats were not recorded")
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the collection mutation-lock unlock closure with a small typed unlock token
- preserve wait/hold timing and mutation-lock counters
- add a regression test that `lockCollectionDomainMutation` remains allocation-free

## Why
The #1159 two-index BSON update profile still showed `lockCollectionDomainMutation` as an allocation-object hotspot after #1170. The helper returned a closure for every mutation, which is unnecessary in a write hot path.

## Benchmarks / profiles
Same profile command used in #1170:
```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1159_lock_token_after_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

#1170 baseline from the previous profile:
- `949586` iterations, `11938 ns/op`, `83766 docs/sec`, `1257 B/op`, `7 allocs/op`
- `lockCollectionDomainMutation`: `393234` allocated objects in alloc_objects profile

After this PR:
- `977728` iterations, `11551 ns/op`, `86574 docs/sec`, `1264 B/op`, `6 allocs/op`
- `lockCollectionDomainMutation`: no longer appears in alloc_objects profile (`go tool pprof -alloc_objects -list=lockCollectionDomainMutation` reports no match)

Focused benchmark from #1170 remains stable:
```bash
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkSnapshotUpdateBatchBufferedReadPrimaryRunIndexPendingUnits$' -benchmem -count=3
```
- `415.3 ns/op`, `48 B/op`, `2 allocs/op`
- `406.2 ns/op`, `48 B/op`, `2 allocs/op`
- `405.0 ns/op`, `48 B/op`, `2 allocs/op`

## Tests
- `go test ./TreeDB/collections -run 'TestLockCollectionDomainMutationDoesNotAllocate|TestCollectionLockAndValidateInsertBatchPlanAllowsDisjointRootDrift|TestSnapshotUpdateBatchBufferedReadPrimaryRunIndexAvoidsCollectingPendingRuns' -count=1`
- `go test ./TreeDB/collections -run '^$' -bench '^BenchmarkSnapshotUpdateBatchBufferedReadPrimaryRunIndexPendingUnits$' -benchmem -count=3`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/mongo_gateway_bench -count=1`
- `git diff --check`

Stacked on #1170. Part of #1159.
