### PR TITLE
Add three-index city update benchmarks

### DIFF
--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9759,6 +9759,7 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 		Indexes: []IndexDefinition{
 			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
 			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "active", Field: "active", ValueType: IndexValueBool},
 		},
 	}); err != nil {
 		t.Fatalf("create collection: %v", err)
@@ -9770,7 +9771,7 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	mgr.SetUpdateBatchDetailedStatsEnabled(true)
 	if _, err := col.InsertBatch(
 		[][]byte{[]byte("u1")},
-		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl","seen":false}`)},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl","active":true,"seen":false}`)},
 	); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
@@ -9798,6 +9799,7 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 			collectionIndexStateRootName("users"),
 			collectionSecondaryRootName("users", "email"),
 			collectionSecondaryRootName("users", "city"),
+			collectionSecondaryRootName("users", "active"),
 		}
 		out := make(map[string]uint64, len(names))
 		for _, name := range names {
@@ -9814,7 +9816,7 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	results, err := col.UpdateBatch([]UpdateBatchItem{{
 		DocumentID: []byte("u1"),
 		Update: func([]byte) ([]byte, bool, error) {
-			return []byte(`{"email":"ada@example.com","city":"sea","seen":false}`), true, nil
+			return []byte(`{"email":"ada@example.com","city":"sea","active":true,"seen":false}`), true, nil
 		},
 	}})
 	if err != nil {
@@ -9839,7 +9841,7 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	if got, want := stats.IndexValueChanges, 1; got != want {
 		t.Fatalf("index value changes=%d want %d", got, want)
 	}
-	if got, want := stats.IndexValueUnchanged, 1; got != want {
+	if got, want := stats.IndexValueUnchanged, 2; got != want {
 		t.Fatalf("index value unchanged=%d want %d", got, want)
 	}
 	if got, want := stats.UniqueIndexChecks, 0; got != want {
@@ -9849,7 +9851,7 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 		t.Fatalf("unique index check skips=%d want %d", got, want)
 	}
 	indexStats := stats.IndexStats[:stats.IndexStatsCount]
-	if got, want := len(indexStats), 2; got != want {
+	if got, want := len(indexStats), 3; got != want {
 		t.Fatalf("index decision stats=%d want %d: %+v", got, want, stats.IndexStats)
 	}
 	indexStatByName := func(stats []CollectionUpdateIndexStats, name string) CollectionUpdateIndexStats {
@@ -9867,6 +9869,9 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	}
 	if idx := indexStatByName(indexStats, "city"); idx.Unique || idx.Changed != 1 || idx.Unchanged != 0 || idx.SecondaryRuns != 1 || idx.SecondaryDeletes != 1 || idx.SecondarySets != 1 || idx.SecondaryKeyBytes == 0 {
 		t.Fatalf("city index decision stats=%+v want changed secondary run", idx)
+	}
+	if idx := indexStatByName(indexStats, "active"); idx.Unique || idx.Changed != 0 || idx.Unchanged != 1 || idx.SecondaryRuns != 0 || idx.SecondaryDeletes != 0 || idx.SecondarySets != 0 || idx.SecondaryKeyBytes != 0 {
+		t.Fatalf("active index decision stats=%+v want unchanged/no secondary work", idx)
 	}
 	stats.SecondaryRuns[0].IndexName = "mutated"
 	if got := col.LastUpdateStats().SecondaryRuns[0].IndexName; got != "city" {
@@ -9891,6 +9896,9 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	if rootName := collectionSecondaryRootName("users", "email"); afterCity[rootName] != before[rootName] {
 		t.Fatalf("root %q changed from %d to %d for city-only update", rootName, before[rootName], afterCity[rootName])
 	}
+	if rootName := collectionSecondaryRootName("users", "active"); afterCity[rootName] != before[rootName] {
+		t.Fatalf("root %q changed from %d to %d for city-only update", rootName, before[rootName], afterCity[rootName])
+	}
 	ids, err := col.FindByIndexValue("city", "sea")
 	if err != nil {
 		t.Fatalf("find city sea: %v", err)
@@ -9910,7 +9918,7 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	if _, err := col.UpdateBatch([]UpdateBatchItem{{
 		DocumentID: []byte("u1"),
 		Update: func([]byte) ([]byte, bool, error) {
-			return []byte(`{"email":"ada@example.com","city":"sea","seen":true}`), true, nil
+			return []byte(`{"email":"ada@example.com","city":"sea","active":true,"seen":true}`), true, nil
 		},
 	}}); err != nil {
 		t.Fatalf("update same indexed values: %v", err)
@@ -9923,7 +9931,7 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 	if got, want := stats.IndexValueChanges, 0; got != want {
 		t.Fatalf("same-index update changes=%d want %d", got, want)
 	}
-	if got, want := stats.IndexValueUnchanged, 2; got != want {
+	if got, want := stats.IndexValueUnchanged, 3; got != want {
 		t.Fatalf("same-index update unchanged=%d want %d", got, want)
 	}
 	if got, want := stats.UniqueIndexChecks, 0; got != want {
@@ -9933,7 +9941,7 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 		t.Fatalf("same-index update unique check skips=%d want %d", got, want)
 	}
 	indexStats = stats.IndexStats[:stats.IndexStatsCount]
-	if got, want := len(indexStats), 2; got != want {
+	if got, want := len(indexStats), 3; got != want {
 		t.Fatalf("same-index update index decision stats=%d want %d: %+v", got, want, stats.IndexStats)
 	}
 	for _, idx := range indexStats {
@@ -9946,6 +9954,7 @@ func TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes(t *testing.T) {
 		collectionIndexStateRootName("users"),
 		collectionSecondaryRootName("users", "email"),
 		collectionSecondaryRootName("users", "city"),
+		collectionSecondaryRootName("users", "active"),
 	} {
 		if afterSame[rootName] != beforeSame[rootName] {
 			t.Fatalf("root %q changed from %d to %d for same-index update", rootName, beforeSame[rootName], afterSame[rootName])

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -341,9 +341,11 @@ The initial workload phases are:
 - `id_delete_one`: optional deletes; disabled unless `-deletes` is non-zero.
 
 Update phases change only non-indexed fields by default.
-`-update-indexed-field` requires `-secondary-indexes=2` so the city index exists
-and the indexed `city` field changes, exercising secondary-index maintenance in
-the update path.
+`-update-indexed-field` requires `-secondary-indexes=2` or greater so the city
+index exists and the indexed `city` field changes, exercising secondary-index
+maintenance in the update path. `-secondary-indexes=3` adds an unchanged
+`active_1` bool index so city-only update runs can verify that unchanged
+secondary indexes are not rebuilt as total index count grows.
 `-range-index` creates an additional `age_1` index so the age range-read phase
 materially exercises indexed range planning instead of the bounded scan
 fallback.
@@ -474,7 +476,7 @@ OUT=$(mktemp -d /tmp/gomap_mongo_gateway_profile_XXXXXX)
 MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=10000 \
 GOWORK=off go test ./cmd/mongo_gateway_bench \
   -run '^$' \
-  -bench '^(BenchmarkTreeDBGatewayLoadBSONIndexes2|BenchmarkTreeDBGatewayLoadGeneratedIDBSONIndexes2|BenchmarkTreeDBGatewayLoadObjectIDBSONIndexes2|BenchmarkTreeDBGatewayLoadUnackBSONIndexes2|BenchmarkTreeDBGatewayRunCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRunRawCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireTCPLoadBSONIndexes2|BenchmarkDirectCollectionLoadBSONIndexes2|BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2|BenchmarkClientBSONBatchEncode)$' \
+  -bench '^(BenchmarkTreeDBGatewayLoadBSONIndexes2|BenchmarkTreeDBGatewayLoadGeneratedIDBSONIndexes2|BenchmarkTreeDBGatewayLoadObjectIDBSONIndexes2|BenchmarkTreeDBGatewayLoadUnackBSONIndexes2|BenchmarkTreeDBGatewayRunCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRunRawCommandLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireLoadBSONIndexes2|BenchmarkTreeDBGatewayRawWireTCPLoadBSONIndexes2|BenchmarkDirectCollectionLoadBSONIndexes2|BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2|BenchmarkDirectCollectionConcurrentUpdateBSONCityIndex1|BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2CityUpdate|BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate|BenchmarkClientBSONBatchEncode)$' \
   -benchtime 2000000x \
   -count 1 \
   -timeout 0 \
@@ -545,6 +547,13 @@ The benchmark shapes are intentionally different:
   `backend_vlog_mmap_sealed_segments`, and `backend_vlog_mmap_active_bytes`, so
   value-log mmap fallbacks can be separated from other `ReadAt` sources in CPU
   profiles and tied back to mmap residency limits.
+- `BenchmarkDirectCollectionConcurrentUpdateBSONCityIndex1`,
+  `BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2CityUpdate`, and
+  `BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate` run the same
+  direct update shape while changing only the indexed `city` field. They are
+  intended to guard per-index changed-delta planning: adding unchanged indexes
+  such as `email_1` and `active_1` should not create extra secondary runs or
+  affected secondary roots for a city-only update.
 - `BenchmarkClientBSONBatchEncode` measures client-side BSON document encoding
   alone.
 
@@ -567,10 +576,11 @@ driver transport while bypassing `InsertMany`'s explicit-`_id` discovery and
 
 ## Interpreting Results
 
-`-secondary-indexes 2` creates `email_1` and `city_1`. The age range phase is a
-bounded scan unless `-range-index` is set; benchmark output names the phase
-`age_range_scan_limit_10` or `age_range_indexed_limit_10` so reports can
-separate fallback cost from indexed range-search cost.
+`-secondary-indexes 2` creates `email_1` and `city_1`; `-secondary-indexes 3`
+adds `active_1`. The age range phase is a bounded scan unless `-range-index` is
+set; benchmark output names the phase `age_range_scan_limit_10` or
+`age_range_indexed_limit_10` so reports can separate fallback cost from indexed
+range-search cost.
 
 For TreeDB, prefer `treedb_disk_after_maintenance.total_bytes` when present, and
 use `treedb_disk_after_checkpoint.total_bytes` for checkpoint-only runs. The

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -463,9 +463,9 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.ConcurrentReads, "concurrent-reads", 0, "total _id read operations for the concurrent read phase")
 	fs.IntVar(&cfg.ConcurrentWriters, "concurrent-writers", 0, "writer goroutines for the concurrent _id update phase; 0 disables the phase")
 	fs.IntVar(&cfg.ConcurrentWrites, "concurrent-writes", 0, "total update operations for the concurrent write phase")
-	fs.BoolVar(&cfg.UpdateIndexedField, "update-indexed-field", false, "include the city field in update phases; requires -secondary-indexes=2 so the city index exists")
+	fs.BoolVar(&cfg.UpdateIndexedField, "update-indexed-field", false, "include the city field in update phases; requires -secondary-indexes >= 2 so the city index exists")
 	fs.BoolVar(&cfg.RangeIndex, "range-index", false, "create an age_1 secondary index for the age range-read phase")
-	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=both single-field indexes: email and city")
+	fs.IntVar(&cfg.SecondaryIndexes, "secondary-indexes", 2, "secondary indexes to create: 0, 1=email, 2=email+city, 3=email+city+active")
 	fs.StringVar(&cfg.ClientMode, "client-mode", cfg.ClientMode, "benchmark client path: driver, driver-command, driver-command-raw, driver-unack, raw-wire, or raw-wire-tcp; raw-wire modes are TreeDB-only and bypass the MongoDB Go driver for the insert load phase")
 	fs.StringVar(&treeDBProfile, "treedb-profile", treeDBProfile, "TreeDB profile for -target treedb: fast, wal_on_fast, durable, or bench")
 	fs.StringVar(&treeDBDocumentFormat, "treedb-document-format", treeDBDocumentFormat, "TreeDB collection document format for -target treedb: json, template-v1, or bson")
@@ -561,11 +561,11 @@ func parseConfig(args []string) (config, error) {
 	if cfg.ProfileHeapGC && strings.TrimSpace(cfg.ProfileDir) == "" {
 		return config{}, errors.New("profile-heap-gc requires -profile-dir")
 	}
-	if cfg.SecondaryIndexes < 0 || cfg.SecondaryIndexes > 2 {
-		return config{}, errors.New("secondary-indexes must be 0, 1, or 2")
+	if cfg.SecondaryIndexes < 0 || cfg.SecondaryIndexes > 3 {
+		return config{}, errors.New("secondary-indexes must be 0, 1, 2, or 3")
 	}
 	if cfg.UpdateIndexedField && cfg.SecondaryIndexes < 2 {
-		return config{}, errors.New("update-indexed-field requires secondary-indexes=2 so the city index exists")
+		return config{}, errors.New("update-indexed-field requires secondary-indexes >= 2 so the city index exists")
 	}
 	if cfg.TreeDBBufferedIndexedWriteMaxDocuments < 0 {
 		return config{}, errors.New("treedb-buffered-indexed-write-max-documents must be >= 0")
@@ -1402,6 +1402,13 @@ func createIndexes(ctx context.Context, db *mongo.Database, coll *mongo.Collecti
 				{Key: "treedbValueType", Value: string(collections.IndexValueString)},
 			})
 		}
+		if secondaryIndexes >= 3 {
+			indexDocs = append(indexDocs, bson.D{
+				{Key: "key", Value: bson.D{{Key: "active", Value: int32(1)}}},
+				{Key: "name", Value: "active_1"},
+				{Key: "treedbValueType", Value: string(collections.IndexValueBool)},
+			})
+		}
 		if rangeIndex {
 			indexDocs = append(indexDocs, bson.D{
 				{Key: "key", Value: bson.D{{Key: "age", Value: int32(1)}}},
@@ -1429,6 +1436,14 @@ func createIndexes(ctx context.Context, db *mongo.Database, coll *mongo.Collecti
 		if _, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
 			Keys:    bson.D{{Key: "city", Value: int32(1)}},
 			Options: options.Index().SetName("city_1"),
+		}); err != nil {
+			return err
+		}
+	}
+	if secondaryIndexes >= 3 {
+		if _, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
+			Keys:    bson.D{{Key: "active", Value: int32(1)}},
+			Options: options.Index().SetName("active_1"),
 		}); err != nil {
 			return err
 		}

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -1386,36 +1386,7 @@ func rangePhaseName(cfg config) string {
 
 func createIndexes(ctx context.Context, db *mongo.Database, coll *mongo.Collection, secondaryIndexes int, rangeIndex bool, treedbTarget bool) error {
 	if treedbTarget {
-		indexDocs := make(bson.A, 0, secondaryIndexes+1)
-		if secondaryIndexes >= 1 {
-			indexDocs = append(indexDocs, bson.D{
-				{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
-				{Key: "name", Value: "email_1"},
-				{Key: "unique", Value: true},
-				{Key: "treedbValueType", Value: string(collections.IndexValueString)},
-			})
-		}
-		if secondaryIndexes >= 2 {
-			indexDocs = append(indexDocs, bson.D{
-				{Key: "key", Value: bson.D{{Key: "city", Value: int32(1)}}},
-				{Key: "name", Value: "city_1"},
-				{Key: "treedbValueType", Value: string(collections.IndexValueString)},
-			})
-		}
-		if secondaryIndexes >= 3 {
-			indexDocs = append(indexDocs, bson.D{
-				{Key: "key", Value: bson.D{{Key: "active", Value: int32(1)}}},
-				{Key: "name", Value: "active_1"},
-				{Key: "treedbValueType", Value: string(collections.IndexValueBool)},
-			})
-		}
-		if rangeIndex {
-			indexDocs = append(indexDocs, bson.D{
-				{Key: "key", Value: bson.D{{Key: "age", Value: int32(1)}}},
-				{Key: "name", Value: "age_1"},
-				{Key: "treedbValueType", Value: string(collections.IndexValueInt64)},
-			})
-		}
+		indexDocs := treedbCreateIndexDocs(secondaryIndexes, rangeIndex)
 		if len(indexDocs) == 0 {
 			return nil
 		}
@@ -1457,6 +1428,40 @@ func createIndexes(ctx context.Context, db *mongo.Database, coll *mongo.Collecti
 		}
 	}
 	return nil
+}
+
+func treedbCreateIndexDocs(secondaryIndexes int, rangeIndex bool) bson.A {
+	indexDocs := make(bson.A, 0, secondaryIndexes+1)
+	if secondaryIndexes >= 1 {
+		indexDocs = append(indexDocs, bson.D{
+			{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}},
+			{Key: "name", Value: "email_1"},
+			{Key: "unique", Value: true},
+			{Key: "treedbValueType", Value: string(collections.IndexValueString)},
+		})
+	}
+	if secondaryIndexes >= 2 {
+		indexDocs = append(indexDocs, bson.D{
+			{Key: "key", Value: bson.D{{Key: "city", Value: int32(1)}}},
+			{Key: "name", Value: "city_1"},
+			{Key: "treedbValueType", Value: string(collections.IndexValueString)},
+		})
+	}
+	if secondaryIndexes >= 3 {
+		indexDocs = append(indexDocs, bson.D{
+			{Key: "key", Value: bson.D{{Key: "active", Value: int32(1)}}},
+			{Key: "name", Value: "active_1"},
+			{Key: "treedbValueType", Value: string(collections.IndexValueBool)},
+		})
+	}
+	if rangeIndex {
+		indexDocs = append(indexDocs, bson.D{
+			{Key: "key", Value: bson.D{{Key: "age", Value: int32(1)}}},
+			{Key: "name", Value: "age_1"},
+			{Key: "treedbValueType", Value: string(collections.IndexValueInt64)},
+		})
+	}
+	return indexDocs
 }
 
 func recordEffectiveTreeDBCollectionOptions(result *benchmarkResult, cfg config, target *benchTarget) error {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1353,6 +1353,57 @@ func TestWriteResultSupportsGenericWriter(t *testing.T) {
 	}
 }
 
+func TestTreeDBCreateIndexDocsIncludesActiveBoolIndex(t *testing.T) {
+	docs := treedbCreateIndexDocs(3, false)
+	if got, want := len(docs), 3; got != want {
+		t.Fatalf("index docs len=%d want %d: %#v", got, want, docs)
+	}
+	active, ok := findBSONDByStringField(docs, "name", "active_1")
+	if !ok {
+		t.Fatalf("active_1 index doc missing: %#v", docs)
+	}
+	if got, ok := bsonDStringField(active, "treedbValueType"); !ok || got != string(collections.IndexValueBool) {
+		t.Fatalf("active_1 treedbValueType=%q ok=%t want %q", got, ok, string(collections.IndexValueBool))
+	}
+	keyDoc, ok := bsonDField(active, "key").(bson.D)
+	if !ok {
+		t.Fatalf("active_1 key doc missing or wrong type: %#v", active)
+	}
+	if got, ok := bsonDField(keyDoc, "active").(int32); !ok || got != 1 {
+		t.Fatalf("active_1 key active=%v ok=%t want int32(1)", bsonDField(keyDoc, "active"), ok)
+	}
+	if _, ok := findBSONDByStringField(treedbCreateIndexDocs(2, false), "name", "active_1"); ok {
+		t.Fatal("active_1 index doc was emitted for secondaryIndexes=2")
+	}
+}
+
+func findBSONDByStringField(docs bson.A, key, want string) (bson.D, bool) {
+	for _, raw := range docs {
+		doc, ok := raw.(bson.D)
+		if !ok {
+			continue
+		}
+		if got, ok := bsonDStringField(doc, key); ok && got == want {
+			return doc, true
+		}
+	}
+	return nil, false
+}
+
+func bsonDStringField(doc bson.D, key string) (string, bool) {
+	got, ok := bsonDField(doc, key).(string)
+	return got, ok
+}
+
+func bsonDField(doc bson.D, key string) any {
+	for _, elem := range doc {
+		if elem.Key == key {
+			return elem.Value
+		}
+	}
+	return nil
+}
+
 func TestBenchmarkSetUpdateCanExerciseIndexedField(t *testing.T) {
 	updatedCityValues := buildBenchmarkUpdatedCityValues()
 

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -402,6 +402,13 @@ func TestParseConfigValidation(t *testing.T) {
 	if oneIndexCfg.SecondaryIndexes != 1 {
 		t.Fatalf("SecondaryIndexes=%d want 1", oneIndexCfg.SecondaryIndexes)
 	}
+	threeIndexCfg, err := parseConfig([]string{"-secondary-indexes", "3", "-update-indexed-field"})
+	if err != nil {
+		t.Fatalf("parse secondary-indexes=3 update-indexed-field config: %v", err)
+	}
+	if threeIndexCfg.SecondaryIndexes != 3 || !threeIndexCfg.UpdateIndexedField {
+		t.Fatalf("three-index config=%+v want SecondaryIndexes=3 UpdateIndexedField=true", threeIndexCfg)
+	}
 	if _, err := parseConfig([]string{"-client-mode", "bad"}); err == nil {
 		t.Fatal("bad client-mode accepted")
 	}
@@ -455,6 +462,9 @@ func TestParseConfigValidation(t *testing.T) {
 	}
 	if _, err := parseConfig([]string{"-secondary-indexes", "1", "-update-indexed-field"}); err == nil {
 		t.Fatal("update-indexed-field accepted without city index")
+	}
+	if _, err := parseConfig([]string{"-secondary-indexes", "4"}); err == nil {
+		t.Fatal("secondary-indexes=4 accepted")
 	}
 	if _, err := parseConfig([]string{"-treedb-buffered-indexed-write-max-documents", "-1"}); err == nil {
 		t.Fatal("negative treedb buffered indexed max documents accepted")

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -142,15 +142,42 @@ func TestProfileBenchParsedUpdateDocsUsesDistinctCityPhases(t *testing.T) {
 	}
 }
 
+func TestProfileBenchParsedUpdateDocsChangesCityAcrossFullSweep(t *testing.T) {
+	updateDocs := profileBenchParsedUpdateDocs(t, true, "timed")
+	if len(updateDocs) == 0 {
+		t.Fatal("expected parsed update docs")
+	}
+	documentCount := profileBenchUpdateDocPoolSize
+	idStride := profileBenchUpdateIDStride(documentCount)
+	operation := 7
+	documentOrdinal := (operation * idStride) % documentCount
+	nextOperation := operation + documentCount
+	nextDocumentOrdinal := (nextOperation * idStride) % documentCount
+	if nextDocumentOrdinal != documentOrdinal {
+		t.Fatalf("test setup document ordinals differ: %d vs %d", documentOrdinal, nextDocumentOrdinal)
+	}
+	firstCity := profileBenchSetUpdateFieldStringAt(t, updateDocs[operation%len(updateDocs)], "city", operation, documentOrdinal, documentCount)
+	nextCity := profileBenchSetUpdateFieldStringAt(t, updateDocs[nextOperation%len(updateDocs)], "city", nextOperation, nextDocumentOrdinal, documentCount)
+	if firstCity == nextCity {
+		t.Fatalf("city repeated across full sweep: %q", firstCity)
+	}
+}
+
 func profileBenchSetUpdateFieldString(t *testing.T, update profileBenchSetUpdate, key string) string {
+	t.Helper()
+	return profileBenchSetUpdateFieldStringAt(t, update, key, -1, 0, 0)
+}
+
+func profileBenchSetUpdateFieldStringAt(t *testing.T, update profileBenchSetUpdate, key string, operation, documentOrdinal, documentCount int) string {
 	t.Helper()
 	for _, field := range update.fields {
 		if field.key != key {
 			continue
 		}
-		got, ok := field.value.StringValueOK()
+		value := profileBenchSetFieldValueForOperation(field, operation, documentOrdinal, documentCount)
+		got, ok := value.StringValueOK()
 		if !ok {
-			t.Fatalf("field %q raw value=%v is not a string", key, field.value.Type)
+			t.Fatalf("field %q raw value=%v is not a string", key, value.Type)
 		}
 		return got
 	}
@@ -664,6 +691,10 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 func profileBenchParsedUpdateDocs(tb testing.TB, updateCity bool, cityPhase string) []profileBenchSetUpdate {
 	tb.Helper()
 	updateDocs := make([]profileBenchSetUpdate, profileBenchUpdateDocPoolSize)
+	var dynamicCityValues []bson.RawValue
+	if updateCity {
+		dynamicCityValues = profileBenchUpdatedCityRawValues(tb, cityPhase)
+	}
 	for i := range updateDocs {
 		set := bson.D{
 			{Key: "concurrent_updated", Value: true},
@@ -680,9 +711,29 @@ func profileBenchParsedUpdateDocs(tb testing.TB, updateCity bool, cityPhase stri
 		if err != nil {
 			tb.Fatalf("parse update document: %v", err)
 		}
+		if len(dynamicCityValues) > 0 {
+			for fieldIdx := range parsed.fields {
+				if parsed.fields[fieldIdx].key == "city" {
+					parsed.fields[fieldIdx].dynamicCityValues = dynamicCityValues
+					break
+				}
+			}
+		}
 		updateDocs[i] = parsed
 	}
 	return updateDocs
+}
+
+func profileBenchUpdatedCityRawValues(tb testing.TB, cityPhase string) []bson.RawValue {
+	tb.Helper()
+	values := make([]bson.RawValue, benchmarkUpdatedCityValueCount)
+	for i := range values {
+		values[i] = bson.RawValue{
+			Type:  bson.TypeString,
+			Value: bsoncore.AppendString(nil, cityPhase+"-"+benchmarkUpdatedCityValue(i)),
+		}
+	}
+	return values
 }
 
 func profileBenchDeltaUintStat(after, before map[string]string, key string) uint64 {
@@ -1070,12 +1121,13 @@ func runProfileBenchDirectCollectionConcurrentUpdates(
 				if op >= operations {
 					return
 				}
-				id := ids[(op*idStride)%documentCount]
+				documentOrdinal := (op * idStride) % documentCount
+				id := ids[documentOrdinal]
 				updateDoc := updateDocs[op%len(updateDocs)]
 				matched, _, err := collection.Update(id, func(stored []byte) ([]byte, bool, error) {
 					raw := bson.Raw(stored)
 					originalID := raw.Lookup("_id")
-					updated, nextScratch, shouldWrite, err := profileBenchApplyParsedSetUpdateTo(updateScratch[:0], raw, updateDoc)
+					updated, nextScratch, shouldWrite, err := profileBenchApplyParsedSetUpdateToOperation(updateScratch[:0], raw, updateDoc, op, documentOrdinal, documentCount)
 					updateScratch = nextScratch
 					if err != nil {
 						return nil, false, err
@@ -1104,9 +1156,10 @@ func runProfileBenchDirectCollectionConcurrentUpdates(
 }
 
 type profileBenchSetField struct {
-	key      string
-	keyBytes []byte
-	value    bson.RawValue
+	key               string
+	keyBytes          []byte
+	value             bson.RawValue
+	dynamicCityValues []bson.RawValue
 }
 
 type profileBenchSetUpdate struct {
@@ -1245,6 +1298,10 @@ func profileBenchApplyParsedSetUpdate(doc bson.Raw, update profileBenchSetUpdate
 }
 
 func profileBenchApplyParsedSetUpdateTo(dst []byte, doc bson.Raw, update profileBenchSetUpdate) (bson.Raw, []byte, bool, error) {
+	return profileBenchApplyParsedSetUpdateToOperation(dst, doc, update, -1, 0, 0)
+}
+
+func profileBenchApplyParsedSetUpdateToOperation(dst []byte, doc bson.Raw, update profileBenchSetUpdate, operation, documentOrdinal, documentCount int) (bson.Raw, []byte, bool, error) {
 	if len(update.fields) == 0 {
 		return doc, dst, false, nil
 	}
@@ -1283,9 +1340,10 @@ func profileBenchApplyParsedSetUpdateTo(dst []byte, doc bson.Raw, update profile
 		}
 		if replacement >= 0 {
 			field := update.fields[replacement]
+			value := profileBenchSetFieldValueForOperation(field, operation, documentOrdinal, documentCount)
 			out = bsoncore.AppendValueElement(out, field.key, bsoncore.Value{
-				Type: bsoncore.Type(field.value.Type),
-				Data: field.value.Value,
+				Type: bsoncore.Type(value.Type),
+				Data: value.Value,
 			})
 			used[replacement] = true
 			continue
@@ -1296,9 +1354,10 @@ func profileBenchApplyParsedSetUpdateTo(dst []byte, doc bson.Raw, update profile
 		if used[i] {
 			continue
 		}
+		value := profileBenchSetFieldValueForOperation(field, operation, documentOrdinal, documentCount)
 		out = bsoncore.AppendValueElement(out, field.key, bsoncore.Value{
-			Type: bsoncore.Type(field.value.Type),
-			Data: field.value.Value,
+			Type: bsoncore.Type(value.Type),
+			Data: value.Value,
 		})
 	}
 	raw, err := bsoncore.AppendDocumentEnd(out, idx)
@@ -1306,6 +1365,18 @@ func profileBenchApplyParsedSetUpdateTo(dst []byte, doc bson.Raw, update profile
 		return nil, out, false, err
 	}
 	return bson.Raw(raw), raw, true, nil
+}
+
+func profileBenchSetFieldValueForOperation(field profileBenchSetField, operation, documentOrdinal, documentCount int) bson.RawValue {
+	if len(field.dynamicCityValues) == 0 || operation < 0 {
+		return field.value
+	}
+	index := benchmarkUpdatedCityIndex(operation, documentOrdinal, documentCount, len(field.dynamicCityValues))
+	if documentCount > 0 && operation >= documentCount {
+		previousIndex := benchmarkUpdatedCityIndex(operation-documentCount, documentOrdinal, documentCount, len(field.dynamicCityValues))
+		index = avoidBenchmarkUpdatedCityRepeat(index, previousIndex, len(field.dynamicCityValues))
+	}
+	return field.dynamicCityValues[index]
 }
 
 func TestProfileBenchApplySetUpdateHappyPath(t *testing.T) {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -129,6 +129,35 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	}
 }
 
+func TestProfileBenchParsedUpdateDocsUsesDistinctCityPhases(t *testing.T) {
+	warmup := profileBenchParsedUpdateDocs(t, true, "warmup")
+	timed := profileBenchParsedUpdateDocs(t, true, "timed")
+	if len(warmup) == 0 || len(timed) == 0 {
+		t.Fatal("expected parsed update docs")
+	}
+	warmupCity := profileBenchSetUpdateFieldString(t, warmup[0], "city")
+	timedCity := profileBenchSetUpdateFieldString(t, timed[0], "city")
+	if warmupCity == timedCity {
+		t.Fatalf("city update phases both produced %q; timed city updates must differ from warmup", warmupCity)
+	}
+}
+
+func profileBenchSetUpdateFieldString(t *testing.T, update profileBenchSetUpdate, key string) string {
+	t.Helper()
+	for _, field := range update.fields {
+		if field.key != key {
+			continue
+		}
+		got, ok := field.value.StringValueOK()
+		if !ok {
+			t.Fatalf("field %q raw value=%v is not a string", key, field.value.Type)
+		}
+		return got
+	}
+	t.Fatalf("missing update field %q in %+v", key, update.fields)
+	return ""
+}
+
 func TestProfileBenchDeltaUintStat(t *testing.T) {
 	before := map[string]string{"x": "10"}
 	after := map[string]string{"x": "17", "bad": "not-a-number"}
@@ -452,6 +481,78 @@ func BenchmarkDirectCollectionLoadBSONIndexes2(b *testing.B) {
 }
 
 func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
+	benchmarkDirectCollectionConcurrentUpdateBSON(b, []collections.IndexDefinition{
+		{
+			Name:          "email_1",
+			Field:         "email",
+			ValueType:     collections.IndexValueString,
+			Unique:        true,
+			StoragePolicy: collections.RootStorageCompressed,
+		},
+		{
+			Name:          "city_1",
+			Field:         "city",
+			ValueType:     collections.IndexValueString,
+			StoragePolicy: collections.RootStorageCompressed,
+		},
+	}, false)
+}
+
+func BenchmarkDirectCollectionConcurrentUpdateBSONCityIndex1(b *testing.B) {
+	benchmarkDirectCollectionConcurrentUpdateBSON(b, []collections.IndexDefinition{
+		{
+			Name:          "city_1",
+			Field:         "city",
+			ValueType:     collections.IndexValueString,
+			StoragePolicy: collections.RootStorageCompressed,
+		},
+	}, true)
+}
+
+func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2CityUpdate(b *testing.B) {
+	benchmarkDirectCollectionConcurrentUpdateBSON(b, []collections.IndexDefinition{
+		{
+			Name:          "email_1",
+			Field:         "email",
+			ValueType:     collections.IndexValueString,
+			Unique:        true,
+			StoragePolicy: collections.RootStorageCompressed,
+		},
+		{
+			Name:          "city_1",
+			Field:         "city",
+			ValueType:     collections.IndexValueString,
+			StoragePolicy: collections.RootStorageCompressed,
+		},
+	}, true)
+}
+
+func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate(b *testing.B) {
+	benchmarkDirectCollectionConcurrentUpdateBSON(b, []collections.IndexDefinition{
+		{
+			Name:          "email_1",
+			Field:         "email",
+			ValueType:     collections.IndexValueString,
+			Unique:        true,
+			StoragePolicy: collections.RootStorageCompressed,
+		},
+		{
+			Name:          "city_1",
+			Field:         "city",
+			ValueType:     collections.IndexValueString,
+			StoragePolicy: collections.RootStorageCompressed,
+		},
+		{
+			Name:          "active_1",
+			Field:         "active",
+			ValueType:     collections.IndexValueBool,
+			StoragePolicy: collections.RootStorageCompressed,
+		},
+	}, true)
+}
+
+func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []collections.IndexDefinition, updateCity bool) {
+	b.Helper()
 	dir := filepath.Join(b.TempDir(), "treedb")
 	opts := treedb.OptionsFor(treedb.ProfileWALOnFast, dir)
 	opts.IndexOuterLeavesInValueLog = true
@@ -476,22 +577,10 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	if err != nil {
 		b.Fatalf("open collection: %v", err)
 	}
-	if _, err := collection.CreateIndex(collections.IndexDefinition{
-		Name:          "email_1",
-		Field:         "email",
-		ValueType:     collections.IndexValueString,
-		Unique:        true,
-		StoragePolicy: collections.RootStorageCompressed,
-	}); err != nil {
-		b.Fatalf("create email index: %v", err)
-	}
-	if _, err := collection.CreateIndex(collections.IndexDefinition{
-		Name:          "city_1",
-		Field:         "city",
-		ValueType:     collections.IndexValueString,
-		StoragePolicy: collections.RootStorageCompressed,
-	}); err != nil {
-		b.Fatalf("create city index: %v", err)
+	for _, idx := range indexes {
+		if _, err := collection.CreateIndex(idx); err != nil {
+			b.Fatalf("create index %s: %v", idx.Name, err)
+		}
 	}
 
 	documentCount := profileBenchUpdateDocumentCount(b)
@@ -523,21 +612,8 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	if err := backend.Checkpoint(); err != nil {
 		b.Fatalf("checkpoint preload: %v", err)
 	}
-	updateDocs := make([]profileBenchSetUpdate, profileBenchUpdateDocPoolSize)
-	for i := range updateDocs {
-		updateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: bson.D{
-			{Key: "concurrent_updated", Value: true},
-			{Key: "concurrent_update_seq", Value: int64(i)},
-		}}})
-		if err != nil {
-			b.Fatalf("marshal update document: %v", err)
-		}
-		parsed, err := parseProfileBenchSetUpdate(bson.Raw(updateRaw))
-		if err != nil {
-			b.Fatalf("parse update document: %v", err)
-		}
-		updateDocs[i] = parsed
-	}
+	warmupUpdateDocs := profileBenchParsedUpdateDocs(b, updateCity, "warmup")
+	updateDocs := profileBenchParsedUpdateDocs(b, updateCity, "timed")
 	ids := make([][]byte, documentCount)
 	for i := range ids {
 		ids[i] = []byte(benchmarkID(i))
@@ -549,7 +625,7 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	if warmupOps > 100000 {
 		warmupOps = 100000
 	}
-	if err := runProfileBenchDirectCollectionConcurrentUpdates(context.Background(), writers, warmupOps, documentCount, idStride, ids, updateDocs, collection); err != nil {
+	if err := runProfileBenchDirectCollectionConcurrentUpdates(context.Background(), writers, warmupOps, documentCount, idStride, ids, warmupUpdateDocs, collection); err != nil {
 		b.Fatalf("warm up concurrent updates: %v", err)
 	}
 	if err := manager.FlushAll(); err != nil {
@@ -583,6 +659,30 @@ func BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2(b *testing.B) {
 	reportProfileBenchOrderedRootPublishStats(b, backendStatsAfter, backendStatsBefore, b.N)
 	reportProfileBenchBackendVlogMmapStats(b, backendStatsAfter, backendStatsBefore, b.N)
 	reportDocsPerSecond(b, b.N, timedElapsed)
+}
+
+func profileBenchParsedUpdateDocs(tb testing.TB, updateCity bool, cityPhase string) []profileBenchSetUpdate {
+	tb.Helper()
+	updateDocs := make([]profileBenchSetUpdate, profileBenchUpdateDocPoolSize)
+	for i := range updateDocs {
+		set := bson.D{
+			{Key: "concurrent_updated", Value: true},
+			{Key: "concurrent_update_seq", Value: int64(i)},
+		}
+		if updateCity {
+			set = append(set, bson.E{Key: "city", Value: cityPhase + "-" + benchmarkUpdatedCity(i, i, profileBenchUpdateDocPoolSize)})
+		}
+		updateRaw, err := bson.Marshal(bson.D{{Key: "$set", Value: set}})
+		if err != nil {
+			tb.Fatalf("marshal update document: %v", err)
+		}
+		parsed, err := parseProfileBenchSetUpdate(bson.Raw(updateRaw))
+		if err != nil {
+			tb.Fatalf("parse update document: %v", err)
+		}
+		updateDocs[i] = parsed
+	}
+	return updateDocs
 }
 
 func profileBenchDeltaUintStat(after, before map[string]string, key string) uint64 {


### PR DESCRIPTION
## Summary

This PR closes a measurement/regression gap in #1159's per-index changed-delta track.

Changes:
- Extend `mongo_gateway_bench -secondary-indexes` from `0..2` to `0..3`.
  - `3` means `email_1 + city_1 + active_1`.
  - `active_1` is intentionally unchanged during city-update phases.
- Add direct collection profile benchmarks for indexed city updates:
  - `BenchmarkDirectCollectionConcurrentUpdateBSONCityIndex1`
  - `BenchmarkDirectCollectionConcurrentUpdateBSONIndexes2CityUpdate`
  - `BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate`
- Keep warmup and timed city update values distinct so the benchmark actually exercises changed city-index deltas instead of same-effective indexed updates.
- Make city-update values depend on the actual operation/document ordinal during direct benchmarks, so repeated full sweeps keep exercising changed indexed values even when the operation count is a multiple of the update-doc pool.
- Add smoke coverage for the TreeDB `active_1` create-index document and bool `treedbValueType`.
- Extend the collection update-batch regression test to cover a third unchanged index and prove the active root is not published for a city-only update.
- Document the new benchmark shapes and `-secondary-indexes=3` meaning.

This is not the root-apply breakthrough PR; it makes the per-index work-reduction invariant reproducible before deeper zipper/leaf-log changes.

## Validation

```text
go test ./TreeDB/collections -run 'TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes|TestCollectionUpdateSkipsIndexRootsWhenIndexedValuesUnchanged|TestCollectionInsertBatchStatsExposeIndexRunShape' -count=1
ok github.com/snissn/gomap/TreeDB/collections 0.385s

go test ./cmd/mongo_gateway_bench -run 'TestProfileBenchParsedUpdateDocsUsesDistinctCityPhases|TestParseConfigValidation|TestProfileBenchBufferedIndexedAsyncFlushEnv' -count=1
ok github.com/snissn/gomap/cmd/mongo_gateway_bench 0.421s

go test ./cmd/mongo_gateway_bench -run 'TestProfileBenchParsedUpdateDocsUsesDistinctCityPhases|TestProfileBenchParsedUpdateDocsChangesCityAcrossFullSweep|TestTreeDBCreateIndexDocsIncludesActiveBoolIndex|TestParseConfigValidation' -count=1
ok github.com/snissn/gomap/cmd/mongo_gateway_bench 0.839s

go test ./TreeDB/collections ./cmd/mongo_gateway_bench -count=1
ok github.com/snissn/gomap/TreeDB/collections 3.111s
ok github.com/snissn/gomap/cmd/mongo_gateway_bench 2.367s

git diff --check
```

## Benchmark

Command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench 'BenchmarkDirectCollectionConcurrentUpdateBSON(CityIndex1|Indexes2CityUpdate|Indexes3CityUpdate)$' \
  -benchtime=200000x \
  -benchmem \
  -count=1
```

Results on Apple M3, branch `codex/1159-three-index-delta-benches`, commit `09b6699e24`:

| Shape | ns/doc | docs/sec | B/op | allocs/op | roots/batch | changed indexes/doc | unchanged indexes/doc | secondary sets/doc | secondary deletes/doc | secondary run ns/doc | root apply ns/doc |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| city index only | 8,296 | 120,541 | 2,602 | 8 | 2.0 | 1.0 | 0.0 | 1.0 | 1.0 | 270.9 | 2,362 |
| email + city | 8,314 | 120,284 | 2,906 | 8 | 2.0 | 1.0 | 1.0 | 1.0 | 1.0 | 255.7 | 2,220 |
| email + city + active | 8,280 | 120,776 | 2,904 | 8 | 2.0 | 1.0 | 2.0 | 1.0 | 1.0 | 259.5 | 2,172 |

Interpretation:
- The 2-index and 3-index city-update rows both publish `2.0` roots/batch: primary + changed `city_1`.
- Adding unchanged indexes increases extraction/unique-check bookkeeping, but it does not add secondary delta roots or secondary set/delete work.
- This gives future #1159 PRs a direct way to catch regressions where unchanged indexes start scaling root work linearly.
