### PR TITLE
bench: add raw TreeDB smoke gate

### DIFF
--- a/TreeDB/db/bench_test.go
+++ b/TreeDB/db/bench_test.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
 
 // BenchmarkStress performs mixed Read/Write operations.
@@ -372,6 +375,31 @@ func BenchmarkLargeVal(b *testing.B) {
 	}
 	defer d.Close()
 
+	walDir := filepath.Join(tmpDir, "value_vlog")
+	if err := os.MkdirAll(walDir, 0o755); err != nil {
+		b.Fatalf("mkdir value log: %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		b.Fatalf("encode value-log file id: %v", err)
+	}
+	valueLogPath := filepath.Join(walDir, "value-l0-000001.log")
+	valueWriter, err := valuelog.NewWriter(valueLogPath, fileID)
+	if err != nil {
+		b.Fatalf("new value-log writer: %v", err)
+	}
+	defer valueWriter.Close()
+	if err := d.valueLogManager.RegisterSegment(valueLogPath, fileID); err != nil {
+		b.Fatalf("register value-log segment: %v", err)
+	}
+	if err := d.valueLogManager.PromoteCurrentWritable(fileID); err != nil {
+		b.Fatalf("promote value-log segment: %v", err)
+	}
+
+	var (
+		valueLogMu sync.Mutex
+		nextRID    atomic.Uint64
+	)
 	valSize := 4096 // 4KB
 	valBuf := make([]byte, valSize)
 	rand.Read(valBuf)
@@ -386,8 +414,30 @@ func BenchmarkLargeVal(b *testing.B) {
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 		for pb.Next() {
 			key := keys[r.Intn(len(keys))]
-			if err := d.Set(key, valBuf); err != nil {
-				b.Errorf("Set failed: %v", err)
+
+			valueLogMu.Lock()
+			ptr, err := valueWriter.Append(0, nil, nextRID.Add(1), valBuf)
+			if err == nil {
+				err = valueWriter.Flush()
+			}
+			valueLogMu.Unlock()
+			if err != nil {
+				b.Errorf("value-log append failed: %v", err)
+				continue
+			}
+
+			unlock := d.lockUpdateKey(key)
+			wb := d.NewBatch().(*Batch)
+			err = wb.SetPointer(key, ptr)
+			if err == nil {
+				err = wb.Write()
+			}
+			if closeErr := wb.Close(); err == nil {
+				err = closeErr
+			}
+			unlock()
+			if err != nil {
+				b.Errorf("SetPointer failed: %v", err)
 			}
 		}
 	})

--- a/TreeDB/db/bench_test.go
+++ b/TreeDB/db/bench_test.go
@@ -375,15 +375,15 @@ func BenchmarkLargeVal(b *testing.B) {
 	}
 	defer d.Close()
 
-	walDir := filepath.Join(tmpDir, "value_vlog")
-	if err := os.MkdirAll(walDir, 0o755); err != nil {
+	valueLogDir := filepath.Join(tmpDir, "value_vlog")
+	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
 		b.Fatalf("mkdir value log: %v", err)
 	}
 	fileID, err := valuelog.EncodeFileID(0, 1)
 	if err != nil {
 		b.Fatalf("encode value-log file id: %v", err)
 	}
-	valueLogPath := filepath.Join(walDir, "value-l0-000001.log")
+	valueLogPath := filepath.Join(valueLogDir, "value-l0-000001.log")
 	valueWriter, err := valuelog.NewWriter(valueLogPath, fileID)
 	if err != nil {
 		b.Fatalf("new value-log writer: %v", err)
@@ -398,7 +398,7 @@ func BenchmarkLargeVal(b *testing.B) {
 
 	var (
 		valueLogMu sync.Mutex
-		nextRID    atomic.Uint64
+		nextRID    uint64
 	)
 	valSize := 4096 // 4KB
 	valBuf := make([]byte, valSize)
@@ -416,10 +416,8 @@ func BenchmarkLargeVal(b *testing.B) {
 			key := keys[r.Intn(len(keys))]
 
 			valueLogMu.Lock()
-			ptr, err := valueWriter.Append(0, nil, nextRID.Add(1), valBuf)
-			if err == nil {
-				err = valueWriter.Flush()
-			}
+			nextRID++
+			ptr, err := valueWriter.Append(0, nil, nextRID, valBuf)
 			valueLogMu.Unlock()
 			if err != nil {
 				b.Errorf("value-log append failed: %v", err)

--- a/scripts/treedb_raw_smoke_gate.sh
+++ b/scripts/treedb_raw_smoke_gate.sh
@@ -89,9 +89,9 @@ RAW_OPS_BENCH_RE='Benchmark(Batch|WriteParallel|Stress|ReadUnderWrite|LargeVal)$
 cat >"$OUT_DIR/commands.sh" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-GOWORK=$GOWORK_MODE go test ./TreeDB/db ./TreeDB/zipper ./TreeDB/caching -run '$RAW_TEST_RE'
-GOWORK=$GOWORK_MODE go test ./TreeDB/db -run '^$' -bench '$ROOT_APPLY_BENCH_RE' -benchmem -count=$COUNT
-GOWORK=$GOWORK_MODE go test ./TreeDB/db -run '^$' -bench '$RAW_OPS_BENCH_RE' -benchmem -count=$COUNT
+GOWORK="$GOWORK_MODE" go test ./TreeDB/db ./TreeDB/zipper ./TreeDB/caching -run '$RAW_TEST_RE'
+GOWORK="$GOWORK_MODE" go test ./TreeDB/db -run '^$' -bench '$ROOT_APPLY_BENCH_RE' -benchmem -count="$COUNT"
+GOWORK="$GOWORK_MODE" go test ./TreeDB/db -run '^$' -bench '$RAW_OPS_BENCH_RE' -benchmem -count="$COUNT"
 EOF
 chmod +x "$OUT_DIR/commands.sh"
 
@@ -99,16 +99,16 @@ GOWORK="$GOWORK_MODE" go version | tee "$OUT_DIR/go_version.txt"
 
 echo "running raw TreeDB tests"
 GOWORK="$GOWORK_MODE" go test ./TreeDB/db ./TreeDB/zipper ./TreeDB/caching \
-  -run "$RAW_TEST_RE" | tee "$OUT_DIR/raw_tests.log"
+  -run "$RAW_TEST_RE" 2>&1 | tee "$OUT_DIR/raw_tests.log"
 
 echo "running raw root-apply benchmarks"
 GOWORK="$GOWORK_MODE" go test ./TreeDB/db -run '^$' \
   -bench "$ROOT_APPLY_BENCH_RE" \
-  -benchmem -count="$COUNT" | tee "$OUT_DIR/raw_db_root_apply.bench"
+  -benchmem -count="$COUNT" 2>&1 | tee "$OUT_DIR/raw_db_root_apply.bench"
 
 echo "running raw DB operation benchmarks"
 GOWORK="$GOWORK_MODE" go test ./TreeDB/db -run '^$' \
   -bench "$RAW_OPS_BENCH_RE" \
-  -benchmem -count="$COUNT" | tee "$OUT_DIR/raw_db_ops.bench"
+  -benchmem -count="$COUNT" 2>&1 | tee "$OUT_DIR/raw_db_ops.bench"
 
 echo "raw TreeDB smoke artifacts: $OUT_DIR"

--- a/scripts/treedb_raw_smoke_gate.sh
+++ b/scripts/treedb_raw_smoke_gate.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+cd "$ROOT"
+
+TMP_BASE="${TMPDIR:-/tmp}"
+TMP_BASE="${TMP_BASE%/}"
+OUT_DIR="${OUT_DIR:-$(mktemp -d "$TMP_BASE/gomap_treedb_raw_smoke_XXXXXX")}"
+COUNT="${COUNT:-5}"
+GOWORK_MODE="${GOWORK:-off}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/treedb_raw_smoke_gate.sh [options]
+
+Runs the #1242 raw TreeDB smoke gate for PRs that touch DB publish, zipper,
+leaf-log, value-log, cache, prepared output, or root apply behavior.
+
+Options:
+  --out DIR    Output directory for benchmark logs. Default: mktemp.
+  --count N    Go benchmark count. Default: 5.
+  --help       Show this help.
+
+Environment:
+  OUT_DIR      Same as --out.
+  COUNT        Same as --count.
+  GOWORK       Go workspace mode. Default: off.
+
+Outputs:
+  raw_tests.log
+  raw_db_root_apply.bench
+  raw_db_ops.bench
+  commands.sh
+  go_version.txt
+EOF
+}
+
+require_option_value() {
+  local opt=$1
+  local value=${2-}
+  if [[ -z "$value" || "$value" == --* ]]; then
+    echo "missing value for $opt" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)
+      require_option_value "$1" "${2-}"
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --count)
+      require_option_value "$1" "${2-}"
+      COUNT="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! [[ "$COUNT" =~ ^[1-9][0-9]*$ ]]; then
+  echo "invalid COUNT=$COUNT (want positive integer)" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+OUT_DIR=$(cd "$OUT_DIR" && pwd -P)
+if [[ -n "$(find "$OUT_DIR" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+  echo "output directory must be empty: $OUT_DIR" >&2
+  exit 2
+fi
+
+RAW_TEST_RE='Test(PublishOrderedRoot|ApplyOrderedRoot|Zipper|Coalesce|MergeLeaf|ShortestSeparator|MaintenanceRoots|Vacuum.*Collection|ValueLogGC|ValueLogRewrite|LeafGeneration|Close|ClosedDB|Reopen)'
+ROOT_APPLY_BENCH_RE='BenchmarkPublishSystemRootIterator_Warm(SparseDelta|DenseDelta)$'
+RAW_OPS_BENCH_RE='Benchmark(Batch|WriteParallel|Stress|ReadUnderWrite|LargeVal)$'
+
+cat >"$OUT_DIR/commands.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+GOWORK=$GOWORK_MODE go test ./TreeDB/db ./TreeDB/zipper ./TreeDB/caching -run '$RAW_TEST_RE'
+GOWORK=$GOWORK_MODE go test ./TreeDB/db -run '^$' -bench '$ROOT_APPLY_BENCH_RE' -benchmem -count=$COUNT
+GOWORK=$GOWORK_MODE go test ./TreeDB/db -run '^$' -bench '$RAW_OPS_BENCH_RE' -benchmem -count=$COUNT
+EOF
+chmod +x "$OUT_DIR/commands.sh"
+
+GOWORK="$GOWORK_MODE" go version | tee "$OUT_DIR/go_version.txt"
+
+echo "running raw TreeDB tests"
+GOWORK="$GOWORK_MODE" go test ./TreeDB/db ./TreeDB/zipper ./TreeDB/caching \
+  -run "$RAW_TEST_RE" | tee "$OUT_DIR/raw_tests.log"
+
+echo "running raw root-apply benchmarks"
+GOWORK="$GOWORK_MODE" go test ./TreeDB/db -run '^$' \
+  -bench "$ROOT_APPLY_BENCH_RE" \
+  -benchmem -count="$COUNT" | tee "$OUT_DIR/raw_db_root_apply.bench"
+
+echo "running raw DB operation benchmarks"
+GOWORK="$GOWORK_MODE" go test ./TreeDB/db -run '^$' \
+  -bench "$RAW_OPS_BENCH_RE" \
+  -benchmem -count="$COUNT" | tee "$OUT_DIR/raw_db_ops.bench"
+
+echo "raw TreeDB smoke artifacts: $OUT_DIR"


### PR DESCRIPTION
## Summary

- adds `scripts/treedb_raw_smoke_gate.sh` for the #1242 raw TreeDB smoke gate across raw tests, ordered-root root-apply benchmarks, and broad raw DB operation benchmarks
- records reproducible artifacts under a caller-provided output directory, including `commands.sh`, `go_version.txt`, raw test logs, and benchmark logs
- updates `BenchmarkLargeVal` to exercise current persistent value-log pointer writes via explicit value-log append plus `SetPointer`, so the raw DB ops gate remains runnable under the no-slab storage model

## Verification

- `go test ./TreeDB/db -run '^$' -bench '^BenchmarkLargeVal$' -benchmem -count=1`
- `scripts/treedb_raw_smoke_gate.sh --out /tmp/gomap_raw_smoke_gate_reduced_KlCsGp --count 1`
