### PR TITLE
Instrument per-index collection update planning

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -330,6 +330,12 @@ type CollectionUpdateStats struct {
 	SecondarySetEntries    int
 	SecondaryKeyBytes      int
 	SecondaryRuns          []CollectionUpdateSecondaryRunStats
+	IndexValueChanges      int
+	IndexValueUnchanged    int
+	UniqueIndexChecks      int
+	UniqueIndexCheckSkips  int
+	// IndexStats is populated only when detailed update-batch stats are enabled.
+	IndexStats []CollectionUpdateIndexStats
 }
 
 // CollectionUpdateSecondaryRunStats captures per-secondary-index delta counters
@@ -339,6 +345,22 @@ type CollectionUpdateSecondaryRunStats struct {
 	Deletes   int
 	Sets      int
 	KeyBytes  int
+}
+
+// CollectionUpdateIndexStats captures per-index update planning decisions from
+// an UpdateBatch-style call. Changed/unchanged are counted per modified
+// document for each cached index runtime.
+type CollectionUpdateIndexStats struct {
+	IndexName         string
+	Unique            bool
+	Changed           int
+	Unchanged         int
+	UniqueChecks      int
+	UniqueCheckSkips  int
+	SecondaryRuns     int
+	SecondaryDeletes  int
+	SecondarySets     int
+	SecondaryKeyBytes int
 }
 
 // CollectionManagerStats captures aggregate write-domain counters for a
@@ -406,11 +428,15 @@ type CollectionManagerStats struct {
 	UpdateBatchBufferRootAppend    time.Duration
 	// UpdateBatchBufferFlush measures only threshold-flush work that was
 	// actually scheduled/executed while staging indexed buffered update batches.
-	UpdateBatchBufferFlush       time.Duration
-	UpdateBatchPublish           time.Duration
-	UpdateBatchSecondaryDeletes  uint64
-	UpdateBatchSecondarySets     uint64
-	UpdateBatchSecondaryKeyBytes uint64
+	UpdateBatchBufferFlush         time.Duration
+	UpdateBatchPublish             time.Duration
+	UpdateBatchSecondaryDeletes    uint64
+	UpdateBatchSecondarySets       uint64
+	UpdateBatchSecondaryKeyBytes   uint64
+	UpdateBatchIndexValueChanges   uint64
+	UpdateBatchIndexValueUnchanged uint64
+	UpdateBatchUniqueChecks        uint64
+	UpdateBatchUniqueCheckSkips    uint64
 }
 
 // DocumentRecord is one primary collection record returned by ScanDocuments.
@@ -693,6 +719,10 @@ type collectionWriteDomain struct {
 	updateBatchSecondaryDeletes      atomic.Uint64
 	updateBatchSecondarySets         atomic.Uint64
 	updateBatchSecondaryKeyBytes     atomic.Uint64
+	updateBatchIndexValueChanges     atomic.Uint64
+	updateBatchIndexValueUnchanged   atomic.Uint64
+	updateBatchUniqueChecks          atomic.Uint64
+	updateBatchUniqueCheckSkips      atomic.Uint64
 	updateBatchDetailedStats         atomic.Bool
 }
 
@@ -803,6 +833,9 @@ func cloneCollectionUpdateStats(stats CollectionUpdateStats) CollectionUpdateSta
 	if len(stats.SecondaryRuns) > 0 {
 		stats.SecondaryRuns = append([]CollectionUpdateSecondaryRunStats(nil), stats.SecondaryRuns...)
 	}
+	if len(stats.IndexStats) > 0 {
+		stats.IndexStats = append([]CollectionUpdateIndexStats(nil), stats.IndexStats...)
+	}
 	return stats
 }
 
@@ -901,6 +934,10 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_batch.secondary_deletes_total"] = fmt.Sprintf("%d", stats.UpdateBatchSecondaryDeletes)
 	out["treedb.collections.write_domain.update_batch.secondary_sets_total"] = fmt.Sprintf("%d", stats.UpdateBatchSecondarySets)
 	out["treedb.collections.write_domain.update_batch.secondary_key_bytes_total"] = fmt.Sprintf("%d", stats.UpdateBatchSecondaryKeyBytes)
+	out["treedb.collections.write_domain.update_batch.index_value_changes_total"] = fmt.Sprintf("%d", stats.UpdateBatchIndexValueChanges)
+	out["treedb.collections.write_domain.update_batch.index_value_unchanged_total"] = fmt.Sprintf("%d", stats.UpdateBatchIndexValueUnchanged)
+	out["treedb.collections.write_domain.update_batch.unique_checks_total"] = fmt.Sprintf("%d", stats.UpdateBatchUniqueChecks)
+	out["treedb.collections.write_domain.update_batch.unique_check_skips_total"] = fmt.Sprintf("%d", stats.UpdateBatchUniqueCheckSkips)
 	return out
 }
 
@@ -991,6 +1028,10 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.UpdateBatchSecondaryDeletes += other.UpdateBatchSecondaryDeletes
 	s.UpdateBatchSecondarySets += other.UpdateBatchSecondarySets
 	s.UpdateBatchSecondaryKeyBytes += other.UpdateBatchSecondaryKeyBytes
+	s.UpdateBatchIndexValueChanges += other.UpdateBatchIndexValueChanges
+	s.UpdateBatchIndexValueUnchanged += other.UpdateBatchIndexValueUnchanged
+	s.UpdateBatchUniqueChecks += other.UpdateBatchUniqueChecks
+	s.UpdateBatchUniqueCheckSkips += other.UpdateBatchUniqueCheckSkips
 }
 
 func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
@@ -1061,6 +1102,10 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateBatchSecondaryDeletes = domain.updateBatchSecondaryDeletes.Load()
 	stats.UpdateBatchSecondarySets = domain.updateBatchSecondarySets.Load()
 	stats.UpdateBatchSecondaryKeyBytes = domain.updateBatchSecondaryKeyBytes.Load()
