### PR TITLE
collections: preflight indexed flush publishes

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5531,7 +5531,10 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 		materializeElapsed := collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
 		work.batch.state = coalescedFlushBatchPublishing
-		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		preflight := func() error {
+			return c.validateRootOverlayDescriptorSystemDeltaForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.batch.rootNames, work.batch.rootBaseIDs, work.batch.rootOverlays)
+		}
+		newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, work.batch.rootNames, work.batch.rootBaseIDs, work.batch.rootOverlays, rootIDs)
 		})
 		publishElapsed := collectionObservedElapsedSince(publishStart)
@@ -5547,6 +5550,8 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	}
 	materializeStart := time.Now()
 	work.batch.state = coalescedFlushBatchMaterializing
+	preflightRootNames := append([]string(nil), work.batch.rootNames...)
+	preflightRootBaseIDs := cloneUint64Map(work.batch.rootBaseIDs)
 	view, err := buildIndexedSemanticPublishView(work.meta, work.batch.mergedUnit, work.batch.rootNames, work.batch.rootBaseIDs)
 	if err != nil {
 		materializeElapsed := collectionObservedElapsedSince(materializeStart)
@@ -5566,7 +5571,10 @@ func (c *Collection) publishPreparedIndexedFlush(work *indexedFlushPublishWork) 
 	materializeElapsed := collectionObservedElapsedSince(materializeStart)
 	publishStart := time.Now()
 	work.batch.state = coalescedFlushBatchPublishing
-	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+	preflight := func() error {
+		return c.validateRootDescriptorSystemDeltaForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, preflightRootNames, preflightRootBaseIDs)
+	}
+	newSystemRoot, rootIDs, publishErr := c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		return c.buildRootDescriptorSystemDeltaIteratorForMeta(work.meta, work.baseCommitSeq, work.baseSystemRoot, view.rootNames, view.rootBaseIDs, rootIDs)
 	})
 	publishElapsed := collectionObservedElapsedSince(publishStart)
@@ -6371,7 +6379,10 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		rootDeltaStats := collectionRootDeltaPlanStatsFromOrdered(meta.Name, rootNames, ordered)
 		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
-		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		preflight := func() error {
+			return c.validateRootOverlayDescriptorSystemDeltaForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays)
+		}
+		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootOverlayDescriptorSystemDeltaIteratorForMeta(meta, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootOverlays, rootIDs)
 		})
 		publishElapsed = collectionObservedElapsedSince(publishStart)
@@ -6399,7 +6410,12 @@ func (c *Collection) flushBufferedIndexedLocked(domain *collectionWriteDomain) (
 		rootDeltaStats := collectionRootDeltaPlanStatsFromOrdered(meta.Name, view.rootNames, ordered)
 		materializeElapsed = collectionObservedElapsedSince(materializeStart)
 		publishStart := time.Now()
-		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		preflightRootNames := append([]string(nil), rootNames...)
+		preflightRootBaseIDs := cloneUint64Map(baseRootIDs)
+		preflight := func() error {
+			return c.validateRootDescriptorSystemDeltaForMeta(meta, baseCommitSeq, baseSystemRoot, preflightRootNames, preflightRootBaseIDs)
+		}
+		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, view.rootNames, view.rootBaseIDs, rootIDs)
 		})
 		publishElapsed = collectionObservedElapsedSince(publishStart)

--- a/TreeDB/collections/indexed_flush_root_mismatch_test.go
+++ b/TreeDB/collections/indexed_flush_root_mismatch_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"errors"
+	"strconv"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -155,8 +156,13 @@ func TestCollectionIndexedAsyncPublishRootBaseMismatchRequeuesFIFOAndCounts(t *t
 		t.Fatalf("flush right row: %v", err)
 	}
 
+	rootApplyCallsBeforeMismatch := orderedRootDeltaGroupRootApplyCallsForTest(t, d)
 	if err := left.publishPreparedIndexedFlush(work); !errors.Is(err, ErrConcurrentMutation) {
 		t.Fatalf("publish prepared left err=%v want ErrConcurrentMutation", err)
+	}
+	rootApplyCallsAfterMismatch := orderedRootDeltaGroupRootApplyCallsForTest(t, d)
+	if got := rootApplyCallsAfterMismatch - rootApplyCallsBeforeMismatch; got != 0 {
+		t.Fatalf("root apply calls during root-mismatched publish=%d want 0", got)
 	}
 	if got := work.batch.state; got != coalescedFlushBatchRequeued {
 		t.Fatalf("root-mismatched batch state=%d want requeued", got)
@@ -196,4 +202,14 @@ func TestCollectionIndexedAsyncPublishRootBaseMismatchRequeuesFIFOAndCounts(t *t
 	if got := stats.IndexedFlushRequeuedUnits; got != 1 {
 		t.Fatalf("indexed flush requeued units=%d want 1", got)
 	}
+}
+
+func orderedRootDeltaGroupRootApplyCallsForTest(tb testing.TB, d *backenddb.DB) uint64 {
+	tb.Helper()
+	raw := d.Stats()["treedb.publish.ordered_root_delta_group.root_apply_calls_total"]
+	got, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		tb.Fatalf("parse root apply calls stat %q: %v", raw, err)
+	}
+	return got
 }

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1716,7 +1716,8 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	var retired []uint64
 	var merged adaptive.Metrics
 	phaseStart := time.Now()
