### PR TITLE
mongo bench: report update combiner queue depth

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1036,6 +1036,26 @@ func (m *CollectionManager) StatsSnapshot() CollectionManagerStats {
 	return stats
 }
 
+// ResetUpdateCombineQueueDepthMax clears the process-local update-combiner
+// queue-depth maximum. It is intended for benchmark/profiling windows; it does
+// not affect collection contents or pending writes.
+func (m *CollectionManager) ResetUpdateCombineQueueDepthMax() {
+	if m == nil {
+		return
+	}
+	m.domainMu.RLock()
+	domains := make([]*collectionWriteDomain, 0, len(m.domains))
+	for _, domain := range m.domains {
+		if domain != nil {
+			domains = append(domains, domain)
+		}
+	}
+	m.domainMu.RUnlock()
+	for _, domain := range domains {
+		domain.updateCombineQueueDepthMax.Store(0)
+	}
+}
+
 func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	if s == nil {
 		return

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1154,6 +1154,25 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	}
 }
 
+func TestCollectionManagerResetUpdateCombineQueueDepthMax(t *testing.T) {
+	domain := &collectionWriteDomain{}
+	mgr := &CollectionManager{
+		domains: map[string]*collectionWriteDomain{"users": domain},
+	}
+	domain.observeUpdateCombineRequest(12)
+	if got := mgr.StatsSnapshot().UpdateCombineQueueDepthMax; got != 12 {
+		t.Fatalf("queue depth max before reset=%d want 12", got)
+	}
+	mgr.ResetUpdateCombineQueueDepthMax()
+	if got := mgr.StatsSnapshot().UpdateCombineQueueDepthMax; got != 0 {
+		t.Fatalf("queue depth max after reset=%d want 0", got)
+	}
+	domain.observeUpdateCombineRequest(5)
+	if got := mgr.StatsSnapshot().UpdateCombineQueueDepthMax; got != 5 {
+		t.Fatalf("queue depth max after new observation=%d want 5", got)
+	}
+}
+
 func writeStandaloneValueLogSegment(t *testing.T, valueDir string, lane, seq uint32, value []byte) string {
 	t.Helper()
 	if err := os.MkdirAll(valueDir, 0o755); err != nil {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -664,6 +664,7 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 
 	b.ReportAllocs()
 	manager.SetUpdateBatchDetailedStatsEnabled(true)
+	manager.ResetUpdateCombineQueueDepthMax()
 	statsBefore := manager.StatsSnapshot()
 	backendStatsBefore := backend.Stats()
 	b.ResetTimer()
@@ -1026,7 +1027,6 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateCombineBatches:           after.UpdateCombineBatches - before.UpdateCombineBatches,
 		UpdateCombineBatchedRequests:   after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
 		UpdateCombineFallbackRequests:  after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
-		UpdateCombineQueueDepthMax:     after.UpdateCombineQueueDepthMax,
 		IndexedFlushCalls:              after.IndexedFlushCalls - before.IndexedFlushCalls,
 		IndexedFlushErrors:             after.IndexedFlushErrors - before.IndexedFlushErrors,
 		IndexedFlushDocs:               after.IndexedFlushDocs - before.IndexedFlushDocs,
@@ -1034,6 +1034,9 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		IndexedFlushRootRuns:           after.IndexedFlushRootRuns - before.IndexedFlushRootRuns,
 		IndexedFlushRoots:              after.IndexedFlushRoots - before.IndexedFlushRoots,
 		IndexedFlushDuration:           after.IndexedFlushDuration - before.IndexedFlushDuration,
+	}
+	if after.UpdateCombineQueueDepthMax > before.UpdateCombineQueueDepthMax {
+		delta.UpdateCombineQueueDepthMax = after.UpdateCombineQueueDepthMax
 	}
 	for i := 0; i < after.UpdateBatchIndexStatsCount && i < len(after.UpdateBatchIndexStats); i++ {
 		next := after.UpdateBatchIndexStats[i]
@@ -1141,6 +1144,13 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	}
 	if got.UpdateCombineQueueDepthMax != 31 {
 		t.Fatalf("UpdateCombineQueueDepthMax=%d want 31", got.UpdateCombineQueueDepthMax)
+	}
+	staleMax := deltaCollectionManagerUpdateStats(
+		collections.CollectionManagerStats{UpdateCombineQueueDepthMax: 31},
+		collections.CollectionManagerStats{UpdateCombineQueueDepthMax: 31},
+	)
+	if staleMax.UpdateCombineQueueDepthMax != 0 {
+		t.Fatalf("stale UpdateCombineQueueDepthMax=%d want 0", staleMax.UpdateCombineQueueDepthMax)
 	}
 	if got.UpdateBatchIndexValueChanges != 7 {
 		t.Fatalf("UpdateBatchIndexValueChanges=%d want 7", got.UpdateBatchIndexValueChanges)

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1026,6 +1026,7 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateCombineBatches:           after.UpdateCombineBatches - before.UpdateCombineBatches,
 		UpdateCombineBatchedRequests:   after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
 		UpdateCombineFallbackRequests:  after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
+		UpdateCombineQueueDepthMax:     after.UpdateCombineQueueDepthMax,
 		IndexedFlushCalls:              after.IndexedFlushCalls - before.IndexedFlushCalls,
 		IndexedFlushErrors:             after.IndexedFlushErrors - before.IndexedFlushErrors,
 		IndexedFlushDocs:               after.IndexedFlushDocs - before.IndexedFlushDocs,
@@ -1084,6 +1085,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateCombineBatches:           3,
 		UpdateCombineBatchedRequests:   8,
 		UpdateCombineFallbackRequests:  1,
+		UpdateCombineQueueDepthMax:     12,
 		UpdateBatchIndexValueChanges:   20,
 		UpdateBatchIndexValueUnchanged: 30,
 		UpdateBatchUniqueChecks:        4,
@@ -1106,6 +1108,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateCombineBatches:           5,
 		UpdateCombineBatchedRequests:   14,
 		UpdateCombineFallbackRequests:  2,
+		UpdateCombineQueueDepthMax:     31,
 		UpdateBatchIndexValueChanges:   27,
 		UpdateBatchIndexValueUnchanged: 43,
 		UpdateBatchUniqueChecks:        6,
@@ -1135,6 +1138,9 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	}
 	if got.UpdateCombineFallbackRequests != 1 {
 		t.Fatalf("UpdateCombineFallbackRequests=%d want 1", got.UpdateCombineFallbackRequests)
+	}
+	if got.UpdateCombineQueueDepthMax != 31 {
+		t.Fatalf("UpdateCombineQueueDepthMax=%d want 31", got.UpdateCombineQueueDepthMax)
 	}
 	if got.UpdateBatchIndexValueChanges != 7 {
 		t.Fatalf("UpdateBatchIndexValueChanges=%d want 7", got.UpdateBatchIndexValueChanges)
@@ -1216,6 +1222,39 @@ func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testin
 	}
 }
 
