### PR TITLE
TreeDB collections: make indexed flush publish batches explicit

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -660,23 +660,45 @@ type indexedFlushUnit struct {
 	rootRunCount    int
 }
 
-type indexedFlushPublishWork struct {
-	pin                *backenddb.Snapshot
-	meta               CollectionMeta
-	catalog            *collectionCatalog
-	baseSystemRoot     uint64
-	baseCommitSeq      uint64
-	units              []indexedFlushUnit
-	flushUnit          indexedFlushUnit
+type coalescedFlushBatchState uint8
+
+const (
+	coalescedFlushBatchQueued coalescedFlushBatchState = iota
+	coalescedFlushBatchActive
+	coalescedFlushBatchMaterializing
+	coalescedFlushBatchPublishing
+	coalescedFlushBatchPublished
+	coalescedFlushBatchRequeued
+	coalescedFlushBatchLostOwnership
+)
+
+type coalescedFlushBatch struct {
+	state coalescedFlushBatchState
+
+	// Original immutable units, in FIFO order. The merged unit is only the
+	// mechanical publish view for the current DB ordered-root API.
+	units      []indexedFlushUnit
+	mergedUnit indexedFlushUnit
+
 	rootNames          []string
 	rootBaseIDs        map[string]uint64
 	rootOverlays       map[string][]uint64
 	rootOverlayFilters map[string]collectionRootOverlayFilter
-	docCount           int
-	byteCount          int64
-	rootRunCount       int
-	rootCount          int
-	rootDeltaStats     collectionRootDeltaPlanStats
+
+	docCount       int
+	byteCount      int64
+	rootRunCount   int
+	rootCount      int
+	rootDeltaStats collectionRootDeltaPlanStats
+}
+
+type indexedFlushPublishWork struct {
+	pin            *backenddb.Snapshot
+	meta           CollectionMeta
+	catalog        *collectionCatalog
+	baseSystemRoot uint64
+	baseCommitSeq  uint64
+	batch          coalescedFlushBatch
 }
 
 type bufferedIndexedCheckpoint struct {
@@ -4974,9 +4996,11 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 
 	rotateIndexedMutableToFlushUnitLocked(domain)
 	units := domain.indexedFlushUnits
-	flushUnit := mergedIndexedFlushUnits(units)
-	rootNames := orderedBufferedRootNames(meta, flushUnit.rootRuns)
-	if len(rootNames) == 0 {
+	batch, err := buildCoalescedFlushBatchFromUnits(meta, catalog, units)
+	if err != nil {
+		return nil, err
+	}
+	if len(batch.rootNames) == 0 {
 		_ = pin.Close()
 		work.pin = nil
 		domain.indexedFlushUnits = nil
@@ -4988,28 +5012,10 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		domain.mutableBytes = 0
 		return nil, nil
 	}
-	rootBaseIDs := make(map[string]uint64, len(rootNames))
-	rootOverlays := make(map[string][]uint64, len(rootNames))
-	for _, rootName := range rootNames {
-		baseRoot, ok := flushUnit.rootBaseIDs[rootName]
-		if !ok {
-			err = fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
-			return nil, err
-		}
-		rootBaseIDs[rootName] = baseRoot
-		rootOverlays[rootName] = append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
-	}
+	batch.state = coalescedFlushBatchActive
 	work.baseSystemRoot = snapshotSystemRoot(pin)
 	work.baseCommitSeq = snapshotCommitSeq(pin)
-	work.units = units
-	work.flushUnit = flushUnit
-	work.rootNames = rootNames
-	work.rootBaseIDs = rootBaseIDs
-	work.rootOverlays = rootOverlays
-	work.docCount = flushUnit.docCount
-	work.byteCount = flushUnit.byteCount
-	work.rootRunCount = indexedFlushUnitRootRunCount(flushUnit)
-	work.rootCount = len(rootNames)
+	work.batch = batch
 
 	domain.indexedPublishingUnits = append(domain.indexedPublishingUnits, units...)
 	domain.indexedFlushUnits = nil
@@ -5029,27 +5035,29 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	}()
 	if collectionMetaUsesIndexedOverlayRoots(work.meta) {
 		materializeStart := time.Now()
-		rootOverlayFilters, err := buildCollectionRootOverlayFilters(work.rootNames, work.flushUnit.rootRuns, work.rootOverlays, work.catalog.rootOverlayFilters)
+		work.batch.state = coalescedFlushBatchMaterializing
+		rootOverlayFilters, err := buildCollectionRootOverlayFilters(work.batch.rootNames, work.batch.mergedUnit.rootRuns, work.batch.rootOverlays, work.catalog.rootOverlayFilters)
 		if err != nil {
 			materializeElapsed := collectionObservedElapsedSince(materializeStart)
 			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
-		work.rootOverlayFilters = rootOverlayFilters
-		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.flushUnit.rootPolicies, work.rootOverlays)
+		work.batch.rootOverlayFilters = rootOverlayFilters
+		ordered, cleanupDeltas, err := buildBufferedRootOverlayDeltaBatchPublishInputs(work.batch.rootNames, work.batch.mergedUnit.rootRuns, work.batch.mergedUnit.rootPolicies, work.batch.rootOverlays)
 		if err != nil {
 			materializeElapsed := collectionObservedElapsedSince(materializeStart)
 			return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 		}
-		work.rootDeltaStats = collectionRootDeltaPlanStatsFromOrdered(work.meta.Name, work.rootNames, ordered)
+		work.batch.rootDeltaStats = collectionRootDeltaPlanStatsFromOrdered(work.meta.Name, work.batch.rootNames, ordered)
 		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
+		work.batch.state = coalescedFlushBatchPublishing
 		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, work.rootOverlays, rootIDs)
+			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.batch.rootNames, work.batch.rootBaseIDs, work.batch.rootOverlays, rootIDs)
 		})
 		publishElapsed := collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
