### PR TITLE
collections: skip heap churn for ordered root runs

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3957,7 +3957,9 @@ func (it *bufferedRootRunsIterator) Next() {
 		return
 	}
 	if it.hasCur {
-		it.advanceItem(it.cur)
+		if it.advanceCurrentItemDirect(it.cur) {
+			return
+		}
 		it.hasCur = false
 	}
 	it.advance()
@@ -4127,6 +4129,34 @@ func (it *bufferedRootRunsIterator) advanceItem(item bufferedRootRunHeapItem) {
 	} else if err := source.Error(); err != nil && it.firstErr == nil {
 		it.firstErr = err
 	}
+}
+
+func (it *bufferedRootRunsIterator) advanceCurrentItemDirect(item bufferedRootRunHeapItem) bool {
+	source := it.iters[item.idx]
+	source.Next()
+	if !source.Valid() {
+		if err := source.Error(); err != nil && it.firstErr == nil {
+			it.firstErr = err
+		}
+		return false
+	}
+	item.key = source.UnsafeKey()
+	if it.end != nil && bytes.Compare(item.key, it.end) >= 0 {
+		return false
+	}
+	if !it.includeDeleted && source.IsDeleted() {
+		it.heap.push(item)
+		return false
+	}
+	next := it.heap.peek()
+	if next == nil || bytes.Compare(item.key, next.key) < 0 {
+		it.cur = item
+		it.hasCur = true
+		it.valid = true
+		return true
+	}
+	it.heap.push(item)
+	return false
 }
 
 func (c *Collection) prepareIndexedAsyncPublish() (*indexedFlushPublishWork, error) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3108,6 +3108,98 @@ func TestBufferedRootRunsIteratorMultiRunIncludesNewestTombstone(t *testing.T) {
 	}
 }
 
+func TestBufferedRootRunsIteratorDirectPathPreservesDisjointRunOrder(t *testing.T) {
+	front := newCollectionRunTable(3)
+	defer resetCollectionRunTable(front)
+	setCollectionRunValue(front, []byte("a"), []byte("front-a"))
+	setCollectionRunValue(front, []byte("c"), []byte("front-c"))
+	setCollectionRunValue(front, []byte("e"), []byte("front-e"))
+	front.Freeze()
+
+	back := newCollectionRunTable(1)
+	defer resetCollectionRunTable(back)
+	setCollectionRunValue(back, []byte("z"), []byte("back-z"))
+	back.Freeze()
+
+	it := newBufferedRootRunsIteratorWithDeleted([]memtable.Table{front, back}, nil, nil, true)
+	defer func() { _ = it.Close() }()
+
+	var got []string
+	for it.Valid() {
+		got = append(got, string(it.UnsafeKey())+"="+string(it.UnsafeValue()))
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	want := []string{"a=front-a", "c=front-c", "e=front-e", "z=back-z"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("entries=%v want %v", got, want)
+	}
+}
+
+func TestBufferedRootRunsIteratorDirectPathFallsBackForEqualKeys(t *testing.T) {
+	older := newCollectionRunTable(2)
+	defer resetCollectionRunTable(older)
+	setCollectionRunValue(older, []byte("a"), []byte("older-a"))
+	setCollectionRunValue(older, []byte("b"), []byte("older-b"))
+	older.Freeze()
+
+	newer := newCollectionRunTable(1)
+	defer resetCollectionRunTable(newer)
+	setCollectionRunValue(newer, []byte("b"), []byte("newer-b"))
+	newer.Freeze()
+
+	it := newBufferedRootRunsIteratorWithDeleted([]memtable.Table{older, newer}, nil, nil, true)
+	defer func() { _ = it.Close() }()
+
+	if !it.Valid() {
+		t.Fatal("iterator invalid, want key a")
+	}
+	if got := string(it.UnsafeKey()) + "=" + string(it.UnsafeValue()); got != "a=older-a" {
+		t.Fatalf("first entry=%s want a=older-a", got)
+	}
+	it.Next()
+	if !it.Valid() {
+		t.Fatal("iterator missing shadowed key b")
+	}
+	if got := string(it.UnsafeKey()) + "=" + string(it.UnsafeValue()); got != "b=newer-b" {
+		t.Fatalf("second entry=%s want b=newer-b", got)
+	}
+	it.Next()
+	if it.Valid() {
+		t.Fatalf("iterator has extra key %q", it.UnsafeKey())
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+}
+
+func TestBufferedRootRunsIteratorDirectPathSkipsMiddleTombstone(t *testing.T) {
+	table := newCollectionRunTable(3)
+	defer resetCollectionRunTable(table)
+	setCollectionRunValue(table, []byte("a"), []byte("live-a"))
+	table.DeleteSteal([]byte("b"))
+	setCollectionRunValue(table, []byte("c"), []byte("live-c"))
+	table.Freeze()
+
+	it := newBufferedRootRunsIterator([]memtable.Table{table}, nil, nil)
+	defer func() { _ = it.Close() }()
+
+	var got []string
+	for it.Valid() {
+		got = append(got, string(it.UnsafeKey()))
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	want := []string{"a", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("keys=%v want %v", got, want)
+	}
+}
+
 func TestBufferedRootRunsIteratorMultiRunStableUnsafeSlices(t *testing.T) {
 	oldAKey := []byte("a")
 	oldBKey := []byte("b")


### PR DESCRIPTION
## Summary
- add a direct-next fast path for `bufferedRootRunsIterator` when the current run's next key remains strictly before the heap head
- keep equal-key/tombstone cases on the existing merge path so shadowing and delete filtering semantics stay unchanged
- add focused iterator tests for disjoint-run direct advancement, equal-key fallback, and middle tombstone skipping

## Benchmark evidence
Focused benchmark compared against `origin/main` after #1213/#1214 on Apple M3.

Main profile dir: `/tmp/gomap_1159_main_after1214_profile_77uuzl`
Branch profile dir: `/tmp/gomap_1215_iter_profile_TxSBsY`

Command:
```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run "^$" \
  -bench "^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$" \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

Results:
- main: `160,831 docs/sec`, `6218 ns/doc`, `1238 B/op`, `3 allocs/op`
- this branch: `165,056 docs/sec`, `6059 ns/doc`, `1234 B/op`, `3 allocs/op`

CPU profile still shows the larger remaining bottlenecks in leaf-log mmap/decode/root apply, so this is intentionally a small root-run merge cleanup before the next leaf-log/root-apply PR.

## Tests
- `GOWORK=off go test ./TreeDB/collections -run "TestBufferedRootRunsIterator" -count 1`
- `GOWORK=off go test ./TreeDB/collections -count 1`
- `GOWORK=off go test ./cmd/mongo_gateway_bench -run "^$" -count 1`
- `git diff --check`