### PR TITLE
Memoize batch sorted-entry compaction

### DIFF
--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -65,6 +65,7 @@ type Batch struct {
 	touchedValueLog         map[uint32]struct{}
 	hasValueLogPointers     bool
 	sorted                  bool
+	compacted               bool
 	lastKey                 []byte
 	closed                  bool
 	reader                  ValueReader
@@ -82,8 +83,9 @@ const (
 var batchPool = sync.Pool{
 	New: func() any {
 		return &Batch{
-			entries: make([]Entry, 0, 16),
-			sorted:  true,
+			entries:   make([]Entry, 0, 16),
+			sorted:    true,
+			compacted: true,
 		}
 	},
 }
@@ -149,6 +151,7 @@ func (b *Batch) resetLocked() {
 	b.hasValueLogPointers = false
 	b.byteSize = 0
 	b.sorted = true
+	b.compacted = true
 	b.lastKey = nil
 	b.resetArenaLocked()
 }
@@ -172,6 +175,7 @@ func (b *Batch) resetForPool() {
 	b.touchedValueLogSmallLen = 0
 	b.hasValueLogPointers = false
 	b.sorted = true
+	b.compacted = true
 	b.lastKey = nil
 	b.resetArenaLocked()
 }
@@ -372,6 +376,7 @@ func (b *Batch) SetView(key, value []byte) error {
 
 	b.entries = append(b.entries, entry)
 	b.byteSize += len(key) + len(value)
+	b.compacted = false
 	b.noteKeyOrder(entry.Key)
 	return nil
 }
@@ -406,6 +411,7 @@ func (b *Batch) Set(key, value []byte) error {
 	b.entries = append(b.entries, entry)
 	// Approximate size tracking (optional for now)
 	b.byteSize += len(k) + len(value)
+	b.compacted = false
 	b.noteKeyOrder(entry.Key)
 	return nil
 }
@@ -426,6 +432,7 @@ func (b *Batch) DeleteView(key []byte) error {
 		Key:  key,
 	})
 	b.byteSize += len(key)
+	b.compacted = false
 	b.noteKeyOrder(key)
 	return nil
 }
@@ -453,6 +460,7 @@ func (b *Batch) SetPointer(key []byte, ptr page.ValuePtr) error {
 	b.entries = append(b.entries, entry)
 	b.hasValueLogPointers = true
 	b.noteTouchedValueLog(ptr)
+	b.compacted = false
 	b.noteKeyOrder(entry.Key)
 	return nil
 }
@@ -491,6 +499,7 @@ func (b *Batch) AppendPointerViewNoTouchTrustedSorted(key []byte, ptr page.Value
 		IsPtr:    true,
 	})
 	b.hasValueLogPointers = true
+	b.compacted = false
 	if b.sorted {
 		b.lastKey = key
 	}
@@ -526,6 +535,7 @@ func (b *Batch) setPointerViewInternal(key []byte, ptr page.ValuePtr, noteTouche
 	if noteTouched {
 		b.noteTouchedValueLog(ptr)
 	}
+	b.compacted = false
 	b.noteKeyOrder(key)
 	return nil
 }
@@ -546,6 +556,7 @@ func (b *Batch) Delete(key []byte) error {
 		Key:  k,
 	})
 	b.byteSize += len(k)
+	b.compacted = false
 	b.noteKeyOrder(k)
 	return nil
 }
@@ -587,6 +598,9 @@ func (b *Batch) SetOps(ops []Entry) error {
 	}
 
 	// Just append them. Deduplication happens at Ops() time.
