### PR TITLE
collections: add opt-in indexed flush overlay roots

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -538,6 +538,11 @@ type CollectionOptions struct {
 	// Flush, FlushAll, and backend Close still drain pending indexed writes before
 	// returning, but auto-flush thresholds no longer imply immediate durability.
 	BufferedIndexedAsyncFlush bool `json:"buffered_indexed_async_flush,omitempty"`
+	// BufferedIndexedOverlayRoots publishes indexed memtable flush units as
+	// durable overlay roots instead of immediately applying them into base roots.
+	// Maintenance can later compact overlay roots into base roots; reads merge
+	// overlay roots over base roots while they are pending.
+	BufferedIndexedOverlayRoots bool `json:"buffered_indexed_overlay_roots,omitempty"`
 	// BufferedIndexedAsyncFlushMaxQueuedUnits bounds immutable indexed flush
 	// units queued for the background publisher. Zero uses the native default
 	// when async flush is enabled on an indexed schema.
@@ -611,6 +616,7 @@ type indexedFlushPublishWork struct {
 	flushUnit      indexedFlushUnit
 	rootNames      []string
 	rootBaseIDs    map[string]uint64
+	rootOverlays   map[string][]uint64
 	docCount       int
 	byteCount      int64
 	rootRunCount   int
@@ -2249,7 +2255,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		if err != nil {
 			return nil, collectionOptions{}, false, err
 		}
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			return nil, collectionOptions{}, false, err
 		}
 		options, err := collectionPlannerOptions(catalog.meta)
@@ -2259,7 +2265,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		return catalog, options, len(catalog.meta.Indexes) > 0, nil
 	}
 	if domain.loaded && domain.count == 0 && domain.baseSystemRoot == currentSystemRoot && domain.baseCommitSeq == currentCommitSeq {
-		if err := rejectCatalogRootOverlaysForWrite(domain.catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(domain.catalog); err != nil {
 			return nil, collectionOptions{}, false, err
 		}
 		options, err := collectionPlannerOptions(domain.meta)
@@ -2276,7 +2282,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 	if catalog := cachedWriteDomainCatalogForStateLocked(domain, baseSystemRoot, baseCommitSeq); catalog != nil {
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			_ = snap.Close()
 			return nil, collectionOptions{}, false, err
 		}
@@ -2301,7 +2307,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		_ = snap.Close()
 		return nil, collectionOptions{}, false, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		_ = snap.Close()
 		return nil, collectionOptions{}, false, err
 	}
@@ -2351,7 +2357,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	if catalog == nil {
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		return nil, err
 	}
 	if !sameCollectionMeta(catalog.meta, domain.meta) {
@@ -2364,12 +2370,18 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 			if rootID := catalog.rootID(rootName); rootID != baseRootID {
 				return errConcurrentRootModification(domain.meta.Name, rootName)
 			}
+			if !uint64SlicesEqual(catalog.overlayRootIDs(rootName), domain.catalog.overlayRootIDs(rootName)) {
+				return errConcurrentRootModification(domain.meta.Name, rootName)
+			}
 			return nil
 		}); err != nil {
 			return nil, err
 		}
 	} else {
 		if rootID := catalog.rootID(primaryRootName); rootID != domain.primaryRoot {
+			return nil, errConcurrentRootModification(domain.meta.Name, primaryRootName)
+		}
+		if !uint64SlicesEqual(catalog.overlayRootIDs(primaryRootName), domain.catalog.overlayRootIDs(primaryRootName)) {
 			return nil, errConcurrentRootModification(domain.meta.Name, primaryRootName)
 		}
 	}
@@ -4378,6 +4390,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		return nil, nil
 	}
 	rootBaseIDs := make(map[string]uint64, len(rootNames))
+	rootOverlays := make(map[string][]uint64, len(rootNames))
 	for _, rootName := range rootNames {
 		baseRoot, ok := flushUnit.rootBaseIDs[rootName]
 		if !ok {
@@ -4385,6 +4398,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 			return nil, err
 		}
 		rootBaseIDs[rootName] = baseRoot
+		rootOverlays[rootName] = append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
 	}
 	work.baseSystemRoot = snapshotSystemRoot(pin)
 	work.baseCommitSeq = snapshotCommitSeq(pin)
@@ -4392,6 +4406,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 	work.flushUnit = flushUnit
 	work.rootNames = rootNames
 	work.rootBaseIDs = rootBaseIDs
+	work.rootOverlays = rootOverlays
 	work.docCount = flushUnit.docCount
 	work.byteCount = flushUnit.byteCount
 	work.rootRunCount = indexedFlushUnitRootRunCount(flushUnit)
@@ -4412,6 +4427,26 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 			_ = work.pin.Close()
 		}
 	}()
+	if collectionMetaUsesIndexedOverlayRoots(work.meta) {
+		ordered, cleanupIters, err := buildBufferedRootOverlayDeltaPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
+		if err != nil {
+			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+		}
+		publishStart := time.Now()
+		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootOverlayDescriptorSystemIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
+		})
+		publishElapsed := time.Since(publishStart)
+		cleanupIters()
+		if publishErr == nil && len(rootIDs) != len(work.rootNames) {
+			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
+		}
+		completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, publishElapsed)
+		if publishErr != nil {
+			return publishErr
+		}
+		return completeErr
+	}
 	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
 	if err != nil {
 		return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
@@ -4430,6 +4465,33 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		return publishErr
 	}
 	return completeErr
+}
+
+func buildBufferedRootOverlayDeltaPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy, rootOverlays map[string][]uint64) ([]backenddb.OrderedRootDeltaPublishInput, func(), error) {
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	cleanup := func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+	}
+	for _, rootName := range rootNames {
+		iter := newBufferedRootRunsIteratorWithDeleted(rootRuns[rootName], nil, nil, true)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot:      overlayDeltaBaseRoot(rootOverlays[rootName]),
+			Iter:          iter,
+			StoragePolicy: rootPolicies[rootName],
+		})
+	}
+	return ordered, cleanup, nil
+}
+
+func overlayDeltaBaseRoot(overlays []uint64) uint64 {
+	if len(overlays) == 1 {
+		return overlays[0]
+	}
+	return 0
 }
 
 func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootBaseIDs map[string]uint64, rootPolicies map[string]backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
@@ -4527,7 +4589,11 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	if baseCatalog == nil {
 		baseCatalog = work.catalog
 	}
+	overlayPublish := collectionMetaUsesIndexedOverlayRoots(work.meta)
 	nextCatalog := cloneCatalogWithRootUpdates(baseCatalog, work.meta, work.rootNames, rootIDs)
+	if overlayPublish {
+		nextCatalog = cloneCatalogWithRootOverlays(baseCatalog, work.meta, work.rootNames, rootIDs)
+	}
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
 		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
