### PR TITLE
batch: retain default indexed flush delta entries

### DIFF
--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -71,7 +71,10 @@ type Batch struct {
 	reader                  ValueReader
 }
 
-const maxBatchPoolCap = 1 << 16
+// maxBatchPoolCap is sized to retain the transient ordered-root delta batches
+// created by the default 96k-document indexed collection flush window. Larger
+// spikes are still dropped so the pool does not pin unbounded entry slices.
+const maxBatchPoolCap = 1 << 18
 
 const (
 	// Store key/value copies in chunks so Set/Delete avoid per-entry allocations.

--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -59,6 +59,8 @@ type Batch struct {
 	byteSize        int
 	inlineThreshold int
 	thresholdForKey func([]byte) int
+	poolKind        batchPoolKind
+	maxPoolEntries  int
 	// Small-set fast path: most batches touch <=4 value-log segments.
 	touchedValueLogSmall    [4]uint32
 	touchedValueLogSmallLen int
@@ -71,10 +73,17 @@ type Batch struct {
 	reader                  ValueReader
 }
 
-// maxBatchPoolCap is sized to retain the transient ordered-root delta batches
-// created by the default 96k-document indexed collection flush window. Larger
-// spikes are still dropped so the pool does not pin unbounded entry slices.
-const maxBatchPoolCap = 1 << 18
+const (
+	maxBatchPoolCap           = 1 << 16
+	maxLargeEntryBatchPoolCap = 1 << 18
+)
+
+type batchPoolKind uint8
+
+const (
+	batchPoolKindDefault batchPoolKind = iota
+	batchPoolKindLargeEntries
+)
 
 const (
 	// Store key/value copies in chunks so Set/Delete avoid per-entry allocations.
@@ -83,14 +92,16 @@ const (
 	batchArenaMaxRetainCap = 1 << 20
 )
 
-var batchPool = sync.Pool{
-	New: func() any {
-		return &Batch{
-			entries:   make([]Entry, 0, 16),
-			sorted:    true,
-			compacted: true,
-		}
-	},
+var batchPool = sync.Pool{New: func() any { return newPooledBatch() }}
+
+var largeEntryBatchPool = sync.Pool{New: func() any { return newPooledBatch() }}
+
+func newPooledBatch() any {
+	return &Batch{
+		entries:   make([]Entry, 0, 16),
+		sorted:    true,
+		compacted: true,
+	}
 }
 
 // New creates a new Batch.
@@ -98,14 +109,33 @@ func New(reader ValueReader, threshold int) *Batch {
 	return Acquire(reader, threshold)
 }
 
+// NewRetainingLargeEntries returns a batch from a separate pool that can retain
+// larger entry slices. Use this only for repeated internal materializations with
+// known large entry counts; ordinary batches should use New/Acquire.
+func NewRetainingLargeEntries(reader ValueReader, threshold int) *Batch {
+	return AcquireRetainingLargeEntries(reader, threshold)
+}
+
 // Acquire returns a reusable Batch from the pool.
 func Acquire(reader ValueReader, threshold int) *Batch {
+	return acquireFromPool(&batchPool, batchPoolKindDefault, maxBatchPoolCap, reader, threshold)
+}
+
+// AcquireRetainingLargeEntries returns a reusable Batch from the large-entry
+// pool. See NewRetainingLargeEntries.
+func AcquireRetainingLargeEntries(reader ValueReader, threshold int) *Batch {
+	return acquireFromPool(&largeEntryBatchPool, batchPoolKindLargeEntries, maxLargeEntryBatchPoolCap, reader, threshold)
+}
+
+func acquireFromPool(pool *sync.Pool, kind batchPoolKind, maxEntries int, reader ValueReader, threshold int) *Batch {
 	if threshold < 0 {
 		threshold = page.DefaultInlineThreshold
 	}
-	b := batchPool.Get().(*Batch)
+	b := pool.Get().(*Batch)
 	b.reader = reader
 	b.inlineThreshold = threshold
+	b.poolKind = kind
+	b.maxPoolEntries = maxEntries
 	b.closed = false
 	b.resetLocked()
 	return b
@@ -161,7 +191,11 @@ func (b *Batch) resetLocked() {
 
 func (b *Batch) resetForPool() {
 	if b.entries != nil {
-		if cap(b.entries) > maxBatchPoolCap {
+		maxEntries := b.maxPoolEntries
+		if maxEntries <= 0 {
+			maxEntries = maxBatchPoolCap
+		}
+		if cap(b.entries) > maxEntries {
 			// Drop oversized backing arrays without clearing them first. Once the
 			// slice is nil, the batch no longer retains the array or its key/value
 			// references, so clearing len entries would only add discard-path CPU.
@@ -233,7 +267,14 @@ func Release(b *Batch) {
 	b.inlineThreshold = 0
 	b.thresholdForKey = nil
 	b.closed = true
-	batchPool.Put(b)
+	switch b.poolKind {
+	case batchPoolKindLargeEntries:
+		largeEntryBatchPool.Put(b)
+	default:
+		b.poolKind = batchPoolKindDefault
+		b.maxPoolEntries = maxBatchPoolCap
+		batchPool.Put(b)
+	}
 }
 
 func (b *Batch) inlineThresholdForKey(key []byte) int {

--- a/TreeDB/batch/batch_pool_test.go
+++ b/TreeDB/batch/batch_pool_test.go
@@ -56,7 +56,7 @@ func TestBatchReleaseDropsOversizedEntriesWithoutClearing(t *testing.T) {
 	}
 }
 
-func TestBatchReleaseRetainsMaxSizedEntries(t *testing.T) {
+func TestBatchReleaseRetainsDefaultMaxSizedEntries(t *testing.T) {
 	b := New(newMapValueReader(), page.DefaultInlineThreshold)
 	key := []byte("flush-sized-key")
 	value := []byte("flush-sized-value")
@@ -77,5 +77,40 @@ func TestBatchReleaseRetainsMaxSizedEntries(t *testing.T) {
 	}
 	if entries[0].Key != nil || entries[0].Value != nil || entries[0].IsPtr || entries[0].ValuePtr != (page.ValuePtr{}) {
 		t.Fatalf("retained entries were not cleared: %+v", entries[0])
+	}
+}
+
+func TestBatchReleaseDropsLargeEntryBatchFromDefaultPool(t *testing.T) {
+	b := New(newMapValueReader(), page.DefaultInlineThreshold)
+	b.entries = make([]Entry, 1, maxLargeEntryBatchPoolCap)
+
+	Release(b)
+
+	if b.entries != nil {
+		t.Fatalf("default pool retained large entries with cap=%d", cap(b.entries))
+	}
+}
+
+func TestLargeEntryBatchReleaseRetainsMaxSizedEntries(t *testing.T) {
+	b := NewRetainingLargeEntries(newMapValueReader(), page.DefaultInlineThreshold)
+	key := []byte("large-flush-sized-key")
+	value := []byte("large-flush-sized-value")
+	b.entries = make([]Entry, 1, maxLargeEntryBatchPoolCap)
+	b.entries[0] = Entry{Type: OpPut, Key: key, Value: value}
+	entries := b.entries
+
+	Release(b)
+
+	if b.entries == nil {
+		t.Fatalf("large-entry pool dropped max-sized entries")
+	}
+	if got := cap(b.entries); got != maxLargeEntryBatchPoolCap {
+		t.Fatalf("retained large entries cap=%d want %d", got, maxLargeEntryBatchPoolCap)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("captured entries len=%d want 1", len(entries))
+	}
+	if entries[0].Key != nil || entries[0].Value != nil || entries[0].IsPtr || entries[0].ValuePtr != (page.ValuePtr{}) {
+		t.Fatalf("retained large entries were not cleared: %+v", entries[0])
 	}
 }

--- a/TreeDB/batch/batch_pool_test.go
+++ b/TreeDB/batch/batch_pool_test.go
@@ -55,3 +55,27 @@ func TestBatchReleaseDropsOversizedEntriesWithoutClearing(t *testing.T) {
 		t.Fatalf("oversized discarded entries were cleared before drop: %+v", entries)
 	}
 }
+
+func TestBatchReleaseRetainsMaxSizedEntries(t *testing.T) {
+	b := New(newMapValueReader(), page.DefaultInlineThreshold)
+	key := []byte("flush-sized-key")
+	value := []byte("flush-sized-value")
+	b.entries = make([]Entry, 1, maxBatchPoolCap)
+	b.entries[0] = Entry{Type: OpPut, Key: key, Value: value}
+	entries := b.entries
+
+	Release(b)
+
+	if b.entries == nil {
+		t.Fatalf("max-sized entries were dropped")
+	}
+	if got := cap(b.entries); got != maxBatchPoolCap {
+		t.Fatalf("retained entries cap=%d want %d", got, maxBatchPoolCap)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("captured entries len=%d want 1", len(entries))
+	}
+	if entries[0].Key != nil || entries[0].Value != nil || entries[0].IsPtr || entries[0].ValuePtr != (page.ValuePtr{}) {
+		t.Fatalf("retained entries were not cleared: %+v", entries[0])
+	}
+}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -338,7 +338,7 @@ func orderedRootDeltaBatchFromIterator(iter iterator.UnsafeIterator) (*batch.Bat
 	if iter == nil {
 		return nil, errors.New("nil ordered root delta iterator")
 	}
-	delta := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	delta := batch.NewRetainingLargeEntries(nil, orderedRootDeltaBatchInlineThreshold)
 	if hint, ok := iter.(orderedRootLenHintIterator); ok {
 		delta.Reserve(hint.Len())
 	}
@@ -607,7 +607,7 @@ func (db *DB) publishOrderedRootDeltaBatch(baseRoot uint64, delta *batch.Batch, 
 }
 
 func buildOrderedRootDeltaBatch(baseIter, targetIter iterator.UnsafeIterator, trackRefs bool) (*batch.Batch, int, *valueLogRefDelta, error) {
-	delta := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	delta := batch.NewRetainingLargeEntries(nil, orderedRootDeltaBatchInlineThreshold)
 	baseValid := baseIter.Valid()
 	targetValid := targetIter.Valid()
 	deltaOps := 0


### PR DESCRIPTION
## Summary

This is a focused #1159 allocation-pressure cleanup for indexed collection flush publishing.

What changed:
- Keeps the ordinary `batch.Batch` pool retention cap at `1<<16`.
- Adds a separate large-entry batch pool capped at `1<<18` for ordered-root delta materialization only.
- Switches ordered-root delta iterator materialization to that separate pool, matching the default 96k-document indexed collection flush window without making every normal batch call site eligible to retain a large entries array.
- Adds regression tests proving default batches still drop large entry buffers, while the dedicated large-entry pool retains and clears max-sized buffers.

Rationale: current indexed collection async flushes materialize ordered-root delta batches outside the DB write lock. With the default flush window, those transient root-local delta batches commonly exceed 64k entries, so the previous default cap discarded the entry buffer on every flush. The new dedicated pool keeps the common ordered-root delta buffers reusable while bounding retention and isolating ordinary batch users from the larger cap.

## Validation

```text
go test ./TreeDB/batch -run 'TestBatchRelease(ClearsPointers|DropsOversizedEntriesWithoutClearing|RetainsDefaultMaxSizedEntries|DropsLargeEntryBatchFromDefaultPool)|TestLargeEntryBatchReleaseRetainsMaxSizedEntries' -count=1
ok  github.com/snissn/gomap/TreeDB/batch 0.439s

go test ./TreeDB/db -run 'TestOrderedRootDeltaBatchFromIterator_StableIteratorUsesViews|TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_PreservesOmittedBaseEntries|TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_AppliesDeletes' -count=1
ok  github.com/snissn/gomap/TreeDB/db 0.354s

go test ./TreeDB/batch ./TreeDB/db -count=1
ok  github.com/snissn/gomap/TreeDB/batch 0.223s
ok  github.com/snissn/gomap/TreeDB/db 68.979s

go test ./TreeDB/collections -run 'TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics|TestCollectionUpdateBatchSkipsUnchangedSecondaryIndexes|TestCollectionUpdateSkipsIndexRootsWhenIndexedValuesUnchanged' -count=1
ok  github.com/snissn/gomap/TreeDB/collections 0.574s

git diff --check
```

## Focused benchmark/profile

Baseline commit: `12cafed8ef`  
Initial branch measurement commit: `00b317101b`

Command for both rows:

```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1159_batchcap_profile_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof" | tee "$PROFILE_DIR/bench.txt"
```

Run dirs:
- Baseline: `/tmp/gomap_1159_current_head_profile_v8udrV`
- Branch: `/tmp/gomap_1159_batchcap_262k_profile_f4Cjl7`

| Metric | Baseline | Branch |
| --- | ---: | ---: |
| docs/sec | 133,371 | 133,963 |
| ns/doc | 7,498 | 7,465 |
| B/op | 1,133 | 922 |
| allocs/op | 4 | 4 |
| total alloc_space | 9.66 GiB | 9.04 GiB |
| `batch.(*Batch).Reserve` alloc_space | 0.97 GiB | 0.39 GiB |
| `runtime.madvise` CPU | 3.28s | 2.81s |
| indexed_flush_ns/doc | 2,132 | 2,098 |
| publish_delta_group_root_apply_ns/doc | 2,091 | 2,047 |

Follow-up review hardening changed the implementation from a global cap increase to a dedicated ordered-root delta pool. The ordered-root delta materialization path still receives the larger retention cap; ordinary batch users keep the smaller default cap.

Additional current-head smoke benchmark on Apple M3, fixed 200k iterations, after the dedicated-pool change:

- run dir: `/tmp/gomap_1211_large_entry_pool_O7tkei`
- `129,153 docs/sec`, `7,743 ns/doc`, `1,578 B/op`, `4 allocs/op`

Interpretation: this is not the root-publish architecture fix. It is a bounded allocation hygiene win that removes a recurring oversized entry-slice allocation pattern from the default indexed flush shape while keeping the larger retention policy isolated to ordered-root delta publishing.

## Rejected alternative

I also prototyped publish-time root-run compaction outside the collection lock. It was worse on the same 200k focused row: `112,866 docs/sec`, `8,860 ns/doc`, `3,450 B/op`, `8 allocs/op`. That path duplicates materialization work instead of reducing the actual root-apply work, so it is not included here.

Fixes part of #1159.
