### PR TITLE
collections: compact overlay roots into base roots

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -538,6 +538,11 @@ type CollectionOptions struct {
 	// Flush, FlushAll, and backend Close still drain pending indexed writes before
 	// returning, but auto-flush thresholds no longer imply immediate durability.
 	BufferedIndexedAsyncFlush bool `json:"buffered_indexed_async_flush,omitempty"`
+	// BufferedIndexedOverlayRoots publishes indexed memtable flush units as
+	// durable overlay roots instead of immediately applying them into base roots.
+	// Maintenance can later compact overlay roots into base roots; reads merge
+	// overlay roots over base roots while they are pending.
+	BufferedIndexedOverlayRoots bool `json:"buffered_indexed_overlay_roots,omitempty"`
 	// BufferedIndexedAsyncFlushMaxQueuedUnits bounds immutable indexed flush
 	// units queued for the background publisher. Zero uses the native default
 	// when async flush is enabled on an indexed schema.
@@ -611,6 +616,7 @@ type indexedFlushPublishWork struct {
 	flushUnit      indexedFlushUnit
 	rootNames      []string
 	rootBaseIDs    map[string]uint64
+	rootOverlays   map[string][]uint64
 	docCount       int
 	byteCount      int64
 	rootRunCount   int
@@ -2249,7 +2255,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		if err != nil {
 			return nil, collectionOptions{}, false, err
 		}
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			return nil, collectionOptions{}, false, err
 		}
 		options, err := collectionPlannerOptions(catalog.meta)
@@ -2259,7 +2265,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		return catalog, options, len(catalog.meta.Indexes) > 0, nil
 	}
 	if domain.loaded && domain.count == 0 && domain.baseSystemRoot == currentSystemRoot && domain.baseCommitSeq == currentCommitSeq {
-		if err := rejectCatalogRootOverlaysForWrite(domain.catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(domain.catalog); err != nil {
 			return nil, collectionOptions{}, false, err
 		}
 		options, err := collectionPlannerOptions(domain.meta)
@@ -2276,7 +2282,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 	if catalog := cachedWriteDomainCatalogForStateLocked(domain, baseSystemRoot, baseCommitSeq); catalog != nil {
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			_ = snap.Close()
 			return nil, collectionOptions{}, false, err
 		}
@@ -2301,7 +2307,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		_ = snap.Close()
 		return nil, collectionOptions{}, false, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		_ = snap.Close()
 		return nil, collectionOptions{}, false, err
 	}
@@ -2351,7 +2357,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	if catalog == nil {
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		return nil, err
 	}
 	if !sameCollectionMeta(catalog.meta, domain.meta) {
@@ -2364,12 +2370,18 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 			if rootID := catalog.rootID(rootName); rootID != baseRootID {
 				return errConcurrentRootModification(domain.meta.Name, rootName)
 			}
+			if !uint64SlicesEqual(catalog.overlayRootIDs(rootName), domain.catalog.overlayRootIDs(rootName)) {
+				return errConcurrentRootModification(domain.meta.Name, rootName)
+			}
 			return nil
 		}); err != nil {
 			return nil, err
 		}
 	} else {
 		if rootID := catalog.rootID(primaryRootName); rootID != domain.primaryRoot {
+			return nil, errConcurrentRootModification(domain.meta.Name, primaryRootName)
+		}
+		if !uint64SlicesEqual(catalog.overlayRootIDs(primaryRootName), domain.catalog.overlayRootIDs(primaryRootName)) {
 			return nil, errConcurrentRootModification(domain.meta.Name, primaryRootName)
 		}
 	}
@@ -4378,6 +4390,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		return nil, nil
 	}
 	rootBaseIDs := make(map[string]uint64, len(rootNames))
+	rootOverlays := make(map[string][]uint64, len(rootNames))
 	for _, rootName := range rootNames {
 		baseRoot, ok := flushUnit.rootBaseIDs[rootName]
 		if !ok {
@@ -4385,6 +4398,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 			return nil, err
 		}
 		rootBaseIDs[rootName] = baseRoot
+		rootOverlays[rootName] = append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
 	}
 	work.baseSystemRoot = snapshotSystemRoot(pin)
 	work.baseCommitSeq = snapshotCommitSeq(pin)
@@ -4392,6 +4406,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 	work.flushUnit = flushUnit
 	work.rootNames = rootNames
 	work.rootBaseIDs = rootBaseIDs
+	work.rootOverlays = rootOverlays
 	work.docCount = flushUnit.docCount
 	work.byteCount = flushUnit.byteCount
 	work.rootRunCount = indexedFlushUnitRootRunCount(flushUnit)
@@ -4412,6 +4427,26 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 			_ = work.pin.Close()
 		}
 	}()
+	if collectionMetaUsesIndexedOverlayRoots(work.meta) {
+		ordered, cleanupIters, err := buildBufferedRootOverlayDeltaPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
+		if err != nil {
+			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+		}
+		publishStart := time.Now()
+		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootOverlayDescriptorSystemIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
+		})
+		publishElapsed := time.Since(publishStart)
+		cleanupIters()
+		if publishErr == nil && len(rootIDs) != len(work.rootNames) {
+			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
+		}
+		completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, publishElapsed)
+		if publishErr != nil {
+			return publishErr
+		}
+		return completeErr
+	}
 	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
 	if err != nil {
 		return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
@@ -4430,6 +4465,33 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		return publishErr
 	}
 	return completeErr
+}
+
+func buildBufferedRootOverlayDeltaPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy, rootOverlays map[string][]uint64) ([]backenddb.OrderedRootDeltaPublishInput, func(), error) {
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	cleanup := func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+	}
+	for _, rootName := range rootNames {
+		iter := newBufferedRootRunsIteratorWithDeleted(rootRuns[rootName], nil, nil, true)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot:      overlayDeltaBaseRoot(rootOverlays[rootName]),
+			Iter:          iter,
+			StoragePolicy: rootPolicies[rootName],
+		})
+	}
+	return ordered, cleanup, nil
+}
+
+func overlayDeltaBaseRoot(overlays []uint64) uint64 {
+	if len(overlays) == 1 {
+		return overlays[0]
+	}
+	return 0
 }
 
 func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootBaseIDs map[string]uint64, rootPolicies map[string]backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
@@ -4527,7 +4589,11 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	if baseCatalog == nil {
 		baseCatalog = work.catalog
 	}
+	overlayPublish := collectionMetaUsesIndexedOverlayRoots(work.meta)
 	nextCatalog := cloneCatalogWithRootUpdates(baseCatalog, work.meta, work.rootNames, rootIDs)
+	if overlayPublish {
+		nextCatalog = cloneCatalogWithRootOverlays(baseCatalog, work.meta, work.rootNames, rootIDs)
+	}
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
 		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
@@ -4543,7 +4609,9 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	domain.count = subtractNonNegativeInt(domain.count, work.docCount)
 	domain.bufferedBytes = subtractNonNegativeInt64(domain.bufferedBytes, work.byteCount)
 	domain.clearIndexedAsyncFlushError()
-	retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
+	if !overlayPublish {
+		retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
+	}
 	rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
 	c.meta = work.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
@@ -4617,21 +4685,36 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
 	baseRootIDs := make(map[string]uint64, len(rootNames))
+	rootOverlays := make(map[string][]uint64, len(rootNames))
 	for _, rootName := range rootNames {
 		baseRoot, ok := flushUnit.rootBaseIDs[rootName]
 		if !ok {
 			return fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
 		}
 		baseRootIDs[rootName] = baseRoot
+		rootOverlays[rootName] = append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
 	}
-	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
-	if err != nil {
-		return err
+	var newSystemRoot uint64
+	var rootIDs []uint64
+	if collectionMetaUsesIndexedOverlayRoots(meta) {
+		ordered, cleanupIters, err := buildBufferedRootOverlayDeltaPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
+		if err != nil {
+			return err
+		}
+		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootOverlayDescriptorSystemIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+		})
+		cleanupIters()
+	} else {
+		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
+		if err != nil {
+			return err
+		}
+		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		})
+		cleanupDeltas()
 	}
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
-	})
-	cleanupDeltas()
 	if err != nil {
 		return err
 	}
@@ -4639,6 +4722,9 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		return unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(domain.catalog, meta, rootNames, rootIDs)
+	if collectionMetaUsesIndexedOverlayRoots(meta) {
+		nextCatalog = cloneCatalogWithRootOverlays(domain.catalog, meta, rootNames, rootIDs)
+	}
 	oldUnits := domain.indexedFlushUnits
 	oldRuns := domain.rootRuns
 	domain.loaded = true
@@ -5082,7 +5168,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		closePlanningSnapshot()
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		closePlanningSnapshot()
 		return nil, err
 	}
@@ -5119,7 +5205,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			closePlanningSnapshot()
 			return nil, errCollectionNotFound
 		}
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			closePlanningSnapshot()
 			return nil, err
 		}
