### PR TITLE
collections: pool buffered update read values

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6903,11 +6903,17 @@ func putUpdateBatchBufferedEntries(entries []updateBatchBufferedEntry, buffer *u
 }
 
 func (buffer *updateBatchBufferedEntryBuffer) copyValue(value []byte) []byte {
-	if len(value) == 0 {
+	if value == nil {
 		return nil
 	}
 	if buffer == nil {
 		return bytes.Clone(value)
+	}
+	if len(value) == 0 {
+		if buffer.arena == nil {
+			buffer.ensureValueArenaCapacity(1)
+		}
+		return buffer.arena[len(buffer.arena):len(buffer.arena):len(buffer.arena)]
 	}
 	start := len(buffer.arena)
 	buffer.arena = append(buffer.arena, value...)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6857,9 +6857,11 @@ var updateBatchBufferedEntryPool sync.Pool
 
 type updateBatchBufferedEntryBuffer struct {
 	entries []updateBatchBufferedEntry
+	arena   []byte
 }
 
 const updateBatchBufferedEntryPoolMaxCap = 1 << 15
+const updateBatchBufferedValueArenaPoolMaxCap = updateBatchPlanScratchMaxDocumentArena
 
 func getUpdateBatchBufferedEntries(count int) ([]updateBatchBufferedEntry, *updateBatchBufferedEntryBuffer) {
 	if count <= 0 {
@@ -6872,6 +6874,7 @@ func getUpdateBatchBufferedEntries(count int) ([]updateBatchBufferedEntry, *upda
 		if buffer, ok := v.(*updateBatchBufferedEntryBuffer); ok && buffer != nil {
 			if cap(buffer.entries) >= count {
 				buffer.entries = buffer.entries[:count]
+				buffer.ensureValueArenaCapacity(estimateUpdateBatchPlanDocumentArenaBytes(count))
 				return buffer.entries, buffer
 			}
 			putUpdateBatchBufferedEntries(buffer.entries, buffer)
@@ -6880,6 +6883,7 @@ func getUpdateBatchBufferedEntries(count int) ([]updateBatchBufferedEntry, *upda
 	buffer := &updateBatchBufferedEntryBuffer{
 		entries: make([]updateBatchBufferedEntry, count),
 	}
+	buffer.ensureValueArenaCapacity(estimateUpdateBatchPlanDocumentArenaBytes(count))
 	return buffer.entries, buffer
 }
 
@@ -6890,7 +6894,39 @@ func putUpdateBatchBufferedEntries(entries []updateBatchBufferedEntry, buffer *u
 	full := entries[:cap(entries)]
 	clear(full)
 	buffer.entries = full[:0]
+	if cap(buffer.arena) > updateBatchBufferedValueArenaPoolMaxCap {
+		buffer.arena = nil
+	} else if buffer.arena != nil {
+		buffer.arena = buffer.arena[:0]
+	}
 	updateBatchBufferedEntryPool.Put(buffer)
+}
+
+func (buffer *updateBatchBufferedEntryBuffer) copyValue(value []byte) []byte {
+	if len(value) == 0 {
+		return nil
+	}
+	if buffer == nil {
+		return bytes.Clone(value)
+	}
+	start := len(buffer.arena)
+	buffer.arena = append(buffer.arena, value...)
+	return buffer.arena[start:len(buffer.arena):len(buffer.arena)]
+}
+
+func (buffer *updateBatchBufferedEntryBuffer) ensureValueArenaCapacity(capacity int) {
+	if buffer == nil {
+		return
+	}
+	if capacity <= 0 {
+		buffer.arena = buffer.arena[:0]
+		return
+	}
+	if cap(buffer.arena) < capacity || cap(buffer.arena) > updateBatchBufferedValueArenaPoolMaxCap {
+		buffer.arena = make([]byte, 0, capacity)
+		return
+	}
+	buffer.arena = buffer.arena[:0]
 }
 
 type updateBatchCurrentDocument struct {
@@ -7140,7 +7176,7 @@ func snapshotUpdateBatchBufferedPrimaryEntries(runs []memtable.Table, items []Up
 		for i, item := range items {
 			if value, _, flags, found := getBufferedRunEntry(runs, item.DocumentID); found {
 				entries[i] = updateBatchBufferedEntry{
-					value: bytes.Clone(value),
+					value: buffer.copyValue(value),
 					flags: flags,
 					found: true,
 				}
@@ -7163,7 +7199,7 @@ func snapshotUpdateBatchBufferedPrimaryEntries(runs []memtable.Table, items []Up
 			if itemIndex, ok := targets[key]; ok && !entries[itemIndex].found {
 				value, _, flags := it.UnsafeEntry()
 				entries[itemIndex] = updateBatchBufferedEntry{
-					value: bytes.Clone(value),
+					value: buffer.copyValue(value),
 					flags: flags,
 					found: true,
 				}
@@ -7196,7 +7232,7 @@ func snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(index *bufferedPrimaryRu
 			continue
 		}
 		entries[i] = updateBatchBufferedEntry{
-			value: bytes.Clone(value),
+			value: buffer.copyValue(value),
 			flags: flags,
 			found: true,
 		}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7757,7 +7757,7 @@ func TestSnapshotUpdateBatchBufferedReadPrimaryRunIndexAvoidsCollectingPendingRu
 	}
 }
 
-func TestSnapshotUpdateBatchBufferedPrimaryEntriesFromIndexReusesValueArena(t *testing.T) {
+func TestSnapshotUpdateBatchBufferedPrimaryEntriesFromIndexUsesValueArena(t *testing.T) {
 	primaryTable := newCollectionRunTable(3)
 	setCollectionRunValue(primaryTable, []byte("u1"), []byte(`{"city":"paris"}`))
 	setCollectionRunValue(primaryTable, []byte("u2"), []byte(`{"city":"rome"}`))
@@ -7802,6 +7802,22 @@ func TestSnapshotUpdateBatchBufferedPrimaryEntriesFromIndexReusesValueArena(t *t
 		}
 	}
 	assertRead()
+}
+
+func TestUpdateBatchBufferedEntryBufferCopyValuePreservesEmptySlice(t *testing.T) {
+	buffer := &updateBatchBufferedEntryBuffer{}
+	buffer.ensureValueArenaCapacity(1)
+	empty := []byte{}
+	got := buffer.copyValue(empty)
+	if got == nil {
+		t.Fatal("copyValue(empty non-nil slice) returned nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("copyValue(empty) len=%d want 0", len(got))
+	}
+	if nilValue := buffer.copyValue(nil); nilValue != nil {
+		t.Fatalf("copyValue(nil)=%v want nil", nilValue)
+	}
 }
 
 func BenchmarkSnapshotUpdateBatchBufferedPrimaryEntriesFromIndexValues(b *testing.B) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7757,6 +7757,95 @@ func TestSnapshotUpdateBatchBufferedReadPrimaryRunIndexAvoidsCollectingPendingRu
 	}
 }
 
+func TestSnapshotUpdateBatchBufferedPrimaryEntriesFromIndexReusesValueArena(t *testing.T) {
+	primaryTable := newCollectionRunTable(3)
+	setCollectionRunValue(primaryTable, []byte("u1"), []byte(`{"city":"paris"}`))
+	setCollectionRunValue(primaryTable, []byte("u2"), []byte(`{"city":"rome"}`))
+	setCollectionRunValue(primaryTable, []byte("u3"), []byte(`{"city":"oslo"}`))
+	primaryTable.Freeze()
+	defer resetCollectionRunTable(primaryTable)
+
+	primaryIndex := newBufferedPrimaryRunIndex(3)
+	if err := addBufferedPrimaryRunIndexEntries(primaryIndex, primaryTable); err != nil {
+		t.Fatalf("add primary run index entries: %v", err)
+	}
+	items := []UpdateBatchItem{
+		{DocumentID: []byte("u1")},
+		{DocumentID: []byte("u2")},
+		{DocumentID: []byte("u3")},
+	}
+	assertRead := func() {
+		t.Helper()
+		entries, buffer, err := snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(primaryIndex, items)
+		if err != nil {
+			t.Fatalf("snapshotUpdateBatchBufferedPrimaryEntriesFromIndex: %v", err)
+		}
+		defer putUpdateBatchBufferedEntries(entries, buffer)
+		if buffer == nil || len(buffer.arena) == 0 {
+			t.Fatal("buffered primary read did not use the pooled value arena")
+		}
+		arenaStart := uintptr(unsafe.Pointer(unsafe.SliceData(buffer.arena)))
+		arenaEnd := arenaStart + uintptr(len(buffer.arena))
+		want := [][]byte{
+			[]byte(`{"city":"paris"}`),
+			[]byte(`{"city":"rome"}`),
+			[]byte(`{"city":"oslo"}`),
+		}
+		for i := range want {
+			if !entries[i].found || !bytes.Equal(entries[i].value, want[i]) {
+				t.Fatalf("entry %d found=%v value=%q want %q", i, entries[i].found, entries[i].value, want[i])
+			}
+			valueStart := uintptr(unsafe.Pointer(unsafe.SliceData(entries[i].value)))
+			if valueStart < arenaStart || valueStart >= arenaEnd {
+				t.Fatalf("entry %d value is not backed by buffered arena", i)
+			}
+		}
+	}
+	assertRead()
+}
+
+func BenchmarkSnapshotUpdateBatchBufferedPrimaryEntriesFromIndexValues(b *testing.B) {
+	const entriesCount = 256
+	primaryTable := newCollectionRunTable(entriesCount)
+	items := make([]UpdateBatchItem, 0, entriesCount)
+	value := []byte(strings.Repeat("x", 512))
+	for i := 0; i < entriesCount; i++ {
+		id := []byte(fmt.Sprintf("u%05d", i))
+		setCollectionRunValue(primaryTable, id, value)
+		items = append(items, UpdateBatchItem{DocumentID: id})
+	}
+	primaryTable.Freeze()
+	defer resetCollectionRunTable(primaryTable)
+
+	primaryIndex := newBufferedPrimaryRunIndex(entriesCount)
+	if err := addBufferedPrimaryRunIndexEntries(primaryIndex, primaryTable); err != nil {
+		b.Fatalf("add primary run index entries: %v", err)
+	}
+	warmEntries, warmBuffer, err := snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(primaryIndex, items)
+	if err != nil {
+		b.Fatalf("warm buffered read: %v", err)
+	}
+	putUpdateBatchBufferedEntries(warmEntries, warmBuffer)
+
+	total := 0
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		entries, buffer, err := snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(primaryIndex, items)
+		if err != nil {
+			b.Fatalf("snapshotUpdateBatchBufferedPrimaryEntriesFromIndex: %v", err)
+		}
+		for j := range entries {
+			total += len(entries[j].value)
+		}
+		putUpdateBatchBufferedEntries(entries, buffer)
+	}
+	b.StopTimer()
+	if total == 0 {
+		b.Fatal("benchmark did not consume buffered values")
+	}
+}
+
 func BenchmarkSnapshotUpdateBatchBufferedReadPrimaryRunIndexPendingUnits(b *testing.B) {
 	meta := CollectionMeta{
 		Name: "users",


### PR DESCRIPTION
## Summary

This is a focused #1159 allocation cleanup for buffered indexed update reads.

What changed:
- Extend the existing `updateBatchBufferedEntryBuffer` pool with a reusable byte arena for copied buffered document values.
- Replace per-value `bytes.Clone` calls in pending-primary buffered read snapshots with arena copies scoped to the update-plan build lifetime.
- Retain the existing large-buffer cap behavior so oversized arenas are dropped instead of pinned.
- Add a regression test that verifies buffered primary values are copied into the pooled arena.
- Add a focused benchmark that consumes buffered values so this path cannot silently return to per-document heap copies.

Rationale: buffered pending-document reads need owned values after releasing the collection domain lock, but those owned values only need to live while building the update plan. A per-call pooled arena matches that lifetime better than one heap allocation per buffered document value.

## Validation

```text
GOWORK=off go test ./TreeDB/collections -run 'TestSnapshotUpdateBatchBufferedPrimaryEntriesFromIndexUsesValueArena|TestUpdateBatchBufferedEntryBufferCopyValuePreservesEmptySlice|TestSnapshotUpdateBatchBufferedReadPrimaryRunIndexAvoidsCollectingPendingRuns' -count=1
ok  github.com/snissn/gomap/TreeDB/collections 0.482s

GOWORK=off go test ./TreeDB/collections -count=1
ok  github.com/snissn/gomap/TreeDB/collections 3.182s

git diff --check
```

## Focused buffered-read benchmark

Benchmark command, run on `origin/main` and this branch with the benchmark present in both worktrees:

```bash
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkSnapshotUpdateBatchBufferedPrimaryEntriesFromIndexValues$' \
  -benchmem \
  -count=5
```

| Metric | `origin/main` | Branch |
| --- | ---: | ---: |
| ns/op range | 32,629 - 33,385 | 18,683 - 20,650 |
| B/op | 131,118 - 131,119 | 0 |
| allocs/op | 256 | 0 |

Representative rows:

```text
origin/main:
BenchmarkSnapshotUpdateBatchBufferedPrimaryEntriesFromIndexValues-8    37053  32669 ns/op  131118 B/op  256 allocs/op

branch:
BenchmarkSnapshotUpdateBatchBufferedPrimaryEntriesFromIndexValues-8    65828  18683 ns/op       0 B/op    0 allocs/op
```

## Focused update profile sanity check

Same command shape used by the recent #1159 PRs:

```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1218_buffered_read_arena_profile_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof" | tee "$PROFILE_DIR/bench.txt"
```

Run dirs:
- Baseline from current `origin/main` after #1215: `/tmp/gomap_1215_iter_profile_TxSBsY`
- Branch: `/tmp/gomap_1218_buffered_read_arena_profile_YSvYOF`

| Metric | Baseline | Branch |
| --- | ---: | ---: |
| docs/sec | 165,056 | 147,311 |
| ns/doc | 6,059 | 6,788 |
| B/op | 1,234 | 1,279 |
| allocs/op | 3 | 3 |
| total alloc_space | 9.78 GiB | 9.18 GiB |
| `bytes.Clone` alloc_space | 0.31 GiB | 0.28 GiB |
| `updateBatchBufferedEntryBuffer.ensureValueArenaCapacity` alloc_space | 0 | 0.17 GiB |

Interpretation: this PR is a targeted buffered-read allocation cleanup. The dedicated benchmark captures the intended path cleanly. The broader update benchmark remains noisy and is not a throughput claim; it shows total alloc_space down but the main remaining bottlenecks are still append-only/memtable allocation, root-run fan-in, and zipper/leaf-log root apply.

Fixes part of #1159.
