### PR TITLE
Avoid compacting trusted ordered root deltas

### DIFF
--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -428,6 +428,32 @@ func (b *Batch) SetView(key, value []byte) error {
 	return nil
 }
 
+// AppendViewTrustedSortedUnique records a Put without copying key/value bytes or
+// invalidating the sorted/compacted state. Caller must guarantee key is non-nil,
+// key/value remain immutable until commit/close, and appended keys are strictly
+// increasing with no duplicates.
+func (b *Batch) AppendViewTrustedSortedUnique(key, value []byte) error {
+	if err := b.ensureOpen(); err != nil {
+		return err
+	}
+	if key == nil {
+		return ErrKeyEmpty
+	}
+	if len(value) > b.inlineThresholdForKey(key) {
+		return ErrValueTooLarge
+	}
+	b.entries = append(b.entries, Entry{
+		Type:  OpPut,
+		Key:   key,
+		Value: value,
+	})
+	b.byteSize += len(key) + len(value)
+	if b.sorted {
+		b.lastKey = key
+	}
+	return nil
+}
+
 // Set adds or replaces a key/value operation.
 func (b *Batch) Set(key, value []byte) error {
 	if err := b.ensureOpen(); err != nil {
@@ -484,6 +510,28 @@ func (b *Batch) DeleteView(key []byte) error {
 	return nil
 }
 
+// AppendDeleteViewTrustedSortedUnique records a Delete without copying key bytes
+// or invalidating sorted/compacted state. Caller must guarantee key is non-nil,
+// key remains immutable until commit/close, and appended keys are strictly
+// increasing with no duplicates.
+func (b *Batch) AppendDeleteViewTrustedSortedUnique(key []byte) error {
+	if err := b.ensureOpen(); err != nil {
+		return err
+	}
+	if key == nil {
+		return ErrKeyEmpty
+	}
+	b.entries = append(b.entries, Entry{
+		Type: OpDelete,
+		Key:  key,
+	})
+	b.byteSize += len(key)
+	if b.sorted {
+		b.lastKey = key
+	}
+	return nil
+}
+
 // SetPointer adds a pointer directly to the batch (used by Compaction).
 func (b *Batch) SetPointer(key []byte, ptr page.ValuePtr) error {
 	if err := b.ensureOpen(); err != nil {
@@ -529,6 +577,34 @@ func (b *Batch) SetPointerView(key []byte, ptr page.ValuePtr) error {
 // publication needs them.
 func (b *Batch) SetPointerViewNoTouch(key []byte, ptr page.ValuePtr) error {
 	return b.setPointerViewInternal(key, ptr, false)
+}
+
+// AppendPointerViewTrustedSortedUnique records a pointer Put without copying key
+// bytes or invalidating sorted/compacted state. Caller must guarantee key is
+// non-empty, key remains immutable until commit/close, ptr is a value-log pointer,
+// and appended keys are strictly increasing with no duplicates.
+func (b *Batch) AppendPointerViewTrustedSortedUnique(key []byte, ptr page.ValuePtr) error {
+	if err := b.ensureOpen(); err != nil {
+		return err
+	}
+	if len(key) == 0 {
+		return ErrKeyEmpty
+	}
+	if !page.IsValueLogFileID(ptr.FileID) {
+		return fmt.Errorf("invalid value-log pointer: file %d", ptr.FileID)
+	}
+	b.entries = append(b.entries, Entry{
+		Type:     OpPut,
+		Key:      key,
+		ValuePtr: ptr,
+		IsPtr:    true,
+	})
+	b.hasValueLogPointers = true
+	b.noteTouchedValueLog(ptr)
+	if b.sorted {
+		b.lastKey = key
+	}
+	return nil
 }
 
 // AppendPointerViewNoTouchTrustedSorted appends a pointer Put without input

--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -429,14 +429,14 @@ func (b *Batch) SetView(key, value []byte) error {
 }
 
 // AppendViewTrustedSortedUnique records a Put without copying key/value bytes or
-// invalidating the sorted/compacted state. Caller must guarantee key is non-nil,
+// invalidating the sorted/compacted state. Caller must guarantee key is non-empty,
 // key/value remain immutable until commit/close, and appended keys are strictly
 // increasing with no duplicates.
 func (b *Batch) AppendViewTrustedSortedUnique(key, value []byte) error {
 	if err := b.ensureOpen(); err != nil {
 		return err
 	}
-	if key == nil {
+	if len(key) == 0 {
 		return ErrKeyEmpty
 	}
 	if len(value) > b.inlineThresholdForKey(key) {
@@ -511,14 +511,14 @@ func (b *Batch) DeleteView(key []byte) error {
 }
 
 // AppendDeleteViewTrustedSortedUnique records a Delete without copying key bytes
-// or invalidating sorted/compacted state. Caller must guarantee key is non-nil,
+// or invalidating sorted/compacted state. Caller must guarantee key is non-empty,
 // key remains immutable until commit/close, and appended keys are strictly
 // increasing with no duplicates.
 func (b *Batch) AppendDeleteViewTrustedSortedUnique(key []byte) error {
 	if err := b.ensureOpen(); err != nil {
 		return err
 	}
-	if key == nil {
+	if len(key) == 0 {
 		return ErrKeyEmpty
 	}
 	b.entries = append(b.entries, Entry{

--- a/TreeDB/batch/batch_test.go
+++ b/TreeDB/batch/batch_test.go
@@ -165,6 +165,70 @@ func TestBatchSortedEntriesInvalidatesCompactionAfterMutation(t *testing.T) {
 	}
 }
 
+func TestBatchAppendViewTrustedSortedUniquePreservesCompactedState(t *testing.T) {
+	b := New(newMapValueReader(), page.DefaultInlineThreshold)
+	t.Cleanup(func() { _ = b.Close() })
+
+	if err := b.AppendViewTrustedSortedUnique([]byte("a"), []byte("va")); err != nil {
+		t.Fatalf("append a: %v", err)
+	}
+	if err := b.AppendViewTrustedSortedUnique([]byte("b"), []byte("vb")); err != nil {
+		t.Fatalf("append b: %v", err)
+	}
+	if err := b.AppendDeleteViewTrustedSortedUnique([]byte("c")); err != nil {
+		t.Fatalf("append delete c: %v", err)
+	}
+	if !b.sorted || !b.compacted {
+		t.Fatalf("trusted appends sorted=%v compacted=%v, want true/true", b.sorted, b.compacted)
+	}
+
+	first := b.SortedEntries()
+	if len(first) != 3 {
+		t.Fatalf("len(first)=%d want 3", len(first))
+	}
+	if &first[0] != &b.entries[0] {
+		t.Fatal("trusted sorted unique appends forced a SortedEntries compaction")
+	}
+	second := b.SortedEntries()
+	if &second[0] != &first[0] {
+		t.Fatal("second SortedEntries did not reuse trusted compacted slice")
+	}
+	if got := string(second[0].Key); got != "a" {
+		t.Fatalf("entry[0] key=%q want a", got)
+	}
+	if second[2].Type != OpDelete || string(second[2].Key) != "c" {
+		t.Fatalf("entry[2]=%v/%q want delete c", second[2].Type, second[2].Key)
+	}
+}
+
+func TestBatchAppendPointerViewTrustedSortedUniqueTracksTouchedSegment(t *testing.T) {
+	b := New(newMapValueReader(), page.DefaultInlineThreshold)
+	t.Cleanup(func() { _ = b.Close() })
+
+	ptr := page.ValuePtr{
+		FileID: page.ValueLogFileID(7),
+		Offset: 123,
+		Length: 456,
+	}
+	if err := b.AppendPointerViewTrustedSortedUnique([]byte("a"), ptr); err != nil {
+		t.Fatalf("append pointer: %v", err)
+	}
+	if !b.sorted || !b.compacted {
+		t.Fatalf("trusted pointer append sorted=%v compacted=%v, want true/true", b.sorted, b.compacted)
+	}
+	if !b.HasValueLogPointers() {
+		t.Fatal("HasValueLogPointers()=false, want true")
+	}
+	touched := b.TouchedValueLogSegments()
+	if len(touched) != 1 || touched[0] != ptr.FileID {
+		t.Fatalf("TouchedValueLogSegments()=%v want [%d]", touched, ptr.FileID)
+	}
+	entries := b.SortedEntries()
+	if len(entries) != 1 || !entries[0].IsPtr || entries[0].ValuePtr != ptr {
+		t.Fatalf("entries=%+v want pointer %+v", entries, ptr)
+	}
+}
+
 func TestBatchSetOps_UsesSlabPointersForLargeValues(t *testing.T) {
 	reader := newMapValueReader()
 	b := New(reader, page.DefaultInlineThreshold)

--- a/TreeDB/batch/batch_test.go
+++ b/TreeDB/batch/batch_test.go
@@ -201,6 +201,18 @@ func TestBatchAppendViewTrustedSortedUniquePreservesCompactedState(t *testing.T)
 	}
 }
 
+func TestBatchAppendTrustedSortedUniqueRejectsEmptyKeys(t *testing.T) {
+	b := New(newMapValueReader(), page.DefaultInlineThreshold)
+	t.Cleanup(func() { _ = b.Close() })
+
+	if err := b.AppendViewTrustedSortedUnique([]byte{}, []byte("value")); err != ErrKeyEmpty {
+		t.Fatalf("AppendViewTrustedSortedUnique empty key error=%v want %v", err, ErrKeyEmpty)
+	}
+	if err := b.AppendDeleteViewTrustedSortedUnique([]byte{}); err != ErrKeyEmpty {
+		t.Fatalf("AppendDeleteViewTrustedSortedUnique empty key error=%v want %v", err, ErrKeyEmpty)
+	}
+}
+
 func TestBatchAppendPointerViewTrustedSortedUniqueTracksTouchedSegment(t *testing.T) {
 	b := New(newMapValueReader(), page.DefaultInlineThreshold)
 	t.Cleanup(func() { _ = b.Close() })

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4078,6 +4078,10 @@ func (it *bufferedRootRunsIterator) StableUnsafeIteratorSlices() bool {
 	return it != nil && it.stableUnsafeSlices
 }
 
+func (it *bufferedRootRunsIterator) OrderedUniqueUnsafeIterator() bool {
+	return true
+}
+
 func (it *bufferedRootRunsIterator) Len() int {
 	if it == nil {
 		return 0

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -132,6 +132,10 @@ type orderedRootStableUnsafeIterator interface {
 	StableUnsafeIteratorSlices() bool
 }
 
+type orderedRootTrustedSortedUniqueIterator interface {
+	OrderedUniqueUnsafeIterator() bool
+}
+
 type orderedRootLenHintIterator interface {
 	Len() int
 }
@@ -317,16 +321,22 @@ func orderedRootEntryValueLogFileID(iter iterator.UnsafeIterator) (uint32, bool)
 	return ptr.FileID, true
 }
 
-func orderedRootBatchPut(delta *batch.Batch, iter iterator.UnsafeIterator, borrowEntryViews bool) error {
+func orderedRootBatchPut(delta *batch.Batch, iter iterator.UnsafeIterator, borrowEntryViews bool, trustedSortedUnique bool) error {
 	if delta == nil || iter == nil || !iter.Valid() {
 		return nil
 	}
 	val, ptr, flags := iter.UnsafeEntry()
 	if flags&node.FlagPointer != 0 && page.IsValueLogFileID(ptr.FileID) {
+		if borrowEntryViews && trustedSortedUnique {
+			return delta.AppendPointerViewTrustedSortedUnique(iter.UnsafeKey(), ptr)
+		}
 		if borrowEntryViews {
 			return delta.SetPointerView(iter.UnsafeKey(), ptr)
 		}
 		return delta.SetPointer(iter.UnsafeKey(), ptr)
+	}
+	if borrowEntryViews && trustedSortedUnique {
+		return delta.AppendViewTrustedSortedUnique(iter.UnsafeKey(), val)
 	}
 	if borrowEntryViews {
 		return delta.SetView(iter.UnsafeKey(), val)
@@ -346,10 +356,16 @@ func orderedRootDeltaBatchFromIterator(iter iterator.UnsafeIterator) (*batch.Bat
 	if stable, ok := iter.(orderedRootStableUnsafeIterator); ok {
 		borrowEntryViews = stable.StableUnsafeIteratorSlices()
 	}
+	trustedSortedUnique := false
+	if trusted, ok := iter.(orderedRootTrustedSortedUniqueIterator); ok {
+		trustedSortedUnique = trusted.OrderedUniqueUnsafeIterator()
+	}
 	for iter.Valid() {
 		if iter.IsDeleted() {
 			var err error
-			if borrowEntryViews {
+			if borrowEntryViews && trustedSortedUnique {
+				err = delta.AppendDeleteViewTrustedSortedUnique(iter.UnsafeKey())
+			} else if borrowEntryViews {
 				err = delta.DeleteView(iter.UnsafeKey())
 			} else {
 				err = delta.Delete(iter.UnsafeKey())
@@ -358,7 +374,7 @@ func orderedRootDeltaBatchFromIterator(iter iterator.UnsafeIterator) (*batch.Bat
 				_ = delta.Close()
 				return nil, err
 			}
-		} else if err := orderedRootBatchPut(delta, iter, borrowEntryViews); err != nil {
+		} else if err := orderedRootBatchPut(delta, iter, borrowEntryViews, trustedSortedUnique); err != nil {
 			_ = delta.Close()
 			return nil, err
 		}
@@ -636,7 +652,7 @@ func buildOrderedRootDeltaBatch(baseIter, targetIter iterator.UnsafeIterator, tr
 					vlogRefDelta.add(fileID, 1)
 				}
 			}
-			if err := orderedRootBatchPut(delta, targetIter, false); err != nil {
+			if err := orderedRootBatchPut(delta, targetIter, false, false); err != nil {
 				_ = delta.Close()
 				return nil, 0, nil, err
 			}
@@ -664,7 +680,7 @@ func buildOrderedRootDeltaBatch(baseIter, targetIter iterator.UnsafeIterator, tr
 						vlogRefDelta.add(fileID, 1)
 					}
 				}
-				if err := orderedRootBatchPut(delta, targetIter, false); err != nil {
+				if err := orderedRootBatchPut(delta, targetIter, false, false); err != nil {
 					_ = delta.Close()
 					return nil, 0, nil, err
 				}
@@ -681,7 +697,7 @@ func buildOrderedRootDeltaBatch(baseIter, targetIter iterator.UnsafeIterator, tr
 							vlogRefDelta.add(fileID, 1)
 						}
 					}
-					if err := orderedRootBatchPut(delta, targetIter, false); err != nil {
+					if err := orderedRootBatchPut(delta, targetIter, false, false); err != nil {
 						_ = delta.Close()
 						return nil, 0, nil, err
 					}

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -1187,6 +1187,8 @@ type stableRootDeltaIterator struct {
 
 func (it *stableRootDeltaIterator) StableUnsafeIteratorSlices() bool { return true }
 
+func (it *stableRootDeltaIterator) OrderedUniqueUnsafeIterator() bool { return true }
+
 func (it *stableRootDeltaIterator) Len() int {
 	if it == nil {
 		return 0


### PR DESCRIPTION
## Summary

- Adds trusted sorted/unique append helpers to `batch.Batch` so internal callers can retain stable key/value views without forcing a later `SortedEntries` compaction pass.
- Teaches ordered-root delta materialization to use the trusted path only when an iterator explicitly advertises ordered unique unsafe views.
- Marks collection buffered root-run iterators as ordered/unique; these iterators already merge runs by key and emit only the newest entry/tombstone for each key.

Refs #1159.

## Validation

- `GOWORK=off go test ./TreeDB/batch ./TreeDB/db ./TreeDB/collections -run 'TestBatchAppend|TestOrderedRootDeltaBatchFromIterator_StableIteratorUsesViews|TestBufferedRootRunsIterator|TestCollectionIndexedWriteMemtablesCompactRootRunsBeforeDocumentFlush' -count=1`
- `GOWORK=off go test ./TreeDB/batch ./TreeDB/db ./TreeDB/collections ./cmd/mongo_gateway_bench -count=1`
- `git diff --check`

## Focused benchmark

Command:

```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1159_trusted_delta_XXXXXX) && echo "PROFILE_DIR=$PROFILE_DIR" && \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof" | tee "$PROFILE_DIR/bench.txt"
```

Baseline from `origin/main` before this PR:

- `7808 ns/op`, `128066 docs/sec`, `1306 B/op`, `4 allocs/op`
- `publish_delta_group_root_apply_ns/doc=2271`
- `publish_delta_group_lock_hold_ns/doc=2288`
- `indexed_flush_root_runs/call=12639`

This PR:

- `7562 ns/op`, `132243 docs/sec`, `1186 B/op`, `4 allocs/op`
- `publish_delta_group_root_apply_ns/doc=2023`
- `publish_delta_group_lock_hold_ns/doc=2052`
- `indexed_flush_root_runs/call=12263`

The pprof profile for this run is in `/tmp/gomap_1159_trusted_delta_w6WCni` on the local runner.
