### PR TITLE
Collections: direct buffered BSON update accumulators

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -659,6 +659,7 @@ type bufferedIndexedCheckpoint struct {
 	mutableBytes           int64
 	writeGeneration        uint64
 	rootRuns               map[string][]memtable.Table
+	rootMutableRuns        map[string]memtable.Table
 	rootPolicies           map[string]backenddb.OrderedRootStoragePolicy
 	rootBaseIDs            map[string]uint64
 	indexedPublishingUnits []indexedFlushUnit
@@ -712,6 +713,7 @@ type collectionWriteDomain struct {
 	indexedPublishingUnits []indexedFlushUnit
 	indexedFlushUnits      []indexedFlushUnit
 	rootRuns               map[string][]memtable.Table
+	rootMutableRuns        map[string]memtable.Table
 	rootPolicies           map[string]backenddb.OrderedRootStoragePolicy
 	rootBaseIDs            map[string]uint64
 	primaryIDIndex         *bufferedUniqueValueIndex
@@ -2764,6 +2766,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 		domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex)
 	}
 	autoFlushEnabled := bufferedIndexedAutoFlushEnabled(catalog.meta.Options)
+	freezeMutableIndexedRunMapsLocked(domain)
 	var checkpoint bufferedIndexedCheckpoint
 	if autoFlushEnabled {
 		checkpoint = checkpointBufferedIndexedDomain(domain)
@@ -2871,6 +2874,7 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.indexedPublishingUnits = nil
 	domain.indexedFlushUnits = nil
 	domain.rootRuns = nil
+	domain.rootMutableRuns = nil
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.rootRunCount = 0
@@ -2971,6 +2975,7 @@ func maybeCompactBufferedIndexedMutableRunsLocked(domain *collectionWriteDomain,
 	}
 	afterBytes := tableRunMapSize(compactedRootRuns) + tableRunMapSize(compactedUniqueRuns)
 	domain.rootRuns = compactedRootRuns
+	domain.rootMutableRuns = nil
 	domain.uniqueValueRuns = compactedUniqueRuns
 	domain.rootRunCount = tableRunMapRunCount(domain.rootRuns)
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(subtractNonNegativeInt64(domain.bufferedBytes, beforeBytes), afterBytes)
@@ -3032,6 +3037,66 @@ func compactTableRuns(runs []memtable.Table) (memtable.Table, error) {
 	}
 	table.Freeze()
 	return table, nil
+}
+
+func mutableRootRunLocked(domain *collectionWriteDomain, rootName string) (memtable.Table, bool) {
+	if domain == nil || rootName == "" {
+		return nil, false
+	}
+	if domain.rootRuns == nil {
+		domain.rootRuns = make(map[string][]memtable.Table)
+	}
+	if domain.rootMutableRuns == nil {
+		domain.rootMutableRuns = make(map[string]memtable.Table)
+	}
+	if table := domain.rootMutableRuns[rootName]; table != nil {
+		return table, false
+	}
+	table := newCollectionRootAccumulatorRunTable()
+	domain.rootMutableRuns[rootName] = table
+	domain.rootRuns[rootName] = append(domain.rootRuns[rootName], table)
+	domain.rootRunCount = saturatingAddNonNegativeInt(domain.rootRunCount, 1)
+	return table, true
+}
+
+func newCollectionRootAccumulatorRunTable() memtable.Table {
+	return newFreezeSortRunTable()
+}
+
+func freezeMutableIndexedRunMapsLocked(domain *collectionWriteDomain) {
+	if domain == nil || len(domain.rootMutableRuns) == 0 {
+		return
+	}
+	for _, table := range domain.rootMutableRuns {
+		if table != nil {
+			table.Freeze()
+		}
+	}
+	domain.rootMutableRuns = nil
+}
+
+func estimateAccumulatedRootRunsForNamesLocked(domain *collectionWriteDomain, rootNames []string) int {
+	added := 0
+	for i, rootName := range rootNames {
+		if rootName == "" {
+			continue
+		}
+		seen := false
+		for j := 0; j < i; j++ {
+			if rootNames[j] == rootName {
+				seen = true
+				break
+			}
+		}
+		if seen {
+			continue
+		}
+		if domain != nil && domain.rootMutableRuns != nil && domain.rootMutableRuns[rootName] != nil {
+			continue
+		}
+		added++
+	}
+	return added
 }
 
 func resetTableRunMap(runs, preserved map[string][]memtable.Table) {
@@ -3401,6 +3466,7 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		mutableBytes:           domain.mutableBytes,
 		writeGeneration:        domain.writeGeneration,
 		rootRuns:               cloneTableRunMap(domain.rootRuns),
+		rootMutableRuns:        cloneMutableRunMap(domain.rootMutableRuns),
 		rootPolicies:           cloneRootPolicyMap(domain.rootPolicies),
 		rootBaseIDs:            cloneUint64Map(domain.rootBaseIDs),
 		indexedPublishingUnits: cloneIndexedFlushUnits(domain.indexedPublishingUnits),
@@ -3433,6 +3499,7 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.indexedPublishingUnits = checkpoint.indexedPublishingUnits
 	domain.indexedFlushUnits = checkpoint.indexedFlushUnits
 	domain.rootRuns = checkpoint.rootRuns
+	domain.rootMutableRuns = checkpoint.rootMutableRuns
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
 	domain.rootRunCount = checkpoint.rootRunCount
@@ -3598,6 +3665,17 @@ func cloneTableRunMap(in map[string][]memtable.Table) map[string][]memtable.Tabl
 	out := make(map[string][]memtable.Table, len(in))
 	for name, runs := range in {
 		out[name] = runs
+	}
+	return out
+}
+
+func cloneMutableRunMap(in map[string]memtable.Table) map[string]memtable.Table {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]memtable.Table, len(in))
+	for name, table := range in {
+		out[name] = table
 	}
 	return out
 }
@@ -3882,6 +3960,25 @@ func addBufferedPrimaryRunIndexEntries(index *bufferedPrimaryRunIndex, batchPrim
 		index.arenas = append(index.arenas, arena)
 	}
 	return nil
