### PR TITLE
unified_bench: include TreeDB stats in benchprof artifacts

### DIFF
--- a/cmd/benchprof/README.md
+++ b/cmd/benchprof/README.md
@@ -60,6 +60,9 @@ Outputs:
   - `checkpoint_cpu_checkpoint_<test>_<db>.pprof` (checkpoint CPU sections)
   - `block.pprof` / `mutex.pprof` (global run-level fallback/supplement)
   - `trace.out` (detected, but not deeply analyzed yet)
+- `benchprof_results.json` preserves selected TreeDB stats under
+  `runs[].treedb_stats` when the benchmark exposes them. This is the raw
+  counter metadata used for TreeDB root-apply/cache review artifacts.
 - Optional flags:
   - `-bin` if you want explicit symbolization target (otherwise profile-only mode is used)
   - `-run-md` to force a specific markdown log file for ops/sec parsing

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -190,6 +190,10 @@ This writes:
 - `block.pprof`, `mutex.pprof`, `trace.out`
 - `insights.md`, `insights.json`, `insights.html` (from `benchprof`)
 
+For TreeDB runs, `benchprof_results.json` also preserves selected TreeDB stats
+under `runs[].treedb_stats`, including ordered-root/root-apply and cache
+counters used by raw-engine review gates.
+
 ## Notes
 
 TreeDB is a cached engine (memtable + background flush). If you run long write-heavy phases and then measure `random_read`/scans immediately, the results can be dominated by background flush work (“flush debt”).

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -31,6 +31,7 @@ import (
 
 	treedb "github.com/snissn/gomap/TreeDB"
 	treedbdb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/cmd/internal/treedbstats"
 	"github.com/snissn/gomap/internal/benchprof"
 	"github.com/snissn/gomap/kvstore"
 	treedbadapter "github.com/snissn/gomap/kvstore/adapters/treedb"
@@ -252,6 +253,7 @@ type benchprofExportRun struct {
 	ExecutionPath string                                  `json:"execution_path,omitempty"`
 	Results       map[string]map[string]float64           `json:"results,omitempty"`
 	TreeDBPerf    map[string]map[string]treeDBPerfMetrics `json:"treedb_perf,omitempty"`
+	TreeDBStats   map[string]map[string]string            `json:"treedb_stats,omitempty"`
 }
 
 type scanDiag struct {
@@ -1072,6 +1074,7 @@ func writeBenchprofArtifacts(dir, executionPath string, runs []BenchRun) error {
 			ExecutionPath: executionPath,
 			Results:       run.Results,
 			TreeDBPerf:    run.TreeDBPerf,
+			TreeDBStats:   selectedBenchprofTreeDBStats(run.TreeDBStats),
 		})
 	}
 
@@ -1096,6 +1099,24 @@ func writeBenchprofArtifacts(dir, executionPath string, runs []BenchRun) error {
 		return fmt.Errorf("write benchprof_results.md: %w", err)
 	}
 	return nil
+}
+
+func selectedBenchprofTreeDBStats(stats map[string]map[string]string) map[string]map[string]string {
+	if len(stats) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]string)
+	for dbName, dbStats := range stats {
+		selected := treedbstats.Selected(dbStats)
+		if len(selected) == 0 {
+			continue
+		}
+		out[dbName] = selected
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func validateBenchprofExecutionPath(executionPath string) error {

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -1400,7 +1400,9 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 			},
 			TreeDBStats: map[string]map[string]string{
 				"TreeDB": {
-					"treedb.cache.vlog_mmap.read.hits": "10",
+					"treedb.cache.vlog_mmap.read.hits":                               "10",
+					"treedb.publish.ordered_root_delta_group.root_apply_calls_total": "4",
+					"treedb.unselected":                                              "drop",
 				},
 			},
 		},
@@ -1446,6 +1448,12 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 	if got := parsed.Runs[0].TreeDBPerf["full_scan"]["TreeDB"].Mmap.Hits; got != 10 {
 		t.Fatalf("unexpected TreeDB perf mmap hits: %v", got)
 	}
+	if got := parsed.Runs[0].TreeDBStats["TreeDB"]["treedb.publish.ordered_root_delta_group.root_apply_calls_total"]; got != "4" {
+		t.Fatalf("unexpected TreeDB selected stat root_apply_calls_total=%q", got)
+	}
+	if _, ok := parsed.Runs[0].TreeDBStats["TreeDB"]["treedb.unselected"]; ok {
+		t.Fatalf("unselected TreeDB stat was exported: %#v", parsed.Runs[0].TreeDBStats["TreeDB"])
+	}
 	var raw map[string]any
 	if err := json.Unmarshal(data, &raw); err != nil {
 		t.Fatalf("unmarshal raw json: %v", err)
@@ -1458,8 +1466,8 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected raw run object, got %#v", runsValue[0])
 	}
-	if _, ok := runValue["treedb_stats"]; ok {
-		t.Fatalf("expected treedb_stats to be omitted from benchprof json, got: %#v", runValue["treedb_stats"])
+	if _, ok := runValue["treedb_stats"]; !ok {
+		t.Fatalf("expected treedb_stats in benchprof json, got: %#v", runValue)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a small #1242 PR 1b benchprof artifact follow-up now that `internal/benchprof` is source-groundable:

- includes selected TreeDB stats in `benchprof_results.json` under `treedb_stats`;
- filters through the shared `cmd/internal/treedbstats` allowlist so ordered-root/root-apply/cache counters are preserved without dumping every stat;
- updates the artifact test to prove selected ordered-root stats are retained and unselected stats are omitted.

No benchmark workload or TreeDB storage behavior changes are included.

## Tests

```sh
go test ./cmd/unified_bench -run 'TestWriteBenchprofArtifacts' -count=1
go test ./cmd/unified_bench ./cmd/internal/treedbstats -count=1
```
