### PR TITLE
valuelog: use length hints for mmap range checks

### DIFF
--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -341,6 +341,37 @@ func TestManagerCurrentWritableReadBarrierUsedForUnverifiedRecord(t *testing.T) 
 	}
 }
 
+func TestFileEnsureMmapRecordInitialRangeRequiresHeaderForSmallHint(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "segment-*.log")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if _, err := tmp.Write(make([]byte, HeaderSize-1)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	file, err := os.Open(tmp.Name())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	data := make([]byte, HeaderSize-1)
+	f := &File{ID: 9, File: file}
+	f.mmapData.Store(data)
+	f.noteVerifiedFileSize(int64(len(data)))
+	ptr := page.ValuePtr{
+		Offset: valueLogRecordCRCPrefixBytes,
+		Length: 1,
+	}
+
+	if _, ok, _ := f.ensureMmapRecordInitialRange(data, ptr, int64(ptr.Offset-4)); ok {
+		t.Fatalf("small nonzero hint should not make a partial header readable")
+	}
+}
+
 func testCurrentWritableRecordPtr(payloadLen uint32) page.ValuePtr {
 	return page.ValuePtr{
 		Offset: valueLogRecordCRCPrefixBytes,

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -33,6 +33,19 @@ func appendDecodedTemplatePayload(dst, payload []byte, lookup TemplateLookup, ca
 // lock-contention amplification on the unsafe view path.
 const readViaMmapViewPrefixCacheEnabled = false
 
+func (f *File) ensureMmapRecordInitialRange(data []byte, ptr page.ValuePtr, start int64) ([]byte, bool, bool) {
+	if hint := page.ValuePtrRecordLength(ptr); hint > 0 {
+		if refreshed, ok := f.ensureMmapRangeReadable(data, start, int64(ptr.Offset)+int64(hint)); ok {
+			return refreshed, true, true
+		}
+		return nil, false, false
+	}
+	if refreshed, ok := f.ensureMmapRangeReadable(data, start, start+HeaderSize); ok {
+		return refreshed, true, false
+	}
+	return nil, false, false
+}
+
 // MaxDeadMappings is the base cap for old mmaps retained to avoid exhausting
 // vm.max_map_count. Unless explicitly configured, the effective cap can grow
 // with mapped size up to maxAdaptiveDeadMappings. Set <= 0 to disable the cap.
@@ -522,8 +535,10 @@ func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error
 		return nil, ErrCorrupt, true
 	}
 	start := int64(ptr.Offset - 4)
-	if refreshed, ok := f.ensureMmapRangeReadable(data, start, start+HeaderSize); ok {
+	fullRangeReadable := false
+	if refreshed, ok, full := f.ensureMmapRecordInitialRange(data, ptr, start); ok {
 		data = refreshed
+		fullRangeReadable = full
 	} else {
 		f.mmapReadMissOutOfRange.Add(1)
 		return nil, nil, false
@@ -546,12 +561,14 @@ func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error
 	}
 
 	end := start + HeaderSize + int64(valueLen)
-	if refreshed, ok := f.ensureMmapRangeReadable(data, start, end); ok {
-		data = refreshed
-		header = data[start : start+HeaderSize]
-	} else {
-		f.mmapReadMissOutOfRange.Add(1)
-		return nil, nil, false
+	if !fullRangeReadable {
+		if refreshed, ok := f.ensureMmapRangeReadable(data, start, end); ok {
+			data = refreshed
+			header = data[start : start+HeaderSize]
+		} else {
+			f.mmapReadMissOutOfRange.Add(1)
+			return nil, nil, false
+		}
 	}
 
 	payload := data[start+HeaderSize : end]
@@ -828,8 +845,10 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		return nil, false, ErrCorrupt, true
 	}
 	start := int64(ptr.Offset - 4)
-	if refreshed, ok := f.ensureMmapRangeReadable(data, start, start+HeaderSize); ok {
+	fullRangeReadable := false
+	if refreshed, ok, full := f.ensureMmapRecordInitialRange(data, ptr, start); ok {
 		data = refreshed
+		fullRangeReadable = full
 	} else {
 		f.mmapReadMissOutOfRange.Add(1)
 		return nil, false, nil, false
@@ -852,12 +871,14 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 
 	end := start + HeaderSize + int64(valueLen)
-	if refreshed, ok := f.ensureMmapRangeReadable(data, start, end); ok {
-		data = refreshed
-		header = data[start : start+HeaderSize]
-	} else {
-		f.mmapReadMissOutOfRange.Add(1)
-		return nil, false, nil, false
+	if !fullRangeReadable {
+		if refreshed, ok := f.ensureMmapRangeReadable(data, start, end); ok {
+			data = refreshed
+			header = data[start : start+HeaderSize]
+		} else {
+			f.mmapReadMissOutOfRange.Add(1)
+			return nil, false, nil, false
+		}
 	}
 
 	payload := data[start+HeaderSize : end]
@@ -1058,8 +1079,10 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 		return nil, ErrCorrupt, true
 	}
 	start := int64(ptr.Offset - 4)
-	if refreshed, ok := f.ensureMmapRangeReadable(data, start, start+HeaderSize); ok {
+	fullRangeReadable := false
+	if refreshed, ok, full := f.ensureMmapRecordInitialRange(data, ptr, start); ok {
 		data = refreshed
+		fullRangeReadable = full
 	} else {
 		f.mmapReadMissOutOfRange.Add(1)
 		return nil, nil, false
@@ -1082,12 +1105,14 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 	}
 
 	end := start + HeaderSize + int64(valueLen)
-	if refreshed, ok := f.ensureMmapRangeReadable(data, start, end); ok {
-		data = refreshed
-		header = data[start : start+HeaderSize]
-	} else {
-		f.mmapReadMissOutOfRange.Add(1)
-		return nil, nil, false
+	if !fullRangeReadable {
+		if refreshed, ok := f.ensureMmapRangeReadable(data, start, end); ok {
+			data = refreshed
+			header = data[start : start+HeaderSize]
+		} else {
+			f.mmapReadMissOutOfRange.Add(1)
+			return nil, nil, false
+		}
 	}
 
 	payload := data[start+HeaderSize : end]

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -35,7 +35,11 @@ const readViaMmapViewPrefixCacheEnabled = false
 
 func (f *File) ensureMmapRecordInitialRange(data []byte, ptr page.ValuePtr, start int64) ([]byte, bool, bool) {
 	if hint := page.ValuePtrRecordLength(ptr); hint > 0 {
-		if refreshed, ok := f.ensureMmapRangeReadable(data, start, int64(ptr.Offset)+int64(hint)); ok {
+		end := int64(ptr.Offset) + int64(hint)
+		if headerEnd := start + HeaderSize; end < headerEnd {
+			end = headerEnd
+		}
+		if refreshed, ok := f.ensureMmapRangeReadable(data, start, end); ok {
 			return refreshed, true, true
 		}
 		return nil, false, false


### PR DESCRIPTION
## Summary
- use non-zero value-log record-length hints to validate the full mmap record range before parsing the header
- skip the second `ensureMmapRangeReadable` call for hinted mmap reads while retaining the existing header-derived length validation
- apply the path to unsafe view, unsafe view-to, and append mmap readers

## Benchmark evidence
Focused benchmark compared against `origin/main` after #1213/#1214 on Apple M3.

Main profile dir: `/tmp/gomap_1159_main_after1214_profile_77uuzl`
Branch profile dir: `/tmp/gomap_1216_mmap_hint_profile_tNaGK3`

Command:
```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run "^$" \
  -bench "^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$" \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

Results:
- main: `160,831 docs/sec`, `6218 ns/doc`, `1238 B/op`, `3 allocs/op`, `publish_delta_group_root_apply_ns/doc=2294`
- this branch: `164,873 docs/sec`, `6065 ns/doc`, `1231 B/op`, `3 allocs/op`, `publish_delta_group_root_apply_ns/doc=2163`

This keeps allocation posture flat while shaving one mmap range check on hinted value-log/leaf-log reads.

## Related negative checks
I also tested two adjacent hypotheses and did not keep them:
- grouped-frame cache admission for caller-owned raw frames: no measurable effect on this workload because hot reads still reported zero grouped-frame cache entries
- immediate outer-leaf read-miss cache admission: worsened throughput (`~152.6k docs/sec`) and increased cache churn, so the repeated-miss admission policy should stay

## Tests
- `GOWORK=off go test ./TreeDB/internal/valuelog -run "TestValueLogManager_ReadUnsafeTo_CompressedGroupedMmapUsesCache|TestReadAtGroupedFastPathWithoutChecksum|TestReadAtGroupedCompressedFrame|TestValueLogManager" -count 1`
- `GOWORK=off go test ./TreeDB/internal/valuelog ./TreeDB/db -count 1`
- `git diff --check`