@@ -5206,6 +5292,11 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		plan.stats.Publish += bufferFlushElapsed
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
 		return resultIDs, nil
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		closePlanningSnapshot()
+		resetCollectionRunTables(plan.runs)
+		return nil, err
 	}
 
 	pin, currentCatalog, pinCommitSeq, pinSystemRoot, err := c.lockAndValidateInsertBatchPlan(&mutationLocked, &unlockMutation, snap, catalog, meta, rootNames, baseRootIDs, plan)
@@ -7507,7 +7598,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		_ = snap.Close()
 		return nil, err
 	}
@@ -7563,7 +7654,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		indexStateRootName = collectionIndexStateRootName(meta.Name)
 	}
 	primaryRoot := catalog.rootID(primaryRootName)
-	if primaryRoot == 0 && !bufferedRead.enabled {
+	if primaryRoot == 0 && !bufferedRead.enabled && len(catalog.overlayRootIDs(primaryRootName)) == 0 {
 		plan := newUpdateBatchPlan()
 		*plan = updateBatchPlan{
 			results:                results,
@@ -7633,6 +7724,14 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	for i, item := range items {
 		phaseStart := updateBatchStatsNow(detailedStats)
 		current, err := readUpdateBatchCurrentDocument(&primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
+		if err == nil && !current.buffered && len(catalog.overlayRootIDs(primaryRootName)) != 0 {
+			value, found, overlayErr := collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, item.DocumentID, currentScratch[:0])
+			if overlayErr != nil {
+				err = overlayErr
+			} else {
+				current = updateBatchCurrentDocument{value: value, found: found}
+			}
+		}
 		stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()
@@ -7999,6 +8098,9 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	}
 	if len(plan.deltaTables) == 0 {
 		return plan.results, nil
+	}
+	if err := rejectCatalogRootOverlaysForWrite(plan.catalog); err != nil {
+		return nil, err
 	}
 	if len(plan.rootNames) != len(plan.deltaTables) || len(plan.rootNames) != len(plan.policies) {
 		return nil, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
@@ -8659,6 +8761,28 @@ func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, r
 	return newCollectionCatalogWithOverlays(copyCollectionMeta(meta), roots, rootOverlays)
 }
 
+func cloneCatalogWithRootOverlays(base *collectionCatalog, meta CollectionMeta, rootNames []string, rootIDs []uint64) *collectionCatalog {
+	roots := make(map[string]uint64)
+	var rootOverlays map[string][]uint64
+	if base != nil {
+		for name, rootID := range base.roots {
+			roots[name] = rootID
+		}
+		rootOverlays = cloneRootOverlayMap(base.rootOverlays)
+	}
+	if rootOverlays == nil {
+		rootOverlays = make(map[string][]uint64)
+	}
+	for i, name := range rootNames {
+		if i >= len(rootIDs) || rootIDs[i] == 0 {
+			continue
+		}
+		existing := rootOverlays[name]
+		rootOverlays[name] = overlayDescriptorRootsAfterDelta(existing, rootIDs[i])
+	}
+	return newCollectionCatalogWithOverlays(copyCollectionMeta(meta), roots, rootOverlays)
+}
+
 func newCollectionCatalog(meta CollectionMeta, roots map[string]uint64) *collectionCatalog {
 	return newCollectionCatalogWithOverlays(meta, roots, nil)
 }
@@ -8703,6 +8827,17 @@ func rejectCatalogRootOverlaysForWrite(catalog *collectionCatalog) error {
 		return nil
 	}
 	return errCollectionRootOverlaysRequireCompaction
+}
+
+func rejectCatalogRootOverlaysForIndexedBufferWrite(catalog *collectionCatalog) error {
+	if catalog == nil || len(catalog.rootOverlays) == 0 || collectionMetaUsesIndexedOverlayRoots(catalog.meta) {
+		return nil
+	}
+	return errCollectionRootOverlaysRequireCompaction
+}
+
+func collectionMetaUsesIndexedOverlayRoots(meta CollectionMeta) bool {
+	return meta.Options.BufferedIndexedOverlayRoots && meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
 }
 
 func (c *collectionCatalog) cachedIndexRuntimes() ([]indexRuntime, error) {
@@ -8963,6 +9098,43 @@ func (c *Collection) buildRootDescriptorSystemDeltaIteratorForMeta(meta Collecti
 	return buildSystemDeltaIterator(updates)
 }
 
+func (c *Collection) buildRootOverlayDescriptorSystemIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	if c == nil || c.db == nil {
+		return nil, backenddb.ErrClosed
+	}
+	if len(rootIDs) != len(rootNames) {
+		return nil, unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
+	}
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	if err := c.validateRootOverlayDescriptorSnapshotForMeta(current, meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs, expectedOverlays); err != nil {
+		return nil, err
+	}
+	updates := make(map[string][]byte, len(rootNames))
+	for i, rootName := range rootNames {
+		existing := expectedOverlays[rootName]
+		overlays := overlayDescriptorRootsAfterDelta(existing, rootIDs[i])
+		updates[systemCollectionRootOverlayKey(rootName)] = encodeRootIDList(overlays)
+	}
+	return buildSystemTargetIterator(current, updates)
+}
+
+func overlayDescriptorRootsAfterDelta(existing []uint64, newRoot uint64) []uint64 {
+	if newRoot == 0 {
+		return append([]uint64(nil), existing...)
+	}
+	if len(existing) <= 1 {
+		return []uint64{newRoot}
+	}
+	overlays := make([]uint64, 0, len(existing)+1)
+	overlays = append(overlays, newRoot)
+	overlays = append(overlays, existing...)
+	return overlays
+}
+
 func (c *Collection) validateRootDescriptorSystemDelta(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64) error {
 	if c == nil || c.db == nil {
 		return backenddb.ErrClosed
@@ -9004,6 +9176,55 @@ func (c *Collection) validateRootDescriptorSystemDeltaForMeta(meta CollectionMet
 		}
 	}
 	return nil
+}
+
+func (c *Collection) validateRootOverlayDescriptorSnapshotForMeta(snap *backenddb.Snapshot, meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64) error {
+	if snap == nil {
+		return backenddb.ErrClosed
+	}
+	if snap.State() == nil {
+		return backenddb.ErrClosed
+	}
+	// A raw TreeDB user-root commit does not change collection descriptors, and
+	// unrelated collection commits should not block this collection. Validate the
+	// descriptor contents directly instead of relying only on commit sequence.
+	_ = expectedCommitSeq
+	_ = expectedSystemRoot
+	catalog, err := loadCollectionCatalog(snap, meta.Name)
+	if err != nil {
+		return err
+	}
+	if catalog == nil {
+		return errCollectionNotFound
+	}
+	if !sameCollectionMeta(catalog.meta, meta) {
+		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
+	}
+	for _, rootName := range rootNames {
+		wantRoot, ok := baseRootIDs[rootName]
+		if !ok {
+			return fmt.Errorf("collections: missing base root for collection %q root %q", meta.Name, rootName)
+		}
+		if got := catalog.rootID(rootName); got != wantRoot {
+			return errConcurrentRootModification(meta.Name, rootName)
+		}
+		if !uint64SlicesEqual(catalog.overlayRootIDs(rootName), expectedOverlays[rootName]) {
+			return errConcurrentRootModification(meta.Name, rootName)
+		}
+	}
+	return nil
+}
+
+func uint64SlicesEqual(left, right []uint64) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *Collection) validateMutationRootDescriptors(expectedUserRoot, expectedSystemRoot, expectedCommitSeq uint64) error {
@@ -10582,6 +10803,7 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		meta.Options.BufferedIndexedWriteMaxBytes = 0
 		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
 		meta.Options.BufferedIndexedAsyncFlush = false
+		meta.Options.BufferedIndexedOverlayRoots = false
 		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
 	} else if len(meta.Indexes) == 0 {
 		meta.Options.BufferedIndexedWrites = false
@@ -10729,6 +10951,27 @@ func uniqueIndexRootIDs(catalog *collectionCatalog) map[string]uint64 {
 		}
 		rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
 		if rootID != 0 {
+			out[idx.Name] = rootID
+		}
+	}
+	return out
+}
+
+func uniqueIndexRootIDsOrOverlays(catalog *collectionCatalog) map[string]uint64 {
+	if catalog == nil {
+		return nil
+	}
+	out := make(map[string]uint64)
+	for _, idx := range catalog.meta.Indexes {
+		if !idx.Unique {
+			continue
+		}
+		rootName := collectionSecondaryRootName(catalog.meta.Name, idx.Name)
+		rootID := catalog.rootID(rootName)
+		if rootID != 0 || len(catalog.overlayRootIDs(rootName)) != 0 {
+			if rootID == 0 {
+				rootID = 1
+			}
 			out[idx.Name] = rootID
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -538,6 +538,11 @@ type CollectionOptions struct {
 	// Flush, FlushAll, and backend Close still drain pending indexed writes before
 	// returning, but auto-flush thresholds no longer imply immediate durability.
 	BufferedIndexedAsyncFlush bool `json:"buffered_indexed_async_flush,omitempty"`
+	// BufferedIndexedOverlayRoots publishes indexed memtable flush units as
+	// durable overlay roots instead of immediately applying them into base roots.
+	// Maintenance can later compact overlay roots into base roots; reads merge
+	// overlay roots over base roots while they are pending.
+	BufferedIndexedOverlayRoots bool `json:"buffered_indexed_overlay_roots,omitempty"`
 	// BufferedIndexedAsyncFlushMaxQueuedUnits bounds immutable indexed flush
 	// units queued for the background publisher. Zero uses the native default
 	// when async flush is enabled on an indexed schema.
@@ -611,6 +616,7 @@ type indexedFlushPublishWork struct {
 	flushUnit      indexedFlushUnit
 	rootNames      []string
 	rootBaseIDs    map[string]uint64
+	rootOverlays   map[string][]uint64
 	docCount       int
 	byteCount      int64
 	rootRunCount   int
@@ -2249,7 +2255,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		if err != nil {
 			return nil, collectionOptions{}, false, err
 		}
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			return nil, collectionOptions{}, false, err
 		}
 		options, err := collectionPlannerOptions(catalog.meta)
@@ -2259,7 +2265,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		return catalog, options, len(catalog.meta.Indexes) > 0, nil
 	}
 	if domain.loaded && domain.count == 0 && domain.baseSystemRoot == currentSystemRoot && domain.baseCommitSeq == currentCommitSeq {
-		if err := rejectCatalogRootOverlaysForWrite(domain.catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(domain.catalog); err != nil {
 			return nil, collectionOptions{}, false, err
 		}
 		options, err := collectionPlannerOptions(domain.meta)
@@ -2276,7 +2282,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 	if catalog := cachedWriteDomainCatalogForStateLocked(domain, baseSystemRoot, baseCommitSeq); catalog != nil {
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			_ = snap.Close()
 			return nil, collectionOptions{}, false, err
 		}
@@ -2301,7 +2307,7 @@ func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*co
 		_ = snap.Close()
 		return nil, collectionOptions{}, false, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		_ = snap.Close()
 		return nil, collectionOptions{}, false, err
 	}
@@ -2351,7 +2357,7 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 	if catalog == nil {
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		return nil, err
 	}
 	if !sameCollectionMeta(catalog.meta, domain.meta) {
@@ -2364,12 +2370,18 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 			if rootID := catalog.rootID(rootName); rootID != baseRootID {
 				return errConcurrentRootModification(domain.meta.Name, rootName)
 			}
+			if !uint64SlicesEqual(catalog.overlayRootIDs(rootName), domain.catalog.overlayRootIDs(rootName)) {
+				return errConcurrentRootModification(domain.meta.Name, rootName)
+			}
 			return nil
 		}); err != nil {
 			return nil, err
 		}
 	} else {
 		if rootID := catalog.rootID(primaryRootName); rootID != domain.primaryRoot {
+			return nil, errConcurrentRootModification(domain.meta.Name, primaryRootName)
+		}
+		if !uint64SlicesEqual(catalog.overlayRootIDs(primaryRootName), domain.catalog.overlayRootIDs(primaryRootName)) {
 			return nil, errConcurrentRootModification(domain.meta.Name, primaryRootName)
 		}
 	}
@@ -4378,6 +4390,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		return nil, nil
 	}
 	rootBaseIDs := make(map[string]uint64, len(rootNames))
+	rootOverlays := make(map[string][]uint64, len(rootNames))
 	for _, rootName := range rootNames {
 		baseRoot, ok := flushUnit.rootBaseIDs[rootName]
 		if !ok {
@@ -4385,6 +4398,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 			return nil, err
 		}
 		rootBaseIDs[rootName] = baseRoot
+		rootOverlays[rootName] = append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
 	}
 	work.baseSystemRoot = snapshotSystemRoot(pin)
 	work.baseCommitSeq = snapshotCommitSeq(pin)
@@ -4392,6 +4406,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 	work.flushUnit = flushUnit
 	work.rootNames = rootNames
 	work.rootBaseIDs = rootBaseIDs
+	work.rootOverlays = rootOverlays
 	work.docCount = flushUnit.docCount
 	work.byteCount = flushUnit.byteCount
 	work.rootRunCount = indexedFlushUnitRootRunCount(flushUnit)
@@ -4412,6 +4427,26 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 			_ = work.pin.Close()
 		}
 	}()
