### PR TITLE
Skip unchanged secondary index update deltas

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7519,7 +7519,13 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
 	hasUniqueSecondaryRoots := collectionMetaHasSecondaryUniqueIndex(plan.meta)
-	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, stagedBytes, stagedRootRuns)
+	projectedStagedBytes := stagedBytes
+	for i := range plan.uniqueValueRuns {
+		if table := plan.uniqueValueRuns[i].table; table != nil {
+			projectedStagedBytes = saturatingAddNonNegativeInt64(projectedStagedBytes, table.Size())
+		}
+	}
+	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, projectedStagedBytes, stagedRootRuns)
 	if !shouldAutoFlushAfterAdding && hasUniqueSecondaryRoots && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
 		for i := range plan.rootNames {
 			if _, ok := updateBatchPlanUniqueSecondaryIndex(plan, i); !ok {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -327,6 +327,16 @@ type CollectionUpdateStats struct {
 	SecondaryDeleteEntries int
 	SecondarySetEntries    int
 	SecondaryKeyBytes      int
+	SecondaryRuns          []CollectionUpdateSecondaryRunStats
+}
+
+// CollectionUpdateSecondaryRunStats captures per-secondary-index delta counters
+// from an UpdateBatch-style call.
+type CollectionUpdateSecondaryRunStats struct {
+	IndexName string
+	Deletes   int
+	Sets      int
+	KeyBytes  int
 }
 
 // CollectionManagerStats captures aggregate write-domain counters for a
@@ -772,7 +782,7 @@ func (c *Collection) LastUpdateStats() CollectionUpdateStats {
 	}
 	c.updateStatsMu.RLock()
 	defer c.updateStatsMu.RUnlock()
-	return c.lastUpdateStats
+	return cloneCollectionUpdateStats(c.lastUpdateStats)
 }
 
 func (c *Collection) setLastUpdateStats(stats CollectionUpdateStats) {
@@ -780,11 +790,18 @@ func (c *Collection) setLastUpdateStats(stats CollectionUpdateStats) {
 		return
 	}
 	c.updateStatsMu.Lock()
-	c.lastUpdateStats = stats
+	c.lastUpdateStats = cloneCollectionUpdateStats(stats)
 	c.updateStatsMu.Unlock()
 	if c.writeDomain != nil {
 		c.writeDomain.observeUpdateBatchStats(stats)
 	}
+}
+
+func cloneCollectionUpdateStats(stats CollectionUpdateStats) CollectionUpdateStats {
+	if len(stats.SecondaryRuns) > 0 {
+		stats.SecondaryRuns = append([]CollectionUpdateSecondaryRunStats(nil), stats.SecondaryRuns...)
+	}
+	return stats
 }
 
 func (c *Collection) updateBatchDetailedStatsEnabled() bool {
@@ -3389,6 +3406,52 @@ func bufferedUniqueIndexValueRun(batchIndex memtable.Table, valueType IndexValue
 	}
 	table.Freeze()
 	return table, prefixes, nil
+}
+
+func bufferedUnchangedUniqueValueRuns(runtimes []indexRuntime, updates []preparedBatchUpdate) ([]updateBatchUniqueValueRun, error) {
+	var out []updateBatchUniqueValueRun
+	for runtimeIdx, runtime := range runtimes {
+		if !runtime.def.unique {
+			continue
+		}
+		var table memtable.Table
+		var prefixes [][]byte
+		var arena []byte
+		for _, update := range updates {
+			if !update.indexStateChanged {
+				continue
+			}
+			if !normalizedEncodedIndexValuesEqual(update.oldState.valuesAt(runtimeIdx), update.newState.valuesAt(runtimeIdx)) {
+				continue
+			}
+			for _, encoded := range update.newState.valuesAt(runtimeIdx) {
+				if table == nil {
+					table = newCollectionRunTable(0)
+				}
+				var prefix []byte
+				var err error
+				arena, prefix, err = appendIndexValuePrefixSlice(arena, encoded)
+				if err != nil {
+					resetCollectionRunTable(table)
+					resetUpdateBatchUniqueValueRuns(out)
+					return nil, err
+				}
+				setCollectionRunValue(table, prefix, nil)
+				prefixes = append(prefixes, prefix)
+			}
+		}
+		if table == nil || table.Len() == 0 {
+			resetCollectionRunTable(table)
+			continue
+		}
+		table.Freeze()
+		out = append(out, updateBatchUniqueValueRun{
+			indexName: runtime.def.name,
+			table:     table,
+			prefixes:  prefixes,
+		})
+	}
+	return out, nil
 }
 
 func indexEntryValuePrefix(key []byte, valueType IndexValueType) ([]byte, error) {
@@ -6068,7 +6131,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		}
 		indexStateChanged = !documentIndexStatesEqual(oldState, newState)
 		if indexStateChanged {
-			if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, newState, documentID, nil); err != nil {
+			if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, oldState, newState, documentID, nil); err != nil {
 				_ = snap.Close()
 				return false, false, err
 			}
@@ -6132,6 +6195,9 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		}
 
 		for _, runtime := range runtimes {
+			if !documentIndexRuntimeChanged(oldState, newState, runtime) {
+				continue
+			}
 			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
 			rootID := catalog.rootID(rootName)
 			table := newCollectionRunTable(0)
@@ -6217,11 +6283,18 @@ type updateBatchPlan struct {
 	policies                    []backenddb.OrderedRootStoragePolicy
 	deltaTables                 []memtable.Table
 	uniqueSecondaryIndexByRoot  []int
+	uniqueValueRuns             []updateBatchUniqueValueRun
 	canBufferIndexedUpdateBatch bool
 	bufferedBase                bool
 	bufferedReadGeneration      uint64
 	bufferedReadBlocked         bool
 	scratch                     *updateBatchPlanScratch
+}
+
+type updateBatchUniqueValueRun struct {
+	indexName string
+	table     memtable.Table
+	prefixes  [][]byte
 }
 
 var updateBatchPlanPool sync.Pool
@@ -6471,6 +6544,7 @@ func (plan *updateBatchPlan) close() {
 		_ = plan.snap.Close()
 	}
 	resetCollectionTables(plan.deltaTables)
+	resetUpdateBatchUniqueValueRuns(plan.uniqueValueRuns)
 	if plan.scratch != nil {
 		putUpdateBatchPlanScratch(plan.scratch)
 	}
@@ -7072,7 +7146,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	batchReplacements := batchUniqueReplacementOwners(runtimes, changed)
 	for i := range changed {
 		if changed[i].indexStateChanged {
-			if err := rejectReplaceUniqueConflictsOrdered(snap, catalog, runtimes, changed[i].newState, changed[i].documentID, batchReplacements); err != nil {
+			if err := rejectReplaceUniqueConflictsOrdered(snap, catalog, runtimes, changed[i].oldState, changed[i].newState, changed[i].documentID, batchReplacements); err != nil {
 				_ = snap.Close()
 				return nil, updateBatchItemError(changed[i].itemIndex, err)
 			}
@@ -7086,6 +7160,8 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 
 	var stateTable memtable.Table
 	secondaryTables := make(map[string]memtable.Table, len(runtimes))
+	secondaryRunStats := make([]CollectionUpdateSecondaryRunStats, len(runtimes))
+	var uniqueValueRuns []updateBatchUniqueValueRun
 	success := false
 	defer func() {
 		if success {
@@ -7097,6 +7173,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		for _, table := range secondaryTables {
 			resetCollectionRunTable(table)
 		}
+		resetUpdateBatchUniqueValueRuns(uniqueValueRuns)
 	}()
 
 	if len(templateRecords) > 0 {
@@ -7171,11 +7248,18 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 				continue
 			}
 			for runtimeIdx, runtime := range runtimes {
+				if !orderedDocumentIndexRuntimeChanged(item.oldState, item.newState, runtimeIdx) {
+					continue
+				}
 				rootName := runtimeSecondaryRootName(meta.Name, runtime)
 				table := secondaryTables[rootName]
 				if table == nil {
 					table = newCollectionRunTable(0)
 					secondaryTables[rootName] = table
+				}
+				runStats := &secondaryRunStats[runtimeIdx]
+				if runStats.IndexName == "" {
+					runStats.IndexName = runtime.def.name
 				}
 				deleteKeys, err := secondaryDeleteKeysForOrderedDocument(runtimeIdx, runtime, item.oldState, item.documentID)
 				if err != nil {
@@ -7186,6 +7270,8 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 					table.DeleteSteal(bytes.Clone(key))
 					stats.SecondaryDeleteEntries++
 					stats.SecondaryKeyBytes += len(key)
+					runStats.Deletes++
+					runStats.KeyBytes += len(key)
 				}
 				for _, encoded := range item.newState.valuesAt(runtimeIdx) {
 					key, err := indexEntryKey(encoded, item.documentID)
@@ -7196,6 +7282,8 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 					table.SetSteal(key, nil)
 					stats.SecondarySetEntries++
 					stats.SecondaryKeyBytes += len(key)
+					runStats.Sets++
+					runStats.KeyBytes += len(key)
 				}
 			}
 		}
@@ -7215,6 +7303,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			baseRootIDs[rootName] = catalog.rootID(rootName)
 			policies = append(policies, runtime.def.storagePolicy)
 			deltaTables = append(deltaTables, table)
+			if runStats := secondaryRunStats[runtimeIdx]; runStats.Deletes != 0 || runStats.Sets != 0 || runStats.KeyBytes != 0 {
+				stats.SecondaryRuns = append(stats.SecondaryRuns, runStats)
+			}
 			delete(secondaryTables, rootName)
 		}
 		stats.SecondaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
@@ -7225,6 +7316,14 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	resetCollectionRunTable(stateTable)
 	for _, table := range secondaryTables {
 		resetCollectionRunTable(table)
+	}
+	if canBufferIndexedUpdateBatch && meta.Options.BufferedIndexedWrites && collectionMetaHasSecondaryUniqueIndex(meta) {
+		var err error
+		uniqueValueRuns, err = bufferedUnchangedUniqueValueRuns(runtimes, changed)
+		if err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
 	}
 	success = true
 	plan := newUpdateBatchPlan()
@@ -7248,7 +7347,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		policies:                    policies,
 		deltaTables:                 deltaTables,
 		scratch:                     scratch,
+		uniqueValueRuns:             uniqueValueRuns,
 	}
+	uniqueValueRuns = nil
 	scratchOwnedByPlan = true
 	return plan, nil
 }
@@ -7497,6 +7598,32 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		plan.stats.BufferStageRootAppend += updateBatchStatsSince(detailedStats, phaseStart)
 	}
 	plan.deltaTables = nil
