### PR TITLE
bench: add zero-index writer sweep wrapper

### DIFF
--- a/scripts/mongo_gateway_zero_index_writer_sweep.sh
+++ b/scripts/mongo_gateway_zero_index_writer_sweep.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+
+# #1242 PR1B canonical zero-secondary-index writer sweep:
+# fresh load, non-indexed _id point updates, and writers 1/2/4/8/16/32.
+export DOCS="${DOCS:-1000000}"
+export INDEXES="${INDEXES:-0}"
+export CONCURRENT_WRITES="${CONCURRENT_WRITES:-80000}"
+export WRITERS_LIST="${WRITERS_LIST:-1 2 4 8 16 32}"
+export UPDATE_INDEXED_FIELD="${UPDATE_INDEXED_FIELD:-false}"
+export TITLE="${TITLE:-Mongo Gateway 0-Index Writer Sweep}"
+
+exec "$ROOT/scripts/mongo_gateway_scaling_bench.sh" --no-reader-sweep "$@"


### PR DESCRIPTION
## Summary

- add `scripts/mongo_gateway_zero_index_writer_sweep.sh` as the #1242 PR1B preset for the dedicated 0-secondary-index writer sweep
- default the wrapper to 1M docs, 80k `_id` point updates per writer cell, writers `1 2 4 8 16 32`, and no reader sweep
- keep all values overrideable through the same env/flag surface as `mongo_gateway_scaling_bench.sh`

## Stack

Stacked on #1290 because it uses `--no-reader-sweep`.

## Tests

```sh
bash -n scripts/mongo_gateway_zero_index_writer_sweep.sh scripts/mongo_gateway_scaling_bench.sh

OUT=$(mktemp -d /tmp/gomap_zero_index_writer_sweep_smoke_XXXXXX)
OUT_DIR="$OUT" DOCS=20 BATCH_SIZE=10 INSERT_PRODUCERS=1 WRITERS_LIST="1" CONCURRENT_WRITES=5 TIMEOUT=2m GOWORK=off scripts/mongo_gateway_zero_index_writer_sweep.sh
# verified matrix.tsv contains only writers_1, secondary_indexes=0, and no readers_ rows
```
