### PR TITLE
collections: expose PR1B write-domain counters

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1285,12 +1285,13 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	domain.mu.RLock()
 	stats.PendingDocuments = domain.count
 	stats.PendingBytes = domain.bufferedBytes
-	stats.PendingRootRuns = bufferedIndexedRootRunCount(domain)
+	pendingRootRuns := bufferedIndexedRootRunCount(domain)
+	stats.PendingRootRuns = pendingRootRuns
 	stats.PendingIndexedFlushUnits = len(domain.indexedPublishingUnits) + len(domain.indexedFlushUnits)
 	stats.OverlayMutableDocuments = domain.mutableCount
 	stats.OverlayQueuedIndexedFlushUnits = len(domain.indexedFlushUnits)
 	stats.OverlayActiveIndexedFlushUnits = len(domain.indexedPublishingUnits)
-	stats.OverlayVisibleDepth = collectionWriteDomainVisibleDepthLocked(domain)
+	stats.OverlayVisibleDepth = collectionWriteDomainVisibleDepthLocked(domain, pendingRootRuns)
 	stats.UpdateBatchIndexStatsCount = len(domain.meta.Indexes)
 	if stats.UpdateBatchIndexStatsCount > len(stats.UpdateBatchIndexStats) {
 		stats.UpdateBatchIndexStatsCount = len(stats.UpdateBatchIndexStats)
@@ -1396,12 +1397,12 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	return stats
 }
 