+	if len(plan.uniqueValueRuns) > 0 {
+		phaseStart = updateBatchStatsNow(detailedStats)
+		if domain.uniqueValueRuns == nil {
+			domain.uniqueValueRuns = make(map[string][]memtable.Table)
+		}
+		if domain.uniqueValueIndex == nil {
+			domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex)
+		}
+		for i := range plan.uniqueValueRuns {
+			run := &plan.uniqueValueRuns[i]
+			if run.table == nil {
+				continue
+			}
+			domain.uniqueValueRuns[run.indexName] = append(domain.uniqueValueRuns[run.indexName], run.table)
+			index := domain.uniqueValueIndex[run.indexName]
+			if index == nil {
+				index = newBufferedUniqueValueIndex(max(1, len(run.prefixes)))
+				domain.uniqueValueIndex[run.indexName] = index
+			}
+			index.addAll(run.prefixes)
+			stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, run.table.Size())
+			run.table = nil
+			run.prefixes = nil
+		}
+		plan.stats.BufferStageUniqueIdx += updateBatchStatsSince(detailedStats, phaseStart)
+	}
 	domain.loaded = true
 	domain.meta = plan.meta
 	domain.catalog = plan.catalog
@@ -7593,6 +7720,13 @@ func rejectBatchUniqueConflicts(runtimes []indexRuntime, updates []preparedBatch
 	return nil
 }
 
