### PR TITLE
Collections: buffer template-v1 update roots directly

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7288,10 +7288,12 @@ type updateBatchPlan struct {
 }
 
 type directBufferedUpdatePlan struct {
-	changed         []preparedBatchUpdate
-	runtimes        []indexRuntime
-	primaryRootName string
-	stagedBytes     int64
+	changed          []preparedBatchUpdate
+	runtimes         []indexRuntime
+	templateRecords  []templateV1Record
+	templateRootName string
+	primaryRootName  string
+	stagedBytes      int64
 }
 
 var updateBatchPlanPool sync.Pool
@@ -7600,14 +7602,11 @@ func (c *Collection) validateUpdateBatchPlanRootDescriptors(plan *updateBatchPla
 	return c.validateRootDescriptorSystemDeltaForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs)
 }
 
-func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode, templateRecords []templateV1Record) bool {
+func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts collectionOptions, canBuffer bool, mode updateBatchMode) bool {
 	if c == nil || c.writeDomain == nil || !canBuffer || mode == updateBatchModeAny {
 		return false
 	}
 	if !meta.Options.BufferedIndexedWrites || len(meta.Indexes) == 0 {
-		return false
-	}
-	if len(templateRecords) != 0 {
 		return false
 	}
 	return !persistIndexStateForOptions(opts)
@@ -8319,13 +8318,32 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 
 	success := false
-	if c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, templateRecords) {
+	if c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode) {
+		phaseStart = updateBatchStatsNow(detailedStats)
+		if len(templateRecords) > 0 {
+			sortTemplateV1Records(templateRecords)
+			var err error
+			templateRecords, err = dedupeTemplateV1Records(templateRecords)
+			if err != nil {
+				_ = snap.Close()
+				return nil, err
+			}
+			rootNames = append(rootNames, templateRootName)
+			uniqueSecondary = append(uniqueSecondary, -1)
+			baseRootIDs[templateRootName] = catalog.rootID(templateRootName)
+			policies = append(policies, plannerOptions.dataStoragePolicy)
+		}
+		stats.TemplateRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
+
 		phaseStart = updateBatchStatsNow(detailedStats)
 		rootNames = append(rootNames, primaryRootName)
 		uniqueSecondary = append(uniqueSecondary, -1)
 		baseRootIDs[primaryRootName] = primaryRoot
 		policies = append(policies, plannerOptions.dataStoragePolicy)
 		var stagedBytes int64
+		for i := range templateRecords {
+			stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, int64(len(templateRecords[i].id)+len(templateRecords[i].raw)))
+		}
 		for i := range changed {
 			results[changed[i].itemIndex].Modified = true
 			stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, int64(len(changed[i].documentID)+len(changed[i].document)))
@@ -8405,10 +8423,12 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			bufferedReadBlocked:         bufferedReadBlocked,
 			policies:                    policies,
 			directBufferedUpdate: &directBufferedUpdatePlan{
-				changed:         changed,
-				runtimes:        runtimes,
-				primaryRootName: primaryRootName,
-				stagedBytes:     stagedBytes,
+				changed:          changed,
+				runtimes:         runtimes,
+				templateRecords:  templateRecords,
+				templateRootName: templateRootName,
+				primaryRootName:  primaryRootName,
+				stagedBytes:      stagedBytes,
 			},
 			scratch: scratch,
 		}
@@ -8796,13 +8816,30 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 			actualRootRuns = saturatingAddNonNegativeInt(actualRootRuns, 1)
 		}
 	}
+	if len(direct.templateRecords) > 0 {
+		templateTable := rootTables[direct.templateRootName]
+		if templateTable == nil {
+			return false, fmt.Errorf("collections: UpdateBatch collection %q missing direct template root accumulator for %q", plan.meta.Name, direct.templateRootName)
+		}
+		if err := applyCollectionRunEntries(templateTable, len(direct.templateRecords), func(i int) (key, value []byte, err error) {
+			record := direct.templateRecords[i]
+			return bytes.Clone(record.id[:]), bytes.Clone(record.raw), nil
+		}); err != nil {
+			return false, err
+		}
+	}
 	primaryTable := rootTables[direct.primaryRootName]
 	var primaryIndexKeys [][]byte
 	if domain.primaryRunIndex != nil {
 		primaryIndexKeys = make([][]byte, 0, len(direct.changed))
 	}