+	if collectionMetaUsesIndexedOverlayRoots(work.meta) {
+		ordered, cleanupIters, err := buildBufferedRootOverlayPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies)
+		if err != nil {
+			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+		}
+		publishStart := time.Now()
+		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootOverlayDescriptorSystemIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
+		})
+		publishElapsed := time.Since(publishStart)
+		cleanupIters()
+		if publishErr == nil && len(rootIDs) != len(work.rootNames) {
+			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
+		}
+		completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, publishElapsed)
+		if publishErr != nil {
+			return publishErr
+		}
+		return completeErr
+	}
 	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
 	if err != nil {
 		return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
@@ -4430,6 +4465,26 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		return publishErr
 	}
 	return completeErr
+}
+
+func buildBufferedRootOverlayPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootPublishInput, func(), error) {
+	ordered := make([]backenddb.OrderedRootPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	cleanup := func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+	}
+	for _, rootName := range rootNames {
+		iter := newBufferedRootRunsIteratorWithDeleted(rootRuns[rootName], nil, nil, true)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootPublishInput{
+			BaseRoot:      0,
+			Iter:          iter,
+			StoragePolicy: rootPolicies[rootName],
+		})
+	}
+	return ordered, cleanup, nil
 }
 
 func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootBaseIDs map[string]uint64, rootPolicies map[string]backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
@@ -4527,7 +4582,11 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	if baseCatalog == nil {
 		baseCatalog = work.catalog
 	}
+	overlayPublish := collectionMetaUsesIndexedOverlayRoots(work.meta)
 	nextCatalog := cloneCatalogWithRootUpdates(baseCatalog, work.meta, work.rootNames, rootIDs)
+	if overlayPublish {
+		nextCatalog = cloneCatalogWithRootOverlays(baseCatalog, work.meta, work.rootNames, rootIDs)
+	}
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
 		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
@@ -4543,7 +4602,9 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	domain.count = subtractNonNegativeInt(domain.count, work.docCount)
 	domain.bufferedBytes = subtractNonNegativeInt64(domain.bufferedBytes, work.byteCount)
 	domain.clearIndexedAsyncFlushError()
-	retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
+	if !overlayPublish {
+		retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
+	}
 	rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
 	c.meta = work.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
@@ -4617,21 +4678,36 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
 	baseRootIDs := make(map[string]uint64, len(rootNames))
+	rootOverlays := make(map[string][]uint64, len(rootNames))
 	for _, rootName := range rootNames {
 		baseRoot, ok := flushUnit.rootBaseIDs[rootName]
 		if !ok {
 			return fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
 		}
 		baseRootIDs[rootName] = baseRoot
+		rootOverlays[rootName] = append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
 	}
-	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
-	if err != nil {
-		return err
+	var newSystemRoot uint64
+	var rootIDs []uint64
+	if collectionMetaUsesIndexedOverlayRoots(meta) {
+		ordered, cleanupIters, err := buildBufferedRootOverlayPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies)
+		if err != nil {
+			return err
+		}
+		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootOverlayDescriptorSystemIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+		})
+		cleanupIters()
+	} else {
+		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
+		if err != nil {
+			return err
+		}
+		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		})
+		cleanupDeltas()
 	}
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
-	})
-	cleanupDeltas()
 	if err != nil {
 		return err
 	}
@@ -4639,6 +4715,9 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		return unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(domain.catalog, meta, rootNames, rootIDs)
+	if collectionMetaUsesIndexedOverlayRoots(meta) {
+		nextCatalog = cloneCatalogWithRootOverlays(domain.catalog, meta, rootNames, rootIDs)
+	}
 	oldUnits := domain.indexedFlushUnits
 	oldRuns := domain.rootRuns
 	domain.loaded = true
@@ -5082,7 +5161,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		closePlanningSnapshot()
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		closePlanningSnapshot()
 		return nil, err
 	}
@@ -5119,7 +5198,7 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 			closePlanningSnapshot()
 			return nil, errCollectionNotFound
 		}
-		if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 			closePlanningSnapshot()
 			return nil, err
 		}
@@ -5206,6 +5285,11 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		plan.stats.Publish += bufferFlushElapsed
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
 		return resultIDs, nil
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		closePlanningSnapshot()
+		resetCollectionRunTables(plan.runs)
+		return nil, err
 	}
 
 	pin, currentCatalog, pinCommitSeq, pinSystemRoot, err := c.lockAndValidateInsertBatchPlan(&mutationLocked, &unlockMutation, snap, catalog, meta, rootNames, baseRootIDs, plan)