+func resetUpdateBatchUniqueValueRuns(runs []updateBatchUniqueValueRun) {
+	for i := range runs {
+		resetCollectionRunTable(runs[i].table)
+		runs[i] = updateBatchUniqueValueRun{}
+	}
+}
+
 func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []preparedBatchUpdate) bool {
 	if len(runtimes) == 0 || len(updates) == 0 {
 		return false
@@ -7608,6 +7742,14 @@ func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []p
 		}
 	}
 	return false
+}
+
+func documentIndexRuntimeChanged(oldState, newState documentIndexState, runtime indexRuntime) bool {
+	return !normalizedEncodedIndexValuesEqual(oldState[runtime.def.name], newState[runtime.def.name])
+}
+
+func orderedDocumentIndexRuntimeChanged(oldState, newState orderedDocumentIndexState, runtimeIdx int) bool {
+	return !normalizedEncodedIndexValuesEqual(oldState.valuesAt(runtimeIdx), newState.valuesAt(runtimeIdx))
 }
 
 func normalizedEncodedIndexValuesEqual(left, right [][]byte) bool {
@@ -8344,7 +8486,7 @@ func secondaryDeleteKeysForOrderedDocument(runtimeIdx int, runtime indexRuntime,
 	return out, nil
 }
 
-func rejectReplaceUniqueConflicts(snap *backenddb.Snapshot, catalog *collectionCatalog, runtimes []indexRuntime, state documentIndexState, documentID []byte, batchReplacements batchUniqueReplacementSet) error {
+func rejectReplaceUniqueConflicts(snap *backenddb.Snapshot, catalog *collectionCatalog, runtimes []indexRuntime, oldState, newState documentIndexState, documentID []byte, batchReplacements batchUniqueReplacementSet) error {
 	if snap == nil || catalog == nil {
 		return nil
 	}
@@ -8352,11 +8494,14 @@ func rejectReplaceUniqueConflicts(snap *backenddb.Snapshot, catalog *collectionC
 		if !runtime.def.unique {
 			continue
 		}
+		if !documentIndexRuntimeChanged(oldState, newState, runtime) {
+			continue
+		}
 		rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, runtime.def.name))
 		if rootID == 0 {
 			continue
 		}
-		for _, encoded := range state[runtime.def.name] {
+		for _, encoded := range newState[runtime.def.name] {
 			_, prefix, err := appendIndexValuePrefixSlice(make([]byte, 0, 2+len(encoded)), encoded)
 			if err != nil {
 				return err
@@ -8394,7 +8539,7 @@ func rejectReplaceUniqueConflicts(snap *backenddb.Snapshot, catalog *collectionC
 	return nil
 }
 
-func rejectReplaceUniqueConflictsOrdered(snap *backenddb.Snapshot, catalog *collectionCatalog, runtimes []indexRuntime, state orderedDocumentIndexState, documentID []byte, batchReplacements batchUniqueReplacementSet) error {
+func rejectReplaceUniqueConflictsOrdered(snap *backenddb.Snapshot, catalog *collectionCatalog, runtimes []indexRuntime, oldState, newState orderedDocumentIndexState, documentID []byte, batchReplacements batchUniqueReplacementSet) error {
 	if snap == nil || catalog == nil {
 		return nil
 	}
@@ -8402,11 +8547,14 @@ func rejectReplaceUniqueConflictsOrdered(snap *backenddb.Snapshot, catalog *coll
 		if !runtime.def.unique {
 			continue
 		}
+		if !orderedDocumentIndexRuntimeChanged(oldState, newState, runtimeIdx) {
+			continue
+		}
 		rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, runtime.def.name))
 		if rootID == 0 {
 			continue
 		}
-		for _, encoded := range state.valuesAt(runtimeIdx) {
+		for _, encoded := range newState.valuesAt(runtimeIdx) {
 			_, prefix, err := appendIndexValuePrefixSlice(make([]byte, 0, 2+len(encoded)), encoded)
 			if err != nil {
 				return err

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9535,6 +9535,9 @@ func TestCollectionUpdateSkipsIndexRootsWhenIndexedValuesUnchanged(t *testing.T)
 			t.Fatalf("root %q did not change for indexed update", rootName)
 		}
 	}
+	if rootName := collectionSecondaryRootName("users", "city"); afterIndexed[rootName] != after[rootName] {
+		t.Fatalf("root %q changed from %d to %d for email-only update", rootName, after[rootName], afterIndexed[rootName])
+	}
 	ids, err := col.FindByIndexValue("email", "ada2@example.com")
 	if err != nil {
 		t.Fatalf("find new email: %v", err)
@@ -9548,6 +9551,160 @@ func TestCollectionUpdateSkipsIndexRootsWhenIndexedValuesUnchanged(t *testing.T)
 	}
 	if len(ids) != 0 {
 		t.Fatalf("old email ids=%q want none", ids)
+	}
+}
+
+func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DisableIndexedWriteMemtables: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl","seen":false}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	loadCatalog := func() *collectionCatalog {
+		t.Helper()
+		snap := d.AcquireSnapshot()
+		if snap == nil {
+			t.Fatal("expected snapshot")
+		}
+		defer func() { _ = snap.Close() }()
+		catalog, err := loadCollectionCatalog(snap, "users")
+		if err != nil {
+			t.Fatalf("load catalog: %v", err)
+		}
+		if catalog == nil {
+			t.Fatal("missing catalog")
+		}
+		return catalog
+	}
+	roots := func(catalog *collectionCatalog) map[string]uint64 {
+		t.Helper()
+		names := []string{
+			collectionPrimaryRootName("users"),
+			collectionIndexStateRootName("users"),
+			collectionSecondaryRootName("users", "email"),
+			collectionSecondaryRootName("users", "city"),
+		}
+		out := make(map[string]uint64, len(names))
+		for _, name := range names {
+			rootID := catalog.rootID(name)
+			if rootID == 0 {
+				t.Fatalf("root %q was not persisted", name)
+			}
+			out[name] = rootID
+		}
+		return out
+	}
+
+	before := roots(loadCatalog())
+	results, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func([]byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"sea","seen":false}`), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("update city: %v", err)
+	}
+	if got := results; len(got) != 1 || !got[0].Matched || !got[0].Modified {
+		t.Fatalf("results=%+v want one matched modified row", got)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.SecondaryDeleteEntries, 1; got != want {
+		t.Fatalf("secondary deletes=%d want %d", got, want)
+	}
+	if got, want := stats.SecondarySetEntries, 1; got != want {
+		t.Fatalf("secondary sets=%d want %d", got, want)
+	}
+	if got, want := len(stats.SecondaryRuns), 1; got != want {
+		t.Fatalf("secondary runs=%d want %d: %+v", got, want, stats.SecondaryRuns)
+	}
+	if run := stats.SecondaryRuns[0]; run.IndexName != "city" || run.Deletes != 1 || run.Sets != 1 || run.KeyBytes == 0 {
+		t.Fatalf("city secondary run stats=%+v want city delete+set with key bytes", run)
+	}
+	stats.SecondaryRuns[0].IndexName = "mutated"
+	if got := col.LastUpdateStats().SecondaryRuns[0].IndexName; got != "city" {
+		t.Fatalf("LastUpdateStats did not return owned secondary-run stats, got %q", got)
+	}
+
+	afterCity := roots(loadCatalog())
+	for _, rootName := range []string{
+		collectionPrimaryRootName("users"),
+		collectionIndexStateRootName("users"),
+		collectionSecondaryRootName("users", "city"),
+	} {
+		if afterCity[rootName] == before[rootName] {
+			t.Fatalf("root %q did not change for city update", rootName)
+		}
+	}
+	if rootName := collectionSecondaryRootName("users", "email"); afterCity[rootName] != before[rootName] {
+		t.Fatalf("root %q changed from %d to %d for city-only update", rootName, before[rootName], afterCity[rootName])
+	}
+	ids, err := col.FindByIndexValue("city", "sea")
+	if err != nil {
+		t.Fatalf("find city sea: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("city sea ids=%q want u1", ids)
+	}
+	ids, err = col.FindByIndexValue("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("email ids=%q want u1", ids)
+	}
+
+	beforeSame := roots(loadCatalog())
+	if _, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func([]byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"sea","seen":true}`), true, nil
+		},
+	}}); err != nil {
+		t.Fatalf("update same indexed values: %v", err)
+	}
+	stats = col.LastUpdateStats()
+	if stats.SecondaryDeleteEntries != 0 || stats.SecondarySetEntries != 0 || stats.SecondaryKeyBytes != 0 || len(stats.SecondaryRuns) != 0 {
+		t.Fatalf("same-index update secondary stats deletes=%d sets=%d bytes=%d runs=%+v, want no secondary work",
+			stats.SecondaryDeleteEntries, stats.SecondarySetEntries, stats.SecondaryKeyBytes, stats.SecondaryRuns)
+	}
+	afterSame := roots(loadCatalog())
+	for _, rootName := range []string{
+		collectionIndexStateRootName("users"),
+		collectionSecondaryRootName("users", "email"),
+		collectionSecondaryRootName("users", "city"),
+	} {
+		if afterSame[rootName] != beforeSame[rootName] {
+			t.Fatalf("root %q changed from %d to %d for same-index update", rootName, beforeSame[rootName], afterSame[rootName])
+		}
+	}
+	if rootName := collectionPrimaryRootName("users"); afterSame[rootName] == beforeSame[rootName] {
+		t.Fatalf("primary root %q did not change for document replacement", rootName)
 	}
 }
 


