### PR TITLE
Avoid double sorting ordered root deltas

### DIFF
--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -130,6 +130,11 @@ func (b *Batch) Reset() {
 	b.resetLocked()
 }
 
+// IsEmpty reports whether the batch currently has no queued operations.
+func (b *Batch) IsEmpty() bool {
+	return b == nil || len(b.entries) == 0
+}
+
 func (b *Batch) resetLocked() {
 	if b.entries != nil {
 		// Avoid holding onto key/value copies from previous uses.

--- a/TreeDB/batch/batch_test.go
+++ b/TreeDB/batch/batch_test.go
@@ -63,6 +63,31 @@ func TestBatchPreWrite(t *testing.T) {
 	}
 }
 
+func TestBatchIsEmpty(t *testing.T) {
+	if !((*Batch)(nil)).IsEmpty() {
+		t.Fatalf("nil batch should be empty")
+	}
+	b := New(newMapValueReader(), page.DefaultInlineThreshold)
+	t.Cleanup(func() { _ = b.Close() })
+	if !b.IsEmpty() {
+		t.Fatalf("new batch should be empty")
+	}
+	if err := b.Set([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if b.IsEmpty() {
+		t.Fatalf("batch with queued op should not be empty")
+	}
+	_ = b.SortedEntries()
+	if b.IsEmpty() {
+		t.Fatalf("batch remains non-empty after sorting entries")
+	}
+	b.Reset()
+	if !b.IsEmpty() {
+		t.Fatalf("reset batch should be empty")
+	}
+}
+
 func TestBatchSetOps_UsesSlabPointersForLargeValues(t *testing.T) {
 	reader := newMapValueReader()
 	b := New(reader, page.DefaultInlineThreshold)

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -556,7 +556,7 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 		return 0, nil, metrics, err
 	}
 	defer delta.Close()
-	if len(delta.SortedEntries()) == 0 {
+	if delta.IsEmpty() {
 		return baseRoot, nil, metrics, nil
 	}
 	rootZipper, err := db.orderedRootZipperForOptions(idx, opts)
@@ -580,7 +580,7 @@ func (db *DB) publishOrderedRootDeltaBatch(baseRoot uint64, delta *batch.Batch, 
 		err = errors.New("ordered root value-log leaf storage requires a leaf page log")
 		return
 	}
-	if len(delta.SortedEntries()) == 0 {
+	if delta.IsEmpty() {
 		return baseRoot, nil, metrics, nil
 	}
 	if baseRoot == 0 {


### PR DESCRIPTION
## Summary

- add `batch.Batch.IsEmpty()` for cheap queued-operation emptiness checks
- avoid calling `SortedEntries()` only to test ordered-root delta batch emptiness before zipper `Apply`
- keep zipper as the single sorted/compacted-entry consumer for non-empty delta batches

This follows #1180's phase instrumentation. The benchmark there showed root apply/zipper dominates the remaining lock-held publish time; this removes one avoidable pre-`Apply` sorted-entry pass in the ordered-root delta publish path.

## Validation

```bash
go test ./TreeDB/batch -run TestBatchIsEmpty -count=1
# ok github.com/snissn/gomap/TreeDB/batch 0.389s

go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder|TestPublishOrderedRootDeltaGroupWithSystemBuilder_ReportsPublishStats' -count=1
# ok github.com/snissn/gomap/TreeDB/db 0.363s

go test ./TreeDB/batch ./TreeDB/db ./cmd/mongo_gateway_bench -count=1
# ok github.com/snissn/gomap/TreeDB/batch 0.227s
# ok github.com/snissn/gomap/TreeDB/db 81.006s
# ok github.com/snissn/gomap/cmd/mongo_gateway_bench 2.991s

git diff --check
# clean
```

## Focused benchmark

Base comparison is the #1180 phase-metrics row from the same machine/config:

```text
#1180: 200000  12562 ns/op  79602 docs/sec  12562 ns/doc  1849 B/op  4 allocs/op
       publish_delta_group_lock_hold_ns/doc=7858
       publish_delta_group_root_apply_ns/doc=7769
```

This branch:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=200000x \
  -benchmem \
  -count=1
```

```text
200000  11389 ns/op  87804 docs/sec  11389 ns/doc  1183 B/op  4 allocs/op
publish_delta_group_calls=13
publish_delta_group_roots/call=1.000
publish_delta_group_lock_hold_ns/doc=6793
publish_delta_group_lock_wait_ns/doc=0.01167
publish_delta_group_root_apply_ns/doc=6727
publish_delta_group_root_apply_ns/call=103487865
publish_delta_group_finalize_ns/doc=64.96
publish_delta_group_system_apply_ns/doc=1.254
publish_delta_group_system_build_ns/doc=0.2756
backend_vlog_mmap_hit_ratio=1.000
backend_vlog_mmap_fallback_readat/doc=0
```

Readout: one focused run shows the intended movement in the measured phase: root-apply time drops from about `7.77us/doc` to `6.73us/doc`, and total docs/sec improves from about `79.6k` to `87.8k`. Treat this as directional pending CI and any reviewer-requested repeat runs.