+	stats.UpdateBatchIndexValueChanges = domain.updateBatchIndexValueChanges.Load()
+	stats.UpdateBatchIndexValueUnchanged = domain.updateBatchIndexValueUnchanged.Load()
+	stats.UpdateBatchUniqueChecks = domain.updateBatchUniqueChecks.Load()
+	stats.UpdateBatchUniqueCheckSkips = domain.updateBatchUniqueCheckSkips.Load()
 	return stats
 }
 
@@ -1151,6 +1196,18 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 	}
 	if stats.SecondaryKeyBytes > 0 {
 		domain.updateBatchSecondaryKeyBytes.Add(uint64(stats.SecondaryKeyBytes))
+	}
+	if stats.IndexValueChanges > 0 {
+		domain.updateBatchIndexValueChanges.Add(uint64(stats.IndexValueChanges))
+	}
+	if stats.IndexValueUnchanged > 0 {
+		domain.updateBatchIndexValueUnchanged.Add(uint64(stats.IndexValueUnchanged))
+	}
+	if stats.UniqueIndexChecks > 0 {
+		domain.updateBatchUniqueChecks.Add(uint64(stats.UniqueIndexChecks))
+	}
+	if stats.UniqueIndexCheckSkips > 0 {
+		domain.updateBatchUniqueCheckSkips.Add(uint64(stats.UniqueIndexCheckSkips))
 	}
 }
 
@@ -3561,7 +3618,7 @@ func bufferedUnchangedUniqueValueRuns(runtimes []indexRuntime, updates []prepare
 			if !update.indexStateChanged {
 				continue
 			}
-			if !normalizedEncodedIndexValuesEqual(update.oldState.valuesAt(runtimeIdx), update.newState.valuesAt(runtimeIdx)) {
+			if preparedBatchUpdateIndexChanged(update, runtimeIdx) {
 				continue
 			}
 			for _, encoded := range update.newState.valuesAt(runtimeIdx) {
@@ -6406,6 +6463,7 @@ type preparedBatchUpdate struct {
 	document          []byte
 	oldState          orderedDocumentIndexState
 	newState          orderedDocumentIndexState
+	changedIndexes    uint64
 	indexStateChanged bool
 }
 
@@ -6458,6 +6516,7 @@ type updateBatchPlanScratch struct {
 	policies         []backenddb.OrderedRootStoragePolicy
 	deltaTables      []memtable.Table
 	uniqueSecondary  []int
+	indexStats       []CollectionUpdateIndexStats
 }
 
 var updateBatchPlanScratchPool sync.Pool
@@ -6551,6 +6610,11 @@ func getUpdateBatchPlanScratch(itemCount, runtimeCount int) *updateBatchPlanScra
 	} else {
 		scratch.uniqueSecondary = scratch.uniqueSecondary[:0]
 	}
+	if cap(scratch.indexStats) < runtimeCount || cap(scratch.indexStats) > updateBatchPlanScratchMaxRootNameCap {
+		scratch.indexStats = make([]CollectionUpdateIndexStats, 0, runtimeCount)
+	} else {
+		scratch.indexStats = scratch.indexStats[:0]
+	}
 	return scratch
 }
 
@@ -6605,6 +6669,12 @@ func putUpdateBatchPlanScratch(scratch *updateBatchPlanScratch) {
 	scratch.deltaTables = scratch.deltaTables[:0]
 	clear(scratch.uniqueSecondary)
 	scratch.uniqueSecondary = scratch.uniqueSecondary[:0]
+	clear(scratch.indexStats)
+	if cap(scratch.indexStats) > updateBatchPlanScratchMaxRootNameCap {
+		scratch.indexStats = nil
+	} else {
+		scratch.indexStats = scratch.indexStats[:0]
+	}
 	updateBatchPlanScratchPool.Put(scratch)
 }
 
@@ -7149,6 +7219,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	policies := scratch.policies
 	deltaTables := scratch.deltaTables
 	uniqueSecondary := scratch.uniqueSecondary
+	indexStats := scratch.indexStats
 	defer func() {
 		scratch.changed = changed
 		scratch.changedDocuments = changedDocuments
@@ -7156,10 +7227,19 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		scratch.policies = policies
 		scratch.deltaTables = deltaTables
 		scratch.uniqueSecondary = uniqueSecondary
+		scratch.indexStats = indexStats
 		if !scratchOwnedByPlan {
 			putUpdateBatchPlanScratch(scratch)
 		}
 	}()
+	if detailedStats {
+		for _, runtime := range runtimes {
+			indexStats = append(indexStats, CollectionUpdateIndexStats{
+				IndexName: runtime.def.name,
+				Unique:    runtime.def.unique,
+			})
+		}
+	}
 	var currentScratch []byte
 	for i, item := range items {
 		phaseStart := updateBatchStatsNow(detailedStats)
@@ -7275,7 +7355,40 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 				_ = snap.Close()
 				return nil, updateBatchItemError(changed[i].itemIndex, err)
 			}
-			changed[i].indexStateChanged = !orderedDocumentIndexStatesEqual(changed[i].oldState, changed[i].newState)
+			var changedIndexes uint64
+			indexStateChanged := false
+			for runtimeIdx, runtime := range runtimes {
+				runtimeChanged := orderedDocumentIndexRuntimeChanged(changed[i].oldState, changed[i].newState, runtimeIdx)
+				if runtimeChanged {
+					indexStateChanged = true
+					if bit, ok := updateIndexChangedMaskBit(runtimeIdx); ok {
+						changedIndexes |= bit
+					}
+					stats.IndexValueChanges++
+					if runtime.def.unique {
+						stats.UniqueIndexChecks++
+					}
+					if runtimeIdx < len(indexStats) {
+						indexStats[runtimeIdx].Changed++
+						if runtime.def.unique {
+							indexStats[runtimeIdx].UniqueChecks++
+						}
+					}
+					continue
+				}
+				stats.IndexValueUnchanged++
+				if runtime.def.unique {
+					stats.UniqueIndexCheckSkips++
+				}
+				if runtimeIdx < len(indexStats) {
+					indexStats[runtimeIdx].Unchanged++
+					if runtime.def.unique {
+						indexStats[runtimeIdx].UniqueCheckSkips++
+					}
+				}
+			}
+			changed[i].changedIndexes = changedIndexes
+			changed[i].indexStateChanged = indexStateChanged
 		}
 	}
 	if mode == updateBatchModeNoSecondaryUniqueIndexChanges && updateBatchChangesSecondaryUniqueIndex(runtimes, changed) {
@@ -7286,7 +7399,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	batchReplacements := batchUniqueReplacementOwners(runtimes, changed)
 	for i := range changed {
 		if changed[i].indexStateChanged {
-			if err := rejectReplaceUniqueConflictsOrdered(snap, catalog, runtimes, changed[i].oldState, changed[i].newState, changed[i].documentID, batchReplacements); err != nil {
+			if err := rejectReplaceUniqueConflictsOrdered(snap, catalog, runtimes, changed[i], batchReplacements); err != nil {
 				_ = snap.Close()
 				return nil, updateBatchItemError(changed[i].itemIndex, err)
 			}
@@ -7388,7 +7501,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 				continue
 			}
 			for runtimeIdx, runtime := range runtimes {
-				if !orderedDocumentIndexRuntimeChanged(item.oldState, item.newState, runtimeIdx) {
+				if !preparedBatchUpdateIndexChanged(item, runtimeIdx) {
 					continue
 				}
 				rootName := runtimeSecondaryRootName(meta.Name, runtime)
@@ -7412,6 +7525,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 					stats.SecondaryKeyBytes += len(key)
 					runStats.Deletes++
 					runStats.KeyBytes += len(key)
+					if runtimeIdx < len(indexStats) {
+						indexStats[runtimeIdx].SecondaryDeletes++
+						indexStats[runtimeIdx].SecondaryKeyBytes += len(key)
+					}
 				}
 				for _, encoded := range item.newState.valuesAt(runtimeIdx) {
 					key, err := indexEntryKey(encoded, item.documentID)
@@ -7424,6 +7541,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 					stats.SecondaryKeyBytes += len(key)
 					runStats.Sets++
 					runStats.KeyBytes += len(key)
+					if runtimeIdx < len(indexStats) {
+						indexStats[runtimeIdx].SecondarySets++
+						indexStats[runtimeIdx].SecondaryKeyBytes += len(key)
+					}
 				}
 			}
 		}
@@ -7446,6 +7567,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			if runStats := secondaryRunStats[runtimeIdx]; runStats.Deletes != 0 || runStats.Sets != 0 || runStats.KeyBytes != 0 {
 				stats.SecondaryRuns = append(stats.SecondaryRuns, runStats)
 			}
+			if runtimeIdx < len(indexStats) {
+				indexStats[runtimeIdx].SecondaryRuns++
+			}
 			delete(secondaryTables, rootName)
 		}
 		stats.SecondaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
@@ -7467,6 +7591,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	}
 	success = true
 	plan := newUpdateBatchPlan()
