### PR TITLE
Skip unchanged unique runs for buffered updates

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3607,52 +3607,6 @@ func bufferedUniqueIndexValueRun(batchIndex memtable.Table, valueType IndexValue
 	return table, prefixes, nil
 }
 
-func bufferedUnchangedUniqueValueRuns(runtimes []indexRuntime, updates []preparedBatchUpdate) ([]updateBatchUniqueValueRun, error) {
-	var out []updateBatchUniqueValueRun
-	for runtimeIdx, runtime := range runtimes {
-		if !runtime.def.unique {
-			continue
-		}
-		var table memtable.Table
-		var prefixes [][]byte
-		var arena []byte
-		for _, update := range updates {
-			if !update.indexStateChanged {
-				continue
-			}
-			if preparedBatchUpdateIndexChanged(update, runtimeIdx) {
-				continue
-			}
-			for _, encoded := range update.newState.valuesAt(runtimeIdx) {
-				if table == nil {
-					table = newCollectionRunTable(0)
-				}
-				var prefix []byte
-				var err error
-				arena, prefix, err = appendIndexValuePrefixSlice(arena, encoded)
-				if err != nil {
-					resetCollectionRunTable(table)
-					resetUpdateBatchUniqueValueRuns(out)
-					return nil, err
-				}
-				setCollectionRunValue(table, prefix, nil)
-				prefixes = append(prefixes, prefix)
-			}
-		}
-		if table == nil || table.Len() == 0 {
-			resetCollectionRunTable(table)
-			continue
-		}
-		table.Freeze()
-		out = append(out, updateBatchUniqueValueRun{
-			indexName: runtime.def.name,
-			table:     table,
-			prefixes:  prefixes,
-		})
-	}
-	return out, nil
-}
-
 func indexEntryValuePrefix(key []byte, valueType IndexValueType) ([]byte, error) {
 	n, err := indexComponentLength(valueType, key)
 	if err != nil {
@@ -6505,18 +6459,11 @@ type updateBatchPlan struct {
 	policies                    []backenddb.OrderedRootStoragePolicy
 	deltaTables                 []memtable.Table
 	uniqueSecondaryIndexByRoot  []int
-	uniqueValueRuns             []updateBatchUniqueValueRun
 	canBufferIndexedUpdateBatch bool
 	bufferedBase                bool
 	bufferedReadGeneration      uint64
 	bufferedReadBlocked         bool
 	scratch                     *updateBatchPlanScratch
-}
-
-type updateBatchUniqueValueRun struct {
-	indexName string
-	table     memtable.Table
-	prefixes  [][]byte
 }
 
 var updateBatchPlanPool sync.Pool
@@ -6766,7 +6713,6 @@ func (plan *updateBatchPlan) close() {
 		_ = plan.snap.Close()
 	}
 	resetCollectionTables(plan.deltaTables)
-	resetUpdateBatchUniqueValueRuns(plan.uniqueValueRuns)
 	if plan.scratch != nil {
 		putUpdateBatchPlanScratch(plan.scratch)
 	}
@@ -7435,7 +7381,6 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	var stateTable memtable.Table
 	secondaryTables := make(map[string]memtable.Table, len(runtimes))
 	secondaryRunStats := make([]CollectionUpdateSecondaryRunStats, len(runtimes))
-	var uniqueValueRuns []updateBatchUniqueValueRun
 	success := false
 	defer func() {
 		if success {
@@ -7447,7 +7392,6 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		for _, table := range secondaryTables {
 			resetCollectionRunTable(table)
 		}
-		resetUpdateBatchUniqueValueRuns(uniqueValueRuns)
 	}()
 
 	if len(templateRecords) > 0 {
@@ -7602,14 +7546,6 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	for _, table := range secondaryTables {
 		resetCollectionRunTable(table)
 	}
-	if canBufferIndexedUpdateBatch && meta.Options.BufferedIndexedWrites && collectionMetaHasSecondaryUniqueIndex(meta) {
-		var err error
-		uniqueValueRuns, err = bufferedUnchangedUniqueValueRuns(runtimes, changed)
-		if err != nil {
-			_ = snap.Close()
-			return nil, err
-		}
-	}
 	success = true
 	plan := newUpdateBatchPlan()
 	stats = updateCollectionUpdateStatsCounts(stats, results, len(deltaTables))
@@ -7632,9 +7568,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		policies:                    policies,
 		deltaTables:                 deltaTables,
 		scratch:                     scratch,
-		uniqueValueRuns:             uniqueValueRuns,
 	}
-	uniqueValueRuns = nil
 	scratchOwnedByPlan = true
 	return plan, nil
 }
@@ -7805,11 +7739,6 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	}
 	hasUniqueSecondaryRoots := collectionMetaHasSecondaryUniqueIndex(plan.meta)
 	projectedStagedBytes := stagedBytes
-	for i := range plan.uniqueValueRuns {
-		if table := plan.uniqueValueRuns[i].table; table != nil {
-			projectedStagedBytes = saturatingAddNonNegativeInt64(projectedStagedBytes, table.Size())
-		}
-	}
 	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, projectedStagedBytes, stagedRootRuns)
 	if !shouldAutoFlushAfterAdding && hasUniqueSecondaryRoots && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
 		for i := range plan.rootNames {
@@ -7889,32 +7818,6 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		plan.stats.BufferStageRootAppend += updateBatchStatsSince(detailedStats, phaseStart)
 	}
 	plan.deltaTables = nil
