### PR TITLE
collections: aggregate #1242 PR1a guardrails

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -82,6 +82,7 @@ var (
 	errCollectionRootOverlaysRequireCompaction = errors.New("collections: collection root overlays require compaction before writes")
 	errUpdateBatchHasSecondaryUniqueIndex      = errors.New("collections: update batch has secondary unique index")
 	errUpdateBatchChangesSecondaryUniqueIndex  = errors.New("collections: update batch changes secondary unique index")
+	errIndexedFlushLostOwnership               = errors.New("collections: async indexed publish lost ownership of in-flight flush units")
 	errUpdateCombinerStopped                   = errors.New("collections: update combiner stopped before DB update completed; callback may have been invoked")
 	indexedAsyncFlushPprofLabels               = pprof.Labels(
 		collectionPprofComponentKey, collectionPprofIndexedAsyncFlush,
@@ -3626,7 +3627,7 @@ func pendingIndexedUniqueValueRunMapLocked(domain *collectionWriteDomain) map[st
 	return indexedFlushUnitPendingUniqueValueRunMap(indexedFlushUnitsWithPublishing(domain.indexedPublishingUnits, domain.indexedFlushUnits), domain.uniqueValueRuns)
 }
 
-func pendingUniqueReservationIndexLocked(domain *collectionWriteDomain, indexName string) *bufferedUniqueValueIndex {
+func pendingUniqueReservationIndexLocked(domain *collectionWriteDomain, indexName string, cache bool) *bufferedUniqueValueIndex {
 	if domain == nil || indexName == "" {
 		return nil
 	}
@@ -3637,11 +3638,18 @@ func pendingUniqueReservationIndexLocked(domain *collectionWriteDomain, indexNam
 	if len(runs) == 0 {
 		return nil
 	}
-	return rebuildBufferedUniqueValueIndexes(map[string][]memtable.Table{indexName: runs})[indexName]
+	index := rebuildBufferedUniqueValueIndexes(map[string][]memtable.Table{indexName: runs})[indexName]
+	if cache && index != nil {
+		if domain.uniqueValueIndex == nil {
+			domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex, 1)
+		}
+		domain.uniqueValueIndex[indexName] = index
+	}
+	return index
 }
 
 func pendingUniqueReservationProbeLocked(domain *collectionWriteDomain, indexName string, valuePrefix []byte) bool {
-	index := pendingUniqueReservationIndexLocked(domain, indexName)
+	index := pendingUniqueReservationIndexLocked(domain, indexName, false)
 	return index != nil && index.contains(valuePrefix)
 }
 
@@ -3871,7 +3879,7 @@ func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collecti
 		if _, ok := uniqueIndexes[run.indexName]; !ok {
 			continue
 		}
-		pending := pendingUniqueReservationIndexLocked(domain, run.indexName)
+		pending := pendingUniqueReservationIndexLocked(domain, run.indexName, true)
 		if pending == nil || pending.len() == 0 {
 			continue
 		}
@@ -4996,10 +5004,9 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	}
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
-		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
 		domain.indexedFlushLostOwnership.Add(1)
-		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, err)
-		return err
+		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, errIndexedFlushLostOwnership)
+		return errIndexedFlushLostOwnership
 	}
 	domain.loaded = true
 	domain.meta = work.meta
