### PR TITLE
collections: prove BSON direct double minimization

### DIFF
--- a/TreeDB/collections/bson_direct_double_minimization_test.go
+++ b/TreeDB/collections/bson_direct_double_minimization_test.go
@@ -1,0 +1,150 @@
+package collections
+
+import (
+	"sort"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestCollectionDirectUpdateBSONDoubleSameEffectiveSkipsSecondaryRoot(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "scores",
+		Options: CollectionOptions{
+			DocumentFormat:               DocumentFormatBSON,
+			DisableIndexedWriteMemtables: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "score", Field: "score", ValueType: IndexValueDouble},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("scores")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	const (
+		oldScore = 2.5
+		newScore = 3.5
+	)
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: oldScore},
+			{Key: "note", Value: "before"},
+		})},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	rootNames := []string{
+		collectionPrimaryRootName("scores"),
+		collectionSecondaryRootName("scores", "score"),
+	}
+	before := mustBSONDirectDoubleRootIDs(t, d, "scores", rootNames...)
+	assertBSONDirectDoubleIDs(t, col, oldScore, "u1")
+
+	matched, modified, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: oldScore},
+			{Key: "note", Value: "after"},
+		}), true, nil
+	})
+	if err != nil {
+		t.Fatalf("direct BSON same-score update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("direct BSON same-score update matched=%v modified=%v want true/true", matched, modified)
+	}
+
+	afterSame := mustBSONDirectDoubleRootIDs(t, d, "scores", rootNames...)
+	if afterSame[collectionPrimaryRootName("scores")] == before[collectionPrimaryRootName("scores")] {
+		t.Fatalf("primary root did not change for BSON replacement")
+	}
+	scoreRoot := collectionSecondaryRootName("scores", "score")
+	if afterSame[scoreRoot] != before[scoreRoot] {
+		t.Fatalf("score secondary root changed from %d to %d for same BSON double value", before[scoreRoot], afterSame[scoreRoot])
+	}
+	assertBSONDirectDoubleIDs(t, col, oldScore, "u1")
+
+	matched, modified, err = col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "score", Value: newScore},
+			{Key: "note", Value: "changed-score"},
+		}), true, nil
+	})
+	if err != nil {
+		t.Fatalf("direct BSON changed-score update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("direct BSON changed-score update matched=%v modified=%v want true/true", matched, modified)
+	}
+	afterChanged := mustBSONDirectDoubleRootIDs(t, d, "scores", rootNames...)
+	if afterChanged[scoreRoot] == afterSame[scoreRoot] {
+		t.Fatalf("score secondary root did not change for changed BSON double value")
+	}
+	assertBSONDirectDoubleIDs(t, col, oldScore)
+	assertBSONDirectDoubleIDs(t, col, newScore, "u1")
+}
+
+func mustBSONDirectDoubleRootIDs(t *testing.T, d *backenddb.DB, collectionName string, rootNames ...string) map[string]uint64 {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	catalog, err := loadCollectionCatalog(snap, collectionName)
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatalf("missing catalog for collection %q", collectionName)
+	}
+	out := make(map[string]uint64, len(rootNames))
+	for _, name := range rootNames {
+		rootID := catalog.rootID(name)
+		if rootID == 0 {
+			t.Fatalf("root %q was not persisted", name)
+		}
+		out[name] = rootID
+	}
+	return out
+}
+
+func assertBSONDirectDoubleIDs(t *testing.T, col *Collection, score float64, want ...string) {
+	t.Helper()
+	ids, err := col.FindByIndexValue("score", score)
+	if err != nil {
+		t.Fatalf("find score %v: %v", score, err)
+	}
+	got := make([]string, len(ids))
+	for i := range ids {
+		got[i] = string(ids[i])
+	}
+	sort.Strings(got)
+	wantSorted := append([]string(nil), want...)
+	sort.Strings(wantSorted)
+	if len(got) != len(wantSorted) {
+		t.Fatalf("score %v ids=%q want %q", score, ids, want)
+	}
+	for i := range wantSorted {
+		if got[i] != wantSorted[i] {
+			t.Fatalf("score %v ids=%q want %q", score, ids, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- adds a PR2 direct-update proof for BSON native double index minimization
- verifies a replacement that keeps the same BSON double indexed value moves only the primary root
- verifies changing the BSON double value moves the secondary root and updates exact index lookup visibility

## Why

#1242 PR2 asks for numeric exactness proof across formats and paths. This complements the BSON int64 rows with the `IndexValueDouble` extractor/encoding path.

## Tests

```sh
go test ./TreeDB/collections -run '^TestCollectionDirectUpdateBSONDoubleSameEffectiveSkipsSecondaryRoot$' -count=1

go test ./TreeDB/collections -run 'Test(CollectionDirectUpdateBSONDoubleSameEffectiveSkipsSecondaryRoot|CollectionIndexesCanonicalExtendedJSONNumbers|CollectionFindByIndexRangeTypedInt64|CollectionBSONFormatStoresNativeBSONAndIndexes)$' -count=1

go test ./TreeDB/collections -count=1
```