-	if len(plan.uniqueValueRuns) > 0 {
-		phaseStart = updateBatchStatsNow(detailedStats)
-		if domain.uniqueValueRuns == nil {
-			domain.uniqueValueRuns = make(map[string][]memtable.Table)
-		}
-		if domain.uniqueValueIndex == nil {
-			domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex)
-		}
-		for i := range plan.uniqueValueRuns {
-			run := &plan.uniqueValueRuns[i]
-			if run.table == nil {
-				continue
-			}
-			domain.uniqueValueRuns[run.indexName] = append(domain.uniqueValueRuns[run.indexName], run.table)
-			index := domain.uniqueValueIndex[run.indexName]
-			if index == nil {
-				index = newBufferedUniqueValueIndex(max(1, len(run.prefixes)))
-				domain.uniqueValueIndex[run.indexName] = index
-			}
-			index.addAll(run.prefixes)
-			stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, run.table.Size())
-			run.table = nil
-			run.prefixes = nil
-		}
-		plan.stats.BufferStageUniqueIdx += updateBatchStatsSince(detailedStats, phaseStart)
-	}
 	domain.loaded = true
 	domain.meta = plan.meta
 	domain.catalog = plan.catalog
@@ -8018,13 +7921,6 @@ func rejectBatchUniqueConflicts(runtimes []indexRuntime, updates []preparedBatch
 		}
 	}
 	return nil
-}
-
-func resetUpdateBatchUniqueValueRuns(runs []updateBatchUniqueValueRun) {
-	for i := range runs {
-		resetCollectionRunTable(runs[i].table)
-		runs[i] = updateBatchUniqueValueRun{}
-	}
 }
 
 func updateBatchChangesSecondaryUniqueIndex(runtimes []indexRuntime, updates []preparedBatchUpdate) bool {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7499,7 +7499,7 @@ func collectionHasBufferedPrimaryRunIndexForTest(t *testing.T, col *Collection) 
 	return col.writeDomain.primaryRunIndex != nil
 }
 