@@ -10981,7 +10988,7 @@ func bufferedIndexPrefixTableLocked(domain *collectionWriteDomain, collectionNam
 		return nil, nil
 	}
 	if unique {
-		pending := pendingUniqueReservationIndexLocked(domain, indexName)
+		pending := pendingUniqueReservationIndexLocked(domain, indexName, false)
 		if pending != nil && !pending.contains(prefix) {
 			return nil, nil
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -401,53 +401,57 @@ type CollectionUpdateIndexStats struct {
 // CollectionManager. The counters are process-local observability; they are
 // not persisted with collection metadata.
 type CollectionManagerStats struct {
-	Domains                       int
-	PendingDocuments              int
-	PendingBytes                  int64
-	PendingRootRuns               int
-	PendingIndexedFlushUnits      int
-	IndexedAsyncFlushRunning      int
-	MutationLockCalls             uint64
-	MutationLockWait              time.Duration
-	MutationLockHold              time.Duration
-	IndexedStageBatches           uint64
-	IndexedStageDocs              uint64
-	IndexedStageBytes             uint64
-	IndexedStageRootRuns          uint64
-	IndexedAutoFlushes            uint64
-	IndexedAsyncFlushScheduled    uint64
-	IndexedAsyncFlushBackpressure uint64
-	IndexedAsyncFlushErrors       uint64
-	IndexedFlushCalls             uint64
-	IndexedFlushErrors            uint64
-	IndexedFlushDocs              uint64
-	IndexedFlushBytes             uint64
-	IndexedFlushRootRuns          uint64
-	IndexedFlushRoots             uint64
-	IndexedFlushDuration          time.Duration
-	IndexedFlushMaterialize       time.Duration
-	IndexedFlushPublish           time.Duration
-	UpdateCombineRequests         uint64
-	UpdateCombineBatches          uint64
-	UpdateCombineBatchedRequests  uint64
-	UpdateCombineFallbackRequests uint64
-	UpdateCombineQueueDepthMax    uint64
-	UpdateBatchCalls              uint64
-	UpdateBatchItems              uint64
-	UpdateBatchMatched            uint64
-	UpdateBatchModified           uint64
-	UpdateBatchRuns               uint64
-	UpdateBatchBufferedBatches    uint64
-	UpdateBatchCurrentRead        time.Duration
-	UpdateBatchCallback           time.Duration
-	UpdateBatchPrepareDocuments   time.Duration
-	UpdateBatchIndexStateExtract  time.Duration
-	UpdateBatchUniquePreflight    time.Duration
-	UpdateBatchTemplateRunBuild   time.Duration
-	UpdateBatchPrimaryRunBuild    time.Duration
-	UpdateBatchIndexStateRunBuild time.Duration
-	UpdateBatchSecondaryRunBuild  time.Duration
-	UpdateBatchBufferStage        time.Duration
+	Domains                        int
+	PendingDocuments               int
+	PendingBytes                   int64
+	PendingRootRuns                int
+	PendingIndexedFlushUnits       int
+	IndexedAsyncFlushRunning       int
+	MutationLockCalls              uint64
+	MutationLockWait               time.Duration
+	MutationLockHold               time.Duration
+	IndexedStageBatches            uint64
+	IndexedStageDocs               uint64
+	IndexedStageBytes              uint64
+	IndexedStageRootRuns           uint64
+	IndexedAutoFlushes             uint64
+	IndexedAsyncFlushScheduled     uint64
+	IndexedAsyncFlushBackpressure  uint64
+	IndexedAsyncFlushErrors        uint64
+	IndexedFlushCalls              uint64
+	IndexedFlushErrors             uint64
+	IndexedFlushRequeues           uint64
+	IndexedFlushRequeuedUnits      uint64
+	IndexedFlushLostOwnership      uint64
+	IndexedFlushRootBaseMismatches uint64
+	IndexedFlushDocs               uint64
+	IndexedFlushBytes              uint64
+	IndexedFlushRootRuns           uint64
+	IndexedFlushRoots              uint64
+	IndexedFlushDuration           time.Duration
+	IndexedFlushMaterialize        time.Duration
+	IndexedFlushPublish            time.Duration
+	UpdateCombineRequests          uint64
+	UpdateCombineBatches           uint64
+	UpdateCombineBatchedRequests   uint64
+	UpdateCombineFallbackRequests  uint64
+	UpdateCombineQueueDepthMax     uint64
+	UpdateBatchCalls               uint64
+	UpdateBatchItems               uint64
+	UpdateBatchMatched             uint64
+	UpdateBatchModified            uint64
+	UpdateBatchRuns                uint64
+	UpdateBatchBufferedBatches     uint64
+	UpdateBatchCurrentRead         time.Duration
+	UpdateBatchCallback            time.Duration
+	UpdateBatchPrepareDocuments    time.Duration
+	UpdateBatchIndexStateExtract   time.Duration
+	UpdateBatchUniquePreflight     time.Duration
+	UpdateBatchTemplateRunBuild    time.Duration
+	UpdateBatchPrimaryRunBuild     time.Duration
+	UpdateBatchIndexStateRunBuild  time.Duration
+	UpdateBatchSecondaryRunBuild   time.Duration
+	UpdateBatchBufferStage         time.Duration
 	// Detailed buffer-stage aggregate timings are populated only when
 	// CollectionManager.SetUpdateBatchDetailedStatsEnabled(true) is enabled.
 	// UpdateBatchBufferLockHold is an enclosing domain mutex hold-time metric
@@ -745,6 +749,10 @@ type collectionWriteDomain struct {
 	indexedAsyncFlushErrors          atomic.Uint64
 	indexedFlushCalls                atomic.Uint64
 	indexedFlushErrors               atomic.Uint64
+	indexedFlushRequeues             atomic.Uint64
+	indexedFlushRequeuedUnits        atomic.Uint64
+	indexedFlushLostOwnership        atomic.Uint64
+	indexedFlushRootBaseMismatches   atomic.Uint64
 	indexedFlushDocs                 atomic.Uint64
 	indexedFlushBytes                atomic.Uint64
 	indexedFlushRootRuns             atomic.Uint64
@@ -967,6 +975,10 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_async_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushErrors)
 	out["treedb.collections.write_domain.indexed_flush.calls_total"] = fmt.Sprintf("%d", stats.IndexedFlushCalls)
 	out["treedb.collections.write_domain.indexed_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedFlushErrors)
+	out["treedb.collections.write_domain.indexed_flush.requeue_total"] = fmt.Sprintf("%d", stats.IndexedFlushRequeues)
+	out["treedb.collections.write_domain.indexed_flush.requeued_units_total"] = fmt.Sprintf("%d", stats.IndexedFlushRequeuedUnits)
+	out["treedb.collections.write_domain.indexed_flush.lost_ownership_total"] = fmt.Sprintf("%d", stats.IndexedFlushLostOwnership)
+	out["treedb.collections.write_domain.indexed_flush.root_base_mismatch_total"] = fmt.Sprintf("%d", stats.IndexedFlushRootBaseMismatches)
 	out["treedb.collections.write_domain.indexed_flush.docs_total"] = fmt.Sprintf("%d", stats.IndexedFlushDocs)
 	out["treedb.collections.write_domain.indexed_flush.bytes_total"] = fmt.Sprintf("%d", stats.IndexedFlushBytes)
 	out["treedb.collections.write_domain.indexed_flush.root_runs_total"] = fmt.Sprintf("%d", stats.IndexedFlushRootRuns)
@@ -1138,6 +1150,10 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.IndexedAsyncFlushErrors += other.IndexedAsyncFlushErrors
 	s.IndexedFlushCalls += other.IndexedFlushCalls
 	s.IndexedFlushErrors += other.IndexedFlushErrors
+	s.IndexedFlushRequeues += other.IndexedFlushRequeues
+	s.IndexedFlushRequeuedUnits += other.IndexedFlushRequeuedUnits
+	s.IndexedFlushLostOwnership += other.IndexedFlushLostOwnership
+	s.IndexedFlushRootBaseMismatches += other.IndexedFlushRootBaseMismatches
 	s.IndexedFlushDocs += other.IndexedFlushDocs
 	s.IndexedFlushBytes += other.IndexedFlushBytes
 	s.IndexedFlushRootRuns += other.IndexedFlushRootRuns
@@ -1229,6 +1245,10 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.IndexedAsyncFlushErrors = domain.indexedAsyncFlushErrors.Load()
 	stats.IndexedFlushCalls = domain.indexedFlushCalls.Load()
 	stats.IndexedFlushErrors = domain.indexedFlushErrors.Load()
+	stats.IndexedFlushRequeues = domain.indexedFlushRequeues.Load()
+	stats.IndexedFlushRequeuedUnits = domain.indexedFlushRequeuedUnits.Load()
+	stats.IndexedFlushLostOwnership = domain.indexedFlushLostOwnership.Load()
+	stats.IndexedFlushRootBaseMismatches = domain.indexedFlushRootBaseMismatches.Load()
 	stats.IndexedFlushDocs = domain.indexedFlushDocs.Load()
 	stats.IndexedFlushBytes = domain.indexedFlushBytes.Load()
 	stats.IndexedFlushRootRuns = domain.indexedFlushRootRuns.Load()
@@ -2527,6 +2547,9 @@ func (c *Collection) revalidateBufferedWriteDomainLocked(domain *collectionWrite
 			}
 			return nil
 		}); err != nil {
+			if errors.Is(err, ErrConcurrentMutation) {
+				domain.indexedFlushRootBaseMismatches.Add(1)
+			}
 			return nil, err
 		}
 	} else {
@@ -3603,6 +3626,25 @@ func pendingIndexedUniqueValueRunMapLocked(domain *collectionWriteDomain) map[st
 	return indexedFlushUnitPendingUniqueValueRunMap(indexedFlushUnitsWithPublishing(domain.indexedPublishingUnits, domain.indexedFlushUnits), domain.uniqueValueRuns)
 }
 
+func pendingUniqueReservationIndexLocked(domain *collectionWriteDomain, indexName string) *bufferedUniqueValueIndex {
+	if domain == nil || indexName == "" {
+		return nil
+	}
+	if index := domain.uniqueValueIndex[indexName]; index != nil {
+		return index
+	}
+	runs := pendingIndexedUniqueValueRunMapLocked(domain)[indexName]
+	if len(runs) == 0 {
+		return nil
+	}
+	return rebuildBufferedUniqueValueIndexes(map[string][]memtable.Table{indexName: runs})[indexName]
+}
+
+func pendingUniqueReservationProbeLocked(domain *collectionWriteDomain, indexName string, valuePrefix []byte) bool {
+	index := pendingUniqueReservationIndexLocked(domain, indexName)
+	return index != nil && index.contains(valuePrefix)
+}
+
 func rebuildBufferedPendingIndexesLocked(domain *collectionWriteDomain, collectionName string, preservePrimaryRunIndex bool) {
 	if domain == nil {
 		return
@@ -3829,7 +3871,7 @@ func (c *Collection) rejectBufferedIndexedInsertConflictsLocked(domain *collecti
 		if _, ok := uniqueIndexes[run.indexName]; !ok {
 			continue
 		}
-		pending := domain.uniqueValueIndex[run.indexName]
+		pending := pendingUniqueReservationIndexLocked(domain, run.indexName)
 		if pending == nil || pending.len() == 0 {
 			continue
 		}
@@ -4630,6 +4672,9 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		}
 		return nil
 	}); err != nil {
+		if errors.Is(err, ErrConcurrentMutation) {
+			domain.indexedFlushRootBaseMismatches.Add(1)
+		}
 		return nil, err
 	}
 
@@ -4925,6 +4970,10 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	preservePrimaryRunIndex := domain.primaryRunIndex != nil
 	if publishErr != nil {
 		if removed, ok := removeIndexedPublishingWorkUnitsLocked(domain, work.units); ok {
+			if len(removed) > 0 {
+				domain.indexedFlushRequeues.Add(1)
+				domain.indexedFlushRequeuedUnits.Add(uint64(len(removed)))
+			}
 			domain.indexedFlushUnits = append(removed, domain.indexedFlushUnits...)
 		}
 		rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
@@ -4944,6 +4993,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
 	if !owned {
 		err := errors.New("collections: async indexed publish lost ownership of in-flight flush units")
+		domain.indexedFlushLostOwnership.Add(1)
 		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, err)
 		return err
 	}
@@ -10927,7 +10977,7 @@ func bufferedIndexPrefixTableLocked(domain *collectionWriteDomain, collectionNam
 		return nil, nil
 	}
 	if unique {
-		pending := domain.uniqueValueIndex[indexName]
+		pending := pendingUniqueReservationIndexLocked(domain, indexName)
 		if pending != nil && !pending.contains(prefix) {
 			return nil, nil
 		}
@@ -10976,13 +11026,13 @@ func bufferedIndexRangeTableLocked(domain *collectionWriteDomain, collectionName
 	if domain == nil {
 		return nil, nil
 	}
-	if domain.count == 0 || len(domain.rootRuns) == 0 {
+	if domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
 		return nil, nil
 	}
 	if domain.meta.Name != "" {
 		collectionName = domain.meta.Name
 	}
-	runs := domain.rootRuns[collectionSecondaryRootName(collectionName, indexName)]
+	runs := pendingIndexedRootRunsLocked(domain, collectionSecondaryRootName(collectionName, indexName))
 	if len(runs) == 0 {
 		return nil, nil
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4673,6 +4673,9 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		return nil
 	}); err != nil {
 		if errors.Is(err, ErrConcurrentMutation) {
+			// This is distinct from revalidateBufferedWriteDomainLocked above:
+			// revalidation checks the current root before acquiring the publish
+			// pin, while this catches races observed after the pin is held.
 			domain.indexedFlushRootBaseMismatches.Add(1)
 		}
 		return nil, err
@@ -4730,6 +4733,7 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	defer func() {
 		if work.pin != nil {
 			_ = work.pin.Close()
+			work.pin = nil
 		}
 	}()
 	if collectionMetaUsesIndexedOverlayRoots(work.meta) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -402,57 +402,53 @@ type CollectionUpdateIndexStats struct {
 // CollectionManager. The counters are process-local observability; they are
 // not persisted with collection metadata.
 type CollectionManagerStats struct {
-	Domains                        int
-	PendingDocuments               int
-	PendingBytes                   int64
-	PendingRootRuns                int
-	PendingIndexedFlushUnits       int
-	IndexedAsyncFlushRunning       int
-	MutationLockCalls              uint64
-	MutationLockWait               time.Duration
-	MutationLockHold               time.Duration
-	IndexedStageBatches            uint64
-	IndexedStageDocs               uint64
-	IndexedStageBytes              uint64
-	IndexedStageRootRuns           uint64
-	IndexedAutoFlushes             uint64
-	IndexedAsyncFlushScheduled     uint64
-	IndexedAsyncFlushBackpressure  uint64
-	IndexedAsyncFlushErrors        uint64
-	IndexedFlushCalls              uint64
-	IndexedFlushErrors             uint64
-	IndexedFlushRequeues           uint64
-	IndexedFlushRequeuedUnits      uint64
-	IndexedFlushLostOwnership      uint64
-	IndexedFlushRootBaseMismatches uint64
-	IndexedFlushDocs               uint64
-	IndexedFlushBytes              uint64
-	IndexedFlushRootRuns           uint64
-	IndexedFlushRoots              uint64
-	IndexedFlushDuration           time.Duration
-	IndexedFlushMaterialize        time.Duration
-	IndexedFlushPublish            time.Duration
-	UpdateCombineRequests          uint64
-	UpdateCombineBatches           uint64
-	UpdateCombineBatchedRequests   uint64
-	UpdateCombineFallbackRequests  uint64
-	UpdateCombineQueueDepthMax     uint64
-	UpdateBatchCalls               uint64
-	UpdateBatchItems               uint64
-	UpdateBatchMatched             uint64
-	UpdateBatchModified            uint64
-	UpdateBatchRuns                uint64
-	UpdateBatchBufferedBatches     uint64
-	UpdateBatchCurrentRead         time.Duration
-	UpdateBatchCallback            time.Duration
-	UpdateBatchPrepareDocuments    time.Duration
-	UpdateBatchIndexStateExtract   time.Duration
-	UpdateBatchUniquePreflight     time.Duration
-	UpdateBatchTemplateRunBuild    time.Duration
-	UpdateBatchPrimaryRunBuild     time.Duration
-	UpdateBatchIndexStateRunBuild  time.Duration
-	UpdateBatchSecondaryRunBuild   time.Duration
-	UpdateBatchBufferStage         time.Duration
+	Domains                       int
+	PendingDocuments              int
+	PendingBytes                  int64
+	PendingRootRuns               int
+	PendingIndexedFlushUnits      int
+	IndexedAsyncFlushRunning      int
+	MutationLockCalls             uint64
+	MutationLockWait              time.Duration
+	MutationLockHold              time.Duration
+	IndexedStageBatches           uint64
+	IndexedStageDocs              uint64
+	IndexedStageBytes             uint64
+	IndexedStageRootRuns          uint64
+	IndexedAutoFlushes            uint64
+	IndexedAsyncFlushScheduled    uint64
+	IndexedAsyncFlushBackpressure uint64
+	IndexedAsyncFlushErrors       uint64
+	IndexedFlushCalls             uint64
+	IndexedFlushErrors            uint64
+	IndexedFlushDocs              uint64
+	IndexedFlushBytes             uint64
+	IndexedFlushRootRuns          uint64
+	IndexedFlushRoots             uint64
+	IndexedFlushDuration          time.Duration
+	IndexedFlushMaterialize       time.Duration
+	IndexedFlushPublish           time.Duration
+	UpdateCombineRequests         uint64
+	UpdateCombineBatches          uint64
+	UpdateCombineBatchedRequests  uint64
+	UpdateCombineFallbackRequests uint64
+	UpdateCombineQueueDepthMax    uint64
+	UpdateBatchCalls              uint64
+	UpdateBatchItems              uint64
+	UpdateBatchMatched            uint64
+	UpdateBatchModified           uint64
+	UpdateBatchRuns               uint64
+	UpdateBatchBufferedBatches    uint64
+	UpdateBatchCurrentRead        time.Duration
+	UpdateBatchCallback           time.Duration
+	UpdateBatchPrepareDocuments   time.Duration
+	UpdateBatchIndexStateExtract  time.Duration
+	UpdateBatchUniquePreflight    time.Duration
+	UpdateBatchTemplateRunBuild   time.Duration
+	UpdateBatchPrimaryRunBuild    time.Duration
+	UpdateBatchIndexStateRunBuild time.Duration
+	UpdateBatchSecondaryRunBuild  time.Duration
+	UpdateBatchBufferStage        time.Duration
 	// Detailed buffer-stage aggregate timings are populated only when
 	// CollectionManager.SetUpdateBatchDetailedStatsEnabled(true) is enabled.
 	// UpdateBatchBufferLockHold is an enclosing domain mutex hold-time metric
@@ -480,6 +476,10 @@ type CollectionManagerStats struct {
 	UpdateBatchUniqueCheckSkips    uint64
 	UpdateBatchIndexStatsCount     int
 	UpdateBatchIndexStats          [maxCollectionUpdateInlineIndexStats]CollectionUpdateIndexStats
+	IndexedFlushRequeues           uint64
+	IndexedFlushRequeuedUnits      uint64
+	IndexedFlushLostOwnership      uint64
+	IndexedFlushRootBaseMismatches uint64
 }
 
 // DocumentRecord is one primary collection record returned by ScanDocuments.
@@ -976,7 +976,7 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_async_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushErrors)
 	out["treedb.collections.write_domain.indexed_flush.calls_total"] = fmt.Sprintf("%d", stats.IndexedFlushCalls)
 	out["treedb.collections.write_domain.indexed_flush.errors_total"] = fmt.Sprintf("%d", stats.IndexedFlushErrors)
-	out["treedb.collections.write_domain.indexed_flush.requeue_total"] = fmt.Sprintf("%d", stats.IndexedFlushRequeues)
+	out["treedb.collections.write_domain.indexed_flush.requeues_total"] = fmt.Sprintf("%d", stats.IndexedFlushRequeues)
 	out["treedb.collections.write_domain.indexed_flush.requeued_units_total"] = fmt.Sprintf("%d", stats.IndexedFlushRequeuedUnits)
 	out["treedb.collections.write_domain.indexed_flush.lost_ownership_total"] = fmt.Sprintf("%d", stats.IndexedFlushLostOwnership)
 	out["treedb.collections.write_domain.indexed_flush.root_base_mismatch_total"] = fmt.Sprintf("%d", stats.IndexedFlushRootBaseMismatches)
@@ -3627,6 +3627,9 @@ func pendingIndexedUniqueValueRunMapLocked(domain *collectionWriteDomain) map[st
 	return indexedFlushUnitPendingUniqueValueRunMap(indexedFlushUnitsWithPublishing(domain.indexedPublishingUnits, domain.indexedFlushUnits), domain.uniqueValueRuns)
 }
 
+// pendingUniqueReservationIndexLocked requires domain.mu to be held. When
+// cache is true it may write the rebuilt pending unique index back to the
+// domain, so callers using only an RLock must pass cache=false.
 func pendingUniqueReservationIndexLocked(domain *collectionWriteDomain, indexName string, cache bool) *bufferedUniqueValueIndex {
 	if domain == nil || indexName == "" {
 		return nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4768,10 +4768,10 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
 		}
 		completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, materializeElapsed+publishElapsed, materializeElapsed, publishElapsed)
-		if publishErr != nil {
-			return publishErr
+		if completeErr != nil {
+			return completeErr
 		}
-		return completeErr
+		return publishErr
 	}
 	materializeStart := time.Now()
 	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
@@ -4790,10 +4790,10 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
 	}
 	completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, materializeElapsed+publishElapsed, materializeElapsed, publishElapsed)
-	if publishErr != nil {
-		return publishErr
+	if completeErr != nil {
+		return completeErr
 	}
-	return completeErr
+	return publishErr
 }
 
 func buildBufferedRootOverlayDeltaBatchPublishInputs(rootNames []string, rootRuns map[string][]memtable.Table, rootPolicies map[string]backenddb.OrderedRootStoragePolicy, rootOverlays map[string][]uint64) ([]backenddb.OrderedRootDeltaBatchPublishInput, func(), error) {
@@ -4981,13 +4981,21 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	defer domain.mu.Unlock()
 	preservePrimaryRunIndex := domain.primaryRunIndex != nil
 	if publishErr != nil {
-		if removed, ok := removeIndexedPublishingWorkUnitsLocked(domain, work.units); ok {
-			if len(removed) > 0 {
-				domain.indexedFlushRequeues.Add(1)
-				domain.indexedFlushRequeuedUnits.Add(uint64(len(removed)))
-			}
-			domain.indexedFlushUnits = append(removed, domain.indexedFlushUnits...)
+		if errors.Is(publishErr, ErrConcurrentMutation) {
+			domain.indexedFlushRootBaseMismatches.Add(1)
 		}
+		removed, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
+		if !owned {
+			err := errors.Join(errIndexedFlushLostOwnership, publishErr)
+			domain.indexedFlushLostOwnership.Add(1)
+			domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, err)
+			return err
+		}
+		if len(removed) > 0 {
+			domain.indexedFlushRequeues.Add(1)
+			domain.indexedFlushRequeuedUnits.Add(uint64(len(removed)))
+		}
+		domain.indexedFlushUnits = append(removed, domain.indexedFlushUnits...)
 		rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
 		domain.observeIndexedFlush(work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, publishErr)
 		return publishErr

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3678,6 +3678,7 @@ func pendingUniqueReservationIndexLocked(domain *collectionWriteDomain, indexNam
 	return index
 }
 
+// pendingUniqueReservationProbeLocked requires domain.mu to be held.
 func pendingUniqueReservationProbeLocked(domain *collectionWriteDomain, indexName string, valuePrefix []byte) bool {
 	index := pendingUniqueReservationIndexLocked(domain, indexName, false)
 	return index != nil && index.contains(valuePrefix)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1541,6 +1541,7 @@ func (domain *collectionWriteDomain) waitIndexedAsyncFlush() {
 		domain.indexedAsyncCond = sync.NewCond(&domain.indexedAsyncMu)
 	}
 	for domain.indexedAsyncRun {
+		runCollectionWaitIndexedAsyncFlushHook()
 		domain.indexedAsyncCond.Wait()
 	}
 	domain.indexedAsyncMu.Unlock()
@@ -1574,6 +1575,32 @@ func (domain *collectionWriteDomain) consumeIndexedAsyncFlushError() error {
 	domain.indexedAsyncErr = nil
 	domain.indexedAsyncMu.Unlock()
 	return err
+}
+
+var collectionWaitIndexedAsyncFlushHook struct {
+	mu sync.Mutex
+	fn func()
+}
+
+func setCollectionWaitIndexedAsyncFlushHookForTest(fn func()) func() {
+	collectionWaitIndexedAsyncFlushHook.mu.Lock()
+	prev := collectionWaitIndexedAsyncFlushHook.fn
+	collectionWaitIndexedAsyncFlushHook.fn = fn
+	collectionWaitIndexedAsyncFlushHook.mu.Unlock()
+	return func() {
+		collectionWaitIndexedAsyncFlushHook.mu.Lock()
+		collectionWaitIndexedAsyncFlushHook.fn = prev
+		collectionWaitIndexedAsyncFlushHook.mu.Unlock()
+	}
+}
+
+func runCollectionWaitIndexedAsyncFlushHook() {
+	collectionWaitIndexedAsyncFlushHook.mu.Lock()
+	fn := collectionWaitIndexedAsyncFlushHook.fn
+	collectionWaitIndexedAsyncFlushHook.mu.Unlock()
+	if fn != nil {
+		fn()
+	}
 }
 
 func (domain *collectionWriteDomain) observeIndexedFlush(docs int, bytes int64, rootRuns, roots int, duration, materialize, publish time.Duration, err error) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -10897,6 +10897,8 @@ func TestCollectionFindByIndexRangeTypedInt64(t *testing.T) {
 		t.Fatalf("insert batch: %v", err)
 	}
 
+	// Use a non-equality range so this exercises non-exact range materialization,
+	// not the exact-prefix helper that already used pending root runs.
 	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(0), Inclusive: true},
 		Upper: IndexRangeBound{Value: int64(10), Inclusive: false},
@@ -11013,6 +11015,8 @@ func TestCollectionFindByIndexRangeMergesBufferedUpdates(t *testing.T) {
 		t.Fatalf("buffered update advanced commit seq by %d, want 0", after.CommitSeq-before.CommitSeq)
 	}
 
+	// Use a non-equality range so this exercises non-exact range materialization,
+	// not the exact-prefix helper that already used pending root runs.
 	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(5), Inclusive: true},
 		Upper: IndexRangeBound{Value: int64(6), Inclusive: true},
@@ -11045,6 +11049,168 @@ func TestCollectionFindByIndexRangeMergesBufferedUpdates(t *testing.T) {
 	}
 	if truncated || len(ids) != 2 || !bytes.Equal(ids[0], []byte("u1")) || !bytes.Equal(ids[1], []byte("u2")) {
 		t.Fatalf("flushed score ids=%q truncated=%v want u1,u2 false", ids, truncated)
+	}
+}
+
+func TestCollectionFindByIndexRangeSeesQueuedIndexedFlushUnits(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "score", Field: "score", ValueType: IndexValueInt64}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2"), []byte("u3")},
+		[][]byte{
+			[]byte(`{"score":5}`),
+			[]byte(`{"score":6}`),
+			[]byte(`{"score":9}`),
+		},
+	); err != nil {
+		t.Fatalf("insert persisted rows: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush persisted rows: %v", err)
+	}
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONField("score", int64(7))},
+		{DocumentID: []byte("u2"), Update: setJSONField("score", int64(8))},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatalf("batched=%v results=%+v want buffered update batch", batched, results)
+	}
+	col.writeDomain.mu.Lock()
+	if !rotateIndexedMutableToFlushUnitLocked(col.writeDomain) {
+		col.writeDomain.mu.Unlock()
+		t.Fatal("rotate indexed mutable state returned false")
+	}
+	if got := len(col.writeDomain.indexedFlushUnits); got != 1 {
+		col.writeDomain.mu.Unlock()
+		t.Fatalf("queued flush units=%d want 1", got)
+	}
+	col.writeDomain.mu.Unlock()
+
+	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(7), Inclusive: true},
+		Upper: IndexRangeBound{Value: int64(9), Inclusive: false},
+	})
+	if err != nil {
+		t.Fatalf("find queued new score range: %v", err)
+	}
+	if truncated || len(ids) != 2 || !bytes.Equal(ids[0], []byte("u1")) || !bytes.Equal(ids[1], []byte("u2")) {
+		t.Fatalf("queued new score ids=%q truncated=%v want u1,u2 false", ids, truncated)
+	}
+	ids, truncated, err = col.FindByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(5), Inclusive: true},
+		Upper: IndexRangeBound{Value: int64(7), Inclusive: false},
+	})
+	if err != nil {
+		t.Fatalf("find queued old score range: %v", err)
+	}
+	if truncated || len(ids) != 0 {
+		t.Fatalf("queued old score ids=%q truncated=%v want none false", ids, truncated)
+	}
+}
+
+func TestCollectionFindByIndexRangeSeesPublishingIndexedFlushUnits(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "score", Field: "score", ValueType: IndexValueInt64}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2"), []byte("u3")},
+		[][]byte{
+			[]byte(`{"score":5}`),
+			[]byte(`{"score":6}`),
+			[]byte(`{"score":9}`),
+		},
+	); err != nil {
+		t.Fatalf("insert persisted rows: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush persisted rows: %v", err)
+	}
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONField("score", int64(7))},
+		{DocumentID: []byte("u2"), Update: setJSONField("score", int64(8))},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatalf("batched=%v results=%+v want buffered update batch", batched, results)
+	}
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	publishAttempted := false
+	defer func() {
+		if !publishAttempted && work.pin != nil {
+			_ = work.pin.Close()
+			work.pin = nil
+		}
+	}()
+
+	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(7), Inclusive: true},
+		Upper: IndexRangeBound{Value: int64(9), Inclusive: false},
+	})
+	if err != nil {
+		t.Fatalf("find publishing new score range: %v", err)
+	}
+	if truncated || len(ids) != 2 || !bytes.Equal(ids[0], []byte("u1")) || !bytes.Equal(ids[1], []byte("u2")) {
+		t.Fatalf("publishing new score ids=%q truncated=%v want u1,u2 false", ids, truncated)
+	}
+	ids, truncated, err = col.FindByIndexRange("score", IndexRangeOptions{
+		Lower: IndexRangeBound{Value: int64(5), Inclusive: true},
+		Upper: IndexRangeBound{Value: int64(7), Inclusive: false},
+	})
+	if err != nil {
+		t.Fatalf("find publishing old score range: %v", err)
+	}
+	if truncated || len(ids) != 0 {
+		t.Fatalf("publishing old score ids=%q truncated=%v want none false", ids, truncated)
+	}
+	publishAttempted = true
+	if err := col.publishPreparedIndexedFlush(work); err != nil {
+		t.Fatalf("publish prepared async flush: %v", err)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4998,15 +4998,22 @@ func TestCollectionIndexedWriteMemtablesFlushWaitsForPublishingUnits(t *testing.
 		finishAsync(errors.New("test cleanup"))
 	})
 
