### PR TITLE
collections: prove template-v1 update batch bool minimization

### DIFF
--- a/TreeDB/collections/template_v1_updatebatch_bool_minimization_test.go
+++ b/TreeDB/collections/template_v1_updatebatch_bool_minimization_test.go
@@ -1,0 +1,181 @@
+package collections
+
+import (
+	"sort"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionUpdateBatchTemplateV1BoolSameEffectiveSkipsSecondaryRoot(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "flags",
+		Options: CollectionOptions{
+			DocumentFormat:               DocumentFormatTemplateV1,
+			DisableIndexedWriteMemtables: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "active", Field: "active", ValueType: IndexValueBool},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("flags")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{
+		mustTemplateV1UpdateBatchBoolDocument(t, true, "before"),
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	rootNames := []string{
+		collectionPrimaryRootName("flags"),
+		collectionTemplateRootName("flags"),
+		collectionSecondaryRootName("flags", "active"),
+	}
+	before := mustTemplateV1UpdateBatchBoolRootIDs(t, d, "flags", rootNames...)
+	assertTemplateV1UpdateBatchBoolIDs(t, col, true, "u1")
+
+	results, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func([]byte) ([]byte, bool, error) {
+			return mustTemplateV1UpdateBatchBoolDocument(t, true, "same-active"), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("update same template-v1 active: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("same-active update results=%+v want one matched modified row", results)
+	}
+	stats := col.LastUpdateStats()
+	if stats.SecondaryDeleteEntries != 0 || stats.SecondarySetEntries != 0 || stats.SecondaryKeyBytes != 0 || len(stats.SecondaryRuns) != 0 {
+		t.Fatalf("same-active update secondary stats deletes=%d sets=%d bytes=%d runs=%+v, want no secondary work",
+			stats.SecondaryDeleteEntries, stats.SecondarySetEntries, stats.SecondaryKeyBytes, stats.SecondaryRuns)
+	}
+	if got, want := stats.IndexValueChanges, 0; got != want {
+		t.Fatalf("same-active update index changes=%d want %d", got, want)
+	}
+	if got, want := stats.IndexValueUnchanged, 1; got != want {
+		t.Fatalf("same-active update index unchanged=%d want %d", got, want)
+	}
+
+	afterSame := mustTemplateV1UpdateBatchBoolRootIDs(t, d, "flags", rootNames...)
+	if afterSame[collectionPrimaryRootName("flags")] == before[collectionPrimaryRootName("flags")] {
+		t.Fatalf("primary root did not change for template-v1 replacement")
+	}
+	templateRoot := collectionTemplateRootName("flags")
+	if afterSame[templateRoot] != before[templateRoot] {
+		t.Fatalf("template root changed from %d to %d for same template shape", before[templateRoot], afterSame[templateRoot])
+	}
+	activeRoot := collectionSecondaryRootName("flags", "active")
+	if afterSame[activeRoot] != before[activeRoot] {
+		t.Fatalf("active secondary root changed from %d to %d for same template-v1 bool value", before[activeRoot], afterSame[activeRoot])
+	}
+	assertTemplateV1UpdateBatchBoolIDs(t, col, true, "u1")
+
+	results, err = col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func([]byte) ([]byte, bool, error) {
+			return mustTemplateV1UpdateBatchBoolDocument(t, false, "changed-active"), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("update changed template-v1 active: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("changed-active update results=%+v want one matched modified row", results)
+	}
+	stats = col.LastUpdateStats()
+	if got, want := stats.SecondaryDeleteEntries, 1; got != want {
+		t.Fatalf("changed-active update secondary deletes=%d want %d", got, want)
+	}
+	if got, want := stats.SecondarySetEntries, 1; got != want {
+		t.Fatalf("changed-active update secondary sets=%d want %d", got, want)
+	}
+	if got, want := stats.IndexValueChanges, 1; got != want {
+		t.Fatalf("changed-active update index changes=%d want %d", got, want)
+	}
+	afterChanged := mustTemplateV1UpdateBatchBoolRootIDs(t, d, "flags", rootNames...)
+	if afterChanged[activeRoot] == afterSame[activeRoot] {
+		t.Fatalf("active secondary root did not change for changed template-v1 bool value")
+	}
+	if afterChanged[templateRoot] != afterSame[templateRoot] {
+		t.Fatalf("template root changed from %d to %d for same shape active update", afterSame[templateRoot], afterChanged[templateRoot])
+	}
+	assertTemplateV1UpdateBatchBoolIDs(t, col, true)
+	assertTemplateV1UpdateBatchBoolIDs(t, col, false, "u1")
+}
+
+func mustTemplateV1UpdateBatchBoolDocument(t *testing.T, active bool, note string) []byte {
+	t.Helper()
+	activeJSON := "false"
+	if active {
+		activeJSON = "true"
+	}
+	doc, err := EncodeTemplateV1DocumentJSON([]byte(`{"active":` + activeJSON + `,"note":"` + note + `"}`))
+	if err != nil {
+		t.Fatalf("encode template-v1 document: %v", err)
+	}
+	return doc
+}
+
+func mustTemplateV1UpdateBatchBoolRootIDs(t *testing.T, d *backenddb.DB, collectionName string, rootNames ...string) map[string]uint64 {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	catalog, err := loadCollectionCatalog(snap, collectionName)
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatalf("missing catalog for collection %q", collectionName)
+	}
+	out := make(map[string]uint64, len(rootNames))
+	for _, name := range rootNames {
+		rootID := catalog.rootID(name)
+		if rootID == 0 {
+			t.Fatalf("root %q was not persisted", name)
+		}
+		out[name] = rootID
+	}
+	return out
+}
+
+func assertTemplateV1UpdateBatchBoolIDs(t *testing.T, col *Collection, active bool, want ...string) {
+	t.Helper()
+	ids, err := col.FindByIndexValue("active", active)
+	if err != nil {
+		t.Fatalf("find active %v: %v", active, err)
+	}
+	got := make([]string, len(ids))
+	for i := range ids {
+		got[i] = string(ids[i])
+	}
+	sort.Strings(got)
+	wantSorted := append([]string(nil), want...)
+	sort.Strings(wantSorted)
+	if len(got) != len(wantSorted) {
+		t.Fatalf("active %v ids=%q want %q", active, ids, want)
+	}
+	for i := range wantSorted {
+		if got[i] != wantSorted[i] {
+			t.Fatalf("active %v ids=%q want %q", active, ids, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add a PR2 `UpdateBatch` proof for template-v1 `IndexValueBool` minimization
- verify a same-shape replacement with the same bool indexed value reports no secondary work and keeps template/secondary roots stable
- verify changing the bool indexed value reports delete/set work, moves the secondary root, keeps the template root stable, and updates index lookup visibility

## Why

#1242 PR2 asks for path/format coverage for same-effective replacement updates, update-batch stats, and template-root work separation. Existing template-v1 coverage pins strings, null/missing, multikey, int64, and double; this adds the bool scalar batch case.

## Tests

- `go test ./TreeDB/collections -run '^TestCollectionUpdateBatchTemplateV1BoolSameEffectiveSkipsSecondaryRoot$' -count=1`\n- `go test ./TreeDB/collections -run 'Test(CollectionUpdateBatchTemplateV1BoolSameEffectiveSkipsSecondaryRoot|CollectionUpdateBatchTemplateV1DoubleSameEffectiveSkipsSecondaryRoot|CollectionUpdateBatchTemplateV1Int64SameEffectiveSkipsSecondaryRoot|CollectionUpdateBatchSkipsUnchangedSecondaryIndexes)$' -count=1`\n- `go test ./TreeDB/collections -count=1`