### PR TITLE
collections: count async indexed flush waits

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -422,9 +422,11 @@ type CollectionManagerStats struct {
 	IndexedAutoFlushes             uint64
 	IndexedAsyncFlushScheduled     uint64
 	IndexedAsyncFlushBackpressure  uint64
+	IndexedAsyncFlushWait          time.Duration
 	IndexedAsyncFlushErrors        uint64
 	IndexedFlushCalls              uint64
 	IndexedFlushErrors             uint64
+	IndexedFlushForcedDrains       uint64
 	IndexedFlushUnits              uint64
 	IndexedFlushDocs               uint64
 	IndexedFlushBytes              uint64
@@ -766,9 +768,11 @@ type collectionWriteDomain struct {
 	indexedAutoFlushes               atomic.Uint64
 	indexedAsyncFlushScheduled       atomic.Uint64
 	indexedAsyncFlushBackpressure    atomic.Uint64
+	indexedAsyncFlushWaitTotalNs     atomic.Uint64
 	indexedAsyncFlushErrors          atomic.Uint64
 	indexedFlushCalls                atomic.Uint64
 	indexedFlushErrors               atomic.Uint64
+	indexedFlushForcedDrains         atomic.Uint64
 	indexedFlushUnitsTotal           atomic.Uint64
 	indexedFlushDocs                 atomic.Uint64
 	indexedFlushBytes                atomic.Uint64
@@ -1010,9 +1014,11 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_stage.auto_flushes_total"] = fmt.Sprintf("%d", stats.IndexedAutoFlushes)
 	out["treedb.collections.write_domain.indexed_async_flush.scheduled_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushScheduled)
 	out["treedb.collections.write_domain.indexed_async_flush.backpressure_sync_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushBackpressure)
+	out["treedb.collections.write_domain.indexed_async_flush.wait_ns_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushWait.Nanoseconds())
 	out["treedb.collections.write_domain.indexed_async_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushErrors)
 	out["treedb.collections.write_domain.indexed_flush.calls_total"] = fmt.Sprintf("%d", stats.IndexedFlushCalls)
 	out["treedb.collections.write_domain.indexed_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedFlushErrors)
+	out["treedb.collections.write_domain.indexed_flush.forced_drains_total"] = fmt.Sprintf("%d", stats.IndexedFlushForcedDrains)
 	out["treedb.collections.write_domain.indexed_flush.units_total"] = fmt.Sprintf("%d", stats.IndexedFlushUnits)
 	out["treedb.collections.write_domain.indexed_flush.docs_total"] = fmt.Sprintf("%d", stats.IndexedFlushDocs)
 	out["treedb.collections.write_domain.indexed_flush.bytes_total"] = fmt.Sprintf("%d", stats.IndexedFlushBytes)
@@ -1203,9 +1209,11 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.IndexedAutoFlushes += other.IndexedAutoFlushes
 	s.IndexedAsyncFlushScheduled += other.IndexedAsyncFlushScheduled
 	s.IndexedAsyncFlushBackpressure += other.IndexedAsyncFlushBackpressure
+	s.IndexedAsyncFlushWait += other.IndexedAsyncFlushWait
 	s.IndexedAsyncFlushErrors += other.IndexedAsyncFlushErrors
 	s.IndexedFlushCalls += other.IndexedFlushCalls
 	s.IndexedFlushErrors += other.IndexedFlushErrors
+	s.IndexedFlushForcedDrains += other.IndexedFlushForcedDrains
 	s.IndexedFlushUnits += other.IndexedFlushUnits
 	s.IndexedFlushDocs += other.IndexedFlushDocs
 	s.IndexedFlushBytes += other.IndexedFlushBytes
@@ -1317,9 +1325,11 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.IndexedAutoFlushes = domain.indexedAutoFlushes.Load()
 	stats.IndexedAsyncFlushScheduled = domain.indexedAsyncFlushScheduled.Load()
 	stats.IndexedAsyncFlushBackpressure = domain.indexedAsyncFlushBackpressure.Load()
+	stats.IndexedAsyncFlushWait = durationFromAtomicNs(domain.indexedAsyncFlushWaitTotalNs.Load())
 	stats.IndexedAsyncFlushErrors = domain.indexedAsyncFlushErrors.Load()
 	stats.IndexedFlushCalls = domain.indexedFlushCalls.Load()
 	stats.IndexedFlushErrors = domain.indexedFlushErrors.Load()
+	stats.IndexedFlushForcedDrains = domain.indexedFlushForcedDrains.Load()
 	stats.IndexedFlushUnits = domain.indexedFlushUnitsTotal.Load()
 	stats.IndexedFlushDocs = domain.indexedFlushDocs.Load()
 	stats.IndexedFlushBytes = domain.indexedFlushBytes.Load()
@@ -1635,14 +1645,21 @@ func (domain *collectionWriteDomain) waitIndexedAsyncFlush() {
 	if domain == nil {
 		return
 	}
+	var waitStart time.Time
 	domain.indexedAsyncMu.Lock()
 	if domain.indexedAsyncCond == nil {
 		domain.indexedAsyncCond = sync.NewCond(&domain.indexedAsyncMu)
 	}
 	for domain.indexedAsyncRun {
+		if waitStart.IsZero() {
+			waitStart = time.Now()
+		}
 		domain.indexedAsyncCond.Wait()
 	}
 	domain.indexedAsyncMu.Unlock()
+	if !waitStart.IsZero() {
+		domain.indexedAsyncFlushWaitTotalNs.Add(durationToAtomicNs(time.Since(waitStart)))
+	}
 }
 
 func (domain *collectionWriteDomain) indexedAsyncFlushRunning() bool {
@@ -1701,6 +1718,13 @@ func (domain *collectionWriteDomain) observeIndexedFlush(units, docs int, bytes 
 	domain.indexedFlushDurationTotalNs.Add(durationToAtomicNs(duration))
 	domain.indexedFlushMaterializeTotalNs.Add(durationToAtomicNs(materialize))
 	domain.indexedFlushPublishTotalNs.Add(durationToAtomicNs(publish))
+}
+
+func (domain *collectionWriteDomain) observeIndexedFlushForcedDrain() {
+	if domain == nil {
+		return
+	}
+	domain.indexedFlushForcedDrains.Add(1)
 }
 
 type collectionRootDeltaPlanStats struct {
@@ -1862,6 +1886,9 @@ func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain)
 	domain.waitIndexedAsyncFlush()
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
+	if hasBufferedIndexedRootRuns(domain) {
+		domain.observeIndexedFlushForcedDrain()
+	}
 	return collection.flushBufferedWritesLocked(domain)
 }
 
@@ -2777,6 +2804,9 @@ func (c *Collection) flushBufferedWrites() error {
 			domain.mu.Unlock()
 			continue
 		}
+		if hasBufferedIndexedRootRuns(domain) {
+			domain.observeIndexedFlushForcedDrain()
+		}
 		err := c.flushBufferedWritesLocked(domain)
 		domain.mu.Unlock()
 		return err
@@ -3402,6 +3432,7 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 		if opts.BufferedIndexedAsyncFlushMaxQueuedUnits > 0 && len(domain.indexedFlushUnits) >= opts.BufferedIndexedAsyncFlushMaxQueuedUnits {
 			if len(domain.indexedPublishingUnits) == 0 {
 				domain.indexedAsyncFlushBackpressure.Add(1)
+				domain.observeIndexedFlushForcedDrain()
 				flushStart := time.Now()
 				err := c.flushBufferedIndexedLocked(domain)
 				return collectionObservedElapsedSince(flushStart), 0, 0, err
@@ -3425,6 +3456,7 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 					return 0, lockReleased, relockWait, nil
 				}
 				if len(domain.indexedPublishingUnits) == 0 {
+					domain.observeIndexedFlushForcedDrain()
 					flushStart = time.Now()
 					err := c.flushBufferedIndexedLocked(domain)
 					return collectionObservedElapsedSince(flushStart), lockReleased, relockWait, err
@@ -3432,6 +3464,7 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 			}
 			flushStart = time.Now()
 			if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
+				domain.observeIndexedFlushForcedDrain()
 				err := c.flushBufferedIndexedLocked(domain)
 				return collectionObservedElapsedSince(flushStart), lockReleased, relockWait, err
 			}
@@ -3439,6 +3472,7 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 		}
 		flushStart := time.Now()
 		if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
+			domain.observeIndexedFlushForcedDrain()
 			err := c.flushBufferedIndexedLocked(domain)
 			return collectionObservedElapsedSince(flushStart), 0, 0, err
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1285,12 +1285,13 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	domain.mu.RLock()
 	stats.PendingDocuments = domain.count
 	stats.PendingBytes = domain.bufferedBytes
-	stats.PendingRootRuns = bufferedIndexedRootRunCount(domain)
+	pendingRootRuns := bufferedIndexedRootRunCount(domain)
+	stats.PendingRootRuns = pendingRootRuns
 	stats.PendingIndexedFlushUnits = len(domain.indexedPublishingUnits) + len(domain.indexedFlushUnits)
 	stats.OverlayMutableDocuments = domain.mutableCount
 	stats.OverlayQueuedIndexedFlushUnits = len(domain.indexedFlushUnits)
 	stats.OverlayActiveIndexedFlushUnits = len(domain.indexedPublishingUnits)
-	stats.OverlayVisibleDepth = collectionWriteDomainVisibleDepthLocked(domain)
+	stats.OverlayVisibleDepth = collectionWriteDomainVisibleDepthLocked(domain, pendingRootRuns)
 	stats.UpdateBatchIndexStatsCount = len(domain.meta.Indexes)
 	if stats.UpdateBatchIndexStatsCount > len(stats.UpdateBatchIndexStats) {
 		stats.UpdateBatchIndexStatsCount = len(stats.UpdateBatchIndexStats)
@@ -1396,12 +1397,12 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	return stats
 }
 
-func collectionWriteDomainVisibleDepthLocked(domain *collectionWriteDomain) int {
+func collectionWriteDomainVisibleDepthLocked(domain *collectionWriteDomain, pendingRootRuns int) int {
 	if domain == nil {
 		return 0
 	}
 	depth := len(domain.indexedPublishingUnits) + len(domain.indexedFlushUnits)
-	if hasBufferedIndexedRootRuns(domain) {
+	if pendingRootRuns > 0 {
 		depth++
 	}
 	return depth

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -422,9 +422,11 @@ type CollectionManagerStats struct {
 	IndexedAutoFlushes             uint64
 	IndexedAsyncFlushScheduled     uint64
 	IndexedAsyncFlushBackpressure  uint64
+	IndexedAsyncFlushWait          time.Duration
 	IndexedAsyncFlushErrors        uint64
 	IndexedFlushCalls              uint64
 	IndexedFlushErrors             uint64
+	IndexedFlushForcedDrains       uint64
 	IndexedFlushUnits              uint64
 	IndexedFlushDocs               uint64
 	IndexedFlushBytes              uint64
@@ -766,9 +768,11 @@ type collectionWriteDomain struct {
 	indexedAutoFlushes               atomic.Uint64
 	indexedAsyncFlushScheduled       atomic.Uint64
 	indexedAsyncFlushBackpressure    atomic.Uint64
+	indexedAsyncFlushWaitTotalNs     atomic.Uint64
 	indexedAsyncFlushErrors          atomic.Uint64
 	indexedFlushCalls                atomic.Uint64
 	indexedFlushErrors               atomic.Uint64
+	indexedFlushForcedDrains         atomic.Uint64
 	indexedFlushUnitsTotal           atomic.Uint64
 	indexedFlushDocs                 atomic.Uint64
 	indexedFlushBytes                atomic.Uint64
@@ -1010,9 +1014,11 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_stage.auto_flushes_total"] = fmt.Sprintf("%d", stats.IndexedAutoFlushes)
 	out["treedb.collections.write_domain.indexed_async_flush.scheduled_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushScheduled)
 	out["treedb.collections.write_domain.indexed_async_flush.backpressure_sync_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushBackpressure)
+	out["treedb.collections.write_domain.indexed_async_flush.wait_ns_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushWait.Nanoseconds())
 	out["treedb.collections.write_domain.indexed_async_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushErrors)
 	out["treedb.collections.write_domain.indexed_flush.calls_total"] = fmt.Sprintf("%d", stats.IndexedFlushCalls)
 	out["treedb.collections.write_domain.indexed_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedFlushErrors)
+	out["treedb.collections.write_domain.indexed_flush.forced_drains_total"] = fmt.Sprintf("%d", stats.IndexedFlushForcedDrains)
 	out["treedb.collections.write_domain.indexed_flush.units_total"] = fmt.Sprintf("%d", stats.IndexedFlushUnits)
 	out["treedb.collections.write_domain.indexed_flush.docs_total"] = fmt.Sprintf("%d", stats.IndexedFlushDocs)
 	out["treedb.collections.write_domain.indexed_flush.bytes_total"] = fmt.Sprintf("%d", stats.IndexedFlushBytes)
@@ -1203,9 +1209,11 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.IndexedAutoFlushes += other.IndexedAutoFlushes
 	s.IndexedAsyncFlushScheduled += other.IndexedAsyncFlushScheduled
 	s.IndexedAsyncFlushBackpressure += other.IndexedAsyncFlushBackpressure
+	s.IndexedAsyncFlushWait += other.IndexedAsyncFlushWait
 	s.IndexedAsyncFlushErrors += other.IndexedAsyncFlushErrors
 	s.IndexedFlushCalls += other.IndexedFlushCalls
 	s.IndexedFlushErrors += other.IndexedFlushErrors
+	s.IndexedFlushForcedDrains += other.IndexedFlushForcedDrains
 	s.IndexedFlushUnits += other.IndexedFlushUnits
 	s.IndexedFlushDocs += other.IndexedFlushDocs
 	s.IndexedFlushBytes += other.IndexedFlushBytes
@@ -1316,9 +1324,11 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.IndexedAutoFlushes = domain.indexedAutoFlushes.Load()
 	stats.IndexedAsyncFlushScheduled = domain.indexedAsyncFlushScheduled.Load()
 	stats.IndexedAsyncFlushBackpressure = domain.indexedAsyncFlushBackpressure.Load()
+	stats.IndexedAsyncFlushWait = durationFromAtomicNs(domain.indexedAsyncFlushWaitTotalNs.Load())
 	stats.IndexedAsyncFlushErrors = domain.indexedAsyncFlushErrors.Load()
 	stats.IndexedFlushCalls = domain.indexedFlushCalls.Load()
 	stats.IndexedFlushErrors = domain.indexedFlushErrors.Load()
+	stats.IndexedFlushForcedDrains = domain.indexedFlushForcedDrains.Load()
 	stats.IndexedFlushUnits = domain.indexedFlushUnitsTotal.Load()
 	stats.IndexedFlushDocs = domain.indexedFlushDocs.Load()
 	stats.IndexedFlushBytes = domain.indexedFlushBytes.Load()
@@ -1634,14 +1644,21 @@ func (domain *collectionWriteDomain) waitIndexedAsyncFlush() {
 	if domain == nil {
 		return
 	}
+	var waitStart time.Time
 	domain.indexedAsyncMu.Lock()
 	if domain.indexedAsyncCond == nil {
 		domain.indexedAsyncCond = sync.NewCond(&domain.indexedAsyncMu)
 	}
 	for domain.indexedAsyncRun {
+		if waitStart.IsZero() {
+			waitStart = time.Now()
+		}
 		domain.indexedAsyncCond.Wait()
 	}
 	domain.indexedAsyncMu.Unlock()
+	if !waitStart.IsZero() {
+		domain.indexedAsyncFlushWaitTotalNs.Add(durationToAtomicNs(time.Since(waitStart)))
+	}
 }
 
 func (domain *collectionWriteDomain) indexedAsyncFlushRunning() bool {
@@ -1700,6 +1717,13 @@ func (domain *collectionWriteDomain) observeIndexedFlush(units, docs int, bytes 
 	domain.indexedFlushDurationTotalNs.Add(durationToAtomicNs(duration))
 	domain.indexedFlushMaterializeTotalNs.Add(durationToAtomicNs(materialize))
 	domain.indexedFlushPublishTotalNs.Add(durationToAtomicNs(publish))
+}
+
+func (domain *collectionWriteDomain) observeIndexedFlushForcedDrain() {
+	if domain == nil {
+		return
+	}
+	domain.indexedFlushForcedDrains.Add(1)
 }
 
 type collectionRootDeltaPlanStats struct {
@@ -1861,6 +1885,9 @@ func flushCollectionWriteDomain(db *backenddb.DB, domain *collectionWriteDomain)
 	domain.waitIndexedAsyncFlush()
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
+	if hasBufferedIndexedRootRuns(domain) {
+		domain.observeIndexedFlushForcedDrain()
+	}
 	return collection.flushBufferedWritesLocked(domain)
 }
 
@@ -2776,6 +2803,9 @@ func (c *Collection) flushBufferedWrites() error {
 			domain.mu.Unlock()
 			continue
 		}
+		if hasBufferedIndexedRootRuns(domain) {
+			domain.observeIndexedFlushForcedDrain()
+		}
 		err := c.flushBufferedWritesLocked(domain)
 		domain.mu.Unlock()
 		return err
@@ -3401,6 +3431,7 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 		if opts.BufferedIndexedAsyncFlushMaxQueuedUnits > 0 && len(domain.indexedFlushUnits) >= opts.BufferedIndexedAsyncFlushMaxQueuedUnits {
 			if len(domain.indexedPublishingUnits) == 0 {
 				domain.indexedAsyncFlushBackpressure.Add(1)
+				domain.observeIndexedFlushForcedDrain()
 				flushStart := time.Now()
 				err := c.flushBufferedIndexedLocked(domain)
 				return collectionObservedElapsedSince(flushStart), 0, 0, err
@@ -3424,6 +3455,7 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 					return 0, lockReleased, relockWait, nil
 				}
 				if len(domain.indexedPublishingUnits) == 0 {
+					domain.observeIndexedFlushForcedDrain()
 					flushStart = time.Now()
 					err := c.flushBufferedIndexedLocked(domain)
 					return collectionObservedElapsedSince(flushStart), lockReleased, relockWait, err
@@ -3431,6 +3463,7 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 			}
 			flushStart = time.Now()
 			if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
+				domain.observeIndexedFlushForcedDrain()
 				err := c.flushBufferedIndexedLocked(domain)
 				return collectionObservedElapsedSince(flushStart), lockReleased, relockWait, err
 			}
@@ -3438,6 +3471,7 @@ func (c *Collection) flushBufferedIndexedAfterThresholdLocked(domain *collection
 		}
 		flushStart := time.Now()
 		if !c.scheduleIndexedAsyncFlush(domain) && len(domain.indexedPublishingUnits) == 0 {
+			domain.observeIndexedFlushForcedDrain()
 			err := c.flushBufferedIndexedLocked(domain)
 			return collectionObservedElapsedSince(flushStart), 0, 0, err
 		}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1147,6 +1147,7 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 		"treedb.collections.write_domain.overlay.visible_depth",
 		"treedb.collections.write_domain.indexed_stage.batches_total",
 		"treedb.collections.write_domain.indexed_async_flush.scheduled_total",
+		"treedb.collections.write_domain.indexed_async_flush.wait_ns_total",
 		"treedb.collections.write_domain.mutation_lock.calls_total",
 	} {
 		if exported[key] == "" {
@@ -1185,6 +1186,7 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	exported = mgr.Stats()
 	for _, key := range []string{
 		"treedb.collections.write_domain.indexed_flush.units_total",
+		"treedb.collections.write_domain.indexed_flush.forced_drains_total",
 		"treedb.collections.write_domain.indexed_flush.duration_ns_total",
 		"treedb.collections.write_domain.indexed_flush.materialize_ns_total",
 		"treedb.collections.write_domain.indexed_flush.publish_ns_total",
@@ -4874,6 +4876,12 @@ func TestCollectionIndexedWriteMemtablesAsyncBackpressureWaitsForPublishingUnit(
 	if got := stats.PendingDocuments; got != 0 {
 		t.Fatalf("pending documents after backpressure drain=%d want 0", got)
 	}
+	if got := stats.IndexedAsyncFlushWait; got <= 0 {
+		t.Fatalf("async flush wait=%s want positive", got)
+	}
+	if got := stats.IndexedFlushForcedDrains; got == 0 {
+		t.Fatal("indexed flush forced drains=0 want positive")
+	}
 	for _, id := range []string{"u1", "u2"} {
 		got, err := col.Get([]byte(id))
 		if err != nil {
@@ -4924,6 +4932,9 @@ func TestCollectionIndexedWriteMemtablesAsyncScheduleRacePublishesSynchronously(
 	}
 	if got := stats.IndexedFlushCalls; got != 1 {
 		t.Fatalf("indexed flush calls=%d want sync fallback flush", got)
+	}
+	if got := stats.IndexedFlushForcedDrains; got != 1 {
+		t.Fatalf("indexed flush forced drains=%d want 1", got)
 	}
 	if got := stats.PendingDocuments; got != 0 {
 		t.Fatalf("pending docs after sync fallback=%d want 0", got)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1189,10 +1189,14 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 		"treedb.collections.write_domain.indexed_flush.materialize_ns_total",
 		"treedb.collections.write_domain.indexed_flush.publish_ns_total",
 		"treedb.collections.write_domain.root_delta_plan.roots.primary_total",
+		"treedb.collections.write_domain.root_delta_plan.roots.template_total",
+		"treedb.collections.write_domain.root_delta_plan.roots.index_state_total",
 		"treedb.collections.write_domain.root_delta_plan.roots.secondary_total",
 		"treedb.collections.write_domain.root_delta_plan.entries_total",
 		"treedb.collections.write_domain.root_delta_plan.key_bytes_total",
 		"treedb.collections.write_domain.root_delta_plan.value_bytes_total",
+		"treedb.collections.write_domain.root_delta_plan.tombstones_total",
+		"treedb.collections.write_domain.primary_only.buffered_calls_total",
 	} {
 		if exported[key] == "" {
 			t.Fatalf("exported stats missing %s from %#v", key, exported)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1147,6 +1147,7 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 		"treedb.collections.write_domain.overlay.visible_depth",
 		"treedb.collections.write_domain.indexed_stage.batches_total",
 		"treedb.collections.write_domain.indexed_async_flush.scheduled_total",
+		"treedb.collections.write_domain.indexed_async_flush.wait_ns_total",
 		"treedb.collections.write_domain.mutation_lock.calls_total",
 	} {
 		if exported[key] == "" {
@@ -1185,6 +1186,7 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 	exported = mgr.Stats()
 	for _, key := range []string{
 		"treedb.collections.write_domain.indexed_flush.units_total",
+		"treedb.collections.write_domain.indexed_flush.forced_drains_total",
 		"treedb.collections.write_domain.indexed_flush.duration_ns_total",
 		"treedb.collections.write_domain.indexed_flush.materialize_ns_total",
 		"treedb.collections.write_domain.indexed_flush.publish_ns_total",
@@ -4878,6 +4880,12 @@ func TestCollectionIndexedWriteMemtablesAsyncBackpressureWaitsForPublishingUnit(
 	if got := stats.PendingDocuments; got != 0 {
 		t.Fatalf("pending documents after backpressure drain=%d want 0", got)
 	}
+	if got := stats.IndexedAsyncFlushWait; got <= 0 {
+		t.Fatalf("async flush wait=%s want positive", got)
+	}
+	if got := stats.IndexedFlushForcedDrains; got == 0 {
+		t.Fatal("indexed flush forced drains=0 want positive")
+	}
 	for _, id := range []string{"u1", "u2"} {
 		got, err := col.Get([]byte(id))
 		if err != nil {
@@ -4928,6 +4936,9 @@ func TestCollectionIndexedWriteMemtablesAsyncScheduleRacePublishesSynchronously(
 	}
 	if got := stats.IndexedFlushCalls; got != 1 {
 		t.Fatalf("indexed flush calls=%d want sync fallback flush", got)
+	}
+	if got := stats.IndexedFlushForcedDrains; got != 1 {
+		t.Fatalf("indexed flush forced drains=%d want 1", got)
 	}
 	if got := stats.PendingDocuments; got != 0 {
 		t.Fatalf("pending docs after sync fallback=%d want 0", got)

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1214,13 +1214,17 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushMaterialize:        12 * time.Millisecond,
 		IndexedFlushPublish:            18 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      3,
+		RootDeltaPlanTemplateRoots:     2,
+		RootDeltaPlanIndexStateRoots:   1,
 		RootDeltaPlanSecondaryRoots:    6,
 		RootDeltaPlanEntries:           300,
 		RootDeltaPlanKeyBytes:          1200,
 		RootDeltaPlanValueBytes:        2400,
+		RootDeltaPlanTombstones:        30,
 		PrimaryOnlyUpdateCalls:         10,
 		PrimaryOnlyMatched:             9,
 		PrimaryOnlyModified:            8,
+		PrimaryOnlyBufferedCalls:       1,
 		PrimaryOnlyRootPublishes:       8,
 		PrimaryOnlyRootDeltaEntries:    8,
 		PrimaryOnlyRootDeltaKeyBytes:   16,
@@ -1253,13 +1257,17 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushMaterialize:        30 * time.Millisecond,
 		IndexedFlushPublish:            60 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      8,
+		RootDeltaPlanTemplateRoots:     5,
+		RootDeltaPlanIndexStateRoots:   4,
 		RootDeltaPlanSecondaryRoots:    16,
 		RootDeltaPlanEntries:           900,
 		RootDeltaPlanKeyBytes:          3600,
 		RootDeltaPlanValueBytes:        7200,
+		RootDeltaPlanTombstones:        90,
 		PrimaryOnlyUpdateCalls:         17,
 		PrimaryOnlyMatched:             16,
 		PrimaryOnlyModified:            15,
+		PrimaryOnlyBufferedCalls:       3,
 		PrimaryOnlyRootPublishes:       15,
 		PrimaryOnlyRootDeltaEntries:    15,
 		PrimaryOnlyRootDeltaKeyBytes:   30,
@@ -1320,20 +1328,24 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 			got.IndexedFlushPublish,
 		)
 	}
-	if got.RootDeltaPlanPrimaryRoots != 5 || got.RootDeltaPlanSecondaryRoots != 10 || got.RootDeltaPlanEntries != 600 || got.RootDeltaPlanKeyBytes != 2400 || got.RootDeltaPlanValueBytes != 4800 {
-		t.Fatalf("root delta plan stats=%d/%d/%d/%d/%d want 5/10/600/2400/4800",
+	if got.RootDeltaPlanPrimaryRoots != 5 || got.RootDeltaPlanTemplateRoots != 3 || got.RootDeltaPlanIndexStateRoots != 3 || got.RootDeltaPlanSecondaryRoots != 10 || got.RootDeltaPlanEntries != 600 || got.RootDeltaPlanKeyBytes != 2400 || got.RootDeltaPlanValueBytes != 4800 || got.RootDeltaPlanTombstones != 60 {
+		t.Fatalf("root delta plan stats=%d/%d/%d/%d/%d/%d/%d/%d want 5/3/3/10/600/2400/4800/60",
 			got.RootDeltaPlanPrimaryRoots,
+			got.RootDeltaPlanTemplateRoots,
+			got.RootDeltaPlanIndexStateRoots,
 			got.RootDeltaPlanSecondaryRoots,
 			got.RootDeltaPlanEntries,
 			got.RootDeltaPlanKeyBytes,
 			got.RootDeltaPlanValueBytes,
+			got.RootDeltaPlanTombstones,
 		)
 	}
-	if got.PrimaryOnlyUpdateCalls != 7 || got.PrimaryOnlyMatched != 7 || got.PrimaryOnlyModified != 7 || got.PrimaryOnlyRootPublishes != 7 || got.PrimaryOnlyRootDeltaEntries != 7 || got.PrimaryOnlyRootDeltaKeyBytes != 14 || got.PrimaryOnlyRootDeltaValueBytes != 140 || got.PrimaryOnlyCoalescedDocs != 7 {
-		t.Fatalf("primary-only stats calls/matched/modified/publishes/entries/key/value/coalesced=%d/%d/%d/%d/%d/%d/%d/%d want 7/7/7/7/7/14/140/7",
+	if got.PrimaryOnlyUpdateCalls != 7 || got.PrimaryOnlyMatched != 7 || got.PrimaryOnlyModified != 7 || got.PrimaryOnlyBufferedCalls != 2 || got.PrimaryOnlyRootPublishes != 7 || got.PrimaryOnlyRootDeltaEntries != 7 || got.PrimaryOnlyRootDeltaKeyBytes != 14 || got.PrimaryOnlyRootDeltaValueBytes != 140 || got.PrimaryOnlyCoalescedDocs != 7 {
+		t.Fatalf("primary-only stats calls/matched/modified/buffered/publishes/entries/key/value/coalesced=%d/%d/%d/%d/%d/%d/%d/%d/%d want 7/7/7/2/7/7/14/140/7",
 			got.PrimaryOnlyUpdateCalls,
 			got.PrimaryOnlyMatched,
 			got.PrimaryOnlyModified,
+			got.PrimaryOnlyBufferedCalls,
 			got.PrimaryOnlyRootPublishes,
 			got.PrimaryOnlyRootDeltaEntries,
 			got.PrimaryOnlyRootDeltaKeyBytes,
@@ -1373,13 +1385,17 @@ func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testin
 		IndexedFlushMaterialize:        18 * time.Millisecond,
 		IndexedFlushPublish:            42 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      5,
+		RootDeltaPlanTemplateRoots:     2,
+		RootDeltaPlanIndexStateRoots:   3,
 		RootDeltaPlanSecondaryRoots:    10,
 		RootDeltaPlanEntries:           600,
 		RootDeltaPlanKeyBytes:          2400,
 		RootDeltaPlanValueBytes:        4800,
+		RootDeltaPlanTombstones:        60,
 		PrimaryOnlyUpdateCalls:         600,
 		PrimaryOnlyMatched:             600,
 		PrimaryOnlyModified:            600,
+		PrimaryOnlyBufferedCalls:       30,
 		PrimaryOnlyRootPublishes:       600,
 		PrimaryOnlyRootDeltaEntries:    600,
 		PrimaryOnlyRootDeltaKeyBytes:   1200,
@@ -1414,11 +1430,16 @@ func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testin
 		"root_delta_plan_entries/doc":         1,
 		"root_delta_plan_key_bytes/doc":       4,
 		"root_delta_plan_value_bytes/doc":     8,
+		"root_delta_plan_tombstones/doc":      0.1,
 		"affected_primary_roots/doc":          1.0 / 120.0,
+		"affected_template_roots/doc":         1.0 / 300.0,
+		"affected_index_state_roots/doc":      0.005,
 		"affected_secondary_roots/doc":        1.0 / 60.0,
 		"primary_only_update_calls/doc":       1,
 		"primary_only_matched/doc":            1,
 		"primary_only_modified/doc":           1,
+		"primary_only_buffered_calls":         30,
+		"primary_only_buffered_calls/doc":     0.05,
 		"primary_root_publishes/doc":          1,
 		"primary_root_delta_entries/doc":      1,
 		"primary_root_delta_bytes/doc":        22,
@@ -1566,6 +1587,10 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	}
 	if stats.PrimaryOnlyModified > 0 {
 		b.ReportMetric(float64(stats.PrimaryOnlyModified)/float64(docs), "primary_only_modified/doc")
+	}
+	if stats.PrimaryOnlyBufferedCalls > 0 {
+		b.ReportMetric(float64(stats.PrimaryOnlyBufferedCalls), "primary_only_buffered_calls")
+		b.ReportMetric(float64(stats.PrimaryOnlyBufferedCalls)/float64(docs), "primary_only_buffered_calls/doc")
 	}
 	if stats.PrimaryOnlyRootPublishes > 0 {
 		b.ReportMetric(float64(stats.PrimaryOnlyRootPublishes)/float64(docs), "primary_root_publishes/doc")

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1115,6 +1115,7 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateCombineFallbackRequests:  after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
 		IndexedFlushCalls:              after.IndexedFlushCalls - before.IndexedFlushCalls,
 		IndexedFlushErrors:             after.IndexedFlushErrors - before.IndexedFlushErrors,
+		IndexedFlushForcedDrains:       after.IndexedFlushForcedDrains - before.IndexedFlushForcedDrains,
 		IndexedFlushUnits:              after.IndexedFlushUnits - before.IndexedFlushUnits,
 		IndexedFlushDocs:               after.IndexedFlushDocs - before.IndexedFlushDocs,
 		IndexedFlushBytes:              after.IndexedFlushBytes - before.IndexedFlushBytes,
@@ -1123,6 +1124,7 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		IndexedFlushDuration:           after.IndexedFlushDuration - before.IndexedFlushDuration,
 		IndexedFlushMaterialize:        after.IndexedFlushMaterialize - before.IndexedFlushMaterialize,
 		IndexedFlushPublish:            after.IndexedFlushPublish - before.IndexedFlushPublish,
+		IndexedAsyncFlushWait:          after.IndexedAsyncFlushWait - before.IndexedAsyncFlushWait,
 		RootDeltaPlanPrimaryRoots:      after.RootDeltaPlanPrimaryRoots - before.RootDeltaPlanPrimaryRoots,
 		RootDeltaPlanTemplateRoots:     after.RootDeltaPlanTemplateRoots - before.RootDeltaPlanTemplateRoots,
 		RootDeltaPlanIndexStateRoots:   after.RootDeltaPlanIndexStateRoots - before.RootDeltaPlanIndexStateRoots,
@@ -1205,6 +1207,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateBatchUniqueCheckSkips:    10,
 		IndexedFlushCalls:              3,
 		IndexedFlushErrors:             1,
+		IndexedFlushForcedDrains:       2,
 		IndexedFlushUnits:              6,
 		IndexedFlushDocs:               300,
 		IndexedFlushBytes:              9000,
@@ -1213,6 +1216,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushDuration:           30 * time.Millisecond,
 		IndexedFlushMaterialize:        12 * time.Millisecond,
 		IndexedFlushPublish:            18 * time.Millisecond,
+		IndexedAsyncFlushWait:          2 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      3,
 		RootDeltaPlanTemplateRoots:     2,
 		RootDeltaPlanIndexStateRoots:   1,
@@ -1248,6 +1252,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateBatchUniqueCheckSkips:    19,
 		IndexedFlushCalls:              8,
 		IndexedFlushErrors:             2,
+		IndexedFlushForcedDrains:       5,
 		IndexedFlushUnits:              16,
 		IndexedFlushDocs:               900,
 		IndexedFlushBytes:              27000,
@@ -1256,6 +1261,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushDuration:           90 * time.Millisecond,
 		IndexedFlushMaterialize:        30 * time.Millisecond,
 		IndexedFlushPublish:            60 * time.Millisecond,
+		IndexedAsyncFlushWait:          11 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      8,
 		RootDeltaPlanTemplateRoots:     5,
 		RootDeltaPlanIndexStateRoots:   4,
@@ -1314,10 +1320,11 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	if got.UpdateBatchUniqueCheckSkips != 9 {
 		t.Fatalf("UpdateBatchUniqueCheckSkips=%d want 9", got.UpdateBatchUniqueCheckSkips)
 	}
-	if got.IndexedFlushCalls != 5 || got.IndexedFlushErrors != 1 || got.IndexedFlushUnits != 10 || got.IndexedFlushDocs != 600 || got.IndexedFlushBytes != 18000 || got.IndexedFlushRootRuns != 180 || got.IndexedFlushRoots != 15 || got.IndexedFlushDuration != 60*time.Millisecond || got.IndexedFlushMaterialize != 18*time.Millisecond || got.IndexedFlushPublish != 42*time.Millisecond {
-		t.Fatalf("indexed flush delta calls/errors/units/docs/bytes/rootRuns/roots/duration/materialize/publish=%d/%d/%d/%d/%d/%d/%d/%s/%s/%s want 5/1/10/600/18000/180/15/60ms/18ms/42ms",
+	if got.IndexedFlushCalls != 5 || got.IndexedFlushErrors != 1 || got.IndexedFlushForcedDrains != 3 || got.IndexedFlushUnits != 10 || got.IndexedFlushDocs != 600 || got.IndexedFlushBytes != 18000 || got.IndexedFlushRootRuns != 180 || got.IndexedFlushRoots != 15 || got.IndexedFlushDuration != 60*time.Millisecond || got.IndexedFlushMaterialize != 18*time.Millisecond || got.IndexedFlushPublish != 42*time.Millisecond || got.IndexedAsyncFlushWait != 9*time.Millisecond {
+		t.Fatalf("indexed flush delta calls/errors/forced/units/docs/bytes/rootRuns/roots/duration/materialize/publish/wait=%d/%d/%d/%d/%d/%d/%d/%d/%s/%s/%s/%s want 5/1/3/10/600/18000/180/15/60ms/18ms/42ms/9ms",
 			got.IndexedFlushCalls,
 			got.IndexedFlushErrors,
+			got.IndexedFlushForcedDrains,
 			got.IndexedFlushUnits,
 			got.IndexedFlushDocs,
 			got.IndexedFlushBytes,
@@ -1326,6 +1333,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 			got.IndexedFlushDuration,
 			got.IndexedFlushMaterialize,
 			got.IndexedFlushPublish,
+			got.IndexedAsyncFlushWait,
 		)
 	}
 	if got.RootDeltaPlanPrimaryRoots != 5 || got.RootDeltaPlanTemplateRoots != 3 || got.RootDeltaPlanIndexStateRoots != 3 || got.RootDeltaPlanSecondaryRoots != 10 || got.RootDeltaPlanEntries != 600 || got.RootDeltaPlanKeyBytes != 2400 || got.RootDeltaPlanValueBytes != 4800 || got.RootDeltaPlanTombstones != 60 {
@@ -1376,6 +1384,7 @@ func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testin
 	stats := collections.CollectionManagerStats{
 		IndexedFlushCalls:              5,
 		IndexedFlushErrors:             1,
+		IndexedFlushForcedDrains:       2,
 		IndexedFlushUnits:              10,
 		IndexedFlushDocs:               600,
 		IndexedFlushBytes:              18000,
@@ -1384,6 +1393,7 @@ func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testin
 		IndexedFlushDuration:           60 * time.Millisecond,
 		IndexedFlushMaterialize:        18 * time.Millisecond,
 		IndexedFlushPublish:            42 * time.Millisecond,
+		IndexedAsyncFlushWait:          6 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      5,
 		RootDeltaPlanTemplateRoots:     2,
 		RootDeltaPlanIndexStateRoots:   3,
@@ -1421,12 +1431,16 @@ func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testin
 		"indexed_flush_roots/call":            3,
 		"indexed_flush_roots/doc":             0.025,
 		"indexed_flush_errors":                1,
+		"indexed_flush_forced_drains":         2,
+		"indexed_flush_forced_drains/doc":     1.0 / 300.0,
 		"indexed_flush_ns/call":               12_000_000,
 		"indexed_flush_ns/doc":                100_000,
 		"indexed_flush_materialize_ns/call":   3_600_000,
 		"indexed_flush_materialize_ns/doc":    30_000,
 		"indexed_flush_publish_ns/call":       8_400_000,
 		"indexed_flush_publish_ns/doc":        70_000,
+		"indexed_async_flush_wait_ns":         6_000_000,
+		"indexed_async_flush_wait_ns/doc":     10_000,
 		"root_delta_plan_entries/doc":         1,
 		"root_delta_plan_key_bytes/doc":       4,
 		"root_delta_plan_value_bytes/doc":     8,
@@ -1524,6 +1538,10 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 		if stats.IndexedFlushErrors > 0 {
 			b.ReportMetric(float64(stats.IndexedFlushErrors), "indexed_flush_errors")
 		}
+		if stats.IndexedFlushForcedDrains > 0 {
+			b.ReportMetric(float64(stats.IndexedFlushForcedDrains), "indexed_flush_forced_drains")
+			b.ReportMetric(float64(stats.IndexedFlushForcedDrains)/float64(docs), "indexed_flush_forced_drains/doc")
+		}
 		if stats.IndexedFlushDuration > 0 {
 			b.ReportMetric(float64(stats.IndexedFlushDuration.Nanoseconds())/float64(stats.IndexedFlushCalls), "indexed_flush_ns/call")
 			if stats.IndexedFlushDocs > 0 {
@@ -1542,6 +1560,10 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 				b.ReportMetric(float64(stats.IndexedFlushPublish.Nanoseconds())/float64(stats.IndexedFlushDocs), "indexed_flush_publish_ns/doc")
 			}
 		}
+	}
+	if stats.IndexedAsyncFlushWait > 0 {
+		b.ReportMetric(float64(stats.IndexedAsyncFlushWait.Nanoseconds()), "indexed_async_flush_wait_ns")
+		b.ReportMetric(float64(stats.IndexedAsyncFlushWait.Nanoseconds())/float64(docs), "indexed_async_flush_wait_ns/doc")
 	}
 	if stats.OverlayMutableDocuments > 0 {
 		b.ReportMetric(float64(stats.OverlayMutableDocuments), "overlay_mutable_docs")

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1115,6 +1115,7 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateCombineFallbackRequests:  after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
 		IndexedFlushCalls:              after.IndexedFlushCalls - before.IndexedFlushCalls,
 		IndexedFlushErrors:             after.IndexedFlushErrors - before.IndexedFlushErrors,
+		IndexedFlushForcedDrains:       after.IndexedFlushForcedDrains - before.IndexedFlushForcedDrains,
 		IndexedFlushUnits:              after.IndexedFlushUnits - before.IndexedFlushUnits,
 		IndexedFlushDocs:               after.IndexedFlushDocs - before.IndexedFlushDocs,
 		IndexedFlushBytes:              after.IndexedFlushBytes - before.IndexedFlushBytes,
@@ -1123,6 +1124,7 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		IndexedFlushDuration:           after.IndexedFlushDuration - before.IndexedFlushDuration,
 		IndexedFlushMaterialize:        after.IndexedFlushMaterialize - before.IndexedFlushMaterialize,
 		IndexedFlushPublish:            after.IndexedFlushPublish - before.IndexedFlushPublish,
+		IndexedAsyncFlushWait:          after.IndexedAsyncFlushWait - before.IndexedAsyncFlushWait,
 		RootDeltaPlanPrimaryRoots:      after.RootDeltaPlanPrimaryRoots - before.RootDeltaPlanPrimaryRoots,
 		RootDeltaPlanTemplateRoots:     after.RootDeltaPlanTemplateRoots - before.RootDeltaPlanTemplateRoots,
 		RootDeltaPlanIndexStateRoots:   after.RootDeltaPlanIndexStateRoots - before.RootDeltaPlanIndexStateRoots,
@@ -1205,6 +1207,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateBatchUniqueCheckSkips:    10,
 		IndexedFlushCalls:              3,
 		IndexedFlushErrors:             1,
+		IndexedFlushForcedDrains:       2,
 		IndexedFlushUnits:              6,
 		IndexedFlushDocs:               300,
 		IndexedFlushBytes:              9000,
@@ -1213,6 +1216,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushDuration:           30 * time.Millisecond,
 		IndexedFlushMaterialize:        12 * time.Millisecond,
 		IndexedFlushPublish:            18 * time.Millisecond,
+		IndexedAsyncFlushWait:          2 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      3,
 		RootDeltaPlanSecondaryRoots:    6,
 		RootDeltaPlanEntries:           300,
@@ -1244,6 +1248,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateBatchUniqueCheckSkips:    19,
 		IndexedFlushCalls:              8,
 		IndexedFlushErrors:             2,
+		IndexedFlushForcedDrains:       5,
 		IndexedFlushUnits:              16,
 		IndexedFlushDocs:               900,
 		IndexedFlushBytes:              27000,
@@ -1252,6 +1257,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		IndexedFlushDuration:           90 * time.Millisecond,
 		IndexedFlushMaterialize:        30 * time.Millisecond,
 		IndexedFlushPublish:            60 * time.Millisecond,
+		IndexedAsyncFlushWait:          11 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      8,
 		RootDeltaPlanSecondaryRoots:    16,
 		RootDeltaPlanEntries:           900,
@@ -1306,10 +1312,11 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	if got.UpdateBatchUniqueCheckSkips != 9 {
 		t.Fatalf("UpdateBatchUniqueCheckSkips=%d want 9", got.UpdateBatchUniqueCheckSkips)
 	}
-	if got.IndexedFlushCalls != 5 || got.IndexedFlushErrors != 1 || got.IndexedFlushUnits != 10 || got.IndexedFlushDocs != 600 || got.IndexedFlushBytes != 18000 || got.IndexedFlushRootRuns != 180 || got.IndexedFlushRoots != 15 || got.IndexedFlushDuration != 60*time.Millisecond || got.IndexedFlushMaterialize != 18*time.Millisecond || got.IndexedFlushPublish != 42*time.Millisecond {
-		t.Fatalf("indexed flush delta calls/errors/units/docs/bytes/rootRuns/roots/duration/materialize/publish=%d/%d/%d/%d/%d/%d/%d/%s/%s/%s want 5/1/10/600/18000/180/15/60ms/18ms/42ms",
+	if got.IndexedFlushCalls != 5 || got.IndexedFlushErrors != 1 || got.IndexedFlushForcedDrains != 3 || got.IndexedFlushUnits != 10 || got.IndexedFlushDocs != 600 || got.IndexedFlushBytes != 18000 || got.IndexedFlushRootRuns != 180 || got.IndexedFlushRoots != 15 || got.IndexedFlushDuration != 60*time.Millisecond || got.IndexedFlushMaterialize != 18*time.Millisecond || got.IndexedFlushPublish != 42*time.Millisecond || got.IndexedAsyncFlushWait != 9*time.Millisecond {
+		t.Fatalf("indexed flush delta calls/errors/forced/units/docs/bytes/rootRuns/roots/duration/materialize/publish/wait=%d/%d/%d/%d/%d/%d/%d/%d/%s/%s/%s/%s want 5/1/3/10/600/18000/180/15/60ms/18ms/42ms/9ms",
 			got.IndexedFlushCalls,
 			got.IndexedFlushErrors,
+			got.IndexedFlushForcedDrains,
 			got.IndexedFlushUnits,
 			got.IndexedFlushDocs,
 			got.IndexedFlushBytes,
@@ -1318,6 +1325,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 			got.IndexedFlushDuration,
 			got.IndexedFlushMaterialize,
 			got.IndexedFlushPublish,
+			got.IndexedAsyncFlushWait,
 		)
 	}
 	if got.RootDeltaPlanPrimaryRoots != 5 || got.RootDeltaPlanSecondaryRoots != 10 || got.RootDeltaPlanEntries != 600 || got.RootDeltaPlanKeyBytes != 2400 || got.RootDeltaPlanValueBytes != 4800 {
@@ -1364,6 +1372,7 @@ func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testin
 	stats := collections.CollectionManagerStats{
 		IndexedFlushCalls:              5,
 		IndexedFlushErrors:             1,
+		IndexedFlushForcedDrains:       2,
 		IndexedFlushUnits:              10,
 		IndexedFlushDocs:               600,
 		IndexedFlushBytes:              18000,
@@ -1372,6 +1381,7 @@ func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testin
 		IndexedFlushDuration:           60 * time.Millisecond,
 		IndexedFlushMaterialize:        18 * time.Millisecond,
 		IndexedFlushPublish:            42 * time.Millisecond,
+		IndexedAsyncFlushWait:          6 * time.Millisecond,
 		RootDeltaPlanPrimaryRoots:      5,
 		RootDeltaPlanSecondaryRoots:    10,
 		RootDeltaPlanEntries:           600,
@@ -1405,12 +1415,16 @@ func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testin
 		"indexed_flush_roots/call":            3,
 		"indexed_flush_roots/doc":             0.025,
 		"indexed_flush_errors":                1,
+		"indexed_flush_forced_drains":         2,
+		"indexed_flush_forced_drains/doc":     1.0 / 300.0,
 		"indexed_flush_ns/call":               12_000_000,
 		"indexed_flush_ns/doc":                100_000,
 		"indexed_flush_materialize_ns/call":   3_600_000,
 		"indexed_flush_materialize_ns/doc":    30_000,
 		"indexed_flush_publish_ns/call":       8_400_000,
 		"indexed_flush_publish_ns/doc":        70_000,
+		"indexed_async_flush_wait_ns":         6_000_000,
+		"indexed_async_flush_wait_ns/doc":     10_000,
 		"root_delta_plan_entries/doc":         1,
 		"root_delta_plan_key_bytes/doc":       4,
 		"root_delta_plan_value_bytes/doc":     8,
@@ -1503,6 +1517,10 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 		if stats.IndexedFlushErrors > 0 {
 			b.ReportMetric(float64(stats.IndexedFlushErrors), "indexed_flush_errors")
 		}
+		if stats.IndexedFlushForcedDrains > 0 {
+			b.ReportMetric(float64(stats.IndexedFlushForcedDrains), "indexed_flush_forced_drains")
+			b.ReportMetric(float64(stats.IndexedFlushForcedDrains)/float64(docs), "indexed_flush_forced_drains/doc")
+		}
 		if stats.IndexedFlushDuration > 0 {
 			b.ReportMetric(float64(stats.IndexedFlushDuration.Nanoseconds())/float64(stats.IndexedFlushCalls), "indexed_flush_ns/call")
 			if stats.IndexedFlushDocs > 0 {
@@ -1521,6 +1539,10 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 				b.ReportMetric(float64(stats.IndexedFlushPublish.Nanoseconds())/float64(stats.IndexedFlushDocs), "indexed_flush_publish_ns/doc")
 			}
 		}
+	}
+	if stats.IndexedAsyncFlushWait > 0 {
+		b.ReportMetric(float64(stats.IndexedAsyncFlushWait.Nanoseconds()), "indexed_async_flush_wait_ns")
+		b.ReportMetric(float64(stats.IndexedAsyncFlushWait.Nanoseconds())/float64(docs), "indexed_async_flush_wait_ns/doc")
 	}
 	if stats.OverlayMutableDocuments > 0 {
 		b.ReportMetric(float64(stats.OverlayMutableDocuments), "overlay_mutable_docs")


### PR DESCRIPTION
Stacked on #1285. This finishes the PR1B async-flush observability slice by exposing the queue/wait side of indexed flush behavior without changing publish semantics.

Changes:
- Add `indexed_async_flush.wait_ns_total` and `indexed_flush.forced_drains_total` to collection manager stats.
- Count blocking time spent waiting for an active async indexed flush and count synchronous forced-drain fallback paths.
- Report the new deltas in mongo gateway profile benchmark metrics.
- Extend focused stats/backpressure/schedule-race tests.

Local tests:
- `go test ./TreeDB/collections -run 'TestCollectionIndexedWriteMemtablesAsync(BackpressureWaitsForPublishingUnit|ScheduleRacePublishesSynchronously)|TestCollectionManagerStatsExposeIndexedWriteDomainMetrics' -count=1`\n- `go test ./cmd/mongo_gateway_bench -run 'Test(DeltaCollectionManagerUpdateStatsIncludesCombinerStats|ReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics)' -count=1`\n- `go test ./TreeDB/collections -count=1`\n- `go test ./cmd/mongo_gateway_bench -count=1`\n- `go test ./cmd/internal/treedbstats -count=1`