+	waitEntered, releaseWait := collectionWaitIndexedAsyncFlushGateForTest(t)
 	flushDone := make(chan error, 1)
 	go func() {
 		flushDone <- col.flushBufferedWrites()
 	}()
 	select {
-	case err := <-flushDone:
-		t.Fatalf("flush returned before in-flight async publish drained: %v", err)
-	case <-time.After(50 * time.Millisecond):
+	case <-waitEntered:
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out waiting for flush to reach indexed async drain")
 	}
+	select {
+	case err := <-flushDone:
+		t.Fatalf("flush returned after entering indexed async drain but before publish finished: %v", err)
+	default:
+	}
+	releaseWait()
 	publishDone := make(chan error, 1)
 	go func() {
 		err := col.publishPreparedIndexedFlush(work)
@@ -5065,6 +5072,7 @@ func TestCollectionIndexedWriteMemtablesFlushRetriesAsyncScheduledDuringWaitGap(
 	}
 
 	domain := col.writeDomain
+	waitEntered, releaseWait := collectionWaitIndexedAsyncFlushGateForTest(t)
 	domain.mu.Lock()
 	scanDone := make(chan error, 1)
 	go func() {
@@ -5073,7 +5081,6 @@ func TestCollectionIndexedWriteMemtablesFlushRetriesAsyncScheduledDuringWaitGap(
 		})
 		scanDone <- err
 	}()
