### PR TITLE
[codex] Add Mongo client mode matrix and benchmark runbook

### DIFF
--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -188,6 +188,13 @@ TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack raw-w
 scripts/mongo_gateway_compare.sh
 ```
 
+To run matching MongoDB client-mode rows where MongoDB supports the mode:
+
+```sh
+MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack" \
+scripts/mongo_gateway_compare.sh
+```
+
 ```sh
 scripts/mongo_gateway_compare.sh \
   --out /tmp/gomap_mongo_gateway_compare \
@@ -242,6 +249,7 @@ Useful overrides:
 - `DOCS_LIST="1000 10000 100000"`
 - `INDEXES_LIST="0 1 2"`
 - `TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack raw-wire-tcp raw-wire"`
+- `MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack"`
 - `READS=50000`, `RANGE_READS=5000`, `UPDATES=5000`
 - `DELETES=1000`
 - `RANGE_INDEX=true` or `--range-index` to create `age_1` and report

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -188,9 +188,12 @@ TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack raw-w
 scripts/mongo_gateway_compare.sh
 ```
 
-To run matching MongoDB client-mode rows where MongoDB supports the mode:
+To run matching TreeDB and MongoDB client-mode rows where MongoDB supports the
+mode:
 
 ```sh
+TREEDB_DOCUMENT_FORMATS="bson" \
+TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack" \
 MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack" \
 scripts/mongo_gateway_compare.sh
 ```

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -195,6 +195,11 @@ MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack" \
 scripts/mongo_gateway_compare.sh
 ```
 
