### PR TITLE
collections: publish safe PR3b secondary semantic deltas

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -765,6 +765,7 @@ type coalescedFlushBatch struct {
 	rootCount         int
 	rootDeltaStats    collectionRootDeltaPlanStats
 	rawRootDeltaStats collectionRootDeltaPlanStats
+	effectiveRecords  int
 }
 
 type indexedFlushPublishWork struct {
@@ -2230,6 +2231,13 @@ func (domain *collectionWriteDomain) observeRootDeltaPlanCoalescing(rawStats, fi
 	if rawStats.entries > 0 && finalStats.entries == 0 {
 		domain.rootDeltaPlanNetZeroPlans.Add(1)
 	}
+}
+
+func (domain *collectionWriteDomain) observeIndexedSemanticEffectiveRecords(records int) {
+	if domain == nil || records <= 0 {
+		return
+	}
+	domain.indexedSemanticEffectiveRecords.Add(uint64(records))
 }
 
 func (domain *collectionWriteDomain) observePrimaryOnlyDrain(docs int, bytes int64, uniqueDocs int, duration time.Duration) {
@@ -5539,22 +5547,32 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	}
 	materializeStart := time.Now()
 	work.batch.state = coalescedFlushBatchMaterializing
-	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(work.batch.rootNames, work.batch.mergedUnit.rootRuns, work.batch.rootBaseIDs, work.batch.mergedUnit.rootPolicies)
+	view, err := buildIndexedSemanticPublishView(work.meta, work.batch.mergedUnit, work.batch.rootNames, work.batch.rootBaseIDs)
 	if err != nil {
 		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
 	}
-	work.batch.rootDeltaStats = collectionRootDeltaPlanStatsFromOrdered(work.meta.Name, work.batch.rootNames, ordered)
+	defer resetIndexedSemanticPublishView(view)
+	work.batch.rootNames = view.rootNames
+	work.batch.rootBaseIDs = view.rootBaseIDs
+	work.batch.rootCount = len(view.rootNames)
+	work.batch.effectiveRecords = view.effectiveRecords
+	ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(view.rootNames, view.rootRuns, view.rootBaseIDs, view.rootPolicies)
+	if err != nil {
+		materializeElapsed := collectionObservedElapsedSince(materializeStart)
+		return c.completePreparedIndexedFlush(work, 0, nil, err, materializeElapsed, materializeElapsed, 0)
+	}
+	work.batch.rootDeltaStats = collectionRootDeltaPlanStatsFromOrdered(work.meta.Name, view.rootNames, ordered)
 	materializeElapsed := collectionObservedElapsedSince(materializeStart)
 	publishStart := time.Now()
 	work.batch.state = coalescedFlushBatchPublishing
 	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-		return c.buildRootDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.batch.rootNames, work.batch.rootBaseIDs, rootIDs)
+		return c.buildRootDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, view.rootNames, view.rootBaseIDs, rootIDs)
 	})
 	publishElapsed := collectionObservedElapsedSince(publishStart)
 	cleanupDeltas()
-	if publishErr == nil && len(rootIDs) != len(work.batch.rootNames) {
-		publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(work.batch.rootNames), len(rootIDs))
+	if publishErr == nil && len(rootIDs) != len(view.rootNames) {
+		publishErr = unexpectedOrderedRootCountError(work.meta.Name, len(view.rootNames), len(rootIDs))
 	}
 	completeErr := c.completePreparedIndexedFlush(work, newSystemRoot, rootIDs, publishErr, materializeElapsed+publishElapsed, materializeElapsed, publishElapsed)
 	if completeErr != nil {
@@ -5791,6 +5809,196 @@ func collectionRootDeltaPlanStatsFromRootRuns(collectionName string, rootRuns ma
 		}
 	}
 	return stats, nil
