### PR TITLE
TreeDB collections: stage primary-only no-index updates

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -111,6 +111,8 @@ const (
 	updateBatchModeNoSecondaryUniqueIndexChanges
 )
 
+var errPrimaryOnlyNoIndexWriteBackNotEligible = errors.New("collections: primary-only no-index write-back not eligible")
+
 const bsonIDSnapshotInlineValueLen = 64
 
 // UpdateBatchResult reports the outcome for one UpdateBatch item.
@@ -763,6 +765,9 @@ type collectionWriteDomain struct {
 	mutableBytes     int64
 	rootRunCount     int
 	writeGeneration  uint64
+
+	primaryOnlyPendingUpdateKeys  map[string]struct{}
+	primaryOnlyPendingUpdateCalls int
 
 	mutationLockCalls                atomic.Uint64
 	mutationLockWaitTotalNs          atomic.Uint64
@@ -1851,12 +1856,12 @@ func (domain *collectionWriteDomain) observePrimaryOnlyUpdateBatch(items, matche
 	}
 	if items > 0 {
 		domain.primaryOnlyUpdateCalls.Add(uint64(items))
-	}
-	if matched > 0 {
-		domain.primaryOnlyMatched.Add(uint64(matched))
-	}
-	if modified > 0 {
-		domain.primaryOnlyModified.Add(uint64(modified))
+		if matched > 0 {
+			domain.primaryOnlyMatched.Add(uint64(matched))
+		}
+		if modified > 0 {
+			domain.primaryOnlyModified.Add(uint64(modified))
+		}
 	}
 	if !published {
 		return
@@ -1868,6 +1873,33 @@ func (domain *collectionWriteDomain) observePrimaryOnlyUpdateBatch(items, matche
 	if modified > 0 {
 		domain.primaryOnlyCoalescedDocs.Add(uint64(modified))
 	}
+}
+
+func (domain *collectionWriteDomain) observePrimaryOnlyBufferedUpdateBatch(items, matched, modified int) {
+	if domain == nil {
+		return
+	}
+	if items > 0 {
+		domain.primaryOnlyUpdateCalls.Add(uint64(items))
+	}
+	if matched > 0 {
+		domain.primaryOnlyMatched.Add(uint64(matched))
+	}
+	if modified > 0 {
+		domain.primaryOnlyModified.Add(uint64(modified))
+		domain.primaryOnlyBufferedCalls.Add(uint64(modified))
+	}
+}
+
+func (domain *collectionWriteDomain) observePrimaryOnlyNoIndexFlush(updateDocs int, deltaStats collectionRootDeltaPlanStats) {
+	if domain == nil || updateDocs <= 0 {
+		return
+	}
+	domain.primaryOnlyRootPublishes.Add(1)
+	domain.primaryOnlyRootDeltaEntries.Add(deltaStats.primaryEntries)
+	domain.primaryOnlyRootDeltaKeyBytes.Add(deltaStats.primaryKeyBytes)
+	domain.primaryOnlyRootDeltaValueBytes.Add(deltaStats.primaryValueBytes)
+	domain.primaryOnlyCoalescedDocs.Add(uint64(updateDocs))
 }
 
 func (domain *collectionWriteDomain) observeUpdateCombineRequest(queueDepth int) {
@@ -2685,6 +2717,7 @@ func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, erro
 	domain.storagePolicy = plannerOptions.dataStoragePolicy
 	domain.table.SetEntry(id, document, page.ValuePtr{}, node.FlagInline)
 	domain.count++
+	domain.writeGeneration++
 	resultID := bytes.Clone(id)
 	domain.mu.Unlock()
 	return resultID, nil
@@ -2958,6 +2991,8 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	baseCommitSeq := snapshotCommitSeq(pin)
 	baseRootIDs := map[string]uint64{rootName: baseRoot}
 	table := domain.table
+	primaryOnlyUpdateCalls := domain.primaryOnlyPendingUpdateCalls
+	primaryOnlyDeltaStats := primaryOnlyPendingUpdateDeltaStatsLocked(domain)
 	iter := table.NewIterator(nil, nil)
 
 	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]backenddb.OrderedRootDeltaPublishInput{{
@@ -2983,12 +3018,49 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	domain.primaryRoot = rootIDs[0]
 	domain.table = newCollectionRunTable(0)
 	domain.count = 0
+	domain.bufferedBytes = 0
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
+	domain.primaryOnlyPendingUpdateKeys = nil
+	domain.primaryOnlyPendingUpdateCalls = 0
+	domain.writeGeneration++
 	c.meta = meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	if primaryOnlyUpdateCalls > 0 {
+		domain.observeRootDeltaPlan(primaryOnlyDeltaStats)
+		domain.observePrimaryOnlyNoIndexFlush(primaryOnlyUpdateCalls, primaryOnlyDeltaStats)
+	}
 	resetCollectionRunTable(table)
 	return nil
+}
+
+func primaryOnlyPendingUpdateDeltaStatsLocked(domain *collectionWriteDomain) collectionRootDeltaPlanStats {
+	if domain == nil || domain.table == nil || len(domain.primaryOnlyPendingUpdateKeys) == 0 {
+		return collectionRootDeltaPlanStats{}
+	}
+	var stats collectionRootDeltaPlanStats
+	stats.primaryRoots = 1
+	for key := range domain.primaryOnlyPendingUpdateKeys {
+		value, _, flags, found := domain.table.GetEntry([]byte(key))
+		if !found {
+			continue
+		}
+		stats.entries++
+		stats.primaryEntries++
+		stats.keyBytes += uint64(len(key))
+		stats.primaryKeyBytes += uint64(len(key))
+		if flags&node.FlagTombstone != 0 {
+			stats.tombstones++
+			stats.primaryTombstones++
+			continue
+		}
+		stats.valueBytes += uint64(len(value))
+		stats.primaryValueBytes += uint64(len(value))
+	}
+	if stats.entries == 0 {
+		return collectionRootDeltaPlanStats{}
+	}
+	return stats
 }
 
 func (c *Collection) shouldBufferIndexedInserts(meta CollectionMeta) bool {
@@ -6618,19 +6690,13 @@ func (c *Collection) Replace(documentID, document []byte) (bool, error) {
 	return matched, err
 }
 
-// Update applies update to the latest document value and retries if another
-// collection write changes the root before this update publishes. For indexed
-// collections with BufferedIndexedWrites enabled, updates that do not change
-// secondary unique index values may be staged in the write domain and become
-// durable at Flush/Close or auto-flush.
-//
-// For no-secondary-index collections, single-document Update deliberately
-// preserves the current synchronous publish contract: pending collection-local
-// writes are flushed first, then a modified document is published to the
-// primary root before Update returns. No-index updates may coalesce only
-// opportunistically when callers already reach the existing combiner as a
-// multi-request UpdateBatch-backed batch; they are not staged in the no-index
-// insert buffer or indexed flush queues.
+// Update applies update to the latest document value visible to this collection
+// manager. For no-secondary-index JSON/BSON collections, modified updates are
+// staged as final primary document bytes in the collection write domain and
+// become durable at Flush/Close or another collection drain boundary. Other
+// managers are not required to see those staged updates until they are flushed.
+// Indexed collections and unsupported document formats use the existing direct
+// or indexed buffered update paths.
 //
 // Callback panics are recovered and returned as errors in both direct and
 // combined execution. When the collection write domain combines concurrent
@@ -6669,13 +6735,39 @@ func validateCollectionUpdateInput(c *Collection, documentID []byte, update func
 func (c *Collection) updateDirect(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
 	unlockMutation := c.lockMutation()
 	defer unlockMutation.Unlock()
-	// PR2b pins no-index Update as synchronous: pending no-index inserts or
-	// indexed buffered writes are drained before reading/planning the update,
-	// and a modified no-index replacement publishes before this call returns.
+
+	var lastErr error
+	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
+		matched, modified, handled, err := c.updatePrimaryOnlyNoIndexWriteBack(documentID, update)
+		if handled {
+			if errors.Is(err, ErrConcurrentMutation) {
+				lastErr = err
+				waitBeforeCollectionMutationRetry(attempt)
+				continue
+			}
+			return matched, modified, err
+		}
+		if err := c.flushBufferedWrites(); err != nil {
+			return false, false, err
+		}
+		matched, modified, err = c.updateDocumentOnce(documentID, update)
+		if errors.Is(err, ErrConcurrentMutation) {
+			lastErr = err
+			waitBeforeCollectionMutationRetry(attempt)
+			continue
+		}
+		return matched, modified, err
+	}
+	return false, false, collectionMutationRetryExhausted(lastErr)
+}
+
+func (c *Collection) updateDirectSynchronous(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, error) {
+	unlockMutation := c.lockMutation()
+	defer unlockMutation.Unlock()
+
 	if err := c.flushBufferedWrites(); err != nil {
 		return false, false, err
 	}
-
 	var lastErr error
 	for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
 		matched, modified, err := c.updateDocumentOnce(documentID, update)
@@ -6687,6 +6779,208 @@ func (c *Collection) updateDirect(documentID []byte, update func(current []byte)
 		return matched, modified, err
 	}
 	return false, false, collectionMutationRetryExhausted(lastErr)
+}
+
+type primaryOnlyNoIndexWriteBackRead struct {
+	catalog         *collectionCatalog
+	meta            CollectionMeta
+	options         collectionOptions
+	primaryRootName string
+	primaryRoot     uint64
+	baseCommitSeq   uint64
+	baseSystemRoot  uint64
+	writeGeneration uint64
+	current         []byte
+	found           bool
+}
+
+func (c *Collection) updatePrimaryOnlyNoIndexWriteBack(documentID []byte, update func(current []byte) (replacement []byte, changed bool, err error)) (bool, bool, bool, error) {
+	domain := c.writeDomain
+	if domain == nil {
+		return false, false, false, nil
+	}
+	read, handled, err := c.readPrimaryOnlyNoIndexWriteBackCurrent(domain, documentID)
+	if !handled || err != nil {
+		return false, false, handled, err
+	}
+	stats := CollectionUpdateStats{Items: 1}
+	if !read.found {
+		if err := c.validatePrimaryOnlyNoIndexWriteBackDomain(domain, read); err != nil {
+			return false, false, true, err
+		}
+		domain.observePrimaryOnlyUpdate(false, false, false, collectionRootDeltaPlanStats{})
+		c.setLastUpdateStats(stats)
+		return false, false, true, nil
+	}
+	stats.Matched = 1
+	currentID, err := captureBSONIDSnapshot(read.current, read.options)
+	if err != nil {
+		return false, false, true, err
+	}
+	document, changed, err := callCollectionUpdateCallback(update, read.current)
+	if err != nil {
+		return false, false, true, err
+	}
+	if !changed {
+		if err := c.validatePrimaryOnlyNoIndexWriteBackDomain(domain, read); err != nil {
+			return false, false, true, err
+		}
+		domain.observePrimaryOnlyUpdate(true, false, false, collectionRootDeltaPlanStats{})
+		c.setLastUpdateStats(stats)
+		return true, false, true, nil
+	}
+	if len(document) == 0 {
+		return false, false, true, errors.New("changed replacement document cannot be empty")
+	}
+	if err := validateBSONReplacementPreservesIDSnapshot(currentID, document, read.options); err != nil {
+		return false, false, true, err
+	}
+	preparedDocuments, templateRecords, _, err := prepareInsertDocuments([][]byte{document}, read.options)
+	if err != nil {
+		return false, false, true, err
+	}
+	if len(templateRecords) != 0 {
+		return false, false, false, nil
+	}
+	if len(preparedDocuments) != 1 {
+		return false, false, true, errors.New("collections: update prepared unexpected document count")
+	}
+	if err := c.stagePrimaryOnlyNoIndexWriteBack(domain, read, documentID, preparedDocuments[0]); err != nil {
+		return false, false, true, err
+	}
+	stats.Modified = 1
+	stats.Runs = 1
+	stats.BufferedBatches = 1
+	c.setLastUpdateStats(stats)
+	return true, true, true, nil
+}
+
+func (c *Collection) readPrimaryOnlyNoIndexWriteBackCurrent(domain *collectionWriteDomain, documentID []byte) (primaryOnlyNoIndexWriteBackRead, bool, error) {
+	var read primaryOnlyNoIndexWriteBackRead
+	if domain == nil {
+		return read, false, nil
+	}
+	domain.mu.Lock()
+	catalog, options, indexed, err := c.ensureWriteDomainLocked(domain)
+	if err != nil {
+		domain.mu.Unlock()
+		return read, true, err
+	}
+	if catalog == nil || indexed || len(catalog.meta.Indexes) != 0 || !primaryOnlyNoIndexWriteBackSupportsFormat(options.documentFormat) {
+		domain.mu.Unlock()
+		return read, false, nil
+	}
+	c.meta = catalog.meta
+	read.catalog = catalog
+	read.meta = catalog.meta
+	read.options = options
+	read.primaryRootName = collectionPrimaryRootName(catalog.meta.Name)
+	read.primaryRoot = domain.primaryRoot
+	read.baseCommitSeq = domain.baseCommitSeq
+	read.baseSystemRoot = domain.baseSystemRoot
+	read.writeGeneration = domain.writeGeneration
+	if domain.table != nil {
+		value, _, flags, found := domain.table.GetEntry(documentID)
+		if found {
+			if flags&node.FlagTombstone != 0 {
+				domain.mu.Unlock()
+				return read, true, nil
+			}
+			read.current = bytes.Clone(value)
+			read.found = true
+			domain.mu.Unlock()
+			return read, true, nil
+		}
+	}
+	domain.mu.Unlock()
+
+	if read.primaryRoot == 0 {
+		return read, true, nil
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return read, true, backenddb.ErrClosed
+	}
+	value, found, err := collectionGetAppendAtCatalogRoot(snap, read.catalog, read.primaryRootName, documentID, nil)
+	_ = snap.Close()
+	if err != nil {
+		return read, true, err
+	}
+	if found {
+		read.current = bytes.Clone(value)
+		read.found = true
+	}
+	return read, true, nil
+}
+
+func primaryOnlyNoIndexWriteBackSupportsFormat(format DocumentFormat) bool {
+	switch normalizedDocumentFormat(format) {
+	case DocumentFormatJSON, DocumentFormatBSON:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *Collection) validatePrimaryOnlyNoIndexWriteBackDomain(domain *collectionWriteDomain, read primaryOnlyNoIndexWriteBackRead) error {
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	return c.validatePrimaryOnlyNoIndexWriteBackDomainLocked(domain, read)
+}
+
+func (c *Collection) validatePrimaryOnlyNoIndexWriteBackDomainLocked(domain *collectionWriteDomain, read primaryOnlyNoIndexWriteBackRead) error {
+	if domain == nil {
+		return errPrimaryOnlyNoIndexWriteBackNotEligible
+	}
+	if domain.writeGeneration != read.writeGeneration {
+		return ErrConcurrentMutation
+	}
+	currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
+	catalog, err := c.revalidateBufferedWriteDomainLocked(domain, currentCommitSeq, currentSystemRoot)
+	if err != nil {
+		return err
+	}
+	if catalog == nil || !sameCollectionMeta(catalog.meta, read.meta) || len(catalog.meta.Indexes) != 0 {
+		return ErrConcurrentMutation
+	}
+	if rootID := catalog.rootID(read.primaryRootName); rootID != read.primaryRoot {
+		return errConcurrentRootModification(read.meta.Name, read.primaryRootName)
+	}
+	if !primaryOnlyNoIndexWriteBackSupportsFormat(read.options.documentFormat) {
+		return errPrimaryOnlyNoIndexWriteBackNotEligible
+	}
+	return nil
+}
+
+func (c *Collection) stagePrimaryOnlyNoIndexWriteBack(domain *collectionWriteDomain, read primaryOnlyNoIndexWriteBackRead, documentID, document []byte) error {
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	if err := c.validatePrimaryOnlyNoIndexWriteBackDomainLocked(domain, read); err != nil {
+		return err
+	}
+	if domain.table == nil {
+		domain.table = newCollectionRunTable(0)
+	}
+	_, _, _, existed := domain.table.GetEntry(documentID)
+	if !existed {
+		domain.count++
+		domain.mutableCount++
+	}
+	key := bytes.Clone(documentID)
+	value := bytes.Clone(document)
+	domain.table.SetEntry(key, value, page.ValuePtr{}, node.FlagInline)
+	if domain.primaryOnlyPendingUpdateKeys == nil {
+		domain.primaryOnlyPendingUpdateKeys = make(map[string]struct{})
+	}
+	domain.primaryOnlyPendingUpdateKeys[string(documentID)] = struct{}{}
+	domain.primaryOnlyPendingUpdateCalls++
+	stagedBytes := int64(len(key) + len(value))
+	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
+	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
+	domain.writeGeneration++
+	domain.observePrimaryOnlyBufferedUpdateBatch(1, 1, 1)
+	c.meta = read.meta
+	return nil
 }
 
 // UpdateBatch applies a unique set of document updates under one collection
@@ -7281,6 +7575,14 @@ func runUpdateCombineDirect(req collectionUpdateCombineRequest) collectionUpdate
 	return collectionUpdateCombineResult{matched: matched, modified: modified, err: err}
 }
 
+func runUpdateCombineDirectSynchronous(req collectionUpdateCombineRequest) collectionUpdateCombineResult {
+	if err := validateCollectionUpdateCombineRequest(req); err != nil {
+		return collectionUpdateCombineResult{err: err}
+	}
+	matched, modified, err := req.collection.updateDirectSynchronous((&req).documentIDBytes(), req.update)
+	return collectionUpdateCombineResult{matched: matched, modified: modified, err: err}
+}
+
 func validateCollectionUpdateCombineRequest(req collectionUpdateCombineRequest) error {
 	if req.collection == nil {
 		return errCollectionNil
@@ -7348,7 +7650,7 @@ func completeUpdateCombineBatchWithItemFallback(batch []collectionUpdateCombineR
 			completeUpdateCombineRequest(req, collectionUpdateCombineResult{err: reqErr})
 			continue
 		}
-		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
+		completeUpdateCombineRequest(req, runUpdateCombineDirectSynchronous(req))
 	}
 	return true
 }
@@ -8521,7 +8823,8 @@ func (c *Collection) bufferedUpdateBatchPlanStillCurrent(plan *updateBatchPlan) 
 	if domain.count == 0 {
 		return false
 	}
-	return updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) &&
+	return (updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) ||
+		updateBatchCanReadNoIndexBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot)) &&
 		plan.bufferedReadGeneration == domain.writeGeneration
 }
 
@@ -8532,13 +8835,19 @@ func (c *Collection) withMutationLock(fn func() error) error {
 }
 
 func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMode) bool {
-	if c == nil || c.writeDomain == nil || mode == updateBatchModeAny {
+	if c == nil || c.writeDomain == nil {
 		return false
 	}
 	domain := c.writeDomain
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()
-	return domain.count > 0 && hasBufferedIndexedRootRuns(domain)
+	if domain.count == 0 {
+		return false
+	}
+	if hasBufferedIndexedRootRuns(domain) {
+		return mode != updateBatchModeAny
+	}
+	return domain.table != nil && domain.table.Len() > 0
 }
 
 func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64) bool {
@@ -8559,6 +8868,25 @@ func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta 
 		return false
 	}
 	return meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
