### PR TITLE
collections: pin no-index update publish contract

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6624,6 +6624,14 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 // secondary unique index values may be staged in the write domain and become
 // durable at Flush/Close or auto-flush.
 //
+// For no-secondary-index collections, single-document Update deliberately
+// preserves the current synchronous publish contract: pending collection-local
+// writes are flushed first, then a modified document is published to the
+// primary root before Update returns. No-index updates may coalesce only
+// opportunistically when callers already reach the existing combiner as a
+// multi-request UpdateBatch-backed batch; they are not staged in the no-index
+// insert buffer or indexed flush queues.
+//
 // Callback panics are recovered and returned as errors in both direct and
 // combined execution. When the collection write domain combines concurrent
 // updates, update may run on an internal combiner goroutine. The callback must
@@ -6661,6 +6669,9 @@ func validateCollectionUpdateInput(c *Collection, documentID []byte, update func
 func (c *Collection) updateDirect(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
 	unlockMutation := c.lockMutation()
 	defer unlockMutation.Unlock()
+	// PR2b pins no-index Update as synchronous: pending no-index inserts or
+	// indexed buffered writes are drained before reading/planning the update,
+	// and a modified no-index replacement publishes before this call returns.
 	if err := c.flushBufferedWrites(); err != nil {
 		return false, false, err
 	}

--- a/TreeDB/collections/checkpoint_boundary_test.go
+++ b/TreeDB/collections/checkpoint_boundary_test.go
@@ -60,6 +60,74 @@ func TestCollectionCheckpointDoesNotFlushPendingNoIndexInsert(t *testing.T) {
 	}
 }
 
+func TestCollectionCheckpointSeesSynchronousNoIndexUpdate(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"ada","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	beforeRoot := collectionCheckpointBoundaryPrimaryRootIDForTest(t, d, "users")
+
+	matched, modified, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"name":"ada","city":"sea"}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("update matched/modified=%v/%v want true/true", matched, modified)
+	}
+	updatedRoot := collectionCheckpointBoundaryPrimaryRootIDForTest(t, d, "users")
+	if updatedRoot == beforeRoot {
+		t.Fatalf("synchronous no-index update left primary root at %d", updatedRoot)
+	}
+	if got := collectionCheckpointBoundaryPendingCountForTest(t, col); got != 0 {
+		t.Fatalf("pending count after synchronous no-index update=%d want 0", got)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	afterCheckpointRoot := collectionCheckpointBoundaryPrimaryRootIDForTest(t, d, "users")
+	if afterCheckpointRoot != updatedRoot {
+		t.Fatalf("checkpoint changed primary root from %d to %d after synchronous update", updatedRoot, afterCheckpointRoot)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	got, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get reopened updated doc: %v", err)
+	}
+	if want := []byte(`{"name":"ada","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("reopened updated doc=%q want %q", got, want)
+	}
+}
+
 func collectionCheckpointBoundaryPrimaryRootIDForTest(t *testing.T, d *backenddb.DB, collectionName string) uint64 {
 	t.Helper()
 	snap := d.AcquireSnapshot()

--- a/TreeDB/collections/no_index_update_baseline_test.go
+++ b/TreeDB/collections/no_index_update_baseline_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -31,6 +32,7 @@ func TestCollectionNoIndexUpdatePublishesSynchronouslyNotQueued(t *testing.T) {
 	}
 	beforeState := d.State()
 	beforePrimaryRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	beforeStats := mgr.StatsSnapshot()
 
 	callbackErr := errors.New("unexpected current document")
 	var unexpectedCurrent []byte
@@ -58,6 +60,22 @@ func TestCollectionNoIndexUpdatePublishesSynchronouslyNotQueued(t *testing.T) {
 	if afterPrimaryRoot == beforePrimaryRoot {
 		t.Fatalf("primary root stayed at %d after synchronous no-index update", afterPrimaryRoot)
 	}
+	afterStats := mgr.StatsSnapshot()
+	if got, want := afterStats.PrimaryOnlyUpdateCalls-beforeStats.PrimaryOnlyUpdateCalls, uint64(1); got != want {
+		t.Fatalf("primary-only update calls delta=%d want %d", got, want)
+	}
+	if got, want := afterStats.PrimaryOnlyMatched-beforeStats.PrimaryOnlyMatched, uint64(1); got != want {
+		t.Fatalf("primary-only matched delta=%d want %d", got, want)
+	}
+	if got, want := afterStats.PrimaryOnlyModified-beforeStats.PrimaryOnlyModified, uint64(1); got != want {
+		t.Fatalf("primary-only modified delta=%d want %d", got, want)
+	}
+	if got, want := afterStats.PrimaryOnlyRootPublishes-beforeStats.PrimaryOnlyRootPublishes, uint64(1); got != want {
+		t.Fatalf("primary-only root publishes delta=%d want %d", got, want)
+	}
+	if got, want := afterStats.PrimaryOnlyCoalescedDocs-beforeStats.PrimaryOnlyCoalescedDocs, uint64(1); got != want {
+		t.Fatalf("primary-only coalesced docs delta=%d want %d", got, want)
+	}
 
 	col.writeDomain.mu.RLock()
 	queuedIndexedUnits := len(col.writeDomain.indexedFlushUnits)
@@ -83,6 +101,275 @@ func TestCollectionNoIndexUpdatePublishesSynchronouslyNotQueued(t *testing.T) {
 	if want := []byte(`{"name":"ada","city":"sea"}`); !bytes.Equal(got, want) {
 		t.Fatalf("updated document=%q want %q", got, want)
 	}
+}
+
+func TestCollectionNoIndexUpdateFlushesPendingInsertBeforeSynchronousPublish(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"ada","city":"hnl"}`)); err != nil {
+		t.Fatalf("buffered insert: %v", err)
+	}
+	if got := collectionNoIndexPendingStateForTest(t, col).count; got != 1 {
+		t.Fatalf("pending insert count=%d want 1", got)
+	}
+	beforeState := d.State()
+
+	callbackErr := errors.New("unexpected current document")
+	var unexpectedCurrent []byte
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		if !bytes.Equal(current, []byte(`{"name":"ada","city":"hnl"}`)) {
+			unexpectedCurrent = bytes.Clone(current)
+			return nil, false, callbackErr
+		}
+		return []byte(`{"name":"ada","city":"sea"}`), true, nil
+	})
+	if unexpectedCurrent != nil {
+		t.Fatalf("update callback current=%q want pending insert document", unexpectedCurrent)
+	}
+	if err != nil {
+		t.Fatalf("update pending insert: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("update pending insert matched/modified=%v/%v want true/true", matched, modified)
+	}
+	afterState := d.State()
+	if got, want := afterState.CommitSeq-beforeState.CommitSeq, uint64(2); got != want {
+		t.Fatalf("commit seq delta after insert flush + update publish=%d want %d", got, want)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after synchronous update=%+v want empty", state)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	got, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get reopened updated doc: %v", err)
+	}
+	if want := []byte(`{"name":"ada","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("reopened updated doc=%q want %q", got, want)
+	}
+}
+
+func TestCollectionNoIndexUpdateMissingAndUnchangedDoNotPublishOrQueue(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"ada","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+
+	beforeRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	beforeState := d.State()
+	beforeStats := mgr.StatsSnapshot()
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		return current, false, nil
+	})
+	if err != nil {
+		t.Fatalf("unchanged update: %v", err)
+	}
+	if !matched || modified {
+		t.Fatalf("unchanged update matched/modified=%v/%v want true/false", matched, modified)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("unchanged update commit seq=%d want %d", got, beforeState.CommitSeq)
+	}
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+		t.Fatalf("unchanged update primary root=%d want %d", got, beforeRoot)
+	}
+	afterUnchangedStats := mgr.StatsSnapshot()
+	if got := afterUnchangedStats.PrimaryOnlyRootPublishes - beforeStats.PrimaryOnlyRootPublishes; got != 0 {
+		t.Fatalf("unchanged update primary root publishes delta=%d want 0", got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after unchanged update=%+v want empty", state)
+	}
+
+	callbackRan := false
+	matched, modified, err = col.Update([]byte("missing"), func(current []byte) ([]byte, bool, error) {
+		callbackRan = true
+		return nil, false, fmt.Errorf("callback should not run, current=%q", current)
+	})
+	if err != nil {
+		t.Fatalf("missing update: %v", err)
+	}
+	if callbackRan {
+		t.Fatal("missing update callback ran")
+	}
+	if matched || modified {
+		t.Fatalf("missing update matched/modified=%v/%v want false/false", matched, modified)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("missing update commit seq=%d want %d", got, beforeState.CommitSeq)
+	}
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+		t.Fatalf("missing update primary root=%d want %d", got, beforeRoot)
+	}
+	afterMissingStats := mgr.StatsSnapshot()
+	if got := afterMissingStats.PrimaryOnlyRootPublishes - beforeStats.PrimaryOnlyRootPublishes; got != 0 {
+		t.Fatalf("missing update primary root publishes delta=%d want 0", got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after missing update=%+v want empty", state)
+	}
+}
+
+func TestCollectionNoIndexUpdateFlushAfterSyncPublishDoesNotRepublish(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"ada","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	if _, _, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"name":"ada","city":"sea"}`), true, nil
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	beforeFlushState := d.State()
+	beforeFlushRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	beforeFlushStats := mgr.StatsSnapshot()
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush after synchronous update: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeFlushState.CommitSeq {
+		t.Fatalf("flush after synchronous update commit seq=%d want %d", got, beforeFlushState.CommitSeq)
+	}
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeFlushRoot {
+		t.Fatalf("flush after synchronous update primary root=%d want %d", got, beforeFlushRoot)
+	}
+	afterFlushStats := mgr.StatsSnapshot()
+	if got := afterFlushStats.PrimaryOnlyRootPublishes - beforeFlushStats.PrimaryOnlyRootPublishes; got != 0 {
+		t.Fatalf("flush after synchronous update primary root publishes delta=%d want 0", got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after flush=%+v want empty", state)
+	}
+}
+
+func TestCollectionNoIndexUpdateSynchronousVisibilityAcrossManagers(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	writerMgr := NewCollectionManager(d)
+	if _, err := writerMgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	writer, err := writerMgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open writer collection: %v", err)
+	}
+	sameManagerReader, err := writerMgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open same-manager reader collection: %v", err)
+	}
+	otherManagerReader, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open other-manager reader collection: %v", err)
+	}
+	if _, err := writer.Insert([]byte("u1"), []byte(`{"name":"ada","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	if _, _, err := writer.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"name":"ada","city":"sea"}`), true, nil
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	for name, reader := range map[string]*Collection{
+		"writer":               writer,
+		"same-manager-reader":  sameManagerReader,
+		"other-manager-reader": otherManagerReader,
+	} {
+		got, err := reader.Get([]byte("u1"))
+		if err != nil {
+			t.Fatalf("%s get updated doc: %v", name, err)
+		}
+		if want := []byte(`{"name":"ada","city":"sea"}`); !bytes.Equal(got, want) {
+			t.Fatalf("%s updated doc=%q want %q", name, got, want)
+		}
+	}
+}
+
+type collectionNoIndexPendingState struct {
+	count             int
+	tableLen          int
+	indexedQueued     int
+	indexedPublishing int
+	indexedRootRuns   int
+}
+
+func collectionNoIndexPendingStateForTest(t *testing.T, col *Collection) collectionNoIndexPendingState {
+	t.Helper()
+	col.writeDomain.mu.RLock()
+	defer col.writeDomain.mu.RUnlock()
+	state := collectionNoIndexPendingState{
+		count:             col.writeDomain.count,
+		indexedQueued:     len(col.writeDomain.indexedFlushUnits),
+		indexedPublishing: len(col.writeDomain.indexedPublishingUnits),
+		indexedRootRuns:   len(col.writeDomain.rootRuns),
+	}
+	if col.writeDomain.table != nil {
+		state.tableLen = col.writeDomain.table.Len()
+	}
+	return state
 }
 
 func collectionNoIndexPrimaryRootIDForTest(t *testing.T, d *backenddb.DB, collectionName string) uint64 {


### PR DESCRIPTION
## Summary

PR2B chooses the narrow pin-only strategy for #1242. The GPT-5 Pro review batch split between combiner tuning and primary-only write-back, but the common conclusion was that combiner-only is not a reliable fix and primary-only write-back has a larger visibility/durability surface. This PR therefore documents and tests the current synchronous no-index update contract, and opens #1332 for the larger write-back design.

## Changes

- Documents that no-secondary-index single-document `Update` flushes pending collection-local writes and publishes the primary root before returning.
- Strengthens the no-index update baseline with primary-only counter assertions and empty write-domain state checks.
- Adds tests for pending no-index insert drain before update, unchanged/missing no-op updates, flush-after-update no-op behavior, cross-manager visibility after return, and checkpoint contrast for synchronous no-index updates.

## Verification

- `go test ./TreeDB/collections -run 'TestCollection(NoIndexUpdate|Checkpoint)' -count=1`\n- `go test ./TreeDB/collections -run 'Test(CollectionNoIndexUpdate|PrimaryOnlyNoIndexUpdateCounters|CollectionUpdateCombinerRunBatchPublishesDistinctIDsOnce|CollectionUpdateCombinerRunBatchStartingWithYieldsForQueuedPeer)' -count=1`\n- `go test ./TreeDB/collections -count=1`\n\nFollow-up: #1332