### PR TITLE
Use leaf-page cache for snapshot leaf-log reads

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -981,7 +981,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	snap.state = state
 	snap.vlogManager = vm
 	snap.vlogPinned = vlogNeedsPin
-	snap.reader.reconfigure(vlogSet)
+	snap.reader.reconfigure(vlogSet, db.leafPageReadCache)
 	for i := range snap.rootTrees {
 		snap.rootTrees[i].root = 0
 		snap.rootTrees[i].tree.Reset(nil, nil, 0)

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -229,6 +229,36 @@ func TestValueReaderLeafLogPageUnsafeToUsesCacheHit(t *testing.T) {
 	}
 }
 
+func TestValueReaderLeafLogPageUnsafeToSmallDstBypassesCache(t *testing.T) {
+	cache := newLeafPageReadCache(8)
+	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
+	cachedLeaf := bytes.Repeat([]byte{0x33}, page.PageSize)
+	fallbackLeaf := bytes.Repeat([]byte{0x55}, page.PageSize)
+	cache.store(ptr, cachedLeaf)
+
+	fallback := &leafPageCacheTestFallback{data: fallbackLeaf}
+	reader := valueReader{
+		vlogs:         fallback,
+		leafPageCache: cache,
+	}
+	got, usedDst, err := reader.ReadLeafLogPageUnsafeTo(ptr, nil)
+	if err != nil {
+		t.Fatalf("ReadLeafLogPageUnsafeTo: %v", err)
+	}
+	if usedDst {
+		t.Fatal("nil dst should not report usedDst")
+	}
+	if !bytes.Equal(got, fallbackLeaf) {
+		t.Fatal("small-dst read should use fallback instead of copying from cache")
+	}
+	if fallback.readUnsafeToCalls != 1 {
+		t.Fatalf("fallback ReadUnsafeTo calls=%d, want 1", fallback.readUnsafeToCalls)
+	}
+	if stats := cache.stats(); stats.Hits != 0 || stats.Misses != 0 || stats.Stores != 1 {
+		t.Fatalf("stats=%+v, want cache bypass without extra store", stats)
+	}
+}
+
 func TestValueReaderLeafLogPageUnsafeToStoresFallbackLeafPage(t *testing.T) {
 	cache := newLeafPageReadCache(8)
 	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -15,6 +15,13 @@ type leafPageCacheTestFallback struct {
 	data              []byte
 }
 
+func (f *leafPageCacheTestFallback) Read(ptr page.ValuePtr) ([]byte, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return append([]byte(nil), f.data...), nil
+}
+
 func (f *leafPageCacheTestFallback) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
 	f.readUnsafeCalls++
 	if f.err != nil {
@@ -40,6 +47,13 @@ type leafPageCacheUnsafeOnlyFallback struct {
 	readUnsafeCalls int
 	err             error
 	data            []byte
+}
+
+func (f *leafPageCacheUnsafeOnlyFallback) Read(ptr page.ValuePtr) ([]byte, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return append([]byte(nil), f.data...), nil
 }
 
 func (f *leafPageCacheUnsafeOnlyFallback) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
@@ -186,6 +200,73 @@ func TestCachedLeafPageReaderMissUsesReadUnsafeFallback(t *testing.T) {
 	}
 	if stats := cache.stats(); stats.Misses != 1 {
 		t.Fatalf("misses=%d, want 1", stats.Misses)
+	}
+}
+
+func TestValueReaderLeafLogPageUnsafeToUsesCacheHit(t *testing.T) {
+	cache := newLeafPageReadCache(8)
+	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
+	leaf := bytes.Repeat([]byte{0x33}, page.PageSize)
+	cache.store(ptr, leaf)
+
+	reader := valueReader{
+		vlogs:         &leafPageCacheTestFallback{err: errors.New("fallback should not be used")},
+		leafPageCache: cache,
+	}
+	dst := make([]byte, 0, page.PageSize)
+	got, usedDst, err := reader.ReadLeafLogPageUnsafeTo(ptr, dst)
+	if err != nil {
+		t.Fatalf("ReadLeafLogPageUnsafeTo: %v", err)
+	}
+	if !usedDst {
+		t.Fatal("expected cache hit to copy into dst")
+	}
+	if !bytes.Equal(got, leaf) {
+		t.Fatal("cached leaf mismatch")
+	}
+	if stats := cache.stats(); stats.Hits != 1 || stats.Misses != 0 || stats.Stores != 1 {
+		t.Fatalf("stats=%+v, want one hit and one store", stats)
+	}
+}
+
+func TestValueReaderLeafLogPageUnsafeToStoresFallbackLeafPage(t *testing.T) {
+	cache := newLeafPageReadCache(8)
+	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
+	leaf := bytes.Repeat([]byte{0x44}, page.PageSize)
+	fallback := &leafPageCacheTestFallback{data: leaf}
+	reader := valueReader{
+		vlogs:         fallback,
+		leafPageCache: cache,
+	}
+
+	dst := make([]byte, 0, page.PageSize)
+	got, usedDst, err := reader.ReadLeafLogPageUnsafeTo(ptr, dst)
+	if err != nil {
+		t.Fatalf("ReadLeafLogPageUnsafeTo: %v", err)
+	}
+	if !usedDst {
+		t.Fatal("expected fallback ReadUnsafeTo to use dst")
+	}
+	if !bytes.Equal(got, leaf) {
+		t.Fatal("fallback leaf mismatch")
+	}
+	if fallback.readUnsafeToCalls != 1 {
+		t.Fatalf("fallback ReadUnsafeTo calls=%d, want 1", fallback.readUnsafeToCalls)
+	}
+
+	fallback.err = errors.New("fallback should not be used after cache store")
+	again, usedDst, err := reader.ReadLeafLogPageUnsafeTo(ptr, dst[:0])
+	if err != nil {
+		t.Fatalf("ReadLeafLogPageUnsafeTo cached: %v", err)
+	}
+	if !usedDst || !bytes.Equal(again, leaf) {
+		t.Fatalf("cached leaf mismatch usedDst=%v", usedDst)
+	}
+	if fallback.readUnsafeToCalls != 1 {
+		t.Fatalf("fallback calls after cache hit=%d, want 1", fallback.readUnsafeToCalls)
+	}
+	if stats := cache.stats(); stats.Hits != 1 || stats.Misses != 1 || stats.Stores != 1 {
+		t.Fatalf("stats=%+v, want one miss, one store, one hit", stats)
 	}
 }
 

--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -25,7 +25,8 @@ type readChecksumCapability interface {
 
 // valueReader resolves value-log pointers for tree lookups/iterators.
 type valueReader struct {
-	vlogs tree.SlabReader
+	vlogs         tree.SlabReader
+	leafPageCache *leafPageReadCache
 }
 
 // ValueReaderForState returns a reader that resolves value-log pointers.
@@ -40,11 +41,12 @@ func newValueReader(vlogs tree.SlabReader) valueReader {
 	return valueReader{vlogs: vlogs}
 }
 
-func (r *valueReader) reconfigure(vlogs tree.SlabReader) {
+func (r *valueReader) reconfigure(vlogs tree.SlabReader, leafPageCache *leafPageReadCache) {
 	if r == nil {
 		return
 	}
 	r.vlogs = vlogs
+	r.leafPageCache = leafPageCache
 }
 
 func (r valueReader) Read(ptr page.ValuePtr) ([]byte, error) {
@@ -83,6 +85,25 @@ func (r valueReader) ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]byte, bool, 
 		return nil, false, err
 	}
 	return val, false, nil
+}
+
+func (r valueReader) ReadLeafLogPageUnsafeTo(ptr page.LeafLogPtr, dst []byte) ([]byte, bool, error) {
+	if r.vlogs == nil {
+		return nil, false, errors.New("treedb: missing value-log reader")
+	}
+	if r.leafPageCache != nil {
+		if val, usedDst, ok := r.leafPageCache.getTo(ptr, dst); ok {
+			return val, usedDst, nil
+		}
+	}
+	val, usedDst, err := r.ReadUnsafeTo(ptr.ValuePtr(), dst)
+	if err != nil {
+		return nil, false, err
+	}
+	if r.leafPageCache != nil && len(val) == page.PageSize {
+		r.leafPageCache.store(ptr, val)
+	}
+	return val, usedDst, nil
 }
 
 func (r valueReader) ReadUnsafeAppend(ptr page.ValuePtr, dst []byte) ([]byte, error) {

--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -91,7 +91,7 @@ func (r valueReader) ReadLeafLogPageUnsafeTo(ptr page.LeafLogPtr, dst []byte) ([
 	if r.vlogs == nil {
 		return nil, false, errors.New("treedb: missing value-log reader")
 	}
-	if r.leafPageCache != nil {
+	if r.leafPageCache != nil && cap(dst) >= page.PageSize {
 		if val, usedDst, ok := r.leafPageCache.getTo(ptr, dst); ok {
 			return val, usedDst, nil
 		}
@@ -100,7 +100,7 @@ func (r valueReader) ReadLeafLogPageUnsafeTo(ptr page.LeafLogPtr, dst []byte) ([
 	if err != nil {
 		return nil, false, err
 	}
-	if r.leafPageCache != nil && len(val) == page.PageSize {
+	if r.leafPageCache != nil && cap(dst) >= page.PageSize && len(val) == page.PageSize {
 		r.leafPageCache.store(ptr, val)
 	}
 	return val, usedDst, nil

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -1026,17 +1026,11 @@ func (it *Iterator) loadNodeRef(ref page.ChildRef) (node.Node, error) {
 		if err != nil {
 			return node.Node{}, err
 		}
-		if len(data) != page.PageSize {
-			return node.Node{}, fmt.Errorf("invalid leaf page size %d for leaf-log ref file=%d offset=%d", len(data), ptr.FileID, ptr.Offset)
+		n, err := validateLeafLogNode(data, ptr, it.tree.shouldVerifyLeafRefChecksum(), true)
+		if err != nil {
+			it.leafRefScratch = it.leafRefScratch[:0]
+			return node.Node{}, err
 		}
-		n := node.NewNodeView(data)
-		if it.tree.shouldVerifyLeafRefChecksum() && !n.VerifyChecksum() {
-			return node.Node{}, fmt.Errorf("checksum mismatch on leaf-log ref file=%d offset=%d", ptr.FileID, ptr.Offset)
-		}
-		if n.Type() != page.PageTypeLeaf {
-			return node.Node{}, fmt.Errorf("invalid page type %d at leaf-log ref file=%d offset=%d", n.Type(), ptr.FileID, ptr.Offset)
-		}
-		noteOuterLeafLoad(ptr.ValuePtr(), len(data), true)
 		if usedDst {
 			it.leafRefScratch = data[:0]
 		} else {
@@ -1053,17 +1047,11 @@ func (it *Iterator) loadNodeRef(ref page.ChildRef) (node.Node, error) {
 		if err != nil {
 			return node.Node{}, err
 		}
-		if len(data) != page.PageSize {
-			return node.Node{}, fmt.Errorf("invalid leaf page size %d for leaf-log ref file=%d offset=%d", len(data), ptr.FileID, ptr.Offset)
+		n, err := validateLeafLogNode(data, ptr, it.tree.shouldVerifyLeafRefChecksum(), true)
+		if err != nil {
+			it.leafRefScratch = it.leafRefScratch[:0]
+			return node.Node{}, err
 		}
-		n := node.NewNodeView(data)
-		if it.tree.shouldVerifyLeafRefChecksum() && !n.VerifyChecksum() {
-			return node.Node{}, fmt.Errorf("checksum mismatch on leaf-log ref file=%d offset=%d", ptr.FileID, ptr.Offset)
-		}
-		if n.Type() != page.PageTypeLeaf {
-			return node.Node{}, fmt.Errorf("invalid page type %d at leaf-log ref file=%d offset=%d", n.Type(), ptr.FileID, ptr.Offset)
-		}
-		noteOuterLeafLoad(ptr.ValuePtr(), len(data), true)
 		it.leafRefScratch = data[:0]
 		return n, nil
 	}

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -1017,6 +1017,33 @@ func (it *Iterator) loadNodeRef(ref page.ChildRef) (node.Node, error) {
 	if it == nil || it.tree == nil {
 		return node.Node{}, errors.New("missing tree")
 	}
+	if ref.Kind == page.ChildRefLeafLog && it.tree.leafLogToReader != nil {
+		ptr := ref.Log
+		if cap(it.leafRefScratch) != page.PageSize {
+			it.leafRefScratch = make([]byte, 0, page.PageSize)
+		}
+		data, usedDst, err := it.tree.leafLogToReader.ReadLeafLogPageUnsafeTo(ptr, it.leafRefScratch[:0])
+		if err != nil {
+			return node.Node{}, err
+		}
+		if len(data) != page.PageSize {
+			return node.Node{}, fmt.Errorf("invalid leaf page size %d for leaf-log ref file=%d offset=%d", len(data), ptr.FileID, ptr.Offset)
+		}
+		n := node.NewNodeView(data)
+		if it.tree.shouldVerifyLeafRefChecksum() && !n.VerifyChecksum() {
+			return node.Node{}, fmt.Errorf("checksum mismatch on leaf-log ref file=%d offset=%d", ptr.FileID, ptr.Offset)
+		}
+		if n.Type() != page.PageTypeLeaf {
+			return node.Node{}, fmt.Errorf("invalid page type %d at leaf-log ref file=%d offset=%d", n.Type(), ptr.FileID, ptr.Offset)
+		}
+		noteOuterLeafLoad(ptr.ValuePtr(), len(data), true)
+		if usedDst {
+			it.leafRefScratch = data[:0]
+		} else {
+			it.leafRefScratch = it.leafRefScratch[:0]
+		}
+		return n, nil
+	}
 	if ref.Kind == page.ChildRefLeafLog && it.slabAppender != nil {
 		ptr := ref.Log
 		if cap(it.leafRefScratch) != page.PageSize {

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -121,6 +121,13 @@ type slabUnsafeKeyBatchAppender interface {
 	ReadUnsafeAppendBatchForKeys(ptrs []page.ValuePtr, keys [][]byte, dst [][]byte) ([][]byte, error)
 }
 
+// Optional fast path for leaf-log page reads. Unlike SlabReader, this receives
+// the typed leaf-log pointer so implementations can safely use page-only caches
+// without confusing ordinary value-log payloads with B-tree leaf pages.
+type leafLogPageUnsafeToReader interface {
+	ReadLeafLogPageUnsafeTo(ptr page.LeafLogPtr, dst []byte) ([]byte, bool, error)
+}
+
 // Optional capability gate for key-aware pointer read interfaces.
 type slabKeyAwareCapability interface {
 	KeyAwareEnabled() bool
@@ -157,6 +164,7 @@ type Tree struct {
 	slabKeyReader   slabUnsafeKeyReader
 	slabKeyAppender slabUnsafeKeyAppender
 	slabKeyBatcher  slabUnsafeKeyBatchAppender
+	leafLogToReader leafLogPageUnsafeToReader
 	rootPageID      uint64
 }
 
@@ -175,6 +183,9 @@ func New(p *pager.Pager, sr SlabReader, root uint64) *Tree {
 	}
 	if toer, ok := sr.(slabUnsafeToReader); ok {
 		t.slabToReader = toer
+	}
+	if leafToReader, ok := sr.(leafLogPageUnsafeToReader); ok {
+		t.leafLogToReader = leafToReader
 	}
 	if keyAwareEnabled {
 		if keyReader, ok := sr.(slabUnsafeKeyReader); ok {
@@ -208,6 +219,11 @@ func (t *Tree) Reset(p *pager.Pager, sr SlabReader, root uint64) {
 		t.slabToReader = toer
 	} else {
 		t.slabToReader = nil
+	}
+	if leafToReader, ok := sr.(leafLogPageUnsafeToReader); ok {
+		t.leafLogToReader = leafToReader
+	} else {
+		t.leafLogToReader = nil
 	}
 	if keyAwarePointerReadsEnabled(sr) {
 		if keyReader, ok := sr.(slabUnsafeKeyReader); ok {
@@ -253,7 +269,15 @@ func (t *Tree) loadLeafLogNodeView(ptr page.LogRecordRef, iterator bool) (node.N
 	if t.slabReader == nil {
 		return node.Node{}, errors.New("missing slab reader")
 	}
-	data, err := t.slabReader.ReadUnsafe(ptr.ValuePtr())
+	var (
+		data []byte
+		err  error
+	)
+	if t.leafLogToReader != nil {
+		data, _, err = t.leafLogToReader.ReadLeafLogPageUnsafeTo(ptr, nil)
+	} else {
+		data, err = t.slabReader.ReadUnsafe(ptr.ValuePtr())
+	}
 	if err != nil {
 		return node.Node{}, err
 	}
@@ -397,7 +421,20 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 					data []byte
 					err  error
 				)
-				if t.slabToReader != nil {
+				if t.leafLogToReader != nil {
+					var usedDst bool
+					data, usedDst, err = t.leafLogToReader.ReadLeafLogPageUnsafeTo(ptr, leafScratch.buf)
+					if err != nil {
+						putLeafRefPageScratch(leafScratch)
+						return nil, page.ValuePtr{}, 0, false, err
+					}
+					loadedLeafRef = true
+					leafScratchOwned = usedDst
+					if !usedDst {
+						putLeafRefPageScratch(leafScratch)
+						leafScratch = nil
+					}
+				} else if t.slabToReader != nil {
 					var usedDst bool
 					data, usedDst, err = t.slabToReader.ReadUnsafeTo(ptr.ValuePtr(), leafScratch.buf)
 					if err != nil {

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -281,11 +281,15 @@ func (t *Tree) loadLeafLogNodeView(ptr page.LogRecordRef, iterator bool) (node.N
 	if err != nil {
 		return node.Node{}, err
 	}
+	return validateLeafLogNode(data, ptr, t.shouldVerifyLeafRefChecksum(), iterator)
+}
+
+func validateLeafLogNode(data []byte, ptr page.LogRecordRef, verifyChecksum bool, iterator bool) (node.Node, error) {
 	if len(data) != page.PageSize {
 		return node.Node{}, fmt.Errorf("invalid leaf page size %d for leaf-log ref file=%d offset=%d", len(data), ptr.FileID, ptr.Offset)
 	}
 	n := node.NewNodeView(data)
-	if t.shouldVerifyLeafRefChecksum() && !n.VerifyChecksum() {
+	if verifyChecksum && !n.VerifyChecksum() {
 		return node.Node{}, fmt.Errorf("checksum mismatch on leaf-log ref file=%d offset=%d", ptr.FileID, ptr.Offset)
 	}
 	if n.Type() != page.PageTypeLeaf {
@@ -460,26 +464,14 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 					leafScratch = nil
 				}
 				if loadedLeafRef {
-					if len(data) != page.PageSize {
+					var err error
+					n, err = validateLeafLogNode(data, ptr, t.shouldVerifyLeafRefChecksum(), false)
+					if err != nil {
 						if leafScratchOwned {
 							putLeafRefPageScratch(leafScratch)
 						}
-						return nil, page.ValuePtr{}, 0, false, fmt.Errorf("invalid leaf page size %d for leaf-log ref file=%d offset=%d", len(data), ptr.FileID, ptr.Offset)
+						return nil, page.ValuePtr{}, 0, false, err
 					}
-					n = node.NewNodeView(data)
-					if t.shouldVerifyLeafRefChecksum() && !n.VerifyChecksum() {
-						if leafScratchOwned {
-							putLeafRefPageScratch(leafScratch)
-						}
-						return nil, page.ValuePtr{}, 0, false, fmt.Errorf("checksum mismatch on leaf-log ref file=%d offset=%d", ptr.FileID, ptr.Offset)
-					}
-					if n.Type() != page.PageTypeLeaf {
-						if leafScratchOwned {
-							putLeafRefPageScratch(leafScratch)
-						}
-						return nil, page.ValuePtr{}, 0, false, fmt.Errorf("invalid page type %d at leaf-log ref file=%d offset=%d", n.Type(), ptr.FileID, ptr.Offset)
-					}
-					noteOuterLeafLoad(ptr.ValuePtr(), len(data), false)
 				}
 			}
 		}

--- a/TreeDB/tree/tree_test.go
+++ b/TreeDB/tree/tree_test.go
@@ -54,6 +54,11 @@ type trackedValueReaderWithChecksumMode struct {
 	readChecksumEnabled bool
 }
 
+type trackedLeafLogPageReader struct {
+	*trackedValueReader
+	leafLogPageCalls int
+}
+
 func (r *trackedValueReaderWithChecksumMode) ReadChecksumEnabled() bool {
 	return r.readChecksumEnabled
 }
@@ -66,6 +71,20 @@ func (r *trackedValueReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
 func (r *trackedValueReader) ReadUnsafeAppend(ptr page.ValuePtr, dst []byte) ([]byte, error) {
 	r.readUnsafeAppendCalls++
 	return r.mapValueReader.ReadUnsafeAppend(ptr, dst)
+}
+
+func (r *trackedLeafLogPageReader) ReadLeafLogPageUnsafeTo(ptr page.LeafLogPtr, dst []byte) ([]byte, bool, error) {
+	r.leafLogPageCalls++
+	val, err := r.mapValueReader.ReadUnsafe(ptr.ValuePtr())
+	if err != nil {
+		return nil, false, err
+	}
+	if cap(dst) >= len(val) {
+		out := dst[:len(val)]
+		copy(out, val)
+		return out, true, nil
+	}
+	return val, false, nil
 }
 
 func TestTreeGet(t *testing.T) {
@@ -322,6 +341,54 @@ func TestTreeGetAppend_UsesAppendReaderForLeafRefPages(t *testing.T) {
 	}
 	if tracked.readUnsafeCalls != 0 {
 		t.Fatalf("expected ReadUnsafe to be bypassed, got %d calls", tracked.readUnsafeCalls)
+	}
+}
+
+func TestTreeGetAppend_UsesLeafLogPageReaderForLeafRefPages(t *testing.T) {
+	tracked := &trackedLeafLogPageReader{
+		trackedValueReader: &trackedValueReader{mapValueReader: newMapValueReader()},
+	}
+
+	leafData := make([]byte, page.PageSize)
+	leaf := node.NewNode(leafData)
+	leaf.SetType(page.PageTypeLeaf)
+	leaf.SetPageID(1)
+	leaf.AddLeafEntry([]byte("k"), []byte("v"), node.FlagInline, page.ValuePtr{})
+	leaf.UpdateChecksum()
+
+	ptr := page.LeafLogPtr{
+		FileID: 1,
+		Offset: 8,
+	}
+	tracked.values[ptr.ValuePtr()] = append([]byte(nil), leafData...)
+
+	tr, closeTree := newTreeWithLeafLogRoot(t, tracked, []byte{}, ptr)
+	defer closeTree()
+	got, err := tr.GetAppend([]byte("k"), nil)
+	if err != nil {
+		t.Fatalf("GetAppend failed: %v", err)
+	}
+	if string(got) != "v" {
+		t.Fatalf("unexpected value: %q", got)
+	}
+	if tracked.leafLogPageCalls != 1 {
+		t.Fatalf("expected ReadLeafLogPageUnsafeTo to be used once, got %d", tracked.leafLogPageCalls)
+	}
+	if tracked.readUnsafeAppendCalls != 0 {
+		t.Fatalf("expected generic ReadUnsafeAppend to be bypassed, got %d", tracked.readUnsafeAppendCalls)
+	}
+	if tracked.readUnsafeCalls != 0 {
+		t.Fatalf("expected generic ReadUnsafe to be bypassed, got %d", tracked.readUnsafeCalls)
+	}
+	gotUnsafe, err := tr.GetUnsafe([]byte("k"))
+	if err != nil {
+		t.Fatalf("GetUnsafe failed: %v", err)
+	}
+	if string(gotUnsafe) != "v" {
+		t.Fatalf("unexpected unsafe value: %q", gotUnsafe)
+	}
+	if tracked.leafLogPageCalls != 2 {
+		t.Fatalf("expected ReadLeafLogPageUnsafeTo to cover GetUnsafe too, got %d calls", tracked.leafLogPageCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a typed `ReadLeafLogPageUnsafeTo` boundary for B-tree leaf-log page reads
- wire snapshot point reads and iterators through that typed path so they can use the existing outer-leaf page cache
- keep ordinary value-log pointer reads on the existing `SlabReader` path so document values are not confused with leaf pages
- add focused tests for tree leaf-log reads and `valueReader` cache hit/miss behavior

This is a read-path/current-read follow-up for #1159. It is intentionally cache-bound: the existing 4k-entry cache is often too small for the sparse updated-root working set, but with a cache sized to the leaf working set the current-read cost drops materially.

## Local validation

```bash
go test ./TreeDB/tree ./TreeDB/db -run 'TestTreeGetAppend_UsesLeafLogPageReaderForLeafRefPages|TestTreeGetAppend_UsesAppendReaderForLeafRefPages|TestValueReaderLeafLogPageUnsafeToUsesCacheHit|TestValueReaderLeafLogPageUnsafeToStoresFallbackLeafPage|TestCachedLeafPageReaderHitAvoidsFallback' -count=1

go test ./TreeDB/tree ./TreeDB/db ./TreeDB/collections ./cmd/mongo_gateway_bench -count=1

go test ./TreeDB/tree ./TreeDB/db -count=1

git diff --check
```

## Benchmark evidence

Focused shape:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=<8|32> \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=3
```

Baseline `origin/main` / #1190, default 4k outer-leaf cache:

| Writers | docs/sec | ns/doc | current read ns/doc | cache hit ratio | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 8 | 127,777 | 7,826 | 2,119 | 0.117 | 1,464 | 5 |
| 8 | 164,475 | 6,080 | 1,897 | 0.116 | 1,390 | 4 |
| 8 | 171,462 | 5,832 | 1,871 | 0.115 | 1,383 | 4 |
| 32 | 210,731 | 4,745 | 1,776 | 0.117 | 1,124 | 2 |
| 32 | 196,701 | 5,084 | 1,788 | 0.117 | 1,533 | 2 |
| 32 | 209,543 | 4,772 | 1,787 | 0.116 | 1,113 | 2 |

Baseline `origin/main` with `TREEDB_LEAF_PAGE_CACHE_ENTRIES=32768`:

| Writers | docs/sec | ns/doc | current read ns/doc | cache hit ratio | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 32 | 218,744 | 4,572 | 1,561 | 0.633 | 1,380 | 2 |
| 32 | 206,164 | 4,851 | 1,602 | 0.637 | 1,877 | 2 |
| 32 | 218,252 | 4,582 | 1,576 | 0.635 | 1,377 | 2 |

This branch with `TREEDB_LEAF_PAGE_CACHE_ENTRIES=32768`:

| Writers | docs/sec | ns/doc | current read ns/doc | cache hit ratio | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 8 | 194,188 | 5,150 | 1,267 | 0.734 | 1,689 | 4 |
| 8 | 185,070 | 5,403 | 1,295 | 0.736 | 1,656 | 4 |
| 8 | 191,569 | 5,220 | 1,288 | 0.734 | 1,654 | 4 |
| 32 | 232,983 | 4,292 | 1,235 | 0.745 | 1,382 | 2 |
| 32 | 233,077 | 4,290 | 1,240 | 0.741 | 1,386 | 2 |
| 32 | 234,465 | 4,265 | 1,240 | 0.734 | 1,396 | 2 |

This branch with `TREEDB_LEAF_PAGE_CACHE_ENTRIES=65536`:

| Writers | docs/sec | ns/doc | current read ns/doc | cache hit ratio | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 8 | 198,525 | 5,037 | 1,167 | 0.855 | 1,852 | 4 |
| 8 | 174,177 | 5,741 | 1,352 | 0.851 | 1,887 | 5 |
| 8 | 193,155 | 5,177 | 1,167 | 0.857 | 1,846 | 4 |
| 32 | 230,563 | 4,337 | 1,154 | 0.849 | 2,122 | 2 |
| 32 | 241,013 | 4,149 | 1,133 | 0.860 | 1,562 | 2 |
| 32 | 239,148 | 4,182 | 1,129 | 0.852 | 1,572 | 2 |

Interpretation:

- The typed snapshot leaf-log cache path is real: at the same 32k cache size, current-read cost improved from roughly 1.56-1.60 us/doc on `origin/main` to roughly 1.23-1.24 us/doc on this branch.
- The default 4k cache is often too small for this sparse updated-root working set. I did not raise the default in this PR because 32k-64k entries can retain about 100-140 MiB in this benchmark and the memory policy deserves a separate tuning decision.
- This PR gives us the safe read boundary needed for that later policy work: leaf-log page reads are now distinct from ordinary value-log reads.

Fixes part of #1159.
