### PR TITLE
valuelog: cache mmap grouped frame reads into dst

### DIFF
--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -987,26 +987,64 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		Reserved: frameHeader[3],
 		DictID:   binary.LittleEndian.Uint64(frameHeader[4:12]),
 	}
-	raw, err := decodeFramePayloadTo(frame, payload[prefixLen:], f.dictLookup, rawLen, dst)
+	valLen := int(valEnd - valStart)
+	copyValueToDst := dst != nil && cap(dst) >= valLen && cap(dst) < int(rawLen)
+	cacheableRaw := false
+	if copyValueToDst {
+		f.cacheMu.Lock()
+		cacheableRaw = f.groupedFrameCacheEntries > 0 && (f.groupedFrameCacheMaxRaw <= 0 || int(rawLen) <= f.groupedFrameCacheMaxRaw)
+		f.cacheMu.Unlock()
+	}
+	decodeDst := dst
+	rawPooled := false
+	if copyValueToDst {
+		decodeDst = f.takeDecodeScratch(int(rawLen))
+		rawPooled = true
+	}
+	raw, err := decodeFramePayloadTo(frame, payload[prefixLen:], f.dictLookup, rawLen, decodeDst)
 	if err != nil {
+		if rawPooled {
+			f.releaseDecodeScratch(decodeDst)
+		}
 		return nil, false, err, true
 	}
 	if uint32(len(raw)) != rawLen {
+		if rawPooled {
+			f.releaseDecodeScratch(raw)
+		}
 		return nil, false, ErrCorrupt, true
 	}
-	// dst is used iff it was provided with enough capacity to hold rawLen.
-	usedDst := dst != nil && cap(dst) >= int(rawLen)
-
 	val, decoded, err := decodeTemplatePayload(raw[valStart:valEnd])
 	if err != nil {
+		if rawPooled {
+			f.releaseDecodeScratch(raw)
+		}
 		return nil, false, err, true
+	}
+	if cacheableRaw {
+		cachedRaw := f.groupedFrameCacheStore(start, verifyCRC, k, offsets, raw, rawPooled)
+		if rawPooled && cachedRaw {
+			rawPooled = false
+		}
 	}
 	// Template decoding allocates new bytes; the returned slice is no longer
 	// backed by dst even if we decoded into it.
 	if decoded {
-		usedDst = false
+		if rawPooled {
+			f.releaseDecodeScratch(raw)
+		}
+		return val, false, nil, true
 	}
