### PR TITLE
bench: write scaling writer metrics TSV

### DIFF
--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -312,6 +312,7 @@ DATABASE_PREFIX=$(mongo_database_prefix_label "$DATABASE_PREFIX")
 RAW_DIR="$OUT_DIR/raw"
 BIN_DIR="$OUT_DIR/bin"
 MATRIX="$OUT_DIR/matrix.tsv"
+WRITER_METRICS="$OUT_DIR/writer_metrics.tsv"
 REPORT="$OUT_DIR/report.md"
 SUMMARY="$OUT_DIR/summary.tsv"
 README="$OUT_DIR/README.md"
@@ -351,6 +352,11 @@ report_treedb_location_on_exit() {
 trap 'report_treedb_location_on_exit "$?"' EXIT
 
 mkdir -p "$RAW_DIR" "$TREE_DIR" "$BIN_DIR"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required to write writer_metrics.tsv" >&2
+  exit 2
+fi
 
 BENCH_BIN="$BIN_DIR/mongo_gateway_bench"
 REPORT_BIN="$BIN_DIR/mongo_gateway_compare_report"
@@ -474,6 +480,142 @@ fi
   -title "$TITLE" \
   "${report_extra[@]}"
 
+python3 - "$OUT_DIR" "$MATRIX" "$WRITER_METRICS" <<'PY'
+import csv
+import json
+import os
+import re
+import sys
+
+out_dir, matrix_path, writer_metrics_path = sys.argv[1:4]
+
+columns = [
+    "target",
+    "config",
+    "documents",
+    "secondary_indexes",
+    "writers",
+    "phase",
+    "ops_per_sec",
+    "sampled_ns_per_op",
+    "driver_calls",
+    "publish_delta_group_calls_per_doc",
+    "root_apply_calls_per_doc",
+    "roots_per_publish",
+    "primary_root_publishes_per_doc",
+    "primary_root_delta_entries_per_doc",
+    "primary_root_delta_bytes_per_doc",
+    "indexed_flush_units_per_batch",
+    "indexed_flush_docs_per_batch",
+    "leaf_log_node_loads_per_doc",
+    "leaf_log_pages_written_per_doc",
+    "leaf_log_read_bytes_per_doc",
+    "leaf_log_write_bytes_per_doc",
+    "backpressure_sync_total",
+    "root_mismatch_total",
+    "raw_json",
+]
+
+metric_columns = {
+    "publish_delta_group_calls_per_doc": "publish_delta_group_calls/doc",
+    "root_apply_calls_per_doc": "root_apply_calls/doc",
+    "roots_per_publish": "roots/publish",
+    "primary_root_publishes_per_doc": "primary_root_publishes/doc",
+    "primary_root_delta_entries_per_doc": "primary_root_delta_entries/doc",
+    "primary_root_delta_bytes_per_doc": "primary_root_delta_bytes/doc",
+    "indexed_flush_units_per_batch": "indexed_flush_units/batch",
+    "indexed_flush_docs_per_batch": "indexed_flush_docs/batch",
+    "leaf_log_node_loads_per_doc": "leaf_log_node_loads/doc",
+    "leaf_log_pages_written_per_doc": "leaf_log_pages_written/doc",
+    "leaf_log_read_bytes_per_doc": "leaf_log_read_bytes/doc",
+    "leaf_log_write_bytes_per_doc": "leaf_log_write_bytes/doc",
+}
+
+writer_phase_re = re.compile(r"^concurrent_id_update_set_w([0-9]+)$")
+
+
+def fmt(value):
+    if value is None or value == "":
+        return ""
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return format(value, ".12g")
+    return str(value)
+
+
+def parse_number(value):
+    if value is None or value == "":
+        return 0.0, False
+    try:
+        return float(value), True
+    except (TypeError, ValueError):
+        return 0.0, False
+
+
+def delta_count(delta, keys):
+    found = False
+    total = 0.0
+    for key in keys:
+        if key not in delta:
+            continue
+        found = True
+        value, ok = parse_number(delta.get(key))
+        if ok:
+            total += value
+    if not found:
+        return ""
+    return fmt(total)
+
+
+with open(writer_metrics_path, "w", newline="") as out_file:
+    writer = csv.DictWriter(out_file, fieldnames=columns, delimiter="\t", lineterminator="\n")
+    writer.writeheader()
+    with open(matrix_path, newline="") as matrix_file:
+        matrix = csv.DictReader(matrix_file, delimiter="\t")
+        for row in matrix:
+            raw_json = row.get("raw_json", "")
+            if not raw_json:
+                continue
+            raw_path = raw_json if os.path.isabs(raw_json) else os.path.join(out_dir, raw_json)
+            with open(raw_path) as raw_file:
+                result = json.load(raw_file)
+            target = row.get("target") or result.get("target", "")
+            config = row.get("config", "")
+            documents = row.get("documents") or str(result.get("documents", ""))
+            secondary_indexes = row.get("secondary_indexes") or str(result.get("secondary_indexes", ""))
+            for phase in result.get("phases") or []:
+                phase_name = phase.get("name", "")
+                match = writer_phase_re.match(phase_name)
+                if not match:
+                    continue
+                metrics = phase.get("treedb_metrics") or {}
+                delta = phase.get("treedb_stats_delta") or {}
+                out = {
+                    "target": target,
+                    "config": config,
+                    "documents": documents,
+                    "secondary_indexes": secondary_indexes,
+                    "writers": match.group(1),
+                    "phase": phase_name,
+                    "ops_per_sec": fmt(phase.get("ops_per_sec")),
+                    "sampled_ns_per_op": fmt(phase.get("sampled_ns_per_op")),
+                    "driver_calls": fmt(phase.get("driver_calls")),
+                    "raw_json": raw_json,
+                }
+                for column, metric_name in metric_columns.items():
+                    out[column] = fmt(metrics.get(metric_name))
+                out["backpressure_sync_total"] = delta_count(delta, [
+                    "treedb.collections.write_domain.indexed_async_flush.backpressure_sync_total",
+                ])
+                out["root_mismatch_total"] = delta_count(delta, [
+                    "treedb.collections.write_domain.collection_root_base_mismatch_total",
+                    "treedb.collections.write_domain.indexed_flush.root_base_mismatch_total",
+                    "treedb.collections.write_domain.coordinator_requeue_on_mismatch_total",
+                ])
+                writer.writerow(out)
+PY
+
 report_extra_text=""
 if (( ${#report_extra[@]} > 0 )); then
   report_extra_text=" \\
@@ -487,6 +629,7 @@ cat >"$README" <<EOF
 - report: \`$REPORT\`
 - summary TSV: \`$SUMMARY\`
 - matrix TSV: \`$MATRIX\`
+- writer metrics TSV: \`$WRITER_METRICS\`
 - raw JSON directory: \`$RAW_DIR\`
 - TreeDB data directory: \`$TREE_DIR\`
 - TreeDB location metadata: \`$TREE_METADATA\`
@@ -522,4 +665,5 @@ EOF
 
 echo "scaling report: $REPORT"
 echo "summary TSV: $SUMMARY"
+echo "writer metrics TSV: $WRITER_METRICS"
 echo "bundle README: $README"


### PR DESCRIPTION
Stacked on #1245. This adds the optional PR1B scaling-script artifact requested by the #1242 measurement plan: a `writer_metrics.tsv` file beside `matrix.tsv` for the dedicated writer sweep.

Changes:
- Keep existing benchmark behavior and `matrix.tsv` unchanged.
- Post-process raw `mongo_gateway_bench` JSON rows into `writer_metrics.tsv`.
- Emit one row per `concurrent_id_update_set_wN` phase with writer count, phase throughput/latency, selected normalized TreeDB metrics, queue/backpressure count, root mismatch count, and raw JSON path.
- Document and print the writer metrics TSV path in the scaling bundle.

Local checks:
- `bash -n scripts/mongo_gateway_scaling_bench.sh`
- `go test ./cmd/mongo_gateway_bench ./cmd/mongo_gateway_compare_report -count=1`
- Tiny smoke: `OUT_DIR=$(mktemp -d /tmp/gomap_scaling_writer_metrics_smoke_XXXXXX) DOCS=20 INDEXES=0 BATCH_SIZE=10 INSERT_PRODUCERS=1 WRITERS_LIST="1" READERS_LIST="" CONCURRENT_WRITES=5 CONCURRENT_READS=1 TIMEOUT=2m GOWORK=off scripts/mongo_gateway_scaling_bench.sh` and verified `writer_metrics.tsv` contained the `concurrent_id_update_set_w1` row.

Note: setting `READERS_LIST=""` still falls back to the script default reader sweep because that is existing `${READERS_LIST:-...}` behavior; this PR does not change that.