-		if publishErr == nil && len(rootIDs) != len(work.rootNames) {
-			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
+		if publishErr == nil && len(rootIDs) != len(work.batch.rootNames) {
+			publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.batch.rootNames), len(rootIDs))
 		}
 		completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, materializeElapsed+publishElapsed, materializeElapsed, publishElapsed)
 		if completeErr != nil {
@@ -5058,21 +5066,23 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		return publishErr
 	}
 	materializeStart := time.Now()
-	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.rootNames, work.flushUnit.rootRuns, work.rootBaseIDs, work.flushUnit.rootPolicies)
+	work.batch.state = coalescedFlushBatchMaterializing
+	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.batch.rootNames, work.batch.mergedUnit.rootRuns, work.batch.rootBaseIDs, work.batch.mergedUnit.rootPolicies)
 	if err != nil {
 		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 	}
-	work.rootDeltaStats = collectionRootDeltaPlanStatsFromOrdered(work.meta.Name, work.rootNames, ordered)
+	work.batch.rootDeltaStats = collectionRootDeltaPlanStatsFromOrdered(work.meta.Name, work.batch.rootNames, ordered)
 	materializeElapsed := collectionObservedElapsedSince(materializeStart)
 	publishStart := time.Now()
+	work.batch.state = coalescedFlushBatchPublishing
 	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.rootNames, work.rootBaseIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.batch.rootNames, work.batch.rootBaseIDs, rootIDs)
 	})
 	publishElapsed := collectionObservedElapsedSince(publishStart)
 	cleanupDeltas()
-	if publishErr == nil && len(rootIDs) != len(work.rootNames) {
-		publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.rootNames), len(rootIDs))
+	if publishErr == nil && len(rootIDs) != len(work.batch.rootNames) {
+		publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.batch.rootNames), len(rootIDs))
 	}
 	completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, materializeElapsed+publishElapsed, materializeElapsed, publishElapsed)
 	if completeErr != nil {
@@ -5340,20 +5350,22 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 		if errors.Is(publishErr, ErrConcurrentMutation) {
 			domain.indexedFlushRootBaseMismatches.Add(1)
 		}
-		removed, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
+		removed, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.batch.units)
 		if !owned {
 			err := errors.Join(errIndexedFlushLostOwnership, publishErr)
+			work.batch.state = coalescedFlushBatchLostOwnership
 			domain.indexedFlushLostOwnership.Add(1)
-			domain.observeIndexedFlush(len(work.units), work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, err)
+			domain.observeIndexedFlush(len(work.batch.units), work.batch.docCount, work.batch.byteCount, work.batch.rootRunCount, work.batch.rootCount, observedElapsed(), materializeElapsed, publishElapsed, err)
 			return err
 		}
 		if len(removed) > 0 {
 			domain.indexedFlushRequeues.Add(1)
 			domain.indexedFlushRequeuedUnits.Add(uint64(len(removed)))
 		}
