### PR TITLE
bench: allow writer-only scaling sweeps

### DIFF
--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -13,6 +13,7 @@ BATCH_SIZE="${BATCH_SIZE:-10000}"
 INSERT_PRODUCERS="${INSERT_PRODUCERS:-8}"
 WRITERS_LIST="${WRITERS_LIST:-1 2 4 8 16 32}"
 READERS_LIST="${READERS_LIST:-1 2 4 8 16}"
+RUN_READER_SWEEP="${RUN_READER_SWEEP:-true}"
 CONCURRENT_WRITES="${CONCURRENT_WRITES:-80000}"
 CONCURRENT_READS="${CONCURRENT_READS:-80000}"
 READS="${READS:-0}"
@@ -54,6 +55,7 @@ Options:
   --insert-producers N   Insert load producers. Default: 8.
   --writers LIST         Quoted space-separated concurrent writer counts (for example: "1 2 4"). Default: "1 2 4 8 16 32".
   --readers LIST         Quoted space-separated concurrent reader counts (for example: "1 2 4"). Default: "1 2 4 8 16".
+  --no-reader-sweep      Run writer-scaling cells only.
   --concurrent-writes N  Total updates per writer-scaling cell. Default: 80000.
   --concurrent-reads N   Total reads per reader-scaling cell. Default: 80000.
   --include-mongo        Also run each cell against an external MongoDB URI.
@@ -73,7 +75,7 @@ Environment overrides use the uppercase variable names shown in the script:
 OUT_DIR, DOCS, INDEXES, BATCH_SIZE, INSERT_PRODUCERS, WRITERS_LIST,
 READERS_LIST, CONCURRENT_WRITES, CONCURRENT_READS, INCLUDE_MONGO (0/1, true/false, or yes/no), MONGO_URI, DATABASE_PREFIX,
 TREEDB_DOCUMENT_FORMAT, TREEDB_CLIENT_MODE, TREEDB_PROFILE,
-TREEDB_MAINTENANCE, UPDATE_INDEXED_FIELD (0/1, true/false, or yes/no), GOWORK, TIMEOUT, TITLE,
+TREEDB_MAINTENANCE, UPDATE_INDEXED_FIELD (0/1, true/false, or yes/no), RUN_READER_SWEEP (0/1, true/false, or yes/no), GOWORK, TIMEOUT, TITLE,
 and related storage/pool settings.
 EOF
 }
@@ -168,6 +170,10 @@ while [[ $# -gt 0 ]]; do
       require_option_value "$1" "${2-}"
       READERS_LIST="$2"
       shift 2
+      ;;
+    --no-reader-sweep)
+      RUN_READER_SWEEP=false
+      shift
       ;;
     --concurrent-writes)
       require_option_value "$1" "${2-}"
@@ -297,6 +303,7 @@ case "$UPDATE_INDEXED_FIELD" in
 esac
 UPDATE_INDEXED_FIELD_TEXT=$(bool_01_text "$UPDATE_INDEXED_FIELD")
 INCLUDE_MONGO=$(normalize_bool_01 INCLUDE_MONGO "$INCLUDE_MONGO")
+RUN_READER_SWEEP=$(normalize_bool_01 RUN_READER_SWEEP "$RUN_READER_SWEEP")
 
 mkdir -p "$OUT_DIR"
 OUT_DIR=$(cd "$OUT_DIR" && pwd -P)
@@ -410,7 +417,7 @@ printf "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n
 
 echo "running Mongo gateway scaling matrix into: $OUT_DIR"
 echo "docs=$DOCS indexes=$INDEXES batch_size=$BATCH_SIZE insert_producers=$INSERT_PRODUCERS"
-echo "writers=$WRITERS_LIST readers=$READERS_LIST include_mongo=$INCLUDE_MONGO update_indexed_field=$UPDATE_INDEXED_FIELD_TEXT"
+echo "writers=$WRITERS_LIST readers=$READERS_LIST run_reader_sweep=$RUN_READER_SWEEP include_mongo=$INCLUDE_MONGO update_indexed_field=$UPDATE_INDEXED_FIELD_TEXT"
 
 run_cell() {
   local scenario=$1
@@ -458,9 +465,11 @@ for writers in $WRITERS_LIST; do
   run_cell "writers_${writers}" 0 0 "$writers" "$CONCURRENT_WRITES"
 done
 
-for readers in $READERS_LIST; do
-  run_cell "readers_${readers}" "$readers" "$CONCURRENT_READS" 0 0
-done
+if [[ "$RUN_READER_SWEEP" == "1" ]]; then
+  for readers in $READERS_LIST; do
+    run_cell "readers_${readers}" "$readers" "$CONCURRENT_READS" 0 0
+  done
+fi
 
 report_extra=()
 if [[ "$INCLUDE_MONGO" != "1" ]]; then
@@ -496,6 +505,7 @@ cat >"$README" <<EOF
 - insert producers: \`$INSERT_PRODUCERS\`
 - writer sweep: \`$WRITERS_LIST\`
 - reader sweep: \`$READERS_LIST\`
+- run reader sweep: \`$RUN_READER_SWEEP\`
 - concurrent writes per writer cell: \`$CONCURRENT_WRITES\`
 - concurrent reads per reader cell: \`$CONCURRENT_READS\`
 - TreeDB profile: \`$TREEDB_PROFILE\`


### PR DESCRIPTION
Stacked on #1289. This makes the dedicated #1242 writer sweep easier to run without spending time on reader-scaling cells.

Changes:
- Add `--no-reader-sweep`.
- Add `RUN_READER_SWEEP` environment override with the same bool parsing as other script booleans.
- Record the reader-sweep setting in stdout and the bundle README.

Local checks:
- `bash -n scripts/mongo_gateway_scaling_bench.sh`
- Tiny smoke: `scripts/mongo_gateway_scaling_bench.sh --out "$OUT" --docs 10 --indexes 0 --batch-size 5 --insert-producers 1 --writers "1" --no-reader-sweep --concurrent-writes 3 --concurrent-reads 1 --timeout 2m`; verified `matrix.tsv` contained only the writer row and no `readers_` row.