### PR TITLE
collections: label indexed async flush profiles

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2,11 +2,13 @@ package collections
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"runtime"
+	"runtime/pprof"
 	"sort"
 	"strings"
 	"sync"
@@ -50,6 +52,10 @@ const (
 	defaultCollectionUpdateCombineMaxBatch              = 256
 	defaultCollectionUpdateCombineDrainYields           = 1
 	collectionUpdateCombineIdleTTL                      = 30 * time.Second
+	collectionPprofComponentKey                         = "gomap_component"
+	collectionPprofOperationKey                         = "gomap_operation"
+	collectionPprofIndexedAsyncFlush                    = "collections_indexed_async_flush"
+	collectionPprofIndexedAsyncFlushRun                 = "publish_buffered_indexed_flush"
 )
 
 var (
@@ -1645,7 +1651,13 @@ func (c *Collection) scheduleIndexedAsyncFlush(domain *collectionWriteDomain) bo
 	domain.indexedAsyncFlushScheduled.Add(1)
 	db := c.db
 	go func() {
-		err := flushCollectionWriteDomainAsync(db, domain)
+		var err error
+		pprof.Do(context.Background(), pprof.Labels(
+			collectionPprofComponentKey, collectionPprofIndexedAsyncFlush,
+			collectionPprofOperationKey, collectionPprofIndexedAsyncFlushRun,
+		), func(context.Context) {
+			err = flushCollectionWriteDomainAsync(db, domain)
+		})
 		domain.finishIndexedAsyncFlush(err)
 	}()
 	return true

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -73,6 +73,10 @@ var (
 	errUpdateBatchHasSecondaryUniqueIndex     = errors.New("collections: update batch has secondary unique index")
 	errUpdateBatchChangesSecondaryUniqueIndex = errors.New("collections: update batch changes secondary unique index")
 	errUpdateCombinerStopped                  = errors.New("collections: update combiner stopped before DB update completed; callback may have been invoked")
+	indexedAsyncFlushPprofLabels              = pprof.Labels(
+		collectionPprofComponentKey, collectionPprofIndexedAsyncFlush,
+		collectionPprofOperationKey, collectionPprofIndexedAsyncFlushRun,
+	)
 )
 
 // UpdateBatchItem describes one document update in a batch. DocumentID must be
@@ -1652,10 +1656,7 @@ func (c *Collection) scheduleIndexedAsyncFlush(domain *collectionWriteDomain) bo
 	db := c.db
 	go func() {
 		var err error
-		pprof.Do(context.Background(), pprof.Labels(
-			collectionPprofComponentKey, collectionPprofIndexedAsyncFlush,
-			collectionPprofOperationKey, collectionPprofIndexedAsyncFlushRun,
-		), func(context.Context) {
+		pprof.Do(context.Background(), indexedAsyncFlushPprofLabels, func(context.Context) {
 			err = flushCollectionWriteDomainAsync(db, domain)
 		})
 		domain.finishIndexedAsyncFlush(err)

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"sync"
@@ -38,6 +39,10 @@ const (
 	// Preferred deterministic stride for scrambling sequential operation
 	// numbers across the preloaded ID set.
 	profileBenchPreferredUpdateIDStride = 37
+	profileBenchLabelBenchmarkKey       = "gomap_benchmark"
+	profileBenchLabelPhaseKey           = "gomap_benchmark_phase"
+	profileBenchDirectUpdateBenchmark   = "direct_collection_concurrent_update_bson"
+	profileBenchTimedUpdatePhase        = "timed_update_and_flush"
 )
 
 func profileBenchUpdateIDStride(documentCount int) int {
@@ -126,6 +131,26 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "789")
 	if got := profileBenchBufferedIndexedWriteMaxRootRuns(t); got != 789 {
 		t.Fatalf("buffered max root runs=%d want 789", got)
+	}
+}
+
+func TestProfileBenchTimedUpdatePhaseLabels(t *testing.T) {
+	called := false
+	err := runProfileBenchTimedUpdatePhase(context.Background(), func(ctx context.Context) error {
+		called = true
+		if got, ok := pprof.Label(ctx, profileBenchLabelBenchmarkKey); !ok || got != profileBenchDirectUpdateBenchmark {
+			t.Fatalf("benchmark label=(%q,%v), want (%q,true)", got, ok, profileBenchDirectUpdateBenchmark)
+		}
+		if got, ok := pprof.Label(ctx, profileBenchLabelPhaseKey); !ok || got != profileBenchTimedUpdatePhase {
+			t.Fatalf("phase label=(%q,%v), want (%q,true)", got, ok, profileBenchTimedUpdatePhase)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run timed phase: %v", err)
+	}
+	if !called {
+		t.Fatal("timed phase callback was not called")
 	}
 }
 
@@ -669,12 +694,14 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	backendStatsBefore := backend.Stats()
 	b.ResetTimer()
 	started := time.Now()
-	err = runProfileBenchDirectCollectionConcurrentUpdates(context.Background(), writers, b.N, documentCount, idStride, ids, updateDocs, collection)
-	if err == nil {
+	err = runProfileBenchTimedUpdatePhase(context.Background(), func(ctx context.Context) error {
+		if err := runProfileBenchDirectCollectionConcurrentUpdates(ctx, writers, b.N, documentCount, idStride, ids, updateDocs, collection); err != nil {
+			return err
+		}
 		// Keep async indexed-flush rows comparable with synchronous rows: the
 		// timed update phase includes the final drain of deferred publish work.
-		err = manager.FlushAll()
-	}
+		return manager.FlushAll()
+	})
 	timedElapsed := time.Since(started)
 	b.StopTimer()
 	if err != nil {
@@ -687,6 +714,23 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	reportProfileBenchOrderedRootPublishStats(b, backendStatsAfter, backendStatsBefore, b.N)
 	reportProfileBenchBackendVlogMmapStats(b, backendStatsAfter, backendStatsBefore, b.N)
 	reportDocsPerSecond(b, b.N, timedElapsed)
+}
+
+func runProfileBenchTimedUpdatePhase(ctx context.Context, run func(context.Context) error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if run == nil {
+		return nil
+	}
+	var err error
+	pprof.Do(ctx, pprof.Labels(
+		profileBenchLabelBenchmarkKey, profileBenchDirectUpdateBenchmark,
+		profileBenchLabelPhaseKey, profileBenchTimedUpdatePhase,
+	), func(ctx context.Context) {
+		err = run(ctx)
+	})
+	return err
 }
 
 func profileBenchParsedUpdateDocs(tb testing.TB, updateCity bool, cityPhase string) []profileBenchSetUpdate {
@@ -1448,6 +1492,7 @@ func runProfileBenchDirectCollectionConcurrentUpdates(
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			pprof.SetGoroutineLabels(runCtx)
 			updateScratch := make([]byte, 0, 512)
 			for {
 				if err := runCtx.Err(); err != nil {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -152,6 +152,9 @@ func TestProfileBenchTimedUpdatePhaseLabels(t *testing.T) {
 	if !called {
 		t.Fatal("timed phase callback was not called")
 	}
+	if err := runProfileBenchTimedUpdatePhase(context.Background(), nil); err == nil {
+		t.Fatal("nil timed phase callback returned nil error")
+	}
 }
 
 func TestProfileBenchParsedUpdateDocsUsesDistinctCityPhases(t *testing.T) {
@@ -721,7 +724,7 @@ func runProfileBenchTimedUpdatePhase(ctx context.Context, run func(context.Conte
 		ctx = context.Background()
 	}
 	if run == nil {
-		return nil
+		return errors.New("mongo gateway profile benchmark timed update phase callback is nil")
 	}
 	var err error
 	pprof.Do(ctx, pprof.Labels(


### PR DESCRIPTION
## Summary

Adds pprof labels for the collection indexed async-flush publish path and the mongo gateway direct-collection timed update benchmark phase.

This is a measurement/attribution PR for #1159. The last optimization probe showed that lowering the root-run threshold and flushing instead of compacting was not a win, and normal `go test -cpuprofile` output was still polluted by preload/warmup work. These labels make the next root-apply optimization pass easier to profile without conflating setup, foreground update waits, and background async publish work.

## What changed

- Labels collection indexed async flush goroutines with:
  - `gomap_component=collections_indexed_async_flush`
  - `gomap_operation=publish_buffered_indexed_flush`
- Labels the direct collection concurrent update timed benchmark callback with:
  - `gomap_benchmark=direct_collection_concurrent_update_bson`
  - `gomap_benchmark_phase=timed_update_and_flush`
- Applies timed-phase labels to worker goroutines launched by the benchmark.
- Adds a unit test for the benchmark timed-phase label helper.

## Validation

```text
GOWORK=off go test ./cmd/mongo_gateway_bench -run 'TestProfileBenchTimedUpdatePhaseLabels|TestProfileBenchParsedUpdateDocs|TestProfileBenchBufferedIndexedAsyncFlushEnv' -count=1
ok  	github.com/snissn/gomap/cmd/mongo_gateway_bench	0.558s

GOWORK=off go test ./cmd/mongo_gateway_bench -count=1
ok  	github.com/snissn/gomap/cmd/mongo_gateway_bench	2.441s

GOWORK=off go test ./TreeDB/collections -run 'TestCollectionIndexed|TestCollectionManagerStats|TestCollectionUpdate' -count=1
ok  	github.com/snissn/gomap/TreeDB/collections	1.096s

GOWORK=off go test ./TreeDB/collections -count=1
ok  	github.com/snissn/gomap/TreeDB/collections	3.578s

git diff --check
ok
```

## Focused profile check

Command:

```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1221_pprof_labels_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=100000x \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" | tee "$PROFILE_DIR/bench.txt"
go tool pprof -tags "$PROFILE_DIR/cpu.pprof" | tee "$PROFILE_DIR/tags.txt"
```

Run dir: `/tmp/gomap_1221_pprof_labels_Vx6UNK`

Benchmark row:

```text
100000 6506 ns/op 153715 docs/sec 6506 ns/doc 1207 B/op 3 allocs/op
indexed_flush_calls=2 indexed_flush_ns/doc=1442 publish_delta_group_root_apply_ns/doc=1405 update_current_read_ns/doc=1342
```

Profile labels observed:

```text
gomap_benchmark: Total 90ms of 3.10s (2.90%)
  direct_collection_concurrent_update_bson

gomap_benchmark_phase: Total 90ms of 3.10s (2.90%)
  timed_update_and_flush

gomap_component: Total 620ms of 3.10s (20.00%)
  collections_indexed_async_flush

gomap_operation: Total 620ms of 3.10s (20.00%)
  publish_buffered_indexed_flush
```

Example async-flush filtered pprof:

```bash
go tool pprof -top -nodecount=25 -tagfocus=gomap_component:collections_indexed_async_flush /tmp/gomap_1221_pprof_labels_Vx6UNK/cpu.pprof
```

The filtered profile attributes the async publish work to `publishPreparedIndexedFlush` and the root-run/zipper path, which is the intended next optimization target.

## Rejected probe before this PR

I also tested a root-run-threshold variant that skipped mutable compaction and flushed once the threshold was reached:

```text
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS=4096
200000 7524 ns/op 132915 docs/sec 1229 B/op 3 allocs/op
indexed_flush_calls=5 indexed_flush_root_runs/call=3967 publish_delta_group_root_apply_ns/doc=4012 update_buffer_stage_ns/doc=154
```

That was worse than current main/HEAD shape, so it was discarded rather than turned into an optimization PR.

Fixes part of #1159 measurement/pprof attribution.