+}
+
+func updateBatchCanReadNoIndexBufferedDomainLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64) bool {
+	if domain == nil || domain.count == 0 || domain.table == nil || domain.table.Len() == 0 {
+		return false
+	}
+	if hasBufferedIndexedRootRuns(domain) {
+		return false
+	}
+	if !domain.loaded || domain.catalog == nil {
+		return false
+	}
+	if domain.baseSystemRoot != baseSystemRoot {
+		return false
+	}
+	if !sameCollectionMeta(domain.meta, meta) {
+		return false
+	}
+	return len(meta.Indexes) == 0
 }
 
 func readUpdateBatchCurrentDocument(primaryReader *backenddb.SnapshotRootReader, primaryReaderOK bool, itemIndex int, documentID []byte, buffered updateBatchBufferedRead, dst []byte) (updateBatchCurrentDocument, error) {
@@ -8688,6 +9016,25 @@ func snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(index *bufferedPrimaryRu
 	return entries, buffer, nil
 }
 
+func snapshotUpdateBatchNoIndexBufferedPrimaryEntriesLocked(domain *collectionWriteDomain, items []UpdateBatchItem) ([]updateBatchBufferedEntry, *updateBatchBufferedEntryBuffer, error) {
+	entries, buffer := getUpdateBatchBufferedEntries(len(items))
+	if domain == nil || domain.table == nil || len(items) == 0 {
+		return entries, buffer, nil
+	}
+	for i, item := range items {
+		value, _, flags, found := domain.table.GetEntry(item.DocumentID)
+		if !found {
+			continue
+		}
+		entries[i] = updateBatchBufferedEntry{
+			value: buffer.copyValue(value),
+			flags: flags,
+			found: true,
+		}
+	}
+	return entries, buffer, nil
+}
+
 func snapshotUpdateBatchBufferedRead(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64, items []UpdateBatchItem, documentFormat DocumentFormat) (updateBatchBufferedRead, []memtable.Table, bool, error) {
 	if domain == nil {
 		return updateBatchBufferedRead{}, nil, false, nil
@@ -8717,6 +9064,18 @@ func snapshotUpdateBatchBufferedRead(domain *collectionWriteDomain, meta Collect
 }
 
 func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64, items []UpdateBatchItem, documentFormat DocumentFormat, allowPrimaryRunIndexBuild bool) (updateBatchBufferedRead, []memtable.Table, bool, bool, error) {
+	if updateBatchCanReadNoIndexBufferedDomainLocked(domain, meta, baseSystemRoot) {
+		primaryEntries, primaryBuffer, err := snapshotUpdateBatchNoIndexBufferedPrimaryEntriesLocked(domain, items)
+		if err != nil {
+			return updateBatchBufferedRead{}, nil, false, false, err
+		}
+		return updateBatchBufferedRead{
+			enabled:         true,
+			primaryEntries:  primaryEntries,
+			primaryBuffer:   primaryBuffer,
+			writeGeneration: domain.writeGeneration,
+		}, nil, false, false, nil
+	}
 	if updateBatchCanReadBufferedDomainLocked(domain, meta, baseSystemRoot) {
 		bufferedCollectionName := bufferedDomainCollectionName(domain, meta.Name)
 		if allowPrimaryRunIndexBuild && domain.primaryRunIndex == nil && hasBufferedPrimaryRootRuns(domain, bufferedCollectionName) {
@@ -8747,6 +9106,9 @@ func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta C
 			primaryBuffer:   primaryBuffer,
 			writeGeneration: domain.writeGeneration,
 		}, templateRuns, false, false, nil
+	}
+	if domain.count > 0 && !hasBufferedIndexedRootRuns(domain) && domain.table != nil && domain.table.Len() > 0 {
+		return updateBatchBufferedRead{}, nil, true, false, nil
 	}
 	if domain.count > 0 && hasBufferedIndexedRootRuns(domain) {
 		return updateBatchBufferedRead{}, nil, true, false, nil
@@ -8800,7 +9162,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	var bufferedTemplateRuns []memtable.Table
 	defer func() { resetCollectionTables(bufferedTemplateRuns) }()
 	bufferedReadBlocked := false
-	if domain := c.writeDomain; useBufferedRead && domain != nil && mode != updateBatchModeAny {
+	if domain := c.writeDomain; useBufferedRead && domain != nil {
 		bufferedRead, bufferedTemplateRuns, bufferedReadBlocked, err = snapshotUpdateBatchBufferedRead(domain, meta, baseSystemRoot, items, plannerOptions.documentFormat)
 		if err != nil {
 			_ = snap.Close()
@@ -9626,12 +9988,166 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	return true, nil
 }
 
+func isPrimaryOnlyNoIndexUpdateBatchPlan(plan *updateBatchPlan) bool {
+	if plan == nil || plan.directBufferedUpdate != nil {
+		return false
+	}
+	if len(plan.meta.Indexes) != 0 {
+		return false
+	}
+	if len(plan.rootNames) != 1 || len(plan.deltaTables) != 1 || len(plan.policies) != 1 {
+		return false
+	}
+	if plan.rootNames[0] != collectionPrimaryRootName(plan.meta.Name) {
+		return false
+	}
+	if len(plan.uniqueSecondaryIndexByRoot) == 1 && plan.uniqueSecondaryIndexByRoot[0] >= 0 {
+		return false
+	}
+	return updateBatchModifiedCount(plan.results) > 0
+}
+
+type noIndexPrimaryEntry struct {
+	key   []byte
+	value []byte
+	flags byte
+}
+
+func collectNoIndexPrimaryEntries(table memtable.Table) ([]noIndexPrimaryEntry, error) {
+	if table == nil {
+		return nil, nil
+	}
+	entries := make([]noIndexPrimaryEntry, 0, table.Len())
+	it := table.NewIterator(nil, nil)
+	for it.Valid() {
+		key := bytes.Clone(it.UnsafeKey())
+		value, _, flags := it.UnsafeEntry()
+		entries = append(entries, noIndexPrimaryEntry{
+			key:   key,
+			value: bytes.Clone(value),
+			flags: flags,
+		})
+		it.Next()
+	}
+	err := it.Error()
+	_ = it.Close()
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func (c *Collection) bufferNoIndexUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, error) {
+	if c == nil || c.writeDomain == nil || !isPrimaryOnlyNoIndexUpdateBatchPlan(plan) {
+		return false, nil
+	}
+	detailedStats := c.updateBatchDetailedStatsEnabled()
+	bufferStart := updateBatchStatsNow(detailedStats)
+	precheckStart := updateBatchStatsNow(detailedStats)
+	defer func() {
+		plan.stats.BufferStage += updateBatchStatsSince(detailedStats, bufferStart)
+	}()
+	modifiedCount := updateBatchModifiedCount(plan.results)
+	if modifiedCount == 0 {
+		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
+		return false, nil
+	}
+	primaryTable := plan.deltaTables[0]
+	if primaryTable == nil || primaryTable.Len() == 0 {
+		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
+		return false, fmt.Errorf("collections: UpdateBatch collection %q modified rows without primary no-index delta", plan.meta.Name)
+	}
+	plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
+	entries, err := collectNoIndexPrimaryEntries(primaryTable)
+	if err != nil {
+		return false, err
+	}
+	if len(entries) != modifiedCount {
+		return false, fmt.Errorf("collections: UpdateBatch collection %q primary no-index delta entries=%d modified=%d", plan.meta.Name, len(entries), modifiedCount)
+	}
+
+	domain := c.writeDomain
+	lockStart := updateBatchStatsNow(detailedStats)
+	domain.mu.Lock()
+	plan.stats.BufferStageLockWait += updateBatchStatsSince(detailedStats, lockStart)
+	lockHoldStart := updateBatchStatsNow(detailedStats)
+	defer func() {
+		plan.stats.BufferStageLockHold += updateBatchStatsSince(detailedStats, lockHoldStart)
+		domain.mu.Unlock()
+	}()
+
+	phaseStart := updateBatchStatsNow(detailedStats)
+	if hasBufferedIndexedRootRuns(domain) {
+		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+		return false, ErrConcurrentMutation
+	}
+	if domain.count != 0 {
+		if !plan.bufferedBase ||
+			!updateBatchCanReadNoIndexBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) ||
+			plan.bufferedReadGeneration != domain.writeGeneration {
+			plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+			return false, ErrConcurrentMutation
+		}
+	}
+	if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
+		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+		return false, err
+	}
+	if len(plan.meta.Indexes) != 0 {
+		plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+		return false, nil
+	}
+	plan.stats.BufferStageValidation += updateBatchStatsSince(detailedStats, phaseStart)
+
+	phaseStart = updateBatchStatsNow(detailedStats)
+	if domain.count == 0 && plan.catalog != nil {
+		c.initializeWriteDomainFromCatalogLocked(domain, plan.catalog, plan.baseCommitSeq, plan.baseSystemRoot)
+	}
+	if domain.table == nil {
+		domain.table = newCollectionRunTable(0)
+	}
+	uniqueAdds := 0
+	for _, entry := range entries {
+		_, _, _, existed := domain.table.GetEntry(entry.key)
+		if !existed {
+			uniqueAdds++
+		}
+		domain.table.SetEntry(entry.key, entry.value, page.ValuePtr{}, entry.flags)
+		if domain.primaryOnlyPendingUpdateKeys == nil {
+			domain.primaryOnlyPendingUpdateKeys = make(map[string]struct{})
+		}
+		domain.primaryOnlyPendingUpdateKeys[string(entry.key)] = struct{}{}
+	}
+	domain.primaryOnlyPendingUpdateCalls += modifiedCount
+	domain.loaded = true
+	domain.meta = plan.meta
+	domain.catalog = plan.catalog
+	domain.baseCommitSeq = plan.baseCommitSeq
+	domain.baseSystemRoot = plan.baseSystemRoot
+	domain.primaryRoot = plan.baseRootIDs[collectionPrimaryRootName(plan.meta.Name)]
+	domain.storagePolicy = plan.policies[0]
+	domain.count = saturatingAddNonNegativeInt(domain.count, uniqueAdds)
+	stagedBytes := primaryTable.Size()
+	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
+	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, uniqueAdds)
+	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
+	domain.writeGeneration++
+	domain.observePrimaryOnlyBufferedUpdateBatch(plan.stats.Items, plan.stats.Matched, plan.stats.Modified)
+	c.meta = plan.meta
+	plan.stats.BufferStageRootAppend += updateBatchStatsSince(detailedStats, phaseStart)
+	plan.stats.BufferedBatches = 1
+	return true, nil
+}
+
 func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, error) {
 	if c == nil || plan == nil {
 		return false, nil
 	}
 	if plan.directBufferedUpdate != nil {
 		return c.bufferDirectUpdateBatchPlanLocked(plan)
+	}
+	if isPrimaryOnlyNoIndexUpdateBatchPlan(plan) {
+		return c.bufferNoIndexUpdateBatchPlanLocked(plan)
 	}
 	if len(plan.deltaTables) == 0 {
 		return false, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2699,11 +2699,13 @@ func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, erro
 	if domain.table == nil {
 		domain.table = newCollectionRunTable(0)
 	}
-	if _, _, flags, found := domain.table.GetEntry(id); found && flags&node.FlagTombstone == 0 {
+	_, _, flags, found := domain.table.GetEntry(id)
+	pendingTombstone := found && flags&node.FlagTombstone != 0
+	if found && !pendingTombstone {
 		domain.mu.Unlock()
 		return nil, ErrDocumentExists
 	}
-	if domain.primaryRoot != 0 {
+	if !pendingTombstone && domain.primaryRoot != 0 {
 		exists, err := c.persistedDocumentExists(domain.primaryRoot, id)
 		if err != nil {
 			domain.mu.Unlock()
@@ -2716,7 +2718,15 @@ func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, erro
 	}
 	domain.storagePolicy = plannerOptions.dataStoragePolicy
 	domain.table.SetEntry(id, document, page.ValuePtr{}, node.FlagInline)
-	domain.count++
+	if found {
+		table, err := coalesceNoIndexBufferedTable(domain.table)
+		if err != nil {
+			domain.mu.Unlock()
+			return nil, err
+		}
+		domain.table = table
+	}
+	refreshNoIndexBufferedAccountingLocked(domain)
 	domain.writeGeneration++
 	resultID := bytes.Clone(id)
 	domain.mu.Unlock()
@@ -6552,42 +6562,12 @@ func (c *Collection) insertBatchNoIndexBuffered(
 			return nil, ErrDuplicateDocumentID
 		}
 	}
-	rootName := collectionPrimaryRootName(c.meta.Name)
-	baseRoot := catalog.rootID(rootName)
-	if len(catalog.overlayRootIDs(rootName)) == 0 {
-		if baseRoot != 0 {
-			keys := make([][]byte, len(entries))
-			for i := range entries {
-				keys[i] = entries[i].id
-			}
-			exists, err := snap.HasAnySortedAtRoot(baseRoot, keys)
-			if err != nil {
-				return nil, err
-			}
-			if exists {
-				return nil, ErrDocumentExists
-			}
-		}
-	} else {
-		for i := range entries {
-			entry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, rootName, entries[i].id)
-			if err == nil {
-				if entry.Flags&node.FlagTombstone == 0 {
-					return nil, ErrDocumentExists
-				}
-				continue
-			}
-			if !errors.Is(err, tree.ErrKeyNotFound) {
-				return nil, err
-			}
-		}
-	}
-	stats.DuplicateDocumentPreflight = time.Since(phaseStart)
-
 	domain := c.writeDomain
 	if domain == nil {
 		return nil, errPrimaryOnlyNoIndexWriteBackNotEligible
 	}
+	rootName := collectionPrimaryRootName(c.meta.Name)
+	baseRoot := catalog.rootID(rootName)
 	domain.mu.Lock()
 	defer domain.mu.Unlock()
 	read := primaryOnlyNoIndexWriteBackRead{
@@ -6606,6 +6586,46 @@ func (c *Collection) insertBatchNoIndexBuffered(
 	if domain.table == nil {
 		domain.table = newCollectionRunTable(0)
 	}
+	var persistedEntries []noIndexBatchEntry
+	for _, entry := range entries {
+		_, _, flags, found := domain.table.GetEntry(entry.id)
+		if found && flags&node.FlagTombstone == 0 {
+			return nil, ErrDocumentExists
+		}
+		if !found {
+			persistedEntries = append(persistedEntries, entry)
+		}
+	}
+	if len(catalog.overlayRootIDs(rootName)) == 0 {
+		if baseRoot != 0 && len(persistedEntries) > 0 {
+			keys := make([][]byte, len(persistedEntries))
+			for i := range persistedEntries {
+				keys[i] = persistedEntries[i].id
+			}
+			exists, err := snap.HasAnySortedAtRoot(baseRoot, keys)
+			if err != nil {
+				return nil, err
+			}
+			if exists {
+				return nil, ErrDocumentExists
+			}
+		}
+	} else {
+		for i := range persistedEntries {
+			entry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, rootName, persistedEntries[i].id)
+			if err == nil {
+				if entry.Flags&node.FlagTombstone == 0 {
+					return nil, ErrDocumentExists
+				}
+				continue
+			}
+			if !errors.Is(err, tree.ErrKeyNotFound) {
+				return nil, err
+			}
+		}
+	}
+	stats.DuplicateDocumentPreflight = time.Since(phaseStart)
+
 	replaced := false
 	for _, entry := range entries {
 		_, _, flags, found := domain.table.GetEntry(entry.id)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6962,9 +6962,7 @@ func (c *Collection) stagePrimaryOnlyNoIndexWriteBack(domain *collectionWriteDom
 		domain.table = newCollectionRunTable(0)
 	}
 	_, _, _, existed := domain.table.GetEntry(documentID)
-	key := bytes.Clone(documentID)
-	value := bytes.Clone(document)
-	domain.table.SetEntry(key, value, page.ValuePtr{}, node.FlagInline)
+	domain.table.SetEntry(documentID, document, page.ValuePtr{}, node.FlagInline)
 	if existed {
 		table, err := coalesceNoIndexBufferedTable(domain.table)
 		if err != nil {
@@ -7001,12 +6999,19 @@ func coalesceNoIndexBufferedTable(table memtable.Table) (memtable.Table, error) 
 		return nil, err
 	}
 	out := newCollectionRunTable(len(keys))
+	orderedKeys := make([][]byte, 0, len(keys))
 	for _, key := range keys {
+		orderedKeys = append(orderedKeys, key)
+	}
+	sort.Slice(orderedKeys, func(i, j int) bool {
+		return bytes.Compare(orderedKeys[i], orderedKeys[j]) < 0
+	})
+	for _, key := range orderedKeys {
 		value, ptr, flags, found := table.GetEntry(key)
 		if !found {
 			continue
 		}
-		out.SetEntry(key, bytes.Clone(value), ptr, flags)
+		out.SetEntry(key, value, ptr, flags)
 	}
 	return out, nil
 }
@@ -10233,7 +10238,7 @@ func (c *Collection) bufferNoIndexUpdateBatchPlanLocked(plan *updateBatchPlan) (
 	for _, entry := range entries {
 		_, _, _, existed := domain.table.GetEntry(entry.key)
 		replaced = replaced || existed
-		domain.table.SetEntry(entry.key, entry.value, page.ValuePtr{}, entry.flags)
+		domain.table.SetEntrySteal(entry.key, entry.value, page.ValuePtr{}, entry.flags)
 		if domain.primaryOnlyPendingUpdateKeys == nil {
 			domain.primaryOnlyPendingUpdateKeys = make(map[string]struct{})
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7221,6 +7221,7 @@ func coalesceNoIndexBufferedTable(table memtable.Table) (memtable.Table, error) 
 		}
 		out.SetEntry(key, value, ptr, flags)
 	}
+	resetCollectionRunTable(table)
 	return out, nil
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -7694,10 +7694,10 @@ func completeUpdateCombineBatchWithItemFallback(batch []collectionUpdateCombineR
 			completeUpdateCombineRequest(req, collectionUpdateCombineResult{err: reqErr})
 			continue
 		}
-		// Keep the non-error fallbacks synchronous: the original internal batch
-		// already had one item callback fail, so staging the remaining items
-		// would partially accept a failed combined execution into write-back.
-		completeUpdateCombineRequest(req, runUpdateCombineDirectSynchronous(req))
+		// The failed combined batch has not staged any rows. Retry sibling
+		// requests as independent Update calls so eligible no-index updates keep
+		// the same write-back contract as the public direct path.
+		completeUpdateCombineRequest(req, runUpdateCombineDirect(req))
 	}
 	return true
 }
@@ -8211,6 +8211,7 @@ type updateBatchPlan struct {
 	uniqueSecondaryIndexByRoot  []int
 	canBufferIndexedUpdateBatch bool
 	bufferedBase                bool
+	bufferedReadNoIndex         bool
 	bufferedReadGeneration      uint64
 	bufferedReadBlocked         bool
 	scratch                     *updateBatchPlanScratch
@@ -8565,6 +8566,7 @@ func appendUpdateBatchPlanScratchDocument(scratch *updateBatchPlanScratch, docum
 
 type updateBatchBufferedRead struct {
 	enabled         bool
+	noIndex         bool
 	primaryEntries  []updateBatchBufferedEntry
 	primaryBuffer   *updateBatchBufferedEntryBuffer
 	writeGeneration uint64
@@ -8702,6 +8704,17 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMode) ([]UpdateBatchResult, error) {
 	if c.shouldPlanUpdateBatchWithBufferedWrites(mode) {
 		useBufferedRead := true
+		noIndexReplans := 0
+		replanNoIndex := func(cause error) error {
+			noIndexReplans++
+			if noIndexReplans > maxCollectionMutationRetries {
+				if cause == nil {
+					cause = ErrConcurrentMutation
+				}
+				return collectionMutationRetryExhausted(cause)
+			}
+			return nil
+		}
 		for {
 			plan, err := c.buildUpdateBatchPlan(items, mode, useBufferedRead)
 			if err != nil {
@@ -8715,6 +8728,13 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 			err = c.withMutationLock(func() error {
 				if len(plan.deltaTables) == 0 && plan.directBufferedUpdate == nil {
 					if plan.bufferedReadBlocked && useBufferedRead {
+						if c.hasPendingNoIndexBufferedWrites() {
+							if err := replanNoIndex(ErrConcurrentMutation); err != nil {
+								return err
+							}
+							replan = true
+							return nil
+						}
 						if err := c.flushBufferedWrites(); err != nil {
 							return err
 						}
@@ -8724,6 +8744,13 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 					}
 					if plan.bufferedBase && !c.bufferedUpdateBatchPlanStillCurrent(plan) {
 						if useBufferedRead {
+							if plan.bufferedReadNoIndex {
+								if err := replanNoIndex(ErrConcurrentMutation); err != nil {
+									return err
+								}
+								replan = true
+								return nil
+							}
 							if err := c.flushBufferedWrites(); err != nil {
 								return err
 							}
@@ -8743,6 +8770,13 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 				buffered, bufferErr := c.bufferUpdateBatchPlanLocked(plan)
 				if bufferErr != nil {
 					if errors.Is(bufferErr, ErrConcurrentMutation) && useBufferedRead {
+						if plan.bufferedReadNoIndex || isPrimaryOnlyNoIndexUpdateBatchPlan(plan) {
+							if err := replanNoIndex(bufferErr); err != nil {
+								return err
+							}
+							replan = true
+							return nil
+						}
 						if err := c.flushBufferedWrites(); err != nil {
 							return err
 						}
@@ -8873,6 +8907,24 @@ func (c *Collection) bufferedUpdateBatchPlanStillCurrent(plan *updateBatchPlan) 
 	return (updateBatchCanReadBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot) ||
 		updateBatchCanReadNoIndexBufferedDomainLocked(domain, plan.meta, plan.baseSystemRoot)) &&
 		plan.bufferedReadGeneration == domain.writeGeneration
+}
+
+func (c *Collection) hasPendingNoIndexBufferedWrites() bool {
+	if c == nil || c.writeDomain == nil {
+		return false
+	}
+	domain := c.writeDomain
+	domain.mu.RLock()
+	defer domain.mu.RUnlock()
+	return hasPendingNoIndexBufferedWritesLocked(domain)
+}
+
+func hasPendingNoIndexBufferedWritesLocked(domain *collectionWriteDomain) bool {
+	return domain != nil &&
+		domain.count > 0 &&
+		domain.table != nil &&
+		domain.table.Len() > 0 &&
+		!hasBufferedIndexedRootRuns(domain)
 }
 
 func (c *Collection) withMutationLock(fn func() error) error {
@@ -9110,6 +9162,24 @@ func snapshotUpdateBatchBufferedRead(domain *collectionWriteDomain, meta Collect
 	return read, templateRuns, blocked, err
 }
 
+func (c *Collection) snapshotUpdateBatchBufferedReadForPlan(domain *collectionWriteDomain, meta CollectionMeta, baseCommitSeq, baseSystemRoot uint64, items []UpdateBatchItem, documentFormat DocumentFormat) (updateBatchBufferedRead, []memtable.Table, bool, error) {
+	read, templateRuns, blocked, err := snapshotUpdateBatchBufferedRead(domain, meta, baseSystemRoot, items, documentFormat)
+	if err != nil || !blocked || domain == nil {
+		return read, templateRuns, blocked, err
+	}
+
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	if !hasPendingNoIndexBufferedWritesLocked(domain) {
+		return read, templateRuns, blocked, nil
+	}
+	if _, err := c.revalidateBufferedWriteDomainLocked(domain, baseCommitSeq, baseSystemRoot); err != nil {
+		return updateBatchBufferedRead{}, nil, false, err
+	}
+	read, templateRuns, blocked, _, err = snapshotUpdateBatchBufferedReadLocked(domain, meta, baseSystemRoot, items, documentFormat, false)
+	return read, templateRuns, blocked, err
+}
+
 func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64, items []UpdateBatchItem, documentFormat DocumentFormat, allowPrimaryRunIndexBuild bool) (updateBatchBufferedRead, []memtable.Table, bool, bool, error) {
 	if updateBatchCanReadNoIndexBufferedDomainLocked(domain, meta, baseSystemRoot) {
 		primaryEntries, primaryBuffer, err := snapshotUpdateBatchNoIndexBufferedPrimaryEntriesLocked(domain, items)
@@ -9118,6 +9188,7 @@ func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta C
 		}
 		return updateBatchBufferedRead{
 			enabled:         true,
+			noIndex:         true,
 			primaryEntries:  primaryEntries,
 			primaryBuffer:   primaryBuffer,
 			writeGeneration: domain.writeGeneration,
@@ -9210,7 +9281,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	defer func() { resetCollectionTables(bufferedTemplateRuns) }()
 	bufferedReadBlocked := false
 	if domain := c.writeDomain; useBufferedRead && domain != nil {
-		bufferedRead, bufferedTemplateRuns, bufferedReadBlocked, err = snapshotUpdateBatchBufferedRead(domain, meta, baseSystemRoot, items, plannerOptions.documentFormat)
+		bufferedRead, bufferedTemplateRuns, bufferedReadBlocked, err = c.snapshotUpdateBatchBufferedReadForPlan(domain, meta, baseCommitSeq, baseSystemRoot, items, plannerOptions.documentFormat)
 		if err != nil {
 			_ = snap.Close()
 			return nil, err
@@ -9247,6 +9318,8 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			baseCommitSeq:          baseCommitSeq,
 			rootNames:              []string{primaryRootName},
 			baseRootIDs:            map[string]uint64{primaryRootName: primaryRoot},
+			bufferedBase:           bufferedRead.enabled,
+			bufferedReadNoIndex:    bufferedRead.noIndex,
 			bufferedReadGeneration: bufferedRead.writeGeneration,
 			bufferedReadBlocked:    bufferedReadBlocked,
 		}
@@ -9367,6 +9440,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			baseRootIDs:                baseRootIDs,
 			uniqueSecondaryIndexByRoot: uniqueSecondary,
 			bufferedBase:               bufferedRead.enabled,
+			bufferedReadNoIndex:        bufferedRead.noIndex,
 			bufferedReadGeneration:     bufferedRead.writeGeneration,
 			bufferedReadBlocked:        bufferedReadBlocked,
 			scratch:                    scratch,
@@ -9538,6 +9612,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			uniqueSecondaryIndexByRoot:  uniqueSecondary,
 			canBufferIndexedUpdateBatch: canBufferIndexedUpdateBatch,
 			bufferedBase:                bufferedRead.enabled,
+			bufferedReadNoIndex:         bufferedRead.noIndex,
 			bufferedReadGeneration:      bufferedRead.writeGeneration,
 			bufferedReadBlocked:         bufferedReadBlocked,
 			policies:                    policies,
@@ -9737,6 +9812,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		uniqueSecondaryIndexByRoot:  uniqueSecondary,
 		canBufferIndexedUpdateBatch: canBufferIndexedUpdateBatch,
 		bufferedBase:                bufferedRead.enabled,
+		bufferedReadNoIndex:         bufferedRead.noIndex,
 		bufferedReadGeneration:      bufferedRead.writeGeneration,
 		bufferedReadBlocked:         bufferedReadBlocked,
 		policies:                    policies,

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6962,25 +6962,69 @@ func (c *Collection) stagePrimaryOnlyNoIndexWriteBack(domain *collectionWriteDom
 		domain.table = newCollectionRunTable(0)
 	}
 	_, _, _, existed := domain.table.GetEntry(documentID)
-	if !existed {
-		domain.count++
-		domain.mutableCount++
-	}
 	key := bytes.Clone(documentID)
 	value := bytes.Clone(document)
 	domain.table.SetEntry(key, value, page.ValuePtr{}, node.FlagInline)
+	if existed {
+		table, err := coalesceNoIndexBufferedTable(domain.table)
+		if err != nil {
+			return err
+		}
+		domain.table = table
+	}
 	if domain.primaryOnlyPendingUpdateKeys == nil {
 		domain.primaryOnlyPendingUpdateKeys = make(map[string]struct{})
 	}
 	domain.primaryOnlyPendingUpdateKeys[string(documentID)] = struct{}{}
 	domain.primaryOnlyPendingUpdateCalls++
-	stagedBytes := int64(len(key) + len(value))
-	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
-	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
+	refreshNoIndexBufferedAccountingLocked(domain)
 	domain.writeGeneration++
 	domain.observePrimaryOnlyBufferedUpdateBatch(1, 1, 1)
 	c.meta = read.meta
 	return nil
+}
+
+func coalesceNoIndexBufferedTable(table memtable.Table) (memtable.Table, error) {
+	if table == nil {
+		return newCollectionRunTable(0), nil
+	}
+	keys := make(map[string][]byte, max(0, table.Len()))
+	it := table.NewIterator(nil, nil)
+	for it.Valid() {
+		key := bytes.Clone(it.UnsafeKey())
+		keys[string(key)] = key
+		it.Next()
+	}
+	err := it.Error()
+	_ = it.Close()
+	if err != nil {
+		return nil, err
+	}
+	out := newCollectionRunTable(len(keys))
+	for _, key := range keys {
+		value, ptr, flags, found := table.GetEntry(key)
+		if !found {
+			continue
+		}
+		out.SetEntry(key, bytes.Clone(value), ptr, flags)
+	}
+	return out, nil
+}
+
+func refreshNoIndexBufferedAccountingLocked(domain *collectionWriteDomain) {
+	if domain == nil || domain.table == nil {
+		if domain != nil {
+			domain.count = 0
+			domain.bufferedBytes = 0
+			domain.mutableCount = 0
+			domain.mutableBytes = 0
+		}
+		return
+	}
+	domain.count = domain.table.Len()
+	domain.bufferedBytes = domain.table.Size()
+	domain.mutableCount = domain.count
+	domain.mutableBytes = domain.bufferedBytes
 }
 
 // UpdateBatch applies a unique set of document updates under one collection
@@ -7650,6 +7694,9 @@ func completeUpdateCombineBatchWithItemFallback(batch []collectionUpdateCombineR
 			completeUpdateCombineRequest(req, collectionUpdateCombineResult{err: reqErr})
 			continue
 		}
+		// Keep the non-error fallbacks synchronous: the original internal batch
+		// already had one item callback fail, so staging the remaining items
+		// would partially accept a failed combined execution into write-back.
 		completeUpdateCombineRequest(req, runUpdateCombineDirectSynchronous(req))
 	}
 	return true
@@ -10106,17 +10153,22 @@ func (c *Collection) bufferNoIndexUpdateBatchPlanLocked(plan *updateBatchPlan) (
 	if domain.table == nil {
 		domain.table = newCollectionRunTable(0)
 	}
-	uniqueAdds := 0
+	replaced := false
 	for _, entry := range entries {
 		_, _, _, existed := domain.table.GetEntry(entry.key)
-		if !existed {
-			uniqueAdds++
-		}
+		replaced = replaced || existed
 		domain.table.SetEntry(entry.key, entry.value, page.ValuePtr{}, entry.flags)
 		if domain.primaryOnlyPendingUpdateKeys == nil {
 			domain.primaryOnlyPendingUpdateKeys = make(map[string]struct{})
 		}
 		domain.primaryOnlyPendingUpdateKeys[string(entry.key)] = struct{}{}
+	}
+	if replaced {
+		table, err := coalesceNoIndexBufferedTable(domain.table)
+		if err != nil {
+			return false, err
+		}
+		domain.table = table
 	}
 	domain.primaryOnlyPendingUpdateCalls += modifiedCount
 	domain.loaded = true
@@ -10126,11 +10178,7 @@ func (c *Collection) bufferNoIndexUpdateBatchPlanLocked(plan *updateBatchPlan) (
 	domain.baseSystemRoot = plan.baseSystemRoot
 	domain.primaryRoot = plan.baseRootIDs[collectionPrimaryRootName(plan.meta.Name)]
 	domain.storagePolicy = plan.policies[0]
-	domain.count = saturatingAddNonNegativeInt(domain.count, uniqueAdds)
-	stagedBytes := primaryTable.Size()
-	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedBytes)
-	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, uniqueAdds)
-	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedBytes)
+	refreshNoIndexBufferedAccountingLocked(domain)
 	domain.writeGeneration++
 	domain.observePrimaryOnlyBufferedUpdateBatch(plan.stats.Items, plan.stats.Matched, plan.stats.Modified)
 	c.meta = plan.meta

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6028,10 +6028,6 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 		})
 		return nil, nil
 	}
-	if err := c.flushBufferedNoIndex(); err != nil {
-		return nil, err
-	}
-
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
 		return nil, backenddb.ErrClosed
@@ -6114,6 +6110,9 @@ func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON b
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
 
+	if len(meta.Indexes) == 0 && c.hasPendingNoIndexBufferedWrites() && primaryOnlyNoIndexWriteBackSupportsFormat(plannerOptions.documentFormat) {
+		return c.insertBatchNoIndexBuffered(catalog, snap, baseCommitSeq, baseSystemRoot, plannerOptions, ids, documents)
+	}
 	if len(meta.Indexes) == 0 && plannerOptions.documentFormat == DocumentFormatJSON {
 		return c.insertBatchNoIndex(catalog, snap, baseCommitSeq, baseSystemRoot, plannerOptions, ids, documents)
 	}
@@ -6505,6 +6504,132 @@ func (c *Collection) insertBatchNoIndex(
 	return resultIDs, nil
 }
 
+func (c *Collection) insertBatchNoIndexBuffered(
+	catalog *collectionCatalog,
+	snap *backenddb.Snapshot,
+	baseCommitSeq uint64,
+	baseSystemRoot uint64,
+	plannerOptions collectionOptions,
+	ids, documents [][]byte,
+) ([][]byte, error) {
+	defer func() { _ = snap.Close() }()
+	if len(ids) != len(documents) {
+		return nil, fmt.Errorf("collections: caller-provided batch ids length mismatch")
+	}
+	stats := CollectionInsertStats{
+		Documents: len(documents),
+		Indexes:   len(c.meta.Indexes),
+	}
+	resultIDs, err := cloneBatchDocumentIDs(ids)
+	if err != nil {
+		return nil, err
+	}
+	phaseStart := time.Now()
+	preparedDocuments, templateRecords, _, err := prepareInsertDocuments(documents, plannerOptions)
+	stats.PrepareDocuments = time.Since(phaseStart)
+	if err != nil {
+		return nil, err
+	}
+	if len(templateRecords) != 0 {
+		return nil, errPrimaryOnlyNoIndexWriteBackNotEligible
+	}
+	if len(preparedDocuments) != len(documents) {
+		return nil, errors.New("collections: no-index insert prepared unexpected document count")
+	}
+	entries := make([]noIndexBatchEntry, len(preparedDocuments))
+	for i := range preparedDocuments {
+		entries[i] = noIndexBatchEntry{
+			id:       resultIDs[i],
+			document: preparedDocuments[i],
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return bytes.Compare(entries[i].id, entries[j].id) < 0
+	})
+	phaseStart = time.Now()
+	for i := 1; i < len(entries); i++ {
+		if bytes.Equal(entries[i-1].id, entries[i].id) {
+			return nil, ErrDuplicateDocumentID
+		}
+	}
+	rootName := collectionPrimaryRootName(c.meta.Name)
+	baseRoot := catalog.rootID(rootName)
+	if len(catalog.overlayRootIDs(rootName)) == 0 {
+		if baseRoot != 0 {
+			keys := make([][]byte, len(entries))
+			for i := range entries {
+				keys[i] = entries[i].id
+			}
+			exists, err := snap.HasAnySortedAtRoot(baseRoot, keys)
+			if err != nil {
+				return nil, err
+			}
+			if exists {
+				return nil, ErrDocumentExists
+			}
+		}
+	} else {
+		for i := range entries {
+			entry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, rootName, entries[i].id)
+			if err == nil {
+				if entry.Flags&node.FlagTombstone == 0 {
+					return nil, ErrDocumentExists
+				}
+				continue
+			}
+			if !errors.Is(err, tree.ErrKeyNotFound) {
+				return nil, err
+			}
+		}
+	}
+	stats.DuplicateDocumentPreflight = time.Since(phaseStart)
+
+	domain := c.writeDomain
+	if domain == nil {
+		return nil, errPrimaryOnlyNoIndexWriteBackNotEligible
+	}
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	read := primaryOnlyNoIndexWriteBackRead{
+		catalog:         catalog,
+		meta:            catalog.meta,
+		options:         plannerOptions,
+		primaryRootName: rootName,
+		primaryRoot:     baseRoot,
+		baseCommitSeq:   baseCommitSeq,
+		baseSystemRoot:  baseSystemRoot,
+		writeGeneration: domain.writeGeneration,
+	}
+	if err := c.validatePrimaryOnlyNoIndexWriteBackDomainLocked(domain, read); err != nil {
+		return nil, err
+	}
+	if domain.table == nil {
+		domain.table = newCollectionRunTable(0)
+	}
+	replaced := false
+	for _, entry := range entries {
+		_, _, flags, found := domain.table.GetEntry(entry.id)
+		if found && flags&node.FlagTombstone == 0 {
+			return nil, ErrDocumentExists
+		}
+		replaced = replaced || found
+		domain.table.SetEntry(entry.id, entry.document, page.ValuePtr{}, node.FlagInline)
+	}
+	if replaced {
+		table, err := coalesceNoIndexBufferedTable(domain.table)
+		if err != nil {
+			return nil, err
+		}
+		domain.table = table
+	}
+	refreshNoIndexBufferedAccountingLocked(domain)
+	domain.writeGeneration++
+	stats.Runs = 1
+	c.meta = catalog.meta
+	c.setLastInsertStats(stats)
+	return resultIDs, nil
+}
+
 func (c *Collection) Delete(documentID []byte) error {
 	_, err := c.DeleteDocument(documentID)
 	return err
@@ -6527,6 +6652,24 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 	}
 	unlockMutation := c.lockMutation()
 	defer unlockMutation.Unlock()
+	if c.hasPendingNoIndexBufferedWrites() {
+		var lastErr error
+		for attempt := 0; attempt < maxCollectionMutationRetries; attempt++ {
+			deleted, handled, err := c.deletePrimaryOnlyNoIndexWriteBack(documentID)
+			if errors.Is(err, ErrConcurrentMutation) {
+				lastErr = err
+				waitBeforeCollectionMutationRetry(attempt)
+				continue
+			}
+			if handled {
+				return deleted, err
+			}
+			break
+		}
+		if lastErr != nil {
+			return false, collectionMutationRetryExhausted(lastErr)
+		}
+	}
 	if err := c.flushBufferedWrites(); err != nil {
 		return false, err
 	}
@@ -6855,6 +6998,27 @@ func (c *Collection) updatePrimaryOnlyNoIndexWriteBack(documentID []byte, update
 	return true, true, true, nil
 }
 
+func (c *Collection) deletePrimaryOnlyNoIndexWriteBack(documentID []byte) (bool, bool, error) {
+	domain := c.writeDomain
+	if domain == nil {
+		return false, false, nil
+	}
+	read, handled, err := c.readPrimaryOnlyNoIndexWriteBackCurrent(domain, documentID)
+	if !handled || err != nil {
+		return false, handled, err
+	}
+	if !read.found {
+		if err := c.validatePrimaryOnlyNoIndexWriteBackDomain(domain, read); err != nil {
+			return false, true, err
+		}
+		return false, true, nil
+	}
+	if err := c.stagePrimaryOnlyNoIndexTombstone(domain, read, documentID); err != nil {
+		return false, true, err
+	}
+	return true, true, nil
+}
+
 func (c *Collection) readPrimaryOnlyNoIndexWriteBackCurrent(domain *collectionWriteDomain, documentID []byte) (primaryOnlyNoIndexWriteBackRead, bool, error) {
 	var read primaryOnlyNoIndexWriteBackRead
 	if domain == nil {
@@ -6978,6 +7142,30 @@ func (c *Collection) stagePrimaryOnlyNoIndexWriteBack(domain *collectionWriteDom
 	refreshNoIndexBufferedAccountingLocked(domain)
 	domain.writeGeneration++
 	domain.observePrimaryOnlyBufferedUpdateBatch(1, 1, 1)
+	c.meta = read.meta
+	return nil
+}
+
+func (c *Collection) stagePrimaryOnlyNoIndexTombstone(domain *collectionWriteDomain, read primaryOnlyNoIndexWriteBackRead, documentID []byte) error {
+	domain.mu.Lock()
+	defer domain.mu.Unlock()
+	if err := c.validatePrimaryOnlyNoIndexWriteBackDomainLocked(domain, read); err != nil {
+		return err
+	}
+	if domain.table == nil {
+		domain.table = newCollectionRunTable(0)
+	}
+	_, _, _, existed := domain.table.GetEntry(documentID)
+	domain.table.SetEntry(documentID, nil, page.ValuePtr{}, node.FlagTombstone)
+	if existed {
+		table, err := coalesceNoIndexBufferedTable(domain.table)
+		if err != nil {
+			return err
+		}
+		domain.table = table
+	}
+	refreshNoIndexBufferedAccountingLocked(domain)
+	domain.writeGeneration++
 	c.meta = read.meta
 	return nil
 }
@@ -8834,7 +9022,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 	}
 
 	if err := c.withMutationLock(func() error {
-		return c.flushBufferedWrites()
+		return c.flushBufferedWritesForUpdateBatchNonBarrier()
 	}); err != nil {
 		return nil, err
 	}
@@ -8849,7 +9037,7 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 	defer plan.close()
 	if len(plan.deltaTables) == 0 && plan.directBufferedUpdate == nil {
 		if err := c.withMutationLock(func() error {
-			if err := c.flushBufferedWrites(); err != nil {
+			if err := c.flushBufferedWritesForUpdateBatchNonBarrier(); err != nil {
 				return err
 			}
 			if err := c.validateUpdateBatchPlanRootDescriptors(plan); err != nil {
@@ -8878,13 +9066,13 @@ func (c *Collection) updateBatchOnce(items []UpdateBatchItem, mode updateBatchMo
 			return nil
 		}
 		if plan.directBufferedUpdate != nil {
-			if err := c.flushBufferedWrites(); err != nil {
+			if err := c.flushBufferedWritesForUpdateBatchNonBarrier(); err != nil {
 				return err
 			}
 			return ErrConcurrentMutation
 		}
 		var publishErr error
-		if err := c.flushBufferedWrites(); err != nil {
+		if err := c.flushBufferedWritesForUpdateBatchNonBarrier(); err != nil {
 			return err
 		}
 		results, publishErr = c.publishUpdateBatchPlanLocked(plan)
@@ -8922,6 +9110,13 @@ func (c *Collection) hasPendingNoIndexBufferedWrites() bool {
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()
 	return hasPendingNoIndexBufferedWritesLocked(domain)
+}
+
+func (c *Collection) flushBufferedWritesForUpdateBatchNonBarrier() error {
+	if c.hasPendingNoIndexBufferedWrites() {
+		return ErrConcurrentMutation
+	}
+	return c.flushBufferedWrites()
 }
 
 func hasPendingNoIndexBufferedWritesLocked(domain *collectionWriteDomain) bool {
@@ -12059,9 +12254,6 @@ func (c *Collection) scanIndexRange(indexName string, opts IndexRangeOptions, fn
 	if opts.Desc {
 		return false, false, errors.New("collections: descending index range scans are not supported")
 	}
-	if err := c.flushBufferedNoIndex(); err != nil {
-		return false, false, err
-	}
 	domain := c.writeDomain
 	domainLocked := false
 	if domain != nil {
@@ -12516,10 +12708,12 @@ func (c *Collection) ScanDocuments(maxDocuments int) ([]DocumentRecord, bool, er
 	return out, truncated, nil
 }
 
-// ScanDocumentsFunc flushes buffered writes before acquiring a snapshot, then
-// calls fn for primary collection records until maxDocuments is reached, the
-// collection is exhausted, or fn returns false. The returned boolean is true
-// only when additional documents were present beyond the maxDocuments limit.
+// ScanDocumentsFunc drains indexed buffered writes before acquiring a snapshot,
+// then calls fn for primary collection records until maxDocuments is reached,
+// the collection is exhausted, or fn returns false. Primary-only no-index
+// staged updates are not published by scans; callers that require durable scan
+// visibility should Flush first. The returned boolean is true only when
+// additional documents were present beyond the maxDocuments limit.
 func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord) (bool, error)) (bool, error) {
 	if c == nil {
 		return false, errCollectionNil
@@ -12533,8 +12727,10 @@ func (c *Collection) ScanDocumentsFunc(maxDocuments int, fn func(DocumentRecord)
 	if fn == nil {
 		return false, errors.New("collections: scan callback is nil")
 	}
-	if err := c.flushBufferedWrites(); err != nil {
-		return false, err
+	if !c.hasPendingNoIndexBufferedWrites() {
+		if err := c.flushBufferedWrites(); err != nil {
+			return false, err
+		}
 	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1380,6 +1380,21 @@ func TestPrimaryOnlyNoIndexUpdateCounters(t *testing.T) {
 	if got := stats.PrimaryOnlyCoalescedDocs - statsBefore.PrimaryOnlyCoalescedDocs; got != 0 {
 		t.Fatalf("primary-only coalesced docs before flush delta=%d want 0", got)
 	}
+	if got := stats.RootDeltaPlanPrimaryRoots - statsBefore.RootDeltaPlanPrimaryRoots; got != 0 {
+		t.Fatalf("root delta primary roots before flush delta=%d want 0", got)
+	}
+	if got := stats.RootDeltaPlanTemplateRoots - statsBefore.RootDeltaPlanTemplateRoots; got != 0 {
+		t.Fatalf("root delta template roots before flush delta=%d want 0", got)
+	}
+	if got := stats.RootDeltaPlanIndexStateRoots - statsBefore.RootDeltaPlanIndexStateRoots; got != 0 {
+		t.Fatalf("root delta index-state roots before flush delta=%d want 0", got)
+	}
+	if got := stats.RootDeltaPlanSecondaryRoots - statsBefore.RootDeltaPlanSecondaryRoots; got != 0 {
+		t.Fatalf("root delta secondary roots before flush delta=%d want 0", got)
+	}
+	if got := stats.RootDeltaPlanEntries - statsBefore.RootDeltaPlanEntries; got != 0 {
+		t.Fatalf("root delta entries before flush delta=%d want 0", got)
+	}
 
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush staged update: %v", err)
@@ -1408,6 +1423,27 @@ func TestPrimaryOnlyNoIndexUpdateCounters(t *testing.T) {
 	}
 	if got, want := afterFlush.PrimaryOnlyCoalescedDocs-statsBefore.PrimaryOnlyCoalescedDocs, uint64(1); got != want {
 		t.Fatalf("primary-only coalesced docs delta=%d want %d", got, want)
+	}
+	if got, want := afterFlush.RootDeltaPlanPrimaryRoots-statsBefore.RootDeltaPlanPrimaryRoots, uint64(1); got != want {
+		t.Fatalf("root delta primary roots after flush delta=%d want %d", got, want)
+	}
+	if got := afterFlush.RootDeltaPlanTemplateRoots - statsBefore.RootDeltaPlanTemplateRoots; got != 0 {
+		t.Fatalf("root delta template roots after flush delta=%d want 0", got)
+	}
+	if got := afterFlush.RootDeltaPlanIndexStateRoots - statsBefore.RootDeltaPlanIndexStateRoots; got != 0 {
+		t.Fatalf("root delta index-state roots after flush delta=%d want 0", got)
+	}
+	if got := afterFlush.RootDeltaPlanSecondaryRoots - statsBefore.RootDeltaPlanSecondaryRoots; got != 0 {
+		t.Fatalf("root delta secondary roots after flush delta=%d want 0", got)
+	}
+	if got, want := afterFlush.RootDeltaPlanEntries-statsBefore.RootDeltaPlanEntries, uint64(1); got != want {
+		t.Fatalf("root delta entries after flush delta=%d want %d", got, want)
+	}
+	if got := afterFlush.RootDeltaPlanKeyBytes - statsBefore.RootDeltaPlanKeyBytes; got != uint64(len("u1")) {
+		t.Fatalf("root delta key bytes after flush delta=%d want %d", got, len("u1"))
+	}
+	if got := afterFlush.RootDeltaPlanValueBytes - statsBefore.RootDeltaPlanValueBytes; got == 0 {
+		t.Fatal("root delta value bytes after flush delta=0 want positive")
 	}
 	exported := mgr.Stats()
 	for _, key := range []string{
@@ -7552,9 +7588,14 @@ func TestCollectionUpdateCombinerRunBatchPreservesIndependentItemErrorOutcomes(t
 	); err != nil {
 		t.Fatalf("insert batch: %v", err)
 	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert batch: %v", err)
+	}
 
 	itemErr := errors.New("bad update")
-	combiner := &collectionUpdateCombiner{maxBatch: 8}
+	beforeState := d.State()
+	beforeRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	combiner := &collectionUpdateCombiner{maxBatch: 8, domain: col.writeDomain}
 	firstCalls := 0
 	secondCalls := 0
 	requests := []collectionUpdateCombineRequest{
@@ -7592,6 +7633,15 @@ func TestCollectionUpdateCombinerRunBatchPreservesIndependentItemErrorOutcomes(t
 	if firstCalls == 0 || secondCalls != 1 {
 		t.Fatalf("callback calls first=%d second=%d want first called and second called once", firstCalls, secondCalls)
 	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("item-error fallback advanced commit seq from %d to %d before flush", beforeState.CommitSeq, got)
+	}
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+		t.Fatalf("item-error fallback published primary root from %d to %d before flush", beforeRoot, got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen != 1 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after item-error fallback=%+v want one no-index row", state)
+	}
 	got, err := col.Get([]byte("u1"))
 	if err != nil {
 		t.Fatalf("get u1: %v", err)
@@ -7605,6 +7655,15 @@ func TestCollectionUpdateCombinerRunBatchPreservesIndependentItemErrorOutcomes(t
 	}
 	if !bytes.Contains(got, []byte(`"score":0`)) {
 		t.Fatalf("u2 document=%s want unchanged score", got)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush item-error fallback update: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq+1 {
+		t.Fatalf("item-error fallback flush commit seq=%d want %d", got, beforeState.CommitSeq+1)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 {
+		t.Fatalf("pending state after item-error fallback flush=%+v want empty", state)
 	}
 }
 
@@ -7629,8 +7688,13 @@ func TestCollectionUpdateCombinerRunBatchRecoversCallbackPanic(t *testing.T) {
 	); err != nil {
 		t.Fatalf("insert batch: %v", err)
 	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert batch: %v", err)
+	}
 
-	combiner := &collectionUpdateCombiner{maxBatch: 8}
+	beforeState := d.State()
+	beforeRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	combiner := &collectionUpdateCombiner{maxBatch: 8, domain: col.writeDomain}
 	secondCalls := 0
 	requests := []collectionUpdateCombineRequest{
 		{
@@ -7667,12 +7731,123 @@ func TestCollectionUpdateCombinerRunBatchRecoversCallbackPanic(t *testing.T) {
 	if secondCalls != 1 {
 		t.Fatalf("second callback calls=%d want 1", secondCalls)
 	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("panic fallback advanced commit seq from %d to %d before flush", beforeState.CommitSeq, got)
+	}
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+		t.Fatalf("panic fallback published primary root from %d to %d before flush", beforeRoot, got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen != 1 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after panic fallback=%+v want one no-index row", state)
+	}
 	got, err := col.Get([]byte("u2"))
 	if err != nil {
 		t.Fatalf("get u2: %v", err)
 	}
 	if !bytes.Contains(got, []byte(`"score":2`)) {
 		t.Fatalf("u2 document=%s want updated score", got)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush panic fallback update: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq+1 {
+		t.Fatalf("panic fallback flush commit seq=%d want %d", got, beforeState.CommitSeq+1)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 {
+		t.Fatalf("pending state after panic fallback flush=%+v want empty", state)
+	}
+}
+
+func TestCollectionUpdateCombinerRunBatchDuplicateIDsUseSerialNoIndexWriteBack(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"count":0}`)}); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert batch: %v", err)
+	}
+
+	beforeState := d.State()
+	beforeRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	combiner := &collectionUpdateCombiner{maxBatch: 8, domain: col.writeDomain}
+	firstCalls := 0
+	secondCalls := 0
+	requests := []collectionUpdateCombineRequest{
+		{
+			collection: col,
+			documentID: []byte("u1"),
+			update: func(current []byte) ([]byte, bool, error) {
+				firstCalls++
+				if !bytes.Equal(current, []byte(`{"count":0}`)) {
+					return nil, false, fmt.Errorf("first current=%q want count 0", current)
+				}
+				return []byte(`{"count":1}`), true, nil
+			},
+			done: make(chan collectionUpdateCombineResult, 1),
+		},
+		{
+			collection: col,
+			documentID: []byte("u1"),
+			update: func(current []byte) ([]byte, bool, error) {
+				secondCalls++
+				if !bytes.Equal(current, []byte(`{"count":1}`)) {
+					return nil, false, fmt.Errorf("second current=%q want staged count 1", current)
+				}
+				return []byte(`{"count":2}`), true, nil
+			},
+			done: make(chan collectionUpdateCombineResult, 1),
+		},
+	}
+	combiner.runBatch(requests)
+	for i := range requests {
+		result := <-requests[i].done
+		if result.err != nil {
+			t.Fatalf("request %d err=%v", i, result.err)
+		}
+		if !result.matched || !result.modified {
+			t.Fatalf("request %d matched=%v modified=%v want true,true", i, result.matched, result.modified)
+		}
+	}
+	if firstCalls != 1 || secondCalls != 1 {
+		t.Fatalf("callback calls first=%d second=%d want 1,1", firstCalls, secondCalls)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("duplicate-id fallback advanced commit seq from %d to %d before flush", beforeState.CommitSeq, got)
+	}
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+		t.Fatalf("duplicate-id fallback published primary root from %d to %d before flush", beforeRoot, got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen != 1 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after duplicate-id fallback=%+v want one no-index row", state)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if want := []byte(`{"count":2}`); !bytes.Equal(got, want) {
+		t.Fatalf("u1 document=%q want %q", got, want)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush duplicate-id fallback update: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq+1 {
+		t.Fatalf("duplicate-id fallback flush commit seq=%d want %d", got, beforeState.CommitSeq+1)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 {
+		t.Fatalf("pending state after duplicate-id fallback flush=%+v want empty", state)
 	}
 }
 

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -1368,19 +1368,45 @@ func TestPrimaryOnlyNoIndexUpdateCounters(t *testing.T) {
 	if got, want := stats.PrimaryOnlyModified-statsBefore.PrimaryOnlyModified, uint64(1); got != want {
 		t.Fatalf("primary-only modified delta=%d want %d", got, want)
 	}
-	if got, want := stats.PrimaryOnlyRootPublishes-statsBefore.PrimaryOnlyRootPublishes, uint64(1); got != want {
-		t.Fatalf("primary-only root publishes delta=%d want %d", got, want)
+	if got, want := stats.PrimaryOnlyBufferedCalls-statsBefore.PrimaryOnlyBufferedCalls, uint64(1); got != want {
+		t.Fatalf("primary-only buffered calls delta=%d want %d", got, want)
 	}
-	if got, want := stats.PrimaryOnlyRootDeltaEntries-statsBefore.PrimaryOnlyRootDeltaEntries, uint64(1); got != want {
-		t.Fatalf("primary-only root delta entries delta=%d want %d", got, want)
+	if got := stats.PrimaryOnlyRootPublishes - statsBefore.PrimaryOnlyRootPublishes; got != 0 {
+		t.Fatalf("primary-only root publishes before flush delta=%d want 0", got)
 	}
-	if got := stats.PrimaryOnlyRootDeltaKeyBytes - statsBefore.PrimaryOnlyRootDeltaKeyBytes; got != uint64(len("u1")) {
+	if got := stats.PrimaryOnlyRootDeltaEntries - statsBefore.PrimaryOnlyRootDeltaEntries; got != 0 {
+		t.Fatalf("primary-only root delta entries before flush delta=%d want 0", got)
+	}
+	if got := stats.PrimaryOnlyCoalescedDocs - statsBefore.PrimaryOnlyCoalescedDocs; got != 0 {
+		t.Fatalf("primary-only coalesced docs before flush delta=%d want 0", got)
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush staged update: %v", err)
+	}
+	afterFlush := mgr.StatsSnapshot()
+	if got, want := afterFlush.PrimaryOnlyUpdateCalls-statsBefore.PrimaryOnlyUpdateCalls, uint64(1); got != want {
+		t.Fatalf("primary-only update calls after flush delta=%d want %d", got, want)
+	}
+	if got, want := afterFlush.PrimaryOnlyMatched-statsBefore.PrimaryOnlyMatched, uint64(1); got != want {
+		t.Fatalf("primary-only matched after flush delta=%d want %d", got, want)
+	}
+	if got, want := afterFlush.PrimaryOnlyModified-statsBefore.PrimaryOnlyModified, uint64(1); got != want {
+		t.Fatalf("primary-only modified after flush delta=%d want %d", got, want)
+	}
+	if got, want := afterFlush.PrimaryOnlyRootPublishes-statsBefore.PrimaryOnlyRootPublishes, uint64(1); got != want {
+		t.Fatalf("primary-only root publishes after flush delta=%d want %d", got, want)
+	}
+	if got, want := afterFlush.PrimaryOnlyRootDeltaEntries-statsBefore.PrimaryOnlyRootDeltaEntries, uint64(1); got != want {
+		t.Fatalf("primary-only root delta entries after flush delta=%d want %d", got, want)
+	}
+	if got := afterFlush.PrimaryOnlyRootDeltaKeyBytes - statsBefore.PrimaryOnlyRootDeltaKeyBytes; got != uint64(len("u1")) {
 		t.Fatalf("primary-only root delta key bytes delta=%d want %d", got, len("u1"))
 	}
-	if got := stats.PrimaryOnlyRootDeltaValueBytes - statsBefore.PrimaryOnlyRootDeltaValueBytes; got == 0 {
+	if got := afterFlush.PrimaryOnlyRootDeltaValueBytes - statsBefore.PrimaryOnlyRootDeltaValueBytes; got == 0 {
 		t.Fatal("primary-only root delta value bytes delta=0 want positive")
 	}
-	if got, want := stats.PrimaryOnlyCoalescedDocs-statsBefore.PrimaryOnlyCoalescedDocs, uint64(1); got != want {
+	if got, want := afterFlush.PrimaryOnlyCoalescedDocs-statsBefore.PrimaryOnlyCoalescedDocs, uint64(1); got != want {
 		t.Fatalf("primary-only coalesced docs delta=%d want %d", got, want)
 	}
 	exported := mgr.Stats()
@@ -7036,8 +7062,11 @@ func TestCollectionUpdateBatchUpdatesMultipleDocuments(t *testing.T) {
 		t.Fatalf("missing document result matched/modified: %+v", results[2])
 	}
 	after := d.State()
-	if after.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("CommitSeq after batch=%d want %d", after.CommitSeq, before.CommitSeq+1)
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("CommitSeq after staged no-index batch=%d want %d", after.CommitSeq, before.CommitSeq)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 2 || state.tableLen < 2 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after staged no-index batch=%+v want two staged primary rows", state)
 	}
 	for _, id := range []string{"u1", "u2"} {
 		got, err := col.Get([]byte(id))
@@ -7047,6 +7076,16 @@ func TestCollectionUpdateBatchUpdatesMultipleDocuments(t *testing.T) {
 		if !bytes.Contains(got, []byte(`"count":1`)) {
 			t.Fatalf("%s document=%s want count 1", id, got)
 		}
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush staged no-index batch: %v", err)
+	}
+	flushed := d.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("CommitSeq after flushing staged no-index batch=%d want %d", flushed.CommitSeq, before.CommitSeq+1)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after flushing no-index batch=%+v want empty", state)
 	}
 }
 
@@ -7161,7 +7200,7 @@ func TestCollectionUpdateBatchRejectsUniqueConflictsWithinBatch(t *testing.T) {
 	}
 }
 
-func TestCollectionUpdateCombinerRunBatchPublishesDistinctIDsOnce(t *testing.T) {
+func TestCollectionUpdateCombinerStagesDistinctNoIndexIDsAndFlushPublishesOnce(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -7213,9 +7252,34 @@ func TestCollectionUpdateCombinerRunBatchPublishesDistinctIDsOnce(t *testing.T) 
 			t.Fatalf("request %d matched=%v modified=%v", i, result.matched, result.modified)
 		}
 	}
-	after := d.State()
-	if after.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("combined batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	afterBatch := d.State()
+	if afterBatch.CommitSeq != before.CommitSeq {
+		t.Fatalf("combined no-index batch advanced commit seq by %d before flush, want 0", afterBatch.CommitSeq-before.CommitSeq)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 2 || state.tableLen < 2 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("combined no-index pending state=%+v want two staged primary rows", state)
+	}
+	for _, tc := range []struct {
+		id   []byte
+		want []byte
+	}{
+		{[]byte("u1"), []byte(`{"score":1}`)},
+		{[]byte("u2"), []byte(`{"score":2}`)},
+	} {
+		got, err := col.Get(tc.id)
+		if err != nil {
+			t.Fatalf("get staged %s: %v", tc.id, err)
+		}
+		if !bytes.Equal(got, tc.want) {
+			t.Fatalf("staged %s=%q want %q", tc.id, got, tc.want)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush combined no-index batch: %v", err)
+	}
+	afterFlush := d.State()
+	if afterFlush.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flushed combined batch advanced commit seq by %d, want 1", afterFlush.CommitSeq-before.CommitSeq)
 	}
 }
 
@@ -7288,12 +7352,22 @@ func TestCollectionUpdateCombinerRunBatchStartingWithYieldsForQueuedPeer(t *test
 			t.Fatalf("request %d was not included in yielded batch", i)
 		}
 	}
-	after := d.State()
-	if after.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("combined batch advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	afterBatch := d.State()
+	if afterBatch.CommitSeq != before.CommitSeq {
+		t.Fatalf("combined no-index batch advanced commit seq by %d before flush, want 0", afterBatch.CommitSeq-before.CommitSeq)
 	}
 	if yieldCalls != 1 {
 		t.Fatalf("drainYield calls=%d want exactly one bounded yield", yieldCalls)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 2 || state.tableLen < 2 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("combined yielded no-index pending state=%+v want two staged primary rows", state)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush yielded combined no-index batch: %v", err)
+	}
+	afterFlush := d.State()
+	if afterFlush.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flushed yielded combined batch advanced commit seq by %d, want 1", afterFlush.CommitSeq-before.CommitSeq)
 	}
 }
 

--- a/TreeDB/collections/bson_direct_update_id_test.go
+++ b/TreeDB/collections/bson_direct_update_id_test.go
@@ -81,6 +81,72 @@ func TestCollectionNoIndexUpdateBSONStagesValidIDPreservingReplacement(t *testin
 	requireBSONInt32FieldForUpdateTest(t, got, "score", 1)
 }
 
+func TestCollectionNoIndexUpdateBSONMissingIndexLookupDoesNotFlushStagedUpdate(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Options: CollectionOptions{DocumentFormat: DocumentFormatBSON},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	other, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open other collection: %v", err)
+	}
+	doc := mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(0)}})
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{doc}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	beforeState := d.State()
+	beforeRoot := collectionPrimaryRootIDForTest(t, d, "users")
+	replacement := mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(1)}})
+	if _, _, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		if err := checkBSONInt32FieldForUpdateTest(current, "score", 0); err != nil {
+			return nil, false, err
+		}
+		return replacement, true, nil
+	}); err != nil {
+		t.Fatalf("stage BSON update: %v", err)
+	}
+	if ids, err := col.FindByIndex("missing", "x"); err != nil {
+		t.Fatalf("FindByIndex missing: %v", err)
+	} else if len(ids) != 0 {
+		t.Fatalf("FindByIndex missing ids=%q want empty", ids)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("missing-index lookup advanced commit seq from %d to %d", beforeState.CommitSeq, got)
+	}
+	if got := collectionPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+		t.Fatalf("missing-index lookup published primary root from %d to %d", beforeRoot, got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen < 1 {
+		t.Fatalf("pending BSON state=%+v want one row", state)
+	}
+	got, err := other.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("other-manager get BSON before flush: %v", err)
+	}
+	requireBSONInt32FieldForUpdateTest(t, got, "score", 0)
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush staged BSON update: %v", err)
+	}
+	got, err = other.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("other-manager get BSON after flush: %v", err)
+	}
+	requireBSONInt32FieldForUpdateTest(t, got, "score", 1)
+}
+
 func TestCollectionUpdateBSONRejectsIDMutationBeforeStaging(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/bson_direct_update_id_test.go
+++ b/TreeDB/collections/bson_direct_update_id_test.go
@@ -9,7 +9,76 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-func TestCollectionUpdateBSONRejectsIDMutationBeforeRootWork(t *testing.T) {
+func TestCollectionNoIndexUpdateBSONStagesValidIDPreservingReplacement(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Options: CollectionOptions{DocumentFormat: DocumentFormatBSON},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	doc := mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(0)}})
+	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{doc}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	beforeState := d.State()
+	beforeRoot := collectionPrimaryRootIDForTest(t, d, "users")
+	replacement := mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(1)}})
+
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		requireBSONInt32FieldForUpdateTest(t, current, "score", 0)
+		return replacement, true, nil
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("Update matched/modified=%v/%v want true/true", matched, modified)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("staged BSON update commit seq=%d want %d", got, beforeState.CommitSeq)
+	}
+	if got := collectionPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+		t.Fatalf("staged BSON update primary root=%d want %d", got, beforeRoot)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen < 1 {
+		t.Fatalf("pending state after staged BSON update=%+v want one row", state)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get staged BSON u1: %v", err)
+	}
+	requireBSONStringFieldForUpdateTest(t, got, "_id", "u1")
+	requireBSONInt32FieldForUpdateTest(t, got, "score", 1)
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush staged BSON update: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq+1 {
+		t.Fatalf("flushed BSON update commit seq=%d want %d", got, beforeState.CommitSeq+1)
+	}
+	if got := collectionPrimaryRootIDForTest(t, d, "users"); got == beforeRoot {
+		t.Fatalf("flushed BSON update primary root stayed at %d", got)
+	}
+	got, err = col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get flushed BSON u1: %v", err)
+	}
+	requireBSONStringFieldForUpdateTest(t, got, "_id", "u1")
+	requireBSONInt32FieldForUpdateTest(t, got, "score", 1)
+}
+
+func TestCollectionUpdateBSONRejectsIDMutationBeforeStaging(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -66,9 +135,15 @@ func TestCollectionUpdateBSONRejectsIDMutationBeforeRootWork(t *testing.T) {
 	if got != nil {
 		t.Fatalf("u2 after rejected _id update=%x want nil", got)
 	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush after rejected _id update: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("flush after rejected _id update commit seq=%d want %d", got, beforeState.CommitSeq)
+	}
 }
 
-func TestCollectionUpdateBSONRejectsInPlaceIDMutationBeforeRootWork(t *testing.T) {
+func TestCollectionUpdateBSONRejectsInPlaceIDMutationBeforeStaging(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -129,9 +204,15 @@ func TestCollectionUpdateBSONRejectsInPlaceIDMutationBeforeRootWork(t *testing.T
 	if got != nil {
 		t.Fatalf("u2 after rejected in-place _id update=%x want nil", got)
 	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush after rejected in-place _id update: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("flush after rejected in-place _id update commit seq=%d want %d", got, beforeState.CommitSeq)
+	}
 }
 
-func TestCollectionUpdateBSONRejectsMissingIDBeforeRootWork(t *testing.T) {
+func TestCollectionUpdateBSONRejectsMissingIDBeforeStaging(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -180,6 +261,34 @@ func TestCollectionUpdateBSONRejectsMissingIDBeforeRootWork(t *testing.T) {
 	}
 	if !bytes.Equal(got, doc) {
 		t.Fatalf("u1 after rejected missing _id update=%x want original %x", got, doc)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush after rejected missing _id update: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("flush after rejected missing _id update commit seq=%d want %d", got, beforeState.CommitSeq)
+	}
+}
+
+func requireBSONStringFieldForUpdateTest(t *testing.T, raw []byte, field, want string) {
+	t.Helper()
+	value := bson.Raw(raw).Lookup(field)
+	if value.Type != bson.TypeString {
+		t.Fatalf("BSON field %q type=%s want string", field, value.Type)
+	}
+	if got := value.StringValue(); got != want {
+		t.Fatalf("BSON field %q=%q want %q", field, got, want)
+	}
+}
+
+func requireBSONInt32FieldForUpdateTest(t *testing.T, raw []byte, field string, want int32) {
+	t.Helper()
+	value := bson.Raw(raw).Lookup(field)
+	if value.Type != bson.TypeInt32 {
+		t.Fatalf("BSON field %q type=%s want int32", field, value.Type)
+	}
+	if got := value.Int32(); got != want {
+		t.Fatalf("BSON field %q=%d want %d", field, got, want)
 	}
 }
 

--- a/TreeDB/collections/bson_direct_update_id_test.go
+++ b/TreeDB/collections/bson_direct_update_id_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -36,7 +37,9 @@ func TestCollectionNoIndexUpdateBSONStagesValidIDPreservingReplacement(t *testin
 	replacement := mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(1)}})
 
 	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
-		requireBSONInt32FieldForUpdateTest(t, current, "score", 0)
+		if err := checkBSONInt32FieldForUpdateTest(current, "score", 0); err != nil {
+			return nil, false, err
+		}
 		return replacement, true, nil
 	})
 	if err != nil {
@@ -283,13 +286,20 @@ func requireBSONStringFieldForUpdateTest(t *testing.T, raw []byte, field, want s
 
 func requireBSONInt32FieldForUpdateTest(t *testing.T, raw []byte, field string, want int32) {
 	t.Helper()
+	if err := checkBSONInt32FieldForUpdateTest(raw, field, want); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkBSONInt32FieldForUpdateTest(raw []byte, field string, want int32) error {
 	value := bson.Raw(raw).Lookup(field)
 	if value.Type != bson.TypeInt32 {
-		t.Fatalf("BSON field %q type=%s want int32", field, value.Type)
+		return fmt.Errorf("BSON field %q type=%s want int32", field, value.Type)
 	}
 	if got := value.Int32(); got != want {
-		t.Fatalf("BSON field %q=%d want %d", field, got, want)
+		return fmt.Errorf("BSON field %q=%d want %d", field, got, want)
 	}
+	return nil
 }
 
 func collectionPrimaryRootIDForTest(t *testing.T, d *backenddb.DB, collectionName string) uint64 {

--- a/TreeDB/collections/checkpoint_boundary_test.go
+++ b/TreeDB/collections/checkpoint_boundary_test.go
@@ -60,7 +60,7 @@ func TestCollectionCheckpointDoesNotFlushPendingNoIndexInsert(t *testing.T) {
 	}
 }
 
-func TestCollectionCheckpointSeesSynchronousNoIndexUpdate(t *testing.T) {
+func TestCollectionCheckpointDoesNotFlushPendingNoIndexUpdate(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})
 	if err != nil {
@@ -82,6 +82,7 @@ func TestCollectionCheckpointSeesSynchronousNoIndexUpdate(t *testing.T) {
 		t.Fatalf("flush insert: %v", err)
 	}
 	beforeRoot := collectionCheckpointBoundaryPrimaryRootIDForTest(t, d, "users")
+	beforeStats := mgr.StatsSnapshot()
 
 	matched, modified, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
 		return []byte(`{"name":"ada","city":"sea"}`), true, nil
@@ -92,19 +93,50 @@ func TestCollectionCheckpointSeesSynchronousNoIndexUpdate(t *testing.T) {
 	if !matched || !modified {
 		t.Fatalf("update matched/modified=%v/%v want true/true", matched, modified)
 	}
-	updatedRoot := collectionCheckpointBoundaryPrimaryRootIDForTest(t, d, "users")
-	if updatedRoot == beforeRoot {
-		t.Fatalf("synchronous no-index update left primary root at %d", updatedRoot)
+	stagedRoot := collectionCheckpointBoundaryPrimaryRootIDForTest(t, d, "users")
+	if stagedRoot != beforeRoot {
+		t.Fatalf("staged no-index update changed primary root from %d to %d before flush", beforeRoot, stagedRoot)
 	}
-	if got := collectionCheckpointBoundaryPendingCountForTest(t, col); got != 0 {
-		t.Fatalf("pending count after synchronous no-index update=%d want 0", got)
+	if got := collectionCheckpointBoundaryPendingCountForTest(t, col); got != 1 {
+		t.Fatalf("pending count after staged no-index update=%d want 1", got)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get staged update before checkpoint: %v", err)
+	}
+	if want := []byte(`{"name":"ada","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("staged update before checkpoint=%q want %q", got, want)
 	}
 	if err := d.Checkpoint(); err != nil {
 		t.Fatalf("checkpoint: %v", err)
 	}
 	afterCheckpointRoot := collectionCheckpointBoundaryPrimaryRootIDForTest(t, d, "users")
-	if afterCheckpointRoot != updatedRoot {
-		t.Fatalf("checkpoint changed primary root from %d to %d after synchronous update", updatedRoot, afterCheckpointRoot)
+	if afterCheckpointRoot != beforeRoot {
+		t.Fatalf("checkpoint changed primary root from %d to %d for pending no-index update", beforeRoot, afterCheckpointRoot)
+	}
+	if got := collectionCheckpointBoundaryPendingCountForTest(t, col); got != 1 {
+		t.Fatalf("pending count after checkpoint=%d want 1", got)
+	}
+	afterCheckpointStats := mgr.StatsSnapshot()
+	if got := afterCheckpointStats.PrimaryOnlyRootPublishes - beforeStats.PrimaryOnlyRootPublishes; got != 0 {
+		t.Fatalf("checkpoint primary-only root publishes delta=%d want 0", got)
+	}
+	got, err = col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get staged update after checkpoint: %v", err)
+	}
+	if want := []byte(`{"name":"ada","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("staged update after checkpoint=%q want %q", got, want)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush staged update: %v", err)
+	}
+	flushedRoot := collectionCheckpointBoundaryPrimaryRootIDForTest(t, d, "users")
+	if flushedRoot == beforeRoot {
+		t.Fatalf("flush left primary root at %d, want published staged update", flushedRoot)
+	}
+	if got := collectionCheckpointBoundaryPendingCountForTest(t, col); got != 0 {
+		t.Fatalf("pending count after flush=%d want 0", got)
 	}
 	if err := d.Close(); err != nil {
 		t.Fatalf("close db: %v", err)
@@ -119,7 +151,7 @@ func TestCollectionCheckpointSeesSynchronousNoIndexUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open reopened collection: %v", err)
 	}
-	got, err := reopenedCol.Get([]byte("u1"))
+	got, err = reopenedCol.Get([]byte("u1"))
 	if err != nil {
 		t.Fatalf("get reopened updated doc: %v", err)
 	}

--- a/TreeDB/collections/close_indexed_flush_test.go
+++ b/TreeDB/collections/close_indexed_flush_test.go
@@ -74,3 +74,58 @@ func TestCollectionManagerCloseDrainsQueuedIndexedFlushUnit(t *testing.T) {
 		t.Fatalf("reopened email ids=%q want [u1]", ids)
 	}
 }
+
+func TestCollectionManagerCloseDrainsPendingPrimaryOnlyNoIndexUpdate(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"name":"ada","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	matched, modified, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"name":"ada","city":"sea"}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("update matched/modified=%v/%v want true/true", matched, modified)
+	}
+	if got := collectionCheckpointBoundaryPendingCountForTest(t, col); got != 1 {
+		t.Fatalf("pending count before close=%d want 1", got)
+	}
+
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	got, err := reopenedCol.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get reopened document: %v", err)
+	}
+	if want := []byte(`{"name":"ada","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("reopened document=%q want %q", got, want)
+	}
+}

--- a/TreeDB/collections/no_index_update_baseline_test.go
+++ b/TreeDB/collections/no_index_update_baseline_test.go
@@ -595,7 +595,7 @@ func TestCollectionNoIndexUpdateCallbackErrorDoesNotDropPriorStagedUpdate(t *tes
 	sentinel := errors.New("callback failed")
 	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
 		if !bytes.Equal(current, []byte(`{"count":1}`)) {
-			t.Fatalf("error callback current=%q want staged count 1", current)
+			return nil, false, fmt.Errorf("error callback current=%q want staged count 1", current)
 		}
 		return nil, false, sentinel
 	})
@@ -667,7 +667,7 @@ func TestCollectionNoIndexUpdateCallbackPanicDoesNotDropPriorStagedUpdate(t *tes
 	beforeStats := mgr.StatsSnapshot()
 	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
 		if !bytes.Equal(current, []byte(`{"count":1}`)) {
-			t.Fatalf("panic callback current=%q want staged count 1", current)
+			return nil, false, fmt.Errorf("panic callback current=%q want staged count 1", current)
 		}
 		panic("bad callback")
 	})

--- a/TreeDB/collections/no_index_update_baseline_test.go
+++ b/TreeDB/collections/no_index_update_baseline_test.go
@@ -872,6 +872,101 @@ func TestCollectionNoIndexUpdateCreateIndexDrainsStagedUpdateBeforeBackfill(t *t
 	}
 }
 
+func TestCollectionNoIndexUpdateBatchNoOpNestedStageDoesNotFlush(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	other, err := NewCollectionManager(d).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open other collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"count":0}`), []byte(`{"count":0}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	beforeState := d.State()
+	beforeRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	nested := false
+	results, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: func(current []byte) ([]byte, bool, error) {
+			if !bytes.Equal(current, []byte(`{"count":0}`)) {
+				return nil, false, fmt.Errorf("batch current=%q want count 0", current)
+			}
+			if !nested {
+				nested = true
+				matched, modified, err := col.Update([]byte("u2"), func(current []byte) ([]byte, bool, error) {
+					if !bytes.Equal(current, []byte(`{"count":0}`)) {
+						return nil, false, fmt.Errorf("nested current=%q want count 0", current)
+					}
+					return []byte(`{"count":1}`), true, nil
+				})
+				if err != nil {
+					return nil, false, err
+				}
+				if !matched || !modified {
+					return nil, false, fmt.Errorf("nested matched/modified=%v/%v want true/true", matched, modified)
+				}
+			}
+			return current, false, nil
+		}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || results[0].Modified {
+		t.Fatalf("UpdateBatch results=%+v want matched no-op", results)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("no-op UpdateBatch nested stage advanced commit seq from %d to %d", beforeState.CommitSeq, got)
+	}
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+		t.Fatalf("no-op UpdateBatch nested stage published primary root from %d to %d", beforeRoot, got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen != 1 {
+		t.Fatalf("pending state after no-op nested stage=%+v want one no-index row", state)
+	}
+	got, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("same-manager get staged u2: %v", err)
+	}
+	if want := []byte(`{"count":1}`); !bytes.Equal(got, want) {
+		t.Fatalf("same-manager staged u2=%q want %q", got, want)
+	}
+	got, err = other.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("other-manager get u2 before flush: %v", err)
+	}
+	if want := []byte(`{"count":0}`); !bytes.Equal(got, want) {
+		t.Fatalf("other-manager u2 before flush=%q want %q", got, want)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush staged u2: %v", err)
+	}
+	got, err = other.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("other-manager get u2 after flush: %v", err)
+	}
+	if want := []byte(`{"count":1}`); !bytes.Equal(got, want) {
+		t.Fatalf("other-manager u2 after flush=%q want %q", got, want)
+	}
+}
+
 func TestCollectionNoIndexUpdateCallbackErrorDoesNotDropPriorStagedUpdate(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -1007,6 +1102,165 @@ func TestCollectionNoIndexUpdateCallbackPanicDoesNotDropPriorStagedUpdate(t *tes
 	}
 	if want := []byte(`{"count":1}`); !bytes.Equal(got, want) {
 		t.Fatalf("document after flush=%q want %q", got, want)
+	}
+}
+
+func TestCollectionNoIndexStagedUpdateSurvivesNonBarrierOperations(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(t *testing.T, col, other *Collection)
+		want int
+	}{
+		{
+			name: "missing-index-lookup",
+			run: func(t *testing.T, col, other *Collection) {
+				t.Helper()
+				ids, err := col.FindByIndex("missing", "x")
+				if err != nil {
+					t.Fatalf("FindByIndex missing: %v", err)
+				}
+				if len(ids) != 0 {
+					t.Fatalf("FindByIndex missing ids=%q want empty", ids)
+				}
+			},
+			want: 1,
+		},
+		{
+			name: "scan",
+			run: func(t *testing.T, col, other *Collection) {
+				t.Helper()
+				seen := 0
+				if _, err := col.ScanDocumentsFunc(10, func(DocumentRecord) (bool, error) {
+					seen++
+					return true, nil
+				}); err != nil {
+					t.Fatalf("ScanDocumentsFunc: %v", err)
+				}
+				if seen == 0 {
+					t.Fatal("ScanDocumentsFunc saw no persisted documents")
+				}
+			},
+			want: 1,
+		},
+		{
+			name: "insert-batch",
+			run: func(t *testing.T, col, other *Collection) {
+				t.Helper()
+				if _, err := col.InsertBatch(
+					[][]byte{[]byte("u3")},
+					[][]byte{[]byte(`{"count":3}`)},
+				); err != nil {
+					t.Fatalf("InsertBatch: %v", err)
+				}
+				got, err := col.Get([]byte("u3"))
+				if err != nil {
+					t.Fatalf("same-manager get staged u3: %v", err)
+				}
+				if want := []byte(`{"count":3}`); !bytes.Equal(got, want) {
+					t.Fatalf("same-manager u3=%q want %q", got, want)
+				}
+				if got, found, err := other.GetInto([]byte("u3"), nil); err != nil {
+					t.Fatalf("other-manager get u3 before flush: %v", err)
+				} else if found {
+					t.Fatalf("other-manager saw staged insert u3=%q before flush", got)
+				}
+			},
+			want: 2,
+		},
+		{
+			name: "delete-document",
+			run: func(t *testing.T, col, other *Collection) {
+				t.Helper()
+				deleted, err := col.DeleteDocument([]byte("u2"))
+				if err != nil {
+					t.Fatalf("DeleteDocument: %v", err)
+				}
+				if !deleted {
+					t.Fatal("DeleteDocument deleted=false want true")
+				}
+				if got, found, err := col.GetInto([]byte("u2"), nil); err != nil {
+					t.Fatalf("same-manager get u2 after staged delete: %v", err)
+				} else if found {
+					t.Fatalf("same-manager saw deleted u2=%q", got)
+				}
+				got, err := other.Get([]byte("u2"))
+				if err != nil {
+					t.Fatalf("other-manager get u2 before flush: %v", err)
+				}
+				if want := []byte(`{"count":0}`); !bytes.Equal(got, want) {
+					t.Fatalf("other-manager u2 before flush=%q want %q", got, want)
+				}
+			},
+			want: 2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+			if err != nil {
+				t.Fatalf("open db: %v", err)
+			}
+			defer func() { _ = d.Close() }()
+			mgr := NewCollectionManager(d)
+			if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+				t.Fatalf("create collection: %v", err)
+			}
+			col, err := mgr.OpenCollection("users")
+			if err != nil {
+				t.Fatalf("open collection: %v", err)
+			}
+			other, err := NewCollectionManager(d).OpenCollection("users")
+			if err != nil {
+				t.Fatalf("open other collection: %v", err)
+			}
+			if _, err := col.InsertBatch(
+				[][]byte{[]byte("u1"), []byte("u2")},
+				[][]byte{[]byte(`{"count":0}`), []byte(`{"count":0}`)},
+			); err != nil {
+				t.Fatalf("insert batch: %v", err)
+			}
+			if err := col.Flush(); err != nil {
+				t.Fatalf("flush insert: %v", err)
+			}
+			beforeState := d.State()
+			beforeRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+			if _, _, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+				if !bytes.Equal(current, []byte(`{"count":0}`)) {
+					return nil, false, fmt.Errorf("stage current=%q want count 0", current)
+				}
+				return []byte(`{"count":1}`), true, nil
+			}); err != nil {
+				t.Fatalf("stage update: %v", err)
+			}
+
+			tc.run(t, col, other)
+
+			if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+				t.Fatalf("%s advanced commit seq from %d to %d", tc.name, beforeState.CommitSeq, got)
+			}
+			if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+				t.Fatalf("%s published primary root from %d to %d", tc.name, beforeRoot, got)
+			}
+			if state := collectionNoIndexPendingStateForTest(t, col); state.count != tc.want || state.tableLen != tc.want {
+				t.Fatalf("%s pending state=%+v want %d no-index rows", tc.name, state, tc.want)
+			}
+			got, err := other.Get([]byte("u1"))
+			if err != nil {
+				t.Fatalf("other-manager get u1 before flush: %v", err)
+			}
+			if want := []byte(`{"count":0}`); !bytes.Equal(got, want) {
+				t.Fatalf("other-manager u1 before flush=%q want %q", got, want)
+			}
+			if err := col.Flush(); err != nil {
+				t.Fatalf("flush after %s: %v", tc.name, err)
+			}
+			got, err = other.Get([]byte("u1"))
+			if err != nil {
+				t.Fatalf("other-manager get u1 after flush: %v", err)
+			}
+			if want := []byte(`{"count":1}`); !bytes.Equal(got, want) {
+				t.Fatalf("other-manager u1 after flush=%q want %q", got, want)
+			}
+		})
 	}
 }
 

--- a/TreeDB/collections/no_index_update_baseline_test.go
+++ b/TreeDB/collections/no_index_update_baseline_test.go
@@ -239,6 +239,18 @@ func TestCollectionNoIndexUpdateMissingAndUnchangedDoNotPublishOrQueue(t *testin
 		t.Fatalf("unchanged update primary root=%d want %d", got, beforeRoot)
 	}
 	afterUnchangedStats := mgr.StatsSnapshot()
+	if got, want := afterUnchangedStats.PrimaryOnlyUpdateCalls-beforeStats.PrimaryOnlyUpdateCalls, uint64(1); got != want {
+		t.Fatalf("unchanged update primary-only update calls delta=%d want %d", got, want)
+	}
+	if got, want := afterUnchangedStats.PrimaryOnlyMatched-beforeStats.PrimaryOnlyMatched, uint64(1); got != want {
+		t.Fatalf("unchanged update primary-only matched delta=%d want %d", got, want)
+	}
+	if got := afterUnchangedStats.PrimaryOnlyModified - beforeStats.PrimaryOnlyModified; got != 0 {
+		t.Fatalf("unchanged update primary-only modified delta=%d want 0", got)
+	}
+	if got := afterUnchangedStats.PrimaryOnlyBufferedCalls - beforeStats.PrimaryOnlyBufferedCalls; got != 0 {
+		t.Fatalf("unchanged update primary-only buffered calls delta=%d want 0", got)
+	}
 	if got := afterUnchangedStats.PrimaryOnlyRootPublishes - beforeStats.PrimaryOnlyRootPublishes; got != 0 {
 		t.Fatalf("unchanged update primary root publishes delta=%d want 0", got)
 	}
@@ -267,6 +279,18 @@ func TestCollectionNoIndexUpdateMissingAndUnchangedDoNotPublishOrQueue(t *testin
 		t.Fatalf("missing update primary root=%d want %d", got, beforeRoot)
 	}
 	afterMissingStats := mgr.StatsSnapshot()
+	if got, want := afterMissingStats.PrimaryOnlyUpdateCalls-afterUnchangedStats.PrimaryOnlyUpdateCalls, uint64(1); got != want {
+		t.Fatalf("missing update primary-only update calls delta=%d want %d", got, want)
+	}
+	if got := afterMissingStats.PrimaryOnlyMatched - afterUnchangedStats.PrimaryOnlyMatched; got != 0 {
+		t.Fatalf("missing update primary-only matched delta=%d want 0", got)
+	}
+	if got := afterMissingStats.PrimaryOnlyModified - afterUnchangedStats.PrimaryOnlyModified; got != 0 {
+		t.Fatalf("missing update primary-only modified delta=%d want 0", got)
+	}
+	if got := afterMissingStats.PrimaryOnlyBufferedCalls - afterUnchangedStats.PrimaryOnlyBufferedCalls; got != 0 {
+		t.Fatalf("missing update primary-only buffered calls delta=%d want 0", got)
+	}
 	if got := afterMissingStats.PrimaryOnlyRootPublishes - beforeStats.PrimaryOnlyRootPublishes; got != 0 {
 		t.Fatalf("missing update primary root publishes delta=%d want 0", got)
 	}
@@ -436,6 +460,13 @@ func TestCollectionNoIndexRepeatedSameIDUpdatesCoalesceAndPreserveOrder(t *testi
 	if !matched || !modified {
 		t.Fatalf("first update matched/modified=%v/%v want true/true", matched, modified)
 	}
+	afterFirstStats := mgr.StatsSnapshot()
+	if got, want := afterFirstStats.PendingDocuments, 1; got != want {
+		t.Fatalf("pending docs after first same-id update=%d want %d", got, want)
+	}
+	if afterFirstStats.PendingBytes <= 0 {
+		t.Fatalf("pending bytes after first same-id update=%d want positive", afterFirstStats.PendingBytes)
+	}
 	matched, modified, err = col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
 		if !bytes.Equal(current, []byte(`{"count":1}`)) {
 			return nil, false, fmt.Errorf("second callback current=%q want count 1", current)
@@ -447,6 +478,13 @@ func TestCollectionNoIndexRepeatedSameIDUpdatesCoalesceAndPreserveOrder(t *testi
 	}
 	if !matched || !modified {
 		t.Fatalf("second update matched/modified=%v/%v want true/true", matched, modified)
+	}
+	afterSecondStats := mgr.StatsSnapshot()
+	if got, want := afterSecondStats.PendingDocuments, 1; got != want {
+		t.Fatalf("pending docs after second same-id update=%d want %d", got, want)
+	}
+	if got, want := afterSecondStats.PendingBytes, afterFirstStats.PendingBytes; got != want {
+		t.Fatalf("pending bytes after same-length overwrite=%d want current-table bytes %d", got, want)
 	}
 	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen < 1 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
 		t.Fatalf("pending state after repeated updates=%+v want one unique no-index row", state)
@@ -561,6 +599,276 @@ func TestCollectionNoIndexUpdateBatchReadsStagedPrimaryOnlyValue(t *testing.T) {
 	}
 	if got, want := afterFlushStats.PrimaryOnlyCoalescedDocs-beforeStats.PrimaryOnlyCoalescedDocs, uint64(2); got != want {
 		t.Fatalf("primary-only coalesced docs delta=%d want %d", got, want)
+	}
+}
+
+func TestCollectionNoIndexUpdateBatchAfterUnrelatedCatalogChangePreservesStagedWrite(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"count":0}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	if _, _, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		if !bytes.Equal(current, []byte(`{"count":0}`)) {
+			return nil, false, fmt.Errorf("stage current=%q want count 0", current)
+		}
+		return []byte(`{"count":1}`), true, nil
+	}); err != nil {
+		t.Fatalf("stage update: %v", err)
+	}
+	stagedRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen != 1 {
+		t.Fatalf("pending state after staged update=%+v want one no-index row", state)
+	}
+
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "other"}); err != nil {
+		t.Fatalf("create unrelated collection: %v", err)
+	}
+	beforeBatchState := d.State()
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != stagedRoot {
+		t.Fatalf("unrelated catalog change changed users primary root from %d to %d", stagedRoot, got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen != 1 {
+		t.Fatalf("pending state after unrelated catalog change=%+v want one no-index row", state)
+	}
+
+	results, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: func(current []byte) ([]byte, bool, error) {
+			if !bytes.Equal(current, []byte(`{"count":1}`)) {
+				return nil, false, fmt.Errorf("batch current=%q want staged count 1", current)
+			}
+			return []byte(`{"count":2}`), true, nil
+		}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("UpdateBatch results=%+v want one matched/modified result", results)
+	}
+	if got := d.State().CommitSeq; got != beforeBatchState.CommitSeq {
+		t.Fatalf("UpdateBatch after unrelated catalog change advanced commit seq from %d to %d", beforeBatchState.CommitSeq, got)
+	}
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != stagedRoot {
+		t.Fatalf("UpdateBatch after unrelated catalog change published primary root from %d to %d", stagedRoot, got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen != 1 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after UpdateBatch replan=%+v want one no-index row", state)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get staged batch update: %v", err)
+	}
+	if want := []byte(`{"count":2}`); !bytes.Equal(got, want) {
+		t.Fatalf("staged batch document=%q want %q", got, want)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush staged batch update: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeBatchState.CommitSeq+1 {
+		t.Fatalf("flush after staged batch advanced commit seq to %d want %d", got, beforeBatchState.CommitSeq+1)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 {
+		t.Fatalf("pending state after flush=%+v want empty", state)
+	}
+}
+
+func TestCollectionNoIndexUpdateBatchGenerationConflictReplansWithoutFlush(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"count":0}`), []byte(`{"count":0}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	beforeState := d.State()
+	beforeRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	if _, _, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		if !bytes.Equal(current, []byte(`{"count":0}`)) {
+			return nil, false, fmt.Errorf("stage u1 current=%q want count 0", current)
+		}
+		return []byte(`{"count":1}`), true, nil
+	}); err != nil {
+		t.Fatalf("stage u1: %v", err)
+	}
+
+	injected := false
+	callbackCalls := 0
+	results, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: func(current []byte) ([]byte, bool, error) {
+			callbackCalls++
+			if !bytes.Equal(current, []byte(`{"count":1}`)) {
+				return nil, false, fmt.Errorf("batch current=%q want staged count 1", current)
+			}
+			if !injected {
+				injected = true
+				matched, modified, err := col.Update([]byte("u2"), func(current []byte) ([]byte, bool, error) {
+					if !bytes.Equal(current, []byte(`{"count":0}`)) {
+						return nil, false, fmt.Errorf("nested u2 current=%q want count 0", current)
+					}
+					return []byte(`{"count":1}`), true, nil
+				})
+				if err != nil {
+					return nil, false, err
+				}
+				if !matched || !modified {
+					return nil, false, fmt.Errorf("nested u2 matched/modified=%v/%v want true/true", matched, modified)
+				}
+			}
+			return []byte(`{"count":2}`), true, nil
+		}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("UpdateBatch results=%+v want one matched/modified result", results)
+	}
+	if callbackCalls < 2 {
+		t.Fatalf("batch callback calls=%d want retry after generation conflict", callbackCalls)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("generation-conflict retry advanced commit seq from %d to %d", beforeState.CommitSeq, got)
+	}
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+		t.Fatalf("generation-conflict retry published primary root from %d to %d", beforeRoot, got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 2 || state.tableLen != 2 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after generation-conflict retry=%+v want two no-index rows", state)
+	}
+	for _, tc := range []struct {
+		id   []byte
+		want []byte
+	}{
+		{id: []byte("u1"), want: []byte(`{"count":2}`)},
+		{id: []byte("u2"), want: []byte(`{"count":1}`)},
+	} {
+		got, err := col.Get(tc.id)
+		if err != nil {
+			t.Fatalf("get %s: %v", tc.id, err)
+		}
+		if !bytes.Equal(got, tc.want) {
+			t.Fatalf("document %s=%q want %q", tc.id, got, tc.want)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush staged generation-conflict updates: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq+1 {
+		t.Fatalf("flush after generation-conflict retry advanced commit seq to %d want %d", got, beforeState.CommitSeq+1)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 {
+		t.Fatalf("pending state after flush=%+v want empty", state)
+	}
+}
+
+func TestCollectionNoIndexUpdateCreateIndexDrainsStagedUpdateBeforeBackfill(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"city":"hnl","score":0}`), []byte(`{"city":"hnl","score":0}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	beforeState := d.State()
+	beforeRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	if _, _, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		if !bytes.Contains(current, []byte(`"city":"hnl"`)) {
+			return nil, false, fmt.Errorf("stage current=%q missing hnl", current)
+		}
+		return []byte(`{"city":"sea","score":1}`), true, nil
+	}); err != nil {
+		t.Fatalf("stage update: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("staged update before CreateIndex advanced commit seq from %d to %d", beforeState.CommitSeq, got)
+	}
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+		t.Fatalf("staged update before CreateIndex changed primary root from %d to %d", beforeRoot, got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen != 1 {
+		t.Fatalf("pending state before CreateIndex=%+v want one no-index row", state)
+	}
+
+	if _, err := col.CreateIndex(IndexDefinition{Name: "city", Field: "city", ValueType: IndexValueString}); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	if got := d.State().CommitSeq; got <= beforeState.CommitSeq {
+		t.Fatalf("CreateIndex commit seq=%d want greater than %d", got, beforeState.CommitSeq)
+	}
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got == beforeRoot {
+		t.Fatalf("CreateIndex left primary root at %d after draining staged update", got)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 {
+		t.Fatalf("pending state after CreateIndex=%+v want empty", state)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1 after CreateIndex: %v", err)
+	}
+	if !bytes.Equal(got, []byte(`{"city":"sea","score":1}`)) {
+		t.Fatalf("u1 after CreateIndex=%q want staged value", got)
+	}
+	seaIDs, err := col.FindByIndex("city", "sea")
+	if err != nil {
+		t.Fatalf("find sea city: %v", err)
+	}
+	if len(seaIDs) != 1 || !bytes.Equal(seaIDs[0], []byte("u1")) {
+		t.Fatalf("sea city ids=%q want [u1]", seaIDs)
+	}
+	hnlIDs, err := col.FindByIndex("city", "hnl")
+	if err != nil {
+		t.Fatalf("find hnl city: %v", err)
+	}
+	if len(hnlIDs) != 1 || !bytes.Equal(hnlIDs[0], []byte("u2")) {
+		t.Fatalf("hnl city ids=%q want [u2]", hnlIDs)
 	}
 }
 

--- a/TreeDB/collections/no_index_update_baseline_test.go
+++ b/TreeDB/collections/no_index_update_baseline_test.go
@@ -1264,6 +1264,137 @@ func TestCollectionNoIndexStagedUpdateSurvivesNonBarrierOperations(t *testing.T)
 	}
 }
 
+func TestCollectionNoIndexInsertReusesPendingDeletedIDWithoutPublishing(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(t *testing.T, col *Collection)
+	}{
+		{
+			name: "insert-one",
+			run: func(t *testing.T, col *Collection) {
+				t.Helper()
+				if _, err := col.Insert([]byte("u1"), []byte(`{"count":1}`)); err != nil {
+					t.Fatalf("Insert after staged delete: %v", err)
+				}
+			},
+		},
+		{
+			name: "insert-batch",
+			run: func(t *testing.T, col *Collection) {
+				t.Helper()
+				if _, err := col.InsertBatch(
+					[][]byte{[]byte("u1")},
+					[][]byte{[]byte(`{"count":1}`)},
+				); err != nil {
+					t.Fatalf("InsertBatch after staged delete: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+			if err != nil {
+				t.Fatalf("open db: %v", err)
+			}
+			defer func() { _ = d.Close() }()
+			mgr := NewCollectionManager(d)
+			if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+				t.Fatalf("create collection: %v", err)
+			}
+			col, err := mgr.OpenCollection("users")
+			if err != nil {
+				t.Fatalf("open collection: %v", err)
+			}
+			other, err := NewCollectionManager(d).OpenCollection("users")
+			if err != nil {
+				t.Fatalf("open other collection: %v", err)
+			}
+			if _, err := col.InsertBatch(
+				[][]byte{[]byte("u1"), []byte("u2")},
+				[][]byte{[]byte(`{"count":0}`), []byte(`{"count":0}`)},
+			); err != nil {
+				t.Fatalf("insert seed: %v", err)
+			}
+			if err := col.Flush(); err != nil {
+				t.Fatalf("flush seed: %v", err)
+			}
+			beforeState := d.State()
+			beforeRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+			if _, _, err := col.Update([]byte("u2"), func(current []byte) ([]byte, bool, error) {
+				if !bytes.Equal(current, []byte(`{"count":0}`)) {
+					return nil, false, fmt.Errorf("stage u2 current=%q want count 0", current)
+				}
+				return []byte(`{"count":2}`), true, nil
+			}); err != nil {
+				t.Fatalf("stage u2 update: %v", err)
+			}
+
+			deleted, err := col.DeleteDocument([]byte("u1"))
+			if err != nil {
+				t.Fatalf("staged delete: %v", err)
+			}
+			if !deleted {
+				t.Fatal("staged delete deleted=false want true")
+			}
+			if got, found, err := col.GetInto([]byte("u1"), nil); err != nil {
+				t.Fatalf("same-manager get after staged delete: %v", err)
+			} else if found {
+				t.Fatalf("same-manager saw staged-deleted u1=%q", got)
+			}
+
+			tc.run(t, col)
+
+			if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+				t.Fatalf("%s advanced commit seq from %d to %d", tc.name, beforeState.CommitSeq, got)
+			}
+			if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeRoot {
+				t.Fatalf("%s published primary root from %d to %d", tc.name, beforeRoot, got)
+			}
+			if state := collectionNoIndexPendingStateForTest(t, col); state.count != 2 || state.tableLen != 2 {
+				t.Fatalf("%s pending state=%+v want replacement row plus staged u2", tc.name, state)
+			}
+			got, err := col.Get([]byte("u1"))
+			if err != nil {
+				t.Fatalf("same-manager get replacement: %v", err)
+			}
+			if want := []byte(`{"count":1}`); !bytes.Equal(got, want) {
+				t.Fatalf("same-manager replacement=%q want %q", got, want)
+			}
+			got, err = other.Get([]byte("u1"))
+			if err != nil {
+				t.Fatalf("other-manager get before flush: %v", err)
+			}
+			if want := []byte(`{"count":0}`); !bytes.Equal(got, want) {
+				t.Fatalf("other-manager before flush=%q want %q", got, want)
+			}
+			got, err = other.Get([]byte("u2"))
+			if err != nil {
+				t.Fatalf("other-manager get u2 before flush: %v", err)
+			}
+			if want := []byte(`{"count":0}`); !bytes.Equal(got, want) {
+				t.Fatalf("other-manager u2 before flush=%q want %q", got, want)
+			}
+			if err := col.Flush(); err != nil {
+				t.Fatalf("flush replacement: %v", err)
+			}
+			got, err = other.Get([]byte("u1"))
+			if err != nil {
+				t.Fatalf("other-manager get after flush: %v", err)
+			}
+			if want := []byte(`{"count":1}`); !bytes.Equal(got, want) {
+				t.Fatalf("other-manager after flush=%q want %q", got, want)
+			}
+			got, err = other.Get([]byte("u2"))
+			if err != nil {
+				t.Fatalf("other-manager get u2 after flush: %v", err)
+			}
+			if want := []byte(`{"count":2}`); !bytes.Equal(got, want) {
+				t.Fatalf("other-manager u2 after flush=%q want %q", got, want)
+			}
+		})
+	}
+}
+
 type collectionNoIndexPendingState struct {
 	count             int
 	tableLen          int

--- a/TreeDB/collections/no_index_update_baseline_test.go
+++ b/TreeDB/collections/no_index_update_baseline_test.go
@@ -9,7 +9,7 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
-func TestCollectionNoIndexUpdatePublishesSynchronouslyNotQueued(t *testing.T) {
+func TestCollectionNoIndexUpdateStagesPrimaryOnlyAndFlushPublishes(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -52,49 +52,74 @@ func TestCollectionNoIndexUpdatePublishesSynchronouslyNotQueued(t *testing.T) {
 	if !matched || !modified {
 		t.Fatalf("update matched/modified=%v/%v want true/true", matched, modified)
 	}
-	afterState := d.State()
-	if afterState.CommitSeq != beforeState.CommitSeq+1 {
-		t.Fatalf("no-index update advanced commit seq by %d want 1", afterState.CommitSeq-beforeState.CommitSeq)
+	afterUpdateState := d.State()
+	if afterUpdateState.CommitSeq != beforeState.CommitSeq {
+		t.Fatalf("staged no-index update advanced commit seq by %d want 0", afterUpdateState.CommitSeq-beforeState.CommitSeq)
 	}
-	afterPrimaryRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
-	if afterPrimaryRoot == beforePrimaryRoot {
-		t.Fatalf("primary root stayed at %d after synchronous no-index update", afterPrimaryRoot)
+	afterUpdatePrimaryRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	if afterUpdatePrimaryRoot != beforePrimaryRoot {
+		t.Fatalf("staged no-index update changed primary root from %d to %d before flush", beforePrimaryRoot, afterUpdatePrimaryRoot)
 	}
-	afterStats := mgr.StatsSnapshot()
-	if got, want := afterStats.PrimaryOnlyUpdateCalls-beforeStats.PrimaryOnlyUpdateCalls, uint64(1); got != want {
+	afterUpdateStats := mgr.StatsSnapshot()
+	if got, want := afterUpdateStats.PrimaryOnlyUpdateCalls-beforeStats.PrimaryOnlyUpdateCalls, uint64(1); got != want {
 		t.Fatalf("primary-only update calls delta=%d want %d", got, want)
 	}
-	if got, want := afterStats.PrimaryOnlyMatched-beforeStats.PrimaryOnlyMatched, uint64(1); got != want {
+	if got, want := afterUpdateStats.PrimaryOnlyMatched-beforeStats.PrimaryOnlyMatched, uint64(1); got != want {
 		t.Fatalf("primary-only matched delta=%d want %d", got, want)
 	}
-	if got, want := afterStats.PrimaryOnlyModified-beforeStats.PrimaryOnlyModified, uint64(1); got != want {
+	if got, want := afterUpdateStats.PrimaryOnlyModified-beforeStats.PrimaryOnlyModified, uint64(1); got != want {
 		t.Fatalf("primary-only modified delta=%d want %d", got, want)
 	}
-	if got, want := afterStats.PrimaryOnlyRootPublishes-beforeStats.PrimaryOnlyRootPublishes, uint64(1); got != want {
-		t.Fatalf("primary-only root publishes delta=%d want %d", got, want)
+	if got, want := afterUpdateStats.PrimaryOnlyBufferedCalls-beforeStats.PrimaryOnlyBufferedCalls, uint64(1); got != want {
+		t.Fatalf("primary-only buffered calls delta=%d want %d", got, want)
 	}
-	if got, want := afterStats.PrimaryOnlyCoalescedDocs-beforeStats.PrimaryOnlyCoalescedDocs, uint64(1); got != want {
-		t.Fatalf("primary-only coalesced docs delta=%d want %d", got, want)
+	if got := afterUpdateStats.PrimaryOnlyRootPublishes - beforeStats.PrimaryOnlyRootPublishes; got != 0 {
+		t.Fatalf("primary-only root publishes before flush delta=%d want 0", got)
+	}
+	if got := afterUpdateStats.PrimaryOnlyCoalescedDocs - beforeStats.PrimaryOnlyCoalescedDocs; got != 0 {
+		t.Fatalf("primary-only coalesced docs before flush delta=%d want 0", got)
 	}
 
-	col.writeDomain.mu.RLock()
-	queuedIndexedUnits := len(col.writeDomain.indexedFlushUnits)
-	publishingIndexedUnits := len(col.writeDomain.indexedPublishingUnits)
-	indexedRootRuns := len(col.writeDomain.rootRuns)
-	noIndexBufferedCount := col.writeDomain.count
-	noIndexTable := col.writeDomain.table
-	noIndexTableLen := 0
-	if noIndexTable != nil {
-		noIndexTableLen = noIndexTable.Len()
+	state := collectionNoIndexPendingStateForTest(t, col)
+	if state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("no-index update queued indexed state=%+v, want indexed state zero", state)
 	}
-	col.writeDomain.mu.RUnlock()
-	if queuedIndexedUnits != 0 || publishingIndexedUnits != 0 || indexedRootRuns != 0 {
-		t.Fatalf("no-index update queued indexed state queued=%d publishing=%d rootRuns=%d, want all zero", queuedIndexedUnits, publishingIndexedUnits, indexedRootRuns)
-	}
-	if noIndexBufferedCount != 0 || noIndexTableLen != 0 {
-		t.Fatalf("no-index update left collection-local buffer count=%d tableLen=%d, want drained", noIndexBufferedCount, noIndexTableLen)
+	if state.count != 1 || state.tableLen != 1 {
+		t.Fatalf("no-index staged update pending state=%+v want count/tableLen 1", state)
 	}
 	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get staged document: %v", err)
+	}
+	if want := []byte(`{"name":"ada","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("staged document=%q want %q", got, want)
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush staged update: %v", err)
+	}
+	afterFlushState := d.State()
+	if afterFlushState.CommitSeq != beforeState.CommitSeq+1 {
+		t.Fatalf("flush advanced commit seq by %d want 1", afterFlushState.CommitSeq-beforeState.CommitSeq)
+	}
+	afterFlushPrimaryRoot := collectionNoIndexPrimaryRootIDForTest(t, d, "users")
+	if afterFlushPrimaryRoot == beforePrimaryRoot {
+		t.Fatalf("primary root stayed at %d after flushing staged update", afterFlushPrimaryRoot)
+	}
+	afterFlushStats := mgr.StatsSnapshot()
+	if got, want := afterFlushStats.PrimaryOnlyRootPublishes-beforeStats.PrimaryOnlyRootPublishes, uint64(1); got != want {
+		t.Fatalf("primary-only root publishes after flush delta=%d want %d", got, want)
+	}
+	if got, want := afterFlushStats.PrimaryOnlyRootDeltaEntries-beforeStats.PrimaryOnlyRootDeltaEntries, uint64(1); got != want {
+		t.Fatalf("primary-only root delta entries after flush delta=%d want %d", got, want)
+	}
+	if got, want := afterFlushStats.PrimaryOnlyCoalescedDocs-beforeStats.PrimaryOnlyCoalescedDocs, uint64(1); got != want {
+		t.Fatalf("primary-only coalesced docs delta=%d want %d", got, want)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after flush=%+v want empty", state)
+	}
+	got, err = col.Get([]byte("u1"))
 	if err != nil {
 		t.Fatalf("get updated document: %v", err)
 	}
@@ -103,7 +128,7 @@ func TestCollectionNoIndexUpdatePublishesSynchronouslyNotQueued(t *testing.T) {
 	}
 }
 
-func TestCollectionNoIndexUpdateFlushesPendingInsertBeforeSynchronousPublish(t *testing.T) {
+func TestCollectionNoIndexUpdateReadsAndOverwritesPendingInsert(t *testing.T) {
 	dir := t.TempDir()
 	d, err := backenddb.Open(backenddb.Options{Dir: dir})
 	if err != nil {
@@ -145,11 +170,11 @@ func TestCollectionNoIndexUpdateFlushesPendingInsertBeforeSynchronousPublish(t *
 		t.Fatalf("update pending insert matched/modified=%v/%v want true/true", matched, modified)
 	}
 	afterState := d.State()
-	if got, want := afterState.CommitSeq-beforeState.CommitSeq, uint64(2); got != want {
-		t.Fatalf("commit seq delta after insert flush + update publish=%d want %d", got, want)
+	if got := afterState.CommitSeq - beforeState.CommitSeq; got != 0 {
+		t.Fatalf("commit seq delta after staged insert update=%d want 0", got)
 	}
-	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
-		t.Fatalf("pending state after synchronous update=%+v want empty", state)
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen < 1 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after staged insert update=%+v want one unique no-index row", state)
 	}
 	if err := d.Close(); err != nil {
 		t.Fatalf("close db: %v", err)
@@ -250,7 +275,7 @@ func TestCollectionNoIndexUpdateMissingAndUnchangedDoNotPublishOrQueue(t *testin
 	}
 }
 
-func TestCollectionNoIndexUpdateFlushAfterSyncPublishDoesNotRepublish(t *testing.T) {
+func TestCollectionNoIndexUpdateFlushPublishesOnceThenNoOps(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -281,24 +306,36 @@ func TestCollectionNoIndexUpdateFlushAfterSyncPublishDoesNotRepublish(t *testing
 	beforeFlushStats := mgr.StatsSnapshot()
 
 	if err := col.Flush(); err != nil {
-		t.Fatalf("flush after synchronous update: %v", err)
+		t.Fatalf("flush staged update: %v", err)
 	}
-	if got := d.State().CommitSeq; got != beforeFlushState.CommitSeq {
-		t.Fatalf("flush after synchronous update commit seq=%d want %d", got, beforeFlushState.CommitSeq)
+	if got := d.State().CommitSeq; got != beforeFlushState.CommitSeq+1 {
+		t.Fatalf("flush staged update commit seq=%d want %d", got, beforeFlushState.CommitSeq+1)
 	}
-	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got != beforeFlushRoot {
-		t.Fatalf("flush after synchronous update primary root=%d want %d", got, beforeFlushRoot)
+	if got := collectionNoIndexPrimaryRootIDForTest(t, d, "users"); got == beforeFlushRoot {
+		t.Fatalf("flush staged update primary root stayed at %d", got)
 	}
 	afterFlushStats := mgr.StatsSnapshot()
-	if got := afterFlushStats.PrimaryOnlyRootPublishes - beforeFlushStats.PrimaryOnlyRootPublishes; got != 0 {
-		t.Fatalf("flush after synchronous update primary root publishes delta=%d want 0", got)
+	if got, want := afterFlushStats.PrimaryOnlyRootPublishes-beforeFlushStats.PrimaryOnlyRootPublishes, uint64(1); got != want {
+		t.Fatalf("flush staged update primary root publishes delta=%d want %d", got, want)
+	}
+	beforeSecondFlushState := d.State()
+	beforeSecondFlushStats := mgr.StatsSnapshot()
+	if err := col.Flush(); err != nil {
+		t.Fatalf("second flush: %v", err)
+	}
+	if got := d.State().CommitSeq; got != beforeSecondFlushState.CommitSeq {
+		t.Fatalf("second flush commit seq=%d want %d", got, beforeSecondFlushState.CommitSeq)
+	}
+	afterSecondFlushStats := mgr.StatsSnapshot()
+	if got := afterSecondFlushStats.PrimaryOnlyRootPublishes - beforeSecondFlushStats.PrimaryOnlyRootPublishes; got != 0 {
+		t.Fatalf("second flush primary root publishes delta=%d want 0", got)
 	}
 	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 0 || state.tableLen != 0 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
 		t.Fatalf("pending state after flush=%+v want empty", state)
 	}
 }
 
-func TestCollectionNoIndexUpdateSynchronousVisibilityAcrossManagers(t *testing.T) {
+func TestCollectionNoIndexUpdateWriteBackVisibilityAcrossManagers(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -334,17 +371,334 @@ func TestCollectionNoIndexUpdateSynchronousVisibilityAcrossManagers(t *testing.T
 	}
 
 	for name, reader := range map[string]*Collection{
-		"writer":               writer,
-		"same-manager-reader":  sameManagerReader,
-		"other-manager-reader": otherManagerReader,
+		"writer":              writer,
+		"same-manager-reader": sameManagerReader,
 	} {
 		got, err := reader.Get([]byte("u1"))
 		if err != nil {
-			t.Fatalf("%s get updated doc: %v", name, err)
+			t.Fatalf("%s get staged doc: %v", name, err)
 		}
 		if want := []byte(`{"name":"ada","city":"sea"}`); !bytes.Equal(got, want) {
-			t.Fatalf("%s updated doc=%q want %q", name, got, want)
+			t.Fatalf("%s staged doc=%q want %q", name, got, want)
 		}
+	}
+	got, err := otherManagerReader.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("other-manager get old doc before flush: %v", err)
+	}
+	if want := []byte(`{"name":"ada","city":"hnl"}`); !bytes.Equal(got, want) {
+		t.Fatalf("other-manager doc before flush=%q want %q", got, want)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush writer: %v", err)
+	}
+	got, err = otherManagerReader.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("other-manager get flushed doc: %v", err)
+	}
+	if want := []byte(`{"name":"ada","city":"sea"}`); !bytes.Equal(got, want) {
+		t.Fatalf("other-manager doc after flush=%q want %q", got, want)
+	}
+}
+
+func TestCollectionNoIndexRepeatedSameIDUpdatesCoalesceAndPreserveOrder(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"count":0}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	beforeStats := mgr.StatsSnapshot()
+
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		if !bytes.Equal(current, []byte(`{"count":0}`)) {
+			return nil, false, fmt.Errorf("first callback current=%q want count 0", current)
+		}
+		return []byte(`{"count":1}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("first update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("first update matched/modified=%v/%v want true/true", matched, modified)
+	}
+	matched, modified, err = col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		if !bytes.Equal(current, []byte(`{"count":1}`)) {
+			return nil, false, fmt.Errorf("second callback current=%q want count 1", current)
+		}
+		return []byte(`{"count":2}`), true, nil
+	})
+	if err != nil {
+		t.Fatalf("second update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("second update matched/modified=%v/%v want true/true", matched, modified)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen < 1 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after repeated updates=%+v want one unique no-index row", state)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get staged repeated update: %v", err)
+	}
+	if want := []byte(`{"count":2}`); !bytes.Equal(got, want) {
+		t.Fatalf("staged repeated update=%q want %q", got, want)
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush repeated updates: %v", err)
+	}
+	afterFlushStats := mgr.StatsSnapshot()
+	if got, want := afterFlushStats.PrimaryOnlyBufferedCalls-beforeStats.PrimaryOnlyBufferedCalls, uint64(2); got != want {
+		t.Fatalf("primary-only buffered calls delta=%d want %d", got, want)
+	}
+	if got, want := afterFlushStats.PrimaryOnlyRootPublishes-beforeStats.PrimaryOnlyRootPublishes, uint64(1); got != want {
+		t.Fatalf("primary-only root publishes delta=%d want %d", got, want)
+	}
+	if got, want := afterFlushStats.PrimaryOnlyCoalescedDocs-beforeStats.PrimaryOnlyCoalescedDocs, uint64(2); got != want {
+		t.Fatalf("primary-only coalesced docs delta=%d want %d", got, want)
+	}
+	if got, want := afterFlushStats.PrimaryOnlyRootDeltaEntries-beforeStats.PrimaryOnlyRootDeltaEntries, uint64(1); got != want {
+		t.Fatalf("primary-only root delta entries delta=%d want %d", got, want)
+	}
+	got, err = col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get flushed repeated update: %v", err)
+	}
+	if want := []byte(`{"count":2}`); !bytes.Equal(got, want) {
+		t.Fatalf("flushed repeated update=%q want %q", got, want)
+	}
+}
+
+func TestCollectionNoIndexUpdateBatchReadsStagedPrimaryOnlyValue(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"count":0}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	beforeState := d.State()
+	beforeStats := mgr.StatsSnapshot()
+	if _, _, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		if !bytes.Equal(current, []byte(`{"count":0}`)) {
+			return nil, false, fmt.Errorf("direct update current=%q want count 0", current)
+		}
+		return []byte(`{"count":1}`), true, nil
+	}); err != nil {
+		t.Fatalf("stage direct update: %v", err)
+	}
+
+	results, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: func(current []byte) ([]byte, bool, error) {
+			if !bytes.Equal(current, []byte(`{"count":1}`)) {
+				return nil, false, fmt.Errorf("batch update current=%q want staged count 1", current)
+			}
+			return []byte(`{"count":2}`), true, nil
+		}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("UpdateBatch results=%+v want one matched/modified result", results)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("staged direct+batch updates commit seq=%d want %d", got, beforeState.CommitSeq)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen < 1 || state.indexedQueued != 0 || state.indexedPublishing != 0 || state.indexedRootRuns != 0 {
+		t.Fatalf("pending state after direct+batch updates=%+v want one unique no-index row", state)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get staged batch update: %v", err)
+	}
+	if want := []byte(`{"count":2}`); !bytes.Equal(got, want) {
+		t.Fatalf("staged batch update=%q want %q", got, want)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush staged batch update: %v", err)
+	}
+	afterFlushStats := mgr.StatsSnapshot()
+	if got, want := afterFlushStats.PrimaryOnlyUpdateCalls-beforeStats.PrimaryOnlyUpdateCalls, uint64(2); got != want {
+		t.Fatalf("primary-only update calls delta=%d want %d", got, want)
+	}
+	if got, want := afterFlushStats.PrimaryOnlyBufferedCalls-beforeStats.PrimaryOnlyBufferedCalls, uint64(2); got != want {
+		t.Fatalf("primary-only buffered calls delta=%d want %d", got, want)
+	}
+	if got, want := afterFlushStats.PrimaryOnlyRootPublishes-beforeStats.PrimaryOnlyRootPublishes, uint64(1); got != want {
+		t.Fatalf("primary-only root publishes delta=%d want %d", got, want)
+	}
+	if got, want := afterFlushStats.PrimaryOnlyRootDeltaEntries-beforeStats.PrimaryOnlyRootDeltaEntries, uint64(1); got != want {
+		t.Fatalf("primary-only root delta entries delta=%d want %d", got, want)
+	}
+	if got, want := afterFlushStats.PrimaryOnlyCoalescedDocs-beforeStats.PrimaryOnlyCoalescedDocs, uint64(2); got != want {
+		t.Fatalf("primary-only coalesced docs delta=%d want %d", got, want)
+	}
+}
+
+func TestCollectionNoIndexUpdateCallbackErrorDoesNotDropPriorStagedUpdate(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"count":0}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	if _, _, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"count":1}`), true, nil
+	}); err != nil {
+		t.Fatalf("stage first update: %v", err)
+	}
+	beforeState := d.State()
+	beforeStats := mgr.StatsSnapshot()
+	sentinel := errors.New("callback failed")
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		if !bytes.Equal(current, []byte(`{"count":1}`)) {
+			t.Fatalf("error callback current=%q want staged count 1", current)
+		}
+		return nil, false, sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error callback err=%v want sentinel", err)
+	}
+	if matched || modified {
+		t.Fatalf("error callback matched/modified=%v/%v want false/false", matched, modified)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("failed callback commit seq=%d want %d", got, beforeState.CommitSeq)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen < 1 {
+		t.Fatalf("pending state after failed callback=%+v want prior staged row", state)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get after failed callback: %v", err)
+	}
+	if want := []byte(`{"count":1}`); !bytes.Equal(got, want) {
+		t.Fatalf("document after failed callback=%q want %q", got, want)
+	}
+	afterFailedStats := mgr.StatsSnapshot()
+	if got := afterFailedStats.PrimaryOnlyUpdateCalls - beforeStats.PrimaryOnlyUpdateCalls; got != 0 {
+		t.Fatalf("failed callback update calls delta=%d want 0", got)
+	}
+	if got := afterFailedStats.PrimaryOnlyBufferedCalls - beforeStats.PrimaryOnlyBufferedCalls; got != 0 {
+		t.Fatalf("failed callback buffered calls delta=%d want 0", got)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush prior staged update: %v", err)
+	}
+	got, err = col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get after flush: %v", err)
+	}
+	if want := []byte(`{"count":1}`); !bytes.Equal(got, want) {
+		t.Fatalf("document after flush=%q want %q", got, want)
+	}
+}
+
+func TestCollectionNoIndexUpdateCallbackPanicDoesNotDropPriorStagedUpdate(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"count":0}`)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
+	}
+	if _, _, err := col.Update([]byte("u1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"count":1}`), true, nil
+	}); err != nil {
+		t.Fatalf("stage first update: %v", err)
+	}
+	beforeState := d.State()
+	beforeStats := mgr.StatsSnapshot()
+	matched, modified, err := col.Update([]byte("u1"), func(current []byte) ([]byte, bool, error) {
+		if !bytes.Equal(current, []byte(`{"count":1}`)) {
+			t.Fatalf("panic callback current=%q want staged count 1", current)
+		}
+		panic("bad callback")
+	})
+	if err == nil || !bytes.Contains([]byte(err.Error()), []byte("bad callback")) {
+		t.Fatalf("panic callback err=%v want bad callback error", err)
+	}
+	if matched || modified {
+		t.Fatalf("panic callback matched/modified=%v/%v want false/false", matched, modified)
+	}
+	if got := d.State().CommitSeq; got != beforeState.CommitSeq {
+		t.Fatalf("panic callback commit seq=%d want %d", got, beforeState.CommitSeq)
+	}
+	if state := collectionNoIndexPendingStateForTest(t, col); state.count != 1 || state.tableLen < 1 {
+		t.Fatalf("pending state after panic callback=%+v want prior staged row", state)
+	}
+	afterPanicStats := mgr.StatsSnapshot()
+	if got := afterPanicStats.PrimaryOnlyUpdateCalls - beforeStats.PrimaryOnlyUpdateCalls; got != 0 {
+		t.Fatalf("panic callback update calls delta=%d want 0", got)
+	}
+	if got := afterPanicStats.PrimaryOnlyBufferedCalls - beforeStats.PrimaryOnlyBufferedCalls; got != 0 {
+		t.Fatalf("panic callback buffered calls delta=%d want 0", got)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush prior staged update: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get after flush: %v", err)
+	}
+	if want := []byte(`{"count":1}`); !bytes.Equal(got, want) {
+		t.Fatalf("document after flush=%q want %q", got, want)
 	}
 }
 

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -3,9 +3,9 @@
 Status: normative for the current implementation.
 
 This document specifies the current collection-local write-domain behavior for
-indexed collections. It intentionally does not promise a durable-at-ack
-collection mutation log; that is a future architecture option, not the current
-contract.
+indexed collections and primary-only no-index update write-back. It
+intentionally does not promise a durable-at-ack collection mutation log; that is
+a future architecture option, not the current contract.
 
 ## Indexed Write Memtables
 
@@ -21,10 +21,31 @@ The write domain stages the ordered runs for one collection together:
 The `DisableIndexedWriteMemtables` option is a debugging and benchmark baseline
 escape hatch. It is not the production-mainline path.
 
+## Primary-Only No-Index Write-Back
+
+For no-secondary-index JSON/BSON collections, modified `Collection.Update`
+calls stage the final replacement primary document bytes in the collection
+write domain instead of publishing a primary root before returning.
+
+The staged value shares the no-index primary table used by buffered no-index
+inserts. `Get`, `GetInto`, and later `Update` callbacks through the same
+collection manager must read that staged value before falling back to persisted
+primary roots.
+
+Repeated updates to the same document ID before a flush are serialized by the
+collection mutation lock. Each callback observes the previous staged
+replacement, while the pending primary table keeps only the latest value for
+the eventual root publish.
+
+The current implementation keeps indexed collections, unique-index work, and
+template-v1/template-root work on the indexed or synchronous paths unless a
+later PR explicitly extends the primary-only write-back contract to those
+shapes.
+
 ## Visibility
 
-Pending indexed writes are visible through the collection manager that owns the
-write domain.
+Pending indexed writes and primary-only no-index staged updates are visible
+through the collection manager that owns the write domain.
 
 Reads and checks MUST merge these layers with the following newest-to-oldest
 precedence:
@@ -43,6 +64,10 @@ This applies to:
 
 Tombstones in pending runs MUST suppress older values from persisted roots or
 older pending runs.
+
+For no-index primary-only staged updates, another collection manager on the same
+backend has a separate write domain and is not required to see staged values
+until the owning manager publishes them through a flush or close barrier.
 
 ## Flush Units
 
@@ -70,11 +95,13 @@ rotating new immutable units while the background publisher is busy.
 
 ## Durability Boundary
 
-The current async indexed write-domain contract is flush-boundary durable.
+The current collection write-domain contract is flush-boundary durable for both
+async indexed write memtables and primary-only no-index update write-back.
 
 An acknowledged collection write that is still only in mutable, queued, or
-publishing write-domain state is visible in-process through the owning manager,
-but callers MUST NOT treat that acknowledgement as a crash-durable boundary.
+publishing write-domain state, or in the no-index primary table, is visible
+in-process through the owning manager, but callers MUST NOT treat that
+acknowledgement as a crash-durable boundary.
 
 Durability is established when one of these barriers returns successfully:
 
@@ -85,6 +112,10 @@ Durability is established when one of these barriers returns successfully:
 
 A background async publish may complete before an explicit flush, but that is an
 implementation outcome, not a durable-at-ack API guarantee.
+
+`DB.Checkpoint()` is not a collection write-domain drain. It syncs backend state
+that has already been published, but it must not be relied on to publish staged
+primary-only no-index updates or queued/active indexed write-domain work.
 
 If TreeDB later needs durable-at-ack async collection writes, it MUST add a
 replayable collection mutation log or equivalent recovery mechanism before

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -162,13 +162,24 @@ unique checks, and update/delete planning must merge write-domain state with
 explicit newest-to-oldest precedence: current mutable runs, queued immutable
 flush units, in-flight async publishing units, then persisted roots.
 
+No-secondary-index JSON/BSON `Collection.Update` uses primary-only write-back:
+modified updates stage the final replacement primary document bytes in the
+owning collection manager's write domain. The owning manager sees staged values
+through point reads and later update callbacks before flush; another collection
+manager on the same backend is not required to see those values until they are
+published.
+
 `BufferedIndexedAsyncFlush` is a throughput feature, not a durable-at-ack
-mutation log. The current contract is flush-boundary durable: callers may treat
+mutation log. Primary-only no-index write-back has the same durability shape.
+The current contract is flush-boundary durable: callers may treat
 `Collection.Flush`, `CollectionManager.FlushAll`, backend `DB.Close`, or a
 threshold-triggered synchronous publish as durability boundaries when those
 operations return successfully. Background async publish may complete earlier,
-but acknowledged writes that remain only in mutable, queued, or publishing
-write-domain state must not be advertised as crash-durable.
+but acknowledged writes that remain only in mutable, queued, publishing, or
+no-index staged write-domain state must not be advertised as crash-durable.
+
+`DB.Checkpoint()` syncs already-published backend state but does not drain
+collection-local write-domain state.
 
 Operations that need persisted roots as planning input, including schema/index
 changes, must drain pending indexed write-domain state and wait for in-flight

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -182,8 +182,9 @@ no-index staged write-domain state must not be advertised as crash-durable.
 collection-local write-domain state.
 
 Operations that need persisted roots as planning input, including schema/index
-changes, must drain pending indexed write-domain state and wait for in-flight
-async publish units before taking their planning snapshot.
+changes, must drain primary-only no-index staged updates and pending indexed
+write-domain state, and wait for in-flight async publish units before taking
+their planning snapshot.
 
 Detailed indexed collection write-domain semantics are in
 `TreeDB/docs/spec/collections-write-domain.md`.

--- a/TreeDB/docs/spec/write-path-and-durability.md
+++ b/TreeDB/docs/spec/write-path-and-durability.md
@@ -104,6 +104,12 @@ Current behavior:
 
 In backend-only mode, checkpoint is implemented as an empty sync batch write.
 
+Collection-local write domains are a separate layer above backend checkpoint.
+`DB.Checkpoint()` does not drain collection-local staged no-index primary
+updates or queued/active indexed write memtables. Collection callers that need
+those staged writes to reach persisted collection roots must use
+`Collection.Flush`, `CollectionManager.FlushAll`, or backend `DB.Close`.
+
 ## 7. Auto-Checkpoint Defaults (Cached Mode)
 
 When WAL is enabled, public `treedb.Open` defaults to:

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1023,8 +1023,15 @@ func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 		assertInt32(t, response.doc, "nModified", 1)
 	}
 	after := db.State()
-	if after.CommitSeq != before.CommitSeq+1 {
-		t.Fatalf("coalesced updates advanced commit seq by %d, want 1", after.CommitSeq-before.CommitSeq)
+	if after.CommitSeq != before.CommitSeq {
+		t.Fatalf("coalesced updates advanced commit seq by %d before flush, want 0", after.CommitSeq-before.CommitSeq)
+	}
+	if err := server.Collections.FlushAll(); err != nil {
+		t.Fatalf("flush coalesced updates: %v", err)
+	}
+	flushed := db.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flushed coalesced updates advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
 	}
 }
 


### PR DESCRIPTION
## Summary
- changes eligible no-secondary-index JSON/BSON `Update` and no-index `UpdateBatch` paths to stage final primary document bytes in the existing collection write-domain no-index table
- makes same-manager reads and later callbacks observe staged values, while durability moves to `Flush`, `FlushAll`, and `Close`
- updates no-index baseline, checkpoint, combiner, BSON `_id`, close-drain, and docs around the new #1332 contract

## Notes
- indexed, unique, template-v1, secondary-root, and persisted index-state paths remain on the existing indexed/synchronous behavior
- `DB.Checkpoint()` is documented and tested as not draining collection-local staged no-index updates

## Verification
- `go test ./TreeDB/collections -count=1`
- `go test ./TreeDB/docs ./TreeDB/collections -count=1`
- `go test ./TreeDB/collections -run 'TestCollection(NoIndexUpdateBSON|UpdateBSONRejects)|TestCollectionNoIndexUpdate|TestPrimaryOnlyNoIndexUpdateCounters' -count=1`\n- `go test ./TreeDB/collections -run 'TestCollectionNoIndex(UpdateBatchReadsStagedPrimaryOnlyValue|UpdateCallbackErrorDoesNotDropPriorStagedUpdate|UpdateCallbackPanicDoesNotDropPriorStagedUpdate|RepeatedSameIDUpdatesCoalesceAndPreserveOrder)|TestCollectionUpdateBatchUpdatesMultipleDocuments' -count=1`\n\nA broader `go test ./TreeDB/... -count=1` run hit `TreeDB/caching TestVlogGenerationMaintenance_CheckpointPendingYieldsToDueAgeBlockedRetry`; the same test passed when rerun directly, and `go test ./TreeDB/caching -count=1` reproduced it independent of these collections changes.\n\nCloses #1332