+		work.batch.state = coalescedFlushBatchRequeued
 		domain.indexedFlushUnits = append(removed, domain.indexedFlushUnits...)
 		rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
-		domain.observeIndexedFlush(len(work.units), work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, publishErr)
+		domain.observeIndexedFlush(len(work.batch.units), work.batch.docCount, work.batch.byteCount, work.batch.rootRunCount, work.batch.rootCount, observedElapsed(), materializeElapsed, publishElapsed, publishErr)
 		return publishErr
 	}
 	baseCatalog := domain.catalog
@@ -5361,35 +5373,37 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 		baseCatalog = work.catalog
 	}
 	overlayPublish := collectionMetaUsesIndexedOverlayRoots(work.meta)
-	nextCatalog := cloneCatalogWithRootUpdates(baseCatalog, work.meta, work.rootNames, rootIDs)
+	nextCatalog := cloneCatalogWithRootUpdates(baseCatalog, work.meta, work.batch.rootNames, rootIDs)
 	if overlayPublish {
-		nextCatalog = cloneCatalogWithRootOverlays(baseCatalog, work.meta, work.rootNames, rootIDs)
-		nextCatalog = cloneCatalogWithRootOverlayFilters(nextCatalog, work.rootNames, rootIDs, work.rootOverlayFilters)
+		nextCatalog = cloneCatalogWithRootOverlays(baseCatalog, work.meta, work.batch.rootNames, rootIDs)
+		nextCatalog = cloneCatalogWithRootOverlayFilters(nextCatalog, work.batch.rootNames, rootIDs, work.batch.rootOverlayFilters)
 	}
-	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.units)
+	oldPublishing, owned := removeIndexedPublishingWorkUnitsLocked(domain, work.batch.units)
 	if !owned {
+		work.batch.state = coalescedFlushBatchLostOwnership
 		domain.indexedFlushLostOwnership.Add(1)
-		domain.observeIndexedFlush(len(work.units), work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, errIndexedFlushLostOwnership)
+		domain.observeIndexedFlush(len(work.batch.units), work.batch.docCount, work.batch.byteCount, work.batch.rootRunCount, work.batch.rootCount, observedElapsed(), materializeElapsed, publishElapsed, errIndexedFlushLostOwnership)
 		return errIndexedFlushLostOwnership
 	}
+	work.batch.state = coalescedFlushBatchPublished
 	domain.loaded = true
 	domain.meta = work.meta
 	domain.catalog = nextCatalog
 	domain.baseCommitSeq = c.commitSeqForSystemRoot(newSystemRoot)
 	domain.baseSystemRoot = newSystemRoot
 	domain.primaryRoot = nextCatalog.rootID(collectionPrimaryRootName(work.meta.Name))
-	domain.count = subtractNonNegativeInt(domain.count, work.docCount)
-	domain.bufferedBytes = subtractNonNegativeInt64(domain.bufferedBytes, work.byteCount)
+	domain.count = subtractNonNegativeInt(domain.count, work.batch.docCount)
+	domain.bufferedBytes = subtractNonNegativeInt64(domain.bufferedBytes, work.batch.byteCount)
 	domain.clearIndexedAsyncFlushError()
 	if !overlayPublish {
-		retargetPendingIndexedRootBaseIDsLocked(domain, work.rootNames, work.rootBaseIDs, rootIDs)
+		retargetPendingIndexedRootBaseIDsLocked(domain, work.batch.rootNames, work.batch.rootBaseIDs, rootIDs)
 	}
 	rebuildBufferedPendingIndexesLocked(domain, work.meta.Name, preservePrimaryRunIndex)
 	c.meta = work.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	resetIndexedFlushUnits(oldPublishing)
-	domain.observeIndexedFlush(len(work.units), work.docCount, work.byteCount, work.rootRunCount, work.rootCount, observedElapsed(), materializeElapsed, publishElapsed, nil)
-	domain.observeRootDeltaPlan(work.rootDeltaStats)
+	domain.observeIndexedFlush(len(work.batch.units), work.batch.docCount, work.batch.byteCount, work.batch.rootRunCount, work.batch.rootCount, observedElapsed(), materializeElapsed, publishElapsed, nil)
+	domain.observeRootDeltaPlan(work.batch.rootDeltaStats)
 	return nil
 }
 
