### PR TITLE
db: optimistic batch publish cold roots

### DIFF
--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1509,12 +1509,6 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 			db.writeMu.RUnlock()
 		}
 	}()
-	for orderedIdx := range ordered {
-		if ordered[orderedIdx].BaseRoot == 0 {
-			retrySerialized = true
-			return 0, nil, retrySerialized, nil
-		}
-	}
 	if baseSystemRoot == 0 {
 		retrySerialized = true
 		return 0, nil, retrySerialized, nil

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -1183,6 +1183,81 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptimisticAppli
 	}
 }
 
+func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptimisticColdBuildsRootsInParallel(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	deltaAIter := mustFrozenSystemMemtable(t, "a/1", "delta-a").NewIterator(nil, nil)
+	deltaA, err := OrderedRootDeltaBatchFromIterator(deltaAIter)
+	_ = deltaAIter.Close()
+	if err != nil {
+		t.Fatalf("delta a batch: %v", err)
+	}
+	defer func() { _ = deltaA.Close() }()
+
+	deltaBIter := mustFrozenSystemMemtable(t, "b/1", "delta-b").NewIterator(nil, nil)
+	deltaB, err := OrderedRootDeltaBatchFromIterator(deltaBIter)
+	_ = deltaBIter.Close()
+	if err != nil {
+		t.Fatalf("delta b batch: %v", err)
+	}
+	defer func() { _ = deltaB.Close() }()
+
+	systemRoot, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{
+		{BaseRoot: 0, Delta: deltaA, ParallelApply: true},
+		{BaseRoot: 0, Delta: deltaB, ParallelApply: true},
+	}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 2 || rootIDs[0] == 0 || rootIDs[1] == 0 {
+			return nil, errors.New("unexpected optimistic cold root IDs")
+		}
+		return mustFrozenSystemMemtable(t,
+			"sys/collections/users/a", strconv.FormatUint(rootIDs[0], 10),
+			"sys/collections/users/b", strconv.FormatUint(rootIDs[1], 10),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish cold delta batch group: %v", err)
+	}
+	if systemRoot == 0 || len(rootIDs) != 2 || rootIDs[0] == 0 || rootIDs[1] == 0 {
+		t.Fatalf("systemRoot=%d rootIDs=%v, want non-zero system root and two non-zero roots", systemRoot, rootIDs)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	for rootIdx, kv := range []map[string]string{
+		{"a/1": "delta-a"},
+		{"b/1": "delta-b"},
+	} {
+		for key, want := range kv {
+			entry, err := snap.GetEntryAtRoot(rootIDs[rootIdx], []byte(key))
+			if err != nil {
+				t.Fatalf("GetEntryAtRoot(root=%d key=%s): %v", rootIdx, key, err)
+			}
+			if got := string(entry.Value); got != want {
+				t.Fatalf("root=%d key=%s got=%q want %q", rootIdx, key, got, want)
+			}
+		}
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_parallel_groups_total"]; got != "1" {
+		t.Fatalf("parallel groups stat=%q want 1", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_parallel_roots_total"]; got != "2" {
+		t.Fatalf("parallel roots stat=%q want 2", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_calls_total"]; got != "2" {
+		t.Fatalf("root apply calls stat=%q want 2", got)
+	}
+}
+
 func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptimisticMixedOptInStaysSerialized(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})


### PR DESCRIPTION
## Summary

- allow optimistic ordered-root batch publish to handle cold root builds (`BaseRoot == 0`) instead of immediately retrying through the serialized path
- keep the existing system-root safety gate; the optimistic path still falls back when there is no system root to validate/rebase against
- add a regression test proving cold roots publish correctly and increment the parallel root-apply counters

## Why this is architectural

This removes an engine-level publish-path gate. Cold roots are common for first collection/index publishes and future overlay/fan-in publish designs. Before this change, those batches could not use the optimistic/parallel root-apply path even when every active root opted in.

## Validation

Tests:

```bash
go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_Optimistic(ColdBuildsRootsInParallel|AppliesRootsInParallel|MixedOptInStaysSerialized|PublishesUnderSharedWriteGate|PreservesConcurrentUserRootWrite|RebasesSystemDeltaAfterConcurrentSystemCommit)|TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_DeleteOnlyColdBuildPublishesEmptyRoot|TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_AppliesDeletes' -count=1
go test ./TreeDB/db -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/mongo_gateway_bench -count=1
```

Focused before/after benchmark, current main vs this branch, Apple M3, direct collection BSON two-index load, 100k inserts, batch 2000, default sync flush:

```bash
env MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
  go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionLoadBSONIndexes2$' \
  -benchtime=100000x \
  -count=5 \
  -timeout 15m
```

Observed main rows: 685k, 634k, 681k, 674k, 755k docs/sec.
Observed branch rows: 695k, 758k, 725k, 786k, 797k docs/sec.

The benchmark is noisy, but the branch consistently exercises the new cold-root optimistic path in the direct test, and the focused regression test verifies the architectural counter shift from serialized cold publish to `parallel_groups=1`, `parallel_roots=2`.

Also observed while testing async threshold load on both main and this branch: one run in each worktree hit the existing async benchmark retry-budget failure (`concurrent root modification detected`). Since it reproduced on main too, this PR does not treat that as caused by the change.

Refs #1159