@@ -4543,7 +4609,9 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	domain.count = subtractNonNegativeInt(domain.count, work.docCount)
 	domain.bufferedBytes = subtractNonNegativeInt64(domain.bufferedBytes, work.byteCount)
 	domain.clearIndexedAsyncFlushError()
-	retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
+	if !overlayPublish {
+		retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
+	}
 	rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
 	c.meta = work.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
@@ -4617,21 +4685,36 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
 	baseRootIDs := make(map[string]uint64, len(rootNames))
+	rootOverlays := make(map[string][]uint64, len(rootNames))
 	for _, rootName := range rootNames {
 		baseRoot, ok := flushUnit.rootBaseIDs[rootName]
 		if !ok {
 			return fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
 		}
 		baseRootIDs[rootName] = baseRoot
+		rootOverlays[rootName] = append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
 	}
-	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
-	if err != nil {
-		return err
+	var newSystemRoot uint64
+	var rootIDs []uint64
+	if collectionMetaUsesIndexedOverlayRoots(meta) {
+		ordered, cleanupIters, err := buildBufferedRootOverlayDeltaPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
+		if err != nil {
+			return err
+		}
+		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootOverlayDescriptorSystemIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+		})
+		cleanupIters()
+	} else {
+		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
+		if err != nil {
+			return err
+		}
+		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		})
+		cleanupDeltas()
 	}
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
-	})
-	cleanupDeltas()
 	if err != nil {
 		return err
 	}
@@ -4639,6 +4722,9 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		return unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(domain.catalog, meta, rootNames, rootIDs)
+	if collectionMetaUsesIndexedOverlayRoots(meta) {
+		nextCatalog = cloneCatalogWithRootOverlays(domain.catalog, meta, rootNames, rootIDs)
+	}
 	oldUnits := domain.indexedFlushUnits
 	oldRuns := domain.rootRuns
 	domain.loaded = true
@@ -5082,7 +5168,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		closePlanningSnapshot()
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		closePlanningSnapshot()
 		return nil, err
 	}
@@ -5119,7 +5205,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			closePlanningSnapshot()
 			return nil, errCollectionNotFound
 		}
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			closePlanningSnapshot()
 			return nil, err
 		}
@@ -5206,6 +5292,11 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		plan.stats.Publish += bufferFlushElapsed
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
 		return resultIDs, nil
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		closePlanningSnapshot()
+		resetCollectionRunTables(plan.runs)
+		return nil, err
 	}
 
 	pin, currentCatalog, pinCommitSeq, pinSystemRoot, err := c.lockAndValidateInsertBatchPlan(&mutationLocked, &unlockMutation, snap, catalog, meta, rootNames, baseRootIDs, plan)
@@ -7507,7 +7598,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		_ = snap.Close()
 		return nil, err
 	}
@@ -7563,7 +7654,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		indexStateRootName = collectionIndexStateRootName(meta.Name)
 	}
 	primaryRoot := catalog.rootID(primaryRootName)