+	if err := applyCollectionRunEntries(primaryTable, len(direct.changed), func(i int) (key, value []byte, err error) {
+		item := direct.changed[i]
+		return bytes.Clone(item.documentID), bytes.Clone(item.document), nil
+	}); err != nil {
+		return false, err
+	}
 	for _, item := range direct.changed {
-		setCollectionRunCopiedValue(primaryTable, item.documentID, item.document)
 		if primaryIndexKeys != nil {
 			primaryIndexKeys = append(primaryIndexKeys, item.documentID)
 		}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -8386,6 +8386,114 @@ func TestCollectionUpdateBatchDirectBufferedBSONAccumulatesRootRuns(t *testing.T
 	}
 }
 
+func TestCollectionUpdateBatchDirectBufferedTemplateV1AccumulatesRootRuns(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatTemplateV1,
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustTemplateV1Document(t, []string{"email", "city"}, []any{"a@example.com", "hnl"})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert buffer: %v", err)
+	}
+	before := d.State()
+
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setTemplateV1JSON(t, `{"email":"a@example.com","city":"sea","score":1}`)},
+	}); err != nil {
+		t.Fatalf("first UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("first batch was declined")
+	}
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setTemplateV1JSON(t, `{"email":"a@example.com","city":"sfo","score":2}`)},
+	}); err != nil {
+		t.Fatalf("second UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatalf("second batch was declined")
+	}
+	afterSecond := d.State()
+	if afterSecond.CommitSeq != before.CommitSeq {
+		t.Fatalf("buffered template-v1 updates advanced commit seq by %d, want 0", afterSecond.CommitSeq-before.CommitSeq)
+	}
+
+	col.writeDomain.mu.RLock()
+	rootRunCount := col.writeDomain.rootRunCount
+	templateRuns := len(col.writeDomain.rootRuns[collectionTemplateRootName("users")])
+	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
+	cityRuns := len(col.writeDomain.rootRuns[collectionSecondaryRootName("users", "city")])
+	rootMutableRuns := len(col.writeDomain.rootMutableRuns)
+	col.writeDomain.mu.RUnlock()
+	if rootRunCount != 3 {
+		t.Fatalf("rootRunCount=%d want 3 accumulated roots after two template-v1 update batches", rootRunCount)
+	}
+	if templateRuns != 1 || primaryRuns != 1 || cityRuns != 1 {
+		t.Fatalf("runs template=%d primary=%d city=%d, want one run per affected root", templateRuns, primaryRuns, cityRuns)
+	}
+	if rootMutableRuns != 3 {
+		t.Fatalf("rootMutableRuns=%d want 3 active root-local accumulators", rootMutableRuns)
+	}
+
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city: %v", err)
+	}
+	if len(seaIDs) != 0 {
+		t.Fatalf("sea ids=%q want none after second buffered update", seaIDs)
+	}
+	sfoIDs, err := col.FindByIndex("city", "sfo")
+	if err != nil {
+		t.Fatalf("find sfo city: %v", err)
+	}
+	if len(sfoIDs) != 1 || !bytes.Equal(sfoIDs[0], []byte("u1")) {
+		t.Fatalf("sfo ids=%q want [u1]", sfoIDs)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get template-v1 buffered document: %v", err)
+	}
+	gotJSON, err := col.StoredDocumentJSON(got)
+	if err != nil {
+		t.Fatalf("materialize template-v1 buffered document: %v", err)
+	}
+	for _, want := range [][]byte{[]byte(`"city":"sfo"`), []byte(`"score":2`)} {
+		if !bytes.Contains(gotJSON, want) {
+			t.Fatalf("buffered document=%s missing %s", gotJSON, want)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered template-v1 update batches: %v", err)
+	}
+	flushed := d.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flush advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
+	}
+}
+
 func newBufferedUsersUpdateCollection(t *testing.T) (*backenddb.DB, *Collection) {
 	t.Helper()
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
@@ -9949,6 +10057,17 @@ func setBSONField(field string, value any) func([]byte) ([]byte, bool, error) {
 		if err != nil {
 			return nil, false, err
 		}
+		return next, true, nil
+	}
+}
+
+func setTemplateV1JSON(t *testing.T, raw string) func([]byte) ([]byte, bool, error) {
+	t.Helper()
+	next, err := EncodeTemplateV1DocumentJSON([]byte(raw))
+	if err != nil {
+		t.Fatalf("encode template-v1 update document: %v", err)
+	}
+	return func([]byte) ([]byte, bool, error) {
 		return next, true, nil
 	}
 }

