### PR TITLE
Expose TreeDB leaf-page read cache sizing

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1166,6 +1166,9 @@ func Open(opts Options) (*DB, error) {
 }
 
 func validateOptions(opts Options) error {
+	if _, err := resolveLeafPageReadCacheEntries(opts.LeafPageReadCacheEntries); err != nil {
+		return err
+	}
 	if opts.ReadOnly {
 		// Read-only opens never mutate on-disk state, so "unsafe" write options do
 		// not apply.

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -645,6 +645,16 @@ type Options struct {
 	// prefetch requests opportunistically (e.g. before rewriting child pages
 	// during checkpoint/merge). It is a no-op on unsupported platforms.
 	PagerPrefetchOnRead bool
+	// LeafPageReadCacheEntries controls the bounded process-local cache used for
+	// B-tree leaf pages stored in the value log. The cache stores decoded 4KiB
+	// leaf pages and is most useful for sparse update/publish/read workloads that
+	// revisit recently-written outer leaves.
+	//
+	// Semantics:
+	//   - 0 uses the process default/env override.
+	//   - <0 disables the cache for this DB.
+	//   - >0 sets the exact number of direct-mapped cache slots.
+	LeafPageReadCacheEntries int
 
 	// Durability configures cached-mode durability semantics.
 	//
@@ -1366,7 +1376,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 	gen.zipper.SetIndexPackedValuePtr(opts.IndexPackedValuePtr)
 	gen.zipper.SetIndexInternalBaseDelta(opts.IndexInternalBaseDelta)
 	gen.zipper.SetOuterLeavesInValueLog(opts.IndexOuterLeavesInValueLog)
-	db.leafPageReadCache = newLeafPageReadCache(configuredLeafPageReadCacheEntries())
+	db.leafPageReadCache = newLeafPageReadCache(configuredLeafPageReadCacheEntries(opts.LeafPageReadCacheEntries))
 	gen.zipper.SetLeafPageReader(db.leafPageReader(vm))
 	gen.zipper.SetAdaptiveLeafEncoding(opts.IndexAdaptiveLeafEncoding)
 	gen.zipper.SetMaintenanceOpsPerCoalesce(opts.MaintenanceOpsPerCoalesce)

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -14,23 +15,42 @@ import (
 const (
 	leafPageReadCacheEntriesEnvKey  = "TREEDB_LEAF_PAGE_CACHE_ENTRIES"
 	defaultLeafPageReadCacheEntries = 4096
+	maxLeafPageReadCacheEntries     = 1 << 18
 )
 
 var LeafPageReadCacheEntries = defaultLeafPageReadCacheEntries
 
 func configuredLeafPageReadCacheEntries(optionEntries int) int {
-	if optionEntries < 0 {
+	entries, err := resolveLeafPageReadCacheEntries(optionEntries)
+	if err != nil {
 		return 0
 	}
+	return entries
+}
+
+func resolveLeafPageReadCacheEntries(optionEntries int) (int, error) {
+	if optionEntries < 0 {
+		return 0, nil
+	}
 	if optionEntries > 0 {
-		return optionEntries
+		return validateLeafPageReadCacheEntries(optionEntries)
 	}
 	if raw := strings.TrimSpace(os.Getenv(leafPageReadCacheEntriesEnvKey)); raw != "" {
 		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
-			return v
+			return validateLeafPageReadCacheEntries(v)
 		}
 	}
-	return LeafPageReadCacheEntries
+	return validateLeafPageReadCacheEntries(LeafPageReadCacheEntries)
+}
+
+func validateLeafPageReadCacheEntries(entries int) (int, error) {
+	if entries < 0 {
+		return 0, nil
+	}
+	if entries > maxLeafPageReadCacheEntries {
+		return 0, fmt.Errorf("treedb: leaf page read cache entries out of range [0,%d]: %d", maxLeafPageReadCacheEntries, entries)
+	}
+	return entries, nil
 }
 
 type leafPageReadCacheEntry struct {

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -18,7 +18,13 @@ const (
 
 var LeafPageReadCacheEntries = defaultLeafPageReadCacheEntries
 
-func configuredLeafPageReadCacheEntries() int {
+func configuredLeafPageReadCacheEntries(optionEntries int) int {
+	if optionEntries < 0 {
+		return 0
+	}
+	if optionEntries > 0 {
+		return optionEntries
+	}
 	if raw := strings.TrimSpace(os.Getenv(leafPageReadCacheEntriesEnvKey)); raw != "" {
 		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
 			return v

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"bytes"
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/page"
@@ -393,6 +394,29 @@ func TestConfiguredLeafPageReadCacheEntriesNegativeOptionDisables(t *testing.T) 
 
 	if got := configuredLeafPageReadCacheEntries(-1); got != 0 {
 		t.Fatalf("configuredLeafPageReadCacheEntries(-1)=%d, want disabled cache 0", got)
+	}
+}
+
+func TestValidateOptionsRejectsHugeLeafPageReadCacheEntries(t *testing.T) {
+	err := validateOptions(Options{LeafPageReadCacheEntries: maxLeafPageReadCacheEntries + 1})
+	if err == nil {
+		t.Fatal("validateOptions unexpectedly accepted huge leaf page read cache")
+	}
+}
+
+func TestValidateOptionsRejectsHugeLeafPageReadCacheEntriesForReadOnly(t *testing.T) {
+	err := validateOptions(Options{ReadOnly: true, LeafPageReadCacheEntries: maxLeafPageReadCacheEntries + 1})
+	if err == nil {
+		t.Fatal("validateOptions unexpectedly accepted huge read-only leaf page read cache")
+	}
+}
+
+func TestValidateOptionsRejectsHugeLeafPageReadCacheEntriesFromEnv(t *testing.T) {
+	t.Setenv(leafPageReadCacheEntriesEnvKey, strconv.Itoa(maxLeafPageReadCacheEntries+1))
+
+	err := validateOptions(Options{})
+	if err == nil {
+		t.Fatal("validateOptions unexpectedly accepted huge env leaf page read cache")
 	}
 }
 

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -365,8 +365,34 @@ func TestConfiguredLeafPageReadCacheEntriesReadsEnvAtOpenTime(t *testing.T) {
 	})
 	t.Setenv(leafPageReadCacheEntriesEnvKey, "3")
 
-	if got := configuredLeafPageReadCacheEntries(); got != 3 {
+	if got := configuredLeafPageReadCacheEntries(0); got != 3 {
 		t.Fatalf("configuredLeafPageReadCacheEntries()=%d, want env override 3", got)
+	}
+}
+
+func TestConfiguredLeafPageReadCacheEntriesOptionOverridesEnv(t *testing.T) {
+	prev := LeafPageReadCacheEntries
+	LeafPageReadCacheEntries = 8
+	t.Cleanup(func() {
+		LeafPageReadCacheEntries = prev
+	})
+	t.Setenv(leafPageReadCacheEntriesEnvKey, "3")
+
+	if got := configuredLeafPageReadCacheEntries(16); got != 16 {
+		t.Fatalf("configuredLeafPageReadCacheEntries(16)=%d, want option override 16", got)
+	}
+}
+
+func TestConfiguredLeafPageReadCacheEntriesNegativeOptionDisables(t *testing.T) {
+	prev := LeafPageReadCacheEntries
+	LeafPageReadCacheEntries = 8
+	t.Cleanup(func() {
+		LeafPageReadCacheEntries = prev
+	})
+	t.Setenv(leafPageReadCacheEntriesEnvKey, "3")
+
+	if got := configuredLeafPageReadCacheEntries(-1); got != 0 {
+		t.Fatalf("configuredLeafPageReadCacheEntries(-1)=%d, want disabled cache 0", got)
 	}
 }
 

--- a/TreeDB/db/open_readonly.go
+++ b/TreeDB/db/open_readonly.go
@@ -13,6 +13,9 @@ import (
 )
 
 func openReadOnly(opts Options) (*DB, error) {
+	if _, err := resolveLeafPageReadCacheEntries(opts.LeafPageReadCacheEntries); err != nil {
+		return nil, err
+	}
 	if err := ensureNoLegacyMixedWALValueSegments(opts.Dir); err != nil {
 		return nil, err
 	}
@@ -110,6 +113,9 @@ func openReadOnly(opts Options) (*DB, error) {
 
 	gen.zipper.SetFillTargets(opts.LeafFillTargetPPM, opts.InternalFillTargetPPM)
 	gen.zipper.SetPiggybackCompaction(!opts.DisablePiggybackCompaction)
+	gen.zipper.SetOuterLeavesInValueLog(opts.IndexOuterLeavesInValueLog)
+	db.leafPageReadCache = newLeafPageReadCache(configuredLeafPageReadCacheEntries(opts.LeafPageReadCacheEntries))
+	gen.zipper.SetLeafPageReader(db.leafPageReader(vm))
 	gen.zipper.SetMaintenanceOpsPerCoalesce(opts.MaintenanceOpsPerCoalesce)
 
 	if err := db.recover(); err != nil {
@@ -141,6 +147,9 @@ func openReadOnly(opts Options) (*DB, error) {
 }
 
 func openReadOnlyNoLock(opts Options) (*DB, error) {
+	if _, err := resolveLeafPageReadCacheEntries(opts.LeafPageReadCacheEntries); err != nil {
+		return nil, err
+	}
 	if err := ensureNoLegacyMixedWALValueSegments(opts.Dir); err != nil {
 		return nil, err
 	}
@@ -225,6 +234,9 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 
 	gen.zipper.SetFillTargets(opts.LeafFillTargetPPM, opts.InternalFillTargetPPM)
 	gen.zipper.SetPiggybackCompaction(!opts.DisablePiggybackCompaction)
+	gen.zipper.SetOuterLeavesInValueLog(opts.IndexOuterLeavesInValueLog)
+	db.leafPageReadCache = newLeafPageReadCache(configuredLeafPageReadCacheEntries(opts.LeafPageReadCacheEntries))
+	gen.zipper.SetLeafPageReader(db.leafPageReader(vm))
 	gen.zipper.SetMaintenanceOpsPerCoalesce(opts.MaintenanceOpsPerCoalesce)
 
 	if err := db.recover(); err != nil {

--- a/TreeDB/db/readonly_open_test.go
+++ b/TreeDB/db/readonly_open_test.go
@@ -39,6 +39,55 @@ func TestReadOnlyRejectsWrites(t *testing.T) {
 	}
 }
 
+func TestReadOnlyOpenConfiguresLeafPageReadCacheEntries(t *testing.T) {
+	dir := t.TempDir()
+
+	w, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.SetSync([]byte("k"), []byte("v")); err != nil {
+		_ = w.Close()
+		t.Fatalf("SetSync: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	openers := []struct {
+		name string
+		open func(Options) (*DB, error)
+	}{
+		{
+			name: "shared_lock",
+			open: func(opts Options) (*DB, error) {
+				opts.ReadOnly = true
+				return Open(opts)
+			},
+		},
+		{name: "no_lock", open: openReadOnlyNoLock},
+	}
+	for _, opener := range openers {
+		t.Run(opener.name, func(t *testing.T) {
+			ro, err := opener.open(Options{
+				Dir:                      dir,
+				ReadOnly:                 true,
+				ChunkSize:                256 * 1024,
+				LeafPageReadCacheEntries: 7,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = ro.Close() }()
+
+			stats := ro.Stats()
+			if got := stats["treedb.process.read_path.outer_leaf.cache.capacity"]; got != "7" {
+				t.Fatalf("outer leaf cache capacity=%q want 7", got)
+			}
+		})
+	}
+}
+
 func TestReadOnlyDoesNotReplayOrRemoveCommitLog(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,7 +18,11 @@ import (
 	treedbadapter "github.com/snissn/gomap/kvstore/adapters/treedb"
 )
 
-const defaultTreeDBChunkSizeBytes int64 = 256 * 1024
+const (
+	defaultTreeDBChunkSizeBytes           int64 = 256 * 1024
+	defaultTreeDBLeafPageReadCacheEntries       = 4096
+	treeDBLeafPageReadCacheEntriesEnvKey        = "TREEDB_LEAF_PAGE_CACHE_ENTRIES"
+)
 
 var (
 	treedbFlushThreshold                  = flag.Int64("treedb-flush-threshold", 64*1024*1024, "TreeDB (cached): flush threshold in bytes")
@@ -444,10 +449,25 @@ func formatTreeDBLeafPageReadCacheEntries(entries int) string {
 	case entries < 0:
 		return "disabled"
 	case entries == 0:
-		return "default/env"
+		return fmt.Sprintf("default/env (effective=%d)", effectiveTreeDBLeafPageReadCacheEntries(entries))
 	default:
 		return fmt.Sprintf("%d", entries)
 	}
+}
+
+func effectiveTreeDBLeafPageReadCacheEntries(entries int) int {
+	if entries < 0 {
+		return 0
+	}
+	if entries > 0 {
+		return entries
+	}
+	if raw := strings.TrimSpace(os.Getenv(treeDBLeafPageReadCacheEntriesEnvKey)); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
+			return v
+		}
+	}
+	return defaultTreeDBLeafPageReadCacheEntries
 }
 
 func formatTreeDBVlogCompression(mode treedb.ValueLogCompressionMode) string {

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -34,6 +34,7 @@ var (
 	treedbPagerSyncConcurrency            = flag.Int("treedb-pager-sync-concurrency", 0, "TreeDB: pager msync concurrency (0=default)")
 	treedbPagerMmapPopulate               = flag.Bool("treedb-pager-mmap-populate", false, "TreeDB (Linux): enable MAP_POPULATE on index.db mmap")
 	treedbPagerPrefetchOnRead             = flag.Bool("treedb-pager-prefetch-on-read", false, "TreeDB (Linux): enable best-effort mmap prefetch hints (madvise WILLNEED) during checkpoint/merge rewrites")
+	treedbLeafPageReadCacheEntries        = flag.Int("treedb-leaf-page-read-cache-entries", 0, "TreeDB: outer-leaf read cache slots for leaf pages stored in the value log (0=default/env, <0=disable)")
 	treedbChunkSize                       = flag.Int64("treedb-chunk-size", defaultTreeDBChunkSizeBytes, "TreeDB: pager chunk size in bytes (default 256KiB)")
 	treedbJournalLanes                    = flag.Int("treedb-journal-lanes", 0, "TreeDB: journal lane count (0=auto)")
 	treedbJournalCompress                 = flag.Bool("treedb-journal-compress", false, "TreeDB: compress journal/commitlog segments (zstd)")
@@ -336,6 +337,7 @@ func (r treeDBOptionsReport) formatText(indent string) string {
 	lines = append(lines, fmt.Sprintf("index_packed_valueptr=%t", r.opts.IndexPackedValuePtr))
 	lines = append(lines, fmt.Sprintf("index_internal_base_delta=%t", r.opts.IndexInternalBaseDelta))
 	lines = append(lines, fmt.Sprintf("index_outer_leaves_in_vlog=%t", r.opts.IndexOuterLeavesInValueLog))
+	lines = append(lines, fmt.Sprintf("outer_leaf_read_cache_entries=%s", formatTreeDBLeafPageReadCacheEntries(r.opts.LeafPageReadCacheEntries)))
 	lines = append(lines, fmt.Sprintf("cached.domain_ingress_workers=%d", r.opts.DomainIngressWorkers))
 	lines = append(lines, fmt.Sprintf("cached.domain_ingress_queue_size=%d", r.opts.DomainIngressQueueSize))
 	lines = append(lines, fmt.Sprintf("vlog.force_pointers=%t", r.opts.ValueLog.ForcePointers))
@@ -434,6 +436,17 @@ func formatTreeDBIntegrity(mode treedb.IntegrityMode) string {
 		return "skip_checksums"
 	default:
 		return fmt.Sprintf("integrity_%d", mode)
+	}
+}
+
+func formatTreeDBLeafPageReadCacheEntries(entries int) string {
+	switch {
+	case entries < 0:
+		return "disabled"
+	case entries == 0:
+		return "default/env"
+	default:
+		return fmt.Sprintf("%d", entries)
 	}
 }
 
@@ -595,6 +608,7 @@ func buildTreeDBOptions(dir string) (treedb.Options, treeDBOptionsReport, error)
 		PagerSyncConcurrency:      *treedbPagerSyncConcurrency,
 		PagerMmapPopulate:         *treedbPagerMmapPopulate,
 		PagerPrefetchOnRead:       *treedbPagerPrefetchOnRead,
+		LeafPageReadCacheEntries:  *treedbLeafPageReadCacheEntries,
 		PreferAppendAlloc:         *treedbPreferAppendAlloc,
 		FreelistRegionPages:       *treedbFreelistRegionPages,
 		FreelistRegionRadius:      *treedbFreelistRegionRadius,

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -56,6 +56,22 @@ func TestBuildTreeDBOptions_LeafPageReadCacheEntries(t *testing.T) {
 	}
 }
 
+func TestBuildTreeDBOptions_LeafPageReadCacheEntriesDefaultReportsEffective(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+	t.Setenv(treeDBLeafPageReadCacheEntriesEnvKey, "")
+
+	resetTreeDBIndexFlagsForTest()
+
+	_, rep, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions default leaf page read cache entries: %v", err)
+	}
+	if got := rep.formatText(""); !strings.Contains(got, "outer_leaf_read_cache_entries=default/env (effective=4096)") {
+		t.Fatalf("resolved options missing effective default cache entries: %q", got)
+	}
+}
+
 func TestParseTreeDBVlogGenerationPolicy(t *testing.T) {
 	got, err := parseTreeDBVlogGenerationPolicy("default")
 	if err != nil {
@@ -280,6 +296,7 @@ func restoreTreeDBFlagState(s savedTreeDBFlagState) {
 func resetTreeDBIndexFlagsForTest() {
 	*treedbIndexOptimizations = false
 	*treedbIndexOuterLeavesInVlog = true
+	*treedbLeafPageReadCacheEntries = 0
 	*treedbPreferAppendAlloc = false
 	*treedbForceValuePointers = false
 	*treedbLeafPrefixCompression = false

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -37,6 +37,25 @@ func TestBuildTreeDBOptions_IndexOuterLeavesInVlogEnable(t *testing.T) {
 	}
 }
 
+func TestBuildTreeDBOptions_LeafPageReadCacheEntries(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbLeafPageReadCacheEntries = 32768
+
+	opts, rep, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions leaf page read cache entries: %v", err)
+	}
+	if got := opts.LeafPageReadCacheEntries; got != 32768 {
+		t.Fatalf("LeafPageReadCacheEntries=%d want 32768", got)
+	}
+	if got := rep.formatText(""); !strings.Contains(got, "outer_leaf_read_cache_entries=32768") {
+		t.Fatalf("resolved options missing outer_leaf_read_cache_entries=32768: %q", got)
+	}
+}
+
 func TestParseTreeDBVlogGenerationPolicy(t *testing.T) {
 	got, err := parseTreeDBVlogGenerationPolicy("default")
 	if err != nil {
@@ -156,6 +175,7 @@ type savedTreeDBFlagState struct {
 	columnarLeaves          bool
 	packedValuePtr          bool
 	internalBaseDelta       bool
+	leafPageReadCache       int
 	chunkSize               int64
 	vlogCompression         string
 	vlogBlockCodec          string
@@ -195,6 +215,7 @@ func saveTreeDBFlagState() savedTreeDBFlagState {
 		columnarLeaves:          *treedbIndexColumnarLeaves,
 		packedValuePtr:          *treedbIndexPackedValuePtr,
 		internalBaseDelta:       *treedbIndexInternalBaseDelta,
+		leafPageReadCache:       *treedbLeafPageReadCacheEntries,
 		chunkSize:               *treedbChunkSize,
 		vlogCompression:         *treedbVlogCompression,
 		vlogBlockCodec:          *treedbVlogBlockCodec,
@@ -230,6 +251,7 @@ func restoreTreeDBFlagState(s savedTreeDBFlagState) {
 	*treedbIndexColumnarLeaves = s.columnarLeaves
 	*treedbIndexPackedValuePtr = s.packedValuePtr
 	*treedbIndexInternalBaseDelta = s.internalBaseDelta
+	*treedbLeafPageReadCacheEntries = s.leafPageReadCache
 	*treedbChunkSize = s.chunkSize
 	*treedbVlogCompression = s.vlogCompression
 	*treedbVlogBlockCodec = s.vlogBlockCodec

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -231,9 +231,16 @@ process-local cache of recently appended decoded leaf pages. This avoids
 rereading freshly written leaves from mmap or `ReadAt` during follow-up publish,
 update, and maintenance work.
 
-- `TREEDB_LEAF_PAGE_CACHE_ENTRIES` sets the direct-mapped cache slot count.
-  The default is 4096 entries, or about 16 MiB of leaf-page payloads. Set to `0`
-  to disable the cache.
+- `Options.LeafPageReadCacheEntries` sets the direct-mapped cache slot count per
+  DB. `0` uses the process default/env override, `<0` disables the cache, and
+  `>0` sets an explicit slot count.
+- `TREEDB_LEAF_PAGE_CACHE_ENTRIES` sets the process default slot count when the
+  option is left at `0`. The default is 4096 entries, or about 16 MiB of
+  leaf-page payloads. Set the env var to `0` to disable the cache for DBs that
+  do not set `Options.LeafPageReadCacheEntries`.
+- `unified-bench` exposes this as `-treedb-leaf-page-read-cache-entries` so
+  read/publish cache-capacity experiments are captured in the reproduced command
+  instead of relying on ambient environment.
 
 Useful stats:
 - `treedb.process.read_path.outer_leaf.cache.hits`

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -238,6 +238,9 @@ update, and maintenance work.
   option is left at `0`. The default is 4096 entries, or about 16 MiB of
   leaf-page payloads. Set the env var to `0` to disable the cache for DBs that
   do not set `Options.LeafPageReadCacheEntries`.
+- Explicit and env-derived cache sizes are capped at 262144 entries to fail
+  early with a clear configuration error instead of risking an accidental huge
+  cache.
 - `unified-bench` exposes this as `-treedb-leaf-page-read-cache-entries` so
   read/publish cache-capacity experiments are captured in the reproduced command
   instead of relying on ambient environment.


### PR DESCRIPTION
## Summary

Follow-up for #1159 and stacked on #1192.

This exposes the outer-leaf read cache size as an explicit TreeDB option and unified-bench flag, without changing the default cache size.

- Add `Options.LeafPageReadCacheEntries` with explicit semantics:
  - `0`: use the existing process default / `TREEDB_LEAF_PAGE_CACHE_ENTRIES`
  - `<0`: disable the cache for this DB
  - `>0`: set an exact direct-mapped slot count
- Keep the existing env/global fallback behavior for callers that do not set the option.
- Add `unified-bench -treedb-leaf-page-read-cache-entries` and include the resolved value in the TreeDB option report.
- Document the option/env/benchmark flag in `docs/TREEDB_TUNING.md`.

This is intentionally a reproducibility/tuning PR, not a silent default bump. The #1191/#1192 benchmark readout showed 32k/64k entries can materially improve the focused sparse-update current-read phase, but the memory policy needs to remain explicit while we study larger-than-memory behavior.

## Validation

```bash
go test ./TreeDB/db -run 'TestConfiguredLeafPageReadCacheEntries' -count=1

go test ./cmd/unified_bench -run 'TestBuildTreeDBOptions_LeafPageReadCacheEntries' -count=1

go test ./TreeDB/db ./cmd/unified_bench -count=1

git diff --check
```

## Benchmark context

No new throughput claim in this PR. It makes the cache-capacity experiments from #1191/#1192 reproducible through options and benchmark command lines instead of relying on ambient env vars.