-	if primaryRoot == 0 && !bufferedRead.enabled {
+	if primaryRoot == 0 && !bufferedRead.enabled && len(catalog.overlayRootIDs(primaryRootName)) == 0 {
 		plan := newUpdateBatchPlan()
 		*plan = updateBatchPlan{
 			results:                results,
@@ -7633,6 +7724,14 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	for i, item := range items {
 		phaseStart := updateBatchStatsNow(detailedStats)
 		current, err := readUpdateBatchCurrentDocument(&primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
+		if err == nil && !current.buffered && len(catalog.overlayRootIDs(primaryRootName)) != 0 {
+			value, found, overlayErr := collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, item.DocumentID, currentScratch[:0])
+			if overlayErr != nil {
+				err = overlayErr
+			} else {
+				current = updateBatchCurrentDocument{value: value, found: found}
+			}
+		}
 		stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()
@@ -7999,6 +8098,9 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	}
 	if len(plan.deltaTables) == 0 {
 		return plan.results, nil
+	}
+	if err := rejectCatalogRootOverlaysForWrite(plan.catalog); err != nil {
+		return nil, err
 	}
 	if len(plan.rootNames) != len(plan.deltaTables) || len(plan.rootNames) != len(plan.policies) {
 		return nil, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
@@ -8659,6 +8761,28 @@ func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, r
 	return newCollectionCatalogWithOverlays(copyCollectionMeta(meta), roots, rootOverlays)
 }
 
+func cloneCatalogWithRootOverlays(base *collectionCatalog, meta CollectionMeta, rootNames []string, rootIDs []uint64) *collectionCatalog {
+	roots := make(map[string]uint64)
+	var rootOverlays map[string][]uint64
+	if base != nil {
+		for name, rootID := range base.roots {
+			roots[name] = rootID
+		}
+		rootOverlays = cloneRootOverlayMap(base.rootOverlays)
+	}
+	if rootOverlays == nil {
+		rootOverlays = make(map[string][]uint64)
+	}
+	for i, name := range rootNames {
+		if i >= len(rootIDs) || rootIDs[i] == 0 {
+			continue
+		}
+		existing := rootOverlays[name]
+		rootOverlays[name] = overlayDescriptorRootsAfterDelta(existing, rootIDs[i])
+	}
+	return newCollectionCatalogWithOverlays(copyCollectionMeta(meta), roots, rootOverlays)
+}
+
 func newCollectionCatalog(meta CollectionMeta, roots map[string]uint64) *collectionCatalog {
 	return newCollectionCatalogWithOverlays(meta, roots, nil)
 }
@@ -8703,6 +8827,17 @@ func rejectCatalogRootOverlaysForWrite(catalog *collectionCatalog) error {
 		return nil
 	}
 	return errCollectionRootOverlaysRequireCompaction
+}
+
+func rejectCatalogRootOverlaysForIndexedBufferWrite(catalog *collectionCatalog) error {
+	if catalog == nil || len(catalog.rootOverlays) == 0 || collectionMetaUsesIndexedOverlayRoots(catalog.meta) {
+		return nil
+	}
+	return errCollectionRootOverlaysRequireCompaction
+}
+
+func collectionMetaUsesIndexedOverlayRoots(meta CollectionMeta) bool {
+	return meta.Options.BufferedIndexedOverlayRoots && meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
 }
 
 func (c *collectionCatalog) cachedIndexRuntimes() ([]indexRuntime, error) {
@@ -8963,6 +9098,43 @@ func (c *Collection) buildRootDescriptorSystemDeltaIteratorForMeta(meta Collecti
 	return buildSystemDeltaIterator(updates)
 }
 
+func (c *Collection) buildRootOverlayDescriptorSystemIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	if c == nil || c.db == nil {
+		return nil, backenddb.ErrClosed
+	}
+	if len(rootIDs) != len(rootNames) {
+		return nil, unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
+	}
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	if err := c.validateRootOverlayDescriptorSnapshotForMeta(current, meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs, expectedOverlays); err != nil {
+		return nil, err
+	}
+	updates := make(map[string][]byte, len(rootNames))
+	for i, rootName := range rootNames {
+		existing := expectedOverlays[rootName]
+		overlays := overlayDescriptorRootsAfterDelta(existing, rootIDs[i])
+		updates[systemCollectionRootOverlayKey(rootName)] = encodeRootIDList(overlays)
+	}
+	return buildSystemTargetIterator(current, updates)
+}
+
+func overlayDescriptorRootsAfterDelta(existing []uint64, newRoot uint64) []uint64 {
+	if newRoot == 0 {
+		return append([]uint64(nil), existing...)
+	}
+	if len(existing) <= 1 {
+		return []uint64{newRoot}
+	}
+	overlays := make([]uint64, 0, len(existing)+1)
+	overlays = append(overlays, newRoot)
+	overlays = append(overlays, existing...)
+	return overlays
+}
+
 func (c *Collection) validateRootDescriptorSystemDelta(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64) error {
 	if c == nil || c.db == nil {
 		return backenddb.ErrClosed
@@ -9004,6 +9176,55 @@ func (c *Collection) validateRootDescriptorSystemDeltaForMeta(meta CollectionMet
 		}
 	}
 	return nil
+}
+
+func (c *Collection) validateRootOverlayDescriptorSnapshotForMeta(snap *backenddb.Snapshot, meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64) error {
+	if snap == nil {
+		return backenddb.ErrClosed
+	}
+	if snap.State() == nil {
+		return backenddb.ErrClosed
+	}
+	// A raw TreeDB user-root commit does not change collection descriptors, and
+	// unrelated collection commits should not block this collection. Validate the
+	// descriptor contents directly instead of relying only on commit sequence.
+	_ = expectedCommitSeq
+	_ = expectedSystemRoot
+	catalog, err := loadCollectionCatalog(snap, meta.Name)
+	if err != nil {
+		return err
+	}
+	if catalog == nil {
+		return errCollectionNotFound
+	}
+	if !sameCollectionMeta(catalog.meta, meta) {
+		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
+	}
+	for _, rootName := range rootNames {
+		wantRoot, ok := baseRootIDs[rootName]
+		if !ok {
+			return fmt.Errorf("collections: missing base root for collection %q root %q", meta.Name, rootName)
+		}
+		if got := catalog.rootID(rootName); got != wantRoot {
+			return errConcurrentRootModification(meta.Name, rootName)
+		}
+		if !uint64SlicesEqual(catalog.overlayRootIDs(rootName), expectedOverlays[rootName]) {
+			return errConcurrentRootModification(meta.Name, rootName)
+		}
+	}
+	return nil
+}
+
+func uint64SlicesEqual(left, right []uint64) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *Collection) validateMutationRootDescriptors(expectedUserRoot, expectedSystemRoot, expectedCommitSeq uint64) error {
@@ -10582,6 +10803,7 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		meta.Options.BufferedIndexedWriteMaxBytes = 0
 		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
 		meta.Options.BufferedIndexedAsyncFlush = false
+		meta.Options.BufferedIndexedOverlayRoots = false
 		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
 	} else if len(meta.Indexes) == 0 {
 		meta.Options.BufferedIndexedWrites = false
@@ -10729,6 +10951,27 @@ func uniqueIndexRootIDs(catalog *collectionCatalog) map[string]uint64 {
 		}
 		rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
 		if rootID != 0 {
+			out[idx.Name] = rootID
+		}
+	}
+	return out
+}
+
+func uniqueIndexRootIDsOrOverlays(catalog *collectionCatalog) map[string]uint64 {
+	if catalog == nil {
+		return nil
+	}
+	out := make(map[string]uint64)
+	for _, idx := range catalog.meta.Indexes {
+		if !idx.Unique {
+			continue
+		}
+		rootName := collectionSecondaryRootName(catalog.meta.Name, idx.Name)
+		rootID := catalog.rootID(rootName)
+		if rootID != 0 || len(catalog.overlayRootIDs(rootName)) != 0 {
+			if rootID == 0 {
+				rootID = 1
+			}
 			out[idx.Name] = rootID
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -538,6 +538,11 @@ type CollectionOptions struct {
 	// Flush, FlushAll, and backend Close still drain pending indexed writes before
 	// returning, but auto-flush thresholds no longer imply immediate durability.
 	BufferedIndexedAsyncFlush bool `json:"buffered_indexed_async_flush,omitempty"`
+	// BufferedIndexedOverlayRoots publishes indexed memtable flush units as
+	// durable overlay roots instead of immediately applying them into base roots.
+	// Maintenance can later compact overlay roots into base roots; reads merge
+	// overlay roots over base roots while they are pending.
+	BufferedIndexedOverlayRoots bool `json:"buffered_indexed_overlay_roots,omitempty"`
 	// BufferedIndexedAsyncFlushMaxQueuedUnits bounds immutable indexed flush
 	// units queued for the background publisher. Zero uses the native default
 	// when async flush is enabled on an indexed schema.
@@ -611,6 +616,7 @@ type indexedFlushPublishWork struct {
 	flushUnit      indexedFlushUnit
 	rootNames      []string
 	rootBaseIDs    map[string]uint64
+	rootOverlays   map[string][]uint64
 	docCount       int
 	byteCount      int64
 	rootRunCount   int
@@ -2249,7 +2255,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		if err != nil {
 			return nil, collectionOptions{}, false, err
 		}
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			return nil, collectionOptions{}, false, err
 		}
 		options, err := collectionPlannerOptions(catalog.meta)
@@ -2259,7 +2265,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		return catalog, options, len(catalog.meta.Indexes) > 0, nil
 	}
 	if domain.loaded && domain.count == 0 && domain.baseSystemRoot == currentSystemRoot && domain.baseCommitSeq == currentCommitSeq {
-		if err := rejectCatalogRootOverlaysForWrite(domain.catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(domain.catalog); err != nil {
 			return nil, collectionOptions{}, false, err
 		}
 		options, err := collectionPlannerOptions(domain.meta)
@@ -2276,7 +2282,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 	if catalog := cachedWriteDomainCatalogForStateLocked(domain, baseSystemRoot, baseCommitSeq); catalog != nil {
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			_ = snap.Close()
 			return nil, collectionOptions{}, false, err
 		}
@@ -2301,7 +2307,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		_ = snap.Close()
 		return nil, collectionOptions{}, false, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		_ = snap.Close()
 		return nil, collectionOptions{}, false, err
 	}
@@ -2351,7 +2357,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	if catalog == nil {
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		return nil, err
 	}
 	if !sameCollectionMeta(catalog.meta, domain.meta) {
@@ -2364,12 +2370,18 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 			if rootID := catalog.rootID(rootName); rootID != baseRootID {
 				return errConcurrentRootModification(domain.meta.Name, rootName)
 			}
+			if !uint64SlicesEqual(catalog.overlayRootIDs(rootName), domain.catalog.overlayRootIDs(rootName)) {
+				return errConcurrentRootModification(domain.meta.Name, rootName)
+			}
 			return nil
 		}); err != nil {
 			return nil, err
 		}
 	} else {
 		if rootID := catalog.rootID(primaryRootName); rootID != domain.primaryRoot {
+			return nil, errConcurrentRootModification(domain.meta.Name, primaryRootName)
+		}
+		if !uint64SlicesEqual(catalog.overlayRootIDs(primaryRootName), domain.catalog.overlayRootIDs(primaryRootName)) {
 			return nil, errConcurrentRootModification(domain.meta.Name, primaryRootName)
 		}
 	}
@@ -4378,6 +4390,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		return nil, nil
 	}
 	rootBaseIDs := make(map[string]uint64, len(rootNames))
+	rootOverlays := make(map[string][]uint64, len(rootNames))
 	for _, rootName := range rootNames {
 		baseRoot, ok := flushUnit.rootBaseIDs[rootName]
 		if !ok {
@@ -4385,6 +4398,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 			return nil, err
 		}
 		rootBaseIDs[rootName] = baseRoot
+		rootOverlays[rootName] = append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
 	}
 	work.baseSystemRoot = snapshotSystemRoot(pin)
 	work.baseCommitSeq = snapshotCommitSeq(pin)
@@ -4392,6 +4406,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 	work.flushUnit = flushUnit
 	work.rootNames = rootNames
 	work.rootBaseIDs = rootBaseIDs
+	work.rootOverlays = rootOverlays
 	work.docCount = flushUnit.docCount
 	work.byteCount = flushUnit.byteCount
 	work.rootRunCount = indexedFlushUnitRootRunCount(flushUnit)
@@ -4412,6 +4427,26 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 			_ = work.pin.Close()
 		}
 	}()
