### PR TITLE
unified_bench: render ordered root selected stats

### DIFF
--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -4809,6 +4809,19 @@ func renderTreeDBSelectedStatsString(instances []*DBInstance, treeStats map[stri
 		{label: "vlog_mmap.read.hit_ratio", alts: []string{"treedb.cache.vlog_mmap.read.hit_ratio", "treedb.vlog.mmap_read.hit_ratio"}},
 		{label: "leaf_generation.generations.pinned", alts: []string{"treedb.leaf_generation.generations.pinned"}},
 		{label: "leaf_generation.pins.total", alts: []string{"treedb.leaf_generation.pins.total"}},
+		{label: "publish.ordered_root_delta_group.calls_total", alts: []string{"treedb.publish.ordered_root_delta_group.calls_total"}},
+		{label: "publish.ordered_root_delta_group.roots_total", alts: []string{"treedb.publish.ordered_root_delta_group.roots_total"}},
+		{label: "publish.ordered_root_delta_group.avg_roots_per_call", alts: []string{"treedb.publish.ordered_root_delta_group.avg_roots_per_call"}},
+		{label: "publish.ordered_root_delta_group.root_apply_calls_total", alts: []string{"treedb.publish.ordered_root_delta_group.root_apply_calls_total"}},
+		{label: "publish.ordered_root_delta_group.root_apply_ns_total", alts: []string{"treedb.publish.ordered_root_delta_group.root_apply_ns_total"}},
+		{label: "publish.ordered_root_delta_group.root_apply_ops_total", alts: []string{"treedb.publish.ordered_root_delta_group.root_apply_ops_total"}},
+		{label: "publish.ordered_root_delta_group.root_apply_node_loads_total", alts: []string{"treedb.publish.ordered_root_delta_group.root_apply_node_loads_total"}},
+		{label: "publish.ordered_root_delta_group.root_apply_leaf_log_node_loads_total", alts: []string{"treedb.publish.ordered_root_delta_group.root_apply_leaf_log_node_loads_total"}},
+		{label: "publish.ordered_root_delta_group.root_apply_leaf_log_pages_written_total", alts: []string{"treedb.publish.ordered_root_delta_group.root_apply_leaf_log_pages_written_total"}},
+		{label: "publish.ordered_root_delta_group.root_apply_leaf_log_node_bytes_read_total", alts: []string{"treedb.publish.ordered_root_delta_group.root_apply_leaf_log_node_bytes_read_total"}},
+		{label: "publish.ordered_root_delta_group.root_apply_leaf_log_page_bytes_written_total", alts: []string{"treedb.publish.ordered_root_delta_group.root_apply_leaf_log_page_bytes_written_total"}},
+		{label: "publish.ordered_root_delta_group.write_lock_wait_ns_total", alts: []string{"treedb.publish.ordered_root_delta_group.write_lock_wait_ns_total"}},
+		{label: "publish.ordered_root_delta_group.write_lock_hold_ns_total", alts: []string{"treedb.publish.ordered_root_delta_group.write_lock_hold_ns_total"}},
 	}
 	var sb strings.Builder
 	for _, inst := range instances {

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1204,10 +1204,15 @@ func TestRenderMarkdownSingle_IncludesTreeDBPerfSections(t *testing.T) {
 		},
 		TreeDBStats: map[string]map[string]string{
 			"TreeDB": {
-				"treedb.cache.vlog_mmap.read.hits":          "7",
-				"treedb.cache.vlog_mmap.read.hit_ratio":     "0.700000",
-				"treedb.leaf_generation.generations.pinned": "1",
-				"treedb.leaf_generation.pins.total":         "4",
+				"treedb.cache.vlog_mmap.read.hits":                                                     "7",
+				"treedb.cache.vlog_mmap.read.hit_ratio":                                                "0.700000",
+				"treedb.leaf_generation.generations.pinned":                                            "1",
+				"treedb.leaf_generation.pins.total":                                                    "4",
+				"treedb.publish.ordered_root_delta_group.calls_total":                                  "9",
+				"treedb.publish.ordered_root_delta_group.root_apply_calls_total":                       "11",
+				"treedb.publish.ordered_root_delta_group.root_apply_leaf_log_node_bytes_read_total":    "2048",
+				"treedb.publish.ordered_root_delta_group.root_apply_leaf_log_page_bytes_written_total": "4096",
+				"treedb.publish.ordered_root_delta_group.write_lock_hold_ns_total":                     "12345",
 			},
 		},
 	}
@@ -1227,6 +1232,17 @@ func TestRenderMarkdownSingle_IncludesTreeDBPerfSections(t *testing.T) {
 	}
 	if !strings.Contains(md, "leaf_generation.pins.total: 4") {
 		t.Fatalf("expected selected stats in markdown, got:\n%s", md)
+	}
+	for _, want := range []string{
+		"publish.ordered_root_delta_group.calls_total: 9",
+		"publish.ordered_root_delta_group.root_apply_calls_total: 11",
+		"publish.ordered_root_delta_group.root_apply_leaf_log_node_bytes_read_total: 2048",
+		"publish.ordered_root_delta_group.root_apply_leaf_log_page_bytes_written_total: 4096",
+		"publish.ordered_root_delta_group.write_lock_hold_ns_total: 12345",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("expected selected ordered-root stat %q in markdown, got:\n%s", want, md)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a small #1242 PR 1b raw-engine reporting slice:

- extends `cmd/unified_bench` selected end-of-run TreeDB stats rendering to include ordered-root/root-apply counters already preserved by the shared selected-stats allowlist;
- renders raw root-apply calls, root-apply time/work, leaf-log physical bytes/pages, and write-lock wait/hold counters in markdown output;
- adds test coverage proving these ordered-root stats appear in the `TreeDB Selected Stats (End of Run)` section.

No benchmark workload or TreeDB storage behavior changes are included.

## Tests

```sh
go test ./cmd/unified_bench
```
