### PR TITLE
Bind collection update current reads to root reader

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6942,7 +6942,7 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 	return meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
 }
 
-func readUpdateBatchCurrentDocument(primaryReader backenddb.SnapshotRootReader, primaryReaderOK bool, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
+func readUpdateBatchCurrentDocument(primaryReader *backenddb.SnapshotRootReader, primaryReaderOK bool, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
 	if buffered.enabled {
 		if itemIndex >= 0 && itemIndex < len(buffered.primaryEntries) {
 			entry := buffered.primaryEntries[itemIndex]
@@ -7242,7 +7242,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	var currentScratch []byte
 	for i, item := range items {
 		phaseStart := updateBatchStatsNow(detailedStats)
-		current, err := readUpdateBatchCurrentDocument(primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
+		current, err := readUpdateBatchCurrentDocument(&primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
 		stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6942,7 +6942,7 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 	return meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
 }
 
-func readUpdateBatchCurrentDocument(snap *backenddb.Snapshot, primaryRoot uint64, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
+func readUpdateBatchCurrentDocument(primaryReader backenddb.SnapshotRootReader, primaryReaderOK bool, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
 	if buffered.enabled {
 		if itemIndex >= 0 && itemIndex < len(buffered.primaryEntries) {
 			entry := buffered.primaryEntries[itemIndex]
@@ -6954,10 +6954,10 @@ func readUpdateBatchCurrentDocument(snap *backenddb.Snapshot, primaryRoot uint64
 			}
 		}
 	}
-	if primaryRoot == 0 {
+	if !primaryReaderOK {
 		return updateBatchCurrentDocument{}, nil
 	}
-	value, err := snap.GetAppendAtRoot(primaryRoot, documentID, dst)
+	value, err := primaryReader.GetAppend(documentID, dst)
 	if errors.Is(err, tree.ErrKeyNotFound) {
 		return updateBatchCurrentDocument{}, nil
 	}
@@ -7198,6 +7198,16 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, err
 	}
+	var primaryReader backenddb.SnapshotRootReader
+	primaryReaderOK := false
+	if primaryRoot != 0 {
+		primaryReader, err = snap.ReaderAtRoot(primaryRoot)
+		if err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		primaryReaderOK = true
+	}
 
 	scratch := getUpdateBatchPlanScratch(len(items), len(runtimes))
 	scratchOwnedByPlan := false
@@ -7232,7 +7242,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	var currentScratch []byte
 	for i, item := range items {
 		phaseStart := updateBatchStatsNow(detailedStats)
-		current, err := readUpdateBatchCurrentDocument(snap, primaryRoot, i, item.DocumentID, bufferedRead, currentScratch[:0])
+		current, err := readUpdateBatchCurrentDocument(primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
 		stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()

--- a/TreeDB/db/root_snapshot.go
+++ b/TreeDB/db/root_snapshot.go
@@ -8,6 +8,12 @@ import (
 	"github.com/snissn/gomap/TreeDB/tree"
 )
 
+// SnapshotRootReader is a root-bound read view owned by a Snapshot.
+// It is valid only while the parent Snapshot remains open.
+type SnapshotRootReader struct {
+	tree *tree.Tree
+}
+
 func (s *Snapshot) treeAtRoot(rootID uint64) (*tree.Tree, error) {
 	if s == nil || s.closed.Load() {
 		return nil, ErrClosed
@@ -29,6 +35,21 @@ func (s *Snapshot) treeAtRoot(rootID uint64) (*tree.Tree, error) {
 	cached := &s.rootTrees[len(s.rootTrees)-1]
 	cached.tree.Reset(s.idx.pager, &s.reader, rootID)
 	return &cached.tree, nil
+}
+
+func (s *Snapshot) ReaderAtRoot(rootID uint64) (SnapshotRootReader, error) {
+	tr, err := s.treeAtRoot(rootID)
+	if err != nil {
+		return SnapshotRootReader{}, err
+	}
+	return SnapshotRootReader{tree: tr}, nil
+}
+
+func (r SnapshotRootReader) GetAppend(key, dst []byte) ([]byte, error) {
+	if r.tree == nil {
+		return dst, tree.ErrKeyNotFound
+	}
+	return r.tree.GetAppend(key, dst)
 }
 
 func (s *Snapshot) GetEntryAtRoot(rootID uint64, key []byte) (node.LeafEntry, error) {

--- a/TreeDB/db/root_snapshot.go
+++ b/TreeDB/db/root_snapshot.go
@@ -11,7 +11,8 @@ import (
 // SnapshotRootReader is a root-bound read view owned by a Snapshot.
 // It is valid only while the parent Snapshot remains open.
 type SnapshotRootReader struct {
-	tree *tree.Tree
+	tree tree.Tree
+	ok   bool
 }
 
 func (s *Snapshot) treeAtRoot(rootID uint64) (*tree.Tree, error) {
@@ -42,11 +43,11 @@ func (s *Snapshot) ReaderAtRoot(rootID uint64) (SnapshotRootReader, error) {
 	if err != nil {
 		return SnapshotRootReader{}, err
 	}
-	return SnapshotRootReader{tree: tr}, nil
+	return SnapshotRootReader{tree: *tr, ok: true}, nil
 }
 
-func (r SnapshotRootReader) GetAppend(key, dst []byte) ([]byte, error) {
-	if r.tree == nil {
+func (r *SnapshotRootReader) GetAppend(key, dst []byte) ([]byte, error) {
+	if r == nil || !r.ok {
 		return dst, tree.ErrKeyNotFound
 	}
 	return r.tree.GetAppend(key, dst)

--- a/TreeDB/db/snapshot_probe_test.go
+++ b/TreeDB/db/snapshot_probe_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"reflect"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 func TestSnapshot_HasManyAndHasPrefixes(t *testing.T) {
@@ -183,6 +185,131 @@ func TestSnapshot_HasManyAtRootAndHasPrefixesAtRoot(t *testing.T) {
 	if want := []bool{false}; !reflect.DeepEqual(missingRootHasPrefixes, want) {
 		t.Fatalf("HasPrefixesAtRoot missing root mismatch: got=%v want=%v", missingRootHasPrefixes, want)
 	}
+}
+
+func TestSnapshotReaderAtRootGetAppend(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, rootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{{
+		Iter: mustFrozenSystemMemtable(t,
+			"doc/a", "va",
+			"doc/b", "vb",
+		).NewIterator(nil, nil),
+	}})
+	if err != nil {
+		t.Fatalf("publish root: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("root IDs len=%d want 1", len(rootIDs))
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+
+	reader, err := snap.ReaderAtRoot(rootIDs[0])
+	if err != nil {
+		t.Fatalf("ReaderAtRoot: %v", err)
+	}
+	again, err := snap.ReaderAtRoot(rootIDs[0])
+	if err != nil {
+		t.Fatalf("ReaderAtRoot again: %v", err)
+	}
+	if reader.tree != again.tree {
+		t.Fatal("ReaderAtRoot did not reuse the snapshot root-tree cache")
+	}
+
+	got, err := reader.GetAppend([]byte("doc/a"), []byte("prefix:"))
+	if err != nil {
+		t.Fatalf("reader GetAppend: %v", err)
+	}
+	if want := []byte("prefix:va"); !bytes.Equal(got, want) {
+		t.Fatalf("reader GetAppend got=%q want %q", got, want)
+	}
+
+	out, err := reader.GetAppend([]byte("doc/missing"), []byte("keep"))
+	if !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("reader missing err=%v want %v", err, tree.ErrKeyNotFound)
+	}
+	if !bytes.Equal(out, []byte("keep")) {
+		t.Fatalf("reader missing output=%q want original dst", out)
+	}
+}
+
+func BenchmarkSnapshotRootReaderGetAppend(b *testing.B) {
+	dir := b.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		b.Fatalf("open: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+
+	const keyCount = 1024
+	table := memtable.NewAppendOnlyWithCapacity(keyCount)
+	keys := make([][]byte, keyCount)
+	for i := 0; i < keyCount; i++ {
+		key := []byte(fmt.Sprintf("doc/%04d", i))
+		value := []byte(fmt.Sprintf("value/%04d", i))
+		keys[i] = key
+		table.Set(key, value)
+	}
+	table.Freeze()
+	_, rootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{{
+		Iter: table.NewIterator(nil, nil),
+	}})
+	if err != nil {
+		b.Fatalf("publish root: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		b.Fatalf("root IDs len=%d want 1", len(rootIDs))
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		b.Fatal("AcquireSnapshot returned nil")
+	}
+	b.Cleanup(func() { _ = snap.Close() })
+	if _, err := snap.GetAppendAtRoot(rootIDs[0], keys[0], nil); err != nil {
+		b.Fatalf("warm GetAppendAtRoot: %v", err)
+	}
+	reader, err := snap.ReaderAtRoot(rootIDs[0])
+	if err != nil {
+		b.Fatalf("ReaderAtRoot: %v", err)
+	}
+
+	b.Run("snapshot_get_append_at_root", func(b *testing.B) {
+		b.ReportAllocs()
+		dst := make([]byte, 0, 32)
+		for i := 0; i < b.N; i++ {
+			out, err := snap.GetAppendAtRoot(rootIDs[0], keys[i&(keyCount-1)], dst[:0])
+			if err != nil {
+				b.Fatalf("GetAppendAtRoot: %v", err)
+			}
+			if len(out) == 0 {
+				b.Fatal("GetAppendAtRoot returned empty value")
+			}
+		}
+	})
+	b.Run("bound_reader_get_append", func(b *testing.B) {
+		b.ReportAllocs()
+		dst := make([]byte, 0, 32)
+		for i := 0; i < b.N; i++ {
+			out, err := reader.GetAppend(keys[i&(keyCount-1)], dst[:0])
+			if err != nil {
+				b.Fatalf("reader GetAppend: %v", err)
+			}
+			if len(out) == 0 {
+				b.Fatal("reader GetAppend returned empty value")
+			}
+		}
+	})
 }
 
 func TestSnapshotTreeAtRootCachesRootTrees(t *testing.T) {

--- a/TreeDB/db/snapshot_probe_test.go
+++ b/TreeDB/db/snapshot_probe_test.go
@@ -195,17 +195,27 @@ func TestSnapshotReaderAtRootGetAppend(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	_, rootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{{
+	const rootCount = 16
+	inputs := make([]OrderedRootPublishInput, rootCount)
+	inputs[0] = OrderedRootPublishInput{
 		Iter: mustFrozenSystemMemtable(t,
 			"doc/a", "va",
 			"doc/b", "vb",
 		).NewIterator(nil, nil),
-	}})
+	}
+	for i := 1; i < rootCount; i++ {
+		inputs[i] = OrderedRootPublishInput{
+			Iter: mustFrozenSystemMemtable(t,
+				fmt.Sprintf("other/%02d", i), fmt.Sprintf("value/%02d", i),
+			).NewIterator(nil, nil),
+		}
+	}
+	_, rootIDs, err := db.PublishOrderedRootGroup(nil, inputs)
 	if err != nil {
 		t.Fatalf("publish root: %v", err)
 	}
-	if len(rootIDs) != 1 {
-		t.Fatalf("root IDs len=%d want 1", len(rootIDs))
+	if len(rootIDs) != rootCount {
+		t.Fatalf("root IDs len=%d want %d", len(rootIDs), rootCount)
 	}
 
 	snap := db.AcquireSnapshot()
@@ -218,12 +228,10 @@ func TestSnapshotReaderAtRootGetAppend(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReaderAtRoot: %v", err)
 	}
-	again, err := snap.ReaderAtRoot(rootIDs[0])
-	if err != nil {
-		t.Fatalf("ReaderAtRoot again: %v", err)
-	}
-	if reader.tree != again.tree {
-		t.Fatal("ReaderAtRoot did not reuse the snapshot root-tree cache")
+	for i := 1; i < len(rootIDs); i++ {
+		if _, err := snap.ReaderAtRoot(rootIDs[i]); err != nil {
+			t.Fatalf("ReaderAtRoot(%d): %v", i, err)
+		}
 	}
 
 	got, err := reader.GetAppend([]byte("doc/a"), []byte("prefix:"))


### PR DESCRIPTION
## Summary

Part of #1159. This is a small current-read hygiene PR: bind a snapshot root reader once per collection update-batch plan and reuse it for per-document current reads instead of calling `Snapshot.GetAppendAtRoot` for each item. The point is to avoid repeated root-tree lookup/mutex work inside the update current-read loop while preserving the same snapshot/root semantics.

Changes:
- Add `SnapshotRootReader` / `Snapshot.ReaderAtRoot` for root-bound snapshot reads.
- Use the bound reader in collection update-batch current-document reads.
- Add a DB test covering root-reader GetAppend behavior and snapshot root-tree cache reuse.
- Add a microbenchmark comparing repeated `GetAppendAtRoot` with a bound root reader.

## Validation

```text
go test ./TreeDB/db -run 'TestSnapshotReaderAtRootGetAppend|TestSnapshotTreeAtRootCachesRootTrees' -count=1\nok github.com/snissn/gomap/TreeDB/db 0.582s\n\ngo test ./TreeDB/collections -run 'TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes|TestCollectionUpdateBatchStatsExposeIndexRunShape|TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation' -count=1\nok github.com/snissn/gomap/TreeDB/collections 0.482s\n\ngo test ./TreeDB/db ./TreeDB/collections -count=1\nok github.com/snissn/gomap/TreeDB/db 73.017s\nok github.com/snissn/gomap/TreeDB/collections 9.373s\n\ngo test ./cmd/mongo_gateway_bench -run 'TestProfileBenchBufferedIndexedAsyncFlushEnv|TestProfileBenchDeltaUintStat|TestBenchmarkSetUpdateCanExerciseIndexedField' -count=1\nok github.com/snissn/gomap/cmd/mongo_gateway_bench 0.505s\n\ngit diff --check\n```\n\n## Benchmark notes\n\nCurrent-main focused baseline before this change:\n\n```text\nMONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \\\nMONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \\\nMONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \\\nMONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \\\nMONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \\\ngo test ./cmd/mongo_gateway_bench -run ^\\\$ -bench ^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2\\\$ -benchtime=200000x -benchmem -count=1\n\n200000 6263 ns/op 159675 docs/sec 6263 ns/doc 1153 B/op 2 allocs/op\nupdate_current_read_ns/doc=2084\npublish_delta_group_root_apply_ns/doc=2096\n```\n\nAfter this change, representative rows were noisy overall but stayed allocation-neutral and moved the targeted current-read counter slightly:\n\n```text\n200000 6334 ns/op 157879 docs/sec 6334 ns/doc 1151 B/op 2 allocs/op update_current_read_ns/doc=1990\n200000 5745 ns/op 174062 docs/sec 5745 ns/doc 1137 B/op 2 allocs/op update_current_read_ns/doc=2067\n200000 5920 ns/op 168932 docs/sec 5920 ns/doc 1133 B/op 2 allocs/op update_current_read_ns/doc=2054\n```\n\nMicrobenchmark for the exact mechanism:\n\n```text\ngo test ./TreeDB/db -run ^\\\$ -bench ^BenchmarkSnapshotRootReaderGetAppend\\\$ -benchmem -count=5\n\nsnapshot_get_append_at_root: 242.1 / 237.9 / 231.2 / 231.0 / 231.0 ns/op, 0 B/op, 0 allocs/op\nbound_reader_get_append:     226.6 / 225.3 / 225.2 / 225.6 / 225.6 ns/op, 0 B/op, 0 allocs/op\n```\n\nInterpretation: this is a bounded low-risk current-read cleanup, not a headline throughput breakthrough. The next #1159 targets remain larger: current-read leaf-log/cache behavior and root-apply leaf-log read/write/build cost.\n\nFixes part of #1159.\n