### PR TITLE
Raise indexed write root-run flush threshold

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -35,7 +35,7 @@ const (
 	// DefaultIndexedWriteMemtableMaxRootRuns bounds accumulated root-local
 	// mutation runs so many small indexed update batches do not create an
 	// expensive pending-run chain before the document threshold is reached.
-	DefaultIndexedWriteMemtableMaxRootRuns = 4096
+	DefaultIndexedWriteMemtableMaxRootRuns = 16 * 1024
 	// DefaultIndexedWriteMemtableDirectBatchDocuments keeps large, already
 	// well-amortized InsertBatch calls on the immediate publish path. Smaller
 	// batches use the indexed write-domain memtable path by default.

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -119,9 +119,9 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	if got := profileBenchBufferedIndexedWriteMaxDocuments(t); got != 123 {
 		t.Fatalf("buffered max docs=%d want 123", got)
 	}
-	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", "456")
-	if got := profileBenchBufferedIndexedWriteMaxBytes(t); got != 456 {
-		t.Fatalf("buffered max bytes=%d want 456", got)
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", "1099511627776")
+	if got := profileBenchBufferedIndexedWriteMaxBytes(t); got != 1099511627776 {
+		t.Fatalf("buffered max bytes=%d want 1099511627776", got)
 	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "789")
 	if got := profileBenchBufferedIndexedWriteMaxRootRuns(t); got != 789 {
@@ -285,7 +285,7 @@ func BenchmarkTreeDBGatewayRawWireLoadBSONIndexes2(b *testing.B) {
 	}
 	timedElapsed += time.Since(flushStart)
 	b.StopTimer()
-	reportProfileBenchBufferedIndexedAsyncFlush(b, collection.Meta().Options)
+	reportProfileBenchBufferedIndexedWriteOptions(b, collection.Meta().Options)
 	reportDocsPerSecond(b, b.N, timedElapsed)
 }
 
@@ -447,7 +447,7 @@ func BenchmarkDirectCollectionLoadBSONIndexes2(b *testing.B) {
 	if err := backend.Checkpoint(); err != nil {
 		b.Fatalf("checkpoint backend: %v", err)
 	}
-	reportProfileBenchBufferedIndexedAsyncFlush(b, collection.Meta().Options)
+	reportProfileBenchBufferedIndexedWriteOptions(b, collection.Meta().Options)
 	reportDocsPerSecond(b, b.N, timedElapsed)
 }
 
@@ -577,7 +577,7 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 		b.Fatalf("run concurrent updates: %v", err)
 	}
 	b.ReportMetric(float64(writers), "writers")
-	reportProfileBenchBufferedIndexedAsyncFlush(b, collection.Meta().Options)
+	reportProfileBenchBufferedIndexedWriteOptions(b, collection.Meta().Options)
 	reportCollectionManagerUpdateStats(b, deltaCollectionManagerUpdateStats(manager.StatsSnapshot(), statsBefore), b.N)
 	backendStatsAfter := backend.Stats()
 	reportProfileBenchOrderedRootPublishStats(b, backendStatsAfter, backendStatsBefore, b.N)
@@ -1453,8 +1453,8 @@ func profileBenchBufferedIndexedWriteMaxDocuments(tb testing.TB) int {
 	return profileBenchNonNegativeEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", 0)
 }
 
-func profileBenchBufferedIndexedWriteMaxBytes(tb testing.TB) int {
-	return profileBenchNonNegativeEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", 0)
+func profileBenchBufferedIndexedWriteMaxBytes(tb testing.TB) int64 {
+	return profileBenchNonNegativeEnvInt64(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", 0)
 }
 
 func profileBenchBufferedIndexedWriteMaxRootRuns(tb testing.TB) int {
@@ -1468,7 +1468,7 @@ func profileBenchCollectionOptions(tb testing.TB, format collections.DocumentFor
 		DataRootStoragePolicy:                   collections.RootStorageCompressed,
 		IndexStateStoragePolicy:                 collections.RootStorageCompressed,
 		BufferedIndexedWriteMaxDocuments:        profileBenchBufferedIndexedWriteMaxDocuments(tb),
-		BufferedIndexedWriteMaxBytes:            int64(profileBenchBufferedIndexedWriteMaxBytes(tb)),
+		BufferedIndexedWriteMaxBytes:            profileBenchBufferedIndexedWriteMaxBytes(tb),
 		BufferedIndexedWriteMaxRootRuns:         profileBenchBufferedIndexedWriteMaxRootRuns(tb),
 		BufferedIndexedAsyncFlush:               profileBenchBufferedIndexedAsyncFlush(tb),
 		BufferedIndexedAsyncFlushMaxQueuedUnits: profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(tb),
@@ -1514,7 +1514,20 @@ func profileBenchNonNegativeEnvInt(tb testing.TB, name string, defaultValue int)
 	return value
 }
 
-func reportProfileBenchBufferedIndexedAsyncFlush(b *testing.B, opts collections.CollectionOptions) {
+func profileBenchNonNegativeEnvInt64(tb testing.TB, name string, defaultValue int64) int64 {
+	tb.Helper()
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return defaultValue
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || value < 0 {
+		tb.Fatalf("invalid %s=%q", name, raw)
+	}
+	return value
+}
+
+func reportProfileBenchBufferedIndexedWriteOptions(b *testing.B, opts collections.CollectionOptions) {
 	b.Helper()
 	if opts.BufferedIndexedWriteMaxDocuments > 0 {
 		b.ReportMetric(float64(opts.BufferedIndexedWriteMaxDocuments), "buffered_max_docs")

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -89,11 +89,23 @@ func TestProfileBenchUpdateIDStrideCoversDocumentSet(t *testing.T) {
 func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "")
 	if profileBenchBufferedIndexedAsyncFlush(t) {
 		t.Fatal("async flush default=true want false")
 	}
 	if got := profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(t); got != 0 {
 		t.Fatalf("async max queued units default=%d want 0", got)
+	}
+	if got := profileBenchBufferedIndexedWriteMaxDocuments(t); got != 0 {
+		t.Fatalf("buffered max docs default=%d want 0", got)
+	}
+	if got := profileBenchBufferedIndexedWriteMaxBytes(t); got != 0 {
+		t.Fatalf("buffered max bytes default=%d want 0", got)
+	}
+	if got := profileBenchBufferedIndexedWriteMaxRootRuns(t); got != 0 {
+		t.Fatalf("buffered max root runs default=%d want 0", got)
 	}
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH", "true")
 	if !profileBenchBufferedIndexedAsyncFlush(t) {
@@ -102,6 +114,18 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS", "6")
 	if got := profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(t); got != 6 {
 		t.Fatalf("async max queued units=%d want 6", got)
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", "123")
+	if got := profileBenchBufferedIndexedWriteMaxDocuments(t); got != 123 {
+		t.Fatalf("buffered max docs=%d want 123", got)
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", "456")
+	if got := profileBenchBufferedIndexedWriteMaxBytes(t); got != 456 {
+		t.Fatalf("buffered max bytes=%d want 456", got)
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "789")
+	if got := profileBenchBufferedIndexedWriteMaxRootRuns(t); got != 789 {
+		t.Fatalf("buffered max root runs=%d want 789", got)
 	}
 }
 
@@ -179,14 +203,8 @@ func BenchmarkTreeDBGatewayRawWireLoadBSONIndexes2(b *testing.B) {
 	}()
 	manager := collections.NewCollectionManager(backend)
 	if _, err := manager.CreateCollection(&collections.CollectionMeta{
-		Name: "bench.docs",
-		Options: collections.CollectionOptions{
-			DocumentFormat:                          collections.DocumentFormatBSON,
-			DataRootStoragePolicy:                   collections.RootStorageCompressed,
-			IndexStateStoragePolicy:                 collections.RootStorageCompressed,
-			BufferedIndexedAsyncFlush:               profileBenchBufferedIndexedAsyncFlush(b),
-			BufferedIndexedAsyncFlushMaxQueuedUnits: profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(b),
-		},
+		Name:    "bench.docs",
+		Options: profileBenchCollectionOptions(b, collections.DocumentFormatBSON),
 	}); err != nil {
 		b.Fatalf("create collection: %v", err)
 	}
@@ -214,13 +232,7 @@ func BenchmarkTreeDBGatewayRawWireLoadBSONIndexes2(b *testing.B) {
 	server := mongogateway.NewServer()
 	server.Collections = manager
 	server.MaxFindScanDocuments = b.N
-	server.DefaultCollectionOptions = collections.CollectionOptions{
-		DocumentFormat:                          collections.DocumentFormatBSON,
-		DataRootStoragePolicy:                   collections.RootStorageCompressed,
-		IndexStateStoragePolicy:                 collections.RootStorageCompressed,
-		BufferedIndexedAsyncFlush:               profileBenchBufferedIndexedAsyncFlush(b),
-		BufferedIndexedAsyncFlushMaxQueuedUnits: profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(b),
-	}
+	server.DefaultCollectionOptions = profileBenchCollectionOptions(b, collections.DocumentFormatBSON)
 	server.DefaultIndexStoragePolicy = collections.RootStorageCompressed
 	commandDoc := mustProfileBenchDocument(b, bson.D{
 		{Key: "insert", Value: "docs"},
@@ -370,14 +382,8 @@ func BenchmarkDirectCollectionLoadBSONIndexes2(b *testing.B) {
 	}()
 	manager := collections.NewCollectionManager(backend)
 	if _, err := manager.CreateCollection(&collections.CollectionMeta{
-		Name: "bench.docs",
-		Options: collections.CollectionOptions{
-			DocumentFormat:                          collections.DocumentFormatBSON,
-			DataRootStoragePolicy:                   collections.RootStorageCompressed,
-			IndexStateStoragePolicy:                 collections.RootStorageCompressed,
-			BufferedIndexedAsyncFlush:               profileBenchBufferedIndexedAsyncFlush(b),
-			BufferedIndexedAsyncFlushMaxQueuedUnits: profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(b),
-		},
+		Name:    "bench.docs",
+		Options: profileBenchCollectionOptions(b, collections.DocumentFormatBSON),
 	}); err != nil {
 		b.Fatalf("create collection: %v", err)
 	}
@@ -461,14 +467,8 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	}()
 	manager := collections.NewCollectionManager(backend)
 	if _, err := manager.CreateCollection(&collections.CollectionMeta{
-		Name: "bench.docs",
-		Options: collections.CollectionOptions{
-			DocumentFormat:                          collections.DocumentFormatBSON,
-			DataRootStoragePolicy:                   collections.RootStorageCompressed,
-			IndexStateStoragePolicy:                 collections.RootStorageCompressed,
-			BufferedIndexedAsyncFlush:               profileBenchBufferedIndexedAsyncFlush(b),
-			BufferedIndexedAsyncFlushMaxQueuedUnits: profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(b),
-		},
+		Name:    "bench.docs",
+		Options: profileBenchCollectionOptions(b, collections.DocumentFormatBSON),
 	}); err != nil {
 		b.Fatalf("create collection: %v", err)
 	}
@@ -1449,6 +1449,32 @@ func profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(tb testing.TB) int {
 	return profileBenchNonNegativeEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS", 0)
 }
 
+func profileBenchBufferedIndexedWriteMaxDocuments(tb testing.TB) int {
+	return profileBenchNonNegativeEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", 0)
+}
+
+func profileBenchBufferedIndexedWriteMaxBytes(tb testing.TB) int {
+	return profileBenchNonNegativeEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", 0)
+}
+
+func profileBenchBufferedIndexedWriteMaxRootRuns(tb testing.TB) int {
+	return profileBenchNonNegativeEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", 0)
+}
+
+func profileBenchCollectionOptions(tb testing.TB, format collections.DocumentFormat) collections.CollectionOptions {
+	tb.Helper()
+	return collections.CollectionOptions{
+		DocumentFormat:                          format,
+		DataRootStoragePolicy:                   collections.RootStorageCompressed,
+		IndexStateStoragePolicy:                 collections.RootStorageCompressed,
+		BufferedIndexedWriteMaxDocuments:        profileBenchBufferedIndexedWriteMaxDocuments(tb),
+		BufferedIndexedWriteMaxBytes:            int64(profileBenchBufferedIndexedWriteMaxBytes(tb)),
+		BufferedIndexedWriteMaxRootRuns:         profileBenchBufferedIndexedWriteMaxRootRuns(tb),
+		BufferedIndexedAsyncFlush:               profileBenchBufferedIndexedAsyncFlush(tb),
+		BufferedIndexedAsyncFlushMaxQueuedUnits: profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(tb),
+	}
+}
+
 func profileBenchBoolEnv(tb testing.TB, name string, defaultValue bool) bool {
 	tb.Helper()
 	raw := strings.TrimSpace(os.Getenv(name))
@@ -1490,6 +1516,15 @@ func profileBenchNonNegativeEnvInt(tb testing.TB, name string, defaultValue int)
 
 func reportProfileBenchBufferedIndexedAsyncFlush(b *testing.B, opts collections.CollectionOptions) {
 	b.Helper()
+	if opts.BufferedIndexedWriteMaxDocuments > 0 {
+		b.ReportMetric(float64(opts.BufferedIndexedWriteMaxDocuments), "buffered_max_docs")
+	}
+	if opts.BufferedIndexedWriteMaxBytes > 0 {
+		b.ReportMetric(float64(opts.BufferedIndexedWriteMaxBytes), "buffered_max_bytes")
+	}
+	if opts.BufferedIndexedWriteMaxRootRuns > 0 {
+		b.ReportMetric(float64(opts.BufferedIndexedWriteMaxRootRuns), "buffered_max_root_runs")
+	}
 	if opts.BufferedIndexedAsyncFlush {
 		b.ReportMetric(1, "buffered_async_flush")
 		if opts.BufferedIndexedAsyncFlushMaxQueuedUnits > 0 {


### PR DESCRIPTION
## Summary
- raise the indexed collection write-domain root-run auto-flush threshold from 4,096 to 16,384
- add profile benchmark env knobs for indexed write max documents, max bytes, and max root runs
- report normalized buffered thresholds in the profile benchmark output

## Why
#1183's structural counters show the focused concurrent update workload was dominated by frequent root apply flushes. The old 4,096 root-run threshold flushed before the 64k document threshold, causing 13 publish calls for a 200k update run and nearly one rewritten leaf-log page per updated document. Raising the root-run threshold lets the document threshold dominate while still bounding pending run chains.

## Local validation
- go test ./cmd/mongo_gateway_bench -run 'TestProfileBenchBufferedIndexedAsyncFlushEnv|TestProfileBenchDeltaUintStat' -count=1
- go test ./TreeDB/collections -run 'TestCollection.*BufferedIndexed|TestShouldFlushBufferedIndexedWritesAfterAddingBoundaries|TestNormalize|TestCollectionIndexedWriteMemtables' -count=1
- go test ./cmd/mongo_gateway_bench ./TreeDB/collections -count=1
- git diff --check

## Focused benchmark
Command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=200000x -benchmem -count=1
```

Comparison from this machine:

| setting | docs/sec | ns/doc | publish calls | root apply ns/doc | leaf-log pages written/doc | leaf-log node loads/doc | lock hold ns/doc |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| old default root-runs=4096 | 79,513 | 12,576 | 13 | 8,116 | 0.9620 | 0.8851 | 8,286 |
| root-runs=16,384 sweep | 134,856 | 7,415 | 4 | 2,805 | 0.4247 | 0.3478 | 2,870 |
| root-runs=65,536 sweep, docs=64k default | 140,803 | 7,102 | 4 | 2,476 | 0.4247 | 0.3478 | 2,505 |
| new default root-runs=16,384 | 137,267 | 7,285 | 4 | 2,664 | 0.4287 | 0.3518 | 2,725 |
| docs=256k, root-runs=65,536 | 140,528 | 7,116 | 1 | 800 | 0.2308 | 0.1538 | 813 |

Readout: 16,384 is the practical default improvement. Larger document thresholds reduce root apply further but do not materially improve total throughput here and increase memory/visibility lag more than this PR should take on.