### PR TITLE
Collections: parallelize indexed root delta materialization

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4578,21 +4578,21 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		materializeStart := time.Now()
 		rootOverlayFilters, err := buildCollectionRootOverlayFilters(work.rootNames, work.flushUnit.rootRuns, work.rootOverlays, work.catalog.rootOverlayFilters)
 		if err != nil {
-			materializeElapsed := time.Since(materializeStart)
+			materializeElapsed := collectionObservedElapsedSince(materializeStart)
 			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
 		work.rootOverlayFilters = rootOverlayFilters
 		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
 		if err != nil {
-			materializeElapsed := time.Since(materializeStart)
+			materializeElapsed := collectionObservedElapsedSince(materializeStart)
 			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
-		materializeElapsed := time.Since(materializeStart)
+		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
 		})
-		publishElapsed := time.Since(publishStart)
+		publishElapsed := collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
 		if publishErr == nil && len(rootIDs) != len(work.rootNames) {
 			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
@@ -4606,15 +4606,15 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	materializeStart := time.Now()
 	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
 	if err != nil {
-		materializeElapsed := time.Since(materializeStart)
+		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 	}
-	materializeElapsed := time.Since(materializeStart)
+	materializeElapsed := collectionObservedElapsedSince(materializeStart)
 	publishStart := time.Now()
 	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, rootIDs)
 	})
-	publishElapsed := time.Since(publishStart)
+	publishElapsed := collectionObservedElapsedSince(publishStart)
 	cleanupDeltas()
 	if publishErr == nil && len(rootIDs) != len(work.rootNames) {
 		publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
@@ -4856,7 +4856,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	var materializeElapsed time.Duration
 	var publishElapsed time.Duration
 	defer func() {
-		domain.observeIndexedFlush(flushDocs, flushBytes, flushRootRuns, flushRoots, time.Since(flushStart), materializeElapsed, publishElapsed, err)
+		domain.observeIndexedFlush(flushDocs, flushBytes, flushRootRuns, flushRoots, collectionObservedElapsedSince(flushStart), materializeElapsed, publishElapsed, err)
 	}()
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
@@ -4877,34 +4877,34 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		materializeStart := time.Now()
 		rootOverlayFilters, err = buildCollectionRootOverlayFilters(rootNames, flushUnit.rootRuns, rootOverlays, catalog.rootOverlayFilters)
 		if err != nil {
-			materializeElapsed = time.Since(materializeStart)
+			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
 		}
 		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
 		if err != nil {
-			materializeElapsed = time.Since(materializeStart)
+			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
 		}
-		materializeElapsed = time.Since(materializeStart)
+		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
 		})
