### PR TITLE
Reduce indexed update root-apply amplification

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2394,7 +2394,8 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.writeGeneration++
 	domain.observeIndexedStage(len(plan.resultIDs), stagedBytes, stagedRootRuns)
 	c.meta = catalog.meta
-	if _, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, catalog.meta.Options); err != nil {
+	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, catalog.meta.Options)
+	if err != nil {
 		if autoFlushEnabled {
 			rollbackBufferedIndexedDomain(domain, checkpoint)
 		}
@@ -2406,8 +2407,10 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 			rollbackBufferedIndexedDomain(domain, checkpoint)
 			return 0, err
 		}
+		resetCollectionTables(compactedObsolete)
 		return flushElapsed, nil
 	}
+	resetCollectionTables(compactedObsolete)
 	return 0, nil
 }
 
@@ -2502,22 +2505,22 @@ func shouldCompactBufferedIndexedMutableRuns(domain *collectionWriteDomain, opts
 	return domain.mutableCount < opts.BufferedIndexedWriteMaxDocuments
 }
 
-func maybeCompactBufferedIndexedMutableRunsLocked(domain *collectionWriteDomain, opts CollectionOptions) (bool, error) {
+func maybeCompactBufferedIndexedMutableRunsLocked(domain *collectionWriteDomain, opts CollectionOptions) ([]memtable.Table, error) {
 	if !shouldCompactBufferedIndexedMutableRuns(domain, opts) {
-		return false, nil
+		return nil, nil
 	}
 	beforeBytes := tableRunMapSize(domain.rootRuns) + tableRunMapSize(domain.uniqueValueRuns)
 	compactedRootRuns, obsoleteRootRuns, rootRunsChanged, err := compactTableRunMap(domain.rootRuns)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	compactedUniqueRuns, obsoleteUniqueRuns, uniqueRunsChanged, err := compactTableRunMap(domain.uniqueValueRuns)
 	if err != nil {
 		resetTableRunMap(compactedRootRuns, domain.rootRuns)
-		return false, err
+		return nil, err
 	}
 	if !rootRunsChanged && !uniqueRunsChanged {
-		return false, nil
+		return nil, nil
 	}
 	afterBytes := tableRunMapSize(compactedRootRuns) + tableRunMapSize(compactedUniqueRuns)
 	domain.rootRuns = compactedRootRuns
@@ -2526,14 +2529,11 @@ func maybeCompactBufferedIndexedMutableRunsLocked(domain *collectionWriteDomain,
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(subtractNonNegativeInt64(domain.bufferedBytes, beforeBytes), afterBytes)
 	domain.mutableBytes = saturatingAddNonNegativeInt64(subtractNonNegativeInt64(domain.mutableBytes, beforeBytes), afterBytes)
 	domain.writeGeneration++
-	for _, table := range obsoleteRootRuns {
-		resetCollectionRunTable(table)
-	}
-	for _, table := range obsoleteUniqueRuns {
-		resetCollectionRunTable(table)
-	}
 	rebuildBufferedPendingIndexesLocked(domain, domain.meta.Name, domain.primaryRunIndex != nil)
-	return true, nil
+	obsolete := make([]memtable.Table, 0, len(obsoleteRootRuns)+len(obsoleteUniqueRuns))
+	obsolete = append(obsolete, obsoleteRootRuns...)
+	obsolete = append(obsolete, obsoleteUniqueRuns...)
+	return obsolete, nil
 }
 
 func compactTableRunMap(runs map[string][]memtable.Table) (map[string][]memtable.Table, []memtable.Table, bool, error) {
@@ -2968,9 +2968,10 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	if domain == nil {
 		return
 	}
+	keep := bufferedIndexedCheckpointTableSet(checkpoint)
 	resetIndexedFlushUnitsAddedAfterCheckpoint(domain.indexedFlushUnits, checkpoint)
-	resetTableRunsAddedAfterCheckpoint(domain.rootRuns, checkpoint.rootRuns)
-	resetTableRunsAddedAfterCheckpoint(domain.uniqueValueRuns, checkpoint.uniqueValueRuns)
+	resetTablesNotInSet(domain.rootRuns, keep)
+	resetTablesNotInSet(domain.uniqueValueRuns, keep)
 	domain.loaded = checkpoint.loaded
 	domain.meta = checkpoint.meta
 	domain.catalog = checkpoint.catalog
@@ -3138,18 +3139,6 @@ func resetTablesNotInSet(runs map[string][]memtable.Table, keep map[memtable.Tab
 			if _, ok := keep[table]; ok {
 				continue
 			}
-			resetCollectionRunTable(table)
-		}
-	}
-}
-
-func resetTableRunsAddedAfterCheckpoint(current, checkpoint map[string][]memtable.Table) {
-	for name, runs := range current {
-		keep := 0
-		if checkpointRuns, ok := checkpoint[name]; ok {
-			keep = len(checkpointRuns)
-		}
-		for _, table := range runs[keep:] {
 			resetCollectionRunTable(table)
 		}
 	}
@@ -7796,7 +7785,8 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.writeGeneration++
 	domain.observeIndexedStage(modifiedCount, stagedBytes, stagedRootRuns)
 	c.meta = plan.meta
-	if _, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options); err != nil {
+	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options)
+	if err != nil {
 		if shouldAutoFlushAfterAdding {
 			rollbackBufferedIndexedDomain(domain, checkpoint)
 			c.meta = collectionMetaCheckpoint
@@ -7818,6 +7808,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			return false, err
 		}
 	}
+	resetCollectionTables(compactedObsolete)
 	plan.stats.BufferedBatches = 1
 	return true, nil
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -31,15 +31,17 @@ const (
 
 	// DefaultIndexedWriteMemtableMaxDocuments bounds the native indexed
 	// collection write-domain before it auto-flushes to persistent roots.
-	DefaultIndexedWriteMemtableMaxDocuments = 64000
+	DefaultIndexedWriteMemtableMaxDocuments = 96000
 	// DefaultIndexedWriteMemtableMaxRootRuns bounds accumulated root-local
-	// mutation runs so many small indexed update batches do not create an
-	// expensive pending-run chain before the document threshold is reached.
-	DefaultIndexedWriteMemtableMaxRootRuns = 16 * 1024
+	// mutation runs. When the document threshold is also enabled, hitting this
+	// limit compacts mutable root runs in memory before publishing so many small
+	// indexed update batches do not create an expensive pending-run chain before
+	// the document threshold is reached.
+	DefaultIndexedWriteMemtableMaxRootRuns = DefaultIndexedWriteMemtableMaxDocuments
 	// DefaultIndexedWriteMemtableDirectBatchDocuments keeps large, already
 	// well-amortized InsertBatch calls on the immediate publish path. Smaller
 	// batches use the indexed write-domain memtable path by default.
-	DefaultIndexedWriteMemtableDirectBatchDocuments = DefaultIndexedWriteMemtableMaxDocuments / 4
+	DefaultIndexedWriteMemtableDirectBatchDocuments = 16000
 	// DefaultIndexedWriteMemtableAsyncFlushMaxQueuedUnits bounds opt-in
 	// background indexed flush work. When the queue reaches this many immutable
 	// flush units, the triggering writer publishes synchronously to cap memory
@@ -2392,6 +2394,12 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	domain.writeGeneration++
 	domain.observeIndexedStage(len(plan.resultIDs), stagedBytes, stagedRootRuns)
 	c.meta = catalog.meta
+	if _, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, catalog.meta.Options); err != nil {
+		if autoFlushEnabled {
+			rollbackBufferedIndexedDomain(domain, checkpoint)
+		}
+		return 0, err
+	}
 	if shouldFlushBufferedIndexedWrites(domain, catalog.meta.Options) {
 		flushElapsed, _, _, err := c.flushBufferedIndexedAfterThresholdLocked(domain, catalog.meta.Options)
 		if err != nil {
@@ -2479,6 +2487,149 @@ func shouldFlushBufferedIndexedWritesAfterAdding(domain *collectionWriteDomain, 
 		return true
 	}
 	return false
+}
+
+func shouldCompactBufferedIndexedMutableRuns(domain *collectionWriteDomain, opts CollectionOptions) bool {
+	if domain == nil || domain.rootRunCount <= 0 {
+		return false
+	}
+	if opts.BufferedIndexedWriteMaxRootRuns <= 0 || opts.BufferedIndexedWriteMaxDocuments <= 0 {
+		return false
+	}
+	if domain.rootRunCount < opts.BufferedIndexedWriteMaxRootRuns {
+		return false
+	}
+	return domain.mutableCount < opts.BufferedIndexedWriteMaxDocuments
+}
+
+func maybeCompactBufferedIndexedMutableRunsLocked(domain *collectionWriteDomain, opts CollectionOptions) (bool, error) {
+	if !shouldCompactBufferedIndexedMutableRuns(domain, opts) {
+		return false, nil
+	}
+	beforeBytes := tableRunMapSize(domain.rootRuns) + tableRunMapSize(domain.uniqueValueRuns)
+	compactedRootRuns, obsoleteRootRuns, rootRunsChanged, err := compactTableRunMap(domain.rootRuns)
+	if err != nil {
+		return false, err
+	}
+	compactedUniqueRuns, obsoleteUniqueRuns, uniqueRunsChanged, err := compactTableRunMap(domain.uniqueValueRuns)
+	if err != nil {
+		resetTableRunMap(compactedRootRuns, domain.rootRuns)
+		return false, err
+	}
+	if !rootRunsChanged && !uniqueRunsChanged {
+		return false, nil
+	}
+	afterBytes := tableRunMapSize(compactedRootRuns) + tableRunMapSize(compactedUniqueRuns)
+	domain.rootRuns = compactedRootRuns
+	domain.uniqueValueRuns = compactedUniqueRuns
+	domain.rootRunCount = tableRunMapRunCount(domain.rootRuns)
+	domain.bufferedBytes = saturatingAddNonNegativeInt64(subtractNonNegativeInt64(domain.bufferedBytes, beforeBytes), afterBytes)
+	domain.mutableBytes = saturatingAddNonNegativeInt64(subtractNonNegativeInt64(domain.mutableBytes, beforeBytes), afterBytes)
+	domain.writeGeneration++
+	for _, table := range obsoleteRootRuns {
+		resetCollectionRunTable(table)
+	}
+	for _, table := range obsoleteUniqueRuns {
+		resetCollectionRunTable(table)
+	}
+	rebuildBufferedPendingIndexesLocked(domain, domain.meta.Name, domain.primaryRunIndex != nil)
+	return true, nil
+}
+
+func compactTableRunMap(runs map[string][]memtable.Table) (map[string][]memtable.Table, []memtable.Table, bool, error) {
+	if len(runs) == 0 {
+		return runs, nil, false, nil
+	}
+	out := make(map[string][]memtable.Table, len(runs))
+	var obsolete []memtable.Table
+	changed := false
+	for name, tables := range runs {
+		if len(tables) <= 1 {
+			out[name] = tables
+			continue
+		}
+		table, err := compactTableRuns(tables)
+		if err != nil {
+			resetTableRunMap(out, runs)
+			return nil, nil, false, err
+		}
+		out[name] = []memtable.Table{table}
+		obsolete = append(obsolete, tables...)
+		changed = true
+	}
+	return out, obsolete, changed, nil
+}
+
+func compactTableRuns(runs []memtable.Table) (memtable.Table, error) {
+	entryCapacity := 0
+	for _, table := range runs {
+		if table != nil {
+			entryCapacity = saturatingAddNonNegativeInt(entryCapacity, table.Len())
+		}
+	}
+	table := newCollectionRunTable(entryCapacity)
+	iter := newBufferedRootRunsIteratorWithDeleted(runs, nil, nil, true)
+	defer func() { _ = iter.Close() }()
+	for ; iter.Valid(); iter.Next() {
+		key := bytes.Clone(iter.UnsafeKey())
+		value, ptr, flags := iter.UnsafeEntry()
+		var valueCopy []byte
+		if value != nil {
+			valueCopy = bytes.Clone(value)
+		}
+		table.SetEntrySteal(key, valueCopy, ptr, flags)
+	}
+	if err := iter.Error(); err != nil {
+		resetCollectionRunTable(table)
+		return nil, err
+	}
+	table.Freeze()
+	return table, nil
+}
+
+func resetTableRunMap(runs, preserved map[string][]memtable.Table) {
+	if len(runs) == 0 {
+		return
+	}
+	preservedTables := make(map[memtable.Table]struct{})
+	for _, tables := range preserved {
+		for _, table := range tables {
+			if table != nil {
+				preservedTables[table] = struct{}{}
+			}
+		}
+	}
+	for _, tables := range runs {
+		for _, table := range tables {
+			if table == nil {
+				continue
+			}
+			if _, ok := preservedTables[table]; ok {
+				continue
+			}
+			resetCollectionRunTable(table)
+		}
+	}
+}
+
+func tableRunMapSize(runs map[string][]memtable.Table) int64 {
+	var total int64
+	for _, tables := range runs {
+		for _, table := range tables {
+			if table != nil {
+				total = saturatingAddNonNegativeInt64(total, table.Size())
+			}
+		}
+	}
+	return total
+}
+
+func tableRunMapRunCount(runs map[string][]memtable.Table) int {
+	total := 0
+	for _, tables := range runs {
+		total = saturatingAddNonNegativeInt(total, len(tables))
+	}
+	return total
 }
 
 func bufferedIndexedRootRunCount(domain *collectionWriteDomain) int {
@@ -7645,6 +7796,13 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	domain.writeGeneration++
 	domain.observeIndexedStage(modifiedCount, stagedBytes, stagedRootRuns)
 	c.meta = plan.meta
+	if _, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options); err != nil {
+		if shouldAutoFlushAfterAdding {
+			rollbackBufferedIndexedDomain(domain, checkpoint)
+			c.meta = collectionMetaCheckpoint
+		}
+		return false, err
+	}
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4050,6 +4050,96 @@ func TestCollectionIndexedWriteMemtablesAutoFlushMaxBytes(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedWriteMemtablesCompactRootRunsBeforeDocumentFlush(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 5,
+			BufferedIndexedWriteMaxRootRuns:  6,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	for i, id := range []string{"u1", "u2"} {
+		doc := fmt.Sprintf(`{"email":"user%d@example.com"}`, i+1)
+		if _, err := col.InsertBatch([][]byte{[]byte(id)}, [][]byte{[]byte(doc)}); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot before document threshold")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog before document threshold: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got != 0 {
+		t.Fatalf("primary root persisted before document threshold: %d", got)
+	}
+
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	rootNames := len(col.writeDomain.rootRuns)
+	uniqueRuns := len(col.writeDomain.uniqueValueRuns["email"])
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != rootNames {
+		t.Fatalf("rootRunCount=%d rootNames=%d, want compacted one run per root", rootRunCount, rootNames)
+	}
+	if uniqueRuns != 1 {
+		t.Fatalf("unique value runs=%d want 1 compacted run", uniqueRuns)
+	}
+	got, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get pending compacted doc: %v", err)
+	}
+	if got == nil {
+		t.Fatal("pending compacted doc not visible")
+	}
+	ids, err := col.FindByIndex("email", "user2@example.com")
+	if err != nil {
+		t.Fatalf("find pending compacted email: %v", err)
+	}
+	if !reflect.DeepEqual(ids, [][]byte{[]byte("u2")}) {
+		t.Fatalf("pending compacted email ids=%q want [u2]", ids)
+	}
+
+	for i, id := range []string{"u3", "u4", "u5"} {
+		doc := fmt.Sprintf(`{"email":"user%d@example.com"}`, i+3)
+		if _, err := col.InsertBatch([][]byte{[]byte(id)}, [][]byte{[]byte(doc)}); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+	snap = d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot after document threshold")
+	}
+	catalog, err = loadCollectionCatalog(snap, "users")
+	_ = snap.Close()
+	if err != nil {
+		t.Fatalf("load catalog after document threshold: %v", err)
+	}
+	if got := catalog.rootID(collectionPrimaryRootName("users")); got == 0 {
+		t.Fatal("primary root was not persisted after document threshold")
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesAutoFlushMaxRootRuns(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4489,6 +4489,86 @@ func TestRollbackBufferedIndexedDomainRestoresPreRotationRuns(t *testing.T) {
 	resetCollectionRunTable(oldTable)
 }
 
+func TestRollbackBufferedIndexedDomainPreservesCompactedCheckpointRuns(t *testing.T) {
+	primaryName := collectionPrimaryRootName("users")
+	emailUniqueName := collectionSecondaryRootName("users", "email")
+	primaryOld := newCollectionRunTable(1)
+	setCollectionRunValue(primaryOld, []byte("u1"), []byte(`{"email":"a@example.com","city":"nyc"}`))
+	primaryOld.Freeze()
+	primaryNew := newCollectionRunTable(1)
+	setCollectionRunValue(primaryNew, []byte("u1"), []byte(`{"email":"a@example.com","city":"sf"}`))
+	primaryNew.Freeze()
+	uniqueOld := newCollectionRunTable(1)
+	setCollectionRunValue(uniqueOld, []byte("a@example.com"), nil)
+	uniqueOld.Freeze()
+	uniqueNew := newCollectionRunTable(1)
+	setCollectionRunValue(uniqueNew, []byte("b@example.com"), nil)
+	uniqueNew.Freeze()
+
+	domain := &collectionWriteDomain{
+		loaded:         true,
+		meta:           CollectionMeta{Name: "users"},
+		catalog:        &collectionCatalog{meta: CollectionMeta{Name: "users"}, roots: map[string]uint64{primaryName: 42, emailUniqueName: 43}},
+		baseCommitSeq:  7,
+		baseSystemRoot: 11,
+		primaryRoot:    42,
+		count:          1,
+		mutableCount:   1,
+		rootRuns: map[string][]memtable.Table{
+			primaryName: {primaryOld, primaryNew},
+		},
+		rootPolicies: map[string]backenddb.OrderedRootStoragePolicy{
+			primaryName: backenddb.OrderedRootStorageDefault,
+		},
+		rootBaseIDs: map[string]uint64{
+			primaryName: 42,
+		},
+		uniqueValueRuns: map[string][]memtable.Table{
+			"email": {uniqueOld, uniqueNew},
+		},
+		rootRunCount: 2,
+	}
+	checkpoint := checkpointBufferedIndexedDomain(domain)
+
+	obsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, CollectionOptions{
+		BufferedIndexedWriteMaxDocuments: 3,
+		BufferedIndexedWriteMaxRootRuns:  2,
+	})
+	if err != nil {
+		t.Fatalf("compact mutable runs: %v", err)
+	}
+	if len(domain.rootRuns[primaryName]) != 1 {
+		t.Fatalf("compacted primary run count=%d want 1", len(domain.rootRuns[primaryName]))
+	}
+	if len(domain.uniqueValueRuns["email"]) != 1 {
+		t.Fatalf("compacted unique run count=%d want 1", len(domain.uniqueValueRuns["email"]))
+	}
+	if len(obsolete) != 4 {
+		t.Fatalf("obsolete table count=%d want 4", len(obsolete))
+	}
+
+	rollbackBufferedIndexedDomain(domain, checkpoint)
+	primaryRuns := domain.rootRuns[primaryName]
+	if len(primaryRuns) != 2 || primaryRuns[0] != primaryOld || primaryRuns[1] != primaryNew {
+		t.Fatalf("primary runs after rollback=%v want checkpoint tables", primaryRuns)
+	}
+	value, _, flags, found := getBufferedRunEntry(primaryRuns, []byte("u1"))
+	if !found || flags&node.FlagTombstone != 0 || !bytes.Equal(value, []byte(`{"email":"a@example.com","city":"sf"}`)) {
+		t.Fatalf("primary value after rollback found=%v flags=%d value=%q", found, flags, value)
+	}
+	uniqueRuns := domain.uniqueValueRuns["email"]
+	if len(uniqueRuns) != 2 || uniqueRuns[0] != uniqueOld || uniqueRuns[1] != uniqueNew {
+		t.Fatalf("unique runs after rollback=%v want checkpoint tables", uniqueRuns)
+	}
+	if _, _, flags, found := getBufferedRunEntry(uniqueRuns, []byte("a@example.com")); !found || flags&node.FlagTombstone != 0 {
+		t.Fatalf("unique a@example.com after rollback found=%v flags=%d", found, flags)
+	}
+	if _, _, flags, found := getBufferedRunEntry(uniqueRuns, []byte("b@example.com")); !found || flags&node.FlagTombstone != 0 {
+		t.Fatalf("unique b@example.com after rollback found=%v flags=%d", found, flags)
+	}
+	resetCollectionTables(obsolete)
+}
+
 func TestHasBufferedPrimaryRootRunsIgnoresSecondaryOnlyRuns(t *testing.T) {
 	domain := &collectionWriteDomain{
 		meta: CollectionMeta{Name: "users"},

--- a/cmd/collection_load_fixture/README.md
+++ b/cmd/collection_load_fixture/README.md
@@ -16,7 +16,7 @@ Default load shape:
 - two secondary indexes: unique `email_idx` and non-unique `city_idx`
 - collection data/index-state outer leaves in the value log
 - secondary-index outer leaves in the value log
-- native indexed write memtables enabled with a default 64000-document
+- native indexed write memtables enabled with a default 96000-document
   auto-flush limit; batches at 16000 documents or larger use direct publish by
   default because they already amortize publish overhead well
 - `fast` TreeDB profile
@@ -52,12 +52,12 @@ Useful variants:
 ./bin/collection-load-fixture -index-outer-leaves-in-vlog=false -dir /tmp/treedb_two_index_template_v1_fast_index -reset
 
 # Native indexed write memtables are enabled by default. This explicitly keeps
-# them enabled and force-bounds publishes every 64000 staged docs; very large
+# them enabled and force-bounds publishes every 96000 staged docs; very large
 # batches at the default 16000-document direct-publish threshold still bypass
 # staging.
 ./bin/collection-load-fixture \
   -buffered-indexed-writes=true \
-  -buffered-indexed-write-max-docs 64000 \
+  -buffered-indexed-write-max-docs 96000 \
   -buffered-indexed-write-max-root-runs 256 \
   -dir /tmp/treedb_two_index_buffered_bounded \
   -reset

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -92,8 +92,8 @@ collection benchmark profile:
 - `-treedb-data-root-storage compressed`
 - `-treedb-index-state-root-storage compressed`
 - `-treedb-index-root-storage compressed`
-- `-treedb-buffered-indexed-write-max-documents 64000`
-- `-treedb-buffered-indexed-write-max-root-runs 4096`
+- `-treedb-buffered-indexed-write-max-documents 96000`
+- `-treedb-buffered-indexed-write-max-root-runs 96000`
 - `-treedb-maintenance full`
 - `-client-mode driver`
 


### PR DESCRIPTION
## Summary

Part of #1159.

This PR attacks the sparse flush/root-apply amplification exposed by #1188's zipper counters:

- raise the native indexed write-domain default document threshold from 64k to 96k;
- keep the large InsertBatch direct-publish bypass fixed at 16k so the insert path does not accidentally move when the document threshold changes;
- raise the default root-run threshold to the same 96k level for common one-root update buffering;
- add an in-memory mutable root-run compaction safety valve when both document and root-run thresholds are configured and the root-run threshold is hit before the document threshold.

The compaction path collapses multiple pending mutable runs per root into one latest-value/tombstone-preserving run, also compacts pending unique-value runs, rebuilds buffered lookup indexes, and only then re-evaluates whether a persistent flush is actually needed. Explicit root-run-only configurations still flush on the root-run threshold; this preserves the existing root-run-only behavior covered by tests.

## Why

After #1187, the focused non-indexed-field BSON update shape only publishes the primary root. #1188 then showed the remaining cost was leaf-log root apply work. A threshold sanity check showed that fewer, denser flushes materially reduce leaf-log reads/writes and internal child refs per document, but a blind 200k threshold had too much staged allocation. The 96k point is a more conservative default: fewer sparse publishes than 64k, much less staged allocation than the 200k single-flush experiment.

## Validation

```bash
go test ./TreeDB/collections -run 'TestCollectionIndexedWriteMemtablesCompactRootRunsBeforeDocumentFlush|TestCollectionIndexedWriteMemtablesAutoFlushMaxRootRuns|TestCollectionIndexedWriteMemtablesAutoFlushMaxDocuments|TestCollectionIndexedWriteMemtablesBypassDefaultLargeBatches' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/mongo_gateway_bench -run 'TestProfileBenchBufferedIndexedAsyncFlushEnv|TestProfileBenchDeltaUintStat|TestBenchmarkSetUpdateCanExerciseIndexedField' -count=1
```

All passed locally.

## Focused Update Benchmark

Command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=200000x \
  -benchmem \
  -count=1
```

Baseline `origin/main` at #1188 head / 64k defaults, representative local rerun:

```text
200000  7404 ns/op  135065 docs/sec  1386 B/op  4 allocs/op
buffered_max_docs=64000
buffered_max_root_runs=16384
publish_delta_group_calls/doc=0.0000200
publish_delta_group_root_apply_ns/doc=2786
publish_delta_group_root_apply_leaf_log_node_loads/doc=0.3599
publish_delta_group_root_apply_leaf_log_pages_written/doc=0.4369
publish_delta_group_root_apply_internal_child_refs/doc=0.7994
```

This PR at `7d6a319eb5` / 96k defaults:

```text
200000  6706 ns/op  149112 docs/sec  1398 B/op  4 allocs/op
buffered_max_docs=96000
buffered_max_root_runs=96000
publish_delta_group_calls/doc=0.0000150
publish_delta_group_root_apply_ns/doc=1886
publish_delta_group_root_apply_leaf_log_node_loads/doc=0.2677
publish_delta_group_root_apply_leaf_log_pages_written/doc=0.3446
publish_delta_group_root_apply_internal_child_refs/doc=0.6226
```

Readout:

- throughput improved from ~135k to ~149k docs/sec in this local single-run comparison;
- root-apply time dropped from ~2.8us/doc to ~1.9us/doc;
- leaf-log node loads/doc dropped about 26%;
- leaf-log pages written/doc dropped about 21%;
- internal child refs/doc dropped about 22%;
- allocation count stayed at 4 allocs/op and B/op stayed roughly flat.

The benchmark is still noisy, so the important result is not the exact docs/sec point estimate. The important result is that root-apply structural counters move in the intended direction because the workload performs fewer sparse persistent publishes.

## Insert Sanity Benchmark

Command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=10000 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionLoadBSONIndexes2$' \
  -benchtime=200000x \
  -benchmem \
  -count=1
```

Result on this PR:

```text
200000  1604 ns/op  623331 docs/sec  4621 B/op  1 allocs/op
buffered_max_docs=96000
buffered_max_root_runs=96000
```
