### PR TITLE
Collections: split indexed flush phase metrics

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4578,21 +4578,21 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		materializeStart := time.Now()
 		rootOverlayFilters, err := buildCollectionRootOverlayFilters(work.rootNames, work.flushUnit.rootRuns, work.rootOverlays, work.catalog.rootOverlayFilters)
 		if err != nil {
-			materializeElapsed := time.Since(materializeStart)
+			materializeElapsed := collectionObservedElapsedSince(materializeStart)
 			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
 		work.rootOverlayFilters = rootOverlayFilters
 		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
 		if err != nil {
-			materializeElapsed := time.Since(materializeStart)
+			materializeElapsed := collectionObservedElapsedSince(materializeStart)
 			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
-		materializeElapsed := time.Since(materializeStart)
+		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
 		})
-		publishElapsed := time.Since(publishStart)
+		publishElapsed := collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
 		if publishErr == nil && len(rootIDs) != len(work.rootNames) {
 			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
@@ -4606,15 +4606,15 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	materializeStart := time.Now()
 	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
 	if err != nil {
-		materializeElapsed := time.Since(materializeStart)
+		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 	}
-	materializeElapsed := time.Since(materializeStart)
+	materializeElapsed := collectionObservedElapsedSince(materializeStart)
 	publishStart := time.Now()
 	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, rootIDs)
 	})
-	publishElapsed := time.Since(publishStart)
+	publishElapsed := collectionObservedElapsedSince(publishStart)
 	cleanupDeltas()
 	if publishErr == nil && len(rootIDs) != len(work.rootNames) {
 		publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
@@ -4856,7 +4856,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	var materializeElapsed time.Duration
 	var publishElapsed time.Duration
 	defer func() {
-		domain.observeIndexedFlush(flushDocs, flushBytes, flushRootRuns, flushRoots, time.Since(flushStart), materializeElapsed, publishElapsed, err)
+		domain.observeIndexedFlush(flushDocs, flushBytes, flushRootRuns, flushRoots, collectionObservedElapsedSince(flushStart), materializeElapsed, publishElapsed, err)
 	}()
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
@@ -4877,34 +4877,34 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		materializeStart := time.Now()
 		rootOverlayFilters, err = buildCollectionRootOverlayFilters(rootNames, flushUnit.rootRuns, rootOverlays, catalog.rootOverlayFilters)
 		if err != nil {
-			materializeElapsed = time.Since(materializeStart)
+			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
 		}
 		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
 		if err != nil {
-			materializeElapsed = time.Since(materializeStart)
+			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
 		}
-		materializeElapsed = time.Since(materializeStart)
+		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
 		})
