### PR TITLE
collections: include pending indexed units in range scans

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10976,13 +10976,13 @@ func bufferedIndexRangeTableLocked(domain *collectionWriteDomain, collectionName
 	if domain == nil {
 		return nil, nil
 	}
-	if domain.count == 0 || len(domain.rootRuns) == 0 {
+	if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
 		return nil, nil
 	}
 	if domain.meta.Name != "" {
 		collectionName = domain.meta.Name
 	}
-	runs := domain.rootRuns[collectionSecondaryRootName(collectionName, indexName)]
+	runs := pendingIndexedRootRunsLocked(domain, collectionSecondaryRootName(collectionName, indexName))
 	if len(runs) == 0 {
 		return nil, nil
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10897,6 +10897,8 @@ func TestCollectionFindByIndexRangeTypedInt64(t *testing.T) {
 		t.Fatalf("insert batch: %v", err)
 	}
 
+	// Use a half-open range so this exercises non-exact range materialization,
+	// not the exact-prefix helper that already used pending root runs.
 	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(0), Inclusive: true},
 		Upper: IndexRangeBound{Value: int64(10), Inclusive: false},
@@ -11013,6 +11015,8 @@ func TestCollectionFindByIndexRangeMergesBufferedUpdates(t *testing.T) {
 		t.Fatalf("buffered update advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
 	}
 
+	// Use a half-open range so this exercises non-exact range materialization,
+	// not the exact-prefix helper that already used pending root runs.
 	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(5), Inclusive: true},
 		Upper: IndexRangeBound{Value: int64(6), Inclusive: true},
@@ -11045,6 +11049,168 @@ func TestCollectionFindByIndexRangeMergesBufferedUpdates(t *testing.T) {
 	}
 	if truncated || len(ids) != 2 || !bytes.Equal(ids[0], []byte("u1")) || !bytes.Equal(ids[1], []byte("u2")) {
 		t.Fatalf("flushed score ids=%q truncated=%v want u1,u2 false", ids, truncated)
+	}
+}
+
+func TestCollectionFindByIndexRangeSeesQueuedIndexedFlushUnits(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "score", Field: "score", ValueType: IndexValueInt64}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2"), []byte("u3")},
+		[][]byte{
+			[]byte(`{"score":5}`),
+			[]byte(`{"score":6}`),
+			[]byte(`{"score":9}`),
+		},
+	); err != nil {
+		t.Fatalf("insert persisted rows: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush persisted rows: %v", err)
+	}
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONField("score", int64(7))},
+		{DocumentID: []byte("u2"), Update: setJSONField("score", int64(8))},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatalf("batched=%v results=%+v want buffered update batch", batched, results)
+	}
+	col.writeDomain.mu.Lock()
+	if !rotateIndexedMutableToFlushUnitLocked(col.writeDomain) {
+		col.writeDomain.mu.Unlock()
+		t.Fatal("rotate indexed mutable state returned false")
+	}
+	if got := len(col.writeDomain.indexedFlushUnits); got != 1 {
+		col.writeDomain.mu.Unlock()
+		t.Fatalf("queued flush units=%d want 1", got)
+	}
+	col.writeDomain.mu.Unlock()
+
+	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(7), Inclusive: true},
+		Upper: IndexRangeBound{Value: int64(9), Inclusive: false},
+	})
+	if err != nil {
+		t.Fatalf("find queued new score range: %v", err)
+	}
+	if truncated || len(ids) != 2 || !bytes.Equal(ids[0], []byte("u1")) || !bytes.Equal(ids[1], []byte("u2")) {
+		t.Fatalf("queued new score ids=%q truncated=%v want u1,u2 false", ids, truncated)
+	}
+	ids, truncated, err = col.FindByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(5), Inclusive: true},
+		Upper: IndexRangeBound{Value: int64(7), Inclusive: false},
+	})
+	if err != nil {
+		t.Fatalf("find queued old score range: %v", err)
+	}
+	if truncated || len(ids) != 0 {
+		t.Fatalf("queued old score ids=%q truncated=%v want none false", ids, truncated)
+	}
+}
+
+func TestCollectionFindByIndexRangeSeesPublishingIndexedFlushUnits(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "score", Field: "score", ValueType: IndexValueInt64}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2"), []byte("u3")},
+		[][]byte{
+			[]byte(`{"score":5}`),
+			[]byte(`{"score":6}`),
+			[]byte(`{"score":9}`),
+		},
+	); err != nil {
+		t.Fatalf("insert persisted rows: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush persisted rows: %v", err)
+	}
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONField("score", int64(7))},
+		{DocumentID: []byte("u2"), Update: setJSONField("score", int64(8))},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatalf("batched=%v results=%+v want buffered update batch", batched, results)
+	}
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	publishAttempted := false
+	defer func() {
+		if !publishAttempted && work.pin != nil {
+			_ = work.pin.Close()
+			work.pin = nil
+		}
+	}()
+
+	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(7), Inclusive: true},
+		Upper: IndexRangeBound{Value: int64(9), Inclusive: false},
+	})
+	if err != nil {
+		t.Fatalf("find publishing new score range: %v", err)
+	}
+	if truncated || len(ids) != 2 || !bytes.Equal(ids[0], []byte("u1")) || !bytes.Equal(ids[1], []byte("u2")) {
+		t.Fatalf("publishing new score ids=%q truncated=%v want u1,u2 false", ids, truncated)
+	}
+	ids, truncated, err = col.FindByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(5), Inclusive: true},
+		Upper: IndexRangeBound{Value: int64(7), Inclusive: false},
+	})
+	if err != nil {
+		t.Fatalf("find publishing old score range: %v", err)
+	}
+	if truncated || len(ids) != 0 {
+		t.Fatalf("publishing old score ids=%q truncated=%v want none false", ids, truncated)
+	}
+	publishAttempted = true
+	if err := col.publishPreparedIndexedFlush(work); err != nil {
+		t.Fatalf("publish prepared async flush: %v", err)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10897,7 +10897,7 @@ func TestCollectionFindByIndexRangeTypedInt64(t *testing.T) {
 		t.Fatalf("insert batch: %v", err)
 	}
 
-	// Use a half-open range so this exercises non-exact range materialization,
+	// Use a non-equality range so this exercises non-exact range materialization,
 	// not the exact-prefix helper that already used pending root runs.
 	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(0), Inclusive: true},
