### PR TITLE
[codex] Avoid published snapshot GetAppend probe allocations

### DIFF
--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -889,10 +889,23 @@ func rootDomainSystemSnapshotFromCachedSnapshot(s *Snapshot) rootDomainSnapshot 
 			snap.publishedRootID = rootID
 		}
 		if rootID != 0 {
-			snap.published = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
+			snap.published = s.backendSnapshotLookupForRoot(rootID)
 		}
 	}
 	return snap
+}
+
+func (s *Snapshot) backendSnapshotLookupForRoot(rootID uint64) rootDomainLookup {
+	if s == nil || s.backend == nil {
+		return nil
+	}
+	if s.backendRootOK && s.backendRoot.rootID == rootID {
+		return &s.backendRoot
+	}
+	if s.backendSystemOK && s.backendSystem.rootID == rootID {
+		return &s.backendSystem
+	}
+	return backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
 }
 
 func rootDomainSnapshotBackendRootID(s *Snapshot, fallback uint64) uint64 {
@@ -934,7 +947,7 @@ func rootDomainApplyPublishedRef(s *Snapshot, snap *rootDomainSnapshot, ref publ
 		return true
 	}
 	if s != nil && s.backend != nil && snap.publishedRootID != 0 {
-		snap.published = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: snap.publishedRootID}
+		snap.published = s.backendSnapshotLookupForRoot(snap.publishedRootID)
 		return true
 	}
 	return false
