### PR TITLE
Report per-index update delta counters

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -731,9 +731,14 @@ type collectionWriteDomain struct {
 	updateBatchUniqueChecks          atomic.Uint64
 	updateBatchUniqueCheckSkips      atomic.Uint64
 	updateBatchDetailedStats         atomic.Bool
-	updateBatchIndexStatsMu          sync.Mutex
-	updateBatchIndexStatsCount       int
-	updateBatchIndexStats            [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats
+	updateBatchIndexChanged          [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexUnchanged        [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexUniqueChecks     [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexUniqueSkips      [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexSecondaryRuns    [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexSecondaryDeletes [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexSecondarySets    [maxCollectionUpdateInlineIndexStats]atomic.Uint64
+	updateBatchIndexSecondaryBytes   [maxCollectionUpdateInlineIndexStats]atomic.Uint64
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -1098,6 +1103,14 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.PendingBytes = domain.bufferedBytes
 	stats.PendingRootRuns = bufferedIndexedRootRunCount(domain)
 	stats.PendingIndexedFlushUnits = len(domain.indexedPublishingUnits) + len(domain.indexedFlushUnits)
+	stats.UpdateBatchIndexStatsCount = len(domain.meta.Indexes)
+	if stats.UpdateBatchIndexStatsCount > len(stats.UpdateBatchIndexStats) {
+		stats.UpdateBatchIndexStatsCount = len(stats.UpdateBatchIndexStats)
+	}
+	for i := 0; i < stats.UpdateBatchIndexStatsCount; i++ {
+		stats.UpdateBatchIndexStats[i].IndexName = domain.meta.Indexes[i].Name
+		stats.UpdateBatchIndexStats[i].Unique = domain.meta.Indexes[i].Unique
+	}
 	domain.mu.RUnlock()
 	if domain.indexedAsyncFlushRunning() {
 		stats.IndexedAsyncFlushRunning = 1
@@ -1160,11 +1173,24 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateBatchIndexValueUnchanged = domain.updateBatchIndexValueUnchanged.Load()
 	stats.UpdateBatchUniqueChecks = domain.updateBatchUniqueChecks.Load()
 	stats.UpdateBatchUniqueCheckSkips = domain.updateBatchUniqueCheckSkips.Load()
-	domain.updateBatchIndexStatsMu.Lock()
-	stats.UpdateBatchIndexStatsCount = domain.updateBatchIndexStatsCount
-	stats.UpdateBatchIndexStats = domain.updateBatchIndexStats
-	domain.updateBatchIndexStatsMu.Unlock()
+	for i := 0; i < stats.UpdateBatchIndexStatsCount; i++ {
+		stats.UpdateBatchIndexStats[i].Changed = collectionStatsUint64ToInt(domain.updateBatchIndexChanged[i].Load())
+		stats.UpdateBatchIndexStats[i].Unchanged = collectionStatsUint64ToInt(domain.updateBatchIndexUnchanged[i].Load())
+		stats.UpdateBatchIndexStats[i].UniqueChecks = collectionStatsUint64ToInt(domain.updateBatchIndexUniqueChecks[i].Load())
+		stats.UpdateBatchIndexStats[i].UniqueCheckSkips = collectionStatsUint64ToInt(domain.updateBatchIndexUniqueSkips[i].Load())
+		stats.UpdateBatchIndexStats[i].SecondaryRuns = collectionStatsUint64ToInt(domain.updateBatchIndexSecondaryRuns[i].Load())
+		stats.UpdateBatchIndexStats[i].SecondaryDeletes = collectionStatsUint64ToInt(domain.updateBatchIndexSecondaryDeletes[i].Load())
+		stats.UpdateBatchIndexStats[i].SecondarySets = collectionStatsUint64ToInt(domain.updateBatchIndexSecondarySets[i].Load())
+		stats.UpdateBatchIndexStats[i].SecondaryKeyBytes = collectionStatsUint64ToInt(domain.updateBatchIndexSecondaryBytes[i].Load())
+	}
 	return stats
+}
+
+func collectionStatsUint64ToInt(v uint64) int {
+	if v > uint64(maxCollectionInt) {
+		return maxCollectionInt
+	}
+	return int(v)
 }
 
 func durationFromAtomicNs(ns uint64) time.Duration {
@@ -1268,12 +1294,25 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 		domain.updateBatchUniqueCheckSkips.Add(uint64(stats.UniqueIndexCheckSkips))
 	}
 	if stats.IndexStatsCount > 0 {
-		domain.updateBatchIndexStatsMu.Lock()
 		for i := 0; i < stats.IndexStatsCount && i < len(stats.IndexStats); i++ {
-			mergeCollectionUpdateIndexStat(&domain.updateBatchIndexStats, &domain.updateBatchIndexStatsCount, stats.IndexStats[i])
+			indexStats := stats.IndexStats[i]
+			atomicAddNonNegativeInt(&domain.updateBatchIndexChanged[i], indexStats.Changed)
+			atomicAddNonNegativeInt(&domain.updateBatchIndexUnchanged[i], indexStats.Unchanged)
+			atomicAddNonNegativeInt(&domain.updateBatchIndexUniqueChecks[i], indexStats.UniqueChecks)
+			atomicAddNonNegativeInt(&domain.updateBatchIndexUniqueSkips[i], indexStats.UniqueCheckSkips)
+			atomicAddNonNegativeInt(&domain.updateBatchIndexSecondaryRuns[i], indexStats.SecondaryRuns)
+			atomicAddNonNegativeInt(&domain.updateBatchIndexSecondaryDeletes[i], indexStats.SecondaryDeletes)
+			atomicAddNonNegativeInt(&domain.updateBatchIndexSecondarySets[i], indexStats.SecondarySets)
+			atomicAddNonNegativeInt(&domain.updateBatchIndexSecondaryBytes[i], indexStats.SecondaryKeyBytes)
 		}
-		domain.updateBatchIndexStatsMu.Unlock()
 	}
+}
+
+func atomicAddNonNegativeInt(counter *atomic.Uint64, n int) {
+	if counter == nil || n <= 0 {
+		return
+	}
+	counter.Add(uint64(n))
 }
 
 func mergeCollectionUpdateIndexStat(dst *[maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats, dstCount *int, src CollectionUpdateIndexStats) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -442,6 +442,8 @@ type CollectionManagerStats struct {
 	UpdateBatchIndexValueUnchanged uint64
 	UpdateBatchUniqueChecks        uint64
 	UpdateBatchUniqueCheckSkips    uint64
+	UpdateBatchIndexStatsCount     int
+	UpdateBatchIndexStats          [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats
 }
 
 // DocumentRecord is one primary collection record returned by ScanDocuments.
@@ -729,6 +731,9 @@ type collectionWriteDomain struct {
 	updateBatchUniqueChecks          atomic.Uint64
 	updateBatchUniqueCheckSkips      atomic.Uint64
 	updateBatchDetailedStats         atomic.Bool
+	updateBatchIndexStatsMu          sync.Mutex
+	updateBatchIndexStatsCount       int
+	updateBatchIndexStats            [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats
 }
 
 func NewCollectionManager(database *backenddb.DB) *CollectionManager {
@@ -940,6 +945,50 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_batch.index_value_unchanged_total"] = fmt.Sprintf("%d", stats.UpdateBatchIndexValueUnchanged)
 	out["treedb.collections.write_domain.update_batch.unique_checks_total"] = fmt.Sprintf("%d", stats.UpdateBatchUniqueChecks)
 	out["treedb.collections.write_domain.update_batch.unique_check_skips_total"] = fmt.Sprintf("%d", stats.UpdateBatchUniqueCheckSkips)
+	for i := 0; i < stats.UpdateBatchIndexStatsCount && i < len(stats.UpdateBatchIndexStats); i++ {
+		indexStats := stats.UpdateBatchIndexStats[i]
+		if indexStats.IndexName == "" {
+			continue
+		}
+		prefix := "treedb.collections.write_domain.update_batch.index." + collectionStatsMetricToken(indexStats.IndexName) + "."
+		if indexStats.Unique {
+			out[prefix+"unique"] = "1"
+		} else {
+			out[prefix+"unique"] = "0"
+		}
+		out[prefix+"changed_total"] = fmt.Sprintf("%d", indexStats.Changed)
+		out[prefix+"unchanged_total"] = fmt.Sprintf("%d", indexStats.Unchanged)
+		out[prefix+"unique_checks_total"] = fmt.Sprintf("%d", indexStats.UniqueChecks)
+		out[prefix+"unique_check_skips_total"] = fmt.Sprintf("%d", indexStats.UniqueCheckSkips)
+		out[prefix+"secondary_runs_total"] = fmt.Sprintf("%d", indexStats.SecondaryRuns)
+		out[prefix+"secondary_deletes_total"] = fmt.Sprintf("%d", indexStats.SecondaryDeletes)
+		out[prefix+"secondary_sets_total"] = fmt.Sprintf("%d", indexStats.SecondarySets)
+		out[prefix+"secondary_key_bytes_total"] = fmt.Sprintf("%d", indexStats.SecondaryKeyBytes)
+	}
+	return out
+}
+
+func collectionStatsMetricToken(name string) string {
+	name = strings.TrimSpace(strings.ToLower(name))
+	var builder strings.Builder
+	builder.Grow(len(name))
+	lastUnderscore := false
+	for _, r := range name {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			builder.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			builder.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	out := strings.Trim(builder.String(), "_")
+	if out == "" {
+		return "unnamed"
+	}
 	return out
 }
 
@@ -1034,6 +1083,9 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.UpdateBatchIndexValueUnchanged += other.UpdateBatchIndexValueUnchanged
 	s.UpdateBatchUniqueChecks += other.UpdateBatchUniqueChecks
 	s.UpdateBatchUniqueCheckSkips += other.UpdateBatchUniqueCheckSkips
+	for i := 0; i < other.UpdateBatchIndexStatsCount && i < len(other.UpdateBatchIndexStats); i++ {
+		mergeCollectionUpdateIndexStat(&s.UpdateBatchIndexStats, &s.UpdateBatchIndexStatsCount, other.UpdateBatchIndexStats[i])
+	}
 }
 
 func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
@@ -1108,6 +1160,10 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateBatchIndexValueUnchanged = domain.updateBatchIndexValueUnchanged.Load()
 	stats.UpdateBatchUniqueChecks = domain.updateBatchUniqueChecks.Load()
 	stats.UpdateBatchUniqueCheckSkips = domain.updateBatchUniqueCheckSkips.Load()
+	domain.updateBatchIndexStatsMu.Lock()
+	stats.UpdateBatchIndexStatsCount = domain.updateBatchIndexStatsCount
+	stats.UpdateBatchIndexStats = domain.updateBatchIndexStats
+	domain.updateBatchIndexStatsMu.Unlock()
 	return stats
 }
 
@@ -1211,6 +1267,38 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 	if stats.UniqueIndexCheckSkips > 0 {
 		domain.updateBatchUniqueCheckSkips.Add(uint64(stats.UniqueIndexCheckSkips))
 	}
+	if stats.IndexStatsCount > 0 {
+		domain.updateBatchIndexStatsMu.Lock()
+		for i := 0; i < stats.IndexStatsCount && i < len(stats.IndexStats); i++ {
+			mergeCollectionUpdateIndexStat(&domain.updateBatchIndexStats, &domain.updateBatchIndexStatsCount, stats.IndexStats[i])
+		}
+		domain.updateBatchIndexStatsMu.Unlock()
+	}
+}
+
+func mergeCollectionUpdateIndexStat(dst *[maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats, dstCount *int, src CollectionUpdateIndexStats) {
+	if dst == nil || dstCount == nil || src.IndexName == "" {
+		return
+	}
+	for i := 0; i < *dstCount && i < len(dst); i++ {
+		if dst[i].IndexName == src.IndexName {
+			dst[i].Unique = src.Unique
+			dst[i].Changed = saturatingAddNonNegativeInt(dst[i].Changed, src.Changed)
+			dst[i].Unchanged = saturatingAddNonNegativeInt(dst[i].Unchanged, src.Unchanged)
+			dst[i].UniqueChecks = saturatingAddNonNegativeInt(dst[i].UniqueChecks, src.UniqueChecks)
+			dst[i].UniqueCheckSkips = saturatingAddNonNegativeInt(dst[i].UniqueCheckSkips, src.UniqueCheckSkips)
+			dst[i].SecondaryRuns = saturatingAddNonNegativeInt(dst[i].SecondaryRuns, src.SecondaryRuns)
+			dst[i].SecondaryDeletes = saturatingAddNonNegativeInt(dst[i].SecondaryDeletes, src.SecondaryDeletes)
+			dst[i].SecondarySets = saturatingAddNonNegativeInt(dst[i].SecondarySets, src.SecondarySets)
+			dst[i].SecondaryKeyBytes = saturatingAddNonNegativeInt(dst[i].SecondaryKeyBytes, src.SecondaryKeyBytes)
+			return
+		}
+	}
+	if *dstCount >= len(dst) {
+		return
+	}
+	dst[*dstCount] = src
+	*dstCount = *dstCount + 1
 }
 
 func collectionUpdateStatsHasBufferStageBreakdown(stats CollectionUpdateStats) bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -356,7 +356,9 @@ type CollectionUpdateSecondaryRunStats struct {
 // an UpdateBatch-style call. Changed/unchanged are counted per modified
 // document for each cached index runtime.
 type CollectionUpdateIndexStats struct {
+	CollectionName    string
 	IndexName         string
+	IndexOrdinal      int
 	Unique            bool
 	Changed           int
 	Unchanged         int
@@ -955,7 +957,12 @@ func (m *CollectionManager) Stats() map[string]string {
 		if indexStats.IndexName == "" {
 			continue
 		}
-		prefix := "treedb.collections.write_domain.update_batch.index." + collectionStatsMetricToken(indexStats.IndexName) + "."
+		prefix := fmt.Sprintf(
+			"treedb.collections.write_domain.update_batch.collection.%s.index.%d.%s.",
+			collectionStatsMetricToken(indexStats.CollectionName),
+			indexStats.IndexOrdinal,
+			collectionStatsMetricToken(indexStats.IndexName),
+		)
 		if indexStats.Unique {
 			out[prefix+"unique"] = "1"
 		} else {
@@ -974,7 +981,8 @@ func (m *CollectionManager) Stats() map[string]string {
 }
 
 func collectionStatsMetricToken(name string) string {
-	name = strings.TrimSpace(strings.ToLower(name))
+	original := strings.TrimSpace(name)
+	name = strings.ToLower(original)
 	var builder strings.Builder
 	builder.Grow(len(name))
 	lastUnderscore := false
@@ -994,7 +1002,7 @@ func collectionStatsMetricToken(name string) string {
 	if out == "" {
 		return "unnamed"
 	}
-	return out
+	return fmt.Sprintf("%s_%016x", out, xxhash.Sum64String(original))
 }
 
 // StatsSnapshot returns aggregate process-local collection write-domain
@@ -1003,19 +1011,26 @@ func (m *CollectionManager) StatsSnapshot() CollectionManagerStats {
 	if m == nil {
 		return CollectionManagerStats{}
 	}
+	type domainTarget struct {
+		name   string
+		domain *collectionWriteDomain
+	}
 	m.domainMu.RLock()
-	domains := make([]*collectionWriteDomain, 0, len(m.domains))
-	for _, domain := range m.domains {
+	domains := make([]domainTarget, 0, len(m.domains))
+	for name, domain := range m.domains {
 		if domain != nil {
-			domains = append(domains, domain)
+			domains = append(domains, domainTarget{name: name, domain: domain})
 		}
 	}
 	m.domainMu.RUnlock()
+	sort.Slice(domains, func(i, j int) bool {
+		return domains[i].name < domains[j].name
+	})
 
 	var stats CollectionManagerStats
 	stats.Domains = len(domains)
-	for _, domain := range domains {
-		stats.add(domain.statsSnapshot())
+	for _, target := range domains {
+		stats.add(target.domain.statsSnapshot())
 	}
 	return stats
 }
@@ -1108,7 +1123,9 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 		stats.UpdateBatchIndexStatsCount = len(stats.UpdateBatchIndexStats)
 	}
 	for i := 0; i < stats.UpdateBatchIndexStatsCount; i++ {
+		stats.UpdateBatchIndexStats[i].CollectionName = domain.meta.Name
 		stats.UpdateBatchIndexStats[i].IndexName = domain.meta.Indexes[i].Name
+		stats.UpdateBatchIndexStats[i].IndexOrdinal = i
 		stats.UpdateBatchIndexStats[i].Unique = domain.meta.Indexes[i].Unique
 	}
 	domain.mu.RUnlock()
@@ -1320,7 +1337,7 @@ func mergeCollectionUpdateIndexStat(dst *[maxCollectionUpdateInlineIndexStats]Co
 		return
 	}
 	for i := 0; i < *dstCount && i < len(dst); i++ {
-		if dst[i].IndexName == src.IndexName {
+		if sameCollectionUpdateIndexStat(dst[i], src) {
 			dst[i].Unique = src.Unique
 			dst[i].Changed = saturatingAddNonNegativeInt(dst[i].Changed, src.Changed)
 			dst[i].Unchanged = saturatingAddNonNegativeInt(dst[i].Unchanged, src.Unchanged)
@@ -1338,6 +1355,12 @@ func mergeCollectionUpdateIndexStat(dst *[maxCollectionUpdateInlineIndexStats]Co
 	}
 	dst[*dstCount] = src
 	*dstCount = *dstCount + 1
+}
+
+func sameCollectionUpdateIndexStat(a, b CollectionUpdateIndexStats) bool {
+	return a.CollectionName == b.CollectionName &&
+		a.IndexOrdinal == b.IndexOrdinal &&
+		a.IndexName == b.IndexName
 }
 
 func collectionUpdateStatsHasBufferStageBreakdown(stats CollectionUpdateStats) bool {
@@ -7329,8 +7352,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		stats.IndexStatsCount = len(runtimes)
 		for i, runtime := range runtimes {
 			stats.IndexStats[i] = CollectionUpdateIndexStats{
-				IndexName: runtime.def.name,
-				Unique:    runtime.def.unique,
+				CollectionName: meta.Name,
+				IndexName:      runtime.def.name,
+				IndexOrdinal:   i,
+				Unique:         runtime.def.unique,
 			}
 		}
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -812,7 +812,7 @@ func TestCollectionUpdateIndexStatsSnapshotAndExport(t *testing.T) {
 		},
 	}
 	domain := &collectionWriteDomain{
-		meta: CollectionMeta{Indexes: []IndexDefinition{
+		meta: CollectionMeta{Name: "users", Indexes: []IndexDefinition{
 			{Name: "email", Unique: true},
 			{Name: "city/name"},
 		}},
@@ -836,11 +836,11 @@ func TestCollectionUpdateIndexStatsSnapshotAndExport(t *testing.T) {
 	}
 	stats := snapshot.UpdateBatchIndexStats[:snapshot.UpdateBatchIndexStatsCount]
 	email := indexStatByName(stats, "email")
-	if !email.Unique || email.Unchanged != 2 || email.UniqueCheckSkips != 2 {
+	if email.CollectionName != "users" || email.IndexOrdinal != 0 || !email.Unique || email.Unchanged != 2 || email.UniqueCheckSkips != 2 {
 		t.Fatalf("email aggregate=%+v want unchanged/skips 2", email)
 	}
 	city := indexStatByName(stats, "city/name")
-	if city.Changed != 4 || city.SecondaryRuns != 4 || city.SecondaryDeletes != 4 || city.SecondarySets != 4 || city.SecondaryKeyBytes != 256 {
+	if city.CollectionName != "users" || city.IndexOrdinal != 1 || city.Changed != 4 || city.SecondaryRuns != 4 || city.SecondaryDeletes != 4 || city.SecondarySets != 4 || city.SecondaryKeyBytes != 256 {
 		t.Fatalf("city aggregate=%+v want doubled secondary work", city)
 	}
 
@@ -852,20 +852,103 @@ func TestCollectionUpdateIndexStatsSnapshotAndExport(t *testing.T) {
 	}
 
 	exported := (&CollectionManager{domains: map[string]*collectionWriteDomain{"test": domain}}).Stats()
-	if got, want := exported["treedb.collections.write_domain.update_batch.index.email.unique"], "1"; got != want {
+	emailPrefix := "treedb.collections.write_domain.update_batch.collection." + collectionStatsMetricToken("users") + ".index.0." + collectionStatsMetricToken("email") + "."
+	cityPrefix := "treedb.collections.write_domain.update_batch.collection." + collectionStatsMetricToken("users") + ".index.1." + collectionStatsMetricToken("city/name") + "."
+	if got, want := exported[emailPrefix+"unique"], "1"; got != want {
 		t.Fatalf("exported email unique=%q want %q", got, want)
 	}
-	if got, want := exported["treedb.collections.write_domain.update_batch.index.email.unchanged_total"], "2"; got != want {
+	if got, want := exported[emailPrefix+"unchanged_total"], "2"; got != want {
 		t.Fatalf("exported email unchanged=%q want %q", got, want)
 	}
-	if got, want := exported["treedb.collections.write_domain.update_batch.index.email.unique_check_skips_total"], "2"; got != want {
+	if got, want := exported[emailPrefix+"unique_check_skips_total"], "2"; got != want {
 		t.Fatalf("exported email skips=%q want %q", got, want)
 	}
-	if got, want := exported["treedb.collections.write_domain.update_batch.index.city_name.changed_total"], "4"; got != want {
+	if got, want := exported[cityPrefix+"changed_total"], "4"; got != want {
 		t.Fatalf("exported city changed=%q want %q", got, want)
 	}
-	if got, want := exported["treedb.collections.write_domain.update_batch.index.city_name.secondary_key_bytes_total"], "256"; got != want {
+	if got, want := exported[cityPrefix+"secondary_key_bytes_total"], "256"; got != want {
 		t.Fatalf("exported city key bytes=%q want %q", got, want)
+	}
+}
+
+func TestCollectionUpdateIndexStatsDoNotMergeOverlappingIndexNames(t *testing.T) {
+	newDomain := func(collection string, changed int) *collectionWriteDomain {
+		domain := &collectionWriteDomain{
+			meta: CollectionMeta{
+				Name:    collection,
+				Indexes: []IndexDefinition{{Name: "email", Unique: true}},
+			},
+		}
+		domain.observeUpdateBatchStats(CollectionUpdateStats{
+			IndexStatsCount: 1,
+			IndexStats: [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats{
+				{CollectionName: collection, IndexName: "email", IndexOrdinal: 0, Unique: true, Changed: changed},
+			},
+		})
+		return domain
+	}
+	mgr := &CollectionManager{domains: map[string]*collectionWriteDomain{
+		"users":  newDomain("users", 1),
+		"orders": newDomain("orders", 2),
+	}}
+	stats := mgr.StatsSnapshot()
+	indexStat := func(collection, index string) CollectionUpdateIndexStats {
+		t.Helper()
+		for _, stat := range stats.UpdateBatchIndexStats[:stats.UpdateBatchIndexStatsCount] {
+			if stat.CollectionName == collection && stat.IndexName == index {
+				return stat
+			}
+		}
+		t.Fatalf("missing %s/%s in %+v", collection, index, stats.UpdateBatchIndexStats)
+		return CollectionUpdateIndexStats{}
+	}
+	if got := indexStat("users", "email").Changed; got != 1 {
+		t.Fatalf("users/email changed=%d want 1", got)
+	}
+	if got := indexStat("orders", "email").Changed; got != 2 {
+		t.Fatalf("orders/email changed=%d want 2", got)
+	}
+
+	exported := mgr.Stats()
+	usersPrefix := "treedb.collections.write_domain.update_batch.collection." + collectionStatsMetricToken("users") + ".index.0." + collectionStatsMetricToken("email") + "."
+	ordersPrefix := "treedb.collections.write_domain.update_batch.collection." + collectionStatsMetricToken("orders") + ".index.0." + collectionStatsMetricToken("email") + "."
+	if usersPrefix == ordersPrefix {
+		t.Fatalf("collection-qualified prefixes collided: %q", usersPrefix)
+	}
+	if got, want := exported[usersPrefix+"changed_total"], "1"; got != want {
+		t.Fatalf("users exported changed=%q want %q", got, want)
+	}
+	if got, want := exported[ordersPrefix+"changed_total"], "2"; got != want {
+		t.Fatalf("orders exported changed=%q want %q", got, want)
+	}
+}
+
+func TestCollectionUpdateIndexStatsSnapshotCapsAtInlineIndexLimit(t *testing.T) {
+	indexes := make([]IndexDefinition, maxCollectionUpdateInlineIndexStats+1)
+	for i := range indexes {
+		indexes[i] = IndexDefinition{Name: fmt.Sprintf("idx_%02d", i)}
+	}
+	domain := &collectionWriteDomain{
+		meta: CollectionMeta{Name: "wide", Indexes: indexes},
+	}
+	var updateStats CollectionUpdateStats
+	updateStats.IndexStatsCount = maxCollectionUpdateInlineIndexStats
+	for i := 0; i < maxCollectionUpdateInlineIndexStats; i++ {
+		updateStats.IndexStats[i] = CollectionUpdateIndexStats{
+			CollectionName: "wide",
+			IndexName:      indexes[i].Name,
+			IndexOrdinal:   i,
+			Changed:        i + 1,
+		}
+	}
+	domain.observeUpdateBatchStats(updateStats)
+	stats := domain.statsSnapshot()
+	if got, want := stats.UpdateBatchIndexStatsCount, maxCollectionUpdateInlineIndexStats; got != want {
+		t.Fatalf("index stats count=%d want cap %d", got, want)
+	}
+	last := stats.UpdateBatchIndexStats[maxCollectionUpdateInlineIndexStats-1]
+	if got, want := last.IndexName, indexes[maxCollectionUpdateInlineIndexStats-1].Name; got != want {
+		t.Fatalf("last retained index=%q want %q", got, want)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -791,6 +791,79 @@ func TestCollectionUpdateBufferBreakdownStatsSnapshotAndAdd(t *testing.T) {
 	}
 }
 
+func TestCollectionUpdateIndexStatsSnapshotAndExport(t *testing.T) {
+	updateStats := CollectionUpdateStats{
+		IndexStatsCount: 2,
+		IndexStats: [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats{
+			{
+				IndexName:        "email",
+				Unique:           true,
+				Unchanged:        1,
+				UniqueCheckSkips: 1,
+			},
+			{
+				IndexName:         "city/name",
+				Changed:           2,
+				SecondaryRuns:     2,
+				SecondaryDeletes:  2,
+				SecondarySets:     2,
+				SecondaryKeyBytes: 128,
+			},
+		},
+	}
+	domain := &collectionWriteDomain{}
+	domain.observeUpdateBatchStats(updateStats)
+	domain.observeUpdateBatchStats(updateStats)
+
+	snapshot := domain.statsSnapshot()
+	if got, want := snapshot.UpdateBatchIndexStatsCount, 2; got != want {
+		t.Fatalf("snapshot index stats count=%d want %d", got, want)
+	}
+	indexStatByName := func(stats []CollectionUpdateIndexStats, name string) CollectionUpdateIndexStats {
+		t.Helper()
+		for _, stat := range stats {
+			if stat.IndexName == name {
+				return stat
+			}
+		}
+		t.Fatalf("missing index stat %q in %+v", name, stats)
+		return CollectionUpdateIndexStats{}
+	}
+	stats := snapshot.UpdateBatchIndexStats[:snapshot.UpdateBatchIndexStatsCount]
+	email := indexStatByName(stats, "email")
+	if !email.Unique || email.Unchanged != 2 || email.UniqueCheckSkips != 2 {
+		t.Fatalf("email aggregate=%+v want unchanged/skips 2", email)
+	}
+	city := indexStatByName(stats, "city/name")
+	if city.Changed != 4 || city.SecondaryRuns != 4 || city.SecondaryDeletes != 4 || city.SecondarySets != 4 || city.SecondaryKeyBytes != 256 {
+		t.Fatalf("city aggregate=%+v want doubled secondary work", city)
+	}
+
+	var merged CollectionManagerStats
+	merged.add(snapshot)
+	mergedStats := merged.UpdateBatchIndexStats[:merged.UpdateBatchIndexStatsCount]
+	if got := indexStatByName(mergedStats, "city/name").SecondaryKeyBytes; got != 256 {
+		t.Fatalf("merged city key bytes=%d want 256", got)
+	}
+
+	exported := (&CollectionManager{domains: map[string]*collectionWriteDomain{"test": domain}}).Stats()
+	if got, want := exported["treedb.collections.write_domain.update_batch.index.email.unique"], "1"; got != want {
+		t.Fatalf("exported email unique=%q want %q", got, want)
+	}
+	if got, want := exported["treedb.collections.write_domain.update_batch.index.email.unchanged_total"], "2"; got != want {
+		t.Fatalf("exported email unchanged=%q want %q", got, want)
+	}
+	if got, want := exported["treedb.collections.write_domain.update_batch.index.email.unique_check_skips_total"], "2"; got != want {
+		t.Fatalf("exported email skips=%q want %q", got, want)
+	}
+	if got, want := exported["treedb.collections.write_domain.update_batch.index.city_name.changed_total"], "4"; got != want {
+		t.Fatalf("exported city changed=%q want %q", got, want)
+	}
+	if got, want := exported["treedb.collections.write_domain.update_batch.index.city_name.secondary_key_bytes_total"], "256"; got != want {
+		t.Fatalf("exported city key bytes=%q want %q", got, want)
+	}
+}
+
 func TestUpdateBatchPlanUniqueSecondaryIndexByRootAvoidsMapAllocation(t *testing.T) {
 	meta := CollectionMeta{
 		Name: "users",

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -811,7 +811,12 @@ func TestCollectionUpdateIndexStatsSnapshotAndExport(t *testing.T) {
 			},
 		},
 	}
-	domain := &collectionWriteDomain{}
+	domain := &collectionWriteDomain{
+		meta: CollectionMeta{Indexes: []IndexDefinition{
+			{Name: "email", Unique: true},
+			{Name: "city/name"},
+		}},
+	}
 	domain.observeUpdateBatchStats(updateStats)
 	domain.observeUpdateBatchStats(updateStats)
 

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -527,10 +527,11 @@ The benchmark shapes are intentionally different:
   `update_index_value_changes/doc`, `update_index_value_unchanged/doc`,
   `update_unique_checks/doc`, `update_unique_check_skips/doc`,
   per-index changed-delta metrics such as
-  `update_index_city_1_changed/doc`,
-  `update_index_city_1_secondary_runs/doc`,
-  `update_index_email_1_unchanged/doc`, and
-  `update_index_email_1_unique_check_skips/doc`,
+  `update_collection_bench.docs_index_1_city_1_changed/doc`,
+  `update_collection_bench.docs_index_1_city_1_secondary_runs/doc`,
+  `update_collection_bench.docs_index_2_email_1_unchanged/doc`, and
+  `update_collection_bench.docs_index_2_email_1_unique_check_skips/doc`
+  for collections with at most eight index runtimes,
   `update_buffer_stage_ns/doc`, buffer-stage submetrics such as
   `update_buffer_precheck_ns/doc`, `update_buffer_lock_wait_ns/doc`,
   `update_buffer_lock_hold_ns/doc`, `update_buffer_validation_ns/doc`,

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -526,6 +526,11 @@ The benchmark shapes are intentionally different:
   `update_primary_run_ns/doc`, `update_secondary_runs_ns/doc`,
   `update_index_value_changes/doc`, `update_index_value_unchanged/doc`,
   `update_unique_checks/doc`, `update_unique_check_skips/doc`,
+  per-index changed-delta metrics such as
+  `update_index_city_1_changed/doc`,
+  `update_index_city_1_secondary_runs/doc`,
+  `update_index_email_1_unchanged/doc`, and
+  `update_index_email_1_unique_check_skips/doc`,
   `update_buffer_stage_ns/doc`, buffer-stage submetrics such as
   `update_buffer_precheck_ns/doc`, `update_buffer_lock_wait_ns/doc`,
   `update_buffer_lock_hold_ns/doc`, `update_buffer_validation_ns/doc`,

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -976,7 +976,7 @@ func reportProfileBenchOrderedRootPublishStats(b *testing.B, after, before map[s
 }
 
 func deltaCollectionManagerUpdateStats(after, before collections.CollectionManagerStats) collections.CollectionManagerStats {
-	return collections.CollectionManagerStats{
+	delta := collections.CollectionManagerStats{
 		UpdateBatchCalls:               after.UpdateBatchCalls - before.UpdateBatchCalls,
 		UpdateBatchItems:               after.UpdateBatchItems - before.UpdateBatchItems,
 		UpdateBatchMatched:             after.UpdateBatchMatched - before.UpdateBatchMatched,
@@ -1016,6 +1016,36 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateCombineBatchedRequests:   after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
 		UpdateCombineFallbackRequests:  after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
 	}
+	for i := 0; i < after.UpdateBatchIndexStatsCount && i < len(after.UpdateBatchIndexStats); i++ {
+		next := after.UpdateBatchIndexStats[i]
+		if next.IndexName == "" {
+			continue
+		}
+		if previous, ok := collectionManagerUpdateIndexStatByName(before, next.IndexName); ok {
+			next.Changed -= previous.Changed
+			next.Unchanged -= previous.Unchanged
+			next.UniqueChecks -= previous.UniqueChecks
+			next.UniqueCheckSkips -= previous.UniqueCheckSkips
+			next.SecondaryRuns -= previous.SecondaryRuns
+			next.SecondaryDeletes -= previous.SecondaryDeletes
+			next.SecondarySets -= previous.SecondarySets
+			next.SecondaryKeyBytes -= previous.SecondaryKeyBytes
+		}
+		if delta.UpdateBatchIndexStatsCount < len(delta.UpdateBatchIndexStats) {
+			delta.UpdateBatchIndexStats[delta.UpdateBatchIndexStatsCount] = next
+			delta.UpdateBatchIndexStatsCount++
+		}
+	}
+	return delta
+}
+
+func collectionManagerUpdateIndexStatByName(stats collections.CollectionManagerStats, name string) (collections.CollectionUpdateIndexStats, bool) {
+	for i := 0; i < stats.UpdateBatchIndexStatsCount && i < len(stats.UpdateBatchIndexStats); i++ {
+		if stats.UpdateBatchIndexStats[i].IndexName == name {
+			return stats.UpdateBatchIndexStats[i], true
+		}
+	}
+	return collections.CollectionUpdateIndexStats{}, false
 }
 
 func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
@@ -1028,6 +1058,11 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateBatchIndexValueUnchanged: 30,
 		UpdateBatchUniqueChecks:        4,
 		UpdateBatchUniqueCheckSkips:    10,
+		UpdateBatchIndexStatsCount:     2,
+		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
+			{IndexName: "email", Unique: true, Changed: 1, Unchanged: 9, UniqueChecks: 1, UniqueCheckSkips: 8},
+			{IndexName: "city", Changed: 10, SecondaryRuns: 10, SecondaryDeletes: 10, SecondarySets: 10, SecondaryKeyBytes: 1000},
+		},
 	}
 	after := collections.CollectionManagerStats{
 		UpdateCombineRequests:          17,
@@ -1038,6 +1073,11 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateBatchIndexValueUnchanged: 43,
 		UpdateBatchUniqueChecks:        6,
 		UpdateBatchUniqueCheckSkips:    19,
+		UpdateBatchIndexStatsCount:     2,
+		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
+			{IndexName: "email", Unique: true, Changed: 1, Unchanged: 22, UniqueChecks: 1, UniqueCheckSkips: 17},
+			{IndexName: "city", Changed: 17, SecondaryRuns: 17, SecondaryDeletes: 17, SecondarySets: 17, SecondaryKeyBytes: 1700},
+		},
 	}
 	got := deltaCollectionManagerUpdateStats(after, before)
 	if got.UpdateCombineRequests != 7 {
@@ -1063,6 +1103,23 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	}
 	if got.UpdateBatchUniqueCheckSkips != 9 {
 		t.Fatalf("UpdateBatchUniqueCheckSkips=%d want 9", got.UpdateBatchUniqueCheckSkips)
+	}
+	if got.UpdateBatchIndexStatsCount != 2 {
+		t.Fatalf("UpdateBatchIndexStatsCount=%d want 2", got.UpdateBatchIndexStatsCount)
+	}
+	email, ok := collectionManagerUpdateIndexStatByName(got, "email")
+	if !ok {
+		t.Fatalf("missing email index stat in %+v", got.UpdateBatchIndexStats)
+	}
+	if !email.Unique || email.Changed != 0 || email.Unchanged != 13 || email.UniqueChecks != 0 || email.UniqueCheckSkips != 9 {
+		t.Fatalf("email delta=%+v want unchanged=13 unique_skips=9", email)
+	}
+	city, ok := collectionManagerUpdateIndexStatByName(got, "city")
+	if !ok {
+		t.Fatalf("missing city index stat in %+v", got.UpdateBatchIndexStats)
+	}
+	if city.Changed != 7 || city.SecondaryRuns != 7 || city.SecondaryDeletes != 7 || city.SecondarySets != 7 || city.SecondaryKeyBytes != 700 {
+		t.Fatalf("city delta=%+v want changed/run/delete/set/key-bytes 7/7/7/7/700", city)
 	}
 }
 
@@ -1123,6 +1180,37 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	}
 	if stats.UpdateBatchUniqueCheckSkips > 0 {
 		b.ReportMetric(float64(stats.UpdateBatchUniqueCheckSkips)/float64(docs), "update_unique_check_skips/doc")
+	}
+	for i := 0; i < stats.UpdateBatchIndexStatsCount && i < len(stats.UpdateBatchIndexStats); i++ {
+		indexStats := stats.UpdateBatchIndexStats[i]
+		if indexStats.IndexName == "" {
+			continue
+		}
+		prefix := "update_index_" + sanitizeProfileName(indexStats.IndexName) + "_"
+		if indexStats.Changed > 0 {
+			b.ReportMetric(float64(indexStats.Changed)/float64(docs), prefix+"changed/doc")
+		}
+		if indexStats.Unchanged > 0 {
+			b.ReportMetric(float64(indexStats.Unchanged)/float64(docs), prefix+"unchanged/doc")
+		}
+		if indexStats.UniqueChecks > 0 {
+			b.ReportMetric(float64(indexStats.UniqueChecks)/float64(docs), prefix+"unique_checks/doc")
+		}
+		if indexStats.UniqueCheckSkips > 0 {
+			b.ReportMetric(float64(indexStats.UniqueCheckSkips)/float64(docs), prefix+"unique_check_skips/doc")
+		}
+		if indexStats.SecondaryRuns > 0 {
+			b.ReportMetric(float64(indexStats.SecondaryRuns)/float64(docs), prefix+"secondary_runs/doc")
+		}
+		if indexStats.SecondaryDeletes > 0 {
+			b.ReportMetric(float64(indexStats.SecondaryDeletes)/float64(docs), prefix+"secondary_deletes/doc")
+		}
+		if indexStats.SecondarySets > 0 {
+			b.ReportMetric(float64(indexStats.SecondarySets)/float64(docs), prefix+"secondary_sets/doc")
+		}
+		if indexStats.SecondaryKeyBytes > 0 {
+			b.ReportMetric(float64(indexStats.SecondaryKeyBytes)/float64(docs), prefix+"secondary_key_bytes/doc")
+		}
 	}
 	reportDuration := func(name string, d time.Duration) {
 		if d > 0 {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1021,7 +1021,7 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		if next.IndexName == "" {
 			continue
 		}
-		if previous, ok := collectionManagerUpdateIndexStatByName(before, next.IndexName); ok {
+		if previous, ok := collectionManagerUpdateIndexStat(before, next); ok {
 			next.Changed -= previous.Changed
 			next.Unchanged -= previous.Unchanged
 			next.UniqueChecks -= previous.UniqueChecks
@@ -1048,6 +1048,18 @@ func collectionManagerUpdateIndexStatByName(stats collections.CollectionManagerS
 	return collections.CollectionUpdateIndexStats{}, false
 }
 
+func collectionManagerUpdateIndexStat(stats collections.CollectionManagerStats, target collections.CollectionUpdateIndexStats) (collections.CollectionUpdateIndexStats, bool) {
+	for i := 0; i < stats.UpdateBatchIndexStatsCount && i < len(stats.UpdateBatchIndexStats); i++ {
+		candidate := stats.UpdateBatchIndexStats[i]
+		if candidate.CollectionName == target.CollectionName &&
+			candidate.IndexOrdinal == target.IndexOrdinal &&
+			candidate.IndexName == target.IndexName {
+			return candidate, true
+		}
+	}
+	return collections.CollectionUpdateIndexStats{}, false
+}
+
 func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	before := collections.CollectionManagerStats{
 		UpdateCombineRequests:          10,
@@ -1060,8 +1072,8 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateBatchUniqueCheckSkips:    10,
 		UpdateBatchIndexStatsCount:     2,
 		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
-			{IndexName: "email", Unique: true, Changed: 1, Unchanged: 9, UniqueChecks: 1, UniqueCheckSkips: 8},
-			{IndexName: "city", Changed: 10, SecondaryRuns: 10, SecondaryDeletes: 10, SecondarySets: 10, SecondaryKeyBytes: 1000},
+			{CollectionName: "users", IndexName: "email", IndexOrdinal: 0, Unique: true, Changed: 1, Unchanged: 9, UniqueChecks: 1, UniqueCheckSkips: 8},
+			{CollectionName: "users", IndexName: "city", IndexOrdinal: 1, Changed: 10, SecondaryRuns: 10, SecondaryDeletes: 10, SecondarySets: 10, SecondaryKeyBytes: 1000},
 		},
 	}
 	after := collections.CollectionManagerStats{
@@ -1075,8 +1087,8 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateBatchUniqueCheckSkips:    19,
 		UpdateBatchIndexStatsCount:     2,
 		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
-			{IndexName: "email", Unique: true, Changed: 1, Unchanged: 22, UniqueChecks: 1, UniqueCheckSkips: 17},
-			{IndexName: "city", Changed: 17, SecondaryRuns: 17, SecondaryDeletes: 17, SecondarySets: 17, SecondaryKeyBytes: 1700},
+			{CollectionName: "users", IndexName: "email", IndexOrdinal: 0, Unique: true, Changed: 1, Unchanged: 22, UniqueChecks: 1, UniqueCheckSkips: 17},
+			{CollectionName: "users", IndexName: "city", IndexOrdinal: 1, Changed: 17, SecondaryRuns: 17, SecondaryDeletes: 17, SecondarySets: 17, SecondaryKeyBytes: 1700},
 		},
 	}
 	got := deltaCollectionManagerUpdateStats(after, before)
@@ -1186,7 +1198,8 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 		if indexStats.IndexName == "" {
 			continue
 		}
-		prefix := "update_index_" + sanitizeProfileName(indexStats.IndexName) + "_"
+		prefix := "update_collection_" + sanitizeProfileName(indexStats.CollectionName) +
+			"_index_" + strconv.Itoa(indexStats.IndexOrdinal) + "_" + sanitizeProfileName(indexStats.IndexName) + "_"
 		if indexStats.Changed > 0 {
 			b.ReportMetric(float64(indexStats.Changed)/float64(docs), prefix+"changed/doc")
 		}


### PR DESCRIPTION
## Summary

This is a focused #1159 instrumentation/guardrail PR for the per-index changed-delta track.

What changed:
- Aggregate detailed update-batch `CollectionUpdateIndexStats` into `CollectionManagerStats` with collection name, index ordinal, and index name.
- Export qualified per-index changed/unchanged, unique-check, secondary-run, secondary-delete/set, and secondary-key-byte counters through `CollectionManager.Stats()`.
- Report those per-index counters in the direct collection profile benchmark rows, for example `update_collection_bench.docs_index_1_city_1_changed/doc` and `update_collection_bench.docs_index_2_email_1_unique_check_skips/doc`.
- Document the new profile benchmark metric shape and its current inline cap of eight index runtimes.

Normal collection writes do not pay for this aggregation unless detailed update stats are enabled, matching the existing benchmark/profiling path. The aggregate counter path uses fixed per-index atomics rather than a hot mutex so concurrent profile rows are not distorted by counter serialization.

## Validation

```text
go test ./TreeDB/collections -run 'TestCollectionUpdate(IndexStatsSnapshotAndExport|IndexStatsDoNotMergeOverlappingIndexNames|IndexStatsSnapshotCapsAtInlineIndexLimit|BufferBreakdownStatsSnapshotAndAdd|BatchSkipsUnchangedSecondaryIndexes)$' -count=1
ok   github.com/snissn/gomap/TreeDB/collections 0.490s

go test ./cmd/mongo_gateway_bench -run 'TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats|TestSanitizeProfileName' -count=1
ok   github.com/snissn/gomap/cmd/mongo_gateway_bench 0.438s

go test ./TreeDB/collections -count=1
ok   github.com/snissn/gomap/TreeDB/collections 3.456s

go test ./cmd/mongo_gateway_bench -count=1
ok   github.com/snissn/gomap/cmd/mongo_gateway_bench 2.790s

git diff --check
```

## Focused Benchmark

Command:

```bash
RUN_DIR=$(mktemp -d /tmp/gomap_1159_index_counters_qualified_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=200000x \
  -benchmem \
  -count=1 | tee "$RUN_DIR/bench.txt"
```

Run dir: `/tmp/gomap_1159_index_counters_qualified_FR6heo`

Result row:

```text
200000 7736 ns/op 129264 docs/sec 7736 ns/doc 1066 B/op 6 allocs/op
update_collection_bench.docs_index_1_city_1_changed/doc=1.000
update_collection_bench.docs_index_1_city_1_secondary_runs/doc=0.07092
update_collection_bench.docs_index_1_city_1_secondary_deletes/doc=1.000
update_collection_bench.docs_index_1_city_1_secondary_sets/doc=1.000
update_collection_bench.docs_index_1_city_1_secondary_key_bytes/doc=58.80
update_collection_bench.docs_index_2_email_1_unchanged/doc=1.000
update_collection_bench.docs_index_2_email_1_unique_check_skips/doc=1.000
update_collection_bench.docs_index_0_active_1_unchanged/doc=1.000
update_roots/batch=2.000
publish_delta_group_roots/call=2.000
publish_delta_group_root_apply_ns/doc=2119
update_current_read_ns/doc=1923
```

Interpretation: this PR is attribution-only. It makes the per-index changed-delta invariant visible in the benchmark output: city-only updates do secondary work for `city_1`, report `email_1` and `active_1` as unchanged, and keep roots per update batch at primary + changed city root.

Note: an attempted focused rerun before clearing the local Go build cache failed with `no space left on device` under the Go test temp directory. After `go clean -cache -testcache` freed local cache space, the same benchmark command passed and produced the row above.