-		publishElapsed = time.Since(publishStart)
+		publishElapsed = collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
 	} else {
 		materializeStart := time.Now()
 		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
 		if err != nil {
-			materializeElapsed = time.Since(materializeStart)
+			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
 		}
-		materializeElapsed = time.Since(materializeStart)
+		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 		})
-		publishElapsed = time.Since(publishStart)
+		publishElapsed = collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
 	}
 	if err != nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -425,6 +425,8 @@ type CollectionManagerStats struct {
 	IndexedFlushRootRuns          uint64
 	IndexedFlushRoots             uint64
 	IndexedFlushDuration          time.Duration
+	IndexedFlushMaterialize       time.Duration
+	IndexedFlushPublish           time.Duration
 	UpdateCombineRequests         uint64
 	UpdateCombineBatches          uint64
 	UpdateCombineBatchedRequests  uint64
@@ -743,6 +745,8 @@ type collectionWriteDomain struct {
 	indexedFlushRootRuns             atomic.Uint64
 	indexedFlushRoots                atomic.Uint64
 	indexedFlushDurationTotalNs      atomic.Uint64
+	indexedFlushMaterializeTotalNs   atomic.Uint64
+	indexedFlushPublishTotalNs       atomic.Uint64
 	updateCombineRequests            atomic.Uint64
 	updateCombineBatches             atomic.Uint64
 	updateCombineBatchedRequests     atomic.Uint64
@@ -963,6 +967,8 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_flush.root_runs_total"] = fmt.Sprintf("%d", stats.IndexedFlushRootRuns)
 	out["treedb.collections.write_domain.indexed_flush.roots_total"] = fmt.Sprintf("%d", stats.IndexedFlushRoots)
 	out["treedb.collections.write_domain.indexed_flush.duration_ns_total"] = fmt.Sprintf("%d", stats.IndexedFlushDuration.Nanoseconds())
+	out["treedb.collections.write_domain.indexed_flush.materialize_ns_total"] = fmt.Sprintf("%d", stats.IndexedFlushMaterialize.Nanoseconds())
+	out["treedb.collections.write_domain.indexed_flush.publish_ns_total"] = fmt.Sprintf("%d", stats.IndexedFlushPublish.Nanoseconds())
 	out["treedb.collections.write_domain.update_combine.requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineRequests)
 	out["treedb.collections.write_domain.update_combine.batches_total"] = fmt.Sprintf("%d", stats.UpdateCombineBatches)
 	out["treedb.collections.write_domain.update_combine.batched_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineBatchedRequests)
@@ -1132,6 +1138,8 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.IndexedFlushRootRuns += other.IndexedFlushRootRuns
 	s.IndexedFlushRoots += other.IndexedFlushRoots
 	s.IndexedFlushDuration += other.IndexedFlushDuration
+	s.IndexedFlushMaterialize += other.IndexedFlushMaterialize
+	s.IndexedFlushPublish += other.IndexedFlushPublish
 	s.UpdateCombineRequests += other.UpdateCombineRequests
 	s.UpdateCombineBatches += other.UpdateCombineBatches
 	s.UpdateCombineBatchedRequests += other.UpdateCombineBatchedRequests
@@ -1221,6 +1229,8 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.IndexedFlushRootRuns = domain.indexedFlushRootRuns.Load()
 	stats.IndexedFlushRoots = domain.indexedFlushRoots.Load()
 	stats.IndexedFlushDuration = durationFromAtomicNs(domain.indexedFlushDurationTotalNs.Load())
+	stats.IndexedFlushMaterialize = durationFromAtomicNs(domain.indexedFlushMaterializeTotalNs.Load())
+	stats.IndexedFlushPublish = durationFromAtomicNs(domain.indexedFlushPublishTotalNs.Load())
 	stats.UpdateCombineRequests = domain.updateCombineRequests.Load()
 	stats.UpdateCombineBatches = domain.updateCombineBatches.Load()
 	stats.UpdateCombineBatchedRequests = domain.updateCombineBatchedRequests.Load()
@@ -1540,7 +1550,7 @@ func (domain *collectionWriteDomain) consumeIndexedAsyncFlushError() error {
 	return err
 }
 
-func (domain *collectionWriteDomain) observeIndexedFlush(docs int, bytes int64, rootRuns, roots int, duration time.Duration, err error) {
+func (domain *collectionWriteDomain) observeIndexedFlush(docs int, bytes int64, rootRuns, roots int, duration, materialize, publish time.Duration, err error) {
 	if domain == nil {
 		return
 	}
@@ -1561,6 +1571,8 @@ func (domain *collectionWriteDomain) observeIndexedFlush(docs int, bytes int64, 
 		domain.indexedFlushRoots.Add(uint64(roots))
 	}
 	domain.indexedFlushDurationTotalNs.Add(durationToAtomicNs(duration))
+	domain.indexedFlushMaterializeTotalNs.Add(durationToAtomicNs(materialize))
+	domain.indexedFlushPublishTotalNs.Add(durationToAtomicNs(publish))
 }
 
 func (domain *collectionWriteDomain) observeUpdateCombineRequest(queueDepth int) {
@@ -4563,15 +4575,19 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		}
 	}()
 	if collectionMetaUsesIndexedOverlayRoots(work.meta) {
+		materializeStart := time.Now()
 		rootOverlayFilters, err := buildCollectionRootOverlayFilters(work.rootNames, work.flushUnit.rootRuns, work.rootOverlays, work.catalog.rootOverlayFilters)
 		if err != nil {
-			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+			materializeElapsed := time.Since(materializeStart)
+			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
 		work.rootOverlayFilters = rootOverlayFilters
 		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
 		if err != nil {
-			return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+			materializeElapsed := time.Since(materializeStart)
+			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
+		materializeElapsed := time.Since(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
@@ -4581,16 +4597,19 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		if publishErr == nil && len(rootIDs) != len(work.rootNames) {
 			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
 		}
-		completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, publishElapsed)
+		completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, materializeElapsed+publishElapsed, materializeElapsed, publishElapsed)
 		if publishErr != nil {
 			return publishErr
 		}
 		return completeErr
 	}
+	materializeStart := time.Now()
 	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
 	if err != nil {
-		return c.completePreparedIndexedFlush(work, 0, nil, err, 0)
+		materializeElapsed := time.Since(materializeStart)
+		return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 	}
+	materializeElapsed := time.Since(materializeStart)
 	publishStart := time.Now()
 	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, rootIDs)
@@ -4600,7 +4619,7 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	if publishErr == nil && len(rootIDs) != len(work.rootNames) {
 		publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
 	}
-	completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, publishElapsed)
+	completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, materializeElapsed+publishElapsed, materializeElapsed, publishElapsed)
 	if publishErr != nil {
 		return publishErr
 	}
@@ -4723,7 +4742,7 @@ func buildRootDeltaBatchPublishInputsFromTables(collectionName string, rootNames
 	return ordered, cleanup, nil
 }
 
-func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork, newSystemRoot uint64, rootIDs []uint64, publishErr error, elapsed time.Duration) error {
+func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork, newSystemRoot uint64, rootIDs []uint64, publishErr error, elapsed, materializeElapsed, publishElapsed time.Duration) error {
 	if c == nil || c.writeDomain == nil || work == nil {
 		return publishErr
 	}
@@ -4736,7 +4755,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 			domain.indexedFlushUnits = append(removed, domain.indexedFlushUnits...)
 		}
 		rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
-		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, publishErr)
+		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, publishErr)
 		return publishErr
 	}
 	baseCatalog := domain.catalog
@@ -4752,7 +4771,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
 		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
-		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, err)
+		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, err)
 		return err
 	}
 	domain.loaded = true
@@ -4771,7 +4790,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	c.meta = work.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetIndexedFlushUnits(oldPublishing)
-	domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, nil)
+	domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, nil)
 	return nil
 }
 
@@ -4834,8 +4853,10 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	flushRootRuns := bufferedIndexedRootRunCount(domain)
 	flushRoots := len(rootNames)
 	flushStart := time.Now()
+	var materializeElapsed time.Duration
+	var publishElapsed time.Duration
 	defer func() {
-		domain.observeIndexedFlush(flushDocs, flushBytes, flushRootRuns, flushRoots, time.Since(flushStart), err)
+		domain.observeIndexedFlush(flushDocs, flushBytes, flushRootRuns, flushRoots, time.Since(flushStart), materializeElapsed, publishElapsed, err)
 	}()
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
@@ -4853,26 +4874,37 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	var rootIDs []uint64
 	var rootOverlayFilters map[string]collectionRootOverlayFilter
 	if collectionMetaUsesIndexedOverlayRoots(meta) {
+		materializeStart := time.Now()
 		rootOverlayFilters, err = buildCollectionRootOverlayFilters(rootNames, flushUnit.rootRuns, rootOverlays, catalog.rootOverlayFilters)
 		if err != nil {
+			materializeElapsed = time.Since(materializeStart)
 			return err
 		}
 		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootPolicies, rootOverlays)
 		if err != nil {
+			materializeElapsed = time.Since(materializeStart)
 			return err
 		}
+		materializeElapsed = time.Since(materializeStart)
+		publishStart := time.Now()
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
 		})
+		publishElapsed = time.Since(publishStart)
 		cleanupDeltas()
 	} else {
+		materializeStart := time.Now()
 		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
 		if err != nil {
+			materializeElapsed = time.Since(materializeStart)
 			return err
 		}
+		materializeElapsed = time.Since(materializeStart)
+		publishStart := time.Now()
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 		})
+		publishElapsed = time.Since(publishStart)
 		cleanupDeltas()
 	}
 	if err != nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4698,15 +4698,29 @@ func buildBufferedRootDeltaBatchPublishInputsFromSpecs(specs []bufferedRootDelta
 		return ordered, cleanup, nil
 	}
 