-	time.Sleep(20 * time.Millisecond)
 	if !domain.beginIndexedAsyncFlush() {
 		domain.mu.Unlock()
 		t.Fatal("begin async flush returned false")
@@ -5106,10 +5113,16 @@ func TestCollectionIndexedWriteMemtablesFlushRetriesAsyncScheduledDuringWaitGap(
 	})
 
 	select {
-	case err := <-scanDone:
-		t.Fatalf("scan returned before scheduled async publish drained: %v", err)
-	case <-time.After(50 * time.Millisecond):
+	case <-waitEntered:
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out waiting for scan to reach indexed async drain")
 	}
+	select {
+	case err := <-scanDone:
+		t.Fatalf("scan returned after entering indexed async drain but before publish finished: %v", err)
+	default:
+	}
+	releaseWait()
 	publishDone := make(chan error, 1)
 	go func() {
 		err := col.publishPreparedIndexedFlush(work)
@@ -5187,16 +5200,23 @@ func TestCollectionIndexedWriteMemtablesCreateIndexWaitsForPublishingUnits(t *te
 		finishAsync(errors.New("test cleanup"))
 	})
 
+	waitEntered, releaseWait := collectionWaitIndexedAsyncFlushGateForTest(t)
 	createDone := make(chan error, 1)
 	go func() {
 		_, err := col.CreateIndex(IndexDefinition{Name: "city", Field: "city", ValueType: IndexValueString})
 		createDone <- err
 	}()
 	select {
-	case err := <-createDone:
-		t.Fatalf("CreateIndex returned before in-flight async publish drained: %v", err)
-	case <-time.After(50 * time.Millisecond):
+	case <-waitEntered:
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out waiting for CreateIndex to reach indexed async drain")
 	}
+	select {
+	case err := <-createDone:
+		t.Fatalf("CreateIndex returned after entering indexed async drain but before publish finished: %v", err)
+	default:
+	}
+	releaseWait()
 	publishDone := make(chan error, 1)
 	go func() {
 		err := col.publishPreparedIndexedFlush(work)
@@ -5224,6 +5244,28 @@ func TestCollectionIndexedWriteMemtablesCreateIndexWaitsForPublishingUnits(t *te
 		t.Fatalf("find city after CreateIndex: %v", err)
 	}
 	collectionMaintenanceRequireUnorderedIDs(t, ids, []byte("u1"))
+}
+
+func collectionWaitIndexedAsyncFlushGateForTest(tb testing.TB) (<-chan struct{}, func()) {
+	tb.Helper()
+	waitEntered := make(chan struct{})
+	allowWait := make(chan struct{})
+	var waitEnteredOnce sync.Once
+	var releaseOnce sync.Once
+	restoreWaitHook := setCollectionWaitIndexedAsyncFlushHookForTest(func() {
+		waitEnteredOnce.Do(func() {
+			close(waitEntered)
+			<-allowWait
+		})
+	})
+	release := func() {
+		releaseOnce.Do(func() {
+			close(allowWait)
+			restoreWaitHook()
+		})
+	}
+	tb.Cleanup(release)
+	return waitEntered, release
 }
 
 func TestCollectionIndexedWriteMemtablesAsyncSuccessClearsPriorError(t *testing.T) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11258,9 +11258,11 @@ func TestCollectionFindByIndexRangeSkipsBufferedTombstone(t *testing.T) {
 	}
 	domain.mu.Unlock()
 
+	// Use a non-equality range so this exercises bufferedIndexRangeTableLocked,
+	// not the exact-prefix helper.
 	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(5), Inclusive: true},
-		Upper: IndexRangeBound{Value: int64(5), Inclusive: true},
+		Upper: IndexRangeBound{Value: int64(6), Inclusive: false},
 	})
 	if err != nil {
 		t.Fatalf("find range: %v", err)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -11180,13 +11180,7 @@ func TestCollectionFindByIndexRangeSeesPublishingIndexedFlushUnits(t *testing.T)
 	if work == nil {
 		t.Fatal("prepare async publish returned nil work")
 	}
-	publishAttempted := false
-	defer func() {
-		if !publishAttempted && work.pin != nil {
-			_ = work.pin.Close()
-			work.pin = nil
-		}
-	}()
+	defer collectionTestCloseIndexedFlushWork(work)
 
 	ids, truncated, err := col.FindByIndexRange("score", IndexRangeOptions{
 		Lower: IndexRangeBound{Value: int64(7), Inclusive: true},
@@ -11208,7 +11202,6 @@ func TestCollectionFindByIndexRangeSeesPublishingIndexedFlushUnits(t *testing.T)
 	if truncated || len(ids) != 0 {
 		t.Fatalf("publishing old score ids=%q truncated=%v want none false", ids, truncated)
 	}
-	publishAttempted = true
 	if err := col.publishPreparedIndexedFlush(work); err != nil {
 		t.Fatalf("publish prepared async flush: %v", err)
 	}

--- a/TreeDB/collections/changed_unique_pending_test.go
+++ b/TreeDB/collections/changed_unique_pending_test.go
@@ -1,0 +1,111 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionUpdateChangedUniqueFlushesPendingReservationsBeforeConflict(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		queue    bool
+		wantUnit int
+	}{
+		{name: "mutable", queue: false, wantUnit: 0},
+		{name: "queued", queue: true, wantUnit: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+			if err != nil {
+				t.Fatalf("open db: %v", err)
+			}
+			defer func() { _ = d.Close() }()
+
+			mgr := NewCollectionManager(d)
+			if _, err := mgr.CreateCollection(&CollectionMeta{
+				Name: "users",
+				Options: CollectionOptions{
+					BufferedIndexedWrites: true,
+				},
+				Indexes: []IndexDefinition{
+					{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+				},
+			}); err != nil {
+				t.Fatalf("create collection: %v", err)
+			}
+			col, err := mgr.OpenCollection("users")
+			if err != nil {
+				t.Fatalf("open collection: %v", err)
+			}
+			if _, err := col.InsertBatch(
+				[][]byte{[]byte("u1")},
+				[][]byte{[]byte(`{"email":"old@example.com"}`)},
+			); err != nil {
+				t.Fatalf("insert durable document: %v", err)
+			}
+			if err := col.Flush(); err != nil {
+				t.Fatalf("flush durable document: %v", err)
+			}
+			if _, err := col.InsertBatch(
+				[][]byte{[]byte("u2")},
+				[][]byte{[]byte(`{"email":"pending@example.com"}`)},
+			); err != nil {
+				t.Fatalf("insert pending unique document: %v", err)
+			}
+			if tc.queue {
+				col.writeDomain.mu.Lock()
+				if !rotateIndexedMutableToFlushUnitLocked(col.writeDomain) {
+					col.writeDomain.mu.Unlock()
+					t.Fatal("rotate indexed mutable state returned false")
+				}
+				col.writeDomain.mu.Unlock()
+			}
+			stats := mgr.StatsSnapshot()
+			if got := stats.PendingDocuments; got != 1 {
+				t.Fatalf("pending documents before update=%d want 1", got)
+			}
+			if got := stats.PendingIndexedFlushUnits; got != tc.wantUnit {
+				t.Fatalf("pending indexed flush units before update=%d want %d", got, tc.wantUnit)
+			}
+
+			matched, modified, err := col.Update([]byte("u1"), setJSONEmail("pending@example.com"))
+			if !errors.Is(err, ErrUniqueIndexConflict) {
+				t.Fatalf("Update err=%v want ErrUniqueIndexConflict", err)
+			}
+			if matched || modified {
+				t.Fatalf("Update matched/modified=%v/%v want false/false on rejected unique change", matched, modified)
+			}
+			stats = mgr.StatsSnapshot()
+			if got := stats.PendingDocuments; got != 0 {
+				t.Fatalf("pending documents after rejected update=%d want 0 after forced drain", got)
+			}
+			if got := stats.PendingIndexedFlushUnits; got != 0 {
+				t.Fatalf("pending indexed flush units after rejected update=%d want 0 after forced drain", got)
+			}
+			got, err := col.Get([]byte("u1"))
+			if err != nil {
+				t.Fatalf("get u1: %v", err)
+			}
+			if !bytes.Equal(got, []byte(`{"email":"old@example.com"}`)) {
+				t.Fatalf("u1 after rejected update=%q want old email", got)
+			}
+			got, err = col.Get([]byte("u2"))
+			if err != nil {
+				t.Fatalf("get u2: %v", err)
+			}
+			if !bytes.Equal(got, []byte(`{"email":"pending@example.com"}`)) {
+				t.Fatalf("u2 after forced drain=%q want pending email", got)
+			}
+			ids, err := col.FindByIndexValue("email", "pending@example.com")
+			if err != nil {
+				t.Fatalf("find pending email: %v", err)
+			}
+			if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
+				t.Fatalf("pending email ids=%q want [u2]", ids)
+			}
+		})
+	}
+}

--- a/TreeDB/collections/checkpoint_boundary_test.go
+++ b/TreeDB/collections/checkpoint_boundary_test.go
@@ -1,0 +1,85 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionCheckpointDoesNotFlushPendingNoIndexInsert(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"ada"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	beforeRoot := collectionCheckpointBoundaryPrimaryRootIDForTest(t, d, "users")
+	if got := collectionCheckpointBoundaryPendingCountForTest(t, col); got != 1 {
+		t.Fatalf("pending count before checkpoint=%d want 1", got)
+	}
+
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	afterCheckpointRoot := collectionCheckpointBoundaryPrimaryRootIDForTest(t, d, "users")
+	if afterCheckpointRoot != beforeRoot {
+		t.Fatalf("checkpoint changed primary root from %d to %d for pending collection-local insert", beforeRoot, afterCheckpointRoot)
+	}
+	if got := collectionCheckpointBoundaryPendingCountForTest(t, col); got != 1 {
+		t.Fatalf("pending count after checkpoint=%d want 1", got)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get pending document after checkpoint: %v", err)
+	}
+	if want := []byte(`{"name":"ada"}`); !bytes.Equal(got, want) {
+		t.Fatalf("pending document after checkpoint=%q want %q", got, want)
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	afterFlushRoot := collectionCheckpointBoundaryPrimaryRootIDForTest(t, d, "users")
+	if afterFlushRoot == beforeRoot {
+		t.Fatalf("flush left primary root at %d, want published root descriptor", afterFlushRoot)
+	}
+	if got := collectionCheckpointBoundaryPendingCountForTest(t, col); got != 0 {
+		t.Fatalf("pending count after flush=%d want 0", got)
+	}
+}
+
+func collectionCheckpointBoundaryPrimaryRootIDForTest(t *testing.T, d *backenddb.DB, collectionName string) uint64 {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, collectionName)
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatal("missing catalog")
+	}
+	return catalog.rootID(collectionPrimaryRootName(collectionName))
+}
+
+func collectionCheckpointBoundaryPendingCountForTest(t *testing.T, col *Collection) int {
+	t.Helper()
+	col.writeDomain.mu.RLock()
+	defer col.writeDomain.mu.RUnlock()
+	return col.writeDomain.count
+}

