### PR TITLE
collections: batch publish overlay roots

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4630,10 +4630,11 @@ func buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames []string, rootRun
 			return nil, func() {}, err
 		}
 		ordered = append(ordered, backenddb.OrderedRootDeltaBatchPublishInput{
-			BaseRoot:      overlayDeltaBaseRoot(rootOverlays[rootName]),
-			Delta:         delta,
-			StoragePolicy: rootPolicies[rootName],
-			ParallelApply: true,
+			BaseRoot:                  overlayDeltaBaseRoot(rootOverlays[rootName]),
+			Delta:                     delta,
+			StoragePolicy:             rootPolicies[rootName],
+			IncludeDeletedOnColdBuild: true,
+			ParallelApply:             true,
 		})
 	}
 	return ordered, cleanup, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4568,26 +4568,6 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
 		}
 		work.rootOverlayFilters = rootOverlayFilters
-		if !bufferedRootOverlayDeltaBatchEligible(work.rootNames, work.rootOverlays) {
-			ordered, cleanupIters, err := buildBufferedRootOverlayDeltaPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
-			if err != nil {
-				return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
-			}
-			publishStart := time.Now()
-			newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-				return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
-			})
-			publishElapsed := time.Since(publishStart)
-			cleanupIters()
-			if publishErr == nil && len(rootIDs) != len(work.rootNames) {
-				publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
-			}
-			completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, publishElapsed)
-			if publishErr != nil {
-				return publishErr
-			}
-			return completeErr
-		}
 		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
 		if err != nil {
 			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
@@ -4627,35 +4607,6 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	return completeErr
 }
 
-func bufferedRootOverlayDeltaBatchEligible(rootNames []string, rootOverlays map[string][]uint64) bool {
-	for _, rootName := range rootNames {
-		if overlayDeltaBaseRoot(rootOverlays[rootName]) == 0 {
-			return false
-		}
-	}
-	return true
-}
-
-func buildBufferedRootOverlayDeltaPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy, rootOverlays map[string][]uint64) ([]backenddb.OrderedRootDeltaPublishInput, func(), error) {
-	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
-	cleanup := func() {
-		for _, it := range iterators {
-			_ = it.Close()
-		}
-	}
-	for _, rootName := range rootNames {
-		iter := newBufferedRootRunsIteratorWithDeleted(rootRuns[rootName], nil, nil, true)
-		iterators = append(iterators, iter)
-		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      overlayDeltaBaseRoot(rootOverlays[rootName]),
-			Iter:          iter,
-			StoragePolicy: rootPolicies[rootName],
-		})
-	}
-	return ordered, cleanup, nil
-}
-
 func buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy, rootOverlays map[string][]uint64) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
 	ordered := make([]backenddb.OrderedRootDeltaBatchPublishInput, 0, len(rootNames))
 	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
@@ -4682,6 +4633,7 @@ func buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames []string, rootRun
 			BaseRoot:      overlayDeltaBaseRoot(rootOverlays[rootName]),
 			Delta:         delta,
 			StoragePolicy: rootPolicies[rootName],
+			ParallelApply: true,
 		})
 	}
 	return ordered, cleanup, nil
@@ -4904,25 +4856,14 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		if err != nil {
 			return err
 		}
-		if bufferedRootOverlayDeltaBatchEligible(rootNames, rootOverlays) {
-			ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
-			if err != nil {
-				return err
-			}
-			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-				return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
-			})
-			cleanupDeltas()
-		} else {
-			ordered, cleanupIters, err := buildBufferedRootOverlayDeltaPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
-			if err != nil {
-				return err
-			}
-			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-				return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
-			})
-			cleanupIters()
+		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
+		if err != nil {
+			return err
 		}
+		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
+		})
+		cleanupDeltas()
 	} else {
 		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
 		if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2578,6 +2578,63 @@ func TestCollectionIndexedOverlayRootColdFlushPublishesBatchRootsInParallel(t *t
 	}
 }
 
