### PR TITLE
PR3b: capture raw semantic indexed update records

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -403,77 +403,82 @@ type CollectionUpdateIndexStats struct {
 // CollectionManager. The counters are process-local observability; they are
 // not persisted with collection metadata.
 type CollectionManagerStats struct {
-	Domains                        int
-	PendingDocuments               int
-	PendingBytes                   int64
-	PendingRootRuns                int
-	PendingIndexedFlushUnits       int
-	OverlayMutableDocuments        int
-	OverlayQueuedIndexedFlushUnits int
-	OverlayActiveIndexedFlushUnits int
-	OverlayVisibleDepth            int
-	IndexedAsyncFlushRunning       int
-	MutationLockCalls              uint64
-	MutationLockWait               time.Duration
-	MutationLockHold               time.Duration
-	IndexedStageBatches            uint64
-	IndexedStageDocs               uint64
-	IndexedStageBytes              uint64
-	IndexedStageRootRuns           uint64
-	IndexedAutoFlushes             uint64
-	IndexedAsyncFlushScheduled     uint64
-	IndexedAsyncFlushBackpressure  uint64
-	IndexedAsyncFlushWait          time.Duration
-	IndexedAsyncFlushErrors        uint64
-	IndexedFlushCalls              uint64
-	IndexedFlushErrors             uint64
-	IndexedFlushForcedDrains       uint64
-	IndexedFlushUnits              uint64
-	IndexedFlushDocs               uint64
-	IndexedFlushBytes              uint64
-	IndexedFlushRootRuns           uint64
-	IndexedFlushRoots              uint64
-	IndexedFlushDuration           time.Duration
-	IndexedFlushMaterialize        time.Duration
-	IndexedFlushPublish            time.Duration
-	RootDeltaPlanPrimaryRoots      uint64
-	RootDeltaPlanTemplateRoots     uint64
-	RootDeltaPlanIndexStateRoots   uint64
-	RootDeltaPlanSecondaryRoots    uint64
-	RootDeltaPlanEntries           uint64
-	RootDeltaPlanKeyBytes          uint64
-	RootDeltaPlanValueBytes        uint64
-	RootDeltaPlanTombstones        uint64
-	PrimaryOnlyUpdateCalls         uint64
-	PrimaryOnlyMatched             uint64
-	PrimaryOnlyModified            uint64
-	PrimaryOnlyBufferedCalls       uint64
-	PrimaryOnlyRootPublishes       uint64
-	PrimaryOnlyRootDeltaEntries    uint64
-	PrimaryOnlyRootDeltaKeyBytes   uint64
-	PrimaryOnlyRootDeltaValueBytes uint64
-	PrimaryOnlyCoalescedDocs       uint64
-	UpdateCombineRequests          uint64
-	UpdateCombineBatches           uint64
-	UpdateCombineBatchedRequests   uint64
-	UpdateCombineFallbackRequests  uint64
-	UpdateCombineQueueDepthMax     uint64
-	UpdateBatchCalls               uint64
-	UpdateBatchItems               uint64
-	UpdateBatchMatched             uint64
-	UpdateBatchModified            uint64
-	UpdateBatchRuns                uint64
-	UpdateBatchBufferedBatches     uint64
-	UpdateBatchCurrentRead         time.Duration
-	UpdateBatchCallback            time.Duration
-	UpdateBatchPrepareDocuments    time.Duration
-	UpdateBatchIndexStateExtract   time.Duration
-	UpdateBatchUniquePreflight     time.Duration
-	UpdateBatchTemplateRunBuild    time.Duration
-	UpdateBatchPrimaryRunBuild     time.Duration
-	UpdateBatchIndexStateRunBuild  time.Duration
-	UpdateBatchSecondaryRunBuild   time.Duration
-	UpdateBatchBufferStage         time.Duration
+	Domains                         int
+	PendingDocuments                int
+	PendingBytes                    int64
+	PendingRootRuns                 int
+	PendingIndexedFlushUnits        int
+	PendingIndexedSemanticRecords   int
+	OverlayMutableDocuments         int
+	OverlayQueuedIndexedFlushUnits  int
+	OverlayActiveIndexedFlushUnits  int
+	OverlayVisibleDepth             int
+	IndexedAsyncFlushRunning        int
+	MutationLockCalls               uint64
+	MutationLockWait                time.Duration
+	MutationLockHold                time.Duration
+	IndexedStageBatches             uint64
+	IndexedStageDocs                uint64
+	IndexedStageBytes               uint64
+	IndexedStageRootRuns            uint64
+	IndexedSemanticRawRecords       uint64
+	IndexedSemanticRawIndexDeltas   uint64
+	IndexedSemanticFallbackRecords  uint64
+	IndexedSemanticEffectiveRecords uint64
+	IndexedAutoFlushes              uint64
+	IndexedAsyncFlushScheduled      uint64
+	IndexedAsyncFlushBackpressure   uint64
+	IndexedAsyncFlushWait           time.Duration
+	IndexedAsyncFlushErrors         uint64
+	IndexedFlushCalls               uint64
+	IndexedFlushErrors              uint64
+	IndexedFlushForcedDrains        uint64
+	IndexedFlushUnits               uint64
+	IndexedFlushDocs                uint64
+	IndexedFlushBytes               uint64
+	IndexedFlushRootRuns            uint64
+	IndexedFlushRoots               uint64
+	IndexedFlushDuration            time.Duration
+	IndexedFlushMaterialize         time.Duration
+	IndexedFlushPublish             time.Duration
+	RootDeltaPlanPrimaryRoots       uint64
+	RootDeltaPlanTemplateRoots      uint64
+	RootDeltaPlanIndexStateRoots    uint64
+	RootDeltaPlanSecondaryRoots     uint64
+	RootDeltaPlanEntries            uint64
+	RootDeltaPlanKeyBytes           uint64
+	RootDeltaPlanValueBytes         uint64
+	RootDeltaPlanTombstones         uint64
+	PrimaryOnlyUpdateCalls          uint64
+	PrimaryOnlyMatched              uint64
+	PrimaryOnlyModified             uint64
+	PrimaryOnlyBufferedCalls        uint64
+	PrimaryOnlyRootPublishes        uint64
+	PrimaryOnlyRootDeltaEntries     uint64
+	PrimaryOnlyRootDeltaKeyBytes    uint64
+	PrimaryOnlyRootDeltaValueBytes  uint64
+	PrimaryOnlyCoalescedDocs        uint64
+	UpdateCombineRequests           uint64
+	UpdateCombineBatches            uint64
+	UpdateCombineBatchedRequests    uint64
+	UpdateCombineFallbackRequests   uint64
+	UpdateCombineQueueDepthMax      uint64
+	UpdateBatchCalls                uint64
+	UpdateBatchItems                uint64
+	UpdateBatchMatched              uint64
+	UpdateBatchModified             uint64
+	UpdateBatchRuns                 uint64
+	UpdateBatchBufferedBatches      uint64
+	UpdateBatchCurrentRead          time.Duration
+	UpdateBatchCallback             time.Duration
+	UpdateBatchPrepareDocuments     time.Duration
+	UpdateBatchIndexStateExtract    time.Duration
+	UpdateBatchUniquePreflight      time.Duration
+	UpdateBatchTemplateRunBuild     time.Duration
+	UpdateBatchPrimaryRunBuild      time.Duration
+	UpdateBatchIndexStateRunBuild   time.Duration
+	UpdateBatchSecondaryRunBuild    time.Duration
+	UpdateBatchBufferStage          time.Duration
 	// Detailed buffer-stage aggregate timings are populated only when
 	// CollectionManager.SetUpdateBatchDetailedStatsEnabled(true) is enabled.
 	// UpdateBatchBufferLockHold is an enclosing domain mutex hold-time metric
@@ -649,11 +654,42 @@ type noIndexBatchEntry struct {
 	document []byte
 }
 
+type indexedSemanticRecordKind uint8
+
+const (
+	indexedSemanticRecordUnknown indexedSemanticRecordKind = iota
+	indexedSemanticRecordUpdate
+)
+
+type indexedSemanticFallbackReason uint8
+
+const (
+	indexedSemanticFallbackNone indexedSemanticFallbackReason = iota
+	indexedSemanticFallbackRawOnly
+)
+
+type indexedSemanticRecord struct {
+	kind        indexedSemanticRecordKind
+	documentID  []byte
+	indexDeltas []indexedSemanticIndexDelta
+	fallback    indexedSemanticFallbackReason
+}
+
+type indexedSemanticIndexDelta struct {
+	indexName  string
+	rootName   string
+	runtimeIdx int
+	unique     bool
+	oldValues  [][]byte
+	newValues  [][]byte
+}
+
 type indexedFlushUnit struct {
 	rootRuns        map[string][]memtable.Table
 	rootPolicies    map[string]backenddb.OrderedRootStoragePolicy
 	rootBaseIDs     map[string]uint64
 	uniqueValueRuns map[string][]memtable.Table
+	semanticRecords []indexedSemanticRecord
 	arenaRefs       [][]byte
 	docCount        int
 	byteCount       int64
@@ -677,8 +713,9 @@ type coalescedFlushBatch struct {
 
 	// Original immutable units, in FIFO order. The merged unit is only the
 	// mechanical publish view for the current DB ordered-root API.
-	units      []indexedFlushUnit
-	mergedUnit indexedFlushUnit
+	units           []indexedFlushUnit
+	mergedUnit      indexedFlushUnit
+	semanticRecords []indexedSemanticRecord
 
 	rootNames          []string
 	rootBaseIDs        map[string]uint64
@@ -718,6 +755,7 @@ type bufferedIndexedCheckpoint struct {
 	rootPolicies           map[string]backenddb.OrderedRootStoragePolicy
 	rootBaseIDs            map[string]uint64
 	rootValueArenas        [][]byte
+	indexedSemanticRecords []indexedSemanticRecord
 	indexedPublishingUnits []indexedFlushUnit
 	indexedFlushUnits      []indexedFlushUnit
 	primaryRunIndexActive  bool
@@ -773,6 +811,7 @@ type collectionWriteDomain struct {
 	rootPolicies           map[string]backenddb.OrderedRootStoragePolicy
 	rootBaseIDs            map[string]uint64
 	rootValueArenas        [][]byte
+	indexedSemanticRecords []indexedSemanticRecord
 	primaryIDIndex         *bufferedUniqueValueIndex
 	// Built lazily by readers so write-only indexed buffering does not pay for
 	// an auxiliary lookup structure it never uses.
@@ -793,6 +832,10 @@ type collectionWriteDomain struct {
 	indexedStageDocs                 atomic.Uint64
 	indexedStageBytes                atomic.Uint64
 	indexedStageRootRuns             atomic.Uint64
+	indexedSemanticRawRecords        atomic.Uint64
+	indexedSemanticRawIndexDeltas    atomic.Uint64
+	indexedSemanticFallbackRecords   atomic.Uint64
+	indexedSemanticEffectiveRecords  atomic.Uint64
 	indexedAutoFlushes               atomic.Uint64
 	indexedAsyncFlushScheduled       atomic.Uint64
 	indexedAsyncFlushBackpressure    atomic.Uint64
@@ -1049,6 +1092,7 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.pending_bytes"] = fmt.Sprintf("%d", stats.PendingBytes)
 	out["treedb.collections.write_domain.pending_root_runs"] = fmt.Sprintf("%d", stats.PendingRootRuns)
 	out["treedb.collections.write_domain.pending_indexed_flush_units"] = fmt.Sprintf("%d", stats.PendingIndexedFlushUnits)
+	out["treedb.collections.write_domain.pending_indexed_semantic_raw_records"] = fmt.Sprintf("%d", stats.PendingIndexedSemanticRecords)
 	out["treedb.collections.write_domain.overlay.mutable_docs"] = fmt.Sprintf("%d", stats.OverlayMutableDocuments)
 	out["treedb.collections.write_domain.overlay.queued_indexed_flush_units"] = fmt.Sprintf("%d", stats.OverlayQueuedIndexedFlushUnits)
 	out["treedb.collections.write_domain.overlay.active_indexed_flush_units"] = fmt.Sprintf("%d", stats.OverlayActiveIndexedFlushUnits)
@@ -1064,6 +1108,10 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_stage.docs_total"] = fmt.Sprintf("%d", stats.IndexedStageDocs)
 	out["treedb.collections.write_domain.indexed_stage.bytes_total"] = fmt.Sprintf("%d", stats.IndexedStageBytes)
 	out["treedb.collections.write_domain.indexed_stage.root_runs_total"] = fmt.Sprintf("%d", stats.IndexedStageRootRuns)
+	out["treedb.collections.write_domain.indexed_semantic.raw_records_total"] = fmt.Sprintf("%d", stats.IndexedSemanticRawRecords)
+	out["treedb.collections.write_domain.indexed_semantic.raw_index_deltas_total"] = fmt.Sprintf("%d", stats.IndexedSemanticRawIndexDeltas)
+	out["treedb.collections.write_domain.indexed_semantic.fallback_records_total"] = fmt.Sprintf("%d", stats.IndexedSemanticFallbackRecords)
+	out["treedb.collections.write_domain.indexed_semantic.effective_records_total"] = fmt.Sprintf("%d", stats.IndexedSemanticEffectiveRecords)
 	out["treedb.collections.write_domain.indexed_stage.auto_flushes_total"] = fmt.Sprintf("%d", stats.IndexedAutoFlushes)
 	out["treedb.collections.write_domain.indexed_async_flush.scheduled_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushScheduled)
 	out["treedb.collections.write_domain.indexed_async_flush.backpressure_sync_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushBackpressure)
@@ -1252,6 +1300,7 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.PendingBytes = saturatingAddNonNegativeInt64(s.PendingBytes, other.PendingBytes)
 	s.PendingRootRuns = saturatingAddNonNegativeInt(s.PendingRootRuns, other.PendingRootRuns)
 	s.PendingIndexedFlushUnits = saturatingAddNonNegativeInt(s.PendingIndexedFlushUnits, other.PendingIndexedFlushUnits)
+	s.PendingIndexedSemanticRecords = saturatingAddNonNegativeInt(s.PendingIndexedSemanticRecords, other.PendingIndexedSemanticRecords)
 	s.OverlayMutableDocuments = saturatingAddNonNegativeInt(s.OverlayMutableDocuments, other.OverlayMutableDocuments)
 	s.OverlayQueuedIndexedFlushUnits = saturatingAddNonNegativeInt(s.OverlayQueuedIndexedFlushUnits, other.OverlayQueuedIndexedFlushUnits)
 	s.OverlayActiveIndexedFlushUnits = saturatingAddNonNegativeInt(s.OverlayActiveIndexedFlushUnits, other.OverlayActiveIndexedFlushUnits)
@@ -1264,6 +1313,10 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.IndexedStageDocs += other.IndexedStageDocs
 	s.IndexedStageBytes += other.IndexedStageBytes
 	s.IndexedStageRootRuns += other.IndexedStageRootRuns
+	s.IndexedSemanticRawRecords += other.IndexedSemanticRawRecords
+	s.IndexedSemanticRawIndexDeltas += other.IndexedSemanticRawIndexDeltas
+	s.IndexedSemanticFallbackRecords += other.IndexedSemanticFallbackRecords
+	s.IndexedSemanticEffectiveRecords += other.IndexedSemanticEffectiveRecords
 	s.IndexedAutoFlushes += other.IndexedAutoFlushes
 	s.IndexedAsyncFlushScheduled += other.IndexedAsyncFlushScheduled
 	s.IndexedAsyncFlushBackpressure += other.IndexedAsyncFlushBackpressure
@@ -1359,6 +1412,7 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	pendingRootRuns := bufferedIndexedRootRunCount(domain)
 	stats.PendingRootRuns = pendingRootRuns
 	stats.PendingIndexedFlushUnits = len(domain.indexedPublishingUnits) + len(domain.indexedFlushUnits)
+	stats.PendingIndexedSemanticRecords = pendingIndexedSemanticRecordCountLocked(domain)
 	stats.OverlayMutableDocuments = domain.mutableCount
 	stats.OverlayQueuedIndexedFlushUnits = len(domain.indexedFlushUnits)
 	stats.OverlayActiveIndexedFlushUnits = len(domain.indexedPublishingUnits)
@@ -1385,6 +1439,10 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.IndexedStageDocs = domain.indexedStageDocs.Load()
 	stats.IndexedStageBytes = domain.indexedStageBytes.Load()
 	stats.IndexedStageRootRuns = domain.indexedStageRootRuns.Load()
+	stats.IndexedSemanticRawRecords = domain.indexedSemanticRawRecords.Load()
+	stats.IndexedSemanticRawIndexDeltas = domain.indexedSemanticRawIndexDeltas.Load()
+	stats.IndexedSemanticFallbackRecords = domain.indexedSemanticFallbackRecords.Load()
+	stats.IndexedSemanticEffectiveRecords = domain.indexedSemanticEffectiveRecords.Load()
 	stats.IndexedAutoFlushes = domain.indexedAutoFlushes.Load()
 	stats.IndexedAsyncFlushScheduled = domain.indexedAsyncFlushScheduled.Load()
 	stats.IndexedAsyncFlushBackpressure = domain.indexedAsyncFlushBackpressure.Load()
@@ -1484,6 +1542,38 @@ func collectionWriteDomainVisibleDepthLocked(domain *collectionWriteDomain) int 
 		depth++
 	}
 	return depth
+}
+
+func pendingIndexedSemanticRecordCountLocked(domain *collectionWriteDomain) int {
+	if domain == nil {
+		return 0
+	}
+	total := len(domain.indexedSemanticRecords)
+	for _, unit := range domain.indexedPublishingUnits {
+		total = saturatingAddNonNegativeInt(total, len(unit.semanticRecords))
+	}
+	for _, unit := range domain.indexedFlushUnits {
+		total = saturatingAddNonNegativeInt(total, len(unit.semanticRecords))
+	}
+	return total
+}
+
+func indexedSemanticRecordIndexDeltaCount(records []indexedSemanticRecord) int {
+	total := 0
+	for _, record := range records {
+		total = saturatingAddNonNegativeInt(total, len(record.indexDeltas))
+	}
+	return total
+}
+
+func indexedSemanticRecordFallbackCount(records []indexedSemanticRecord) int {
+	total := 0
+	for _, record := range records {
+		if record.fallback != indexedSemanticFallbackNone {
+			total = saturatingAddNonNegativeInt(total, 1)
+		}
+	}
+	return total
 }
 
 func collectionStatsUint64ToInt(v uint64) int {
@@ -1675,6 +1765,19 @@ func (domain *collectionWriteDomain) observeIndexedStage(docs int, bytes int64, 
 	}
 	if rootRuns > 0 {
 		domain.indexedStageRootRuns.Add(uint64(rootRuns))
+	}
+}
+
+func (domain *collectionWriteDomain) observeIndexedSemanticRawRecords(records []indexedSemanticRecord) {
+	if domain == nil || len(records) == 0 {
+		return
+	}
+	domain.indexedSemanticRawRecords.Add(uint64(len(records)))
+	if deltas := indexedSemanticRecordIndexDeltaCount(records); deltas > 0 {
+		domain.indexedSemanticRawIndexDeltas.Add(uint64(deltas))
+	}
+	if fallbacks := indexedSemanticRecordFallbackCount(records); fallbacks > 0 {
+		domain.indexedSemanticFallbackRecords.Add(uint64(fallbacks))
 	}
 }
 
@@ -3202,6 +3305,7 @@ func (c *Collection) initializeWriteDomainFromCatalogLocked(domain *collectionWr
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.rootValueArenas = nil
+	domain.indexedSemanticRecords = nil
 	domain.rootRunCount = 0
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
@@ -3799,6 +3903,7 @@ func checkpointBufferedIndexedDomain(domain *collectionWriteDomain) bufferedInde
 		rootPolicies:           cloneRootPolicyMap(domain.rootPolicies),
 		rootBaseIDs:            cloneUint64Map(domain.rootBaseIDs),
 		rootValueArenas:        cloneArenaRefs(domain.rootValueArenas),
+		indexedSemanticRecords: cloneIndexedSemanticRecords(domain.indexedSemanticRecords),
 		indexedPublishingUnits: cloneIndexedFlushUnits(domain.indexedPublishingUnits),
 		indexedFlushUnits:      cloneIndexedFlushUnits(domain.indexedFlushUnits),
 		primaryRunIndexActive:  domain.primaryRunIndex != nil,
@@ -3833,6 +3938,7 @@ func rollbackBufferedIndexedDomain(domain *collectionWriteDomain, checkpoint buf
 	domain.rootPolicies = checkpoint.rootPolicies
 	domain.rootBaseIDs = checkpoint.rootBaseIDs
 	domain.rootValueArenas = checkpoint.rootValueArenas
+	domain.indexedSemanticRecords = checkpoint.indexedSemanticRecords
 	domain.rootRunCount = checkpoint.rootRunCount
 	pendingRuns := indexedFlushUnitPendingRootRunMap(indexedFlushUnitsWithPublishing(checkpoint.indexedPublishingUnits, checkpoint.indexedFlushUnits), checkpoint.rootRuns)
 	domain.primaryIDIndex = rebuildBufferedPrimaryIDIndex(checkpoint.meta.Name, pendingRuns)
@@ -3862,11 +3968,57 @@ func cloneIndexedFlushUnits(in []indexedFlushUnit) []indexedFlushUnit {
 			rootPolicies:    cloneRootPolicyMap(unit.rootPolicies),
 			rootBaseIDs:     cloneUint64Map(unit.rootBaseIDs),
 			uniqueValueRuns: cloneTableRunMap(unit.uniqueValueRuns),
+			semanticRecords: cloneIndexedSemanticRecords(unit.semanticRecords),
 			arenaRefs:       cloneArenaRefs(unit.arenaRefs),
 			docCount:        unit.docCount,
 			byteCount:       unit.byteCount,
 			rootRunCount:    unit.rootRunCount,
 		}
+	}
+	return out
+}
+
+func cloneIndexedSemanticRecords(in []indexedSemanticRecord) []indexedSemanticRecord {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]indexedSemanticRecord, len(in))
+	for i, record := range in {
+		out[i] = indexedSemanticRecord{
+			kind:        record.kind,
+			documentID:  bytes.Clone(record.documentID),
+			fallback:    record.fallback,
+			indexDeltas: cloneIndexedSemanticIndexDeltas(record.indexDeltas),
+		}
+	}
+	return out
+}
+
+func cloneIndexedSemanticIndexDeltas(in []indexedSemanticIndexDelta) []indexedSemanticIndexDelta {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]indexedSemanticIndexDelta, len(in))
+	for i, delta := range in {
+		out[i] = indexedSemanticIndexDelta{
+			indexName:  delta.indexName,
+			rootName:   delta.rootName,
+			runtimeIdx: delta.runtimeIdx,
+			unique:     delta.unique,
+			oldValues:  cloneIndexedSemanticValueSet(delta.oldValues),
+			newValues:  cloneIndexedSemanticValueSet(delta.newValues),
+		}
+	}
+	return out
+}
+
+func cloneIndexedSemanticValueSet(in [][]byte) [][]byte {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([][]byte, len(in))
+	for i, value := range in {
+		out[i] = bytes.Clone(value)
 	}
 	return out
 }
@@ -5009,6 +5161,7 @@ func (c *Collection) prepareIndexedAsyncPublishLocked(domain *collectionWriteDom
 		domain.indexedFlushUnits = nil
 		domain.rootMutableRuns = nil
 		domain.rootValueArenas = nil
+		domain.indexedSemanticRecords = nil
 		domain.count = 0
 		domain.bufferedBytes = 0
 		domain.mutableCount = 0
@@ -5460,6 +5613,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		domain.indexedFlushUnits = nil
 		domain.rootMutableRuns = nil
 		domain.rootValueArenas = nil
+		domain.indexedSemanticRecords = nil
 		domain.count = 0
 		domain.bufferedBytes = 0
 		domain.mutableCount = 0
@@ -5559,6 +5713,7 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 	domain.rootPolicies = nil
 	domain.rootBaseIDs = nil
 	domain.rootValueArenas = nil
+	domain.indexedSemanticRecords = nil
 	domain.rootRunCount = 0
 	domain.primaryIDIndex = nil
 	domain.primaryRunIndex = nil
@@ -5591,6 +5746,7 @@ func rotateIndexedMutableToFlushUnitLocked(domain *collectionWriteDomain) bool {
 		rootPolicies:    domain.rootPolicies,
 		rootBaseIDs:     domain.rootBaseIDs,
 		uniqueValueRuns: domain.uniqueValueRuns,
+		semanticRecords: domain.indexedSemanticRecords,
 		arenaRefs:       domain.rootValueArenas,
 		docCount:        domain.mutableCount,
 		byteCount:       domain.mutableBytes,
@@ -5603,6 +5759,7 @@ func rotateIndexedMutableToFlushUnitLocked(domain *collectionWriteDomain) bool {
 	domain.rootBaseIDs = nil
 	domain.uniqueValueRuns = nil
 	domain.rootValueArenas = nil
+	domain.indexedSemanticRecords = nil
 	domain.rootRunCount = 0
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
@@ -5691,14 +5848,15 @@ func buildCoalescedFlushBatchFromUnits(meta CollectionMeta, catalog *collectionC
 	merged := mergedIndexedFlushUnits(units)
 	rootNames := orderedBufferedRootNames(meta, merged.rootRuns)
 	batch := coalescedFlushBatch{
-		state:        coalescedFlushBatchQueued,
-		units:        append([]indexedFlushUnit(nil), units...),
-		mergedUnit:   merged,
-		rootNames:    rootNames,
-		docCount:     merged.docCount,
-		byteCount:    merged.byteCount,
-		rootRunCount: indexedFlushUnitRootRunCount(merged),
-		rootCount:    len(rootNames),
+		state:           coalescedFlushBatchQueued,
+		units:           append([]indexedFlushUnit(nil), units...),
+		mergedUnit:      merged,
+		semanticRecords: cloneIndexedSemanticRecords(merged.semanticRecords),
+		rootNames:       rootNames,
+		docCount:        merged.docCount,
+		byteCount:       merged.byteCount,
+		rootRunCount:    indexedFlushUnitRootRunCount(merged),
+		rootCount:       len(rootNames),
 	}
 	if len(rootNames) == 0 {
 		return batch, nil
@@ -5747,6 +5905,9 @@ func mergedIndexedFlushUnits(units []indexedFlushUnit) indexedFlushUnit {
 	if len(unit.uniqueValueRuns) == 0 {
 		unit.uniqueValueRuns = nil
 	}
+	if len(unit.semanticRecords) == 0 {
+		unit.semanticRecords = nil
+	}
 	return unit
 }
 
@@ -5771,6 +5932,7 @@ func mergedIndexedFlushUnitLocked(domain *collectionWriteDomain) indexedFlushUni
 		rootPolicies:    domain.rootPolicies,
 		rootBaseIDs:     domain.rootBaseIDs,
 		uniqueValueRuns: domain.uniqueValueRuns,
+		semanticRecords: domain.indexedSemanticRecords,
 		arenaRefs:       domain.rootValueArenas,
 		rootRunCount:    domain.rootRunCount,
 	})
@@ -5786,6 +5948,9 @@ func mergedIndexedFlushUnitLocked(domain *collectionWriteDomain) indexedFlushUni
 	if len(unit.uniqueValueRuns) == 0 {
 		unit.uniqueValueRuns = nil
 	}
+	if len(unit.semanticRecords) == 0 {
+		unit.semanticRecords = nil
+	}
 	return unit
 }
 
@@ -5795,6 +5960,7 @@ func mergeIndexedFlushUnit(dst *indexedFlushUnit, src indexedFlushUnit) {
 	}
 	appendTableRunMap(dst.rootRuns, src.rootRuns)
 	appendTableRunMap(dst.uniqueValueRuns, src.uniqueValueRuns)
+	dst.semanticRecords = append(dst.semanticRecords, src.semanticRecords...)
 	dst.arenaRefs = append(dst.arenaRefs, src.arenaRefs...)
 	for rootName, policy := range src.rootPolicies {
 		dst.rootPolicies[rootName] = policy
@@ -7908,6 +8074,7 @@ type updateBatchPlan struct {
 	policies                    []backenddb.OrderedRootStoragePolicy
 	deltaTables                 []memtable.Table
 	directBufferedUpdate        *directBufferedUpdatePlan
+	semanticRecords             []indexedSemanticRecord
 	uniqueSecondaryIndexByRoot  []int
 	canBufferIndexedUpdateBatch bool
 	bufferedBase                bool
@@ -8004,6 +8171,44 @@ func applyDirectBufferedRootEntries(table memtable.Table, entries []directBuffer
 		entry := entries[i]
 		return entry.key, entry.value, page.ValuePtr{}, entry.flags, nil
 	})
+}
+
+func buildIndexedSemanticUpdateRecords(collectionName string, runtimes []indexRuntime, updates []preparedBatchUpdate) []indexedSemanticRecord {
+	if len(updates) == 0 {
+		return nil
+	}
+	records := make([]indexedSemanticRecord, 0, len(updates))
+	for _, update := range updates {
+		record := indexedSemanticRecord{
+			kind:       indexedSemanticRecordUpdate,
+			documentID: bytes.Clone(update.documentID),
+			fallback:   indexedSemanticFallbackRawOnly,
+		}
+		if update.indexStateChanged && len(runtimes) > 0 {
+			for runtimeIdx, runtime := range runtimes {
+				if !preparedBatchUpdateIndexChanged(update, runtimeIdx) {
+					continue
+				}
+				record.indexDeltas = append(record.indexDeltas, indexedSemanticIndexDelta{
+					indexName:  runtime.def.name,
+					rootName:   runtimeSecondaryRootName(collectionName, runtime),
+					runtimeIdx: runtimeIdx,
+					unique:     runtime.def.unique,
+					oldValues:  cloneIndexedSemanticValueSet(update.oldState.valuesAt(runtimeIdx)),
+					newValues:  cloneIndexedSemanticValueSet(update.newState.valuesAt(runtimeIdx)),
+				})
+			}
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func appendIndexedSemanticRecordsLocked(domain *collectionWriteDomain, records []indexedSemanticRecord) {
+	if domain == nil || len(records) == 0 {
+		return
+	}
+	domain.indexedSemanticRecords = append(domain.indexedSemanticRecords, cloneIndexedSemanticRecords(records)...)
 }
 
 func buildDirectBufferedSecondaryRootPlans(collectionName string, runtimes []indexRuntime, changed []preparedBatchUpdate, stats *CollectionUpdateStats) ([]directBufferedSecondaryRootPlan, int64, error) {
@@ -9164,6 +9369,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		success = true
 		plan := newUpdateBatchPlan()
 		stats = updateCollectionUpdateStatsCounts(stats, results, len(rootNames))
+		semanticRecords := buildIndexedSemanticUpdateRecords(meta.Name, runtimes, changed)
 		*plan = updateBatchPlan{
 			results:                     results,
 			stats:                       stats,
@@ -9181,6 +9387,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 			bufferedReadGeneration:      bufferedRead.writeGeneration,
 			bufferedReadBlocked:         bufferedReadBlocked,
 			policies:                    policies,
+			semanticRecords:             semanticRecords,
 			directBufferedUpdate: &directBufferedUpdatePlan{
 				templateEntries:    templateEntries,
 				primaryEntries:     primaryEntries,
@@ -9363,6 +9570,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	success = true
 	plan := newUpdateBatchPlan()
 	stats = updateCollectionUpdateStatsCounts(stats, results, len(deltaTables))
+	semanticRecords := buildIndexedSemanticUpdateRecords(meta.Name, runtimes, changed)
 	*plan = updateBatchPlan{
 		results:                     results,
 		stats:                       stats,
@@ -9381,6 +9589,7 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		bufferedReadBlocked:         bufferedReadBlocked,
 		policies:                    policies,
 		deltaTables:                 deltaTables,
+		semanticRecords:             semanticRecords,
 		scratch:                     scratch,
 	}
 	scratchOwnedByPlan = true
@@ -9655,6 +9864,10 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		}
 		return false, err
 	}
+	semanticRecords := plan.semanticRecords
+	if len(semanticRecords) > 0 {
+		appendIndexedSemanticRecordsLocked(domain, semanticRecords)
+	}
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {
@@ -9671,6 +9884,9 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		}
 	}
 	resetCollectionTables(compactedObsolete)
+	if len(semanticRecords) > 0 {
+		domain.observeIndexedSemanticRawRecords(semanticRecords)
+	}
 	plan.stats.BufferedBatches = 1
 	return true, nil
 }
@@ -9897,6 +10113,10 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		}
 		return false, err
 	}
+	semanticRecords := plan.semanticRecords
+	if len(semanticRecords) > 0 {
+		appendIndexedSemanticRecordsLocked(domain, semanticRecords)
+	}
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
 		if lockReleased > 0 {
@@ -9913,6 +10133,9 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		}
 	}
 	resetCollectionTables(compactedObsolete)
+	if len(semanticRecords) > 0 {
+		domain.observeIndexedSemanticRawRecords(semanticRecords)
+	}
 	plan.stats.BufferedBatches = 1
 	return true, nil
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1092,7 +1092,7 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.pending_bytes"] = fmt.Sprintf("%d", stats.PendingBytes)
 	out["treedb.collections.write_domain.pending_root_runs"] = fmt.Sprintf("%d", stats.PendingRootRuns)
 	out["treedb.collections.write_domain.pending_indexed_flush_units"] = fmt.Sprintf("%d", stats.PendingIndexedFlushUnits)
-	out["treedb.collections.write_domain.pending_indexed_semantic_raw_records"] = fmt.Sprintf("%d", stats.PendingIndexedSemanticRecords)
+	out["treedb.collections.write_domain.pending_indexed_semantic_records"] = fmt.Sprintf("%d", stats.PendingIndexedSemanticRecords)
 	out["treedb.collections.write_domain.overlay.mutable_docs"] = fmt.Sprintf("%d", stats.OverlayMutableDocuments)
 	out["treedb.collections.write_domain.overlay.queued_indexed_flush_units"] = fmt.Sprintf("%d", stats.OverlayQueuedIndexedFlushUnits)
 	out["treedb.collections.write_domain.overlay.active_indexed_flush_units"] = fmt.Sprintf("%d", stats.OverlayActiveIndexedFlushUnits)
@@ -8208,7 +8208,9 @@ func appendIndexedSemanticRecordsLocked(domain *collectionWriteDomain, records [
 	if domain == nil || len(records) == 0 {
 		return
 	}
-	domain.indexedSemanticRecords = append(domain.indexedSemanticRecords, cloneIndexedSemanticRecords(records)...)
+	// buildIndexedSemanticUpdateRecords already owns cloned document IDs and
+	// value sets; staging transfers those records into the mutable domain.
+	domain.indexedSemanticRecords = append(domain.indexedSemanticRecords, records...)
 }
 
 func buildDirectBufferedSecondaryRootPlans(collectionName string, runtimes []indexRuntime, changed []preparedBatchUpdate, stats *CollectionUpdateStats) ([]directBufferedSecondaryRootPlan, int64, error) {
@@ -9369,7 +9371,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 		success = true
 		plan := newUpdateBatchPlan()
 		stats = updateCollectionUpdateStatsCounts(stats, results, len(rootNames))
-		semanticRecords := buildIndexedSemanticUpdateRecords(meta.Name, runtimes, changed)
+		var semanticRecords []indexedSemanticRecord
+		if c.writeDomain != nil && canBufferIndexedUpdateBatch && meta.Options.BufferedIndexedWrites {
+			semanticRecords = buildIndexedSemanticUpdateRecords(meta.Name, runtimes, changed)
+		}
 		*plan = updateBatchPlan{
 			results:                     results,
 			stats:                       stats,
@@ -9570,7 +9575,10 @@ func (c *Collection) buildUpdateBatchPlan(items []UpdateBatchItem, mode updateBa
 	success = true
 	plan := newUpdateBatchPlan()
 	stats = updateCollectionUpdateStatsCounts(stats, results, len(deltaTables))
-	semanticRecords := buildIndexedSemanticUpdateRecords(meta.Name, runtimes, changed)
+	var semanticRecords []indexedSemanticRecord
+	if c.writeDomain != nil && canBufferIndexedUpdateBatch && meta.Options.BufferedIndexedWrites {
+		semanticRecords = buildIndexedSemanticUpdateRecords(meta.Name, runtimes, changed)
+	}
 	*plan = updateBatchPlan{
 		results:                     results,
 		stats:                       stats,

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -9873,8 +9873,13 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		return false, err
 	}
 	semanticRecords := plan.semanticRecords
+	semanticRecordsObserved := false
 	if len(semanticRecords) > 0 {
 		appendIndexedSemanticRecordsLocked(domain, semanticRecords)
+		if !shouldAutoFlushAfterAdding {
+			domain.observeIndexedSemanticRawRecords(semanticRecords)
+			semanticRecordsObserved = true
+		}
 	}
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
@@ -9892,7 +9897,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		}
 	}
 	resetCollectionTables(compactedObsolete)
-	if len(semanticRecords) > 0 {
+	if len(semanticRecords) > 0 && !semanticRecordsObserved {
 		domain.observeIndexedSemanticRawRecords(semanticRecords)
 	}
 	plan.stats.BufferedBatches = 1
@@ -10122,8 +10127,13 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		return false, err
 	}
 	semanticRecords := plan.semanticRecords
+	semanticRecordsObserved := false
 	if len(semanticRecords) > 0 {
 		appendIndexedSemanticRecordsLocked(domain, semanticRecords)
+		if !shouldAutoFlushAfterAdding {
+			domain.observeIndexedSemanticRawRecords(semanticRecords)
+			semanticRecordsObserved = true
+		}
 	}
 	if shouldFlushBufferedIndexedWrites(domain, plan.meta.Options) {
 		flushDuration, lockReleased, relockWait, err := c.flushBufferedIndexedAfterThresholdLocked(domain, plan.meta.Options)
@@ -10141,7 +10151,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 		}
 	}
 	resetCollectionTables(compactedObsolete)
-	if len(semanticRecords) > 0 {
+	if len(semanticRecords) > 0 && !semanticRecordsObserved {
 		domain.observeIndexedSemanticRawRecords(semanticRecords)
 	}
 	plan.stats.BufferedBatches = 1

--- a/TreeDB/collections/pr3b_semantic_indexed_test.go
+++ b/TreeDB/collections/pr3b_semantic_indexed_test.go
@@ -1,0 +1,458 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestPR3bSemanticRawRecordsSurviveMutableQueuedActiveRequeued(t *testing.T) {
+	d, mgr, col := pr3bSemanticTestCollection(t)
+	defer func() { _ = d.Close() }()
+	pr3bSeedSemanticUser(t, col)
+
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update:     setJSONCity("sea"),
+	}}); err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatal("city update was not buffered")
+	}
+
+	col.writeDomain.mu.RLock()
+	mutableRecords := cloneIndexedSemanticRecords(col.writeDomain.indexedSemanticRecords)
+	queuedBeforeRotate := len(col.writeDomain.indexedFlushUnits)
+	publishingBeforeRotate := len(col.writeDomain.indexedPublishingUnits)
+	col.writeDomain.mu.RUnlock()
+	if queuedBeforeRotate != 0 || publishingBeforeRotate != 0 {
+		t.Fatalf("pre-rotate queued=%d publishing=%d want 0/0", queuedBeforeRotate, publishingBeforeRotate)
+	}
+	pr3bRequireCitySemanticRecord(t, mutableRecords, "hnl", "sea")
+	pr3bRequireIndexIDs(t, col, "city", "sea", "u1")
+	pr3bRequireIndexIDs(t, col, "city", "hnl")
+
+	stats := mgr.StatsSnapshot()
+	if got := stats.IndexedSemanticRawRecords; got != 1 {
+		t.Fatalf("raw semantic records after stage=%d want 1", got)
+	}
+	if got := stats.IndexedSemanticRawIndexDeltas; got != 1 {
+		t.Fatalf("raw semantic index deltas after stage=%d want 1", got)
+	}
+	if got := stats.IndexedSemanticFallbackRecords; got != 1 {
+		t.Fatalf("fallback semantic records after stage=%d want 1", got)
+	}
+	if got := stats.IndexedSemanticEffectiveRecords; got != 0 {
+		t.Fatalf("effective semantic records after stage=%d want 0", got)
+	}
+	if got := stats.PendingIndexedSemanticRecords; got != 1 {
+		t.Fatalf("pending semantic records after stage=%d want 1", got)
+	}
+	pr3bRequireSemanticMetricKeys(t, mgr)
+
+	col.writeDomain.mu.Lock()
+	if !rotateIndexedMutableToFlushUnitLocked(col.writeDomain) {
+		col.writeDomain.mu.Unlock()
+		t.Fatal("rotate indexed mutable state returned false")
+	}
+	queuedRecords := cloneIndexedSemanticRecords(col.writeDomain.indexedFlushUnits[0].semanticRecords)
+	mutableAfterRotate := len(col.writeDomain.indexedSemanticRecords)
+	col.writeDomain.mu.Unlock()
+	if mutableAfterRotate != 0 {
+		t.Fatalf("mutable semantic records after rotate=%d want 0", mutableAfterRotate)
+	}
+	pr3bRequireCitySemanticRecord(t, queuedRecords, "hnl", "sea")
+	pr3bRequireIndexIDs(t, col, "city", "sea", "u1")
+
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async publish returned nil work")
+	}
+	defer collectionTestCloseIndexedFlushWork(work)
+	if got := work.batch.state; got != coalescedFlushBatchActive {
+		t.Fatalf("prepared batch state=%d want active", got)
+	}
+	pr3bRequireCitySemanticRecord(t, work.batch.semanticRecords, "hnl", "sea")
+	col.writeDomain.mu.RLock()
+	activeRecords := cloneIndexedSemanticRecords(col.writeDomain.indexedPublishingUnits[0].semanticRecords)
+	queuedAfterPrepare := len(col.writeDomain.indexedFlushUnits)
+	col.writeDomain.mu.RUnlock()
+	if queuedAfterPrepare != 0 {
+		t.Fatalf("queued units after prepare=%d want 0", queuedAfterPrepare)
+	}
+	pr3bRequireCitySemanticRecord(t, activeRecords, "hnl", "sea")
+
+	injectedErr := errors.New("injected PR3b publish failure")
+	if err := col.completePreparedIndexedFlush(work, 0, nil, injectedErr, 0, 0, 0); !errors.Is(err, injectedErr) {
+		t.Fatalf("complete failure err=%v want injected error", err)
+	}
+	if got := work.batch.state; got != coalescedFlushBatchRequeued {
+		t.Fatalf("failed batch state=%d want requeued", got)
+	}
+	col.writeDomain.mu.RLock()
+	requeuedRecords := cloneIndexedSemanticRecords(col.writeDomain.indexedFlushUnits[0].semanticRecords)
+	publishingAfterFailure := len(col.writeDomain.indexedPublishingUnits)
+	col.writeDomain.mu.RUnlock()
+	if publishingAfterFailure != 0 {
+		t.Fatalf("publishing units after failure=%d want 0", publishingAfterFailure)
+	}
+	pr3bRequireCitySemanticRecord(t, requeuedRecords, "hnl", "sea")
+	pr3bRequireIndexIDs(t, col, "city", "sea", "u1")
+
+	stats = mgr.StatsSnapshot()
+	if got := stats.IndexedSemanticRawRecords; got != 1 {
+		t.Fatalf("raw semantic records after requeue=%d want 1", got)
+	}
+	if got := stats.PendingIndexedSemanticRecords; got != 1 {
+		t.Fatalf("pending semantic records after requeue=%d want 1", got)
+	}
+	if got := stats.IndexedSemanticEffectiveRecords; got != 0 {
+		t.Fatalf("effective semantic records after requeue=%d want 0", got)
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush requeued semantic update: %v", err)
+	}
+	pr3bRequireIndexIDs(t, col, "city", "sea", "u1")
+	stats = mgr.StatsSnapshot()
+	if got := stats.PendingIndexedSemanticRecords; got != 0 {
+		t.Fatalf("pending semantic records after flush=%d want 0", got)
+	}
+	if got := stats.IndexedSemanticRawRecords; got != 1 {
+		t.Fatalf("raw semantic records after flush=%d want 1", got)
+	}
+	if got := stats.IndexedSemanticEffectiveRecords; got != 0 {
+		t.Fatalf("effective semantic records after flush=%d want 0", got)
+	}
+}
+
+func TestPR3bSemanticRepeatedSameDocumentUpdatesSerialEquivalent(t *testing.T) {
+	d, mgr, col := pr3bSemanticTestCollection(t)
+	defer func() { _ = d.Close() }()
+	pr3bSeedSemanticUser(t, col)
+
+	firstCalls := 0
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			firstCalls++
+			if !bytes.Contains(current, []byte(`"city":"hnl"`)) {
+				return nil, false, fmt.Errorf("first callback current=%s want city hnl", current)
+			}
+			return []byte(`{"email":"a@example.com","city":"sea","score":1}`), true, nil
+		},
+	}}); err != nil {
+		t.Fatalf("first UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatal("first update was not buffered")
+	}
+
+	secondCalls := 0
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			secondCalls++
+			if !bytes.Contains(current, []byte(`"city":"sea"`)) || !bytes.Contains(current, []byte(`"score":1`)) {
+				return nil, false, fmt.Errorf("second callback current=%s want buffered city sea score 1", current)
+			}
+			return []byte(`{"email":"a@example.com","city":"hnl","score":2}`), true, nil
+		},
+	}}); err != nil {
+		t.Fatalf("second UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	} else if !batched {
+		t.Fatal("second update was not buffered")
+	}
+	if firstCalls != 1 || secondCalls != 1 {
+		t.Fatalf("callback calls first=%d second=%d want 1/1", firstCalls, secondCalls)
+	}
+
+	pr3bRequireIndexIDs(t, col, "city", "hnl", "u1")
+	pr3bRequireIndexIDs(t, col, "city", "sea")
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get buffered u1: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"city":"hnl"`)) || !bytes.Contains(got, []byte(`"score":2`)) {
+		t.Fatalf("buffered u1=%s want city hnl score 2", got)
+	}
+
+	stats := mgr.StatsSnapshot()
+	if got := stats.IndexedSemanticRawRecords; got != 2 {
+		t.Fatalf("raw semantic records before flush=%d want 2", got)
+	}
+	if got := stats.IndexedSemanticRawIndexDeltas; got != 2 {
+		t.Fatalf("raw semantic index deltas before flush=%d want 2", got)
+	}
+	if got := stats.IndexedSemanticEffectiveRecords; got != 0 {
+		t.Fatalf("effective semantic records before flush=%d want 0", got)
+	}
+	if got := stats.PendingIndexedSemanticRecords; got != 2 {
+		t.Fatalf("pending semantic records before flush=%d want 2", got)
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered serial updates: %v", err)
+	}
+	pr3bRequireIndexIDs(t, col, "city", "hnl", "u1")
+	pr3bRequireIndexIDs(t, col, "city", "sea")
+	stats = mgr.StatsSnapshot()
+	if got := stats.PendingIndexedSemanticRecords; got != 0 {
+		t.Fatalf("pending semantic records after flush=%d want 0", got)
+	}
+	if got := stats.IndexedSemanticRawRecords; got != 2 {
+		t.Fatalf("raw semantic records after flush=%d want 2", got)
+	}
+	if got := stats.IndexedSemanticEffectiveRecords; got != 0 {
+		t.Fatalf("effective semantic records after flush=%d want 0", got)
+	}
+}
+
+func TestPR3bSemanticNonUniqueChangeChangeBackFallsBackRawOnly(t *testing.T) {
+	d, mgr, col := pr3bSemanticTestCollection(t)
+	defer func() { _ = d.Close() }()
+	pr3bSeedSemanticUser(t, col)
+
+	for _, city := range []string{"sea", "hnl"} {
+		if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+			DocumentID: []byte("u1"),
+			Update:     setJSONCity(city),
+		}}); err != nil {
+			t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges city=%s: %v", city, err)
+		} else if !batched {
+			t.Fatalf("city=%s update was not buffered", city)
+		}
+	}
+
+	col.writeDomain.mu.RLock()
+	records := cloneIndexedSemanticRecords(col.writeDomain.indexedSemanticRecords)
+	col.writeDomain.mu.RUnlock()
+	if got := len(records); got != 2 {
+		t.Fatalf("mutable semantic records=%d want 2", got)
+	}
+	for i, record := range records {
+		if record.fallback != indexedSemanticFallbackRawOnly {
+			t.Fatalf("record %d fallback=%d want raw-only", i, record.fallback)
+		}
+	}
+	pr3bRequireCitySemanticRecord(t, records[:1], "hnl", "sea")
+	pr3bRequireCitySemanticRecord(t, records[1:], "sea", "hnl")
+	pr3bRequireIndexIDs(t, col, "city", "hnl", "u1")
+	pr3bRequireIndexIDs(t, col, "city", "sea")
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush change-change-back updates: %v", err)
+	}
+	pr3bRequireIndexIDs(t, col, "city", "hnl", "u1")
+	stats := mgr.StatsSnapshot()
+	if got := stats.IndexedSemanticRawRecords; got != 2 {
+		t.Fatalf("raw semantic records=%d want 2", got)
+	}
+	if got := stats.IndexedSemanticFallbackRecords; got != 2 {
+		t.Fatalf("fallback semantic records=%d want 2", got)
+	}
+	if got := stats.IndexedSemanticEffectiveRecords; got != 0 {
+		t.Fatalf("effective semantic records=%d want 0", got)
+	}
+}
+
+func TestPR3bSemanticUniqueHandoffFallsBackToMechanicalPath(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{[]byte(`{"email":"a@example.com"}`), []byte(`{"email":"b@example.com"}`)},
+	); err != nil {
+		t.Fatalf("insert users: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed users: %v", err)
+	}
+
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONEmail("c@example.com")},
+		{DocumentID: []byte("u2"), Update: setJSONEmail("a@example.com")},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges unique handoff: %v", err)
+	}
+	if batched {
+		t.Fatalf("unique handoff batched=%v results=%+v want explicit fallback", batched, results)
+	}
+	stats := mgr.StatsSnapshot()
+	if got := stats.IndexedSemanticRawRecords; got != 0 {
+		t.Fatalf("raw semantic records after unique fallback=%d want 0", got)
+	}
+	if got := stats.PendingIndexedSemanticRecords; got != 0 {
+		t.Fatalf("pending semantic records after unique fallback=%d want 0", got)
+	}
+	pr3bRequireIndexIDs(t, col, "email", "a@example.com", "u1")
+	pr3bRequireIndexIDs(t, col, "email", "b@example.com", "u2")
+
+	published, err := col.UpdateBatch([]UpdateBatchItem{
+		{DocumentID: []byte("u1"), Update: setJSONEmail("c@example.com")},
+		{DocumentID: []byte("u2"), Update: setJSONEmail("a@example.com")},
+	})
+	if err != nil {
+		t.Fatalf("mechanical UpdateBatch unique handoff: %v", err)
+	}
+	if len(published) != 2 || !published[0].Modified || !published[1].Modified {
+		t.Fatalf("mechanical handoff results=%+v want two modified rows", published)
+	}
+	pr3bRequireIndexIDs(t, col, "email", "a@example.com", "u2")
+	pr3bRequireIndexIDs(t, col, "email", "c@example.com", "u1")
+	stats = mgr.StatsSnapshot()
+	if got := stats.IndexedSemanticRawRecords; got != 0 {
+		t.Fatalf("raw semantic records after mechanical handoff=%d want 0", got)
+	}
+	if got := stats.PendingIndexedSemanticRecords; got != 0 {
+		t.Fatalf("pending semantic records after mechanical handoff=%d want 0", got)
+	}
+}
+
+func pr3bSemanticTestCollection(tb testing.TB) (*backenddb.DB, *CollectionManager, *Collection) {
+	tb.Helper()
+	d, err := backenddb.Open(backenddb.Options{Dir: tb.TempDir()})
+	if err != nil {
+		tb.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:                   true,
+			BufferedIndexedAsyncFlush:               true,
+			BufferedIndexedAsyncFlushMaxQueuedUnits: 8,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		_ = d.Close()
+		tb.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("open collection: %v", err)
+	}
+	return d, mgr, col
+}
+
+func pr3bSeedSemanticUser(tb testing.TB, col *Collection) {
+	tb.Helper()
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"a@example.com","city":"hnl","score":0}`)},
+	); err != nil {
+		tb.Fatalf("insert seed user: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		tb.Fatalf("flush seed user: %v", err)
+	}
+}
+
+func pr3bRequireCitySemanticRecord(tb testing.TB, records []indexedSemanticRecord, oldCity, newCity string) {
+	tb.Helper()
+	if len(records) != 1 {
+		tb.Fatalf("semantic records=%d want 1", len(records))
+	}
+	record := records[0]
+	if record.kind != indexedSemanticRecordUpdate {
+		tb.Fatalf("semantic record kind=%d want update", record.kind)
+	}
+	if !bytes.Equal(record.documentID, []byte("u1")) {
+		tb.Fatalf("semantic record documentID=%q want u1", record.documentID)
+	}
+	if record.fallback != indexedSemanticFallbackRawOnly {
+		tb.Fatalf("semantic record fallback=%d want raw-only", record.fallback)
+	}
+	if len(record.indexDeltas) != 1 {
+		tb.Fatalf("semantic index deltas=%d want 1", len(record.indexDeltas))
+	}
+	delta := record.indexDeltas[0]
+	if delta.indexName != "city" || delta.rootName != collectionSecondaryRootName("users", "city") || delta.unique {
+		tb.Fatalf("city delta identity index=%q root=%q unique=%v", delta.indexName, delta.rootName, delta.unique)
+	}
+	wantOld, err := encodeIndexScalar(IndexValueString, oldCity)
+	if err != nil {
+		tb.Fatalf("encode old city %q: %v", oldCity, err)
+	}
+	wantNew, err := encodeIndexScalar(IndexValueString, newCity)
+	if err != nil {
+		tb.Fatalf("encode new city %q: %v", newCity, err)
+	}
+	if !pr3bSemanticValueSetsEqual(delta.oldValues, [][]byte{wantOld}) {
+		tb.Fatalf("old city values=%q want %q", delta.oldValues, [][]byte{wantOld})
+	}
+	if !pr3bSemanticValueSetsEqual(delta.newValues, [][]byte{wantNew}) {
+		tb.Fatalf("new city values=%q want %q", delta.newValues, [][]byte{wantNew})
+	}
+}
+
+func pr3bSemanticValueSetsEqual(left, right [][]byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if !bytes.Equal(left[i], right[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func pr3bRequireIndexIDs(tb testing.TB, col *Collection, indexName string, value any, want ...string) {
+	tb.Helper()
+	ids, err := col.FindByIndexValue(indexName, value)
+	if err != nil {
+		tb.Fatalf("find index %s=%v: %v", indexName, value, err)
+	}
+	if len(ids) != len(want) {
+		tb.Fatalf("index %s=%v ids=%q want %q", indexName, value, ids, want)
+	}
+	for i := range want {
+		if !bytes.Equal(ids[i], []byte(want[i])) {
+			tb.Fatalf("index %s=%v ids=%q want %q", indexName, value, ids, want)
+		}
+	}
+}
+
+func pr3bRequireSemanticMetricKeys(tb testing.TB, mgr *CollectionManager) {
+	tb.Helper()
+	exported := mgr.Stats()
+	for _, key := range []string{
+		"treedb.collections.write_domain.pending_indexed_semantic_raw_records",
+		"treedb.collections.write_domain.indexed_semantic.raw_records_total",
+		"treedb.collections.write_domain.indexed_semantic.raw_index_deltas_total",
+		"treedb.collections.write_domain.indexed_semantic.fallback_records_total",
+		"treedb.collections.write_domain.indexed_semantic.effective_records_total",
+	} {
+		if exported[key] == "" {
+			tb.Fatalf("exported stats missing %s from %#v", key, exported)
+		}
+	}
+}

--- a/TreeDB/collections/pr3b_semantic_indexed_test.go
+++ b/TreeDB/collections/pr3b_semantic_indexed_test.go
@@ -445,7 +445,7 @@ func pr3bRequireSemanticMetricKeys(tb testing.TB, mgr *CollectionManager) {
 	tb.Helper()
 	exported := mgr.Stats()
 	for _, key := range []string{
-		"treedb.collections.write_domain.pending_indexed_semantic_raw_records",
+		"treedb.collections.write_domain.pending_indexed_semantic_records",
 		"treedb.collections.write_domain.indexed_semantic.raw_records_total",
 		"treedb.collections.write_domain.indexed_semantic.raw_index_deltas_total",
 		"treedb.collections.write_domain.indexed_semantic.fallback_records_total",


### PR DESCRIPTION
# PR3b semantic indexed coalescing: raw-material slice

## Supported semantic cases

This PR captures raw semantic material for buffered indexed `UpdateBatch` staging without changing the mechanical publish output. For each buffered modified document, the write-domain now records:

- the updated document ID;
- record kind `update`;
- per-index old/new encoded value sets for changed secondary index runtimes;
- index name, secondary root name, runtime ordinal, and uniqueness bit;
- a `raw-only` fallback marker.

The records are captured for update batches that actually stage in the indexed write-domain, including the safe `UpdateBatchIfNoSecondaryUniqueIndexChanges` path. Records are threaded through mutable state, queued `indexedFlushUnit`s, active `coalescedFlushBatch` work, and requeued units. They are also cloned/restored by buffered write-domain checkpoint/rollback helpers.

## Fallback cases

All captured records are deliberately marked `raw-only` in this slice. Publish still uses the existing root-run tables and ordered-root publish APIs.

Unique secondary changes that cannot use `UpdateBatchIfNoSecondaryUniqueIndexChanges` continue to fall back to existing mechanical behavior. Inserts, deletes, template-v1-specific semantic interpretation, and effective semantic delta reduction are not implemented here.

## What remains for later PRs

- Compute effective semantic deltas from the raw records.
- Reduce durable root-delta entries for bounded non-unique secondary cases.
- Add unique handoff/conflict-aware semantic coalescing where safe.
- Extend semantic records to inserts/deletes if needed.
- Add benchmarks once root-delta volume changes.

## Preservation notes

Visibility remains driven by the existing primary and secondary root runs; semantic records are not consulted by reads or unique probes. Unique pending reservations remain in `uniqueValueRuns`/`uniqueValueIndex`. FIFO unit boundaries remain in `coalescedFlushBatch.units`; the merged unit is still only the mechanical publish view. Root mismatch and publish failure requeue prepend the original units with their semantic records intact. Lost ownership behavior remains table-identity based and ignores semantic records. Raw semantic stats are observed when staging succeeds and are not incremented again by requeue or retry.

## Benchmark expectations

No root-delta volume change is expected in this PR because every semantic record is raw-only fallback and publish output remains mechanical. The only expected overhead is small in-memory record capture and observability counters for buffered indexed update batches.