@@ -7507,7 +7591,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		_ = snap.Close()
 		return nil, errCollectionNotFound
 	}
-	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+	if err := rejectCatalogRootOverlaysForIndexedBufferWrite(catalog); err != nil {
 		_ = snap.Close()
 		return nil, err
 	}
@@ -7563,7 +7647,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		indexStateRootName = collectionIndexStateRootName(meta.Name)
 	}
 	primaryRoot := catalog.rootID(primaryRootName)
-	if primaryRoot == 0 && !bufferedRead.enabled {
+	if primaryRoot == 0 && !bufferedRead.enabled && len(catalog.overlayRootIDs(primaryRootName)) == 0 {
 		plan := newUpdateBatchPlan()
 		*plan = updateBatchPlan{
 			results:                results,
@@ -7633,6 +7717,14 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	for i, item := range items {
 		phaseStart := updateBatchStatsNow(detailedStats)
 		current, err := readUpdateBatchCurrentDocument(&primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
+		if err == nil && !current.buffered && len(catalog.overlayRootIDs(primaryRootName)) != 0 {
+			value, found, overlayErr := collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, item.DocumentID, currentScratch[:0])
+			if overlayErr != nil {
+				err = overlayErr
+			} else {
+				current = updateBatchCurrentDocument{value: value, found: found}
+			}
+		}
 		stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()
@@ -7999,6 +8091,9 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	}
 	if len(plan.deltaTables) == 0 {
 		return plan.results, nil
+	}
+	if err := rejectCatalogRootOverlaysForWrite(plan.catalog); err != nil {
+		return nil, err
 	}
 	if len(plan.rootNames) != len(plan.deltaTables) || len(plan.rootNames) != len(plan.policies) {
 		return nil, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
@@ -8659,6 +8754,31 @@ func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, r
 	return newCollectionCatalogWithOverlays(copyCollectionMeta(meta), roots, rootOverlays)
 }
 
+func cloneCatalogWithRootOverlays(base *collectionCatalog, meta CollectionMeta, rootNames []string, rootIDs []uint64) *collectionCatalog {
+	roots := make(map[string]uint64)
+	var rootOverlays map[string][]uint64
+	if base != nil {
+		for name, rootID := range base.roots {
+			roots[name] = rootID
+		}
+		rootOverlays = cloneRootOverlayMap(base.rootOverlays)
+	}
+	if rootOverlays == nil {
+		rootOverlays = make(map[string][]uint64)
+	}
+	for i, name := range rootNames {
+		if i >= len(rootIDs) || rootIDs[i] == 0 {
+			continue
+		}
+		existing := rootOverlays[name]
+		next := make([]uint64, 0, len(existing)+1)
+		next = append(next, rootIDs[i])
+		next = append(next, existing...)
+		rootOverlays[name] = next
+	}
+	return newCollectionCatalogWithOverlays(copyCollectionMeta(meta), roots, rootOverlays)
+}
+
 func newCollectionCatalog(meta CollectionMeta, roots map[string]uint64) *collectionCatalog {
 	return newCollectionCatalogWithOverlays(meta, roots, nil)
 }
@@ -8703,6 +8823,17 @@ func rejectCatalogRootOverlaysForWrite(catalog *collectionCatalog) error {
 		return nil
 	}
 	return errCollectionRootOverlaysRequireCompaction
+}
+
+func rejectCatalogRootOverlaysForIndexedBufferWrite(catalog *collectionCatalog) error {
+	if catalog == nil || len(catalog.rootOverlays) == 0 || collectionMetaUsesIndexedOverlayRoots(catalog.meta) {
+		return nil
+	}
+	return errCollectionRootOverlaysRequireCompaction
+}
+
+func collectionMetaUsesIndexedOverlayRoots(meta CollectionMeta) bool {
+	return meta.Options.BufferedIndexedOverlayRoots && meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
 }
 
 func (c *collectionCatalog) cachedIndexRuntimes() ([]indexRuntime, error) {
@@ -8963,6 +9094,32 @@ func (c *Collection) buildRootDescriptorSystemDeltaIteratorForMeta(meta Collecti
 	return buildSystemDeltaIterator(updates)
 }
 
+func (c *Collection) buildRootOverlayDescriptorSystemIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	if c == nil || c.db == nil {
+		return nil, backenddb.ErrClosed
+	}
+	if len(rootIDs) != len(rootNames) {
+		return nil, unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
+	}
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	if err := c.validateRootOverlayDescriptorSnapshotForMeta(current, meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs, expectedOverlays); err != nil {
+		return nil, err
+	}
+	updates := make(map[string][]byte, len(rootNames))
+	for i, rootName := range rootNames {
+		existing := expectedOverlays[rootName]
+		overlays := make([]uint64, 0, len(existing)+1)
+		overlays = append(overlays, rootIDs[i])
+		overlays = append(overlays, existing...)
+		updates[systemCollectionRootOverlayKey(rootName)] = encodeRootIDList(overlays)
+	}
+	return buildSystemTargetIterator(current, updates)
+}
+
 func (c *Collection) validateRootDescriptorSystemDelta(expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64) error {
 	if c == nil || c.db == nil {
 		return backenddb.ErrClosed
@@ -9004,6 +9161,55 @@ func (c *Collection) validateRootDescriptorSystemDeltaForMeta(meta CollectionMet
 		}
 	}
 	return nil
+}
+
+func (c *Collection) validateRootOverlayDescriptorSnapshotForMeta(snap *backenddb.Snapshot, meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64) error {
+	if snap == nil {
+		return backenddb.ErrClosed
+	}
+	if snap.State() == nil {
+		return backenddb.ErrClosed
+	}
+	// A raw TreeDB user-root commit does not change collection descriptors, and
+	// unrelated collection commits should not block this collection. Validate the
+	// descriptor contents directly instead of relying only on commit sequence.
+	_ = expectedCommitSeq
+	_ = expectedSystemRoot
+	catalog, err := loadCollectionCatalog(snap, meta.Name)
+	if err != nil {
+		return err
+	}
+	if catalog == nil {
+		return errCollectionNotFound
+	}
+	if !sameCollectionMeta(catalog.meta, meta) {
+		return fmt.Errorf("collections: concurrent schema modification detected for %q", meta.Name)
+	}
+	for _, rootName := range rootNames {
+		wantRoot, ok := baseRootIDs[rootName]
+		if !ok {
+			return fmt.Errorf("collections: missing base root for collection %q root %q", meta.Name, rootName)
+		}
+		if got := catalog.rootID(rootName); got != wantRoot {
+			return errConcurrentRootModification(meta.Name, rootName)
+		}
+		if !uint64SlicesEqual(catalog.overlayRootIDs(rootName), expectedOverlays[rootName]) {
+			return errConcurrentRootModification(meta.Name, rootName)
+		}
+	}
+	return nil
+}
+
+func uint64SlicesEqual(left, right []uint64) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *Collection) validateMutationRootDescriptors(expectedUserRoot, expectedSystemRoot, expectedCommitSeq uint64) error {
@@ -10582,6 +10788,7 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		meta.Options.BufferedIndexedWriteMaxBytes = 0
 		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
 		meta.Options.BufferedIndexedAsyncFlush = false
+		meta.Options.BufferedIndexedOverlayRoots = false
 		meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits = 0
 	} else if len(meta.Indexes) == 0 {
 		meta.Options.BufferedIndexedWrites = false
@@ -10729,6 +10936,27 @@ func uniqueIndexRootIDs(catalog *collectionCatalog) map[string]uint64 {
 		}
 		rootID := catalog.rootID(collectionSecondaryRootName(catalog.meta.Name, idx.Name))
 		if rootID != 0 {
+			out[idx.Name] = rootID
+		}
+	}
+	return out
+}
+
+func uniqueIndexRootIDsOrOverlays(catalog *collectionCatalog) map[string]uint64 {
+	if catalog == nil {
+		return nil
+	}
+	out := make(map[string]uint64)
+	for _, idx := range catalog.meta.Indexes {
+		if !idx.Unique {
+			continue
+		}
+		rootName := collectionSecondaryRootName(catalog.meta.Name, idx.Name)
+		rootID := catalog.rootID(rootName)
+		if rootID != 0 || len(catalog.overlayRootIDs(rootName)) != 0 {
+			if rootID == 0 {
+				rootID = 1
+			}
 			out[idx.Name] = rootID
 		}
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7227,6 +7227,16 @@ func (plan *updateBatchPlan) close() {
 	updateBatchPlanPool.Put(plan)
 }
 
+func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPlan) error {
+	if plan == nil {
+		return nil
+	}
+	if plan.catalog != nil && len(plan.catalog.rootOverlays) != 0 && collectionMetaUsesIndexedOverlayRoots(plan.catalog.meta) {
+		return c.validateRootOverlayDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, plan.catalog.rootOverlays)
+	}
+	return c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs)
+}
+
 func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMode) ([]UpdateBatchResult, error) {
 	if c.shouldPlanUpdateBatchWithBufferedWrites(mode) {
 		useBufferedRead := true
@@ -7261,7 +7271,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 						}
 						return ErrConcurrentMutation
 					}