@@ -948,7 +961,7 @@ func rootDomainApplyBackendFallback(s *Snapshot, snap *rootDomainSnapshot) {
 	if rootID != 0 {
 		snap.publishedRootID = rootID
 	}
-	snap.published = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
+	snap.published = s.backendSnapshotLookupForRoot(rootID)
 }
 
 func rootDomainIteratorPublishedRef(set *publishedRootSet) publishedRootRef {
@@ -1120,7 +1133,7 @@ func (s rootDomainSnapshot) getEntry(key []byte) (val []byte, ptr page.ValuePtr,
 	return val, ptr, flags, found
 }
 
-func (s rootDomainSnapshot) getEntryWithSource(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
+func (s rootDomainSnapshot) getCachedEntryWithSource(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
 	if s.mutable != nil {
 		if val, ptr, flags, found = s.mutable.GetEntry(key); found {
 			return val, ptr, flags, true, rootDomainEntrySourceCached
@@ -1131,13 +1144,25 @@ func (s rootDomainSnapshot) getEntryWithSource(key []byte) (val []byte, ptr page
 			return val, ptr, flags, true, rootDomainEntrySourceCached
 		}
 	}
-	if s.published != nil {
-		val, ptr, flags, found = s.published.GetEntry(key)
-		if found {
-			return val, ptr, flags, true, rootDomainEntrySourcePublished
-		}
+	return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+}
+
+func (s rootDomainSnapshot) getPublishedEntryWithSource(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
+	if s.published == nil {
+		return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+	}
+	val, ptr, flags, found = s.published.GetEntry(key)
+	if found {
+		return val, ptr, flags, true, rootDomainEntrySourcePublished
 	}
 	return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+}
+
+func (s rootDomainSnapshot) getEntryWithSource(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
+	if val, ptr, flags, found, source = s.getCachedEntryWithSource(key); found {
+		return val, ptr, flags, true, source
+	}
+	return s.getPublishedEntryWithSource(key)
 }
 
 func (s rootDomainSnapshot) visibleValue(key []byte) ([]byte, bool) {

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -926,7 +926,7 @@ func (s *Snapshot) backendSnapshotLookupForRoot(rootID uint64) rootDomainLookup 
 	return backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
 }
 
-func (s *Snapshot) installBackendPublishedRootLookups() {
+func (s *Snapshot) installBackendPublishedRootLookups(publishedRootsOwned bool) {
 	if s == nil || s.backend == nil || s.publishedRoots == nil {
 		return
 	}
@@ -945,7 +945,10 @@ func (s *Snapshot) installBackendPublishedRootLookups() {
 		return
 	}
 
-	cloned := clonePublishedRootSet(s.publishedRoots)
+	cloned := s.publishedRoots
+	if !publishedRootsOwned {
+		cloned = clonePublishedRootSet(s.publishedRoots)
+	}
 	s.backendPublishedLookups = make([]backendSnapshotLookup, needed)
 	next := 0
 	installRef := func(ref *publishedRootRef) {

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -19,6 +19,10 @@ type rootDomainLookup interface {
 	GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool)
 }
 
+type rootDomainLookupWithError interface {
+	GetEntryWithError(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, err error)
+}
+
 type rootDomainIteratorFactory interface {
 	Iterator(start, end []byte) (iterator.UnsafeIterator, error)
 }
@@ -692,18 +696,17 @@ type backendSnapshotLookup struct {
 	rootID   uint64
 }
 
-func (l backendSnapshotLookup) GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+func (l backendSnapshotLookup) GetEntryWithError(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, err error) {
 	if l.snapshot == nil {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, false, backenddb.ErrClosed
 	}
 	if l.db != nil {
 		if err := l.db.flushValueLogForBackendRead(); err != nil {
-			return nil, page.ValuePtr{}, 0, false
+			return nil, page.ValuePtr{}, 0, false, err
 		}
 	}
 	var (
 		entry node.LeafEntry
-		err   error
 	)
 	if l.rootID != 0 {
 		entry, err = l.snapshot.GetEntryAtRoot(l.rootID, key)
@@ -712,11 +715,16 @@ func (l backendSnapshotLookup) GetEntry(key []byte) (val []byte, ptr page.ValueP
 	}
 	if err != nil {
 		if errors.Is(err, tree.ErrKeyNotFound) {
-			return nil, page.ValuePtr{}, 0, false
+			return nil, page.ValuePtr{}, 0, false, nil
 		}
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, false, err
 	}
-	return entry.Value, entry.ValuePtr, entry.Flags, true
+	return entry.Value, entry.ValuePtr, entry.Flags, true, nil
+}
+
+func (l backendSnapshotLookup) GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	val, ptr, flags, found, _ = l.GetEntryWithError(key)
+	return val, ptr, flags, found
 }
 
 func (l backendSnapshotLookup) GetValueAppend(key, dst []byte) ([]byte, error) {
@@ -1221,21 +1229,41 @@ func (s rootDomainSnapshot) getCachedEntryWithSource(key []byte) (val []byte, pt
 }
 
 func (s rootDomainSnapshot) getPublishedEntryWithSource(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
+	val, ptr, flags, found, source, _ = s.getPublishedEntryWithSourceError(key)
+	return val, ptr, flags, found, source
+}
+
+func (s rootDomainSnapshot) getPublishedEntryWithSourceError(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource, err error) {
 	if s.published == nil {
-		return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+		return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone, nil
+	}
+	if lookup, ok := s.published.(rootDomainLookupWithError); ok {
+		val, ptr, flags, found, err = lookup.GetEntryWithError(key)
+		if err != nil {
+			return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone, err
+		}
+		if found {
+			return val, ptr, flags, true, rootDomainEntrySourcePublished, nil
+		}
+		return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone, nil
 	}
 	val, ptr, flags, found = s.published.GetEntry(key)
 	if found {
-		return val, ptr, flags, true, rootDomainEntrySourcePublished
+		return val, ptr, flags, true, rootDomainEntrySourcePublished, nil
 	}
-	return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+	return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone, nil
 }
 
 func (s rootDomainSnapshot) getEntryWithSource(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
+	val, ptr, flags, found, source, _ = s.getEntryWithSourceError(key)
+	return val, ptr, flags, found, source
+}
+
+func (s rootDomainSnapshot) getEntryWithSourceError(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource, err error) {
 	if val, ptr, flags, found, source = s.getCachedEntryWithSource(key); found {
-		return val, ptr, flags, true, source
+		return val, ptr, flags, true, source, nil
 	}
-	return s.getPublishedEntryWithSource(key)
+	return s.getPublishedEntryWithSourceError(key)
 }
 
 func (s rootDomainSnapshot) visibleValue(key []byte) ([]byte, bool) {

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -927,47 +927,88 @@ func (s *Snapshot) backendSnapshotLookupForRoot(rootID uint64) rootDomainLookup 
 }
 
 func (s *Snapshot) installBackendPublishedRootLookups(publishedRootsOwned bool) {
-	if s == nil || s.backend == nil || s.publishedRoots == nil {
+	if s == nil || s.backend == nil {
 		return
 	}
 	needed := 0
+	directPointNeedsInstall := false
 	countRef := func(ref publishedRootRef) {
 		if ref.lookup == nil && ref.rootID != 0 && s.staticBackendSnapshotLookupForRoot(ref.rootID) == nil {
 			needed++
 		}
 	}
-	for _, ref := range s.publishedRoots.pointShards {
-		countRef(ref)
+	countSnapshot := func(snap rootDomainSnapshot) bool {
+		if snap.published != nil || snap.publishedRootID == 0 {
+			return false
+		}
+		if s.staticBackendSnapshotLookupForRoot(snap.publishedRootID) == nil {
+			needed++
+		}
+		return true
 	}
-	countRef(s.publishedRoots.system)
-	countRef(s.publishedRoots.iterator)
+	if s.publishedRoots != nil {
+		for _, ref := range s.publishedRoots.pointShards {
+			countRef(ref)
+		}
+		countRef(s.publishedRoots.system)
+		countRef(s.publishedRoots.iterator)
+	}
+	for _, snap := range s.rootPointShards {
+		if countSnapshot(snap) {
+			directPointNeedsInstall = true
+		}
+	}
+	countSnapshot(s.rootSystem)
+	countSnapshot(s.rootIterator)
 	if needed == 0 {
 		return
 	}
 
 	cloned := s.publishedRoots
-	if !publishedRootsOwned {
+	if cloned != nil && !publishedRootsOwned {
 		cloned = clonePublishedRootSet(s.publishedRoots)
 	}
 	s.backendPublishedLookups = make([]backendSnapshotLookup, needed)
 	next := 0
+	installLookup := func(rootID uint64) rootDomainLookup {
+		if rootID == 0 {
+			return nil
+		}
+		if lookup := s.staticBackendSnapshotLookupForRoot(rootID); lookup != nil {
+			return lookup
+		}
+		s.backendPublishedLookups[next] = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
+		lookup := &s.backendPublishedLookups[next]
+		next++
+		return lookup
+	}
 	installRef := func(ref *publishedRootRef) {
 		if ref == nil || ref.lookup != nil || ref.rootID == 0 {
 			return
 		}
-		if lookup := s.staticBackendSnapshotLookupForRoot(ref.rootID); lookup != nil {
-			ref.lookup = lookup
+		ref.lookup = installLookup(ref.rootID)
+	}
+	installSnapshot := func(snap *rootDomainSnapshot) {
+		if snap == nil || snap.published != nil || snap.publishedRootID == 0 {
 			return
 		}
-		s.backendPublishedLookups[next] = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: ref.rootID}
-		ref.lookup = &s.backendPublishedLookups[next]
-		next++
+		snap.published = installLookup(snap.publishedRootID)
 	}
-	for i := range cloned.pointShards {
-		installRef(&cloned.pointShards[i])
+	if cloned != nil {
+		for i := range cloned.pointShards {
+			installRef(&cloned.pointShards[i])
+		}
+		installRef(&cloned.system)
+		installRef(&cloned.iterator)
 	}
-	installRef(&cloned.system)
-	installRef(&cloned.iterator)
+	if directPointNeedsInstall {
+		s.rootPointShards = append([]rootDomainSnapshot(nil), s.rootPointShards...)
+	}
+	for i := range s.rootPointShards {
+		installSnapshot(&s.rootPointShards[i])
+	}
+	installSnapshot(&s.rootSystem)
+	installSnapshot(&s.rootIterator)
 	s.backendPublishedLookups = s.backendPublishedLookups[:next]
 	s.publishedRoots = cloned
 }

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -895,17 +895,90 @@ func rootDomainSystemSnapshotFromCachedSnapshot(s *Snapshot) rootDomainSnapshot 
 	return snap
 }
 
-func (s *Snapshot) backendSnapshotLookupForRoot(rootID uint64) rootDomainLookup {
+func (s *Snapshot) staticBackendSnapshotLookupForRoot(rootID uint64) *backendSnapshotLookup {
 	if s == nil || s.backend == nil {
 		return nil
 	}
-	if s.backendRootOK && s.backendRoot.rootID == rootID {
+	if s.backendRootOK && (s.backendRoot.rootID == rootID || rootID == 0) {
 		return &s.backendRoot
 	}
 	if s.backendSystemOK && s.backendSystem.rootID == rootID {
 		return &s.backendSystem
 	}
+	return nil
+}
+
+func (s *Snapshot) backendSnapshotLookupForRoot(rootID uint64) rootDomainLookup {
+	if s == nil || s.backend == nil {
+		return nil
+	}
+	if lookup := s.staticBackendSnapshotLookupForRoot(rootID); lookup != nil {
+		return lookup
+	}
 	return backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: rootID}
+}
+
+func (s *Snapshot) installBackendPublishedRootLookups() {
+	if s == nil || s.backend == nil || s.publishedRoots == nil {
+		return
+	}
+	needed := 0
+	countRef := func(ref publishedRootRef) {
+		if ref.lookup == nil && ref.rootID != 0 && s.staticBackendSnapshotLookupForRoot(ref.rootID) == nil {
+			needed++
+		}
+	}
+	for _, ref := range s.publishedRoots.pointShards {
+		countRef(ref)
+	}
+	countRef(s.publishedRoots.system)
+	countRef(s.publishedRoots.iterator)
+	if needed == 0 {
+		return
+	}
+
+	cloned := clonePublishedRootSet(s.publishedRoots)
+	s.backendPublishedLookups = make([]backendSnapshotLookup, needed)
+	next := 0
+	installRef := func(ref *publishedRootRef) {
+		if ref == nil || ref.lookup != nil || ref.rootID == 0 {
+			return
+		}
+		if lookup := s.staticBackendSnapshotLookupForRoot(ref.rootID); lookup != nil {
+			ref.lookup = lookup
+			return
+		}
+		s.backendPublishedLookups[next] = backendSnapshotLookup{db: s.db, snapshot: s.backend, rootID: ref.rootID}
+		ref.lookup = &s.backendPublishedLookups[next]
+		next++
+	}
+	for i := range cloned.pointShards {
+		installRef(&cloned.pointShards[i])
+	}
+	installRef(&cloned.system)
+	installRef(&cloned.iterator)
+	s.backendPublishedLookups = s.backendPublishedLookups[:next]
+	s.publishedRoots = cloned
+}
+
+func backendSnapshotLookupFromRootDomainLookup(lookup rootDomainLookup) (backendSnapshotLookup, bool) {
+	switch l := lookup.(type) {
+	case backendSnapshotLookup:
+		return l, true
+	case *backendSnapshotLookup:
+		if l != nil {
+			return *l, true
+		}
+	}
+	return backendSnapshotLookup{}, false
+}
+
+func (s *Snapshot) publishedLookupBackedByBackendSnapshot(snap rootDomainSnapshot) bool {
+	if s == nil || s.backend == nil {
+		return false
+	}
+	lookup, ok := backendSnapshotLookupFromRootDomainLookup(snap.published)
+	return ok && lookup.snapshot == s.backend
 }
 
 func rootDomainSnapshotBackendRootID(s *Snapshot, fallback uint64) uint64 {

--- a/TreeDB/caching/root_group_snapshot_test.go
+++ b/TreeDB/caching/root_group_snapshot_test.go
@@ -508,6 +508,13 @@ func TestAcquireSnapshot_FallsBackToBackendPublishedSetWithoutInstalledGroup(t *
 	if rootSnap.publishedRootID == 0 {
 		t.Fatal("expected backend published root id")
 	}
+	lookup, ok := rootSnap.published.(*backendSnapshotLookup)
+	if !ok {
+		t.Fatalf("published lookup type=%T, want *backendSnapshotLookup", rootSnap.published)
+	}
+	if lookup != &snap.backendRoot {
+		t.Fatal("expected point fallback to reuse snapshot backendRoot lookup")
+	}
 	if stats := db.rootDomainPublishStatsSnapshot(); stats.backendFallbacks != 1 {
 		t.Fatalf("backendFallbacks=%d want 1", stats.backendFallbacks)
 	}
@@ -535,5 +542,75 @@ func TestAcquireSnapshot_BackendFallbackPinsSystemRootPageID(t *testing.T) {
 	systemSnap := rootDomainSystemSnapshotFromCachedSnapshot(snap)
 	if got, want := systemSnap.publishedRootID, backend.State().SystemRootPageID; got != want {
 		t.Fatalf("system published root id=%d want %d", got, want)
+	}
+	lookup, ok := systemSnap.published.(*backendSnapshotLookup)
+	if !ok {
+		t.Fatalf("system published lookup type=%T, want *backendSnapshotLookup", systemSnap.published)
+	}
+	if lookup != &snap.backendSystem {
+		t.Fatal("expected system fallback to reuse snapshot backendSystem lookup")
+	}
+}
+
+func TestAcquireSnapshot_InstallsBackendLookupForPublishedPointRoots(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer backend.Close()
+
+	pointTable := newRootDomainTestTable(t, rootDomainTestOp{key: "published/k", value: "published-v"})
+	pointRootID, err := backend.PublishOrderedRootIterator(0, pointTable.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish point root: %v", err)
+	}
+	if pointRootID == backend.State().RootPageID {
+		t.Fatalf("test point root unexpectedly matches default root %d", pointRootID)
+	}
+
+	db := &DB{
+		backend:          backend,
+		mutableShards:    make([]memShard, 1),
+		mutableShardMask: 0,
+	}
+	view := &memtableView{
+		rootSnapshotShards: []rootDomainSnapshot{{}},
+		publishedRoots: &publishedRootSet{
+			pointShards: []publishedRootRef{{rootID: pointRootID}},
+		},
+	}
+	view.refs.Store(1)
+	db.memtables.Store(view)
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer snap.Close()
+
+	if snap.publishedRoots == view.publishedRoots {
+		t.Fatal("expected snapshot to clone published root set before installing lookups")
+	}
+	if got := len(snap.backendPublishedLookups); got != 1 {
+		t.Fatalf("backendPublishedLookups len=%d want 1", got)
+	}
+
+	rootSnap := rootDomainSnapshotFromCachedSnapshot(snap, []byte("published/k"))
+	lookup, ok := rootSnap.published.(*backendSnapshotLookup)
+	if !ok {
+		t.Fatalf("published lookup type=%T, want *backendSnapshotLookup", rootSnap.published)
+	}
+	if lookup != &snap.backendPublishedLookups[0] {
+		t.Fatal("expected point published ref to use snapshot-owned backend lookup")
+	}
+	if lookup.rootID != pointRootID {
+		t.Fatalf("lookup rootID=%d want %d", lookup.rootID, pointRootID)
+	}
+	if lookup.snapshot != snap.backend {
+		t.Fatal("expected published lookup to use acquired backend snapshot")
+	}
+	if lookup.db != db {
+		t.Fatal("expected published lookup to retain parent db")
 	}
 }

--- a/TreeDB/caching/root_group_snapshot_test.go
+++ b/TreeDB/caching/root_group_snapshot_test.go
@@ -615,6 +615,131 @@ func TestAcquireSnapshot_InstallsBackendLookupForPublishedPointRoots(t *testing.
 	}
 }
 
+func TestAcquireSnapshot_InstallsBackendLookupForPublishedSystemAndIteratorRoots(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer backend.Close()
+
+	systemTable := newRootDomainTestTable(t, rootDomainTestOp{key: "system/k", value: "system-v"})
+	systemRootID, err := backend.PublishOrderedRootIterator(0, systemTable.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish system root: %v", err)
+	}
+	iteratorTable := newRootDomainTestTable(t, rootDomainTestOp{key: "iterator/k", value: "iterator-v"})
+	iteratorRootID, err := backend.PublishOrderedRootIterator(0, iteratorTable.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish iterator root: %v", err)
+	}
+	if state := backend.State(); state != nil {
+		if systemRootID == state.RootPageID || systemRootID == state.SystemRootPageID {
+			t.Fatalf("test system root unexpectedly matches static root state: %d", systemRootID)
+		}
+		if iteratorRootID == state.RootPageID || iteratorRootID == state.SystemRootPageID {
+			t.Fatalf("test iterator root unexpectedly matches static root state: %d", iteratorRootID)
+		}
+	}
+
+	db := &DB{
+		backend:          backend,
+		mutableShards:    make([]memShard, 1),
+		mutableShardMask: 0,
+	}
+	view := &memtableView{
+		publishedRoots: &publishedRootSet{
+			system:   publishedRootRef{rootID: systemRootID},
+			iterator: publishedRootRef{rootID: iteratorRootID},
+		},
+	}
+	view.refs.Store(1)
+	db.memtables.Store(view)
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer snap.Close()
+
+	if got := len(snap.backendPublishedLookups); got != 2 {
+		t.Fatalf("backendPublishedLookups len=%d want 2", got)
+	}
+	systemLookup, ok := snap.publishedRoots.system.lookup.(*backendSnapshotLookup)
+	if !ok {
+		t.Fatalf("system lookup type=%T, want *backendSnapshotLookup", snap.publishedRoots.system.lookup)
+	}
+	iteratorLookup, ok := snap.publishedRoots.iterator.lookup.(*backendSnapshotLookup)
+	if !ok {
+		t.Fatalf("iterator lookup type=%T, want *backendSnapshotLookup", snap.publishedRoots.iterator.lookup)
+	}
+	if systemLookup.rootID != systemRootID {
+		t.Fatalf("system lookup rootID=%d want %d", systemLookup.rootID, systemRootID)
+	}
+	if iteratorLookup.rootID != iteratorRootID {
+		t.Fatalf("iterator lookup rootID=%d want %d", iteratorLookup.rootID, iteratorRootID)
+	}
+	if systemLookup == iteratorLookup {
+		t.Fatal("expected distinct system and iterator lookup slots")
+	}
+}
+
+func TestAcquireSnapshot_InstallsBackendLookupForDirectPublishedPointRootID(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer backend.Close()
+
+	pointTable := newRootDomainTestTable(t, rootDomainTestOp{key: "published/k", value: "published-v"})
+	pointRootID, err := backend.PublishOrderedRootIterator(0, pointTable.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish point root: %v", err)
+	}
+	if pointRootID == backend.State().RootPageID {
+		t.Fatalf("test point root unexpectedly matches default root %d", pointRootID)
+	}
+
+	db := &DB{
+		backend:          backend,
+		mutableShards:    make([]memShard, 1),
+		mutableShardMask: 0,
+	}
+	view := &memtableView{
+		queue:              []memtable.Table{newRootDomainTestTable(t, rootDomainTestOp{key: "queued/k", value: "queued-v"})},
+		rootSnapshotShards: []rootDomainSnapshot{{publishedRootID: pointRootID}},
+	}
+	view.refs.Store(1)
+	db.memtables.Store(view)
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer snap.Close()
+
+	if got := len(snap.backendPublishedLookups); got != 1 {
+		t.Fatalf("backendPublishedLookups len=%d want 1", got)
+	}
+	if snap.publishedRoots != nil {
+		t.Fatal("expected direct published root ID to avoid synthesizing a published root set")
+	}
+	if view.rootSnapshotShards[0].published != nil {
+		t.Fatal("expected snapshot acquisition not to mutate retained memtable view root snapshot")
+	}
+	lookup, ok := snap.rootPointShards[0].published.(*backendSnapshotLookup)
+	if !ok {
+		t.Fatalf("published lookup type=%T, want *backendSnapshotLookup", snap.rootPointShards[0].published)
+	}
+	if lookup != &snap.backendPublishedLookups[0] {
+		t.Fatal("expected direct point root to use snapshot-owned backend lookup")
+	}
+	if lookup.rootID != pointRootID {
+		t.Fatalf("lookup rootID=%d want %d", lookup.rootID, pointRootID)
+	}
+}
+
 func TestAcquireSnapshot_InstalledPublishedPointRootAllocsBounded(t *testing.T) {
 	if testRaceEnabled {
 		t.Skip("AllocsPerRun is not stable under -race")

--- a/TreeDB/caching/root_group_snapshot_test.go
+++ b/TreeDB/caching/root_group_snapshot_test.go
@@ -614,3 +614,62 @@ func TestAcquireSnapshot_InstallsBackendLookupForPublishedPointRoots(t *testing.
 		t.Fatal("expected published lookup to retain parent db")
 	}
 }
+
+func TestAcquireSnapshot_InstalledPublishedPointRootAllocsBounded(t *testing.T) {
+	if testRaceEnabled {
+		t.Skip("AllocsPerRun is not stable under -race")
+	}
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer backend.Close()
+
+	pointTable := newRootDomainTestTable(t, rootDomainTestOp{key: "published/k", value: "published-v"})
+	pointRootID, err := backend.PublishOrderedRootIterator(0, pointTable.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish point root: %v", err)
+	}
+	if pointRootID == backend.State().RootPageID {
+		t.Fatalf("test point root unexpectedly matches default root %d", pointRootID)
+	}
+
+	db := &DB{
+		backend:          backend,
+		mutableShards:    make([]memShard, 1),
+		mutableShardMask: 0,
+	}
+	view := &memtableView{
+		rootSnapshotShards: []rootDomainSnapshot{{}},
+		publishedRoots: &publishedRootSet{
+			pointShards: []publishedRootRef{{rootID: pointRootID}},
+		},
+	}
+	view.refs.Store(1)
+	db.memtables.Store(view)
+
+	warm := db.AcquireSnapshot()
+	if warm == nil {
+		t.Fatal("warm AcquireSnapshot=nil")
+	}
+	if err := warm.Close(); err != nil {
+		t.Fatalf("warm Close: %v", err)
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		snap := db.AcquireSnapshot()
+		if snap == nil {
+			t.Fatal("AcquireSnapshot=nil")
+		}
+		if len(snap.backendPublishedLookups) != 1 {
+			t.Fatalf("backendPublishedLookups len=%d want 1", len(snap.backendPublishedLookups))
+		}
+		if err := snap.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+	if allocs > 5.1 {
+		t.Fatalf("AcquireSnapshot allocs/run=%f, want <= 5.1 with installed published point root", allocs)
+	}
+}

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -782,7 +782,10 @@ func (s *Snapshot) HasPrefixes(prefixes [][]byte) ([]bool, error) {
 }
 
 func (s *Snapshot) GetEntry(key []byte) (node.LeafEntry, error) {
-	val, ptr, flags, found := s.lookupQueueEntry(key)
+	snap, val, ptr, flags, found, _, err := s.lookupRootDomainSnapshotEntryWithError(key)
+	if err != nil {
+		return node.LeafEntry{}, err
+	}
 	if found {
 		keyCopy := append([]byte(nil), key...)
 		return node.LeafEntry{
@@ -791,6 +794,9 @@ func (s *Snapshot) GetEntry(key []byte) (node.LeafEntry, error) {
 			ValuePtr: ptr,
 			Flags:    flags,
 		}, nil
+	}
+	if s.publishedLookupBackedByBackendSnapshot(snap) {
+		return node.LeafEntry{}, tree.ErrKeyNotFound
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {
@@ -803,7 +809,10 @@ func (s *Snapshot) GetEntry(key []byte) (node.LeafEntry, error) {
 }
 
 func (s *Snapshot) GetEntryExact(key []byte) (node.LeafEntry, error) {
-	val, ptr, flags, found := s.lookupQueueEntry(key)
+	snap, val, ptr, flags, found, _, err := s.lookupRootDomainSnapshotEntryWithError(key)
+	if err != nil {
+		return node.LeafEntry{}, err
+	}
 	if found {
 		keyCopy := append([]byte(nil), key...)
 		return node.LeafEntry{
@@ -812,6 +821,9 @@ func (s *Snapshot) GetEntryExact(key []byte) (node.LeafEntry, error) {
 			ValuePtr: ptr,
 			Flags:    flags,
 		}, nil
+	}
+	if s.publishedLookupBackedByBackendSnapshot(snap) {
+		return node.LeafEntry{}, tree.ErrKeyNotFound
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -240,12 +240,17 @@ func (s *Snapshot) lookupQueueEntry(key []byte) (val []byte, ptr page.ValuePtr, 
 }
 
 func (s *Snapshot) lookupRootDomainSnapshotEntry(key []byte) (snap rootDomainSnapshot, val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
+	snap, val, ptr, flags, found, source, _ = s.lookupRootDomainSnapshotEntryWithError(key)
+	return snap, val, ptr, flags, found, source
+}
+
+func (s *Snapshot) lookupRootDomainSnapshotEntryWithError(key []byte) (snap rootDomainSnapshot, val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource, err error) {
 	if s == nil {
-		return rootDomainSnapshot{}, nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+		return rootDomainSnapshot{}, nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone, nil
 	}
 	snap = rootDomainSnapshotFromCachedSnapshot(s, key)
-	val, ptr, flags, found, source = snap.getEntryWithSource(key)
-	return snap, val, ptr, flags, found, source
+	val, ptr, flags, found, source, err = snap.getEntryWithSourceError(key)
+	return snap, val, ptr, flags, found, source, err
 }
 
 func (s *Snapshot) lookupRootDomainEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
@@ -472,7 +477,10 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 }
 
 func (s *Snapshot) Get(key []byte) ([]byte, error) {
-	snap, val, ptr, flags, found, source := s.lookupRootDomainSnapshotEntry(key)
+	snap, val, ptr, flags, found, source, err := s.lookupRootDomainSnapshotEntryWithError(key)
+	if err != nil {
+		return nil, err
+	}
 	if found {
 		if flags&node.FlagTombstone != 0 {
 			return nil, tree.ErrKeyNotFound
@@ -545,7 +553,10 @@ func (s *Snapshot) Get(key []byte) ([]byte, error) {
 }
 
 func (s *Snapshot) GetUnsafe(key []byte) ([]byte, error) {
-	snap, val, ptr, flags, found, source := s.lookupRootDomainSnapshotEntry(key)
+	snap, val, ptr, flags, found, source, err := s.lookupRootDomainSnapshotEntryWithError(key)
+	if err != nil {
+		return nil, err
+	}
 	if found {
 		if flags&node.FlagTombstone != 0 {
 			return nil, tree.ErrKeyNotFound
@@ -584,12 +595,10 @@ func (s *Snapshot) Has(key []byte) (bool, error) {
 	if s == nil {
 		return false, nil
 	}
-	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
-	_, _, flags, found, _ := snap.getCachedEntryWithSource(key)
-	if found {
-		return flags&node.FlagTombstone == 0, nil
+	snap, _, _, flags, found, _, err := s.lookupRootDomainSnapshotEntryWithError(key)
+	if err != nil {
+		return false, err
 	}
-	_, _, flags, found, _ = snap.getPublishedEntryWithSource(key)
 	if found {
 		return flags&node.FlagTombstone == 0, nil
 	}

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -38,6 +38,10 @@ type Snapshot struct {
 	rootSystem      rootDomainSnapshot
 	rootIterator    rootDomainSnapshot
 	publishedRoots  *publishedRootSet
+	backendRoot     backendSnapshotLookup
+	backendRootOK   bool
+	backendSystem   backendSnapshotLookup
+	backendSystemOK bool
 
 	closed atomic.Bool
 }
@@ -163,6 +167,15 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	}
 
 	snap := &Snapshot{db: db, view: view, backend: backendSnap}
+	snap.backendRoot = backendSnapshotLookup{db: db, snapshot: backendSnap}
+	snap.backendRootOK = true
+	if state := backendSnap.State(); state != nil {
+		snap.backendRoot.rootID = state.RootPageID
+		if state.SystemRootPageID != 0 {
+			snap.backendSystem = backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: state.SystemRootPageID}
+			snap.backendSystemOK = true
+		}
+	}
 	snap.rootVersion = viewRootVersion
 	snap.rootPointShards = viewRootPointShards
 	snap.rootSystem = viewRootSystem
@@ -209,6 +222,10 @@ func (s *Snapshot) Close() error {
 	s.rootSystem = rootDomainSnapshot{}
 	s.rootIterator = rootDomainSnapshot{}
 	s.publishedRoots = nil
+	s.backendRoot = backendSnapshotLookup{}
+	s.backendRootOK = false
+	s.backendSystem = backendSnapshotLookup{}
+	s.backendSystemOK = false
 	s.rootVersion = 0
 	s.db = nil
 	return err
@@ -376,7 +393,11 @@ func (s *Snapshot) ReverseIterator(start, end []byte) (merging.Iterator, error) 
 }
 
 func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
-	snap, val, ptr, flags, found, source := s.lookupRootDomainSnapshotEntry(key)
+	if s == nil {
+		return dst, tree.ErrKeyNotFound
+	}
+	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
+	val, ptr, flags, found, source := snap.getCachedEntryWithSource(key)
 	if found {
 		if flags&node.FlagTombstone != 0 {
 			return dst, tree.ErrKeyNotFound
@@ -412,14 +433,49 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		return append(dst, val...), nil
 	}
 
+	oldLen := len(dst)
+	out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
+	if ok {
+		if err == nil {
+			recordSnapshotRootDomainRead(rootDomainEntrySourcePublished, true, len(out)-oldLen)
+			return out, nil
+		}
+		if !errors.Is(err, tree.ErrKeyNotFound) {
+			return dst, err
+		}
+	} else {
+		val, ptr, flags, found, source = snap.getPublishedEntryWithSource(key)
+		if found {
+			if flags&node.FlagTombstone != 0 {
+				return dst, tree.ErrKeyNotFound
+			}
+			if flags&node.FlagPointer != 0 {
+				if s.db == nil {
+					return dst, errors.New("caching snapshot: value-log reader unavailable")
+				}
+				out, err := s.db.readValueLogAppend(key, ptr, dst)
+				if err != nil {
+					return dst, err
+				}
+				recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+				return out, nil
+			}
+			if val == nil {
+				recordSnapshotRootDomainRead(source, false, 0)
+				return dst, nil
+			}
+			recordSnapshotRootDomainRead(source, false, len(val))
+			return append(dst, val...), nil
+		}
+	}
+
 	if s == nil || s.backend == nil || s.db == nil {
 		return dst, tree.ErrKeyNotFound
 	}
 	if err := s.db.flushValueLogForBackendRead(); err != nil {
 		return dst, err
 	}
-	oldLen := len(dst)
-	out, err := s.backend.GetAppend(key, dst)
+	out, err = s.backend.GetAppend(key, dst)
 	if err != nil {
 		return dst, err
 	}

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -236,16 +236,6 @@ func (s *Snapshot) Close() error {
 	return err
 }
 
-func (s *Snapshot) lookupQueueEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
-	val, ptr, flags, found, _ = s.lookupRootDomainEntry(key)
-	return val, ptr, flags, found
-}
-
-func (s *Snapshot) lookupRootDomainSnapshotEntry(key []byte) (snap rootDomainSnapshot, val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
-	snap, val, ptr, flags, found, source, _ = s.lookupRootDomainSnapshotEntryWithError(key)
-	return snap, val, ptr, flags, found, source
-}
-
 func (s *Snapshot) lookupRootDomainSnapshotEntryWithError(key []byte) (snap rootDomainSnapshot, val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource, err error) {
 	if s == nil {
 		return rootDomainSnapshot{}, nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone, nil
@@ -253,11 +243,6 @@ func (s *Snapshot) lookupRootDomainSnapshotEntryWithError(key []byte) (snap root
 	snap = rootDomainSnapshotFromCachedSnapshot(s, key)
 	val, ptr, flags, found, source, err = snap.getEntryWithSourceError(key)
 	return snap, val, ptr, flags, found, source, err
-}
-
-func (s *Snapshot) lookupRootDomainEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
-	_, val, ptr, flags, found, source = s.lookupRootDomainSnapshotEntry(key)
-	return val, ptr, flags, found, source
 }
 
 func (s *Snapshot) lookupCachedRootDomainEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -245,18 +245,25 @@ func (s *Snapshot) lookupRootDomainSnapshotEntryWithError(key []byte) (snap root
 	return snap, val, ptr, flags, found, source, err
 }
 
-func (s *Snapshot) lookupCachedRootDomainEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+func (s *Snapshot) cachedRootDomainSnapshot(key []byte) rootDomainSnapshot {
 	if s == nil || len(s.rootPointShards) == 0 {
-		return nil, page.ValuePtr{}, 0, false
+		return rootDomainSnapshot{}
 	}
 	shardIdx := 0
 	if s.db != nil {
 		shardIdx = s.db.shardIndex(key)
 	}
 	if shardIdx < 0 || shardIdx >= len(s.rootPointShards) {
+		return rootDomainSnapshot{}
+	}
+	return s.rootPointShards[shardIdx]
+}
+
+func (s *Snapshot) lookupCachedRootDomainEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	snap := s.cachedRootDomainSnapshot(key)
+	if !rootDomainSnapshotHasInMemoryState(snap) {
 		return nil, page.ValuePtr{}, 0, false
 	}
-	snap := s.rootPointShards[shardIdx]
 	snap.published = nil
 	snap.publishedRootID = 0
 	return snap.getEntry(key)
@@ -581,6 +588,17 @@ func (s *Snapshot) GetUnsafe(key []byte) ([]byte, error) {
 func (s *Snapshot) Has(key []byte) (bool, error) {
 	if s == nil {
 		return false, nil
+	}
+	cachedSnap := s.cachedRootDomainSnapshot(key)
+	if s.publishedRoots == nil && !rootDomainSnapshotHasPublishedState(cachedSnap) {
+		_, _, flags, found := s.lookupCachedRootDomainEntry(key)
+		if found {
+			return flags&node.FlagTombstone == 0, nil
+		}
+		if s.backend == nil {
+			return false, nil
+		}
+		return s.backend.Has(key)
 	}
 	snap, _, _, flags, found, _, err := s.lookupRootDomainSnapshotEntryWithError(key)
 	if err != nil {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -397,7 +397,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		return dst, tree.ErrKeyNotFound
 	}
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
-	val, ptr, flags, found, source := snap.getCachedEntryWithSource(key)
+	val, ptr, flags, found, _ := snap.getCachedEntryWithSource(key)
 	if found {
 		if flags&node.FlagTombstone != 0 {
 			return dst, tree.ErrKeyNotFound
@@ -411,14 +411,14 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			if err != nil {
 				return dst, err
 			}
-			recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+			recordSnapshotRootDomainRead(rootDomainEntrySourceCached, true, len(out)-oldLen)
 			return out, nil
 		}
 		if val == nil {
-			recordSnapshotRootDomainRead(source, false, 0)
+			recordSnapshotRootDomainRead(rootDomainEntrySourceCached, false, 0)
 			return dst, nil
 		}
-		recordSnapshotRootDomainRead(source, false, len(val))
+		recordSnapshotRootDomainRead(rootDomainEntrySourceCached, false, len(val))
 		return append(dst, val...), nil
 	}
 
@@ -433,7 +433,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return dst, err
 		}
 	}
-	val, ptr, flags, found, source = snap.getPublishedEntryWithSource(key)
+	val, ptr, flags, found, source := snap.getPublishedEntryWithSource(key)
 	if found {
 		if flags&node.FlagTombstone != 0 {
 			return dst, tree.ErrKeyNotFound

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -130,6 +130,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		viewRootSystem      rootDomainSnapshot
 		viewRootIterator    rootDomainSnapshot
 		viewPublishedRoots  *publishedRootSet
+		publishedRootsOwned bool
 	)
 	if view != nil {
 		viewRootVersion = view.rootVersion
@@ -146,6 +147,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 			} else {
 				viewRootPointShards = append([]rootDomainSnapshot(nil), view.rootSnapshotShards...)
 				viewPublishedRoots = clonePublishedRootSet(view.publishedRoots)
+				publishedRootsOwned = true
 			}
 			db.releaseMemtableView(view)
 			view = nil
@@ -182,7 +184,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	snap.rootSystem = viewRootSystem
 	snap.rootIterator = viewRootIterator
 	snap.publishedRoots = viewPublishedRoots
-	snap.installBackendPublishedRootLookups()
+	snap.installBackendPublishedRootLookups(publishedRootsOwned)
 	if snap.publishedRoots == nil {
 		db.rootPublishStats.backendFallbacks.Add(1)
 	}

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -30,18 +30,19 @@ import (
 // Snapshot pointers are single-use: after Close returns, callers must discard the
 // pointer and treat further use as invalid.
 type Snapshot struct {
-	db              *DB
-	view            *memtableView
-	backend         *backenddb.Snapshot
-	rootVersion     uint64
-	rootPointShards []rootDomainSnapshot // snapshot point roots; mutable runs are intentionally excluded
-	rootSystem      rootDomainSnapshot
-	rootIterator    rootDomainSnapshot
-	publishedRoots  *publishedRootSet
-	backendRoot     backendSnapshotLookup
-	backendRootOK   bool
-	backendSystem   backendSnapshotLookup
-	backendSystemOK bool
+	db                      *DB
+	view                    *memtableView
+	backend                 *backenddb.Snapshot
+	rootVersion             uint64
+	rootPointShards         []rootDomainSnapshot // snapshot point roots; mutable runs are intentionally excluded
+	rootSystem              rootDomainSnapshot
+	rootIterator            rootDomainSnapshot
+	publishedRoots          *publishedRootSet
+	backendRoot             backendSnapshotLookup
+	backendRootOK           bool
+	backendSystem           backendSnapshotLookup
+	backendSystemOK         bool
+	backendPublishedLookups []backendSnapshotLookup
 
 	closed atomic.Bool
 }
@@ -181,6 +182,7 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	snap.rootSystem = viewRootSystem
 	snap.rootIterator = viewRootIterator
 	snap.publishedRoots = viewPublishedRoots
+	snap.installBackendPublishedRootLookups()
 	if snap.publishedRoots == nil {
 		db.rootPublishStats.backendFallbacks.Add(1)
 	}
@@ -226,6 +228,7 @@ func (s *Snapshot) Close() error {
 	s.backendRootOK = false
 	s.backendSystem = backendSnapshotLookup{}
 	s.backendSystemOK = false
+	s.backendPublishedLookups = nil
 	s.rootVersion = 0
 	s.db = nil
 	return err
@@ -317,6 +320,36 @@ func rootDomainPublishedGetUnsafe(snap rootDomainSnapshot, key []byte) ([]byte, 
 	return out, true, err
 }
 
+func (s *Snapshot) appendRootDomainEntryValue(
+	key, dst []byte,
+	val []byte,
+	ptr page.ValuePtr,
+	flags byte,
+	source rootDomainEntrySource,
+	oldLen int,
+) ([]byte, error) {
+	if flags&node.FlagTombstone != 0 {
+		return dst, tree.ErrKeyNotFound
+	}
+	if flags&node.FlagPointer != 0 {
+		if s == nil || s.db == nil {
+			return dst, errors.New("caching snapshot: value-log reader unavailable")
+		}
+		out, err := s.db.readValueLogAppend(key, ptr, dst)
+		if err != nil {
+			return dst, err
+		}
+		recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+		return out, nil
+	}
+	if val == nil {
+		recordSnapshotRootDomainRead(source, false, 0)
+		return dst, nil
+	}
+	recordSnapshotRootDomainRead(source, false, len(val))
+	return append(dst, val...), nil
+}
+
 func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.IteratorSource, error) {
 	if s == nil || s.backend == nil {
 		return nil, backenddb.ErrClosed
@@ -399,27 +432,7 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
 	val, ptr, flags, found, _ := snap.getCachedEntryWithSource(key)
 	if found {
-		if flags&node.FlagTombstone != 0 {
-			return dst, tree.ErrKeyNotFound
-		}
-		if flags&node.FlagPointer != 0 {
-			if s.db == nil {
-				return dst, errors.New("caching snapshot: value-log reader unavailable")
-			}
-			oldLen := len(dst)
-			out, err := s.db.readValueLogAppend(key, ptr, dst)
-			if err != nil {
-				return dst, err
-			}
-			recordSnapshotRootDomainRead(rootDomainEntrySourceCached, true, len(out)-oldLen)
-			return out, nil
-		}
-		if val == nil {
-			recordSnapshotRootDomainRead(rootDomainEntrySourceCached, false, 0)
-			return dst, nil
-		}
-		recordSnapshotRootDomainRead(rootDomainEntrySourceCached, false, len(val))
-		return append(dst, val...), nil
+		return s.appendRootDomainEntryValue(key, dst, val, ptr, flags, rootDomainEntrySourceCached, len(dst))
 	}
 
 	oldLen := len(dst)
@@ -432,29 +445,13 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		if !errors.Is(err, tree.ErrKeyNotFound) {
 			return dst, err
 		}
+		if s.publishedLookupBackedByBackendSnapshot(snap) {
+			return dst, tree.ErrKeyNotFound
+		}
 	}
 	val, ptr, flags, found, source := snap.getPublishedEntryWithSource(key)
 	if found {
-		if flags&node.FlagTombstone != 0 {
-			return dst, tree.ErrKeyNotFound
-		}
-		if flags&node.FlagPointer != 0 {
-			if s.db == nil {
-				return dst, errors.New("caching snapshot: value-log reader unavailable")
-			}
-			out, err := s.db.readValueLogAppend(key, ptr, dst)
-			if err != nil {
-				return dst, err
-			}
-			recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
-			return out, nil
-		}
-		if val == nil {
-			recordSnapshotRootDomainRead(source, false, 0)
-			return dst, nil
-		}
-		recordSnapshotRootDomainRead(source, false, len(val))
-		return append(dst, val...), nil
+		return s.appendRootDomainEntryValue(key, dst, val, ptr, flags, source, oldLen)
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -521,6 +521,9 @@ func (s *Snapshot) Get(key []byte) ([]byte, error) {
 		copy(owned, val)
 		return owned, nil
 	}
+	if s.publishedLookupBackedByBackendSnapshot(snap) {
+		return nil, tree.ErrKeyNotFound
+	}
 
 	if s == nil || s.backend == nil || s.db == nil {
 		return nil, tree.ErrKeyNotFound
@@ -564,6 +567,9 @@ func (s *Snapshot) GetUnsafe(key []byte) ([]byte, error) {
 		}
 		return val, nil
 	}
+	if s.publishedLookupBackedByBackendSnapshot(snap) {
+		return nil, tree.ErrKeyNotFound
+	}
 
 	if s == nil || s.backend == nil || s.db == nil {
 		return nil, tree.ErrKeyNotFound
@@ -575,15 +581,19 @@ func (s *Snapshot) GetUnsafe(key []byte) ([]byte, error) {
 }
 
 func (s *Snapshot) Has(key []byte) (bool, error) {
-	_, _, flags, found := s.lookupCachedRootDomainEntry(key)
+	if s == nil {
+		return false, nil
+	}
+	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
+	_, _, flags, found, _ := snap.getCachedEntryWithSource(key)
 	if found {
 		return flags&node.FlagTombstone == 0, nil
 	}
-	_, _, flags, found = s.lookupQueueEntry(key)
+	_, _, flags, found, _ = snap.getPublishedEntryWithSource(key)
 	if found {
 		return flags&node.FlagTombstone == 0, nil
 	}
-	if s == nil || s.backend == nil {
+	if s.publishedLookupBackedByBackendSnapshot(snap) || s.backend == nil {
 		return false, nil
 	}
 	return s.backend.Has(key)

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -403,17 +403,6 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 			return dst, tree.ErrKeyNotFound
 		}
 		if flags&node.FlagPointer != 0 {
-			if source == rootDomainEntrySourcePublished {
-				oldLen := len(dst)
-				out, ok, err := rootDomainPublishedGetAppend(snap, key, dst)
-				if ok {
-					if err != nil {
-						return dst, err
-					}
-					recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
-					return out, nil
-				}
-			}
 			if s.db == nil {
 				return dst, errors.New("caching snapshot: value-log reader unavailable")
 			}
@@ -443,30 +432,29 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		if !errors.Is(err, tree.ErrKeyNotFound) {
 			return dst, err
 		}
-	} else {
-		val, ptr, flags, found, source = snap.getPublishedEntryWithSource(key)
-		if found {
-			if flags&node.FlagTombstone != 0 {
-				return dst, tree.ErrKeyNotFound
-			}
-			if flags&node.FlagPointer != 0 {
-				if s.db == nil {
-					return dst, errors.New("caching snapshot: value-log reader unavailable")
-				}
-				out, err := s.db.readValueLogAppend(key, ptr, dst)
-				if err != nil {
-					return dst, err
-				}
-				recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
-				return out, nil
-			}
-			if val == nil {
-				recordSnapshotRootDomainRead(source, false, 0)
-				return dst, nil
-			}
-			recordSnapshotRootDomainRead(source, false, len(val))
-			return append(dst, val...), nil
+	}
+	val, ptr, flags, found, source = snap.getPublishedEntryWithSource(key)
+	if found {
+		if flags&node.FlagTombstone != 0 {
+			return dst, tree.ErrKeyNotFound
 		}
+		if flags&node.FlagPointer != 0 {
+			if s.db == nil {
+				return dst, errors.New("caching snapshot: value-log reader unavailable")
+			}
+			out, err := s.db.readValueLogAppend(key, ptr, dst)
+			if err != nil {
+				return dst, err
+			}
+			recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+			return out, nil
+		}
+		if val == nil {
+			recordSnapshotRootDomainRead(source, false, 0)
+			return dst, nil
+		}
+		recordSnapshotRootDomainRead(source, false, len(val))
+		return append(dst, val...), nil
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {

--- a/TreeDB/caching/snapshot_getappend_test.go
+++ b/TreeDB/caching/snapshot_getappend_test.go
@@ -1,0 +1,99 @@
+package caching
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/tree"
+)
+
+type snapshotPublishedValueLookup struct {
+	value []byte
+
+	getEntryCalls       int
+	getValueAppendCalls int
+	getValueUnsafeCalls int
+}
+
+func (l *snapshotPublishedValueLookup) GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	l.getEntryCalls++
+	if string(key) != "k" {
+		return nil, page.ValuePtr{}, 0, false
+	}
+	return l.value, page.ValuePtr{}, node.FlagInline, true
+}
+
+func (l *snapshotPublishedValueLookup) GetValueAppend(key, dst []byte) ([]byte, error) {
+	l.getValueAppendCalls++
+	if string(key) != "k" {
+		return dst, tree.ErrKeyNotFound
+	}
+	return append(dst, l.value...), nil
+}
+
+func (l *snapshotPublishedValueLookup) GetValueUnsafe(key []byte) ([]byte, error) {
+	l.getValueUnsafeCalls++
+	if string(key) != "k" {
+		return nil, tree.ErrKeyNotFound
+	}
+	return l.value, nil
+}
+
+type snapshotPublishedEntryOnlyLookup struct {
+	value         []byte
+	getEntryCalls int
+}
+
+func (l *snapshotPublishedEntryOnlyLookup) GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	l.getEntryCalls++
+	if string(key) != "k" {
+		return nil, page.ValuePtr{}, 0, false
+	}
+	return l.value, page.ValuePtr{}, node.FlagInline, true
+}
+
+func TestSnapshotGetAppendPublishedUsesValueAppendDirectly(t *testing.T) {
+	lookup := &snapshotPublishedValueLookup{value: []byte("published")}
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{{
+			published:       lookup,
+			publishedRootID: 1,
+		}},
+	}
+
+	got, err := snap.GetAppend([]byte("k"), []byte("p:"))
+	if err != nil {
+		t.Fatalf("GetAppend: %v", err)
+	}
+	if string(got) != "p:published" {
+		t.Fatalf("value=%q, want p:published", got)
+	}
+	if lookup.getValueAppendCalls != 1 {
+		t.Fatalf("GetValueAppend calls=%d, want 1", lookup.getValueAppendCalls)
+	}
+	if lookup.getEntryCalls != 0 {
+		t.Fatalf("GetEntry calls=%d, want 0", lookup.getEntryCalls)
+	}
+}
+
+func TestSnapshotGetAppendPublishedFallsBackToEntryLookup(t *testing.T) {
+	lookup := &snapshotPublishedEntryOnlyLookup{value: []byte("published")}
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{{
+			published:       lookup,
+			publishedRootID: 1,
+		}},
+	}
+
+	got, err := snap.GetAppend([]byte("k"), []byte("p:"))
+	if err != nil {
+		t.Fatalf("GetAppend: %v", err)
+	}
+	if string(got) != "p:published" {
+		t.Fatalf("value=%q, want p:published", got)
+	}
+	if lookup.getEntryCalls != 1 {
+		t.Fatalf("GetEntry calls=%d, want 1", lookup.getEntryCalls)
+	}
+}

--- a/TreeDB/caching/snapshot_getappend_test.go
+++ b/TreeDB/caching/snapshot_getappend_test.go
@@ -149,7 +149,7 @@ func TestSnapshotGetAppendPublishedValueAppendAllocs(t *testing.T) {
 			t.Fatalf("unexpected GetAppend value %q", got)
 		}
 	})
-	if allocs > 0.5 {
+	if allocs != 0 {
 		t.Fatalf("GetAppend allocs/run=%f, want 0", allocs)
 	}
 	if lookup.getEntryCalls != 0 {

--- a/TreeDB/caching/snapshot_getappend_test.go
+++ b/TreeDB/caching/snapshot_getappend_test.go
@@ -18,9 +18,13 @@ type snapshotPublishedValueLookup struct {
 	getValueUnsafeCalls int
 }
 
+func snapshotGetAppendTestKey(key []byte) bool {
+	return len(key) == 1 && key[0] == 'k'
+}
+
 func (l *snapshotPublishedValueLookup) GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
 	l.getEntryCalls++
-	if string(key) != "k" {
+	if !snapshotGetAppendTestKey(key) {
 		return nil, page.ValuePtr{}, 0, false
 	}
 	return l.value, page.ValuePtr{}, node.FlagInline, true
@@ -28,7 +32,7 @@ func (l *snapshotPublishedValueLookup) GetEntry(key []byte) (val []byte, ptr pag
 
 func (l *snapshotPublishedValueLookup) GetValueAppend(key, dst []byte) ([]byte, error) {
 	l.getValueAppendCalls++
-	if string(key) != "k" {
+	if !snapshotGetAppendTestKey(key) {
 		return dst, tree.ErrKeyNotFound
 	}
 	return append(dst, l.value...), nil
@@ -36,7 +40,7 @@ func (l *snapshotPublishedValueLookup) GetValueAppend(key, dst []byte) ([]byte, 
 
 func (l *snapshotPublishedValueLookup) GetValueUnsafe(key []byte) ([]byte, error) {
 	l.getValueUnsafeCalls++
-	if string(key) != "k" {
+	if !snapshotGetAppendTestKey(key) {
 		return nil, tree.ErrKeyNotFound
 	}
 	return l.value, nil
@@ -50,7 +54,7 @@ type snapshotPublishedEntryOnlyLookup struct {
 
 func (l *snapshotPublishedEntryOnlyLookup) GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
 	l.getEntryCalls++
-	if string(key) != "k" {
+	if !snapshotGetAppendTestKey(key) {
 		return nil, page.ValuePtr{}, 0, false
 	}
 	flags = l.flags
@@ -71,7 +75,7 @@ type snapshotPublishedAppendMissLookup struct {
 
 func (l *snapshotPublishedAppendMissLookup) GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
 	l.getEntryCalls++
-	if string(key) != "k" {
+	if !snapshotGetAppendTestKey(key) {
 		return nil, page.ValuePtr{}, 0, false
 	}
 	flags = l.flags
@@ -109,6 +113,44 @@ func TestSnapshotGetAppendPublishedUsesValueAppendDirectly(t *testing.T) {
 	}
 	if lookup.getValueAppendCalls != 1 {
 		t.Fatalf("GetValueAppend calls=%d, want 1", lookup.getValueAppendCalls)
+	}
+	if lookup.getEntryCalls != 0 {
+		t.Fatalf("GetEntry calls=%d, want 0", lookup.getEntryCalls)
+	}
+	if lookup.getValueUnsafeCalls != 0 {
+		t.Fatalf("GetValueUnsafe calls=%d, want 0", lookup.getValueUnsafeCalls)
+	}
+}
+
+func TestSnapshotGetAppendPublishedValueAppendAllocs(t *testing.T) {
+	if testRaceEnabled {
+		t.Skip("AllocsPerRun is not stable under -race")
+	}
+	lookup := &snapshotPublishedValueLookup{value: []byte("published")}
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{{
+			published:       lookup,
+			publishedRootID: 1,
+		}},
+	}
+	key := []byte("k")
+	prefix := []byte("p:")
+	wantLen := len(prefix) + len(lookup.value)
+	buf := make([]byte, len(prefix), wantLen)
+	copy(buf, prefix)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		dst := buf[:len(prefix)]
+		got, err := snap.GetAppend(key, dst)
+		if err != nil {
+			t.Fatalf("GetAppend: %v", err)
+		}
+		if len(got) != wantLen || got[0] != 'p' || got[1] != ':' || got[2] != 'p' {
+			t.Fatalf("unexpected GetAppend value %q", got)
+		}
+	})
+	if allocs > 0.5 {
+		t.Fatalf("GetAppend allocs/run=%f, want 0", allocs)
 	}
 	if lookup.getEntryCalls != 0 {
 		t.Fatalf("GetEntry calls=%d, want 0", lookup.getEntryCalls)

--- a/TreeDB/caching/snapshot_getappend_test.go
+++ b/TreeDB/caching/snapshot_getappend_test.go
@@ -252,11 +252,18 @@ func TestSnapshotGetAppendBackendPublishedHitViaInstalledLookup(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = backend.Close() })
 
+	if err := backend.SetSync([]byte("k"), []byte("default-root")); err != nil {
+		t.Fatalf("backend set: %v", err)
+	}
+
 	// Publish a backend root that contains the key we want to read.
 	pubTable := newRootDomainTestTable(t, rootDomainTestOp{key: "k", value: "from-published-root"})
 	pointRootID, err := backend.PublishOrderedRootIterator(0, pubTable.NewIterator(nil, nil))
 	if err != nil {
 		t.Fatalf("publish root: %v", err)
+	}
+	if pointRootID == backend.State().RootPageID {
+		t.Fatalf("test point root unexpectedly matches default root %d", pointRootID)
 	}
 
 	db := &DB{

--- a/TreeDB/caching/snapshot_getappend_test.go
+++ b/TreeDB/caching/snapshot_getappend_test.go
@@ -194,12 +194,44 @@ func TestSnapshotGetAppendPublishedAppendMissPreservesTombstone(t *testing.T) {
 }
 
 func TestSnapshotGetAppendBackendPublishedMissDoesNotFallBackToDefaultRoot(t *testing.T) {
+	snap := newSnapshotWithBackendPublishedPointRootMissingKey(t)
+
+	got, err := snap.GetAppend([]byte("k"), []byte("p:"))
+	if !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetAppend err=%v, want ErrKeyNotFound", err)
+	}
+	if string(got) != "p:" {
+		t.Fatalf("value=%q, want unchanged prefix", got)
+	}
+}
+
+func TestSnapshotBackendPublishedMissConsistentAcrossReadAPIs(t *testing.T) {
+	snap := newSnapshotWithBackendPublishedPointRootMissingKey(t)
+
+	if _, err := snap.Get([]byte("k")); !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("Get err=%v, want ErrKeyNotFound", err)
+	}
+	if _, err := snap.GetUnsafe([]byte("k")); !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetUnsafe err=%v, want ErrKeyNotFound", err)
+	}
+	ok, err := snap.Has([]byte("k"))
+	if err != nil {
+		t.Fatalf("Has: %v", err)
+	}
+	if ok {
+		t.Fatal("Has=true, want false")
+	}
+}
+
+func newSnapshotWithBackendPublishedPointRootMissingKey(t *testing.T) *Snapshot {
+	t.Helper()
+
 	dir := t.TempDir()
 	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
 	if err != nil {
 		t.Fatalf("open backend: %v", err)
 	}
-	defer backend.Close()
+	t.Cleanup(func() { _ = backend.Close() })
 
 	if err := backend.SetSync([]byte("k"), []byte("default")); err != nil {
 		t.Fatalf("backend set: %v", err)
@@ -217,22 +249,14 @@ func TestSnapshotGetAppendBackendPublishedMissDoesNotFallBackToDefaultRoot(t *te
 	if backendSnap == nil {
 		t.Fatal("expected backend snapshot")
 	}
-	defer backendSnap.Close()
+	t.Cleanup(func() { _ = backendSnap.Close() })
 
 	db := &DB{backend: backend, mutableShards: make([]memShard, 1)}
-	snap := &Snapshot{
+	return &Snapshot{
 		db:              db,
 		backend:         backendSnap,
 		rootPointShards: []rootDomainSnapshot{{publishedRootID: pointRootID}},
 		backendRoot:     backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendSnap.State().RootPageID},
 		backendRootOK:   true,
-	}
-
-	got, err := snap.GetAppend([]byte("k"), []byte("p:"))
-	if !errors.Is(err, tree.ErrKeyNotFound) {
-		t.Fatalf("GetAppend err=%v, want ErrKeyNotFound", err)
-	}
-	if string(got) != "p:" {
-		t.Fatalf("value=%q, want unchanged prefix", got)
 	}
 }

--- a/TreeDB/caching/snapshot_getappend_test.go
+++ b/TreeDB/caching/snapshot_getappend_test.go
@@ -1,6 +1,7 @@
 package caching
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/node"
@@ -42,6 +43,7 @@ func (l *snapshotPublishedValueLookup) GetValueUnsafe(key []byte) ([]byte, error
 
 type snapshotPublishedEntryOnlyLookup struct {
 	value         []byte
+	flags         byte
 	getEntryCalls int
 }
 
@@ -50,7 +52,42 @@ func (l *snapshotPublishedEntryOnlyLookup) GetEntry(key []byte) (val []byte, ptr
 	if string(key) != "k" {
 		return nil, page.ValuePtr{}, 0, false
 	}
-	return l.value, page.ValuePtr{}, node.FlagInline, true
+	flags = l.flags
+	if flags == 0 {
+		flags = node.FlagInline
+	}
+	return l.value, page.ValuePtr{}, flags, true
+}
+
+type snapshotPublishedAppendMissLookup struct {
+	value []byte
+	flags byte
+
+	getEntryCalls       int
+	getValueAppendCalls int
+	getValueUnsafeCalls int
+}
+
+func (l *snapshotPublishedAppendMissLookup) GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	l.getEntryCalls++
+	if string(key) != "k" {
+		return nil, page.ValuePtr{}, 0, false
+	}
+	flags = l.flags
+	if flags == 0 {
+		flags = node.FlagInline
+	}
+	return l.value, page.ValuePtr{}, flags, true
+}
+
+func (l *snapshotPublishedAppendMissLookup) GetValueAppend(_ []byte, dst []byte) ([]byte, error) {
+	l.getValueAppendCalls++
+	return dst, tree.ErrKeyNotFound
+}
+
+func (l *snapshotPublishedAppendMissLookup) GetValueUnsafe(_ []byte) ([]byte, error) {
+	l.getValueUnsafeCalls++
+	return nil, tree.ErrKeyNotFound
 }
 
 func TestSnapshotGetAppendPublishedUsesValueAppendDirectly(t *testing.T) {
@@ -92,6 +129,54 @@ func TestSnapshotGetAppendPublishedFallsBackToEntryLookup(t *testing.T) {
 	}
 	if string(got) != "p:published" {
 		t.Fatalf("value=%q, want p:published", got)
+	}
+	if lookup.getEntryCalls != 1 {
+		t.Fatalf("GetEntry calls=%d, want 1", lookup.getEntryCalls)
+	}
+}
+
+func TestSnapshotGetAppendPublishedAppendMissFallsBackToEntryLookup(t *testing.T) {
+	lookup := &snapshotPublishedAppendMissLookup{value: []byte("published")}
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{{
+			published:       lookup,
+			publishedRootID: 1,
+		}},
+	}
+
+	got, err := snap.GetAppend([]byte("k"), []byte("p:"))
+	if err != nil {
+		t.Fatalf("GetAppend: %v", err)
+	}
+	if string(got) != "p:published" {
+		t.Fatalf("value=%q, want p:published", got)
+	}
+	if lookup.getValueAppendCalls != 1 {
+		t.Fatalf("GetValueAppend calls=%d, want 1", lookup.getValueAppendCalls)
+	}
+	if lookup.getEntryCalls != 1 {
+		t.Fatalf("GetEntry calls=%d, want 1", lookup.getEntryCalls)
+	}
+}
+
+func TestSnapshotGetAppendPublishedAppendMissPreservesTombstone(t *testing.T) {
+	lookup := &snapshotPublishedAppendMissLookup{flags: node.FlagTombstone}
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{{
+			published:       lookup,
+			publishedRootID: 1,
+		}},
+	}
+
+	got, err := snap.GetAppend([]byte("k"), []byte("p:"))
+	if !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetAppend err=%v, want ErrKeyNotFound", err)
+	}
+	if string(got) != "p:" {
+		t.Fatalf("value=%q, want unchanged prefix", got)
+	}
+	if lookup.getValueAppendCalls != 1 {
+		t.Fatalf("GetValueAppend calls=%d, want 1", lookup.getValueAppendCalls)
 	}
 	if lookup.getEntryCalls != 1 {
 		t.Fatalf("GetEntry calls=%d, want 1", lookup.getEntryCalls)

--- a/TreeDB/caching/snapshot_getappend_test.go
+++ b/TreeDB/caching/snapshot_getappend_test.go
@@ -223,6 +223,27 @@ func TestSnapshotBackendPublishedMissConsistentAcrossReadAPIs(t *testing.T) {
 	}
 }
 
+func TestSnapshotBackendPublishedReadErrorsPropagate(t *testing.T) {
+	snap := &Snapshot{
+		rootPointShards: []rootDomainSnapshot{{
+			published:       backendSnapshotLookup{},
+			publishedRootID: 1,
+		}},
+	}
+	if _, err := snap.Get([]byte("k")); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("Get err=%v, want ErrClosed", err)
+	}
+	if _, err := snap.GetUnsafe([]byte("k")); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("GetUnsafe err=%v, want ErrClosed", err)
+	}
+	if _, err := snap.GetAppend([]byte("k"), nil); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("GetAppend err=%v, want ErrClosed", err)
+	}
+	if _, err := snap.Has([]byte("k")); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("Has err=%v, want ErrClosed", err)
+	}
+}
+
 func newSnapshotWithBackendPublishedPointRootMissingKey(t *testing.T) *Snapshot {
 	t.Helper()
 

--- a/TreeDB/caching/snapshot_getappend_test.go
+++ b/TreeDB/caching/snapshot_getappend_test.go
@@ -221,6 +221,12 @@ func TestSnapshotBackendPublishedMissConsistentAcrossReadAPIs(t *testing.T) {
 	if ok {
 		t.Fatal("Has=true, want false")
 	}
+	if _, err := snap.GetEntry([]byte("k")); !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetEntry err=%v, want ErrKeyNotFound", err)
+	}
+	if _, err := snap.GetEntryExact([]byte("k")); !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetEntryExact err=%v, want ErrKeyNotFound", err)
+	}
 }
 
 func TestSnapshotBackendPublishedReadErrorsPropagate(t *testing.T) {
@@ -241,6 +247,12 @@ func TestSnapshotBackendPublishedReadErrorsPropagate(t *testing.T) {
 	}
 	if _, err := snap.Has([]byte("k")); !errors.Is(err, backenddb.ErrClosed) {
 		t.Fatalf("Has err=%v, want ErrClosed", err)
+	}
+	if _, err := snap.GetEntry([]byte("k")); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("GetEntry err=%v, want ErrClosed", err)
+	}
+	if _, err := snap.GetEntryExact([]byte("k")); !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("GetEntryExact err=%v, want ErrClosed", err)
 	}
 }
 
@@ -300,6 +312,13 @@ func TestSnapshotGetAppendBackendPublishedHitViaInstalledLookup(t *testing.T) {
 	}
 	if string(got) != "prefix:from-published-root" {
 		t.Fatalf("GetAppend value=%q, want prefix:from-published-root", got)
+	}
+	entry, err := snap.GetEntry([]byte("k"))
+	if err != nil {
+		t.Fatalf("GetEntry: %v", err)
+	}
+	if string(entry.Value) != "from-published-root" {
+		t.Fatalf("GetEntry value=%q, want from-published-root", entry.Value)
 	}
 }
 

--- a/TreeDB/caching/snapshot_getappend_test.go
+++ b/TreeDB/caching/snapshot_getappend_test.go
@@ -244,6 +244,58 @@ func TestSnapshotBackendPublishedReadErrorsPropagate(t *testing.T) {
 	}
 }
 
+func TestSnapshotGetAppendBackendPublishedHitViaInstalledLookup(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+
+	// Publish a backend root that contains the key we want to read.
+	pubTable := newRootDomainTestTable(t, rootDomainTestOp{key: "k", value: "from-published-root"})
+	pointRootID, err := backend.PublishOrderedRootIterator(0, pubTable.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish root: %v", err)
+	}
+
+	db := &DB{
+		backend:          backend,
+		mutableShards:    make([]memShard, 1),
+		mutableShardMask: 0,
+	}
+
+	// Install a published root set with only a rootID (no lookup object).
+	// AcquireSnapshot must wire the backend lookup via installBackendPublishedRootLookups.
+	db.mu.Lock()
+	db.installPublishedRootSetLocked(&publishedRootSet{
+		generation:  1,
+		pointShards: []publishedRootRef{{rootID: pointRootID}},
+	})
+	db.mu.Unlock()
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	t.Cleanup(func() { _ = snap.Close() })
+
+	// Verify the backend lookup was wired by installBackendPublishedRootLookups.
+	if len(snap.backendPublishedLookups) == 0 {
+		t.Fatal("expected backendPublishedLookups to be populated")
+	}
+
+	// GetAppend must read through the wired backend lookup without falling through
+	// to the default-root backend fallback.
+	got, err := snap.GetAppend([]byte("k"), []byte("prefix:"))
+	if err != nil {
+		t.Fatalf("GetAppend: %v", err)
+	}
+	if string(got) != "prefix:from-published-root" {
+		t.Fatalf("GetAppend value=%q, want prefix:from-published-root", got)
+	}
+}
+
 func newSnapshotWithBackendPublishedPointRootMissingKey(t *testing.T) *Snapshot {
 	t.Helper()
 

--- a/TreeDB/caching/snapshot_getappend_test.go
+++ b/TreeDB/caching/snapshot_getappend_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/tree"
@@ -112,6 +113,9 @@ func TestSnapshotGetAppendPublishedUsesValueAppendDirectly(t *testing.T) {
 	if lookup.getEntryCalls != 0 {
 		t.Fatalf("GetEntry calls=%d, want 0", lookup.getEntryCalls)
 	}
+	if lookup.getValueUnsafeCalls != 0 {
+		t.Fatalf("GetValueUnsafe calls=%d, want 0", lookup.getValueUnsafeCalls)
+	}
 }
 
 func TestSnapshotGetAppendPublishedFallsBackToEntryLookup(t *testing.T) {
@@ -157,6 +161,9 @@ func TestSnapshotGetAppendPublishedAppendMissFallsBackToEntryLookup(t *testing.T
 	if lookup.getEntryCalls != 1 {
 		t.Fatalf("GetEntry calls=%d, want 1", lookup.getEntryCalls)
 	}
+	if lookup.getValueUnsafeCalls != 0 {
+		t.Fatalf("GetValueUnsafe calls=%d, want 0", lookup.getValueUnsafeCalls)
+	}
 }
 
 func TestSnapshotGetAppendPublishedAppendMissPreservesTombstone(t *testing.T) {
@@ -180,5 +187,52 @@ func TestSnapshotGetAppendPublishedAppendMissPreservesTombstone(t *testing.T) {
 	}
 	if lookup.getEntryCalls != 1 {
 		t.Fatalf("GetEntry calls=%d, want 1", lookup.getEntryCalls)
+	}
+	if lookup.getValueUnsafeCalls != 0 {
+		t.Fatalf("GetValueUnsafe calls=%d, want 0", lookup.getValueUnsafeCalls)
+	}
+}
+
+func TestSnapshotGetAppendBackendPublishedMissDoesNotFallBackToDefaultRoot(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer backend.Close()
+
+	if err := backend.SetSync([]byte("k"), []byte("default")); err != nil {
+		t.Fatalf("backend set: %v", err)
+	}
+	otherRoot := newRootDomainTestTable(t, rootDomainTestOp{key: "other", value: "published"})
+	pointRootID, err := backend.PublishOrderedRootIterator(0, otherRoot.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish point root: %v", err)
+	}
+	if pointRootID == backend.State().RootPageID {
+		t.Fatalf("test point root unexpectedly matches default root %d", pointRootID)
+	}
+
+	backendSnap := backend.AcquireSnapshot()
+	if backendSnap == nil {
+		t.Fatal("expected backend snapshot")
+	}
+	defer backendSnap.Close()
+
+	db := &DB{backend: backend, mutableShards: make([]memShard, 1)}
+	snap := &Snapshot{
+		db:              db,
+		backend:         backendSnap,
+		rootPointShards: []rootDomainSnapshot{{publishedRootID: pointRootID}},
+		backendRoot:     backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendSnap.State().RootPageID},
+		backendRootOK:   true,
+	}
+
+	got, err := snap.GetAppend([]byte("k"), []byte("p:"))
+	if !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("GetAppend err=%v, want ErrKeyNotFound", err)
+	}
+	if string(got) != "p:" {
+		t.Fatalf("value=%q, want unchanged prefix", got)
 	}
 }


### PR DESCRIPTION
## Summary

- route published `Snapshot.GetAppend` reads directly through `GetValueAppend` after cached memtable checks
- cache backend snapshot lookups on the snapshot object to avoid per-key interface boxing without regressing snapshot allocation bounds
- add regression tests for the direct published append path and entry-only fallback path

## Root Cause

`Snapshot.GetAppend` first probed published roots through `GetEntry`. For TreeDB roots backed by leaf-log pages, that metadata probe decoded leaf pages without the append-path scratch buffer and then performed a second tree read for the actual value append. Under `random_read_parallel`, that made leaf-log frame decompression and compact leaf expansion dominate allocation space.

## Validation

- `go test ./TreeDB/caching ./TreeDB/tree ./TreeDB/db`
- `./bin/unified-bench -dbs treedb -profile fast -test random_read_parallel -keys 800000 -batchsize 8000 -valsize 128 -read-workers 12 -path-label native-fastpath -profile-dir /tmp/gomap_random_read_parallel_final_yaB9Jn -progress=false -format markdown -allocsprofilerate 1`
- `./bin/benchprof -profiles-dir /tmp/gomap_random_read_parallel_final_yaB9Jn`

## Profile Notes

- baseline profile dir: `/tmp/gomap_random_read_parallel_main_uxKuBS`
- final profile dir: `/tmp/gomap_random_read_parallel_final_yaB9Jn`
- exact allocation-profile throughput: `432,386` -> `3,644,537` reads/sec
- allocation space: about `57.1 GiB` -> `12.6 MiB`
- former hot allocation sites in `decodeFramePayloadTo`, `decodeCompactLeafLogPayloadTo`, `ensureKeyScratch`, and `rootDomainApplyBackendFallback` are gone from the allocation profile
