### PR TITLE
Prebuild indexed collection root publish deltas

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3867,12 +3867,16 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 
 func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootBaseIDs map[string]uint64, rootPolicies map[string]backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
 	ordered := make([]backenddb.OrderedRootDeltaBatchPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
 	cleanup := func() {
 		for idx := range ordered {
 			if ordered[idx].Delta != nil {
 				_ = ordered[idx].Delta.Close()
 				ordered[idx].Delta = nil
 			}
+		}
+		for _, it := range iterators {
+			_ = it.Close()
 		}
 	}
 	for _, rootName := range rootNames {
@@ -3882,11 +3886,8 @@ func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[s
 			return nil, func() {}, fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
 		}
 		iter := newBufferedRootRunsIteratorWithDeleted(rootRuns[rootName], nil, nil, true)
+		iterators = append(iterators, iter)
 		delta, err := backenddb.OrderedRootDeltaBatchFromIterator(iter)
-		closeErr := iter.Close()
-		if err == nil {
-			err = closeErr
-		}
 		if err != nil {
 			cleanup()
 			return nil, func() {}, err

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3845,32 +3845,59 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 			_ = work.pin.Close()
 		}
 	}()
-	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(work.rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(work.rootNames))
-	for _, rootName := range work.rootNames {
-		iter := newBufferedRootRunsIteratorWithDeleted(work.flushUnit.rootRuns[rootName], nil, nil, true)
-		iterators = append(iterators, iter)
-		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      work.rootBaseIDs[rootName],
-			Iter:          iter,
-			StoragePolicy: work.flushUnit.rootPolicies[rootName],
-		})
+	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
+	if err != nil {
+		return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
 	}
 	publishStart := time.Now()
-	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, rootIDs)
 	})
-	for _, it := range iterators {
-		_ = it.Close()
-	}
+	publishElapsed := time.Since(publishStart)
+	cleanupDeltas()
 	if publishErr == nil && len(rootIDs) != len(work.rootNames) {
 		publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
 	}
-	completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, time.Since(publishStart))
+	completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, publishElapsed)
 	if publishErr != nil {
 		return publishErr
 	}
 	return completeErr
+}
+
+func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootBaseIDs map[string]uint64, rootPolicies map[string]backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
+	ordered := make([]backenddb.OrderedRootDeltaBatchPublishInput, 0, len(rootNames))
+	cleanup := func() {
+		for idx := range ordered {
+			if ordered[idx].Delta != nil {
+				_ = ordered[idx].Delta.Close()
+				ordered[idx].Delta = nil
+			}
+		}
+	}
+	for _, rootName := range rootNames {
+		baseRoot, ok := rootBaseIDs[rootName]
+		if !ok {
+			cleanup()
+			return nil, func() {}, fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
+		}
+		iter := newBufferedRootRunsIteratorWithDeleted(rootRuns[rootName], nil, nil, true)
+		delta, err := backenddb.OrderedRootDeltaBatchFromIterator(iter)
+		closeErr := iter.Close()
+		if err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			cleanup()
+			return nil, func() {}, err
+		}
+		ordered = append(ordered, backenddb.OrderedRootDeltaBatchPublishInput{
+			BaseRoot:      baseRoot,
+			Delta:         delta,
+			StoragePolicy: rootPolicies[rootName],
+		})
+	}
+	return ordered, cleanup, nil
 }
 
 func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork, newSystemRoot uint64, rootIDs []uint64, publishErr error, elapsed time.Duration) error {
@@ -3983,31 +4010,21 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
 	baseRootIDs := make(map[string]uint64, len(rootNames))
-	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
 	for _, rootName := range rootNames {
-		iter := newBufferedRootRunsIteratorWithDeleted(flushUnit.rootRuns[rootName], nil, nil, true)
-		iterators = append(iterators, iter)
 		baseRoot, ok := flushUnit.rootBaseIDs[rootName]
 		if !ok {
-			for _, it := range iterators {
-				_ = it.Close()
-			}
 			return fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
 		}
 		baseRootIDs[rootName] = baseRoot
-		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      baseRoot,
-			Iter:          iter,
-			StoragePolicy: flushUnit.rootPolicies[rootName],
-		})
 	}
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
+	if err != nil {
+		return err
+	}
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
-	for _, it := range iterators {
-		_ = it.Close()
-	}
+	cleanupDeltas()
 	if err != nil {
 		return err
 	}

