### PR TITLE
collections: populate direct update stats

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -359,9 +359,9 @@ type CollectionUpdateStats struct {
 	IndexValueUnchanged    int
 	UniqueIndexChecks      int
 	UniqueIndexCheckSkips  int
-	// IndexStats is populated only when detailed update-batch stats are enabled
-	// and the collection has at most len(IndexStats) index runtimes. The first
-	// IndexStatsCount entries are valid.
+	// IndexStats is populated for the first inline index runtimes when detailed
+	// update-batch stats are enabled. The first IndexStatsCount entries are
+	// valid; remaining indexes are represented only by aggregate counters.
 	IndexStatsCount int
 	IndexStats      [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats
 }
@@ -908,6 +908,26 @@ func cloneCollectionUpdateStats(stats CollectionUpdateStats) CollectionUpdateSta
 		stats.SecondaryRuns = append([]CollectionUpdateSecondaryRunStats(nil), stats.SecondaryRuns...)
 	}
 	return stats
+}
+
+func initCollectionUpdateIndexStats(stats *CollectionUpdateStats, collectionName string, runtimes []indexRuntime, enabled bool) {
+	if stats == nil || !enabled || len(runtimes) == 0 {
+		return
+	}
+	count := len(runtimes)
+	if count > len(stats.IndexStats) {
+		count = len(stats.IndexStats)
+	}
+	stats.IndexStatsCount = count
+	for i := 0; i < count; i++ {
+		runtime := runtimes[i]
+		stats.IndexStats[i] = CollectionUpdateIndexStats{
+			CollectionName: collectionName,
+			IndexName:      runtime.def.name,
+			IndexOrdinal:   i,
+			Unique:         runtime.def.unique,
+		}
+	}
 }
 
 func (c *Collection) updateBatchDetailedStatsEnabled() bool {
@@ -7110,17 +7130,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		_ = snap.Close()
 		return false, false, err
 	}
-	if detailedStats && len(runtimes) <= len(stats.IndexStats) {
-		stats.IndexStatsCount = len(runtimes)
-		for i, runtime := range runtimes {
-			stats.IndexStats[i] = CollectionUpdateIndexStats{
-				CollectionName: c.meta.Name,
-				IndexName:      runtime.def.name,
-				IndexOrdinal:   i,
-				Unique:         runtime.def.unique,
-			}
-		}
-	}
+	initCollectionUpdateIndexStats(&stats, c.meta.Name, runtimes, detailedStats)
 	currentID, err := captureBSONIDSnapshot(currentValue, plannerOptions)
 	if err != nil {
 		_ = snap.Close()
@@ -8408,17 +8418,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			putUpdateBatchPlanScratch(scratch)
 		}
 	}()