+	if collectionMetaUsesIndexedOverlayRoots(work.meta) {
+		ordered, cleanupIters, err := buildBufferedRootOverlayPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies)
+		if err != nil {
+			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+		}
+		publishStart := time.Now()
+		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootOverlayDescriptorSystemIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
+		})
+		publishElapsed := time.Since(publishStart)
+		cleanupIters()
+		if publishErr == nil && len(rootIDs) != len(work.rootNames) {
+			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
+		}
+		completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, publishElapsed)
+		if publishErr != nil {
+			return publishErr
+		}
+		return completeErr
+	}
 	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
 	if err != nil {
 		return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
@@ -4430,6 +4465,26 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		return publishErr
 	}
 	return completeErr
+}
+
+func buildBufferedRootOverlayPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootPublishInput, func(), error) {
+	ordered := make([]backenddb.OrderedRootPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	cleanup := func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+	}
+	for _, rootName := range rootNames {
+		iter := newBufferedRootRunsIteratorWithDeleted(rootRuns[rootName], nil, nil, true)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootPublishInput{
+			BaseRoot:      0,
+			Iter:          iter,
+			StoragePolicy: rootPolicies[rootName],
+		})
+	}
+	return ordered, cleanup, nil
 }
 
 func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootBaseIDs map[string]uint64, rootPolicies map[string]backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
@@ -4527,7 +4582,11 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	if baseCatalog == nil {
 		baseCatalog = work.catalog
 	}
+	overlayPublish := collectionMetaUsesIndexedOverlayRoots(work.meta)
 	nextCatalog := cloneCatalogWithRootUpdates(baseCatalog, work.meta, work.rootNames, rootIDs)
+	if overlayPublish {
+		nextCatalog = cloneCatalogWithRootOverlays(baseCatalog, work.meta, work.rootNames, rootIDs)
+	}
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
 		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
@@ -4543,7 +4602,9 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	domain.count = subtractNonNegativeInt(domain.count, work.docCount)
 	domain.bufferedBytes = subtractNonNegativeInt64(domain.bufferedBytes, work.byteCount)
 	domain.clearIndexedAsyncFlushError()
-	retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
+	if !overlayPublish {
+		retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
+	}
 	rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
 	c.meta = work.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
@@ -4617,21 +4678,36 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
 	baseRootIDs := make(map[string]uint64, len(rootNames))
+	rootOverlays := make(map[string][]uint64, len(rootNames))
 	for _, rootName := range rootNames {
 		baseRoot, ok := flushUnit.rootBaseIDs[rootName]
 		if !ok {
 			return fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
 		}
 		baseRootIDs[rootName] = baseRoot
+		rootOverlays[rootName] = append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
 	}
-	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
-	if err != nil {
-		return err
+	var newSystemRoot uint64
+	var rootIDs []uint64
+	if collectionMetaUsesIndexedOverlayRoots(meta) {
+		ordered, cleanupIters, err := buildBufferedRootOverlayPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies)
+		if err != nil {
+			return err
+		}
+		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootOverlayDescriptorSystemIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+		})
+		cleanupIters()
+	} else {
+		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
+		if err != nil {
+			return err
+		}
+		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		})
+		cleanupDeltas()
 	}
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
-	})
-	cleanupDeltas()
 	if err != nil {
 		return err
 	}
@@ -4639,6 +4715,9 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		return unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(domain.catalog, meta, rootNames, rootIDs)
+	if collectionMetaUsesIndexedOverlayRoots(meta) {
+		nextCatalog = cloneCatalogWithRootOverlays(domain.catalog, meta, rootNames, rootIDs)
+	}
 	oldUnits := domain.indexedFlushUnits
 	oldRuns := domain.rootRuns
 	domain.loaded = true
@@ -5082,7 +5161,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		closePlanningSnapshot()
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		closePlanningSnapshot()
 		return nil, err
 	}
@@ -5119,7 +5198,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			closePlanningSnapshot()
 			return nil, errCollectionNotFound
 		}
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			closePlanningSnapshot()
 			return nil, err
 		}
@@ -5206,6 +5285,11 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		plan.stats.Publish += bufferFlushElapsed
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
 		return resultIDs, nil
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		closePlanningSnapshot()
+		resetCollectionRunTables(plan.runs)
+		return nil, err
 	}
 
 	pin, currentCatalog, pinCommitSeq, pinSystemRoot, err := c.lockAndValidateInsertBatchPlan(&mutationLocked, &unlockMutation, snap, catalog, meta, rootNames, baseRootIDs, plan)
@@ -7507,7 +7591,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		_ = snap.Close()
 		return nil, err
 	}
@@ -7563,7 +7647,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		indexStateRootName = collectionIndexStateRootName(meta.Name)
 	}
 	primaryRoot := catalog.rootID(primaryRootName)
