### PR TITLE
db: prefer optimistic batch root publish

### DIFF
--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1373,10 +1373,6 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 
 func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered []OrderedRootDeltaBatchPublishInput, preflight OrderedRootGroupPreflight, buildSystemDeltaIter OrderedRootGroupSystemBuilder) (newSystemRoot uint64, rootIDs []uint64, err error) {
 	if preflight == nil && db != nil && !db.closing.Load() {
-		if db.writeMu.TryLock() {
-			db.writeMu.Unlock()
-			return db.publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(ordered, preflight, buildSystemDeltaIter)
-		}
 		var retry bool
 		newSystemRoot, rootIDs, retry, err = db.tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered, buildSystemDeltaIter)
 		if err != nil || !retry {


### PR DESCRIPTION
## Summary
- remove the uncontended `writeMu.TryLock` fast-exit from ordered root delta-batch group publishing
- route preflight-free batch root publishes through the existing optimistic apply path by default
- keep the serialized fallback when optimistic apply cannot safely proceed, such as base root 0, missing system root, or system-root race

This is an architectural root-publishing change, not a local allocation tweak. The existing optimistic path already builds root changes before the commit critical section and commits with validation; this PR makes that the normal batch path instead of using it only when the write lock is already contended.

## Validation
- `GOWORK=off go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroup' -count 1`
- `GOWORK=off go test ./TreeDB/db -count 1`
- `GOWORK=off go test ./TreeDB/collections -count 1`
- `GOWORK=off go test ./cmd/mongo_gateway_bench -count 1`
- `git diff --check`

## Focused benchmark
Command:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=1000000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=1000000x \
  -benchmem \
  -count=1
```

Result: `6663 ns/op`, `150078 docs/sec`, `2258 B/op`, `4 allocs/op`; `publish_delta_group_lock_hold_ns/doc=23.57`, `publish_delta_group_root_apply_ns/doc=2426`, `update_current_read_ns/doc=1616`.

Comparison point from #1225 baseline/default path before this change: `6795 ns/op`, `147160 docs/sec`, `2329 B/op`, `4 allocs/op`; `publish_delta_group_lock_hold_ns/doc` tracked the serialized root apply path and was roughly `2736 ns/doc`.

Interpretation: throughput moves only modestly in this focused run, but the important architectural metric changes materially: root apply work is no longer part of the commit lock hold in the normal batch path. This is the right direction for the synchronized collection root-publishing ceiling because it shortens the unavoidable critical section instead of just reducing local per-document costs.