-	errs := make([]error, len(specs))
-	var wg sync.WaitGroup
-	for i := range specs {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			errs[i] = buildBufferedRootDeltaBatchPublishInput(specs[i], rootRuns, &ordered[i], &iterators[i])
-		}(i)
+	parallelism := runtime.GOMAXPROCS(0)
+	if parallelism < 1 {
+		parallelism = 1
 	}
+	if parallelism > len(specs) {
+		parallelism = len(specs)
+	}
+	errs := make([]error, len(specs))
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for worker := 0; worker < parallelism; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				errs[i] = buildBufferedRootDeltaBatchPublishInput(specs[i], rootRuns, &ordered[i], &iterators[i])
+			}
+		}()
+	}
+	for i := range specs {
+		jobs <- i
+	}
+	close(jobs)
 	wg.Wait()
 	for _, err := range errs {
 		if err != nil {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4746,6 +4746,10 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	if c == nil || c.writeDomain == nil || work == nil {
 		return publishErr
 	}
+	completeStart := time.Now()
+	observedElapsed := func() time.Duration {
+		return elapsed + collectionObservedElapsedSince(completeStart)
+	}
 	domain := c.writeDomain
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
@@ -4755,7 +4759,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 			domain.indexedFlushUnits = append(removed, domain.indexedFlushUnits...)
 		}
 		rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
-		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, publishErr)
+		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, publishErr)
 		return publishErr
 	}
 	baseCatalog := domain.catalog
@@ -4771,7 +4775,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
 		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
-		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, err)
+		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, err)
 		return err
 	}
 	domain.loaded = true
@@ -4790,7 +4794,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	c.meta = work.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetIndexedFlushUnits(oldPublishing)
-	domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, elapsed, materializeElapsed, publishElapsed, nil)
+	domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, nil)
 	return nil
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4627,36 +4627,17 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 }
 
 func buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy, rootOverlays map[string][]uint64) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