+	if len(indexStats) > 0 {
+		stats.IndexStats = append([]CollectionUpdateIndexStats(nil), indexStats...)
+	}
 	stats = updateCollectionUpdateStatsCounts(stats, results, len(deltaTables))
 	*plan = updateBatchPlan{
 		results:                     results,
@@ -7852,7 +7979,7 @@ func rejectBatchUniqueConflicts(runtimes []indexRuntime, updates []preparedBatch
 		}
 		hasChangedUniqueValue := false
 		for _, update := range updates {
-			if normalizedEncodedIndexValuesEqual(update.oldState.valuesAt(runtimeIdx), update.newState.valuesAt(runtimeIdx)) {
+			if !preparedBatchUpdateIndexChanged(update, runtimeIdx) {
 				continue
 			}
 			hasChangedUniqueValue = true
@@ -7891,7 +8018,7 @@ func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []p
 			continue
 		}
 		for _, update := range updates {
-			if !normalizedEncodedIndexValuesEqual(update.oldState.valuesAt(runtimeIdx), update.newState.valuesAt(runtimeIdx)) {
+			if preparedBatchUpdateIndexChanged(update, runtimeIdx) {
 				return true
 			}
 		}
@@ -7905,6 +8032,20 @@ func documentIndexRuntimeChanged(oldState, newState documentIndexState, runtime 
 
 func orderedDocumentIndexRuntimeChanged(oldState, newState orderedDocumentIndexState, runtimeIdx int) bool {
 	return !normalizedEncodedIndexValuesEqual(oldState.valuesAt(runtimeIdx), newState.valuesAt(runtimeIdx))
+}
+
+func updateIndexChangedMaskBit(runtimeIdx int) (uint64, bool) {
+	if runtimeIdx < 0 || runtimeIdx >= 64 {
+		return 0, false
+	}
+	return uint64(1) << uint(runtimeIdx), true
+}
+
+func preparedBatchUpdateIndexChanged(update preparedBatchUpdate, runtimeIdx int) bool {
+	if bit, ok := updateIndexChangedMaskBit(runtimeIdx); ok {
+		return update.changedIndexes&bit != 0
+	}
+	return orderedDocumentIndexRuntimeChanged(update.oldState, update.newState, runtimeIdx)
 }
 
 func normalizedEncodedIndexValuesEqual(left, right [][]byte) bool {
@@ -7932,6 +8073,9 @@ func batchUniqueReplacementOwners(runtimes []indexRuntime, updates []preparedBat
 		}
 		indexName := runtime.def.name
 		for _, update := range updates {
+			if !preparedBatchUpdateIndexChanged(update, runtimeIdx) {
+				continue
+			}
 			oldValues := update.oldState.valuesAt(runtimeIdx)
 			if len(oldValues) == 0 {
 				continue
@@ -8694,7 +8838,7 @@ func rejectReplaceUniqueConflicts(snap *backenddb.Snapshot, catalog *collectionC
 	return nil
 }
 
-func rejectReplaceUniqueConflictsOrdered(snap *backenddb.Snapshot, catalog *collectionCatalog, runtimes []indexRuntime, oldState, newState orderedDocumentIndexState, documentID []byte, batchReplacements batchUniqueReplacementSet) error {
+func rejectReplaceUniqueConflictsOrdered(snap *backenddb.Snapshot, catalog *collectionCatalog, runtimes []indexRuntime, update preparedBatchUpdate, batchReplacements batchUniqueReplacementSet) error {
 	if snap == nil || catalog == nil {
 		return nil
 	}
@@ -8702,14 +8846,14 @@ func rejectReplaceUniqueConflictsOrdered(snap *backenddb.Snapshot, catalog *coll
 		if !runtime.def.unique {
 			continue
 		}
-		if !orderedDocumentIndexRuntimeChanged(oldState, newState, runtimeIdx) {
+		if !preparedBatchUpdateIndexChanged(update, runtimeIdx) {
 			continue
 		}
 		rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, runtime.def.name))
 		if rootID == 0 {
 			continue
 		}
-		for _, encoded := range newState.valuesAt(runtimeIdx) {
+		for _, encoded := range update.newState.valuesAt(runtimeIdx) {
 			_, prefix, err := appendIndexValuePrefixSlice(make([]byte, 0, 2+len(encoded)), encoded)
 			if err != nil {
 				return err
@@ -8728,7 +8872,7 @@ func rejectReplaceUniqueConflictsOrdered(snap *backenddb.Snapshot, catalog *coll
 					break
 				}
 				ownerID := key[len(prefix):]
-				if !it.IsDeleted() && !bytes.Equal(ownerID, documentID) && !batchReplacements.allows(runtime.def.name, encoded, ownerID) {
+				if !it.IsDeleted() && !bytes.Equal(ownerID, update.documentID) && !batchReplacements.allows(runtime.def.name, encoded, ownerID) {
 					conflict = true
 					break
 				}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -334,9 +334,14 @@ type CollectionUpdateStats struct {
 	IndexValueUnchanged    int
 	UniqueIndexChecks      int
 	UniqueIndexCheckSkips  int
-	// IndexStats is populated only when detailed update-batch stats are enabled.
-	IndexStats []CollectionUpdateIndexStats
+	// IndexStats is populated only when detailed update-batch stats are enabled
+	// and the collection has at most len(IndexStats) index runtimes. The first
+	// IndexStatsCount entries are valid.
+	IndexStatsCount int
+	IndexStats      [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats
 }
+
+const maxCollectionUpdateInlineIndexStats = 8
 
 // CollectionUpdateSecondaryRunStats captures per-secondary-index delta counters
 // from an UpdateBatch-style call.
@@ -832,9 +837,6 @@ func (c *Collection) setLastUpdateStats(stats CollectionUpdateStats) {
 func cloneCollectionUpdateStats(stats CollectionUpdateStats) CollectionUpdateStats {
 	if len(stats.SecondaryRuns) > 0 {
 		stats.SecondaryRuns = append([]CollectionUpdateSecondaryRunStats(nil), stats.SecondaryRuns...)
-	}
-	if len(stats.IndexStats) > 0 {
-		stats.IndexStats = append([]CollectionUpdateIndexStats(nil), stats.IndexStats...)
 	}
 	return stats
 }
@@ -6516,7 +6518,6 @@ type updateBatchPlanScratch struct {
 	policies         []backenddb.OrderedRootStoragePolicy
 	deltaTables      []memtable.Table
 	uniqueSecondary  []int
-	indexStats       []CollectionUpdateIndexStats
 }
 
 var updateBatchPlanScratchPool sync.Pool
@@ -6530,7 +6531,6 @@ const (
 	updateBatchPlanScratchMaxStateArenaCap        = 4 << 20
 	updateBatchPlanScratchMaxStateSliceCap        = 1 << 16
 	updateBatchPlanScratchMaxValueRefCap          = 1 << 16
-	updateBatchPlanScratchMaxIndexStatsCap        = 64
 )
 
 func estimateUpdateBatchPlanDocumentArenaBytes(itemCount int) int {
@@ -6611,11 +6611,6 @@ func getUpdateBatchPlanScratch(itemCount, runtimeCount int) *updateBatchPlanScra
 	} else {
 		scratch.uniqueSecondary = scratch.uniqueSecondary[:0]
 	}
-	if cap(scratch.indexStats) < runtimeCount || cap(scratch.indexStats) > updateBatchPlanScratchMaxIndexStatsCap {
-		scratch.indexStats = make([]CollectionUpdateIndexStats, 0, runtimeCount)
-	} else {
-		scratch.indexStats = scratch.indexStats[:0]
-	}
 	return scratch
 }
 
@@ -6670,12 +6665,6 @@ func putUpdateBatchPlanScratch(scratch *updateBatchPlanScratch) {
 	scratch.deltaTables = scratch.deltaTables[:0]
 	clear(scratch.uniqueSecondary)
 	scratch.uniqueSecondary = scratch.uniqueSecondary[:0]
-	clear(scratch.indexStats)
-	if cap(scratch.indexStats) > updateBatchPlanScratchMaxIndexStatsCap {
-		scratch.indexStats = nil
-	} else {
-		scratch.indexStats = scratch.indexStats[:0]
-	}
 	updateBatchPlanScratchPool.Put(scratch)
 }
 
@@ -7220,7 +7209,6 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	policies := scratch.policies
 	deltaTables := scratch.deltaTables
 	uniqueSecondary := scratch.uniqueSecondary
-	indexStats := scratch.indexStats
 	defer func() {
 		scratch.changed = changed
 		scratch.changedDocuments = changedDocuments
@@ -7228,17 +7216,17 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		scratch.policies = policies
 		scratch.deltaTables = deltaTables
 		scratch.uniqueSecondary = uniqueSecondary
-		scratch.indexStats = indexStats
 		if !scratchOwnedByPlan {
 			putUpdateBatchPlanScratch(scratch)
 		}
 	}()
-	if detailedStats {
-		for _, runtime := range runtimes {
-			indexStats = append(indexStats, CollectionUpdateIndexStats{
+	if detailedStats && len(runtimes) <= len(stats.IndexStats) {
+		stats.IndexStatsCount = len(runtimes)
+		for i, runtime := range runtimes {
+			stats.IndexStats[i] = CollectionUpdateIndexStats{
 				IndexName: runtime.def.name,
 				Unique:    runtime.def.unique,
-			})
+			}
 		}
 	}
 	var currentScratch []byte
@@ -7369,10 +7357,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 					if runtime.def.unique {
 						stats.UniqueIndexChecks++
 					}
-					if runtimeIdx < len(indexStats) {
-						indexStats[runtimeIdx].Changed++
+					if runtimeIdx < stats.IndexStatsCount {
+						stats.IndexStats[runtimeIdx].Changed++
 						if runtime.def.unique {
-							indexStats[runtimeIdx].UniqueChecks++
+							stats.IndexStats[runtimeIdx].UniqueChecks++
 						}
 					}
 					continue
@@ -7381,10 +7369,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 				if runtime.def.unique {
 					stats.UniqueIndexCheckSkips++
 				}
-				if runtimeIdx < len(indexStats) {
-					indexStats[runtimeIdx].Unchanged++
+				if runtimeIdx < stats.IndexStatsCount {
+					stats.IndexStats[runtimeIdx].Unchanged++
 					if runtime.def.unique {
-						indexStats[runtimeIdx].UniqueCheckSkips++
+						stats.IndexStats[runtimeIdx].UniqueCheckSkips++
 					}
 				}
 			}
@@ -7526,9 +7514,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 					stats.SecondaryKeyBytes += len(key)
 					runStats.Deletes++
 					runStats.KeyBytes += len(key)
-					if runtimeIdx < len(indexStats) {
-						indexStats[runtimeIdx].SecondaryDeletes++
-						indexStats[runtimeIdx].SecondaryKeyBytes += len(key)
+					if runtimeIdx < stats.IndexStatsCount {
+						stats.IndexStats[runtimeIdx].SecondaryDeletes++
+						stats.IndexStats[runtimeIdx].SecondaryKeyBytes += len(key)
 					}
 				}
 				for _, encoded := range item.newState.valuesAt(runtimeIdx) {
@@ -7542,9 +7530,9 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 					stats.SecondaryKeyBytes += len(key)
 					runStats.Sets++
 					runStats.KeyBytes += len(key)
-					if runtimeIdx < len(indexStats) {
-						indexStats[runtimeIdx].SecondarySets++
-						indexStats[runtimeIdx].SecondaryKeyBytes += len(key)
+					if runtimeIdx < stats.IndexStatsCount {
+						stats.IndexStats[runtimeIdx].SecondarySets++
+						stats.IndexStats[runtimeIdx].SecondaryKeyBytes += len(key)
 					}
 				}
 			}
@@ -7568,8 +7556,8 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			if runStats := secondaryRunStats[runtimeIdx]; runStats.Deletes != 0 || runStats.Sets != 0 || runStats.KeyBytes != 0 {
 				stats.SecondaryRuns = append(stats.SecondaryRuns, runStats)
 			}
-			if runtimeIdx < len(indexStats) {
-				indexStats[runtimeIdx].SecondaryRuns++
+			if runtimeIdx < stats.IndexStatsCount {
+				stats.IndexStats[runtimeIdx].SecondaryRuns++
 			}
 			delete(secondaryTables, rootName)
 		}
@@ -7592,9 +7580,6 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	}
 	success = true
 	plan := newUpdateBatchPlan()
-	if len(indexStats) > 0 {
-		stats.IndexStats = append([]CollectionUpdateIndexStats(nil), indexStats...)
-	}
 	stats = updateCollectionUpdateStatsCounts(stats, results, len(deltaTables))
 	*plan = updateBatchPlan{
 		results:                     results,

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6530,6 +6530,7 @@ const (
 	updateBatchPlanScratchMaxStateArenaCap        = 4 << 20
 	updateBatchPlanScratchMaxStateSliceCap        = 1 << 16
 	updateBatchPlanScratchMaxValueRefCap          = 1 << 16
+	updateBatchPlanScratchMaxIndexStatsCap        = 64
 )
 
 func estimateUpdateBatchPlanDocumentArenaBytes(itemCount int) int {
@@ -6610,7 +6611,7 @@ func getUpdateBatchPlanScratch(itemCount, runtimeCount int) *updateBatchPlanScra
 	} else {
 		scratch.uniqueSecondary = scratch.uniqueSecondary[:0]
 	}
-	if cap(scratch.indexStats) < runtimeCount || cap(scratch.indexStats) > updateBatchPlanScratchMaxRootNameCap {
+	if cap(scratch.indexStats) < runtimeCount || cap(scratch.indexStats) > updateBatchPlanScratchMaxIndexStatsCap {
 		scratch.indexStats = make([]CollectionUpdateIndexStats, 0, runtimeCount)
 	} else {
 		scratch.indexStats = scratch.indexStats[:0]
@@ -6670,7 +6671,7 @@ func putUpdateBatchPlanScratch(scratch *updateBatchPlanScratch) {
 	clear(scratch.uniqueSecondary)
 	scratch.uniqueSecondary = scratch.uniqueSecondary[:0]
 	clear(scratch.indexStats)
-	if cap(scratch.indexStats) > updateBatchPlanScratchMaxRootNameCap {
+	if cap(scratch.indexStats) > updateBatchPlanScratchMaxIndexStatsCap {
 		scratch.indexStats = nil
 	} else {
 		scratch.indexStats = scratch.indexStats[:0]

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9848,7 +9848,8 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	if got, want := stats.UniqueIndexCheckSkips, 1; got != want {
 		t.Fatalf("unique index check skips=%d want %d", got, want)
 	}
-	if got, want := len(stats.IndexStats), 2; got != want {
+	indexStats := stats.IndexStats[:stats.IndexStatsCount]
+	if got, want := len(indexStats), 2; got != want {
 		t.Fatalf("index decision stats=%d want %d: %+v", got, want, stats.IndexStats)
 	}
 	indexStatByName := func(stats []CollectionUpdateIndexStats, name string) CollectionUpdateIndexStats {
@@ -9861,10 +9862,10 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 		t.Fatalf("missing index stat %q in %+v", name, stats)
 		return CollectionUpdateIndexStats{}
 	}
-	if idx := indexStatByName(stats.IndexStats, "email"); !idx.Unique || idx.Changed != 0 || idx.Unchanged != 1 || idx.UniqueChecks != 0 || idx.UniqueCheckSkips != 1 || idx.SecondaryRuns != 0 {
+	if idx := indexStatByName(indexStats, "email"); !idx.Unique || idx.Changed != 0 || idx.Unchanged != 1 || idx.UniqueChecks != 0 || idx.UniqueCheckSkips != 1 || idx.SecondaryRuns != 0 {
 		t.Fatalf("email index decision stats=%+v want unchanged unique skip", idx)
 	}
-	if idx := indexStatByName(stats.IndexStats, "city"); idx.Unique || idx.Changed != 1 || idx.Unchanged != 0 || idx.SecondaryRuns != 1 || idx.SecondaryDeletes != 1 || idx.SecondarySets != 1 || idx.SecondaryKeyBytes == 0 {
+	if idx := indexStatByName(indexStats, "city"); idx.Unique || idx.Changed != 1 || idx.Unchanged != 0 || idx.SecondaryRuns != 1 || idx.SecondaryDeletes != 1 || idx.SecondarySets != 1 || idx.SecondaryKeyBytes == 0 {
 		t.Fatalf("city index decision stats=%+v want changed secondary run", idx)
 	}
 	stats.SecondaryRuns[0].IndexName = "mutated"
@@ -9872,7 +9873,8 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 		t.Fatalf("LastUpdateStats did not return owned secondary-run stats, got %q", got)
 	}
 	stats.IndexStats[0].IndexName = "mutated"
-	if got := indexStatByName(col.LastUpdateStats().IndexStats, "email").IndexName; got != "email" {
+	again := col.LastUpdateStats()
+	if got := indexStatByName(again.IndexStats[:again.IndexStatsCount], "email").IndexName; got != "email" {
 		t.Fatalf("LastUpdateStats did not return owned index decision stats, got %q", got)
 	}
 
@@ -9930,10 +9932,11 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	if got, want := stats.UniqueIndexCheckSkips, 1; got != want {
 		t.Fatalf("same-index update unique check skips=%d want %d", got, want)
 	}
-	if got, want := len(stats.IndexStats), 2; got != want {
+	indexStats = stats.IndexStats[:stats.IndexStatsCount]
+	if got, want := len(indexStats), 2; got != want {
 		t.Fatalf("same-index update index decision stats=%d want %d: %+v", got, want, stats.IndexStats)
 	}
-	for _, idx := range stats.IndexStats {
+	for _, idx := range indexStats {
 		if idx.Changed != 0 || idx.Unchanged != 1 || idx.SecondaryRuns != 0 || idx.SecondaryDeletes != 0 || idx.SecondarySets != 0 || idx.SecondaryKeyBytes != 0 {
 			t.Fatalf("same-index update per-index stats=%+v want unchanged/no secondary work", idx)
 		}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -646,9 +646,28 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	if got := managerStats.UpdateBatchSecondarySets; got < 2 {
 		t.Fatalf("manager update batch secondary sets=%d want at least 2", got)
 	}
+	if got := managerStats.UpdateBatchIndexValueChanges; got < 2 {
+		t.Fatalf("manager update batch index value changes=%d want at least 2", got)
+	}
+	if got := managerStats.UpdateBatchIndexValueUnchanged; got < 2 {
+		t.Fatalf("manager update batch index value unchanged=%d want at least 2", got)
+	}
+	if got := managerStats.UpdateBatchUniqueCheckSkips; got < 2 {
+		t.Fatalf("manager update batch unique check skips=%d want at least 2", got)
+	}
 	exported := mgr.Stats()
 	if _, ok := exported["treedb.collections.write_domain.update_batch.secondary_sets_total"]; !ok {
 		t.Fatalf("manager stats missing update batch secondary set counter: keys=%v", exported)
+	}
+	for _, key := range []string{
+		"treedb.collections.write_domain.update_batch.index_value_changes_total",
+		"treedb.collections.write_domain.update_batch.index_value_unchanged_total",
+		"treedb.collections.write_domain.update_batch.unique_checks_total",
+		"treedb.collections.write_domain.update_batch.unique_check_skips_total",
+	} {
+		if _, ok := exported[key]; !ok {
+			t.Fatalf("manager stats missing %s: keys=%v", key, exported)
+		}
 	}
 	for _, key := range []string{
 		"treedb.collections.write_domain.update_batch.buffer_stage_precheck_ns_total",
@@ -9748,6 +9767,7 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open collection: %v", err)
 	}
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
 	if _, err := col.InsertBatch(
 		[][]byte{[]byte("u1")},
 		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl","seen":false}`)},
@@ -9816,9 +9836,44 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	if run := stats.SecondaryRuns[0]; run.IndexName != "city" || run.Deletes != 1 || run.Sets != 1 || run.KeyBytes == 0 {
 		t.Fatalf("city secondary run stats=%+v want city delete+set with key bytes", run)
 	}
+	if got, want := stats.IndexValueChanges, 1; got != want {
+		t.Fatalf("index value changes=%d want %d", got, want)
+	}
+	if got, want := stats.IndexValueUnchanged, 1; got != want {
+		t.Fatalf("index value unchanged=%d want %d", got, want)
+	}
+	if got, want := stats.UniqueIndexChecks, 0; got != want {
+		t.Fatalf("unique index checks=%d want %d", got, want)
+	}
+	if got, want := stats.UniqueIndexCheckSkips, 1; got != want {
+		t.Fatalf("unique index check skips=%d want %d", got, want)
+	}
+	if got, want := len(stats.IndexStats), 2; got != want {
+		t.Fatalf("index decision stats=%d want %d: %+v", got, want, stats.IndexStats)
+	}
+	indexStatByName := func(stats []CollectionUpdateIndexStats, name string) CollectionUpdateIndexStats {
+		t.Helper()
+		for _, stat := range stats {
+			if stat.IndexName == name {
+				return stat
+			}
+		}
+		t.Fatalf("missing index stat %q in %+v", name, stats)
+		return CollectionUpdateIndexStats{}
+	}
+	if idx := indexStatByName(stats.IndexStats, "email"); !idx.Unique || idx.Changed != 0 || idx.Unchanged != 1 || idx.UniqueChecks != 0 || idx.UniqueCheckSkips != 1 || idx.SecondaryRuns != 0 {
+		t.Fatalf("email index decision stats=%+v want unchanged unique skip", idx)
+	}
+	if idx := indexStatByName(stats.IndexStats, "city"); idx.Unique || idx.Changed != 1 || idx.Unchanged != 0 || idx.SecondaryRuns != 1 || idx.SecondaryDeletes != 1 || idx.SecondarySets != 1 || idx.SecondaryKeyBytes == 0 {
+		t.Fatalf("city index decision stats=%+v want changed secondary run", idx)
+	}
 	stats.SecondaryRuns[0].IndexName = "mutated"
 	if got := col.LastUpdateStats().SecondaryRuns[0].IndexName; got != "city" {
 		t.Fatalf("LastUpdateStats did not return owned secondary-run stats, got %q", got)
+	}
+	stats.IndexStats[0].IndexName = "mutated"
+	if got := indexStatByName(col.LastUpdateStats().IndexStats, "email").IndexName; got != "email" {
+		t.Fatalf("LastUpdateStats did not return owned index decision stats, got %q", got)
 	}
 
 	afterCity := roots(loadCatalog())
@@ -9862,6 +9917,26 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	if stats.SecondaryDeleteEntries != 0 || stats.SecondarySetEntries != 0 || stats.SecondaryKeyBytes != 0 || len(stats.SecondaryRuns) != 0 {
 		t.Fatalf("same-index update secondary stats deletes=%d sets=%d bytes=%d runs=%+v, want no secondary work",
 			stats.SecondaryDeleteEntries, stats.SecondarySetEntries, stats.SecondaryKeyBytes, stats.SecondaryRuns)
+	}
+	if got, want := stats.IndexValueChanges, 0; got != want {
+		t.Fatalf("same-index update changes=%d want %d", got, want)
+	}
+	if got, want := stats.IndexValueUnchanged, 2; got != want {
+		t.Fatalf("same-index update unchanged=%d want %d", got, want)
+	}
+	if got, want := stats.UniqueIndexChecks, 0; got != want {
+		t.Fatalf("same-index update unique checks=%d want %d", got, want)
+	}
+	if got, want := stats.UniqueIndexCheckSkips, 1; got != want {
+		t.Fatalf("same-index update unique check skips=%d want %d", got, want)
+	}
+	if got, want := len(stats.IndexStats), 2; got != want {
+		t.Fatalf("same-index update index decision stats=%d want %d: %+v", got, want, stats.IndexStats)
+	}
+	for _, idx := range stats.IndexStats {
+		if idx.Changed != 0 || idx.Unchanged != 1 || idx.SecondaryRuns != 0 || idx.SecondaryDeletes != 0 || idx.SecondarySets != 0 || idx.SecondaryKeyBytes != 0 {
+			t.Fatalf("same-index update per-index stats=%+v want unchanged/no secondary work", idx)
+		}
 	}
 	afterSame := roots(loadCatalog())
 	for _, rootName := range []string{

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -522,6 +522,8 @@ The benchmark shapes are intentionally different:
   update attribution metrics such as `update_current_read_ns/doc`,
   `update_callback_ns/doc`, `update_index_state_extract_ns/doc`,
   `update_primary_run_ns/doc`, `update_secondary_runs_ns/doc`,
+  `update_index_value_changes/doc`, `update_index_value_unchanged/doc`,
+  `update_unique_checks/doc`, `update_unique_check_skips/doc`,
   `update_buffer_stage_ns/doc`, buffer-stage submetrics such as
   `update_buffer_precheck_ns/doc`, `update_buffer_lock_wait_ns/doc`,
   `update_buffer_lock_hold_ns/doc`, `update_buffer_validation_ns/doc`,

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -780,6 +780,10 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateBatchSecondaryDeletes:    after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
 		UpdateBatchSecondarySets:       after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
 		UpdateBatchSecondaryKeyBytes:   after.UpdateBatchSecondaryKeyBytes - before.UpdateBatchSecondaryKeyBytes,
+		UpdateBatchIndexValueChanges:   after.UpdateBatchIndexValueChanges - before.UpdateBatchIndexValueChanges,
+		UpdateBatchIndexValueUnchanged: after.UpdateBatchIndexValueUnchanged - before.UpdateBatchIndexValueUnchanged,
+		UpdateBatchUniqueChecks:        after.UpdateBatchUniqueChecks - before.UpdateBatchUniqueChecks,
+		UpdateBatchUniqueCheckSkips:    after.UpdateBatchUniqueCheckSkips - before.UpdateBatchUniqueCheckSkips,
 		UpdateCombineRequests:          after.UpdateCombineRequests - before.UpdateCombineRequests,
 		UpdateCombineBatches:           after.UpdateCombineBatches - before.UpdateCombineBatches,
 		UpdateCombineBatchedRequests:   after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
@@ -789,16 +793,24 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 
 func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	before := collections.CollectionManagerStats{
-		UpdateCombineRequests:         10,
-		UpdateCombineBatches:          3,
-		UpdateCombineBatchedRequests:  8,
-		UpdateCombineFallbackRequests: 1,
+		UpdateCombineRequests:          10,
+		UpdateCombineBatches:           3,
+		UpdateCombineBatchedRequests:   8,
+		UpdateCombineFallbackRequests:  1,
+		UpdateBatchIndexValueChanges:   20,
+		UpdateBatchIndexValueUnchanged: 30,
+		UpdateBatchUniqueChecks:        4,
+		UpdateBatchUniqueCheckSkips:    10,
 	}
 	after := collections.CollectionManagerStats{
-		UpdateCombineRequests:         17,
-		UpdateCombineBatches:          5,
-		UpdateCombineBatchedRequests:  14,
-		UpdateCombineFallbackRequests: 2,
+		UpdateCombineRequests:          17,
+		UpdateCombineBatches:           5,
+		UpdateCombineBatchedRequests:   14,
+		UpdateCombineFallbackRequests:  2,
+		UpdateBatchIndexValueChanges:   27,
+		UpdateBatchIndexValueUnchanged: 43,
+		UpdateBatchUniqueChecks:        6,
+		UpdateBatchUniqueCheckSkips:    19,
 	}
 	got := deltaCollectionManagerUpdateStats(after, before)
 	if got.UpdateCombineRequests != 7 {
@@ -812,6 +824,18 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	}
 	if got.UpdateCombineFallbackRequests != 1 {
 		t.Fatalf("UpdateCombineFallbackRequests=%d want 1", got.UpdateCombineFallbackRequests)
+	}
+	if got.UpdateBatchIndexValueChanges != 7 {
+		t.Fatalf("UpdateBatchIndexValueChanges=%d want 7", got.UpdateBatchIndexValueChanges)
+	}
+	if got.UpdateBatchIndexValueUnchanged != 13 {
+		t.Fatalf("UpdateBatchIndexValueUnchanged=%d want 13", got.UpdateBatchIndexValueUnchanged)
+	}
+	if got.UpdateBatchUniqueChecks != 2 {
+		t.Fatalf("UpdateBatchUniqueChecks=%d want 2", got.UpdateBatchUniqueChecks)
+	}
+	if got.UpdateBatchUniqueCheckSkips != 9 {
+		t.Fatalf("UpdateBatchUniqueCheckSkips=%d want 9", got.UpdateBatchUniqueCheckSkips)
 	}
 }
 
@@ -860,6 +884,18 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	}
 	if stats.UpdateBatchSecondaryKeyBytes > 0 {
 		b.ReportMetric(float64(stats.UpdateBatchSecondaryKeyBytes)/float64(docs), "update_secondary_key_bytes/doc")
+	}
+	if stats.UpdateBatchIndexValueChanges > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchIndexValueChanges)/float64(docs), "update_index_value_changes/doc")
+	}
+	if stats.UpdateBatchIndexValueUnchanged > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchIndexValueUnchanged)/float64(docs), "update_index_value_unchanged/doc")
+	}
+	if stats.UpdateBatchUniqueChecks > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchUniqueChecks)/float64(docs), "update_unique_checks/doc")
+	}
+	if stats.UpdateBatchUniqueCheckSkips > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchUniqueCheckSkips)/float64(docs), "update_unique_check_skips/doc")
 	}
 	reportDuration := func(name string, d time.Duration) {
 		if d > 0 {


### PR DESCRIPTION
## Summary

Part of #1159.

This PR turns the per-index changed-delta invariant into explicit update-planner instrumentation:

- adds lightweight aggregate counters for changed/unchanged indexed-value decisions and unique-check/check-skip decisions
- adds detailed per-index `CollectionUpdateIndexStats` when detailed update stats are enabled, including changed/unchanged counts plus secondary run/delete/set/key-byte counters
- reuses a per-update changed-index bit mask for the common <=64-index case so secondary deltas, batch unique checks, replacement-owner tracking, and unchanged unique-value staging share the same per-index decision
- exports aggregate counters through collection manager stats and the direct collection profile benchmark
- documents the new benchmark metrics

The behavior this guards already exists on main: updating `city` with `email_1` + `city_1` only touches `city_1`, and updating non-indexed fields emits no secondary deltas. This PR makes that measurable and harder to regress.

## Validation

```bash
go test ./TreeDB/collections -run 'TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes|TestCollectionUpdateBatchStatsExposeIndexRunShape|TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation' -count=1

go test ./cmd/mongo_gateway_bench -run 'TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats' -count=1

go test ./TreeDB/collections ./cmd/mongo_gateway_bench -count=1

git diff --check
```

## Benchmark smoke

Command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=1
```

Representative row on this branch:

```text
BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2-8  100000  4725 ns/op  211621 docs/sec  4725 ns/doc  1147 B/op  2 allocs/op
update_index_value_unchanged/doc=2.000
update_unique_check_skips/doc=1.000
update_secondary_runs_ns/doc=3.940
update_roots/batch=1.000
publish_delta_group_roots/call=1.000
```

Interpretation: this focused non-indexed-field update shape now reports the intended work-reduction invariant directly: both indexed values are unchanged per updated document, the unique email check is skipped, no secondary delete/set counters are emitted, and the benchmark still reports `2 allocs/op` in the detailed-stats mode.
