### PR TITLE
collections: count update mask fallbacks

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -359,6 +359,7 @@ type CollectionUpdateStats struct {
 	SecondaryRuns          []CollectionUpdateSecondaryRunStats
 	IndexValueChanges      int
 	IndexValueUnchanged    int
+	MaskFallbacks          int
 	UniqueIndexChecks      int
 	UniqueIndexCheckSkips  int
 	// IndexStats is populated only when detailed update-batch stats are enabled
@@ -471,6 +472,7 @@ type CollectionManagerStats struct {
 	UpdateBatchSecondaryKeyBytes   uint64
 	UpdateBatchIndexValueChanges   uint64
 	UpdateBatchIndexValueUnchanged uint64
+	UpdateBatchMaskFallbacks       uint64
 	UpdateBatchUniqueChecks        uint64
 	UpdateBatchUniqueCheckSkips    uint64
 	UpdateBatchIndexStatsCount     int
@@ -789,6 +791,7 @@ type collectionWriteDomain struct {
 	updateBatchSecondaryKeyBytes     atomic.Uint64
 	updateBatchIndexValueChanges     atomic.Uint64
 	updateBatchIndexValueUnchanged   atomic.Uint64
+	updateBatchMaskFallbacks         atomic.Uint64
 	updateBatchUniqueChecks          atomic.Uint64
 	updateBatchUniqueCheckSkips      atomic.Uint64
 	updateBatchDetailedStats         atomic.Bool
@@ -1011,6 +1014,7 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.update_batch.secondary_key_bytes_total"] = fmt.Sprintf("%d", stats.UpdateBatchSecondaryKeyBytes)
 	out["treedb.collections.write_domain.update_batch.index_value_changes_total"] = fmt.Sprintf("%d", stats.UpdateBatchIndexValueChanges)
 	out["treedb.collections.write_domain.update_batch.index_value_unchanged_total"] = fmt.Sprintf("%d", stats.UpdateBatchIndexValueUnchanged)
+	out["treedb.collections.write_domain.update_batch.changed_index_fast_mask_fallbacks_total"] = fmt.Sprintf("%d", stats.UpdateBatchMaskFallbacks)
 	out["treedb.collections.write_domain.update_batch.unique_checks_total"] = fmt.Sprintf("%d", stats.UpdateBatchUniqueChecks)
 	out["treedb.collections.write_domain.update_batch.unique_check_skips_total"] = fmt.Sprintf("%d", stats.UpdateBatchUniqueCheckSkips)
 	for i := 0; i < stats.UpdateBatchIndexStatsCount && i < len(stats.UpdateBatchIndexStats); i++ {
@@ -1184,6 +1188,7 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.UpdateBatchSecondaryKeyBytes += other.UpdateBatchSecondaryKeyBytes
 	s.UpdateBatchIndexValueChanges += other.UpdateBatchIndexValueChanges
 	s.UpdateBatchIndexValueUnchanged += other.UpdateBatchIndexValueUnchanged
+	s.UpdateBatchMaskFallbacks += other.UpdateBatchMaskFallbacks
 	s.UpdateBatchUniqueChecks += other.UpdateBatchUniqueChecks
 	s.UpdateBatchUniqueCheckSkips += other.UpdateBatchUniqueCheckSkips
 	for i := 0; i < other.UpdateBatchIndexStatsCount && i < len(other.UpdateBatchIndexStats); i++ {
@@ -1273,6 +1278,7 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.UpdateBatchSecondaryKeyBytes = domain.updateBatchSecondaryKeyBytes.Load()
 	stats.UpdateBatchIndexValueChanges = domain.updateBatchIndexValueChanges.Load()
 	stats.UpdateBatchIndexValueUnchanged = domain.updateBatchIndexValueUnchanged.Load()
+	stats.UpdateBatchMaskFallbacks = domain.updateBatchMaskFallbacks.Load()
 	stats.UpdateBatchUniqueChecks = domain.updateBatchUniqueChecks.Load()
 	stats.UpdateBatchUniqueCheckSkips = domain.updateBatchUniqueCheckSkips.Load()
 	for i := 0; i < stats.UpdateBatchIndexStatsCount; i++ {
@@ -1388,6 +1394,9 @@ func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpd
 	}
 	if stats.IndexValueUnchanged > 0 {
 		domain.updateBatchIndexValueUnchanged.Add(uint64(stats.IndexValueUnchanged))
+	}
+	if stats.MaskFallbacks > 0 {
+		domain.updateBatchMaskFallbacks.Add(uint64(stats.MaskFallbacks))
 	}
 	if stats.UniqueIndexChecks > 0 {
 		domain.updateBatchUniqueChecks.Add(uint64(stats.UniqueIndexChecks))
@@ -8444,10 +8453,14 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			indexStateChanged := false
 			for runtimeIdx, runtime := range runtimes {
 				runtimeChanged := orderedDocumentIndexRuntimeChanged(changed[i].oldState, changed[i].newState, runtimeIdx)
+				maskBit, maskBitOK := updateIndexChangedMaskBit(runtimeIdx)
+				if !maskBitOK {
+					stats.MaskFallbacks++
+				}
 				if runtimeChanged {
 					indexStateChanged = true
-					if bit, ok := updateIndexChangedMaskBit(runtimeIdx); ok {
-						changedIndexes |= bit
+					if maskBitOK {
+						changedIndexes |= maskBit
 					}
 					stats.IndexValueChanges++
 					if runtime.def.unique {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -666,6 +666,7 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 	for _, key := range []string{
 		"treedb.collections.write_domain.update_batch.index_value_changes_total",
 		"treedb.collections.write_domain.update_batch.index_value_unchanged_total",
+		"treedb.collections.write_domain.update_batch.changed_index_fast_mask_fallbacks_total",
 		"treedb.collections.write_domain.update_batch.unique_checks_total",
 		"treedb.collections.write_domain.update_batch.unique_check_skips_total",
 	} {
@@ -688,6 +689,88 @@ func TestCollectionUpdateBatchStatsExposeIndexRunShape(t *testing.T) {
 		if _, ok := exported[key]; !ok {
 			t.Fatalf("manager stats missing %s: keys=%v", key, exported)
 		}
+	}
+}
+
+func TestCollectionUpdateBatchStatsCountFastMaskFallbacks(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	indexes := make([]IndexDefinition, 65)
+	for i := range indexes {
+		field := fmt.Sprintf("f%d", i)
+		indexes[i] = IndexDefinition{
+			Name:      fmt.Sprintf("idx_%02d", i),
+			Field:     field,
+			ValueType: IndexValueString,
+		}
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "wide", Indexes: indexes}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("wide")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	document := func(value64 string) []byte {
+		var b strings.Builder
+		b.WriteByte('{')
+		for i := range indexes {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			value := fmt.Sprintf("v%d", i)
+			if i == 64 {
+				value = value64
+			}
+			fmt.Fprintf(&b, "%q:%q", fmt.Sprintf("f%d", i), value)
+		}
+		b.WriteByte('}')
+		return []byte(b.String())
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{document("v64")}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	results, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			return document("changed"), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("update batch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("results=%+v want one matched modified update", results)
+	}
+	stats := col.LastUpdateStats()
+	if got, want := stats.MaskFallbacks, 1; got != want {
+		t.Fatalf("last update fast-mask fallbacks=%d want %d", got, want)
+	}
+	if got, want := stats.IndexValueChanges, 1; got != want {
+		t.Fatalf("last update changed indexes=%d want %d", got, want)
+	}
+	if got, want := stats.IndexValueUnchanged, 64; got != want {
+		t.Fatalf("last update unchanged indexes=%d want %d", got, want)
+	}
+	managerStats := mgr.StatsSnapshot()
+	if got, want := managerStats.UpdateBatchMaskFallbacks, uint64(1); got != want {
+		t.Fatalf("manager fast-mask fallbacks=%d want %d", got, want)
+	}
+	exported := mgr.Stats()
+	if got, want := exported["treedb.collections.write_domain.update_batch.changed_index_fast_mask_fallbacks_total"], "1"; got != want {
+		t.Fatalf("exported fast-mask fallback counter=%q want %q", got, want)
+	}
+	ids, err := col.FindByIndexValue("idx_64", "changed")
+	if err != nil {
+		t.Fatalf("find updated ordinal 64 index: %v", err)
+	}
+	if len(ids) != 1 || string(ids[0]) != "u1" {
+		t.Fatalf("idx_64 changed ids=%q want [u1]", ids)
 	}
 }
 

--- a/cmd/mongo_gateway_bench/profile_bench_test.go
+++ b/cmd/mongo_gateway_bench/profile_bench_test.go
@@ -1107,6 +1107,7 @@ func deltaCollectionManagerUpdateStats(after, before collections.CollectionManag
 		UpdateBatchSecondaryKeyBytes:   after.UpdateBatchSecondaryKeyBytes - before.UpdateBatchSecondaryKeyBytes,
 		UpdateBatchIndexValueChanges:   after.UpdateBatchIndexValueChanges - before.UpdateBatchIndexValueChanges,
 		UpdateBatchIndexValueUnchanged: after.UpdateBatchIndexValueUnchanged - before.UpdateBatchIndexValueUnchanged,
+		UpdateBatchMaskFallbacks:       after.UpdateBatchMaskFallbacks - before.UpdateBatchMaskFallbacks,
 		UpdateBatchUniqueChecks:        after.UpdateBatchUniqueChecks - before.UpdateBatchUniqueChecks,
 		UpdateBatchUniqueCheckSkips:    after.UpdateBatchUniqueCheckSkips - before.UpdateBatchUniqueCheckSkips,
 		UpdateCombineRequests:          after.UpdateCombineRequests - before.UpdateCombineRequests,
@@ -1179,6 +1180,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateCombineQueueDepthMax:     12,
 		UpdateBatchIndexValueChanges:   20,
 		UpdateBatchIndexValueUnchanged: 30,
+		UpdateBatchMaskFallbacks:       5,
 		UpdateBatchUniqueChecks:        4,
 		UpdateBatchUniqueCheckSkips:    10,
 		IndexedFlushCalls:              3,
@@ -1204,6 +1206,7 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 		UpdateCombineQueueDepthMax:     31,
 		UpdateBatchIndexValueChanges:   27,
 		UpdateBatchIndexValueUnchanged: 43,
+		UpdateBatchMaskFallbacks:       12,
 		UpdateBatchUniqueChecks:        6,
 		UpdateBatchUniqueCheckSkips:    19,
 		IndexedFlushCalls:              8,
@@ -1250,6 +1253,9 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 	if got.UpdateBatchIndexValueUnchanged != 13 {
 		t.Fatalf("UpdateBatchIndexValueUnchanged=%d want 13", got.UpdateBatchIndexValueUnchanged)
 	}
+	if got.UpdateBatchMaskFallbacks != 7 {
+		t.Fatalf("UpdateBatchMaskFallbacks=%d want 7", got.UpdateBatchMaskFallbacks)
+	}
 	if got.UpdateBatchUniqueChecks != 2 {
 		t.Fatalf("UpdateBatchUniqueChecks=%d want 2", got.UpdateBatchUniqueChecks)
 	}
@@ -1290,36 +1296,42 @@ func TestDeltaCollectionManagerUpdateStatsIncludesCombinerStats(t *testing.T) {
 
 func TestReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics(t *testing.T) {
 	stats := collections.CollectionManagerStats{
-		IndexedFlushCalls:       5,
-		IndexedFlushErrors:      1,
-		IndexedFlushDocs:        600,
-		IndexedFlushBytes:       18000,
-		IndexedFlushRootRuns:    180,
-		IndexedFlushRoots:       15,
-		IndexedFlushDuration:    60 * time.Millisecond,
-		IndexedFlushMaterialize: 18 * time.Millisecond,
-		IndexedFlushPublish:     42 * time.Millisecond,
+		IndexedFlushCalls:              5,
+		IndexedFlushErrors:             1,
+		IndexedFlushDocs:               600,
+		IndexedFlushBytes:              18000,
+		IndexedFlushRootRuns:           180,
+		IndexedFlushRoots:              15,
+		IndexedFlushDuration:           60 * time.Millisecond,
+		IndexedFlushMaterialize:        18 * time.Millisecond,
+		IndexedFlushPublish:            42 * time.Millisecond,
+		UpdateBatchIndexValueChanges:   300,
+		UpdateBatchIndexValueUnchanged: 900,
+		UpdateBatchMaskFallbacks:       60,
 	}
 	result := testing.Benchmark(func(b *testing.B) {
 		reportCollectionManagerUpdateStats(b, stats, 600)
 	})
 	want := map[string]float64{
-		"indexed_flush_calls":               5,
-		"indexed_flush_docs/call":           120,
-		"indexed_flush_docs/doc":            1,
-		"indexed_flush_bytes/call":          3600,
-		"indexed_flush_bytes/doc":           30,
-		"indexed_flush_root_runs/call":      36,
-		"indexed_flush_root_runs/doc":       0.3,
-		"indexed_flush_roots/call":          3,
-		"indexed_flush_roots/doc":           0.025,
-		"indexed_flush_errors":              1,
-		"indexed_flush_ns/call":             12_000_000,
-		"indexed_flush_ns/doc":              100_000,
-		"indexed_flush_materialize_ns/call": 3_600_000,
-		"indexed_flush_materialize_ns/doc":  30_000,
-		"indexed_flush_publish_ns/call":     8_400_000,
-		"indexed_flush_publish_ns/doc":      70_000,
+		"indexed_flush_calls":                   5,
+		"indexed_flush_docs/call":               120,
+		"indexed_flush_docs/doc":                1,
+		"indexed_flush_bytes/call":              3600,
+		"indexed_flush_bytes/doc":               30,
+		"indexed_flush_root_runs/call":          36,
+		"indexed_flush_root_runs/doc":           0.3,
+		"indexed_flush_roots/call":              3,
+		"indexed_flush_roots/doc":               0.025,
+		"indexed_flush_errors":                  1,
+		"indexed_flush_ns/call":                 12_000_000,
+		"indexed_flush_ns/doc":                  100_000,
+		"indexed_flush_materialize_ns/call":     3_600_000,
+		"indexed_flush_materialize_ns/doc":      30_000,
+		"indexed_flush_publish_ns/call":         8_400_000,
+		"indexed_flush_publish_ns/doc":          70_000,
+		"update_index_value_changes/doc":        0.5,
+		"update_index_value_unchanged/doc":      1.5,
+		"changed_index_fast_mask_fallbacks/doc": 0.1,
 	}
 	for metric, wantValue := range want {
 		gotValue, ok := result.Extra[metric]
@@ -1459,6 +1471,9 @@ func reportCollectionManagerUpdateStats(b *testing.B, stats collections.Collecti
 	}
 	if stats.UpdateBatchIndexValueUnchanged > 0 {
 		b.ReportMetric(float64(stats.UpdateBatchIndexValueUnchanged)/float64(docs), "update_index_value_unchanged/doc")
+	}
+	if stats.UpdateBatchMaskFallbacks > 0 {
+		b.ReportMetric(float64(stats.UpdateBatchMaskFallbacks)/float64(docs), "changed_index_fast_mask_fallbacks/doc")
 	}
 	if stats.UpdateBatchUniqueChecks > 0 {
 		b.ReportMetric(float64(stats.UpdateBatchUniqueChecks)/float64(docs), "update_unique_checks/doc")


### PR DESCRIPTION
PR2 observability tightening for #1242. The existing `changedIndexes uint64` fast path is correct for ordinals <64 and falls back to old/new state comparison for ordinals >=64. This PR exposes when that fallback is exercised.

Changes:
- Add update-batch `MaskFallbacks` / `UpdateBatchMaskFallbacks` counters.
- Export `treedb.collections.write_domain.update_batch.changed_index_fast_mask_fallbacks_total`.
- Report `changed_index_fast_mask_fallbacks/doc` in mongo gateway profile benchmarks.
- Add a 65-index UpdateBatch test that changes ordinal 64, verifies the fallback counter, and confirms the ordinal-64 secondary index is updated.

Local tests:
- `go test ./TreeDB/collections -run 'TestCollectionUpdateBatchStats(ExposeIndexRunShape|CountFastMaskFallbacks)' -count=1`\n- `go test ./cmd/mongo_gateway_bench -run 'Test(DeltaCollectionManagerUpdateStatsIncludesCombinerStats|ReportCollectionManagerUpdateStatsIncludesIndexedFlushMetrics)' -count=1`\n- `go test ./TreeDB/collections -count=1`\n- `go test ./cmd/mongo_gateway_bench -count=1`