### PR TITLE
Copy unchanged leaf-log internal refs in zipper

### DIFF
--- a/TreeDB/node/builder.go
+++ b/TreeDB/node/builder.go
@@ -887,6 +887,50 @@ func (b *Builder) addInternalLeafLogChild(key []byte, ref page.LogRecordRef) err
 	return nil
 }
 
+// AddInternalLeafLogChildFromNode appends an already-encoded leaf-log child
+// entry from src. Zipper path-copy rebuilds use this when an internal child is
+// unchanged, avoiding LogRecordRef decode/re-encode work while preserving the
+// encoded on-page representation exactly.
+func (b *Builder) AddInternalLeafLogChildFromNode(src *Node, index uint16) error {
+	if b.pType != page.PageTypeInternal || src == nil || !src.internalLeafLogRefs() {
+		return ErrInvalidType
+	}
+	if b.internalBaseDelta {
+		return ErrInvalidType
+	}
+	if b.count > 0 && !b.internalLeafLogRefs {
+		return ErrInvalidType
+	}
+
+	offset, err := src.getOffset(index)
+	if err != nil {
+		return err
+	}
+	ptr := int(offset)
+	if ptr+internalLeafLogRefHeaderSize > len(src.data) {
+		return ErrCorruptedNode
+	}
+	keyLen := int(binary.LittleEndian.Uint16(src.data[ptr : ptr+2]))
+	entrySize := internalLeafLogRefHeaderSize + keyLen
+	if ptr+entrySize > len(src.data) {
+		return ErrCorruptedNode
+	}
+	required := entrySize + DirectoryEntrySize
+	if b.heapStart-b.dirEnd < required {
+		return ErrNodeFull
+	}
+
+	entryStart := b.heapStart - entrySize
+	copy(b.data[entryStart:entryStart+entrySize], src.data[ptr:ptr+entrySize])
+	b.data[b.dirEnd] = byte(entryStart)
+	b.data[b.dirEnd+1] = byte(entryStart >> 8)
+	b.internalLeafLogRefs = true
+	b.heapStart = entryStart
+	b.dirEnd += DirectoryEntrySize
+	b.count++
+	return nil
+}
+
 func (b *Builder) finalize() {
 	internalBaseDeltaApplied := false
 	if b.pType == page.PageTypeInternal && b.internalBaseDelta {

--- a/TreeDB/node/internal_leaf_log_ref_copy_test.go
+++ b/TreeDB/node/internal_leaf_log_ref_copy_test.go
@@ -70,7 +70,7 @@ func TestBuilderAddInternalLeafLogChildFromNodeRejectsWrongSource(t *testing.T) 
 func BenchmarkBuilderAddInternalLeafLogChildRef(b *testing.B) {
 	refs, _, src := benchmarkLeafLogInternalEntries(b)
 	b.Run("decode_reencode", func(b *testing.B) {
-		for b.Loop() {
+		for n := 0; n < b.N; n++ {
 			dstBuilder := NewBuilder(make([]byte, page.PageSize), page.PageTypeInternal)
 			for i := range refs {
 				key, ref, err := src.GetInternalEntryRefView(uint16(i))
@@ -85,7 +85,7 @@ func BenchmarkBuilderAddInternalLeafLogChildRef(b *testing.B) {
 		}
 	})
 	b.Run("copy_encoded", func(b *testing.B) {
-		for b.Loop() {
+		for n := 0; n < b.N; n++ {
 			dstBuilder := NewBuilder(make([]byte, page.PageSize), page.PageTypeInternal)
 			for i := range refs {
 				if err := dstBuilder.AddInternalLeafLogChildFromNode(src, uint16(i)); err != nil {

--- a/TreeDB/node/internal_leaf_log_ref_copy_test.go
+++ b/TreeDB/node/internal_leaf_log_ref_copy_test.go
@@ -1,0 +1,124 @@
+package node
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestBuilderAddInternalLeafLogChildFromNodeCopiesEncodedEntry(t *testing.T) {
+	srcBuilder := NewBuilder(make([]byte, page.PageSize), page.PageTypeInternal)
+	refs := []page.ChildRef{
+		page.LeafLogChildRef(page.LogRecordRef{FileID: 1, Offset: 128, RecordLengthHint: 4096}),
+		page.LeafLogChildRef(page.LogRecordRef{FileID: 1, Offset: 8192, RecordLengthHint: 2048, SubIndex: 2}),
+		page.LeafLogChildRef(page.LogRecordRef{FileID: 2, Offset: 16384, RecordLengthHint: 1024}),
+	}
+	keys := [][]byte{nil, []byte("city:hnl"), []byte("city:sea")}
+	for i := range refs {
+		if err := srcBuilder.AddInternalChildRef(keys[i], refs[i]); err != nil {
+			t.Fatalf("source add %d: %v", i, err)
+		}
+	}
+	src := srcBuilder.Finish()
+	if !src.InternalLeafLogRefsEnabled() {
+		t.Fatal("source did not finish as leaf-log-ref internal page")
+	}
+
+	dstBuilder := NewBuilder(make([]byte, page.PageSize), page.PageTypeInternal)
+	for i := range refs {
+		if err := dstBuilder.AddInternalLeafLogChildFromNode(src, uint16(i)); err != nil {
+			t.Fatalf("copy add %d: %v", i, err)
+		}
+	}
+	dst := dstBuilder.Finish()
+	if !dst.InternalLeafLogRefsEnabled() {
+		t.Fatal("destination did not finish as leaf-log-ref internal page")
+	}
+	if got, want := dst.Count(), src.Count(); got != want {
+		t.Fatalf("count=%d want %d", got, want)
+	}
+	for i := range refs {
+		key, ref, err := dst.GetInternalEntryRefView(uint16(i))
+		if err != nil {
+			t.Fatalf("dst entry %d: %v", i, err)
+		}
+		if !bytes.Equal(key, keys[i]) {
+			t.Fatalf("dst key %d=%q want %q", i, key, keys[i])
+		}
+		if ref != refs[i] {
+			t.Fatalf("dst ref %d=%+v want %+v", i, ref, refs[i])
+		}
+	}
+}
+
+func TestBuilderAddInternalLeafLogChildFromNodeRejectsWrongSource(t *testing.T) {
+	srcBuilder := NewBuilder(make([]byte, page.PageSize), page.PageTypeInternal)
+	if err := srcBuilder.AddInternalChild([]byte{}, 7); err != nil {
+		t.Fatalf("source add page child: %v", err)
+	}
+	src := srcBuilder.Finish()
+
+	dstBuilder := NewBuilder(make([]byte, page.PageSize), page.PageTypeInternal)
+	err := dstBuilder.AddInternalLeafLogChildFromNode(src, 0)
+	if err != ErrInvalidType {
+		t.Fatalf("error=%v want %v", err, ErrInvalidType)
+	}
+}
+
+func BenchmarkBuilderAddInternalLeafLogChildRef(b *testing.B) {
+	refs, _, src := benchmarkLeafLogInternalEntries(b)
+	b.Run("decode_reencode", func(b *testing.B) {
+		for b.Loop() {
+			dstBuilder := NewBuilder(make([]byte, page.PageSize), page.PageTypeInternal)
+			for i := range refs {
+				key, ref, err := src.GetInternalEntryRefView(uint16(i))
+				if err != nil {
+					b.Fatalf("source entry %d: %v", i, err)
+				}
+				if err := dstBuilder.AddInternalChildRef(key, ref); err != nil {
+					b.Fatalf("add %d: %v", i, err)
+				}
+			}
+			_ = dstBuilder.Finish()
+		}
+	})
+	b.Run("copy_encoded", func(b *testing.B) {
+		for b.Loop() {
+			dstBuilder := NewBuilder(make([]byte, page.PageSize), page.PageTypeInternal)
+			for i := range refs {
+				if err := dstBuilder.AddInternalLeafLogChildFromNode(src, uint16(i)); err != nil {
+					b.Fatalf("copy %d: %v", i, err)
+				}
+			}
+			_ = dstBuilder.Finish()
+		}
+	})
+}
+
+func benchmarkLeafLogInternalEntries(tb testing.TB) ([]page.ChildRef, [][]byte, *Node) {
+	tb.Helper()
+	refs := make([]page.ChildRef, 96)
+	keys := make([][]byte, len(refs))
+	srcBuilder := NewBuilder(make([]byte, page.PageSize), page.PageTypeInternal)
+	for i := range refs {
+		refs[i] = page.LeafLogChildRef(page.LogRecordRef{
+			FileID:           uint32(1 + i/32),
+			Offset:           uint64(4096 * i),
+			RecordLengthHint: 4096,
+			SubIndex:         uint16(i % 8),
+		})
+		if i > 0 {
+			keys[i] = []byte(fmt.Sprintf("key:%04d", i))
+		}
+		if err := srcBuilder.AddInternalChildRef(keys[i], refs[i]); err != nil {
+			tb.Fatalf("source add %d: %v", i, err)
+		}
+	}
+	src := srcBuilder.Finish()
+	if !src.InternalLeafLogRefsEnabled() {
+		tb.Fatal("source did not finish as leaf-log-ref internal page")
+	}
+	return refs, keys, src
+}

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1708,7 +1708,7 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 	}
 
 	target := builder
-	appendInternal := func(key []byte, childRef page.ChildRef, first bool) error {
+	appendInternalMaybeCopied := func(sourceIndex uint16, key []byte, childRef page.ChildRef, first bool, copySourceLeafLog bool) error {
 		pageCount := z.pager.PageCount()
 		if childRef.Kind == page.ChildRefPage && childRef.Page >= pageCount {
 			return fmt.Errorf("zipper: detected OOB child ID %d (page_count=%d)", childRef.Page, pageCount)
@@ -1724,6 +1724,11 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 		}
 		if z.internalSoftFull(target, entrySize) {
 			err = node.ErrNodeFull
+		} else if copySourceLeafLog && childRef.Kind == page.ChildRefLeafLog && oldNode.InternalLeafLogRefsEnabled() {
+			err = target.AddInternalLeafLogChildFromNode(oldNode, sourceIndex)
+			if err == nil {
+				recordZipperInternalChildRef(metrics, childRef)
+			}
 		} else {
 			err = target.AddInternalChildRef(key, childRef)
 			if err == nil {
@@ -1738,6 +1743,12 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 			return nil
 		}
 		return err
+	}
+	appendInternal := func(key []byte, childRef page.ChildRef, first bool) error {
+		return appendInternalMaybeCopied(0, key, childRef, first, false)
+	}
+	appendExistingInternal := func(sourceIndex uint16, key []byte, childRef page.ChildRef, first bool) error {
+		return appendInternalMaybeCopied(sourceIndex, key, childRef, first, true)
 	}
 
 	// Fast path: most benchmarked writes are non-maintenance and below the
@@ -1798,8 +1809,14 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 				}
 			}
 
-			if err := appendInternal(lowKey, newChildRef, firstEntry); err != nil {
-				return page.ChildRef{}, nil, err
+			if len(childOps) == 0 {
+				if err := appendExistingInternal(i, lowKey, newChildRef, firstEntry); err != nil {
+					return page.ChildRef{}, nil, err
+				}
+			} else {
+				if err := appendInternal(lowKey, newChildRef, firstEntry); err != nil {
+					return page.ChildRef{}, nil, err
+				}
 			}
 			firstEntry = false
 			for _, s := range childSplits {
@@ -1968,8 +1985,14 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 		firstEntry := true
 		for i := range children {
 			child := &children[i]
-			if err := appendInternal(child.key, child.newChild, firstEntry); err != nil {
-				return page.ChildRef{}, nil, err
+			if len(child.ops) == 0 {
+				if err := appendExistingInternal(uint16(i), child.key, child.newChild, firstEntry); err != nil {
+					return page.ChildRef{}, nil, err
+				}
+			} else {
+				if err := appendInternal(child.key, child.newChild, firstEntry); err != nil {
+					return page.ChildRef{}, nil, err
+				}
 			}
 			firstEntry = false
 			for _, s := range child.splits {


### PR DESCRIPTION
## Summary

Part of #1159's deeper zipper / leaf-log root-apply cost track.

This PR adds a narrow fast path for rebuilding internal pages whose children are value-log-backed outer leaves:

- adds `node.Builder.AddInternalLeafLogChildFromNode` to copy an already encoded leaf-log child entry from a source internal node
- uses that path in zipper internal merges when a child has no ops and therefore its child ref/key are unchanged
- preserves existing zipper internal child-ref metrics when the copy path is used
- adds node tests and a focused microbenchmark for the copied-entry primitive

This does not reduce root applies, leaf-log reads, or leaf-log pages written. It only makes one part of unavoidable internal child construction cheaper when unchanged leaf-log child entries are path-copied during root apply.

## Validation

```bash
go test ./TreeDB/node ./TreeDB/zipper -count=1

go test ./TreeDB/db -count=1

go test ./TreeDB/node -run '^$' -bench '^BenchmarkBuilderAddInternalLeafLogChildRef$' -benchmem -count=3

MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2$' \
  -benchtime=100000x \
  -benchmem \
  -count=2

git diff --check
```

## Focused primitive benchmark

```text
BenchmarkBuilderAddInternalLeafLogChildRef/decode_reencode-8  1771 ns/op  4928 B/op  3 allocs/op
BenchmarkBuilderAddInternalLeafLogChildRef/decode_reencode-8  1743 ns/op  4928 B/op  3 allocs/op
BenchmarkBuilderAddInternalLeafLogChildRef/decode_reencode-8  1760 ns/op  4928 B/op  3 allocs/op
BenchmarkBuilderAddInternalLeafLogChildRef/copy_encoded-8     1201 ns/op  4928 B/op  3 allocs/op
BenchmarkBuilderAddInternalLeafLogChildRef/copy_encoded-8     1200 ns/op  4928 B/op  3 allocs/op
BenchmarkBuilderAddInternalLeafLogChildRef/copy_encoded-8     1200 ns/op  4928 B/op  3 allocs/op
```

Interpretation: the primitive is roughly 30% faster for rebuilding a 96-entry internal node with unchanged leaf-log child refs. Allocation count is unchanged because the benchmark allocates a page buffer per rebuild in both variants.

## Macro smoke

The direct BSON two-index update macro row was noisy/neutral rather than a clear end-to-end win:

```text
100000  5023 ns/op  199098 docs/sec  1124 B/op  2 allocs/op
100000  4895 ns/op  204293 docs/sec  1132 B/op  2 allocs/op
```

Interpretation: this should be reviewed as a low-risk CPU cleanup for one zipper substep, not as a standalone throughput breakthrough. The larger #1159 wins still need to come from reducing leaf-log pages read/written/rebuilt, current-read cost, and/or root-apply frequency.