--- a/TreeDB/collections/close_indexed_flush_test.go
+++ b/TreeDB/collections/close_indexed_flush_test.go
@@ -1,0 +1,76 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionManagerCloseDrainsQueuedIndexedFlushUnit(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert buffered indexed batch: %v", err)
+	}
+
+	col.writeDomain.mu.Lock()
+	if !rotateIndexedMutableToFlushUnitLocked(col.writeDomain) {
+		col.writeDomain.mu.Unlock()
+		t.Fatal("rotate indexed mutable state returned false")
+	}
+	col.writeDomain.mu.Unlock()
+	if got := mgr.StatsSnapshot().PendingIndexedFlushUnits; got != 1 {
+		t.Fatalf("pending indexed flush units before Close=%d want 1", got)
+	}
+	ids, err := col.FindByIndexValue("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find pending email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("pending email ids=%q want [u1]", ids)
+	}
+
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err = reopenedCol.FindByIndexValue("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find reopened email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("reopened email ids=%q want [u1]", ids)
+	}
+}

--- a/TreeDB/collections/close_indexed_publish_test.go
+++ b/TreeDB/collections/close_indexed_publish_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 	"time"
 
@@ -50,18 +51,32 @@ func TestCollectionManagerCloseWaitsForActiveIndexedPublish(t *testing.T) {
 		t.Fatal("begin indexed async flush returned false")
 	}
 
+	waitEntered := make(chan struct{})
+	allowWait := make(chan struct{})
+	var waitEnteredOnce sync.Once
+	restoreWaitHook := setCollectionWaitIndexedAsyncFlushHookForTest(func() {
+		waitEnteredOnce.Do(func() {
+			close(waitEntered)
+			<-allowWait
+		})
+	})
+	defer restoreWaitHook()
+
 	closeDone := make(chan error, 1)
-	closeStarted := make(chan struct{})
 	go func() {
-		close(closeStarted)
 		closeDone <- d.Close()
 	}()
-	<-closeStarted
+	select {
+	case <-waitEntered:
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out waiting for Close to reach indexed async flush drain")
+	}
 	select {
 	case err := <-closeDone:
 		t.Fatalf("Close returned before active indexed publish finished: %v", err)
-	case <-time.After(collectionTestTimeout(t, 100*time.Millisecond)):
+	default:
 	}
+	close(allowWait)
 
 	publishErr := col.publishPreparedIndexedFlush(work)
 	col.writeDomain.finishIndexedAsyncFlush(publishErr)