+}
+
+func addBufferedPrimaryRunIndexKeys(index *bufferedPrimaryRunIndex, keys [][]byte, table memtable.Table) {
+	if index == nil || table == nil || len(keys) == 0 {
+		return
+	}
+	arena := make([]byte, 0, bufferedPrimaryIDArenaCap(len(keys)))
+	for _, key := range keys {
+		if len(key) == 0 {
+			continue
+		}
+		start := len(arena)
+		arena = append(arena, key...)
+		refKey := arena[start:len(arena)]
+		index.addRef(xxhash.Sum64(key), bufferedPrimaryRunRef{key: refKey, table: table})
+	}
+	if len(arena) > 0 {
+		index.arenas = append(index.arenas, arena)
+	}
 }
 
 func bufferedPrimaryIDArenaCap(entries int) int {
@@ -4530,6 +4627,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		_ = pin.Close()
 		work.pin = nil
 		domain.indexedFlushUnits = nil
+		domain.rootMutableRuns = nil
 		domain.count = 0
 		domain.bufferedBytes = 0
 		domain.mutableCount = 0
@@ -4902,6 +5000,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	rootNames := orderedBufferedRootNames(meta, flushUnit.rootRuns)
 	if len(rootNames) == 0 {
 		domain.indexedFlushUnits = nil
+		domain.rootMutableRuns = nil
 		domain.count = 0
 		domain.bufferedBytes = 0
 		domain.mutableCount = 0
@@ -4988,6 +5087,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	domain.primaryRoot = nextCatalog.rootID(collectionPrimaryRootName(meta.Name))
 	domain.indexedFlushUnits = nil
 	domain.rootRuns = nil
+	domain.rootMutableRuns = nil
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.rootRunCount = 0
@@ -5016,6 +5116,7 @@ func rotateIndexedMutableToFlushUnitLocked(domain *collectionWriteDomain) bool {
 	if domain == nil || len(domain.rootRuns) == 0 {
 		return false
 	}
+	freezeMutableIndexedRunMapsLocked(domain)
 	unit := indexedFlushUnit{
 		rootRuns:        domain.rootRuns,
 		rootPolicies:    domain.rootPolicies,
@@ -5027,6 +5128,7 @@ func rotateIndexedMutableToFlushUnitLocked(domain *collectionWriteDomain) bool {
 	}
 	domain.indexedFlushUnits = append(domain.indexedFlushUnits, unit)
 	domain.rootRuns = nil
+	domain.rootMutableRuns = nil
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.uniqueValueRuns = nil
@@ -7176,12 +7278,20 @@ type updateBatchPlan struct {
 	baseRootIDs                 map[string]uint64
 	policies                    []backenddb.OrderedRootStoragePolicy
 	deltaTables                 []memtable.Table
+	directBufferedUpdate        *directBufferedUpdatePlan
 	uniqueSecondaryIndexByRoot  []int
 	canBufferIndexedUpdateBatch bool
 	bufferedBase                bool
 	bufferedReadGeneration      uint64
 	bufferedReadBlocked         bool
 	scratch                     *updateBatchPlanScratch
+}
+
+type directBufferedUpdatePlan struct {
+	changed         []preparedBatchUpdate
+	runtimes        []indexRuntime
+	primaryRootName string
+	stagedBytes     int64
 }
 
 var updateBatchPlanPool sync.Pool
@@ -7490,6 +7600,19 @@ func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPla
 	return c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs)
 }
 
+func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, templateRecords []templateV1Record) bool {
+	if c == nil || c.writeDomain == nil || !canBuffer || mode == updateBatchModeAny {
+		return false
+	}
+	if !meta.Options.BufferedIndexedWrites || len(meta.Indexes) == 0 {
+		return false
+	}
+	if len(templateRecords) != 0 {
+		return false
+	}
+	return !persistIndexStateForOptions(opts)
+}
+
 func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMode) ([]UpdateBatchResult, error) {
 	if c.shouldPlanUpdateBatchWithBufferedWrites(mode) {
 		useBufferedRead := true
@@ -7504,7 +7627,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 			var results []UpdateBatchResult
 			replan := false
 			err = c.withMutationLock(func() error {
-				if len(plan.deltaTables) == 0 {
+				if len(plan.deltaTables) == 0 && plan.directBufferedUpdate == nil {
 					if plan.bufferedReadBlocked && useBufferedRead {
 						if err := c.flushBufferedWrites(); err != nil {
 							return err
@@ -7548,6 +7671,14 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 					results = plan.results
 					return nil
 				}
+				if plan.directBufferedUpdate != nil {
+					if err := c.flushBufferedWrites(); err != nil {
+						return err
+					}
+					useBufferedRead = false
+					replan = true
+					return nil
+				}
 				if err := c.flushBufferedWrites(); err != nil {
 					return err
 				}
@@ -7587,7 +7718,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 		return nil, nil
 	}
 	defer plan.close()
-	if len(plan.deltaTables) == 0 {
+	if len(plan.deltaTables) == 0 && plan.directBufferedUpdate == nil {
 		if err := c.withMutationLock(func() error {
 			if err := c.flushBufferedWrites(); err != nil {
 				return err
@@ -7613,6 +7744,12 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 		if buffered {
 			results = plan.results
 			return nil
+		}
+		if plan.directBufferedUpdate != nil {
+			if err := c.flushBufferedWrites(); err != nil {
+				return err
+			}
+			return ErrConcurrentMutation
 		}
 		var publishErr error
 		if err := c.flushBufferedWrites(); err != nil {
@@ -8181,10 +8318,107 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	}
 	stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 
+	success := false
+	if c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, templateRecords) {
+		phaseStart = updateBatchStatsNow(detailedStats)
+		rootNames = append(rootNames, primaryRootName)
+		uniqueSecondary = append(uniqueSecondary, -1)
+		baseRootIDs[primaryRootName] = primaryRoot
+		policies = append(policies, plannerOptions.dataStoragePolicy)
+		var stagedBytes int64
+		for i := range changed {
+			results[changed[i].itemIndex].Modified = true
+			stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, int64(len(changed[i].documentID)+len(changed[i].document)))
+		}
+		secondaryRunStats := make([]CollectionUpdateSecondaryRunStats, len(runtimes))
+		for runtimeIdx, runtime := range runtimes {
+			rootHasDelta := false
+			runStats := &secondaryRunStats[runtimeIdx]
+			runStats.IndexName = runtime.def.name
+			for _, item := range changed {
+				if !item.indexStateChanged || !preparedBatchUpdateIndexChanged(item, runtimeIdx) {
+					continue
+				}
+				for _, encoded := range item.oldState.valuesAt(runtimeIdx) {
+					keyBytes := len(encoded) + len(item.documentID)
+					stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, int64(keyBytes))
+					stats.SecondaryDeleteEntries++
+					stats.SecondaryKeyBytes += keyBytes
+					runStats.Deletes++
+					runStats.KeyBytes += keyBytes
+					if runtimeIdx < stats.IndexStatsCount {
+						stats.IndexStats[runtimeIdx].SecondaryDeletes++
+						stats.IndexStats[runtimeIdx].SecondaryKeyBytes += keyBytes
+					}
+					rootHasDelta = true
+				}
+				for _, encoded := range item.newState.valuesAt(runtimeIdx) {
+					keyBytes := len(encoded) + len(item.documentID)
+					stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, int64(keyBytes))
+					stats.SecondarySetEntries++
+					stats.SecondaryKeyBytes += keyBytes
+					runStats.Sets++
+					runStats.KeyBytes += keyBytes
+					if runtimeIdx < stats.IndexStatsCount {
+						stats.IndexStats[runtimeIdx].SecondarySets++
+						stats.IndexStats[runtimeIdx].SecondaryKeyBytes += keyBytes
+					}
+					rootHasDelta = true
+				}
+			}
+			if !rootHasDelta {
+				continue
+			}
+			rootName := runtimeSecondaryRootName(meta.Name, runtime)
+			rootNames = append(rootNames, rootName)
+			if runtime.def.unique {
+				uniqueSecondary = append(uniqueSecondary, runtimeIdx)
+			} else {
+				uniqueSecondary = append(uniqueSecondary, -1)
+			}
+			baseRootIDs[rootName] = catalog.rootID(rootName)
+			policies = append(policies, runtime.def.storagePolicy)
+			stats.SecondaryRuns = append(stats.SecondaryRuns, *runStats)
+			if runtimeIdx < stats.IndexStatsCount {
+				stats.IndexStats[runtimeIdx].SecondaryRuns++
+			}
+		}
+		stats.SecondaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
+		success = true
+		plan := newUpdateBatchPlan()
+		stats = updateCollectionUpdateStatsCounts(stats, results, len(rootNames))
+		*plan = updateBatchPlan{
+			results:                     results,
+			stats:                       stats,
+			meta:                        meta,
+			catalog:                     catalog,
+			snap:                        snap,
+			baseUserRoot:                baseUserRoot,
+			baseSystemRoot:              baseSystemRoot,
+			baseCommitSeq:               baseCommitSeq,
+			rootNames:                   rootNames,
+			baseRootIDs:                 baseRootIDs,
+			uniqueSecondaryIndexByRoot:  uniqueSecondary,
+			canBufferIndexedUpdateBatch: canBufferIndexedUpdateBatch,
+			bufferedBase:                bufferedRead.enabled,
+			bufferedReadGeneration:      bufferedRead.writeGeneration,
+			bufferedReadBlocked:         bufferedReadBlocked,
+			policies:                    policies,
+			directBufferedUpdate: &directBufferedUpdatePlan{
+				changed:         changed,
+				runtimes:        runtimes,
+				primaryRootName: primaryRootName,
+				stagedBytes:     stagedBytes,
+			},
+			scratch: scratch,
+		}
+		scratchOwnedByPlan = true
+		return plan, nil
+	}
+
 	var stateTable memtable.Table
 	secondaryTables := make(map[string]memtable.Table, len(runtimes))
 	secondaryRunStats := make([]CollectionUpdateSecondaryRunStats, len(runtimes))
-	success := false
 	defer func() {
 		if success {
 			return
@@ -8430,8 +8664,235 @@ func updateBatchPlanUniqueSecondaryIndex(plan *updateBatchPlan, rootOffset int) 
 	return indexDef, true
 }
 
+func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, error) {
+	if c == nil || plan == nil || plan.directBufferedUpdate == nil || len(plan.directBufferedUpdate.changed) == 0 {
+		return false, nil
+	}
+	direct := plan.directBufferedUpdate
+	detailedStats := c.updateBatchDetailedStatsEnabled()
+	bufferStart := updateBatchStatsNow(detailedStats)
+	precheckStart := updateBatchStatsNow(detailedStats)
+	defer func() {
+		plan.stats.BufferStage += updateBatchStatsSince(detailedStats, bufferStart)
+	}()
+	if c.writeDomain == nil || !plan.canBufferIndexedUpdateBatch || !plan.meta.Options.BufferedIndexedWrites || len(plan.meta.Indexes) == 0 {
+		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
+		return false, nil
+	}
+	if len(plan.rootNames) == 0 || len(plan.rootNames) != len(plan.policies) || len(plan.rootNames) != len(plan.uniqueSecondaryIndexByRoot) {
+		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
+		return false, fmt.Errorf("collections: UpdateBatch collection %q invalid direct plan lengths roots=%d policies=%d unique=%d", plan.meta.Name, len(plan.rootNames), len(plan.policies), len(plan.uniqueSecondaryIndexByRoot))
+	}
+	modifiedCount := updateBatchModifiedCount(plan.results)
+	if modifiedCount == 0 {
+		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
+		return false, nil
+	}
+	plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
+
+	domain := c.writeDomain
+	lockStart := updateBatchStatsNow(detailedStats)
+	domain.mu.Lock()
+	plan.stats.BufferStageLockWait += updateBatchStatsSince(detailedStats, lockStart)
+	lockHoldStart := updateBatchStatsNow(detailedStats)
+	var lockReleasedDuringHold time.Duration
+	defer func() {
+		lockHold := updateBatchStatsSince(detailedStats, lockHoldStart)
+		if lockReleasedDuringHold > 0 {
+			if lockHold > lockReleasedDuringHold {
+				lockHold -= lockReleasedDuringHold
+			} else {
+				lockHold = 0
+			}
+		}
+		plan.stats.BufferStageLockHold += lockHold
+		domain.mu.Unlock()
+	}()
+
+	phaseStart := updateBatchStatsNow(detailedStats)
+	if domain.count != 0 {
+		if !plan.bufferedBase || !updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) {
+			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+			return false, ErrConcurrentMutation
+		}
+		if plan.bufferedReadGeneration != domain.writeGeneration {
+			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+			return false, ErrConcurrentMutation
+		}
+	}
+	if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
+		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+		return false, err
+	}
+	plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+
+	phaseStart = updateBatchStatsNow(detailedStats)
+	for _, rootName := range plan.rootNames {
+		baseRoot, ok := plan.baseRootIDs[rootName]
+		if !ok {
+			plan.stats.BufferStageRootScan += updateBatchStatsSince(detailedStats, phaseStart)
+			return false, fmt.Errorf("collections: UpdateBatch collection %q direct plan missing base root for %q", plan.meta.Name, rootName)
+		}
+		if hasPendingIndexedRootRunsForRootLocked(domain, rootName) {
+			if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, rootName); ok && pendingBaseRoot != baseRoot {
+				plan.stats.BufferStageRootScan += updateBatchStatsSince(detailedStats, phaseStart)
+				return false, errConcurrentRootModification(plan.meta.Name, rootName)
+			}
+		}
+	}
+	plan.stats.BufferStageRootScan += updateBatchStatsSince(detailedStats, phaseStart)
+
+	phaseStart = updateBatchStatsNow(detailedStats)
+	if domain.count == 0 && plan.catalog != nil {
+		c.initializeWriteDomainFromCatalogLocked(domain, plan.catalog, plan.baseCommitSeq, plan.baseSystemRoot)
+	}
+	if domain.rootPolicies == nil {
+		domain.rootPolicies = make(map[string]backenddb.OrderedRootStoragePolicy, len(plan.rootNames))
+	}
+	if domain.rootBaseIDs == nil {
+		domain.rootBaseIDs = make(map[string]uint64, len(plan.rootNames))
+	}
+	if domain.rootRuns == nil {
+		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
+	}
+	addedRootRuns := estimateAccumulatedRootRunsForNamesLocked(domain, plan.rootNames)
+	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, direct.stagedBytes, addedRootRuns)
+	if !shouldAutoFlushAfterAdding && collectionMetaHasSecondaryUniqueIndex(plan.meta) && bufferedIndexedAutoFlushEnabled(plan.meta.Options) {
+		for i := range plan.rootNames {
+			if _, ok := updateBatchPlanUniqueSecondaryIndex(plan, i); ok {
+				shouldAutoFlushAfterAdding = true
+				break
+			}
+		}
+	}
+	if shouldAutoFlushAfterAdding {
+		freezeMutableIndexedRunMapsLocked(domain)
+	}
+	var checkpoint bufferedIndexedCheckpoint
+	collectionMetaCheckpoint := c.meta
+	if shouldAutoFlushAfterAdding {
+		checkpoint = checkpointBufferedIndexedDomain(domain)
+	}
+	plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
+
+	phaseStart = updateBatchStatsNow(detailedStats)
+	rootTables := make(map[string]memtable.Table, len(plan.rootNames))
+	actualRootRuns := 0
+	for i, rootName := range plan.rootNames {
+		baseRoot := plan.baseRootIDs[rootName]
+		if pendingBaseRoot, ok := pendingIndexedRootBaseIDLocked(domain, rootName); ok && pendingBaseRoot != baseRoot {
+			return false, errConcurrentRootModification(plan.meta.Name, rootName)
+		}
+		if _, ok := domain.rootBaseIDs[rootName]; !ok {
+			domain.rootBaseIDs[rootName] = baseRoot
+		}
+		domain.rootPolicies[rootName] = plan.policies[i]
+		table, created := mutableRootRunLocked(domain, rootName)
+		if table == nil {
+			return false, fmt.Errorf("collections: UpdateBatch collection %q failed to allocate direct root accumulator for %q", plan.meta.Name, rootName)
+		}
+		rootTables[rootName] = table
+		if created {
+			actualRootRuns = saturatingAddNonNegativeInt(actualRootRuns, 1)
+		}
+	}
+	primaryTable := rootTables[direct.primaryRootName]
+	var primaryIndexKeys [][]byte
+	if domain.primaryRunIndex != nil {
+		primaryIndexKeys = make([][]byte, 0, len(direct.changed))
+	}
+	for _, item := range direct.changed {
+		setCollectionRunCopiedValue(primaryTable, item.documentID, item.document)
+		if primaryIndexKeys != nil {
+			primaryIndexKeys = append(primaryIndexKeys, item.documentID)
+		}
+	}
+	if primaryIndexKeys != nil {
+		addBufferedPrimaryRunIndexKeys(domain.primaryRunIndex, primaryIndexKeys, primaryTable)
+	}
+	for runtimeIdx, runtime := range direct.runtimes {
+		rootName := runtimeSecondaryRootName(plan.meta.Name, runtime)
+		table := rootTables[rootName]
+		if table == nil {
+			continue
+		}
+		for _, item := range direct.changed {
+			if !item.indexStateChanged || !preparedBatchUpdateIndexChanged(item, runtimeIdx) {
+				continue
+			}
+			for _, encoded := range item.oldState.valuesAt(runtimeIdx) {
+				if _, err := deleteCollectionSecondaryIndexEntry(table, encoded, item.documentID); err != nil {
+					if shouldAutoFlushAfterAdding {
+						rollbackBufferedIndexedDomain(domain, checkpoint)
+						c.meta = collectionMetaCheckpoint
+					}
+					return false, err
+				}
+			}
+			for _, encoded := range item.newState.valuesAt(runtimeIdx) {
+				if _, err := setCollectionSecondaryIndexEntry(table, encoded, item.documentID); err != nil {
+					if shouldAutoFlushAfterAdding {
+						rollbackBufferedIndexedDomain(domain, checkpoint)
+						c.meta = collectionMetaCheckpoint
+					}
+					return false, err
+				}
+			}
+		}
+	}
+	plan.stats.BufferStageRootAppend += updateBatchStatsSince(detailedStats, phaseStart)
+
+	domain.loaded = true
+	domain.meta = plan.meta
+	domain.catalog = plan.catalog
+	domain.baseCommitSeq = plan.baseCommitSeq
+	domain.baseSystemRoot = plan.baseSystemRoot
+	if plan.catalog != nil {
+		domain.primaryRoot = plan.catalog.rootID(collectionPrimaryRootName(plan.meta.Name))
+	}
+	domain.count += modifiedCount
+	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, direct.stagedBytes)
+	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
+	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, direct.stagedBytes)
+	domain.writeGeneration++
+	domain.observeIndexedStage(modifiedCount, direct.stagedBytes, actualRootRuns)
+	c.meta = plan.meta
+	compactedObsolete, err := maybeCompactBufferedIndexedMutableRunsLocked(domain, plan.meta.Options)
+	if err != nil {
+		if shouldAutoFlushAfterAdding {
+			rollbackBufferedIndexedDomain(domain, checkpoint)
+			c.meta = collectionMetaCheckpoint
+		}
+		return false, err
+	}
+	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
+		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
+		if lockReleased > 0 {
+			lockReleasedDuringHold += lockReleased
+		}
+		plan.stats.BufferStageLockWait += updateBatchStatsDuration(detailedStats, relockWait)
+		plan.stats.BufferStageFlush += updateBatchStatsDuration(detailedStats, flushDuration)
+		if err != nil {
+			if shouldAutoFlushAfterAdding {
+				rollbackBufferedIndexedDomain(domain, checkpoint)
+				c.meta = collectionMetaCheckpoint
+			}
+			return false, err
+		}
+	}
+	resetCollectionTables(compactedObsolete)
+	plan.stats.BufferedBatches = 1
+	return true, nil
+}
+
 func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, error) {
-	if c == nil || plan == nil || len(plan.deltaTables) == 0 {
+	if c == nil || plan == nil {
+		return false, nil
+	}
+	if plan.directBufferedUpdate != nil {
+		return c.bufferDirectUpdateBatchPlanLocked(plan)
+	}
+	if len(plan.deltaTables) == 0 {
 		return false, nil
 	}
 	detailedStats := c.updateBatchDetailedStatsEnabled()
@@ -8541,6 +9002,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	if domain.rootRuns == nil {
 		domain.rootRuns = make(map[string][]memtable.Table, len(plan.rootNames))
 	}
+	freezeMutableIndexedRunMapsLocked(domain)
 	hasUniqueSecondaryRoots := collectionMetaHasSecondaryUniqueIndex(plan.meta)
 	projectedStagedBytes := stagedBytes
 	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, plan.meta.Options, modifiedCount, projectedStagedBytes, stagedRootRuns)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -8287,6 +8287,105 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesAppendsToBufferedUp
 	}
 }
 
