### PR TITLE
collections: publish overlay roots from prebuilt batches

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4547,16 +4547,36 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		}
 	}()
 	if collectionMetaUsesIndexedOverlayRoots(work.meta) {
-		ordered, cleanupIters, err := buildBufferedRootOverlayDeltaPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
+		if !bufferedRootOverlayDeltaBatchEligible(work.rootNames, work.rootOverlays) {
+			ordered, cleanupIters, err := buildBufferedRootOverlayDeltaPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
+			if err != nil {
+				return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+			}
+			publishStart := time.Now()
+			newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
+			})
+			publishElapsed := time.Since(publishStart)
+			cleanupIters()
+			if publishErr == nil && len(rootIDs) != len(work.rootNames) {
+				publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
+			}
+			completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, publishElapsed)
+			if publishErr != nil {
+				return publishErr
+			}
+			return completeErr
+		}
+		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
 		if err != nil {
 			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
 		}
 		publishStart := time.Now()
-		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootOverlayDescriptorSystemIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
+		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
 		})
 		publishElapsed := time.Since(publishStart)
-		cleanupIters()
+		cleanupDeltas()
 		if publishErr == nil && len(rootIDs) != len(work.rootNames) {
 			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
 		}
@@ -4586,6 +4606,15 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	return completeErr
 }
 
+func bufferedRootOverlayDeltaBatchEligible(rootNames []string, rootOverlays map[string][]uint64) bool {
+	for _, rootName := range rootNames {
+		if overlayDeltaBaseRoot(rootOverlays[rootName]) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func buildBufferedRootOverlayDeltaPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy, rootOverlays map[string][]uint64) ([]backenddb.OrderedRootDeltaPublishInput, func(), error) {
 	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
 	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
@@ -4600,6 +4629,37 @@ func buildBufferedRootOverlayDeltaPublishInputs(rootNames []string, rootRuns map
 		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
 			BaseRoot:      overlayDeltaBaseRoot(rootOverlays[rootName]),
 			Iter:          iter,
+			StoragePolicy: rootPolicies[rootName],
+		})
+	}
+	return ordered, cleanup, nil
+}
+
+func buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy, rootOverlays map[string][]uint64) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
+	ordered := make([]backenddb.OrderedRootDeltaBatchPublishInput, 0, len(rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	cleanup := func() {
+		for idx := range ordered {
+			if ordered[idx].Delta != nil {
+				_ = ordered[idx].Delta.Close()
+				ordered[idx].Delta = nil
+			}
+		}
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+	}
+	for _, rootName := range rootNames {
+		iter := newBufferedRootRunsIteratorWithDeleted(rootRuns[rootName], nil, nil, true)
+		iterators = append(iterators, iter)
+		delta, err := backenddb.OrderedRootDeltaBatchFromIterator(iter)
+		if err != nil {
+			cleanup()
+			return nil, func() {}, err
+		}
+		ordered = append(ordered, backenddb.OrderedRootDeltaBatchPublishInput{
+			BaseRoot:      overlayDeltaBaseRoot(rootOverlays[rootName]),
+			Delta:         delta,
 			StoragePolicy: rootPolicies[rootName],
 		})
 	}
@@ -4816,14 +4876,25 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	if collectionMetaUsesIndexedOverlayRoots(meta) {
-		ordered, cleanupIters, err := buildBufferedRootOverlayDeltaPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
-		if err != nil {
-			return err
+		if bufferedRootOverlayDeltaBatchEligible(rootNames, rootOverlays) {
+			ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
+			if err != nil {
+				return err
+			}
+			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+			})
+			cleanupDeltas()
+		} else {
+			ordered, cleanupIters, err := buildBufferedRootOverlayDeltaPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
+			if err != nil {
+				return err
+			}
+			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+			})
+			cleanupIters()
 		}