+func TestCollectionIndexedOverlayRootColdFlushPreservesDeletes(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			BufferedIndexedWriteMaxDocuments: 1024,
+			BufferedIndexedWriteMaxRootRuns:  1024,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"city":"hnl"}`)); err != nil {
+		t.Fatalf("insert base doc: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush base doc: %v", err)
+	}
+	if _, err := col.CompactRootOverlays(context.Background()); err != nil {
+		t.Fatalf("compact base overlay: %v", err)
+	}
+	deleted, err := col.DeleteDocument([]byte("u1"))
+	if err != nil {
+		t.Fatalf("delete base doc: %v", err)
+	}
+	if !deleted {
+		t.Fatal("delete base doc deleted=false want true")
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush cold delete overlay: %v", err)
+	}
+	if got, err := col.Get([]byte("u1")); err != nil {
+		t.Fatalf("get deleted doc: %v", err)
+	} else if got != nil {
+		t.Fatalf("deleted doc=%s want nil", got)
+	}
+	ids, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find city after delete: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("city ids=%q want empty after delete", ids)
+	}
+}
+
 func TestCollectionIndexedOverlayRootFilterUnionsDeltaBase(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2502,6 +2503,79 @@ func TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks(t 
 		t.Fatalf("reopened primary overlay without in-memory filter must fall back to maybe-present")
 	}
 	_ = reopenedSnap.Close()
+}
+
+func TestCollectionIndexedOverlayRootColdFlushPublishesBatchRootsInParallel(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			BufferedIndexedWriteMaxDocuments: 1024,
+			BufferedIndexedWriteMaxRootRuns:  1024,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	statUint := func(stats map[string]string, key string) uint64 {
+		t.Helper()
+		raw, ok := stats[key]
+		if !ok {
+			t.Fatalf("missing stat %s", key)
+		}
+		value, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			t.Fatalf("parse stat %s=%q: %v", key, raw, err)
+		}
+		return value
+	}
+	const parallelGroupsKey = "treedb.publish.ordered_root_delta_group.root_apply_parallel_groups_total"
+	const parallelRootsKey = "treedb.publish.ordered_root_delta_group.root_apply_parallel_roots_total"
+	before := db.Stats()
+	beforeParallelGroups := statUint(before, parallelGroupsKey)
+	beforeParallelRoots := statUint(before, parallelRootsKey)
+
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"city":"hnl"}`),
+			[]byte(`{"city":"sea"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush overlays: %v", err)
+	}
+	after := db.Stats()
+	if got := statUint(after, parallelGroupsKey) - beforeParallelGroups; got != 1 {
+		t.Fatalf("parallel groups delta=%d want 1", got)
+	}
+	if got := statUint(after, parallelRootsKey) - beforeParallelRoots; got < 2 {
+		t.Fatalf("parallel roots delta=%d want at least 2", got)
+	}
+	if got, err := col.Get([]byte("u1")); err != nil || !bytes.Contains(got, []byte(`"hnl"`)) {
+		t.Fatalf("get u1 doc=%q err=%v", got, err)
+	}
+	ids, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find city: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
+		t.Fatalf("city ids=%q want [u2]", ids)
+	}
 }
 
 func TestCollectionIndexedOverlayRootFilterUnionsDeltaBase(t *testing.T) {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1692,6 +1692,11 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 		err = ErrReadOnly
 		return 0, nil, err
 	}
+	idxGen := db.idx.Load()
+	if idxGen == nil {
+		err = errors.New("missing index")
+		return 0, nil, err
+	}
 
 	db.mu.RLock()
 	userRoot := db.meta.UserRootPageID
@@ -1716,7 +1721,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 			return 0, nil, err
 		}
 		phaseStart := time.Now()
-		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaBatch(ordered[idx].BaseRoot, ordered[idx].Delta, opts)
+		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaBatchWithAllocator(idxGen, ordered[idx].BaseRoot, ordered[idx].Delta, opts, idxGen.allocator, &pagerAllocator{p: idxGen.pager}, ordered[idx].IncludeDeletedOnColdBuild)
 		phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 		phaseStats.rootApplyCalls++
 		if err != nil {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -106,6 +106,11 @@ type OrderedRootDeltaBatchPublishInput struct {
 	BaseRoot      uint64
 	Delta         *batch.Batch
 	StoragePolicy OrderedRootStoragePolicy
+	// IncludeDeletedOnColdBuild preserves tombstones when BaseRoot is zero.
+	// Most cold root builds can omit deletes because there is no base tree to
+	// hide, but collection overlay roots need tombstones to mask older overlay
+	// or base-root entries during reads.
+	IncludeDeletedOnColdBuild bool
 	// ParallelApply allows this root-local batch apply to run concurrently with
 	// other opted-in roots in the same group before the final commit validation.
 	// Callers should opt in only when root deltas are already materialized and
@@ -644,10 +649,10 @@ func (db *DB) publishOrderedRootDeltaBatch(baseRoot uint64, delta *batch.Batch, 
 		err = errors.New("missing index")
 		return
 	}
-	return db.publishOrderedRootDeltaBatchWithAllocator(idx, baseRoot, delta, opts, idx.allocator, &pagerAllocator{p: idx.pager})
+	return db.publishOrderedRootDeltaBatchWithAllocator(idx, baseRoot, delta, opts, idx.allocator, &pagerAllocator{p: idx.pager}, false)
 }
 
-func (db *DB) publishOrderedRootDeltaBatchWithAllocator(idx *indexGen, baseRoot uint64, delta *batch.Batch, opts orderedRootPublishOptions, alloc zipper.PageAllocator, coldBuildAlloc bulk.Allocator) (newRoot uint64, retired []uint64, metrics adaptive.Metrics, err error) {
+func (db *DB) publishOrderedRootDeltaBatchWithAllocator(idx *indexGen, baseRoot uint64, delta *batch.Batch, opts orderedRootPublishOptions, alloc zipper.PageAllocator, coldBuildAlloc bulk.Allocator, includeDeletedOnColdBuild bool) (newRoot uint64, retired []uint64, metrics adaptive.Metrics, err error) {
 	if db == nil {
 		err = ErrClosed
 		return
@@ -672,7 +677,7 @@ func (db *DB) publishOrderedRootDeltaBatchWithAllocator(idx *indexGen, baseRoot 
 		return baseRoot, nil, metrics, nil
 	}
 	if baseRoot == 0 {
-		iter := newOrderedRootDeltaBatchIterator(delta, false)
+		iter := newOrderedRootDeltaBatchIterator(delta, includeDeletedOnColdBuild)
 		defer func() { _ = iter.Close() }()
 		if coldBuildAlloc == nil {
 			coldBuildAlloc = alloc
@@ -1422,7 +1427,7 @@ func (db *DB) applyOrderedRootDeltaBatchGroupRoots(idx *indexGen, ordered []Orde
 			result.err = err
 			return result
 		}
-		rootID, retired, metrics, err := db.publishOrderedRootDeltaBatchWithAllocator(idx, ordered[orderedIdx].BaseRoot, ordered[orderedIdx].Delta, opts, alloc, coldBuildAlloc)
+		rootID, retired, metrics, err := db.publishOrderedRootDeltaBatchWithAllocator(idx, ordered[orderedIdx].BaseRoot, ordered[orderedIdx].Delta, opts, alloc, coldBuildAlloc, ordered[orderedIdx].IncludeDeletedOnColdBuild)
 		result.rootID = rootID
 		result.retired = retired
 		result.metrics = metrics
@@ -1586,7 +1591,7 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 			return 0, nil, false, err
 		}
 		phaseStart = time.Now()
-		rootID, systemRetired, systemMetrics, applyErr := db.publishOrderedRootDeltaBatchWithAllocator(idx, systemBaseRoot, systemDelta, systemOpts, systemTracker, systemTracker)
+		rootID, systemRetired, systemMetrics, applyErr := db.publishOrderedRootDeltaBatchWithAllocator(idx, systemBaseRoot, systemDelta, systemOpts, systemTracker, systemTracker, false)
 		phaseStats.systemApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 		phaseStats.systemApplyCalls++
 		_ = systemDelta.Close()

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -1543,7 +1543,7 @@ func TestApplyOrderedRootDeltaBatchGroupRoots_MixedOptInStartsParallelBeforeSeri
 	}
 }
 
-func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ColdBatchCanPreserveDeletes(t *testing.T) {
+func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_SerializedColdBatchCanPreserveDeletes(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})
 	if err != nil {
@@ -1557,11 +1557,13 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ColdBatchCanPre
 	}
 	defer func() { _ = delta.Close() }()
 
-	_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+	_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
 		BaseRoot:                  0,
 		Delta:                     delta,
 		IncludeDeletedOnColdBuild: true,
-	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	}}, func() error {
+		return nil
+	}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		if len(rootIDs) != 1 || rootIDs[0] == 0 {
 			return nil, errors.New("unexpected cold tombstone root ID")
 		}

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -1543,6 +1543,54 @@ func TestApplyOrderedRootDeltaBatchGroupRoots_MixedOptInStartsParallelBeforeSeri
 	}
 }
 
+func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_ColdBatchCanPreserveDeletes(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	delta := batch.New(nil, orderedRootDeltaBatchInlineThreshold)
+	if err := delta.Delete([]byte("doc/u1")); err != nil {
+		t.Fatalf("delete delta: %v", err)
+	}
+	defer func() { _ = delta.Close() }()
+
+	_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+		BaseRoot:                  0,
+		Delta:                     delta,
+		IncludeDeletedOnColdBuild: true,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 || rootIDs[0] == 0 {
+			return nil, errors.New("unexpected cold tombstone root ID")
+		}
+		return mustFrozenSystemMemtable(t,
+			"sys/collections/users/primary", strconv.FormatUint(rootIDs[0], 10),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish cold delete batch group: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	it, err := snap.IteratorAtRootWithOptions(rootIDs[0], []byte("doc/u1"), nil, IteratorOptions{IncludeTombstones: true})
+	if err != nil {
+		t.Fatalf("IteratorAtRootWithOptions: %v", err)
+	}
+	defer func() { _ = it.Close() }()
+	if !it.Valid() || !bytes.Equal(it.UnsafeKey(), []byte("doc/u1")) || !it.IsDeleted() {
+		t.Fatalf("iterator valid/key/deleted=%v/%q/%v, want tombstone doc/u1", it.Valid(), it.UnsafeKey(), it.Valid() && it.IsDeleted())
+	}
+}
+
 type orderedRootDeltaBatchGroupTestAllocator struct {
 	delegate interface {
 		Alloc(uint64) (uint64, error)


### PR DESCRIPTION
## Summary

- route buffered indexed overlay-root flushes through batch publish even when overlay roots are cold or stacked
- opt overlay root-local batches into parallel root apply
- remove the iterator fallback that existed because cold batch roots previously could not use the optimistic path
- add a collection regression test proving cold overlay flushes publish with parallel root-apply counters and remain readable by primary and secondary index

## Why this is architectural

This changes the collection overlay-root publish shape from iterator fallback to batch publish, using the engine work in #1233 and #1234. It keeps overlay roots compatible with the same root-apply fan-in architecture as normal indexed flush units.

## Validation

```bash
go test ./TreeDB/collections -run 'TestCollectionIndexedOverlayRootColdFlushPublishesBatchRootsInParallel|TestCollectionIndexedOverlayRootFlushSupportsReadsUpdatesAndUniqueChecks|TestCollectionIndexedOverlayRootFilterUnionsDeltaBase' -count=1
go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_Optimistic(ColdBuildsRootsInParallel|MixedOptInParallelizesEligibleRoots)' -count=1
go test ./TreeDB/collections -count=1
go test ./TreeDB/db -count=1
go test ./cmd/mongo_gateway_bench -count=1
```

Focused overlay benchmark command:

```bash
env MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=100000 \
  MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
  MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
  MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
  MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
  MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_OVERLAY_ROOTS=true \
  go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=100000x \
  -count=1 \
  -timeout 15m
```

Observed on this stack: 135,470 docs/sec, 7,382 ns/doc, and overlay publish now reports `publish_delta_group_root_apply_parallel_groups=1`, `publish_delta_group_root_apply_parallel_roots=2`. The comparable pre-stack local all-overlay row was 132,749 docs/sec, 7,533 ns/doc, and `parallel_groups=0`. Throughput remains limited by overlay read/root-apply costs, but the publish shape is now on the optimistic batch path.

Stacked on #1234. Refs #1159.