--- a/TreeDB/db/closed_db_public_methods_test.go
+++ b/TreeDB/db/closed_db_public_methods_test.go
@@ -349,6 +349,27 @@ func TestClosedDB_PublishOrderedRootDeltaGroupWithSystemBuilder(t *testing.T) {
 	})
 }
 
+func TestClosedDB_PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(t *testing.T) {
+	runClosedDBMethod(t, "PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder", func(d *DB) {
+		table := mustFrozenSystemMemtable(t, "root/k", "v")
+		iter := table.NewIterator(nil, nil)
+		delta, err := OrderedRootDeltaBatchFromIterator(iter)
+		_ = iter.Close()
+		if err != nil {
+			t.Fatalf("OrderedRootDeltaBatchFromIterator: %v", err)
+		}
+		defer func() { _ = delta.Close() }()
+		_, _, err = d.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+			Delta: delta,
+		}}, func([]uint64) (iterator.UnsafeIterator, error) {
+			return mustFrozenSystemMemtable(t, "sys/k", "v").NewIterator(nil, nil), nil
+		})
+		if !errors.Is(err, ErrClosed) {
+			t.Fatalf("PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder err=%v want %v", err, ErrClosed)
+		}
+	})
+}
+
 func TestClosedDB_Stats(t *testing.T) {
 	runClosedDBMethod(t, "Stats", func(d *DB) {
 		_ = d.Stats()

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -3,6 +3,7 @@ package db
 import (
 	"bytes"
 	"errors"
+	"sort"
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
@@ -81,6 +82,16 @@ type OrderedRootPublishInput struct {
 type OrderedRootDeltaPublishInput struct {
 	BaseRoot      uint64
 	Iter          iterator.UnsafeIterator
+	StoragePolicy OrderedRootStoragePolicy
+}
+
+// OrderedRootDeltaBatchPublishInput describes a sorted root-local mutation
+// batch whose iterator materialization has already been done by the caller.
+// Callers retain ownership of Delta and must keep any borrowed key/value views
+// immutable until the publish call returns.
+type OrderedRootDeltaBatchPublishInput struct {
+	BaseRoot      uint64
+	Delta         *batch.Batch
 	StoragePolicy OrderedRootStoragePolicy
 }
 
@@ -324,6 +335,9 @@ func orderedRootBatchPut(delta *batch.Batch, iter iterator.UnsafeIterator, borro
 }
 
 func orderedRootDeltaBatchFromIterator(iter iterator.UnsafeIterator) (*batch.Batch, error) {
+	if iter == nil {
+		return nil, errors.New("nil ordered root delta iterator")
+	}
 	delta := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
 	if hint, ok := iter.(orderedRootLenHintIterator); ok {
 		delta.Reserve(hint.Len())
@@ -355,6 +369,134 @@ func orderedRootDeltaBatchFromIterator(iter iterator.UnsafeIterator) (*batch.Bat
 		return nil, err
 	}
 	return delta, nil
+}
+
+// OrderedRootDeltaBatchFromIterator materializes a root-local mutation iterator
+// into the same transient batch shape used by ordered-root delta publishing.
+// It does not close iter.
+func OrderedRootDeltaBatchFromIterator(iter iterator.UnsafeIterator) (*batch.Batch, error) {
+	return orderedRootDeltaBatchFromIterator(iter)
+}
+
+type orderedRootDeltaBatchIterator struct {
+	entries        []batch.Entry
+	idx            int
+	includeDeleted bool
+}
+
+func newOrderedRootDeltaBatchIterator(delta *batch.Batch, includeDeleted bool) *orderedRootDeltaBatchIterator {
+	it := &orderedRootDeltaBatchIterator{includeDeleted: includeDeleted}
+	if delta != nil {
+		it.entries = delta.SortedEntries()
+	}
+	it.skipDeleted()
+	return it
+}
+
+func (it *orderedRootDeltaBatchIterator) Valid() bool {
+	return it != nil && it.idx < len(it.entries)
+}
+
+func (it *orderedRootDeltaBatchIterator) Next() {
+	if !it.Valid() {
+		return
+	}
+	it.idx++
+	it.skipDeleted()
+}
+
+func (it *orderedRootDeltaBatchIterator) Seek(key []byte) {
+	if it == nil {
+		return
+	}
+	it.idx = sort.Search(len(it.entries), func(i int) bool {
+		return bytes.Compare(it.entries[i].Key, key) >= 0
+	})
+	it.skipDeleted()
+}
+
+func (it *orderedRootDeltaBatchIterator) UnsafeKey() []byte {
+	if !it.Valid() {
+		return nil
+	}
+	return it.entries[it.idx].Key
+}
+
+func (it *orderedRootDeltaBatchIterator) UnsafeValue() []byte {
+	if !it.Valid() || it.entries[it.idx].Type == batch.OpDelete {
+		return nil
+	}
+	return it.entries[it.idx].Value
+}
+
+func (it *orderedRootDeltaBatchIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	if !it.Valid() {
+		return nil, page.ValuePtr{}, node.FlagInline
+	}
+	entry := it.entries[it.idx]
+	if entry.Type == batch.OpDelete {
+		return nil, page.ValuePtr{}, node.FlagTombstone
+	}
+	if entry.IsPtr {
+		return entry.Value, entry.ValuePtr, node.FlagPointer
+	}
+	return entry.Value, page.ValuePtr{}, node.FlagInline
+}
+
+func (it *orderedRootDeltaBatchIterator) Key() []byte {
+	return it.UnsafeKey()
+}
+
+func (it *orderedRootDeltaBatchIterator) Value() []byte {
+	return it.UnsafeValue()
+}
+
+func (it *orderedRootDeltaBatchIterator) KeyCopy(dst []byte) []byte {
+	return append(dst[:0], it.UnsafeKey()...)
+}
+
+func (it *orderedRootDeltaBatchIterator) ValueCopy(dst []byte) []byte {
+	return append(dst[:0], it.UnsafeValue()...)
+}
+
+func (it *orderedRootDeltaBatchIterator) IsDeleted() bool {
+	return it.Valid() && it.entries[it.idx].Type == batch.OpDelete
+}
+
+func (it *orderedRootDeltaBatchIterator) Error() error {
+	return nil
+}
+
+func (it *orderedRootDeltaBatchIterator) Close() error {
+	if it != nil {
+		it.entries = nil
+		it.idx = 0
+	}
+	return nil
+}
+
+func (it *orderedRootDeltaBatchIterator) Domain() (start, end []byte) {
+	return nil, nil
+}
+
+func (it *orderedRootDeltaBatchIterator) StableUnsafeIteratorSlices() bool {
+	return true
+}
+
+func (it *orderedRootDeltaBatchIterator) Len() int {
+	if it == nil {
+		return 0
+	}
+	return len(it.entries) - it.idx
+}
+
+func (it *orderedRootDeltaBatchIterator) skipDeleted() {
+	if it == nil || it.includeDeleted {
+		return
+	}
+	for it.idx < len(it.entries) && it.entries[it.idx].Type == batch.OpDelete {
+		it.idx++
+	}
 }
 
 func collectValueLogRefDeltaFromIterator(iter iterator.UnsafeIterator) (*valueLogRefDelta, error) {
@@ -407,6 +549,45 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 	defer delta.Close()
 	if len(delta.SortedEntries()) == 0 {
 		return baseRoot, nil, metrics, nil
+	}
+	rootZipper, err := db.orderedRootZipperForOptions(idx, opts)
+	if err != nil {
+		return 0, nil, metrics, err
+	}
+	newRoot, retired, metrics, err = rootZipper.Apply(baseRoot, delta)
+	return
+}
+
+func (db *DB) publishOrderedRootDeltaBatch(baseRoot uint64, delta *batch.Batch, opts orderedRootPublishOptions) (newRoot uint64, retired []uint64, metrics adaptive.Metrics, err error) {
+	if db == nil {
+		err = ErrClosed
+		return
+	}
+	if delta == nil {
+		err = errors.New("nil ordered root delta batch")
+		return
+	}
+	if opts.outerLeavesInValueLog && opts.leafPageLog == nil {
+		err = errors.New("ordered root value-log leaf storage requires a leaf page log")
+		return
+	}
+	if len(delta.SortedEntries()) == 0 {
+		return baseRoot, nil, metrics, nil
+	}
+	if baseRoot == 0 {
+		iter := newOrderedRootDeltaBatchIterator(delta, false)
+		if !iter.Valid() {
+			_ = iter.Close()
+			return 0, nil, metrics, nil
+		}
+		newRoot, retired, metrics, _, _, err = db.publishOrderedRootIterator(0, iter, opts, false)
+		return
+	}
+
+	idx := db.idx.Load()
+	if idx == nil {
+		err = errors.New("missing index")
+		return
 	}
 	rootZipper, err := db.orderedRootZipperForOptions(idx, opts)
 	if err != nil {
@@ -932,6 +1113,22 @@ func (db *DB) PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ord
 	return db.publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, preflight, buildSystemDeltaIter)
 }
 
+// PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder is like
+// PublishOrderedRootDeltaGroupWithSystemDeltaBuilder, but the root-local
+// mutation batches have already been materialized by the caller. This lets
+// collection flush paths do iterator-to-batch work before entering the DB write
+// critical section.
+func (db *DB) PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered []OrderedRootDeltaBatchPublishInput, buildSystemDeltaIter OrderedRootGroupSystemBuilder) (uint64, []uint64, error) {
+	return db.publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, nil, buildSystemDeltaIter)
+}
+
+// PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder is like
+// PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder, but runs preflight
+// under the DB write lock before applying root-local deltas.
+func (db *DB) PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered []OrderedRootDeltaBatchPublishInput, preflight OrderedRootGroupPreflight, buildSystemDeltaIter OrderedRootGroupSystemBuilder) (uint64, []uint64, error) {
+	return db.publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, preflight, buildSystemDeltaIter)
+}
+
 func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []OrderedRootDeltaPublishInput, preflight OrderedRootGroupPreflight, buildSystemDeltaIter OrderedRootGroupSystemBuilder) (newSystemRoot uint64, rootIDs []uint64, err error) {
 	if buildSystemDeltaIter == nil {
 		return 0, nil, errors.New("nil ordered root group system delta builder")
@@ -1023,6 +1220,102 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 	// The system root was applied as a delta, so we do not have an exact
 	// value-log ref delta for system-root pointer changes. Passing nil keeps the
 	// tracker conservative by invalidating it after commit.
+	var vlogRefDelta *valueLogRefDelta
+	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil); err != nil {
+		return 0, nil, err
+	}
+	return newSystemRoot, rootIDs, nil
+}
+
+func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered []OrderedRootDeltaBatchPublishInput, preflight OrderedRootGroupPreflight, buildSystemDeltaIter OrderedRootGroupSystemBuilder) (newSystemRoot uint64, rootIDs []uint64, err error) {
+	if buildSystemDeltaIter == nil {
+		return 0, nil, errors.New("nil ordered root group system delta builder")
+	}
+	if db == nil {
+		return 0, nil, ErrClosed
+	}
+	if db.closing.Load() {
+		return 0, nil, ErrClosed
+	}
+
+	lockStart := time.Now()
+	db.writeMu.Lock()
+	holdStart := time.Now()
+	wait := holdStart.Sub(lockStart)
+	rootsObserved := 0
+	finished := false
+	finishPublish := func() {
+		if finished {
+			return
+		}
+		finished = true
+		hold := time.Since(holdStart)
+		db.writeMu.Unlock()
+		db.observeOrderedRootDeltaGroupPublish(wait, hold, rootsObserved, err)
+	}
+	defer finishPublish()
+
+	if db.readOnly {
+		err = ErrReadOnly
+		return 0, nil, err
+	}
+
+	db.mu.RLock()
+	userRoot := db.meta.UserRootPageID
+	baseSystemRoot := db.meta.SystemRootPageID
+	db.mu.RUnlock()
+	if preflight != nil {
+		if err = preflight(); err != nil {
+			return 0, nil, err
+		}
+	}
+
+	rootIDs = make([]uint64, len(ordered))
+	systemOpts := systemRootOrderedPublishOptions(db)
+	var retired []uint64
+	var merged adaptive.Metrics
+	for idx := range ordered {
+		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[idx].StoragePolicy)
+		if err != nil {
+			return 0, nil, err
+		}
+		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaBatch(ordered[idx].BaseRoot, ordered[idx].Delta, opts)
+		if err != nil {
+			return 0, nil, err
+		}
+		rootIDs[idx] = rootID
+		rootsObserved++
+		retired = append(retired, rootRetired...)
+		mergeOrderedRootPublishMetrics(&merged, metrics)
+	}
+
+	iter, err := buildSystemDeltaIter(append([]uint64(nil), rootIDs...))
+	if err != nil {
+		return 0, nil, err
+	}
+	if iter == nil {
+		return 0, nil, errors.New("nil system root delta iterator")
+	}
+	rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(baseSystemRoot, iter, systemOpts)
+	if err != nil {
+		return 0, nil, err
+	}
+	newSystemRoot = rootID
+	retired = append(retired, rootRetired...)
+	mergeOrderedRootPublishMetrics(&merged, metrics)
+
+	db.mu.RLock()
+	curUserRoot := db.meta.UserRootPageID
+	curSystemRoot := db.meta.SystemRootPageID
+	db.mu.RUnlock()
+	if curUserRoot != userRoot || curSystemRoot != baseSystemRoot {
+		return 0, nil, errors.New("concurrent modification detected during ordered root group publish")
+	}
+
+	// Batch-based grouped deltas have the same value-log reachability shape as
+	// iterator-based grouped deltas: non-system roots changed, and the system
+	// delta can change collection descriptors. Keep the incremental ref tracker
+	// conservative by invalidating it after commit.
 	var vlogRefDelta *valueLogRefDelta
 	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil); err != nil {
 		return 0, nil, err

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -487,6 +487,15 @@ func (it *orderedRootDeltaBatchIterator) Len() int {
 	if it == nil {
 		return 0
 	}
+	if !it.includeDeleted {
+		n := 0
+		for idx := it.idx; idx < len(it.entries); idx++ {
+			if it.entries[idx].Type != batch.OpDelete {
+				n++
+			}
+		}
+		return n
+	}
 	return len(it.entries) - it.idx
 }
 

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -875,6 +875,126 @@ func TestPublishOrderedRootDeltaGroupWithSystemBuilder_AppliesDeletes(t *testing
 	}
 }
 