-	return val, usedDst, nil, true
+	if copyValueToDst {
+		out := dst[:valLen]
+		copy(out, val)
+		if rawPooled {
+			f.releaseDecodeScratch(raw)
+		}
+		return out, true, nil, true
+	}
+	// dst is used iff it was provided with enough capacity to hold rawLen.
+	return val, dst != nil && cap(dst) >= int(rawLen), nil, true
 }
 
 func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte, error, bool) {

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -924,6 +924,8 @@ func TestValueLogManager_ReadUnsafeTo_CompressedGroupedMmapUsesCache(t *testing.
 	if f == nil {
 		t.Fatalf("missing opened file for id=%d", fileID)
 	}
+	f.remapToFileSize()
+	hitsBefore, _, _, _, fallbacksBefore := m.MmapReadStats()
 
 	dst := make([]byte, 0, 512)
 	got0, used0, err := m.ReadUnsafeTo(ptrs[0], dst[:0])
@@ -935,6 +937,13 @@ func TestValueLogManager_ReadUnsafeTo_CompressedGroupedMmapUsesCache(t *testing.
 	}
 	if !bytes.Equal(got0, want[0]) {
 		t.Fatalf("first value mismatch: got=%q want=%q", got0, want[0])
+	}
+	hitsAfterFirst, _, _, _, fallbacksAfterFirst := m.MmapReadStats()
+	if hitsAfterFirst <= hitsBefore {
+		t.Fatalf("expected first read to use mmap path: hits before=%d after=%d", hitsBefore, hitsAfterFirst)
+	}
+	if fallbacksAfterFirst != fallbacksBefore {
+		t.Fatalf("unexpected readat fallback on first read: before=%d after=%d", fallbacksBefore, fallbacksAfterFirst)
 	}
 
 	hits0, misses0, entries0, _ := f.groupedFrameCacheStats()
@@ -954,6 +963,13 @@ func TestValueLogManager_ReadUnsafeTo_CompressedGroupedMmapUsesCache(t *testing.
 	}
 	if !bytes.Equal(got1, want[1]) {
 		t.Fatalf("second value mismatch: got=%q want=%q", got1, want[1])
+	}
+	hitsAfterSecond, _, _, _, fallbacksAfterSecond := m.MmapReadStats()
+	if hitsAfterSecond <= hitsAfterFirst {
+		t.Fatalf("expected second read to use mmap path: hits before=%d after=%d", hitsAfterFirst, hitsAfterSecond)
+	}
+	if fallbacksAfterSecond != fallbacksBefore {
+		t.Fatalf("unexpected readat fallback after second read: before=%d after=%d", fallbacksBefore, fallbacksAfterSecond)
 	}
 
 	hits1, misses1, entries1, _ := f.groupedFrameCacheStats()

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -888,6 +888,86 @@ func TestValueLogManager_ReadUnsafeTo_CompressedGroupedFallbackUsesCache(t *test
 	}
 }
 
+func TestValueLogManager_ReadUnsafeTo_CompressedGroupedMmapUsesCache(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+
+	withMappedSealedBudget(t, 8)
+
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+	ptrs, want := appendCompressedFrameForCacheTests(t, writer, 0, 4)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+	m.SetDisableReadChecksum(true)
+	m.SetGroupedFrameCacheEntries(4)
+
+	f := m.files[fileID]
+	if f == nil {
+		t.Fatalf("missing opened file for id=%d", fileID)
+	}
+
+	dst := make([]byte, 0, 512)
+	got0, used0, err := m.ReadUnsafeTo(ptrs[0], dst[:0])
+	if err != nil {
+		t.Fatalf("read unsafe to first: %v", err)
+	}
+	if !used0 {
+		t.Fatalf("expected first read to use dst")
+	}
+	if !bytes.Equal(got0, want[0]) {
+		t.Fatalf("first value mismatch: got=%q want=%q", got0, want[0])
+	}
+
+	hits0, misses0, entries0, _ := f.groupedFrameCacheStats()
+	if misses0 == 0 {
+		t.Fatalf("expected first mmap grouped read to miss cache")
+	}
+	if entries0 == 0 {
+		t.Fatalf("expected first mmap grouped read to populate cache")
+	}
+
+	got1, used1, err := m.ReadUnsafeTo(ptrs[1], dst[:0])
+	if err != nil {
+		t.Fatalf("read unsafe to second: %v", err)
+	}
+	if !used1 {
+		t.Fatalf("expected second read to use dst")
+	}
+	if !bytes.Equal(got1, want[1]) {
+		t.Fatalf("second value mismatch: got=%q want=%q", got1, want[1])
+	}
+
+	hits1, misses1, entries1, _ := f.groupedFrameCacheStats()
+	if entries1 != entries0 {
+		t.Fatalf("cache entries changed after hit: before=%d after=%d", entries0, entries1)
+	}
+	if hits1 <= hits0 {
+		t.Fatalf("expected second mmap read to hit grouped cache: hits before=%d after=%d", hits0, hits1)
+	}
+	if misses1 != misses0 {
+		t.Fatalf("unexpected cache miss increase on second mmap read: before=%d after=%d", misses0, misses1)
+	}
+}
+
 func TestReadAtGroupedFastPathWithoutChecksum(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "value-000001.log")

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -789,6 +789,8 @@ func reportProfileBenchBackendVlogMmapStats(b *testing.B, after, before map[stri
 	reportPerDoc("backend_vlog_mmap_fallback_readat/doc", "treedb.vlog.mmap_read.fallback_readat")
 	reportPerDoc("backend_vlog_mmap_sealed_denied_count_cap/doc", "treedb.vlog.mmap_sealed_map_denied.count_cap")
 	reportPerDoc("backend_vlog_mmap_sealed_denied_bytes_cap/doc", "treedb.vlog.mmap_sealed_map_denied.bytes_cap")
+	reportPerDoc("backend_vlog_grouped_frame_cache_hits/doc", "treedb.vlog.grouped_frame_cache.hits")
+	reportPerDoc("backend_vlog_grouped_frame_cache_misses/doc", "treedb.vlog.grouped_frame_cache.misses")
 	reportPerDoc("backend_tree_get_append_inline_hits/doc", "treedb.process.read_path.backend_tree.get_append_inline_hits_total")
 	reportPerDoc("backend_tree_get_append_inline_bytes/doc", "treedb.process.read_path.backend_tree.get_append_inline_bytes_total")
 	reportPerDoc("backend_tree_get_append_pointer_hits/doc", "treedb.process.read_path.backend_tree.get_append_pointer_hits_total")
@@ -810,6 +812,11 @@ func reportProfileBenchBackendVlogMmapStats(b *testing.B, after, before map[stri
 	if total := hits + fallbacks; total > 0 {
 		b.ReportMetric(float64(hits)/float64(total), "backend_vlog_mmap_hit_ratio")
 	}
+	groupedFrameCacheHits := profileBenchDeltaUintStat(after, before, "treedb.vlog.grouped_frame_cache.hits")
+	groupedFrameCacheMisses := profileBenchDeltaUintStat(after, before, "treedb.vlog.grouped_frame_cache.misses")
+	if total := groupedFrameCacheHits + groupedFrameCacheMisses; total > 0 {
+		b.ReportMetric(float64(groupedFrameCacheHits)/float64(total), "backend_vlog_grouped_frame_cache_hit_ratio")
+	}
 	outerLeafCacheHits := profileBenchDeltaUintStat(after, before, "treedb.process.read_path.outer_leaf.cache.hits")
 	outerLeafCacheMisses := profileBenchDeltaUintStat(after, before, "treedb.process.read_path.outer_leaf.cache.misses")
 	if total := outerLeafCacheHits + outerLeafCacheMisses; total > 0 {
@@ -822,6 +829,8 @@ func reportProfileBenchBackendVlogMmapStats(b *testing.B, after, before map[stri
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.vlog.mmap_sealed_bytes")), "backend_vlog_mmap_sealed_bytes")
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.vlog.mmap_active_segments")), "backend_vlog_mmap_active_segments")
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.vlog.mmap_active_bytes")), "backend_vlog_mmap_active_bytes")
+	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.vlog.grouped_frame_cache.entries")), "backend_vlog_grouped_frame_cache_entries")
+	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.vlog.grouped_frame_cache.capacity")), "backend_vlog_grouped_frame_cache_capacity")
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.process.read_path.outer_leaf.cache.entries")), "backend_outer_leaf_cache_entries")
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.process.read_path.outer_leaf.cache.capacity")), "backend_outer_leaf_cache_capacity")
 	b.ReportMetric(float64(profileBenchUintStat(after, "treedb.process.read_path.outer_leaf.cache.bytes")), "backend_outer_leaf_cache_bytes")


### PR DESCRIPTION
## Summary

- Teach the mmap grouped-frame `ReadUnsafeTo` path to populate and reuse the grouped-frame cache when the caller's destination buffer can hold the selected subrecord but not the full decoded grouped frame.
- Preserve caller-buffer semantics by decoding the full grouped frame into reusable file scratch, caching that decoded raw frame when eligible, and copying only the requested subrecord into `dst`.
- Add profile-benchmark metrics for grouped-frame cache hits, misses, hit ratio, entries, and capacity so future profiles can distinguish cache behavior from plain mmap hit rate.

## Why

The fallback grouped-frame read path already populated the grouped-frame cache, but the mmap `ReadUnsafeTo` path decoded the full compressed grouped frame directly into `dst` only when `dst` could hold the entire raw frame. With a smaller but still sufficient value buffer, it missed the cache population opportunity and returned an allocated decode path. This keeps the hot API contract intact while making repeated subrecord reads observable and cacheable.

## Validation

- `go test ./TreeDB/internal/valuelog -count=1`
- `go test ./cmd/mongo_gateway_bench -run 'TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats|TestProfileBenchBufferedIndexedAsyncFlushEnv' -count=1`
- `git diff --check`

## Benchmark note

Focused randomized collection-update run, for observability only:

```bash
RUN_DIR=$(mktemp -d /tmp/gomap_1159_grouped_frame_cache_fix_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=200000x \
  -benchmem \
  -count=1 | tee "$RUN_DIR/bench.txt"
```

Result directory: `/tmp/gomap_1159_grouped_frame_cache_fix_eqCBjx`

- `130,310 docs/sec`, `7,674 ns/doc`, `1,548 B/op`, `4 allocs/op`
- New metrics emitted: `backend_vlog_grouped_frame_cache_hits/doc`, `backend_vlog_grouped_frame_cache_misses/doc`, `backend_vlog_grouped_frame_cache_hit_ratio`, `backend_vlog_grouped_frame_cache_entries`, `backend_vlog_grouped_frame_cache_capacity`
- In this randomized update shape, grouped-frame cache entries remained `0` and hit ratio remained `0`; this PR is a targeted mmap read-path/cache correctness and instrumentation change, not the primary randomized update bottleneck fix.