--- a/TreeDB/collections/close_indexed_publish_test.go
+++ b/TreeDB/collections/close_indexed_publish_test.go
@@ -45,6 +45,7 @@ func TestCollectionManagerCloseWaitsForActiveIndexedPublish(t *testing.T) {
 	if work == nil {
 		t.Fatal("prepare indexed async publish returned nil work")
 	}
+	defer collectionTestCloseIndexedFlushWork(work)
 	if !col.writeDomain.beginIndexedAsyncFlush() {
 		t.Fatal("begin indexed async flush returned false")
 	}

--- a/TreeDB/collections/close_indexed_publish_test.go
+++ b/TreeDB/collections/close_indexed_publish_test.go
@@ -54,6 +54,13 @@ func TestCollectionManagerCloseWaitsForActiveIndexedPublish(t *testing.T) {
 	waitEntered := make(chan struct{})
 	allowWait := make(chan struct{})
 	var waitEnteredOnce sync.Once
+	var allowWaitOnce sync.Once
+	releaseWait := func() {
+		allowWaitOnce.Do(func() {
+			close(allowWait)
+		})
+	}
+	defer releaseWait()
 	restoreWaitHook := setCollectionWaitIndexedAsyncFlushHookForTest(func() {
 		waitEnteredOnce.Do(func() {
 			close(waitEntered)
@@ -76,7 +83,7 @@ func TestCollectionManagerCloseWaitsForActiveIndexedPublish(t *testing.T) {
 		t.Fatalf("Close returned before active indexed publish finished: %v", err)
 	default:
 	}
-	close(allowWait)
+	releaseWait()
 
 	publishErr := col.publishPreparedIndexedFlush(work)
 	col.writeDomain.finishIndexedAsyncFlush(publishErr)

--- a/TreeDB/collections/close_indexed_publish_test.go
+++ b/TreeDB/collections/close_indexed_publish_test.go
@@ -51,13 +51,16 @@ func TestCollectionManagerCloseWaitsForActiveIndexedPublish(t *testing.T) {
 	}
 
 	closeDone := make(chan error, 1)
+	closeStarted := make(chan struct{})
 	go func() {
+		close(closeStarted)
 		closeDone <- d.Close()
 	}()
+	<-closeStarted
 	select {
 	case err := <-closeDone:
 		t.Fatalf("Close returned before active indexed publish finished: %v", err)
-	default:
+	case <-time.After(collectionTestTimeout(t, 100*time.Millisecond)):
 	}
 
 	publishErr := col.publishPreparedIndexedFlush(work)

--- a/TreeDB/collections/close_indexed_publish_test.go
+++ b/TreeDB/collections/close_indexed_publish_test.go
@@ -1,0 +1,92 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionManagerCloseWaitsForActiveIndexedPublish(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:     true,
+			BufferedIndexedAsyncFlush: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert buffered indexed batch: %v", err)
+	}
+
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare indexed async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare indexed async publish returned nil work")
+	}
+	if !col.writeDomain.beginIndexedAsyncFlush() {
+		t.Fatal("begin indexed async flush returned false")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- d.Close()
+	}()
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before active indexed publish finished: %v", err)
+	default:
+	}
+
+	publishErr := col.publishPreparedIndexedFlush(work)
+	col.writeDomain.finishIndexedAsyncFlush(publishErr)
+	if publishErr != nil {
+		t.Fatalf("publish prepared indexed flush: %v", publishErr)
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("close db: %v", err)
+		}
+	case <-time.After(collectionTestTimeout(t, 5*time.Second)):
+		t.Fatal("timed out waiting for close after active indexed publish finished")
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err := reopenedCol.FindByIndexValue("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find reopened email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("reopened email ids=%q want [u1]", ids)
+	}
+}

--- a/TreeDB/collections/flushall_indexed_flush_test.go
+++ b/TreeDB/collections/flushall_indexed_flush_test.go
@@ -13,6 +13,12 @@ func TestCollectionManagerFlushAllDrainsQueuedIndexedFlushUnit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = d.Close()
+		}
+	}()
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{
 		Name: "users",
@@ -66,6 +72,7 @@ func TestCollectionManagerFlushAllDrainsQueuedIndexedFlushUnit(t *testing.T) {
 	if err := d.Close(); err != nil {
 		t.Fatalf("close db: %v", err)
 	}
+	closed = true
 
 	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
 	if err != nil {

--- a/TreeDB/collections/flushall_indexed_flush_test.go
+++ b/TreeDB/collections/flushall_indexed_flush_test.go
@@ -1,0 +1,86 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionManagerFlushAllDrainsQueuedIndexedFlushUnit(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert buffered indexed batch: %v", err)
+	}
+
+	col.writeDomain.mu.Lock()
+	if !rotateIndexedMutableToFlushUnitLocked(col.writeDomain) {
+		col.writeDomain.mu.Unlock()
+		t.Fatal("rotate indexed mutable state returned false")
+	}
+	col.writeDomain.mu.Unlock()
+	if got := mgr.StatsSnapshot().PendingIndexedFlushUnits; got != 1 {
+		t.Fatalf("pending indexed flush units before FlushAll=%d want 1", got)
+	}
+
+	if err := mgr.FlushAll(); err != nil {
+		t.Fatalf("FlushAll: %v", err)
+	}
+	stats := mgr.StatsSnapshot()
+	if got := stats.PendingIndexedFlushUnits; got != 0 {
+		t.Fatalf("pending indexed flush units after FlushAll=%d want 0", got)
+	}
+	if got := stats.PendingDocuments; got != 0 {
+		t.Fatalf("pending documents after FlushAll=%d want 0", got)
+	}
+	ids, err := col.FindByIndexValue("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find flushed email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("flushed email ids=%q want [u1]", ids)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	ids, err = reopenedCol.FindByIndexValue("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find reopened email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("reopened email ids=%q want [u1]", ids)
+	}
+}

--- a/TreeDB/collections/indexed_flush_guard_counters_test.go
+++ b/TreeDB/collections/indexed_flush_guard_counters_test.go
@@ -41,7 +41,7 @@ func TestCollectionIndexedFlushGuardCounters(t *testing.T) {
 		if got := stats.IndexedFlushRequeuedUnits; got != 1 {
 			t.Fatalf("indexed flush requeued units=%d want 1", got)
 		}
-		if got := mgr.Stats()["treedb.collections.write_domain.indexed_flush.requeue_total"]; got != "1" {
+		if got := mgr.Stats()["treedb.collections.write_domain.indexed_flush.requeues_total"]; got != "1" {
 			t.Fatalf("requeue stat=%q want 1", got)
 		}
 	})

--- a/TreeDB/collections/indexed_flush_guard_counters_test.go
+++ b/TreeDB/collections/indexed_flush_guard_counters_test.go
@@ -2,7 +2,6 @@ package collections
 
 import (
 	"errors"
-	"strings"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -77,7 +76,7 @@ func TestCollectionIndexedFlushGuardCounters(t *testing.T) {
 			rootIDs[i] = uint64(1000 + i)
 		}
 		err = col.completePreparedIndexedFlush(work, 999, rootIDs, nil, 0, 0, 0)
-		if err == nil || !strings.Contains(err.Error(), "lost ownership") {
+		if !errors.Is(err, errIndexedFlushLostOwnership) {
 			t.Fatalf("complete err=%v want lost ownership", err)
 		}
 		stats := mgr.StatsSnapshot()

--- a/TreeDB/collections/indexed_flush_guard_counters_test.go
+++ b/TreeDB/collections/indexed_flush_guard_counters_test.go
@@ -1,0 +1,164 @@
+package collections
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionIndexedFlushGuardCounters(t *testing.T) {
+	t.Run("publish_error_requeue", func(t *testing.T) {
+		d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		mgr, col := collectionTestIndexedFlushCounterCollection(t, d)
+		if _, err := col.InsertBatch(
+			[][]byte{[]byte("u1")},
+			[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+		); err != nil {
+			t.Fatalf("insert buffered batch: %v", err)
+		}
+		work, err := col.prepareIndexedAsyncPublish()
+		if err != nil {
+			t.Fatalf("prepare async publish: %v", err)
+		}
+		if work == nil {
+			t.Fatal("prepare async publish returned nil work")
+		}
+		defer collectionTestCloseIndexedFlushWork(work)
+
+		injectedErr := errors.New("injected publish failure")
+		if err := col.completePreparedIndexedFlush(work, 0, nil, injectedErr, 0, 0, 0); !errors.Is(err, injectedErr) {
+			t.Fatalf("complete failure err=%v want injected error", err)
+		}
+		stats := mgr.StatsSnapshot()
+		if got := stats.IndexedFlushRequeues; got != 1 {
+			t.Fatalf("indexed flush requeues=%d want 1", got)
+		}
+		if got := stats.IndexedFlushRequeuedUnits; got != 1 {
+			t.Fatalf("indexed flush requeued units=%d want 1", got)
+		}
+		if got := mgr.Stats()["treedb.collections.write_domain.indexed_flush.requeue_total"]; got != "1" {
+			t.Fatalf("requeue stat=%q want 1", got)
+		}
+	})
+
+	t.Run("lost_ownership", func(t *testing.T) {
+		d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		mgr, col := collectionTestIndexedFlushCounterCollection(t, d)
+		if _, err := col.InsertBatch(
+			[][]byte{[]byte("u1")},
+			[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+		); err != nil {
+			t.Fatalf("insert buffered batch: %v", err)
+		}
+		work, err := col.prepareIndexedAsyncPublish()
+		if err != nil {
+			t.Fatalf("prepare async publish: %v", err)
+		}
+		if work == nil {
+			t.Fatal("prepare async publish returned nil work")
+		}
+		defer collectionTestCloseIndexedFlushWork(work)
+
+		col.writeDomain.mu.Lock()
+		col.writeDomain.indexedPublishingUnits = []indexedFlushUnit{{}}
+		col.writeDomain.mu.Unlock()
+		rootIDs := make([]uint64, len(work.rootNames))
+		for i := range rootIDs {
+			rootIDs[i] = uint64(1000 + i)
+		}
+		err = col.completePreparedIndexedFlush(work, 999, rootIDs, nil, 0, 0, 0)
+		if err == nil || !strings.Contains(err.Error(), "lost ownership") {
+			t.Fatalf("complete err=%v want lost ownership", err)
+		}
+		stats := mgr.StatsSnapshot()
+		if got := stats.IndexedFlushLostOwnership; got != 1 {
+			t.Fatalf("indexed flush lost ownership=%d want 1", got)
+		}
+		if got := mgr.Stats()["treedb.collections.write_domain.indexed_flush.lost_ownership_total"]; got != "1" {
+			t.Fatalf("lost ownership stat=%q want 1", got)
+		}
+	})
+
+	t.Run("root_base_mismatch", func(t *testing.T) {
+		d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		leftMgr, left := collectionTestIndexedFlushCounterCollection(t, d)
+		if _, err := left.InsertBatch(
+			[][]byte{[]byte("u1")},
+			[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+		); err != nil {
+			t.Fatalf("stage left pending insert: %v", err)
+		}
+
+		right, err := NewCollectionManager(d).OpenCollection("users")
+		if err != nil {
+			t.Fatalf("open right collection: %v", err)
+		}
+		if _, err := right.InsertBatch(
+			[][]byte{[]byte("u2")},
+			[][]byte{[]byte(`{"email":"grace@example.com"}`)},
+		); err != nil {
+			t.Fatalf("insert right durable row: %v", err)
+		}
+		if err := right.Flush(); err != nil {
+			t.Fatalf("flush right row: %v", err)
+		}
+
+		work, err := left.prepareIndexedAsyncPublish()
+		if work != nil {
+			collectionTestCloseIndexedFlushWork(work)
+			t.Fatal("prepare returned work despite root-base mismatch")
+		}
+		if !errors.Is(err, ErrConcurrentMutation) {
+			t.Fatalf("prepare err=%v want ErrConcurrentMutation", err)
+		}
+		stats := leftMgr.StatsSnapshot()
+		if got := stats.IndexedFlushRootBaseMismatches; got != 1 {
+			t.Fatalf("indexed flush root-base mismatches=%d want 1", got)
+		}
+		if got := leftMgr.Stats()["treedb.collections.write_domain.indexed_flush.root_base_mismatch_total"]; got != "1" {
+			t.Fatalf("root-base mismatch stat=%q want 1", got)
+		}
+	})
+}
+
+func collectionTestIndexedFlushCounterCollection(tb testing.TB, d *backenddb.DB) (*CollectionManager, *Collection) {
+	tb.Helper()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		tb.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		tb.Fatalf("open collection: %v", err)
+	}
+	return mgr, col
+}
+
+func collectionTestCloseIndexedFlushWork(work *indexedFlushPublishWork) {
+	if work != nil && work.pin != nil {
+		_ = work.pin.Close()
+		work.pin = nil
+	}
+}

--- a/TreeDB/collections/indexed_flush_guard_counters_test.go
+++ b/TreeDB/collections/indexed_flush_guard_counters_test.go
@@ -46,6 +46,63 @@ func TestCollectionIndexedFlushGuardCounters(t *testing.T) {
 		}
 	})
 
+	t.Run("publish_error_lost_ownership", func(t *testing.T) {
+		d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = d.Close() }()
+		mgr, col := collectionTestIndexedFlushCounterCollection(t, d)
+		if _, err := col.InsertBatch(
+			[][]byte{[]byte("u1")},
+			[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+		); err != nil {
+			t.Fatalf("insert buffered batch: %v", err)
+		}
+		work, err := col.prepareIndexedAsyncPublish()
+		if err != nil {
+			t.Fatalf("prepare async publish: %v", err)
+		}
+		if work == nil {
+			t.Fatal("prepare async publish returned nil work")
+		}
+		defer collectionTestCloseIndexedFlushWork(work)
+
+		col.writeDomain.mu.Lock()
+		currentPublishing := indexedFlushUnit{}
+		col.writeDomain.indexedPublishingUnits = []indexedFlushUnit{currentPublishing}
+		col.writeDomain.mu.Unlock()
+
+		injectedErr := errors.New("injected publish failure")
+		err = col.completePreparedIndexedFlush(work, 0, nil, injectedErr, 0, 0, 0)
+		if !errors.Is(err, errIndexedFlushLostOwnership) {
+			t.Fatalf("complete failure err=%v want lost ownership", err)
+		}
+		if !errors.Is(err, injectedErr) {
+			t.Fatalf("complete failure err=%v want injected error", err)
+		}
+		col.writeDomain.mu.RLock()
+		publishingUnits := append([]indexedFlushUnit(nil), col.writeDomain.indexedPublishingUnits...)
+		queuedUnits := len(col.writeDomain.indexedFlushUnits)
+		col.writeDomain.mu.RUnlock()
+		if len(publishingUnits) != 1 || !sameIndexedFlushUnitTables(publishingUnits[0], currentPublishing) {
+			t.Fatalf("publishing units after lost ownership publish error=%+v want current unit retained", publishingUnits)
+		}
+		if queuedUnits != 0 {
+			t.Fatalf("queued units after lost ownership publish error=%d want 0", queuedUnits)
+		}
+		stats := mgr.StatsSnapshot()
+		if got := stats.IndexedFlushLostOwnership; got != 1 {
+			t.Fatalf("indexed flush lost ownership=%d want 1", got)
+		}
+		if got := stats.IndexedFlushRequeues; got != 0 {
+			t.Fatalf("indexed flush requeues=%d want 0", got)
+		}
+		if got := mgr.Stats()["treedb.collections.write_domain.indexed_flush.lost_ownership_total"]; got != "1" {
+			t.Fatalf("lost ownership stat=%q want 1", got)
+		}
+	})
+
 	t.Run("lost_ownership", func(t *testing.T) {
 		d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 		if err != nil {

--- a/TreeDB/collections/indexed_flush_ownership_test.go
+++ b/TreeDB/collections/indexed_flush_ownership_test.go
@@ -1,7 +1,7 @@
 package collections
 
 import (
-	"strings"
+	"errors"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -56,7 +56,7 @@ func TestCollectionIndexedAsyncPublishLostOwnershipDoesNotRemoveCurrentPublishin
 		rootIDs[i] = uint64(1000 + i)
 	}
 	err = col.completePreparedIndexedFlush(work, 999, rootIDs, nil, 0, 0, 0)
-	if err == nil || !strings.Contains(err.Error(), "lost ownership") {
+	if !errors.Is(err, errIndexedFlushLostOwnership) {
 		t.Fatalf("complete lost ownership err=%v want lost ownership", err)
 	}
 

--- a/TreeDB/collections/indexed_flush_ownership_test.go
+++ b/TreeDB/collections/indexed_flush_ownership_test.go
@@ -1,0 +1,76 @@
+package collections
+
+import (
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionIndexedAsyncPublishLostOwnershipDoesNotRemoveCurrentPublishingUnit(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert buffered batch: %v", err)
+	}
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	if work.pin != nil {
+		defer func() { _ = work.pin.Close() }()
+	}
+
+	col.writeDomain.mu.Lock()
+	col.writeDomain.indexedPublishingUnits = []indexedFlushUnit{{}}
+	col.writeDomain.mu.Unlock()
+
+	rootIDs := make([]uint64, len(work.rootNames))
+	for i := range rootIDs {
+		rootIDs[i] = uint64(1000 + i)
+	}
+	err = col.completePreparedIndexedFlush(work, 999, rootIDs, nil, 0, 0, 0)
+	if err == nil || !strings.Contains(err.Error(), "lost ownership") {
+		t.Fatalf("complete lost ownership err=%v want lost ownership", err)
+	}
+
+	col.writeDomain.mu.RLock()
+	publishingUnits := append([]indexedFlushUnit(nil), col.writeDomain.indexedPublishingUnits...)
+	col.writeDomain.mu.RUnlock()
+	if len(publishingUnits) != 1 || !sameIndexedFlushUnitTables(publishingUnits[0], indexedFlushUnit{}) {
+		t.Fatalf("publishing units after lost ownership=%+v want original current unit retained", publishingUnits)
+	}
+	stats := mgr.StatsSnapshot()
+	if got := stats.IndexedFlushErrors; got != 1 {
+		t.Fatalf("indexed flush errors=%d want 1", got)
+	}
+	if got := stats.IndexedFlushCalls; got != 1 {
+		t.Fatalf("indexed flush calls=%d want 1", got)
+	}
+}

--- a/TreeDB/collections/indexed_flush_ownership_test.go
+++ b/TreeDB/collections/indexed_flush_ownership_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
@@ -46,10 +47,30 @@ func TestCollectionIndexedAsyncPublishLostOwnershipDoesNotRemoveCurrentPublishin
 	if work.pin != nil {
 		defer func() { _ = work.pin.Close() }()
 	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"email":"grace@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert replacement publishing batch: %v", err)
+	}
 
 	col.writeDomain.mu.Lock()
-	col.writeDomain.indexedPublishingUnits = []indexedFlushUnit{{}}
+	rotateIndexedMutableToFlushUnitLocked(col.writeDomain)
+	if len(col.writeDomain.indexedFlushUnits) != 1 {
+		t.Fatalf("replacement queued units=%d want 1", len(col.writeDomain.indexedFlushUnits))
+	}
+	currentPublishing := col.writeDomain.indexedFlushUnits[0]
+	col.writeDomain.indexedPublishingUnits = []indexedFlushUnit{currentPublishing}
+	col.writeDomain.indexedFlushUnits = nil
+	rebuildBufferedPendingIndexesLocked(col.writeDomain, "users", true)
 	col.writeDomain.mu.Unlock()
+	t.Cleanup(func() {
+		col.writeDomain.mu.Lock()
+		publishingUnits := col.writeDomain.indexedPublishingUnits
+		col.writeDomain.indexedPublishingUnits = nil
+		col.writeDomain.mu.Unlock()
+		resetIndexedFlushUnits(publishingUnits)
+	})
 
 	rootIDs := make([]uint64, len(work.rootNames))
 	for i := range rootIDs {
@@ -63,8 +84,28 @@ func TestCollectionIndexedAsyncPublishLostOwnershipDoesNotRemoveCurrentPublishin
 	col.writeDomain.mu.RLock()
 	publishingUnits := append([]indexedFlushUnit(nil), col.writeDomain.indexedPublishingUnits...)
 	col.writeDomain.mu.RUnlock()
-	if len(publishingUnits) != 1 || !sameIndexedFlushUnitTables(publishingUnits[0], indexedFlushUnit{}) {
+	if len(publishingUnits) != 1 || !sameIndexedFlushUnitTables(publishingUnits[0], currentPublishing) {
 		t.Fatalf("publishing units after lost ownership=%+v want original current unit retained", publishingUnits)
+	}
+	got, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get retained publishing document: %v", err)
+	}
+	if want := []byte(`{"email":"grace@example.com"}`); !bytes.Equal(got, want) {
+		t.Fatalf("retained publishing document=%q want %q", got, want)
+	}
+	ids, err := col.FindByIndexValue("email", "grace@example.com")
+	if err != nil {
+		t.Fatalf("find retained publishing email: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u2")) {
+		t.Fatalf("retained publishing email ids=%q want [u2]", ids)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u3")},
+		[][]byte{[]byte(`{"email":"grace@example.com"}`)},
+	); !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("duplicate retained publishing unique insert err=%v want ErrUniqueIndexConflict", err)
 	}
 	stats := mgr.StatsSnapshot()
 	if got := stats.IndexedFlushErrors; got != 1 {
@@ -72,5 +113,8 @@ func TestCollectionIndexedAsyncPublishLostOwnershipDoesNotRemoveCurrentPublishin
 	}
 	if got := stats.IndexedFlushCalls; got != 1 {
 		t.Fatalf("indexed flush calls=%d want 1", got)
+	}
+	if got := stats.IndexedFlushLostOwnership; got != 1 {
+		t.Fatalf("indexed flush lost ownership=%d want 1", got)
 	}
 }

--- a/TreeDB/collections/indexed_flush_requeue_test.go
+++ b/TreeDB/collections/indexed_flush_requeue_test.go
@@ -1,0 +1,162 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionIndexedAsyncPublishFailureRequeuesUnitsAndPreservesUniqueReservations(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"a@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert first buffered batch: %v", err)
+	}
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	if work.pin != nil {
+		defer func() { _ = work.pin.Close() }()
+	}
+
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"email":"b@example.com","city":"sea"}`)},
+	); err != nil {
+		t.Fatalf("insert second buffered batch while first publishes: %v", err)
+	}
+	col.writeDomain.mu.Lock()
+	if !rotateIndexedMutableToFlushUnitLocked(col.writeDomain) {
+		col.writeDomain.mu.Unlock()
+		t.Fatal("rotate second buffered batch returned false")
+	}
+	if got := len(col.writeDomain.indexedPublishingUnits); got != 1 {
+		col.writeDomain.mu.Unlock()
+		t.Fatalf("publishing units before failure=%d want 1", got)
+	}
+	if got := len(col.writeDomain.indexedFlushUnits); got != 1 {
+		col.writeDomain.mu.Unlock()
+		t.Fatalf("queued units before failure=%d want 1", got)
+	}
+	col.writeDomain.mu.Unlock()
+
+	prefixA := indexedFlushRequeueEmailPrefix(t, "a@example.com")
+	prefixB := indexedFlushRequeueEmailPrefix(t, "b@example.com")
+	injectedErr := errors.New("injected publish failure")
+	if err := col.completePreparedIndexedFlush(work, 0, nil, injectedErr, 0, 0, 0); !errors.Is(err, injectedErr) {
+		t.Fatalf("complete failure err=%v want injected publish failure", err)
+	}
+	if work.pin != nil {
+		_ = work.pin.Close()
+		work.pin = nil
+	}
+
+	col.writeDomain.mu.RLock()
+	publishingUnits := len(col.writeDomain.indexedPublishingUnits)
+	queuedUnits := append([]indexedFlushUnit(nil), col.writeDomain.indexedFlushUnits...)
+	pending := col.writeDomain.uniqueValueIndex["email"]
+	containsA := pending != nil && pending.contains(prefixA)
+	containsB := pending != nil && pending.contains(prefixB)
+	col.writeDomain.mu.RUnlock()
+	if publishingUnits != 0 {
+		t.Fatalf("publishing units after failure=%d want 0", publishingUnits)
+	}
+	if got, want := len(queuedUnits), 2; got != want {
+		t.Fatalf("queued units after failure=%d want %d", got, want)
+	}
+	if !indexedFlushRequeueUnitHasUniquePrefix(queuedUnits[0], "email", prefixA) {
+		t.Fatal("first requeued unit does not contain original active unique reservation")
+	}
+	if !indexedFlushRequeueUnitHasUniquePrefix(queuedUnits[1], "email", prefixB) {
+		t.Fatal("second queued unit does not contain later queued unique reservation")
+	}
+	if !containsA || !containsB {
+		t.Fatalf("pending unique reservations after failure contain a=%v b=%v want true/true", containsA, containsB)
+	}
+
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("dupe")},
+		[][]byte{[]byte(`{"email":"a@example.com","city":"duplicate"}`)},
+	); !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("duplicate active/requeued email err=%v want ErrUniqueIndexConflict", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("dupe2")},
+		[][]byte{[]byte(`{"email":"b@example.com","city":"duplicate"}`)},
+	); !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("duplicate queued email err=%v want ErrUniqueIndexConflict", err)
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush requeued units: %v", err)
+	}
+	indexedFlushRequeueRequireIndexIDs(t, col, "email", "a@example.com", "u1")
+	indexedFlushRequeueRequireIndexIDs(t, col, "email", "b@example.com", "u2")
+}
+
+func indexedFlushRequeueEmailPrefix(tb testing.TB, email string) []byte {
+	tb.Helper()
+	encoded, err := encodeIndexScalar(IndexValueString, email)
+	if err != nil {
+		tb.Fatalf("encode email %q: %v", email, err)
+	}
+	_, prefix, err := appendIndexValuePrefixSlice(nil, encoded)
+	if err != nil {
+		tb.Fatalf("email prefix %q: %v", email, err)
+	}
+	return prefix
+}
+
+func indexedFlushRequeueUnitHasUniquePrefix(unit indexedFlushUnit, indexName string, prefix []byte) bool {
+	pending := rebuildBufferedUniqueValueIndexes(unit.uniqueValueRuns)[indexName]
+	return pending != nil && pending.contains(prefix)
+}
+
+func indexedFlushRequeueRequireIndexIDs(tb testing.TB, col *Collection, indexName string, value any, want ...string) {
+	tb.Helper()
+	ids, err := col.FindByIndexValue(indexName, value)
+	if err != nil {
+		tb.Fatalf("find index %s=%v: %v", indexName, value, err)
+	}
+	if len(ids) != len(want) {
+		tb.Fatalf("index %s=%v ids=%q want %q", indexName, value, ids, want)
+	}
+	for i := range want {
+		if !bytes.Equal(ids[i], []byte(want[i])) {
+			tb.Fatalf("index %s=%v ids=%q want %q", indexName, value, ids, want)
+		}
+	}
+}

--- a/TreeDB/collections/indexed_flush_requeue_test.go
+++ b/TreeDB/collections/indexed_flush_requeue_test.go
@@ -48,9 +48,7 @@ func TestCollectionIndexedAsyncPublishFailureRequeuesUnitsAndPreservesUniqueRese
 	if work == nil {
 		t.Fatal("prepare async publish returned nil work")
 	}
-	if work.pin != nil {
-		defer func() { _ = work.pin.Close() }()
-	}
+	defer collectionTestCloseIndexedFlushWork(work)
 
 	if _, err := col.InsertBatch(
 		[][]byte{[]byte("u2")},
@@ -78,10 +76,6 @@ func TestCollectionIndexedAsyncPublishFailureRequeuesUnitsAndPreservesUniqueRese
 	injectedErr := errors.New("injected publish failure")
 	if err := col.completePreparedIndexedFlush(work, 0, nil, injectedErr, 0, 0, 0); !errors.Is(err, injectedErr) {
 		t.Fatalf("complete failure err=%v want injected publish failure", err)
-	}
-	if work.pin != nil {
-		_ = work.pin.Close()
-		work.pin = nil
 	}
 
 	col.writeDomain.mu.RLock()

--- a/TreeDB/collections/indexed_flush_root_mismatch_test.go
+++ b/TreeDB/collections/indexed_flush_root_mismatch_test.go
@@ -78,3 +78,116 @@ func TestCollectionIndexedAsyncPrepareRejectsRootBaseMismatchAndPreservesPending
 		t.Fatalf("pending email ids=%q want [u1]", ids)
 	}
 }
+
+func TestCollectionIndexedAsyncPublishRootBaseMismatchRequeuesFIFOAndCounts(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	leftMgr := NewCollectionManager(d)
+	if _, err := leftMgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	left, err := leftMgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open left collection: %v", err)
+	}
+	if _, err := left.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"a@example.com"}`)},
+	); err != nil {
+		t.Fatalf("stage left active pending insert: %v", err)
+	}
+	work, err := left.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare left async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare left async publish returned nil work")
+	}
+	defer collectionTestCloseIndexedFlushWork(work)
+
+	if _, err := left.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"email":"b@example.com"}`)},
+	); err != nil {
+		t.Fatalf("stage later queued insert: %v", err)
+	}
+	left.writeDomain.mu.Lock()
+	if !rotateIndexedMutableToFlushUnitLocked(left.writeDomain) {
+		left.writeDomain.mu.Unlock()
+		t.Fatal("rotate later queued insert returned false")
+	}
+	if got := len(left.writeDomain.indexedPublishingUnits); got != 1 {
+		left.writeDomain.mu.Unlock()
+		t.Fatalf("publishing units before mismatch=%d want 1", got)
+	}
+	if got := len(left.writeDomain.indexedFlushUnits); got != 1 {
+		left.writeDomain.mu.Unlock()
+		t.Fatalf("queued units before mismatch=%d want 1", got)
+	}
+	left.writeDomain.mu.Unlock()
+
+	right, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open right collection: %v", err)
+	}
+	if _, err := right.InsertBatch(
+		[][]byte{[]byte("u3")},
+		[][]byte{[]byte(`{"email":"c@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert right durable row: %v", err)
+	}
+	if err := right.Flush(); err != nil {
+		t.Fatalf("flush right row: %v", err)
+	}
+
+	if err := left.publishPreparedIndexedFlush(work); !errors.Is(err, ErrConcurrentMutation) {
+		t.Fatalf("publish prepared left err=%v want ErrConcurrentMutation", err)
+	}
+
+	prefixA := indexedFlushRequeueEmailPrefix(t, "a@example.com")
+	prefixB := indexedFlushRequeueEmailPrefix(t, "b@example.com")
+	left.writeDomain.mu.RLock()
+	publishingUnits := len(left.writeDomain.indexedPublishingUnits)
+	queuedUnits := append([]indexedFlushUnit(nil), left.writeDomain.indexedFlushUnits...)
+	pending := left.writeDomain.uniqueValueIndex["email"]
+	containsA := pending != nil && pending.contains(prefixA)
+	containsB := pending != nil && pending.contains(prefixB)
+	left.writeDomain.mu.RUnlock()
+	if publishingUnits != 0 {
+		t.Fatalf("publishing units after mismatch=%d want 0", publishingUnits)
+	}
+	if got, want := len(queuedUnits), 2; got != want {
+		t.Fatalf("queued units after mismatch=%d want %d", got, want)
+	}
+	if !indexedFlushRequeueUnitHasUniquePrefix(queuedUnits[0], "email", prefixA) {
+		t.Fatal("first requeued unit does not contain original active unique reservation")
+	}
+	if !indexedFlushRequeueUnitHasUniquePrefix(queuedUnits[1], "email", prefixB) {
+		t.Fatal("second queued unit does not contain later queued unique reservation")
+	}
+	if !containsA || !containsB {
+		t.Fatalf("pending unique reservations after mismatch contain a=%v b=%v want true/true", containsA, containsB)
+	}
+	stats := leftMgr.StatsSnapshot()
+	if got := stats.IndexedFlushRootBaseMismatches; got != 1 {
+		t.Fatalf("indexed flush root-base mismatches=%d want 1", got)
+	}
+	if got := stats.IndexedFlushRequeues; got != 1 {
+		t.Fatalf("indexed flush requeues=%d want 1", got)
+	}
+	if got := stats.IndexedFlushRequeuedUnits; got != 1 {
+		t.Fatalf("indexed flush requeued units=%d want 1", got)
+	}
+}