-func TestCollectionUpdateBatchMaintainsBufferedUniqueValueIndex(t *testing.T) {
+func TestCollectionUpdateBatchDoesNotBufferUnchangedUniqueValues(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -7543,20 +7543,48 @@ func TestCollectionUpdateBatchMaintainsBufferedUniqueValueIndex(t *testing.T) {
 		t.Fatal("update batch was not buffered")
 	}
 
-	encoded, err := encodeIndexScalar(IndexValueString, "a@example.com")
+	encodedA, err := encodeIndexScalar(IndexValueString, "a@example.com")
 	if err != nil {
 		t.Fatalf("encode email: %v", err)
 	}
-	_, prefix, err := appendIndexValuePrefixSlice(nil, encoded)
+	_, prefixA, err := appendIndexValuePrefixSlice(nil, encodedA)
 	if err != nil {
 		t.Fatalf("email prefix: %v", err)
 	}
+	encodedB, err := encodeIndexScalar(IndexValueString, "b@example.com")
+	if err != nil {
+		t.Fatalf("encode buffered email: %v", err)
+	}
+	_, prefixB, err := appendIndexValuePrefixSlice(nil, encodedB)
+	if err != nil {
+		t.Fatalf("buffered email prefix: %v", err)
+	}
 	col.writeDomain.mu.RLock()
 	pending := col.writeDomain.uniqueValueIndex["email"]
-	contains := pending != nil && pending.contains(prefix)
+	containsA := pending != nil && pending.contains(prefixA)
+	containsB := pending != nil && pending.contains(prefixB)
+	uniqueRuns := len(col.writeDomain.uniqueValueRuns["email"])
 	col.writeDomain.mu.RUnlock()
-	if !contains {
-		t.Fatal("buffered update did not add unchanged unique email to pending unique-value index")
+	if containsA {
+		t.Fatal("buffered non-unique update added unchanged persisted unique email to pending unique-value index")
+	}
+	if !containsB {
+		t.Fatal("pending buffered insert unique email missing from pending unique-value index")
+	}
+	if uniqueRuns != 1 {
+		t.Fatalf("unique value runs=%d want only the pending insert run", uniqueRuns)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u3")},
+		[][]byte{[]byte(`{"email":"a@example.com","city":"hnl"}`)},
+	); !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("duplicate persisted unique email err=%v want ErrUniqueIndexConflict", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u4")},
+		[][]byte{[]byte(`{"email":"b@example.com","city":"hnl"}`)},
+	); !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("duplicate pending unique email err=%v want ErrUniqueIndexConflict", err)
 	}
 	ids, err := col.FindByIndex("email", "a@example.com")
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7574,6 +7574,31 @@ func TestCollectionUpdateBatchDoesNotBufferUnchangedUniqueValues(t *testing.T) {
 	if uniqueRuns != 1 {
 		t.Fatalf("unique value runs=%d want only the pending insert run", uniqueRuns)
 	}
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	col.writeDomain.mu.RLock()
+	pending = col.writeDomain.uniqueValueIndex["email"]
+	containsA = pending != nil && pending.contains(prefixA)
+	containsB = pending != nil && pending.contains(prefixB)
+	publishingUniqueRuns := 0
+	if len(col.writeDomain.indexedPublishingUnits) > 0 {
+		publishingUniqueRuns = len(col.writeDomain.indexedPublishingUnits[0].uniqueValueRuns["email"])
+	}
+	col.writeDomain.mu.RUnlock()
+	if containsA {
+		t.Fatal("rotated non-unique update added unchanged persisted unique email to pending unique-value index")
+	}
+	if !containsB {
+		t.Fatal("rotated pending insert unique email missing from pending unique-value index")
+	}
+	if publishingUniqueRuns != 1 {
+		t.Fatalf("publishing unique value runs=%d want only the pending insert run", publishingUniqueRuns)
+	}
 	if _, err := col.InsertBatch(
 		[][]byte{[]byte("u3")},
 		[][]byte{[]byte(`{"email":"a@example.com","city":"hnl"}`)},
@@ -7592,6 +7617,9 @@ func TestCollectionUpdateBatchDoesNotBufferUnchangedUniqueValues(t *testing.T) {
 	}
 	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
 		t.Fatalf("email ids=%q want [u1]", ids)
+	}
+	if err := col.publishPreparedIndexedFlush(work); err != nil {
+		t.Fatalf("publish prepared async flush: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Part of #1159's per-index changed-delta work-reduction track.

Buffered indexed updates no longer build synthetic pending unique-value runs for unique indexes whose encoded value set did not change. For a schema with `email` unique and `city` non-unique, a city-only buffered update should stage the primary replacement plus the changed city secondary delta; it should not allocate another email unique-value run.

The correctness argument is:

- persisted unchanged unique values remain protected by the persisted unique secondary root;
- pending inserts or actual unique-value changes are still protected by the real pending unique secondary root runs;
- unchanged unique indexes still skip unique conflict preflight and emit no secondary root deltas.

## Tests

```bash
go test ./TreeDB/collections -run 'TestCollectionUpdateBatchDoesNotBufferUnchangedUniqueValues|TestCollectionIndexedWriteMemtablesAsyncQueuedUnitsParticipateInUniqueChecks|TestCollectionIndexedWriteMemtablesAsyncPublishingUnitsParticipateInReadsAndUniqueChecks|TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes' -count=1

go test ./TreeDB/collections -count=1

git diff --check
```

## Focused benchmark/profile

Baseline on `origin/main` at `0187148252`:

```bash
RUN_DIR=/tmp/gomap_1159_skip_unchanged_unique_main_GTXgWw
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=200000x \
  -benchmem \
  -count=1 \
  -cpuprofile "$RUN_DIR/cpu.pprof" \
  -memprofile "$RUN_DIR/mem.pprof"
```

Result:

- `94,016 docs/sec`, `10,636 ns/doc`, `1382 B/op`, `6 allocs/op`
- `update_buffer_unique_index_ns/doc=100.4`
- `update_buffer_stage_ns/doc=260.6`
- `publish_delta_group_root_apply_ns/doc=4543`

This branch, profiled before commit with the same code as `65dff016ed8f`:

```bash
RUN_DIR=/tmp/gomap_1159_skip_unchanged_unique_after_brWEE2
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=200000x \
  -benchmem \
  -count=1 \
  -cpuprofile "$RUN_DIR/cpu.pprof" \
  -memprofile "$RUN_DIR/mem.pprof"
```

Result:

- `114,189 docs/sec`, `8757 ns/doc`, `1053 B/op`, `5 allocs/op`
- no `update_buffer_unique_index_ns/doc` row for this city-only update path
- `update_buffer_stage_ns/doc=151.1`
- `publish_delta_group_root_apply_ns/doc=3151`

Repeated no-profile branch run:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=200000x \
  -benchmem \
  -count=3
```

Rows:

- `108,892 docs/sec`, `9183 ns/doc`, `1542 B/op`, `6 allocs/op`
- `122,997 docs/sec`, `8130 ns/doc`, `1053 B/op`, `5 allocs/op`
- `122,897 docs/sec`, `8137 ns/doc`, `1086 B/op`, `6 allocs/op`

Interpretation: timing remains noisy because the async combiner forms slightly different batch sizes, but the direct staged-unique-index work for unchanged unique indexes is removed and the allocation profile improves in the representative run. The remaining large costs are still current-document read and zipper/root apply, not this unique-index staging path.

## Post-open update

Refreshed the PR branch onto main after #1204 merged using merge commit `5fbbcf575b91` because repository rules reject force-pushes to PR branches.

Additional local smoke after the refresh:

```bash
go test ./TreeDB/collections -run 'TestCollectionUpdateBatchDoesNotBufferUnchangedUniqueValues|TestCollectionIndexedWriteMemtablesAsyncQueuedUnitsParticipateInUniqueChecks|TestCollectionIndexedWriteMemtablesAsyncPublishingUnitsParticipateInReadsAndUniqueChecks|TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes' -count=1

go test ./TreeDB/batch -run 'TestBatchReleaseClearsPointers|TestBatchReleaseDropsOversizedEntriesWithoutClearing' -count=1
```

An earlier CI attempt before the refresh hit the unrelated known Windows caching flake in `TreeDB/caching`: `TestVlogGenerationRewriteQueue_FreshBypassThenExpiredRetryPrefersImprovedStalePayoff`, output `unexpected rewrite source ids=[11]`. Local rerun of that exact test passed: `go test ./TreeDB/caching -run '^TestVlogGenerationRewriteQueue_FreshBypassThenExpiredRetryPrefersImprovedStalePayoff$' -count=1`.