-					if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
+					if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
 						return err
 					}
 					c.meta = plan.meta
@@ -7329,7 +7339,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 			if err := c.flushBufferedWrites(); err != nil {
 				return err
 			}
-			if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
+			if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
 				return err
 			}
 			c.meta = plan.meta
@@ -8218,7 +8228,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 			return false, ErrConcurrentMutation
 		}
 	}
-	if err := c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs); err != nil {
+	if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
 		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
 		return false, err
 	}
@@ -9176,6 +9186,18 @@ func (c *Collection) validateRootDescriptorSystemDeltaForMeta(meta CollectionMet
 		}
 	}
 	return nil
+}
+
+func (c *Collection) validateRootOverlayDescriptorSystemDeltaForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64) error {
+	if c == nil || c.db == nil {
+		return backenddb.ErrClosed
+	}
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	return c.validateRootOverlayDescriptorSnapshotForMeta(current, meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs, expectedOverlays)
 }
 
 func (c *Collection) validateRootOverlayDescriptorSnapshotForMeta(snap *backenddb.Snapshot, meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64) error {
@@ -10957,11 +10979,11 @@ func uniqueIndexRootIDs(catalog *collectionCatalog) map[string]uint64 {
 	return out
 }
 
-func uniqueIndexRootIDsOrOverlays(catalog *collectionCatalog) map[string]uint64 {
+func uniqueIndexNamesWithDataOrOverlays(catalog *collectionCatalog) map[string]struct{} {
 	if catalog == nil {
 		return nil
 	}
-	out := make(map[string]uint64)
+	out := make(map[string]struct{})
 	for _, idx := range catalog.meta.Indexes {
 		if !idx.Unique {
 			continue
@@ -10969,10 +10991,7 @@ func uniqueIndexRootIDsOrOverlays(catalog *collectionCatalog) map[string]uint64 
 		rootName := collectionSecondaryRootName(catalog.meta.Name, idx.Name)
 		rootID := catalog.rootID(rootName)
 		if rootID != 0 || len(catalog.overlayRootIDs(rootName)) != 0 {
-			if rootID == 0 {
-				rootID = 1
-			}
-			out[idx.Name] = rootID
+			out[idx.Name] = struct{}{}
 		}
 	}
 	return out

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2252,7 +2252,7 @@ func (c *Collection) compactRootOverlaysLocked(ctx context.Context) (CollectionR
 	}
 	baseRootIDs := make(map[string]uint64, len(rootNames))
 	rootOverlays := make(map[string][]uint64, len(rootNames))
-	ordered := make([]backenddb.OrderedRootPublishInput, 0, len(rootNames))
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
 	cleanupIters := func() {
 		for i := range ordered {
 			if ordered[i].Iter != nil {
@@ -2284,7 +2284,7 @@ func (c *Collection) compactRootOverlaysLocked(ctx context.Context) (CollectionR
 		}
 		baseRootIDs[rootName] = catalog.rootID(rootName)
 		rootOverlays[rootName] = overlays
-		ordered = append(ordered, backenddb.OrderedRootPublishInput{
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
 			BaseRoot:      0,
 			Iter:          it,
 			StoragePolicy: policy,
@@ -2297,8 +2297,8 @@ func (c *Collection) compactRootOverlaysLocked(ctx context.Context) (CollectionR
 	}
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
-	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootOverlayCompactionSystemIteratorForMeta(catalog.meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootOverlayCompactionSystemDeltaIteratorForMeta(catalog.meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
 	})
 	cleanupIters()
 	if err != nil {
@@ -9251,7 +9251,7 @@ func (c *Collection) buildRootOverlayDescriptorSystemIteratorForMeta(meta Collec
 	return buildSystemTargetIterator(current, updates)
 }
 
-func (c *Collection) buildRootOverlayCompactionSystemIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+func (c *Collection) buildRootOverlayCompactionSystemDeltaIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 	if c == nil || c.db == nil {
 		return nil, backenddb.ErrClosed
 	}
@@ -9271,7 +9271,7 @@ func (c *Collection) buildRootOverlayCompactionSystemIteratorForMeta(meta Collec
 		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
 		updates[systemCollectionRootOverlayKey(rootName)] = encodeRootIDList(nil)
 	}
-	return buildSystemTargetIterator(current, updates)
+	return buildSystemDeltaIterator(updates)
 }
 
 func overlayDescriptorRootsAfterDelta(existing []uint64, newRoot uint64) []uint64 {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -219,6 +219,11 @@ type Collection struct {
 	lastUpdateStats   CollectionUpdateStats
 }
 
+type CollectionRootOverlayCompactionStats struct {
+	Roots        int
+	OverlayRoots int
+}
+
 // StoredDocumentJSONMaterializer reuses any resources needed to materialize
 // stored collection documents as JSON.
 type StoredDocumentJSONMaterializer struct {
@@ -2193,6 +2198,120 @@ func (c *Collection) Flush() error {
 		return c.flushBufferedWrites()
 	}
 	return c.flushBufferedWrites()
+}
+
+// CompactRootOverlays folds durable collection root overlays into their base
+// collection roots and clears the overlay descriptors in the same backend
+// commit. It is an explicit maintenance boundary for the overlay-root write-back
+// architecture: hot writes may publish durable overlays quickly, then maintenance
+// can restore the simple one-root read shape.
+func (c *Collection) CompactRootOverlays(ctx context.Context) (CollectionRootOverlayCompactionStats, error) {
+	if c == nil {
+		return CollectionRootOverlayCompactionStats{}, errCollectionNil
+	}
+	if c.db == nil {
+		return CollectionRootOverlayCompactionStats{}, errCollectionDBNil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation.Unlock()
+	if c.writeDomain != nil {
+		c.writeDomain.waitIndexedAsyncFlush()
+	}
+	return c.compactRootOverlaysLocked(ctx)
+}
+
+func (c *Collection) compactRootOverlaysLocked(ctx context.Context) (CollectionRootOverlayCompactionStats, error) {
+	var stats CollectionRootOverlayCompactionStats
+	if err := ctx.Err(); err != nil {
+		return stats, err
+	}
+	if err := c.flushBufferedWrites(); err != nil {
+		return stats, err
+	}
+	if err := ctx.Err(); err != nil {
+		return stats, err
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return stats, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return stats, err
+	}
+	if catalog == nil {
+		return stats, errCollectionNotFound
+	}
+	rootNames := catalog.overlayRootNames()
+	if len(rootNames) == 0 {
+		return stats, nil
+	}
+	baseRootIDs := make(map[string]uint64, len(rootNames))
+	rootOverlays := make(map[string][]uint64, len(rootNames))
+	ordered := make([]backenddb.OrderedRootPublishInput, 0, len(rootNames))
+	cleanupIters := func() {
+		for i := range ordered {
+			if ordered[i].Iter != nil {
+				_ = ordered[i].Iter.Close()
+			}
+		}
+	}
+	for _, rootName := range rootNames {
+		if err := ctx.Err(); err != nil {
+			cleanupIters()
+			return stats, err
+		}
+		overlays := append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
+		if len(overlays) == 0 {
+			continue
+		}
+		policy, err := collectionRootStoragePolicy(catalog.meta, rootName)
+		if err != nil {
+			cleanupIters()
+			return stats, err
+		}
+		it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, nil, nil, false)
+		if err != nil {
+			cleanupIters()
+			return stats, err
+		}
+		if it == nil {
+			it = &systemTargetIterator{}
+		}
+		baseRootIDs[rootName] = catalog.rootID(rootName)
+		rootOverlays[rootName] = overlays
+		ordered = append(ordered, backenddb.OrderedRootPublishInput{
+			BaseRoot:      0,
+			Iter:          it,
+			StoragePolicy: policy,
+		})
+		stats.Roots++
+		stats.OverlayRoots += len(overlays)
+	}
+	if len(ordered) == 0 {
+		return stats, nil
+	}
+	baseSystemRoot := snapshotSystemRoot(snap)
+	baseCommitSeq := snapshotCommitSeq(snap)
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildRootOverlayCompactionSystemIteratorForMeta(catalog.meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+	})
+	cleanupIters()
+	if err != nil {
+		return stats, err
+	}
+	if len(rootIDs) != len(rootNames) {
+		return stats, unexpectedOrderedRootCountError(catalog.meta.Name, len(rootNames), len(rootIDs))
+	}
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, catalog.meta, rootNames, rootIDs)
+	c.meta = catalog.meta
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return stats, nil
 }
 
 func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, error) {
@@ -9132,6 +9251,29 @@ func (c *Collection) buildRootOverlayDescriptorSystemIteratorForMeta(meta Collec
 	return buildSystemTargetIterator(current, updates)
 }
 
+func (c *Collection) buildRootOverlayCompactionSystemIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	if c == nil || c.db == nil {
+		return nil, backenddb.ErrClosed
+	}
+	if len(rootIDs) != len(rootNames) {
+		return nil, unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
+	}
+	current := c.db.AcquireSnapshot()
+	if current == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = current.Close() }()
+	if err := c.validateRootOverlayDescriptorSnapshotForMeta(current, meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs, expectedOverlays); err != nil {
+		return nil, err
+	}
+	updates := make(map[string][]byte, len(rootNames)*2)
+	for i, rootName := range rootNames {
+		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
+		updates[systemCollectionRootOverlayKey(rootName)] = encodeRootIDList(nil)
+	}
+	return buildSystemTargetIterator(current, updates)
+}
+
 func overlayDescriptorRootsAfterDelta(existing []uint64, newRoot uint64) []uint64 {
 	if newRoot == 0 {
 		return append([]uint64(nil), existing...)
@@ -10401,11 +10543,40 @@ func (c *collectionCatalog) rootID(rootName string) uint64 {
 	return c.roots[rootName]
 }
 
+func (c *collectionCatalog) overlayRootNames() []string {
+	if c == nil || len(c.rootOverlays) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(c.rootOverlays))
+	for rootName, overlays := range c.rootOverlays {
+		if len(overlays) != 0 {
+			names = append(names, rootName)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
 func (c *collectionCatalog) overlayRootIDs(rootName string) []uint64 {
 	if c == nil || len(c.rootOverlays) == 0 {
 		return nil
 	}
 	return c.rootOverlays[rootName]
+}
+
+func collectionRootStoragePolicy(meta CollectionMeta, rootName string) (backenddb.OrderedRootStoragePolicy, error) {
+	switch rootName {
+	case collectionPrimaryRootName(meta.Name), collectionTemplateRootName(meta.Name):
+		return backendRootStoragePolicy(meta.Options.DataRootStoragePolicy)
+	case collectionIndexStateRootName(meta.Name):
+		return backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy)
+	}
+	for _, idx := range meta.Indexes {
+		if rootName == collectionSecondaryRootName(meta.Name, idx.Name) {
+			return backendRootStoragePolicy(idx.StoragePolicy)
+		}
+	}
+	return backenddb.OrderedRootStorageDefault, fmt.Errorf("collections: unknown collection root %q for %q", rootName, meta.Name)
 }
 
 func (c *collectionCatalog) rootStack(rootName string) []uint64 {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2358,6 +2358,116 @@ func TestCollectionCatalogOverlayRootsAreVisibleAfterReopen(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if _, err := col.Insert([]byte("u2"), []byte(`{"email":"ada@example.com","city":"sea"}`)); !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("insert duplicate email err=%v want %v", err, ErrUniqueIndexConflict)
+	}
+	results, buffered, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"sea"}`), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("update city: %v", err)
+	}
+	if !buffered || len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("update results=%+v buffered=%v", results, buffered)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush overlays: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated doc: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("updated doc=%q want %q", got, want)
+	}
+	hnlIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find old city: %v", err)
+	}
+	if len(hnlIDs) != 0 {
+		t.Fatalf("old city ids=%q want none", hnlIDs)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find new city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("new city ids=%q want [u1]", seaIDs)
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog: %v", err)
+	}
+	if got := len(catalog.overlayRootIDs(collectionPrimaryRootName("users"))); got < 2 {
+		_ = snap.Close()
+		t.Fatalf("primary overlay roots=%d want at least 2", got)
+	}
+	_ = snap.Close()
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	reopenedDoc, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get reopened doc: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"sea"}`); !bytes.Equal(reopenedDoc, want) {
+		t.Fatalf("reopened doc=%q want %q", reopenedDoc, want)
+	}
+	reopenedSeaIDs, err := reopenedCol.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find reopened city: %v", err)
+	}
+	if len(reopenedSeaIDs) != 1 || !bytes.Equal(reopenedSeaIDs[0], []byte("u1")) {
+		t.Fatalf("reopened city ids=%q want [u1]", reopenedSeaIDs)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesReadFlushedDocumentWithBufferedRuns(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2538,6 +2538,133 @@ func TestCollectionIndexedOverlayRootValidationRejectsStaleOverlayDescriptors(t 
 	}
 }
 
+func TestCollectionCompactRootOverlaysFoldsIntoBaseRoots(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if _, _, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"sea"}`), true, nil
+		},
+	}}); err != nil {
+		t.Fatalf("update city: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush overlays: %v", err)
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog before compact: %v", err)
+	}
+	if got := len(catalog.overlayRootNames()); got == 0 {
+		_ = snap.Close()
+		t.Fatal("overlay root names before compact=0")
+	}
+	_ = snap.Close()
+
+	stats, err := col.CompactRootOverlays(context.Background())
+	if err != nil {
+		t.Fatalf("compact root overlays: %v", err)
+	}
+	if stats.Roots == 0 || stats.OverlayRoots == 0 {
+		t.Fatalf("compact stats=%+v want nonzero roots and overlays", stats)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get compacted doc: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("compacted doc=%q want %q", got, want)
+	}
+	hnlIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find compacted old city: %v", err)
+	}
+	if len(hnlIDs) != 0 {
+		t.Fatalf("old city ids=%q want none", hnlIDs)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find compacted new city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("new city ids=%q want [u1]", seaIDs)
+	}
+	snap = db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot after compact")
+	}
+	catalog, err = loadCollectionCatalog(snap, "users")
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog after compact: %v", err)
+	}
+	if got := len(catalog.overlayRootNames()); got != 0 {
+		_ = snap.Close()
+		t.Fatalf("overlay root names after compact=%d want 0", got)
+	}
+	_ = snap.Close()
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"email":"ada@example.com","city":"lax"}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("direct update after compact: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("direct update after compact matched=%v modified=%v", matched, modified)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	reopenedIDs, err := reopenedCol.FindByIndex("city", "lax")
+	if err != nil {
+		t.Fatalf("find reopened direct update city: %v", err)
+	}
+	if len(reopenedIDs) != 1 || !bytes.Equal(reopenedIDs[0], []byte("u1")) {
+		t.Fatalf("reopened city ids=%q want [u1]", reopenedIDs)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesReadFlushedDocumentWithBufferedRuns(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2358,6 +2358,116 @@ func TestCollectionCatalogOverlayRootsAreVisibleAfterReopen(t *testing.T) {
 	}
 }
 
+func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if _, err := col.Insert([]byte("u2"), []byte(`{"email":"ada@example.com","city":"sea"}`)); !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("insert duplicate email err=%v want %v", err, ErrUniqueIndexConflict)
+	}
+	results, buffered, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"sea"}`), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("update city: %v", err)
+	}
+	if !buffered || len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("update results=%+v buffered=%v", results, buffered)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush overlays: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated doc: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("updated doc=%q want %q", got, want)
+	}
+	hnlIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find old city: %v", err)
+	}
+	if len(hnlIDs) != 0 {
+		t.Fatalf("old city ids=%q want none", hnlIDs)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find new city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("new city ids=%q want [u1]", seaIDs)
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog: %v", err)
+	}
+	if got := len(catalog.overlayRootIDs(collectionPrimaryRootName("users"))); got != 1 {
+		_ = snap.Close()
+		t.Fatalf("primary overlay roots=%d want 1 coalesced overlay", got)
+	}
+	_ = snap.Close()
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	reopenedDoc, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get reopened doc: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com","city":"sea"}`); !bytes.Equal(reopenedDoc, want) {
+		t.Fatalf("reopened doc=%q want %q", reopenedDoc, want)
+	}
+	reopenedSeaIDs, err := reopenedCol.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find reopened city: %v", err)
+	}
+	if len(reopenedSeaIDs) != 1 || !bytes.Equal(reopenedSeaIDs[0], []byte("u1")) {
+		t.Fatalf("reopened city ids=%q want [u1]", reopenedSeaIDs)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesReadFlushedDocumentWithBufferedRuns(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2468,6 +2468,76 @@ func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t 
 	}
 }
 
+func TestCollectionIndexedOverlayRootValidationRejectsStaleOverlayDescriptors(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush u1: %v", err)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog: %v", err)
+	}
+	primaryRootName := collectionPrimaryRootName("users")
+	if got := len(catalog.overlayRootIDs(primaryRootName)); got != 1 {
+		_ = snap.Close()
+		t.Fatalf("primary overlay roots=%d want 1", got)
+	}
+	stalePlan := &updateBatchPlan{
+		meta:           catalog.meta,
+		catalog:        catalog,
+		baseCommitSeq:  snapshotCommitSeq(snap),
+		baseSystemRoot: snapshotSystemRoot(snap),
+		rootNames:      []string{primaryRootName},
+		baseRootIDs: map[string]uint64{
+			primaryRootName: catalog.rootID(primaryRootName),
+		},
+	}
+	_ = snap.Close()
+
+	if _, err := col.Insert([]byte("u2"), []byte(`{"email":"grace@example.com","city":"sea"}`)); err != nil {
+		t.Fatalf("insert u2: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush u2: %v", err)
+	}
+	if err := col.validateUpdateBatchPlanRootDescriptors(stalePlan); !errors.Is(err, ErrConcurrentMutation) {
+		t.Fatalf("stale overlay validation err=%v want %v", err, ErrConcurrentMutation)
+	}
+}
+
 func TestCollectionIndexedWriteMemtablesReadFlushedDocumentWithBufferedRuns(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/tree"
 	"github.com/tidwall/gjson"
 )
 