-	if primaryRoot == 0 && !bufferedRead.enabled {
+	if primaryRoot == 0 && !bufferedRead.enabled && len(catalog.overlayRootIDs(primaryRootName)) == 0 {
 		plan := newUpdateBatchPlan()
 		*plan = updateBatchPlan{
 			results:                results,
@@ -7633,6 +7717,14 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	for i, item := range items {
 		phaseStart := updateBatchStatsNow(detailedStats)
 		current, err := readUpdateBatchCurrentDocument(&primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
+		if err == nil && !current.buffered && len(catalog.overlayRootIDs(primaryRootName)) != 0 {
+			value, found, overlayErr := collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, item.DocumentID, currentScratch[:0])
+			if overlayErr != nil {
+				err = overlayErr
+			} else {
+				current = updateBatchCurrentDocument{value: value, found: found}
+			}
+		}
 		stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()
@@ -7999,6 +8091,9 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	}
 	if len(plan.deltaTables) == 0 {
 		return plan.results, nil
+	}
+	if err := rejectCatalogRootOverlaysForWrite(plan.catalog); err != nil {
+		return nil, err
 	}
 	if len(plan.rootNames) != len(plan.deltaTables) || len(plan.rootNames) != len(plan.policies) {
 		return nil, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
@@ -8659,6 +8754,31 @@ func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, r
 	return newCollectionCatalogWithOverlays(copyCollectionMeta(meta), roots, rootOverlays)
 }
 
+func cloneCatalogWithRootOverlays(base *collectionCatalog, meta CollectionMeta, rootNames []string, rootIDs []uint64) *collectionCatalog {
+	roots := make(map[string]uint64)
+	var rootOverlays map[string][]uint64
+	if base != nil {
+		for name, rootID := range base.roots {
+			roots[name] = rootID
+		}
+		rootOverlays = cloneRootOverlayMap(base.rootOverlays)
+	}
+	if rootOverlays == nil {
+		rootOverlays = make(map[string][]uint64)
+	}
+	for i, name := range rootNames {
+		if i >= len(rootIDs) || rootIDs[i] == 0 {
+			continue
+		}
+		existing := rootOverlays[name]
+		next := make([]uint64, 0, len(existing)+1)
+		next = append(next, rootIDs[i])
+		next = append(next, existing...)
+		rootOverlays[name] = next
+	}
+	return newCollectionCatalogWithOverlays(copyCollectionMeta(meta), roots, rootOverlays)
+}
+
 func newCollectionCatalog(meta CollectionMeta, roots map[string]uint64) *collectionCatalog {
 	return newCollectionCatalogWithOverlays(meta, roots, nil)
 }
@@ -8703,6 +8823,17 @@ func rejectCatalogRootOverlaysForWrite(catalog *collectionCatalog) error {
 		return nil
 	}
 	return errCollectionRootOverlaysRequireCompaction
+}
+
+func rejectCatalogRootOverlaysForIndexedBufferWrite(catalog *collectionCatalog) error {
+	if catalog == nil || len(catalog.rootOverlays) == 0 || collectionMetaUsesIndexedOverlayRoots(catalog.meta) {
+		return nil
+	}
+	return errCollectionRootOverlaysRequireCompaction
+}
+
+func collectionMetaUsesIndexedOverlayRoots(meta CollectionMeta) bool {
+	return meta.Options.BufferedIndexedOverlayRoots && meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
 }
 
 func (c *collectionCatalog) cachedIndexRuntimes() ([]indexRuntime, error) {
@@ -8963,6 +9094,32 @@ func (c *Collection) buildRootDescriptorSystemDeltaIteratorForMeta(meta Collecti
 	return buildSystemDeltaIterator(updates)
 }
 
+func (c *Collection) buildRootOverlayDescriptorSystemIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	if c == nil || c.db == nil {
+		return nil, backenddb.ErrClosed
+	}
+	if len(rootIDs) != len(rootNames) {
+		return nil, unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
+	}
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	if err := c.validateRootOverlayDescriptorSnapshotForMeta(current, meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs, expectedOverlays); err != nil {
+		return nil, err
+	}
+	updates := make(map[string][]byte, len(rootNames))
+	for i, rootName := range rootNames {
+		existing := expectedOverlays[rootName]
+		overlays := make([]uint64, 0, len(existing)+1)
+		overlays = append(overlays, rootIDs[i])
+		overlays = append(overlays, existing...)
+		updates[systemCollectionRootOverlayKey(rootName)] = encodeRootIDList(overlays)
+	}
+	return buildSystemTargetIterator(current, updates)
+}
+
 func (c *Collection) validateRootDescriptorSystemDelta(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64) error {
 	if c == nil || c.db == nil {
 		return backenddb.ErrClosed
@@ -9004,6 +9161,55 @@ func (c *Collection) validateRootDescriptorSystemDeltaForMeta(meta CollectionMet
 		}
 	}
 	return nil
+}
+
+func (c *Collection) validateRootOverlayDescriptorSnapshotForMeta(snap *backenddb.Snapshot, meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64) error {
+	if snap == nil {
+		return backenddb.ErrClosed
+	}
+	if snap.State() == nil {
+		return backenddb.ErrClosed
+	}
+	// A raw TreeDB user-root commit does not change collection descriptors, and
+	// unrelated collection commits should not block this collection. Validate the
+	// descriptor contents directly instead of relying only on commit sequence.
+	_ = expectedCommitSeq
+	_ = expectedSystemRoot
+	catalog, err := loadCollectionCatalog(snap, meta.Name)
+	if err != nil {
+		return err
+	}
+	if catalog == nil {
+		return errCollectionNotFound
+	}
+	if !sameCollectionMeta(catalog.meta, meta) {
+		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
+	}
+	for _, rootName := range rootNames {
+		wantRoot, ok := baseRootIDs[rootName]
+		if !ok {
+			return fmt.Errorf("collections: missing base root for collection %q root %q", meta.Name, rootName)
+		}
+		if got := catalog.rootID(rootName); got != wantRoot {
+			return errConcurrentRootModification(meta.Name, rootName)
+		}
+		if !uint64SlicesEqual(catalog.overlayRootIDs(rootName), expectedOverlays[rootName]) {
+			return errConcurrentRootModification(meta.Name, rootName)
+		}
+	}
+	return nil
+}
+
+func uint64SlicesEqual(left, right []uint64) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *Collection) validateMutationRootDescriptors(expectedUserRoot, expectedSystemRoot, expectedCommitSeq uint64) error {
@@ -10582,6 +10788,7 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		meta.Options.BufferedIndexedWriteMaxBytes = 0
 		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
 		meta.Options.BufferedIndexedAsyncFlush = false
+		meta.Options.BufferedIndexedOverlayRoots = false
 		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
 	} else if len(meta.Indexes) == 0 {
 		meta.Options.BufferedIndexedWrites = false
@@ -10729,6 +10936,27 @@ func uniqueIndexRootIDs(catalog *collectionCatalog) map[string]uint64 {
 		}
 		rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
 		if rootID != 0 {
+			out[idx.Name] = rootID
+		}
+	}
+	return out
+}
+
+func uniqueIndexRootIDsOrOverlays(catalog *collectionCatalog) map[string]uint64 {
+	if catalog == nil {
+		return nil
+	}
+	out := make(map[string]uint64)
+	for _, idx := range catalog.meta.Indexes {
+		if !idx.Unique {
+			continue
+		}
+		rootName := collectionSecondaryRootName(catalog.meta.Name, idx.Name)
+		rootID := catalog.rootID(rootName)
+		if rootID != 0 || len(catalog.overlayRootIDs(rootName)) != 0 {
+			if rootID == 0 {
+				rootID = 1
+			}
 			out[idx.Name] = rootID
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7227,6 +7227,16 @@ func (plan *updateBatchPlan) close() {
 	updateBatchPlanPool.Put(plan)
 }
 
+func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPlan) error {
+	if plan == nil {
+		return nil
+	}
+	if plan.catalog != nil && len(plan.catalog.rootOverlays) != 0 && collectionMetaUsesIndexedOverlayRoots(plan.catalog.meta) {
+		return c.validateRootOverlayDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, plan.catalog.rootOverlays)
+	}
+	return c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs)
+}
+
 func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMode) ([]UpdateBatchResult, error) {
 	if c.shouldPlanUpdateBatchWithBufferedWrites(mode) {
 		useBufferedRead := true
@@ -7261,7 +7271,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 						}
 						return ErrConcurrentMutation
 					}