-func collectionWriteDomainVisibleDepthLocked(domain *collectionWriteDomain) int {
+func collectionWriteDomainVisibleDepthLocked(domain *collectionWriteDomain, pendingRootRuns int) int {
 	if domain == nil {
 		return 0
 	}
 	depth := len(domain.indexedPublishingUnits) + len(domain.indexedFlushUnits)
-	if hasBufferedIndexedRootRuns(domain) {
+	if pendingRootRuns > 0 {
 		depth++
 	}
 	return depth

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/snissn/gomap/TreeDB/batch"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
@@ -401,53 +402,75 @@ type CollectionUpdateIndexStats struct {
 // CollectionManager. The counters are process-local observability; they are
 // not persisted with collection metadata.
 type CollectionManagerStats struct {
-	Domains                       int
-	PendingDocuments              int
-	PendingBytes                  int64
-	PendingRootRuns               int
-	PendingIndexedFlushUnits      int
-	IndexedAsyncFlushRunning      int
-	MutationLockCalls             uint64
-	MutationLockWait              time.Duration
-	MutationLockHold              time.Duration
-	IndexedStageBatches           uint64
-	IndexedStageDocs              uint64
-	IndexedStageBytes             uint64
-	IndexedStageRootRuns          uint64
-	IndexedAutoFlushes            uint64
-	IndexedAsyncFlushScheduled    uint64
-	IndexedAsyncFlushBackpressure uint64
-	IndexedAsyncFlushErrors       uint64
-	IndexedFlushCalls             uint64
-	IndexedFlushErrors            uint64
-	IndexedFlushDocs              uint64
-	IndexedFlushBytes             uint64
-	IndexedFlushRootRuns          uint64
-	IndexedFlushRoots             uint64
-	IndexedFlushDuration          time.Duration
-	IndexedFlushMaterialize       time.Duration
-	IndexedFlushPublish           time.Duration
-	UpdateCombineRequests         uint64
-	UpdateCombineBatches          uint64
-	UpdateCombineBatchedRequests  uint64
-	UpdateCombineFallbackRequests uint64
-	UpdateCombineQueueDepthMax    uint64
-	UpdateBatchCalls              uint64
-	UpdateBatchItems              uint64
-	UpdateBatchMatched            uint64
-	UpdateBatchModified           uint64
-	UpdateBatchRuns               uint64
-	UpdateBatchBufferedBatches    uint64
-	UpdateBatchCurrentRead        time.Duration
-	UpdateBatchCallback           time.Duration
-	UpdateBatchPrepareDocuments   time.Duration
-	UpdateBatchIndexStateExtract  time.Duration
-	UpdateBatchUniquePreflight    time.Duration
-	UpdateBatchTemplateRunBuild   time.Duration
-	UpdateBatchPrimaryRunBuild    time.Duration
-	UpdateBatchIndexStateRunBuild time.Duration
-	UpdateBatchSecondaryRunBuild  time.Duration
-	UpdateBatchBufferStage        time.Duration
+	Domains                        int
+	PendingDocuments               int
+	PendingBytes                   int64
+	PendingRootRuns                int
+	PendingIndexedFlushUnits       int
+	OverlayMutableDocuments        int
+	OverlayQueuedIndexedFlushUnits int
+	OverlayActiveIndexedFlushUnits int
+	OverlayVisibleDepth            int
+	IndexedAsyncFlushRunning       int
+	MutationLockCalls              uint64
+	MutationLockWait               time.Duration
+	MutationLockHold               time.Duration
+	IndexedStageBatches            uint64
+	IndexedStageDocs               uint64
+	IndexedStageBytes              uint64
+	IndexedStageRootRuns           uint64
+	IndexedAutoFlushes             uint64
+	IndexedAsyncFlushScheduled     uint64
+	IndexedAsyncFlushBackpressure  uint64
+	IndexedAsyncFlushErrors        uint64
+	IndexedFlushCalls              uint64
+	IndexedFlushErrors             uint64
+	IndexedFlushUnits              uint64
+	IndexedFlushDocs               uint64
+	IndexedFlushBytes              uint64
+	IndexedFlushRootRuns           uint64
+	IndexedFlushRoots              uint64
+	IndexedFlushDuration           time.Duration
+	IndexedFlushMaterialize        time.Duration
+	IndexedFlushPublish            time.Duration
+	RootDeltaPlanPrimaryRoots      uint64
+	RootDeltaPlanTemplateRoots     uint64
+	RootDeltaPlanIndexStateRoots   uint64
+	RootDeltaPlanSecondaryRoots    uint64
+	RootDeltaPlanEntries           uint64
+	RootDeltaPlanKeyBytes          uint64
+	RootDeltaPlanValueBytes        uint64
+	RootDeltaPlanTombstones        uint64
+	PrimaryOnlyUpdateCalls         uint64
+	PrimaryOnlyMatched             uint64
+	PrimaryOnlyModified            uint64
+	PrimaryOnlyBufferedCalls       uint64
+	PrimaryOnlyRootPublishes       uint64
+	PrimaryOnlyRootDeltaEntries    uint64
+	PrimaryOnlyRootDeltaKeyBytes   uint64
+	PrimaryOnlyRootDeltaValueBytes uint64
+	PrimaryOnlyCoalescedDocs       uint64
+	UpdateCombineRequests          uint64
+	UpdateCombineBatches           uint64
+	UpdateCombineBatchedRequests   uint64
+	UpdateCombineFallbackRequests  uint64
+	UpdateCombineQueueDepthMax     uint64
+	UpdateBatchCalls               uint64
+	UpdateBatchItems               uint64
+	UpdateBatchMatched             uint64
+	UpdateBatchModified            uint64
+	UpdateBatchRuns                uint64
+	UpdateBatchBufferedBatches     uint64
+	UpdateBatchCurrentRead         time.Duration
+	UpdateBatchCallback            time.Duration
+	UpdateBatchPrepareDocuments    time.Duration
+	UpdateBatchIndexStateExtract   time.Duration
+	UpdateBatchUniquePreflight     time.Duration
+	UpdateBatchTemplateRunBuild    time.Duration
+	UpdateBatchPrimaryRunBuild     time.Duration
+	UpdateBatchIndexStateRunBuild  time.Duration
+	UpdateBatchSecondaryRunBuild   time.Duration
+	UpdateBatchBufferStage         time.Duration
 	// Detailed buffer-stage aggregate timings are populated only when
 	// CollectionManager.SetUpdateBatchDetailedStatsEnabled(true) is enabled.
 	// UpdateBatchBufferLockHold is an enclosing domain mutex hold-time metric
@@ -645,6 +668,7 @@ type indexedFlushPublishWork struct {
 	byteCount          int64
 	rootRunCount       int
 	rootCount          int
+	rootDeltaStats     collectionRootDeltaPlanStats
 }
 
 type bufferedIndexedCheckpoint struct {
@@ -745,6 +769,7 @@ type collectionWriteDomain struct {
 	indexedAsyncFlushErrors          atomic.Uint64
 	indexedFlushCalls                atomic.Uint64
 	indexedFlushErrors               atomic.Uint64
+	indexedFlushUnitsTotal           atomic.Uint64
 	indexedFlushDocs                 atomic.Uint64
 	indexedFlushBytes                atomic.Uint64
 	indexedFlushRootRuns             atomic.Uint64
@@ -752,6 +777,23 @@ type collectionWriteDomain struct {
 	indexedFlushDurationTotalNs      atomic.Uint64
 	indexedFlushMaterializeTotalNs   atomic.Uint64
 	indexedFlushPublishTotalNs       atomic.Uint64
+	rootDeltaPlanPrimaryRoots        atomic.Uint64
+	rootDeltaPlanTemplateRoots       atomic.Uint64
+	rootDeltaPlanIndexStateRoots     atomic.Uint64
+	rootDeltaPlanSecondaryRoots      atomic.Uint64
+	rootDeltaPlanEntries             atomic.Uint64
+	rootDeltaPlanKeyBytes            atomic.Uint64
+	rootDeltaPlanValueBytes          atomic.Uint64
+	rootDeltaPlanTombstones          atomic.Uint64
+	primaryOnlyUpdateCalls           atomic.Uint64
+	primaryOnlyMatched               atomic.Uint64
+	primaryOnlyModified              atomic.Uint64
+	primaryOnlyBufferedCalls         atomic.Uint64
+	primaryOnlyRootPublishes         atomic.Uint64
+	primaryOnlyRootDeltaEntries      atomic.Uint64
+	primaryOnlyRootDeltaKeyBytes     atomic.Uint64
+	primaryOnlyRootDeltaValueBytes   atomic.Uint64
+	primaryOnlyCoalescedDocs         atomic.Uint64
 	updateCombineRequests            atomic.Uint64
 	updateCombineBatches             atomic.Uint64
 	updateCombineBatchedRequests     atomic.Uint64
@@ -950,6 +992,10 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.pending_bytes"] = fmt.Sprintf("%d", stats.PendingBytes)
 	out["treedb.collections.write_domain.pending_root_runs"] = fmt.Sprintf("%d", stats.PendingRootRuns)
 	out["treedb.collections.write_domain.pending_indexed_flush_units"] = fmt.Sprintf("%d", stats.PendingIndexedFlushUnits)
+	out["treedb.collections.write_domain.overlay.mutable_docs"] = fmt.Sprintf("%d", stats.OverlayMutableDocuments)
+	out["treedb.collections.write_domain.overlay.queued_indexed_flush_units"] = fmt.Sprintf("%d", stats.OverlayQueuedIndexedFlushUnits)
+	out["treedb.collections.write_domain.overlay.active_indexed_flush_units"] = fmt.Sprintf("%d", stats.OverlayActiveIndexedFlushUnits)
+	out["treedb.collections.write_domain.overlay.visible_depth"] = fmt.Sprintf("%d", stats.OverlayVisibleDepth)
 	out["treedb.collections.write_domain.indexed_async_flush.running_domains"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushRunning)
 	out["treedb.collections.write_domain.mutation_lock.calls_total"] = fmt.Sprintf("%d", stats.MutationLockCalls)
 	out["treedb.collections.write_domain.mutation_lock.wait_ns_total"] = fmt.Sprintf("%d", stats.MutationLockWait.Nanoseconds())
@@ -967,6 +1013,7 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_async_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushErrors)
 	out["treedb.collections.write_domain.indexed_flush.calls_total"] = fmt.Sprintf("%d", stats.IndexedFlushCalls)
 	out["treedb.collections.write_domain.indexed_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedFlushErrors)
+	out["treedb.collections.write_domain.indexed_flush.units_total"] = fmt.Sprintf("%d", stats.IndexedFlushUnits)
 	out["treedb.collections.write_domain.indexed_flush.docs_total"] = fmt.Sprintf("%d", stats.IndexedFlushDocs)
 	out["treedb.collections.write_domain.indexed_flush.bytes_total"] = fmt.Sprintf("%d", stats.IndexedFlushBytes)
 	out["treedb.collections.write_domain.indexed_flush.root_runs_total"] = fmt.Sprintf("%d", stats.IndexedFlushRootRuns)
@@ -974,6 +1021,23 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_flush.duration_ns_total"] = fmt.Sprintf("%d", stats.IndexedFlushDuration.Nanoseconds())
 	out["treedb.collections.write_domain.indexed_flush.materialize_ns_total"] = fmt.Sprintf("%d", stats.IndexedFlushMaterialize.Nanoseconds())
 	out["treedb.collections.write_domain.indexed_flush.publish_ns_total"] = fmt.Sprintf("%d", stats.IndexedFlushPublish.Nanoseconds())
+	out["treedb.collections.write_domain.root_delta_plan.roots.primary_total"] = fmt.Sprintf("%d", stats.RootDeltaPlanPrimaryRoots)
+	out["treedb.collections.write_domain.root_delta_plan.roots.template_total"] = fmt.Sprintf("%d", stats.RootDeltaPlanTemplateRoots)
+	out["treedb.collections.write_domain.root_delta_plan.roots.index_state_total"] = fmt.Sprintf("%d", stats.RootDeltaPlanIndexStateRoots)
+	out["treedb.collections.write_domain.root_delta_plan.roots.secondary_total"] = fmt.Sprintf("%d", stats.RootDeltaPlanSecondaryRoots)
+	out["treedb.collections.write_domain.root_delta_plan.entries_total"] = fmt.Sprintf("%d", stats.RootDeltaPlanEntries)
+	out["treedb.collections.write_domain.root_delta_plan.key_bytes_total"] = fmt.Sprintf("%d", stats.RootDeltaPlanKeyBytes)
+	out["treedb.collections.write_domain.root_delta_plan.value_bytes_total"] = fmt.Sprintf("%d", stats.RootDeltaPlanValueBytes)
+	out["treedb.collections.write_domain.root_delta_plan.tombstones_total"] = fmt.Sprintf("%d", stats.RootDeltaPlanTombstones)
+	out["treedb.collections.write_domain.primary_only.update_calls_total"] = fmt.Sprintf("%d", stats.PrimaryOnlyUpdateCalls)
+	out["treedb.collections.write_domain.primary_only.matched_total"] = fmt.Sprintf("%d", stats.PrimaryOnlyMatched)
+	out["treedb.collections.write_domain.primary_only.modified_total"] = fmt.Sprintf("%d", stats.PrimaryOnlyModified)
+	out["treedb.collections.write_domain.primary_only.buffered_calls_total"] = fmt.Sprintf("%d", stats.PrimaryOnlyBufferedCalls)
+	out["treedb.collections.write_domain.primary_only.root_publishes_total"] = fmt.Sprintf("%d", stats.PrimaryOnlyRootPublishes)
+	out["treedb.collections.write_domain.primary_only.root_delta_entries_total"] = fmt.Sprintf("%d", stats.PrimaryOnlyRootDeltaEntries)
+	out["treedb.collections.write_domain.primary_only.root_delta_key_bytes_total"] = fmt.Sprintf("%d", stats.PrimaryOnlyRootDeltaKeyBytes)
+	out["treedb.collections.write_domain.primary_only.root_delta_value_bytes_total"] = fmt.Sprintf("%d", stats.PrimaryOnlyRootDeltaValueBytes)
+	out["treedb.collections.write_domain.primary_only.coalesced_docs_total"] = fmt.Sprintf("%d", stats.PrimaryOnlyCoalescedDocs)
 	out["treedb.collections.write_domain.update_combine.requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineRequests)
 	out["treedb.collections.write_domain.update_combine.batches_total"] = fmt.Sprintf("%d", stats.UpdateCombineBatches)
 	out["treedb.collections.write_domain.update_combine.batched_requests_total"] = fmt.Sprintf("%d", stats.UpdateCombineBatchedRequests)
@@ -1124,6 +1188,10 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.PendingBytes = saturatingAddNonNegativeInt64(s.PendingBytes, other.PendingBytes)
 	s.PendingRootRuns = saturatingAddNonNegativeInt(s.PendingRootRuns, other.PendingRootRuns)
 	s.PendingIndexedFlushUnits = saturatingAddNonNegativeInt(s.PendingIndexedFlushUnits, other.PendingIndexedFlushUnits)
+	s.OverlayMutableDocuments = saturatingAddNonNegativeInt(s.OverlayMutableDocuments, other.OverlayMutableDocuments)
+	s.OverlayQueuedIndexedFlushUnits = saturatingAddNonNegativeInt(s.OverlayQueuedIndexedFlushUnits, other.OverlayQueuedIndexedFlushUnits)
+	s.OverlayActiveIndexedFlushUnits = saturatingAddNonNegativeInt(s.OverlayActiveIndexedFlushUnits, other.OverlayActiveIndexedFlushUnits)
+	s.OverlayVisibleDepth = saturatingAddNonNegativeInt(s.OverlayVisibleDepth, other.OverlayVisibleDepth)
 	s.IndexedAsyncFlushRunning = saturatingAddNonNegativeInt(s.IndexedAsyncFlushRunning, other.IndexedAsyncFlushRunning)
 	s.MutationLockCalls += other.MutationLockCalls
 	s.MutationLockWait += other.MutationLockWait
@@ -1138,6 +1206,7 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.IndexedAsyncFlushErrors += other.IndexedAsyncFlushErrors
 	s.IndexedFlushCalls += other.IndexedFlushCalls
 	s.IndexedFlushErrors += other.IndexedFlushErrors
+	s.IndexedFlushUnits += other.IndexedFlushUnits
 	s.IndexedFlushDocs += other.IndexedFlushDocs
 	s.IndexedFlushBytes += other.IndexedFlushBytes
 	s.IndexedFlushRootRuns += other.IndexedFlushRootRuns
@@ -1145,6 +1214,23 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.IndexedFlushDuration += other.IndexedFlushDuration
 	s.IndexedFlushMaterialize += other.IndexedFlushMaterialize
 	s.IndexedFlushPublish += other.IndexedFlushPublish
+	s.RootDeltaPlanPrimaryRoots += other.RootDeltaPlanPrimaryRoots
+	s.RootDeltaPlanTemplateRoots += other.RootDeltaPlanTemplateRoots
+	s.RootDeltaPlanIndexStateRoots += other.RootDeltaPlanIndexStateRoots
+	s.RootDeltaPlanSecondaryRoots += other.RootDeltaPlanSecondaryRoots
+	s.RootDeltaPlanEntries += other.RootDeltaPlanEntries
+	s.RootDeltaPlanKeyBytes += other.RootDeltaPlanKeyBytes
+	s.RootDeltaPlanValueBytes += other.RootDeltaPlanValueBytes
+	s.RootDeltaPlanTombstones += other.RootDeltaPlanTombstones
+	s.PrimaryOnlyUpdateCalls += other.PrimaryOnlyUpdateCalls
+	s.PrimaryOnlyMatched += other.PrimaryOnlyMatched
+	s.PrimaryOnlyModified += other.PrimaryOnlyModified
+	s.PrimaryOnlyBufferedCalls += other.PrimaryOnlyBufferedCalls
+	s.PrimaryOnlyRootPublishes += other.PrimaryOnlyRootPublishes
+	s.PrimaryOnlyRootDeltaEntries += other.PrimaryOnlyRootDeltaEntries
+	s.PrimaryOnlyRootDeltaKeyBytes += other.PrimaryOnlyRootDeltaKeyBytes
+	s.PrimaryOnlyRootDeltaValueBytes += other.PrimaryOnlyRootDeltaValueBytes
+	s.PrimaryOnlyCoalescedDocs += other.PrimaryOnlyCoalescedDocs
 	s.UpdateCombineRequests += other.UpdateCombineRequests
 	s.UpdateCombineBatches += other.UpdateCombineBatches
 	s.UpdateCombineBatchedRequests += other.UpdateCombineBatchedRequests
@@ -1201,6 +1287,10 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.PendingBytes = domain.bufferedBytes
 	stats.PendingRootRuns = bufferedIndexedRootRunCount(domain)
 	stats.PendingIndexedFlushUnits = len(domain.indexedPublishingUnits) + len(domain.indexedFlushUnits)
+	stats.OverlayMutableDocuments = domain.mutableCount
+	stats.OverlayQueuedIndexedFlushUnits = len(domain.indexedFlushUnits)
+	stats.OverlayActiveIndexedFlushUnits = len(domain.indexedPublishingUnits)
+	stats.OverlayVisibleDepth = collectionWriteDomainVisibleDepthLocked(domain)
 	stats.UpdateBatchIndexStatsCount = len(domain.meta.Indexes)
 	if stats.UpdateBatchIndexStatsCount > len(stats.UpdateBatchIndexStats) {
 		stats.UpdateBatchIndexStatsCount = len(stats.UpdateBatchIndexStats)
@@ -1229,6 +1319,7 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.IndexedAsyncFlushErrors = domain.indexedAsyncFlushErrors.Load()
 	stats.IndexedFlushCalls = domain.indexedFlushCalls.Load()
 	stats.IndexedFlushErrors = domain.indexedFlushErrors.Load()
+	stats.IndexedFlushUnits = domain.indexedFlushUnitsTotal.Load()
 	stats.IndexedFlushDocs = domain.indexedFlushDocs.Load()
 	stats.IndexedFlushBytes = domain.indexedFlushBytes.Load()
 	stats.IndexedFlushRootRuns = domain.indexedFlushRootRuns.Load()
@@ -1236,6 +1327,23 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.IndexedFlushDuration = durationFromAtomicNs(domain.indexedFlushDurationTotalNs.Load())
 	stats.IndexedFlushMaterialize = durationFromAtomicNs(domain.indexedFlushMaterializeTotalNs.Load())
 	stats.IndexedFlushPublish = durationFromAtomicNs(domain.indexedFlushPublishTotalNs.Load())
+	stats.RootDeltaPlanPrimaryRoots = domain.rootDeltaPlanPrimaryRoots.Load()
+	stats.RootDeltaPlanTemplateRoots = domain.rootDeltaPlanTemplateRoots.Load()
+	stats.RootDeltaPlanIndexStateRoots = domain.rootDeltaPlanIndexStateRoots.Load()
+	stats.RootDeltaPlanSecondaryRoots = domain.rootDeltaPlanSecondaryRoots.Load()
+	stats.RootDeltaPlanEntries = domain.rootDeltaPlanEntries.Load()
+	stats.RootDeltaPlanKeyBytes = domain.rootDeltaPlanKeyBytes.Load()
+	stats.RootDeltaPlanValueBytes = domain.rootDeltaPlanValueBytes.Load()
+	stats.RootDeltaPlanTombstones = domain.rootDeltaPlanTombstones.Load()
+	stats.PrimaryOnlyUpdateCalls = domain.primaryOnlyUpdateCalls.Load()
+	stats.PrimaryOnlyMatched = domain.primaryOnlyMatched.Load()
+	stats.PrimaryOnlyModified = domain.primaryOnlyModified.Load()
+	stats.PrimaryOnlyBufferedCalls = domain.primaryOnlyBufferedCalls.Load()
+	stats.PrimaryOnlyRootPublishes = domain.primaryOnlyRootPublishes.Load()
+	stats.PrimaryOnlyRootDeltaEntries = domain.primaryOnlyRootDeltaEntries.Load()
+	stats.PrimaryOnlyRootDeltaKeyBytes = domain.primaryOnlyRootDeltaKeyBytes.Load()
+	stats.PrimaryOnlyRootDeltaValueBytes = domain.primaryOnlyRootDeltaValueBytes.Load()
+	stats.PrimaryOnlyCoalescedDocs = domain.primaryOnlyCoalescedDocs.Load()
 	stats.UpdateCombineRequests = domain.updateCombineRequests.Load()
 	stats.UpdateCombineBatches = domain.updateCombineBatches.Load()
 	stats.UpdateCombineBatchedRequests = domain.updateCombineBatchedRequests.Load()
@@ -1286,6 +1394,17 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 		stats.UpdateBatchIndexStats[i].SecondaryKeyBytes = collectionStatsUint64ToInt(domain.updateBatchIndexSecondaryBytes[i].Load())
 	}
 	return stats
+}
+
+func collectionWriteDomainVisibleDepthLocked(domain *collectionWriteDomain) int {
+	if domain == nil {
+		return 0
+	}
+	depth := len(domain.indexedPublishingUnits) + len(domain.indexedFlushUnits)
+	if hasBufferedIndexedRootRuns(domain) {
+		depth++
+	}
+	return depth
 }
 
 func collectionStatsUint64ToInt(v uint64) int {
@@ -1555,13 +1674,16 @@ func (domain *collectionWriteDomain) consumeIndexedAsyncFlushError() error {
 	return err
 }
 
-func (domain *collectionWriteDomain) observeIndexedFlush(docs int, bytes int64, rootRuns, roots int, duration, materialize, publish time.Duration, err error) {
+func (domain *collectionWriteDomain) observeIndexedFlush(units, docs int, bytes int64, rootRuns, roots int, duration, materialize, publish time.Duration, err error) {
 	if domain == nil {
 		return
 	}
 	domain.indexedFlushCalls.Add(1)
 	if err != nil {
 		domain.indexedFlushErrors.Add(1)
+	}
+	if units > 0 {
+		domain.indexedFlushUnitsTotal.Add(uint64(units))
 	}
 	if docs > 0 {
 		domain.indexedFlushDocs.Add(uint64(docs))
@@ -1578,6 +1700,69 @@ func (domain *collectionWriteDomain) observeIndexedFlush(docs int, bytes int64, 
 	domain.indexedFlushDurationTotalNs.Add(durationToAtomicNs(duration))
 	domain.indexedFlushMaterializeTotalNs.Add(durationToAtomicNs(materialize))
 	domain.indexedFlushPublishTotalNs.Add(durationToAtomicNs(publish))
+}
+
+type collectionRootDeltaPlanStats struct {
+	primaryRoots    uint64
+	templateRoots   uint64
+	indexStateRoots uint64
+	secondaryRoots  uint64
+	entries         uint64
+	keyBytes        uint64
+	valueBytes      uint64
+	tombstones      uint64
+}
+
+func (domain *collectionWriteDomain) observeRootDeltaPlan(stats collectionRootDeltaPlanStats) {
+	if domain == nil || stats == (collectionRootDeltaPlanStats{}) {
+		return
+	}
+	domain.rootDeltaPlanPrimaryRoots.Add(stats.primaryRoots)
+	domain.rootDeltaPlanTemplateRoots.Add(stats.templateRoots)
+	domain.rootDeltaPlanIndexStateRoots.Add(stats.indexStateRoots)
+	domain.rootDeltaPlanSecondaryRoots.Add(stats.secondaryRoots)
+	domain.rootDeltaPlanEntries.Add(stats.entries)
+	domain.rootDeltaPlanKeyBytes.Add(stats.keyBytes)
+	domain.rootDeltaPlanValueBytes.Add(stats.valueBytes)
+	domain.rootDeltaPlanTombstones.Add(stats.tombstones)
+}
+
+func (domain *collectionWriteDomain) observePrimaryOnlyUpdate(matched, modified, published bool, deltaStats collectionRootDeltaPlanStats) {
+	items := 1
+	matchedCount := 0
+	if matched {
+		matchedCount = 1
+	}
+	modifiedCount := 0
+	if modified {
+		modifiedCount = 1
+	}
+	domain.observePrimaryOnlyUpdateBatch(items, matchedCount, modifiedCount, published, deltaStats)
+}
+
+func (domain *collectionWriteDomain) observePrimaryOnlyUpdateBatch(items, matched, modified int, published bool, deltaStats collectionRootDeltaPlanStats) {
+	if domain == nil {
+		return
+	}
+	if items > 0 {
+		domain.primaryOnlyUpdateCalls.Add(uint64(items))
+	}
+	if matched > 0 {
+		domain.primaryOnlyMatched.Add(uint64(matched))
+	}
+	if modified > 0 {
+		domain.primaryOnlyModified.Add(uint64(modified))
+	}
+	if !published {
+		return
+	}
+	domain.primaryOnlyRootPublishes.Add(1)
+	domain.primaryOnlyRootDeltaEntries.Add(deltaStats.entries)
+	domain.primaryOnlyRootDeltaKeyBytes.Add(deltaStats.keyBytes)
+	domain.primaryOnlyRootDeltaValueBytes.Add(deltaStats.valueBytes)
+	if modified > 0 {
+		domain.primaryOnlyCoalescedDocs.Add(uint64(modified))
+	}
 }
 
 func (domain *collectionWriteDomain) observeUpdateCombineRequest(queueDepth int) {
@@ -4700,6 +4885,7 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 			materializeElapsed := collectionObservedElapsedSince(materializeStart)
 			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
+		work.rootDeltaStats = collectionRootDeltaPlanStatsFromOrdered(work.meta.Name, work.rootNames, ordered)
 		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
@@ -4722,6 +4908,7 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 	}
+	work.rootDeltaStats = collectionRootDeltaPlanStatsFromOrdered(work.meta.Name, work.rootNames, ordered)
 	materializeElapsed := collectionObservedElapsedSince(materializeStart)
 	publishStart := time.Now()
 	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
@@ -4911,6 +5098,48 @@ func buildRootDeltaBatchPublishInputsFromTables(collectionName string, rootNames
 	return ordered, cleanup, nil
 }
 
+func collectionRootDeltaPlanStatsFromOrdered(collectionName string, rootNames []string, ordered []backenddb.OrderedRootDeltaBatchPublishInput) collectionRootDeltaPlanStats {
+	var stats collectionRootDeltaPlanStats
+	for i, rootName := range rootNames {
+		stats.addRoot(collectionName, rootName)
+		if i < len(ordered) {
+			stats.addBatch(ordered[i].Delta)
+		}
+	}
+	return stats
+}
+
+func (stats *collectionRootDeltaPlanStats) addRoot(collectionName, rootName string) {
+	if stats == nil || rootName == "" {
+		return
+	}
+	switch {
+	case rootName == collectionPrimaryRootName(collectionName):
+		stats.primaryRoots++
+	case rootName == collectionTemplateRootName(collectionName):
+		stats.templateRoots++
+	case rootName == collectionIndexStateRootName(collectionName):
+		stats.indexStateRoots++
+	case strings.HasPrefix(rootName, collectionName+"/index/"):
+		stats.secondaryRoots++
+	}
+}
+
+func (stats *collectionRootDeltaPlanStats) addBatch(delta *batch.Batch) {
+	if stats == nil || delta == nil {
+		return
+	}
+	for _, entry := range delta.SortedEntries() {
+		stats.entries++
+		stats.keyBytes += uint64(len(entry.Key))
+		if entry.Type == batch.OpDelete {
+			stats.tombstones++
+			continue
+		}
+		stats.valueBytes += uint64(len(entry.Value))
+	}
+}
+
 func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork, newSystemRoot uint64, rootIDs []uint64, publishErr error, elapsed, materializeElapsed, publishElapsed time.Duration) error {
 	if c == nil || c.writeDomain == nil || work == nil {
 		return publishErr
@@ -4928,7 +5157,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 			domain.indexedFlushUnits = append(removed, domain.indexedFlushUnits...)
 		}
 		rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
-		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, publishErr)
+		domain.observeIndexedFlush(len(work.units), work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, publishErr)
 		return publishErr
 	}
 	baseCatalog := domain.catalog
@@ -4944,7 +5173,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
 		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
-		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, err)
+		domain.observeIndexedFlush(len(work.units), work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, err)
 		return err
 	}
 	domain.loaded = true
@@ -4963,7 +5192,8 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	c.meta = work.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetIndexedFlushUnits(oldPublishing)
-	domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, nil)
+	domain.observeIndexedFlush(len(work.units), work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, nil)
+	domain.observeRootDeltaPlan(work.rootDeltaStats)
 	return nil
 }
 
@@ -5025,13 +5255,14 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	}
 	flushDocs := domain.count
 	flushBytes := domain.bufferedBytes
+	flushUnits := len(domain.indexedFlushUnits)
 	flushRootRuns := bufferedIndexedRootRunCount(domain)
 	flushRoots := len(rootNames)
 	flushStart := time.Now()
 	var materializeElapsed time.Duration
 	var publishElapsed time.Duration
 	defer func() {
-		domain.observeIndexedFlush(flushDocs, flushBytes, flushRootRuns, flushRoots, collectionObservedElapsedSince(flushStart), materializeElapsed, publishElapsed, err)
+		domain.observeIndexedFlush(flushUnits, flushDocs, flushBytes, flushRootRuns, flushRoots, collectionObservedElapsedSince(flushStart), materializeElapsed, publishElapsed, err)
 	}()
 	baseSystemRoot := snapshotSystemRoot(pin)
 	baseCommitSeq := snapshotCommitSeq(pin)
@@ -5060,6 +5291,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
 		}
+		rootDeltaStats := collectionRootDeltaPlanStatsFromOrdered(meta.Name, rootNames, ordered)
 		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
@@ -5067,6 +5299,9 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		})
 		publishElapsed = collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
+		if err == nil {
+			domain.observeRootDeltaPlan(rootDeltaStats)
+		}
 	} else {
 		materializeStart := time.Now()
 		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
@@ -5074,6 +5309,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
 		}
+		rootDeltaStats := collectionRootDeltaPlanStatsFromOrdered(meta.Name, rootNames, ordered)
 		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
@@ -5081,6 +5317,9 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		})
 		publishElapsed = collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
