### PR TITLE
collections: size pending index rebuild maps

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3706,6 +3706,21 @@ func bufferedRunLenHint(tables []memtable.Table) int {
 		}
 		total = saturatingAddNonNegativeInt(total, table.Len())
 	}
+	return boundedBufferedRunLenHint(total)
+}
+
+// bufferedRunLenHintMaxCapacity keeps duplicate-heavy pending-run rebuilds from
+// sizing maps to the full historical mutation count when the final cardinality
+// may be much smaller.
+const bufferedRunLenHintMaxCapacity = 1 << 16
+
+func boundedBufferedRunLenHint(total int) int {
+	if total <= 0 {
+		return 0
+	}
+	if total > bufferedRunLenHintMaxCapacity {
+		return bufferedRunLenHintMaxCapacity
+	}
 	return total
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3457,7 +3457,7 @@ func rebuildBufferedUniqueValueIndexes(runs map[string][]memtable.Table) map[str
 	}
 	out := make(map[string]*bufferedUniqueValueIndex, len(runs))
 	for indexName, tables := range runs {
-		index := newBufferedUniqueValueIndex(0)
+		index := newBufferedUniqueValueIndex(bufferedRunLenHint(tables))
 		for _, table := range tables {
 			it := table.NewIterator(nil, nil)
 			for it.Valid() {
@@ -3666,7 +3666,7 @@ func rebuildBufferedPrimaryRunIndex(collectionName string, runs map[string][]mem
 	if len(tables) == 0 {
 		return nil, nil
 	}
-	index := newBufferedPrimaryRunIndex(0)
+	index := newBufferedPrimaryRunIndex(bufferedRunLenHint(tables))
 	for _, table := range tables {
 		if err := addBufferedPrimaryRunIndexEntries(index, table); err != nil {
 			return nil, err
@@ -3686,7 +3686,7 @@ func rebuildBufferedPrimaryIDIndex(collectionName string, runs map[string][]memt
 	if len(tables) == 0 {
 		return nil
 	}
-	index := newBufferedUniqueValueIndex(0)
+	index := newBufferedUniqueValueIndex(bufferedRunLenHint(tables))
 	for _, table := range tables {
 		if err := addBufferedPrimaryIDs(index, table); err != nil {
 			return nil
@@ -3696,6 +3696,17 @@ func rebuildBufferedPrimaryIDIndex(collectionName string, runs map[string][]memt
 		return nil
 	}
 	return index
+}
+
+func bufferedRunLenHint(tables []memtable.Table) int {
+	total := 0
+	for _, table := range tables {
+		if table == nil {
+			continue
+		}
+		total = saturatingAddNonNegativeInt(total, table.Len())
+	}
+	return total
 }
 
 func uniqueCollectionIndexNames(meta CollectionMeta) map[string]struct{} {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7772,6 +7772,9 @@ func TestBufferedRunLenHintSumsPendingRunLengths(t *testing.T) {
 	if got := bufferedRunLenHint([]memtable.Table{nil, first, second}); got != 3 {
 		t.Fatalf("bufferedRunLenHint=%d want 3", got)
 	}
+	if got := boundedBufferedRunLenHint(bufferedRunLenHintMaxCapacity + 1); got != bufferedRunLenHintMaxCapacity {
+		t.Fatalf("boundedBufferedRunLenHint over cap=%d want %d", got, bufferedRunLenHintMaxCapacity)
+	}
 }
 
 func TestRebuildBufferedIndexesCoverMultiplePendingRuns(t *testing.T) {
@@ -7802,8 +7805,11 @@ func TestRebuildBufferedIndexesCoverMultiplePendingRuns(t *testing.T) {
 		"city_1":    {uniqueA, uniqueB},
 	}
 	primaryIDs := rebuildBufferedPrimaryIDIndex("users", runs)
-	if primaryIDs == nil || primaryIDs.len() != 3 {
-		t.Fatalf("primary ID index len=%d want 3", primaryIDs.len())
+	if primaryIDs == nil {
+		t.Fatal("primary ID index is nil")
+	}
+	if got := primaryIDs.len(); got != 3 {
+		t.Fatalf("primary ID index len=%d want 3", got)
 	}
 	for _, key := range [][]byte{[]byte("u1"), []byte("u2"), []byte("u3")} {
 		if !primaryIDs.contains(key) {
@@ -7833,8 +7839,11 @@ func TestRebuildBufferedIndexesCoverMultiplePendingRuns(t *testing.T) {
 		"city_1": {uniqueA, uniqueB},
 	})
 	unique := uniqueIndexes["city_1"]
-	if unique == nil || unique.len() != 2 {
-		t.Fatalf("unique index len=%d want 2", unique.len())
+	if unique == nil {
+		t.Fatal("unique index is nil")
+	}
+	if got := unique.len(); got != 2 {
+		t.Fatalf("unique index len=%d want 2", got)
 	}
 	for _, key := range [][]byte{[]byte("city:boston"), []byte("city:seattle")} {
 		if !unique.contains(key) {
@@ -7862,16 +7871,30 @@ func BenchmarkRebuildBufferedPendingIndexes(b *testing.B) {
 		primaryName: {primary},
 		"email_1":   {unique},
 	}
+	uniqueRuns := map[string][]memtable.Table{"email_1": {unique}}
 	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if index := rebuildBufferedPrimaryIDIndex("users", runs); index == nil || index.len() != entries {
-			b.Fatalf("primary ID index len=%d want %d", index.len(), entries)
+			got := 0
+			if index != nil {
+				got = index.len()
+			}
+			b.Fatalf("primary ID index len=%d want %d", got, entries)
 		}
 		if index, err := rebuildBufferedPrimaryRunIndex("users", runs); err != nil || index == nil || len(index.values) != entries {
-			b.Fatalf("primary run index len=%d err=%v want %d", len(index.values), err, entries)
+			got := 0
+			if index != nil {
+				got = len(index.values)
+			}
+			b.Fatalf("primary run index len=%d err=%v want %d", got, err, entries)
 		}
-		if indexes := rebuildBufferedUniqueValueIndexes(map[string][]memtable.Table{"email_1": {unique}}); indexes["email_1"] == nil || indexes["email_1"].len() != entries {
-			b.Fatalf("unique index len=%d want %d", indexes["email_1"].len(), entries)
+		if indexes := rebuildBufferedUniqueValueIndexes(uniqueRuns); indexes["email_1"] == nil || indexes["email_1"].len() != entries {
+			got := 0
+			if index := indexes["email_1"]; index != nil {
+				got = index.len()
+			}
+			b.Fatalf("unique index len=%d want %d", got, entries)
 		}
 	}
 }

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7757,6 +7757,125 @@ func TestSnapshotUpdateBatchBufferedReadPrimaryRunIndexAvoidsCollectingPendingRu
 	}
 }
 
+func TestBufferedRunLenHintSumsPendingRunLengths(t *testing.T) {
+	first := newCollectionRunTable(2)
+	setCollectionRunValue(first, []byte("u1"), []byte("one"))
+	setCollectionRunValue(first, []byte("u2"), []byte("two"))
+	first.Freeze()
+	defer resetCollectionRunTable(first)
+
+	second := newCollectionRunTable(1)
+	setCollectionRunValue(second, []byte("u3"), []byte("three"))
+	second.Freeze()
+	defer resetCollectionRunTable(second)
+
+	if got := bufferedRunLenHint([]memtable.Table{nil, first, second}); got != 3 {
+		t.Fatalf("bufferedRunLenHint=%d want 3", got)
+	}
+}
+
+func TestRebuildBufferedIndexesCoverMultiplePendingRuns(t *testing.T) {
+	primaryName := collectionPrimaryRootName("users")
+	primaryA := newCollectionRunTable(2)
+	setCollectionRunValue(primaryA, []byte("u1"), []byte("one"))
+	setCollectionRunValue(primaryA, []byte("u2"), []byte("two"))
+	primaryA.Freeze()
+	defer resetCollectionRunTable(primaryA)
+
+	primaryB := newCollectionRunTable(1)
+	setCollectionRunValue(primaryB, []byte("u3"), []byte("three"))
+	primaryB.Freeze()
+	defer resetCollectionRunTable(primaryB)
+
+	uniqueA := newCollectionRunTable(1)
+	setCollectionRunValue(uniqueA, []byte("city:boston"), nil)
+	uniqueA.Freeze()
+	defer resetCollectionRunTable(uniqueA)
+
+	uniqueB := newCollectionRunTable(1)
+	setCollectionRunValue(uniqueB, []byte("city:seattle"), nil)
+	uniqueB.Freeze()
+	defer resetCollectionRunTable(uniqueB)
+
+	runs := map[string][]memtable.Table{
+		primaryName: {primaryA, primaryB},
+		"city_1":    {uniqueA, uniqueB},
+	}
+	primaryIDs := rebuildBufferedPrimaryIDIndex("users", runs)
+	if primaryIDs == nil || primaryIDs.len() != 3 {
+		t.Fatalf("primary ID index len=%d want 3", primaryIDs.len())
+	}
+	for _, key := range [][]byte{[]byte("u1"), []byte("u2"), []byte("u3")} {
+		if !primaryIDs.contains(key) {
+			t.Fatalf("primary ID index missing %q", key)
+		}
+	}
+
+	primaryRuns, err := rebuildBufferedPrimaryRunIndex("users", runs)
+	if err != nil {
+		t.Fatalf("rebuildBufferedPrimaryRunIndex: %v", err)
+	}
+	for _, tc := range []struct {
+		key   []byte
+		table memtable.Table
+	}{
+		{[]byte("u1"), primaryA},
+		{[]byte("u2"), primaryA},
+		{[]byte("u3"), primaryB},
+	} {
+		got, ok := primaryRuns.lookup(tc.key)
+		if !ok || got != tc.table {
+			t.Fatalf("primary run lookup %q table=%p ok=%v want %p", tc.key, got, ok, tc.table)
+		}
+	}
+
+	uniqueIndexes := rebuildBufferedUniqueValueIndexes(map[string][]memtable.Table{
+		"city_1": {uniqueA, uniqueB},
+	})
+	unique := uniqueIndexes["city_1"]
+	if unique == nil || unique.len() != 2 {
+		t.Fatalf("unique index len=%d want 2", unique.len())
+	}
+	for _, key := range [][]byte{[]byte("city:boston"), []byte("city:seattle")} {
+		if !unique.contains(key) {
+			t.Fatalf("unique index missing %q", key)
+		}
+	}
+}
+
+func BenchmarkRebuildBufferedPendingIndexes(b *testing.B) {
+	const entries = 4096
+	primaryName := collectionPrimaryRootName("users")
+	primary := newCollectionRunTable(entries)
+	unique := newCollectionRunTable(entries)
+	for i := 0; i < entries; i++ {
+		id := fmt.Sprintf("u%05d", i)
+		setCollectionRunValue(primary, []byte(id), []byte("doc"))
+		setCollectionRunValue(unique, []byte("email:"+id), nil)
+	}
+	primary.Freeze()
+	unique.Freeze()
+	defer resetCollectionRunTable(primary)
+	defer resetCollectionRunTable(unique)
+
+	runs := map[string][]memtable.Table{
+		primaryName: {primary},
+		"email_1":   {unique},
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if index := rebuildBufferedPrimaryIDIndex("users", runs); index == nil || index.len() != entries {
+			b.Fatalf("primary ID index len=%d want %d", index.len(), entries)
+		}
+		if index, err := rebuildBufferedPrimaryRunIndex("users", runs); err != nil || index == nil || len(index.values) != entries {
+			b.Fatalf("primary run index len=%d err=%v want %d", len(index.values), err, entries)
+		}
+		if indexes := rebuildBufferedUniqueValueIndexes(map[string][]memtable.Table{"email_1": {unique}}); indexes["email_1"] == nil || indexes["email_1"].len() != entries {
+			b.Fatalf("unique index len=%d want %d", indexes["email_1"].len(), entries)
+		}
+	}
+}
+
 func BenchmarkSnapshotUpdateBatchBufferedReadPrimaryRunIndexPendingUnits(b *testing.B) {
 	meta := CollectionMeta{
 		Name: "users",


### PR DESCRIPTION
## Summary

This is a focused #1159 allocation-pressure cleanup for indexed collection pending-index rebuilds.

What changed:
- Size rebuilt buffered primary ID, primary-run, and unique-value index maps from pending memtable run `Len()` hints instead of rebuilding from zero-capacity maps.
- Bound the hint with `bufferedRunLenHintMaxCapacity` so duplicate-heavy high-churn workloads cannot size maps to the full historical mutation count.
- Add regression coverage for multi-run rebuild correctness across primary ID lookup, primary-run lookup, and unique-value lookup.
- Add a focused rebuild benchmark so future changes can recheck this allocation path directly.

Rationale: the focused 3-index city-update profile still showed allocation space in `bufferedPrimaryRunIndex.addRef` and `bufferedUniqueValueIndex.add`. These rebuilds happen after pending/rotated indexed flush units are republished, where run lengths are already available. Pre-sizing does not change lookup semantics; it avoids avoidable map growth while rebuilding pending lookup structures, with a cap to avoid pathological over-allocation on duplicate-heavy histories.

## Validation

```text
GOWORK=off go test ./TreeDB/collections -run 'TestBufferedRunLenHintSumsPendingRunLengths|TestRebuildBufferedIndexesCoverMultiplePendingRuns|TestSnapshotUpdateBatchBufferedReadPrimaryRunIndexAvoidsCollectingPendingRuns' -count=1
ok  github.com/snissn/gomap/TreeDB/collections 0.521s

GOWORK=off go test ./TreeDB/collections -count=1
ok  github.com/snissn/gomap/TreeDB/collections 3.095s

git diff --check
```

## Focused rebuild benchmark

Benchmark command, run on `origin/main` and this branch with the benchmark present in both worktrees:

```bash
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkRebuildBufferedPendingIndexes$' \
  -benchmem \
  -count=5
```

| Metric | `origin/main` | Branch |
| --- | ---: | ---: |
| ns/op range | 854,558 - 942,659 | 455,451 - 480,501 |
| B/op | ~2,351,600 | ~1,247,146 |
| allocs/op | 4,265 - 4,266 | 4,160 |

Representative rows:

```text
origin/main:
BenchmarkRebuildBufferedPendingIndexes-8    1405  892883 ns/op  2351651 B/op  4265 allocs/op

branch:
BenchmarkRebuildBufferedPendingIndexes-8    2650  455451 ns/op  1247146 B/op  4160 allocs/op
```

## Focused update profile sanity check

Same command shape used by the recent #1159 PRs:

```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1217_index_capacity_profile_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof" | tee "$PROFILE_DIR/bench.txt"
```

Run dirs:
- Baseline from current `origin/main` after #1215: `/tmp/gomap_1215_iter_profile_TxSBsY`
- Branch before the bounded-hint review fix: `/tmp/gomap_1217_index_capacity_profile_IEgzJL`

| Metric | Baseline | Branch |
| --- | ---: | ---: |
| docs/sec | 165,056 | 142,890 |
| ns/doc | 6,059 | 6,998 |
| B/op | 1,234 | 1,148 |
| allocs/op | 3 | 3 |
| total alloc_space | 9.78 GiB | 9.37 GiB |
| `bufferedPrimaryRunIndex.addRef` alloc_space | 0.76 GiB | 0.49 GiB |
| `bufferedUniqueValueIndex.add` alloc_space | 0.46 GiB | 0.25 GiB |

Interpretation: this PR is an allocation-path cleanup, not a throughput claim. The update benchmark wall-time row is noisy and slower in this single branch run, while the targeted allocation sites drop materially and `B/op` improves. The bounded hint review fix keeps the optimization from over-sizing maps in duplicate-heavy workloads. The root-apply/zipper/read-path bottlenecks remain the larger #1159 targets.

Fixes part of #1159.
