### PR TITLE
db: rebase optimistic system root deltas

### DIFF
--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1442,8 +1442,10 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		if freeErr := rootTracker.FreeAll(); freeErr != nil && err == nil {
 			err = freeErr
 		}
-		if freeErr := systemTracker.FreeAll(); freeErr != nil && err == nil {
-			err = freeErr
+		if systemTracker != nil {
+			if freeErr := systemTracker.FreeAll(); freeErr != nil && err == nil {
+				err = freeErr
+			}
 		}
 	}
 	defer func() {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -35,6 +35,8 @@ const (
 // delta streams bounded rather than using this as a bulk-load accumulator.
 var orderedRootDeltaBatchInlineThreshold = int(^uint(0) >> 1)
 
+const orderedRootOptimisticSystemDeltaRebaseMaxAttempts = 4
+
 type orderedRootPublishStats struct {
 	warmAttempts                          uint64
 	warmNativeApplyAttempts               uint64
@@ -1433,10 +1435,14 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		return 0, nil, retrySerialized, nil
 	}
 
-	tracker := newAllocTracker(idx.allocator)
+	rootTracker := newAllocTracker(idx.allocator)
+	var systemTracker *allocTracker
 	commitStarted := false
 	freeTrackedPages := func() {
-		if freeErr := tracker.FreeAll(); freeErr != nil && err == nil {
+		if freeErr := rootTracker.FreeAll(); freeErr != nil && err == nil {
+			err = freeErr
+		}
+		if freeErr := systemTracker.FreeAll(); freeErr != nil && err == nil {
 			err = freeErr
 		}
 	}
@@ -1448,15 +1454,15 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 
 	rootIDs = make([]uint64, len(ordered))
 	systemOpts := systemRootOrderedPublishOptions(db)
-	var retired []uint64
-	var merged adaptive.Metrics
+	var nonSystemRetired []uint64
+	var nonSystemMetrics adaptive.Metrics
 	for orderedIdx := range ordered {
 		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[orderedIdx].StoragePolicy)
 		if err != nil {
 			return 0, nil, false, err
 		}
 		phaseStart := time.Now()
-		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaBatchWithAllocator(idx, ordered[orderedIdx].BaseRoot, ordered[orderedIdx].Delta, opts, tracker, tracker)
+		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaBatchWithAllocator(idx, ordered[orderedIdx].BaseRoot, ordered[orderedIdx].Delta, opts, rootTracker, rootTracker)
 		phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 		phaseStats.rootApplyCalls++
 		if err != nil {
@@ -1464,76 +1470,97 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		}
 		rootIDs[orderedIdx] = rootID
 		rootsObserved++
-		retired = append(retired, rootRetired...)
-		mergeOrderedRootPublishMetrics(&merged, metrics)
+		nonSystemRetired = append(nonSystemRetired, rootRetired...)
+		mergeOrderedRootPublishMetrics(&nonSystemMetrics, metrics)
 		phaseStats.rootApplyMetrics.add(metrics)
 	}
 
-	phaseStart := time.Now()
-	iter, err := buildSystemDeltaIter(append([]uint64(nil), rootIDs...))
-	phaseStats.systemBuildNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
-	if err != nil {
-		return 0, nil, false, err
-	}
-	if iter == nil {
-		return 0, nil, false, errors.New("nil system root delta iterator")
-	}
-	systemDelta, err := orderedRootDeltaBatchFromIterator(iter)
-	_ = iter.Close()
-	if err != nil {
-		return 0, nil, false, err
-	}
-	defer func() { _ = systemDelta.Close() }()
-	phaseStart = time.Now()
-	rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaBatchWithAllocator(idx, baseSystemRoot, systemDelta, systemOpts, tracker, tracker)
-	phaseStats.systemApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
-	phaseStats.systemApplyCalls++
-	if err != nil {
-		return 0, nil, false, err
-	}
-	newSystemRoot = rootID
-	retired = append(retired, rootRetired...)
-	mergeOrderedRootPublishMetrics(&merged, metrics)
-	phaseStats.systemApplyMetrics.add(metrics)
+	systemBaseRoot := baseSystemRoot
+	var committedRootPages []uint64
+	var committedSystemPages []uint64
+	for attempt := 0; ; attempt++ {
+		systemTracker = newAllocTracker(idx.allocator)
+		phaseStart := time.Now()
+		iter, err := buildSystemDeltaIter(append([]uint64(nil), rootIDs...))
+		phaseStats.systemBuildNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
+		if err != nil {
+			return 0, nil, false, err
+		}
+		if iter == nil {
+			return 0, nil, false, errors.New("nil system root delta iterator")
+		}
+		systemDelta, err := orderedRootDeltaBatchFromIterator(iter)
+		_ = iter.Close()
+		if err != nil {
+			return 0, nil, false, err
+		}
+		phaseStart = time.Now()
+		rootID, systemRetired, systemMetrics, applyErr := db.publishOrderedRootDeltaBatchWithAllocator(idx, systemBaseRoot, systemDelta, systemOpts, systemTracker, systemTracker)
+		phaseStats.systemApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
+		phaseStats.systemApplyCalls++
+		_ = systemDelta.Close()
+		if applyErr != nil {
+			err = applyErr
+			return 0, nil, false, err
+		}
+		phaseStats.systemApplyMetrics.add(systemMetrics)
 
-	lockStart := time.Now()
-	db.commitMu.Lock()
-	holdStart := time.Now()
-	wait := holdStart.Sub(lockStart)
-	db.mu.RLock()
-	curUserRoot := db.meta.UserRootPageID
-	curSystemRoot := db.meta.SystemRootPageID
-	db.mu.RUnlock()
-	if curSystemRoot != baseSystemRoot {
+		lockStart := time.Now()
+		db.commitMu.Lock()
+		holdStart := time.Now()
+		wait := holdStart.Sub(lockStart)
+		db.mu.RLock()
+		curUserRoot := db.meta.UserRootPageID
+		curSystemRoot := db.meta.SystemRootPageID
+		db.mu.RUnlock()
+		if curSystemRoot != systemBaseRoot {
+			db.commitMu.Unlock()
+			if freeErr := systemTracker.FreeAll(); freeErr != nil {
+				err = freeErr
+				return 0, nil, false, err
+			}
+			systemTracker = nil
+			if curSystemRoot == 0 || attempt+1 >= orderedRootOptimisticSystemDeltaRebaseMaxAttempts {
+				retrySerialized = true
+				return 0, nil, retrySerialized, nil
+			}
+			systemBaseRoot = curSystemRoot
+			continue
+		}
+		if curUserRoot == 0 {
+			curUserRoot = baseUserRoot
+		}
+
+		retired := append([]uint64(nil), nonSystemRetired...)
+		retired = append(retired, systemRetired...)
+		merged := nonSystemMetrics
+		mergeOrderedRootPublishMetrics(&merged, systemMetrics)
+		newSystemRoot = rootID
+
+		// Batch-based grouped deltas have the same value-log reachability shape as
+		// iterator-based grouped deltas: non-system roots changed, and the system
+		// delta can change collection descriptors. Keep the incremental ref tracker
+		// conservative by invalidating it after commit.
+		var vlogRefDelta *valueLogRefDelta
+		phaseStart = time.Now()
+		var post finalizeCommitPost
+		commitStarted = true
+		post, err = db.finalizeCommitLocked(curUserRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil)
+		phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
+		phaseStats.finalizeCalls++
+		hold := time.Since(holdStart)
+		committedRootPages = rootTracker.Pages()
+		committedSystemPages = systemTracker.Pages()
 		db.commitMu.Unlock()
-		retrySerialized = true
-		return 0, nil, retrySerialized, nil
+		if err != nil {
+			return 0, nil, false, err
+		}
+		db.invalidateLeafGenerationSubtreeStats(append(committedRootPages, committedSystemPages...))
+		db.finalizeCommitPostWork(post)
+		db.writeMu.RUnlock()
+		db.observeOrderedRootDeltaGroupPublish(wait, hold, rootsObserved, phaseStats, nil)
+		return newSystemRoot, rootIDs, false, nil
 	}
-	if curUserRoot == 0 {
-		curUserRoot = baseUserRoot
-	}
-
-	// Batch-based grouped deltas have the same value-log reachability shape as
-	// iterator-based grouped deltas: non-system roots changed, and the system
-	// delta can change collection descriptors. Keep the incremental ref tracker
-	// conservative by invalidating it after commit.
-	var vlogRefDelta *valueLogRefDelta
-	phaseStart = time.Now()
-	var post finalizeCommitPost
-	commitStarted = true
-	post, err = db.finalizeCommitLocked(curUserRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil)
-	phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
-	phaseStats.finalizeCalls++
-	hold := time.Since(holdStart)
-	db.commitMu.Unlock()
-	if err != nil {
-		return 0, nil, false, err
-	}
-	db.invalidateLeafGenerationSubtreeStats(tracker.Pages())
-	db.finalizeCommitPostWork(post)
-	db.writeMu.RUnlock()
-	db.observeOrderedRootDeltaGroupPublish(wait, hold, rootsObserved, phaseStats, nil)
-	return newSystemRoot, rootIDs, false, nil
 }
 
 func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(ordered []OrderedRootDeltaBatchPublishInput, preflight OrderedRootGroupPreflight, buildSystemDeltaIter OrderedRootGroupSystemBuilder) (newSystemRoot uint64, rootIDs []uint64, err error) {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1373,10 +1373,6 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered []Order
 
 func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered []OrderedRootDeltaBatchPublishInput, preflight OrderedRootGroupPreflight, buildSystemDeltaIter OrderedRootGroupSystemBuilder) (newSystemRoot uint64, rootIDs []uint64, err error) {
 	if preflight == nil && db != nil && !db.closing.Load() {
-		if db.writeMu.TryLock() {
-			db.writeMu.Unlock()
-			return db.publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(ordered, preflight, buildSystemDeltaIter)
-		}
 		var retry bool
 		newSystemRoot, rootIDs, retry, err = db.tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered, buildSystemDeltaIter)
 		if err != nil || !retry {

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"reflect"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1354,6 +1355,13 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptimisticRebas
 	aBuilderEntered := make(chan struct{})
 	releaseABuilder := make(chan struct{})
 	aDone := make(chan publishResult, 1)
+	var releaseABuilderOnce sync.Once
+	releaseA := func() {
+		releaseABuilderOnce.Do(func() {
+			close(releaseABuilder)
+		})
+	}
+	t.Cleanup(releaseA)
 	var aBuilderCalls atomic.Int32
 	go func() {
 		systemRoot, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
@@ -1398,7 +1406,7 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptimisticRebas
 		t.Fatalf("systemRootB=%d rootIDsB=%v, want non-zero roots", systemRootB, rootIDsB)
 	}
 
-	close(releaseABuilder)
+	releaseA()
 	var resultA publishResult
 	select {
 	case resultA = <-aDone:

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"reflect"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1303,6 +1304,161 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptimisticPrese
 	}
 	if got := string(entry.Value); got != "vb" {
 		t.Fatalf("root/b=%q want vb", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptimisticRebasesSystemDeltaAfterConcurrentSystemCommit(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	baseRootA, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t,
+		"root/a", "va",
+	).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root A: %v", err)
+	}
+	baseRootB, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t,
+		"root/x", "vx",
+	).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish base root B: %v", err)
+	}
+
+	deltaTableA := mustFrozenSystemMemtable(t, "root/b", "vb")
+	iterA := deltaTableA.NewIterator(nil, nil)
+	deltaA, err := OrderedRootDeltaBatchFromIterator(iterA)
+	_ = iterA.Close()
+	if err != nil {
+		t.Fatalf("OrderedRootDeltaBatchFromIterator A: %v", err)
+	}
+	defer func() { _ = deltaA.Close() }()
+
+	deltaTableB := mustFrozenSystemMemtable(t, "root/y", "vy")
+	iterB := deltaTableB.NewIterator(nil, nil)
+	deltaB, err := OrderedRootDeltaBatchFromIterator(iterB)
+	_ = iterB.Close()
+	if err != nil {
+		t.Fatalf("OrderedRootDeltaBatchFromIterator B: %v", err)
+	}
+	defer func() { _ = deltaB.Close() }()
+
+	type publishResult struct {
+		systemRoot uint64
+		rootIDs    []uint64
+		err        error
+	}
+	aBuilderEntered := make(chan struct{})
+	releaseABuilder := make(chan struct{})
+	aDone := make(chan publishResult, 1)
+	var aBuilderCalls atomic.Int32
+	go func() {
+		systemRoot, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+			BaseRoot: baseRootA,
+			Delta:    deltaA,
+		}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			if len(rootIDs) != 1 || rootIDs[0] == 0 {
+				return nil, errors.New("unexpected root IDs for A")
+			}
+			if aBuilderCalls.Add(1) == 1 {
+				close(aBuilderEntered)
+				<-releaseABuilder
+			}
+			return mustFrozenSystemMemtable(t,
+				"sys/collections/a/primary", strconv.FormatUint(rootIDs[0], 10),
+			).NewIterator(nil, nil), nil
+		})
+		aDone <- publishResult{systemRoot: systemRoot, rootIDs: rootIDs, err: err}
+	}()
+
+	select {
+	case <-aBuilderEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("publish A did not reach system delta builder")
+	}
+
+	systemRootB, rootIDsB, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+		BaseRoot: baseRootB,
+		Delta:    deltaB,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 || rootIDs[0] == 0 {
+			return nil, errors.New("unexpected root IDs for B")
+		}
+		return mustFrozenSystemMemtable(t,
+			"sys/collections/b/primary", strconv.FormatUint(rootIDs[0], 10),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish B: %v", err)
+	}
+	if systemRootB == 0 || len(rootIDsB) != 1 || rootIDsB[0] == 0 {
+		t.Fatalf("systemRootB=%d rootIDsB=%v, want non-zero roots", systemRootB, rootIDsB)
+	}
+
+	close(releaseABuilder)
+	var resultA publishResult
+	select {
+	case resultA = <-aDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("publish A did not complete after system root rebase")
+	}
+	if resultA.err != nil {
+		t.Fatalf("publish A: %v", resultA.err)
+	}
+	if resultA.systemRoot == 0 || len(resultA.rootIDs) != 1 || resultA.rootIDs[0] == 0 {
+		t.Fatalf("systemRootA=%d rootIDsA=%v, want non-zero roots", resultA.systemRoot, resultA.rootIDs)
+	}
+	if got := aBuilderCalls.Load(); got != 2 {
+		t.Fatalf("A system delta builder calls=%d want 2", got)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.publish.ordered_root_delta_group.calls_total"]; got != "2" {
+		t.Fatalf("calls stat=%q want 2", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.errors_total"]; got != "0" {
+		t.Fatalf("errors stat=%q want 0", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_calls_total"]; got != "2" {
+		t.Fatalf("root apply calls stat=%q want 2; non-system root work should not be rebuilt after system-root rebase", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.system_apply_calls_total"]; got != "3" {
+		t.Fatalf("system apply calls stat=%q want 3", got)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	for key, wantRoot := range map[string]uint64{
+		"sys/collections/a/primary": resultA.rootIDs[0],
+		"sys/collections/b/primary": rootIDsB[0],
+	} {
+		entry, err := snap.GetEntryAtRoot(snap.State().SystemRootPageID, []byte(key))
+		if err != nil {
+			t.Fatalf("GetEntryAtRoot(%s): %v", key, err)
+		}
+		if got := string(entry.Value); got != strconv.FormatUint(wantRoot, 10) {
+			t.Fatalf("%s=%q want %d", key, got, wantRoot)
+		}
+	}
+	for rootID, kv := range map[uint64]map[string]string{
+		resultA.rootIDs[0]: {"root/a": "va", "root/b": "vb"},
+		rootIDsB[0]:        {"root/x": "vx", "root/y": "vy"},
+	} {
+		for key, want := range kv {
+			entry, err := snap.GetEntryAtRoot(rootID, []byte(key))
+			if err != nil {
+				t.Fatalf("GetEntryAtRoot(root=%d key=%s): %v", rootID, key, err)
+			}
+			if got := string(entry.Value); got != want {
+				t.Fatalf("root=%d key=%s got %q want %q", rootID, key, got, want)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Architectural follow-on to #1227. Optimistic batch root publishes already prebuild non-system collection roots outside the commit critical section. This PR keeps that prebuilt non-system work when another optimistic/system-root commit wins the race first: instead of immediately falling back to the serialized full publish path, it rebuilds/reapplies only the small system-root delta against the newer system root, up to a bounded retry count.

This targets root fan-in/system-root contention directly. Independent collection root publishes should not throw away expensive prebuilt non-system zipper work just because an unrelated descriptor delta committed first.

## Correctness

- Keeps the existing serialized fallback when base roots are cold, DB is closing, or system delta rebase keeps racing.
- Frees abandoned system-root attempt pages before retrying.
- Preserves non-system prebuilt roots across a system-root rebase.
- Added a concurrent publish test that forces one optimistic publish to see a newer system root, then verifies:
  - both system descriptors survive,
  - both non-system roots are readable,
  - root apply calls stay at 2 for 2 publishes, proving the losing publish did not rebuild its non-system root,
  - system apply calls are 3, showing only the small system-root delta was retried.

## Local validation

```bash
go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder' -count 1
go test ./TreeDB/db -count 1
go test ./TreeDB/collections -count 1
go test ./cmd/mongo_gateway_bench -count 1
git diff --check
```

## Notes

This is intentionally architecture-level work, not local allocation tuning. It reduces wasted root-apply work under independent system-root publish races and is a step toward a stronger grouped publish model.