### PR TITLE
Prebuild direct collection delta publish batches

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3900,6 +3900,44 @@ func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[s
 	return ordered, cleanup, nil
 }
 
+func buildRootDeltaBatchPublishInputsFromTables(collectionName string, rootNames []string, tables []memtable.Table, rootBaseIDs map[string]uint64, policies []backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
+	if len(rootNames) != len(tables) || len(rootNames) != len(policies) {
+		return nil, func() {}, fmt.Errorf("collections: collection %q invalid delta lengths roots=%d tables=%d policies=%d", collectionName, len(rootNames), len(tables), len(policies))
+	}
+	ordered := make([]backenddb.OrderedRootDeltaBatchPublishInput, 0, len(rootNames))
+	cleanup := func() {
+		for idx := range ordered {
+			if ordered[idx].Delta != nil {
+				_ = ordered[idx].Delta.Close()
+				ordered[idx].Delta = nil
+			}
+		}
+	}
+	for i, rootName := range rootNames {
+		baseRoot, ok := rootBaseIDs[rootName]
+		if !ok {
+			cleanup()
+			return nil, func() {}, fmt.Errorf("collections: collection %q delta publish missing base root for %q", collectionName, rootName)
+		}
+		iter := tables[i].NewIterator(nil, nil)
+		delta, err := backenddb.OrderedRootDeltaBatchFromIterator(iter)
+		closeErr := iter.Close()
+		if err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			cleanup()
+			return nil, func() {}, err
+		}
+		ordered = append(ordered, backenddb.OrderedRootDeltaBatchPublishInput{
+			BaseRoot:      baseRoot,
+			Delta:         delta,
+			StoragePolicy: policies[i],
+		})
+	}
+	return ordered, cleanup, nil
+}
+
 func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork, newSystemRoot uint64, rootIDs []uint64, publishErr error, elapsed time.Duration) error {
 	if c == nil || c.writeDomain == nil || work == nil {
 		return publishErr
@@ -5029,26 +5067,17 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
 
-	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
 	defer func() {
-		for _, it := range iterators {
-			_ = it.Close()
-		}
 		resetCollectionTables(deltaTables)
 	}()
-	for i, rootName := range rootNames {
-		iter := deltaTables[i].NewIterator(nil, nil)
-		iterators = append(iterators, iter)
-		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      baseRootIDs[rootName],
-			Iter:          iter,
-			StoragePolicy: policies[i],
-		})
+	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(c.meta.Name, rootNames, deltaTables, baseRootIDs, policies)
+	if err != nil {
+		return false, err
 	}
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
+	cleanupDeltas()
 	if err != nil {
 		return false, err
 	}
@@ -6137,29 +6166,20 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
 
-	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
 	defer func() {
-		for _, it := range iterators {
-			_ = it.Close()
-		}
 		resetCollectionTables(deltaTables)
 	}()
-	for i, rootName := range rootNames {
-		iter := deltaTables[i].NewIterator(nil, nil)
-		iterators = append(iterators, iter)
-		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      baseRootIDs[rootName],
-			Iter:          iter,
-			StoragePolicy: policies[i],
-		})
+	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(c.meta.Name, rootNames, deltaTables, baseRootIDs, policies)
+	if err != nil {
+		return false, false, err
 	}
 	preflight := func() error {
 		return c.validateMutationRootDescriptors(baseUserRoot, baseSystemRoot, baseCommitSeq)
 	}
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
+	cleanupDeltas()
 	if err != nil {
 		return false, false, err
 	}
@@ -7242,34 +7262,19 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 		return nil, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
 	}
 