-					if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
+					if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
 						return err
 					}
 					c.meta = plan.meta
@@ -7329,7 +7339,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 			if err := c.flushBufferedWrites(); err != nil {
 				return err
 			}
-			if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
+			if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
 				return err
 			}
 			c.meta = plan.meta
@@ -8218,7 +8228,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			return false, ErrConcurrentMutation
 		}
 	}
-	if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
+	if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
 		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 		return false, err
 	}
@@ -9176,6 +9186,18 @@ func (c *Collection) validateRootDescriptorSystemDeltaForMeta(meta CollectionMet
 		}
 	}
 	return nil
+}
+
+func (c *Collection) validateRootOverlayDescriptorSystemDeltaForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64) error {
+	if c == nil || c.db == nil {
+		return backenddb.ErrClosed
+	}
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	return c.validateRootOverlayDescriptorSnapshotForMeta(current, meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs, expectedOverlays)
 }
 
 func (c *Collection) validateRootOverlayDescriptorSnapshotForMeta(snap *backenddb.Snapshot, meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64) error {
@@ -10957,11 +10979,11 @@ func uniqueIndexRootIDs(catalog *collectionCatalog) map[string]uint64 {
 	return out
 }
 
-func uniqueIndexRootIDsOrOverlays(catalog *collectionCatalog) map[string]uint64 {
+func uniqueIndexNamesWithDataOrOverlays(catalog *collectionCatalog) map[string]struct{} {
 	if catalog == nil {
 		return nil
 	}
-	out := make(map[string]uint64)
+	out := make(map[string]struct{})
 	for _, idx := range catalog.meta.Indexes {
 		if !idx.Unique {
 			continue
@@ -10969,10 +10991,7 @@ func uniqueIndexRootIDsOrOverlays(catalog *collectionCatalog) map[string]uint64 
 		rootName := collectionSecondaryRootName(catalog.meta.Name, idx.Name)
 		rootID := catalog.rootID(rootName)
 		if rootID != 0 || len(catalog.overlayRootIDs(rootName)) != 0 {
-			if rootID == 0 {
-				rootID = 1
-			}
-			out[idx.Name] = rootID
+			out[idx.Name] = struct{}{}
 		}
 	}
 	return out

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2358,6 +2358,116 @@ func TestCollectionCatalogOverlayRootsAreVisibleAfterReopen(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if _, err := col.Insert([]byte("u2"), []byte(`{"email":"ada@example.com","city":"sea"}`)); !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("insert duplicate email err=%v want %v", err, ErrUniqueIndexConflict)
+	}
+	results, buffered, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"sea"}`), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("update city: %v", err)
+	}
+	if !buffered || len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("update results=%+v buffered=%v", results, buffered)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush overlays: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated doc: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("updated doc=%q want %q", got, want)
+	}
+	hnlIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find old city: %v", err)
+	}
+	if len(hnlIDs) != 0 {
+		t.Fatalf("old city ids=%q want none", hnlIDs)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find new city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("new city ids=%q want [u1]", seaIDs)
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog: %v", err)
+	}
+	if got := len(catalog.overlayRootIDs(collectionPrimaryRootName("users"))); got < 2 {
+		_ = snap.Close()
+		t.Fatalf("primary overlay roots=%d want at least 2", got)
+	}
+	_ = snap.Close()
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	reopenedDoc, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get reopened doc: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"sea"}`); !bytes.Equal(reopenedDoc, want) {
+		t.Fatalf("reopened doc=%q want %q", reopenedDoc, want)
+	}
+	reopenedSeaIDs, err := reopenedCol.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find reopened city: %v", err)
+	}
+	if len(reopenedSeaIDs) != 1 || !bytes.Equal(reopenedSeaIDs[0], []byte("u1")) {
+		t.Fatalf("reopened city ids=%q want [u1]", reopenedSeaIDs)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesReadFlushedDocumentWithBufferedRuns(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2358,6 +2358,116 @@ func TestCollectionCatalogOverlayRootsAreVisibleAfterReopen(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if _, err := col.Insert([]byte("u2"), []byte(`{"email":"ada@example.com","city":"sea"}`)); !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("insert duplicate email err=%v want %v", err, ErrUniqueIndexConflict)
+	}
+	results, buffered, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"sea"}`), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("update city: %v", err)
+	}
+	if !buffered || len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("update results=%+v buffered=%v", results, buffered)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush overlays: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated doc: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("updated doc=%q want %q", got, want)
+	}
+	hnlIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find old city: %v", err)
+	}
+	if len(hnlIDs) != 0 {
+		t.Fatalf("old city ids=%q want none", hnlIDs)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find new city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("new city ids=%q want [u1]", seaIDs)
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog: %v", err)
+	}
+	if got := len(catalog.overlayRootIDs(collectionPrimaryRootName("users"))); got != 1 {
+		_ = snap.Close()
+		t.Fatalf("primary overlay roots=%d want 1 coalesced overlay", got)
+	}
+	_ = snap.Close()
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	reopenedDoc, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get reopened doc: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"sea"}`); !bytes.Equal(reopenedDoc, want) {
+		t.Fatalf("reopened doc=%q want %q", reopenedDoc, want)
+	}
+	reopenedSeaIDs, err := reopenedCol.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find reopened city: %v", err)
+	}
+	if len(reopenedSeaIDs) != 1 || !bytes.Equal(reopenedSeaIDs[0], []byte("u1")) {
+		t.Fatalf("reopened city ids=%q want [u1]", reopenedSeaIDs)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesReadFlushedDocumentWithBufferedRuns(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2468,6 +2468,76 @@ func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t 
 	}
 }
 