-		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootOverlayDescriptorSystemIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
-		})
-		cleanupIters()
 	} else {
 		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
 		if err != nil {
@@ -9227,19 +9298,14 @@ func (c *Collection) buildRootDescriptorSystemDeltaIteratorForMeta(meta Collecti
 	return buildSystemDeltaIterator(updates)
 }
 
-func (c *Collection) buildRootOverlayDescriptorSystemIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+func (c *Collection) buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {
 	if c == nil || c.db == nil {
 		return nil, backenddb.ErrClosed
 	}
 	if len(rootIDs) != len(rootNames) {
 		return nil, unexpectedOrderedRootCountError(meta.Name, len(rootNames), len(rootIDs))
 	}
-	current := c.db.AcquireSnapshot()
-	if current == nil {
-		return nil, backenddb.ErrClosed
-	}
-	defer func() { _ = current.Close() }()
-	if err := c.validateRootOverlayDescriptorSnapshotForMeta(current, meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs, expectedOverlays); err != nil {
+	if err := c.validateRootOverlayDescriptorSystemDeltaForMeta(meta, expectedCommitSeq, expectedSystemRoot, rootNames, baseRootIDs, expectedOverlays); err != nil {
 		return nil, err
 	}
 	updates := make(map[string][]byte, len(rootNames))
@@ -9248,7 +9314,7 @@ func (c *Collection) buildRootOverlayDescriptorSystemIteratorForMeta(meta Collec
 		overlays := overlayDescriptorRootsAfterDelta(existing, rootIDs[i])
 		updates[systemCollectionRootOverlayKey(rootName)] = encodeRootIDList(overlays)
 	}
-	return buildSystemTargetIterator(current, updates)
+	return buildSystemDeltaIterator(updates)
 }
 
 func (c *Collection) buildRootOverlayCompactionSystemDeltaIteratorForMeta(meta CollectionMeta, expectedCommitSeq, expectedSystemRoot uint64, rootNames []string, baseRootIDs map[string]uint64, expectedOverlays map[string][]uint64, rootIDs []uint64) (iterator.UnsafeIterator, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10682,6 +10682,9 @@ func collectionGetAppendAtCatalogOverlayRoot(snap *backenddb.Snapshot, catalog *
 		if entry.Flags&node.FlagTombstone != 0 {
 			return dst[:0], true, false, nil
 		}
+		if entry.Flags&node.FlagPointer == 0 {
+			return append(dst[:0], entry.Value...), true, true, nil
+		}
 		out, err := snap.GetAppendAtRoot(rootID, key, dst[:0])
 		if errors.Is(err, tree.ErrKeyNotFound) {
 			return dst[:0], false, false, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -9400,6 +9400,15 @@ func (c *Collection) validateRootOverlayDescriptorSystemDeltaForMeta(meta Collec
 	if c == nil || c.db == nil {
 		return backenddb.ErrClosed
 	}
+	for _, rootName := range rootNames {
+		if _, ok := baseRootIDs[rootName]; !ok {
+			return fmt.Errorf("collections: missing base root for collection %q root %q", meta.Name, rootName)
+		}
+	}
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
+	if currentSystemRoot == expectedSystemRoot && currentCommitSeq == expectedCommitSeq {
+		return nil
+	}
 	current := c.db.AcquireSnapshot()
 	if current == nil {
 		return backenddb.ErrClosed

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7854,11 +7854,11 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		phaseStart := updateBatchStatsNow(detailedStats)
 		current, err := readUpdateBatchCurrentDocument(&primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
 		if err == nil && !current.buffered && len(catalog.overlayRootIDs(primaryRootName)) != 0 {
-			value, found, overlayErr := collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, item.DocumentID, currentScratch[:0])
+			value, overlayFound, documentFound, overlayErr := collectionGetAppendAtCatalogOverlayRoot(snap, catalog, primaryRootName, item.DocumentID, currentScratch[:0])
 			if overlayErr != nil {
 				err = overlayErr
-			} else {
-				current = updateBatchCurrentDocument{value: value, found: found}
+			} else if overlayFound {
+				current = updateBatchCurrentDocument{value: value, found: documentFound}
 			}
 		}
 		stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
@@ -10662,6 +10662,36 @@ func collectionGetAppendAtCatalogRoot(snap *backenddb.Snapshot, catalog *collect
 		return dst[:0], false, err
 	}
 	return out, true, nil
+}
+
+func collectionGetAppendAtCatalogOverlayRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, key, dst []byte) ([]byte, bool, bool, error) {
+	if snap == nil {
+		return dst[:0], false, false, backenddb.ErrClosed
+	}
+	for _, rootID := range catalog.overlayRootIDs(rootName) {
+		if rootID == 0 {
+			continue
+		}
+		entry, err := snap.GetEntryAtRoot(rootID, key)
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			continue
+		}
+		if err != nil {
+			return dst[:0], false, false, err
+		}
+		if entry.Flags&node.FlagTombstone != 0 {
+			return dst[:0], true, false, nil
+		}
+		out, err := snap.GetAppendAtRoot(rootID, key, dst[:0])
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			return dst[:0], false, false, nil
+		}
+		if err != nil {
+			return dst[:0], false, false, err
+		}
+		return out, true, true, nil
+	}
+	return dst[:0], false, false, nil
 }
 
 func collectionIteratorAtCatalogRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, start, end []byte, includeDeleted bool) (iterator.UnsafeIterator, error) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2468,6 +2468,95 @@ func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t 
 	}
 }
 
+func TestCollectionOverlayPrimaryProbeDoesNotReadBaseOnMiss(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	for _, doc := range []struct {
+		id  string
+		raw string
+	}{
+		{id: "u1", raw: `{"city":"hnl"}`},
+		{id: "u2", raw: `{"city":"sea"}`},
+		{id: "u3", raw: `{"city":"lax"}`},
+	} {
+		if _, err := col.Insert([]byte(doc.id), []byte(doc.raw)); err != nil {
+			t.Fatalf("insert %s: %v", doc.id, err)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush base: %v", err)
+	}
+
+	primaryRootName := collectionPrimaryRootName("users")
+	primaryOverlay := newCollectionRunTable(2)
+	setCollectionRunValue(primaryOverlay, []byte("u2"), []byte(`{"city":"bos"}`))
+	primaryOverlay.DeleteSteal([]byte("u3"))
+	primaryOverlay.Freeze()
+	defer resetCollectionRunTable(primaryOverlay)
+	_, overlayRootIDs, err := db.PublishOrderedRootGroupWithSystemBuilder([]backenddb.OrderedRootPublishInput{{
+		BaseRoot: 0,
+		Iter:     primaryOverlay.NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		snap := db.AcquireSnapshot()
+		if snap == nil {
+			return nil, backenddb.ErrClosed
+		}
+		defer func() { _ = snap.Close() }()
+		return buildSystemTargetIterator(snap, map[string][]byte{
+			systemCollectionRootOverlayKey(primaryRootName): encodeRootIDList([]uint64{rootIDs[0]}),
+		})
+	})
+	if err != nil {
+		t.Fatalf("publish primary overlay: %v", err)
+	}
+	if len(overlayRootIDs) != 1 {
+		t.Fatalf("overlay roots=%d want 1", len(overlayRootIDs))
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, "users")
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	value, overlayFound, documentFound, err := collectionGetAppendAtCatalogOverlayRoot(snap, catalog, primaryRootName, []byte("u1"), nil)
+	if err != nil {
+		t.Fatalf("overlay miss probe: %v", err)
+	}
+	if overlayFound || documentFound || len(value) != 0 {
+		t.Fatalf("overlay miss value=%q overlayFound=%v documentFound=%v, want no overlay result", value, overlayFound, documentFound)
+	}
+	value, overlayFound, documentFound, err = collectionGetAppendAtCatalogOverlayRoot(snap, catalog, primaryRootName, []byte("u2"), nil)
+	if err != nil {
+		t.Fatalf("overlay hit probe: %v", err)
+	}
+	if !overlayFound || !documentFound || !bytes.Equal(value, []byte(`{"city":"bos"}`)) {
+		t.Fatalf("overlay hit value=%q overlayFound=%v documentFound=%v", value, overlayFound, documentFound)
+	}
+	value, overlayFound, documentFound, err = collectionGetAppendAtCatalogOverlayRoot(snap, catalog, primaryRootName, []byte("u3"), nil)
+	if err != nil {
+		t.Fatalf("overlay tombstone probe: %v", err)
+	}
+	if !overlayFound || documentFound || len(value) != 0 {
+		t.Fatalf("overlay tombstone value=%q overlayFound=%v documentFound=%v, want overlay tombstone", value, overlayFound, documentFound)
+	}
+}
+
 func TestCollectionIndexedOverlayRootValidationRejectsStaleOverlayDescriptors(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2468,7 +2468,7 @@ func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t 
 	}
 }
 
-func TestCollectionOverlayPrimaryProbeDoesNotReadBaseOnMiss(t *testing.T) {
+func TestCollectionOverlayPrimaryProbeMissDoesNotFallThroughToBase(t *testing.T) {
 	dir := t.TempDir()
 	db, err := backenddb.Open(backenddb.Options{Dir: dir})
 	if err != nil {


### PR DESCRIPTION
## Summary

This is the next stacked #1159 architecture step on top of #1229. Overlay-root collection flushes now use the ordered-root batch publish API once an overlay base root exists, so iterator-to-batch materialization happens before entering the DB write critical section.

The first overlay generation still uses the iterator publish path because cold batch builds suppress delete/tombstone entries when `baseRoot == 0`; overlay roots need those tombstones to hide base index entries. Both paths now use the system-delta builder so the system root update remains a delta instead of rebuilding a full system target iterator.

## Architecture effect

This does not default overlay roots on globally. It makes the overlay-root architecture less expensive and keeps the key correctness boundary explicit:

- cold overlay generation: iterator publish path preserves tombstones
- existing overlay generation: prebuilt batch publish path reduces work under `writeMu`
- system metadata update: root-overlay descriptor delta only

## Focused benchmark

Workload:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=1000000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS=true \
GOWORK=off go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=1000000x \
  -benchmem \
  -count=1
```

For compacted overlay shape, add:

```bash
MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH=true
```

Comparison against #1229 local baseline:

| Shape | ns/doc | docs/sec | B/op | allocs/op | update_current_read_ns/doc | indexed_flush_ns/doc | root_apply_ns/doc | lock_hold_ns/doc |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| #1229 overlay roots | 10,112 | 98,890 | 12,595 | 11 | 4,248 | 3,694 | 3,612 | 3,643 |
| this PR overlay roots | 10,032 | 99,676 | 12,352 | 11 | 4,149 | 2,771 | 2,460 | 9.0 |
| #1229 overlay roots + compact | 8,788 | 113,797 | 8,590 | 7 | 3,285 | 3,331 | 3,195 | 3,209 |
| this PR overlay roots + compact | 8,610 | 116,139 | 8,560 | 8 | 3,286 | 2,806 | 2,180 | 549 |

Readout:

- overlay-only lock hold drops from ~3,643 ns/doc to ~9 ns/doc
- overlay+compact lock hold drops from ~3,209 ns/doc to ~549 ns/doc
- root apply drops from ~3.6 us/doc to ~2.46 us/doc in overlay-only and from ~3.2 us/doc to ~2.18 us/doc in overlay+compact
- throughput improves modestly because update-current reads and flush preparation are now the next visible costs

## Validation

```bash
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionOverlayPrimaryProbeDoesNotReadBaseOnMiss|TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks|TestCollectionCompactRootOverlaysFoldsIntoBaseRoots' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test ./TreeDB/db -run 'TestOrderedRootDeltaBatch|TestPublishOrderedRootDelta' -count=1
git diff --check
```