@@ -11015,7 +11015,7 @@ func TestCollectionFindByIndexRangeMergesBufferedUpdates(t *testing.T) {
 		t.Fatalf("buffered update advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
 	}
 
-	// Use a half-open range so this exercises non-exact range materialization,
+	// Use a non-equality range so this exercises non-exact range materialization,
 	// not the exact-prefix helper that already used pending root runs.
 	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(5), Inclusive: true},


### PR DESCRIPTION
## Summary

Fixes the PR 1a visibility gap from #1242 where non-exact secondary range scans only read the current mutable indexed runs. They now use the same pending-root enumeration as exact secondary lookup, covering:

- active/publishing indexed flush units
- queued indexed flush units
- current mutable indexed runs

## Details

- Updates `bufferedIndexRangeTableLocked` to use `pendingIndexedRootRunsLocked(...)`.
- Keeps the existing owned-table materialization behavior so pending tombstones can still suppress durable entries during the persisted merge.
- Adds deterministic regression tests for queued and active/publishing indexed flush units.
- The tests use half-open ranges to force the non-exact range path, and verify both pending new secondary entries and tombstone suppression of durable old secondary entries.

## Tests

```sh
go test ./TreeDB/collections -run 'TestCollectionFindByIndexRange(SeesQueuedIndexedFlushUnits|SeesPublishingIndexedFlushUnits|MergesBufferedUpdates|SkipsBufferedTombstone)'
go test ./TreeDB/collections
```

No DB/zipper hooks were added in this PR. The same-package tests can deterministically put units into queued and publishing states without timing gates.

Closes #1242 for the PR 1a range-visibility slice.
