### PR TITLE
collections: heapify buffered root runs

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3842,6 +3842,13 @@ func (h *bufferedRootRunHeap) push(item bufferedRootRunHeapItem) {
 	h.up(len(*h) - 1)
 }
 
+func (h *bufferedRootRunHeap) init() {
+	n := len(*h)
+	for i := n/2 - 1; i >= 0; i-- {
+		h.down(i, n)
+	}
+}
+
 func (h *bufferedRootRunHeap) pop() bufferedRootRunHeapItem {
 	old := *h
 	n := len(old)
@@ -3918,6 +3925,7 @@ func newBufferedRootRunsIteratorWithDeleted(runs []memtable.Table, start, end []
 	}
 	it := &bufferedRootRunsIterator{
 		iters:              make([]iterator.UnsafeIterator, 0, len(runs)),
+		heap:               make(bufferedRootRunHeap, 0, len(runs)),
 		includeDeleted:     includeDeleted,
 		stableUnsafeSlices: true,
 		start:              start,
@@ -3937,13 +3945,14 @@ func newBufferedRootRunsIteratorWithDeleted(runs []memtable.Table, start, end []
 		idx := len(it.iters)
 		it.iters = append(it.iters, runIter)
 		if runIter.Valid() {
-			it.heap.push(bufferedRootRunHeapItem{
+			it.heap = append(it.heap, bufferedRootRunHeapItem{
 				idx:      idx,
 				priority: len(runs) - 1 - i,
 				key:      runIter.UnsafeKey(),
 			})
 		}
 	}
+	it.heap.init()
 	it.advance()
 	return it
 }

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3279,6 +3279,30 @@ func TestBufferedRootRunsIteratorMultiRunStableUnsafeSlices(t *testing.T) {
 	}
 }
 
+func BenchmarkBufferedRootRunsIteratorBuildManyRuns(b *testing.B) {
+	const runCount = 8192
+	runs := make([]memtable.Table, 0, runCount)
+	for i := 0; i < runCount; i++ {
+		table := newCollectionRunTable(1)
+		setCollectionRunValue(table, []byte(fmt.Sprintf("k%08d", i)), []byte("value"))
+		table.Freeze()
+		runs = append(runs, table)
+	}
+	defer resetCollectionTables(runs)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		it := newBufferedRootRunsIteratorWithDeleted(runs, nil, nil, true)
+		if !it.Valid() {
+			b.Fatal("iterator invalid")
+		}
+		if err := it.Close(); err != nil {
+			b.Fatalf("close iterator: %v", err)
+		}
+	}
+}
+
 func TestCollectMergedCollectionIndexIDsSkipsPersistedTombstones(t *testing.T) {
 	encoded, err := encodeIndexScalar(IndexValueString, "hnl")
 	if err != nil {


### PR DESCRIPTION
## Summary

This is a focused #1159 root-run fan-in cleanup for indexed collection flush publishing.

What changed:
- Preallocate the `bufferedRootRunsIterator` heap backing array to the number of input runs.
- Build the initial heap with linear heapify instead of pushing every run through `up` one by one.
- Add a focused benchmark covering the many-root-run iterator construction shape that appears during indexed async flush publish.

Rationale: recent #1159 profiles still show `bufferedRootRunHeap.down/up/Less` and `orderedRootDeltaBatchFromIterator` in the root-run materialization path. This does not change the deeper root-apply/zipper architecture, but it removes avoidable heap-construction growth and O(n log n) setup before the iterator begins publishing root-local deltas.

## Validation

```text
GOWORK=off go test ./TreeDB/collections -run 'TestBufferedRootRunsIterator' -count=1
ok  github.com/snissn/gomap/TreeDB/collections 0.842s

GOWORK=off go test ./TreeDB/collections -count=1
ok  github.com/snissn/gomap/TreeDB/collections 2.930s

git diff --check
```

## Focused iterator benchmark

Benchmark command, run on `origin/main` and this branch with the benchmark present in both worktrees:

```bash
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkBufferedRootRunsIteratorBuildManyRuns$' \
  -benchmem \
  -count=5
```

| Metric | `origin/main` | Branch |
| --- | ---: | ---: |
| ns/op range | 874,055 - 1,028,687 | 764,927 - 782,202 |
| B/op | ~2,695,350 | ~1,638,900 |
| allocs/op | 8,218 - 8,219 | 8,200 |

Representative rows:

```text
origin/main:
BenchmarkBufferedRootRunsIteratorBuildManyRuns-8    1245  874055 ns/op  2695365 B/op  8218 allocs/op

branch:
BenchmarkBufferedRootRunsIteratorBuildManyRuns-8    1516  773019 ns/op  1638882 B/op  8200 allocs/op
```

## Focused update profile sanity check

Same command shape used by recent #1159 PRs:

```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1219_rootrun_heapify_profile_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=10s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof" | tee "$PROFILE_DIR/bench.txt"
```

Run dirs:
- Baseline from current `origin/main` after #1215: `/tmp/gomap_1215_iter_profile_TxSBsY`
- Branch: `/tmp/gomap_1219_rootrun_heapify_profile_qCQnhv`

| Metric | Baseline | Branch |
| --- | ---: | ---: |
| docs/sec | 165,056 | 165,401 |
| ns/doc | 6,059 | 6,046 |
| B/op | 1,234 | 1,205 |
| allocs/op | 3 | 3 |
| indexed_flush_root_runs/call | 7,984 | 8,130 |
| publish_delta_group_root_apply_ns/doc | 2,215 | 2,196 |

Interpretation: this is a root-run iterator setup cleanup, not the root-apply/zipper rearchitecture. The focused iterator benchmark captures the intended effect; the broad update profile is directionally flat/slightly better and keeps the next larger target unchanged: reducing the amount and cost of necessary root apply work.

Fixes part of #1159.