+}
+
+type indexedSemanticPublishView struct {
+	rootNames        []string
+	rootRuns         map[string][]memtable.Table
+	rootPolicies     map[string]backenddb.OrderedRootStoragePolicy
+	rootBaseIDs      map[string]uint64
+	ownedTables      []memtable.Table
+	effectiveRecords int
+}
+
+func buildIndexedSemanticPublishView(meta CollectionMeta, unit indexedFlushUnit, rootNames []string, rootBaseIDs map[string]uint64) (indexedSemanticPublishView, error) {
+	view := indexedSemanticPublishView{
+		rootNames:    rootNames,
+		rootRuns:     unit.rootRuns,
+		rootPolicies: unit.rootPolicies,
+		rootBaseIDs:  rootBaseIDs,
+	}
+	if normalizedDocumentFormat(meta.Options.DocumentFormat) == DocumentFormatTemplateV1 ||
+		len(unit.semanticRecords) == 0 ||
+		unit.docCount != len(unit.semanticRecords) ||
+		len(unit.uniqueValueRuns) != 0 {
+		return view, nil
+	}
+	effectiveRuns, effectiveRecords, ok, err := buildIndexedSemanticEffectiveSecondaryRuns(unit.semanticRecords)
+	if err != nil || !ok || len(effectiveRuns) == 0 {
+		return view, err
+	}
+
+	rootRuns := cloneTableRunMap(unit.rootRuns)
+	rootPolicies := cloneRootPolicyMap(unit.rootPolicies)
+	baseIDs := cloneUint64Map(rootBaseIDs)
+	for rootName, table := range effectiveRuns {
+		if table == nil || table.Len() == 0 {
+			resetCollectionRunTable(table)
+			delete(rootRuns, rootName)
+			delete(rootPolicies, rootName)
+			continue
+		}
+		rootRuns[rootName] = []memtable.Table{table}
+		view.ownedTables = append(view.ownedTables, table)
+	}
+	view.rootRuns = rootRuns
+	view.rootPolicies = rootPolicies
+	view.rootBaseIDs = baseIDs
+	view.rootNames = orderedBufferedRootNames(meta, rootRuns)
+	if len(view.rootNames) == 0 {
+		resetIndexedSemanticPublishView(view)
+		return indexedSemanticPublishView{
+			rootNames:    rootNames,
+			rootRuns:     unit.rootRuns,
+			rootPolicies: unit.rootPolicies,
+			rootBaseIDs:  rootBaseIDs,
+		}, nil
+	}
+	view.effectiveRecords = effectiveRecords
+	return view, nil
+}
+
+func resetIndexedSemanticPublishView(view indexedSemanticPublishView) {
+	for _, table := range view.ownedTables {
+		resetCollectionRunTable(table)
+	}
+}
+
+type indexedSemanticDocumentRootState struct {
+	documentID  []byte
+	baseValues  [][]byte
+	finalValues [][]byte
+}
+
+func buildIndexedSemanticEffectiveSecondaryRuns(records []indexedSemanticRecord) (map[string]memtable.Table, int, bool, error) {
+	type stateKey struct {
+		rootName   string
+		documentID string
+	}
+	states := make(map[stateKey]*indexedSemanticDocumentRootState)
+	roots := make(map[string]struct{})
+	for _, record := range records {
+		if record.kind != indexedSemanticRecordUpdate {
+			return nil, 0, false, nil
+		}
+		for _, delta := range record.indexDeltas {
+			if delta.unique {
+				return nil, 0, false, nil
+			}
+			if delta.rootName == "" {
+				return nil, 0, false, nil
+			}
+			key := stateKey{rootName: delta.rootName, documentID: string(record.documentID)}
+			state := states[key]
+			if state == nil {
+				states[key] = &indexedSemanticDocumentRootState{
+					documentID:  bytes.Clone(record.documentID),
+					baseValues:  cloneIndexedSemanticValueSet(delta.oldValues),
+					finalValues: cloneIndexedSemanticValueSet(delta.newValues),
+				}
+				roots[delta.rootName] = struct{}{}
+				continue
+			}
+			if !indexedSemanticValueSetsEqual(state.finalValues, delta.oldValues) {
+				return nil, 0, false, nil
+			}
+			state.finalValues = cloneIndexedSemanticValueSet(delta.newValues)
+		}
+	}
+	if len(states) == 0 {
+		return nil, 0, false, nil
+	}
+
+	rootTables := make(map[string]memtable.Table, len(roots))
+	effectiveRecords := 0
+	for rootName := range roots {
+		table := newCollectionRunTable(0)
+		for key, state := range states {
+			if key.rootName != rootName {
+				continue
+			}
+			deletes, sets := indexedSemanticValueSetDiff(state.baseValues, state.finalValues)
+			if len(deletes) == 0 && len(sets) == 0 {
+				continue
+			}
+			effectiveRecords++
+			for _, encoded := range deletes {
+				if _, err := deleteCollectionSecondaryIndexEntry(table, encoded, state.documentID); err != nil {
+					resetCollectionRunTable(table)
+					for _, existing := range rootTables {
+						resetCollectionRunTable(existing)
+					}
+					return nil, 0, false, err
+				}
+			}
+			for _, encoded := range sets {
+				if _, err := setCollectionSecondaryIndexEntry(table, encoded, state.documentID); err != nil {
+					resetCollectionRunTable(table)
+					for _, existing := range rootTables {
+						resetCollectionRunTable(existing)
+					}
+					return nil, 0, false, err
+				}
+			}
+		}
+		table.Freeze()
+		rootTables[rootName] = table
+	}
+	return rootTables, effectiveRecords, true, nil
+}
+
+func indexedSemanticValueSetsEqual(left, right [][]byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	seen := make(map[string]int, len(left))
+	for _, value := range left {
+		seen[string(value)]++
+	}
+	for _, value := range right {
+		key := string(value)
+		if seen[key] == 0 {
+			return false
+		}
+		seen[key]--
+	}
+	return true
+}
+
+func indexedSemanticValueSetDiff(base, final [][]byte) (deletes, sets [][]byte) {
+	finalCounts := make(map[string]int, len(final))
+	finalValues := make(map[string][]byte, len(final))
+	for _, value := range final {
+		key := string(value)
+		finalCounts[key]++
+		if _, ok := finalValues[key]; !ok {
+			finalValues[key] = value
+		}
+	}
+	for _, value := range base {
+		key := string(value)
+		if finalCounts[key] > 0 {
+			finalCounts[key]--
+			continue
+		}
+		deletes = append(deletes, value)
+	}
+	for key, count := range finalCounts {
+		for i := 0; i < count; i++ {
+			sets = append(sets, finalValues[key])
+		}
+	}
+	return deletes, sets
 }
 
 func collectionRootDeltaPlanStatsFromCollectionRootRuns(collectionName string, runs []collectionRootRun) (collectionRootDeltaPlanStats, error) {
@@ -6056,6 +6264,7 @@ func (c *Collection) completePreparedIndexedFlush(work *indexedFlushPublishWork,
 	domain.observeRootDeltaPlanFinal(work.batch.rootDeltaStats)
 	domain.observeRootDeltaPlanCoalescing(work.batch.rawRootDeltaStats, work.batch.rootDeltaStats)
 	domain.observeRootDeltaPlan(work.batch.rootDeltaStats)
+	domain.observeIndexedSemanticEffectiveRecords(work.batch.effectiveRecords)
 	return nil
 }
 
@@ -6178,25 +6387,35 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		}
 	} else {
 		materializeStart := time.Now()
-		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(rootNames, flushUnit.rootRuns, flushUnit.rootBaseIDs, flushUnit.rootPolicies)
+		view, err := buildIndexedSemanticPublishView(meta, flushUnit, rootNames, baseRootIDs)
 		if err != nil {
 			materializeElapsed = collectionObservedElapsedSince(materializeStart)
 			return err
 		}
-		rootDeltaStats := collectionRootDeltaPlanStatsFromOrdered(meta.Name, rootNames, ordered)
+		defer resetIndexedSemanticPublishView(view)
+		ordered, cleanupDeltas, err := buildBufferedRootDeltaBatchPublishInputs(view.rootNames, view.rootRuns, view.rootBaseIDs, view.rootPolicies)
+		if err != nil {
+			materializeElapsed = collectionObservedElapsedSince(materializeStart)
+			return err
+		}
+		rootDeltaStats := collectionRootDeltaPlanStatsFromOrdered(meta.Name, view.rootNames, ordered)
 		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, view.rootNames, view.rootBaseIDs, rootIDs)
 		})
 		publishElapsed = collectionObservedElapsedSince(publishStart)
 		cleanupDeltas()
 		if err == nil {
+			rootNames = view.rootNames
+			baseRootIDs = view.rootBaseIDs
+			flushRoots = len(view.rootNames)
 			domain.observeCoalescedFlushBatch(flushUnits, flushDocs, flushBytes, rootDeltaStats.entries == 0)
 			domain.observeRootDeltaPlanRawUnit(rawRootDeltaStats)
 			domain.observeRootDeltaPlanFinal(rootDeltaStats)
 			domain.observeRootDeltaPlanCoalescing(rawRootDeltaStats, rootDeltaStats)
 			domain.observeRootDeltaPlan(rootDeltaStats)
+			domain.observeIndexedSemanticEffectiveRecords(view.effectiveRecords)
 		}
 	}
 	if err != nil {
@@ -8734,12 +8953,14 @@ func buildIndexedSemanticUpdateRecords(collectionName string, runtimes []indexRu
 		record := indexedSemanticRecord{
 			kind:       indexedSemanticRecordUpdate,
 			documentID: bytes.Clone(update.documentID),
-			fallback:   indexedSemanticFallbackRawOnly,
 		}
 		if update.indexStateChanged && len(runtimes) > 0 {
 			for runtimeIdx, runtime := range runtimes {
 				if !preparedBatchUpdateIndexChanged(update, runtimeIdx) {
 					continue
+				}
+				if runtime.def.unique {
+					record.fallback = indexedSemanticFallbackRawOnly
 				}
 				record.indexDeltas = append(record.indexDeltas, indexedSemanticIndexDelta{
 					indexName:  runtime.def.name,

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5914,6 +5914,10 @@ func buildIndexedSemanticEffectiveSecondaryRuns(records []indexedSemanticRecord)
 		if record.kind != indexedSemanticRecordUpdate {
 			return nil, 0, false, nil
 		}
+		var documentKey string
+		if len(record.indexDeltas) > 0 {
+			documentKey = string(record.documentID)
+		}
 		for _, delta := range record.indexDeltas {
 			if delta.unique {
 				return nil, 0, false, nil
@@ -5926,11 +5930,10 @@ func buildIndexedSemanticEffectiveSecondaryRuns(records []indexedSemanticRecord)
 				states = make(map[string]*indexedSemanticDocumentRootState)
 				rootStates[delta.rootName] = states
 			}
-			documentKey := string(record.documentID)
 			state := states[documentKey]
 			if state == nil {
 				states[documentKey] = &indexedSemanticDocumentRootState{
-					documentID:  bytes.Clone(record.documentID),
+					documentID:  record.documentID,
 					baseValues:  cloneIndexedSemanticValueSet(delta.oldValues),
 					finalValues: cloneIndexedSemanticValueSet(delta.newValues),
 				}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5881,12 +5881,7 @@ type indexedSemanticDocumentRootState struct {
 }
 
 func buildIndexedSemanticEffectiveSecondaryRuns(records []indexedSemanticRecord) (map[string]memtable.Table, int, bool, error) {
-	type stateKey struct {
-		rootName   string
-		documentID string
-	}
-	states := make(map[stateKey]*indexedSemanticDocumentRootState)
-	roots := make(map[string]struct{})
+	statesByRoot := make(map[string]map[string]*indexedSemanticDocumentRootState)
 	for _, record := range records {
 		if record.kind != indexedSemanticRecordUpdate {
 			return nil, 0, false, nil
@@ -5898,15 +5893,19 @@ func buildIndexedSemanticEffectiveSecondaryRuns(records []indexedSemanticRecord)
 			if delta.rootName == "" {
 				return nil, 0, false, nil
 			}
-			key := stateKey{rootName: delta.rootName, documentID: string(record.documentID)}
-			state := states[key]
+			rootStates := statesByRoot[delta.rootName]
+			if rootStates == nil {
+				rootStates = make(map[string]*indexedSemanticDocumentRootState)
+				statesByRoot[delta.rootName] = rootStates
+			}
+			documentKey := string(record.documentID)
+			state := rootStates[documentKey]
 			if state == nil {
-				states[key] = &indexedSemanticDocumentRootState{
+				rootStates[documentKey] = &indexedSemanticDocumentRootState{
 					documentID:  bytes.Clone(record.documentID),
 					baseValues:  cloneIndexedSemanticValueSet(delta.oldValues),
 					finalValues: cloneIndexedSemanticValueSet(delta.newValues),
 				}
-				roots[delta.rootName] = struct{}{}
 				continue
 			}
 			if !indexedSemanticValueSetsEqual(state.finalValues, delta.oldValues) {
@@ -5915,23 +5914,20 @@ func buildIndexedSemanticEffectiveSecondaryRuns(records []indexedSemanticRecord)
 			state.finalValues = cloneIndexedSemanticValueSet(delta.newValues)
 		}
 	}
-	if len(states) == 0 {
+	if len(statesByRoot) == 0 {
 		return nil, 0, false, nil
 	}
 
-	rootTables := make(map[string]memtable.Table, len(roots))
-	effectiveRecords := 0
-	for rootName := range roots {
+	rootTables := make(map[string]memtable.Table, len(statesByRoot))
+	effectiveDocuments := make(map[string]struct{})
+	for rootName, states := range statesByRoot {
 		table := newCollectionRunTable(0)
-		for key, state := range states {
-			if key.rootName != rootName {
-				continue
-			}
+		for documentKey, state := range states {
 			deletes, sets := indexedSemanticValueSetDiff(state.baseValues, state.finalValues)
 			if len(deletes) == 0 && len(sets) == 0 {
 				continue
 			}
-			effectiveRecords++
+			effectiveDocuments[documentKey] = struct{}{}
 			for _, encoded := range deletes {
 				if _, err := deleteCollectionSecondaryIndexEntry(table, encoded, state.documentID); err != nil {
 					resetCollectionRunTable(table)
@@ -5954,7 +5950,7 @@ func buildIndexedSemanticEffectiveSecondaryRuns(records []indexedSemanticRecord)
 		table.Freeze()
 		rootTables[rootName] = table
 	}
-	return rootTables, effectiveRecords, true, nil
+	return rootTables, len(effectiveDocuments), true, nil
 }
 
 func indexedSemanticValueSetsEqual(left, right [][]byte) bool {
@@ -5976,14 +5972,13 @@ func indexedSemanticValueSetsEqual(left, right [][]byte) bool {
 }
 
 func indexedSemanticValueSetDiff(base, final [][]byte) (deletes, sets [][]byte) {
+	baseCounts := make(map[string]int, len(base))
+	for _, value := range base {
+		baseCounts[string(value)]++
+	}
 	finalCounts := make(map[string]int, len(final))
-	finalValues := make(map[string][]byte, len(final))
 	for _, value := range final {
-		key := string(value)
-		finalCounts[key]++
-		if _, ok := finalValues[key]; !ok {
-			finalValues[key] = value
-		}
+		finalCounts[string(value)]++
 	}
 	for _, value := range base {
 		key := string(value)
@@ -5993,10 +5988,13 @@ func indexedSemanticValueSetDiff(base, final [][]byte) (deletes, sets [][]byte) 
 		}
 		deletes = append(deletes, value)
 	}
-	for key, count := range finalCounts {
-		for i := 0; i < count; i++ {
-			sets = append(sets, finalValues[key])
+	for _, value := range final {
+		key := string(value)
+		if baseCounts[key] > 0 {
+			baseCounts[key]--
+			continue
 		}
+		sets = append(sets, value)
 	}
 	return deletes, sets
 }

--- a/TreeDB/collections/pr3b_semantic_indexed_test.go
+++ b/TreeDB/collections/pr3b_semantic_indexed_test.go
@@ -484,6 +484,70 @@ func TestPR3bSemanticMixedInsertUpdateFallsBackToMechanicalPublish(t *testing.T)
 	}
 }
 
+func TestPR3bSemanticMultiSecondaryChangeCountsOneEffectiveRecord(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "score", Field: "score", ValueType: IndexValueInt64},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl","score":1}`)},
+	); err != nil {
+		t.Fatalf("insert seed user: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed user: %v", err)
+	}
+
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			if !bytes.Contains(current, []byte(`"city":"hnl"`)) {
+				return nil, false, fmt.Errorf("current=%s want city hnl", current)
+			}
+			return []byte(`{"city":"sea","score":2}`), true, nil
+		},
+	}}); err != nil {
+		t.Fatalf("buffer multi-secondary update: %v", err)
+	} else if !batched {
+		t.Fatal("multi-secondary update was not buffered")
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush multi-secondary update: %v", err)
+	}
+
+	pr3bRequireIndexIDs(t, col, "city", "sea", "u1")
+	pr3bRequireIndexIDs(t, col, "score", int64(2), "u1")
+	stats := mgr.StatsSnapshot()
+	if got := stats.IndexedSemanticRawRecords; got != 1 {
+		t.Fatalf("raw semantic records after multi-secondary flush=%d want 1", got)
+	}
+	if got := stats.IndexedSemanticRawIndexDeltas; got != 2 {
+		t.Fatalf("raw semantic index deltas after multi-secondary flush=%d want 2", got)
+	}
+	if got := stats.IndexedSemanticEffectiveRecords; got != 1 {
+		t.Fatalf("effective semantic records after multi-secondary flush=%d want 1", got)
+	}
+}
+
 func TestPR3bSemanticUniqueHandoffFallsBackToMechanicalPath(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/pr3b_semantic_indexed_test.go
+++ b/TreeDB/collections/pr3b_semantic_indexed_test.go
@@ -42,8 +42,8 @@ func TestPR3bSemanticRawRecordsSurviveMutableQueuedActiveRequeued(t *testing.T) 
 	if got := stats.IndexedSemanticRawIndexDeltas; got != 1 {
 		t.Fatalf("raw semantic index deltas after stage=%d want 1", got)
 	}
-	if got := stats.IndexedSemanticFallbackRecords; got != 1 {
-		t.Fatalf("fallback semantic records after stage=%d want 1", got)
+	if got := stats.IndexedSemanticFallbackRecords; got != 0 {
+		t.Fatalf("fallback semantic records after stage=%d want 0", got)
 	}
 	if got := stats.IndexedSemanticEffectiveRecords; got != 0 {
 		t.Fatalf("effective semantic records after stage=%d want 0", got)
@@ -127,8 +127,8 @@ func TestPR3bSemanticRawRecordsSurviveMutableQueuedActiveRequeued(t *testing.T) 
 	if got := stats.IndexedSemanticRawRecords; got != 1 {
 		t.Fatalf("raw semantic records after flush=%d want 1", got)
 	}
-	if got := stats.IndexedSemanticEffectiveRecords; got != 0 {
-		t.Fatalf("effective semantic records after flush=%d want 0", got)
+	if got := stats.IndexedSemanticEffectiveRecords; got != 1 {
+		t.Fatalf("effective semantic records after flush=%d want 1", got)
 	}
 }
 
@@ -216,6 +216,7 @@ func TestPR3bSemanticRepeatedSameDocumentUpdatesSerialEquivalent(t *testing.T) {
 	d, mgr, col := pr3bSemanticTestCollection(t)
 	defer func() { _ = d.Close() }()
 	pr3bSeedSemanticUser(t, col)
+	before := mgr.StatsSnapshot()
 
 	firstCalls := 0
 	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
@@ -291,12 +292,25 @@ func TestPR3bSemanticRepeatedSameDocumentUpdatesSerialEquivalent(t *testing.T) {
 	if got := stats.IndexedSemanticEffectiveRecords; got != 0 {
 		t.Fatalf("effective semantic records after flush=%d want 0", got)
 	}
+	if got := stats.RootDeltaPlanRawUnitSecondaryEntries - before.RootDeltaPlanRawUnitSecondaryEntries; got == 0 {
+		t.Fatalf("raw secondary root entries delta=%d want >0", got)
+	}
+	if got := stats.RootDeltaPlanFinalSecondaryEntries - before.RootDeltaPlanFinalSecondaryEntries; got != 0 {
+		t.Fatalf("final secondary root entries delta=%d want 0", got)
+	}
+	if got := stats.IndexedSemanticSkippedSecondaryRoots - before.IndexedSemanticSkippedSecondaryRoots; got == 0 {
+		t.Fatalf("skipped secondary roots delta=%d want >0", got)
+	}
+	if got := stats.RootDeltaPlanSquashedEntries - before.RootDeltaPlanSquashedEntries; got == 0 {
+		t.Fatalf("squashed entries delta=%d want >0", got)
+	}
 }
 
-func TestPR3bSemanticNonUniqueChangeChangeBackFallsBackRawOnly(t *testing.T) {
+func TestPR3bSemanticNonUniqueChangeChangeBackSkipsSecondaryRoot(t *testing.T) {
 	d, mgr, col := pr3bSemanticTestCollection(t)
 	defer func() { _ = d.Close() }()
 	pr3bSeedSemanticUser(t, col)
+	before := mgr.StatsSnapshot()
 
 	for _, city := range []string{"sea", "hnl"} {
 		if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
@@ -316,8 +330,8 @@ func TestPR3bSemanticNonUniqueChangeChangeBackFallsBackRawOnly(t *testing.T) {
 		t.Fatalf("mutable semantic records=%d want 2", got)
 	}
 	for i, record := range records {
-		if record.fallback != indexedSemanticFallbackRawOnly {
-			t.Fatalf("record %d fallback=%d want raw-only", i, record.fallback)
+		if record.fallback != indexedSemanticFallbackNone {
+			t.Fatalf("record %d fallback=%d want none", i, record.fallback)
 		}
 	}
 	pr3bRequireCitySemanticRecord(t, records[:1], "hnl", "sea")
@@ -333,11 +347,140 @@ func TestPR3bSemanticNonUniqueChangeChangeBackFallsBackRawOnly(t *testing.T) {
 	if got := stats.IndexedSemanticRawRecords; got != 2 {
 		t.Fatalf("raw semantic records=%d want 2", got)
 	}
-	if got := stats.IndexedSemanticFallbackRecords; got != 2 {
-		t.Fatalf("fallback semantic records=%d want 2", got)
+	if got := stats.IndexedSemanticFallbackRecords; got != 0 {
+		t.Fatalf("fallback semantic records=%d want 0", got)
 	}
 	if got := stats.IndexedSemanticEffectiveRecords; got != 0 {
 		t.Fatalf("effective semantic records=%d want 0", got)
+	}
+	if got := stats.RootDeltaPlanRawUnitSecondaryEntries - before.RootDeltaPlanRawUnitSecondaryEntries; got == 0 {
+		t.Fatalf("raw secondary root entries delta=%d want >0", got)
+	}
+	if got := stats.RootDeltaPlanFinalSecondaryEntries - before.RootDeltaPlanFinalSecondaryEntries; got != 0 {
+		t.Fatalf("final secondary root entries delta=%d want 0", got)
+	}
+	if got := stats.IndexedSemanticSkippedSecondaryRoots - before.IndexedSemanticSkippedSecondaryRoots; got == 0 {
+		t.Fatalf("skipped secondary roots delta=%d want >0", got)
+	}
+	if got := stats.RootDeltaPlanSquashedEntries - before.RootDeltaPlanSquashedEntries; got == 0 {
+		t.Fatalf("squashed entries delta=%d want >0", got)
+	}
+}
+
+func TestPR3bSemanticAsyncPublishSkipsChangeBackSecondaryRoot(t *testing.T) {
+	d, mgr, col := pr3bSemanticTestCollection(t)
+	defer func() { _ = d.Close() }()
+	pr3bSeedSemanticUser(t, col)
+	before := mgr.StatsSnapshot()
+
+	for _, city := range []string{"sea", "hnl"} {
+		if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+			DocumentID: []byte("u1"),
+			Update:     setJSONCity(city),
+		}}); err != nil {
+			t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges city=%s: %v", city, err)
+		} else if !batched {
+			t.Fatalf("city=%s update was not buffered", city)
+		}
+		col.writeDomain.mu.Lock()
+		if !rotateIndexedMutableToFlushUnitLocked(col.writeDomain) {
+			col.writeDomain.mu.Unlock()
+			t.Fatalf("rotate indexed mutable state for city=%s returned false", city)
+		}
+		col.writeDomain.mu.Unlock()
+	}
+
+	work, err := col.prepareIndexedAsyncPublish()
+	if err != nil {
+		t.Fatalf("prepare async semantic publish: %v", err)
+	}
+	if work == nil {
+		t.Fatal("prepare async semantic publish returned nil work")
+	}
+	if got := len(work.batch.units); got != 2 {
+		collectionTestCloseIndexedFlushWork(work)
+		t.Fatalf("prepared semantic units=%d want 2", got)
+	}
+	if err := col.publishPreparedIndexedFlush(work); err != nil {
+		t.Fatalf("publish async semantic work: %v", err)
+	}
+
+	pr3bRequireIndexIDs(t, col, "city", "hnl", "u1")
+	pr3bRequireIndexIDs(t, col, "city", "sea")
+	stats := mgr.StatsSnapshot()
+	if got := stats.PendingIndexedSemanticRecords; got != 0 {
+		t.Fatalf("pending semantic records after async publish=%d want 0", got)
+	}
+	if got := stats.RootDeltaPlanRawUnitSecondaryEntries - before.RootDeltaPlanRawUnitSecondaryEntries; got == 0 {
+		t.Fatalf("async raw secondary root entries delta=%d want >0", got)
+	}
+	if got := stats.RootDeltaPlanFinalSecondaryEntries - before.RootDeltaPlanFinalSecondaryEntries; got != 0 {
+		t.Fatalf("async final secondary root entries delta=%d want 0", got)
+	}
+	if got := stats.IndexedSemanticSkippedSecondaryRoots - before.IndexedSemanticSkippedSecondaryRoots; got == 0 {
+		t.Fatalf("async skipped secondary roots delta=%d want >0", got)
+	}
+	if got := stats.RootDeltaPlanSquashedEntries - before.RootDeltaPlanSquashedEntries; got == 0 {
+		t.Fatalf("async squashed entries delta=%d want >0", got)
+	}
+}
+
+func TestPR3bSemanticMixedInsertUpdateFallsBackToMechanicalPublish(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"city":"hnl","score":0}`)},
+	); err != nil {
+		t.Fatalf("insert seed user: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed user: %v", err)
+	}
+
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"city":"lax","score":0}`)},
+	); err != nil {
+		t.Fatalf("buffer insert u2: %v", err)
+	}
+	if _, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update:     setJSONCity("sea"),
+	}}); err != nil {
+		t.Fatalf("buffer update u1: %v", err)
+	} else if !batched {
+		t.Fatal("u1 city update was not buffered")
+	}
+
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush mixed insert/update: %v", err)
+	}
+	pr3bRequireIndexIDs(t, col, "city", "sea", "u1")
+	pr3bRequireIndexIDs(t, col, "city", "lax", "u2")
+	stats := mgr.StatsSnapshot()
+	if got := stats.IndexedSemanticRawRecords; got != 1 {
+		t.Fatalf("raw semantic records after mixed flush=%d want 1", got)
+	}
+	if got := stats.IndexedSemanticEffectiveRecords; got != 0 {
+		t.Fatalf("effective semantic records after mixed flush=%d want 0", got)
 	}
 }
 
@@ -467,8 +610,8 @@ func pr3bRequireCitySemanticRecord(tb testing.TB, records []indexedSemanticRecor
 	if !bytes.Equal(record.documentID, []byte("u1")) {
 		tb.Fatalf("semantic record documentID=%q want u1", record.documentID)
 	}
-	if record.fallback != indexedSemanticFallbackRawOnly {
-		tb.Fatalf("semantic record fallback=%d want raw-only", record.fallback)
+	if record.fallback != indexedSemanticFallbackNone {
+		tb.Fatalf("semantic record fallback=%d want none", record.fallback)
 	}
 	if len(record.indexDeltas) != 1 {
 		tb.Fatalf("semantic index deltas=%d want 1", len(record.indexDeltas))

--- a/TreeDB/docs/spec/collections-write-domain.md
+++ b/TreeDB/docs/spec/collections-write-domain.md
@@ -61,8 +61,10 @@ published by a background worker.
 
 The async worker may move queued immutable units into one active coalesced flush
 batch before root publication completes. The batch preserves the original FIFO
-unit boundaries and uses a mechanical merged view only for ordered-root publish.
-Active publishing units remain visible to reads, unique checks,
+unit boundaries. Ordered-root publish uses either the mechanical merged view or
+a narrower semantic effective view for proven-safe non-unique secondary-index
+update chains; raw FIFO units remain the visibility, ownership, and requeue
+source. Active publishing units remain visible to reads, unique checks,
 schema-change barriers, and explicit flush barriers.
 
 `BufferedIndexedAsyncFlushMaxQueuedUnits` bounds queued immutable flush units.

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -162,7 +162,9 @@ unique checks, and update/delete planning must merge write-domain state with
 newest-wins shadowing: current mutable runs, queued immutable flush units,
 active in-flight async publishing units, then persisted roots. The active async
 publish uses a coalesced flush batch that preserves original FIFO unit
-boundaries while using a mechanical merged view for ordered-root publish.
+boundaries. Ordered-root publish uses either the mechanical merged view or a
+safe semantic effective view for non-unique secondary-index update chains; raw
+FIFO units remain the source for visibility, ownership, and requeue behavior.
 
 `BufferedIndexedAsyncFlush` is a throughput feature, not a durable-at-ack
 mutation log. The current contract is flush-boundary durable: callers may treat


### PR DESCRIPTION
## Summary
- add a narrow PR3b effective publish view for proven-safe non-unique secondary-index update chains
- keep raw indexed flush units as the visibility, ownership, and requeue source; mixed insert/update, unique, template-v1, overlay, and incomplete semantic cases fall back to mechanical publish
- observe effective semantic record counters on successful sync/async publish and update the write-domain contracts

## Scope
This does not implement primary-root semantic coalescing, insert/delete semantic cycles, unique-owner handoff, root rebase, prepared output inventory, or DB ordered-root API changes.

## Tests
- `go test ./TreeDB/collections -run 'TestPR3bSemantic|TestPR3bRootDeltaCoalescing' -count=1`\n- `go test ./TreeDB/collections -run 'TestPR3bSemantic|TestPR3bRootDeltaCoalescing|TestCollectionIndexedAsyncPublish|TestCollectionIndexedFlush|TestCollectionFindByIndexRangeSeesPublishingIndexedFlushUnits' -count=1`\n- `go test ./TreeDB/collections -count=1`\n- `go test ./TreeDB/docs -count=1`\n- `go test ./cmd/internal/treedbstats ./cmd/mongo_gateway_bench ./cmd/mongo_gateway_compare_report -count=1`\n- `python3 scripts/mongo_gateway_writer_metrics_test.py`\n- `git diff --check`