+When the MongoDB side runs only the ordinary `driver` mode, the matrix keeps
+the legacy baseline config names `mongo` and `mongo_range_index`. Explicit
+`mongo_driver` config names are used only when `driver` is part of a multi-mode
+MongoDB client matrix.
+
 ```sh
 scripts/mongo_gateway_compare.sh \
   --out /tmp/gomap_mongo_gateway_compare \

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -361,24 +361,36 @@ func mongoRecordsForTreeConfig(treeConfig string, mongoIndex mongoScenarioIndex)
 }
 
 func isMongoDriverBaselineConfig(config string) bool {
-	if config == "mongo" || config == "mongo_driver" {
+	if config == "mongo" {
 		return true
 	}
 	if !strings.HasPrefix(config, "mongo_") {
 		return false
 	}
-	suffix := strings.TrimPrefix(config, "mongo_")
-	for _, explicitNonBaseline := range []string{"driver_command", "driver_unack"} {
-		if suffix == explicitNonBaseline || strings.HasPrefix(suffix, explicitNonBaseline+"_") {
-			return false
-		}
-	}
-	if suffix == "driver" || strings.HasPrefix(suffix, "driver_") {
-		return true
+	if config == "mongo_driver" || strings.HasPrefix(config, "mongo_driver_") {
+		return isExplicitMongoDriverBaselineConfig(config)
 	}
 	// Legacy Mongo rows predate explicit client-mode naming and look like
 	// mongo_range_index or mongo_writers_4. They are ordinary driver baselines.
 	return true
+}
+
+func isExplicitMongoDriverBaselineConfig(config string) bool {
+	if config == "mongo_driver" {
+		return true
+	}
+	for _, base := range []string{"mongo_driver", "mongo_driver_range_index"} {
+		if config == base {
+			return true
+		}
+		for _, marker := range []string{"_writers_", "_readers_"} {
+			if strings.HasPrefix(config, base+marker) {
+				scenario := parseScalingScenario(config)
+				return scenario.hasMarker && scenario.valid
+			}
+		}
+	}
+	return false
 }
 
 func sortedRunRecordKeys(records map[string]*runRecord) []string {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -367,7 +367,10 @@ func sortedMongoRecords(recordsByConfig map[string]*runRecord) []*runRecord {
 		records = append(records, record)
 	}
 	sort.Slice(records, func(i, j int) bool {
-		return records[i].Row.Config < records[j].Row.Config
+		if records[i].Row.Config != records[j].Row.Config {
+			return records[i].Row.Config < records[j].Row.Config
+		}
+		return records[i].DisplayRawPath < records[j].DisplayRawPath
 	})
 	return records
 }

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -260,7 +260,7 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 				},
 				TreeDB:          cell.trees[config],
 				Mongo:           mongo,
-				MongoAlternates: mongoRecordsForTreeConfig(config, mongoIndex),
+				MongoAlternates: sortedMongoRecords(cell.mongos),
 			})
 		}
 	}
@@ -361,12 +361,11 @@ func preferredMongoDriverBaseline(records []*runRecord) *runRecord {
 	return explicit
 }
 
-func mongoRecordsForTreeConfig(treeConfig string, mongoIndex mongoScenarioIndex) []*runRecord {
-	treeScenario := parseScalingScenario(treeConfig)
-	if !treeScenario.valid {
-		return nil
+func sortedMongoRecords(recordsByConfig map[string]*runRecord) []*runRecord {
+	records := make([]*runRecord, 0, len(recordsByConfig))
+	for _, record := range recordsByConfig {
+		records = append(records, record)
 	}
-	records := append([]*runRecord(nil), mongoIndex.bySuffix[treeScenario.suffix]...)
 	sort.Slice(records, func(i, j int) bool {
 		return records[i].Row.Config < records[j].Row.Config
 	})

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -335,17 +335,30 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongoIndex mongoSce
 }
 
 func preferredMongoDriverBaseline(records []*runRecord) *runRecord {
-	var out *runRecord
+	var legacy *runRecord
+	var explicit *runRecord
 	for _, record := range records {
-		if record == nil || !isMongoDriverBaselineConfig(record.Row.Config) {
+		if record == nil {
 			continue
 		}
-		if out != nil {
-			return nil
+		if isLegacyMongoDriverBaselineConfig(record.Row.Config) {
+			if legacy != nil {
+				return nil
+			}
+			legacy = record
+			continue
 		}
-		out = record
+		if isExplicitMongoDriverBaselineConfig(record.Row.Config) {
+			if explicit != nil {
+				return nil
+			}
+			explicit = record
+		}
 	}
-	return out
+	if legacy != nil {
+		return legacy
+	}
+	return explicit
 }
 
 func mongoRecordsForTreeConfig(treeConfig string, mongoIndex mongoScenarioIndex) []*runRecord {
@@ -361,6 +374,10 @@ func mongoRecordsForTreeConfig(treeConfig string, mongoIndex mongoScenarioIndex)
 }
 
 func isMongoDriverBaselineConfig(config string) bool {
+	return isLegacyMongoDriverBaselineConfig(config) || isExplicitMongoDriverBaselineConfig(config)
+}
+
+func isLegacyMongoDriverBaselineConfig(config string) bool {
 	if config == "mongo" {
 		return true
 	}
@@ -368,7 +385,7 @@ func isMongoDriverBaselineConfig(config string) bool {
 		return false
 	}
 	if config == "mongo_driver" || strings.HasPrefix(config, "mongo_driver_") {
-		return isExplicitMongoDriverBaselineConfig(config)
+		return false
 	}
 	// Legacy Mongo rows predate explicit client-mode naming and look like
 	// mongo_range_index or mongo_writers_4. They are ordinary driver baselines.

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -110,6 +110,7 @@ type phaseComparison struct {
 	Cell        cellKey
 	Name        string
 	RangeIndex  bool
+	MongoConfig string
 	TreeDBPhase phaseResult
 	MongoPhase  phaseResult
 	HasTreeDB   bool
@@ -323,16 +324,11 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongoIndex mongoSce
 	matches := mongoIndex.bySuffix[treeScenario.suffix]
 	candidates := mongoIndex.suffixConfig[treeScenario.suffix]
 	if len(candidates) > 1 {
-		if record, ambiguous := preferredMongoDriverBaseline(matches); record != nil {
-			return record, nil
-		} else if ambiguous {
-			return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenarioLabel, candidates, sortedRunRecordKeys(mongoIndex.exact))
+		record, err := mongoComparisonBaseline(matches)
+		if err != nil {
+			return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v: %w", key.Documents, key.SecondaryIndexes, treeConfig, treeScenarioLabel, candidates, sortedRunRecordKeys(mongoIndex.exact), err)
 		}
-		records := sortedRunRecords(matches)
-		if len(records) > 0 {
-			return records[0], nil
-		}
-		return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenarioLabel, candidates, sortedRunRecordKeys(mongoIndex.exact))
+		return record, nil
 	}
 	if len(matches) == 1 {
 		return matches[0], nil
@@ -340,34 +336,39 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongoIndex mongoSce
 	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q tree_scenario=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenarioLabel, sortedRunRecordKeys(mongoIndex.exact))
 }
 
-func preferredMongoDriverBaseline(records []*runRecord) (*runRecord, bool) {
+func mongoComparisonBaseline(records []*runRecord) (*runRecord, error) {
 	var legacy *runRecord
 	var explicit *runRecord
-	baselines := 0
 	for _, record := range records {
 		if record == nil {
 			continue
 		}
 		if isLegacyMongoDriverBaselineConfig(record.Row.Config) {
-			baselines++
+			if legacy != nil {
+				return nil, fmt.Errorf("multiple legacy MongoDB driver baseline candidates: %q and %q", legacy.Row.Config, record.Row.Config)
+			}
 			legacy = record
 			continue
 		}
 		if isExplicitMongoDriverBaselineConfig(record.Row.Config) {
-			baselines++
+			if explicit != nil {
+				return nil, fmt.Errorf("multiple explicit MongoDB driver baseline candidates: %q and %q", explicit.Row.Config, record.Row.Config)
+			}
 			explicit = record
 		}
 	}
-	if baselines > 1 && legacy == nil {
-		return nil, true
-	}
-	if baselines > 1 && explicit == nil {
-		return nil, true
-	}
 	if legacy != nil {
-		return legacy, false
+		return legacy, nil
 	}
-	return explicit, false
+	if explicit != nil {
+		return explicit, nil
+	}
+	for _, record := range sortedRunRecords(records) {
+		if record != nil {
+			return record, nil
+		}
+	}
+	return nil, errors.New("no MongoDB baseline candidates")
 }
 
 func sortedMongoRecords(recordsByConfig map[string]*runRecord) []*runRecord {
@@ -666,6 +667,7 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	b.WriteString("- Wall ops/sec values include the full benchmark phase loop. Sampled ops/sec values isolate the timed driver/gateway call inside each phase and are useful when prebuilt fixtures are enabled.\n")
 	b.WriteString("- `concurrent_id_find_one_rN` phases are an `_id` read throughput sweep over `N` concurrent readers, and are grouped in the Concurrent Read Sweep section when present.\n")
 	b.WriteString("- Range-query benchmark rows use explicit phase names: `age_range_indexed_limit_10` means `-range-index` created `age_1`; `age_range_scan_limit_10` means bounded scan fallback.\n")
+	b.WriteString("- Main comparison tables label the MongoDB config chosen as the baseline. In multi-mode matrices, all other MongoDB rows remain visible in the Mongo Matrix Rows section.\n")
 	return b.String()
 }
 
@@ -919,8 +921,8 @@ func cellDiskScore(cell cellComparison) int64 {
 
 func renderDiskTable(b *strings.Builder, cells []cellComparison) {
 	b.WriteString("## Disk Summary\n\n")
-	b.WriteString("| docs | indexes | range index | TreeDB config | TreeDB snapshot | TreeDB bytes | TreeDB bytes/doc | TreeDB physical du | TreeDB physical bytes/doc | MongoDB dbStats dataSize | MongoDB dbStats totalSize | MongoDB physical du | MongoDB physical bytes/doc | TreeDB / MongoDB dbStats totalSize | TreeDB / MongoDB physical |\n")
-	b.WriteString("| ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+	b.WriteString("| docs | indexes | range index | TreeDB config | MongoDB baseline config | TreeDB snapshot | TreeDB bytes | TreeDB bytes/doc | TreeDB physical du | TreeDB physical bytes/doc | MongoDB dbStats dataSize | MongoDB dbStats totalSize | MongoDB physical du | MongoDB physical bytes/doc | TreeDB / MongoDB dbStats totalSize | TreeDB / MongoDB physical |\n")
+	b.WriteString("| ---: | ---: | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
 	for _, cell := range cells {
 		treeBytes, treeSnapshot, treeOK := treeDBBytesSnapshot(cell.TreeDB.Result)
 		treePhysical := cell.TreeDB.Row.PhysicalBytes
@@ -932,11 +934,12 @@ func renderDiskTable(b *strings.Builder, cells []cellComparison) {
 			mongoTotal, mongoTotalOK = mongoDBStatsTotalBytes(cell.Mongo.Result)
 			mongoPhysical = cell.Mongo.Row.PhysicalBytes
 		}
-		fmt.Fprintf(b, "| %d | %d | %t | `%s` | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",
+		fmt.Fprintf(b, "| %d | %d | %t | `%s` | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",
 			cell.Key.Documents,
 			cell.Key.SecondaryIndexes,
 			cell.TreeDB.Result.RangeIndex,
 			cell.Key.TreeDBConfig,
+			formatRunConfig(cell.Mongo),
 			treeSnapshot,
 			formatMeasuredBytes(treeOK, treeBytes),
 			formatMeasuredBytesPerDoc(treeOK, treeBytes, cell.Key.Documents),
@@ -959,14 +962,15 @@ func renderConcurrentReadSweepTable(b *strings.Builder, cells []cellComparison) 
 	}
 	b.WriteString("## Concurrent Read Sweep\n\n")
 	b.WriteString("These rows group `concurrent_id_find_one_rN` phases as one `_id` read throughput sweep. Serial `id_find_one` remains a separate single-in-flight latency phase.\n\n")
-	b.WriteString("| docs | indexes | TreeDB config | readers | TreeDB wall ops/sec | TreeDB sampled ops/sec | MongoDB wall ops/sec | MongoDB sampled ops/sec | TreeDB / MongoDB wall | TreeDB p95 us | MongoDB p95 us |\n")
-	b.WriteString("| ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+	b.WriteString("| docs | indexes | TreeDB config | MongoDB baseline config | readers | TreeDB wall ops/sec | TreeDB sampled ops/sec | MongoDB wall ops/sec | MongoDB sampled ops/sec | TreeDB / MongoDB wall | TreeDB p95 us | MongoDB p95 us |\n")
+	b.WriteString("| ---: | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
 	for _, cmp := range rows {
 		readers, _ := concurrentReadReaders(cmp.Name)
-		fmt.Fprintf(b, "| %d | %d | `%s` | %d | %s | %s | %s | %s | %s | %s | %s |\n",
+		fmt.Fprintf(b, "| %d | %d | `%s` | %s | %d | %s | %s | %s | %s | %s | %s | %s |\n",
 			cmp.Cell.Documents,
 			cmp.Cell.SecondaryIndexes,
 			cmp.Cell.TreeDBConfig,
+			formatConfig(cmp.MongoConfig),
 			readers,
 			formatPhaseOps(cmp.HasTreeDB, cmp.TreeDBPhase.OpsPerSecond),
 			formatPhaseOps(cmp.HasTreeDB && cmp.TreeDBPhase.SampledOpsPerSecond > 0, cmp.TreeDBPhase.SampledOpsPerSecond),
@@ -1002,6 +1006,7 @@ func concurrentReadSweepComparisons(cells []cellComparison) []phaseComparison {
 				Cell:        cell.Key,
 				Name:        name,
 				RangeIndex:  cell.TreeDB.Result.RangeIndex,
+				MongoConfig: recordConfig(cell.Mongo),
 				TreeDBPhase: treePhase,
 				MongoPhase:  mongoPhase,
 				HasTreeDB:   hasTree,
@@ -1065,8 +1070,8 @@ func concurrentReadReaders(name string) (int, bool) {
 
 func renderOpsTable(b *strings.Builder, cells []cellComparison) {
 	b.WriteString("## Ops/Sec Summary\n\n")
-	b.WriteString("| docs | indexes | range index | range mode | TreeDB config | phase | TreeDB wall ops/sec | TreeDB sampled ops/sec | MongoDB wall ops/sec | MongoDB sampled ops/sec | TreeDB / MongoDB wall | TreeDB / MongoDB sampled | TreeDB p95 us | MongoDB p95 us |\n")
-	b.WriteString("| ---: | ---: | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+	b.WriteString("| docs | indexes | range index | range mode | TreeDB config | MongoDB baseline config | phase | TreeDB wall ops/sec | TreeDB sampled ops/sec | MongoDB wall ops/sec | MongoDB sampled ops/sec | TreeDB / MongoDB wall | TreeDB / MongoDB sampled | TreeDB p95 us | MongoDB p95 us |\n")
+	b.WriteString("| ---: | ---: | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
 	sweepCells := make(map[cellKey]bool, len(cells))
 	for _, cell := range cells {
 		if cellHasConcurrentReadSweep(cell) {
@@ -1080,12 +1085,13 @@ func renderOpsTable(b *strings.Builder, cells []cellComparison) {
 			}
 		}
 		sampledRatio := safeRatio(cmp.TreeDBPhase.SampledOpsPerSecond, cmp.MongoPhase.SampledOpsPerSecond)
-		fmt.Fprintf(b, "| %d | %d | %t | %s | `%s` | `%s` | %s | %s | %s | %s | %s | %s | %s | %s |\n",
+		fmt.Fprintf(b, "| %d | %d | %t | %s | `%s` | %s | `%s` | %s | %s | %s | %s | %s | %s | %s | %s |\n",
 			cmp.Cell.Documents,
 			cmp.Cell.SecondaryIndexes,
 			cmp.TreeDBRangeIndex(),
 			formatRangeMode(cmp.Name),
 			cmp.Cell.TreeDBConfig,
+			formatConfig(cmp.MongoConfig),
 			cmp.Name,
 			formatPhaseOps(cmp.HasTreeDB, cmp.TreeDBPhase.OpsPerSecond),
 			formatPhaseOps(cmp.HasTreeDB && cmp.TreeDBPhase.SampledOpsPerSecond > 0, cmp.TreeDBPhase.SampledOpsPerSecond),
@@ -1116,6 +1122,7 @@ func allPhaseComparisons(cells []cellComparison) []phaseComparison {
 				Cell:        cell.Key,
 				Name:        name,
 				RangeIndex:  cell.TreeDB.Result.RangeIndex,
+				MongoConfig: recordConfig(cell.Mongo),
 				TreeDBPhase: treePhase,
 				MongoPhase:  mongoPhase,
 				HasTreeDB:   hasTree,
@@ -1174,6 +1181,24 @@ func formatOptionalCode(raw string) string {
 	return "`" + raw + "`"
 }
 
+func recordConfig(record *runRecord) string {
+	if record == nil {
+		return ""
+	}
+	return record.Row.Config
+}
+
+func formatRunConfig(record *runRecord) string {
+	return formatConfig(recordConfig(record))
+}
+
+func formatConfig(config string) string {
+	if config == "" {
+		return "n/a"
+	}
+	return "`" + config + "`"
+}
+
 func writeSummaryTSV(path string, cells []cellComparison) error {
 	f, err := os.Create(path)
 	if err != nil {
@@ -1188,6 +1213,7 @@ func writeSummaryTSV(path string, cells []cellComparison) error {
 		"range_index",
 		"range_mode",
 		"treedb_config",
+		"mongo_config",
 		"phase",
 		"treedb_ops_sec",
 		"treedb_sampled_ops_sec",
@@ -1234,6 +1260,7 @@ func writeSummaryTSV(path string, cells []cellComparison) error {
 			strconv.FormatBool(cmp.TreeDBRangeIndex()),
 			rangeMode(cmp.Name),
 			cmp.Cell.TreeDBConfig,
+			recordConfig(cell.Mongo),
 			cmp.Name,
 			formatRawFloat(cmp.HasTreeDB, cmp.TreeDBPhase.OpsPerSecond),
 			formatRawFloat(cmp.HasTreeDB && cmp.TreeDBPhase.SampledOpsPerSecond > 0, cmp.TreeDBPhase.SampledOpsPerSecond),

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -100,9 +100,10 @@ type baseCellKey struct {
 }
 
 type cellComparison struct {
-	Key    cellKey
-	TreeDB *runRecord
-	Mongo  *runRecord
+	Key             cellKey
+	TreeDB          *runRecord
+	Mongo           *runRecord
+	MongoAlternates []*runRecord
 }
 
 type phaseComparison struct {
@@ -257,8 +258,9 @@ func loadComparisons(matrixPath string, allowIncomplete bool) ([]cellComparison,
 					SecondaryIndexes: key.SecondaryIndexes,
 					TreeDBConfig:     config,
 				},
-				TreeDB: cell.trees[config],
-				Mongo:  mongo,
+				TreeDB:          cell.trees[config],
+				Mongo:           mongo,
+				MongoAlternates: mongoRecordsForTreeConfig(config, mongoIndex),
 			})
 		}
 	}
@@ -346,15 +348,37 @@ func preferredMongoDriverBaseline(records []*runRecord) *runRecord {
 	return out
 }
 
+func mongoRecordsForTreeConfig(treeConfig string, mongoIndex mongoScenarioIndex) []*runRecord {
+	treeScenario := parseScalingScenario(treeConfig)
+	if !treeScenario.valid {
+		return nil
+	}
+	records := append([]*runRecord(nil), mongoIndex.bySuffix[treeScenario.suffix]...)
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].Row.Config < records[j].Row.Config
+	})
+	return records
+}
+
 func isMongoDriverBaselineConfig(config string) bool {
 	if config == "mongo" || config == "mongo_driver" {
 		return true
 	}
-	if !strings.HasPrefix(config, "mongo_driver_") {
+	if !strings.HasPrefix(config, "mongo_") {
 		return false
 	}
-	return !strings.HasPrefix(config, "mongo_driver_command") &&
-		!strings.HasPrefix(config, "mongo_driver_unack")
+	suffix := strings.TrimPrefix(config, "mongo_")
+	for _, explicitNonBaseline := range []string{"driver_command", "driver_unack"} {
+		if suffix == explicitNonBaseline || strings.HasPrefix(suffix, explicitNonBaseline+"_") {
+			return false
+		}
+	}
+	if suffix == "driver" || strings.HasPrefix(suffix, "driver_") {
+		return true
+	}
+	// Legacy Mongo rows predate explicit client-mode naming and look like
+	// mongo_range_index or mongo_writers_4. They are ordinary driver baselines.
+	return true
 }
 
 func sortedRunRecordKeys(records map[string]*runRecord) []string {
@@ -571,34 +595,21 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	b.WriteString("\n")
 	renderDiskTable(&b, cells)
 	b.WriteString("\n")
+	renderMongoRowsTable(&b, cells)
+	b.WriteString("\n")
 	renderConcurrentReadSweepTable(&b, cells)
 	renderOpsTable(&b, cells)
 	b.WriteString("\n")
 	b.WriteString("## Raw Inputs\n\n")
 	b.WriteString("| docs | indexes | range index | config | target | raw json | profile dir |\n")
 	b.WriteString("| ---: | ---: | --- | --- | --- | --- | --- |\n")
-	type mongoRawKey struct {
-		baseCellKey
-		Config     string
-		RangeIndex bool
-	}
-	seenMongoRaw := make(map[mongoRawKey]struct{})
 	for _, cell := range cells {
 		fmt.Fprintf(&b, "| %d | %d | %t | `%s` | treedb | `%s` | %s |\n",
 			cell.Key.Documents, cell.Key.SecondaryIndexes, cell.TreeDB.Result.RangeIndex, cell.Key.TreeDBConfig, cell.TreeDB.DisplayRawPath, formatOptionalCode(cell.TreeDB.Result.ProfileDir))
-		if cell.Mongo != nil {
-			mongoKey := mongoRawKey{
-				baseCellKey: baseCellKey{Documents: cell.Key.Documents, SecondaryIndexes: cell.Key.SecondaryIndexes},
-				Config:      cell.Mongo.Row.Config,
-				RangeIndex:  cell.Mongo.Result.RangeIndex,
-			}
-			if _, ok := seenMongoRaw[mongoKey]; ok {
-				continue
-			}
-			fmt.Fprintf(&b, "| %d | %d | %t | `%s` | mongo | `%s` | %s |\n",
-				cell.Key.Documents, cell.Key.SecondaryIndexes, cell.Mongo.Result.RangeIndex, cell.Mongo.Row.Config, cell.Mongo.DisplayRawPath, formatOptionalCode(cell.Mongo.Result.ProfileDir))
-			seenMongoRaw[mongoKey] = struct{}{}
-		}
+	}
+	for _, mongo := range uniqueMongoRecords(cells) {
+		fmt.Fprintf(&b, "| %d | %d | %t | `%s` | mongo | `%s` | %s |\n",
+			mongo.Row.Documents, mongo.Row.SecondaryIndexes, mongo.Result.RangeIndex, mongo.Row.Config, mongo.DisplayRawPath, formatOptionalCode(mongo.Result.ProfileDir))
 	}
 	b.WriteString("\n")
 	b.WriteString("## Notes\n\n")
@@ -611,6 +622,105 @@ func renderReport(cfg config, cells []cellComparison, generatedAt time.Time) str
 	b.WriteString("- `concurrent_id_find_one_rN` phases are an `_id` read throughput sweep over `N` concurrent readers, and are grouped in the Concurrent Read Sweep section when present.\n")
 	b.WriteString("- Range-query benchmark rows use explicit phase names: `age_range_indexed_limit_10` means `-range-index` created `age_1`; `age_range_scan_limit_10` means bounded scan fallback.\n")
 	return b.String()
+}
+
+func renderMongoRowsTable(b *strings.Builder, cells []cellComparison) {
+	rows := uniqueMongoRecords(cells)
+	if len(rows) == 0 {
+		return
+	}
+	b.WriteString("## Mongo Matrix Rows\n\n")
+	b.WriteString("These rows list every MongoDB matrix row, including non-baseline client-mode rows that are not used as the TreeDB comparison baseline.\n\n")
+	b.WriteString("| docs | indexes | range index | config | phase | ops/sec | sampled ops/sec | p95 us | dbStats totalSize | physical du | raw json |\n")
+	b.WriteString("| ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |\n")
+	for _, record := range rows {
+		phase, hasPhase := primaryMongoPhase(record)
+		total, totalOK := mongoDBStatsTotalBytes(record.Result)
+		fmt.Fprintf(b, "| %d | %d | %t | `%s` | `%s` | %s | %s | %s | %s | %s | `%s` |\n",
+			record.Row.Documents,
+			record.Row.SecondaryIndexes,
+			record.Result.RangeIndex,
+			record.Row.Config,
+			phase.Name,
+			formatPhaseOps(hasPhase, phase.OpsPerSecond),
+			formatPhaseOps(hasPhase && phase.SampledOpsPerSecond > 0, phase.SampledOpsPerSecond),
+			formatPhaseLatency(hasPhase, phase.LatencyMicros.P95),
+			formatMeasuredBytes(totalOK, total),
+			formatOptionalBytes(record.Row.PhysicalBytes),
+			record.DisplayRawPath,
+		)
+	}
+	b.WriteString("\n")
+}
+
+func primaryMongoPhase(record *runRecord) (phaseResult, bool) {
+	if record == nil {
+		return phaseResult{}, false
+	}
+	if phase, ok := record.PhaseMap["load_insert_many"]; ok {
+		return phase, true
+	}
+	for _, phase := range record.Result.Phases {
+		if phase.OpsPerSecond > 0 {
+			return phase, true
+		}
+	}
+	if len(record.Result.Phases) > 0 {
+		return record.Result.Phases[0], true
+	}
+	return phaseResult{}, false
+}
+
+type runRecordRawKey struct {
+	baseCellKey
+	Config     string
+	RangeIndex bool
+	RawPath    string
+}
+
+func uniqueMongoRecords(cells []cellComparison) []*runRecord {
+	seen := make(map[runRecordRawKey]struct{})
+	var out []*runRecord
+	for _, cell := range cells {
+		addMongoRecord(&out, seen, cell.Mongo)
+		for _, record := range cell.MongoAlternates {
+			addMongoRecord(&out, seen, record)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.Row.Documents != b.Row.Documents {
+			return a.Row.Documents < b.Row.Documents
+		}
+		if a.Row.SecondaryIndexes != b.Row.SecondaryIndexes {
+			return a.Row.SecondaryIndexes < b.Row.SecondaryIndexes
+		}
+		if a.Result.RangeIndex != b.Result.RangeIndex {
+			return !a.Result.RangeIndex && b.Result.RangeIndex
+		}
+		if a.Row.Config != b.Row.Config {
+			return a.Row.Config < b.Row.Config
+		}
+		return a.DisplayRawPath < b.DisplayRawPath
+	})
+	return out
+}
+
+func addMongoRecord(out *[]*runRecord, seen map[runRecordRawKey]struct{}, record *runRecord) {
+	if record == nil {
+		return
+	}
+	key := runRecordRawKey{
+		baseCellKey: baseCellKey{Documents: record.Row.Documents, SecondaryIndexes: record.Row.SecondaryIndexes},
+		Config:      record.Row.Config,
+		RangeIndex:  record.Result.RangeIndex,
+		RawPath:     record.DisplayRawPath,
+	}
+	if _, ok := seen[key]; ok {
+		return
+	}
+	seen[key] = struct{}{}
+	*out = append(*out, record)
 }
 
 func hasMongoCells(cells []cellComparison) bool {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -321,12 +321,40 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongoIndex mongoSce
 	matches := mongoIndex.bySuffix[treeScenario.suffix]
 	candidates := mongoIndex.suffixConfig[treeScenario.suffix]
 	if len(candidates) > 1 {
+		if record := preferredMongoDriverBaseline(matches); record != nil {
+			return record, nil
+		}
 		return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenarioLabel, candidates, sortedRunRecordKeys(mongoIndex.exact))
 	}
 	if len(matches) == 1 {
 		return matches[0], nil
 	}
 	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q tree_scenario=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenarioLabel, sortedRunRecordKeys(mongoIndex.exact))
+}
+
+func preferredMongoDriverBaseline(records []*runRecord) *runRecord {
+	var out *runRecord
+	for _, record := range records {
+		if record == nil || !isMongoDriverBaselineConfig(record.Row.Config) {
+			continue
+		}
+		if out != nil {
+			return nil
+		}
+		out = record
+	}
+	return out
+}
+
+func isMongoDriverBaselineConfig(config string) bool {
+	if config == "mongo" || config == "mongo_driver" {
+		return true
+	}
+	if !strings.HasPrefix(config, "mongo_driver_") {
+		return false
+	}
+	return !strings.HasPrefix(config, "mongo_driver_command") &&
+		!strings.HasPrefix(config, "mongo_driver_unack")
 }
 
 func sortedRunRecordKeys(records map[string]*runRecord) []string {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -323,8 +323,14 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongoIndex mongoSce
 	matches := mongoIndex.bySuffix[treeScenario.suffix]
 	candidates := mongoIndex.suffixConfig[treeScenario.suffix]
 	if len(candidates) > 1 {
-		if record := preferredMongoDriverBaseline(matches); record != nil {
+		if record, ambiguous := preferredMongoDriverBaseline(matches); record != nil {
 			return record, nil
+		} else if ambiguous {
+			return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenarioLabel, candidates, sortedRunRecordKeys(mongoIndex.exact))
+		}
+		records := sortedRunRecords(matches)
+		if len(records) > 0 {
+			return records[0], nil
 		}
 		return nil, fmt.Errorf("ambiguous mongo rows for documents=%d secondary_indexes=%d config=%q tree_scenario=%q candidates=%v available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenarioLabel, candidates, sortedRunRecordKeys(mongoIndex.exact))
 	}
@@ -334,31 +340,34 @@ func matchingMongoRecord(key baseCellKey, treeConfig string, mongoIndex mongoSce
 	return nil, fmt.Errorf("missing mongo row for documents=%d secondary_indexes=%d config=%q tree_scenario=%q available_mongo_configs=%v", key.Documents, key.SecondaryIndexes, treeConfig, treeScenarioLabel, sortedRunRecordKeys(mongoIndex.exact))
 }
 
-func preferredMongoDriverBaseline(records []*runRecord) *runRecord {
+func preferredMongoDriverBaseline(records []*runRecord) (*runRecord, bool) {
 	var legacy *runRecord
 	var explicit *runRecord
+	baselines := 0
 	for _, record := range records {
 		if record == nil {
 			continue
 		}
 		if isLegacyMongoDriverBaselineConfig(record.Row.Config) {
-			if legacy != nil {
-				return nil
-			}
+			baselines++
 			legacy = record
 			continue
 		}
 		if isExplicitMongoDriverBaselineConfig(record.Row.Config) {
-			if explicit != nil {
-				return nil
-			}
+			baselines++
 			explicit = record
 		}
 	}
-	if legacy != nil {
-		return legacy
+	if baselines > 1 && legacy == nil {
+		return nil, true
 	}
-	return explicit
+	if baselines > 1 && explicit == nil {
+		return nil, true
+	}
+	if legacy != nil {
+		return legacy, false
+	}
+	return explicit, false
 }
 
 func sortedMongoRecords(recordsByConfig map[string]*runRecord) []*runRecord {
@@ -366,6 +375,11 @@ func sortedMongoRecords(recordsByConfig map[string]*runRecord) []*runRecord {
 	for _, record := range recordsByConfig {
 		records = append(records, record)
 	}
+	return sortedRunRecords(records)
+}
+
+func sortedRunRecords(records []*runRecord) []*runRecord {
+	records = append([]*runRecord(nil), records...)
 	sort.Slice(records, func(i, j int) bool {
 		if records[i].Row.Config != records[j].Row.Config {
 			return records[i].Row.Config < records[j].Row.Config
@@ -688,6 +702,11 @@ func primaryMongoPhase(record *runRecord) (phaseResult, bool) {
 	if record == nil {
 		return phaseResult{}, false
 	}
+	if phaseName := scalingPrimaryPhaseName(record.Row.Config); phaseName != "" {
+		if phase, ok := record.PhaseMap[phaseName]; ok {
+			return phase, true
+		}
+	}
 	if phase, ok := record.PhaseMap["load_insert_many"]; ok {
 		return phase, true
 	}
@@ -700,6 +719,20 @@ func primaryMongoPhase(record *runRecord) (phaseResult, bool) {
 		return record.Result.Phases[0], true
 	}
 	return phaseResult{}, false
+}
+
+func scalingPrimaryPhaseName(config string) string {
+	scenario := parseScalingScenario(config)
+	if !scenario.valid || !scenario.hasMarker {
+		return ""
+	}
+	if count, ok := strings.CutPrefix(scenario.suffix, "writers_"); ok {
+		return "concurrent_id_update_set_w" + count
+	}
+	if count, ok := strings.CutPrefix(scenario.suffix, "readers_"); ok {
+		return "concurrent_id_find_one_r" + count
+	}
+	return ""
 }
 
 type runRecordRawKey struct {

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -785,15 +785,14 @@ func TestReportMatchesUnsuffixedTreeConfigWithMixedMongoRows(t *testing.T) {
 		t.Fatalf("run failed: %v", err)
 	}
 	report := readFile(t, reportPath)
-	if !strings.Contains(report, "| 100 | 2 | false | n/a | `treedb_bson_driver-command-raw` | `insert` | 1000 | n/a | 500 | n/a | 2.00x | n/a |") {
-		t.Fatalf("report missing unsuffixed comparison\n%s", report)
-	}
 	for _, want := range []string{
+		"| 100 | 2 | false | n/a | `treedb_bson_driver-command-raw` | `insert` | 1000 | n/a | 500 | n/a | 2.00x | n/a |",
+		"## Mongo Matrix Rows",
 		"| 100 | 2 | false | `mongo_writers_1` | `concurrent_id_update_set_w1` | 600 | n/a | 0 | 4.00 KiB | 4.00 KiB | `mongo_w1.json` |",
 		"| 100 | 2 | false | `mongo_writers_1` | mongo | `mongo_w1.json` | n/a |",
 	} {
 		if !strings.Contains(report, want) {
-			t.Fatalf("report missing mixed Mongo row %q\n%s", want, report)
+			t.Fatalf("report missing %q\n%s", want, report)
 		}
 	}
 }

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -771,7 +771,10 @@ func TestReportMatchesUnsuffixedTreeConfigWithMixedMongoRows(t *testing.T) {
   "target": "mongo",
   "documents": 100,
   "secondary_indexes": 2,
-  "phases": [{"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 600, "latency_micros": {}}],
+  "phases": [
+    {"name": "load_insert_many", "operations": 100, "ops_per_sec": 300, "latency_micros": {}},
+    {"name": "concurrent_id_update_set_w1", "operations": 100, "ops_per_sec": 600, "latency_micros": {}}
+  ],
   "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4100}
 }`)
 	matrixPath := filepath.Join(dir, "matrix.tsv")