-	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(plan.rootNames))
-	defer func() {
-		for _, it := range iterators {
-			_ = it.Close()
-		}
-	}()
-	for i, rootName := range plan.rootNames {
-		baseRoot, ok := plan.baseRootIDs[rootName]
-		if !ok {
-			return nil, fmt.Errorf("collections: UpdateBatch collection %q plan missing base root for %q", plan.meta.Name, rootName)
-		}
-		iter := plan.deltaTables[i].NewIterator(nil, nil)
-		iterators = append(iterators, iter)
-		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      baseRoot,
-			Iter:          iter,
-			StoragePolicy: plan.policies[i],
-		})
+	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(plan.meta.Name, plan.rootNames, plan.deltaTables, plan.baseRootIDs, plan.policies)
+	if err != nil {
+		return nil, err
 	}
 	preflight := func() error {
 		return c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq)
 	}
 	detailedStats := c.updateBatchDetailedStatsEnabled()
 	publishStart := updateBatchStatsNow(detailedStats)
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIteratorForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, rootIDs)
 	})
+	cleanupDeltas()
 	plan.stats.Publish += updateBatchStatsSince(detailedStats, publishStart)
 	if err != nil {
 		return nil, err

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3901,6 +3901,45 @@ func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[s
 	return ordered, cleanup, nil
 }
 
+func buildRootDeltaBatchPublishInputsFromTables(collectionName string, rootNames []string, tables []memtable.Table, rootBaseIDs map[string]uint64, policies []backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
+	if len(rootNames) != len(tables) || len(rootNames) != len(policies) {
+		return nil, func() {}, fmt.Errorf("collections: collection %q invalid delta lengths roots=%d tables=%d policies=%d", collectionName, len(rootNames), len(tables), len(policies))
+	}
+	ordered := make([]backenddb.OrderedRootDeltaBatchPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	cleanup := func() {
+		for idx := range ordered {
+			if ordered[idx].Delta != nil {
+				_ = ordered[idx].Delta.Close()
+				ordered[idx].Delta = nil
+			}
+		}
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+	}
+	for i, rootName := range rootNames {
+		baseRoot, ok := rootBaseIDs[rootName]
+		if !ok {
+			cleanup()
+			return nil, func() {}, fmt.Errorf("collections: collection %q delta publish missing base root for %q", collectionName, rootName)
+		}
+		iter := tables[i].NewIterator(nil, nil)
+		iterators = append(iterators, iter)
+		delta, err := backenddb.OrderedRootDeltaBatchFromIterator(iter)
+		if err != nil {
+			cleanup()
+			return nil, func() {}, err
+		}
+		ordered = append(ordered, backenddb.OrderedRootDeltaBatchPublishInput{
+			BaseRoot:      baseRoot,
+			Delta:         delta,
+			StoragePolicy: policies[i],
+		})
+	}
+	return ordered, cleanup, nil
+}
+
 func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork, newSystemRoot uint64, rootIDs []uint64, publishErr error, elapsed time.Duration) error {
 	if c == nil || c.writeDomain == nil || work == nil {
 		return publishErr
@@ -5030,26 +5069,17 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
 
-	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
 	defer func() {
-		for _, it := range iterators {
-			_ = it.Close()
-		}
 		resetCollectionTables(deltaTables)
 	}()
-	for i, rootName := range rootNames {
-		iter := deltaTables[i].NewIterator(nil, nil)
-		iterators = append(iterators, iter)
-		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      baseRootIDs[rootName],
-			Iter:          iter,
-			StoragePolicy: policies[i],
-		})
+	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(c.meta.Name, rootNames, deltaTables, baseRootIDs, policies)
+	if err != nil {
+		return false, err
 	}
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
+	cleanupDeltas()
 	if err != nil {
 		return false, err
 	}
@@ -6138,29 +6168,20 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
 
-	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
 	defer func() {
-		for _, it := range iterators {
-			_ = it.Close()
-		}
 		resetCollectionTables(deltaTables)
 	}()
-	for i, rootName := range rootNames {
-		iter := deltaTables[i].NewIterator(nil, nil)
-		iterators = append(iterators, iter)
-		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      baseRootIDs[rootName],
-			Iter:          iter,
-			StoragePolicy: policies[i],
-		})
+	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(c.meta.Name, rootNames, deltaTables, baseRootIDs, policies)
+	if err != nil {
+		return false, false, err
 	}
 	preflight := func() error {
 		return c.validateMutationRootDescriptors(baseUserRoot, baseSystemRoot, baseCommitSeq)
 	}
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
+	cleanupDeltas()
 	if err != nil {
 		return false, false, err
 	}
@@ -7243,34 +7264,19 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 		return nil, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
 	}
 