+func TestCollectionUpdateBatchDirectBufferedBSONAccumulatesRootRuns(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatBSON,
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "email", Value: "a@example.com"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	before := d.State()
+
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setBSONField("city", "sea")},
+	}); err != nil {
+		t.Fatalf("first UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("first batch was declined")
+	}
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setBSONField("city", "sfo")},
+	}); err != nil {
+		t.Fatalf("second UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("second batch was declined")
+	}
+	afterSecond := d.State()
+	if afterSecond.CommitSeq != before.CommitSeq {
+		t.Fatalf("buffered BSON updates advanced commit seq by %d, want 0", afterSecond.CommitSeq-before.CommitSeq)
+	}
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
+	cityRuns := len(col.writeDomain.rootRuns[collectionSecondaryRootName("users", "city")])
+	rootMutableRuns := len(col.writeDomain.rootMutableRuns)
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 2 {
+		t.Fatalf("rootRunCount=%d want 2 accumulated roots after two BSON update batches", rootRunCount)
+	}
+	if primaryRuns != 1 || cityRuns != 1 {
+		t.Fatalf("runs primary=%d city=%d, want one run per affected root", primaryRuns, cityRuns)
+	}
+	if rootMutableRuns != 2 {
+		t.Fatalf("rootMutableRuns=%d want 2 active root-local accumulators", rootMutableRuns)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city: %v", err)
+	}
+	if len(seaIDs) != 0 {
+		t.Fatalf("sea ids=%q want none after second buffered update", seaIDs)
+	}
+	sfoIDs, err := col.FindByIndex("city", "sfo")
+	if err != nil {
+		t.Fatalf("find sfo city: %v", err)
+	}
+	if len(sfoIDs) != 1 || !bytes.Equal(sfoIDs[0], []byte("u1")) {
+		t.Fatalf("sfo ids=%q want [u1]", sfoIDs)
+	}
+	emailIDs, err := col.FindByIndex("email", "a@example.com")
+	if err != nil {
+		t.Fatalf("find email: %v", err)
+	}
+	if len(emailIDs) != 1 || !bytes.Equal(emailIDs[0], []byte("u1")) {
+		t.Fatalf("email ids=%q want [u1]", emailIDs)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered BSON update batches: %v", err)
+	}
+}
+
 func newBufferedUsersUpdateCollection(t *testing.T) (*backenddb.DB, *Collection) {
 	t.Helper()
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
@@ -9837,6 +9936,21 @@ func setJSONEmail(email string) func([]byte) ([]byte, bool, error) {
 
 func setJSONCity(city string) func([]byte) ([]byte, bool, error) {
 	return setJSONField("city", city)
+}
+
+func setBSONField(field string, value any) func([]byte) ([]byte, bool, error) {
+	return func(current []byte) ([]byte, bool, error) {
+		var doc bson.M
+		if err := bson.Unmarshal(current, &doc); err != nil {
+			return nil, false, err
+		}
+		doc[field] = value
+		next, err := bson.Marshal(doc)
+		if err != nil {
+			return nil, false, err
+		}
+		return next, true, nil
+	}
 }
 
 func setJSONField(field string, value any) func([]byte) ([]byte, bool, error) {

--- a/TreeDB/collections/freeze_sort_run_table.go
+++ b/TreeDB/collections/freeze_sort_run_table.go
@@ -133,16 +133,24 @@ func (t *freezeSortRunTable) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, 
 	if t == nil || len(key) == 0 {
 		return nil, page.ValuePtr{}, 0, false
 	}
+	t.mu.RLock()
+	if t.frozen {
+		entry, found := t.getFrozenEntryLocked(key)
+		t.mu.RUnlock()
+		if !found {
+			return nil, page.ValuePtr{}, 0, false
+		}
+		return entry.value, entry.ptr, entry.flags, true
+	}
+	t.mu.RUnlock()
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.frozen {
-		idx := sort.Search(len(t.entries), func(i int) bool {
-			return bytes.Compare(t.entries[i].key, key) >= 0
-		})
-		if idx >= len(t.entries) || !bytes.Equal(t.entries[idx].key, key) {
+		entry, found := t.getFrozenEntryLocked(key)
+		if !found {
 			return nil, page.ValuePtr{}, 0, false
 		}
-		entry := t.entries[idx]
 		return entry.value, entry.ptr, entry.flags, true
 	}
 	t.rebuildLatestLocked()
@@ -155,6 +163,16 @@ func (t *freezeSortRunTable) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, 
 		return nil, page.ValuePtr{}, 0, false
 	}
 	return entry.value, entry.ptr, entry.flags, true
+}
+
+func (t *freezeSortRunTable) getFrozenEntryLocked(key []byte) (freezeSortRunEntry, bool) {
+	idx := sort.Search(len(t.entries), func(i int) bool {
+		return bytes.Compare(t.entries[i].key, key) >= 0
+	})
+	if idx >= len(t.entries) || !bytes.Equal(t.entries[idx].key, key) {
+		return freezeSortRunEntry{}, false
+	}
+	return t.entries[idx], true
 }
 
 func (t *freezeSortRunTable) Size() int64 {
@@ -460,6 +478,42 @@ func (it *freezeSortRunIterator) Domain() ([]byte, []byte) {
 		return nil, nil
 	}
 	return it.start, it.end
+}
+
+func (it *freezeSortRunIterator) StableUnsafeIteratorSlices() bool {
+	return true
+}
+
+func (it *freezeSortRunIterator) OrderedUniqueUnsafeIterator() bool {
+	return true
+}
+
+func (it *freezeSortRunIterator) Len() int {
+	if it == nil || !it.Valid() {
+		return 0
+	}
+	if it.reverse {
+		lower := 0
+		if it.start != nil {
+			lower = sort.Search(len(it.entries), func(i int) bool {
+				return bytes.Compare(it.entries[i].key, it.start) >= 0
+			})
+		}
+		if it.idx < lower {
+			return 0
+		}
+		return it.idx - lower + 1
+	}
+	upper := len(it.entries)
+	if it.end != nil {
+		upper = sort.Search(len(it.entries), func(i int) bool {
+			return bytes.Compare(it.entries[i].key, it.end) >= 0
+		})
+	}
+	if it.idx >= upper {
+		return 0
+	}
+	return upper - it.idx
 }
 
 func (it *freezeSortRunIterator) inBounds() bool {

--- a/TreeDB/collections/freeze_sort_run_table.go
+++ b/TreeDB/collections/freeze_sort_run_table.go
@@ -1,0 +1,477 @@
+package collections
+
+import (
+	"bytes"
+	"sort"
+	"sync"
+	"unsafe"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type freezeSortRunEntry struct {
+	key   []byte
+	value []byte
+	ptr   page.ValuePtr
+	seq   uint64
+	flags byte
+}
+
+type freezeSortRunTable struct {
+	mu          sync.RWMutex
+	entries     []freezeSortRunEntry
+	latest      map[string]int
+	latestDirty bool
+	frozen      bool
+	sizeBytes   int64
+	nextSeq     uint64
+}
+
+// freezeSortRunTable is a collection-write-domain run table optimized for
+// root-local accumulation: writes append cheaply while mutable, and rotation to
+// an immutable flush unit pays the sort/coalesce cost once.
+func newFreezeSortRunTable() memtable.Table {
+	return &freezeSortRunTable{}
+}
+
+func (*freezeSortRunTable) StableUnsafeIteratorSlices() bool { return true }
+
+func (t *freezeSortRunTable) Set(key, value []byte) {
+	t.SetEntry(key, value, page.ValuePtr{}, node.FlagInline)
+}
+
+func (t *freezeSortRunTable) SetSteal(key, value []byte) {
+	t.SetEntrySteal(key, value, page.ValuePtr{}, node.FlagInline)
+}
+
+func (t *freezeSortRunTable) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
+	t.SetEntrySteal(bytes.Clone(key), bytes.Clone(value), ptr, flags)
+}
+
+func (t *freezeSortRunTable) PutWithCallback(key, value []byte, cb func(k, v []byte) error) error {
+	keyCopy := bytes.Clone(key)
+	valueCopy := bytes.Clone(value)
+	if cb != nil {
+		if err := cb(keyCopy, valueCopy); err != nil {
+			return err
+		}
+	}
+	t.SetEntrySteal(keyCopy, valueCopy, page.ValuePtr{}, node.FlagInline)
+	return nil
+}
+
+func (t *freezeSortRunTable) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) {
+	if t == nil || len(key) == 0 {
+		return
+	}
+	if flags&node.FlagTombstone != 0 {
+		value = nil
+		ptr = page.ValuePtr{}
+	}
+	t.mu.Lock()
+	idx := len(t.entries)
+	t.entries = append(t.entries, freezeSortRunEntry{
+		key:   key,
+		value: value,
+		ptr:   ptr,
+		seq:   t.nextSeq,
+		flags: flags,
+	})
+	t.nextSeq++
+	t.sizeBytes += int64(len(key) + entryLogicalValueSize(flags, value))
+	if t.latest != nil && !t.latestDirty {
+		t.latest[unsafe.String(&key[0], len(key))] = idx
+	}
+	t.mu.Unlock()
+}
+
+func (t *freezeSortRunTable) Delete(key []byte) {
+	t.SetEntry(key, nil, page.ValuePtr{}, node.FlagTombstone)
+}
+
+func (t *freezeSortRunTable) DeleteWithCallback(key []byte, cb func(k, v []byte) error) error {
+	keyCopy := bytes.Clone(key)
+	if cb != nil {
+		if err := cb(keyCopy, nil); err != nil {
+			return err
+		}
+	}
+	t.SetEntrySteal(keyCopy, nil, page.ValuePtr{}, node.FlagTombstone)
+	return nil
+}
+
+func (t *freezeSortRunTable) DeleteSteal(key []byte) {
+	t.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+}
+
+func (t *freezeSortRunTable) SetInlineNilKeyParts(first, second []byte) {
+	key := make([]byte, len(first)+len(second))
+	n := copy(key, first)
+	copy(key[n:], second)
+	t.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagInline)
+}
+
+func (t *freezeSortRunTable) DeleteKeyParts(first, second []byte) {
+	key := make([]byte, len(first)+len(second))
+	n := copy(key, first)
+	copy(key[n:], second)
+	t.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+}
+
+func (t *freezeSortRunTable) Get(key []byte) ([]byte, bool, bool) {
+	value, _, flags, found := t.GetEntry(key)
+	if !found {
+		return nil, false, false
+	}
+	return value, flags&node.FlagTombstone != 0, true
+}
+
+func (t *freezeSortRunTable) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
+	if t == nil || len(key) == 0 {
+		return nil, page.ValuePtr{}, 0, false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.frozen {
+		idx := sort.Search(len(t.entries), func(i int) bool {
+			return bytes.Compare(t.entries[i].key, key) >= 0
+		})
+		if idx >= len(t.entries) || !bytes.Equal(t.entries[idx].key, key) {
+			return nil, page.ValuePtr{}, 0, false
+		}
+		entry := t.entries[idx]
+		return entry.value, entry.ptr, entry.flags, true
+	}
+	t.rebuildLatestLocked()
+	idx, ok := t.latest[unsafe.String(&key[0], len(key))]
+	if !ok || idx < 0 || idx >= len(t.entries) {
+		return nil, page.ValuePtr{}, 0, false
+	}
+	entry := t.entries[idx]
+	if !bytes.Equal(entry.key, key) {
+		return nil, page.ValuePtr{}, 0, false
+	}
+	return entry.value, entry.ptr, entry.flags, true
+}
+
+func (t *freezeSortRunTable) Size() int64 {
+	if t == nil {
+		return 0
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.sizeBytes
+}
+
+func (t *freezeSortRunTable) Len() int {
+	if t == nil {
+		return 0
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.entries)
+}
+
+func (t *freezeSortRunTable) Freeze() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.frozen {
+		return
+	}
+	t.sortAndCoalesceLocked()
+	t.latest = nil
+	t.latestDirty = false
+	t.frozen = true
+}
+
+func (t *freezeSortRunTable) Reset() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	clear(t.entries)
+	t.entries = t.entries[:0]
+	t.latest = nil
+	t.latestDirty = false
+	t.frozen = false
+	t.sizeBytes = 0
+	t.nextSeq = 0
+	t.mu.Unlock()
+}
+
+func (t *freezeSortRunTable) NewIterator(start, end []byte) iterator.UnsafeIterator {
+	return t.newIterator(start, end, false)
+}
+
+func (t *freezeSortRunTable) NewReverseIterator(start, end []byte) iterator.UnsafeIterator {
+	return t.newIterator(start, end, true)
+}
+
+func (t *freezeSortRunTable) newIterator(start, end []byte, reverse bool) iterator.UnsafeIterator {
+	if t == nil {
+		return &freezeSortRunIterator{reverse: reverse, idx: -1}
+	}
+	t.mu.RLock()
+	if t.frozen {
+		entries := t.entries
+		it := &freezeSortRunIterator{entries: entries, start: start, end: end, reverse: reverse, table: t}
+		it.seekInitial()
+		return it
+	}
+	t.mu.RUnlock()
+	t.mu.Lock()
+	entries := t.sortedLatestCopyLocked()
+	t.mu.Unlock()
+	it := &freezeSortRunIterator{entries: entries, start: start, end: end, reverse: reverse}
+	it.seekInitial()
+	return it
+}
+
+func (t *freezeSortRunTable) rebuildLatestLocked() {
+	if t.latest != nil && !t.latestDirty {
+		return
+	}
+	if len(t.entries) == 0 {
+		t.latest = nil
+		t.latestDirty = false
+		return
+	}
+	latest := t.latest
+	if latest == nil {
+		latest = make(map[string]int, len(t.entries))
+	} else {
+		clear(latest)
+	}
+	for i := range t.entries {
+		key := t.entries[i].key
+		latest[unsafe.String(&key[0], len(key))] = i
+	}
+	t.latest = latest
+	t.latestDirty = false
+}
+
+func (t *freezeSortRunTable) sortedLatestCopyLocked() []freezeSortRunEntry {
+	if len(t.entries) == 0 {
+		return nil
+	}
+	entries := make([]freezeSortRunEntry, len(t.entries))
+	copy(entries, t.entries)
+	return sortAndCoalesceFreezeSortEntries(entries)
+}
+
+func (t *freezeSortRunTable) sortAndCoalesceLocked() {
+	t.entries = sortAndCoalesceFreezeSortEntries(t.entries)
+	t.sizeBytes = freezeSortEntriesSize(t.entries)
+}
+
+func sortAndCoalesceFreezeSortEntries(entries []freezeSortRunEntry) []freezeSortRunEntry {
+	if len(entries) <= 1 {
+		return entries
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if cmp := bytes.Compare(entries[i].key, entries[j].key); cmp != 0 {
+			return cmp < 0
+		}
+		return entries[i].seq < entries[j].seq
+	})
+	out := entries[:0]
+	for i := 0; i < len(entries); {
+		j := i + 1
+		for j < len(entries) && bytes.Equal(entries[i].key, entries[j].key) {
+			j++
+		}
+		out = append(out, entries[j-1])
+		i = j
+	}
+	clear(entries[len(out):])
+	return out
+}
+
+func freezeSortEntriesSize(entries []freezeSortRunEntry) int64 {
+	var total int64
+	for i := range entries {
+		total += int64(len(entries[i].key) + entryLogicalValueSize(entries[i].flags, entries[i].value))
+	}
+	return total
+}
+
+func entryLogicalValueSize(flags byte, value []byte) int {
+	if flags&node.FlagPointer != 0 {
+		return page.ValuePtrSize + len(value)
+	}
+	if flags&node.FlagTombstone != 0 {
+		return 0
+	}
+	return len(value)
+}
+
+type freezeSortRunIterator struct {
+	entries []freezeSortRunEntry
+	start   []byte
+	end     []byte
+	table   *freezeSortRunTable
+	idx     int
+	reverse bool
+	closed  bool
+}
+
+func (it *freezeSortRunIterator) seekInitial() {
+	if it.reverse {
+		it.seekReverseEnd()
+		return
+	}
+	it.idx = 0
+	if it.start != nil {
+		it.Seek(it.start)
+	}
+	if !it.inBounds() {
+		it.idx = len(it.entries)
+	}
+}
+
+func (it *freezeSortRunIterator) seekReverseEnd() {
+	n := len(it.entries)
+	if n == 0 {
+		it.idx = -1
+		return
+	}
+	if it.end == nil {
+		it.idx = n - 1
+	} else {
+		pos := sort.Search(n, func(i int) bool {
+			return bytes.Compare(it.entries[i].key, it.end) >= 0
+		})
+		it.idx = pos - 1
+	}
+	if !it.inBounds() {
+		it.idx = -1
+	}
+}
+
+func (it *freezeSortRunIterator) Valid() bool {
+	return it != nil && it.idx >= 0 && it.idx < len(it.entries) && it.inBounds()
+}
+
+func (it *freezeSortRunIterator) Next() {
+	if it == nil {
+		return
+	}
+	if it.reverse {
+		it.idx--
+	} else {
+		it.idx++
+	}
+}
+
+func (it *freezeSortRunIterator) Seek(key []byte) {
+	if it == nil {
+		return
+	}
+	pos := sort.Search(len(it.entries), func(i int) bool {
+		return bytes.Compare(it.entries[i].key, key) >= 0
+	})
+	if it.reverse {
+		if pos < len(it.entries) && bytes.Equal(it.entries[pos].key, key) {
+			it.idx = pos
+		} else {
+			it.idx = pos - 1
+		}
+	} else {
+		it.idx = pos
+	}
+	if !it.inBounds() {
+		if it.reverse {
+			it.idx = -1
+		} else {
+			it.idx = len(it.entries)
+		}
+	}
+}
+
+func (it *freezeSortRunIterator) UnsafeKey() []byte {
+	if !it.Valid() {
+		return nil
+	}
+	return it.entries[it.idx].key
+}
+
+func (it *freezeSortRunIterator) UnsafeValue() []byte {
+	if !it.Valid() {
+		return nil
+	}
+	return it.entries[it.idx].value
+}
+
+func (it *freezeSortRunIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	if !it.Valid() {
+		return nil, page.ValuePtr{}, 0
+	}
+	entry := it.entries[it.idx]
+	return entry.value, entry.ptr, entry.flags
+}
+
+func (it *freezeSortRunIterator) Key() []byte { return it.UnsafeKey() }
+
+func (it *freezeSortRunIterator) Value() []byte { return it.UnsafeValue() }
+
+func (it *freezeSortRunIterator) KeyCopy(dst []byte) []byte {
+	if !it.Valid() {
+		return dst
+	}
+	return append(dst, it.entries[it.idx].key...)
+}
+
+func (it *freezeSortRunIterator) ValueCopy(dst []byte) []byte {
+	if !it.Valid() {
+		return dst
+	}
+	return append(dst, it.entries[it.idx].value...)
+}
+
+func (it *freezeSortRunIterator) IsDeleted() bool {
+	if !it.Valid() {
+		return false
+	}
+	return it.entries[it.idx].flags&node.FlagTombstone != 0
+}
+
+func (it *freezeSortRunIterator) Error() error { return nil }
+
+func (it *freezeSortRunIterator) Close() error {
+	if it == nil || it.closed {
+		return nil
+	}
+	it.closed = true
+	if it.table != nil {
+		it.table.mu.RUnlock()
+		it.table = nil
+	}
+	return nil
+}
+
+func (it *freezeSortRunIterator) Domain() ([]byte, []byte) {
+	if it == nil {
+		return nil, nil
+	}
+	return it.start, it.end
+}
+
+func (it *freezeSortRunIterator) inBounds() bool {
+	if it == nil || it.idx < 0 || it.idx >= len(it.entries) {
+		return false
+	}
+	key := it.entries[it.idx].key
+	if it.start != nil && bytes.Compare(key, it.start) < 0 {
+		return false
+	}
+	if it.end != nil && bytes.Compare(key, it.end) >= 0 {
+		return false
+	}
+	return true
+}

