### PR TITLE
treedb: own secondary key parts in append-only runs

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6536,13 +6536,11 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 				return false, false, err
 			}
 			for _, encoded := range newState[runtime.def.name] {
-				key, err := indexEntryKey(encoded, documentID)
-				if err != nil {
+				if _, err := setCollectionSecondaryIndexEntry(table, encoded, documentID); err != nil {
 					_ = snap.Close()
 					resetCollectionTables(append(deltaTables, table))
 					return false, false, err
 				}
-				table.SetSteal(key, nil)
 			}
 			if table.Len() == 0 {
 				resetCollectionRunTable(table)
@@ -7632,35 +7630,33 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 					runStats.IndexName = runtime.def.name
 				}
 				for _, encoded := range item.oldState.valuesAt(runtimeIdx) {
-					key, err := indexEntryKey(encoded, item.documentID)
+					keyLen, err := deleteCollectionSecondaryIndexEntry(table, encoded, item.documentID)
 					if err != nil {
 						_ = snap.Close()
 						return nil, err
 					}
-					table.DeleteSteal(key)
 					stats.SecondaryDeleteEntries++
-					stats.SecondaryKeyBytes += len(key)
+					stats.SecondaryKeyBytes += keyLen
 					runStats.Deletes++
-					runStats.KeyBytes += len(key)
+					runStats.KeyBytes += keyLen
 					if runtimeIdx < stats.IndexStatsCount {
 						stats.IndexStats[runtimeIdx].SecondaryDeletes++
-						stats.IndexStats[runtimeIdx].SecondaryKeyBytes += len(key)
+						stats.IndexStats[runtimeIdx].SecondaryKeyBytes += keyLen
 					}
 				}
 				for _, encoded := range item.newState.valuesAt(runtimeIdx) {
-					key, err := indexEntryKey(encoded, item.documentID)
+					keyLen, err := setCollectionSecondaryIndexEntry(table, encoded, item.documentID)
 					if err != nil {
 						_ = snap.Close()
 						return nil, err
 					}
-					table.SetSteal(key, nil)
 					stats.SecondarySetEntries++
-					stats.SecondaryKeyBytes += len(key)
+					stats.SecondaryKeyBytes += keyLen
 					runStats.Sets++
-					runStats.KeyBytes += len(key)
+					runStats.KeyBytes += keyLen
 					if runtimeIdx < stats.IndexStatsCount {
 						stats.IndexStats[runtimeIdx].SecondarySets++
-						stats.IndexStats[runtimeIdx].SecondaryKeyBytes += len(key)
+						stats.IndexStats[runtimeIdx].SecondaryKeyBytes += keyLen
 					}
 				}
 			}