-	rootApplyResults, parallelRootApply := db.applyOrderedRootDeltaBatchGroupRoots(idxGen, ordered, idxGen.allocator, &pagerAllocator{p: idxGen.pager})
+	rootApplyAlloc := newAllocTracker(idxGen.allocator)
+	rootApplyResults, parallelRootApply := db.applyOrderedRootDeltaBatchGroupRoots(idxGen, ordered, rootApplyAlloc, rootApplyAlloc)
 	phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	if parallelRootApply {
 		phaseStats.rootApplyParallelGroups++

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1715,26 +1715,31 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	systemOpts := systemRootOrderedPublishOptions(db)
 	var retired []uint64
 	var merged adaptive.Metrics
-	for idx := range ordered {
-		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[idx].StoragePolicy)
-		if err != nil {
-			return 0, nil, err
+	phaseStart := time.Now()
+	rootApplyResults, parallelRootApply := db.applyOrderedRootDeltaBatchGroupRoots(idxGen, ordered, idxGen.allocator, &pagerAllocator{p: idxGen.pager})
+	phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
+	if parallelRootApply {
+		phaseStats.rootApplyParallelGroups++
+		for orderedIdx := range ordered {
+			if ordered[orderedIdx].ParallelApply && ordered[orderedIdx].Delta != nil && !ordered[orderedIdx].Delta.IsEmpty() {
+				phaseStats.rootApplyParallelRoots++
+			}
 		}
-		phaseStart := time.Now()
-		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaBatchWithAllocator(idxGen, ordered[idx].BaseRoot, ordered[idx].Delta, opts, idxGen.allocator, &pagerAllocator{p: idxGen.pager}, ordered[idx].IncludeDeletedOnColdBuild)
-		phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
-		phaseStats.rootApplyCalls++
-		if err != nil {
-			return 0, nil, err
+	}
+	for orderedIdx := range rootApplyResults {
+		result := rootApplyResults[orderedIdx]
+		if result.err != nil {
+			return 0, nil, result.err
 		}
-		rootIDs[idx] = rootID
+		rootIDs[orderedIdx] = result.rootID
 		rootsObserved++
-		retired = append(retired, rootRetired...)
-		mergeOrderedRootPublishMetrics(&merged, metrics)
-		phaseStats.rootApplyMetrics.add(metrics)
+		retired = append(retired, result.retired...)
+		mergeOrderedRootPublishMetrics(&merged, result.metrics)
+		phaseStats.rootApplyMetrics.add(result.metrics)
+		phaseStats.rootApplyCalls++
 	}
 
-	phaseStart := time.Now()
+	phaseStart = time.Now()
 	iter, err := buildSystemDeltaIter(append([]uint64(nil), rootIDs...))
 	phaseStats.systemBuildNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	if err != nil {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -1717,6 +1717,12 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	var merged adaptive.Metrics
 	phaseStart := time.Now()
 	rootApplyAlloc := newAllocTracker(idxGen.allocator)
+	rootApplyCommitted := false
+	defer func() {
+		if err != nil && !rootApplyCommitted {
+			_ = rootApplyAlloc.FreeAll()
+		}
+	}()
 	rootApplyResults, parallelRootApply := db.applyOrderedRootDeltaBatchGroupRoots(idxGen, ordered, rootApplyAlloc, rootApplyAlloc)
 	phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	if parallelRootApply {
@@ -1781,6 +1787,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	if err != nil {
 		return 0, nil, err
 	}
+	rootApplyCommitted = true
 	return newSystemRoot, rootIDs, nil
 }
 


### PR DESCRIPTION
## Summary

PR3c slice for #1242: run collection indexed flush descriptor/root guards as a DB ordered-root preflight before applying root-local deltas.

- switches async and sync indexed flush publish paths to `PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder`
- validates captured collection root descriptors under the DB ordered-root write lock before root apply
- preserves PR3b effective publish views for actual published roots, while preflighting the full raw captured root set so skipped semantic roots cannot drift silently
- keeps overlay indexed flushes on preflighted publish as well
- keeps serialized batch publish root-level parallelism after preflight succeeds

## Non-goals

- no same-root rebase
- no prepared output inventory
- no leaf-span planning
- no change to raw indexed visibility/requeue ownership
- no no-index write-back behavior change

## Tests

- `go test ./TreeDB/collections -run 'TestCollectionIndexedAsyncPublishRootBaseMismatchRequeuesFIFOAndCounts|TestCollectionIndexedOverlayRootColdFlushPublishesBatchRootsInParallel|TestPR3bSemantic|TestPR3bRootDeltaCoalescing' -count=1`
- `go test ./TreeDB/db -run 'TestPublishOrderedRootDelta.*Preflight|TestPublishOrderedRootDelta.*Stats|TestPublishOrderedRootDelta.*RootApply' -count=1`
- `go test ./TreeDB/collections ./TreeDB/db -count=1`
- `go test -race ./TreeDB/collections -run 'TestCollectionIndexedAsyncPublishRootBaseMismatchRequeuesFIFOAndCounts|TestCollectionIndexedOverlayRootColdFlushPublishesBatchRootsInParallel' -count=1`
- `go test -race ./TreeDB/db -run 'TestPublishOrderedRootDelta.*Preflight|TestPublishOrderedRootDelta.*Stats|TestPublishOrderedRootDelta.*RootApply' -count=1`
- `git diff --check`
