### PR TITLE
Avoid cloning generated secondary delete keys

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5311,20 +5311,26 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 			}
 		}
 		for _, runtime := range runtimes {
-			deleteKeys, err := secondaryDeleteKeysForDocument(runtime, state, documentID)
-			if err != nil {
-				_ = snap.Close()
-				return false, err
-			}
 			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
 			rootID := catalog.rootID(rootName)
-			if rootID == 0 || len(deleteKeys) == 0 {
+			if rootID == 0 {
 				continue
 			}
+			table := newCollectionRunTable(0)
+			if err := deleteSecondaryEntriesForDocument(table, runtime, state, documentID); err != nil {
+				_ = snap.Close()
+				resetCollectionRunTable(table)
+				return false, err
+			}
+			if table.Len() == 0 {
+				resetCollectionRunTable(table)
+				continue
+			}
+			table.Freeze()
 			rootNames = append(rootNames, rootName)
 			baseRootIDs[rootName] = rootID
 			policies = append(policies, runtime.def.storagePolicy)
-			deltaTables = append(deltaTables, buildDeleteRootDeltaTable(deleteKeys))
+			deltaTables = append(deltaTables, table)
 		}
 	}
 	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
@@ -6400,14 +6406,10 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
 			rootID := catalog.rootID(rootName)
 			table := newCollectionRunTable(0)