@@ -8506,11 +8502,9 @@ func buildCreateIndexBackfillPlan(
 		}
 
 		for _, encoded := range values {
-			key, err := indexEntryKey(encoded, documentID)
-			if err != nil {
+			if _, err := setCollectionSecondaryIndexEntry(secondaryTable, encoded, documentID); err != nil {
 				return nil, err
 			}
-			secondaryTable.SetSteal(key, nil)
 			secondaryCount++
 			if !newRuntime.def.unique {
 				continue
@@ -8828,11 +8822,9 @@ func deleteSecondaryEntriesForDocument(table memtable.Table, runtime indexRuntim
 		return nil
 	}
 	for _, encoded := range values {
-		key, err := indexEntryKey(encoded, documentID)
-		if err != nil {
+		if _, err := deleteCollectionSecondaryIndexEntry(table, encoded, documentID); err != nil {
 			return err
 		}
-		table.DeleteSteal(key)
 	}
 	return nil
 }

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -1929,16 +1929,11 @@ func appendIndexEntryKey(dst, encodedValue, documentID []byte) ([]byte, []byte, 
 	return dst, dst[start:len(dst):len(dst)], nil
 }
 
-type collectionSecondaryKeyPartsTable interface {
-	SetInlineNilKeyParts(first, second []byte)
-	DeleteKeyParts(first, second []byte)
-}
-
 func setCollectionSecondaryIndexEntry(table memtable.Table, encodedValue, documentID []byte) (int, error) {
 	if table == nil {
 		return 0, nil
 	}
-	if keyParts, ok := table.(collectionSecondaryKeyPartsTable); ok {
+	if keyParts, ok := table.(memtable.KeyPartsWriter); ok {
 		keyParts.SetInlineNilKeyParts(encodedValue, documentID)
 		return len(encodedValue) + len(documentID), nil
 	}
@@ -1954,7 +1949,7 @@ func deleteCollectionSecondaryIndexEntry(table memtable.Table, encodedValue, doc
 	if table == nil {
 		return 0, nil
 	}
-	if keyParts, ok := table.(collectionSecondaryKeyPartsTable); ok {
+	if keyParts, ok := table.(memtable.KeyPartsWriter); ok {
 		keyParts.DeleteKeyParts(encodedValue, documentID)
 		return len(encodedValue) + len(documentID), nil
 	}

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -1929,6 +1929,43 @@ func appendIndexEntryKey(dst, encodedValue, documentID []byte) ([]byte, []byte, 
 	return dst, dst[start:len(dst):len(dst)], nil
 }
 
+type collectionSecondaryKeyPartsTable interface {
+	SetInlineNilKeyParts(first, second []byte)
+	DeleteKeyParts(first, second []byte)
+}
+
+func setCollectionSecondaryIndexEntry(table memtable.Table, encodedValue, documentID []byte) (int, error) {
+	if table == nil {
+		return 0, nil
+	}
+	if keyParts, ok := table.(collectionSecondaryKeyPartsTable); ok {
+		keyParts.SetInlineNilKeyParts(encodedValue, documentID)
+		return len(encodedValue) + len(documentID), nil
+	}
+	key, err := indexEntryKey(encodedValue, documentID)
+	if err != nil {
+		return 0, err
+	}
+	table.SetSteal(key, nil)
+	return len(key), nil
+}
+
+func deleteCollectionSecondaryIndexEntry(table memtable.Table, encodedValue, documentID []byte) (int, error) {
+	if table == nil {
+		return 0, nil
+	}
+	if keyParts, ok := table.(collectionSecondaryKeyPartsTable); ok {
+		keyParts.DeleteKeyParts(encodedValue, documentID)
+		return len(encodedValue) + len(documentID), nil
+	}
+	key, err := indexEntryKey(encodedValue, documentID)
+	if err != nil {
+		return 0, err
+	}
+	table.DeleteSteal(key)
+	return len(key), nil
+}
+
 func indexValuePrefix(encodedValue []byte) ([]byte, error) {
 	_, prefix, err := appendIndexValuePrefixSlice(make([]byte, 0, len(encodedValue)), encodedValue)
 	return prefix, err

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -27,6 +27,7 @@ const (
 	appendOnlyIteratorPoolMaxCap            = 1 << 20
 	appendOnlyIteratorPtrPoolMaxCap         = 1 << 20
 	appendOnlyReusableKeyMaxCap             = 1 << 10
+	appendOnlyKeyArenaDefaultChunk          = 2 << 10
 	appendOnlyValueArenaMinShift            = 12
 	appendOnlyValueArenaMaxShift            = 20
 	appendOnlyValueArenaClassCount          = appendOnlyValueArenaMaxShift - appendOnlyValueArenaMinShift + 1
@@ -51,6 +52,7 @@ type appendOnlyEntry struct {
 	inlineKey  [appendOnlyInlineKeyLen]byte
 	flags      byte
 	keyInline  bool
+	keyArena   bool
 	valueOwned bool
 }
 
@@ -62,6 +64,12 @@ type appendOnlyValueArena struct {
 	curPos    int
 }
 
+type appendOnlyKeyArena struct {
+	chunks [][]byte
+	cur    []byte
+	curPos int
+}
+
 type AppendOnly struct {
 	mu sync.RWMutex
 
@@ -71,6 +79,7 @@ type AppendOnly struct {
 	latest64       map[uint64]int
 	snapshot       []*appendOnlyEntry
 	indexBuf       []int
+	keyArena       appendOnlyKeyArena
 	valueArena     appendOnlyValueArena
 	count          int
 	snapCount      int
@@ -424,6 +433,34 @@ func (a *appendOnlyValueArena) dropRetained() {
 	a.retainedB = 0
 }
 
+func (a *appendOnlyKeyArena) alloc(length int) []byte {
+	if length <= 0 {
+		return nil
+	}
+	if a.cur == nil || cap(a.cur)-a.curPos < length {
+		chunkCap := appendOnlyKeyArenaDefaultChunk
+		if length > chunkCap {
+			chunkCap = 1 << uint(bits.Len(uint(length-1)))
+		}
+		chunk := make([]byte, chunkCap)
+		a.chunks = append(a.chunks, chunk)
+		a.cur = chunk
+		a.curPos = 0
+	}
+	out := a.cur[a.curPos : a.curPos+length : a.curPos+length]
+	a.curPos += length
+	return out
+}
+
+func (a *appendOnlyKeyArena) reset() {
+	for i := range a.chunks {
+		a.chunks[i] = nil
+	}
+	a.chunks = a.chunks[:0]
+	a.cur = nil
+	a.curPos = 0
+}
+
 func appendOnlyNextCapacity(current int) int {
 	if current < appendOnlyMinInitialEntries {
 		return appendOnlyMinInitialEntries
@@ -563,7 +600,7 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 	m.latest[appendOnlyKeyString(key)] = idx
 }
 
-func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) {
+func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) *appendOnlyEntry {
 	if m.count == len(m.entries) {
 		nextCap := appendOnlyNextCapacity(len(m.entries))
 		prev := m.entries
@@ -578,6 +615,7 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	ent.ptr = ptr
 	ent.flags = flags
 	ent.keyInline = false
+	ent.keyArena = false
 	ent.valueOwned = false
 	if steal {
 		ent.key = key
@@ -613,14 +651,14 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	if !m.hasLast {
 		m.lastIdx = idx
 		m.hasLast = true
-		return
+		return ent
 	}
 	if m.ordered {
 		prev := appendOnlyEntryKey(&m.entries[m.lastIdx])
 		cmp := bytes.Compare(k, prev)
 		if cmp > 0 {
 			m.lastIdx = idx
-			return
+			return ent
 		}
 		m.ordered = false
 		// Once order breaks, invalidate the cached snapshot state and
@@ -630,12 +668,13 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		// rebuildLatestIndexLocked clears the cached snapshot as part of the
 		// transition.
 		m.rebuildLatestIndexLocked()
-		return
+		return ent
 	}
 	if !m.latestDirty {
 		m.updateLatestIndexLocked(k, idx)
 	}
 	m.clearSnapshotLocked()
+	return ent
 }
 
 func (m *AppendOnly) Set(key, value []byte) {
@@ -658,6 +697,28 @@ func (m *AppendOnly) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags b
 	m.mu.Unlock()
 }
 
+func (m *AppendOnly) copyKeyPartsLocked(first, second []byte) []byte {
+	total := len(first) + len(second)
+	if total <= 0 {
+		return nil
+	}
+	key := m.keyArena.alloc(total)
+	n := copy(key, first)
+	copy(key[n:], second)
+	return key
+}
+
+// SetInlineNilKeyParts stores an inline entry with a nil value and a key built
+// from first+second. The key is copied into table-owned storage so callers can
+// reuse or mutate both input slices after the call.
+func (m *AppendOnly) SetInlineNilKeyParts(first, second []byte) {
+	m.mu.Lock()
+	key := m.copyKeyPartsLocked(first, second)
+	ent := m.appendEntryLocked(key, nil, page.ValuePtr{}, node.FlagInline, true, false)
+	ent.keyArena = true
+	m.mu.Unlock()
+}
+
 func (m *AppendOnly) SetEntryBorrowValue(key, value []byte, ptr page.ValuePtr, flags byte) {
 	m.mu.Lock()
 	m.appendEntryLocked(key, value, ptr, flags, false, true)
@@ -670,6 +731,16 @@ func (m *AppendOnly) Delete(key []byte) {
 
 func (m *AppendOnly) DeleteSteal(key []byte) {
 	m.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+}
+
+// DeleteKeyParts stores a tombstone whose key is built from first+second and
+// copied into table-owned storage.
+func (m *AppendOnly) DeleteKeyParts(first, second []byte) {
+	m.mu.Lock()
+	key := m.copyKeyPartsLocked(first, second)
+	ent := m.appendEntryLocked(key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+	ent.keyArena = true
+	m.mu.Unlock()
 }
 
 func (m *AppendOnly) PutWithCallback(key, value []byte, cb func(k, v []byte) error) error {
@@ -955,6 +1026,7 @@ func (m *AppendOnly) Release() {
 	m.latest64 = nil
 	m.snapshot = nil
 	m.indexBuf = nil
+	m.keyArena.reset()
 	m.valueArena.reset()
 	m.valueArena.dropRetained()
 	m.count = 0
@@ -1014,7 +1086,11 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int,
 		ent := &m.entries[i]
 		ent.ptr = page.ValuePtr{}
 		ent.flags = 0
+		if ent.keyArena {
+			ent.key = nil
+		}
 		ent.keyInline = false
+		ent.keyArena = false
 		ent.valueOwned = false
 		if cap(ent.key) > appendOnlyReusableKeyMaxCap {
 			ent.key = nil
@@ -1023,6 +1099,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int,
 		}
 		ent.value = nil
 	}
+	m.keyArena.reset()
 	m.valueArena.reset()
 	if !retainObserved {
 		m.valueArena.dropRetained()

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -46,14 +46,15 @@ var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
 
 type appendOnlyEntry struct {
-	key        []byte
-	value      []byte
-	ptr        page.ValuePtr
-	inlineKey  [appendOnlyInlineKeyLen]byte
-	flags      byte
-	keyInline  bool
-	keyArena   bool
-	valueOwned bool
+	key         []byte
+	value       []byte
+	ptr         page.ValuePtr
+	inlineKey   [appendOnlyInlineKeyLen]byte
+	flags       byte
+	keyInline   bool
+	keyArena    bool
+	keyReusable bool
+	valueOwned  bool
 }
 
 type appendOnlyValueArena struct {
@@ -616,6 +617,7 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	ent.flags = flags
 	ent.keyInline = false
 	ent.keyArena = false
+	ent.keyReusable = false
 	ent.valueOwned = false
 	if steal {
 		ent.key = key
@@ -627,6 +629,7 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 			ent.key = nil
 		} else {
 			ent.key = cloneOrReuseBytes(ent.key, key, appendOnlyReusableKeyMaxCap)
+			ent.keyReusable = true
 		}
 		if len(value) > 0 {
 			if borrowValue {
@@ -1091,6 +1094,10 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int,
 		}
 		ent.keyInline = false
 		ent.keyArena = false
+		if !ent.keyReusable {
+			ent.key = nil
+		}
+		ent.keyReusable = false
 		ent.valueOwned = false
 		if cap(ent.key) > appendOnlyReusableKeyMaxCap {
 			ent.key = nil

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -445,6 +445,18 @@ func TestAppendOnlyResetDoesNotPoolStolenValueSlices(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyResetDoesNotPoolStolenKeySlices(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	external := []byte("external-key")
+	m.SetEntrySteal(external, nil, page.ValuePtr{}, node.FlagInline)
+	m.Reset()
+
+	m.Set([]byte("replacement"), nil)
+	if string(external) != "external-key" {
+		t.Fatalf("stolen caller key was mutated via pooled reuse: got %q", external)
+	}
+}
+
 func TestAppendOnlyResetDoesNotPoolBorrowedValueSlices(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	external := []byte("borrowed-immutable")

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -133,6 +133,49 @@ func TestAppendOnlyCRUD(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyKeyPartsOwnsKeyBytes(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	first := []byte("city\x00\x00")
+	second := []byte("user-0001")
+	m.SetInlineNilKeyParts(first, second)
+
+	first[0] = 'x'
+	second[0] = 'x'
+
+	key := []byte("city\x00\x00user-0001")
+	value, _, flags, found := m.GetEntry(key)
+	if !found {
+		t.Fatalf("missing key built from original parts")
+	}
+	if flags != node.FlagInline {
+		t.Fatalf("flags=%08b want inline", flags)
+	}
+	if value != nil {
+		t.Fatalf("value=%q want nil", value)
+	}
+	if _, _, _, found := m.GetEntry([]byte("xity\x00\x00xser-0001")); found {
+		t.Fatalf("mutated caller key parts affected stored key")
+	}
+}
+
+func TestAppendOnlyDeleteKeyPartsOwnsKeyBytes(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	first := []byte("city\x00\x00")
+	second := []byte("user-0001")
+	m.DeleteKeyParts(first, second)
+
+	first[0] = 'x'
+	second[0] = 'x'
+
+	_, deleted, found := m.Get([]byte("city\x00\x00user-0001"))
+	if !found || !deleted {
+		t.Fatalf("Get(original)=(deleted=%v,found=%v) want tombstone", deleted, found)
+	}
+	if _, _, found := m.Get([]byte("xity\x00\x00xser-0001")); found {
+		t.Fatalf("mutated caller key parts affected stored tombstone")
+	}
+}
+
 func TestAppendOnlyApplyStealEntryFunc(t *testing.T) {
 	m := NewAppendOnlyWithEntryCapacity(3)
 	err := m.ApplyStealEntryFunc(3, func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error) {

--- a/TreeDB/internal/memtable/memtable.go
+++ b/TreeDB/internal/memtable/memtable.go
@@ -102,6 +102,13 @@ type ValueBorrower interface {
 	SetEntryBorrowValue(key, value []byte, ptr page.ValuePtr, flags byte)
 }
 
+// KeyPartsWriter marks memtables that can build and own common two-part keys
+// without forcing callers to allocate a concatenated key slice first.
+type KeyPartsWriter interface {
+	SetInlineNilKeyParts(first, second []byte)
+	DeleteKeyParts(first, second []byte)
+}
+
 // StableUnsafeIteratorTable marks memtable implementations whose
 // iterator.UnsafeIterator key/value views (from UnsafeKey/UnsafeValue/UnsafeEntry)
 // are backed by storage that outlives the iterator itself.


### PR DESCRIPTION
## Summary

Focused #1159 allocation/ownership cleanup for secondary-index collection runs.

What changed:
- Adds append-only key-parts helpers that copy `first+second` keys into table-owned storage.
- Uses that path for collection secondary index set/delete entries in single-document update, batch update, create-index backfill, and secondary delete helpers.
- Keeps caller-slice ownership safe: input encoded values/document IDs can be reused or mutated after insertion.
- Uses a dedicated small 2 KiB key arena, not the value arena, so small update tables avoid the old 32 KiB value-arena minimum while batch update runs avoid one Go object per secondary key.

This is intentionally not a zipper/root-apply redesign. It removes avoidable secondary-key allocation pressure so the next #1159 profiles stay focused on current-document reads and leaf-log root apply.

## Validation

```text
go test ./TreeDB/internal/memtable -run 'TestAppendOnly(KeyPartsOwnsKeyBytes|DeleteKeyPartsOwnsKeyBytes|CRUD|IteratorSortedLatest)' -count=1
ok  github.com/snissn/gomap/TreeDB/internal/memtable  0.508s

go test ./TreeDB/collections -run 'TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes|TestCollectionIndexedWriteMemtablesFindSkipsBufferedSecondaryTombstone' -count=1
ok  github.com/snissn/gomap/TreeDB/collections  0.411s

go test ./TreeDB/internal/memtable -count=1
ok  github.com/snissn/gomap/TreeDB/internal/memtable  0.729s

go test ./TreeDB/collections -count=1
ok  github.com/snissn/gomap/TreeDB/collections  4.679s

go test ./cmd/mongo_gateway_bench -count=1
ok  github.com/snissn/gomap/cmd/mongo_gateway_bench  3.376s

git diff --check
```

## Focused Benchmark Evidence

Baseline on `origin/main` at `02ac418219`:

```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1159_next_profile_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

Baseline profile dir: `/tmp/gomap_1159_next_profile_fUcUQq`

Branch command used the same benchmark/profile command on this branch.

Branch profile dir: `/tmp/gomap_1159_keyparts_profile_Qm7MZz`

| Metric | origin/main | this PR |
| --- | ---: | ---: |
| docs/sec | 135,599 | 131,816 |
| ns/doc | 7,375 | 7,586 |
| B/op | 1,228 | 1,223 |
| allocs/op | 5 | 4 |
| update_secondary_runs_ns/doc | 209.4 | 202.5 |
| update_current_read_ns/doc | 1,650 | 1,645 |
| publish_delta_group_root_apply_ns/doc | 2,117 | 2,068 |
| update_roots/batch | 2.000 | 2.000 |

Allocation profile readout:
- On baseline, `collections.indexEntryKey` was a top allocation site: `5,712,730` flat alloc objects in the 10s profile.
- On this PR's 10s profile, `collections.indexEntryKey` drops out of the allocation top list.
- The replacement `appendOnlyKeyArena.alloc` accounts for `572,855` alloc objects in the 1 KiB test run and `72,675` alloc objects after tuning to 2 KiB chunks in the focused fixed-count run.

Fixed-count smoke after the 2 KiB key-arena tuning:

```bash
RUN_DIR=$(mktemp -d /tmp/gomap_1159_keyparts_bench3_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=200000x \
  -benchmem \
  -count=1 \
  -memprofile "$RUN_DIR/mem.pprof"
```

Run dir: `/tmp/gomap_1159_keyparts_bench3_kVbe2w`

Result row: `130,367 docs/sec`, `7,671 ns/doc`, `1,134 B/op`, `4 allocs/op`.

Interpretation: this PR is a narrow allocation-pressure cleanup. It removes one avoidable object allocation from each measured update operation and removes `collections.indexEntryKey` from the allocation profile. Throughput remains noisy/roughly neutral; the next #1159 target remains current-document read cost and zipper/leaf-log root-apply work.
