### PR TITLE
Report update combiner metrics in profile bench

### DIFF
--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -780,6 +780,44 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateBatchSecondaryDeletes:    after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
 		UpdateBatchSecondarySets:       after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
 		UpdateBatchSecondaryKeyBytes:   after.UpdateBatchSecondaryKeyBytes - before.UpdateBatchSecondaryKeyBytes,
+		UpdateCombineRequests:          after.UpdateCombineRequests - before.UpdateCombineRequests,
+		UpdateCombineBatches:           after.UpdateCombineBatches - before.UpdateCombineBatches,
+		UpdateCombineBatchedRequests:   after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
+		UpdateCombineFallbackRequests:  after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
+		UpdateCombineQueueDepthMax:     after.UpdateCombineQueueDepthMax,
+	}
+}
+
+func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
+	before := collections.CollectionManagerStats{
+		UpdateCombineRequests:         10,
+		UpdateCombineBatches:          3,
+		UpdateCombineBatchedRequests:  8,
+		UpdateCombineFallbackRequests: 1,
+		UpdateCombineQueueDepthMax:    4,
+	}
+	after := collections.CollectionManagerStats{
+		UpdateCombineRequests:         17,
+		UpdateCombineBatches:          5,
+		UpdateCombineBatchedRequests:  14,
+		UpdateCombineFallbackRequests: 2,
+		UpdateCombineQueueDepthMax:    9,
+	}
+	got := deltaCollectionManagerUpdateStats(after, before)
+	if got.UpdateCombineRequests != 7 {
+		t.Fatalf("UpdateCombineRequests=%d want 7", got.UpdateCombineRequests)
+	}
+	if got.UpdateCombineBatches != 2 {
+		t.Fatalf("UpdateCombineBatches=%d want 2", got.UpdateCombineBatches)
+	}
+	if got.UpdateCombineBatchedRequests != 6 {
+		t.Fatalf("UpdateCombineBatchedRequests=%d want 6", got.UpdateCombineBatchedRequests)
+	}
+	if got.UpdateCombineFallbackRequests != 1 {
+		t.Fatalf("UpdateCombineFallbackRequests=%d want 1", got.UpdateCombineFallbackRequests)
+	}
+	if got.UpdateCombineQueueDepthMax != 9 {
+		t.Fatalf("UpdateCombineQueueDepthMax=%d want observed max 9", got.UpdateCombineQueueDepthMax)
 	}
 }
 
@@ -803,6 +841,25 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	}
 	if stats.UpdateBatchBufferedBatches > 0 {
 		b.ReportMetric(float64(stats.UpdateBatchBufferedBatches), "update_buffered_batches")
+	}
+	if stats.UpdateCombineRequests > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineRequests), "update_combine_requests")
+		b.ReportMetric(float64(stats.UpdateCombineRequests)/float64(docs), "update_combine_requests/doc")
+	}
+	if stats.UpdateCombineBatches > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineBatches), "update_combine_batches")
+		b.ReportMetric(float64(stats.UpdateCombineBatchedRequests)/float64(stats.UpdateCombineBatches), "update_combine_items/batch")
+	}
+	if stats.UpdateCombineBatchedRequests > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineBatchedRequests), "update_combine_batched_requests")
+		b.ReportMetric(float64(stats.UpdateCombineBatchedRequests)/float64(docs), "update_combine_batched_requests/doc")
+	}
+	if stats.UpdateCombineFallbackRequests > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineFallbackRequests), "update_combine_fallback_requests")
+		b.ReportMetric(float64(stats.UpdateCombineFallbackRequests)/float64(docs), "update_combine_fallback_requests/doc")
+	}
+	if stats.UpdateCombineQueueDepthMax > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineQueueDepthMax), "update_combine_queue_depth_max")
 	}
 	if stats.UpdateBatchSecondaryDeletes > 0 {
 		b.ReportMetric(float64(stats.UpdateBatchSecondaryDeletes)/float64(docs), "update_secondary_deletes/doc")

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -784,7 +784,6 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateCombineBatches:           after.UpdateCombineBatches - before.UpdateCombineBatches,
 		UpdateCombineBatchedRequests:   after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
 		UpdateCombineFallbackRequests:  after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
-		UpdateCombineQueueDepthMax:     after.UpdateCombineQueueDepthMax,
 	}
 }
 
@@ -794,14 +793,12 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateCombineBatches:          3,
 		UpdateCombineBatchedRequests:  8,
 		UpdateCombineFallbackRequests: 1,
-		UpdateCombineQueueDepthMax:    4,
 	}
 	after := collections.CollectionManagerStats{
 		UpdateCombineRequests:         17,
 		UpdateCombineBatches:          5,
 		UpdateCombineBatchedRequests:  14,
 		UpdateCombineFallbackRequests: 2,
-		UpdateCombineQueueDepthMax:    9,
 	}
 	got := deltaCollectionManagerUpdateStats(after, before)
 	if got.UpdateCombineRequests != 7 {
@@ -815,9 +812,6 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	}
 	if got.UpdateCombineFallbackRequests != 1 {
 		t.Fatalf("UpdateCombineFallbackRequests=%d want 1", got.UpdateCombineFallbackRequests)
-	}
-	if got.UpdateCombineQueueDepthMax != 9 {
-		t.Fatalf("UpdateCombineQueueDepthMax=%d want observed max 9", got.UpdateCombineQueueDepthMax)
 	}
 }
 
@@ -857,9 +851,6 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	if stats.UpdateCombineFallbackRequests > 0 {
 		b.ReportMetric(float64(stats.UpdateCombineFallbackRequests), "update_combine_fallback_requests")
 		b.ReportMetric(float64(stats.UpdateCombineFallbackRequests)/float64(docs), "update_combine_fallback_requests/doc")
-	}
-	if stats.UpdateCombineQueueDepthMax > 0 {
-		b.ReportMetric(float64(stats.UpdateCombineQueueDepthMax), "update_combine_queue_depth_max")
 	}
 	if stats.UpdateBatchSecondaryDeletes > 0 {
 		b.ReportMetric(float64(stats.UpdateBatchSecondaryDeletes)/float64(docs), "update_secondary_deletes/doc")


### PR DESCRIPTION
## Summary

- Adds update-combiner request/batch/fallback counters to `BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2` output.
- Keeps existing update batch metrics and adds a focused regression test that `deltaCollectionManagerUpdateStats` carries interval-safe combiner stats.
- This is instrumentation for #1159 so future combiner batching/coalescing experiments can be judged by actual batch fullness and fallback behavior.

## Validation

```bash
go test ./cmd/mongo_gateway_bench \
  -run 'TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats|TestProfileBenchBufferedIndexedAsyncFlushEnv|TestProfileBenchDeltaUintStat|TestBenchmarkSetUpdateCanExerciseIndexedField' \
  -count=1

go test ./cmd/mongo_gateway_bench -count=1

git diff --check
```

## Benchmark Smoke

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=8 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=200000x \
  -benchmem \
  -count=1
```

Representative added metrics from the latest smoke run:

```text
update_combine_requests=200000
update_combine_requests/doc=1.000
update_combine_batches=52733
update_combine_items/batch=3.793
update_combine_batched_requests=200000
update_combine_batched_requests/doc=1.000
```

This confirms the current 8-writer focused benchmark is only reaching about 3.7-4.0 requests per combiner batch, which should be tracked explicitly before changing coalescing behavior. `UpdateCombineQueueDepthMax` is intentionally not reported here because it is a monotonic max across prior warmup phases, not an interval-safe timed-run delta.

Related issue: #1159