-			deleteKeys, err := secondaryDeleteKeysForDocument(runtime, oldState, documentID)
-			if err != nil {
+			if err := deleteSecondaryEntriesForDocument(table, runtime, oldState, documentID); err != nil {
 				_ = snap.Close()
 				resetCollectionTables(append(deltaTables, table))
 				return false, false, err
-			}
-			for _, key := range deleteKeys {
-				table.DeleteSteal(bytes.Clone(key))
 			}
 			for _, encoded := range newState[runtime.def.name] {
 				key, err := indexEntryKey(encoded, documentID)
@@ -7513,13 +7515,13 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 				if runStats.IndexName == "" {
 					runStats.IndexName = runtime.def.name
 				}
-				deleteKeys, err := secondaryDeleteKeysForOrderedDocument(runtimeIdx, runtime, item.oldState, item.documentID)
-				if err != nil {
-					_ = snap.Close()
-					return nil, err
-				}
-				for _, key := range deleteKeys {
-					table.DeleteSteal(bytes.Clone(key))
+				for _, encoded := range item.oldState.valuesAt(runtimeIdx) {
+					key, err := indexEntryKey(encoded, item.documentID)
+					if err != nil {
+						_ = snap.Close()
+						return nil, err
+					}
+					table.DeleteSteal(key)
 					stats.SecondaryDeleteEntries++
 					stats.SecondaryKeyBytes += len(key)
 					runStats.Deletes++
@@ -8749,36 +8751,22 @@ func loadDeleteIndexState(snap *backenddb.Snapshot, catalog *collectionCatalog, 
 	return indexStateForDocument(document, runtimes, opts)
 }
 
-func secondaryDeleteKeysForDocument(runtime indexRuntime, state documentIndexState, documentID []byte) ([][]byte, error) {
+func deleteSecondaryEntriesForDocument(table memtable.Table, runtime indexRuntime, state documentIndexState, documentID []byte) error {
+	if table == nil {
+		return nil
+	}
 	values := state[runtime.def.name]
 	if len(values) == 0 {
-		return nil, nil
+		return nil
 	}
-	out := make([][]byte, 0, len(values))
 	for _, encoded := range values {
 		key, err := indexEntryKey(encoded, documentID)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		out = append(out, key)
+		table.DeleteSteal(key)
 	}
-	return out, nil
-}
-
-func secondaryDeleteKeysForOrderedDocument(runtimeIdx int, runtime indexRuntime, state orderedDocumentIndexState, documentID []byte) ([][]byte, error) {
-	values := state.valuesAt(runtimeIdx)
-	if len(values) == 0 {
-		return nil, nil
-	}
-	out := make([][]byte, 0, len(values))
-	for _, encoded := range values {
-		key, err := indexEntryKey(encoded, documentID)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, key)
-	}
-	return out, nil
+	return nil
 }
 
 func rejectReplaceUniqueConflicts(snap *backenddb.Snapshot, catalog *collectionCatalog, runtimes []indexRuntime, oldState, newState documentIndexState, documentID []byte, batchReplacements batchUniqueReplacementSet) error {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5316,15 +5316,15 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 			if rootID == 0 {
 				continue
 			}
-			table := newCollectionRunTable(0)
+			deleteValues := state[runtime.def.name]
+			if len(deleteValues) == 0 {
+				continue
+			}
+			table := newCollectionRunTable(len(deleteValues))
 			if err := deleteSecondaryEntriesForDocument(table, runtime, state, documentID); err != nil {
 				_ = snap.Close()
 				resetCollectionRunTable(table)
 				return false, err
-			}
-			if table.Len() == 0 {
-				resetCollectionRunTable(table)
-				continue
 			}
 			table.Freeze()
 			rootNames = append(rootNames, rootName)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -826,6 +826,52 @@ func TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation(t *testing
 	}
 }
 
+func TestDeleteSecondaryEntriesForDocumentOwnsGeneratedKeys(t *testing.T) {
+	encoded, err := encodeIndexScalar(IndexValueString, "hnl")
+	if err != nil {
+		t.Fatalf("encode city: %v", err)
+	}
+	documentID := []byte("u1")
+	wantKey, err := indexEntryKey(encoded, documentID)
+	if err != nil {
+		t.Fatalf("index key: %v", err)
+	}
+	state := documentIndexState{"city": {encoded}}
+	runtime := indexRuntime{def: indexDefinition{name: "city", valueType: IndexValueString}}
+	table := newCollectionRunTable(1)
+	if err := deleteSecondaryEntriesForDocument(table, runtime, state, documentID); err != nil {
+		t.Fatalf("delete secondary entries: %v", err)
+	}
+
+	for i := range encoded {
+		encoded[i] = 0
+	}
+	for i := range documentID {
+		documentID[i] = 0
+	}
+	table.Freeze()
+	defer resetCollectionRunTable(table)
+
+	it := table.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		t.Fatal("delete table is empty")
+	}
+	if got := it.UnsafeKey(); !bytes.Equal(got, wantKey) {
+		t.Fatalf("delete key=%q want %q", got, wantKey)
+	}
+	if !it.IsDeleted() {
+		t.Fatal("delete entry is not a tombstone")
+	}
+	it.Next()
+	if it.Valid() {
+		t.Fatalf("unexpected extra delete entry %q", it.UnsafeKey())
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+}
+
 func TestCollectionCatalogCachesIndexRuntimesAndRootNames(t *testing.T) {
 	meta := CollectionMeta{
 		Name: "users",


### PR DESCRIPTION
## Summary

Clean follow-up for #1159 after #1198 landed.

This removes avoidable allocation in secondary-index delete delta construction:
- Generated secondary index-entry keys are already owned by `indexEntryKey`, so update/delete paths can pass them directly to `DeleteSteal`.
- The update-batch changed-index path no longer materializes a temporary `[][]byte` of delete keys before inserting tombstones.
- Single-document delete now builds the secondary delete table directly and skips work when the secondary root does not exist.
- Adds an ownership regression test that mutates the source encoded value and document ID after creating the tombstone, proving the table owns the generated key.

This is intentionally not a planner semantics change: roots/batch, changed/unchanged index decisions, and secondary set/delete counts should remain stable.

Supersedes #1199, whose branch could not be force-pushed after #1198 was squash-merged.

## Validation

```text
go test ./TreeDB/collections -run 'TestDeleteSecondaryEntriesForDocumentOwnsGeneratedKeys|TestCollectionDeleteBridge_RemovesPrimaryAndSecondaryEntries|TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes' -count=1
ok github.com/snissn/gomap/TreeDB/collections 0.556s

go test ./cmd/mongo_gateway_bench -run 'TestProfileBenchParsedUpdateDocsUsesDistinctCityPhases|TestProfileBenchParsedUpdateDocsChangesCityAcrossFullSweep|TestTreeDBCreateIndexDocsIncludesActiveBoolIndex' -count=1
ok github.com/snissn/gomap/cmd/mongo_gateway_bench 0.964s

go test ./TreeDB/collections ./cmd/mongo_gateway_bench -count=1
ok github.com/snissn/gomap/TreeDB/collections 7.337s
ok github.com/snissn/gomap/cmd/mongo_gateway_bench 5.366s

git diff --check
```

## Benchmark

Command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench 'BenchmarkDirectCollectionConcurrentUpdateBSON(CityIndex1|Indexes2CityUpdate|Indexes3CityUpdate)$' \
  -benchtime=200000x \
  -benchmem \
  -count=1
```

Results on Apple M3, branch `codex/1159-secondary-delete-key-alloc`, commit `63c8b6f690` before the clean rebase; the clean branch contains the same code change on top of #1198/main:

| Shape | ns/doc | docs/sec | B/op | allocs/op | roots/batch | changed indexes/doc | unchanged indexes/doc | secondary sets/doc | secondary deletes/doc | secondary run ns/doc | root apply ns/doc |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| city index only | 7,897 | 126,633 | 2,539 | 6 | 2.0 | 1.0 | 0.0 | 1.0 | 1.0 | 207.3 | 2,226 |
| email + city | 8,210 | 121,805 | 2,848 | 6 | 2.0 | 1.0 | 1.0 | 1.0 | 1.0 | 220.5 | 2,125 |
| email + city + active | 8,170 | 122,401 | 2,868 | 6 | 2.0 | 1.0 | 2.0 | 1.0 | 1.0 | 215.8 | 2,166 |

Comparison against the corrected #1198 rows:

| Shape | #1198 B/op | This PR B/op | #1198 allocs/op | This PR allocs/op |
| --- | ---: | ---: | ---: | ---: |
| city index only | 2,602 | 2,539 | 8 | 6 |
| email + city | 2,906 | 2,848 | 8 | 6 |
| email + city + active | 2,904 | 2,868 | 8 | 6 |

The main signal is allocation count: the changed secondary-index update path drops from 8 to 6 allocs/op while preserving the per-index planning invariant.

Follow-up profile on the clean code path:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=200000x \
  -benchmem \
  -count=1 \
  -cpuprofile /tmp/gomap_1159_1199_city3_cpu.pprof \
  -memprofile /tmp/gomap_1159_1199_city3_mem.pprof
```

Result: `8512 ns/doc`, `117488 docs/sec`, `2860 B/op`, `6 allocs/op`, `roots/batch=2.0`, `changed=1.0`, `unchanged=2.0`, `secondary_sets/deletes=1.0/1.0`.

The post-cleanup profile confirms this PR removes the redundant delete-key clone but does not change the larger structural bottleneck. The next real #1159 targets are still current-document reads (`~1927 ns/doc`) and root apply (`~2602 ns/doc`), with CPU still showing scheduler/GC noise plus visible `addInternalLeafLogChild` and `readViaMmapViewTo` work.