--- a/TreeDB/collections/freeze_sort_run_table_test.go
+++ b/TreeDB/collections/freeze_sort_run_table_test.go
@@ -3,7 +3,9 @@ package collections
 import (
 	"bytes"
 	"testing"
+	"unsafe"
 
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/node"
 )
 
@@ -34,6 +36,69 @@ func TestFreezeSortRunTableLatestSortedAndTombstoneSemantics(t *testing.T) {
 	requireFreezeSortRunIterator(t, table.NewIterator([]byte("b"), nil), []string{"b", "c"})
 	requireFreezeSortRunIterator(t, table.NewIterator(nil, []byte("c")), []string{"a", "b"})
 	requireFreezeSortRunReverseIterator(t, table.NewReverseIterator(nil, []byte("c")), []string{"b", "a"})
+}
+
+func TestFreezeSortRunIteratorAdvertisesTrustedMaterializeFastPath(t *testing.T) {
+	table := newFreezeSortRunTable()
+	key := []byte("a")
+	value := []byte("value-a")
+	table.SetSteal(key, value)
+	table.Set([]byte("b"), []byte("value-b"))
+	table.Freeze()
+
+	it := table.NewIterator(nil, nil)
+	stable, ok := it.(interface {
+		StableUnsafeIteratorSlices() bool
+	})
+	if !ok || !stable.StableUnsafeIteratorSlices() {
+		t.Fatalf("freeze-sort iterator exposes stable=%v, want stable unsafe slices", ok)
+	}
+	trusted, ok := it.(interface {
+		OrderedUniqueUnsafeIterator() bool
+	})
+	if !ok || !trusted.OrderedUniqueUnsafeIterator() {
+		t.Fatalf("freeze-sort iterator exposes trusted=%v, want ordered unique", ok)
+	}
+	lenHint, ok := it.(interface {
+		Len() int
+	})
+	if !ok {
+		t.Fatal("freeze-sort iterator does not expose Len hint")
+	}
+	if got := lenHint.Len(); got != 2 {
+		t.Fatalf("freeze-sort iterator Len=%d want 2", got)
+	}
+
+	delta, err := backenddb.OrderedRootDeltaBatchFromIterator(it)
+	if err != nil {
+		t.Fatalf("materialize delta: %v", err)
+	}
+	defer func() { _ = delta.Close() }()
+	if err := it.Close(); err != nil {
+		t.Fatalf("close iterator: %v", err)
+	}
+	entries := delta.SortedEntries()
+	if len(entries) != 2 {
+		t.Fatalf("delta entries=%d want 2", len(entries))
+	}
+	if unsafe.SliceData(entries[0].Key) != unsafe.SliceData(key) {
+		t.Fatal("trusted materialize path copied key instead of borrowing stable view")
+	}
+	if unsafe.SliceData(entries[0].Value) != unsafe.SliceData(value) {
+		t.Fatal("trusted materialize path copied value instead of borrowing stable view")
+	}
+
+	ranged := table.NewIterator([]byte("b"), nil)
+	defer func() { _ = ranged.Close() }()
+	rangedLen, ok := ranged.(interface {
+		Len() int
+	})
+	if !ok {
+		t.Fatal("ranged iterator does not expose Len hint")
+	}
+	if got := rangedLen.Len(); got != 1 {
+		t.Fatalf("ranged iterator Len=%d want 1", got)
+	}
 }
 
 func requireFreezeSortRunIterator(t *testing.T, it interface {

--- a/TreeDB/collections/freeze_sort_run_table_test.go
+++ b/TreeDB/collections/freeze_sort_run_table_test.go
@@ -1,0 +1,69 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/node"
+)
+
+func TestFreezeSortRunTableLatestSortedAndTombstoneSemantics(t *testing.T) {
+	table := newFreezeSortRunTable()
+	table.Set([]byte("b"), []byte("old-b"))
+	table.Set([]byte("a"), []byte("value-a"))
+	table.Set([]byte("b"), []byte("new-b"))
+	table.Delete([]byte("c"))
+
+	if got, _, flags, ok := table.GetEntry([]byte("b")); !ok || flags&node.FlagTombstone != 0 || !bytes.Equal(got, []byte("new-b")) {
+		t.Fatalf("mutable GetEntry b=(%q,%02x,%v), want latest new-b", got, flags, ok)
+	}
+	if _, _, flags, ok := table.GetEntry([]byte("c")); !ok || flags&node.FlagTombstone == 0 {
+		t.Fatalf("mutable GetEntry c flags=%02x ok=%v, want tombstone", flags, ok)
+	}
+
+	requireFreezeSortRunIterator(t, table.NewIterator(nil, nil), []string{"a", "b", "c"})
+	requireFreezeSortRunReverseIterator(t, table.NewReverseIterator(nil, nil), []string{"c", "b", "a"})
+
+	table.Freeze()
+	if table.Len() != 3 {
+		t.Fatalf("frozen Len=%d want 3 coalesced entries", table.Len())
+	}
+	if got, _, flags, ok := table.GetEntry([]byte("b")); !ok || flags&node.FlagTombstone != 0 || !bytes.Equal(got, []byte("new-b")) {
+		t.Fatalf("frozen GetEntry b=(%q,%02x,%v), want latest new-b", got, flags, ok)
+	}
+	requireFreezeSortRunIterator(t, table.NewIterator([]byte("b"), nil), []string{"b", "c"})
+	requireFreezeSortRunIterator(t, table.NewIterator(nil, []byte("c")), []string{"a", "b"})
+	requireFreezeSortRunReverseIterator(t, table.NewReverseIterator(nil, []byte("c")), []string{"b", "a"})
+}
+
+func requireFreezeSortRunIterator(t *testing.T, it interface {
+	Valid() bool
+	Next()
+	UnsafeKey() []byte
+	Close() error
+}, want []string) {
+	t.Helper()
+	defer func() { _ = it.Close() }()
+	var got []string
+	for ; it.Valid(); it.Next() {
+		got = append(got, string(it.UnsafeKey()))
+	}
+	if len(got) != len(want) {
+		t.Fatalf("iterator keys=%v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("iterator keys=%v want %v", got, want)
+		}
+	}
+}
+
+func requireFreezeSortRunReverseIterator(t *testing.T, it interface {
+	Valid() bool
+	Next()
+	UnsafeKey() []byte
+	Close() error
+}, want []string) {
+	t.Helper()
+	requireFreezeSortRunIterator(t, it, want)
+}


### PR DESCRIPTION
## Summary

This PR takes the architectural path suggested in #1159: reduce indexed collection update root-run fan-in without making the hot staging path maintain a B-tree.

Changes:
- Add a collection-specific freeze-sort run table for root-local accumulators.
  - Mutable writes append cheaply.
  - `Freeze()` sorts/coalesces latest keys once when rotating into an immutable flush unit.
  - Mutable `GetEntry` lazily builds a lookup map only when reads need it.
  - Frozen reads use `RLock`, and frozen/copy-backed iterators expose stable ordered-unique length hints so ordered-root publishing can use the trusted append path.
- Add a direct buffered BSON update plan for formats that do not persist index-state roots.
  - The buffered path skips transient per-batch delta memtables.
  - It appends directly into root-local accumulators for primary and changed secondary roots.
  - It keeps primary-run index refs current instead of invalidating/rebuilding them.
- Keep the existing generic delta-table path for JSON/template cases that are not eligible for this direct path.
- Add correctness tests for freeze-sort table semantics, trusted materialization, and BSON direct buffered update accumulation.

## Benchmark Evidence

Benchmark shape:

```bash
MONGO_GATEWAY_PROFILE_BENCH_UPDATE_DOCUMENTS=200000 \
MONGO_GATEWAY_PROFILE_BENCH_BATCH_SIZE=2000 \
MONGO_GATEWAY_PROFILE_BENCH_WRITERS=32 \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH=true \
MONGO_GATEWAY_PROFILE_BENCH_BUFFERED_INDEXED_ASYNC_FLUSH_MAX_QUEUED_UNITS=4 \
go test ./cmd/mongo_gateway_bench -run '^$' -bench '^BenchmarkDirectCollectionConcurrentUpdateBSONIndexes3CityUpdate$' -benchtime=10s -benchmem -count=1
```

Comparison against current `origin/main` run from the same machine and benchmark shape:

| Variant | docs/sec | ns/doc | indexed_flush_root_runs/doc | indexed_flush_materialize_ns/doc | update_buffer_stage_ns/doc | publish root apply ns/doc | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| current main | 144,107 | 6,939 | 0.09564 | 2,131 | 227.5 | 1,301 | 1,272 | 3 |
| this PR | 197,685 | 5,059 | 0.0000183 | 67.25 | 848.7 | 1,201 | 2,378 | 5 |

Artifacts:
- current main: `/tmp/gomap_1159_current_main_10s_5lVLqX`
- this PR: `/tmp/gomap_1159_direct_freezesort_reviewfix_10s_3O0z3P`

Interpretation:
- Throughput improves about 37% in this focused BSON two-secondary-index update shape.
- Root-run fan-in is essentially eliminated for this path.
- Materialization cost drops materially.
- The trusted iterator fast path reduces the post-review PR allocation footprint from 2,671 B/op to 2,378 B/op.
- Staging cost and allocations are still higher than current main because this PR moves direct root-entry staging into the buffered path. It is still a net win in this benchmark and gives us a cleaner architecture to optimize further.

## Tests

```bash
go test ./TreeDB/collections -count 1
go test ./cmd/mongo_gateway_bench -count 1
go test ./TreeDB/collections -run 'TestFreezeSortRunTable|TestCollectionUpdateBatchDirectBufferedBSONAccumulatesRootRuns' -count 1
go test -race ./TreeDB/collections -run 'TestFreezeSortRunTable|TestCollectionUpdateBatchDirectBufferedBSONAccumulatesRootRuns' -count 1
```

## Notes

This follows the rejected accumulator experiments documented in #1159. The key difference is that this PR appends to a collection-specific freeze-sort table and coalesces on freeze, instead of maintaining B-tree ordering under the writer lock or copying already-built transient run tables into another accumulator.

Fixes part of #1159.
