### PR TITLE
Report backend read path profile counters

### DIFF
--- a/cmd/internal/treedbstats/selected.go
+++ b/cmd/internal/treedbstats/selected.go
@@ -35,6 +35,8 @@ func isSelectedKey(key string) bool {
 		return true
 	case strings.HasPrefix(key, "treedb.vlog.outer_leaf_block_cache."):
 		return true
+	case strings.HasPrefix(key, "treedb.process.read_path.backend_tree."):
+		return true
 	case strings.HasPrefix(key, "treedb.process.read_path.outer_leaf."):
 		return true
 	case strings.HasPrefix(key, "treedb.cache.vlog_generation."):

--- a/cmd/internal/treedbstats/selected_test.go
+++ b/cmd/internal/treedbstats/selected_test.go
@@ -5,16 +5,18 @@ import "testing"
 func TestSelectedKeepsSharedTreeDBStats(t *testing.T) {
 	stats := map[string]string{
 		"treedb.commit_seq": "7",
-		"treedb.process.read_path.outer_leaf.cache.hits":            "11",
-		"treedb.vlog.mmap_read.fallback_readat":                     "13",
-		"treedb.publish.ordered_root_delta_group.calls_total":       "19",
-		"treedb.publish.watermark.latency_p99_ms":                   "23",
-		"treedb.collections.write_domain.indexed_flush.calls_total": "29",
-		"treedb.unrelated_stat_that_should_not_leave_the_helper":    "17",
+		"treedb.process.read_path.backend_tree.get_append_pointer_hits_total": "5",
+		"treedb.process.read_path.outer_leaf.cache.hits":                      "11",
+		"treedb.vlog.mmap_read.fallback_readat":                               "13",
+		"treedb.publish.ordered_root_delta_group.calls_total":                 "19",
+		"treedb.publish.watermark.latency_p99_ms":                             "23",
+		"treedb.collections.write_domain.indexed_flush.calls_total":           "29",
+		"treedb.unrelated_stat_that_should_not_leave_the_helper":              "17",
 	}
 	got := Selected(stats)
 	for _, key := range []string{
 		"treedb.commit_seq",
+		"treedb.process.read_path.backend_tree.get_append_pointer_hits_total",
 		"treedb.process.read_path.outer_leaf.cache.hits",
 		"treedb.vlog.mmap_read.fallback_readat",
 		"treedb.publish.ordered_root_delta_group.calls_total",

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -126,6 +126,7 @@ func TestSelectedTreeDBStatsKeepsExpectedKeys(t *testing.T) {
 		want bool
 	}{
 		{name: "exact commit seq", key: "treedb.commit_seq", want: true},
+		{name: "backend tree read path prefix", key: "treedb.process.read_path.backend_tree.get_append_pointer_hits_total", want: true},
 		{name: "ordered root prefix", key: "treedb.publish.ordered_root_delta_group.calls_total", want: true},
 		{name: "watermark prefix", key: "treedb.publish.watermark.latency_p99_ms", want: true},
 		{name: "collection write-domain prefix", key: "treedb.collections.write_domain.indexed_flush.calls_total", want: true},
@@ -150,18 +151,20 @@ func TestSelectedTreeDBStats(t *testing.T) {
 	}
 	got := selectedTreeDBStats(map[string]string{
 		"treedb.commit_seq": "11",
-		"treedb.publish.ordered_root_delta_group.calls_total":       "3",
-		"treedb.publish.ordered_root_delta_group.latency_p99_ms":    "1.5",
-		"treedb.publish.watermark.latency_p99_ms":                   "2.5",
-		"treedb.collections.write_domain.indexed_flush.calls_total": "4",
-		"treedb.vlog.reads_total":                                   "7",
+		"treedb.process.read_path.backend_tree.get_append_pointer_hits_total": "2",
+		"treedb.publish.ordered_root_delta_group.calls_total":                 "3",
+		"treedb.publish.ordered_root_delta_group.latency_p99_ms":              "1.5",
+		"treedb.publish.watermark.latency_p99_ms":                             "2.5",
+		"treedb.collections.write_domain.indexed_flush.calls_total":           "4",
+		"treedb.vlog.reads_total":                                             "7",
 	})
 	want := map[string]string{
 		"treedb.commit_seq": "11",
-		"treedb.publish.ordered_root_delta_group.calls_total":       "3",
-		"treedb.publish.ordered_root_delta_group.latency_p99_ms":    "1.5",
-		"treedb.publish.watermark.latency_p99_ms":                   "2.5",
-		"treedb.collections.write_domain.indexed_flush.calls_total": "4",
+		"treedb.process.read_path.backend_tree.get_append_pointer_hits_total": "2",
+		"treedb.publish.ordered_root_delta_group.calls_total":                 "3",
+		"treedb.publish.ordered_root_delta_group.latency_p99_ms":              "1.5",
+		"treedb.publish.watermark.latency_p99_ms":                             "2.5",
+		"treedb.collections.write_domain.indexed_flush.calls_total":           "4",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("selected stats=%v want %v", got, want)

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -789,10 +789,20 @@ func reportProfileBenchBackendVlogMmapStats(b *testing.B, after, before map[stri
 	reportPerDoc("backend_vlog_mmap_fallback_readat/doc", "treedb.vlog.mmap_read.fallback_readat")
 	reportPerDoc("backend_vlog_mmap_sealed_denied_count_cap/doc", "treedb.vlog.mmap_sealed_map_denied.count_cap")
 	reportPerDoc("backend_vlog_mmap_sealed_denied_bytes_cap/doc", "treedb.vlog.mmap_sealed_map_denied.bytes_cap")
+	reportPerDoc("backend_tree_get_append_inline_hits/doc", "treedb.process.read_path.backend_tree.get_append_inline_hits_total")
+	reportPerDoc("backend_tree_get_append_inline_bytes/doc", "treedb.process.read_path.backend_tree.get_append_inline_bytes_total")
+	reportPerDoc("backend_tree_get_append_pointer_hits/doc", "treedb.process.read_path.backend_tree.get_append_pointer_hits_total")
+	reportPerDoc("backend_tree_get_append_pointer_bytes/doc", "treedb.process.read_path.backend_tree.get_append_pointer_bytes_total")
+	reportPerDoc("backend_outer_leaf_loads/doc", "treedb.process.read_path.outer_leaf.loads_total")
+	reportPerDoc("backend_outer_leaf_point_loads/doc", "treedb.process.read_path.outer_leaf.point_loads_total")
+	reportPerDoc("backend_outer_leaf_iterator_loads/doc", "treedb.process.read_path.outer_leaf.iterator_loads_total")
+	reportPerDoc("backend_outer_leaf_bytes/doc", "treedb.process.read_path.outer_leaf.bytes_total")
+	reportPerDoc("backend_outer_leaf_samples/doc", "treedb.process.read_path.outer_leaf.samples_total")
 	reportPerDoc("backend_outer_leaf_cache_hits/doc", "treedb.process.read_path.outer_leaf.cache.hits")
 	reportPerDoc("backend_outer_leaf_cache_misses/doc", "treedb.process.read_path.outer_leaf.cache.misses")
 	reportPerDoc("backend_outer_leaf_cache_stores/doc", "treedb.process.read_path.outer_leaf.cache.stores")
 	reportPerDoc("backend_outer_leaf_cache_evictions/doc", "treedb.process.read_path.outer_leaf.cache.evictions")
+	reportProfileBenchBackendReadPathRatios(b, after, before)
 	hits := profileBenchDeltaUintStat(after, before, "treedb.vlog.mmap_read.hits")
 	fallbacks := profileBenchDeltaUintStat(after, before, "treedb.vlog.mmap_read.fallback_readat")
 	if total := hits + fallbacks; total > 0 {
@@ -813,6 +823,45 @@ func reportProfileBenchBackendVlogMmapStats(b *testing.B, after, before map[stri
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.process.read_path.outer_leaf.cache.entries")), "backend_outer_leaf_cache_entries")
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.process.read_path.outer_leaf.cache.capacity")), "backend_outer_leaf_cache_capacity")
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.process.read_path.outer_leaf.cache.bytes")), "backend_outer_leaf_cache_bytes")
+	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.process.read_path.outer_leaf.sample_mod")), "backend_outer_leaf_sample_mod")
+}
+
+func reportProfileBenchBackendReadPathRatios(b *testing.B, after, before map[string]string) {
+	b.Helper()
+	reportPerHit := func(metric, bytesKey, hitsKey string) {
+		bytes := profileBenchDeltaUintStat(after, before, bytesKey)
+		hits := profileBenchDeltaUintStat(after, before, hitsKey)
+		if hits > 0 {
+			b.ReportMetric(float64(bytes)/float64(hits), metric)
+		}
+	}
+	reportPerHit(
+		"backend_tree_get_append_inline_bytes/hit",
+		"treedb.process.read_path.backend_tree.get_append_inline_bytes_total",
+		"treedb.process.read_path.backend_tree.get_append_inline_hits_total",
+	)
+	reportPerHit(
+		"backend_tree_get_append_pointer_bytes/hit",
+		"treedb.process.read_path.backend_tree.get_append_pointer_bytes_total",
+		"treedb.process.read_path.backend_tree.get_append_pointer_hits_total",
+	)
+	outerLeafLoads := profileBenchDeltaUintStat(after, before, "treedb.process.read_path.outer_leaf.loads_total")
+	outerLeafBytes := profileBenchDeltaUintStat(after, before, "treedb.process.read_path.outer_leaf.bytes_total")
+	if outerLeafLoads > 0 {
+		b.ReportMetric(float64(outerLeafBytes)/float64(outerLeafLoads), "backend_outer_leaf_bytes/load")
+	}
+	outerLeafSamples := profileBenchDeltaUintStat(after, before, "treedb.process.read_path.outer_leaf.samples_total")
+	if outerLeafSamples == 0 {
+		return
+	}
+	reportPotential := func(metric, key string) {
+		hits := profileBenchDeltaUintStat(after, before, key)
+		b.ReportMetric(float64(hits)/float64(outerLeafSamples), metric)
+	}
+	reportPotential("backend_outer_leaf_cache_potential_64_hit_ratio", "treedb.process.read_path.outer_leaf.cache_potential.capacity_64_hits_total")
+	reportPotential("backend_outer_leaf_cache_potential_256_hit_ratio", "treedb.process.read_path.outer_leaf.cache_potential.capacity_256_hits_total")
+	reportPotential("backend_outer_leaf_cache_potential_1024_hit_ratio", "treedb.process.read_path.outer_leaf.cache_potential.capacity_1024_hits_total")
+	reportPotential("backend_outer_leaf_cache_potential_4096_hit_ratio", "treedb.process.read_path.outer_leaf.cache_potential.capacity_4096_hits_total")
 }
 
 func reportProfileBenchOrderedRootPublishStats(b *testing.B, after, before map[string]string, docs int) {


### PR DESCRIPTION
## Summary

- preserve `treedb.process.read_path.backend_tree.*` stats in benchmark JSON artifacts
- add direct collection profile-benchmark reporting for backend-tree `GetAppend` inline/pointer hits and bytes
- add outer-leaf load/byte/sample/cache-potential counters to the same benchmark output

This is a small #1159 attribution PR. It does not change engine behavior; it makes the current read/root-apply bottleneck easier to measure before the next optimization slice.

## Validation

```bash
go test ./cmd/internal/treedbstats -count=1
ok  	github.com/snissn/gomap/cmd/internal/treedbstats	0.447s

go test ./cmd/mongo_gateway_bench -run 'TestSelectedTreeDBStats|TestProfileBenchUpdateIDStrideCoversDocumentSet|TestProfileBenchDeltaUintStat' -count=1
ok  	github.com/snissn/gomap/cmd/mongo_gateway_bench	0.381s

go test ./cmd/mongo_gateway_bench -count=1
ok  	github.com/snissn/gomap/cmd/mongo_gateway_bench	1.882s

git diff --check
```

Focused benchmark command:

```bash
PROFILE_DIR=/tmp/gomap_1159_read_rootapply_1777766049
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=200000x \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

Focused result:

```text
BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate-8  200000  9192 ns/op  108786 docs/sec  9192 ns/doc  2858 B/op  6 allocs/op
backend_tree_get_append_inline_hits/doc=1.000
backend_tree_get_append_inline_bytes/doc=324.0
backend_tree_get_append_inline_bytes/hit=323.9
backend_tree_get_append_pointer_hits/doc=0
backend_tree_get_append_pointer_bytes/doc=0
backend_outer_leaf_loads/doc=1.000
backend_outer_leaf_point_loads/doc=1.000
backend_outer_leaf_iterator_loads/doc=0
backend_outer_leaf_bytes/doc=4097
backend_outer_leaf_bytes/load=4096
backend_outer_leaf_cache_hit_ratio=0.04094
backend_vlog_mmap_hit_ratio=1.000
backend_vlog_mmap_fallback_readat/doc=0
publish_delta_group_root_apply_ns/doc=3079
publish_delta_group_root_apply_leaf_log_node_loads/doc=0.2988
publish_delta_group_root_apply_leaf_log_pages_written/doc=0.3708
update_current_read_ns/doc=1920
update_roots/batch=2.000
update_index_value_changes/doc=1.000
update_index_value_unchanged/doc=2.000
```

CPU profile top entries from the same run still show the next bottleneck shape:

```text
runtime.pthread_cond_signal                25.53% flat
runtime.madvise                            12.68% flat
runtime.memclrNoHeapPointers                6.87% flat
runtime.memmove                             6.69% flat
node.(*Builder).addInternalLeafLogChild     3.17% flat
valuelog.(*File).readViaMmapViewTo          1.41% flat / 3.52% cum
```

Interpretation for #1159:

- Current-document reads are inline `GetAppend` reads in this BSON collection shape, not value-log pointer reads.
- The current-read path still performs about one 4 KiB outer-leaf point load per document.
- There is no `ReadAt` fallback in this row; mmap is serving the value-log reads.
- Root apply still writes about `0.37` leaf-log pages/doc and loads about `0.30` leaf-log nodes/doc.
- The next optimization should focus on reducing outer-leaf point loads/copy/decode for current reads and reducing leaf-log pages loaded/written/rebuilt by zipper apply.

Fixes part of #1159.