@@ -790,6 +793,51 @@ func TestReportMatchesUnsuffixedTreeConfigWithMixedMongoRows(t *testing.T) {
 		"## Mongo Matrix Rows",
 		"| 100 | 2 | false | `mongo_writers_1` | `concurrent_id_update_set_w1` | 600 | n/a | 0 | 4.00 KiB | 4.00 KiB | `mongo_w1.json` |",
 		"| 100 | 2 | false | `mongo_writers_1` | mongo | `mongo_w1.json` | n/a |",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q\n%s", want, report)
+		}
+	}
+}
+
+func TestReportUsesDeterministicMongoFallbackWithoutDriverBaseline(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_command.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 800, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_unack.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 700, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4100}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	reportPath := filepath.Join(dir, "report.md")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver_command_raw\t100\t2\ttreedb.json\t2000\n"+
+		"mongo\tmongo_driver_command\t100\t2\tmongo_command.json\t4000\n"+
+		"mongo\tmongo_driver_unack\t100\t2\tmongo_unack.json\t4100\n")
+
+	if err := run([]string{"-matrix", matrixPath, "-report", reportPath}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	report := readFile(t, reportPath)
+	for _, want := range []string{
+		"| 100 | 2 | false | n/a | `treedb_bson_driver_command_raw` | `load_insert_many` | 1000 | n/a | 800 | n/a | 1.25x | n/a |",
+		"| 100 | 2 | false | `mongo_driver_command` | `load_insert_many` | 800 | n/a | 0 | 3.91 KiB | 3.91 KiB | `mongo_command.json` |",
+		"| 100 | 2 | false | `mongo_driver_unack` | `load_insert_many` | 700 | n/a | 0 | 4.00 KiB | 4.00 KiB | `mongo_unack.json` |",
 	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("report missing %q\n%s", want, report)

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -57,8 +57,8 @@ func TestReportFromMatrix(t *testing.T) {
 		"# Mongo Gateway Benchmark Comparison",
 		"Largest TreeDB ops/sec lead: `load_insert_many`",
 		"Largest MongoDB ops/sec lead: `id_find_one`",
-		"| 100 | 1 | false | n/a | `treedb` | `load_insert_many` | 10000 | 12500 | 5000 | 6250 | 2.00x | 2.00x | 20.0 | 40.0 |",
-		"| 100 | 1 | false | `treedb` | checkpoint | 1000 B | 10.0 B | 2.00 KiB | 20.5 B | 1.27 KiB | 1.46 KiB | 4.00 KiB | 41.0 B | 0.67x | 0.50x |",
+		"| 100 | 1 | false | n/a | `treedb` | `mongo` | `load_insert_many` | 10000 | 12500 | 5000 | 6250 | 2.00x | 2.00x | 20.0 | 40.0 |",
+		"| 100 | 1 | false | `treedb` | `mongo` | checkpoint | 1000 B | 10.0 B | 2.00 KiB | 20.5 B | 1.27 KiB | 1.46 KiB | 4.00 KiB | 41.0 B | 0.67x | 0.50x |",
 	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("report missing %q\n%s", want, report)
@@ -120,7 +120,7 @@ func TestReportShowsRangeIndexModeAndProfileDir(t *testing.T) {
 
 	report := readFile(t, reportPath)
 	for _, want := range []string{
-		"| 1000 | 0 | true | `indexed` | `treedb_template_v1_driver_range_index` | `age_range_indexed_limit_10` | 3000 | 3100 | 4000 | 4100 | 0.75x | 0.76x | 400 | 300 |",
+		"| 1000 | 0 | true | `indexed` | `treedb_template_v1_driver_range_index` | `mongo_range_index` | `age_range_indexed_limit_10` | 3000 | 3100 | 4000 | 4100 | 0.75x | 0.76x | 400 | 300 |",
 		"| 1000 | 0 | true | `treedb_template_v1_driver_range_index` | treedb | `treedb_range.json` | `/tmp/range-profiles` |",
 		"Range-query benchmark rows use explicit phase names",
 	} {
@@ -129,7 +129,7 @@ func TestReportShowsRangeIndexModeAndProfileDir(t *testing.T) {
 		}
 	}
 	summary := readFile(t, summaryPath)
-	if !strings.Contains(summary, "1000\t0\ttrue\tindexed\ttreedb_template_v1_driver_range_index\tage_range_indexed_limit_10") {
+	if !strings.Contains(summary, "1000\t0\ttrue\tindexed\ttreedb_template_v1_driver_range_index\tmongo_range_index\tage_range_indexed_limit_10") {
 		t.Fatalf("summary missing indexed range mode:\n%s", summary)
 	}
 }
@@ -224,14 +224,14 @@ func TestReportGroupsConcurrentReadSweepRows(t *testing.T) {
 	for _, want := range []string{
 		"## Concurrent Read Sweep",
 		"Serial `id_find_one` remains a separate single-in-flight latency phase.",
-		"| 100 | 0 | `treedb_bson` | 1 | 1000 | 1200 | 500 | 600 | 2.00x | 15.0 | 30.0 |",
-		"| 100 | 0 | `treedb_bson` | 4 | 4000 | 4200 | 2000 | 2200 | 2.00x | 10.0 | 20.0 |",
+		"| 100 | 0 | `treedb_bson` | `mongo` | 1 | 1000 | 1200 | 500 | 600 | 2.00x | 15.0 | 30.0 |",
+		"| 100 | 0 | `treedb_bson` | `mongo` | 4 | 4000 | 4200 | 2000 | 2200 | 2.00x | 10.0 | 20.0 |",
 	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("report missing %q\n%s", want, report)
 		}
 	}
-	if strings.Index(report, "| 100 | 0 | `treedb_bson` | 1 |") > strings.Index(report, "| 100 | 0 | `treedb_bson` | 4 |") {
+	if strings.Index(report, "| 100 | 0 | `treedb_bson` | `mongo` | 1 |") > strings.Index(report, "| 100 | 0 | `treedb_bson` | `mongo` | 4 |") {
 		t.Fatalf("reader sweep rows should be ordered by reader count:\n%s", report)
 	}
 	opsSection := strings.Split(strings.Split(report, "## Ops/Sec Summary")[1], "## Raw Inputs")[0]
@@ -418,8 +418,8 @@ func TestReportAllowsMixedIncompleteCells(t *testing.T) {
 	}
 	report := readFile(t, reportPath)
 	for _, want := range []string{
-		"| 10 | 0 | false | n/a | `treedb_complete` | `load_insert_many` | 1000 | 1100 | 500 | 550 | 2.00x | 2.00x | 2.00 | 4.00 |",
-		"| 20 | 1 | false | n/a | `treedb_only` | `concurrent_id_find_one_r2` | 2000 | 2200 | n/a | n/a | n/a | n/a | 3.00 | n/a |",
+		"| 10 | 0 | false | n/a | `treedb_complete` | `mongo` | `load_insert_many` | 1000 | 1100 | 500 | 550 | 2.00x | 2.00x | 2.00 | 4.00 |",
+		"| 20 | 1 | false | n/a | `treedb_only` | n/a | `concurrent_id_find_one_r2` | 2000 | 2200 | n/a | n/a | n/a | n/a | 3.00 | n/a |",
 	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("report missing %q\n%s", want, report)
@@ -472,8 +472,8 @@ func TestReportSupportsMultipleTreeDBConfigsPerMongoCell(t *testing.T) {
 	report := readFile(t, reportPath)
 	for _, want := range []string{
 		"comparison cells: `2`",
-		"| 100 | 2 | false | `treedb_bson` | maintenance | 1.46 KiB",
-		"| 100 | 2 | false | `treedb_json` | maintenance | 1.95 KiB",
+		"| 100 | 2 | false | `treedb_bson` | `mongo` | maintenance | 1.46 KiB",
+		"| 100 | 2 | false | `treedb_json` | `mongo` | maintenance | 1.95 KiB",
 		"| 100 | 2 | false | `mongo` | mongo | `mongo.json` | n/a |",
 	} {
 		if !strings.Contains(report, want) {
@@ -528,8 +528,8 @@ func TestReportSupportsScalingMongoConfigsPerScenario(t *testing.T) {
 	}
 	report := readFile(t, reportPath)
 	for _, want := range []string{
-		"| 100 | 2 | false | n/a | `treedb_bson_driver-command-raw_writers_1` | `concurrent_id_update_set_w1` | 1000 | n/a | 500 | n/a | 2.00x | n/a | 10.0 | 30.0 |",
-		"| 100 | 2 | false | n/a | `treedb_bson_driver-command-raw_writers_2` | `concurrent_id_update_set_w2` | 1500 | n/a | 750 | n/a | 2.00x | n/a | 20.0 | 40.0 |",
+		"| 100 | 2 | false | n/a | `treedb_bson_driver-command-raw_writers_1` | `mongo_writers_1` | `concurrent_id_update_set_w1` | 1000 | n/a | 500 | n/a | 2.00x | n/a | 10.0 | 30.0 |",
+		"| 100 | 2 | false | n/a | `treedb_bson_driver-command-raw_writers_2` | `mongo_writers_2` | `concurrent_id_update_set_w2` | 1500 | n/a | 750 | n/a | 2.00x | n/a | 20.0 | 40.0 |",
 		"| 100 | 2 | false | `mongo_writers_1` | mongo | `mongo_w1.json` | n/a |",
 		"| 100 | 2 | false | `mongo_writers_2` | mongo | `mongo_w2.json` | n/a |",
 	} {
@@ -789,7 +789,7 @@ func TestReportMatchesUnsuffixedTreeConfigWithMixedMongoRows(t *testing.T) {
 	}
 	report := readFile(t, reportPath)
 	for _, want := range []string{
-		"| 100 | 2 | false | n/a | `treedb_bson_driver-command-raw` | `insert` | 1000 | n/a | 500 | n/a | 2.00x | n/a |",
+		"| 100 | 2 | false | n/a | `treedb_bson_driver-command-raw` | `mongo` | `insert` | 1000 | n/a | 500 | n/a | 2.00x | n/a |",
 		"## Mongo Matrix Rows",
 		"| 100 | 2 | false | `mongo_writers_1` | `concurrent_id_update_set_w1` | 600 | n/a | 0 | 4.00 KiB | 4.00 KiB | `mongo_w1.json` |",
 		"| 100 | 2 | false | `mongo_writers_1` | mongo | `mongo_w1.json` | n/a |",
@@ -825,23 +825,28 @@ func TestReportUsesDeterministicMongoFallbackWithoutDriverBaseline(t *testing.T)
 }`)
 	matrixPath := filepath.Join(dir, "matrix.tsv")
 	reportPath := filepath.Join(dir, "report.md")
+	summaryPath := filepath.Join(dir, "summary.tsv")
 	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
 		"treedb\ttreedb_bson_driver_command_raw\t100\t2\ttreedb.json\t2000\n"+
 		"mongo\tmongo_driver_command\t100\t2\tmongo_command.json\t4000\n"+
 		"mongo\tmongo_driver_unack\t100\t2\tmongo_unack.json\t4100\n")
 
-	if err := run([]string{"-matrix", matrixPath, "-report", reportPath}); err != nil {
+	if err := run([]string{"-matrix", matrixPath, "-report", reportPath, "-summary", summaryPath}); err != nil {
 		t.Fatalf("run failed: %v", err)
 	}
 	report := readFile(t, reportPath)
 	for _, want := range []string{
-		"| 100 | 2 | false | n/a | `treedb_bson_driver_command_raw` | `load_insert_many` | 1000 | n/a | 800 | n/a | 1.25x | n/a |",
+		"| 100 | 2 | false | n/a | `treedb_bson_driver_command_raw` | `mongo_driver_command` | `load_insert_many` | 1000 | n/a | 800 | n/a | 1.25x | n/a |",
 		"| 100 | 2 | false | `mongo_driver_command` | `load_insert_many` | 800 | n/a | 0 | 3.91 KiB | 3.91 KiB | `mongo_command.json` |",
 		"| 100 | 2 | false | `mongo_driver_unack` | `load_insert_many` | 700 | n/a | 0 | 4.00 KiB | 4.00 KiB | `mongo_unack.json` |",
 	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("report missing %q\n%s", want, report)
 		}
+	}
+	summary := readFile(t, summaryPath)
+	if !strings.Contains(summary, "treedb_bson_driver_command_raw\tmongo_driver_command\tload_insert_many") {
+		t.Fatalf("summary missing selected non-driver Mongo config:\n%s", summary)
 	}
 }
 
@@ -879,7 +884,7 @@ func TestReportUsesMongoDriverBaselineWithMultipleMongoClientModes(t *testing.T)
 		t.Fatalf("run failed: %v", err)
 	}
 	report := readFile(t, reportPath)
-	if !strings.Contains(report, "| 100 | 2 | false | n/a | `treedb_bson_driver_command_raw` | `load_insert_many` | 1000 | n/a | 500 | n/a | 2.00x | n/a |") {
+	if !strings.Contains(report, "| 100 | 2 | false | n/a | `treedb_bson_driver_command_raw` | `mongo_driver` | `load_insert_many` | 1000 | n/a | 500 | n/a | 2.00x | n/a |") {
 		t.Fatalf("report missing driver-baseline comparison\n%s", report)
 	}
 	for _, want := range []string{
@@ -891,6 +896,35 @@ func TestReportUsesMongoDriverBaselineWithMultipleMongoClientModes(t *testing.T)
 		if !strings.Contains(report, want) {
 			t.Fatalf("report missing %q\n%s", want, report)
 		}
+	}
+}
+
+func TestPrimaryMongoPhaseUsesScalingScenarioPhase(t *testing.T) {
+	record := &runRecord{
+		Row: matrixRow{Config: "mongo_writers_4"},
+		Result: benchmarkResult{Phases: []phaseResult{
+			{Name: "load_insert_many", OpsPerSecond: 100},
+			{Name: "concurrent_id_update_set_w4", OpsPerSecond: 400},
+		}},
+		PhaseMap: phaseMap([]phaseResult{
+			{Name: "load_insert_many", OpsPerSecond: 100},
+			{Name: "concurrent_id_update_set_w4", OpsPerSecond: 400},
+		}),
+	}
+	phase, ok := primaryMongoPhase(record)
+	if !ok || phase.Name != "concurrent_id_update_set_w4" || phase.OpsPerSecond != 400 {
+		t.Fatalf("primaryMongoPhase=%+v,%t want scenario-specific writer phase", phase, ok)
+	}
+
+	record.Row.Config = "mongo_readers_16"
+	record.Result.Phases = []phaseResult{
+		{Name: "load_insert_many", OpsPerSecond: 100},
+		{Name: "concurrent_id_find_one_r16", OpsPerSecond: 1600},
+	}
+	record.PhaseMap = phaseMap(record.Result.Phases)
+	phase, ok = primaryMongoPhase(record)
+	if !ok || phase.Name != "concurrent_id_find_one_r16" || phase.OpsPerSecond != 1600 {
+		t.Fatalf("primaryMongoPhase=%+v,%t want scenario-specific reader phase", phase, ok)
 	}
 }
 
@@ -932,7 +966,7 @@ func TestReportUsesLegacyMongoBaselineWithMultipleMongoClientModes(t *testing.T)
 	}
 	report := readFile(t, reportPath)
 	for _, want := range []string{
-		"| 100 | 2 | true | n/a | `treedb_bson_driver_command_raw_range_index` | `load_insert_many` | 1000 | n/a | 500 | n/a | 2.00x | n/a |",
+		"| 100 | 2 | true | n/a | `treedb_bson_driver_command_raw_range_index` | `mongo_range_index` | `load_insert_many` | 1000 | n/a | 500 | n/a | 2.00x | n/a |",
 		"| 100 | 2 | true | `mongo_driver_command_raw_range_index` | `load_insert_many` | 900 | n/a | 0 | 4.00 KiB | 4.00 KiB | `mongo_command.json` |",
 		"| 100 | 2 | true | `mongo_driver_command_raw_range_index` | mongo | `mongo_command.json` | n/a |",
 	} {
@@ -985,13 +1019,50 @@ func TestReportPrefersLegacyMongoBaselineWhenMixedWithExplicitDriverRows(t *test
 	}
 	report := readFile(t, reportPath)
 	for _, want := range []string{
-		"| 100 | 2 | false | n/a | `treedb_bson_driver_command_raw` | `load_insert_many` | 1000 | n/a | 500 | n/a | 2.00x | n/a |",
+		"| 100 | 2 | false | n/a | `treedb_bson_driver_command_raw` | `mongo` | `load_insert_many` | 1000 | n/a | 500 | n/a | 2.00x | n/a |",
 		"| 100 | 2 | false | `mongo_driver` | `load_insert_many` | 600 | n/a | 0 | 4.00 KiB | 4.00 KiB | `mongo_driver.json` |",
 		"| 100 | 2 | false | `mongo_driver_command_raw` | `load_insert_many` | 900 | n/a | 0 | 4.10 KiB | 4.10 KiB | `mongo_command.json` |",
 	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("report missing %q\n%s", want, report)
 		}
+	}
+}
+
+func TestReportRejectsMultipleLegacyMongoBaselines(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 500, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_legacy.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 550, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3100, "totalSize": 4100}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver_command_raw\t100\t2\ttreedb.json\t2000\n"+
+		"mongo\tmongo\t100\t2\tmongo.json\t4000\n"+
+		"mongo\tmongo_range_index\t100\t2\tmongo_legacy.json\t4100\n")
+
+	err := run([]string{"-matrix", matrixPath, "-report", filepath.Join(dir, "report.md")})
+	if err == nil ||
+		!strings.Contains(err.Error(), "multiple legacy MongoDB driver baseline candidates") ||
+		!strings.Contains(err.Error(), "mongo_range_index") {
+		t.Fatalf("err=%v want multiple legacy MongoDB baseline rejection", err)
 	}
 }
 
@@ -1143,7 +1214,7 @@ func TestMissingTreeDBDiskSnapshotRendersNA(t *testing.T) {
 
 	var table strings.Builder
 	renderDiskTable(&table, cells)
-	row := "| 100 | 1 | false | `` | n/a | n/a | n/a | n/a | n/a | 1.27 KiB | 1.46 KiB | n/a | n/a | n/a | n/a |"
+	row := "| 100 | 1 | false | `` | n/a | n/a | n/a | n/a | n/a | n/a | 1.27 KiB | 1.46 KiB | n/a | n/a | n/a | n/a |"
 	if !strings.Contains(table.String(), row) {
 		t.Fatalf("disk table missing n/a row %q:\n%s", row, table.String())
 	}

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -827,6 +827,64 @@ func TestReportUsesMongoDriverBaselineWithMultipleMongoClientModes(t *testing.T)
 	if !strings.Contains(report, "| 100 | 2 | false | n/a | `treedb_bson_driver_command_raw` | `load_insert_many` | 1000 | n/a | 500 | n/a | 2.00x | n/a |") {
 		t.Fatalf("report missing driver-baseline comparison\n%s", report)
 	}
+	for _, want := range []string{
+		"## Mongo Matrix Rows",
+		"| 100 | 2 | false | `mongo_driver` | `load_insert_many` | 500 | n/a | 0 | 3.91 KiB | 3.91 KiB | `mongo_driver.json` |",
+		"| 100 | 2 | false | `mongo_driver_command` | `load_insert_many` | 800 | n/a | 0 | 4.00 KiB | 4.00 KiB | `mongo_command.json` |",
+		"| 100 | 2 | false | `mongo_driver_command` | mongo | `mongo_command.json` | n/a |",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q\n%s", want, report)
+		}
+	}
+}
+
+func TestReportUsesLegacyMongoBaselineWithMultipleMongoClientModes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "range_index": true,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_range.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "range_index": true,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 500, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_command.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "range_index": true,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 900, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4100}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	reportPath := filepath.Join(dir, "report.md")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver_command_raw_range_index\t100\t2\ttreedb.json\t2000\n"+
+		"mongo\tmongo_range_index\t100\t2\tmongo_range.json\t4000\n"+
+		"mongo\tmongo_driver_command_raw_range_index\t100\t2\tmongo_command.json\t4100\n")
+
+	if err := run([]string{"-matrix", matrixPath, "-report", reportPath}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	report := readFile(t, reportPath)
+	for _, want := range []string{
+		"| 100 | 2 | true | n/a | `treedb_bson_driver_command_raw_range_index` | `load_insert_many` | 1000 | n/a | 500 | n/a | 2.00x | n/a |",
+		"| 100 | 2 | true | `mongo_driver_command_raw_range_index` | `load_insert_many` | 900 | n/a | 0 | 4.00 KiB | 4.00 KiB | `mongo_command.json` |",
+		"| 100 | 2 | true | `mongo_driver_command_raw_range_index` | mongo | `mongo_command.json` | n/a |",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q\n%s", want, report)
+		}
+	}
 }
 
 func TestReportRejectsAmbiguousScalingMongoConfigsPerScenario(t *testing.T) {

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -788,6 +788,14 @@ func TestReportMatchesUnsuffixedTreeConfigWithMixedMongoRows(t *testing.T) {
 	if !strings.Contains(report, "| 100 | 2 | false | n/a | `treedb_bson_driver-command-raw` | `insert` | 1000 | n/a | 500 | n/a | 2.00x | n/a |") {
 		t.Fatalf("report missing unsuffixed comparison\n%s", report)
 	}
+	for _, want := range []string{
+		"| 100 | 2 | false | `mongo_writers_1` | `concurrent_id_update_set_w1` | 600 | n/a | 0 | 4.00 KiB | 4.00 KiB | `mongo_w1.json` |",
+		"| 100 | 2 | false | `mongo_writers_1` | mongo | `mongo_w1.json` | n/a |",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing mixed Mongo row %q\n%s", want, report)
+		}
+	}
 }
 
 func TestReportUsesMongoDriverBaselineWithMultipleMongoClientModes(t *testing.T) {

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -887,6 +887,59 @@ func TestReportUsesLegacyMongoBaselineWithMultipleMongoClientModes(t *testing.T)
 	}
 }
 
+func TestReportPrefersLegacyMongoBaselineWhenMixedWithExplicitDriverRows(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 500, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_driver.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 600, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4100}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_command.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 900, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4200}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	reportPath := filepath.Join(dir, "report.md")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver_command_raw\t100\t2\ttreedb.json\t2000\n"+
+		"mongo\tmongo\t100\t2\tmongo.json\t4000\n"+
+		"mongo\tmongo_driver\t100\t2\tmongo_driver.json\t4100\n"+
+		"mongo\tmongo_driver_command_raw\t100\t2\tmongo_command.json\t4200\n")
+
+	if err := run([]string{"-matrix", matrixPath, "-report", reportPath}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	report := readFile(t, reportPath)
+	for _, want := range []string{
+		"| 100 | 2 | false | n/a | `treedb_bson_driver_command_raw` | `load_insert_many` | 1000 | n/a | 500 | n/a | 2.00x | n/a |",
+		"| 100 | 2 | false | `mongo_driver` | `load_insert_many` | 600 | n/a | 0 | 4.00 KiB | 4.00 KiB | `mongo_driver.json` |",
+		"| 100 | 2 | false | `mongo_driver_command_raw` | `load_insert_many` | 900 | n/a | 0 | 4.10 KiB | 4.10 KiB | `mongo_command.json` |",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q\n%s", want, report)
+		}
+	}
+}
+
 func TestMongoDriverBaselineConfigRequiresKnownBaselineForms(t *testing.T) {
 	for _, tc := range []struct {
 		config string

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -887,6 +887,36 @@ func TestReportUsesLegacyMongoBaselineWithMultipleMongoClientModes(t *testing.T)
 	}
 }
 
+func TestMongoDriverBaselineConfigRequiresKnownBaselineForms(t *testing.T) {
+	for _, tc := range []struct {
+		config string
+		want   bool
+	}{
+		{config: "mongo", want: true},
+		{config: "mongo_driver", want: true},
+		{config: "mongo_driver_range_index", want: true},
+		{config: "mongo_driver_writers_4", want: true},
+		{config: "mongo_driver_readers_16", want: true},
+		{config: "mongo_driver_range_index_writers_4", want: true},
+		{config: "mongo_driver_range_index_readers_16", want: true},
+		{config: "mongo_driver_command", want: false},
+		{config: "mongo_driver_command_range_index", want: false},
+		{config: "mongo_driver_command_raw", want: false},
+		{config: "mongo_driver_command_raw_range_index", want: false},
+		{config: "mongo_driver_unack", want: false},
+		{config: "mongo_driver_unack_range_index", want: false},
+		{config: "mongo_driver_future_mode", want: false},
+		{config: "mongo_driver_future_mode_writers_4", want: false},
+		{config: "mongo_range_index", want: true},
+		{config: "mongo_writers_4", want: true},
+		{config: "treedb_bson_driver", want: false},
+	} {
+		if got := isMongoDriverBaselineConfig(tc.config); got != tc.want {
+			t.Fatalf("isMongoDriverBaselineConfig(%q)=%t want %t", tc.config, got, tc.want)
+		}
+	}
+}
+
 func TestReportRejectsAmbiguousScalingMongoConfigsPerScenario(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "treedb_w1.json"), `{

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -790,6 +790,45 @@ func TestReportMatchesUnsuffixedTreeConfigWithMixedMongoRows(t *testing.T) {
 	}
 }
 
+func TestReportUsesMongoDriverBaselineWithMultipleMongoClientModes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "treedb.json"), `{
+  "target": "treedb",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 1000, "latency_micros": {}}],
+  "treedb_disk_after_checkpoint": {"total_bytes": 2000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_driver.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 500, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4000}
+}`)
+	writeFile(t, filepath.Join(dir, "mongo_command.json"), `{
+  "target": "mongo",
+  "documents": 100,
+  "secondary_indexes": 2,
+  "phases": [{"name": "load_insert_many", "operations": 100, "ops_per_sec": 800, "latency_micros": {}}],
+  "mongodb_stats_final": {"dataSize": 3000, "totalSize": 4100}
+}`)
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	reportPath := filepath.Join(dir, "report.md")
+	writeFile(t, matrixPath, "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\ttreedb_bson_driver_command_raw\t100\t2\ttreedb.json\t2000\n"+
+		"mongo\tmongo_driver\t100\t2\tmongo_driver.json\t4000\n"+
+		"mongo\tmongo_driver_command\t100\t2\tmongo_command.json\t4100\n")
+
+	if err := run([]string{"-matrix", matrixPath, "-report", reportPath}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	report := readFile(t, reportPath)
+	if !strings.Contains(report, "| 100 | 2 | false | n/a | `treedb_bson_driver_command_raw` | `load_insert_many` | 1000 | n/a | 500 | n/a | 2.00x | n/a |") {
+		t.Fatalf("report missing driver-baseline comparison\n%s", report)
+	}
+}
+
 func TestReportRejectsAmbiguousScalingMongoConfigsPerScenario(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "treedb_w1.json"), `{

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,8 @@ Behavioral guarantees for downstream systems (e.g., replication layers).
 ## 📊 Benchmarking
 
 - **[Benchmark Spec](BENCHMARK_SPEC.md)**: Methodology and test definitions.
+- **[TreeDB Canonical Benchmark Runbook](benchmarks/treedb_canonical_benchmark_runbook.md)**: Standard TreeDB engine, collections, Mongo gateway, profiling, and reporting workflows.
+- **[TreeDB Collections Canonical Benchmark](benchmarks/collections_canonical_benchmark.md)**: Canonical TreeDB-vs-SQLite collection benchmark and maintenance-phase semantics.
 - **[Unified Bench](../cmd/unified_bench/README.md)**: Usage guide for benchmark execution and artifact capture.
 - **[BenchProf](../cmd/benchprof/README.md)**: Analysis tool for CPU/alloc/block/mutex profiles and ops/sec outputs.
 - **[Redis Protocol Benchmarking](REDIS_PROTOCOL_BENCHMARKING.md)**: Preferred way to measure Redis wrapper throughput.

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -71,22 +71,31 @@ Build the tools:
 make unified-bench benchprof
 ```
 
-Standard profile capture:
+Standard profile capture runs the full raw-engine test matrix at 800k keys.
+Omit `-test`; the default is `-test all`.
 
 ```sh
-OUT=$(mktemp -d /tmp/gomap_profiles_XXXXXX)
+OUT_ROOT=/tmp/gomap_raw_engine_full_$(date +%Y%m%d_%H%M%S)
+mkdir -p "$OUT_ROOT"
 
-./bin/unified-bench \
-  -dbs treedb \
-  -keys 800000 \
-  -profile wal_on_fast \
-  -path-label native-fastpath \
-  -checkpoint-between-tests \
-  -test random_write,random_delete,random_read,full_scan,prefix_scan \
-  -profile-dir "$OUT" \
-  -progress=false
-
-./bin/benchprof -profiles-dir "$OUT"
+for profile in wal_on_fast fast; do
+  for checkpoint_mode in checkpoint_between_tests no_checkpoint_between_tests; do
+    OUT="$OUT_ROOT/${profile}_${checkpoint_mode}"
+    args=(
+      -dbs treedb
+      -keys 800000
+      -profile "$profile"
+      -path-label native-fastpath
+      -profile-dir "$OUT"
+      -progress=false
+    )
+    if [ "$checkpoint_mode" = checkpoint_between_tests ]; then
+      args+=(-checkpoint-between-tests)
+    fi
+    ./bin/unified-bench "${args[@]}"
+    ./bin/benchprof -profiles-dir "$OUT"
+  done
+done
 ```
 
 Expected profile artifacts:
@@ -123,8 +132,12 @@ Use a stable output directory for any result that will be posted to a PR or
 issue:
 
 ```sh
-OUT=/tmp/collections_canonical_$(date +%Y%m%d_%H%M%S)
-./scripts/bench_collections_canonical.sh -out-dir "$OUT"
+OUT_ROOT=/tmp/collections_canonical_$(date +%Y%m%d_%H%M%S)
+for indexes in 0 1 2; do
+  ./scripts/bench_collections_canonical.sh \
+    -out-dir "$OUT_ROOT/indexes_${indexes}" \
+    -indexes "$indexes"
+done
 ```
 
 The canonical runner emits:
@@ -255,6 +268,10 @@ scripts/mongo_gateway_compare.sh \
   --timeout 120m
 ```
 
+This client-mode matrix is load-only by design. It should report insert
+throughput and disk by client mode, and should not be used as reader/writer
+scaling evidence.
+
 MongoDB matrix config names intentionally keep `mongo` / `mongo_range_index`
 for the ordinary single-driver case. The explicit `mongo_driver` row name is
 reserved for multi-mode MongoDB client matrices so older comparison bundles and
@@ -277,24 +294,30 @@ only to estimate TreeDB gateway/server ceiling.
 ## Reader and Writer Scaling
 
 Use the scaling wrapper when the question is concurrency plateau, update cost,
-or indexed-field update overhead:
+or indexed-field update overhead. Run the index-count loop when reader/writer
+scaling is part of a PR evidence bundle:
 
 ```sh
-scripts/mongo_gateway_scaling_bench.sh \
-  --out /tmp/gomap_mongo_gateway_scaling \
-  --docs 1000000 \
-  --indexes 2 \
-  --batch-size 10000 \
-  --insert-producers 8 \
-  --writers "1 2 4 8 16 32" \
-  --readers "1 2 4 8 16 32" \
-  --concurrent-writes 80000 \
-  --concurrent-reads 80000
+OUT_ROOT=/tmp/gomap_mongo_gateway_scaling_$(date +%Y%m%d_%H%M%S)
+for indexes in 0 1 2; do
+  scripts/mongo_gateway_scaling_bench.sh \
+    --out "$OUT_ROOT/indexes_${indexes}" \
+    --docs 1000000 \
+    --indexes "$indexes" \
+    --batch-size 10000 \
+    --insert-producers 8 \
+    --writers "1 2 4 8 16 32" \
+    --readers "1 2 4 8 16 32" \
+    --concurrent-writes 80000 \
+    --concurrent-reads 80000 \
+    --include-mongo \
+    --mongo-uri mongodb://127.0.0.1:27017
+done
 ```
 
-Add `--include-mongo --mongo-uri mongodb://127.0.0.1:27017` to compare against
-an existing MongoDB server. Add `--update-indexed-field` to update `city` and
-exercise secondary-index maintenance instead of non-indexed document updates.
+Omit `--include-mongo` for a TreeDB-only scaling ceiling check. Add
+`--update-indexed-field` to update `city` and exercise secondary-index
+maintenance instead of non-indexed document updates.
 
 ## Recommended Reference Workloads
 

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -255,6 +255,11 @@ scripts/mongo_gateway_compare.sh \
   --timeout 120m
 ```
 
+MongoDB matrix config names intentionally keep `mongo` / `mongo_range_index`
+for the ordinary single-driver case. The explicit `mongo_driver` row name is
+reserved for multi-mode MongoDB client matrices so older comparison bundles and
+new client-mode bundles remain readable side by side.
+
 Interpret client modes as separate questions:
 
 - `driver`: ordinary official MongoDB Go driver CRUD-helper path.

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -1,0 +1,395 @@
+# TreeDB Canonical Benchmark Runbook
+
+This runbook defines the preferred benchmark entrypoints for TreeDB engine,
+TreeDB collections, and Mongo-compatible collection workloads. Use it when a PR
+or issue needs reproducible throughput, latency, profile, or disk-usage
+evidence.
+
+## Principles
+
+- Start every report with the git commit, branch, host, OS, Go version, command,
+  and output directory.
+- Keep fixture shape explicit: document count, key count, value size, batch size,
+  secondary index count, document format, profile, client mode, concurrency, and
+  maintenance mode.
+- Report both throughput and disk. For latency-sensitive phases, include p50,
+  p95, and p99 when the harness emits them.
+- Keep TreeDB maintenance phases named exactly. Do not call a row "compacted"
+  unless the row is from `offline_rewrite`, `full_leafgen_pack_gc`,
+  `sqlite_vacuum`, or another explicitly documented full-maintenance phase.
+- Keep raw artifacts. Markdown tables are for review; JSON, TSV, profiles, and
+  data directories are the durable evidence.
+
+## Benchmark Layers
+
+TreeDB has three benchmark layers. Pick the lowest layer that answers the
+question, then add higher layers only when the user-facing path matters.
+
+1. Raw TreeDB engine: `cmd/unified_bench` plus `cmd/benchprof`.
+2. TreeDB collections: `cmd/collection_bench_matrix` and the canonical
+   TreeDB-vs-SQLite runner.
+3. Mongo-compatible collections: `cmd/mongo_gateway_bench` and
+   `scripts/mongo_gateway_compare.sh`.
+
+Raw engine results explain storage-engine ceilings and hot paths. Collection
+results explain document storage, secondary indexes, maintenance, and SQLite
+equivalence. Mongo gateway results explain Mongo-compatible ergonomics and the
+cost of the official MongoDB driver, BSON wire handling, and gateway command
+paths.
+
+## Tiers
+
+Use a small tier before running an expensive tier.
+
+`smoke`
+
+- Purpose: validate a harness change or check that the output schema still
+  works.
+- Size: 100 to 10,000 docs or keys.
+- Expected runtime: seconds to a few minutes.
+- Use before publishing benchmark harness PRs.
+
+`pr`
+
+- Purpose: provide reviewable PR evidence.
+- Size: 100,000 to 1,000,000 docs or keys.
+- Expected runtime: minutes to tens of minutes.
+- Use for throughput, latency, disk, and profile comparisons.
+
+`large`
+
+- Purpose: answer scale questions and disk-maintenance questions.
+- Size: 10,000,000 docs or more when the local machine can sustain it.
+- Expected runtime: hours.
+- Use only with an output directory, explicit timeout, and enough disk headroom.
+
+## Raw TreeDB Engine
+
+Build the tools:
+
+```sh
+make unified-bench benchprof
+```
+
+Standard profile capture:
+
+```sh
+OUT=$(mktemp -d /tmp/gomap_profiles_XXXXXX)
+
+./bin/unified-bench \
+  -dbs treedb \
+  -keys 800000 \
+  -profile wal_on_fast \
+  -checkpoint-between-tests \
+  -test random_write,random_delete,random_read,full_scan,prefix_scan \
+  -profile-dir "$OUT" \
+  -progress=false
+
+./bin/benchprof -profiles-dir "$OUT"
+```
+
+Expected profile artifacts:
+
+- `benchprof_results.json`
+- `benchprof_results.md`
+- `cpu_<test>_<db>.pprof`
+- `allocs_<test>_<db>.pprof`
+- `checkpoint_cpu_checkpoint_<test>_<db>.pprof`
+- `block.pprof`
+- `mutex.pprof`
+- `trace.out`
+
+Use this layer for write-path, read-path, checkpoint, value-log, cache,
+allocator, and contention investigations. If profile names or profile-dir output
+changes, update the parsers and tests documented in `AGENTS.md` and
+`cmd/benchprof/README.md` in the same PR.
+
+## TreeDB Collections vs SQLite
+
+The canonical end-to-end TreeDB collections benchmark is:
+
+```sh
+make bench-collections-canonical
+```
+
+Equivalent direct command:
+
+```sh
+./scripts/bench_collections_canonical.sh
+```
+
+Use a stable output directory for any result that will be posted to a PR or
+issue:
+
+```sh
+OUT=/tmp/collections_canonical_$(date +%Y%m%d_%H%M%S)
+./scripts/bench_collections_canonical.sh -out-dir "$OUT"
+```
+
+The canonical runner emits:
+
+- `benchmark_results.json`
+- `benchmark_summary.md`
+- `benchmark_matrix.csv`
+- `timed_matrix/`
+- `offline_rewrite/`
+- `full_leafgen_pack_gc/`
+
+For broader matrix work, build and run:
+
+```sh
+make collection-bench-matrix
+OUT=/tmp/collection_matrix_$(date +%Y%m%d_%H%M%S)
+./bin/collection-bench-matrix \
+  -out-dir "$OUT" \
+  -batch-size 16000 \
+  -benchtime 100000x
+```
+
+Use a smoke matrix before changing report code:
+
+```sh
+OUT=/tmp/collection_matrix_smoke_$(date +%Y%m%d_%H%M%S)
+./bin/collection-bench-matrix \
+  -out-dir "$OUT" \
+  -benchtime 1000x \
+  -count 1
+```
+
+Collection report files to preserve:
+
+- `README.md`
+- `collections_matrix_summary.md`
+- `collections_matrix_summary.html`
+- `collections_user_story_summary.tsv`
+- `collections_disk_usage_summary.tsv`
+- `collections_maintenance_summary.tsv`
+- `<cell>/collections_report.md`
+- `<cell>/go_test.json`
+
+Use `CGO_ENABLED=1` when the SQLite cells or SQLite native-column baselines are
+part of the comparison.
+
+## Collection Maintenance Semantics
+
+The canonical collection maintenance phases are:
+
+- `post_insert`: after insert plus the flush/checkpoint needed for correctness.
+- `online_one_pass_maintenance`: bounded online maintenance; useful, but not a
+  full compaction state.
+- `offline_rewrite`: full/offline TreeDB value-log rewrite comparison point.
+- `full_leafgen_pack_gc`: full leaf-generation pack/GC comparison point.
+- `sqlite_vacuum`: SQLite compacted baseline after `VACUUM`.
+
+Fair post-insert comparison:
+
+- TreeDB `post_insert`
+- SQLite `post_insert`
+
+Fair compacted-state comparison:
+
+- TreeDB `offline_rewrite`
+- TreeDB `full_leafgen_pack_gc`
+- SQLite `sqlite_vacuum`
+
+When disk is the focus, report both logical file bytes from the harness and
+filesystem physical usage when it is available. For TreeDB, include the
+component breakdown for `index.db`, `leaf_vlog`, `value_vlog`, and `wal`. For
+SQLite, report both the database file and the post-`VACUUM` size.
+
+## Mongo-Compatible Collections vs MongoDB
+
+Use the comparison wrapper for TreeDB-vs-MongoDB bundles:
+
+```sh
+scripts/mongo_gateway_compare.sh \
+  --out /tmp/gomap_mongo_gateway_compare \
+  --docs "100000 1000000" \
+  --indexes "0 1 2" \
+  --reads 50000 \
+  --range-reads 5000 \
+  --range-index \
+  --updates 5000 \
+  --concurrent-reader-sweep "1,2,4,8,16" \
+  --concurrent-reads 50000 \
+  --concurrent-writers 8 \
+  --concurrent-writes 10000 \
+  --insert-producers 8 \
+  --mongo-max-pool-size 128 \
+  --mongo-max-connecting 32 \
+  --prebuild-documents \
+  --mongo-mode docker \
+  --timeout 120m
+```
+
+Use BSON for the current optimized TreeDB Mongo-compatible storage path:
+
+```sh
+TREEDB_DOCUMENT_FORMATS="bson" \
+TREEDB_CLIENT_MODES="driver-command-raw" \
+scripts/mongo_gateway_compare.sh
+```
+
+Use a client-mode matrix when measuring driver overhead and gateway ceiling:
+
+```sh
+TREEDB_DOCUMENT_FORMATS="bson" \
+TREEDB_CLIENT_MODES="driver driver-command driver-command-raw driver-unack raw-wire-tcp raw-wire" \
+MONGO_CLIENT_MODES="driver driver-command driver-command-raw driver-unack" \
+BATCH_SIZE=5000 \
+INSERT_PRODUCERS=8 \
+MONGO_MAX_POOL_SIZE=128 \
+MONGO_MAX_CONNECTING=32 \
+PREBUILD_DOCUMENTS=true \
+READS=0 \
+RANGE_READS=0 \
+UPDATES=0 \
+CONCURRENT_READERS=0 \
+CONCURRENT_WRITERS=0 \
+scripts/mongo_gateway_compare.sh \
+  --out /tmp/gomap_mongo_client_modes_1m_load \
+  --docs "1000000" \
+  --indexes "0 1 2" \
+  --mongo-mode docker \
+  --timeout 120m
+```
+
+Interpret client modes as separate questions:
+
+- `driver`: ordinary official MongoDB Go driver CRUD-helper path.
+- `driver-command`: official driver `RunCommand` insert path.
+- `driver-command-raw`: official driver `RunCommand` with prebuilt raw BSON.
+- `driver-unack`: official driver unacknowledged insert enqueue path plus
+  post-load visibility wait.
+- `raw-wire-tcp`: TreeDB-only raw OP_MSG load over loopback TCP.
+- `raw-wire`: TreeDB-only in-process raw OP_MSG load.
+
+Use `driver` for user-visible Mongo compatibility. Use `driver-command-raw` for
+the fastest current acknowledged official-driver load path. Use raw-wire modes
+only to estimate TreeDB gateway/server ceiling.
+
+## Reader and Writer Scaling
+
+Use the scaling wrapper when the question is concurrency plateau, update cost,
+or indexed-field update overhead:
+
+```sh
+scripts/mongo_gateway_scaling_bench.sh \
+  --out /tmp/gomap_mongo_gateway_scaling \
+  --docs 1000000 \
+  --indexes 2 \
+  --batch-size 10000 \
+  --insert-producers 8 \
+  --writers "1 2 4 8 16 32" \
+  --readers "1 2 4 8 16 32" \
+  --concurrent-writes 80000 \
+  --concurrent-reads 80000
+```
+
+Add `--include-mongo --mongo-uri mongodb://127.0.0.1:27017` to compare against
+an existing MongoDB server. Add `--update-indexed-field` to update `city` and
+exercise secondary-index maintenance instead of non-indexed document updates.
+
+## Recommended Reference Workloads
+
+Use deterministic documents with this shape unless a feature requires a
+different fixture:
+
+- `_id`: stable unique string or ObjectID.
+- `email`: unique string secondary-index candidate.
+- `city`: non-unique string secondary-index candidate.
+- `age`: numeric range-index candidate.
+- `active`: bool secondary-index candidate for unchanged-index update tests.
+- `status` / `updated_at`: non-indexed update fields.
+- `tags`: array field for future multikey and Mongo-query coverage.
+- `pad`: fixed payload string for size and compression control.
+
+Reference index counts:
+
+- `0`: primary key only.
+- `1`: primary key plus `email_1`.
+- `2`: primary key plus `email_1` and `city_1`.
+- `3`: adds `active_1` for unchanged-index update planning tests.
+
+Reference phases:
+
+- load insert throughput.
+- point read by `_id`.
+- point read by `email`.
+- indexed age range with limit.
+- fallback age range scan with limit when deliberately testing planner fallback.
+- non-indexed `$set` update by `_id`.
+- indexed-field `$set` update by `_id`.
+- concurrent reader sweep.
+- concurrent writer sweep.
+- maintenance and disk phases.
+
+## Reporting Template
+
+Use this shape in PR and issue comments:
+
+```md
+## Benchmark
+
+- base: `<commit>`
+- branch: `<branch>`
+- command: `<command or script>`
+- artifacts: `<output dir>`
+- host: `<machine summary>`
+- docs/keys: `<count>`
+- indexes: `<counts>`
+- format/profile/client modes: `<values>`
+- maintenance: `<phase or mode>`
+
+### Throughput
+
+| scenario | phase | TreeDB ops/s | baseline ops/s | ratio | TreeDB p95 | baseline p95 |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+
+### Disk
+
+| scenario | phase | TreeDB bytes/doc | baseline bytes/doc | TreeDB total | baseline total |
+| --- | --- | ---: | ---: | ---: | ---: |
+
+### Notes
+
+- State the main win or loss.
+- State whether the result is post-insert, post-checkpoint, partial
+  maintenance, or full maintenance.
+- State any likely bottleneck and the profile artifact that supports it.
+```
+
+## Validation Before Publishing Harness Changes
+
+For Mongo gateway harness changes:
+
+```sh
+bash -n scripts/mongo_gateway_compare.sh
+GOWORK=off go test ./cmd/mongo_gateway_bench ./cmd/mongo_gateway_compare_report
+```
+
+For collection benchmark/report changes, run the narrow tests that match the
+changed package, then one smoke matrix:
+
+```sh
+GOWORK=off go test ./cmd/collection_bench_matrix ./cmd/collection_bench_report
+make collection-bench-matrix
+OUT=/tmp/collection_matrix_smoke_$(date +%Y%m%d_%H%M%S)
+./bin/collection-bench-matrix -out-dir "$OUT" -benchtime 1000x -count 1
+```
+
+When SQLite code paths are involved:
+
+```sh
+CGO_ENABLED=1 GOWORK=off go test -tags sqlite_bench ./TreeDB/collections
+```
+
+For raw TreeDB profile-output changes:
+
+```sh
+GOWORK=off go test ./cmd/unified_bench ./cmd/benchprof
+make unified-bench benchprof
+OUT=$(mktemp -d /tmp/gomap_profiles_smoke_XXXXXX)
+./bin/unified-bench -dbs treedb -keys 200000 -profile wal_on_fast -profile-dir "$OUT" -progress=false
+./bin/benchprof -profiles-dir "$OUT"
+```

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -80,6 +80,7 @@ OUT=$(mktemp -d /tmp/gomap_profiles_XXXXXX)
   -dbs treedb \
   -keys 800000 \
   -profile wal_on_fast \
+  -path-label native-fastpath \
   -checkpoint-between-tests \
   -test random_write,random_delete,random_read,full_scan,prefix_scan \
   -profile-dir "$OUT" \
@@ -390,6 +391,6 @@ For raw TreeDB profile-output changes:
 GOWORK=off go test ./cmd/unified_bench ./cmd/benchprof
 make unified-bench benchprof
 OUT=$(mktemp -d /tmp/gomap_profiles_smoke_XXXXXX)
-./bin/unified-bench -dbs treedb -keys 200000 -profile wal_on_fast -profile-dir "$OUT" -progress=false
+./bin/unified-bench -dbs treedb -keys 200000 -profile wal_on_fast -path-label native-fastpath -profile-dir "$OUT" -progress=false
 ./bin/benchprof -profiles-dir "$OUT"
 ```

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -373,7 +373,7 @@ reset_mongo_data_dir() {
 }
 
 safe_label() {
-  printf '%s' "$1" | tr -c '[:alnum:]_.-' '_'
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]_.-' '_'
 }
 
 list_word_count() {
@@ -411,7 +411,7 @@ mongo_config_name() {
   local client_mode=$1
   local client_label=$2
   local config
-  if [[ "$client_mode" == "driver" ]] && [[ "$(list_word_count "$MONGO_CLIENT_MODES")" -eq 1 ]]; then
+  if [[ "$client_label" == "driver" ]] && [[ "$(list_word_count "$MONGO_CLIENT_MODES")" -eq 1 ]]; then
     config="mongo"
   else
     config="mongo_${client_label}"

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -376,6 +376,46 @@ safe_label() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]_.-' '_'
 }
 
+lower_word() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+normalized_label() {
+  local value
+  value=$(lower_word "$1")
+  value="${value//-/_}"
+  safe_label "$value"
+}
+
+normalize_unique_word_list() {
+  local name=$1
+  local values=$2
+  local seen=""
+  local out=""
+  local count=0
+  local item normalized label
+  for item in $values; do
+    normalized=$(lower_word "$item")
+    label=$(normalized_label "$normalized")
+    if [[ " $seen " == *" $label "* ]]; then
+      echo "duplicate $name value after normalization: $item (label=$label)" >&2
+      exit 2
+    fi
+    seen="$seen $label"
+    if [[ -z "$out" ]]; then
+      out=$normalized
+    else
+      out="$out $normalized"
+    fi
+    count=$((count + 1))
+  done
+  if [[ "$count" -eq 0 ]]; then
+    echo "$name must contain at least one value" >&2
+    exit 2
+  fi
+  printf '%s' "$out"
+}
+
 list_word_count() {
   local count=0
   local item
@@ -385,33 +425,12 @@ list_word_count() {
   echo "$count"
 }
 
-validate_unique_labels() {
-  local name=$1
-  local values=$2
-  local seen=""
-  local count=0
-  local item
-  local label
-  for item in $values; do
-    label=$(safe_label "${item//-/_}")
-    if [[ " $seen " == *" $label "* ]]; then
-      echo "duplicate $name value after normalization: $item" >&2
-      exit 2
-    fi
-    seen="$seen $label"
-    count=$((count + 1))
-  done
-  if [[ "$count" -eq 0 ]]; then
-    echo "$name must contain at least one value" >&2
-    exit 2
-  fi
-}
-
 mongo_config_name() {
-  local client_mode=$1
+  local client_mode
+  client_mode=$(lower_word "$1")
   local client_label=$2
   local config
-  if [[ "$client_label" == "driver" ]] && [[ "$(list_word_count "$MONGO_CLIENT_MODES")" -eq 1 ]]; then
+  if [[ "$client_mode" == "driver" ]] && [[ "$(list_word_count "$MONGO_CLIENT_MODES")" -eq 1 ]]; then
     config="mongo"
   else
     config="mongo_${client_label}"
@@ -583,9 +602,9 @@ if [[ "$PROFILE_TREEDB" != "true" && "$PROFILE_TREEDB" != "false" ]]; then
   echo "invalid PROFILE_TREEDB=$PROFILE_TREEDB (want true or false)" >&2
   exit 2
 fi
-validate_unique_labels MONGO_CLIENT_MODES "$MONGO_CLIENT_MODES"
-validate_unique_labels TREEDB_CLIENT_MODES "$TREEDB_CLIENT_MODES"
-validate_unique_labels TREEDB_DOCUMENT_FORMATS "$TREEDB_DOCUMENT_FORMATS"
+MONGO_CLIENT_MODES=$(normalize_unique_word_list MONGO_CLIENT_MODES "$MONGO_CLIENT_MODES")
+TREEDB_CLIENT_MODES=$(normalize_unique_word_list TREEDB_CLIENT_MODES "$TREEDB_CLIENT_MODES")
+TREEDB_DOCUMENT_FORMATS=$(normalize_unique_word_list TREEDB_DOCUMENT_FORMATS "$TREEDB_DOCUMENT_FORMATS")
 raw_concurrent_reader_sweep=$CONCURRENT_READER_SWEEP
 CONCURRENT_READER_SWEEP=$(trim_spaces "$CONCURRENT_READER_SWEEP")
 if [[ -n "$raw_concurrent_reader_sweep" && -z "$CONCURRENT_READER_SWEEP" ]]; then
@@ -719,8 +738,8 @@ for docs in $DOCS_LIST; do
 
     for tree_format in $TREEDB_DOCUMENT_FORMATS; do
       for tree_client_mode in $TREEDB_CLIENT_MODES; do
-        format_label=$(safe_label "${tree_format//-/_}")
-        client_label=$(safe_label "${tree_client_mode//-/_}")
+        format_label=$(normalized_label "$tree_format")
+        client_label=$(normalized_label "$tree_client_mode")
         tree_config="treedb_${format_label}_${client_label}"
         if [[ "$RANGE_INDEX" == "true" ]]; then
           tree_config="${tree_config}_range_index"
@@ -756,7 +775,7 @@ for docs in $DOCS_LIST; do
     done
 
     for mongo_client_mode in $MONGO_CLIENT_MODES; do
-      mongo_client_label=$(safe_label "${mongo_client_mode//-/_}")
+      mongo_client_label=$(normalized_label "$mongo_client_mode")
       mongo_config=$(mongo_config_name "$mongo_client_mode" "$mongo_client_label")
       mongo_raw_rel="raw/${mongo_config}_${cell}.json"
       mongo_raw="$OUT_DIR/$mongo_raw_rel"

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -34,6 +34,8 @@ CONCURRENT_WRITES_DIVISOR="${CONCURRENT_WRITES_DIVISOR:-10}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
 MONGO_IMAGE="${MONGO_IMAGE:-mongo:7}"
+MONGO_CLIENT_MODE="${MONGO_CLIENT_MODE:-driver}"
+MONGO_CLIENT_MODES="${MONGO_CLIENT_MODES:-$MONGO_CLIENT_MODE}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-mongo_gateway_compare}"
 COLLECTION="${COLLECTION:-docs}"
 TIMEOUT="${TIMEOUT:-20m}"
@@ -90,6 +92,12 @@ Options:
   --mongo-mode MODE     docker or external. Default: docker.
   --mongo-uri URI       MongoDB URI for --mongo-mode external.
   --mongo-image IMAGE   Docker image for --mongo-mode docker. Default: mongo:7.
+  --mongo-client-mode MODE
+                        Single MongoDB client mode: driver, driver-command,
+                        driver-command-raw, or driver-unack.
+  --mongo-client-modes LIST
+                        Space-separated MongoDB client modes. Example:
+                        "driver driver-command driver-command-raw driver-unack".
   --timeout DURATION    Per-run benchmark timeout. Default: 20m.
   --treedb-profile NAME TreeDB profile. Default: wal_on_fast.
   --treedb-document-format FORMAT
@@ -115,6 +123,7 @@ Environment overrides:
   CONCURRENT_READER_SWEEP,
   CONCURRENT_WRITERS, CONCURRENT_WRITES, CONCURRENT_WRITES_DIVISOR,
   MONGO_MODE, MONGO_URI, MONGO_IMAGE, DATABASE_PREFIX, COLLECTION, TIMEOUT,
+  MONGO_CLIENT_MODE, MONGO_CLIENT_MODES,
   TREEDB_PROFILE, TREEDB_DOCUMENT_FORMAT, TREEDB_DOCUMENT_FORMATS,
   TREEDB_CLIENT_MODE, TREEDB_CLIENT_MODES,
   TREEDB_DATA_ROOT_STORAGE, TREEDB_INDEX_STATE_ROOT_STORAGE, TREEDB_INDEX_ROOT_STORAGE,
@@ -210,6 +219,15 @@ while [[ $# -gt 0 ]]; do
       ;;
     --mongo-image)
       MONGO_IMAGE="$2"
+      shift 2
+      ;;
+    --mongo-client-mode)
+      MONGO_CLIENT_MODE="$2"
+      MONGO_CLIENT_MODES="$2"
+      shift 2
+      ;;
+    --mongo-client-modes)
+      MONGO_CLIENT_MODES="$2"
       shift 2
       ;;
     --timeout)
@@ -598,6 +616,7 @@ fi
   echo "concurrent writers: $CONCURRENT_WRITERS"
   echo "concurrent writes: ${CONCURRENT_WRITES:-documents / $CONCURRENT_WRITES_DIVISOR when writers > 0}"
   echo "mongo mode: $MONGO_MODE"
+  echo "mongo client modes: $MONGO_CLIENT_MODES"
   echo "treedb profile: $TREEDB_PROFILE"
   echo "treedb document formats: $TREEDB_DOCUMENT_FORMATS"
   echo "treedb client modes: $TREEDB_CLIENT_MODES"
@@ -647,12 +666,6 @@ for docs in $DOCS_LIST; do
     fi
     cell="docs_${docs}_idx_${indexes}"
     database="${DATABASE_PREFIX}_${cell}"
-    mongo_config="mongo"
-    if [[ "$RANGE_INDEX" == "true" ]]; then
-      mongo_config="mongo_range_index"
-    fi
-    mongo_raw_rel="raw/${mongo_config}_${cell}.json"
-    mongo_raw="$OUT_DIR/$mongo_raw_rel"
     mongo_data="$MONGO_DIR/$cell"
 
     for tree_format in $TREEDB_DOCUMENT_FORMATS; do
@@ -693,28 +706,40 @@ for docs in $DOCS_LIST; do
       done
     done
 
-    echo "==> $cell MongoDB"
-    mongo_uri="$MONGO_URI"
-    mongo_container=""
-    if [[ "$MONGO_MODE" == "docker" ]]; then
-      start_mongo_container "$cell" "$mongo_data"
-      mongo_uri="$STARTED_MONGO_URI"
-      mongo_container="$STARTED_MONGO_CONTAINER"
-      if ! wait_for_mongo "$mongo_uri" "$database"; then
-        echo "MongoDB container did not become ready for $cell" >&2
-        exit 1
+    for mongo_client_mode in $MONGO_CLIENT_MODES; do
+      mongo_client_label=$(safe_label "${mongo_client_mode//-/_}")
+      mongo_config="mongo_${mongo_client_label}"
+      if [[ "$RANGE_INDEX" == "true" ]]; then
+        mongo_config="${mongo_config}_range_index"
       fi
-    fi
-    run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
-      "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
-      -mongo-uri "$mongo_uri"
-    if [[ "$MONGO_MODE" == "docker" ]]; then
-      stop_mongo_container "$mongo_container"
-      mongo_physical=$(docker_du_bytes "$mongo_data")
-    else
-      mongo_physical=0
-    fi
-    printf "mongo\t%s\t%s\t%s\t%s\t%s\n" "$mongo_config" "$docs" "$indexes" "$mongo_raw_rel" "$mongo_physical" >>"$MATRIX"
+      mongo_raw_rel="raw/${mongo_config}_${cell}.json"
+      mongo_raw="$OUT_DIR/$mongo_raw_rel"
+      mongo_cell_data="$mongo_data/$mongo_client_label"
+
+      echo "==> $cell MongoDB (client=$mongo_client_mode)"
+      mongo_uri="$MONGO_URI"
+      mongo_container=""
+      if [[ "$MONGO_MODE" == "docker" ]]; then
+        start_mongo_container "${cell}_${mongo_client_label}" "$mongo_cell_data"
+        mongo_uri="$STARTED_MONGO_URI"
+        mongo_container="$STARTED_MONGO_CONTAINER"
+        if ! wait_for_mongo "$mongo_uri" "$database"; then
+          echo "MongoDB container did not become ready for $cell client=$mongo_client_mode" >&2
+          exit 1
+        fi
+      fi
+      run_target mongo "$docs" "$indexes" "$mongo_raw" "$database" "$reads" "$range_reads" "$updates" "$DELETES" \
+        "$CONCURRENT_READERS" "$concurrent_reads" "$CONCURRENT_WRITERS" "$concurrent_writes" \
+        -mongo-uri "$mongo_uri" \
+        -client-mode "$mongo_client_mode"
+      if [[ "$MONGO_MODE" == "docker" ]]; then
+        stop_mongo_container "$mongo_container"
+        mongo_physical=$(docker_du_bytes "$mongo_cell_data")
+      else
+        mongo_physical=0
+      fi
+      printf "mongo\t%s\t%s\t%s\t%s\t%s\n" "$mongo_config" "$docs" "$indexes" "$mongo_raw_rel" "$mongo_physical" >>"$MATRIX"
+    done
   done
 done
 
@@ -754,6 +779,7 @@ cat >"$README" <<EOF
 - concurrent writes: \`${CONCURRENT_WRITES:-documents / $CONCURRENT_WRITES_DIVISOR when writers > 0}\`
 - MongoDB mode: \`$MONGO_MODE\`
 - MongoDB image: \`$MONGO_IMAGE\`
+- MongoDB client modes: \`$MONGO_CLIENT_MODES\`
 - benchmark timeout: \`$TIMEOUT\`
 - TreeDB profile: \`$TREEDB_PROFILE\`
 - TreeDB document formats: \`$TREEDB_DOCUMENT_FORMATS\`

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -416,6 +416,20 @@ normalize_unique_word_list() {
   printf '%s' "$out"
 }
 
+validate_mongo_client_modes() {
+  local mode
+  for mode in $1; do
+    case "$mode" in
+      driver|driver-command|driver-command-raw|driver-unack)
+        ;;
+      *)
+        echo "invalid MONGO_CLIENT_MODES value: $mode (want driver, driver-command, driver-command-raw, or driver-unack)" >&2
+        exit 2
+        ;;
+    esac
+  done
+}
+
 list_word_count() {
   local count=0
   local item
@@ -603,6 +617,7 @@ if [[ "$PROFILE_TREEDB" != "true" && "$PROFILE_TREEDB" != "false" ]]; then
   exit 2
 fi
 MONGO_CLIENT_MODES=$(normalize_unique_word_list MONGO_CLIENT_MODES "$MONGO_CLIENT_MODES")
+validate_mongo_client_modes "$MONGO_CLIENT_MODES"
 TREEDB_CLIENT_MODES=$(normalize_unique_word_list TREEDB_CLIENT_MODES "$TREEDB_CLIENT_MODES")
 TREEDB_DOCUMENT_FORMATS=$(normalize_unique_word_list TREEDB_DOCUMENT_FORMATS "$TREEDB_DOCUMENT_FORMATS")
 raw_concurrent_reader_sweep=$CONCURRENT_READER_SWEEP

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -376,6 +376,30 @@ safe_label() {
   printf '%s' "$1" | tr -c '[:alnum:]_.-' '_'
 }
 
+list_word_count() {
+  local count=0
+  local item
+  for item in $1; do
+    count=$((count + 1))
+  done
+  echo "$count"
+}
+
+mongo_config_name() {
+  local client_mode=$1
+  local client_label=$2
+  local config
+  if [[ "$client_mode" == "driver" ]] && [[ "$(list_word_count "$MONGO_CLIENT_MODES")" -eq 1 ]]; then
+    config="mongo"
+  else
+    config="mongo_${client_label}"
+  fi
+  if [[ "$RANGE_INDEX" == "true" ]]; then
+    config="${config}_range_index"
+  fi
+  printf '%s' "$config"
+}
+
 start_mongo_container() {
   local cell=$1
   local data_dir=$2
@@ -708,10 +732,7 @@ for docs in $DOCS_LIST; do
 
     for mongo_client_mode in $MONGO_CLIENT_MODES; do
       mongo_client_label=$(safe_label "${mongo_client_mode//-/_}")
-      mongo_config="mongo_${mongo_client_label}"
-      if [[ "$RANGE_INDEX" == "true" ]]; then
-        mongo_config="${mongo_config}_range_index"
-      fi
+      mongo_config=$(mongo_config_name "$mongo_client_mode" "$mongo_client_label")
       mongo_raw_rel="raw/${mongo_config}_${cell}.json"
       mongo_raw="$OUT_DIR/$mongo_raw_rel"
       mongo_cell_data="$mongo_data/$mongo_client_label"

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -385,6 +385,28 @@ list_word_count() {
   echo "$count"
 }
 
+validate_unique_labels() {
+  local name=$1
+  local values=$2
+  local seen=""
+  local count=0
+  local item
+  local label
+  for item in $values; do
+    label=$(safe_label "${item//-/_}")
+    if [[ " $seen " == *" $label "* ]]; then
+      echo "duplicate $name value after normalization: $item" >&2
+      exit 2
+    fi
+    seen="$seen $label"
+    count=$((count + 1))
+  done
+  if [[ "$count" -eq 0 ]]; then
+    echo "$name must contain at least one value" >&2
+    exit 2
+  fi
+}
+
 mongo_config_name() {
   local client_mode=$1
   local client_label=$2
@@ -561,6 +583,9 @@ if [[ "$PROFILE_TREEDB" != "true" && "$PROFILE_TREEDB" != "false" ]]; then
   echo "invalid PROFILE_TREEDB=$PROFILE_TREEDB (want true or false)" >&2
   exit 2
 fi
+validate_unique_labels MONGO_CLIENT_MODES "$MONGO_CLIENT_MODES"
+validate_unique_labels TREEDB_CLIENT_MODES "$TREEDB_CLIENT_MODES"
+validate_unique_labels TREEDB_DOCUMENT_FORMATS "$TREEDB_DOCUMENT_FORMATS"
 raw_concurrent_reader_sweep=$CONCURRENT_READER_SWEEP
 CONCURRENT_READER_SWEEP=$(trim_spaces "$CONCURRENT_READER_SWEEP")
 if [[ -n "$raw_concurrent_reader_sweep" && -z "$CONCURRENT_READER_SWEEP" ]]; then


### PR DESCRIPTION
## Summary

- adds `MONGO_CLIENT_MODES` support to `scripts/mongo_gateway_compare.sh` so MongoDB can be benchmarked with `driver`, `driver-command`, `driver-command-raw`, and `driver-unack` rows alongside TreeDB client modes
- updates the comparison report to keep the ordinary Mongo driver row as the baseline when multiple Mongo client-mode rows exist
- documents the Mongo client-mode matrix and adds a canonical TreeDB benchmark runbook covering raw TreeDB, collections, SQLite, Mongo gateway, maintenance phases, profiling, and reporting

## Validation

- `bash -n scripts/mongo_gateway_compare.sh`
- `GOWORK=off go test ./cmd/mongo_gateway_bench ./cmd/mongo_gateway_compare_report`
- smoke matrix: `/tmp/gomap_mongo_client_modes_smoke2_20260502_170338`
- larger 1M-doc Mongo/TreeDB client-mode matrix posted at https://github.com/snissn/gomap/issues/1177#issuecomment-4365276803

## Notes

The runbook intentionally keeps TreeDB maintenance phase names explicit (`post_insert`, `online_one_pass_maintenance`, `offline_rewrite`, `full_leafgen_pack_gc`, `sqlite_vacuum`) so future disk-size reports do not flatten partial and full maintenance states into one ambiguous compacted label.