--- a/TreeDB/collections/direct_buffered_update_bench_test.go
+++ b/TreeDB/collections/direct_buffered_update_bench_test.go
@@ -1,0 +1,275 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func BenchmarkCollectionUpdateBatchDirectBufferedTemplateV1NewShape(b *testing.B) {
+	for _, batchSize := range []int{80, 16000} {
+		b.Run(fmt.Sprintf("batch_%d", batchSize), func(b *testing.B) {
+			benchmarkCollectionUpdateBatchDirectBufferedTemplateV1NewShape(b, batchSize)
+		})
+	}
+}
+
+func benchmarkCollectionUpdateBatchDirectBufferedTemplateV1NewShape(b *testing.B, batchSize int) {
+	b.Helper()
+	if batchSize <= 0 {
+		b.Fatalf("invalid batch size %d", batchSize)
+	}
+	docs := b.N
+	if docs <= 0 {
+		docs = 1
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: b.TempDir()})
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "bench",
+		Options: CollectionOptions{
+			DocumentFormat:                          DocumentFormatTemplateV1,
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedWriteMaxDocuments:        1 << 30,
+			BufferedIndexedWriteMaxBytes:            1 << 40,
+			BufferedIndexedWriteMaxRootRuns:         1 << 30,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 1 << 20,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		b.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("bench")
+	if err != nil {
+		b.Fatalf("open collection: %v", err)
+	}
+
+	ids := make([][]byte, docs)
+	var preloadEncoder TemplateV1Encoder
+	const preloadBatchSize = 16000
+	for start := 0; start < docs; start += preloadBatchSize {
+		n := preloadBatchSize
+		if remaining := docs - start; remaining < n {
+			n = remaining
+		}
+		batchIDs := make([][]byte, n)
+		batchDocs := make([][]byte, n)
+		for i := 0; i < n; i++ {
+			docID := benchmarkTemplateV1UpdateDocID(start + i)
+			ids[start+i] = docID
+			batchIDs[i] = docID
+			batchDocs[i] = benchmarkTemplateV1BaseUpdateDocument(b, &preloadEncoder, start+i)
+		}
+		if _, err := col.InsertBatch(batchIDs, batchDocs); err != nil {
+			b.Fatalf("insert preload batch %d: %v", start/preloadBatchSize, err)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		b.Fatalf("flush preload: %v", err)
+	}
+
+	updateDocs := make([][]byte, docs)
+	for start := 0; start < docs; start += batchSize {
+		shapeOrdinal := start / batchSize
+		for i := start; i < start+batchSize && i < docs; i++ {
+			updateDocs[i] = benchmarkTemplateV1NewShapeUpdateDocument(b, i, shapeOrdinal)
+		}
+	}
+
+	batch := make([]UpdateBatchItem, batchSize)
+	statsBefore := mgr.StatsSnapshot()
+	b.ReportAllocs()
+	b.ResetTimer()
+	startTime := time.Now()
+	for start := 0; start < docs; start += batchSize {
+		n := batchSize
+		if remaining := docs - start; remaining < n {
+			n = remaining
+		}
+		for i := 0; i < n; i++ {
+			batch[i] = UpdateBatchItem{
+				DocumentID: ids[start+i],
+				Update:     benchmarkTemplateV1ReplaceWith(updateDocs[start+i]),
+			}
+		}
+		if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges(batch[:n]); err != nil {
+			b.Fatalf("update batch %d: %v", start/batchSize, err)
+		} else if !batched {
+			b.Fatalf("update batch %d was declined", start/batchSize)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		b.Fatalf("flush updates: %v", err)
+	}
+	elapsed := time.Since(startTime)
+	b.StopTimer()
+
+	stats := collectionManagerStatsBenchmarkDelta(mgr.StatsSnapshot(), statsBefore)
+	b.ReportMetric(float64(docs)/elapsed.Seconds(), "docs/sec")
+	b.ReportMetric(float64(elapsed.Nanoseconds())/float64(docs), "ns/doc")
+	reportCollectionUpdateStatsForBenchmark(b, stats, docs)
+}
+
+func benchmarkTemplateV1UpdateDocID(n int) []byte {
+	return []byte(fmt.Sprintf("u-%09d", n))
+}
+
+func benchmarkTemplateV1BaseUpdateDocument(tb testing.TB, encoder *TemplateV1Encoder, n int) []byte {
+	tb.Helper()
+	doc, err := encoder.EncodeDocument(
+		[]string{"name", "email", "city", "score"},
+		[]any{
+			fmt.Sprintf("user-%09d", n),
+			fmt.Sprintf("user-%09d@example.com", n),
+			fmt.Sprintf("city-%02d", n%64),
+			int64(0),
+		},
+	)
+	if err != nil {
+		tb.Fatalf("encode base template-v1 doc %d: %v", n, err)
+	}
+	return doc
+}
+
+func benchmarkTemplateV1NewShapeUpdateDocument(tb testing.TB, n, shapeOrdinal int) []byte {
+	tb.Helper()
+	doc, err := EncodeTemplateV1Document(
+		[]string{"name", "email", "city", "score", fmt.Sprintf("shape_%06d", shapeOrdinal)},
+		[]any{
+			fmt.Sprintf("user-%09d", n),
+			fmt.Sprintf("user-%09d@example.com", n),
+			fmt.Sprintf("updated-city-%02d", (n+shapeOrdinal)%64),
+			int64(shapeOrdinal),
+			"x",
+		},
+	)
+	if err != nil {
+		tb.Fatalf("encode new-shape template-v1 doc %d/%d: %v", n, shapeOrdinal, err)
+	}
+	return doc
+}
+
+func benchmarkTemplateV1ReplaceWith(raw []byte) func([]byte) ([]byte, bool, error) {
+	return func([]byte) ([]byte, bool, error) {
+		return raw, true, nil
+	}
+}
+
+func collectionManagerStatsBenchmarkDelta(after, before CollectionManagerStats) CollectionManagerStats {
+	return CollectionManagerStats{
+		IndexedStageBatches:            after.IndexedStageBatches - before.IndexedStageBatches,
+		IndexedStageDocs:               after.IndexedStageDocs - before.IndexedStageDocs,
+		IndexedStageBytes:              after.IndexedStageBytes - before.IndexedStageBytes,
+		IndexedStageRootRuns:           after.IndexedStageRootRuns - before.IndexedStageRootRuns,
+		IndexedFlushCalls:              after.IndexedFlushCalls - before.IndexedFlushCalls,
+		IndexedFlushErrors:             after.IndexedFlushErrors - before.IndexedFlushErrors,
+		IndexedFlushDocs:               after.IndexedFlushDocs - before.IndexedFlushDocs,
+		IndexedFlushBytes:              after.IndexedFlushBytes - before.IndexedFlushBytes,
+		IndexedFlushRootRuns:           after.IndexedFlushRootRuns - before.IndexedFlushRootRuns,
+		IndexedFlushRoots:              after.IndexedFlushRoots - before.IndexedFlushRoots,
+		IndexedFlushDuration:           after.IndexedFlushDuration - before.IndexedFlushDuration,
+		IndexedFlushMaterialize:        after.IndexedFlushMaterialize - before.IndexedFlushMaterialize,
+		IndexedFlushPublish:            after.IndexedFlushPublish - before.IndexedFlushPublish,
+		UpdateBatchCalls:               after.UpdateBatchCalls - before.UpdateBatchCalls,
+		UpdateBatchItems:               after.UpdateBatchItems - before.UpdateBatchItems,
+		UpdateBatchMatched:             after.UpdateBatchMatched - before.UpdateBatchMatched,
+		UpdateBatchModified:            after.UpdateBatchModified - before.UpdateBatchModified,
+		UpdateBatchRuns:                after.UpdateBatchRuns - before.UpdateBatchRuns,
+		UpdateBatchBufferedBatches:     after.UpdateBatchBufferedBatches - before.UpdateBatchBufferedBatches,
+		UpdateBatchCurrentRead:         after.UpdateBatchCurrentRead - before.UpdateBatchCurrentRead,
+		UpdateBatchCallback:            after.UpdateBatchCallback - before.UpdateBatchCallback,
+		UpdateBatchPrepareDocuments:    after.UpdateBatchPrepareDocuments - before.UpdateBatchPrepareDocuments,
+		UpdateBatchIndexStateExtract:   after.UpdateBatchIndexStateExtract - before.UpdateBatchIndexStateExtract,
+		UpdateBatchUniquePreflight:     after.UpdateBatchUniquePreflight - before.UpdateBatchUniquePreflight,
+		UpdateBatchTemplateRunBuild:    after.UpdateBatchTemplateRunBuild - before.UpdateBatchTemplateRunBuild,
+		UpdateBatchPrimaryRunBuild:     after.UpdateBatchPrimaryRunBuild - before.UpdateBatchPrimaryRunBuild,
+		UpdateBatchSecondaryRunBuild:   after.UpdateBatchSecondaryRunBuild - before.UpdateBatchSecondaryRunBuild,
+		UpdateBatchBufferStage:         after.UpdateBatchBufferStage - before.UpdateBatchBufferStage,
+		UpdateBatchBufferLockWait:      after.UpdateBatchBufferLockWait - before.UpdateBatchBufferLockWait,
+		UpdateBatchBufferLockHold:      after.UpdateBatchBufferLockHold - before.UpdateBatchBufferLockHold,
+		UpdateBatchBufferRootAppend:    after.UpdateBatchBufferRootAppend - before.UpdateBatchBufferRootAppend,
+		UpdateBatchPublish:             after.UpdateBatchPublish - before.UpdateBatchPublish,
+		UpdateBatchSecondaryDeletes:    after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
+		UpdateBatchSecondarySets:       after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
+		UpdateBatchSecondaryKeyBytes:   after.UpdateBatchSecondaryKeyBytes - before.UpdateBatchSecondaryKeyBytes,
+		UpdateBatchIndexValueChanges:   after.UpdateBatchIndexValueChanges - before.UpdateBatchIndexValueChanges,
+		UpdateBatchIndexValueUnchanged: after.UpdateBatchIndexValueUnchanged - before.UpdateBatchIndexValueUnchanged,
+		UpdateBatchUniqueChecks:        after.UpdateBatchUniqueChecks - before.UpdateBatchUniqueChecks,
+		UpdateBatchUniqueCheckSkips:    after.UpdateBatchUniqueCheckSkips - before.UpdateBatchUniqueCheckSkips,
+	}
+}
+
+func reportCollectionUpdateStatsForBenchmark(b *testing.B, stats CollectionManagerStats, docs int) {
+	b.Helper()
+	if docs <= 0 {
+		return
+	}
+	reportUintPerDoc := func(value uint64, name string) {
+		if value > 0 {
+			b.ReportMetric(float64(value)/float64(docs), name)
+		}
+	}
+	reportDurationPerDoc := func(value time.Duration, name string) {
+		if value > 0 {
+			b.ReportMetric(float64(value.Nanoseconds())/float64(docs), name)
+		}
+	}
+	if stats.IndexedStageBatches > 0 {
+		b.ReportMetric(float64(stats.IndexedStageBatches), "indexed_stage_batches")
+		b.ReportMetric(float64(stats.IndexedStageDocs)/float64(stats.IndexedStageBatches), "indexed_stage_docs/batch")
+	}
+	reportUintPerDoc(stats.IndexedStageDocs, "indexed_stage_docs/doc")
+	reportUintPerDoc(stats.IndexedStageBytes, "indexed_stage_bytes/doc")
+	reportUintPerDoc(stats.IndexedStageRootRuns, "indexed_stage_root_runs/doc")
+	if stats.IndexedFlushCalls > 0 {
+		b.ReportMetric(float64(stats.IndexedFlushCalls), "indexed_flush_calls")
+		b.ReportMetric(float64(stats.IndexedFlushDocs)/float64(stats.IndexedFlushCalls), "indexed_flush_docs/call")
+		b.ReportMetric(float64(stats.IndexedFlushRootRuns)/float64(stats.IndexedFlushCalls), "indexed_flush_root_runs/call")
+		b.ReportMetric(float64(stats.IndexedFlushRoots)/float64(stats.IndexedFlushCalls), "indexed_flush_roots/call")
+	}
+	reportUintPerDoc(stats.IndexedFlushDocs, "indexed_flush_docs/doc")
+	reportUintPerDoc(stats.IndexedFlushBytes, "indexed_flush_bytes/doc")
+	reportUintPerDoc(stats.IndexedFlushRootRuns, "indexed_flush_root_runs/doc")
+	reportUintPerDoc(stats.IndexedFlushRoots, "indexed_flush_roots/doc")
+	reportDurationPerDoc(stats.IndexedFlushDuration, "indexed_flush_ns/doc")
+	reportDurationPerDoc(stats.IndexedFlushMaterialize, "indexed_flush_materialize_ns/doc")
+	reportDurationPerDoc(stats.IndexedFlushPublish, "indexed_flush_publish_ns/doc")
+	if stats.UpdateBatchCalls > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchCalls), "update_batches")
+		b.ReportMetric(float64(stats.UpdateBatchItems)/float64(stats.UpdateBatchCalls), "update_items/batch")
+		b.ReportMetric(float64(stats.UpdateBatchRuns)/float64(stats.UpdateBatchCalls), "update_roots/batch")
+	}
+	reportUintPerDoc(stats.UpdateBatchMatched, "update_matched/doc")
+	reportUintPerDoc(stats.UpdateBatchModified, "update_modified/doc")
+	reportUintPerDoc(stats.UpdateBatchSecondaryDeletes, "update_secondary_deletes/doc")
+	reportUintPerDoc(stats.UpdateBatchSecondarySets, "update_secondary_sets/doc")
+	reportUintPerDoc(stats.UpdateBatchSecondaryKeyBytes, "update_secondary_key_bytes/doc")
+	reportUintPerDoc(stats.UpdateBatchIndexValueChanges, "update_index_value_changes/doc")
+	reportUintPerDoc(stats.UpdateBatchIndexValueUnchanged, "update_index_value_unchanged/doc")
+	reportUintPerDoc(stats.UpdateBatchUniqueChecks, "update_unique_checks/doc")
+	reportUintPerDoc(stats.UpdateBatchUniqueCheckSkips, "update_unique_check_skips/doc")
+	reportDurationPerDoc(stats.UpdateBatchCurrentRead, "update_current_read_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchCallback, "update_callback_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchPrepareDocuments, "update_prepare_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchIndexStateExtract, "update_index_state_extract_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchUniquePreflight, "update_unique_preflight_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchTemplateRunBuild, "update_template_run_build_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchPrimaryRunBuild, "update_primary_run_build_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchSecondaryRunBuild, "update_secondary_run_build_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferStage, "update_buffer_stage_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferLockWait, "update_buffer_lock_wait_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferLockHold, "update_buffer_lock_hold_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferRootAppend, "update_buffer_root_append_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchPublish, "update_publish_ns/doc")
+}