-	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(plan.rootNames))
-	defer func() {
-		for _, it := range iterators {
-			_ = it.Close()
-		}
-	}()
-	for i, rootName := range plan.rootNames {
-		baseRoot, ok := plan.baseRootIDs[rootName]
-		if !ok {
-			return nil, fmt.Errorf("collections: UpdateBatch collection %q plan missing base root for %q", plan.meta.Name, rootName)
-		}
-		iter := plan.deltaTables[i].NewIterator(nil, nil)
-		iterators = append(iterators, iter)
-		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      baseRoot,
-			Iter:          iter,
-			StoragePolicy: plan.policies[i],
-		})
+	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(plan.meta.Name, plan.rootNames, plan.deltaTables, plan.baseRootIDs, plan.policies)
+	if err != nil {
+		return nil, err
 	}
 	preflight := func() error {
 		return c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq)
 	}
 	detailedStats := c.updateBatchDetailedStatsEnabled()
 	publishStart := updateBatchStatsNow(detailedStats)
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIteratorForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, rootIDs)
 	})
+	cleanupDeltas()
 	plan.stats.Publish += updateBatchStatsSince(detailedStats, publishStart)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Refs #1159. Stacked on #1178.

This follow-up applies the #1178 batch-based delta publish path to direct collection mutation paths whose base roots already exist:

- `deleteDocumentOnce`
- `updateDocumentOnce`
- `publishUpdateBatchPlanLocked`

It intentionally does **not** convert direct `InsertBatch` cold-root publish. A quick large-batch insert check showed that cold roots (`baseRoot == 0`) are better left on the existing iterator-to-bulk-build path because prebuilding a delta batch adds an unnecessary materialization step before the initial bulk build.

## Validation

```bash
go test ./TreeDB/collections -run 'TestCollectionIndexedWriteMemtables|TestCollectionUpdateBatch|TestCollectionDelete|TestCollectionInsert|TestTemplateV1IndexedWriteMemtables' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 0.811s
```

```bash
go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 3.223s
```

## Benchmark / no-regression checks

Large direct insert check, parent #1178 commit `267a83a3a4`, worktree `/tmp/gomap-1178-parent-bench`:

```bash
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=32000 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionLoadBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=2
```

```text
100000  1019 ns/op   980954 docs/sec  1019 ns/doc  2014 B/op  0 allocs/op
100000  839.7 ns/op  1190985 docs/sec 839.6 ns/doc 1732 B/op  0 allocs/op
```

Same check on this branch after leaving direct insert on the existing iterator path:

```bash
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=32000 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionLoadBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=1
```

```text
100000  1076 ns/op  929688 docs/sec  1076 ns/doc  1830 B/op  0 allocs/op
```

Focused update smoke on this branch:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=1
```

```text
100000  11262 ns/op  88792 docs/sec  11262 ns/doc  1140 B/op  4 allocs/op
publish_delta_group_calls=7
publish_delta_group_roots/call=1.000
publish_delta_group_lock_hold_ns/doc=6594
publish_delta_group_lock_wait_ns/doc=0.008330
backend_vlog_mmap_hit_ratio=1.000
backend_vlog_mmap_fallback_readat/doc=0
```

## Readout

This PR is a hygiene/coverage extension of #1178, not a headline throughput PR. The key implementation point is keeping batch prebuild on warm direct mutation deltas and avoiding the cold-root direct insert regression.
