### PR TITLE
collections: centralize pending unique reservation probes

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3603,6 +3603,25 @@ func pendingIndexedUniqueValueRunMapLocked(domain *collectionWriteDomain) map[st
 	return indexedFlushUnitPendingUniqueValueRunMap(indexedFlushUnitsWithPublishing(domain.indexedPublishingUnits, domain.indexedFlushUnits), domain.uniqueValueRuns)
 }
 
+func pendingUniqueReservationIndexLocked(domain *collectionWriteDomain, indexName string) *bufferedUniqueValueIndex {
+	if domain == nil || indexName == "" {
+		return nil
+	}
+	if index := domain.uniqueValueIndex[indexName]; index != nil {
+		return index
+	}
+	runs := pendingIndexedUniqueValueRunMapLocked(domain)[indexName]
+	if len(runs) == 0 {
+		return nil
+	}
+	return rebuildBufferedUniqueValueIndexes(map[string][]memtable.Table{indexName: runs})[indexName]
+}
+
+func pendingUniqueReservationProbeLocked(domain *collectionWriteDomain, indexName string, valuePrefix []byte) bool {
+	index := pendingUniqueReservationIndexLocked(domain, indexName)
+	return index != nil && index.contains(valuePrefix)
+}
+
 func rebuildBufferedPendingIndexesLocked(domain *collectionWriteDomain, collectionName string, preservePrimaryRunIndex bool) {
 	if domain == nil {
 		return
@@ -3829,7 +3848,7 @@ func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collecti
 		if _, ok := uniqueIndexes[run.indexName]; !ok {
 			continue
 		}
-		pending := domain.uniqueValueIndex[run.indexName]
+		pending := pendingUniqueReservationIndexLocked(domain, run.indexName)
 		if pending == nil || pending.len() == 0 {
 			continue
 		}
@@ -10927,7 +10946,7 @@ func bufferedIndexPrefixTableLocked(domain *collectionWriteDomain, collectionNam
 		return nil, nil
 	}
 	if unique {
-		pending := domain.uniqueValueIndex[indexName]
+		pending := pendingUniqueReservationIndexLocked(domain, indexName)
 		if pending != nil && !pending.contains(prefix) {
 			return nil, nil
 		}

--- a/TreeDB/collections/pending_unique_probe_test.go
+++ b/TreeDB/collections/pending_unique_probe_test.go
@@ -1,0 +1,66 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+)
+
+func TestPendingUniqueReservationProbeIncludesPublishingQueuedAndMutable(t *testing.T) {
+	const indexName = "email"
+	activePrefix := collectionTestUniquePrefix(t, "active@example.com")
+	queuedPrefix := collectionTestUniquePrefix(t, "queued@example.com")
+	mutablePrefix := collectionTestUniquePrefix(t, "mutable@example.com")
+	domain := &collectionWriteDomain{
+		indexedPublishingUnits: []indexedFlushUnit{{
+			uniqueValueRuns: map[string][]memtable.Table{
+				indexName: {collectionTestUniqueRunTable(activePrefix)},
+			},
+		}},
+		indexedFlushUnits: []indexedFlushUnit{{
+			uniqueValueRuns: map[string][]memtable.Table{
+				indexName: {collectionTestUniqueRunTable(queuedPrefix)},
+			},
+		}},
+		uniqueValueRuns: map[string][]memtable.Table{
+			indexName: {collectionTestUniqueRunTable(mutablePrefix)},
+		},
+	}
+	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(pendingIndexedUniqueValueRunMapLocked(domain))
+
+	for _, tt := range []struct {
+		name   string
+		prefix []byte
+	}{
+		{name: "active", prefix: activePrefix},
+		{name: "queued", prefix: queuedPrefix},
+		{name: "mutable", prefix: mutablePrefix},
+	} {
+		if !pendingUniqueReservationProbeLocked(domain, indexName, tt.prefix) {
+			t.Fatalf("pending unique probe missed %s reservation", tt.name)
+		}
+	}
+	if pendingUniqueReservationProbeLocked(domain, indexName, collectionTestUniquePrefix(t, "durable@example.com")) {
+		t.Fatal("pending unique probe reported absent durable-only value")
+	}
+}
+
+func collectionTestUniqueRunTable(prefix []byte) memtable.Table {
+	table := newCollectionRunTable(1)
+	setCollectionRunValue(table, append([]byte(nil), prefix...), nil)
+	table.Freeze()
+	return table
+}
+
+func collectionTestUniquePrefix(tb testing.TB, value string) []byte {
+	tb.Helper()
+	encoded, err := encodeIndexScalar(IndexValueString, value)
+	if err != nil {
+		tb.Fatalf("encode value %q: %v", value, err)
+	}
+	_, prefix, err := appendIndexValuePrefixSlice(nil, encoded)
+	if err != nil {
+		tb.Fatalf("prefix value %q: %v", value, err)
+	}
+	return prefix
+}


### PR DESCRIPTION
## Summary

Adds a small #1242 PR 1a unique-reservation guardrail:

- routes pending unique reservation lookups through `pendingUniqueReservationIndexLocked` / `pendingUniqueReservationProbeLocked`;
- uses the helper in buffered insert conflict checks and unique exact-prefix scan pruning;
- adds direct coverage proving the probe sees active/publishing, queued, and mutable pending unique layers.

This preserves current inferred-reservation behavior and does not implement PR 3b semantic unique ownership or changed-unique update buffering.

## Tests

```sh
go test ./TreeDB/collections -run 'TestPendingUniqueReservationProbeIncludesPublishingQueuedAndMutable|TestCollectionIndexedWriteMemtablesAsyncQueuedUnitsParticipateInUniqueChecks|TestCollectionIndexedWriteMemtablesAsyncPublishingUnitsParticipateInReadsAndUniqueChecks' -count=1
go test ./TreeDB/collections -count=1
```