+		if err == nil {
+			domain.observeRootDeltaPlan(rootDeltaStats)
+		}
 	}
 	if err != nil {
 		return err
@@ -6150,6 +6389,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	deltaStats := collectionRootDeltaPlanStatsFromOrdered(c.meta.Name, rootNames, ordered)
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 	})
@@ -6163,6 +6403,9 @@ func (c *Collection) deleteDocumentOnce(documentID []byte) (bool, error) {
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	if c.writeDomain != nil {
+		c.writeDomain.observeRootDeltaPlan(deltaStats)
+	}
 	return true, nil
 }
 
@@ -7079,6 +7322,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 		return false, false, err
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
+	primaryOnlyUpdate := len(c.meta.Indexes) == 0
 	baseUserRoot := snapshotUserRoot(snap)
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
@@ -7091,6 +7335,9 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	}
 	if !found {
 		_ = snap.Close()
+		if primaryOnlyUpdate && c.writeDomain != nil {
+			c.writeDomain.observePrimaryOnlyUpdate(false, false, false, collectionRootDeltaPlanStats{})
+		}
 		return false, false, nil
 	}
 	primaryRoot := catalog.rootID(primaryRootName)
@@ -7126,6 +7373,9 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	}
 	if !changed {
 		_ = snap.Close()
+		if primaryOnlyUpdate && c.writeDomain != nil {
+			c.writeDomain.observePrimaryOnlyUpdate(true, false, false, collectionRootDeltaPlanStats{})
+		}
 		return true, false, nil
 	}
 	if err := validateBSONReplacementPreservesIDSnapshot(currentID, document, plannerOptions); err != nil {
@@ -7257,6 +7507,7 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	if err != nil {
 		return false, false, err
 	}
+	deltaStats := collectionRootDeltaPlanStatsFromOrdered(c.meta.Name, rootNames, ordered)
 	preflight := func() error {
 		return c.validateMutationRootDescriptors(baseUserRoot, baseSystemRoot, baseCommitSeq)
 	}
@@ -7273,6 +7524,12 @@ func (c *Collection) updateDocumentOnce(documentID []byte, update func(current [
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	if c.writeDomain != nil {
+		c.writeDomain.observeRootDeltaPlan(deltaStats)
+		if primaryOnlyUpdate {
+			c.writeDomain.observePrimaryOnlyUpdate(true, true, true, deltaStats)
+		}
+	}
 	return true, true, nil
 }
 
@@ -7869,6 +8126,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 				results, publishErr = c.publishUpdateBatchPlanLocked(plan)
 				return publishErr
 			})
+			primaryOnlyNoPublish := len(plan.meta.Indexes) == 0 && len(plan.deltaTables) == 0 && plan.directBufferedUpdate == nil
 			stats := plan.stats
 			plan.close()
 			if err != nil {
@@ -7876,6 +8134,9 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 			}
 			if replan {
 				continue
+			}
+			if primaryOnlyNoPublish && c.writeDomain != nil {
+				c.writeDomain.observePrimaryOnlyUpdateBatch(stats.Items, stats.Matched, stats.Modified, false, collectionRootDeltaPlanStats{})
 			}
 			c.setLastUpdateStats(stats)
 			return results, nil
@@ -7908,6 +8169,9 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 			return nil
 		}); err != nil {
 			return nil, err
+		}
+		if len(plan.meta.Indexes) == 0 && c.writeDomain != nil {
+			c.writeDomain.observePrimaryOnlyUpdateBatch(plan.stats.Items, plan.stats.Matched, plan.stats.Modified, false, collectionRootDeltaPlanStats{})
 		}
 		c.setLastUpdateStats(plan.stats)
 		return plan.results, nil