+func TestCollectionIndexedOverlayRootValidationRejectsStaleOverlayDescriptors(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush u1: %v", err)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog: %v", err)
+	}
+	primaryRootName := collectionPrimaryRootName("users")
+	if got := len(catalog.overlayRootIDs(primaryRootName)); got != 1 {
+		_ = snap.Close()
+		t.Fatalf("primary overlay roots=%d want 1", got)
+	}
+	stalePlan := &updateBatchPlan{
+		meta:           catalog.meta,
+		catalog:        catalog,
+		baseCommitSeq:  snapshotCommitSeq(snap),
+		baseSystemRoot: snapshotSystemRoot(snap),
+		rootNames:      []string{primaryRootName},
+		baseRootIDs: map[string]uint64{
+			primaryRootName: catalog.rootID(primaryRootName),
+		},
+	}
+	_ = snap.Close()
+
+	if _, err := col.Insert([]byte("u2"), []byte(`{"email":"grace@example.com","city":"sea"}`)); err != nil {
+		t.Fatalf("insert u2: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush u2: %v", err)
+	}
+	if err := col.validateUpdateBatchPlanRootDescriptors(stalePlan); !errors.Is(err, ErrConcurrentMutation) {
+		t.Fatalf("stale overlay validation err=%v want %v", err, ErrConcurrentMutation)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesReadFlushedDocumentWithBufferedRuns(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/tree"
 	"github.com/tidwall/gjson"
 )
 
@@ -362,9 +363,18 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 		return fmt.Errorf("collections: insert conflict check missing primary keys: got %d, want %d", len(plan.primaryKeys), len(plan.resultIDs))
 	}
 	uniqueRootIDs := uniqueIndexRootIDs(catalog)
+	if len(catalog.rootOverlays) != 0 {
+		uniqueRootIDs = uniqueIndexRootIDsOrOverlays(catalog)
+	}
 	uniqueProbeRuns, err := plan.uniqueProbeRunsForPersistedConflicts(uniqueRootIDs)
 	if err != nil {
 		return err
+	}
+	if len(catalog.rootOverlays) != 0 {
+		if err := plan.checkPersistedDocumentConflictsAtCatalogRoot(snap, catalog); err != nil {
+			return err
+		}
+		return checkPersistedUniqueConflictsAtCatalogRoots(snap, catalog, uniqueProbeRuns)
 	}
 	preflight := insertBatchPreflight{
 		snapshot:           snap,
@@ -375,6 +385,47 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 		return err
 	}
 	return preflight.checkUniqueConflicts(uniqueProbeRuns)
