### PR TITLE
collections: count indexed flush guard transitions

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -401,53 +401,57 @@ type CollectionUpdateIndexStats struct {
 // CollectionManager. The counters are process-local observability; they are
 // not persisted with collection metadata.
 type CollectionManagerStats struct {
-	Domains                       int
-	PendingDocuments              int
-	PendingBytes                  int64
-	PendingRootRuns               int
-	PendingIndexedFlushUnits      int
-	IndexedAsyncFlushRunning      int
-	MutationLockCalls             uint64
-	MutationLockWait              time.Duration
-	MutationLockHold              time.Duration
-	IndexedStageBatches           uint64
-	IndexedStageDocs              uint64
-	IndexedStageBytes             uint64
-	IndexedStageRootRuns          uint64
-	IndexedAutoFlushes            uint64
-	IndexedAsyncFlushScheduled    uint64
-	IndexedAsyncFlushBackpressure uint64
-	IndexedAsyncFlushErrors       uint64
-	IndexedFlushCalls             uint64
-	IndexedFlushErrors            uint64
-	IndexedFlushDocs              uint64
-	IndexedFlushBytes             uint64
-	IndexedFlushRootRuns          uint64
-	IndexedFlushRoots             uint64
-	IndexedFlushDuration          time.Duration
-	IndexedFlushMaterialize       time.Duration
-	IndexedFlushPublish           time.Duration
-	UpdateCombineRequests         uint64
-	UpdateCombineBatches          uint64
-	UpdateCombineBatchedRequests  uint64
-	UpdateCombineFallbackRequests uint64
-	UpdateCombineQueueDepthMax    uint64
-	UpdateBatchCalls              uint64
-	UpdateBatchItems              uint64
-	UpdateBatchMatched            uint64
-	UpdateBatchModified           uint64
-	UpdateBatchRuns               uint64
-	UpdateBatchBufferedBatches    uint64
-	UpdateBatchCurrentRead        time.Duration
-	UpdateBatchCallback           time.Duration
-	UpdateBatchPrepareDocuments   time.Duration
-	UpdateBatchIndexStateExtract  time.Duration
-	UpdateBatchUniquePreflight    time.Duration
-	UpdateBatchTemplateRunBuild   time.Duration
-	UpdateBatchPrimaryRunBuild    time.Duration
-	UpdateBatchIndexStateRunBuild time.Duration
-	UpdateBatchSecondaryRunBuild  time.Duration
-	UpdateBatchBufferStage        time.Duration
+	Domains                        int
+	PendingDocuments               int
+	PendingBytes                   int64
+	PendingRootRuns                int
+	PendingIndexedFlushUnits       int
+	IndexedAsyncFlushRunning       int
+	MutationLockCalls              uint64
+	MutationLockWait               time.Duration
+	MutationLockHold               time.Duration
+	IndexedStageBatches            uint64
+	IndexedStageDocs               uint64
+	IndexedStageBytes              uint64
+	IndexedStageRootRuns           uint64
+	IndexedAutoFlushes             uint64
+	IndexedAsyncFlushScheduled     uint64
+	IndexedAsyncFlushBackpressure  uint64
+	IndexedAsyncFlushErrors        uint64
+	IndexedFlushCalls              uint64
+	IndexedFlushErrors             uint64
+	IndexedFlushRequeues           uint64
+	IndexedFlushRequeuedUnits      uint64
+	IndexedFlushLostOwnership      uint64
+	IndexedFlushRootBaseMismatches uint64
+	IndexedFlushDocs               uint64
+	IndexedFlushBytes              uint64
+	IndexedFlushRootRuns           uint64
+	IndexedFlushRoots              uint64
+	IndexedFlushDuration           time.Duration
+	IndexedFlushMaterialize        time.Duration
+	IndexedFlushPublish            time.Duration
+	UpdateCombineRequests          uint64
+	UpdateCombineBatches           uint64
+	UpdateCombineBatchedRequests   uint64
+	UpdateCombineFallbackRequests  uint64
+	UpdateCombineQueueDepthMax     uint64
+	UpdateBatchCalls               uint64
+	UpdateBatchItems               uint64
+	UpdateBatchMatched             uint64
+	UpdateBatchModified            uint64
+	UpdateBatchRuns                uint64
+	UpdateBatchBufferedBatches     uint64
+	UpdateBatchCurrentRead         time.Duration
+	UpdateBatchCallback            time.Duration
+	UpdateBatchPrepareDocuments    time.Duration
+	UpdateBatchIndexStateExtract   time.Duration
+	UpdateBatchUniquePreflight     time.Duration
+	UpdateBatchTemplateRunBuild    time.Duration
+	UpdateBatchPrimaryRunBuild     time.Duration
+	UpdateBatchIndexStateRunBuild  time.Duration
+	UpdateBatchSecondaryRunBuild   time.Duration
+	UpdateBatchBufferStage         time.Duration
 	// Detailed buffer-stage aggregate timings are populated only when
 	// CollectionManager.SetUpdateBatchDetailedStatsEnabled(true) is enabled.
 	// UpdateBatchBufferLockHold is an enclosing domain mutex hold-time metric
@@ -745,6 +749,10 @@ type collectionWriteDomain struct {
 	indexedAsyncFlushErrors          atomic.Uint64
 	indexedFlushCalls                atomic.Uint64
 	indexedFlushErrors               atomic.Uint64
+	indexedFlushRequeues             atomic.Uint64
+	indexedFlushRequeuedUnits        atomic.Uint64
+	indexedFlushLostOwnership        atomic.Uint64
+	indexedFlushRootBaseMismatches   atomic.Uint64
 	indexedFlushDocs                 atomic.Uint64
 	indexedFlushBytes                atomic.Uint64
 	indexedFlushRootRuns             atomic.Uint64
@@ -967,6 +975,10 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_async_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushErrors)
 	out["treedb.collections.write_domain.indexed_flush.calls_total"] = fmt.Sprintf("%d", stats.IndexedFlushCalls)
 	out["treedb.collections.write_domain.indexed_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedFlushErrors)
+	out["treedb.collections.write_domain.indexed_flush.requeue_total"] = fmt.Sprintf("%d", stats.IndexedFlushRequeues)
+	out["treedb.collections.write_domain.indexed_flush.requeued_units_total"] = fmt.Sprintf("%d", stats.IndexedFlushRequeuedUnits)
+	out["treedb.collections.write_domain.indexed_flush.lost_ownership_total"] = fmt.Sprintf("%d", stats.IndexedFlushLostOwnership)
+	out["treedb.collections.write_domain.indexed_flush.root_base_mismatch_total"] = fmt.Sprintf("%d", stats.IndexedFlushRootBaseMismatches)
 	out["treedb.collections.write_domain.indexed_flush.docs_total"] = fmt.Sprintf("%d", stats.IndexedFlushDocs)
 	out["treedb.collections.write_domain.indexed_flush.bytes_total"] = fmt.Sprintf("%d", stats.IndexedFlushBytes)
 	out["treedb.collections.write_domain.indexed_flush.root_runs_total"] = fmt.Sprintf("%d", stats.IndexedFlushRootRuns)
@@ -1138,6 +1150,10 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.IndexedAsyncFlushErrors += other.IndexedAsyncFlushErrors
 	s.IndexedFlushCalls += other.IndexedFlushCalls
 	s.IndexedFlushErrors += other.IndexedFlushErrors
+	s.IndexedFlushRequeues += other.IndexedFlushRequeues
+	s.IndexedFlushRequeuedUnits += other.IndexedFlushRequeuedUnits
+	s.IndexedFlushLostOwnership += other.IndexedFlushLostOwnership
+	s.IndexedFlushRootBaseMismatches += other.IndexedFlushRootBaseMismatches
 	s.IndexedFlushDocs += other.IndexedFlushDocs
 	s.IndexedFlushBytes += other.IndexedFlushBytes
 	s.IndexedFlushRootRuns += other.IndexedFlushRootRuns
@@ -1229,6 +1245,10 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.IndexedAsyncFlushErrors = domain.indexedAsyncFlushErrors.Load()
 	stats.IndexedFlushCalls = domain.indexedFlushCalls.Load()
 	stats.IndexedFlushErrors = domain.indexedFlushErrors.Load()
+	stats.IndexedFlushRequeues = domain.indexedFlushRequeues.Load()
+	stats.IndexedFlushRequeuedUnits = domain.indexedFlushRequeuedUnits.Load()
+	stats.IndexedFlushLostOwnership = domain.indexedFlushLostOwnership.Load()
+	stats.IndexedFlushRootBaseMismatches = domain.indexedFlushRootBaseMismatches.Load()
 	stats.IndexedFlushDocs = domain.indexedFlushDocs.Load()
 	stats.IndexedFlushBytes = domain.indexedFlushBytes.Load()
 	stats.IndexedFlushRootRuns = domain.indexedFlushRootRuns.Load()
@@ -2527,6 +2547,9 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 			}
 			return nil
 		}); err != nil {
+			if errors.Is(err, ErrConcurrentMutation) {
+				domain.indexedFlushRootBaseMismatches.Add(1)
+			}
 			return nil, err
 		}
 	} else {
@@ -4630,6 +4653,9 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		}
 		return nil
 	}); err != nil {
+		if errors.Is(err, ErrConcurrentMutation) {
+			domain.indexedFlushRootBaseMismatches.Add(1)
+		}
 		return nil, err
 	}
 