### PR DESCRIPTION
## Summary

Part of #1159.

This PR makes collection update planning operate at secondary-index granularity:

- skips secondary delete/set delta emission for indexes whose encoded value set did not change
- skips persisted unique-conflict preflight for unchanged unique indexes
- avoids publishing unchanged secondary roots for both direct `Update` and `UpdateBatch`
- preserves buffered unique-value metadata for unchanged unique indexes only when some indexed value changed, so buffered unique/read fast paths stay correct without reintroducing unchanged secondary root runs
- adds per-index update secondary-run stats via `CollectionUpdateStats.SecondaryRuns`

## Correctness coverage

New/updated tests cover:

- direct update: changing `email_1` does not rewrite `city_1`
- batch update: changing `city_1` does not rewrite `email_1`
- batch update: changing only a non-indexed field emits zero secondary deletes/sets and leaves secondary roots unchanged
- `LastUpdateStats` returns owned per-index secondary-run stats
- buffered indexed writes still maintain the pending unique-value index for unchanged unique values when another indexed value changed

## Validation

```sh
go test ./TreeDB/collections -run 'TestCollectionUpdateBatchMaintainsBufferedUniqueValueIndex|TestCollectionUpdateSkipsIndexRootsWhenIndexedValuesUnchanged|TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes|TestNormalizedEncodedIndexValuesEqualUsesCanonicalOrder|TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation' -count=1

go test ./TreeDB/collections -count=1

go test ./cmd/mongo_gateway_bench -run 'TestProfileBenchBufferedIndexedAsyncFlushEnv|TestProfileBenchDeltaUintStat|TestBenchmarkSetUpdateCanExerciseIndexedField' -count=1
```