+	if len(ops) > 0 {
+		b.compacted = false
+	}
 	for _, op := range ops {
 		if op.IsPtr {
 			if !page.IsValueLogFileID(op.ValuePtr.FileID) {
@@ -607,7 +621,13 @@ func (b *Batch) SetOps(ops []Entry) error {
 // This modifies the internal entries slice (sorts and compacts).
 func (b *Batch) SortedEntries() []Entry {
 	if len(b.entries) == 0 {
+		b.sorted = true
+		b.compacted = true
+		b.lastKey = nil
 		return nil
+	}
+	if b.sorted && b.compacted {
+		return b.entries
 	}
 	if !b.sorted {
 		sort.SliceStable(b.entries, func(i, j int) bool {
@@ -617,18 +637,21 @@ func (b *Batch) SortedEntries() []Entry {
 	}
 
 	// Compact in place: keep only the last entry for each key
-	oldLen := len(b.entries)
-	out := b.entries[:0]
-	for i := 0; i < len(b.entries); i++ {
-		// If next is same key, skip this one (it's overwritten by next)
-		if i+1 < len(b.entries) && bytes.Equal(b.entries[i].Key, b.entries[i+1].Key) {
-			continue
+	if !b.compacted {
+		oldLen := len(b.entries)
+		out := b.entries[:0]
+		for i := 0; i < len(b.entries); i++ {
+			// If next is same key, skip this one (it's overwritten by next)
+			if i+1 < len(b.entries) && bytes.Equal(b.entries[i].Key, b.entries[i+1].Key) {
+				continue
+			}
+			out = append(out, b.entries[i])
 		}
-		out = append(out, b.entries[i])
+		// Clear the now-unused tail to avoid pinning batch arenas via stale pointers.
+		clear(b.entries[len(out):oldLen])
+		b.entries = out
+		b.compacted = true
 	}
-	// Clear the now-unused tail to avoid pinning batch arenas via stale pointers.
-	clear(b.entries[len(out):oldLen])
-	b.entries = out
 	if len(b.entries) > 0 {
 		b.lastKey = b.entries[len(b.entries)-1].Key
 	}

--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -619,6 +619,9 @@ func (b *Batch) SetOps(ops []Entry) error {
 // SortedEntries returns the operations sorted by key.
 // Duplicate keys are resolved (last write wins).
 // This modifies the internal entries slice (sorts and compacts).
+// The returned slice aliases batch-owned storage and must be treated as
+// read-only. It remains valid only until the batch is mutated, reset, released,
+// or closed.
 func (b *Batch) SortedEntries() []Entry {
 	if len(b.entries) == 0 {
 		b.sorted = true

--- a/TreeDB/batch/batch_test.go
+++ b/TreeDB/batch/batch_test.go
@@ -88,6 +88,83 @@ func TestBatchIsEmpty(t *testing.T) {
 	}
 }
 
+func TestBatchSortedEntriesMemoizesCompactionUntilMutation(t *testing.T) {
+	b := New(newMapValueReader(), page.DefaultInlineThreshold)
+	t.Cleanup(func() { _ = b.Close() })
+
+	if err := b.Set([]byte("a"), []byte("old")); err != nil {
+		t.Fatalf("Set old: %v", err)
+	}
+	if err := b.Set([]byte("a"), []byte("new")); err != nil {
+		t.Fatalf("Set new: %v", err)
+	}
+	if b.compacted {
+		t.Fatalf("batch compacted before SortedEntries")
+	}
+
+	first := b.SortedEntries()
+	if len(first) != 1 {
+		t.Fatalf("first len=%d want 1", len(first))
+	}
+	if got := string(first[0].Value); got != "new" {
+		t.Fatalf("first value=%q want new", got)
+	}
+	if !b.sorted || !b.compacted {
+		t.Fatalf("after first SortedEntries sorted=%v compacted=%v, want true/true", b.sorted, b.compacted)
+	}
+
+	second := b.SortedEntries()
+	if len(second) != 1 {
+		t.Fatalf("second len=%d want 1", len(second))
+	}
+	if &second[0] != &first[0] {
+		t.Fatalf("second SortedEntries did not return the memoized compacted entry slice")
+	}
+	if !b.compacted {
+		t.Fatalf("second SortedEntries invalidated compaction")
+	}
+}
+
+func TestBatchSortedEntriesInvalidatesCompactionAfterMutation(t *testing.T) {
+	b := New(newMapValueReader(), page.DefaultInlineThreshold)
+	t.Cleanup(func() { _ = b.Close() })
+
+	if err := b.Set([]byte("b"), []byte("first-b")); err != nil {
+		t.Fatalf("Set first b: %v", err)
+	}
+	if err := b.Set([]byte("a"), []byte("first-a")); err != nil {
+		t.Fatalf("Set first a: %v", err)
+	}
+	entries := b.SortedEntries()
+	if len(entries) != 2 {
+		t.Fatalf("initial len=%d want 2", len(entries))
+	}
+	if !b.compacted {
+		t.Fatalf("initial SortedEntries did not mark compacted")
+	}
+
+	if err := b.Set([]byte("a"), []byte("second-a")); err != nil {
+		t.Fatalf("Set second a: %v", err)
+	}
+	if b.compacted {
+		t.Fatalf("mutation after SortedEntries did not invalidate compaction")
+	}
+
+	entries = b.SortedEntries()
+	if len(entries) != 2 {
+		t.Fatalf("after mutation len=%d want 2", len(entries))
+	}
+	if gotKey, gotValue := string(entries[0].Key), string(entries[0].Value); gotKey != "a" || gotValue != "second-a" {
+		t.Fatalf("entry[0]=%q/%q want a/second-a", gotKey, gotValue)
+	}
+	if gotKey, gotValue := string(entries[1].Key), string(entries[1].Value); gotKey != "b" || gotValue != "first-b" {
+		t.Fatalf("entry[1]=%q/%q want b/first-b", gotKey, gotValue)
+	}
+	if !b.sorted || !b.compacted {
+		t.Fatalf("after mutation SortedEntries sorted=%v compacted=%v, want true/true", b.sorted, b.compacted)
+	}
+}
+
 func TestBatchSetOps_UsesSlabPointersForLargeValues(t *testing.T) {
 	reader := newMapValueReader()
 	b := New(reader, page.DefaultInlineThreshold)


### PR DESCRIPTION
## Summary
- add an internal compacted bit to batch.Batch so repeated SortedEntries calls can return the already sorted/deduplicated entry slice until the batch is mutated
- invalidate the compacted bit on all append-style batch mutations
- add tests covering memoized repeated SortedEntries calls and mutation after compaction

## Why
#1159 profiling still shows ordered-root publish dominated by zipper root-apply work. Some root apply and rewrite paths can touch sorted batch entries repeatedly; before this change every SortedEntries call walked and compacted the full slice even when nothing changed. This keeps the existing last-write-wins behavior while avoiding that repeated scan.

## Local validation
- go test ./TreeDB/batch -run 'TestBatchSortedEntries|TestBatchIsEmpty|TestAppendPointerViewNoTouchTrustedSorted|TestBatchSetOps' -count=1
- go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder|TestPublishOrderedRootDeltaGroupWithSystemBuilder_ReportsPublishStats' -count=1
- go test ./TreeDB/batch ./TreeDB/db ./cmd/mongo_gateway_bench -count=1
- git diff --check

## Focused benchmark
Command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=200000x -benchmem -count=3
```

Same-machine main baseline before this branch:

| run | ns/doc | docs/sec | root apply ns/doc | lock hold ns/doc | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 13,974 | 71,561 | 9,087 | 9,456 | 1,169 | 4 |
| 2 | 12,981 | 77,037 | 8,197 | 8,454 | 1,080 | 4 |
| 3 | 11,745 | 85,140 | 7,010 | 7,219 | 1,085 | 4 |

This branch:

| run | ns/doc | docs/sec | root apply ns/doc | lock hold ns/doc | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 11,580 | 86,352 | 6,834 | 6,956 | 1,087 | 4 |
| 2 | 11,430 | 87,487 | 6,807 | 6,952 | 1,150 | 4 |
| 3 | 11,358 | 88,047 | 6,686 | 6,804 | 1,140 | 4 |

Readout: this is a small cleanup with favorable focused numbers, but the bigger finding remains unchanged: root apply/zipper internals still dominate ordered-root publish lock hold and need further split/optimization.