### PR TITLE
collections: add bounded primary overlay filters

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -582,12 +582,27 @@ type collectionCatalog struct {
 	meta               CollectionMeta
 	roots              map[string]uint64
 	rootOverlays       map[string][]uint64
+	rootOverlayFilters map[string]map[uint64]collectionRootOverlayFilter
 	primaryRootName    string
 	templateRootName   string
 	indexStateRootName string
 	indexRuntimes      []indexRuntime
 	indexRuntimesErr   error
 }
+
+type collectionRootOverlayFilter struct {
+	words []uint64
+	count uint32
+}
+
+const (
+	// Overlay filters are handle-local metadata. Persisted overlay descriptors
+	// keep only root IDs, so reopened handles fall back to safe maybe-present
+	// probing instead of growing system-root descriptors.
+	collectionRootOverlayFilterBits    = 2 << 20
+	collectionRootOverlayFilterWords   = collectionRootOverlayFilterBits / 64
+	maxCollectionRootOverlayFilterKeys = 512 << 10
+)
 
 type createIndexBackfillPlan struct {
 	rootNames   []string
@@ -612,20 +627,21 @@ type indexedFlushUnit struct {
 }
 
 type indexedFlushPublishWork struct {
-	pin            *backenddb.Snapshot
-	meta           CollectionMeta
-	catalog        *collectionCatalog
-	baseSystemRoot uint64
-	baseCommitSeq  uint64
-	units          []indexedFlushUnit
-	flushUnit      indexedFlushUnit
-	rootNames      []string
-	rootBaseIDs    map[string]uint64
-	rootOverlays   map[string][]uint64
-	docCount       int
-	byteCount      int64
-	rootRunCount   int
-	rootCount      int
+	pin                *backenddb.Snapshot
+	meta               CollectionMeta
+	catalog            *collectionCatalog
+	baseSystemRoot     uint64
+	baseCommitSeq      uint64
+	units              []indexedFlushUnit
+	flushUnit          indexedFlushUnit
+	rootNames          []string
+	rootBaseIDs        map[string]uint64
+	rootOverlays       map[string][]uint64
+	rootOverlayFilters map[string]collectionRootOverlayFilter
+	docCount           int
+	byteCount          int64
+	rootRunCount       int
+	rootCount          int
 }
 
 type bufferedIndexedCheckpoint struct {
@@ -4547,6 +4563,11 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		}
 	}()
 	if collectionMetaUsesIndexedOverlayRoots(work.meta) {
+		rootOverlayFilters, err := buildCollectionRootOverlayFilters(work.rootNames, work.flushUnit.rootRuns, work.rootOverlays, work.catalog.rootOverlayFilters)
+		if err != nil {
+			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+		}
+		work.rootOverlayFilters = rootOverlayFilters
 		if !bufferedRootOverlayDeltaBatchEligible(work.rootNames, work.rootOverlays) {
 			ordered, cleanupIters, err := buildBufferedRootOverlayDeltaPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
 			if err != nil {
@@ -4772,6 +4793,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	nextCatalog := cloneCatalogWithRootUpdates(baseCatalog, work.meta, work.rootNames, rootIDs)
 	if overlayPublish {
 		nextCatalog = cloneCatalogWithRootOverlays(baseCatalog, work.meta, work.rootNames, rootIDs)
+		nextCatalog = cloneCatalogWithRootOverlayFilters(nextCatalog, work.rootNames, rootIDs, work.rootOverlayFilters)
 	}
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
@@ -4875,7 +4897,12 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	}
 	var newSystemRoot uint64
 	var rootIDs []uint64
+	var rootOverlayFilters map[string]collectionRootOverlayFilter
 	if collectionMetaUsesIndexedOverlayRoots(meta) {
+		rootOverlayFilters, err = buildCollectionRootOverlayFilters(rootNames, flushUnit.rootRuns, rootOverlays, catalog.rootOverlayFilters)
+		if err != nil {
+			return err
+		}
 		if bufferedRootOverlayDeltaBatchEligible(rootNames, rootOverlays) {
 			ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
 			if err != nil {
@@ -4914,6 +4941,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	nextCatalog := cloneCatalogWithRootUpdates(domain.catalog, meta, rootNames, rootIDs)
 	if collectionMetaUsesIndexedOverlayRoots(meta) {
 		nextCatalog = cloneCatalogWithRootOverlays(domain.catalog, meta, rootNames, rootIDs)
+		nextCatalog = cloneCatalogWithRootOverlayFilters(nextCatalog, rootNames, rootIDs, rootOverlayFilters)
 	}
 	oldUnits := domain.indexedFlushUnits
 	oldRuns := domain.rootRuns
@@ -7642,6 +7670,33 @@ func readUpdateBatchCurrentDocument(primaryReader *backenddb.SnapshotRootReader,
 	return updateBatchCurrentDocument{value: value, found: true}, nil
 }
 
+func readUpdateBatchCurrentDocumentAtCatalogRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, primaryRootName string, primaryReader *backenddb.SnapshotRootReader, primaryReaderOK bool, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
+	if buffered.enabled {
+		if itemIndex >= 0 && itemIndex < len(buffered.primaryEntries) {
+			entry := buffered.primaryEntries[itemIndex]
+			if entry.found {
+				if entry.flags&node.FlagTombstone != 0 {
+					return updateBatchCurrentDocument{buffered: true}, nil
+				}
+				return updateBatchCurrentDocument{value: entry.value, buffered: true, found: true}, nil
+			}
+		}
+	}
+	if catalog == nil || len(catalog.overlayRootIDs(primaryRootName)) == 0 {
+		return readUpdateBatchCurrentDocument(primaryReader, primaryReaderOK, -1, documentID, updateBatchBufferedRead{}, dst)
+	}
+	if catalog.rootID(primaryRootName) == 0 || catalog.anyOverlayRootMayContainKey(primaryRootName, documentID) {
+		value, overlayFound, documentFound, err := collectionGetAppendAtCatalogOverlayRoot(snap, catalog, primaryRootName, documentID, dst)
+		if err != nil {
+			return updateBatchCurrentDocument{}, err
+		}
+		if overlayFound {
+			return updateBatchCurrentDocument{value: value, found: documentFound}, nil
+		}
+	}
+	return readUpdateBatchCurrentDocument(primaryReader, primaryReaderOK, -1, documentID, updateBatchBufferedRead{}, dst)
+}
+
 const updateBatchBufferedPrimaryDirectProbeLimit = 1024
 
 func snapshotUpdateBatchBufferedPrimaryEntries(runs []memtable.Table, items []UpdateBatchItem) ([]updateBatchBufferedEntry, *updateBatchBufferedEntryBuffer, error) {
@@ -7923,15 +7978,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	var currentScratch []byte
 	for i, item := range items {
 		phaseStart := updateBatchStatsNow(detailedStats)
-		current, err := readUpdateBatchCurrentDocument(&primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
-		if err == nil && !current.buffered && len(catalog.overlayRootIDs(primaryRootName)) != 0 {
-			value, overlayFound, documentFound, overlayErr := collectionGetAppendAtCatalogOverlayRoot(snap, catalog, primaryRootName, item.DocumentID, currentScratch[:0])
-			if overlayErr != nil {
-				err = overlayErr
-			} else if overlayFound {
-				current = updateBatchCurrentDocument{value: value, found: documentFound}
-			}
-		}
+		current, err := readUpdateBatchCurrentDocumentAtCatalogRoot(snap, catalog, primaryRootName, &primaryReader, primaryReaderOK, i, item.DocumentID, bufferedRead, currentScratch[:0])
 		stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()
@@ -8944,11 +8991,13 @@ func (c *Collection) noteWriteDomainCatalog(systemRoot uint64, catalog *collecti
 func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, rootNames []string, rootIDs []uint64) *collectionCatalog {
 	roots := make(map[string]uint64)
 	var rootOverlays map[string][]uint64
+	var rootOverlayFilters map[string]map[uint64]collectionRootOverlayFilter
 	if base != nil {
 		for name, rootID := range base.roots {
 			roots[name] = rootID
 		}
 		rootOverlays = cloneRootOverlayMap(base.rootOverlays)
+		rootOverlayFilters = cloneRootOverlayFilterMap(base.rootOverlayFilters)
 	}
 	for i, name := range rootNames {
 		if i < len(rootIDs) {
@@ -8956,19 +9005,24 @@ func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, r
 			if len(rootOverlays) != 0 {
 				delete(rootOverlays, name)
 			}
+			if len(rootOverlayFilters) != 0 {
+				delete(rootOverlayFilters, name)
+			}
 		}
 	}
-	return newCollectionCatalogWithOverlays(copyCollectionMeta(meta), roots, rootOverlays)
+	return newCollectionCatalogWithOverlayMetadata(copyCollectionMeta(meta), roots, rootOverlays, rootOverlayFilters)
 }
 
 func cloneCatalogWithRootOverlays(base *collectionCatalog, meta CollectionMeta, rootNames []string, rootIDs []uint64) *collectionCatalog {
 	roots := make(map[string]uint64)
 	var rootOverlays map[string][]uint64
+	var rootOverlayFilters map[string]map[uint64]collectionRootOverlayFilter
 	if base != nil {
 		for name, rootID := range base.roots {
 			roots[name] = rootID
 		}
 		rootOverlays = cloneRootOverlayMap(base.rootOverlays)
+		rootOverlayFilters = cloneRootOverlayFilterMap(base.rootOverlayFilters)
 	}
 	if rootOverlays == nil {
 		rootOverlays = make(map[string][]uint64)
@@ -8978,9 +9032,47 @@ func cloneCatalogWithRootOverlays(base *collectionCatalog, meta CollectionMeta, 
 			continue
 		}
 		existing := rootOverlays[name]
-		rootOverlays[name] = overlayDescriptorRootsAfterDelta(existing, rootIDs[i])
+		overlays := overlayDescriptorRootsAfterDelta(existing, rootIDs[i])
+		rootOverlays[name] = overlays
+		if len(rootOverlayFilters) != 0 {
+			rootOverlayFilters[name] = pruneRootOverlayFilters(rootOverlayFilters[name], overlays)
+			if len(rootOverlayFilters[name]) == 0 {
+				delete(rootOverlayFilters, name)
+			}
+		}
 	}
-	return newCollectionCatalogWithOverlays(copyCollectionMeta(meta), roots, rootOverlays)
+	return newCollectionCatalogWithOverlayMetadata(copyCollectionMeta(meta), roots, rootOverlays, rootOverlayFilters)
+}
+
+func cloneCatalogWithRootOverlayFilters(base *collectionCatalog, rootNames []string, rootIDs []uint64, filters map[string]collectionRootOverlayFilter) *collectionCatalog {
+	if base == nil || len(filters) == 0 {
+		return base
+	}
+	roots := make(map[string]uint64, len(base.roots))
+	for name, rootID := range base.roots {
+		roots[name] = rootID
+	}
+	rootOverlays := cloneRootOverlayMap(base.rootOverlays)
+	rootOverlayFilters := cloneRootOverlayFilterMap(base.rootOverlayFilters)
+	if rootOverlayFilters == nil {
+		rootOverlayFilters = make(map[string]map[uint64]collectionRootOverlayFilter)
+	}
+	for i, rootName := range rootNames {
+		if i >= len(rootIDs) || rootIDs[i] == 0 {
+			continue
+		}
+		filter, ok := filters[rootName]
+		if !ok {
+			continue
+		}
+		byRoot := rootOverlayFilters[rootName]
+		if byRoot == nil {
+			byRoot = make(map[uint64]collectionRootOverlayFilter)
+			rootOverlayFilters[rootName] = byRoot
+		}
+		byRoot[rootIDs[i]] = filter.clone()
+	}
+	return newCollectionCatalogWithOverlayMetadata(copyCollectionMeta(base.meta), roots, rootOverlays, rootOverlayFilters)
 }
 
 func newCollectionCatalog(meta CollectionMeta, roots map[string]uint64) *collectionCatalog {
@@ -8988,10 +9080,15 @@ func newCollectionCatalog(meta CollectionMeta, roots map[string]uint64) *collect
 }
 
 func newCollectionCatalogWithOverlays(meta CollectionMeta, roots map[string]uint64, rootOverlays map[string][]uint64) *collectionCatalog {
+	return newCollectionCatalogWithOverlayMetadata(meta, roots, rootOverlays, nil)
+}
+
+func newCollectionCatalogWithOverlayMetadata(meta CollectionMeta, roots map[string]uint64, rootOverlays map[string][]uint64, rootOverlayFilters map[string]map[uint64]collectionRootOverlayFilter) *collectionCatalog {
 	catalog := &collectionCatalog{
 		meta:               meta,
 		roots:              roots,
 		rootOverlays:       cloneRootOverlayMap(rootOverlays),
+		rootOverlayFilters: cloneRootOverlayFilterMap(rootOverlayFilters),
 		primaryRootName:    collectionPrimaryRootName(meta.Name),
 		templateRootName:   collectionTemplateRootName(meta.Name),
 		indexStateRootName: collectionIndexStateRootName(meta.Name),
@@ -9015,6 +9112,47 @@ func cloneRootOverlayMap(in map[string][]uint64) map[string][]uint64 {
 			continue
 		}
 		out[name] = append([]uint64(nil), roots...)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func cloneRootOverlayFilterMap(in map[string]map[uint64]collectionRootOverlayFilter) map[string]map[uint64]collectionRootOverlayFilter {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]map[uint64]collectionRootOverlayFilter, len(in))
+	for rootName, byRoot := range in {
+		if len(byRoot) == 0 {
+			continue
+		}
+		outByRoot := make(map[uint64]collectionRootOverlayFilter, len(byRoot))
+		for rootID, filter := range byRoot {
+			outByRoot[rootID] = filter.clone()
+		}
+		if len(outByRoot) != 0 {
+			out[rootName] = outByRoot
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func pruneRootOverlayFilters(filters map[uint64]collectionRootOverlayFilter, rootIDs []uint64) map[uint64]collectionRootOverlayFilter {
+	if len(filters) == 0 || len(rootIDs) == 0 {
+		return nil
+	}
+	out := make(map[uint64]collectionRootOverlayFilter, len(rootIDs))
+	for _, rootID := range rootIDs {
+		filter, ok := filters[rootID]
+		if !ok {
+			continue
+		}
+		out[rootID] = filter.clone()
 	}
 	if len(out) == 0 {
 		return nil
@@ -10639,6 +10777,33 @@ func (c *collectionCatalog) overlayRootIDs(rootName string) []uint64 {
 	return c.rootOverlays[rootName]
 }
 
+func (c *collectionCatalog) overlayRootMayContainKey(rootName string, rootID uint64, key []byte) bool {
+	if c == nil || rootID == 0 || len(c.rootOverlayFilters) == 0 {
+		return true
+	}
+	byRoot := c.rootOverlayFilters[rootName]
+	if byRoot == nil {
+		return true
+	}
+	filter, ok := byRoot[rootID]
+	if !ok {
+		return true
+	}
+	return filter.mayContainKey(key)
+}
+
+func (c *collectionCatalog) anyOverlayRootMayContainKey(rootName string, key []byte) bool {
+	if c == nil {
+		return false
+	}
+	for _, rootID := range c.overlayRootIDs(rootName) {
+		if c.overlayRootMayContainKey(rootName, rootID, key) {
+			return true
+		}
+	}
+	return false
+}
+
 func collectionRootStoragePolicy(meta CollectionMeta, rootName string) (backenddb.OrderedRootStoragePolicy, error) {
 	switch rootName {
 	case collectionPrimaryRootName(meta.Name), collectionTemplateRootName(meta.Name):
@@ -10688,7 +10853,11 @@ func collectionGetEntryAtCatalogRoot(snap *backenddb.Snapshot, catalog *collecti
 		entry, err := snap.GetEntryAtRoot(rootID, key)
 		return entry, rootID, err
 	}
+	useOverlayFilters := catalog.rootID(rootName) != 0
 	for _, rootID := range catalog.rootStack(rootName) {
+		if useOverlayFilters && !catalog.overlayRootMayContainKey(rootName, rootID, key) {
+			continue
+		}
 		entry, err := snap.GetEntryAtRoot(rootID, key)
 		if errors.Is(err, tree.ErrKeyNotFound) {
 			continue
@@ -10743,8 +10912,12 @@ func collectionGetAppendAtCatalogOverlayRoot(snap *backenddb.Snapshot, catalog *
 	if snap == nil {
 		return dst[:0], false, false, backenddb.ErrClosed
 	}
+	useOverlayFilters := catalog.rootID(rootName) != 0
 	for _, rootID := range catalog.overlayRootIDs(rootName) {
 		if rootID == 0 {
+			continue
+		}
+		if useOverlayFilters && !catalog.overlayRootMayContainKey(rootName, rootID, key) {
 			continue
 		}
 		entry, err := snap.GetEntryAtRoot(rootID, key)
@@ -10828,7 +11001,8 @@ func (c *collectionCatalog) copy() *collectionCatalog {
 		roots[name] = rootID
 	}
 	rootOverlays := cloneRootOverlayMap(c.rootOverlays)
-	return newCollectionCatalogWithOverlays(copyCollectionMeta(c.meta), roots, rootOverlays)
+	rootOverlayFilters := cloneRootOverlayFilterMap(c.rootOverlayFilters)
+	return newCollectionCatalogWithOverlayMetadata(copyCollectionMeta(c.meta), roots, rootOverlays, rootOverlayFilters)
 }
 
 func getSystemValue(snap *backenddb.Snapshot, key string) ([]byte, bool, error) {
@@ -11363,6 +11537,128 @@ func decodeRootIDList(raw []byte) ([]uint64, error) {
 		out[i] = binary.BigEndian.Uint64(raw[i*8 : (i+1)*8])
 	}
 	return out, nil
+}
+
+func buildCollectionRootOverlayFilters(rootNames []string, rootRuns map[string][]memtable.Table, rootOverlays map[string][]uint64, existingFilters map[string]map[uint64]collectionRootOverlayFilter) (map[string]collectionRootOverlayFilter, error) {
+	if len(rootNames) == 0 || len(rootRuns) == 0 {
+		return nil, nil
+	}
+	filters := make(map[string]collectionRootOverlayFilter, len(rootNames))
+	for _, rootName := range rootNames {
+		// The current read bottleneck is the primary document root; secondary
+		// overlay probes are left on the existing safe path until their cost is
+		// proven separately.
+		if !strings.HasSuffix(rootName, "/primary") {
+			continue
+		}
+		baseRoot := overlayDeltaBaseRoot(rootOverlays[rootName])
+		var baseFilter collectionRootOverlayFilter
+		if baseRoot != 0 {
+			var ok bool
+			baseFilter, ok = existingFilters[rootName][baseRoot]
+			if !ok {
+				continue
+			}
+		}
+		filter, err := buildCollectionRootOverlayFilter(rootRuns[rootName])
+		if err != nil {
+			return nil, err
+		}
+		if baseRoot != 0 {
+			filter = unionCollectionRootOverlayFilters(baseFilter, filter)
+		}
+		if !filter.empty() && filter.count <= maxCollectionRootOverlayFilterKeys {
+			filters[rootName] = filter
+		}
+	}
+	return filters, nil
+}
+
+func buildCollectionRootOverlayFilter(runs []memtable.Table) (collectionRootOverlayFilter, error) {
+	if len(runs) == 0 {
+		return collectionRootOverlayFilter{}, nil
+	}
+	it := newBufferedRootRunsIteratorWithDeleted(runs, nil, nil, true)
+	defer func() { _ = it.Close() }()
+	var filter collectionRootOverlayFilter
+	for it.Valid() {
+		filter.addKey(it.UnsafeKey())
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return collectionRootOverlayFilter{}, err
+	}
+	return filter, nil
+}
+
+func unionCollectionRootOverlayFilters(left, right collectionRootOverlayFilter) collectionRootOverlayFilter {
+	if left.empty() {
+		return right.clone()
+	}
+	if right.empty() {
+		return left.clone()
+	}
+	out := left.clone()
+	for i := range out.words {
+		out.words[i] |= right.words[i]
+	}
+	out.count = saturatingAddUint32(out.count, right.count)
+	return out
+}
+
+func (f collectionRootOverlayFilter) mayContainKey(key []byte) bool {
+	if f.empty() {
+		return false
+	}
+	hash := xxhash.Sum64(key)
+	for i := uint64(0); i < 4; i++ {
+		bit := collectionRootOverlayFilterBit(hash, i)
+		if f.words[bit>>6]&(uint64(1)<<(bit&63)) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (f *collectionRootOverlayFilter) addKey(key []byte) {
+	if f.words == nil {
+		f.words = make([]uint64, collectionRootOverlayFilterWords)
+	}
+	hash := xxhash.Sum64(key)
+	for i := uint64(0); i < 4; i++ {
+		bit := collectionRootOverlayFilterBit(hash, i)
+		f.words[bit>>6] |= uint64(1) << (bit & 63)
+	}
+	if f.count < ^uint32(0) {
+		f.count++
+	}
+}
+
+func (f collectionRootOverlayFilter) clone() collectionRootOverlayFilter {
+	if len(f.words) == 0 {
+		return collectionRootOverlayFilter{}
+	}
+	return collectionRootOverlayFilter{words: append([]uint64(nil), f.words...), count: f.count}
+}
+
+func (f collectionRootOverlayFilter) empty() bool {
+	return len(f.words) == 0
+}
+
+func collectionRootOverlayFilterBit(hash, ordinal uint64) uint64 {
+	mixed := hash + ordinal*0x9e3779b97f4a7c15
+	mixed ^= mixed >> 33
+	mixed *= 0xff51afd7ed558ccd
+	mixed ^= mixed >> 33
+	return mixed & (collectionRootOverlayFilterBits - 1)
+}
+
+func saturatingAddUint32(left, right uint32) uint32 {
+	sum := uint64(left) + uint64(right)
+	if sum > uint64(^uint32(0)) {
+		return ^uint32(0)
+	}
+	return uint32(sum)
 }
 
 func ValidateCollectionName(name string) error {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11568,6 +11568,9 @@ func buildCollectionRootOverlayFilters(rootNames []string, rootRuns map[string][
 		if err != nil {
 			return nil, err
 		}
+		if filter.empty() {
+			continue
+		}
 		if baseRoot != 0 {
 			filter = unionCollectionRootOverlayFilters(baseFilter, filter)
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -9010,7 +9010,7 @@ func cloneCatalogWithRootUpdates(base *collectionCatalog, meta CollectionMeta, r
 			}
 		}
 	}
-	return newCollectionCatalogWithOverlayMetadata(copyCollectionMeta(meta), roots, rootOverlays, rootOverlayFilters)
+	return newCollectionCatalogWithOverlayMetadataOwned(copyCollectionMeta(meta), roots, rootOverlays, rootOverlayFilters)
 }
 
 func cloneCatalogWithRootOverlays(base *collectionCatalog, meta CollectionMeta, rootNames []string, rootIDs []uint64) *collectionCatalog {
@@ -9041,7 +9041,7 @@ func cloneCatalogWithRootOverlays(base *collectionCatalog, meta CollectionMeta, 
 			}
 		}
 	}
-	return newCollectionCatalogWithOverlayMetadata(copyCollectionMeta(meta), roots, rootOverlays, rootOverlayFilters)
+	return newCollectionCatalogWithOverlayMetadataOwned(copyCollectionMeta(meta), roots, rootOverlays, rootOverlayFilters)
 }
 
 func cloneCatalogWithRootOverlayFilters(base *collectionCatalog, rootNames []string, rootIDs []uint64, filters map[string]collectionRootOverlayFilter) *collectionCatalog {
@@ -9072,7 +9072,7 @@ func cloneCatalogWithRootOverlayFilters(base *collectionCatalog, rootNames []str
 		}
 		byRoot[rootIDs[i]] = filter.clone()
 	}
-	return newCollectionCatalogWithOverlayMetadata(copyCollectionMeta(base.meta), roots, rootOverlays, rootOverlayFilters)
+	return newCollectionCatalogWithOverlayMetadataOwned(copyCollectionMeta(base.meta), roots, rootOverlays, rootOverlayFilters)
 }
 
 func newCollectionCatalog(meta CollectionMeta, roots map[string]uint64) *collectionCatalog {
@@ -9084,11 +9084,15 @@ func newCollectionCatalogWithOverlays(meta CollectionMeta, roots map[string]uint
 }
 
 func newCollectionCatalogWithOverlayMetadata(meta CollectionMeta, roots map[string]uint64, rootOverlays map[string][]uint64, rootOverlayFilters map[string]map[uint64]collectionRootOverlayFilter) *collectionCatalog {
+	return newCollectionCatalogWithOverlayMetadataOwned(meta, roots, cloneRootOverlayMap(rootOverlays), cloneRootOverlayFilterMap(rootOverlayFilters))
+}
+
+func newCollectionCatalogWithOverlayMetadataOwned(meta CollectionMeta, roots map[string]uint64, rootOverlays map[string][]uint64, rootOverlayFilters map[string]map[uint64]collectionRootOverlayFilter) *collectionCatalog {
 	catalog := &collectionCatalog{
 		meta:               meta,
 		roots:              roots,
-		rootOverlays:       cloneRootOverlayMap(rootOverlays),
-		rootOverlayFilters: cloneRootOverlayFilterMap(rootOverlayFilters),
+		rootOverlays:       rootOverlays,
+		rootOverlayFilters: rootOverlayFilters,
 		primaryRootName:    collectionPrimaryRootName(meta.Name),
 		templateRootName:   collectionTemplateRootName(meta.Name),
 		indexStateRootName: collectionIndexStateRootName(meta.Name),
@@ -11002,7 +11006,7 @@ func (c *collectionCatalog) copy() *collectionCatalog {
 	}
 	rootOverlays := cloneRootOverlayMap(c.rootOverlays)
 	rootOverlayFilters := cloneRootOverlayFilterMap(c.rootOverlayFilters)
-	return newCollectionCatalogWithOverlayMetadata(copyCollectionMeta(c.meta), roots, rootOverlays, rootOverlayFilters)
+	return newCollectionCatalogWithOverlayMetadataOwned(copyCollectionMeta(c.meta), roots, rootOverlays, rootOverlayFilters)
 }
 
 func getSystemValue(snap *backenddb.Snapshot, key string) ([]byte, bool, error) {
@@ -11583,6 +11587,9 @@ func buildCollectionRootOverlayFilter(runs []memtable.Table) (collectionRootOver
 	var filter collectionRootOverlayFilter
 	for it.Valid() {
 		filter.addKey(it.UnsafeKey())
+		if filter.count > maxCollectionRootOverlayFilterKeys {
+			return collectionRootOverlayFilter{}, it.Error()
+		}
 		it.Next()
 	}
 	if err := it.Error(); err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2571,6 +2571,27 @@ func TestCollectionIndexedOverlayRootFilterUnionsDeltaBase(t *testing.T) {
 	}
 }
 
+func TestCollectionRootOverlayFilterSkipsBaseOnlyUnionWhenDeltaFilterDisabled(t *testing.T) {
+	primaryRootName := collectionPrimaryRootName("users")
+	var baseFilter collectionRootOverlayFilter
+	baseFilter.addKey([]byte("u1"))
+
+	filters, err := buildCollectionRootOverlayFilters(
+		[]string{primaryRootName},
+		map[string][]memtable.Table{primaryRootName: nil},
+		map[string][]uint64{primaryRootName: []uint64{123}},
+		map[string]map[uint64]collectionRootOverlayFilter{
+			primaryRootName: map[uint64]collectionRootOverlayFilter{123: baseFilter},
+		},
+	)
+	if err != nil {
+		t.Fatalf("build overlay filters: %v", err)
+	}
+	if len(filters) != 0 {
+		t.Fatalf("filters=%v, want no base-only filter when delta filter is disabled", filters)
+	}
+}
+
 func TestCollectionOverlayPrimaryProbeMissDoesNotFallThroughToBase(t *testing.T) {
 	dir := t.TempDir()
 	db, err := backenddb.Open(backenddb.Options{Dir: dir})

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2286,6 +2286,9 @@ func TestCollectionCatalogOverlayRootsAreVisibleAfterReopen(t *testing.T) {
 	if got := catalog.overlayRootIDs(cityRootName); !reflect.DeepEqual(got, []uint64{overlayRootIDs[1]}) {
 		t.Fatalf("city overlay roots=%v want [%d]", got, overlayRootIDs[1])
 	}
+	if !catalog.overlayRootMayContainKey(primaryRootName, overlayRootIDs[0], []byte("definitely-missing")) {
+		t.Fatalf("legacy overlay descriptor without filter must fall back to maybe-present")
+	}
 	rawOverlayIt, err := snap.IteratorAtRootWithOptions(overlayRootIDs[1], oldCity, prefixEnd(oldCity), backenddb.IteratorOptions{IncludeTombstones: true})
 	if err != nil {
 		t.Fatalf("open raw old city overlay iterator: %v", err)
@@ -2429,7 +2432,7 @@ func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t 
 	if snap == nil {
 		t.Fatal("acquire snapshot")
 	}
-	catalog, err := loadCollectionCatalog(snap, "users")
+	catalog, err := col.catalogForSnapshot(snap)
 	if err != nil {
 		_ = snap.Close()
 		t.Fatalf("load catalog: %v", err)
@@ -2437,6 +2440,16 @@ func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t 
 	if got := len(catalog.overlayRootIDs(collectionPrimaryRootName("users"))); got != 1 {
 		_ = snap.Close()
 		t.Fatalf("primary overlay roots=%d want 1 coalesced overlay", got)
+	}
+	primaryRootName := collectionPrimaryRootName("users")
+	primaryOverlays := catalog.overlayRootIDs(primaryRootName)
+	if !catalog.overlayRootMayContainKey(primaryRootName, primaryOverlays[0], []byte("u1")) {
+		_ = snap.Close()
+		t.Fatalf("primary overlay filter does not contain updated document")
+	}
+	if catalog.overlayRootMayContainKey(primaryRootName, primaryOverlays[0], []byte("definitely-missing")) {
+		_ = snap.Close()
+		t.Fatalf("primary overlay filter contains unrelated document")
 	}
 	_ = snap.Close()
 	if err := db.Close(); err != nil {
@@ -2465,6 +2478,96 @@ func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t 
 	}
 	if len(reopenedSeaIDs) != 1 || !bytes.Equal(reopenedSeaIDs[0], []byte("u1")) {
 		t.Fatalf("reopened city ids=%q want [u1]", reopenedSeaIDs)
+	}
+	reopenedSnap := reopened.AcquireSnapshot()
+	if reopenedSnap == nil {
+		t.Fatal("acquire reopened snapshot")
+	}
+	reopenedCatalog, err := loadCollectionCatalog(reopenedSnap, "users")
+	if err != nil {
+		_ = reopenedSnap.Close()
+		t.Fatalf("load reopened catalog: %v", err)
+	}
+	reopenedPrimaryOverlays := reopenedCatalog.overlayRootIDs(primaryRootName)
+	if len(reopenedPrimaryOverlays) != 1 {
+		_ = reopenedSnap.Close()
+		t.Fatalf("reopened primary overlay roots=%d want 1", len(reopenedPrimaryOverlays))
+	}
+	if !reopenedCatalog.overlayRootMayContainKey(primaryRootName, reopenedPrimaryOverlays[0], []byte("u1")) {
+		_ = reopenedSnap.Close()
+		t.Fatalf("reopened primary overlay filter does not contain updated document")
+	}
+	if !reopenedCatalog.overlayRootMayContainKey(primaryRootName, reopenedPrimaryOverlays[0], []byte("definitely-missing")) {
+		_ = reopenedSnap.Close()
+		t.Fatalf("reopened primary overlay without in-memory filter must fall back to maybe-present")
+	}
+	_ = reopenedSnap.Close()
+}
+
+func TestCollectionIndexedOverlayRootFilterUnionsDeltaBase(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"city":"hnl"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if _, err := col.Insert([]byte("u2"), []byte(`{"city":"sea"}`)); err != nil {
+		t.Fatalf("insert u2: %v", err)
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("acquire snapshot")
+	}
+	catalog, err := col.catalogForSnapshot(snap)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog: %v", err)
+	}
+	primaryRootName := collectionPrimaryRootName("users")
+	primaryOverlays := catalog.overlayRootIDs(primaryRootName)
+	if len(primaryOverlays) != 1 {
+		_ = snap.Close()
+		t.Fatalf("primary overlay roots=%d want 1 coalesced overlay", len(primaryOverlays))
+	}
+	for _, id := range []string{"u1", "u2"} {
+		if !catalog.overlayRootMayContainKey(primaryRootName, primaryOverlays[0], []byte(id)) {
+			_ = snap.Close()
+			t.Fatalf("primary overlay filter does not contain %s after delta-over-overlay publish", id)
+		}
+	}
+	_ = snap.Close()
+
+	results, buffered, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"city":"bos"}`), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("update u1: %v", err)
+	}
+	if !buffered || len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("update results=%+v buffered=%v", results, buffered)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds bounded, handle-local primary overlay membership filters for collection overlay roots.

This is an architectural read-path improvement for the overlay-root write-back path: after compaction, current update planning can avoid a base-root document read when the primary overlay filter proves the document cannot be in an overlay. The filter is intentionally:

- primary-root only, because the current measured bottleneck is primary current-document reads
- bounded to a 2 MiB-bit Bloom-style filter and capped at ~512K inserted keys
- in-memory only, so system-root overlay descriptors remain compact root-ID lists and reopened handles safely fall back to maybe-present probing
- unioned when an overlay delta is published over a previous overlay root, preventing false negatives for keys that came from the base overlay

I initially prototyped persisted exact hash-set filters and rejected that shape: it bloated system-root overlay descriptors and hit `node is full` in the benchmark path. The final implementation avoids that storage-format/system-root risk.

## Benchmarks

Run directory:

`/tmp/gomap_1159_overlay_bloom_capped_1777809909`

Command shape:

```bash
GOWORK=off \
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=1000000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=1000000x \
  -benchmem \
  -count=1
```

Overlay rows add `MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS=true`; compact row also adds `MONGO_GATEWAY_PROFILE_BENCH_COMPACT_OVERLAY_ROOTS_AFTER_FLUSH=true`.

| Mode | ns/op | docs/sec | update_current_read_ns/doc | indexed_flush_ns/doc | publish_root_apply_ns/doc | publish_lock_hold_ns/doc | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| no overlay roots | 7,596 | 131,653 | 1,675 | 2,963 | 2,580 | 23.35 | 2,229 | 3 |
| overlay roots | 7,579 | 131,937 | 2,516 | 3,019 | 2,392 | 13.00 | 11,010 | 6 |
| overlay roots + compact | 7,023 | 142,392 | 2,273 | 2,816 | 2,163 | 543.8 | 3,832 | 4 |

For context, the earlier post-#1230 local overlay+compact row was about `8,234 ns/op`, `121,453 docs/sec`, and `update_current_read_ns/doc=3,208`, so this reduces the compacted overlay current-read cost and makes the compacted overlay row materially faster in this focused workload.

## Validation

```bash
go test ./TreeDB/collections ./TreeDB/db -count=1
go test ./cmd/mongo_gateway_bench -run 'Test' -count=1
```

Both passed locally.
