### PR TITLE
treedb: gate outer leaf read-miss cache admission

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24105,6 +24105,12 @@ func (db *DB) Stats() map[string]string {
 		stats["treedb.process.read_path.outer_leaf.cache_potential.capacity_1024_hit_ratio"] = fmt.Sprintf("%.6f", float64(outerLeafReadStats.Recent1KHitsTotal)/float64(outerLeafReadStats.SamplesTotal))
 		stats["treedb.process.read_path.outer_leaf.cache_potential.capacity_4096_hit_ratio"] = fmt.Sprintf("%.6f", float64(outerLeafReadStats.Recent4KHitsTotal)/float64(outerLeafReadStats.SamplesTotal))
 	}
+	if _, ok := stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips"]; !ok {
+		stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips"] = "0"
+	}
+	if _, ok := stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores"]; !ok {
+		stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores"] = "0"
+	}
 	stats["treedb.process.flush_merge.shadowed_ops_total"] = fmt.Sprintf("%d", mergeShadowedOpsTotal)
 	stats["treedb.process.flush_merge.applied_ops_total"] = fmt.Sprintf("%d", mergeAppliedOpsTotal)
 	if mergeAppliedOpsTotal > 0 {

--- a/TreeDB/caching/memory_stats_test.go
+++ b/TreeDB/caching/memory_stats_test.go
@@ -105,6 +105,8 @@ func TestProcessMemoryStatsIncludeRuntimeBreakdown(t *testing.T) {
 		"treedb.process.read_path.outer_leaf.cache_potential.capacity_256_hits_total",
 		"treedb.process.read_path.outer_leaf.cache_potential.capacity_1024_hits_total",
 		"treedb.process.read_path.outer_leaf.cache_potential.capacity_4096_hits_total",
+		"treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips",
+		"treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores",
 		"treedb.process.batch.set.calls_total",
 		"treedb.process.batch.set.bytes_total",
 		"treedb.process.batch.set_view.calls_total",

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -648,6 +648,8 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.process.read_path.outer_leaf.cache.entries"] = fmt.Sprintf("%d", cacheStats.Entries)
 	stats["treedb.process.read_path.outer_leaf.cache.capacity"] = fmt.Sprintf("%d", cacheStats.Capacity)
 	stats["treedb.process.read_path.outer_leaf.cache.bytes"] = fmt.Sprintf("%d", cacheStats.Bytes)
+	stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips"] = fmt.Sprintf("%d", cacheStats.ReadMissAdmissionSkips)
+	stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores"] = fmt.Sprintf("%d", cacheStats.ReadMissAdmissionStores)
 
 	if db.valueLogManager != nil {
 		vlogRemaps, vlogDeadMappings := db.valueLogManager.RemapStats()

--- a/TreeDB/db/api_test.go
+++ b/TreeDB/db/api_test.go
@@ -308,6 +308,12 @@ func TestStatsIncludesWatermarkLagDriftMetric(t *testing.T) {
 	if _, ok := stats["treedb.process.read_path.outer_leaf.cache_potential.capacity_1024_hits_total"]; !ok {
 		t.Fatalf("missing treedb.process.read_path.outer_leaf.cache_potential.capacity_1024_hits_total")
 	}
+	if _, ok := stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips"]; !ok {
+		t.Fatalf("missing treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips")
+	}
+	if _, ok := stats["treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores"]; !ok {
+		t.Fatalf("missing treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores")
+	}
 }
 
 func TestIteratorOptions_SnapshotCompatibility(t *testing.T) {

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -73,10 +73,12 @@ func newLeafPageReadCacheKey(ptr page.LeafLogPtr) leafPageReadCacheKey {
 }
 
 type leafPageReadCacheSlot struct {
-	mu    sync.RWMutex
-	key   leafPageReadCacheKey
-	data  []byte
-	valid bool
+	mu                     sync.RWMutex
+	key                    leafPageReadCacheKey
+	data                   []byte
+	valid                  bool
+	readMissCandidate      leafPageReadCacheKey
+	readMissCandidateValid bool
 }
 
 type leafPageReadCache struct {
@@ -87,16 +89,21 @@ type leafPageReadCache struct {
 	stores    atomic.Uint64
 	evictions atomic.Uint64
 	entries   atomic.Uint64
+
+	readMissAdmissionSkips  atomic.Uint64
+	readMissAdmissionStores atomic.Uint64
 }
 
 type leafPageReadCacheStats struct {
-	Hits      uint64
-	Misses    uint64
-	Stores    uint64
-	Evictions uint64
-	Entries   uint64
-	Capacity  uint64
-	Bytes     uint64
+	Hits                    uint64
+	Misses                  uint64
+	Stores                  uint64
+	Evictions               uint64
+	Entries                 uint64
+	Capacity                uint64
+	Bytes                   uint64
+	ReadMissAdmissionSkips  uint64
+	ReadMissAdmissionStores uint64
 }
 
 func newLeafPageReadCache(entries int) *leafPageReadCache {
@@ -113,21 +120,66 @@ func (c *leafPageReadCache) store(ptr page.LeafLogPtr, leafPage []byte) {
 	key := newLeafPageReadCacheKey(ptr)
 	slot := &c.slots[c.slotIndex(key)]
 	slot.mu.Lock()
-	wasValid := slot.valid
-	prevKey := slot.key
-	if cap(slot.data) < page.PageSize {
-		slot.data = make([]byte, page.PageSize)
-	}
-	slot.data = slot.data[:page.PageSize]
-	copy(slot.data, leafPage)
-	slot.key = key
-	slot.valid = true
+	result := slot.storeLocked(key, leafPage)
 	slot.mu.Unlock()
+	c.recordStore(result, key)
+}
+
+// storeReadMiss admits read-miss pages only after a repeated miss to the same
+// direct-mapped slot/key. Write-side stores remain immediate; this keeps
+// one-off sparse reads from copying 4KiB pages into the cache and evicting
+// recently-written leaves that are likely to be reused during publish/apply.
+func (c *leafPageReadCache) storeReadMiss(ptr page.LeafLogPtr, leafPage []byte) {
+	if c == nil || len(c.slots) == 0 || len(leafPage) != page.PageSize {
+		return
+	}
+	key := newLeafPageReadCacheKey(ptr)
+	slot := &c.slots[c.slotIndex(key)]
+	slot.mu.Lock()
+	if slot.valid && slot.key == key {
+		slot.mu.Unlock()
+		return
+	}
+	if !slot.readMissCandidateValid || slot.readMissCandidate != key {
+		slot.readMissCandidate = key
+		slot.readMissCandidateValid = true
+		slot.mu.Unlock()
+		c.readMissAdmissionSkips.Add(1)
+		return
+	}
+	result := slot.storeLocked(key, leafPage)
+	slot.mu.Unlock()
+	c.readMissAdmissionStores.Add(1)
+	c.recordStore(result, key)
+}
+
+type leafPageReadCacheStoreResult struct {
+	wasValid bool
+	prevKey  leafPageReadCacheKey
+}
+
+func (s *leafPageReadCacheSlot) storeLocked(key leafPageReadCacheKey, leafPage []byte) leafPageReadCacheStoreResult {
+	result := leafPageReadCacheStoreResult{
+		wasValid: s.valid,
+		prevKey:  s.key,
+	}
+	if cap(s.data) < page.PageSize {
+		s.data = make([]byte, page.PageSize)
+	}
+	s.data = s.data[:page.PageSize]
+	copy(s.data, leafPage)
+	s.key = key
+	s.valid = true
+	s.readMissCandidateValid = false
+	return result
+}
+
+func (c *leafPageReadCache) recordStore(result leafPageReadCacheStoreResult, key leafPageReadCacheKey) {
 	c.stores.Add(1)
 	switch {
-	case !wasValid:
+	case !result.wasValid:
 		c.entries.Add(1)
-	case prevKey != key:
+	case result.prevKey != key:
 		c.evictions.Add(1)
 	}
 }
@@ -181,13 +233,15 @@ func (c *leafPageReadCache) stats() leafPageReadCacheStats {
 	}
 	entries := c.entries.Load()
 	return leafPageReadCacheStats{
-		Hits:      c.hits.Load(),
-		Misses:    c.misses.Load(),
-		Stores:    c.stores.Load(),
-		Evictions: c.evictions.Load(),
-		Entries:   entries,
-		Capacity:  uint64(len(c.slots)),
-		Bytes:     entries * page.PageSize,
+		Hits:                    c.hits.Load(),
+		Misses:                  c.misses.Load(),
+		Stores:                  c.stores.Load(),
+		Evictions:               c.evictions.Load(),
+		Entries:                 entries,
+		Capacity:                uint64(len(c.slots)),
+		Bytes:                   entries * page.PageSize,
+		ReadMissAdmissionSkips:  c.readMissAdmissionSkips.Load(),
+		ReadMissAdmissionStores: c.readMissAdmissionStores.Load(),
 	}
 }
 

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -317,7 +317,7 @@ func TestValueReaderLeafLogPageUnsafeToSmallDstBypassesCache(t *testing.T) {
 	}
 }
 
-func TestValueReaderLeafLogPageUnsafeToStoresFallbackLeafPage(t *testing.T) {
+func TestValueReaderLeafLogPageUnsafeToAdmitsRepeatedReadMiss(t *testing.T) {
 	cache := newLeafPageReadCache(8)
 	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
 	leaf := bytes.Repeat([]byte{0x44}, page.PageSize)
@@ -342,19 +342,78 @@ func TestValueReaderLeafLogPageUnsafeToStoresFallbackLeafPage(t *testing.T) {
 		t.Fatalf("fallback ReadUnsafeTo calls=%d, want 1", fallback.readUnsafeToCalls)
 	}
 
-	fallback.err = errors.New("fallback should not be used after cache store")
+	if stats := cache.stats(); stats.Hits != 0 || stats.Misses != 1 || stats.Stores != 0 || stats.ReadMissAdmissionSkips != 1 {
+		t.Fatalf("stats=%+v, want first miss to skip read-miss admission", stats)
+	}
+
 	again, usedDst, err := reader.ReadLeafLogPageUnsafeTo(ptr, dst[:0])
+	if err != nil {
+		t.Fatalf("ReadLeafLogPageUnsafeTo second miss: %v", err)
+	}
+	if !usedDst || !bytes.Equal(again, leaf) {
+		t.Fatalf("second fallback leaf mismatch usedDst=%v", usedDst)
+	}
+	if fallback.readUnsafeToCalls != 2 {
+		t.Fatalf("fallback calls after second miss=%d, want 2", fallback.readUnsafeToCalls)
+	}
+	if stats := cache.stats(); stats.Hits != 0 || stats.Misses != 2 || stats.Stores != 1 || stats.ReadMissAdmissionStores != 1 {
+		t.Fatalf("stats=%+v, want repeated read miss admitted", stats)
+	}
+
+	fallback.err = errors.New("fallback should not be used after repeated read-miss admission")
+	third, usedDst, err := reader.ReadLeafLogPageUnsafeTo(ptr, dst[:0])
 	if err != nil {
 		t.Fatalf("ReadLeafLogPageUnsafeTo cached: %v", err)
 	}
-	if !usedDst || !bytes.Equal(again, leaf) {
+	if !usedDst || !bytes.Equal(third, leaf) {
 		t.Fatalf("cached leaf mismatch usedDst=%v", usedDst)
 	}
-	if fallback.readUnsafeToCalls != 1 {
-		t.Fatalf("fallback calls after cache hit=%d, want 1", fallback.readUnsafeToCalls)
+	if fallback.readUnsafeToCalls != 2 {
+		t.Fatalf("fallback calls after cache hit=%d, want 2", fallback.readUnsafeToCalls)
 	}
-	if stats := cache.stats(); stats.Hits != 1 || stats.Misses != 1 || stats.Stores != 1 {
-		t.Fatalf("stats=%+v, want one miss, one store, one hit", stats)
+	if stats := cache.stats(); stats.Hits != 1 || stats.Misses != 2 || stats.Stores != 1 {
+		t.Fatalf("stats=%+v, want two misses, one admitted store, one hit", stats)
+	}
+}
+
+func TestValueReaderLeafLogPageUnsafeToOneOffReadMissDoesNotEvictStoredLeaf(t *testing.T) {
+	cache := newLeafPageReadCache(1)
+	hotPtr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
+	coldPtr := page.LeafLogPtr{FileID: 7, Offset: 256, RecordLengthHint: 4096}
+	hotLeaf := bytes.Repeat([]byte{0x33}, page.PageSize)
+	coldLeaf := bytes.Repeat([]byte{0x55}, page.PageSize)
+	cache.store(hotPtr, hotLeaf)
+
+	fallback := &leafPageCacheTestFallback{data: coldLeaf}
+	reader := valueReader{
+		vlogs:         fallback,
+		leafPageCache: cache,
+	}
+	dst := make([]byte, 0, page.PageSize)
+	got, usedDst, err := reader.ReadLeafLogPageUnsafeTo(coldPtr, dst)
+	if err != nil {
+		t.Fatalf("ReadLeafLogPageUnsafeTo cold miss: %v", err)
+	}
+	if !usedDst || !bytes.Equal(got, coldLeaf) {
+		t.Fatalf("cold fallback mismatch usedDst=%v", usedDst)
+	}
+	if fallback.readUnsafeToCalls != 1 {
+		t.Fatalf("fallback calls=%d, want 1", fallback.readUnsafeToCalls)
+	}
+	if stats := cache.stats(); stats.Stores != 1 || stats.Evictions != 0 || stats.ReadMissAdmissionSkips != 1 {
+		t.Fatalf("stats=%+v, want one-off read miss not to evict stored hot leaf", stats)
+	}
+
+	fallback.err = errors.New("hot leaf should still be cached")
+	got, usedDst, err = reader.ReadLeafLogPageUnsafeTo(hotPtr, dst[:0])
+	if err != nil {
+		t.Fatalf("ReadLeafLogPageUnsafeTo hot hit: %v", err)
+	}
+	if !usedDst || !bytes.Equal(got, hotLeaf) {
+		t.Fatalf("hot cache mismatch usedDst=%v", usedDst)
+	}
+	if stats := cache.stats(); stats.Hits != 1 || stats.Stores != 1 || stats.Evictions != 0 {
+		t.Fatalf("stats=%+v, want hot cache entry retained", stats)
 	}
 }
 

--- a/TreeDB/db/value_reader.go
+++ b/TreeDB/db/value_reader.go
@@ -101,7 +101,7 @@ func (r valueReader) ReadLeafLogPageUnsafeTo(ptr page.LeafLogPtr, dst []byte) ([
 		return nil, false, err
 	}
 	if r.leafPageCache != nil && cap(dst) >= page.PageSize && len(val) == page.PageSize {
-		r.leafPageCache.store(ptr, val)
+		r.leafPageCache.storeReadMiss(ptr, val)
 	}
 	return val, usedDst, nil
 }

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -802,6 +802,8 @@ func reportProfileBenchBackendVlogMmapStats(b *testing.B, after, before map[stri
 	reportPerDoc("backend_outer_leaf_cache_misses/doc", "treedb.process.read_path.outer_leaf.cache.misses")
 	reportPerDoc("backend_outer_leaf_cache_stores/doc", "treedb.process.read_path.outer_leaf.cache.stores")
 	reportPerDoc("backend_outer_leaf_cache_evictions/doc", "treedb.process.read_path.outer_leaf.cache.evictions")
+	reportPerDoc("backend_outer_leaf_cache_read_miss_admission_skips/doc", "treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips")
+	reportPerDoc("backend_outer_leaf_cache_read_miss_admission_stores/doc", "treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores")
 	reportProfileBenchBackendReadPathRatios(b, after, before)
 	hits := profileBenchDeltaUintStat(after, before, "treedb.vlog.mmap_read.hits")
 	fallbacks := profileBenchDeltaUintStat(after, before, "treedb.vlog.mmap_read.fallback_readat")


### PR DESCRIPTION
## Summary

Refs #1159.

This PR changes only read-miss admission for the process-local outer-leaf page read cache. Write-side leaf-page stores still populate the cache immediately, but value-reader read misses now use second-touch admission: the first miss records a candidate for that direct-mapped slot/key without copying a 4KiB page into the cache; a repeated miss to the same slot/key admits the page.

The target is the sparse update profile where cache-potential counters showed near-zero locality but every read miss was still copying into the cache and evicting recently-written pages.

## Changes

- Add `leafPageReadCache.storeReadMiss` with second-touch admission.
- Keep direct `store` semantics unchanged for write-side leaf-log appends and explicit cache seeding.
- Add stats:
  - `treedb.process.read_path.outer_leaf.cache.read_miss_admission_skips`
  - `treedb.process.read_path.outer_leaf.cache.read_miss_admission_stores`
- Report those counters in `mongo_gateway_bench`.
- Add tests for repeated read-miss admission and one-off read misses preserving existing cached leaves.

## Focused benchmark

Command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=200000x \
  -benchmem \
  -count=1
```

Baseline run dir: `/tmp/gomap_1159_leaf_admit_base_hDiAok`
After run dirs: `/tmp/gomap_1159_leaf_admit_after_2OjCah`, `/tmp/gomap_1159_leaf_admit_after_repeat_hpBiYf`

| Metric | Baseline main | This PR |
| --- | ---: | ---: |
| docs/sec | 129,743 | 134,720 / 138,412 |
| ns/doc | 7,708 | 7,423 / 7,225 |
| update_current_read_ns/doc | 1,907 | 1,614 / 1,627 |
| outer_leaf_cache_stores/doc | 1.331 | 0.4009 / 0.4013 |
| outer_leaf_cache_evictions/doc | 1.331 | 0.4009 / 0.4013 |
| outer_leaf_cache_hit_ratio | 0.0405 | 0.1014 / 0.1017 |
| read_miss_admission_skips/doc | n/a | 0.8432 / 0.8426 |
| read_miss_admission_stores/doc | n/a | 0.0301 / 0.0305 |
| B/op | 1044 | 1059 / 1054 |
| allocs/op | 5 | 5 / 6 |

Interpretation: this removes most read-miss cache-copy churn in the focused sparse-update shape and improves the current-document read phase. The small B/op and allocs/op movement varies between repeated runs; this PR does not add per-read allocations, and the focused path stayed at 5 allocs/op in one of the repeated after-runs.

## Read sanity checks

```bash
go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkCollectionShapeReadPrimaryInto/indexes_2$' \
  -benchtime=200000x \
  -benchmem \
  -count=1
```

Run dir: `/tmp/gomap_1159_leaf_admit_read_YZw2xf`

```text
BenchmarkCollectionShapeReadPrimaryInto/indexes_2-8           200000  184.3 ns/op  4 B/op  0 allocs/op
BenchmarkCollectionShapeReadPrimaryIntoParallel/indexes_2-8   200000  130.3 ns/op  4 B/op  0 allocs/op
```

Raw TreeDB sanity:

```bash
go run ./cmd/unified_bench \
  -dbs treedb \
  -profile fast \
  -keys 100000 \
  -test random_read \
  -progress=false \
  -format markdown
```

Run dir: `/tmp/gomap_1159_leaf_admit_unified_OpfYMC`

```text
Random Read / TreeDB = 3,701,213 ops/sec
```

## Tests

```bash
go test ./TreeDB/db -count=1
go test ./TreeDB/caching -count=1
go test ./cmd/mongo_gateway_bench -count=1
go test ./TreeDB/collections -run 'Test|^$' -count=1
go test ./TreeDB/db -run 'Test.*LeafPage.*Cache|TestValueReaderLeafLogPageUnsafeTo' -count=1
go test ./TreeDB/caching -run TestProcessMemoryStatsIncludeRuntimeBreakdown -count=1
```