All passed locally.

## Benchmark evidence

Local machine: Apple M3, darwin/arm64. Single-run numbers, so treat throughput as directional; the structural counters are the important signal.

### Indexed-field update benchmark

Command used on `origin/main` and this branch:

```sh
go run ./cmd/mongo_gateway_bench \
  -target treedb \
  -documents 100000 \
  -batch-size 16000 \
  -reads 0 \
  -range-reads 0 \
  -updates 0 \
  -concurrent-writers 8 \
  -concurrent-writes 200000 \
  -secondary-indexes 2 \
  -update-indexed-field \
  -treedb-profile wal_on_fast \
  -treedb-document-format bson \
  -treedb-buffered-indexed-async-flush \
  -treedb-buffered-indexed-async-flush-max-queued-units 4 \
  -treedb-buffered-indexed-write-max-root-runs 16384 \
  -treedb-maintenance checkpoint \
  -format json \
  -timeout 10m
```

| Metric | origin/main | This PR |
| --- | ---: | ---: |
| concurrent update throughput | 36,788 ops/sec | 41,135 ops/sec |
| driver mean latency | 216.4 us | 193.4 us |
| update secondary deletes | 400,000 | 200,000 |
| update secondary sets | 400,000 | 200,000 |
| update secondary key bytes | 34,259,617 | 12,659,617 |
| update root runs | 325,437 | 229,254 |
| indexed flush bytes | 116,544,685 | 94,944,685 |
| publish roots total | 90 | 57 |
| publish avg roots/call | 3.000 | 2.280 |
| root-apply node loads | 249,918 | 181,539 |
| root-apply leaf-log node loads | 237,924 | 171,490 |
| root-apply leaf pages written | 262,257 | 196,175 |
| root-apply ns total | 2,046,602,829 | 1,576,783,041 |
| checkpointed disk bytes | 256,780,241 | 195,066,882 |

### Non-indexed update allocation guard

Command used on `origin/main` and this branch:

```sh
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=16000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=200000x \
  -benchmem \
  -count=1
```

| Metric | origin/main | This PR |
| --- | ---: | ---: |
| ns/op | 6,149 | 6,049 |
| docs/sec | 162,641 | 165,308 |
| B/op | 1,420 | 1,378 |
| allocs/op | 4 | 4 |
| update roots/batch | 1.000 | 1.000 |

This confirms the non-indexed update path stays at 4 allocs/op and does not gain the buffered unique-metadata allocation that was briefly possible during development.