-	ordered := make([]backenddb.OrderedRootDeltaBatchPublishInput, 0, len(rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
-	cleanup := func() {
-		for idx := range ordered {
-			if ordered[idx].Delta != nil {
-				_ = ordered[idx].Delta.Close()
-				ordered[idx].Delta = nil
-			}
-		}
-		for _, it := range iterators {
-			_ = it.Close()
+	specs := make([]bufferedRootDeltaBatchSpec, len(rootNames))
+	for i, rootName := range rootNames {
+		specs[i] = bufferedRootDeltaBatchSpec{
+			rootName:                  rootName,
+			baseRoot:                  overlayDeltaBaseRoot(rootOverlays[rootName]),
+			storagePolicy:             rootPolicies[rootName],
+			includeDeletedOnColdBuild: true,
+			parallelApply:             true,
 		}
 	}
-	for _, rootName := range rootNames {
-		iter := newBufferedRootRunsIteratorWithDeleted(rootRuns[rootName], nil, nil, true)
-		iterators = append(iterators, iter)
-		delta, err := backenddb.OrderedRootDeltaBatchFromIterator(iter)
-		if err != nil {
-			cleanup()
-			return nil, func() {}, err
-		}
-		ordered = append(ordered, backenddb.OrderedRootDeltaBatchPublishInput{
-			BaseRoot:                  overlayDeltaBaseRoot(rootOverlays[rootName]),
-			Delta:                     delta,
-			StoragePolicy:             rootPolicies[rootName],
-			IncludeDeletedOnColdBuild: true,
-			ParallelApply:             true,
-		})
-	}
-	return ordered, cleanup, nil
+	return buildBufferedRootDeltaBatchPublishInputsFromSpecs(specs, rootRuns)
 }
 
 func overlayDeltaBaseRoot(overlays []uint64) uint64 {
@@ -4667,8 +4648,33 @@ func overlayDeltaBaseRoot(overlays []uint64) uint64 {
 }
 
 func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootBaseIDs map[string]uint64, rootPolicies map[string]backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
-	ordered := make([]backenddb.OrderedRootDeltaBatchPublishInput, 0, len(rootNames))
-	iterators := make([]iterator.UnsafeIterator, 0, len(rootNames))
+	specs := make([]bufferedRootDeltaBatchSpec, 0, len(rootNames))
+	for _, rootName := range rootNames {
+		baseRoot, ok := rootBaseIDs[rootName]
+		if !ok {
+			return nil, func() {}, fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
+		}
+		specs = append(specs, bufferedRootDeltaBatchSpec{
+			rootName:      rootName,
+			baseRoot:      baseRoot,
+			storagePolicy: rootPolicies[rootName],
+			parallelApply: true,
+		})
+	}
+	return buildBufferedRootDeltaBatchPublishInputsFromSpecs(specs, rootRuns)
+}
+
+type bufferedRootDeltaBatchSpec struct {
+	rootName                  string
+	baseRoot                  uint64
+	storagePolicy             backenddb.OrderedRootStoragePolicy
+	includeDeletedOnColdBuild bool
+	parallelApply             bool
+}
+
+func buildBufferedRootDeltaBatchPublishInputsFromSpecs(specs []bufferedRootDeltaBatchSpec, rootRuns map[string][]memtable.Table) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
+	ordered := make([]backenddb.OrderedRootDeltaBatchPublishInput, len(specs))
+	iterators := make([]iterator.UnsafeIterator, len(specs))
 	cleanup := func() {
 		for idx := range ordered {
 			if ordered[idx].Delta != nil {
@@ -4677,30 +4683,57 @@ func buildBufferedRootDeltaBatchPublishInputs(rootNames []string, rootRuns map[s
 			}
 		}
 		for _, it := range iterators {
-			_ = it.Close()
+			if it != nil {
+				_ = it.Close()
+			}
 		}
 	}
-	for _, rootName := range rootNames {
-		baseRoot, ok := rootBaseIDs[rootName]
-		if !ok {
-			cleanup()
-			return nil, func() {}, fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
+	if len(specs) <= 1 {
+		for i := range specs {
+			if err := buildBufferedRootDeltaBatchPublishInput(specs[i], rootRuns, &ordered[i], &iterators[i]); err != nil {
+				cleanup()
+				return nil, func() {}, err
+			}
 		}
-		iter := newBufferedRootRunsIteratorWithDeleted(rootRuns[rootName], nil, nil, true)
-		iterators = append(iterators, iter)
-		delta, err := backenddb.OrderedRootDeltaBatchFromIterator(iter)
+		return ordered, cleanup, nil
+	}
+
+	errs := make([]error, len(specs))
+	var wg sync.WaitGroup
+	for i := range specs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = buildBufferedRootDeltaBatchPublishInput(specs[i], rootRuns, &ordered[i], &iterators[i])
+		}(i)
+	}
+	wg.Wait()
+	for _, err := range errs {
 		if err != nil {
 			cleanup()
 			return nil, func() {}, err
 		}
-		ordered = append(ordered, backenddb.OrderedRootDeltaBatchPublishInput{
-			BaseRoot:      baseRoot,
-			Delta:         delta,
-			StoragePolicy: rootPolicies[rootName],
-			ParallelApply: true,
-		})
 	}
 	return ordered, cleanup, nil
+}
+
+func buildBufferedRootDeltaBatchPublishInput(spec bufferedRootDeltaBatchSpec, rootRuns map[string][]memtable.Table, ordered *backenddb.OrderedRootDeltaBatchPublishInput, iterOut *iterator.UnsafeIterator) error {
+	iter := newBufferedRootRunsIteratorWithDeleted(rootRuns[spec.rootName], nil, nil, true)
+	if iterOut != nil {
+		*iterOut = iter
+	}
+	delta, err := backenddb.OrderedRootDeltaBatchFromIterator(iter)
+	if err != nil {
+		return err
+	}
+	*ordered = backenddb.OrderedRootDeltaBatchPublishInput{
+		BaseRoot:                  spec.baseRoot,
+		Delta:                     delta,
+		StoragePolicy:             spec.storagePolicy,
+		IncludeDeletedOnColdBuild: spec.includeDeletedOnColdBuild,
+		ParallelApply:             spec.parallelApply,
+	}
+	return nil
 }
 
 func buildRootDeltaBatchPublishInputsFromTables(collectionName string, rootNames []string, tables []memtable.Table, rootBaseIDs map[string]uint64, policies []backenddb.OrderedRootStoragePolicy) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4705,6 +4705,15 @@ func buildBufferedRootDeltaBatchPublishInputsFromSpecs(specs []bufferedRootDelta
 	if parallelism > len(specs) {
 		parallelism = len(specs)
 	}
+	if parallelism <= 1 {
+		for i := range specs {
+			if err := buildBufferedRootDeltaBatchPublishInput(specs[i], rootRuns, &ordered[i], &iterators[i]); err != nil {
+				cleanup()
+				return nil, func() {}, err
+			}
+		}
+		return ordered, cleanup, nil
+	}
 	errs := make([]error, len(specs))
 	jobs := make(chan int)
 	var wg sync.WaitGroup

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4146,6 +4146,156 @@ func TestBufferedRootRunsIteratorMultiRunStableUnsafeSlices(t *testing.T) {
 	}
 }
 
+func TestBuildBufferedRootDeltaBatchPublishInputsParallelPreservesRootOrderAndTombstones(t *testing.T) {
+	primaryName := collectionPrimaryRootName("users")
+	stateName := collectionIndexStateRootName("users")
+	cityName := collectionSecondaryRootName("users", "city")
+
+	primaryTable := newCollectionRunTable(2)
+	primaryTable.DeleteSteal([]byte("u1"))
+	setCollectionRunValue(primaryTable, []byte("u2"), []byte(`{"city":"sea"}`))
+	primaryTable.Freeze()
+
+	stateTable := newCollectionRunTable(1)
+	setCollectionRunValue(stateTable, []byte("u2"), []byte("state"))
+	stateTable.Freeze()
+
+	cityTable := newCollectionRunTable(1)
+	setCollectionRunValue(cityTable, []byte("city:sea/u2"), nil)
+	cityTable.Freeze()
+	defer resetCollectionTables([]memtable.Table{primaryTable, stateTable, cityTable})
+
+	rootNames := []string{stateName, primaryName, cityName}
+	rootRuns := map[string][]memtable.Table{
+		primaryName: {primaryTable},
+		stateName:   {stateTable},
+		cityName:    {cityTable},
+	}
+	rootBaseIDs := map[string]uint64{
+		primaryName: 42,
+		stateName:   43,
+		cityName:    44,
+	}
+	rootPolicies := map[string]backenddb.OrderedRootStoragePolicy{
+		primaryName: backenddb.OrderedRootStorageValueLogLeaves,
+		stateName:   backenddb.OrderedRootStoragePagerLeaves,
+		cityName:    backenddb.OrderedRootStoragePagerLeaves,
+	}
+
+	ordered, cleanup, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, rootRuns, rootBaseIDs, rootPolicies)
+	if err != nil {
+		t.Fatalf("build buffered root deltas: %v", err)
+	}
+	defer cleanup()
+
+	if got, want := len(ordered), len(rootNames); got != want {
+		t.Fatalf("ordered roots=%d want %d", got, want)
+	}
+	for i, rootName := range rootNames {
+		if ordered[i].BaseRoot != rootBaseIDs[rootName] {
+			t.Fatalf("ordered[%d] base=%d want %d", i, ordered[i].BaseRoot, rootBaseIDs[rootName])
+		}
+		if ordered[i].StoragePolicy != rootPolicies[rootName] {
+			t.Fatalf("ordered[%d] policy=%d want %d", i, ordered[i].StoragePolicy, rootPolicies[rootName])
+		}
+		if !ordered[i].ParallelApply {
+			t.Fatalf("ordered[%d] ParallelApply=false want true", i)
+		}
+		if ordered[i].IncludeDeletedOnColdBuild {
+			t.Fatalf("ordered[%d] IncludeDeletedOnColdBuild=true want false", i)
+		}
+	}
+
+	primaryEntries := ordered[1].Delta.SortedEntries()
+	if got, want := len(primaryEntries), 2; got != want {
+		t.Fatalf("primary entries=%d want %d", got, want)
+	}
+	if entry := primaryEntries[0]; string(entry.Key) != "u1" || entry.Type != batch.OpDelete {
+		t.Fatalf("primary entry[0]=%+v want tombstone u1", entry)
+	}
+	if entry := primaryEntries[1]; string(entry.Key) != "u2" || string(entry.Value) != `{"city":"sea"}` {
+		t.Fatalf("primary entry[1]=%+v want u2 document", entry)
+	}
+
+	stateEntries := ordered[0].Delta.SortedEntries()
+	if got, want := len(stateEntries), 1; got != want || string(stateEntries[0].Key) != "u2" || string(stateEntries[0].Value) != "state" {
+		t.Fatalf("state entries=%+v want u2=state", stateEntries)
+	}
+	cityEntries := ordered[2].Delta.SortedEntries()
+	if got, want := len(cityEntries), 1; got != want || string(cityEntries[0].Key) != "city:sea/u2" || cityEntries[0].Type != batch.OpPut {
+		t.Fatalf("city entries=%+v want city:sea/u2 put", cityEntries)
+	}
+}
+
+func TestBuildBufferedRootOverlayDeltaBatchPublishInputsPreservesColdTombstones(t *testing.T) {
+	primaryName := collectionPrimaryRootName("users")
+	cityName := collectionSecondaryRootName("users", "city")
+
+	primaryTable := newCollectionRunTable(2)
+	primaryTable.DeleteSteal([]byte("u1"))
+	setCollectionRunValue(primaryTable, []byte("u2"), []byte(`{"city":"sea"}`))
+	primaryTable.Freeze()
+
+	cityTable := newCollectionRunTable(1)
+	cityTable.DeleteSteal([]byte("city:old/u1"))
+	cityTable.Freeze()
+	defer resetCollectionTables([]memtable.Table{primaryTable, cityTable})
+
+	rootNames := []string{primaryName, cityName}
+	rootRuns := map[string][]memtable.Table{
+		primaryName: {primaryTable},
+		cityName:    {cityTable},
+	}
+	rootPolicies := map[string]backenddb.OrderedRootStoragePolicy{
+		primaryName: backenddb.OrderedRootStorageValueLogLeaves,
+		cityName:    backenddb.OrderedRootStoragePagerLeaves,
+	}
+	rootOverlays := map[string][]uint64{
+		primaryName: {102},
+		cityName:    nil,
+	}
+
+	ordered, cleanup, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, rootRuns, rootPolicies, rootOverlays)
+	if err != nil {
+		t.Fatalf("build overlay root deltas: %v", err)
+	}
+	defer cleanup()
+
+	if got, want := len(ordered), len(rootNames); got != want {
+		t.Fatalf("ordered roots=%d want %d", got, want)
+	}
+	if ordered[0].BaseRoot != 102 {
+		t.Fatalf("primary overlay base=%d want latest overlay 102", ordered[0].BaseRoot)
+	}
+	if ordered[1].BaseRoot != 0 {
+		t.Fatalf("city overlay base=%d want cold overlay 0", ordered[1].BaseRoot)
+	}
+	for i := range ordered {
+		if !ordered[i].IncludeDeletedOnColdBuild {
+			t.Fatalf("ordered[%d] IncludeDeletedOnColdBuild=false want true", i)
+		}
+		if !ordered[i].ParallelApply {
+			t.Fatalf("ordered[%d] ParallelApply=false want true", i)
+		}
+	}
+
+	primaryEntries := ordered[0].Delta.SortedEntries()
+	if got, want := len(primaryEntries), 2; got != want {
+		t.Fatalf("primary entries=%d want %d", got, want)
+	}
+	if entry := primaryEntries[0]; string(entry.Key) != "u1" || entry.Type != batch.OpDelete {
+		t.Fatalf("primary entry[0]=%+v want tombstone u1", entry)
+	}
+
+	cityEntries := ordered[1].Delta.SortedEntries()
+	if got, want := len(cityEntries), 1; got != want {
+		t.Fatalf("city entries=%d want %d", got, want)
+	}
+	if entry := cityEntries[0]; string(entry.Key) != "city:old/u1" || entry.Type != batch.OpDelete {
+		t.Fatalf("city entry[0]=%+v want tombstone city:old/u1", entry)
+	}
+}
+
 func BenchmarkBufferedRootRunsIteratorBuildManyRuns(b *testing.B) {
 	const runCount = 8192
 	runs := make([]memtable.Table, 0, runCount)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4143,6 +4143,156 @@ func TestBufferedRootRunsIteratorMultiRunStableUnsafeSlices(t *testing.T) {
 	}
 }
 
+func TestBuildBufferedRootDeltaBatchPublishInputsParallelPreservesRootOrderAndTombstones(t *testing.T) {
+	primaryName := collectionPrimaryRootName("users")
+	stateName := collectionIndexStateRootName("users")
+	cityName := collectionSecondaryRootName("users", "city")
+
+	primaryTable := newCollectionRunTable(2)
+	primaryTable.DeleteSteal([]byte("u1"))
+	setCollectionRunValue(primaryTable, []byte("u2"), []byte(`{"city":"sea"}`))
+	primaryTable.Freeze()
+
+	stateTable := newCollectionRunTable(1)
+	setCollectionRunValue(stateTable, []byte("u2"), []byte("state"))
+	stateTable.Freeze()
+
+	cityTable := newCollectionRunTable(1)
+	setCollectionRunValue(cityTable, []byte("city:sea/u2"), nil)
+	cityTable.Freeze()
+	defer resetCollectionTables([]memtable.Table{primaryTable, stateTable, cityTable})
+
+	rootNames := []string{stateName, primaryName, cityName}
+	rootRuns := map[string][]memtable.Table{
+		primaryName: {primaryTable},
+		stateName:   {stateTable},
+		cityName:    {cityTable},
+	}
+	rootBaseIDs := map[string]uint64{
+		primaryName: 42,
+		stateName:   43,
+		cityName:    44,
+	}
+	rootPolicies := map[string]backenddb.OrderedRootStoragePolicy{
+		primaryName: backenddb.OrderedRootStorageValueLogLeaves,
+		stateName:   backenddb.OrderedRootStoragePagerLeaves,
+		cityName:    backenddb.OrderedRootStoragePagerLeaves,
+	}
+
+	ordered, cleanup, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, rootRuns, rootBaseIDs, rootPolicies)
+	if err != nil {
+		t.Fatalf("build buffered root deltas: %v", err)
+	}
+	defer cleanup()
+
+	if got, want := len(ordered), len(rootNames); got != want {
+		t.Fatalf("ordered roots=%d want %d", got, want)
+	}
+	for i, rootName := range rootNames {
+		if ordered[i].BaseRoot != rootBaseIDs[rootName] {
+			t.Fatalf("ordered[%d] base=%d want %d", i, ordered[i].BaseRoot, rootBaseIDs[rootName])
+		}
+		if ordered[i].StoragePolicy != rootPolicies[rootName] {
+			t.Fatalf("ordered[%d] policy=%d want %d", i, ordered[i].StoragePolicy, rootPolicies[rootName])
+		}
+		if !ordered[i].ParallelApply {
+			t.Fatalf("ordered[%d] ParallelApply=false want true", i)
+		}
+		if ordered[i].IncludeDeletedOnColdBuild {
+			t.Fatalf("ordered[%d] IncludeDeletedOnColdBuild=true want false", i)
+		}
+	}
+
+	primaryEntries := ordered[1].Delta.SortedEntries()
+	if got, want := len(primaryEntries), 2; got != want {
+		t.Fatalf("primary entries=%d want %d", got, want)
+	}
+	if entry := primaryEntries[0]; string(entry.Key) != "u1" || entry.Type != batch.OpDelete {
+		t.Fatalf("primary entry[0]=%+v want tombstone u1", entry)
+	}
+	if entry := primaryEntries[1]; string(entry.Key) != "u2" || string(entry.Value) != `{"city":"sea"}` {
+		t.Fatalf("primary entry[1]=%+v want u2 document", entry)
+	}
+
+	stateEntries := ordered[0].Delta.SortedEntries()
+	if got, want := len(stateEntries), 1; got != want || string(stateEntries[0].Key) != "u2" || string(stateEntries[0].Value) != "state" {
+		t.Fatalf("state entries=%+v want u2=state", stateEntries)
+	}
+	cityEntries := ordered[2].Delta.SortedEntries()
+	if got, want := len(cityEntries), 1; got != want || string(cityEntries[0].Key) != "city:sea/u2" || cityEntries[0].Type != batch.OpPut {
+		t.Fatalf("city entries=%+v want city:sea/u2 put", cityEntries)
+	}
+}
+
+func TestBuildBufferedRootOverlayDeltaBatchPublishInputsPreservesColdTombstones(t *testing.T) {
+	primaryName := collectionPrimaryRootName("users")
+	cityName := collectionSecondaryRootName("users", "city")
+
+	primaryTable := newCollectionRunTable(2)
+	primaryTable.DeleteSteal([]byte("u1"))
+	setCollectionRunValue(primaryTable, []byte("u2"), []byte(`{"city":"sea"}`))
+	primaryTable.Freeze()
+
+	cityTable := newCollectionRunTable(1)
+	cityTable.DeleteSteal([]byte("city:old/u1"))
+	cityTable.Freeze()
+	defer resetCollectionTables([]memtable.Table{primaryTable, cityTable})
+
+	rootNames := []string{primaryName, cityName}
+	rootRuns := map[string][]memtable.Table{
+		primaryName: {primaryTable},
+		cityName:    {cityTable},
+	}
+	rootPolicies := map[string]backenddb.OrderedRootStoragePolicy{
+		primaryName: backenddb.OrderedRootStorageValueLogLeaves,
+		cityName:    backenddb.OrderedRootStoragePagerLeaves,
+	}
+	rootOverlays := map[string][]uint64{
+		primaryName: {102},
+		cityName:    nil,
+	}
+
+	ordered, cleanup, err := buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames, rootRuns, rootPolicies, rootOverlays)
+	if err != nil {
+		t.Fatalf("build overlay root deltas: %v", err)
+	}
+	defer cleanup()
+
+	if got, want := len(ordered), len(rootNames); got != want {
+		t.Fatalf("ordered roots=%d want %d", got, want)
+	}
+	if ordered[0].BaseRoot != 102 {
+		t.Fatalf("primary overlay base=%d want latest overlay 102", ordered[0].BaseRoot)
+	}
+	if ordered[1].BaseRoot != 0 {
+		t.Fatalf("city overlay base=%d want cold overlay 0", ordered[1].BaseRoot)
+	}
+	for i := range ordered {
+		if !ordered[i].IncludeDeletedOnColdBuild {
+			t.Fatalf("ordered[%d] IncludeDeletedOnColdBuild=false want true", i)
+		}
+		if !ordered[i].ParallelApply {
+			t.Fatalf("ordered[%d] ParallelApply=false want true", i)
+		}
+	}
+
+	primaryEntries := ordered[0].Delta.SortedEntries()
+	if got, want := len(primaryEntries), 2; got != want {
+		t.Fatalf("primary entries=%d want %d", got, want)
+	}
+	if entry := primaryEntries[0]; string(entry.Key) != "u1" || entry.Type != batch.OpDelete {
+		t.Fatalf("primary entry[0]=%+v want tombstone u1", entry)
+	}
+
+	cityEntries := ordered[1].Delta.SortedEntries()
+	if got, want := len(cityEntries), 1; got != want {
+		t.Fatalf("city entries=%d want %d", got, want)
+	}
+	if entry := cityEntries[0]; string(entry.Key) != "city:old/u1" || entry.Type != batch.OpDelete {
+		t.Fatalf("city entry[0]=%+v want tombstone city:old/u1", entry)
+	}
+}
+
 func BenchmarkBufferedRootRunsIteratorBuildManyRuns(b *testing.B) {
 	const runCount = 8192
 	runs := make([]memtable.Table, 0, runCount)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1154,9 +1154,6 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	if stats.IndexedFlushBytes == 0 || stats.IndexedFlushRootRuns == 0 || stats.IndexedFlushRoots == 0 {
 		t.Fatalf("stats indexed flush bytes/root-runs/roots=%d/%d/%d want positive", stats.IndexedFlushBytes, stats.IndexedFlushRootRuns, stats.IndexedFlushRoots)
 	}
-	if stats.IndexedFlushDuration <= 0 || stats.IndexedFlushMaterialize <= 0 || stats.IndexedFlushPublish <= 0 {
-		t.Fatalf("stats indexed flush duration/materialize/publish=%s/%s/%s want positive", stats.IndexedFlushDuration, stats.IndexedFlushMaterialize, stats.IndexedFlushPublish)
-	}
 	exported = mgr.Stats()
 	for _, key := range []string{
 		"treedb.collections.write_domain.indexed_flush.duration_ns_total",

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1154,6 +1154,19 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	if stats.IndexedFlushBytes == 0 || stats.IndexedFlushRootRuns == 0 || stats.IndexedFlushRoots == 0 {
 		t.Fatalf("stats indexed flush bytes/root-runs/roots=%d/%d/%d want positive", stats.IndexedFlushBytes, stats.IndexedFlushRootRuns, stats.IndexedFlushRoots)
 	}
+	if stats.IndexedFlushDuration <= 0 || stats.IndexedFlushMaterialize <= 0 || stats.IndexedFlushPublish <= 0 {
+		t.Fatalf("stats indexed flush duration/materialize/publish=%s/%s/%s want positive", stats.IndexedFlushDuration, stats.IndexedFlushMaterialize, stats.IndexedFlushPublish)
+	}
+	exported = mgr.Stats()
+	for _, key := range []string{
+		"treedb.collections.write_domain.indexed_flush.duration_ns_total",
+		"treedb.collections.write_domain.indexed_flush.materialize_ns_total",
+		"treedb.collections.write_domain.indexed_flush.publish_ns_total",
+	} {
+		if exported[key] == "" {
+			t.Fatalf("exported stats missing %s from %#v", key, exported)
+		}
+	}
 }
 
 func TestCollectionManagerResetUpdateCombineQueueDepthMax(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1154,6 +1154,9 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	if stats.IndexedFlushBytes == 0 || stats.IndexedFlushRootRuns == 0 || stats.IndexedFlushRoots == 0 {
 		t.Fatalf("stats indexed flush bytes/root-runs/roots=%d/%d/%d want positive", stats.IndexedFlushBytes, stats.IndexedFlushRootRuns, stats.IndexedFlushRoots)
 	}
+	if stats.IndexedFlushDuration <= 0 || stats.IndexedFlushMaterialize <= 0 || stats.IndexedFlushPublish <= 0 {
+		t.Fatalf("stats indexed flush duration/materialize/publish=%s/%s/%s want positive", stats.IndexedFlushDuration, stats.IndexedFlushMaterialize, stats.IndexedFlushPublish)
+	}
 	exported = mgr.Stats()
 	for _, key := range []string{
 		"treedb.collections.write_domain.indexed_flush.duration_ns_total",

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1120,6 +1120,8 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		IndexedFlushRootRuns:           after.IndexedFlushRootRuns - before.IndexedFlushRootRuns,
 		IndexedFlushRoots:              after.IndexedFlushRoots - before.IndexedFlushRoots,
 		IndexedFlushDuration:           after.IndexedFlushDuration - before.IndexedFlushDuration,
+		IndexedFlushMaterialize:        after.IndexedFlushMaterialize - before.IndexedFlushMaterialize,
+		IndexedFlushPublish:            after.IndexedFlushPublish - before.IndexedFlushPublish,
 	}
 	if after.UpdateCombineQueueDepthMax > before.UpdateCombineQueueDepthMax {
 		delta.UpdateCombineQueueDepthMax = after.UpdateCombineQueueDepthMax
@@ -1186,6 +1188,8 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushRootRuns:           90,
 		IndexedFlushRoots:              9,
 		IndexedFlushDuration:           30 * time.Millisecond,
+		IndexedFlushMaterialize:        12 * time.Millisecond,
+		IndexedFlushPublish:            18 * time.Millisecond,
 		UpdateBatchIndexStatsCount:     2,
 		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
 			{CollectionName: "users", IndexName: "email", IndexOrdinal: 0, Unique: true, Changed: 1, Unchanged: 9, UniqueChecks: 1, UniqueCheckSkips: 8},
@@ -1209,6 +1213,8 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushRootRuns:           270,
 		IndexedFlushRoots:              24,
 		IndexedFlushDuration:           90 * time.Millisecond,
+		IndexedFlushMaterialize:        30 * time.Millisecond,
+		IndexedFlushPublish:            60 * time.Millisecond,
 		UpdateBatchIndexStatsCount:     2,
 		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
 			{CollectionName: "users", IndexName: "email", IndexOrdinal: 0, Unique: true, Changed: 1, Unchanged: 22, UniqueChecks: 1, UniqueCheckSkips: 17},
@@ -1250,8 +1256,8 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	if got.UpdateBatchUniqueCheckSkips != 9 {
 		t.Fatalf("UpdateBatchUniqueCheckSkips=%d want 9", got.UpdateBatchUniqueCheckSkips)
 	}
-	if got.IndexedFlushCalls != 5 || got.IndexedFlushErrors != 1 || got.IndexedFlushDocs != 600 || got.IndexedFlushBytes != 18000 || got.IndexedFlushRootRuns != 180 || got.IndexedFlushRoots != 15 || got.IndexedFlushDuration != 60*time.Millisecond {
-		t.Fatalf("indexed flush delta calls/errors/docs/bytes/rootRuns/roots/duration=%d/%d/%d/%d/%d/%d/%s want 5/1/600/18000/180/15/60ms",
+	if got.IndexedFlushCalls != 5 || got.IndexedFlushErrors != 1 || got.IndexedFlushDocs != 600 || got.IndexedFlushBytes != 18000 || got.IndexedFlushRootRuns != 180 || got.IndexedFlushRoots != 15 || got.IndexedFlushDuration != 60*time.Millisecond || got.IndexedFlushMaterialize != 18*time.Millisecond || got.IndexedFlushPublish != 42*time.Millisecond {
+		t.Fatalf("indexed flush delta calls/errors/docs/bytes/rootRuns/roots/duration/materialize/publish=%d/%d/%d/%d/%d/%d/%s/%s/%s want 5/1/600/18000/180/15/60ms/18ms/42ms",
 			got.IndexedFlushCalls,
 			got.IndexedFlushErrors,
 			got.IndexedFlushDocs,
@@ -1259,6 +1265,8 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 			got.IndexedFlushRootRuns,
 			got.IndexedFlushRoots,
 			got.IndexedFlushDuration,
+			got.IndexedFlushMaterialize,
+			got.IndexedFlushPublish,
 		)
 	}
 	if got.UpdateBatchIndexStatsCount != 2 {
@@ -1282,30 +1290,36 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 
 func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testing.T) {
 	stats := collections.CollectionManagerStats{
-		IndexedFlushCalls:    5,
-		IndexedFlushErrors:   1,
-		IndexedFlushDocs:     600,
-		IndexedFlushBytes:    18000,
-		IndexedFlushRootRuns: 180,
-		IndexedFlushRoots:    15,
-		IndexedFlushDuration: 60 * time.Millisecond,
+		IndexedFlushCalls:       5,
+		IndexedFlushErrors:      1,
+		IndexedFlushDocs:        600,
+		IndexedFlushBytes:       18000,
+		IndexedFlushRootRuns:    180,
+		IndexedFlushRoots:       15,
+		IndexedFlushDuration:    60 * time.Millisecond,
+		IndexedFlushMaterialize: 18 * time.Millisecond,
+		IndexedFlushPublish:     42 * time.Millisecond,
 	}
 	result := testing.Benchmark(func(b *testing.B) {
 		reportCollectionManagerUpdateStats(b, stats, 600)
 	})
 	want := map[string]float64{
-		"indexed_flush_calls":          5,
-		"indexed_flush_docs/call":      120,
-		"indexed_flush_docs/doc":       1,
-		"indexed_flush_bytes/call":     3600,
-		"indexed_flush_bytes/doc":      30,
-		"indexed_flush_root_runs/call": 36,
-		"indexed_flush_root_runs/doc":  0.3,
-		"indexed_flush_roots/call":     3,
-		"indexed_flush_roots/doc":      0.025,
-		"indexed_flush_errors":         1,
-		"indexed_flush_ns/call":        12_000_000,
-		"indexed_flush_ns/doc":         100_000,
+		"indexed_flush_calls":               5,
+		"indexed_flush_docs/call":           120,
+		"indexed_flush_docs/doc":            1,
+		"indexed_flush_bytes/call":          3600,
+		"indexed_flush_bytes/doc":           30,
+		"indexed_flush_root_runs/call":      36,
+		"indexed_flush_root_runs/doc":       0.3,
+		"indexed_flush_roots/call":          3,
+		"indexed_flush_roots/doc":           0.025,
+		"indexed_flush_errors":              1,
+		"indexed_flush_ns/call":             12_000_000,
+		"indexed_flush_ns/doc":              100_000,
+		"indexed_flush_materialize_ns/call": 3_600_000,
+		"indexed_flush_materialize_ns/doc":  30_000,
+		"indexed_flush_publish_ns/call":     8_400_000,
+		"indexed_flush_publish_ns/doc":      70_000,
 	}
 	for metric, wantValue := range want {
 		gotValue, ok := result.Extra[metric]
@@ -1381,6 +1395,18 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 			b.ReportMetric(float64(stats.IndexedFlushDuration.Nanoseconds())/float64(stats.IndexedFlushCalls), "indexed_flush_ns/call")
 			if stats.IndexedFlushDocs > 0 {
 				b.ReportMetric(float64(stats.IndexedFlushDuration.Nanoseconds())/float64(stats.IndexedFlushDocs), "indexed_flush_ns/doc")
+			}
+		}
+		if stats.IndexedFlushMaterialize > 0 {
+			b.ReportMetric(float64(stats.IndexedFlushMaterialize.Nanoseconds())/float64(stats.IndexedFlushCalls), "indexed_flush_materialize_ns/call")
+			if stats.IndexedFlushDocs > 0 {
+				b.ReportMetric(float64(stats.IndexedFlushMaterialize.Nanoseconds())/float64(stats.IndexedFlushDocs), "indexed_flush_materialize_ns/doc")
+			}
+		}
+		if stats.IndexedFlushPublish > 0 {
+			b.ReportMetric(float64(stats.IndexedFlushPublish.Nanoseconds())/float64(stats.IndexedFlushCalls), "indexed_flush_publish_ns/call")
+			if stats.IndexedFlushDocs > 0 {
+				b.ReportMetric(float64(stats.IndexedFlushPublish.Nanoseconds())/float64(stats.IndexedFlushDocs), "indexed_flush_publish_ns/doc")
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Architecture track: indexed collection root publish fan-in / pre-publish materialization.

This PR changes buffered indexed flush publish preparation so each affected collection root materializes its ordered root delta batch independently. The durable publish path still receives the same ordered root list and preserves the existing grouped publish semantics, but expensive iterator-to-batch conversion can now run concurrently before root publish.

## Correctness

- Preserves root order by materializing into pre-sized output slots keyed by the original root order.
- Keeps cleanup ownership for every materialized delta and iterator.
- Preserves overlay cold-build tombstones via `IncludeDeletedOnColdBuild`.
- Leaves single-root flushes on the sequential path.

## Local validation

```bash
go test ./TreeDB/collections -run 'TestBuildBufferedRootDeltaBatchPublishInputs|TestBuildBufferedRootOverlayDeltaBatchPublishInputs|TestCollectionManagerStatsExposeIndexedWriteDomainMetrics|TestCollectionUpdateBufferFlushTimingCountsAsyncSchedule' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/mongo_gateway_bench -count=1
go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder' -count=1
git diff --check
```

All passed locally.

## Focused benchmark evidence

Base for comparisons: #1236 / `codex/1159-arch-next` after the Windows sub-tick timing assertion fix.

Two-index BSON insert, 500k docs, batch=2000, async indexed flush, max queued units=4:

| Branch | ns/doc | docs/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| #1236 base | 1,184 | 844,568 | 1,894 | 1 |
| this PR | 1,128 | 886,215 | 2,141 | 1 |

Command shape:

```bash
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench \
  -run '^$' \
  -bench '^BenchmarkDirectCollectionLoadBSONIndexes2$' \
  -benchtime=500000x \
  -benchmem \
  -count=1
```

Three-index city-update, 200k preload docs, batch=2000, 32 writers, async indexed flush, max queued units=4:

| Branch | ns/doc | docs/sec | indexed_flush_materialize_ns/doc | indexed_flush_publish_ns/doc | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| #1236 previous run | 5,234 | 191,049 | 1,423 | 1,052 | 1,830 | 3 |
| this PR run 1 | 5,239 | 190,880 | 1,288 | 1,077 | 1,818 | 3 |
| this PR run 2 | 5,451 | 183,441 | 1,408 | 1,241 | 2,094 | 3 |

Interpretation: the update shape is roughly neutral because per-index planning now publishes only two roots. The insert shape, which touches more roots per flush, shows the intended benefit. This is still not the final #1159 architecture endpoint; it is a small root-fan-in preparation step before larger write-back/zipper work.