@@ -362,9 +363,18 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 		return fmt.Errorf("collections: insert conflict check missing primary keys: got %d, want %d", len(plan.primaryKeys), len(plan.resultIDs))
 	}
 	uniqueRootIDs := uniqueIndexRootIDs(catalog)
+	if len(catalog.rootOverlays) != 0 {
+		uniqueRootIDs = uniqueIndexRootIDsOrOverlays(catalog)
+	}
 	uniqueProbeRuns, err := plan.uniqueProbeRunsForPersistedConflicts(uniqueRootIDs)
 	if err != nil {
 		return err
+	}
+	if len(catalog.rootOverlays) != 0 {
+		if err := plan.checkPersistedDocumentConflictsAtCatalogRoot(snap, catalog); err != nil {
+			return err
+		}
+		return checkPersistedUniqueConflictsAtCatalogRoots(snap, catalog, uniqueProbeRuns)
 	}
 	preflight := insertBatchPreflight{
 		snapshot:           snap,
@@ -375,6 +385,47 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 		return err
 	}
 	return preflight.checkUniqueConflicts(uniqueProbeRuns)
+}
+
+func (plan *insertBatchPlan) checkPersistedDocumentConflictsAtCatalogRoot(snap *backenddb.Snapshot, catalog *collectionCatalog) error {
+	rootName := collectionPrimaryRootName(catalog.meta.Name)
+	for _, key := range plan.primaryKeys {
+		entry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, rootName, key)
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if entry.Flags&node.FlagTombstone == 0 {
+			return ErrDocumentExists
+		}
+	}
+	return nil
+}
+
+func checkPersistedUniqueConflictsAtCatalogRoots(snap *backenddb.Snapshot, catalog *collectionCatalog, runs []collectionUniqueProbeRun) error {
+	if snap == nil || catalog == nil || len(runs) == 0 {
+		return nil
+	}
+	for _, run := range runs {
+		rootName := collectionSecondaryRootName(catalog.meta.Name, run.indexName)
+		for _, prefix := range run.prefixes {
+			it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, prefix, prefixEnd(prefix), false)
+			if err != nil {
+				return err
+			}
+			if it == nil {
+				continue
+			}
+			conflict := it.Valid()
+			_ = it.Close()
+			if conflict {
+				return fmt.Errorf("%w %q", ErrUniqueIndexConflict, run.indexName)
+			}
+		}
+	}
+	return nil
 }
 
 func (plan *insertBatchPlan) uniqueProbeRunsForPersistedConflicts(uniqueRootIDs map[string]uint64) ([]collectionUniqueProbeRun, error) {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -362,19 +362,24 @@ func (plan *insertBatchPlan) checkPersistedConflicts(snap *backenddb.Snapshot, c
 	if len(plan.primaryKeys) != len(plan.resultIDs) {
 		return fmt.Errorf("collections: insert conflict check missing primary keys: got %d, want %d", len(plan.primaryKeys), len(plan.resultIDs))
 	}
-	uniqueRootIDs := uniqueIndexRootIDs(catalog)
 	if len(catalog.rootOverlays) != 0 {
-		uniqueRootIDs = uniqueIndexRootIDsOrOverlays(catalog)
-	}
-	uniqueProbeRuns, err := plan.uniqueProbeRunsForPersistedConflicts(uniqueRootIDs)
-	if err != nil {
-		return err
-	}
-	if len(catalog.rootOverlays) != 0 {
+		uniqueIndexNames := uniqueIndexNamesWithDataOrOverlays(catalog)
+		uniqueProbeRuns, err := plan.uniqueProbeRunsForPersistedConflictIndexes(func(indexName string) bool {
+			_, ok := uniqueIndexNames[indexName]
+			return ok
+		})
+		if err != nil {
+			return err
+		}
 		if err := plan.checkPersistedDocumentConflictsAtCatalogRoot(snap, catalog); err != nil {
 			return err
 		}
 		return checkPersistedUniqueConflictsAtCatalogRoots(snap, catalog, uniqueProbeRuns)
+	}
+	uniqueRootIDs := uniqueIndexRootIDs(catalog)
+	uniqueProbeRuns, err := plan.uniqueProbeRunsForPersistedConflicts(uniqueRootIDs)
+	if err != nil {
+		return err
 	}
 	preflight := insertBatchPreflight{
 		snapshot:           snap,
@@ -419,7 +424,14 @@ func checkPersistedUniqueConflictsAtCatalogRoots(snap *backenddb.Snapshot, catal
 				continue
 			}
 			conflict := it.Valid()
-			_ = it.Close()
+			iterErr := it.Error()
+			closeErr := it.Close()
+			if iterErr != nil {
+				return iterErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
 			if conflict {
 				return fmt.Errorf("%w %q", ErrUniqueIndexConflict, run.indexName)
 			}
@@ -432,15 +444,28 @@ func (plan *insertBatchPlan) uniqueProbeRunsForPersistedConflicts(uniqueRootIDs 
 	if plan == nil || len(plan.resultIDs) == 0 || len(uniqueRootIDs) == 0 {
 		return nil, nil
 	}
+	return plan.uniqueProbeRunsForPersistedConflictIndexes(func(indexName string) bool {
+		return uniqueRootIDs[indexName] != 0
+	})
+}
+
+func (plan *insertBatchPlan) uniqueProbeRunsForPersistedConflictIndexes(includeIndex func(indexName string) bool) ([]collectionUniqueProbeRun, error) {
+	if plan == nil || len(plan.resultIDs) == 0 || includeIndex == nil {
+		return nil, nil
+	}
 	if plan.allUniqueProbeRunsBuilt {
-		return plan.allUniqueProbeRuns, nil
+		out := make([]collectionUniqueProbeRun, 0, len(plan.allUniqueProbeRuns))
+		for _, run := range plan.allUniqueProbeRuns {
+			if includeIndex(run.indexName) {
+				out = append(out, run)
+			}
+		}
+		return out, nil
 	}
 	if !plan.uniqueProbeCandidatesBuilt {
 		return nil, errors.New("collections: insert conflict check missing unique probe candidates")
 	}
-	return buildUniqueProbeRunsFromSorted(plan.uniqueProbeCandidates, func(indexName string) bool {
-		return uniqueRootIDs[indexName] != 0
-	})
+	return buildUniqueProbeRunsFromSorted(plan.uniqueProbeCandidates, includeIndex)
 }
 
 func (p insertBatchPreflight) checkUniqueConflicts(runs []collectionUniqueProbeRun) error {

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -97,8 +97,12 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_DOCUMENTS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "")
 	if profileBenchBufferedIndexedAsyncFlush(t) {
 		t.Fatal("async flush default=true want false")
+	}
+	if profileBenchBufferedIndexedOverlayRoots(t) {
+		t.Fatal("overlay roots default=true want false")
 	}
 	if got := profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(t); got != 0 {
 		t.Fatalf("async max queued units default=%d want 0", got)
@@ -131,6 +135,10 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "789")
 	if got := profileBenchBufferedIndexedWriteMaxRootRuns(t); got != 789 {
 		t.Fatalf("buffered max root runs=%d want 789", got)
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "true")
+	if !profileBenchBufferedIndexedOverlayRoots(t) {
+		t.Fatal("overlay roots env=true want true")
 	}
 }
 
@@ -2128,6 +2136,10 @@ func profileBenchBufferedIndexedWriteMaxRootRuns(tb testing.TB) int {
 	return profileBenchNonNegativeEnvInt(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", 0)
 }
 
+func profileBenchBufferedIndexedOverlayRoots(tb testing.TB) bool {
+	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", false)
+}
+
 func profileBenchCollectionOptions(tb testing.TB, format collections.DocumentFormat) collections.CollectionOptions {
 	tb.Helper()
 	return collections.CollectionOptions{
@@ -2138,6 +2150,7 @@ func profileBenchCollectionOptions(tb testing.TB, format collections.DocumentFor
 		BufferedIndexedWriteMaxBytes:            profileBenchBufferedIndexedWriteMaxBytes(tb),
 		BufferedIndexedWriteMaxRootRuns:         profileBenchBufferedIndexedWriteMaxRootRuns(tb),
 		BufferedIndexedAsyncFlush:               profileBenchBufferedIndexedAsyncFlush(tb),
+		BufferedIndexedOverlayRoots:             profileBenchBufferedIndexedOverlayRoots(tb),
 		BufferedIndexedAsyncFlushMaxQueuedUnits: profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(tb),
 	}
 }
@@ -2210,6 +2223,9 @@ func reportProfileBenchBufferedIndexedWriteOptions(b *testing.B, opts collection
 		if opts.BufferedIndexedAsyncFlushMaxQueuedUnits > 0 {
 			b.ReportMetric(float64(opts.BufferedIndexedAsyncFlushMaxQueuedUnits), "buffered_async_max_units")
 		}
+	}
+	if opts.BufferedIndexedOverlayRoots {
+		b.ReportMetric(1, "buffered_overlay_roots")
 	}
 }
 

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -98,11 +98,15 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_BYTES", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_WRITE_MAX_ROOT_RUNS", "")
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "")
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH", "")
 	if profileBenchBufferedIndexedAsyncFlush(t) {
 		t.Fatal("async flush default=true want false")
 	}
 	if profileBenchBufferedIndexedOverlayRoots(t) {
 		t.Fatal("overlay roots default=true want false")
+	}
+	if profileBenchCompactOverlayRootsAfterFlush(t) {
+		t.Fatal("compact overlay roots after flush default=true want false")
 	}
 	if got := profileBenchBufferedIndexedAsyncFlushMaxQueuedUnits(t); got != 0 {
 		t.Fatalf("async max queued units default=%d want 0", got)
@@ -139,6 +143,10 @@ func TestProfileBenchBufferedIndexedAsyncFlushEnv(t *testing.T) {
 	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", "true")
 	if !profileBenchBufferedIndexedOverlayRoots(t) {
 		t.Fatal("overlay roots env=true want true")
+	}
+	t.Setenv("MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH", "true")
+	if !profileBenchCompactOverlayRootsAfterFlush(t) {
+		t.Fatal("compact overlay roots after flush env=true want true")
 	}
 }
 
@@ -672,6 +680,7 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	if err := manager.FlushAll(); err != nil {
 		b.Fatalf("flush preload: %v", err)
 	}
+	preloadCompactStats := compactProfileBenchOverlayRootsAfterFlush(b, collection, "preload")
 	if err := backend.Checkpoint(); err != nil {
 		b.Fatalf("checkpoint preload: %v", err)
 	}
@@ -694,6 +703,7 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	if err := manager.FlushAll(); err != nil {
 		b.Fatalf("flush warm up: %v", err)
 	}
+	warmupCompactStats := compactProfileBenchOverlayRootsAfterFlush(b, collection, "warmup")
 	if err := backend.Checkpoint(); err != nil {
 		b.Fatalf("checkpoint warm up: %v", err)
 	}
@@ -720,6 +730,8 @@ func benchmarkDirectCollectionConcurrentUpdateBSON(b *testing.B, indexes []colle
 	}
 	b.ReportMetric(float64(writers), "writers")
 	reportProfileBenchBufferedIndexedWriteOptions(b, collection.Meta().Options)
+	reportProfileBenchOverlayCompactionStats(b, "preload", preloadCompactStats)
+	reportProfileBenchOverlayCompactionStats(b, "warmup", warmupCompactStats)
 	reportCollectionManagerUpdateStats(b, deltaCollectionManagerUpdateStats(manager.StatsSnapshot(), statsBefore), b.N)
 	backendStatsAfter := backend.Stats()
 	reportProfileBenchOrderedRootPublishStats(b, backendStatsAfter, backendStatsBefore, b.N)
@@ -742,6 +754,21 @@ func runProfileBenchTimedUpdatePhase(ctx context.Context, run func(context.Conte
 		err = run(ctx)
 	})
 	return err
+}
+
+func compactProfileBenchOverlayRootsAfterFlush(tb testing.TB, collection *collections.Collection, phase string) collections.CollectionRootOverlayCompactionStats {
+	tb.Helper()
+	if !profileBenchCompactOverlayRootsAfterFlush(tb) {
+		return collections.CollectionRootOverlayCompactionStats{}
+	}
+	if collection == nil {
+		tb.Fatalf("compact overlay roots after %s: collection is nil", phase)
+	}
+	stats, err := collection.CompactRootOverlays(context.Background())
+	if err != nil {
+		tb.Fatalf("compact overlay roots after %s: %v", phase, err)
+	}
+	return stats
 }
 
 func profileBenchParsedUpdateDocs(tb testing.TB, updateCity bool, cityPhase string) []profileBenchSetUpdate {
@@ -2140,6 +2167,10 @@ func profileBenchBufferedIndexedOverlayRoots(tb testing.TB) bool {
 	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS", false)
 }
 
+func profileBenchCompactOverlayRootsAfterFlush(tb testing.TB) bool {
+	return profileBenchBoolEnv(tb, "MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH", false)
+}
+
 func profileBenchCollectionOptions(tb testing.TB, format collections.DocumentFormat) collections.CollectionOptions {
 	tb.Helper()
 	return collections.CollectionOptions{
@@ -2227,6 +2258,21 @@ func reportProfileBenchBufferedIndexedWriteOptions(b *testing.B, opts collection
 	if opts.BufferedIndexedOverlayRoots {
 		b.ReportMetric(1, "buffered_overlay_roots")
 	}
+	if profileBenchCompactOverlayRootsAfterFlush(b) {
+		b.ReportMetric(1, "compact_overlay_roots_after_flush")
+	}
+}
+
+func reportProfileBenchOverlayCompactionStats(b *testing.B, phase string, stats collections.CollectionRootOverlayCompactionStats) {
+	b.Helper()
+	if !profileBenchCompactOverlayRootsAfterFlush(b) {
+		return
+	}
+	if phase == "" {
+		phase = "unknown"
+	}
+	b.ReportMetric(float64(stats.Roots), phase+"_overlay_compact_roots")
+	b.ReportMetric(float64(stats.OverlayRoots), phase+"_overlay_compact_overlay_roots")
 }
 
 func reportDocsPerSecond(b *testing.B, docs int, elapsed time.Duration) {


### PR DESCRIPTION
## Summary
- add `Collection.CompactRootOverlays(ctx)` as the explicit maintenance boundary for durable collection overlay roots
- fold each overlay root stack into a rebuilt base collection root and clear the corresponding `collections/root-overlay/<root>` descriptor in the same backend commit
- preserve visible primary/secondary/index-state semantics by compacting through the catalog-root merged iterator, so overlay tombstones still hide base entries
- refresh collection and write-domain catalog caches after compaction
- add `MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH=true` so the focused mongo gateway update benchmark can compact overlays after preload/warmup flushes before the timed phase

This is the stacked architectural follow-up to #1225. #1225 proves durable overlay roots as a committed write-back shape; this PR adds the first explicit mechanism to return those overlays to a simple one-root read shape. It is still an explicit maintenance primitive, not the final background scheduler.

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCompactRootOverlaysFoldsIntoBaseRoots|TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks|TestCollectionIndexedOverlayRootValidationRejectsStaleOverlayDescriptors' -count 1`
- `GOWORK=off go test ./TreeDB/collections -count 1`
- `GOWORK=off go test ./TreeDB/db -count 1`
- `GOWORK=off go test ./cmd/mongo_gateway_bench -run 'TestProfileBenchBufferedIndexedAsyncFlushEnv' -count 1`
- `GOWORK=off go test ./cmd/mongo_gateway_bench -count 1`
- `git diff --check`

## Focused benchmark
Command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=1000000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS=true \
MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH=true \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=1000000x \
  -benchmem \
  -count=1
```

Result: `11575 ns/op`, `86393 docs/sec`, `13953 B/op`, `10 allocs/op`; `compact_overlay_roots_after_flush=1`, `preload_overlay_compact_roots=4`, `warmup_overlay_compact_roots=2`, `update_current_read_ns/doc=5673`, `publish_delta_group_root_apply_ns/doc=3696`.

Interpretation: this is a correctness/maintenance primitive, not the throughput win by itself. It confirms that cadence alone does not resolve the hot-path architecture: even after compaction before the timed phase, coalesced overlay flushes still pay root apply, and current reads still remain too expensive. The next high-value architectural work should avoid per-flush root apply and/or avoid overlay miss probes, likely through background/prebuilt root apply, overlay read manifests/filters, or a committed overlay read index.

## Architectural note
This intentionally does not claim to solve the hot publish path by itself. It gives the overlay-root design a correctness-tested collapse operation that future PRs can schedule asynchronously or replace with prebuilt/off-lock root application. The expected end state remains: writes publish durable flush units cheaply, compaction folds overlays before read fanout grows, and eventually root construction moves out of the writer critical path.