+func TestReportCollectionManagerUpdateStatsIncludesCombinerQueueDepth(t *testing.T) {
+	stats := collections.CollectionManagerStats{
+		UpdateCombineRequests:         600,
+		UpdateCombineBatches:          30,
+		UpdateCombineBatchedRequests:  600,
+		UpdateCombineFallbackRequests: 6,
+		UpdateCombineQueueDepthMax:    31,
+	}
+	result := testing.Benchmark(func(b *testing.B) {
+		reportCollectionManagerUpdateStats(b, stats, 600)
+	})
+	want := map[string]float64{
+		"update_combine_requests":              600,
+		"update_combine_requests/doc":          1,
+		"update_combine_batches":               30,
+		"update_combine_items/batch":           20,
+		"update_combine_batched_requests":      600,
+		"update_combine_batched_requests/doc":  1,
+		"update_combine_fallback_requests":     6,
+		"update_combine_fallback_requests/doc": 0.01,
+		"update_combine_queue_depth_max":       31,
+	}
+	for metric, wantValue := range want {
+		gotValue, ok := result.Extra[metric]
+		if !ok {
+			t.Fatalf("missing benchmark metric %q in %v", metric, result.Extra)
+		}
+		if math.Abs(gotValue-wantValue) > 1e-9 {
+			t.Fatalf("benchmark metric %s=%g want %g", metric, gotValue, wantValue)
+		}
+	}
+}
+
 func reportCollectionManagerUpdateStats(b *testing.B, stats collections.CollectionManagerStats, docs int) {
 	b.Helper()
 	if docs <= 0 {
@@ -1280,6 +1319,9 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	if stats.UpdateCombineFallbackRequests > 0 {
 		b.ReportMetric(float64(stats.UpdateCombineFallbackRequests), "update_combine_fallback_requests")
 		b.ReportMetric(float64(stats.UpdateCombineFallbackRequests)/float64(docs), "update_combine_fallback_requests/doc")
+	}
+	if stats.UpdateCombineQueueDepthMax > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineQueueDepthMax), "update_combine_queue_depth_max")
 	}
 	if stats.UpdateBatchSecondaryDeletes > 0 {
 		b.ReportMetric(float64(stats.UpdateBatchSecondaryDeletes)/float64(docs), "update_secondary_deletes/doc")


### PR DESCRIPTION
## Summary

Adds the existing collection `UpdateCombineQueueDepthMax` counter to the direct collection profile benchmark output as `update_combine_queue_depth_max`.

This is benchmark/profiling support for #1159. The current focused update rows show many root-run tables per indexed flush; queue depth makes it explicit whether small update-combine batches are due to combiner policy or simply producer concurrency.

## Validation

```text
GOWORK=off go test ./cmd/mongo_gateway_bench -run 'TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats|TestReportCollectionManagerUpdateStatsIncludesCombinerQueueDepth|TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics' -count=1
ok  github.com/snissn/gomap/cmd/mongo_gateway_bench 0.495s

GOWORK=off go test ./cmd/mongo_gateway_bench -count=1
ok  github.com/snissn/gomap/cmd/mongo_gateway_bench 1.855s

git diff --check
```

## Focused benchmark

Command:

```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1220_queue_depth_profile_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=200000x \
  -benchmem \
  -count=1 | tee "$PROFILE_DIR/bench.txt"
```

Run dir: `/tmp/gomap_1220_queue_depth_profile_TX3ra1`

Representative row:

```text
200000 6650 ns/op 150371 docs/sec 6650 ns/doc 1846 B/op 3 allocs/op
update_combine_items/batch=20.15
update_combine_queue_depth_max=32
indexed_flush_root_runs/call=6616
indexed_flush_root_runs/doc=0.09924
publish_delta_group_root_apply_ns/doc=2466
update_current_read_ns/doc=1597
```

Interpretation: with 32 synchronous writers, the combiner queue reaches the producer ceiling and batches around 20 items. That makes larger root-run fan-in reduction a producer/pipeline or deeper root-run/root-apply architecture problem, not a simple drain-yield tuning issue.