--- a/TreeDB/collections/freeze_sort_run_table.go
+++ b/TreeDB/collections/freeze_sort_run_table.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"errors"
 	"sort"
 	"sync"
 	"unsafe"
@@ -86,6 +87,47 @@ func (t *freezeSortRunTable) SetEntrySteal(key, value []byte, ptr page.ValuePtr,
 		t.latest[unsafe.String(&key[0], len(key))] = idx
 	}
 	t.mu.Unlock()
+}
+
+func (t *freezeSortRunTable) ApplyStealEntryFunc(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error)) error {
+	if count <= 0 {
+		return nil
+	}
+	if emit == nil {
+		return errors.New("collections: nil freeze-sort entry emitter")
+	}
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i := 0; i < count; i++ {
+		key, value, ptr, flags, err := emit(i)
+		if err != nil {
+			return err
+		}
+		if len(key) == 0 {
+			continue
+		}
+		if flags&node.FlagTombstone != 0 {
+			value = nil
+			ptr = page.ValuePtr{}
+		}
+		idx := len(t.entries)
+		t.entries = append(t.entries, freezeSortRunEntry{
+			key:   key,
+			value: value,
+			ptr:   ptr,
+			seq:   t.nextSeq,
+			flags: flags,
+		})
+		t.nextSeq++
+		t.sizeBytes += int64(len(key) + entryLogicalValueSize(flags, value))
+		if t.latest != nil && !t.latestDirty {
+			t.latest[unsafe.String(&key[0], len(key))] = idx
+		}
+	}
+	return nil
 }
 
 func (t *freezeSortRunTable) Delete(key []byte) {

--- a/TreeDB/collections/freeze_sort_run_table_test.go
+++ b/TreeDB/collections/freeze_sort_run_table_test.go
@@ -7,6 +7,7 @@ import (
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 func TestFreezeSortRunTableLatestSortedAndTombstoneSemantics(t *testing.T) {
@@ -98,6 +99,40 @@ func TestFreezeSortRunIteratorAdvertisesTrustedMaterializeFastPath(t *testing.T)
 	}
 	if got := rangedLen.Len(); got != 1 {
 		t.Fatalf("ranged iterator Len=%d want 1", got)
+	}
+}
+
+func TestFreezeSortRunTableApplyStealEntryFunc(t *testing.T) {
+	table := newFreezeSortRunTable()
+	appender, ok := table.(interface {
+		ApplyStealEntryFunc(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error)) error
+	})
+	if !ok {
+		t.Fatal("freeze-sort run table does not expose ApplyStealEntryFunc")
+	}
+	err := appender.ApplyStealEntryFunc(4, func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error) {
+		switch i {
+		case 0:
+			return []byte("b"), []byte("old-b"), page.ValuePtr{}, node.FlagInline, nil
+		case 1:
+			return []byte("a"), []byte("value-a"), page.ValuePtr{}, node.FlagInline, nil
+		case 2:
+			return []byte("b"), []byte("new-b"), page.ValuePtr{}, node.FlagInline, nil
+		default:
+			return []byte("c"), nil, page.ValuePtr{}, node.FlagTombstone, nil
+		}
+	})
+	if err != nil {
+		t.Fatalf("ApplyStealEntryFunc: %v", err)
+	}
+
+	if got, _, flags, ok := table.GetEntry([]byte("b")); !ok || flags&node.FlagTombstone != 0 || !bytes.Equal(got, []byte("new-b")) {
+		t.Fatalf("mutable GetEntry b=(%q,%02x,%v), want latest new-b", got, flags, ok)
+	}
+	table.Freeze()
+	requireFreezeSortRunIterator(t, table.NewIterator(nil, nil), []string{"a", "b", "c"})
+	if got := table.Len(); got != 3 {
+		t.Fatalf("frozen Len=%d want 3", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

This follows the indexed-write memtable/root fan-in work from #1159 and extends the direct buffered update path from BSON to template-v1 updates.

The old path deliberately declined direct buffering whenever template-v1 updates produced template records, so indexed template-v1 updates with new template shapes fell back to per-batch delta tables. This PR stages template records into the same collection write-domain root accumulators as primary and secondary roots, preserving the append-then-freeze/sort memtable shape instead of introducing a mutable B-tree-style structure.

Changes:
- allow direct buffered indexed update plans when template-v1 template records are present
- stage template root records into the collection write-domain alongside primary and affected secondary roots
- add a single-lock `ApplyStealEntryFunc` fast path for `freezeSortRunTable` so root accumulators append batches cheaply before freeze/sort
- add correctness coverage proving two template-v1 update batches accumulate into one template, one primary, and one city root run while buffered reads/index lookups remain correct
- add a targeted template-v1 new-shape update benchmark that reports docs/sec, ns/doc, root-runs/doc, flush costs, and update phase counters

## Benchmark Evidence

Local machine: Apple M3, darwin/arm64.

Benchmark commands:

```bash
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionUpdateBatchDirectBufferedTemplateV1NewShape/batch_80$' -benchtime=8000x -count 1
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionUpdateBatchDirectBufferedTemplateV1NewShape/batch_16000$' -benchtime=160000x -count 1
```

Baseline was measured by temporarily removing only the `api.go` direct-template behavior while keeping the benchmark in-tree.

| Case | docs/sec | ns/doc | staged root-runs/doc | flush root-runs/doc | flush materialize ns/doc |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline batch 80 | 269,322 | 3,713 | 0.03750 | 0.03750 | 500.4 |
| PR batch 80 | 337,500 | 2,963 | 0.000375 | 0.000375 | 88.4 |
| baseline batch 16,000 x10 | 413,136 | 2,421 | 0.0001875 | 0.0001875 | 496.9 |
| PR batch 16,000 x10 | 421,503 | 2,372 | 0.0000187 | 0.0000187 | 34.5 |

The main architectural win is root-run fan-in: repeated template-v1 update batches with new template records now keep appending into one root-local accumulator per affected root, then pay sort/coalesce once at freeze/flush.

## Tests

```bash
go test ./TreeDB/collections -run '^Test(CollectionUpdateBatchDirectBuffered(TemplateV1|BSON)AccumulatesRootRuns|FreezeSortRunTableApplyStealEntryFunc)$|^TestTemplateV1IndexedFlushUnitResolveBufferedTemplate$|^TestTemplateV1UpdatePublishesNewTemplateShape$' -count 1
go test ./TreeDB/collections -count 1
```

Both passed locally.

Closes #1159 partially; this is one direct root fan-in reduction step, not the whole #1159 architecture endpoint.