-		publishElapsed = time.Since(publishStart)
+		publishElapsed = collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
 	} else {
 		materializeStart := time.Now()
 		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
 		if err != nil {
-			materializeElapsed = time.Since(materializeStart)
+			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
 		}
-		materializeElapsed = time.Since(materializeStart)
+		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 		})
-		publishElapsed = time.Since(publishStart)
+		publishElapsed = collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
 	}
 	if err != nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -425,6 +425,8 @@ type CollectionManagerStats struct {
 	IndexedFlushRootRuns          uint64
 	IndexedFlushRoots             uint64
 	IndexedFlushDuration          time.Duration
+	IndexedFlushMaterialize       time.Duration
+	IndexedFlushPublish           time.Duration
 	UpdateCombineRequests         uint64
 	UpdateCombineBatches          uint64
 	UpdateCombineBatchedRequests  uint64
@@ -743,6 +745,8 @@ type collectionWriteDomain struct {
 	indexedFlushRootRuns             atomic.Uint64
 	indexedFlushRoots                atomic.Uint64
 	indexedFlushDurationTotalNs      atomic.Uint64
+	indexedFlushMaterializeTotalNs   atomic.Uint64
+	indexedFlushPublishTotalNs       atomic.Uint64
 	updateCombineRequests            atomic.Uint64
 	updateCombineBatches             atomic.Uint64
 	updateCombineBatchedRequests     atomic.Uint64
@@ -963,6 +967,8 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_flush.root_runs_total"] = fmt.Sprintf("%d", stats.IndexedFlushRootRuns)
 	out["treedb.collections.write_domain.indexed_flush.roots_total"] = fmt.Sprintf("%d", stats.IndexedFlushRoots)
 	out["treedb.collections.write_domain.indexed_flush.duration_ns_total"] = fmt.Sprintf("%d", stats.IndexedFlushDuration.Nanoseconds())
+	out["treedb.collections.write_domain.indexed_flush.materialize_ns_total"] = fmt.Sprintf("%d", stats.IndexedFlushMaterialize.Nanoseconds())
+	out["treedb.collections.write_domain.indexed_flush.publish_ns_total"] = fmt.Sprintf("%d", stats.IndexedFlushPublish.Nanoseconds())
 	out["treedb.collections.write_domain.update_combine.requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineRequests)
 	out["treedb.collections.write_domain.update_combine.batches_total"] = fmt.Sprintf("%d", stats.UpdateCombineBatches)
 	out["treedb.collections.write_domain.update_combine.batched_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineBatchedRequests)
@@ -1132,6 +1138,8 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.IndexedFlushRootRuns += other.IndexedFlushRootRuns
 	s.IndexedFlushRoots += other.IndexedFlushRoots
 	s.IndexedFlushDuration += other.IndexedFlushDuration
+	s.IndexedFlushMaterialize += other.IndexedFlushMaterialize
+	s.IndexedFlushPublish += other.IndexedFlushPublish
 	s.UpdateCombineRequests += other.UpdateCombineRequests
 	s.UpdateCombineBatches += other.UpdateCombineBatches
 	s.UpdateCombineBatchedRequests += other.UpdateCombineBatchedRequests
@@ -1221,6 +1229,8 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.IndexedFlushRootRuns = domain.indexedFlushRootRuns.Load()
 	stats.IndexedFlushRoots = domain.indexedFlushRoots.Load()
 	stats.IndexedFlushDuration = durationFromAtomicNs(domain.indexedFlushDurationTotalNs.Load())
+	stats.IndexedFlushMaterialize = durationFromAtomicNs(domain.indexedFlushMaterializeTotalNs.Load())
+	stats.IndexedFlushPublish = durationFromAtomicNs(domain.indexedFlushPublishTotalNs.Load())
 	stats.UpdateCombineRequests = domain.updateCombineRequests.Load()
 	stats.UpdateCombineBatches = domain.updateCombineBatches.Load()
 	stats.UpdateCombineBatchedRequests = domain.updateCombineBatchedRequests.Load()
@@ -1540,7 +1550,7 @@ func (domain *collectionWriteDomain) consumeIndexedAsyncFlushError() error {
 	return err
 }
 
-func (domain *collectionWriteDomain) observeIndexedFlush(docs int, bytes int64, rootRuns, roots int, duration time.Duration, err error) {
+func (domain *collectionWriteDomain) observeIndexedFlush(docs int, bytes int64, rootRuns, roots int, duration, materialize, publish time.Duration, err error) {
 	if domain == nil {
 		return
 	}
@@ -1561,6 +1571,8 @@ func (domain *collectionWriteDomain) observeIndexedFlush(docs int, bytes int64, 
 		domain.indexedFlushRoots.Add(uint64(roots))
 	}
 	domain.indexedFlushDurationTotalNs.Add(durationToAtomicNs(duration))
+	domain.indexedFlushMaterializeTotalNs.Add(durationToAtomicNs(materialize))
+	domain.indexedFlushPublishTotalNs.Add(durationToAtomicNs(publish))
 }
 
 func (domain *collectionWriteDomain) observeUpdateCombineRequest(queueDepth int) {
@@ -4563,15 +4575,19 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		}
 	}()
 	if collectionMetaUsesIndexedOverlayRoots(work.meta) {
+		materializeStart := time.Now()
 		rootOverlayFilters, err := buildCollectionRootOverlayFilters(work.rootNames, work.flushUnit.rootRuns, work.rootOverlays, work.catalog.rootOverlayFilters)
 		if err != nil {
-			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+			materializeElapsed := time.Since(materializeStart)
+			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
 		work.rootOverlayFilters = rootOverlayFilters
 		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
 		if err != nil {
-			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+			materializeElapsed := time.Since(materializeStart)
+			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
+		materializeElapsed := time.Since(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
@@ -4581,16 +4597,19 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		if publishErr == nil && len(rootIDs) != len(work.rootNames) {
 			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
 		}
-		completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, publishElapsed)
+		completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, materializeElapsed+publishElapsed, materializeElapsed, publishElapsed)
 		if publishErr != nil {
 			return publishErr
 		}
 		return completeErr
 	}
+	materializeStart := time.Now()
 	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
 	if err != nil {
-		return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+		materializeElapsed := time.Since(materializeStart)
+		return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 	}
+	materializeElapsed := time.Since(materializeStart)
 	publishStart := time.Now()
 	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, rootIDs)
@@ -4600,7 +4619,7 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	if publishErr == nil && len(rootIDs) != len(work.rootNames) {
 		publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
 	}
-	completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, publishElapsed)
+	completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, materializeElapsed+publishElapsed, materializeElapsed, publishElapsed)
 	if publishErr != nil {
 		return publishErr
 	}
@@ -4723,7 +4742,7 @@ func buildRootDeltaBatchPublishInputsFromTables(collectionName string, rootNames
 	return ordered, cleanup, nil
 }
 
-func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork, newSystemRoot uint64, rootIDs []uint64, publishErr error, elapsed time.Duration) error {
+func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork, newSystemRoot uint64, rootIDs []uint64, publishErr error, elapsed, materializeElapsed, publishElapsed time.Duration) error {
 	if c == nil || c.writeDomain == nil || work == nil {
 		return publishErr
 	}
@@ -4736,7 +4755,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 			domain.indexedFlushUnits = append(removed, domain.indexedFlushUnits...)
 		}
 		rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
-		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, publishErr)
+		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, publishErr)
 		return publishErr
 	}
 	baseCatalog := domain.catalog