-	if detailedStats && len(runtimes) <= len(stats.IndexStats) {
-		stats.IndexStatsCount = len(runtimes)
-		for i, runtime := range runtimes {
-			stats.IndexStats[i] = CollectionUpdateIndexStats{
-				CollectionName: meta.Name,
-				IndexName:      runtime.def.name,
-				IndexOrdinal:   i,
-				Unique:         runtime.def.unique,
-			}
-		}
-	}
+	initCollectionUpdateIndexStats(&stats, meta.Name, runtimes, detailedStats)
 	var currentScratch []byte
 	for i, item := range items {
 		phaseStart := updateBatchStatsNow(detailedStats)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -309,9 +309,7 @@ type CollectionSecondaryRunStats struct {
 }
 
 // CollectionUpdateStats captures phase timings and counters from the most
-// recent successful UpdateBatch-style call on a Collection handle. Individual
-// Update calls that fall back to the legacy direct path are intentionally not
-// represented here yet; the write combiner and UpdateBatch path use this shape.
+// recent successful Update/UpdateBatch-style call on a Collection handle.
 type CollectionUpdateStats struct {
 	Items                int
 	Matched              int
@@ -7055,6 +7053,7 @@ func errConcurrentRootModification(collectionName, rootName string) error {
 }
 
 func (c *Collection) updateDocumentOnce(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
+	detailedStats := c.updateBatchDetailedStatsEnabled()
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
 		return false, false, backenddb.ErrClosed
@@ -7078,21 +7077,29 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		_ = snap.Close()
 		return false, false, err
 	}
+	stats := CollectionUpdateStats{
+		Items:   1,
+		Indexes: len(c.meta.Indexes),
+	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 	baseUserRoot := snapshotUserRoot(snap)
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 
 	primaryRootName := collectionPrimaryRootName(c.meta.Name)
+	phaseStart := updateBatchStatsNow(detailedStats)
 	currentValue, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, documentID, nil)
+	stats.CurrentRead += updateBatchStatsSince(detailedStats, phaseStart)
 	if err != nil {
 		_ = snap.Close()
 		return false, false, err
 	}
 	if !found {
 		_ = snap.Close()
+		c.setLastUpdateStats(stats)
 		return false, false, nil
 	}
+	stats.Matched = 1
 	primaryRoot := catalog.rootID(primaryRootName)
 
 	runtimes, err := (insertBatchPlanner{
@@ -7103,6 +7110,17 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		_ = snap.Close()
 		return false, false, err
 	}
+	if detailedStats && len(runtimes) <= len(stats.IndexStats) {
+		stats.IndexStatsCount = len(runtimes)
+		for i, runtime := range runtimes {
+			stats.IndexStats[i] = CollectionUpdateIndexStats{
+				CollectionName: c.meta.Name,
+				IndexName:      runtime.def.name,
+				IndexOrdinal:   i,
+				Unique:         runtime.def.unique,
+			}
+		}
+	}
 	currentID, err := captureBSONIDSnapshot(currentValue, plannerOptions)
 	if err != nil {
 		_ = snap.Close()
@@ -7112,27 +7130,34 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	var newState documentIndexState
 	indexStateChanged := false
 	if len(runtimes) > 0 {
+		phaseStart = updateBatchStatsNow(detailedStats)
 		oldState, err = indexStateForDocument(currentValue, runtimes, plannerOptions)
+		stats.IndexStateExtraction += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()
 			return false, false, err
 		}
 	}
 
+	phaseStart = updateBatchStatsNow(detailedStats)
 	document, changed, err := callCollectionUpdateCallback(update, currentValue)
+	stats.Callback += updateBatchStatsSince(detailedStats, phaseStart)
 	if err != nil {
 		_ = snap.Close()
 		return false, false, err
 	}
 	if !changed {
 		_ = snap.Close()
+		c.setLastUpdateStats(stats)
 		return true, false, nil
 	}
 	if err := validateBSONReplacementPreservesIDSnapshot(currentID, document, plannerOptions); err != nil {
 		_ = snap.Close()
 		return false, false, err
 	}
+	phaseStart = updateBatchStatsNow(detailedStats)
 	preparedDocuments, templateRecords, templateResolver, err := prepareInsertDocuments([][]byte{document}, plannerOptions)
+	stats.PrepareDocuments += updateBatchStatsSince(detailedStats, phaseStart)
 	if err != nil {
 		_ = snap.Close()
 		return false, false, err
@@ -7147,17 +7172,46 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	}
 
 	if len(runtimes) > 0 {
+		phaseStart = updateBatchStatsNow(detailedStats)
 		newState, err = indexStateForDocument(document, runtimes, plannerOptions)
+		stats.IndexStateExtraction += updateBatchStatsSince(detailedStats, phaseStart)
 		if err != nil {
 			_ = snap.Close()
 			return false, false, err
 		}
 		indexStateChanged = !documentIndexStatesEqual(oldState, newState)
+		for runtimeIdx, runtime := range runtimes {
+			if documentIndexRuntimeChanged(oldState, newState, runtime) {
+				stats.IndexValueChanges++
+				if runtime.def.unique {
+					stats.UniqueIndexChecks++
+				}
+				if runtimeIdx < stats.IndexStatsCount {
+					stats.IndexStats[runtimeIdx].Changed++
+					if runtime.def.unique {
+						stats.IndexStats[runtimeIdx].UniqueChecks++
+					}
+				}
+				continue
+			}
+			stats.IndexValueUnchanged++
+			if runtime.def.unique {
+				stats.UniqueIndexCheckSkips++
+			}
+			if runtimeIdx < stats.IndexStatsCount {
+				stats.IndexStats[runtimeIdx].Unchanged++
+				if runtime.def.unique {
+					stats.IndexStats[runtimeIdx].UniqueCheckSkips++
+				}
+			}
+		}
 		if indexStateChanged {
+			phaseStart = updateBatchStatsNow(detailedStats)
 			if err := rejectReplaceUniqueConflicts(snap, catalog, runtimes, oldState, newState, documentID, nil); err != nil {
 				_ = snap.Close()
 				return false, false, err
 			}
+			stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 		}
 	}
 
@@ -7167,6 +7221,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	deltaTables := make([]memtable.Table, 0, 2+len(runtimes))
 
 	if len(templateRecords) > 0 {
+		phaseStart = updateBatchStatsNow(detailedStats)
 		templatePlan := &insertBatchPlan{}
 		if err := (insertBatchPlanner{
 			collection:             c.meta.Name,
@@ -7183,18 +7238,22 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 			policies = append(policies, run.storagePolicy)
 			deltaTables = append(deltaTables, run.table)
 		}
+		stats.TemplateRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 	}
 
 	rootNames = append(rootNames, primaryRootName)
 	baseRootIDs[primaryRootName] = primaryRoot
 	policies = append(policies, plannerOptions.dataStoragePolicy)
+	phaseStart = updateBatchStatsNow(detailedStats)
 	primaryTable := newCollectionRunTable(1)
 	setCollectionRunValue(primaryTable, bytes.Clone(documentID), document)
 	primaryTable.Freeze()
 	deltaTables = append(deltaTables, primaryTable)
+	stats.PrimaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 
 	if indexStateChanged {
 		if persistIndexStateForOptions(plannerOptions) {
+			phaseStart = updateBatchStatsNow(detailedStats)
 			stateRootName := collectionIndexStateRootName(c.meta.Name)
 			stateRootID := catalog.rootID(stateRootName)
 			rootNames = append(rootNames, stateRootName)
@@ -7214,25 +7273,48 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 			}
 			stateTable.Freeze()
 			deltaTables = append(deltaTables, stateTable)
+			stats.IndexStateRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 		}
 
-		for _, runtime := range runtimes {
+		phaseStart = updateBatchStatsNow(detailedStats)
+		for runtimeIdx, runtime := range runtimes {
 			if !documentIndexRuntimeChanged(oldState, newState, runtime) {
 				continue
 			}
 			rootName := collectionSecondaryRootName(c.meta.Name, runtime.def.name)
 			rootID := catalog.rootID(rootName)
 			table := newCollectionRunTable(0)
-			if err := deleteSecondaryEntriesForDocument(table, runtime, oldState, documentID); err != nil {
-				_ = snap.Close()
-				resetCollectionTables(append(deltaTables, table))
-				return false, false, err
-			}
-			for _, encoded := range newState[runtime.def.name] {
-				if _, err := setCollectionSecondaryIndexEntry(table, encoded, documentID); err != nil {
+			runStats := CollectionUpdateSecondaryRunStats{IndexName: runtime.def.name}
+			for _, encoded := range oldState[runtime.def.name] {
+				keyLen, err := deleteCollectionSecondaryIndexEntry(table, encoded, documentID)
+				if err != nil {
 					_ = snap.Close()
 					resetCollectionTables(append(deltaTables, table))
 					return false, false, err
+				}
+				stats.SecondaryDeleteEntries++
+				stats.SecondaryKeyBytes += keyLen
+				runStats.Deletes++
+				runStats.KeyBytes += keyLen
+				if runtimeIdx < stats.IndexStatsCount {
+					stats.IndexStats[runtimeIdx].SecondaryDeletes++
+					stats.IndexStats[runtimeIdx].SecondaryKeyBytes += keyLen
+				}
+			}
+			for _, encoded := range newState[runtime.def.name] {
+				keyLen, err := setCollectionSecondaryIndexEntry(table, encoded, documentID)
+				if err != nil {
+					_ = snap.Close()
+					resetCollectionTables(append(deltaTables, table))
+					return false, false, err
+				}
+				stats.SecondarySetEntries++
+				stats.SecondaryKeyBytes += keyLen
+				runStats.Sets++
+				runStats.KeyBytes += keyLen
+				if runtimeIdx < stats.IndexStatsCount {
+					stats.IndexStats[runtimeIdx].SecondarySets++
+					stats.IndexStats[runtimeIdx].SecondaryKeyBytes += keyLen
 				}
 			}
 			if table.Len() == 0 {
@@ -7244,7 +7326,14 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 			baseRootIDs[rootName] = rootID
 			policies = append(policies, runtime.def.storagePolicy)
 			deltaTables = append(deltaTables, table)
+			if runStats.Deletes != 0 || runStats.Sets != 0 || runStats.KeyBytes != 0 {
+				stats.SecondaryRuns = append(stats.SecondaryRuns, runStats)
+			}
+			if runtimeIdx < stats.IndexStatsCount {
+				stats.IndexStats[runtimeIdx].SecondaryRuns++
+			}
 		}
+		stats.SecondaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 	}
 	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
 	// base roots before stale-root validation rejects concurrent modifications.
@@ -7260,9 +7349,11 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	preflight := func() error {
 		return c.validateMutationRootDescriptors(baseUserRoot, baseSystemRoot, baseCommitSeq)
 	}
+	phaseStart = updateBatchStatsNow(detailedStats)
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
+	stats.Publish += updateBatchStatsSince(detailedStats, phaseStart)
 	cleanupDeltas()
 	if err != nil {
 		return false, false, err
@@ -7273,6 +7364,9 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	stats.Modified = 1
+	stats.Runs = len(rootNames)
+	c.setLastUpdateStats(stats)
 	return true, true, nil
 }
 

--- a/TreeDB/collections/direct_update_stats_test.go
+++ b/TreeDB/collections/direct_update_stats_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"fmt"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -158,6 +159,86 @@ func TestCollectionDirectUpdateStatsForNoopAndMissingDocument(t *testing.T) {
 	if stats.Items != 1 || stats.Matched != 0 || stats.Modified != 0 || stats.Runs != 0 || stats.IndexValueChanges != 0 || stats.IndexValueUnchanged != 0 {
 		t.Fatalf("missing stats=%+v want one unmatched item and no root/index work", stats)
 	}
+}
+
+func TestCollectionDirectUpdateDetailedStatsCapsAtInlineIndexLimit(t *testing.T) {
+	const indexCount = maxCollectionUpdateInlineIndexStats + 2
+
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	indexes := make([]IndexDefinition, indexCount)
+	for i := range indexes {
+		indexes[i] = IndexDefinition{
+			Name:      fmt.Sprintf("idx%02d", i),
+			Field:     fmt.Sprintf("f%02d", i),
+			ValueType: IndexValueString,
+		}
+	}
+	mgr := NewCollectionManager(d)
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DisableIndexedWriteMemtables: true,
+		},
+		Indexes: indexes,
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{directUpdateStatsWideDocument(indexCount, -1, "")},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	matched, modified, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return directUpdateStatsWideDocument(indexCount, 1, "changed"), true, nil
+	})
+	if err != nil {
+		t.Fatalf("direct update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("direct update matched/modified=%v/%v want true/true", matched, modified)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.IndexStatsCount, maxCollectionUpdateInlineIndexStats; got != want {
+		t.Fatalf("index stats count=%d want inline cap %d", got, want)
+	}
+	if got, want := stats.IndexStats[maxCollectionUpdateInlineIndexStats-1].IndexName, fmt.Sprintf("idx%02d", maxCollectionUpdateInlineIndexStats-1); got != want {
+		t.Fatalf("last inline index stat name=%q want %q", got, want)
+	}
+	if got, want := stats.IndexValueChanges, 1; got != want {
+		t.Fatalf("aggregate index changes=%d want %d", got, want)
+	}
+	if got, want := stats.IndexValueUnchanged, indexCount-1; got != want {
+		t.Fatalf("aggregate index unchanged=%d want %d", got, want)
+	}
+	directUpdateStatsRequireIndex(t, stats.IndexStats[:stats.IndexStatsCount], "idx01", false, 1, 0, 0, 0, 1, 1, 1)
+}
+
+func directUpdateStatsWideDocument(indexCount, changedOrdinal int, changedValue string) []byte {
+	out := []byte{'{'}
+	for i := 0; i < indexCount; i++ {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		value := fmt.Sprintf("v%02d", i)
+		if i == changedOrdinal {
+			value = changedValue
+		}
+		out = fmt.Appendf(out, "%q:%q", fmt.Sprintf("f%02d", i), value)
+	}
+	out = append(out, '}')
+	return out
 }
 
 func directUpdateStatsRequireIndex(

--- a/TreeDB/collections/direct_update_stats_test.go
+++ b/TreeDB/collections/direct_update_stats_test.go
@@ -1,0 +1,189 @@
+package collections
+
+import (
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionDirectUpdatePopulatesLastUpdateStats(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DisableIndexedWriteMemtables: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "active", Field: "active", ValueType: IndexValueBool},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl","active":true,"seen":false}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	matched, modified, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"email":"ada@example.com","city":"sea","active":true,"seen":false}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("direct update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("direct update matched/modified=%v/%v want true/true", matched, modified)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.Items, 1; got != want {
+		t.Fatalf("items=%d want %d", got, want)
+	}
+	if got, want := stats.Matched, 1; got != want {
+		t.Fatalf("matched=%d want %d", got, want)
+	}
+	if got, want := stats.Modified, 1; got != want {
+		t.Fatalf("modified=%d want %d", got, want)
+	}
+	if got, want := stats.Indexes, 3; got != want {
+		t.Fatalf("indexes=%d want %d", got, want)
+	}
+	if got, want := stats.Runs, 3; got != want {
+		t.Fatalf("runs=%d want primary/index-state/city roots", got)
+	}
+	if got, want := stats.IndexValueChanges, 1; got != want {
+		t.Fatalf("index changes=%d want %d", got, want)
+	}
+	if got, want := stats.IndexValueUnchanged, 2; got != want {
+		t.Fatalf("index unchanged=%d want %d", got, want)
+	}
+	if got, want := stats.UniqueIndexChecks, 0; got != want {
+		t.Fatalf("unique checks=%d want %d", got, want)
+	}
+	if got, want := stats.UniqueIndexCheckSkips, 1; got != want {
+		t.Fatalf("unique skips=%d want %d", got, want)
+	}
+	if got, want := stats.SecondaryDeleteEntries, 1; got != want {
+		t.Fatalf("secondary deletes=%d want %d", got, want)
+	}
+	if got, want := stats.SecondarySetEntries, 1; got != want {
+		t.Fatalf("secondary sets=%d want %d", got, want)
+	}
+	if got := stats.SecondaryKeyBytes; got == 0 {
+		t.Fatal("secondary key bytes=0 want positive")
+	}
+	if got, want := len(stats.SecondaryRuns), 1; got != want {
+		t.Fatalf("secondary runs=%d want %d: %+v", got, want, stats.SecondaryRuns)
+	}
+	if run := stats.SecondaryRuns[0]; run.IndexName != "city" || run.Deletes != 1 || run.Sets != 1 || run.KeyBytes == 0 {
+		t.Fatalf("city secondary run stats=%+v want delete+set with key bytes", run)
+	}
+	indexStats := stats.IndexStats[:stats.IndexStatsCount]
+	if got, want := len(indexStats), 3; got != want {
+		t.Fatalf("index stats=%d want %d: %+v", got, want, stats.IndexStats)
+	}
+	directUpdateStatsRequireIndex(t, indexStats, "email", true, 0, 1, 0, 1, 0, 0, 0)
+	directUpdateStatsRequireIndex(t, indexStats, "city", false, 1, 0, 0, 0, 1, 1, 1)
+	directUpdateStatsRequireIndex(t, indexStats, "active", false, 0, 1, 0, 0, 0, 0, 0)
+
+	stats.SecondaryRuns[0].IndexName = "mutated"
+	if got := col.LastUpdateStats().SecondaryRuns[0].IndexName; got != "city" {
+		t.Fatalf("LastUpdateStats did not return owned secondary-run stats, got %q", got)
+	}
+}
+
+func TestCollectionDirectUpdateStatsForNoopAndMissingDocument(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","seen":false}`)},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		return current, false, nil
+	})
+	if err != nil {
+		t.Fatalf("noop update: %v", err)
+	}
+	if !matched || modified {
+		t.Fatalf("noop update matched/modified=%v/%v want true/false", matched, modified)
+	}
+	stats := col.LastUpdateStats()
+	if stats.Items != 1 || stats.Matched != 1 || stats.Modified != 0 || stats.Runs != 0 || stats.IndexValueChanges != 0 || stats.IndexValueUnchanged != 0 {
+		t.Fatalf("noop stats=%+v want one matched unmodified item and no root/index work", stats)
+	}
+
+	matched, modified, err = col.Update([]byte("missing"), func(current []byte) ([]byte, bool, error) {
+		t.Fatalf("callback should not run for missing document: %q", current)
+		return nil, false, nil
+	})
+	if err != nil {
+		t.Fatalf("missing update: %v", err)
+	}
+	if matched || modified {
+		t.Fatalf("missing update matched/modified=%v/%v want false/false", matched, modified)
+	}
+	stats = col.LastUpdateStats()
+	if stats.Items != 1 || stats.Matched != 0 || stats.Modified != 0 || stats.Runs != 0 || stats.IndexValueChanges != 0 || stats.IndexValueUnchanged != 0 {
+		t.Fatalf("missing stats=%+v want one unmatched item and no root/index work", stats)
+	}
+}
+
+func directUpdateStatsRequireIndex(
+	t *testing.T,
+	stats []CollectionUpdateIndexStats,
+	name string,
+	unique bool,
+	changed, unchanged, uniqueChecks, uniqueSkips, secondaryRuns, secondaryDeletes, secondarySets int,
+) {
+	t.Helper()
+	for _, stat := range stats {
+		if stat.IndexName != name {
+			continue
+		}
+		if stat.Unique != unique ||
+			stat.Changed != changed ||
+			stat.Unchanged != unchanged ||
+			stat.UniqueChecks != uniqueChecks ||
+			stat.UniqueCheckSkips != uniqueSkips ||
+			stat.SecondaryRuns != secondaryRuns ||
+			stat.SecondaryDeletes != secondaryDeletes ||
+			stat.SecondarySets != secondarySets {
+			t.Fatalf("index %s stats=%+v want unique=%v changed=%d unchanged=%d uniqueChecks=%d uniqueSkips=%d secondaryRuns=%d deletes=%d sets=%d",
+				name, stat, unique, changed, unchanged, uniqueChecks, uniqueSkips, secondaryRuns, secondaryDeletes, secondarySets)
+		}
+		return
+	}
+	t.Fatalf("missing index stats for %q in %+v", name, stats)
+}


### PR DESCRIPTION
## Summary

Implements a small #1242 PR 2 observability tightening for the direct single-document `Update` path:

- populates `CollectionUpdateStats` for successful direct update outcomes, including matched/no-op/missing cases;
- records changed/unchanged index decisions, unique check/skip counts, secondary delete/set/key-byte work, secondary-run stats, and detailed per-index stats when enabled;
- keeps update semantics unchanged and reuses the existing stats shape instead of adding a broad new metrics subsystem.

## Tests

```sh
go test ./TreeDB/collections -run 'TestCollectionDirectUpdate.*Stats' -count=1
go test ./TreeDB/collections -count=1
```