@@ -4925,6 +4951,10 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	preservePrimaryRunIndex := domain.primaryRunIndex != nil
 	if publishErr != nil {
 		if removed, ok := removeIndexedPublishingWorkUnitsLocked(domain, work.units); ok {
+			if len(removed) > 0 {
+				domain.indexedFlushRequeues.Add(1)
+				domain.indexedFlushRequeuedUnits.Add(uint64(len(removed)))
+			}
 			domain.indexedFlushUnits = append(removed, domain.indexedFlushUnits...)
 		}
 		rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
@@ -4944,6 +4974,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
 		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
+		domain.indexedFlushLostOwnership.Add(1)
 		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, err)
 		return err
 	}

--- a/TreeDB/collections/indexed_flush_guard_counters_test.go
+++ b/TreeDB/collections/indexed_flush_guard_counters_test.go
@@ -1,0 +1,164 @@
+package collections
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionIndexedFlushGuardCounters(t *testing.T) {
+	t.Run("publish_error_requeue", func(t *testing.T) {
+		d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		mgr, col := collectionTestIndexedFlushCounterCollection(t, d)
+		if _, err := col.InsertBatch(
+			[][]byte{[]byte("u1")},
+			[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+		); err != nil {
+			t.Fatalf("insert buffered batch: %v", err)
+		}
+		work, err := col.prepareIndexedAsyncPublish()
+		if err != nil {
+			t.Fatalf("prepare async publish: %v", err)
+		}
+		if work == nil {
+			t.Fatal("prepare async publish returned nil work")
+		}
+		defer collectionTestCloseIndexedFlushWork(work)
+
+		injectedErr := errors.New("injected publish failure")
+		if err := col.completePreparedIndexedFlush(work, 0, nil, injectedErr, 0, 0, 0); !errors.Is(err, injectedErr) {
+			t.Fatalf("complete failure err=%v want injected error", err)
+		}
+		stats := mgr.StatsSnapshot()
+		if got := stats.IndexedFlushRequeues; got != 1 {
+			t.Fatalf("indexed flush requeues=%d want 1", got)
+		}
+		if got := stats.IndexedFlushRequeuedUnits; got != 1 {
+			t.Fatalf("indexed flush requeued units=%d want 1", got)
+		}
+		if got := mgr.Stats()["treedb.collections.write_domain.indexed_flush.requeue_total"]; got != "1" {
+			t.Fatalf("requeue stat=%q want 1", got)
+		}
+	})
+
+	t.Run("lost_ownership", func(t *testing.T) {
+		d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		mgr, col := collectionTestIndexedFlushCounterCollection(t, d)
+		if _, err := col.InsertBatch(
+			[][]byte{[]byte("u1")},
+			[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+		); err != nil {
+			t.Fatalf("insert buffered batch: %v", err)
+		}
+		work, err := col.prepareIndexedAsyncPublish()
+		if err != nil {
+			t.Fatalf("prepare async publish: %v", err)
+		}
+		if work == nil {
+			t.Fatal("prepare async publish returned nil work")
+		}
+		defer collectionTestCloseIndexedFlushWork(work)
+
+		col.writeDomain.mu.Lock()
+		col.writeDomain.indexedPublishingUnits = []indexedFlushUnit{{}}
+		col.writeDomain.mu.Unlock()
+		rootIDs := make([]uint64, len(work.rootNames))
+		for i := range rootIDs {
+			rootIDs[i] = uint64(1000 + i)
+		}
+		err = col.completePreparedIndexedFlush(work, 999, rootIDs, nil, 0, 0, 0)
+		if err == nil || !strings.Contains(err.Error(), "lost ownership") {
+			t.Fatalf("complete err=%v want lost ownership", err)
+		}
+		stats := mgr.StatsSnapshot()
+		if got := stats.IndexedFlushLostOwnership; got != 1 {
+			t.Fatalf("indexed flush lost ownership=%d want 1", got)
+		}
+		if got := mgr.Stats()["treedb.collections.write_domain.indexed_flush.lost_ownership_total"]; got != "1" {
+			t.Fatalf("lost ownership stat=%q want 1", got)
+		}
+	})
+
+	t.Run("root_base_mismatch", func(t *testing.T) {
+		d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		leftMgr, left := collectionTestIndexedFlushCounterCollection(t, d)
+		if _, err := left.InsertBatch(
+			[][]byte{[]byte("u1")},
+			[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+		); err != nil {
+			t.Fatalf("stage left pending insert: %v", err)
+		}
+
+		right, err := NewCollectionManager(d).OpenCollection("users")
+		if err != nil {
+			t.Fatalf("open right collection: %v", err)
+		}
+		if _, err := right.InsertBatch(
+			[][]byte{[]byte("u2")},
+			[][]byte{[]byte(`{"email":"grace@example.com"}`)},
+		); err != nil {
+			t.Fatalf("insert right durable row: %v", err)
+		}
+		if err := right.Flush(); err != nil {
+			t.Fatalf("flush right row: %v", err)
+		}
+
+		work, err := left.prepareIndexedAsyncPublish()
+		if work != nil {
+			collectionTestCloseIndexedFlushWork(work)
+			t.Fatal("prepare returned work despite root-base mismatch")
+		}
+		if !errors.Is(err, ErrConcurrentMutation) {
+			t.Fatalf("prepare err=%v want ErrConcurrentMutation", err)
+		}
+		stats := leftMgr.StatsSnapshot()
+		if got := stats.IndexedFlushRootBaseMismatches; got != 1 {
+			t.Fatalf("indexed flush root-base mismatches=%d want 1", got)
+		}
+		if got := leftMgr.Stats()["treedb.collections.write_domain.indexed_flush.root_base_mismatch_total"]; got != "1" {
+			t.Fatalf("root-base mismatch stat=%q want 1", got)
+		}
+	})
+}
+
+func collectionTestIndexedFlushCounterCollection(tb testing.TB, d *backenddb.DB) (*CollectionManager, *Collection) {
+	tb.Helper()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		tb.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		tb.Fatalf("open collection: %v", err)
+	}
+	return mgr, col
+}
+
+func collectionTestCloseIndexedFlushWork(work *indexedFlushPublishWork) {
+	if work != nil && work.pin != nil {
+		_ = work.pin.Close()
+		work.pin = nil
+	}
+}


### PR DESCRIPTION
## Summary

Adds narrow #1242 PR 1a/1b guard counters for existing indexed flush transitions:

- publish-error requeues and requeued units;
- lost publishing ownership;
- root-base mismatch during pending indexed flush validation.

The counters are exposed through `CollectionManagerStats` and `Stats()` under `treedb.collections.write_domain.indexed_flush.*`. Existing behavior is unchanged.

## Tests

```sh
go test ./TreeDB/collections -run 'TestCollectionIndexedFlushGuardCounters' -count=1
go test ./TreeDB/collections -count=1
```