--- a/TreeDB/collections/indexed_flush_root_mismatch_test.go
+++ b/TreeDB/collections/indexed_flush_root_mismatch_test.go
@@ -1,0 +1,80 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionIndexedAsyncPrepareRejectsRootBaseMismatchAndPreservesPendingVisibility(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	leftMgr := NewCollectionManager(d)
+	if _, err := leftMgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	left, err := leftMgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open left collection: %v", err)
+	}
+	if _, err := left.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+	); err != nil {
+		t.Fatalf("stage left pending insert: %v", err)
+	}
+
+	right, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open right collection: %v", err)
+	}
+	if _, err := right.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"email":"grace@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert right durable row: %v", err)
+	}
+	if err := right.Flush(); err != nil {
+		t.Fatalf("flush right row: %v", err)
+	}
+
+	work, err := left.prepareIndexedAsyncPublish()
+	if work != nil {
+		if work.pin != nil {
+			_ = work.pin.Close()
+		}
+		t.Fatal("prepare returned work despite root-base mismatch")
+	}
+	if !errors.Is(err, ErrConcurrentMutation) {
+		t.Fatalf("prepare err=%v want ErrConcurrentMutation", err)
+	}
+
+	got, err := left.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get pending left row after mismatch: %v", err)
+	}
+	if want := []byte(`{"email":"ada@example.com"}`); !bytes.Equal(got, want) {
+		t.Fatalf("pending left row=%q want %q", got, want)
+	}
+	ids, err := left.FindByIndexValue("email", "ada@example.com")
+	if err != nil {
+		t.Fatalf("find pending email after mismatch: %v", err)
+	}
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("pending email ids=%q want [u1]", ids)
+	}
+}

