### PR TITLE
collections: prove close drains queued indexed units

### DIFF
--- a/TreeDB/collections/close_indexed_flush_test.go
+++ b/TreeDB/collections/close_indexed_flush_test.go
@@ -1,0 +1,76 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionManagerCloseDrainsQueuedIndexedFlushUnit(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert buffered indexed batch: %v", err)
+	}
+
+	col.writeDomain.mu.Lock()
+	if !rotateIndexedMutableToFlushUnitLocked(col.writeDomain) {
+		col.writeDomain.mu.Unlock()
+		t.Fatal("rotate indexed mutable state returned false")
+	}
+	col.writeDomain.mu.Unlock()
+	if got := mgr.StatsSnapshot().PendingIndexedFlushUnits; got != 1 {
+		t.Fatalf("pending indexed flush units before Close=%d want 1", got)
+	}
+	ids, err := col.FindByIndexValue("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find pending email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("pending email ids=%q want [u1]", ids)
+	}
+
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err = reopenedCol.FindByIndexValue("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find reopened email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("reopened email ids=%q want [u1]", ids)
+	}
+}


### PR DESCRIPTION
## Summary

- add a PR1a close-boundary proof for queued indexed flush units
- stage an indexed insert, rotate it into a queued flush unit, and verify overlay secondary visibility before close
- close the backend DB and verify reopen sees the secondary entry durably

## Why

#1242 PR1a separates `Flush`/backend `Close` from `DB.Checkpoint`: close hooks should drain collection write domains, while checkpoint should not invent durability for pending collection-local units. #1278 covers `FlushAll`; this pins the backend `Close` hook path.

## Tests

```sh
go test ./TreeDB/collections -run '^TestCollectionManagerCloseDrainsQueuedIndexedFlushUnit$' -count=1

go test ./TreeDB/collections -count=1
```
