### PR TITLE
Avoid clearing discarded large batch entries

### DIFF
--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -158,12 +158,15 @@ func (b *Batch) resetLocked() {
 
 func (b *Batch) resetForPool() {
 	if b.entries != nil {
-		// SortedEntries clears the compacted tail, so clearing len is sufficient
-		// here while avoiding O(cap) work for large pooled batches.
-		clear(b.entries)
 		if cap(b.entries) > maxBatchPoolCap {
+			// Drop oversized backing arrays without clearing them first. Once the
+			// slice is nil, the batch no longer retains the array or its key/value
+			// references, so clearing would only add O(cap) CPU before GC.
 			b.entries = nil
 		} else {
+			// SortedEntries clears the compacted tail, so clearing len is sufficient
+			// here while avoiding O(cap) work for normal pooled batches.
+			clear(b.entries)
 			b.entries = b.entries[:0]
 		}
 	}

--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -161,11 +161,11 @@ func (b *Batch) resetForPool() {
 		if cap(b.entries) > maxBatchPoolCap {
 			// Drop oversized backing arrays without clearing them first. Once the
 			// slice is nil, the batch no longer retains the array or its key/value
-			// references, so clearing would only add O(cap) CPU before GC.
+			// references, so clearing len entries would only add discard-path CPU.
 			b.entries = nil
 		} else {
-			// SortedEntries clears the compacted tail, so clearing len is sufficient
-			// here while avoiding O(cap) work for normal pooled batches.
+			// SortedEntries clears the compacted tail, so clearing len here is
+			// sufficient for normal pooled batches.
 			clear(b.entries)
 			b.entries = b.entries[:0]
 		}

--- a/TreeDB/batch/batch_pool_test.go
+++ b/TreeDB/batch/batch_pool_test.go
@@ -37,3 +37,21 @@ func TestBatchReleaseClearsPointers(t *testing.T) {
 		}
 	}
 }
+
+func TestBatchReleaseDropsOversizedEntriesWithoutClearing(t *testing.T) {
+	b := New(newMapValueReader(), page.DefaultInlineThreshold)
+	key := []byte("large-key")
+	value := []byte("large-value")
+	b.entries = make([]Entry, 1, maxBatchPoolCap+1)
+	b.entries[0] = Entry{Type: OpPut, Key: key, Value: value}
+	entries := b.entries
+
+	Release(b)
+
+	if b.entries != nil {
+		t.Fatalf("oversized entries retained with cap=%d", cap(b.entries))
+	}
+	if len(entries) != 1 || string(entries[0].Key) != string(key) || string(entries[0].Value) != string(value) {
+		t.Fatalf("oversized discarded entries were cleared before drop: %+v", entries)
+	}
+}


### PR DESCRIPTION
## Summary

Small #1159 allocation/CPU hygiene PR. `batch.Batch.resetForPool` already drops oversized entry backing arrays instead of retaining them in the pool, but it cleared the large slice before dropping it. For large ordered-root delta batches this can add O(cap) zeroing work even though the batch immediately releases the backing array.

This changes the oversized path to detach the slice first. Normal pooled batches still clear retained entries, preserving the existing pointer-release behavior for arrays that remain in the pool.

## Tests

- `go test ./TreeDB/batch -run 'TestBatchReleaseClearsPointers|TestBatchReleaseDropsOversizedEntriesWithoutClearing' -count=1`\n- `go test ./TreeDB/db -run 'TestOrderedRootDeltaBatchFromIterator_StableIteratorUsesViews|TestOrderedRootDeltaBatchIteratorLenSkipsDeletedWhenHidden' -count=1`\n- `go test ./TreeDB/batch ./TreeDB/db -count=1`\n- `git diff --check`\n\n## Focused benchmark/profile\n\nBaseline on current `origin/main` (`0187148252a95ca24c09803a5ed10689bba312cd`):\n\n```bash\nPROFILE_DIR=/tmp/gomap_1159_next_main_OhYDkn\nMONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \\\nMONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \\\nMONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \\\nMONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \\\nMONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \\\ngo test ./cmd/mongo_gateway_bench \\\n  -run '^$' \\\n  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \\\n  -benchtime=200000x \\\n  -benchmem \\\n  -count=1 \\\n  -cpuprofile "$PROFILE_DIR/cpu.pprof" \\\n  -memprofile "$PROFILE_DIR/mem.pprof"\n```\n\nResult: `98,288 docs/sec`, `10,174 ns/doc`, `1388 B/op`, `7 allocs/op`.\n\nAfter this PR:\n\n```bash\nPROFILE_DIR=/tmp/gomap_1159_batch_reset_after_rguWV3\nMONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \\\nMONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \\\nMONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \\\nMONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \\\nMONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \\\ngo test ./cmd/mongo_gateway_bench \\\n  -run '^$' \\\n  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \\\n  -benchtime=200000x \\\n  -benchmem \\\n  -count=1 \\\n  -cpuprofile "$PROFILE_DIR/cpu.pprof" \\\n  -memprofile "$PROFILE_DIR/mem.pprof"\n```\n\nResult: `119,356 docs/sec`, `8,378 ns/doc`, `1373 B/op`, `6 allocs/op`.\n\nInterpretation: the pprof still shows real `Batch.Reserve` allocation and other `memclr` sources, so this PR should be treated as a narrow cleanup, not the root-apply architecture fix. The structural #1203 counters were effectively unchanged, as expected.\n\n## Next #1159 target\n\nThe next larger target remains either direct ordered-root iterator apply/materialization reduction, or current-document read batching/locality. This PR only removes one avoidable clear-before-drop cost.