### PR TITLE
Borrow buffered root run delta views

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3789,16 +3789,18 @@ func (h *bufferedRootRunHeap) down(i0, n int) bool {
 }
 
 type bufferedRootRunsIterator struct {
-	iters          []iterator.UnsafeIterator
-	heap           bufferedRootRunHeap
-	cur            bufferedRootRunHeapItem
-	hasCur         bool
-	valid          bool
-	includeDeleted bool
-	start          []byte
-	end            []byte
-	closed         bool
-	firstErr       error
+	iters              []iterator.UnsafeIterator
+	heap               bufferedRootRunHeap
+	cur                bufferedRootRunHeapItem
+	hasCur             bool
+	valid              bool
+	includeDeleted     bool
+	stableUnsafeSlices bool
+	lenHint            int
+	start              []byte
+	end                []byte
+	closed             bool
+	firstErr           error
 }
 
 func newBufferedRootRunsIterator(runs []memtable.Table, start, end []byte) iterator.UnsafeIterator {
@@ -3810,14 +3812,21 @@ func newBufferedRootRunsIteratorWithDeleted(runs []memtable.Table, start, end []
 		return runs[0].NewIterator(start, end)
 	}
 	it := &bufferedRootRunsIterator{
-		iters:          make([]iterator.UnsafeIterator, 0, len(runs)),
-		includeDeleted: includeDeleted,
-		start:          start,
-		end:            end,
+		iters:              make([]iterator.UnsafeIterator, 0, len(runs)),
+		includeDeleted:     includeDeleted,
+		stableUnsafeSlices: true,
+		start:              start,
+		end:                end,
 	}
 	for i, run := range runs {
 		if run == nil {
 			continue
+		}
+		if stable, ok := run.(memtable.StableUnsafeIteratorTable); !ok || !stable.StableUnsafeIteratorSlices() {
+			it.stableUnsafeSlices = false
+		}
+		if start == nil && end == nil {
+			it.lenHint += run.Len()
 		}
 		runIter := run.NewIterator(start, end)
 		idx := len(it.iters)
@@ -3959,6 +3968,17 @@ func (it *bufferedRootRunsIterator) Domain() (start, end []byte) {
 		return nil, nil
 	}
 	return it.start, it.end
+}
+
+func (it *bufferedRootRunsIterator) StableUnsafeIteratorSlices() bool {
+	return it != nil && it.stableUnsafeSlices
+}
+
+func (it *bufferedRootRunsIterator) Len() int {
+	if it == nil {
+		return 0
+	}
+	return it.lenHint
 }
 
 func (it *bufferedRootRunsIterator) advance() {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3826,7 +3826,7 @@ func newBufferedRootRunsIteratorWithDeleted(runs []memtable.Table, start, end []
 			it.stableUnsafeSlices = false
 		}
 		if start == nil && end == nil {
-			it.lenHint += run.Len()
+			it.lenHint = saturatingAddNonNegativeInt(it.lenHint, run.Len())
 		}
 		runIter := run.NewIterator(start, end)
 		idx := len(it.iters)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/batch"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
@@ -2942,6 +2943,63 @@ func TestBufferedRootRunsIteratorMultiRunIncludesNewestTombstone(t *testing.T) {
 	}
 	if err := it.Error(); err != nil {
 		t.Fatalf("iterator error: %v", err)
+	}
+}
+
+func TestBufferedRootRunsIteratorMultiRunStableUnsafeSlices(t *testing.T) {
+	older := newCollectionRunTable(2)
+	defer resetCollectionRunTable(older)
+	setCollectionRunValue(older, []byte("a"), []byte("older"))
+	setCollectionRunValue(older, []byte("b"), []byte("older"))
+	older.Freeze()
+
+	newer := newCollectionRunTable(2)
+	defer resetCollectionRunTable(newer)
+	newer.DeleteSteal([]byte("a"))
+	setCollectionRunValue(newer, []byte("c"), []byte("newer"))
+	newer.Freeze()
+
+	it := newBufferedRootRunsIteratorWithDeleted([]memtable.Table{older, newer}, nil, nil, true)
+	stable, ok := it.(interface {
+		StableUnsafeIteratorSlices() bool
+	})
+	if !ok {
+		t.Fatalf("buffered root iterator does not expose StableUnsafeIteratorSlices")
+	}
+	if !stable.StableUnsafeIteratorSlices() {
+		t.Fatalf("buffered root iterator did not preserve stable memtable slices")
+	}
+	lenHint, ok := it.(interface {
+		Len() int
+	})
+	if !ok {
+		t.Fatalf("buffered root iterator does not expose Len hint")
+	}
+	if got, want := lenHint.Len(), 4; got != want {
+		t.Fatalf("buffered root iterator Len hint=%d want %d", got, want)
+	}
+
+	delta, err := backenddb.OrderedRootDeltaBatchFromIterator(it)
+	if err != nil {
+		t.Fatalf("materialize delta: %v", err)
+	}
+	defer func() { _ = delta.Close() }()
+	if err := it.Close(); err != nil {
+		t.Fatalf("close iterator: %v", err)
+	}
+
+	entries := delta.SortedEntries()
+	if got, want := len(entries), 3; got != want {
+		t.Fatalf("delta entries=%d want %d", got, want)
+	}
+	if got := entries[0]; string(got.Key) != "a" || got.Type != batch.OpDelete {
+		t.Fatalf("entry[0]=%+v want tombstone a", got)
+	}
+	if got := entries[1]; string(got.Key) != "b" || string(got.Value) != "older" {
+		t.Fatalf("entry[1]=%+v want b=older", got)
+	}
+	if got := entries[2]; string(got.Key) != "c" || string(got.Value) != "newer" {
+		t.Fatalf("entry[2]=%+v want c=newer", got)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/batch"
@@ -2947,16 +2948,23 @@ func TestBufferedRootRunsIteratorMultiRunIncludesNewestTombstone(t *testing.T) {
 }
 
 func TestBufferedRootRunsIteratorMultiRunStableUnsafeSlices(t *testing.T) {
+	oldAKey := []byte("a")
+	oldBKey := []byte("b")
+	oldBValue := []byte("older")
+	newAKey := []byte("a")
+	newCKey := []byte("c")
+	newCValue := []byte("newer")
+
 	older := newCollectionRunTable(2)
 	defer resetCollectionRunTable(older)
-	setCollectionRunValue(older, []byte("a"), []byte("older"))
-	setCollectionRunValue(older, []byte("b"), []byte("older"))
+	setCollectionRunValue(older, oldAKey, []byte("older"))
+	setCollectionRunValue(older, oldBKey, oldBValue)
 	older.Freeze()
 
 	newer := newCollectionRunTable(2)
 	defer resetCollectionRunTable(newer)
-	newer.DeleteSteal([]byte("a"))
-	setCollectionRunValue(newer, []byte("c"), []byte("newer"))
+	newer.DeleteSteal(newAKey)
+	setCollectionRunValue(newer, newCKey, newCValue)
 	newer.Freeze()
 
 	it := newBufferedRootRunsIteratorWithDeleted([]memtable.Table{older, newer}, nil, nil, true)
@@ -2975,8 +2983,8 @@ func TestBufferedRootRunsIteratorMultiRunStableUnsafeSlices(t *testing.T) {
 	if !ok {
 		t.Fatalf("buffered root iterator does not expose Len hint")
 	}
-	if got, want := lenHint.Len(), 4; got != want {
-		t.Fatalf("buffered root iterator Len hint=%d want %d", got, want)
+	if got, wantAtLeast := lenHint.Len(), 3; got < wantAtLeast {
+		t.Fatalf("buffered root iterator Len hint=%d want at least %d", got, wantAtLeast)
 	}
 
 	delta, err := backenddb.OrderedRootDeltaBatchFromIterator(it)
@@ -2995,11 +3003,26 @@ func TestBufferedRootRunsIteratorMultiRunStableUnsafeSlices(t *testing.T) {
 	if got := entries[0]; string(got.Key) != "a" || got.Type != batch.OpDelete {
 		t.Fatalf("entry[0]=%+v want tombstone a", got)
 	}
+	if unsafe.SliceData(entries[0].Key) != unsafe.SliceData(newAKey) {
+		t.Fatal("tombstone key was copied instead of borrowed from the newer run")
+	}
 	if got := entries[1]; string(got.Key) != "b" || string(got.Value) != "older" {
 		t.Fatalf("entry[1]=%+v want b=older", got)
 	}
+	if unsafe.SliceData(entries[1].Key) != unsafe.SliceData(oldBKey) {
+		t.Fatal("older run key was copied instead of borrowed")
+	}
+	if unsafe.SliceData(entries[1].Value) != unsafe.SliceData(oldBValue) {
+		t.Fatal("older run value was copied instead of borrowed")
+	}
 	if got := entries[2]; string(got.Key) != "c" || string(got.Value) != "newer" {
 		t.Fatalf("entry[2]=%+v want c=newer", got)
+	}
+	if unsafe.SliceData(entries[2].Key) != unsafe.SliceData(newCKey) {
+		t.Fatal("newer run key was copied instead of borrowed")
+	}
+	if unsafe.SliceData(entries[2].Value) != unsafe.SliceData(newCValue) {
+		t.Fatal("newer run value was copied instead of borrowed")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Mark merged buffered collection root-run iterators as stable unsafe-slice iterators when their source memtables have stable views.
- Add a full-range length hint so ordered-root delta materialization can reserve `batch.Batch` entries up front.
- Add a regression test proving merged buffered root runs preserve the stable-view contract through `OrderedRootDeltaBatchFromIterator`.

This targets #1159 allocation pressure in the indexed collection async flush/root-publish path. The previous path copied merged buffered root-run keys/values into transient ordered-root delta batches; this lets the delta batch borrow from the still-live memtable runs during publish.

## Local validation

```bash
go test ./TreeDB/collections -run 'TestBufferedRootRunsIterator|TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes' -count=1
go test ./TreeDB/db -run 'TestOrderedRootDeltaBatchFromIterator' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/mongo_gateway_bench -run 'TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats|TestProfileBenchDeltaUintStat|TestSelectedTreeDBStats' -count=1
go test ./TreeDB/db -count=1
git diff --check
```

All passed locally.

## Focused benchmark

Command for both rows:

```bash
PROFILE_DIR=/tmp/gomap_1159_next_profile_1777767330 # baseline
PROFILE_DIR=/tmp/gomap_1159_buffered_views_lenhint_1777767637 # this branch
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=200000x \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

| Build | docs/sec | ns/doc | B/op | allocs/op | current read ns/doc | root apply ns/doc | update roots/batch |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `origin/main` (`7fb2aa5`) | 100,429 | 9,957 | 2,910 | 6 | 2,053 | 3,225 | 2.0 |
| this branch (`4ec3973`) | 122,512 | 8,162 | 1,355 | 6 | 1,948 | 2,411 | 2.0 |

Allocation profile movement:

- Before: `batch.(*Batch).Set` + `batch.(*Batch).ensureArenaChunk` accounted for about `1.31 GiB` alloc space in the focused run.
- Stable-view only intermediate check moved that allocation into `Batch.SetView` entry growth, confirming borrowed views were active but missing a capacity hint.
- After the length hint: `Batch.Reserve` accounts for about `0.21 GiB`; `Batch.Set`/`Delete` copy churn falls out of the top allocation list.

Notes:

- This does not change root counts: per-index changed-delta planning still reports `update_index_value_changes/doc=1`, `update_index_value_unchanged/doc=2`, and `update_roots/batch=2` for this 3-index city-update shape.
- The root-apply/read timings are still noisy at this run length, but the allocation reduction is direct and visible in `B/op` and pprof.

Fixes part of #1159.