+func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_PreservesOmittedBaseEntries(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t,
+		"root/a", "va",
+		"root/b", "vb",
+	).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+
+	deltaTable := mustFrozenSystemMemtable(t,
+		"root/b", "vb2",
+		"root/c", "vc",
+	)
+	iter := deltaTable.NewIterator(nil, nil)
+	delta, err := OrderedRootDeltaBatchFromIterator(iter)
+	_ = iter.Close()
+	if err != nil {
+		t.Fatalf("OrderedRootDeltaBatchFromIterator: %v", err)
+	}
+	defer func() { _ = delta.Close() }()
+
+	newSystemRoot, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+		BaseRoot: baseRoot,
+		Delta:    delta,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 || rootIDs[0] == 0 {
+			t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+		}
+		return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish delta batch group: %v", err)
+	}
+	if newSystemRoot == 0 || len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("newSystemRoot=%d rootIDs=%v", newSystemRoot, rootIDs)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	for key, want := range map[string]string{
+		"root/a": "va",
+		"root/b": "vb2",
+		"root/c": "vc",
+	} {
+		entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte(key))
+		if err != nil {
+			t.Fatalf("GetEntryAtRoot(%s): %v", key, err)
+		}
+		if got := string(entry.Value); got != want {
+			t.Fatalf("%s=%q want %q", key, got, want)
+		}
+	}
+}
+
+func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_AppliesDeletes(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t,
+		"root/a", "va",
+		"root/b", "vb",
+	).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root: %v", err)
+	}
+	deltaTable, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		t.Fatalf("new delta table: %v", err)
+	}
+	deltaTable.Delete([]byte("root/b"))
+	deltaTable.Freeze()
+	iter := deltaTable.NewIterator(nil, nil)
+	delta, err := OrderedRootDeltaBatchFromIterator(iter)
+	_ = iter.Close()
+	if err != nil {
+		t.Fatalf("OrderedRootDeltaBatchFromIterator: %v", err)
+	}
+	defer func() { _ = delta.Close() }()
+
+	_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+		BaseRoot: baseRoot,
+		Delta:    delta,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish delta batch group: %v", err)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte("root/a"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(root/a): %v", err)
+	}
+	if got, want := string(entry.Value), "va"; got != want {
+		t.Fatalf("root/a=%q want %q", got, want)
+	}
+	if _, err := snap.GetEntryAtRoot(rootIDs[0], []byte("root/b")); err == nil {
+		t.Fatal("root/b still exists after delta delete")
+	}
+}
+
 func TestPublishOrderedRootDeltaGroupWithSystemBuilder_AcceptsLargeDeltaValueLogLeafValue(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -1084,6 +1085,36 @@ func TestOrderedRootDeltaBatchFromIterator_StableIteratorUsesViews(t *testing.T)
 	}
 	if &entries[0].Value[0] != &value[0] {
 		t.Fatal("stable iterator value was copied into batch arena")
+	}
+}
+
+func TestOrderedRootDeltaBatchIteratorLenSkipsDeletedWhenHidden(t *testing.T) {
+	delta := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	if err := delta.Set([]byte("root/a"), []byte("va")); err != nil {
+		t.Fatalf("set root/a: %v", err)
+	}
+	if err := delta.Delete([]byte("root/b")); err != nil {
+		t.Fatalf("delete root/b: %v", err)
+	}
+	if err := delta.Set([]byte("root/c"), []byte("vc")); err != nil {
+		t.Fatalf("set root/c: %v", err)
+	}
+
+	withoutDeletes := newOrderedRootDeltaBatchIterator(delta, false)
+	defer func() { _ = withoutDeletes.Close() }()
+	if got := withoutDeletes.Len(); got != 2 {
+		t.Fatalf("Len without deletes=%d want 2", got)
+	}
+	withoutDeletes.Next()
+	if got := withoutDeletes.Len(); got != 1 {
+		t.Fatalf("Len after Next without deletes=%d want 1", got)
+	}
+
+	withDeletes := newOrderedRootDeltaBatchIterator(delta, true)
+	defer func() { _ = withDeletes.Close() }()
+	if got := withDeletes.Len(); got != 3 {
+		t.Fatalf("Len with deletes=%d want 3", got)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -579,7 +579,9 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	b.ReportMetric(float64(writers), "writers")
 	reportProfileBenchBufferedIndexedAsyncFlush(b, collection.Meta().Options)
 	reportCollectionManagerUpdateStats(b, deltaCollectionManagerUpdateStats(manager.StatsSnapshot(), statsBefore), b.N)
-	reportProfileBenchBackendVlogMmapStats(b, backend.Stats(), backendStatsBefore, b.N)
+	backendStatsAfter := backend.Stats()
+	reportProfileBenchOrderedRootPublishStats(b, backendStatsAfter, backendStatsBefore, b.N)
+	reportProfileBenchBackendVlogMmapStats(b, backendStatsAfter, backendStatsBefore, b.N)
 	reportDocsPerSecond(b, b.N, timedElapsed)
 }
 
@@ -648,6 +650,28 @@ func reportProfileBenchBackendVlogMmapStats(b *testing.B, after, before map[stri
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.vlog.mmap_sealed_bytes")), "backend_vlog_mmap_sealed_bytes")
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.vlog.mmap_active_segments")), "backend_vlog_mmap_active_segments")
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.vlog.mmap_active_bytes")), "backend_vlog_mmap_active_bytes")
+}
+
+func reportProfileBenchOrderedRootPublishStats(b *testing.B, after, before map[string]string, docs int) {
+	b.Helper()
+	if docs <= 0 {
+		return
+	}
+	const prefix = "treedb.publish.ordered_root_delta_group."
+	calls := profileBenchDeltaUintStat(after, before, prefix+"calls_total")
+	if calls == 0 {
+		return
+	}
+	roots := profileBenchDeltaUintStat(after, before, prefix+"roots_total")
+	holdNs := profileBenchDeltaUintStat(after, before, prefix+"write_lock_hold_ns_total")
+	waitNs := profileBenchDeltaUintStat(after, before, prefix+"write_lock_wait_ns_total")
+	b.ReportMetric(float64(calls), "publish_delta_group_calls")
+	b.ReportMetric(float64(calls)/float64(docs), "publish_delta_group_calls/doc")
+	b.ReportMetric(float64(roots)/float64(calls), "publish_delta_group_roots/call")
+	b.ReportMetric(float64(holdNs)/float64(docs), "publish_delta_group_lock_hold_ns/doc")
+	b.ReportMetric(float64(waitNs)/float64(docs), "publish_delta_group_lock_wait_ns/doc")
+	b.ReportMetric(float64(holdNs)/float64(calls), "publish_delta_group_lock_hold_ns/call")
+	b.ReportMetric(float64(waitNs)/float64(calls), "publish_delta_group_lock_wait_ns/call")
 }
 
 func deltaCollectionManagerUpdateStats(after, before collections.CollectionManagerStats) collections.CollectionManagerStats {


### PR DESCRIPTION
## Summary

Refs #1159.

This is a narrow #1132/#1159 publish-path step: indexed collection flushes now materialize root-local delta batches before entering the DB ordered-root publish critical section. The DB gets a batch-based ordered-root delta group API, and collection flushes use it for both async prepared flushes and synchronous buffered indexed flushes.

This does not solve the larger zipper/write serialization ceiling. It removes iterator-to-batch materialization from the synchronized DB publish section and adds benchmark metrics that make the remaining lock-held publish work visible.

## Changes

- Add `OrderedRootDeltaBatchPublishInput` and `PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder` in `TreeDB/db`.
- Export `OrderedRootDeltaBatchFromIterator` for callers that can safely prebuild root-local deltas while keeping borrowed stable views alive.
- Switch indexed collection flush paths to prebuild delta batches before calling the DB publish API.
- Add DB tests covering batch-delta group publish preserving omitted base entries and applying deletes.
- Add closed-DB coverage for the new public publish API.
- Add profile-benchmark metrics for ordered-root delta group publish calls, roots/call, lock hold ns/doc/call, and lock wait ns/doc/call.

## Correctness validation

```bash
go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroup|TestClosedDB_PublishOrderedRootDeltaBatch|TestOrderedRootDeltaBatchFromIterator' -count=1
# ok github.com/snissn/gomap/TreeDB/db 0.590s
```

```bash
go test ./TreeDB/collections -run 'TestCollectionIndexedWriteMemtables|TestCollectionUpdateBatch|TestTemplateV1IndexedWriteMemtables' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.473s
```

```bash
go test ./TreeDB/db -count=1
# ok github.com/snissn/gomap/TreeDB/db 72.499s
```

```bash
go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 8.792s
```

```bash
go test ./cmd/mongo_gateway_bench -run 'TestSelectedTreeDBStats|TestProfile' -count=1
# ok github.com/snissn/gomap/cmd/mongo_gateway_bench 1.336s
```

```bash
go test ./TreeDB/db ./TreeDB/collections ./cmd/mongo_gateway_bench -count=1
# ok github.com/snissn/gomap/TreeDB/db 73.590s
# ok github.com/snissn/gomap/TreeDB/collections 9.054s
# ok github.com/snissn/gomap/cmd/mongo_gateway_bench 4.458s
```

```bash
git diff --check
# clean
```

## Benchmark evidence

Baseline current main worktree:

- worktree: `/tmp/gomap-1159-main-profile`
- commit: `fc2bbfe2c9a1f8747369acd1522fdf94d266bb6e`
- profile dir: `/tmp/gomap_1159_publish_base_I1EpC9`

```bash
PROFILE_DIR=/tmp/gomap_1159_publish_base_I1EpC9
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

Result:

```text
893491  12099 ns/op  82654 docs/sec  12099 ns/doc  1063 B/op  4 allocs/op
backend_vlog_mmap_hit_ratio=1.000
backend_vlog_mmap_fallback_readat/doc=0
update_current_read_ns/doc=1750
update_buffer_stage_ns/doc=309.9
update_index_state_extract_ns/doc=321.7
update_primary_run_ns/doc=146.4
update_secondary_runs_ns/doc=8.869
```

This PR:

- worktree: `/tmp/gomap-1159-publish`
- commit: `267a83a3a4`
- profile dir: `/tmp/gomap_1159_publish_branch_metrics_gWp5JW`

```bash
PROFILE_DIR=/tmp/gomap_1159_publish_branch_metrics_gWp5JW
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

Result:

```text
1000000  11575 ns/op  86392 docs/sec  11575 ns/doc  1105 B/op  4 allocs/op
backend_vlog_mmap_hit_ratio=1.000
backend_vlog_mmap_fallback_readat/doc=0
publish_delta_group_calls=64
publish_delta_group_calls/doc=0.0000640
publish_delta_group_roots/call=1.000
publish_delta_group_lock_hold_ns/doc=6896
publish_delta_group_lock_wait_ns/doc=0.008912
publish_delta_group_lock_hold_ns/call=107747090
publish_delta_group_lock_wait_ns/call=139.2
update_current_read_ns/doc=1805
update_buffer_stage_ns/doc=334.1
update_index_state_extract_ns/doc=309.2
update_primary_run_ns/doc=176.0
update_secondary_runs_ns/doc=8.802
```

Readout:

- Throughput improved modestly in the comparable 10s focused run: `82.7k docs/sec` -> `86.4k docs/sec`.
- `allocs/op` stayed at `4`; `B/op` is in the same noisy range for this benchmark.
- The new publish metrics show the next bottleneck clearly: root publish still holds the DB write lock for about `6.9us/doc` in this shape. This PR moves batch materialization out of that lock; the remaining major cost is zipper/write work inside publish.

CPU profile top after this PR still shows scheduler/publish/write/read work as expected, not a new allocation regression:

```text
runtime.pthread_cond_signal                         24.43%
runtime.pthread_cond_wait                           21.42%
runtime.usleep                                      17.00%
TreeDB/internal/valuelog.(*File).readViaMmapViewTo  11.45% cum
syscall.syscall                                      4.55%
TreeDB/zipper.(*Zipper).mergeLeaf                    6.29% cum
TreeDB/db.orderedRootBatchPut                        1.75% cum
```

Allocation profile after this PR remains dominated by expected ownership/setup sites:

```text
TreeDB/batch.(*Batch).Set                           24.61% cum
TreeDB/batch.(*Batch).ensureArenaChunk              10.18%
TreeDB/internal/memtable.getAppendOnlyValueArenaChunk 9.66%
TreeDB/internal/memtable.getAppendOnlyEntriesFromPool 6.70%
zstd dictionary/setup and benchmark document/BSON setup remain visible
```