@@ -4752,7 +4771,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
 		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
-		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, err)
+		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, err)
 		return err
 	}
 	domain.loaded = true
@@ -4771,7 +4790,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	c.meta = work.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetIndexedFlushUnits(oldPublishing)
-	domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, nil)
+	domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, nil)
 	return nil
 }
 
@@ -4834,8 +4853,10 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	flushRootRuns := bufferedIndexedRootRunCount(domain)
 	flushRoots := len(rootNames)
 	flushStart := time.Now()
+	var materializeElapsed time.Duration
+	var publishElapsed time.Duration
 	defer func() {
-		domain.observeIndexedFlush(flushDocs, flushBytes, flushRootRuns, flushRoots, time.Since(flushStart), err)
+		domain.observeIndexedFlush(flushDocs, flushBytes, flushRootRuns, flushRoots, time.Since(flushStart), materializeElapsed, publishElapsed, err)
 	}()
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
@@ -4853,26 +4874,37 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	var rootIDs []uint64
 	var rootOverlayFilters map[string]collectionRootOverlayFilter
 	if collectionMetaUsesIndexedOverlayRoots(meta) {
+		materializeStart := time.Now()
 		rootOverlayFilters, err = buildCollectionRootOverlayFilters(rootNames, flushUnit.rootRuns, rootOverlays, catalog.rootOverlayFilters)
 		if err != nil {
+			materializeElapsed = time.Since(materializeStart)
 			return err
 		}
 		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
 		if err != nil {
+			materializeElapsed = time.Since(materializeStart)
 			return err
 		}
+		materializeElapsed = time.Since(materializeStart)
+		publishStart := time.Now()
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
 		})
+		publishElapsed = time.Since(publishStart)
 		cleanupDeltas()
 	} else {
+		materializeStart := time.Now()
 		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
 		if err != nil {
+			materializeElapsed = time.Since(materializeStart)
 			return err
 		}
+		materializeElapsed = time.Since(materializeStart)
+		publishStart := time.Now()
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 		})
+		publishElapsed = time.Since(publishStart)
 		cleanupDeltas()
 	}
 	if err != nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4746,6 +4746,10 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	if c == nil || c.writeDomain == nil || work == nil {
 		return publishErr
 	}
+	completeStart := time.Now()
+	observedElapsed := func() time.Duration {
+		return elapsed + collectionObservedElapsedSince(completeStart)
+	}
 	domain := c.writeDomain
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
@@ -4755,7 +4759,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 			domain.indexedFlushUnits = append(removed, domain.indexedFlushUnits...)
 		}
 		rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
-		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, publishErr)
+		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, publishErr)
 		return publishErr
 	}
 	baseCatalog := domain.catalog
@@ -4771,7 +4775,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
 		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
-		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, err)
+		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, err)
 		return err
 	}
 	domain.loaded = true
@@ -4790,7 +4794,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	c.meta = work.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetIndexedFlushUnits(oldPublishing)
-	domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, nil)
+	domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, nil)
 	return nil
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1154,9 +1154,6 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	if stats.IndexedFlushBytes == 0 || stats.IndexedFlushRootRuns == 0 || stats.IndexedFlushRoots == 0 {
 		t.Fatalf("stats indexed flush bytes/root-runs/roots=%d/%d/%d want positive", stats.IndexedFlushBytes, stats.IndexedFlushRootRuns, stats.IndexedFlushRoots)
 	}
