### PR TITLE
collections: add durable overlay root scaffolding

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -75,14 +75,15 @@ var (
 	ErrUniqueIndexConflict = errors.New("collections: unique index conflict")
 	ErrConcurrentMutation  = errors.New("collections: concurrent mutation")
 
-	errCollectionManagerNil                   = errors.New("collections: collection manager is nil")
-	errCollectionNil                          = errors.New("collections: collection is nil")
-	errCollectionDBNil                        = errors.New("collections: db is nil")
-	errCollectionNotFound                     = ErrCollectionNotFound
-	errUpdateBatchHasSecondaryUniqueIndex     = errors.New("collections: update batch has secondary unique index")
-	errUpdateBatchChangesSecondaryUniqueIndex = errors.New("collections: update batch changes secondary unique index")
-	errUpdateCombinerStopped                  = errors.New("collections: update combiner stopped before DB update completed; callback may have been invoked")
-	indexedAsyncFlushPprofLabels              = pprof.Labels(
+	errCollectionManagerNil                    = errors.New("collections: collection manager is nil")
+	errCollectionNil                           = errors.New("collections: collection is nil")
+	errCollectionDBNil                         = errors.New("collections: db is nil")
+	errCollectionNotFound                      = ErrCollectionNotFound
+	errCollectionRootOverlaysRequireCompaction = errors.New("collections: collection root overlays require compaction before writes")
+	errUpdateBatchHasSecondaryUniqueIndex      = errors.New("collections: update batch has secondary unique index")
+	errUpdateBatchChangesSecondaryUniqueIndex  = errors.New("collections: update batch changes secondary unique index")
+	errUpdateCombinerStopped                   = errors.New("collections: update combiner stopped before DB update completed; callback may have been invoked")
+	indexedAsyncFlushPprofLabels               = pprof.Labels(
 		collectionPprofComponentKey, collectionPprofIndexedAsyncFlush,
 		collectionPprofOperationKey, collectionPprofIndexedAsyncFlushRun,
 	)
@@ -143,8 +144,9 @@ func IsDuplicateKeyError(err error) bool {
 }
 
 const (
-	systemCollectionMetaPrefix = "collections/meta/"
-	systemCollectionRootPrefix = "collections/root/"
+	systemCollectionMetaPrefix        = "collections/meta/"
+	systemCollectionRootPrefix        = "collections/root/"
+	systemCollectionRootOverlayPrefix = "collections/root-overlay/"
 )
 
 func backendRootStoragePolicy(policy RootStoragePolicy) (backenddb.OrderedRootStoragePolicy, error) {
@@ -569,6 +571,7 @@ type collectionCatalog struct {
 	// create a replacement catalog via cloneCatalogWithRootUpdates.
 	meta               CollectionMeta
 	roots              map[string]uint64
+	rootOverlays       map[string][]uint64
 	primaryRootName    string
 	templateRootName   string
 	indexStateRootName string
@@ -1959,6 +1962,10 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 		_ = snap.Close()
 		return nil, errCollectionNotFound
 	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
 
 	baseMeta := catalog.meta
 	c.meta = baseMeta
@@ -2079,6 +2086,10 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 	if catalog == nil {
 		_ = snap.Close()
 		return nil, errCollectionNotFound
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		_ = snap.Close()
+		return nil, err
 	}
 	baseMeta := catalog.meta
 	c.meta = baseMeta
@@ -2238,6 +2249,9 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		if err != nil {
 			return nil, collectionOptions{}, false, err
 		}
+		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+			return nil, collectionOptions{}, false, err
+		}
 		options, err := collectionPlannerOptions(catalog.meta)
 		if err != nil {
 			return nil, collectionOptions{}, false, err
@@ -2245,6 +2259,9 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		return catalog, options, len(catalog.meta.Indexes) > 0, nil
 	}
 	if domain.loaded && domain.count == 0 && domain.baseSystemRoot == currentSystemRoot && domain.baseCommitSeq == currentCommitSeq {
+		if err := rejectCatalogRootOverlaysForWrite(domain.catalog); err != nil {
+			return nil, collectionOptions{}, false, err
+		}
 		options, err := collectionPlannerOptions(domain.meta)
 		if err != nil {
 			return nil, collectionOptions{}, false, err
@@ -2259,6 +2276,10 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 	if catalog := cachedWriteDomainCatalogForStateLocked(domain, baseSystemRoot, baseCommitSeq); catalog != nil {
+		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+			_ = snap.Close()
+			return nil, collectionOptions{}, false, err
+		}
 		c.rememberCatalog(snap, catalog)
 		_ = snap.Close()
 		options, err := collectionPlannerOptions(catalog.meta)
@@ -2279,6 +2300,10 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	if catalog == nil {
 		_ = snap.Close()
 		return nil, collectionOptions{}, false, errCollectionNotFound
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		_ = snap.Close()
+		return nil, collectionOptions{}, false, err
 	}
 	c.rememberCatalog(snap, catalog)
 	_ = snap.Close()
@@ -2325,6 +2350,9 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	}
 	if catalog == nil {
 		return nil, errCollectionNotFound
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		return nil, err
 	}
 	if !sameCollectionMeta(catalog.meta, domain.meta) {
 		return nil, fmt.Errorf("collections: concurrent schema modification detected for %q", domain.meta.Name)
@@ -3978,6 +4006,8 @@ func (h *bufferedRootRunHeap) down(i0, n int) bool {
 
 type bufferedRootRunsIterator struct {
 	iters              []iterator.UnsafeIterator
+	priorities         []int
+	priorityInline     [8]int
 	heap               bufferedRootRunHeap
 	cur                bufferedRootRunHeapItem
 	hasCur             bool
@@ -3991,6 +4021,12 @@ type bufferedRootRunsIterator struct {
 	firstErr           error
 }
 
+type bufferedRootRunIteratorSource struct {
+	iter     iterator.UnsafeIterator
+	priority int
+	lenHint  int
+}
+
 func newBufferedRootRunsIterator(runs []memtable.Table, start, end []byte) iterator.UnsafeIterator {
 	return newBufferedRootRunsIteratorWithDeleted(runs, start, end, false)
 }
@@ -3999,32 +4035,57 @@ func newBufferedRootRunsIteratorWithDeleted(runs []memtable.Table, start, end []
 	if len(runs) == 1 && includeDeleted && runs[0] != nil {
 		return runs[0].NewIterator(start, end)
 	}
-	it := &bufferedRootRunsIterator{
-		iters:              make([]iterator.UnsafeIterator, 0, len(runs)),
-		heap:               make(bufferedRootRunHeap, 0, len(runs)),
-		includeDeleted:     includeDeleted,
-		stableUnsafeSlices: true,
-		start:              start,
-		end:                end,
-	}
+	sources := make([]bufferedRootRunIteratorSource, 0, len(runs))
+	stableUnsafeSlices := true
 	for i, run := range runs {
 		if run == nil {
 			continue
 		}
 		if stable, ok := run.(memtable.StableUnsafeIteratorTable); !ok || !stable.StableUnsafeIteratorSlices() {
-			it.stableUnsafeSlices = false
+			stableUnsafeSlices = false
+		}
+		lenHint := 0
+		if start == nil && end == nil {
+			lenHint = run.Len()
+		}
+		sources = append(sources, bufferedRootRunIteratorSource{
+			iter:     run.NewIterator(start, end),
+			priority: len(runs) - 1 - i,
+			lenHint:  lenHint,
+		})
+	}
+	return newBufferedRootRunIteratorSourcesIteratorWithDeleted(sources, start, end, includeDeleted, stableUnsafeSlices)
+}
+
+func newBufferedRootRunIteratorSourcesIteratorWithDeleted(sources []bufferedRootRunIteratorSource, start, end []byte, includeDeleted, stableUnsafeSlices bool) iterator.UnsafeIterator {
+	it := &bufferedRootRunsIterator{
+		iters:              make([]iterator.UnsafeIterator, 0, len(sources)),
+		heap:               make(bufferedRootRunHeap, 0, len(sources)),
+		includeDeleted:     includeDeleted,
+		stableUnsafeSlices: stableUnsafeSlices,
+		start:              start,
+		end:                end,
+	}
+	if len(sources) <= len(it.priorityInline) {
+		it.priorities = it.priorityInline[:0]
+	} else {
+		it.priorities = make([]int, 0, len(sources))
+	}
+	for _, source := range sources {
+		if source.iter == nil {
+			continue
 		}
 		if start == nil && end == nil {
-			it.lenHint = saturatingAddNonNegativeInt(it.lenHint, run.Len())
+			it.lenHint = saturatingAddNonNegativeInt(it.lenHint, source.lenHint)
 		}
-		runIter := run.NewIterator(start, end)
 		idx := len(it.iters)
-		it.iters = append(it.iters, runIter)
-		if runIter.Valid() {
+		it.iters = append(it.iters, source.iter)
+		it.priorities = append(it.priorities, source.priority)
+		if source.iter.Valid() {
 			it.heap = append(it.heap, bufferedRootRunHeapItem{
 				idx:      idx,
-				priority: len(runs) - 1 - i,
-				key:      runIter.UnsafeKey(),
+				priority: source.priority,
+				key:      source.iter.UnsafeKey(),
 			})
 		}
 	}
@@ -4065,7 +4126,7 @@ func (it *bufferedRootRunsIterator) Seek(key []byte) {
 		if source.Valid() {
 			it.heap.push(bufferedRootRunHeapItem{
 				idx:      idx,
-				priority: len(it.iters) - 1 - idx,
+				priority: it.priorities[idx],
 				key:      source.UnsafeKey(),
 			})
 		}
@@ -4866,6 +4927,10 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 		_ = snap.Close()
 		return nil, errCollectionNotFound
 	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
 	c.meta = catalog.meta
 	if len(c.meta.Indexes) > 0 {
 		_ = snap.Close()
@@ -4885,16 +4950,16 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 	baseCommitSeq := snapshotCommitSeq(snap)
 
 	rootName := collectionPrimaryRootName(c.meta.Name)
-	baseRoot := catalog.rootID(rootName)
-	if baseRoot != 0 {
-		if _, err := snap.GetEntryAtRoot(baseRoot, id); err == nil {
+	if entry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, rootName, id); err == nil {
+		if entry.Flags&node.FlagTombstone == 0 {
 			_ = snap.Close()
 			return nil, ErrDocumentExists
-		} else if !errors.Is(err, tree.ErrKeyNotFound) {
-			_ = snap.Close()
-			return nil, err
 		}
+	} else if !errors.Is(err, tree.ErrKeyNotFound) {
+		_ = snap.Close()
+		return nil, err
 	}
+	baseRoot := catalog.rootID(rootName)
 	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
 	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
@@ -5017,6 +5082,10 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		closePlanningSnapshot()
 		return nil, errCollectionNotFound
 	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		closePlanningSnapshot()
+		return nil, err
+	}
 	meta := catalog.meta
 	c.meta = meta
 	plannerOptions, err := collectionPlannerOptions(meta)
@@ -5049,6 +5118,10 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		if catalog == nil {
 			closePlanningSnapshot()
 			return nil, errCollectionNotFound
+		}
+		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+			closePlanningSnapshot()
+			return nil, err
 		}
 		meta = catalog.meta
 		c.meta = meta
@@ -5382,23 +5455,41 @@ func (c *Collection) insertBatchNoIndex(
 	}
 
 	rootName := collectionPrimaryRootName(c.meta.Name)
-	baseRoot := catalog.rootID(rootName)
-	if baseRoot != 0 {
-		keys := make([][]byte, len(entries))
+	if len(catalog.overlayRootIDs(rootName)) == 0 {
+		baseRoot := catalog.rootID(rootName)
+		if baseRoot != 0 {
+			keys := make([][]byte, len(entries))
+			for i := range entries {
+				keys[i] = entries[i].id
+			}
+			exists, err := snap.HasAnySortedAtRoot(baseRoot, keys)
+			if err != nil {
+				_ = snap.Close()
+				return nil, err
+			}
+			if exists {
+				_ = snap.Close()
+				return nil, ErrDocumentExists
+			}
+		}
+	} else {
 		for i := range entries {
-			keys[i] = entries[i].id
-		}
-		exists, err := snap.HasAnySortedAtRoot(baseRoot, keys)
-		if err != nil {
-			_ = snap.Close()
-			return nil, err
-		}
-		if exists {
-			_ = snap.Close()
-			return nil, ErrDocumentExists
+			entry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, rootName, entries[i].id)
+			if err == nil {
+				if entry.Flags&node.FlagTombstone == 0 {
+					_ = snap.Close()
+					return nil, ErrDocumentExists
+				}
+				continue
+			}
+			if !errors.Is(err, tree.ErrKeyNotFound) {
+				_ = snap.Close()
+				return nil, err
+			}
 		}
 	}
 	stats.DuplicateDocumentPreflight = time.Since(phaseStart)
+	baseRoot := catalog.rootID(rootName)
 	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
 	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
@@ -5493,6 +5584,10 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 		_ = snap.Close()
 		return false, errCollectionNotFound
 	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		_ = snap.Close()
+		return false, err
+	}
 	c.meta = catalog.meta
 	plannerOptions, err := collectionPlannerOptions(c.meta)
 	if err != nil {
@@ -5503,12 +5598,8 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 
-	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
-	if primaryRoot == 0 {
-		_ = snap.Close()
-		return false, nil
-	}
-	entry, err := snap.GetEntryAtRoot(primaryRoot, documentID)
+	primaryRootName := collectionPrimaryRootName(c.meta.Name)
+	entry, primaryRoot, err := collectionGetEntryAtCatalogRoot(snap, catalog, primaryRootName, documentID)
 	if errors.Is(err, tree.ErrKeyNotFound) {
 		_ = snap.Close()
 		return false, nil
@@ -5516,6 +5607,10 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	if err != nil {
 		_ = snap.Close()
 		return false, err
+	}
+	if entry.Flags&node.FlagTombstone != 0 {
+		_ = snap.Close()
+		return false, nil
 	}
 
 	runtimes, err := (insertBatchPlanner{
@@ -6506,6 +6601,10 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		_ = snap.Close()
 		return false, false, errCollectionNotFound
 	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		_ = snap.Close()
+		return false, false, err
+	}
 	c.meta = catalog.meta
 	plannerOptions, err := collectionPlannerOptions(c.meta)
 	if err != nil {
@@ -6517,20 +6616,17 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 
-	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
-	if primaryRoot == 0 {
-		_ = snap.Close()
-		return false, false, nil
-	}
-	currentValue, err := snap.GetAppendAtRoot(primaryRoot, documentID, nil)
-	if errors.Is(err, tree.ErrKeyNotFound) {
-		_ = snap.Close()
-		return false, false, nil
-	}
+	primaryRootName := collectionPrimaryRootName(c.meta.Name)
+	currentValue, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, documentID, nil)
 	if err != nil {
 		_ = snap.Close()
 		return false, false, err
 	}
+	if !found {
+		_ = snap.Close()
+		return false, false, nil
+	}
+	primaryRoot := catalog.rootID(primaryRootName)
 
 	runtimes, err := (insertBatchPlanner{
 		collection: c.meta.Name,
@@ -6622,7 +6718,6 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		}
 	}
 
-	primaryRootName := collectionPrimaryRootName(c.meta.Name)
 	rootNames = append(rootNames, primaryRootName)
 	baseRootIDs[primaryRootName] = primaryRoot
 	policies = append(policies, plannerOptions.dataStoragePolicy)
@@ -7411,6 +7506,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	if catalog == nil {
 		_ = snap.Close()
 		return nil, errCollectionNotFound
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		_ = snap.Close()
+		return nil, err
 	}
 	meta := catalog.meta
 	stats := CollectionUpdateStats{
@@ -8542,23 +8641,33 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 
 func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, rootNames []string, rootIDs []uint64) *collectionCatalog {
 	roots := make(map[string]uint64)
+	var rootOverlays map[string][]uint64
 	if base != nil {
 		for name, rootID := range base.roots {
 			roots[name] = rootID
 		}
+		rootOverlays = cloneRootOverlayMap(base.rootOverlays)
 	}
 	for i, name := range rootNames {
 		if i < len(rootIDs) {
 			roots[name] = rootIDs[i]
+			if len(rootOverlays) != 0 {
+				delete(rootOverlays, name)
+			}
 		}
 	}
-	return newCollectionCatalog(copyCollectionMeta(meta), roots)
+	return newCollectionCatalogWithOverlays(copyCollectionMeta(meta), roots, rootOverlays)
 }
 
 func newCollectionCatalog(meta CollectionMeta, roots map[string]uint64) *collectionCatalog {
+	return newCollectionCatalogWithOverlays(meta, roots, nil)
+}
+
+func newCollectionCatalogWithOverlays(meta CollectionMeta, roots map[string]uint64, rootOverlays map[string][]uint64) *collectionCatalog {
 	catalog := &collectionCatalog{
 		meta:               meta,
 		roots:              roots,
+		rootOverlays:       cloneRootOverlayMap(rootOverlays),
 		primaryRootName:    collectionPrimaryRootName(meta.Name),
 		templateRootName:   collectionTemplateRootName(meta.Name),
 		indexStateRootName: collectionIndexStateRootName(meta.Name),
@@ -8570,6 +8679,30 @@ func newCollectionCatalog(meta CollectionMeta, roots map[string]uint64) *collect
 		}).indexRuntimes()
 	}
 	return catalog
+}
+
+func cloneRootOverlayMap(in map[string][]uint64) map[string][]uint64 {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]uint64, len(in))
+	for name, roots := range in {
+		if len(roots) == 0 {
+			continue
+		}
+		out[name] = append([]uint64(nil), roots...)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func rejectCatalogRootOverlaysForWrite(catalog *collectionCatalog) error {
+	if catalog == nil || len(catalog.rootOverlays) == 0 {
+		return nil
+	}
+	return errCollectionRootOverlaysRequireCompaction
 }
 
 func (c *collectionCatalog) cachedIndexRuntimes() ([]indexRuntime, error) {
@@ -8618,12 +8751,12 @@ func buildCreateIndexBackfillPlan(
 		return plan, nil
 	}
 
-	it, err := snap.IteratorAtRoot(primaryRootID, nil, nil)
-	if errors.Is(err, tree.ErrKeyNotFound) {
-		return plan, nil
-	}
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, primaryRootName, nil, nil, false)
 	if err != nil {
 		return nil, err
+	}
+	if it == nil {
+		return plan, nil
 	}
 	defer func() { _ = it.Close() }()
 
@@ -8973,9 +9106,10 @@ func loadDeleteIndexState(snap *backenddb.Snapshot, catalog *collectionCatalog, 
 	if catalog == nil || len(runtimes) == 0 {
 		return nil, nil
 	}
-	stateRoot := catalog.rootID(collectionIndexStateRootName(catalog.meta.Name))
-	if persistIndexStateForOptions(opts) && stateRoot != 0 {
-		entry, err := snap.GetEntryAtRoot(stateRoot, documentID)
+	stateRootName := collectionIndexStateRootName(catalog.meta.Name)
+	stateRoot := catalog.rootID(stateRootName)
+	if persistIndexStateForOptions(opts) && (stateRoot != 0 || len(catalog.overlayRootIDs(stateRootName)) != 0) {
+		entry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, stateRootName, documentID)
 		if err == nil {
 			return decodeDocumentIndexState(entry.Value)
 		}
@@ -9013,21 +9147,18 @@ func rejectReplaceUniqueConflicts(snap *backenddb.Snapshot, catalog *collectionC
 		if !documentIndexRuntimeChanged(oldState, newState, runtime) {
 			continue
 		}
-		rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, runtime.def.name))
-		if rootID == 0 {
-			continue
-		}
+		rootName := collectionSecondaryRootName(catalog.meta.Name, runtime.def.name)
 		for _, encoded := range newState[runtime.def.name] {
 			_, prefix, err := appendIndexValuePrefixSlice(make([]byte, 0, 2+len(encoded)), encoded)
 			if err != nil {
 				return err
 			}
-			it, err := snap.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
-			if errors.Is(err, tree.ErrKeyNotFound) {
-				continue
-			}
+			it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, prefix, prefixEnd(prefix), true)
 			if err != nil {
 				return err
+			}
+			if it == nil {
+				continue
 			}
 			conflict := false
 			for it.Valid() {
@@ -9066,21 +9197,18 @@ func rejectReplaceUniqueConflictsOrdered(snap *backenddb.Snapshot, catalog *coll
 		if !preparedBatchUpdateIndexChanged(update, runtimeIdx) {
 			continue
 		}
-		rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, runtime.def.name))
-		if rootID == 0 {
-			continue
-		}
+		rootName := collectionSecondaryRootName(catalog.meta.Name, runtime.def.name)
 		for _, encoded := range update.newState.valuesAt(runtimeIdx) {
 			_, prefix, err := appendIndexValuePrefixSlice(make([]byte, 0, 2+len(encoded)), encoded)
 			if err != nil {
 				return err
 			}
-			it, err := snap.IteratorAtRoot(rootID, prefix, prefixEnd(prefix))
-			if errors.Is(err, tree.ErrKeyNotFound) {
-				continue
-			}
+			it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, prefix, prefixEnd(prefix), true)
 			if err != nil {
 				return err
+			}
+			if it == nil {
+				continue
 			}
 			conflict := false
 			for it.Valid() {
@@ -9224,18 +9352,7 @@ func (c *Collection) GetInto(documentID []byte, dst []byte) ([]byte, bool, error
 	if catalog == nil {
 		return dst[:0], false, errCollectionNotFound
 	}
-	primaryRoot := catalog.rootID(collectionPrimaryRootName(c.meta.Name))
-	if primaryRoot == 0 {
-		return dst[:0], false, nil
-	}
-	out, err := snap.GetAppendAtRoot(primaryRoot, documentID, dst[:0])
-	if errors.Is(err, tree.ErrKeyNotFound) {
-		return dst[:0], false, nil
-	}
-	if err != nil {
-		return dst[:0], false, err
-	}
-	return out, true, nil
+	return collectionGetAppendAtCatalogRoot(snap, catalog, collectionPrimaryRootName(c.meta.Name), documentID, dst)
 }
 
 func (c *Collection) getBufferedDocumentInto(documentID []byte, dst []byte) ([]byte, bool, bool) {
@@ -9487,17 +9604,13 @@ func (c *Collection) scanIndexRange(indexName string, opts IndexRangeOptions, fn
 		bufferedIt = bufferedTable.NewIterator(start, end)
 		defer func() { _ = bufferedIt.Close() }()
 	}
-	rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
 	var persistedIt iterator.UnsafeIterator
-	if rootID != 0 {
-		it, err := snap.IteratorAtRoot(rootID, start, end)
-		if err != nil && !errors.Is(err, tree.ErrKeyNotFound) {
-			return false, true, err
-		}
-		if err == nil {
-			persistedIt = it
-			defer func() { _ = persistedIt.Close() }()
-		}
+	persistedIt, err = collectionIteratorAtCatalogRoot(snap, catalog, collectionSecondaryRootName(catalog.meta.Name, idx.Name), start, end, true)
+	if err != nil {
+		return false, true, err
+	}
+	if persistedIt != nil {
+		defer func() { _ = persistedIt.Close() }()
 	}
 	truncated, err := scanMergedCollectionIndexIDs(bufferedIt, persistedIt, idx.ValueType, opts.Limit, fn)
 	return truncated, true, err
@@ -9918,16 +10031,12 @@ func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord)
 	if catalog == nil {
 		return false, errCollectionNotFound
 	}
-	rootID := catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
-	if rootID == 0 {
-		return false, nil
-	}
-	it, err := snap.IteratorAtRoot(rootID, nil, nil)
-	if errors.Is(err, tree.ErrKeyNotFound) {
-		return false, nil
-	}
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, collectionPrimaryRootName(catalog.meta.Name), nil, nil, false)
 	if err != nil {
 		return false, err
+	}
+	if it == nil {
+		return false, nil
 	}
 	defer func() { _ = it.Close() }()
 	truncated := false
@@ -9971,7 +10080,8 @@ func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCa
 		return nil, err
 	}
 	roots := make(map[string]uint64)
-	for _, rootName := range collectionRootNames(meta) {
+	rootNames := collectionRootNames(meta)
+	for _, rootName := range rootNames {
 		rawRoot, ok, err := getSystemValue(snap, systemCollectionRootKey(rootName))
 		if err != nil {
 			return nil, err
@@ -9985,7 +10095,60 @@ func loadCollectionCatalog(snap *backenddb.Snapshot, name string) (*collectionCa
 		}
 		roots[rootName] = rootID
 	}
-	return newCollectionCatalog(meta, roots), nil
+	rootOverlays, err := loadCollectionCatalogRootOverlays(snap, rootNames)
+	if err != nil {
+		return nil, err
+	}
+	return newCollectionCatalogWithOverlays(meta, roots, rootOverlays), nil
+}
+
+func loadCollectionCatalogRootOverlays(snap *backenddb.Snapshot, rootNames []string) (map[string][]uint64, error) {
+	if snap == nil || snap.State() == nil || snap.State().SystemRootPageID == 0 || len(rootNames) == 0 {
+		return nil, nil
+	}
+	prefix := []byte(systemCollectionRootOverlayPrefix)
+	it, err := snap.IteratorAtRoot(snap.State().SystemRootPageID, prefix, prefixEnd(prefix))
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = it.Close() }()
+	if !it.Valid() || !bytes.HasPrefix(it.UnsafeKey(), prefix) {
+		return nil, it.Error()
+	}
+	rootNameSet := make(map[string]struct{}, len(rootNames))
+	for _, rootName := range rootNames {
+		rootNameSet[rootName] = struct{}{}
+	}
+	rootOverlays := make(map[string][]uint64)
+	for it.Valid() {
+		key := it.UnsafeKey()
+		if !bytes.HasPrefix(key, prefix) {
+			break
+		}
+		rootName := strings.TrimPrefix(string(key), systemCollectionRootOverlayPrefix)
+		if _, ok := rootNameSet[rootName]; !ok {
+			it.Next()
+			continue
+		}
+		overlayIDs, err := decodeRootIDList(it.ValueCopy(nil))
+		if err != nil {
+			return nil, fmt.Errorf("collections: root %q overlays: %w", rootName, err)
+		}
+		if len(overlayIDs) != 0 {
+			rootOverlays[rootName] = overlayIDs
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	if len(rootOverlays) == 0 {
+		return nil, nil
+	}
+	return rootOverlays, nil
 }
 
 func (c *collectionCatalog) rootID(rootName string) uint64 {
@@ -9993,6 +10156,145 @@ func (c *collectionCatalog) rootID(rootName string) uint64 {
 		return 0
 	}
 	return c.roots[rootName]
+}
+
+func (c *collectionCatalog) overlayRootIDs(rootName string) []uint64 {
+	if c == nil || len(c.rootOverlays) == 0 {
+		return nil
+	}
+	return c.rootOverlays[rootName]
+}
+
+func (c *collectionCatalog) rootStack(rootName string) []uint64 {
+	if c == nil || rootName == "" {
+		return nil
+	}
+	overlays := c.overlayRootIDs(rootName)
+	baseRoot := c.rootID(rootName)
+	if len(overlays) == 0 {
+		if baseRoot == 0 {
+			return nil
+		}
+		return []uint64{baseRoot}
+	}
+	// Overlay descriptors are ordered newest-to-oldest so the merge iterator can
+	// let newer overlay entries shadow older overlays and the base root.
+	out := make([]uint64, 0, len(overlays)+1)
+	out = append(out, overlays...)
+	if baseRoot != 0 {
+		out = append(out, baseRoot)
+	}
+	return out
+}
+
+func collectionGetEntryAtCatalogRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, key []byte) (node.LeafEntry, uint64, error) {
+	if snap == nil {
+		return node.LeafEntry{}, 0, backenddb.ErrClosed
+	}
+	if len(catalog.overlayRootIDs(rootName)) == 0 {
+		rootID := catalog.rootID(rootName)
+		if rootID == 0 {
+			return node.LeafEntry{}, 0, tree.ErrKeyNotFound
+		}
+		entry, err := snap.GetEntryAtRoot(rootID, key)
+		return entry, rootID, err
+	}
+	for _, rootID := range catalog.rootStack(rootName) {
+		entry, err := snap.GetEntryAtRoot(rootID, key)
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			continue
+		}
+		if err != nil {
+			return node.LeafEntry{}, 0, err
+		}
+		return entry, rootID, nil
+	}
+	return node.LeafEntry{}, 0, tree.ErrKeyNotFound
+}
+
+func collectionGetAppendAtCatalogRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, key, dst []byte) ([]byte, bool, error) {
+	if snap == nil {
+		return dst[:0], false, backenddb.ErrClosed
+	}
+	if len(catalog.overlayRootIDs(rootName)) == 0 {
+		rootID := catalog.rootID(rootName)
+		if rootID == 0 {
+			return dst[:0], false, nil
+		}
+		out, err := snap.GetAppendAtRoot(rootID, key, dst[:0])
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			return dst[:0], false, nil
+		}
+		if err != nil {
+			return dst[:0], false, err
+		}
+		return out, true, nil
+	}
+	entry, rootID, err := collectionGetEntryAtCatalogRoot(snap, catalog, rootName, key)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return dst[:0], false, nil
+	}
+	if err != nil {
+		return dst[:0], false, err
+	}
+	if entry.Flags&node.FlagTombstone != 0 {
+		return dst[:0], false, nil
+	}
+	out, err := snap.GetAppendAtRoot(rootID, key, dst[:0])
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return dst[:0], false, nil
+	}
+	if err != nil {
+		return dst[:0], false, err
+	}
+	return out, true, nil
+}
+
+func collectionIteratorAtCatalogRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, start, end []byte, includeDeleted bool) (iterator.UnsafeIterator, error) {
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	if len(catalog.overlayRootIDs(rootName)) == 0 {
+		rootID := catalog.rootID(rootName)
+		if rootID == 0 {
+			return nil, nil
+		}
+		it, err := snap.IteratorAtRootWithOptions(rootID, start, end, backenddb.IteratorOptions{IncludeTombstones: includeDeleted})
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			return nil, nil
+		}
+		return it, err
+	}
+	rootIDs := catalog.rootStack(rootName)
+	if len(rootIDs) == 0 {
+		return nil, nil
+	}
+	sources := make([]bufferedRootRunIteratorSource, 0, len(rootIDs))
+	for i, rootID := range rootIDs {
+		if rootID == 0 {
+			continue
+		}
+		it, err := snap.IteratorAtRootWithOptions(rootID, start, end, backenddb.IteratorOptions{IncludeTombstones: true})
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			continue
+		}
+		if err != nil {
+			for _, source := range sources {
+				if source.iter != nil {
+					_ = source.iter.Close()
+				}
+			}
+			return nil, err
+		}
+		sources = append(sources, bufferedRootRunIteratorSource{
+			iter:     it,
+			priority: i,
+		})
+	}
+	if len(sources) == 0 {
+		return nil, nil
+	}
+	return newBufferedRootRunIteratorSourcesIteratorWithDeleted(sources, start, end, includeDeleted, false), nil
 }
 
 func (c *collectionCatalog) copy() *collectionCatalog {
@@ -10003,7 +10305,8 @@ func (c *collectionCatalog) copy() *collectionCatalog {
 	for name, rootID := range c.roots {
 		roots[name] = rootID
 	}
-	return newCollectionCatalog(copyCollectionMeta(c.meta), roots)
+	rootOverlays := cloneRootOverlayMap(c.rootOverlays)
+	return newCollectionCatalogWithOverlays(copyCollectionMeta(c.meta), roots, rootOverlays)
 }
 
 func getSystemValue(snap *backenddb.Snapshot, key string) ([]byte, bool, error) {
@@ -10479,6 +10782,10 @@ func systemCollectionRootKey(rootName string) string {
 	return systemCollectionRootPrefix + rootName
 }
 
+func systemCollectionRootOverlayKey(rootName string) string {
+	return systemCollectionRootOverlayPrefix + rootName
+}
+
 func encodeRootID(rootID uint64) []byte {
 	out := make([]byte, 8)
 	binary.BigEndian.PutUint64(out, rootID)
@@ -10490,6 +10797,31 @@ func decodeRootID(raw []byte) (uint64, error) {
 		return 0, errors.New("malformed root id")
 	}
 	return binary.BigEndian.Uint64(raw), nil
+}
+
+func encodeRootIDList(rootIDs []uint64) []byte {
+	if len(rootIDs) == 0 {
+		return nil
+	}
+	out := make([]byte, len(rootIDs)*8)
+	for i, rootID := range rootIDs {
+		binary.BigEndian.PutUint64(out[i*8:(i+1)*8], rootID)
+	}
+	return out
+}
+
+func decodeRootIDList(raw []byte) ([]uint64, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if len(raw)%8 != 0 {
+		return nil, errors.New("malformed root id list")
+	}
+	out := make([]uint64, len(raw)/8)
+	for i := range out {
+		out[i] = binary.BigEndian.Uint64(raw[i*8 : (i+1)*8])
+	}
+	return out, nil
 }
 
 func ValidateCollectionName(name string) error {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -19,6 +19,7 @@ import (
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/batch"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -2186,6 +2187,174 @@ func TestCollectionIndexedFlushUnitCloseFlushesRotatedState(t *testing.T) {
 	}
 	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
 		t.Fatalf("reopened email ids=%q want [u1]", ids)
+	}
+}
+
+func TestCollectionCatalogOverlayRootsAreVisibleAfterReopen(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush base collection: %v", err)
+	}
+
+	primaryOverlay := newCollectionRunTable(1)
+	setCollectionRunValue(primaryOverlay, []byte("u1"), []byte(`{"email":"ada@example.com","city":"sea"}`))
+	primaryOverlay.Freeze()
+	defer resetCollectionRunTable(primaryOverlay)
+
+	cityOverlay := newCollectionRunTable(2)
+	oldCity, err := encodeIndexScalar(IndexValueString, "hnl")
+	if err != nil {
+		t.Fatalf("encode old city: %v", err)
+	}
+	if _, err := deleteCollectionSecondaryIndexEntry(cityOverlay, oldCity, []byte("u1")); err != nil {
+		t.Fatalf("delete old city entry: %v", err)
+	}
+	newCity, err := encodeIndexScalar(IndexValueString, "sea")
+	if err != nil {
+		t.Fatalf("encode new city: %v", err)
+	}
+	if _, err := setCollectionSecondaryIndexEntry(cityOverlay, newCity, []byte("u1")); err != nil {
+		t.Fatalf("set new city entry: %v", err)
+	}
+	cityOverlay.Freeze()
+	defer resetCollectionRunTable(cityOverlay)
+
+	primaryRootName := collectionPrimaryRootName("users")
+	cityRootName := collectionSecondaryRootName("users", "city")
+	_, overlayRootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]backenddb.OrderedRootPublishInput{
+		{BaseRoot: 0, Iter: primaryOverlay.NewIterator(nil, nil)},
+		{BaseRoot: 0, Iter: cityOverlay.NewIterator(nil, nil)},
+	}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		snap := db.AcquireSnapshot()
+		if snap == nil {
+			return nil, backenddb.ErrClosed
+		}
+		defer func() { _ = snap.Close() }()
+		return buildSystemTargetIterator(snap, map[string][]byte{
+			systemCollectionRootOverlayKey(primaryRootName): encodeRootIDList([]uint64{rootIDs[0]}),
+			systemCollectionRootOverlayKey(cityRootName):    encodeRootIDList([]uint64{rootIDs[1]}),
+		})
+	})
+	if err != nil {
+		t.Fatalf("publish overlay roots: %v", err)
+	}
+	if len(overlayRootIDs) != 2 {
+		t.Fatalf("overlay root ids len=%d want 2", len(overlayRootIDs))
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	snap := reopened.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire reopened snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load reopened catalog: %v", err)
+	}
+	if got := catalog.overlayRootIDs(cityRootName); !reflect.DeepEqual(got, []uint64{overlayRootIDs[1]}) {
+		t.Fatalf("city overlay roots=%v want [%d]", got, overlayRootIDs[1])
+	}
+	rawOverlayIt, err := snap.IteratorAtRootWithOptions(overlayRootIDs[1], oldCity, prefixEnd(oldCity), backenddb.IteratorOptions{IncludeTombstones: true})
+	if err != nil {
+		t.Fatalf("open raw old city overlay iterator: %v", err)
+	}
+	if !rawOverlayIt.Valid() || !rawOverlayIt.IsDeleted() {
+		t.Fatalf("raw old city overlay iterator valid/deleted=%v/%v key=%x", rawOverlayIt.Valid(), rawOverlayIt.Valid() && rawOverlayIt.IsDeleted(), rawOverlayIt.UnsafeKey())
+	}
+	_ = rawOverlayIt.Close()
+	oldCityIt, err := collectionIteratorAtCatalogRoot(snap, catalog, cityRootName, oldCity, prefixEnd(oldCity), true)
+	if err != nil {
+		t.Fatalf("open old city overlay iterator: %v", err)
+	}
+	if oldCityIt == nil || !oldCityIt.Valid() || !oldCityIt.IsDeleted() {
+		t.Fatalf("old city overlay iterator valid/deleted=%v/%v", oldCityIt != nil && oldCityIt.Valid(), oldCityIt != nil && oldCityIt.IsDeleted())
+	}
+	_ = oldCityIt.Close()
+	hiddenOldCityIt, err := collectionIteratorAtCatalogRoot(snap, catalog, cityRootName, oldCity, prefixEnd(oldCity), false)
+	if err != nil {
+		t.Fatalf("open hidden old city overlay iterator: %v", err)
+	}
+	if hiddenOldCityIt != nil {
+		hiddenOldCityIt.Seek(oldCity)
+		if hiddenOldCityIt.Valid() {
+			t.Fatalf("hidden old city iterator key=%x deleted=%v, want no visible base row after overlay tombstone", hiddenOldCityIt.UnsafeKey(), hiddenOldCityIt.IsDeleted())
+		}
+		_ = hiddenOldCityIt.Close()
+	}
+	_ = snap.Close()
+	if _, err := reopenedCol.Insert([]byte("u2"), []byte(`{"email":"grace@example.com","city":"sea"}`)); !errors.Is(err, errCollectionRootOverlaysRequireCompaction) {
+		t.Fatalf("insert with overlay roots err=%v want %v", err, errCollectionRootOverlaysRequireCompaction)
+	}
+	if matched, modified, err := reopenedCol.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"email":"ada@example.com","city":"bos"}`), true, nil
+	}); !errors.Is(err, errCollectionRootOverlaysRequireCompaction) || matched || modified {
+		t.Fatalf("update with overlay roots matched=%v modified=%v err=%v want %v", matched, modified, err, errCollectionRootOverlaysRequireCompaction)
+	}
+	if deleted, err := reopenedCol.DeleteDocument([]byte("u1")); !errors.Is(err, errCollectionRootOverlaysRequireCompaction) || deleted {
+		t.Fatalf("delete with overlay roots deleted=%v err=%v want %v", deleted, err, errCollectionRootOverlaysRequireCompaction)
+	}
+	if _, err := reopenedCol.CreateIndex(IndexDefinition{Name: "email", Field: "email", ValueType: IndexValueString}); !errors.Is(err, errCollectionRootOverlaysRequireCompaction) {
+		t.Fatalf("create index with overlay roots err=%v want %v", err, errCollectionRootOverlaysRequireCompaction)
+	}
+	got, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get overlay document: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("overlay document=%q want %q", got, want)
+	}
+	hnlIDs, err := reopenedCol.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find old city: %v", err)
+	}
+	if len(hnlIDs) != 0 {
+		t.Fatalf("old city ids=%q want none", hnlIDs)
+	}
+	seaIDs, err := reopenedCol.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find new city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("new city ids=%q want [u1]", seaIDs)
+	}
+	docs, truncated, err := reopenedCol.ScanDocuments(10)
+	if err != nil {
+		t.Fatalf("scan documents: %v", err)
+	}
+	if truncated || len(docs) != 1 || !bytes.Equal(docs[0].Document, []byte(`{"email":"ada@example.com","city":"sea"}`)) {
+		t.Fatalf("scan docs=%+v truncated=%v", docs, truncated)
 	}
 }
 

--- a/TreeDB/collections/native_default_test.go
+++ b/TreeDB/collections/native_default_test.go
@@ -26,7 +26,6 @@ func TestCollectionsRuntimeHasNoOracleOrTranslationSelectors(t *testing.T) {
 			"TREEDB_COLLECTION_PATH_LABEL",
 			"executionPath",
 			"detached",
-			"overlay",
 			"replay",
 		} {
 			if strings.Contains(src, forbidden) {

--- a/TreeDB/db/maintenance_roots.go
+++ b/TreeDB/db/maintenance_roots.go
@@ -8,12 +8,19 @@ import (
 )
 
 const collectionRootDescriptorPrefix = vacuumCollectionRootDescriptorPrefix
+const collectionRootOverlayDescriptorPrefix = vacuumCollectionRootOverlayDescriptorPrefix
 
 var collectionRootDescriptorPrefixBytes = vacuumCollectionRootDescriptorPrefixBytes
 var collectionRootDescriptorPrefixEndBytes = vacuumCollectionRootDescriptorPrefixEnd()
+var collectionRootOverlayDescriptorPrefixBytes = vacuumCollectionRootOverlayDescriptorPrefixBytes
+var collectionRootOverlayDescriptorPrefixEndBytes = vacuumCollectionRootOverlayDescriptorPrefixEnd()
 
 func collectionRootDescriptorPrefixEnd() []byte {
 	return collectionRootDescriptorPrefixEndBytes
+}
+
+func collectionRootOverlayDescriptorPrefixEnd() []byte {
+	return collectionRootOverlayDescriptorPrefixEndBytes
 }
 
 type maintenanceRootKind uint8

--- a/TreeDB/db/maintenance_roots_test.go
+++ b/TreeDB/db/maintenance_roots_test.go
@@ -111,6 +111,49 @@ func TestMaintenanceRoots_DeduplicatesCollectionRootDescriptors(t *testing.T) {
 	requireMaintenanceRootCount(t, roots, maintenanceRootCollection, 1)
 }
 
+func TestMaintenanceRoots_IncludesCollectionOverlayRootDescriptors(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	_, rootIDs, err := d.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{
+		{BaseRoot: 0, Iter: mustFrozenSystemMemtable(t, "doc/u1", "base").NewIterator(nil, nil), StoragePolicy: OrderedRootStoragePagerLeaves},
+		{BaseRoot: 0, Iter: mustFrozenSystemMemtable(t, "doc/u1", "overlay-1").NewIterator(nil, nil), StoragePolicy: OrderedRootStoragePagerLeaves},
+		{BaseRoot: 0, Iter: mustFrozenSystemMemtable(t, "doc/u2", "overlay-2").NewIterator(nil, nil), StoragePolicy: OrderedRootStoragePagerLeaves},
+	}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenRawMemtable(t,
+			maintenanceTestCollectionRootKey, encodeMaintenanceRootID(rootIDs[0]),
+			"collections/root-overlay/users/primary", encodeCollectionRootDescriptorRootIDs([]uint64{rootIDs[2], rootIDs[1]}),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish roots: %v", err)
+	}
+	if len(rootIDs) != 3 {
+		t.Fatalf("rootIDs=%d want 3", len(rootIDs))
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil || snap.state == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	roots, err := maintenanceRootsForSnapshot(snap)
+	if err != nil {
+		t.Fatalf("maintenanceRootsForSnapshot: %v", err)
+	}
+	requireMaintenanceRoot(t, roots, maintenanceRootCollection, rootIDs[0])
+	overlayNewest := requireMaintenanceRoot(t, roots, maintenanceRootCollection, rootIDs[2])
+	overlayOlder := requireMaintenanceRoot(t, roots, maintenanceRootCollection, rootIDs[1])
+	if want := []byte("collections/root-overlay/users/primary"); !bytes.Equal(overlayNewest.descriptorKey, want) || !bytes.Equal(overlayOlder.descriptorKey, want) {
+		t.Fatalf("overlay descriptor keys newest=%q older=%q want %q", overlayNewest.descriptorKey, overlayOlder.descriptorKey, want)
+	}
+	requireMaintenanceRootCount(t, roots, maintenanceRootCollection, 3)
+}
+
 func TestMaintenanceRoots_MalformedCollectionDescriptorFails(t *testing.T) {
 	d, err := Open(Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -246,19 +246,42 @@ type orderedRootCollectionDescriptorEntry struct {
 }
 
 func orderedRootTableCollectionRootDescriptorEntries(table memtable.Table) ([]orderedRootCollectionDescriptorEntry, error) {
-	iter := table.NewIterator(collectionRootDescriptorPrefixBytes, collectionRootDescriptorPrefixEnd())
-	defer func() { _ = iter.Close() }()
-	return orderedRootIteratorCollectionRootDescriptorEntries(iter)
+	rootIter := table.NewIterator(collectionRootDescriptorPrefixBytes, collectionRootDescriptorPrefixEnd())
+	entries, err := orderedRootIteratorCollectionRootDescriptorEntriesForPrefix(rootIter, collectionRootDescriptorPrefixBytes)
+	_ = rootIter.Close()
+	if err != nil {
+		return nil, err
+	}
+	overlayIter := table.NewIterator(collectionRootOverlayDescriptorPrefixBytes, collectionRootOverlayDescriptorPrefixEnd())
+	overlayEntries, err := orderedRootIteratorCollectionRootDescriptorEntriesForPrefix(overlayIter, collectionRootOverlayDescriptorPrefixBytes)
+	_ = overlayIter.Close()
+	if err != nil {
+		return nil, err
+	}
+	return append(entries, overlayEntries...), nil
 }
 
 func orderedRootIteratorCollectionRootDescriptorEntries(iter iterator.UnsafeIterator) ([]orderedRootCollectionDescriptorEntry, error) {
+	entries, err := orderedRootIteratorCollectionRootDescriptorEntriesForPrefix(iter, collectionRootDescriptorPrefixBytes)
+	if err != nil {
+		return nil, err
+	}
+	overlayEntries, err := orderedRootIteratorCollectionRootDescriptorEntriesForPrefix(iter, collectionRootOverlayDescriptorPrefixBytes)
+	if err != nil {
+		return nil, err
+	}
+	return append(entries, overlayEntries...), nil
+}
+
+func orderedRootIteratorCollectionRootDescriptorEntriesForPrefix(iter iterator.UnsafeIterator, prefix []byte) ([]orderedRootCollectionDescriptorEntry, error) {
 	if iter == nil {
 		return nil, nil
 	}
 	var out []orderedRootCollectionDescriptorEntry
+	iter.Seek(prefix)
 	for iter.Valid() {
 		key := iter.UnsafeKey()
-		if !bytes.HasPrefix(key, collectionRootDescriptorPrefixBytes) {
+		if !bytes.HasPrefix(key, prefix) {
 			break
 		}
 		val, ptr, flags := iter.UnsafeEntry()
@@ -795,7 +818,7 @@ func (db *DB) publishOrderedRootIterator(baseRoot uint64, iter iterator.UnsafeIt
 			return rootTree.CollectPageIDs()
 		}
 		if trackValueLogRefs {
-			baseDescriptorIter := rootTree.Iterator(collectionRootDescriptorPrefixBytes, collectionRootDescriptorPrefixEnd())
+			baseDescriptorIter := rootTree.Iterator(nil, nil)
 			stats.collectionRootDescriptorBaseEntries, err = orderedRootIteratorCollectionRootDescriptorEntries(baseDescriptorIter)
 			_ = baseDescriptorIter.Close()
 			if err != nil {

--- a/TreeDB/db/vacuum_collection_roots.go
+++ b/TreeDB/db/vacuum_collection_roots.go
@@ -16,13 +16,21 @@ import (
 	"github.com/snissn/gomap/TreeDB/tree"
 )
 
-const vacuumCollectionRootDescriptorPrefix = "collections/root/"
+const (
+	vacuumCollectionRootDescriptorPrefix        = "collections/root/"
+	vacuumCollectionRootOverlayDescriptorPrefix = "collections/root-overlay/"
+)
 
-var vacuumCollectionRootDescriptorPrefixBytes = []byte(vacuumCollectionRootDescriptorPrefix)
+var (
+	vacuumCollectionRootDescriptorPrefixBytes        = []byte(vacuumCollectionRootDescriptorPrefix)
+	vacuumCollectionRootOverlayDescriptorPrefixBytes = []byte(vacuumCollectionRootOverlayDescriptorPrefix)
+)
 
 type vacuumCollectionRootDescriptor struct {
-	key    []byte
-	rootID uint64
+	key       []byte
+	rootID    uint64
+	rootIDs   []uint64
+	rootIndex int
 }
 
 type vacuumCollectionRootReplacement struct {
@@ -45,7 +53,15 @@ type vacuumUnsafeAppendReader interface {
 }
 
 func vacuumCollectionRootDescriptorPrefixEnd() []byte {
-	out := append([]byte(nil), vacuumCollectionRootDescriptorPrefixBytes...)
+	return vacuumDescriptorPrefixEnd(vacuumCollectionRootDescriptorPrefixBytes)
+}
+
+func vacuumCollectionRootOverlayDescriptorPrefixEnd() []byte {
+	return vacuumDescriptorPrefixEnd(vacuumCollectionRootOverlayDescriptorPrefixBytes)
+}
+
+func vacuumDescriptorPrefixEnd(prefix []byte) []byte {
+	out := append([]byte(nil), prefix...)
 	for i := len(out) - 1; i >= 0; i-- {
 		if out[i] != 0xff {
 			out[i]++
@@ -73,38 +89,79 @@ func vacuumCollectCollectionRootDescriptorsWithContext(ctx context.Context, p *p
 		return nil, err
 	}
 
-	it := tree.New(p, reader, systemRootID).IteratorWithOptions(vacuumCollectionRootDescriptorPrefixBytes, vacuumCollectionRootDescriptorPrefixEnd(), tree.IteratorOptions{
-		Mode: tree.IteratorModePointerProjection,
-	})
-	defer func() { _ = it.Close() }()
-
 	var out []vacuumCollectionRootDescriptor
 	var pointerScratch []byte
-	for it.Valid() {
-		if err := ctx.Err(); err != nil {
+	descriptorPrefixes := []struct {
+		prefix    []byte
+		end       []byte
+		allowList bool
+	}{
+		{prefix: vacuumCollectionRootDescriptorPrefixBytes, end: vacuumCollectionRootDescriptorPrefixEnd()},
+		{prefix: vacuumCollectionRootOverlayDescriptorPrefixBytes, end: vacuumCollectionRootOverlayDescriptorPrefixEnd(), allowList: true},
+	}
+	for _, descriptorPrefix := range descriptorPrefixes {
+		it := tree.New(p, reader, systemRootID).IteratorWithOptions(descriptorPrefix.prefix, descriptorPrefix.end, tree.IteratorOptions{
+			Mode: tree.IteratorModePointerProjection,
+		})
+		for it.Valid() {
+			if err := ctx.Err(); err != nil {
+				_ = it.Close()
+				return nil, err
+			}
+			key := it.UnsafeKey()
+			if !bytes.HasPrefix(key, descriptorPrefix.prefix) {
+				break
+			}
+			val, ptr, flags := it.UnsafeEntry()
+			var err error
+			val, pointerScratch, err = vacuumCollectionRootDescriptorValue(reader, key, val, ptr, flags, pointerScratch)
+			if err != nil {
+				_ = it.Close()
+				return nil, err
+			}
+			rootIDs, err := decodeCollectionRootDescriptorRootIDs(key, val, descriptorPrefix.allowList)
+			if err != nil {
+				_ = it.Close()
+				return nil, err
+			}
+			keyCopy := append([]byte(nil), key...)
+			for i, rootID := range rootIDs {
+				out = append(out, vacuumCollectionRootDescriptor{
+					key:       keyCopy,
+					rootID:    rootID,
+					rootIDs:   append([]uint64(nil), rootIDs...),
+					rootIndex: i,
+				})
+			}
+			it.Next()
+		}
+		if err := it.Error(); err != nil {
+			_ = it.Close()
 			return nil, err
 		}
-		key := it.UnsafeKey()
-		if !bytes.HasPrefix(key, vacuumCollectionRootDescriptorPrefixBytes) {
-			break
-		}
-		val, ptr, flags := it.UnsafeEntry()
-		var err error
-		val, pointerScratch, err = vacuumCollectionRootDescriptorValue(reader, key, val, ptr, flags, pointerScratch)
-		if err != nil {
+		if err := it.Close(); err != nil {
 			return nil, err
 		}
+	}
+	return out, nil
+}
+
+func decodeCollectionRootDescriptorRootIDs(key, val []byte, allowList bool) ([]uint64, error) {
+	if len(val) == 0 && allowList {
+		return nil, nil
+	}
+	if !allowList {
 		if len(val) != 8 {
 			return nil, fmt.Errorf("vacuum: collection root descriptor %q has malformed root id length %d", string(key), len(val))
 		}
-		out = append(out, vacuumCollectionRootDescriptor{
-			key:    append([]byte(nil), key...),
-			rootID: binary.BigEndian.Uint64(val),
-		})
-		it.Next()
+		return []uint64{binary.BigEndian.Uint64(val)}, nil
 	}
-	if err := it.Error(); err != nil {
-		return nil, err
+	if len(val)%8 != 0 {
+		return nil, fmt.Errorf("vacuum: collection root overlay descriptor %q has malformed root id list length %d", string(key), len(val))
+	}
+	out := make([]uint64, len(val)/8)
+	for i := range out {
+		out[i] = binary.BigEndian.Uint64(val[i*8 : (i+1)*8])
 	}
 	return out, nil
 }
@@ -159,9 +216,23 @@ func vacuumRewriteCollectionRootDescriptors(descriptors []vacuumCollectionRootDe
 		return nil, errors.New(errPrefix + ": missing rewrite function")
 	}
 
-	replacements := make([]vacuumCollectionRootReplacement, 0, len(descriptors))
 	rootRemap := make(map[uint64]uint64, len(descriptors))
+	type descriptorRewriteState struct {
+		key     []byte
+		rootIDs []uint64
+		changed bool
+	}
+	statesByKey := make(map[string]*descriptorRewriteState, len(descriptors))
 	for _, descriptor := range descriptors {
+		key := string(descriptor.key)
+		state := statesByKey[key]
+		if state == nil {
+			state = &descriptorRewriteState{
+				key:     append([]byte(nil), descriptor.key...),
+				rootIDs: append([]uint64(nil), descriptor.rootIDs...),
+			}
+			statesByKey[key] = state
+		}
 		oldRoot := descriptor.rootID
 		newRoot := oldRoot
 		if oldRoot != 0 {
@@ -177,11 +248,22 @@ func vacuumRewriteCollectionRootDescriptors(descriptors []vacuumCollectionRootDe
 			}
 		}
 		if newRoot != oldRoot {
-			replacements = append(replacements, vacuumCollectionRootReplacement{
-				key:   descriptor.key,
-				value: encodeCollectionRootDescriptorRootID(newRoot),
-			})
+			if descriptor.rootIndex < 0 || descriptor.rootIndex >= len(state.rootIDs) {
+				return nil, fmt.Errorf("%s %q: malformed descriptor root index %d", errPrefix, string(descriptor.key), descriptor.rootIndex)
+			}
+			state.rootIDs[descriptor.rootIndex] = newRoot
+			state.changed = true
 		}
+	}
+	replacements := make([]vacuumCollectionRootReplacement, 0, len(statesByKey))
+	for _, state := range statesByKey {
+		if !state.changed {
+			continue
+		}
+		replacements = append(replacements, vacuumCollectionRootReplacement{
+			key:   state.key,
+			value: encodeCollectionRootDescriptorRootIDs(state.rootIDs),
+		})
 	}
 	if len(replacements) == 0 {
 		return nil, nil
@@ -195,6 +277,17 @@ func vacuumRewriteCollectionRootDescriptors(descriptors []vacuumCollectionRootDe
 func encodeCollectionRootDescriptorRootID(rootID uint64) []byte {
 	encoded := make([]byte, 8)
 	binary.BigEndian.PutUint64(encoded, rootID)
+	return encoded
+}
+
+func encodeCollectionRootDescriptorRootIDs(rootIDs []uint64) []byte {
+	if len(rootIDs) == 1 {
+		return encodeCollectionRootDescriptorRootID(rootIDs[0])
+	}
+	encoded := make([]byte, len(rootIDs)*8)
+	for i, rootID := range rootIDs {
+		binary.BigEndian.PutUint64(encoded[i*8:(i+1)*8], rootID)
+	}
 	return encoded
 }
 
@@ -306,9 +399,6 @@ func (it *vacuumSystemRootRewriteIterator) replacement() ([]byte, bool) {
 		return nil, false
 	}
 	key := it.base.UnsafeKey()
-	if !bytes.HasPrefix(key, vacuumCollectionRootDescriptorPrefixBytes) {
-		return nil, false
-	}
 	idx := sort.Search(len(it.replacements), func(i int) bool {
 		return bytes.Compare(it.replacements[i].key, key) >= 0
 	})

--- a/TreeDB/db/vacuum_collection_roots_test.go
+++ b/TreeDB/db/vacuum_collection_roots_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"reflect"
 	"runtime"
 	"testing"
 
@@ -56,6 +57,35 @@ func TestVacuumIndexOnline_PreservesCollectionRootFromPointerBackedDescriptor(t 
 		t.Fatalf("vacuum online: %v", err)
 	}
 	verifyVacuumCollectionRootDescriptor(t, d, vacuumTestCollectionRootKey)
+}
+
+func TestVacuumRewriteCollectionRootDescriptorsRewritesOverlayLists(t *testing.T) {
+	key := []byte("collections/root-overlay/users/primary")
+	rootIDs := []uint64{3, 2}
+	descriptors := []vacuumCollectionRootDescriptor{
+		{key: key, rootID: 3, rootIDs: rootIDs, rootIndex: 0},
+		{key: key, rootID: 2, rootIDs: rootIDs, rootIndex: 1},
+	}
+	replacements, err := vacuumRewriteCollectionRootDescriptors(descriptors, func(descriptor vacuumCollectionRootDescriptor) (uint64, error) {
+		return descriptor.rootID + 100, nil
+	}, "test")
+	if err != nil {
+		t.Fatalf("rewrite descriptors: %v", err)
+	}
+	if len(replacements) != 1 {
+		t.Fatalf("replacements=%d want 1", len(replacements))
+	}
+	if !bytes.Equal(replacements[0].key, key) {
+		t.Fatalf("replacement key=%q want %q", replacements[0].key, key)
+	}
+	got, err := decodeCollectionRootDescriptorRootIDs(key, replacements[0].value, true)
+	if err != nil {
+		t.Fatalf("decode replacement: %v", err)
+	}
+	want := []uint64{103, 102}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("replacement root ids=%v want %v", got, want)
+	}
 }
 
 func vacuumPointerDescriptorOptions(dir string) Options {


### PR DESCRIPTION
## Summary
- add durable `collections/root-overlay/<root>` catalog descriptors and load them into collection catalogs
- merge overlay roots above base collection roots for primary reads, scans, secondary index reads, unique checks, delete/update state reads, and create-index backfill
- make maintenance roots, collection-aware vacuum, and ordered-root value-log reachability tracking aware of overlay root descriptor lists
- deliberately reject ordinary collection writes/schema mutations while overlay roots are present until the follow-up overlay compaction/write path lands

This is an architecture-only #1159 scaffold. It does not route indexed writes into overlay roots yet; it makes the durable representation readable and maintenance-safe first.

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCatalogOverlayRootsAreVisibleAfterReopen' -count 1`\n- `GOWORK=off go test ./TreeDB/collections -count 1`\n- `GOWORK=off go test ./TreeDB/db -run 'TestMaintenanceRoots_IncludesCollectionOverlayRootDescriptors|TestVacuumRewriteCollectionRootDescriptorsRewritesOverlayLists' -count 1`\n- `GOWORK=off go test ./TreeDB/db -count 1`\n- `GOWORK=off go test ./TreeDB/... -count 1`\n- `GOWORK=off go test ./cmd/mongo_gateway_bench -run '^$' -count 1`\n- `git diff --check`\n\n## Benchmark smoke\nSame command on branch and clean `origin/main` worktree:\n\n```bash\nMONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=1000000 \\\nMONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \\\nMONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \\\nMONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \\\nMONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \\\nGOWORK=off go test ./cmd/mongo_gateway_bench \\\n  -run '^$' \\\n  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \\\n  -benchtime=1000000x \\\n  -benchmem \\\n  -count=1\n```\n\nClean `origin/main` sample: `6860 ns/op`, `145779 docs/sec`, `2333 B/op`, `3 allocs/op`.\n\nThis branch samples after the no-overlay fast-path cleanup: `6745 ns/op`, `148263 docs/sec`, `2310 B/op`, `3 allocs/op`; another local run was `7991 ns/op`, `125143 docs/sec`, `2267 B/op`, `3 allocs/op`. The benchmark remains dominated by publish/root apply and leaf-log work; this scaffold is not expected to change that ceiling yet.\n\n## Follow-up\nNext PR should publish rotated indexed flush units into durable overlay root descriptors, then add overlay compaction into base roots once read/maintenance correctness is already covered here.