@@ -8796,6 +9060,7 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	if err != nil {
 		return nil, err
 	}
+	deltaStats := collectionRootDeltaPlanStatsFromOrdered(plan.meta.Name, plan.rootNames, ordered)
 	preflight := func() error {
 		return c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq)
 	}
@@ -8816,6 +9081,12 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan) ([]Upda
 	c.meta = plan.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	if c.writeDomain != nil {
+		c.writeDomain.observeRootDeltaPlan(deltaStats)
+		if len(plan.meta.Indexes) == 0 {
+			c.writeDomain.observePrimaryOnlyUpdateBatch(plan.stats.Items, plan.stats.Matched, plan.stats.Modified, true, deltaStats)
+		}
+	}
 	return plan.results, nil
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1189,10 +1189,14 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 		"treedb.collections.write_domain.indexed_flush.materialize_ns_total",
 		"treedb.collections.write_domain.indexed_flush.publish_ns_total",
 		"treedb.collections.write_domain.root_delta_plan.roots.primary_total",
+		"treedb.collections.write_domain.root_delta_plan.roots.template_total",
+		"treedb.collections.write_domain.root_delta_plan.roots.index_state_total",
 		"treedb.collections.write_domain.root_delta_plan.roots.secondary_total",
 		"treedb.collections.write_domain.root_delta_plan.entries_total",
 		"treedb.collections.write_domain.root_delta_plan.key_bytes_total",
 		"treedb.collections.write_domain.root_delta_plan.value_bytes_total",
+		"treedb.collections.write_domain.root_delta_plan.tombstones_total",
+		"treedb.collections.write_domain.primary_only.buffered_calls_total",
 	} {
 		if exported[key] == "" {
 			t.Fatalf("exported stats missing %s from %#v", key, exported)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1113,6 +1113,18 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	if stats.PendingRootRuns == 0 {
 		t.Fatal("stats pending root runs=0 want positive")
 	}
+	if got, want := stats.OverlayMutableDocuments, 2; got != want {
+		t.Fatalf("stats overlay mutable docs=%d want %d", got, want)
+	}
+	if got := stats.OverlayQueuedIndexedFlushUnits; got != 0 {
+		t.Fatalf("stats overlay queued flush units=%d want 0", got)
+	}
+	if got := stats.OverlayActiveIndexedFlushUnits; got != 0 {
+		t.Fatalf("stats overlay active flush units=%d want 0", got)
+	}
+	if got, want := stats.OverlayVisibleDepth, 1; got != want {
+		t.Fatalf("stats overlay visible depth=%d want %d", got, want)
+	}
 	if got, want := stats.IndexedStageBatches, uint64(1); got != want {
 		t.Fatalf("stats indexed stage batches=%d want %d", got, want)
 	}
@@ -1129,6 +1141,10 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	for _, key := range []string{
 		"treedb.collections.write_domain.pending_docs",
 		"treedb.collections.write_domain.pending_indexed_flush_units",
+		"treedb.collections.write_domain.overlay.mutable_docs",
+		"treedb.collections.write_domain.overlay.queued_indexed_flush_units",
+		"treedb.collections.write_domain.overlay.active_indexed_flush_units",
+		"treedb.collections.write_domain.overlay.visible_depth",
 		"treedb.collections.write_domain.indexed_stage.batches_total",
 		"treedb.collections.write_domain.indexed_async_flush.scheduled_total",
 		"treedb.collections.write_domain.mutation_lock.calls_total",
@@ -1148,6 +1164,9 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	if got, want := stats.IndexedFlushCalls, uint64(1); got != want {
 		t.Fatalf("stats indexed flush calls=%d want %d", got, want)
 	}
+	if got, want := stats.IndexedFlushUnits, uint64(1); got != want {
+		t.Fatalf("stats indexed flush units=%d want %d", got, want)
+	}
 	if got, want := stats.IndexedFlushDocs, uint64(2); got != want {
 		t.Fatalf("stats indexed flush docs=%d want %d", got, want)
 	}
@@ -1157,11 +1176,93 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	if stats.IndexedFlushDuration <= 0 || stats.IndexedFlushMaterialize <= 0 || stats.IndexedFlushPublish <= 0 {
 		t.Fatalf("stats indexed flush duration/materialize/publish=%s/%s/%s want positive", stats.IndexedFlushDuration, stats.IndexedFlushMaterialize, stats.IndexedFlushPublish)
 	}
+	if stats.RootDeltaPlanPrimaryRoots == 0 || stats.RootDeltaPlanSecondaryRoots == 0 || stats.RootDeltaPlanEntries == 0 {
+		t.Fatalf("stats root delta primary/secondary/entries=%d/%d/%d want positive", stats.RootDeltaPlanPrimaryRoots, stats.RootDeltaPlanSecondaryRoots, stats.RootDeltaPlanEntries)
+	}
+	if stats.RootDeltaPlanKeyBytes == 0 || stats.RootDeltaPlanValueBytes == 0 {
+		t.Fatalf("stats root delta key/value bytes=%d/%d want positive", stats.RootDeltaPlanKeyBytes, stats.RootDeltaPlanValueBytes)
+	}
 	exported = mgr.Stats()
 	for _, key := range []string{
+		"treedb.collections.write_domain.indexed_flush.units_total",
 		"treedb.collections.write_domain.indexed_flush.duration_ns_total",
 		"treedb.collections.write_domain.indexed_flush.materialize_ns_total",
 		"treedb.collections.write_domain.indexed_flush.publish_ns_total",
+		"treedb.collections.write_domain.root_delta_plan.roots.primary_total",
+		"treedb.collections.write_domain.root_delta_plan.roots.secondary_total",
+		"treedb.collections.write_domain.root_delta_plan.entries_total",
+		"treedb.collections.write_domain.root_delta_plan.key_bytes_total",
+		"treedb.collections.write_domain.root_delta_plan.value_bytes_total",
+	} {
+		if exported[key] == "" {
+			t.Fatalf("exported stats missing %s from %#v", key, exported)
+		}
+	}
+}
+
+func TestPrimaryOnlyNoIndexUpdateCounters(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"ada","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	statsBefore := mgr.StatsSnapshot()
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"name":"ada","city":"sea"}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("update matched/modified=%v/%v want true/true", matched, modified)
+	}
+	stats := mgr.StatsSnapshot()
+	if got, want := stats.PrimaryOnlyUpdateCalls-statsBefore.PrimaryOnlyUpdateCalls, uint64(1); got != want {
+		t.Fatalf("primary-only update calls delta=%d want %d", got, want)
+	}
+	if got, want := stats.PrimaryOnlyMatched-statsBefore.PrimaryOnlyMatched, uint64(1); got != want {
+		t.Fatalf("primary-only matched delta=%d want %d", got, want)
+	}
+	if got, want := stats.PrimaryOnlyModified-statsBefore.PrimaryOnlyModified, uint64(1); got != want {
+		t.Fatalf("primary-only modified delta=%d want %d", got, want)
+	}
+	if got, want := stats.PrimaryOnlyRootPublishes-statsBefore.PrimaryOnlyRootPublishes, uint64(1); got != want {
+		t.Fatalf("primary-only root publishes delta=%d want %d", got, want)
+	}
+	if got, want := stats.PrimaryOnlyRootDeltaEntries-statsBefore.PrimaryOnlyRootDeltaEntries, uint64(1); got != want {
+		t.Fatalf("primary-only root delta entries delta=%d want %d", got, want)
+	}
+	if got := stats.PrimaryOnlyRootDeltaKeyBytes - statsBefore.PrimaryOnlyRootDeltaKeyBytes; got != uint64(len("u1")) {
+		t.Fatalf("primary-only root delta key bytes delta=%d want %d", got, len("u1"))
+	}
+	if got := stats.PrimaryOnlyRootDeltaValueBytes - statsBefore.PrimaryOnlyRootDeltaValueBytes; got == 0 {
+		t.Fatal("primary-only root delta value bytes delta=0 want positive")
+	}
+	if got, want := stats.PrimaryOnlyCoalescedDocs-statsBefore.PrimaryOnlyCoalescedDocs, uint64(1); got != want {
+		t.Fatalf("primary-only coalesced docs delta=%d want %d", got, want)
+	}
+	exported := mgr.Stats()
+	for _, key := range []string{
+		"treedb.collections.write_domain.primary_only.update_calls_total",
+		"treedb.collections.write_domain.primary_only.matched_total",
+		"treedb.collections.write_domain.primary_only.modified_total",
+		"treedb.collections.write_domain.primary_only.root_publishes_total",
+		"treedb.collections.write_domain.primary_only.root_delta_entries_total",
+		"treedb.collections.write_domain.primary_only.root_delta_key_bytes_total",
+		"treedb.collections.write_domain.primary_only.root_delta_value_bytes_total",
+		"treedb.collections.write_domain.primary_only.coalesced_docs_total",
 	} {
 		if exported[key] == "" {
 			t.Fatalf("exported stats missing %s from %#v", key, exported)

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1214,13 +1214,17 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushMaterialize:        12 * time.Millisecond,
 		IndexedFlushPublish:            18 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      3,
+		RootDeltaPlanTemplateRoots:     2,
+		RootDeltaPlanIndexStateRoots:   1,
 		RootDeltaPlanSecondaryRoots:    6,
 		RootDeltaPlanEntries:           300,
 		RootDeltaPlanKeyBytes:          1200,
 		RootDeltaPlanValueBytes:        2400,
+		RootDeltaPlanTombstones:        30,
 		PrimaryOnlyUpdateCalls:         10,
 		PrimaryOnlyMatched:             9,
 		PrimaryOnlyModified:            8,
+		PrimaryOnlyBufferedCalls:       1,
 		PrimaryOnlyRootPublishes:       8,
 		PrimaryOnlyRootDeltaEntries:    8,
 		PrimaryOnlyRootDeltaKeyBytes:   16,
@@ -1253,13 +1257,17 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushMaterialize:        30 * time.Millisecond,
 		IndexedFlushPublish:            60 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      8,
+		RootDeltaPlanTemplateRoots:     5,
+		RootDeltaPlanIndexStateRoots:   4,
 		RootDeltaPlanSecondaryRoots:    16,
 		RootDeltaPlanEntries:           900,
 		RootDeltaPlanKeyBytes:          3600,
 		RootDeltaPlanValueBytes:        7200,
+		RootDeltaPlanTombstones:        90,
 		PrimaryOnlyUpdateCalls:         17,
 		PrimaryOnlyMatched:             16,
 		PrimaryOnlyModified:            15,
+		PrimaryOnlyBufferedCalls:       3,
 		PrimaryOnlyRootPublishes:       15,
 		PrimaryOnlyRootDeltaEntries:    15,
 		PrimaryOnlyRootDeltaKeyBytes:   30,
@@ -1320,20 +1328,24 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 			got.IndexedFlushPublish,
 		)
 	}
-	if got.RootDeltaPlanPrimaryRoots != 5 || got.RootDeltaPlanSecondaryRoots != 10 || got.RootDeltaPlanEntries != 600 || got.RootDeltaPlanKeyBytes != 2400 || got.RootDeltaPlanValueBytes != 4800 {
-		t.Fatalf("root delta plan stats=%d/%d/%d/%d/%d want 5/10/600/2400/4800",
+	if got.RootDeltaPlanPrimaryRoots != 5 || got.RootDeltaPlanTemplateRoots != 3 || got.RootDeltaPlanIndexStateRoots != 3 || got.RootDeltaPlanSecondaryRoots != 10 || got.RootDeltaPlanEntries != 600 || got.RootDeltaPlanKeyBytes != 2400 || got.RootDeltaPlanValueBytes != 4800 || got.RootDeltaPlanTombstones != 60 {
+		t.Fatalf("root delta plan stats=%d/%d/%d/%d/%d/%d/%d/%d want 5/3/3/10/600/2400/4800/60",
 			got.RootDeltaPlanPrimaryRoots,
+			got.RootDeltaPlanTemplateRoots,
+			got.RootDeltaPlanIndexStateRoots,
 			got.RootDeltaPlanSecondaryRoots,
 			got.RootDeltaPlanEntries,
 			got.RootDeltaPlanKeyBytes,
 			got.RootDeltaPlanValueBytes,
+			got.RootDeltaPlanTombstones,
 		)
 	}
-	if got.PrimaryOnlyUpdateCalls != 7 || got.PrimaryOnlyMatched != 7 || got.PrimaryOnlyModified != 7 || got.PrimaryOnlyRootPublishes != 7 || got.PrimaryOnlyRootDeltaEntries != 7 || got.PrimaryOnlyRootDeltaKeyBytes != 14 || got.PrimaryOnlyRootDeltaValueBytes != 140 || got.PrimaryOnlyCoalescedDocs != 7 {
-		t.Fatalf("primary-only stats calls/matched/modified/publishes/entries/key/value/coalesced=%d/%d/%d/%d/%d/%d/%d/%d want 7/7/7/7/7/14/140/7",
+	if got.PrimaryOnlyUpdateCalls != 7 || got.PrimaryOnlyMatched != 7 || got.PrimaryOnlyModified != 7 || got.PrimaryOnlyBufferedCalls != 2 || got.PrimaryOnlyRootPublishes != 7 || got.PrimaryOnlyRootDeltaEntries != 7 || got.PrimaryOnlyRootDeltaKeyBytes != 14 || got.PrimaryOnlyRootDeltaValueBytes != 140 || got.PrimaryOnlyCoalescedDocs != 7 {
+		t.Fatalf("primary-only stats calls/matched/modified/buffered/publishes/entries/key/value/coalesced=%d/%d/%d/%d/%d/%d/%d/%d/%d want 7/7/7/2/7/7/14/140/7",
 			got.PrimaryOnlyUpdateCalls,
 			got.PrimaryOnlyMatched,
 			got.PrimaryOnlyModified,
+			got.PrimaryOnlyBufferedCalls,
 			got.PrimaryOnlyRootPublishes,
 			got.PrimaryOnlyRootDeltaEntries,
 			got.PrimaryOnlyRootDeltaKeyBytes,
@@ -1373,13 +1385,17 @@ func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testin
 		IndexedFlushMaterialize:        18 * time.Millisecond,
 		IndexedFlushPublish:            42 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      5,
+		RootDeltaPlanTemplateRoots:     2,
+		RootDeltaPlanIndexStateRoots:   3,
 		RootDeltaPlanSecondaryRoots:    10,
 		RootDeltaPlanEntries:           600,
 		RootDeltaPlanKeyBytes:          2400,
 		RootDeltaPlanValueBytes:        4800,
+		RootDeltaPlanTombstones:        60,
 		PrimaryOnlyUpdateCalls:         600,
 		PrimaryOnlyMatched:             600,
 		PrimaryOnlyModified:            600,
+		PrimaryOnlyBufferedCalls:       30,
 		PrimaryOnlyRootPublishes:       600,
 		PrimaryOnlyRootDeltaEntries:    600,
 		PrimaryOnlyRootDeltaKeyBytes:   1200,
@@ -1414,11 +1430,16 @@ func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testin
 		"root_delta_plan_entries/doc":         1,
 		"root_delta_plan_key_bytes/doc":       4,
 		"root_delta_plan_value_bytes/doc":     8,
+		"root_delta_plan_tombstones/doc":      0.1,
 		"affected_primary_roots/doc":          1.0 / 120.0,
+		"affected_template_roots/doc":         1.0 / 300.0,
+		"affected_index_state_roots/doc":      0.005,
 		"affected_secondary_roots/doc":        1.0 / 60.0,
 		"primary_only_update_calls/doc":       1,
 		"primary_only_matched/doc":            1,
 		"primary_only_modified/doc":           1,
+		"primary_only_buffered_calls":         30,
+		"primary_only_buffered_calls/doc":     0.05,
 		"primary_root_publishes/doc":          1,
 		"primary_root_delta_entries/doc":      1,
 		"primary_root_delta_bytes/doc":        22,
@@ -1566,6 +1587,10 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	}
 	if stats.PrimaryOnlyModified > 0 {
 		b.ReportMetric(float64(stats.PrimaryOnlyModified)/float64(docs), "primary_only_modified/doc")
+	}
+	if stats.PrimaryOnlyBufferedCalls > 0 {
+		b.ReportMetric(float64(stats.PrimaryOnlyBufferedCalls), "primary_only_buffered_calls")
+		b.ReportMetric(float64(stats.PrimaryOnlyBufferedCalls)/float64(docs), "primary_only_buffered_calls/doc")
 	}
 	if stats.PrimaryOnlyRootPublishes > 0 {
 		b.ReportMetric(float64(stats.PrimaryOnlyRootPublishes)/float64(docs), "primary_root_publishes/doc")

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1115,6 +1115,7 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateCombineFallbackRequests:  after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
 		IndexedFlushCalls:              after.IndexedFlushCalls - before.IndexedFlushCalls,
 		IndexedFlushErrors:             after.IndexedFlushErrors - before.IndexedFlushErrors,
+		IndexedFlushUnits:              after.IndexedFlushUnits - before.IndexedFlushUnits,
 		IndexedFlushDocs:               after.IndexedFlushDocs - before.IndexedFlushDocs,
 		IndexedFlushBytes:              after.IndexedFlushBytes - before.IndexedFlushBytes,
 		IndexedFlushRootRuns:           after.IndexedFlushRootRuns - before.IndexedFlushRootRuns,
@@ -1122,7 +1123,28 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		IndexedFlushDuration:           after.IndexedFlushDuration - before.IndexedFlushDuration,
 		IndexedFlushMaterialize:        after.IndexedFlushMaterialize - before.IndexedFlushMaterialize,
 		IndexedFlushPublish:            after.IndexedFlushPublish - before.IndexedFlushPublish,
+		RootDeltaPlanPrimaryRoots:      after.RootDeltaPlanPrimaryRoots - before.RootDeltaPlanPrimaryRoots,
+		RootDeltaPlanTemplateRoots:     after.RootDeltaPlanTemplateRoots - before.RootDeltaPlanTemplateRoots,
+		RootDeltaPlanIndexStateRoots:   after.RootDeltaPlanIndexStateRoots - before.RootDeltaPlanIndexStateRoots,
+		RootDeltaPlanSecondaryRoots:    after.RootDeltaPlanSecondaryRoots - before.RootDeltaPlanSecondaryRoots,
+		RootDeltaPlanEntries:           after.RootDeltaPlanEntries - before.RootDeltaPlanEntries,
+		RootDeltaPlanKeyBytes:          after.RootDeltaPlanKeyBytes - before.RootDeltaPlanKeyBytes,
+		RootDeltaPlanValueBytes:        after.RootDeltaPlanValueBytes - before.RootDeltaPlanValueBytes,
+		RootDeltaPlanTombstones:        after.RootDeltaPlanTombstones - before.RootDeltaPlanTombstones,
+		PrimaryOnlyUpdateCalls:         after.PrimaryOnlyUpdateCalls - before.PrimaryOnlyUpdateCalls,
+		PrimaryOnlyMatched:             after.PrimaryOnlyMatched - before.PrimaryOnlyMatched,
+		PrimaryOnlyModified:            after.PrimaryOnlyModified - before.PrimaryOnlyModified,
+		PrimaryOnlyBufferedCalls:       after.PrimaryOnlyBufferedCalls - before.PrimaryOnlyBufferedCalls,
+		PrimaryOnlyRootPublishes:       after.PrimaryOnlyRootPublishes - before.PrimaryOnlyRootPublishes,
+		PrimaryOnlyRootDeltaEntries:    after.PrimaryOnlyRootDeltaEntries - before.PrimaryOnlyRootDeltaEntries,
+		PrimaryOnlyRootDeltaKeyBytes:   after.PrimaryOnlyRootDeltaKeyBytes - before.PrimaryOnlyRootDeltaKeyBytes,
+		PrimaryOnlyRootDeltaValueBytes: after.PrimaryOnlyRootDeltaValueBytes - before.PrimaryOnlyRootDeltaValueBytes,
+		PrimaryOnlyCoalescedDocs:       after.PrimaryOnlyCoalescedDocs - before.PrimaryOnlyCoalescedDocs,
 	}
+	delta.OverlayMutableDocuments = after.OverlayMutableDocuments
+	delta.OverlayQueuedIndexedFlushUnits = after.OverlayQueuedIndexedFlushUnits
+	delta.OverlayActiveIndexedFlushUnits = after.OverlayActiveIndexedFlushUnits
+	delta.OverlayVisibleDepth = after.OverlayVisibleDepth
 	if after.UpdateCombineQueueDepthMax > before.UpdateCombineQueueDepthMax {
 		delta.UpdateCombineQueueDepthMax = after.UpdateCombineQueueDepthMax
 	}
@@ -1183,6 +1205,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateBatchUniqueCheckSkips:    10,
 		IndexedFlushCalls:              3,
 		IndexedFlushErrors:             1,
+		IndexedFlushUnits:              6,
 		IndexedFlushDocs:               300,
 		IndexedFlushBytes:              9000,
 		IndexedFlushRootRuns:           90,
@@ -1190,6 +1213,19 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushDuration:           30 * time.Millisecond,
 		IndexedFlushMaterialize:        12 * time.Millisecond,
 		IndexedFlushPublish:            18 * time.Millisecond,
+		RootDeltaPlanPrimaryRoots:      3,
+		RootDeltaPlanSecondaryRoots:    6,
+		RootDeltaPlanEntries:           300,
+		RootDeltaPlanKeyBytes:          1200,
+		RootDeltaPlanValueBytes:        2400,
+		PrimaryOnlyUpdateCalls:         10,
+		PrimaryOnlyMatched:             9,
+		PrimaryOnlyModified:            8,
+		PrimaryOnlyRootPublishes:       8,
+		PrimaryOnlyRootDeltaEntries:    8,
+		PrimaryOnlyRootDeltaKeyBytes:   16,
+		PrimaryOnlyRootDeltaValueBytes: 160,
+		PrimaryOnlyCoalescedDocs:       8,
 		UpdateBatchIndexStatsCount:     2,
 		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
 			{CollectionName: "users", IndexName: "email", IndexOrdinal: 0, Unique: true, Changed: 1, Unchanged: 9, UniqueChecks: 1, UniqueCheckSkips: 8},
@@ -1208,6 +1244,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateBatchUniqueCheckSkips:    19,
 		IndexedFlushCalls:              8,
 		IndexedFlushErrors:             2,
+		IndexedFlushUnits:              16,
 		IndexedFlushDocs:               900,
 		IndexedFlushBytes:              27000,
 		IndexedFlushRootRuns:           270,
@@ -1215,6 +1252,19 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushDuration:           90 * time.Millisecond,
 		IndexedFlushMaterialize:        30 * time.Millisecond,
 		IndexedFlushPublish:            60 * time.Millisecond,
+		RootDeltaPlanPrimaryRoots:      8,
+		RootDeltaPlanSecondaryRoots:    16,
+		RootDeltaPlanEntries:           900,
+		RootDeltaPlanKeyBytes:          3600,
+		RootDeltaPlanValueBytes:        7200,
+		PrimaryOnlyUpdateCalls:         17,
+		PrimaryOnlyMatched:             16,
+		PrimaryOnlyModified:            15,
+		PrimaryOnlyRootPublishes:       15,
+		PrimaryOnlyRootDeltaEntries:    15,
+		PrimaryOnlyRootDeltaKeyBytes:   30,
+		PrimaryOnlyRootDeltaValueBytes: 300,
+		PrimaryOnlyCoalescedDocs:       15,
 		UpdateBatchIndexStatsCount:     2,
 		UpdateBatchIndexStats: [8]collections.CollectionUpdateIndexStats{
 			{CollectionName: "users", IndexName: "email", IndexOrdinal: 0, Unique: true, Changed: 1, Unchanged: 22, UniqueChecks: 1, UniqueCheckSkips: 17},
@@ -1256,10 +1306,11 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	if got.UpdateBatchUniqueCheckSkips != 9 {
 		t.Fatalf("UpdateBatchUniqueCheckSkips=%d want 9", got.UpdateBatchUniqueCheckSkips)
 	}
-	if got.IndexedFlushCalls != 5 || got.IndexedFlushErrors != 1 || got.IndexedFlushDocs != 600 || got.IndexedFlushBytes != 18000 || got.IndexedFlushRootRuns != 180 || got.IndexedFlushRoots != 15 || got.IndexedFlushDuration != 60*time.Millisecond || got.IndexedFlushMaterialize != 18*time.Millisecond || got.IndexedFlushPublish != 42*time.Millisecond {
-		t.Fatalf("indexed flush delta calls/errors/docs/bytes/rootRuns/roots/duration/materialize/publish=%d/%d/%d/%d/%d/%d/%s/%s/%s want 5/1/600/18000/180/15/60ms/18ms/42ms",
+	if got.IndexedFlushCalls != 5 || got.IndexedFlushErrors != 1 || got.IndexedFlushUnits != 10 || got.IndexedFlushDocs != 600 || got.IndexedFlushBytes != 18000 || got.IndexedFlushRootRuns != 180 || got.IndexedFlushRoots != 15 || got.IndexedFlushDuration != 60*time.Millisecond || got.IndexedFlushMaterialize != 18*time.Millisecond || got.IndexedFlushPublish != 42*time.Millisecond {
+		t.Fatalf("indexed flush delta calls/errors/units/docs/bytes/rootRuns/roots/duration/materialize/publish=%d/%d/%d/%d/%d/%d/%d/%s/%s/%s want 5/1/10/600/18000/180/15/60ms/18ms/42ms",
 			got.IndexedFlushCalls,
 			got.IndexedFlushErrors,
+			got.IndexedFlushUnits,
 			got.IndexedFlushDocs,
 			got.IndexedFlushBytes,
 			got.IndexedFlushRootRuns,
@@ -1267,6 +1318,27 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 			got.IndexedFlushDuration,
 			got.IndexedFlushMaterialize,
 			got.IndexedFlushPublish,
+		)
+	}
+	if got.RootDeltaPlanPrimaryRoots != 5 || got.RootDeltaPlanSecondaryRoots != 10 || got.RootDeltaPlanEntries != 600 || got.RootDeltaPlanKeyBytes != 2400 || got.RootDeltaPlanValueBytes != 4800 {
+		t.Fatalf("root delta plan stats=%d/%d/%d/%d/%d want 5/10/600/2400/4800",
+			got.RootDeltaPlanPrimaryRoots,
+			got.RootDeltaPlanSecondaryRoots,
+			got.RootDeltaPlanEntries,
+			got.RootDeltaPlanKeyBytes,
+			got.RootDeltaPlanValueBytes,
+		)
+	}
+	if got.PrimaryOnlyUpdateCalls != 7 || got.PrimaryOnlyMatched != 7 || got.PrimaryOnlyModified != 7 || got.PrimaryOnlyRootPublishes != 7 || got.PrimaryOnlyRootDeltaEntries != 7 || got.PrimaryOnlyRootDeltaKeyBytes != 14 || got.PrimaryOnlyRootDeltaValueBytes != 140 || got.PrimaryOnlyCoalescedDocs != 7 {
+		t.Fatalf("primary-only stats calls/matched/modified/publishes/entries/key/value/coalesced=%d/%d/%d/%d/%d/%d/%d/%d want 7/7/7/7/7/14/140/7",
+			got.PrimaryOnlyUpdateCalls,
+			got.PrimaryOnlyMatched,
+			got.PrimaryOnlyModified,
+			got.PrimaryOnlyRootPublishes,
+			got.PrimaryOnlyRootDeltaEntries,
+			got.PrimaryOnlyRootDeltaKeyBytes,
+			got.PrimaryOnlyRootDeltaValueBytes,
+			got.PrimaryOnlyCoalescedDocs,
 		)
 	}
 	if got.UpdateBatchIndexStatsCount != 2 {
@@ -1290,36 +1362,67 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 
 func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testing.T) {
 	stats := collections.CollectionManagerStats{
-		IndexedFlushCalls:       5,
-		IndexedFlushErrors:      1,
-		IndexedFlushDocs:        600,
-		IndexedFlushBytes:       18000,
-		IndexedFlushRootRuns:    180,
-		IndexedFlushRoots:       15,
-		IndexedFlushDuration:    60 * time.Millisecond,
-		IndexedFlushMaterialize: 18 * time.Millisecond,
-		IndexedFlushPublish:     42 * time.Millisecond,
+		IndexedFlushCalls:              5,
+		IndexedFlushErrors:             1,
+		IndexedFlushUnits:              10,
+		IndexedFlushDocs:               600,
+		IndexedFlushBytes:              18000,
+		IndexedFlushRootRuns:           180,
+		IndexedFlushRoots:              15,
+		IndexedFlushDuration:           60 * time.Millisecond,
+		IndexedFlushMaterialize:        18 * time.Millisecond,
+		IndexedFlushPublish:            42 * time.Millisecond,
+		RootDeltaPlanPrimaryRoots:      5,
+		RootDeltaPlanSecondaryRoots:    10,
+		RootDeltaPlanEntries:           600,
+		RootDeltaPlanKeyBytes:          2400,
+		RootDeltaPlanValueBytes:        4800,
+		PrimaryOnlyUpdateCalls:         600,
+		PrimaryOnlyMatched:             600,
+		PrimaryOnlyModified:            600,
+		PrimaryOnlyRootPublishes:       600,
+		PrimaryOnlyRootDeltaEntries:    600,
+		PrimaryOnlyRootDeltaKeyBytes:   1200,
+		PrimaryOnlyRootDeltaValueBytes: 12000,
+		PrimaryOnlyCoalescedDocs:       600,
 	}
 	result := testing.Benchmark(func(b *testing.B) {
 		reportCollectionManagerUpdateStats(b, stats, 600)
 	})
 	want := map[string]float64{
-		"indexed_flush_calls":               5,
-		"indexed_flush_docs/call":           120,
-		"indexed_flush_docs/doc":            1,
-		"indexed_flush_bytes/call":          3600,
-		"indexed_flush_bytes/doc":           30,
-		"indexed_flush_root_runs/call":      36,
-		"indexed_flush_root_runs/doc":       0.3,
-		"indexed_flush_roots/call":          3,
-		"indexed_flush_roots/doc":           0.025,
-		"indexed_flush_errors":              1,
-		"indexed_flush_ns/call":             12_000_000,
-		"indexed_flush_ns/doc":              100_000,
-		"indexed_flush_materialize_ns/call": 3_600_000,
-		"indexed_flush_materialize_ns/doc":  30_000,
-		"indexed_flush_publish_ns/call":     8_400_000,
-		"indexed_flush_publish_ns/doc":      70_000,
+		"indexed_flush_calls":                 5,
+		"indexed_flush_units/call":            2,
+		"indexed_flush_units/batch":           2,
+		"indexed_flush_units/doc":             1.0 / 60.0,
+		"indexed_flush_docs/call":             120,
+		"indexed_flush_docs/batch":            120,
+		"indexed_flush_docs/doc":              1,
+		"indexed_flush_docs/unit":             60,
+		"indexed_flush_bytes/call":            3600,
+		"indexed_flush_bytes/doc":             30,
+		"indexed_flush_root_runs/call":        36,
+		"indexed_flush_root_runs/doc":         0.3,
+		"indexed_flush_roots/call":            3,
+		"indexed_flush_roots/doc":             0.025,
+		"indexed_flush_errors":                1,
+		"indexed_flush_ns/call":               12_000_000,
+		"indexed_flush_ns/doc":                100_000,
+		"indexed_flush_materialize_ns/call":   3_600_000,
+		"indexed_flush_materialize_ns/doc":    30_000,
+		"indexed_flush_publish_ns/call":       8_400_000,
+		"indexed_flush_publish_ns/doc":        70_000,
+		"root_delta_plan_entries/doc":         1,
+		"root_delta_plan_key_bytes/doc":       4,
+		"root_delta_plan_value_bytes/doc":     8,
+		"affected_primary_roots/doc":          1.0 / 120.0,
+		"affected_secondary_roots/doc":        1.0 / 60.0,
+		"primary_only_update_calls/doc":       1,
+		"primary_only_matched/doc":            1,
+		"primary_only_modified/doc":           1,
+		"primary_root_publishes/doc":          1,
+		"primary_root_delta_entries/doc":      1,
+		"primary_root_delta_bytes/doc":        22,
+		"primary_only_coalesced_docs/publish": 1,
 	}
 	for metric, wantValue := range want {
 		gotValue, ok := result.Extra[metric]
@@ -1372,9 +1475,18 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	}
 	if stats.IndexedFlushCalls > 0 {
 		b.ReportMetric(float64(stats.IndexedFlushCalls), "indexed_flush_calls")
+		if stats.IndexedFlushUnits > 0 {
+			b.ReportMetric(float64(stats.IndexedFlushUnits)/float64(stats.IndexedFlushCalls), "indexed_flush_units/call")
+			b.ReportMetric(float64(stats.IndexedFlushUnits)/float64(stats.IndexedFlushCalls), "indexed_flush_units/batch")
+			b.ReportMetric(float64(stats.IndexedFlushUnits)/float64(docs), "indexed_flush_units/doc")
+		}
 		if stats.IndexedFlushDocs > 0 {
 			b.ReportMetric(float64(stats.IndexedFlushDocs)/float64(stats.IndexedFlushCalls), "indexed_flush_docs/call")
+			b.ReportMetric(float64(stats.IndexedFlushDocs)/float64(stats.IndexedFlushCalls), "indexed_flush_docs/batch")
 			b.ReportMetric(float64(stats.IndexedFlushDocs)/float64(docs), "indexed_flush_docs/doc")
+		}
+		if stats.IndexedFlushUnits > 0 && stats.IndexedFlushDocs > 0 {
+			b.ReportMetric(float64(stats.IndexedFlushDocs)/float64(stats.IndexedFlushUnits), "indexed_flush_docs/unit")
 		}
 		if stats.IndexedFlushBytes > 0 {
 			b.ReportMetric(float64(stats.IndexedFlushBytes)/float64(stats.IndexedFlushCalls), "indexed_flush_bytes/call")
@@ -1409,6 +1521,63 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 				b.ReportMetric(float64(stats.IndexedFlushPublish.Nanoseconds())/float64(stats.IndexedFlushDocs), "indexed_flush_publish_ns/doc")
 			}
 		}
+	}
+	if stats.OverlayMutableDocuments > 0 {
+		b.ReportMetric(float64(stats.OverlayMutableDocuments), "overlay_mutable_docs")
+	}
+	if stats.OverlayQueuedIndexedFlushUnits > 0 {
+		b.ReportMetric(float64(stats.OverlayQueuedIndexedFlushUnits), "overlay_queued_indexed_flush_units")
+	}
+	if stats.OverlayActiveIndexedFlushUnits > 0 {
+		b.ReportMetric(float64(stats.OverlayActiveIndexedFlushUnits), "overlay_active_indexed_flush_units")
+	}
+	if stats.OverlayVisibleDepth > 0 {
+		b.ReportMetric(float64(stats.OverlayVisibleDepth), "overlay_visible_depth")
+	}
+	if stats.RootDeltaPlanEntries > 0 {
+		b.ReportMetric(float64(stats.RootDeltaPlanEntries)/float64(docs), "root_delta_plan_entries/doc")
+	}
+	if stats.RootDeltaPlanKeyBytes > 0 {
+		b.ReportMetric(float64(stats.RootDeltaPlanKeyBytes)/float64(docs), "root_delta_plan_key_bytes/doc")
+	}
+	if stats.RootDeltaPlanValueBytes > 0 {
+		b.ReportMetric(float64(stats.RootDeltaPlanValueBytes)/float64(docs), "root_delta_plan_value_bytes/doc")
+	}
+	if stats.RootDeltaPlanTombstones > 0 {
+		b.ReportMetric(float64(stats.RootDeltaPlanTombstones)/float64(docs), "root_delta_plan_tombstones/doc")
+	}
+	if stats.RootDeltaPlanPrimaryRoots > 0 {
+		b.ReportMetric(float64(stats.RootDeltaPlanPrimaryRoots)/float64(docs), "affected_primary_roots/doc")
+	}
+	if stats.RootDeltaPlanTemplateRoots > 0 {
+		b.ReportMetric(float64(stats.RootDeltaPlanTemplateRoots)/float64(docs), "affected_template_roots/doc")
+	}
+	if stats.RootDeltaPlanIndexStateRoots > 0 {
+		b.ReportMetric(float64(stats.RootDeltaPlanIndexStateRoots)/float64(docs), "affected_index_state_roots/doc")
+	}
+	if stats.RootDeltaPlanSecondaryRoots > 0 {
+		b.ReportMetric(float64(stats.RootDeltaPlanSecondaryRoots)/float64(docs), "affected_secondary_roots/doc")
+	}
+	if stats.PrimaryOnlyUpdateCalls > 0 {
+		b.ReportMetric(float64(stats.PrimaryOnlyUpdateCalls)/float64(docs), "primary_only_update_calls/doc")
+	}
+	if stats.PrimaryOnlyMatched > 0 {
+		b.ReportMetric(float64(stats.PrimaryOnlyMatched)/float64(docs), "primary_only_matched/doc")
+	}
+	if stats.PrimaryOnlyModified > 0 {
+		b.ReportMetric(float64(stats.PrimaryOnlyModified)/float64(docs), "primary_only_modified/doc")
+	}
+	if stats.PrimaryOnlyRootPublishes > 0 {
+		b.ReportMetric(float64(stats.PrimaryOnlyRootPublishes)/float64(docs), "primary_root_publishes/doc")
+	}
+	if stats.PrimaryOnlyRootDeltaEntries > 0 {
+		b.ReportMetric(float64(stats.PrimaryOnlyRootDeltaEntries)/float64(docs), "primary_root_delta_entries/doc")
+	}
+	if stats.PrimaryOnlyRootDeltaKeyBytes+stats.PrimaryOnlyRootDeltaValueBytes > 0 {
+		b.ReportMetric(float64(stats.PrimaryOnlyRootDeltaKeyBytes+stats.PrimaryOnlyRootDeltaValueBytes)/float64(docs), "primary_root_delta_bytes/doc")
+	}
+	if stats.PrimaryOnlyRootPublishes > 0 {
+		b.ReportMetric(float64(stats.PrimaryOnlyCoalescedDocs)/float64(stats.PrimaryOnlyRootPublishes), "primary_only_coalesced_docs/publish")
 	}
 	if stats.UpdateBatchCalls > 0 {
 		b.ReportMetric(float64(stats.UpdateBatchCalls), "update_batches")


### PR DESCRIPTION
## Summary
- add PR1B collection write-domain counters for indexed flush units, overlay queued/active/mutable depth, root-delta plan roots/entries/bytes/tombstones, and primary-only no-index update publishes
- wire counters at existing indexed flush and direct/update-batch publish boundaries without changing publish behavior
- report the new counters from the Mongo gateway profile benchmark helper, including indexed_flush_units/batch and primary_root_delta_* metrics

## Tests
- go test ./TreeDB/collections -count=1
- go test ./cmd/mongo_gateway_bench -count=1
- go test ./cmd/internal/treedbstats -count=1