-	if stats.IndexedFlushDuration <= 0 || stats.IndexedFlushMaterialize <= 0 || stats.IndexedFlushPublish <= 0 {
-		t.Fatalf("stats indexed flush duration/materialize/publish=%s/%s/%s want positive", stats.IndexedFlushDuration, stats.IndexedFlushMaterialize, stats.IndexedFlushPublish)
-	}
 	exported = mgr.Stats()
 	for _, key := range []string{
 		"treedb.collections.write_domain.indexed_flush.duration_ns_total",

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1154,6 +1154,19 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	if stats.IndexedFlushBytes == 0 || stats.IndexedFlushRootRuns == 0 || stats.IndexedFlushRoots == 0 {
 		t.Fatalf("stats indexed flush bytes/root-runs/roots=%d/%d/%d want positive", stats.IndexedFlushBytes, stats.IndexedFlushRootRuns, stats.IndexedFlushRoots)
 	}
+	if stats.IndexedFlushDuration <= 0 || stats.IndexedFlushMaterialize <= 0 || stats.IndexedFlushPublish <= 0 {
+		t.Fatalf("stats indexed flush duration/materialize/publish=%s/%s/%s want positive", stats.IndexedFlushDuration, stats.IndexedFlushMaterialize, stats.IndexedFlushPublish)
+	}
+	exported = mgr.Stats()
+	for _, key := range []string{
+		"treedb.collections.write_domain.indexed_flush.duration_ns_total",
+		"treedb.collections.write_domain.indexed_flush.materialize_ns_total",
+		"treedb.collections.write_domain.indexed_flush.publish_ns_total",
+	} {
+		if exported[key] == "" {
+			t.Fatalf("exported stats missing %s from %#v", key, exported)
+		}
+	}
 }
 
 func TestCollectionManagerResetUpdateCombineQueueDepthMax(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1154,6 +1154,9 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	if stats.IndexedFlushBytes == 0 || stats.IndexedFlushRootRuns == 0 || stats.IndexedFlushRoots == 0 {
 		t.Fatalf("stats indexed flush bytes/root-runs/roots=%d/%d/%d want positive", stats.IndexedFlushBytes, stats.IndexedFlushRootRuns, stats.IndexedFlushRoots)
 	}
+	if stats.IndexedFlushDuration <= 0 || stats.IndexedFlushMaterialize <= 0 || stats.IndexedFlushPublish <= 0 {
+		t.Fatalf("stats indexed flush duration/materialize/publish=%s/%s/%s want positive", stats.IndexedFlushDuration, stats.IndexedFlushMaterialize, stats.IndexedFlushPublish)
+	}
 	exported = mgr.Stats()
 	for _, key := range []string{
 		"treedb.collections.write_domain.indexed_flush.duration_ns_total",

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1120,6 +1120,8 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		IndexedFlushRootRuns:           after.IndexedFlushRootRuns - before.IndexedFlushRootRuns,
 		IndexedFlushRoots:              after.IndexedFlushRoots - before.IndexedFlushRoots,
 		IndexedFlushDuration:           after.IndexedFlushDuration - before.IndexedFlushDuration,
+		IndexedFlushMaterialize:        after.IndexedFlushMaterialize - before.IndexedFlushMaterialize,
+		IndexedFlushPublish:            after.IndexedFlushPublish - before.IndexedFlushPublish,
 	}
 	if after.UpdateCombineQueueDepthMax > before.UpdateCombineQueueDepthMax {
 		delta.UpdateCombineQueueDepthMax = after.UpdateCombineQueueDepthMax
@@ -1186,6 +1188,8 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushRootRuns:           90,
 		IndexedFlushRoots:              9,
 		IndexedFlushDuration:           30 * time.Millisecond,
+		IndexedFlushMaterialize:        12 * time.Millisecond,
+		IndexedFlushPublish:            18 * time.Millisecond,
 		UpdateBatchIndexStatsCount:     2,
 		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
 			{CollectionName: "users", IndexName: "email", IndexOrdinal: 0, Unique: true, Changed: 1, Unchanged: 9, UniqueChecks: 1, UniqueCheckSkips: 8},
@@ -1209,6 +1213,8 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushRootRuns:           270,
 		IndexedFlushRoots:              24,
 		IndexedFlushDuration:           90 * time.Millisecond,
+		IndexedFlushMaterialize:        30 * time.Millisecond,
+		IndexedFlushPublish:            60 * time.Millisecond,
 		UpdateBatchIndexStatsCount:     2,
 		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
 			{CollectionName: "users", IndexName: "email", IndexOrdinal: 0, Unique: true, Changed: 1, Unchanged: 22, UniqueChecks: 1, UniqueCheckSkips: 17},
@@ -1250,8 +1256,8 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	if got.UpdateBatchUniqueCheckSkips != 9 {
 		t.Fatalf("UpdateBatchUniqueCheckSkips=%d want 9", got.UpdateBatchUniqueCheckSkips)
 	}
-	if got.IndexedFlushCalls != 5 || got.IndexedFlushErrors != 1 || got.IndexedFlushDocs != 600 || got.IndexedFlushBytes != 18000 || got.IndexedFlushRootRuns != 180 || got.IndexedFlushRoots != 15 || got.IndexedFlushDuration != 60*time.Millisecond {
-		t.Fatalf("indexed flush delta calls/errors/docs/bytes/rootRuns/roots/duration=%d/%d/%d/%d/%d/%d/%s want 5/1/600/18000/180/15/60ms",
+	if got.IndexedFlushCalls != 5 || got.IndexedFlushErrors != 1 || got.IndexedFlushDocs != 600 || got.IndexedFlushBytes != 18000 || got.IndexedFlushRootRuns != 180 || got.IndexedFlushRoots != 15 || got.IndexedFlushDuration != 60*time.Millisecond || got.IndexedFlushMaterialize != 18*time.Millisecond || got.IndexedFlushPublish != 42*time.Millisecond {
+		t.Fatalf("indexed flush delta calls/errors/docs/bytes/rootRuns/roots/duration/materialize/publish=%d/%d/%d/%d/%d/%d/%s/%s/%s want 5/1/600/18000/180/15/60ms/18ms/42ms",
 			got.IndexedFlushCalls,
 			got.IndexedFlushErrors,
 			got.IndexedFlushDocs,
@@ -1259,6 +1265,8 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 			got.IndexedFlushRootRuns,
 			got.IndexedFlushRoots,
 			got.IndexedFlushDuration,
+			got.IndexedFlushMaterialize,
+			got.IndexedFlushPublish,
 		)
 	}
 	if got.UpdateBatchIndexStatsCount != 2 {
@@ -1282,30 +1290,36 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 
 func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testing.T) {
 	stats := collections.CollectionManagerStats{
-		IndexedFlushCalls:    5,
-		IndexedFlushErrors:   1,
-		IndexedFlushDocs:     600,
-		IndexedFlushBytes:    18000,
-		IndexedFlushRootRuns: 180,
-		IndexedFlushRoots:    15,
-		IndexedFlushDuration: 60 * time.Millisecond,
+		IndexedFlushCalls:       5,
+		IndexedFlushErrors:      1,
+		IndexedFlushDocs:        600,
+		IndexedFlushBytes:       18000,
+		IndexedFlushRootRuns:    180,
+		IndexedFlushRoots:       15,
+		IndexedFlushDuration:    60 * time.Millisecond,
+		IndexedFlushMaterialize: 18 * time.Millisecond,
+		IndexedFlushPublish:     42 * time.Millisecond,
 	}
 	result := testing.Benchmark(func(b *testing.B) {
 		reportCollectionManagerUpdateStats(b, stats, 600)
 	})
 	want := map[string]float64{
-		"indexed_flush_calls":          5,
-		"indexed_flush_docs/call":      120,
-		"indexed_flush_docs/doc":       1,
-		"indexed_flush_bytes/call":     3600,
-		"indexed_flush_bytes/doc":      30,
-		"indexed_flush_root_runs/call": 36,
-		"indexed_flush_root_runs/doc":  0.3,
-		"indexed_flush_roots/call":     3,
-		"indexed_flush_roots/doc":      0.025,
-		"indexed_flush_errors":         1,
-		"indexed_flush_ns/call":        12_000_000,
-		"indexed_flush_ns/doc":         100_000,
+		"indexed_flush_calls":               5,
+		"indexed_flush_docs/call":           120,
+		"indexed_flush_docs/doc":            1,
+		"indexed_flush_bytes/call":          3600,
+		"indexed_flush_bytes/doc":           30,
+		"indexed_flush_root_runs/call":      36,
+		"indexed_flush_root_runs/doc":       0.3,
+		"indexed_flush_roots/call":          3,
+		"indexed_flush_roots/doc":           0.025,
+		"indexed_flush_errors":              1,
+		"indexed_flush_ns/call":             12_000_000,
+		"indexed_flush_ns/doc":              100_000,
+		"indexed_flush_materialize_ns/call": 3_600_000,
+		"indexed_flush_materialize_ns/doc":  30_000,
+		"indexed_flush_publish_ns/call":     8_400_000,
+		"indexed_flush_publish_ns/doc":      70_000,
 	}
 	for metric, wantValue := range want {
 		gotValue, ok := result.Extra[metric]
@@ -1381,6 +1395,18 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 			b.ReportMetric(float64(stats.IndexedFlushDuration.Nanoseconds())/float64(stats.IndexedFlushCalls), "indexed_flush_ns/call")
 			if stats.IndexedFlushDocs > 0 {
 				b.ReportMetric(float64(stats.IndexedFlushDuration.Nanoseconds())/float64(stats.IndexedFlushDocs), "indexed_flush_ns/doc")
+			}
+		}
+		if stats.IndexedFlushMaterialize > 0 {
+			b.ReportMetric(float64(stats.IndexedFlushMaterialize.Nanoseconds())/float64(stats.IndexedFlushCalls), "indexed_flush_materialize_ns/call")
+			if stats.IndexedFlushDocs > 0 {
+				b.ReportMetric(float64(stats.IndexedFlushMaterialize.Nanoseconds())/float64(stats.IndexedFlushDocs), "indexed_flush_materialize_ns/doc")
+			}
+		}
+		if stats.IndexedFlushPublish > 0 {
+			b.ReportMetric(float64(stats.IndexedFlushPublish.Nanoseconds())/float64(stats.IndexedFlushCalls), "indexed_flush_publish_ns/call")
+			if stats.IndexedFlushDocs > 0 {
+				b.ReportMetric(float64(stats.IndexedFlushPublish.Nanoseconds())/float64(stats.IndexedFlushDocs), "indexed_flush_publish_ns/doc")
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Architecture track: indexed collection root fan-in / immutable flush-unit publish attribution for #1159.

This PR splits indexed collection flush timing into:

- total indexed flush time (`indexed_flush_ns/*`, existing metric)
- root-delta materialization time (`indexed_flush_materialize_ns/*`, new)
- durable publish/root-apply time (`indexed_flush_publish_ns/*`, new)

The goal is to prevent future #1159 work from conflating staged root-run materialization with durable publish/root apply. The next architectural PR should target staged root-delta representation because this split shows root-delta materialization is now larger than durable publish on the focused default async update path.

## Benchmark / profile

Commit: `0bea448aac`
Run directory: `/tmp/gomap_1159_flush_phase_AJQvtu`

Command:

```bash
PROFILE_DIR=$(mktemp -d /tmp/gomap_1159_flush_phase_XXXXXX)
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' \
  -benchtime=5s \
  -benchmem \
  -count=1 \
  -cpuprofile "$PROFILE_DIR/cpu.pprof" \
  -memprofile "$PROFILE_DIR/mem.pprof"
```

Focused result:

| metric | value |
| --- | ---: |
| docs/sec | 191,049 |
| ns/doc | 5,234 |
| B/op | 1,830 |
| allocs/op | 3 |
| indexed_flush_ns/doc | 2,494 |
| indexed_flush_materialize_ns/doc | 1,423 |
| indexed_flush_publish_ns/doc | 1,052 |
| publish_delta_group_root_apply_ns/doc | 1,047 |
| indexed_flush_root_runs/call | 19,567 |
| indexed_flush_docs/call | 198,819 |
| update_current_read_ns/doc | 832.1 |

Readout: durable publish/root apply remains important, but staged root-run materialization is now the larger half of indexed flush time on this shape. That supports the next architecture PR focusing on replacing the current many-run flush-unit representation with a coalesced/prepared root-delta shape rather than local cache/path tweaks.

## Tests

```bash
go test ./TreeDB/collections -run 'TestCollectionManagerStats|TestCollectionUpdateBufferFlushTimingCountsAsyncSchedule' -count=1
go test ./cmd/mongo_gateway_bench -run 'TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats|TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics|TestProfileBenchBufferedIndexedAsyncFlushEnv' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/mongo_gateway_bench -count=1
go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder' -count=1
```
