### PR TITLE
Attribute zipper leaf-page cache hits

### DIFF
--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -202,18 +202,30 @@ func (r *cachedLeafPageReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
 }
 
 func (r *cachedLeafPageReader) ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]byte, bool, error) {
+	data, usedDst, _, err := r.ReadUnsafeToWithCacheHit(ptr, dst)
+	return data, usedDst, err
+}
+
+func (r *cachedLeafPageReader) ReadUnsafeToWithCacheHit(ptr page.ValuePtr, dst []byte) ([]byte, bool, bool, error) {
 	if key, err := page.LeafLogPtrFromValuePtr(ptr); err == nil {
 		if data, usedDst, ok := r.cache.getTo(key, dst); ok {
-			return data, usedDst, nil
+			return data, usedDst, true, nil
 		}
 	}
 	if toReader, ok := r.fallback.(interface {
 		ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]byte, bool, error)
 	}); ok {
-		return toReader.ReadUnsafeTo(ptr, dst)
+		data, usedDst, err := toReader.ReadUnsafeTo(ptr, dst)
+		if err != nil {
+			return nil, false, false, err
+		}
+		return data, usedDst, false, nil
 	}
 	data, err := r.fallback.ReadUnsafe(ptr)
-	return data, false, err
+	if err != nil {
+		return nil, false, false, err
+	}
+	return data, false, false, nil
 }
 
 func cloneLeafPageReadCacheData(data []byte) []byte {

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -96,6 +96,34 @@ func TestCachedLeafPageReaderHitAvoidsFallback(t *testing.T) {
 	}
 }
 
+func TestCachedLeafPageReaderReadUnsafeToWithCacheHitReportsHit(t *testing.T) {
+	cache := newLeafPageReadCache(8)
+	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
+	leaf := bytes.Repeat([]byte{0x42}, page.PageSize)
+	cache.store(ptr, leaf)
+
+	fallback := &leafPageCacheTestFallback{err: errors.New("fallback should not be used")}
+	reader := newCachedLeafPageReader(cache, fallback)
+
+	dst := make([]byte, 0, page.PageSize)
+	got, usedDst, cacheHit, err := reader.ReadUnsafeToWithCacheHit(ptr.ValuePtr(), dst)
+	if err != nil {
+		t.Fatalf("ReadUnsafeToWithCacheHit: %v", err)
+	}
+	if !cacheHit {
+		t.Fatalf("expected cache hit source")
+	}
+	if !usedDst {
+		t.Fatalf("expected cache hit to copy into caller dst")
+	}
+	if !bytes.Equal(got, leaf) {
+		t.Fatalf("cached leaf mismatch")
+	}
+	if fallback.readUnsafeCalls != 0 || fallback.readUnsafeToCalls != 0 {
+		t.Fatalf("fallback calls unsafe=%d unsafeTo=%d, want zero", fallback.readUnsafeCalls, fallback.readUnsafeToCalls)
+	}
+}
+
 func TestCachedLeafPageReaderHitReturnsOwnedBytes(t *testing.T) {
 	cache := newLeafPageReadCache(8)
 	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
@@ -175,6 +203,35 @@ func TestCachedLeafPageReaderMissUsesFallback(t *testing.T) {
 	}
 	if stats := cache.stats(); stats.Misses != 1 {
 		t.Fatalf("misses=%d, want 1", stats.Misses)
+	}
+}
+
+func TestCachedLeafPageReaderMissReportsNoCacheHit(t *testing.T) {
+	cache := newLeafPageReadCache(8)
+	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
+	leaf := bytes.Repeat([]byte{0x24}, page.PageSize)
+	fallback := &leafPageCacheTestFallback{data: leaf}
+	reader := newCachedLeafPageReader(cache, fallback)
+
+	dst := make([]byte, 0, page.PageSize)
+	got, usedDst, cacheHit, err := reader.ReadUnsafeToWithCacheHit(ptr.ValuePtr(), dst)
+	if err != nil {
+		t.Fatalf("ReadUnsafeToWithCacheHit: %v", err)
+	}
+	if cacheHit {
+		t.Fatalf("first read should miss cache")
+	}
+	if !usedDst {
+		t.Fatalf("expected fallback to copy into dst")
+	}
+	if !bytes.Equal(got, leaf) {
+		t.Fatalf("fallback leaf mismatch")
+	}
+	if fallback.readUnsafeToCalls != 1 {
+		t.Fatalf("fallback ReadUnsafeTo calls=%d, want 1", fallback.readUnsafeToCalls)
+	}
+	if stats := cache.stats(); stats.Misses != 1 || stats.Stores != 0 || stats.Hits != 0 {
+		t.Fatalf("stats=%+v, want one miss and no store", stats)
 	}
 }
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -976,6 +976,14 @@ func validateLoadedLeafLogNode(data []byte) (node.Node, error) {
 	return n, nil
 }
 
