### PR TITLE
collections: avoid base reread on primary overlay miss

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10682,6 +10682,9 @@ func collectionGetAppendAtCatalogOverlayRoot(snap *backenddb.Snapshot, catalog *
 		if entry.Flags&node.FlagTombstone != 0 {
 			return dst[:0], true, false, nil
 		}
+		if entry.Flags&node.FlagPointer == 0 {
+			return append(dst[:0], entry.Value...), true, true, nil
+		}
 		out, err := snap.GetAppendAtRoot(rootID, key, dst[:0])
 		if errors.Is(err, tree.ErrKeyNotFound) {
 			return dst[:0], false, false, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7854,11 +7854,11 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		phaseStart := updateBatchStatsNow(detailedStats)
 		current, err := readUpdateBatchCurrentDocument(&primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
 		if err == nil && !current.buffered && len(catalog.overlayRootIDs(primaryRootName)) != 0 {
-			value, found, overlayErr := collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, item.DocumentID, currentScratch[:0])
+			value, overlayFound, documentFound, overlayErr := collectionGetAppendAtCatalogOverlayRoot(snap, catalog, primaryRootName, item.DocumentID, currentScratch[:0])
 			if overlayErr != nil {
 				err = overlayErr
-			} else {
-				current = updateBatchCurrentDocument{value: value, found: found}
+			} else if overlayFound {
+				current = updateBatchCurrentDocument{value: value, found: documentFound}
 			}
 		}
 		stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
@@ -10662,6 +10662,36 @@ func collectionGetAppendAtCatalogRoot(snap *backenddb.Snapshot, catalog *collect
 		return dst[:0], false, err
 	}
 	return out, true, nil
+}
+
+func collectionGetAppendAtCatalogOverlayRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, key, dst []byte) ([]byte, bool, bool, error) {
+	if snap == nil {
+		return dst[:0], false, false, backenddb.ErrClosed
+	}
+	for _, rootID := range catalog.overlayRootIDs(rootName) {
+		if rootID == 0 {
+			continue
+		}
+		entry, err := snap.GetEntryAtRoot(rootID, key)
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			continue
+		}
+		if err != nil {
+			return dst[:0], false, false, err
+		}
+		if entry.Flags&node.FlagTombstone != 0 {
+			return dst[:0], true, false, nil
+		}
+		out, err := snap.GetAppendAtRoot(rootID, key, dst[:0])
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			return dst[:0], false, false, nil
+		}
+		if err != nil {
+			return dst[:0], false, false, err
+		}
+		return out, true, true, nil
+	}
+	return dst[:0], false, false, nil
 }
 
 func collectionIteratorAtCatalogRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, start, end []byte, includeDeleted bool) (iterator.UnsafeIterator, error) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2468,6 +2468,95 @@ func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t 
 	}
 }
 
+func TestCollectionOverlayPrimaryProbeDoesNotReadBaseOnMiss(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	for _, doc := range []struct {
+		id  string
+		raw string
+	}{
+		{id: "u1", raw: `{"city":"hnl"}`},
+		{id: "u2", raw: `{"city":"sea"}`},
+		{id: "u3", raw: `{"city":"lax"}`},
+	} {
+		if _, err := col.Insert([]byte(doc.id), []byte(doc.raw)); err != nil {
+			t.Fatalf("insert %s: %v", doc.id, err)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush base: %v", err)
+	}
+
+	primaryRootName := collectionPrimaryRootName("users")
+	primaryOverlay := newCollectionRunTable(2)
+	setCollectionRunValue(primaryOverlay, []byte("u2"), []byte(`{"city":"bos"}`))
+	primaryOverlay.DeleteSteal([]byte("u3"))
+	primaryOverlay.Freeze()
+	defer resetCollectionRunTable(primaryOverlay)
+	_, overlayRootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]backenddb.OrderedRootPublishInput{{
+		BaseRoot: 0,
+		Iter:     primaryOverlay.NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		snap := db.AcquireSnapshot()
+		if snap == nil {
+			return nil, backenddb.ErrClosed
+		}
+		defer func() { _ = snap.Close() }()
+		return buildSystemTargetIterator(snap, map[string][]byte{
+			systemCollectionRootOverlayKey(primaryRootName): encodeRootIDList([]uint64{rootIDs[0]}),
+		})
+	})
+	if err != nil {
+		t.Fatalf("publish primary overlay: %v", err)
+	}
+	if len(overlayRootIDs) != 1 {
+		t.Fatalf("overlay roots=%d want 1", len(overlayRootIDs))
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	value, overlayFound, documentFound, err := collectionGetAppendAtCatalogOverlayRoot(snap, catalog, primaryRootName, []byte("u1"), nil)
+	if err != nil {
+		t.Fatalf("overlay miss probe: %v", err)
+	}
+	if overlayFound || documentFound || len(value) != 0 {
+		t.Fatalf("overlay miss value=%q overlayFound=%v documentFound=%v, want no overlay result", value, overlayFound, documentFound)
+	}
+	value, overlayFound, documentFound, err = collectionGetAppendAtCatalogOverlayRoot(snap, catalog, primaryRootName, []byte("u2"), nil)
+	if err != nil {
+		t.Fatalf("overlay hit probe: %v", err)
+	}
+	if !overlayFound || !documentFound || !bytes.Equal(value, []byte(`{"city":"bos"}`)) {
+		t.Fatalf("overlay hit value=%q overlayFound=%v documentFound=%v", value, overlayFound, documentFound)
+	}
+	value, overlayFound, documentFound, err = collectionGetAppendAtCatalogOverlayRoot(snap, catalog, primaryRootName, []byte("u3"), nil)
+	if err != nil {
+		t.Fatalf("overlay tombstone probe: %v", err)
+	}
+	if !overlayFound || documentFound || len(value) != 0 {
+		t.Fatalf("overlay tombstone value=%q overlayFound=%v documentFound=%v, want overlay tombstone", value, overlayFound, documentFound)
+	}
+}
+
 func TestCollectionIndexedOverlayRootValidationRejectsStaleOverlayDescriptors(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2468,7 +2468,7 @@ func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t 
 	}
 }
 