+}
+
+func (plan *insertBatchPlan) checkPersistedDocumentConflictsAtCatalogRoot(snap *backenddb.Snapshot, catalog *collectionCatalog) error {
+	rootName := collectionPrimaryRootName(catalog.meta.Name)
+	for _, key := range plan.primaryKeys {
+		entry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, rootName, key)
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if entry.Flags&node.FlagTombstone == 0 {
+			return ErrDocumentExists
+		}
+	}
+	return nil
+}
+
+func checkPersistedUniqueConflictsAtCatalogRoots(snap *backenddb.Snapshot, catalog *collectionCatalog, runs []collectionUniqueProbeRun) error {
+	if snap == nil || catalog == nil || len(runs) == 0 {
+		return nil
+	}
+	for _, run := range runs {
+		rootName := collectionSecondaryRootName(catalog.meta.Name, run.indexName)
+		for _, prefix := range run.prefixes {
+			it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, prefix, prefixEnd(prefix), false)
+			if err != nil {
+				return err
+			}
+			if it == nil {
+				continue
+			}
+			conflict := it.Valid()
+			_ = it.Close()
+			if conflict {
+				return fmt.Errorf("%w %q", ErrUniqueIndexConflict, run.indexName)
+			}
+		}
+	}
+	return nil
 }
 
 func (plan *insertBatchPlan) uniqueProbeRunsForPersistedConflicts(uniqueRootIDs map[string]uint64) ([]collectionUniqueProbeRun, error) {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -362,19 +362,24 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 	if len(plan.primaryKeys) != len(plan.resultIDs) {
 		return fmt.Errorf("collections: insert conflict check missing primary keys: got %d, want %d", len(plan.primaryKeys), len(plan.resultIDs))
 	}
-	uniqueRootIDs := uniqueIndexRootIDs(catalog)
 	if len(catalog.rootOverlays) != 0 {
-		uniqueRootIDs = uniqueIndexRootIDsOrOverlays(catalog)
-	}
-	uniqueProbeRuns, err := plan.uniqueProbeRunsForPersistedConflicts(uniqueRootIDs)
-	if err != nil {
-		return err
-	}
-	if len(catalog.rootOverlays) != 0 {
+		uniqueIndexNames := uniqueIndexNamesWithDataOrOverlays(catalog)
+		uniqueProbeRuns, err := plan.uniqueProbeRunsForPersistedConflictIndexes(func(indexName string) bool {
+			_, ok := uniqueIndexNames[indexName]
+			return ok
+		})
+		if err != nil {
+			return err
+		}
 		if err := plan.checkPersistedDocumentConflictsAtCatalogRoot(snap, catalog); err != nil {
 			return err
 		}
 		return checkPersistedUniqueConflictsAtCatalogRoots(snap, catalog, uniqueProbeRuns)
+	}
+	uniqueRootIDs := uniqueIndexRootIDs(catalog)
+	uniqueProbeRuns, err := plan.uniqueProbeRunsForPersistedConflicts(uniqueRootIDs)
+	if err != nil {
+		return err
 	}
 	preflight := insertBatchPreflight{
 		snapshot:           snap,
@@ -419,7 +424,14 @@ func checkPersistedUniqueConflictsAtCatalogRoots(snap *backenddb.Snapshot, catal
 				continue
 			}
 			conflict := it.Valid()
-			_ = it.Close()
+			iterErr := it.Error()
+			closeErr := it.Close()
+			if iterErr != nil {
+				return iterErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
 			if conflict {
 				return fmt.Errorf("%w %q", ErrUniqueIndexConflict, run.indexName)
 			}
@@ -432,15 +444,28 @@ func (plan *insertBatchPlan) uniqueProbeRunsForPersistedConflicts(uniqueRootIDs 
 	if plan == nil || len(plan.resultIDs) == 0 || len(uniqueRootIDs) == 0 {
 		return nil, nil
 	}
+	return plan.uniqueProbeRunsForPersistedConflictIndexes(func(indexName string) bool {
+		return uniqueRootIDs[indexName] != 0
+	})
+}
+
+func (plan *insertBatchPlan) uniqueProbeRunsForPersistedConflictIndexes(includeIndex func(indexName string) bool) ([]collectionUniqueProbeRun, error) {
+	if plan == nil || len(plan.resultIDs) == 0 || includeIndex == nil {
+		return nil, nil
+	}
 	if plan.allUniqueProbeRunsBuilt {
-		return plan.allUniqueProbeRuns, nil
+		out := make([]collectionUniqueProbeRun, 0, len(plan.allUniqueProbeRuns))
+		for _, run := range plan.allUniqueProbeRuns {
+			if includeIndex(run.indexName) {
+				out = append(out, run)
+			}
+		}
+		return out, nil
 	}
 	if !plan.uniqueProbeCandidatesBuilt {
 		return nil, errors.New("collections: insert conflict check missing unique probe candidates")
 	}
-	return buildUniqueProbeRunsFromSorted(plan.uniqueProbeCandidates, func(indexName string) bool {
-		return uniqueRootIDs[indexName] != 0
-	})
+	return buildUniqueProbeRunsFromSorted(plan.uniqueProbeCandidates, includeIndex)
 }
 
 func (p insertBatchPreflight) checkUniqueConflicts(runs []collectionUniqueProbeRun) error {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -97,8 +97,12 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "")
 	if profileBenchBufferedIndexedAsyncFlush(t) {
 		t.Fatal("async flush default=true want false")
+	}
+	if profileBenchBufferedIndexedOverlayRoots(t) {
+		t.Fatal("overlay roots default=true want false")
 	}
 	if got := profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(t); got != 0 {
 		t.Fatalf("async max queued units default=%d want 0", got)
@@ -131,6 +135,10 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "789")
 	if got := profileBenchBufferedIndexedWriteMaxRootRuns(t); got != 789 {
 		t.Fatalf("buffered max root runs=%d want 789", got)
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "true")
+	if !profileBenchBufferedIndexedOverlayRoots(t) {
+		t.Fatal("overlay roots env=true want true")
 	}
 }
 
@@ -2128,6 +2136,10 @@ func profileBenchBufferedIndexedWriteMaxRootRuns(tb testing.TB) int {
 	return profileBenchNonNegativeEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", 0)
 }
 
+func profileBenchBufferedIndexedOverlayRoots(tb testing.TB) bool {
+	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", false)
+}
+
 func profileBenchCollectionOptions(tb testing.TB, format collections.DocumentFormat) collections.CollectionOptions {
 	tb.Helper()
 	return collections.CollectionOptions{
@@ -2138,6 +2150,7 @@ func profileBenchCollectionOptions(tb testing.TB, format collections.DocumentFor
 		BufferedIndexedWriteMaxBytes:            profileBenchBufferedIndexedWriteMaxBytes(tb),
 		BufferedIndexedWriteMaxRootRuns:         profileBenchBufferedIndexedWriteMaxRootRuns(tb),
 		BufferedIndexedAsyncFlush:               profileBenchBufferedIndexedAsyncFlush(tb),
+		BufferedIndexedOverlayRoots:             profileBenchBufferedIndexedOverlayRoots(tb),
 		BufferedIndexedAsyncFlushMaxQueuedUnits: profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(tb),
 	}
 }
@@ -2210,6 +2223,9 @@ func reportProfileBenchBufferedIndexedWriteOptions(b *testing.B, opts collection
 		if opts.BufferedIndexedAsyncFlushMaxQueuedUnits > 0 {
 			b.ReportMetric(float64(opts.BufferedIndexedAsyncFlushMaxQueuedUnits), "buffered_async_max_units")
 		}
+	}
+	if opts.BufferedIndexedOverlayRoots {
+		b.ReportMetric(1, "buffered_overlay_roots")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add opt-in `BufferedIndexedOverlayRoots` for indexed collection memtable flushes
- publish flushed indexed root runs as durable `collections/root-overlay/<root>` descriptors instead of applying them into base roots
- allow indexed buffered inserts/updates to read through existing overlays and keep non-overlay writes guarded
- make insert duplicate/unique preflight overlay-aware
- coalesce the normal single-overlay case by applying each new overlay delta against the previous overlay root, so durable overlay reads do not grow an unbounded root stack
- add benchmark env support via `MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS=true`

This is intentionally architecture-only and opt-in. It is not a default speed win yet; it proves the committed overlay-root write-back shape and exposes the next architectural bottleneck clearly. The latest benchmark shows that coalescing fixes the worst read fanout from the naive overlay path, but root apply work still re-enters the publish path when we coalesce by applying against the prior overlay root.

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks|TestCollectionCatalogOverlayRootsAreVisibleAfterReopen' -count 1`
- `GOWORK=off go test ./TreeDB/collections -count 1`
- `GOWORK=off go test ./TreeDB/db -count 1`
- `GOWORK=off go test ./cmd/mongo_gateway_bench -count 1`
- `GOWORK=off go test ./cmd/mongo_gateway_bench -run 'TestProfileBenchBufferedIndexedAsyncFlushEnv' -count 1`
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks' -count 1`
- `git diff --check`

A broad `GOWORK=off go test ./TreeDB/... -count 1` had one transient unrelated failure in `TreeDB/caching`: `TestVlogGenerationChunkHarness_StagesAndExecutesRealChunkDebt`, output `remaining chunk live bytes=12420 want < initial 12420 (chunks before=3 after=3)`. Rerunning that exact test and then `GOWORK=off go test ./TreeDB/caching -count 1` both passed.

## Benchmark notes
Baseline/default path, overlay roots disabled:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=1000000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=1000000x \
  -benchmem \
  -count=1
```

Result: `6795 ns/op`, `147160 docs/sec`, `2329 B/op`, `4 allocs/op`; publish/root apply remains visible (`publish_delta_group_root_apply_ns/doc=2736`, `update_current_read_ns/doc=1637`).

Naive overlay-root path before coalescing:

Result: `15865 ns/op`, `63031 docs/sec`, `49812 B/op`, `17 allocs/op`; `buffered_overlay_roots=1`. Root-apply publish metrics disappeared from the timed path, but update current reads became the bottleneck (`update_current_read_ns/doc=12294`, `backend_outer_leaf_point_loads/doc=6.623`) because reads probed multiple durable overlay roots.

Coalesced overlay-root path enabled:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=1000000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS=true \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=1000000x \
  -benchmem \
  -count=1
```

Result: `9663 ns/op`, `103485 docs/sec`, `10875 B/op`, `7 allocs/op`; `buffered_overlay_roots=1`, `backend_outer_leaf_point_loads/doc=2.000`, `update_current_read_ns/doc=4108`, `publish_delta_group_root_apply_ns/doc=4010`.

Interpretation: durable overlay publishing is the right committed write-back primitive, but the steady-state architecture still needs a stronger root-apply solution. Naive overlays remove publish root-apply work but make reads probe too many roots. Coalesced overlays cap the root stack and reduce read fanout, but they do it by applying each overlay against the previous overlay root under publish. The next architectural step should move this consolidation out of the critical publish path or replace per-flush root apply with a larger committed write-back design: staged overlay compaction, base-root apply outside the writer critical path, or a read index that makes overlay lookups cheap without merging every flush.
