### PR TITLE
Pool buffered update read entries

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6377,6 +6377,36 @@ type updateBatchBufferedEntry struct {
 	found bool
 }
 
+var updateBatchBufferedEntryPool sync.Pool
+
+const updateBatchBufferedEntryPoolMaxCap = 1 << 15
+
+func getUpdateBatchBufferedEntries(count int) []updateBatchBufferedEntry {
+	if count <= 0 {
+		return nil
+	}
+	if count > updateBatchBufferedEntryPoolMaxCap {
+		return make([]updateBatchBufferedEntry, count)
+	}
+	if v := updateBatchBufferedEntryPool.Get(); v != nil {
+		if entries, ok := v.([]updateBatchBufferedEntry); ok && cap(entries) >= count {
+			out := entries[:count]
+			clear(out)
+			return out
+		}
+	}
+	return make([]updateBatchBufferedEntry, count)
+}
+
+func putUpdateBatchBufferedEntries(entries []updateBatchBufferedEntry) {
+	if entries == nil || cap(entries) == 0 || cap(entries) > updateBatchBufferedEntryPoolMaxCap {
+		return
+	}
+	full := entries[:cap(entries)]
+	clear(full)
+	updateBatchBufferedEntryPool.Put(full[:0])
+}
+
 type updateBatchCurrentDocument struct {
 	value    []byte
 	buffered bool
@@ -6616,7 +6646,7 @@ func readUpdateBatchCurrentDocument(snap *backenddb.Snapshot, primaryRoot uint64
 const updateBatchBufferedPrimaryDirectProbeLimit = 1024
 
 func snapshotUpdateBatchBufferedPrimaryEntries(runs []memtable.Table, items []UpdateBatchItem) ([]updateBatchBufferedEntry, error) {
-	entries := make([]updateBatchBufferedEntry, len(items))
+	entries := getUpdateBatchBufferedEntries(len(items))
 	if len(runs) == 0 || len(items) == 0 {
 		return entries, nil
 	}
@@ -6665,7 +6695,7 @@ func snapshotUpdateBatchBufferedPrimaryEntries(runs []memtable.Table, items []Up
 }
 
 func snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(index *bufferedPrimaryRunIndex, items []UpdateBatchItem) ([]updateBatchBufferedEntry, error) {
-	entries := make([]updateBatchBufferedEntry, len(items))
+	entries := getUpdateBatchBufferedEntries(len(items))
 	if index == nil || len(items) == 0 {
 		return entries, nil
 	}
@@ -6799,6 +6829,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			_ = snap.Close()
 			return nil, err
 		}
+		defer putUpdateBatchBufferedEntries(bufferedRead.primaryEntries)
 		if len(bufferedTemplateRuns) > 0 {
 			plannerOptions = collectionOptionsWithBufferedTemplateV1RunsResolver(plannerOptions, bufferedTemplateRuns)
 		}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -5820,6 +5820,26 @@ func TestCollectionUpdateCombinerDocumentIDLongStorageClonesCallerBytes(t *testi
 	}
 }
 
+func TestUpdateBatchBufferedEntryPoolClearsEntries(t *testing.T) {
+	updateBatchBufferedEntryPool = sync.Pool{}
+
+	entries := getUpdateBatchBufferedEntries(2)
+	entries[0] = updateBatchBufferedEntry{
+		value: []byte("current"),
+		flags: node.FlagTombstone,
+		found: true,
+	}
+	putUpdateBatchBufferedEntries(entries)
+
+	reused := getUpdateBatchBufferedEntries(2)
+	defer putUpdateBatchBufferedEntries(reused)
+	for i, entry := range reused {
+		if entry.value != nil || entry.flags != 0 || entry.found {
+			t.Fatalf("entry %d not cleared after pool reuse: %+v", i, entry)
+		}
+	}
+}
+
 func TestCollectionUpdateCombinerCloseRequestsAllowsNilRequests(t *testing.T) {
 	combiner := &collectionUpdateCombiner{}
 	if !combiner.closeRequests() {


### PR DESCRIPTION
## Summary
- pool the small `[]updateBatchBufferedEntry` slices used while update planning reads pending buffered primary entries
- return the buffered-read entry scratch at the end of `buildUpdateBatchPlan`
- clear pooled entries on return so cloned current-document values are not retained
- add a focused pool-clearing regression test

## Why
After #1174, the focused #1159 allocation profile still showed `snapshotUpdateBatchBufferedPrimaryEntriesFromIndex` as a per-update-batch allocation source. These slices are short-lived planning scratch and can be reused without changing ownership semantics for the cloned buffered values.

## Benchmarks / profiles
Focused profile command:
```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1159_buffered_entries_profile_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \\\n  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \\\n  -benchtime=5s \\\n  -benchmem \\\n  -count=1 \\\n  -memprofile "$PROFILE_DIR/mem.pprof"\n```\n\nRepresentative result:\n- `11798 ns/op`, `84761 docs/sec`, `1016 B/op`, `4 allocs/op`\n- `backend_vlog_mmap_hit_ratio=1.000`, `backend_vlog_mmap_fallback_readat/doc=0`\n- `snapshotUpdateBatchBufferedPrimaryEntriesFromIndex` no longer appears as an allocation-object source in the profile.\n\nThis is a targeted allocation-source cleanup rather than a headline throughput claim; the run is noisy and still bounded by document generation, ownership copies, memtable append/storage, and publish work.\n\n## Tests\n- `go test ./TreeDB/collections -run '^TestUpdateBatchBufferedEntryPoolClearsEntries$' -count=1`\n- `go test ./TreeDB/collections -run '^TestCollectionUpdateCombinerDocumentID(InlineStorageDoesNotAllocate|LongStorageClonesCallerBytes)$' -count=1`\n- `go test ./TreeDB/collections -count=1`\n- `git diff --check`\n\nStacked on #1174. Part of #1159.