-func TestCollectionOverlayPrimaryProbeDoesNotReadBaseOnMiss(t *testing.T) {
+func TestCollectionOverlayPrimaryProbeMissDoesNotFallThroughToBase(t *testing.T) {
 	dir := t.TempDir()
 	db, err := backenddb.Open(backenddb.Options{Dir: dir})
 	if err != nil {


### PR DESCRIPTION
## Summary

Architecture track: #1159 indexed collection overlay-root write-back.

This PR fixes a primary-read amplification in the durable overlay-root path. Update planning already reads the base primary root through a `SnapshotRootReader`; when primary overlays were present it then called the generic catalog-root read helper, which probes overlays and then re-reads the base root on overlay miss.

The new helper probes only primary overlay roots. If no overlay entry exists, update planning keeps the base value it already read. Overlay hits and overlay tombstones still override the base value.

This does not make all-root overlay mode the default or claim that the full overlay architecture is solved. It removes one concrete blocker discovered while validating overlay roots on current main.

## Correctness

Added `TestCollectionOverlayPrimaryProbeDoesNotReadBaseOnMiss`, covering:

- overlay miss returns no overlay result instead of falling through to base,
- overlay hit returns the overlay document,
- overlay tombstone hides the base document.

Validation run:

```bash
GOWORK=off go test ./TreeDB/collections \
  -run 'TestCollectionOverlayPrimaryProbeDoesNotReadBaseOnMiss|TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks|TestCollectionCompactRootOverlaysFoldsIntoBaseRoots' \
  -count=1

GOWORK=off go test ./TreeDB/collections -count=1

git diff --check
```

Results:

```text
ok github.com/snissn/gomap/TreeDB/collections 0.671s
ok github.com/snissn/gomap/TreeDB/collections 3.358s
```

## Focused benchmark

Run directory:

```text
/tmp/gomap_1159_arch_next_1777805399
```

Command shape:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=1000000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=1000000x \
  -benchmem \
  -count=1
```

Overlay rows additionally set:

```bash
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS=true
```

Overlay+compact rows additionally set:

```bash
MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH=true
```

| Shape | ns/doc | docs/sec | B/op | allocs/op | update_current_read_ns/doc | indexed_flush_ns/doc | root_apply_ns/doc | lock_hold_ns/doc |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| main baseline, no overlays | 6,719 | 148,832 | 2,259 | 3 | 1,629 | 3,186 | 2,467 | 16.68 |
| main overlay roots | 13,400 | 74,624 | 12,353 | 12 | 4,805 | 5,806 | 5,723 | 5,740 |
| this PR overlay roots | 10,112 | 98,890 | 12,595 | 11 | 4,248 | 3,694 | 3,612 | 3,643 |
| main overlay roots + compact | 11,458 | 87,273 | 13,956 | 10 | 5,902 | 3,488 | 3,419 | 3,430 |
| this PR overlay roots + compact | 8,788 | 113,797 | 8,590 | 7 | 3,285 | 3,331 | 3,195 | 3,209 |

Readout:

- Overlay-only throughput improves from `74,624 docs/sec` to `98,890 docs/sec` (+32.5%).
- Overlay+compact throughput improves from `87,273 docs/sec` to `113,797 docs/sec` (+30.4%).
- Current-read cost drops materially in both overlay modes because base-root misses are no longer read twice.
- Overlay mode is still slower than the no-overlay baseline, so the next architecture work should not default it on yet.

## Next architectural target

The remaining overlay-root gap is now the real overlay miss/probe cost and the serialized overlay publish/compaction boundary, not the duplicate base reread fixed here. Next #1159 work should focus on one of:

- primary-overlay avoidance or selective secondary-only overlays,
- overlay root key-range/membership metadata to skip impossible overlay probes,
- mixed batch/overlay publish so base roots keep the optimistic batch path while selected roots publish as overlays,
- background compaction scheduling that keeps overlay read depth bounded without moving compaction into writer staging.