+func validateLoadedLeafLogNodeFrom(source string, data []byte) (node.Node, error) {
+	n, err := validateLoadedLeafLogNode(data)
+	if err != nil {
+		return node.Node{}, fmt.Errorf("zipper: %s invalid leaf-log page: %w", source, err)
+	}
+	return n, nil
+}
+
 // Apply applies the batch to the tree rooted at rootID.
 // Returns the new root page ID, list of retired pages, and commit metrics.
 func (z *Zipper) Apply(rootID uint64, b *batch.Batch) (uint64, []uint64, adaptive.Metrics, error) {
@@ -1152,7 +1160,7 @@ func (z *Zipper) loadNodeRef(ref page.ChildRef, scratchCtx *mergeScratch) (node.
 			data, cached := z.leafRefCache[ptr]
 			z.leafRefCacheMu.RUnlock()
 			if cached {
-				n, err := validateLoadedLeafLogNode(data)
+				n, err := validateLoadedLeafLogNodeFrom("leaf-ref cache", data)
 				if err != nil {
 					return node.Node{}, false, nil, false, zipperNodeLoadLeafLogCache, err
 				}
@@ -1170,16 +1178,19 @@ func (z *Zipper) loadNodeRef(ref page.ChildRef, scratchCtx *mergeScratch) (node.
 				return node.Node{}, false, nil, false, zipperNodeLoadLeafLogView, err
 			}
 			source := zipperNodeLoadLeafLogScratch
+			sourceLabel := "leaf-page reader scratch"
 			if cacheHit {
 				source = zipperNodeLoadLeafLogCache
+				sourceLabel = "leaf-page reader cache"
 			} else if !usedScratch {
 				source = zipperNodeLoadLeafLogView
+				sourceLabel = "leaf-page reader view"
 			}
 			if !usedScratch {
 				releaseLeafPageScratch(scratchCtx, scratch)
 				scratch = nil
 			}
-			n, err := validateLoadedLeafLogNode(data)
+			n, err := validateLoadedLeafLogNodeFrom(sourceLabel, data)
 			if err != nil {
 				if scratch != nil {
 					releaseLeafPageScratch(scratchCtx, scratch)
@@ -1199,12 +1210,14 @@ func (z *Zipper) loadNodeRef(ref page.ChildRef, scratchCtx *mergeScratch) (node.
 				return node.Node{}, false, nil, false, zipperNodeLoadLeafLogView, err
 			}
 			source := zipperNodeLoadLeafLogScratch
+			sourceLabel := "leaf-page reader scratch"
 			if !usedScratch {
 				releaseLeafPageScratch(scratchCtx, scratch)
 				scratch = nil
 				source = zipperNodeLoadLeafLogView
+				sourceLabel = "leaf-page reader view"
 			}
-			n, err := validateLoadedLeafLogNode(data)
+			n, err := validateLoadedLeafLogNodeFrom(sourceLabel, data)
 			if err != nil {
 				if scratch != nil {
 					releaseLeafPageScratch(scratchCtx, scratch)
@@ -1221,7 +1234,7 @@ func (z *Zipper) loadNodeRef(ref page.ChildRef, scratchCtx *mergeScratch) (node.
 		if err != nil {
 			return node.Node{}, false, nil, false, zipperNodeLoadLeafLogView, err
 		}
-		n, err := validateLoadedLeafLogNode(data)
+		n, err := validateLoadedLeafLogNodeFrom("leaf-page reader unsafe", data)
 		if err != nil {
 			return node.Node{}, false, nil, false, zipperNodeLoadLeafLogView, err
 		}

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -34,6 +34,10 @@ type leafPageUnsafeToReader interface {
 	ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]byte, bool, error)
 }
 
+type leafPageUnsafeToReaderWithCacheHit interface {
+	ReadUnsafeToWithCacheHit(ptr page.ValuePtr, dst []byte) ([]byte, bool, bool, error)
+}
+
 var leafPageScratchPool = sync.Pool{
 	New: func() any {
 		return make([]byte, 0, page.PageSize)
@@ -961,6 +965,17 @@ func recordZipperInternalChildRef(metrics *adaptive.Metrics, ref page.ChildRef) 
 	metrics.ZipperInternalPageChildRefs++
 }
 
+func validateLoadedLeafLogNode(data []byte) (node.Node, error) {
+	if len(data) != page.PageSize {
+		return node.Node{}, errors.New("zipper: leaf page has invalid size")
+	}
+	n := node.NewNodeView(data)
+	if n.Type() != page.PageTypeLeaf {
+		return node.Node{}, errors.New("zipper: leafref resolved to non-leaf page")
+	}
+	return n, nil
+}
+
 // Apply applies the batch to the tree rooted at rootID.
 // Returns the new root page ID, list of retired pages, and commit metrics.
 func (z *Zipper) Apply(rootID uint64, b *batch.Batch) (uint64, []uint64, adaptive.Metrics, error) {
@@ -1137,18 +1152,44 @@ func (z *Zipper) loadNodeRef(ref page.ChildRef, scratchCtx *mergeScratch) (node.
 			data, cached := z.leafRefCache[ptr]
 			z.leafRefCacheMu.RUnlock()
 			if cached {
-				if len(data) != page.PageSize {
-					return node.Node{}, false, nil, false, zipperNodeLoadLeafLogCache, errors.New("zipper: cached leaf page has invalid size")
-				}
-				n := node.NewNodeView(data)
-				if n.Type() != page.PageTypeLeaf {
-					return node.Node{}, false, nil, false, zipperNodeLoadLeafLogCache, errors.New("zipper: cached leafref resolved to non-leaf page")
+				n, err := validateLoadedLeafLogNode(data)
+				if err != nil {
+					return node.Node{}, false, nil, false, zipperNodeLoadLeafLogCache, err
 				}
 				return n, false, nil, false, zipperNodeLoadLeafLogCache, nil
 			}
 		}
 		if z.leafPageReader == nil {
 			return node.Node{}, false, nil, false, zipperNodeLoadLeafLogView, errors.New("zipper: missing leaf page reader")
+		}
+		if r, ok := z.leafPageReader.(leafPageUnsafeToReaderWithCacheHit); ok {
+			scratch := acquireLeafPageScratch(scratchCtx)
+			data, usedScratch, cacheHit, err := r.ReadUnsafeToWithCacheHit(ptr.ValuePtr(), scratch[:0])
+			if err != nil {
+				releaseLeafPageScratch(scratchCtx, scratch)
+				return node.Node{}, false, nil, false, zipperNodeLoadLeafLogView, err
+			}
+			source := zipperNodeLoadLeafLogScratch
+			if cacheHit {
+				source = zipperNodeLoadLeafLogCache
+			} else if !usedScratch {
+				source = zipperNodeLoadLeafLogView
+			}
+			if !usedScratch {
+				releaseLeafPageScratch(scratchCtx, scratch)
+				scratch = nil
+			}
+			n, err := validateLoadedLeafLogNode(data)
+			if err != nil {
+				if scratch != nil {
+					releaseLeafPageScratch(scratchCtx, scratch)
+				}
+				return node.Node{}, false, nil, false, source, err
+			}
+			if scratch != nil {
+				return n, false, scratch, true, source, nil
+			}
+			return n, false, nil, false, source, nil
 		}
 		if r, ok := z.leafPageReader.(leafPageUnsafeToReader); ok {
 			scratch := acquireLeafPageScratch(scratchCtx)
@@ -1163,18 +1204,12 @@ func (z *Zipper) loadNodeRef(ref page.ChildRef, scratchCtx *mergeScratch) (node.
 				scratch = nil
 				source = zipperNodeLoadLeafLogView
 			}
-			if len(data) != page.PageSize {
+			n, err := validateLoadedLeafLogNode(data)
+			if err != nil {
 				if scratch != nil {
 					releaseLeafPageScratch(scratchCtx, scratch)
 				}
-				return node.Node{}, false, nil, false, source, errors.New("zipper: leaf page has invalid size")
-			}
-			n := node.NewNodeView(data)
-			if n.Type() != page.PageTypeLeaf {
-				if scratch != nil {
-					releaseLeafPageScratch(scratchCtx, scratch)
-				}
-				return node.Node{}, false, nil, false, source, errors.New("zipper: leafref resolved to non-leaf page")
+				return node.Node{}, false, nil, false, source, err
 			}
 			if scratch != nil {
 				return n, false, scratch, true, source, nil
@@ -1186,12 +1221,9 @@ func (z *Zipper) loadNodeRef(ref page.ChildRef, scratchCtx *mergeScratch) (node.
 		if err != nil {
 			return node.Node{}, false, nil, false, zipperNodeLoadLeafLogView, err
 		}
-		if len(data) != page.PageSize {
-			return node.Node{}, false, nil, false, zipperNodeLoadLeafLogView, errors.New("zipper: leaf page has invalid size")
-		}
-		n := node.NewNodeView(data)
-		if n.Type() != page.PageTypeLeaf {
-			return node.Node{}, false, nil, false, zipperNodeLoadLeafLogView, errors.New("zipper: leafref resolved to non-leaf page")
+		n, err := validateLoadedLeafLogNode(data)
+		if err != nil {
+			return node.Node{}, false, nil, false, zipperNodeLoadLeafLogView, err
 		}
 		return n, false, nil, false, zipperNodeLoadLeafLogView, nil
 	}

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -45,6 +45,27 @@ func (r *countingLeafPageReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
 	return nil, io.EOF
 }
 
+type sourceReportingLeafPageReader struct {
+	leaf     []byte
+	cacheHit bool
+	calls    int
+}
+
+func (r *sourceReportingLeafPageReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
+	r.calls++
+	return append([]byte(nil), r.leaf...), nil
+}
+
+func (r *sourceReportingLeafPageReader) ReadUnsafeToWithCacheHit(ptr page.ValuePtr, dst []byte) ([]byte, bool, bool, error) {
+	r.calls++
+	if cap(dst) >= len(r.leaf) {
+		out := dst[:len(r.leaf)]
+		copy(out, r.leaf)
+		return out, true, r.cacheHit, nil
+	}
+	return append([]byte(nil), r.leaf...), false, r.cacheHit, nil
+}
+
 type stubLeafPageLog struct {
 	next uint32
 }
@@ -209,6 +230,48 @@ func TestZipperLeafRefCacheAvoidsUnflushedReads(t *testing.T) {
 	}
 	if got := reader.calls.Load(); got != 0 {
 		t.Fatalf("leafPageReader calls=%d want 0", got)
+	}
+}
+
+func TestZipperLoadNodeRefAttributesLeafPageReaderCacheHit(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	z.SetOuterLeavesInValueLog(true)
+
+	leaf := make([]byte, page.PageSize)
+	leafNode := node.NewNode(leaf)
+	leafNode.SetPageID(0)
+	leafNode.SetType(page.PageTypeLeaf)
+	leafNode.UpdateChecksum()
+	reader := &sourceReportingLeafPageReader{leaf: leaf, cacheHit: true}
+	z.SetLeafPageReader(reader)
+
+	ptr := page.LeafLogPtr{FileID: 1, Offset: 128, RecordLengthHint: page.PageSize}
+	loaded, fromPager, leafScratch, leafScratchRef, loadSource, err := z.loadNodeRef(page.LeafLogChildRef(ptr), nil)
+	if err != nil {
+		t.Fatalf("loadNodeRef: %v", err)
+	}
+	if leafScratchRef {
+		putLeafPageScratch(leafScratch)
+	}
+	if fromPager {
+		t.Fatalf("fromPager=%t want false", fromPager)
+	}
+	if loadSource != zipperNodeLoadLeafLogCache {
+		t.Fatalf("loadSource=%d want leaf-log cache", loadSource)
+	}
+	if loaded.Type() != page.PageTypeLeaf {
+		t.Fatalf("loaded.Type()=%d want %d", loaded.Type(), page.PageTypeLeaf)
+	}
+	if reader.calls != 1 {
+		t.Fatalf("reader calls=%d want 1", reader.calls)
 	}
 }
 

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/rand"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -272,6 +273,30 @@ func TestZipperLoadNodeRefAttributesLeafPageReaderCacheHit(t *testing.T) {
 	}
 	if reader.calls != 1 {
 		t.Fatalf("reader calls=%d want 1", reader.calls)
+	}
+}
+
+func TestZipperLoadNodeRefAnnotatesLeafPageReaderCacheValidationError(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	z.SetOuterLeavesInValueLog(true)
+	z.SetLeafPageReader(&sourceReportingLeafPageReader{leaf: []byte("short"), cacheHit: true})
+
+	ptr := page.LeafLogPtr{FileID: 1, Offset: 128, RecordLengthHint: page.PageSize}
+	_, _, _, _, _, err = z.loadNodeRef(page.LeafLogChildRef(ptr), nil)
+	if err == nil {
+		t.Fatal("loadNodeRef unexpectedly succeeded")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "leaf-page reader cache invalid leaf-log page") || !strings.Contains(msg, "invalid size") {
+		t.Fatalf("error=%q, want source context and validation detail", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a source-aware `ReadUnsafeToWithCacheHit` leaf-page reader path for zipper outer-leaf reads
- make `cachedLeafPageReader` report whether a page-sized read came from the existing outer-leaf cache
- route zipper leaf-log loads through that source-aware path so root-apply metrics split cache hits from fallback reader/scratch reads
- factor zipper leaf-log page validation to keep the new source-aware path aligned with the existing reader paths

This intentionally does **not** store every zipper read miss in the leaf-page cache. I tested that first and rejected it because it caused heavy cache churn (`~0.99 stores/doc` and high evictions) and regressed the focused row. This PR is the safe attribution piece: it makes the existing cache benefit visible without adding miss-store churn.

## Validation

```bash
go test ./TreeDB/db ./TreeDB/zipper -run 'TestCachedLeafPageReaderReadUnsafeToWithCacheHitReportsHit|TestCachedLeafPageReaderMissReportsNoCacheHit|TestCachedLeafPageReaderHitAvoidsFallback|TestCachedLeafPageReaderMissUsesFallback|TestCachedLeafPageReaderMissUsesReadUnsafeFallback|TestZipperLoadNodeRefAttributesLeafPageReaderCacheHit|TestZipperLeafRefCacheAvoidsUnflushedReads' -count=1

go test ./TreeDB/db ./TreeDB/zipper ./TreeDB/collections ./cmd/mongo_gateway_bench -count=1

git diff --check
```

## Benchmark / Profile Evidence

Current main baseline profile after #1191:

```bash
OUT=/tmp/gomap_1159_after1191_profile_1777755136
TREEDB_LEAF_PAGE_CACHE_ENTRIES=32768 \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$OUT/cpu.pprof" \
  -memprofile "$OUT/mem.pprof"
```

Current main result:

```text
185,956 docs/sec, 5,378 ns/doc, 1,187 B/op, 2 allocs/op
update_current_read_ns/doc=1,598
publish_delta_group_root_apply_ns/doc=1,650
publish_delta_group_root_apply_leaf_log_cache_hits/doc=0
publish_delta_group_root_apply_leaf_log_reader_calls/doc=0.3084
publish_delta_group_root_apply_leaf_log_scratch_reads/doc=0.3084
```

Rejected experiment on this branch with zipper miss-store enabled:

```text
179,002 docs/sec, 5,587 ns/doc, 1,156 B/op, 2 allocs/op
publish_delta_group_root_apply_leaf_log_cache_hits/doc=0.1074
publish_delta_group_root_apply_leaf_log_reader_calls/doc=0.1999
backend_outer_leaf_cache_stores/doc=0.9940
backend_outer_leaf_cache_evictions/doc=0.9909
```

Conclusion: storing every zipper miss is not a safe default because it churns the cache.

Final branch repeat comparison, 100k direct BSON two-index concurrent updates, 32 writers, async indexed flush, 32k leaf-page cache:

```bash
TREEDB_LEAF_PAGE_CACHE_ENTRIES=32768 \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=3
```

| Variant | ns/doc | docs/sec | root apply ns/doc | leaf-log cache hits/doc | leaf-log reader calls/doc | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| origin/main | 4,463 / 4,446 / 4,431 | 224,084 / 224,896 / 225,700 | 969.2 / 974.8 / 949.5 | 0 / 0 / 0 | 0.1936 / 0.1938 / 0.1938 | 1,387 / 1,370 / 1,371 | 2 |
| this PR | 4,404 / 4,376 / 4,320 | 227,049 / 228,521 / 231,506 | 973.9 / 958.4 / 942.8 | 0.1340 / 0.1330 / 0.1344 | 0.05967 / 0.06082 / 0.05932 | 1,370 / 1,400 / 1,366 | 2 |

Interpretation: this PR is primarily attribution. It shows that about `0.133-0.134` root-apply leaf-log loads/doc were already served by the outer-leaf cache in this shape, leaving only about `0.059-0.061` fallback reader/scratch calls/doc. Throughput and allocation are effectively neutral in this short repeat.

## Next #1159 readout

After #1191 and this attribution fix, the remaining focused costs are clearer:

- current-document read remains around `1.3-1.6 us/doc` depending on cache working set and run length
- publish root apply remains around `0.95-1.8 us/doc` depending on flush shape/run length
- root apply still writes about `0.19-0.32` leaf-log pages/doc in the focused update shape
- the next optimization should target either cache sizing/adaptive policy for current reads, or the deeper zipper/leaf-log page rewrite cost itself rather than cache attribution

Refs #1159.