--- a/TreeDB/collections/no_index_update_baseline_test.go
+++ b/TreeDB/collections/no_index_update_baseline_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -31,12 +32,18 @@ func TestCollectionNoIndexUpdatePublishesSynchronouslyNotQueued(t *testing.T) {
 	beforeState := d.State()
 	beforePrimaryRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
 
+	callbackErr := errors.New("unexpected current document")
+	var unexpectedCurrent []byte
 	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
 		if !bytes.Contains(current, []byte(`"city":"hnl"`)) {
-			t.Fatalf("current document=%s missing city hnl", current)
+			unexpectedCurrent = bytes.Clone(current)
+			return nil, false, callbackErr
 		}
 		return []byte(`{"name":"ada","city":"sea"}`), true, nil
 	})
+	if unexpectedCurrent != nil {
+		t.Fatalf("current document=%s missing city hnl", unexpectedCurrent)
+	}
 	if err != nil {
 		t.Fatalf("update: %v", err)
 	}

--- a/TreeDB/collections/no_index_update_baseline_test.go
+++ b/TreeDB/collections/no_index_update_baseline_test.go
@@ -1,0 +1,100 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionNoIndexUpdatePublishesSynchronouslyNotQueued(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"ada","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	beforeState := d.State()
+	beforePrimaryRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		if !bytes.Contains(current, []byte(`"city":"hnl"`)) {
+			t.Fatalf("current document=%s missing city hnl", current)
+		}
+		return []byte(`{"name":"ada","city":"sea"}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("update matched/modified=%v/%v want true/true", matched, modified)
+	}
+	afterState := d.State()
+	if afterState.CommitSeq != beforeState.CommitSeq+1 {
+		t.Fatalf("no-index update advanced commit seq by %d want 1", afterState.CommitSeq-beforeState.CommitSeq)
+	}
+	afterPrimaryRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	if afterPrimaryRoot == beforePrimaryRoot {
+		t.Fatalf("primary root stayed at %d after synchronous no-index update", afterPrimaryRoot)
+	}
+
+	col.writeDomain.mu.RLock()
+	queuedIndexedUnits := len(col.writeDomain.indexedFlushUnits)
+	publishingIndexedUnits := len(col.writeDomain.indexedPublishingUnits)
+	indexedRootRuns := len(col.writeDomain.rootRuns)
+	noIndexBufferedCount := col.writeDomain.count
+	noIndexTable := col.writeDomain.table
+	noIndexTableLen := 0
+	if noIndexTable != nil {
+		noIndexTableLen = noIndexTable.Len()
+	}
+	col.writeDomain.mu.RUnlock()
+	if queuedIndexedUnits != 0 || publishingIndexedUnits != 0 || indexedRootRuns != 0 {
+		t.Fatalf("no-index update queued indexed state queued=%d publishing=%d rootRuns=%d, want all zero", queuedIndexedUnits, publishingIndexedUnits, indexedRootRuns)
+	}
+	if noIndexBufferedCount != 0 || noIndexTableLen != 0 {
+		t.Fatalf("no-index update left collection-local buffer count=%d tableLen=%d, want drained", noIndexBufferedCount, noIndexTableLen)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated document: %v", err)
+	}
+	if want := []byte(`{"name":"ada","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("updated document=%q want %q", got, want)
+	}
+}
+
+func collectionNoIndexPrimaryRootIDForTest(t *testing.T, d *backenddb.DB, collectionName string) uint64 {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, collectionName)
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatal("missing catalog")
+	}
+	rootID := catalog.rootID(collectionPrimaryRootName(collectionName))
+	if rootID == 0 {
+		t.Fatalf("primary root for %q was not persisted", collectionName)
+	}
+	return rootID
+}

--- a/TreeDB/collections/pending_unique_probe_test.go
+++ b/TreeDB/collections/pending_unique_probe_test.go
@@ -1,0 +1,66 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+)
+
+func TestPendingUniqueReservationProbeIncludesPublishingQueuedAndMutable(t *testing.T) {
+	const indexName = "email"
+	activePrefix := collectionTestUniquePrefix(t, "active@example.com")
+	queuedPrefix := collectionTestUniquePrefix(t, "queued@example.com")
+	mutablePrefix := collectionTestUniquePrefix(t, "mutable@example.com")
+	domain := &collectionWriteDomain{
+		indexedPublishingUnits: []indexedFlushUnit{{
+			uniqueValueRuns: map[string][]memtable.Table{
+				indexName: {collectionTestUniqueRunTable(activePrefix)},
+			},
+		}},
+		indexedFlushUnits: []indexedFlushUnit{{
+			uniqueValueRuns: map[string][]memtable.Table{
+				indexName: {collectionTestUniqueRunTable(queuedPrefix)},
+			},
+		}},
+		uniqueValueRuns: map[string][]memtable.Table{
+			indexName: {collectionTestUniqueRunTable(mutablePrefix)},
+		},
+	}
+	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(pendingIndexedUniqueValueRunMapLocked(domain))
+
+	for _, tt := range []struct {
+		name   string
+		prefix []byte
+	}{
+		{name: "active", prefix: activePrefix},
+		{name: "queued", prefix: queuedPrefix},
+		{name: "mutable", prefix: mutablePrefix},
+	} {
+		if !pendingUniqueReservationProbeLocked(domain, indexName, tt.prefix) {
+			t.Fatalf("pending unique probe missed %s reservation", tt.name)
+		}
+	}
+	if pendingUniqueReservationProbeLocked(domain, indexName, collectionTestUniquePrefix(t, "durable@example.com")) {
+		t.Fatal("pending unique probe reported absent durable-only value")
+	}
+}
+
+func collectionTestUniqueRunTable(prefix []byte) memtable.Table {
+	table := newCollectionRunTable(1)
+	setCollectionRunValue(table, append([]byte(nil), prefix...), nil)
+	table.Freeze()
+	return table
+}
+
+func collectionTestUniquePrefix(tb testing.TB, value string) []byte {
+	tb.Helper()
+	encoded, err := encodeIndexScalar(IndexValueString, value)
+	if err != nil {
+		tb.Fatalf("encode value %q: %v", value, err)
+	}
+	_, prefix, err := appendIndexValuePrefixSlice(nil, encoded)
+	if err != nil {
+		tb.Fatalf("prefix value %q: %v", value, err)
+	}
+	return prefix
+}

--- a/TreeDB/collections/pending_unique_probe_test.go
+++ b/TreeDB/collections/pending_unique_probe_test.go
@@ -26,8 +26,12 @@ func TestPendingUniqueReservationProbeIncludesPublishingQueuedAndMutable(t *test
 			indexName: {collectionTestUniqueRunTable(mutablePrefix)},
 		},
 	}
+	domain.mu.Lock()
 	domain.uniqueValueIndex = rebuildBufferedUniqueValueIndexes(pendingIndexedUniqueValueRunMapLocked(domain))
+	domain.mu.Unlock()
 
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
 	for _, tt := range []struct {
 		name   string
 		prefix []byte
@@ -55,6 +59,8 @@ func TestPendingUniqueReservationIndexCachesWriteLockRebuild(t *testing.T) {
 			},
 		}},
 	}
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
 	index := pendingUniqueReservationIndexLocked(domain, indexName, true)
 	if index == nil || !index.contains(prefix) {
 		t.Fatal("rebuilt pending unique index missed queued reservation")

--- a/TreeDB/collections/pending_unique_probe_test.go
+++ b/TreeDB/collections/pending_unique_probe_test.go
@@ -45,6 +45,25 @@ func TestPendingUniqueReservationProbeIncludesPublishingQueuedAndMutable(t *test
 	}
 }
 
+func TestPendingUniqueReservationIndexCachesWriteLockRebuild(t *testing.T) {
+	const indexName = "email"
+	prefix := collectionTestUniquePrefix(t, "queued@example.com")
+	domain := &collectionWriteDomain{
+		indexedFlushUnits: []indexedFlushUnit{{
+			uniqueValueRuns: map[string][]memtable.Table{
+				indexName: {collectionTestUniqueRunTable(prefix)},
+			},
+		}},
+	}
+	index := pendingUniqueReservationIndexLocked(domain, indexName, true)
+	if index == nil || !index.contains(prefix) {
+		t.Fatal("rebuilt pending unique index missed queued reservation")
+	}
+	if domain.uniqueValueIndex[indexName] != index {
+		t.Fatal("rebuilt pending unique index was not cached on write-lock path")
+	}
+}
+
 func collectionTestUniqueRunTable(prefix []byte) memtable.Table {
 	table := newCollectionRunTable(1)
 	setCollectionRunValue(table, append([]byte(nil), prefix...), nil)


### PR DESCRIPTION
Refs #1242.

## Summary

This replaces the scattered PR1a guardrail PRs with one reviewable aggregate PR. The scope is intentionally narrow: current collection flush-unit ownership, pending-layer visibility, and source-confirmed checkpoint/no-index boundaries.

Included here:

- fixes non-exact secondary range scans to enumerate pending indexed units the same way exact secondary lookup does
- centralizes pending unique reservation probing over active/publishing, queued, and mutable unique runs
- adds indexed flush guard counters for publish requeue, lost ownership, and root-base mismatch
- proves async publish failure requeues units without losing visibility or unique reservation protection
- proves queued and active/publishing indexed units remain visible through primary, exact secondary, and range secondary reads
- pins no-index primary updates as synchronous/non-queued for PR1a
- pins `DB.Checkpoint` as a sync boundary for already-published backend state, while `Flush`/`Close` drain collection-local pending units

Non-goals remain out of this PR: prepared output, leaf-span parallelism, semantic coalescing, root rebase, and no-index async write-back.

## Supersedes

This aggregate supersedes #1244, #1249, #1250, #1277, #1278, #1280, #1282, #1283, #1284, #1296, #1297, and #1298.

## Tests

- `go test ./TreeDB/collections -count=1`