@@ -5668,6 +5682,38 @@ func retargetPendingIndexedRootBaseIDsLocked(domain *collectionWriteDomain, root
 		retarget(domain.indexedFlushUnits[i].rootBaseIDs)
 	}
 	retarget(domain.rootBaseIDs)
+}
+
+func buildCoalescedFlushBatchFromUnits(meta CollectionMeta, catalog *collectionCatalog, units []indexedFlushUnit) (coalescedFlushBatch, error) {
+	merged := mergedIndexedFlushUnits(units)
+	rootNames := orderedBufferedRootNames(meta, merged.rootRuns)
+	batch := coalescedFlushBatch{
+		state:        coalescedFlushBatchQueued,
+		units:        append([]indexedFlushUnit(nil), units...),
+		mergedUnit:   merged,
+		rootNames:    rootNames,
+		docCount:     merged.docCount,
+		byteCount:    merged.byteCount,
+		rootRunCount: indexedFlushUnitRootRunCount(merged),
+		rootCount:    len(rootNames),
+	}
+	if len(rootNames) == 0 {
+		return batch, nil
+	}
+	if catalog == nil {
+		return coalescedFlushBatch{}, errCollectionNotFound
+	}
+	batch.rootBaseIDs = make(map[string]uint64, len(rootNames))
+	batch.rootOverlays = make(map[string][]uint64, len(rootNames))
+	for _, rootName := range rootNames {
+		baseRoot, ok := merged.rootBaseIDs[rootName]
+		if !ok {
+			return coalescedFlushBatch{}, fmt.Errorf("collections: buffered indexed flush missing base root for %q", rootName)
+		}
+		batch.rootBaseIDs[rootName] = baseRoot
+		batch.rootOverlays[rootName] = append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
+	}
+	return batch, nil
 }
 
 func mergedIndexedFlushUnits(units []indexedFlushUnit) indexedFlushUnit {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4944,6 +4944,9 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 	if c == nil || c.db == nil || domain == nil || domain.count == 0 || !hasBufferedIndexedRootRuns(domain) {
 		return nil, nil
 	}
+	if len(domain.indexedPublishingUnits) != 0 {
+		return nil, errors.New("collections: indexed async publish still in flight")
+	}
 	if len(domain.indexedFlushUnits) == 0 && len(domain.rootRuns) == 0 {
 		return nil, nil
 	}
@@ -5017,7 +5020,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 	work.baseCommitSeq = snapshotCommitSeq(pin)
 	work.batch = batch
 
-	domain.indexedPublishingUnits = append(domain.indexedPublishingUnits, units...)
+	domain.indexedPublishingUnits = append([]indexedFlushUnit(nil), units...)
 	domain.indexedFlushUnits = nil
 	domain.writeGeneration++
 	return work, nil
@@ -5613,7 +5616,7 @@ func removeIndexedPublishingUnitsLocked(domain *collectionWriteDomain, n int) []
 	if n > len(domain.indexedPublishingUnits) {
 		n = len(domain.indexedPublishingUnits)
 	}
-	removed := domain.indexedPublishingUnits[:n]
+	removed := append([]indexedFlushUnit(nil), domain.indexedPublishingUnits[:n]...)
 	remaining := domain.indexedPublishingUnits[n:]
 	if len(remaining) == 0 {
 		domain.indexedPublishingUnits = nil
@@ -5627,7 +5630,7 @@ func removeIndexedPublishingWorkUnitsLocked(domain *collectionWriteDomain, units
 	if len(units) == 0 {
 		return nil, true
 	}
-	if domain == nil || len(domain.indexedPublishingUnits) < len(units) {
+	if domain == nil || len(domain.indexedPublishingUnits) != len(units) {
 		return nil, false
 	}
 	for i := range units {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -5180,6 +5180,9 @@ func TestCollectionIndexedWriteMemtablesAsyncPublishingUnitsParticipateInReadsAn
 	if err := col.publishPreparedIndexedFlush(work); err != nil {
 		t.Fatalf("publish prepared async flush: %v", err)
 	}
+	if got := work.batch.state; got != coalescedFlushBatchPublished {
+		t.Fatalf("published batch state=%d want published", got)
+	}
 	if got := mgr.StatsSnapshot().PendingDocuments; got != 0 {
 		t.Fatalf("pending docs after publish=%d want 0", got)
 	}

--- a/TreeDB/collections/indexed_flush_guard_counters_test.go
+++ b/TreeDB/collections/indexed_flush_guard_counters_test.go
@@ -128,7 +128,7 @@ func TestCollectionIndexedFlushGuardCounters(t *testing.T) {
 		col.writeDomain.mu.Lock()
 		col.writeDomain.indexedPublishingUnits = []indexedFlushUnit{{}}
 		col.writeDomain.mu.Unlock()
-		rootIDs := make([]uint64, len(work.rootNames))
+		rootIDs := make([]uint64, len(work.batch.rootNames))
 		for i := range rootIDs {
 			rootIDs[i] = uint64(1000 + i)
 		}

--- a/TreeDB/collections/indexed_flush_ownership_test.go
+++ b/TreeDB/collections/indexed_flush_ownership_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func TestCollectionIndexedAsyncPublishLostOwnershipDoesNotRemoveCurrentPublishingUnit(t *testing.T) {
@@ -122,5 +123,40 @@ func TestCollectionIndexedAsyncPublishLostOwnershipDoesNotRemoveCurrentPublishin
 	}
 	if got := stats.IndexedFlushLostOwnership; got != 1 {
 		t.Fatalf("indexed flush lost ownership=%d want 1", got)
+	}
+}
+
+func TestIndexedPublishingWorkOwnershipRejectsPrefixOfActiveBatch(t *testing.T) {
+	unitA := indexedFlushOwnershipUnitForTest("users")
+	unitB := indexedFlushOwnershipUnitForTest("users")
+	t.Cleanup(func() {
+		resetIndexedFlushUnits([]indexedFlushUnit{unitA, unitB})
+	})
+
+	domain := &collectionWriteDomain{
+		indexedPublishingUnits: []indexedFlushUnit{unitA, unitB},
+	}
+	removed, owned := removeIndexedPublishingWorkUnitsLocked(domain, []indexedFlushUnit{unitA})
+	if owned {
+		t.Fatal("prefix work unexpectedly owned the active multi-unit batch")
+	}
+	if removed != nil {
+		t.Fatalf("removed prefix units=%+v want nil", removed)
+	}
+	if got := len(domain.indexedPublishingUnits); got != 2 {
+		t.Fatalf("active publishing units after prefix removal attempt=%d want 2", got)
+	}
+	if !sameIndexedFlushUnitTables(domain.indexedPublishingUnits[0], unitA) ||
+		!sameIndexedFlushUnitTables(domain.indexedPublishingUnits[1], unitB) {
+		t.Fatal("active publishing units changed after rejected prefix ownership attempt")
+	}
+}
+
+func indexedFlushOwnershipUnitForTest(collectionName string) indexedFlushUnit {
+	rootName := collectionPrimaryRootName(collectionName)
+	return indexedFlushUnit{
+		rootRuns: map[string][]memtable.Table{
+			rootName: {newCollectionRunTable(0)},
+		},
 	}
 }

--- a/TreeDB/collections/indexed_flush_ownership_test.go
+++ b/TreeDB/collections/indexed_flush_ownership_test.go
@@ -44,6 +44,9 @@ func TestCollectionIndexedAsyncPublishLostOwnershipDoesNotRemoveCurrentPublishin
 	if work == nil {
 		t.Fatal("prepare async publish returned nil work")
 	}
+	if got := work.batch.state; got != coalescedFlushBatchActive {
+		t.Fatalf("prepared batch state=%d want active", got)
+	}
 	if work.pin != nil {
 		defer func() { _ = work.pin.Close() }()
 	}
@@ -72,13 +75,16 @@ func TestCollectionIndexedAsyncPublishLostOwnershipDoesNotRemoveCurrentPublishin
 		resetIndexedFlushUnits(publishingUnits)
 	})
 
-	rootIDs := make([]uint64, len(work.rootNames))
+	rootIDs := make([]uint64, len(work.batch.rootNames))
 	for i := range rootIDs {
 		rootIDs[i] = uint64(1000 + i)
 	}
 	err = col.completePreparedIndexedFlush(work, 999, rootIDs, nil, 0, 0, 0)
 	if !errors.Is(err, errIndexedFlushLostOwnership) {
 		t.Fatalf("complete lost ownership err=%v want lost ownership", err)
+	}
+	if got := work.batch.state; got != coalescedFlushBatchLostOwnership {
+		t.Fatalf("lost-ownership batch state=%d want lost ownership", got)
 	}
 
 	col.writeDomain.mu.RLock()

--- a/TreeDB/collections/indexed_flush_requeue_test.go
+++ b/TreeDB/collections/indexed_flush_requeue_test.go
@@ -48,6 +48,9 @@ func TestCollectionIndexedAsyncPublishFailureRequeuesUnitsAndPreservesUniqueRese
 	if work == nil {
 		t.Fatal("prepare async publish returned nil work")
 	}
+	if got := work.batch.state; got != coalescedFlushBatchActive {
+		t.Fatalf("prepared batch state=%d want active", got)
+	}
 	defer collectionTestCloseIndexedFlushWork(work)
 
 	if _, err := col.InsertBatch(
@@ -76,6 +79,9 @@ func TestCollectionIndexedAsyncPublishFailureRequeuesUnitsAndPreservesUniqueRese
 	injectedErr := errors.New("injected publish failure")
 	if err := col.completePreparedIndexedFlush(work, 0, nil, injectedErr, 0, 0, 0); !errors.Is(err, injectedErr) {
 		t.Fatalf("complete failure err=%v want injected publish failure", err)
+	}
+	if got := work.batch.state; got != coalescedFlushBatchRequeued {
+		t.Fatalf("failed batch state=%d want requeued", got)
 	}
 
 	col.writeDomain.mu.RLock()

--- a/TreeDB/collections/indexed_flush_root_mismatch_test.go
+++ b/TreeDB/collections/indexed_flush_root_mismatch_test.go
@@ -115,6 +115,9 @@ func TestCollectionIndexedAsyncPublishRootBaseMismatchRequeuesFIFOAndCounts(t *t
 	if work == nil {
 		t.Fatal("prepare left async publish returned nil work")
 	}
+	if got := work.batch.state; got != coalescedFlushBatchActive {
+		t.Fatalf("prepared batch state=%d want active", got)
+	}
 	defer collectionTestCloseIndexedFlushWork(work)
 
 	if _, err := left.InsertBatch(
@@ -154,6 +157,9 @@ func TestCollectionIndexedAsyncPublishRootBaseMismatchRequeuesFIFOAndCounts(t *t
 
 	if err := left.publishPreparedIndexedFlush(work); !errors.Is(err, ErrConcurrentMutation) {
 		t.Fatalf("publish prepared left err=%v want ErrConcurrentMutation", err)
+	}
+	if got := work.batch.state; got != coalescedFlushBatchRequeued {
+		t.Fatalf("root-mismatched batch state=%d want requeued", got)
 	}
 
 	prefixA := indexedFlushRequeueEmailPrefix(t, "a@example.com")

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -26,12 +26,11 @@ escape hatch. It is not the production-mainline path.
 Pending indexed writes are visible through the collection manager that owns the
 write domain.
 
-Reads and checks MUST merge these layers with the following newest-to-oldest
-precedence:
+Reads and checks MUST merge these layers with the following precedence:
 
-1. current mutable indexed runs,
-2. queued immutable indexed flush units,
-3. in-flight async publishing units,
+1. the active in-flight async publishing batch, in original FIFO unit order,
+2. queued immutable indexed flush units, in FIFO order,
+3. current mutable indexed runs,
 4. persisted backend roots from the current collection catalog.
 
 This applies to:
@@ -58,9 +57,11 @@ separate durable log.
 `BufferedIndexedAsyncFlush` allows threshold-triggered indexed flush units to be
 published by a background worker.
 
-The async worker may move a queued immutable unit into the publishing state
-before root publication completes. Publishing units remain visible to reads,
-unique checks, schema-change barriers, and explicit flush barriers.
+The async worker may move queued immutable units into one active coalesced flush
+batch before root publication completes. The batch preserves the original FIFO
+unit boundaries and uses a mechanical merged view only for ordered-root publish.
+Active publishing units remain visible to reads, unique checks,
+schema-change barriers, and explicit flush barriers.
 
 `BufferedIndexedAsyncFlushMaxQueuedUnits` bounds queued immutable flush units.
 When the queue is full and a publish is already in flight, writers MUST apply

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -26,11 +26,13 @@ escape hatch. It is not the production-mainline path.
 Pending indexed writes are visible through the collection manager that owns the
 write domain.
 
-Reads and checks MUST merge these layers with the following precedence:
+Reads and checks enumerate pending runs in active, queued, then mutable order.
+Lookups and merged iterators use newest-wins shadowing, so effective precedence
+is:
 
-1. the active in-flight async publishing batch, in original FIFO unit order,
+1. current mutable indexed runs,
 2. queued immutable indexed flush units, in FIFO order,
-3. current mutable indexed runs,
+3. the active in-flight async publishing batch, in original FIFO unit order,
 4. persisted backend roots from the current collection catalog.
 
 This applies to:

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -159,8 +159,8 @@ Indexed collection writes use collection-local write memtables by default.
 Pending indexed writes are visible through the owning collection manager before
 they are published to persisted roots. Primary reads, secondary index lookups,
 unique checks, and update/delete planning must merge write-domain state with
-explicit precedence: active in-flight async publishing units, queued immutable
-flush units, current mutable runs, then persisted roots. The active async
+newest-wins shadowing: current mutable runs, queued immutable flush units,
+active in-flight async publishing units, then persisted roots. The active async
 publish uses a coalesced flush batch that preserves original FIFO unit
 boundaries while using a mechanical merged view for ordered-root publish.
 

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -159,8 +159,10 @@ Indexed collection writes use collection-local write memtables by default.
 Pending indexed writes are visible through the owning collection manager before
 they are published to persisted roots. Primary reads, secondary index lookups,
 unique checks, and update/delete planning must merge write-domain state with
-explicit newest-to-oldest precedence: current mutable runs, queued immutable
-flush units, in-flight async publishing units, then persisted roots.
+explicit precedence: active in-flight async publishing units, queued immutable
+flush units, current mutable runs, then persisted roots. The active async
+publish uses a coalesced flush batch that preserves original FIFO unit
+boundaries while using a mechanical merged view for ordered-root publish.
 
 `BufferedIndexedAsyncFlush` is a throughput feature, not a durable-at-ack
 mutation log. The current contract is flush-boundary durable: callers may treat


### PR DESCRIPTION
## Summary

- Introduce an explicit `coalescedFlushBatch` for indexed async publish work, preserving original FIFO `indexedFlushUnit` boundaries separately from the mechanical merged publish view.
- Move publish-attempt root names, base IDs, overlays, counters, and root-delta stats under `indexedFlushPublishWork.batch` and record batch state transitions for active, materializing, publishing, published, requeued, and lost-ownership outcomes.
- Extend existing requeue/root-mismatch/lost-ownership/publishing tests to assert the new batch lifecycle states.
- Update collection write-domain specs to document active async publishing batch precedence and FIFO unit preservation.

## Scope boundaries

This is PR3a indexed coordinator lifecycle plumbing only. It intentionally does not change:

- no-index / primary-only `Collection.Update` behavior,
- `flushBufferedNoIndexLocked`,
- primary-only counters,
- PR3b semantic coalescing,
- prepared output, root rebase, leaf-span planning, or DB ordered-root publish APIs.

## Verification

Passed:

```bash
go test ./TreeDB/collections -run 'TestCollectionIndexedAsyncPublish(FailureRequeuesUnitsAndPreservesUniqueReservations|RootBaseMismatchRequeuesFIFOAndCounts|LostOwnershipDoesNotRemoveCurrentPublishingUnit)|TestCollectionIndexedFlushGuardCounters|TestCollectionFindByIndexRangeSeesPublishingIndexedFlushUnits' -count=1
go test ./TreeDB/collections -count=1
go test ./TreeDB/docs ./TreeDB/collections -count=1
go test ./TreeDB/db ./TreeDB/collections ./TreeDB/docs -count=1
go test -race ./TreeDB/collections -run 'TestCollectionIndexedAsyncPublish(FailureRequeuesUnitsAndPreservesUniqueReservations|RootBaseMismatchRequeuesFIFOAndCounts|LostOwnershipDoesNotRemoveCurrentPublishingUnit)|TestCollectionIndexedWriteMemtablesAsyncPublishingUnitsParticipateInReadsAndUniqueChecks' -count=1
go test ./TreeDB/caching -run 'TestVlogGenerationMaintenance_CheckpointPendingYieldsToDueAgeBlockedRetry' -count=1
```

Full sweep note:

```bash
go test ./... -count=1
```

does not currently pass on this checkout because tracked prompt-packet source copies under `artifacts/gpt5pro_1332_pr3a/packets/...` are included as Go packages and violate Go `internal` package import rules. The same sweep also reproduced the existing order-sensitive `TreeDB/caching` failure in `TestVlogGenerationMaintenance_CheckpointPendingYieldsToDueAgeBlockedRetry`; that test passed when run directly as shown above.

Refs #1242.
